### PR TITLE
Binary NOT Support for comptime_int (#1382)

### DIFF
--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -435,6 +435,21 @@ bool mul_u64_overflow(uint64_t op1, uint64_t op2, uint64_t *result) {
 }
 #endif
 
+static inline void _twos_complement_inplace(BigInt *bn) {
+    if (bn->digit_count == 1) {
+        bn->data.digit = ~bn->data.digit + 1;
+    } else {
+        size_t i = 0;
+        bool increment = true;
+        for (; i < bn->digit_count; i += 1) {
+            bn->data.digits[i] = ~bn->data.digits[i];
+            if (increment) {
+                increment = add_u64_overflow(bn->data.digits[i], 1, &bn->data.digits[i]);
+            }
+        }
+    }
+}
+
 void bigint_add(BigInt *dest, const BigInt *op1, const BigInt *op2) {
     if (op1->digit_count == 0) {
         return bigint_init_bigint(dest, op2);

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -1447,9 +1447,12 @@ void bigint_negate_wrap(BigInt *dest, const BigInt *op, size_t bit_count) {
 }
 
 void bigint_not(BigInt *dest, const BigInt *op, size_t bit_count, bool is_signed) {
-    if (bit_count == 0) {
-        bigint_init_unsigned(dest, 0);
-        return;
+    if (!bit_count) {
+        bit_count = (op->digit_count * 64) - bigint_clz(op, op->digit_count * 64) + (is_signed ? 1 : 0);
+        if (bit_count == 0) {
+            bigint_init_unsigned(dest, 0);
+            return;
+        }
     }
 
     if (is_signed) {

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -1220,7 +1220,6 @@ void bigint_or(BigInt *dest, const BigInt *op1, const BigInt *op2) {
         _twos_complement_inplace(dest);
         dest->is_negative = true;
     }
-    dest->allow_binop_cast = true;
     bigint_normalize(dest);
 }
 
@@ -1251,7 +1250,6 @@ void bigint_and(BigInt *dest, const BigInt *op1, const BigInt *op2) {
         _twos_complement_inplace(dest);
         dest->is_negative = true;
     }
-    dest->allow_binop_cast = true;
     bigint_normalize(dest);
 }
 
@@ -1290,7 +1288,6 @@ void bigint_xor(BigInt *dest, const BigInt *op1, const BigInt *op2) {
         _twos_complement_inplace(dest);
         dest->is_negative = true;
     }
-    dest->allow_binop_cast = true;
     bigint_normalize(dest);
 }
 

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -1643,7 +1643,7 @@ size_t bigint_ctz(const BigInt *bi, size_t bit_count) {
 }
 
 size_t bigint_clz(const BigInt *bi, size_t bit_count) {
-    if (bi->is_negative || bit_count == 0)
+    if (bit_count == 0)
         return 0;
     if (bi->digit_count == 0)
         return bit_count;

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -1225,46 +1225,34 @@ void bigint_or(BigInt *dest, const BigInt *op1, const BigInt *op2) {
 }
 
 void bigint_and(BigInt *dest, const BigInt *op1, const BigInt *op2) {
+    size_t i = 0;
     if (op1->digit_count == 0 || op2->digit_count == 0) {
         return bigint_init_unsigned(dest, 0);
     }
-    if (op1->is_negative || op2->is_negative) {
-        // TODO this code path is untested
-        size_t big_bit_count = max(bigint_bits_needed(op1), bigint_bits_needed(op2));
-
-        BigInt twos_comp_op1 = {0};
-        to_twos_complement(&twos_comp_op1, op1, big_bit_count);
-
-        BigInt twos_comp_op2 = {0};
-        to_twos_complement(&twos_comp_op2, op2, big_bit_count);
-
-        BigInt twos_comp_dest = {0};
-        bigint_and(&twos_comp_dest, &twos_comp_op1, &twos_comp_op2);
-
-        from_twos_complement(dest, &twos_comp_dest, big_bit_count, true);
+    dest->is_negative = false;
+    const uint64_t *op1_digits = bigint_ptr(op1);
+    const uint64_t *op2_digits = bigint_ptr(op2);
+    if (op1->digit_count == 1 && op2->digit_count == 1) {
+        dest->digit_count = 1;
+        dest->data.digit = (op1->is_negative ? (~(op1_digits[0]))+1 : op1_digits[0]);
+        dest->data.digit &= (op2->is_negative ? (~(op2_digits[0]))+1 : op2_digits[0]);
     } else {
-        dest->is_negative = false;
-        const uint64_t *op1_digits = bigint_ptr(op1);
-        const uint64_t *op2_digits = bigint_ptr(op2);
-        if (op1->digit_count == 1 && op2->digit_count == 1) {
-            dest->digit_count = 1;
-            dest->data.digit = op1_digits[0] & op2_digits[0];
-            bigint_normalize(dest);
-            return;
-        }
-
         dest->digit_count = max(op1->digit_count, op2->digit_count);
         dest->data.digits = allocate_nonzero<uint64_t>(dest->digit_count);
-
-        size_t i = 0;
         for (; i < op1->digit_count && i < op2->digit_count; i += 1) {
-            dest->data.digits[i] = op1_digits[i] & op2_digits[i];
+            dest->data.digits[i] = (op1->is_negative ? (~(op1_digits[i]))+1 : op1_digits[i]);
+            dest->data.digits[i] &= (op2->is_negative ? (~(op2_digits[i]))+1 : op2_digits[i]);
         }
         for (; i < dest->digit_count; i += 1) {
             dest->data.digits[i] = 0;
         }
-        bigint_normalize(dest);
     }
+    if (op1->is_negative && op2->is_negative) {
+        _twos_complement_inplace(dest);
+        dest->is_negative = true;
+    }
+    dest->allow_binop_cast = true;
+    bigint_normalize(dest);
 }
 
 void bigint_xor(BigInt *dest, const BigInt *op1, const BigInt *op2) {

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -1194,54 +1194,34 @@ void bigint_mod(BigInt *dest, const BigInt *op1, const BigInt *op2) {
 }
 
 void bigint_or(BigInt *dest, const BigInt *op1, const BigInt *op2) {
+    size_t i = 0;
     if (op1->digit_count == 0) {
         return bigint_init_bigint(dest, op2);
     }
     if (op2->digit_count == 0) {
         return bigint_init_bigint(dest, op1);
     }
-    if (op1->is_negative || op2->is_negative) {
-        // TODO this code path is untested
-        size_t big_bit_count = max(bigint_bits_needed(op1), bigint_bits_needed(op2));
-
-        BigInt twos_comp_op1 = {0};
-        to_twos_complement(&twos_comp_op1, op1, big_bit_count);
-
-        BigInt twos_comp_op2 = {0};
-        to_twos_complement(&twos_comp_op2, op2, big_bit_count);
-
-        BigInt twos_comp_dest = {0};
-        bigint_or(&twos_comp_dest, &twos_comp_op1, &twos_comp_op2);
-
-        from_twos_complement(dest, &twos_comp_dest, big_bit_count, true);
+    dest->is_negative = false;
+    const uint64_t *op1_digits = bigint_ptr(op1);
+    const uint64_t *op2_digits = bigint_ptr(op2);
+    if (op1->digit_count == 1 && op2->digit_count == 1) {
+        dest->digit_count = 1;
+        dest->data.digit = (op1->is_negative ? (~(op1_digits[0]))+1 : op1_digits[0]);
+        dest->data.digit |= (op2->is_negative ? (~(op2_digits[0]))+1 : op2_digits[0]);
     } else {
-        dest->is_negative = false;
-        const uint64_t *op1_digits = bigint_ptr(op1);
-        const uint64_t *op2_digits = bigint_ptr(op2);
-        if (op1->digit_count == 1 && op2->digit_count == 1) {
-            dest->digit_count = 1;
-            dest->data.digit = op1_digits[0] | op2_digits[0];
-            bigint_normalize(dest);
-            return;
-        }
-        // TODO this code path is untested
-        uint64_t first_digit = dest->data.digit;
         dest->digit_count = max(op1->digit_count, op2->digit_count);
         dest->data.digits = allocate_nonzero<uint64_t>(dest->digit_count);
-        dest->data.digits[0] = first_digit;
-        size_t i = 1;
-        for (; i < dest->digit_count; i += 1) {
-            uint64_t digit = 0;
-            if (i < op1->digit_count) {
-                digit |= op1_digits[i];
-            }
-            if (i < op2->digit_count) {
-                digit |= op2_digits[i];
-            }
-            dest->data.digits[i] = digit;
+        for (; i < op1->digit_count && i < op2->digit_count; i += 1) {
+            dest->data.digits[i] = (op1->is_negative ? (~(op1_digits[i]))+1 : op1_digits[i]);
+            dest->data.digits[i] |= (op2->is_negative ? (~(op2_digits[i]))+1 : op2_digits[i]);
         }
-        bigint_normalize(dest);
     }
+    if (op1->is_negative || op2->is_negative) {
+        _twos_complement_inplace(dest);
+        dest->is_negative = true;
+    }
+    dest->allow_binop_cast = true;
+    bigint_normalize(dest);
 }
 
 void bigint_and(BigInt *dest, const BigInt *op1, const BigInt *op2) {

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -1256,46 +1256,26 @@ void bigint_and(BigInt *dest, const BigInt *op1, const BigInt *op2) {
 }
 
 void bigint_xor(BigInt *dest, const BigInt *op1, const BigInt *op2) {
+    size_t i = 0;
     if (op1->digit_count == 0) {
         return bigint_init_bigint(dest, op2);
     }
     if (op2->digit_count == 0) {
         return bigint_init_bigint(dest, op1);
     }
-    if (op1->is_negative || op2->is_negative) {
-        // TODO this code path is untested
-        size_t big_bit_count = max(bigint_bits_needed(op1), bigint_bits_needed(op2));
-
-        BigInt twos_comp_op1 = {0};
-        to_twos_complement(&twos_comp_op1, op1, big_bit_count);
-
-        BigInt twos_comp_op2 = {0};
-        to_twos_complement(&twos_comp_op2, op2, big_bit_count);
-
-        BigInt twos_comp_dest = {0};
-        bigint_xor(&twos_comp_dest, &twos_comp_op1, &twos_comp_op2);
-
-        from_twos_complement(dest, &twos_comp_dest, big_bit_count, true);
+    dest->is_negative = false;
+    const uint64_t *op1_digits = bigint_ptr(op1);
+    const uint64_t *op2_digits = bigint_ptr(op2);
+    if (op1->digit_count == 1 && op2->digit_count == 1) {
+        dest->digit_count = 1;
+        dest->data.digit = (op1->is_negative ? (~(op1_digits[0]))+1 : op1_digits[0]);
+        dest->data.digit ^= (op2->is_negative ? (~(op2_digits[0]))+1 : op2_digits[0]);
     } else {
-        dest->is_negative = false;
-        const uint64_t *op1_digits = bigint_ptr(op1);
-        const uint64_t *op2_digits = bigint_ptr(op2);
-
-        assert(op1->digit_count > 0 && op2->digit_count > 0);
-        uint64_t first_digit = op1_digits[0] ^ op2_digits[0];
-        if (op1->digit_count == 1 && op2->digit_count == 1) {
-            dest->digit_count = 1;
-            dest->data.digit = first_digit;
-            bigint_normalize(dest);
-            return;
-        }
-        // TODO this code path is untested
         dest->digit_count = max(op1->digit_count, op2->digit_count);
         dest->data.digits = allocate_nonzero<uint64_t>(dest->digit_count);
-        dest->data.digits[0] = first_digit;
-        size_t i = 1;
         for (; i < op1->digit_count && i < op2->digit_count; i += 1) {
-            dest->data.digits[i] = op1_digits[i] ^ op2_digits[i];
+            dest->data.digits[i] = (op1->is_negative ? (~(op1_digits[i]))+1 : op1_digits[i]);
+            dest->data.digits[i] ^= (op2->is_negative ? (~(op2_digits[i]))+1 : op2_digits[i]);
         }
         for (; i < dest->digit_count; i += 1) {
             if (i < op1->digit_count) {
@@ -1305,8 +1285,13 @@ void bigint_xor(BigInt *dest, const BigInt *op1, const BigInt *op2) {
                 dest->data.digits[i] = op2_digits[i];
             }
         }
-        bigint_normalize(dest);
     }
+    if (op1->is_negative != op2->is_negative) {
+        _twos_complement_inplace(dest);
+        dest->is_negative = true;
+    }
+    dest->allow_binop_cast = true;
+    bigint_normalize(dest);
 }
 
 void bigint_shl(BigInt *dest, const BigInt *op1, const BigInt *op2) {

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -133,9 +133,7 @@ static void from_twos_complement(BigInt *dest, const BigInt *src, size_t bit_cou
 
         bigint_negate(dest, &inverted);
         return;
-
     }
-
     bigint_init_bigint(dest, src);
 }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -9203,7 +9203,8 @@ static ZigType *ir_resolve_peer_types( IrAnalyze *ira
         if (cur_type->id == ZigTypeIdComptimeInt ||
                    cur_type->id == ZigTypeIdComptimeFloat)
         {
-            if (ir_num_lit_fits_in_other_type(ira, cur_inst, prev_type, false)) {
+            bool explicit_cast = (parent_instruction && parent_instruction->id == IrInstructionIdBinOp);
+            if (ir_num_lit_fits_in_other_type(ira, cur_inst, prev_type, explicit_cast)) {
                 continue;
             } else {
                 return ira->codegen->builtin_types.entry_invalid;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -8373,6 +8373,18 @@ static bool ir_num_lit_fits_in_other_type(IrAnalyze *ira, IrInstruction *instruc
                     other_type->data.integral.is_signed))
         {
             return true;
+        } else {
+            size_t full_bits = const_val->data.x_bigint.digit_count * 64;
+            size_t number_bits = full_bits - bigint_clz(&const_val->data.x_bigint, full_bits);
+            Buf *val_buf = buf_alloc();
+            bigint_append_buf(val_buf, &const_val->data.x_bigint, 10);
+            ir_add_error(ira, instruction,
+                buf_sprintf("cannot cast number literal '%s' of %zu bits into %u bit type '%s'",
+                  buf_ptr(val_buf),
+                  number_bits,
+                  other_type->data.integral.bit_count,
+                  buf_ptr(&other_type->name)));
+            return false;
         }
     } else if (const_val_fits_in_num_lit(const_val, other_type)) {
         return true;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -8364,7 +8364,7 @@ static bool ir_num_lit_fits_in_other_type(IrAnalyze *ira, IrInstruction *instruc
             Buf *val_buf = buf_alloc();
             bigint_append_buf(val_buf, &const_val->data.x_bigint, 10);
             ir_add_error(ira, instruction,
-                buf_sprintf("cannot cast negative value %s to unsigned integer type '%s'",
+                buf_sprintf("cannot cast negative number literal '%s' to unsigned integer type '%s'",
                     buf_ptr(val_buf),
                     buf_ptr(&other_type->name)));
             return false;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -13970,15 +13970,19 @@ static ZigType *ir_analyze_bin_not(IrAnalyze *ira, IrInstructionUnOp *instructio
     if (type_is_invalid(expr_type))
         return ira->codegen->builtin_types.entry_invalid;
 
-    if (expr_type->id == ZigTypeIdInt) {
+    if ( expr_type->id == ZigTypeIdInt
+      || expr_type->id == ZigTypeIdComptimeInt ) {
         if (instr_is_comptime(value)) {
             ConstExprValue *target_const_val = ir_resolve_const(ira, value, UndefBad);
             if (target_const_val == nullptr)
                 return ira->codegen->builtin_types.entry_invalid;
 
             ConstExprValue *out_val = ir_build_const_from(ira, &instruction->base);
-            bigint_not(&out_val->data.x_bigint, &target_const_val->data.x_bigint,
-                    expr_type->data.integral.bit_count, expr_type->data.integral.is_signed);
+            bigint_not( &out_val->data.x_bigint
+                      , &target_const_val->data.x_bigint
+                      , expr_type->data.integral.bit_count
+                      , expr_type->id == ZigTypeIdComptimeInt ? true : expr_type->data.integral.is_signed
+                      );
             return expr_type;
         }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -8360,7 +8360,7 @@ static bool ir_num_lit_fits_in_other_type(IrAnalyze *ira, IrInstruction *instruc
     if (other_type->id == ZigTypeIdFloat) {
         return true;
     } else if (other_type->id == ZigTypeIdInt && const_val_is_int) {
-        if (!other_type->data.integral.is_signed && const_val->data.x_bigint.is_negative) {
+        if (!explicit_cast && !other_type->data.integral.is_signed && const_val->data.x_bigint.is_negative) {
             Buf *val_buf = buf_alloc();
             bigint_append_buf(val_buf, &const_val->data.x_bigint, 10);
             ir_add_error(ira, instruction,

--- a/test/cases/math.zig
+++ b/test/cases/math.zig
@@ -570,3 +570,13 @@ test "cast of bitwise negated number literal to f16 through f64" {
     assert( const_to_f64 == -5.0 );
 }
 
+test "binary operations" {
+  // ref https://github.com/ziglang/zig/issues/1387
+  assert( i64(3 & -1) == 3 );
+  assert( i64(3 & 1) == 1 );
+  assert( i64(-3 & -1) == -3 );
+  assert( u64(18446744073709551615 & 18446744073709551611) == 18446744073709551611 );
+  assert( i128(-18446744073709551615 & -18446744073709551611) == -18446744073709551615 );
+  assert( i64(3 | -1) == -1);
+  assert( i64(3 ^ -1) == -4);
+}

--- a/test/cases/math.zig
+++ b/test/cases/math.zig
@@ -495,3 +495,78 @@ test "comptime_int param and return" {
 fn comptimeAdd(comptime a: comptime_int, comptime b: comptime_int) comptime_int {
     return a + b;
 }
+
+test "binary operations on number literal" {
+    const TINY_QUANTUM_SHIFT = 4;
+    const TINY_QUANTUM_SIZE = 1 << TINY_QUANTUM_SHIFT;
+    const RESULT = (4 + TINY_QUANTUM_SIZE) & ~(TINY_QUANTUM_SIZE - 1);
+    assert( RESULT == 16 );
+}
+
+test "binary operations on number literal -- repetitive" {
+    const TINY_QUANTUM_SHIFT = 4;
+    assert( ~(~(~(~(~(~TINY_QUANTUM_SHIFT) - 1) - 1) + 16)) == 20 );
+}
+
+test "binary operations on number literal -- flags" {
+  const LEVEL_ONE = 1 << 0;
+  const LEVEL_TWO = 1 << 1;
+  const LEVEL_THREE = 1 << 2;
+
+  var flags: u32 = 0;
+
+  flags |= LEVEL_ONE;
+  flags |= LEVEL_TWO;
+  flags |= LEVEL_THREE;
+
+  assert(flags == (LEVEL_ONE + LEVEL_TWO + LEVEL_THREE));
+
+  // remove LEVEL_TWO from flags via unary operation
+  flags &= ~LEVEL_TWO;
+
+  assert(flags == (LEVEL_ONE + LEVEL_THREE));
+
+  // remove LEVEL_* from flags via unary operation
+  flags &= ~LEVEL_ONE;
+  flags &= ~LEVEL_TWO;
+  flags &= ~LEVEL_THREE;
+
+  assert(flags == 0);
+
+}
+
+test "cast of bitwise negated number literal to u8 through u64" {
+    const CONST_NUMBER = 4;
+    var const_to_u8: u8 = ~CONST_NUMBER;
+    var const_to_u16: u16 = ~CONST_NUMBER;
+    var const_to_u32: u32 = ~CONST_NUMBER;
+    var const_to_u64: u64 = ~CONST_NUMBER;
+
+    assert( const_to_u8 == 0xfb );
+    assert( const_to_u16 == 0xfffb );
+    assert( const_to_u32 == 0xfffffffb );
+    assert( const_to_u64 == 0xfffffffffffffffb );
+}
+
+test "cast of bitwise negated number literal to i16 through i64" {
+    const CONST_NUMBER = 4;
+    var const_to_i16: i16 = ~CONST_NUMBER;
+    var const_to_i32: i32 = ~CONST_NUMBER;
+    var const_to_i64: i64 = ~CONST_NUMBER;
+
+    assert( const_to_i16 == -5 );
+    assert( const_to_i32 == -5 );
+    assert( const_to_i64 == -5 );
+}
+
+test "cast of bitwise negated number literal to f16 through f64" {
+    const CONST_NUMBER = 4;
+    var const_to_f16: f16 = ~CONST_NUMBER;
+    var const_to_f32: f32 = ~CONST_NUMBER;
+    var const_to_f64: f64 = ~CONST_NUMBER;
+
+    assert( const_to_f16 == -5.0 );
+    assert( const_to_f32 == -5.0 );
+    assert( const_to_f64 == -5.0 );
+}
+

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2989,7 +2989,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(y)); }
     ,
-        ".tmp_source.zig:3:14: error: operation caused overflow",
+        ".tmp_source.zig:3:14: error: cannot cast negative number literal '-10' to unsigned integer type 'u16'",
         ".tmp_source.zig:1:14: note: called from here",
     );
 

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -422,7 +422,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @IntType(false, @maxValue(u32) + 1);
         \\}
     ,
-        ".tmp_source.zig:2:40: error: integer value 4294967296 cannot be implicitly casted to type 'u32'",
+        ".tmp_source.zig:2:40: error: cannot cast number literal '4294967296' of 33 bits into 32 bit type 'u32'",
     );
 
     cases.add(

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1090,15 +1090,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
-        "cast negative integer literal to usize",
-        \\export fn entry() void {
-        \\    const x = usize(-10);
-        \\}
-    ,
-        ".tmp_source.zig:2:21: error: cannot cast negative value -10 to unsigned integer type 'usize'",
-    );
-
-    cases.add(
         "use invalid number literal as array index",
         \\var v = 25;
         \\export fn entry() void {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -87,7 +87,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = @floatToInt(i8, 200);
         \\}
     ,
-        ".tmp_source.zig:2:31: error: integer value 200 cannot be implicitly casted to type 'i8'",
+        ".tmp_source.zig:2:31: error: cannot cast number literal '200' of 8 bits into 8 bit type 'i8'",
     );
 
     cases.add(
@@ -2989,7 +2989,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(y)); }
     ,
-        ".tmp_source.zig:3:14: error: cannot cast negative number literal '-10' to unsigned integer type 'u16'",
+        ".tmp_source.zig:3:14: error: operation caused overflow",
         ".tmp_source.zig:1:14: note: called from here",
     );
 
@@ -3002,7 +3002,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(y)); }
     ,
-        ".tmp_source.zig:3:14: error: operation caused overflow",
+        ".tmp_source.zig:3:14: error: cannot cast negative number literal '-10' to unsigned integer type 'u16'",
         ".tmp_source.zig:1:14: note: called from here",
     );
 

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3364,7 +3364,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var vga_mem: u16 = 0xB8000;
         \\}
     ,
-        ".tmp_source.zig:2:24: error: integer value 753664 cannot be implicitly casted to type 'u16'",
+        ".tmp_source.zig:2:24: error: cannot cast number literal '753664' of 20 bits into 16 bit type 'u16'",
     );
 
     cases.add(

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -555,15 +555,11 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @floatToInt(i8, f32(-129.1));
         \\}
         \\comptime {
-        \\    _ = @floatToInt(u8, f32(-1.1));
-        \\}
-        \\comptime {
         \\    _ = @floatToInt(u8, f32(256.1));
         \\}
     ,
         ".tmp_source.zig:2:9: error: integer value '-129' cannot be stored in type 'i8'",
-        ".tmp_source.zig:5:9: error: integer value '-1' cannot be stored in type 'u8'",
-        ".tmp_source.zig:8:9: error: integer value '256' cannot be stored in type 'u8'",
+        ".tmp_source.zig:5:9: error: integer value '256' cannot be stored in type 'u8'",
     );
 
     cases.add(

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2202,7 +2202,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const x : u8 = 300;
         \\export fn entry() usize { return @sizeOf(@typeOf(x)); }
     ,
-        ".tmp_source.zig:1:16: error: integer value 300 cannot be implicitly casted to type 'u8'",
+        ".tmp_source.zig:1:16: error: cannot cast number literal '300' of 9 bits into 8 bit type 'u8'",
     );
 
     cases.add(

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3259,17 +3259,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         ".tmp_source.zig:23:5: error: expected type '*Allocator', found '*List'",
     );
 
-    cases.add(
-        "binary not on number literal",
-        \\const TINY_QUANTUM_SHIFT = 4;
-        \\const TINY_QUANTUM_SIZE = 1 << TINY_QUANTUM_SHIFT;
-        \\var block_aligned_stuff: usize = (4 + TINY_QUANTUM_SIZE) & ~(TINY_QUANTUM_SIZE - 1);
-        \\
-        \\export fn entry() usize { return @sizeOf(@typeOf(block_aligned_stuff)); }
-    ,
-        ".tmp_source.zig:3:60: error: unable to perform binary not operation on type 'comptime_int'",
-    );
-
     cases.addCase(x: {
         const tc = cases.create(
             "multiple files with private function error",


### PR DESCRIPTION
fixes #1382 

**#1382**
* [X] `~` operator on `TypeTableEntryIdComptimeInt `
* [X] Compiler Error Tests
* [X] Compiler Behavior Tests

This is now possible:
```zig
test "cast of bitwise negated number literal to u8 through u64" {
    const CONST_NUMBER = 4;
    var const_to_u8: u8 = ~CONST_NUMBER;
    var const_to_u16: u16 = ~CONST_NUMBER;
    var const_to_u32: u32 = ~CONST_NUMBER;
    var const_to_u64: u64 = ~CONST_NUMBER;
    
    assert( const_to_u8 == 0xfb );
    assert( const_to_u16 == 0xfffb );
    assert( const_to_u32 == 0xfffffffb );
    assert( const_to_u64 == 0xfffffffffffffffb );
}
```

Its also smart enough to keep the sign when casting to signed integers:
```zig
test "cast of bitwise negated number literal to i16 through i64" {
    const CONST_NUMBER = 4;
    var const_to_i16: i16 = ~CONST_NUMBER;
    var const_to_i32: i32 = ~CONST_NUMBER;
    var const_to_i64: i64 = ~CONST_NUMBER;

    assert( const_to_i16 == -5 );
    assert( const_to_i32 == -5 );
    assert( const_to_i64 == -5 );
}
```