### PR TITLE
POSIX: add fcntl (ref #1271)

### DIFF
--- a/std/c/darwin.zig
+++ b/std/c/darwin.zig
@@ -30,6 +30,8 @@ pub extern "c" fn sysctl(name: [*]c_int, namelen: c_uint, oldp: ?*c_void, oldlen
 pub extern "c" fn sysctlbyname(name: [*]const u8, oldp: ?*c_void, oldlenp: ?*usize, newp: ?*c_void, newlen: usize) c_int;
 pub extern "c" fn sysctlnametomib(name: [*]const u8, mibp: ?*c_int, sizep: ?*usize) c_int;
 
+pub extern "c" fn fcntl(fildes: c_int, cmd: c_int, ...) c_int;
+
 pub use @import("../os/darwin/errno.zig");
 
 pub const _errno = __error;

--- a/std/os/darwin.zig
+++ b/std/os/darwin.zig
@@ -568,6 +568,71 @@ pub const SOCK_RDM: c_int = 4;
 pub const SOCK_SEQPACKET: c_int = 5;
 pub const SOCK_MAXADDRLEN: c_int = 255;
 
+// Constants used for fcntl(2)
+
+// command values
+pub const F_DUPFD = 0; // duplicate file descriptor
+pub const F_GETFD = 1; // get file descriptor flags
+pub const F_SETFD = 2; // set file descriptor flags
+pub const F_GETFL = 3; // get file status flags
+pub const F_SETFL = 4; // set file status flags
+pub const F_GETOWN = 5; // get SIGIO/SIGURG proc/pgrp
+pub const F_SETOWN = 6; // set SIGIO/SIGURG proc/pgrp
+pub const F_GETLK = 7; // get record locking information
+pub const F_SETLK = 8; // set record locking information
+pub const F_SETLKW = 9; // F_SETLK; wait if blocked
+pub const F_FLUSH_DATA = 4; 
+pub const F_CHKCLEAN = 41; // Used for regression test
+pub const F_PREALLOCATE = 42; // Preallocate storage
+pub const F_SETSIZE = 43; // Truncate a file without zeroing space 
+pub const F_RDADVISE = 44; // Issue an advisory read async with no copy to user
+pub const F_RDAHEAD = 45; // turn read ahead off/on for this fd
+pub const F_READBOOTSTRAP = 46; // Read bootstrap from disk
+pub const F_WRITEBOOTSTRAP = 47; // Write bootstrap on disk
+pub const F_NOCACHE = 48; // turn data caching off/on for this fd
+pub const F_LOG2PHYS = 49; // file offset to device offset
+pub const F_GETPATH = 50; // return the full path of the fd
+pub const F_FULLFSYNC = 51; // fsync + ask the drive to flush to the media
+pub const F_PATHPKG_CHECK = 52; // find which component (if any) is a package
+pub const F_FREEZE_FS = 53; // "freeze" all fs operations
+pub const F_THAW_FS = 54; // "thaw" all fs operations
+pub const F_GLOBAL_NOCACHE = 55; // turn data caching off/on (globally) for this file
+pub const F_ADDSIGS = 59; // add detached signatures
+pub const F_MARKDEPENDENCY = 60; // this process hosts the device supporting the fs backing this fd
+pub const F_ADDFILESIGS = 61; // add signature from same file (used by dyld for shared libs)
+pub const F_NODIRECT = 62; // used in conjunction with F_NOCACHE to indicate that DIRECT, synchonous writes
+                          // should not be used (i.e. its ok to temporaily create cached pages)
+
+pub const F_GETPROTECTIONCLASS = 63; // Get the protection class of a file from the EA, returns int
+pub const F_SETPROTECTIONCLASS = 64; // Set the protection class of a file for the EA, requires int
+pub const F_LOG2PHYS_EXT = 65; // file offset to device offset, extended
+pub const F_GETLKPID = 66; // get record locking information, per-process
+pub const F_SETBACKINGSTORE = 0; // Mark the file as being the backing store for another filesystem
+pub const F_GETPATH_MTMINFO = 1; // return the full path of the FD, but error in specific mtmd circumstances
+// F_GETENCRYPTEDDATA == 72 was removed from darwin
+pub const F_SETNOSIGPIPE = 73; // No SIGPIPE generated on EPIPE
+pub const F_GETNOSIGPIPE = 74; // Status of SIGPIPE for this fd
+pub const F_TRANSCODEKEY = 75; // For some cases, we need to rewrap the key for AKS/MKB
+pub const F_SINGLE_WRITER = 76; // file being written to a by single writer... if throttling enabled, writes
+                               // may be broken into smaller chunks with throttling in between
+pub const F_GETPROTECTIONLEVEL = 77; // Get the protection version number for this filesystem
+
+pub const FCNTL_FS_SPECIFIC_BASE = 0x00010000;
+
+// file descriptor flags (F_GETFD, F_SETFD)
+pub const FD_CLOEXEC = 1; // close-on-exec flag
+
+// record locking flags (F_GETLK, F_SETLK, F_SETLKW)
+pub const F_RDLCK = 1; // shared or read lock
+pub const F_UNLCK = 2; // unlock
+pub const F_WRLCK = 3; // exclusive or write lock
+pub const F_WAIT = 0x010; // Wait until lock is granted
+pub const F_FLOCK = 0x020; // Use flock(2) semantics for lock
+pub const F_POSIX = 0x040; // Use POSIX semantics for lock
+pub const F_PROV = 0x080; // Non-coalesced provisional lock
+pub const F_WAKE1_SAFE = 0x100; // its safe to only wake one waiter
+pub const F_ABORT = 0x200; // lock attempt aborted (force umount)
+
 fn wstatus(x: i32) i32 {
     return x & 0o177;
 }

--- a/std/os/darwin.zig
+++ b/std/os/darwin.zig
@@ -742,17 +742,17 @@ pub fn fork() usize {
 }
 
 ///fcntl with zero parameters
-pub fn fcntlZero(fildes: i32, cmd: i32) usize {
+pub fn fcntl0(fildes: i32, cmd: i32) usize {
     return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd)));
 }
 
 ///fcntl with one parameter
