### PR TITLE
fix build-exe for --target-arch wasm32 (#1570)

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -386,7 +386,7 @@ static void construct_linker_job_elf(LinkJob *lj) {
 static void construct_linker_job_wasm(LinkJob *lj) {
     CodeGen *g = lj->codegen;
 
-    lj->args.append("--relocatable");  // So lld doesn't look for _start.
+    lj->args.append("--no-entry");  // So lld doesn't look for _start.
     lj->args.append("-o");
     lj->args.append(buf_ptr(&g->output_file_path));
 


### PR DESCRIPTION
Pass --no-entry instead of --relocatable to lld. Both stop a reference
to the _start() entry point from being emitted but --relocatable also
prevents public symbols from being exported when creating an executable.