### PR TITLE
Fixed Linux version DynLib. 

### DIFF
--- a/std/dynamic_library.zig
+++ b/std/dynamic_library.zig
@@ -19,7 +19,6 @@ pub const DynLib = switch (builtin.os) {
 };
 
 pub const LinuxDynLib = struct {
-    allocator: *mem.Allocator,
     elf_lib: ElfLib,
     fd: i32,
     map_addr: usize,
@@ -27,7 +26,7 @@ pub const LinuxDynLib = struct {
 
     /// Trusts the file
     pub fn open(allocator: *mem.Allocator, path: []const u8) !DynLib {
-        const fd = try std.os.posixOpen(allocator, path, 0, linux.O_RDONLY | linux.O_CLOEXEC);
+        const fd = try std.os.posixOpen(path, 0, linux.O_RDONLY | linux.O_CLOEXEC);
         errdefer std.os.close(fd);
 
         const size = @intCast(usize, (try std.os.posixFStat(fd)).size);
@@ -45,7 +44,6 @@ pub const LinuxDynLib = struct {
         const bytes = @intToPtr([*]align(std.os.page_size) u8, addr)[0..size];
 
         return DynLib{
-            .allocator = allocator,
             .elf_lib = try ElfLib.init(bytes),
             .fd = fd,
             .map_addr = addr,

--- a/std/index.zig
+++ b/std/index.zig
@@ -57,7 +57,8 @@ test "std" {
     _ = @import("mutex.zig");
     _ = @import("segmented_list.zig");
     _ = @import("spinlock.zig");
-
+    
+    _ = @import("dynamic_library.zig");
     _ = @import("base64.zig");
     _ = @import("build.zig");
     _ = @import("c/index.zig");


### PR DESCRIPTION
Removed `allocator` from LinuxDynLib and corrected the call to posixOpen.
Added dynamic_library.zig to std test list.