### PR TITLE
Fix -Werror=maybe-uninitialized errors

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -2640,8 +2640,8 @@ static void resolve_union_zero_bits(CodeGen *g, TypeTableEntry *union_type) {
     bool want_safety = (field_count >= 2) && (auto_layout || enum_type_node != nullptr);
     TypeTableEntry *tag_type;
     bool create_enum_type = decl_node->data.container_decl.auto_enum || (enum_type_node == nullptr && want_safety);
-    bool *covered_enum_fields;
-    ZigLLVMDIEnumerator **di_enumerators;
+    bool *covered_enum_fields = nullptr;
+    ZigLLVMDIEnumerator **di_enumerators = nullptr;
     uint32_t abi_alignment_so_far;
     if (create_enum_type) {
         occupied_tag_values.init(field_count);
@@ -2841,6 +2841,8 @@ static void resolve_union_zero_bits(CodeGen *g, TypeTableEntry *union_type) {
             case ContainerLayoutExtern:
                 qual_str = "extern";
                 break;
+            default:
+                zig_unreachable();
         }
         AstNode *source_node = (decl_node->data.container_decl.init_arg_expr != nullptr) ?
             decl_node->data.container_decl.init_arg_expr : decl_node;

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -515,6 +515,8 @@ void bigint_add(BigInt *dest, const BigInt *op1, const BigInt *op2) {
             smaller_op = &op_neg_abs;
             dest->is_negative = false;
             break;
+        default:
+            zig_unreachable();
     }
     const uint64_t *bigger_op_digits = bigint_ptr(bigger_op);
     const uint64_t *smaller_op_digits = bigint_ptr(smaller_op);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -704,6 +704,8 @@ static LLVMValueRef get_int_overflow_fn(CodeGen *g, TypeTableEntry *type_entry, 
         case AddSubMulMul:
             fn_val = get_arithmetic_overflow_fn(g, type_entry, "smul", "umul");
             break;
+        default:
+            zig_unreachable();
     }
 
     g->llvm_fn_table.put(key, fn_val);
@@ -3110,6 +3112,8 @@ static LLVMValueRef ir_render_call(CodeGen *g, IrExecutable *executable, IrInstr
         case FnInlineNever:
             fn_inline = ZigLLVM_FnInlineNever;
             break;
+        default:
+            zig_unreachable();
     }
 
     LLVMCallConv llvm_cc = get_llvm_cc(g, fn_type->data.fn.fn_type_id.cc);
@@ -4107,6 +4111,8 @@ static LLVMValueRef ir_render_overflow_op(CodeGen *g, IrExecutable *executable, 
             break;
         case IrOverflowOpShl:
             return render_shl_with_overflow(g, instruction);
+        default:
+            zig_unreachable();
     }
 
     TypeTableEntry *int_type = instruction->result_ptr_type;
@@ -4541,7 +4547,7 @@ static LLVMValueRef get_coro_alloc_helper_fn_val(CodeGen *g, LLVMTypeRef alloc_f
     LLVMValueRef alloc_fn_val = LLVMGetParam(fn_val, next_arg);
     next_arg += 1;
 
-    LLVMValueRef stack_trace_val;
+    LLVMValueRef stack_trace_val = nullptr;
     if (g->have_err_ret_tracing) {
         stack_trace_val = LLVMGetParam(fn_val, next_arg);
         next_arg += 1;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -6964,14 +6964,14 @@ bool ir_gen(CodeGen *codegen, AstNode *node, Scope *scope, IrExecutable *ir_exec
 
     FnTableEntry *fn_entry = exec_fn_entry(irb->exec);
     bool is_async = fn_entry != nullptr && fn_entry->type_entry->data.fn.fn_type_id.cc == CallingConventionAsync;
-    IrInstruction *coro_id;
+    IrInstruction *coro_id = nullptr;
     IrInstruction *u8_ptr_type;
-    IrInstruction *const_bool_false;
-    IrInstruction *coro_promise_ptr;
-    IrInstruction *err_ret_trace_ptr;
-    TypeTableEntry *return_type;
+    IrInstruction *const_bool_false = nullptr;
+    IrInstruction *coro_promise_ptr = nullptr;
+    IrInstruction *err_ret_trace_ptr = nullptr;
+    TypeTableEntry *return_type = nullptr;
     Buf *result_ptr_field_name;
-    VariableTableEntry *coro_size_var;
+    VariableTableEntry *coro_size_var = nullptr;
     if (is_async) {
         // create the coro promise
         Scope *coro_scope = create_coro_prelude_scope(node, scope);
@@ -13761,6 +13761,8 @@ static TypeTableEntry *ir_analyze_instruction_elem_ptr(IrAnalyze *ira, IrInstruc
                         zig_unreachable();
                     case ConstPtrSpecialFunction:
                         zig_panic("TODO element ptr of a function casted to a ptr");
+                    default:
+                        zig_unreachable();
                 }
                 if (new_index >= mem_size) {
                     ir_add_error_node(ira, elem_ptr_instruction->base.source_node,
@@ -17968,6 +17970,8 @@ static TypeTableEntry *ir_analyze_instruction_memset(IrAnalyze *ira, IrInstructi
                 zig_unreachable();
             case ConstPtrSpecialFunction:
                 zig_panic("TODO memset on ptr cast from function");
+            default:
+                zig_unreachable();
         }
 
         size_t count = bigint_as_unsigned(&casted_count->value.data.x_bigint);
@@ -18068,6 +18072,8 @@ static TypeTableEntry *ir_analyze_instruction_memcpy(IrAnalyze *ira, IrInstructi
                 zig_unreachable();
             case ConstPtrSpecialFunction:
                 zig_panic("TODO memcpy on ptr cast from function");
+            default:
+                zig_unreachable();
         }
 
         if (dest_start + count > dest_end) {
@@ -18104,6 +18110,8 @@ static TypeTableEntry *ir_analyze_instruction_memcpy(IrAnalyze *ira, IrInstructi
                 zig_unreachable();
             case ConstPtrSpecialFunction:
                 zig_panic("TODO memcpy on ptr cast from function");
+            default:
+                zig_unreachable();
         }
 
         if (src_start + count > src_end) {
@@ -18260,6 +18268,8 @@ static TypeTableEntry *ir_analyze_instruction_slice(IrAnalyze *ira, IrInstructio
                     break;
                 case ConstPtrSpecialFunction:
                     zig_panic("TODO slice of ptr cast from function");
+                default:
+                    zig_unreachable();
             }
         } else if (is_slice(array_type)) {
             ConstExprValue *slice_ptr = const_ptr_pointee(ira->codegen, &ptr_ptr->value);
@@ -18289,6 +18299,8 @@ static TypeTableEntry *ir_analyze_instruction_slice(IrAnalyze *ira, IrInstructio
                     break;
                 case ConstPtrSpecialFunction:
                     zig_panic("TODO slice of slice cast from function");
+                default:
+                    zig_unreachable();
             }
         } else {
             zig_unreachable();


### PR DESCRIPTION
Because there weren't obvious intention to fall through the switch statement when no options matched, I used the following default branch to instruct compiler that those values won't be used uninitialized. 

```c++
default:
    zig_unreachable();
```