### PR TITLE
Fix macOS instruction for LLVM location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ bin/zig build --build-file ../build.zig test
 ##### MacOS
 
 ```
-brew install cmake llvm@6
-brew outdated llvm@6 || brew upgrade llvm@6
+brew install cmake llvm
+brew outdated llvm || brew upgrade llvm
 mkdir build
 cd build
-cmake .. -DCMAKE_PREFIX_PATH=/usr/local/opt/llvm@6/
+cmake .. -DCMAKE_PREFIX_PATH=/usr/local/opt/llvm/
 make install
 bin/zig build --build-file ../build.zig test
 ```


### PR DESCRIPTION
It looks like Homebrew LLVM is now [version 6 by default](https://github.com/Homebrew/homebrew-core/blob/master/Formula/llvm.rb#L23-L73), so the build instructions for macOS will result in a missing path if you suffix with `@6`.