### PR TITLE
Fix version detection for out-of-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(ZIG_VERSION "${ZIG_VERSION_MAJOR}.${ZIG_VERSION_MINOR}.${ZIG_VERSION_PATCH}"
 find_program(GIT_EXE NAMES git)
 if(GIT_EXE)
     execute_process(
-        COMMAND ${GIT_EXE} name-rev HEAD --tags --name-only --no-undefined --always
+        COMMAND ${GIT_EXE} -C ${CMAKE_SOURCE_DIR} name-rev HEAD --tags --name-only --no-undefined --always
         OUTPUT_VARIABLE ZIG_GIT_REV
         OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(ZIG_GIT_REV MATCHES "\\^0$")


### PR DESCRIPTION
Git was called in the build directory and not the source directory.
This works fine when the build directory resides within the source
repository, but doesn't work for out-of-source builds. Example:

```
~/zigbuild$ cmake ../zig
fatal: not a git repository (or any of the parent directories): .git
Configuring zig version 0.2.0+
```

Use Git's `-C <path>` flag to always point to the source directory so
that it doesn't matter where the build directory lives.