### PR TITLE
fix std.os.windows.PathFileExists specified in the wrong DLL

### DIFF
--- a/std/os/file.zig
+++ b/std/os/file.zig
@@ -123,7 +123,8 @@ pub const File = struct {
             }
             return true;
         } else if (is_windows) {
-            if (os.windows.PathFileExists(path_with_null.ptr) == os.windows.TRUE) {
+            // TODO do not depend on shlwapi.dll
+            if (os.windows.PathFileExistsA(path_with_null.ptr) == os.windows.TRUE) {
                 return true;
             }
 

--- a/std/os/windows/index.zig
+++ b/std/os/windows/index.zig
@@ -123,8 +123,6 @@ pub extern "kernel32" stdcallcc fn QueryPerformanceCounter(lpPerformanceCount: *
 
 pub extern "kernel32" stdcallcc fn QueryPerformanceFrequency(lpFrequency: *LARGE_INTEGER) BOOL;
 
-pub extern "kernel32" stdcallcc fn PathFileExists(pszPath: ?LPCTSTR) BOOL;
-
 pub extern "kernel32" stdcallcc fn ReadFile(
     in_hFile: HANDLE,
     out_lpBuffer: *c_void,
@@ -162,6 +160,8 @@ pub extern "kernel32" stdcallcc fn LoadLibraryA(lpLibFileName: LPCSTR) ?HMODULE;
 pub extern "kernel32" stdcallcc fn FreeLibrary(hModule: HMODULE) BOOL;
 
 pub extern "user32" stdcallcc fn MessageBoxA(hWnd: ?HANDLE, lpText: ?LPCTSTR, lpCaption: ?LPCTSTR, uType: UINT) c_int;
+
+pub extern "shlwapi" stdcallcc fn PathFileExistsA(pszPath: ?LPCTSTR) BOOL;
 
 pub const PROV_RSA_FULL = 1;
 


### PR DESCRIPTION
closes #1054