### PR TITLE
Added NullOutStream and CountingOutStream

### DIFF
--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -646,7 +646,7 @@ fn cmdFmt(allocator: *Allocator, args: []const []const u8) !void {
             os.exit(1);
         }
         if (flags.present("check")) {
-            const anything_changed = try std.zig.render(allocator, io.noop_out_stream, &tree);
+            const anything_changed = try std.zig.render(allocator, io.null_out_stream, &tree);
             const code = if (anything_changed) u8(1) else u8(0);
             os.exit(code);
         }
@@ -792,7 +792,7 @@ async fn fmtPath(fmt: *Fmt, file_path_ref: []const u8, check_mode: bool) FmtErro
     }
 
     if (check_mode) {
-        const anything_changed = try std.zig.render(fmt.loop.allocator, io.noop_out_stream, &tree);
+        const anything_changed = try std.zig.render(fmt.loop.allocator, io.null_out_stream, &tree);
         if (anything_changed) {
             try stderr.print("{}\n", file_path);
             fmt.any_error = true;

--- a/std/io.zig
+++ b/std/io.zig
@@ -249,13 +249,6 @@ pub fn OutStream(comptime WriteError: type) type {
     };
 }
 
-pub const noop_out_stream = &noop_out_stream_state;
-const NoopOutStreamError = error{};
-var noop_out_stream_state = OutStream(NoopOutStreamError){
-    .writeFn = noop_out_stream_write,
-};
-fn noop_out_stream_write(self: *OutStream(NoopOutStreamError), bytes: []const u8) error{}!void {}
-
 pub fn writeFile(path: []const u8, data: []const u8) !void {
     var file = try File.openWrite(path);
     defer file.close();
@@ -503,6 +496,9 @@ test "io.SliceOutStream" {
     try stream.print("{}{}!", "Hello", "World");
     debug.assert(mem.eql(u8, "HelloWorld!", slice_stream.getWritten()));
 }
+
+var null_out_stream_state = NullOutStream.init();
+pub const null_out_stream = &null_out_stream_state.stream;
 
 /// An OutStream that doesn't write to anything.
 pub const NullOutStream = struct {


### PR DESCRIPTION
Added `NullOutStream` and `CountingOutStream` to `std.io` which can be used together to easily align formatted text.

```rust
const std = @import("std");

const io = std.io;
const os = std.os;

test "" {
    const tabel = [4][4]usize{
        []usize{1,2,3,4},
        []usize{10,20,30,40},
        []usize{100,200,300,400},
        []usize{1000,2000,3000,4000},
    };


    var null_stream = io.NullOutStream.init();
    var col_widths = []usize{0} ** 4;
    for (tabel) |rom| {
        for (rom) |num, i| {
            var counting_stream = io.CountingOutStream(io.NullOutStream.Error).init(&null_stream.stream);
            try counting_stream.stream.print("{}", num);
            if (col_widths[i] < counting_stream.bytes_written)
                col_widths[i] = counting_stream.bytes_written;
        }
    }

    const stderr_file = try std.io.getStdErr();
    var stderr_out_stream = stderr_file.outStream();
    const stream = &stderr_out_stream.stream;

    try stream.print("\n");
    for (tabel) |rom| {
        for (rom) |num, i| {
            try stream.print("|");
            var counting_stream = io.CountingOutStream(os.File.OutStream.Error).init(&stderr_out_stream.stream);
            try counting_stream.stream.print("{}", num);
            try stream.writeByteNTimes(' ', col_widths[i] - counting_stream.bytes_written);
        }
        try stream.print("|\n");
    }
}
```

```
Test 1/1 ...
|1   |2   |3   |4   |
|10  |20  |30  |40  |
|100 |200 |300 |400 |
|1000|2000|3000|4000|
OK
All tests passed.
```