### PR TITLE
fixed handling of [*]u8 when no format specifier is set

### DIFF
--- a/std/fmt/index.zig
+++ b/std/fmt/index.zig
@@ -179,7 +179,7 @@ pub fn formatType(
             },
             builtin.TypeInfo.Pointer.Size.Many => {
                 if (ptr_info.child == u8) {
-                    if (fmt[0] == 's') {
+                    if (fmt.len > 0 and fmt[0] == 's') {
                         const len = std.cstr.len(value);
                         return formatText(value[0..len], fmt, context, Errors, output);
                     }


### PR DESCRIPTION
If fmt was called on with a `[*]u8` or `[*]const u8` argument, but the fmt string did not specify 's' to treat it as a string, it produced a compile error due to accessing index 1 of a 0 length slice.