### PR TITLE
wasm: Pass --allow-undefined and --export-all to the linker

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -1092,6 +1092,8 @@ static void construct_linker_job_wasm(LinkJob *lj) {
 
     lj->args.append("-error-limit=0");
     lj->args.append("--no-entry");  // So lld doesn't look for _start.
+    lj->args.append("--allow-undefined");
+    lj->args.append("--export-all");
     lj->args.append("-o");
     lj->args.append(buf_ptr(&g->output_file_path));
 


### PR DESCRIPTION
This is ugly but does fix #1622 and we get seamless WebAssembly experience out of the box.

**Edit:** Just read the full nuances in the issue. I was too excited to get things working out of the box. Feel free to close the pull request if this doesn't cut it.