-pub fn fcntlOne(fildes: i32, cmd: i32, arg: var) usize {
+pub fn fcntl1(fildes: i32, cmd: i32, arg: var) usize {
     return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd), arg));
 }
 
 ///fcntl with two parameters
-pub fn fcntlTwo(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
+pub fn fcntl2(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
     return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd), arg_a, arg_b));
 }
 

--- a/std/os/darwin.zig
+++ b/std/os/darwin.zig
@@ -741,19 +741,14 @@ pub fn fork() usize {
     return errnoWrap(c.fork());
 }
 
-///fcntl with zero parameters
-pub fn fcntl0(fildes: i32, cmd: i32) usize {
-    return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd)));
-}
-
-///fcntl with one parameter
-pub fn fcntl1(fildes: i32, cmd: i32, arg: var) usize {
-    return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd), arg));
-}
-
-///fcntl with two parameters
-pub fn fcntl2(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
-    return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd), arg_a, arg_b));
+pub fn fcntl(fildes: i32, cmd: i32, args: ...) usize {
+    switch (args.len) {
+        0 => return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd))),
+        1 => return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd), args[0])),
+        2 => return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd), args[0], args[1])),
+        3 => return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd), args[0], args[1], args[2])),
+        else => @compileError("fcntl only supports up to 5 arguments"),
+    }
 }
 
 pub fn access(path: [*]const u8, mode: u32) usize {

--- a/std/os/darwin.zig
+++ b/std/os/darwin.zig
@@ -741,6 +741,21 @@ pub fn fork() usize {
     return errnoWrap(c.fork());
 }
 
+///fcntl with zero parameters
+pub fn fcntlZero(fildes: i32, cmd: i32) usize {
+    return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd)));
+}
+
+///fcntl with one parameter
+pub fn fcntlOne(fildes: i32, cmd: i32, arg: var) usize {
+    return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd), arg));
+}
+
+///fcntl with two parameters
+pub fn fcntlTwo(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
+    return errnoWrap(c.fcntl(@bitCast(c_int, fildes), @bitCast(c_int, cmd), arg_a, arg_b));
+}
+
 pub fn access(path: [*]const u8, mode: u32) usize {
     return errnoWrap(c.access(path, mode));
 }

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -2555,7 +2555,7 @@ pub fn posixFcntl(fd: i32, cmd: i32, a: ...) PosixFcntlError!i32 {
 test "os.posixFcntl" {
   // Only test on POSIX systems
   if (!is_posix)
-    return error.ZigSkipTest;
+    return error.SkipZigTest;
 
   // Simple Test of F_GETFD and F_SETFD
   var flags = try posixFcntl(0, posix.F_GETFD);

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -2943,3 +2943,18 @@ pub fn bsdKEvent(
         }
     }
 }
