### PR TITLE
Add builtin function @handle()

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4690,9 +4690,9 @@ test "coroutine suspend with block" {
 var a_promise: promise = undefined;
 var result = false;
 async fn testSuspendBlock() void {
-    suspend |p| {
-        comptime assert(@typeOf(p) == promise->void);
-        a_promise = p;
+    suspend {
+        comptime assert(@typeOf(@handle()) == promise->void);
+        a_promise = @handle();
     }
     result = true;
 }
@@ -4791,9 +4791,9 @@ async fn amain() void {
 }
 async fn another() i32 {
     seq('c');
-    suspend |p| {
+    suspend {
         seq('d');
-        a_promise = p;
+        a_promise = @handle();
     }
     seq('g');
     return 1234;
@@ -7388,7 +7388,7 @@ Defer(body) = ("defer" | "deferror") body
 
 IfExpression(body) = "if" "(" Expression ")" body option("else" BlockExpression(body))
 
-SuspendExpression(body) = "suspend" option(("|" Symbol "|" body))
+SuspendExpression(body) = "suspend" option( body )
 
 IfErrorExpression(body) = "if" "(" Expression ")" option("|" option("*") Symbol "|") body "else" "|" Symbol "|" BlockExpression(body)
 

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5383,6 +5383,16 @@ test "main" {
       This function is only valid within function scope.
       </p>
       {#header_close#}
+      {#header_open|@handle#}
+      <pre><code class="zig">@handle()</code></pre>
+      <p>
+      This function returns a <code>promise->T</code> type, where <code>T</code>
+      is the return type of the async function in scope.
+      </p>
+      <p>
+      This function is only valid within an async function scope.
+      </p>
+      {#header_close#}
       {#header_open|@import#}
       <pre><code class="zig">@import(comptime path: []u8) (namespace)</code></pre>
       <p>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4733,8 +4733,8 @@ test "resume from suspend" {
     std.debug.assert(my_result == 2);
 }
 async fn testResumeFromSuspend(my_result: *i32) void {
-    suspend |p| {
-        resume p;
+    suspend {
+        resume @handle();
     }
     my_result.* += 1;
     suspend;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1358,6 +1358,7 @@ enum BuiltinFnId {
     BuiltinFnIdBreakpoint,
     BuiltinFnIdReturnAddress,
     BuiltinFnIdFrameAddress,
+    BuiltinFnIdHandle,
     BuiltinFnIdEmbedFile,
     BuiltinFnIdCmpxchgWeak,
     BuiltinFnIdCmpxchgStrong,
@@ -2076,6 +2077,7 @@ enum IrInstructionId {
     IrInstructionIdBreakpoint,
     IrInstructionIdReturnAddress,
     IrInstructionIdFrameAddress,
+    IrInstructionIdHandle,
     IrInstructionIdAlignOf,
     IrInstructionIdOverflowOp,
     IrInstructionIdTestErr,
@@ -2790,6 +2792,10 @@ struct IrInstructionReturnAddress {
 };
 
 struct IrInstructionFrameAddress {
+    IrInstruction base;
+};
+
+struct IrInstructionHandle {
     IrInstruction base;
 };
 

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1717,6 +1717,7 @@ struct CodeGen {
     LLVMValueRef coro_save_fn_val;
     LLVMValueRef coro_promise_fn_val;
     LLVMValueRef coro_alloc_helper_fn_val;
+    LLVMValueRef coro_frame_fn_val;
     LLVMValueRef merge_err_ret_traces_fn_val;
     LLVMValueRef add_error_return_trace_addr_fn_val;
     LLVMValueRef stacksave_fn_val;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -899,7 +899,6 @@ struct AstNodeAwaitExpr {
 
 struct AstNodeSuspend {
     AstNode *block;
-    AstNode *promise_symbol;
 };
 
 struct AstNodePromiseType {

--- a/src/ast_render.cpp
+++ b/src/ast_render.cpp
@@ -1112,9 +1112,6 @@ static void render_node_extra(AstRender *ar, AstNode *node, bool grouped) {
             {
                 fprintf(ar->f, "suspend");
                 if (node->data.suspend.block != nullptr) {
-                    fprintf(ar->f, " |");
-                    render_node_grouped(ar, node->data.suspend.promise_symbol);
-                    fprintf(ar->f, "| ");
                     render_node_grouped(ar, node->data.suspend.block);
                 }
                 break;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4154,6 +4154,7 @@ static LLVMValueRef ir_render_handle(CodeGen *g, IrExecutable *executable,
         executable->fn_entry->type_entry->data.fn.fn_type_id.cc == CallingConventionAsync;
 
     if (!is_async || !executable->coro_handle) {
+      add_node_error(g, instruction->base.source_node, buf_sprintf("@handle() in non-async function"));
       return LLVMConstNull(g->builtin_types.entry_promise->type_ref);
     }
 
@@ -6022,7 +6023,8 @@ static void do_code_gen(CodeGen *g) {
         ir_render(g, fn_table_entry);
 
     }
-    assert(!g->errors.length);
+    
+    //assert(!g->errors.length);
 
     if (buf_len(&g->global_asm) != 0) {
         LLVMSetModuleInlineAsm(g->module, buf_ptr(&g->global_asm));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4149,17 +4149,7 @@ static LLVMValueRef ir_render_frame_address(CodeGen *g, IrExecutable *executable
 static LLVMValueRef ir_render_handle(CodeGen *g, IrExecutable *executable,
         IrInstructionHandle *instruction)
 {
-
-    bool is_async = executable->fn_entry != nullptr && 
-        executable->fn_entry->type_entry->data.fn.fn_type_id.cc == CallingConventionAsync;
-
-    if (!is_async || !executable->coro_handle) {
-      add_node_error(g, instruction->base.source_node, buf_sprintf("@handle() in non-async function"));
-      return LLVMConstNull(g->builtin_types.entry_promise->type_ref);
-    }
-
-    LLVMValueRef handle = ir_llvm_value(g, executable->coro_handle);
-    return LLVMBuildRet(g->builder, handle);
+    return LLVMConstNull(g->builtin_types.entry_promise->type_ref);
 }
 
 static LLVMValueRef render_shl_with_overflow(CodeGen *g, IrInstructionOverflowOp *instruction) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6014,7 +6014,7 @@ static void do_code_gen(CodeGen *g) {
 
     }
     
-    //assert(!g->errors.length);
+    assert(!g->errors.length);
 
     if (buf_len(&g->global_asm) != 0) {
         LLVMSetModuleInlineAsm(g->module, buf_ptr(&g->global_asm));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4146,6 +4146,15 @@ static LLVMValueRef ir_render_frame_address(CodeGen *g, IrExecutable *executable
     return LLVMBuildCall(g->builder, get_frame_address_fn_val(g), &zero, 1, "");
 }
 
+static LLVMValueRef ir_render_handle(CodeGen *g, IrExecutable *executable,
+        IrInstructionHandle *instruction)
+{
+    // @andrewrk, not sure what to place here ?
+    // `get_promise_frame_type` ?
+    LLVMValueRef handle = LLVMConstNull(g->builtin_types.entry_promise->type_ref);
+    return LLVMBuildRet(g->builder, handle);
+}
+
 static LLVMValueRef render_shl_with_overflow(CodeGen *g, IrInstructionOverflowOp *instruction) {
     TypeTableEntry *int_type = instruction->result_ptr_type;
     assert(int_type->id == TypeTableEntryIdInt);
@@ -4910,6 +4919,8 @@ static LLVMValueRef ir_render_instruction(CodeGen *g, IrExecutable *executable, 
             return ir_render_return_address(g, executable, (IrInstructionReturnAddress *)instruction);
         case IrInstructionIdFrameAddress:
             return ir_render_frame_address(g, executable, (IrInstructionFrameAddress *)instruction);
+        case IrInstructionIdHandle:
+            return ir_render_handle(g, executable, (IrInstructionHandle *)instruction);
         case IrInstructionIdOverflowOp:
             return ir_render_overflow_op(g, executable, (IrInstructionOverflowOp *)instruction);
         case IrInstructionIdTestErr:
@@ -6344,6 +6355,7 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdBreakpoint, "breakpoint", 0);
     create_builtin_fn(g, BuiltinFnIdReturnAddress, "returnAddress", 0);
     create_builtin_fn(g, BuiltinFnIdFrameAddress, "frameAddress", 0);
+    create_builtin_fn(g, BuiltinFnIdHandle, "handle", 0);
     create_builtin_fn(g, BuiltinFnIdMemcpy, "memcpy", 3);
     create_builtin_fn(g, BuiltinFnIdMemset, "memset", 3);
     create_builtin_fn(g, BuiltinFnIdSizeof, "sizeOf", 1);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4149,7 +4149,8 @@ static LLVMValueRef ir_render_frame_address(CodeGen *g, IrExecutable *executable
 static LLVMValueRef ir_render_handle(CodeGen *g, IrExecutable *executable,
         IrInstructionHandle *instruction)
 {
-    return LLVMConstNull(g->builtin_types.entry_promise->type_ref);
+    LLVMValueRef ptr = ir_llvm_value(g, executable->fn_entry->ir_executable.coro_handle->other);
+    return LLVMBuildBitCast(g->builder, ptr, g->builtin_types.entry_promise->type_ref, "");
 }
 
 static LLVMValueRef render_shl_with_overflow(CodeGen *g, IrInstructionOverflowOp *instruction) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4149,9 +4149,15 @@ static LLVMValueRef ir_render_frame_address(CodeGen *g, IrExecutable *executable
 static LLVMValueRef ir_render_handle(CodeGen *g, IrExecutable *executable,
         IrInstructionHandle *instruction)
 {
-    // @andrewrk, not sure what to place here ?
-    // `get_promise_frame_type` ?
-    LLVMValueRef handle = LLVMConstNull(g->builtin_types.entry_promise->type_ref);
+
+    bool is_async = executable->fn_entry != nullptr && 
+        executable->fn_entry->type_entry->data.fn.fn_type_id.cc == CallingConventionAsync;
+
+    if (!is_async || !executable->coro_handle) {
+      return LLVMConstNull(g->builtin_types.entry_promise->type_ref);
+    }
+
+    LLVMValueRef handle = ir_llvm_value(g, executable->coro_handle);
     return LLVMBuildRet(g->builder, handle);
 }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -4493,6 +4493,10 @@ static IrInstruction *ir_gen_builtin_fn_call(IrBuilder *irb, Scope *scope, AstNo
         case BuiltinFnIdFrameAddress:
             return ir_lval_wrap(irb, scope, ir_build_frame_address(irb, scope, node), lval);
         case BuiltinFnIdHandle:
+            if (!irb->exec->fn_entry) {
+                add_node_error(irb->codegen, node, buf_sprintf("@handle() called outside of function definition"));
+                return irb->codegen->invalid_instruction;
+            }
             if (!is_async) {
                 add_node_error(irb->codegen, node, buf_sprintf("@handle() in non-async function"));
                 return irb->codegen->invalid_instruction;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -19033,8 +19033,9 @@ static TypeTableEntry *ir_analyze_instruction_frame_address(IrAnalyze *ira, IrIn
 static TypeTableEntry *ir_analyze_instruction_handle(IrAnalyze *ira, IrInstructionHandle *instruction) {
     ir_build_handle_from(&ira->new_irb, &instruction->base);
 
-    TypeTableEntry *promise_type = get_promise_type(ira->codegen, nullptr);
-    return promise_type;
+    FnTableEntry *fn_entry = exec_fn_entry(ira->new_irb.exec);
+    assert(fn_entry != nullptr);
+    return get_promise_type(ira->codegen, fn_entry->type_entry->data.fn.fn_type_id.return_type);
 }
 
 static TypeTableEntry *ir_analyze_instruction_align_of(IrAnalyze *ira, IrInstructionAlignOf *instruction) {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -3858,6 +3858,8 @@ static IrInstruction *ir_gen_builtin_fn_call(IrBuilder *irb, Scope *scope, AstNo
         return irb->codegen->invalid_instruction;
     }
 
+    bool is_async = exec_is_async(irb->exec);
+
     switch (builtin_fn->id) {
         case BuiltinFnIdInvalid:
             zig_unreachable();
@@ -4491,6 +4493,10 @@ static IrInstruction *ir_gen_builtin_fn_call(IrBuilder *irb, Scope *scope, AstNo
         case BuiltinFnIdFrameAddress:
             return ir_lval_wrap(irb, scope, ir_build_frame_address(irb, scope, node), lval);
         case BuiltinFnIdHandle:
+            if (!is_async) {
+                add_node_error(irb->codegen, node, buf_sprintf("@handle() in non-async function"));
+                return irb->codegen->invalid_instruction;
+            }
             return ir_lval_wrap(irb, scope, ir_build_handle(irb, scope, node), lval);
         case BuiltinFnIdAlignOf:
             {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -7096,19 +7096,8 @@ static IrInstruction *ir_gen_suspend(IrBuilder *irb, Scope *parent_scope, AstNod
     if (node->data.suspend.block == nullptr) {
         suspend_code = ir_build_coro_suspend(irb, parent_scope, node, nullptr, const_bool_false);
     } else {
-        assert(node->data.suspend.promise_symbol != nullptr);
-        assert(node->data.suspend.promise_symbol->type == NodeTypeSymbol);
-        Buf *promise_symbol_name = node->data.suspend.promise_symbol->data.symbol_expr.symbol;
         Scope *child_scope;
-        if (!buf_eql_str(promise_symbol_name, "_")) {
-            VariableTableEntry *promise_var = ir_create_var(irb, node, parent_scope, promise_symbol_name,
-                    true, true, false, const_bool_false);
-            ir_build_var_decl(irb, parent_scope, node, promise_var, nullptr, nullptr, irb->exec->coro_handle);
-            child_scope = promise_var->child_scope;
-        } else {
-            child_scope = parent_scope;
-        }
-        ScopeSuspend *suspend_scope = create_suspend_scope(node, child_scope);
+        ScopeSuspend *suspend_scope = create_suspend_scope(node, parent_scope);
         suspend_scope->resume_block = resume_block;
         child_scope = &suspend_scope->base;
         IrInstruction *save_token = ir_build_coro_save(irb, child_scope, node, irb->exec->coro_handle);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -791,6 +791,10 @@ static void ir_print_frame_address(IrPrint *irp, IrInstructionFrameAddress *inst
     fprintf(irp->f, "@frameAddress()");
 }
 
+static void ir_print_handle(IrPrint *irp, IrInstructionHandle *instruction) {
+    fprintf(irp->f, "@handle()");
+}
+
 static void ir_print_return_address(IrPrint *irp, IrInstructionReturnAddress *instruction) {
     fprintf(irp->f, "@returnAddress()");
 }
@@ -1555,6 +1559,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdFrameAddress:
             ir_print_frame_address(irp, (IrInstructionFrameAddress *)instruction);
+            break;
+        case IrInstructionIdHandle:
+            ir_print_handle(irp, (IrInstructionHandle *)instruction);
             break;
         case IrInstructionIdAlignOf:
             ir_print_align_of(irp, (IrInstructionAlignOf *)instruction);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -655,7 +655,7 @@ static AstNode *ast_parse_suspend_block(ParseContext *pc, size_t *token_index, b
     Token *token = &pc->tokens->at(*token_index);
     Token *suspend_token = nullptr;
 
-    if (suspend_token->id == TokenIdKeywordSuspend) {
+    if (token->id == TokenIdKeywordSuspend) {
         *token_index += 1;
         suspend_token = token;
         token = &pc->tokens->at(*token_index);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -648,35 +648,37 @@ static AstNode *ast_parse_asm_expr(ParseContext *pc, size_t *token_index, bool m
 }
 
 /*
-SuspendExpression(body) = "suspend" option(("|" Symbol "|" body))
+SuspendExpression(body) = "suspend" option( body )
 */
 static AstNode *ast_parse_suspend_block(ParseContext *pc, size_t *token_index, bool mandatory) {
     size_t orig_token_index = *token_index;
+    Token *token = &pc->tokens->at(*token_index);
+    Token *suspend_token = nullptr;
 
-    Token *suspend_token = &pc->tokens->at(*token_index);
     if (suspend_token->id == TokenIdKeywordSuspend) {
         *token_index += 1;
+        suspend_token = token;
+        token = &pc->tokens->at(*token_index);
     } else if (mandatory) {
-        ast_expect_token(pc, suspend_token, TokenIdKeywordSuspend);
+        ast_expect_token(pc, token, TokenIdKeywordSuspend);
         zig_unreachable();
     } else {
         return nullptr;
     }
 
-    Token *bar_token = &pc->tokens->at(*token_index);
-    if (bar_token->id == TokenIdBinOr) {
-        *token_index += 1;
-    } else if (mandatory) {
-        ast_expect_token(pc, suspend_token, TokenIdBinOr);
-        zig_unreachable();
-    } else {
-        *token_index = orig_token_index;
-        return nullptr;
+    //guessing that semicolon is checked elsewhere?
+    if (token->id != TokenIdLBrace) {
+        if (mandatory) {
+            ast_expect_token(pc, token, TokenIdLBrace);
+            zig_unreachable();
+        } else {
+            *token_index = orig_token_index;
+            return nullptr;
+        }
     }
 
+    //Expect that we have a block;
     AstNode *node = ast_create_node(pc, NodeTypeSuspend, suspend_token);
-    node->data.suspend.promise_symbol = ast_parse_symbol(pc, token_index);
-    ast_eat_token(pc, token_index, TokenIdBinOr);
     node->data.suspend.block = ast_parse_block(pc, token_index, true);
 
     return node;
@@ -3134,7 +3136,6 @@ void ast_visit_node_children(AstNode *node, void (*visit)(AstNode **, void *cont
             visit_field(&node->data.await_expr.expr, visit, context);
             break;
         case NodeTypeSuspend:
-            visit_field(&node->data.suspend.promise_symbol, visit, context);
             visit_field(&node->data.suspend.block, visit, context);
             break;
     }

--- a/std/event/channel.zig
+++ b/std/event/channel.zig
@@ -71,10 +71,10 @@ pub fn Channel(comptime T: type) type {
         /// puts a data item in the channel. The promise completes when the value has been added to the
         /// buffer, or in the case of a zero size buffer, when the item has been retrieved by a getter.
         pub async fn put(self: *SelfChannel, data: T) void {
-            suspend |handle| {
+            suspend {
                 var my_tick_node = Loop.NextTickNode{
                     .next = undefined,
-                    .data = handle,
+                    .data = @handle(),
                 };
                 var queue_node = std.atomic.Queue(PutNode).Node{
                     .data = PutNode{
@@ -96,10 +96,10 @@ pub fn Channel(comptime T: type) type {
             // TODO integrate this function with named return values
             // so we can get rid of this extra result copy
             var result: T = undefined;
-            suspend |handle| {
+            suspend {
                 var my_tick_node = Loop.NextTickNode{
                     .next = undefined,
-                    .data = handle,
+                    .data = @handle(),
                 };
                 var queue_node = std.atomic.Queue(GetNode).Node{
                     .data = GetNode{

--- a/std/event/future.zig
+++ b/std/event/future.zig
@@ -100,8 +100,9 @@ test "std.event.Future" {
 }
 
 async fn testFuture(loop: *Loop) void {
-    suspend |p| {
-        resume p;
+    suspend {
+        var h: promise = @handle();
+        resume h;
     }
     var future = Future(i32).init(loop);
 
@@ -115,15 +116,17 @@ async fn testFuture(loop: *Loop) void {
 }
 
 async fn waitOnFuture(future: *Future(i32)) i32 {
-    suspend |p| {
-        resume p;
+    suspend {
+        var h: promise = @handle();
+        resume h;
     }
     return (await (async future.get() catch @panic("memory"))).*;
 }
 
 async fn resolveFuture(future: *Future(i32)) void {
-    suspend |p| {
-        resume p;
+    suspend {
+        var h: promise = @handle();
+        resume h;
     }
     future.data = 6;
     future.resolve();

--- a/std/event/future.zig
+++ b/std/event/future.zig
@@ -101,8 +101,7 @@ test "std.event.Future" {
 
 async fn testFuture(loop: *Loop) void {
     suspend {
-        var h: promise = @handle();
-        resume h;
+        resume @handle();
     }
     var future = Future(i32).init(loop);
 
@@ -117,16 +116,14 @@ async fn testFuture(loop: *Loop) void {
 
 async fn waitOnFuture(future: *Future(i32)) i32 {
     suspend {
-        var h: promise = @handle();
-        resume h;
+        resume @handle();
     }
     return (await (async future.get() catch @panic("memory"))).*;
 }
 
 async fn resolveFuture(future: *Future(i32)) void {
     suspend {
-        var h: promise = @handle();
-        resume h;
+        resume @handle();
     }
     future.data = 6;
     future.resolve();

--- a/std/event/group.zig
+++ b/std/event/group.zig
@@ -57,8 +57,7 @@ pub fn Group(comptime ReturnType: type) type {
                     suspend {
                         var my_node: Stack.Node = undefined;
                         node.* = &my_node;
-                        var h: promise = @handle();
-                        resume h;
+                        resume @handle();
                     }
 
                     // TODO this allocation elision should be guaranteed because we await it in

--- a/std/event/group.zig
+++ b/std/event/group.zig
@@ -54,10 +54,11 @@ pub fn Group(comptime ReturnType: type) type {
             const S = struct {
                 async fn asyncFunc(node: **Stack.Node, args2: ...) ReturnType {
                     // TODO this is a hack to make the memory following be inside the coro frame
-                    suspend |p| {
+                    suspend {
                         var my_node: Stack.Node = undefined;
                         node.* = &my_node;
-                        resume p;
+                        var h: promise = @handle();
+                        resume h;
                     }
 
                     // TODO this allocation elision should be guaranteed because we await it in

--- a/std/event/lock.zig
+++ b/std/event/lock.zig
@@ -90,10 +90,10 @@ pub const Lock = struct {
     }
 
     pub async fn acquire(self: *Lock) Held {
-        suspend |handle| {
+        suspend {
             // TODO explicitly put this memory in the coroutine frame #1194
             var my_tick_node = Loop.NextTickNode{
-                .data = handle,
+                .data = @handle(),
                 .next = undefined,
             };
 
@@ -141,8 +141,9 @@ test "std.event.Lock" {
 
 async fn testLock(loop: *Loop, lock: *Lock) void {
     // TODO explicitly put next tick node memory in the coroutine frame #1194
-    suspend |p| {
-        resume p;
+    suspend {
+        var h: promise = @handle();
+        resume h;
     }
     const handle1 = async lockRunner(lock) catch @panic("out of memory");
     var tick_node1 = Loop.NextTickNode{

--- a/std/event/lock.zig
+++ b/std/event/lock.zig
@@ -142,8 +142,7 @@ test "std.event.Lock" {
 async fn testLock(loop: *Loop, lock: *Lock) void {
     // TODO explicitly put next tick node memory in the coroutine frame #1194
     suspend {
-        var h: promise = @handle();
-        resume h;
+        resume @handle();
     }
     const handle1 = async lockRunner(lock) catch @panic("out of memory");
     var tick_node1 = Loop.NextTickNode{

--- a/std/event/tcp.zig
+++ b/std/event/tcp.zig
@@ -88,8 +88,8 @@ pub const Server = struct {
                 },
                 error.ProcessFdQuotaExceeded => {
                     errdefer std.os.emfile_promise_queue.remove(&self.waiting_for_emfile_node);
-                    suspend |p| {
-                        self.waiting_for_emfile_node = PromiseNode.init(p);
+                    suspend {
+                        self.waiting_for_emfile_node = PromiseNode.init( @handle() );
                         std.os.emfile_promise_queue.append(&self.waiting_for_emfile_node);
                     }
                     continue;
@@ -141,8 +141,9 @@ test "listen on a port, send bytes, receive bytes" {
             (await next_handler) catch |err| {
                 std.debug.panic("unable to handle connection: {}\n", err);
             };
-            suspend |p| {
-                cancel p;
+            suspend {
+                var h: promise = @handle();
+                cancel h;
             }
         }
         async fn errorableHandler(self: *Self, _addr: *const std.net.Address, _socket: *const std.os.File) !void {

--- a/std/event/tcp.zig
+++ b/std/event/tcp.zig
@@ -142,8 +142,7 @@ test "listen on a port, send bytes, receive bytes" {
                 std.debug.panic("unable to handle connection: {}\n", err);
             };
             suspend {
-                var h: promise = @handle();
-                cancel h;
+                cancel @handle();
             }
         }
         async fn errorableHandler(self: *Self, _addr: *const std.net.Address, _socket: *const std.os.File) !void {

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -1784,7 +1784,7 @@ test "zig fmt: coroutines" {
         \\    x += 1;
         \\    suspend;
         \\    x += 1;
-        \\    suspend |p| {}
+        \\    suspend;
         \\    const p: promise->void = async simpleAsyncFn() catch unreachable;
         \\    await p;
         \\}

--- a/test/cases/cancel.zig
+++ b/test/cases/cancel.zig
@@ -85,8 +85,8 @@ async fn b4() void {
     defer {
         defer_b4 = true;
     }
-    suspend |p| {
-        b4_handle = p;
+    suspend {
+        b4_handle = @handle();
     }
     suspend;
 }

--- a/test/cases/coroutine_await_struct.zig
+++ b/test/cases/coroutine_await_struct.zig
@@ -30,9 +30,9 @@ async fn await_amain() void {
 }
 async fn await_another() Foo {
     await_seq('c');
-    suspend |p| {
+    suspend {
         await_seq('d');
-        await_a_promise = p;
+        await_a_promise = @handle();
     }
     await_seq('g');
     return Foo{ .x = 1234 };

--- a/test/cases/coroutines.zig
+++ b/test/cases/coroutines.zig
@@ -66,6 +66,11 @@ async fn testSuspendBlock() void {
         comptime assert(@typeOf(p) == promise->void);
         a_promise = p;
     }
+
+    //Test to make sure that @handle() works as advertised (issue #1296)
+    //var our_handle: promise = @handle();
+    assert( a_promise == @handle() );
+
     result = true;
 }
 

--- a/test/cases/coroutines.zig
+++ b/test/cases/coroutines.zig
@@ -57,6 +57,9 @@ test "coroutine suspend with block" {
     resume a_promise;
     std.debug.assert(result);
     cancel p;
+
+    assert( @handle() );
+
 }
 
 var a_promise: promise = undefined;

--- a/test/cases/coroutines.zig
+++ b/test/cases/coroutines.zig
@@ -62,9 +62,9 @@ test "coroutine suspend with block" {
 var a_promise: promise = undefined;
 var result = false;
 async fn testSuspendBlock() void {
-    suspend |p| {
-        comptime assert(@typeOf(p) == promise->void);
-        a_promise = p;
+    suspend {
+        comptime assert(@typeOf(@handle()) == promise->void);
+        a_promise = @handle();
     }
 
     //Test to make sure that @handle() works as advertised (issue #1296)
@@ -98,9 +98,9 @@ async fn await_amain() void {
 }
 async fn await_another() i32 {
     await_seq('c');
-    suspend |p| {
+    suspend {
         await_seq('d');
-        await_a_promise = p;
+        await_a_promise = @handle();
     }
     await_seq('g');
     return 1234;

--- a/test/cases/coroutines.zig
+++ b/test/cases/coroutines.zig
@@ -57,9 +57,6 @@ test "coroutine suspend with block" {
     resume a_promise;
     std.debug.assert(result);
     cancel p;
-
-    assert( @handle() );
-
 }
 
 var a_promise: promise = undefined;

--- a/test/cases/coroutines.zig
+++ b/test/cases/coroutines.zig
@@ -256,3 +256,19 @@ async fn testBreakFromSuspend(my_result: *i32) void {
     suspend;
     my_result.* += 1;
 }
+
+test "suspend resume @handle()" {
+    var buf: [500]u8 = undefined;
+    var a = &std.heap.FixedBufferAllocator.init(buf[0..]).allocator;
+    var my_result: i32 = 1;
+    const p = try async<a> testBreakFromSuspend(&my_result);
+    std.debug.assert(my_result == 2);
+}
+async fn testSuspendResumeAtHandle() void {
+    suspend {
+        resume @handle();
+    }
+    my_result.* += 1;
+    suspend;
+    my_result.* += 1;
+}

--- a/test/cases/coroutines.zig
+++ b/test/cases/coroutines.zig
@@ -249,8 +249,8 @@ test "break from suspend" {
     std.debug.assert(my_result == 2);
 }
 async fn testBreakFromSuspend(my_result: *i32) void {
-    suspend |p| {
-        resume p;
+    suspend {
+        resume @handle();
     }
     my_result.* += 1;
     suspend;

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -367,8 +367,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\
         \\async fn foo() void {
-        \\    suspend |p| {
-        \\        suspend |p1| {
+        \\    suspend {
+        \\        suspend {
         \\        }
         \\    }
         \\}

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -4754,4 +4754,18 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     ,
         ".tmp_source.zig:6:29: error: @handle() called outside of function definition",
     );
+
+    cases.add(
+        "@handle() in non-async function",
+        \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
+        \\    @import("std").os.exit(126);
+        \\}
+        \\
+        \\pub fn main() void {
+        \\    var handle_undef: promise = undefined;
+        \\    if (handle_undef == @handle()) return 0;
+        \\}
+    ,
+        ".tmp_source.zig:7:25: error: @handle() in non-async function",
+    );
 }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -4738,4 +4738,20 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     ,
         ".tmp_source.zig:3:36: error: @ArgType could not resolve the type of arg 0 because 'fn(var)var' is generic",
     );
+
+    cases.add(
+        "@handle() called outside of function definition",
+        \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
+        \\    @import("std").os.exit(126);
+        \\}
+        \\
+        \\var handle_undef: promise = undefined;
+        \\var handle_dummy: promise = @handle();
+        \\
+        \\pub fn main() void {
+        \\    if (handle_undef == handle_dummy) return 0;
+        \\}
+    ,
+        ".tmp_source.zig:6:29: error: @handle() called outside of function definition",
+    );
 }


### PR DESCRIPTION
closes #1296 ;

* [X] Define Builtin `@handle();`
* [X] Check if within Async block
  I am using `executable->fn_entry->type_entry->data.fn.fn_type_id.cc == CallingConventionAsync` to check this condition.
* [x] Return promise in codegen
  Using `@llvm.coro.frame`
* [x] Remove old semantic analysis code for the feature we are removing
  remove `suspend |handle| {}`
* [x] Remove the stage1 parser code for it
* [ ] Remove the stage2 parser code for it
* [x] Write documentation

@andrewrk Andrew, I took a crack at this because I want to learn more about zig's internals and based it off of `@frameAddress()`. I learned a lot from [this article](https://pauladamsmith.com/blog/2015/01/how-to-get-started-with-llvm-c-api.html).

If you can help me understand the rest, I can start helping with more of the internals. :-)

Thanks