### PR TITLE
Make std/index.zig tests compile on FreeBSD

### DIFF
--- a/std/c/freebsd.zig
+++ b/std/c/freebsd.zig
@@ -93,3 +93,28 @@ pub const dirent = extern struct {
     d_pad1: u16,
     d_name: [256]u8,
 };
+
+pub const in_port_t = u16;
+pub const sa_family_t = u16;
+
+pub const sockaddr = extern union {
+    in: sockaddr_in,
+    in6: sockaddr_in6,
+};
+
+pub const sockaddr_in = extern struct {
+    len: u8,
+    family: sa_family_t,
+    port: in_port_t,
+    addr: [16]u8,
+    zero: [8]u8,
+};
+
+pub const sockaddr_in6 = extern struct {
+    len: u8,
+    family: sa_family_t,
+    port: in_port_t,
+    flowinfo: u32,
+    addr: [16]u8,
+    scope_id: u32,
+};

--- a/std/c/freebsd.zig
+++ b/std/c/freebsd.zig
@@ -22,6 +22,8 @@ pub extern "c" fn openat(fd: c_int, path: ?[*]const u8, flags: c_int) c_int;
 pub extern "c" fn setgid(ruid: c_uint, euid: c_uint) c_int;
 pub extern "c" fn setuid(uid: c_uint) c_int;
 pub extern "c" fn kill(pid: c_int, sig: c_int) c_int;
+pub extern "c" fn clock_gettime(clk_id: c_int, tp: *timespec) c_int;
+pub extern "c" fn clock_getres(clk_id: c_int, tp: *timespec) c_int;
 
 /// Renamed from `kevent` to `Kevent` to avoid conflict with function name.
 pub const Kevent = extern struct {

--- a/std/os/freebsd/index.zig
+++ b/std/os/freebsd/index.zig
@@ -26,6 +26,21 @@ pub const PROT_READ = 1;
 pub const PROT_WRITE = 2;
 pub const PROT_EXEC = 4;
 
+pub const CLOCK_REALTIME = 0;
+pub const CLOCK_VIRTUAL = 1;
+pub const CLOCK_PROF = 2;
+pub const CLOCK_MONOTONIC = 4;
+pub const CLOCK_UPTIME = 5;
+pub const CLOCK_UPTIME_PRECISE = 7;
+pub const CLOCK_UPTIME_FAST = 8;
+pub const CLOCK_REALTIME_PRECISE = 9;
+pub const CLOCK_REALTIME_FAST = 10;
+pub const CLOCK_MONOTONIC_PRECISE = 11;
+pub const CLOCK_MONOTONIC_FAST = 12;
+pub const CLOCK_SECOND = 13;
+pub const CLOCK_THREAD_CPUTIME_ID = 14;
+pub const CLOCK_PROCESS_CPUTIME_ID = 15;
+
 pub const MAP_FAILED = maxInt(usize);
 pub const MAP_SHARED = 0x0001;
 pub const MAP_PRIVATE = 0x0002;

--- a/std/os/freebsd/index.zig
+++ b/std/os/freebsd/index.zig
@@ -714,6 +714,14 @@ pub fn nanosleep(req: *const timespec, rem: ?*timespec) usize {
     return errnoWrap(c.nanosleep(req, rem));
 }
 
+pub fn clock_gettime(clk_id: i32, tp: *timespec) usize {
+    return errnoWrap(c.clock_gettime(clk_id, tp));
+}
+
+pub fn clock_getres(clk_id: i32, tp: *timespec) usize {
+    return clock_gettime(clk_id, tp);
+}
+
 pub fn setuid(uid: u32) usize {
     return errnoWrap(c.setuid(uid));
 }

--- a/std/os/freebsd/index.zig
+++ b/std/os/freebsd/index.zig
@@ -525,6 +525,10 @@ pub const TIOCGPKT = 0x80045438;
 pub const TIOCGPTLCK = 0x80045439;
 pub const TIOCGEXCL = 0x80045440;
 
+pub const sockaddr = c.sockaddr;
+pub const sockaddr_in = c.sockaddr_in;
+pub const sockaddr_in6 = c.sockaddr_in6;
+
 fn unsigned(s: i32) u32 {
     return @bitCast(u32, s);
 }

--- a/std/os/time.zig
+++ b/std/os/time.zig
@@ -61,7 +61,7 @@ pub fn timestamp() u64 {
 /// Get the posix timestamp, UTC, in milliseconds
 pub const milliTimestamp = switch (builtin.os) {
     Os.windows => milliTimestampWindows,
-    Os.linux => milliTimestampPosix,
+    Os.linux, Os.freebsd => milliTimestampPosix,
     Os.macosx, Os.ios => milliTimestampDarwin,
     else => @compileError("Unsupported OS"),
 };
@@ -179,7 +179,7 @@ pub const Timer = struct {
                 debug.assert(err != windows.FALSE);
                 self.start_time = @intCast(u64, start_time);
             },
-            Os.linux => {
+            Os.linux, Os.freebsd => {
                 //On Linux, seccomp can do arbitrary things to our ability to call
                 //  syscalls, including return any errno value it wants and
                 //  inconsistently throwing errors. Since we can't account for
@@ -215,7 +215,7 @@ pub const Timer = struct {
         var clock = clockNative() - self.start_time;
         return switch (builtin.os) {
             Os.windows => @divFloor(clock * ns_per_s, self.frequency),
-            Os.linux => clock,
+            Os.linux, Os.freebsd => clock,
             Os.macosx, Os.ios => @divFloor(clock * self.frequency.numer, self.frequency.denom),
             else => @compileError("Unsupported OS"),
         };
@@ -236,7 +236,7 @@ pub const Timer = struct {
 
     const clockNative = switch (builtin.os) {
         Os.windows => clockWindows,
-        Os.linux => clockLinux,
+        Os.linux, Os.freebsd => clockLinux,
         Os.macosx, Os.ios => clockDarwin,
         else => @compileError("Unsupported OS"),
     };


### PR DESCRIPTION
Implements some clock and sockaddr related functions and definitions that was
preventing `std/index.zig` to compile the tests.

We cannot enable the CI tests yet because the `std/event/fs.zig` tests hang on
"[write a file, watch it, write it again..](https://github.com/ziglang/zig/blob/master/std/event/fs.zig#L1310)"