### PR TITLE
overhaul api for getting random integers

### DIFF
--- a/std/rand/index.zig
+++ b/std/rand/index.zig
@@ -5,11 +5,11 @@
 // ```
 // var buf: [8]u8 = undefined;
 // try std.os.getRandomBytes(buf[0..]);
-// const seed = mem.readInt(buf[0..8], u64, builtin.Endian.Little);
+// const seed = mem.readIntLE(u64, buf[0..8]);
 //
 // var r = DefaultPrng.init(seed);
 //
-// const s = r.random.scalar(u64);
+// const s = r.random.int(u64);
 // ```
 //
 // TODO(tiehuis): Benchmark these against other reference implementations.
@@ -35,60 +35,175 @@ pub const Random = struct {
         r.fillFn(r, buf);
     }
 
-    /// Return a random integer/boolean type.
-    pub fn scalar(r: *Random, comptime T: type) T {
-        var rand_bytes: [@sizeOf(T)]u8 = undefined;
+    pub fn boolean(r: *Random) bool {
+        return r.int(u1) != 0;
+    }
+
+    /// Returns a random int `i` such that `0 <= i <= @maxValue(T)`.
+    /// `i` is evenly distributed.
+    pub fn int(r: *Random, comptime T: type) T {
+        const UnsignedT = @IntType(false, T.bit_count);
+        const ByteAlignedT = @IntType(false, @divTrunc(T.bit_count + 7, 8) * 8);
+
+        var rand_bytes: [@sizeOf(ByteAlignedT)]u8 = undefined;
         r.bytes(rand_bytes[0..]);
 
-        if (T == bool) {
-            return rand_bytes[0] & 0b1 == 0;
-        } else {
-            // NOTE: Cannot @bitCast array to integer type.
-            return mem.readInt(rand_bytes, T, builtin.Endian.Little);
+        // use LE instead of native endian for better portability maybe?
+        // TODO: endian portability is pointless if the underlying prng isn't endian portable.
+        // TODO: document the endian portability of this library.
+        const byte_aligned_result = mem.readIntLE(ByteAlignedT, rand_bytes);
+        const unsigned_result = @truncate(UnsignedT, byte_aligned_result);
+        return @bitCast(T, unsigned_result);
+    }
+
+    /// Return a random unsigned integer `i < less_than`.
+    /// `less_than` must be at least `1`.
+    /// The higher `retry_limit` is, the more evenly distributed `i` is.
+    /// The lower `retry_limit` is, the more biased `i` is toward smaller values.
+    /// If `less_than` is a power of 2, `i` is always evenly distributed, and `retry_limit` is effectively ignored.
+    /// If your `less_than` is a comptime-known power of 2, consider using ::int instead.
+    /// For example, if your `less_than` is always `1024`, then instead use `int(u10)`.
+    /// This function requests `@sizeOf(T)` bytes from ::fillFn
+    /// regardless of the value of `less_than`.
+    pub fn uintLessThan(r: *Random, comptime T: type, less_than: T, retry_limit: usize) T {
+        return r.uintLessThanMaybeRetry(T, less_than, true, retry_limit);
+    }
+
+    /// Return an evenly distributed random unsigned integer `i < less_than`.
+    /// `less_than` must be at least `1`.
+    /// This function effectively calls ::uintLessThan with a `retry_limit` of infinity.
+    /// The runtime of this function is exponentially distributed with a worst case runtime of infinity.
+    /// A degenerate `fillFn` backend can cause this function to run forever.
+    pub fn uintLessThanRetryForever(r: *Random, comptime T: type, less_than: T) T {
+        return r.uintLessThanMaybeRetry(T, less_than, false, 0);
+    }
+
+    /// Return a random integer `i` such that `at_least <= i < less_than`.
+    /// See ::uintLessThan for the meaning of `retry_limit`.
+    pub fn intRangeLessThan(r: *Random, comptime T: type, at_least: T, less_than: T, retry_limit: usize) T {
+        return r.intRangeLessThanMaybeRetry(T, at_least, less_than, true, retry_limit);
+    }
+    /// Return an evenly distributed random integer `i` such that `at_least <= i < less_than`.
+    /// This function effectively calls ::intRangeLessThan with a `retry_limit` of infinity.
+    /// The runtime of this function is exponentially distributed with a worst case runtime of infinity.
+    /// A degenerate `fillFn` backend can cause this function to run forever.
+    pub fn intRangeLessThanRetryForever(r: *Random, comptime T: type, at_least: T, less_than: T) T {
+        return r.intRangeLessThanMaybeRetry(T, at_least, less_than, false, 0);
+    }
+
+    /// Return a random unsigned integer `i <= at_most`.
+    /// The higher `retry_limit` is, the more evenly distributed `i` is.
+    /// The lower `retry_limit` is, the more biased `i` is toward smaller values.
+    /// If `at_most + 1` is a power of 2, `i` is always evenly distributed, and `retry_limit` is effectively ignored.
+    /// If your `at_most + 1` is a comptime-known power of 2, consider using ::int instead.
+    /// For example, if your `at_most` is always `1023`, then instead use `int(u10)`.
+    /// This function requests `@sizeOf(T)` bytes from ::fillFn
+    /// regardless of the value of `at_most`.
+    pub fn uintAtMost(r: *Random, comptime T: type, at_most: T, retry_limit: usize) T {
+        return r.uintAtMostMaybeRetry(T, at_most, true, retry_limit);
+    }
+
+    /// Return an evenly distributed random unsigned integer `i <= at_most`.
+    /// This function effectively calls ::uintAtMost with a `retry_limit` of infinity.
+    /// The runtime of this function is exponentially distributed with a worst case runtime of infinity.
+    /// A degenerate `fillFn` backend can cause this function to run forever.
+    pub fn uintAtMostRetryForever(r: *Random, comptime T: type, less_than: T) T {
+        return r.uintAtMostMaybeRetry(T, less_than, false, 0);
+    }
+
+    /// Return a random integer `i` such that `at_least <= i < at_most`.
+    /// See ::uintAtMost for the meaning of `retry_limit`.
+    pub fn intRangeAtMost(r: *Random, comptime T: type, at_least: T, at_most: T, retry_limit: usize) T {
+        return r.intRangeAtMostMaybeRetry(T, at_least, at_most, true, retry_limit);
+    }
+    /// Return an evenly distributed random integer `i` such that `at_least <= i <= at_most`.
+    /// This function effectively calls ::intRangeAtMost with a `retry_limit` of infinity.
+    /// The runtime of this function is exponentially distributed with a worst case runtime of infinity.
+    /// A degenerate `fillFn` backend can cause this function to run forever.
+    pub fn intRangeAtMostRetryForever(r: *Random, comptime T: type, at_least: T, at_most: T) T {
+        return r.intRangeAtMostMaybeRetry(T, at_least, at_most, false, 0);
+    }
+
+    fn uintLessThanMaybeRetry(r: *Random, comptime T: type, less_than: T, comptime use_retry_limit: bool, retry_limit: usize) T {
+        assert(T.is_signed == false);
+        assert(0 < less_than);
+
+        const last_group_size_minus_one: T = @maxValue(T) % less_than;
+        if (last_group_size_minus_one == less_than - 1) {
+            // less_than is a power of two.
+            assert(math.floorPowerOfTwo(T, less_than) == less_than);
+            // There is no retry zone. The optimal retry_zone_start would be @maxValue(T) + 1.
+            return r.int(T) % less_than;
         }
+        const retry_zone_start = @maxValue(T) - last_group_size_minus_one;
+
+        var i: usize = 0;
+        while (true) {
+            const rand_val = r.int(T);
+            if (rand_val < retry_zone_start) {
+                return rand_val % less_than;
+            }
+            if (use_retry_limit) {
+                if (i >= retry_limit) {
+                    // good enough
+                    return rand_val % less_than;
+                }
+                i += 1;
+            }
+        }
+    }
+
+    fn uintAtMostMaybeRetry(r: *Random, comptime T: type, at_most: T, comptime use_retry_limit: bool, retry_limit: usize) T {
+        assert(T.is_signed == false);
+        if (at_most == @maxValue(T)) {
+            // have the full range
+            return r.int(T);
+        }
+        return r.uintLessThanMaybeRetry(T, at_most + 1, use_retry_limit, retry_limit);
+    }
+
+    fn intRangeLessThanMaybeRetry(r: *Random, comptime T: type, at_least: T, less_than: T, comptime use_retry_limit: bool, retry_limit: usize) T {
+        assert(at_least < less_than);
+        if (T.is_signed) {
+            // Two's complement makes this math pretty easy.
+            const UnsignedT = @IntType(false, T.bit_count);
+            const lo = @bitCast(UnsignedT, at_least);
+            const hi = @bitCast(UnsignedT, less_than);
+            const result = lo +% r.uintLessThanMaybeRetry(UnsignedT, hi -% lo, use_retry_limit, retry_limit);
+            return @bitCast(T, result);
+        } else {
+            // The signed implemented would work fine, but we can use stricter arithmetic operators here.
+            return at_least + r.uintLessThanMaybeRetry(T, less_than - at_least, use_retry_limit, retry_limit);
+        }
+    }
+
+    fn intRangeAtMostMaybeRetry(r: *Random, comptime T: type, at_least: T, at_most: T, comptime use_retry_limit: bool, retry_limit: usize) T {
+        assert(at_least <= at_most);
+        if (T.is_signed) {
+            // Two's complement makes this math pretty easy.
+            const UnsignedT = @IntType(false, T.bit_count);
+            const lo = @bitCast(UnsignedT, at_least);
+            const hi = @bitCast(UnsignedT, at_most);
+            const result = lo +% r.uintAtMostMaybeRetry(UnsignedT, hi -% lo, use_retry_limit, retry_limit);
+            return @bitCast(T, result);
+        } else {
+            // The signed implemented would work fine, but we can use stricter arithmetic operators here.
+            return at_least + r.uintAtMostMaybeRetry(T, at_most - at_least, use_retry_limit, retry_limit);
+        }
+    }
+
+    /// Return a random integer/boolean type.
+    /// TODO: deprecated. use ::boolean or ::int instead.
+    pub fn scalar(r: *Random, comptime T: type) T {
+        if (T == bool) return r.boolean();
+        return r.int(T);
     }
 
     /// Return a random integer with even distribution between `start`
     /// inclusive and `end` exclusive.  `start` must be less than `end`.
+    /// TODO: deprecated. use ::intRangeLessThan or ::intRangeLessThanRetryForever
     pub fn range(r: *Random, comptime T: type, start: T, end: T) T {
-        assert(start < end);
-        if (T.is_signed) {
-            const uint = @IntType(false, T.bit_count);
-            if (start >= 0 and end >= 0) {
-                return @intCast(T, r.range(uint, @intCast(uint, start), @intCast(uint, end)));
-            } else if (start < 0 and end < 0) {
-                // Can't overflow because the range is over signed ints
-                return math.negateCast(r.range(uint, math.absCast(end), math.absCast(start)) + 1) catch unreachable;
-            } else if (start < 0 and end >= 0) {
-                const end_uint = @intCast(uint, end);
-                const total_range = math.absCast(start) + end_uint;
-                const value = r.range(uint, 0, total_range);
-                const result = if (value < end_uint) x: {
-                    break :x @intCast(T, value);
-                } else if (value == end_uint) x: {
-                    break :x start;
-                } else x: {
-                    // Can't overflow because the range is over signed ints
-                    break :x math.negateCast(value - end_uint) catch unreachable;
-                };
-                return result;
-            } else {
-                unreachable;
-            }
-        } else {
-            const total_range = end - start;
-            const leftover = @maxValue(T) % total_range;
-            const upper_bound = @maxValue(T) - leftover;
-            var rand_val_array: [@sizeOf(T)]u8 = undefined;
-
-            while (true) {
-                r.bytes(rand_val_array[0..]);
-                const rand_val = mem.readInt(rand_val_array, T, builtin.Endian.Little);
-                if (rand_val < upper_bound) {
-                    return start + (rand_val % total_range);
-                }
-            }
-        }
+        return r.intRangeLessThanRetryForever(T, start, end);
     }
 
     /// Return a floating point value evenly distributed in the range [0, 1).
@@ -97,12 +212,12 @@ pub const Random = struct {
         // Note: The lowest mantissa bit is always set to 0 so we only use half the available range.
         switch (T) {
             f32 => {
-                const s = r.scalar(u32);
+                const s = r.int(u32);
                 const repr = (0x7f << 23) | (s >> 9);
                 return @bitCast(f32, repr) - 1.0;
             },
             f64 => {
-                const s = r.scalar(u64);
+                const s = r.int(u64);
                 const repr = (0x3ff << 52) | (s >> 12);
                 return @bitCast(f64, repr) - 1.0;
             },
@@ -147,6 +262,152 @@ pub const Random = struct {
         }
     }
 };
+
+/// This prng will always produce the same byte every time.
+/// Useful for testing. https://xkcd.com/221/
+pub const DegenerateConstantPrng = struct {
+    const Self = @This();
+    random: Random,
+    value: u8,
+
+    pub fn init(value: u8) Self {
+        return Self{
+            .random = Random{ .fillFn = fill },
+            .value = value,
+        };
+    }
+
+    fn fill(r: *Random, buf: []u8) void {
+        const self = @fieldParentPtr(Self, "random", r);
+        mem.set(u8, buf, self.value);
+    }
+};
+
+/// This prng will produce sequentially increasing bytes starting with 0.
+/// Useful for testing.
+pub const DegenerateSequentialPrng = struct {
+    const Self = @This();
+    random: Random,
+    next_value: u8,
+
+    pub fn init() Self {
+        return Self{
+            .random = Random{ .fillFn = fill },
+            .next_value = 0,
+        };
+    }
+
+    fn fill(r: *Random, buf: []u8) void {
+        const self = @fieldParentPtr(Self, "random", r);
+        for (buf) |*b| {
+            b.* = self.next_value;
+            self.next_value +%= 1;
+        }
+    }
+};
+
+test "Random.int" {
+    testRandomInt();
+    comptime testRandomInt();
+}
+fn testRandomInt() void {
+    var r = DegenerateConstantPrng.init(0xff);
+    assert(r.random.int(u8) == 0xff);
+    assert(r.random.int(u32) == 0xffffffff);
+    assert(r.random.int(i32) == -1);
+    assert(r.random.int(i8) == -1);
+    assert(r.random.int(u0) == 0);
+    assert(r.random.int(u1) == 1);
+    assert(r.random.int(u2) == 3);
+    assert(r.random.int(u33) == 0x1ffffffff);
+    assert(r.random.int(i1) == -1);
+    assert(r.random.int(i2) == -1);
+    assert(r.random.int(i33) == -1);
+}
+
+test "Random.boolean" {
+    testRandomBoolean();
+    comptime testRandomBoolean();
+}
+fn testRandomBoolean() void {
+    var f = DegenerateConstantPrng.init(0);
+    assert(f.random.boolean() == false);
+    var t = DegenerateConstantPrng.init(1);
+    assert(t.random.boolean() == true);
+}
+
+test "Random.intLessThan" {
+    // the retries need a lot of execution
+    @setEvalBranchQuota(10000);
+    testRandomIntLessThan();
+    comptime testRandomIntLessThan();
+}
+fn testRandomIntLessThan() void {
+    var ff = DegenerateConstantPrng.init(0xff);
+    assert(ff.random.uintLessThan(u8, 4, 0) == 3);
+    assert(ff.random.uintLessThan(u8, 3, 0) == 0);
+
+    assert(ff.random.uintLessThanRetryForever(u8, 4) == 3);
+    // This would run forever.
+    //assert(ff.random.uintLessThanRetryForever(u8, 3) == 0);
+
+    // these all have to have a range that is a power of 2.
+    assert(ff.random.uintLessThanRetryForever(u8, 0x80) == 0x7f);
+
+    assert(ff.random.intRangeLessThanRetryForever(u8, 0, 0x80) == 0x7f);
+    assert(ff.random.intRangeLessThanRetryForever(u8, 0x7f, 0xff) == 0xfe);
+
+    assert(ff.random.intRangeLessThanRetryForever(i8, 0, 0x40) == 0x3f);
+    assert(ff.random.intRangeLessThanRetryForever(i8, -0x40, 0x40) == 0x3f);
+    assert(ff.random.intRangeLessThanRetryForever(i8, -0x80, 0) == -1);
+
+    assert(ff.random.intRangeLessThanRetryForever(i64, -0x8000000000000000, 0) == -1);
+    assert(ff.random.intRangeLessThanRetryForever(i3, -4, 0) == -1);
+    assert(ff.random.intRangeLessThanRetryForever(i3, -2, 2) == 1);
+
+    // test retrying and eventually getting a good value
+    var inc = DegenerateSequentialPrng.init();
+    // start just out of bounds
+    inc.next_value = 0x81;
+    assert(inc.random.uintLessThan(u8, 0x81, 0x7f) == 0);
+}
+
+test "Random.intAtMost" {
+    // the retries need a lot of execution
+    @setEvalBranchQuota(10000);
+    testRandomIntAtMost();
+    comptime testRandomIntAtMost();
+}
+fn testRandomIntAtMost() void {
+    var ff = DegenerateConstantPrng.init(0xff);
+    assert(ff.random.uintAtMost(u8, 3, 0) == 3);
+    assert(ff.random.uintAtMost(u8, 2, 0) == 0);
+
+    assert(ff.random.uintAtMostRetryForever(u8, 3) == 3);
+    // This would run forever.
+    //assert(ff.random.uintAtMostRetryForever(u8, 2) == 0);
+
+    // these all have to have a range that is a mersenne number.
+    assert(ff.random.uintAtMostRetryForever(u8, 0x7f) == 0x7f);
+
+    assert(ff.random.intRangeAtMostRetryForever(u8, 0, 0x7f) == 0x7f);
+    assert(ff.random.intRangeAtMostRetryForever(u8, 0x80, 0xff) == 0xff);
+
+    assert(ff.random.intRangeAtMostRetryForever(i8, 0, 0x3f) == 0x3f);
+    assert(ff.random.intRangeAtMostRetryForever(i8, -0x40, 0x3f) == 0x3f);
+    assert(ff.random.intRangeAtMostRetryForever(i8, -0x80, -1) == -1);
+
+    assert(ff.random.intRangeAtMostRetryForever(i64, -0x8000000000000000, -1) == -1);
+    assert(ff.random.intRangeAtMostRetryForever(i3, -4, -1) == -1);
+    assert(ff.random.intRangeAtMostRetryForever(i3, -2, 1) == 1);
+    assert(ff.random.uintAtMostRetryForever(u0, 0) == 0);
+
+    // test retrying and eventually getting a good value
+    var inc = DegenerateSequentialPrng.init();
+    // start just out of bounds
+    inc.next_value = 0x81;
+    assert(inc.random.uintAtMost(u8, 0x80, 0x7f) == 0);
+}
 
 // Generator to extend 64-bit seed values into longer sequences.
 //
@@ -664,16 +925,17 @@ test "Random range" {
     testRange(&prng.random, -4, 3);
     testRange(&prng.random, -4, -1);
     testRange(&prng.random, 10, 14);
+    testRange(&prng.random, -0x80, 0x7f);
     // TODO: test that prng.random.range(1, 1) causes an assertion error
 }
 
-fn testRange(r: *Random, start: i32, end: i32) void {
-    const count = @intCast(usize, end - start);
-    var values_buffer = []bool{false} ** 20;
+fn testRange(r: *Random, start: i8, end: i8) void {
+    const count = @intCast(usize, i32(end) - i32(start));
+    var values_buffer = []bool{false} ** 0x100;
     const values = values_buffer[0..count];
     var i: usize = 0;
     while (i < count) {
-        const value = r.range(i32, start, end);
+        const value: i32 = r.range(i8, start, end);
         const index = @intCast(usize, value - start);
         if (!values[index]) {
             i += 1;


### PR DESCRIPTION
What I like about this PR

* The existing `Random.scalar()` method seemed silly, because it could either give an int or a boolean. So I made `Random.int()` and `Random.boolean()` instead. Seems more reasonable.
* `Random.range()` has a worst case runtime of infinity for the sake of perfectly even distribution. This doesn't seem in line with the Zen of Zig, so I renamed that to include `*RetryForever` in the name to be clear that there's a loop in it. The default-named range functions like `Random.intRangeLessThan()` take a parameter which is the retry limit. For many applications (e.g. real time video games), retrying twice or so is good enough, and now there's an api for that.
* Added support for weird integer types like `u0` and `u33`.
* Drastically simplified the signed integer range function with the power of two's complement signed arithmetic. Pretty much just enable wrap-around arithmetic and bitcast everything.
* Added `*AtMost*` variants in addition to `*LessThan*` functions with a runtime upper bound. There are usecases for each:
  * LessThan: Selecting a random element from an array.
  * AtMost: When you want to be able to get the maximum integer value out of the range. Maybe you've partitioned the 32-bit number space into n groups, and you want to pick a random number from the top partition. The upper bound needs to be `@maxValue(u32)`, so a LessThan function is not suitable. The AtMost variants have the unique ability to cover the entire number space of an integer type if the runtime-known bounds want it. e.g. `random.intRangeAtMost(u64, 0, @maxValue(u64), 0)`.
* Added `DegenerateConstantPrng` and `DegenerateSequentialPrng` to illustrate the unsafe nature of the `RetryForever` variants and to test actual values from the Random utility functions in a simple deterministic way.

What's still a little questionable about this PR:

* Lots of copypasted documentation. I didn't thoroughly double check it all before committing.
* The AtMost tests are mostly copypasted LessThan tests. Perhaps those could be unified?
* The api names are awkward. When the name doesn't mention that one of the parameters is a retry limit, it looks like you're giving a lower and upper bound on the range. `random.uintLessThan(u32, 100, 200)`
* The `AtMost` functions have two different runtime early returns for special upper bound values. Seems like we should be able to do that in just one check.
* Haven't updated all the uses of `scalar()` and `range()` throughout the codebase yet. For now, I marked the functions as `TODO: deprecated`.