### PR TITLE
Allow tests to be marked as SKIPPED.

### DIFF
--- a/std/event/tcp.zig
+++ b/std/event/tcp.zig
@@ -125,7 +125,7 @@ pub async fn connect(loop: *Loop, _address: *const std.net.Address) !std.os.File
 test "listen on a port, send bytes, receive bytes" {
     if (builtin.os != builtin.Os.linux) {
         // TODO build abstractions for other operating systems
-        return;
+        return error.skip;
     }
     const MyServer = struct {
         tcp_server: Server,

--- a/std/event/tcp.zig
+++ b/std/event/tcp.zig
@@ -123,10 +123,17 @@ pub async fn connect(loop: *Loop, _address: *const std.net.Address) !std.os.File
 }
 
 test "listen on a port, send bytes, receive bytes" {
-    if (builtin.os != builtin.Os.linux) {
-        // TODO build abstractions for other operating systems
+    // TODO build abstractions for other operating systems
+    const skip_test: bool = switch (builtin.os) {
+        builtin.Os.linux => false,
+        //builtin.Os.macosx, builtin.Os.ios => false,
+        else => true,
+    };
+
+    if (skip_test == true) {
         return error.skip;
     }
+
     const MyServer = struct {
         tcp_server: Server,
 

--- a/std/special/test_runner.zig
+++ b/std/special/test_runner.zig
@@ -8,7 +8,13 @@ pub fn main() !void {
     for (test_fn_list) |test_fn, i| {
         warn("Test {}/{} {}...", i + 1, test_fn_list.len, test_fn.name);
 
-        try test_fn.func();
+        test_fn.func() catch |err| {
+            if (err == error.skip) {
+                warn("SKIPPED\n");
+                continue;
+            }
+            return err;
+        };
 
         warn("OK\n");
     }


### PR DESCRIPTION
closes #1274

tests can be skipped by returning `error.skip`

