### PR TITLE
build: usageAndErr clean exit

### DIFF
--- a/std/special/build_runner.zig
+++ b/std/special/build_runner.zig
@@ -202,7 +202,7 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: var) !void {
 
 fn usageAndErr(builder: *Builder, already_ran_build: bool, out_stream: var) anyerror {
     usage(builder, already_ran_build, out_stream) catch {};
-    return error.InvalidArgs;
+    os.exit(1);
 }
 
 const UnwrapArgError = error{OutOfMemory};

--- a/std/special/build_runner.zig
+++ b/std/special/build_runner.zig
@@ -200,7 +200,7 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: var) !void {
     );
 }
 
-fn usageAndErr(builder: *Builder, already_ran_build: bool, out_stream: var) anyerror {
+fn usageAndErr(builder: *Builder, already_ran_build: bool, out_stream: var) void {
     usage(builder, already_ran_build, out_stream) catch {};
     os.exit(1);
 }


### PR DESCRIPTION
Fixes #1938 and #1879

Cleanly exit as the error has been clearly shown to the user already. Displaying a compiler stack trace is unnecessary.