### PR TITLE
Veritcally align array literal columns

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -470,6 +470,34 @@ test "zig fmt: array literal with hint" {
     );
 }
 
+test "zig fmt: array literal veritical column alignment" {
+    try testTransform(
+        \\const a = []u8{
+        \\    1000, 200,
+        \\    30, 4,
+        \\    50000, 60
+        \\};
+        \\const a = []u8{0,   1, 2, 3, 40,
+        \\    4,5,600,7,
+        \\           80,
+        \\    9, 10, 11, 0, 13, 14, 15};
+        \\
+    ,
+        \\const a = []u8{
+        \\    1000,  200,
+        \\    30,    4,
+        \\    50000, 60,
+        \\};
+        \\const a = []u8{
+        \\    0,  1,  2,   3, 40,
+        \\    4,  5,  600, 7, 80,
+        \\    9,  10, 11,  0, 13,
+        \\    14, 15,
+        \\};
+        \\
+    );
+}
+
 test "zig fmt: multiline string with backslash at end of line" {
     try testCanonical(
         \\comptime {


### PR DESCRIPTION
:duck: :duck: :duck: 
:duck: :duck: :duck: 
:duck: :duck: :duck: 

---

Closes https://github.com/ziglang/zig/issues/1793

The approach here is to get the printed width of each array element expression by rendering it to a temporary `BufferOutStream` in the same way that the entire file is. Because of the recursive nature, this might perform poorly for arrays of arrays, I dunno.

This is a **draft** because [one of the existing tests (whose expected output I don't understand)](https://github.com/ziglang/zig/blob/master/std/zig/parser_test.zig#L452-L458) is failing (for a reason I don't understand). Meanwhile, I welcome any comments :speech_balloon: 