### PR TITLE
src/cache_hash.cpp: support file paths that contain spaces

### DIFF
--- a/src/cache_hash.cpp
+++ b/src/cache_hash.cpp
@@ -337,6 +337,16 @@ Error cache_hit(CacheHash *ch, Buf *out_digest) {
             return ErrorInvalidFormat;
         }
 
+        // We should be at the last item,
+        // so switch from iterating on spaces ' ' to newlines '\n'
+        // First, check to make sure we have the runway to do so:
+        if (it.index == it.buffer.len) {
+            os_file_close(ch->manifest_file);
+            return ErrorInvalidFormat;
+        }
+        it.index++;
+        // Too close for missiles, I’m switching to guns
+        it.split_bytes = str("\n");
         Optional<Slice<uint8_t>> opt_file_path = SplitIterator_next(&it);
         if (!opt_file_path.is_some) {
             os_file_close(ch->manifest_file);


### PR DESCRIPTION
fixes #1510

The manifest data splits sections by spaces and ignores the possibility of spaces in file paths.

This patch switches the iterator from spaces to newlines at the last item, overcoming the issue.