### PR TITLE
A few new functions in InStream/OutStream

### DIFF
--- a/std/io.zig
+++ b/std/io.zig
@@ -200,6 +200,13 @@ pub fn InStream(comptime ReadError: type) type {
             try self.readNoEof(input_slice);
             return mem.readInt(input_slice, T, endian);
         }
+
+        pub fn skipBytes(self: *Self, num_bytes: usize) !void {
+            var i: usize = 0;
+            while (i < num_bytes) : (i += 1) {
+                _ = try self.readByte();
+            }
+        }
     };
 }
 

--- a/std/io.zig
+++ b/std/io.zig
@@ -230,6 +230,20 @@ pub fn OutStream(comptime WriteError: type) type {
                 try self.writeFn(self, slice);
             }
         }
+
+        pub fn writeIntLe(self: *Self, comptime T: type, value: T) !void {
+            return self.writeInt(builtin.Endian.Little, T, value);
+        }
+
+        pub fn writeIntBe(self: *Self, comptime T: type, value: T) !void {
+            return self.writeInt(builtin.Endian.Big, T, value);
+        }
+
+        pub fn writeInt(self: *Self, endian: builtin.Endian, comptime T: type, value: T) !void {
+            var bytes: [@sizeOf(T)]u8 = undefined;
+            mem.writeInt(bytes[0..], value, endian);
+            return self.writeFn(self, bytes);
+        }
     };
 }
 


### PR DESCRIPTION
This adds a few functions to InStream and OutStream which have proven useful for me multiple times (I finally got tired of defining them in my own projects).

To InStream, I added skipBytes. This provides a heavy handed way of seeking forward in any kind of stream. Useful for e.g. parsing the header of a binary format and skipping over unused areas.

To OutStream, I added writeInt, writeIntLe, and writeIntBe. Read versions of these functions already exist in InStream.