### PR TITLE
remove the (namespace) type and make every file an empty struct

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8168,7 +8168,7 @@ coding style.
             If {#syntax#}x{#endsyntax#} is a {#syntax#}type{#endsyntax#}
             then {#syntax#}x{#endsyntax#} should be {#syntax#}TitleCase{#endsyntax#}, unless it
             is a {#syntax#}struct{#endsyntax#} with 0 fields and is never meant to be instantiated,
-            in which case it is considered to be a "namespace" and uses {#syntax#}snake_case{#end_syntax#}.
+            in which case it is considered to be a "namespace" and uses {#syntax#}snake_case{#endsyntax#}.
         </li>
         <li>
             If {#syntax#}x{#endsyntax#} is callable, and {#syntax#}x{#endsyntax#}'s return type is

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6785,7 +6785,6 @@ pub const TypeId = enum {
     Enum,
     Union,
     Fn,
-    Namespace,
     Block,
     BoundFn,
     ArgTuple,
@@ -6820,7 +6819,6 @@ pub const TypeInfo = union(TypeId) {
     Enum: Enum,
     Union: Union,
     Fn: Fn,
-    Namespace: void,
     BoundFn: Fn,
     ArgTuple: void,
     Opaque: void,
@@ -8167,17 +8165,18 @@ coding style.
       </p>
       <ul>
         <li>
-            If {#syntax#}x{#endsyntax#} is a {#syntax#}struct{#endsyntax#} (or an alias of a {#syntax#}struct{#endsyntax#}),
-                        then {#syntax#}x{#endsyntax#} should be {#syntax#}TitleCase{#endsyntax#}.
+            If {#syntax#}x{#endsyntax#} is a {#syntax#}type{#endsyntax#}
+            then {#syntax#}x{#endsyntax#} should be {#syntax#}TitleCase{#endsyntax#}, unless it
+            is a {#syntax#}struct{#endsyntax#} with 0 fields and is never meant to be instantiated,
+            in which case it is considered to be a "namespace" and uses {#syntax#}snake_case{#end_syntax#}.
         </li>
         <li>
-            If {#syntax#}x{#endsyntax#} otherwise identifies a type, {#syntax#}x{#endsyntax#} should have {#syntax#}snake_case{#endsyntax#}.
+            If {#syntax#}x{#endsyntax#} is callable, and {#syntax#}x{#endsyntax#}'s return type is
+            {#syntax#}type{#endsyntax#}, then {#syntax#}x{#endsyntax#} should be {#syntax#}TitleCase{#endsyntax#}.
         </li>
         <li>
-            If {#syntax#}x{#endsyntax#} is callable, and {#syntax#}x{#endsyntax#}'s return type is {#syntax#}type{#endsyntax#}, then {#syntax#}x{#endsyntax#} should be {#syntax#}TitleCase{#endsyntax#}.
-        </li>
-        <li>
-            If {#syntax#}x{#endsyntax#} is otherwise callable, then {#syntax#}x{#endsyntax#} should be {#syntax#}camelCase{#endsyntax#}.
+            If {#syntax#}x{#endsyntax#} is otherwise callable, then {#syntax#}x{#endsyntax#} should
+            be {#syntax#}camelCase{#endsyntax#}.
         </li>
         <li>
             Otherwise, {#syntax#}x{#endsyntax#} should be {#syntax#}snake_case{#endsyntax#}.
@@ -8203,7 +8202,9 @@ const const_name = 42;
 const primitive_type_alias = f32;
 const string_alias = []u8;
 
-const StructName = struct {};
+const StructName = struct {
+    field: i32,
+};
 const StructAlias = StructName;
 
 fn functionName(param_name: TypeName) void {
@@ -8231,7 +8232,9 @@ const xml_document =
     \\<document>
     \\</document>
 ;
-const XmlParser = struct {};
+const XmlParser = struct {
+    field: i32,
+};
 
 // The initials BE (Big Endian) are just another word in Zig identifier names.
 fn readU32Be() u32 {}

--- a/src-self-hosted/compilation.zig
+++ b/src-self-hosted/compilation.zig
@@ -47,7 +47,7 @@ pub const ZigCompiler = struct {
 
     var lazy_init_targets = std.lazyInit(void);
 
-    fn init(loop: *event.Loop) !ZigCompiler {
+    pub fn init(loop: *event.Loop) !ZigCompiler {
         lazy_init_targets.get() orelse {
             Target.initializeAll();
             lazy_init_targets.resolve();

--- a/src-self-hosted/type.zig
+++ b/src-self-hosted/type.zig
@@ -39,7 +39,6 @@ pub const Type = struct {
             Id.ErrorSet => @fieldParentPtr(ErrorSet, "base", base).destroy(comp),
             Id.Enum => @fieldParentPtr(Enum, "base", base).destroy(comp),
             Id.Union => @fieldParentPtr(Union, "base", base).destroy(comp),
-            Id.Namespace => @fieldParentPtr(Namespace, "base", base).destroy(comp),
             Id.BoundFn => @fieldParentPtr(BoundFn, "base", base).destroy(comp),
             Id.ArgTuple => @fieldParentPtr(ArgTuple, "base", base).destroy(comp),
             Id.Opaque => @fieldParentPtr(Opaque, "base", base).destroy(comp),
@@ -73,7 +72,6 @@ pub const Type = struct {
             Id.ErrorSet => return @fieldParentPtr(ErrorSet, "base", base).getLlvmType(allocator, llvm_context),
             Id.Enum => return @fieldParentPtr(Enum, "base", base).getLlvmType(allocator, llvm_context),
             Id.Union => return @fieldParentPtr(Union, "base", base).getLlvmType(allocator, llvm_context),
-            Id.Namespace => unreachable,
             Id.BoundFn => return @fieldParentPtr(BoundFn, "base", base).getLlvmType(allocator, llvm_context),
             Id.ArgTuple => unreachable,
             Id.Opaque => return @fieldParentPtr(Opaque, "base", base).getLlvmType(allocator, llvm_context),
@@ -89,7 +87,6 @@ pub const Type = struct {
             Id.ComptimeInt,
             Id.Undefined,
             Id.Null,
-            Id.Namespace,
             Id.BoundFn,
             Id.ArgTuple,
             Id.Opaque,
@@ -123,7 +120,6 @@ pub const Type = struct {
             Id.ComptimeInt,
             Id.Undefined,
             Id.Null,
-            Id.Namespace,
             Id.BoundFn,
             Id.ArgTuple,
             Id.Opaque,
@@ -1017,14 +1013,6 @@ pub const Type = struct {
 
         pub fn getLlvmType(self: *Union, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
-        }
-    };
-
-    pub const Namespace = struct {
-        base: Type,
-
-        pub fn destroy(self: *Namespace, comp: *Compilation) void {
-            comp.gpa().destroy(self);
         }
     };
 

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -698,7 +698,7 @@ struct AstNodeUse {
     AstNode *expr;
 
     TldResolution resolution;
-    ConstExprValue *value;
+    ConstExprValue *using_namespace_value;
 };
 
 struct AstNodeIfBoolExpr {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1262,6 +1262,10 @@ enum OnePossibleValue {
     OnePossibleValueYes,
 };
 
+struct ZigTypeOpaque {
+    Buf *bare_name;
+};
+
 struct ZigType {
     ZigTypeId id;
     Buf name;
@@ -1284,6 +1288,7 @@ struct ZigType {
         ZigTypeBoundFn bound_fn;
         ZigTypePromise promise;
         ZigTypeVector vector;
+        ZigTypeOpaque opaque;
     } data;
 
     // use these fields to make sure we don't duplicate type table entries for the same type
@@ -1941,6 +1946,7 @@ struct ScopeDecls {
     ZigType *import;
     // If this is a scope from a container, this is the type entry, otherwise null
     ZigType *container_type;
+    Buf *bare_name;
 
     bool safety_off;
     bool fast_math_on;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1076,6 +1076,7 @@ enum ResolveStatus {
 struct ZigPackage {
     Buf root_src_dir;
     Buf root_src_path; // relative to root_src_dir
+    Buf pkg_path; // a.b.c.d which follows the package dependency chain from the root package
 
     // reminder: hash tables must be initialized before use
     HashMap<Buf *, ZigPackage *, buf_hash, buf_eql_buf> package_table;
@@ -1089,7 +1090,6 @@ struct RootStruct {
     Buf *source_code;
     AstNode *c_import_node;
     ZigLLVMDIFile *di_file;
-    bool scanned;
 };
 
 struct ZigTypeStruct {
@@ -1678,8 +1678,6 @@ struct CodeGen {
     HashMap<Buf *, ConstExprValue *, buf_hash, buf_eql_buf> string_literals_table;
     HashMap<const ZigType *, ConstExprValue *, type_ptr_hash, type_ptr_eql> type_info_cache;
 
-    ZigList<ZigType *> import_queue;
-    size_t import_queue_index;
     ZigList<Tld *> resolve_queue;
     size_t resolve_queue_index;
     ZigList<AstNode *> use_queue;
@@ -3472,6 +3470,8 @@ static const size_t stack_trace_ptr_count = 30;
 #define ERR_RET_TRACE_PTR_FIELD_NAME "err_ret_trace_ptr"
 #define RESULT_PTR_FIELD_NAME "result_ptr"
 
+#define NAMESPACE_SEP_CHAR '.'
+#define NAMESPACE_SEP_STR "."
 
 enum FloatMode {
     FloatModeStrict,

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -369,8 +369,6 @@ struct Tld {
 
     ZigType *import;
     Scope *parent_scope;
-    // set this flag temporarily to detect infinite loops
-    bool dep_loop_flag;
     TldResolution resolution;
 };
 
@@ -380,6 +378,7 @@ struct TldVar {
     ZigVar *var;
     Buf *extern_lib_name;
     Buf *section_name;
+    bool analyzing_type; // flag to detect dependency loops
 };
 
 struct TldFn {

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -28,10 +28,14 @@ static Error ATTRIBUTE_MUST_USE resolve_enum_zero_bits(CodeGen *g, ZigType *enum
 static Error ATTRIBUTE_MUST_USE resolve_union_zero_bits(CodeGen *g, ZigType *union_type);
 static void analyze_fn_body(CodeGen *g, ZigFn *fn_table_entry);
 
-static ErrorMsg *add_error_note_token(CodeGen *g, ErrorMsg *parent_msg, ImportTableEntry *owner, Token *token,
-        Buf *msg)
-{
-    if (owner->c_import_node != nullptr) {
+static bool is_top_level_struct(ZigType *import) {
+    return import->id == ZigTypeIdStruct && import->data.structure.root_struct != nullptr;
+}
+
+static ErrorMsg *add_error_note_token(CodeGen *g, ErrorMsg *parent_msg, ZigType *owner, Token *token, Buf *msg) {
+    assert(is_top_level_struct(owner));
+    RootStruct *root_struct = owner->data.structure.root_struct;
+    if (root_struct->c_import_node != nullptr) {
         // if this happens, then translate_c generated code that
         // failed semantic analysis, which isn't supposed to happen
 
@@ -46,18 +50,20 @@ static ErrorMsg *add_error_note_token(CodeGen *g, ErrorMsg *parent_msg, ImportTa
         return note;
     }
 
-    ErrorMsg *err = err_msg_create_with_line(owner->path, token->start_line, token->start_column,
-            owner->source_code, owner->line_offsets, msg);
+    ErrorMsg *err = err_msg_create_with_line(root_struct->path, token->start_line, token->start_column,
+            root_struct->source_code, root_struct->line_offsets, msg);
 
     err_msg_add_note(parent_msg, err);
     return err;
 }
 
-ErrorMsg *add_token_error(CodeGen *g, ImportTableEntry *owner, Token *token, Buf *msg) {
-    if (owner->c_import_node != nullptr) {
+ErrorMsg *add_token_error(CodeGen *g, ZigType *owner, Token *token, Buf *msg) {
+    assert(is_top_level_struct(owner));
+    RootStruct *root_struct = owner->data.structure.root_struct;
+    if (root_struct->c_import_node != nullptr) {
         // if this happens, then translate_c generated code that
         // failed semantic analysis, which isn't supposed to happen
-        ErrorMsg *err = add_node_error(g, owner->c_import_node,
+        ErrorMsg *err = add_node_error(g, root_struct->c_import_node,
             buf_sprintf("compiler bug: @cImport generated invalid zig code"));
 
         add_error_note_token(g, err, owner, token, msg);
@@ -65,8 +71,8 @@ ErrorMsg *add_token_error(CodeGen *g, ImportTableEntry *owner, Token *token, Buf
         g->errors.append(err);
         return err;
     }
-    ErrorMsg *err = err_msg_create_with_line(owner->path, token->start_line, token->start_column,
-            owner->source_code, owner->line_offsets, msg);
+    ErrorMsg *err = err_msg_create_with_line(root_struct->path, token->start_line, token->start_column,
+            root_struct->source_code, root_struct->line_offsets, msg);
 
     g->errors.append(err);
     return err;
@@ -114,7 +120,7 @@ void init_scope(CodeGen *g, Scope *dest, ScopeId id, AstNode *source_node, Scope
     dest->parent = parent;
 }
 
-ScopeDecls *create_decls_scope(CodeGen *g, AstNode *node, Scope *parent, ZigType *container_type, ImportTableEntry *import) {
+ScopeDecls *create_decls_scope(CodeGen *g, AstNode *node, Scope *parent, ZigType *container_type, ZigType *import) {
     assert(node == nullptr || node->type == NodeTypeContainerDecl || node->type == NodeTypeFnCallExpr);
     ScopeDecls *scope = allocate<ScopeDecls>(1);
     init_scope(g, &scope->base, ScopeIdDecls, node, parent);
@@ -207,11 +213,11 @@ Scope *create_coro_prelude_scope(CodeGen *g, AstNode *node, Scope *parent) {
     return &scope->base;
 }
 
-ImportTableEntry *get_scope_import(Scope *scope) {
+ZigType *get_scope_import(Scope *scope) {
     while (scope) {
         if (scope->id == ScopeIdDecls) {
             ScopeDecls *decls_scope = (ScopeDecls *)scope;
-            assert(decls_scope->import);
+            assert(is_top_level_struct(decls_scope->import));
             return decls_scope->import;
         }
         scope = scope->parent;
@@ -261,7 +267,6 @@ AstNode *type_decl_node(ZigType *type_entry) {
         case ZigTypeIdErrorUnion:
         case ZigTypeIdErrorSet:
         case ZigTypeIdFn:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdArgTuple:
         case ZigTypeIdPromise:
@@ -323,7 +328,6 @@ bool type_is_resolved(ZigType *type_entry, ResolveStatus status) {
         case ZigTypeIdErrorUnion:
         case ZigTypeIdErrorSet:
         case ZigTypeIdFn:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdArgTuple:
         case ZigTypeIdPromise:
@@ -1010,14 +1014,14 @@ ZigType *get_opaque_type(CodeGen *g, Scope *scope, AstNode *source_node, const c
 
     buf_init_from_str(&entry->name, name);
 
-    ImportTableEntry *import = scope ? get_scope_import(scope) : nullptr;
+    ZigType *import = scope ? get_scope_import(scope) : nullptr;
     unsigned line = source_node ? (unsigned)(source_node->line + 1) : 0;
 
     entry->type_ref = LLVMInt8Type();
     entry->di_type = ZigLLVMCreateDebugForwardDeclType(g->dbuilder,
         ZigLLVMTag_DW_structure_type(), buf_ptr(&entry->name),
-        import ? ZigLLVMFileToScope(import->di_file) : nullptr,
-        import ? import->di_file : nullptr,
+        import ? ZigLLVMFileToScope(import->data.structure.root_struct->di_file) : nullptr,
+        import ? import->data.structure.root_struct->di_file : nullptr,
         line);
     entry->zero_bits = false;
 
@@ -1288,6 +1292,25 @@ static ZigTypeId container_to_type(ContainerKind kind) {
     zig_unreachable();
 }
 
+// This is like get_partial_container_type except it's for the implicit root struct of files.
+ZigType *get_root_container_type(CodeGen *g, const char *name, RootStruct *root_struct) {
+    ZigType *entry = new_type_table_entry(ZigTypeIdStruct);
+    entry->data.structure.decls_scope = create_decls_scope(g, nullptr, nullptr, nullptr, entry);
+    entry->data.structure.root_struct = root_struct;
+    entry->data.structure.layout = ContainerLayoutAuto;
+    entry->type_ref = LLVMStructCreateNamed(LLVMGetGlobalContext(), name);
+
+    size_t line = 0; // root therefore first line
+    unsigned dwarf_kind = ZigLLVMTag_DW_structure_type();
+
+    entry->di_type = ZigLLVMCreateReplaceableCompositeType(g->dbuilder,
+        dwarf_kind, name,
+        ZigLLVMFileToScope(root_struct->di_file), root_struct->di_file, (unsigned)(line + 1));
+
+    buf_init_from_str(&entry->name, name);
+    return entry;
+}
+
 ZigType *get_partial_container_type(CodeGen *g, Scope *scope, ContainerKind kind,
         AstNode *decl_node, const char *name, ContainerLayout layout)
 {
@@ -1312,11 +1335,12 @@ ZigType *get_partial_container_type(CodeGen *g, Scope *scope, ContainerKind kind
     size_t line = decl_node ? decl_node->line : 0;
     unsigned dwarf_kind = ZigLLVMTag_DW_structure_type();
 
-    ImportTableEntry *import = get_scope_import(scope);
+    ZigType *import = get_scope_import(scope);
     entry->type_ref = LLVMStructCreateNamed(LLVMGetGlobalContext(), name);
     entry->di_type = ZigLLVMCreateReplaceableCompositeType(g->dbuilder,
         dwarf_kind, name,
-        ZigLLVMFileToScope(import->di_file), import->di_file, (unsigned)(line + 1));
+        ZigLLVMFileToScope(import->data.structure.root_struct->di_file),
+        import->data.structure.root_struct->di_file, (unsigned)(line + 1));
 
     buf_init_from_str(&entry->name, name);
 
@@ -1459,7 +1483,6 @@ static Error emit_error_unless_type_allowed_in_packed_struct(CodeGen *g, ZigType
         case ZigTypeIdNull:
         case ZigTypeIdErrorUnion:
         case ZigTypeIdErrorSet:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdArgTuple:
         case ZigTypeIdOpaque:
@@ -1547,7 +1570,6 @@ bool type_allowed_in_extern(CodeGen *g, ZigType *type_entry) {
         case ZigTypeIdNull:
         case ZigTypeIdErrorUnion:
         case ZigTypeIdErrorSet:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdArgTuple:
         case ZigTypeIdPromise:
@@ -1706,7 +1728,6 @@ static ZigType *analyze_fn_type(CodeGen *g, AstNode *proto_node, Scope *child_sc
                 return g->builtin_types.entry_invalid;
             case ZigTypeIdComptimeFloat:
             case ZigTypeIdComptimeInt:
-            case ZigTypeIdNamespace:
             case ZigTypeIdBoundFn:
             case ZigTypeIdMetaType:
             case ZigTypeIdVoid:
@@ -1801,7 +1822,6 @@ static ZigType *analyze_fn_type(CodeGen *g, AstNode *proto_node, Scope *child_sc
 
         case ZigTypeIdComptimeFloat:
         case ZigTypeIdComptimeInt:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdMetaType:
         case ZigTypeIdUnreachable:
@@ -1895,7 +1915,7 @@ static Error resolve_enum_type(CodeGen *g, ZigType *enum_type) {
     ZigLLVMDIEnumerator **di_enumerators = allocate<ZigLLVMDIEnumerator*>(field_count);
 
     Scope *scope = &enum_type->data.enumeration.decls_scope->base;
-    ImportTableEntry *import = get_scope_import(scope);
+    ZigType *import = get_scope_import(scope);
 
     // set temporary flag
     enum_type->data.enumeration.embedded_in_current = true;
@@ -1924,9 +1944,9 @@ static Error resolve_enum_type(CodeGen *g, ZigType *enum_type) {
         ZigLLVMDIType **di_root_members = nullptr;
         size_t debug_member_count = 0;
         ZigLLVMDIType *replacement_di_type = ZigLLVMCreateDebugStructType(g->dbuilder,
-                ZigLLVMFileToScope(import->di_file),
+                ZigLLVMFileToScope(import->data.structure.root_struct->di_file),
                 buf_ptr(&enum_type->name),
-                import->di_file, (unsigned)(decl_node->line + 1),
+                import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
                 debug_size_in_bits,
                 debug_align_in_bits,
                 0, nullptr, di_root_members, (int)debug_member_count, 0, nullptr, "");
@@ -1942,8 +1962,8 @@ static Error resolve_enum_type(CodeGen *g, ZigType *enum_type) {
     uint64_t tag_debug_size_in_bits = 8*LLVMStoreSizeOfType(g->target_data_ref, tag_int_type->type_ref);
     uint64_t tag_debug_align_in_bits = 8*LLVMABIAlignmentOfType(g->target_data_ref, tag_int_type->type_ref);
     ZigLLVMDIType *tag_di_type = ZigLLVMCreateDebugEnumerationType(g->dbuilder,
-            ZigLLVMFileToScope(import->di_file), buf_ptr(&enum_type->name),
-            import->di_file, (unsigned)(decl_node->line + 1),
+            ZigLLVMFileToScope(import->data.structure.root_struct->di_file), buf_ptr(&enum_type->name),
+            import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
             tag_debug_size_in_bits,
             tag_debug_align_in_bits,
             di_enumerators, field_count,
@@ -2159,15 +2179,15 @@ static Error resolve_struct_type(CodeGen *g, ZigType *struct_type) {
     if (struct_type->zero_bits) {
         struct_type->type_ref = LLVMVoidType();
 
-        ImportTableEntry *import = get_scope_import(scope);
+        ZigType *import = get_scope_import(scope);
         uint64_t debug_size_in_bits = 0;
         uint64_t debug_align_in_bits = 0;
         ZigLLVMDIType **di_element_types = nullptr;
         size_t debug_field_count = 0;
         ZigLLVMDIType *replacement_di_type = ZigLLVMCreateDebugStructType(g->dbuilder,
-                ZigLLVMFileToScope(import->di_file),
+                ZigLLVMFileToScope(import->data.structure.root_struct->di_file),
                 buf_ptr(&struct_type->name),
-                import->di_file, (unsigned)(decl_node->line + 1),
+                import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
                 debug_size_in_bits,
                 debug_align_in_bits,
                 0, nullptr, di_element_types, (int)debug_field_count, 0, nullptr, "");
@@ -2191,7 +2211,7 @@ static Error resolve_struct_type(CodeGen *g, ZigType *struct_type) {
 
     ZigLLVMDIType **di_element_types = allocate<ZigLLVMDIType*>(debug_field_count);
 
-    ImportTableEntry *import = get_scope_import(scope);
+    ZigType *import = get_scope_import(scope);
     size_t debug_field_index = 0;
     for (size_t i = 0; i < field_count; i += 1) {
         AstNode *field_node = decl_node->data.container_decl.fields.at(i);
@@ -2234,7 +2254,7 @@ static Error resolve_struct_type(CodeGen *g, ZigType *struct_type) {
         }
         di_element_types[debug_field_index] = ZigLLVMCreateDebugMemberType(g->dbuilder,
                 ZigLLVMTypeToScope(struct_type->di_type), buf_ptr(type_struct_field->name),
-                import->di_file, (unsigned)(field_node->line + 1),
+                import->data.structure.root_struct->di_file, (unsigned)(field_node->line + 1),
                 debug_size_in_bits,
                 debug_align_in_bits,
                 debug_offset_in_bits,
@@ -2247,9 +2267,9 @@ static Error resolve_struct_type(CodeGen *g, ZigType *struct_type) {
     uint64_t debug_size_in_bits = 8*LLVMStoreSizeOfType(g->target_data_ref, struct_type->type_ref);
     uint64_t debug_align_in_bits = 8*LLVMABISizeOfType(g->target_data_ref, struct_type->type_ref);
     ZigLLVMDIType *replacement_di_type = ZigLLVMCreateDebugStructType(g->dbuilder,
-            ZigLLVMFileToScope(import->di_file),
+            ZigLLVMFileToScope(import->data.structure.root_struct->di_file),
             buf_ptr(&struct_type->name),
-            import->di_file, (unsigned)(decl_node->line + 1),
+            import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
             debug_size_in_bits,
             debug_align_in_bits,
             0, nullptr, di_element_types, (int)debug_field_count, 0, nullptr, "");
@@ -2298,7 +2318,7 @@ static Error resolve_union_type(CodeGen *g, ZigType *union_type) {
     uint64_t biggest_size_in_bits = 0;
 
     Scope *scope = &union_type->data.unionation.decls_scope->base;
-    ImportTableEntry *import = get_scope_import(scope);
+    ZigType *import = get_scope_import(scope);
 
     // set temporary flag
     union_type->data.unionation.embedded_in_current = true;
@@ -2325,7 +2345,7 @@ static Error resolve_union_type(CodeGen *g, ZigType *union_type) {
 
         union_inner_di_types[union_field->gen_index] = ZigLLVMCreateDebugMemberType(g->dbuilder,
                 ZigLLVMTypeToScope(union_type->di_type), buf_ptr(union_field->enum_field->name),
-                import->di_file, (unsigned)(field_node->line + 1),
+                import->data.structure.root_struct->di_file, (unsigned)(field_node->line + 1),
                 store_size_in_bits,
                 abi_align_in_bits,
                 0,
@@ -2358,9 +2378,9 @@ static Error resolve_union_type(CodeGen *g, ZigType *union_type) {
         ZigLLVMDIType **di_root_members = nullptr;
         size_t debug_member_count = 0;
         ZigLLVMDIType *replacement_di_type = ZigLLVMCreateDebugUnionType(g->dbuilder,
-                ZigLLVMFileToScope(import->di_file),
+                ZigLLVMFileToScope(import->data.structure.root_struct->di_file),
                 buf_ptr(&union_type->name),
-                import->di_file, (unsigned)(decl_node->line + 1),
+                import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
                 debug_size_in_bits,
                 debug_align_in_bits,
                 0, di_root_members, (int)debug_member_count, 0, "");
@@ -2396,8 +2416,8 @@ static Error resolve_union_type(CodeGen *g, ZigType *union_type) {
 
         // create debug type for union
         ZigLLVMDIType *replacement_di_type = ZigLLVMCreateDebugUnionType(g->dbuilder,
-            ZigLLVMFileToScope(import->di_file), buf_ptr(&union_type->name),
-            import->di_file, (unsigned)(decl_node->line + 1),
+            ZigLLVMFileToScope(import->data.structure.root_struct->di_file), buf_ptr(&union_type->name),
+            import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
             biggest_size_in_bits, biggest_align_in_bits, 0, union_inner_di_types,
             gen_field_count, 0, "");
 
@@ -2452,7 +2472,7 @@ static Error resolve_union_type(CodeGen *g, ZigType *union_type) {
     // create debug type for union
     ZigLLVMDIType *union_di_type = ZigLLVMCreateDebugUnionType(g->dbuilder,
             ZigLLVMTypeToScope(union_type->di_type), "AnonUnion",
-            import->di_file, (unsigned)(decl_node->line + 1),
+            import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
             biggest_size_in_bits, biggest_align_in_bits, 0, union_inner_di_types,
             gen_field_count, 0, "");
 
@@ -2463,7 +2483,7 @@ static Error resolve_union_type(CodeGen *g, ZigType *union_type) {
 
     ZigLLVMDIType *union_member_di_type = ZigLLVMCreateDebugMemberType(g->dbuilder,
             ZigLLVMTypeToScope(union_type->di_type), "payload",
-            import->di_file, (unsigned)(decl_node->line + 1),
+            import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
             biggest_size_in_bits,
             biggest_align_in_bits,
             union_offset_in_bits,
@@ -2474,7 +2494,7 @@ static Error resolve_union_type(CodeGen *g, ZigType *union_type) {
 
     ZigLLVMDIType *tag_member_di_type = ZigLLVMCreateDebugMemberType(g->dbuilder,
             ZigLLVMTypeToScope(union_type->di_type), "tag",
-            import->di_file, (unsigned)(decl_node->line + 1),
+            import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
             tag_debug_size_in_bits,
             tag_debug_align_in_bits,
             tag_offset_in_bits,
@@ -2487,9 +2507,9 @@ static Error resolve_union_type(CodeGen *g, ZigType *union_type) {
     uint64_t debug_size_in_bits = 8*LLVMStoreSizeOfType(g->target_data_ref, union_type->type_ref);
     uint64_t debug_align_in_bits = 8*LLVMABISizeOfType(g->target_data_ref, union_type->type_ref);
     ZigLLVMDIType *replacement_di_type = ZigLLVMCreateDebugStructType(g->dbuilder,
-            ZigLLVMFileToScope(import->di_file),
+            ZigLLVMFileToScope(import->data.structure.root_struct->di_file),
             buf_ptr(&union_type->name),
-            import->di_file, (unsigned)(decl_node->line + 1),
+            import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
             debug_size_in_bits,
             debug_align_in_bits,
             0, nullptr, di_root_members, 2, 0, nullptr, "");
@@ -3185,15 +3205,15 @@ static Error resolve_union_zero_bits(CodeGen *g, ZigType *union_type) {
     }
 
     if (create_enum_type) {
-        ImportTableEntry *import = get_scope_import(scope);
+        ZigType *import = get_scope_import(scope);
         uint64_t tag_debug_size_in_bits = tag_type->zero_bits ? 0 :
             8*LLVMStoreSizeOfType(g->target_data_ref, tag_type->type_ref);
         uint64_t tag_debug_align_in_bits = tag_type->zero_bits ? 0 :
             8*LLVMABIAlignmentOfType(g->target_data_ref, tag_type->type_ref);
         // TODO get a more accurate debug scope
         ZigLLVMDIType *tag_di_type = ZigLLVMCreateDebugEnumerationType(g->dbuilder,
-                ZigLLVMFileToScope(import->di_file), buf_ptr(&tag_type->name),
-                import->di_file, (unsigned)(decl_node->line + 1),
+                ZigLLVMFileToScope(import->data.structure.root_struct->di_file), buf_ptr(&tag_type->name),
+                import->data.structure.root_struct->di_file, (unsigned)(decl_node->line + 1),
                 tag_debug_size_in_bits, tag_debug_align_in_bits, di_enumerators, field_count,
                 tag_type->di_type, "");
         tag_type->di_type = tag_di_type;
@@ -3265,7 +3285,8 @@ static bool scope_is_root_decls(Scope *scope) {
     while (scope) {
         if (scope->id == ScopeIdDecls) {
             ScopeDecls *scope_decls = (ScopeDecls *)scope;
-            return (scope_decls->container_type == nullptr);
+            return scope_decls->container_type == nullptr ||
+                is_top_level_struct(scope_decls->container_type);
         }
         scope = scope->parent;
     }
@@ -3326,7 +3347,7 @@ void add_fn_export(CodeGen *g, ZigFn *fn_table_entry, Buf *symbol_name, GlobalLi
 }
 
 static void resolve_decl_fn(CodeGen *g, TldFn *tld_fn) {
-    ImportTableEntry *import = tld_fn->base.import;
+    ZigType *import = tld_fn->base.import;
     AstNode *source_node = tld_fn->base.source_node;
     if (source_node->type == NodeTypeFnProto) {
         AstNodeFnProto *fn_proto = &source_node->data.fn_proto;
@@ -3382,11 +3403,11 @@ static void resolve_decl_fn(CodeGen *g, TldFn *tld_fn) {
         }
 
         if (scope_is_root_decls(tld_fn->base.parent_scope) &&
-            (import == g->root_import || import->package == g->panic_package))
+            (import == g->root_import || import->data.structure.root_struct->package == g->panic_package))
         {
             if (g->have_pub_main && buf_eql_str(&fn_table_entry->symbol_name, "main")) {
                 g->main_fn = fn_table_entry;
-            } else if ((import->package == g->panic_package || g->have_pub_panic) &&
+            } else if ((import->data.structure.root_struct->package == g->panic_package || g->have_pub_panic) &&
                     buf_eql_str(&fn_table_entry->symbol_name, "panic"))
             {
                 g->panic_fn = fn_table_entry;
@@ -3473,8 +3494,8 @@ static void preview_test_decl(CodeGen *g, AstNode *node, ScopeDecls *decls_scope
     if (!g->is_test_build)
         return;
 
-    ImportTableEntry *import = get_scope_import(&decls_scope->base);
-    if (import->package != g->root_package)
+    ZigType *import = get_scope_import(&decls_scope->base);
+    if (import->data.structure.root_struct->package != g->root_package)
         return;
 
     Buf *decl_name_buf = node->data.test_decl.name;
@@ -3511,8 +3532,8 @@ void init_tld(Tld *tld, TldId id, Buf *name, VisibMod visib_mod, AstNode *source
 }
 
 void update_compile_var(CodeGen *g, Buf *name, ConstExprValue *value) {
-    Tld *tld = g->compile_var_import->decls_scope->decl_table.get(name);
-    resolve_top_level_decl(g, tld, false, tld->source_node);
+    Tld *tld = get_container_scope(g->compile_var_import)->decl_table.get(name);
+    resolve_top_level_decl(g, tld, tld->source_node);
     assert(tld->id == TldIdVar);
     TldVar *tld_var = (TldVar *)tld;
     tld_var->var->const_value = value;
@@ -3561,8 +3582,8 @@ void scan_decls(CodeGen *g, ScopeDecls *decls_scope, AstNode *node) {
         case NodeTypeUse:
             {
                 g->use_queue.append(node);
-                ImportTableEntry *import = get_scope_import(&decls_scope->base);
-                import->use_decls.append(node);
+                ZigType *import = get_scope_import(&decls_scope->base);
+                get_container_scope(import)->use_decls.append(node);
                 break;
             }
         case NodeTypeTestDecl:
@@ -3654,7 +3675,6 @@ ZigType *validate_var_type(CodeGen *g, AstNode *source_node, ZigType *type_entry
             return g->builtin_types.entry_invalid;
         case ZigTypeIdComptimeFloat:
         case ZigTypeIdComptimeInt:
-        case ZigTypeIdNamespace:
         case ZigTypeIdMetaType:
         case ZigTypeIdVoid:
         case ZigTypeIdBool:
@@ -3847,15 +3867,9 @@ static void resolve_decl_var(CodeGen *g, TldVar *tld_var) {
     g->global_vars.append(tld_var);
 }
 
-void resolve_top_level_decl(CodeGen *g, Tld *tld, bool pointer_only, AstNode *source_node) {
+void resolve_top_level_decl(CodeGen *g, Tld *tld, AstNode *source_node) {
     if (tld->resolution != TldResolutionUnresolved)
         return;
-
-    if (tld->dep_loop_flag) {
-        add_node_error(g, tld->source_node, buf_sprintf("'%s' depends on itself", buf_ptr(tld->name)));
-        tld->resolution = TldResolutionInvalid;
-        return;
-    }
 
     tld->dep_loop_flag = true;
     g->tld_ref_source_node_stack.append(source_node);
@@ -3894,9 +3908,9 @@ void resolve_top_level_decl(CodeGen *g, Tld *tld, bool pointer_only, AstNode *so
 
 Tld *find_decl(CodeGen *g, Scope *scope, Buf *name) {
     // we must resolve all the use decls
-    ImportTableEntry *import = get_scope_import(scope);
-    for (size_t i = 0; i < import->use_decls.length; i += 1) {
-        AstNode *use_decl_node = import->use_decls.at(i);
+    ZigType *import = get_scope_import(scope);
+    for (size_t i = 0; i < get_container_scope(import)->use_decls.length; i += 1) {
+        AstNode *use_decl_node = get_container_scope(import)->use_decls.at(i);
         if (use_decl_node->data.use.resolution == TldResolutionUnresolved) {
             preview_use_decl(g, use_decl_node);
             resolve_use_decl(g, use_decl_node);
@@ -4039,7 +4053,6 @@ static bool is_container(ZigType *type_entry) {
         case ZigTypeIdErrorUnion:
         case ZigTypeIdErrorSet:
         case ZigTypeIdFn:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdArgTuple:
         case ZigTypeIdOpaque:
@@ -4098,7 +4111,6 @@ void resolve_container_type(CodeGen *g, ZigType *type_entry) {
         case ZigTypeIdErrorUnion:
         case ZigTypeIdErrorSet:
         case ZigTypeIdFn:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdInvalid:
         case ZigTypeIdArgTuple:
@@ -4344,7 +4356,7 @@ static void add_symbols_from_import(CodeGen *g, AstNode *src_use_node, AstNode *
 
     ConstExprValue *use_target_value = src_use_node->data.use.value;
     if (type_is_invalid(use_target_value->type)) {
-        dst_use_node->owner->any_imports_failed = true;
+        get_container_scope(dst_use_node->owner)->any_imports_failed = true;
         return;
     }
 
@@ -4352,14 +4364,15 @@ static void add_symbols_from_import(CodeGen *g, AstNode *src_use_node, AstNode *
 
     assert(use_target_value->special != ConstValSpecialRuntime);
 
-    ImportTableEntry *target_import = use_target_value->data.x_import;
+    ZigType *target_import = use_target_value->data.x_type;
     assert(target_import);
+    assert(target_import->id == ZigTypeIdStruct);
 
-    if (target_import->any_imports_failed) {
-        dst_use_node->owner->any_imports_failed = true;
+    if (get_container_scope(target_import)->any_imports_failed) {
+        get_container_scope(dst_use_node->owner)->any_imports_failed = true;
     }
 
-    auto it = target_import->decls_scope->decl_table.entry_iterator();
+    auto it = get_container_scope(target_import)->decl_table.entry_iterator();
     for (;;) {
         auto *entry = it.next();
         if (!entry)
@@ -4374,7 +4387,7 @@ static void add_symbols_from_import(CodeGen *g, AstNode *src_use_node, AstNode *
 
         Buf *target_tld_name = entry->key;
 
-        auto existing_entry = dst_use_node->owner->decls_scope->decl_table.put_unique(target_tld_name, target_tld);
+        auto existing_entry = get_container_scope(dst_use_node->owner)->decl_table.put_unique(target_tld_name, target_tld);
         if (existing_entry) {
             Tld *existing_decl = existing_entry->value;
             if (existing_decl != target_tld) {
@@ -4387,8 +4400,8 @@ static void add_symbols_from_import(CodeGen *g, AstNode *src_use_node, AstNode *
         }
     }
 
-    for (size_t i = 0; i < target_import->use_decls.length; i += 1) {
-        AstNode *use_decl_node = target_import->use_decls.at(i);
+    for (size_t i = 0; i < get_container_scope(target_import)->use_decls.length; i += 1) {
+        AstNode *use_decl_node = get_container_scope(target_import)->use_decls.at(i);
         if (use_decl_node->data.use.visib_mod != VisibModPrivate)
             add_symbols_from_import(g, use_decl_node, dst_use_node);
     }
@@ -4415,16 +4428,16 @@ void preview_use_decl(CodeGen *g, AstNode *node) {
     }
 
     node->data.use.resolution = TldResolutionResolving;
-    ConstExprValue *result = analyze_const_value(g, &node->owner->decls_scope->base,
-        node->data.use.expr, g->builtin_types.entry_namespace, nullptr);
+    ConstExprValue *result = analyze_const_value(g, &get_container_scope(node->owner)->base,
+        node->data.use.expr, g->builtin_types.entry_type, nullptr);
 
     if (type_is_invalid(result->type))
-        node->owner->any_imports_failed = true;
+        get_container_scope(node->owner)->any_imports_failed = true;
 
     node->data.use.value = result;
 }
 
-ImportTableEntry *add_source_file(CodeGen *g, PackageTableEntry *package, Buf *resolved_path, Buf *source_code) {
+ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *resolved_path, Buf *source_code) {
     if (g->verbose_tokenize) {
         fprintf(stderr, "\nOriginal Source (%s):\n", buf_ptr(resolved_path));
         fprintf(stderr, "----------------\n");
@@ -4452,32 +4465,34 @@ ImportTableEntry *add_source_file(CodeGen *g, PackageTableEntry *package, Buf *r
         fprintf(stderr, "------\n");
     }
 
-    ImportTableEntry *import_entry = allocate<ImportTableEntry>(1);
-    import_entry->package = package;
-    import_entry->source_code = source_code;
-    import_entry->line_offsets = tokenization.line_offsets;
-    import_entry->path = resolved_path;
-
-    import_entry->root = ast_parse(source_code, tokenization.tokens, import_entry, g->err_color);
-    assert(import_entry->root);
-    if (g->verbose_ast) {
-        ast_print(stderr, import_entry->root, 0);
-    }
-
     Buf *src_dirname = buf_alloc();
     Buf *src_basename = buf_alloc();
     os_path_split(resolved_path, src_dirname, src_basename);
 
-    import_entry->di_file = ZigLLVMCreateFile(g->dbuilder, buf_ptr(src_basename), buf_ptr(src_dirname));
+    Buf noextname = BUF_INIT;
+    os_path_extname(src_basename, &noextname, nullptr);
+    RootStruct *root_struct = allocate<RootStruct>(1);
+    root_struct->package = package;
+    root_struct->source_code = source_code;
+    root_struct->line_offsets = tokenization.line_offsets;
+    root_struct->path = resolved_path;
+    root_struct->di_file = ZigLLVMCreateFile(g->dbuilder, buf_ptr(src_basename), buf_ptr(src_dirname));
+    ZigType *import_entry = get_root_container_type(g, buf_ptr(&noextname), root_struct);
+
+    AstNode *root_node = ast_parse(source_code, tokenization.tokens, import_entry, g->err_color);
+    assert(root_node != nullptr);
+    assert(root_node->type == NodeTypeContainerDecl);
+    import_entry->data.structure.decl_node = root_node;
+    import_entry->data.structure.decls_scope->base.source_node = root_node;
+    if (g->verbose_ast) {
+        ast_print(stderr, root_node, 0);
+    }
+
     g->import_table.put(resolved_path, import_entry);
     g->import_queue.append(import_entry);
 
-    import_entry->decls_scope = create_decls_scope(g, import_entry->root, nullptr, nullptr, import_entry);
-
-
-    assert(import_entry->root->type == NodeTypeContainerDecl);
-    for (size_t decl_i = 0; decl_i < import_entry->root->data.container_decl.decls.length; decl_i += 1) {
-        AstNode *top_level_decl = import_entry->root->data.container_decl.decls.at(decl_i);
+    for (size_t decl_i = 0; decl_i < root_node->data.container_decl.decls.length; decl_i += 1) {
+        AstNode *top_level_decl = root_node->data.container_decl.decls.at(decl_i);
 
         if (top_level_decl->type == NodeTypeFnDef) {
             AstNode *proto_node = top_level_decl->data.fn_def.fn_proto;
@@ -4502,16 +4517,16 @@ ImportTableEntry *add_source_file(CodeGen *g, PackageTableEntry *package, Buf *r
     return import_entry;
 }
 
-void scan_import(CodeGen *g, ImportTableEntry *import) {
-    if (!import->scanned) {
-        import->scanned = true;
-        scan_decls(g, import->decls_scope, import->root);
+void scan_import(CodeGen *g, ZigType *import) {
+    if (!import->data.structure.root_struct->scanned) {
+        import->data.structure.root_struct->scanned = true;
+        scan_decls(g, import->data.structure.decls_scope, import->data.structure.decl_node);
     }
 }
 
 void semantic_analyze(CodeGen *g) {
     for (; g->import_queue_index < g->import_queue.length; g->import_queue_index += 1) {
-        ImportTableEntry *import = g->import_queue.at(g->import_queue_index);
+        ZigType *import = g->import_queue.at(g->import_queue_index);
         scan_import(g, import);
     }
 
@@ -4530,9 +4545,8 @@ void semantic_analyze(CodeGen *g) {
     {
         for (; g->resolve_queue_index < g->resolve_queue.length; g->resolve_queue_index += 1) {
             Tld *tld = g->resolve_queue.at(g->resolve_queue_index);
-            bool pointer_only = false;
             AstNode *source_node = nullptr;
-            resolve_top_level_decl(g, tld, pointer_only, source_node);
+            resolve_top_level_decl(g, tld, source_node);
         }
 
         for (; g->fn_defs_index < g->fn_defs.length; g->fn_defs_index += 1) {
@@ -4613,7 +4627,6 @@ bool handle_is_ptr(ZigType *type_entry) {
         case ZigTypeIdComptimeInt:
         case ZigTypeIdUndefined:
         case ZigTypeIdNull:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdArgTuple:
         case ZigTypeIdOpaque:
@@ -4880,8 +4893,6 @@ static uint32_t hash_const_val(ConstExprValue *const_val) {
             return 3415065496;
         case ZigTypeIdErrorSet:
             return hash_const_val_error_set(const_val);
-        case ZigTypeIdNamespace:
-            return hash_ptr(const_val->data.x_import);
         case ZigTypeIdVector:
             // TODO better hashing algorithm
             return 3647867726;
@@ -4943,7 +4954,6 @@ static bool can_mutate_comptime_var_state(ConstExprValue *value) {
         case ZigTypeIdComptimeInt:
         case ZigTypeIdUndefined:
         case ZigTypeIdNull:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdFn:
         case ZigTypeIdOpaque:
@@ -5013,7 +5023,6 @@ static bool return_type_is_cacheable(ZigType *return_type) {
         case ZigTypeIdComptimeInt:
         case ZigTypeIdUndefined:
         case ZigTypeIdNull:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdFn:
         case ZigTypeIdOpaque:
@@ -5143,7 +5152,6 @@ OnePossibleValue type_has_one_possible_value(CodeGen *g, ZigType *type_entry) {
         case ZigTypeIdComptimeFloat:
         case ZigTypeIdComptimeInt:
         case ZigTypeIdMetaType:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdArgTuple:
         case ZigTypeIdOptional:
@@ -5209,7 +5217,6 @@ ReqCompTime type_requires_comptime(CodeGen *g, ZigType *type_entry) {
         case ZigTypeIdUndefined:
         case ZigTypeIdNull:
         case ZigTypeIdMetaType:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdArgTuple:
             return ReqCompTimeYes;
@@ -5797,8 +5804,6 @@ bool const_values_equal(CodeGen *g, ConstExprValue *a, ConstExprValue *b) {
             }
         case ZigTypeIdErrorUnion:
             zig_panic("TODO");
-        case ZigTypeIdNamespace:
-            return a->data.x_import == b->data.x_import;
         case ZigTypeIdArgTuple:
             return a->data.x_arg_tuple.start_index == b->data.x_arg_tuple.start_index &&
                    a->data.x_arg_tuple.end_index == b->data.x_arg_tuple.end_index;
@@ -6072,16 +6077,6 @@ void render_const_value(CodeGen *g, Buf *buf, ConstExprValue *const_val) {
                 }
                 return;
             }
-        case ZigTypeIdNamespace:
-            {
-                ImportTableEntry *import = const_val->data.x_import;
-                if (import->c_import_node) {
-                    buf_appendf(buf, "(namespace from C import)");
-                } else {
-                    buf_appendf(buf, "(namespace: %s)", buf_ptr(import->path));
-                }
-                return;
-            }
         case ZigTypeIdBoundFn:
             {
                 ZigFn *fn_entry = const_val->data.x_bound_fn.fn;
@@ -6203,7 +6198,6 @@ uint32_t type_id_hash(TypeId x) {
         case ZigTypeIdEnum:
         case ZigTypeIdUnion:
         case ZigTypeIdFn:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdArgTuple:
         case ZigTypeIdPromise:
@@ -6252,7 +6246,6 @@ bool type_id_eql(TypeId a, TypeId b) {
         case ZigTypeIdEnum:
         case ZigTypeIdUnion:
         case ZigTypeIdFn:
-        case ZigTypeIdNamespace:
         case ZigTypeIdBoundFn:
         case ZigTypeIdArgTuple:
         case ZigTypeIdOpaque:
@@ -6419,7 +6412,6 @@ static const ZigTypeId all_type_ids[] = {
     ZigTypeIdEnum,
     ZigTypeIdUnion,
     ZigTypeIdFn,
-    ZigTypeIdNamespace,
     ZigTypeIdBoundFn,
     ZigTypeIdArgTuple,
     ZigTypeIdOpaque,
@@ -6480,18 +6472,16 @@ size_t type_id_index(ZigType *entry) {
             return 17;
         case ZigTypeIdFn:
             return 18;
-        case ZigTypeIdNamespace:
-            return 19;
         case ZigTypeIdBoundFn:
-            return 20;
+            return 19;
         case ZigTypeIdArgTuple:
-            return 21;
+            return 20;
         case ZigTypeIdOpaque:
-            return 22;
+            return 21;
         case ZigTypeIdPromise:
-            return 23;
+            return 22;
         case ZigTypeIdVector:
-            return 24;
+            return 23;
     }
     zig_unreachable();
 }
@@ -6538,8 +6528,6 @@ const char *type_id_name(ZigTypeId id) {
             return "Union";
         case ZigTypeIdFn:
             return "Fn";
-        case ZigTypeIdNamespace:
-            return "Namespace";
         case ZigTypeIdBoundFn:
             return "BoundFn";
         case ZigTypeIdArgTuple:
@@ -6619,8 +6607,8 @@ bool type_ptr_eql(const ZigType *a, const ZigType *b) {
 }
 
 ConstExprValue *get_builtin_value(CodeGen *codegen, const char *name) {
-    Tld *tld = codegen->compile_var_import->decls_scope->decl_table.get(buf_create_from_str(name));
-    resolve_top_level_decl(codegen, tld, false, nullptr);
+    Tld *tld = get_container_scope(codegen->compile_var_import)->decl_table.get(buf_create_from_str(name));
+    resolve_top_level_decl(codegen, tld, nullptr);
     assert(tld->id == TldIdVar);
     TldVar *tld_var = (TldVar *)tld;
     ConstExprValue *var_value = tld_var->var->const_value;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -6852,3 +6852,19 @@ void emit_error_notes_for_ref_stack(CodeGen *g, ErrorMsg *msg) {
         }
     }
 }
+
+Buf *type_bare_name(ZigType *type_entry) {
+    if (is_container(type_entry)) {
+        return get_container_scope(type_entry)->bare_name;
+    } else if (type_entry->id == ZigTypeIdOpaque) {
+        return type_entry->data.opaque.bare_name;
+    } else {
+        return &type_entry->name;
+    }
+}
+
+// TODO this will have to be more clever, probably using the full name
+// and replacing '.' with '_' or something like that
+Buf *type_h_name(ZigType *t) {
+    return type_bare_name(t);
+}

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -14,6 +14,7 @@ void semantic_analyze(CodeGen *g);
 ErrorMsg *add_node_error(CodeGen *g, AstNode *node, Buf *msg);
 ErrorMsg *add_token_error(CodeGen *g, ZigType *owner, Token *token, Buf *msg);
 ErrorMsg *add_error_note(CodeGen *g, ErrorMsg *parent_msg, AstNode *node, Buf *msg);
+void emit_error_notes_for_ref_stack(CodeGen *g, ErrorMsg *msg);
 ZigType *new_type_table_entry(ZigTypeId id);
 ZigType *get_pointer_to_type(CodeGen *g, ZigType *child_type, bool is_const);
 ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type, bool is_const,
@@ -49,6 +50,7 @@ bool type_is_nonnull_ptr(ZigType *type);
 
 enum SourceKind {
     SourceKindRoot,
+    SourceKindPkgMain,
     SourceKindNonRoot,
 };
 ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *abs_full_path, Buf *source_code,
@@ -56,6 +58,7 @@ ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *abs_full_path, Bu
 
 ZigVar *find_variable(CodeGen *g, Scope *orig_context, Buf *name, ScopeFnDef **crossed_fndef_scope);
 Tld *find_decl(CodeGen *g, Scope *scope, Buf *name);
+Tld *find_container_decl(CodeGen *g, ScopeDecls *decls_scope, Buf *name);
 void resolve_top_level_decl(CodeGen *g, Tld *tld, AstNode *source_node);
 bool type_is_codegen_pointer(ZigType *type);
 

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -47,8 +47,12 @@ bool type_allowed_in_extern(CodeGen *g, ZigType *type_entry);
 bool ptr_allows_addr_zero(ZigType *ptr_type);
 bool type_is_nonnull_ptr(ZigType *type);
 
-ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *abs_full_path, Buf *source_code);
-
+enum SourceKind {
+    SourceKindRoot,
+    SourceKindNonRoot,
+};
+ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *abs_full_path, Buf *source_code,
+        SourceKind source_kind);
 
 ZigVar *find_variable(CodeGen *g, Scope *orig_context, Buf *name, ScopeFnDef **crossed_fndef_scope);
 Tld *find_decl(CodeGen *g, Scope *scope, Buf *name);
@@ -78,10 +82,10 @@ bool is_array_ref(ZigType *type_entry);
 bool is_container_ref(ZigType *type_entry);
 bool is_valid_vector_elem_type(ZigType *elem_type);
 void scan_decls(CodeGen *g, ScopeDecls *decls_scope, AstNode *node);
-void scan_import(CodeGen *g, ZigType *import);
 void preview_use_decl(CodeGen *g, AstNode *node);
 void resolve_use_decl(CodeGen *g, AstNode *node);
 ZigFn *scope_fn_entry(Scope *scope);
+ZigPackage *scope_package(Scope *scope);
 ZigType *get_scope_import(Scope *scope);
 void init_tld(Tld *tld, TldId id, Buf *name, VisibMod visib_mod, AstNode *source_node, Scope *parent_scope);
 ZigVar *add_variable(CodeGen *g, AstNode *source_node, Scope *parent_scope, Buf *name,

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -12,7 +12,7 @@
 
 void semantic_analyze(CodeGen *g);
 ErrorMsg *add_node_error(CodeGen *g, AstNode *node, Buf *msg);
-ErrorMsg *add_token_error(CodeGen *g, ImportTableEntry *owner, Token *token, Buf *msg);
+ErrorMsg *add_token_error(CodeGen *g, ZigType *owner, Token *token, Buf *msg);
 ErrorMsg *add_error_note(CodeGen *g, ErrorMsg *parent_msg, AstNode *node, Buf *msg);
 ZigType *new_type_table_entry(ZigTypeId id);
 ZigType *get_pointer_to_type(CodeGen *g, ZigType *child_type, bool is_const);
@@ -30,6 +30,7 @@ ZigType *get_array_type(CodeGen *g, ZigType *child_type, uint64_t array_size);
 ZigType *get_slice_type(CodeGen *g, ZigType *ptr_type);
 ZigType *get_partial_container_type(CodeGen *g, Scope *scope, ContainerKind kind,
         AstNode *decl_node, const char *name, ContainerLayout layout);
+ZigType *get_root_container_type(CodeGen *g, const char *name, RootStruct *root_struct);
 ZigType *get_smallest_unsigned_int_type(CodeGen *g, uint64_t x);
 ZigType *get_error_union_type(CodeGen *g, ZigType *err_set_type, ZigType *payload_type);
 ZigType *get_bound_fn_type(CodeGen *g, ZigFn *fn_entry);
@@ -46,12 +47,12 @@ bool type_allowed_in_extern(CodeGen *g, ZigType *type_entry);
 bool ptr_allows_addr_zero(ZigType *ptr_type);
 bool type_is_nonnull_ptr(ZigType *type);
 
-ImportTableEntry *add_source_file(CodeGen *g, PackageTableEntry *package, Buf *abs_full_path, Buf *source_code);
+ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *abs_full_path, Buf *source_code);
 
 
 ZigVar *find_variable(CodeGen *g, Scope *orig_context, Buf *name, ScopeFnDef **crossed_fndef_scope);
 Tld *find_decl(CodeGen *g, Scope *scope, Buf *name);
-void resolve_top_level_decl(CodeGen *g, Tld *tld, bool pointer_only, AstNode *source_node);
+void resolve_top_level_decl(CodeGen *g, Tld *tld, AstNode *source_node);
 bool type_is_codegen_pointer(ZigType *type);
 
 ZigType *get_src_ptr_type(ZigType *type);
@@ -77,11 +78,11 @@ bool is_array_ref(ZigType *type_entry);
 bool is_container_ref(ZigType *type_entry);
 bool is_valid_vector_elem_type(ZigType *elem_type);
 void scan_decls(CodeGen *g, ScopeDecls *decls_scope, AstNode *node);
-void scan_import(CodeGen *g, ImportTableEntry *import);
+void scan_import(CodeGen *g, ZigType *import);
 void preview_use_decl(CodeGen *g, AstNode *node);
 void resolve_use_decl(CodeGen *g, AstNode *node);
 ZigFn *scope_fn_entry(Scope *scope);
-ImportTableEntry *get_scope_import(Scope *scope);
+ZigType *get_scope_import(Scope *scope);
 void init_tld(Tld *tld, TldId id, Buf *name, VisibMod visib_mod, AstNode *source_node, Scope *parent_scope);
 ZigVar *add_variable(CodeGen *g, AstNode *source_node, Scope *parent_scope, Buf *name,
     bool is_const, ConstExprValue *init_value, Tld *src_tld, ZigType *var_type);
@@ -109,7 +110,7 @@ ScopeCImport *create_cimport_scope(CodeGen *g, AstNode *node, Scope *parent);
 ScopeLoop *create_loop_scope(CodeGen *g, AstNode *node, Scope *parent);
 ScopeSuspend *create_suspend_scope(CodeGen *g, AstNode *node, Scope *parent);
 ScopeFnDef *create_fndef_scope(CodeGen *g, AstNode *node, Scope *parent, ZigFn *fn_entry);
-ScopeDecls *create_decls_scope(CodeGen *g, AstNode *node, Scope *parent, ZigType *container_type, ImportTableEntry *import);
+ScopeDecls *create_decls_scope(CodeGen *g, AstNode *node, Scope *parent, ZigType *container_type, ZigType *import);
 Scope *create_comptime_scope(CodeGen *g, AstNode *node, Scope *parent);
 Scope *create_coro_prelude_scope(CodeGen *g, AstNode *node, Scope *parent);
 Scope *create_runtime_scope(CodeGen *g, AstNode *node, Scope *parent, IrInstruction *is_comptime);
@@ -186,7 +187,7 @@ LinkLib *add_link_lib(CodeGen *codegen, Buf *lib);
 
 uint32_t get_abi_alignment(CodeGen *g, ZigType *type_entry);
 ZigType *get_align_amt_type(CodeGen *g);
-PackageTableEntry *new_anonymous_package(void);
+ZigPackage *new_anonymous_package(void);
 
 Buf *const_value_to_buffer(ConstExprValue *const_val);
 void add_fn_export(CodeGen *g, ZigFn *fn_table_entry, Buf *symbol_name, GlobalLinkageId linkage, bool ccc);

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -30,12 +30,13 @@ ZigType *get_optional_type(CodeGen *g, ZigType *child_type);
 ZigType *get_array_type(CodeGen *g, ZigType *child_type, uint64_t array_size);
 ZigType *get_slice_type(CodeGen *g, ZigType *ptr_type);
 ZigType *get_partial_container_type(CodeGen *g, Scope *scope, ContainerKind kind,
-        AstNode *decl_node, const char *name, ContainerLayout layout);
-ZigType *get_root_container_type(CodeGen *g, const char *name, RootStruct *root_struct);
+        AstNode *decl_node, const char *full_name, Buf *bare_name, ContainerLayout layout);
+ZigType *get_root_container_type(CodeGen *g, const char *full_name, Buf *bare_name,
+        RootStruct *root_struct);
 ZigType *get_smallest_unsigned_int_type(CodeGen *g, uint64_t x);
 ZigType *get_error_union_type(CodeGen *g, ZigType *err_set_type, ZigType *payload_type);
 ZigType *get_bound_fn_type(CodeGen *g, ZigFn *fn_entry);
-ZigType *get_opaque_type(CodeGen *g, Scope *scope, AstNode *source_node, const char *name);
+ZigType *get_opaque_type(CodeGen *g, Scope *scope, AstNode *source_node, const char *full_name, Buf *bare_name);
 ZigType *get_struct_type(CodeGen *g, const char *type_name, const char *field_names[],
         ZigType *field_types[], size_t field_count);
 ZigType *get_promise_type(CodeGen *g, ZigType *result_type);
@@ -117,7 +118,6 @@ ScopeCImport *create_cimport_scope(CodeGen *g, AstNode *node, Scope *parent);
 ScopeLoop *create_loop_scope(CodeGen *g, AstNode *node, Scope *parent);
 ScopeSuspend *create_suspend_scope(CodeGen *g, AstNode *node, Scope *parent);
 ScopeFnDef *create_fndef_scope(CodeGen *g, AstNode *node, Scope *parent, ZigFn *fn_entry);
-ScopeDecls *create_decls_scope(CodeGen *g, AstNode *node, Scope *parent, ZigType *container_type, ZigType *import);
 Scope *create_comptime_scope(CodeGen *g, AstNode *node, Scope *parent);
 Scope *create_coro_prelude_scope(CodeGen *g, AstNode *node, Scope *parent);
 Scope *create_runtime_scope(CodeGen *g, AstNode *node, Scope *parent, IrInstruction *is_comptime);

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -240,4 +240,6 @@ Error ensure_const_val_repr(IrAnalyze *ira, CodeGen *codegen, AstNode *source_no
         ConstExprValue *const_val, ZigType *wanted_type);
 
 void typecheck_panic_fn(CodeGen *g, TldFn *tld_fn, ZigFn *panic_fn);
+Buf *type_bare_name(ZigType *t);
+Buf *type_h_name(ZigType *t);
 #endif

--- a/src/buffer.hpp
+++ b/src/buffer.hpp
@@ -59,7 +59,7 @@ static inline void buf_deinit(Buf *buf) {
 static inline void buf_init_from_mem(Buf *buf, const char *ptr, size_t len) {
     assert(len != SIZE_MAX);
     buf->list.resize(len + 1);
-    safe_memcpy(buf_ptr(buf), ptr, len);
+    memcpy(buf_ptr(buf), ptr, len);
     buf->list.at(buf_len(buf)) = 0;
 }
 
@@ -98,7 +98,7 @@ static inline Buf *buf_slice(Buf *in_buf, size_t start, size_t end) {
     assert(end <= buf_len(in_buf));
     Buf *out_buf = allocate<Buf>(1);
     out_buf->list.resize(end - start + 1);
-    safe_memcpy(buf_ptr(out_buf), buf_ptr(in_buf) + start, end - start);
+    memcpy(buf_ptr(out_buf), buf_ptr(in_buf) + start, end - start);
     out_buf->list.at(buf_len(out_buf)) = 0;
     return out_buf;
 }
@@ -108,7 +108,7 @@ static inline void buf_append_mem(Buf *buf, const char *mem, size_t mem_len) {
     assert(mem_len != SIZE_MAX);
     size_t old_len = buf_len(buf);
     buf_resize(buf, old_len + mem_len);
-    safe_memcpy(buf_ptr(buf) + old_len, mem, mem_len);
+    memcpy(buf_ptr(buf) + old_len, mem, mem_len);
     buf->list.at(buf_len(buf)) = 0;
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8484,19 +8484,19 @@ static void get_c_type(CodeGen *g, GenH *gen_h, ZigType *type_entry, Buf *out_bu
         case ZigTypeIdOpaque:
             {
                 buf_init_from_str(out_buf, "struct ");
-                buf_append_buf(out_buf, &type_entry->name);
+                buf_append_buf(out_buf, type_h_name(type_entry));
                 return;
             }
         case ZigTypeIdUnion:
             {
                 buf_init_from_str(out_buf, "union ");
-                buf_append_buf(out_buf, &type_entry->name);
+                buf_append_buf(out_buf, type_h_name(type_entry));
                 return;
             }
         case ZigTypeIdEnum:
             {
                 buf_init_from_str(out_buf, "enum ");
-                buf_append_buf(out_buf, &type_entry->name);
+                buf_append_buf(out_buf, type_h_name(type_entry));
                 return;
             }
         case ZigTypeIdArray:
@@ -8679,7 +8679,7 @@ static void gen_h_file(CodeGen *g) {
                 zig_unreachable();
             case ZigTypeIdEnum:
                 if (type_entry->data.enumeration.layout == ContainerLayoutExtern) {
-                    fprintf(out_h, "enum %s {\n", buf_ptr(&type_entry->name));
+                    fprintf(out_h, "enum %s {\n", buf_ptr(type_h_name(type_entry)));
                     for (uint32_t field_i = 0; field_i < type_entry->data.enumeration.src_field_count; field_i += 1) {
                         TypeEnumField *enum_field = &type_entry->data.enumeration.fields[field_i];
                         Buf *value_buf = buf_alloc();
@@ -8692,12 +8692,12 @@ static void gen_h_file(CodeGen *g) {
                     }
                     fprintf(out_h, "};\n\n");
                 } else {
-                    fprintf(out_h, "enum %s;\n", buf_ptr(&type_entry->name));
+                    fprintf(out_h, "enum %s;\n", buf_ptr(type_h_name(type_entry)));
                 }
                 break;
             case ZigTypeIdStruct:
                 if (type_entry->data.structure.layout == ContainerLayoutExtern) {
-                    fprintf(out_h, "struct %s {\n", buf_ptr(&type_entry->name));
+                    fprintf(out_h, "struct %s {\n", buf_ptr(type_h_name(type_entry)));
                     for (uint32_t field_i = 0; field_i < type_entry->data.structure.src_field_count; field_i += 1) {
                         TypeStructField *struct_field = &type_entry->data.structure.fields[field_i];
 
@@ -8715,12 +8715,12 @@ static void gen_h_file(CodeGen *g) {
                     }
                     fprintf(out_h, "};\n\n");
                 } else {
-                    fprintf(out_h, "struct %s;\n", buf_ptr(&type_entry->name));
+                    fprintf(out_h, "struct %s;\n", buf_ptr(type_h_name(type_entry)));
                 }
                 break;
             case ZigTypeIdUnion:
                 if (type_entry->data.unionation.layout == ContainerLayoutExtern) {
-                    fprintf(out_h, "union %s {\n", buf_ptr(&type_entry->name));
+                    fprintf(out_h, "union %s {\n", buf_ptr(type_h_name(type_entry)));
                     for (uint32_t field_i = 0; field_i < type_entry->data.unionation.src_field_count; field_i += 1) {
                         TypeUnionField *union_field = &type_entry->data.unionation.fields[field_i];
 
@@ -8730,11 +8730,11 @@ static void gen_h_file(CodeGen *g) {
                     }
                     fprintf(out_h, "};\n\n");
                 } else {
-                    fprintf(out_h, "union %s;\n", buf_ptr(&type_entry->name));
+                    fprintf(out_h, "union %s;\n", buf_ptr(type_h_name(type_entry)));
                 }
                 break;
             case ZigTypeIdOpaque:
-                fprintf(out_h, "struct %s;\n\n", buf_ptr(&type_entry->name));
+                fprintf(out_h, "struct %s;\n\n", buf_ptr(type_h_name(type_entry)));
                 break;
         }
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8591,10 +8591,17 @@ static void gen_h_file(CodeGen *g) {
         Buf return_type_c = BUF_INIT;
         get_c_type(g, gen_h, fn_type_id->return_type, &return_type_c);
 
+        Buf *symbol_name;
+        if (fn_table_entry->export_list.length == 0) {
+            symbol_name = &fn_table_entry->symbol_name;
+        } else {
+            FnExport *fn_export = &fn_table_entry->export_list.items[0];
+            symbol_name = &fn_export->name;
+        }
         buf_appendf(&h_buf, "%s %s %s(",
                 buf_ptr(export_macro),
                 buf_ptr(&return_type_c),
-                buf_ptr(&fn_table_entry->symbol_name));
+                buf_ptr(symbol_name));
 
         Buf param_type_c = BUF_INIT;
         if (fn_type_id->param_count > 0) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7748,7 +7748,7 @@ static Error define_builtin_compile_vars(CodeGen *g) {
     g->std_package->package_table.put(buf_create_from_str("builtin"), g->compile_var_package);
     g->std_package->package_table.put(buf_create_from_str("std"), g->std_package);
     g->compile_var_import = add_source_file(g, g->compile_var_package, builtin_zig_path, contents,
-            SourceKindNonRoot);
+            SourceKindPkgMain);
 
     return ErrorNone;
 }
@@ -7987,7 +7987,7 @@ static ZigType *add_special_code(CodeGen *g, ZigPackage *package, const char *ba
         zig_panic("unable to open '%s': %s\n", buf_ptr(&path_to_code_src), err_str(err));
     }
 
-    return add_source_file(g, package, resolved_path, import_code, SourceKindNonRoot);
+    return add_source_file(g, package, resolved_path, import_code, SourceKindPkgMain);
 }
 
 static ZigPackage *create_bootstrap_pkg(CodeGen *g, ZigPackage *pkg_with_main) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7123,7 +7123,8 @@ static void define_builtin_types(CodeGen *g) {
     g->builtin_types.entry_i64 = get_int_type(g, true, 64);
 
     {
-        g->builtin_types.entry_c_void = get_opaque_type(g, nullptr, nullptr, "c_void");
+        g->builtin_types.entry_c_void = get_opaque_type(g, nullptr, nullptr, "c_void",
+                buf_create_from_str("c_void"));
         g->primitive_type_table.put(&g->builtin_types.entry_c_void->name, g->builtin_types.entry_c_void);
     }
 
@@ -7943,18 +7944,17 @@ void codegen_translate_c(CodeGen *g, Buf *full_path) {
     Buf noextname = BUF_INIT;
     os_path_extname(src_basename, &noextname, nullptr);
 
+    detect_libc(g);
+
+    init(g);
+
     RootStruct *root_struct = allocate<RootStruct>(1);
     root_struct->source_code = nullptr;
     root_struct->path = full_path;
     root_struct->di_file = ZigLLVMCreateFile(g->dbuilder, buf_ptr(src_basename), buf_ptr(src_dirname));
 
-    ZigType *import = get_root_container_type(g, buf_ptr(&noextname), root_struct);
+    ZigType *import = get_root_container_type(g, buf_ptr(&noextname), &noextname, root_struct);
     g->root_import = import;
-
-    detect_libc(g);
-
-    init(g);
-
 
     ZigList<ErrorMsg *> errors = {0};
     Error err = parse_h_file(import, &errors, buf_ptr(full_path), g, nullptr);

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -48,7 +48,7 @@ void codegen_print_timing_report(CodeGen *g, FILE *f);
 void codegen_link(CodeGen *g);
 void codegen_build_and_link(CodeGen *g);
 
-PackageTableEntry *codegen_create_package(CodeGen *g, const char *root_src_dir, const char *root_src_path);
+ZigPackage *codegen_create_package(CodeGen *g, const char *root_src_dir, const char *root_src_path);
 void codegen_add_assembly(CodeGen *g, Buf *path);
 void codegen_add_object(CodeGen *g, Buf *object_path);
 

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -48,7 +48,8 @@ void codegen_print_timing_report(CodeGen *g, FILE *f);
 void codegen_link(CodeGen *g);
 void codegen_build_and_link(CodeGen *g);
 
-ZigPackage *codegen_create_package(CodeGen *g, const char *root_src_dir, const char *root_src_path);
+ZigPackage *codegen_create_package(CodeGen *g, const char *root_src_dir, const char *root_src_path,
+        const char *pkg_path);
 void codegen_add_assembly(CodeGen *g, Buf *path);
 void codegen_add_object(CodeGen *g, Buf *object_path);
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -6612,8 +6612,8 @@ static Buf *get_anon_type_name(CodeGen *codegen, IrExecutable *exec, const char 
         Scope *scope, AstNode *source_node)
 {
     if (exec->name) {
-        ZigPackage *cur_scope_pkg = scope_package(scope);
-        Buf *namespace_name = buf_create_from_buf(&cur_scope_pkg->pkg_path);
+        ZigType *import = get_scope_import(scope);
+        Buf *namespace_name = buf_create_from_buf(&import->name);
         if (buf_len(namespace_name) != 0) buf_append_char(namespace_name, NAMESPACE_SEP_CHAR);
         buf_append_buf(namespace_name, exec->name);
         return namespace_name;
@@ -6625,8 +6625,8 @@ static Buf *get_anon_type_name(CodeGen *codegen, IrExecutable *exec, const char 
         buf_appendf(name, ")");
         return name;
     } else {
-        ZigPackage *cur_scope_pkg = scope_package(scope);
-        Buf *namespace_name = buf_create_from_buf(&cur_scope_pkg->pkg_path);
+        ZigType *import = get_scope_import(scope);
+        Buf *namespace_name = buf_create_from_buf(&import->name);
         if (buf_len(namespace_name) != 0) buf_append_char(namespace_name, NAMESPACE_SEP_CHAR);
         buf_appendf(namespace_name, "%s:%" ZIG_PRI_usize ":%" ZIG_PRI_usize, kind_name,
                 source_node->line + 1, source_node->column + 1);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -18685,15 +18685,7 @@ static IrInstruction *ir_analyze_instruction_type_name(IrAnalyze *ira, IrInstruc
         return ira->codegen->invalid_instruction;
 
     if (!type_entry->cached_const_name_val) {
-        Buf *name;
-        if (is_container(type_entry)) {
-            name = get_container_scope(type_entry)->bare_name;
-        } else if (type_entry->id == ZigTypeIdOpaque) {
-            name = type_entry->data.opaque.bare_name;
-        } else {
-            name = &type_entry->name;
-        }
-        type_entry->cached_const_name_val = create_const_str_lit(ira->codegen, name);
+        type_entry->cached_const_name_val = create_const_str_lit(ira->codegen, type_bare_name(type_entry));
     }
     IrInstruction *result = ir_const(ira, &instruction->base, nullptr);
     copy_const_val(&result->value, type_entry->cached_const_name_val, true);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -6637,23 +6637,6 @@ static Buf *get_anon_type_name(CodeGen *codegen, IrExecutable *exec, const char 
     }
 }
 
-static void get_namespace_name(Buf *buf, Scope *scope, uint8_t sep) {
-    if (!scope)
-        return;
-
-    if (scope->id == ScopeIdDecls) {
-        get_namespace_name(buf, scope->parent, sep);
-
-        ScopeDecls *scope_decls = (ScopeDecls *)scope;
-        if (scope_decls->container_type) {
-            buf_append_buf(buf, &scope_decls->container_type->name);
-            buf_append_char(buf, sep);
-        }
-        return;
-    }
-
-    get_namespace_name(buf, scope->parent, sep);
-}
 static IrInstruction *ir_gen_container_decl(IrBuilder *irb, Scope *parent_scope, AstNode *node) {
     assert(node->type == NodeTypeContainerDecl);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,7 +215,7 @@ struct CliPkg {
     CliPkg *parent;
 };
 
-static void add_package(CodeGen *g, CliPkg *cli_pkg, PackageTableEntry *pkg) {
+static void add_package(CodeGen *g, CliPkg *cli_pkg, ZigPackage *pkg) {
     for (size_t i = 0; i < cli_pkg->children.length; i += 1) {
         CliPkg *child_cli_pkg = cli_pkg->children.at(i);
 
@@ -223,10 +223,10 @@ static void add_package(CodeGen *g, CliPkg *cli_pkg, PackageTableEntry *pkg) {
         Buf *basename = buf_alloc();
         os_path_split(buf_create_from_str(child_cli_pkg->path), dirname, basename);
 
-        PackageTableEntry *child_pkg = codegen_create_package(g, buf_ptr(dirname), buf_ptr(basename));
+        ZigPackage *child_pkg = codegen_create_package(g, buf_ptr(dirname), buf_ptr(basename));
         auto entry = pkg->package_table.put_unique(buf_create_from_str(child_cli_pkg->name), child_pkg);
         if (entry) {
-            PackageTableEntry *existing_pkg = entry->value;
+            ZigPackage *existing_pkg = entry->value;
             Buf *full_path = buf_alloc();
             os_path_join(&existing_pkg->root_src_dir, &existing_pkg->root_src_path, full_path);
             fprintf(stderr, "Unable to add package '%s'->'%s': already exists as '%s'\n",
@@ -543,7 +543,7 @@ int main(int argc, char **argv) {
             return EXIT_FAILURE;
         }
 
-        PackageTableEntry *build_pkg = codegen_create_package(g, buf_ptr(&build_file_dirname),
+        ZigPackage *build_pkg = codegen_create_package(g, buf_ptr(&build_file_dirname),
                 buf_ptr(&build_file_basename));
         g->root_package->package_table.put(buf_create_from_str("@build"), build_pkg);
         g->enable_cache = get_cache_opt(enable_cache, true);
@@ -1145,7 +1145,7 @@ int main(int argc, char **argv) {
                 }
             } else if (cmd == CmdTranslateC) {
                 codegen_translate_c(g, in_file_buf);
-                ast_render(g, stdout, g->root_import->root, 4);
+                ast_render(g, stdout, g->root_import->data.structure.decl_node, 4);
                 if (timing_info)
                     codegen_print_timing_report(g, stdout);
                 return EXIT_SUCCESS;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,7 +223,8 @@ static void add_package(CodeGen *g, CliPkg *cli_pkg, ZigPackage *pkg) {
         Buf *basename = buf_alloc();
         os_path_split(buf_create_from_str(child_cli_pkg->path), dirname, basename);
 
-        ZigPackage *child_pkg = codegen_create_package(g, buf_ptr(dirname), buf_ptr(basename));
+        ZigPackage *child_pkg = codegen_create_package(g, buf_ptr(dirname), buf_ptr(basename),
+                buf_ptr(buf_sprintf("%s.%s", buf_ptr(&pkg->pkg_path), child_cli_pkg->name)));
         auto entry = pkg->package_table.put_unique(buf_create_from_str(child_cli_pkg->name), child_pkg);
         if (entry) {
             ZigPackage *existing_pkg = entry->value;
@@ -544,7 +545,7 @@ int main(int argc, char **argv) {
         }
 
         ZigPackage *build_pkg = codegen_create_package(g, buf_ptr(&build_file_dirname),
-                buf_ptr(&build_file_basename));
+                buf_ptr(&build_file_basename), "std.special");
         g->root_package->package_table.put(buf_create_from_str("@build"), build_pkg);
         g->enable_cache = get_cache_opt(enable_cache, true);
         codegen_build_and_link(g);

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -264,7 +264,7 @@ void os_path_join(Buf *dirname, Buf *basename, Buf *out_full_path) {
     buf_append_buf(out_full_path, basename);
 }
 
-int os_path_real(Buf *rel_path, Buf *out_abs_path) {
+Error os_path_real(Buf *rel_path, Buf *out_abs_path) {
 #if defined(ZIG_OS_WINDOWS)
     buf_resize(out_abs_path, 4096);
     if (_fullpath(buf_ptr(out_abs_path), buf_ptr(rel_path), buf_len(out_abs_path)) == nullptr) {

--- a/src/os.hpp
+++ b/src/os.hpp
@@ -96,7 +96,7 @@ void os_path_dirname(Buf *full_path, Buf *out_dirname);
 void os_path_split(Buf *full_path, Buf *out_dirname, Buf *out_basename);
 void os_path_extname(Buf *full_path, Buf *out_basename, Buf *out_extname);
 void os_path_join(Buf *dirname, Buf *basename, Buf *out_full_path);
-int os_path_real(Buf *rel_path, Buf *out_abs_path);
+Error os_path_real(Buf *rel_path, Buf *out_abs_path);
 Buf os_path_resolve(Buf **paths_ptr, size_t paths_len);
 bool os_path_is_absolute(Buf *path);
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -18,7 +18,7 @@ struct ParseContext {
     Buf *buf;
     size_t current_token;
     ZigList<Token> *tokens;
-    ImportTableEntry *owner;
+    ZigType *owner;
     ErrColor err_color;
 };
 
@@ -130,8 +130,10 @@ static void ast_error(ParseContext *pc, Token *token, const char *format, ...) {
     va_end(ap);
 
 
-    ErrorMsg *err = err_msg_create_with_line(pc->owner->path, token->start_line, token->start_column,
-            pc->owner->source_code, pc->owner->line_offsets, msg);
+    ErrorMsg *err = err_msg_create_with_line(pc->owner->data.structure.root_struct->path,
+            token->start_line, token->start_column,
+            pc->owner->data.structure.root_struct->source_code,
+            pc->owner->data.structure.root_struct->line_offsets, msg);
     err->line_start = token->start_line;
     err->column_start = token->start_column;
 
@@ -148,8 +150,10 @@ static void ast_asm_error(ParseContext *pc, AstNode *node, size_t offset, const 
     Buf *msg = buf_vprintf(format, ap);
     va_end(ap);
 
-    ErrorMsg *err = err_msg_create_with_line(pc->owner->path, node->line, node->column,
-            pc->owner->source_code, pc->owner->line_offsets, msg);
+    ErrorMsg *err = err_msg_create_with_line(pc->owner->data.structure.root_struct->path,
+            node->line, node->column,
+            pc->owner->data.structure.root_struct->source_code,
+            pc->owner->data.structure.root_struct->line_offsets, msg);
 
     print_err_msg(err, pc->err_color);
     exit(EXIT_FAILURE);
@@ -570,9 +574,7 @@ static void ast_parse_asm_template(ParseContext *pc, AstNode *node) {
     }
 }
 
-AstNode *ast_parse(Buf *buf, ZigList<Token> *tokens, ImportTableEntry *owner,
-        ErrColor err_color)
-{
+AstNode *ast_parse(Buf *buf, ZigList<Token> *tokens, ZigType *owner, ErrColor err_color) {
     ParseContext pc = {};
     pc.err_color = err_color;
     pc.owner = owner;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -16,7 +16,7 @@ ATTRIBUTE_PRINTF(2, 3)
 void ast_token_error(Token *token, const char *format, ...);
 
 
-AstNode * ast_parse(Buf *buf, ZigList<Token> *tokens, ImportTableEntry *owner, ErrColor err_color);
+AstNode * ast_parse(Buf *buf, ZigList<Token> *tokens, ZigType *owner, ErrColor err_color);
 
 void ast_print(AstNode *node, int indent);
 

--- a/src/translate_c.cpp
+++ b/src/translate_c.cpp
@@ -76,7 +76,7 @@ struct TransScopeWhile {
 };
 
 struct Context {
-    ImportTableEntry *import;
+    ZigType *import;
     ZigList<ErrorMsg *> *errors;
     VisibMod visib_mod;
     bool want_export;
@@ -4732,7 +4732,7 @@ static void process_preprocessor_entities(Context *c, ZigClangASTUnit *zunit) {
     }
 }
 
-Error parse_h_buf(ImportTableEntry *import, ZigList<ErrorMsg *> *errors, Buf *source,
+Error parse_h_buf(ZigType *import, ZigList<ErrorMsg *> *errors, Buf *source,
         CodeGen *codegen, AstNode *source_node)
 {
     Error err;
@@ -4748,7 +4748,7 @@ Error parse_h_buf(ImportTableEntry *import, ZigList<ErrorMsg *> *errors, Buf *so
     return err;
 }
 
-Error parse_h_file(ImportTableEntry *import, ZigList<ErrorMsg *> *errors, const char *target_file,
+Error parse_h_file(ZigType *import, ZigList<ErrorMsg *> *errors, const char *target_file,
         CodeGen *codegen, AstNode *source_node)
 {
     Context context = {0};
@@ -4958,7 +4958,8 @@ Error parse_h_file(ImportTableEntry *import, ZigList<ErrorMsg *> *errors, const 
     render_macros(c);
     render_aliases(c);
 
-    import->root = c->root;
+    import->data.structure.decl_node = c->root;
+    import->data.structure.decls_scope->base.source_node = c->root;
 
     return ErrorNone;
 }

--- a/src/translate_c.hpp
+++ b/src/translate_c.hpp
@@ -11,10 +11,10 @@
 
 #include "all_types.hpp"
 
-Error parse_h_file(ImportTableEntry *import, ZigList<ErrorMsg *> *errors, const char *target_file,
+Error parse_h_file(ZigType *import, ZigList<ErrorMsg *> *errors, const char *target_file,
         CodeGen *codegen, AstNode *source_node);
 
-Error parse_h_buf(ImportTableEntry *import, ZigList<ErrorMsg *> *errors, Buf *source,
+Error parse_h_buf(ZigType *import, ZigList<ErrorMsg *> *errors, Buf *source,
         CodeGen *codegen, AstNode *source_node);
 
 #endif

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -94,18 +94,6 @@ ATTRIBUTE_RETURNS_NOALIAS static inline T *allocate(size_t count) {
 }
 
 template<typename T>
-static inline void safe_memcpy(T *dest, const T *src, size_t count) {
-#ifdef NDEBUG
-    memcpy(dest, src, count * sizeof(T));
-#else
-    // manually assign every elment to trigger compile error for non-copyable structs
-    for (size_t i = 0; i < count; i += 1) {
-        dest[i] = src[i];
-    }
-#endif
-}
-
-template<typename T>
 static inline T *reallocate(T *old, size_t old_count, size_t new_count) {
     T *ptr = reallocate_nonzero(old, old_count, new_count);
     if (new_count > old_count) {

--- a/std/crypto/blake2.zig
+++ b/std/crypto/blake2.zig
@@ -34,8 +34,8 @@ pub const Blake2s256 = Blake2s(256);
 fn Blake2s(comptime out_len: usize) type {
     return struct {
         const Self = @This();
-        const block_length = 64;
-        const digest_length = out_len / 8;
+        pub const block_length = 64;
+        pub const digest_length = out_len / 8;
 
         const iv = [8]u32{
             0x6A09E667,

--- a/std/crypto/md5.zig
+++ b/std/crypto/md5.zig
@@ -29,8 +29,8 @@ fn Rp(a: usize, b: usize, c: usize, d: usize, k: usize, s: u32, t: u32) RoundPar
 
 pub const Md5 = struct {
     const Self = @This();
-    const block_length = 64;
-    const digest_length = 16;
+    pub const block_length = 64;
+    pub const digest_length = 16;
 
     s: [4]u32,
     // Streaming Cache

--- a/std/crypto/sha1.zig
+++ b/std/crypto/sha1.zig
@@ -26,8 +26,8 @@ fn Rp(a: usize, b: usize, c: usize, d: usize, e: usize, i: u32) RoundParam {
 
 pub const Sha1 = struct {
     const Self = @This();
-    const block_length = 64;
-    const digest_length = 20;
+    pub const block_length = 64;
+    pub const digest_length = 20;
 
     s: [5]u32,
     // Streaming Cache

--- a/std/crypto/sha2.zig
+++ b/std/crypto/sha2.zig
@@ -78,8 +78,8 @@ pub const Sha256 = Sha2_32(Sha256Params);
 fn Sha2_32(comptime params: Sha2Params32) type {
     return struct {
         const Self = @This();
-        const block_length = 64;
-        const digest_length = params.out_len / 8;
+        pub const block_length = 64;
+        pub const digest_length = params.out_len / 8;
 
         s: [8]u32,
         // Streaming Cache

--- a/std/crypto/sha3.zig
+++ b/std/crypto/sha3.zig
@@ -13,8 +13,8 @@ pub const Sha3_512 = Keccak(512, 0x06);
 fn Keccak(comptime bits: usize, comptime delim: u8) type {
     return struct {
         const Self = @This();
-        const block_length = 200;
-        const digest_length = bits / 8;
+        pub const block_length = 200;
+        pub const digest_length = bits / 8;
 
         s: [200]u8,
         offset: usize,

--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -486,7 +486,6 @@ pub fn autoHash(key: var, comptime rng: *std.rand.Random, comptime HashInt: type
         builtin.TypeId.ErrorSet => return autoHash(@errorToInt(key), rng),
         builtin.TypeId.Promise, builtin.TypeId.Fn => return autoHash(@ptrToInt(key), rng),
 
-        builtin.TypeId.Namespace,
         builtin.TypeId.BoundFn,
         builtin.TypeId.ComptimeFloat,
         builtin.TypeId.ComptimeInt,
@@ -532,7 +531,6 @@ pub fn autoEql(a: var, b: @typeOf(a)) bool {
         builtin.TypeId.Float,
         builtin.TypeId.ComptimeFloat,
         builtin.TypeId.ComptimeInt,
-        builtin.TypeId.Namespace,
         builtin.TypeId.Promise,
         builtin.TypeId.Enum,
         builtin.TypeId.BoundFn,

--- a/std/pdb.zig
+++ b/std/pdb.zig
@@ -12,7 +12,6 @@ const ArrayList = std.ArrayList;
 // Note: most of this is based on information gathered from LLVM source code,
 // documentation and/or contributors.
 
-
 // https://llvm.org/docs/PDB/DbiStream.html#stream-header
 pub const DbiStreamHeader = packed struct {
     VersionSignature: i32,
@@ -393,10 +392,9 @@ pub const LineNumberEntry = packed struct {
     Flags: u32,
 
     /// TODO runtime crash when I make the actual type of Flags this
-    const Flags = packed struct {
+    pub const Flags = packed struct {
         /// Start line number
         Start: u24,
-
         /// Delta of lines to the end of the expression. Still unclear.
         // TODO figure out the point of this field.
         End: u7,

--- a/std/testing.zig
+++ b/std/testing.zig
@@ -44,7 +44,6 @@ pub fn expectEqual(expected: var, actual: @typeOf(expected)) void {
         TypeId.ComptimeFloat,
         TypeId.ComptimeInt,
         TypeId.Enum,
-        TypeId.Namespace,
         TypeId.Fn,
         TypeId.Promise,
         TypeId.Vector,

--- a/std/zig/ast.zig
+++ b/std/zig/ast.zig
@@ -617,7 +617,7 @@ pub const Node = struct {
 
         pub const DeclList = Root.DeclList;
 
-        const InitArg = union(enum) {
+        pub const InitArg = union(enum) {
             None,
             Enum: ?*Node,
             Type: *Node,
@@ -1744,7 +1744,7 @@ pub const Node = struct {
         kind: Kind,
         rhs: ?*Node,
 
-        const Kind = union(enum) {
+        pub const Kind = union(enum) {
             Break: ?*Node,
             Continue: ?*Node,
             Return,
@@ -2022,7 +2022,7 @@ pub const Node = struct {
         kind: Kind,
         rparen: TokenIndex,
 
-        const Kind = union(enum) {
+        pub const Kind = union(enum) {
             Variable: *Identifier,
             Return: *Node,
         };
@@ -2101,9 +2101,9 @@ pub const Node = struct {
         clobbers: ClobberList,
         rparen: TokenIndex,
 
-        const OutputList = SegmentedList(*AsmOutput, 2);
-        const InputList = SegmentedList(*AsmInput, 2);
-        const ClobberList = SegmentedList(TokenIndex, 2);
+        pub const OutputList = SegmentedList(*AsmOutput, 2);
+        pub const InputList = SegmentedList(*AsmInput, 2);
+        pub const ClobberList = SegmentedList(TokenIndex, 2);
 
         pub fn iterate(self: *Asm, index: usize) ?*Node {
             var i = index;

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1231,10 +1231,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
             \\
             \\fn bar(x: *b.Foo) void {}
         ,
-            "tmp.zig:6:10: error: expected type '*Foo', found '*Foo'",
-            "tmp.zig:6:10: note: pointer type child 'Foo' cannot cast into pointer type child 'Foo'",
-            "a.zig:1:17: note: Foo declared here",
-            "b.zig:1:17: note: Foo declared here",
+            "tmp.zig:6:10: error: expected type '*b.Foo', found '*a.Foo'",
+            "tmp.zig:6:10: note: pointer type child 'a.Foo' cannot cast into pointer type child 'b.Foo'",
+            "a.zig:1:17: note: a.Foo declared here",
+            "b.zig:1:17: note: b.Foo declared here",
         );
 
         tc.addSourceFile("a.zig",

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3,6 +3,68 @@ const builtin = @import("builtin");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "bogus compile var",
+        \\const x = @import("builtin").bogus;
+        \\export fn entry() usize { return @sizeOf(@typeOf(x)); }
+    ,
+        "tmp.zig:1:29: error: container 'builtin' has no member called 'bogus'",
+    );
+
+    cases.add(
+        "wrong panic signature, runtime function",
+        \\test "" {}
+        \\
+        \\pub fn panic() void {}
+        \\
+    ,
+        "tmp.zig:3:5: error: expected type 'fn([]const u8, ?*builtin.StackTrace) noreturn', found 'fn() void'",
+    );
+
+    cases.add(
+        "wrong panic signature, generic function",
+        \\pub fn panic(comptime msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
+        \\    while (true) {}
+        \\}
+    ,
+        "tmp.zig:1:5: error: expected type 'fn([]const u8, ?*builtin.StackTrace) noreturn', found 'fn([]const u8,var)var'",
+        "tmp.zig:1:5: note: only one of the functions is generic",
+    );
+
+    cases.add(
+        "direct struct loop",
+        \\const A = struct { a : A, };
+        \\export fn entry() usize { return @sizeOf(A); }
+    ,
+        "tmp.zig:1:11: error: struct 'A' contains itself",
+    );
+
+    cases.add(
+        "indirect struct loop",
+        \\const A = struct { b : B, };
+        \\const B = struct { c : C, };
+        \\const C = struct { a : A, };
+        \\export fn entry() usize { return @sizeOf(A); }
+    ,
+        "tmp.zig:1:11: error: struct 'A' contains itself",
+    );
+
+    cases.add(
+        "instantiating an undefined value for an invalid struct that contains itself",
+        \\const Foo = struct {
+        \\    x: Foo,
+        \\};
+        \\
+        \\var foo: Foo = undefined;
+        \\
+        \\export fn entry() usize {
+        \\    return @sizeOf(@typeOf(foo.x));
+        \\}
+    ,
+        "tmp.zig:1:13: error: struct 'Foo' contains itself",
+        "tmp.zig:8:28: note: referenced here",
+    );
+
+    cases.add(
         "@typeInfo causing depend on itself compile error",
         \\const start = struct {
         \\    fn crash() bug() {
@@ -16,7 +78,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var boom = start.crash();
         \\}
     ,
-        ".tmp_source.zig:2:5: error: 'crash' depends on itself",
+        "tmp.zig:7:9: error: dependency loop detected",
+        "tmp.zig:2:19: note: called from here",
+        "tmp.zig:10:21: note: referenced here",
     );
 
     cases.add(
@@ -29,7 +93,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var s: Foo = Foo.E;
         \\}
     ,
-        ".tmp_source.zig:1:17: error: 'Foo' depends on itself",
+        "tmp.zig:1:17: error: 'Foo' depends on itself",
     );
 
     cases.add(
@@ -40,7 +104,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const c = a + b;
         \\}
     ,
-        ".tmp_source.zig:1:1: error: 'a' depends on itself",
+        "tmp.zig:2:19: error: dependency loop detected",
+        "tmp.zig:1:19: note: referenced here",
+        "tmp.zig:4:15: note: referenced here",
     );
 
     cases.addTest(
@@ -59,7 +125,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const InvalidToken = struct {};
         \\const ExpectedVarDeclOrFn = struct {};
     ,
-        ".tmp_source.zig:4:9: error: not an enum type",
+        "tmp.zig:4:9: error: not an enum type",
     );
 
     cases.addTest(
@@ -70,7 +136,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x: AB = undefined;
         \\}
     ,
-        ".tmp_source.zig:2:18: error: invalid operands to binary expression: 'error{A}' and 'error{B}'",
+        "tmp.zig:2:18: error: invalid operands to binary expression: 'error{A}' and 'error{B}'",
     );
 
     if (builtin.os == builtin.Os.linux) {
@@ -81,7 +147,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
             \\    exit(0);
             \\}
         ,
-            ".tmp_source.zig:3:5: error: dependency on library c must be explicitly specified in the build command",
+            "tmp.zig:3:5: error: dependency on library c must be explicitly specified in the build command",
         );
 
         cases.addTest(
@@ -91,8 +157,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
             \\    _ = c.printf(c"hello, world!\n");
             \\}
         ,
-            ".tmp_source.zig:1:11: error: C import failed",
-            ".tmp_source.zig:1:11: note: libc headers not available; compilation does not link against libc",
+            "tmp.zig:1:11: error: C import failed",
+            "tmp.zig:1:11: note: libc headers not available; compilation does not link against libc",
         );
     }
 
@@ -104,8 +170,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = a + b;
         \\}
     ,
-        ".tmp_source.zig:4:15: error: operation caused overflow",
-        ".tmp_source.zig:4:15: note: when computing vector element at index 2",
+        "tmp.zig:4:15: error: operation caused overflow",
+        "tmp.zig:4:15: note: when computing vector element at index 2",
     );
 
     cases.addTest(
@@ -152,14 +218,14 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    B,
         \\};
     ,
-        ".tmp_source.zig:2:5: error: type 'anyerror' not allowed in packed struct; no guaranteed in-memory representation",
-        ".tmp_source.zig:5:5: error: array of 'u24' not allowed in packed struct due to padding bits",
-        ".tmp_source.zig:8:5: error: type 'anyerror' not allowed in packed struct; no guaranteed in-memory representation",
-        ".tmp_source.zig:11:5: error: non-packed, non-extern struct 'S' not allowed in packed struct; no guaranteed in-memory representation",
-        ".tmp_source.zig:14:5: error: non-packed, non-extern struct 'U' not allowed in packed struct; no guaranteed in-memory representation",
-        ".tmp_source.zig:17:5: error: type '?anyerror' not allowed in packed struct; no guaranteed in-memory representation",
-        ".tmp_source.zig:20:5: error: type 'Enum' not allowed in packed struct; no guaranteed in-memory representation",
-        ".tmp_source.zig:38:14: note: enum declaration does not specify an integer tag type",
+        "tmp.zig:2:5: error: type 'anyerror' not allowed in packed struct; no guaranteed in-memory representation",
+        "tmp.zig:5:5: error: array of 'u24' not allowed in packed struct due to padding bits",
+        "tmp.zig:8:5: error: type 'anyerror' not allowed in packed struct; no guaranteed in-memory representation",
+        "tmp.zig:11:5: error: non-packed, non-extern struct 'S' not allowed in packed struct; no guaranteed in-memory representation",
+        "tmp.zig:14:5: error: non-packed, non-extern struct 'U' not allowed in packed struct; no guaranteed in-memory representation",
+        "tmp.zig:17:5: error: type '?anyerror' not allowed in packed struct; no guaranteed in-memory representation",
+        "tmp.zig:20:5: error: type 'Enum' not allowed in packed struct; no guaranteed in-memory representation",
+        "tmp.zig:38:14: note: enum declaration does not specify an integer tag type",
     );
 
     cases.addCase(x: {
@@ -172,7 +238,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
             \\    x += 1;
             \\}
         ,
-            ".tmp_source.zig:2:5: error: use of undeclared identifier 'x'",
+            "tmp.zig:2:5: error: use of undeclared identifier 'x'",
         );
         tc.expect_exact = true;
         break :x tc;
@@ -184,7 +250,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return 0;
         \\}
     ,
-        ".tmp_source.zig:1:15: error: parameter of type 'var' not allowed in function with calling convention 'ccc'",
+        "tmp.zig:1:15: error: parameter of type 'var' not allowed in function with calling convention 'ccc'",
     );
 
     cases.addTest(
@@ -194,7 +260,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var y: [*c]c_void = x;
         \\}
     ,
-        ".tmp_source.zig:3:12: error: C pointers cannot point opaque types",
+        "tmp.zig:3:12: error: C pointers cannot point opaque types",
     );
 
     cases.addTest(
@@ -214,8 +280,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bar: Bar = undefined;
         \\}
     ,
-        ".tmp_source.zig:3:8: error: opaque types have unknown size and therefore cannot be directly embedded in structs",
-        ".tmp_source.zig:7:10: error: opaque types have unknown size and therefore cannot be directly embedded in unions",
+        "tmp.zig:3:8: error: opaque types have unknown size and therefore cannot be directly embedded in structs",
+        "tmp.zig:7:10: error: opaque types have unknown size and therefore cannot be directly embedded in unions",
     );
 
     cases.addTest(
@@ -245,13 +311,13 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x: [*c]u32 = y;
         \\}
     ,
-        ".tmp_source.zig:3:27: error: cast increases pointer alignment",
-        ".tmp_source.zig:7:18: error: cast discards const qualifier",
-        ".tmp_source.zig:11:19: error: expected type '*u32', found '[*c]u8'",
-        ".tmp_source.zig:11:19: note: pointer type child 'u8' cannot cast into pointer type child 'u32'",
-        ".tmp_source.zig:15:22: error: cast increases pointer alignment",
-        ".tmp_source.zig:19:21: error: cast discards const qualifier",
-        ".tmp_source.zig:23:22: error: expected type '[*c]u32', found '*u8'",
+        "tmp.zig:3:27: error: cast increases pointer alignment",
+        "tmp.zig:7:18: error: cast discards const qualifier",
+        "tmp.zig:11:19: error: expected type '*u32', found '[*c]u8'",
+        "tmp.zig:11:19: note: pointer type child 'u8' cannot cast into pointer type child 'u32'",
+        "tmp.zig:15:22: error: cast increases pointer alignment",
+        "tmp.zig:19:21: error: cast discards const qualifier",
+        "tmp.zig:23:22: error: expected type '[*c]u32', found '*u8'",
     );
 
     cases.addTest(
@@ -261,7 +327,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var zig_ptr: *u8 = c_ptr;
         \\}
     ,
-        ".tmp_source.zig:3:24: error: null pointer casted to type '*u8'",
+        "tmp.zig:3:24: error: null pointer casted to type '*u8'",
     );
 
     cases.addTest(
@@ -271,7 +337,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var zig_ptr: *u8 = c_ptr;
         \\}
     ,
-        ".tmp_source.zig:3:24: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:24: error: use of undefined value here causes undefined behavior",
     );
 
     cases.addTest(
@@ -291,12 +357,12 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var c_ptr: [*c][*c]const u8 = ptr_opt_many_ptr;
         \\}
     ,
-        ".tmp_source.zig:6:24: error: expected type '*const [*]const u8', found '[*c]const [*c]const u8'",
-        ".tmp_source.zig:6:24: note: pointer type child '[*c]const u8' cannot cast into pointer type child '[*]const u8'",
-        ".tmp_source.zig:6:24: note: '[*c]const u8' could have null values which are illegal in type '[*]const u8'",
-        ".tmp_source.zig:13:35: error: expected type '[*c][*c]const u8', found '*[*]u8'",
-        ".tmp_source.zig:13:35: note: pointer type child '[*]u8' cannot cast into pointer type child '[*c]const u8'",
-        ".tmp_source.zig:13:35: note: mutable '[*c]const u8' allows illegal null values stored to type '[*]u8'",
+        "tmp.zig:6:24: error: expected type '*const [*]const u8', found '[*c]const [*c]const u8'",
+        "tmp.zig:6:24: note: pointer type child '[*c]const u8' cannot cast into pointer type child '[*]const u8'",
+        "tmp.zig:6:24: note: '[*c]const u8' could have null values which are illegal in type '[*]const u8'",
+        "tmp.zig:13:35: error: expected type '[*c][*c]const u8', found '*[*]u8'",
+        "tmp.zig:13:35: note: pointer type child '[*]u8' cannot cast into pointer type child '[*c]const u8'",
+        "tmp.zig:13:35: note: mutable '[*c]const u8' allows illegal null values stored to type '[*]u8'",
     );
 
     cases.addTest(
@@ -309,8 +375,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var ptr: [*c]u8 = x;
         \\}
     ,
-        ".tmp_source.zig:2:33: error: integer value 71615590737044764481 cannot be implicitly casted to type 'usize'",
-        ".tmp_source.zig:6:23: error: integer type 'u65' too big for implicit @intToPtr to type '[*c]u8'",
+        "tmp.zig:2:33: error: integer value 71615590737044764481 cannot be implicitly casted to type 'usize'",
+        "tmp.zig:6:23: error: integer type 'u65' too big for implicit @intToPtr to type '[*c]u8'",
     );
 
     cases.addTest(
@@ -320,7 +386,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const T = [*c]Foo;
         \\}
     ,
-        ".tmp_source.zig:3:15: error: C pointers cannot point to non-C-ABI-compatible type 'Foo'",
+        "tmp.zig:3:15: error: C pointers cannot point to non-C-ABI-compatible type 'Foo'",
     );
 
     cases.addCase(x: {
@@ -335,7 +401,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
             \\    inline while (i < n) : (i += 1) { @compileLog("!@#$"); }
             \\}
         ,
-            ".tmp_source.zig:7:39: error: found compile log statement",
+            "tmp.zig:7:39: error: found compile log statement",
         );
         tc.expect_exact = true;
         break :x tc;
@@ -347,7 +413,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    'a'.* = 1;
         \\}
     ,
-        ".tmp_source.zig:2:8: error: attempt to dereference non-pointer type 'comptime_int'",
+        "tmp.zig:2:8: error: attempt to dereference non-pointer type 'comptime_int'",
     );
 
     cases.addTest(
@@ -356,7 +422,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = 'a'.*[0..];
         \\}
     ,
-        ".tmp_source.zig:2:18: error: attempt to dereference non-pointer type 'comptime_int'",
+        "tmp.zig:2:18: error: attempt to dereference non-pointer type 'comptime_int'",
     );
 
     cases.addTest(
@@ -365,14 +431,14 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var z = @truncate(u8, u16(undefined));
         \\}
     ,
-        ".tmp_source.zig:2:30: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:2:30: error: use of undefined value here causes undefined behavior",
     );
 
     cases.addTest(
         "return invalid type from test",
         \\test "example" { return 1; }
     ,
-        ".tmp_source.zig:1:25: error: integer value 1 cannot be implicitly casted to type 'void'",
+        "tmp.zig:1:25: error: integer value 1 cannot be implicitly casted to type 'void'",
     );
 
     cases.add(
@@ -382,7 +448,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return x;
         \\}
     ,
-        ".tmp_source.zig:1:13: error: threadlocal variable cannot be constant",
+        "tmp.zig:1:13: error: threadlocal variable cannot be constant",
     );
 
     cases.add(
@@ -391,7 +457,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    threadlocal var x: i32 = 1234;
         \\}
     ,
-        ".tmp_source.zig:2:5: error: function-local variable 'x' cannot be threadlocal",
+        "tmp.zig:2:5: error: function-local variable 'x' cannot be threadlocal",
     );
 
     cases.add(
@@ -400,7 +466,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var oops = @bitCast(u7, byte);
         \\}
     ,
-        ".tmp_source.zig:2:16: error: destination type 'u7' has 7 bits but source type 'u8' has 8 bits",
+        "tmp.zig:2:16: error: destination type 'u7' has 7 bits but source type 'u8' has 8 bits",
     );
 
     cases.add(
@@ -412,7 +478,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return 5678;
         \\}
     ,
-        ".tmp_source.zig:2:12: error: `&&` is invalid. Note that `and` is boolean AND.",
+        "tmp.zig:2:12: error: `&&` is invalid. Note that `and` is boolean AND.",
     );
 
     cases.add(
@@ -424,8 +490,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return 5678;
         \\}
     ,
-        ".tmp_source.zig:2:9: error: expected error set type, found 'bool'",
-        ".tmp_source.zig:2:11: note: `||` merges error sets; `or` performs boolean OR",
+        "tmp.zig:2:9: error: expected error set type, found 'bool'",
+        "tmp.zig:2:11: note: `||` merges error sets; `or` performs boolean OR",
     );
 
     cases.add(
@@ -434,7 +500,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @compileLog(@ptrCast(*const c_void, &entry));
         \\}
     ,
-        ".tmp_source.zig:2:5: error: found compile log statement",
+        "tmp.zig:2:5: error: found compile log statement",
     );
 
     cases.add(
@@ -454,8 +520,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    };
         \\}
     ,
-        ".tmp_source.zig:5:9: error: duplicate switch value",
-        ".tmp_source.zig:12:9: error: duplicate switch value",
+        "tmp.zig:5:9: error: duplicate switch value",
+        "tmp.zig:12:9: error: duplicate switch value",
     );
 
     cases.add(
@@ -471,8 +537,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    };
         \\}
     ,
-        ".tmp_source.zig:2:15: error: switch must handle all possibilities",
-        ".tmp_source.zig:7:15: error: switch must handle all possibilities",
+        "tmp.zig:2:15: error: switch must handle all possibilities",
+        "tmp.zig:7:15: error: switch must handle all possibilities",
     );
 
     cases.add(
@@ -484,7 +550,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const deref = int_ptr.*;
         \\}
     ,
-        ".tmp_source.zig:5:26: error: attempt to read 4 bytes from [4]u8 at index 1 which is 3 bytes",
+        "tmp.zig:5:26: error: attempt to read 4 bytes from [4]u8 at index 1 which is 3 bytes",
     );
 
     cases.add(
@@ -495,8 +561,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    do_the_thing(bar);
         \\}
     ,
-        ".tmp_source.zig:4:18: error: expected type 'fn(i32) void', found 'fn(bool) void",
-        ".tmp_source.zig:4:18: note: parameter 0: 'bool' cannot cast into 'i32'",
+        "tmp.zig:4:18: error: expected type 'fn(i32) void', found 'fn(bool) void",
+        "tmp.zig:4:18: note: parameter 0: 'bool' cannot cast into 'i32'",
     );
 
     cases.add(
@@ -510,8 +576,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const unsigned: u32 = value;
         \\}
     ,
-        ".tmp_source.zig:3:36: error: cannot cast negative value -1 to unsigned integer type 'u32'",
-        ".tmp_source.zig:7:27: error: cannot cast negative value -1 to unsigned integer type 'u32'",
+        "tmp.zig:3:36: error: cannot cast negative value -1 to unsigned integer type 'u32'",
+        "tmp.zig:7:27: error: cannot cast negative value -1 to unsigned integer type 'u32'",
     );
 
     cases.add(
@@ -529,9 +595,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var byte: u8 = spartan_count;
         \\}
     ,
-        ".tmp_source.zig:3:31: error: integer value 300 cannot be implicitly casted to type 'u8'",
-        ".tmp_source.zig:7:22: error: integer value 300 cannot be implicitly casted to type 'u8'",
-        ".tmp_source.zig:11:20: error: expected type 'u8', found 'u16'",
+        "tmp.zig:3:31: error: integer value 300 cannot be implicitly casted to type 'u8'",
+        "tmp.zig:7:22: error: integer value 300 cannot be implicitly casted to type 'u8'",
+        "tmp.zig:11:20: error: expected type 'u8', found 'u16'",
     );
 
     cases.add(
@@ -541,7 +607,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const y: f32 = x;
         \\}
     ,
-        ".tmp_source.zig:3:20: error: cast of value 16777217.000000 to type 'f32' loses information",
+        "tmp.zig:3:20: error: cast of value 16777217.000000 to type 'f32' loses information",
     );
 
     cases.add(
@@ -551,7 +617,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(y)); }
     ,
-        ".tmp_source.zig:2:14: error: expected type 'f32', found 'f64'",
+        "tmp.zig:2:14: error: expected type 'f32', found 'f64'",
     );
 
     cases.add(
@@ -563,28 +629,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x: i65536 = 1;
         \\}
     ,
-        ".tmp_source.zig:2:31: error: integer value 65536 cannot be implicitly casted to type 'u16'",
-        ".tmp_source.zig:5:12: error: primitive integer type 'i65536' exceeds maximum bit width of 65535",
-    );
-
-    cases.add(
-        "wrong panic signature, runtime function",
-        \\test "" {}
-        \\
-        \\pub fn panic() void {}
-        \\
-    ,
-        ".tmp_source.zig:3:5: error: expected type 'fn([]const u8, ?*StackTrace) noreturn', found 'fn() void'",
-    );
-
-    cases.add(
-        "wrong panic signature, generic function",
-        \\pub fn panic(comptime msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
-        \\    while (true) {}
-        \\}
-    ,
-        ".tmp_source.zig:1:5: error: expected type 'fn([]const u8, ?*StackTrace) noreturn', found 'fn([]const u8,var)var'",
-        ".tmp_source.zig:1:5: note: only one of the functions is generic",
+        "tmp.zig:2:31: error: integer value 65536 cannot be implicitly casted to type 'u16'",
+        "tmp.zig:5:12: error: primitive integer type 'i65536' exceeds maximum bit width of 65535",
     );
 
     cases.add(
@@ -597,7 +643,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const car = Car.init();
         \\}
     ,
-        ".tmp_source.zig:2:11: error: use of undeclared identifier 'SymbolThatDoesNotExist'",
+        "tmp.zig:2:11: error: use of undeclared identifier 'SymbolThatDoesNotExist'",
     );
 
     cases.add(
@@ -609,7 +655,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var ptr2: *c_void = &b;
         \\}
     ,
-        ".tmp_source.zig:5:26: error: expected type '*c_void', found '**u32'",
+        "tmp.zig:5:26: error: expected type '*c_void', found '**u32'",
     );
 
     cases.add(
@@ -625,7 +671,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const field = @typeInfo(Struct).Struct.fields[index];
         \\}
     ,
-        ".tmp_source.zig:9:51: error: values of type 'StructField' must be comptime known, but index value is runtime known",
+        "tmp.zig:9:51: error: values of type 'builtin.StructField' must be comptime known, but index value is runtime known",
     );
 
     cases.add(
@@ -639,7 +685,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @typeName(Foo(i32));
         \\}
     ,
-        ".tmp_source.zig:2:5: error: found compile log statement",
+        "tmp.zig:2:5: error: found compile log statement",
     );
 
     cases.add(
@@ -649,7 +695,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var b = a[0..10];
         \\}
     ,
-        ".tmp_source.zig:3:14: error: slice of undefined",
+        "tmp.zig:3:14: error: slice of undefined",
     );
 
     cases.add(
@@ -659,7 +705,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const sliceA: []u8 = &buffer;
         \\}
     ,
-        ".tmp_source.zig:3:27: error: expected type '[]u8', found '*const [1]u8'",
+        "tmp.zig:3:27: error: expected type '[]u8', found '*const [1]u8'",
     );
 
     cases.add(
@@ -669,7 +715,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a.*.len;
         \\}
     ,
-        ".tmp_source.zig:3:10: error: attempt to dereference non-pointer type '[]u8'",
+        "tmp.zig:3:10: error: attempt to dereference non-pointer type '[]u8'",
     );
 
     cases.add(
@@ -680,9 +726,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return p == null;
         \\}
     ,
-        ".tmp_source.zig:3:15: error: '*u0' and '?*u0' do not have the same in-memory representation",
-        ".tmp_source.zig:3:31: note: '*u0' has no in-memory bits",
-        ".tmp_source.zig:3:24: note: '?*u0' has in-memory bits",
+        "tmp.zig:3:15: error: '*u0' and '?*u0' do not have the same in-memory representation",
+        "tmp.zig:3:31: note: '*u0' has no in-memory bits",
+        "tmp.zig:3:24: note: '?*u0' has in-memory bits",
     );
 
     cases.add(
@@ -692,7 +738,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = &x == null;
         \\}
     ,
-        ".tmp_source.zig:3:12: error: comparison against null can only be done with optionals",
+        "tmp.zig:3:12: error: comparison against null can only be done with optionals",
     );
 
     cases.add(
@@ -704,10 +750,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const Errors = error{} || u16;
         \\}
     ,
-        ".tmp_source.zig:2:20: error: expected error set type, found type 'u8'",
-        ".tmp_source.zig:2:23: note: `||` merges error sets; `or` performs boolean OR",
-        ".tmp_source.zig:5:31: error: expected error set type, found type 'u16'",
-        ".tmp_source.zig:5:28: note: `||` merges error sets; `or` performs boolean OR",
+        "tmp.zig:2:20: error: expected error set type, found type 'u8'",
+        "tmp.zig:2:23: note: `||` merges error sets; `or` performs boolean OR",
+        "tmp.zig:5:31: error: expected error set type, found type 'u16'",
+        "tmp.zig:5:28: note: `||` merges error sets; `or` performs boolean OR",
     );
 
     cases.add(
@@ -725,7 +771,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const S = Gen();
         \\}
     ,
-        ".tmp_source.zig:2:12: error: use of undeclared identifier 'T'",
+        "tmp.zig:2:12: error: use of undeclared identifier 'T'",
     );
 
     cases.add(
@@ -736,7 +782,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    f(i32);
         \\}
     ,
-        ".tmp_source.zig:4:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:4:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -754,9 +800,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = func(3);
         \\}
     ,
-        ".tmp_source.zig:4:24: error: 'y' not accessible from inner function",
-        ".tmp_source.zig:3:28: note: crossed function definition here",
-        ".tmp_source.zig:1:10: note: declared here",
+        "tmp.zig:4:24: error: 'y' not accessible from inner function",
+        "tmp.zig:3:28: note: crossed function definition here",
+        "tmp.zig:1:10: note: declared here",
     );
 
     cases.add(
@@ -765,7 +811,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = @intToFloat(f32, 1.1);
         \\}
     ,
-        ".tmp_source.zig:2:32: error: expected int type, found 'comptime_float'",
+        "tmp.zig:2:32: error: expected int type, found 'comptime_float'",
     );
 
     cases.add(
@@ -774,7 +820,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = @floatToInt(i32, i32(54));
         \\}
     ,
-        ".tmp_source.zig:2:35: error: expected float type, found 'i32'",
+        "tmp.zig:2:35: error: expected float type, found 'i32'",
     );
 
     cases.add(
@@ -783,7 +829,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = @floatToInt(i8, 200);
         \\}
     ,
-        ".tmp_source.zig:2:31: error: integer value 200 cannot be implicitly casted to type 'i8'",
+        "tmp.zig:2:31: error: integer value 200 cannot be implicitly casted to type 'i8'",
     );
 
     cases.add(
@@ -795,7 +841,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const int_val = int_ptr.*;
         \\}
     ,
-        ".tmp_source.zig:5:28: error: attempt to read 8 bytes from pointer to f32 which is 4 bytes",
+        "tmp.zig:5:28: error: attempt to read 8 bytes from pointer to f32 which is 4 bytes",
     );
 
     cases.add(
@@ -808,7 +854,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a = items[0];
         \\}
     ,
-        ".tmp_source.zig:2:12: error: use of undeclared identifier 'SomeNonexistentType'",
+        "tmp.zig:2:12: error: use of undeclared identifier 'SomeNonexistentType'",
     );
 
     cases.add(
@@ -819,7 +865,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @noInlineCall(foo);
         \\}
     ,
-        ".tmp_source.zig:4:5: error: no-inline call of inline function",
+        "tmp.zig:4:5: error: no-inline call of inline function",
     );
 
     cases.add(
@@ -836,8 +882,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:6:19: error: comptime control flow inside runtime block",
-        ".tmp_source.zig:5:9: note: runtime block created here",
+        "tmp.zig:6:19: error: comptime control flow inside runtime block",
+        "tmp.zig:5:9: note: runtime block created here",
     );
 
     cases.add(
@@ -853,8 +899,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:6:13: error: comptime control flow inside runtime block",
-        ".tmp_source.zig:5:9: note: runtime block created here",
+        "tmp.zig:6:13: error: comptime control flow inside runtime block",
+        "tmp.zig:5:9: note: runtime block created here",
     );
 
     cases.add(
@@ -868,8 +914,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:5:23: error: comptime control flow inside runtime block",
-        ".tmp_source.zig:5:9: note: runtime block created here",
+        "tmp.zig:5:23: error: comptime control flow inside runtime block",
+        "tmp.zig:5:9: note: runtime block created here",
     );
 
     cases.add(
@@ -883,8 +929,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:5:25: error: comptime control flow inside runtime block",
-        ".tmp_source.zig:5:9: note: runtime block created here",
+        "tmp.zig:5:25: error: comptime control flow inside runtime block",
+        "tmp.zig:5:9: note: runtime block created here",
     );
 
     cases.add(
@@ -898,8 +944,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:5:20: error: comptime control flow inside runtime block",
-        ".tmp_source.zig:5:9: note: runtime block created here",
+        "tmp.zig:5:20: error: comptime control flow inside runtime block",
+        "tmp.zig:5:9: note: runtime block created here",
     );
 
     cases.add(
@@ -913,8 +959,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:5:20: error: comptime control flow inside runtime block",
-        ".tmp_source.zig:5:9: note: runtime block created here",
+        "tmp.zig:5:20: error: comptime control flow inside runtime block",
+        "tmp.zig:5:9: note: runtime block created here",
     );
 
     cases.add(
@@ -928,8 +974,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:5:22: error: comptime control flow inside runtime block",
-        ".tmp_source.zig:5:9: note: runtime block created here",
+        "tmp.zig:5:22: error: comptime control flow inside runtime block",
+        "tmp.zig:5:9: note: runtime block created here",
     );
 
     cases.add(
@@ -945,7 +991,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    };
         \\}
     ,
-        ".tmp_source.zig:7:17: error: switch on type 'type' provides no expression parameter",
+        "tmp.zig:7:17: error: switch on type 'type' provides no expression parameter",
     );
 
     cases.add(
@@ -955,7 +1001,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    foo();
         \\}
     ,
-        ".tmp_source.zig:1:1: error: non-extern function has no body",
+        "tmp.zig:1:1: error: non-extern function has no body",
     );
 
     cases.add(
@@ -966,7 +1012,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return handle_undef == handle_dummy;
         \\}
     ,
-        ".tmp_source.zig:2:29: error: @handle() called outside of function definition",
+        "tmp.zig:2:29: error: @handle() called outside of function definition",
     );
 
     cases.add(
@@ -976,7 +1022,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return handle_undef == @handle();
         \\}
     ,
-        ".tmp_source.zig:3:28: error: @handle() in non-async function",
+        "tmp.zig:3:28: error: @handle() in non-async function",
     );
 
     cases.add(
@@ -986,8 +1032,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return _;
         \\}
     ,
-        ".tmp_source.zig:2:5: error: `_` is not a declarable symbol",
-        ".tmp_source.zig:3:12: error: use of undeclared identifier '_'",
+        "tmp.zig:2:5: error: `_` is not a declarable symbol",
+        "tmp.zig:3:12: error: use of undeclared identifier '_'",
     );
 
     cases.add(
@@ -1000,7 +1046,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:4:20: error: use of undeclared identifier '_'",
+        "tmp.zig:4:20: error: use of undeclared identifier '_'",
     );
 
     cases.add(
@@ -1016,7 +1062,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return 1;
         \\}
     ,
-        ".tmp_source.zig:4:20: error: use of undeclared identifier '_'",
+        "tmp.zig:4:20: error: use of undeclared identifier '_'",
     );
 
     cases.add(
@@ -1034,7 +1080,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return error.optionalReturnError;
         \\}
     ,
-        ".tmp_source.zig:6:17: error: use of undeclared identifier '_'",
+        "tmp.zig:6:17: error: use of undeclared identifier '_'",
     );
 
     cases.add(
@@ -1054,9 +1100,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    while (x) |_| returns() else |_| unreachable;
         \\}
     ,
-        ".tmp_source.zig:5:25: error: expression value is ignored",
-        ".tmp_source.zig:9:26: error: expression value is ignored",
-        ".tmp_source.zig:13:26: error: expression value is ignored",
+        "tmp.zig:5:25: error: expression value is ignored",
+        "tmp.zig:9:26: error: expression value is ignored",
+        "tmp.zig:13:26: error: expression value is ignored",
     );
 
     cases.add(
@@ -1067,7 +1113,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    dump(a);
         \\}
     ,
-        ".tmp_source.zig:1:9: error: missing parameter name",
+        "tmp.zig:1:9: error: missing parameter name",
     );
 
     cases.add(
@@ -1081,7 +1127,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    for (xx) |f| {}
         \\}
     ,
-        ".tmp_source.zig:7:15: error: variable of type 'Foo' must be const or comptime",
+        "tmp.zig:7:15: error: variable of type 'Foo' must be const or comptime",
     );
 
     cases.add(
@@ -1092,7 +1138,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    f(g);
         \\}
     ,
-        ".tmp_source.zig:1:9: error: parameter of type 'fn(var)var' must be declared comptime",
+        "tmp.zig:1:9: error: parameter of type 'fn(var)var' must be declared comptime",
     );
 
     cases.add(
@@ -1106,7 +1152,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\};
         \\export fn entry(bar: *Bar) void {}
     ,
-        ".tmp_source.zig:2:5: error: extern structs cannot contain fields of type '?*const void'",
+        "tmp.zig:2:5: error: extern structs cannot contain fields of type '?*const void'",
     );
 
     cases.add(
@@ -1119,7 +1165,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    command.exec();
         \\}
     ,
-        ".tmp_source.zig:6:12: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:6:12: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -1132,7 +1178,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    command.exec();
         \\}
     ,
-        ".tmp_source.zig:6:12: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:6:12: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -1142,7 +1188,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const aligned = @alignCast(4, ptr);
         \\}
     ,
-        ".tmp_source.zig:3:35: error: pointer address 0x1 is not aligned to 4 bytes",
+        "tmp.zig:3:35: error: pointer address 0x1 is not aligned to 4 bytes",
     );
 
     cases.add(
@@ -1151,7 +1197,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @ptrToInt(&{}) == @ptrToInt(&{});
         \\}
     ,
-        ".tmp_source.zig:2:23: error: pointer to size 0 type has no address",
+        "tmp.zig:2:23: error: pointer to size 0 type has no address",
     );
 
     cases.add(
@@ -1160,7 +1206,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @popCount(x);
         \\}
     ,
-        ".tmp_source.zig:2:22: error: expected integer type, found 'f32'",
+        "tmp.zig:2:22: error: expected integer type, found 'f32'",
     );
 
     cases.add(
@@ -1169,7 +1215,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @popCount(-1);
         \\}
     ,
-        ".tmp_source.zig:2:9: error: @popCount on negative comptime_int value -1",
+        "tmp.zig:2:9: error: @popCount on negative comptime_int value -1",
     );
 
     cases.addCase(x: {
@@ -1185,8 +1231,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
             \\
             \\fn bar(x: *b.Foo) void {}
         ,
-            ".tmp_source.zig:6:10: error: expected type '*Foo', found '*Foo'",
-            ".tmp_source.zig:6:10: note: pointer type child 'Foo' cannot cast into pointer type child 'Foo'",
+            "tmp.zig:6:10: error: expected type '*Foo', found '*Foo'",
+            "tmp.zig:6:10: note: pointer type child 'Foo' cannot cast into pointer type child 'Foo'",
             "a.zig:1:17: note: Foo declared here",
             "b.zig:1:17: note: Foo declared here",
         );
@@ -1218,9 +1264,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @floatToInt(u8, f32(256.1));
         \\}
     ,
-        ".tmp_source.zig:2:9: error: integer value '-129' cannot be stored in type 'i8'",
-        ".tmp_source.zig:5:9: error: integer value '-1' cannot be stored in type 'u8'",
-        ".tmp_source.zig:8:9: error: integer value '256' cannot be stored in type 'u8'",
+        "tmp.zig:2:9: error: integer value '-129' cannot be stored in type 'i8'",
+        "tmp.zig:5:9: error: integer value '-1' cannot be stored in type 'u8'",
+        "tmp.zig:8:9: error: integer value '256' cannot be stored in type 'u8'",
     );
 
     cases.add(
@@ -1229,7 +1275,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a: fn () c_void = undefined;
         \\}
     ,
-        ".tmp_source.zig:2:20: error: return type cannot be opaque",
+        "tmp.zig:2:20: error: return type cannot be opaque",
     );
 
     cases.add(
@@ -1242,7 +1288,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var y = p.*;
         \\}
     ,
-        ".tmp_source.zig:4:23: error: expected type '*?*i32', found '**i32'",
+        "tmp.zig:4:23: error: expected type '*?*i32', found '**i32'",
     );
 
     cases.add(
@@ -1251,7 +1297,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x: [*]const bool = true;
         \\}
     ,
-        ".tmp_source.zig:2:30: error: expected type '[*]const bool', found 'bool'",
+        "tmp.zig:2:30: error: expected type '[*]const bool', found 'bool'",
     );
 
     cases.add(
@@ -1260,7 +1306,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return x.*;
         \\}
     ,
-        ".tmp_source.zig:2:13: error: index syntax required for unknown-length pointer type '[*]i32'",
+        "tmp.zig:2:13: error: index syntax required for unknown-length pointer type '[*]i32'",
     );
 
     cases.add(
@@ -1273,14 +1319,14 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    foo.a += 1;
         \\}
     ,
-        ".tmp_source.zig:6:8: error: type '[*]Foo' does not support field access",
+        "tmp.zig:6:8: error: type '[*]Foo' does not support field access",
     );
 
     cases.add(
         "unknown length pointer to opaque",
         \\export const T = [*]@OpaqueType();
     ,
-        ".tmp_source.zig:1:18: error: unknown-length pointer to opaque",
+        "tmp.zig:1:18: error: unknown-length pointer to opaque",
     );
 
     cases.add(
@@ -1296,7 +1342,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var rule_set = try Foo.init();
         \\}
     ,
-        ".tmp_source.zig:2:13: error: expected type 'i32', found 'type'",
+        "tmp.zig:2:13: error: expected type 'i32', found 'type'",
     );
 
     cases.add(
@@ -1305,7 +1351,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const slice = ptr[0..2];
         \\}
     ,
-        ".tmp_source.zig:2:22: error: slice of single-item pointer",
+        "tmp.zig:2:22: error: slice of single-item pointer",
     );
 
     cases.add(
@@ -1314,7 +1360,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return ptr[1];
         \\}
     ,
-        ".tmp_source.zig:2:15: error: index of single-item pointer",
+        "tmp.zig:2:15: error: index of single-item pointer",
     );
 
     cases.add(
@@ -1330,10 +1376,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return null;
         \\}
     ,
-        ".tmp_source.zig:5:34: error: expected type '?NextError!i32', found '?OtherError!i32'",
-        ".tmp_source.zig:5:34: note: optional type child 'OtherError!i32' cannot cast into optional type child 'NextError!i32'",
-        ".tmp_source.zig:5:34: note: error set 'OtherError' cannot cast into error set 'NextError'",
-        ".tmp_source.zig:2:26: note: 'error.OutOfMemory' not a member of destination error set",
+        "tmp.zig:5:34: error: expected type '?NextError!i32', found '?OtherError!i32'",
+        "tmp.zig:5:34: note: optional type child 'OtherError!i32' cannot cast into optional type child 'NextError!i32'",
+        "tmp.zig:5:34: note: error set 'OtherError' cannot cast into error set 'NextError'",
+        "tmp.zig:2:26: note: 'error.OutOfMemory' not a member of destination error set",
     );
 
     cases.add(
@@ -1350,14 +1396,14 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    Filled,
         \\};
     ,
-        ".tmp_source.zig:3:17: error: attempt to dereference non-pointer type 'Tile'",
+        "tmp.zig:3:17: error: attempt to dereference non-pointer type 'Tile'",
     );
 
     cases.add(
         "invalid field access in comptime",
         \\comptime { var x = doesnt_exist.whatever; }
     ,
-        ".tmp_source.zig:1:20: error: use of undeclared identifier 'doesnt_exist'",
+        "tmp.zig:1:20: error: use of undeclared identifier 'doesnt_exist'",
     );
 
     cases.add(
@@ -1378,8 +1424,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:12:9: error: cannot suspend inside suspend block",
-        ".tmp_source.zig:11:5: note: other suspend block here",
+        "tmp.zig:12:9: error: cannot suspend inside suspend block",
+        "tmp.zig:11:5: note: other suspend block here",
     );
 
     cases.add(
@@ -1389,8 +1435,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\inline fn b() void { }
     ,
-        ".tmp_source.zig:2:5: error: functions marked inline must be stored in const or comptime var",
-        ".tmp_source.zig:4:1: note: declared here",
+        "tmp.zig:2:5: error: functions marked inline must be stored in const or comptime var",
+        "tmp.zig:4:1: note: declared here",
     );
 
     cases.add(
@@ -1400,7 +1446,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @panic(e);
         \\}
     ,
-        ".tmp_source.zig:3:12: error: expected type '[]const u8', found 'error{Foo}'",
+        "tmp.zig:3:12: error: expected type '[]const u8', found 'error{Foo}'",
     );
 
     cases.add(
@@ -1414,8 +1460,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var tagName = @tagName(fi);
         \\}
     ,
-        ".tmp_source.zig:7:19: error: union has no associated enum",
-        ".tmp_source.zig:1:18: note: declared here",
+        "tmp.zig:7:19: error: union has no associated enum",
+        "tmp.zig:1:18: note: declared here",
     );
 
     cases.add(
@@ -1428,7 +1474,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return error.ShouldBeCompileError;
         \\}
     ,
-        ".tmp_source.zig:6:17: error: expected type 'void', found 'error{ShouldBeCompileError}'",
+        "tmp.zig:6:17: error: expected type 'void', found 'error{ShouldBeCompileError}'",
     );
 
     cases.add(
@@ -1437,7 +1483,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\   var s = (struct{v: var}){.v=i32(10)};
         \\}
     ,
-        ".tmp_source.zig:2:23: error: invalid token: 'var'",
+        "tmp.zig:2:23: error: invalid token: 'var'",
     );
 
     cases.add(
@@ -1447,7 +1493,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const y = @ptrCast(*i32, &x);
         \\}
     ,
-        ".tmp_source.zig:3:15: error: cast discards const qualifier",
+        "tmp.zig:3:15: error: cast discards const qualifier",
     );
 
     cases.add(
@@ -1456,7 +1502,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const slice = ([*]i32)(undefined)[0..1];
         \\}
     ,
-        ".tmp_source.zig:2:38: error: non-zero length slice of undefined pointer",
+        "tmp.zig:2:38: error: non-zero length slice of undefined pointer",
     );
 
     cases.add(
@@ -1471,7 +1517,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a(c);
         \\}
     ,
-        ".tmp_source.zig:8:7: error: expected type 'fn(*const u8) void', found 'fn(u8) void'",
+        "tmp.zig:8:7: error: expected type 'fn(*const u8) void', found 'fn(u8) void'",
     );
 
     cases.add(
@@ -1485,7 +1531,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:5:5: error: else prong required when switching on type 'anyerror'",
+        "tmp.zig:5:5: error: else prong required when switching on type 'anyerror'",
     );
 
     cases.add(
@@ -1496,7 +1542,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn foo() !void {
         \\}
     ,
-        ".tmp_source.zig:4:11: error: function with inferred error set must return at least one possible error",
+        "tmp.zig:4:11: error: function with inferred error set must return at least one possible error",
     );
 
     cases.add(
@@ -1515,8 +1561,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:2:26: error: error.Baz not handled in switch",
-        ".tmp_source.zig:2:26: error: error.Bar not handled in switch",
+        "tmp.zig:2:26: error: error.Baz not handled in switch",
+        "tmp.zig:2:26: error: error.Bar not handled in switch",
     );
 
     cases.add(
@@ -1537,8 +1583,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:5:14: error: duplicate switch value: '@typeOf(foo).ReturnType.ErrorSet.Foo'",
-        ".tmp_source.zig:3:14: note: other value is here",
+        "tmp.zig:5:14: error: duplicate switch value: '@typeOf(foo).ReturnType.ErrorSet.Foo'",
+        "tmp.zig:3:14: note: other value is here",
     );
 
     cases.add("invalid cast from integral type to enum",
@@ -1553,7 +1599,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\        E.One => {},
         \\    }
         \\}
-    , ".tmp_source.zig:9:10: error: expected type 'usize', found 'E'");
+    , "tmp.zig:9:10: error: expected type 'usize', found 'E'");
 
     cases.add(
         "range operator in switch used on error set",
@@ -1571,7 +1617,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:3:17: error: operator not allowed for errors",
+        "tmp.zig:3:17: error: operator not allowed for errors",
     );
 
     cases.add(
@@ -1580,7 +1626,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const z: ?fn()!void = null;
         \\}
     ,
-        ".tmp_source.zig:2:15: error: inferring error set of return type valid only for function definitions",
+        "tmp.zig:2:15: error: inferring error set of return type valid only for function definitions",
     );
 
     cases.add(
@@ -1590,7 +1636,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const z = Foo.Bar;
         \\}
     ,
-        ".tmp_source.zig:3:18: error: no error named 'Bar' in 'Foo'",
+        "tmp.zig:3:18: error: no error named 'Bar' in 'Foo'",
     );
 
     cases.add(
@@ -1599,7 +1645,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const z = i32!i32;
         \\}
     ,
-        ".tmp_source.zig:2:15: error: expected error set type, found type 'i32'",
+        "tmp.zig:2:15: error: expected error set type, found type 'i32'",
     );
 
     cases.add(
@@ -1615,7 +1661,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:7:11: error: error sets 'Set1' and 'Set2' have no common errors",
+        "tmp.zig:7:11: error: error sets 'Set1' and 'Set2' have no common errors",
     );
 
     cases.add(
@@ -1624,7 +1670,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const z = error.A > error.B;
         \\}
     ,
-        ".tmp_source.zig:2:23: error: operator not allowed for errors",
+        "tmp.zig:2:23: error: operator not allowed for errors",
     );
 
     cases.add(
@@ -1636,7 +1682,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var y = @errSetCast(Set2, x);
         \\}
     ,
-        ".tmp_source.zig:5:13: error: error.B not a member of error set 'Set2'",
+        "tmp.zig:5:13: error: error.B not a member of error set 'Set2'",
     );
 
     cases.add(
@@ -1649,9 +1695,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return error.B;
         \\}
     ,
-        ".tmp_source.zig:3:35: error: expected type 'SmallErrorSet!i32', found 'anyerror!i32'",
-        ".tmp_source.zig:3:35: note: error set 'anyerror' cannot cast into error set 'SmallErrorSet'",
-        ".tmp_source.zig:3:35: note: cannot cast global error set into smaller set",
+        "tmp.zig:3:35: error: expected type 'SmallErrorSet!i32', found 'anyerror!i32'",
+        "tmp.zig:3:35: note: error set 'anyerror' cannot cast into error set 'SmallErrorSet'",
+        "tmp.zig:3:35: note: cannot cast global error set into smaller set",
     );
 
     cases.add(
@@ -1664,10 +1710,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return error.B;
         \\}
     ,
-        ".tmp_source.zig:3:31: error: expected type 'SmallErrorSet', found 'anyerror'",
-        ".tmp_source.zig:3:31: note: cannot cast global error set into smaller set",
+        "tmp.zig:3:31: error: expected type 'SmallErrorSet', found 'anyerror'",
+        "tmp.zig:3:31: note: cannot cast global error set into smaller set",
     );
-
     cases.add(
         "recursive inferred error set",
         \\export fn entry() void {
@@ -1677,7 +1722,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    try foo();
         \\}
     ,
-        ".tmp_source.zig:5:5: error: cannot resolve inferred error set '@typeOf(foo).ReturnType.ErrorSet': function 'foo' not fully analyzed yet",
+        "tmp.zig:5:5: error: cannot resolve inferred error set '@typeOf(foo).ReturnType.ErrorSet': function 'foo' not fully analyzed yet",
     );
 
     cases.add(
@@ -1691,8 +1736,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x: Set2 = set1;
         \\}
     ,
-        ".tmp_source.zig:7:19: error: expected type 'Set2', found 'Set1'",
-        ".tmp_source.zig:1:23: note: 'error.B' not a member of destination error set",
+        "tmp.zig:7:19: error: expected type 'Set2', found 'Set1'",
+        "tmp.zig:1:23: note: 'error.B' not a member of destination error set",
     );
 
     cases.add(
@@ -1706,7 +1751,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var y = @intToError(x);
         \\}
     ,
-        ".tmp_source.zig:7:13: error: integer value 3 represents no error",
+        "tmp.zig:7:13: error: integer value 3 represents no error",
     );
 
     cases.add(
@@ -1724,7 +1769,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var y = @errSetCast(Set2, @intToError(x));
         \\}
     ,
-        ".tmp_source.zig:11:13: error: error.B not a member of error set 'Set2'",
+        "tmp.zig:11:13: error: error.B not a member of error set 'Set2'",
     );
 
     cases.add(
@@ -1733,7 +1778,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @memberCount(anyerror);
         \\}
     ,
-        ".tmp_source.zig:2:9: error: global error set member count not available at comptime",
+        "tmp.zig:2:9: error: global error set member count not available at comptime",
     );
 
     cases.add(
@@ -1746,8 +1791,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a: Foo = undefined;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: duplicate error: 'Bar'",
-        ".tmp_source.zig:2:5: note: other error here",
+        "tmp.zig:3:5: error: duplicate error: 'Bar'",
+        "tmp.zig:2:5: note: other error here",
     );
 
     cases.add(
@@ -1756,7 +1801,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = usize(-10);
         \\}
     ,
-        ".tmp_source.zig:2:21: error: cannot cast negative value -10 to unsigned integer type 'usize'",
+        "tmp.zig:2:21: error: cannot cast negative value -10 to unsigned integer type 'usize'",
     );
 
     cases.add(
@@ -1766,7 +1811,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var arr: [v]u8 = undefined;
         \\}
     ,
-        ".tmp_source.zig:1:1: error: unable to infer variable type",
+        "tmp.zig:1:1: error: unable to infer variable type",
     );
 
     cases.add(
@@ -1779,8 +1824,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a: Foo = undefined;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: duplicate struct field: 'Bar'",
-        ".tmp_source.zig:2:5: note: other field here",
+        "tmp.zig:3:5: error: duplicate struct field: 'Bar'",
+        "tmp.zig:2:5: note: other field here",
     );
 
     cases.add(
@@ -1793,8 +1838,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a: Foo = undefined;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: duplicate union field: 'Bar'",
-        ".tmp_source.zig:2:5: note: other field here",
+        "tmp.zig:3:5: error: duplicate union field: 'Bar'",
+        "tmp.zig:2:5: note: other field here",
     );
 
     cases.add(
@@ -1808,8 +1853,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a: Foo = undefined;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: duplicate enum field: 'Bar'",
-        ".tmp_source.zig:2:5: note: other field here",
+        "tmp.zig:3:5: error: duplicate enum field: 'Bar'",
+        "tmp.zig:2:5: note: other field here",
     );
 
     cases.add(
@@ -1819,15 +1864,15 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\nakedcc fn foo() void { }
     ,
-        ".tmp_source.zig:2:5: error: unable to call function with naked calling convention",
-        ".tmp_source.zig:4:1: note: declared here",
+        "tmp.zig:2:5: error: unable to call function with naked calling convention",
+        "tmp.zig:4:1: note: declared here",
     );
 
     cases.add(
         "function with invalid return type",
         \\export fn foo() boid {}
     ,
-        ".tmp_source.zig:1:17: error: use of undeclared identifier 'boid'",
+        "tmp.zig:1:17: error: use of undeclared identifier 'boid'",
     );
 
     cases.add(
@@ -1835,7 +1880,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const Foo = enum { A, B, C };
         \\export fn entry(foo: Foo) void { }
     ,
-        ".tmp_source.zig:2:22: error: parameter of type 'Foo' not allowed in function with calling convention 'ccc'",
+        "tmp.zig:2:22: error: parameter of type 'Foo' not allowed in function with calling convention 'ccc'",
     );
 
     cases.add(
@@ -1847,7 +1892,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\};
         \\export fn entry(foo: Foo) void { }
     ,
-        ".tmp_source.zig:6:22: error: parameter of type 'Foo' not allowed in function with calling convention 'ccc'",
+        "tmp.zig:6:22: error: parameter of type 'Foo' not allowed in function with calling convention 'ccc'",
     );
 
     cases.add(
@@ -1859,7 +1904,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\};
         \\export fn entry(foo: Foo) void { }
     ,
-        ".tmp_source.zig:6:22: error: parameter of type 'Foo' not allowed in function with calling convention 'ccc'",
+        "tmp.zig:6:22: error: parameter of type 'Foo' not allowed in function with calling convention 'ccc'",
     );
 
     cases.add(
@@ -1871,7 +1916,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    switch (f) {}
         \\}
     ,
-        ".tmp_source.zig:5:5: error: enumeration value 'Foo.M' not handled in switch",
+        "tmp.zig:5:5: error: enumeration value 'Foo.M' not handled in switch",
     );
 
     cases.add(
@@ -1880,7 +1925,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var a = 1 >> -1;
         \\}
     ,
-        ".tmp_source.zig:2:18: error: shift by negative value -1",
+        "tmp.zig:2:18: error: shift by negative value -1",
     );
 
     cases.add(
@@ -1891,7 +1936,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:3:9: error: encountered @panic at compile-time",
+        "tmp.zig:3:9: error: encountered @panic at compile-time",
     );
 
     cases.add(
@@ -1921,7 +1966,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    bogus;
         \\}
     ,
-        ".tmp_source.zig:8:5: error: use of undeclared identifier 'bogus'",
+        "tmp.zig:8:5: error: use of undeclared identifier 'bogus'",
     );
 
     cases.add(
@@ -1934,7 +1979,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:4:13: error: label not found: 'outer'",
+        "tmp.zig:4:13: error: label not found: 'outer'",
     );
 
     cases.add(
@@ -1948,7 +1993,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:5:13: error: labeled loop not found: 'outer'",
+        "tmp.zig:5:13: error: labeled loop not found: 'outer'",
     );
 
     cases.add(
@@ -1961,8 +2006,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\extern fn bar(x: *void) void { }
     ,
-        ".tmp_source.zig:1:30: error: parameter of type '*void' has 0 bits; not allowed in function with calling convention 'ccc'",
-        ".tmp_source.zig:7:18: error: parameter of type '*void' has 0 bits; not allowed in function with calling convention 'ccc'",
+        "tmp.zig:1:30: error: parameter of type '*void' has 0 bits; not allowed in function with calling convention 'ccc'",
+        "tmp.zig:7:18: error: parameter of type '*void' has 0 bits; not allowed in function with calling convention 'ccc'",
     );
 
     cases.add(
@@ -1974,7 +2019,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -1986,7 +2031,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -1998,7 +2043,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2010,7 +2055,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2022,7 +2067,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2034,7 +2079,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2046,7 +2091,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2058,7 +2103,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2070,7 +2115,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2082,7 +2127,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2094,7 +2139,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2106,7 +2151,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2118,7 +2163,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2130,7 +2175,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2142,7 +2187,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2154,7 +2199,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2166,7 +2211,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2178,7 +2223,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2190,7 +2235,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2202,7 +2247,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2214,7 +2259,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var bad = {};
         \\}
     ,
-        ".tmp_source.zig:5:5: error: expected token ';', found 'var'",
+        "tmp.zig:5:5: error: expected token ';', found 'var'",
     );
 
     cases.add(
@@ -2223,7 +2268,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn a() void {}
         \\export fn entry() void { a(); }
     ,
-        ".tmp_source.zig:2:1: error: redefinition of 'a'",
+        "tmp.zig:2:1: error: redefinition of 'a'",
     );
 
     cases.add(
@@ -2231,7 +2276,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn a() noreturn {return;}
         \\export fn entry() void { a(); }
     ,
-        ".tmp_source.zig:1:18: error: expected type 'noreturn', found 'void'",
+        "tmp.zig:1:18: error: expected type 'noreturn', found 'void'",
     );
 
     cases.add(
@@ -2239,7 +2284,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn a() i32 {}
         \\export fn entry() void { _ = a(); }
     ,
-        ".tmp_source.zig:1:12: error: expected type 'i32', found 'void'",
+        "tmp.zig:1:12: error: expected type 'i32', found 'void'",
     );
 
     cases.add(
@@ -2248,7 +2293,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    b();
         \\}
     ,
-        ".tmp_source.zig:2:5: error: use of undeclared identifier 'b'",
+        "tmp.zig:2:5: error: use of undeclared identifier 'b'",
     );
 
     cases.add(
@@ -2258,7 +2303,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn b(a: i32, b: i32, c: i32) void { }
     ,
-        ".tmp_source.zig:2:6: error: expected 3 arguments, found 1",
+        "tmp.zig:2:6: error: expected 3 arguments, found 1",
     );
 
     cases.add(
@@ -2266,7 +2311,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn a() bogus {}
         \\export fn entry() void { _ = a(); }
     ,
-        ".tmp_source.zig:1:8: error: use of undeclared identifier 'bogus'",
+        "tmp.zig:1:8: error: use of undeclared identifier 'bogus'",
     );
 
     cases.add(
@@ -2274,7 +2319,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn a() *noreturn {}
         \\export fn entry() void { _ = a(); }
     ,
-        ".tmp_source.zig:1:8: error: pointer to noreturn not allowed",
+        "tmp.zig:1:8: error: pointer to noreturn not allowed",
     );
 
     cases.add(
@@ -2286,7 +2331,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\fn b() void {}
     ,
-        ".tmp_source.zig:3:5: error: unreachable code",
+        "tmp.zig:3:5: error: unreachable code",
     );
 
     cases.add(
@@ -2294,7 +2339,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const bogus = @import("bogus-does-not-exist.zig",);
         \\export fn entry() void { bogus.bogo(); }
     ,
-        ".tmp_source.zig:1:15: error: unable to find 'bogus-does-not-exist.zig'",
+        "tmp.zig:1:15: error: unable to find 'bogus-does-not-exist.zig'",
     );
 
     cases.add(
@@ -2305,8 +2350,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    c;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undeclared identifier 'b'",
-        ".tmp_source.zig:4:5: error: use of undeclared identifier 'c'",
+        "tmp.zig:3:5: error: use of undeclared identifier 'b'",
+        "tmp.zig:4:5: error: use of undeclared identifier 'c'",
     );
 
     cases.add(
@@ -2315,7 +2360,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() void { f(1, 2); }
     ,
-        ".tmp_source.zig:1:15: error: redeclaration of variable 'a'",
+        "tmp.zig:1:15: error: redeclaration of variable 'a'",
     );
 
     cases.add(
@@ -2325,7 +2370,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a = 0;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: redeclaration of variable 'a'",
+        "tmp.zig:3:5: error: redeclaration of variable 'a'",
     );
 
     cases.add(
@@ -2335,7 +2380,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() void { f(1); }
     ,
-        ".tmp_source.zig:2:5: error: redeclaration of variable 'a'",
+        "tmp.zig:2:5: error: redeclaration of variable 'a'",
     );
 
     cases.add(
@@ -2345,7 +2390,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return a;
         \\}
     ,
-        ".tmp_source.zig:3:12: error: expected type 'i32', found '[*]const u8'",
+        "tmp.zig:3:12: error: expected type 'i32', found '[*]const u8'",
     );
 
     cases.add(
@@ -2354,7 +2399,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    if (0) {}
         \\}
     ,
-        ".tmp_source.zig:2:9: error: expected type 'bool', found 'comptime_int'",
+        "tmp.zig:2:9: error: expected type 'bool', found 'comptime_int'",
     );
 
     cases.add(
@@ -2363,7 +2408,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a = return;
         \\}
     ,
-        ".tmp_source.zig:2:5: error: unreachable code",
+        "tmp.zig:2:5: error: unreachable code",
     );
 
     cases.add(
@@ -2372,7 +2417,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a: noreturn = {};
         \\}
     ,
-        ".tmp_source.zig:2:14: error: variable of type 'noreturn' not allowed",
+        "tmp.zig:2:14: error: variable of type 'noreturn' not allowed",
     );
 
     cases.add(
@@ -2380,7 +2425,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn f(a: noreturn) void {}
         \\export fn entry() void { f(); }
     ,
-        ".tmp_source.zig:1:9: error: parameter of type 'noreturn' not allowed",
+        "tmp.zig:1:9: error: parameter of type 'noreturn' not allowed",
     );
 
     cases.add(
@@ -2389,7 +2434,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    3 = 3;
         \\}
     ,
-        ".tmp_source.zig:2:7: error: cannot assign to constant",
+        "tmp.zig:2:7: error: cannot assign to constant",
     );
 
     cases.add(
@@ -2399,7 +2444,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a = 4;
         \\}
     ,
-        ".tmp_source.zig:3:7: error: cannot assign to constant",
+        "tmp.zig:3:7: error: cannot assign to constant",
     );
 
     cases.add(
@@ -2408,7 +2453,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    b = 3;
         \\}
     ,
-        ".tmp_source.zig:2:5: error: use of undeclared identifier 'b'",
+        "tmp.zig:2:5: error: use of undeclared identifier 'b'",
     );
 
     cases.add(
@@ -2417,7 +2462,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    (const a = 0);
         \\}
     ,
-        ".tmp_source.zig:2:6: error: invalid token: 'const'",
+        "tmp.zig:2:6: error: invalid token: 'const'",
     );
 
     cases.add(
@@ -2426,7 +2471,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    i[i] = i[i];
         \\}
     ,
-        ".tmp_source.zig:2:5: error: use of undeclared identifier 'i'",
+        "tmp.zig:2:5: error: use of undeclared identifier 'i'",
     );
 
     cases.add(
@@ -2436,8 +2481,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    bad[bad] = bad[bad];
         \\}
     ,
-        ".tmp_source.zig:3:8: error: array access of non-array type 'bool'",
-        ".tmp_source.zig:3:19: error: array access of non-array type 'bool'",
+        "tmp.zig:3:8: error: array access of non-array type 'bool'",
+        "tmp.zig:3:19: error: array access of non-array type 'bool'",
     );
 
     cases.add(
@@ -2448,8 +2493,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    array[bad] = array[bad];
         \\}
     ,
-        ".tmp_source.zig:4:11: error: expected type 'usize', found 'bool'",
-        ".tmp_source.zig:4:24: error: expected type 'usize', found 'bool'",
+        "tmp.zig:4:11: error: expected type 'usize', found 'bool'",
+        "tmp.zig:4:24: error: expected type 'usize', found 'bool'",
     );
 
     cases.add(
@@ -2460,7 +2505,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() void { f(); }
     ,
-        ".tmp_source.zig:3:7: error: cannot assign to constant",
+        "tmp.zig:3:7: error: cannot assign to constant",
     );
 
     cases.add(
@@ -2471,26 +2516,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() void { f(true); }
     ,
-        ".tmp_source.zig:2:42: error: integer value 1 cannot be implicitly casted to type 'void'",
-        ".tmp_source.zig:3:15: error: incompatible types: 'i32' and 'void'",
-    );
-
-    cases.add(
-        "direct struct loop",
-        \\const A = struct { a : A, };
-        \\export fn entry() usize { return @sizeOf(A); }
-    ,
-        ".tmp_source.zig:1:11: error: struct 'A' contains itself",
-    );
-
-    cases.add(
-        "indirect struct loop",
-        \\const A = struct { b : B, };
-        \\const B = struct { c : C, };
-        \\const C = struct { a : A, };
-        \\export fn entry() usize { return @sizeOf(A); }
-    ,
-        ".tmp_source.zig:1:11: error: struct 'A' contains itself",
+        "tmp.zig:2:42: error: integer value 1 cannot be implicitly casted to type 'void'",
+        "tmp.zig:3:15: error: incompatible types: 'i32' and 'void'",
     );
 
     cases.add(
@@ -2502,8 +2529,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const y = a.bar;
         \\}
     ,
-        ".tmp_source.zig:4:6: error: no member named 'foo' in struct 'A'",
-        ".tmp_source.zig:5:16: error: no member named 'bar' in struct 'A'",
+        "tmp.zig:4:6: error: no member named 'foo' in struct 'A'",
+        "tmp.zig:5:16: error: no member named 'bar' in struct 'A'",
     );
 
     cases.add(
@@ -2511,7 +2538,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const A = struct { x : i32, };
         \\const A = struct { y : i32, };
     ,
-        ".tmp_source.zig:2:1: error: redefinition of 'A'",
+        "tmp.zig:2:1: error: redefinition of 'A'",
     );
 
     cases.add(
@@ -2519,7 +2546,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const A = enum {};
         \\const A = enum {};
     ,
-        ".tmp_source.zig:2:1: error: redefinition of 'A'",
+        "tmp.zig:2:1: error: redefinition of 'A'",
     );
 
     cases.add(
@@ -2527,8 +2554,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\var a : i32 = 1;
         \\var a : i32 = 2;
     ,
-        ".tmp_source.zig:2:1: error: redefinition of 'a'",
-        ".tmp_source.zig:1:1: note: previous definition is here",
+        "tmp.zig:2:1: error: redefinition of 'a'",
+        "tmp.zig:1:1: note: previous definition is here",
     );
 
     cases.add(
@@ -2547,7 +2574,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    };
         \\}
     ,
-        ".tmp_source.zig:11:9: error: duplicate field",
+        "tmp.zig:11:9: error: duplicate field",
     );
 
     cases.add(
@@ -2566,7 +2593,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    };
         \\}
     ,
-        ".tmp_source.zig:9:17: error: missing field: 'x'",
+        "tmp.zig:9:17: error: missing field: 'x'",
     );
 
     cases.add(
@@ -2584,7 +2611,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    };
         \\}
     ,
-        ".tmp_source.zig:10:9: error: no member named 'foo' in struct 'A'",
+        "tmp.zig:10:9: error: no member named 'foo' in struct 'A'",
     );
 
     cases.add(
@@ -2593,7 +2620,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    break;
         \\}
     ,
-        ".tmp_source.zig:2:5: error: break expression outside loop",
+        "tmp.zig:2:5: error: break expression outside loop",
     );
 
     cases.add(
@@ -2602,7 +2629,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    continue;
         \\}
     ,
-        ".tmp_source.zig:2:5: error: continue expression outside loop",
+        "tmp.zig:2:5: error: continue expression outside loop",
     );
 
     cases.add(
@@ -2611,7 +2638,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    if (true) |x| { }
         \\}
     ,
-        ".tmp_source.zig:2:9: error: expected optional type, found 'bool'",
+        "tmp.zig:2:9: error: expected optional type, found 'bool'",
     );
 
     cases.add(
@@ -2621,7 +2648,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() void { _ = f(); }
     ,
-        ".tmp_source.zig:2:15: error: unreachable code",
+        "tmp.zig:2:15: error: unreachable code",
     );
 
     cases.add(
@@ -2630,7 +2657,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() void { _ = f(); }
     ,
-        ".tmp_source.zig:1:8: error: invalid builtin function: 'bogus'",
+        "tmp.zig:1:8: error: invalid builtin function: 'bogus'",
     );
 
     cases.add(
@@ -2638,7 +2665,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn f(noalias x: i32) void {}
         \\export fn entry() void { f(1234); }
     ,
-        ".tmp_source.zig:1:6: error: noalias on non-pointer parameter",
+        "tmp.zig:1:6: error: noalias on non-pointer parameter",
     );
 
     cases.add(
@@ -2646,7 +2673,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const foo = []u16{.x = 1024,};
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:1:18: error: type '[]u16' does not support struct initialization syntax",
+        "tmp.zig:1:18: error: type '[]u16' does not support struct initialization syntax",
     );
 
     cases.add(
@@ -2656,7 +2683,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return 1;
         \\}
     ,
-        ".tmp_source.zig:1:1: error: variable of type 'type' must be constant",
+        "tmp.zig:1:1: error: variable of type 'type' must be constant",
     );
 
     cases.add(
@@ -2672,10 +2699,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    f(1234);
         \\}
     ,
-        ".tmp_source.zig:4:6: error: redefinition of 'Foo'",
-        ".tmp_source.zig:1:1: note: previous definition is here",
-        ".tmp_source.zig:5:5: error: redefinition of 'Bar'",
-        ".tmp_source.zig:2:1: note: previous definition is here",
+        "tmp.zig:4:6: error: redefinition of 'Foo'",
+        "tmp.zig:1:1: note: previous definition is here",
+        "tmp.zig:5:5: error: redefinition of 'Bar'",
+        "tmp.zig:2:1: note: previous definition is here",
     );
 
     cases.add(
@@ -2696,7 +2723,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(f)); }
     ,
-        ".tmp_source.zig:8:5: error: enumeration value 'Number.Four' not handled in switch",
+        "tmp.zig:8:5: error: enumeration value 'Number.Four' not handled in switch",
     );
 
     cases.add(
@@ -2719,8 +2746,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(f)); }
     ,
-        ".tmp_source.zig:13:15: error: duplicate switch value",
-        ".tmp_source.zig:10:15: note: other value is here",
+        "tmp.zig:13:15: error: duplicate switch value",
+        "tmp.zig:10:15: note: other value is here",
     );
 
     cases.add(
@@ -2744,8 +2771,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(f)); }
     ,
-        ".tmp_source.zig:13:15: error: duplicate switch value",
-        ".tmp_source.zig:10:15: note: other value is here",
+        "tmp.zig:13:15: error: duplicate switch value",
+        "tmp.zig:10:15: note: other value is here",
     );
 
     cases.add(
@@ -2761,7 +2788,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    f(1234);
         \\}
     ,
-        ".tmp_source.zig:5:9: error: multiple else prongs in switch expression",
+        "tmp.zig:5:9: error: multiple else prongs in switch expression",
     );
 
     cases.add(
@@ -2773,7 +2800,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:2:5: error: switch must handle all possibilities",
+        "tmp.zig:2:5: error: switch must handle all possibilities",
     );
 
     cases.add(
@@ -2788,8 +2815,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:6:9: error: duplicate switch value",
-        ".tmp_source.zig:5:14: note: previous value is here",
+        "tmp.zig:6:9: error: duplicate switch value",
+        "tmp.zig:5:14: note: previous value is here",
     );
 
     cases.add(
@@ -2802,7 +2829,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const y: u8 = 100;
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:2:5: error: else prong required when switching on type '*u8'",
+        "tmp.zig:2:5: error: else prong required when switching on type '*u8'",
     );
 
     cases.add(
@@ -2811,7 +2838,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const x = foo();
         \\export fn entry() i32 { return x; }
     ,
-        ".tmp_source.zig:2:11: error: unable to evaluate constant expression",
+        "tmp.zig:2:11: error: unable to evaluate constant expression",
     );
 
     cases.add(
@@ -2822,7 +2849,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(a)); }
     ,
-        ".tmp_source.zig:3:11: error: expected array or C string literal, found 'usize'",
+        "tmp.zig:3:11: error: expected array or C string literal, found 'usize'",
     );
 
     cases.add(
@@ -2833,7 +2860,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\var s: [10]u8 = undefined;
         \\export fn entry() usize { return @sizeOf(@typeOf(f)); }
     ,
-        ".tmp_source.zig:2:12: error: unable to evaluate constant expression",
+        "tmp.zig:2:12: error: unable to evaluate constant expression",
     );
 
     cases.add(
@@ -2841,7 +2868,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const c = @cImport(@cInclude("bogus.h"));
         \\export fn entry() usize { return @sizeOf(@typeOf(c.bogo)); }
     ,
-        ".tmp_source.zig:1:11: error: C import failed",
+        "tmp.zig:1:11: error: C import failed",
         ".h:1:10: note: 'bogus.h' file not found",
     );
 
@@ -2852,7 +2879,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn foo() *const i32 { return y; }
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:3:30: error: expected type '*const i32', found '*const comptime_int'",
+        "tmp.zig:3:30: error: expected type '*const i32', found '*const comptime_int'",
     );
 
     cases.add(
@@ -2860,7 +2887,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const x : u8 = 300;
         \\export fn entry() usize { return @sizeOf(@typeOf(x)); }
     ,
-        ".tmp_source.zig:1:16: error: integer value 300 cannot be implicitly casted to type 'u8'",
+        "tmp.zig:1:16: error: integer value 300 cannot be implicitly casted to type 'u8'",
     );
 
     cases.add(
@@ -2871,8 +2898,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() u16 { return f(); }
     ,
-        ".tmp_source.zig:3:14: error: RHS of shift is too large for LHS type",
-        ".tmp_source.zig:3:17: note: value 8 cannot fit into type u3",
+        "tmp.zig:3:14: error: RHS of shift is too large for LHS type",
+        "tmp.zig:3:17: note: value 8 cannot fit into type u3",
     );
 
     cases.add(
@@ -2880,7 +2907,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const x = 2 == 2.0;
         \\export fn entry() usize { return @sizeOf(@typeOf(x)); }
     ,
-        ".tmp_source.zig:1:11: error: integer value 2 cannot be implicitly casted to type 'comptime_float'",
+        "tmp.zig:1:11: error: integer value 2 cannot be implicitly casted to type 'comptime_float'",
     );
 
     cases.add(
@@ -2909,7 +2936,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(f)); }
     ,
-        ".tmp_source.zig:20:34: error: expected 1 arguments, found 0",
+        "tmp.zig:20:34: error: expected 1 arguments, found 0",
     );
 
     cases.add(
@@ -2918,8 +2945,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn f(i32) void {}
         \\export fn entry() usize { return @sizeOf(@typeOf(f)); }
     ,
-        ".tmp_source.zig:1:1: error: missing function name",
-        ".tmp_source.zig:2:6: error: missing parameter name",
+        "tmp.zig:1:1: error: missing function name",
+        "tmp.zig:2:6: error: missing parameter name",
     );
 
     cases.add(
@@ -2930,7 +2957,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn c() i32 {return 2;}
         \\export fn entry() usize { return @sizeOf(@typeOf(fns)); }
     ,
-        ".tmp_source.zig:1:27: error: expected type 'fn() void', found 'fn() i32'",
+        "tmp.zig:1:27: error: expected type 'fn() void', found 'fn() i32'",
     );
 
     cases.add(
@@ -2942,7 +2969,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(fns)); }
     ,
-        ".tmp_source.zig:1:36: error: expected type 'fn(i32) i32', found 'extern fn(i32) i32'",
+        "tmp.zig:1:36: error: expected type 'fn(i32) i32', found 'extern fn(i32) i32'",
     );
 
     cases.add(
@@ -2951,16 +2978,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn func() bogus {}
         \\export fn entry() usize { return @sizeOf(@typeOf(func)); }
     ,
-        ".tmp_source.zig:2:1: error: redefinition of 'func'",
-        ".tmp_source.zig:1:11: error: use of undeclared identifier 'bogus'",
-    );
-
-    cases.add(
-        "bogus compile var",
-        \\const x = @import("builtin").bogus;
-        \\export fn entry() usize { return @sizeOf(@typeOf(x)); }
-    ,
-        ".tmp_source.zig:1:29: error: no member named 'bogus' in '",
+        "tmp.zig:2:1: error: redefinition of 'func'",
+        "tmp.zig:1:11: error: use of undeclared identifier 'bogus'",
     );
 
     cases.add(
@@ -2973,9 +2992,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(Foo)); }
     ,
-        ".tmp_source.zig:5:25: error: unable to evaluate constant expression",
-        ".tmp_source.zig:2:12: note: called from here",
-        ".tmp_source.zig:2:8: note: called from here",
+        "tmp.zig:5:25: error: unable to evaluate constant expression",
+        "tmp.zig:2:12: note: called from here",
+        "tmp.zig:2:8: note: called from here",
     );
 
     cases.add(
@@ -2987,7 +3006,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(x)); }
     ,
-        ".tmp_source.zig:4:28: error: invalid operands to binary expression: 'Foo' and 'Foo'",
+        "tmp.zig:4:28: error: invalid operands to binary expression: 'Foo' and 'Foo'",
     );
 
     cases.add(
@@ -3002,10 +3021,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\export fn entry3() usize { return @sizeOf(@typeOf(int_x)); }
         \\export fn entry4() usize { return @sizeOf(@typeOf(float_x)); }
     ,
-        ".tmp_source.zig:1:21: error: division by zero",
-        ".tmp_source.zig:2:25: error: division by zero",
-        ".tmp_source.zig:3:22: error: division by zero",
-        ".tmp_source.zig:4:26: error: division by zero",
+        "tmp.zig:1:21: error: division by zero",
+        "tmp.zig:2:25: error: division by zero",
+        "tmp.zig:3:22: error: division by zero",
+        "tmp.zig:4:26: error: division by zero",
     );
 
     cases.add(
@@ -3015,7 +3034,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:1:15: error: newline not allowed in string literal",
+        "tmp.zig:1:15: error: newline not allowed in string literal",
     );
 
     cases.add(
@@ -3025,7 +3044,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(invalid)); }
     ,
-        ".tmp_source.zig:2:21: error: operator not allowed for type 'fn() void'",
+        "tmp.zig:2:21: error: operator not allowed for type 'fn() void'",
     );
 
     cases.add(
@@ -3037,7 +3056,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(test1)); }
     ,
-        ".tmp_source.zig:3:16: error: unable to evaluate constant expression",
+        "tmp.zig:3:16: error: unable to evaluate constant expression",
     );
 
     cases.add(
@@ -3046,7 +3065,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(a)); }
     ,
-        ".tmp_source.zig:1:16: error: expected type '*u8', found '(null)'",
+        "tmp.zig:1:16: error: expected type '*u8', found '(null)'",
     );
 
     cases.add(
@@ -3056,7 +3075,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const pointer = &array[0];
         \\}
     ,
-        ".tmp_source.zig:3:27: error: index 0 outside array of size 0",
+        "tmp.zig:3:27: error: index 0 outside array of size 0",
     );
 
     cases.add(
@@ -3068,8 +3087,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(y)); }
     ,
-        ".tmp_source.zig:3:14: error: division by zero",
-        ".tmp_source.zig:1:14: note: called from here",
+        "tmp.zig:3:14: error: division by zero",
+        "tmp.zig:1:14: note: called from here",
     );
 
     cases.add(
@@ -3078,7 +3097,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(x)); }
     ,
-        ".tmp_source.zig:1:15: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:1:15: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3088,7 +3107,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a / a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3098,7 +3117,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a /= a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3108,7 +3127,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a % a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3118,7 +3137,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a %= a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3128,7 +3147,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a + a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3138,7 +3157,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a += a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3148,7 +3167,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a +% a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3158,7 +3177,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a +%= a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3168,7 +3187,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a - a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3178,7 +3197,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a -= a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3188,7 +3207,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a -% a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3198,7 +3217,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a -%= a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3208,7 +3227,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a * a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3218,7 +3237,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a *= a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3228,7 +3247,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a *% a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3238,7 +3257,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a *%= a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3248,7 +3267,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a << 2;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3258,7 +3277,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a <<= 2;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3268,7 +3287,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a >> 2;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3278,7 +3297,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a >>= 2;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3288,7 +3307,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a & a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3298,7 +3317,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a &= a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3308,7 +3327,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a | a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3318,7 +3337,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a |= a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3328,7 +3347,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a ^ a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3338,7 +3357,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    a ^= a;
         \\}
     ,
-        ".tmp_source.zig:3:5: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:5: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3348,7 +3367,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a == a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3358,7 +3377,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a != a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3368,7 +3387,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a > a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3378,7 +3397,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a >= a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3388,7 +3407,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a < a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3398,7 +3417,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a <= a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3408,7 +3427,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a and a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3418,7 +3437,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a or a;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:9: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3428,7 +3447,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = -a;
         \\}
     ,
-        ".tmp_source.zig:3:10: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:10: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3438,7 +3457,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = -%a;
         \\}
     ,
-        ".tmp_source.zig:3:11: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:11: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3448,7 +3467,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = ~a;
         \\}
     ,
-        ".tmp_source.zig:3:10: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:10: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3458,7 +3477,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = !a;
         \\}
     ,
-        ".tmp_source.zig:3:10: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:10: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3468,7 +3487,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a orelse false;
         \\}
     ,
-        ".tmp_source.zig:3:11: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:11: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3478,7 +3497,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a catch |err| false;
         \\}
     ,
-        ".tmp_source.zig:3:11: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:3:11: error: use of undefined value here causes undefined behavior",
     );
 
     cases.add(
@@ -3488,7 +3507,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = a.*;
         \\}
     ,
-        ".tmp_source.zig:3:9: error: attempt to dereference undefined value",
+        "tmp.zig:3:9: error: attempt to dereference undefined value",
     );
 
     cases.add(
@@ -3500,8 +3519,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(seventh_fib_number)); }
     ,
-        ".tmp_source.zig:3:21: error: evaluation exceeded 1000 backwards branches",
-        ".tmp_source.zig:3:21: note: called from here",
+        "tmp.zig:3:21: error: evaluation exceeded 1000 backwards branches",
+        "tmp.zig:3:21: note: called from here",
     );
 
     cases.add(
@@ -3510,7 +3529,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(resource)); }
     ,
