### PR TITLE
Silence gcc8 class-memaccess warnings

### DIFF
--- a/src/translate_c.cpp
+++ b/src/translate_c.cpp
@@ -129,17 +129,17 @@ static AstNode *trans_bool_expr(Context *c, ResultUsed result_used, TransScope *
 
 static ZigClangSourceLocation bitcast(clang::SourceLocation src) {
     ZigClangSourceLocation dest;
-    memcpy(&dest, &src, sizeof(ZigClangSourceLocation));
+    memcpy(&dest, static_cast<void *>(&src), sizeof(ZigClangSourceLocation));
     return dest;
 }
 static ZigClangQualType bitcast(clang::QualType src) {
     ZigClangQualType dest;
-    memcpy(&dest, &src, sizeof(ZigClangQualType));
+    memcpy(&dest, static_cast<void *>(&src), sizeof(ZigClangQualType));
     return dest;
 }
 static clang::QualType bitcast(ZigClangQualType src) {
     clang::QualType dest;
-    memcpy(&dest, &src, sizeof(ZigClangQualType));
+    memcpy(&dest, static_cast<void *>(&src), sizeof(ZigClangQualType));
     return dest;
 }
 

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -140,24 +140,24 @@ static_assert((clang::UnaryOperatorKind)ZigClangUO_Real == clang::UO_Real, "");
 static_assert(sizeof(ZigClangSourceLocation) == sizeof(clang::SourceLocation), "");
 static ZigClangSourceLocation bitcast(clang::SourceLocation src) {
     ZigClangSourceLocation dest;
-    memcpy(&dest, &src, sizeof(ZigClangSourceLocation));
+    memcpy(&dest, static_cast<void *>(&src), sizeof(ZigClangSourceLocation));
     return dest;
 }
 static clang::SourceLocation bitcast(ZigClangSourceLocation src) {
     clang::SourceLocation dest;
-    memcpy(&dest, &src, sizeof(ZigClangSourceLocation));
+    memcpy(&dest, static_cast<void *>(&src), sizeof(ZigClangSourceLocation));
     return dest;
 }
 
 static_assert(sizeof(ZigClangQualType) == sizeof(clang::QualType), "");
 static ZigClangQualType bitcast(clang::QualType src) {
     ZigClangQualType dest;
-    memcpy(&dest, &src, sizeof(ZigClangQualType));
+    memcpy(&dest, static_cast<void *>(&src), sizeof(ZigClangQualType));
     return dest;
 }
 static clang::QualType bitcast(ZigClangQualType src) {
     clang::QualType dest;
-    memcpy(&dest, &src, sizeof(ZigClangQualType));
+    memcpy(&dest, static_cast<void *>(&src), sizeof(ZigClangQualType));
     return dest;
 }
 


### PR DESCRIPTION
Use an explicit cast to tell gcc we know what we're doing.

#1474 and 9a123697e30a15a178767d7bb9237528044c129d tried to silence the warning by disabling it altogether but failed to do so for every platform/compiler.

This partially fixes the build on debian Buster as I also had to apply another patch to turn the `KFreeBSD` enum into `kFreeBSD` ([wtf indeed](https://salsa.debian.org/pkg-llvm-team/llvm-toolchain/blob/7/debian/patches/kfreebsd/include_llvm_ADT_Triple.h.diff)).