### PR TITLE
Use bitwise-and instead of modulo in __zig_return_error

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -3463,7 +3463,8 @@ static const size_t err_union_err_index = 0;
 static const size_t err_union_payload_index = 1;
 
 // TODO call graph analysis to find out what this number needs to be for every function
-static const size_t stack_trace_ptr_count = 30;
+// MUST BE A POWER OF TWO.
+static const size_t stack_trace_ptr_count = 32;
 
 // these belong to the async function
 #define RETURN_ADDRESSES_FIELD_NAME "return_addresses"

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1236,7 +1236,7 @@ static LLVMValueRef get_add_error_return_trace_addr_fn(CodeGen *g) {
 
     LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->type_ref;
 
-    // stack_trace.instruction_addresses[stack_trace.index % stack_trace.instruction_addresses.len] = return_address;
+    // stack_trace.instruction_addresses[stack_trace.index & (stack_trace.instruction_addresses.len - 1)] = return_address;
 
     LLVMValueRef err_ret_trace_ptr = LLVMGetParam(fn_val, 0);
     LLVMValueRef address_value = LLVMGetParam(fn_val, 1);
@@ -1254,9 +1254,10 @@ static LLVMValueRef get_add_error_return_trace_addr_fn(CodeGen *g) {
 
     LLVMValueRef len_value = gen_load_untyped(g, len_field_ptr, 0, false, "");
     LLVMValueRef index_val = gen_load_untyped(g, index_field_ptr, 0, false, "");
-    LLVMValueRef modded_val = LLVMBuildURem(g->builder, index_val, len_value, "");
+    LLVMValueRef len_val_minus_one = LLVMBuildSub(g->builder, len_value, LLVMConstInt(usize_type_ref, 1, false), "");
+    LLVMValueRef masked_val = LLVMBuildAnd(g->builder, index_val, len_val_minus_one, "");
     LLVMValueRef address_indices[] = {
-        modded_val,
+        masked_val,
     };
 
     LLVMValueRef ptr_value = gen_load_untyped(g, ptr_field_ptr, 0, false, "");


### PR DESCRIPTION
Avoids emitting compiler-rt div calls on some targets.

As mentioned in this [reddit post](https://www.reddit.com/r/Zig/comments/avm3lb/what_is_the_purpose_of_the_call_to_aeabi_uidivmod/). Done a quick test using the following program to confirm the wrapping behaviour.

```zig
fn errorhere(num: i32) !i32 {
    if (num < 33) {
        return errorhere(num + 1);
    } else {
        return error.Maybe;
    }
}

pub fn main !void {
    _ = try errorhere(0);
}
```