### PR TITLE
Do not allow integer type of zero bits (u0)

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -4391,6 +4391,10 @@ void semantic_analyze(CodeGen *g) {
 }
 
 ZigType *get_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits) {
+    if (size_in_bits < ZigLLVM_MIN_INT_BITS || size_in_bits > ZigLLVM_MAX_INT_BITS) {
+        return nullptr;
+    }
+
     TypeId type_id = {};
     type_id.id = ZigTypeIdInt;
     type_id.data.integer.is_signed = is_signed;
@@ -4403,7 +4407,9 @@ ZigType *get_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits) {
     }
 
     ZigType *new_entry = make_int_type(g, is_signed, size_in_bits);
-    g->type_table.put(type_id, new_entry);
+    if (new_entry) {
+        g->type_table.put(type_id, new_entry);
+    }
     return new_entry;
 }
 
@@ -5926,8 +5932,8 @@ void render_const_value(CodeGen *g, Buf *buf, ConstExprValue *const_val) {
 ZigType *make_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits) {
     ZigType *entry = new_type_table_entry(ZigTypeIdInt);
     entry->is_copyable = true;
-    entry->type_ref = (size_in_bits == 0) ? LLVMVoidType() : LLVMIntType(size_in_bits);
-    entry->zero_bits = (size_in_bits == 0);
+    entry->type_ref = LLVMIntType(size_in_bits);
+    entry->zero_bits = false;
 
     const char u_or_i = is_signed ? 'i' : 'u';
     buf_resize(&entry->name, 0);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -18697,6 +18697,18 @@ static ZigType *ir_analyze_instruction_int_type(IrAnalyze *ira, IrInstructionInt
 
     ConstExprValue *out_val = ir_build_const_from(ira, &instruction->base);
     out_val->data.x_type = get_int_type(ira->codegen, is_signed, (uint32_t)bit_count);
+    if (out_val->data.x_type == nullptr) {
+        ErrorMsg *msg = ir_add_error( ira
+                                    , bit_count_value
+                                    , buf_sprintf("integer type of %llu bits is not allowed", bit_count));
+        add_error_note( ira->codegen
+                      , msg
+                      , bit_count_value->source_node
+                      , buf_sprintf( "integer types must be from %llu to %llu bits"
+                                   , (uint64_t)ZigLLVM_MIN_INT_BITS
+                                   , (uint64_t)ZigLLVM_MAX_INT_BITS));
+        return ira->codegen->builtin_types.entry_invalid;
+    }
     return ira->codegen->builtin_types.entry_type;
 }
 

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -403,4 +403,9 @@ ZIG_EXTERN_C void ZigLLVMGetNativeTarget(enum ZigLLVM_ArchType *arch_type, enum 
         enum ZigLLVM_VendorType *vendor_type, enum ZigLLVM_OSType *os_type, enum ZigLLVM_EnvironmentType *environ_type,
         enum ZigLLVM_ObjectFormatType *oformat);
 
+enum ZigLLVM_BitWidth {
+    ZigLLVM_MIN_INT_BITS = 1,
+    ZigLLVM_MAX_INT_BITS = (1<<24)-1, //llvm::IntegerType::MAX_INT_BITS
+};
+
 #endif

--- a/std/math/big/int.zig
+++ b/std/math/big/int.zig
@@ -1253,12 +1253,7 @@ test "big.int bitcount/to" {
 test "big.int fits" {
     var a = try Int.init(al);
 
-    try a.set(0);
-    debug.assert(a.fits(u0));
-    debug.assert(a.fits(i0));
-
     try a.set(255);
-    debug.assert(!a.fits(u0));
     debug.assert(!a.fits(u1));
     debug.assert(!a.fits(i8));
     debug.assert(a.fits(u8));

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -15,6 +15,28 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
+        "assigning variables of type u0 and i0",
+        \\export fn entry() void {
+        \\    var i: u0 = undefined;
+        \\    var k: i0 = undefined;
+        \\}
+    ,
+        ".tmp_source.zig:2:12: error: use of undeclared identifier 'u0'",
+        ".tmp_source.zig:3:12: error: use of undeclared identifier 'i0'",
+    );
+
+    cases.add(
+        "@IntType for bit_count < 1 and bit_count > 16777216",
+        \\export fn entry() void {
+        \\    var i: @IntType(false, 0) = undefined;
+        \\    var k: @IntType(false, 16777216) = undefined;
+        \\}
+    ,
+        ".tmp_source.zig:2:28: error: integer type of 0 bits is not allowed",
+        ".tmp_source.zig:3:28: error: integer type of 16777216 bits is not allowed",
+    );
+
+    cases.add(
         "variable initialization compile error then referenced",
         \\fn Undeclared() type {
         \\    return T;


### PR DESCRIPTION
closes #1530;

- [X] implementation: `u0` and `i0`
- [X] implementation: `@IntType(false, 0)`
- [X] tests

![screen shot 2018-09-17 at 15 50 56](https://user-images.githubusercontent.com/44620/45609126-863d7900-ba91-11e8-80af-18650f0cfaeb.png)
