### PR TITLE
Return error for integer type with bitwidth larger than 16777215

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -4430,6 +4430,11 @@ void semantic_analyze(CodeGen *g) {
 }
 
 ZigType *get_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits) {
+    if ( (ZigLLVM_MIN_INT_BITS > 0 && size_in_bits < ZigLLVM_MIN_INT_BITS)
+      || size_in_bits > ZigLLVM_MAX_INT_BITS) {
+        return nullptr;
+    }
+
     TypeId type_id = {};
     type_id.id = ZigTypeIdInt;
     type_id.data.integer.is_signed = is_signed;
@@ -4442,7 +4447,9 @@ ZigType *get_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits) {
     }
 
     ZigType *new_entry = make_int_type(g, is_signed, size_in_bits);
-    g->type_table.put(type_id, new_entry);
+    if (new_entry) {
+        g->type_table.put(type_id, new_entry);
+    }
     return new_entry;
 }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -18505,7 +18505,23 @@ static IrInstruction *ir_analyze_instruction_int_type(IrAnalyze *ira, IrInstruct
     if (!ir_resolve_unsigned(ira, bit_count_value, ira->codegen->builtin_types.entry_u32, &bit_count))
         return ira->codegen->invalid_instruction;
 
-    return ir_const_type(ira, &instruction->base, get_int_type(ira->codegen, is_signed, (uint32_t)bit_count));
+    IrInstruction *return_val = ir_const_type( ira
+                                             , &instruction->base
+                                             , get_int_type(ira->codegen, is_signed, (uint32_t)bit_count)
+                                             );
+    if (return_val->value.data.x_type == nullptr) {
+        ErrorMsg *msg = ir_add_error( ira
+                                    , bit_count_value
+                                    , buf_sprintf("integer type of %llu bits is not allowed", bit_count));
+        add_error_note( ira->codegen
+                      , msg
+                      , bit_count_value->source_node
+                      , buf_sprintf( "integer types must be from %llu to %llu bits"
+                                   , (uint64_t)ZigLLVM_MIN_INT_BITS
+                                   , (uint64_t)ZigLLVM_MAX_INT_BITS));
+        return ira->codegen->invalid_instruction;
+    }
+    return return_val;
 }
 
 static IrInstruction *ir_analyze_instruction_bool_not(IrAnalyze *ira, IrInstructionBoolNot *instruction) {

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -413,4 +413,9 @@ ZIG_EXTERN_C void ZigLLVMGetNativeTarget(enum ZigLLVM_ArchType *arch_type, enum 
         enum ZigLLVM_VendorType *vendor_type, enum ZigLLVM_OSType *os_type, enum ZigLLVM_EnvironmentType *environ_type,
         enum ZigLLVM_ObjectFormatType *oformat);
 
+enum ZigLLVM_BitWidth {
+    ZigLLVM_MIN_INT_BITS = 0, // llvm::IntegerType::MIN_INT_BITS is 1, but zig currently supports u0
+    ZigLLVM_MAX_INT_BITS = (1<<24)-1, // llvm::IntegerType::MAX_INT_BITS
+};
+
 #endif

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -133,6 +133,30 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
+        "integer type with bitwidth larger than 16777215",
+        \\export fn entry() void {
+        \\    var i: i16777216 = undefined;
+        \\    var u: u16777216 = undefined;
+        \\}
+    ,
+        ".tmp_source.zig:2:12: error: use of undeclared identifier 'i16777216'",
+        ".tmp_source.zig:3:12: error: use of undeclared identifier 'u16777216'",
+    );
+
+    cases.add(
+        "@IntType for bit_count > 16777215",
+        \\export fn entry() void {
+        \\    var i: @IntType(true, 16777216) = undefined;
+        \\    var u: @IntType(false, 16777216) = undefined;
+        \\}
+    ,
+        ".tmp_source.zig:2:27: error: integer type of 16777216 bits is not allowed",
+        ".tmp_source.zig:2:27: note: integer types must be from 0 to 16777215 bits",
+        ".tmp_source.zig:3:28: error: integer type of 16777216 bits is not allowed",
+        ".tmp_source.zig:3:28: note: integer types must be from 0 to 16777215 bits",
+    );
+
+    cases.add(
         "variable initialization compile error then referenced",
         \\fn Undeclared() type {
         \\    return T;


### PR DESCRIPTION
LLVM only supports integer types up to `(1<<24)-1` bits.
This patch guards against attempting to utilize integer types with bitwidth larger than `(1<<24)-1` bits.

ref: #1530 