### PR TITLE
handle LibExeObjStep.disable_gen_h

### DIFF
--- a/std/build.zig
+++ b/std/build.zig
@@ -1206,6 +1206,10 @@ pub const LibExeObjStep = struct {
     pub fn setMainPkgPath(self: *LibExeObjStep, dir_path: []const u8) void {
         self.main_pkg_path = dir_path;
     }
+    
+    pub fn setDisableGenH(self: *LibExeObjStep, value: bool) void {
+        self.disable_gen_h = value;
+    }
 
     /// Unless setOutputDir was called, this function must be called only in
     /// the make step, from a step that has declared a dependency on this one.
@@ -1432,6 +1436,9 @@ pub const LibExeObjStep = struct {
         }
         if (self.is_dynamic) {
             try zig_args.append("-dynamic");
+        }
+        if (self.disable_gen_h) {
+            try zig_args.append("--disable-gen-h");
         }
 
         switch (self.target) {


### PR DESCRIPTION
It is sometimes useful to skip generating of the header file (e.g. https://github.com/ziglang/zig/issues/2173), and zig compiler provides an option `--disable-gen-h` to control that behaviour. However, setting `lib.disable_gen_h = true` in a typical `build.zig` didn't append the option to arguments. This PR fixes it and adds a convenient `setDisableGenH` setter.