### PR TITLE
Added serialization, bitstreams, traits for int sign, TagPayloadType, some fixes to std

### DIFF
--- a/std/io.zig
+++ b/std/io.zig
@@ -1050,8 +1050,13 @@ pub fn Deserializer(endian: builtin.Endian, is_packed: bool, comptime Error: typ
                 else => in_stream,
             } };
         }
+        
+        pub fn alignToByte(self: *Self) void {
+            if(!is_packed) return;
+            self.in_stream.alignToByte();
+        }
 
-        //@BUG: inferred error issue
+        //@BUG: inferred error issue. See: #1386 
         fn deserializeInt(self: *Self, comptime T: type) (Stream.Error || error{EndOfStream})!T {
             debug.assert(trait.is(builtin.TypeId.Int)(T) or trait.is(builtin.TypeId.Float)(T));
 

--- a/std/io.zig
+++ b/std/io.zig
@@ -526,7 +526,9 @@ pub fn BitInStream(endian: builtin.Endian, comptime Error: type) type {
                     if (err == error.EndOfStream) {
                         return @intCast(U, out_buffer);
                     }
-                    return err;
+                    //@BUG: See #1810. Not sure if the bug is that I have to do this for some
+                    // streams, or that I don't for streams with emtpy errorsets.
+                    return @errSetCast(Error, err);
                 };
 
                 switch (endian) {

--- a/std/io.zig
+++ b/std/io.zig
@@ -1243,7 +1243,7 @@ pub fn Deserializer(endian: builtin.Endian, is_packed: bool, comptime Error: typ
 ///  endianess, after which data will resume being written at the next byte boundary.
 ///  Types may implement a custom serialization routine with a
 ///  function named `serialize` in the form of:
-///    pub fn serialize(self: *const Self, serializer: var) !void
+///    pub fn serialize(self: Self, serializer: var) !void
 ///  which will be called when the serializer is used to serialize that type. It will
 ///  pass a const pointer to the type instance to be serialized and a pointer
 ///  to the serializer struct.

--- a/std/io.zig
+++ b/std/io.zig
@@ -1146,7 +1146,7 @@ pub fn Deserializer(endian: builtin.Endian, is_packed: bool, comptime Error: typ
             const child_type_id = @typeId(C);
 
             //custom deserializer: fn(self: *Self, deserializer: var) !void
-            if (comptime trait.hasFn("deserialize")(C)) return ptr.deserialize(self);
+            if (comptime trait.hasFn("deserialize")(C)) return C.deserialize(ptr, self);
 
             if (comptime trait.isPacked(C) and !is_packed) {
                 var packed_deserializer = Deserializer(endian, true, Error).init(self.in_stream);
@@ -1308,8 +1308,8 @@ pub fn Serializer(endian: builtin.Endian, is_packed: bool, comptime Error: type)
                 return;
             }
 
-            //custom serializer: fn(self: *const Self, serializer: var) !void
-            if (comptime trait.hasFn("serialize")(T)) return value.serialize(self);
+            //custom serializer: fn(self: Self, serializer: var) !void
+            if (comptime trait.hasFn("serialize")(T)) return T.serialize(value, self);
 
             if (comptime trait.isPacked(T) and !is_packed) {
                 var packed_serializer = Serializer(endian, true, Error).init(self.out_stream);

--- a/std/io_test.zig
+++ b/std/io_test.zig
@@ -416,6 +416,10 @@ test "Serializer/Deserializer Int: Inf/NaN" {
     try testIntSerializerDeserializerInfNaN(builtin.Endian.Little, true);
 }
 
+fn testAlternateSerializer(self: var, serializer: var) !void {
+    try serializer.serialize(self.f_f16);
+}
+
 fn testSerializerDeserializer(comptime endian: builtin.Endian, comptime is_packed: bool) !void {
     const ColorType = enum(u4) {
         RGB8 = 1,
@@ -448,6 +452,8 @@ fn testSerializerDeserializer(comptime endian: builtin.Endian, comptime is_packe
         f_u2: u2,
     };
 
+    
+    
     //to test custom serialization
     const Custom = struct {
         f_f16: f16,
@@ -458,9 +464,7 @@ fn testSerializerDeserializer(comptime endian: builtin.Endian, comptime is_packe
             self.f_unused_u32 = 47;
         }
 
-        pub fn serialize(self: *const @This(), serializer: var) !void {
-            try serializer.serialize(self.f_f16);
-        }
+        pub const serialize = testAlternateSerializer;
     };
 
     const MyStruct = struct {

--- a/std/io_test.zig
+++ b/std/io_test.zig
@@ -1,5 +1,7 @@
 const std = @import("index.zig");
 const io = std.io;
+const meta = std.meta;
+const trait = std.trait;
 const DefaultPrng = std.rand.DefaultPrng;
 const assert = std.debug.assert;
 const assertError = std.debug.assertError;
@@ -131,4 +133,331 @@ test "SliceOutStream" {
 
     assertError(ss.stream.write("Hello world!"), error.OutOfSpace);
     assert(mem.eql(u8, ss.getWritten(), "Hello worl"));
+}
+
+test "BitInStream" {
+    const mem_be = []u8{ 0b11001101, 0b00001011 };
+    const mem_le = []u8{ 0b00011101, 0b10010101 };
+
+    var mem_in_be = io.SliceInStream.init(mem_be[0..]);
+    const InError = io.SliceInStream.Error;
+    var bit_stream_be = io.BitInStream(builtin.Endian.Big, InError).init(&mem_in_be.stream);
+
+    var out_bits: usize = undefined;
+
+    assert(1 == try bit_stream_be.readBits(u2, 1, &out_bits));
+    assert(out_bits == 1);
+    assert(2 == try bit_stream_be.readBits(u5, 2, &out_bits));
+    assert(out_bits == 2);
+    assert(3 == try bit_stream_be.readBits(u128, 3, &out_bits));
+    assert(out_bits == 3);
+    assert(4 == try bit_stream_be.readBits(u8, 4, &out_bits));
+    assert(out_bits == 4);
+    assert(5 == try bit_stream_be.readBits(u9, 5, &out_bits));
+    assert(out_bits == 5);
+    assert(1 == try bit_stream_be.readBits(u1, 1, &out_bits));
+    assert(out_bits == 1);
+
+    mem_in_be.pos = 0;
+    bit_stream_be.bit_count = 0;
+    assert(0b110011010000101 == try bit_stream_be.readBits(u15, 15, &out_bits));
+    assert(out_bits == 15);
+
+    mem_in_be.pos = 0;
+    bit_stream_be.bit_count = 0;
+    assert(0b1100110100001011 == try bit_stream_be.readBits(u16, 16, &out_bits));
+    assert(out_bits == 16);
+
+    _ = try bit_stream_be.readBits(u0, 0, &out_bits);
+
+    var mem_in_le = io.SliceInStream.init(mem_le[0..]);
+    var bit_stream_le = io.BitInStream(builtin.Endian.Little, InError).init(&mem_in_le.stream);
+
+    assert(1 == try bit_stream_le.readBits(u2, 1, &out_bits));
+    assert(out_bits == 1);
+    assert(2 == try bit_stream_le.readBits(u5, 2, &out_bits));
+    assert(out_bits == 2);
+    assert(3 == try bit_stream_le.readBits(u128, 3, &out_bits));
+    assert(out_bits == 3);
+    assert(4 == try bit_stream_le.readBits(u8, 4, &out_bits));
+    assert(out_bits == 4);
+    assert(5 == try bit_stream_le.readBits(u9, 5, &out_bits));
+    assert(out_bits == 5);
+    assert(1 == try bit_stream_le.readBits(u1, 1, &out_bits));
+    assert(out_bits == 1);
+
+    mem_in_le.pos = 0;
+    bit_stream_le.bit_count = 0;
+    assert(0b001010100011101 == try bit_stream_le.readBits(u15, 15, &out_bits));
+    assert(out_bits == 15);
+
+    mem_in_le.pos = 0;
+    bit_stream_le.bit_count = 0;
+    assert(0b1001010100011101 == try bit_stream_le.readBits(u16, 16, &out_bits));
+    assert(out_bits == 16);
+
+    _ = try bit_stream_le.readBits(u0, 0, &out_bits);
+}
+
+test "BitOutStream" {
+    var mem_be = []u8{0} ** 2;
+    var mem_le = []u8{0} ** 2;
+
+    var mem_out_be = io.SliceOutStream.init(mem_be[0..]);
+    const OutError = io.SliceOutStream.Error;
+    var bit_stream_be = io.BitOutStream(builtin.Endian.Big, OutError).init(&mem_out_be.stream);
+
+    try bit_stream_be.writeBits(u2(1), 1);
+    try bit_stream_be.writeBits(u5(2), 2);
+    try bit_stream_be.writeBits(u128(3), 3);
+    try bit_stream_be.writeBits(u8(4), 4);
+    try bit_stream_be.writeBits(u9(5), 5);
+    try bit_stream_be.writeBits(u1(1), 1);
+
+    assert(mem_be[0] == 0b11001101 and mem_be[1] == 0b00001011);
+
+    mem_out_be.pos = 0;
+
+    try bit_stream_be.writeBits(u15(0b110011010000101), 15);
+    try bit_stream_be.flushBits();
+    assert(mem_be[0] == 0b11001101 and mem_be[1] == 0b00001010);
+
+    mem_out_be.pos = 0;
+    try bit_stream_be.writeBits(u32(0b110011010000101), 16);
+    assert(mem_be[0] == 0b01100110 and mem_be[1] == 0b10000101);
+
+    try bit_stream_be.writeBits(u0(0), 0);
+
+    var mem_out_le = io.SliceOutStream.init(mem_le[0..]);
+    var bit_stream_le = io.BitOutStream(builtin.Endian.Little, OutError).init(&mem_out_le.stream);
+
+    try bit_stream_le.writeBits(u2(1), 1);
+    try bit_stream_le.writeBits(u5(2), 2);
+    try bit_stream_le.writeBits(u128(3), 3);
+    try bit_stream_le.writeBits(u8(4), 4);
+    try bit_stream_le.writeBits(u9(5), 5);
+    try bit_stream_le.writeBits(u1(1), 1);
+
+    assert(mem_le[0] == 0b00011101 and mem_le[1] == 0b10010101);
+
+    mem_out_le.pos = 0;
+    try bit_stream_le.writeBits(u15(0b110011010000101), 15);
+    try bit_stream_le.flushBits();
+    assert(mem_le[0] == 0b10000101 and mem_le[1] == 0b01100110);
+
+    mem_out_le.pos = 0;
+    try bit_stream_le.writeBits(u32(0b1100110100001011), 16);
+    assert(mem_le[0] == 0b00001011 and mem_le[1] == 0b11001101);
+
+    try bit_stream_le.writeBits(u0(0), 0);
+}
+
+fn testIntSerializerDeserializer(comptime endian: builtin.Endian, comptime is_packed: bool) !void {
+    const max_test_bitsize = 17;
+    
+    const total_bytes = comptime blk: {
+        var bytes = 0;
+        comptime var i = 0;
+        while (i <= max_test_bitsize) : (i += 1) bytes += (i / 8) + @boolToInt(i % 8 > 0);
+        break :blk bytes * 2;
+    };
+    
+    var data_mem: [total_bytes]u8 = undefined;
+    var out = io.SliceOutStream.init(data_mem[0..]);
+    const OutError = io.SliceOutStream.Error;
+    var out_stream = &out.stream;
+    var serializer = io.Serializer(endian, is_packed, OutError).init(out_stream);
+
+    var in = io.SliceInStream.init(data_mem[0..]);
+    const InError = io.SliceInStream.Error;
+    var in_stream = &in.stream;
+    var deserializer = io.Deserializer(endian, is_packed, InError).init(in_stream);
+
+    comptime var i = 0;
+    inline while (i <= max_test_bitsize) : (i += 1) {
+        const U = @IntType(false, i);
+        const S = @IntType(true, i);
+        try serializer.serializeInt(U(i));
+        if (i != 0) try serializer.serializeInt(S(-1));
+    }
+    try serializer.flush();
+
+    i = 0;
+    inline while (i <= max_test_bitsize) : (i += 1) {
+        const U = @IntType(false, i);
+        const S = @IntType(true, i);
+        const x = try deserializer.deserializeInt(U);
+        const y = if (i != 0) try deserializer.deserializeInt(S);
+        assert(x == U(i));
+        if (i != 0) assert(y == S(-1));
+    }
+
+    const u8_bit_count = comptime meta.bitCount(u8);
+    //0 + 1 + 2 + ... n = (n * (n + 1)) / 2
+    //and we have each for unsigned and signed, so * 2
+    const total_bits = (max_test_bitsize * (max_test_bitsize + 1));
+    const extra_packed_byte = @boolToInt(total_bits % u8_bit_count > 0);
+    const total_packed_bytes = (total_bits / u8_bit_count) + extra_packed_byte;
+
+    
+
+    assert(in.pos == if (is_packed) total_packed_bytes else total_bytes);
+}
+
+test "Serializer/Deserializer Int" {
+    try testIntSerializerDeserializer(builtin.Endian.Big, false);
+    try testIntSerializerDeserializer(builtin.Endian.Little, false);
+    try testIntSerializerDeserializer(builtin.Endian.Big, true);
+    try testIntSerializerDeserializer(builtin.Endian.Little, true);
+}
+
+fn testSerializerDeserializer(comptime endian: builtin.Endian, comptime is_packed: bool) !void {
+    const ColorType = enum(u4) {
+        RGB8 = 1,
+        RA16 = 2,
+        R32 = 3,
+    };
+
+    const TagAlign = union(enum(u32)) {
+        A: u8,
+        B: u8,
+        C: u8,
+    };
+
+    const Color = union(ColorType) {
+        RGB8: struct {
+            r: u8,
+            g: u8,
+            b: u8,
+            a: u8,
+        },
+        RA16: struct {
+            r: u16,
+            a: u16,
+        },
+        R32: u32,
+    };
+
+    const PackedStruct = packed struct {
+        f_i3: i3,
+        f_u2: u2,
+    };
+
+    //to test custom serialization
+    const Custom = struct {
+        f_f16: f16,
+        f_unused_u32: u32,
+
+        pub fn deserialize(self: *@This(), deserializer: var) !void {
+            try deserializer.deserializeInto(&self.f_f16);
+            self.f_unused_u32 = 47;
+        }
+
+        pub fn serialize(self: *const @This(), serializer: var) !void {
+            try serializer.serialize(self.f_f16);
+        }
+    };
+
+    const MyStruct = struct {
+        f_i3: i3,
+        f_u8: u8,
+        f_tag_align: TagAlign,
+        f_u24: u24,
+        f_i19: i19,
+        f_void: void,
+        f_f32: f32,
+        f_f128: f128,
+        f_packed_0: PackedStruct,
+        f_i7arr: [10]i7,
+        f_of64n: ?f64,
+        f_of64v: ?f64,
+        f_color_type: ColorType,
+        f_packed_1: PackedStruct,
+        f_custom: Custom,
+        f_color: Color,
+    };
+
+    const my_inst = MyStruct{
+        .f_i3 = -1,
+        .f_u8 = 8,
+        .f_tag_align = TagAlign{ .B = 148 },
+        .f_u24 = 24,
+        .f_i19 = 19,
+        .f_void = {},
+        .f_f32 = 32.32,
+        .f_f128 = 128.128,
+        .f_packed_0 = PackedStruct{ .f_i3 = -1, .f_u2 = 2 },
+        .f_i7arr = [10]i7{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+        .f_of64n = null,
+        .f_of64v = 64.64,
+        .f_color_type = ColorType.R32,
+        .f_packed_1 = PackedStruct{ .f_i3 = 1, .f_u2 = 1 },
+        .f_custom = Custom{ .f_f16 = 38.63, .f_unused_u32 = 47 },
+        .f_color = Color{ .R32 = 123822 },
+    };
+
+    var data_mem: [@sizeOf(MyStruct)]u8 = undefined;
+    var out = io.SliceOutStream.init(data_mem[0..]);
+    const OutError = io.SliceOutStream.Error;
+    var out_stream = &out.stream;
+    var serializer = io.Serializer(endian, is_packed, OutError).init(out_stream);
+
+    var in = io.SliceInStream.init(data_mem[0..]);
+    const InError = io.SliceInStream.Error;
+    var in_stream = &in.stream;
+    var deserializer = io.Deserializer(endian, is_packed, InError).init(in_stream);
+
+    try serializer.serialize(my_inst);
+
+    const my_copy = try deserializer.deserialize(MyStruct);
+
+    assert(meta.eql(my_copy, my_inst));
+}
+
+test "Serializer/Deserializer generic" {
+    try testSerializerDeserializer(builtin.Endian.Big, false);
+    try testSerializerDeserializer(builtin.Endian.Little, false);
+    try testSerializerDeserializer(builtin.Endian.Big, true);
+    try testSerializerDeserializer(builtin.Endian.Little, true);
+}
+
+fn testBadData(comptime endian: builtin.Endian, comptime is_packed: bool) !void {
+    const E = enum(u14) {
+        One = 1,
+        Two = 2,
+    };
+
+    const A = struct {
+        e: E,
+    };
+
+    const C = union(E) {
+        One: u14,
+        Two: f16,
+    };
+
+    var data_mem: [4]u8 = undefined;
+    var out = io.SliceOutStream.init(data_mem[0..]);
+    const OutError = io.SliceOutStream.Error;
+    var out_stream = &out.stream;
+    var serializer = io.Serializer(endian, is_packed, OutError).init(out_stream);
+
+    var in = io.SliceInStream.init(data_mem[0..]);
+    const InError = io.SliceInStream.Error;
+    var in_stream = &in.stream;
+    var deserializer = io.Deserializer(endian, is_packed, InError).init(in_stream);
+
+    try serializer.serialize(u14(3));
+    assertError(deserializer.deserialize(A), error.InvalidEnumTag);
+    out.pos = 0;
+    try serializer.serialize(u14(3));
+    try serializer.serialize(u14(88));
+    assertError(deserializer.deserialize(C), error.InvalidEnumTag);
+}
+
+test "Deserializer bad data" {
+    try testBadData(builtin.Endian.Big, false);
+    try testBadData(builtin.Endian.Little, false);
+    try testBadData(builtin.Endian.Big, true);
+    try testBadData(builtin.Endian.Little, true);
 }

--- a/std/io_test.zig
+++ b/std/io_test.zig
@@ -169,6 +169,10 @@ test "BitInStream" {
     assert(out_bits == 16);
 
     _ = try bit_stream_be.readBits(u0, 0, &out_bits);
+    
+    assert(0 == try bit_stream_be.readBits(u1, 1, &out_bits));
+    assert(out_bits == 0);
+    assertError(bit_stream_be.readBitsNoEof(u1, 1), error.EndOfStream);
 
     var mem_in_le = io.SliceInStream.init(mem_le[0..]);
     var bit_stream_le = io.BitInStream(builtin.Endian.Little, InError).init(&mem_in_le.stream);
@@ -197,6 +201,10 @@ test "BitInStream" {
     assert(out_bits == 16);
 
     _ = try bit_stream_le.readBits(u0, 0, &out_bits);
+    
+    assert(0 == try bit_stream_le.readBits(u1, 1, &out_bits));
+    assert(out_bits == 0);
+    assertError(bit_stream_le.readBitsNoEof(u1, 1), error.EndOfStream);
 }
 
 test "BitOutStream" {

--- a/std/meta/trait.zig
+++ b/std/meta/trait.zig
@@ -232,6 +232,37 @@ test "std.meta.trait.isPacked" {
 }
 
 ///
+pub fn isUnsignedInt(comptime T: type) bool {
+    return switch (@typeId(T)) {
+        builtin.TypeId.Int => !@typeInfo(T).Int.is_signed,
+        else => false,
+    };
+}
+
+test "isUnsignedInt" {
+    debug.assert(isUnsignedInt(u32) == true);
+    debug.assert(isUnsignedInt(comptime_int) == false);
+    debug.assert(isUnsignedInt(i64) == false);
+    debug.assert(isUnsignedInt(f64) == false);
+}
+
+///
+pub fn isSignedInt(comptime T: type) bool {
+    return switch (@typeId(T)) {
+        builtin.TypeId.ComptimeInt => true,
+        builtin.TypeId.Int => @typeInfo(T).Int.is_signed,
+        else => false,
+    };
+}
+
+test "isSignedInt" {
+    debug.assert(isSignedInt(u32) == false);
+    debug.assert(isSignedInt(comptime_int) == true);
+    debug.assert(isSignedInt(i64) == true);
+    debug.assert(isSignedInt(f64) == false);
+}
+
+///
 pub fn isSingleItemPtr(comptime T: type) bool {
     if (comptime is(builtin.TypeId.Pointer)(T)) {
         const info = @typeInfo(T);


### PR DESCRIPTION
Added `BitInStream`/`BitOutStream` to `std.io`:
  These streams wrap any other In/Out stream and allow you to read/write bitfields with a specified endianess.

Added `Serialzer`/`Deserializer` to `std.io`:
  These wrap any other In/Out stream and provide the ability to read/write almost any type, including packed types, with specified endianess. Operates in either packed or unpacked mode. The former will bit-pack everything, the latter will byte-pack everything except packed structs which are bit-packed and then padded to the nearest byte.

Added traits for int sign to std.meta.trait:
  `trait.isSignedInt`, `trait.isUnsignedInt`. These should be self-explanatory.

Added `TagPayloadType` to std.meta:
  Given an enum tag and a union type, returns the type of the union field corresponding to the tag. Solves #1765. 

Fixes:
  `std.meta.bitCount` and `std.meta.alignment` now return comptime_int. `std.meta.eql` now handles Optionals.