### PR TITLE
Implemented new more flexible readLineFrom

### DIFF
--- a/example/guess_number/main.zig
+++ b/example/guess_number/main.zig
@@ -24,15 +24,15 @@ pub fn main() !void {
         try stdout.print("\nGuess a number between 1 and 100: ");
         var line_buf: [20]u8 = undefined;
 
-        const line_len = io.readLine(line_buf[0..]) catch |err| switch (err) {
-            error.InputTooLong => {
+        const line = io.readLineSlice(line_buf[0..]) catch |err| switch (err) {
+            error.OutOfMemory => {
                 try stdout.print("Input too long.\n");
                 continue;
             },
-            error.EndOfFile, error.StdInUnavailable => return err,
+            else => return err,
         };
 
-        const guess = fmt.parseUnsigned(u8, line_buf[0..line_len], 10) catch {
+        const guess = fmt.parseUnsigned(u8, line, 10) catch {
             try stdout.print("Invalid number.\n");
             continue;
         };

--- a/example/guess_number/main.zig
+++ b/example/guess_number/main.zig
@@ -4,6 +4,8 @@ const io = std.io;
 const fmt = std.fmt;
 const os = std.os;
 
+const allocator = std.debug.global_allocator;
+
 pub fn main() !void {
     var stdout_file = try io.getStdOut();
     const stdout = &stdout_file.outStream().stream;
@@ -19,20 +21,16 @@ pub fn main() !void {
     var prng = std.rand.DefaultPrng.init(seed);
 
     const answer = prng.random.range(u8, 0, 100) + 1;
+    var buf = try std.Buffer.initSize(allocator, 0);
+    defer buf.deinit();
 
     while (true) {
         try stdout.print("\nGuess a number between 1 and 100: ");
-        var line_buf: [20]u8 = undefined;
 
-        const line_len = io.readLine(line_buf[0..]) catch |err| switch (err) {
-            error.InputTooLong => {
-                try stdout.print("Input too long.\n");
-                continue;
-            },
-            error.EndOfFile, error.StdInUnavailable => return err,
-        };
+        const line = try io.readLine(&buf);
+        defer buf.shrink(0);
 
-        const guess = fmt.parseUnsigned(u8, line_buf[0..line_len], 10) catch {
+        const guess = fmt.parseUnsigned(u8, line, 10) catch {
             try stdout.print("Invalid number.\n");
             continue;
         };


### PR DESCRIPTION
Fixes #1709, #1579, #1055

I decided to break the API for this function as I think, taking a `std.Buffer` is a better approach.
* It allows arbitrary sized lines
* The read bytes are available through the buffer, even if `error.EndOfStream` is returned.
* It can easily be wrapped to accept an `[]u8` or `mem.Allocator`
```rust
pub fn readLineSlice(slice: []u8) ![]u8 {
    var buf = try std.Buffer.fromOwnedSlice(debug.failing_allocator, slice);
    return try readLine(&buf);
}

pub fn readLineAlloc(allocator: *mem.Allocator) ![]u8 {
    var buf = try std.Buffer.initSize(allocator, 0);
    _ = try readLine(&buf);
    return buf.toOwnedSlice();
}
```

It now also returns the bytes read, instead of just a length.