+
+test "os.posix.fcntl" {
+  // Only test on POSIX systems
+  if (!is_posix)
+    return error.SkipZigTest;
+
+  // Simple Test of F_GETFD and F_SETFD
+  var rc = posix.fcntl(0, posix.F_GETFD);
+  var err = posix.getErrno(rc);
+  assert(err == 0);
+
+  rc = posix.fcntl(0, posix.F_SETFD, rc);
+  err = posix.getErrno(rc);
+  assert(err == 0);
+}

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -2520,11 +2520,8 @@ pub const PosixFcntlError = error{
     /// mapped by another process.
     SystemResources,
 
-    /// EBUSY: cmd is F_SETPIPE_SZ and the new pipe capacity specified in arg
-    /// is smaller than the amount of buffer space currently used to
-    /// store data in the pipe.
-    /// OR cmd is F_ADD_SEALS, arg includes F_SEAL_WRITE, and there
-    /// exists a writable, shared mapping on the file referred to by fd.
+    /// EBUSY: The file or resource operated on was deemed busy by the OS.
+    /// Please check your operating system manual for specifics.
     FileBusy,
 
     Unexpected,

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -2555,6 +2555,17 @@ pub fn posixFcntl(fd: i32, cmd: i32, a: ...) PosixFcntlError!i32 {
     }
 }
 
