### PR TITLE
fixed WriteFile segfault

### DIFF
--- a/std/os/windows/util.zig
+++ b/std/os/windows/util.zig
@@ -52,7 +52,8 @@ pub const WriteError = error{
 };
 
 pub fn windowsWrite(handle: windows.HANDLE, bytes: []const u8) WriteError!void {
-    if (windows.WriteFile(handle, bytes.ptr, @intCast(u32, bytes.len), null, null) == 0) {
+    var bytes_written: windows.DWORD = undefined;
+    if (windows.WriteFile(handle, bytes.ptr, @intCast(u32, bytes.len), &bytes_written, null) == 0) {
         const err = windows.GetLastError();
         return switch (err) {
             windows.ERROR.INVALID_USER_BUFFER => WriteError.SystemResources,


### PR DESCRIPTION
accord to the msdn docs for [`WriteFile`](https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-writefile), `lpNumberOfBytesWritten` cannot be null if `lpOverlapped` is null. if both are null a segfault occurs. 