### PR TITLE
stage1: hint at use of and/or when &&/|| is improperly used

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6024,7 +6024,7 @@ fn add(a: i32, b: i32) i32 {
       This is typically used for type safety when interacting with C code that does not expose struct details.
       Example:
       </p>
-      {#code_begin|test_err|expected type '*Derp', found '*Wat'#}
+      {#code_begin|test_err|expected '*Derp' type, found '*Wat'#}
 const Derp = @OpaqueType();
 const Wat = @OpaqueType();
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -122,18 +122,36 @@ static AstNode *ast_parse_container_decl_type(ParseContext *pc);
 static AstNode *ast_parse_byte_align(ParseContext *pc);
 
 ATTRIBUTE_PRINTF(3, 4)
-ATTRIBUTE_NORETURN
-static void ast_error(ParseContext *pc, Token *token, const char *format, ...) {
+static ErrorMsg *ast_error(ParseContext *pc, Token *token, const char *format, ...) {
     va_list ap;
     va_start(ap, format);
     Buf *msg = buf_vprintf(format, ap);
     va_end(ap);
 
+    ErrorMsg *err = err_msg_create_with_line(pc->owner->path, token->start_line, token->start_column,
+            pc->owner->source_code, pc->owner->line_offsets, msg);
+    err->line_start = token->start_line;
+    err->column_start = token->start_column;
+
+    return err;
+}
+
+ATTRIBUTE_PRINTF(4, 5)
+ATTRIBUTE_NORETURN
+static void ast_error_exit(ParseContext *pc, Token *token, ErrorMsg *note, const char *format, ...) {
+    va_list ap;
+    va_start(ap, format);
+    Buf *msg = buf_vprintf(format, ap);
+    va_end(ap);
 
     ErrorMsg *err = err_msg_create_with_line(pc->owner->path, token->start_line, token->start_column,
             pc->owner->source_code, pc->owner->line_offsets, msg);
     err->line_start = token->start_line;
     err->column_start = token->start_column;
+
+    if (note) {
+      err->notes.append(note);
+    }
 
     print_err_msg(err, pc->err_color);
     exit(EXIT_FAILURE);
@@ -164,7 +182,7 @@ static Buf ast_token_str(Buf *input, Token *token) {
 ATTRIBUTE_NORETURN
 static void ast_invalid_token_error(ParseContext *pc, Token *token) {
     Buf token_value = ast_token_str(pc->buf, token);
-    ast_error(pc, token, "invalid token: '%s'", buf_ptr(&token_value));
+    ast_error_exit(pc, token, NULL, "invalid token: '%s'", buf_ptr(&token_value));
 }
 
 static AstNode *ast_create_node_no_line_info(ParseContext *pc, NodeType type) {
@@ -214,8 +232,13 @@ static Token *eat_token_if(ParseContext *pc, TokenId id) {
 
 static Token *expect_token(ParseContext *pc, TokenId id) {
     Token *res = eat_token(pc);
-    if (res->id != id)
-        ast_error(pc, res, "expected token '%s', found '%s'", token_name(id), token_name(res->id));
+    if (res->id != id) {
+        ErrorMsg *note = NULL;
+        if (res->id == TokenIdAmpersandAmpersand) {
+            note = ast_error(pc, res, "did you mean to use `and`?");
+        }
+        ast_error_exit(pc, res, note, "expected token '%s', found '%s'", token_name(id), token_name(res->id));
+    }
 
     return res;
 }
@@ -837,7 +860,7 @@ static AstNode *ast_parse_fn_proto(ParseContext *pc) {
         if (param_decl->data.param_decl.is_var_args)
             res->data.fn_proto.is_var_args = true;
         if (i != params.length - 1 && res->data.fn_proto.is_var_args)
-            ast_error(pc, first, "Function prototype have varargs as a none last paramter.");
+            ast_error_exit(pc, first, NULL, "Function prototype have varargs as a none last paramter.");
     }
     return res;
 }

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -199,6 +199,7 @@ enum TokenizeState {
     TokenizeStateSawDash,
     TokenizeStateSawMinusPercent,
     TokenizeStateSawAmpersand,
+    TokenizeStateSawAmpersandAmpersand,
     TokenizeStateSawCaret,
     TokenizeStateSawBar,
     TokenizeStateSawBarBar,
@@ -891,6 +892,10 @@ void tokenize(Buf *buf, Tokenization *out) {
                         end_token(&t);
                         t.state = TokenizeStateStart;
                         break;
+                    case '&':
+                        set_token_id(&t, t.cur_tok, TokenIdAmpersandAmpersand);
+                        t.state = TokenizeStateSawAmpersandAmpersand;
+                        break;
                     default:
                         t.pos -= 1;
                         end_token(&t);
@@ -898,6 +903,11 @@ void tokenize(Buf *buf, Tokenization *out) {
                         continue;
                 }
                 break;
+            case TokenizeStateSawAmpersandAmpersand:
+                t.pos -= 1;
+                end_token(&t);
+                t.state = TokenizeStateStart;
+                continue;
             case TokenizeStateSawCaret:
                 switch (c) {
                     case '=':
@@ -1468,6 +1478,7 @@ void tokenize(Buf *buf, Tokenization *out) {
         case TokenizeStateSawPlus:
         case TokenizeStateSawDash:
         case TokenizeStateSawAmpersand:
+        case TokenizeStateSawAmpersandAmpersand:
         case TokenizeStateSawCaret:
         case TokenizeStateSawBar:
         case TokenizeStateSawEq:
@@ -1515,6 +1526,7 @@ void tokenize(Buf *buf, Tokenization *out) {
 const char * token_name(TokenId id) {
     switch (id) {
         case TokenIdAmpersand: return "&";
+        case TokenIdAmpersandAmpersand: return "&&";
         case TokenIdArrow: return "->";
         case TokenIdAtSign: return "@";
         case TokenIdBang: return "!";

--- a/src/tokenizer.hpp
+++ b/src/tokenizer.hpp
@@ -14,6 +14,7 @@
 
 enum TokenId {
     TokenIdAmpersand,
+    TokenIdAmpersandAmpersand,
     TokenIdArrow,
     TokenIdAtSign,
     TokenIdBang,

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -59,7 +59,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    do_the_thing(bar);
         \\}
     ,
-        ".tmp_source.zig:4:18: error: expected type 'fn(i32) void', found 'fn(bool) void",
+        ".tmp_source.zig:4:18: error: expected 'fn(i32) void' type, found 'fn(bool) void",
         ".tmp_source.zig:4:18: note: parameter 0: 'bool' cannot cast into 'i32'",
     );
 
@@ -95,7 +95,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     ,
         ".tmp_source.zig:3:31: error: integer value 300 cannot be implicitly casted to type 'u8'",
         ".tmp_source.zig:7:22: error: integer value 300 cannot be implicitly casted to type 'u8'",
-        ".tmp_source.zig:11:20: error: expected type 'u8', found 'u16'",
+        ".tmp_source.zig:11:20: error: expected 'u8' type, found 'u16'",
     );
 
     cases.add(
@@ -115,7 +115,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(y)); }
     ,
-        ".tmp_source.zig:2:14: error: expected type 'f32', found 'f64'",
+        ".tmp_source.zig:2:14: error: expected 'f32' type, found 'f64'",
     );
 
     cases.add(
@@ -163,7 +163,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var ptr2: *c_void = &b;
         \\}
     ,
-        ".tmp_source.zig:5:26: error: expected type '*c_void', found '**u32'",
+        ".tmp_source.zig:5:26: error: expected '*c_void' type, found '**u32'",
     );
 
     cases.add(
@@ -213,7 +213,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const sliceA: []u8 = &buffer;
         \\}
     ,
-        ".tmp_source.zig:3:27: error: expected type '[]u8', found '*const [1]u8'",
+        ".tmp_source.zig:3:27: error: expected '[]u8' type, found '*const [1]u8'",
     );
 
     cases.add(
@@ -754,7 +754,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
             \\
             \\fn bar(x: *b.Foo) void {}
         ,
-            ".tmp_source.zig:6:10: error: expected type '*Foo', found '*Foo'",
+            ".tmp_source.zig:6:10: error: expected '*Foo' type, found '*Foo'",
             ".tmp_source.zig:6:10: note: pointer type child 'Foo' cannot cast into pointer type child 'Foo'",
             "a.zig:1:17: note: Foo declared here",
             "b.zig:1:17: note: Foo declared here",
@@ -824,7 +824,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var y = p.*;
         \\}
     ,
-        ".tmp_source.zig:4:23: error: expected type '*?*i32', found '**i32'",
+        ".tmp_source.zig:4:23: error: expected '*?*i32' type, found '**i32'",
     );
 
     cases.add(
@@ -833,7 +833,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x: [*]const bool = true;
         \\}
     ,
-        ".tmp_source.zig:2:30: error: expected type '[*]const bool', found 'bool'",
+        ".tmp_source.zig:2:30: error: expected '[*]const bool' type, found 'bool'",
     );
 
     cases.add(
@@ -878,7 +878,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var rule_set = try Foo.init();
         \\}
     ,
-        ".tmp_source.zig:2:13: error: expected type 'i32', found 'type'",
+        ".tmp_source.zig:2:13: error: expected 'i32' type, found 'type'",
     );
 
     cases.add(
@@ -912,7 +912,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return null;
         \\}
     ,
-        ".tmp_source.zig:5:34: error: expected type '?NextError!i32', found '?OtherError!i32'",
+        ".tmp_source.zig:5:34: error: expected '?NextError!i32' type, found '?OtherError!i32'",
         ".tmp_source.zig:5:34: note: optional type child 'OtherError!i32' cannot cast into optional type child 'NextError!i32'",
         ".tmp_source.zig:5:34: note: error set 'OtherError' cannot cast into error set 'NextError'",
         ".tmp_source.zig:2:26: note: 'error.OutOfMemory' not a member of destination error set",
@@ -982,7 +982,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @panic(e);
         \\}
     ,
-        ".tmp_source.zig:3:12: error: expected type '[]const u8', found 'error{Foo}'",
+        ".tmp_source.zig:3:12: error: expected '[]const u8' type, found 'error{Foo}'",
     );
 
     cases.add(
@@ -1010,7 +1010,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return error.ShouldBeCompileError;
         \\}
     ,
-        ".tmp_source.zig:6:17: error: expected type 'void', found 'error{ShouldBeCompileError}'",
+        ".tmp_source.zig:6:17: error: expected 'void' type, found 'error{ShouldBeCompileError}'",
     );
 
     cases.add(
@@ -1053,7 +1053,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a(c);
         \\}
     ,
-        ".tmp_source.zig:8:7: error: expected type 'fn(*const u8) void', found 'fn(u8) void'",
+        ".tmp_source.zig:8:7: error: expected 'fn(*const u8) void' type, found 'fn(u8) void'",
     );
 
     cases.add(
@@ -1135,7 +1135,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\        E.One => {},
         \\    }
         \\}
