### PR TITLE
breaking: make @clz(), @ctz(), and @popCount() accept a type like oth…

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6075,7 +6075,7 @@ comptime {
       {#header_close#}
 
       {#header_open|@bitreverse#}
-      <pre>{#syntax#}@bitreverse(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@bitreverse(comptime T: type, integer: T) T{#endsyntax#}</pre>
       <p>{#syntax#}T{#endsyntax#} accepts any integer type.</p>
       <p>
       Reverses the bitpattern of an integer value, including the sign bit if applicable.
@@ -6163,14 +6163,15 @@ comptime {
       {#header_close#}
 
       {#header_open|@clz#}
-      <pre>{#syntax#}@clz(x: T) U{#endsyntax#}</pre>
+      <pre>{#syntax#}@clz(comptime T: type, integer: T) math.Log2Int(@intType(false, @typeOf(T).Int.bits + 1)){#endsyntax#}</pre>
       <p>
       This function counts the number of leading zeroes in {#syntax#}x{#endsyntax#} which is an integer
           type {#syntax#}T{#endsyntax#}.
       </p>
       <p>
-      The return type {#syntax#}U{#endsyntax#} is an unsigned integer with the minimum number
-          of bits that can represent the value {#syntax#}T.bit_count{#endsyntax#}.
+      If {#syntax#}integer{#endsyntax#} is known at {#link|comptime#}, the return type is {#syntax#}comptime_int{#endsyntax#}.
+      Otherwise, the return type is an unsigned integer with the minimum number
+      of bits that can represent the bit count of the integer type.
       </p>
       <p>
       If {#syntax#}x{#endsyntax#} is zero, {#syntax#}@clz{#endsyntax#} returns {#syntax#}T.bit_count{#endsyntax#}.
@@ -6303,14 +6304,15 @@ test "main" {
       {#header_close#}
 
       {#header_open|@ctz#}
-      <pre>{#syntax#}@ctz(x: T) U{#endsyntax#}</pre>
+      <pre>{#syntax#}@ctz(comptime T: type, integer: T) math.Log2Int(@intType(false, @typeOf(T).Int.bits + 1)){#endsyntax#}</pre>
       <p>
       This function counts the number of trailing zeroes in {#syntax#}x{#endsyntax#} which is an integer
           type {#syntax#}T{#endsyntax#}.
       </p>
       <p>
-      The return type {#syntax#}U{#endsyntax#} is an unsigned integer with the minimum number
-          of bits that can represent the value {#syntax#}T.bit_count{#endsyntax#}.
+      If {#syntax#}integer{#endsyntax#} is known at {#link|comptime#}, the return type is {#syntax#}comptime_int{#endsyntax#}.
+      Otherwise, the return type is an unsigned integer with the minimum number
+      of bits that can represent the bit count of the integer type.
       </p>
       <p>
       If {#syntax#}x{#endsyntax#} is zero, {#syntax#}@ctz{#endsyntax#} returns {#syntax#}T.bit_count{#endsyntax#}.
@@ -6860,7 +6862,7 @@ test "call foo" {
       {#header_close#}
 
       {#header_open|@popCount#}
-      <pre>{#syntax#}@popCount(integer: var) var{#endsyntax#}</pre>
+      <pre>{#syntax#}@popCount(comptime T: type, value: T) math.Log2Int(@intType(false, @typeOf(T).Int.bits + 1)){#endsyntax#}</pre>
       <p>Counts the number of bits set in an integer.</p>
       <p>
       If {#syntax#}integer{#endsyntax#} is known at {#link|comptime#}, the return type is {#syntax#}comptime_int{#endsyntax#}.

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6065,8 +6065,8 @@ comptime {
 
       {#header_close#}
 
-      {#header_open|@bswap#}
-      <pre>{#syntax#}@bswap(comptime T: type, value: T) T{#endsyntax#}</pre>
+      {#header_open|@bSwap#}
+      <pre>{#syntax#}@bSwap(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>{#syntax#}T{#endsyntax#} must be an integer type with bit count evenly divisible by 8.</p>
       <p>
       Swaps the byte order of the integer. This converts a big endian integer to a little endian integer,
@@ -6074,8 +6074,8 @@ comptime {
       </p>
       {#header_close#}
 
-      {#header_open|@bitreverse#}
-      <pre>{#syntax#}@bitreverse(comptime T: type, integer: T) T{#endsyntax#}</pre>
+      {#header_open|@bitReverse#}
+      <pre>{#syntax#}@bitReverse(comptime T: type, integer: T) T{#endsyntax#}</pre>
       <p>{#syntax#}T{#endsyntax#} accepts any integer type.</p>
       <p>
       Reverses the bitpattern of an integer value, including the sign bit if applicable.

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2732,19 +2732,22 @@ struct IrInstructionOptionalUnwrapPtr {
 struct IrInstructionCtz {
     IrInstruction base;
 
-    IrInstruction *value;
+    IrInstruction *type;
+    IrInstruction *op;
 };
 
 struct IrInstructionClz {
     IrInstruction base;
 
-    IrInstruction *value;
+    IrInstruction *type;
+    IrInstruction *op;
 };
 
 struct IrInstructionPopCount {
     IrInstruction base;
 
-    IrInstruction *value;
+    IrInstruction *type;
+    IrInstruction *op;
 };
 
 struct IrInstructionUnionTag {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4065,9 +4065,9 @@ static LLVMValueRef get_int_builtin_fn(CodeGen *g, ZigType *int_type, BuiltinFnI
 }
 
 static LLVMValueRef ir_render_clz(CodeGen *g, IrExecutable *executable, IrInstructionClz *instruction) {
-    ZigType *int_type = instruction->value->value.type;
+    ZigType *int_type = instruction->op->value.type;
     LLVMValueRef fn_val = get_int_builtin_fn(g, int_type, BuiltinFnIdClz);
-    LLVMValueRef operand = ir_llvm_value(g, instruction->value);
+    LLVMValueRef operand = ir_llvm_value(g, instruction->op);
     LLVMValueRef params[] {
         operand,
         LLVMConstNull(LLVMInt1Type()),
@@ -4077,9 +4077,9 @@ static LLVMValueRef ir_render_clz(CodeGen *g, IrExecutable *executable, IrInstru
 }
 
 static LLVMValueRef ir_render_ctz(CodeGen *g, IrExecutable *executable, IrInstructionCtz *instruction) {
-    ZigType *int_type = instruction->value->value.type;
+    ZigType *int_type = instruction->op->value.type;
     LLVMValueRef fn_val = get_int_builtin_fn(g, int_type, BuiltinFnIdCtz);
-    LLVMValueRef operand = ir_llvm_value(g, instruction->value);
+    LLVMValueRef operand = ir_llvm_value(g, instruction->op);
     LLVMValueRef params[] {
         operand,
         LLVMConstNull(LLVMInt1Type()),
@@ -4089,9 +4089,9 @@ static LLVMValueRef ir_render_ctz(CodeGen *g, IrExecutable *executable, IrInstru
 }
 
 static LLVMValueRef ir_render_pop_count(CodeGen *g, IrExecutable *executable, IrInstructionPopCount *instruction) {
-    ZigType *int_type = instruction->value->value.type;
+    ZigType *int_type = instruction->op->value.type;
     LLVMValueRef fn_val = get_int_builtin_fn(g, int_type, BuiltinFnIdPopCount);
-    LLVMValueRef operand = ir_llvm_value(g, instruction->value);
+    LLVMValueRef operand = ir_llvm_value(g, instruction->op);
     LLVMValueRef wrong_size_int = LLVMBuildCall(g->builder, fn_val, &operand, 1, "");
     return gen_widen_or_shorten(g, false, int_type, instruction->base.value.type, wrong_size_int);
 }
@@ -7229,9 +7229,9 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdCInclude, "cInclude", 1);
     create_builtin_fn(g, BuiltinFnIdCDefine, "cDefine", 2);
     create_builtin_fn(g, BuiltinFnIdCUndef, "cUndef", 1);
-    create_builtin_fn(g, BuiltinFnIdCtz, "ctz", 1);
-    create_builtin_fn(g, BuiltinFnIdClz, "clz", 1);
-    create_builtin_fn(g, BuiltinFnIdPopCount, "popCount", 1);
+    create_builtin_fn(g, BuiltinFnIdCtz, "ctz", 2);
+    create_builtin_fn(g, BuiltinFnIdClz, "clz", 2);
+    create_builtin_fn(g, BuiltinFnIdPopCount, "popCount", 2);
     create_builtin_fn(g, BuiltinFnIdImport, "import", 1);
     create_builtin_fn(g, BuiltinFnIdCImport, "cImport", 1);
     create_builtin_fn(g, BuiltinFnIdErrName, "errorName", 1);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7292,8 +7292,8 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdToBytes, "sliceToBytes", 1);
     create_builtin_fn(g, BuiltinFnIdFromBytes, "bytesToSlice", 2);
     create_builtin_fn(g, BuiltinFnIdThis, "This", 0);
-    create_builtin_fn(g, BuiltinFnIdBswap, "bswap", 2);
-    create_builtin_fn(g, BuiltinFnIdBitReverse, "bitreverse", 2);
+    create_builtin_fn(g, BuiltinFnIdBswap, "bSwap", 2);
+    create_builtin_fn(g, BuiltinFnIdBitReverse, "bitReverse", 2);
 }
 
 static const char *bool_to_str(bool b) {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -22672,7 +22672,7 @@ static IrInstruction *ir_analyze_instruction_bswap(IrAnalyze *ira, IrInstruction
 
     if (int_type->data.integral.bit_count % 8 != 0) {
         ir_add_error(ira, instruction->type,
-            buf_sprintf("@bswap integer type '%s' has %" PRIu32 " bits which is not evenly divisible by 8",
+            buf_sprintf("@bSwap integer type '%s' has %" PRIu32 " bits which is not evenly divisible by 8",
                 buf_ptr(&int_type->name), int_type->data.integral.bit_count));
         return ira->codegen->invalid_instruction;
     }

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1417,7 +1417,7 @@ static void ir_print_decl_var_gen(IrPrint *irp, IrInstructionDeclVarGen *decl_va
 }
 
 static void ir_print_bswap(IrPrint *irp, IrInstructionBswap *instruction) {
-    fprintf(irp->f, "@bswap(");
+    fprintf(irp->f, "@bSwap(");
     if (instruction->type != nullptr) {
         ir_print_other_instruction(irp, instruction->type);
     } else {
@@ -1429,7 +1429,7 @@ static void ir_print_bswap(IrPrint *irp, IrInstructionBswap *instruction) {
 }
 
 static void ir_print_bit_reverse(IrPrint *irp, IrInstructionBitReverse *instruction) {
-    fprintf(irp->f, "@bitreverse(");
+    fprintf(irp->f, "@bitReverse(");
     if (instruction->type != nullptr) {
         ir_print_other_instruction(irp, instruction->type);
     } else {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -504,19 +504,37 @@ static void ir_print_optional_unwrap_ptr(IrPrint *irp, IrInstructionOptionalUnwr
 
 static void ir_print_clz(IrPrint *irp, IrInstructionClz *instruction) {
     fprintf(irp->f, "@clz(");
-    ir_print_other_instruction(irp, instruction->value);
+    if (instruction->type != nullptr) {
+        ir_print_other_instruction(irp, instruction->type);
+    } else {
+        fprintf(irp->f, "null");
+    }
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->op);
     fprintf(irp->f, ")");
 }
 
 static void ir_print_ctz(IrPrint *irp, IrInstructionCtz *instruction) {
     fprintf(irp->f, "@ctz(");
-    ir_print_other_instruction(irp, instruction->value);
+    if (instruction->type != nullptr) {
+        ir_print_other_instruction(irp, instruction->type);
+    } else {
+        fprintf(irp->f, "null");
+    }
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->op);
     fprintf(irp->f, ")");
 }
 
 static void ir_print_pop_count(IrPrint *irp, IrInstructionPopCount *instruction) {
     fprintf(irp->f, "@popCount(");
-    ir_print_other_instruction(irp, instruction->value);
+    if (instruction->type != nullptr) {
+        ir_print_other_instruction(irp, instruction->type);
+    } else {
+        fprintf(irp->f, "null");
+    }
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->op);
     fprintf(irp->f, ")");
 }
 

--- a/std/heap.zig
+++ b/std/heap.zig
@@ -591,7 +591,7 @@ fn testAllocatorLargeAlignment(allocator: *mem.Allocator) mem.Allocator.Error!vo
     const large_align = u29(os.page_size << 2);
 
     var align_mask: usize = undefined;
-    _ = @shlWithOverflow(usize, ~usize(0), USizeShift(@ctz(large_align)), &align_mask);
+    _ = @shlWithOverflow(usize, ~usize(0), USizeShift(@ctz(u29, large_align)), &align_mask);
 
     var slice = try allocator.alignedAlloc(u8, large_align, 500);
     testing.expect(@ptrToInt(slice.ptr) & align_mask == @ptrToInt(slice.ptr));

--- a/std/math.zig
+++ b/std/math.zig
@@ -698,7 +698,7 @@ test "math.floorPowerOfTwo" {
 
 pub fn log2_int(comptime T: type, x: T) Log2Int(T) {
     assert(x != 0);
-    return @intCast(Log2Int(T), T.bit_count - 1 - @clz(x));
+    return @intCast(Log2Int(T), T.bit_count - 1 - @clz(T, x));
 }
 
 pub fn log2_int_ceil(comptime T: type, x: T) Log2Int(T) {

--- a/std/math/big/int.zig
+++ b/std/math/big/int.zig
@@ -121,7 +121,7 @@ pub const Int = struct {
 
     // Returns the number of bits required to represent the absolute value of self.
     fn bitCountAbs(self: Int) usize {
-        return (self.len - 1) * Limb.bit_count + (Limb.bit_count - @clz(self.limbs[self.len - 1]));
+        return (self.len - 1) * Limb.bit_count + (Limb.bit_count - @clz(Limb, self.limbs[self.len - 1]));
     }
 
     // Returns the number of bits required to represent the integer in twos-complement form.
@@ -853,7 +853,7 @@ pub const Int = struct {
         defer tmp.deinit();
 
         // Normalize so y > Limb.bit_count / 2 (i.e. leading bit is set)
-        const norm_shift = @clz(y.limbs[y.len - 1]);
+        const norm_shift = @clz(Limb, y.limbs[y.len - 1]);
         try x.shiftLeft(x.*, norm_shift);
         try y.shiftLeft(y.*, norm_shift);
 

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -519,7 +519,7 @@ pub fn readIntNative(comptime T: type, bytes: *const [@divExact(T.bit_count, 8)]
 /// This function cannot fail and cannot cause undefined behavior.
 /// Assumes the endianness of memory is foreign, so it must byte-swap.
 pub fn readIntForeign(comptime T: type, bytes: *const [@divExact(T.bit_count, 8)]u8) T {
-    return @bswap(T, readIntNative(T, bytes));
+    return @bSwap(T, readIntNative(T, bytes));
 }
 
 pub const readIntLittle = switch (builtin.endian) {
@@ -549,7 +549,7 @@ pub fn readIntSliceNative(comptime T: type, bytes: []const u8) T {
 /// The bit count of T must be evenly divisible by 8.
 /// Assumes the endianness of memory is foreign, so it must byte-swap.
 pub fn readIntSliceForeign(comptime T: type, bytes: []const u8) T {
-    return @bswap(T, readIntSliceNative(T, bytes));
+    return @bSwap(T, readIntSliceNative(T, bytes));
 }
 
 pub const readIntSliceLittle = switch (builtin.endian) {
@@ -630,9 +630,9 @@ pub fn writeIntNative(comptime T: type, buf: *[(T.bit_count + 7) / 8]u8, value: 
 /// Writes an integer to memory, storing it in twos-complement.
 /// This function always succeeds, has defined behavior for all inputs, but
 /// the integer bit width must be divisible by 8.
-/// This function stores in foreign endian, which means it does a @bswap first.
+/// This function stores in foreign endian, which means it does a @bSwap first.
 pub fn writeIntForeign(comptime T: type, buf: *[@divExact(T.bit_count, 8)]u8, value: T) void {
-    writeIntNative(T, buf, @bswap(T, value));
+    writeIntNative(T, buf, @bSwap(T, value));
 }
 
 pub const writeIntLittle = switch (builtin.endian) {
@@ -1235,14 +1235,14 @@ test "std.mem.rotate" {
 pub fn littleToNative(comptime T: type, x: T) T {
     return switch (builtin.endian) {
         builtin.Endian.Little => x,
-        builtin.Endian.Big => @bswap(T, x),
+        builtin.Endian.Big => @bSwap(T, x),
     };
 }
 
 /// Converts a big-endian integer to host endianness.
 pub fn bigToNative(comptime T: type, x: T) T {
     return switch (builtin.endian) {
-        builtin.Endian.Little => @bswap(T, x),
+        builtin.Endian.Little => @bSwap(T, x),
         builtin.Endian.Big => x,
     };
 }
@@ -1267,14 +1267,14 @@ pub fn nativeTo(comptime T: type, x: T, desired_endianness: builtin.Endian) T {
 pub fn nativeToLittle(comptime T: type, x: T) T {
     return switch (builtin.endian) {
         builtin.Endian.Little => x,
-        builtin.Endian.Big => @bswap(T, x),
+        builtin.Endian.Big => @bSwap(T, x),
     };
 }
 
 /// Converts an integer which has host endianness to big endian.
 pub fn nativeToBig(comptime T: type, x: T) T {
     return switch (builtin.endian) {
-        builtin.Endian.Little => @bswap(T, x),
+        builtin.Endian.Little => @bSwap(T, x),
         builtin.Endian.Big => x,
     };
 }

--- a/std/special/compiler_rt.zig
+++ b/std/special/compiler_rt.zig
@@ -321,7 +321,7 @@ extern fn __udivsi3(n: u32, d: u32) u32 {
     // special cases
     if (d == 0) return 0; // ?!
     if (n == 0) return 0;
-    var sr = @bitCast(c_uint, c_int(@clz(d)) - c_int(@clz(n)));
+    var sr = @bitCast(c_uint, c_int(@clz(u32, d)) - c_int(@clz(u32, n)));
     // 0 <= sr <= n_uword_bits - 1 or sr large
     if (sr > n_uword_bits - 1) {
         // d > r

--- a/std/special/compiler_rt/addXf3.zig
+++ b/std/special/compiler_rt/addXf3.zig
@@ -20,7 +20,7 @@ inline fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)
     const significandBits = std.math.floatMantissaBits(T);
     const implicitBit = Z(1) << significandBits;
 
-    const shift = @clz(significand.*) - @clz(implicitBit);
+    const shift = @clz(@typeOf(significand.*), significand.*) - @clz(@typeOf(implicitBit), implicitBit);
     significand.* <<= @intCast(u7, shift);
     return 1 - shift;
 }
@@ -140,7 +140,7 @@ inline fn addXf3(comptime T: type, a: T, b: T) T {
         // If partial cancellation occured, we need to left-shift the result
         // and adjust the exponent:
         if (aSignificand < implicitBit << 3) {
-            const shift = @intCast(i32, @clz(aSignificand)) - @intCast(i32, @clz(implicitBit << 3));
+            const shift = @intCast(i32, @clz(Z, aSignificand)) - @intCast(i32, @clz(Z, implicitBit << 3));
             aSignificand <<= @intCast(u7, shift);
             aExponent -= shift;
         }

--- a/std/special/compiler_rt/extendXfYf2.zig
+++ b/std/special/compiler_rt/extendXfYf2.zig
@@ -69,7 +69,7 @@ inline fn extendXfYf2(comptime dst_t: type, comptime src_t: type, a: src_t) dst_
         // a is denormal.
         // renormalize the significand and clear the leading bit, then insert
         // the correct adjusted exponent in the destination type.
-        const scale: u32 = @clz(aAbs) - @clz(src_rep_t(srcMinNormal));
+        const scale: u32 = @clz(src_rep_t, aAbs) - @clz(src_rep_t, src_rep_t(srcMinNormal));
         absResult = dst_rep_t(aAbs) << @intCast(DstShift, dstSigBits - srcSigBits + scale);
         absResult ^= dstMinNormal;
         const resultExponent: u32 = dstExpBias - srcExpBias - scale + 1;

--- a/std/special/compiler_rt/floattidf.zig
+++ b/std/special/compiler_rt/floattidf.zig
@@ -17,7 +17,7 @@ pub extern fn __floattidf(arg: i128) f64 {
     ai = ((ai ^ si) -% si);
     var a = @bitCast(u128, ai);
 
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
     if (sd > DBL_MANT_DIG) {
         //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx

--- a/std/special/compiler_rt/floattisf.zig
+++ b/std/special/compiler_rt/floattisf.zig
@@ -17,7 +17,7 @@ pub extern fn __floattisf(arg: i128) f32 {
     ai = ((ai ^ si) -% si);
     var a = @bitCast(u128, ai);
 
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
 
     if (sd > FLT_MANT_DIG) {

--- a/std/special/compiler_rt/floattitf.zig
+++ b/std/special/compiler_rt/floattitf.zig
@@ -17,7 +17,7 @@ pub extern fn __floattitf(arg: i128) f128 {
     ai = ((ai ^ si) -% si);
     var a = @bitCast(u128, ai);
 
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
     if (sd > LDBL_MANT_DIG) {
         //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx

--- a/std/special/compiler_rt/floatunditf.zig
+++ b/std/special/compiler_rt/floatunditf.zig
@@ -14,7 +14,7 @@ pub extern fn __floatunditf(a: u128) f128 {
     const exponent_bias = (1 << (exponent_bits - 1)) - 1;
     const implicit_bit = 1 << mantissa_bits;
 
-    const exp = (u128.bit_count - 1) - @clz(a);
+    const exp = (u128.bit_count - 1) - @clz(u128, a);
     const shift = mantissa_bits - @intCast(u7, exp);
 
     var result: u128 align(16) = (a << shift) ^ implicit_bit;

--- a/std/special/compiler_rt/floatunsitf.zig
+++ b/std/special/compiler_rt/floatunsitf.zig
@@ -14,7 +14,7 @@ pub extern fn __floatunsitf(a: u64) f128 {
     const exponent_bias = (1 << (exponent_bits - 1)) - 1;
     const implicit_bit = 1 << mantissa_bits;
 
-    const exp = (u64.bit_count - 1) - @clz(a);
+    const exp = (u64.bit_count - 1) - @clz(u64, a);
     const shift = mantissa_bits - @intCast(u7, exp);
 
     // TODO(#1148): @bitCast alignment error

--- a/std/special/compiler_rt/floatuntidf.zig
+++ b/std/special/compiler_rt/floatuntidf.zig
@@ -13,7 +13,7 @@ pub extern fn __floatuntidf(arg: u128) f64 {
 
     var a = arg;
     const N: u32 = @sizeOf(u128) * 8;
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
     if (sd > DBL_MANT_DIG) {
         //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx

--- a/std/special/compiler_rt/floatuntisf.zig
+++ b/std/special/compiler_rt/floatuntisf.zig
@@ -13,7 +13,7 @@ pub extern fn __floatuntisf(arg: u128) f32 {
 
     var a = arg;
     const N: u32 = @sizeOf(u128) * 8;
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
     if (sd > FLT_MANT_DIG) {
         //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx

--- a/std/special/compiler_rt/floatuntitf.zig
+++ b/std/special/compiler_rt/floatuntitf.zig
@@ -13,7 +13,7 @@ pub extern fn __floatuntitf(arg: u128) f128 {
 
     var a = arg;
     const N: u32 = @sizeOf(u128) * 8;
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
     if (sd > LDBL_MANT_DIG) {
         //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx

--- a/std/special/compiler_rt/mulXf3.zig
+++ b/std/special/compiler_rt/mulXf3.zig
@@ -257,7 +257,7 @@ fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     const significandBits = std.math.floatMantissaBits(T);
     const implicitBit = Z(1) << significandBits;
 
-    const shift = @clz(significand.*) - @clz(implicitBit);
+    const shift = @clz(@typeOf(significand.*), significand.*) - @clz(@typeOf(implicitBit), implicitBit);
     significand.* <<= @intCast(std.math.Log2Int(Z), shift);
     return 1 - shift;
 }

--- a/std/special/compiler_rt/udivmod.zig
+++ b/std/special/compiler_rt/udivmod.zig
@@ -71,12 +71,12 @@ pub fn udivmod(comptime DoubleInt: type, a: DoubleInt, b: DoubleInt, maybe_rem: 
                 r[high] = n[high] & (d[high] - 1);
                 rem.* = @ptrCast(*align(@alignOf(SingleInt)) DoubleInt, &r[0]).*; // TODO issue #421
             }
-            return n[high] >> @intCast(Log2SingleInt, @ctz(d[high]));
+            return n[high] >> @intCast(Log2SingleInt, @ctz(SingleInt, d[high]));
         }
         // K K
         // ---
         // K 0
-        sr = @bitCast(c_uint, c_int(@clz(d[high])) - c_int(@clz(n[high])));
+        sr = @bitCast(c_uint, c_int(@clz(SingleInt, d[high])) - c_int(@clz(SingleInt, n[high])));
         // 0 <= sr <= SingleInt.bit_count - 2 or sr large
         if (sr > SingleInt.bit_count - 2) {
             if (maybe_rem) |rem| {
@@ -106,7 +106,7 @@ pub fn udivmod(comptime DoubleInt: type, a: DoubleInt, b: DoubleInt, maybe_rem: 
                 if (d[low] == 1) {
                     return a;
                 }
-                sr = @ctz(d[low]);
+                sr = @ctz(SingleInt, d[low]);
                 q[high] = n[high] >> @intCast(Log2SingleInt, sr);
                 q[low] = (n[high] << @intCast(Log2SingleInt, SingleInt.bit_count - sr)) | (n[low] >> @intCast(Log2SingleInt, sr));
                 return @ptrCast(*align(@alignOf(SingleInt)) DoubleInt, &q[0]).*; // TODO issue #421
@@ -114,7 +114,7 @@ pub fn udivmod(comptime DoubleInt: type, a: DoubleInt, b: DoubleInt, maybe_rem: 
             // K X
             // ---
             // 0 K
-            sr = 1 + SingleInt.bit_count + c_uint(@clz(d[low])) - c_uint(@clz(n[high]));
+            sr = 1 + SingleInt.bit_count + c_uint(@clz(SingleInt, d[low])) - c_uint(@clz(SingleInt, n[high]));
             // 2 <= sr <= DoubleInt.bit_count - 1
             // q.all = a << (DoubleInt.bit_count - sr);
             // r.all = a >> sr;
@@ -140,7 +140,7 @@ pub fn udivmod(comptime DoubleInt: type, a: DoubleInt, b: DoubleInt, maybe_rem: 
             // K X
             // ---
             // K K
-            sr = @bitCast(c_uint, c_int(@clz(d[high])) - c_int(@clz(n[high])));
+            sr = @bitCast(c_uint, c_int(@clz(SingleInt, d[high])) - c_int(@clz(SingleInt, n[high])));
             // 0 <= sr <= SingleInt.bit_count - 1 or sr large
             if (sr > SingleInt.bit_count - 1) {
                 if (maybe_rem) |rem| {

--- a/std/special/fmt/arg.zig
+++ b/std/special/fmt/arg.zig
@@ -1,0 +1,293 @@
+const std = @import("std");
+const debug = std.debug;
+const testing = std.testing;
+const mem = std.mem;
+
+const Allocator = mem.Allocator;
+const ArrayList = std.ArrayList;
+const HashMap = std.HashMap;
+
+fn trimStart(slice: []const u8, ch: u8) []const u8 {
+    var i: usize = 0;
+    for (slice) |b| {
+        if (b != '-') break;
+        i += 1;
+    }
+
+    return slice[i..];
+}
+
+fn argInAllowedSet(maybe_set: ?[]const []const u8, arg: []const u8) bool {
+    if (maybe_set) |set| {
+        for (set) |possible| {
+            if (mem.eql(u8, arg, possible)) {
+                return true;
+            }
+        }
+        return false;
+    } else {
+        return true;
+    }
+}
+
+// Modifies the current argument index during iteration
+fn readFlagArguments(allocator: *Allocator, args: []const []const u8, required: usize, allowed_set: ?[]const []const u8, index: *usize) !FlagArg {
+    switch (required) {
+        0 => return FlagArg{ .None = undefined }, // TODO: Required to force non-tag but value?
+        1 => {
+            if (index.* + 1 >= args.len) {
+                return error.MissingFlagArguments;
+            }
+
+            index.* += 1;
+            const arg = args[index.*];
+
+            if (!argInAllowedSet(allowed_set, arg)) {
+                return error.ArgumentNotInAllowedSet;
+            }
+
+            return FlagArg{ .Single = arg };
+        },
+        else => |needed| {
+            var extra = ArrayList([]const u8).init(allocator);
+            errdefer extra.deinit();
+
+            var j: usize = 0;
+            while (j < needed) : (j += 1) {
+                if (index.* + 1 >= args.len) {
+                    return error.MissingFlagArguments;
+                }
+
+                index.* += 1;
+                const arg = args[index.*];
+
+                if (!argInAllowedSet(allowed_set, arg)) {
+                    return error.ArgumentNotInAllowedSet;
+                }
+
+                try extra.append(arg);
+            }
+
+            return FlagArg{ .Many = extra };
+        },
+    }
+}
+
+const HashMapFlags = HashMap([]const u8, FlagArg, std.hash.Fnv1a_32.hash, mem.eql_slice_u8);
+
+// A store for querying found flags and positional arguments.
+pub const Args = struct {
+    flags: HashMapFlags,
+    positionals: ArrayList([]const u8),
+
+    pub fn parse(allocator: *Allocator, comptime spec: []const Flag, args: []const []const u8) !Args {
+        var parsed = Args{
+            .flags = HashMapFlags.init(allocator),
+            .positionals = ArrayList([]const u8).init(allocator),
+        };
+
+        var i: usize = 0;
+        next: while (i < args.len) : (i += 1) {
+            const arg = args[i];
+
+            if (arg.len != 0 and arg[0] == '-') {
+                // TODO: hashmap, although the linear scan is okay for small argument sets as is
+                for (spec) |flag| {
+                    if (mem.eql(u8, arg, flag.name)) {
+                        const flag_name_trimmed = trimStart(flag.name, '-');
+                        const flag_args = readFlagArguments(allocator, args, flag.required, flag.allowed_set, &i) catch |err| {
+                            switch (err) {
+                                error.ArgumentNotInAllowedSet => {
+                                    std.debug.warn("argument '{}' is invalid for flag '{}'\n", args[i], arg);
+                                    std.debug.warn("allowed options are ");
+                                    for (flag.allowed_set.?) |possible| {
+                                        std.debug.warn("'{}' ", possible);
+                                    }
+                                    std.debug.warn("\n");
+                                },
+                                error.MissingFlagArguments => {
+                                    std.debug.warn("missing argument for flag: {}\n", arg);
+                                },
+                                else => {},
+                            }
+
+                            return err;
+                        };
+
+                        if (flag.mergable) {
+                            var prev = if (parsed.flags.get(flag_name_trimmed)) |entry| entry.value.Many else ArrayList([]const u8).init(allocator);
+
+                            // MergeN creation disallows 0 length flag entry (doesn't make sense)
+                            switch (flag_args) {
+                                FlagArg.None => unreachable,
+                                FlagArg.Single => |inner| try prev.append(inner),
+                                FlagArg.Many => |inner| try prev.appendSlice(inner.toSliceConst()),
+                            }
+
+                            _ = try parsed.flags.put(flag_name_trimmed, FlagArg{ .Many = prev });
+                        } else {
+                            _ = try parsed.flags.put(flag_name_trimmed, flag_args);
+                        }
+
+                        continue :next;
+                    }
+                }
+
+                // TODO: Better errors with context, global error state and return is sufficient.
+                std.debug.warn("could not match flag: {}\n", arg);
+                return error.UnknownFlag;
+            } else {
+                try parsed.positionals.append(arg);
+            }
+        }
+
+        return parsed;
+    }
+
+    pub fn deinit(self: *Args) void {
+        self.flags.deinit();
+        self.positionals.deinit();
+    }
+
+    // e.g. --help
+    pub fn present(self: *const Args, name: []const u8) bool {
+        return self.flags.contains(name);
+    }
+
+    // e.g. --name value
+    pub fn single(self: *Args, name: []const u8) ?[]const u8 {
+        if (self.flags.get(name)) |entry| {
+            switch (entry.value) {
+                FlagArg.Single => |inner| {
+                    return inner;
+                },
+                else => @panic("attempted to retrieve flag with wrong type"),
+            }
+        } else {
+            return null;
+        }
+    }
+
+    // e.g. --names value1 value2 value3
+    pub fn many(self: *Args, name: []const u8) []const []const u8 {
+        if (self.flags.get(name)) |entry| {
+            switch (entry.value) {
+                FlagArg.Many => |inner| {
+                    return inner.toSliceConst();
+                },
+                else => @panic("attempted to retrieve flag with wrong type"),
+            }
+        } else {
+            return []const []const u8{};
+        }
+    }
+};
+
+// Arguments for a flag. e.g. arg1, arg2 in `--command arg1 arg2`.
+const FlagArg = union(enum) {
+    None,
+    Single: []const u8,
+    Many: ArrayList([]const u8),
+};
+
+// Specification for how a flag should be parsed.
+pub const Flag = struct {
+    name: []const u8,
+    required: usize,
+    mergable: bool,
+    allowed_set: ?[]const []const u8,
+
+    pub fn Bool(comptime name: []const u8) Flag {
+        return ArgN(name, 0);
+    }
+
+    pub fn Arg1(comptime name: []const u8) Flag {
+        return ArgN(name, 1);
+    }
+
+    pub fn ArgN(comptime name: []const u8, comptime n: usize) Flag {
+        return Flag{
+            .name = name,
+            .required = n,
+            .mergable = false,
+            .allowed_set = null,
+        };
+    }
+
+    pub fn ArgMergeN(comptime name: []const u8, comptime n: usize) Flag {
+        if (n == 0) {
+            @compileError("n must be greater than 0");
+        }
+
+        return Flag{
+            .name = name,
+            .required = n,
+            .mergable = true,
+            .allowed_set = null,
+        };
+    }
+
+    pub fn Option(comptime name: []const u8, comptime set: []const []const u8) Flag {
+        return Flag{
+            .name = name,
+            .required = 1,
+            .mergable = false,
+            .allowed_set = set,
+        };
+    }
+};
+
+test "parse arguments" {
+    const spec1 = comptime []const Flag{
+        Flag.Bool("--help"),
+        Flag.Bool("--init"),
+        Flag.Arg1("--build-file"),
+        Flag.Option("--color", []const []const u8{
+            "on",
+            "off",
+            "auto",
+        }),
+        Flag.ArgN("--pkg-begin", 2),
+        Flag.ArgMergeN("--object", 1),
+        Flag.ArgN("--library", 1),
+    };
+
+    const cliargs = []const []const u8{
+        "build",
+        "--help",
+        "pos1",
+        "--build-file",
+        "build.zig",
+        "--object",
+        "obj1",
+        "--object",
+        "obj2",
+        "--library",
+        "lib1",
+        "--library",
+        "lib2",
+        "--color",
+        "on",
+        "pos2",
+    };
+
+    var args = try Args.parse(std.debug.global_allocator, spec1, cliargs);
+
+    testing.expect(args.present("help"));
+    testing.expect(!args.present("help2"));
+    testing.expect(!args.present("init"));
+
+    testing.expect(mem.eql(u8, args.single("build-file").?, "build.zig"));
+    testing.expect(mem.eql(u8, args.single("color").?, "on"));
+
+    const objects = args.many("object").?;
+    testing.expect(mem.eql(u8, objects[0], "obj1"));
+    testing.expect(mem.eql(u8, objects[1], "obj2"));
+
+    testing.expect(mem.eql(u8, args.single("library").?, "lib2"));
+
+    const pos = args.positionals.toSliceConst();
+    testing.expect(mem.eql(u8, pos[0], "build"));
+    testing.expect(mem.eql(u8, pos[1], "pos1"));
+    testing.expect(mem.eql(u8, pos[2], "pos2"));
+}

--- a/std/special/fmt/errmsg.zig
+++ b/std/special/fmt/errmsg.zig
@@ -1,0 +1,288 @@
+const std = @import("std");
+const mem = std.mem;
+const os = std.os;
+const Token = std.zig.Token;
+const ast = std.zig.ast;
+const TokenIndex = std.zig.ast.TokenIndex;
+const Compilation = @import("compilation.zig").Compilation;
+const Scope = @import("scope.zig").Scope;
+
+pub const Color = enum {
+    Auto,
+    Off,
+    On,
+};
+
+pub const Span = struct {
+    first: ast.TokenIndex,
+    last: ast.TokenIndex,
+
+    pub fn token(i: TokenIndex) Span {
+        return Span{
+            .first = i,
+            .last = i,
+        };
+    }
+
+    pub fn node(n: *ast.Node) Span {
+        return Span{
+            .first = n.firstToken(),
+            .last = n.lastToken(),
+        };
+    }
+};
+
+pub const Msg = struct {
+    text: []u8,
+    realpath: []u8,
+    data: Data,
+
+    const Data = union(enum) {
+        Cli: Cli,
+        PathAndTree: PathAndTree,
+        ScopeAndComp: ScopeAndComp,
+    };
+
+    const PathAndTree = struct {
+        span: Span,
+        tree: *ast.Tree,
+        allocator: *mem.Allocator,
+    };
+
+    const ScopeAndComp = struct {
+        span: Span,
+        tree_scope: *Scope.AstTree,
+        compilation: *Compilation,
+    };
+
+    const Cli = struct {
+        allocator: *mem.Allocator,
+    };
+
+    pub fn destroy(self: *Msg) void {
+        switch (self.data) {
+            Data.Cli => |cli| {
+                cli.allocator.free(self.text);
+                cli.allocator.free(self.realpath);
+                cli.allocator.destroy(self);
+            },
+            Data.PathAndTree => |path_and_tree| {
+                path_and_tree.allocator.free(self.text);
+                path_and_tree.allocator.free(self.realpath);
+                path_and_tree.allocator.destroy(self);
+            },
+            Data.ScopeAndComp => |scope_and_comp| {
+                scope_and_comp.tree_scope.base.deref(scope_and_comp.compilation);
+                scope_and_comp.compilation.gpa().free(self.text);
+                scope_and_comp.compilation.gpa().free(self.realpath);
+                scope_and_comp.compilation.gpa().destroy(self);
+            },
+        }
+    }
+
+    fn getAllocator(self: *const Msg) *mem.Allocator {
+        switch (self.data) {
+            Data.Cli => |cli| return cli.allocator,
+            Data.PathAndTree => |path_and_tree| {
+                return path_and_tree.allocator;
+            },
+            Data.ScopeAndComp => |scope_and_comp| {
+                return scope_and_comp.compilation.gpa();
+            },
+        }
+    }
+
+    pub fn getTree(self: *const Msg) *ast.Tree {
+        switch (self.data) {
+            Data.Cli => unreachable,
+            Data.PathAndTree => |path_and_tree| {
+                return path_and_tree.tree;
+            },
+            Data.ScopeAndComp => |scope_and_comp| {
+                return scope_and_comp.tree_scope.tree;
+            },
+        }
+    }
+
+    pub fn getSpan(self: *const Msg) Span {
+        return switch (self.data) {
+            Data.Cli => unreachable,
+            Data.PathAndTree => |path_and_tree| path_and_tree.span,
+            Data.ScopeAndComp => |scope_and_comp| scope_and_comp.span,
+        };
+    }
+
+    /// Takes ownership of text
+    /// References tree_scope, and derefs when the msg is freed
+    pub fn createFromScope(comp: *Compilation, tree_scope: *Scope.AstTree, span: Span, text: []u8) !*Msg {
+        const realpath = try mem.dupe(comp.gpa(), u8, tree_scope.root().realpath);
+        errdefer comp.gpa().free(realpath);
+
+        const msg = try comp.gpa().create(Msg);
+        msg.* = Msg{
+            .text = text,
+            .realpath = realpath,
+            .data = Data{
+                .ScopeAndComp = ScopeAndComp{
+                    .tree_scope = tree_scope,
+                    .compilation = comp,
+                    .span = span,
+                },
+            },
+        };
+        tree_scope.base.ref();
+        return msg;
+    }
+
+    /// Caller owns returned Msg and must free with `allocator`
+    /// allocator will additionally be used for printing messages later.
+    pub fn createFromCli(comp: *Compilation, realpath: []const u8, text: []u8) !*Msg {
+        const realpath_copy = try mem.dupe(comp.gpa(), u8, realpath);
+        errdefer comp.gpa().free(realpath_copy);
+
+        const msg = try comp.gpa().create(Msg);
+        msg.* = Msg{
+            .text = text,
+            .realpath = realpath_copy,
+            .data = Data{
+                .Cli = Cli{ .allocator = comp.gpa() },
+            },
+        };
+        return msg;
+    }
+
+    pub fn createFromParseErrorAndScope(
+        comp: *Compilation,
+        tree_scope: *Scope.AstTree,
+        parse_error: *const ast.Error,
+    ) !*Msg {
+        const loc_token = parse_error.loc();
+        var text_buf = try std.Buffer.initSize(comp.gpa(), 0);
+        defer text_buf.deinit();
+
+        const realpath_copy = try mem.dupe(comp.gpa(), u8, tree_scope.root().realpath);
+        errdefer comp.gpa().free(realpath_copy);
+
+        var out_stream = &std.io.BufferOutStream.init(&text_buf).stream;
+        try parse_error.render(&tree_scope.tree.tokens, out_stream);
+
+        const msg = try comp.gpa().create(Msg);
+        msg.* = Msg{
+            .text = undefined,
+            .realpath = realpath_copy,
+            .data = Data{
+                .ScopeAndComp = ScopeAndComp{
+                    .tree_scope = tree_scope,
+                    .compilation = comp,
+                    .span = Span{
+                        .first = loc_token,
+                        .last = loc_token,
+                    },
+                },
+            },
+        };
+        tree_scope.base.ref();
+        msg.text = text_buf.toOwnedSlice();
+        return msg;
+    }
+
+    /// `realpath` must outlive the returned Msg
+    /// `tree` must outlive the returned Msg
+    /// Caller owns returned Msg and must free with `allocator`
+    /// allocator will additionally be used for printing messages later.
+    pub fn createFromParseError(
+        allocator: *mem.Allocator,
+        parse_error: *const ast.Error,
+        tree: *ast.Tree,
+        realpath: []const u8,
+    ) !*Msg {
+        const loc_token = parse_error.loc();
+        var text_buf = try std.Buffer.initSize(allocator, 0);
+        defer text_buf.deinit();
+
+        const realpath_copy = try mem.dupe(allocator, u8, realpath);
+        errdefer allocator.free(realpath_copy);
+
+        var out_stream = &std.io.BufferOutStream.init(&text_buf).stream;
+        try parse_error.render(&tree.tokens, out_stream);
+
+        const msg = try allocator.create(Msg);
+        msg.* = Msg{
+            .text = undefined,
+            .realpath = realpath_copy,
+            .data = Data{
+                .PathAndTree = PathAndTree{
+                    .allocator = allocator,
+                    .tree = tree,
+                    .span = Span{
+                        .first = loc_token,
+                        .last = loc_token,
+                    },
+                },
+            },
+        };
+        msg.text = text_buf.toOwnedSlice();
+        errdefer allocator.destroy(msg);
+
+        return msg;
+    }
+
+    pub fn printToStream(msg: *const Msg, stream: var, color_on: bool) !void {
+        switch (msg.data) {
+            Data.Cli => {
+                try stream.print("{}:-:-: error: {}\n", msg.realpath, msg.text);
+                return;
+            },
+            else => {},
+        }
+
+        const allocator = msg.getAllocator();
+        const tree = msg.getTree();
+
+        const cwd = try os.getCwdAlloc(allocator);
+        defer allocator.free(cwd);
+
+        const relpath = try os.path.relative(allocator, cwd, msg.realpath);
+        defer allocator.free(relpath);
+
+        const path = if (relpath.len < msg.realpath.len) relpath else msg.realpath;
+        const span = msg.getSpan();
+
+        const first_token = tree.tokens.at(span.first);
+        const last_token = tree.tokens.at(span.last);
+        const start_loc = tree.tokenLocationPtr(0, first_token);
+        const end_loc = tree.tokenLocationPtr(first_token.end, last_token);
+        if (!color_on) {
+            try stream.print(
+                "{}:{}:{}: error: {}\n",
+                path,
+                start_loc.line + 1,
+                start_loc.column + 1,
+                msg.text,
+            );
+            return;
+        }
+
+        try stream.print(
+            "{}:{}:{}: error: {}\n{}\n",
+            path,
+            start_loc.line + 1,
+            start_loc.column + 1,
+            msg.text,
+            tree.source[start_loc.line_start..start_loc.line_end],
+        );
+        try stream.writeByteNTimes(' ', start_loc.column);
+        try stream.writeByteNTimes('~', last_token.end - first_token.start);
+        try stream.write("\n");
+    }
+
+    pub fn printToFile(msg: *const Msg, file: os.File, color: Color) !void {
+        const color_on = switch (color) {
+            Color.Auto => file.isTty(),
+            Color.On => true,
+            Color.Off => false,
+        };
+        var stream = &file.outStream().stream;
+        return msg.printToStream(stream, color_on);
+    }
+};

--- a/std/special/fmt/main.zig
+++ b/std/special/fmt/main.zig
@@ -1,0 +1,959 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const event = std.event;
+const os = std.os;
+const io = std.io;
+const mem = std.mem;
+const Allocator = mem.Allocator;
+const ArrayList = std.ArrayList;
+const Buffer = std.Buffer;
+
+const arg = @import("arg.zig");
+const c = @import("c.zig");
+const introspect = @import("introspect.zig");
+const Args = arg.Args;
+const Flag = arg.Flag;
+const ZigCompiler = @import("compilation.zig").ZigCompiler;
+const Compilation = @import("compilation.zig").Compilation;
+const Target = @import("target.zig").Target;
+const errmsg = @import("errmsg.zig");
+const LibCInstallation = @import("libc_installation.zig").LibCInstallation;
+
+var stderr_file: os.File = undefined;
+var stderr: *io.OutStream(os.File.WriteError) = undefined;
+var stdout: *io.OutStream(os.File.WriteError) = undefined;
+
+pub const max_src_size = 2 * 1024 * 1024 * 1024; // 2 GiB
+
+const usage =
+    \\usage: zig [command] [options]
+    \\
+    \\Commands:
+    \\
+    \\  build-exe  [source]      Create executable from source or object files
+    \\  build-lib  [source]      Create library from source or object files
+    \\  build-obj  [source]      Create object from source or assembly
+    \\  fmt        [source]      Parse file and render in canonical zig format
+    \\  libc       [paths_file]  Display native libc paths file or validate one
+    \\  targets                  List available compilation targets
+    \\  version                  Print version number and exit
+    \\  zen                      Print zen of zig and exit
+    \\
+    \\
+;
+
+const Command = struct {
+    name: []const u8,
+    exec: fn (*Allocator, []const []const u8) anyerror!void,
+};
+
+pub fn main() !void {
+    // This allocator needs to be thread-safe because we use it for the event.Loop
+    // which multiplexes coroutines onto kernel threads.
+    // libc allocator is guaranteed to have this property.
+    const allocator = std.heap.c_allocator;
+
+    var stdout_file = try std.io.getStdOut();
+    var stdout_out_stream = stdout_file.outStream();
+    stdout = &stdout_out_stream.stream;
+
+    stderr_file = try std.io.getStdErr();
+    var stderr_out_stream = stderr_file.outStream();
+    stderr = &stderr_out_stream.stream;
+
+    const args = try os.argsAlloc(allocator);
+    // TODO I'm getting  unreachable code here, which shouldn't happen
+    //defer os.argsFree(allocator, args);
+
+    if (args.len <= 1) {
+        try stderr.write("expected command argument\n\n");
+        try stderr.write(usage);
+        os.exit(1);
+    }
+
+    const commands = []Command{
+        Command{
+            .name = "build-exe",
+            .exec = cmdBuildExe,
+        },
+        Command{
+            .name = "build-lib",
+            .exec = cmdBuildLib,
+        },
+        Command{
+            .name = "build-obj",
+            .exec = cmdBuildObj,
+        },
+        Command{
+            .name = "fmt",
+            .exec = cmdFmt,
+        },
+        Command{
+            .name = "libc",
+            .exec = cmdLibC,
+        },
+        Command{
+            .name = "targets",
+            .exec = cmdTargets,
+        },
+        Command{
+            .name = "version",
+            .exec = cmdVersion,
+        },
+        Command{
+            .name = "zen",
+            .exec = cmdZen,
+        },
+
+        // undocumented commands
+        Command{
+            .name = "help",
+            .exec = cmdHelp,
+        },
+        Command{
+            .name = "internal",
+            .exec = cmdInternal,
+        },
+    };
+
+    for (commands) |command| {
+        if (mem.eql(u8, command.name, args[1])) {
+            return command.exec(allocator, args[2..]);
+        }
+    }
+
+    try stderr.print("unknown command: {}\n\n", args[1]);
+    try stderr.write(usage);
+    os.exit(1);
+}
+
+const usage_build_generic =
+    \\usage: zig build-exe <options> [file]
+    \\       zig build-lib <options> [file]
+    \\       zig build-obj <options> [file]
+    \\
+    \\General Options:
+    \\  --help                       Print this help and exit
+    \\  --color [auto|off|on]        Enable or disable colored error messages
+    \\
+    \\Compile Options:
+    \\  --libc [file]                Provide a file which specifies libc paths
+    \\  --assembly [source]          Add assembly file to build
+    \\  --emit [filetype]            Emit a specific file format as compilation output
+    \\  --enable-timing-info         Print timing diagnostics
+    \\  --name [name]                Override output name
+    \\  --output [file]              Override destination path
+    \\  --output-h [file]            Override generated header file path
+    \\  --pkg-begin [name] [path]    Make package available to import and push current pkg
+    \\  --pkg-end                    Pop current pkg
+    \\  --mode [mode]                Set the build mode
+    \\    debug                      (default) optimizations off, safety on
+    \\    release-fast               optimizations on, safety off
+    \\    release-safe               optimizations on, safety on
+    \\    release-small              optimize for small binary, safety off
+    \\  --static                     Output will be statically linked
+    \\  --strip                      Exclude debug symbols
+    \\  -target [name]               <arch><sub>-<os>-<abi> see the targets command
+    \\  --verbose-tokenize           Turn on compiler debug output for tokenization
+    \\  --verbose-ast-tree           Turn on compiler debug output for parsing into an AST (tree view)
+    \\  --verbose-ast-fmt            Turn on compiler debug output for parsing into an AST (render source)
+    \\  --verbose-link               Turn on compiler debug output for linking
+    \\  --verbose-ir                 Turn on compiler debug output for Zig IR
+    \\  --verbose-llvm-ir            Turn on compiler debug output for LLVM IR
+    \\  --verbose-cimport            Turn on compiler debug output for C imports
+    \\  -dirafter [dir]              Same as -isystem but do it last
+    \\  -isystem [dir]               Add additional search path for other .h files
+    \\  -mllvm [arg]                 Additional arguments to forward to LLVM's option processing
+    \\
+    \\Link Options:
+    \\  --ar-path [path]             Set the path to ar
+    \\  --each-lib-rpath             Add rpath for each used dynamic library
+    \\  --library [lib]              Link against lib
+    \\  --forbid-library [lib]       Make it an error to link against lib
+    \\  --library-path [dir]         Add a directory to the library search path
+    \\  --linker-script [path]       Use a custom linker script
+    \\  --object [obj]               Add object file to build
+    \\  -rdynamic                    Add all symbols to the dynamic symbol table
+    \\  -rpath [path]                Add directory to the runtime library search path
+    \\  -mconsole                    (windows) --subsystem console to the linker
+    \\  -mwindows                    (windows) --subsystem windows to the linker
+    \\  -framework [name]            (darwin) link against framework
+    \\  -mios-version-min [ver]      (darwin) set iOS deployment target
+    \\  -mmacosx-version-min [ver]   (darwin) set Mac OS X deployment target
+    \\  --ver-major [ver]            Dynamic library semver major version
+    \\  --ver-minor [ver]            Dynamic library semver minor version
+    \\  --ver-patch [ver]            Dynamic library semver patch version
+    \\
+    \\
+;
+
+const args_build_generic = []Flag{
+    Flag.Bool("--help"),
+    Flag.Option("--color", []const []const u8{
+        "auto",
+        "off",
+        "on",
+    }),
+    Flag.Option("--mode", []const []const u8{
+        "debug",
+        "release-fast",
+        "release-safe",
+        "release-small",
+    }),
+
+    Flag.ArgMergeN("--assembly", 1),
+    Flag.Option("--emit", []const []const u8{
+        "asm",
+        "bin",
+        "llvm-ir",
+    }),
+    Flag.Bool("--enable-timing-info"),
+    Flag.Arg1("--libc"),
+    Flag.Arg1("--name"),
+    Flag.Arg1("--output"),
+    Flag.Arg1("--output-h"),
+    // NOTE: Parsed manually after initial check
+    Flag.ArgN("--pkg-begin", 2),
+    Flag.Bool("--pkg-end"),
+    Flag.Bool("--static"),
+    Flag.Bool("--strip"),
+    Flag.Arg1("-target"),
+    Flag.Bool("--verbose-tokenize"),
+    Flag.Bool("--verbose-ast-tree"),
+    Flag.Bool("--verbose-ast-fmt"),
+    Flag.Bool("--verbose-link"),
+    Flag.Bool("--verbose-ir"),
+    Flag.Bool("--verbose-llvm-ir"),
+    Flag.Bool("--verbose-cimport"),
+    Flag.Arg1("-dirafter"),
+    Flag.ArgMergeN("-isystem", 1),
+    Flag.Arg1("-mllvm"),
+
+    Flag.Arg1("--ar-path"),
+    Flag.Bool("--each-lib-rpath"),
+    Flag.ArgMergeN("--library", 1),
+    Flag.ArgMergeN("--forbid-library", 1),
+    Flag.ArgMergeN("--library-path", 1),
+    Flag.Arg1("--linker-script"),
+    Flag.ArgMergeN("--object", 1),
+    // NOTE: Removed -L since it would need to be special-cased and we have an alias in library-path
+    Flag.Bool("-rdynamic"),
+    Flag.Arg1("-rpath"),
+    Flag.Bool("-mconsole"),
+    Flag.Bool("-mwindows"),
+    Flag.ArgMergeN("-framework", 1),
+    Flag.Arg1("-mios-version-min"),
+    Flag.Arg1("-mmacosx-version-min"),
+    Flag.Arg1("--ver-major"),
+    Flag.Arg1("--ver-minor"),
+    Flag.Arg1("--ver-patch"),
+};
+
+fn buildOutputType(allocator: *Allocator, args: []const []const u8, out_type: Compilation.Kind) !void {
+    var flags = try Args.parse(allocator, args_build_generic, args);
+    defer flags.deinit();
+
+    if (flags.present("help")) {
+        try stdout.write(usage_build_generic);
+        os.exit(0);
+    }
+
+    const build_mode = blk: {
+        if (flags.single("mode")) |mode_flag| {
+            if (mem.eql(u8, mode_flag, "debug")) {
+                break :blk builtin.Mode.Debug;
+            } else if (mem.eql(u8, mode_flag, "release-fast")) {
+                break :blk builtin.Mode.ReleaseFast;
+            } else if (mem.eql(u8, mode_flag, "release-safe")) {
+                break :blk builtin.Mode.ReleaseSafe;
+            } else if (mem.eql(u8, mode_flag, "release-small")) {
+                break :blk builtin.Mode.ReleaseSmall;
+            } else unreachable;
+        } else {
+            break :blk builtin.Mode.Debug;
+        }
+    };
+
+    const color = blk: {
+        if (flags.single("color")) |color_flag| {
+            if (mem.eql(u8, color_flag, "auto")) {
+                break :blk errmsg.Color.Auto;
+            } else if (mem.eql(u8, color_flag, "on")) {
+                break :blk errmsg.Color.On;
+            } else if (mem.eql(u8, color_flag, "off")) {
+                break :blk errmsg.Color.Off;
+            } else unreachable;
+        } else {
+            break :blk errmsg.Color.Auto;
+        }
+    };
+
+    const emit_type = blk: {
+        if (flags.single("emit")) |emit_flag| {
+            if (mem.eql(u8, emit_flag, "asm")) {
+                break :blk Compilation.Emit.Assembly;
+            } else if (mem.eql(u8, emit_flag, "bin")) {
+                break :blk Compilation.Emit.Binary;
+            } else if (mem.eql(u8, emit_flag, "llvm-ir")) {
+                break :blk Compilation.Emit.LlvmIr;
+            } else unreachable;
+        } else {
+            break :blk Compilation.Emit.Binary;
+        }
+    };
+
+    var cur_pkg = try CliPkg.init(allocator, "", "", null);
+    defer cur_pkg.deinit();
+
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg_name = args[i];
+        if (mem.eql(u8, "--pkg-begin", arg_name)) {
+            // following two arguments guaranteed to exist due to arg parsing
+            i += 1;
+            const new_pkg_name = args[i];
+            i += 1;
+            const new_pkg_path = args[i];
+
+            var new_cur_pkg = try CliPkg.init(allocator, new_pkg_name, new_pkg_path, cur_pkg);
+            try cur_pkg.children.append(new_cur_pkg);
+            cur_pkg = new_cur_pkg;
+        } else if (mem.eql(u8, "--pkg-end", arg_name)) {
+            if (cur_pkg.parent) |parent| {
+                cur_pkg = parent;
+            } else {
+                try stderr.print("encountered --pkg-end with no matching --pkg-begin\n");
+                os.exit(1);
+            }
+        }
+    }
+
+    if (cur_pkg.parent != null) {
+        try stderr.print("unmatched --pkg-begin\n");
+        os.exit(1);
+    }
+
+    const provided_name = flags.single("name");
+    const root_source_file = switch (flags.positionals.len) {
+        0 => null,
+        1 => flags.positionals.at(0),
+        else => {
+            try stderr.print("unexpected extra parameter: {}\n", flags.positionals.at(1));
+            os.exit(1);
+        },
+    };
+
+    const root_name = if (provided_name) |n| n else blk: {
+        if (root_source_file) |file| {
+            const basename = os.path.basename(file);
+            var it = mem.separate(basename, ".");
+            break :blk it.next() orelse basename;
+        } else {
+            try stderr.write("--name [name] not provided and unable to infer\n");
+            os.exit(1);
+        }
+    };
+
+    const is_static = flags.present("static");
+
+    const assembly_files = flags.many("assembly");
+    const link_objects = flags.many("object");
+    if (root_source_file == null and link_objects.len == 0 and assembly_files.len == 0) {
+        try stderr.write("Expected source file argument or at least one --object or --assembly argument\n");
+        os.exit(1);
+    }
+
+    if (out_type == Compilation.Kind.Obj and link_objects.len != 0) {
+        try stderr.write("When building an object file, --object arguments are invalid\n");
+        os.exit(1);
+    }
+
+    var clang_argv_buf = ArrayList([]const u8).init(allocator);
+    defer clang_argv_buf.deinit();
+
+    const mllvm_flags = flags.many("mllvm");
+    for (mllvm_flags) |mllvm| {
+        try clang_argv_buf.append("-mllvm");
+        try clang_argv_buf.append(mllvm);
+    }
+    try ZigCompiler.setLlvmArgv(allocator, mllvm_flags);
+
+    const zig_lib_dir = introspect.resolveZigLibDir(allocator) catch os.exit(1);
+    defer allocator.free(zig_lib_dir);
+
+    var override_libc: LibCInstallation = undefined;
+
+    var loop: event.Loop = undefined;
+    try loop.initMultiThreaded(allocator);
+    defer loop.deinit();
+
+    var zig_compiler = try ZigCompiler.init(&loop);
+    defer zig_compiler.deinit();
+
+    var comp = try Compilation.create(
+        &zig_compiler,
+        root_name,
+        root_source_file,
+        Target.Native,
+        out_type,
+        build_mode,
+        is_static,
+        zig_lib_dir,
+    );
+    defer comp.destroy();
+
+    if (flags.single("libc")) |libc_path| {
+        parseLibcPaths(loop.allocator, &override_libc, libc_path);
+        comp.override_libc = &override_libc;
+    }
+
+    for (flags.many("library")) |lib| {
+        _ = try comp.addLinkLib(lib, true);
+    }
+
+    comp.version_major = try std.fmt.parseUnsigned(u32, flags.single("ver-major") orelse "0", 10);
+    comp.version_minor = try std.fmt.parseUnsigned(u32, flags.single("ver-minor") orelse "0", 10);
+    comp.version_patch = try std.fmt.parseUnsigned(u32, flags.single("ver-patch") orelse "0", 10);
+
+    comp.is_test = false;
+
+    comp.linker_script = flags.single("linker-script");
+    comp.each_lib_rpath = flags.present("each-lib-rpath");
+
+    comp.clang_argv = clang_argv_buf.toSliceConst();
+
+    comp.strip = flags.present("strip");
+
+    comp.verbose_tokenize = flags.present("verbose-tokenize");
+    comp.verbose_ast_tree = flags.present("verbose-ast-tree");
+    comp.verbose_ast_fmt = flags.present("verbose-ast-fmt");
+    comp.verbose_link = flags.present("verbose-link");
+    comp.verbose_ir = flags.present("verbose-ir");
+    comp.verbose_llvm_ir = flags.present("verbose-llvm-ir");
+    comp.verbose_cimport = flags.present("verbose-cimport");
+
+    comp.err_color = color;
+    comp.lib_dirs = flags.many("library-path");
+    comp.darwin_frameworks = flags.many("framework");
+    comp.rpath_list = flags.many("rpath");
+
+    if (flags.single("output-h")) |output_h| {
+        comp.out_h_path = output_h;
+    }
+
+    comp.windows_subsystem_windows = flags.present("mwindows");
+    comp.windows_subsystem_console = flags.present("mconsole");
+    comp.linker_rdynamic = flags.present("rdynamic");
+
+    if (flags.single("mmacosx-version-min") != null and flags.single("mios-version-min") != null) {
+        try stderr.write("-mmacosx-version-min and -mios-version-min options not allowed together\n");
+        os.exit(1);
+    }
+
+    if (flags.single("mmacosx-version-min")) |ver| {
+        comp.darwin_version_min = Compilation.DarwinVersionMin{ .MacOS = ver };
+    }
+    if (flags.single("mios-version-min")) |ver| {
+        comp.darwin_version_min = Compilation.DarwinVersionMin{ .Ios = ver };
+    }
+
+    comp.emit_file_type = emit_type;
+    comp.assembly_files = assembly_files;
+    comp.link_out_file = flags.single("output");
+    comp.link_objects = link_objects;
+
+    comp.start();
+    const process_build_events_handle = try async<loop.allocator> processBuildEvents(comp, color);
+    defer cancel process_build_events_handle;
+    loop.run();
+}
+
+async fn processBuildEvents(comp: *Compilation, color: errmsg.Color) void {
+    var count: usize = 0;
+    while (true) {
+        // TODO directly awaiting async should guarantee memory allocation elision
+        const build_event = await (async comp.events.get() catch unreachable);
+        count += 1;
+
+        switch (build_event) {
+            Compilation.Event.Ok => {
+                stderr.print("Build {} succeeded\n", count) catch os.exit(1);
+            },
+            Compilation.Event.Error => |err| {
+                stderr.print("Build {} failed: {}\n", count, @errorName(err)) catch os.exit(1);
+            },
+            Compilation.Event.Fail => |msgs| {
+                stderr.print("Build {} compile errors:\n", count) catch os.exit(1);
+                for (msgs) |msg| {
+                    defer msg.destroy();
+                    msg.printToFile(stderr_file, color) catch os.exit(1);
+                }
+            },
+        }
+    }
+}
+
+fn cmdBuildExe(allocator: *Allocator, args: []const []const u8) !void {
+    return buildOutputType(allocator, args, Compilation.Kind.Exe);
+}
+
+fn cmdBuildLib(allocator: *Allocator, args: []const []const u8) !void {
+    return buildOutputType(allocator, args, Compilation.Kind.Lib);
+}
+
+fn cmdBuildObj(allocator: *Allocator, args: []const []const u8) !void {
+    return buildOutputType(allocator, args, Compilation.Kind.Obj);
+}
+
+pub const usage_fmt =
+    \\usage: zig fmt [file]...
+    \\
+    \\   Formats the input files and modifies them in-place.
+    \\   Arguments can be files or directories, which are searched
+    \\   recursively.
+    \\
+    \\Options:
+    \\   --help                 Print this help and exit
+    \\   --color [auto|off|on]  Enable or disable colored error messages
+    \\   --stdin                Format code from stdin; output to stdout
+    \\   --check                List non-conforming files and exit with an error
+    \\                          if the list is non-empty
+    \\
+    \\
+;
+
+pub const args_fmt_spec = []Flag{
+    Flag.Bool("--help"),
+    Flag.Bool("--check"),
+    Flag.Option("--color", []const []const u8{
+        "auto",
+        "off",
+        "on",
+    }),
+    Flag.Bool("--stdin"),
+};
+
+const Fmt = struct {
+    seen: event.Locked(SeenMap),
+    any_error: bool,
+    color: errmsg.Color,
+    loop: *event.Loop,
+
+    const SeenMap = std.HashMap([]const u8, void, mem.hash_slice_u8, mem.eql_slice_u8);
+};
+
+fn parseLibcPaths(allocator: *Allocator, libc: *LibCInstallation, libc_paths_file: []const u8) void {
+    libc.parse(allocator, libc_paths_file, stderr) catch |err| {
+        stderr.print(
+            "Unable to parse libc path file '{}': {}.\n" ++
+                "Try running `zig libc` to see an example for the native target.\n",
+            libc_paths_file,
+            @errorName(err),
+        ) catch os.exit(1);
+        os.exit(1);
+    };
+}
+
+fn cmdLibC(allocator: *Allocator, args: []const []const u8) !void {
+    switch (args.len) {
+        0 => {},
+        1 => {
+            var libc_installation: LibCInstallation = undefined;
+            parseLibcPaths(allocator, &libc_installation, args[0]);
+            return;
+        },
+        else => {
+            try stderr.print("unexpected extra parameter: {}\n", args[1]);
+            os.exit(1);
+        },
+    }
+
+    var loop: event.Loop = undefined;
+    try loop.initMultiThreaded(allocator);
+    defer loop.deinit();
+
+    var zig_compiler = try ZigCompiler.init(&loop);
+    defer zig_compiler.deinit();
+
+    const handle = try async<loop.allocator> findLibCAsync(&zig_compiler);
+    defer cancel handle;
+
+    loop.run();
+}
+
+async fn findLibCAsync(zig_compiler: *ZigCompiler) void {
+    const libc = (await (async zig_compiler.getNativeLibC() catch unreachable)) catch |err| {
+        stderr.print("unable to find libc: {}\n", @errorName(err)) catch os.exit(1);
+        os.exit(1);
+    };
+    libc.render(stdout) catch os.exit(1);
+}
+
+fn cmdFmt(allocator: *Allocator, args: []const []const u8) !void {
+    var flags = try Args.parse(allocator, args_fmt_spec, args);
+    defer flags.deinit();
+
+    if (flags.present("help")) {
+        try stdout.write(usage_fmt);
+        os.exit(0);
+    }
+
+    const color = blk: {
+        if (flags.single("color")) |color_flag| {
+            if (mem.eql(u8, color_flag, "auto")) {
+                break :blk errmsg.Color.Auto;
+            } else if (mem.eql(u8, color_flag, "on")) {
+                break :blk errmsg.Color.On;
+            } else if (mem.eql(u8, color_flag, "off")) {
+                break :blk errmsg.Color.Off;
+            } else unreachable;
+        } else {
+            break :blk errmsg.Color.Auto;
+        }
+    };
+
+    if (flags.present("stdin")) {
+        if (flags.positionals.len != 0) {
+            try stderr.write("cannot use --stdin with positional arguments\n");
+            os.exit(1);
+        }
+
+        var stdin_file = try io.getStdIn();
+        var stdin = stdin_file.inStream();
+
+        const source_code = try stdin.stream.readAllAlloc(allocator, max_src_size);
+        defer allocator.free(source_code);
+
+        var tree = std.zig.parse(allocator, source_code) catch |err| {
+            try stderr.print("error parsing stdin: {}\n", err);
+            os.exit(1);
+        };
+        defer tree.deinit();
+
+        var error_it = tree.errors.iterator(0);
+        while (error_it.next()) |parse_error| {
+            const msg = try errmsg.Msg.createFromParseError(allocator, parse_error, &tree, "<stdin>");
+            defer msg.destroy();
+
+            try msg.printToFile(stderr_file, color);
+        }
+        if (tree.errors.len != 0) {
+            os.exit(1);
+        }
+        if (flags.present("check")) {
+            const anything_changed = try std.zig.render(allocator, io.null_out_stream, &tree);
+            const code = if (anything_changed) u8(1) else u8(0);
+            os.exit(code);
+        }
+
+        _ = try std.zig.render(allocator, stdout, &tree);
+        return;
+    }
+
+    if (flags.positionals.len == 0) {
+        try stderr.write("expected at least one source file argument\n");
+        os.exit(1);
+    }
+
+    var loop: event.Loop = undefined;
+    try loop.initMultiThreaded(allocator);
+    defer loop.deinit();
+
+    var result: FmtError!void = undefined;
+    const main_handle = try async<allocator> asyncFmtMainChecked(
+        &result,
+        &loop,
+        &flags,
+        color,
+    );
+    defer cancel main_handle;
+    loop.run();
+    return result;
+}
+
+async fn asyncFmtMainChecked(
+    result: *(FmtError!void),
+    loop: *event.Loop,
+    flags: *const Args,
+    color: errmsg.Color,
+) void {
+    result.* = await (async asyncFmtMain(loop, flags, color) catch unreachable);
+}
+
+const FmtError = error{
+    SystemResources,
+    OperationAborted,
+    IoPending,
+    BrokenPipe,
+    Unexpected,
+    WouldBlock,
+    FileClosed,
+    DestinationAddressRequired,
+    DiskQuota,
+    FileTooBig,
+    InputOutput,
+    NoSpaceLeft,
+    AccessDenied,
+    OutOfMemory,
+    RenameAcrossMountPoints,
+    ReadOnlyFileSystem,
+    LinkQuotaExceeded,
+    FileBusy,
+} || os.File.OpenError;
+
+async fn asyncFmtMain(
+    loop: *event.Loop,
+    flags: *const Args,
+    color: errmsg.Color,
+) FmtError!void {
+    suspend {
+        resume @handle();
+    }
+    var fmt = Fmt{
+        .seen = event.Locked(Fmt.SeenMap).init(loop, Fmt.SeenMap.init(loop.allocator)),
+        .any_error = false,
+        .color = color,
+        .loop = loop,
+    };
+
+    const check_mode = flags.present("check");
+
+    var group = event.Group(FmtError!void).init(loop);
+    for (flags.positionals.toSliceConst()) |file_path| {
+        try group.call(fmtPath, &fmt, file_path, check_mode);
+    }
+    try await (async group.wait() catch unreachable);
+    if (fmt.any_error) {
+        os.exit(1);
+    }
+}
+
+async fn fmtPath(fmt: *Fmt, file_path_ref: []const u8, check_mode: bool) FmtError!void {
+    const file_path = try std.mem.dupe(fmt.loop.allocator, u8, file_path_ref);
+    defer fmt.loop.allocator.free(file_path);
+
+    {
+        const held = await (async fmt.seen.acquire() catch unreachable);
+        defer held.release();
+
+        if (try held.value.put(file_path, {})) |_| return;
+    }
+
+    const source_code = (await try async event.fs.readFile(
+        fmt.loop,
+        file_path,
+        max_src_size,
+    )) catch |err| switch (err) {
+        error.IsDir, error.AccessDenied => {
+            // TODO make event based (and dir.next())
+            var dir = try std.os.Dir.open(fmt.loop.allocator, file_path);
+            defer dir.close();
+
+            var group = event.Group(FmtError!void).init(fmt.loop);
+            while (try dir.next()) |entry| {
+                if (entry.kind == std.os.Dir.Entry.Kind.Directory or mem.endsWith(u8, entry.name, ".zig")) {
+                    const full_path = try os.path.join(fmt.loop.allocator, [][]const u8{ file_path, entry.name });
+                    try group.call(fmtPath, fmt, full_path, check_mode);
+                }
+            }
+            return await (async group.wait() catch unreachable);
+        },
+        else => {
+            // TODO lock stderr printing
+            try stderr.print("unable to open '{}': {}\n", file_path, err);
+            fmt.any_error = true;
+            return;
+        },
+    };
+    defer fmt.loop.allocator.free(source_code);
+
+    var tree = std.zig.parse(fmt.loop.allocator, source_code) catch |err| {
+        try stderr.print("error parsing file '{}': {}\n", file_path, err);
+        fmt.any_error = true;
+        return;
+    };
+    defer tree.deinit();
+
+    var error_it = tree.errors.iterator(0);
+    while (error_it.next()) |parse_error| {
+        const msg = try errmsg.Msg.createFromParseError(fmt.loop.allocator, parse_error, &tree, file_path);
+        defer fmt.loop.allocator.destroy(msg);
+
+        try msg.printToFile(stderr_file, fmt.color);
+    }
+    if (tree.errors.len != 0) {
+        fmt.any_error = true;
+        return;
+    }
+
+    if (check_mode) {
+        const anything_changed = try std.zig.render(fmt.loop.allocator, io.null_out_stream, &tree);
+        if (anything_changed) {
+            try stderr.print("{}\n", file_path);
+            fmt.any_error = true;
+        }
+    } else {
+        // TODO make this evented
+        const baf = try io.BufferedAtomicFile.create(fmt.loop.allocator, file_path);
+        defer baf.destroy();
+
+        const anything_changed = try std.zig.render(fmt.loop.allocator, baf.stream(), &tree);
+        if (anything_changed) {
+            try stderr.print("{}\n", file_path);
+            try baf.finish();
+        }
+    }
+}
+
+// cmd:targets /////////////////////////////////////////////////////////////////////////////////////
+
+fn cmdTargets(allocator: *Allocator, args: []const []const u8) !void {
+    try stdout.write("Architectures:\n");
+    {
+        comptime var i: usize = 0;
+        inline while (i < @memberCount(builtin.Arch)) : (i += 1) {
+            comptime const arch_tag = @memberName(builtin.Arch, i);
+            // NOTE: Cannot use empty string, see #918.
+            comptime const native_str = if (comptime mem.eql(u8, arch_tag, @tagName(builtin.arch))) " (native)\n" else "\n";
+
+            try stdout.print("  {}{}", arch_tag, native_str);
+        }
+    }
+    try stdout.write("\n");
+
+    try stdout.write("Operating Systems:\n");
+    {
+        comptime var i: usize = 0;
+        inline while (i < @memberCount(builtin.Os)) : (i += 1) {
+            comptime const os_tag = @memberName(builtin.Os, i);
+            // NOTE: Cannot use empty string, see #918.
+            comptime const native_str = if (comptime mem.eql(u8, os_tag, @tagName(builtin.os))) " (native)\n" else "\n";
+
+            try stdout.print("  {}{}", os_tag, native_str);
+        }
+    }
+    try stdout.write("\n");
+
+    try stdout.write("C ABIs:\n");
+    {
+        comptime var i: usize = 0;
+        inline while (i < @memberCount(builtin.Abi)) : (i += 1) {
+            comptime const abi_tag = @memberName(builtin.Abi, i);
+            // NOTE: Cannot use empty string, see #918.
+            comptime const native_str = if (comptime mem.eql(u8, abi_tag, @tagName(builtin.abi))) " (native)\n" else "\n";
+
+            try stdout.print("  {}{}", abi_tag, native_str);
+        }
+    }
+}
+
+fn cmdVersion(allocator: *Allocator, args: []const []const u8) !void {
+    try stdout.print("{}\n", std.cstr.toSliceConst(c.ZIG_VERSION_STRING));
+}
+
+const args_test_spec = []Flag{Flag.Bool("--help")};
+
+fn cmdHelp(allocator: *Allocator, args: []const []const u8) !void {
+    try stdout.write(usage);
+}
+
+const info_zen =
+    \\
+    \\ * Communicate intent precisely.
+    \\ * Edge cases matter.
+    \\ * Favor reading code over writing code.
+    \\ * Only one obvious way to do things.
+    \\ * Runtime crashes are better than bugs.
+    \\ * Compile errors are better than runtime crashes.
+    \\ * Incremental improvements.
+    \\ * Avoid local maximums.
+    \\ * Reduce the amount one must remember.
+    \\ * Minimize energy spent on coding style.
+    \\ * Together we serve end users.
+    \\
+    \\
+;
+
+fn cmdZen(allocator: *Allocator, args: []const []const u8) !void {
+    try stdout.write(info_zen);
+}
+
+const usage_internal =
+    \\usage: zig internal [subcommand]
+    \\
+    \\Sub-Commands:
+    \\  build-info                   Print static compiler build-info
+    \\
+    \\
+;
+
+fn cmdInternal(allocator: *Allocator, args: []const []const u8) !void {
+    if (args.len == 0) {
+        try stderr.write(usage_internal);
+        os.exit(1);
+    }
+
+    const sub_commands = []Command{Command{
+        .name = "build-info",
+        .exec = cmdInternalBuildInfo,
+    }};
+
+    for (sub_commands) |sub_command| {
+        if (mem.eql(u8, sub_command.name, args[0])) {
+            try sub_command.exec(allocator, args[1..]);
+            return;
+        }
+    }
+
+    try stderr.print("unknown sub command: {}\n\n", args[0]);
+    try stderr.write(usage_internal);
+}
+
+fn cmdInternalBuildInfo(allocator: *Allocator, args: []const []const u8) !void {
+    try stdout.print(
+        \\ZIG_CMAKE_BINARY_DIR {}
+        \\ZIG_CXX_COMPILER     {}
+        \\ZIG_LLVM_CONFIG_EXE  {}
+        \\ZIG_LLD_INCLUDE_PATH {}
+        \\ZIG_LLD_LIBRARIES    {}
+        \\ZIG_STD_FILES        {}
+        \\ZIG_C_HEADER_FILES   {}
+        \\ZIG_DIA_GUIDS_LIB    {}
+        \\
+    ,
+        std.cstr.toSliceConst(c.ZIG_CMAKE_BINARY_DIR),
+        std.cstr.toSliceConst(c.ZIG_CXX_COMPILER),
+        std.cstr.toSliceConst(c.ZIG_LLVM_CONFIG_EXE),
+        std.cstr.toSliceConst(c.ZIG_LLD_INCLUDE_PATH),
+        std.cstr.toSliceConst(c.ZIG_LLD_LIBRARIES),
+        std.cstr.toSliceConst(c.ZIG_STD_FILES),
+        std.cstr.toSliceConst(c.ZIG_C_HEADER_FILES),
+        std.cstr.toSliceConst(c.ZIG_DIA_GUIDS_LIB),
+    );
+}
+
+const CliPkg = struct {
+    name: []const u8,
+    path: []const u8,
+    children: ArrayList(*CliPkg),
+    parent: ?*CliPkg,
+
+    pub fn init(allocator: *mem.Allocator, name: []const u8, path: []const u8, parent: ?*CliPkg) !*CliPkg {
+        var pkg = try allocator.create(CliPkg);
+        pkg.* = CliPkg{
+            .name = name,
+            .path = path,
+            .children = ArrayList(*CliPkg).init(allocator),
+            .parent = parent,
+        };
+        return pkg;
+    }
+
+    pub fn deinit(self: *CliPkg) void {
+        for (self.children.toSliceConst()) |child| {
+            child.deinit();
+        }
+        self.children.deinit();
+    }
+};

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1311,14 +1311,44 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
-        "@popCount - negative comptime_int",
+        "@bitreverse - up-cast",
         \\comptime {
-        \\    _ = @popCount(-1);
+        \\    var i: u8 = 3;
+        \\    _ = @bitreverse(u16, i);
         \\}
     ,
-        "tmp.zig:2:9: error: @popCount on negative comptime_int value -1",
+        "tmp.zig:3:9: error: upcasting 'u8' to 'u16' changes result",
     );
 
+    cases.add(
+        "@bswap - up-cast",
+        \\comptime {
+        \\    var i: u8 = 3;
+        \\    _ = @bswap(u16, i);
+        \\}
+    ,
+        "tmp.zig:3:9: error: upcasting 'u8' to 'u16' changes result",
+    );
+
+    cases.add(
+        "@clz - up-cast",
+        \\comptime {
+        \\    var i: u8 = 3;
+        \\    _ = @clz(u16, i);
+        \\}
+    ,
+        "tmp.zig:3:9: error: upcasting 'u8' to 'u16' changes result",
+    );
+
+    cases.add(
+        "@popCount - up-cast of negative number",
+        \\comptime {
+        \\    var i: i8 = -3;
+        \\    _ = @popCount(i16, i);
+        \\}
+    ,
+        "tmp.zig:3:9: error: upcasting 'i8' to 'i16' changes result",
+    );
     cases.addCase(x: {
         const tc = cases.create(
             "wrong same named struct",

--- a/test/stage1/behavior/bitreverse.zig
+++ b/test/stage1/behavior/bitreverse.zig
@@ -2,80 +2,80 @@ const std = @import("std");
 const expect = std.testing.expect;
 const minInt = std.math.minInt;
 
-test "@bitreverse" {
+test "@bitReverse" {
     comptime testBitReverse();
     testBitReverse();
 }
 
 fn testBitReverse() void {
     // using comptime_ints, unsigned
-    expect(@bitreverse(u0, 0) == 0);
-    expect(@bitreverse(u5, 0x12) == 0x9);
-    expect(@bitreverse(u8, 0x12) == 0x48);
-    expect(@bitreverse(u16, 0x1234) == 0x2c48);
-    expect(@bitreverse(u24, 0x123456) == 0x6a2c48);
-    expect(@bitreverse(u32, 0x12345678) == 0x1e6a2c48);
-    expect(@bitreverse(u40, 0x123456789a) == 0x591e6a2c48);
-    expect(@bitreverse(u48, 0x123456789abc) == 0x3d591e6a2c48);
-    expect(@bitreverse(u56, 0x123456789abcde) == 0x7b3d591e6a2c48);
-    expect(@bitreverse(u64, 0x123456789abcdef1) == 0x8f7b3d591e6a2c48);
-    expect(@bitreverse(u128, 0x123456789abcdef11121314151617181) == 0x818e868a828c84888f7b3d591e6a2c48);
+    expect(@bitReverse(u0, 0) == 0);
+    expect(@bitReverse(u5, 0x12) == 0x9);
+    expect(@bitReverse(u8, 0x12) == 0x48);
+    expect(@bitReverse(u16, 0x1234) == 0x2c48);
+    expect(@bitReverse(u24, 0x123456) == 0x6a2c48);
+    expect(@bitReverse(u32, 0x12345678) == 0x1e6a2c48);
+    expect(@bitReverse(u40, 0x123456789a) == 0x591e6a2c48);
+    expect(@bitReverse(u48, 0x123456789abc) == 0x3d591e6a2c48);
+    expect(@bitReverse(u56, 0x123456789abcde) == 0x7b3d591e6a2c48);
+    expect(@bitReverse(u64, 0x123456789abcdef1) == 0x8f7b3d591e6a2c48);
+    expect(@bitReverse(u128, 0x123456789abcdef11121314151617181) == 0x818e868a828c84888f7b3d591e6a2c48);
 
     // using runtime uints, unsigned
     var num0: u0 = 0;
-    expect(@bitreverse(u0, num0) == 0);
+    expect(@bitReverse(u0, num0) == 0);
     var num5: u5 = 0x12;
-    expect(@bitreverse(u5, num5) == 0x9);
+    expect(@bitReverse(u5, num5) == 0x9);
     var num8: u8 = 0x12;
-    expect(@bitreverse(u8, num8) == 0x48);
+    expect(@bitReverse(u8, num8) == 0x48);
     var num16: u16 = 0x1234;
-    expect(@bitreverse(u16, num16) == 0x2c48);
+    expect(@bitReverse(u16, num16) == 0x2c48);
     var num24: u24 = 0x123456;
-    expect(@bitreverse(u24, num24) == 0x6a2c48);
+    expect(@bitReverse(u24, num24) == 0x6a2c48);
     var num32: u32 = 0x12345678;
-    expect(@bitreverse(u32, num32) == 0x1e6a2c48);
+    expect(@bitReverse(u32, num32) == 0x1e6a2c48);
     var num40: u40 = 0x123456789a;
-    expect(@bitreverse(u40, num40) == 0x591e6a2c48);
+    expect(@bitReverse(u40, num40) == 0x591e6a2c48);
     var num48: u48 = 0x123456789abc;
-    expect(@bitreverse(u48, num48) == 0x3d591e6a2c48);
+    expect(@bitReverse(u48, num48) == 0x3d591e6a2c48);
     var num56: u56 = 0x123456789abcde;
-    expect(@bitreverse(u56, num56) == 0x7b3d591e6a2c48);
+    expect(@bitReverse(u56, num56) == 0x7b3d591e6a2c48);
     var num64: u64 = 0x123456789abcdef1;
-    expect(@bitreverse(u64, num64) == 0x8f7b3d591e6a2c48);
+    expect(@bitReverse(u64, num64) == 0x8f7b3d591e6a2c48);
     var num128: u128 = 0x123456789abcdef11121314151617181;
-    expect(@bitreverse(u128, num128) == 0x818e868a828c84888f7b3d591e6a2c48);
+    expect(@bitReverse(u128, num128) == 0x818e868a828c84888f7b3d591e6a2c48);
 
     // using comptime_ints, signed, positive
-    expect(@bitreverse(i0, 0) == 0);
-    expect(@bitreverse(i8, @bitCast(i8, u8(0x92))) == @bitCast(i8, u8(0x49)));
-    expect(@bitreverse(i16, @bitCast(i16, u16(0x1234))) == @bitCast(i16, u16(0x2c48)));
-    expect(@bitreverse(i24, @bitCast(i24, u24(0x123456))) == @bitCast(i24, u24(0x6a2c48)));
-    expect(@bitreverse(i32, @bitCast(i32, u32(0x12345678))) == @bitCast(i32, u32(0x1e6a2c48)));
-    expect(@bitreverse(i40, @bitCast(i40, u40(0x123456789a))) == @bitCast(i40, u40(0x591e6a2c48)));
-    expect(@bitreverse(i48, @bitCast(i48, u48(0x123456789abc))) == @bitCast(i48, u48(0x3d591e6a2c48)));
-    expect(@bitreverse(i56, @bitCast(i56, u56(0x123456789abcde))) == @bitCast(i56, u56(0x7b3d591e6a2c48)));
-    expect(@bitreverse(i64, @bitCast(i64, u64(0x123456789abcdef1))) == @bitCast(i64, u64(0x8f7b3d591e6a2c48)));
-    expect(@bitreverse(i128, @bitCast(i128, u128(0x123456789abcdef11121314151617181))) == @bitCast(i128, u128(0x818e868a828c84888f7b3d591e6a2c48)));
+    expect(@bitReverse(i0, 0) == 0);
+    expect(@bitReverse(i8, @bitCast(i8, u8(0x92))) == @bitCast(i8, u8(0x49)));
+    expect(@bitReverse(i16, @bitCast(i16, u16(0x1234))) == @bitCast(i16, u16(0x2c48)));
+    expect(@bitReverse(i24, @bitCast(i24, u24(0x123456))) == @bitCast(i24, u24(0x6a2c48)));
+    expect(@bitReverse(i32, @bitCast(i32, u32(0x12345678))) == @bitCast(i32, u32(0x1e6a2c48)));
+    expect(@bitReverse(i40, @bitCast(i40, u40(0x123456789a))) == @bitCast(i40, u40(0x591e6a2c48)));
+    expect(@bitReverse(i48, @bitCast(i48, u48(0x123456789abc))) == @bitCast(i48, u48(0x3d591e6a2c48)));
+    expect(@bitReverse(i56, @bitCast(i56, u56(0x123456789abcde))) == @bitCast(i56, u56(0x7b3d591e6a2c48)));
+    expect(@bitReverse(i64, @bitCast(i64, u64(0x123456789abcdef1))) == @bitCast(i64, u64(0x8f7b3d591e6a2c48)));
+    expect(@bitReverse(i128, @bitCast(i128, u128(0x123456789abcdef11121314151617181))) == @bitCast(i128, u128(0x818e868a828c84888f7b3d591e6a2c48)));
 
     // using comptime_ints, signed, negative. Compare to runtime ints returned from llvm.
     var neg5: i5 = minInt(i5) + 1;
-    expect(@bitreverse(i5, minInt(i5) + 1) == @bitreverse(i5, neg5));
+    expect(@bitReverse(i5, minInt(i5) + 1) == @bitReverse(i5, neg5));
     var neg8: i8 = -18;
-    expect(@bitreverse(i8, -18) == @bitreverse(i8, neg8));
+    expect(@bitReverse(i8, -18) == @bitReverse(i8, neg8));
     var neg16: i16 = -32694;
-    expect(@bitreverse(i16, -32694) == @bitreverse(i16, neg16));
+    expect(@bitReverse(i16, -32694) == @bitReverse(i16, neg16));
     var neg24: i24 = -6773785;
-    expect(@bitreverse(i24, -6773785) == @bitreverse(i24, neg24));
+    expect(@bitReverse(i24, -6773785) == @bitReverse(i24, neg24));
     var neg32: i32 = -16773785;
-    expect(@bitreverse(i32, -16773785) == @bitreverse(i32, neg32));
+    expect(@bitReverse(i32, -16773785) == @bitReverse(i32, neg32));
     var neg40: i40 = minInt(i40) + 12345;
-    expect(@bitreverse(i40, minInt(i40) + 12345) == @bitreverse(i40, neg40));
+    expect(@bitReverse(i40, minInt(i40) + 12345) == @bitReverse(i40, neg40));
     var neg48: i48 = minInt(i48) + 12345;
-    expect(@bitreverse(i48, minInt(i48) + 12345) == @bitreverse(i48, neg48));
+    expect(@bitReverse(i48, minInt(i48) + 12345) == @bitReverse(i48, neg48));
     var neg56: i56 = minInt(i56) + 12345;
-    expect(@bitreverse(i56, minInt(i56) + 12345) == @bitreverse(i56, neg56));
+    expect(@bitReverse(i56, minInt(i56) + 12345) == @bitReverse(i56, neg56));
     var neg64: i64 = minInt(i64) + 12345;
-    expect(@bitreverse(i64, minInt(i64) + 12345) == @bitreverse(i64, neg64));
+    expect(@bitReverse(i64, minInt(i64) + 12345) == @bitReverse(i64, neg64));
     var neg128: i128 = minInt(i128) + 12345;
-    expect(@bitreverse(i128, minInt(i128) + 12345) == @bitreverse(i128, neg128));
+    expect(@bitReverse(i128, minInt(i128) + 12345) == @bitReverse(i128, neg128));
 }

--- a/test/stage1/behavior/bswap.zig
+++ b/test/stage1/behavior/bswap.zig
@@ -1,32 +1,32 @@
 const std = @import("std");
 const expect = std.testing.expect;
 
-test "@bswap" {
+test "@bSwap" {
     comptime testByteSwap();
     testByteSwap();
 }
 
 fn testByteSwap() void {
-    expect(@bswap(u0, 0) == 0);
-    expect(@bswap(u8, 0x12) == 0x12);
-    expect(@bswap(u16, 0x1234) == 0x3412);
-    expect(@bswap(u24, 0x123456) == 0x563412);
-    expect(@bswap(u32, 0x12345678) == 0x78563412);
-    expect(@bswap(u40, 0x123456789a) == 0x9a78563412);
-    expect(@bswap(u48, 0x123456789abc) == 0xbc9a78563412);
-    expect(@bswap(u56, 0x123456789abcde) == 0xdebc9a78563412);
-    expect(@bswap(u64, 0x123456789abcdef1) == 0xf1debc9a78563412);
-    expect(@bswap(u128, 0x123456789abcdef11121314151617181) == 0x8171615141312111f1debc9a78563412);
+    expect(@bSwap(u0, 0) == 0);
+    expect(@bSwap(u8, 0x12) == 0x12);
+    expect(@bSwap(u16, 0x1234) == 0x3412);
+    expect(@bSwap(u24, 0x123456) == 0x563412);
+    expect(@bSwap(u32, 0x12345678) == 0x78563412);
+    expect(@bSwap(u40, 0x123456789a) == 0x9a78563412);
+    expect(@bSwap(u48, 0x123456789abc) == 0xbc9a78563412);
+    expect(@bSwap(u56, 0x123456789abcde) == 0xdebc9a78563412);
+    expect(@bSwap(u64, 0x123456789abcdef1) == 0xf1debc9a78563412);
+    expect(@bSwap(u128, 0x123456789abcdef11121314151617181) == 0x8171615141312111f1debc9a78563412);
 
-    expect(@bswap(i0, 0) == 0);
-    expect(@bswap(i8, -50) == -50);
-    expect(@bswap(i16, @bitCast(i16, u16(0x1234))) == @bitCast(i16, u16(0x3412)));
-    expect(@bswap(i24, @bitCast(i24, u24(0x123456))) == @bitCast(i24, u24(0x563412)));
-    expect(@bswap(i32, @bitCast(i32, u32(0x12345678))) == @bitCast(i32, u32(0x78563412)));
-    expect(@bswap(i40, @bitCast(i40, u40(0x123456789a))) == @bitCast(i40, u40(0x9a78563412)));
-    expect(@bswap(i48, @bitCast(i48, u48(0x123456789abc))) == @bitCast(i48, u48(0xbc9a78563412)));
-    expect(@bswap(i56, @bitCast(i56, u56(0x123456789abcde))) == @bitCast(i56, u56(0xdebc9a78563412)));
-    expect(@bswap(i64, @bitCast(i64, u64(0x123456789abcdef1))) == @bitCast(i64, u64(0xf1debc9a78563412)));
-    expect(@bswap(i128, @bitCast(i128, u128(0x123456789abcdef11121314151617181))) ==
+    expect(@bSwap(i0, 0) == 0);
+    expect(@bSwap(i8, -50) == -50);
+    expect(@bSwap(i16, @bitCast(i16, u16(0x1234))) == @bitCast(i16, u16(0x3412)));
+    expect(@bSwap(i24, @bitCast(i24, u24(0x123456))) == @bitCast(i24, u24(0x563412)));
+    expect(@bSwap(i32, @bitCast(i32, u32(0x12345678))) == @bitCast(i32, u32(0x78563412)));
+    expect(@bSwap(i40, @bitCast(i40, u40(0x123456789a))) == @bitCast(i40, u40(0x9a78563412)));
+    expect(@bSwap(i48, @bitCast(i48, u48(0x123456789abc))) == @bitCast(i48, u48(0xbc9a78563412)));
+    expect(@bSwap(i56, @bitCast(i56, u56(0x123456789abcde))) == @bitCast(i56, u56(0xdebc9a78563412)));
+    expect(@bSwap(i64, @bitCast(i64, u64(0x123456789abcdef1))) == @bitCast(i64, u64(0xf1debc9a78563412)));
+    expect(@bSwap(i128, @bitCast(i128, u128(0x123456789abcdef11121314151617181))) ==
         @bitCast(i128, u128(0x8171615141312111f1debc9a78563412)));
 }

--- a/test/stage1/behavior/math.zig
+++ b/test/stage1/behavior/math.zig
@@ -101,15 +101,15 @@ test "@clz" {
 }
 
 fn testClz() void {
-    expect(clz(u8(0b00001010)) == 4);
-    expect(clz(u8(0b10001010)) == 0);
-    expect(clz(u8(0b00000000)) == 8);
-    expect(clz(u128(0xffffffffffffffff)) == 64);
-    expect(clz(u128(0x10000000000000000)) == 63);
+    expect(clz(u8, u8(0b00001010)) == 4);
+    expect(clz(u8, u8(0b10001010)) == 0);
+    expect(clz(u8, u8(0b00000000)) == 8);
+    expect(clz(u128, u128(0xffffffffffffffff)) == 64);
+    expect(clz(u128, u128(0x10000000000000000)) == 63);
 }
 
-fn clz(x: var) usize {
-    return @clz(x);
+fn clz(comptime T: type, x: T) usize {
+    return @clz(T, x);
 }
 
 test "@ctz" {
@@ -118,13 +118,13 @@ test "@ctz" {
 }
 
 fn testCtz() void {
-    expect(ctz(u8(0b10100000)) == 5);
-    expect(ctz(u8(0b10001010)) == 1);
-    expect(ctz(u8(0b00000000)) == 8);
+    expect(ctz(u8, u8(0b10100000)) == 5);
+    expect(ctz(u8, u8(0b10001010)) == 1);
+    expect(ctz(u8, u8(0b00000000)) == 8);
 }
 
-fn ctz(x: var) usize {
-    return @ctz(x);
+fn ctz(comptime T: type, x: T) usize {
+    return @ctz(T, x);
 }
 
 test "assignment operators" {

--- a/test/stage1/behavior/popcount.zig
+++ b/test/stage1/behavior/popcount.zig
@@ -8,18 +8,29 @@ test "@popCount" {
 fn testPopCount() void {
     {
         var x: u32 = 0xaa;
-        expect(@popCount(x) == 4);
+        expect(@popCount(u32, x) == 4);
     }
     {
         var x: u32 = 0xaaaaaaaa;
-        expect(@popCount(x) == 16);
+        expect(@popCount(u32, x) == 16);
+    }
+    {
+        var x: u32 = 0xaaaaaaaa;
+        expect(@popCount(u64, x) == 16);
     }
     {
         var x: i16 = -1;
-        expect(@popCount(x) == 16);
+        expect(@popCount(i16, x) == 16);
+    }
+    {
+        var x: i8 = -120;
+        expect(@popCount(i8, x) == 2);
     }
     comptime {
-        expect(@popCount(0b11111111000110001100010000100001000011000011100101010001) == 24);
+        expect(@popCount(i8, -120) == 2);
+    }
+    comptime {
+        expect(@popCount(u128, 0b11111111000110001100010000100001000011000011100101010001) == 24);
     }
 }
 


### PR DESCRIPTION
…er functions

Closes: #2119

Also, do not implicitely up-cast @bswap() and @bitreverse().

Closes: #2121

Comes with tests.

Thanks for the behavior tests test/stage1/behavior/math.zig or I wouldn't
have realized that @clz() can't be implicitely up-cast either, because
it would changes the result when value == 0.


----

Docs are coming, but I wanted to run the tests while I write them.