### PR TITLE
Improve realloc on fixed buffer allocator

### DIFF
--- a/std/heap.zig
+++ b/std/heap.zig
@@ -467,6 +467,17 @@ test "FixedBufferAllocator" {
     try testAllocatorLargeAlignment(&fixed_buffer_allocator.allocator);
 }
 
+test "FixedBufferAllocator Reuse memory on realloc" {
+    var small_fixed_buffer: [10]u8 = undefined;
+    var fixed_buffer_allocator = FixedBufferAllocator.init(small_fixed_buffer[0..]);
+
+    var slice = try fixed_buffer_allocator.allocator.alloc(u8, 5);
+    assert(slice.len == 5);
+    slice = try fixed_buffer_allocator.allocator.realloc(u8, slice, 10);
+    assert(slice.len == 10);
+    debug.assertError(fixed_buffer_allocator.allocator.realloc(u8, slice, 11), error.OutOfMemory);
+}
+
 test "ThreadSafeFixedBufferAllocator" {
     var fixed_buffer_allocator = ThreadSafeFixedBufferAllocator.init(test_fixed_buffer_allocator_memory[0..]);
 

--- a/std/heap.zig
+++ b/std/heap.zig
@@ -494,10 +494,14 @@ test "FixedBufferAllocator Reuse memory on realloc" {
         var fixed_buffer_allocator = FixedBufferAllocator.init(small_fixed_buffer[0..]);
 
         var slice0 = try fixed_buffer_allocator.allocator.alloc(u8, 2);
+        slice0[0] = 1;
+        slice0[1] = 2;
         var slice1 = try fixed_buffer_allocator.allocator.alloc(u8, 2);
         var slice2 = try fixed_buffer_allocator.allocator.realloc(u8, slice0, 4);
         assert(slice0.ptr != slice2.ptr);
         assert(slice1.ptr != slice2.ptr);
+        assert(slice2[0] == 1);
+        assert(slice2[1] == 2);
     }
 }
 
@@ -516,12 +520,14 @@ fn testAllocator(allocator: *mem.Allocator) !void {
         item.* = try allocator.create(@intCast(i32, i));
     }
 
-    for (slice) |item, i| {
+    slice = try allocator.realloc(*i32, slice, 20000);
+    assert(slice.len == 20000);
+
+    for (slice[0..100]) |item, i| {
+        assert(item.* == @intCast(i32, i));
         allocator.destroy(item);
     }
 
-    slice = try allocator.realloc(*i32, slice, 20000);
-    assert(slice.len == 20000);
     slice = try allocator.realloc(*i32, slice, 50);
     assert(slice.len == 50);
     slice = try allocator.realloc(*i32, slice, 25);


### PR DESCRIPTION
I was looking through the code and figured this would be useful. 

The FixedBufferAllocator now checks if the memory buffer you pass into realloc is at the end of the used memory and just extends it instead of always allocating a new block.