### PR TITLE
macOS: provide stacktrace via atos

### DIFF
--- a/std/c/darwin.zig
+++ b/std/c/darwin.zig
@@ -26,6 +26,7 @@ pub extern "c" fn kevent64(
     timeout: ?*const timespec,
 ) c_int;
 
+pub extern "c" fn getpid() c_int;
 pub extern "c" fn sysctl(name: [*]c_int, namelen: c_uint, oldp: ?*c_void, oldlenp: ?*usize, newp: ?*c_void, newlen: usize) c_int;
 pub extern "c" fn sysctlbyname(name: [*]const u8, oldp: ?*c_void, oldlenp: ?*usize, newp: ?*c_void, newlen: usize) c_int;
 pub extern "c" fn sysctlnametomib(name: [*]const u8, mibp: ?*c_int, sizep: ?*usize) c_int;

--- a/std/debug/index.zig
+++ b/std/debug/index.zig
@@ -42,6 +42,54 @@ pub fn getStderrStream() !*io.OutStream(io.FileOutStream.Error) {
     }
 }
 
+// Stop-gap until macho library is built-out
+fn writeOutMacOS(allocator: *mem.Allocator) !void {
+
+    var args = ArrayList([]const u8).init(allocator);
+    defer args.deinit();
+
+    const self_exe_path = try os.selfExePath(allocator);
+    defer allocator.free(self_exe_path);
+
+    args.append("xcrun") catch unreachable;
+    args.append("atos") catch unreachable;
+
+    var buf = try allocator.alloc(u8, 32);
+    defer allocator.free( buf );
+
+    args.append( try std.fmt.bufPrint(buf, "-p{}", std.c.getpid() ) ) catch unreachable;
+
+    var fp = @ptrToInt(@frameAddress());
+    while (fp != 0) : (fp = @intToPtr(*const usize, fp).*) {
+        const return_address = @intToPtr(*const usize, fp + @sizeOf(usize)).*;
+        var tmp = try allocator.alloc(u8, 32);
+        defer allocator.free( tmp );
+        args.append( try std.fmt.bufPrint(tmp, "{x}", return_address) ) catch unreachable;
+    }
+
+    const child = os.ChildProcess.init(args.toSliceConst(), allocator) catch unreachable;
+    defer child.deinit();
+
+    child.stdin_behavior = os.ChildProcess.StdIo.Ignore;
+
+    child.spawn() catch |err| panic(
+        \\Unable to spawn atos: {}
+        \\Do you have xcode tools installed?
+        \\Please try: xcode-select --install
+        , @errorName(err)
+    );
+
+    const term = child.wait() catch |err| {
+        panic(
+            \\Unable to spawn atos: {}
+            \\Do you have xcode tools installed?
+            \\Please try: xcode-select --install
+            , @errorName(err)
+        );
+    };
+
+}
+
 var self_debug_info: ?*ElfStackTrace = null;
 pub fn getSelfDebugInfo() !*ElfStackTrace {
     if (self_debug_info) |info| {
@@ -198,6 +246,10 @@ pub fn writeCurrentStackTrace(out_stream: var, allocator: *mem.Allocator, debug_
         addr_state = AddressState{ .LookingForStartAddress = addr };
     } else {
         addr_state = AddressState.NotLookingForStartAddress;
+    }
+
+    if (builtin.os == builtin.Os.macosx) {
+      return try writeOutMacOS(allocator);
     }
 
     var fp = @ptrToInt(@frameAddress());

--- a/std/debug/index.zig
+++ b/std/debug/index.zig
@@ -132,6 +132,8 @@ var panicking: u8 = 0; // TODO make this a bool
 pub fn panicExtra(trace: ?*const builtin.StackTrace, first_trace_addr: ?usize, comptime format: []const u8, args: ...) noreturn {
     @setCold(true);
 
+    const stderr = getStderrStream() catch os.abort();
+    stderr.print(format ++ "\n", args) catch os.abort();
     if (@atomicRmw(u8, &panicking, builtin.AtomicRmwOp.Xchg, 1, builtin.AtomicOrder.SeqCst) == 1) {
         // Panicked during a panic.
 
@@ -140,8 +142,6 @@ pub fn panicExtra(trace: ?*const builtin.StackTrace, first_trace_addr: ?usize, c
         // which first called panic can finish printing a stack trace.
         os.abort();
     }
-    const stderr = getStderrStream() catch os.abort();
-    stderr.print(format ++ "\n", args) catch os.abort();
     if (trace) |t| {
         dumpStackTrace(t);
     }


### PR DESCRIPTION
Temporary stopgap solution until `macho.zig` gets built-out.

Has the added benefit that it doesn't dynamically load anything from libc.

Looks like this in practice:
```
$ bin/zig build-exe panic.zig ; ./panic
DOKIDOKI
writeCurrentStackTrace (in panic) (index.zig:252)
dumpCurrentStackTrace (in panic) (index.zig:117)
panicExtra (in panic) (index.zig:198)
0x000000010f3c85fb (in panic)
0x000000010f3e91a4 (in panic)
callMain (in panic) (bootstrap.zig:86)
callMainWithArgs (in panic) (bootstrap.zig:70)
main (in panic) (bootstrap.zig:77)
start (in libdyld.dylib) + 1
0x00000001 (in panic)
Abort trap: 6
```

ref issue #1365