### PR TITLE
Ignore class-memaccess error for gcc 8 and above

### DIFF
--- a/src/translate_c.cpp
+++ b/src/translate_c.cpp
@@ -15,9 +15,18 @@
 #include "parser.hpp"
 
 
+#if __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+
 #include <clang/Frontend/ASTUnit.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/AST/Expr.h>
+
+#if __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
 
 #include <string.h>
 

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -15,6 +15,11 @@
 
 #include "zig_llvm.h"
 
+#if __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/IR/DIBuilder.h>
@@ -41,6 +46,10 @@
 #include <llvm/Transforms/Utils.h>
 
 #include <lld/Common/Driver.h>
+
+#if __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
 
 #include <new>
 


### PR DESCRIPTION
On Arch Linux the current default compiler is gcc 8.2.1 and this change
is needed to ignore the following errors:

  In file included from /home/wink/local/include/llvm/ADT/STLExtras.h:21,
                   from /home/wink/local/include/llvm/ADT/StringRef.h:13,
                   from /home/wink/local/include/llvm/ADT/StringMap.h:17,
                   from /home/wink/local/include/llvm/Support/Host.h:17,
                   from /home/wink/local/include/llvm/ADT/Hashing.h:49,
                   from /home/wink/local/include/llvm/ADT/ArrayRef.h:13,
                   from /home/wink/local/include/llvm/ADT/APFloat.h:21,
                   from /home/wink/local/include/clang/AST/APValue.h:18,
                   from /home/wink/local/include/clang/AST/Decl.h:17,
                   from /home/wink/local/include/clang/AST/ASTTypeTraits.h:20,
                   from /home/wink/local/include/clang/AST/ASTContext.h:18,
                   from /home/wink/local/include/clang/Frontend/ASTUnit.h:18,
                   from /home/wink/prgs/ziglang/zig/src/translate_c.cpp:18:
  /home/wink/local/include/llvm/ADT/SmallVector.h: In instantiation of ‘void llvm::SmallVectorTemplateBase<T, true>::push_back(const T&) [with T = std::pair<void*, long unsigned int>]’:
  /home/wink/local/include/llvm/Support/Allocator.h:249:33:   required from ‘void* llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold>::Allocate(size_t, size_t) [with AllocatorT = llvm::MallocAllocator; long unsigned int SlabSize = 4096; long unsigned int SizeThreshold = 4096; size_t = long unsigned int]’
  /home/wink/local/include/clang/AST/ASTContext.h:659:42:   required from here
  /home/wink/local/include/llvm/ADT/SmallVector.h:313:11: error: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of type ‘struct std::pair<void*, long unsigned int>’ with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Werror=class-memaccess]
       memcpy(this->end(), &Elt, sizeof(T));
       ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  In file included from /usr/include/c++/8.2.1/utility:70,
                   from /home/wink/local/include/llvm/Support/type_traits.h:19,
                   from /home/wink/local/include/llvm/Support/Casting.h:19,
                   from /home/wink/local/include/clang/Basic/LLVM.h:22,
                   from /home/wink/local/include/clang/AST/APValue.h:17,
                   from /home/wink/local/include/clang/AST/Decl.h:17,
                   from /home/wink/local/include/clang/AST/ASTTypeTraits.h:20,
                   from /home/wink/local/include/clang/AST/ASTContext.h:18,
                   from /home/wink/local/include/clang/Frontend/ASTUnit.h:18,
                   from /home/wink/prgs/ziglang/zig/src/translate_c.cpp:18:
  /usr/include/c++/8.2.1/bits/stl_pair.h:198:12: note: ‘struct std::pair<void*, long unsigned int>’ declared here
       struct pair
              ^~~~