### PR TITLE
Fix additional regressions calling FileOutStream/FileInStream init()

### DIFF
--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -114,7 +114,7 @@ pub fn Queue(comptime T: type) type {
 
         fn dumpRecursive(optional_node: ?*Node, indent: usize) void {
             var stderr_file = std.io.getStdErr() catch return;
-            const stderr = &std.io.FileOutStream.init(&stderr_file).stream;
+            const stderr = &std.io.FileOutStream.init(stderr_file).stream;
             stderr.writeByteNTimes(' ', indent) catch return;
             if (optional_node) |node| {
                 std.debug.warn("0x{x}={}\n", @ptrToInt(node), node.data);

--- a/std/zig/bench.zig
+++ b/std/zig/bench.zig
@@ -24,7 +24,7 @@ pub fn main() !void {
     const mb_per_sec = bytes_per_sec / (1024 * 1024);
 
     var stdout_file = try std.io.getStdOut();
-    const stdout = &std.io.FileOutStream.init(&stdout_file).stream;
+    const stdout = &std.io.FileOutStream.init(stdout_file).stream;
     try stdout.print("{.3} MiB/s, {} KiB used \n", mb_per_sec, memory_used / 1024);
 }
 

--- a/test/standalone/brace_expansion/main.zig
+++ b/test/standalone/brace_expansion/main.zig
@@ -191,7 +191,7 @@ pub fn main() !void {
     var stdin_buf = try Buffer.initSize(global_allocator, 0);
     defer stdin_buf.deinit();
 
-    var stdin_adapter = io.FileInStream.init(&stdin_file);
+    var stdin_adapter = io.FileInStream.init(stdin_file);
     try stdin_adapter.stream.readAllBuffer(&stdin_buf, @maxValue(usize));
 
     var result_buf = try Buffer.initSize(global_allocator, 0);


### PR DESCRIPTION
This is caused by change 686663239af6afd8dea814a9fe6a8885f06d6cb3 and not
fixed in 832caefc2a1b20deb513d43306d6723670ba9c8f.