### PR TITLE
std.mem: match readInt signature with readIntBE/LE signature;

### DIFF
--- a/example/guess_number/main.zig
+++ b/example/guess_number/main.zig
@@ -15,7 +15,7 @@ pub fn main() !void {
         std.debug.warn("unable to seed random number generator: {}", err);
         return err;
     };
-    const seed = std.mem.readInt(seed_bytes, u64, builtin.Endian.Big);
+    const seed = std.mem.readInt(u64, seed_bytes, builtin.Endian.Big);
     var prng = std.rand.DefaultPrng.init(seed);
 
     const answer = prng.random.range(u8, 0, 100) + 1;

--- a/src-self-hosted/compilation.zig
+++ b/src-self-hosted/compilation.zig
@@ -55,7 +55,7 @@ pub const ZigCompiler = struct {
 
         var seed_bytes: [@sizeOf(u64)]u8 = undefined;
         try std.os.getRandomBytes(seed_bytes[0..]);
-        const seed = std.mem.readInt(seed_bytes, u64, builtin.Endian.Big);
+        const seed = std.mem.readInt(u64, seed_bytes, builtin.Endian.Big);
 
         return ZigCompiler{
             .loop = loop,

--- a/std/crypto/poly1305.zig
+++ b/std/crypto/poly1305.zig
@@ -59,19 +59,19 @@ pub const Poly1305 = struct {
         {
             var i: usize = 0;
             while (i < 1) : (i += 1) {
-                ctx.r[0] = readInt(key[0..4], u32, Endian.Little) & 0x0fffffff;
+                ctx.r[0] = readInt(u32, key[0..4], Endian.Little) & 0x0fffffff;
             }
         }
         {
             var i: usize = 1;
             while (i < 4) : (i += 1) {
-                ctx.r[i] = readInt(key[i * 4 .. i * 4 + 4], u32, Endian.Little) & 0x0ffffffc;
+                ctx.r[i] = readInt(u32, key[i * 4 .. i * 4 + 4], Endian.Little) & 0x0ffffffc;
             }
         }
         {
             var i: usize = 0;
             while (i < 4) : (i += 1) {
-                ctx.pad[i] = readInt(key[i * 4 + 16 .. i * 4 + 16 + 4], u32, Endian.Little);
+                ctx.pad[i] = readInt(u32, key[i * 4 + 16 .. i * 4 + 16 + 4], Endian.Little);
             }
         }
 
@@ -168,10 +168,10 @@ pub const Poly1305 = struct {
         const nb_blocks = nmsg.len >> 4;
         var i: usize = 0;
         while (i < nb_blocks) : (i += 1) {
-            ctx.c[0] = readInt(nmsg[0..4], u32, Endian.Little);
-            ctx.c[1] = readInt(nmsg[4..8], u32, Endian.Little);
-            ctx.c[2] = readInt(nmsg[8..12], u32, Endian.Little);
-            ctx.c[3] = readInt(nmsg[12..16], u32, Endian.Little);
+            ctx.c[0] = readInt(u32, nmsg[0..4], Endian.Little);
+            ctx.c[1] = readInt(u32, nmsg[4..8], Endian.Little);
+            ctx.c[2] = readInt(u32, nmsg[8..12], Endian.Little);
+            ctx.c[3] = readInt(u32, nmsg[12..16], Endian.Little);
             polyBlock(ctx);
             nmsg = nmsg[16..];
         }

--- a/std/crypto/x25519.zig
+++ b/std/crypto/x25519.zig
@@ -255,16 +255,16 @@ const Fe = struct {
 
         var t: [10]i64 = undefined;
 
-        t[0] = readInt(s[0..4], u32, Endian.Little);
-        t[1] = readInt(s[4..7], u32, Endian.Little) << 6;
-        t[2] = readInt(s[7..10], u32, Endian.Little) << 5;
-        t[3] = readInt(s[10..13], u32, Endian.Little) << 3;
-        t[4] = readInt(s[13..16], u32, Endian.Little) << 2;
-        t[5] = readInt(s[16..20], u32, Endian.Little);
-        t[6] = readInt(s[20..23], u32, Endian.Little) << 7;
-        t[7] = readInt(s[23..26], u32, Endian.Little) << 5;
-        t[8] = readInt(s[26..29], u32, Endian.Little) << 4;
-        t[9] = (readInt(s[29..32], u32, Endian.Little) & 0x7fffff) << 2;
+        t[0] = readInt(u32, s[0..4], Endian.Little);
+        t[1] = readInt(u32, s[4..7], Endian.Little) << 6;
+        t[2] = readInt(u32, s[7..10], Endian.Little) << 5;
+        t[3] = readInt(u32, s[10..13], Endian.Little) << 3;
+        t[4] = readInt(u32, s[13..16], Endian.Little) << 2;
+        t[5] = readInt(u32, s[16..20], Endian.Little);
+        t[6] = readInt(u32, s[20..23], Endian.Little) << 7;
+        t[7] = readInt(u32, s[23..26], Endian.Little) << 5;
+        t[8] = readInt(u32, s[26..29], Endian.Little) << 4;
+        t[9] = (readInt(u32, s[29..32], Endian.Little) & 0x7fffff) << 2;
 
         carry1(h, t[0..]);
     }

--- a/std/elf.zig
+++ b/std/elf.zig
@@ -406,7 +406,7 @@ pub const Elf = struct {
         // skip over padding
         try elf.in_file.seekForward(9);
 
-        elf.file_type = switch (try in.readInt(elf.endian, u16)) {
+        elf.file_type = switch (try in.readInt(u16, elf.endian)) {
             1 => FileType.Relocatable,
             2 => FileType.Executable,
             3 => FileType.Shared,
@@ -414,7 +414,7 @@ pub const Elf = struct {
             else => return error.InvalidFormat,
         };
 
-        elf.arch = switch (try in.readInt(elf.endian, u16)) {
+        elf.arch = switch (try in.readInt(u16, elf.endian)) {
             0x02 => Arch.Sparc,
             0x03 => Arch.x86,
             0x08 => Arch.Mips,
@@ -427,32 +427,32 @@ pub const Elf = struct {
             else => return error.InvalidFormat,
         };
 
-        const elf_version = try in.readInt(elf.endian, u32);
+        const elf_version = try in.readInt(u32, elf.endian);
         if (elf_version != 1) return error.InvalidFormat;
 
         if (elf.is_64) {
-            elf.entry_addr = try in.readInt(elf.endian, u64);
-            elf.program_header_offset = try in.readInt(elf.endian, u64);
-            elf.section_header_offset = try in.readInt(elf.endian, u64);
+            elf.entry_addr = try in.readInt(u64, elf.endian);
+            elf.program_header_offset = try in.readInt(u64, elf.endian);
+            elf.section_header_offset = try in.readInt(u64, elf.endian);
         } else {
-            elf.entry_addr = u64(try in.readInt(elf.endian, u32));
-            elf.program_header_offset = u64(try in.readInt(elf.endian, u32));
-            elf.section_header_offset = u64(try in.readInt(elf.endian, u32));
+            elf.entry_addr = u64(try in.readInt(u32, elf.endian));
+            elf.program_header_offset = u64(try in.readInt(u32, elf.endian));
+            elf.section_header_offset = u64(try in.readInt(u32, elf.endian));
         }
 
         // skip over flags
         try elf.in_file.seekForward(4);
 
-        const header_size = try in.readInt(elf.endian, u16);
+        const header_size = try in.readInt(u16, elf.endian);
         if ((elf.is_64 and header_size != 64) or (!elf.is_64 and header_size != 52)) {
             return error.InvalidFormat;
         }
 
-        const ph_entry_size = try in.readInt(elf.endian, u16);
-        const ph_entry_count = try in.readInt(elf.endian, u16);
-        const sh_entry_size = try in.readInt(elf.endian, u16);
-        const sh_entry_count = try in.readInt(elf.endian, u16);
-        elf.string_section_index = u64(try in.readInt(elf.endian, u16));
+        const ph_entry_size = try in.readInt(u16, elf.endian);
+        const ph_entry_count = try in.readInt(u16, elf.endian);
+        const sh_entry_size = try in.readInt(u16, elf.endian);
+        const sh_entry_count = try in.readInt(u16, elf.endian);
+        elf.string_section_index = u64(try in.readInt(u16, elf.endian));
 
         if (elf.string_section_index >= sh_entry_count) return error.InvalidFormat;
 
@@ -475,32 +475,32 @@ pub const Elf = struct {
             if (sh_entry_size != 64) return error.InvalidFormat;
 
             for (elf.section_headers) |*elf_section| {
-                elf_section.name = try in.readInt(elf.endian, u32);
-                elf_section.sh_type = try in.readInt(elf.endian, u32);
-                elf_section.flags = try in.readInt(elf.endian, u64);
-                elf_section.addr = try in.readInt(elf.endian, u64);
-                elf_section.offset = try in.readInt(elf.endian, u64);
-                elf_section.size = try in.readInt(elf.endian, u64);
-                elf_section.link = try in.readInt(elf.endian, u32);
-                elf_section.info = try in.readInt(elf.endian, u32);
-                elf_section.addr_align = try in.readInt(elf.endian, u64);
-                elf_section.ent_size = try in.readInt(elf.endian, u64);
+                elf_section.name = try in.readInt(u32, elf.endian);
+                elf_section.sh_type = try in.readInt(u32, elf.endian);
+                elf_section.flags = try in.readInt(u64, elf.endian);
+                elf_section.addr = try in.readInt(u64, elf.endian);
+                elf_section.offset = try in.readInt(u64, elf.endian);
+                elf_section.size = try in.readInt(u64, elf.endian);
+                elf_section.link = try in.readInt(u32, elf.endian);
+                elf_section.info = try in.readInt(u32, elf.endian);
+                elf_section.addr_align = try in.readInt(u64, elf.endian);
+                elf_section.ent_size = try in.readInt(u64, elf.endian);
             }
         } else {
             if (sh_entry_size != 40) return error.InvalidFormat;
 
             for (elf.section_headers) |*elf_section| {
                 // TODO (multiple occurrences) allow implicit cast from %u32 -> %u64 ?
-                elf_section.name = try in.readInt(elf.endian, u32);
-                elf_section.sh_type = try in.readInt(elf.endian, u32);
-                elf_section.flags = u64(try in.readInt(elf.endian, u32));
-                elf_section.addr = u64(try in.readInt(elf.endian, u32));
-                elf_section.offset = u64(try in.readInt(elf.endian, u32));
-                elf_section.size = u64(try in.readInt(elf.endian, u32));
-                elf_section.link = try in.readInt(elf.endian, u32);
-                elf_section.info = try in.readInt(elf.endian, u32);
-                elf_section.addr_align = u64(try in.readInt(elf.endian, u32));
-                elf_section.ent_size = u64(try in.readInt(elf.endian, u32));
+                elf_section.name = try in.readInt(u32, elf.endian);
+                elf_section.sh_type = try in.readInt(u32, elf.endian);
+                elf_section.flags = u64(try in.readInt(u32, elf.endian));
+                elf_section.addr = u64(try in.readInt(u32, elf.endian));
+                elf_section.offset = u64(try in.readInt(u32, elf.endian));
+                elf_section.size = u64(try in.readInt(u32, elf.endian));
+                elf_section.link = try in.readInt(u32, elf.endian);
+                elf_section.info = try in.readInt(u32, elf.endian);
+                elf_section.addr_align = u64(try in.readInt(u32, elf.endian));
+                elf_section.ent_size = u64(try in.readInt(u32, elf.endian));
             }
         }
 

--- a/std/event/io.zig
+++ b/std/event/io.zig
@@ -40,17 +40,17 @@ pub fn InStream(comptime ReadError: type) type {
         }
 
         pub async fn readIntLe(self: *Self, comptime T: type) !T {
-            return await (async self.readInt(builtin.Endian.Little, T) catch unreachable);
+            return await (async self.readInt(T, builtin.Endian.Little) catch unreachable);
         }
 
         pub async fn readIntBe(self: *Self, comptime T: type) !T {
-            return await (async self.readInt(builtin.Endian.Big, T) catch unreachable);
+            return await (async self.readInt(T, builtin.Endian.Big) catch unreachable);
         }
 
-        pub async fn readInt(self: *Self, endian: builtin.Endian, comptime T: type) !T {
+        pub async fn readInt(self: *Self, comptime T: type, endian: builtin.Endian) !T {
             var bytes: [@sizeOf(T)]u8 = undefined;
             try await (async self.readNoEof(bytes[0..]) catch unreachable);
-            return mem.readInt(bytes, T, endian);
+            return mem.readInt(T, bytes, endian);
         }
 
         pub async fn readStruct(self: *Self, comptime T: type) !T {

--- a/std/hash/siphash.zig
+++ b/std/hash/siphash.zig
@@ -42,8 +42,8 @@ fn SipHash(comptime T: type, comptime c_rounds: usize, comptime d_rounds: usize)
         pub fn init(key: []const u8) Self {
             debug.assert(key.len >= 16);
 
-            const k0 = mem.readInt(key[0..8], u64, Endian.Little);
-            const k1 = mem.readInt(key[8..16], u64, Endian.Little);
+            const k0 = mem.readInt(u64, key[0..8], Endian.Little);
+            const k1 = mem.readInt(u64, key[8..16], Endian.Little);
 
             var d = Self{
                 .v0 = k0 ^ 0x736f6d6570736575,
@@ -121,7 +121,7 @@ fn SipHash(comptime T: type, comptime c_rounds: usize, comptime d_rounds: usize)
         fn round(d: *Self, b: []const u8) void {
             debug.assert(b.len == 8);
 
-            const m = mem.readInt(b[0..], u64, Endian.Little);
+            const m = mem.readInt(u64, b[0..], Endian.Little);
             d.v3 ^= m;
 
             comptime var i: usize = 0;
@@ -235,7 +235,7 @@ test "siphash64-2-4 sanity" {
     for (vectors) |vector, i| {
         buffer[i] = @intCast(u8, i);
 
-        const expected = mem.readInt(vector, u64, Endian.Little);
+        const expected = mem.readInt(u64, vector, Endian.Little);
         debug.assert(siphash.hash(test_key, buffer[0..i]) == expected);
     }
 }
@@ -314,7 +314,7 @@ test "siphash128-2-4 sanity" {
     for (vectors) |vector, i| {
         buffer[i] = @intCast(u8, i);
 
-        const expected = mem.readInt(vector, u128, Endian.Little);
+        const expected = mem.readInt(u128, vector, Endian.Little);
         debug.assert(siphash.hash(test_key, buffer[0..i]) == expected);
     }
 }

--- a/std/io.zig
+++ b/std/io.zig
@@ -151,7 +151,7 @@ pub fn InStream(comptime ReadError: type) type {
 
         /// Reads a native-endian integer
         pub fn readIntNe(self: *Self, comptime T: type) !T {
-            return self.readInt(builtin.endian, T);
+            return self.readInt(T, builtin.endian);
         }
 
         pub fn readIntLe(self: *Self, comptime T: type) !T {
@@ -166,19 +166,19 @@ pub fn InStream(comptime ReadError: type) type {
             return mem.readIntBE(T, bytes);
         }
 
-        pub fn readInt(self: *Self, endian: builtin.Endian, comptime T: type) !T {
+        pub fn readInt(self: *Self, comptime T: type, endian: builtin.Endian) !T {
             var bytes: [@sizeOf(T)]u8 = undefined;
             try self.readNoEof(bytes[0..]);
-            return mem.readInt(bytes, T, endian);
+            return mem.readInt(T, bytes, endian);
         }
 
-        pub fn readVarInt(self: *Self, endian: builtin.Endian, comptime T: type, size: usize) !T {
+        pub fn readVarInt(self: *Self, comptime T: type, endian: builtin.Endian, size: usize) !T {
             assert(size <= @sizeOf(T));
             assert(size <= 8);
             var input_buf: [8]u8 = undefined;
             const input_slice = input_buf[0..size];
             try self.readNoEof(input_slice);
-            return mem.readInt(input_slice, T, endian);
+            return mem.readInt(T, input_slice, endian);
         }
 
         pub fn skipBytes(self: *Self, num_bytes: usize) !void {

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -411,7 +411,7 @@ test "mem.indexOf" {
 /// T specifies the return type, which must be large enough to store
 /// the result.
 /// See also ::readIntBE or ::readIntLE.
-pub fn readInt(bytes: []const u8, comptime T: type, endian: builtin.Endian) T {
+pub fn readInt(comptime T: type, bytes: []const u8, endian: builtin.Endian) T {
     if (T.bit_count == 8) {
         return bytes[0];
     }
@@ -737,10 +737,10 @@ fn testReadIntImpl() void {
             0x56,
             0x78,
         };
-        assert(readInt(bytes, u32, builtin.Endian.Big) == 0x12345678);
+        assert(readInt(u32, bytes, builtin.Endian.Big) == 0x12345678);
         assert(readIntBE(u32, bytes) == 0x12345678);
         assert(readIntBE(i32, bytes) == 0x12345678);
-        assert(readInt(bytes, u32, builtin.Endian.Little) == 0x78563412);
+        assert(readInt(u32, bytes, builtin.Endian.Little) == 0x78563412);
         assert(readIntLE(u32, bytes) == 0x78563412);
         assert(readIntLE(i32, bytes) == 0x78563412);
     }
@@ -751,7 +751,7 @@ fn testReadIntImpl() void {
             0x12,
             0x34,
         };
-        const answer = readInt(buf, u64, builtin.Endian.Big);
+        const answer = readInt(u64, buf, builtin.Endian.Big);
         assert(answer == 0x00001234);
     }
     {
@@ -761,7 +761,7 @@ fn testReadIntImpl() void {
             0x00,
             0x00,
         };
-        const answer = readInt(buf, u64, builtin.Endian.Little);
+        const answer = readInt(u64, buf, builtin.Endian.Little);
         assert(answer == 0x00003412);
     }
     {
@@ -959,7 +959,7 @@ pub fn endianSwapIf(endian: builtin.Endian, comptime T: type, x: T) T {
 pub fn endianSwap(comptime T: type, x: T) T {
     var buf: [@sizeOf(T)]u8 = undefined;
     mem.writeInt(buf[0..], x, builtin.Endian.Little);
-    return mem.readInt(buf, T, builtin.Endian.Big);
+    return mem.readInt(T, buf, builtin.Endian.Big);
 }
 
 test "std.mem.endianSwap" {


### PR DESCRIPTION
This PR updates the signature for `std.mem.readInt` to match the signatures of readIntBE/LE.

`pub fn readInt(comptime T: type, bytes: []const u8, endian: builtin.Endian) T`
`pub fn readIntBE(comptime T: type, bytes: []const u8) T`
`pub fn readIntLE(comptime T: type, bytes: []const u8) T`

`std.mem.readInt` used to have the following signature (compared with others):

`pub fn readInt(bytes: []const u8, comptime T: type, endian: builtin.Endian) T `
`pub fn readIntBE(comptime T: type, bytes: []const u8) T`
`pub fn readIntLE(comptime T: type, bytes: []const u8) T`

Thanks.