### PR TITLE
std.mem: add new separate method and rework SplitIterator;

### DIFF
--- a/std/mem.zig
+++ b/std/mem.zig
@@ -654,6 +654,16 @@ test "mem.split" {
     assert(it.next() == null);
 }
 
+test "mem.split (multibyte)" {
+    var it = split("a|b,c/d e", " /,|");
+    assert(eql(u8, it.next().?, "a"));
+    assert(eql(u8, it.next().?, "b"));
+    assert(eql(u8, it.next().?, "c"));
+    assert(eql(u8, it.next().?, "d"));
+    assert(eql(u8, it.next().?, "e"));
+    assert(it.next() == null);
+}
+
 /// Returns an iterator that iterates over the slices of `buffer` that
 /// seperates by bytes in `delimiter`.
 /// separate("abc|def||ghi", "|")
@@ -694,7 +704,16 @@ test "mem.separate" {
     it = separate("hello", " ");
     assert(eql(u8, it.next().?, "hello"));
     assert(it.next() == null);
+}
 
+test "mem.separate (multibyte)" {
+    var it = separate("a|b,c/d e", " /,|");
+    assert(eql(u8, it.next().?, "a"));
+    assert(eql(u8, it.next().?, "b"));
+    assert(eql(u8, it.next().?, "c"));
+    assert(eql(u8, it.next().?, "d"));
+    assert(eql(u8, it.next().?, "e"));
+    assert(it.next() == null);
 }
 
 pub fn startsWith(comptime T: type, haystack: []const T, needle: []const T) bool {

--- a/std/os/path.zig
+++ b/std/os/path.zig
@@ -967,12 +967,14 @@ pub fn relativeWindows(allocator: *Allocator, from: []const u8, to: []const u8) 
         // shave off the trailing slash
         result_index -= 1;
 
-        var rest_it = mem.split(to_rest, "/\\");
-        while (rest_it.next()) |to_component| {
-            result[result_index] = '\\';
-            result_index += 1;
-            mem.copy(u8, result[result_index..], to_component);
-            result_index += to_component.len;
+        if (to_rest.len > 0) {
+            var rest_it = mem.split(to_rest, "/\\");
+            while (rest_it.next()) |to_component| {
+                result[result_index] = '\\';
+                result_index += 1;
+                mem.copy(u8, result[result_index..], to_component);
+                result_index += to_component.len;
+            }
         }
 
         return result[0..result_index];


### PR DESCRIPTION
closes #1784;

Adds a new method `separate` to `std.mem`:

* [X] Implementation
* [X] Documentation
* [X] Tests


```zig
    var it = @import("std").mem.separate("abc|def||ghi", "|");
    assert(eql(u8, it.next().?, "abc"));
    assert(eql(u8, it.next().?, "def"));
    assert(eql(u8, it.next().?, ""));
    assert(eql(u8, it.next().?, "ghi"));
    assert(it.next() == null);
```

Thanks
