### PR TITLE
support `--target-arch wasm32`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -63,6 +63,7 @@ pub fn build(b: *Builder) !void {
             exe.addObjectFile(lib);
         }
     } else {
+        addCppLib(b, exe, cmake_binary_dir, "embedded_lld_wasm");
         addCppLib(b, exe, cmake_binary_dir, "embedded_lld_elf");
         addCppLib(b, exe, cmake_binary_dir, "embedded_lld_coff");
         addCppLib(b, exe, cmake_binary_dir, "embedded_lld_lib");

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -391,6 +391,19 @@ static void construct_linker_job_elf(LinkJob *lj) {
     }
 }
 
+static void construct_linker_job_wasm(LinkJob *lj) {
+    CodeGen *g = lj->codegen;
+
+    lj->args.append("--relocatable");  // So lld doesn't look for _start.
+    lj->args.append("-o");
+    lj->args.append(buf_ptr(&lj->out_file));
+
+    // .o files
+    for (size_t i = 0; i < g->link_objects.length; i += 1) {
+        lj->args.append((const char *)buf_ptr(g->link_objects.at(i)));
+    }
+}
+
 //static bool is_target_cyg_mingw(const ZigTarget *target) {
 //    return (target->os == ZigLLVM_Win32 && target->env_type == ZigLLVM_Cygnus) ||
 //        (target->os == ZigLLVM_Win32 && target->env_type == ZigLLVM_GNU);
@@ -924,7 +937,7 @@ static void construct_linker_job(LinkJob *lj) {
         case ZigLLVM_MachO:
             return construct_linker_job_macho(lj);
         case ZigLLVM_Wasm:
-            zig_panic("TODO link wasm");
+            return construct_linker_job_wasm(lj);
     }
 }
 

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -597,10 +597,13 @@ void resolve_target_object_format(ZigTarget *target) {
         case ZigLLVM_tce:
         case ZigLLVM_tcele:
         case ZigLLVM_thumbeb:
-        case ZigLLVM_wasm32:
-        case ZigLLVM_wasm64:
         case ZigLLVM_xcore:
             target->oformat= ZigLLVM_ELF;
+            return;
+
+        case ZigLLVM_wasm32:
+        case ZigLLVM_wasm64:
+            target->oformat = ZigLLVM_Wasm;
             return;
 
         case ZigLLVM_ppc:

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -838,7 +838,7 @@ bool ZigLLDLink(ZigLLVM_ObjectFormatType oformat, const char **args, size_t arg_
             return lld::mach_o::link(array_ref_args, diag);
 
         case ZigLLVM_Wasm:
-            assert(false); // TODO ZigLLDLink for Wasm
+            return lld::wasm::link(array_ref_args, false, diag);
     }
     assert(false); // unreachable
     abort();


### PR DESCRIPTION
Add wasm32 support to the build-obj, build-exe and build-lib commands
of the stage 1 compiler.  Wasm64 should work transparently once it's
supported in upstream LLVM.

To export a function:

    // lib.zig - for exposition, not necessary for this example
    pub use @import("add.zig");

    // add.zig
    export fn add(a: i32, b: i32) i32 {
        return a + b;
    }

To import a function:

    // cube.zig
    extern fn square(x: i32) i32;

    export fn cube(x: i32) i32 {
        return x * square(x);
    }