-        ".tmp_source.zig:1:29: error: unable to find '",
+        "tmp.zig:1:29: error: unable to find '",
         "bogus.txt'",
     );
 
@@ -3524,7 +3543,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(a)); }
     ,
-        ".tmp_source.zig:4:21: error: unable to evaluate constant expression",
+        "tmp.zig:4:21: error: unable to evaluate constant expression",
     );
 
     cases.add(
@@ -3541,8 +3560,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(a)); }
     ,
-        ".tmp_source.zig:6:24: error: unable to evaluate constant expression",
-        ".tmp_source.zig:4:17: note: called from here",
+        "tmp.zig:6:24: error: unable to evaluate constant expression",
+        "tmp.zig:4:17: note: called from here",
     );
 
     cases.add(
@@ -3554,7 +3573,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    bad_fn_call();
         \\}
     ,
-        ".tmp_source.zig:5:5: error: use of undeclared identifier 'bad_fn_call'",
+        "tmp.zig:5:5: error: use of undeclared identifier 'bad_fn_call'",
     );
 
     cases.add(
@@ -3573,8 +3592,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\export fn entry1() usize { return @sizeOf(@typeOf(bad_eql_1)); }
         \\export fn entry2() usize { return @sizeOf(@typeOf(bad_eql_2)); }
     ,
-        ".tmp_source.zig:2:14: error: operator not allowed for type '[]u8'",
-        ".tmp_source.zig:9:16: error: operator not allowed for type 'EnumWithData'",
+        "tmp.zig:2:14: error: operator not allowed for type '[]u8'",
+        "tmp.zig:9:16: error: operator not allowed for type 'EnumWithData'",
     );
 
     cases.add(
@@ -3590,7 +3609,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return 2;
         \\}
     ,
