### PR TITLE
Fix "std" not found error in meta/trait

### DIFF
--- a/std/meta/index.zig
+++ b/std/meta/index.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../index.zig");
 const builtin = @import("builtin");
 const debug = std.debug;
 const mem = std.mem;

--- a/std/meta/trait.zig
+++ b/std/meta/trait.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../index.zig");
 const builtin = @import("builtin");
 const mem = std.mem;
 const debug = std.debug;


### PR DESCRIPTION
Note to self, when including things in std, you can't reference std as "std".