### PR TITLE
reopened: Use the scope of the while body inside of the continue expression

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -5331,11 +5331,11 @@ static IrInstruction *ir_gen_while_expr(IrBuilder *irb, Scope *scope, AstNode *n
 
         if (continue_expr_node) {
             ir_set_cursor_at_end_and_append_block(irb, continue_block);
-            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, payload_scope);
+            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, body_result->scope);
             if (expr_result == irb->codegen->invalid_instruction)
                 return expr_result;
             if (!instr_is_unreachable(expr_result))
-                ir_mark_gen(ir_build_br(irb, payload_scope, node, cond_block, is_comptime));
+                ir_mark_gen(ir_build_br(irb, body_result->scope, node, cond_block, is_comptime));
         }
 
         IrInstruction *else_result = nullptr;
@@ -5413,11 +5413,11 @@ static IrInstruction *ir_gen_while_expr(IrBuilder *irb, Scope *scope, AstNode *n
 
         if (continue_expr_node) {
             ir_set_cursor_at_end_and_append_block(irb, continue_block);
-            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, child_scope);
+            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, body_result->scope);
             if (expr_result == irb->codegen->invalid_instruction)
                 return expr_result;
             if (!instr_is_unreachable(expr_result))
-                ir_mark_gen(ir_build_br(irb, child_scope, node, cond_block, is_comptime));
+                ir_mark_gen(ir_build_br(irb, body_result->scope, node, cond_block, is_comptime));
         }
 
         IrInstruction *else_result = nullptr;
@@ -5476,11 +5476,11 @@ static IrInstruction *ir_gen_while_expr(IrBuilder *irb, Scope *scope, AstNode *n
 
         if (continue_expr_node) {
             ir_set_cursor_at_end_and_append_block(irb, continue_block);
-            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, scope);
+            IrInstruction *expr_result = ir_gen_node(irb, continue_expr_node, body_result->scope);
             if (expr_result == irb->codegen->invalid_instruction)
                 return expr_result;
             if (!instr_is_unreachable(expr_result))
-                ir_mark_gen(ir_build_br(irb, scope, node, cond_block, is_comptime));
+                ir_mark_gen(ir_build_br(irb, body_result->scope, node, cond_block, is_comptime));
         }
 
         IrInstruction *else_result = nullptr;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -12981,7 +12981,11 @@ static IrInstruction *ir_get_var_ptr(IrAnalyze *ira, IrInstruction *instruction,
         assert(ira->codegen->errors.length != 0);
         return ira->codegen->invalid_instruction;
     }
-    assert(var->value->type);
+    if (!var->value->type) {
+        ir_add_error(ira, instruction,
+            buf_sprintf("cannot reference variable from unreachable code region"));
+        return ira->codegen->invalid_instruction;
+    }
     if (type_is_invalid(var->value->type))
         return ira->codegen->invalid_instruction;
 

--- a/test/cases/while.zig
+++ b/test/cases/while.zig
@@ -68,6 +68,17 @@ test "while with continue expression" {
     assert(sum == 40);
 }
 
+test "while with continue expression node including scope of while body" {
+    var a: u32 = 2;
+    var b: u32 = 0;
+    const result = while (a != 0) : ({a -= 1; b += c;}) {
+        const c = 1;
+        if (b == 1)
+            break true;
+    } else false;
+    assert(result);
+}
+
 test "while with else" {
     var sum: i32 = 0;
     var i: i32 = 0;

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,6 +2,23 @@ const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "reference variable from unreachable code region",
+        \\pub fn a() void {
+        \\    var i: usize = 0;
+        \\    while (i <= 10) : ({ i += b; }) {
+        \\        continue;
+        \\        const b = 42;
+        \\    }
+        \\}
+        \\export fn entry() void {
+        \\    return a();
+        \\}
+    ,
+        ".tmp_source.zig:5:9: error: unreachable code",
+        ".tmp_source.zig:3:31: error: cannot reference variable from unreachable code region",
+    );
+
+    cases.add(
         "@typeInfo causing depend on itself compile error",
         \\const start = struct {
         \\    fn crash() bug() {


### PR DESCRIPTION
Fixes #1403

* [X] Implementation: `src/ir.cpp` d08016d
* [X] Implementation: `src/ir.cpp` 8acaca8
* [X] Test: `test/cases/while.zig` 5821f56
* [X] Test: `test/compile_errors.zig` 5007177

@thejoshwolfe correctly [pointed-out](https://github.com/ziglang/zig/issues/1403#issuecomment-416060119) that if a variable is defined in a pattern where unreachable code would be referenced, the compiler may crash -- I added an error message for such an event:

```
/Users/cfkk/Source/zig2/build/test.zig:5:9: error: unreachable code
        const b = 42;
        ^
/Users/cfkk/Source/zig2/build/test.zig:3:31: error: cannot reference variable from unreachable code region
    while (i <= 10) : ({ i += b; }) {
                              ^
```

where the following code was used to test:

```zig
test "reference variable from unreachable code region" {
    var i: usize = 0;
    while (i <= 10) : ({ i += b; }) {
        continue;
        const b = 42;
    }
}
```

```zig
test "while with continue expression node including scope of while body" {
    var a: u32 = 2;
    var b: u32 = 0;
    const result = while (a != 0) : ({a -= 1; b += c;}) {
        const c = 1;
        if (b == 1)
            break true;
    } else false;
    assert(result);
}
```

Prioritized because like @andrewrk, I wanted to use the scope of the while body inside of the continue expression.

Thank-you.

