### PR TITLE
Machine readable errors

### DIFF
--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -682,12 +682,16 @@ const usage_fmt =
     \\   Formats the input files and modifies them in-place.
     \\
     \\Options:
+    \\   --machine-errors       Print errors in a machine-friendly format
     \\   --help                 Print this help and exit
     \\
     \\
 ;
 
-const args_fmt_spec = []Flag{Flag.Bool("--help")};
+const args_fmt_spec = []Flag{
+    Flag.Bool("--machine-errors"),
+    Flag.Bool("--help"),
+};
 
 fn cmdFmt(allocator: &Allocator, args: []const []const u8) !void {
     var flags = try Args.parse(allocator, args_fmt_spec, args);
@@ -725,6 +729,12 @@ fn cmdFmt(allocator: &Allocator, args: []const []const u8) !void {
             const loc = tree.tokenLocation(0, parse_error.loc());
             try stderr.print("{}:{}:{}: error: ", file_path, loc.line + 1, loc.column + 1);
             try tree.renderError(parse_error, stderr);
+
+            if (flags.present("machine-errors")) {
+                try stderr.write("\n");
+                continue;
+            }
+
             try stderr.print("\n{}\n", source_code[loc.line_start..loc.line_end]);
             {
                 var i: usize = 0;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1722,6 +1722,7 @@ struct CodeGen {
     ZigList<Buf *> forbidden_libs;
 
     bool no_rosegment_workaround;
+    bool machine_readable_errors;
 };
 
 enum VarLinkage {

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -4102,7 +4102,7 @@ ImportTableEntry *add_source_file(CodeGen *g, PackageTableEntry *package, Buf *a
         ErrorMsg *err = err_msg_create_with_line(abs_full_path, tokenization.err_line, tokenization.err_column,
                 source_code, tokenization.line_offsets, tokenization.err);
 
-        print_err_msg(err, g->err_color);
+        print_err_msg(err, g->err_color, g->machine_readable_errors);
         exit(1);
     }
 
@@ -4119,7 +4119,7 @@ ImportTableEntry *add_source_file(CodeGen *g, PackageTableEntry *package, Buf *a
     import_entry->line_offsets = tokenization.line_offsets;
     import_entry->path = abs_full_path;
 
-    import_entry->root = ast_parse(source_code, tokenization.tokens, import_entry, g->err_color);
+    import_entry->root = ast_parse(source_code, tokenization.tokens, import_entry, g->err_color, g->machine_readable_errors);
     assert(import_entry->root);
     if (g->verbose_ast) {
         ast_print(stderr, import_entry->root, 0);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5513,7 +5513,7 @@ static void report_errors_and_maybe_exit(CodeGen *g) {
     if (g->errors.length != 0) {
         for (size_t i = 0; i < g->errors.length; i += 1) {
             ErrorMsg *err = g->errors.at(i);
-            print_err_msg(err, g->err_color);
+            print_err_msg(err, g->err_color, g->machine_readable_errors);
         }
         exit(1);
     }
@@ -6819,7 +6819,7 @@ void codegen_translate_c(CodeGen *g, Buf *full_path) {
     if (err == ErrorCCompileErrors && errors.length > 0) {
         for (size_t i = 0; i < errors.length; i += 1) {
             ErrorMsg *err_msg = errors.at(i);
-            print_err_msg(err_msg, g->err_color);
+            print_err_msg(err_msg, g->err_color, g->machine_readable_errors);
         }
         exit(1);
     }

--- a/src/errmsg.hpp
+++ b/src/errmsg.hpp
@@ -27,7 +27,7 @@ struct ErrorMsg {
     ZigList<ErrorMsg *> notes;
 };
 
-void print_err_msg(ErrorMsg *msg, ErrColor color);
+void print_err_msg(ErrorMsg *msg, ErrColor color, bool machine_readable);
 
 void err_msg_add_note(ErrorMsg *parent, ErrorMsg *note);
 ErrorMsg *err_msg_create_with_offset(Buf *path, size_t line, size_t column, size_t offset,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@ static int usage(const char *arg0) {
         "  --emit [filetype]            emit a specific file format as compilation output\n"
         "  --enable-timing-info         print timing diagnostics\n"
         "  --libc-include-dir [path]    directory where libc stdlib.h resides\n"
+        "  --machine-errors             print compiler errors in a machine-readable format\n"
         "  --name [name]                override output name\n"
         "  --output [file]              override destination path\n"
         "  --output-h [file]            override generated header file path\n"
@@ -326,6 +327,7 @@ int main(int argc, char **argv) {
     int comptime_args_end = 0;
     int runtime_args_start = argc;
     bool no_rosegment_workaround = false;
+    bool machine_readable_errors = false;
 
     if (argc >= 2 && strcmp(argv[1], "build") == 0) {
         const char *zig_exe_path = arg0;
@@ -509,6 +511,8 @@ int main(int argc, char **argv) {
                 mconsole = true;
             } else if (strcmp(arg, "-rdynamic") == 0) {
                 rdynamic = true;
+            } else if (strcmp(arg, "--machine-errors") == 0) {
+                machine_readable_errors = true;
             } else if (strcmp(arg, "--no-rosegment") == 0) {
                 no_rosegment_workaround = true;
             } else if (strcmp(arg, "--each-lib-rpath") == 0) {
@@ -826,6 +830,7 @@ int main(int argc, char **argv) {
             g->verbose_ir = verbose_ir;
             g->verbose_llvm_ir = verbose_llvm_ir;
             g->verbose_cimport = verbose_cimport;
+            g->machine_readable_errors = machine_readable_errors;
             codegen_set_errmsg_color(g, color);
 
             for (size_t i = 0; i < lib_dirs.length; i += 1) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -20,6 +20,7 @@ struct ParseContext {
     ZigList<Token> *tokens;
     ImportTableEntry *owner;
     ErrColor err_color;
+    bool machine_readable_errors;
     // These buffers are used freqently so we preallocate them once here.
     Buf *void_buf;
 };
@@ -42,7 +43,7 @@ static void ast_asm_error(ParseContext *pc, AstNode *node, size_t offset, const 
     ErrorMsg *err = err_msg_create_with_line(pc->owner->path, pos.line, pos.column,
             pc->owner->source_code, pc->owner->line_offsets, msg);
 
-    print_err_msg(err, pc->err_color);
+    print_err_msg(err, pc->err_color, pc->machine_readable_errors);
     exit(EXIT_FAILURE);
 }
 
@@ -60,7 +61,7 @@ static void ast_error(ParseContext *pc, Token *token, const char *format, ...) {
     err->line_start = token->start_line;
     err->column_start = token->start_column;
 
-    print_err_msg(err, pc->err_color);
+    print_err_msg(err, pc->err_color, pc->machine_readable_errors);
     exit(EXIT_FAILURE);
 }
 
@@ -2905,7 +2906,7 @@ static AstNode *ast_parse_root(ParseContext *pc, size_t *token_index) {
 }
 
 AstNode *ast_parse(Buf *buf, ZigList<Token> *tokens, ImportTableEntry *owner,
-        ErrColor err_color)
+        ErrColor err_color, bool machine_readable_errors)
 {
     ParseContext pc = {0};
     pc.void_buf = buf_create_from_str("void");
@@ -2913,6 +2914,7 @@ AstNode *ast_parse(Buf *buf, ZigList<Token> *tokens, ImportTableEntry *owner,
     pc.owner = owner;
     pc.buf = buf;
     pc.tokens = tokens;
+    pc.machine_readable_errors = machine_readable_errors;
     size_t token_index = 0;
     pc.root = ast_parse_root(&pc, &token_index);
     return pc.root;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -16,7 +16,7 @@ ATTRIBUTE_PRINTF(2, 3)
 void ast_token_error(Token *token, const char *format, ...);
 
 
-AstNode * ast_parse(Buf *buf, ZigList<Token> *tokens, ImportTableEntry *owner, ErrColor err_color);
+AstNode * ast_parse(Buf *buf, ZigList<Token> *tokens, ImportTableEntry *owner, ErrColor err_color, bool machine_readable_errors);
 
 void ast_print(AstNode *node, int indent);
 


### PR DESCRIPTION
This adds an option to the compiler for emitting machine-parseable error messages. The intended use is for editors or any command line processing. I need this currently for better error messages from `zig fmt` when putting itnegrating as part of an editor plugin.

---

```
pub fn main() !void {
    a = b;
}
```

Normal error messages:

```
$ zig build-exe t.zig
/tmp/t.zig:2:5: error: use of undeclared identifier 'a'
    a = b;
    ^
/tmp/t.zig:2:9: error: use of undeclared identifier 'b'
    a = b;
        ^
```

Machine error messages:

```
$ zig build-exe t.zig --machine-errors
/tmp/t.zig:2:5: use of undeclared identifier 'a'
/tmp/t.zig:2:9: use of undeclared identifier 'b'
```