### PR TITLE
Fix bigint_append_buf

### DIFF
--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -441,7 +441,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var ptr: [*c]u8 = x;
         \\}
     ,
-        "tmp.zig:2:33: error: integer value 71615590737044764481 cannot be implicitly casted to type 'usize'",
+        "tmp.zig:2:33: error: integer value 18446744073709551617 cannot be implicitly casted to type 'usize'",
         "tmp.zig:6:23: error: integer type 'u65' too big for implicit @intToPtr to type '[*c]u8'",
     );
 


### PR DESCRIPTION
All current usages use base 10 and have a limb length of 1, hence why
we weren't hitting this error in practice.

Should be fine to merge but hit some really long test errors locally and unsure just yet if its my environment, hence the PR for CI.