### PR TITLE
Always write a multiline struct literal if a field expr is multiline

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -393,6 +393,50 @@ test "zig fmt: struct literal no trailing comma" {
     );
 }
 
+test "zig fmt: struct literal containing a multiline expression" {
+    try testTransform(
+        \\const a = A{ .x = if (f1()) 10 else 20 };
+        \\const a = A{ .x = if (f1()) 10 else 20, };
+        \\const a = A{ .x = if (f1())
+        \\    10 else 20 };
+        \\const a = A{ .x = if (f1()) 10 else 20, .y = f2() + 100 };
+        \\const a = A{ .x = if (f1()) 10 else 20, .y = f2() + 100, };
+        \\const a = A{ .x = if (f1())
+        \\    10 else 20};
+        \\const a = A{ .x = switch(g) {0 => "ok", else => "no"} };
+        \\
+    ,
+        \\const a = A{ .x = if (f1()) 10 else 20 };
+        \\const a = A{
+        \\    .x = if (f1()) 10 else 20,
+        \\};
+        \\const a = A{
+        \\    .x = if (f1())
+        \\        10
+        \\    else
+        \\        20,
+        \\};
+        \\const a = A{ .x = if (f1()) 10 else 20, .y = f2() + 100 };
+        \\const a = A{
+        \\    .x = if (f1()) 10 else 20,
+        \\    .y = f2() + 100,
+        \\};
+        \\const a = A{
+        \\    .x = if (f1())
+        \\        10
+        \\    else
+        \\        20,
+        \\};
+        \\const a = A{
+        \\    .x = switch (g) {
+        \\        0 => "ok",
+        \\        else => "no",
+        \\    },
+        \\};
+        \\
+    );
+}
+
 test "zig fmt: array literal with hint" {
     try testTransform(
         \\const a = []u8{


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/1782

Note the `FindByteOutStream` helper type which is private to render.zig. This could also be implemented as a wrapper type like `CountingOutStream` and used around a `NullOutStream` [like this](https://github.com/hryx/zig/blob/f9c316960b9fe6328ca8aeb72d7938f0d17be600/std/zig/render.zig#L729-L730) (thanks @Hejsil for showing me that). But I figured that would only be worthwhile if it should be added to std/io, and this might be too much of a special case to justify adding to the stdlib. I'm open to either.