-    , ".tmp_source.zig:9:10: error: expected type 'usize', found 'E'");
+    , ".tmp_source.zig:9:10: error: expected 'usize' type, found 'E'");
 
     cases.add(
         "range operator in switch used on error set",
@@ -1181,7 +1181,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const z = i32!i32;
         \\}
     ,
-        ".tmp_source.zig:2:15: error: expected error set type, found type 'i32'",
+        ".tmp_source.zig:2:15: error: expected error set type, found 'i32'",
     );
 
     cases.add(
@@ -1231,7 +1231,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return error.B;
         \\}
     ,
-        ".tmp_source.zig:3:35: error: expected type 'SmallErrorSet!i32', found 'anyerror!i32'",
+        ".tmp_source.zig:3:35: error: expected 'SmallErrorSet!i32' type, found 'anyerror!i32'",
         ".tmp_source.zig:3:35: note: error set 'anyerror' cannot cast into error set 'SmallErrorSet'",
         ".tmp_source.zig:3:35: note: cannot cast global error set into smaller set",
     );
@@ -1246,7 +1246,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return error.B;
         \\}
     ,
-        ".tmp_source.zig:3:31: error: expected type 'SmallErrorSet', found 'anyerror'",
+        ".tmp_source.zig:3:31: error: expected 'SmallErrorSet' type, found 'anyerror'",
         ".tmp_source.zig:3:31: note: cannot cast global error set into smaller set",
     );
 
