### PR TITLE
Mark comptime int hardcoded address pointee as a run time variable #1171

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -20363,6 +20363,7 @@ static IrInstruction *ir_analyze_instruction_int_to_ptr(IrAnalyze *ira, IrInstru
 
         IrInstruction *result = ir_const(ira, &instruction->base, dest_type);
         result->value.data.x_ptr.special = ConstPtrSpecialHardCodedAddr;
+        result->value.data.x_ptr.mut = ConstPtrMutRuntimeVar;
         result->value.data.x_ptr.data.hard_coded_addr.addr = bigint_as_unsigned(&val->data.x_bigint);
         return result;
     }

--- a/test/cases/inttoptr.zig
+++ b/test/cases/inttoptr.zig
@@ -11,3 +11,17 @@ fn randomAddressToFunction() void {
     var addr: usize = 0xdeadbeef;
     var ptr = @intToPtr(fn () void, addr);
 }
+
+test "mutate through ptr initialized with constant intToPtr value" {
+    forceCompilerAnalyzeBranchHardCodedPtrDereference(false);
+}
+
+fn forceCompilerAnalyzeBranchHardCodedPtrDereference(x: bool) void {
+    const hardCodedP = @intToPtr(*volatile u8, 0xdeadbeef);
+    if (x) {
+        hardCodedP.* = hardCodedP.* | 10;
+    } else {
+        return;
+    }
+}
+    


### PR DESCRIPTION
This fixes the compiler error from #1171.

Without this line, it was set to `ConstPtrMutComptimeVar`.