### PR TITLE
Add elf riscv32 and elf riscv64 as options in getLDMOption during con…

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -627,6 +627,10 @@ static const char *getLDMOption(const ZigTarget *t) {
                 return "elf_x86_64_fbsd";
             }
             return "elf_x86_64";
+        case ZigLLVM_riscv32:
+            return "elf32lriscv";
+        case ZigLLVM_riscv64:
+            return "elf64lriscv";
         default:
             zig_unreachable();
     }


### PR DESCRIPTION
…struction of link job.

This change enabled me to get a little further when trying to link a bare metal RISCV executable.

I pulled these emulation strings from the LLD source code:

https://github.com/llvm-mirror/lld/blob/release_80/ELF/Driver.cpp#L132