@@ -1273,7 +1273,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x: Set2 = set1;
         \\}
     ,
-        ".tmp_source.zig:7:19: error: expected type 'Set2', found 'Set1'",
+        ".tmp_source.zig:7:19: error: expected 'Set2' type, found 'Set1'",
         ".tmp_source.zig:1:23: note: 'error.B' not a member of destination error set",
     );
 
@@ -1813,7 +1813,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn a() noreturn {return;}
         \\export fn entry() void { a(); }
     ,
-        ".tmp_source.zig:1:18: error: expected type 'noreturn', found 'void'",
+        ".tmp_source.zig:1:18: error: expected 'noreturn' type, found 'void'",
     );
 
     cases.add(
@@ -1821,7 +1821,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn a() i32 {}
         \\export fn entry() void { _ = a(); }
     ,
-        ".tmp_source.zig:1:12: error: expected type 'i32', found 'void'",
+        ".tmp_source.zig:1:12: error: expected 'i32' type, found 'void'",
     );
 
     cases.add(
@@ -1927,7 +1927,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return a;
         \\}
     ,
-        ".tmp_source.zig:3:12: error: expected type 'i32', found '[*]const u8'",
+        ".tmp_source.zig:3:12: error: expected 'i32' type, found '[*]const u8'",
     );
 
     cases.add(
@@ -1936,7 +1936,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    if (0) {}
         \\}
     ,
