### PR TITLE
Mark third-party dependencies as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
 *.zig text eol=lf
 langref.html.in text eol=lf
+
+c_headers/ linguist-vendored
+deps/ linguist-vendored
+libc/glibc/ linguist-vendored
+libc/include/ linguist-vendored
+libcxx/ linguist-vendored
+libunwind/ linguist-vendored


### PR DESCRIPTION
Since we have recently added a lot of new third-party dependencies. See https://github.com/github/linguist#using-gitattributes.