### PR TITLE
Issue #1851: fix alignedAlloc API to correctly allocate aligned memory;

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5203,6 +5203,16 @@ fn seq(c: u8) void {
       to the generated code to make sure the pointer is aligned as promised.</p>
 
       {#header_close#}
+      {#header_open|@alignedSizeOf#}
+      <pre>{#syntax#}@alignedSizeOf(comptime T: type) comptime_int{#endsyntax#}</pre>
+      <p>
+      This function returns the number of bytes it takes to store and align {#syntax#}T{#endsyntax#} in memory.
+      </p>
+      <p>
+      The result is a target-specific compile time constant.
+      </p>
+      {#see_also|@sizeOf#}
+      {#header_close#}
       {#header_open|@alignOf#}
       <pre>{#syntax#}@alignOf(comptime T: type) comptime_int{#endsyntax#}</pre>
       <p>
@@ -6302,6 +6312,7 @@ pub const FloatMode = enum {
       <p>
       The result is a target-specific compile time constant.
       </p>
+      {#see_also|@alignedSizeOf#}
       {#header_close#}
 
       {#header_open|@sliceToBytes#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5220,6 +5220,20 @@ comptime {
       </p>
       {#see_also|Alignment#}
       {#header_close#}
+      {#header_open|@alignTo#}
+      <pre>{#syntax#}@alignTo(align_from: T, align_to: T) usize{#endsyntax#}</pre>
+      <p>{#syntax#}T{#endsyntax#} must be an unsigned integer type.</p>
+      <p>
+      This function returns the next {#syntax#}T{#endsyntax#} integer that is greater than or equal to {#syntax#}align_from{#endsyntax#} and is a multiple of {#syntax#}align_to{#endsyntax#}.
+      {#syntax#}align_to{#endsyntax#} must be non-zero.
+      </p>
+      <pre>{#syntax#}const assert = @import("std").debug.assert;
+comptime {
+    assert(@alignTo(2, 8) == 8);
+    assert(@alignTo(1, @alignOf(u32)) == @alignOf(u32));
+}{#endsyntax#}</pre>
+      {#see_also|Alignment#}
+      {#header_close#}
       {#header_open|@ArgType#}
       <pre>{#syntax#}@ArgType(comptime T: type, comptime n: usize) type{#endsyntax#}</pre>
       <p>

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1379,6 +1379,7 @@ enum BuiltinFnId {
     BuiltinFnIdMemset,
     BuiltinFnIdSizeof,
     BuiltinFnIdAlignOf,
+    BuiltinFnIdAlignedSizeOf,
     BuiltinFnIdAlignTo,
     BuiltinFnIdMemberCount,
     BuiltinFnIdMemberType,
@@ -2172,6 +2173,7 @@ enum IrInstructionId {
     IrInstructionIdFrameAddress,
     IrInstructionIdHandle,
     IrInstructionIdAlignOf,
+    IrInstructionIdAlignedSizeOf,
     IrInstructionIdAlignTo,
     IrInstructionIdOverflowOp,
     IrInstructionIdTestErr,
@@ -2924,6 +2926,12 @@ struct IrInstructionOverflowOp {
 };
 
 struct IrInstructionAlignOf {
+    IrInstruction base;
+
+    IrInstruction *type_value;
+};
+
+struct IrInstructionAlignedSizeOf {
     IrInstruction base;
 
     IrInstruction *type_value;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1379,6 +1379,7 @@ enum BuiltinFnId {
     BuiltinFnIdMemset,
     BuiltinFnIdSizeof,
     BuiltinFnIdAlignOf,
+    BuiltinFnIdAlignTo,
     BuiltinFnIdMemberCount,
     BuiltinFnIdMemberType,
     BuiltinFnIdMemberName,
@@ -2171,6 +2172,7 @@ enum IrInstructionId {
     IrInstructionIdFrameAddress,
     IrInstructionIdHandle,
     IrInstructionIdAlignOf,
+    IrInstructionIdAlignTo,
     IrInstructionIdOverflowOp,
     IrInstructionIdTestErr,
     IrInstructionIdUnwrapErrCode,
@@ -2925,6 +2927,13 @@ struct IrInstructionAlignOf {
     IrInstruction base;
 
     IrInstruction *type_value;
+};
+
+struct IrInstructionAlignTo {
+    IrInstruction base;
+
+    IrInstruction *align_from;
+    IrInstruction *align_to;
 };
 
 // returns true if error, returns false if not error

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5261,6 +5261,7 @@ static LLVMValueRef ir_render_instruction(CodeGen *g, IrExecutable *executable, 
         case IrInstructionIdMemberType:
         case IrInstructionIdMemberName:
         case IrInstructionIdAlignOf:
+        case IrInstructionIdAlignedSizeOf:
         case IrInstructionIdFnProto:
         case IrInstructionIdTestComptime:
         case IrInstructionIdCheckSwitchProngs:
@@ -6948,6 +6949,7 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdMemset, "memset", 3);
     create_builtin_fn(g, BuiltinFnIdSizeof, "sizeOf", 1);
     create_builtin_fn(g, BuiltinFnIdAlignOf, "alignOf", 1);
+    create_builtin_fn(g, BuiltinFnIdAlignedSizeOf, "alignedSizeOf", 1);
     create_builtin_fn(g, BuiltinFnIdAlignTo, "alignTo", 2);
     create_builtin_fn(g, BuiltinFnIdMemberCount, "memberCount", 1);
     create_builtin_fn(g, BuiltinFnIdMemberType, "memberType", 2);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -806,6 +806,12 @@ static void ir_print_align_of(IrPrint *irp, IrInstructionAlignOf *instruction) {
     fprintf(irp->f, ")");
 }
 
+static void ir_print_aligned_size_of(IrPrint *irp, IrInstructionAlignedSizeOf *instruction) {
+    fprintf(irp->f, "@alignedSizeOf(");
+    ir_print_other_instruction(irp, instruction->type_value);
+    fprintf(irp->f, ")");
+}
+
 static void ir_print_align_to(IrPrint *irp, IrInstructionAlignTo *instruction) {
     fprintf(irp->f, "@alignTo(");
     ir_print_other_instruction(irp, instruction->align_from);
@@ -1630,6 +1636,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdAlignOf:
             ir_print_align_of(irp, (IrInstructionAlignOf *)instruction);
+            break;
+        case IrInstructionIdAlignedSizeOf:
+            ir_print_aligned_size_of(irp, (IrInstructionAlignedSizeOf *)instruction);
             break;
         case IrInstructionIdAlignTo:
             ir_print_align_to(irp, (IrInstructionAlignTo *)instruction);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -806,6 +806,13 @@ static void ir_print_align_of(IrPrint *irp, IrInstructionAlignOf *instruction) {
     fprintf(irp->f, ")");
 }
 
+static void ir_print_align_to(IrPrint *irp, IrInstructionAlignTo *instruction) {
+    fprintf(irp->f, "@alignTo(");
+    ir_print_other_instruction(irp, instruction->align_from);
+    ir_print_other_instruction(irp, instruction->align_to);
+    fprintf(irp->f, ")");
+}
+
 static void ir_print_overflow_op(IrPrint *irp, IrInstructionOverflowOp *instruction) {
     switch (instruction->op) {
         case IrOverflowOpAdd:
@@ -1623,6 +1630,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdAlignOf:
             ir_print_align_of(irp, (IrInstructionAlignOf *)instruction);
+            break;
+        case IrInstructionIdAlignTo:
+            ir_print_align_to(irp, (IrInstructionAlignTo *)instruction);
             break;
         case IrInstructionIdOverflowOp:
             ir_print_overflow_op(irp, (IrInstructionOverflowOp *)instruction);

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -15,7 +15,7 @@
 
 #if defined(_MSC_VER)
 
-#include <intrin.h>  
+#include <intrin.h>
 
 #define ATTRIBUTE_COLD __declspec(noinline)
 #define ATTRIBUTE_PRINTF(a, b)
@@ -130,6 +130,29 @@ static inline T *reallocate_nonzero(T *old, size_t old_count, size_t new_count) 
 template <typename T, size_t n>
 constexpr size_t array_length(const T (&)[n]) {
     return n;
+}
+
+/// Returns the next integer (mod 2**64) that is greater than or equal to
+/// Value and is a multiple of Align. Align must be non-zero.
+///
+/// If non-zero Skew is specified, the return value will be a minimal
+/// integer that is greater than or equal to Value and equal to
+/// Align * N + Skew for some integer N. If Skew is larger than Align,
+/// its value is adjusted to 'Skew mod Align'.
+///
+/// Examples:
+/// ```
+///   alignTo(2, 8) = 8
+///   alignTo(20, 8) = 24
+///   alignTo(~0LL, 8) = 0
+///   // With Skew:
+///   alignTo(5, 8, 7) = 7
+/// ```
+template <typename T>
+static inline T alignTo(T val, T align, T skew = 0) {
+    assert(align != 0u && "cannot align to 0");
+    skew %= align;
+    return (((val + align - 1 - skew) / align) * align) + skew;
 }
 
 template <typename T>

--- a/std/array_list.zig
+++ b/std/array_list.zig
@@ -80,7 +80,7 @@ pub fn AlignedArrayList(comptime T: type, comptime A: u29) type {
         /// The caller owns the returned memory. ArrayList becomes empty.
         pub fn toOwnedSlice(self: *Self) []align(A) T {
             const allocator = self.allocator;
-            const result = allocator.alignedShrink(T, A, self.items, self.len);
+            const result = allocator.alignedShrink(T, self.items, self.len, null);
             self.* = init(allocator);
             return result;
         }
@@ -153,7 +153,7 @@ pub fn AlignedArrayList(comptime T: type, comptime A: u29) type {
                 better_capacity += better_capacity / 2 + 8;
                 if (better_capacity >= new_capacity) break;
             }
-            self.items = try self.allocator.alignedRealloc(T, A, self.items, better_capacity);
+            self.items = try self.allocator.alignedRealloc(T, self.items, better_capacity, null);
         }
 
         pub fn addOne(self: *Self) !*T {

--- a/std/cstr.zig
+++ b/std/cstr.zig
@@ -76,7 +76,7 @@ pub const NullTerminated2DArray = struct {
         const index_size = @sizeOf(usize) * new_len; // size of the ptrs
         byte_count += index_size;
 
-        const buf = try allocator.alignedAlloc(u8, @alignOf(?*u8), byte_count);
+        const buf = @sliceToBytes(try allocator.alignedAlloc(?*u8, 0, byte_count));
         errdefer allocator.free(buf);
 
         var write_index = index_size;

--- a/std/debug/index.zig
+++ b/std/debug/index.zig
@@ -1559,7 +1559,7 @@ fn getLineNumberInfoMacOs(di: *DebugInfo, symbol: MachoSymbol, target_address: u
         const ofile_path = mem.toSliceConst(u8, di.strings.ptr + ofile.n_strx);
 
         gop.kv.value = MachOFile{
-            .bytes = try std.io.readFileAllocAligned(di.ofiles.allocator, ofile_path, @alignOf(macho.mach_header_64)),
+            .bytes = try std.io.readFileAllocAligned(di.ofiles.allocator, ofile_path, macho.mach_header_64),
             .sect_debug_info = null,
             .sect_debug_line = null,
         };

--- a/std/io.zig
+++ b/std/io.zig
@@ -280,16 +280,17 @@ pub fn writeFile(path: []const u8, data: []const u8) !void {
 
 /// On success, caller owns returned buffer.
 pub fn readFileAlloc(allocator: *mem.Allocator, path: []const u8) ![]u8 {
-    return readFileAllocAligned(allocator, path, @alignOf(u8));
+    return readFileAllocAligned(allocator, path, u8);
 }
 
 /// On success, caller owns returned buffer.
-pub fn readFileAllocAligned(allocator: *mem.Allocator, path: []const u8, comptime A: u29) ![]align(A) u8 {
+pub fn readFileAllocAligned(allocator: *mem.Allocator, path: []const u8, comptime T: type) ![]align(@alignOf(T)) u8 {
     var file = try File.openRead(path);
     defer file.close();
 
     const size = try file.getEndPos();
-    const buf = try allocator.alignedAlloc(u8, A, size);
+    // cast to u8
+    const buf = @sliceToBytes( (try allocator.alignedAlloc(T, 0, size))[0..] );
     errdefer allocator.free(buf);
 
     var adapter = file.inStream();

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -2172,7 +2172,7 @@ pub fn argsAlloc(allocator: *mem.Allocator) ![]const []u8 {
     const slice_sizes = slice_list.toSliceConst();
     const slice_list_bytes = try math.mul(usize, @sizeOf([]u8), slice_sizes.len);
     const total_bytes = try math.add(usize, slice_list_bytes, contents_slice.len);
-    const buf = try allocator.alignedAlloc(u8, @alignOf([]u8), total_bytes);
+    const buf = @sliceToBytes(try allocator.alignedAlloc([]u8, 0, total_bytes));
     errdefer allocator.free(buf);
 
     const result_slice_list = @bytesToSlice([]u8, buf[0..slice_list_bytes]);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,6 +2,44 @@ const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "@alignTo: attempting to align at zero length boundary",
+        \\comptime {
+        \\    _ = @alignTo(1, 0);
+        \\}
+    ,
+        ".tmp_source.zig:2:9: error: @alignTo cannot align to 0",
+    );
+
+    cases.add(
+        "@alignTo: using negative comptime_int (from)",
+        \\comptime {
+        \\    _ = @alignTo(-1, 8);
+        \\}
+    ,
+        ".tmp_source.zig:2:9: error: @alignTo cannot operate on negative integers",
+    );
+
+    cases.add(
+        "@alignTo: using negative comptime_int (to)",
+        \\comptime {
+        \\    _ = @alignTo(1, -8);
+        \\}
+    ,
+        ".tmp_source.zig:2:9: error: @alignTo cannot operate on negative integers",
+    );
+
+    cases.add(
+        "@alignTo: using signed integers at runtime",
+        \\export fn entry() void {
+        \\    var isize_from: isize = 1;
+        \\    var isize_to: isize = 8;
+        \\    _ = @alignTo(isize_from, isize_to);
+        \\}
+    ,
+        ".tmp_source.zig:4:18: error: expected type 'usize', found 'isize'",
+    );
+
+    cases.add(
         "@bitCast same size but bit count mismatch",
         \\export fn entry(byte: u8) void {
         \\    var oops = @bitCast(u7, byte);

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -19,6 +19,7 @@ comptime {
     _ = @import("behavior/bugs/1421.zig");
     _ = @import("behavior/bugs/1442.zig");
     _ = @import("behavior/bugs/1486.zig");
+    _ = @import("behavior/bugs/1851.zig");
     _ = @import("behavior/bugs/394.zig");
     _ = @import("behavior/bugs/655.zig");
     _ = @import("behavior/bugs/656.zig");

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -1,6 +1,7 @@
 comptime {
     _ = @import("behavior/align.zig");
     _ = @import("behavior/alignof.zig");
+    _ = @import("behavior/alignto.zig");
     _ = @import("behavior/array.zig");
     _ = @import("behavior/asm.zig");
     _ = @import("behavior/atomics.zig");

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -1,5 +1,6 @@
 comptime {
     _ = @import("behavior/align.zig");
+    _ = @import("behavior/alignedsizeof.zig");
     _ = @import("behavior/alignof.zig");
     _ = @import("behavior/alignto.zig");
     _ = @import("behavior/array.zig");

--- a/test/stage1/behavior/alignedsizeof.zig
+++ b/test/stage1/behavior/alignedsizeof.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const builtin = @import("builtin");
+const maxInt = std.math.maxInt;
+
+const Foo = struct {
+    w: u32,
+    x: u32,
+    y: u32,
+    z: u24,
+};
+
+const FooPacked = packed struct {
+    w: u32,
+    x: u32,
+    y: u32,
+    z: u24,
+};
+
+test "@alignedSizeOf(T) before referencing T" {
+    comptime assert(@alignedSizeOf(Foo) != maxInt(usize));
+    if (builtin.arch != builtin.Arch.x86_64) {
+        return error.SkipZigTest;
+    }
+
+    //Foo type
+    comptime assert(@sizeOf(Foo) == 16);
+    comptime assert(@alignOf(Foo) == 4);
+    comptime assert(@alignedSizeOf(Foo) == 16);
+
+    //FooPacked type
+    comptime assert(@sizeOf(FooPacked) == 15);
+    comptime assert(@alignOf(FooPacked) == 1);
+    comptime assert(@alignedSizeOf(FooPacked) == 15);
+
+    //u24 type
+    comptime assert(@sizeOf(u24) == 3);
+    comptime assert(@alignOf(u24) == 4);
+    comptime assert(@alignedSizeOf(u24) == 4);
+}

--- a/test/stage1/behavior/alignof.zig
+++ b/test/stage1/behavior/alignof.zig
@@ -11,8 +11,9 @@ const Foo = struct {
 
 test "@alignOf(T) before referencing T" {
     comptime assertOrPanic(@alignOf(Foo) != maxInt(usize));
-    if (builtin.arch == builtin.Arch.x86_64) {
-        comptime assertOrPanic(@alignOf(Foo) == 4);
+    if (builtin.arch != builtin.Arch.x86_64) {
+        return error.SkipZigTest;
     }
+    comptime assertOrPanic(@alignOf(Foo) == 4);
 }
 

--- a/test/stage1/behavior/alignto.zig
+++ b/test/stage1/behavior/alignto.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+test "@alignTo" {
+    comptime testAlignTo();
+    testAlignTo();
+
+    assert(testAlignToCallSite(5, 8) == 8);
+    assert(testAlignToCallSite(17, 8) == 24);
+    assert(testAlignToCallSite(~usize(0), 8) == 0);
+    assert(testAlignToCallSite(321, 255) == 510);
+}
+
+fn testAlignTo() void {
+    assert(@alignTo(5, 8) == 8);
+    assert(@alignTo(17, 8) == 24);
+    assert(@alignTo(~usize(0), 8) == 0);
+    assert(@alignTo(321, 255) == 510);
+}
+
+fn testAlignToCallSite(from: usize, to: usize) usize {
+    return @alignTo(from, to);
+}

--- a/test/stage1/behavior/bugs/1851.zig
+++ b/test/stage1/behavior/bugs/1851.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const debug = std.debug;
+const assert = debug.assert;
+const builtin = @import("builtin");
+
+test "allocator correctly allocates aligned memory"
+{
+    if (builtin.arch != builtin.Arch.x86_64) {
+        return error.SkipZigTest;
+    }
+
+    assert(@sizeOf(u24) == 3);
+    assert(@alignOf(u24) == 4);
+    assert(@alignedSizeOf(u24) == 4);
+
+    var two_u24 = try debug.global_allocator.alloc(u24, 2);
+    assert(two_u24.len == 2); // should give us two u24s
+    var two_u24_bytes = @sliceToBytes(two_u24);
+    assert(two_u24_bytes.len == 8); // bug was that it was assigning 6 bytes instead of 8
+
+    two_u24[0] = 0xFFFFFF;
+    two_u24[1] = 0xFFFFFF;
+
+    // operate on bytes
+    for(@alignCast(1, two_u24_bytes)) |*b| b.* = 0x00;
+
+    assert(two_u24[0] == 0x00);
+    assert(two_u24[1] == 0x00);
+}

--- a/test/stage1/behavior/sizeof_and_typeof.zig
+++ b/test/stage1/behavior/sizeof_and_typeof.zig
@@ -4,6 +4,7 @@ const assertOrPanic = @import("std").debug.assertOrPanic;
 test "@sizeOf and @typeOf" {
     const y: @typeOf(x) = 120;
     assertOrPanic(@sizeOf(@typeOf(y)) == 2);
+    assertOrPanic(@sizeOf(u24) == 3);
 }
 const x: u16 = 13;
 const z: @typeOf(x) = 19;


### PR DESCRIPTION
Fixes #1851

`@alignTo(from: T, to: T)` 82c4c71
* [X] Implementation
* [X] Documentation
* [X] Test Cases
  * [X] non-zero
  * [X] negative comptime
  * [X] non-unsigned integer

`@alignedSizeOf(T)` 2f26126
* [X] Implementation
* [X] Documentation
* [X] Test Cases

`alignedAlloc` 413db10 a9b59ef
* [X] Implementation
* [X] Documentation
* [X] Test Cases
  * [X] issue 1851

--------

On a side-note, this will be my last PR of 2018. I want to say thanks to everyone in the community for a fun and enjoyable 2018. I look forward to a productive 2019 with everyone! Happy New Year!