-        ".tmp_source.zig:2:9: error: expected type 'bool', found 'comptime_int'",
+        ".tmp_source.zig:2:9: error: expected 'bool' type, found 'comptime_int'",
     );
 
     cases.add(
@@ -2031,8 +2031,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    array[bad] = array[bad];
         \\}
     ,
-        ".tmp_source.zig:4:11: error: expected type 'usize', found 'bool'",
-        ".tmp_source.zig:4:24: error: expected type 'usize', found 'bool'",
+        ".tmp_source.zig:4:11: error: expected 'usize' type, found 'bool'",
+        ".tmp_source.zig:4:24: error: expected 'usize' type, found 'bool'",
     );
 
     cases.add(
@@ -2446,7 +2446,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn foo() *const i32 { return y; }
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:3:30: error: expected type '*const i32', found '*const comptime_int'",
+        ".tmp_source.zig:3:30: error: expected '*const i32' type, found '*const comptime_int'",
     );
 
     cases.add(
@@ -2524,7 +2524,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn c() i32 {return 2;}
         \\export fn entry() usize { return @sizeOf(@typeOf(fns)); }
     ,
-        ".tmp_source.zig:1:27: error: expected type 'fn() void', found 'fn() i32'",
+        ".tmp_source.zig:1:27: error: expected 'fn() void' type, found 'fn() i32'",
     );
 
     cases.add(
@@ -2536,7 +2536,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(fns)); }
     ,
-        ".tmp_source.zig:1:36: error: expected type 'fn(i32) i32', found 'extern fn(i32) i32'",
+        ".tmp_source.zig:1:36: error: expected 'fn(i32) i32' type, found 'extern fn(i32) i32'",
     );
 
     cases.add(
@@ -2640,7 +2640,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(a)); }
     ,
-        ".tmp_source.zig:1:16: error: expected type '*u8', found '(null)'",
+        ".tmp_source.zig:1:16: error: expected '*u8' type, found '(null)'",
     );
 
     cases.add(
@@ -3280,7 +3280,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn something() anyerror!void { }
     ,
-        ".tmp_source.zig:2:5: error: expected type 'void', found 'anyerror'",
+        ".tmp_source.zig:2:5: error: expected 'void' type, found 'anyerror'",
         ".tmp_source.zig:1:15: note: return type declared here",
     );
 