-        ".tmp_source.zig:2:15: error: values of type 'comptime_int' must be comptime known",
+        "tmp.zig:2:15: error: values of type 'comptime_int' must be comptime known",
     );
 
     cases.add(
@@ -3601,7 +3620,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    while (!@cmpxchgWeak(i32, &x, 1234, 5678, AtomicOrder.Monotonic, AtomicOrder.SeqCst)) {}
         \\}
     ,
-        ".tmp_source.zig:4:81: error: failure atomic ordering must be no stricter than success",
+        "tmp.zig:4:81: error: failure atomic ordering must be no stricter than success",
     );
 
     cases.add(
@@ -3612,7 +3631,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    while (!@cmpxchgWeak(i32, &x, 1234, 5678, AtomicOrder.Unordered, AtomicOrder.Unordered)) {}
         \\}
     ,
-        ".tmp_source.zig:4:58: error: success atomic ordering must be Monotonic or stricter",
+        "tmp.zig:4:58: error: success atomic ordering must be Monotonic or stricter",
     );
 
     cases.add(
@@ -3624,8 +3643,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(y)); }
     ,
-        ".tmp_source.zig:3:12: error: negation caused overflow",
-        ".tmp_source.zig:1:14: note: called from here",
+        "tmp.zig:3:12: error: negation caused overflow",
+        "tmp.zig:1:14: note: called from here",
     );
 
     cases.add(
@@ -3637,8 +3656,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(y)); }
     ,
