### PR TITLE
support --emit in 'test' command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -924,6 +924,8 @@ int main(int argc, char **argv) {
                     codegen_print_timing_report(g, stdout);
                 return EXIT_SUCCESS;
             } else if (cmd == CmdTest) {
+                codegen_set_emit_file_type(g, emit_file_type);
+
                 ZigTarget native;
                 get_native_target(&native);
 


### PR DESCRIPTION
Support the `--emit` switch in `zig --emit asm test file.zig`.

The command fails because no tests run (no executable is created) but
it emits the requested file.  That seems like a good tradeoff.