@@ -3459,7 +3459,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    derp.init();
         \\}
     ,
-        ".tmp_source.zig:14:5: error: expected type 'i32', found 'Foo'",
+        ".tmp_source.zig:14:5: error: expected 'i32' type, found 'Foo'",
     );
 
     cases.add(
@@ -3489,7 +3489,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    x.init();
         \\}
     ,
-        ".tmp_source.zig:23:5: error: expected type '*Allocator', found '*List'",
+        ".tmp_source.zig:23:5: error: expected '*Allocator' type, found '*List'",
     );
 
     cases.add(
@@ -3661,7 +3661,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:8:26: error: expected type '*const u3', found '*align(:3:1) const u3'",
+        ".tmp_source.zig:8:26: error: expected '*const u3' type, found '*align(:3:1) const u3'",
     );
 
     cases.add(
@@ -3790,7 +3790,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:4:19: error: expected type '*[]const u8', found '*const []const u8'",
+        ".tmp_source.zig:4:19: error: expected '*[]const u8' type, found '*const []const u8'",
     );
 
     cases.addCase(x: {
@@ -3822,7 +3822,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    foo(global_array);
         \\}
     ,
-        ".tmp_source.zig:4:9: error: expected type '[]i32', found '[10]i32'",
+        ".tmp_source.zig:4:9: error: expected '[]i32' type, found '[10]i32'",
     );
 
     cases.add(
@@ -3831,7 +3831,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @ptrCast(usize, a);
         \\}
     ,
-        ".tmp_source.zig:2:21: error: expected pointer, found 'usize'",
+        ".tmp_source.zig:2:21: error: expected pointer type, found 'usize'",
     );
 
     cases.add(
@@ -3902,7 +3902,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @fieldParentPtr(Foo, "a", a);
         \\}
     ,
-        ".tmp_source.zig:5:38: error: expected pointer, found 'i32'",
+        ".tmp_source.zig:5:38: error: expected pointer type, found 'i32'",
     );
 
     cases.add(
@@ -4057,7 +4057,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() ?i32 { return 1; }
     ,
-        ".tmp_source.zig:2:15: error: expected type 'bool', found '?i32'",
+        ".tmp_source.zig:2:15: error: expected 'bool' type, found '?i32'",
     );
 
     cases.add(
@@ -4067,7 +4067,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() anyerror!i32 { return 1; }
     ,
-        ".tmp_source.zig:2:15: error: expected type 'bool', found 'anyerror!i32'",
+        ".tmp_source.zig:2:15: error: expected 'bool' type, found 'anyerror!i32'",
     );
 
     cases.add(
@@ -4328,7 +4328,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @ptrToInt(x);
         \\}
     ,
-        ".tmp_source.zig:2:22: error: expected pointer, found 'i32'",
+        ".tmp_source.zig:2:22: error: expected pointer type, found 'i32'",
     );
 
     cases.add(
@@ -4364,7 +4364,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return x << y;
         \\}
     ,
-        ".tmp_source.zig:2:17: error: expected type 'u3', found 'u8'",
+        ".tmp_source.zig:2:17: error: expected 'u3' type, found 'u8'",
     );
 
     cases.add(
@@ -4393,7 +4393,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    x.* += 1;
         \\}
     ,
-        ".tmp_source.zig:8:13: error: expected type '*u32', found '*align(1) u32'",
+        ".tmp_source.zig:8:13: error: expected '*u32' type, found '*align(1) u32'",
     );
 
     cases.add(
@@ -4437,7 +4437,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @alignCast(4, u32(3));
         \\}
     ,
-        ".tmp_source.zig:2:22: error: expected pointer or slice, found 'u32'",
+        ".tmp_source.zig:2:22: error: expected pointer or slice type, found 'u32'",
     );
 
     cases.add(
@@ -4450,7 +4450,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn alignedSmall() align(4) i32 { return 1234; }
     ,
-        ".tmp_source.zig:2:35: error: expected type 'fn() align(8) i32', found 'fn() align(4) i32'",
+        ".tmp_source.zig:2:35: error: expected 'fn() align(8) i32' type, found 'fn() align(4) i32'",
     );
 
     cases.add(
@@ -4462,7 +4462,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return x == 5678;
         \\}
     ,
