### PR TITLE
Work in progress on NetBSD CI

### DIFF
--- a/.builds/netbsd.yml
+++ b/.builds/netbsd.yml
@@ -1,0 +1,43 @@
+image: netbsd/current
+packages:
+  - devel/cmake
+  - devel/ninja-build
+  - lang/llvm
+sources:
+  - https://github.com/ziglang/zig
+tasks:
+  - build: |
+      cd zig && mkdir build && cd build
+      cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release
+      ninja install
+  - test: |
+      cd zig/build
+      bin/zig test ../test/stage1/behavior.zig
+      bin/zig test ../std/special/compiler_rt/index.zig
+
+      bin/zig test ../test/stage1/behavior.zig --library c
+      bin/zig test ../std/special/compiler_rt/index.zig --library c
+
+      bin/zig test ../test/stage1/behavior.zig --release-fast
+      bin/zig test ../std/special/compiler_rt/index.zig --release-fast
+
+      bin/zig test ../test/stage1/behavior.zig --release-fast --library c
+      bin/zig test ../std/special/compiler_rt/index.zig --release-fast --library c
+
+      bin/zig test ../test/stage1/behavior.zig --release-small --library c
+      bin/zig test ../std/special/compiler_rt/index.zig --release-small --library c
+
+      bin/zig test ../test/stage1/behavior.zig --release-small
+      bin/zig test ../std/special/compiler_rt/index.zig --release-small
+
+      bin/zig test ../test/stage1/behavior.zig --release-safe
+      bin/zig test ../std/special/compiler_rt/index.zig --release-safe
+
+      bin/zig test ../test/stage1/behavior.zig --release-safe --library c
+      bin/zig test ../std/special/compiler_rt/index.zig --release-safe --library c
+      # TODO enable all tests
+      #bin/zig build --build-file ../build.zig test
+      # TODO integrate with the download page updater and make a
+      # static build available to download for NetBSD.
+      # This will require setting up a cache of LLVM/Clang built
+      # statically.


### PR DESCRIPTION
Fixes #1984.

Using NetBSD current rather than latest as latest seems to be missing the `lanai` target and the Zig build complains about this. Unfortunately this means we have to build everything from source, which means slow builds for now until we can cache the built LLVM, Ninja and CMake binaries.

I haven't yet tested this as the LLVM build from `pkgsrc` was taking a while and I ran out of time.