### PR TITLE
Find local llvm-config first

### DIFF
--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -8,7 +8,7 @@
 # LLVM_LIBDIRS
 
 find_program(LLVM_CONFIG_EXE
-    NAMES llvm-config-6.0 llvm-config
+    NAMES llvm-config llvm-config-6.0
     PATHS
         "/mingw64/bin"
         "/c/msys64/mingw64/bin"


### PR DESCRIPTION
Distro's llvm usually have a 6.0 suffix.Any custom llvm build
names the binary as llvm-config.Keeping 6.0 variant first causes
the distro's llvm to be compiled in place of a custom one even if
given using CMAKE_PREFIX_PATH.