### PR TITLE
Downgrade new g++-8.0 error to warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,7 +774,7 @@ if(MSVC)
 elseif(MINGW)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Werror -Wno-error=format= -Wno-error=format -Wno-error=format-extra-args")
 else()
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror -Wall")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror -Wall -Wno-unknown-warning-option -Wno-error=class-memaccess")
 endif()
 
 if(MSVC)


### PR DESCRIPTION
Allows building in Debug mode. Closes #1357.

Tested with g++ 8.2.1 and clang++-6.0.0. The `Wno-unknown-warning-option` is required to ensure this is backwards compatible to compilers which don't implement the warning.