### PR TITLE
Armv7m compiler rt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -664,6 +664,7 @@ set(ZIG_STD_FILES
     "special/compiler_rt/muloti4.zig"
     "special/compiler_rt/mulXf3.zig"
     "special/compiler_rt/multi3.zig"
+    "special/compiler_rt/negXf2.zig"
     "special/compiler_rt/popcountdi2.zig"
     "special/compiler_rt/truncXfYf2.zig"
     "special/compiler_rt/udivmod.zig"

--- a/std/special/builtin.zig
+++ b/std/special/builtin.zig
@@ -55,6 +55,31 @@ export fn memmove(dest: ?[*]u8, src: ?[*]const u8, n: usize) ?[*]u8 {
     return dest;
 }
 
+export fn memcmp(vl: ?[*]const u8, vr: ?[*]const u8, n: usize) isize {
+    @setRuntimeSafety(false);
+
+    var index: usize = 0;
+    while (index != n) : (index += 1) {
+        const compare_val = @bitCast(i8, vl.?[index] -% vr.?[index]);
+        if (compare_val != 0) {
+            return compare_val;
+        }
+    }
+
+    return 0;
+}
+
+test "test_memcmp" {
+    const base_arr = []u8{ 1, 1, 1 };
+    const arr1 = []u8{ 1, 1, 1 };
+    const arr2 = []u8{ 1, 0, 1 };
+    const arr3 = []u8{ 1, 2, 1 };
+
+    std.testing.expect(memcmp(base_arr[0..].ptr, arr1[0..].ptr, base_arr.len) == 0);
+    std.testing.expect(memcmp(base_arr[0..].ptr, arr2[0..].ptr, base_arr.len) == 1);
+    std.testing.expect(memcmp(base_arr[0..].ptr, arr3[0..].ptr, base_arr.len) == -1);
+}
+
 comptime {
     if (builtin.mode != builtin.Mode.ReleaseFast and
         builtin.mode != builtin.Mode.ReleaseSmall and

--- a/std/special/compiler_rt.zig
+++ b/std/special/compiler_rt.zig
@@ -82,6 +82,9 @@ comptime {
     @export("__umoddi3", __umoddi3, linkage);
     @export("__udivmodsi4", __udivmodsi4, linkage);
 
+    @export("__negsf2", @import("compiler_rt/negXf2.zig").__negsf2, linkage);
+    @export("__negdf2", @import("compiler_rt/negXf2.zig").__negdf2, linkage);
+
     if (is_arm_arch and !is_arm_64) {
         @export("__aeabi_uldivmod", __aeabi_uldivmod, linkage);
         @export("__aeabi_uidivmod", __aeabi_uidivmod, linkage);
@@ -106,6 +109,9 @@ comptime {
         @export("__aeabi_memcmp", __aeabi_memcmp, linkage);
         @export("__aeabi_memcmp4", __aeabi_memcmp, linkage);
         @export("__aeabi_memcmp8", __aeabi_memcmp, linkage);
+
+        @export("__aeabi_fneg", @import("compiler_rt/negXf2.zig").__negsf2, linkage);
+        @export("__aeabi_dneg", @import("compiler_rt/negXf2.zig").__negdf2, linkage);
 
         @export("__aeabi_fadd", @import("compiler_rt/addXf3.zig").__addsf3, linkage);
         @export("__aeabi_dadd", @import("compiler_rt/addXf3.zig").__adddf3, linkage);

--- a/std/special/compiler_rt.zig
+++ b/std/special/compiler_rt.zig
@@ -113,10 +113,31 @@ comptime {
         @export("__aeabi_fneg", @import("compiler_rt/negXf2.zig").__negsf2, linkage);
         @export("__aeabi_dneg", @import("compiler_rt/negXf2.zig").__negdf2, linkage);
 
+        @export("__aeabi_fmul", @import("compiler_rt/mulXf3.zig").__mulsf3, linkage);
+        @export("__aeabi_dmul", @import("compiler_rt/mulXf3.zig").__muldf3, linkage);
+
+        @export("__aeabi_d2h", @import("compiler_rt/truncXfYf2.zig").__truncdfhf2, linkage);
+
+        @export("__aeabi_f2ulz", @import("compiler_rt/fixunssfdi.zig").__fixunssfdi, linkage);
+        @export("__aeabi_d2ulz", @import("compiler_rt/fixunsdfdi.zig").__fixunsdfdi, linkage);
+
+        @export("__aeabi_f2lz", @import("compiler_rt/fixsfdi.zig").__fixsfdi, linkage);
+        @export("__aeabi_d2lz", @import("compiler_rt/fixdfdi.zig").__fixdfdi, linkage);
+
+        @export("__aeabi_d2uiz", @import("compiler_rt/fixunsdfsi.zig").__fixunsdfsi, linkage);
+
+        @export("__aeabi_h2f", @import("compiler_rt/extendXfYf2.zig").__extendhfsf2, linkage);
+        @export("__aeabi_f2h", @import("compiler_rt/truncXfYf2.zig").__truncsfhf2, linkage);
+
         @export("__aeabi_fadd", @import("compiler_rt/addXf3.zig").__addsf3, linkage);
         @export("__aeabi_dadd", @import("compiler_rt/addXf3.zig").__adddf3, linkage);
         @export("__aeabi_fsub", @import("compiler_rt/addXf3.zig").__subsf3, linkage);
         @export("__aeabi_dsub", @import("compiler_rt/addXf3.zig").__subdf3, linkage);
+
+        @export("__aeabi_f2uiz", @import("compiler_rt/fixunssfsi.zig").__fixunssfsi, linkage);
+
+        @export("__aeabi_f2iz", @import("compiler_rt/fixsfsi.zig").__fixsfsi, linkage);
+        @export("__aeabi_d2iz", @import("compiler_rt/fixdfsi.zig").__fixdfsi, linkage);
     }
     if (builtin.os == builtin.Os.windows) {
         switch (builtin.arch) {

--- a/std/special/compiler_rt.zig
+++ b/std/special/compiler_rt.zig
@@ -21,7 +21,11 @@ comptime {
 
     @export("__unordtf2", @import("compiler_rt/comparetf2.zig").__unordtf2, linkage);
 
+    @export("__addsf3", @import("compiler_rt/addXf3.zig").__addsf3, linkage);
+    @export("__adddf3", @import("compiler_rt/addXf3.zig").__adddf3, linkage);
     @export("__addtf3", @import("compiler_rt/addXf3.zig").__addtf3, linkage);
+    @export("__subsf3", @import("compiler_rt/addXf3.zig").__subsf3, linkage);
+    @export("__subdf3", @import("compiler_rt/addXf3.zig").__subdf3, linkage);
     @export("__subtf3", @import("compiler_rt/addXf3.zig").__subtf3, linkage);
 
     @export("__mulsf3", @import("compiler_rt/mulXf3.zig").__mulsf3, linkage);
@@ -102,6 +106,11 @@ comptime {
         @export("__aeabi_memcmp", __aeabi_memcmp, linkage);
         @export("__aeabi_memcmp4", __aeabi_memcmp, linkage);
         @export("__aeabi_memcmp8", __aeabi_memcmp, linkage);
+
+        @export("__aeabi_fadd", @import("compiler_rt/addXf3.zig").__addsf3, linkage);
+        @export("__aeabi_dadd", @import("compiler_rt/addXf3.zig").__adddf3, linkage);
+        @export("__aeabi_fsub", @import("compiler_rt/addXf3.zig").__subsf3, linkage);
+        @export("__aeabi_dsub", @import("compiler_rt/addXf3.zig").__subdf3, linkage);
     }
     if (builtin.os == builtin.Os.windows) {
         switch (builtin.arch) {

--- a/std/special/compiler_rt/addXf3.zig
+++ b/std/special/compiler_rt/addXf3.zig
@@ -33,7 +33,8 @@ pub extern fn __subtf3(a: f128, b: f128) f128 {
     return addXf3(f128, a, neg_b);
 }
 
-inline fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
+// TODO: restore inline keyword, see: https://github.com/ziglang/zig/issues/2154
+fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     const Z = @IntType(false, T.bit_count);
     const S = @IntType(false, T.bit_count - @clz(Z(T.bit_count) - 1));
     const significandBits = std.math.floatMantissaBits(T);
@@ -44,7 +45,8 @@ inline fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)
     return 1 - shift;
 }
 
-inline fn addXf3(comptime T: type, a: T, b: T) T {
+// TODO: restore inline keyword, see: https://github.com/ziglang/zig/issues/2154
+fn addXf3(comptime T: type, a: T, b: T) T {
     const Z = @IntType(false, T.bit_count);
     const S = @IntType(false, T.bit_count - @clz(Z(T.bit_count) - 1));
 

--- a/std/special/compiler_rt/negXf2.zig
+++ b/std/special/compiler_rt/negXf2.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+
+pub extern fn __negsf2(a: f32) f32 {
+    return negXf2(f32, a);
+}
+
+pub extern fn __negdf2(a: f64) f64 {
+    return negXf2(f64, a);
+}
+
+fn negXf2(comptime T: type, a: T) T {
+    const Z = @IntType(false, T.bit_count);
+
+    const typeWidth = T.bit_count;
+    const significandBits = std.math.floatMantissaBits(T);
+    const exponentBits = std.math.floatExponentBits(T);
+
+    const signBit = (Z(1) << (significandBits + exponentBits));
+
+    return @bitCast(T, @bitCast(Z, a) ^ signBit);
+}


### PR DESCRIPTION
The builtin functions that are getting included for no reason will still require:

__aeabi_fdiv
__aeabi_ddiv
__aeabi_fcmpeq
__aeabi_dcmpeq
__aeabi_dcmpgt
__aeabi_dcmplt