+test "os.posixFcntl" {
+  // Only test on POSIX systems
+  if (!is_posix)
+    return error.ZigSkipTest;
+
+  // Simple Test of F_GETFD and F_SETFD
+  var flags = try posixFcntl(0, posix.F_GETFD);
+  _ = try posixFcntl(0, posix.F_SETFD, flags);
+
+}
+
 pub const Thread = struct {
     data: Data,
 

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -2533,9 +2533,9 @@ pub const PosixFcntlError = error{
 pub fn posixFcntl(fd: i32, cmd: i32, a: ...) PosixFcntlError!i32 {
     while (true) {
         const rc = switch (comptime a.len) {
-          0 => posix.fcntlZero(fd, cmd),
-          1 => posix.fcntlOne(fd, cmd, a[0]),
-          2 => posix.fcntlTwo(fd, cmd, a[0], a[1]),
+          0 => posix.fcntl0(fd, cmd),
+          1 => posix.fcntl1(fd, cmd, a[0]),
+          2 => posix.fcntl2(fd, cmd, a[0], a[1]),
           else => @compileError("posixFcntl only supports up to two arguments at this time"),
         };
         const err = posix.getErrno(rc);

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -2512,6 +2512,49 @@ pub fn posixGetSockOptConnectError(sockfd: i32) PosixConnectError!void {
     }
 }
 
+pub const PosixFcntlError = error{
+    /// EACCES: Operation is prohibited by locks held by other processes.
+    PermissionDenied,
+
+    /// EAGAIN: The operation is prohibited because the file has been memory-
+    /// mapped by another process.
+    SystemResources,
+
+    /// EBUSY: cmd is F_SETPIPE_SZ and the new pipe capacity specified in arg
+    /// is smaller than the amount of buffer space currently used to
+    /// store data in the pipe.
+    /// OR cmd is F_ADD_SEALS, arg includes F_SEAL_WRITE, and there
+    /// exists a writable, shared mapping on the file referred to by fd.
+    FileBusy,
+
+    Unexpected,
+};
+
+pub fn posixFcntl(fd: i32, cmd: i32, a: ...) PosixFcntlError!i32 {
+    while (true) {
+        const rc = switch (comptime a.len) {
+          0 => posix.fcntlZero(fd, cmd),
+          1 => posix.fcntlOne(fd, cmd, a[0]),
+          2 => posix.fcntlTwo(fd, cmd, a[0], a[1]),
+          else => @compileError("posixFcntl only supports up to two arguments at this time"),
+        };
+        const err = posix.getErrno(rc);
+        switch (err) {
+            0 => return @intCast(i32, rc),
+            else => return unexpectedErrorPosix(err),
+
+            posix.EACCES => return PosixFcntlError.PermissionDenied,
+            posix.EAGAIN => return PosixFcntlError.SystemResources,
+            posix.EBADF => unreachable,
+            posix.EBUSY => return PosixFcntlError.FileBusy,
+            posix.EDEADLK => unreachable, // It was detected that cmd would cause a deadlock.
+            posix.EFAULT => unreachable, // The address pointed to by optval or optlen is not in a valid part of the process address space.
+            posix.EINTR => continue,
+            posix.EINVAL => unreachable,
+        }
+    }
+}
+
 pub const Thread = struct {
     data: Data,
 

--- a/std/os/linux/index.zig
+++ b/std/os/linux/index.zig
@@ -659,6 +659,20 @@ pub const winsize = extern struct {
     ws_ypixel: u16,
 };
 
+pub fn varToSyscall(p: var) usize {
+    switch (@typeInfo(@typeOf(p))) {
+        builtin.TypeId.Int,
+        builtin.TypeId.ComptimeInt => {
+            return @bitCast(usize, isize( p ));
+        },
+        builtin.TypeId.Pointer => {
+            return @ptrToInt( p );
+        },
+        else => unreachable,
+    }
+    return 0;
+}
+
 /// Get the errno from a syscall return value, or 0 for no error.
 pub fn getErrno(r: usize) usize {
     const signed_r = @bitCast(isize, r);

--- a/std/os/linux/index.zig
+++ b/std/os/linux/index.zig
@@ -1256,17 +1256,17 @@ pub fn timerfd_settime(fd: i32, flags: u32, new_value: *const itimerspec, old_va
 
 /// fcntl with zero parameters
 pub fn fcntl0(fildes: i32, cmd: i32) usize {
-    return syscall2(SYS_fcntl, @intCast(c_int, fd), @bitCast(c_int, cmd));
+    return syscall2(SYS_fcntl, @intCast(c_int, fildes), @bitCast(c_int, cmd));
 }
 
 /// fcntl with one parameter
 pub fn fcnt1(fildes: i32, cmd: i32, arg: var) usize {
-    return syscall3(SYS_fcntl, @intCast(c_int, fd), @bitCast(c_int, cmd), arg);
+    return syscall3(SYS_fcntl, @intCast(c_int, fildes), @bitCast(c_int, cmd), arg);
 }
 
 /// fcntl with two parameters
 pub fn fcntl2(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
-    return syscall4(SYS_fcntl, @intCast(c_int, fd), @bitCast(c_int, cmd), arg_a, arg_b);
+    return syscall4(SYS_fcntl, @intCast(c_int, fildes), @bitCast(c_int, cmd), arg_a, arg_b);
 }
 
 pub const _LINUX_CAPABILITY_VERSION_1 = 0x19980330;

--- a/std/os/linux/index.zig
+++ b/std/os/linux/index.zig
@@ -1268,20 +1268,16 @@ pub fn timerfd_settime(fd: i32, flags: u32, new_value: *const itimerspec, old_va
     return syscall4(SYS_timerfd_settime, @intCast(usize, fd), @intCast(usize, flags), @ptrToInt(new_value), @ptrToInt(old_value));
 }
 
-/// fcntl with zero parameters
-pub fn fcntl0(fildes: i32, cmd: i32) usize {
-    return syscall2(SYS_fcntl, varToSyscall(fildes), varToSyscall(cmd));
+pub fn fcntl(fildes: i32, cmd: i32, args: ...) usize {
+    switch (args.len) {
+        0 => return syscall2(SYS_fcntl, varToSyscall(fildes), varToSyscall(cmd)),
+        1 => return syscall3(SYS_fcntl, varToSyscall(fildes), varToSyscall(cmd), varToSyscall(args[0])),
+        2 => return syscall4(SYS_fcntl, varToSyscall(fildes), varToSyscall(cmd), varToSyscall(args[0]), varToSyscall(args[1])),
+        3 => return syscall5(SYS_fcntl, varToSyscall(fildes), varToSyscall(cmd), varToSyscall(args[0]), varToSyscall(args[1]), varToSyscall(args[2])),
+        else => @compileError("fcntl only supports up to 5 arguments"),
+    }
 }
 
-/// fcntl with one parameter
-pub fn fcntl1(fildes: i32, cmd: i32, arg: var) usize {
-    return syscall3(SYS_fcntl, varToSyscall(fildes), varToSyscall(cmd), varToSyscall(arg) );
-}
-
-/// fcntl with two parameters
-pub fn fcntl2(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
-    return syscall4(SYS_fcntl, varToSyscall(fildes), varToSyscall(cmd), varToSyscall(arg_a), varToSyscall(arg_b));
-}
 
 pub const _LINUX_CAPABILITY_VERSION_1 = 0x19980330;
 pub const _LINUX_CAPABILITY_U32S_1 = 1;

--- a/std/os/linux/index.zig
+++ b/std/os/linux/index.zig
@@ -1255,17 +1255,17 @@ pub fn timerfd_settime(fd: i32, flags: u32, new_value: *const itimerspec, old_va
 }
 
 /// fcntl with zero parameters
-pub fn fcntlZero(fildes: i32, cmd: i32) usize {
+pub fn fcntl0(fildes: i32, cmd: i32) usize {
     return syscall2(SYS_fcntl, @intCast(c_int, fd), @bitCast(c_int, cmd));
 }
 
 /// fcntl with one parameter
-pub fn fcntlOne(fildes: i32, cmd: i32, arg: var) usize {
+pub fn fcnt1(fildes: i32, cmd: i32, arg: var) usize {
     return syscall3(SYS_fcntl, @intCast(c_int, fd), @bitCast(c_int, cmd), arg);
 }
 
 /// fcntl with two parameters
-pub fn fcntlTwo(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
+pub fn fcntl2(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
     return syscall4(SYS_fcntl, @intCast(c_int, fd), @bitCast(c_int, cmd), arg_a, arg_b);
 }
 

--- a/std/os/linux/index.zig
+++ b/std/os/linux/index.zig
@@ -663,7 +663,11 @@ pub fn varToSyscall(p: var) usize {
     switch (@typeInfo(@typeOf(p))) {
         builtin.TypeId.Int,
         builtin.TypeId.ComptimeInt => {
-            return @bitCast(usize, isize( p ));
+            if (@alignOf(@typeOf(p)) == @sizeOf(usize)) {
+                return p;
+            } else {
+                return @bitCast(usize, isize( p ));
+            }
         },
         builtin.TypeId.Pointer => {
             return @ptrToInt( p );

--- a/std/os/linux/index.zig
+++ b/std/os/linux/index.zig
@@ -1270,17 +1270,17 @@ pub fn timerfd_settime(fd: i32, flags: u32, new_value: *const itimerspec, old_va
 
 /// fcntl with zero parameters
 pub fn fcntl0(fildes: i32, cmd: i32) usize {
-    return syscall2(SYS_fcntl, @intCast(usize, isize(fildes)), @bitCast(usize, isize(cmd)));
+    return syscall2(SYS_fcntl, varToSyscall(fildes), varToSyscall(cmd));
 }
 
 /// fcntl with one parameter
 pub fn fcntl1(fildes: i32, cmd: i32, arg: var) usize {
-    return syscall3(SYS_fcntl, @intCast(usize, isize(fildes)), @bitCast(usize, isize(cmd)), arg);
+    return syscall3(SYS_fcntl, varToSyscall(fildes), varToSyscall(cmd), varToSyscall(arg) );
 }
 
 /// fcntl with two parameters
 pub fn fcntl2(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
-    return syscall4(SYS_fcntl, @intCast(usize, isize(fildes)), @bitCast(usize, isize(cmd)), arg_a, arg_b);
+    return syscall4(SYS_fcntl, varToSyscall(fildes), varToSyscall(cmd), varToSyscall(arg_a), varToSyscall(arg_b));
 }
 
 pub const _LINUX_CAPABILITY_VERSION_1 = 0x19980330;

--- a/std/os/linux/index.zig
+++ b/std/os/linux/index.zig
@@ -1256,17 +1256,17 @@ pub fn timerfd_settime(fd: i32, flags: u32, new_value: *const itimerspec, old_va
 
 /// fcntl with zero parameters
 pub fn fcntl0(fildes: i32, cmd: i32) usize {
-    return syscall2(SYS_fcntl, @intCast(c_int, fildes), @bitCast(c_int, cmd));
+    return syscall2(SYS_fcntl, @intCast(usize, isize(fildes)), @bitCast(usize, isize(cmd)));
 }
 
 /// fcntl with one parameter
-pub fn fcnt1(fildes: i32, cmd: i32, arg: var) usize {
-    return syscall3(SYS_fcntl, @intCast(c_int, fildes), @bitCast(c_int, cmd), arg);
+pub fn fcntl1(fildes: i32, cmd: i32, arg: var) usize {
+    return syscall3(SYS_fcntl, @intCast(usize, isize(fildes)), @bitCast(usize, isize(cmd)), arg);
 }
 
 /// fcntl with two parameters
 pub fn fcntl2(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
-    return syscall4(SYS_fcntl, @intCast(c_int, fildes), @bitCast(c_int, cmd), arg_a, arg_b);
+    return syscall4(SYS_fcntl, @intCast(usize, isize(fildes)), @bitCast(usize, isize(cmd)), arg_a, arg_b);
 }
 
 pub const _LINUX_CAPABILITY_VERSION_1 = 0x19980330;

--- a/std/os/linux/index.zig
+++ b/std/os/linux/index.zig
@@ -1254,6 +1254,21 @@ pub fn timerfd_settime(fd: i32, flags: u32, new_value: *const itimerspec, old_va
     return syscall4(SYS_timerfd_settime, @intCast(usize, fd), @intCast(usize, flags), @ptrToInt(new_value), @ptrToInt(old_value));
 }
 
+/// fcntl with zero parameters
+pub fn fcntlZero(fildes: i32, cmd: i32) usize {
+    return syscall2(SYS_fcntl, @intCast(c_int, fd), @bitCast(c_int, cmd));
+}
+
+/// fcntl with one parameter
+pub fn fcntlOne(fildes: i32, cmd: i32, arg: var) usize {
+    return syscall3(SYS_fcntl, @intCast(c_int, fd), @bitCast(c_int, cmd), arg);
+}
+
+/// fcntl with two parameters
+pub fn fcntlTwo(fildes: i32, cmd: i32, arg_a: var, arg_b: var) usize {
+    return syscall4(SYS_fcntl, @intCast(c_int, fd), @bitCast(c_int, cmd), arg_a, arg_b);
+}
+
 pub const _LINUX_CAPABILITY_VERSION_1 = 0x19980330;
 pub const _LINUX_CAPABILITY_U32S_1 = 1;
 


### PR DESCRIPTION
Adds `fnctl` support to linux and darwin.
Cherry picked from work on UDP.

ref #1271