### PR TITLE
allow passing by non-copying value

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2797,39 +2797,30 @@ fn foo() void { }
       {#code_end#}
       {#header_open|Pass-by-value Parameters#}
       <p>
-      In Zig, structs, unions, and enums with payloads cannot be passed by value
-      to a function.
-      </p>
-      {#code_begin|test_err|not copyable; cannot pass by value#}
-const Foo = struct {
-    x: i32,
-};
-
-fn bar(foo: Foo) void {}
-
-test "pass aggregate type by value to function" {
-    bar(Foo {.x = 12,});
-}
-      {#code_end#}
-      <p>
-      Instead, one must use <code>*const</code>. Zig allows implicitly casting something
-      to a const pointer to it:
+      In Zig, structs, unions, and enums with payloads can be passed directly to a function:
       </p>
       {#code_begin|test#}
-const Foo = struct {
+const Point = struct {
     x: i32,
+    y: i32,
 };
 
-fn bar(foo: *const Foo) void {}
+fn foo(point: Point) i32 {
+    return point.x + point.y;
+}
 
-test "implicitly cast to const pointer" {
-    bar(Foo {.x = 12,});
+const assert = @import("std").debug.assert;
+
+test "pass aggregate type by non-copy value to function" {
+    assert(foo(Point{ .x = 1, .y = 2 }) == 3);
 }
       {#code_end#}
       <p>
-      However,
-      the C ABI does allow passing structs and unions by value. So functions which
-      use the C calling convention may pass structs and unions by value.
+      In this case, the value may be passed by reference, or by value, whichever way
+      Zig decides will be faster.
+      </p>
+      <p>
+      For extern functions, Zig follows the C ABI for passing structs and unions by value.
       </p>
       {#header_close#}
       {#header_open|Function Reflection#}

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -1135,7 +1135,10 @@ TypeTableEntry *get_fn_type(CodeGen *g, FnTypeId *fn_type_id) {
             gen_param_info->src_index = i;
             gen_param_info->gen_index = SIZE_MAX;
 
-            type_ensure_zero_bits_known(g, type_entry);
+            ensure_complete_type(g, type_entry);
+            if (type_is_invalid(type_entry))
+                return g->builtin_types.entry_invalid;
+
             if (type_has_bits(type_entry)) {
                 TypeTableEntry *gen_type;
                 if (handle_is_ptr(type_entry)) {
@@ -1546,12 +1549,6 @@ static TypeTableEntry *analyze_fn_type(CodeGen *g, AstNode *proto_node, Scope *c
             case TypeTableEntryIdUnion:
             case TypeTableEntryIdFn:
             case TypeTableEntryIdPromise:
-                ensure_complete_type(g, type_entry);
-                if (calling_convention_allows_zig_types(fn_type_id.cc) && !type_is_copyable(g, type_entry)) {
-                    add_node_error(g, param_node->data.param_decl.type,
-                        buf_sprintf("type '%s' is not copyable; cannot pass by value", buf_ptr(&type_entry->name)));
-                    return g->builtin_types.entry_invalid;
-                }
                 break;
         }
         FnTypeParamInfo *param_info = &fn_type_id.param_info[fn_type_id.next_param_index];

--- a/std/array_list.zig
+++ b/std/array_list.zig
@@ -29,36 +29,36 @@ pub fn AlignedArrayList(comptime T: type, comptime A: u29) type {
             };
         }
 
-        pub fn deinit(self: *const Self) void {
+        pub fn deinit(self: Self) void {
             self.allocator.free(self.items);
         }
 
-        pub fn toSlice(self: *const Self) []align(A) T {
+        pub fn toSlice(self: Self) []align(A) T {
             return self.items[0..self.len];
         }
 
-        pub fn toSliceConst(self: *const Self) []align(A) const T {
+        pub fn toSliceConst(self: Self) []align(A) const T {
             return self.items[0..self.len];
         }
 
-        pub fn at(self: *const Self, n: usize) T {
+        pub fn at(self: Self, n: usize) T {
             return self.toSliceConst()[n];
         }
 
         /// Sets the value at index `i`, or returns `error.OutOfBounds` if
         /// the index is not in range.
-        pub fn setOrError(self: *const Self, i: usize, item: *const T) !void {
+        pub fn setOrError(self: Self, i: usize, item: T) !void {
             if (i >= self.len) return error.OutOfBounds;
-            self.items[i] = item.*;
+            self.items[i] = item;
         }
 
         /// Sets the value at index `i`, asserting that the value is in range.
-        pub fn set(self: *const Self, i: usize, item: *const T) void {
+        pub fn set(self: *Self, i: usize, item: T) void {
             assert(i < self.len);
-            self.items[i] = item.*;
+            self.items[i] = item;
         }
 
-        pub fn count(self: *const Self) usize {
+        pub fn count(self: Self) usize {
             return self.len;
         }
 
@@ -81,12 +81,12 @@ pub fn AlignedArrayList(comptime T: type, comptime A: u29) type {
             return result;
         }
 
-        pub fn insert(self: *Self, n: usize, item: *const T) !void {
+        pub fn insert(self: *Self, n: usize, item: T) !void {
             try self.ensureCapacity(self.len + 1);
             self.len += 1;
 
             mem.copy(T, self.items[n + 1 .. self.len], self.items[n .. self.len - 1]);
-            self.items[n] = item.*;
+            self.items[n] = item;
         }
 
         pub fn insertSlice(self: *Self, n: usize, items: []align(A) const T) !void {
@@ -97,9 +97,9 @@ pub fn AlignedArrayList(comptime T: type, comptime A: u29) type {
             mem.copy(T, self.items[n .. n + items.len], items);
         }
 
-        pub fn append(self: *Self, item: *const T) !void {
+        pub fn append(self: *Self, item: T) !void {
             const new_item_ptr = try self.addOne();
-            new_item_ptr.* = item.*;
+            new_item_ptr.* = item;
         }
 
         pub fn appendSlice(self: *Self, items: []align(A) const T) !void {

--- a/std/build.zig
+++ b/std/build.zig
@@ -234,7 +234,7 @@ pub const Builder = struct {
         defer wanted_steps.deinit();
 
         if (step_names.len == 0) {
-            try wanted_steps.append(&self.default_step);
+            try wanted_steps.append(self.default_step);
         } else {
             for (step_names) |step_name| {
                 const s = try self.getTopLevelStepByName(step_name);

--- a/std/fmt/index.zig
+++ b/std/fmt/index.zig
@@ -162,8 +162,6 @@ pub fn formatType(
             },
             builtin.TypeInfo.Pointer.Size.Many => {
                 if (ptr_info.child == u8) {
-                    //This is a bit of a hack, but it made more sense to
-                    // do this check here than have formatText do it
                     if (fmt[0] == 's') {
                         const len = std.cstr.len(value);
                         return formatText(value[0..len], fmt, context, Errors, output);
@@ -175,6 +173,12 @@ pub fn formatType(
                 const casted_value = ([]const u8)(value);
                 return output(context, casted_value);
             },
+        },
+        builtin.TypeId.Array => |info| {
+            if (info.child == u8) {
+                return formatText(value, fmt, context, Errors, output);
+            }
+            return format(context, Errors, output, "{}@{x}", @typeName(T.Child), @ptrToInt(&value));
         },
         else => @compileError("Unable to format type '" ++ @typeName(T) ++ "'"),
     }

--- a/std/json.zig
+++ b/std/json.zig
@@ -1326,7 +1326,7 @@ pub const Parser = struct {
             },
             // Array Parent -> [ ..., <array>, value ]
             Value.Array => |*array| {
-                try array.append(value);
+                try array.append(value.*);
                 p.state = State.ArrayValue;
             },
             else => {

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -40,16 +40,12 @@ pub const Allocator = struct {
 
     /// Call destroy with the result
     /// TODO once #733 is solved, this will replace create
-    pub fn construct(self: *Allocator, init: var) t: {
-        // TODO this is a workaround for type getting parsed as Error!&const T
-        const T = @typeOf(init).Child;
-        break :t Error!*T;
-    } {
-        const T = @typeOf(init).Child;
+    pub fn construct(self: *Allocator, init: var) Error!*@typeOf(init) {
+        const T = @typeOf(init);
         if (@sizeOf(T) == 0) return &{};
         const slice = try self.alloc(T, 1);
         const ptr = &slice[0];
-        ptr.* = init.*;
+        ptr.* = init;
         return ptr;
     }
 

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -13,6 +13,7 @@ comptime {
     _ = @import("cases/bugs/656.zig");
     _ = @import("cases/bugs/828.zig");
     _ = @import("cases/bugs/920.zig");
+    _ = @import("cases/byval_arg_var.zig");
     _ = @import("cases/cast.zig");
     _ = @import("cases/const_slice_child.zig");
     _ = @import("cases/coroutines.zig");

--- a/test/cases/byval_arg_var.zig
+++ b/test/cases/byval_arg_var.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+
+var result: []const u8 = "wrong";
+
+test "aoeu" {
+    start();
+    blowUpStack(10);
+
+    std.debug.assert(std.mem.eql(u8, result, "string literal"));
+}
+
+fn start() void {
+    foo("string literal");
+}
+
+fn foo(x: var) void {
+    bar(x);
+}
+
+fn bar(x: var) void {
+    result = x;
+}
+
+fn blowUpStack(x: u32) void {
+    if (x == 0) return;
+    blowUpStack(x - 1);
+}

--- a/test/cases/cast.zig
+++ b/test/cases/cast.zig
@@ -318,14 +318,6 @@ fn testCastConstArrayRefToConstSlice() void {
     assert(mem.eql(u8, slice, "aoeu"));
 }
 
-test "var args implicitly casts by value arg to const ref" {
-    foo("hello");
-}
-
-fn foo(args: ...) void {
-    assert(@typeOf(args[0]) == *const [5]u8);
-}
-
 test "peer type resolution: error and [N]T" {
     // TODO: implicit error!T to error!U where T can implicitly cast to U
     //assert(mem.eql(u8, try testPeerErrorAndArray(0), "OK"));

--- a/test/cases/fn.zig
+++ b/test/cases/fn.zig
@@ -121,7 +121,7 @@ test "assign inline fn to const variable" {
 inline fn inlineFn() void {}
 
 test "pass by non-copying value" {
-    assert(bar(Point{ .x = 1, .y = 2 }) == 3);
+    assert(addPointCoords(Point{ .x = 1, .y = 2 }) == 3);
 }
 
 const Point = struct {
@@ -129,6 +129,50 @@ const Point = struct {
     y: i32,
 };
 
-fn bar(pt: Point) i32 {
+fn addPointCoords(pt: Point) i32 {
     return pt.x + pt.y;
+}
+
+test "pass by non-copying value through var arg" {
+    assert(addPointCoordsVar(Point{ .x = 1, .y = 2 }) == 3);
+}
+
+fn addPointCoordsVar(pt: var) i32 {
+    comptime assert(@typeOf(pt) == Point);
+    return pt.x + pt.y;
+}
+
+test "pass by non-copying value as method" {
+    var pt = Point2{ .x = 1, .y = 2 };
+    assert(pt.addPointCoords() == 3);
+}
+
+const Point2 = struct {
+    x: i32,
+    y: i32,
+
+    fn addPointCoords(self: Point2) i32 {
+        return self.x + self.y;
+    }
+};
+
+test "pass by non-copying value as method, which is generic" {
+    var pt = Point3{ .x = 1, .y = 2 };
+    assert(pt.addPointCoords(i32) == 3);
+}
+
+const Point3 = struct {
+    x: i32,
+    y: i32,
+
+    fn addPointCoords(self: Point3, comptime T: type) i32 {
+        return self.x + self.y;
+    }
+};
+
+test "pass by non-copying value as method, at comptime" {
+    comptime {
+        var pt = Point2{ .x = 1, .y = 2 };
+        assert(pt.addPointCoords() == 3);
+    }
 }

--- a/test/cases/fn.zig
+++ b/test/cases/fn.zig
@@ -119,3 +119,16 @@ test "assign inline fn to const variable" {
 }
 
 inline fn inlineFn() void {}
+
+test "pass by non-copying value" {
+    assert(bar(Point{ .x = 1, .y = 2 }) == 3);
+}
+
+const Point = struct {
+    x: i32,
+    y: i32,
+};
+
+fn bar(pt: Point) i32 {
+    return pt.x + pt.y;
+}

--- a/test/cases/var_args.zig
+++ b/test/cases/var_args.zig
@@ -75,18 +75,6 @@ test "array of var args functions" {
     assert(!foos[1]());
 }
 
-test "pass array and slice of same array to var args should have same pointers" {
-    const array = "hi";
-    const slice: []const u8 = array;
-    return assertSlicePtrsEql(array, slice);
-}
-
-fn assertSlicePtrsEql(args: ...) void {
-    const s1 = ([]const u8)(args[0]);
-    const s2 = args[1];
-    assert(s1.ptr == s2.ptr);
-}
-
 test "pass zero length array to var args param" {
     doNothingWithFirstArg("");
 }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2574,15 +2574,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     });
 
     cases.add(
-        "pass non-copyable type by value to function",
-        \\const Point = struct { x: i32, y: i32, };
-        \\fn foo(p: Point) void { }
-        \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
-    ,
-        ".tmp_source.zig:2:11: error: type 'Point' is not copyable; cannot pass by value",
-    );
-
-    cases.add(
         "implicit cast from array to mutable slice",
         \\var global_array: [10]i32 = undefined;
         \\fn foo(param: []i32) void {}
@@ -4064,20 +4055,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     ,
         ".tmp_source.zig:11:20: error: runtime cast to union 'Value' which has non-void fields",
         ".tmp_source.zig:3:5: note: field 'A' has type 'i32'",
-    );
-
-    cases.add(
-        "self-referencing function pointer field",
-        \\const S = struct {
-        \\    f: fn(_: S) void,
-        \\};
-        \\fn f(_: S) void {
-        \\}
-        \\export fn entry() void {
-        \\    var _ = S { .f = f };
-        \\}
-    ,
-        ".tmp_source.zig:4:9: error: type 'S' is not copyable; cannot pass by value",
     );
 
     cases.add(

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2215,7 +2215,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    derp.init();
         \\}
     ,
-        ".tmp_source.zig:14:5: error: expected type 'i32', found '*const Foo'",
+        ".tmp_source.zig:14:5: error: expected type 'i32', found 'Foo'",
     );
 
     cases.add(


### PR DESCRIPTION
closes #733

Here's the new thing you're allowed to do:

```zig
test "pass by non-copying value" {
    assert(bar(Point{ .x = 1, .y = 2 }) == 3);
}

const Point = struct {
    x: i32,
    y: i32,
};

fn bar(pt: Point) i32 {
    return pt.x + pt.y;
} 
```

See https://github.com/ziglang/zig/issues/733#issuecomment-397149295

All the old code still works, but it is now un-idiomatic when one would be better using these semantics.

And then the breaking change will come when we remove the implicit cast from `T` to `*const T`.
