### PR TITLE
allow implicit cast from *[N]T to ?[*]T

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -10697,6 +10697,22 @@ static IrInstruction *ir_analyze_cast(IrAnalyze *ira, IrInstruction *source_inst
                 return ira->codegen->invalid_instruction;
 
             return cast2;
+        } else if (
+            wanted_child_type->id == TypeTableEntryIdPointer &&
+            wanted_child_type->data.pointer.ptr_len == PtrLenUnknown &&
+            actual_type->id == TypeTableEntryIdPointer &&
+            actual_type->data.pointer.ptr_len == PtrLenSingle &&
+            actual_type->data.pointer.child_type->id == TypeTableEntryIdArray &&
+            actual_type->data.pointer.alignment >= wanted_child_type->data.pointer.alignment &&
+            types_match_const_cast_only(ira, wanted_child_type->data.pointer.child_type,
+            actual_type->data.pointer.child_type->data.array.child_type, source_node,
+            !wanted_child_type->data.pointer.is_const).id == ConstCastResultIdOk)
+        {
+            IrInstruction *cast1 = ir_analyze_cast(ira, source_instr, wanted_child_type, value);
+            if (type_is_invalid(cast1->value.type))
+                return ira->codegen->invalid_instruction;
+
+            return ir_analyze_maybe_wrap(ira, source_instr, cast1, wanted_type);
         }
     }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -10708,10 +10708,7 @@ static IrInstruction *ir_analyze_cast(IrAnalyze *ira, IrInstruction *source_inst
             actual_type->data.pointer.child_type->data.array.child_type, source_node,
             !wanted_child_type->data.pointer.is_const).id == ConstCastResultIdOk)
         {
-            IrInstruction *cast1 = ir_analyze_cast(ira, source_instr, wanted_child_type, value);
-            if (type_is_invalid(cast1->value.type))
-                return ira->codegen->invalid_instruction;
-
+            IrInstruction *cast1 = ir_resolve_ptr_of_array_to_slice(ira, source_instr, value, wanted_child_type);
             return ir_analyze_maybe_wrap(ira, source_instr, cast1, wanted_type);
         }
     }

--- a/test/cases/cast.zig
+++ b/test/cases/cast.zig
@@ -491,6 +491,8 @@ test "implicit cast from *[N]T to ?[*]T" {
   var y: [4]u16 = [4]u16 {0, 1, 2, 3};
 
   x = &y;
-  
+  assert(std.mem.eql(u16, x.?[0..4], y[0..4]));
+  x.?[0] = 8;
+  y[3] = 6;
   assert(std.mem.eql(u16, x.?[0..4], y[0..4]));
 }

--- a/test/cases/cast.zig
+++ b/test/cases/cast.zig
@@ -485,3 +485,12 @@ fn MakeType(comptime T: type) type {
         }
     };
 }
+
+test "implicit cast from *[N]T to ?[*]T" {
+  var x: ?[*]u16 = null;
+  var y: [4]u16 = [4]u16 {0, 1, 2, 3};
+
+  x = &y;
+  
+  assert(std.mem.eql(u16, x.?[0..4], y[0..4]));
+}


### PR DESCRIPTION
For #1395.

I'm sure some of those checks are unnecessary if we're just calling ir_analyze_cast again. I considered handling it directly with ir_resolve_ptr_of_array_to_slice as above. Would that be better?

I'd appreciate any comments