### PR TITLE
Clarify reason implicit cast does not work for large RHS

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -11434,8 +11434,10 @@ static TypeTableEntry *ir_analyze_bit_shift(IrAnalyze *ira, IrInstructionBinOp *
                 op1->value.type->data.integral.bit_count - 1);
 
         casted_op2 = ir_implicit_cast(ira, op2, shift_amt_type);
-        if (casted_op2 == ira->codegen->invalid_instruction)
+        if (casted_op2 == ira->codegen->invalid_instruction) {
+            ir_add_error(ira, &bin_op_instruction->base, buf_sprintf("RHS of shift is too large for LHS type"));
             return ira->codegen->builtin_types.entry_invalid;
+        }
     }
 
     if (instr_is_comptime(op1) && instr_is_comptime(casted_op2)) {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -11437,9 +11437,18 @@ static TypeTableEntry *ir_analyze_bit_shift(IrAnalyze *ira, IrInstructionBinOp *
             if (!bigint_fits_in_bits(&op2->value.data.x_bigint,
                                      shift_amt_type->data.integral.bit_count,
                                      op2->value.data.x_bigint.is_negative)) {
-                ir_add_error(ira,
-                             &bin_op_instruction->base,
-                             buf_sprintf("RHS of shift is too large for LHS type"));
+                Buf *val_buf = buf_alloc();
+                bigint_append_buf(val_buf, &op2->value.data.x_bigint, 10);
+                ErrorMsg* msg = ir_add_error(ira,
+                    &bin_op_instruction->base,
+                    buf_sprintf("RHS of shift is too large for LHS type"));
+                add_error_note(
+                    ira->codegen,
+                    msg,
+                    op2->source_node,
+                    buf_sprintf("value %s cannot fit into type %s",
+                        buf_ptr(val_buf),
+                        buf_ptr(&shift_amt_type->name)));
                 return ira->codegen->builtin_types.entry_invalid;
             }
         }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1685,7 +1685,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() u16 { return f(); }
     ,
-        ".tmp_source.zig:3:17: error: integer value 8 cannot be implicitly casted to type 'u3'",
         ".tmp_source.zig:3:14: error: RHS of shift is too large for LHS type",
     );
 

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1686,6 +1686,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\export fn entry() u16 { return f(); }
     ,
         ".tmp_source.zig:3:14: error: RHS of shift is too large for LHS type",
+        ".tmp_source.zig:3:17: note: value 8 cannot fit into type u3",
     );
 
     cases.add(

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1678,6 +1678,18 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
+        "invalid shift amount error",
+        \\const x : u8 = 2;
+        \\fn f() u16 {
+        \\    return x << 8;
+        \\}
+        \\export fn entry() u16 { return f(); }
+    ,
+        ".tmp_source.zig:3:17: error: integer value 8 cannot be implicitly casted to type 'u3'",
+        ".tmp_source.zig:3:14: error: RHS of shift is too large for LHS type",
+    );
+
+    cases.add(
         "incompatible number literals",
         \\const x = 2 == 2.0;
         \\export fn entry() usize { return @sizeOf(@typeOf(x)); }


### PR DESCRIPTION
Took me a while to figure out that I had to cast LHS of bit shift for this case:

```
var x : u8 = 5;
fn make16Bits() u16 {
    return (x << 8) & 0xff00;
}
```

Error message:
```
 error: integer value 8 cannot be implicitly casted to type 'u3'
```

Fix:
```
var x : u8 = 5;
fn make16Bits() u16 {
    return (u16(x) << 8) & 0xff00;
}
```

So I improved the error message to help out here.