### PR TITLE
stage1: compile error for implicit cast from *const T to *[1]T

### DIFF
--- a/std/fmt/index.zig
+++ b/std/fmt/index.zig
@@ -378,7 +378,7 @@ pub fn formatAsciiChar(
     comptime Errors: type,
     output: fn (@typeOf(context), []const u8) Errors!void,
 ) Errors!void {
-    return output(context, (*[1]u8)(&c)[0..]);
+    return output(context, &c);
 }
 
 pub fn formatBuf(
@@ -393,7 +393,7 @@ pub fn formatBuf(
     var leftover_padding = if (width > buf.len) (width - buf.len) else return;
     const pad_byte: u8 = ' ';
     while (leftover_padding > 0) : (leftover_padding -= 1) {
-        try output(context, (*[1]u8)(&pad_byte)[0..1]);
+        try output(context, &pad_byte);
     }
 }
 
@@ -708,7 +708,7 @@ fn formatIntSigned(
     const uint = @IntType(false, @typeOf(value).bit_count);
     if (value < 0) {
         const minus_sign: u8 = '-';
-        try output(context, (*[1]u8)(&minus_sign)[0..]);
+        try output(context, &minus_sign);
         const new_value = @intCast(uint, -(value + 1)) + 1;
         const new_width = if (width == 0) 0 else (width - 1);
         return formatIntUnsigned(new_value, base, uppercase, new_width, context, Errors, output);
@@ -716,7 +716,7 @@ fn formatIntSigned(
         return formatIntUnsigned(@intCast(uint, value), base, uppercase, width, context, Errors, output);
     } else {
         const plus_sign: u8 = '+';
-        try output(context, (*[1]u8)(&plus_sign)[0..]);
+        try output(context, &plus_sign);
         const new_value = @intCast(uint, value);
         const new_width = if (width == 0) 0 else (width - 1);
         return formatIntUnsigned(new_value, base, uppercase, new_width, context, Errors, output);
@@ -755,7 +755,7 @@ fn formatIntUnsigned(
         const zero_byte: u8 = '0';
         var leftover_padding = padding - index;
         while (true) {
-            try output(context, (*[1]u8)(&zero_byte)[0..]);
+            try output(context, &zero_byte);
             leftover_padding -= 1;
             if (leftover_padding == 0) break;
         }

--- a/std/io.zig
+++ b/std/io.zig
@@ -227,12 +227,11 @@ pub fn OutStream(comptime WriteError: type) type {
         }
 
         pub fn writeByte(self: *Self, byte: u8) Error!void {
-            const slice = (*[1]u8)(&byte)[0..];
-            return self.writeFn(self, slice);
+            return self.writeFn(self, &byte);
         }
 
         pub fn writeByteNTimes(self: *Self, byte: u8, n: usize) Error!void {
-            const slice = (*[1]u8)(&byte)[0..];
+            const slice = &byte;
             var i: usize = 0;
             while (i < n) : (i += 1) {
                 try self.writeFn(self, slice);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1,6 +1,16 @@
 const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
+    cases.add(
+        "attempted implicit cast from *const T to []T",
+        \\export fn entry() void {
+        \\    const u: u32 = 42;
+        \\    const x: []u32 = &u;
+        \\}
+    ,
+        ".tmp_source.zig:3:23: error: expected type '[]u32', found '*const [1]u32'",
+    );
+
     cases.addTest(
         "@truncate undefined value",
         \\export fn entry() void {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,6 +2,18 @@ const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "attempted implicit cast from *const T to *[1]T",
+        \\export fn entry(byte: u8) void {
+        \\    const w: i32 = 1234;
+        \\    var x: *const i32 = &w;
+        \\    var y: *[1]i32 = x;
+        \\    y[0] += 1;
+        \\}
+    ,
+        ".tmp_source.zig:4:22: error: expected type '*[1]i32', found '*const i32'",
+    );
+
+    cases.add(
         "attempted implicit cast from *const T to []T",
         \\export fn entry() void {
         \\    const u: u32 = 42;

--- a/test/stage1/behavior/align.zig
+++ b/test/stage1/behavior/align.zig
@@ -60,7 +60,7 @@ fn addUnaligned(a: *align(1) const u32, b: *align(1) const u32) u32 {
 test "implicitly decreasing slice alignment" {
     const a: u32 align(4) = 3;
     const b: u32 align(8) = 4;
-    expect(addUnalignedSlice((*[1]u32)(&a)[0..], (*[1]u32)(&b)[0..]) == 7);
+    expect(addUnalignedSlice(&a, &b) == 7);
 }
 fn addUnalignedSlice(a: []align(1) const u32, b: []align(1) const u32) u32 {
     return a[0] + b[0];

--- a/test/stage1/behavior/align.zig
+++ b/test/stage1/behavior/align.zig
@@ -6,7 +6,7 @@ var foo: u8 align(4) = 100;
 test "global variable alignment" {
     expect(@typeOf(&foo).alignment == 4);
     expect(@typeOf(&foo) == *align(4) u8);
-    const slice = (*[1]u8)(&foo)[0..];
+    const slice = ([]u8)(&foo);
     expect(@typeOf(slice) == []align(4) u8);
 }
 

--- a/test/stage1/behavior/array.zig
+++ b/test/stage1/behavior/array.zig
@@ -148,7 +148,7 @@ test "implicit cast single-item pointer" {
 
 fn testImplicitCastSingleItemPtr() void {
     var byte: u8 = 100;
-    const slice = (*[1]u8)(&byte)[0..];
+    const slice = ([]u8)(&byte);
     slice[0] += 1;
     expect(byte == 101);
 }

--- a/test/stage1/behavior/cast.zig
+++ b/test/stage1/behavior/cast.zig
@@ -321,6 +321,29 @@ test "cast *[1][*]const u8 to [*]const ?[*]const u8" {
     expect(mem.eql(u8, std.cstr.toSliceConst(x[0].?), "window name"));
 }
 
+const C = struct {
+    c: u32,
+};
+test "cast *T to []T" {
+    var c = C{ .c = 42 };
+    mem.secureZero(C, &c);
+    expect(c.c == 0);
+}
+
+test "cast *T to []const T" {
+    var c = C{ .c = 0xFFFFFFFF };
+    var b = @sliceToBytes(([]const u32)(&c.c));
+    expect(b.len == 4);
+    expect(mem.eql(u8, b, []u8{0xFF} ** 4));
+}
+
+test "cast *const T to []const T" {
+    const c = C{ .c = 0xFFFFFFFF };
+    var b = @sliceToBytes(([]const u32)(&c.c));
+    expect(b.len == 4);
+    expect(mem.eql(u8, b, []u8{0xFF} ** 4));
+}
+
 test "@intCast comptime_int" {
     const result = @intCast(i32, 1234);
     expect(@typeOf(result) == i32);


### PR DESCRIPTION
fix #1940 

* [X] Implementation
  * `src/ir.cpp`
* [X] Tests
  * `test/compile_errors.zig`

Of note: this PR is based on PR #1941 to cure these errors:

![screen shot 2019-02-10 at 17 20 56](https://user-images.githubusercontent.com/44620/52531461-38375380-2d59-11e9-8348-528881468344.png)
