### PR TITLE
Fix lvalue dereference type checking

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2091,6 +2091,11 @@ struct IrBasicBlock {
     IrInstruction *must_be_comptime_source_instr;
 };
 
+enum LVal {
+    LValNone,
+    LValPtr,
+};
+
 // These instructions are in transition to having "pass 1" instructions
 // and "pass 2" instructions. The pass 1 instructions are suffixed with Src
 // and pass 2 are suffixed with Gen.
@@ -2354,6 +2359,7 @@ struct IrInstructionUnOp {
 
     IrUnOp op_id;
     IrInstruction *value;
+    LVal lval;
 };
 
 enum IrBinOp {
@@ -3088,11 +3094,6 @@ struct IrInstructionTypeName {
     IrInstruction base;
 
     IrInstruction *type_value;
-};
-
-enum LVal {
-    LValNone,
-    LValPtr,
 };
 
 struct IrInstructionDeclRef {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -138,6 +138,24 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.addTest(
+        "assign to invalid dereference",
+        \\export fn entry() void {
+        \\    'a'.* = 1;
+        \\}
+    ,
+        ".tmp_source.zig:2:8: error: attempt to dereference non-pointer type 'comptime_int'",
+    );
+
+    cases.addTest(
+        "take slice of invalid dereference",
+        \\export fn entry() void {
+        \\    const x = 'a'.*[0..];
+        \\}
+    ,
+        ".tmp_source.zig:2:18: error: attempt to dereference non-pointer type 'comptime_int'",
+    );
+
+    cases.addTest(
         "@truncate undefined value",
         \\export fn entry() void {
         \\    var z = @truncate(u8, u16(undefined));
@@ -447,7 +465,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a.*.len;
         \\}
     ,
-        ".tmp_source.zig:3:12: error: attempt to dereference non-pointer type '[]u8'",
+        ".tmp_source.zig:3:10: error: attempt to dereference non-pointer type '[]u8'",
     );
 
     cases.add(
@@ -1158,7 +1176,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    Filled,
         \\};
     ,
-        ".tmp_source.zig:3:17: error: invalid deref on switch target",
+        ".tmp_source.zig:3:17: error: attempt to dereference non-pointer type 'Tile'",
     );
 
     cases.add(
@@ -4000,7 +4018,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(pass)); }
     ,
-        ".tmp_source.zig:4:10: error: attempt to dereference non pointer type '[10]u8'",
+        ".tmp_source.zig:4:10: error: attempt to dereference non-pointer type '[10]u8'",
     );
 
     cases.add(


### PR DESCRIPTION
Previously, if a dereference instruction was an lvalue, it would fail to typecheck that the value being dereferenced was indeed a pointer. Although a little clunky, this change obviates the need for redundant type checks scattered about the analysis.

I found this issue when doing `x.*[0..]` caused an assertion error if `x` was not a pointer, hence the branch name.