### PR TITLE
only define libc finding functions when not using the BSDs

### DIFF
--- a/src/libc_installation.cpp
+++ b/src/libc_installation.cpp
@@ -303,6 +303,9 @@ static Error zig_libc_cc_print_file_name(const char *o_file, Buf *out, bool want
     }
     return ErrorNone;
 }
+#endif
+
+#if !defined(ZIG_OS_FREEBSD) || !defined(ZIG_OS_NETBSD) || !defined(ZIG_OS_OPENBSD)
 static Error zig_libc_find_native_crt_dir_posix(ZigLibCInstallation *self, bool verbose) {
     return zig_libc_cc_print_file_name("crt1.o", &self->crt_dir, true, verbose);
 }


### PR DESCRIPTION
closes #2012 

Tested only on OpenBSD.