### PR TITLE
Fix a type error in std.os.linux.getpid()

### DIFF
--- a/std/os/linux/index.zig
+++ b/std/os/linux/index.zig
@@ -944,7 +944,7 @@ pub fn setgroups(size: usize, list: *const u32) usize {
 }
 
 pub fn getpid() i32 {
-    return @bitCast(i32, u32(syscall0(SYS_getpid)));
+    return @bitCast(i32, @truncate(u32, syscall0(SYS_getpid)));
 }
 
 pub fn sigprocmask(flags: u32, noalias set: *const sigset_t, noalias oldset: ?*sigset_t) usize {

--- a/std/os/linux/test.zig
+++ b/std/os/linux/test.zig
@@ -3,6 +3,10 @@ const builtin = @import("builtin");
 const linux = std.os.linux;
 const assert = std.debug.assert;
 
+test "getpid" {
+    assert(linux.getpid() != 0);
+}
+
 test "timer" {
     const epoll_fd = linux.epoll_create();
     var err = linux.getErrno(epoll_fd);


### PR DESCRIPTION
syscall0() returns usize, but we were trying to @bitCast to i32.