### PR TITLE
zig fmt fixes hard tabs and windows newlines

### DIFF
--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -772,7 +772,7 @@ async fn fmtPath(fmt: *Fmt, file_path_ref: []const u8, check_mode: bool) FmtErro
     };
     defer fmt.loop.allocator.free(source_code);
 
-    var tree = std.zig.parse(fmt.loop.allocator, source_code) catch |err| {
+    var tree = std.zig.parseAndTurnABlindEyeToInvalidWhitespace(fmt.loop.allocator, source_code) catch |err| {
         try stderr.print("error parsing file '{}': {}\n", file_path, err);
         fmt.any_error = true;
         return;

--- a/std/zig/index.zig
+++ b/std/zig/index.zig
@@ -2,6 +2,7 @@ const tokenizer = @import("tokenizer.zig");
 pub const Token = tokenizer.Token;
 pub const Tokenizer = tokenizer.Tokenizer;
 pub const parse = @import("parse.zig").parse;
+pub const parseAndTurnABlindEyeToInvalidWhitespace = @import("parse.zig").parseAndTurnABlindEyeToInvalidWhitespace;
 pub const parseStringLiteral = @import("parse_string_literal.zig").parseStringLiteral;
 pub const render = @import("render.zig").render;
 pub const ast = @import("ast.zig");

--- a/std/zig/parse.zig
+++ b/std/zig/parse.zig
@@ -10,6 +10,12 @@ const Error = ast.Error;
 /// Result should be freed with tree.deinit() when there are
 /// no more references to any of the tokens or nodes.
 pub fn parse(allocator: *mem.Allocator, source: []const u8) !ast.Tree {
+    return _parse(allocator, source, false);
+}
+pub fn parseAndTurnABlindEyeToInvalidWhitespace(allocator: *mem.Allocator, source: []const u8) !ast.Tree {
+    return _parse(allocator, source, true);
+}
+fn _parse(allocator: *mem.Allocator, source: []const u8, turn_a_blind_eye_to_invalid_whitespace: bool) !ast.Tree {
     var tree_arena = std.heap.ArenaAllocator.init(allocator);
     errdefer tree_arena.deinit();
 
@@ -35,6 +41,9 @@ pub fn parse(allocator: *mem.Allocator, source: []const u8) !ast.Tree {
     };
 
     var tokenizer = Tokenizer.init(tree.source);
+    if (turn_a_blind_eye_to_invalid_whitespace) {
+        tokenizer.turn_a_blind_eye_to_invalid_whitespace = true;
+    }
     while (true) {
         const token_ptr = try tree.tokens.addOne();
         token_ptr.* = tokenizer.next();

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -1871,6 +1871,20 @@ test "zig fmt: error return" {
     );
 }
 
+test "zig fmt: fix invalid whitespace" {
+    try testTransform("" ++
+        "fn foo() void {\r\n" ++
+        "\tcall();\r\n" ++
+        "\treturn;\r\n" ++
+        "}\r\n",
+        \\fn foo() void {
+        \\    call();
+        \\    return;
+        \\}
+        \\
+    );
+}
+
 const std = @import("std");
 const mem = std.mem;
 const warn = std.debug.warn;
@@ -1883,7 +1897,7 @@ fn testParse(source: []const u8, allocator: *mem.Allocator, anything_changed: *b
     var stderr_file = try io.getStdErr();
     var stderr = &stderr_file.outStream().stream;
 
-    var tree = try std.zig.parse(allocator, source);
+    var tree = try std.zig.parseAndTurnABlindEyeToInvalidWhitespace(allocator, source);
     defer tree.deinit();
 
     var error_it = tree.errors.iterator(0);


### PR DESCRIPTION
This exposes a very ugly overload in std.zig called parseAndTurnABlindEyeToInvalidWhitespace. `@_@` Hopefully that will make it clear that you're not supposed to use that function for normal operation.

The actual strategy for "fixing" the invalid characters is to ignore them like we ignore whitespace, and then the canonicalization code uses a number of spaces and unix newlines as appropriate, and the invalid whitespace disappears. Note that since the canonicalization looks specifically for `'\n'` characters, this will not necessarily work as you might expect for classic MAC-style newlines that are just `'\r'`, but that's so rare that who cares.