### PR TITLE
Windows: Call RtlGenRandom() instead of CryptGetRandom()

### DIFF
--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -153,8 +153,14 @@ pub fn getRandomBytes(buf: []u8) !void {
 }
 
 test "os.getRandomBytes" {
-    var buf: [50]u8 = undefined;
-    try getRandomBytes(buf[0..]);
+    var buf_a: [50]u8 = undefined;
+    var buf_b: [50]u8 = undefined;
+    // Call Twice
+    try getRandomBytes(buf_a[0..]);
+    try getRandomBytes(buf_b[0..]);
+
+    // Check if random (not 100% conclusive)
+    assert( !mem.eql(u8, buf_a, buf_b) );
 }
 
 /// Raises a signal in the current kernel thread, ending its execution.

--- a/std/os/windows/advapi32.zig
+++ b/std/os/windows/advapi32.zig
@@ -28,3 +28,8 @@ pub extern "advapi32" stdcallcc fn RegOpenKeyExW(hKey: HKEY, lpSubKey: LPCWSTR, 
 
 pub extern "advapi32" stdcallcc fn RegQueryValueExW(hKey: HKEY, lpValueName: LPCWSTR, lpReserved: LPDWORD,
     lpType: LPDWORD, lpData: LPBYTE, lpcbData: LPDWORD,) LSTATUS;
+
+// RtlGenRandom is known as SystemFunction036 under advapi32
+// http://msdn.microsoft.com/en-us/library/windows/desktop/aa387694.aspx */
+pub extern "advapi32" stdcallcc fn SystemFunction036(output: PVOID, length: ULONG_PTR) BOOL;
+pub const RtlGenRandom = SystemFunction036;

--- a/std/os/windows/util.zig
+++ b/std/os/windows/util.zig
@@ -166,7 +166,7 @@ pub fn windowsUnloadDll(hModule: windows.HMODULE) void {
 }
 
 test "InvalidDll" {
-    if (builtin.os != builtin.Os.windows) return;
+    if (builtin.os != builtin.Os.windows) return error.SkipZigTest;
 
     const DllName = "asdf.dll";
     const allocator = std.debug.global_allocator;


### PR DESCRIPTION
Closes #1318 
Closes #725
