### PR TITLE
Fix aligned reallocation

### DIFF
--- a/std/mem.zig
+++ b/std/mem.zig
@@ -74,7 +74,7 @@ pub const Allocator = struct {
 
     pub fn alignedRealloc(self: *Allocator, comptime T: type, comptime alignment: u29, old_mem: []align(alignment) T, n: usize) ![]align(alignment) T {
         if (old_mem.len == 0) {
-            return self.alloc(T, n);
+            return self.alignedAlloc(T, alignment, n);
         }
         if (n == 0) {
             self.free(old_mem);


### PR DESCRIPTION
It was broken when trying to allocate with something other than the native type's alignment because it called alloc instead of alignedAlloc. I also fixed up the unit tests to actually test (I think) all the functionality of the allocator.