### PR TITLE
Add a Cirrus config file for FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,16 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+freebsd_test_task:
+  env:
+    CC: "clang70"
+    CXX: "clang++70"
+  install_script:
+    - pkg install -y cmake gmake llvm70
+  build_script:
+    - mkdir build
+    - cd build
+    - cmake .. -DCMAKE_BUILD_TYPE=Release
+    - gmake -j$(sysctl -n hw.ncpu) install
+  test_script:
+    - cd build
+    - ./zig build --build-file ../build.zig test


### PR DESCRIPTION
I enabled Cirrus on my fork in order to test this. An example build log can be found here: https://cirrus-ci.com/task/5722148125540352. Note that the tests are not currently passing; I'm not sure whether that's my fault for how I've set this up (perhaps I'm missing a dependency), so any insight would be appreciated.