### PR TITLE
breaking: let posixRead() return less than buffer size, introduce pos…

### DIFF
--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -757,6 +757,6 @@ fn writeIntFd(fd: i32, value: ErrInt) !void {
 
 fn readIntFd(fd: i32) !ErrInt {
     var bytes: [@sizeOf(ErrInt)]u8 = undefined;
-    os.posixRead(fd, bytes[0..]) catch return error.SystemResources;
+    os.posixReadFull(fd, bytes[0..]) catch return error.SystemResources;
     return mem.readInt(bytes[0..], ErrInt, builtin.endian);
 }


### PR DESCRIPTION
…ixReadFull()

posixRead should be as thin an abstraction on top of read() as possible.

posixReadFull() really should be in io somewhere.

How about importing all the abstractions from go's io? (we need traits for this)
https://golang.org/pkg/io/#ReadFull