### PR TITLE
Fix runtime assignment to comptime aggregate field

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16533,7 +16533,8 @@ static IrInstruction *ir_analyze_container_init_fields_union(IrAnalyze *ira, IrI
     if ((err = type_resolve(ira->codegen, casted_field_value->value.type, ResolveStatusZeroBitsKnown)))
         return ira->codegen->invalid_instruction;
 
-    bool is_comptime = ir_should_inline(ira->new_irb.exec, instruction->scope);
+    bool is_comptime = ir_should_inline(ira->new_irb.exec, instruction->scope)
+        || type_requires_comptime(ira->codegen, container_type) == ReqCompTimeYes;
     if (is_comptime || casted_field_value->value.special != ConstValSpecialRuntime ||
         !type_has_bits(casted_field_value->value.type))
     {
@@ -16584,7 +16585,8 @@ static IrInstruction *ir_analyze_container_init_fields(IrAnalyze *ira, IrInstruc
 
     IrInstructionStructInitField *new_fields = allocate<IrInstructionStructInitField>(actual_field_count);
 
-    bool is_comptime = ir_should_inline(ira->new_irb.exec, instruction->scope);
+    bool is_comptime = ir_should_inline(ira->new_irb.exec, instruction->scope)
+        || type_requires_comptime(ira->codegen, container_type) == ReqCompTimeYes;
 
     ConstExprValue const_val = {};
     const_val.special = ConstValSpecialStatic;

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -5358,4 +5358,32 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     ,
         ".tmp_source.zig:2:35: error: expected sized integer or sized float, found comptime_float",
     );
+
+    cases.add(
+        "runtime assignment to comptime struct type",
+        \\const Foo = struct {
+        \\    Bar: u8,
+        \\    Baz: type,
+        \\};
+        \\export fn f() void {
+        \\    var x: u8 = 0;
+        \\    const foo = Foo { .Bar = x, .Baz = u8 };
+        \\}
+    ,
+        ".tmp_source.zig:7:30: error: unable to evaluate constant expression",
+    );
+
+    cases.add(
+        "runtime assignment to comptime union type",
+        \\const Foo = union {
+        \\    Bar: u8,
+        \\    Baz: type,
+        \\};
+        \\export fn f() void {
+        \\    var x: u8 = 0;
+        \\    const foo = Foo { .Bar = x };
+        \\}
+    ,
+        ".tmp_source.zig:7:30: error: unable to evaluate constant expression",
+    );
 }


### PR DESCRIPTION
This caused a null dereference crash when the code generator tried to emit LLVM IR for the field assignment and expected an LLVM variable to be assigned to the comptime struct variable.