### PR TITLE
breaking: polish @clz() @ctz() @popcount() @bswap() @bitReverse() 

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -113,6 +113,8 @@ pub fn build(b: *Builder) !void {
     const fmt_step = b.step("test-fmt", "Run zig fmt against build.zig to make sure it works");
     fmt_step.dependOn(&fmt_build_zig.step);
 
+    test_step.dependOn(tests.addPkgTests(b, test_filter, "std/zig/parser_test.zig", "parser", "Run the parser tests", modes));
+
     test_step.dependOn(tests.addPkgTests(b, test_filter, "test/stage1/behavior.zig", "behavior", "Run the behavior tests", modes));
 
     test_step.dependOn(tests.addPkgTests(b, test_filter, "std/std.zig", "std", "Run the standard library tests", modes));

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6902,11 +6902,27 @@ fn add(a: i32, b: i32) i32 { return a + b; }
       </p>
       <p>
       This function is a low level intrinsic with no safety mechanisms. Most code
-      should not use this function, and instead use {#syntax#}std.mem.copy{#endsyntax#}.
+      should not use this function.
       </p>
-      <p>There is also a standard library function for this:</p>
+      <p>There is a standard library function for this:</p>
       <pre>{#syntax#}const mem = @import("std").mem;
 mem.copy(u8, dest[0..byte_count], source[0..byte_count]);{#endsyntax#}</pre>
+      {#header_close#}
+
+
+      {#header_open|@memMove#}
+      <pre>{#syntax#}@memMove(dest: [*]u8, source: [*]const u8, byte_count: usize){#endsyntax#}</pre>
+      <p>
+      This function copies bytes from one region of memory to another. {#syntax#}dest{#endsyntax#} and
+          {#syntax#}source{#endsyntax#} are both pointers and may overlap.
+      </p>
+      <p>
+      This function is a low level intrinsic with no safety mechanisms. Most code
+      should not use this function.
+      </p>
+      <p>There is a standard library function for this:</p>
+      <pre>{#syntax#}const mem = @import("std").mem;
+mem.move(u8, dest[0..byte_count], source[0..byte_count]);{#endsyntax#}</pre>
       {#header_close#}
 
       {#header_open|@memset#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6901,11 +6901,7 @@ fn add(a: i32, b: i32) i32 { return a + b; }
       </p>
       <p>
       This function is a low level intrinsic with no safety mechanisms. Most code
-      should not use this function, instead using something like this:
-      </p>
-      <pre>{#syntax#}for (source[0..byte_count]) |b, i| dest[i] = b;{#endsyntax#}</pre>
-      <p>
-      The optimizer is intelligent enough to turn the above snippet into a memcpy.
+      should not use this function, and instead use {#syntax#}std.mem.copy{#endsyntax#}.
       </p>
       <p>There is also a standard library function for this:</p>
       <pre>{#syntax#}const mem = @import("std").mem;

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6236,8 +6236,8 @@ comptime {
 
       {#header_close#}
 
-      {#header_open|@bswap#}
-      <pre>{#syntax#}@bswap(comptime T: type, value: T) T{#endsyntax#}</pre>
+      {#header_open|@bSwap#}
+      <pre>{#syntax#}@bSwap(comptime T: type, integer: T) T{#endsyntax#}</pre>
       <p>{#syntax#}T{#endsyntax#} must be an integer type with bit count evenly divisible by 8.</p>
       <p>
       Swaps the byte order of the integer. This converts a big endian integer to a little endian integer,
@@ -6245,8 +6245,8 @@ comptime {
       </p>
       {#header_close#}
 
-      {#header_open|@bitreverse#}
-      <pre>{#syntax#}@bitreverse(comptime T: type, value: T) T{#endsyntax#}</pre>
+      {#header_open|@bitReverse#}
+      <pre>{#syntax#}@bitReverse(comptime T: type, integer: T) T{#endsyntax#}</pre>
       <p>{#syntax#}T{#endsyntax#} accepts any integer type.</p>
       <p>
       Reverses the bitpattern of an integer value, including the sign bit if applicable.
@@ -6334,14 +6334,15 @@ comptime {
       {#header_close#}
 
       {#header_open|@clz#}
-      <pre>{#syntax#}@clz(x: T) U{#endsyntax#}</pre>
+      <pre>{#syntax#}@clz(comptime T: type, integer: T) math.Log2Int(@intType(false, @typeInfo(T).Int.bits + 1)){#endsyntax#}</pre>
       <p>
       This function counts the number of leading zeroes in {#syntax#}x{#endsyntax#} which is an integer
           type {#syntax#}T{#endsyntax#}.
       </p>
       <p>
-      The return type {#syntax#}U{#endsyntax#} is an unsigned integer with the minimum number
-          of bits that can represent the value {#syntax#}T.bit_count{#endsyntax#}.
+      If {#syntax#}integer{#endsyntax#} is known at {#link|comptime#}, the return type is {#syntax#}comptime_int{#endsyntax#}.
+      Otherwise, the return type is an unsigned integer with the minimum number
+      of bits that can represent the bit count of the integer type.
       </p>
       <p>
       If {#syntax#}x{#endsyntax#} is zero, {#syntax#}@clz{#endsyntax#} returns {#syntax#}T.bit_count{#endsyntax#}.
@@ -6474,14 +6475,15 @@ test "main" {
       {#header_close#}
 
       {#header_open|@ctz#}
-      <pre>{#syntax#}@ctz(x: T) U{#endsyntax#}</pre>
+      <pre>{#syntax#}@ctz(comptime T: type, integer: T) math.Log2Int(@intType(false, @typeInfo(T).Int.bits + 1)){#endsyntax#}</pre>
       <p>
       This function counts the number of trailing zeroes in {#syntax#}x{#endsyntax#} which is an integer
           type {#syntax#}T{#endsyntax#}.
       </p>
       <p>
-      The return type {#syntax#}U{#endsyntax#} is an unsigned integer with the minimum number
-          of bits that can represent the value {#syntax#}T.bit_count{#endsyntax#}.
+      If {#syntax#}integer{#endsyntax#} is known at {#link|comptime#}, the return type is {#syntax#}comptime_int{#endsyntax#}.
+      Otherwise, the return type is an unsigned integer with the minimum number
+      of bits that can represent the bit count of the integer type.
       </p>
       <p>
       If {#syntax#}x{#endsyntax#} is zero, {#syntax#}@ctz{#endsyntax#} returns {#syntax#}T.bit_count{#endsyntax#}.
@@ -7031,7 +7033,7 @@ test "call foo" {
       {#header_close#}
 
       {#header_open|@popCount#}
-      <pre>{#syntax#}@popCount(integer: var) var{#endsyntax#}</pre>
+      <pre>{#syntax#}@popCount(comptime T: type, integer: T) math.Log2Int(@intType(false, @typeInfo(T).Int.bits + 1)){#endsyntax#}</pre>
       <p>Counts the number of bits set in an integer.</p>
       <p>
       If {#syntax#}integer{#endsyntax#} is known at {#link|comptime#}, the return type is {#syntax#}comptime_int{#endsyntax#}.

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2833,6 +2833,7 @@ test "labeled break from labeled block expression" {
 }
       {#code_end#}
       <p>Here, {#syntax#}blk{#endsyntax#} can be any name.</p>
+      <p>Guaranteed to traverse forward.</p>
       {#see_also|Labeled while|Labeled for#}
 
       {#header_open|Shadowing#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6257,6 +6257,28 @@ comptime {
       </p>
       {#header_close#}
 
+      {#header_open|@fshl#}
+      <pre>{#syntax#}@fshl(comptime T: type, high: T, low: T, shift: math.Log2Int(T)) T{#endsyntax#}</pre>
+      <p>{#syntax#}T{#endsyntax#} accepts any integer type.</p>
+      <p>
+      Concatenates {#syntax#}high{#endsyntax#} and {#syntax#}low{#endsyntax#},
+      shifts left by {#syntax#}shift{#endsyntax#}, and then returns the most significant bits.
+      If {#syntax#}high{#endsyntax#} and {#syntax#}low{#endsyntax#} are the same this is identical
+      to a left rotate.
+      </p>
+      {#header_close#}
+
+      {#header_open|@fshr#}
+      <pre>{#syntax#}@fshr(comptime T: type, high: T, low: T, shift: math.Log2Int(T)) T{#endsyntax#}</pre>
+      <p>{#syntax#}T{#endsyntax#} accepts any integer type.</p>
+      <p>
+      Concatenates {#syntax#}high{#endsyntax#} and {#syntax#}low{#endsyntax#},
+      shifts right by {#syntax#}shift{#endsyntax#}, and then returns the least significant bits.
+      If {#syntax#}high{#endsyntax#} and {#syntax#}low{#endsyntax#} are the same this is identical
+      to a right rotate.
+      </p>
+      {#header_close#}
+
       {#header_open|@byteOffsetOf#}
       <pre>{#syntax#}@byteOffsetOf(comptime T: type, comptime field_name: [] const u8) comptime_int{#endsyntax#}</pre>
       <p>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7133,6 +7133,20 @@ test "call foo" {
       a calling function, the returned address will apply to the calling function.
       </p>
       {#header_close#}
+      {#header_open|@satAdd#}
+      <pre>{#syntax#}@addAdd(comptime T: type, a: T, b: T) T{#endsyntax#}</pre>
+      <p>
+      Performs {#syntax#}result.* = a + b{#endsyntax#}. If overflow or underflow occurs,
+          stores {#syntax#}math.maxInt(T){#endsyntax#} or {#syntax#}math.minInt(T){#endsyntax#} in {#syntax#}result{#endsyntax#}.
+      </p>
+      {#header_close#}
+      {#header_open|@satSud#}
+      <pre>{#syntax#}@addAdd(comptime T: type, a: T, b: T) T{#endsyntax#}</pre>
+      <p>
+      Performs {#syntax#}result.* = a - b{#endsyntax#}. If overflow or underflow occurs,
+          stores {#syntax#}math.maxInt(T){#endsyntax#} or {#syntax#}math.minInt(T){#endsyntax#} in {#syntax#}result{#endsyntax#}.
+      </p>
+      {#header_close#}
       {#header_open|@setAlignStack#}
       <pre>{#syntax#}@setAlignStack(comptime alignment: u29){#endsyntax#}</pre>
       <p>

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1574,15 +1574,19 @@ struct ZigLLVMFnKey {
     union {
         struct {
             uint32_t bit_count;
+            uint32_t vector_len; // 0 means not a vector
         } ctz;
         struct {
             uint32_t bit_count;
+            uint32_t vector_len; // 0 means not a vector
         } clz;
         struct {
             uint32_t bit_count;
+            uint32_t vector_len; // 0 means not a vector
         } pop_count;
         struct {
             uint32_t bit_count;
+            uint32_t vector_len; // 0 means not a vector
         } floating;
         struct {
             AddSubMul add_sub_mul;
@@ -1598,15 +1602,19 @@ struct ZigLLVMFnKey {
         } saturating_arithmetic;
         struct {
             uint32_t bit_count;
+            uint32_t vector_len; // 0 means not a vector
         } bswap;
         struct {
             uint32_t bit_count;
+            uint32_t vector_len; // 0 means not a vector
         } bit_reverse;
         struct {
             uint32_t bit_count;
+            uint32_t vector_len; // 0 means not a vector
         } fshl;
         struct {
             uint32_t bit_count;
+            uint32_t vector_len; // 0 means not a vector
         } fshr;
     } data;
 };

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1399,6 +1399,8 @@ enum BuiltinFnId {
     BuiltinFnIdSubWithOverflow,
     BuiltinFnIdMulWithOverflow,
     BuiltinFnIdShlWithOverflow,
+    BuiltinFnIdSaturatingAdd,
+    BuiltinFnIdSaturatingSub,
     BuiltinFnIdCInclude,
     BuiltinFnIdCDefine,
     BuiltinFnIdCUndef,
@@ -1548,6 +1550,7 @@ enum ZigLLVMFnId {
     ZigLLVMFnIdClz,
     ZigLLVMFnIdPopCount,
     ZigLLVMFnIdOverflowArithmetic,
+    ZigLLVMFnIdSaturatingArithmetic,
     ZigLLVMFnIdFloor,
     ZigLLVMFnIdCeil,
     ZigLLVMFnIdSqrt,
@@ -1587,6 +1590,12 @@ struct ZigLLVMFnKey {
             uint32_t vector_len; // 0 means not a vector
             bool is_signed;
         } overflow_arithmetic;
+        struct {
+            AddSubMul add_sub;
+            uint32_t bit_count;
+            uint32_t vector_len; // 0 means not a vector
+            bool is_signed;
+        } saturating_arithmetic;
         struct {
             uint32_t bit_count;
         } bswap;
@@ -2237,6 +2246,7 @@ enum IrInstructionId {
     IrInstructionIdHandle,
     IrInstructionIdAlignOf,
     IrInstructionIdOverflowOp,
+    IrInstructionIdSaturatingOp,
     IrInstructionIdTestErr,
     IrInstructionIdUnwrapErrCode,
     IrInstructionIdUnwrapErrPayload,
@@ -3053,6 +3063,22 @@ struct IrInstructionOverflowOp {
     IrInstruction *result_ptr;
 
     ZigType *result_ptr_type;
+};
+
+enum IrSaturatingOp {
+    IrSaturatingOpSAdd,
+    IrSaturatingOpUAdd,
+    IrSaturatingOpSSub,
+    IrSaturatingOpUSub,
+};
+
+struct IrInstructionSaturatingOp {
+    IrInstruction base;
+
+    IrSaturatingOp op;
+    IrInstruction *type_value;
+    IrInstruction *op1;
+    IrInstruction *op2;
 };
 
 struct IrInstructionAlignOf {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1406,6 +1406,10 @@ enum BuiltinFnId {
     BuiltinFnIdCtz,
     BuiltinFnIdClz,
     BuiltinFnIdPopCount,
+    BuiltinFnIdBswap,
+    BuiltinFnIdBitReverse,
+    BuiltinFnIdFshl,
+    BuiltinFnIdFshr,
     BuiltinFnIdImport,
     BuiltinFnIdCImport,
     BuiltinFnIdErrName,
@@ -1468,8 +1472,6 @@ enum BuiltinFnId {
     BuiltinFnIdErrorReturnTrace,
     BuiltinFnIdAtomicRmw,
     BuiltinFnIdAtomicLoad,
-    BuiltinFnIdBswap,
-    BuiltinFnIdBitReverse,
 };
 
 struct BuiltinFnEntry {
@@ -1550,6 +1552,8 @@ enum ZigLLVMFnId {
     ZigLLVMFnIdSqrt,
     ZigLLVMFnIdBswap,
     ZigLLVMFnIdBitReverse,
+    ZigLLVMFnIdFshl,
+    ZigLLVMFnIdFshr,
 };
 
 // There are a bunch of places in code that rely on these values being in
@@ -1588,6 +1592,12 @@ struct ZigLLVMFnKey {
         struct {
             uint32_t bit_count;
         } bit_reverse;
+        struct {
+            uint32_t bit_count;
+        } fshl;
+        struct {
+            uint32_t bit_count;
+        } fshr;
     } data;
 };
 
@@ -2186,6 +2196,10 @@ enum IrInstructionId {
     IrInstructionIdClz,
     IrInstructionIdCtz,
     IrInstructionIdPopCount,
+    IrInstructionIdBswap,
+    IrInstructionIdBitReverse,
+    IrInstructionIdFshl,
+    IrInstructionIdFshr,
     IrInstructionIdImport,
     IrInstructionIdCImport,
     IrInstructionIdCInclude,
@@ -2282,8 +2296,6 @@ enum IrInstructionId {
     IrInstructionIdMergeErrRetTraces,
     IrInstructionIdMarkErrRetTracePtr,
     IrInstructionIdSqrt,
-    IrInstructionIdBswap,
-    IrInstructionIdBitReverse,
     IrInstructionIdErrSetCast,
     IrInstructionIdToBytes,
     IrInstructionIdFromBytes,
@@ -2730,19 +2742,40 @@ struct IrInstructionOptionalUnwrapPtr {
 struct IrInstructionCtz {
     IrInstruction base;
 
-    IrInstruction *value;
+    IrInstruction *type;
+    IrInstruction *op;
 };
 
 struct IrInstructionClz {
     IrInstruction base;
 
-    IrInstruction *value;
+    IrInstruction *type;
+    IrInstruction *op;
 };
 
 struct IrInstructionPopCount {
     IrInstruction base;
 
-    IrInstruction *value;
+    IrInstruction *type;
+    IrInstruction *op;
+};
+
+struct IrInstructionFshl {
+    IrInstruction base;
+
+    IrInstruction *type;
+    IrInstruction *high;
+    IrInstruction *low;
+    IrInstruction *shift;
+};
+
+struct IrInstructionFshr {
+    IrInstruction base;
+
+    IrInstruction *type;
+    IrInstruction *high;
+    IrInstruction *low;
+    IrInstruction *shift;
 };
 
 struct IrInstructionUnionTag {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1386,6 +1386,7 @@ enum BuiltinFnId {
     BuiltinFnIdInvalid,
     BuiltinFnIdMemcpy,
     BuiltinFnIdMemset,
+    BuiltinFnIdMemMove,
     BuiltinFnIdSizeof,
     BuiltinFnIdAlignOf,
     BuiltinFnIdMemberCount,
@@ -1664,6 +1665,7 @@ struct CodeGen {
     LLVMValueRef cur_err_ret_trace_val_arg;
     LLVMValueRef cur_err_ret_trace_val_stack;
     LLVMValueRef memcpy_fn_val;
+    LLVMValueRef memmove_fn_val;
     LLVMValueRef memset_fn_val;
     LLVMValueRef trap_fn_val;
     LLVMValueRef return_address_fn_val;
@@ -2224,6 +2226,7 @@ enum IrInstructionId {
     IrInstructionIdBoolNot,
     IrInstructionIdMemset,
     IrInstructionIdMemcpy,
+    IrInstructionIdMemMove,
     IrInstructionIdSlice,
     IrInstructionIdMemberCount,
     IrInstructionIdMemberType,
@@ -2970,7 +2973,16 @@ struct IrInstructionMemset {
     IrInstruction *count;
 };
 
+// Warning: this is casted to MemMove, so must be identical
 struct IrInstructionMemcpy {
+    IrInstruction base;
+
+    IrInstruction *dest_ptr;
+    IrInstruction *src_ptr;
+    IrInstruction *count;
+};
+
+struct IrInstructionMemMove {
     IrInstruction base;
 
     IrInstruction *dest_ptr;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5704,25 +5704,35 @@ bool type_id_eql(TypeId a, TypeId b) {
 uint32_t zig_llvm_fn_key_hash(ZigLLVMFnKey x) {
     switch (x.id) {
         case ZigLLVMFnIdCtz:
-            return (uint32_t)(x.data.ctz.bit_count) * (uint32_t)810453934;
+            return (uint32_t)(x.data.ctz.bit_count) * (uint32_t)810453934 +
+                x.data.ctz.vector_len;
         case ZigLLVMFnIdClz:
-            return (uint32_t)(x.data.clz.bit_count) * (uint32_t)2428952817;
+            return (uint32_t)(x.data.clz.bit_count) * (uint32_t)2428952817 +
+                x.data.clz.vector_len;
         case ZigLLVMFnIdPopCount:
-            return (uint32_t)(x.data.clz.bit_count) * (uint32_t)101195049;
+            return (uint32_t)(x.data.pop_count.bit_count) * (uint32_t)101195049 +
+                x.data.pop_count.vector_len;
         case ZigLLVMFnIdFloor:
-            return (uint32_t)(x.data.floating.bit_count) * (uint32_t)1899859168;
+            return (uint32_t)(x.data.floating.bit_count) * (uint32_t)1899859168 +
+                x.data.floating.vector_len;
         case ZigLLVMFnIdCeil:
-            return (uint32_t)(x.data.floating.bit_count) * (uint32_t)1953839089;
+            return (uint32_t)(x.data.floating.bit_count) * (uint32_t)1953839089 +
+                x.data.floating.vector_len;
         case ZigLLVMFnIdSqrt:
-            return (uint32_t)(x.data.floating.bit_count) * (uint32_t)2225366385;
+            return (uint32_t)(x.data.floating.bit_count) * (uint32_t)2225366385 +
+                x.data.floating.vector_len;
         case ZigLLVMFnIdBswap:
-            return (uint32_t)(x.data.bswap.bit_count) * (uint32_t)3661994335;
+            return (uint32_t)(x.data.bswap.bit_count) * (uint32_t)3661994335 +
+                x.data.bswap.vector_len;
         case ZigLLVMFnIdBitReverse:
-            return (uint32_t)(x.data.bit_reverse.bit_count) * (uint32_t)2621398431;
+            return (uint32_t)(x.data.bit_reverse.bit_count) * (uint32_t)2621398431 +
+                x.data.bit_reverse.vector_len;
         case ZigLLVMFnIdFshl:
-            return (uint32_t)(x.data.fshl.bit_count) * (uint32_t)0xfadefade;
+            return (uint32_t)(x.data.fshl.bit_count) * (uint32_t)0xfadefade +
+                x.data.fshl.vector_len;
         case ZigLLVMFnIdFshr:
-            return (uint32_t)(x.data.fshr.bit_count) * (uint32_t)0xedafedaf;
+            return (uint32_t)(x.data.fshr.bit_count) * (uint32_t)0xedafedaf +
+                x.data.fshr.vector_len;
         case ZigLLVMFnIdOverflowArithmetic:
             return ((uint32_t)(x.data.overflow_arithmetic.bit_count) * 87135777) +
                 ((uint32_t)(x.data.overflow_arithmetic.add_sub_mul) * 31640542) +

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5728,6 +5728,11 @@ uint32_t zig_llvm_fn_key_hash(ZigLLVMFnKey x) {
                 ((uint32_t)(x.data.overflow_arithmetic.add_sub_mul) * 31640542) +
                 ((uint32_t)(x.data.overflow_arithmetic.is_signed) ? 1062315172 : 314955820) +
                 x.data.overflow_arithmetic.vector_len * 1435156945;
+        case ZigLLVMFnIdSaturatingArithmetic:
+            return ((uint32_t)(x.data.saturating_arithmetic.bit_count) * 87195777) +
+                ((uint32_t)(x.data.saturating_arithmetic.add_sub) * 31640512) +
+                ((uint32_t)(x.data.saturating_arithmetic.is_signed) ? 1012315172 : 317955820) +
+                x.data.saturating_arithmetic.vector_len * 1435126945;
     }
     zig_unreachable();
 }
@@ -5759,6 +5764,11 @@ bool zig_llvm_fn_key_eql(ZigLLVMFnKey a, ZigLLVMFnKey b) {
                 (a.data.overflow_arithmetic.add_sub_mul == b.data.overflow_arithmetic.add_sub_mul) &&
                 (a.data.overflow_arithmetic.is_signed == b.data.overflow_arithmetic.is_signed) &&
                 (a.data.overflow_arithmetic.vector_len == b.data.overflow_arithmetic.vector_len);
+        case ZigLLVMFnIdSaturatingArithmetic:
+            return (a.data.saturating_arithmetic.bit_count == b.data.saturating_arithmetic.bit_count) &&
+                (a.data.saturating_arithmetic.add_sub == b.data.saturating_arithmetic.add_sub) &&
+                (a.data.saturating_arithmetic.is_signed == b.data.saturating_arithmetic.is_signed) &&
+                (a.data.saturating_arithmetic.vector_len == b.data.saturating_arithmetic.vector_len);
     }
     zig_unreachable();
 }

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -339,6 +339,19 @@ ZigType *get_smallest_unsigned_int_type(CodeGen *g, uint64_t x) {
     return get_int_type(g, false, bits_needed_for_unsigned(x));
 }
 
+static uint8_t bits_needed_for_no_zero_representation_unsigned(uint64_t x) {
+    uint8_t count = 0;
+    for (uint64_t s = x - 1;s != 0;s >>= 1)
+        count++;
+
+    return count;
+}
+
+//Equivilent to math.Log2Int. ceil log2int
+ZigType *get_shift_type(CodeGen *g, uint64_t x) {
+    return get_int_type(g, false, bits_needed_for_no_zero_representation_unsigned(x));
+}
+
 ZigType *get_promise_type(CodeGen *g, ZigType *result_type) {
     if (result_type != nullptr && result_type->promise_parent != nullptr) {
         return result_type->promise_parent;
@@ -5706,6 +5719,10 @@ uint32_t zig_llvm_fn_key_hash(ZigLLVMFnKey x) {
             return (uint32_t)(x.data.bswap.bit_count) * (uint32_t)3661994335;
         case ZigLLVMFnIdBitReverse:
             return (uint32_t)(x.data.bit_reverse.bit_count) * (uint32_t)2621398431;
+        case ZigLLVMFnIdFshl:
+            return (uint32_t)(x.data.fshl.bit_count) * (uint32_t)0xfadefade;
+        case ZigLLVMFnIdFshr:
+            return (uint32_t)(x.data.fshr.bit_count) * (uint32_t)0xedafedaf;
         case ZigLLVMFnIdOverflowArithmetic:
             return ((uint32_t)(x.data.overflow_arithmetic.bit_count) * 87135777) +
                 ((uint32_t)(x.data.overflow_arithmetic.add_sub_mul) * 31640542) +
@@ -5729,6 +5746,10 @@ bool zig_llvm_fn_key_eql(ZigLLVMFnKey a, ZigLLVMFnKey b) {
             return a.data.bswap.bit_count == b.data.bswap.bit_count;
         case ZigLLVMFnIdBitReverse:
             return a.data.bit_reverse.bit_count == b.data.bit_reverse.bit_count;
+        case ZigLLVMFnIdFshl:
+            return a.data.fshl.bit_count == b.data.fshl.bit_count;
+        case ZigLLVMFnIdFshr:
+            return a.data.fshr.bit_count == b.data.fshr.bit_count;
         case ZigLLVMFnIdFloor:
         case ZigLLVMFnIdCeil:
         case ZigLLVMFnIdSqrt:

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -34,6 +34,7 @@ ZigType *get_slice_type(CodeGen *g, ZigType *ptr_type);
 ZigType *get_partial_container_type(CodeGen *g, Scope *scope, ContainerKind kind,
         AstNode *decl_node, const char *full_name, Buf *bare_name, ContainerLayout layout);
 ZigType *get_smallest_unsigned_int_type(CodeGen *g, uint64_t x);
+ZigType *get_shift_type(CodeGen *g, uint64_t x);
 ZigType *get_error_union_type(CodeGen *g, ZigType *err_set_type, ZigType *payload_type);
 ZigType *get_bound_fn_type(CodeGen *g, ZigFn *fn_entry);
 ZigType *get_opaque_type(CodeGen *g, Scope *scope, AstNode *source_node, const char *full_name, Buf *bare_name);

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -11,6 +11,7 @@
 #include "list.hpp"
 #include "os.hpp"
 #include "softfloat.hpp"
+#include "util.hpp"
 
 #include <limits>
 #include <algorithm>
@@ -1334,7 +1335,7 @@ void bigint_shl(BigInt *dest, const BigInt *op1, const BigInt *op2) {
     if (op1->digit_count == 1 && op1->data.digit == 0)
         return bigint_init_unsigned(dest, 0);
 
-    if (op1->digit_count == 1 && __builtin_clzl(op1->data.digit) >= shift_amt) {
+    if (op1->digit_count == 1 && clzll(op1->data.digit) >= shift_amt) {
         dest->data.digit = op1->data.digit << shift_amt;
         dest->digit_count = 1;
         dest->is_negative = op1->is_negative;
@@ -1348,7 +1349,7 @@ void bigint_shl(BigInt *dest, const BigInt *op1, const BigInt *op2) {
     size_t digits_needed = naieve_digits_needed;
     if (op1->digit_count > 1) {
         uint64_t most_sig_digit = op1->data.digits[op1->digit_count - 1];
-        if (__builtin_clzl(most_sig_digit) >= leftover_shift_count)
+        if (clzll(most_sig_digit) >= leftover_shift_count)
             digits_needed--;
     }
     dest->data.digits = allocate<uint64_t>(digits_needed);
@@ -1412,7 +1413,7 @@ void bigint_shr(BigInt *dest, const BigInt *op1, const BigInt *op2) {
     //bool most_sig_fits = false;
     if (op1->digit_count > 1) {
         uint64_t most_sig_digit = op1->data.digits[op1->digit_count - 1];
-        if (__builtin_clzl(most_sig_digit) + leftover_shift_count >= 64) {
+        if (clzll(most_sig_digit) + leftover_shift_count >= 64) {
             digits_needed--;
          //   most_sig_fits = true;
         }

--- a/src/bigint.hpp
+++ b/src/bigint.hpp
@@ -83,6 +83,7 @@ size_t bigint_ctz(const BigInt *bi, size_t bit_count);
 size_t bigint_clz(const BigInt *bi, size_t bit_count);
 size_t bigint_popcount_signed(const BigInt *bi, size_t bit_count);
 size_t bigint_popcount_unsigned(const BigInt *bi);
+void bigint_fsh(BigInt *dest, const BigInt *high, const BigInt *low, const BigInt *shift, size_t bit_count, bool is_fshl);
 
 size_t bigint_bits_needed(const BigInt *op);
 

--- a/src/bigint.hpp
+++ b/src/bigint.hpp
@@ -48,6 +48,7 @@ static inline const uint64_t *bigint_ptr(const BigInt *bigint) {
 }
 
 bool bigint_fits_in_bits(const BigInt *bn, size_t bit_count, bool is_signed);
+void bigint_saturate(BigInt *bn, size_t bit_count, bool is_signed);
 void bigint_write_twos_complement(const BigInt *big_int, uint8_t *buf, size_t bit_count, bool is_big_endian);
 void bigint_read_twos_complement(BigInt *dest, const uint8_t *buf, size_t bit_count, bool is_big_endian,
         bool is_signed);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -17078,43 +17078,82 @@ static IrInstruction *ir_analyze_instruction_ctz(IrAnalyze *ira, IrInstructionCt
     return result;
 }
 
+static void ir_eval_count_zeros_scalar(IrAnalyze *ira, IrInstruction *source_instr, ZigType *scalar_type,
+   ConstExprValue *operand_val, ConstExprValue *scalar_out_val, bool is_clz) {
+    scalar_out_val->special = ConstValSpecialStatic;
+
+    size_t result_usize;
+    if (is_clz)
+        result_usize = bigint_clz(&operand_val->data.x_bigint, scalar_type->data.integral.bit_count);
+    else
+        result_usize = bigint_ctz(&operand_val->data.x_bigint, scalar_type->data.integral.bit_count);
+
+    bigint_init_unsigned(&scalar_out_val->data.x_bigint, result_usize);
+}
+
 static IrInstruction *ir_analyze_instruction_clz(IrAnalyze *ira, IrInstructionClz *instruction) {
-    ZigType *int_type = ir_resolve_type(ira, instruction->type->child);
-    if (type_is_invalid(int_type))
+    ZigType *expr_type = ir_resolve_type(ira, instruction->type->child);
+    if (type_is_invalid(expr_type))
         return ira->codegen->invalid_instruction;
+    ZigType *scalar_type = (expr_type->id == ZigTypeIdVector) ? expr_type->data.vector.elem_type : expr_type;
 
     IrInstruction *op = instruction->op->child;
 
-    if (int_type->id != ZigTypeIdInt) {
+    if (scalar_type->id != ZigTypeIdInt) {
         ir_add_error(ira, instruction->type,
-            buf_sprintf("expected integer type, found '%s'", buf_ptr(&int_type->name)));
+            buf_sprintf("expected integer type, found '%s'", buf_ptr(&scalar_type->name)));
         return ira->codegen->invalid_instruction;
     }
-
-    IrInstruction *casted_op = ir_implicit_cast(ira, op, int_type);
-    if (type_is_invalid(casted_op->value.type))
-        return ira->codegen->invalid_instruction;
 
     if (op->value.type->id == ZigTypeIdComptimeInt) {
         ir_add_error(ira, instruction->op,
-            buf_sprintf("expected %s fixed-width integer type, found %s", buf_ptr(&int_type->name), buf_ptr(&op->value.type->name)));
+            buf_sprintf("expected %s fixed-width integer type, found %s", buf_ptr(&expr_type->name), buf_ptr(&op->value.type->name)));
         return ira->codegen->invalid_instruction;
     }
 
-    ZigType *return_type = get_smallest_unsigned_int_type(ira->codegen, int_type->data.integral.bit_count);
+    IrInstruction *casted_op = ir_implicit_cast(ira, op, expr_type);
+    if (type_is_invalid(casted_op->value.type))
+        return ira->codegen->invalid_instruction;
 
-    if (int_type->data.integral.bit_count == 0) {
-        IrInstruction *result = ir_const(ira, &instruction->base, return_type);
-        bigint_init_unsigned(&result->value.data.x_bigint, 0);
-        return result;
+    ZigType *scalar_return_type = get_smallest_unsigned_int_type(ira->codegen, scalar_type->data.integral.bit_count);
+    ZigType *return_type = (expr_type->id == ZigTypeIdVector) ?
+        get_vector_type(ira->codegen, expr_type->data.vector.len, scalar_return_type) : scalar_return_type;
+
+    if (scalar_type->data.integral.bit_count == 0) {
+        if (expr_type->id == ZigTypeIdVector) {
+            zig_unreachable(); //TODO
+        } else {
+            IrInstruction *result = ir_const(ira, &instruction->base, return_type);
+            bigint_init_unsigned(&result->value.data.x_bigint, 0);
+            return result;
+        }
     }
 
     if (instr_is_comptime(casted_op)) {
-        size_t result_usize = bigint_clz(&op->value.data.x_bigint,
-                op->value.type->data.integral.bit_count);
-        IrInstruction *result = ir_const(ira, &instruction->base, return_type);
-        bigint_init_unsigned(&result->value.data.x_bigint, result_usize);
-        return result;
+        ConstExprValue *operand_val = ir_resolve_const(ira, casted_op, UndefBad);
+        if (!operand_val)
+            return ira->codegen->invalid_instruction;
+
+        IrInstruction *result_instruction = ir_const(ira, &instruction->base, return_type);
+        ConstExprValue *out_val = &result_instruction->value;
+        if (expr_type->id == ZigTypeIdVector) {
+            expand_undef_array(ira->codegen, operand_val);
+            out_val->special = ConstValSpecialUndef;
+            expand_undef_array(ira->codegen, out_val);
+            size_t len = expr_type->data.vector.len;
+            for (size_t i = 0; i < len; i += 1) {
+                ConstExprValue *scalar_operand_val = &operand_val->data.x_array.data.s_none.elements[i];
+                ConstExprValue *scalar_out_val = &out_val->data.x_array.data.s_none.elements[i];
+                assert(scalar_operand_val->type == scalar_type);
+                scalar_out_val->type = scalar_return_type;
+                ir_eval_count_zeros_scalar(ira, &instruction->base, scalar_type,
+                        scalar_operand_val, scalar_out_val, true);
+            }
+            out_val->special = ConstValSpecialStatic;
+        } else {
+            ir_eval_count_zeros_scalar(ira, &instruction->base, scalar_type, operand_val, out_val, true);
+        }
+        return result_instruction;
     }
 
     IrInstruction *result = ir_build_clz(&ira->new_irb, instruction->base.scope,

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -568,6 +568,22 @@ static constexpr IrInstructionId ir_instruction_id(IrInstructionPopCount *) {
     return IrInstructionIdPopCount;
 }
 
+static constexpr IrInstructionId ir_instruction_id(IrInstructionBswap *) {
+    return IrInstructionIdBswap;
+}
+
+static constexpr IrInstructionId ir_instruction_id(IrInstructionBitReverse *) {
+    return IrInstructionIdBitReverse;
+}
+
+static constexpr IrInstructionId ir_instruction_id(IrInstructionFshl *) {
+    return IrInstructionIdFshl;
+}
+
+static constexpr IrInstructionId ir_instruction_id(IrInstructionFshr *) {
+    return IrInstructionIdFshr;
+}
+
 static constexpr IrInstructionId ir_instruction_id(IrInstructionUnionTag *) {
     return IrInstructionIdUnionTag;
 }
@@ -974,14 +990,6 @@ static constexpr IrInstructionId ir_instruction_id(IrInstructionMarkErrRetTraceP
 
 static constexpr IrInstructionId ir_instruction_id(IrInstructionSqrt *) {
     return IrInstructionIdSqrt;
-}
-
-static constexpr IrInstructionId ir_instruction_id(IrInstructionBswap *) {
-    return IrInstructionIdBswap;
-}
-
-static constexpr IrInstructionId ir_instruction_id(IrInstructionBitReverse *) {
-    return IrInstructionIdBitReverse;
 }
 
 static constexpr IrInstructionId ir_instruction_id(IrInstructionCheckRuntimeScope *) {
@@ -1757,29 +1765,87 @@ static IrInstruction *ir_build_err_wrap_code(IrBuilder *irb, Scope *scope, AstNo
     return &instruction->base;
 }
 
-static IrInstruction *ir_build_clz(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *value) {
+static IrInstruction *ir_build_clz(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *type, IrInstruction *op) {
     IrInstructionClz *instruction = ir_build_instruction<IrInstructionClz>(irb, scope, source_node);
-    instruction->value = value;
+    instruction->type = type;
+    instruction->op = op;
 
-    ir_ref_instruction(value, irb->current_basic_block);
+    if (type != nullptr) ir_ref_instruction(type, irb->current_basic_block);
+    ir_ref_instruction(op, irb->current_basic_block);
 
     return &instruction->base;
 }
 
-static IrInstruction *ir_build_ctz(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *value) {
+static IrInstruction *ir_build_ctz(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *type, IrInstruction *op) {
     IrInstructionCtz *instruction = ir_build_instruction<IrInstructionCtz>(irb, scope, source_node);
-    instruction->value = value;
+    instruction->type = type;
+    instruction->op = op;
 
-    ir_ref_instruction(value, irb->current_basic_block);
+    if (type != nullptr) ir_ref_instruction(type, irb->current_basic_block);
+    ir_ref_instruction(op, irb->current_basic_block);
 
     return &instruction->base;
 }
 
-static IrInstruction *ir_build_pop_count(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *value) {
+static IrInstruction *ir_build_pop_count(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *type, IrInstruction *op) {
     IrInstructionPopCount *instruction = ir_build_instruction<IrInstructionPopCount>(irb, scope, source_node);
-    instruction->value = value;
+    instruction->type = type;
+    instruction->op = op;
 
-    ir_ref_instruction(value, irb->current_basic_block);
+    if (type != nullptr) ir_ref_instruction(type, irb->current_basic_block);
+    ir_ref_instruction(op, irb->current_basic_block);
+
+    return &instruction->base;
+}
+
+static IrInstruction *ir_build_bswap(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *type, IrInstruction *op) {
+    IrInstructionBswap *instruction = ir_build_instruction<IrInstructionBswap>(irb, scope, source_node);
+    instruction->type = type;
+    instruction->op = op;
+
+    if (type != nullptr) ir_ref_instruction(type, irb->current_basic_block);
+    ir_ref_instruction(op, irb->current_basic_block);
+
+    return &instruction->base;
+}
+
+static IrInstruction *ir_build_bit_reverse(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *type, IrInstruction *op) {
+    IrInstructionBitReverse *instruction = ir_build_instruction<IrInstructionBitReverse>(irb, scope, source_node);
+    instruction->type = type;
+    instruction->op = op;
+
+    if (type != nullptr) ir_ref_instruction(type, irb->current_basic_block);
+    ir_ref_instruction(op, irb->current_basic_block);
+
+    return &instruction->base;
+}
+
+static IrInstruction *ir_build_fshl(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *type, IrInstruction *high, IrInstruction *low, IrInstruction *shift) {
+    IrInstructionFshl *instruction = ir_build_instruction<IrInstructionFshl>(irb, scope, source_node);
+    instruction->type = type;
+    instruction->high = high;
+    instruction->low = low;
+    instruction->shift = shift;
+
+    if (type != nullptr) ir_ref_instruction(type, irb->current_basic_block);
+    ir_ref_instruction(high, irb->current_basic_block);
+    ir_ref_instruction(low, irb->current_basic_block);
+    ir_ref_instruction(shift, irb->current_basic_block);
+
+    return &instruction->base;
+}
+
+static IrInstruction *ir_build_fshr(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *type, IrInstruction *high, IrInstruction *low, IrInstruction *shift) {
+    IrInstructionFshr *instruction = ir_build_instruction<IrInstructionFshr>(irb, scope, source_node);
+    instruction->type = type;
+    instruction->high = high;
+    instruction->low = low;
+    instruction->shift = shift;
+
+    if (type != nullptr) ir_ref_instruction(type, irb->current_basic_block);
+    ir_ref_instruction(high, irb->current_basic_block);
+    ir_ref_instruction(low, irb->current_basic_block);
+    ir_ref_instruction(shift, irb->current_basic_block);
 
     return &instruction->base;
 }
@@ -2960,28 +3026,6 @@ static IrInstruction *ir_build_sqrt(IrBuilder *irb, Scope *scope, AstNode *sourc
     return &instruction->base;
 }
 
-static IrInstruction *ir_build_bswap(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *type, IrInstruction *op) {
-    IrInstructionBswap *instruction = ir_build_instruction<IrInstructionBswap>(irb, scope, source_node);
-    instruction->type = type;
-    instruction->op = op;
-
-    if (type != nullptr) ir_ref_instruction(type, irb->current_basic_block);
-    ir_ref_instruction(op, irb->current_basic_block);
-
-    return &instruction->base;
-}
-
-static IrInstruction *ir_build_bit_reverse(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *type, IrInstruction *op) {
-    IrInstructionBitReverse *instruction = ir_build_instruction<IrInstructionBitReverse>(irb, scope, source_node);
-    instruction->type = type;
-    instruction->op = op;
-
-    if (type != nullptr) ir_ref_instruction(type, irb->current_basic_block);
-    ir_ref_instruction(op, irb->current_basic_block);
-
-    return &instruction->base;
-}
-
 static IrInstruction *ir_build_check_runtime_scope(IrBuilder *irb, Scope *scope, AstNode *source_node, IrInstruction *scope_is_comptime, IrInstruction *is_comptime) {
     IrInstructionCheckRuntimeScope *instruction = ir_build_instruction<IrInstructionCheckRuntimeScope>(irb, scope, source_node);
     instruction->scope_is_comptime = scope_is_comptime;
@@ -4043,36 +4087,6 @@ static IrInstruction *ir_gen_builtin_fn_call(IrBuilder *irb, Scope *scope, AstNo
                 IrInstruction *size_of = ir_build_size_of(irb, scope, node, arg0_value);
                 return ir_lval_wrap(irb, scope, size_of, lval);
             }
-        case BuiltinFnIdCtz:
-            {
-                AstNode *arg0_node = node->data.fn_call_expr.params.at(0);
-                IrInstruction *arg0_value = ir_gen_node(irb, arg0_node, scope);
-                if (arg0_value == irb->codegen->invalid_instruction)
-                    return arg0_value;
-
-                IrInstruction *ctz = ir_build_ctz(irb, scope, node, arg0_value);
-                return ir_lval_wrap(irb, scope, ctz, lval);
-            }
-        case BuiltinFnIdPopCount:
-            {
-                AstNode *arg0_node = node->data.fn_call_expr.params.at(0);
-                IrInstruction *arg0_value = ir_gen_node(irb, arg0_node, scope);
-                if (arg0_value == irb->codegen->invalid_instruction)
-                    return arg0_value;
-
-                IrInstruction *instr = ir_build_pop_count(irb, scope, node, arg0_value);
-                return ir_lval_wrap(irb, scope, instr, lval);
-            }
-        case BuiltinFnIdClz:
-            {
-                AstNode *arg0_node = node->data.fn_call_expr.params.at(0);
-                IrInstruction *arg0_value = ir_gen_node(irb, arg0_node, scope);
-                if (arg0_value == irb->codegen->invalid_instruction)
-                    return arg0_value;
-
-                IrInstruction *clz = ir_build_clz(irb, scope, node, arg0_value);
-                return ir_lval_wrap(irb, scope, clz, lval);
-            }
         case BuiltinFnIdImport:
             {
                 AstNode *arg0_node = node->data.fn_call_expr.params.at(0);
@@ -5045,21 +5059,10 @@ static IrInstruction *ir_gen_builtin_fn_call(IrBuilder *irb, Scope *scope, AstNo
                 IrInstruction *result = ir_build_enum_to_int(irb, scope, node, arg0_value);
                 return ir_lval_wrap(irb, scope, result, lval);
             }
+        case BuiltinFnIdCtz:
+        case BuiltinFnIdPopCount:
+        case BuiltinFnIdClz:
         case BuiltinFnIdBswap:
-            {
-                AstNode *arg0_node = node->data.fn_call_expr.params.at(0);
-                IrInstruction *arg0_value = ir_gen_node(irb, arg0_node, scope);
-                if (arg0_value == irb->codegen->invalid_instruction)
-                    return arg0_value;
-
-                AstNode *arg1_node = node->data.fn_call_expr.params.at(1);
-                IrInstruction *arg1_value = ir_gen_node(irb, arg1_node, scope);
-                if (arg1_value == irb->codegen->invalid_instruction)
-                    return arg1_value;
-
-                IrInstruction *result = ir_build_bswap(irb, scope, node, arg0_value, arg1_value);
-                return ir_lval_wrap(irb, scope, result, lval);
-            }
         case BuiltinFnIdBitReverse:
             {
                 AstNode *arg0_node = node->data.fn_call_expr.params.at(0);
@@ -5072,7 +5075,62 @@ static IrInstruction *ir_gen_builtin_fn_call(IrBuilder *irb, Scope *scope, AstNo
                 if (arg1_value == irb->codegen->invalid_instruction)
                     return arg1_value;
 
-                IrInstruction *result = ir_build_bit_reverse(irb, scope, node, arg0_value, arg1_value);
+                IrInstruction *result;
+                switch (builtin_fn->id) {
+                case BuiltinFnIdCtz:
+                    result = ir_build_ctz(irb, scope, node, arg0_value, arg1_value);
+                    break;
+                case BuiltinFnIdPopCount:
+                    result = ir_build_pop_count(irb, scope, node, arg0_value, arg1_value);
+                    break;
+                case BuiltinFnIdClz:
+                    result = ir_build_clz(irb, scope, node, arg0_value, arg1_value);
+                    break;
+                case BuiltinFnIdBswap:
+                    result = ir_build_bswap(irb, scope, node, arg0_value, arg1_value);
+                    break;
+                case BuiltinFnIdBitReverse:
+                    result = ir_build_bit_reverse(irb, scope, node, arg0_value, arg1_value);
+                    break;
+                default:
+                    zig_unreachable();
+                }
+                return ir_lval_wrap(irb, scope, result, lval);
+            }
+        case BuiltinFnIdFshl:
+        case BuiltinFnIdFshr:
+            {
+                AstNode *arg0_node = node->data.fn_call_expr.params.at(0);
+                IrInstruction *arg0_value = ir_gen_node(irb, arg0_node, scope);
+                if (arg0_value == irb->codegen->invalid_instruction)
+                    return arg0_value;
+
+                AstNode *arg1_node = node->data.fn_call_expr.params.at(1);
+                IrInstruction *arg1_value = ir_gen_node(irb, arg1_node, scope);
+                if (arg1_value == irb->codegen->invalid_instruction)
+                    return arg1_value;
+
+                AstNode *arg2_node = node->data.fn_call_expr.params.at(2);
+                IrInstruction *arg2_value = ir_gen_node(irb, arg2_node, scope);
+                if (arg2_value == irb->codegen->invalid_instruction)
+                    return arg2_value;
+
+                AstNode *arg3_node = node->data.fn_call_expr.params.at(3);
+                IrInstruction *arg3_value = ir_gen_node(irb, arg3_node, scope);
+                if (arg3_value == irb->codegen->invalid_instruction)
+                    return arg3_value;
+
+                IrInstruction *result;
+                switch (builtin_fn->id) {
+                case BuiltinFnIdFshl:
+                    result = ir_build_fshl(irb, scope, node, arg0_value, arg1_value, arg2_value, arg3_value);
+                    break;
+                case BuiltinFnIdFshr:
+                    result = ir_build_fshr(irb, scope, node, arg0_value, arg1_value, arg2_value, arg3_value);
+                    break;
+                default:
+                    zig_unreachable();
+                }
                 return ir_lval_wrap(irb, scope, result, lval);
             }
     }
@@ -16844,92 +16902,293 @@ static IrInstruction *ir_analyze_instruction_optional_unwrap_ptr(IrAnalyze *ira,
     return ir_analyze_unwrap_optional_payload(ira, &instruction->base, base_ptr, instruction->safety_check_on);
 }
 
-static IrInstruction *ir_analyze_instruction_ctz(IrAnalyze *ira, IrInstructionCtz *ctz_instruction) {
-    IrInstruction *value = ctz_instruction->value->child;
-    if (type_is_invalid(value->value.type)) {
+static IrInstruction *ir_analyze_instruction_ctz(IrAnalyze *ira, IrInstructionCtz *instruction) {
+    ZigType *int_type = ir_resolve_type(ira, instruction->type->child);
+    if (type_is_invalid(int_type))
         return ira->codegen->invalid_instruction;
-    } else if (value->value.type->id == ZigTypeIdInt) {
-        ZigType *return_type = get_smallest_unsigned_int_type(ira->codegen,
-                value->value.type->data.integral.bit_count);
-        if (value->value.special != ConstValSpecialRuntime) {
-            size_t result_usize = bigint_ctz(&value->value.data.x_bigint,
-                    value->value.type->data.integral.bit_count);
-            IrInstruction *result = ir_const(ira, &ctz_instruction->base, return_type);
-            bigint_init_unsigned(&result->value.data.x_bigint, result_usize);
-            return result;
-        }
 
-        IrInstruction *result = ir_build_ctz(&ira->new_irb,
-            ctz_instruction->base.scope, ctz_instruction->base.source_node, value);
-        result->value.type = return_type;
-        return result;
-    } else {
-        ir_add_error_node(ira, ctz_instruction->base.source_node,
-            buf_sprintf("expected integer type, found '%s'", buf_ptr(&value->value.type->name)));
+    IrInstruction *op = instruction->op->child;
+
+    if (int_type->id != ZigTypeIdInt) {
+        ir_add_error(ira, instruction->type,
+            buf_sprintf("expected integer type, found '%s'", buf_ptr(&int_type->name)));
         return ira->codegen->invalid_instruction;
     }
+
+    IrInstruction *casted_op = ir_implicit_cast(ira, op, int_type);
+    if (type_is_invalid(casted_op->value.type))
+        return ira->codegen->invalid_instruction;
+
+    if (op->value.type->id == ZigTypeIdComptimeInt) {
+        ir_add_error(ira, instruction->op,
+            buf_sprintf("expected %s fixed-width integer type, found %s", buf_ptr(&int_type->name), buf_ptr(&op->value.type->name)));
+        return ira->codegen->invalid_instruction;
+    }
+
+    ZigType *return_type = get_smallest_unsigned_int_type(ira->codegen, int_type->data.integral.bit_count);
+
+    if (int_type->data.integral.bit_count == 0) {
+        IrInstruction *result = ir_const(ira, &instruction->base, return_type);
+        bigint_init_unsigned(&result->value.data.x_bigint, 0);
+        return result;
+    }
+
+    if (instr_is_comptime(casted_op)) {
+        size_t result_usize = bigint_ctz(&op->value.data.x_bigint,
+                op->value.type->data.integral.bit_count);
+        IrInstruction *result = ir_const(ira, &instruction->base, return_type);
+        bigint_init_unsigned(&result->value.data.x_bigint, result_usize);
+        return result;
+    }
+
+    IrInstruction *result = ir_build_ctz(&ira->new_irb, instruction->base.scope,
+            instruction->base.source_node, nullptr, casted_op);
+    result->value.type = return_type;
+    return result;
 }
 
-static IrInstruction *ir_analyze_instruction_clz(IrAnalyze *ira, IrInstructionClz *clz_instruction) {
-    IrInstruction *value = clz_instruction->value->child;
-    if (type_is_invalid(value->value.type)) {
+static IrInstruction *ir_analyze_instruction_clz(IrAnalyze *ira, IrInstructionClz *instruction) {
+    ZigType *int_type = ir_resolve_type(ira, instruction->type->child);
+    if (type_is_invalid(int_type))
         return ira->codegen->invalid_instruction;
-    } else if (value->value.type->id == ZigTypeIdInt) {
-        ZigType *return_type = get_smallest_unsigned_int_type(ira->codegen,
-                value->value.type->data.integral.bit_count);
-        if (value->value.special != ConstValSpecialRuntime) {
-            size_t result_usize = bigint_clz(&value->value.data.x_bigint,
-                    value->value.type->data.integral.bit_count);
-            IrInstruction *result = ir_const(ira, &clz_instruction->base, return_type);
-            bigint_init_unsigned(&result->value.data.x_bigint, result_usize);
-            return result;
-        }
 
-        IrInstruction *result = ir_build_clz(&ira->new_irb,
-            clz_instruction->base.scope, clz_instruction->base.source_node, value);
-        result->value.type = return_type;
-        return result;
-    } else {
-        ir_add_error_node(ira, clz_instruction->base.source_node,
-            buf_sprintf("expected integer type, found '%s'", buf_ptr(&value->value.type->name)));
+    IrInstruction *op = instruction->op->child;
+
+    if (int_type->id != ZigTypeIdInt) {
+        ir_add_error(ira, instruction->type,
+            buf_sprintf("expected integer type, found '%s'", buf_ptr(&int_type->name)));
         return ira->codegen->invalid_instruction;
     }
+
+    IrInstruction *casted_op = ir_implicit_cast(ira, op, int_type);
+    if (type_is_invalid(casted_op->value.type))
+        return ira->codegen->invalid_instruction;
+
+    if (op->value.type->id == ZigTypeIdComptimeInt) {
+        ir_add_error(ira, instruction->op,
+            buf_sprintf("expected %s fixed-width integer type, found %s", buf_ptr(&int_type->name), buf_ptr(&op->value.type->name)));
+        return ira->codegen->invalid_instruction;
+    }
+
+    ZigType *return_type = get_smallest_unsigned_int_type(ira->codegen, int_type->data.integral.bit_count);
+
+    if (int_type->data.integral.bit_count == 0) {
+        IrInstruction *result = ir_const(ira, &instruction->base, return_type);
+        bigint_init_unsigned(&result->value.data.x_bigint, 0);
+        return result;
+    }
+
+    if (instr_is_comptime(casted_op)) {
+        size_t result_usize = bigint_clz(&op->value.data.x_bigint,
+                op->value.type->data.integral.bit_count);
+        IrInstruction *result = ir_const(ira, &instruction->base, return_type);
+        bigint_init_unsigned(&result->value.data.x_bigint, result_usize);
+        return result;
+    }
+
+    IrInstruction *result = ir_build_clz(&ira->new_irb, instruction->base.scope,
+            instruction->base.source_node, nullptr, casted_op);
+    result->value.type = return_type;
+    return result;
 }
 
 static IrInstruction *ir_analyze_instruction_pop_count(IrAnalyze *ira, IrInstructionPopCount *instruction) {
-    IrInstruction *value = instruction->value->child;
-    if (type_is_invalid(value->value.type))
+    ZigType *int_type = ir_resolve_type(ira, instruction->type->child);
+    if (type_is_invalid(int_type))
         return ira->codegen->invalid_instruction;
 
-    if (value->value.type->id != ZigTypeIdInt && value->value.type->id != ZigTypeIdComptimeInt) {
-        ir_add_error(ira, value,
-            buf_sprintf("expected integer type, found '%s'", buf_ptr(&value->value.type->name)));
+    IrInstruction *op = instruction->op->child;
+
+    if (int_type->id != ZigTypeIdInt) {
+        ir_add_error(ira, instruction->type,
+            buf_sprintf("expected integer type, found '%s'", buf_ptr(&int_type->name)));
         return ira->codegen->invalid_instruction;
     }
 
-    if (instr_is_comptime(value)) {
-        ConstExprValue *val = ir_resolve_const(ira, value, UndefBad);
+    IrInstruction *casted_op = ir_implicit_cast(ira, op, int_type);
+    if (type_is_invalid(casted_op->value.type))
+        return ira->codegen->invalid_instruction;
+
+    ZigType *return_type = get_smallest_unsigned_int_type(ira->codegen, int_type->data.integral.bit_count);
+
+    if (int_type->data.integral.bit_count == 0) {
+        IrInstruction *result = ir_const(ira, &instruction->base, return_type);
+        bigint_init_unsigned(&result->value.data.x_bigint, 0);
+        return result;
+    }
+
+    if (instr_is_comptime(casted_op)) {
+        ConstExprValue *val = ir_resolve_const(ira, casted_op, UndefBad);
         if (!val)
             return ira->codegen->invalid_instruction;
+
         if (bigint_cmp_zero(&val->data.x_bigint) != CmpLT) {
             size_t result = bigint_popcount_unsigned(&val->data.x_bigint);
             return ir_const_unsigned(ira, &instruction->base, result);
         }
-        if (value->value.type->id == ZigTypeIdComptimeInt) {
+        if (op->value.type->id == ZigTypeIdComptimeInt) {
             Buf *val_buf = buf_alloc();
             bigint_append_buf(val_buf, &val->data.x_bigint, 10);
             ir_add_error(ira, &instruction->base,
-                buf_sprintf("@popCount on negative %s value %s",
-                    buf_ptr(&value->value.type->name), buf_ptr(val_buf)));
+                buf_sprintf("@popCount on negative values (got '%s') must be fixed width, not %s",
+                    buf_ptr(val_buf), buf_ptr(&op->value.type->name)));
             return ira->codegen->invalid_instruction;
         }
-        size_t result = bigint_popcount_signed(&val->data.x_bigint, value->value.type->data.integral.bit_count);
+        size_t result = bigint_popcount_signed(&val->data.x_bigint, op->value.type->data.integral.bit_count);
         return ir_const_unsigned(ira, &instruction->base, result);
     }
 
     IrInstruction *result = ir_build_pop_count(&ira->new_irb, instruction->base.scope,
-            instruction->base.source_node, value);
-    result->value.type = get_smallest_unsigned_int_type(ira->codegen, value->value.type->data.integral.bit_count);
+            instruction->base.source_node, nullptr, casted_op);
+    result->value.type = return_type;
+    return result;
+}
+
+static IrInstruction *ir_analyze_instruction_fshl(IrAnalyze *ira, IrInstructionFshl *instruction) {
+    ZigType *int_type = ir_resolve_type(ira, instruction->type->child);
+    if (type_is_invalid(int_type))
+        return ira->codegen->invalid_instruction;
+
+    IrInstruction *high = instruction->high->child;
+    IrInstruction *low = instruction->low->child;
+    IrInstruction *shift = instruction->shift->child;
+
+    if (int_type->id != ZigTypeIdInt) {
+        ir_add_error(ira, instruction->type,
+            buf_sprintf("expected integer type, found '%s'", buf_ptr(&int_type->name)));
+        return ira->codegen->invalid_instruction;
+    }
+
+    IrInstruction *casted_high = ir_implicit_cast(ira, high, int_type);
+    if (type_is_invalid(casted_high->value.type))
+        return ira->codegen->invalid_instruction;
+
+    IrInstruction *casted_low = ir_implicit_cast(ira, low, int_type);
+    if (type_is_invalid(casted_low->value.type))
+        return ira->codegen->invalid_instruction;
+
+    ZigType *shift_type = get_shift_type(ira->codegen, int_type->data.integral.bit_count);
+
+    IrInstruction *implicitly_casted_shift = ir_implicit_cast(ira, shift, shift_type);
+    if (type_is_invalid(implicitly_casted_shift->value.type))
+        return ira->codegen->invalid_instruction;
+
+    // LLVM actually takes this argument at full width, because that is the register size
+    IrInstruction *casted_shift = ir_analyze_widen_or_shorten(ira, &instruction->base, implicitly_casted_shift, int_type);
+
+    if (int_type->data.integral.bit_count == 0) {
+        IrInstruction *result = ir_const(ira, &instruction->base, int_type);
+        bigint_init_unsigned(&result->value.data.x_bigint, 0);
+        return result;
+    }
+
+    if (instr_is_comptime(casted_high) &&
+        instr_is_comptime(casted_low) &&
+        instr_is_comptime(casted_shift)) {
+        ConstExprValue *val_high = ir_resolve_const(ira, casted_high, UndefBad);
+        if (!val_high)
+            return ira->codegen->invalid_instruction;
+
+        ConstExprValue *val_low = ir_resolve_const(ira, casted_low, UndefBad);
+        if (!val_low)
+            return ira->codegen->invalid_instruction;
+
+        ConstExprValue *val_shift = ir_resolve_const(ira, casted_shift, UndefBad);
+        if (!val_shift)
+            return ira->codegen->invalid_instruction;
+
+        if (bigint_cmp_zero(&val_shift->data.x_bigint) == CmpLT) {
+            Buf *val_buf = buf_alloc();
+            bigint_append_buf(val_buf, &val_shift->data.x_bigint, 10);
+            ir_add_error(ira, &instruction->base,
+                buf_sprintf("shift by negative value %s", buf_ptr(val_buf)));
+        }
+        IrInstruction *result = ir_const(ira, &instruction->base, int_type);
+        bigint_fsh(&result->value.data.x_bigint, &val_high->data.x_bigint,
+            &val_low->data.x_bigint,
+            &val_shift->data.x_bigint,
+            int_type->data.integral.bit_count,
+            true);
+        return result;
+    }
+
+    IrInstruction *result = ir_build_fshl(&ira->new_irb, instruction->base.scope,
+            instruction->base.source_node, nullptr, casted_high, casted_low, casted_shift);
+    result->value.type = int_type;
+    return result;
+}
+
+static IrInstruction *ir_analyze_instruction_fshr(IrAnalyze *ira, IrInstructionFshr *instruction) {
+    ZigType *int_type = ir_resolve_type(ira, instruction->type->child);
+    if (type_is_invalid(int_type))
+        return ira->codegen->invalid_instruction;
+
+    IrInstruction *high = instruction->high->child;
+    IrInstruction *low = instruction->low->child;
+    IrInstruction *shift = instruction->shift->child;
+
+    if (int_type->id != ZigTypeIdInt) {
+        ir_add_error(ira, instruction->type,
+            buf_sprintf("expected integer type, found '%s'", buf_ptr(&int_type->name)));
+        return ira->codegen->invalid_instruction;
+    }
+
+    IrInstruction *casted_high = ir_implicit_cast(ira, high, int_type);
+    if (type_is_invalid(casted_high->value.type))
+        return ira->codegen->invalid_instruction;
+
+    IrInstruction *casted_low = ir_implicit_cast(ira, low, int_type);
+    if (type_is_invalid(casted_low->value.type))
+        return ira->codegen->invalid_instruction;
+
+    ZigType *shift_type = get_shift_type(ira->codegen, int_type->data.integral.bit_count);
+
+    IrInstruction *implicitly_casted_shift = ir_implicit_cast(ira, shift, shift_type);
+    if (type_is_invalid(implicitly_casted_shift->value.type))
+        return ira->codegen->invalid_instruction;
+
+    // LLVM actually takes this argument at full width, because that is the register size
+    IrInstruction *casted_shift = ir_analyze_widen_or_shorten(ira, &instruction->base, implicitly_casted_shift, int_type);
+
+    if (int_type->data.integral.bit_count == 0) {
+        IrInstruction *result = ir_const(ira, &instruction->base, int_type);
+        bigint_init_unsigned(&result->value.data.x_bigint, 0);
+        return result;
+    }
+
+    if (instr_is_comptime(casted_high) &&
+        instr_is_comptime(casted_low) &&
+        instr_is_comptime(casted_shift)) {
+        ConstExprValue *val_high = ir_resolve_const(ira, casted_high, UndefBad);
+        if (!val_high)
+            return ira->codegen->invalid_instruction;
+
+        ConstExprValue *val_low = ir_resolve_const(ira, casted_low, UndefBad);
+        if (!val_low)
+            return ira->codegen->invalid_instruction;
+
+        ConstExprValue *val_shift = ir_resolve_const(ira, casted_shift, UndefBad);
+        if (!val_shift)
+            return ira->codegen->invalid_instruction;
+
+        if (bigint_cmp_zero(&val_shift->data.x_bigint) == CmpLT) {
+            Buf *val_buf = buf_alloc();
+            bigint_append_buf(val_buf, &val_shift->data.x_bigint, 10);
+            ir_add_error(ira, &instruction->base,
+                buf_sprintf("shift by negative value %s", buf_ptr(val_buf)));
+        }
+        IrInstruction *result = ir_const(ira, &instruction->base, int_type);
+        bigint_fsh(&result->value.data.x_bigint, &val_high->data.x_bigint,
+            &val_low->data.x_bigint,
+            &val_shift->data.x_bigint,
+            int_type->data.integral.bit_count,
+            false);
+        return result;
+    }
+
+    IrInstruction *result = ir_build_fshr(&ira->new_irb, instruction->base.scope,
+            instruction->base.source_node, nullptr, casted_high, casted_low, casted_shift);
+    result->value.type = int_type;
     return result;
 }
 
@@ -22648,8 +22907,6 @@ static IrInstruction *ir_analyze_instruction_bswap(IrAnalyze *ira, IrInstruction
         return ira->codegen->invalid_instruction;
 
     IrInstruction *op = instruction->op->child;
-    if (type_is_invalid(op->value.type))
-        return ira->codegen->invalid_instruction;
 
     if (int_type->id != ZigTypeIdInt) {
         ir_add_error(ira, instruction->type,
@@ -22657,16 +22914,22 @@ static IrInstruction *ir_analyze_instruction_bswap(IrAnalyze *ira, IrInstruction
         return ira->codegen->invalid_instruction;
     }
 
+    IrInstruction *casted_op = ir_implicit_cast(ira, op, int_type);
+    if (type_is_invalid(casted_op->value.type))
+        return ira->codegen->invalid_instruction;
+
     if (int_type->data.integral.bit_count % 8 != 0) {
-        ir_add_error(ira, instruction->type,
-            buf_sprintf("@bswap integer type '%s' has %" PRIu32 " bits which is not evenly divisible by 8",
+        ir_add_error(ira, instruction->op,
+            buf_sprintf("@bSwap integer type '%s' has %" PRIu32 " bits which is not evenly divisible by 8",
                 buf_ptr(&int_type->name), int_type->data.integral.bit_count));
         return ira->codegen->invalid_instruction;
     }
 
-    IrInstruction *casted_op = ir_implicit_cast(ira, op, int_type);
-    if (type_is_invalid(casted_op->value.type))
+    if (op->value.type->id == ZigTypeIdComptimeInt) {
+        ir_add_error(ira, instruction->op,
+            buf_sprintf("expected %s fixed-width integer type, found %s", buf_ptr(&int_type->name), buf_ptr(&op->value.type->name)));
         return ira->codegen->invalid_instruction;
+    }
 
     if (int_type->data.integral.bit_count == 0) {
         IrInstruction *result = ir_const(ira, &instruction->base, int_type);
@@ -22675,7 +22938,7 @@ static IrInstruction *ir_analyze_instruction_bswap(IrAnalyze *ira, IrInstruction
     }
 
     if (int_type->data.integral.bit_count == 8) {
-        return casted_op;
+        return op;
     }
 
     if (instr_is_comptime(casted_op)) {
@@ -22704,8 +22967,6 @@ static IrInstruction *ir_analyze_instruction_bit_reverse(IrAnalyze *ira, IrInstr
         return ira->codegen->invalid_instruction;
 
     IrInstruction *op = instruction->op->child;
-    if (type_is_invalid(op->value.type))
-        return ira->codegen->invalid_instruction;
 
     if (int_type->id != ZigTypeIdInt) {
         ir_add_error(ira, instruction->type,
@@ -22908,6 +23169,14 @@ static IrInstruction *ir_analyze_instruction_nocast(IrAnalyze *ira, IrInstructio
             return ir_analyze_instruction_ctz(ira, (IrInstructionCtz *)instruction);
         case IrInstructionIdPopCount:
             return ir_analyze_instruction_pop_count(ira, (IrInstructionPopCount *)instruction);
+        case IrInstructionIdBswap:
+            return ir_analyze_instruction_bswap(ira, (IrInstructionBswap *)instruction);
+        case IrInstructionIdBitReverse:
+            return ir_analyze_instruction_bit_reverse(ira, (IrInstructionBitReverse *)instruction);
+        case IrInstructionIdFshl:
+            return ir_analyze_instruction_fshl(ira, (IrInstructionFshl *)instruction);
+        case IrInstructionIdFshr:
+            return ir_analyze_instruction_fshr(ira, (IrInstructionFshr *)instruction);
         case IrInstructionIdSwitchBr:
             return ir_analyze_instruction_switch_br(ira, (IrInstructionSwitchBr *)instruction);
         case IrInstructionIdSwitchTarget:
@@ -23098,10 +23367,6 @@ static IrInstruction *ir_analyze_instruction_nocast(IrAnalyze *ira, IrInstructio
             return ir_analyze_instruction_mark_err_ret_trace_ptr(ira, (IrInstructionMarkErrRetTracePtr *)instruction);
         case IrInstructionIdSqrt:
             return ir_analyze_instruction_sqrt(ira, (IrInstructionSqrt *)instruction);
-        case IrInstructionIdBswap:
-            return ir_analyze_instruction_bswap(ira, (IrInstructionBswap *)instruction);
-        case IrInstructionIdBitReverse:
-            return ir_analyze_instruction_bit_reverse(ira, (IrInstructionBitReverse *)instruction);
         case IrInstructionIdIntToErr:
             return ir_analyze_instruction_int_to_err(ira, (IrInstructionIntToErr *)instruction);
         case IrInstructionIdErrToInt:
@@ -23275,6 +23540,10 @@ bool ir_has_side_effects(IrInstruction *instruction) {
         case IrInstructionIdClz:
         case IrInstructionIdCtz:
         case IrInstructionIdPopCount:
+        case IrInstructionIdBswap:
+        case IrInstructionIdBitReverse:
+        case IrInstructionIdFshl:
+        case IrInstructionIdFshr:
         case IrInstructionIdSwitchVar:
         case IrInstructionIdSwitchTarget:
         case IrInstructionIdUnionTag:
@@ -23332,8 +23601,6 @@ bool ir_has_side_effects(IrInstruction *instruction) {
         case IrInstructionIdCoroPromise:
         case IrInstructionIdPromiseResultType:
         case IrInstructionIdSqrt:
-        case IrInstructionIdBswap:
-        case IrInstructionIdBitReverse:
         case IrInstructionIdAtomicLoad:
         case IrInstructionIdIntCast:
         case IrInstructionIdFloatCast:

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -504,19 +504,93 @@ static void ir_print_optional_unwrap_ptr(IrPrint *irp, IrInstructionOptionalUnwr
 
 static void ir_print_clz(IrPrint *irp, IrInstructionClz *instruction) {
     fprintf(irp->f, "@clz(");
-    ir_print_other_instruction(irp, instruction->value);
+    if (instruction->type != nullptr) {
+        ir_print_other_instruction(irp, instruction->type);
+    } else {
+        fprintf(irp->f, "null");
+    }
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->op);
     fprintf(irp->f, ")");
 }
 
 static void ir_print_ctz(IrPrint *irp, IrInstructionCtz *instruction) {
     fprintf(irp->f, "@ctz(");
-    ir_print_other_instruction(irp, instruction->value);
+    if (instruction->type != nullptr) {
+        ir_print_other_instruction(irp, instruction->type);
+    } else {
+        fprintf(irp->f, "null");
+    }
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->op);
     fprintf(irp->f, ")");
 }
 
 static void ir_print_pop_count(IrPrint *irp, IrInstructionPopCount *instruction) {
     fprintf(irp->f, "@popCount(");
-    ir_print_other_instruction(irp, instruction->value);
+    if (instruction->type != nullptr) {
+        ir_print_other_instruction(irp, instruction->type);
+    } else {
+        fprintf(irp->f, "null");
+    }
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->op);
+    fprintf(irp->f, ")");
+}
+
+static void ir_print_bswap(IrPrint *irp, IrInstructionBswap *instruction) {
+    fprintf(irp->f, "@bSwap(");
+    if (instruction->type != nullptr) {
+        ir_print_other_instruction(irp, instruction->type);
+    } else {
+        fprintf(irp->f, "null");
+    }
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->op);
+    fprintf(irp->f, ")");
+}
+
+static void ir_print_fshl(IrPrint *irp, IrInstructionFshl *instruction) {
+    fprintf(irp->f, "@fshl(");
+    if (instruction->type != nullptr) {
+        ir_print_other_instruction(irp, instruction->type);
+    } else {
+        fprintf(irp->f, "null");
+    }
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->high);
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->low);
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->shift);
+    fprintf(irp->f, ")");
+}
+
+static void ir_print_fshr(IrPrint *irp, IrInstructionFshr *instruction) {
+    fprintf(irp->f, "@fshr(");
+    if (instruction->type != nullptr) {
+        ir_print_other_instruction(irp, instruction->type);
+    } else {
+        fprintf(irp->f, "null");
+    }
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->high);
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->low);
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->shift);
+    fprintf(irp->f, ")");
+}
+
+static void ir_print_bit_reverse(IrPrint *irp, IrInstructionBitReverse *instruction) {
+    fprintf(irp->f, "@bitReverse(");
+    if (instruction->type != nullptr) {
+        ir_print_other_instruction(irp, instruction->type);
+    } else {
+        fprintf(irp->f, "null");
+    }
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->op);
     fprintf(irp->f, ")");
 }
 
@@ -1398,30 +1472,6 @@ static void ir_print_decl_var_gen(IrPrint *irp, IrInstructionDeclVarGen *decl_va
     }
 }
 
-static void ir_print_bswap(IrPrint *irp, IrInstructionBswap *instruction) {
-    fprintf(irp->f, "@bswap(");
-    if (instruction->type != nullptr) {
-        ir_print_other_instruction(irp, instruction->type);
-    } else {
-        fprintf(irp->f, "null");
-    }
-    fprintf(irp->f, ",");
-    ir_print_other_instruction(irp, instruction->op);
-    fprintf(irp->f, ")");
-}
-
-static void ir_print_bit_reverse(IrPrint *irp, IrInstructionBitReverse *instruction) {
-    fprintf(irp->f, "@bitreverse(");
-    if (instruction->type != nullptr) {
-        ir_print_other_instruction(irp, instruction->type);
-    } else {
-        fprintf(irp->f, "null");
-    }
-    fprintf(irp->f, ",");
-    ir_print_other_instruction(irp, instruction->op);
-    fprintf(irp->f, ")");
-}
-
 static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
     ir_print_prefix(irp, instruction);
     switch (instruction->id) {
@@ -1538,14 +1588,26 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
         case IrInstructionIdOptionalUnwrapPtr:
             ir_print_optional_unwrap_ptr(irp, (IrInstructionOptionalUnwrapPtr *)instruction);
             break;
-        case IrInstructionIdCtz:
-            ir_print_ctz(irp, (IrInstructionCtz *)instruction);
-            break;
         case IrInstructionIdPopCount:
             ir_print_pop_count(irp, (IrInstructionPopCount *)instruction);
             break;
         case IrInstructionIdClz:
             ir_print_clz(irp, (IrInstructionClz *)instruction);
+            break;
+        case IrInstructionIdCtz:
+            ir_print_ctz(irp, (IrInstructionCtz *)instruction);
+            break;
+        case IrInstructionIdBswap:
+            ir_print_bswap(irp, (IrInstructionBswap *)instruction);
+            break;
+        case IrInstructionIdBitReverse:
+            ir_print_bit_reverse(irp, (IrInstructionBitReverse *)instruction);
+            break;
+        case IrInstructionIdFshl:
+            ir_print_fshl(irp, (IrInstructionFshl *)instruction);
+            break;
+        case IrInstructionIdFshr:
+            ir_print_fshr(irp, (IrInstructionFshr *)instruction);
             break;
         case IrInstructionIdSwitchBr:
             ir_print_switch_br(irp, (IrInstructionSwitchBr *)instruction);
@@ -1852,12 +1914,6 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdSqrt:
             ir_print_sqrt(irp, (IrInstructionSqrt *)instruction);
-            break;
-        case IrInstructionIdBswap:
-            ir_print_bswap(irp, (IrInstructionBswap *)instruction);
-            break;
-        case IrInstructionIdBitReverse:
-            ir_print_bit_reverse(irp, (IrInstructionBitReverse *)instruction);
             break;
         case IrInstructionIdAtomicLoad:
             ir_print_atomic_load(irp, (IrInstructionAtomicLoad *)instruction);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -835,6 +835,16 @@ static void ir_print_memcpy(IrPrint *irp, IrInstructionMemcpy *instruction) {
     fprintf(irp->f, ")");
 }
 
+static void ir_print_memmove(IrPrint *irp, IrInstructionMemMove *instruction) {
+    fprintf(irp->f, "@memMove(");
+    ir_print_other_instruction(irp, instruction->dest_ptr);
+    fprintf(irp->f, ", ");
+    ir_print_other_instruction(irp, instruction->src_ptr);
+    fprintf(irp->f, ", ");
+    ir_print_other_instruction(irp, instruction->count);
+    fprintf(irp->f, ")");
+}
+
 static void ir_print_slice(IrPrint *irp, IrInstructionSlice *instruction) {
     ir_print_other_instruction(irp, instruction->ptr);
     fprintf(irp->f, "[");
@@ -1701,6 +1711,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdMemcpy:
             ir_print_memcpy(irp, (IrInstructionMemcpy *)instruction);
+            break;
+        case IrInstructionIdMemMove:
+            ir_print_memmove(irp, (IrInstructionMemMove *)instruction);
             break;
         case IrInstructionIdSlice:
             ir_print_slice(irp, (IrInstructionSlice *)instruction);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -924,6 +924,27 @@ static void ir_print_overflow_op(IrPrint *irp, IrInstructionOverflowOp *instruct
     fprintf(irp->f, ")");
 }
 
+static void ir_print_saturating_op(IrPrint *irp, IrInstructionSaturatingOp *instruction) {
+    switch (instruction->op) {
+        case IrSaturatingOpUAdd:
+        case IrSaturatingOpSAdd:
+            fprintf(irp->f, "@satAdd(");
+            break;
+        case IrSaturatingOpUSub:
+        case IrSaturatingOpSSub:
+            fprintf(irp->f, "@satSub(");
+            break;
+        default:
+            zig_unreachable();
+    }
+    ir_print_other_instruction(irp, instruction->type_value);
+    fprintf(irp->f, ", ");
+    ir_print_other_instruction(irp, instruction->op1);
+    fprintf(irp->f, ", ");
+    ir_print_other_instruction(irp, instruction->op2);
+    fprintf(irp->f, ")");
+}
+
 static void ir_print_test_err(IrPrint *irp, IrInstructionTestErr *instruction) {
     fprintf(irp->f, "@testError(");
     ir_print_other_instruction(irp, instruction->value);
@@ -1744,6 +1765,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdOverflowOp:
             ir_print_overflow_op(irp, (IrInstructionOverflowOp *)instruction);
+            break;
+        case IrInstructionIdSaturatingOp:
+            ir_print_saturating_op(irp, (IrInstructionSaturatingOp *)instruction);
             break;
         case IrInstructionIdTestErr:
             ir_print_test_err(irp, (IrInstructionTestErr *)instruction);

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -78,7 +78,21 @@ static inline int ctzll(unsigned long long mask) {
     zig_unreachable();
 #endif
 }
+static inline int clz(unsigned mask) {
+    unsigned long lz;
+    if (_BitScanReverse(&lz, mask))
+        return static_cast<int>(63 - lz);
+    zig_unreachable();
+}
+static inline int ctz(unsigned mask) {
+    unsigned long result;
+    if (_BitScanForward(&result, mask))
+        return result;
+    zig_unreachable();
+}
 #else
+#define clz(x) __builtin_clz(x)
+#define ctz(x) __builtin_ctz(x)
 #define clzll(x) __builtin_clzll(x)
 #define ctzll(x) __builtin_ctzll(x)
 #endif

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -240,6 +240,13 @@ LLVMValueRef ZigLLVMBuildMemSet(LLVMBuilderRef B, LLVMValueRef Ptr, LLVMValueRef
     return wrap(call_inst);
 }
 
+LLVMValueRef ZigLLVMBuildMemMove(LLVMBuilderRef B, LLVMValueRef Dst, unsigned DstAlign,
+        LLVMValueRef Src, unsigned SrcAlign, LLVMValueRef Size, bool isVolatile)
+{
+    CallInst *call_inst = unwrap(B)->CreateMemMove(unwrap(Dst), DstAlign, unwrap(Src), SrcAlign, unwrap(Size), isVolatile);
+    return wrap(call_inst);
+}
+
 void ZigLLVMFnSetSubprogram(LLVMValueRef fn, ZigLLVMDISubprogram *subprogram) {
     assert( isa<Function>(unwrap(fn)) );
     Function *unwrapped_function = reinterpret_cast<Function*>(unwrap(fn));

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -74,6 +74,9 @@ ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMemCpy(LLVMBuilderRef B, LLVMValueRef Dst,
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMemSet(LLVMBuilderRef B, LLVMValueRef Ptr, LLVMValueRef Val, LLVMValueRef Size,
         unsigned Align, bool isVolatile);
 
+ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMemMove(LLVMBuilderRef B, LLVMValueRef Dst, unsigned DstAlign,
+        LLVMValueRef Src, unsigned SrcAlign, LLVMValueRef Size, bool isVolatile);
+
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildCmpXchg(LLVMBuilderRef builder, LLVMValueRef ptr, LLVMValueRef cmp,
         LLVMValueRef new_val, LLVMAtomicOrdering success_ordering,
         LLVMAtomicOrdering failure_ordering, bool is_weak);

--- a/std/array_list.zig
+++ b/std/array_list.zig
@@ -89,7 +89,7 @@ pub fn AlignedArrayList(comptime T: type, comptime A: u29) type {
             try self.ensureCapacity(self.len + 1);
             self.len += 1;
 
-            mem.copyBackwards(T, self.items[n + 1 .. self.len], self.items[n .. self.len - 1]);
+            mem.move(T, self.items[n + 1 .. self.len], self.items[n .. self.len - 1]);
             self.items[n] = item;
         }
 
@@ -97,7 +97,7 @@ pub fn AlignedArrayList(comptime T: type, comptime A: u29) type {
             try self.ensureCapacity(self.len + items.len);
             self.len += items.len;
 
-            mem.copyBackwards(T, self.items[n + items.len .. self.len], self.items[n .. self.len - items.len]);
+            mem.move(T, self.items[n + items.len .. self.len], self.items[n .. self.len - items.len]);
             mem.copy(T, self.items[n .. n + items.len], items);
         }
 

--- a/std/crypto/blake2.zig
+++ b/std/crypto/blake2.zig
@@ -164,13 +164,13 @@ fn Blake2s(comptime out_len: usize) type {
             inline while (j < 10) : (j += 1) {
                 inline for (rounds) |r| {
                     v[r.a] = v[r.a] +% v[r.b] +% m[sigma[j][r.x]];
-                    v[r.d] = math.rotr(u32, v[r.d] ^ v[r.a], usize(16));
+                    v[r.d] = math.rotr(u32, v[r.d] ^ v[r.a], 16);
                     v[r.c] = v[r.c] +% v[r.d];
-                    v[r.b] = math.rotr(u32, v[r.b] ^ v[r.c], usize(12));
+                    v[r.b] = math.rotr(u32, v[r.b] ^ v[r.c], 12);
                     v[r.a] = v[r.a] +% v[r.b] +% m[sigma[j][r.y]];
-                    v[r.d] = math.rotr(u32, v[r.d] ^ v[r.a], usize(8));
+                    v[r.d] = math.rotr(u32, v[r.d] ^ v[r.a], 8);
                     v[r.c] = v[r.c] +% v[r.d];
-                    v[r.b] = math.rotr(u32, v[r.b] ^ v[r.c], usize(7));
+                    v[r.b] = math.rotr(u32, v[r.b] ^ v[r.c], 7);
                 }
             }
 
@@ -398,13 +398,13 @@ fn Blake2b(comptime out_len: usize) type {
             inline while (j < 12) : (j += 1) {
                 inline for (rounds) |r| {
                     v[r.a] = v[r.a] +% v[r.b] +% m[sigma[j][r.x]];
-                    v[r.d] = math.rotr(u64, v[r.d] ^ v[r.a], usize(32));
+                    v[r.d] = math.rotr(u64, v[r.d] ^ v[r.a], 32);
                     v[r.c] = v[r.c] +% v[r.d];
-                    v[r.b] = math.rotr(u64, v[r.b] ^ v[r.c], usize(24));
+                    v[r.b] = math.rotr(u64, v[r.b] ^ v[r.c], 24);
                     v[r.a] = v[r.a] +% v[r.b] +% m[sigma[j][r.y]];
-                    v[r.d] = math.rotr(u64, v[r.d] ^ v[r.a], usize(16));
+                    v[r.d] = math.rotr(u64, v[r.d] ^ v[r.a], 16);
                     v[r.c] = v[r.c] +% v[r.d];
-                    v[r.b] = math.rotr(u64, v[r.b] ^ v[r.c], usize(63));
+                    v[r.b] = math.rotr(u64, v[r.b] ^ v[r.c], 63);
                 }
             }
 

--- a/std/crypto/chacha20.zig
+++ b/std/crypto/chacha20.zig
@@ -49,13 +49,13 @@ fn salsa20_wordtobyte(out: []u8, input: [16]u32) void {
         // two-round cycles
         inline for (rounds) |r| {
             x[r.a] +%= x[r.b];
-            x[r.d] = std.math.rotl(u32, x[r.d] ^ x[r.a], u32(16));
+            x[r.d] = std.math.rotl(u32, x[r.d] ^ x[r.a], 16);
             x[r.c] +%= x[r.d];
-            x[r.b] = std.math.rotl(u32, x[r.b] ^ x[r.c], u32(12));
+            x[r.b] = std.math.rotl(u32, x[r.b] ^ x[r.c], 12);
             x[r.a] +%= x[r.b];
-            x[r.d] = std.math.rotl(u32, x[r.d] ^ x[r.a], u32(8));
+            x[r.d] = std.math.rotl(u32, x[r.d] ^ x[r.a], 8);
             x[r.c] +%= x[r.d];
-            x[r.b] = std.math.rotl(u32, x[r.b] ^ x[r.c], u32(7));
+            x[r.b] = std.math.rotl(u32, x[r.b] ^ x[r.c], 7);
         }
     }
 

--- a/std/crypto/sha1.zig
+++ b/std/crypto/sha1.zig
@@ -148,8 +148,8 @@ pub const Sha1 = struct {
         inline for (round0a) |r| {
             s[r.i] = (u32(b[r.i * 4 + 0]) << 24) | (u32(b[r.i * 4 + 1]) << 16) | (u32(b[r.i * 4 + 2]) << 8) | (u32(b[r.i * 4 + 3]) << 0);
 
-            v[r.e] = v[r.e] +% math.rotl(u32, v[r.a], u32(5)) +% 0x5A827999 +% s[r.i & 0xf] +% ((v[r.b] & v[r.c]) | (~v[r.b] & v[r.d]));
-            v[r.b] = math.rotl(u32, v[r.b], u32(30));
+            v[r.e] = v[r.e] +% math.rotl(u32, v[r.a], 5) +% 0x5A827999 +% s[r.i & 0xf] +% ((v[r.b] & v[r.c]) | (~v[r.b] & v[r.d]));
+            v[r.b] = math.rotl(u32, v[r.b], 30);
         }
 
         const round0b = comptime []RoundParam{
@@ -160,10 +160,10 @@ pub const Sha1 = struct {
         };
         inline for (round0b) |r| {
             const t = s[(r.i - 3) & 0xf] ^ s[(r.i - 8) & 0xf] ^ s[(r.i - 14) & 0xf] ^ s[(r.i - 16) & 0xf];
-            s[r.i & 0xf] = math.rotl(u32, t, u32(1));
+            s[r.i & 0xf] = math.rotl(u32, t, 1);
 
-            v[r.e] = v[r.e] +% math.rotl(u32, v[r.a], u32(5)) +% 0x5A827999 +% s[r.i & 0xf] +% ((v[r.b] & v[r.c]) | (~v[r.b] & v[r.d]));
-            v[r.b] = math.rotl(u32, v[r.b], u32(30));
+            v[r.e] = v[r.e] +% math.rotl(u32, v[r.a], 5) +% 0x5A827999 +% s[r.i & 0xf] +% ((v[r.b] & v[r.c]) | (~v[r.b] & v[r.d]));
+            v[r.b] = math.rotl(u32, v[r.b], 30);
         }
 
         const round1 = comptime []RoundParam{
@@ -190,10 +190,10 @@ pub const Sha1 = struct {
         };
         inline for (round1) |r| {
             const t = s[(r.i - 3) & 0xf] ^ s[(r.i - 8) & 0xf] ^ s[(r.i - 14) & 0xf] ^ s[(r.i - 16) & 0xf];
-            s[r.i & 0xf] = math.rotl(u32, t, u32(1));
+            s[r.i & 0xf] = math.rotl(u32, t, 1);
 
-            v[r.e] = v[r.e] +% math.rotl(u32, v[r.a], u32(5)) +% 0x6ED9EBA1 +% s[r.i & 0xf] +% (v[r.b] ^ v[r.c] ^ v[r.d]);
-            v[r.b] = math.rotl(u32, v[r.b], u32(30));
+            v[r.e] = v[r.e] +% math.rotl(u32, v[r.a], 5) +% 0x6ED9EBA1 +% s[r.i & 0xf] +% (v[r.b] ^ v[r.c] ^ v[r.d]);
+            v[r.b] = math.rotl(u32, v[r.b], 30);
         }
 
         const round2 = comptime []RoundParam{
@@ -220,10 +220,10 @@ pub const Sha1 = struct {
         };
         inline for (round2) |r| {
             const t = s[(r.i - 3) & 0xf] ^ s[(r.i - 8) & 0xf] ^ s[(r.i - 14) & 0xf] ^ s[(r.i - 16) & 0xf];
-            s[r.i & 0xf] = math.rotl(u32, t, u32(1));
+            s[r.i & 0xf] = math.rotl(u32, t, 1);
 
-            v[r.e] = v[r.e] +% math.rotl(u32, v[r.a], u32(5)) +% 0x8F1BBCDC +% s[r.i & 0xf] +% ((v[r.b] & v[r.c]) ^ (v[r.b] & v[r.d]) ^ (v[r.c] & v[r.d]));
-            v[r.b] = math.rotl(u32, v[r.b], u32(30));
+            v[r.e] = v[r.e] +% math.rotl(u32, v[r.a], 5) +% 0x8F1BBCDC +% s[r.i & 0xf] +% ((v[r.b] & v[r.c]) ^ (v[r.b] & v[r.d]) ^ (v[r.c] & v[r.d]));
+            v[r.b] = math.rotl(u32, v[r.b], 30);
         }
 
         const round3 = comptime []RoundParam{
@@ -250,10 +250,10 @@ pub const Sha1 = struct {
         };
         inline for (round3) |r| {
             const t = s[(r.i - 3) & 0xf] ^ s[(r.i - 8) & 0xf] ^ s[(r.i - 14) & 0xf] ^ s[(r.i - 16) & 0xf];
-            s[r.i & 0xf] = math.rotl(u32, t, u32(1));
+            s[r.i & 0xf] = math.rotl(u32, t, 1);
 
-            v[r.e] = v[r.e] +% math.rotl(u32, v[r.a], u32(5)) +% 0xCA62C1D6 +% s[r.i & 0xf] +% (v[r.b] ^ v[r.c] ^ v[r.d]);
-            v[r.b] = math.rotl(u32, v[r.b], u32(30));
+            v[r.e] = v[r.e] +% math.rotl(u32, v[r.a], 5) +% 0xCA62C1D6 +% s[r.i & 0xf] +% (v[r.b] ^ v[r.c] ^ v[r.d]);
+            v[r.b] = math.rotl(u32, v[r.b], 30);
         }
 
         d.s[0] +%= v[0];

--- a/std/crypto/sha2.zig
+++ b/std/crypto/sha2.zig
@@ -186,7 +186,14 @@ fn Sha2_32(comptime params: Sha2Params32) type {
                 s[i] |= u32(b[i * 4 + 3]) << 0;
             }
             while (i < 64) : (i += 1) {
-                s[i] = s[i - 16] +% s[i - 7] +% (math.rotr(u32, s[i - 15], u32(7)) ^ math.rotr(u32, s[i - 15], u32(18)) ^ (s[i - 15] >> 3)) +% (math.rotr(u32, s[i - 2], u32(17)) ^ math.rotr(u32, s[i - 2], u32(19)) ^ (s[i - 2] >> 10));
+                s[i] = s[i - 16] +%
+                    s[i - 7] +%
+                    (math.rotr(u32, s[i - 15], 7) ^
+                        math.rotr(u32, s[i - 15], 18) ^
+                        (s[i - 15] >> 3)) +%
+                    (math.rotr(u32, s[i - 2], 17) ^
+                        math.rotr(u32, s[i - 2], 19) ^
+                        (s[i - 2] >> 10));
             }
 
             var v: [8]u32 = []u32{

--- a/std/crypto/sha3.zig
+++ b/std/crypto/sha3.zig
@@ -133,7 +133,7 @@ fn keccak_f(comptime F: usize, d: []u8) void {
         }
         x = 0;
         inline while (x < 5) : (x += 1) {
-            t[0] = c[M5[x + 4]] ^ math.rotl(u64, c[M5[x + 1]], usize(1));
+            t[0] = c[M5[x + 4]] ^ math.rotl(u64, c[M5[x + 1]], 1);
             y = 0;
             inline while (y < 5) : (y += 1) {
                 s[x + y * 5] ^= t[0];

--- a/std/hash/siphash.zig
+++ b/std/hash/siphash.zig
@@ -135,19 +135,19 @@ fn SipHash(comptime T: type, comptime c_rounds: usize, comptime d_rounds: usize)
 
         fn sipRound(d: *Self) void {
             d.v0 +%= d.v1;
-            d.v1 = math.rotl(u64, d.v1, u64(13));
+            d.v1 = math.rotl(u64, d.v1, 13);
             d.v1 ^= d.v0;
-            d.v0 = math.rotl(u64, d.v0, u64(32));
+            d.v0 = math.rotl(u64, d.v0, 32);
             d.v2 +%= d.v3;
-            d.v3 = math.rotl(u64, d.v3, u64(16));
+            d.v3 = math.rotl(u64, d.v3, 16);
             d.v3 ^= d.v2;
             d.v0 +%= d.v3;
-            d.v3 = math.rotl(u64, d.v3, u64(21));
+            d.v3 = math.rotl(u64, d.v3, 21);
             d.v3 ^= d.v0;
             d.v2 +%= d.v1;
-            d.v1 = math.rotl(u64, d.v1, u64(17));
+            d.v1 = math.rotl(u64, d.v1, 17);
             d.v1 ^= d.v2;
-            d.v2 = math.rotl(u64, d.v2, u64(32));
+            d.v2 = math.rotl(u64, d.v2, 32);
         }
 
         pub fn hash(key: []const u8, input: []const u8) T {

--- a/std/heap.zig
+++ b/std/heap.zig
@@ -591,7 +591,7 @@ fn testAllocatorLargeAlignment(allocator: *mem.Allocator) mem.Allocator.Error!vo
     const large_align = u29(os.page_size << 2);
 
     var align_mask: usize = undefined;
-    _ = @shlWithOverflow(usize, ~usize(0), USizeShift(@ctz(large_align)), &align_mask);
+    _ = @shlWithOverflow(usize, ~usize(0), USizeShift(@ctz(u29, large_align)), &align_mask);
 
     var slice = try allocator.alignedAlloc(u8, large_align, 500);
     testing.expect(@ptrToInt(slice.ptr) & align_mask == @ptrToInt(slice.ptr));

--- a/std/math.zig
+++ b/std/math.zig
@@ -698,7 +698,7 @@ test "math.floorPowerOfTwo" {
 
 pub fn log2_int(comptime T: type, x: T) Log2Int(T) {
     assert(x != 0);
-    return @intCast(Log2Int(T), T.bit_count - 1 - @clz(x));
+    return @intCast(Log2Int(T), T.bit_count - 1 - @clz(T, x));
 }
 
 pub fn log2_int_ceil(comptime T: type, x: T) Log2Int(T) {

--- a/std/math.zig
+++ b/std/math.zig
@@ -331,41 +331,37 @@ test "math.shr" {
 }
 
 /// Rotates right. Only unsigned values can be rotated.
-/// Negative shift values results in shift modulo the bit count.
-pub fn rotr(comptime T: type, x: T, r: var) T {
+pub fn rotr(comptime T: type, x: T, r: Log2Int(T)) T {
     if (T.is_signed) {
         @compileError("cannot rotate signed integer");
     } else {
-        const ar = @mod(r, T.bit_count);
-        return shr(T, x, ar) | shl(T, x, T.bit_count - ar);
+        return @fshr(T, x, x, r);
     }
 }
 
 test "math.rotr" {
-    testing.expect(rotr(u8, 0b00000001, usize(0)) == 0b00000001);
-    testing.expect(rotr(u8, 0b00000001, usize(9)) == 0b10000000);
-    testing.expect(rotr(u8, 0b00000001, usize(8)) == 0b00000001);
-    testing.expect(rotr(u8, 0b00000001, usize(4)) == 0b00010000);
-    testing.expect(rotr(u8, 0b00000001, isize(-1)) == 0b00000010);
+    testing.expect(rotr(u8, 0b00000001, 0) == 0b00000001);
+    testing.expect(rotr(u8, 0b00000001, 1) == 0b10000000);
+    testing.expect(rotr(u8, 0b00000001, 0) == 0b00000001);
+    testing.expect(rotr(u8, 0b00000001, 4) == 0b00010000);
+    testing.expect(rotr(u8, 0b00000001, 7) == 0b00000010);
 }
 
 /// Rotates left. Only unsigned values can be rotated.
-/// Negative shift values results in shift modulo the bit count.
-pub fn rotl(comptime T: type, x: T, r: var) T {
+pub fn rotl(comptime T: type, x: T, r: Log2Int(T)) T {
     if (T.is_signed) {
         @compileError("cannot rotate signed integer");
     } else {
-        const ar = @mod(r, T.bit_count);
-        return shl(T, x, ar) | shr(T, x, T.bit_count - ar);
+        return @fshl(T, x, x, r);
     }
 }
 
 test "math.rotl" {
-    testing.expect(rotl(u8, 0b00000001, usize(0)) == 0b00000001);
-    testing.expect(rotl(u8, 0b00000001, usize(9)) == 0b00000010);
-    testing.expect(rotl(u8, 0b00000001, usize(8)) == 0b00000001);
-    testing.expect(rotl(u8, 0b00000001, usize(4)) == 0b00010000);
-    testing.expect(rotl(u8, 0b00000001, isize(-1)) == 0b10000000);
+    testing.expect(rotl(u8, 0b00000001, 0) == 0b00000001);
+    testing.expect(rotl(u8, 0b00000001, 1) == 0b00000010);
+    testing.expect(rotl(u8, 0b00000001, 0) == 0b00000001);
+    testing.expect(rotl(u8, 0b00000001, 4) == 0b00010000);
+    testing.expect(rotl(u8, 0b00000001, 7) == 0b10000000);
 }
 
 pub fn Log2Int(comptime T: type) type {

--- a/std/math/big/int.zig
+++ b/std/math/big/int.zig
@@ -121,7 +121,7 @@ pub const Int = struct {
 
     // Returns the number of bits required to represent the absolute value of self.
     fn bitCountAbs(self: Int) usize {
-        return (self.len - 1) * Limb.bit_count + (Limb.bit_count - @clz(self.limbs[self.len - 1]));
+        return (self.len - 1) * Limb.bit_count + (Limb.bit_count - @clz(Limb, self.limbs[self.len - 1]));
     }
 
     // Returns the number of bits required to represent the integer in twos-complement form.
@@ -140,9 +140,9 @@ pub const Int = struct {
         if (!self.positive) block: {
             bits += 1;
 
-            if (@popCount(self.limbs[self.len - 1]) == 1) {
+            if (@popCount(Limb, self.limbs[self.len - 1]) == 1) {
                 for (self.limbs[0 .. self.len - 1]) |limb| {
-                    if (@popCount(limb) != 0) {
+                    if (@popCount(Limb, limb) != 0) {
                         break :block;
                     }
                 }
@@ -846,7 +846,7 @@ pub const Int = struct {
         defer tmp.deinit();
 
         // Normalize so y > Limb.bit_count / 2 (i.e. leading bit is set)
-        const norm_shift = @clz(y.limbs[y.len - 1]);
+        const norm_shift = @clz(Limb, y.limbs[y.len - 1]);
         try x.shiftLeft(x.*, norm_shift);
         try y.shiftLeft(y.*, norm_shift);
 

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -519,7 +519,7 @@ pub fn readIntNative(comptime T: type, bytes: *const [@divExact(T.bit_count, 8)]
 /// This function cannot fail and cannot cause undefined behavior.
 /// Assumes the endianness of memory is foreign, so it must byte-swap.
 pub fn readIntForeign(comptime T: type, bytes: *const [@divExact(T.bit_count, 8)]u8) T {
-    return @bswap(T, readIntNative(T, bytes));
+    return @bSwap(T, readIntNative(T, bytes));
 }
 
 pub const readIntLittle = switch (builtin.endian) {
@@ -549,7 +549,7 @@ pub fn readIntSliceNative(comptime T: type, bytes: []const u8) T {
 /// The bit count of T must be evenly divisible by 8.
 /// Assumes the endianness of memory is foreign, so it must byte-swap.
 pub fn readIntSliceForeign(comptime T: type, bytes: []const u8) T {
-    return @bswap(T, readIntSliceNative(T, bytes));
+    return @bSwap(T, readIntSliceNative(T, bytes));
 }
 
 pub const readIntSliceLittle = switch (builtin.endian) {
@@ -630,9 +630,9 @@ pub fn writeIntNative(comptime T: type, buf: *[(T.bit_count + 7) / 8]u8, value: 
 /// Writes an integer to memory, storing it in twos-complement.
 /// This function always succeeds, has defined behavior for all inputs, but
 /// the integer bit width must be divisible by 8.
-/// This function stores in foreign endian, which means it does a @bswap first.
+/// This function stores in foreign endian, which means it does a @bSwap first.
 pub fn writeIntForeign(comptime T: type, buf: *[@divExact(T.bit_count, 8)]u8, value: T) void {
-    writeIntNative(T, buf, @bswap(T, value));
+    writeIntNative(T, buf, @bSwap(T, value));
 }
 
 pub const writeIntLittle = switch (builtin.endian) {
@@ -1235,14 +1235,14 @@ test "std.mem.rotate" {
 pub fn littleToNative(comptime T: type, x: T) T {
     return switch (builtin.endian) {
         builtin.Endian.Little => x,
-        builtin.Endian.Big => @bswap(T, x),
+        builtin.Endian.Big => @bSwap(T, x),
     };
 }
 
 /// Converts a big-endian integer to host endianness.
 pub fn bigToNative(comptime T: type, x: T) T {
     return switch (builtin.endian) {
-        builtin.Endian.Little => @bswap(T, x),
+        builtin.Endian.Little => @bSwap(T, x),
         builtin.Endian.Big => x,
     };
 }
@@ -1267,14 +1267,14 @@ pub fn nativeTo(comptime T: type, x: T, desired_endianness: builtin.Endian) T {
 pub fn nativeToLittle(comptime T: type, x: T) T {
     return switch (builtin.endian) {
         builtin.Endian.Little => x,
-        builtin.Endian.Big => @bswap(T, x),
+        builtin.Endian.Big => @bSwap(T, x),
     };
 }
 
 /// Converts an integer which has host endianness to big endian.
 pub fn nativeToBig(comptime T: type, x: T) T {
     return switch (builtin.endian) {
-        builtin.Endian.Little => @bswap(T, x),
+        builtin.Endian.Little => @bSwap(T, x),
         builtin.Endian.Big => x,
     };
 }

--- a/std/os.zig
+++ b/std/os.zig
@@ -3287,7 +3287,7 @@ pub fn cpuCount(fallback_allocator: *mem.Allocator) CpuCountError!usize {
                             const result = set[0 .. rc / @sizeOf(usize)];
                             var sum: usize = 0;
                             for (result) |x| {
-                                sum += @popCount(x);
+                                sum += @popCount(usize, x);
                             }
                             return sum;
                         } else {

--- a/std/rand.zig
+++ b/std/rand.zig
@@ -632,8 +632,8 @@ pub const Xoroshiro128 = struct {
         const r = s0 +% s1;
 
         s1 ^= s0;
-        self.s[0] = math.rotl(u64, s0, u8(55)) ^ s1 ^ (s1 << 14);
-        self.s[1] = math.rotl(u64, s1, u8(36));
+        self.s[0] = math.rotl(u64, s0, 55) ^ s1 ^ (s1 << 14);
+        self.s[1] = math.rotl(u64, s1, 36);
 
         return r;
     }

--- a/std/special/compiler_rt.zig
+++ b/std/special/compiler_rt.zig
@@ -9,7 +9,7 @@ comptime {
     @export("__getf2", @import("compiler_rt/comparetf2.zig").__getf2, linkage);
 
     if (!is_test) {
-        // only create these aliases when not testing
+        // only create these aliases when not testing -- Yes, I can read the code, but why?
         @export("__cmptf2", @import("compiler_rt/comparetf2.zig").__letf2, linkage);
         @export("__eqtf2", @import("compiler_rt/comparetf2.zig").__letf2, linkage);
         @export("__lttf2", @import("compiler_rt/comparetf2.zig").__letf2, linkage);
@@ -486,7 +486,7 @@ extern fn __udivsi3(n: u32, d: u32) u32 {
     // special cases
     if (d == 0) return 0; // ?!
     if (n == 0) return 0;
-    var sr = @bitCast(c_uint, c_int(@clz(d)) - c_int(@clz(n)));
+    var sr = @bitCast(c_uint, c_int(@clz(u32, d)) - c_int(@clz(u32, n)));
     // 0 <= sr <= n_uword_bits - 1 or sr large
     if (sr > n_uword_bits - 1) {
         // d > r

--- a/std/special/compiler_rt.zig
+++ b/std/special/compiler_rt.zig
@@ -9,7 +9,7 @@ comptime {
     @export("__getf2", @import("compiler_rt/comparetf2.zig").__getf2, linkage);
 
     if (!is_test) {
-        // only create these aliases when not testing -- Yes, I can read the code, but why?
+        // Why don't we need these when testing?
         @export("__cmptf2", @import("compiler_rt/comparetf2.zig").__letf2, linkage);
         @export("__eqtf2", @import("compiler_rt/comparetf2.zig").__letf2, linkage);
         @export("__lttf2", @import("compiler_rt/comparetf2.zig").__letf2, linkage);

--- a/std/special/compiler_rt/addXf3.zig
+++ b/std/special/compiler_rt/addXf3.zig
@@ -36,11 +36,11 @@ pub extern fn __subtf3(a: f128, b: f128) f128 {
 // TODO: restore inline keyword, see: https://github.com/ziglang/zig/issues/2154
 fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     const Z = @IntType(false, T.bit_count);
-    const S = @IntType(false, T.bit_count - @clz(@IntType(false, T.bit_count), Z(T.bit_count) - 1));
+    const S = @IntType(false, T.bit_count - @clz(Z, Z(T.bit_count) - 1));
     const significandBits = std.math.floatMantissaBits(T);
     const implicitBit = Z(1) << significandBits;
 
-    const shift = @clz(@IntType(false, T.bit_count), significand.*) - @clz(@IntType(false, T.bit_count), implicitBit);
+    const shift = @clz(@IntType(false, T.bit_count), significand.*) - @clz(Z, implicitBit);
     significand.* <<= @intCast(S, shift);
     return 1 - shift;
 }
@@ -48,7 +48,7 @@ fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
 // TODO: restore inline keyword, see: https://github.com/ziglang/zig/issues/2154
 fn addXf3(comptime T: type, a: T, b: T) T {
     const Z = @IntType(false, T.bit_count);
-    const S = @IntType(false, T.bit_count - @clz(@IntType(false, T.bit_count), Z(T.bit_count) - 1));
+    const S = @IntType(false, T.bit_count - @clz(Z, Z(T.bit_count) - 1));
 
     const typeWidth = T.bit_count;
     const significandBits = std.math.floatMantissaBits(T);
@@ -162,7 +162,7 @@ fn addXf3(comptime T: type, a: T, b: T) T {
         // If partial cancellation occured, we need to left-shift the result
         // and adjust the exponent:
         if (aSignificand < implicitBit << 3) {
-            const shift = @intCast(i32, @clz(@IntType(false, T.bit_count), aSignificand)) - @intCast(i32, @clz(@IntType(false, T.bit_count), implicitBit << 3));
+            const shift = @intCast(i32, @clz(Z, aSignificand)) - @intCast(i32, @clz(@IntType(false, T.bit_count), implicitBit << 3));
             aSignificand <<= @intCast(S, shift);
             aExponent -= shift;
         }

--- a/std/special/compiler_rt/addXf3.zig
+++ b/std/special/compiler_rt/addXf3.zig
@@ -36,11 +36,11 @@ pub extern fn __subtf3(a: f128, b: f128) f128 {
 // TODO: restore inline keyword, see: https://github.com/ziglang/zig/issues/2154
 fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     const Z = @IntType(false, T.bit_count);
-    const S = @IntType(false, T.bit_count - @clz(Z(T.bit_count) - 1));
+    const S = @IntType(false, T.bit_count - @clz(@IntType(false, T.bit_count), Z(T.bit_count) - 1));
     const significandBits = std.math.floatMantissaBits(T);
     const implicitBit = Z(1) << significandBits;
 
-    const shift = @clz(significand.*) - @clz(implicitBit);
+    const shift = @clz(@IntType(false, T.bit_count), significand.*) - @clz(@IntType(false, T.bit_count), implicitBit);
     significand.* <<= @intCast(S, shift);
     return 1 - shift;
 }
@@ -48,7 +48,7 @@ fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
 // TODO: restore inline keyword, see: https://github.com/ziglang/zig/issues/2154
 fn addXf3(comptime T: type, a: T, b: T) T {
     const Z = @IntType(false, T.bit_count);
-    const S = @IntType(false, T.bit_count - @clz(Z(T.bit_count) - 1));
+    const S = @IntType(false, T.bit_count - @clz(@IntType(false, T.bit_count), Z(T.bit_count) - 1));
 
     const typeWidth = T.bit_count;
     const significandBits = std.math.floatMantissaBits(T);
@@ -162,7 +162,7 @@ fn addXf3(comptime T: type, a: T, b: T) T {
         // If partial cancellation occured, we need to left-shift the result
         // and adjust the exponent:
         if (aSignificand < implicitBit << 3) {
-            const shift = @intCast(i32, @clz(aSignificand)) - @intCast(i32, @clz(implicitBit << 3));
+            const shift = @intCast(i32, @clz(@IntType(false, T.bit_count), aSignificand)) - @intCast(i32, @clz(@IntType(false, T.bit_count), implicitBit << 3));
             aSignificand <<= @intCast(S, shift);
             aExponent -= shift;
         }

--- a/std/special/compiler_rt/divdf3.zig
+++ b/std/special/compiler_rt/divdf3.zig
@@ -318,7 +318,7 @@ fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     const significandBits = std.math.floatMantissaBits(T);
     const implicitBit = Z(1) << significandBits;
 
-    const shift = @clz(significand.*) - @clz(implicitBit);
+    const shift = @clz(Z, significand.*) - @clz(Z, implicitBit);
     significand.* <<= @intCast(std.math.Log2Int(Z), shift);
     return 1 - shift;
 }

--- a/std/special/compiler_rt/divsf3.zig
+++ b/std/special/compiler_rt/divsf3.zig
@@ -191,7 +191,7 @@ fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     const significandBits = std.math.floatMantissaBits(T);
     const implicitBit = Z(1) << significandBits;
 
-    const shift = @clz(significand.*) - @clz(implicitBit);
+    const shift = @clz(Z, significand.*) - @clz(Z, implicitBit);
     significand.* <<= @intCast(std.math.Log2Int(Z), shift);
     return 1 - shift;
 }

--- a/std/special/compiler_rt/extendXfYf2.zig
+++ b/std/special/compiler_rt/extendXfYf2.zig
@@ -69,7 +69,8 @@ inline fn extendXfYf2(comptime dst_t: type, comptime src_t: type, a: src_t) dst_
         // a is denormal.
         // renormalize the significand and clear the leading bit, then insert
         // the correct adjusted exponent in the destination type.
-        const scale: u32 = @clz(aAbs) - @clz(src_rep_t(srcMinNormal));
+        const scale: u32 = @clz(@IntType(false, @typeInfo(src_t).Float.bits), aAbs) -
+                           @clz(@IntType(false, @typeInfo(src_t).Float.bits), src_rep_t(srcMinNormal));
         absResult = dst_rep_t(aAbs) << @intCast(DstShift, dstSigBits - srcSigBits + scale);
         absResult ^= dstMinNormal;
         const resultExponent: u32 = dstExpBias - srcExpBias - scale + 1;

--- a/std/special/compiler_rt/extendXfYf2.zig
+++ b/std/special/compiler_rt/extendXfYf2.zig
@@ -69,8 +69,8 @@ inline fn extendXfYf2(comptime dst_t: type, comptime src_t: type, a: src_t) dst_
         // a is denormal.
         // renormalize the significand and clear the leading bit, then insert
         // the correct adjusted exponent in the destination type.
-        const scale: u32 = @clz(@IntType(false, @typeInfo(src_t).Float.bits), aAbs) -
-                           @clz(@IntType(false, @typeInfo(src_t).Float.bits), src_rep_t(srcMinNormal));
+        const scale: u32 = @clz(src_rep_t, aAbs) -
+                           @clz(src_rep_t, src_rep_t(srcMinNormal));
         absResult = dst_rep_t(aAbs) << @intCast(DstShift, dstSigBits - srcSigBits + scale);
         absResult ^= dstMinNormal;
         const resultExponent: u32 = dstExpBias - srcExpBias - scale + 1;

--- a/std/special/compiler_rt/floattidf.zig
+++ b/std/special/compiler_rt/floattidf.zig
@@ -17,7 +17,7 @@ pub extern fn __floattidf(arg: i128) f64 {
     ai = ((ai ^ si) -% si);
     var a = @bitCast(u128, ai);
 
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
     if (sd > DBL_MANT_DIG) {
         //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx

--- a/std/special/compiler_rt/floattisf.zig
+++ b/std/special/compiler_rt/floattisf.zig
@@ -17,7 +17,7 @@ pub extern fn __floattisf(arg: i128) f32 {
     ai = ((ai ^ si) -% si);
     var a = @bitCast(u128, ai);
 
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
 
     if (sd > FLT_MANT_DIG) {

--- a/std/special/compiler_rt/floattitf.zig
+++ b/std/special/compiler_rt/floattitf.zig
@@ -17,7 +17,7 @@ pub extern fn __floattitf(arg: i128) f128 {
     ai = ((ai ^ si) -% si);
     var a = @bitCast(u128, ai);
 
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
     if (sd > LDBL_MANT_DIG) {
         //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx

--- a/std/special/compiler_rt/floatunditf.zig
+++ b/std/special/compiler_rt/floatunditf.zig
@@ -14,7 +14,7 @@ pub extern fn __floatunditf(a: u128) f128 {
     const exponent_bias = (1 << (exponent_bits - 1)) - 1;
     const implicit_bit = 1 << mantissa_bits;
 
-    const exp = (u128.bit_count - 1) - @clz(a);
+    const exp = (u128.bit_count - 1) - @clz(u128, a);
     const shift = mantissa_bits - @intCast(u7, exp);
 
     var result: u128 align(16) = (a << shift) ^ implicit_bit;

--- a/std/special/compiler_rt/floatunsitf.zig
+++ b/std/special/compiler_rt/floatunsitf.zig
@@ -14,7 +14,7 @@ pub extern fn __floatunsitf(a: u64) f128 {
     const exponent_bias = (1 << (exponent_bits - 1)) - 1;
     const implicit_bit = 1 << mantissa_bits;
 
-    const exp = (u64.bit_count - 1) - @clz(a);
+    const exp = (u64.bit_count - 1) - @clz(u64, a);
     const shift = mantissa_bits - @intCast(u7, exp);
 
     // TODO(#1148): @bitCast alignment error

--- a/std/special/compiler_rt/floatuntidf.zig
+++ b/std/special/compiler_rt/floatuntidf.zig
@@ -13,7 +13,7 @@ pub extern fn __floatuntidf(arg: u128) f64 {
 
     var a = arg;
     const N: u32 = @sizeOf(u128) * 8;
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
     if (sd > DBL_MANT_DIG) {
         //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx

--- a/std/special/compiler_rt/floatuntisf.zig
+++ b/std/special/compiler_rt/floatuntisf.zig
@@ -13,7 +13,7 @@ pub extern fn __floatuntisf(arg: u128) f32 {
 
     var a = arg;
     const N: u32 = @sizeOf(u128) * 8;
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
     if (sd > FLT_MANT_DIG) {
         //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx

--- a/std/special/compiler_rt/floatuntitf.zig
+++ b/std/special/compiler_rt/floatuntitf.zig
@@ -13,7 +13,7 @@ pub extern fn __floatuntitf(arg: u128) f128 {
 
     var a = arg;
     const N: u32 = @sizeOf(u128) * 8;
-    const sd = @bitCast(i32, N - @clz(a)); // number of significant digits
+    const sd = @bitCast(i32, N - @clz(u128, a)); // number of significant digits
     var e: i32 = sd - 1; // exponent
     if (sd > LDBL_MANT_DIG) {
         //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx

--- a/std/special/compiler_rt/mulXf3.zig
+++ b/std/special/compiler_rt/mulXf3.zig
@@ -260,7 +260,7 @@ fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     const significandBits = std.math.floatMantissaBits(T);
     const implicitBit = Z(1) << significandBits;
 
-    const shift = @clz(significand.*) - @clz(implicitBit);
+    const shift = @clz(@IntType(false, T.bit_count), significand.*) - @clz(@IntType(false, T.bit_count), implicitBit);
     significand.* <<= @intCast(std.math.Log2Int(Z), shift);
     return 1 - shift;
 }

--- a/std/special/compiler_rt/mulXf3.zig
+++ b/std/special/compiler_rt/mulXf3.zig
@@ -260,7 +260,7 @@ fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     const significandBits = std.math.floatMantissaBits(T);
     const implicitBit = Z(1) << significandBits;
 
-    const shift = @clz(@IntType(false, T.bit_count), significand.*) - @clz(@IntType(false, T.bit_count), implicitBit);
+    const shift = @clz(Z, significand.*) - @clz(Z, implicitBit);
     significand.* <<= @intCast(std.math.Log2Int(Z), shift);
     return 1 - shift;
 }

--- a/std/special/compiler_rt/udivmod.zig
+++ b/std/special/compiler_rt/udivmod.zig
@@ -71,12 +71,12 @@ pub fn udivmod(comptime DoubleInt: type, a: DoubleInt, b: DoubleInt, maybe_rem: 
                 r[high] = n[high] & (d[high] - 1);
                 rem.* = @ptrCast(*align(@alignOf(SingleInt)) DoubleInt, &r[0]).*; // TODO issue #421
             }
-            return n[high] >> @intCast(Log2SingleInt, @ctz(d[high]));
+            return n[high] >> @intCast(Log2SingleInt, @ctz(SingleInt, d[high]));
         }
         // K K
         // ---
         // K 0
-        sr = @bitCast(c_uint, c_int(@clz(d[high])) - c_int(@clz(n[high])));
+        sr = @bitCast(c_uint, c_int(@clz(SingleInt, d[high])) - c_int(@clz(SingleInt, n[high])));
         // 0 <= sr <= SingleInt.bit_count - 2 or sr large
         if (sr > SingleInt.bit_count - 2) {
             if (maybe_rem) |rem| {
@@ -106,7 +106,7 @@ pub fn udivmod(comptime DoubleInt: type, a: DoubleInt, b: DoubleInt, maybe_rem: 
                 if (d[low] == 1) {
                     return a;
                 }
-                sr = @ctz(d[low]);
+                sr = @ctz(SingleInt, d[low]);
                 q[high] = n[high] >> @intCast(Log2SingleInt, sr);
                 q[low] = (n[high] << @intCast(Log2SingleInt, SingleInt.bit_count - sr)) | (n[low] >> @intCast(Log2SingleInt, sr));
                 return @ptrCast(*align(@alignOf(SingleInt)) DoubleInt, &q[0]).*; // TODO issue #421
@@ -114,7 +114,7 @@ pub fn udivmod(comptime DoubleInt: type, a: DoubleInt, b: DoubleInt, maybe_rem: 
             // K X
             // ---
             // 0 K
-            sr = 1 + SingleInt.bit_count + c_uint(@clz(d[low])) - c_uint(@clz(n[high]));
+            sr = 1 + SingleInt.bit_count + c_uint(@clz(SingleInt, d[low])) - c_uint(@clz(SingleInt, n[high]));
             // 2 <= sr <= DoubleInt.bit_count - 1
             // q.all = a << (DoubleInt.bit_count - sr);
             // r.all = a >> sr;
@@ -140,7 +140,7 @@ pub fn udivmod(comptime DoubleInt: type, a: DoubleInt, b: DoubleInt, maybe_rem: 
             // K X
             // ---
             // K K
-            sr = @bitCast(c_uint, c_int(@clz(d[high])) - c_int(@clz(n[high])));
+            sr = @bitCast(c_uint, c_int(@clz(SingleInt, d[high])) - c_int(@clz(SingleInt, n[high])));
             // 0 <= sr <= SingleInt.bit_count - 1 or sr large
             if (sr > SingleInt.bit_count - 1) {
                 if (maybe_rem) |rem| {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1325,45 +1325,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:2:22: error: expected integer type, found 'f32'",
     );
 
-    cases.add(
-        "@bitReverse - up-cast",
-        \\comptime {
-        \\    var i: u8 = 3;
-        \\    _ = @bitReverse(u16, i);
-        \\}
-    ,
-        "tmp.zig:3:9: error: upcasting 'u8' to 'u16' changes result",
-    );
-
-    cases.add(
-        "@bswap - up-cast",
-        \\comptime {
-        \\    var i: u8 = 3;
-        \\    _ = @bswap(u16, i);
-        \\}
-    ,
-        "tmp.zig:3:9: error: upcasting 'u8' to 'u16' changes result",
-    );
-
-    cases.add(
-        "@clz - up-cast",
-        \\comptime {
-        \\    var i: u8 = 3;
-        \\    _ = @clz(u16, i);
-        \\}
-    ,
-        "tmp.zig:3:9: error: upcasting 'u8' to 'u16' changes result",
-    );
-
-    cases.add(
-        "@popCount - up-cast of negative number",
-        \\comptime {
-        \\    var i: i8 = -3;
-        \\    _ = @popCount(i16, i);
-        \\}
-    ,
-        "tmp.zig:3:9: error: upcasting 'i8' to 'i16' changes result",
-    );
     cases.addCase(x: {
         const tc = cases.create(
             "wrong same named struct",

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1319,21 +1319,51 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
         "@popCount - non-integer",
         \\export fn entry(x: f32) u32 {
-        \\    return @popCount(x);
+        \\    return @popCount(f32, x);
         \\}
     ,
         "tmp.zig:2:22: error: expected integer type, found 'f32'",
     );
 
     cases.add(
-        "@popCount - negative comptime_int",
+        "@bitReverse - up-cast",
         \\comptime {
-        \\    _ = @popCount(-1);
+        \\    var i: u8 = 3;
+        \\    _ = @bitReverse(u16, i);
         \\}
     ,
-        "tmp.zig:2:9: error: @popCount on negative comptime_int value -1",
+        "tmp.zig:3:9: error: upcasting 'u8' to 'u16' changes result",
     );
 
+    cases.add(
+        "@bswap - up-cast",
+        \\comptime {
+        \\    var i: u8 = 3;
+        \\    _ = @bswap(u16, i);
+        \\}
+    ,
+        "tmp.zig:3:9: error: upcasting 'u8' to 'u16' changes result",
+    );
+
+    cases.add(
+        "@clz - up-cast",
+        \\comptime {
+        \\    var i: u8 = 3;
+        \\    _ = @clz(u16, i);
+        \\}
+    ,
+        "tmp.zig:3:9: error: upcasting 'u8' to 'u16' changes result",
+    );
+
+    cases.add(
+        "@popCount - up-cast of negative number",
+        \\comptime {
+        \\    var i: i8 = -3;
+        \\    _ = @popCount(i16, i);
+        \\}
+    ,
+        "tmp.zig:3:9: error: upcasting 'i8' to 'i16' changes result",
+    );
     cases.addCase(x: {
         const tc = cases.create(
             "wrong same named struct",

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -9,6 +9,7 @@ comptime {
     _ = @import("behavior/bitreverse.zig");
     _ = @import("behavior/bool.zig");
     _ = @import("behavior/bswap.zig");
+    _ = @import("behavior/saturating.zig");
     _ = @import("behavior/bugs/1025.zig");
     _ = @import("behavior/bugs/1076.zig");
     _ = @import("behavior/bugs/1111.zig");

--- a/test/stage1/behavior/bitreverse.zig
+++ b/test/stage1/behavior/bitreverse.zig
@@ -2,80 +2,68 @@ const std = @import("std");
 const expect = std.testing.expect;
 const minInt = std.math.minInt;
 
-test "@bitreverse" {
+test "@bitReverse" {
     comptime testBitReverse();
     testBitReverse();
 }
 
 fn testBitReverse() void {
     // using comptime_ints, unsigned
-    expect(@bitreverse(u0, 0) == 0);
-    expect(@bitreverse(u5, 0x12) == 0x9);
-    expect(@bitreverse(u8, 0x12) == 0x48);
-    expect(@bitreverse(u16, 0x1234) == 0x2c48);
-    expect(@bitreverse(u24, 0x123456) == 0x6a2c48);
-    expect(@bitreverse(u32, 0x12345678) == 0x1e6a2c48);
-    expect(@bitreverse(u40, 0x123456789a) == 0x591e6a2c48);
-    expect(@bitreverse(u48, 0x123456789abc) == 0x3d591e6a2c48);
-    expect(@bitreverse(u56, 0x123456789abcde) == 0x7b3d591e6a2c48);
-    expect(@bitreverse(u64, 0x123456789abcdef1) == 0x8f7b3d591e6a2c48);
-    expect(@bitreverse(u128, 0x123456789abcdef11121314151617181) == 0x818e868a828c84888f7b3d591e6a2c48);
+    expect(@bitReverse(u0, u0(0)) == 0);
+    expect(@bitReverse(u5, u5(0x12)) == 0x9);
+    expect(@bitReverse(u8, u8(0x12)) == 0x48);
+    expect(@bitReverse(u16, u16(0x1234)) == 0x2c48);
+    expect(@bitReverse(u24, u24(0x123456)) == 0x6a2c48);
+    expect(@bitReverse(u32, u32(0x12345678)) == 0x1e6a2c48);
+    expect(@bitReverse(u40, u40(0x123456789a)) == 0x591e6a2c48);
+    expect(@bitReverse(u48, u48(0x123456789abc)) == 0x3d591e6a2c48);
+    expect(@bitReverse(u56, u56(0x123456789abcde)) == 0x7b3d591e6a2c48);
+    expect(@bitReverse(u64, u64(0x123456789abcdef1)) == 0x8f7b3d591e6a2c48);
+    expect(@bitReverse(u128, u128(0x123456789abcdef11121314151617181)) == 0x818e868a828c84888f7b3d591e6a2c48);
 
     // using runtime uints, unsigned
     var num0: u0 = 0;
-    expect(@bitreverse(u0, num0) == 0);
+    expect(@bitReverse(u0, num0) == 0);
     var num5: u5 = 0x12;
-    expect(@bitreverse(u5, num5) == 0x9);
+    expect(@bitReverse(u5, num5) == 0x9);
     var num8: u8 = 0x12;
-    expect(@bitreverse(u8, num8) == 0x48);
+    expect(@bitReverse(u8, num8) == 0x48);
     var num16: u16 = 0x1234;
-    expect(@bitreverse(u16, num16) == 0x2c48);
+    expect(@bitReverse(u16, num16) == 0x2c48);
     var num24: u24 = 0x123456;
-    expect(@bitreverse(u24, num24) == 0x6a2c48);
+    expect(@bitReverse(u24, num24) == 0x6a2c48);
     var num32: u32 = 0x12345678;
-    expect(@bitreverse(u32, num32) == 0x1e6a2c48);
+    expect(@bitReverse(u32, num32) == 0x1e6a2c48);
     var num40: u40 = 0x123456789a;
-    expect(@bitreverse(u40, num40) == 0x591e6a2c48);
+    expect(@bitReverse(u40, num40) == 0x591e6a2c48);
     var num48: u48 = 0x123456789abc;
-    expect(@bitreverse(u48, num48) == 0x3d591e6a2c48);
+    expect(@bitReverse(u48, num48) == 0x3d591e6a2c48);
     var num56: u56 = 0x123456789abcde;
-    expect(@bitreverse(u56, num56) == 0x7b3d591e6a2c48);
+    expect(@bitReverse(u56, num56) == 0x7b3d591e6a2c48);
     var num64: u64 = 0x123456789abcdef1;
-    expect(@bitreverse(u64, num64) == 0x8f7b3d591e6a2c48);
+    expect(@bitReverse(u64, num64) == 0x8f7b3d591e6a2c48);
     var num128: u128 = 0x123456789abcdef11121314151617181;
-    expect(@bitreverse(u128, num128) == 0x818e868a828c84888f7b3d591e6a2c48);
+    expect(@bitReverse(u128, num128) == 0x818e868a828c84888f7b3d591e6a2c48);
 
     // using comptime_ints, signed, positive
-    expect(@bitreverse(i0, 0) == 0);
-    expect(@bitreverse(i8, @bitCast(i8, u8(0x92))) == @bitCast(i8, u8(0x49)));
-    expect(@bitreverse(i16, @bitCast(i16, u16(0x1234))) == @bitCast(i16, u16(0x2c48)));
-    expect(@bitreverse(i24, @bitCast(i24, u24(0x123456))) == @bitCast(i24, u24(0x6a2c48)));
-    expect(@bitreverse(i32, @bitCast(i32, u32(0x12345678))) == @bitCast(i32, u32(0x1e6a2c48)));
-    expect(@bitreverse(i40, @bitCast(i40, u40(0x123456789a))) == @bitCast(i40, u40(0x591e6a2c48)));
-    expect(@bitreverse(i48, @bitCast(i48, u48(0x123456789abc))) == @bitCast(i48, u48(0x3d591e6a2c48)));
-    expect(@bitreverse(i56, @bitCast(i56, u56(0x123456789abcde))) == @bitCast(i56, u56(0x7b3d591e6a2c48)));
-    expect(@bitreverse(i64, @bitCast(i64, u64(0x123456789abcdef1))) == @bitCast(i64, u64(0x8f7b3d591e6a2c48)));
-    expect(@bitreverse(i128, @bitCast(i128, u128(0x123456789abcdef11121314151617181))) == @bitCast(i128, u128(0x818e868a828c84888f7b3d591e6a2c48)));
+    expect(@bitReverse(u8, u8(0)) == 0);
+    expect(@bitReverse(i8, @bitCast(i8, u8(0x92))) == @bitCast(i8, u8(0x49)));
+    expect(@bitReverse(i16, @bitCast(i16, u16(0x1234))) == @bitCast(i16, u16(0x2c48)));
+    expect(@bitReverse(i24, @bitCast(i24, u24(0x123456))) == @bitCast(i24, u24(0x6a2c48)));
+    expect(@bitReverse(i32, @bitCast(i32, u32(0x12345678))) == @bitCast(i32, u32(0x1e6a2c48)));
+    expect(@bitReverse(i40, @bitCast(i40, u40(0x123456789a))) == @bitCast(i40, u40(0x591e6a2c48)));
+    expect(@bitReverse(i48, @bitCast(i48, u48(0x123456789abc))) == @bitCast(i48, u48(0x3d591e6a2c48)));
+    expect(@bitReverse(i56, @bitCast(i56, u56(0x123456789abcde))) == @bitCast(i56, u56(0x7b3d591e6a2c48)));
+    expect(@bitReverse(i64, @bitCast(i64, u64(0x123456789abcdef1))) == @bitCast(i64, u64(0x8f7b3d591e6a2c48)));
+    expect(@bitReverse(i128, @bitCast(i128, u128(0x123456789abcdef11121314151617181))) == @bitCast(i128, u128(0x818e868a828c84888f7b3d591e6a2c48)));
 
-    // using comptime_ints, signed, negative. Compare to runtime ints returned from llvm.
-    var neg5: i5 = minInt(i5) + 1;
-    expect(@bitreverse(i5, minInt(i5) + 1) == @bitreverse(i5, neg5));
+    // using signed, negative. Compare to runtime ints returned from llvm.
     var neg8: i8 = -18;
-    expect(@bitreverse(i8, -18) == @bitreverse(i8, neg8));
+    expect(@bitReverse(i8, i8(-18)) == @bitReverse(i8, neg8));
     var neg16: i16 = -32694;
-    expect(@bitreverse(i16, -32694) == @bitreverse(i16, neg16));
+    expect(@bitReverse(i16, i16(-32694)) == @bitReverse(i16, neg16));
     var neg24: i24 = -6773785;
-    expect(@bitreverse(i24, -6773785) == @bitreverse(i24, neg24));
+    expect(@bitReverse(i24, i24(-6773785)) == @bitReverse(i24, neg24));
     var neg32: i32 = -16773785;
-    expect(@bitreverse(i32, -16773785) == @bitreverse(i32, neg32));
-    var neg40: i40 = minInt(i40) + 12345;
-    expect(@bitreverse(i40, minInt(i40) + 12345) == @bitreverse(i40, neg40));
-    var neg48: i48 = minInt(i48) + 12345;
-    expect(@bitreverse(i48, minInt(i48) + 12345) == @bitreverse(i48, neg48));
-    var neg56: i56 = minInt(i56) + 12345;
-    expect(@bitreverse(i56, minInt(i56) + 12345) == @bitreverse(i56, neg56));
-    var neg64: i64 = minInt(i64) + 12345;
-    expect(@bitreverse(i64, minInt(i64) + 12345) == @bitreverse(i64, neg64));
-    var neg128: i128 = minInt(i128) + 12345;
-    expect(@bitreverse(i128, minInt(i128) + 12345) == @bitreverse(i128, neg128));
+    expect(@bitReverse(i32, i32(-16773785)) == @bitReverse(i32, neg32));
 }

--- a/test/stage1/behavior/bswap.zig
+++ b/test/stage1/behavior/bswap.zig
@@ -1,32 +1,32 @@
 const std = @import("std");
 const expect = std.testing.expect;
 
-test "@bswap" {
+test "@bSwap" {
     comptime testByteSwap();
     testByteSwap();
 }
 
 fn testByteSwap() void {
-    expect(@bswap(u0, 0) == 0);
-    expect(@bswap(u8, 0x12) == 0x12);
-    expect(@bswap(u16, 0x1234) == 0x3412);
-    expect(@bswap(u24, 0x123456) == 0x563412);
-    expect(@bswap(u32, 0x12345678) == 0x78563412);
-    expect(@bswap(u40, 0x123456789a) == 0x9a78563412);
-    expect(@bswap(u48, 0x123456789abc) == 0xbc9a78563412);
-    expect(@bswap(u56, 0x123456789abcde) == 0xdebc9a78563412);
-    expect(@bswap(u64, 0x123456789abcdef1) == 0xf1debc9a78563412);
-    expect(@bswap(u128, 0x123456789abcdef11121314151617181) == 0x8171615141312111f1debc9a78563412);
+    expect(@bSwap(u0, u0(0)) == 0);
+    expect(@bSwap(u8, u8(0x12)) == 0x12);
+    expect(@bSwap(u16, u16(0x1234)) == 0x3412);
+    expect(@bSwap(u24, u24(0x123456)) == 0x563412);
+    expect(@bSwap(u32, u32(0x12345678)) == 0x78563412);
+    expect(@bSwap(u40, u40(0x123456789a)) == 0x9a78563412);
+    expect(@bSwap(i48, u48(0x123456789abc)) == @bitCast(i48, u48(0xbc9a78563412)));
+    expect(@bSwap(u56, u56(0x123456789abcde)) == 0xdebc9a78563412);
+    expect(@bSwap(u64, u64(0x123456789abcdef1)) == 0xf1debc9a78563412);
+    expect(@bSwap(u128, u128(0x123456789abcdef11121314151617181)) == 0x8171615141312111f1debc9a78563412);
 
-    expect(@bswap(i0, 0) == 0);
-    expect(@bswap(i8, -50) == -50);
-    expect(@bswap(i16, @bitCast(i16, u16(0x1234))) == @bitCast(i16, u16(0x3412)));
-    expect(@bswap(i24, @bitCast(i24, u24(0x123456))) == @bitCast(i24, u24(0x563412)));
-    expect(@bswap(i32, @bitCast(i32, u32(0x12345678))) == @bitCast(i32, u32(0x78563412)));
-    expect(@bswap(i40, @bitCast(i40, u40(0x123456789a))) == @bitCast(i40, u40(0x9a78563412)));
-    expect(@bswap(i48, @bitCast(i48, u48(0x123456789abc))) == @bitCast(i48, u48(0xbc9a78563412)));
-    expect(@bswap(i56, @bitCast(i56, u56(0x123456789abcde))) == @bitCast(i56, u56(0xdebc9a78563412)));
-    expect(@bswap(i64, @bitCast(i64, u64(0x123456789abcdef1))) == @bitCast(i64, u64(0xf1debc9a78563412)));
-    expect(@bswap(i128, @bitCast(i128, u128(0x123456789abcdef11121314151617181))) ==
+    expect(@bSwap(u0, u0(0)) == 0);
+    expect(@bSwap(i8, i8(-50)) == -50);
+    expect(@bSwap(i16, @bitCast(i16, u16(0x1234))) == @bitCast(i16, u16(0x3412)));
+    expect(@bSwap(i24, @bitCast(i24, u24(0x123456))) == @bitCast(i24, u24(0x563412)));
+    expect(@bSwap(i32, @bitCast(i32, u32(0x12345678))) == @bitCast(i32, u32(0x78563412)));
+    expect(@bSwap(u40, @bitCast(i40, u40(0x123456789a))) == u40(0x9a78563412));
+    expect(@bSwap(i48, @bitCast(i48, u48(0x123456789abc))) == @bitCast(i48, u48(0xbc9a78563412)));
+    expect(@bSwap(i56, @bitCast(i56, u56(0x123456789abcde))) == @bitCast(i56, u56(0xdebc9a78563412)));
+    expect(@bSwap(i64, @bitCast(i64, u64(0x123456789abcdef1))) == @bitCast(i64, u64(0xf1debc9a78563412)));
+    expect(@bSwap(i128, @bitCast(i128, u128(0x123456789abcdef11121314151617181))) ==
         @bitCast(i128, u128(0x8171615141312111f1debc9a78563412)));
 }

--- a/test/stage1/behavior/math.zig
+++ b/test/stage1/behavior/math.zig
@@ -643,21 +643,6 @@ fn comptimeAdd(comptime a: comptime_int, comptime b: comptime_int) comptime_int 
     return a + b;
 }
 
-test "vector integer addition" {
-    const S = struct {
-        fn doTheTest() void {
-            var a: @Vector(4, i32) = []i32{ 1, 2, 3, 4 };
-            var b: @Vector(4, i32) = []i32{ 5, 6, 7, 8 };
-            var result = a + b;
-            var result_array: [4]i32 = result;
-            const expected = []i32{ 6, 8, 10, 12 };
-            expectEqualSlices(i32, &expected, &result_array);
-        }
-    };
-    S.doTheTest();
-    comptime S.doTheTest();
-}
-
 test "NaN comparison" {
     testNanEqNan(f16);
     testNanEqNan(f32);

--- a/test/stage1/behavior/math.zig
+++ b/test/stage1/behavior/math.zig
@@ -114,15 +114,16 @@ test "@clz" {
 }
 
 fn testClz() void {
-    expect(clz(u8(0b00001010)) == 4);
-    expect(clz(u8(0b10001010)) == 0);
-    expect(clz(u8(0b00000000)) == 8);
-    expect(clz(u128(0xffffffffffffffff)) == 64);
-    expect(clz(u128(0x10000000000000000)) == 63);
+    expect(clz(u8, u8(0b10001010)) == 0);
+    expect(clz(u8, u8(0b00001010)) == 4);
+    expect(clz(u8, u8(0b00011010)) == 3);
+    expect(clz(u8, u8(0b00000000)) == 8);
+    expect(clz(u128, u128(0xffffffffffffffff)) == 64);
+    expect(clz(u128, u128(0x10000000000000000)) == 63);
 }
 
-fn clz(x: var) usize {
-    return @clz(x);
+fn clz(comptime T: type, x: T) usize {
+    return @clz(T, x);
 }
 
 test "@ctz" {
@@ -131,13 +132,59 @@ test "@ctz" {
 }
 
 fn testCtz() void {
-    expect(ctz(u8(0b10100000)) == 5);
-    expect(ctz(u8(0b10001010)) == 1);
-    expect(ctz(u8(0b00000000)) == 8);
+    expect(ctz(u8, u8(0b10100000)) == 5);
+    expect(ctz(u8, u8(0b10001010)) == 1);
+    expect(ctz(u8, u8(0b00000000)) == 8);
+    expect(ctz(u16, u16(0b00000000)) == 16);
 }
 
-fn ctz(x: var) usize {
-    return @ctz(x);
+fn ctz(comptime T: type, x: T) usize {
+    return @ctz(T, x);
+}
+
+test "@fshl" {
+    testFshl();
+    comptime testFshl();
+}
+
+fn testFshl() void {
+    expect(fshl(u8, u8(0), u8(0), 0) == 0);
+    expect(fshl(u8, u8(0b00001010), u8(0b11111111), 1) == 0b00010101);
+    expect(fshl(u16, u16(0b00001010), u16(0xffff), 1) == 0b00010101);
+    expect(fshl(u32, u32(0b00001010), u32(0xffffffff), 1) == 0b00010101);
+    expect(fshl(u64, u64(0xffffffffffffffff), u64(0x0000000000000000), 32) == u64(0xffffffff00000000));
+    expect(fshl(u128, u128(0xffffffffffffffffffffffffffffffff), u128(0x0000000000000000000000000000000000), 64) == u128(0xffffffffffffffff0000000000000000));
+}
+
+fn fshl(comptime T: type, high: T, low: T, shift: Log2Int(T)) T {
+    return @fshl(T, high, low, shift);
+}
+
+test "@fshl" {
+    testFshr();
+    comptime testFshr();
+}
+
+fn testFshr() void {
+    expect(fshr(u8, u8(0), u8(0), 0) == 0);
+    expect(fshr(u8, u8(0b00001010), u8(0b11111111), 1) == 0b01111111);
+    expect(fshr(u64, u64(0xffffffffffffffff), u64(0x00000000000000000), 32) == u64(0xffffffff00000000));
+    expect(fshr(u128, u128(0xffffffffffffffffffffffffffffffff), u128(0x0000000000000000000000000000000000), 64) == u128(0xffffffffffffffff0000000000000000));
+}
+
+pub fn Log2Int(comptime T: type) type {
+    // comptime ceil log2
+    comptime var count = 0;
+    comptime var s = T.bit_count - 1;
+    inline while (s != 0) : (s >>= 1) {
+        count += 1;
+    }
+
+    return @IntType(false, count);
+}
+
+fn fshr(comptime T: type, a: T, b: T, shift: Log2Int(T)) T {
+    return @fshr(T, a, b, shift);
 }
 
 test "assignment operators" {

--- a/test/stage1/behavior/popcount.zig
+++ b/test/stage1/behavior/popcount.zig
@@ -8,18 +8,29 @@ test "@popCount" {
 fn testPopCount() void {
     {
         var x: u32 = 0xaa;
-        expect(@popCount(x) == 4);
+        expect(@popCount(u32, x) == 4);
     }
     {
         var x: u32 = 0xaaaaaaaa;
-        expect(@popCount(x) == 16);
+        expect(@popCount(u32, x) == 16);
+    }
+    {
+        var x: u32 = 0xaaaaaaaa;
+        expect(@popCount(u32, x) == 16);
     }
     {
         var x: i16 = -1;
-        expect(@popCount(x) == 16);
+        expect(@popCount(i16, x) == 16);
+    }
+    {
+        var x: i8 = -120;
+        expect(@popCount(i8, x) == 2);
     }
     comptime {
-        expect(@popCount(0b11111111000110001100010000100001000011000011100101010001) == 24);
+        expect(@popCount(u8, @bitCast(u8, i8(-120))) == 2);
+    }
+    comptime {
+        expect(@popCount(i128, u128(0b11111111000110001100010000100001000011000011100101010001)) == 24);
     }
 }
 

--- a/test/stage1/behavior/saturating.zig
+++ b/test/stage1/behavior/saturating.zig
@@ -22,5 +22,11 @@ fn testSaturating() void {
         var x: i8 = -50;
         expect(@satSub(i8, x, 127) == -128);
     }
+    {
+        const mem = @import("std").mem;
+        var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
+        var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
+        expect(mem.eql(i32, ([4]i32)(@satSub(@typeOf(v), v, x)), [4]i32{ 2147483646, -2147483648, 27, 36 }));
+    }
 }
 

--- a/test/stage1/behavior/saturating.zig
+++ b/test/stage1/behavior/saturating.zig
@@ -1,0 +1,26 @@
+const expect = @import("std").testing.expect;
+
+test "@satAdd, @satSub" {
+    comptime testSaturating();
+    testSaturating();
+}
+
+fn testSaturating() void {
+    {
+        var x: u16 = 0xfffe;
+        expect(@satAdd(u16, x, 100) == 0xffff);
+    }
+    {
+        var x: u32 = 0xfffffffa;
+        expect(@satAdd(u32, x, 1677) == 0xffffffff);
+    }
+    {
+        var x: u64 = 0x021;
+        expect(@satSub(u64, x, 5000) == 0);
+    }
+    {
+        var x: i8 = -50;
+        expect(@satSub(i8, x, 127) == -128);
+    }
+}
+

--- a/test/stage1/behavior/saturating.zig
+++ b/test/stage1/behavior/saturating.zig
@@ -22,11 +22,5 @@ fn testSaturating() void {
         var x: i8 = -50;
         expect(@satSub(i8, x, 127) == -128);
     }
-    {
-        const mem = @import("std").mem;
-        var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
-        var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
-        expect(mem.eql(i32, ([4]i32)(@satSub(@typeOf(v), v, x)), [4]i32{ 2147483646, -2147483648, 27, 36 }));
-    }
 }
 

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -120,6 +120,12 @@ test "vector @clz/@ctz" {
             expect(a[1] == 1);
             expect(a[2] == 8);
             expect(a[3] == 0);
+            v2 = @ctz(@Vector(4, u8), v);
+            a = v2;
+            expect(a[0] == 0);
+            expect(a[1] == 1);
+            expect(a[2] == 8);
+            expect(a[3] == 7);
         }
     };
     S.doTheTest();

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -109,3 +109,19 @@ test "vector widen" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "vector @clz/@ctz" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(4, u8) = [4]u8{ 0b00001111, 0b01111110, 0b00000000, 0b10000000 };
+            var v2: @Vector(4, u8) = @clz(@Vector(4, u8), v);
+            var a: [4]u8 = v2;
+            expect(a[0] == 4);
+            expect(a[1] == 1);
+            expect(a[2] == 8);
+            expect(a[3] == 0);
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -2,6 +2,21 @@ const std = @import("std");
 const mem = std.mem;
 const expect = std.testing.expect;
 
+test "vector integer addition" {
+    const S = struct {
+        fn doTheTest() void {
+            var a: @Vector(4, i32) = []i32{ 1, 2, 3, 4 };
+            var b: @Vector(4, i32) = []i32{ 5, 6, 7, 8 };
+            var result = a + b;
+            var result_array: [4]i32 = result;
+            const expected = []i32{ 6, 8, 10, 12 };
+            expectEqualSlices(i32, &expected, &result_array);
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
 test "vector wrap operators" {
     const S = struct {
         fn doTheTest() void {
@@ -56,6 +71,22 @@ test "vector bit operators" {
             expect(mem.eql(u8, ([4]u8)(v ^ x), [4]u8{ 0b01011010, 0b10100101, 0b00000000, 0b11111111 }));
             expect(mem.eql(u8, ([4]u8)(v | x), [4]u8{ 0b11111010, 0b10101111, 0b10101010, 0b11111111 }));
             expect(mem.eql(u8, ([4]u8)(v & x), [4]u8{ 0b10100000, 0b00001010, 0b10101010, 0b00000000 }));
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
+test "vector saturating operators" {
+    const S = struct {
+        fn doTheTest() void {
+            const mem = @import("std").mem;
+            var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
+            var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
+            expect(mem.eql(i32, ([4]i32)(@satSub(@Vector(4, i32), v, x)), [4]i32{ 2147483646, -2147483648, 27, 36 }));
+            var a: @Vector(4, u8) = [4]u8{ 1, 2, 3, 4 };
+            var b: @Vector(4, u8) = [4]u8{ 253, 253, 253, 253 };
+            expect(mem.eql(u8, ([4]u8)(@satAdd(@Vector(4, u8), a, b)), [4]u8{ 254, 255, 255, 255 }));
         }
     };
     S.doTheTest();

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const mem = std.mem;
 const expect = std.testing.expect;
+const expectEqualSlices = std.testing.expectEqualSlices;
 
 test "vector integer addition" {
     const S = struct {
@@ -80,13 +81,29 @@ test "vector bit operators" {
 test "vector saturating operators" {
     const S = struct {
         fn doTheTest() void {
-            const mem = @import("std").mem;
             var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
             var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
             expect(mem.eql(i32, ([4]i32)(@satSub(@Vector(4, i32), v, x)), [4]i32{ 2147483646, -2147483648, 27, 36 }));
             var a: @Vector(4, u8) = [4]u8{ 1, 2, 3, 4 };
             var b: @Vector(4, u8) = [4]u8{ 253, 253, 253, 253 };
             expect(mem.eql(u8, ([4]u8)(@satAdd(@Vector(4, u8), a, b)), [4]u8{ 254, 255, 255, 255 }));
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
+test "vector widen" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(4, u8) = [4]u8{ 1, 2, 3, 4 };
+            var v2: @Vector(4, u16) = (@Vector(4, u16))(v);
+            var a: [4]u8 = v;
+            var b: [4]u16 = v2;
+            expect(a[0] == b[0]);
+            expect(a[1] == b[1]);
+            expect(a[2] == b[2]);
+            expect(a[3] == b[3]);
         }
     };
     S.doTheTest();


### PR DESCRIPTION
Closes: #2119 

breaking: @bitreverse -> @bitReverse, @bswap -> @bswap

Closes: #2120

Comes with tests

OK. This has changed quite a bit since it was opened. It gained `@fshl` and `@fshr` , and then I added `@memMove` and merged a differn't pull request so I could flesh out `@memMove`. I am working on #767