### PR TITLE
fix std.ascii toUpper(), toLower(), add tests to std.zig

### DIFF
--- a/std/ascii.zig
+++ b/std/ascii.zig
@@ -200,7 +200,7 @@ pub fn isBlank(c: u8) bool {
 
 pub fn toUpper(c: u8) u8 {
     if (isLower(c)) {
-        return c | ~0b00100000;
+        return c & 0b11011111;
     } else {
         return c;
     }
@@ -208,7 +208,7 @@ pub fn toUpper(c: u8) u8 {
 
 pub fn toLower(c: u8) u8 {
     if (isUpper(c)) {
-        return c &  0b00100000;
+        return c | 0b00100000;
     } else {
         return c;
     }

--- a/std/std.zig
+++ b/std/std.zig
@@ -62,6 +62,7 @@ test "std" {
     _ = @import("segmented_list.zig");
     _ = @import("spinlock.zig");
 
+    _ = @import("ascii.zig");
     _ = @import("base64.zig");
     _ = @import("build.zig");
     _ = @import("c.zig");


### PR DESCRIPTION
Since the test in std.ascii actually wasn't run, #2103 silently broke the code (both the logic, and it no longer compiled).
Using the updated files the tests now succeed for me locally using latest master build (0.3.0+64b2cf77) .