### PR TITLE
Improve error message when using 'try'

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -10937,23 +10937,10 @@ static IrInstruction *ir_analyze_cast(IrAnalyze *ira, IrInstruction *source_inst
         }
     }
 
-    ErrorMsg *parent_msg;
-    if (source_instr->id == IrInstructionIdUnwrapErrCode) {
-        ZigFn *cur_fn = ira->codegen->fn_defs.at(ira->codegen->fn_defs_index);
-        parent_msg = ir_add_error_node(ira, source_node,
-            buf_sprintf("trying to unwrap error of type '%s' in a function that expects a non-error return type '%s'",
-                buf_ptr(&actual_type->name),
-                buf_ptr(&wanted_type->name)));
-        add_error_note(ira->codegen, parent_msg, cur_fn->proto_node->data.fn_proto.return_type,
-            buf_sprintf("function return type was defined here as a non-error type; did you mean '!%s'?",
-                buf_ptr(&wanted_type->name)));
-    } else {
-        parent_msg = ir_add_error_node(ira, source_node,
-            buf_sprintf("expected type '%s', found '%s'",
-                buf_ptr(&wanted_type->name),
-                buf_ptr(&actual_type->name)));
-    }
-
+    ErrorMsg *parent_msg = ir_add_error_node(ira, source_instr->source_node,
+        buf_sprintf("expected type '%s', found '%s'",
+            buf_ptr(&wanted_type->name),
+            buf_ptr(&actual_type->name)));
     report_recursive_error(ira, source_instr->source_node, &const_cast_result, parent_msg);
     return ira->codegen->invalid_instruction;
 }

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -10937,10 +10937,23 @@ static IrInstruction *ir_analyze_cast(IrAnalyze *ira, IrInstruction *source_inst
         }
     }
 
-    ErrorMsg *parent_msg = ir_add_error_node(ira, source_instr->source_node,
-        buf_sprintf("expected type '%s', found '%s'",
-            buf_ptr(&wanted_type->name),
-            buf_ptr(&actual_type->name)));
+    ErrorMsg *parent_msg;
+    if (source_instr->id == IrInstructionIdUnwrapErrCode) {
+        ZigFn *cur_fn = ira->codegen->fn_defs.at(ira->codegen->fn_defs_index);
+        parent_msg = ir_add_error_node(ira, source_node,
+            buf_sprintf("trying to unwrap error of type '%s' in a function that expects a non-error return type '%s'",
+                buf_ptr(&actual_type->name),
+                buf_ptr(&wanted_type->name)));
+        add_error_note(ira->codegen, parent_msg, cur_fn->proto_node->data.fn_proto.return_type,
+            buf_sprintf("function return type was defined here as a non-error type; did you mean '!%s'?",
+                buf_ptr(&wanted_type->name)));
+    } else {
+        parent_msg = ir_add_error_node(ira, source_node,
+            buf_sprintf("expected type '%s', found '%s'",
+                buf_ptr(&wanted_type->name),
+                buf_ptr(&actual_type->name)));
+    }
+
     report_recursive_error(ira, source_instr->source_node, &const_cast_result, parent_msg);
     return ira->codegen->invalid_instruction;
 }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3169,7 +3169,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn something() error!void { }
     ,
-        ".tmp_source.zig:2:5: error: expected type 'void', found 'error'",
+        ".tmp_source.zig:2:5: error: trying to unwrap error of type 'error' in a function that expects a non-error return type 'void'",
+        ".tmp_source.zig:1:15: note: function return type was defined here as a non-error type; did you mean '!void'?"
     );
 
     cases.add(

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3169,8 +3169,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn something() error!void { }
     ,
-        ".tmp_source.zig:2:5: error: trying to unwrap error of type 'error' in a function that expects a non-error return type 'void'",
-        ".tmp_source.zig:1:15: note: function return type was defined here as a non-error type; did you mean '!void'?"
+        ".tmp_source.zig:2:5: error: try when the return type cannot handle an error",
+        ".tmp_source.zig:1:15: note: function return type was defined here; did you mean '!void'?"
     );
 
     cases.add(


### PR DESCRIPTION
As described here: https://github.com/ziglang/zig/issues/1587#issuecomment-424264801 when using 'try' in a function with that expects a non-error return type you get a confusing error message.