-        ".tmp_source.zig:3:14: error: operation caused overflow",
-        ".tmp_source.zig:1:14: note: called from here",
+        "tmp.zig:3:14: error: operation caused overflow",
+        "tmp.zig:1:14: note: called from here",
     );
 
     cases.add(
@@ -3650,8 +3669,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(y)); }
     ,
-        ".tmp_source.zig:3:14: error: operation caused overflow",
-        ".tmp_source.zig:1:14: note: called from here",
+        "tmp.zig:3:14: error: operation caused overflow",
+        "tmp.zig:1:14: note: called from here",
     );
 
     cases.add(
@@ -3663,8 +3682,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(y)); }
     ,
-        ".tmp_source.zig:3:14: error: operation caused overflow",
-        ".tmp_source.zig:1:14: note: called from here",
+        "tmp.zig:3:14: error: operation caused overflow",
+        "tmp.zig:1:14: note: called from here",
     );
 
     cases.add(
@@ -3676,7 +3695,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(f)); }
     ,
-        ".tmp_source.zig:3:26: error: expected signed integer type, found 'u32'",
+        "tmp.zig:3:26: error: expected signed integer type, found 'u32'",
     );
 
     cases.add(
@@ -3686,8 +3705,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn something() anyerror!void { }
     ,
-        ".tmp_source.zig:2:5: error: expected type 'void', found 'anyerror'",
-        ".tmp_source.zig:1:15: note: return type declared here",
+        "tmp.zig:2:5: error: expected type 'void', found 'anyerror'",
+        "tmp.zig:1:15: note: return type declared here",
     );
 
     cases.add(
@@ -3700,7 +3719,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:2:13: error: unable to evaluate constant expression",
+        "tmp.zig:2:13: error: unable to evaluate constant expression",
     );
 
     cases.add(
@@ -3709,7 +3728,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return x + y;
         \\}
     ,
