### PR TITLE
Fix for #1878. 'zig init-lib' on MacOS missing __mh_execute_header

### DIFF
--- a/std/special/init-lib/src/main.zig
+++ b/std/special/init-lib/src/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const assertOrPanic = std.debug.assertOrPanic;
 
+// TODO - remove this workaround
 comptime {
     const builtin = @import("builtin");
     if (builtin.os == builtin.Os.macosx) {

--- a/std/special/init-lib/src/main.zig
+++ b/std/special/init-lib/src/main.zig
@@ -1,6 +1,14 @@
 const std = @import("std");
 const assertOrPanic = std.debug.assertOrPanic;
 
+comptime {
+    const builtin = @import("builtin");
+    if (builtin.os == builtin.Os.macosx) {
+        @export("__mh_execute_header", _mh_execute_header, builtin.GlobalLinkage.Weak);
+    }
+}
+var _mh_execute_header = extern struct {x: usize}{.x = 0};
+
 export fn add(a: i32, b: i32) i32 {
     return a + b;
 }


### PR DESCRIPTION
This workaround is also found in the 'shared-library' example with a TODO to remove it. Hopefully this can be used as a quick fix so that new users don't run into an obscure error with init-lib. Apparently, libSystem doesn't define this symbol. 

I think that the __mh_execute_header symbol is supposed to only be in actual executable files, however, during Zigs compilation of the init-lib/src/main.zig file on MacOS, the std/c/darwin.zig file declares this symbol as an external "C" symbol...then I think std/debug/index.zig uses this symbol to set up a base address and offset for debug info. The act of linking the .o file into a library is where 'init-lib' actually fails. 

I assume that this symbol should not be used for .o files and should only be inserted/used when linking an executable and not a library?

I can look further into it if someone else doesn't know of a fix for this? :)