### PR TITLE
fmt: format multi line only on trailing comma

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -584,6 +584,25 @@ test "zig fmt: trailing comma on fn call" {
     );
 }
 
+test "zig fmt: multi line arguments without last comma" {
+    try testTransform(
+        \\pub fn foo(
+        \\    a: usize,
+        \\    b: usize,
+        \\    c: usize,
+        \\    d: usize
+        \\) usize {
+        \\    return a + b + c + d;
+        \\}
+        \\
+    ,
+        \\pub fn foo(a: usize, b: usize, c: usize, d: usize) usize {
+        \\    return a + b + c + d;
+        \\}
+        \\
+    )
+}
+
 test "zig fmt: empty block with only comment" {
     try testCanonical(
         \\comptime {

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -600,7 +600,7 @@ test "zig fmt: multi line arguments without last comma" {
         \\    return a + b + c + d;
         \\}
         \\
-    )
+    );
 }
 
 test "zig fmt: empty block with only comment" {

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -1158,12 +1158,8 @@ fn renderExpression(
                 const maybe_comma = tree.prevToken(rparen);
                 break :blk tree.tokens.at(maybe_comma).id == Token.Id.Comma;
             };
-            const src_params_same_line = blk: {
-                const loc = tree.tokenLocation(tree.tokens.at(lparen).end, rparen);
-                break :blk loc.line == 0;
-            };
 
-            if (!src_params_trailing_comma and src_params_same_line) {
+            if (!src_params_trailing_comma) {
                 try renderToken(tree, stream, lparen, indent, start_col, Space.None); // (
 
                 // render all on one line, no trailing comma


### PR DESCRIPTION
Fixes #2181