### PR TITLE
freebsd: fix pointer cast in mmap

### DIFF
--- a/std/os/freebsd/index.zig
+++ b/std/os/freebsd/index.zig
@@ -617,7 +617,7 @@ pub fn mkdir(path: [*]const u8, mode: u32) usize {
 
 pub fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: u32, fd: i32, offset: isize) usize {
     const ptr_result = c.mmap(
-        @ptrCast(*c_void, address),
+        @ptrCast(?*c_void, address),
         length,
         @bitCast(c_int, @intCast(c_uint, prot)),
         @bitCast(c_int, c_uint(flags)),


### PR DESCRIPTION
this wasn't tested on freebsd, but I am copying the freebsd implementation and was inspired by https://github.com/ziglang/zig/commit/71d7100aa830652490d3995bf4e1319f31b5e647

and it probably needs the same to handle zero address