### PR TITLE
Pointer Reform: proper slicing and indexing

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1565,7 +1565,7 @@ var foo: u8 align(4) = 100;
 test "global variable alignment" {
     assert(@typeOf(&foo).alignment == 4);
     assert(@typeOf(&foo) == *align(4) u8);
-    const slice = (&foo)[0..1];
+    const slice = (*[1]u8)(&foo)[0..];
     assert(@typeOf(slice) == []align(4) u8);
 }
 
@@ -1671,7 +1671,7 @@ test "using slices for strings" {
 
 test "slice pointer" {
     var array: [10]u8 = undefined;
-    const ptr = &array[0];
+    const ptr = &array;
 
     // You can use slicing syntax to convert a pointer into a slice:
     const slice = ptr[0..5];
@@ -6004,9 +6004,12 @@ const c = @cImport({
       {#code_begin|syntax#}
 const base64 = @import("std").base64;
 
-export fn decode_base_64(dest_ptr: *u8, dest_len: usize,
-    source_ptr: *const u8, source_len: usize) usize
-{
+export fn decode_base_64(
+    dest_ptr: [*]u8,
+    dest_len: usize,
+    source_ptr: [*]const u8,
+    source_len: usize,
+) usize {
     const src = source_ptr[0..source_len];
     const dest = dest_ptr[0..dest_len];
     const base64_decoder = base64.standard_decoder_unsafe;

--- a/example/mix_o_files/base64.zig
+++ b/example/mix_o_files/base64.zig
@@ -1,6 +1,6 @@
 const base64 = @import("std").base64;
 
-export fn decode_base_64(dest_ptr: *u8, dest_len: usize, source_ptr: *const u8, source_len: usize) usize {
+export fn decode_base_64(dest_ptr: [*]u8, dest_len: usize, source_ptr: [*]const u8, source_len: usize) usize {
     const src = source_ptr[0..source_len];
     const dest = dest_ptr[0..dest_len];
     const base64_decoder = base64.standard_decoder_unsafe;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -83,6 +83,7 @@ enum ConstParentId {
     ConstParentIdStruct,
     ConstParentIdArray,
     ConstParentIdUnion,
+    ConstParentIdScalar,
 };
 
 struct ConstParent {
@@ -100,6 +101,9 @@ struct ConstParent {
         struct {
             ConstExprValue *union_val;
         } p_union;
+        struct {
+            ConstExprValue *scalar_val;
+        } p_scalar;
     } data;
 };
 
@@ -578,6 +582,7 @@ enum CastOp {
     CastOpBytesToSlice,
     CastOpNumLitToConcrete,
     CastOpErrSet,
+    CastOpBitCast,
 };
 
 struct AstNodeFnCallExpr {

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5158,7 +5158,8 @@ void init_const_slice(CodeGen *g, ConstExprValue *const_val, ConstExprValue *arr
     const_val->type = get_slice_type(g, ptr_type);
     const_val->data.x_struct.fields = create_const_vals(2);
 
-    init_const_ptr_array(g, &const_val->data.x_struct.fields[slice_ptr_index], array_val, start, is_const);
+    init_const_ptr_array(g, &const_val->data.x_struct.fields[slice_ptr_index], array_val, start, is_const,
+            PtrLenUnknown);
     init_const_usize(g, &const_val->data.x_struct.fields[slice_len_index], len);
 }
 
@@ -5169,21 +5170,24 @@ ConstExprValue *create_const_slice(CodeGen *g, ConstExprValue *array_val, size_t
 }
 
 void init_const_ptr_array(CodeGen *g, ConstExprValue *const_val, ConstExprValue *array_val,
-        size_t elem_index, bool is_const)
+        size_t elem_index, bool is_const, PtrLen ptr_len)
 {
     assert(array_val->type->id == TypeTableEntryIdArray);
     TypeTableEntry *child_type = array_val->type->data.array.child_type;
 
     const_val->special = ConstValSpecialStatic;
-    const_val->type = get_pointer_to_type(g, child_type, is_const);
+    const_val->type = get_pointer_to_type_extra(g, child_type, is_const, false,
+            ptr_len, get_abi_alignment(g, child_type), 0, 0);
     const_val->data.x_ptr.special = ConstPtrSpecialBaseArray;
     const_val->data.x_ptr.data.base_array.array_val = array_val;
     const_val->data.x_ptr.data.base_array.elem_index = elem_index;
 }
 
-ConstExprValue *create_const_ptr_array(CodeGen *g, ConstExprValue *array_val, size_t elem_index, bool is_const) {
+ConstExprValue *create_const_ptr_array(CodeGen *g, ConstExprValue *array_val, size_t elem_index, bool is_const,
+        PtrLen ptr_len)
+{
     ConstExprValue *const_val = create_const_vals(1);
-    init_const_ptr_array(g, const_val, array_val, elem_index, is_const);
+    init_const_ptr_array(g, const_val, array_val, elem_index, is_const, ptr_len);
     return const_val;
 }
 

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -152,8 +152,9 @@ ConstExprValue *create_const_ptr_hard_coded_addr(CodeGen *g, TypeTableEntry *poi
         size_t addr, bool is_const);
 
 void init_const_ptr_array(CodeGen *g, ConstExprValue *const_val, ConstExprValue *array_val,
-        size_t elem_index, bool is_const);
-ConstExprValue *create_const_ptr_array(CodeGen *g, ConstExprValue *array_val, size_t elem_index, bool is_const);
+        size_t elem_index, bool is_const, PtrLen ptr_len);
+ConstExprValue *create_const_ptr_array(CodeGen *g, ConstExprValue *array_val, size_t elem_index,
+        bool is_const, PtrLen ptr_len);
 
 void init_const_slice(CodeGen *g, ConstExprValue *const_val, ConstExprValue *array_val,
         size_t start, size_t len, bool is_const);

--- a/std/fmt/errol/index.zig
+++ b/std/fmt/errol/index.zig
@@ -59,7 +59,7 @@ pub fn roundToPrecision(float_decimal: *FloatDecimal, precision: usize, mode: Ro
                 float_decimal.exp += 1;
 
                 // Re-size the buffer to use the reserved leading byte.
-                const one_before = @intToPtr(*u8, @ptrToInt(&float_decimal.digits[0]) - 1);
+                const one_before = @intToPtr([*]u8, @ptrToInt(&float_decimal.digits[0]) - 1);
                 float_decimal.digits = one_before[0 .. float_decimal.digits.len + 1];
                 float_decimal.digits[0] = '1';
                 return;

--- a/std/fmt/index.zig
+++ b/std/fmt/index.zig
@@ -278,7 +278,7 @@ pub fn formatAsciiChar(
     comptime Errors: type,
     output: fn (@typeOf(context), []const u8) Errors!void,
 ) Errors!void {
-    return output(context, (&c)[0..1]);
+    return output(context, (*[1]u8)(&c)[0..]);
 }
 
 pub fn formatBuf(
@@ -603,7 +603,7 @@ fn formatIntSigned(
     const uint = @IntType(false, @typeOf(value).bit_count);
     if (value < 0) {
         const minus_sign: u8 = '-';
-        try output(context, (&minus_sign)[0..1]);
+        try output(context, (*[1]u8)(&minus_sign)[0..]);
         const new_value = uint(-(value + 1)) + 1;
         const new_width = if (width == 0) 0 else (width - 1);
         return formatIntUnsigned(new_value, base, uppercase, new_width, context, Errors, output);
@@ -611,7 +611,7 @@ fn formatIntSigned(
         return formatIntUnsigned(uint(value), base, uppercase, width, context, Errors, output);
     } else {
         const plus_sign: u8 = '+';
-        try output(context, (&plus_sign)[0..1]);
+        try output(context, (*[1]u8)(&plus_sign)[0..]);
         const new_value = uint(value);
         const new_width = if (width == 0) 0 else (width - 1);
         return formatIntUnsigned(new_value, base, uppercase, new_width, context, Errors, output);
@@ -648,7 +648,7 @@ fn formatIntUnsigned(
         const zero_byte: u8 = '0';
         var leftover_padding = padding - index;
         while (true) {
-            try output(context, (&zero_byte)[0..1]);
+            try output(context, (*[1]u8)(&zero_byte)[0..]);
             leftover_padding -= 1;
             if (leftover_padding == 0) break;
         }

--- a/std/heap.zig
+++ b/std/heap.zig
@@ -24,7 +24,7 @@ fn cAlloc(self: *Allocator, n: usize, alignment: u29) ![]u8 {
 fn cRealloc(self: *Allocator, old_mem: []u8, new_size: usize, alignment: u29) ![]u8 {
     const old_ptr = @ptrCast([*]c_void, old_mem.ptr);
     if (c.realloc(old_ptr, new_size)) |buf| {
-        return @ptrCast(*u8, buf)[0..new_size];
+        return @ptrCast([*]u8, buf)[0..new_size];
     } else if (new_size <= old_mem.len) {
         return old_mem[0..new_size];
     } else {

--- a/std/io.zig
+++ b/std/io.zig
@@ -219,12 +219,12 @@ pub fn OutStream(comptime WriteError: type) type {
         }
 
         pub fn writeByte(self: *Self, byte: u8) !void {
-            const slice = (&byte)[0..1];
+            const slice = (*[1]u8)(&byte)[0..];
             return self.writeFn(self, slice);
         }
 
         pub fn writeByteNTimes(self: *Self, byte: u8, n: usize) !void {
-            const slice = (&byte)[0..1];
+            const slice = (*[1]u8)(&byte)[0..];
             var i: usize = 0;
             while (i < n) : (i += 1) {
                 try self.writeFn(self, slice);

--- a/std/macho.zig
+++ b/std/macho.zig
@@ -164,7 +164,7 @@ fn readNoEof(in: *io.FileInStream, comptime T: type, result: []T) !void {
     return in.stream.readNoEof(([]u8)(result));
 }
 fn readOneNoEof(in: *io.FileInStream, comptime T: type, result: *T) !void {
-    return readNoEof(in, T, result[0..1]);
+    return readNoEof(in, T, (*[1]T)(result)[0..]);
 }
 
 fn isSymbol(sym: *const Nlist64) bool {

--- a/std/net.zig
+++ b/std/net.zig
@@ -68,7 +68,7 @@ pub const Address = struct {
 
 pub fn parseIp4(buf: []const u8) !u32 {
     var result: u32 = undefined;
-    const out_ptr = ([]u8)((&result)[0..1]);
+    const out_ptr = ([]u8)((*[1]u32)(&result)[0..]);
 
     var x: u8 = 0;
     var index: u8 = 0;

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -1240,7 +1240,7 @@ pub const Dir = struct {
             const next_index = self.index + darwin_entry.d_reclen;
             self.index = next_index;
 
-            const name = (&darwin_entry.d_name)[0..darwin_entry.d_namlen];
+            const name = @ptrCast([*]u8, &darwin_entry.d_name)[0..darwin_entry.d_namlen];
 
             // skip . and .. entries
             if (mem.eql(u8, name, ".") or mem.eql(u8, name, "..")) {
@@ -1704,7 +1704,7 @@ pub fn argsFree(allocator: *mem.Allocator, args_alloc: []const []u8) void {
     for (args_alloc) |arg| {
         total_bytes += @sizeOf([]u8) + arg.len;
     }
-    const unaligned_allocated_buf = @ptrCast(*const u8, args_alloc.ptr)[0..total_bytes];
+    const unaligned_allocated_buf = @ptrCast([*]const u8, args_alloc.ptr)[0..total_bytes];
     const aligned_allocated_buf = @alignCast(@alignOf([]u8), unaligned_allocated_buf);
     return allocator.free(aligned_allocated_buf);
 }

--- a/test/cases/align.zig
+++ b/test/cases/align.zig
@@ -6,7 +6,7 @@ var foo: u8 align(4) = 100;
 test "global variable alignment" {
     assert(@typeOf(&foo).alignment == 4);
     assert(@typeOf(&foo) == *align(4) u8);
-    const slice = (&foo)[0..1];
+    const slice = (*[1]u8)(&foo)[0..];
     assert(@typeOf(slice) == []align(4) u8);
 }
 
@@ -60,7 +60,7 @@ fn addUnaligned(a: *align(1) const u32, b: *align(1) const u32) u32 {
 test "implicitly decreasing slice alignment" {
     const a: u32 align(4) = 3;
     const b: u32 align(8) = 4;
-    assert(addUnalignedSlice((&a)[0..1], (&b)[0..1]) == 7);
+    assert(addUnalignedSlice((*[1]u32)(&a)[0..], (*[1]u32)(&b)[0..]) == 7);
 }
 fn addUnalignedSlice(a: []align(1) const u32, b: []align(1) const u32) u32 {
     return a[0] + b[0];

--- a/test/cases/array.zig
+++ b/test/cases/array.zig
@@ -115,3 +115,32 @@ test "array len property" {
     var x: [5]i32 = undefined;
     assert(@typeOf(x).len == 5);
 }
+
+test "single-item pointer to array indexing and slicing" {
+    testSingleItemPtrArrayIndexSlice();
+    comptime testSingleItemPtrArrayIndexSlice();
+}
+
+fn testSingleItemPtrArrayIndexSlice() void {
+    var array = "aaaa";
+    doSomeMangling(&array);
+    assert(mem.eql(u8, "azya", array));
+}
+
+fn doSomeMangling(array: *[4]u8) void {
+    array[1] = 'z';
+    array[2..3][0] = 'y';
+}
+
+test "implicit cast single-item pointer" {
+    testImplicitCastSingleItemPtr();
+    comptime testImplicitCastSingleItemPtr();
+}
+
+fn testImplicitCastSingleItemPtr() void {
+    var byte: u8 = 100;
+    const slice = (*[1]u8)(&byte)[0..];
+    slice[0] += 1;
+    assert(byte == 101);
+}
+

--- a/test/cases/eval.zig
+++ b/test/cases/eval.zig
@@ -418,9 +418,9 @@ test "string literal used as comptime slice is memoized" {
 }
 
 test "comptime slice of undefined pointer of length 0" {
-    const slice1 = (*i32)(undefined)[0..0];
+    const slice1 = ([*]i32)(undefined)[0..0];
     assert(slice1.len == 0);
-    const slice2 = (*i32)(undefined)[100..100];
+    const slice2 = ([*]i32)(undefined)[100..100];
     assert(slice2.len == 0);
 }
 
@@ -508,7 +508,7 @@ test "comptime slice of slice preserves comptime var" {
 test "comptime slice of pointer preserves comptime var" {
     comptime {
         var buff: [10]u8 = undefined;
-        var a = &buff[0];
+        var a = buff[0..].ptr;
         a[0..1][0] = 1;
         assert(buff[0..][0..][0] == 1);
     }

--- a/test/cases/misc.zig
+++ b/test/cases/misc.zig
@@ -274,7 +274,7 @@ test "generic malloc free" {
 }
 var some_mem: [100]u8 = undefined;
 fn memAlloc(comptime T: type, n: usize) error![]T {
-    return @ptrCast(*T, &some_mem[0])[0..n];
+    return @ptrCast([*]T, &some_mem[0])[0..n];
 }
 fn memFree(comptime T: type, memory: []T) void {}
 
@@ -588,7 +588,7 @@ var global_ptr = &gdt[0];
 
 // can't really run this test but we can make sure it has no compile error
 // and generates code
-const vram = @intToPtr(*volatile u8, 0x20000000)[0..0x8000];
+const vram = @intToPtr([*]volatile u8, 0x20000000)[0..0x8000];
 export fn writeToVRam() void {
     vram[0] = 'X';
 }

--- a/test/cases/slice.zig
+++ b/test/cases/slice.zig
@@ -1,7 +1,7 @@
 const assert = @import("std").debug.assert;
 const mem = @import("std").mem;
 
-const x = @intToPtr(*i32, 0x1000)[0..0x500];
+const x = @intToPtr([*]i32, 0x1000)[0..0x500];
 const y = x[0x100..];
 test "compile time slice of pointer to hard coded address" {
     assert(@ptrToInt(x.ptr) == 0x1000);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,12 +2,21 @@ const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "slicing single-item pointer",
+        \\export fn entry(ptr: *i32) void {
+        \\    const slice = ptr[0..2];
+        \\}
+    ,
+        ".tmp_source.zig:2:22: error: slice of single-item pointer",
+    );
+
+    cases.add(
         "indexing single-item pointer",
         \\export fn entry(ptr: *i32) i32 {
         \\    return ptr[1];
         \\}
     ,
-        ".tmp_source.zig:2:15: error: indexing not allowed on pointer to single item",
+        ".tmp_source.zig:2:15: error: index of single-item pointer",
     );
 
     cases.add(
@@ -144,10 +153,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
         "comptime slice of undefined pointer non-zero len",
         \\export fn entry() void {
-        \\    const slice = (*i32)(undefined)[0..1];
+        \\    const slice = ([*]i32)(undefined)[0..1];
         \\}
     ,
-        ".tmp_source.zig:2:36: error: non-zero length slice of undefined pointer",
+        ".tmp_source.zig:2:38: error: non-zero length slice of undefined pointer",
     );
 
     cases.add(
@@ -3129,14 +3138,16 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\export fn entry() void {
         \\    var foo = Foo { .a = 1, .b = 10 };
         \\    foo.b += 1;
-        \\    bar((&foo.b)[0..1]);
+        \\    bar((*[1]u32)(&foo.b)[0..]);
         \\}
         \\
         \\fn bar(x: []u32) void {
         \\    x[0] += 1;
         \\}
     ,
-        ".tmp_source.zig:9:17: error: expected type '[]u32', found '[]align(1) u32'",
+        ".tmp_source.zig:9:18: error: cast increases pointer alignment",
+        ".tmp_source.zig:9:23: note: '*align(1) u32' has alignment 1",
+        ".tmp_source.zig:9:18: note: '*[1]u32' has alignment 4",
     );
 
     cases.add(


### PR DESCRIPTION
 * enable slicing for single-item ptr to arrays
 * disable slicing for other single-item pointers
 * enable indexing for single-item ptr to arrays
 * disable indexing for other single-item pointers

see #770
closes #386