### PR TITLE
Fix last pull request. 

### DIFF
--- a/std/mem.zig
+++ b/std/mem.zig
@@ -135,7 +135,7 @@ pub const Allocator = struct {
     }
 };
 
-const Compare = enum {
+pub const Compare = enum {
     LessThan,
     Equal,
     GreaterThan,


### PR DESCRIPTION
mem: use pub on Compare

fixes rb

/home/shawn/git/zig/std/rb.zig:133:37: error: 'Compare' is private
    compare_fn: fn(*Node, *Node) mem.Compare,
