### PR TITLE
ci/azure: set wget to non-verbose mode to make logs easier to read;

### DIFF
--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -22,7 +22,7 @@ mkdir $TMPDIR
 
 cd $HOME
 HAVE_CACHE="true"
-wget "https://ziglang.org/builds/$CACHE_BASENAME.tar.xz" || HAVE_CACHE="false"
+wget -nv "https://ziglang.org/builds/$CACHE_BASENAME.tar.xz" || HAVE_CACHE="false"
 if [ "${HAVE_CACHE}" = "true" ]; then
   tar xf "$CACHE_BASENAME.tar.xz"
 else

--- a/ci/azure/windows_install
+++ b/ci/azure/windows_install
@@ -5,5 +5,5 @@ set -e
 
 pacman -S --needed --noconfirm wget zip python3-pip
 pip install s3cmd
-wget "https://ziglang.org/deps/llvm%2bclang-7.0.0-win64-msvc-release.tar.xz"
+wget -nv "https://ziglang.org/deps/llvm%2bclang-7.0.0-win64-msvc-release.tar.xz"
 tar xf llvm+clang-7.0.0-win64-msvc-release.tar.xz


### PR DESCRIPTION
Over 5000 lines of wget download process updates are stored to the logs:
```
2018-11-05T15:12:23.7688556Z 295750K .......... .......... .......... .......... .......... 99%  113M 0s
2018-11-05T15:12:23.7701251Z 295800K .......... .......... .......... .......... .......... 99% 44.7M 0s
2018-11-05T15:12:23.7705424Z 295850K .......... .......... .......... .......... .......... 99% 70.7M 0s
2018-11-05T15:12:23.7712171Z 295900K .......... .......... .......... .......... .......... 99% 78.8M 0s
2018-11-05T15:12:23.7717977Z 295950K .......... .......... .......... .......... .......... 99% 85.7M 0s
2018-11-05T15:12:23.7724039Z 296000K .......... .......... .......... .......... .......... 99% 83.9M 0s
2018-11-05T15:12:23.7726300Z 296050K .......... .......... .                               100% 96.4M=6.3s
```
