### PR TITLE
fixed native target detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,9 @@ else()
         set(ZIG_LLD_COMPILE_FLAGS "-std=c++11 -D_CRT_SECURE_NO_WARNINGS /w")
     else()
       set(ZIG_LLD_COMPILE_FLAGS "-std=c++11 -fno-exceptions -fno-rtti -Wno-comment")
+      if(MINGW)
+        set(ZIG_LLD_COMPILE_FLAGS "${ZIG_LLD_COMPILE_FLAGS} -D__STDC_FORMAT_MACROS -D__USE_MINGW_ANSI_STDIO -Wno-pedantic-ms-format")
+      endif()
     endif()
     set_target_properties(embedded_lld_lib PROPERTIES
         COMPILE_FLAGS ${ZIG_LLD_COMPILE_FLAGS}

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -712,7 +712,7 @@ void ZigLLVMGetNativeTarget(ZigLLVM_ArchType *arch_type, ZigLLVM_SubArchType *su
         ZigLLVM_ObjectFormatType *oformat)
 {
     char *native_triple = LLVMGetDefaultTargetTriple();
-    Triple triple(native_triple);
+    Triple triple(Triple::normalize(native_triple));
 
     *arch_type = (ZigLLVM_ArchType)triple.getArch();
     *sub_arch_type = (ZigLLVM_SubArchType)triple.getSubArch();


### PR DESCRIPTION
on mingw-w64 llvm was unable to parse to parse the target triple obtained from `LLVMGetDefaultTargetTriple` because it wasn't normalized, leading to zig choosing  the incorrect target when compiling natively.