### PR TITLE
File.openWitemode requesting too permissive share mode in Windows

### DIFF
--- a/std/os/file.zig
+++ b/std/os/file.zig
@@ -58,7 +58,7 @@ pub const File = struct {
                 allocator,
                 path,
                 windows.GENERIC_WRITE,
-                windows.FILE_SHARE_WRITE | windows.FILE_SHARE_READ | windows.FILE_SHARE_DELETE,
+                windows.FILE_SHARE_WRITE,
                 windows.CREATE_ALWAYS,
                 windows.FILE_ATTRIBUTE_NORMAL,
             );


### PR DESCRIPTION
I am currently unable to build (personal reasons) and would appreciate if someone could test this fix.

This fix is meant to address #859; the share mode is too permissive to catch file open errors on existing binaries if they are running. This is because running executables are locked by the Windows for writing while executing.