-        ".tmp_source.zig:1:15: error: comptime parameter not allowed in function with calling convention 'ccc'",
+        "tmp.zig:1:15: error: comptime parameter not allowed in function with calling convention 'ccc'",
     );
 
     cases.add(
@@ -3720,7 +3739,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() usize { return @sizeOf(@typeOf(f)); }
     ,
-        ".tmp_source.zig:1:15: error: comptime parameter not allowed in function with calling convention 'ccc'",
+        "tmp.zig:1:15: error: comptime parameter not allowed in function with calling convention 'ccc'",
     );
 
     cases.add(
@@ -3730,8 +3749,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var foo = @bytesToSlice(u32, array)[0];
         \\}
     ,
-        ".tmp_source.zig:3:15: error: unable to convert [5]u8 to []align(1) const u32: size mismatch",
-        ".tmp_source.zig:3:29: note: u32 has size 4; remaining bytes: 1",
+        "tmp.zig:3:15: error: unable to convert [5]u8 to []align(1) const u32: size mismatch",
+        "tmp.zig:3:29: note: u32 has size 4; remaining bytes: 1",
     );
 
     cases.add(
@@ -3755,8 +3774,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    list.length = 10;
         \\}
     ,
-        ".tmp_source.zig:3:7: error: unable to evaluate constant expression",
-        ".tmp_source.zig:16:19: note: called from here",
+        "tmp.zig:3:7: error: unable to evaluate constant expression",
+        "tmp.zig:16:19: note: called from here",
     );
 
     cases.add(
@@ -3767,7 +3786,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() usize { return @sizeOf(@typeOf(f)); }
     ,
-        ".tmp_source.zig:3:6: error: no member named 'copy' in '[]const u8'",
+        "tmp.zig:3:6: error: no member named 'copy' in '[]const u8'",
     );
 
     cases.add(
@@ -3781,7 +3800,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\export fn entry() usize { return @sizeOf(@typeOf(f)); }
     ,
-        ".tmp_source.zig:6:15: error: expected 2 arguments, found 3",
+        "tmp.zig:6:15: error: expected 2 arguments, found 3",
     );
 
     cases.add(
@@ -3791,7 +3810,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\  cstr[0] = 'W';
         \\}
     ,