-        ".tmp_source.zig:4:32: error: expected type '*i32', found '*align(1) i32'",
+        ".tmp_source.zig:4:32: error: expected '*i32' type, found '*align(1) i32'",
     );
 
     cases.add(
@@ -4497,7 +4497,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    bar(@ptrCast(*c_void, &x));
         \\}
     ,
-        ".tmp_source.zig:5:9: error: expected type '*Derp', found '*c_void'",
+        ".tmp_source.zig:5:9: error: expected '*Derp' type, found '*c_void'",
     );
 
     cases.add(
@@ -4543,7 +4543,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    while (!@cmpxchgWeak(i32, &x, 1234, 5678, u32(1234), u32(1234))) {}
         \\}
     ,
-        ".tmp_source.zig:3:50: error: expected type 'AtomicOrder', found 'u32'",
+        ".tmp_source.zig:3:50: error: expected 'AtomicOrder' type, found 'u32'",
     );
 
     cases.add(
@@ -4553,7 +4553,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @export("entry", entry, u32(1234));
         \\}
     ,
-        ".tmp_source.zig:3:32: error: expected type 'GlobalLinkage', found 'u32'",
+        ".tmp_source.zig:3:32: error: expected 'GlobalLinkage' type, found 'u32'",
     );
 
     cases.add(
@@ -4730,7 +4730,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @ArgType(i32, 3);
         \\}
     ,
-        ".tmp_source.zig:2:18: error: expected function, found 'i32'",
+        ".tmp_source.zig:2:18: error: expected function type, found 'i32'",
     );
 
     cases.add(
@@ -4828,7 +4828,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\pub extern fn foo(format: *const u8, ...) void;
     ,
-        ".tmp_source.zig:2:9: error: expected type '*const u8', found '[5]u8'",
+        ".tmp_source.zig:2:9: error: expected '*const u8' type, found '[5]u8'",
     );
 
     cases.add(
@@ -4897,7 +4897,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x: u2 = Small.Two;
         \\}
     ,
-        ".tmp_source.zig:9:22: error: expected type 'u2', found 'Small'",
+        ".tmp_source.zig:9:22: error: expected 'u2' type, found 'Small'",
     );
 
     cases.add(
@@ -4914,7 +4914,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = @intToEnum(Small, y);
         \\}
     ,
-        ".tmp_source.zig:10:31: error: expected type 'u2', found 'u3'",
+        ".tmp_source.zig:10:31: error: expected 'u2' type, found 'u3'",
     );
 
     cases.add(
@@ -5311,7 +5311,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    asm volatile ("" : : [bar]"r"(3) : "");
         \\}
     ,
-        ".tmp_source.zig:2:35: error: expected sized integer or sized float, found comptime_int",
+        ".tmp_source.zig:2:35: error: expected sized integer or sized float type, found comptime_int",
     );
 
     cases.add(
@@ -5320,6 +5320,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    asm volatile ("" : : [bar]"r"(3.17) : "");
         \\}
     ,
-        ".tmp_source.zig:2:35: error: expected sized integer or sized float, found comptime_float",
+        ".tmp_source.zig:2:35: error: expected sized integer or sized float type, found comptime_float",
     );
 }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,6 +2,16 @@ const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "Use of && in place of `and`",
