### PR TITLE
Fixed #1663 and removed IrInstructionArrayLen

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2071,7 +2071,6 @@ enum IrInstructionId {
     IrInstructionIdCInclude,
     IrInstructionIdCDefine,
     IrInstructionIdCUndef,
-    IrInstructionIdArrayLen,
     IrInstructionIdRef,
     IrInstructionIdCompileErr,
     IrInstructionIdCompileLog,
@@ -2582,12 +2581,6 @@ struct IrInstructionImport {
     IrInstruction base;
 
     IrInstruction *name;
-};
-
-struct IrInstructionArrayLen {
-    IrInstruction base;
-
-    IrInstruction *array_value;
 };
 
 struct IrInstructionRef {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5102,7 +5102,6 @@ static LLVMValueRef ir_render_instruction(CodeGen *g, IrExecutable *executable, 
         case IrInstructionIdContainerInitFields:
         case IrInstructionIdCompileErr:
         case IrInstructionIdCompileLog:
-        case IrInstructionIdArrayLen:
         case IrInstructionIdImport:
         case IrInstructionIdCImport:
         case IrInstructionIdCInclude:

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -553,11 +553,6 @@ static void ir_print_import(IrPrint *irp, IrInstructionImport *instruction) {
     fprintf(irp->f, ")");
 }
 
-static void ir_print_array_len(IrPrint *irp, IrInstructionArrayLen *instruction) {
-    ir_print_other_instruction(irp, instruction->array_value);
-    fprintf(irp->f, ".len");
-}
-
 static void ir_print_ref(IrPrint *irp, IrInstructionRef *instruction) {
     const char *const_str = instruction->is_const ? "const " : "";
     const char *volatile_str = instruction->is_volatile ? "volatile " : "";
@@ -1461,9 +1456,6 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdImport:
             ir_print_import(irp, (IrInstructionImport *)instruction);
-            break;
-        case IrInstructionIdArrayLen:
-            ir_print_array_len(irp, (IrInstructionArrayLen *)instruction);
             break;
         case IrInstructionIdRef:
             ir_print_ref(irp, (IrInstructionRef *)instruction);

--- a/test/cases/for.zig
+++ b/test/cases/for.zig
@@ -35,7 +35,7 @@ fn mangleString(s: []u8) void {
 }
 
 test "basic for loop" {
-    const expected_result = []u8{ 9, 8, 7, 6, 0, 1, 2, 3, 9, 8, 7, 6, 0, 1, 2, 3 };
+    const expected_result = []u8{ 9, 8, 7, 6, 0, 1, 2, 3 } ** 3;
 
     var buffer: [expected_result.len]u8 = undefined;
     var buf_index: usize = 0;
@@ -46,6 +46,15 @@ test "basic for loop" {
         buf_index += 1;
     }
     for (array) |item, index| {
+        buffer[buf_index] = @intCast(u8, index);
+        buf_index += 1;
+    }
+    const array_ptr = &array;
+    for (array_ptr) |item| {
+        buffer[buf_index] = item;
+        buf_index += 1;
+    }
+    for (array_ptr) |item, index| {
         buffer[buf_index] = @intCast(u8, index);
         buf_index += 1;
     }


### PR DESCRIPTION
While working on this, I noticed that this doesn't compile:
```
test "" {
    const a = "111";
    for (a) |*c, i| // error: expected type '*u8', found '*const u8'
        @import("std").debug.assert(c.* == a[i]);
}
```

I know that the ptr type is gotten from the `ir_analyze_instruction_to_ptr_type`, but I'm not sure how I figure out if the array is const from this function.