### PR TITLE
WIP: Add snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,3 +29,6 @@ parts:
     configflags:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX=/
+    prime:
+      - bin/zig
+      - lib/zig/*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,31 @@
+name: zig
+version: git
+summary: The Zig Programming Language
+description: Zig is an open-source programming language designed for robustness, optimality, and clarity.
+grade: devel
+confinement: classic
+
+apps:
+  zig:
+    command: ./bin/zig
+
+parts:
+  install-llvm:
+    # Workaround for installing LLVM 6.0 build packages, which do not exist in
+    # the aptitude repositories for Ubuntu 16.04. This can be cleaned up once
+    # Snapcraft supports custom repositories or an Ubuntu 18.04 base layer.
+    plugin: nil
+    override-pull: |
+      wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+      add-apt-repository -yu "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
+      apt install -y libclang-6.0-dev liblld-6.0-dev llvm-6.0-dev
+  zig:
+    after: [install-llvm]
+    plugin: cmake
+    build-packages:
+      - g++
+      - libxml2-dev
+      - zlib1g-dev
+    configflags:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX=/


### PR DESCRIPTION
This is a work-in-progress that packages the Zig toolchain for [Ubuntu's new-ish package manager](https://snapcraft.io/).

After [setting up Snapcraft](https://docs.snapcraft.io/build-snaps/get-started-snapcraft), this can be tested with:
```
snapcraft cleanbuild
snap install --classic --dangerous zig_git_amd64.snap
```

Snaps are just SquashFS files, so it can be inspected with `unsquashfs -ls zig_git_amd64.snap`.