### PR TITLE
Translate parameterless C functions

### DIFF
--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1417,6 +1417,14 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     );
 
+    cases.addC("Parameterless function prototypes",
+        \\void foo() {}
+        \\void bar(void) {}
+    ,
+        \\pub export fn foo() void {}
+        \\pub export fn bar() void {}
+    );
+
     // cases.add("empty array with initializer",
     //     "int a[4] = {};"
     // ,


### PR DESCRIPTION
Both FunctionNoProto and FunctionProto are subclasses of FunctionType,
the only difference is that the former is parameterless.

Fixes #1970 