### PR TITLE
Remove binary and octal float literals from documentation.

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -9508,12 +9508,8 @@ skip &lt;- ([ \n] / line_comment)*
 
 CHAR_LITERAL &lt;- "'" char_char "'" skip
 FLOAT
-    &lt;- "0b" [01]+  "." [01]+  ([eE] [-+]? [01]+)?  skip
-     / "0o" [0-7]+ "." [0-7]+ ([eE] [-+]? [0-7]+)? skip
-     / "0x" hex+   "." hex+   ([pP] [-+]? hex+)?   skip
+    &lt;- "0x" hex+   "." hex+   ([pP] [-+]? hex+)?   skip
      /      [0-9]+ "." [0-9]+ ([eE] [-+]? [0-9]+)? skip
-     / "0b" [01]+  "."? [eE] [-+]? [01]+  skip
-     / "0o" [0-7]+ "."? [eE] [-+]? [0-7]+ skip
      / "0x" hex+   "."? [pP] [-+]? hex+   skip
      /      [0-9]+ "."? [eE] [-+]? [0-9]+ skip
 INTEGER


### PR DESCRIPTION
Part of #2093