### PR TITLE
Update fmt to handle non-pointer struct/union/enum

### DIFF
--- a/std/fmt/index.zig
+++ b/std/fmt/index.zig
@@ -146,6 +146,9 @@ pub fn formatType(
         builtin.TypeId.Promise => {
             return format(context, Errors, output, "promise@{x}", @ptrToInt(value));
         },
+        builtin.TypeId.Enum, builtin.TypeId.Union, builtin.TypeId.Struct => {
+            return formatType(&value, fmt, context, Errors, output);
+        },
         builtin.TypeId.Pointer => |ptr_info| switch (ptr_info.size) {
             builtin.TypeInfo.Pointer.Size.One => switch (@typeInfo(ptr_info.child)) {
                 builtin.TypeId.Array => |info| {


### PR DESCRIPTION
Since #1109 was merged we cannot be sure that a struct/union will be passed as a pointer. It might be better to implement this fix in the opposite direction: if it is a pointer, pass `value.*` back into `formatType`. 