### PR TITLE
Workaround fixuint causing compiler segfault with u1

### DIFF
--- a/std/special/compiler_rt/fixuint.zig
+++ b/std/special/compiler_rt/fixuint.zig
@@ -4,6 +4,12 @@ const Log2Int = @import("std").math.Log2Int;
 pub fn fixuint(comptime fp_t: type, comptime fixuint_t: type, a: fp_t) fixuint_t {
     @setRuntimeSafety(is_test);
 
+    // Special case u1 otherwise compiler segfaults
+    switch (fixuint_t) {
+        u1 => return if (a <= 0.0) return fixuint_t(0) else fixuint_t(1),
+        else => {},
+    }
+
     const rep_t = switch (fp_t) {
         f32 => u32,
         f64 => u64,

--- a/std/special/compiler_rt/fixuint_test.zig
+++ b/std/special/compiler_rt/fixuint_test.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+const fixuint = @import("fixuint.zig").fixuint;
+
+fn test__fixuint(comptime fp_t: type, comptime fixuint_t: type, a: fp_t, expected: fixuint_t) void {
+    const x = fixuint(fp_t, fixuint_t, a);
+    assert(x == expected);
+}
+
+test "fixuint.u1" {
+    test__fixuint(f32, u1, -1.0, 0);
+    test__fixuint(f32, u1, 0.0, 0);
+    test__fixuint(f32, u1, 1.0, 1);
+    test__fixuint(f32, u1, 2.0, 1);
+}
+


### PR DESCRIPTION
Add fixuint_test.zig to test.