### PR TITLE
Fixed compile error when passing enum to fmt

### DIFF
--- a/std/fmt/index.zig
+++ b/std/fmt/index.zig
@@ -166,6 +166,11 @@ pub fn formatType(
 
             if (has_cust_fmt) return value.format(fmt, context, Errors, output);
             try output(context, @typeName(T));
+            if (comptime @typeId(T) == builtin.TypeId.Enum) {
+                try output(context, ".");
+                try formatType(@tagName(value), "", context, Errors, output);
+                return;
+            }
             comptime var field_i = 0;
             inline while (field_i < @memberCount(T)) : (field_i += 1) {
                 if (field_i == 0) {


### PR DESCRIPTION
Caused by struct printing behavior. Enums are different enough from structs and unions that the field iteration behavior doesn't do what we want even if @memberName didn't error on enums.

Union printing also ignores tag information and prints all unions as though we don't know which field is active, but this is kinda ugly to fix. I'm not sure it's a great idea to print union field values without tag information. Consider the case:

```
const U = extern union {
    value: u8,
    ptr: *SomeStruct,
};

var u = { .value = 0, };

debug.warn("{}\n", u);
```

Even though it is invalid, `ptr` will be dereferenced by fmt.
