### PR TITLE
stage1: create ir.cpp specific `analyze_type_expr`

### DIFF
--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3,6 +3,21 @@ const builtin = @import("builtin");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "Generic function where return type is self-referenced",
+        \\fn Foo(comptime T: type) Foo(T) {
+        \\    return struct{ x: T };
+        \\}
+        \\export fn entry() void {
+        \\    const t = Foo(u32) {
+        \\      .x = 1
+        \\    };
+        \\}
+    ,
+        "tmp.zig:1:29: error: evaluation exceeded 1000 backwards branches",
+        "tmp.zig:1:29: note: called from here",
+    );
+
+    cases.add(
         "@ptrToInt 0 to non optional pointer",
         \\export fn entry() void {
         \\    var b = @intToPtr(*i32, 0);


### PR DESCRIPTION
fixes #532 

**Problem**
`ir.cpp` was jumping out to `analyze_type_expr` on occasion, which is really just a call to its own `ir_eval_const_value` with some type checking. `analyze_type_expr` fakes many of the arguments due to lack of context, primarily that `IrAnalyze` is private to `ir.cpp`.

**Solution**
This PR establishes `ir_analyze_type_expr` which provides more context for `ir_eval_const_value` to work with.