### PR TITLE
Add thread ID support to std.os.Thread (fixes #1316)

### DIFF
--- a/std/c/index.zig
+++ b/std/c/index.zig
@@ -58,6 +58,7 @@ pub extern "pthread" fn pthread_create(noalias newthread: *pthread_t, noalias at
 pub extern "pthread" fn pthread_attr_init(attr: *pthread_attr_t) c_int;
 pub extern "pthread" fn pthread_attr_setstack(attr: *pthread_attr_t, stackaddr: *c_void, stacksize: usize) c_int;
 pub extern "pthread" fn pthread_attr_destroy(attr: *pthread_attr_t) c_int;
+pub extern "pthread" fn pthread_self() pthread_t;
 pub extern "pthread" fn pthread_join(thread: pthread_t, arg_return: ?*?*c_void) c_int;
 
 pub const pthread_t = *@OpaqueType();

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -2517,7 +2517,7 @@ pub const Thread = struct {
 
     pub const use_pthreads = is_posix and builtin.link_libc;
 
-    /// An opaque type representing a kernel thread ID.
+    /// An type representing a kernel thread ID.
     pub const Id = if (use_pthreads)
         c.pthread_t
     else switch (builtin.os) {

--- a/std/os/test.zig
+++ b/std/os/test.zig
@@ -34,12 +34,12 @@ test "access file" {
     try os.deleteTree(a, "os_test_tmp");
 }
 
-fn testThreadIdFn(threadId: *?os.Thread.Id) void {
+fn testThreadIdFn(threadId: *os.Thread.Id) void {
     threadId.* = os.Thread.currentId();
 }
 
 test "std.os.Thread.currentId" {
-    var threadCurrentId: ?os.Thread.Id = null;
+    var threadCurrentId: os.Thread.Id = undefined;
     const thread = try os.spawnThread(&threadCurrentId, testThreadIdFn);
     const threadId = thread.id();
     thread.wait();

--- a/std/os/test.zig
+++ b/std/os/test.zig
@@ -34,6 +34,18 @@ test "access file" {
     try os.deleteTree(a, "os_test_tmp");
 }
 
+fn testThreadIdFn(threadId: *?os.Thread.Id) void {
+    threadId.* = os.Thread.currentId();
+}
+
+test "std.os.Thread.currentId" {
+    var threadCurrentId: ?os.Thread.Id = null;
+    const thread = try os.spawnThread(&threadCurrentId, testThreadIdFn);
+    const threadId = thread.id();
+    thread.wait();
+    assert(threadCurrentId == threadId);
+}
+
 test "spawn threads" {
     var shared_ctx: i32 = 1;
 

--- a/std/os/windows/kernel32.zig
+++ b/std/os/windows/kernel32.zig
@@ -63,6 +63,8 @@ pub extern "kernel32" stdcallcc fn GetConsoleMode(in_hConsoleHandle: HANDLE, out
 
 pub extern "kernel32" stdcallcc fn GetCurrentDirectoryA(nBufferLength: WORD, lpBuffer: ?LPSTR) DWORD;
 
+pub extern "kernel32" stdcallcc fn GetCurrentThread() HANDLE;
+
 pub extern "kernel32" stdcallcc fn GetEnvironmentStringsA() ?[*]u8;
 
 pub extern "kernel32" stdcallcc fn GetEnvironmentVariableA(lpName: LPCSTR, lpBuffer: LPSTR, nSize: DWORD) DWORD;


### PR DESCRIPTION
This provides a cross-platform way to both (1) get a unique (opaque) ID for the current thread (using `std.os.Thread.currentId()`), and (2) given a `std.os.Thread` object, get the unique ID that that thread would get if it called `std.os.Thread.currentId()`.  Note that this second thing is something the proposed `getThreadId` solution in #1316 using `threadlocal` can't do.

What do you think?
