### PR TITLE
codegen: Store returned value if type is 'handle_is_ptr' and function…

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3166,6 +3166,10 @@ static LLVMValueRef ir_render_call(CodeGen *g, IrExecutable *executable, IrInstr
         return nullptr;
     } else if (first_arg_ret) {
         return instruction->tmp_ptr;
+    } else if (handle_is_ptr(src_return_type)) {
+        auto store_instr = LLVMBuildStore(g->builder, result, instruction->tmp_ptr);
+        LLVMSetAlignment(store_instr, LLVMGetAlignment(instruction->tmp_ptr));
+        return instruction->tmp_ptr;
     } else {
         return result;
     }

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -9,6 +9,7 @@ comptime {
     _ = @import("cases/bitcast.zig");
     _ = @import("cases/bool.zig");
     _ = @import("cases/bugs/1111.zig");
+    _ = @import("cases/bugs/1230.zig");
     _ = @import("cases/bugs/394.zig");
     _ = @import("cases/bugs/655.zig");
     _ = @import("cases/bugs/656.zig");

--- a/test/cases/bugs/1230.zig
+++ b/test/cases/bugs/1230.zig
@@ -1,0 +1,11 @@
+const S = extern struct {
+    x: i32,
+};
+
+extern fn ret_struct() S {
+    return S { .x = 0 };
+}
+
+test "extern return small struct (bug 1230)" {
+    const s = ret_struct();
+}


### PR DESCRIPTION
… is not 'first_arg_ret'.

Seems to fix #1230, includes test.

Note: I only test this quickly, I don't know if it can break something else.