### PR TITLE
fmt: fix first line comment indent in struct init

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -955,6 +955,19 @@ test "zig fmt: line comments in struct initializer" {
     );
 }
 
+test "zig fmt: first line comment in struct initializer" {
+    try testCanonical(
+        \\pub async fn acquire(self: *Self) HeldLock {
+        \\    return HeldLock{
+        \\        // TODO guaranteed allocation elision
+        \\        .held = await (async self.lock.acquire() catch unreachable),
+        \\        .value = &self.private_data,
+        \\    };
+        \\}
+        \\
+    );
+}
+
 test "zig fmt: doc comments before struct field" {
     try testCanonical(
         \\pub const Allocator = struct {

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -641,10 +641,10 @@ fn renderExpression(
                         return renderToken(tree, stream, suffix_op.rtoken, indent, start_col, space);
                     }
 
-                    try renderExpression(allocator, stream, tree, indent, start_col, suffix_op.lhs, Space.None);
-                    try renderToken(tree, stream, lbrace, indent, start_col, Space.Newline);
-
                     const new_indent = indent + indent_delta;
+
+                    try renderExpression(allocator, stream, tree, new_indent, start_col, suffix_op.lhs, Space.None);
+                    try renderToken(tree, stream, lbrace, new_indent, start_col, Space.Newline);
 
                     var it = field_inits.iterator(0);
                     while (it.next()) |field_init| {


### PR DESCRIPTION
Fixes #1193 