### PR TITLE
better libc detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,6 +414,7 @@ set(ZIG_SOURCES
     "${CMAKE_SOURCE_DIR}/src/error.cpp"
     "${CMAKE_SOURCE_DIR}/src/ir.cpp"
     "${CMAKE_SOURCE_DIR}/src/ir_print.cpp"
+    "${CMAKE_SOURCE_DIR}/src/libc_installation.cpp"
     "${CMAKE_SOURCE_DIR}/src/link.cpp"
     "${CMAKE_SOURCE_DIR}/src/main.cpp"
     "${CMAKE_SOURCE_DIR}/src/os.cpp"

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -18,6 +18,7 @@
 #include "bigfloat.hpp"
 #include "target.hpp"
 #include "tokenizer.hpp"
+#include "libc_installation.hpp"
 
 struct AstNode;
 struct ImportTableEntry;
@@ -1743,6 +1744,9 @@ struct CodeGen {
     Buf *wanted_output_file_path;
     Buf cache_dir;
 
+    Buf *zig_c_headers_dir; // Cannot be overridden; derived from zig_lib_dir.
+    Buf *zig_std_special_dir; // Cannot be overridden; derived from zig_lib_dir.
+
     IrInstruction *invalid_instruction;
     IrInstruction *unreach_instruction;
 
@@ -1791,6 +1795,8 @@ struct CodeGen {
     bool system_linker_hack;
 
     //////////////////////////// Participates in Input Parameter Cache Hash
+    /////// Note: there is a separate cache hash for builtin.zig, when adding fields,
+    ///////       consider if they need to go into both.
     ZigList<LinkLib *> link_libs_list;
     // add -framework [name] args to linker
     ZigList<Buf *> darwin_frameworks;
@@ -1801,6 +1807,8 @@ struct CodeGen {
     ZigList<Buf *> assembly_files;
     ZigList<const char *> lib_dirs;
 
+    ZigLibCInstallation *libc;
+
     size_t version_major;
     size_t version_minor;
     size_t version_patch;
@@ -1809,14 +1817,13 @@ struct CodeGen {
     EmitFileType emit_file_type;
     BuildMode build_mode;
     OutType out_type;
-    ZigTarget zig_target;
+    const ZigTarget *zig_target;
     TargetSubsystem subsystem;
     ValgrindSupport valgrind_support;
     bool is_static;
     bool strip_debug_symbols;
     bool is_test_build;
     bool is_single_threaded;
-    bool is_native_target;
     bool linker_rdynamic;
     bool each_lib_rpath;
     bool disable_pic;
@@ -1827,26 +1834,14 @@ struct CodeGen {
     Buf *test_filter;
     Buf *test_name_prefix;
     PackageTableEntry *root_package;
+    Buf *zig_lib_dir;
+    Buf *zig_std_dir;
 
     const char **llvm_argv;
     size_t llvm_argv_len;
 
     const char **clang_argv;
     size_t clang_argv_len;
-
-    //////////////////////////// Unsorted
-
-    Buf *libc_lib_dir;
-    Buf *libc_static_lib_dir;
-    Buf *libc_include_dir;
-    Buf *msvc_lib_dir;
-    Buf *kernel32_lib_dir;
-    Buf *zig_lib_dir;
-    Buf *zig_std_dir;
-    Buf *zig_c_headers_dir;
-    Buf *zig_std_special_dir;
-    Buf *dynamic_linker;
-    ZigWindowsSDK *win_sdk;
 };
 
 enum VarLinkage {

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -40,8 +40,6 @@ ZigType *get_promise_type(CodeGen *g, ZigType *result_type);
 ZigType *get_promise_frame_type(CodeGen *g, ZigType *return_type);
 ZigType *get_test_fn_type(CodeGen *g);
 bool handle_is_ptr(ZigType *type_entry);
-void find_libc_include_path(CodeGen *g);
-void find_libc_lib_path(CodeGen *g);
 
 bool type_has_bits(ZigType *type_entry);
 bool type_allowed_in_extern(CodeGen *g, ZigType *type_entry);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7869,6 +7869,11 @@ static void detect_libc(CodeGen *g) {
                     "See `zig libc --help` for more details.\n", err_str(err));
                 exit(1);
             }
+            if ((err = os_make_path(&g->cache_dir))) {
+                fprintf(stderr, "Unable to create %s directory: %s\n",
+                    buf_ptr(&g->cache_dir), err_str(err));
+                exit(1);
+            }
             Buf *native_libc_tmp = buf_sprintf("%s.tmp", buf_ptr(native_libc_txt));
             FILE *file = fopen(buf_ptr(native_libc_tmp), "wb");
             if (file == nullptr) {

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -11,11 +11,12 @@
 #include "parser.hpp"
 #include "errmsg.hpp"
 #include "target.hpp"
+#include "libc_installation.hpp"
 
 #include <stdio.h>
 
 CodeGen *codegen_create(Buf *root_src_path, const ZigTarget *target, OutType out_type, BuildMode build_mode,
-    Buf *zig_lib_dir, Buf *override_std_dir);
+    Buf *zig_lib_dir, Buf *override_std_dir, ZigLibCInstallation *libc);
 
 void codegen_set_clang_argv(CodeGen *codegen, const char **args, size_t len);
 void codegen_set_llvm_argv(CodeGen *codegen, const char **args, size_t len);
@@ -27,12 +28,6 @@ void codegen_set_is_static(CodeGen *codegen, bool is_static);
 void codegen_set_strip(CodeGen *codegen, bool strip);
 void codegen_set_errmsg_color(CodeGen *codegen, ErrColor err_color);
 void codegen_set_out_name(CodeGen *codegen, Buf *out_name);
-void codegen_set_libc_lib_dir(CodeGen *codegen, Buf *libc_lib_dir);
-void codegen_set_libc_static_lib_dir(CodeGen *g, Buf *libc_static_lib_dir);
-void codegen_set_libc_include_dir(CodeGen *codegen, Buf *libc_include_dir);
-void codegen_set_msvc_lib_dir(CodeGen *g, Buf *msvc_lib_dir);
-void codegen_set_kernel32_lib_dir(CodeGen *codegen, Buf *kernel32_lib_dir);
-void codegen_set_dynamic_linker(CodeGen *g, Buf *dynamic_linker);
 void codegen_add_lib_dir(CodeGen *codegen, const char *dir);
 void codegen_add_forbidden_lib(CodeGen *codegen, Buf *lib);
 LinkLib *codegen_add_link_lib(CodeGen *codegen, Buf *lib);

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -34,6 +34,8 @@ const char *err_str(Error err) {
         case ErrorPipeBusy: return "pipe busy";
         case ErrorPrimitiveTypeNotFound: return "primitive type not found";
         case ErrorCacheUnavailable: return "cache unavailable";
+        case ErrorPathTooLong: return "path too long";
+        case ErrorCCompilerCannotFindFile: return "C compiler cannot find file";
     }
     return "(invalid error)";
 }

--- a/src/error.hpp
+++ b/src/error.hpp
@@ -36,6 +36,8 @@ enum Error {
     ErrorPipeBusy,
     ErrorPrimitiveTypeNotFound,
     ErrorCacheUnavailable,
+    ErrorPathTooLong,
+    ErrorCCompilerCannotFindFile,
 };
 
 const char *err_str(Error err);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -18690,8 +18690,6 @@ static IrInstruction *ir_analyze_instruction_c_import(IrAnalyze *ira, IrInstruct
     if (type_is_invalid(cimport_result->type))
         return ira->codegen->invalid_instruction;
 
-    find_libc_include_path(ira->codegen);
-
     ImportTableEntry *child_import = allocate<ImportTableEntry>(1);
     child_import->decls_scope = create_decls_scope(ira->codegen, node, nullptr, nullptr, child_import);
     child_import->c_import_node = node;

--- a/src/libc_installation.cpp
+++ b/src/libc_installation.cpp
@@ -256,6 +256,7 @@ static Error zig_libc_find_native_include_dir_posix(ZigLibCInstallation *self, b
     }
     return ErrorFileNotFound;
 }
+#if !defined(ZIG_OS_DARWIN)
 static Error zig_libc_cc_print_file_name(const char *o_file, Buf *out, bool want_dirname, bool verbose) {
     const char *cc_exe = getenv("CC");
     cc_exe = (cc_exe == nullptr) ? "cc" : cc_exe;
@@ -297,6 +298,7 @@ static Error zig_libc_find_native_lib_dir_posix(ZigLibCInstallation *self, bool 
 static Error zig_libc_find_native_static_lib_dir_posix(ZigLibCInstallation *self, bool verbose) {
     return zig_libc_cc_print_file_name("crtbegin.o", &self->static_lib_dir, true, verbose);
 }
+#endif
 
 static Error zig_libc_find_native_dynamic_linker_posix(ZigLibCInstallation *self, bool verbose) {
 #if defined(ZIG_OS_LINUX)

--- a/src/libc_installation.cpp
+++ b/src/libc_installation.cpp
@@ -48,7 +48,7 @@ Error zig_libc_parse(ZigLibCInstallation *libc, Buf *libc_file, const ZigTarget 
 
     Buf *contents = buf_alloc();
     if ((err = os_fetch_file_path(libc_file, contents, false))) {
-        if (verbose) {
+        if (err != ErrorFileNotFound && verbose) {
             fprintf(stderr, "Unable to read '%s': %s\n", buf_ptr(libc_file), err_str(err));
         }
         return err;
@@ -323,8 +323,8 @@ static Error zig_libc_find_native_dynamic_linker_posix(ZigLibCInstallation *self
 }
 #endif
 
-void zig_libc_render(ZigLibCInstallation *self) {
-    printf(
+void zig_libc_render(ZigLibCInstallation *self, FILE *file) {
+    fprintf(file,
         "# The directory that contains `stdlib.h`.\n"
         "# On Linux, can be found with: `cc -E -Wp,-v -xc /dev/null`\n"
         "include_dir=%s\n"

--- a/src/libc_installation.cpp
+++ b/src/libc_installation.cpp
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2019 Andrew Kelley
+ *
+ * This file is part of zig, which is MIT licensed.
+ * See http://opensource.org/licenses/MIT
+ */
+
+#include "libc_installation.hpp"
+#include "os.hpp"
+#include "windows_sdk.h"
+#include "target.hpp"
+
+static const size_t zig_libc_keys_len = 6;
+
+static const char *zig_libc_keys[] = {
+    "include_dir",
+    "lib_dir",
+    "static_lib_dir",
+    "msvc_lib_dir",
+    "kernel32_lib_dir",
+    "dynamic_linker_path",
+};
+
+static bool zig_libc_match_key(Slice<uint8_t> name, Slice<uint8_t> value, bool *found_keys,
+        size_t index, Buf *field_ptr)
+{
+    if (!memEql(name, str(zig_libc_keys[index]))) return false;
+    buf_init_from_mem(field_ptr, (const char*)value.ptr, value.len);
+    found_keys[index] = true;
+    return true;
+}
+
+static void zig_libc_init_empty(ZigLibCInstallation *libc) {
+    *libc = {};
+    buf_init_from_str(&libc->include_dir, "");
+    buf_init_from_str(&libc->lib_dir, "");
+    buf_init_from_str(&libc->static_lib_dir, "");
+    buf_init_from_str(&libc->msvc_lib_dir, "");
+    buf_init_from_str(&libc->kernel32_lib_dir, "");
+    buf_init_from_str(&libc->dynamic_linker_path, "");
+}
+
+Error zig_libc_parse(ZigLibCInstallation *libc, Buf *libc_file, const ZigTarget *target, bool verbose) {
+    Error err;
+    zig_libc_init_empty(libc);
+
+    bool found_keys[6] = {}; // zig_libc_keys_len
+
+    Buf *contents = buf_alloc();
+    if ((err = os_fetch_file_path(libc_file, contents, false))) {
+        if (verbose) {
+            fprintf(stderr, "Unable to read '%s': %s\n", buf_ptr(libc_file), err_str(err));
+        }
+        return err;
+    }
+
+    SplitIterator it = memSplit(buf_to_slice(contents), str("\n"));
+    for (;;) {
+        Optional<Slice<uint8_t>> opt_line = SplitIterator_next(&it);
+        if (!opt_line.is_some)
+            break;
+
+        if (opt_line.value.len == 0 || opt_line.value.ptr[0] == '#')
+            continue;
+
+        SplitIterator line_it = memSplit(opt_line.value, str("="));
+        Slice<uint8_t> name;
+        if (!SplitIterator_next(&line_it).unwrap(&name)) {
+            if (verbose) {
+                fprintf(stderr, "missing equal sign after field name\n");
+            }
+            return ErrorSemanticAnalyzeFail;
+        }
+        Slice<uint8_t> value = SplitIterator_rest(&line_it);
+        bool match = false;
+        match = match || zig_libc_match_key(name, value, found_keys, 0, &libc->include_dir);
+        match = match || zig_libc_match_key(name, value, found_keys, 1, &libc->lib_dir);
+        match = match || zig_libc_match_key(name, value, found_keys, 2, &libc->static_lib_dir);
+        match = match || zig_libc_match_key(name, value, found_keys, 3, &libc->msvc_lib_dir);
+        match = match || zig_libc_match_key(name, value, found_keys, 4, &libc->kernel32_lib_dir);
+        match = match || zig_libc_match_key(name, value, found_keys, 5, &libc->dynamic_linker_path);
+    }
+
+    for (size_t i = 0; i < zig_libc_keys_len; i += 1) {
+        if (!found_keys[i]) {
+            if (verbose) {
+                fprintf(stderr, "missing field: %s\n", zig_libc_keys[i]);
+            }
+            return ErrorSemanticAnalyzeFail;
+        }
+    }
+
+    if (buf_len(&libc->include_dir) == 0) {
+        if (verbose) {
+            fprintf(stderr, "include_dir may not be empty\n");
+        }
+        return ErrorSemanticAnalyzeFail;
+    }
+
+    if (buf_len(&libc->lib_dir) == 0) {
+        if (!target_is_darwin(target)) {
+            if (verbose) {
+                fprintf(stderr, "lib_dir may not be empty for %s\n", get_target_os_name(target->os));
+            }
+            return ErrorSemanticAnalyzeFail;
+        }
+    }
+
+    if (buf_len(&libc->static_lib_dir) == 0) {
+        if (!target_is_darwin(target) && target->os != OsWindows) {
+            if (verbose) {
+                fprintf(stderr, "static_lib_dir may not be empty for %s\n", get_target_os_name(target->os));
+            }
+            return ErrorSemanticAnalyzeFail;
+        }
+    }
+
+    if (buf_len(&libc->msvc_lib_dir) == 0) {
+        if (target->os == OsWindows) {
+            if (verbose) {
+                fprintf(stderr, "msvc_lib_dir may not be empty for %s\n", get_target_os_name(target->os));
+            }
+            return ErrorSemanticAnalyzeFail;
+        }
+    }
+
+    if (buf_len(&libc->kernel32_lib_dir) == 0) {
+        if (target->os == OsWindows) {
+            if (verbose) {
+                fprintf(stderr, "kernel32_lib_dir may not be empty for %s\n", get_target_os_name(target->os));
+            }
+            return ErrorSemanticAnalyzeFail;
+        }
+    }
+
+    if (buf_len(&libc->dynamic_linker_path) == 0) {
+        if (target->os == OsLinux) {
+            if (verbose) {
+                fprintf(stderr, "dynamic_linker_path may not be empty for %s\n", get_target_os_name(target->os));
+            }
+            return ErrorSemanticAnalyzeFail;
+        }
+    }
+
+    return ErrorNone;
+}
+
+#if defined(ZIG_OS_WINDOWS)
+static Error zig_libc_find_native_include_dir_windows(ZigLibCInstallation *self, ZigWindowsSDK *sdk, bool verbose) {
+    Error err;
+    if ((err = os_get_win32_ucrt_include_path(sdk, &self->include_dir))) {
+        if (verbose) {
+            fprintf(stderr, "Unable to determine libc include path: %s\n", err_str(err));
+        }
+        return err;
+    }
+    return ErrorNone;
+}
+static Error zig_libc_find_lib_dir_windows(ZigLibCInstallation *self, ZigWindowsSDK *sdk, ZigTarget *target,
+        bool verbose)
+{
+    Error err;
+    if ((err = os_get_win32_ucrt_lib_path(sdk, &self->lib_dir, target->arch.arch))) {
+        if (verbose) {
+            fprintf(stderr, "Unable to determine ucrt path: %s\n", err_str(err));
+        }
+        return err;
+    }
+    return ErrorNone;
+}
+static Error zig_libc_find_kernel32_lib_dir(ZigLibCInstallation *self, ZigWindowsSDK *sdk, ZigTarget *target,
+        bool verbose)
+{
+    Error err;
+    if ((err = os_get_win32_kern32_path(sdk, &self->kernel32_lib_dir, target->arch.arch))) {
+        if (verbose) {
+            fprintf(stderr, "Unable to determine kernel32 path: %s\n", err_str(err));
+        }
+        return err;
+    }
+    return ErrorNone;
+}
+static Error zig_libc_find_native_msvc_lib_dir(ZigLibCInstallation *self, ZigWindowsSDK *sdk, bool verbose) {
+    if (sdk->msvc_lib_dir_ptr == nullptr) {
+        if (verbose) {
+            fprintf(stderr, "Unable to determine vcruntime path\n");
+        }
+        return ErrorFileNotFound;
+    }
+    buf_init_from_mem(&self->msvc_lib_dir, sdk->msvc_lib_dir_ptr, sdk->msvc_lib_dir_len);
+    return ErrorNone;
+}
+#else
+static Error zig_libc_find_native_include_dir_posix(ZigLibCInstallation *self, bool verbose) {
+    const char *cc_exe = getenv("CC");
+    cc_exe = (cc_exe == nullptr) ? "cc" : cc_exe;
+    ZigList<const char *> args = {};
+    args.append("-E");
+    args.append("-Wp,-v");
+    args.append("-xc");
+    args.append("/dev/null");
+    Termination term;
+    Buf *out_stderr = buf_alloc();
+    Buf *out_stdout = buf_alloc();
+    Error err;
+    if ((err = os_exec_process(cc_exe, args, &term, out_stderr, out_stdout))) {
+        if (verbose) {
+            fprintf(stderr, "unable to determine libc include path: executing '%s': %s\n", cc_exe, err_str(err));
+        }
+        return err;
+    }
+    if (term.how != TerminationIdClean || term.code != 0) {
+        if (verbose) {
+            fprintf(stderr, "unable to determine libc include path: executing '%s' failed\n", cc_exe);
+        }
+        return ErrorCCompileErrors;
+    }
+    char *prev_newline = buf_ptr(out_stderr);
+    ZigList<const char *> search_paths = {};
+    for (;;) {
+        char *newline = strchr(prev_newline, '\n');
+        if (newline == nullptr) {
+            break;
+        }
+        *newline = 0;
+        if (prev_newline[0] == ' ') {
+            search_paths.append(prev_newline);
+        }
+        prev_newline = newline + 1;
+    }
+    if (search_paths.length == 0) {
+        if (verbose) {
+            fprintf(stderr, "unable to determine libc include path: '%s' cannot find libc headers\n", cc_exe);
+        }
+        return ErrorCCompileErrors;
+    }
+    for (size_t i = 0; i < search_paths.length; i += 1) {
+        // search in reverse order
+        const char *search_path = search_paths.items[search_paths.length - i - 1];
+        // cut off spaces
+        while (*search_path == ' ') {
+            search_path += 1;
+        }
+        Buf *stdlib_path = buf_sprintf("%s/stdlib.h", search_path);
+        bool exists;
+        if ((err = os_file_exists(stdlib_path, &exists))) {
+            exists = false;
+        }
+        if (exists) {
+            buf_init_from_str(&self->include_dir, search_path);
+            return ErrorNone;
+        }
+    }
+    if (verbose) {
+        fprintf(stderr, "unable to determine libc include path: stdlib.h not found in '%s' search paths\n", cc_exe);
+    }
+    return ErrorFileNotFound;
+}
+static Error zig_libc_cc_print_file_name(const char *o_file, Buf *out, bool want_dirname, bool verbose) {
+    const char *cc_exe = getenv("CC");
+    cc_exe = (cc_exe == nullptr) ? "cc" : cc_exe;
+    ZigList<const char *> args = {};
+    args.append(buf_ptr(buf_sprintf("-print-file-name=%s", o_file)));
+    Termination term;
+    Buf *out_stderr = buf_alloc();
+    Buf *out_stdout = buf_alloc();
+    Error err;
+    if ((err = os_exec_process(cc_exe, args, &term, out_stderr, out_stdout))) {
+        if (verbose) {
+            fprintf(stderr, "unable to determine libc include path: executing '%s': %s\n", cc_exe, err_str(err));
+        }
+        return err;
+    }
+    if (term.how != TerminationIdClean || term.code != 0) {
+        if (verbose) {
+            fprintf(stderr, "unable to determine libc include path: executing '%s' failed\n", cc_exe);
+        }
+        return ErrorCCompileErrors;
+    }
+    if (buf_ends_with_str(out_stdout, "\n")) {
+        buf_resize(out_stdout, buf_len(out_stdout) - 1);
+    }
+    if (buf_len(out_stdout) == 0 || buf_eql_str(out_stdout, o_file)) {
+        return ErrorCCompilerCannotFindFile;
+    }
+    if (want_dirname) {
+        os_path_dirname(out_stdout, out);
+    } else {
+        buf_init_from_buf(out, out_stdout);
+    }
+    return ErrorNone;
+}
+static Error zig_libc_find_native_lib_dir_posix(ZigLibCInstallation *self, bool verbose) {
+    return zig_libc_cc_print_file_name("crt1.o", &self->lib_dir, true, verbose);
+}
+
+static Error zig_libc_find_native_static_lib_dir_posix(ZigLibCInstallation *self, bool verbose) {
+    return zig_libc_cc_print_file_name("crtbegin.o", &self->static_lib_dir, true, verbose);
+}
+
+static Error zig_libc_find_native_dynamic_linker_posix(ZigLibCInstallation *self, bool verbose) {
+#if defined(ZIG_OS_LINUX)
+    Error err;
+    static const char *dyn_tests[] = {
+        "ld-linux-x86-64.so.2",
+        "ld-musl-x86_64.so.1",
+    };
+    for (size_t i = 0; i < array_length(dyn_tests); i += 1) {
+        const char *lib_name = dyn_tests[i];
+        if ((err = zig_libc_cc_print_file_name(lib_name, &self->dynamic_linker_path, false, true))) {
+            if (err != ErrorCCompilerCannotFindFile)
+                return err;
+            continue;
+        }
+        return ErrorNone;
+    }
+#endif
+    ZigTarget native_target;
+    get_native_target(&native_target);
+    Buf *dynamic_linker_path = target_dynamic_linker(&native_target);
+    buf_init_from_buf(&self->dynamic_linker_path, dynamic_linker_path);
+    return ErrorNone;
+}
+#endif
+
+void zig_libc_render(ZigLibCInstallation *self) {
+    printf(
+        "# The directory that contains `stdlib.h`.\n"
+        "# On Linux, can be found with: `cc -E -Wp,-v -xc /dev/null`\n"
+        "include_dir=%s\n"
+        "\n"
+        "# The directory that contains `crt1.o`.\n"
+        "# On Linux, can be found with `cc -print-file-name=crt1.o`.\n"
+        "# Not needed when targeting MacOS.\n"
+        "lib_dir=%s\n"
+        "\n"
+        "# The directory that contains `crtbegin.o`.\n"
+        "# On Linux, can be found with `cc -print-file-name=crtbegin.o`.\n"
+        "# Not needed when targeting MacOS or Windows.\n"
+        "static_lib_dir=%s\n"
+        "\n"
+        "# The directory that contains `vcruntime.lib`.\n"
+        "# Only needed when targeting Windows.\n"
+        "msvc_lib_dir=%s\n"
+        "\n"
+        "# The directory that contains `kernel32.lib`.\n"
+        "# Only needed when targeting Windows.\n"
+        "kernel32_lib_dir=%s\n"
+        "\n"
+        "# The full path to the dynamic linker, on the target system.\n"
+        "# Only needed when targeting Linux.\n"
+        "dynamic_linker_path=%s\n"
+        "\n"
+    ,
+        buf_ptr(&self->include_dir),
+        buf_ptr(&self->lib_dir),
+        buf_ptr(&self->static_lib_dir),
+        buf_ptr(&self->msvc_lib_dir),
+        buf_ptr(&self->kernel32_lib_dir),
+        buf_ptr(&self->dynamic_linker_path)
+    );
+}
+
+Error zig_libc_find_native(ZigLibCInstallation *self, bool verbose) {
+    Error err;
+    zig_libc_init_empty(self);
+#if defined(ZIG_OS_WINDOWS)
+    ZigTarget native_target;
+    get_native_target(&native_target);
+    ZigWindowsSDK *sdk;
+    switch (zig_find_windows_sdk(&sdk)) {
+        case ZigFindWindowsSdkErrorNone:
+            if ((err = zig_libc_find_native_msvc_lib_dir(self, sdk, verbose)))
+                return err;
+            if ((err = zig_libc_find_kernel32_lib_dir(self, sdk, &native_target, verbose)))
+                return err;
+            if ((err = zig_libc_find_native_include_dir_windows(self, sdk, verbose)))
+                return err;
+            if ((err = zig_libc_find_lib_dir_windows(self, sdk, &native_target, verbose)))
+                return err;
+            return ErrorNone;
+        case ZigFindWindowsSdkErrorOutOfMemory:
+            return ErrorNoMem;
+        case ZigFindWindowsSdkErrorNotFound:
+            return ErrorFileNotFound;
+        case ZigFindWindowsSdkErrorPathTooLong:
+            return ErrorPathTooLong;
+    }
+    zig_unreachable();
+#else
+    if ((err = zig_libc_find_native_include_dir_posix(self, verbose)))
+        return err;
+#if defined(ZIG_OS_FREEBSD) || defined(ZIG_OS_NETBSD)
+    buf_init_from_str(&self->lib_dir, "/usr/lib");
+    buf_init_from_str(&self->static_lib_dir, "/usr/lib");
+#elif !defined(ZIG_OS_DARWIN)
+    if ((err = zig_libc_find_native_lib_dir_posix(self, verbose)))
+        return err;
+    if ((err = zig_libc_find_native_static_lib_dir_posix(self, verbose)))
+        return err;
+#endif
+    if ((err = zig_libc_find_native_dynamic_linker_posix(self, verbose)))
+        return err;
+    return ErrorNone;
+#endif
+}

--- a/src/libc_installation.hpp
+++ b/src/libc_installation.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Andrew Kelley
+ *
+ * This file is part of zig, which is MIT licensed.
+ * See http://opensource.org/licenses/MIT
+ */
+
+#ifndef ZIG_LIBC_INSTALLATION_HPP
+#define ZIG_LIBC_INSTALLATION_HPP
+
+#include "buffer.hpp"
+#include "error.hpp"
+#include "target.hpp"
+
+// Must be synchronized with zig_libc_keys
+struct ZigLibCInstallation {
+    Buf include_dir;
+    Buf lib_dir;
+    Buf static_lib_dir;
+    Buf msvc_lib_dir;
+    Buf kernel32_lib_dir;
+    Buf dynamic_linker_path;
+};
+
+Error ATTRIBUTE_MUST_USE zig_libc_parse(ZigLibCInstallation *libc, Buf *libc_file,
+        const ZigTarget *target, bool verbose);
+void zig_libc_render(ZigLibCInstallation *self);
+
+Error ATTRIBUTE_MUST_USE zig_libc_find_native(ZigLibCInstallation *self, bool verbose);
+
+#endif

--- a/src/libc_installation.hpp
+++ b/src/libc_installation.hpp
@@ -8,6 +8,8 @@
 #ifndef ZIG_LIBC_INSTALLATION_HPP
 #define ZIG_LIBC_INSTALLATION_HPP
 
+#include <stdio.h>
+
 #include "buffer.hpp"
 #include "error.hpp"
 #include "target.hpp"
@@ -24,7 +26,7 @@ struct ZigLibCInstallation {
 
 Error ATTRIBUTE_MUST_USE zig_libc_parse(ZigLibCInstallation *libc, Buf *libc_file,
         const ZigTarget *target, bool verbose);
-void zig_libc_render(ZigLibCInstallation *self);
+void zig_libc_render(ZigLibCInstallation *self, FILE *file);
 
 Error ATTRIBUTE_MUST_USE zig_libc_find_native(ZigLibCInstallation *self, bool verbose);
 

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -18,31 +18,32 @@ struct LinkJob {
 };
 
 static const char *get_libc_file(CodeGen *g, const char *file) {
+    assert(g->libc != nullptr);
     Buf *out_buf = buf_alloc();
-    os_path_join(g->libc_lib_dir, buf_create_from_str(file), out_buf);
+    os_path_join(&g->libc->lib_dir, buf_create_from_str(file), out_buf);
     return buf_ptr(out_buf);
 }
 
 static const char *get_libc_static_file(CodeGen *g, const char *file) {
+    assert(g->libc != nullptr);
     Buf *out_buf = buf_alloc();
-    os_path_join(g->libc_static_lib_dir, buf_create_from_str(file), out_buf);
+    os_path_join(&g->libc->static_lib_dir, buf_create_from_str(file), out_buf);
     return buf_ptr(out_buf);
 }
 
 static Buf *build_a_raw(CodeGen *parent_gen, const char *aname, Buf *full_path) {
-    ZigTarget *child_target = parent_gen->is_native_target ? nullptr : &parent_gen->zig_target;
-
     // The Mach-O LLD code is not well maintained, and trips an assertion
     // when we link compiler_rt and builtin as libraries rather than objects.
     // Here we workaround this by having compiler_rt and builtin be objects.
     // TODO write our own linker. https://github.com/ziglang/zig/issues/1535
     OutType child_out_type = OutTypeLib;
-    if (parent_gen->zig_target.os == OsMacOSX) {
+    if (parent_gen->zig_target->os == OsMacOSX) {
         child_out_type = OutTypeObj;
     }
 
-    CodeGen *child_gen = codegen_create(full_path, child_target, child_out_type,
-        parent_gen->build_mode, parent_gen->zig_lib_dir, parent_gen->zig_std_dir);
+    CodeGen *child_gen = codegen_create(full_path, parent_gen->zig_target, child_out_type,
+        parent_gen->build_mode, parent_gen->zig_lib_dir, parent_gen->zig_std_dir,
+        parent_gen->libc);
 
     child_gen->out_h_path = nullptr;
     child_gen->verbose_tokenize = parent_gen->verbose_tokenize;
@@ -171,61 +172,10 @@ static void add_rpath(LinkJob *lj, Buf *rpath) {
     lj->rpath_table.put(rpath, true);
 }
 
-static Buf *try_dynamic_linker_path(const char *ld_name) {
-    const char *cc_exe = getenv("CC");
-    cc_exe = (cc_exe == nullptr) ? "cc" : cc_exe;
-    ZigList<const char *> args = {};
-    args.append(buf_ptr(buf_sprintf("-print-file-name=%s", ld_name)));
-    Termination term;
-    Buf *out_stderr = buf_alloc();
-    Buf *out_stdout = buf_alloc();
-    int err;
-    if ((err = os_exec_process(cc_exe, args, &term, out_stderr, out_stdout))) {
-        return nullptr;
-    }
-    if (term.how != TerminationIdClean || term.code != 0) {
-        return nullptr;
-    }
-    if (buf_ends_with_str(out_stdout, "\n")) {
-        buf_resize(out_stdout, buf_len(out_stdout) - 1);
-    }
-    if (buf_len(out_stdout) == 0 || buf_eql_str(out_stdout, ld_name)) {
-        return nullptr;
-    }
-    return out_stdout;
-}
-
-static Buf *get_dynamic_linker_path(CodeGen *g) {
-    if (g->zig_target.os == OsFreeBSD) {
-        return buf_create_from_str("/libexec/ld-elf.so.1");
-    }
-    if (g->zig_target.os == OsNetBSD) {
-        return buf_create_from_str("/libexec/ld.elf_so");
-    }
-    if (g->is_native_target && g->zig_target.arch.arch == ZigLLVM_x86_64) {
-        static const char *ld_names[] = {
-            "ld-linux-x86-64.so.2",
-            "ld-musl-x86_64.so.1",
-        };
-        for (size_t i = 0; i < array_length(ld_names); i += 1) {
-            const char *ld_name = ld_names[i];
-            Buf *result = try_dynamic_linker_path(ld_name);
-            if (result != nullptr) {
-                return result;
-            }
-        }
-    }
-    return target_dynamic_linker(&g->zig_target);
-}
-
 static void construct_linker_job_elf(LinkJob *lj) {
     CodeGen *g = lj->codegen;
 
     lj->args.append("-error-limit=0");
-
-    if (g->libc_link_lib != nullptr) {
-        find_libc_lib_path(g);
-    }
 
     if (g->linker_script) {
         lj->args.append("-T");
@@ -235,14 +185,14 @@ static void construct_linker_job_elf(LinkJob *lj) {
     lj->args.append("--gc-sections");
 
     lj->args.append("-m");
-    lj->args.append(getLDMOption(&g->zig_target));
+    lj->args.append(getLDMOption(g->zig_target));
 
     bool is_lib = g->out_type == OutTypeLib;
     bool shared = !g->is_static && is_lib;
     Buf *soname = nullptr;
     if (g->is_static) {
-        if (g->zig_target.arch.arch == ZigLLVM_arm || g->zig_target.arch.arch == ZigLLVM_armeb ||
-            g->zig_target.arch.arch == ZigLLVM_thumb || g->zig_target.arch.arch == ZigLLVM_thumbeb)
+        if (g->zig_target->arch.arch == ZigLLVM_arm || g->zig_target->arch.arch == ZigLLVM_armeb ||
+            g->zig_target->arch.arch == ZigLLVM_thumb || g->zig_target->arch.arch == ZigLLVM_thumbeb)
         {
             lj->args.append("-Bstatic");
         } else {
@@ -264,13 +214,13 @@ static void construct_linker_job_elf(LinkJob *lj) {
     if (lj->link_in_crt) {
         const char *crt1o;
         const char *crtbegino;
-        if (g->zig_target.os == OsNetBSD) {
-	    crt1o = "crt0.o";
-	    crtbegino = "crtbegin.o";
-	} else if (g->is_static) {
+        if (g->zig_target->os == OsNetBSD) {
+            crt1o = "crt0.o";
+            crtbegino = "crtbegin.o";
+        } else if (g->is_static) {
             crt1o = "crt1.o";
             crtbegino = "crtbeginT.o";
-	} else {
+        } else {
             crt1o = "Scrt1.o";
             crtbegino = "crtbegin.o";
         }
@@ -311,23 +261,19 @@ static void construct_linker_job_elf(LinkJob *lj) {
     }
 
     if (g->libc_link_lib != nullptr) {
+        assert(g->libc != nullptr);
         lj->args.append("-L");
-        lj->args.append(buf_ptr(g->libc_lib_dir));
+        lj->args.append(buf_ptr(&g->libc->lib_dir));
 
         lj->args.append("-L");
-        lj->args.append(buf_ptr(g->libc_static_lib_dir));
-    }
+        lj->args.append(buf_ptr(&g->libc->static_lib_dir));
 
-    if (!g->is_static) {
-        if (g->dynamic_linker != nullptr) {
-            assert(buf_len(g->dynamic_linker) != 0);
+        if (!g->is_static) {
+            assert(buf_len(&g->libc->dynamic_linker_path) != 0);
             lj->args.append("-dynamic-linker");
-            lj->args.append(buf_ptr(g->dynamic_linker));
-        } else {
-            Buf *resolved_dynamic_linker = get_dynamic_linker_path(g);
-            lj->args.append("-dynamic-linker");
-            lj->args.append(buf_ptr(resolved_dynamic_linker));
+            lj->args.append(buf_ptr(&g->libc->dynamic_linker_path));
         }
+
     }
 
     if (shared) {
@@ -397,11 +343,11 @@ static void construct_linker_job_elf(LinkJob *lj) {
         lj->args.append(get_libc_file(g, "crtn.o"));
     }
 
-    if (!g->is_native_target) {
+    if (!g->zig_target->is_native) {
         lj->args.append("--allow-shlib-undefined");
     }
 
-    if (g->zig_target.os == OsZen) {
+    if (g->zig_target->os == OsZen) {
         lj->args.append("-e");
         lj->args.append("_start");
 
@@ -429,11 +375,11 @@ static void construct_linker_job_wasm(LinkJob *lj) {
 //}
 
 static void coff_append_machine_arg(CodeGen *g, ZigList<const char *> *list) {
-    if (g->zig_target.arch.arch == ZigLLVM_x86) {
+    if (g->zig_target->arch.arch == ZigLLVM_x86) {
         list->append("-MACHINE:X86");
-    } else if (g->zig_target.arch.arch == ZigLLVM_x86_64) {
+    } else if (g->zig_target->arch.arch == ZigLLVM_x86_64) {
         list->append("-MACHINE:X64");
-    } else if (g->zig_target.arch.arch == ZigLLVM_arm) {
+    } else if (g->zig_target->arch.arch == ZigLLVM_arm) {
         list->append("-MACHINE:ARM");
     }
 }
@@ -592,10 +538,6 @@ static void construct_linker_job_coff(LinkJob *lj) {
 
     lj->args.append("/ERRORLIMIT:0");
 
-    if (g->libc_link_lib != nullptr) {
-        find_libc_lib_path(g);
-    }
-
     lj->args.append("/NOLOGO");
 
     if (!g->strip_debug_symbols) {
@@ -650,13 +592,11 @@ static void construct_linker_job_coff(LinkJob *lj) {
     lj->args.append(buf_ptr(buf_sprintf("-OUT:%s", buf_ptr(&g->output_file_path))));
 
     if (g->libc_link_lib != nullptr) {
-        lj->args.append(buf_ptr(buf_sprintf("-LIBPATH:%s", buf_ptr(g->msvc_lib_dir))));
-        lj->args.append(buf_ptr(buf_sprintf("-LIBPATH:%s", buf_ptr(g->kernel32_lib_dir))));
+        assert(g->libc != nullptr);
 
-        lj->args.append(buf_ptr(buf_sprintf("-LIBPATH:%s", buf_ptr(g->libc_lib_dir))));
-        if (g->libc_static_lib_dir != nullptr) {
-            lj->args.append(buf_ptr(buf_sprintf("-LIBPATH:%s", buf_ptr(g->libc_static_lib_dir))));
-        }
+        lj->args.append(buf_ptr(buf_sprintf("-LIBPATH:%s", buf_ptr(&g->libc->msvc_lib_dir))));
+        lj->args.append(buf_ptr(buf_sprintf("-LIBPATH:%s", buf_ptr(&g->libc->kernel32_lib_dir))));
+        lj->args.append(buf_ptr(buf_sprintf("-LIBPATH:%s", buf_ptr(&g->libc->lib_dir))));
     }
 
     if (is_library && !g->is_static) {
@@ -691,7 +631,7 @@ static void construct_linker_job_coff(LinkJob *lj) {
             continue;
         }
         if (link_lib->provided_explicitly) {
-            if (lj->codegen->zig_target.env_type == ZigLLVM_GNU) {
+            if (lj->codegen->zig_target->env_type == ZigLLVM_GNU) {
                 Buf *arg = buf_sprintf("-l%s", buf_ptr(link_lib->name));
                 lj->args.append(buf_ptr(arg));
             }
@@ -721,7 +661,8 @@ static void construct_linker_job_coff(LinkJob *lj) {
             gen_lib_args.append(buf_ptr(buf_sprintf("-DEF:%s", buf_ptr(def_path))));
             gen_lib_args.append(buf_ptr(buf_sprintf("-OUT:%s", buf_ptr(generated_lib_path))));
             Buf diag = BUF_INIT;
-            if (!zig_lld_link(g->zig_target.oformat, gen_lib_args.items, gen_lib_args.length, &diag)) {
+            ZigLLVM_ObjectFormatType target_ofmt = target_object_format(g->zig_target);
+            if (!zig_lld_link(target_ofmt, gen_lib_args.items, gen_lib_args.length, &diag)) {
                 fprintf(stderr, "%s\n", buf_ptr(&diag));
                 exit(1);
             }
@@ -790,7 +731,7 @@ static void get_darwin_platform(LinkJob *lj, DarwinPlatform *platform) {
         platform->kind = MacOS;
     } else if (g->mios_version_min) {
         platform->kind = IPhoneOS;
-    } else if (g->zig_target.os == OsMacOSX) {
+    } else if (g->zig_target->os == OsMacOSX) {
         platform->kind = MacOS;
         g->mmacosx_version_min = buf_create_from_str("10.10");
     } else {
@@ -817,8 +758,8 @@ static void get_darwin_platform(LinkJob *lj, DarwinPlatform *platform) {
     }
 
     if (platform->kind == IPhoneOS &&
-        (g->zig_target.arch.arch == ZigLLVM_x86 ||
-         g->zig_target.arch.arch == ZigLLVM_x86_64))
+        (g->zig_target->arch.arch == ZigLLVM_x86 ||
+         g->zig_target->arch.arch == ZigLLVM_x86_64))
     {
         platform->kind = IPhoneOSSimulator;
     }
@@ -882,7 +823,7 @@ static void construct_linker_job_macho(LinkJob *lj) {
     }
 
     lj->args.append("-arch");
-    lj->args.append(get_darwin_arch_string(&g->zig_target));
+    lj->args.append(get_darwin_arch_string(g->zig_target));
 
     DarwinPlatform platform;
     get_darwin_platform(lj, &platform);
@@ -939,7 +880,7 @@ static void construct_linker_job_macho(LinkJob *lj) {
                 }
                 break;
             case IPhoneOS:
-                if (g->zig_target.arch.arch == ZigLLVM_aarch64) {
+                if (g->zig_target->arch.arch == ZigLLVM_aarch64) {
                     // iOS does not need any crt1 files for arm64
                 } else if (darwin_version_lt(&platform, 3, 1)) {
                     lj->args.append("-lcrt1.o");
@@ -969,7 +910,7 @@ static void construct_linker_job_macho(LinkJob *lj) {
         lj->args.append(buf_ptr(compiler_rt_o_path));
     }
 
-    if (g->is_native_target) {
+    if (g->zig_target->is_native) {
         for (size_t lib_i = 0; lib_i < g->link_libs_list.length; lib_i += 1) {
             LinkLib *link_lib = g->link_libs_list.at(lib_i);
             if (buf_eql_str(link_lib->name, "c")) {
@@ -1010,7 +951,7 @@ static void construct_linker_job_macho(LinkJob *lj) {
 }
 
 static void construct_linker_job(LinkJob *lj) {
-    switch (lj->codegen->zig_target.oformat) {
+    switch (target_object_format(lj->codegen->zig_target)) {
         case ZigLLVM_UnknownObjectFormat:
             zig_unreachable();
 
@@ -1050,7 +991,7 @@ void codegen_link(CodeGen *g) {
         for (size_t i = 0; i < g->link_objects.length; i += 1) {
             file_names.append((const char *)buf_ptr(g->link_objects.at(i)));
         }
-        ZigLLVM_OSType os_type = get_llvm_os_type(g->zig_target.os);
+        ZigLLVM_OSType os_type = get_llvm_os_type(g->zig_target->os);
         codegen_add_time_event(g, "LLVM Link");
         if (ZigLLVMWriteArchive(buf_ptr(&g->output_file_path), file_names.items, file_names.length, os_type)) {
             fprintf(stderr, "Unable to write archive '%s'\n", buf_ptr(&g->output_file_path));
@@ -1075,7 +1016,7 @@ void codegen_link(CodeGen *g) {
     Buf diag = BUF_INIT;
 
     codegen_add_time_event(g, "LLVM Link");
-    if (g->system_linker_hack && g->zig_target.os == OsMacOSX) {
+    if (g->system_linker_hack && g->zig_target->os == OsMacOSX) {
         Termination term;
         ZigList<const char *> args = {};
         for (size_t i = 1; i < lj.args.length; i += 1) {
@@ -1085,7 +1026,7 @@ void codegen_link(CodeGen *g) {
         if (term.how != TerminationIdClean || term.code != 0) {
             exit(1);
         }
-    } else if (!zig_lld_link(g->zig_target.oformat, lj.args.items, lj.args.length, &diag)) {
+    } else if (!zig_lld_link(target_object_format(g->zig_target), lj.args.items, lj.args.length, &diag)) {
         fprintf(stderr, "%s\n", buf_ptr(&diag));
         exit(1);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -879,7 +879,7 @@ int main(int argc, char **argv) {
         ZigLibCInstallation libc;
         if ((err = zig_libc_find_native(&libc, true)))
             return EXIT_FAILURE;
-        zig_libc_render(&libc);
+        zig_libc_render(&libc, stdout);
         return EXIT_SUCCESS;
     }
     case CmdBuiltin: {

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -1550,7 +1550,7 @@ void os_stderr_set_color(TermColor color) {
 #endif
 }
 
-int os_get_win32_ucrt_lib_path(ZigWindowsSDK *sdk, Buf* output_buf, ZigLLVM_ArchType platform_type) {
+Error os_get_win32_ucrt_lib_path(ZigWindowsSDK *sdk, Buf* output_buf, ZigLLVM_ArchType platform_type) {
 #if defined(ZIG_OS_WINDOWS)
     buf_resize(output_buf, 0);
     buf_appendf(output_buf, "%s\\Lib\\%s\\ucrt\\", sdk->path10_ptr, sdk->version10_ptr);
@@ -1571,7 +1571,7 @@ int os_get_win32_ucrt_lib_path(ZigWindowsSDK *sdk, Buf* output_buf, ZigLLVM_Arch
     buf_init_from_buf(tmp_buf, output_buf);
     buf_append_str(tmp_buf, "ucrt.lib");
     if (GetFileAttributesA(buf_ptr(tmp_buf)) != INVALID_FILE_ATTRIBUTES) {
-        return 0;
+        return ErrorNone;
     }
     else {
         buf_resize(output_buf, 0);
@@ -1582,12 +1582,12 @@ int os_get_win32_ucrt_lib_path(ZigWindowsSDK *sdk, Buf* output_buf, ZigLLVM_Arch
 #endif
 }
 
-int os_get_win32_ucrt_include_path(ZigWindowsSDK *sdk, Buf* output_buf) {
+Error os_get_win32_ucrt_include_path(ZigWindowsSDK *sdk, Buf* output_buf) {
 #if defined(ZIG_OS_WINDOWS)
     buf_resize(output_buf, 0);
     buf_appendf(output_buf, "%s\\Include\\%s\\ucrt", sdk->path10_ptr, sdk->version10_ptr);
     if (GetFileAttributesA(buf_ptr(output_buf)) != INVALID_FILE_ATTRIBUTES) {
-        return 0;
+        return ErrorNone;
     }
     else {
         buf_resize(output_buf, 0);
@@ -1598,7 +1598,7 @@ int os_get_win32_ucrt_include_path(ZigWindowsSDK *sdk, Buf* output_buf) {
 #endif
 }
 
-int os_get_win32_kern32_path(ZigWindowsSDK *sdk, Buf* output_buf, ZigLLVM_ArchType platform_type) {
+Error os_get_win32_kern32_path(ZigWindowsSDK *sdk, Buf* output_buf, ZigLLVM_ArchType platform_type) {
 #if defined(ZIG_OS_WINDOWS)
     {
         buf_resize(output_buf, 0);

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -1620,7 +1620,7 @@ Error os_get_win32_kern32_path(ZigWindowsSDK *sdk, Buf* output_buf, ZigLLVM_Arch
         buf_init_from_buf(tmp_buf, output_buf);
         buf_append_str(tmp_buf, "kernel32.lib");
         if (GetFileAttributesA(buf_ptr(tmp_buf)) != INVALID_FILE_ATTRIBUTES) {
-            return 0;
+            return ErrorNone;
         }
     }
     {
@@ -1643,7 +1643,7 @@ Error os_get_win32_kern32_path(ZigWindowsSDK *sdk, Buf* output_buf, ZigLLVM_Arch
         buf_init_from_buf(tmp_buf, output_buf);
         buf_append_str(tmp_buf, "kernel32.lib");
         if (GetFileAttributesA(buf_ptr(tmp_buf)) != INVALID_FILE_ATTRIBUTES) {
-            return 0;
+            return ErrorNone;
         }
     }
     return ErrorFileNotFound;

--- a/src/os.hpp
+++ b/src/os.hpp
@@ -135,9 +135,9 @@ Error ATTRIBUTE_MUST_USE os_self_exe_path(Buf *out_path);
 
 Error ATTRIBUTE_MUST_USE os_get_app_data_dir(Buf *out_path, const char *appname);
 
-int os_get_win32_ucrt_include_path(ZigWindowsSDK *sdk, Buf *output_buf);
-int os_get_win32_ucrt_lib_path(ZigWindowsSDK *sdk, Buf *output_buf, ZigLLVM_ArchType platform_type);
-int os_get_win32_kern32_path(ZigWindowsSDK *sdk, Buf *output_buf, ZigLLVM_ArchType platform_type);
+Error ATTRIBUTE_MUST_USE os_get_win32_ucrt_include_path(ZigWindowsSDK *sdk, Buf *output_buf);
+Error ATTRIBUTE_MUST_USE os_get_win32_ucrt_lib_path(ZigWindowsSDK *sdk, Buf *output_buf, ZigLLVM_ArchType platform_type);
+Error ATTRIBUTE_MUST_USE os_get_win32_kern32_path(ZigWindowsSDK *sdk, Buf *output_buf, ZigLLVM_ArchType platform_type);
 
 Error ATTRIBUTE_MUST_USE os_self_exe_shared_libs(ZigList<Buf *> &paths);
 

--- a/src/target.hpp
+++ b/src/target.hpp
@@ -71,7 +71,7 @@ struct ZigTarget {
     ZigLLVM_VendorType vendor;
     Os os;
     ZigLLVM_EnvironmentType env_type;
-    ZigLLVM_ObjectFormatType oformat;
+    bool is_native;
 };
 
 enum CIntType {
@@ -105,8 +105,9 @@ ZigLLVM_EnvironmentType get_target_environ(size_t index);
 
 
 size_t target_oformat_count(void);
-const ZigLLVM_ObjectFormatType get_target_oformat(size_t index);
+ZigLLVM_ObjectFormatType get_target_oformat(size_t index);
 const char *get_target_oformat_name(ZigLLVM_ObjectFormatType oformat);
+ZigLLVM_ObjectFormatType target_object_format(const ZigTarget *target);
 
 void get_native_target(ZigTarget *target);
 void get_unknown_target(ZigTarget *target);
@@ -123,13 +124,14 @@ void resolve_target_object_format(ZigTarget *target);
 
 uint32_t target_c_type_size_in_bits(const ZigTarget *target, CIntType id);
 
-const char *target_o_file_ext(ZigTarget *target);
-const char *target_asm_file_ext(ZigTarget *target);
-const char *target_llvm_ir_file_ext(ZigTarget *target);
-const char *target_exe_file_ext(ZigTarget *target);
-const char *target_lib_file_ext(ZigTarget *target, bool is_static, size_t version_major, size_t version_minor, size_t version_patch);
+const char *target_o_file_ext(const ZigTarget *target);
+const char *target_asm_file_ext(const ZigTarget *target);
+const char *target_llvm_ir_file_ext(const ZigTarget *target);
+const char *target_exe_file_ext(const ZigTarget *target);
+const char *target_lib_file_ext(const ZigTarget *target, bool is_static,
+        size_t version_major, size_t version_minor, size_t version_patch);
 
-Buf *target_dynamic_linker(ZigTarget *target);
+Buf *target_dynamic_linker(const ZigTarget *target);
 
 bool target_can_exec(const ZigTarget *host_target, const ZigTarget *guest_target);
 ZigLLVM_OSType get_llvm_os_type(Os os_type);
@@ -138,5 +140,6 @@ bool target_is_arm(const ZigTarget *target);
 bool target_allows_addr_zero(const ZigTarget *target);
 bool target_has_valgrind_support(const ZigTarget *target);
 bool target_is_darwin(const ZigTarget *target);
+bool target_requires_libc(const ZigTarget *target);
 
 #endif

--- a/src/translate_c.cpp
+++ b/src/translate_c.cpp
@@ -4776,7 +4776,7 @@ Error parse_h_file(ImportTableEntry *import, ZigList<ErrorMsg *> *errors, const 
     clang_argv.append("-x");
     clang_argv.append("c");
 
-    if (c->codegen->is_native_target) {
+    if (c->codegen->zig_target->is_native) {
         char *ZIG_PARSEC_CFLAGS = getenv("ZIG_NATIVE_PARSEC_CFLAGS");
         if (ZIG_PARSEC_CFLAGS) {
             Buf tmp_buf = BUF_INIT;
@@ -4798,9 +4798,9 @@ Error parse_h_file(ImportTableEntry *import, ZigList<ErrorMsg *> *errors, const 
     clang_argv.append("-isystem");
     clang_argv.append(buf_ptr(codegen->zig_c_headers_dir));
 
-    if (codegen->libc_include_dir != nullptr) {
+    if (codegen->libc != nullptr) {
         clang_argv.append("-isystem");
-        clang_argv.append(buf_ptr(codegen->libc_include_dir));
+        clang_argv.append(buf_ptr(&codegen->libc->include_dir));
     }
 
     // windows c runtime requires -D_DEBUG if using debug libraries
@@ -4820,7 +4820,7 @@ Error parse_h_file(ImportTableEntry *import, ZigList<ErrorMsg *> *errors, const 
     clang_argv.append("-Xclang");
     clang_argv.append("-detailed-preprocessing-record");
 
-    if (!c->codegen->is_native_target) {
+    if (!c->codegen->zig_target->is_native) {
         clang_argv.append("-target");
         clang_argv.append(buf_ptr(&c->codegen->triple_str));
     }


### PR DESCRIPTION
This introduces a new command `zig libc` which prints
the various paths of libc files. It outputs them to stdout
in a simple text file format that it is capable of parsing.
You can use `zig libc libc.txt` to validate a file.

Here's what `zig libc` outputs on my machine:

```
# The directory that contains `stdlib.h`.
# On Linux, can be found with: `cc -E -Wp,-v -xc /dev/null`
include_dir=/nix/store/q2q1sg5sljia8sihhwcpbxir70yw33bw-glibc-2.27-dev/include

# The directory that contains `crt1.o`.
# On Linux, can be found with `cc -print-file-name=crt1.o`.
# Not needed when targeting MacOS.
lib_dir=/nix/store/fivq0nbggp4y8mhy3ixprqd7qyn1hy2j-glibc-2.27/lib

# The directory that contains `crtbegin.o`.
# On Linux, can be found with `cc -print-file-name=crtbegin.o`.
# Not needed when targeting MacOS or Windows.
static_lib_dir=/nix/store/4ga86h16l157r7bas9hcwxgl9d3r32s6-gcc-7.4.0/lib/gcc/x86_64-unknown-linux-gnu/7.4.0

# The directory that contains `vcruntime.lib`.
# Only needed when targeting Windows.
msvc_lib_dir=

# The directory that contains `kernel32.lib`.
# Only needed when targeting Windows.
kernel32_lib_dir=

# The full path to the dynamic linker, on the target system.
# Only needed when targeting Linux.
dynamic_linker_path=/nix/store/fivq0nbggp4y8mhy3ixprqd7qyn1hy2j-glibc-2.27/lib/ld-linux-x86-64.so.2
```

These arguments are gone:
--libc-lib-dir [path]        directory where libc crt1.o resides
--libc-static-lib-dir [path] directory where libc crtbegin.o resides
--msvc-lib-dir [path]        (windows) directory where vcruntime.lib resides
--kernel32-lib-dir [path]    (windows) directory where kernel32.lib resides

Instead we have this argument:
--libc [file]                Provide a file which specifies libc paths

This is used to pass a libc text file (which can be generated with
`zig libc`). So it is easier to manage multiple cross compilation
environments.

`--cache on` now works when linking against libc.

`ZigTarget` now has a bool field `is_native`

Better error messaging when you try to link against libc or use
`@cImport` but the various paths cannot be found. It should also be
faster.

The bulk of the work is done. What's left to do:
 * [x] fix test suite regressions
 * [x] when no `--libc` arg is specified, and native libc is found, have it create `zig-cache/libc.txt`, and then have it use this next time instead of finding native libc all over again. this should improve startup time. detecting libc on my system takes 0m0.061s, but parsing libc.txt takes 0m0.012s. On the CI especially for windows I believe the difference is even more significant. If the user wants to re-detect the native libc, they can rm `zig-cache/libc.txt`.