### PR TITLE
docs: Prefer system-ui font-family

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8,7 +8,13 @@
       body{
         background-color:#111;
         color: #bbb;
-        font-family: system-ui, sans-serif;
+        font-family: system-ui,
+          /* Fallbacks for browsers that don't support system-ui */
+          /* https://caniuse.com/#search=system-ui */
+          -apple-system, /* iOS and macOS */
+          Roboto,        /* Android */
+          "Segoe UI",    /* Windows */
+          sans-serif;
       }
       a {
         color: #88f;

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8,7 +8,7 @@
       body{
         background-color:#111;
         color: #bbb;
-        font-family: sans-serif;
+        font-family: system-ui, sans-serif;
       }
       a {
         color: #88f;


### PR DESCRIPTION
system-ui is a new generic font-family for matching the font used in the operating system's native user interface. E.g. Roboto on Android, San Francisco on macOS, Segoe UI on Windows, etc.

https://caniuse.com/#search=system-ui