### PR TITLE
Add context to zig_unreachable calls

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -38,11 +38,11 @@ ATTRIBUTE_NORETURN
 ATTRIBUTE_PRINTF(1, 2)
 void zig_panic(const char *format, ...);
 
-ATTRIBUTE_COLD
-ATTRIBUTE_NORETURN
-static inline void zig_unreachable(void) {
-    zig_panic("unreachable");
-}
+#ifdef WIN32
+#define __func__ __FUNCTION__
+#endif
+
+#define zig_unreachable() zig_panic("unreachable: %s:%s:%d", __FILE__, __func__, __LINE__)
 
 #if defined(_MSC_VER)
 static inline int clzll(unsigned long long mask) {


### PR DESCRIPTION
This greatly aids debugging on platforms with no stack-traces. Mainly intended to help give a bit more context for situations over IRC, for example. Ideally we never hit these anyway, but we do so lets reduce the time spent tracking things down otherwise.