### PR TITLE
use PATH_MAX properly (needs windows work)

### DIFF
--- a/std/debug/index.zig
+++ b/std/debug/index.zig
@@ -341,7 +341,7 @@ pub fn openSelfDebugInfo(allocator: *mem.Allocator) !*ElfStackTrace {
 }
 
 fn printLineFromFile(allocator: *mem.Allocator, out_stream: var, line_info: *const LineInfo) !void {
-    var f = try os.File.openRead(allocator, line_info.file_name);
+    var f = try os.File.openRead(line_info.file_name);
     defer f.close();
     // TODO fstat and make sure that the file has the correct size
 

--- a/std/io_test.zig
+++ b/std/io_test.zig
@@ -28,7 +28,7 @@ test "write a file, read it, then delete it" {
         try buf_stream.flush();
     }
     {
-        var file = try os.File.openRead(allocator, tmp_file_name);
+        var file = try os.File.openRead(tmp_file_name);
         defer file.close();
 
         const file_size = try file.getEndPos();

--- a/std/os/file.zig
+++ b/std/os/file.zig
@@ -29,14 +29,13 @@ pub const File = struct {
 
     /// `path` needs to be copied in memory to add a null terminating byte, hence the allocator.
     /// Call close to clean up.
-    pub fn openRead(allocator: *mem.Allocator, path: []const u8) OpenError!File {
+    pub fn openRead(path: []const u8) OpenError!File {
         if (is_posix) {
             const flags = posix.O_LARGEFILE | posix.O_RDONLY;
-            const fd = try os.posixOpen(allocator, path, flags, 0);
+            const fd = try os.posixOpen(path, flags, 0);
             return openHandle(fd);
         } else if (is_windows) {
             const handle = try os.windowsOpen(
-                allocator,
                 path,
                 windows.GENERIC_READ,
                 windows.FILE_SHARE_READ,
@@ -61,11 +60,10 @@ pub const File = struct {
     pub fn openWriteMode(allocator: *mem.Allocator, path: []const u8, file_mode: Mode) OpenError!File {
         if (is_posix) {
             const flags = posix.O_LARGEFILE | posix.O_WRONLY | posix.O_CREAT | posix.O_CLOEXEC | posix.O_TRUNC;
-            const fd = try os.posixOpen(allocator, path, flags, file_mode);
+            const fd = try os.posixOpen(path, flags, file_mode);
             return openHandle(fd);
         } else if (is_windows) {
             const handle = try os.windowsOpen(
-                allocator,
                 path,
                 windows.GENERIC_WRITE,
                 windows.FILE_SHARE_WRITE | windows.FILE_SHARE_READ | windows.FILE_SHARE_DELETE,

--- a/std/os/path.zig
+++ b/std/os/path.zig
@@ -1166,7 +1166,7 @@ pub fn real(allocator: *Allocator, pathname: []const u8) ![]u8 {
             return allocator.shrink(u8, result_buf, cstr.len(result_buf.ptr));
         },
         Os.linux => {
-            const fd = try os.posixOpen(allocator, pathname, posix.O_PATH | posix.O_NONBLOCK | posix.O_CLOEXEC, 0);
+            const fd = try os.posixOpen(pathname, posix.O_PATH | posix.O_NONBLOCK | posix.O_CLOEXEC, 0);
             defer os.close(fd);
 
             var buf: ["/proc/self/fd/-2147483648".len]u8 = undefined;


### PR DESCRIPTION
we don't need to use an allocator in openRead(). There are probably other places too where we are doing this and don't need to.