+        \\export fn entry() void {
+        \\    if (true && false) return;
+        \\}
+    ,
+        ".tmp_source.zig:2:14: error: expected token ')', found '&&'",
+        ".tmp_source.zig:2:14: note: did you mean to use `and`?",
+    );
+
+    cases.add(
         "duplicate boolean switch value",
         \\comptime {
         \\    const x = switch (true) {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -12,12 +12,23 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
-        "Use of || in place of `or`",
+        "Use of || in place of `or` (using comptime_int)",
         \\export fn entry() void {
         \\    if (1 || 0) return;
         \\}
     ,
+        ".tmp_source.zig:2:9: error: expected ErrorSet type, found 'comptime_int'",
         ".tmp_source.zig:2:11: note: did you mean to use `or`?",
+    );
+
+    cases.add(
+        "Use of || in place of `or` (using booleans)",
+        \\export fn entry() void {
+        \\    if (true || false) return;
+        \\}
+    ,
+        ".tmp_source.zig:2:9: error: expected ErrorSet type, found 'bool'",
+        ".tmp_source.zig:2:14: note: did you mean to use `or`?",
     );
 
     cases.add(
@@ -277,8 +288,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const Errors = error{} || u16;
         \\}
     ,
-        ".tmp_source.zig:2:20: error: expected error set type, found 'u8'",
-        ".tmp_source.zig:5:31: error: expected error set type, found 'u16'",
+        ".tmp_source.zig:2:20: error: expected ErrorSet type, found 'u8'",
+        ".tmp_source.zig:2:23: note: did you mean to use `or`?",
+        ".tmp_source.zig:5:31: error: expected ErrorSet type, found 'u16'",
     );
 
     cases.add(
@@ -1200,7 +1212,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const z = i32!i32;
         \\}
     ,
-        ".tmp_source.zig:2:15: error: expected error set type, found 'i32'",
+        ".tmp_source.zig:2:15: error: expected ErrorSet type, found 'i32'",
     );
 
     cases.add(
@@ -3850,7 +3862,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @ptrCast(usize, a);
         \\}
     ,
-        ".tmp_source.zig:2:21: error: expected pointer type, found 'usize'",
+        ".tmp_source.zig:2:21: error: expected Pointer type, found 'usize'",
     );
 
     cases.add(
@@ -3897,7 +3909,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @fieldParentPtr(Foo, "a", a);
         \\}
     ,
-        ".tmp_source.zig:3:28: error: expected struct type, found 'i32'",
+        ".tmp_source.zig:3:28: error: expected Struct type, found 'i32'",
     );
 
     cases.add(
@@ -3921,7 +3933,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @fieldParentPtr(Foo, "a", a);
         \\}
     ,
-        ".tmp_source.zig:5:38: error: expected pointer type, found 'i32'",
+        ".tmp_source.zig:5:38: error: expected Pointer type, found 'i32'",
     );
 
     cases.add(
@@ -3962,7 +3974,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @byteOffsetOf(Foo, "a",);
         \\}
     ,
-        ".tmp_source.zig:3:26: error: expected struct type, found 'i32'",
+        ".tmp_source.zig:3:26: error: expected Struct type, found 'i32'",
     );
 
     cases.add(
@@ -4347,7 +4359,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @ptrToInt(x);
         \\}
     ,
-        ".tmp_source.zig:2:22: error: expected pointer type, found 'i32'",
+        ".tmp_source.zig:2:22: error: expected Pointer type, found 'i32'",
     );
 
     cases.add(
@@ -4749,7 +4761,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @ArgType(i32, 3);
         \\}
     ,
-        ".tmp_source.zig:2:18: error: expected function type, found 'i32'",
+        ".tmp_source.zig:2:18: error: expected Fn type, found 'i32'",
     );
 
     cases.add(

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -12,6 +12,15 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
+        "Use of || in place of `or`",
+        \\export fn entry() void {
+        \\    if (1 || 0) return;
+        \\}
+    ,
+        ".tmp_source.zig:2:11: note: did you mean to use `or`?",
+    );
+
+    cases.add(
         "duplicate boolean switch value",
         \\comptime {
         \\    const x = switch (true) {


### PR DESCRIPTION
fixes #1877 
fixes #1560

* [X] Implementation
* [X] Test Cases

Screenshots:

![screen shot 2019-01-19 at 1 11 28](https://user-images.githubusercontent.com/44620/51398548-2feb5e80-1b87-11e9-85f4-bd9b7145201f.png)
![screen shot 2019-01-19 at 1 11 14](https://user-images.githubusercontent.com/44620/51398555-35e13f80-1b87-11e9-8f56-636a372c4071.png)
