### PR TITLE
Fixed crash when breaking to labeled block outside inline for loop

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -14318,14 +14318,20 @@ static ZigType *ir_analyze_instruction_phi(IrAnalyze *ira, IrInstructionPhi *phi
     for (size_t i = 0; i < new_incoming_values.length; i += 1) {
         IrInstruction *new_value = new_incoming_values.at(i);
         IrBasicBlock *predecessor = new_incoming_blocks.at(i);
-        IrInstruction *branch_instruction = predecessor->instruction_list.pop();
+        IrInstruction *branch_instruction = nullptr;
+
+        if (predecessor->instruction_list.length != 0)
+            branch_instruction = predecessor->instruction_list.pop();
+
         ir_set_cursor_at_end(&ira->new_irb, predecessor);
         IrInstruction *casted_value = ir_implicit_cast(ira, new_value, resolved_type);
         if (casted_value == ira->codegen->invalid_instruction) {
             return ira->codegen->builtin_types.entry_invalid;
         }
+
         new_incoming_values.items[i] = casted_value;
-        predecessor->instruction_list.append(branch_instruction);
+        if (branch_instruction != nullptr)
+            predecessor->instruction_list.append(branch_instruction);
 
         if (all_stack_ptrs && (casted_value->value.special != ConstValSpecialRuntime ||
             casted_value->value.data.rh_ptr != RuntimeHintPtrStack))

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -16,6 +16,7 @@ comptime {
     _ = @import("cases/bugs/1421.zig");
     _ = @import("cases/bugs/1442.zig");
     _ = @import("cases/bugs/1486.zig");
+    _ = @import("cases/bugs/1609.zig");
     _ = @import("cases/bugs/394.zig");
     _ = @import("cases/bugs/655.zig");
     _ = @import("cases/bugs/656.zig");

--- a/test/cases/bugs/1609.zig
+++ b/test/cases/bugs/1609.zig
@@ -1,0 +1,12 @@
+test "" {
+    failed: {
+        inline for ([]void{{},{}}) |_| {
+            var a = false;
+
+            if (a)
+                break :failed;
+            if (a)
+                break :failed;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1609

I'm not quite sure why `predecessor->instruction_list` ends of being empty with this code, but coding in an check for it seems to fix this issue without breaking any tests.

Idk if this is the right fix, so feel free to reject this, if this is not the way to go about it.