### PR TITLE
fmt: check for extra newline at end of file

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -517,6 +517,18 @@ test "zig fmt: no trailing comma on struct decl" {
     );
 }
 
+test "zig fmt: extra newlines at the end" {
+    try testTransform(
+        \\const a = b;
+        \\
+        \\
+        \\
+    ,
+        \\const a = b;
+        \\
+    );
+}
+
 test "zig fmt: simple asm" {
     try testTransform(
         \\comptime {

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -59,6 +59,10 @@ pub fn render(allocator: *mem.Allocator, stream: var, tree: *ast.Tree) (@typeOf(
 
     try renderRoot(allocator, &my_stream.stream, tree);
 
+    if (!anything_changed and my_stream.source_index != my_stream.source.len) {
+        anything_changed = true;
+    }
+
     return anything_changed;
 }
 


### PR DESCRIPTION
`anything_changed` checks if `source_index` == `source.len`
Fixes #2074