-        ".tmp_source.zig:3:11: error: cannot assign to constant",
+        "tmp.zig:3:11: error: cannot assign to constant",
     );
 
     cases.add(
@@ -3801,14 +3820,14 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\  cstr[0] = 'W';
         \\}
     ,
-        ".tmp_source.zig:3:11: error: cannot assign to constant",
+        "tmp.zig:3:11: error: cannot assign to constant",
     );
 
     cases.add(
         "main function with bogus args type",
         \\pub fn main(args: [][]bogus) !void {}
     ,
-        ".tmp_source.zig:1:23: error: use of undeclared identifier 'bogus'",
+        "tmp.zig:1:23: error: use of undeclared identifier 'bogus'",
     );
 
     cases.add(
@@ -3844,7 +3863,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:5:16: error: use of undeclared identifier 'JsonList'",
+        "tmp.zig:5:16: error: use of undeclared identifier 'JsonList'",
     );
 
     cases.add(
@@ -3865,7 +3884,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    derp.init();
         \\}
     ,
-        ".tmp_source.zig:14:5: error: expected type 'i32', found 'Foo'",
+        "tmp.zig:14:5: error: expected type 'i32', found 'Foo'",
     );
 
     cases.add(
@@ -3895,7 +3914,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    x.init();
         \\}
     ,
