### PR TITLE
freebsd: fix wrong call to clock_getres

### DIFF
--- a/std/os/freebsd/index.zig
+++ b/std/os/freebsd/index.zig
@@ -723,7 +723,7 @@ pub fn clock_gettime(clk_id: i32, tp: *timespec) usize {
 }
 
 pub fn clock_getres(clk_id: i32, tp: *timespec) usize {
-    return clock_gettime(clk_id, tp);
+    return errnoWrap(c.clock_getres(clk_id, tp));
 }
 
 pub fn setuid(uid: u32) usize {


### PR DESCRIPTION
Thanks @daurnimator