### PR TITLE
llvm-config sanity check

### DIFF
--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -15,6 +15,15 @@ find_program(LLVM_CONFIG_EXE
         "c:/msys64/mingw64/bin"
         "C:/Libraries/llvm-7.0.0/bin")
 
+execute_process(
+	COMMAND ${LLVM_CONFIG_EXE} --version
+	OUTPUT_VARIABLE LLVM_CONFIG_VERSION
+	OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(LLVM_CONFIG_VERSION VERSION_LESS 7)
+  message(FATAL_ERROR "expected LLVM version >=7 but found ${LLVM_CONFIG_VERSION}")
+endif()
+
 if(NOT(CMAKE_BUILD_TYPE STREQUAL "Debug") OR ZIG_STATIC)
   execute_process(
       COMMAND ${LLVM_CONFIG_EXE} --libfiles --link-static


### PR DESCRIPTION
In the cmake find-llvm module, `find_program(LLVM_CONFIG_EXE ...)` can be `llvm-config`, possibly from a version lower than llvm:7. This small sanity check ensure that it is at least of the correct version.