-        ".tmp_source.zig:23:5: error: expected type '*Allocator', found '*List'",
+        "tmp.zig:23:5: error: expected type '*Allocator', found '*List'",
     );
 
     cases.add(
@@ -3906,7 +3925,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(block_aligned_stuff)); }
     ,
-        ".tmp_source.zig:3:60: error: unable to perform binary not operation on type 'comptime_int'",
+        "tmp.zig:3:60: error: unable to perform binary not operation on type 'comptime_int'",
     );
 
     cases.addCase(x: {
@@ -3918,7 +3937,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
             \\    foo.privateFunction();
             \\}
         ,
-            ".tmp_source.zig:4:8: error: 'privateFunction' is private",
+            "tmp.zig:4:8: error: 'privateFunction' is private",
             "foo.zig:1:1: note: declared here",
         );
 
@@ -3936,7 +3955,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(a)); }
     ,
-        ".tmp_source.zig:2:11: error: expected type 'type', found 'i32'",
+        "tmp.zig:2:11: error: expected type 'type', found 'i32'",
     );
 
     cases.add(
@@ -3949,7 +3968,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    f.field = 0;
         \\}
     ,
-        ".tmp_source.zig:6:13: error: cannot assign to constant",
+        "tmp.zig:6:13: error: cannot assign to constant",
     );
 
     cases.add(
@@ -3970,7 +3989,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(testTrickyDefer)); }
     ,
-        ".tmp_source.zig:4:11: error: cannot return from defer expression",
+        "tmp.zig:4:11: error: cannot return from defer expression",
     );
 
     cases.add(
@@ -3985,8 +4004,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:2:26: error: index 1 outside argument list of size 1",
-        ".tmp_source.zig:6:15: note: called from here",
+        "tmp.zig:2:26: error: index 1 outside argument list of size 1",
+        "tmp.zig:6:15: note: called from here",
     );
 
     cases.add(
@@ -4005,7 +4024,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(bar)); }
     ,
-        ".tmp_source.zig:10:16: error: compiler bug: integer and float literals in var args function must be casted",
+        "tmp.zig:10:16: error: compiler bug: integer and float literals in var args function must be casted",
     );
 
     cases.add(
@@ -4014,7 +4033,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var vga_mem: u16 = 0xB8000;
         \\}
     ,
-        ".tmp_source.zig:2:24: error: integer value 753664 cannot be implicitly casted to type 'u16'",
+        "tmp.zig:2:24: error: integer value 753664 cannot be implicitly casted to type 'u16'",
     );
 
     cases.add(
@@ -4022,7 +4041,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\const some_data: [100]u8 align(3) = undefined;
         \\export fn entry() usize { return @sizeOf(@typeOf(some_data)); }
     ,
-        ".tmp_source.zig:1:32: error: alignment value 3 is not a power of 2",
+        "tmp.zig:1:32: error: alignment value 3 is not a power of 2",
     );
 
     cases.add(
@@ -4030,7 +4049,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\extern fn foo() align(3) void;
         \\export fn entry() void { return foo(); }
     ,
-        ".tmp_source.zig:1:23: error: alignment value 3 is not a power of 2",
+        "tmp.zig:1:23: error: alignment value 3 is not a power of 2",
     );
 
     cases.add(
@@ -4044,9 +4063,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @compileLog("end",);
         \\}
     ,
-        ".tmp_source.zig:5:5: error: found compile log statement",
-        ".tmp_source.zig:6:5: error: found compile log statement",
-        ".tmp_source.zig:7:5: error: found compile log statement",
+        "tmp.zig:5:5: error: found compile log statement",
+        "tmp.zig:6:5: error: found compile log statement",
+        "tmp.zig:7:5: error: found compile log statement",
     );
 
     cases.add(
@@ -4067,7 +4086,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:8:26: error: expected type '*const u3', found '*align(:3:1) const u3'",
+        "tmp.zig:8:26: error: expected type '*const u3', found '*align(:3:1) const u3'",
     );
 
     cases.add(
@@ -4084,8 +4103,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    if (!ok) unreachable;
         \\}
     ,
-        ".tmp_source.zig:10:14: error: unable to evaluate constant expression",
-        ".tmp_source.zig:6:20: note: called from here",
+        "tmp.zig:10:14: error: unable to evaluate constant expression",
+        "tmp.zig:6:20: note: called from here",
     );
 
     cases.add(
@@ -4099,8 +4118,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\fn bar() void { }
     ,
-        ".tmp_source.zig:3:5: error: control flow attempts to use compile-time variable at runtime",
-        ".tmp_source.zig:3:24: note: compile-time variable assigned here",
+        "tmp.zig:3:5: error: control flow attempts to use compile-time variable at runtime",
+        "tmp.zig:3:24: note: compile-time variable assigned here",
     );
 
     cases.add(
@@ -4110,7 +4129,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() i32 { return 0; }
     ,
-        ".tmp_source.zig:2:8: error: expression value is ignored",
+        "tmp.zig:2:8: error: expression value is ignored",
     );
 
     cases.add(
@@ -4120,7 +4139,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() anyerror!i32 { return 0; }
     ,
-        ".tmp_source.zig:2:11: error: expression value is ignored",
+        "tmp.zig:2:11: error: expression value is ignored",
     );
 
     cases.add(
@@ -4129,7 +4148,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    1;
         \\}
     ,
-        ".tmp_source.zig:2:5: error: expression value is ignored",
+        "tmp.zig:2:5: error: expression value is ignored",
     );
 
     cases.add(
@@ -4138,7 +4157,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    comptime {1;}
         \\}
     ,
-        ".tmp_source.zig:2:15: error: expression value is ignored",
+        "tmp.zig:2:15: error: expression value is ignored",
     );
 
     cases.add(
@@ -4147,7 +4166,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    comptime 1;
         \\}
     ,
-        ".tmp_source.zig:2:5: error: expression value is ignored",
+        "tmp.zig:2:5: error: expression value is ignored",
     );
 
     cases.add(
@@ -4156,7 +4175,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    defer {1;}
         \\}
     ,
-        ".tmp_source.zig:2:12: error: expression value is ignored",
+        "tmp.zig:2:12: error: expression value is ignored",
     );
 
     cases.add(
@@ -4166,7 +4185,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() anyerror!i32 { return 0; }
     ,
-        ".tmp_source.zig:2:14: error: expression value is ignored",
+        "tmp.zig:2:14: error: expression value is ignored",
     );
 
     cases.add(
@@ -4180,7 +4199,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(pass)); }
     ,
-        ".tmp_source.zig:4:10: error: attempt to dereference non-pointer type '[10]u8'",
+        "tmp.zig:4:10: error: attempt to dereference non-pointer type '[10]u8'",
     );
 
     cases.add(
@@ -4196,7 +4215,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() usize { return @sizeOf(@typeOf(foo)); }
     ,
-        ".tmp_source.zig:4:19: error: expected type '*[]const u8', found '*const []const u8'",
+        "tmp.zig:4:19: error: expected type '*[]const u8', found '*const []const u8'",
     );
 
     cases.addCase(x: {
@@ -4209,7 +4228,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
             \\}
         ,
             "foo.zig:1:1: error: exported symbol collision: 'bar'",
-            ".tmp_source.zig:3:1: note: other symbol here",
+            "tmp.zig:3:1: note: other symbol here",
         );
 
         tc.addSourceFile("foo.zig",
@@ -4228,7 +4247,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    foo(global_array);
         \\}
     ,
-        ".tmp_source.zig:4:9: error: expected type '[]i32', found '[10]i32'",
+        "tmp.zig:4:9: error: expected type '[]i32', found '[10]i32'",
     );
 
     cases.add(
@@ -4237,7 +4256,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @ptrCast(usize, a);
         \\}
     ,
-        ".tmp_source.zig:2:21: error: expected pointer, found 'usize'",
+        "tmp.zig:2:21: error: expected pointer, found 'usize'",
     );
 
     cases.add(
@@ -4254,7 +4273,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    );
         \\}
     ,
-        ".tmp_source.zig:6:5: error: unable to evaluate constant expression",
+        "tmp.zig:6:5: error: unable to evaluate constant expression",
     );
 
     cases.add(
@@ -4264,7 +4283,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const foo = builtin.Arch.x86;
         \\}
     ,
-        ".tmp_source.zig:3:29: error: container 'Arch' has no member called 'x86'",
+        "tmp.zig:3:29: error: container 'builtin.Arch' has no member called 'x86'",
     );
 
     cases.add(
@@ -4274,7 +4293,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var y: *void = @intToPtr(*void, x);
         \\}
     ,
-        ".tmp_source.zig:3:30: error: type '*void' has 0 bits and cannot store information",
+        "tmp.zig:3:30: error: type '*void' has 0 bits and cannot store information",
     );
 
     cases.add(
@@ -4284,7 +4303,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @fieldParentPtr(Foo, "a", a);
         \\}
     ,
-        ".tmp_source.zig:3:28: error: expected struct type, found 'i32'",
+        "tmp.zig:3:28: error: expected struct type, found 'i32'",
     );
 
     cases.add(
@@ -4296,7 +4315,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @fieldParentPtr(Foo, "a", a);
         \\}
     ,
-        ".tmp_source.zig:5:33: error: struct 'Foo' has no field 'a'",
+        "tmp.zig:5:33: error: struct 'Foo' has no field 'a'",
     );
 
     cases.add(
@@ -4308,7 +4327,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @fieldParentPtr(Foo, "a", a);
         \\}
     ,
-        ".tmp_source.zig:5:38: error: expected pointer, found 'i32'",
+        "tmp.zig:5:38: error: expected pointer, found 'i32'",
     );
 
     cases.add(
@@ -4324,7 +4343,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const another_foo_ptr = @fieldParentPtr(Foo, "b", field_ptr);
         \\}
     ,
-        ".tmp_source.zig:9:55: error: pointer value not based on parent struct",
+        "tmp.zig:9:55: error: pointer value not based on parent struct",
     );
 
     cases.add(
@@ -4339,7 +4358,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const another_foo_ptr = @fieldParentPtr(Foo, "b", &foo.a);
         \\}
     ,
-        ".tmp_source.zig:8:29: error: field 'b' has index 1 but pointer value is index 0 of struct 'Foo'",
+        "tmp.zig:8:29: error: field 'b' has index 1 but pointer value is index 0 of struct 'Foo'",
     );
 
     cases.add(
@@ -4349,7 +4368,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @byteOffsetOf(Foo, "a",);
         \\}
     ,
-        ".tmp_source.zig:3:26: error: expected struct type, found 'i32'",
+        "tmp.zig:3:26: error: expected struct type, found 'i32'",
     );
 
     cases.add(
@@ -4361,14 +4380,14 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @byteOffsetOf(Foo, "a",);
         \\}
     ,
-        ".tmp_source.zig:5:31: error: struct 'Foo' has no field 'a'",
+        "tmp.zig:5:31: error: struct 'Foo' has no field 'a'",
     );
 
     cases.addExe(
         "missing main fn in executable",
         \\
     ,
-        "error: no member named 'main' in '",
+        "error: root source file has no member called 'main'",
     );
 
     cases.addExe(
@@ -4376,7 +4395,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\fn main() void {}
     ,
         "error: 'main' is private",
-        ".tmp_source.zig:1:1: note: declared here",
+        "tmp.zig:1:1: note: declared here",
     );
 
     cases.add(
@@ -4386,7 +4405,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return foo;
         \\}
     ,
-        ".tmp_source.zig:1:33: error: cannot set section of external variable 'foo'",
+        "tmp.zig:1:33: error: cannot set section of external variable 'foo'",
     );
 
     cases.add(
@@ -4396,7 +4415,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return foo;
         \\}
     ,
-        ".tmp_source.zig:2:30: error: cannot set section of local variable 'foo'",
+        "tmp.zig:2:30: error: cannot set section of local variable 'foo'",
     );
 
     cases.add(
@@ -4406,7 +4425,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    foo();
         \\}
     ,
-        ".tmp_source.zig:1:29: error: cannot set section of external function 'foo'",
+        "tmp.zig:1:29: error: cannot set section of external function 'foo'",
     );
 
     cases.add(
@@ -4416,7 +4435,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return &a;
         \\}
     ,
-        ".tmp_source.zig:3:13: error: function returns address of local variable",
+        "tmp.zig:3:13: error: function returns address of local variable",
     );
 
     cases.add(
@@ -4427,7 +4446,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return if (c) &a else &b;
         \\}
     ,
-        ".tmp_source.zig:4:12: error: function returns address of local variable",
+        "tmp.zig:4:12: error: function returns address of local variable",
     );
 
     cases.add(
@@ -4452,8 +4471,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    if (!ok) unreachable;
         \\}
     ,
-        ".tmp_source.zig:9:17: error: redefinition of 'Self'",
-        ".tmp_source.zig:5:9: note: previous definition is here",
+        "tmp.zig:9:17: error: redefinition of 'Self'",
+        "tmp.zig:5:9: note: previous definition is here",
     );
 
     cases.add(
@@ -4463,7 +4482,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() ?i32 { return 1; }
     ,
-        ".tmp_source.zig:2:15: error: expected type 'bool', found '?i32'",
+        "tmp.zig:2:15: error: expected type 'bool', found '?i32'",
     );
 
     cases.add(
@@ -4473,7 +4492,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() anyerror!i32 { return 1; }
     ,
-        ".tmp_source.zig:2:15: error: expected type 'bool', found 'anyerror!i32'",
+        "tmp.zig:2:15: error: expected type 'bool', found 'anyerror!i32'",
     );
 
     cases.add(
@@ -4483,7 +4502,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() bool { return true; }
     ,
-        ".tmp_source.zig:2:15: error: expected optional type, found 'bool'",
+        "tmp.zig:2:15: error: expected optional type, found 'bool'",
     );
 
     cases.add(
@@ -4493,7 +4512,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() anyerror!i32 { return 1; }
     ,
-        ".tmp_source.zig:2:15: error: expected optional type, found 'anyerror!i32'",
+        "tmp.zig:2:15: error: expected optional type, found 'anyerror!i32'",
     );
 
     cases.add(
@@ -4503,7 +4522,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() bool { return true; }
     ,
-        ".tmp_source.zig:2:15: error: expected error union type, found 'bool'",
+        "tmp.zig:2:15: error: expected error union type, found 'bool'",
     );
 
     cases.add(
@@ -4513,7 +4532,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() ?i32 { return 1; }
     ,
-        ".tmp_source.zig:2:15: error: expected error union type, found '?i32'",
+        "tmp.zig:2:15: error: expected error union type, found '?i32'",
     );
 
     cases.add(
@@ -4531,7 +4550,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\extern fn quux() void;
     ,
-        ".tmp_source.zig:4:1: error: unable to inline function",
+        "tmp.zig:4:1: error: unable to inline function",
     );
 
     cases.add(
@@ -4542,7 +4561,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\inline fn bar() void { }
         \\extern fn quux(usize) void;
     ,
-        ".tmp_source.zig:4:1: error: unable to inline function",
+        "tmp.zig:4:1: error: unable to inline function",
     );
 
     cases.add(
@@ -4551,7 +4570,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return a / b;
         \\}
     ,
-        ".tmp_source.zig:2:14: error: division with 'i32' and 'i32': signed integers must use @divTrunc, @divFloor, or @divExact",
+        "tmp.zig:2:14: error: division with 'i32' and 'i32': signed integers must use @divTrunc, @divFloor, or @divExact",
     );
 
     cases.add(
@@ -4560,7 +4579,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return a % b;
         \\}
     ,
-        ".tmp_source.zig:2:14: error: remainder division with 'i32' and 'i32': signed integers and floats must use @rem or @mod",
+        "tmp.zig:2:14: error: remainder division with 'i32' and 'i32': signed integers and floats must use @rem or @mod",
     );
 
     cases.add(
@@ -4571,7 +4590,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const c = a / b;
         \\}
     ,
-        ".tmp_source.zig:4:17: error: division by zero",
+        "tmp.zig:4:17: error: division by zero",
     );
 
     cases.add(
@@ -4582,7 +4601,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const c = a % b;
         \\}
     ,
-        ".tmp_source.zig:4:17: error: division by zero",
+        "tmp.zig:4:17: error: division by zero",
     );
 
     cases.add(
@@ -4592,8 +4611,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @setRuntimeSafety(false);
         \\}
     ,
-        ".tmp_source.zig:3:5: error: runtime safety set twice for same scope",
-        ".tmp_source.zig:2:5: note: first set here",
+        "tmp.zig:3:5: error: runtime safety set twice for same scope",
+        "tmp.zig:2:5: note: first set here",
     );
 
     cases.add(
@@ -4603,8 +4622,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @setFloatMode(@import("builtin").FloatMode.Optimized);
         \\}
     ,
-        ".tmp_source.zig:3:5: error: float mode set twice for same scope",
-        ".tmp_source.zig:2:5: note: first set here",
+        "tmp.zig:3:5: error: float mode set twice for same scope",
+        "tmp.zig:2:5: note: first set here",
     );
 
     cases.add(
@@ -4613,7 +4632,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var b: u8[40] = undefined;
         \\}
     ,
-        ".tmp_source.zig:2:14: error: array access of non-array type 'type'",
+        "tmp.zig:2:14: error: array access of non-array type 'type'",
     );
 
     cases.add(
@@ -4626,7 +4645,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:4:13: error: cannot break out of defer expression",
+        "tmp.zig:4:13: error: cannot break out of defer expression",
     );
 
     cases.add(
@@ -4639,7 +4658,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:4:13: error: cannot continue out of defer expression",
+        "tmp.zig:4:13: error: cannot continue out of defer expression",
     );
 
     cases.add(
@@ -4653,7 +4672,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    foos[0]();
         \\}
     ,
-        ".tmp_source.zig:7:9: error: calling a generic function requires compile-time known function value",
+        "tmp.zig:7:9: error: calling a generic function requires compile-time known function value",
     );
 
     cases.add(
@@ -4667,7 +4686,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    foos[0](true);
         \\}
     ,
-        ".tmp_source.zig:7:9: error: calling a generic function requires compile-time known function value",
+        "tmp.zig:7:9: error: calling a generic function requires compile-time known function value",
     );
 
     cases.add(
@@ -4681,24 +4700,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return bar;
         \\}
     ,
-        ".tmp_source.zig:1:13: error: aoeu",
-        ".tmp_source.zig:3:19: note: referenced here",
-        ".tmp_source.zig:7:12: note: referenced here",
-    );
-
-    cases.add(
-        "instantiating an undefined value for an invalid struct that contains itself",
-        \\const Foo = struct {
-        \\    x: Foo,
-        \\};
-        \\
-        \\var foo: Foo = undefined;
-        \\
-        \\export fn entry() usize {
-        \\    return @sizeOf(@typeOf(foo.x));
-        \\}
-    ,
-        ".tmp_source.zig:1:13: error: struct 'Foo' contains itself",
+        "tmp.zig:1:13: error: aoeu",
+        "tmp.zig:3:19: note: referenced here",
+        "tmp.zig:7:12: note: referenced here",
     );
 
     cases.add(
@@ -4707,7 +4711,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a = 0x1.0p16384;
         \\}
     ,
-        ".tmp_source.zig:2:15: error: float literal out of range of any type",
+        "tmp.zig:2:15: error: float literal out of range of any type",
     );
 
     cases.add(
@@ -4716,7 +4720,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a = 0x1.0p-16384;
         \\}
     ,
-        ".tmp_source.zig:2:15: error: float literal out of range of any type",
+        "tmp.zig:2:15: error: float literal out of range of any type",
     );
 
     cases.add(
@@ -4725,7 +4729,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return i32(12.34);
         \\}
     ,
-        ".tmp_source.zig:2:16: error: fractional component prevents float value 12.340000 from being casted to type 'i32'",
+        "tmp.zig:2:16: error: fractional component prevents float value 12.340000 from being casted to type 'i32'",
     );
 
     cases.add(
@@ -4734,7 +4738,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @ptrToInt(x);
         \\}
     ,
-        ".tmp_source.zig:2:22: error: expected pointer, found 'i32'",
+        "tmp.zig:2:22: error: expected pointer, found 'i32'",
     );
 
     cases.add(
@@ -4743,7 +4747,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = @shlExact(u8(0b01010101), 2);
         \\}
     ,
-        ".tmp_source.zig:2:15: error: operation caused overflow",
+        "tmp.zig:2:15: error: operation caused overflow",
     );
 
     cases.add(
@@ -4752,7 +4756,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = @shrExact(u8(0b10101010), 2);
         \\}
     ,
-        ".tmp_source.zig:2:15: error: exact shift shifted out 1 bits",
+        "tmp.zig:2:15: error: exact shift shifted out 1 bits",
     );
 
     cases.add(
@@ -4761,7 +4765,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return 0x11 << x;
         \\}
     ,
-        ".tmp_source.zig:2:17: error: LHS of shift must be an integer type, or RHS must be compile-time known",
+        "tmp.zig:2:17: error: LHS of shift must be an integer type, or RHS must be compile-time known",
     );
 
     cases.add(
@@ -4770,7 +4774,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return x << y;
         \\}
     ,
-        ".tmp_source.zig:2:17: error: expected type 'u3', found 'u8'",
+        "tmp.zig:2:17: error: expected type 'u3', found 'u8'",
     );
 
     cases.add(
@@ -4780,7 +4784,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const a: u16 = 300;
         \\}
     ,
-        ".tmp_source.zig:1:1: error: declaration shadows primitive type 'u16'",
+        "tmp.zig:1:1: error: declaration shadows primitive type 'u16'",
     );
 
     cases.add(
@@ -4799,7 +4803,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    x.* += 1;
         \\}
     ,
-        ".tmp_source.zig:8:13: error: expected type '*u32', found '*align(1) u32'",
+        "tmp.zig:8:13: error: expected type '*u32', found '*align(1) u32'",
     );
 
     cases.add(
@@ -4819,9 +4823,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    x[0] += 1;
         \\}
     ,
-        ".tmp_source.zig:9:18: error: cast increases pointer alignment",
-        ".tmp_source.zig:9:23: note: '*align(1) u32' has alignment 1",
-        ".tmp_source.zig:9:18: note: '*[1]u32' has alignment 4",
+        "tmp.zig:9:18: error: cast increases pointer alignment",
+        "tmp.zig:9:23: note: '*align(1) u32' has alignment 1",
+        "tmp.zig:9:18: note: '*[1]u32' has alignment 4",
     );
 
     cases.add(
@@ -4832,9 +4836,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return ptr.*;
         \\}
     ,
-        ".tmp_source.zig:3:17: error: cast increases pointer alignment",
-        ".tmp_source.zig:3:38: note: '*u8' has alignment 1",
-        ".tmp_source.zig:3:26: note: '*u32' has alignment 4",
+        "tmp.zig:3:17: error: cast increases pointer alignment",
+        "tmp.zig:3:38: note: '*u8' has alignment 1",
+        "tmp.zig:3:26: note: '*u32' has alignment 4",
     );
 
     cases.add(
@@ -4843,7 +4847,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @alignCast(4, u32(3));
         \\}
     ,
-        ".tmp_source.zig:2:22: error: expected pointer or slice, found 'u32'",
+        "tmp.zig:2:22: error: expected pointer or slice, found 'u32'",
     );
 
     cases.add(
@@ -4856,7 +4860,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn alignedSmall() align(4) i32 { return 1234; }
     ,
-        ".tmp_source.zig:2:35: error: expected type 'fn() align(8) i32', found 'fn() align(4) i32'",
+        "tmp.zig:2:35: error: expected type 'fn() align(8) i32', found 'fn() align(4) i32'",
     );
 
     cases.add(
@@ -4868,7 +4872,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return x == 5678;
         \\}
     ,
-        ".tmp_source.zig:4:32: error: expected type '*i32', found '*align(1) i32'",
+        "tmp.zig:4:32: error: expected type '*i32', found '*align(1) i32'",
     );
 
     cases.add(
@@ -4877,7 +4881,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const array = [2]u8{1, 2, 3};
         \\}
     ,
