### PR TITLE
Use the scope of the while body inside of the continue expression

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -5326,11 +5326,11 @@ static IrInstruction *ir_gen_while_expr(IrBuilder *irb, Scope *scope, AstNode *n
 
         if (continue_expr_node) {
             ir_set_cursor_at_end_and_append_block(irb, continue_block);
-            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, payload_scope);
+            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, body_result->scope);
             if (expr_result == irb->codegen->invalid_instruction)
                 return expr_result;
             if (!instr_is_unreachable(expr_result))
-                ir_mark_gen(ir_build_br(irb, payload_scope, node, cond_block, is_comptime));
+                ir_mark_gen(ir_build_br(irb, body_result->scope, node, cond_block, is_comptime));
         }
 
         IrInstruction *else_result = nullptr;
@@ -5408,11 +5408,11 @@ static IrInstruction *ir_gen_while_expr(IrBuilder *irb, Scope *scope, AstNode *n
 
         if (continue_expr_node) {
             ir_set_cursor_at_end_and_append_block(irb, continue_block);
-            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, child_scope);
+            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, body_result->scope);
             if (expr_result == irb->codegen->invalid_instruction)
                 return expr_result;
             if (!instr_is_unreachable(expr_result))
-                ir_mark_gen(ir_build_br(irb, child_scope, node, cond_block, is_comptime));
+                ir_mark_gen(ir_build_br(irb, body_result->scope, node, cond_block, is_comptime));
         }
 
         IrInstruction *else_result = nullptr;
@@ -5471,11 +5471,11 @@ static IrInstruction *ir_gen_while_expr(IrBuilder *irb, Scope *scope, AstNode *n
 
         if (continue_expr_node) {
             ir_set_cursor_at_end_and_append_block(irb, continue_block);
-            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, scope);
+            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, body_result->scope);
             if (expr_result == irb->codegen->invalid_instruction)
                 return expr_result;
             if (!instr_is_unreachable(expr_result))
-                ir_mark_gen(ir_build_br(irb, scope, node, cond_block, is_comptime));
+                ir_mark_gen(ir_build_br(irb, body_result->scope, node, cond_block, is_comptime));
         }
 
         IrInstruction *else_result = nullptr;

--- a/test/cases/while.zig
+++ b/test/cases/while.zig
@@ -68,6 +68,17 @@ test "while with continue expression" {
     assert(sum == 40);
 }
 
+test "while with continue expression node including scope of while body" {
+    var a: u32 = 2;
+    var b: u32 = 0;
+    const result = while (a != 0) : ({a -= 1; b += c;}) {
+        const c = 1;
+        if (b == 1)
+            break true;
+    } else false;
+    assert(result);
+}
+
 test "while with else" {
     var sum: i32 = 0;
     var i: i32 = 0;


### PR DESCRIPTION
Fixes #1403 

* [X] Implementation: `src/ir.cpp`
* [X] Tests: `test/cases/while.zig`

```zig
test "while with continue expression node including scope of while body" {
    var a: u32 = 2;
    var b: u32 = 0;
    const result = while (a != 0) : ({a -= 1; b += c;}) {
        const c = 1;
        if (b == 1)
            break true;
    } else false;
    assert(result);
}
```

Prioritized because like @andrewrk, I wanted to use the scope of the while body inside of the continue expression.

Thank-you.

