### PR TITLE
Fix getCurrentId test for pthreads

### DIFF
--- a/std/os/test.zig
+++ b/std/os/test.zig
@@ -48,11 +48,12 @@ test "std.os.Thread.getCurrentId" {
     thread.wait();
     switch (builtin.os) {
         builtin.Os.windows => expect(os.Thread.getCurrentId() != thread_current_id),
-        else => {
+        builtin.Os.linux => {
             // If the thread completes very quickly, then thread_id can be 0. See the
             // documentation comments for `std.os.Thread.handle`.
             expect(thread_id == 0 or thread_current_id == thread_id);
         },
+        else => expect(thread_current_id == thread_id),
     }
 }
 

--- a/std/os/test.zig
+++ b/std/os/test.zig
@@ -46,14 +46,17 @@ test "std.os.Thread.getCurrentId" {
     const thread = try os.spawnThread(&thread_current_id, testThreadIdFn);
     const thread_id = thread.handle();
     thread.wait();
-    switch (builtin.os) {
-        builtin.Os.windows => expect(os.Thread.getCurrentId() != thread_current_id),
-        builtin.Os.linux => {
-            // If the thread completes very quickly, then thread_id can be 0. See the
-            // documentation comments for `std.os.Thread.handle`.
-            expect(thread_id == 0 or thread_current_id == thread_id);
-        },
-        else => expect(thread_current_id == thread_id),
+    if (os.Thread.use_pthreads) {
+        expect(thread_current_id == thread_id);
+    } else {
+        switch (builtin.os) {
+            builtin.Os.windows => expect(os.Thread.getCurrentId() != thread_current_id),
+            else => {
+                // If the thread completes very quickly, then thread_id can be 0. See the
+                // documentation comments for `std.os.Thread.handle`.
+                expect(thread_id == 0 or thread_current_id == thread_id);
+            },
+        }
     }
 }
 


### PR DESCRIPTION
thread_id is opaque when pthreads is used. 