### PR TITLE
Fixes a path corruption when compiling on windows.

### DIFF
--- a/src/os.cpp
+++ b/src/os.cpp
@@ -489,7 +489,7 @@ static Buf os_path_resolve_windows(Buf **paths_ptr, size_t paths_len) {
     }
 
     // determine which disk designator we will result with, if any
-    char result_drive_buf[2] = {'_', ':'};
+    char result_drive_buf[3] = {'_', ':', '\0'}; // 0 needed for strlen later
     Slice<uint8_t> result_disk_designator = str("");
     WindowsPathKind have_drive_kind = WindowsPathKindNone;
     bool have_abs_path = false;


### PR DESCRIPTION
It would be nice to have overloads of `str` to make a distinction between runtime strings, and char arrays/string litterals.
The former would call `strlen` and the latter just deduce the length of the buffer/string with a template.
Unfortunately msvc behaves differently than gcc and clang, and does not select the correct overload in some cases. https://godbolt.org/z/NTmarG