### PR TITLE
Revert removal of IR dead code

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -246,6 +246,8 @@ static void ir_ref_bb(IrBasicBlock *bb) {
 static void ir_ref_instruction(IrInstruction *instruction, IrBasicBlock *cur_bb) {
     assert(instruction->id != IrInstructionIdInvalid);
     instruction->ref_count += 1;
+    if (instruction->owner_bb != cur_bb && !instr_is_comptime(instruction))
+        ir_ref_bb(instruction->owner_bb);
 }
 
 static void ir_ref_var(VariableTableEntry *var) {


### PR DESCRIPTION
Closes #1249.

@andrewrk any background on why these two lines were removed would be very helpful.

Thank-you.