### PR TITLE
Suggestions for misspelled variables / scope items (#1448)

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1959,6 +1959,17 @@ struct ScopeCoroPrelude {
     Scope base;
 };
 
+// used by `find_nearest` to return nearest scope to name
+struct ScopeNearest {
+  size_t distance;
+  Buf *name;
+  Scope *scope;
+  AstNode *decl_node;
+
+  //tuning variables
+  size_t tuning_namelimit;
+};
+
 // synchronized with code in define_builtin_compile_vars
 enum AtomicOrder {
     AtomicOrderUnordered,

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -50,6 +50,7 @@ ImportTableEntry *add_source_file(CodeGen *g, PackageTableEntry *package, Buf *a
 
 VariableTableEntry *find_variable(CodeGen *g, Scope *orig_context, Buf *name);
 Tld *find_decl(CodeGen *g, Scope *scope, Buf *name);
+bool find_nearest_scope(CodeGen *g, Scope *scope, Buf *name, ScopeNearest *nearest);
 void resolve_top_level_decl(CodeGen *g, Tld *tld, bool pointer_only, AstNode *source_node);
 bool type_is_codegen_pointer(TypeTableEntry *type);
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -3779,7 +3779,14 @@ static IrInstruction *ir_gen_symbol(IrBuilder *irb, Scope *scope, AstNode *node,
 
     // TODO put a variable of same name with invalid type in global scope
     // so that future references to this same name will find a variable with an invalid type
-    add_node_error(irb->codegen, node, buf_sprintf("use of undeclared identifier '%s'", buf_ptr(variable_name)));
+    ScopeNearest scope_nearest;
+    scope_nearest.tuning_namelimit = 30;
+    if ( find_nearest_scope(irb->codegen, scope, variable_name, &scope_nearest) ) {
+        ErrorMsg *msg = add_node_error(irb->codegen, node, buf_sprintf("use of undeclared identifier '%s'; did you mean '%s'?", buf_ptr(variable_name), buf_ptr(scope_nearest.name)));
+        add_error_note(irb->codegen, msg, scope_nearest.decl_node, buf_sprintf("'%s' declared here", buf_ptr(scope_nearest.name)));
+    } else {
+        add_node_error(irb->codegen, node, buf_sprintf("use of undeclared identifier '%s'", buf_ptr(variable_name)));
+    }
     return irb->codegen->invalid_instruction;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -43,3 +43,19 @@ uint32_t ptr_hash(const void *ptr) {
 bool ptr_eq(const void *a, const void *b) {
     return a == b;
 }
+
+size_t levenshtein(const char *s, size_t ls, const char *t, size_t lt) {
+    size_t a, b, c;
+    if (!ls) return lt;
+    if (!lt) return ls;
+    if (s[ls] == t[ls]) return levenshtein(s, ls - 1, t, lt - 1);
+
+    a = levenshtein(s, ls - 1, t, lt - 1);
+    b = levenshtein(s, ls,     t, lt - 1);
+    c = levenshtein(s, ls - 1, t, lt    );
+
+    if (a > b) a = b;
+    if (a > c) a = c;
+
+    return a + 1;
+}

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -164,6 +164,7 @@ uint32_t uint64_hash(uint64_t i);
 bool uint64_eq(uint64_t a, uint64_t b);
 uint32_t ptr_hash(const void *ptr);
 bool ptr_eq(const void *a, const void *b);
+size_t levenshtein(const char *s, size_t ls, const char *t, size_t lt);
 
 static inline uint8_t log2_u64(uint64_t x) {
     return (63 - clzll(x));

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -13,6 +13,17 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
+        "typo suggestion on variable names",
+        \\export fn a() bool {
+        \\    const magicnumber = 0xdeadbeef;
+        \\    return magcNumber == 0xdeadbeef;
+        \\}
+    ,
+        ".tmp_source.zig:3:12: error: use of undeclared identifier 'magcNumber'; did you mean 'magicnumber'?",
+        ".tmp_source.zig:2:5: note: 'magicnumber' declared here"
+    );
+
+    cases.add(
         "switch with invalid expression parameter",
         \\export fn entry() void {
         \\    Test(i32);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,6 +2,17 @@ const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "typo suggestion on function names",
+        \\fn helloworld() void {}
+        \\export fn a() void {
+        \\    hellowold();
+        \\}
+    ,
+        ".tmp_source.zig:3:5: error: use of undeclared identifier 'hellowold'; did you mean 'helloworld'",
+        ".tmp_source.zig:1:1: note: 'helloworld' declared here"
+    );
+
+    cases.add(
         "switch with invalid expression parameter",
         \\export fn entry() void {
         \\    Test(i32);


### PR DESCRIPTION
Closes #1448

We should be nice to our programmers and give suggestions for typos.

* [X] Implementation
* [x] Compiler Test case

```zig
fn helloworld() void {}

test "test" {
  hellowold();
}
```

should return:

```
/Users/cfkk/Source/zig2/build/distance.zig:4:3: error: use of undeclared identifier 'hellowold'; did you mean 'helloworld'?
  hellowold();
  ^
/Users/cfkk/Source/zig2/build/distance.zig:1:1: note: 'helloworld' declared here
fn helloworld() void {}
^
```

