### PR TITLE
Move tokenizer error location to offending char

### DIFF
--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -249,13 +249,8 @@ ATTRIBUTE_PRINTF(2, 3)
 static void tokenize_error(Tokenize *t, const char *format, ...) {
     t->state = TokenizeStateError;
 
-    if (t->cur_tok) {
-        t->out->err_line = t->cur_tok->start_line;
-        t->out->err_column = t->cur_tok->start_column;
-    } else {
-        t->out->err_line = t->line;
-        t->out->err_column = t->column;
-    }
+    t->out->err_line = t->line;
+    t->out->err_column = t->column;
 
     va_list ap;
     va_start(ap, format);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2649,7 +2649,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:1:13: error: newline not allowed in string literal",
+        ".tmp_source.zig:1:15: error: newline not allowed in string literal",
     );
 
     cases.add(


### PR DESCRIPTION
Currently, if the tokenizer encounters an invalid character while parsing, say, a string or a floating point literal, the error message points to the start of the token it was processing rather than the location of the character that caused the error. This greatly reduces the usefulness of the message in some cases.

For example, imagine you were in a hurry and you wrote this (slightly contrived) regex that matches nested pairs of parentheses:
```zig
"\\([^()]*\\([^()]*\)[^()]*\\)"
```
Did you spot the mistake? If not, the compiler won't be of much help, as it reports the following:
```
/tmp/foo.zig:1:1: error: invalid character: ')'                                    
"\\([^()]*\\([^()]*\)[^()]*\\)"
^
```
With this patch, it becomes easy to tell where I botched an escape sequence:
```
/tmp/foo.zig:1:21: error: invalid character: ')'
"\\([^()]*\\([^()]*\)[^()]*\\)"
                    ^
```

Since tokens cannot span multiple lines in Zig, it seems much more likely to encounter a scenario such as this one than the reverse case, where knowing the string/token start position is more useful than knowing where exactly the tokenizer failed. The latter seems mostly useful in the case of unterminated strings and comments.