-        ".tmp_source.zig:2:24: error: expected [2]u8 literal, found [3]u8 literal",
+        "tmp.zig:2:24: error: expected [2]u8 literal, found [3]u8 literal",
     );
 
     cases.add(
@@ -4889,7 +4893,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    bar(@ptrCast(*c_void, &x));
         \\}
     ,
-        ".tmp_source.zig:5:9: error: expected type '*Derp', found '*c_void'",
+        "tmp.zig:5:9: error: expected type '*Derp', found '*c_void'",
     );
 
     cases.add(
@@ -4906,7 +4910,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\   var d = null;
         \\   var e = opaque.*;
         \\   var f = i32;
-        \\   var g = @import("std",);
         \\   var h = (Foo {}).bar;
         \\
         \\   var z: noreturn = return;
@@ -4916,16 +4919,15 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    fn bar(self: *const Foo) void {}
         \\};
     ,
-        ".tmp_source.zig:4:4: error: variable of type '*comptime_int' must be const or comptime",
-        ".tmp_source.zig:7:4: error: variable of type '(undefined)' must be const or comptime",
-        ".tmp_source.zig:8:4: error: variable of type 'comptime_int' must be const or comptime",
-        ".tmp_source.zig:9:4: error: variable of type 'comptime_float' must be const or comptime",
-        ".tmp_source.zig:10:4: error: variable of type '(null)' must be const or comptime",
-        ".tmp_source.zig:11:4: error: variable of type 'Opaque' not allowed",
-        ".tmp_source.zig:12:4: error: variable of type 'type' must be const or comptime",
-        ".tmp_source.zig:13:4: error: variable of type '(namespace)' must be const or comptime",
-        ".tmp_source.zig:14:4: error: variable of type '(bound fn(*const Foo) void)' must be const or comptime",
-        ".tmp_source.zig:16:4: error: unreachable code",
+        "tmp.zig:4:4: error: variable of type '*comptime_int' must be const or comptime",
+        "tmp.zig:7:4: error: variable of type '(undefined)' must be const or comptime",
+        "tmp.zig:8:4: error: variable of type 'comptime_int' must be const or comptime",
+        "tmp.zig:9:4: error: variable of type 'comptime_float' must be const or comptime",
+        "tmp.zig:10:4: error: variable of type '(null)' must be const or comptime",
+        "tmp.zig:11:4: error: variable of type 'Opaque' not allowed",
+        "tmp.zig:12:4: error: variable of type 'type' must be const or comptime",
+        "tmp.zig:13:4: error: variable of type '(bound fn(*const Foo) void)' must be const or comptime",
+        "tmp.zig:15:4: error: unreachable code",
     );
 
     cases.add(
@@ -4935,7 +4937,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    while (!@cmpxchgWeak(i32, &x, 1234, 5678, u32(1234), u32(1234))) {}
         \\}
     ,
-        ".tmp_source.zig:3:50: error: expected type 'AtomicOrder', found 'u32'",
+        "tmp.zig:3:50: error: expected type 'builtin.AtomicOrder', found 'u32'",
     );
 
     cases.add(
@@ -4945,7 +4947,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @export("entry", entry, u32(1234));
         \\}
     ,
-        ".tmp_source.zig:3:32: error: expected type 'GlobalLinkage', found 'u32'",
+        "tmp.zig:3:32: error: expected type 'builtin.GlobalLinkage', found 'u32'",
     );
 
     cases.add(
@@ -4974,7 +4976,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    };
         \\}
     ,
-        ".tmp_source.zig:14:17: error: use of undeclared identifier 'HeaderValue'",
+        "tmp.zig:14:17: error: use of undeclared identifier 'HeaderValue'",
     );
 
     cases.add(
@@ -4983,7 +4985,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @setAlignStack(16);
         \\}
     ,
-        ".tmp_source.zig:2:5: error: @setAlignStack outside function",
+        "tmp.zig:2:5: error: @setAlignStack outside function",
     );
 
     cases.add(
@@ -4992,7 +4994,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @setAlignStack(16);
         \\}
     ,
-        ".tmp_source.zig:2:5: error: @setAlignStack in naked function",
+        "tmp.zig:2:5: error: @setAlignStack in naked function",
     );
 
     cases.add(
@@ -5004,7 +5006,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @setAlignStack(16);
         \\}
     ,
-        ".tmp_source.zig:5:5: error: @setAlignStack in inline function",
+        "tmp.zig:5:5: error: @setAlignStack in inline function",
     );
 
     cases.add(
@@ -5014,8 +5016,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @setAlignStack(16);
         \\}
     ,
-        ".tmp_source.zig:3:5: error: alignstack set twice",
-        ".tmp_source.zig:2:5: note: first set here",
+        "tmp.zig:3:5: error: alignstack set twice",
+        "tmp.zig:2:5: note: first set here",
     );
 
     cases.add(
@@ -5024,7 +5026,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    @setAlignStack(511 + 1);
         \\}
     ,
-        ".tmp_source.zig:2:5: error: attempt to @setAlignStack(512); maximum is 256",
+        "tmp.zig:2:5: error: attempt to @setAlignStack(512); maximum is 256",
     );
 
     cases.add(
@@ -5071,7 +5073,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:37:16: error: cannot store runtime value in compile time variable",
+        "tmp.zig:37:16: error: cannot store runtime value in compile time variable",
     );
 
     cases.add(
@@ -5087,7 +5089,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return x.blah;
         \\}
     ,
-        ".tmp_source.zig:9:13: error: type '*MyType' does not support field access",
+        "tmp.zig:9:13: error: type '*MyType' does not support field access",
     );
 
     cases.add(
@@ -5095,7 +5097,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "fn test() bool {\r\n" ++
             "   true\r\n" ++
             "}\r\n",
-        ".tmp_source.zig:1:17: error: invalid carriage return, only '\\n' line endings are supported",
+        "tmp.zig:1:17: error: invalid carriage return, only '\\n' line endings are supported",
     );
 
     cases.add(
@@ -5105,7 +5107,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
             \\    true\r
             \\}
         ,
-        ".tmp_source.zig:1:1: error: invalid character: '\\xff'",
+        "tmp.zig:1:1: error: invalid character: '\\xff'",
     );
 
     cases.add(
@@ -5113,7 +5115,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "fn test() bool {\n" ++
             "\ttrue\n" ++
             "}\n",
-        ".tmp_source.zig:2:1: error: invalid character: '\\t'",
+        "tmp.zig:2:1: error: invalid character: '\\t'",
     );
 
     cases.add(
@@ -5122,7 +5124,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @ArgType(i32, 3);
         \\}
     ,
-        ".tmp_source.zig:2:18: error: expected function, found 'i32'",
+        "tmp.zig:2:18: error: expected function, found 'i32'",
     );
 
     cases.add(
@@ -5132,7 +5134,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn add(a: i32, b: i32) i32 { return a + b; }
     ,
-        ".tmp_source.zig:2:32: error: arg index 2 out of bounds; 'fn(i32, i32) i32' has 2 arguments",
+        "tmp.zig:2:32: error: arg index 2 out of bounds; 'fn(i32, i32) i32' has 2 arguments",
     );
 
     cases.add(
@@ -5141,7 +5143,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @memberType(i32, 0);
         \\}
     ,
-        ".tmp_source.zig:2:21: error: type 'i32' does not support @memberType",
+        "tmp.zig:2:21: error: type 'i32' does not support @memberType",
     );
 
     cases.add(
@@ -5151,7 +5153,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\const Foo = enum {A,};
     ,
-        ".tmp_source.zig:2:21: error: type 'Foo' does not support @memberType",
+        "tmp.zig:2:21: error: type 'Foo' does not support @memberType",
     );
 
     cases.add(
@@ -5161,7 +5163,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\const Foo = struct {};
     ,
-        ".tmp_source.zig:2:26: error: member index 0 out of bounds; 'Foo' has 0 members",
+        "tmp.zig:2:26: error: member index 0 out of bounds; 'Foo' has 0 members",
     );
 
     cases.add(
@@ -5171,7 +5173,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\const Foo = union {A: void,};
     ,
-        ".tmp_source.zig:2:26: error: member index 1 out of bounds; 'Foo' has 1 members",
+        "tmp.zig:2:26: error: member index 1 out of bounds; 'Foo' has 1 members",
     );
 
     cases.add(
@@ -5180,7 +5182,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @memberName(i32, 0);
         \\}
     ,
-        ".tmp_source.zig:2:21: error: type 'i32' does not support @memberName",
+        "tmp.zig:2:21: error: type 'i32' does not support @memberName",
     );
 
     cases.add(
@@ -5190,7 +5192,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\const Foo = struct {};
     ,
-        ".tmp_source.zig:2:26: error: member index 0 out of bounds; 'Foo' has 0 members",
+        "tmp.zig:2:26: error: member index 0 out of bounds; 'Foo' has 0 members",
     );
 
     cases.add(
@@ -5200,7 +5202,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\const Foo = enum {A,};
     ,
-        ".tmp_source.zig:2:26: error: member index 1 out of bounds; 'Foo' has 1 members",
+        "tmp.zig:2:26: error: member index 1 out of bounds; 'Foo' has 1 members",
     );
 
     cases.add(
@@ -5210,7 +5212,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\const Foo = union {A:i32,};
     ,
-        ".tmp_source.zig:2:26: error: member index 1 out of bounds; 'Foo' has 1 members",
+        "tmp.zig:2:26: error: member index 1 out of bounds; 'Foo' has 1 members",
     );
 
     cases.add(
@@ -5220,7 +5222,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\pub extern fn foo(format: *const u8, ...) void;
     ,
-        ".tmp_source.zig:2:9: error: expected type '*const u8', found '[5]u8'",
+        "tmp.zig:2:9: error: expected type '*const u8', found '[5]u8'",
     );
 
     cases.add(
@@ -5239,9 +5241,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var allocator: ContextAllocator = undefined;
         \\}
     ,
-        ".tmp_source.zig:4:25: error: aoeu",
-        ".tmp_source.zig:1:36: note: called from here",
-        ".tmp_source.zig:12:20: note: referenced here",
+        "tmp.zig:4:25: error: aoeu",
+        "tmp.zig:1:36: note: called from here",
+        "tmp.zig:12:20: note: referenced here",
     );
 
     cases.add(
@@ -5258,7 +5260,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = Small.One;
         \\}
     ,
-        ".tmp_source.zig:1:21: error: 'u2' too small to hold all bits; must be at least 'u3'",
+        "tmp.zig:1:21: error: 'u2' too small to hold all bits; must be at least 'u3'",
     );
 
     cases.add(
@@ -5273,7 +5275,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = Small.One;
         \\}
     ,
-        ".tmp_source.zig:1:21: error: expected integer, found 'f32'",
+        "tmp.zig:1:21: error: expected integer, found 'f32'",
     );
 
     cases.add(
@@ -5289,7 +5291,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x: u2 = Small.Two;
         \\}
     ,
-        ".tmp_source.zig:9:22: error: expected type 'u2', found 'Small'",
+        "tmp.zig:9:22: error: expected type 'u2', found 'Small'",
     );
 
     cases.add(
@@ -5306,7 +5308,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = @intToEnum(Small, y);
         \\}
     ,
-        ".tmp_source.zig:10:31: error: expected type 'u2', found 'u3'",
+        "tmp.zig:10:31: error: expected type 'u2', found 'u3'",
     );
 
     cases.add(
@@ -5322,7 +5324,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var y = Small.Two;
         \\}
     ,
-        ".tmp_source.zig:1:20: error: expected unsigned integer, found 'i2'",
+        "tmp.zig:1:20: error: expected unsigned integer, found 'i2'",
     );
 
     cases.add(
@@ -5334,7 +5336,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\        var x: MultipleChoice = undefined;
         \\}
     ,
-        ".tmp_source.zig:2:14: error: enums, not structs, support field assignment",
+        "tmp.zig:2:14: error: enums, not structs, support field assignment",
     );
 
     cases.add(
@@ -5346,8 +5348,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x: MultipleChoice = undefined;
         \\}
     ,
-        ".tmp_source.zig:2:14: error: non-enum union field assignment",
-        ".tmp_source.zig:1:24: note: consider 'union(enum)' here",
+        "tmp.zig:2:14: error: non-enum union field assignment",
+        "tmp.zig:1:24: note: consider 'union(enum)' here",
     );
 
     cases.add(
@@ -5357,7 +5359,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @sizeOf(Foo);
         \\}
     ,
-        ".tmp_source.zig:1:13: error: enums must have 1 or more fields",
+        "tmp.zig:1:13: error: enums must have 1 or more fields",
     );
 
     cases.add(
@@ -5367,7 +5369,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @sizeOf(Foo);
         \\}
     ,
-        ".tmp_source.zig:1:13: error: unions must have 1 or more fields",
+        "tmp.zig:1:13: error: unions must have 1 or more fields",
     );
 
     cases.add(
@@ -5383,8 +5385,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = MultipleChoice.C;
         \\}
     ,
-        ".tmp_source.zig:6:9: error: enum tag value 60 already taken",
-        ".tmp_source.zig:4:9: note: other occurrence here",
+        "tmp.zig:6:9: error: enum tag value 60 already taken",
+        "tmp.zig:4:9: note: other occurrence here",
     );
 
     cases.add(
@@ -5402,8 +5404,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return @sizeOf(Payload);
         \\}
     ,
-        ".tmp_source.zig:6:17: error: enum field missing: 'C'",
-        ".tmp_source.zig:4:5: note: declared here",
+        "tmp.zig:6:17: error: enum field missing: 'C'",
+        "tmp.zig:4:5: note: declared here",
     );
 
     cases.add(
@@ -5415,8 +5417,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = @TagType(Foo);
         \\}
     ,
-        ".tmp_source.zig:5:24: error: union 'Foo' has no tag",
-        ".tmp_source.zig:1:13: note: consider 'union(enum)' here",
+        "tmp.zig:5:24: error: union 'Foo' has no tag",
+        "tmp.zig:1:13: note: consider 'union(enum)' here",
     );
 
     cases.add(
@@ -5428,7 +5430,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = @TagType(Foo);
         \\}
     ,
-        ".tmp_source.zig:1:24: error: expected integer tag type, found 'f32'",
+        "tmp.zig:1:24: error: expected integer tag type, found 'f32'",
     );
 
     cases.add(
@@ -5440,7 +5442,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const x = @TagType(Foo);
         \\}
     ,
-        ".tmp_source.zig:1:19: error: expected enum tag type, found 'u32'",
+        "tmp.zig:1:19: error: expected enum tag type, found 'u32'",
     );
 
     cases.add(
@@ -5456,8 +5458,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = MultipleChoice { .C = {} };
         \\}
     ,
-        ".tmp_source.zig:6:9: error: enum tag value 60 already taken",
-        ".tmp_source.zig:4:9: note: other occurrence here",
+        "tmp.zig:6:9: error: enum tag value 60 already taken",
+        "tmp.zig:4:9: note: other occurrence here",
     );
 
     cases.add(
@@ -5477,8 +5479,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var a = Payload {.A = 1234};
         \\}
     ,
-        ".tmp_source.zig:10:5: error: enum field not found: 'D'",
-        ".tmp_source.zig:1:16: note: enum declared here",
+        "tmp.zig:10:5: error: enum field not found: 'D'",
+        "tmp.zig:1:16: note: enum declared here",
     );
 
     cases.add(
@@ -5492,8 +5494,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var b = Letter.B;
         \\}
     ,
-        ".tmp_source.zig:2:8: error: structs and unions, not enums, support field types",
-        ".tmp_source.zig:1:16: note: consider 'union(enum)' here",
+        "tmp.zig:2:8: error: structs and unions, not enums, support field types",
+        "tmp.zig:1:16: note: consider 'union(enum)' here",
     );
 
     cases.add(
@@ -5505,7 +5507,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var a = Letter { .A = {} };
         \\}
     ,
-        ".tmp_source.zig:2:5: error: struct field missing type",
+        "tmp.zig:2:5: error: struct field missing type",
     );
 
     cases.add(
@@ -5517,7 +5519,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var a = Letter { .A = {} };
         \\}
     ,
-        ".tmp_source.zig:2:5: error: union field missing type",
+        "tmp.zig:2:5: error: union field missing type",
     );
 
     cases.add(
@@ -5536,7 +5538,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var a = Payload { .A = 1234 };
         \\}
     ,
-        ".tmp_source.zig:6:30: error: extern union does not support enum tag type",
+        "tmp.zig:6:30: error: extern union does not support enum tag type",
     );
 
     cases.add(
@@ -5555,7 +5557,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var a = Payload { .A = 1234 };
         \\}
     ,
-        ".tmp_source.zig:6:30: error: packed union does not support enum tag type",
+        "tmp.zig:6:30: error: packed union does not support enum tag type",
     );
 
     cases.add(
@@ -5576,8 +5578,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    }
         \\}
     ,
-        ".tmp_source.zig:11:14: error: switch on union which has no attached enum",
-        ".tmp_source.zig:1:17: note: consider 'union(enum)' here",
+        "tmp.zig:11:14: error: switch on union which has no attached enum",
+        "tmp.zig:1:17: note: consider 'union(enum)' here",
     );
 
     cases.add(
@@ -5590,8 +5592,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = @intToEnum(Foo, 0);
         \\}
     ,
-        ".tmp_source.zig:6:13: error: enum 'Foo' has no tag matching integer value 0",
-        ".tmp_source.zig:1:13: note: 'Foo' declared here",
+        "tmp.zig:6:13: error: enum 'Foo' has no tag matching integer value 0",
+        "tmp.zig:1:13: note: 'Foo' declared here",
     );
 
     cases.add(
@@ -5606,8 +5608,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x: Value = Letter.A;
         \\}
     ,
-        ".tmp_source.zig:8:26: error: cast to union 'Value' must initialize 'i32' field 'A'",
-        ".tmp_source.zig:3:5: note: field 'A' declared here",
+        "tmp.zig:8:26: error: cast to union 'Value' must initialize 'i32' field 'A'",
+        "tmp.zig:3:5: note: field 'A' declared here",
     );
 
     cases.add(
@@ -5625,8 +5627,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x: Value = l;
         \\}
     ,
-        ".tmp_source.zig:11:20: error: runtime cast to union 'Value' which has non-void fields",
-        ".tmp_source.zig:3:5: note: field 'A' has type 'i32'",
+        "tmp.zig:11:20: error: runtime cast to union 'Value' which has non-void fields",
+        "tmp.zig:3:5: note: field 'A' has type 'i32'",
     );
 
     cases.add(
@@ -5638,7 +5640,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const fieldOffset = @byteOffsetOf(Empty, "val",);
         \\}
     ,
-        ".tmp_source.zig:5:46: error: zero-bit field 'val' in struct 'Empty' has no offset",
+        "tmp.zig:5:46: error: zero-bit field 'val' in struct 'Empty' has no offset",
     );
 
     cases.add(
@@ -5650,7 +5652,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const fieldOffset = @bitOffsetOf(Empty, "val",);
         \\}
     ,
-        ".tmp_source.zig:5:45: error: zero-bit field 'val' in struct 'Empty' has no offset",
+        "tmp.zig:5:45: error: zero-bit field 'val' in struct 'Empty' has no offset",
     );
 
     cases.add(
@@ -5664,7 +5666,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const bar_val = foo.Bar;
         \\}
     ,
-        ".tmp_source.zig:7:24: error: accessing union field 'Bar' while field 'Baz' is set",
+        "tmp.zig:7:24: error: accessing union field 'Bar' while field 'Baz' is set",
     );
 
     cases.add(
@@ -5674,7 +5676,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @typeOf(generic).ReturnType;
         \\}
     ,
-        ".tmp_source.zig:3:25: error: ReturnType has not been resolved because 'fn(var)var' is generic",
+        "tmp.zig:3:25: error: ReturnType has not been resolved because 'fn(var)var' is generic",
     );
 
     cases.add(
@@ -5684,7 +5686,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    _ = @ArgType(@typeOf(generic), 0);
         \\}
     ,
-        ".tmp_source.zig:3:36: error: @ArgType could not resolve the type of arg 0 because 'fn(var)var' is generic",
+        "tmp.zig:3:36: error: @ArgType could not resolve the type of arg 0 because 'fn(var)var' is generic",
     );
 
     cases.add(
@@ -5694,7 +5696,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    asm volatile ("" : [baz]"+r"(bar) : : "");
         \\}
     ,
-        ".tmp_source.zig:3:5: error: invalid modifier starting output constraint for 'baz': '+', only '=' is supported. Compiler TODO: see https://github.com/ziglang/zig/issues/215",
+        "tmp.zig:3:5: error: invalid modifier starting output constraint for 'baz': '+', only '=' is supported. Compiler TODO: see https://github.com/ziglang/zig/issues/215",
     );
 
     cases.add(
@@ -5703,7 +5705,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    asm volatile ("" : : [bar]"r"(3) : "");
         \\}
     ,
-        ".tmp_source.zig:2:35: error: expected sized integer or sized float, found comptime_int",
+        "tmp.zig:2:35: error: expected sized integer or sized float, found comptime_int",
     );
 
     cases.add(
@@ -5712,7 +5714,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    asm volatile ("" : : [bar]"r"(3.17) : "");
         \\}
     ,
-        ".tmp_source.zig:2:35: error: expected sized integer or sized float, found comptime_float",
+        "tmp.zig:2:35: error: expected sized integer or sized float, found comptime_float",
     );
 
     cases.add(
@@ -5726,7 +5728,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const foo = Foo { .Bar = x, .Baz = u8 };
         \\}
     ,
-        ".tmp_source.zig:7:30: error: unable to evaluate constant expression",
+        "tmp.zig:7:30: error: unable to evaluate constant expression",
     );
 
     cases.add(
@@ -5740,7 +5742,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const foo = Foo { .Bar = x };
         \\}
     ,
-        ".tmp_source.zig:7:30: error: unable to evaluate constant expression",
+        "tmp.zig:7:30: error: unable to evaluate constant expression",
     );
 
     cases.addTest(
@@ -5750,7 +5752,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var v: V = undefined;
         \\}
     ,
-        ".tmp_source.zig:2:26: error: vector element type must be integer, float, or pointer; '@Vector(4, u8)' is invalid",
+        "tmp.zig:2:26: error: vector element type must be integer, float, or pointer; '@Vector(4, u8)' is invalid",
     );
 
     cases.add("compileLog of tagged enum doesn't crash the compiler",
@@ -5765,5 +5767,5 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\pub fn main () void {
         \\    comptime testCompileLog(Bar{.X = 123});
         \\}
-    , ".tmp_source.zig:6:5: error: found compile log statement");
+    , "tmp.zig:6:5: error: found compile log statement");
 }

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -18,6 +18,7 @@ comptime {
     _ = @import("behavior/bugs/1421.zig");
     _ = @import("behavior/bugs/1442.zig");
     _ = @import("behavior/bugs/1486.zig");
+    _ = @import("behavior/bugs/1500.zig");
     _ = @import("behavior/bugs/1851.zig");
     _ = @import("behavior/bugs/2006.zig");
     _ = @import("behavior/bugs/394.zig");
@@ -25,6 +26,7 @@ comptime {
     _ = @import("behavior/bugs/529.zig");
     _ = @import("behavior/bugs/655.zig");
     _ = @import("behavior/bugs/656.zig");
+    _ = @import("behavior/bugs/679.zig");
     _ = @import("behavior/bugs/704.zig");
     _ = @import("behavior/bugs/718.zig");
     _ = @import("behavior/bugs/726.zig");

--- a/test/stage1/behavior/asm.zig
+++ b/test/stage1/behavior/asm.zig
@@ -4,16 +4,16 @@ const expect = @import("std").testing.expect;
 comptime {
     if (config.arch == config.Arch.x86_64 and config.os == config.Os.linux) {
         asm volatile (
-            \\.globl aoeu;
-            \\.type aoeu, @function;
-            \\.set aoeu, derp;
+            \\.globl this_is_my_alias;
+            \\.type this_is_my_alias, @function;
+            \\.set this_is_my_alias, derp;
         );
     }
 }
 
 test "module level assembly" {
     if (config.arch == config.Arch.x86_64 and config.os == config.Os.linux) {
-        expect(aoeu() == 1234);
+        expect(this_is_my_alias() == 1234);
     }
 }
 
@@ -85,7 +85,7 @@ test "sized integer/float in asm input" {
     );
 }
 
-extern fn aoeu() i32;
+extern fn this_is_my_alias() i32;
 
 export fn derp() i32 {
     return 1234;

--- a/test/stage1/behavior/bugs/1500.zig
+++ b/test/stage1/behavior/bugs/1500.zig
@@ -1,0 +1,10 @@
+const A = struct {
+    b: B,
+};
+
+const B = fn (A) void;
+
+test "allow these dependencies" {
+    var a: A = undefined;
+    var b: B = undefined;
+}

--- a/test/stage1/behavior/bugs/679.zig
+++ b/test/stage1/behavior/bugs/679.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+const expect = std.testing.expect;
+
+pub fn List(comptime T: type) type {
+    return u32;
+}
+
+const ElementList = List(Element);
+const Element = struct {
+    link: ElementList,
+};
+
+test "false dependency loop in struct definition" {
+    const listType = ElementList;
+    var x: listType = 42;
+    expect(x == 42);
+}

--- a/test/stage1/behavior/misc.zig
+++ b/test/stage1/behavior/misc.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const expect = std.testing.expect;
+const expectEqualSlices = std.testing.expectEqualSlices;
 const mem = std.mem;
 const cstr = std.cstr;
 const builtin = @import("builtin");
@@ -488,7 +489,7 @@ test "@typeName" {
         expect(mem.eql(u8, @typeName(i64), "i64"));
         expect(mem.eql(u8, @typeName(*usize), "*usize"));
         // https://github.com/ziglang/zig/issues/675
-        expect(mem.eql(u8, @typeName(TypeFromFn(u8)), "TypeFromFn(u8)"));
+        expectEqualSlices(u8, "behavior.misc.TypeFromFn(u8)", @typeName(TypeFromFn(u8)));
         expect(mem.eql(u8, @typeName(Struct), "Struct"));
         expect(mem.eql(u8, @typeName(Union), "Union"));
         expect(mem.eql(u8, @typeName(Enum), "Enum"));

--- a/test/stage1/behavior/misc.zig
+++ b/test/stage1/behavior/misc.zig
@@ -469,7 +469,7 @@ test "@typeId" {
         expect(@typeId(AUnionEnum) == Tid.Union);
         expect(@typeId(AUnion) == Tid.Union);
         expect(@typeId(fn () void) == Tid.Fn);
-        expect(@typeId(@typeOf(builtin)) == Tid.Namespace);
+        expect(@typeId(@typeOf(builtin)) == Tid.Type);
         // TODO bound fn
         // TODO arg tuple
         // TODO opaque

--- a/test/stage1/behavior/type_info.zig
+++ b/test/stage1/behavior/type_info.zig
@@ -186,7 +186,7 @@ fn testUnion() void {
     expect(TypeId(typeinfo_info) == TypeId.Union);
     expect(typeinfo_info.Union.layout == TypeInfo.ContainerLayout.Auto);
     expect(typeinfo_info.Union.tag_type.? == TypeId);
-    expect(typeinfo_info.Union.fields.len == 25);
+    expect(typeinfo_info.Union.fields.len == 24);
     expect(typeinfo_info.Union.fields[4].enum_field != null);
     expect(typeinfo_info.Union.fields[4].enum_field.?.value == 4);
     expect(typeinfo_info.Union.fields[4].field_type == @typeOf(@typeInfo(u8).Int));

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -569,7 +569,7 @@ pub const CompileErrorContext = struct {
         const ErrLineIter = struct {
             lines: mem.SplitIterator,
 
-            const source_file = ".tmp_source.zig";
+            const source_file = "tmp.zig";
 
             fn init(input: []const u8) ErrLineIter {
                 return ErrLineIter{ .lines = mem.separate(input, "\n") };
@@ -759,7 +759,7 @@ pub const CompileErrorContext = struct {
             .is_test = false,
         };
 
-        tc.addSourceFile(".tmp_source.zig", source);
+        tc.addSourceFile("tmp.zig", source);
         comptime var arg_i = 0;
         inline while (arg_i < expected_lines.len) : (arg_i += 1) {
             tc.addExpectedError(expected_lines[arg_i]);

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -980,15 +980,18 @@ pub const TranslateCContext = struct {
                 Term.Exited => |code| {
                     if (code != 0) {
                         warn("Compilation failed with exit code {}\n", code);
+                        printInvocation(zig_args.toSliceConst());
                         return error.TestFailed;
                     }
                 },
                 Term.Signal => |code| {
                     warn("Compilation failed with signal {}\n", code);
+                    printInvocation(zig_args.toSliceConst());
                     return error.TestFailed;
                 },
                 else => {
                     warn("Compilation terminated unexpectedly\n");
+                    printInvocation(zig_args.toSliceConst());
                     return error.TestFailed;
                 },
             }


### PR DESCRIPTION
closes #1047 

also struct types get fully qualified names, and function symbol names become fully qualified (extern and export being exceptions of course)

`pub` works on struct decls now

 * [x] test on linux
 * [x] test on macos
 * [x] test on windows

@tgschultz this has some serialization implications regarding `@typeName`:

```zig
const std = @import("std");
const os = std.os;

comptime {
    @compileLog(@typeName(os.File)); // "std.os.file.File"
}
```
