### PR TITLE
fix openWriteNoClobber and add test

### DIFF
--- a/std/io_test.zig
+++ b/std/io_test.zig
@@ -29,6 +29,17 @@ test "write a file, read it, then delete it" {
         try st.print("end");
         try buf_stream.flush();
     }
+
+    {
+        // make sure openWriteNoClobber doesn't harm the file
+        if (os.File.openWriteNoClobber(tmp_file_name, os.File.default_mode)) |file| {
+            unreachable;
+        }
+        else |err| {
+            std.debug.assert(err == os.File.OpenError.PathAlreadyExists);
+        }
+    }
+
     {
         var file = try os.File.openRead(tmp_file_name);
         defer file.close();

--- a/std/os/file.zig
+++ b/std/os/file.zig
@@ -105,7 +105,7 @@ pub const File = struct {
     pub fn openWriteNoClobber(path: []const u8, file_mode: Mode) OpenError!File {
         if (is_posix) {
             const path_c = try os.toPosixPath(path);
-            return openWriteNoClobberC(path_c, file_mode);
+            return openWriteNoClobberC(&path_c, file_mode);
         } else if (is_windows) {
             const path_w = try windows_util.sliceToPrefixedFileW(path);
             return openWriteNoClobberW(&path_w, file_mode);


### PR DESCRIPTION
I found that std.os.File.openWriteNoClobber results in a compilation error on Linux. The error appears to be a missing & operator in the "is_posix" branch. I added a test as I didn't find an existing call to std.os.File.openWriteNoClobber.