### PR TITLE
stack traces: fix for windows

### DIFF
--- a/std/debug/index.zig
+++ b/std/debug/index.zig
@@ -282,8 +282,9 @@ fn printSourceAtAddressWindows(di: *DebugInfo, out_stream: var, relocated_addres
 
     var coff_section: *coff.Section = undefined;
     const mod_index = for (di.sect_contribs) |sect_contrib| {
-        if (sect_contrib.Section >= di.coff.sections.len) continue;
-        coff_section = &di.coff.sections.toSlice()[sect_contrib.Section];
+        if (sect_contrib.Section > di.coff.sections.len) continue;
+        // Remember that SectionContribEntry.Section is 1-based.
+        coff_section = &di.coff.sections.toSlice()[sect_contrib.Section-1];
 
         const vaddr_start = coff_section.header.virtual_address + sect_contrib.Offset;
         const vaddr_end = vaddr_start + sect_contrib.Size;

--- a/std/pdb.zig
+++ b/std/pdb.zig
@@ -34,6 +34,7 @@ pub const DbiStreamHeader = packed struct {
 };
 
 pub const SectionContribEntry = packed struct {
+    /// COFF Section index, 1-based
     Section: u16,
     Padding1: [2]u8,
     Offset: u32,


### PR DESCRIPTION
Correcting an off-by-one error and adding comments to warn about it.

Fixes #1655.