### PR TITLE
Add newline to zig fmt error

### DIFF
--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -734,7 +734,7 @@ fn cmdFmt(allocator: *Allocator, args: []const []const u8) !void {
         defer file.close();
 
         const source_code = io.readFileAlloc(allocator, file_path) catch |err| {
-            try stderr.print("unable to open '{}': {}", file_path, err);
+            try stderr.print("unable to open '{}': {}\n", file_path, err);
             fmt_errors = true;
             continue;
         };


### PR DESCRIPTION
Simple as that :).  Caught it during a typo to zig fmt.