### PR TITLE
add cross compilation regression test

### DIFF
--- a/test/build_examples.zig
+++ b/test/build_examples.zig
@@ -18,4 +18,5 @@ pub fn addCases(cases: *tests.BuildExamplesContext) void {
     cases.addBuildFile("test/standalone/pkg_import/build.zig");
     cases.addBuildFile("test/standalone/use_alias/build.zig");
     cases.addBuildFile("test/standalone/brace_expansion/build.zig");
+    cases.addBuildFile("test/standalone/cross_compile/build.zig");
 }

--- a/test/standalone/cross_compile/add.zig
+++ b/test/standalone/cross_compile/add.zig
@@ -1,0 +1,3 @@
+export fn add(a: i32, b: i32) i32 {
+    return a + b;
+}

--- a/test/standalone/cross_compile/build.zig
+++ b/test/standalone/cross_compile/build.zig
@@ -1,0 +1,18 @@
+const builtin = @import("builtin");
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    const exe = b.addExecutable("test", "test.zig");
+    exe.setBuildMode(b.standardReleaseOptions());
+
+    const lib = b.addStaticLibrary("lib", "lib.zig");
+    lib.setBuildMode(builtin.Mode.ReleaseSmall);
+    lib.setTarget(builtin.Arch.wasm32, builtin.Os.freestanding, builtin.Environ.unknown);
+
+    const run = b.addCommand(".", b.env_map, [][]const u8{exe.getOutputPath()});
+    run.step.dependOn(&exe.step);
+    run.step.dependOn(&lib.step);
+
+    const test_step = b.step("test", "Test it");
+    test_step.dependOn(&run.step);
+}

--- a/test/standalone/cross_compile/lib.zig
+++ b/test/standalone/cross_compile/lib.zig
@@ -1,0 +1,1 @@
+pub use @import("add.zig");

--- a/test/standalone/cross_compile/test.zig
+++ b/test/standalone/cross_compile/test.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const mem = std.mem;
+
+pub fn main() !void {
+    var direct = std.heap.DirectAllocator.init();
+    defer direct.deinit();
+
+    const bytes = try std.io.readFileAlloc(&direct.allocator, "zig-cache/liblib.a");
+    defer direct.allocator.free(bytes);
+
+    // Verify that it is a wasm file and has the symbol "add" somewhere in it.
+    assert(mem.indexOf(u8, bytes, "\x00asm").? == 0);
+    assert(mem.indexOf(u8, bytes, "\x03add") != null);
+}


### PR DESCRIPTION
Verify that it's possible to build for the host architecture
and a different target architecture from a single build.zig.

The test doubles as a basic WebAssembly smoke test.