### PR TITLE
Have max/min value of floats be +/-infinity

### DIFF
--- a/std/math/index.zig
+++ b/std/math/index.zig
@@ -777,3 +777,143 @@ test "max value type" {
     const x: u32 = maxInt(i32);
     assert(x == 2147483647);
 }
+
+pub fn maxFloat(comptime T: type) T {
+    return switch (T) {
+        f16 => inf_f16,
+        f32 => inf_f32,
+        f64 => inf_f64,
+        else => @compileError("Expecting type to be a float"),
+    };
+}
+
+test "math.maxFloat" {
+    assert(maxFloat(f16) == inf_f16);
+    assert(maxFloat(f32) == inf_f32);
+    assert(maxFloat(f64) == inf_f64);
+}
+
+pub fn minFloat(comptime T: type) T {
+    return switch (T) {
+        f16 => -inf_f16,
+        f32 => -inf_f32,
+        f64 => -inf_f64,
+        else => @compileError("Expecting type to be a float"),
+    };
+}
+
+test "math.minFloat" {
+    assert(minFloat(f16) == -inf_f16);
+    assert(minFloat(f32) == -inf_f32);
+    assert(minFloat(f64) == -inf_f64);
+}
+
+pub fn maxValue(comptime T: type) T {
+    return switch (@typeId(T)) {
+        TypeId.Int => maxInt(T),
+        TypeId.Float => maxFloat(T),
+        else => @compileError("Expecting type to be a float or int"),
+    };
+}
+
+test "math.maxValue" {
+    assert(maxValue(u0) == 0);
+    assert(maxValue(u1) == 1);
+    assert(maxValue(u8) == 255);
+    assert(maxValue(u16) == 65535);
+    assert(maxValue(u32) == 4294967295);
+    assert(maxValue(u64) == 18446744073709551615);
+
+    assert(maxValue(i0) == 0);
+    assert(maxValue(i1) == 0);
+    assert(maxValue(i8) == 127);
+    assert(maxValue(i16) == 32767);
+    assert(maxValue(i32) == 2147483647);
+    assert(maxValue(i63) == 4611686018427387903);
+    assert(maxValue(i64) == 9223372036854775807);
+
+    assert(maxValue(f16) == inf_f16);
+    assert(maxValue(f32) == inf_f32);
+    assert(maxValue(f64) == inf_f64);
+}
+
+pub fn minValue(comptime T: type) T {
+    return switch (@typeId(T)) {
+        TypeId.Int => minInt(T),
+        TypeId.Float => minFloat(T),
+        else => @compileError("Expecting type to be a float or int"),
+    };
+}
+
+test "math.minValue" {
+    assert(minValue(u0) == 0);
+    assert(minValue(u1) == 0);
+    assert(minValue(u8) == 0);
+    assert(minValue(u16) == 0);
+    assert(minValue(u32) == 0);
+    assert(minValue(u63) == 0);
+    assert(minValue(u64) == 0);
+
+    assert(minValue(i0) == 0);
+    assert(minValue(i1) == -1);
+    assert(minValue(i8) == -128);
+    assert(minValue(i16) == -32768);
+    assert(minValue(i32) == -2147483648);
+    assert(minValue(i63) == -4611686018427387904);
+    assert(minValue(i64) == -9223372036854775808);
+
+    assert(minValue(f16) == -inf_f16);
+    assert(minValue(f32) == -inf_f32);
+    assert(minValue(f64) == -inf_f64);
+}
+
+test "math.minValue" {
+    assert(minValue(f16) < 0);
+    assert(minValue(f16) < maxValue(f16));
+    assert(@intToFloat(f16, minValue(i16)) > minValue(f16));
+    assert(@intToFloat(f16, minValue(i32)) == minValue(f16));
+    assert(@intToFloat(f16, minValue(i64)) == minValue(f16));
+    assert(@intToFloat(f16, minValue(i128)) == minValue(f16));
+
+    assert(minValue(f32) < 0);
+    assert(minValue(f32) < maxValue(f32));
+    assert(@intToFloat(f32, minValue(i16)) > minValue(f32));
+    assert(@intToFloat(f32, minValue(i32)) > minValue(f32));
+    assert(@intToFloat(f32, minValue(i64)) > minValue(f32));
+    assert(@intToFloat(f32, minValue(i128)) > minValue(f32));
+
+    assert(minValue(f64) < 0);
+    assert(minValue(f64) < maxValue(f64));
+    assert(@intToFloat(f64, minValue(i16)) > minValue(f64));
+    assert(@intToFloat(f64, minValue(i32)) > minValue(f64));
+    assert(@intToFloat(f64, minValue(i64)) > minValue(f64));
+    assert(@intToFloat(f64, minValue(i128)) > minValue(f64));
+}
+
+test "math.maxValue" {
+    assert(maxValue(f16) == maxValue(f16));
+    assert(maxValue(f32) == maxValue(f16));
+    assert(maxValue(f64) == maxValue(f16));
+    assert(@intToFloat(f16, maxValue(i16)) < maxValue(f16));
+    assert(@intToFloat(f16, maxValue(u16)) == maxValue(f16));
+    assert(@intToFloat(f16, maxValue(u32)) == maxValue(f16));
+    assert(@intToFloat(f16, maxValue(u64)) == maxValue(f16));
+    assert(@intToFloat(f16, maxValue(u128)) == maxValue(f16));
+
+    assert(f32_max < maxValue(f32));
+    assert(maxValue(f16) == maxValue(f32));
+    assert(maxValue(f32) == maxValue(f32));
+    assert(maxValue(f64) == maxValue(f32));
+    assert(@intToFloat(f32, maxValue(i32)) < maxValue(f32));
+    assert(@intToFloat(f32, maxValue(u32)) < maxValue(f32));
+    assert(@intToFloat(f32, maxValue(u64)) < maxValue(f32));
+    assert(@intToFloat(f32, maxValue(u128)) == maxValue(f32));
+
+    assert(f64_max < maxValue(f64));
+    assert(maxValue(f16) == maxValue(f64));
+    assert(maxValue(f32) == maxValue(f64));
+    assert(maxValue(f64) == maxValue(f64));
+    assert(@intToFloat(f64, maxValue(i64)) < maxValue(f64));
+    assert(@intToFloat(f64, maxValue(u64)) < maxValue(f64));
+    assert(@intToFloat(f64, maxValue(u128)) < maxValue(f64));
+}


### PR DESCRIPTION
I'd made a mistake and min values where wrong and using positive and
negative infinity is a better solution, as pointed out by daurnimator
https://github.com/ziglang/zig/pull/1787#issuecomment-442802030