### PR TITLE
Tweak SYMBOL_CHAR define in tokenizer.cpp

### DIFF
--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -92,10 +92,9 @@
     case 'c'
 
 #define SYMBOL_CHAR \
-    ALPHA_EXCEPT_C: \
+    ALPHA: \
     case DIGIT: \
-    case '_': \
-    case 'c'
+    case '_'
 
 #define SYMBOL_START \
     ALPHA: \


### PR DESCRIPTION
Make it a little clearer what a SYMBOL_CHAR is, use ALPHA instead of
ALPHA_EXCEPT_C and case 'c', which is ALPHA's definition.