### PR TITLE
codegen: use sret correctly (we were producing invalid IR)

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4662,7 +4662,7 @@ static LLVMValueRef get_coro_alloc_helper_fn_val(CodeGen *g, LLVMTypeRef alloc_f
     args.append(allocator_val);
     args.append(coro_size);
     args.append(alignment_val);
-    ZigLLVMBuildCall(g->builder, alloc_fn_val, args.items, args.length, false,
+    ZigLLVMBuildCall(g->builder, alloc_fn_val, args.items, args.length, true,
             get_llvm_cc(g, CallingConventionUnspecified), ZigLLVM_FnInlineAuto, "");
     LLVMValueRef err_val_ptr = LLVMBuildStructGEP(g->builder, sret_ptr, err_union_err_index, "");
     LLVMValueRef err_val = LLVMBuildLoad(g->builder, err_val_ptr, "");

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -189,10 +189,14 @@ ZIG_EXTERN_C LLVMTypeRef ZigLLVMTokenTypeInContext(LLVMContextRef context_ref) {
   return wrap(Type::getTokenTy(*unwrap(context_ref)));
 }
 
+// TODO Generalize SRet to an NumArgs length array of LLVMAttributeRef
 LLVMValueRef ZigLLVMBuildCall(LLVMBuilderRef B, LLVMValueRef Fn, LLVMValueRef *Args,
-        unsigned NumArgs, unsigned CC, ZigLLVM_FnInline fn_inline, const char *Name)
+        unsigned NumArgs, bool SRet, unsigned CC, ZigLLVM_FnInline fn_inline, const char *Name)
 {
     CallInst *call_inst = CallInst::Create(unwrap(Fn), makeArrayRef(unwrap(Args), NumArgs), Name);
+    if (SRet) {
+        call_inst->addAttribute(1, Attribute::StructRet);
+    }
     call_inst->setCallingConv(CC);
     switch (fn_inline) {
         case ZigLLVM_FnInlineAuto:

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -65,7 +65,7 @@ enum ZigLLVM_FnInline {
     ZigLLVM_FnInlineNever,
 };
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildCall(LLVMBuilderRef B, LLVMValueRef Fn, LLVMValueRef *Args,
-        unsigned NumArgs, unsigned CC, enum ZigLLVM_FnInline fn_inline, const char *Name);
+        unsigned NumArgs, bool SRet, unsigned CC, enum ZigLLVM_FnInline fn_inline, const char *Name);
 
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildCmpXchg(LLVMBuilderRef builder, LLVMValueRef ptr, LLVMValueRef cmp,
         LLVMValueRef new_val, LLVMAtomicOrdering success_ordering,


### PR DESCRIPTION
see https://bugs.llvm.org/show_bug.cgi?id=38734

https://llvm.org/docs/LangRef.html#id308

> All ABI-impacting function attributes, such as sret, byval, inreg, returned, and inalloca, must match.

I would love to do this more generally, but for now I want to move on with arm64 work.

There is a great deal of complexity is doing this more generally however, with llvm::AttributeList.