### PR TITLE
std/mem: writeIntLE: buf.* to buf;

### DIFF
--- a/std/mem.zig
+++ b/std/mem.zig
@@ -546,9 +546,7 @@ pub fn writeIntLE(comptime T: type, buf: *[@sizeOf(T)]u8, value: T) void {
         buf[0] = bits;
         return;
     }
-    // FIXME: this should just be for (buf).
-    // See https://github.com/ziglang/zig/issues/1663
-    for (buf.*) |*b| {
+    for (buf) |*b| {
         b.* = @truncate(u8, bits);
         bits >>= 8;
     }


### PR DESCRIPTION
Now that the fix for #1663 landed with be9bb0a8572577f5e5bbac83ff25b88467906d70 we can remove the workaround on `std.mem.writeIntLE`.

cc @thejoshwolfe @Hejsil 

Thanks!