### PR TITLE
decouple llvm types from zig types

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2112,8 +2112,8 @@ test "linked list" {
         <li>A {#link|packed enum#} field uses exactly the bit width of its integer tag type.</li>
         <li>A {#link|packed union#} field uses exactly the bit width of the union field with
         the largest bit width.</li>
-        <li>Non-byte-aligned fields are packed into the smallest possible
-        byte-aligned integers in accordance with the target endianness.
+        <li>Non-ABI-aligned fields are packed into the smallest possible
+        ABI-aligned integers in accordance with the target endianness.
         </li>
       </ul>
       <p>
@@ -2213,10 +2213,10 @@ fn bar(x: *const u3) u3 {
       {#code_end#}
       <p>
       In this case, the function {#syntax#}bar{#endsyntax#} cannot be called becuse the pointer
-      to the non-byte-aligned field mentions the bit offset, but the function expects a byte-aligned pointer.
+      to the non-ABI-aligned field mentions the bit offset, but the function expects an ABI-aligned pointer.
       </p>
       <p>
-      Pointers to non-byte-aligned fields share the same address as the other fields within their host integer:
+      Pointers to non-ABI-aligned fields share the same address as the other fields within their host integer:
       </p>
       {#code_begin|test#}
 const std = @import("std");

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1067,8 +1067,10 @@ struct TypeStructField {
     ZigType *type_entry;
     size_t src_index;
     size_t gen_index;
-    uint32_t bit_offset_in_host; // offset from the memory at gen_index
+    size_t offset; // byte offset from beginning of struct
     AstNode *decl_node;
+    uint32_t bit_offset_in_host; // offset from the memory at gen_index
+    uint32_t host_int_bytes; // size of host integer
 };
 
 enum ResolveStatus {
@@ -1101,14 +1103,13 @@ struct ZigTypeStruct {
     AstNode *decl_node;
     TypeStructField *fields;
     ScopeDecls *decls_scope;
-    uint64_t size_bytes;
     HashMap<Buf *, TypeStructField *, buf_hash, buf_eql_buf> fields_by_name;
     RootStruct *root_struct;
+    uint32_t *host_int_bytes; // available for packed structs, indexed by gen_index
 
     uint32_t src_field_count;
     uint32_t gen_field_count;
 
-    uint32_t abi_alignment; // known after ResolveStatusAlignmentKnown
     ContainerLayout layout;
     ResolveStatus resolve_status;
 
@@ -1164,39 +1165,28 @@ bool type_ptr_eql(const ZigType *a, const ZigType *b);
 
 struct ZigTypeUnion {
     AstNode *decl_node;
-    ContainerLayout layout;
+    TypeUnionField *fields;
+    ScopeDecls *decls_scope;
+    HashMap<Buf *, TypeUnionField *, buf_hash, buf_eql_buf> fields_by_name;
+    ZigType *tag_type; // always an enum or null
+    LLVMTypeRef union_llvm_type;
+    ZigType *most_aligned_union_member;
+    size_t gen_union_index;
+    size_t gen_tag_index;
+    size_t union_abi_size;
+
     uint32_t src_field_count;
     uint32_t gen_field_count;
-    TypeUnionField *fields;
-    bool is_invalid; // true if any fields are invalid
-    ZigType *tag_type; // always an enum or null
-    LLVMTypeRef union_type_ref;
 
-    ScopeDecls *decls_scope;
+    ContainerLayout layout;
+    ResolveStatus resolve_status;
 
-    // set this flag temporarily to detect infinite loops
-    bool embedded_in_current;
+    bool have_explicit_tag_type;
+    bool resolve_loop_flag; // set this flag temporarily to detect infinite loops
     bool reported_infinite_err;
-    // whether we've finished resolving it
-    bool complete;
-
     // whether any of the fields require comptime
     // the value is not valid until zero_bits_known == true
     bool requires_comptime;
-
-    bool zero_bits_loop_flag;
-    bool zero_bits_known;
-    uint32_t abi_alignment; // also figured out with zero_bits pass
-
-    size_t gen_union_index;
-    size_t gen_tag_index;
-
-    bool have_explicit_tag_type;
-
-    uint32_t union_size_bytes;
-    ZigType *most_aligned_union_member;
-
-    HashMap<Buf *, TypeUnionField *, buf_hash, buf_eql_buf> fields_by_name;
 };
 
 struct FnGenParamInfo {
@@ -1277,8 +1267,11 @@ struct ZigType {
     ZigTypeId id;
     Buf name;
 
-    LLVMTypeRef type_ref;
-    ZigLLVMDIType *di_type;
+    // These are not supposed to be accessed directly. They're
+    // null during semantic analysis, memoized with get_llvm_type
+    // and get_llvm_di_type
+    LLVMTypeRef llvm_type;
+    ZigLLVMDIType *llvm_di_type;
 
     union {
         ZigTypePointer pointer;
@@ -1308,8 +1301,14 @@ struct ZigType {
     ConstExprValue *cached_const_name_val;
 
     OnePossibleValue one_possible_value;
+    // Known after ResolveStatusAlignmentKnown.
+    uint32_t abi_align;
+    // The offset in bytes between consecutive array elements of this type. Known
+    // after ResolveStatusSizeKnown.
+    size_t abi_size;
+    // Number of bits of information in this type. Known after ResolveStatusSizeKnown.
+    size_t size_in_bits;
 
-    bool zero_bits; // this is denormalized data
     bool gen_h_loop_flag;
 };
 
@@ -1700,11 +1699,9 @@ struct CodeGen {
     ZigList<AstNode *> use_queue;
     size_t use_queue_index;
     ZigList<TimeEvent> timing_events;
-    ZigList<ZigLLVMDIType **> error_di_types;
     ZigList<AstNode *> tld_ref_source_node_stack;
     ZigList<ZigFn *> inline_fns;
     ZigList<ZigFn *> test_fns;
-    ZigList<ZigLLVMDIEnumerator *> err_enumerators;
     ZigList<ErrorTableEntry *> errors_by_index;
     ZigList<CacheHash *> caches_to_release;
     size_t largest_err_name_len;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -256,7 +256,6 @@ enum ConstValSpecial {
     ConstValSpecialRuntime,
     ConstValSpecialStatic,
     ConstValSpecialUndef,
-    ConstValSpecialLazy,
 };
 
 enum RuntimeHintErrorUnion {
@@ -292,43 +291,6 @@ struct ConstGlobalRefs {
     LLVMValueRef llvm_global;
 };
 
-enum LazyValueId {
-    LazyValueIdInvalid,
-    LazyValueIdAlignOf,
-    LazyValueIdSliceType,
-    LazyValueIdFnType,
-};
-
-struct LazyValue {
-    LazyValueId id;
-    IrExecutable *exec;
-};
-
-struct LazyValueAlignOf {
-    LazyValue base;
-    ZigType *target_type;
-};
-
-struct LazyValueSliceType {
-    LazyValue base;
-    ZigType *elem_type;
-    ConstExprValue *align_val; // can be null
-    bool is_const;
-    bool is_volatile;
-    bool is_allowzero;
-};
-
-struct LazyValueFnType {
-    LazyValue base;
-    AstNode *proto_node;
-    ConstExprValue **param_types;
-    ConstExprValue *align_val; // can be null
-    ConstExprValue *return_type;
-    ConstExprValue *async_allocator_type;
-    bool is_generic;
-    bool is_var_args;
-};
-
 struct ConstExprValue {
     ZigType *type;
     ConstValSpecial special;
@@ -356,7 +318,6 @@ struct ConstExprValue {
         ConstPtrValue x_ptr;
         ConstArgTuple x_arg_tuple;
         Buf *x_enum_literal;
-        LazyValue *x_lazy;
 
         // populated if special == ConstValSpecialRuntime
         RuntimeHintErrorUnion rh_error_union;
@@ -398,7 +359,6 @@ enum TldResolution {
     TldResolutionUnresolved,
     TldResolutionResolving,
     TldResolutionInvalid,
-    TldResolutionOkLazy,
     TldResolutionOk,
 };
 
@@ -1104,8 +1064,7 @@ struct ZigTypeArray {
 
 struct TypeStructField {
     Buf *name;
-    ZigType *type_entry; // available after ResolveStatusSizeKnown
-    ConstExprValue *type_val; // available after ResolveStatusZeroBitsKnown
+    ZigType *type_entry;
     size_t src_index;
     size_t gen_index;
     size_t offset; // byte offset from beginning of struct

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1079,6 +1079,8 @@ enum ResolveStatus {
     ResolveStatusZeroBitsKnown,
     ResolveStatusAlignmentKnown,
     ResolveStatusSizeKnown,
+    ResolveStatusLLVMFwdDecl,
+    ResolveStatusLLVMFull,
 };
 
 struct ZigPackage {

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -1731,7 +1731,7 @@ static Error resolve_union_alignment(CodeGen *g, ZigType *union_type) {
             union_type->data.unionation.reported_infinite_err = true;
             union_type->data.unionation.resolve_status = ResolveStatusInvalid;
             ErrorMsg *msg = add_node_error(g, decl_node,
-                    buf_sprintf("union '%s' depends on its own alignment", buf_ptr(&union_type->name)));
+                    buf_sprintf("union '%s' contains itself", buf_ptr(&union_type->name)));
             emit_error_notes_for_ref_stack(g, msg);
         }
         return ErrorSemanticAnalyzeFail;
@@ -2225,7 +2225,7 @@ static Error resolve_struct_alignment(CodeGen *g, ZigType *struct_type) {
         if (struct_type->data.structure.resolve_status != ResolveStatusInvalid) {
             struct_type->data.structure.resolve_status = ResolveStatusInvalid;
             ErrorMsg *msg = add_node_error(g, decl_node,
-                buf_sprintf("struct '%s' depends on its own alignment", buf_ptr(&struct_type->name)));
+                buf_sprintf("struct '%s' contains itself", buf_ptr(&struct_type->name)));
             emit_error_notes_for_ref_stack(g, msg);
         }
         return ErrorSemanticAnalyzeFail;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -4047,7 +4047,6 @@ bool handle_is_ptr(ZigType *type_entry) {
              return false;
         case ZigTypeIdArray:
         case ZigTypeIdStruct:
-        case ZigTypeIdUnion:
              return type_has_bits(type_entry);
         case ZigTypeIdErrorUnion:
              return type_has_bits(type_entry->data.error_union.payload_type);
@@ -4055,6 +4054,8 @@ bool handle_is_ptr(ZigType *type_entry) {
              return type_has_bits(type_entry->data.maybe.child_type) &&
                     !type_is_nonnull_ptr(type_entry->data.maybe.child_type) &&
                     type_entry->data.maybe.child_type->id != ZigTypeIdErrorSet;
+        case ZigTypeIdUnion:
+             return type_has_bits(type_entry) && type_entry->data.unionation.gen_field_count != 0;
 
     }
     zig_unreachable();

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -6359,6 +6359,7 @@ static void resolve_llvm_types_slice(CodeGen *g, ZigType *type, ResolveStatus wa
     LLVMTypeRef element_types[2];
     element_types[slice_ptr_index] = get_llvm_type(g, ptr_type);
     element_types[slice_len_index] = get_llvm_type(g, g->builtin_types.entry_usize);
+    if (type->data.structure.resolve_status >= wanted_resolve_status) return;
     LLVMStructSetBody(type->llvm_type, element_types, 2, false);
 
     uint64_t ptr_debug_size_in_bits = ptr_type->size_in_bits;
@@ -6776,6 +6777,12 @@ static void resolve_llvm_types_union(CodeGen *g, ZigType *union_type, ResolveSta
 static void resolve_llvm_types_pointer(CodeGen *g, ZigType *type) {
     if (type->llvm_di_type != nullptr) return;
 
+    if (!type_has_bits(type)) {
+        type->llvm_type = g->builtin_types.entry_void->llvm_type;
+        type->llvm_di_type = g->builtin_types.entry_void->llvm_di_type;
+        return;
+    }
+
     ZigType *elem_type = type->data.pointer.child_type;
 
     if (type->data.pointer.is_const || type->data.pointer.is_volatile ||
@@ -6810,6 +6817,12 @@ static void resolve_llvm_types_pointer(CodeGen *g, ZigType *type) {
 
 static void resolve_llvm_types_integer(CodeGen *g, ZigType *type) {
     if (type->llvm_di_type != nullptr) return;
+
+    if (!type_has_bits(type)) {
+        type->llvm_type = g->builtin_types.entry_void->llvm_type;
+        type->llvm_di_type = g->builtin_types.entry_void->llvm_di_type;
+        return;
+    }
 
     unsigned dwarf_tag;
     if (type->data.integral.is_signed) {

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -6653,6 +6653,9 @@ static void resolve_llvm_types_union(CodeGen *g, ZigType *union_type, ResolveSta
         if (!type_has_bits(union_field->type_entry))
             continue;
 
+        ZigLLVMDIType *field_di_type = get_llvm_di_type(g, union_field->type_entry);
+        if (union_type->data.unionation.resolve_status >= wanted_resolve_status) return;
+
         uint64_t store_size_in_bits = union_field->type_entry->size_in_bits;
         uint64_t abi_align_in_bits = 8*union_field->type_entry->abi_align;
         AstNode *field_node = decl_node->data.container_decl.fields.at(i);
@@ -6662,7 +6665,7 @@ static void resolve_llvm_types_union(CodeGen *g, ZigType *union_type, ResolveSta
                 store_size_in_bits,
                 abi_align_in_bits,
                 0,
-                0, get_llvm_di_type(g, union_field->type_entry));
+                0, field_di_type);
 
     }
 
@@ -6670,8 +6673,6 @@ static void resolve_llvm_types_union(CodeGen *g, ZigType *union_type, ResolveSta
         assert(most_aligned_union_member != nullptr);
 
         size_t padding_bytes = union_type->data.unionation.union_abi_size - most_aligned_union_member->abi_size;
-        (void)get_llvm_type(g, most_aligned_union_member);
-        if (union_type->data.unionation.resolve_status >= wanted_resolve_status) return;
         if (padding_bytes > 0) {
             ZigType *u8_type = get_int_type(g, false, 8);
             ZigType *padding_array = get_array_type(g, u8_type, padding_bytes);

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -61,7 +61,7 @@ ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *abs_full_path, Bu
 ZigVar *find_variable(CodeGen *g, Scope *orig_context, Buf *name, ScopeFnDef **crossed_fndef_scope);
 Tld *find_decl(CodeGen *g, Scope *scope, Buf *name);
 Tld *find_container_decl(CodeGen *g, ScopeDecls *decls_scope, Buf *name);
-void resolve_top_level_decl(CodeGen *g, Tld *tld, AstNode *source_node);
+void resolve_top_level_decl(CodeGen *g, Tld *tld, AstNode *source_node, bool allow_lazy);
 
 ZigType *get_src_ptr_type(ZigType *type);
 ZigType *get_codegen_ptr_type(ZigType *type);
@@ -73,7 +73,7 @@ bool type_is_complete(ZigType *type_entry);
 bool type_is_resolved(ZigType *type_entry, ResolveStatus status);
 bool type_is_invalid(ZigType *type_entry);
 bool type_is_global_error_set(ZigType *err_set_type);
-void resolve_container_type(CodeGen *g, ZigType *type_entry);
+Error resolve_container_type(CodeGen *g, ZigType *type_entry);
 ScopeDecls *get_container_scope(ZigType *type_entry);
 TypeStructField *find_struct_type_field(ZigType *type_entry, Buf *name);
 TypeEnumField *find_enum_type_field(ZigType *enum_type, Buf *name);
@@ -246,4 +246,5 @@ Error create_c_object_cache(CodeGen *g, CacheHash **out_cache_hash, bool verbose
 
 LLVMTypeRef get_llvm_type(CodeGen *g, ZigType *type);
 ZigLLVMDIType *get_llvm_di_type(CodeGen *g, ZigType *type);
+
 #endif

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -61,7 +61,7 @@ ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *abs_full_path, Bu
 ZigVar *find_variable(CodeGen *g, Scope *orig_context, Buf *name, ScopeFnDef **crossed_fndef_scope);
 Tld *find_decl(CodeGen *g, Scope *scope, Buf *name);
 Tld *find_container_decl(CodeGen *g, ScopeDecls *decls_scope, Buf *name);
-void resolve_top_level_decl(CodeGen *g, Tld *tld, AstNode *source_node, bool allow_lazy);
+void resolve_top_level_decl(CodeGen *g, Tld *tld, AstNode *source_node);
 
 ZigType *get_src_ptr_type(ZigType *type);
 ZigType *get_codegen_ptr_type(ZigType *type);

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -244,4 +244,6 @@ Buf *type_bare_name(ZigType *t);
 Buf *type_h_name(ZigType *t);
 Error create_c_object_cache(CodeGen *g, CacheHash **out_cache_hash, bool verbose);
 
+LLVMTypeRef get_llvm_type(CodeGen *g, ZigType *type);
+ZigLLVMDIType *get_llvm_di_type(CodeGen *g, ZigType *type);
 #endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3358,8 +3358,6 @@ static bool value_is_all_undef_array(ConstExprValue *const_val, size_t len) {
 
 static bool value_is_all_undef(ConstExprValue *const_val) {
     switch (const_val->special) {
-        case ConstValSpecialLazy:
-            zig_unreachable();
         case ConstValSpecialRuntime:
             return false;
         case ConstValSpecialUndef:
@@ -5824,7 +5822,6 @@ static LLVMValueRef gen_const_ptr_union_recursive(CodeGen *g, ConstExprValue *un
 
 static LLVMValueRef pack_const_int(CodeGen *g, LLVMTypeRef big_int_type_ref, ConstExprValue *const_val) {
     switch (const_val->special) {
-        case ConstValSpecialLazy:
         case ConstValSpecialRuntime:
             zig_unreachable();
         case ConstValSpecialUndef:
@@ -6082,7 +6079,6 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
     assert(type_has_bits(type_entry));
 
     switch (const_val->special) {
-        case ConstValSpecialLazy:
         case ConstValSpecialRuntime:
             zig_unreachable();
         case ConstValSpecialUndef:
@@ -8249,7 +8245,7 @@ static void gen_root_source(CodeGen *g) {
         }
         Tld *panic_tld = find_decl(g, &get_container_scope(import_with_panic)->base, buf_create_from_str("panic"));
         assert(panic_tld != nullptr);
-        resolve_top_level_decl(g, panic_tld, nullptr, false);
+        resolve_top_level_decl(g, panic_tld, nullptr);
     }
 
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -668,7 +668,7 @@ static ZigLLVMDIScope *get_di_scope(CodeGen *g, Scope *scope) {
             if (scope->parent) {
                 ScopeDecls *decls_scope = (ScopeDecls *)scope;
                 assert(decls_scope->container_type);
-                scope->di_scope = ZigLLVMTypeToScope(decls_scope->container_type->di_type);
+                scope->di_scope = ZigLLVMTypeToScope(get_llvm_di_type(g, decls_scope->container_type));
             } else {
                 scope->di_scope = ZigLLVMFileToScope(import->data.structure.root_struct->di_file);
             }
@@ -711,8 +711,8 @@ static LLVMValueRef get_arithmetic_overflow_fn(CodeGen *g, ZigType *operand_type
     const char *signed_str = int_type->data.integral.is_signed ? signed_name : unsigned_name;
 
     LLVMTypeRef param_types[] = {
-        operand_type->type_ref,
-        operand_type->type_ref,
+        get_llvm_type(g, operand_type),
+        get_llvm_type(g, operand_type),
     };
 
     if (operand_type->id == ZigTypeIdVector) {
@@ -720,7 +720,7 @@ static LLVMValueRef get_arithmetic_overflow_fn(CodeGen *g, ZigType *operand_type
                 operand_type->data.vector.len, int_type->data.integral.bit_count);
 
         LLVMTypeRef return_elem_types[] = {
-            operand_type->type_ref,
+            get_llvm_type(g, operand_type),
             LLVMVectorType(LLVMInt1Type(), operand_type->data.vector.len),
         };
         LLVMTypeRef return_struct_type = LLVMStructType(return_elem_types, 2, false);
@@ -732,7 +732,7 @@ static LLVMValueRef get_arithmetic_overflow_fn(CodeGen *g, ZigType *operand_type
         sprintf(fn_name, "llvm.%s.with.overflow.i%" PRIu32, signed_str, int_type->data.integral.bit_count);
 
         LLVMTypeRef return_elem_types[] = {
-            operand_type->type_ref,
+            get_llvm_type(g, operand_type),
             LLVMInt1Type(),
         };
         LLVMTypeRef return_struct_type = LLVMStructType(return_elem_types, 2, false);
@@ -800,7 +800,8 @@ static LLVMValueRef get_float_fn(CodeGen *g, ZigType *type_entry, ZigLLVMFnId fn
 
     char fn_name[64];
     sprintf(fn_name, "llvm.%s.f%" ZIG_PRI_usize "", name, type_entry->data.floating.bit_count);
-    LLVMTypeRef fn_type = LLVMFunctionType(type_entry->type_ref, &type_entry->type_ref, 1, false);
+    LLVMTypeRef float_type_ref = get_llvm_type(g, type_entry);
+    LLVMTypeRef fn_type = LLVMFunctionType(float_type_ref, &float_type_ref, 1, false);
     LLVMValueRef fn_val = LLVMAddFunction(g->module, fn_name, fn_type);
     assert(LLVMGetIntrinsicID(fn_val));
 
@@ -958,7 +959,7 @@ static LLVMValueRef get_panic_msg_ptr_val(CodeGen *g, PanicMsgId msg_id) {
     ZigType *u8_ptr_type = get_pointer_to_type_extra(g, g->builtin_types.entry_u8, true, false,
             PtrLenUnknown, get_abi_alignment(g, g->builtin_types.entry_u8), 0, 0, false);
     ZigType *str_type = get_slice_type(g, u8_ptr_type);
-    return LLVMConstBitCast(val->global_refs->llvm_global, LLVMPointerType(str_type->type_ref, 0));
+    return LLVMConstBitCast(val->global_refs->llvm_global, LLVMPointerType(get_llvm_type(g, str_type), 0));
 }
 
 static void gen_panic(CodeGen *g, LLVMValueRef msg_arg, LLVMValueRef stack_trace_arg) {
@@ -967,7 +968,7 @@ static void gen_panic(CodeGen *g, LLVMValueRef msg_arg, LLVMValueRef stack_trace
     LLVMCallConv llvm_cc = get_llvm_cc(g, g->panic_fn->type_entry->data.fn.fn_type_id.cc);
     if (stack_trace_arg == nullptr) {
         ZigType *ptr_to_stack_trace_type = get_ptr_to_stack_trace_type(g);
-        stack_trace_arg = LLVMConstNull(ptr_to_stack_trace_type->type_ref);
+        stack_trace_arg = LLVMConstNull(get_llvm_type(g, ptr_to_stack_trace_type));
     }
     LLVMValueRef args[] = {
         msg_arg,
@@ -1081,7 +1082,7 @@ static LLVMValueRef get_coro_size_fn_val(CodeGen *g) {
     if (g->coro_size_fn_val)
         return g->coro_size_fn_val;
 
-    LLVMTypeRef fn_type = LLVMFunctionType(g->builtin_types.entry_usize->type_ref, nullptr, 0, false);
+    LLVMTypeRef fn_type = LLVMFunctionType(g->builtin_types.entry_usize->llvm_type, nullptr, 0, false);
     Buf *name = buf_sprintf("llvm.coro.size.i%d", g->pointer_size_bytes * 8);
     g->coro_size_fn_val = LLVMAddFunction(g->module, buf_ptr(name), fn_type);
     assert(LLVMGetIntrinsicID(g->coro_size_fn_val));
@@ -1206,8 +1207,8 @@ static LLVMValueRef get_return_address_fn_val(CodeGen *g) {
 
     ZigType *return_type = get_pointer_to_type(g, g->builtin_types.entry_u8, true);
 
-    LLVMTypeRef fn_type = LLVMFunctionType(return_type->type_ref,
-            &g->builtin_types.entry_i32->type_ref, 1, false);
+    LLVMTypeRef fn_type = LLVMFunctionType(get_llvm_type(g, return_type),
+            &g->builtin_types.entry_i32->llvm_type, 1, false);
     g->return_address_fn_val = LLVMAddFunction(g->module, "llvm.returnaddress", fn_type);
     assert(LLVMGetIntrinsicID(g->return_address_fn_val));
 
@@ -1219,8 +1220,8 @@ static LLVMValueRef get_add_error_return_trace_addr_fn(CodeGen *g) {
         return g->add_error_return_trace_addr_fn_val;
 
     LLVMTypeRef arg_types[] = {
-        get_ptr_to_stack_trace_type(g)->type_ref,
-        g->builtin_types.entry_usize->type_ref,
+        get_llvm_type(g, get_ptr_to_stack_trace_type(g)),
+        g->builtin_types.entry_usize->llvm_type,
     };
     LLVMTypeRef fn_type_ref = LLVMFunctionType(LLVMVoidType(), arg_types, 2, false);
 
@@ -1245,7 +1246,7 @@ static LLVMValueRef get_add_error_return_trace_addr_fn(CodeGen *g) {
     LLVMPositionBuilderAtEnd(g->builder, entry_block);
     ZigLLVMClearCurrentDebugLocation(g->builder);
 
-    LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->type_ref;
+    LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->llvm_type;
 
     // stack_trace.instruction_addresses[stack_trace.index & (stack_trace.instruction_addresses.len - 1)] = return_address;
 
@@ -1297,8 +1298,8 @@ static LLVMValueRef get_merge_err_ret_traces_fn_val(CodeGen *g) {
     assert(g->stack_trace_type != nullptr);
 
     LLVMTypeRef param_types[] = {
-        get_ptr_to_stack_trace_type(g)->type_ref,
-        get_ptr_to_stack_trace_type(g)->type_ref,
+        get_llvm_type(g, get_ptr_to_stack_trace_type(g)),
+        get_llvm_type(g, get_ptr_to_stack_trace_type(g)),
     };
     LLVMTypeRef fn_type_ref = LLVMFunctionType(LLVMVoidType(), param_types, 2, false);
 
@@ -1350,8 +1351,8 @@ static LLVMValueRef get_merge_err_ret_traces_fn_val(CodeGen *g) {
     // }
     LLVMBasicBlockRef return_block = LLVMAppendBasicBlock(fn_val, "Return");
 
-    LLVMValueRef frame_index_ptr = LLVMBuildAlloca(g->builder, g->builtin_types.entry_usize->type_ref, "frame_index");
-    LLVMValueRef frames_left_ptr = LLVMBuildAlloca(g->builder, g->builtin_types.entry_usize->type_ref, "frames_left");
+    LLVMValueRef frame_index_ptr = LLVMBuildAlloca(g->builder, g->builtin_types.entry_usize->llvm_type, "frame_index");
+    LLVMValueRef frames_left_ptr = LLVMBuildAlloca(g->builder, g->builtin_types.entry_usize->llvm_type, "frames_left");
 
     LLVMValueRef dest_stack_trace_ptr = LLVMGetParam(fn_val, 0);
     LLVMValueRef src_stack_trace_ptr = LLVMGetParam(fn_val, 1);
@@ -1377,14 +1378,14 @@ static LLVMValueRef get_merge_err_ret_traces_fn_val(CodeGen *g) {
     LLVMBuildCondBr(g->builder, no_wrap_bit, no_wrap_block, yes_wrap_block);
 
     LLVMPositionBuilderAtEnd(g->builder, no_wrap_block);
-    LLVMValueRef usize_zero = LLVMConstNull(g->builtin_types.entry_usize->type_ref);
+    LLVMValueRef usize_zero = LLVMConstNull(g->builtin_types.entry_usize->llvm_type);
     LLVMBuildStore(g->builder, usize_zero, frame_index_ptr);
     LLVMBuildStore(g->builder, src_index_val, frames_left_ptr);
     LLVMValueRef frames_left_eq_zero_bit = LLVMBuildICmp(g->builder, LLVMIntEQ, src_index_val, usize_zero, "");
     LLVMBuildCondBr(g->builder, frames_left_eq_zero_bit, return_block, loop_block);
 
     LLVMPositionBuilderAtEnd(g->builder, yes_wrap_block);
-    LLVMValueRef usize_one = LLVMConstInt(g->builtin_types.entry_usize->type_ref, 1, false);
+    LLVMValueRef usize_one = LLVMConstInt(g->builtin_types.entry_usize->llvm_type, 1, false);
     LLVMValueRef plus_one = LLVMBuildNUWAdd(g->builder, src_index_val, usize_one, "");
     LLVMValueRef mod_len = LLVMBuildURem(g->builder, plus_one, src_len_val, "");
     LLVMBuildStore(g->builder, mod_len, frame_index_ptr);
@@ -1430,7 +1431,7 @@ static LLVMValueRef get_return_err_fn(CodeGen *g) {
 
     LLVMTypeRef arg_types[] = {
         // error return trace pointer
-        get_ptr_to_stack_trace_type(g)->type_ref,
+        get_llvm_type(g, get_ptr_to_stack_trace_type(g)),
     };
     LLVMTypeRef fn_type_ref = LLVMFunctionType(LLVMVoidType(), arg_types, 1, false);
 
@@ -1461,8 +1462,8 @@ static LLVMValueRef get_return_err_fn(CodeGen *g) {
 
     LLVMValueRef err_ret_trace_ptr = LLVMGetParam(fn_val, 0);
 
-    LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->type_ref;
-    LLVMValueRef zero = LLVMConstNull(g->builtin_types.entry_i32->type_ref);
+    LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->llvm_type;
+    LLVMValueRef zero = LLVMConstNull(get_llvm_type(g, g->builtin_types.entry_i32));
     LLVMValueRef return_address_ptr = LLVMBuildCall(g->builder, get_return_address_fn_val(g), &zero, 1, "");
     LLVMValueRef return_address = LLVMBuildPtrToInt(g->builder, return_address_ptr, usize_type_ref, "");
 
@@ -1508,8 +1509,8 @@ static LLVMValueRef get_safety_crash_err_fn(CodeGen *g) {
 
     ZigType *usize = g->builtin_types.entry_usize;
     LLVMValueRef full_buf_ptr_indices[] = {
-        LLVMConstNull(usize->type_ref),
-        LLVMConstNull(usize->type_ref),
+        LLVMConstNull(usize->llvm_type),
+        LLVMConstNull(usize->llvm_type),
     };
     LLVMValueRef full_buf_ptr = LLVMConstInBoundsGEP(global_array, full_buf_ptr_indices, 2);
 
@@ -1519,9 +1520,9 @@ static LLVMValueRef get_safety_crash_err_fn(CodeGen *g) {
     ZigType *str_type = get_slice_type(g, u8_ptr_type);
     LLVMValueRef global_slice_fields[] = {
         full_buf_ptr,
-        LLVMConstNull(usize->type_ref),
+        LLVMConstNull(usize->llvm_type),
     };
-    LLVMValueRef slice_init_value = LLVMConstNamedStruct(str_type->type_ref, global_slice_fields, 2);
+    LLVMValueRef slice_init_value = LLVMConstNamedStruct(get_llvm_type(g, str_type), global_slice_fields, 2);
     LLVMValueRef global_slice = LLVMAddGlobal(g->module, LLVMTypeOf(slice_init_value), "");
     LLVMSetInitializer(global_slice, slice_init_value);
     LLVMSetLinkage(global_slice, LLVMInternalLinkage);
@@ -1530,15 +1531,15 @@ static LLVMValueRef get_safety_crash_err_fn(CodeGen *g) {
     LLVMSetAlignment(global_slice, get_abi_alignment(g, str_type));
 
     LLVMValueRef offset_ptr_indices[] = {
-        LLVMConstNull(usize->type_ref),
-        LLVMConstInt(usize->type_ref, unwrap_err_msg_text_len, false),
+        LLVMConstNull(usize->llvm_type),
+        LLVMConstInt(usize->llvm_type, unwrap_err_msg_text_len, false),
     };
     LLVMValueRef offset_buf_ptr = LLVMConstInBoundsGEP(global_array, offset_ptr_indices, 2);
 
     Buf *fn_name = get_mangled_name(g, buf_create_from_str("__zig_fail_unwrap"), false);
     LLVMTypeRef arg_types[] = {
-        g->ptr_to_stack_trace_type->type_ref,
-        g->err_tag_type->type_ref,
+        get_llvm_type(g, g->ptr_to_stack_trace_type),
+        get_llvm_type(g, g->err_tag_type),
     };
     LLVMTypeRef fn_type_ref = LLVMFunctionType(LLVMVoidType(), arg_types, 2, false);
     LLVMValueRef fn_val = LLVMAddFunction(g->module, buf_ptr(fn_name), fn_type_ref);
@@ -1565,7 +1566,7 @@ static LLVMValueRef get_safety_crash_err_fn(CodeGen *g) {
     LLVMValueRef err_val = LLVMGetParam(fn_val, 1);
 
     LLVMValueRef err_table_indices[] = {
-        LLVMConstNull(g->builtin_types.entry_usize->type_ref),
+        LLVMConstNull(g->builtin_types.entry_usize->llvm_type),
         err_val,
     };
     LLVMValueRef err_name_val = LLVMBuildInBoundsGEP(g->builder, g->err_name_table, err_table_indices, 2, "");
@@ -1623,7 +1624,7 @@ static void gen_safety_crash_for_err(CodeGen *g, LLVMValueRef err_val, Scope *sc
     LLVMValueRef err_ret_trace_val = get_cur_err_ret_trace_val(g, scope);
     if (err_ret_trace_val == nullptr) {
         ZigType *ptr_to_stack_trace_type = get_ptr_to_stack_trace_type(g);
-        err_ret_trace_val = LLVMConstNull(ptr_to_stack_trace_type->type_ref);
+        err_ret_trace_val = LLVMConstNull(get_llvm_type(g, ptr_to_stack_trace_type));
     }
     LLVMValueRef args[] = {
         err_ret_trace_val,
@@ -1669,7 +1670,7 @@ static void add_bounds_check(CodeGen *g, LLVMValueRef target_val,
 }
 
 static LLVMValueRef gen_assert_zero(CodeGen *g, LLVMValueRef expr_val, ZigType *int_type) {
-    LLVMValueRef zero = LLVMConstNull(int_type->type_ref);
+    LLVMValueRef zero = LLVMConstNull(get_llvm_type(g, int_type));
     LLVMValueRef ok_bit = LLVMBuildICmp(g->builder, LLVMIntEQ, expr_val, zero, "");
     LLVMBasicBlockRef ok_block = LLVMAppendBasicBlock(g->cur_fn_val, "CastShortenOk");
     LLVMBasicBlockRef fail_block = LLVMAppendBasicBlock(g->cur_fn_val, "CastShortenFail");
@@ -1704,7 +1705,7 @@ static LLVMValueRef gen_widen_or_shorten(CodeGen *g, bool want_runtime_safety, Z
         !wanted_type->data.integral.is_signed && actual_type->data.integral.is_signed &&
         want_runtime_safety)
     {
-        LLVMValueRef zero = LLVMConstNull(actual_type->type_ref);
+        LLVMValueRef zero = LLVMConstNull(get_llvm_type(g, actual_type));
         LLVMValueRef ok_bit = LLVMBuildICmp(g->builder, LLVMIntSGE, expr_val, zero, "");
 
         LLVMBasicBlockRef ok_block = LLVMAppendBasicBlock(g->cur_fn_val, "SignCastOk");
@@ -1721,19 +1722,19 @@ static LLVMValueRef gen_widen_or_shorten(CodeGen *g, bool want_runtime_safety, Z
         return expr_val;
     } else if (actual_bits < wanted_bits) {
         if (actual_type->id == ZigTypeIdFloat) {
-            return LLVMBuildFPExt(g->builder, expr_val, wanted_type->type_ref, "");
+            return LLVMBuildFPExt(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
         } else if (actual_type->id == ZigTypeIdInt) {
             if (actual_type->data.integral.is_signed) {
-                return LLVMBuildSExt(g->builder, expr_val, wanted_type->type_ref, "");
+                return LLVMBuildSExt(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
             } else {
-                return LLVMBuildZExt(g->builder, expr_val, wanted_type->type_ref, "");
+                return LLVMBuildZExt(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
             }
         } else {
             zig_unreachable();
         }
     } else if (actual_bits > wanted_bits) {
         if (actual_type->id == ZigTypeIdFloat) {
-            return LLVMBuildFPTrunc(g->builder, expr_val, wanted_type->type_ref, "");
+            return LLVMBuildFPTrunc(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
         } else if (actual_type->id == ZigTypeIdInt) {
             if (wanted_bits == 0) {
                 if (!want_runtime_safety)
@@ -1741,15 +1742,15 @@ static LLVMValueRef gen_widen_or_shorten(CodeGen *g, bool want_runtime_safety, Z
 
                 return gen_assert_zero(g, expr_val, actual_type);
             }
-            LLVMValueRef trunc_val = LLVMBuildTrunc(g->builder, expr_val, wanted_type->type_ref, "");
+            LLVMValueRef trunc_val = LLVMBuildTrunc(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
             if (!want_runtime_safety) {
                 return trunc_val;
             }
             LLVMValueRef orig_val;
             if (wanted_type->data.integral.is_signed) {
-                orig_val = LLVMBuildSExt(g->builder, trunc_val, actual_type->type_ref, "");
+                orig_val = LLVMBuildSExt(g->builder, trunc_val, get_llvm_type(g, actual_type), "");
             } else {
-                orig_val = LLVMBuildZExt(g->builder, trunc_val, actual_type->type_ref, "");
+                orig_val = LLVMBuildZExt(g->builder, trunc_val, get_llvm_type(g, actual_type), "");
             }
             LLVMValueRef ok_bit = LLVMBuildICmp(g->builder, LLVMIntEQ, expr_val, orig_val, "");
             LLVMBasicBlockRef ok_block = LLVMAppendBasicBlock(g->cur_fn_val, "CastShortenOk");
@@ -1793,7 +1794,7 @@ static LLVMValueRef gen_overflow_op(CodeGen *g, ZigType *operand_type, AddSubMul
         LLVMValueRef extended1 = buildExtFn(g->builder, val1, one_more_bit_int_vector, "");
         LLVMValueRef extended2 = buildExtFn(g->builder, val2, one_more_bit_int_vector, "");
         LLVMValueRef extended_result = wrap_op[op](g->builder, extended1, extended2, "");
-        result = LLVMBuildTrunc(g->builder, extended_result, operand_type->type_ref, "");
+        result = LLVMBuildTrunc(g->builder, extended_result, get_llvm_type(g, operand_type), "");
 
         LLVMValueRef re_extended_result = buildExtFn(g->builder, result, one_more_bit_int_vector, "");
         LLVMValueRef overflow_vector = LLVMBuildICmp(g->builder, LLVMIntNE, extended_result, re_extended_result, "");
@@ -1880,12 +1881,13 @@ static LLVMValueRef gen_assign_raw(CodeGen *g, LLVMValueRef ptr, ZigType *ptr_ty
         LLVMValueRef dest_ptr = LLVMBuildBitCast(g->builder, ptr, ptr_u8, "");
 
         ZigType *usize = g->builtin_types.entry_usize;
-        uint64_t size_bytes = LLVMStoreSizeOfType(g->target_data_ref, child_type->type_ref);
+        uint64_t size_bytes = LLVMStoreSizeOfType(g->target_data_ref, get_llvm_type(g, child_type));
         uint64_t align_bytes = get_ptr_align(g, ptr_type);
         assert(size_bytes > 0);
         assert(align_bytes > 0);
 
-        ZigLLVMBuildMemCpy(g->builder, dest_ptr, align_bytes, src_ptr, align_bytes, LLVMConstInt(usize->type_ref, size_bytes, false),
+        ZigLLVMBuildMemCpy(g->builder, dest_ptr, align_bytes, src_ptr, align_bytes,
+                LLVMConstInt(usize->llvm_type, size_bytes, false),
                 ptr_type->data.pointer.is_volatile);
         return nullptr;
     }
@@ -1907,7 +1909,7 @@ static LLVMValueRef gen_assign_raw(CodeGen *g, LLVMValueRef ptr, ZigType *ptr_ty
     uint32_t shift_amt = big_endian ? host_bit_count - bit_offset - size_in_bits : bit_offset;
     LLVMValueRef shift_amt_val = LLVMConstInt(LLVMTypeOf(containing_int), shift_amt, false);
 
-    LLVMValueRef mask_val = LLVMConstAllOnes(child_type->type_ref);
+    LLVMValueRef mask_val = LLVMConstAllOnes(get_llvm_type(g, child_type));
     mask_val = LLVMConstZExt(mask_val, LLVMTypeOf(containing_int));
     mask_val = LLVMConstShl(mask_val, shift_amt_val);
     mask_val = LLVMConstNot(mask_val);
@@ -1942,9 +1944,10 @@ static LLVMValueRef ir_llvm_value(CodeGen *g, IrInstruction *instruction) {
         if (handle_is_ptr(instruction->value.type)) {
             render_const_val_global(g, &instruction->value, "");
             ZigType *ptr_type = get_pointer_to_type(g, instruction->value.type, true);
-            instruction->llvm_value = LLVMBuildBitCast(g->builder, instruction->value.global_refs->llvm_global, ptr_type->type_ref, "");
+            instruction->llvm_value = LLVMBuildBitCast(g->builder, instruction->value.global_refs->llvm_global, get_llvm_type(g, ptr_type), "");
         } else if (instruction->value.type->id == ZigTypeIdPointer) {
-            instruction->llvm_value = LLVMBuildBitCast(g->builder, instruction->value.global_refs->llvm_value, instruction->value.type->type_ref, "");
+            instruction->llvm_value = LLVMBuildBitCast(g->builder, instruction->value.global_refs->llvm_value,
+                    get_llvm_type(g, instruction->value.type), "");
         } else {
             instruction->llvm_value = instruction->value.global_refs->llvm_value;
         }
@@ -1979,7 +1982,7 @@ static void give_up_with_c_abi_error(CodeGen *g, AstNode *source_node) {
 }
 
 static LLVMValueRef build_alloca(CodeGen *g, ZigType *type_entry, const char *name, uint32_t alignment) {
-    LLVMValueRef result = LLVMBuildAlloca(g->builder, type_entry->type_ref, name);
+    LLVMValueRef result = LLVMBuildAlloca(g->builder, get_llvm_type(g, type_entry), name);
     LLVMSetAlignment(result, (alignment == 0) ? get_abi_alignment(g, type_entry) : alignment);
     return result;
 }
@@ -2062,8 +2065,8 @@ static bool iter_function_params_c_abi(CodeGen *g, ZigType *fn_type, FnWalk *fn_
                 fn_walk->data.call.gen_param_values->append(val);
                 break;
             case FnWalkIdTypes:
-                fn_walk->data.types.gen_param_types->append(ty->type_ref);
-                fn_walk->data.types.param_di_types->append(ty->di_type);
+                fn_walk->data.types.gen_param_types->append(get_llvm_type(g, ty));
+                fn_walk->data.types.param_di_types->append(get_llvm_di_type(g, ty));
                 break;
             case FnWalkIdVars: {
                 var->value_ref = build_alloca(g, ty, buf_ptr(&var->name), var->align_bytes);
@@ -2099,8 +2102,8 @@ static bool iter_function_params_c_abi(CodeGen *g, ZigType *fn_type, FnWalk *fn_
                 break;
             case FnWalkIdTypes: {
                 ZigType *gen_type = get_pointer_to_type(g, ty, true);
-                fn_walk->data.types.gen_param_types->append(gen_type->type_ref);
-                fn_walk->data.types.param_di_types->append(gen_type->di_type);
+                fn_walk->data.types.gen_param_types->append(get_llvm_type(g, gen_type));
+                fn_walk->data.types.param_di_types->append(get_llvm_di_type(g, gen_type));
                 break;
             }
             case FnWalkIdVars: {
@@ -2138,8 +2141,8 @@ static bool iter_function_params_c_abi(CodeGen *g, ZigType *fn_type, FnWalk *fn_
                     break;
                 case FnWalkIdTypes: {
                     ZigType *gen_type = get_pointer_to_type(g, ty, true);
-                    fn_walk->data.types.gen_param_types->append(gen_type->type_ref);
-                    fn_walk->data.types.param_di_types->append(gen_type->di_type);
+                    fn_walk->data.types.gen_param_types->append(get_llvm_type(g, gen_type));
+                    fn_walk->data.types.param_di_types->append(get_llvm_di_type(g, gen_type));
                     break;
                 }
                 case FnWalkIdVars: {
@@ -2171,8 +2174,8 @@ static bool iter_function_params_c_abi(CodeGen *g, ZigType *fn_type, FnWalk *fn_
                 }
                 case FnWalkIdTypes: {
                     ZigType *gen_type = get_int_type(g, false, ty_size * 8);
-                    fn_walk->data.types.gen_param_types->append(gen_type->type_ref);
-                    fn_walk->data.types.param_di_types->append(gen_type->di_type);
+                    fn_walk->data.types.gen_param_types->append(get_llvm_type(g, gen_type));
+                    fn_walk->data.types.param_di_types->append(get_llvm_di_type(g, gen_type));
                     break;
                 }
                 case FnWalkIdVars: {
@@ -2210,7 +2213,7 @@ var_ok:
         var->di_loc_var = ZigLLVMCreateParameterVariable(g->dbuilder, get_di_scope(g, var->parent_scope),
                 buf_ptr(&var->name), fn_walk->data.vars.import->data.structure.root_struct->di_file,
                 (unsigned)(var->decl_node->line + 1),
-                dest_ty->di_type, !g->strip_debug_symbols, 0, di_arg_index + 1);
+                get_llvm_di_type(g, dest_ty), !g->strip_debug_symbols, 0, di_arg_index + 1);
     }
     return true;
 }
@@ -2436,7 +2439,7 @@ static LLVMValueRef gen_div(CodeGen *g, bool want_runtime_safety, bool want_fast
 {
     ZigLLVMSetFastMath(g->builder, want_fast_math);
 
-    LLVMValueRef zero = LLVMConstNull(type_entry->type_ref);
+    LLVMValueRef zero = LLVMConstNull(get_llvm_type(g, type_entry));
     if (want_runtime_safety && (want_fast_math || type_entry->id != ZigTypeIdFloat)) {
         LLVMValueRef is_zero_bit;
         if (type_entry->id == ZigTypeIdInt) {
@@ -2456,10 +2459,10 @@ static LLVMValueRef gen_div(CodeGen *g, bool want_runtime_safety, bool want_fast
         LLVMPositionBuilderAtEnd(g->builder, div_zero_ok_block);
 
         if (type_entry->id == ZigTypeIdInt && type_entry->data.integral.is_signed) {
-            LLVMValueRef neg_1_value = LLVMConstInt(type_entry->type_ref, -1, true);
+            LLVMValueRef neg_1_value = LLVMConstInt(get_llvm_type(g, type_entry), -1, true);
             BigInt int_min_bi = {0};
             eval_min_max_value_int(g, type_entry, &int_min_bi, false);
-            LLVMValueRef int_min_value = bigint_to_llvm_const(type_entry->type_ref, &int_min_bi);
+            LLVMValueRef int_min_value = bigint_to_llvm_const(get_llvm_type(g, type_entry), &int_min_bi);
             LLVMBasicBlockRef overflow_ok_block = LLVMAppendBasicBlock(g->cur_fn_val, "DivOverflowOk");
             LLVMBasicBlockRef overflow_fail_block = LLVMAppendBasicBlock(g->cur_fn_val, "DivOverflowFail");
             LLVMValueRef num_is_int_min = LLVMBuildICmp(g->builder, LLVMIntEQ, val1, int_min_value, "");
@@ -2513,7 +2516,7 @@ static LLVMValueRef gen_div(CodeGen *g, bool want_runtime_safety, bool want_fast
                     LLVMBuildBr(g->builder, end_block);
 
                     LLVMPositionBuilderAtEnd(g->builder, end_block);
-                    LLVMValueRef phi = LLVMBuildPhi(g->builder, type_entry->type_ref, "");
+                    LLVMValueRef phi = LLVMBuildPhi(g->builder, get_llvm_type(g, type_entry), "");
                     LLVMValueRef incoming_values[] = { ceiled, floored };
                     LLVMBasicBlockRef incoming_blocks[] = { ceiled_end_block, floored_end_block };
                     LLVMAddIncoming(phi, incoming_values, incoming_blocks, 2);
@@ -2576,7 +2579,7 @@ static LLVMValueRef gen_div(CodeGen *g, bool want_runtime_safety, bool want_fast
                 LLVMValueRef orig_num = LLVMBuildNSWMul(g->builder, result, val2, "");
                 LLVMValueRef orig_ok = LLVMBuildICmp(g->builder, LLVMIntEQ, orig_num, val1, "");
                 LLVMValueRef ok_bit = LLVMBuildOr(g->builder, orig_ok, is_pos, "");
-                LLVMValueRef one = LLVMConstInt(type_entry->type_ref, 1, true);
+                LLVMValueRef one = LLVMConstInt(get_llvm_type(g, type_entry), 1, true);
                 LLVMValueRef result_minus_1 = LLVMBuildNSWSub(g->builder, result, one, "");
                 return LLVMBuildSelect(g->builder, ok_bit, result, result_minus_1, "");
             }
@@ -2595,7 +2598,7 @@ static LLVMValueRef gen_rem(CodeGen *g, bool want_runtime_safety, bool want_fast
 {
     ZigLLVMSetFastMath(g->builder, want_fast_math);
 
-    LLVMValueRef zero = LLVMConstNull(type_entry->type_ref);
+    LLVMValueRef zero = LLVMConstNull(get_llvm_type(g, type_entry));
     if (want_runtime_safety) {
         LLVMValueRef is_zero_bit;
         if (type_entry->id == ZigTypeIdInt) {
@@ -2820,7 +2823,7 @@ static void add_error_range_check(CodeGen *g, ZigType *err_set_type, ZigType *in
     assert(err_set_type->id == ZigTypeIdErrorSet);
 
     if (type_is_global_error_set(err_set_type)) {
-        LLVMValueRef zero = LLVMConstNull(int_type->type_ref);
+        LLVMValueRef zero = LLVMConstNull(get_llvm_type(g, int_type));
         LLVMValueRef neq_zero_bit = LLVMBuildICmp(g->builder, LLVMIntNE, target_val, zero, "");
         LLVMValueRef ok_bit;
 
@@ -2832,7 +2835,7 @@ static void add_error_range_check(CodeGen *g, ZigType *err_set_type, ZigType *in
         {
             ok_bit = neq_zero_bit;
         } else {
-            LLVMValueRef error_value_count = LLVMConstInt(int_type->type_ref, g->errors_by_index.length, false);
+            LLVMValueRef error_value_count = LLVMConstInt(get_llvm_type(g, int_type), g->errors_by_index.length, false);
             LLVMValueRef in_bounds_bit = LLVMBuildICmp(g->builder, LLVMIntULT, target_val, error_value_count, "");
             ok_bit = LLVMBuildAnd(g->builder, neq_zero_bit, in_bounds_bit, "");
         }
@@ -2853,7 +2856,8 @@ static void add_error_range_check(CodeGen *g, ZigType *err_set_type, ZigType *in
         uint32_t err_count = err_set_type->data.error_set.err_count;
         LLVMValueRef switch_instr = LLVMBuildSwitch(g->builder, target_val, fail_block, err_count);
         for (uint32_t i = 0; i < err_count; i += 1) {
-            LLVMValueRef case_value = LLVMConstInt(g->err_tag_type->type_ref, err_set_type->data.error_set.errors[i]->value, false);
+            LLVMValueRef case_value = LLVMConstInt(get_llvm_type(g, g->err_tag_type),
+                    err_set_type->data.error_set.errors[i]->value, false);
             LLVMAddCase(switch_instr, case_value, ok_block);
         }
 
@@ -2892,7 +2896,7 @@ static LLVMValueRef ir_render_resize_slice(CodeGen *g, IrExecutable *executable,
     LLVMValueRef src_ptr_ptr = LLVMBuildStructGEP(g->builder, expr_val, (unsigned)actual_ptr_index, "");
     LLVMValueRef src_ptr = gen_load_untyped(g, src_ptr_ptr, 0, false, "");
     LLVMValueRef src_ptr_casted = LLVMBuildBitCast(g->builder, src_ptr,
-            wanted_type->data.structure.fields[0].type_entry->type_ref, "");
+            get_llvm_type(g, wanted_type->data.structure.fields[0].type_entry), "");
     LLVMValueRef dest_ptr_ptr = LLVMBuildStructGEP(g->builder, instruction->tmp_ptr,
             (unsigned)wanted_ptr_index, "");
     gen_store_untyped(g, src_ptr_casted, dest_ptr_ptr, 0, false);
@@ -2904,13 +2908,13 @@ static LLVMValueRef ir_render_resize_slice(CodeGen *g, IrExecutable *executable,
 
     LLVMValueRef new_len;
     if (dest_size == 1) {
-        LLVMValueRef src_size_val = LLVMConstInt(g->builtin_types.entry_usize->type_ref, src_size, false);
+        LLVMValueRef src_size_val = LLVMConstInt(g->builtin_types.entry_usize->llvm_type, src_size, false);
         new_len = LLVMBuildMul(g->builder, src_len, src_size_val, "");
     } else if (src_size == 1) {
-        LLVMValueRef dest_size_val = LLVMConstInt(g->builtin_types.entry_usize->type_ref, dest_size, false);
+        LLVMValueRef dest_size_val = LLVMConstInt(g->builtin_types.entry_usize->llvm_type, dest_size, false);
         if (ir_want_runtime_safety(g, &instruction->base)) {
             LLVMValueRef remainder_val = LLVMBuildURem(g->builder, src_len, dest_size_val, "");
-            LLVMValueRef zero = LLVMConstNull(g->builtin_types.entry_usize->type_ref);
+            LLVMValueRef zero = LLVMConstNull(g->builtin_types.entry_usize->llvm_type);
             LLVMValueRef ok_bit = LLVMBuildICmp(g->builder, LLVMIntEQ, remainder_val, zero, "");
             LLVMBasicBlockRef ok_block = LLVMAppendBasicBlock(g->cur_fn_val, "SliceWidenOk");
             LLVMBasicBlockRef fail_block = LLVMAppendBasicBlock(g->cur_fn_val, "SliceWidenFail");
@@ -2951,9 +2955,9 @@ static LLVMValueRef ir_render_cast(CodeGen *g, IrExecutable *executable,
         case CastOpIntToFloat:
             assert(actual_type->id == ZigTypeIdInt);
             if (actual_type->data.integral.is_signed) {
-                return LLVMBuildSIToFP(g->builder, expr_val, wanted_type->type_ref, "");
+                return LLVMBuildSIToFP(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
             } else {
-                return LLVMBuildUIToFP(g->builder, expr_val, wanted_type->type_ref, "");
+                return LLVMBuildUIToFP(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
             }
         case CastOpFloatToInt: {
             assert(wanted_type->id == ZigTypeIdInt);
@@ -2963,9 +2967,9 @@ static LLVMValueRef ir_render_cast(CodeGen *g, IrExecutable *executable,
 
             LLVMValueRef result;
             if (wanted_type->data.integral.is_signed) {
-                result = LLVMBuildFPToSI(g->builder, expr_val, wanted_type->type_ref, "");
+                result = LLVMBuildFPToSI(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
             } else {
-                result = LLVMBuildFPToUI(g->builder, expr_val, wanted_type->type_ref, "");
+                result = LLVMBuildFPToUI(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
             }
 
             if (want_safety) {
@@ -2993,14 +2997,14 @@ static LLVMValueRef ir_render_cast(CodeGen *g, IrExecutable *executable,
         case CastOpBoolToInt:
             assert(wanted_type->id == ZigTypeIdInt);
             assert(actual_type->id == ZigTypeIdBool);
-            return LLVMBuildZExt(g->builder, expr_val, wanted_type->type_ref, "");
+            return LLVMBuildZExt(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
         case CastOpErrSet:
             if (ir_want_runtime_safety(g, &cast_instruction->base)) {
                 add_error_range_check(g, wanted_type, g->err_tag_type, expr_val);
             }
             return expr_val;
         case CastOpBitCast:
-            return LLVMBuildBitCast(g->builder, expr_val, wanted_type->type_ref, "");
+            return LLVMBuildBitCast(g->builder, expr_val, get_llvm_type(g, wanted_type), "");
         case CastOpPtrOfArrayToSlice: {
             assert(cast_instruction->tmp_ptr);
             assert(actual_type->id == ZigTypeIdPointer);
@@ -3010,15 +3014,15 @@ static LLVMValueRef ir_render_cast(CodeGen *g, IrExecutable *executable,
             LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, cast_instruction->tmp_ptr,
                     slice_ptr_index, "");
             LLVMValueRef indices[] = {
-                LLVMConstNull(g->builtin_types.entry_usize->type_ref),
-                LLVMConstInt(g->builtin_types.entry_usize->type_ref, 0, false),
+                LLVMConstNull(g->builtin_types.entry_usize->llvm_type),
+                LLVMConstInt(g->builtin_types.entry_usize->llvm_type, 0, false),
             };
             LLVMValueRef slice_start_ptr = LLVMBuildInBoundsGEP(g->builder, expr_val, indices, 2, "");
             gen_store_untyped(g, slice_start_ptr, ptr_field_ptr, 0, false);
 
             LLVMValueRef len_field_ptr = LLVMBuildStructGEP(g->builder, cast_instruction->tmp_ptr,
                     slice_len_index, "");
-            LLVMValueRef len_value = LLVMConstInt(g->builtin_types.entry_usize->type_ref,
+            LLVMValueRef len_value = LLVMConstInt(g->builtin_types.entry_usize->llvm_type,
                     array_type->data.array.len, false);
             gen_store_untyped(g, len_value, len_field_ptr, 0, false);
 
@@ -3036,7 +3040,7 @@ static LLVMValueRef ir_render_ptr_cast(CodeGen *g, IrExecutable *executable,
         return nullptr;
     }
     LLVMValueRef ptr = ir_llvm_value(g, instruction->ptr);
-    LLVMValueRef result_ptr = LLVMBuildBitCast(g->builder, ptr, wanted_type->type_ref, "");
+    LLVMValueRef result_ptr = LLVMBuildBitCast(g->builder, ptr, get_llvm_type(g, wanted_type), "");
     bool want_safety_check = instruction->safety_check_on && ir_want_runtime_safety(g, &instruction->base);
     if (!want_safety_check || ptr_allows_addr_zero(wanted_type))
         return result_ptr;
@@ -3066,16 +3070,16 @@ static LLVMValueRef ir_render_bit_cast(CodeGen *g, IrExecutable *executable,
     if (wanted_is_ptr == actual_is_ptr) {
         // We either bitcast the value directly or bitcast the pointer which does a pointer cast
         LLVMTypeRef wanted_type_ref = wanted_is_ptr ?
-            LLVMPointerType(wanted_type->type_ref, 0) : wanted_type->type_ref;
+            LLVMPointerType(get_llvm_type(g, wanted_type), 0) : get_llvm_type(g, wanted_type);
         return LLVMBuildBitCast(g->builder, value, wanted_type_ref, "");
     } else if (actual_is_ptr) {
-        LLVMTypeRef wanted_ptr_type_ref = LLVMPointerType(wanted_type->type_ref, 0);
+        LLVMTypeRef wanted_ptr_type_ref = LLVMPointerType(get_llvm_type(g, wanted_type), 0);
         LLVMValueRef bitcasted_ptr = LLVMBuildBitCast(g->builder, value, wanted_ptr_type_ref, "");
         uint32_t alignment = get_abi_alignment(g, actual_type);
         return gen_load_untyped(g, bitcasted_ptr, alignment, false, "");
     } else {
         assert(instruction->tmp_ptr != nullptr);
-        LLVMTypeRef wanted_ptr_type_ref = LLVMPointerType(actual_type->type_ref, 0);
+        LLVMTypeRef wanted_ptr_type_ref = LLVMPointerType(get_llvm_type(g, actual_type), 0);
         LLVMValueRef bitcasted_ptr = LLVMBuildBitCast(g->builder, instruction->tmp_ptr, wanted_ptr_type_ref, "");
         uint32_t alignment = get_abi_alignment(g, wanted_type);
         gen_store_untyped(g, value, bitcasted_ptr, alignment, false);
@@ -3115,13 +3119,13 @@ static LLVMValueRef ir_render_int_to_ptr(CodeGen *g, IrExecutable *executable, I
 
         LLVMPositionBuilderAtEnd(g->builder, ok_block);
     }
-    return LLVMBuildIntToPtr(g->builder, target_val, wanted_type->type_ref, "");
+    return LLVMBuildIntToPtr(g->builder, target_val, get_llvm_type(g, wanted_type), "");
 }
 
 static LLVMValueRef ir_render_ptr_to_int(CodeGen *g, IrExecutable *executable, IrInstructionPtrToInt *instruction) {
     ZigType *wanted_type = instruction->base.value.type;
     LLVMValueRef target_val = ir_llvm_value(g, instruction->target);
-    return LLVMBuildPtrToInt(g->builder, target_val, wanted_type->type_ref, "");
+    return LLVMBuildPtrToInt(g->builder, target_val, get_llvm_type(g, wanted_type), "");
 }
 
 static LLVMValueRef ir_render_int_to_enum(CodeGen *g, IrExecutable *executable, IrInstructionIntToEnum *instruction) {
@@ -3139,7 +3143,7 @@ static LLVMValueRef ir_render_int_to_enum(CodeGen *g, IrExecutable *executable, 
         size_t field_count = wanted_type->data.enumeration.src_field_count;
         LLVMValueRef switch_instr = LLVMBuildSwitch(g->builder, tag_int_value, bad_value_block, field_count);
         for (size_t field_i = 0; field_i < field_count; field_i += 1) {
-            LLVMValueRef this_tag_int_value = bigint_to_llvm_const(tag_int_type->type_ref,
+            LLVMValueRef this_tag_int_value = bigint_to_llvm_const(get_llvm_type(g, tag_int_type),
                     &wanted_type->data.enumeration.fields[field_i].value);
             LLVMAddCase(switch_instr, this_tag_int_value, ok_value_block);
         }
@@ -3321,7 +3325,7 @@ static LLVMValueRef ir_render_load_ptr(CodeGen *g, IrExecutable *executable, IrI
     LLVMValueRef shifted_value = LLVMBuildLShr(g->builder, containing_int, shift_amt_val, "");
 
     if (!handle_is_ptr(child_type))
-        return LLVMBuildTrunc(g->builder, shifted_value, child_type->type_ref, "");
+        return LLVMBuildTrunc(g->builder, shifted_value, get_llvm_type(g, child_type), "");
 
     assert(instruction->tmp_ptr != nullptr);
     LLVMTypeRef same_size_int = LLVMIntType(size_in_bits);
@@ -3378,7 +3382,7 @@ static LLVMValueRef gen_valgrind_client_request(CodeGen *g, LLVMValueRef default
     if (!target_has_valgrind_support(g->zig_target)) {
         return default_value;
     }
-    LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->type_ref;
+    LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->llvm_type;
     bool asm_has_side_effects = true;
     bool asm_is_alignstack = false;
     if (g->zig_target->arch == ZigLLVM_x86_64) {
@@ -3445,7 +3449,7 @@ static bool want_valgrind_support(CodeGen *g) {
 
 static void gen_undef_init(CodeGen *g, uint32_t ptr_align_bytes, ZigType *value_type, LLVMValueRef ptr) {
     assert(type_has_bits(value_type));
-    uint64_t size_bytes = LLVMStoreSizeOfType(g->target_data_ref, value_type->type_ref);
+    uint64_t size_bytes = LLVMStoreSizeOfType(g->target_data_ref, get_llvm_type(g, value_type));
     assert(size_bytes > 0);
     assert(ptr_align_bytes > 0);
     // memset uninitialized memory to 0xaa
@@ -3453,14 +3457,14 @@ static void gen_undef_init(CodeGen *g, uint32_t ptr_align_bytes, ZigType *value_
     LLVMValueRef fill_char = LLVMConstInt(LLVMInt8Type(), 0xaa, false);
     LLVMValueRef dest_ptr = LLVMBuildBitCast(g->builder, ptr, ptr_u8, "");
     ZigType *usize = g->builtin_types.entry_usize;
-    LLVMValueRef byte_count = LLVMConstInt(usize->type_ref, size_bytes, false);
+    LLVMValueRef byte_count = LLVMConstInt(usize->llvm_type, size_bytes, false);
     ZigLLVMBuildMemSet(g->builder, dest_ptr, fill_char, byte_count, ptr_align_bytes, false);
     // then tell valgrind that the memory is undefined even though we just memset it
     if (want_valgrind_support(g)) {
         static const uint32_t VG_USERREQ__MAKE_MEM_UNDEFINED = 1296236545;
-        LLVMValueRef zero = LLVMConstInt(usize->type_ref, 0, false);
-        LLVMValueRef req = LLVMConstInt(usize->type_ref, VG_USERREQ__MAKE_MEM_UNDEFINED, false);
-        LLVMValueRef ptr_as_usize = LLVMBuildPtrToInt(g->builder, dest_ptr, usize->type_ref, "");
+        LLVMValueRef zero = LLVMConstInt(usize->llvm_type, 0, false);
+        LLVMValueRef req = LLVMConstInt(usize->llvm_type, VG_USERREQ__MAKE_MEM_UNDEFINED, false);
+        LLVMValueRef ptr_as_usize = LLVMBuildPtrToInt(g->builder, dest_ptr, usize->llvm_type, "");
         gen_valgrind_client_request(g, zero, req, ptr_as_usize, byte_count, zero, zero, zero);
     }
 }
@@ -3515,7 +3519,7 @@ static LLVMValueRef ir_render_elem_ptr(CodeGen *g, IrExecutable *executable, IrI
             array_type = array_type->data.pointer.child_type;
         }
         if (safety_check_on) {
-            LLVMValueRef end = LLVMConstInt(g->builtin_types.entry_usize->type_ref,
+            LLVMValueRef end = LLVMConstInt(g->builtin_types.entry_usize->llvm_type,
                     array_type->data.array.len, false);
             add_bounds_check(g, subscript_value, LLVMIntEQ, nullptr, LLVMIntULT, end);
         }
@@ -3533,18 +3537,18 @@ static LLVMValueRef ir_render_elem_ptr(CodeGen *g, IrExecutable *executable, IrI
                 LLVMTypeRef ptr_u8_type_ref = LLVMPointerType(LLVMInt8Type(), 0);
                 LLVMValueRef u8_array_ptr = LLVMBuildBitCast(g->builder, array_ptr, ptr_u8_type_ref, "");
                 assert(size_in_bits % 8 == 0);
-                LLVMValueRef elem_size_bytes = LLVMConstInt(g->builtin_types.entry_usize->type_ref,
+                LLVMValueRef elem_size_bytes = LLVMConstInt(g->builtin_types.entry_usize->llvm_type,
                         size_in_bits / 8, false);
                 LLVMValueRef byte_offset = LLVMBuildNUWMul(g->builder, subscript_value, elem_size_bytes, "");
                 LLVMValueRef indices[] = {
                     byte_offset
                 };
                 LLVMValueRef elem_byte_ptr = LLVMBuildInBoundsGEP(g->builder, u8_array_ptr, indices, 1, "");
-                return LLVMBuildBitCast(g->builder, elem_byte_ptr, LLVMPointerType(child_type->type_ref, 0), "");
+                return LLVMBuildBitCast(g->builder, elem_byte_ptr, LLVMPointerType(get_llvm_type(g, child_type), 0), "");
             }
         }
         LLVMValueRef indices[] = {
-            LLVMConstNull(g->builtin_types.entry_usize->type_ref),
+            LLVMConstNull(g->builtin_types.entry_usize->llvm_type),
             subscript_value
         };
         return LLVMBuildInBoundsGEP(g->builder, array_ptr, indices, 2, "");
@@ -3773,7 +3777,7 @@ static LLVMValueRef ir_render_union_field_ptr(CodeGen *g, IrExecutable *executab
         return nullptr;
 
     LLVMValueRef union_ptr = ir_llvm_value(g, instruction->union_ptr);
-    LLVMTypeRef field_type_ref = LLVMPointerType(field->type_entry->type_ref, 0);
+    LLVMTypeRef field_type_ref = LLVMPointerType(get_llvm_type(g, field->type_entry), 0);
 
     if (union_type->data.unionation.gen_tag_index == SIZE_MAX) {
         LLVMValueRef union_field_ptr = LLVMBuildStructGEP(g->builder, union_ptr, 0, "");
@@ -3786,7 +3790,7 @@ static LLVMValueRef ir_render_union_field_ptr(CodeGen *g, IrExecutable *executab
         LLVMValueRef tag_value = gen_load_untyped(g, tag_field_ptr, 0, false, "");
 
 
-        LLVMValueRef expected_tag_value = bigint_to_llvm_const(union_type->data.unionation.tag_type->type_ref,
+        LLVMValueRef expected_tag_value = bigint_to_llvm_const(get_llvm_type(g, union_type->data.unionation.tag_type),
                 &field->enum_field->value);
         LLVMBasicBlockRef ok_block = LLVMAppendBasicBlock(g->cur_fn_val, "UnionCheckOk");
         LLVMBasicBlockRef bad_block = LLVMAppendBasicBlock(g->cur_fn_val, "UnionCheckFail");
@@ -3916,7 +3920,7 @@ static LLVMValueRef ir_render_asm(CodeGen *g, IrExecutable *executable, IrInstru
         }
 
         ZigType *const type = ir_input->value.type;
-        LLVMTypeRef type_ref = type->type_ref;
+        LLVMTypeRef type_ref = get_llvm_type(g, type);
         LLVMValueRef value_ref = ir_llvm_value(g, ir_input);
         // Handle integers of non pot bitsize by widening them.
         if (type->id == ZigTypeIdInt) {
@@ -3925,7 +3929,7 @@ static LLVMValueRef ir_render_asm(CodeGen *g, IrExecutable *executable, IrInstru
                 const bool is_signed = type->data.integral.is_signed;
                 const size_t wider_bitsize = bitsize < 8 ? 8 : round_to_next_power_of_2(bitsize);
                 ZigType *const wider_type = get_int_type(g, is_signed, wider_bitsize);
-                type_ref = wider_type->type_ref;
+                type_ref = get_llvm_type(g, wider_type);
                 value_ref = gen_widen_or_shorten(g, false, type, wider_type, value_ref);
             }
         }
@@ -3945,7 +3949,7 @@ static LLVMValueRef ir_render_asm(CodeGen *g, IrExecutable *executable, IrInstru
     if (instruction->return_count == 0) {
         ret_type = LLVMVoidType();
     } else {
-        ret_type = instruction->base.value.type->type_ref;
+        ret_type = get_llvm_type(g, instruction->base.value.type);
     }
     LLVMTypeRef function_type = LLVMFunctionType(ret_type, param_types, (unsigned)input_and_output_count, false);
 
@@ -3964,7 +3968,7 @@ static LLVMValueRef gen_non_null_bit(CodeGen *g, ZigType *maybe_type, LLVMValueR
     } else {
         bool is_scalar = !handle_is_ptr(maybe_type);
         if (is_scalar) {
-            return LLVMBuildICmp(g->builder, LLVMIntNE, maybe_handle, LLVMConstNull(maybe_type->type_ref), "");
+            return LLVMBuildICmp(g->builder, LLVMIntNE, maybe_handle, LLVMConstNull(get_llvm_type(g, maybe_type)), "");
         } else {
             LLVMValueRef maybe_field_ptr = LLVMBuildStructGEP(g->builder, maybe_handle, maybe_null_index, "");
             return gen_load_untyped(g, maybe_field_ptr, 0, false, "");
@@ -3999,7 +4003,7 @@ static LLVMValueRef ir_render_optional_unwrap_ptr(CodeGen *g, IrExecutable *exec
 
         LLVMPositionBuilderAtEnd(g->builder, ok_block);
     }
-    if (child_type->zero_bits) {
+    if (!type_has_bits(child_type)) {
         return nullptr;
     } else {
         bool is_scalar = !handle_is_ptr(maybe_type);
@@ -4052,10 +4056,10 @@ static LLVMValueRef get_int_builtin_fn(CodeGen *g, ZigType *int_type, BuiltinFnI
     char llvm_name[64];
     sprintf(llvm_name, "llvm.%s.i%" PRIu32, fn_name, int_type->data.integral.bit_count);
     LLVMTypeRef param_types[] = {
-        int_type->type_ref,
+        get_llvm_type(g, int_type),
         LLVMInt1Type(),
     };
-    LLVMTypeRef fn_type = LLVMFunctionType(int_type->type_ref, param_types, n_args, false);
+    LLVMTypeRef fn_type = LLVMFunctionType(get_llvm_type(g, int_type), param_types, n_args, false);
     LLVMValueRef fn_val = LLVMAddFunction(g->module, llvm_name, fn_type);
     assert(LLVMGetIntrinsicID(fn_val));
 
@@ -4114,9 +4118,9 @@ static LLVMValueRef ir_render_phi(CodeGen *g, IrExecutable *executable, IrInstru
 
     LLVMTypeRef phi_type;
     if (handle_is_ptr(instruction->base.value.type)) {
-        phi_type = LLVMPointerType(instruction->base.value.type->type_ref, 0);
+        phi_type = LLVMPointerType(get_llvm_type(g,instruction->base.value.type), 0);
     } else {
-        phi_type = instruction->base.value.type->type_ref;
+        phi_type = get_llvm_type(g, instruction->base.value.type);
     }
 
     LLVMValueRef phi = LLVMBuildPhi(g->builder, phi_type, "");
@@ -4160,7 +4164,7 @@ static LLVMValueRef ir_render_err_name(CodeGen *g, IrExecutable *executable, IrI
     }
 
     LLVMValueRef indices[] = {
-        LLVMConstNull(g->builtin_types.entry_usize->type_ref),
+        LLVMConstNull(g->builtin_types.entry_usize->llvm_type),
         err_val,
     };
     return LLVMBuildInBoundsGEP(g->builder, g->err_name_table, indices, 2, "");
@@ -4176,8 +4180,9 @@ static LLVMValueRef get_enum_tag_name_function(CodeGen *g, ZigType *enum_type) {
     ZigType *u8_slice_type = get_slice_type(g, u8_ptr_type);
     ZigType *tag_int_type = enum_type->data.enumeration.tag_int_type;
 
-    LLVMTypeRef fn_type_ref = LLVMFunctionType(LLVMPointerType(u8_slice_type->type_ref, 0),
-            &tag_int_type->type_ref, 1, false);
+    LLVMTypeRef tag_int_llvm_type = get_llvm_type(g, tag_int_type);
+    LLVMTypeRef fn_type_ref = LLVMFunctionType(LLVMPointerType(get_llvm_type(g, u8_slice_type), 0),
+            &tag_int_llvm_type, 1, false);
     
     Buf *fn_name = get_mangled_name(g, buf_sprintf("__zig_tag_name_%s", buf_ptr(&enum_type->name)), false);
     LLVMValueRef fn_val = LLVMAddFunction(g->module, buf_ptr(fn_name), fn_type_ref);
@@ -4209,8 +4214,8 @@ static LLVMValueRef get_enum_tag_name_function(CodeGen *g, ZigType *enum_type) {
 
     ZigType *usize = g->builtin_types.entry_usize;
     LLVMValueRef array_ptr_indices[] = {
-        LLVMConstNull(usize->type_ref),
-        LLVMConstNull(usize->type_ref),
+        LLVMConstNull(usize->llvm_type),
+        LLVMConstNull(usize->llvm_type),
     };
 
     for (size_t field_i = 0; field_i < field_count; field_i += 1) {
@@ -4225,9 +4230,9 @@ static LLVMValueRef get_enum_tag_name_function(CodeGen *g, ZigType *enum_type) {
 
         LLVMValueRef fields[] = {
             LLVMConstGEP(str_global, array_ptr_indices, 2),
-            LLVMConstInt(g->builtin_types.entry_usize->type_ref, buf_len(name), false),
+            LLVMConstInt(g->builtin_types.entry_usize->llvm_type, buf_len(name), false),
         };
-        LLVMValueRef slice_init_value = LLVMConstNamedStruct(u8_slice_type->type_ref, fields, 2);
+        LLVMValueRef slice_init_value = LLVMConstNamedStruct(get_llvm_type(g, u8_slice_type), fields, 2);
 
         LLVMValueRef slice_global = LLVMAddGlobal(g->module, LLVMTypeOf(slice_init_value), "");
         LLVMSetInitializer(slice_global, slice_init_value);
@@ -4237,7 +4242,7 @@ static LLVMValueRef get_enum_tag_name_function(CodeGen *g, ZigType *enum_type) {
         LLVMSetAlignment(slice_global, LLVMABIAlignmentOfType(g->target_data_ref, LLVMTypeOf(slice_init_value)));
 
         LLVMBasicBlockRef return_block = LLVMAppendBasicBlock(g->cur_fn_val, "Name");
-        LLVMValueRef this_tag_int_value = bigint_to_llvm_const(tag_int_type->type_ref,
+        LLVMValueRef this_tag_int_value = bigint_to_llvm_const(get_llvm_type(g, tag_int_type),
                 &enum_type->data.enumeration.fields[field_i].value);
         LLVMAddCase(switch_instr, this_tag_int_value, return_block);
 
@@ -4283,22 +4288,21 @@ static LLVMValueRef ir_render_field_parent_ptr(CodeGen *g, IrExecutable *executa
     ZigType *container_type = container_ptr_type->data.pointer.child_type;
 
     size_t byte_offset = LLVMOffsetOfElement(g->target_data_ref,
-            container_type->type_ref, instruction->field->gen_index);
+            get_llvm_type(g, container_type), instruction->field->gen_index);
 
     LLVMValueRef field_ptr_val = ir_llvm_value(g, instruction->field_ptr);
 
     if (byte_offset == 0) {
-        return LLVMBuildBitCast(g->builder, field_ptr_val, container_ptr_type->type_ref, "");
+        return LLVMBuildBitCast(g->builder, field_ptr_val, get_llvm_type(g, container_ptr_type), "");
     } else {
         ZigType *usize = g->builtin_types.entry_usize;
 
-        LLVMValueRef field_ptr_int = LLVMBuildPtrToInt(g->builder, field_ptr_val,
-                usize->type_ref, "");
+        LLVMValueRef field_ptr_int = LLVMBuildPtrToInt(g->builder, field_ptr_val, usize->llvm_type, "");
 
         LLVMValueRef base_ptr_int = LLVMBuildNUWSub(g->builder, field_ptr_int,
-                LLVMConstInt(usize->type_ref, byte_offset, false), "");
+                LLVMConstInt(usize->llvm_type, byte_offset, false), "");
 
-        return LLVMBuildIntToPtr(g->builder, base_ptr_int, container_ptr_type->type_ref, "");
+        return LLVMBuildIntToPtr(g->builder, base_ptr_int, get_llvm_type(g, container_ptr_type), "");
     }
 }
 
@@ -4349,10 +4353,10 @@ static LLVMValueRef ir_render_align_cast(CodeGen *g, IrExecutable *executable, I
     assert(align_bytes != 1);
 
     ZigType *usize = g->builtin_types.entry_usize;
-    LLVMValueRef ptr_as_int_val = LLVMBuildPtrToInt(g->builder, ptr_val, usize->type_ref, "");
-    LLVMValueRef alignment_minus_1 = LLVMConstInt(usize->type_ref, align_bytes - 1, false);
+    LLVMValueRef ptr_as_int_val = LLVMBuildPtrToInt(g->builder, ptr_val, usize->llvm_type, "");
+    LLVMValueRef alignment_minus_1 = LLVMConstInt(usize->llvm_type, align_bytes - 1, false);
     LLVMValueRef anded_val = LLVMBuildAnd(g->builder, ptr_as_int_val, alignment_minus_1, "");
-    LLVMValueRef ok_bit = LLVMBuildICmp(g->builder, LLVMIntEQ, anded_val, LLVMConstNull(usize->type_ref), "");
+    LLVMValueRef ok_bit = LLVMBuildICmp(g->builder, LLVMIntEQ, anded_val, LLVMConstNull(usize->llvm_type), "");
 
     LLVMBasicBlockRef ok_block = LLVMAppendBasicBlock(g->cur_fn_val, "AlignCastOk");
     LLVMBasicBlockRef fail_block = LLVMAppendBasicBlock(g->cur_fn_val, "AlignCastFail");
@@ -4373,7 +4377,7 @@ static LLVMValueRef ir_render_error_return_trace(CodeGen *g, IrExecutable *execu
     LLVMValueRef cur_err_ret_trace_val = get_cur_err_ret_trace_val(g, instruction->base.scope);
     if (cur_err_ret_trace_val == nullptr) {
         ZigType *ptr_to_stack_trace_type = get_ptr_to_stack_trace_type(g);
-        return LLVMConstNull(ptr_to_stack_trace_type->type_ref);
+        return LLVMConstNull(get_llvm_type(g, ptr_to_stack_trace_type));
     }
     return cur_err_ret_trace_val;
 }
@@ -4439,7 +4443,7 @@ static LLVMValueRef ir_render_cmpxchg(CodeGen *g, IrExecutable *executable, IrIn
     if (!handle_is_ptr(maybe_type)) {
         LLVMValueRef payload_val = LLVMBuildExtractValue(g->builder, result_val, 0, "");
         LLVMValueRef success_bit = LLVMBuildExtractValue(g->builder, result_val, 1, "");
-        return LLVMBuildSelect(g->builder, success_bit, LLVMConstNull(child_type->type_ref), payload_val, "");
+        return LLVMBuildSelect(g->builder, success_bit, LLVMConstNull(get_llvm_type(g, child_type)), payload_val, "");
     }
 
     assert(instruction->tmp_ptr != nullptr);
@@ -4470,10 +4474,10 @@ static LLVMValueRef ir_render_truncate(CodeGen *g, IrExecutable *executable, IrI
         // no-op
         return target_val;
     } if (src_type->data.integral.bit_count == dest_type->data.integral.bit_count) {
-        return LLVMBuildBitCast(g->builder, target_val, dest_type->type_ref, "");
+        return LLVMBuildBitCast(g->builder, target_val, get_llvm_type(g, dest_type), "");
     } else {
         LLVMValueRef target_val = ir_llvm_value(g, instruction->target);
-        return LLVMBuildTrunc(g->builder, target_val, dest_type->type_ref, "");
+        return LLVMBuildTrunc(g->builder, target_val, get_llvm_type(g, dest_type), "");
     }
 }
 
@@ -4539,12 +4543,12 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutable *executable, IrInst
         if (instruction->end) {
             end_val = ir_llvm_value(g, instruction->end);
         } else {
-            end_val = LLVMConstInt(g->builtin_types.entry_usize->type_ref, array_type->data.array.len, false);
+            end_val = LLVMConstInt(g->builtin_types.entry_usize->llvm_type, array_type->data.array.len, false);
         }
         if (want_runtime_safety) {
             add_bounds_check(g, start_val, LLVMIntEQ, nullptr, LLVMIntULE, end_val);
             if (instruction->end) {
-                LLVMValueRef array_end = LLVMConstInt(g->builtin_types.entry_usize->type_ref,
+                LLVMValueRef array_end = LLVMConstInt(g->builtin_types.entry_usize->llvm_type,
                         array_type->data.array.len, false);
                 add_bounds_check(g, end_val, LLVMIntEQ, nullptr, LLVMIntULE, array_end);
             }
@@ -4561,7 +4565,7 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutable *executable, IrInst
 
         LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, tmp_struct_ptr, slice_ptr_index, "");
         LLVMValueRef indices[] = {
-            LLVMConstNull(g->builtin_types.entry_usize->type_ref),
+            LLVMConstNull(g->builtin_types.entry_usize->llvm_type),
             start_val,
         };
         LLVMValueRef slice_start_ptr = LLVMBuildInBoundsGEP(g->builder, array_ptr, indices, 2, "");
@@ -4663,9 +4667,9 @@ static LLVMValueRef ir_render_breakpoint(CodeGen *g, IrExecutable *executable, I
 static LLVMValueRef ir_render_return_address(CodeGen *g, IrExecutable *executable,
         IrInstructionReturnAddress *instruction)
 {
-    LLVMValueRef zero = LLVMConstNull(g->builtin_types.entry_i32->type_ref);
+    LLVMValueRef zero = LLVMConstNull(g->builtin_types.entry_i32->llvm_type);
     LLVMValueRef ptr_val = LLVMBuildCall(g->builder, get_return_address_fn_val(g), &zero, 1, "");
-    return LLVMBuildPtrToInt(g->builder, ptr_val, g->builtin_types.entry_usize->type_ref, "");
+    return LLVMBuildPtrToInt(g->builder, ptr_val, g->builtin_types.entry_usize->llvm_type, "");
 }
 
 static LLVMValueRef get_frame_address_fn_val(CodeGen *g) {
@@ -4674,8 +4678,8 @@ static LLVMValueRef get_frame_address_fn_val(CodeGen *g) {
 
     ZigType *return_type = get_pointer_to_type(g, g->builtin_types.entry_u8, true);
 
-    LLVMTypeRef fn_type = LLVMFunctionType(return_type->type_ref,
-            &g->builtin_types.entry_i32->type_ref, 1, false);
+    LLVMTypeRef fn_type = LLVMFunctionType(get_llvm_type(g, return_type),
+            &g->builtin_types.entry_i32->llvm_type, 1, false);
     g->frame_address_fn_val = LLVMAddFunction(g->module, "llvm.frameaddress", fn_type);
     assert(LLVMGetIntrinsicID(g->frame_address_fn_val));
 
@@ -4685,9 +4689,9 @@ static LLVMValueRef get_frame_address_fn_val(CodeGen *g) {
 static LLVMValueRef ir_render_frame_address(CodeGen *g, IrExecutable *executable,
         IrInstructionFrameAddress *instruction)
 {
-    LLVMValueRef zero = LLVMConstNull(g->builtin_types.entry_i32->type_ref);
+    LLVMValueRef zero = LLVMConstNull(g->builtin_types.entry_i32->llvm_type);
     LLVMValueRef ptr_val = LLVMBuildCall(g->builder, get_frame_address_fn_val(g), &zero, 1, "");
-    return LLVMBuildPtrToInt(g->builder, ptr_val, g->builtin_types.entry_usize->type_ref, "");
+    return LLVMBuildPtrToInt(g->builder, ptr_val, g->builtin_types.entry_usize->llvm_type, "");
 }
 
 static LLVMValueRef get_handle_fn_val(CodeGen *g) {
@@ -4706,7 +4710,7 @@ static LLVMValueRef get_handle_fn_val(CodeGen *g) {
 static LLVMValueRef ir_render_handle(CodeGen *g, IrExecutable *executable,
         IrInstructionHandle *instruction)
 {
-    LLVMValueRef zero = LLVMConstNull(g->builtin_types.entry_promise->type_ref);
+    LLVMValueRef zero = LLVMConstNull(get_llvm_type(g, g->builtin_types.entry_promise));
     return LLVMBuildCall(g->builder, get_handle_fn_val(g), &zero, 0, "");
 }
 
@@ -4786,7 +4790,7 @@ static LLVMValueRef ir_render_test_err(CodeGen *g, IrExecutable *executable, IrI
         err_val = err_union_handle;
     }
 
-    LLVMValueRef zero = LLVMConstNull(g->err_tag_type->type_ref);
+    LLVMValueRef zero = LLVMConstNull(get_llvm_type(g, g->err_tag_type));
     return LLVMBuildICmp(g->builder, LLVMIntNE, err_val, zero, "");
 }
 
@@ -4834,7 +4838,7 @@ static LLVMValueRef ir_render_unwrap_err_payload(CodeGen *g, IrExecutable *execu
         } else {
             err_val = err_union_handle;
         }
-        LLVMValueRef zero = LLVMConstNull(g->err_tag_type->type_ref);
+        LLVMValueRef zero = LLVMConstNull(get_llvm_type(g, g->err_tag_type));
         LLVMValueRef cond_val = LLVMBuildICmp(g->builder, LLVMIntEQ, err_val, zero, "");
         LLVMBasicBlockRef err_block = LLVMAppendBasicBlock(g->cur_fn_val, "UnwrapErrError");
         LLVMBasicBlockRef ok_block = LLVMAppendBasicBlock(g->cur_fn_val, "UnwrapErrOk");
@@ -4860,7 +4864,7 @@ static LLVMValueRef ir_render_maybe_wrap(CodeGen *g, IrExecutable *executable, I
 
     ZigType *child_type = wanted_type->data.maybe.child_type;
 
-    if (child_type->zero_bits) {
+    if (!type_has_bits(child_type)) {
         return LLVMConstInt(LLVMInt1Type(), 1, false);
     }
 
@@ -4913,7 +4917,7 @@ static LLVMValueRef ir_render_err_wrap_payload(CodeGen *g, IrExecutable *executa
         return ir_llvm_value(g, instruction->value);
     }
 
-    LLVMValueRef ok_err_val = LLVMConstNull(g->err_tag_type->type_ref);
+    LLVMValueRef ok_err_val = LLVMConstNull(get_llvm_type(g, g->err_tag_type));
 
     if (!type_has_bits(payload_type))
         return ok_err_val;
@@ -4991,7 +4995,7 @@ static LLVMValueRef ir_render_union_init(CodeGen *g, IrExecutable *executable, I
         LLVMValueRef tag_field_ptr = LLVMBuildStructGEP(g->builder, instruction->tmp_ptr,
                 union_type->data.unionation.gen_tag_index, "");
 
-        LLVMValueRef tag_value = bigint_to_llvm_const(union_type->data.unionation.tag_type->type_ref,
+        LLVMValueRef tag_value = bigint_to_llvm_const(get_llvm_type(g, union_type->data.unionation.tag_type),
                 &type_union_field->enum_field->value);
         gen_store_untyped(g, tag_value, tag_field_ptr, 0, false);
 
@@ -5001,7 +5005,7 @@ static LLVMValueRef ir_render_union_init(CodeGen *g, IrExecutable *executable, I
         uncasted_union_ptr = LLVMBuildStructGEP(g->builder, instruction->tmp_ptr, (unsigned)0, "");
     }
 
-    LLVMValueRef field_ptr = LLVMBuildBitCast(g->builder, uncasted_union_ptr, ptr_type->type_ref, "");
+    LLVMValueRef field_ptr = LLVMBuildBitCast(g->builder, uncasted_union_ptr, get_llvm_type(g, ptr_type), "");
     LLVMValueRef value = ir_llvm_value(g, instruction->init_value);
 
     gen_assign_raw(g, field_ptr, ptr_type, value);
@@ -5023,8 +5027,8 @@ static LLVMValueRef ir_render_container_init_list(CodeGen *g, IrExecutable *exec
     for (size_t i = 0; i < field_count; i += 1) {
         LLVMValueRef elem_val = ir_llvm_value(g, instruction->items[i]);
         LLVMValueRef indices[] = {
-            LLVMConstNull(g->builtin_types.entry_usize->type_ref),
-            LLVMConstInt(g->builtin_types.entry_usize->type_ref, i, false),
+            LLVMConstNull(g->builtin_types.entry_usize->llvm_type),
+            LLVMConstInt(g->builtin_types.entry_usize->llvm_type, i, false),
         };
         LLVMValueRef elem_ptr = LLVMBuildInBoundsGEP(g->builder, tmp_array_ptr, indices, 2, "");
         gen_assign_raw(g, elem_ptr, get_pointer_to_type(g, child_type, false), elem_val);
@@ -5041,7 +5045,7 @@ static LLVMValueRef ir_render_panic(CodeGen *g, IrExecutable *executable, IrInst
 static LLVMValueRef ir_render_coro_id(CodeGen *g, IrExecutable *executable, IrInstructionCoroId *instruction) {
     LLVMValueRef promise_ptr = ir_llvm_value(g, instruction->promise_ptr);
     LLVMValueRef align_val = LLVMConstInt(LLVMInt32Type(), get_coro_frame_align_bytes(g), false);
-    LLVMValueRef null = LLVMConstIntToPtr(LLVMConstNull(g->builtin_types.entry_usize->type_ref),
+    LLVMValueRef null = LLVMConstIntToPtr(LLVMConstNull(g->builtin_types.entry_usize->llvm_type),
             LLVMPointerType(LLVMInt8Type(), 0));
     LLVMValueRef params[] = {
         align_val,
@@ -5140,7 +5144,7 @@ static LLVMValueRef ir_render_coro_promise(CodeGen *g, IrExecutable *executable,
         LLVMConstNull(LLVMInt1Type()),
     };
     LLVMValueRef uncasted_result = LLVMBuildCall(g->builder, get_coro_promise_fn_val(g), params, 3, "");
-    return LLVMBuildBitCast(g->builder, uncasted_result, instruction->base.value.type->type_ref, "");
+    return LLVMBuildBitCast(g->builder, uncasted_result, get_llvm_type(g, instruction->base.value.type), "");
 }
 
 static LLVMValueRef get_coro_alloc_helper_fn_val(CodeGen *g, LLVMTypeRef alloc_fn_type_ref, ZigType *fn_type) {
@@ -5161,8 +5165,8 @@ static LLVMValueRef get_coro_alloc_helper_fn_val(CodeGen *g, LLVMTypeRef alloc_f
         arg_types.append(alloc_fn_arg_types[1]);
     }
     arg_types.append(alloc_fn_arg_types[g->have_err_ret_tracing ? 2 : 1]);
-    arg_types.append(ptr_to_err_code_type->type_ref);
-    arg_types.append(g->builtin_types.entry_usize->type_ref);
+    arg_types.append(get_llvm_type(g, ptr_to_err_code_type));
+    arg_types.append(g->builtin_types.entry_usize->llvm_type);
 
     LLVMTypeRef fn_type_ref = LLVMFunctionType(LLVMPointerType(LLVMInt8Type(), 0),
             arg_types.items, arg_types.length, false);
@@ -5204,7 +5208,7 @@ static LLVMValueRef get_coro_alloc_helper_fn_val(CodeGen *g, LLVMTypeRef alloc_f
     next_arg += 1;
     LLVMValueRef coro_size = LLVMGetParam(fn_val, next_arg);
     next_arg += 1;
-    LLVMValueRef alignment_val = LLVMConstInt(g->builtin_types.entry_u29->type_ref,
+    LLVMValueRef alignment_val = LLVMConstInt(g->builtin_types.entry_u29->llvm_type,
             get_coro_frame_align_bytes(g), false);
 
     ConstExprValue *zero_array = create_const_str_lit(g, buf_create_from_str(""));
@@ -5219,7 +5223,7 @@ static LLVMValueRef get_coro_alloc_helper_fn_val(CodeGen *g, LLVMTypeRef alloc_f
     }
     args.append(allocator_val);
     args.append(undef_slice_zero->global_refs->llvm_global);
-    args.append(LLVMGetUndef(g->builtin_types.entry_u29->type_ref));
+    args.append(LLVMGetUndef(g->builtin_types.entry_u29->llvm_type));
     args.append(coro_size);
     args.append(alignment_val);
     LLVMValueRef call_instruction = ZigLLVMBuildCall(g->builder, realloc_fn_val, args.items, args.length,
@@ -5299,10 +5303,10 @@ static LLVMValueRef ir_render_atomic_rmw(CodeGen *g, IrExecutable *executable,
 
     // it's a pointer but we need to treat it as an int
     LLVMValueRef casted_ptr = LLVMBuildBitCast(g->builder, ptr,
-        LLVMPointerType(g->builtin_types.entry_usize->type_ref, 0), "");
-    LLVMValueRef casted_operand = LLVMBuildPtrToInt(g->builder, operand, g->builtin_types.entry_usize->type_ref, "");
+        LLVMPointerType(g->builtin_types.entry_usize->llvm_type, 0), "");
+    LLVMValueRef casted_operand = LLVMBuildPtrToInt(g->builder, operand, g->builtin_types.entry_usize->llvm_type, "");
     LLVMValueRef uncasted_result = LLVMBuildAtomicRMW(g->builder, op, casted_ptr, casted_operand, ordering, false);
-    return LLVMBuildIntToPtr(g->builder, uncasted_result, operand_type->type_ref, "");
+    return LLVMBuildIntToPtr(g->builder, uncasted_result, get_llvm_type(g, operand_type), "");
 }
 
 static LLVMValueRef ir_render_atomic_load(CodeGen *g, IrExecutable *executable,
@@ -5355,15 +5359,15 @@ static LLVMValueRef ir_render_bswap(CodeGen *g, IrExecutable *executable, IrInst
     ZigType *extended_type = get_int_type(g, int_type->data.integral.is_signed,
             int_type->data.integral.bit_count + 8);
     // aabbcc
-    LLVMValueRef extended = LLVMBuildZExt(g->builder, op, extended_type->type_ref, "");
+    LLVMValueRef extended = LLVMBuildZExt(g->builder, op, get_llvm_type(g, extended_type), "");
     // 00aabbcc
     LLVMValueRef fn_val = get_int_builtin_fn(g, extended_type, BuiltinFnIdBswap);
     LLVMValueRef swapped = LLVMBuildCall(g->builder, fn_val, &extended, 1, "");
     // ccbbaa00
     LLVMValueRef shifted = ZigLLVMBuildLShrExact(g->builder, swapped,
-            LLVMConstInt(extended_type->type_ref, 8, false), "");
+            LLVMConstInt(get_llvm_type(g, extended_type), 8, false), "");
     // 00ccbbaa
-    return LLVMBuildTrunc(g->builder, shifted, int_type->type_ref, "");
+    return LLVMBuildTrunc(g->builder, shifted, get_llvm_type(g, int_type), "");
 }
 
 static LLVMValueRef ir_render_bit_reverse(CodeGen *g, IrExecutable *executable, IrInstructionBitReverse *instruction) {
@@ -5383,7 +5387,7 @@ static LLVMValueRef ir_render_vector_to_array(CodeGen *g, IrExecutable *executab
     assert(instruction->tmp_ptr);
     LLVMValueRef vector = ir_llvm_value(g, instruction->vector);
     LLVMValueRef casted_ptr = LLVMBuildBitCast(g->builder, instruction->tmp_ptr,
-            LLVMPointerType(instruction->vector->value.type->type_ref, 0), "");
+            LLVMPointerType(get_llvm_type(g, instruction->vector->value.type), 0), "");
     gen_store_untyped(g, vector, casted_ptr, 0, false);
     return instruction->tmp_ptr;
 }
@@ -5396,7 +5400,7 @@ static LLVMValueRef ir_render_array_to_vector(CodeGen *g, IrExecutable *executab
     assert(!handle_is_ptr(vector_type));
     LLVMValueRef array_ptr = ir_llvm_value(g, instruction->array);
     LLVMValueRef casted_ptr = LLVMBuildBitCast(g->builder, array_ptr,
-            LLVMPointerType(vector_type->type_ref, 0), "");
+            LLVMPointerType(get_llvm_type(g, vector_type), 0), "");
     return gen_load_untyped(g, casted_ptr, 0, false, "");
 }
 
@@ -5735,15 +5739,15 @@ static LLVMValueRef gen_const_ptr_array_recursive(CodeGen *g, ConstExprValue *ar
     if (el_type == LLVMArrayTypeKind) {
         ZigType *usize = g->builtin_types.entry_usize;
         LLVMValueRef indices[] = {
-            LLVMConstNull(usize->type_ref),
-            LLVMConstInt(usize->type_ref, index, false),
+            LLVMConstNull(usize->llvm_type),
+            LLVMConstInt(usize->llvm_type, index, false),
         };
         return LLVMConstInBoundsGEP(base_ptr, indices, 2);
     } else if (el_type == LLVMStructTypeKind) {
         ZigType *u32 = g->builtin_types.entry_u32;
         LLVMValueRef indices[] = {
-            LLVMConstNull(u32->type_ref),
-            LLVMConstInt(u32->type_ref, index, false),
+            LLVMConstNull(get_llvm_type(g, u32)),
+            LLVMConstInt(get_llvm_type(g, u32), index, false),
         };
         return LLVMConstInBoundsGEP(base_ptr, indices, 2);
     } else {
@@ -5758,8 +5762,8 @@ static LLVMValueRef gen_const_ptr_struct_recursive(CodeGen *g, ConstExprValue *s
 
     ZigType *u32 = g->builtin_types.entry_u32;
     LLVMValueRef indices[] = {
-        LLVMConstNull(u32->type_ref),
-        LLVMConstInt(u32->type_ref, field_index, false),
+        LLVMConstNull(get_llvm_type(g, u32)),
+        LLVMConstInt(get_llvm_type(g, u32), field_index, false),
     };
     return LLVMConstInBoundsGEP(base_ptr, indices, 2);
 }
@@ -5770,8 +5774,8 @@ static LLVMValueRef gen_const_ptr_err_union_code_recursive(CodeGen *g, ConstExpr
 
     ZigType *u32 = g->builtin_types.entry_u32;
     LLVMValueRef indices[] = {
-        LLVMConstNull(u32->type_ref),
-        LLVMConstInt(u32->type_ref, err_union_err_index, false),
+        LLVMConstNull(get_llvm_type(g, u32)),
+        LLVMConstInt(get_llvm_type(g, u32), err_union_err_index, false),
     };
     return LLVMConstInBoundsGEP(base_ptr, indices, 2);
 }
@@ -5782,8 +5786,8 @@ static LLVMValueRef gen_const_ptr_err_union_payload_recursive(CodeGen *g, ConstE
 
     ZigType *u32 = g->builtin_types.entry_u32;
     LLVMValueRef indices[] = {
-        LLVMConstNull(u32->type_ref),
-        LLVMConstInt(u32->type_ref, err_union_payload_index, false),
+        LLVMConstNull(get_llvm_type(g, u32)),
+        LLVMConstInt(get_llvm_type(g, u32), err_union_payload_index, false),
     };
     return LLVMConstInBoundsGEP(base_ptr, indices, 2);
 }
@@ -5794,8 +5798,8 @@ static LLVMValueRef gen_const_ptr_optional_payload_recursive(CodeGen *g, ConstEx
 
     ZigType *u32 = g->builtin_types.entry_u32;
     LLVMValueRef indices[] = {
-        LLVMConstNull(u32->type_ref),
-        LLVMConstInt(u32->type_ref, maybe_child_index, false),
+        LLVMConstNull(get_llvm_type(g, u32)),
+        LLVMConstInt(get_llvm_type(g, u32), maybe_child_index, false),
     };
     return LLVMConstInBoundsGEP(base_ptr, indices, 2);
 }
@@ -5806,8 +5810,8 @@ static LLVMValueRef gen_const_ptr_union_recursive(CodeGen *g, ConstExprValue *un
 
     ZigType *u32 = g->builtin_types.entry_u32;
     LLVMValueRef indices[] = {
-        LLVMConstNull(u32->type_ref),
-        LLVMConstInt(u32->type_ref, 0, false), // TODO test const union with more aligned tag type than payload
+        LLVMConstNull(get_llvm_type(g, u32)),
+        LLVMConstInt(get_llvm_type(g, u32), 0, false), // TODO test const union with more aligned tag type than payload
     };
     return LLVMConstInBoundsGEP(base_ptr, indices, 2);
 }
@@ -5823,7 +5827,7 @@ static LLVMValueRef pack_const_int(CodeGen *g, LLVMTypeRef big_int_type_ref, Con
     }
 
     ZigType *type_entry = const_val->type;
-    assert(!type_entry->zero_bits);
+    assert(type_has_bits(type_entry));
     switch (type_entry->id) {
         case ZigTypeIdInvalid:
         case ZigTypeIdMetaType:
@@ -5866,7 +5870,7 @@ static LLVMValueRef pack_const_int(CodeGen *g, LLVMTypeRef big_int_type_ref, Con
         case ZigTypeIdPromise:
             {
                 LLVMValueRef ptr_val = gen_const_val(g, const_val, "");
-                LLVMValueRef ptr_size_int_val = LLVMConstPtrToInt(ptr_val, g->builtin_types.entry_usize->type_ref);
+                LLVMValueRef ptr_size_int_val = LLVMConstPtrToInt(ptr_val, g->builtin_types.entry_usize->llvm_type);
                 return LLVMConstZExt(ptr_size_int_val, big_int_type_ref);
             }
         case ZigTypeIdArray: {
@@ -5933,8 +5937,8 @@ static LLVMValueRef pack_const_int(CodeGen *g, LLVMTypeRef big_int_type_ref, Con
 
 // We have this because union constants can't be represented by the official union type,
 // and this property bubbles up in whatever aggregate type contains a union constant
-static bool is_llvm_value_unnamed_type(ZigType *type_entry, LLVMValueRef val) {
-    return LLVMTypeOf(val) != type_entry->type_ref;
+static bool is_llvm_value_unnamed_type(CodeGen *g, ZigType *type_entry, LLVMValueRef val) {
+    return LLVMTypeOf(val) != get_llvm_type(g, type_entry);
 }
 
 static LLVMValueRef gen_const_val_ptr(CodeGen *g, ConstExprValue *const_val, const char *name) {
@@ -5948,7 +5952,8 @@ static LLVMValueRef gen_const_val_ptr(CodeGen *g, ConstExprValue *const_val, con
                 ConstExprValue *pointee = const_val->data.x_ptr.data.ref.pointee;
                 render_const_val(g, pointee, "");
                 render_const_val_global(g, pointee, "");
-                const_val->global_refs->llvm_value = LLVMConstBitCast(pointee->global_refs->llvm_global, const_val->type->type_ref);
+                const_val->global_refs->llvm_value = LLVMConstBitCast(pointee->global_refs->llvm_global,
+                        get_llvm_type(g, const_val->type));
                 return const_val->global_refs->llvm_value;
             }
         case ConstPtrSpecialBaseArray:
@@ -5959,13 +5964,13 @@ static LLVMValueRef gen_const_val_ptr(CodeGen *g, ConstExprValue *const_val, con
                 if (!type_has_bits(array_const_val->type)) {
                     // make this a null pointer
                     ZigType *usize = g->builtin_types.entry_usize;
-                    const_val->global_refs->llvm_value = LLVMConstIntToPtr(LLVMConstNull(usize->type_ref),
-                            const_val->type->type_ref);
+                    const_val->global_refs->llvm_value = LLVMConstIntToPtr(LLVMConstNull(usize->llvm_type),
+                            get_llvm_type(g, const_val->type));
                     return const_val->global_refs->llvm_value;
                 }
                 size_t elem_index = const_val->data.x_ptr.data.base_array.elem_index;
                 LLVMValueRef uncasted_ptr_val = gen_const_ptr_array_recursive(g, array_const_val, elem_index);
-                LLVMValueRef ptr_val = LLVMConstBitCast(uncasted_ptr_val, const_val->type->type_ref);
+                LLVMValueRef ptr_val = LLVMConstBitCast(uncasted_ptr_val, get_llvm_type(g, const_val->type));
                 const_val->global_refs->llvm_value = ptr_val;
                 return ptr_val;
             }
@@ -5977,15 +5982,15 @@ static LLVMValueRef gen_const_val_ptr(CodeGen *g, ConstExprValue *const_val, con
                 if (!type_has_bits(struct_const_val->type)) {
                     // make this a null pointer
                     ZigType *usize = g->builtin_types.entry_usize;
-                    const_val->global_refs->llvm_value = LLVMConstIntToPtr(LLVMConstNull(usize->type_ref),
-                            const_val->type->type_ref);
+                    const_val->global_refs->llvm_value = LLVMConstIntToPtr(LLVMConstNull(usize->llvm_type),
+                            get_llvm_type(g, const_val->type));
                     return const_val->global_refs->llvm_value;
                 }
                 size_t src_field_index = const_val->data.x_ptr.data.base_struct.field_index;
                 size_t gen_field_index = struct_const_val->type->data.structure.fields[src_field_index].gen_index;
                 LLVMValueRef uncasted_ptr_val = gen_const_ptr_struct_recursive(g, struct_const_val,
                         gen_field_index);
-                LLVMValueRef ptr_val = LLVMConstBitCast(uncasted_ptr_val, const_val->type->type_ref);
+                LLVMValueRef ptr_val = LLVMConstBitCast(uncasted_ptr_val, get_llvm_type(g, const_val->type));
                 const_val->global_refs->llvm_value = ptr_val;
                 return ptr_val;
             }
@@ -5997,12 +6002,12 @@ static LLVMValueRef gen_const_val_ptr(CodeGen *g, ConstExprValue *const_val, con
                 if (!type_has_bits(err_union_const_val->type)) {
                     // make this a null pointer
                     ZigType *usize = g->builtin_types.entry_usize;
-                    const_val->global_refs->llvm_value = LLVMConstIntToPtr(LLVMConstNull(usize->type_ref),
-                            const_val->type->type_ref);
+                    const_val->global_refs->llvm_value = LLVMConstIntToPtr(LLVMConstNull(usize->llvm_type),
+                            get_llvm_type(g, const_val->type));
                     return const_val->global_refs->llvm_value;
                 }
                 LLVMValueRef uncasted_ptr_val = gen_const_ptr_err_union_code_recursive(g, err_union_const_val);
-                LLVMValueRef ptr_val = LLVMConstBitCast(uncasted_ptr_val, const_val->type->type_ref);
+                LLVMValueRef ptr_val = LLVMConstBitCast(uncasted_ptr_val, get_llvm_type(g, const_val->type));
                 const_val->global_refs->llvm_value = ptr_val;
                 return ptr_val;
             }
@@ -6011,15 +6016,15 @@ static LLVMValueRef gen_const_val_ptr(CodeGen *g, ConstExprValue *const_val, con
                 assert(const_val->global_refs != nullptr);
                 ConstExprValue *err_union_const_val = const_val->data.x_ptr.data.base_err_union_payload.err_union_val;
                 assert(err_union_const_val->type->id == ZigTypeIdErrorUnion);
-                if (err_union_const_val->type->zero_bits) {
+                if (!type_has_bits(err_union_const_val->type)) {
                     // make this a null pointer
                     ZigType *usize = g->builtin_types.entry_usize;
-                    const_val->global_refs->llvm_value = LLVMConstIntToPtr(LLVMConstNull(usize->type_ref),
-                            const_val->type->type_ref);
+                    const_val->global_refs->llvm_value = LLVMConstIntToPtr(LLVMConstNull(usize->llvm_type),
+                            get_llvm_type(g, const_val->type));
                     return const_val->global_refs->llvm_value;
                 }
                 LLVMValueRef uncasted_ptr_val = gen_const_ptr_err_union_payload_recursive(g, err_union_const_val);
-                LLVMValueRef ptr_val = LLVMConstBitCast(uncasted_ptr_val, const_val->type->type_ref);
+                LLVMValueRef ptr_val = LLVMConstBitCast(uncasted_ptr_val, get_llvm_type(g, const_val->type));
                 const_val->global_refs->llvm_value = ptr_val;
                 return ptr_val;
             }
@@ -6028,15 +6033,15 @@ static LLVMValueRef gen_const_val_ptr(CodeGen *g, ConstExprValue *const_val, con
                 assert(const_val->global_refs != nullptr);
                 ConstExprValue *optional_const_val = const_val->data.x_ptr.data.base_optional_payload.optional_val;
                 assert(optional_const_val->type->id == ZigTypeIdOptional);
-                if (optional_const_val->type->zero_bits) {
+                if (!type_has_bits(optional_const_val->type)) {
                     // make this a null pointer
                     ZigType *usize = g->builtin_types.entry_usize;
-                    const_val->global_refs->llvm_value = LLVMConstIntToPtr(LLVMConstNull(usize->type_ref),
-                            const_val->type->type_ref);
+                    const_val->global_refs->llvm_value = LLVMConstIntToPtr(LLVMConstNull(usize->llvm_type),
+                            get_llvm_type(g, const_val->type));
                     return const_val->global_refs->llvm_value;
                 }
                 LLVMValueRef uncasted_ptr_val = gen_const_ptr_optional_payload_recursive(g, optional_const_val);
-                LLVMValueRef ptr_val = LLVMConstBitCast(uncasted_ptr_val, const_val->type->type_ref);
+                LLVMValueRef ptr_val = LLVMConstBitCast(uncasted_ptr_val, get_llvm_type(g, const_val->type));
                 const_val->global_refs->llvm_value = ptr_val;
                 return ptr_val;
             }
@@ -6046,50 +6051,51 @@ static LLVMValueRef gen_const_val_ptr(CodeGen *g, ConstExprValue *const_val, con
                 uint64_t addr_value = const_val->data.x_ptr.data.hard_coded_addr.addr;
                 ZigType *usize = g->builtin_types.entry_usize;
                 const_val->global_refs->llvm_value = LLVMConstIntToPtr(
-                        LLVMConstInt(usize->type_ref, addr_value, false), const_val->type->type_ref);
+                        LLVMConstInt(usize->llvm_type, addr_value, false), get_llvm_type(g, const_val->type));
                 return const_val->global_refs->llvm_value;
             }
         case ConstPtrSpecialFunction:
-            return LLVMConstBitCast(fn_llvm_value(g, const_val->data.x_ptr.data.fn.fn_entry), const_val->type->type_ref);
+            return LLVMConstBitCast(fn_llvm_value(g, const_val->data.x_ptr.data.fn.fn_entry),
+                    get_llvm_type(g, const_val->type));
         case ConstPtrSpecialNull:
-            return LLVMConstNull(const_val->type->type_ref);
+            return LLVMConstNull(get_llvm_type(g, const_val->type));
     }
     zig_unreachable();
 }
 
 static LLVMValueRef gen_const_val_err_set(CodeGen *g, ConstExprValue *const_val, const char *name) {
     uint64_t value = (const_val->data.x_err_set == nullptr) ? 0 : const_val->data.x_err_set->value;
-    return LLVMConstInt(g->builtin_types.entry_global_error_set->type_ref, value, false);
+    return LLVMConstInt(get_llvm_type(g, g->builtin_types.entry_global_error_set), value, false);
 }
 
 static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const char *name) {
     Error err;
 
     ZigType *type_entry = const_val->type;
-    assert(!type_entry->zero_bits);
+    assert(type_has_bits(type_entry));
 
     switch (const_val->special) {
         case ConstValSpecialRuntime:
             zig_unreachable();
         case ConstValSpecialUndef:
-            return LLVMGetUndef(type_entry->type_ref);
+            return LLVMGetUndef(get_llvm_type(g, type_entry));
         case ConstValSpecialStatic:
             break;
     }
 
     switch (type_entry->id) {
         case ZigTypeIdInt:
-            return bigint_to_llvm_const(type_entry->type_ref, &const_val->data.x_bigint);
+            return bigint_to_llvm_const(get_llvm_type(g, type_entry), &const_val->data.x_bigint);
         case ZigTypeIdErrorSet:
             return gen_const_val_err_set(g, const_val, name);
         case ZigTypeIdFloat:
             switch (type_entry->data.floating.bit_count) {
                 case 16:
-                    return LLVMConstReal(type_entry->type_ref, zig_f16_to_double(const_val->data.x_f16));
+                    return LLVMConstReal(get_llvm_type(g, type_entry), zig_f16_to_double(const_val->data.x_f16));
                 case 32:
-                    return LLVMConstReal(type_entry->type_ref, const_val->data.x_f32);
+                    return LLVMConstReal(get_llvm_type(g, type_entry), const_val->data.x_f32);
                 case 64:
-                    return LLVMConstReal(type_entry->type_ref, const_val->data.x_f64);
+                    return LLVMConstReal(get_llvm_type(g, type_entry), const_val->data.x_f64);
                 case 128:
                     {
                         // TODO make sure this is correct on big endian targets too
@@ -6097,7 +6103,7 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                         memcpy(buf, &const_val->data.x_f128, 16);
                         LLVMValueRef as_int = LLVMConstIntOfArbitraryPrecision(LLVMInt128Type(), 2,
                                 (uint64_t*)buf);
-                        return LLVMConstBitCast(as_int, type_entry->type_ref);
+                        return LLVMConstBitCast(as_int, get_llvm_type(g, type_entry));
                     }
                 default:
                     zig_unreachable();
@@ -6125,9 +6131,9 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                         child_val = gen_const_val(g, const_val->data.x_optional, "");
                         maybe_val = LLVMConstAllOnes(LLVMInt1Type());
 
-                        make_unnamed_struct = is_llvm_value_unnamed_type(const_val->type, child_val);
+                        make_unnamed_struct = is_llvm_value_unnamed_type(g, const_val->type, child_val);
                     } else {
-                        child_val = LLVMGetUndef(child_type->type_ref);
+                        child_val = LLVMGetUndef(get_llvm_type(g, child_type));
                         maybe_val = LLVMConstNull(LLVMInt1Type());
 
                         make_unnamed_struct = false;
@@ -6139,7 +6145,7 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                     if (make_unnamed_struct) {
                         return LLVMConstStruct(fields, 2, false);
                     } else {
-                        return LLVMConstNamedStruct(type_entry->type_ref, fields, 2);
+                        return LLVMConstNamedStruct(get_llvm_type(g, type_entry), fields, 2);
                     }
                 }
             }
@@ -6168,10 +6174,10 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                             ConstExprValue *field_val = &const_val->data.x_struct.fields[src_field_index];
                             LLVMValueRef val = gen_const_val(g, field_val, "");
                             fields[type_struct_field->gen_index] = val;
-                            make_unnamed_struct = make_unnamed_struct || is_llvm_value_unnamed_type(field_val->type, val);
+                            make_unnamed_struct = make_unnamed_struct || is_llvm_value_unnamed_type(g, field_val->type, val);
                         } else {
                             bool is_big_endian = g->is_big_endian; // TODO get endianness from struct type
-                            LLVMTypeRef big_int_type_ref = LLVMStructGetTypeAtIndex(type_entry->type_ref,
+                            LLVMTypeRef big_int_type_ref = LLVMStructGetTypeAtIndex(get_llvm_type(g, type_entry),
                                     (unsigned)type_struct_field->gen_index);
                             LLVMValueRef val = LLVMConstInt(big_int_type_ref, 0, false);
                             size_t used_bits = 0;
@@ -6216,14 +6222,14 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
 
                         LLVMValueRef val = gen_const_val(g, field_val, "");
                         fields[type_struct_field->gen_index] = val;
-                        make_unnamed_struct = make_unnamed_struct || is_llvm_value_unnamed_type(field_val->type, val);
+                        make_unnamed_struct = make_unnamed_struct || is_llvm_value_unnamed_type(g, field_val->type, val);
                     }
                 }
                 if (make_unnamed_struct) {
                     return LLVMConstStruct(fields, type_entry->data.structure.gen_field_count,
                         type_entry->data.structure.layout == ContainerLayoutPacked);
                 } else {
-                    return LLVMConstNamedStruct(type_entry->type_ref, fields, type_entry->data.structure.gen_field_count);
+                    return LLVMConstNamedStruct(get_llvm_type(g, type_entry), fields, type_entry->data.structure.gen_field_count);
                 }
             }
         case ZigTypeIdArray:
@@ -6231,16 +6237,16 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                 uint64_t len = type_entry->data.array.len;
                 switch (const_val->data.x_array.special) {
                     case ConstArraySpecialUndef:
-                        return LLVMGetUndef(type_entry->type_ref);
+                        return LLVMGetUndef(get_llvm_type(g, type_entry));
                     case ConstArraySpecialNone: {
                         LLVMValueRef *values = allocate<LLVMValueRef>(len);
-                        LLVMTypeRef element_type_ref = type_entry->data.array.child_type->type_ref;
+                        LLVMTypeRef element_type_ref = get_llvm_type(g, type_entry->data.array.child_type);
                         bool make_unnamed_struct = false;
                         for (uint64_t i = 0; i < len; i += 1) {
                             ConstExprValue *elem_value = &const_val->data.x_array.data.s_none.elements[i];
                             LLVMValueRef val = gen_const_val(g, elem_value, "");
                             values[i] = val;
-                            make_unnamed_struct = make_unnamed_struct || is_llvm_value_unnamed_type(elem_value->type, val);
+                            make_unnamed_struct = make_unnamed_struct || is_llvm_value_unnamed_type(g, elem_value->type, val);
                         }
                         if (make_unnamed_struct) {
                             return LLVMConstStruct(values, len, true);
@@ -6259,7 +6265,7 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
             uint32_t len = type_entry->data.vector.len;
             switch (const_val->data.x_array.special) {
                 case ConstArraySpecialUndef:
-                    return LLVMGetUndef(type_entry->type_ref);
+                    return LLVMGetUndef(get_llvm_type(g, type_entry));
                 case ConstArraySpecialNone: {
                     LLVMValueRef *values = allocate<LLVMValueRef>(len);
                     for (uint64_t i = 0; i < len; i += 1) {
@@ -6273,7 +6279,7 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                     assert(buf_len(buf) == len);
                     LLVMValueRef *values = allocate<LLVMValueRef>(len);
                     for (uint64_t i = 0; i < len; i += 1) {
-                        values[i] = LLVMConstInt(g->builtin_types.entry_u8->type_ref, buf_ptr(buf)[i], false);
+                        values[i] = LLVMConstInt(g->builtin_types.entry_u8->llvm_type, buf_ptr(buf)[i], false);
                     }
                     return LLVMConstVector(values, len);
                 }
@@ -6282,13 +6288,19 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
         }
         case ZigTypeIdUnion:
             {
-                LLVMTypeRef union_type_ref = type_entry->data.unionation.union_type_ref;
+                BREAKPOINT; // TODO rework this logic to take into account the new layout
+
+                // Force type_entry->data.unionation.union_llvm_type to get resolved
+                (void)get_llvm_type(g, type_entry);
+
+                LLVMTypeRef union_type_ref = type_entry->data.unionation.union_llvm_type;
+                assert(union_type_ref != nullptr);
 
                 if (type_entry->data.unionation.gen_field_count == 0) {
                     if (type_entry->data.unionation.tag_type == nullptr) {
                         return nullptr;
                     } else {
-                        return bigint_to_llvm_const(type_entry->data.unionation.tag_type->type_ref,
+                        return bigint_to_llvm_const(get_llvm_type(g, type_entry->data.unionation.tag_type),
                             &const_val->data.x_union.tag);
                     }
                 }
@@ -6298,15 +6310,16 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                 ConstExprValue *payload_value = const_val->data.x_union.payload;
                 if (payload_value == nullptr || !type_has_bits(payload_value->type)) {
                     if (type_entry->data.unionation.gen_tag_index == SIZE_MAX)
-                        return LLVMGetUndef(type_entry->type_ref);
+                        return LLVMGetUndef(get_llvm_type(g, type_entry));
 
                     union_value_ref = LLVMGetUndef(union_type_ref);
                     make_unnamed_struct = false;
                 } else {
-                    uint64_t field_type_bytes = LLVMStoreSizeOfType(g->target_data_ref, payload_value->type->type_ref);
-                    uint64_t pad_bytes = type_entry->data.unionation.union_size_bytes - field_type_bytes;
+                    uint64_t field_type_bytes = LLVMStoreSizeOfType(g->target_data_ref,
+                            get_llvm_type(g, payload_value->type));
+                    uint64_t pad_bytes = type_entry->data.unionation.union_abi_size - field_type_bytes;
                     LLVMValueRef correctly_typed_value = gen_const_val(g, payload_value, "");
-                    make_unnamed_struct = is_llvm_value_unnamed_type(payload_value->type, correctly_typed_value) ||
+                    make_unnamed_struct = is_llvm_value_unnamed_type(g, payload_value->type, correctly_typed_value) ||
                         payload_value->type != type_entry->data.unionation.most_aligned_union_member;
 
                     {
@@ -6329,7 +6342,8 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                     }
                 }
 
-                LLVMValueRef tag_value = bigint_to_llvm_const(type_entry->data.unionation.tag_type->type_ref,
+                LLVMValueRef tag_value = bigint_to_llvm_const(
+                        get_llvm_type(g, type_entry->data.unionation.tag_type),
                         &const_val->data.x_union.tag);
 
                 LLVMValueRef fields[3];
@@ -6341,7 +6355,7 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                     uint64_t last_field_offset = LLVMOffsetOfElement(g->target_data_ref, LLVMTypeOf(result), 1);
                     uint64_t end_offset = last_field_offset +
                         LLVMStoreSizeOfType(g->target_data_ref, LLVMTypeOf(fields[1]));
-                    uint64_t expected_sz = LLVMStoreSizeOfType(g->target_data_ref, type_entry->type_ref);
+                    uint64_t expected_sz = LLVMStoreSizeOfType(g->target_data_ref, get_llvm_type(g, type_entry));
                     unsigned pad_sz = expected_sz - end_offset;
                     if (pad_sz != 0) {
                         fields[2] = LLVMGetUndef(LLVMArrayType(LLVMInt8Type(), pad_sz));
@@ -6351,21 +6365,21 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                     assert(actual_sz == expected_sz);
                     return result;
                 } else {
-                    return LLVMConstNamedStruct(type_entry->type_ref, fields, 2);
+                    return LLVMConstNamedStruct(get_llvm_type(g, type_entry), fields, 2);
                 }
 
             }
 
         case ZigTypeIdEnum:
-            return bigint_to_llvm_const(type_entry->type_ref, &const_val->data.x_enum_tag);
+            return bigint_to_llvm_const(get_llvm_type(g, type_entry), &const_val->data.x_enum_tag);
         case ZigTypeIdFn:
             if (const_val->data.x_ptr.special == ConstPtrSpecialFunction) {
                 assert(const_val->data.x_ptr.mut == ConstPtrMutComptimeConst);
                 return fn_llvm_value(g, const_val->data.x_ptr.data.fn.fn_entry);
             } else if (const_val->data.x_ptr.special == ConstPtrSpecialHardCodedAddr) {
-                LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->type_ref;
+                LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->llvm_type;
                 uint64_t addr = const_val->data.x_ptr.data.hard_coded_addr.addr;
-                return LLVMConstIntToPtr(LLVMConstInt(usize_type_ref, addr, false), type_entry->type_ref);
+                return LLVMConstIntToPtr(LLVMConstInt(usize_type_ref, addr, false), get_llvm_type(g, type_entry));
             } else {
                 zig_unreachable();
             }
@@ -6379,7 +6393,7 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                     assert(type_has_bits(err_set_type));
                     ErrorTableEntry *err_set = const_val->data.x_err_union.error_set->data.x_err_set;
                     uint64_t value = (err_set == nullptr) ? 0 : err_set->value;
-                    return LLVMConstInt(g->err_tag_type->type_ref, value, false);
+                    return LLVMConstInt(get_llvm_type(g, g->err_tag_type), value, false);
                 } else if (!type_has_bits(err_set_type)) {
                     assert(type_has_bits(payload_type));
                     return gen_const_val(g, const_val->data.x_err_union.payload, "");
@@ -6389,17 +6403,17 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                     bool make_unnamed_struct;
                     ErrorTableEntry *err_set = const_val->data.x_err_union.error_set->data.x_err_set;
                     if (err_set != nullptr) {
-                        err_tag_value = LLVMConstInt(g->err_tag_type->type_ref, err_set->value, false);
-                        err_payload_value = LLVMConstNull(payload_type->type_ref);
+                        err_tag_value = LLVMConstInt(get_llvm_type(g, g->err_tag_type), err_set->value, false);
+                        err_payload_value = LLVMConstNull(get_llvm_type(g, payload_type));
                         make_unnamed_struct = false;
                     } else {
-                        err_tag_value = LLVMConstNull(g->err_tag_type->type_ref);
+                        err_tag_value = LLVMConstNull(get_llvm_type(g, g->err_tag_type));
                         ConstExprValue *payload_val = const_val->data.x_err_union.payload;
                         err_payload_value = gen_const_val(g, payload_val, "");
-                        make_unnamed_struct = is_llvm_value_unnamed_type(payload_val->type, err_payload_value);
+                        make_unnamed_struct = is_llvm_value_unnamed_type(g, payload_val->type, err_payload_value);
                     }
                     if (make_unnamed_struct) {
-                        uint64_t payload_off = LLVMOffsetOfElement(g->target_data_ref, type_entry->type_ref, 1);
+                        uint64_t payload_off = LLVMOffsetOfElement(g->target_data_ref, get_llvm_type(g, type_entry), 1);
                         uint64_t err_sz = LLVMStoreSizeOfType(g->target_data_ref, LLVMTypeOf(err_tag_value));
                         unsigned pad_sz = payload_off - err_sz;
                         if (pad_sz == 0) {
@@ -6421,7 +6435,7 @@ static LLVMValueRef gen_const_val(CodeGen *g, ConstExprValue *const_val, const c
                             err_tag_value,
                             err_payload_value,
                         };
-                        return LLVMConstNamedStruct(type_entry->type_ref, fields, 2);
+                        return LLVMConstNamedStruct(get_llvm_type(g, type_entry), fields, 2);
                     }
                 }
             }
@@ -6460,7 +6474,8 @@ static void render_const_val_global(CodeGen *g, ConstExprValue *const_val, const
         const_val->global_refs = allocate<ConstGlobalRefs>(1);
 
     if (!const_val->global_refs->llvm_global) {
-        LLVMTypeRef type_ref = const_val->global_refs->llvm_value ? LLVMTypeOf(const_val->global_refs->llvm_value) : const_val->type->type_ref;
+        LLVMTypeRef type_ref = const_val->global_refs->llvm_value ?
+            LLVMTypeOf(const_val->global_refs->llvm_value) : get_llvm_type(g, const_val->type);
         LLVMValueRef global_value = LLVMAddGlobal(g->module, type_ref, name);
         LLVMSetLinkage(global_value, LLVMInternalLinkage);
         LLVMSetGlobalConstant(global_value, true);
@@ -6486,7 +6501,7 @@ static void generate_error_name_table(CodeGen *g) {
     ZigType *str_type = get_slice_type(g, u8_ptr_type);
 
     LLVMValueRef *values = allocate<LLVMValueRef>(g->errors_by_index.length);
-    values[0] = LLVMGetUndef(str_type->type_ref);
+    values[0] = LLVMGetUndef(get_llvm_type(g, str_type));
     for (size_t i = 1; i < g->errors_by_index.length; i += 1) {
         ErrorTableEntry *err_entry = g->errors_by_index.at(i);
         Buf *name = &err_entry->name;
@@ -6502,13 +6517,13 @@ static void generate_error_name_table(CodeGen *g) {
         LLVMSetAlignment(str_global, LLVMABIAlignmentOfType(g->target_data_ref, LLVMTypeOf(str_init)));
 
         LLVMValueRef fields[] = {
-            LLVMConstBitCast(str_global, u8_ptr_type->type_ref),
-            LLVMConstInt(g->builtin_types.entry_usize->type_ref, buf_len(name), false),
+            LLVMConstBitCast(str_global, get_llvm_type(g, u8_ptr_type)),
+            LLVMConstInt(g->builtin_types.entry_usize->llvm_type, buf_len(name), false),
         };
-        values[i] = LLVMConstNamedStruct(str_type->type_ref, fields, 2);
+        values[i] = LLVMConstNamedStruct(get_llvm_type(g, str_type), fields, 2);
     }
 
-    LLVMValueRef err_name_table_init = LLVMConstArray(str_type->type_ref, values, (unsigned)g->errors_by_index.length);
+    LLVMValueRef err_name_table_init = LLVMConstArray(get_llvm_type(g, str_type), values, (unsigned)g->errors_by_index.length);
 
     g->err_name_table = LLVMAddGlobal(g->module, LLVMTypeOf(err_name_table_init),
             buf_ptr(get_mangled_name(g, buf_create_from_str("__zig_err_name_table"), false)));
@@ -6547,7 +6562,7 @@ static void gen_global_var(CodeGen *g, ZigVar *var, LLVMValueRef init_val,
     ZigLLVMCreateGlobalVariable(g->dbuilder, get_di_scope(g, var->parent_scope), buf_ptr(&var->name),
         buf_ptr(&var->name), import->data.structure.root_struct->di_file,
         (unsigned)(var->decl_node->line + 1),
-        type_entry->di_type, is_local_to_unit);
+        get_llvm_di_type(g, type_entry), is_local_to_unit);
 
     // TODO ^^ make an actual global variable
 }
@@ -6588,28 +6603,6 @@ static LLVMLinkage var_linkage_to_llvm(VarLinkage var_linkage) {
 static void do_code_gen(CodeGen *g) {
     assert(!g->errors.length);
 
-    {
-        // create debug type for error sets
-        assert(g->err_enumerators.length == g->errors_by_index.length);
-        uint64_t tag_debug_size_in_bits = 8*LLVMStoreSizeOfType(g->target_data_ref, g->err_tag_type->type_ref);
-        uint64_t tag_debug_align_in_bits = 8*LLVMABIAlignmentOfType(g->target_data_ref, g->err_tag_type->type_ref);
-        ZigLLVMDIFile *err_set_di_file = nullptr;
-        ZigLLVMDIType *err_set_di_type = ZigLLVMCreateDebugEnumerationType(g->dbuilder,
-                ZigLLVMCompileUnitToScope(g->compile_unit), buf_ptr(&g->builtin_types.entry_global_error_set->name),
-                err_set_di_file, 0,
-                tag_debug_size_in_bits,
-                tag_debug_align_in_bits,
-                g->err_enumerators.items, g->err_enumerators.length,
-                g->err_tag_type->di_type, "");
-        ZigLLVMReplaceTemporary(g->dbuilder, g->builtin_types.entry_global_error_set->di_type, err_set_di_type);
-        g->builtin_types.entry_global_error_set->di_type = err_set_di_type;
-
-        for (size_t i = 0; i < g->error_di_types.length; i += 1) {
-            ZigLLVMDIType **di_type_ptr = g->error_di_types.at(i);
-            *di_type_ptr = err_set_di_type;
-        }
-    }
-
     generate_error_name_table(g);
 
     // Generate module level variables
@@ -6646,7 +6639,7 @@ static void do_code_gen(CodeGen *g) {
                 bits_needed = 8;
             }
             ZigType *var_type = get_int_type(g, const_val->data.x_bigint.is_negative, bits_needed);
-            LLVMValueRef init_val = bigint_to_llvm_const(var_type->type_ref, &const_val->data.x_bigint);
+            LLVMValueRef init_val = bigint_to_llvm_const(get_llvm_type(g, var_type), &const_val->data.x_bigint);
             gen_global_var(g, var, init_val, var_type);
             continue;
         }
@@ -6660,9 +6653,10 @@ static void do_code_gen(CodeGen *g) {
         if (var->linkage == VarLinkageExternal) {
             LLVMValueRef existing_llvm_var = LLVMGetNamedGlobal(g->module, buf_ptr(&var->name));
             if (existing_llvm_var) {
-                global_value = LLVMConstBitCast(existing_llvm_var, LLVMPointerType(var->var_type->type_ref, 0));
+                global_value = LLVMConstBitCast(existing_llvm_var,
+                        LLVMPointerType(get_llvm_type(g, var->var_type), 0));
             } else {
-                global_value = LLVMAddGlobal(g->module, var->var_type->type_ref, buf_ptr(&var->name));
+                global_value = LLVMAddGlobal(g->module, get_llvm_type(g, var->var_type), buf_ptr(&var->name));
                 // TODO debug info for the extern variable
 
                 LLVMSetLinkage(global_value, var_linkage_to_llvm(var->linkage));
@@ -6834,7 +6828,7 @@ static void do_code_gen(CodeGen *g) {
 
                 var->di_loc_var = ZigLLVMCreateAutoVariable(g->dbuilder, get_di_scope(g, var->parent_scope),
                         buf_ptr(&var->name), import->data.structure.root_struct->di_file, (unsigned)(var->decl_node->line + 1),
-                        var->var_type->di_type, !g->strip_debug_symbols, 0);
+                        get_llvm_di_type(g, var->var_type), !g->strip_debug_symbols, 0);
 
             } else if (is_c_abi) {
                 fn_walk_var.data.vars.var = var;
@@ -6859,7 +6853,7 @@ static void do_code_gen(CodeGen *g) {
                     var->di_loc_var = ZigLLVMCreateParameterVariable(g->dbuilder, get_di_scope(g, var->parent_scope),
                             buf_ptr(&var->name), import->data.structure.root_struct->di_file,
                             (unsigned)(var->decl_node->line + 1),
-                            gen_type->di_type, !g->strip_debug_symbols, 0, (unsigned)(var->gen_arg_index + 1));
+                            get_llvm_di_type(g, gen_type), !g->strip_debug_symbols, 0, (unsigned)(var->gen_arg_index + 1));
                 }
 
             }
@@ -6870,7 +6864,7 @@ static void do_code_gen(CodeGen *g) {
             ZigType *usize = g->builtin_types.entry_usize;
             size_t index_field_index = g->stack_trace_type->data.structure.fields[0].gen_index;
             LLVMValueRef index_field_ptr = LLVMBuildStructGEP(g->builder, g->cur_err_ret_trace_val_stack, (unsigned)index_field_index, "");
-            gen_store_untyped(g, LLVMConstNull(usize->type_ref), index_field_ptr, 0, false);
+            gen_store_untyped(g, LLVMConstNull(usize->llvm_type), index_field_ptr, 0, false);
 
             size_t addresses_field_index = g->stack_trace_type->data.structure.fields[1].gen_index;
             LLVMValueRef addresses_field_ptr = LLVMBuildStructGEP(g->builder, g->cur_err_ret_trace_val_stack, (unsigned)addresses_field_index, "");
@@ -6878,7 +6872,7 @@ static void do_code_gen(CodeGen *g) {
             ZigType *slice_type = g->stack_trace_type->data.structure.fields[1].type_entry;
             size_t ptr_field_index = slice_type->data.structure.fields[slice_ptr_index].gen_index;
             LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, addresses_field_ptr, (unsigned)ptr_field_index, "");
-            LLVMValueRef zero = LLVMConstNull(usize->type_ref);
+            LLVMValueRef zero = LLVMConstNull(usize->llvm_type);
             LLVMValueRef indices[] = {zero, zero};
             LLVMValueRef err_ret_array_val_elem0_ptr = LLVMBuildInBoundsGEP(g->builder, err_ret_array_val,
                     indices, 2, "");
@@ -6887,7 +6881,7 @@ static void do_code_gen(CodeGen *g) {
 
             size_t len_field_index = slice_type->data.structure.fields[slice_len_index].gen_index;
             LLVMValueRef len_field_ptr = LLVMBuildStructGEP(g->builder, addresses_field_ptr, (unsigned)len_field_index, "");
-            gen_store(g, LLVMConstInt(usize->type_ref, stack_trace_ptr_count, false), len_field_ptr, get_pointer_to_type(g, usize, false));
+            gen_store(g, LLVMConstInt(usize->llvm_type, stack_trace_ptr_count, false), len_field_ptr, get_pointer_to_type(g, usize, false));
         }
 
         // create debug variable declarations for parameters
@@ -6997,50 +6991,60 @@ static const GlobalLinkageValue global_linkage_values[] = {
     {GlobalLinkageIdLinkOnce, "LinkOnce"},
 };
 
+static void add_fp_entry(CodeGen *g, const char *name, uint32_t bit_count, LLVMTypeRef type_ref,
+        ZigType **field)
+{
+    ZigType *entry = new_type_table_entry(ZigTypeIdFloat);
+    entry->llvm_type = type_ref;
+    entry->size_in_bits = 8*LLVMStoreSizeOfType(g->target_data_ref, entry->llvm_type);
+    entry->abi_size = LLVMABISizeOfType(g->target_data_ref, entry->llvm_type);
+    entry->abi_align = LLVMABIAlignmentOfType(g->target_data_ref, entry->llvm_type);
+    buf_init_from_str(&entry->name, name);
+    entry->data.floating.bit_count = bit_count;
+
+    entry->llvm_di_type = ZigLLVMCreateDebugBasicType(g->dbuilder, buf_ptr(&entry->name),
+            entry->size_in_bits, ZigLLVMEncoding_DW_ATE_float());
+    *field = entry;
+    g->primitive_type_table.put(&entry->name, entry);
+}
+
 static void define_builtin_types(CodeGen *g) {
     {
         // if this type is anywhere in the AST, we should never hit codegen.
         ZigType *entry = new_type_table_entry(ZigTypeIdInvalid);
         buf_init_from_str(&entry->name, "(invalid)");
-        entry->zero_bits = true;
         g->builtin_types.entry_invalid = entry;
     }
     {
         ZigType *entry = new_type_table_entry(ZigTypeIdComptimeFloat);
         buf_init_from_str(&entry->name, "comptime_float");
-        entry->zero_bits = true;
         g->builtin_types.entry_num_lit_float = entry;
         g->primitive_type_table.put(&entry->name, entry);
     }
     {
         ZigType *entry = new_type_table_entry(ZigTypeIdComptimeInt);
         buf_init_from_str(&entry->name, "comptime_int");
-        entry->zero_bits = true;
         g->builtin_types.entry_num_lit_int = entry;
         g->primitive_type_table.put(&entry->name, entry);
     }
     {
         ZigType *entry = new_type_table_entry(ZigTypeIdEnumLiteral);
         buf_init_from_str(&entry->name, "(enum literal)");
-        entry->zero_bits = true;
         g->builtin_types.entry_enum_literal = entry;
     }
     {
         ZigType *entry = new_type_table_entry(ZigTypeIdUndefined);
         buf_init_from_str(&entry->name, "(undefined)");
-        entry->zero_bits = true;
         g->builtin_types.entry_undef = entry;
     }
     {
         ZigType *entry = new_type_table_entry(ZigTypeIdNull);
         buf_init_from_str(&entry->name, "(null)");
-        entry->zero_bits = true;
         g->builtin_types.entry_null = entry;
     }
     {
         ZigType *entry = new_type_table_entry(ZigTypeIdArgTuple);
         buf_init_from_str(&entry->name, "(args)");
-        entry->zero_bits = true;
         g->builtin_types.entry_arg_tuple = entry;
     }
 
@@ -7050,14 +7054,15 @@ static void define_builtin_types(CodeGen *g) {
         bool is_signed = info->is_signed;
 
         ZigType *entry = new_type_table_entry(ZigTypeIdInt);
-        entry->type_ref = LLVMIntType(size_in_bits);
+        entry->llvm_type = LLVMIntType(size_in_bits);
+        entry->size_in_bits = size_in_bits;
+        entry->abi_size = LLVMABISizeOfType(g->target_data_ref, entry->llvm_type);
+        entry->abi_align = LLVMABIAlignmentOfType(g->target_data_ref, entry->llvm_type);
 
         buf_init_from_str(&entry->name, info->name);
 
-        uint64_t debug_size_in_bits = 8*LLVMStoreSizeOfType(g->target_data_ref, entry->type_ref);
-        entry->di_type = ZigLLVMCreateDebugBasicType(g->dbuilder, buf_ptr(&entry->name),
-                debug_size_in_bits,
-                is_signed ? ZigLLVMEncoding_DW_ATE_signed() : ZigLLVMEncoding_DW_ATE_unsigned());
+        entry->llvm_di_type = ZigLLVMCreateDebugBasicType(g->dbuilder, buf_ptr(&entry->name),
+                size_in_bits, is_signed ? ZigLLVMEncoding_DW_ATE_signed() : ZigLLVMEncoding_DW_ATE_unsigned());
         entry->data.integral.is_signed = is_signed;
         entry->data.integral.bit_count = size_in_bits;
         g->primitive_type_table.put(&entry->name, entry);
@@ -7067,12 +7072,13 @@ static void define_builtin_types(CodeGen *g) {
 
     {
         ZigType *entry = new_type_table_entry(ZigTypeIdBool);
-        entry->type_ref = LLVMInt1Type();
+        entry->llvm_type = LLVMInt1Type();
+        entry->size_in_bits = 1;
+        entry->abi_size = LLVMABISizeOfType(g->target_data_ref, entry->llvm_type);
+        entry->abi_align = LLVMABIAlignmentOfType(g->target_data_ref, entry->llvm_type);
         buf_init_from_str(&entry->name, "bool");
-        uint64_t debug_size_in_bits = 8*LLVMStoreSizeOfType(g->target_data_ref, entry->type_ref);
-        entry->di_type = ZigLLVMCreateDebugBasicType(g->dbuilder, buf_ptr(&entry->name),
-                debug_size_in_bits,
-                ZigLLVMEncoding_DW_ATE_boolean());
+        entry->llvm_di_type = ZigLLVMCreateDebugBasicType(g->dbuilder, buf_ptr(&entry->name),
+                entry->size_in_bits, ZigLLVMEncoding_DW_ATE_boolean());
         g->builtin_types.entry_bool = entry;
         g->primitive_type_table.put(&entry->name, entry);
     }
@@ -7081,7 +7087,10 @@ static void define_builtin_types(CodeGen *g) {
         bool is_signed = is_signed_list[sign_i];
 
         ZigType *entry = new_type_table_entry(ZigTypeIdInt);
-        entry->type_ref = LLVMIntType(g->pointer_size_bytes * 8);
+        entry->llvm_type = LLVMIntType(g->pointer_size_bytes * 8);
+        entry->size_in_bits = g->pointer_size_bytes * 8;
+        entry->abi_size = LLVMABISizeOfType(g->target_data_ref, entry->llvm_type);
+        entry->abi_align = LLVMABIAlignmentOfType(g->target_data_ref, entry->llvm_type);
 
         const char u_or_i = is_signed ? 'i' : 'u';
         buf_resize(&entry->name, 0);
@@ -7090,9 +7099,8 @@ static void define_builtin_types(CodeGen *g) {
         entry->data.integral.is_signed = is_signed;
         entry->data.integral.bit_count = g->pointer_size_bytes * 8;
 
-        uint64_t debug_size_in_bits = 8*LLVMStoreSizeOfType(g->target_data_ref, entry->type_ref);
-        entry->di_type = ZigLLVMCreateDebugBasicType(g->dbuilder, buf_ptr(&entry->name),
-                debug_size_in_bits,
+        entry->llvm_di_type = ZigLLVMCreateDebugBasicType(g->dbuilder, buf_ptr(&entry->name),
+                entry->size_in_bits,
                 is_signed ? ZigLLVMEncoding_DW_ATE_signed() : ZigLLVMEncoding_DW_ATE_unsigned());
         g->primitive_type_table.put(&entry->name, entry);
 
@@ -7103,23 +7111,6 @@ static void define_builtin_types(CodeGen *g) {
         }
     }
 
-    auto add_fp_entry = [] (CodeGen *g,
-                            const char *name,
-                            uint32_t bit_count,
-                            LLVMTypeRef type_ref,
-                            ZigType **field) {
-        ZigType *entry = new_type_table_entry(ZigTypeIdFloat);
-        entry->type_ref = type_ref;
-        buf_init_from_str(&entry->name, name);
-        entry->data.floating.bit_count = bit_count;
-
-        uint64_t debug_size_in_bits = 8*LLVMStoreSizeOfType(g->target_data_ref, entry->type_ref);
-        entry->di_type = ZigLLVMCreateDebugBasicType(g->dbuilder, buf_ptr(&entry->name),
-                debug_size_in_bits,
-                ZigLLVMEncoding_DW_ATE_float());
-        *field = entry;
-        g->primitive_type_table.put(&entry->name, entry);
-    };
     add_fp_entry(g, "f16", 16, LLVMHalfType(), &g->builtin_types.entry_f16);
     add_fp_entry(g, "f32", 32, LLVMFloatType(), &g->builtin_types.entry_f32);
     add_fp_entry(g, "f64", 64, LLVMDoubleType(), &g->builtin_types.entry_f64);
@@ -7128,10 +7119,9 @@ static void define_builtin_types(CodeGen *g) {
 
     {
         ZigType *entry = new_type_table_entry(ZigTypeIdVoid);
-        entry->type_ref = LLVMVoidType();
-        entry->zero_bits = true;
+        entry->llvm_type = LLVMVoidType();
         buf_init_from_str(&entry->name, "void");
-        entry->di_type = ZigLLVMCreateDebugBasicType(g->dbuilder, buf_ptr(&entry->name),
+        entry->llvm_di_type = ZigLLVMCreateDebugBasicType(g->dbuilder, buf_ptr(&entry->name),
                 0,
                 ZigLLVMEncoding_DW_ATE_unsigned());
         g->builtin_types.entry_void = entry;
@@ -7139,17 +7129,15 @@ static void define_builtin_types(CodeGen *g) {
     }
     {
         ZigType *entry = new_type_table_entry(ZigTypeIdUnreachable);
-        entry->type_ref = LLVMVoidType();
-        entry->zero_bits = true;
+        entry->llvm_type = LLVMVoidType();
         buf_init_from_str(&entry->name, "noreturn");
-        entry->di_type = g->builtin_types.entry_void->di_type;
+        entry->llvm_di_type = g->builtin_types.entry_void->llvm_di_type;
         g->builtin_types.entry_unreachable = entry;
         g->primitive_type_table.put(&entry->name, entry);
     }
     {
         ZigType *entry = new_type_table_entry(ZigTypeIdMetaType);
         buf_init_from_str(&entry->name, "type");
-        entry->zero_bits = true;
         g->builtin_types.entry_type = entry;
         g->primitive_type_table.put(&entry->name, entry);
     }
@@ -7174,19 +7162,15 @@ static void define_builtin_types(CodeGen *g) {
         buf_init_from_str(&entry->name, "anyerror");
         entry->data.error_set.err_count = UINT32_MAX;
 
-        // TODO allow overriding this type and keep track of max value and emit an
-        // error if there are too many errors declared
+        // TODO https://github.com/ziglang/zig/issues/786
         g->err_tag_type = g->builtin_types.entry_u16;
 
+        entry->size_in_bits = g->err_tag_type->size_in_bits;
+        entry->abi_align = g->err_tag_type->abi_align;
+        entry->abi_size = g->err_tag_type->abi_size;
+
         g->builtin_types.entry_global_error_set = entry;
-        entry->type_ref = g->err_tag_type->type_ref;
 
-        entry->di_type = ZigLLVMCreateReplaceableCompositeType(g->dbuilder,
-            ZigLLVMTag_DW_enumeration_type(), "anyerror",
-            ZigLLVMCompileUnitToScope(g->compile_unit), nullptr, 0);
-
-        // reserve index 0 to indicate no error
-        g->err_enumerators.append(ZigLLVMCreateDebugEnumerator(g->dbuilder, "(none)", 0));
         g->errors_by_index.append(nullptr);
 
         g->primitive_type_table.put(&entry->name, entry);
@@ -7194,6 +7178,9 @@ static void define_builtin_types(CodeGen *g) {
     {
         ZigType *entry = get_promise_type(g, nullptr);
         g->primitive_type_table.put(&entry->name, entry);
+        entry->size_in_bits = g->builtin_types.entry_usize->size_in_bits;
+        entry->abi_align = g->builtin_types.entry_usize->abi_align;
+        entry->abi_size = g->builtin_types.entry_usize->abi_size;
     }
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6737,6 +6737,9 @@ static void do_code_gen(CodeGen *g) {
         if (have_err_ret_trace_stack) {
             ZigType *array_type = get_array_type(g, g->builtin_types.entry_usize, stack_trace_ptr_count);
             err_ret_array_val = build_alloca(g, array_type, "error_return_trace_addresses", get_abi_alignment(g, array_type));
+
+            // populate g->stack_trace_type
+            (void)get_ptr_to_stack_trace_type(g);
             g->cur_err_ret_trace_val_stack = build_alloca(g, g->stack_trace_type, "error_return_trace", get_abi_alignment(g, g->stack_trace_type));
         } else {
             g->cur_err_ret_trace_val_stack = nullptr;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3566,7 +3566,9 @@ static LLVMValueRef ir_render_elem_ptr(CodeGen *g, IrExecutable *executable, IrI
         return LLVMBuildInBoundsGEP(g->builder, array_ptr, indices, 1, "");
     } else if (array_type->id == ZigTypeIdStruct) {
         assert(array_type->data.structure.is_slice);
-        if (!type_has_bits(instruction->base.value.type)) {
+
+        ZigType *ptr_type = instruction->base.value.type;
+        if (!type_has_bits(ptr_type)) {
             if (safety_check_on) {
                 assert(LLVMGetTypeKind(LLVMTypeOf(array_ptr)) == LLVMIntegerTypeKind);
                 add_bounds_check(g, subscript_value, LLVMIntEQ, nullptr, LLVMIntULT, array_ptr);
@@ -5695,6 +5697,7 @@ static void ir_render(CodeGen *g, ZigFn *fn_entry) {
             IrInstruction *instruction = current_block->instruction_list.at(instr_i);
             if (instruction->ref_count == 0 && !ir_has_side_effects(instruction))
                 continue;
+
             instruction->llvm_value = ir_render_instruction(g, executable, instruction);
         }
         current_block->llvm_exit_block = LLVMGetInsertBlock(g->builder);
@@ -6855,9 +6858,9 @@ static void do_code_gen(CodeGen *g) {
                 }
                 if (var->decl_node) {
                     var->di_loc_var = ZigLLVMCreateParameterVariable(g->dbuilder, get_di_scope(g, var->parent_scope),
-                            buf_ptr(&var->name), import->data.structure.root_struct->di_file,
-                            (unsigned)(var->decl_node->line + 1),
-                            get_llvm_di_type(g, gen_type), !g->strip_debug_symbols, 0, (unsigned)(gen_info->gen_index));
+                        buf_ptr(&var->name), import->data.structure.root_struct->di_file,
+                        (unsigned)(var->decl_node->line + 1),
+                        get_llvm_di_type(g, gen_type), !g->strip_debug_symbols, 0, (unsigned)(gen_info->gen_index+1));
                 }
 
             }

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -154,7 +154,6 @@ struct ConstCastBadAllowsZero {
 enum UndefAllowed {
     UndefOk,
     UndefBad,
-    LazyOk,
 };
 
 static IrInstruction *ir_gen_node(IrBuilder *irb, AstNode *node, Scope *scope);
@@ -10257,57 +10256,32 @@ static IrInstruction *ir_get_const_ptr(IrAnalyze *ira, IrInstruction *instructio
     return const_instr;
 }
 
-static Error ir_resolve_const_val(CodeGen *codegen, IrExecutable *exec, AstNode *source_node,
-        ConstExprValue *val, UndefAllowed undef_allowed)
-{
-    Error err;
-    for (;;) {
-        switch (val->special) {
-            case ConstValSpecialStatic:
-                return ErrorNone;
-            case ConstValSpecialRuntime:
-                if (!type_has_bits(val->type))
-                    return ErrorNone;
-
-                exec_add_error_node(codegen, exec, source_node,
-                        buf_sprintf("unable to evaluate constant expression"));
-                return ErrorSemanticAnalyzeFail;
-            case ConstValSpecialUndef:
-                if (undef_allowed == UndefOk)
-                    return ErrorNone;
-
-                exec_add_error_node(codegen, exec, source_node,
-                        buf_sprintf("use of undefined value here causes undefined behavior"));
-                return ErrorSemanticAnalyzeFail;
-            case ConstValSpecialLazy:
-                if (undef_allowed == LazyOk)
-                    return ErrorNone;
-
-                if ((err = ir_resolve_lazy(codegen, source_node, val)))
-                    return err;
-
-                continue;
-        }
-    }
-}
-
 static ConstExprValue *ir_resolve_const(IrAnalyze *ira, IrInstruction *value, UndefAllowed undef_allowed) {
-    Error err;
-    if ((err = ir_resolve_const_val(ira->codegen, ira->new_irb.exec, value->source_node,
-                    &value->value, undef_allowed)))
-    {
-        return nullptr;
+    switch (value->value.special) {
+        case ConstValSpecialStatic:
+            return &value->value;
+        case ConstValSpecialRuntime:
+            if (!type_has_bits(value->value.type)) {
+                return &value->value;
+            }
+            ir_add_error(ira, value, buf_sprintf("unable to evaluate constant expression"));
+            return nullptr;
+        case ConstValSpecialUndef:
+            if (undef_allowed == UndefOk) {
+                return &value->value;
+            } else {
+                ir_add_error(ira, value, buf_sprintf("use of undefined value here causes undefined behavior"));
+                return nullptr;
+            }
     }
-    return &value->value;
+    zig_unreachable();
 }
 
 ConstExprValue *ir_eval_const_value(CodeGen *codegen, Scope *scope, AstNode *node,
         ZigType *expected_type, size_t *backward_branch_count, size_t backward_branch_quota,
         ZigFn *fn_entry, Buf *c_import_buf, AstNode *source_node, Buf *exec_name,
-        IrExecutable *parent_exec, AstNode *expected_type_source_node, bool allow_lazy)
+        IrExecutable *parent_exec, AstNode *expected_type_source_node)
 {
-    Error err;
-
     if (expected_type != nullptr && type_is_invalid(expected_type))
         return &codegen->invalid_instruction->value;
 
@@ -10352,24 +10326,7 @@ ConstExprValue *ir_eval_const_value(CodeGen *codegen, Scope *scope, AstNode *nod
         fprintf(stderr, "}\n");
     }
 
-    ConstExprValue *result = ir_exec_const_result(codegen, analyzed_executable);
-
-    if (!allow_lazy) {
-        if ((err = ir_resolve_lazy(codegen, node, result)))
-            return &codegen->invalid_instruction->value;
-    }
-    return result;
-}
-
-static ZigType *ir_resolve_const_type(CodeGen *codegen, IrExecutable *exec, AstNode *source_node,
-        ConstExprValue *val)
-{
-    Error err;
-    if ((err = ir_resolve_const_val(codegen, exec, source_node, val, UndefBad)))
-        return codegen->builtin_types.entry_invalid;
-
-    assert(val->data.x_type != nullptr);
-    return val->data.x_type;
+    return ir_exec_const_result(codegen, analyzed_executable);
 }
 
 static ZigType *ir_resolve_type(IrAnalyze *ira, IrInstruction *type_value) {
@@ -10382,7 +10339,12 @@ static ZigType *ir_resolve_type(IrAnalyze *ira, IrInstruction *type_value) {
         return ira->codegen->builtin_types.entry_invalid;
     }
 
-    return ir_resolve_const_type(ira->codegen, ira->new_irb.exec, type_value->source_node, &type_value->value);
+    ConstExprValue *const_val = ir_resolve_const(ira, type_value, UndefBad);
+    if (!const_val)
+        return ira->codegen->builtin_types.entry_invalid;
+
+    assert(const_val->data.x_type != nullptr);
+    return const_val->data.x_type;
 }
 
 static ZigType *ir_resolve_error_set_type(IrAnalyze *ira, IrInstruction *op_source, IrInstruction *type_value) {
@@ -11873,27 +11835,6 @@ static IrInstruction *ir_get_deref(IrAnalyze *ira, IrInstruction *source_instruc
     }
 }
 
-static bool ir_resolve_const_align(CodeGen *codegen, IrExecutable *exec, AstNode *source_node,
-        ConstExprValue *const_val, uint32_t *out)
-{
-    Error err;
-    if ((err = ir_resolve_const_val(codegen, exec, source_node, const_val, UndefBad)))
-        return false;
-
-    uint32_t align_bytes = bigint_as_unsigned(&const_val->data.x_bigint);
-    if (align_bytes == 0) {
-        exec_add_error_node(codegen, exec, source_node, buf_sprintf("alignment must be >= 1"));
-        return false;
-    }
-
-    if (!is_power_of_2(align_bytes)) {
-        exec_add_error_node(codegen, exec, source_node, buf_sprintf("alignment value %" PRIu32 " is not a power of 2", align_bytes));
-        return false;
-    }
-    *out = align_bytes;
-    return true;
-}
-
 static bool ir_resolve_align(IrAnalyze *ira, IrInstruction *value, uint32_t *out) {
     if (type_is_invalid(value->value.type))
         return false;
@@ -11902,7 +11843,23 @@ static bool ir_resolve_align(IrAnalyze *ira, IrInstruction *value, uint32_t *out
     if (type_is_invalid(casted_value->value.type))
         return false;
 
-    return ir_resolve_const_align(ira->codegen, ira->new_irb.exec, value->source_node, &casted_value->value, out);
+    ConstExprValue *const_val = ir_resolve_const(ira, casted_value, UndefBad);
+    if (!const_val)
+        return false;
+
+    uint32_t align_bytes = bigint_as_unsigned(&const_val->data.x_bigint);
+    if (align_bytes == 0) {
+        ir_add_error(ira, value, buf_sprintf("alignment must be >= 1"));
+        return false;
+    }
+
+    if (!is_power_of_2(align_bytes)) {
+        ir_add_error(ira, value, buf_sprintf("alignment value %" PRIu32 " is not a power of 2", align_bytes));
+        return false;
+    }
+
+    *out = align_bytes;
+    return true;
 }
 
 static bool ir_resolve_unsigned(IrAnalyze *ira, IrInstruction *value, ZigType *int_type, uint64_t *out) {
@@ -12070,140 +12027,6 @@ static Buf *ir_resolve_str(IrAnalyze *ira, IrInstruction *value) {
         buf_ptr(result)[i] = c;
     }
     return result;
-}
-
-static ZigType *ir_resolve_lazy_fn_type(CodeGen *codegen, IrExecutable *exec, AstNode *source_node,
-        LazyValueFnType *lazy_fn_type)
-{
-    AstNode *proto_node = lazy_fn_type->proto_node;
-
-    FnTypeId fn_type_id = {0};
-    init_fn_type_id(&fn_type_id, proto_node, proto_node->data.fn_proto.params.length);
-
-    for (; fn_type_id.next_param_index < fn_type_id.param_count; fn_type_id.next_param_index += 1) {
-        AstNode *param_node = proto_node->data.fn_proto.params.at(fn_type_id.next_param_index);
-        assert(param_node->type == NodeTypeParamDecl);
-
-        bool param_is_var_args = param_node->data.param_decl.is_var_args;
-        if (param_is_var_args) {
-            if (fn_type_id.cc == CallingConventionC) {
-                fn_type_id.param_count = fn_type_id.next_param_index;
-                continue;
-            } else if (fn_type_id.cc == CallingConventionUnspecified) {
-                return get_generic_fn_type(codegen, &fn_type_id);
-            } else {
-                zig_unreachable();
-            }
-        }
-        FnTypeParamInfo *param_info = &fn_type_id.param_info[fn_type_id.next_param_index];
-        param_info->is_noalias = param_node->data.param_decl.is_noalias;
-
-        if (lazy_fn_type->param_types[fn_type_id.next_param_index] == nullptr) {
-            param_info->type = nullptr;
-            return get_generic_fn_type(codegen, &fn_type_id);
-        } else {
-            ZigType *param_type = ir_resolve_const_type(codegen, exec, source_node,
-                    lazy_fn_type->param_types[fn_type_id.next_param_index]);
-            if (type_is_invalid(param_type))
-                return nullptr;
-            switch (type_requires_comptime(codegen, param_type)) {
-            case ReqCompTimeYes:
-                if (!calling_convention_allows_zig_types(fn_type_id.cc)) {
-                    exec_add_error_node(codegen, exec, source_node,
-                        buf_sprintf("parameter of type '%s' not allowed in function with calling convention '%s'",
-                            buf_ptr(&param_type->name), calling_convention_name(fn_type_id.cc)));
-                    return nullptr;
-                }
-                param_info->type = param_type;
-                fn_type_id.next_param_index += 1;
-                return get_generic_fn_type(codegen, &fn_type_id);
-            case ReqCompTimeInvalid:
-                return nullptr;
-            case ReqCompTimeNo:
-                break;
-            }
-            if (!type_has_bits(param_type) && !calling_convention_allows_zig_types(fn_type_id.cc)) {
-                exec_add_error_node(codegen, exec, source_node,
-                    buf_sprintf("parameter of type '%s' has 0 bits; not allowed in function with calling convention '%s'",
-                        buf_ptr(&param_type->name), calling_convention_name(fn_type_id.cc)));
-                return nullptr;
-            }
-            param_info->type = param_type;
-        }
-
-    }
-
-    if (lazy_fn_type->align_val != nullptr) {
-        if (!ir_resolve_const_align(codegen, exec, source_node, lazy_fn_type->align_val, &fn_type_id.alignment))
-            return nullptr;
-    }
-
-    fn_type_id.return_type = ir_resolve_const_type(codegen, exec, source_node, lazy_fn_type->return_type);
-    if (type_is_invalid(fn_type_id.return_type))
-        return nullptr;
-    if (fn_type_id.return_type->id == ZigTypeIdOpaque) {
-        exec_add_error_node(codegen, exec, source_node,
-            buf_sprintf("return type cannot be opaque"));
-        return nullptr;
-    }
-
-    if (lazy_fn_type->async_allocator_type != nullptr) {
-        fn_type_id.async_allocator_type = ir_resolve_const_type(codegen, exec, source_node,
-                lazy_fn_type->async_allocator_type);
-        if (type_is_invalid(fn_type_id.async_allocator_type))
-            return nullptr;
-    }
-
-    return get_fn_type(codegen, &fn_type_id);
-}
-
-Error ir_resolve_lazy(CodeGen *codegen, AstNode *source_node, ConstExprValue *val) {
-    Error err;
-    if (val->special != ConstValSpecialLazy)
-        return ErrorNone;
-    IrExecutable *exec = val->data.x_lazy->exec;
-    switch (val->data.x_lazy->id) {
-        case LazyValueIdInvalid:
-            zig_unreachable();
-        case LazyValueIdAlignOf: {
-            LazyValueAlignOf *lazy_align_of = reinterpret_cast<LazyValueAlignOf *>(val->data.x_lazy);
-            if ((err = type_resolve(codegen, lazy_align_of->target_type, ResolveStatusAlignmentKnown)))
-                return err;
-            uint64_t align_in_bytes = get_abi_alignment(codegen, lazy_align_of->target_type);
-            val->special = ConstValSpecialStatic;
-            assert(val->type->id == ZigTypeIdComptimeInt);
-            bigint_init_unsigned(&val->data.x_bigint, align_in_bytes);
-            return ErrorNone;
-        }
-        case LazyValueIdSliceType: {
-            LazyValueSliceType *lazy_slice_type = reinterpret_cast<LazyValueSliceType *>(val->data.x_lazy);
-            uint32_t align_bytes = 0;
-            if (lazy_slice_type->align_val != nullptr) {
-                if (!ir_resolve_const_align(codegen, exec, source_node, lazy_slice_type->align_val, &align_bytes))
-                    return ErrorSemanticAnalyzeFail;
-            }
-            if ((err = type_resolve(codegen, lazy_slice_type->elem_type, ResolveStatusZeroBitsKnown)))
-                return err;
-            ZigType *slice_ptr_type = get_pointer_to_type_extra(codegen, lazy_slice_type->elem_type,
-                    lazy_slice_type->is_const, lazy_slice_type->is_volatile, PtrLenUnknown, align_bytes,
-                    0, 0, lazy_slice_type->is_allowzero);
-            val->special = ConstValSpecialStatic;
-            assert(val->type->id == ZigTypeIdMetaType);
-            val->data.x_type = get_slice_type(codegen, slice_ptr_type);
-            return ErrorNone;
-        }
-        case LazyValueIdFnType: {
-            ZigType *fn_type = ir_resolve_lazy_fn_type(codegen, exec, source_node,
-                    reinterpret_cast<LazyValueFnType *>(val->data.x_lazy));
-            if (fn_type == nullptr)
-                return ErrorSemanticAnalyzeFail;
-            val->special = ConstValSpecialStatic;
-            assert(val->type->id == ZigTypeIdMetaType);
-            val->data.x_type = fn_type;
-            return ErrorNone;
-        }
-    }
-    zig_unreachable();
 }
 
 static IrInstruction *ir_analyze_instruction_add_implicit_return_type(IrAnalyze *ira,
@@ -14179,7 +14002,7 @@ static IrInstruction *ir_get_var_ptr(IrAnalyze *ira, IrInstruction *instruction,
     if (linkage_makes_it_runtime)
         goto no_mem_slot;
 
-    if (value_is_comptime(var->const_value)) {
+    if (var->const_value->special == ConstValSpecialStatic) {
         mem_slot = var->const_value;
     } else {
         if (var->mem_slot_index != SIZE_MAX && (comptime_var_mem || var->gen_is_const)) {
@@ -14197,7 +14020,6 @@ static IrInstruction *ir_get_var_ptr(IrAnalyze *ira, IrInstruction *instruction,
             case ConstValSpecialRuntime:
                 goto no_mem_slot;
             case ConstValSpecialStatic: // fallthrough
-            case ConstValSpecialLazy: // fallthrough
             case ConstValSpecialUndef: {
                 ConstPtrMut ptr_mut;
                 if (comptime_var_mem) {
@@ -14478,7 +14300,7 @@ static IrInstruction *ir_analyze_fn_call(IrAnalyze *ira, IrInstructionCall *call
             AstNode *body_node = fn_entry->body_node;
             result = ir_eval_const_value(ira->codegen, exec_scope, body_node, return_type,
                 ira->new_irb.exec->backward_branch_count, ira->new_irb.exec->backward_branch_quota, fn_entry,
-                nullptr, call_instruction->base.source_node, nullptr, ira->new_irb.exec, return_type_node, false);
+                nullptr, call_instruction->base.source_node, nullptr, ira->new_irb.exec, return_type_node);
 
             if (inferred_err_set_type != nullptr) {
                 inferred_err_set_type->data.error_set.infer_fn = nullptr;
@@ -14674,8 +14496,7 @@ static IrInstruction *ir_analyze_fn_call(IrAnalyze *ira, IrInstructionCall *call
             ConstExprValue *align_result = ir_eval_const_value(ira->codegen, impl_fn->child_scope,
                     fn_proto_node->data.fn_proto.align_expr, get_align_amt_type(ira->codegen),
                     ira->new_irb.exec->backward_branch_count, ira->new_irb.exec->backward_branch_quota,
-                    nullptr, nullptr, fn_proto_node->data.fn_proto.align_expr, nullptr, ira->new_irb.exec, nullptr,
-                    false);
+                    nullptr, nullptr, fn_proto_node->data.fn_proto.align_expr, nullptr, ira->new_irb.exec, nullptr);
             IrInstructionConst *const_instruction = ir_create_instruction<IrInstructionConst>(&ira->new_irb,
                     impl_fn->child_scope, fn_proto_node->data.fn_proto.align_expr);
             const_instruction->base.value = *align_result;
@@ -15808,7 +15629,7 @@ static IrInstruction *ir_analyze_container_member_access_inner(IrAnalyze *ira,
         auto entry = container_scope->decl_table.maybe_get(field_name);
         Tld *tld = entry ? entry->value : nullptr;
         if (tld && tld->id == TldIdFn) {
-            resolve_top_level_decl(ira->codegen, tld, source_instr->source_node, false);
+            resolve_top_level_decl(ira->codegen, tld, source_instr->source_node);
             if (tld->resolution == TldResolutionInvalid)
                 return ira->codegen->invalid_instruction;
             TldFn *tld_fn = (TldFn *)tld;
@@ -15999,7 +15820,7 @@ static void add_link_lib_symbol(IrAnalyze *ira, Buf *lib_name, Buf *symbol_name,
 
 
 static IrInstruction *ir_analyze_decl_ref(IrAnalyze *ira, IrInstruction *source_instruction, Tld *tld) {
-    resolve_top_level_decl(ira->codegen, tld, source_instruction->source_node, false);
+    resolve_top_level_decl(ira->codegen, tld, source_instruction->source_node);
     if (tld->resolution == TldResolutionInvalid)
         return ira->codegen->invalid_instruction;
 
@@ -16655,29 +16476,22 @@ static IrInstruction *ir_analyze_instruction_set_float_mode(IrAnalyze *ira,
 static IrInstruction *ir_analyze_instruction_slice_type(IrAnalyze *ira,
         IrInstructionSliceType *slice_type_instruction)
 {
-    IrInstruction *result = ir_const(ira, &slice_type_instruction->base, ira->codegen->builtin_types.entry_type);
-    result->value.special = ConstValSpecialLazy;
-
-    LazyValueSliceType *lazy_slice_type = allocate<LazyValueSliceType>(1);
-    result->value.data.x_lazy = &lazy_slice_type->base;
-    lazy_slice_type->base.id = LazyValueIdSliceType;
-    lazy_slice_type->base.exec = ira->new_irb.exec;
-
+    Error err;
+    uint32_t align_bytes = 0;
     if (slice_type_instruction->align_value != nullptr) {
-        lazy_slice_type->align_val = ir_resolve_const(ira, slice_type_instruction->align_value->child, LazyOk);
-        if (lazy_slice_type->align_val == nullptr)
+        if (!ir_resolve_align(ira, slice_type_instruction->align_value->child, &align_bytes))
             return ira->codegen->invalid_instruction;
     }
 
-    lazy_slice_type->elem_type = ir_resolve_type(ira, slice_type_instruction->child_type->child);
-    if (type_is_invalid(lazy_slice_type->elem_type))
+    ZigType *child_type = ir_resolve_type(ira, slice_type_instruction->child_type->child);
+    if (type_is_invalid(child_type))
         return ira->codegen->invalid_instruction;
 
-    lazy_slice_type->is_const = slice_type_instruction->is_const;
-    lazy_slice_type->is_volatile = slice_type_instruction->is_volatile;
-    lazy_slice_type->is_allowzero = slice_type_instruction->is_allow_zero;
+    bool is_const = slice_type_instruction->is_const;
+    bool is_volatile = slice_type_instruction->is_volatile;
+    bool is_allow_zero = slice_type_instruction->is_allow_zero;
 
-    switch (lazy_slice_type->elem_type->id) {
+    switch (child_type->id) {
         case ZigTypeIdInvalid: // handled above
             zig_unreachable();
         case ZigTypeIdUnreachable:
@@ -16686,7 +16500,7 @@ static IrInstruction *ir_analyze_instruction_slice_type(IrAnalyze *ira,
         case ZigTypeIdArgTuple:
         case ZigTypeIdOpaque:
             ir_add_error_node(ira, slice_type_instruction->base.source_node,
-                    buf_sprintf("slice of type '%s' not allowed", buf_ptr(&lazy_slice_type->elem_type->name)));
+                    buf_sprintf("slice of type '%s' not allowed", buf_ptr(&child_type->name)));
             return ira->codegen->invalid_instruction;
         case ZigTypeIdMetaType:
         case ZigTypeIdVoid:
@@ -16708,7 +16522,14 @@ static IrInstruction *ir_analyze_instruction_slice_type(IrAnalyze *ira,
         case ZigTypeIdBoundFn:
         case ZigTypeIdPromise:
         case ZigTypeIdVector:
-            return result;
+            {
+                if ((err = type_resolve(ira->codegen, child_type, ResolveStatusZeroBitsKnown)))
+                    return ira->codegen->invalid_instruction;
+                ZigType *slice_ptr_type = get_pointer_to_type_extra(ira->codegen, child_type,
+                        is_const, is_volatile, PtrLenUnknown, align_bytes, 0, 0, is_allow_zero);
+                ZigType *result_type = get_slice_type(ira->codegen, slice_ptr_type);
+                return ir_const_type(ira, &slice_type_instruction->base, result_type);
+            }
     }
     zig_unreachable();
 }
@@ -16815,7 +16636,7 @@ static IrInstruction *ir_analyze_instruction_array_type(IrAnalyze *ira,
         case ZigTypeIdPromise:
         case ZigTypeIdVector:
             {
-                if ((err = type_resolve(ira->codegen, child_type, ResolveStatusSizeKnown)))
+                if ((err = ensure_complete_type(ira->codegen, child_type)))
                     return ira->codegen->invalid_instruction;
                 ZigType *result_type = get_array_type(ira->codegen, child_type, size);
                 return ir_const_type(ira, &array_type_instruction->base, result_type);
@@ -18172,7 +17993,7 @@ static Error ir_make_type_info_defs(IrAnalyze *ira, IrInstruction *source_instr,
     while ((curr_entry = decl_it.next()) != nullptr) {
         // If the definition is unresolved, force it to be resolved again.
         if (curr_entry->value->resolution == TldResolutionUnresolved) {
-            resolve_top_level_decl(ira->codegen, curr_entry->value, curr_entry->value->source_node, false);
+            resolve_top_level_decl(ira->codegen, curr_entry->value, curr_entry->value->source_node);
             if (curr_entry->value->resolution != TldResolutionOk) {
                 return ErrorSemanticAnalyzeFail;
             }
@@ -19161,7 +18982,7 @@ static IrInstruction *ir_analyze_instruction_c_import(IrAnalyze *ira, IrInstruct
     ZigType *void_type = ira->codegen->builtin_types.entry_void;
     ConstExprValue *cimport_result = ir_eval_const_value(ira->codegen, &cimport_scope->base, block_node, void_type,
         ira->new_irb.exec->backward_branch_count, ira->new_irb.exec->backward_branch_quota, nullptr,
-        &cimport_scope->buf, block_node, nullptr, nullptr, nullptr, false);
+        &cimport_scope->buf, block_node, nullptr, nullptr, nullptr);
     if (type_is_invalid(cimport_result->type))
         return ira->codegen->invalid_instruction;
 
@@ -20708,10 +20529,14 @@ static IrInstruction *ir_analyze_instruction_handle(IrAnalyze *ira, IrInstructio
 }
 
 static IrInstruction *ir_analyze_instruction_align_of(IrAnalyze *ira, IrInstructionAlignOf *instruction) {
+    Error err;
     IrInstruction *type_value = instruction->type_value->child;
     if (type_is_invalid(type_value->value.type))
         return ira->codegen->invalid_instruction;
     ZigType *type_entry = ir_resolve_type(ira, type_value);
+
+    if ((err = type_resolve(ira->codegen, type_entry, ResolveStatusAlignmentKnown)))
+        return ira->codegen->invalid_instruction;
 
     switch (type_entry->id) {
         case ZigTypeIdInvalid:
@@ -20744,25 +20569,12 @@ static IrInstruction *ir_analyze_instruction_align_of(IrAnalyze *ira, IrInstruct
         case ZigTypeIdUnion:
         case ZigTypeIdFn:
         case ZigTypeIdVector:
-            break;
+            {
+                uint64_t align_in_bytes = get_abi_alignment(ira->codegen, type_entry);
+                return ir_const_unsigned(ira, &instruction->base, align_in_bytes);
+            }
     }
-    if (type_is_resolved(type_entry, ResolveStatusAlignmentKnown)) {
-        uint64_t align_in_bytes = get_abi_alignment(ira->codegen, type_entry);
-        return ir_const_unsigned(ira, &instruction->base, align_in_bytes);
-    }
-    // Here we create a lazy value in order to avoid resolving the alignment of the type
-    // immediately. This avoids false positive dependency loops such as:
-    // const Node = struct {
-    //     field: []align(@alignOf(Node)) Node,
-    // };
-    LazyValueAlignOf *lazy_align_of = allocate<LazyValueAlignOf>(1);
-    lazy_align_of->base.id = LazyValueIdAlignOf;
-    lazy_align_of->base.exec = ira->new_irb.exec;
-    lazy_align_of->target_type = type_entry;
-    IrInstruction *result = ir_const(ira, &instruction->base, ira->codegen->builtin_types.entry_num_lit_int);
-    result->value.special = ConstValSpecialLazy;
-    result->value.data.x_lazy = &lazy_align_of->base;
-    return result;
+    zig_unreachable();
 }
 
 static IrInstruction *ir_analyze_instruction_overflow_op(IrAnalyze *ira, IrInstructionOverflowOp *instruction) {
@@ -21017,77 +20829,96 @@ static IrInstruction *ir_analyze_instruction_fn_proto(IrAnalyze *ira, IrInstruct
     AstNode *proto_node = instruction->base.source_node;
     assert(proto_node->type == NodeTypeFnProto);
 
-    IrInstruction *result = ir_const(ira, &instruction->base, ira->codegen->builtin_types.entry_type);
-    result->value.special = ConstValSpecialLazy;
-
-    LazyValueFnType *lazy_fn_type = allocate<LazyValueFnType>(1);
-    result->value.data.x_lazy = &lazy_fn_type->base;
-    lazy_fn_type->base.id = LazyValueIdFnType;
-    lazy_fn_type->base.exec = ira->new_irb.exec;
-
     if (proto_node->data.fn_proto.auto_err_set) {
         ir_add_error(ira, &instruction->base,
             buf_sprintf("inferring error set of return type valid only for function definitions"));
         return ira->codegen->invalid_instruction;
     }
 
-    size_t param_count = proto_node->data.fn_proto.params.length;
-    lazy_fn_type->proto_node = proto_node;
-    lazy_fn_type->param_types = allocate<ConstExprValue *>(param_count);
+    FnTypeId fn_type_id = {0};
+    init_fn_type_id(&fn_type_id, proto_node, proto_node->data.fn_proto.params.length);
 
-    for (size_t i = 0; i < param_count; i += 1) {
-        AstNode *param_node = proto_node->data.fn_proto.params.at(i);
+    for (; fn_type_id.next_param_index < fn_type_id.param_count; fn_type_id.next_param_index += 1) {
+        AstNode *param_node = proto_node->data.fn_proto.params.at(fn_type_id.next_param_index);
         assert(param_node->type == NodeTypeParamDecl);
 
         bool param_is_var_args = param_node->data.param_decl.is_var_args;
-        lazy_fn_type->is_var_args = true;
         if (param_is_var_args) {
-            if (proto_node->data.fn_proto.cc == CallingConventionC) {
-                break;
-            } else if (proto_node->data.fn_proto.cc == CallingConventionUnspecified) {
-                lazy_fn_type->is_generic = true;
-                return result;
+            if (fn_type_id.cc == CallingConventionC) {
+                fn_type_id.param_count = fn_type_id.next_param_index;
+                continue;
+            } else if (fn_type_id.cc == CallingConventionUnspecified) {
+                return ir_const_type(ira, &instruction->base, get_generic_fn_type(ira->codegen, &fn_type_id));
             } else {
                 zig_unreachable();
             }
         }
+        FnTypeParamInfo *param_info = &fn_type_id.param_info[fn_type_id.next_param_index];
+        param_info->is_noalias = param_node->data.param_decl.is_noalias;
 
-        if (instruction->param_types[i] == nullptr) {
-            lazy_fn_type->is_generic = true;
-            return result;
+        if (instruction->param_types[fn_type_id.next_param_index] == nullptr) {
+            param_info->type = nullptr;
+            return ir_const_type(ira, &instruction->base, get_generic_fn_type(ira->codegen, &fn_type_id));
+        } else {
+            IrInstruction *param_type_value = instruction->param_types[fn_type_id.next_param_index]->child;
+            if (type_is_invalid(param_type_value->value.type))
+                return ira->codegen->invalid_instruction;
+            ZigType *param_type = ir_resolve_type(ira, param_type_value);
+            switch (type_requires_comptime(ira->codegen, param_type)) {
+            case ReqCompTimeYes:
+                if (!calling_convention_allows_zig_types(fn_type_id.cc)) {
+                    ir_add_error(ira, param_type_value,
+                        buf_sprintf("parameter of type '%s' not allowed in function with calling convention '%s'",
+                            buf_ptr(&param_type->name), calling_convention_name(fn_type_id.cc)));
+                    return ira->codegen->invalid_instruction;
+                }
+                param_info->type = param_type;
+                fn_type_id.next_param_index += 1;
+                return ir_const_type(ira, &instruction->base, get_generic_fn_type(ira->codegen, &fn_type_id));
+            case ReqCompTimeInvalid:
+                return ira->codegen->invalid_instruction;
+            case ReqCompTimeNo:
+                break;
+            }
+            if (!type_has_bits(param_type) && !calling_convention_allows_zig_types(fn_type_id.cc)) {
+                ir_add_error(ira, param_type_value,
+                    buf_sprintf("parameter of type '%s' has 0 bits; not allowed in function with calling convention '%s'",
+                        buf_ptr(&param_type->name), calling_convention_name(fn_type_id.cc)));
+                return ira->codegen->invalid_instruction;
+            }
+            param_info->type = param_type;
         }
 
-        IrInstruction *param_type_value = instruction->param_types[i]->child;
-        if (type_is_invalid(param_type_value->value.type))
-            return ira->codegen->invalid_instruction;
-        ConstExprValue *param_type_val = ir_resolve_const(ira, param_type_value, LazyOk);
-        if (param_type_val == nullptr)
-            return ira->codegen->invalid_instruction;
-        lazy_fn_type->param_types[i] = param_type_val;
     }
 
     if (instruction->align_value != nullptr) {
-        lazy_fn_type->align_val = ir_resolve_const(ira, instruction->align_value->child, LazyOk);
-        if (lazy_fn_type->align_val == nullptr)
+        if (!ir_resolve_align(ira, instruction->align_value->child, &fn_type_id.alignment))
             return ira->codegen->invalid_instruction;
     }
 
-    lazy_fn_type->return_type = ir_resolve_const(ira, instruction->return_type->child, LazyOk);
-    if (lazy_fn_type->return_type == nullptr)
+    IrInstruction *return_type_value = instruction->return_type->child;
+    fn_type_id.return_type = ir_resolve_type(ira, return_type_value);
+    if (type_is_invalid(fn_type_id.return_type))
         return ira->codegen->invalid_instruction;
+    if (fn_type_id.return_type->id == ZigTypeIdOpaque) {
+        ir_add_error(ira, instruction->return_type,
+            buf_sprintf("return type cannot be opaque"));
+        return ira->codegen->invalid_instruction;
+    }
 
-    if (proto_node->data.fn_proto.cc == CallingConventionAsync) {
+    if (fn_type_id.cc == CallingConventionAsync) {
         if (instruction->async_allocator_type_value == nullptr) {
             ir_add_error(ira, &instruction->base,
                 buf_sprintf("async fn proto missing allocator type"));
             return ira->codegen->invalid_instruction;
         }
-        lazy_fn_type->async_allocator_type = ir_resolve_const(ira, instruction->async_allocator_type_value->child, LazyOk);
-        if (lazy_fn_type->async_allocator_type == nullptr)
+        IrInstruction *async_allocator_type_value = instruction->async_allocator_type_value->child;
+        fn_type_id.async_allocator_type = ir_resolve_type(ira, async_allocator_type_value);
+        if (type_is_invalid(fn_type_id.async_allocator_type))
             return ira->codegen->invalid_instruction;
     }
 
-    return result;
+    return ir_const_type(ira, &instruction->base, get_fn_type(ira->codegen, &fn_type_id));
 }
 
 static IrInstruction *ir_analyze_instruction_test_comptime(IrAnalyze *ira, IrInstructionTestComptime *instruction) {
@@ -21756,11 +21587,8 @@ static Error buf_read_value_bytes(IrAnalyze *ira, CodeGen *codegen, AstNode *sou
                     val->type->data.vector.len);
         case ZigTypeIdEnum:
             switch (val->type->data.enumeration.layout) {
-                case ContainerLayoutAuto: {
-                    opt_ir_add_error_node(ira, codegen, source_node,
-                        buf_sprintf("compiler bug: TODO: implement enum byte reinterpretation"));
-                    return ErrorSemanticAnalyzeFail;
-                }
+                case ContainerLayoutAuto:
+                    zig_panic("TODO buf_read_value_bytes enum auto");
                 case ContainerLayoutPacked:
                     zig_panic("TODO buf_read_value_bytes enum packed");
                 case ContainerLayoutExtern: {
@@ -22056,7 +21884,7 @@ static IrInstruction *ir_analyze_instruction_decl_ref(IrAnalyze *ira,
     Tld *tld = instruction->tld;
     LVal lval = instruction->lval;
 
-    resolve_top_level_decl(ira->codegen, tld, instruction->base.source_node, true);
+    resolve_top_level_decl(ira->codegen, tld, instruction->base.source_node);
     if (tld->resolution == TldResolutionInvalid)
         return ira->codegen->invalid_instruction;
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -8945,11 +8945,9 @@ static ZigType *get_error_set_intersection(IrAnalyze *ira, ZigType *set1, ZigTyp
 
     err_set_type->data.error_set.err_count = intersection_list.length;
     err_set_type->data.error_set.errors = intersection_list.items;
-    if (intersection_list.length != 0) {
-        err_set_type->size_in_bits = ira->codegen->builtin_types.entry_global_error_set->size_in_bits;
-        err_set_type->abi_align = ira->codegen->builtin_types.entry_global_error_set->abi_align;
-        err_set_type->abi_size = ira->codegen->builtin_types.entry_global_error_set->abi_size;
-    }
+    err_set_type->size_in_bits = ira->codegen->builtin_types.entry_global_error_set->size_in_bits;
+    err_set_type->abi_align = ira->codegen->builtin_types.entry_global_error_set->abi_align;
+    err_set_type->abi_size = ira->codegen->builtin_types.entry_global_error_set->abi_size;
 
     buf_appendf(&err_set_type->name, "}");
 

--- a/src/ir.hpp
+++ b/src/ir.hpp
@@ -16,8 +16,7 @@ bool ir_gen_fn(CodeGen *g, ZigFn *fn_entry);
 ConstExprValue *ir_eval_const_value(CodeGen *codegen, Scope *scope, AstNode *node,
         ZigType *expected_type, size_t *backward_branch_count, size_t backward_branch_quota,
         ZigFn *fn_entry, Buf *c_import_buf, AstNode *source_node, Buf *exec_name,
-        IrExecutable *parent_exec, AstNode *expected_type_source_node, bool allow_lazy);
-Error ir_resolve_lazy(CodeGen *codegen, AstNode *source_node, ConstExprValue *val);
+        IrExecutable *parent_exec, AstNode *expected_type_source_node);
 
 ZigType *ir_analyze(CodeGen *g, IrExecutable *old_executable, IrExecutable *new_executable,
         ZigType *expected_type, AstNode *expected_type_source_node);

--- a/src/ir.hpp
+++ b/src/ir.hpp
@@ -16,7 +16,8 @@ bool ir_gen_fn(CodeGen *g, ZigFn *fn_entry);
 ConstExprValue *ir_eval_const_value(CodeGen *codegen, Scope *scope, AstNode *node,
         ZigType *expected_type, size_t *backward_branch_count, size_t backward_branch_quota,
         ZigFn *fn_entry, Buf *c_import_buf, AstNode *source_node, Buf *exec_name,
-        IrExecutable *parent_exec, AstNode *expected_type_source_node);
+        IrExecutable *parent_exec, AstNode *expected_type_source_node, bool allow_lazy);
+Error ir_resolve_lazy(CodeGen *codegen, AstNode *source_node, ConstExprValue *val);
 
 ZigType *ir_analyze(CodeGen *g, IrExecutable *old_executable, IrExecutable *new_executable,
         ZigType *expected_type, AstNode *expected_type_source_node);

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -548,6 +548,7 @@ ZigLLVMDILocalVariable *ZigLLVMCreateParameterVariable(ZigLLVMDIBuilder *dbuilde
         ZigLLVMDIType *type, bool always_preserve, unsigned flags, unsigned arg_no)
 {
     assert(flags == 0);
+    assert(arg_no != 0);
     DILocalVariable *result = reinterpret_cast<DIBuilder*>(dbuilder)->createParameterVariable(
             reinterpret_cast<DIScope*>(scope),
             name,

--- a/std/special/test_runner.zig
+++ b/std/special/test_runner.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const io = std.io;
 const builtin = @import("builtin");
-const test_fn_list = builtin.__zig_test_fn_slice;
+const test_fn_list = builtin.test_functions;
 const warn = std.debug.warn;
 
 pub fn main() !void {

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -256,8 +256,8 @@ const Foo96Bits = packed struct {
 
 test "packed struct 24bits" {
     comptime {
-        expect(@sizeOf(Foo24Bits) == 3);
-        expect(@sizeOf(Foo96Bits) == 12);
+        expect(@sizeOf(Foo24Bits) == 4);
+        expect(@sizeOf(Foo96Bits) == 16);
     }
 
     var value = Foo96Bits{
@@ -291,16 +291,22 @@ test "packed struct 24bits" {
     expect(value.d == 1);
 }
 
+const Foo32Bits = packed struct {
+    field: u24,
+    pad: u8,
+};
+
 const FooArray24Bits = packed struct {
     a: u16,
-    b: [2]Foo24Bits,
+    b: [2]Foo32Bits,
     c: u16,
 };
 
+// TODO revisit this test when doing https://github.com/ziglang/zig/issues/1512
 test "packed array 24bits" {
     comptime {
-        expect(@sizeOf([9]Foo24Bits) == 9 * 3);
-        expect(@sizeOf(FooArray24Bits) == 2 + 2 * 3 + 2);
+        expect(@sizeOf([9]Foo32Bits) == 9 * 4);
+        expect(@sizeOf(FooArray24Bits) == 2 + 2 * 4 + 2);
     }
 
     var bytes = []u8{0} ** (@sizeOf(FooArray24Bits) + 1);


### PR DESCRIPTION
This closes #761, and lays the groundwork for fixing the remaining
false positive "foo depends on itself" bugs, such as #624.

It also lays the groundwork for implementing ability to specify
alignment of fields (#1512).

I started trying to fix even more alignment problems, including removing a dirty hack that master branch has in there for when a struct depends on its own alignment in what should be a harmless way, which required introducing Lazy Values in 3dc8448680cfea2b55a6064c655e400e31e5d3dd. I realized this was going to be taking on way too much in an already large branch, so I backed out the Lazy Values change in d3f2fe2cef7de1173a038365f91e8a574a08f21a and put the master branch hack back in in d7bc7635c0e3324fa08fc809ec21ba014464ea03. Lazy Values will have to be a later commit.

Once this passes all tests and is merged, I'll go through the bugs and see which ones we can solve with this. Unfortunately some of them will have to remain until Lazy Values is in.

This branch also fixes a soundness issue with packed structs. Previously Zig was aligning packed struct fields based on byte-alignment; however according to the LLVM semantics we needed it to be aligned to the ABI alignment of the host integer type.