### PR TITLE
Document explicitly ignoring expression values

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4264,13 +4264,21 @@ fn foo() i32 {
     return 1234;
 }
       {#code_end#}
-      <p>However, if the expression has type {#syntax#}void{#endsyntax#}:</p>
+      <p>However, if the expression has type {#syntax#}void{#endsyntax#}, there will be no error. Function return values can also be explicitly ignored by assigning them to {#syntax#}_{#endsyntax#}. </p>
       {#code_begin|test#}
-test "ignoring expression value" {
-    foo();
+test "void is ignored" {
+    returnsVoid();
 }
 
-fn foo() void {}
+test "explicitly ignoring expression value" {
+    _ = foo();
+}
+
+fn returnsVoid() void {}
+
+fn foo() i32 {
+    return 1234;
+}
       {#code_end#}
       {#header_close#}
 


### PR DESCRIPTION
Adds explanation of how to explicitly ignore expression values in a place which is easier to find for people searching for "error: expression value is ignored" in the documentation.

Resolves  #1825