### PR TITLE
Fix error handling in Buffer::fromOwnedSlice

### DIFF
--- a/std/buffer.zig
+++ b/std/buffer.zig
@@ -41,9 +41,9 @@ pub const Buffer = struct {
     /// Buffer takes ownership of the passed in slice. The slice must have been
     /// allocated with `allocator`.
     /// Must deinitialize with deinit.
-    pub fn fromOwnedSlice(allocator: *Allocator, slice: []u8) Buffer {
+    pub fn fromOwnedSlice(allocator: *Allocator, slice: []u8) !Buffer {
         var self = Buffer{ .list = ArrayList(u8).fromOwnedSlice(allocator, slice) };
-        self.list.append(0);
+        try self.list.append(0);
         return self;
     }
 


### PR DESCRIPTION
Got an error here. I believe this is the correct fix.