### PR TITLE
Add SegmentedList.shrink

### DIFF
--- a/std/segmented_list.zig
+++ b/std/segmented_list.zig
@@ -201,6 +201,11 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
             self.dynamic_segments = self.allocator.shrink([*]T, self.dynamic_segments, new_cap_shelf_count);
         }
 
+        pub fn shrink(self: *Self, new_len: usize) void {
+            assert(new_len <= self.len);
+            self.len = new_len;
+        }
+
         pub fn uncheckedAt(self: var, index: usize) AtType(@typeOf(self)) {
             if (index < prealloc_item_count) {
                 return &self.prealloc_segment[index];


### PR DESCRIPTION
I was exploring std.zig.Tokenizer and wanted to compare performance of
arrays, SegmentedList and ArrayList and needed SegmentedList.shrink
to make the comparison "fair".