### PR TITLE
docs: Use section symbol §, not paragraph symbol ¶

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -966,7 +966,7 @@ fn genHtml(allocator: *mem.Allocator, tokenizer: *Tokenizer, toc: *Toc, out: var
             },
             Node.HeaderOpen => |info| {
                 try out.print(
-                    "<h{} id=\"{}\"><a href=\"#toc-{}\">{}</a><a class=\"hdr\" href=\"#{}\">¶</a></h{}>\n",
+                    "<h{} id=\"{}\"><a href=\"#toc-{}\">{}</a><a class=\"hdr\" href=\"#{}\">§</a></h{}>\n",
                     info.n,
                     info.url,
                     info.url,


### PR DESCRIPTION
A header may cover more than one paragraph, so a section symbol is more appropriate. 

https://en.wikipedia.org/wiki/Section_sign