### PR TITLE
zig fmt: Fix regression in for-else (#2178)

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -1828,6 +1828,15 @@ test "zig fmt: for" {
         \\        continue;
         \\    } else return;
         \\
+        \\    for (a) |v| continue else {
+        \\        return;
+        \\    }
+        \\
+        \\    for (a) |v|
+        \\        continue
+        \\    else
+        \\        return;
+        \\
         \\    for (a) |v|
         \\        continue;
         \\

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -1875,6 +1875,21 @@ test "zig fmt: for" {
         \\}
         \\
     );
+
+    try testTransform(
+        \\test "fix for" {
+        \\    for (a) |x|
+        \\        f(x) else continue;
+        \\}
+        \\
+    ,
+        \\test "fix for" {
+        \\    for (a) |x|
+        \\        f(x)
+        \\    else continue;
+        \\}
+        \\
+    );
 }
 
 test "zig fmt: if" {

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -1460,7 +1460,7 @@ fn renderExpression(
 
             const space_after_body = blk: {
                 if (for_node.@"else") |@"else"| {
-                    const src_one_line_to_else = tree.tokensOnSameLine(for_node.body.lastToken(), @"else".firstToken());
+                    const src_one_line_to_else = tree.tokensOnSameLine(rparen, @"else".firstToken());
                     if (body_is_block or src_one_line_to_else) {
                         break :blk Space.Space;
                     } else {


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/2178

Note: I renamed some variables in this prong purely for the sake of clarity (`rparen_space` -> `space_after_rparen`). Sorry for the diff noise, hopefully it's a helpful change for others (it was for me).

The root cause here was that I was a bit hasty with https://github.com/ziglang/zig/pull/2158. I didn't quite fully understand the relationship between of the indent/after-space parameters to `renderExpression()` and the use of `writeByteNTimes()`.

The new test cases should be enough to cover `for`, but I'm going to play around with it for a bit just to make sure.

Apologies for the hiccup! :bowing_man: 