### PR TITLE
zig fmt: Allow one-line for loops

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -1737,6 +1737,10 @@ test "zig fmt: switch" {
 test "zig fmt: while" {
     try testCanonical(
         \\test "while" {
+        \\    while (10 < 1) unreachable;
+        \\
+        \\    while (10 < 1) unreachable else unreachable;
+        \\
         \\    while (10 < 1) {
         \\        unreachable;
         \\    }
@@ -1803,9 +1807,26 @@ test "zig fmt: while" {
 test "zig fmt: for" {
     try testCanonical(
         \\test "for" {
+        \\    for (a) continue;
+        \\
+        \\    for (a)
+        \\        continue;
+        \\
+        \\    for (a) {
+        \\        continue;
+        \\    }
+        \\
         \\    for (a) |v| {
         \\        continue;
         \\    }
+        \\
+        \\    for (a) |v| continue;
+        \\
+        \\    for (a) |v| continue else return;
+        \\
+        \\    for (a) |v| {
+        \\        continue;
+        \\    } else return;
         \\
         \\    for (a) |v|
         \\        continue;
@@ -1819,6 +1840,17 @@ test "zig fmt: for" {
         \\
         \\    for (a) |v, i|
         \\        continue;
+        \\
+        \\    for (a) |b| switch (b) {
+        \\        c => {},
+        \\        d => {},
+        \\    };
+        \\
+        \\    for (a) |b|
+        \\        switch (b) {
+        \\            c => {},
+        \\            d => {},
+        \\        };
         \\
         \\    const res = for (a) |v, i| {
         \\        break v;


### PR DESCRIPTION
:curly_loop::curly_loop::curly_loop::curly_loop::curly_loop::curly_loop::curly_loop::curly_loop::curly_loop: 
Closes https://github.com/ziglang/zig/issues/1269
:loop::loop::loop::loop::loop::loop::loop::loop::loop:

[This new test case](https://github.com/hryx/zig/blob/7806b5c1e9dc17ea29e25438839626c0ae18542b/std/zig/parser_test.zig#L1849-L1853) might look weird, but I think it's correct unless we have an ambiguity. From what I can tell, a `for/if/else/while` body on a newline but without {body curlies} is _a single expression indented one level deeper_, even if that expression contains sub-expressions (such as the switch body in that test case). Without that logic, it actually looks worse -- compare the before & after:

```zig
// fmt before 
for (a) |b|
    switch (b) {
    c => {},
    d => {},
};
// fmt after fix
for (a) |b|
    switch (b) {
        c => {},
        d => {},
    };
// fmt after fix and some fashion advice
for (a) |b| switch (b) {
    c => {},
    d => {},
};
```

:nail_care: 