### PR TITLE
std.mem.Allocator: replace create signature with construct signature

### DIFF
--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -114,8 +114,10 @@ fn startPuts(ctx: *Context) u8 {
     while (put_count != 0) : (put_count -= 1) {
         std.os.time.sleep(0, 1); // let the os scheduler be our fuzz
         const x = @bitCast(i32, r.random.scalar(u32));
-        const node = ctx.allocator.create(Queue(i32).Node) catch unreachable;
-        node.data = x;
+        const node = ctx.allocator.create(Queue(i32).Node{
+            .next = null,
+            .data = x
+        }) catch unreachable;
         ctx.queue.put(node);
         _ = @atomicRmw(isize, &ctx.put_sum, builtin.AtomicRmwOp.Add, x, AtomicOrder.SeqCst);
     }

--- a/std/atomic/stack.zig
+++ b/std/atomic/stack.zig
@@ -117,8 +117,10 @@ fn startPuts(ctx: *Context) u8 {
     while (put_count != 0) : (put_count -= 1) {
         std.os.time.sleep(0, 1); // let the os scheduler be our fuzz
         const x = @bitCast(i32, r.random.scalar(u32));
-        const node = ctx.allocator.create(Stack(i32).Node) catch unreachable;
-        node.data = x;
+        const node = ctx.allocator.create(Stack(i32).Node{
+            .next = null,
+            .data = x
+        }) catch unreachable;
         ctx.stack.push(node);
         _ = @atomicRmw(isize, &ctx.put_sum, builtin.AtomicRmwOp.Add, x, AtomicOrder.SeqCst);
     }

--- a/std/build.zig
+++ b/std/build.zig
@@ -158,8 +158,7 @@ pub const Builder = struct {
     }
 
     pub fn addTest(self: *Builder, root_src: []const u8) *TestStep {
-        const test_step = self.allocator.create(TestStep) catch unreachable;
-        test_step.* = TestStep.init(self, root_src);
+        const test_step = self.allocator.create(TestStep.init(self, root_src)) catch unreachable;
         return test_step;
     }
 
@@ -191,21 +190,18 @@ pub const Builder = struct {
     }
 
     pub fn addWriteFile(self: *Builder, file_path: []const u8, data: []const u8) *WriteFileStep {
-        const write_file_step = self.allocator.create(WriteFileStep) catch unreachable;
-        write_file_step.* = WriteFileStep.init(self, file_path, data);
+        const write_file_step = self.allocator.create(WriteFileStep.init(self, file_path, data)) catch unreachable;
         return write_file_step;
     }
 
     pub fn addLog(self: *Builder, comptime format: []const u8, args: ...) *LogStep {
         const data = self.fmt(format, args);
-        const log_step = self.allocator.create(LogStep) catch unreachable;
-        log_step.* = LogStep.init(self, data);
+        const log_step = self.allocator.create(LogStep.init(self, data)) catch unreachable;
         return log_step;
     }
 
     pub fn addRemoveDirTree(self: *Builder, dir_path: []const u8) *RemoveDirStep {
-        const remove_dir_step = self.allocator.create(RemoveDirStep) catch unreachable;
-        remove_dir_step.* = RemoveDirStep.init(self, dir_path);
+        const remove_dir_step = self.allocator.create(RemoveDirStep.init(self, dir_path)) catch unreachable;
         return remove_dir_step;
     }
 
@@ -404,11 +400,10 @@ pub const Builder = struct {
     }
 
     pub fn step(self: *Builder, name: []const u8, description: []const u8) *Step {
-        const step_info = self.allocator.create(TopLevelStep) catch unreachable;
-        step_info.* = TopLevelStep{
+        const step_info = self.allocator.create(TopLevelStep{
             .step = Step.initNoOp(name, self.allocator),
             .description = description,
-        };
+        }) catch unreachable;
         self.top_level_steps.append(step_info) catch unreachable;
         return &step_info.step;
     }
@@ -598,8 +593,7 @@ pub const Builder = struct {
         const full_dest_path = os.path.resolve(self.allocator, self.prefix, dest_rel_path) catch unreachable;
         self.pushInstalledFile(full_dest_path);
 
-        const install_step = self.allocator.create(InstallFileStep) catch unreachable;
-        install_step.* = InstallFileStep.init(self, src_path, full_dest_path);
+        const install_step = self.allocator.create(InstallFileStep.init(self, src_path, full_dest_path)) catch unreachable;
         return install_step;
     }
 
@@ -837,51 +831,43 @@ pub const LibExeObjStep = struct {
     };
 
     pub fn createSharedLibrary(builder: *Builder, name: []const u8, root_src: ?[]const u8, ver: *const Version) *LibExeObjStep {
-        const self = builder.allocator.create(LibExeObjStep) catch unreachable;
-        self.* = initExtraArgs(builder, name, root_src, Kind.Lib, false, ver);
+        const self = builder.allocator.create(initExtraArgs(builder, name, root_src, Kind.Lib, false, ver)) catch unreachable;
         return self;
     }
 
     pub fn createCSharedLibrary(builder: *Builder, name: []const u8, version: *const Version) *LibExeObjStep {
-        const self = builder.allocator.create(LibExeObjStep) catch unreachable;
-        self.* = initC(builder, name, Kind.Lib, version, false);
+        const self = builder.allocator.create(initC(builder, name, Kind.Lib, version, false)) catch unreachable;
         return self;
     }
 
     pub fn createStaticLibrary(builder: *Builder, name: []const u8, root_src: ?[]const u8) *LibExeObjStep {
-        const self = builder.allocator.create(LibExeObjStep) catch unreachable;
-        self.* = initExtraArgs(builder, name, root_src, Kind.Lib, true, builder.version(0, 0, 0));
+        const self = builder.allocator.create(initExtraArgs(builder, name, root_src, Kind.Lib, true, builder.version(0, 0, 0))) catch unreachable;
         return self;
     }
 
     pub fn createCStaticLibrary(builder: *Builder, name: []const u8) *LibExeObjStep {
-        const self = builder.allocator.create(LibExeObjStep) catch unreachable;
-        self.* = initC(builder, name, Kind.Lib, builder.version(0, 0, 0), true);
+        const self = builder.allocator.create(initC(builder, name, Kind.Lib, builder.version(0, 0, 0), true)) catch unreachable;
         return self;
     }
 
     pub fn createObject(builder: *Builder, name: []const u8, root_src: []const u8) *LibExeObjStep {
-        const self = builder.allocator.create(LibExeObjStep) catch unreachable;
-        self.* = initExtraArgs(builder, name, root_src, Kind.Obj, false, builder.version(0, 0, 0));
+        const self = builder.allocator.create(initExtraArgs(builder, name, root_src, Kind.Obj, false, builder.version(0, 0, 0))) catch unreachable;
         return self;
     }
 
     pub fn createCObject(builder: *Builder, name: []const u8, src: []const u8) *LibExeObjStep {
-        const self = builder.allocator.create(LibExeObjStep) catch unreachable;
-        self.* = initC(builder, name, Kind.Obj, builder.version(0, 0, 0), false);
+        const self = builder.allocator.create(initC(builder, name, Kind.Obj, builder.version(0, 0, 0), false)) catch unreachable;
         self.object_src = src;
         return self;
     }
 
     pub fn createExecutable(builder: *Builder, name: []const u8, root_src: ?[]const u8) *LibExeObjStep {
-        const self = builder.allocator.create(LibExeObjStep) catch unreachable;
-        self.* = initExtraArgs(builder, name, root_src, Kind.Exe, false, builder.version(0, 0, 0));
+        const self = builder.allocator.create(initExtraArgs(builder, name, root_src, Kind.Exe, false, builder.version(0, 0, 0))) catch unreachable;
         return self;
     }
 
     pub fn createCExecutable(builder: *Builder, name: []const u8) *LibExeObjStep {
-        const self = builder.allocator.create(LibExeObjStep) catch unreachable;
-        self.* = initC(builder, name, Kind.Exe, builder.version(0, 0, 0), false);
+        const self = builder.allocator.create(initC(builder, name, Kind.Exe, builder.version(0, 0, 0), false)) catch unreachable;
         return self;
     }
 
@@ -1748,14 +1734,14 @@ pub const CommandStep = struct {
 
     /// ::argv is copied.
     pub fn create(builder: *Builder, cwd: ?[]const u8, env_map: *const BufMap, argv: []const []const u8) *CommandStep {
-        const self = builder.allocator.create(CommandStep) catch unreachable;
-        self.* = CommandStep{
+        const self = builder.allocator.create(CommandStep{
             .builder = builder,
             .step = Step.init(argv[0], builder.allocator, make),
             .argv = builder.allocator.alloc([]u8, argv.len) catch unreachable,
             .cwd = cwd,
             .env_map = env_map,
-        };
+        }) catch unreachable;
+
         mem.copy([]const u8, self.argv, argv);
         self.step.name = self.argv[0];
         return self;
@@ -1778,18 +1764,17 @@ const InstallArtifactStep = struct {
     const Self = this;
 
     pub fn create(builder: *Builder, artifact: *LibExeObjStep) *Self {
-        const self = builder.allocator.create(Self) catch unreachable;
         const dest_dir = switch (artifact.kind) {
             LibExeObjStep.Kind.Obj => unreachable,
             LibExeObjStep.Kind.Exe => builder.exe_dir,
             LibExeObjStep.Kind.Lib => builder.lib_dir,
         };
-        self.* = Self{
+        const self = builder.allocator.create(Self{
             .builder = builder,
             .step = Step.init(builder.fmt("install {}", artifact.step.name), builder.allocator, make),
             .artifact = artifact,
             .dest_file = os.path.join(builder.allocator, dest_dir, artifact.out_filename) catch unreachable,
-        };
+        }) catch unreachable;
         self.step.dependOn(&artifact.step);
         builder.pushInstalledFile(self.dest_file);
         if (self.artifact.kind == LibExeObjStep.Kind.Lib and !self.artifact.static) {

--- a/std/debug/index.zig
+++ b/std/debug/index.zig
@@ -249,9 +249,7 @@ fn printSourceAtAddress(debug_info: *ElfStackTrace, out_stream: var, address: us
 pub fn openSelfDebugInfo(allocator: *mem.Allocator) !*ElfStackTrace {
     switch (builtin.object_format) {
         builtin.ObjectFormat.elf => {
-            const st = try allocator.create(ElfStackTrace);
-            errdefer allocator.destroy(st);
-            st.* = ElfStackTrace{
+            const st = try allocator.create(ElfStackTrace{
                 .self_exe_file = undefined,
                 .elf = undefined,
                 .debug_info = undefined,
@@ -261,7 +259,8 @@ pub fn openSelfDebugInfo(allocator: *mem.Allocator) !*ElfStackTrace {
                 .debug_ranges = null,
                 .abbrev_table_list = ArrayList(AbbrevTableHeader).init(allocator),
                 .compile_unit_list = ArrayList(CompileUnit).init(allocator),
-            };
+            });
+            errdefer allocator.destroy(st);
             st.self_exe_file = try os.openSelfExe();
             errdefer st.self_exe_file.close();
 
@@ -280,11 +279,10 @@ pub fn openSelfDebugInfo(allocator: *mem.Allocator) !*ElfStackTrace {
             var exe_file = try os.openSelfExe();
             defer exe_file.close();
 
-            const st = try allocator.create(ElfStackTrace);
+            const st = try allocator.create(ElfStackTrace{
+                .symbol_table = try macho.loadSymbols(allocator, &io.FileInStream.init(&exe_file))
+            });
             errdefer allocator.destroy(st);
-
-            st.* = ElfStackTrace{ .symbol_table = try macho.loadSymbols(allocator, &io.FileInStream.init(&exe_file)) };
-
             return st;
         },
         builtin.ObjectFormat.coff => {
@@ -974,8 +972,7 @@ fn scanAllCompileUnits(st: *ElfStackTrace) !void {
 
         try st.self_exe_file.seekTo(compile_unit_pos);
 
-        const compile_unit_die = try st.allocator().create(Die);
-        compile_unit_die.* = try parseDie(st, abbrev_table, is_64);
+        const compile_unit_die = try st.allocator().create( try parseDie(st, abbrev_table, is_64) );
 
         if (compile_unit_die.tag_id != DW.TAG_compile_unit) return error.InvalidDebugInfo;
 

--- a/std/heap.zig
+++ b/std/heap.zig
@@ -407,7 +407,7 @@ fn testAllocator(allocator: *mem.Allocator) !void {
     var slice = try allocator.alloc(*i32, 100);
 
     for (slice) |*item, i| {
-        item.* = try allocator.create(i32);
+        item.* = try allocator.create(i32(0));
         item.*.* = @intCast(i32, i);
     }
 

--- a/std/io.zig
+++ b/std/io.zig
@@ -414,14 +414,12 @@ pub const BufferedAtomicFile = struct {
 
     pub fn create(allocator: *mem.Allocator, dest_path: []const u8) !*BufferedAtomicFile {
         // TODO with well defined copy elision we don't need this allocation
-        var self = try allocator.create(BufferedAtomicFile);
-        errdefer allocator.destroy(self);
-
-        self.* = BufferedAtomicFile{
+        var self = try allocator.create(BufferedAtomicFile{
             .atomic_file = undefined,
             .file_stream = undefined,
             .buffered_stream = undefined,
-        };
+        });
+        errdefer allocator.destroy(self);
 
         self.atomic_file = try os.AtomicFile.init(allocator, dest_path, os.default_file_mode);
         errdefer self.atomic_file.deinit();

--- a/std/linked_list.zig
+++ b/std/linked_list.zig
@@ -193,7 +193,11 @@ fn BaseLinkedList(comptime T: type, comptime ParentType: type, comptime field_na
         ///     A pointer to the new node.
         pub fn allocateNode(list: *Self, allocator: *Allocator) !*Node {
             comptime assert(!isIntrusive());
-            return allocator.create(Node);
+            return allocator.create(Node{
+              .prev = null,
+              .next = null,
+              .data = undefined
+            });
         }
 
         /// Deallocate a node.

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -32,21 +32,20 @@ pub const Allocator = struct {
     freeFn: fn (self: *Allocator, old_mem: []u8) void,
 
     /// Call destroy with the result
-    pub fn create(self: *Allocator, comptime T: type) !*T {
-        if (@sizeOf(T) == 0) return *{};
-        const slice = try self.alloc(T, 1);
-        return &slice[0];
-    }
-
-    /// Call destroy with the result
-    /// TODO once #733 is solved, this will replace create
-    pub fn construct(self: *Allocator, init: var) Error!*@typeOf(init) {
+    pub fn create(self: *Allocator, init: var) Error!*@typeOf(init) {
         const T = @typeOf(init);
         if (@sizeOf(T) == 0) return &{};
         const slice = try self.alloc(T, 1);
         const ptr = &slice[0];
         ptr.* = init;
         return ptr;
+    }
+
+    /// Alias of create
+    /// Call destroy with the result
+    pub fn construct(self: *Allocator, init: var) Error!*@typeOf(init) {
+      debug.warn("std.mem.Allocator.construct is deprecated;\n");
+      return self.create(init);
     }
 
     /// `ptr` should be the return value of `construct` or `create`

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -44,7 +44,6 @@ pub const Allocator = struct {
     /// Alias of create
     /// Call destroy with the result
     pub fn construct(self: *Allocator, init: var) Error!*@typeOf(init) {
-      debug.warn("std.mem.Allocator.construct is deprecated;\n");
       return self.create(init);
     }
 

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -31,7 +31,7 @@ pub const Allocator = struct {
     /// Guaranteed: `old_mem.len` is the same as what was returned from `allocFn` or `reallocFn`
     freeFn: fn (self: *Allocator, old_mem: []u8) void,
 
-    /// Call destroy with the result
+    /// Call `destroy` with the result
     pub fn create(self: *Allocator, init: var) Error!*@typeOf(init) {
         const T = @typeOf(init);
         if (@sizeOf(T) == 0) return &{};
@@ -41,8 +41,8 @@ pub const Allocator = struct {
         return ptr;
     }
 
-    /// Alias of create
-    /// Call destroy with the result
+    /// Alias of `create`
+    /// Call `destroy` with the result
     pub fn construct(self: *Allocator, init: var) Error!*@typeOf(init) {
       return self.create(init);
     }

--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -85,10 +85,7 @@ pub const ChildProcess = struct {
     /// First argument in argv is the executable.
     /// On success must call deinit.
     pub fn init(argv: []const []const u8, allocator: *mem.Allocator) !*ChildProcess {
-        const child = try allocator.create(ChildProcess);
-        errdefer allocator.destroy(child);
-
-        child.* = ChildProcess{
+        const child = try allocator.create(ChildProcess{
             .allocator = allocator,
             .argv = argv,
             .pid = undefined,
@@ -109,8 +106,8 @@ pub const ChildProcess = struct {
             .stdin_behavior = StdIo.Inherit,
             .stdout_behavior = StdIo.Inherit,
             .stderr_behavior = StdIo.Inherit,
-        };
-
+        });
+        errdefer allocator.destroy(child);
         return child;
     }
 

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -2582,8 +2582,11 @@ pub fn spawnThread(context: var, comptime startFn: var) SpawnThreadError!*Thread
         const bytes_ptr = windows.HeapAlloc(heap_handle, 0, byte_count) orelse return SpawnThreadError.OutOfMemory;
         errdefer assert(windows.HeapFree(heap_handle, 0, bytes_ptr) != 0);
         const bytes = @ptrCast([*]u8, bytes_ptr)[0..byte_count];
-        const outer_context = std.heap.FixedBufferAllocator.init(bytes).allocator.create(WinThread.OuterContext) catch unreachable;
-        outer_context.inner = context;
+        const outer_context = std.heap.FixedBufferAllocator.init(bytes).allocator.create(WinThread.OuterContext{
+          .thread = undefined,
+          .inner = context
+        }) catch unreachable;
+
         outer_context.thread.data.heap_handle = heap_handle;
         outer_context.thread.data.alloc_start = bytes_ptr;
 

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -48,13 +48,12 @@ const test_targets = []TestTarget{
 const max_stdout_size = 1 * 1024 * 1024; // 1 MB
 
 pub fn addCompareOutputTests(b: *build.Builder, test_filter: ?[]const u8) *build.Step {
-    const cases = b.allocator.create(CompareOutputContext) catch unreachable;
-    cases.* = CompareOutputContext{
+    const cases = b.allocator.create(CompareOutputContext{
         .b = b,
         .step = b.step("test-compare-output", "Run the compare output tests"),
         .test_index = 0,
         .test_filter = test_filter,
-    };
+    }) catch unreachable;
 
     compare_output.addCases(cases);
 
@@ -62,13 +61,12 @@ pub fn addCompareOutputTests(b: *build.Builder, test_filter: ?[]const u8) *build
 }
 
 pub fn addRuntimeSafetyTests(b: *build.Builder, test_filter: ?[]const u8) *build.Step {
-    const cases = b.allocator.create(CompareOutputContext) catch unreachable;
-    cases.* = CompareOutputContext{
+    const cases = b.allocator.create(CompareOutputContext{
         .b = b,
         .step = b.step("test-runtime-safety", "Run the runtime safety tests"),
         .test_index = 0,
         .test_filter = test_filter,
-    };
+    }) catch unreachable;
 
     runtime_safety.addCases(cases);
 
@@ -76,13 +74,12 @@ pub fn addRuntimeSafetyTests(b: *build.Builder, test_filter: ?[]const u8) *build
 }
 
 pub fn addCompileErrorTests(b: *build.Builder, test_filter: ?[]const u8) *build.Step {
-    const cases = b.allocator.create(CompileErrorContext) catch unreachable;
-    cases.* = CompileErrorContext{
+    const cases = b.allocator.create(CompileErrorContext{
         .b = b,
         .step = b.step("test-compile-errors", "Run the compile error tests"),
         .test_index = 0,
         .test_filter = test_filter,
-    };
+    }) catch unreachable;
 
     compile_errors.addCases(cases);
 
@@ -90,13 +87,12 @@ pub fn addCompileErrorTests(b: *build.Builder, test_filter: ?[]const u8) *build.
 }
 
 pub fn addBuildExampleTests(b: *build.Builder, test_filter: ?[]const u8) *build.Step {
-    const cases = b.allocator.create(BuildExamplesContext) catch unreachable;
-    cases.* = BuildExamplesContext{
+    const cases = b.allocator.create(BuildExamplesContext{
         .b = b,
         .step = b.step("test-build-examples", "Build the examples"),
         .test_index = 0,
         .test_filter = test_filter,
-    };
+    }) catch unreachable;
 
     build_examples.addCases(cases);
 
@@ -104,13 +100,12 @@ pub fn addBuildExampleTests(b: *build.Builder, test_filter: ?[]const u8) *build.
 }
 
 pub fn addAssembleAndLinkTests(b: *build.Builder, test_filter: ?[]const u8) *build.Step {
-    const cases = b.allocator.create(CompareOutputContext) catch unreachable;
-    cases.* = CompareOutputContext{
+    const cases = b.allocator.create(CompareOutputContext{
         .b = b,
         .step = b.step("test-asm-link", "Run the assemble and link tests"),
         .test_index = 0,
         .test_filter = test_filter,
-    };
+    }) catch unreachable;
 
     assemble_and_link.addCases(cases);
 
@@ -118,13 +113,12 @@ pub fn addAssembleAndLinkTests(b: *build.Builder, test_filter: ?[]const u8) *bui
 }
 
 pub fn addTranslateCTests(b: *build.Builder, test_filter: ?[]const u8) *build.Step {
-    const cases = b.allocator.create(TranslateCContext) catch unreachable;
-    cases.* = TranslateCContext{
+    const cases = b.allocator.create(TranslateCContext{
         .b = b,
         .step = b.step("test-translate-c", "Run the C transation tests"),
         .test_index = 0,
         .test_filter = test_filter,
-    };
+    }) catch unreachable;
 
     translate_c.addCases(cases);
 
@@ -132,13 +126,12 @@ pub fn addTranslateCTests(b: *build.Builder, test_filter: ?[]const u8) *build.St
 }
 
 pub fn addGenHTests(b: *build.Builder, test_filter: ?[]const u8) *build.Step {
-    const cases = b.allocator.create(GenHContext) catch unreachable;
-    cases.* = GenHContext{
+    const cases = b.allocator.create(GenHContext{
         .b = b,
         .step = b.step("test-gen-h", "Run the C header file generation tests"),
         .test_index = 0,
         .test_filter = test_filter,
-    };
+    }) catch unreachable;
 
     gen_h.addCases(cases);
 
@@ -240,8 +233,7 @@ pub const CompareOutputContext = struct {
 
         pub fn create(context: *CompareOutputContext, exe_path: []const u8, name: []const u8, expected_output: []const u8, cli_args: []const []const u8) *RunCompareOutputStep {
             const allocator = context.b.allocator;
-            const ptr = allocator.create(RunCompareOutputStep) catch unreachable;
-            ptr.* = RunCompareOutputStep{
+            const ptr = allocator.create(RunCompareOutputStep{
                 .context = context,
                 .exe_path = exe_path,
                 .name = name,
@@ -249,7 +241,7 @@ pub const CompareOutputContext = struct {
                 .test_index = context.test_index,
                 .step = build.Step.init("RunCompareOutput", allocator, make),
                 .cli_args = cli_args,
-            };
+            }) catch unreachable;
             context.test_index += 1;
             return ptr;
         }
@@ -328,14 +320,14 @@ pub const CompareOutputContext = struct {
 
         pub fn create(context: *CompareOutputContext, exe_path: []const u8, name: []const u8) *RuntimeSafetyRunStep {
             const allocator = context.b.allocator;
-            const ptr = allocator.create(RuntimeSafetyRunStep) catch unreachable;
-            ptr.* = RuntimeSafetyRunStep{
+            const ptr = allocator.create(RuntimeSafetyRunStep{
                 .context = context,
                 .exe_path = exe_path,
                 .name = name,
                 .test_index = context.test_index,
                 .step = build.Step.init("RuntimeSafetyRun", allocator, make),
-            };
+            }) catch unreachable;
+
             context.test_index += 1;
             return ptr;
         }
@@ -543,15 +535,15 @@ pub const CompileErrorContext = struct {
 
         pub fn create(context: *CompileErrorContext, name: []const u8, case: *const TestCase, build_mode: Mode) *CompileCmpOutputStep {
             const allocator = context.b.allocator;
-            const ptr = allocator.create(CompileCmpOutputStep) catch unreachable;
-            ptr.* = CompileCmpOutputStep{
+            const ptr = allocator.create(CompileCmpOutputStep{
                 .step = build.Step.init("CompileCmpOutput", allocator, make),
                 .context = context,
                 .name = name,
                 .test_index = context.test_index,
                 .case = case,
                 .build_mode = build_mode,
-            };
+            }) catch unreachable;
+
             context.test_index += 1;
             return ptr;
         }
@@ -662,14 +654,14 @@ pub const CompileErrorContext = struct {
     }
 
     pub fn create(self: *CompileErrorContext, name: []const u8, source: []const u8, expected_lines: ...) *TestCase {
-        const tc = self.b.allocator.create(TestCase) catch unreachable;
-        tc.* = TestCase{
+        const tc = self.b.allocator.create(TestCase{
             .name = name,
             .sources = ArrayList(TestCase.SourceFile).init(self.b.allocator),
             .expected_errors = ArrayList([]const u8).init(self.b.allocator),
             .link_libc = false,
             .is_exe = false,
-        };
+        }) catch unreachable;
+
         tc.addSourceFile(".tmp_source.zig", source);
         comptime var arg_i = 0;
         inline while (arg_i < expected_lines.len) : (arg_i += 1) {
@@ -829,14 +821,14 @@ pub const TranslateCContext = struct {
 
         pub fn create(context: *TranslateCContext, name: []const u8, case: *const TestCase) *TranslateCCmpOutputStep {
             const allocator = context.b.allocator;
-            const ptr = allocator.create(TranslateCCmpOutputStep) catch unreachable;
-            ptr.* = TranslateCCmpOutputStep{
+            const ptr = allocator.create(TranslateCCmpOutputStep{
                 .step = build.Step.init("ParseCCmpOutput", allocator, make),
                 .context = context,
                 .name = name,
                 .test_index = context.test_index,
                 .case = case,
-            };
+            }) catch unreachable;
+
             context.test_index += 1;
             return ptr;
         }
@@ -936,13 +928,13 @@ pub const TranslateCContext = struct {
     }
 
     pub fn create(self: *TranslateCContext, allow_warnings: bool, filename: []const u8, name: []const u8, source: []const u8, expected_lines: ...) *TestCase {
-        const tc = self.b.allocator.create(TestCase) catch unreachable;
-        tc.* = TestCase{
+        const tc = self.b.allocator.create(TestCase{
             .name = name,
             .sources = ArrayList(TestCase.SourceFile).init(self.b.allocator),
             .expected_lines = ArrayList([]const u8).init(self.b.allocator),
             .allow_warnings = allow_warnings,
-        };
+        }) catch unreachable;
+
         tc.addSourceFile(filename, source);
         comptime var arg_i = 0;
         inline while (arg_i < expected_lines.len) : (arg_i += 1) {
@@ -1023,15 +1015,15 @@ pub const GenHContext = struct {
 
         pub fn create(context: *GenHContext, h_path: []const u8, name: []const u8, case: *const TestCase) *GenHCmpOutputStep {
             const allocator = context.b.allocator;
-            const ptr = allocator.create(GenHCmpOutputStep) catch unreachable;
-            ptr.* = GenHCmpOutputStep{
+            const ptr = allocator.create(GenHCmpOutputStep{
                 .step = build.Step.init("ParseCCmpOutput", allocator, make),
                 .context = context,
                 .h_path = h_path,
                 .name = name,
                 .test_index = context.test_index,
                 .case = case,
-            };
+            }) catch unreachable;
+
             context.test_index += 1;
             return ptr;
         }
@@ -1070,12 +1062,12 @@ pub const GenHContext = struct {
     }
 
     pub fn create(self: *GenHContext, filename: []const u8, name: []const u8, source: []const u8, expected_lines: ...) *TestCase {
-        const tc = self.b.allocator.create(TestCase) catch unreachable;
-        tc.* = TestCase{
+        const tc = self.b.allocator.create(TestCase{
             .name = name,
             .sources = ArrayList(TestCase.SourceFile).init(self.b.allocator),
             .expected_lines = ArrayList([]const u8).init(self.b.allocator),
-        };
+        }) catch unreachable;
+
         tc.addSourceFile(filename, source);
         comptime var arg_i = 0;
         inline while (arg_i < expected_lines.len) : (arg_i += 1) {


### PR DESCRIPTION
ref #733 

```
/// Call destroy with the result	
/// TODO once #733 is solved, this will replace create	
pub fn construct(self: *Allocator, init: var) Error!*@typeOf(init) {	
```