### PR TITLE
compiler-rt: correct use_thumb_1 flag

### DIFF
--- a/std/special/compiler_rt.zig
+++ b/std/special/compiler_rt.zig
@@ -253,14 +253,75 @@ const is_arm_arch = switch (builtin.arch) {
 
 const is_arm_32 = is_arm_arch and !is_arm_64;
 
-const use_thumb_1 = is_arm_32 and switch (builtin.arch.arm) {
-    builtin.Arch.Arm32.v6,
-    builtin.Arch.Arm32.v6m,
-    builtin.Arch.Arm32.v6k,
-    builtin.Arch.Arm32.v6t2,
-    => true,
-    else => false,
-};
+const use_thumb_1 = usesThumb1(builtin.arch);
+
+fn usesThumb1(arch: builtin.Arch) bool {
+    return switch (arch) {
+        .arm => switch (arch.arm) {
+            .v6m => true,
+            else => false,
+        },
+        .armeb => switch (arch.armeb) {
+            .v6m => true,
+            else => false,
+        },
+        .thumb => switch (arch.thumb) {
+            .v5,
+            .v5te,
+            .v4t,
+            .v6,
+            .v6m,
+            .v6k,
+            => true,
+            else => false,
+        },
+        .thumbeb => switch (arch.thumbeb) {
+            .v5,
+            .v5te,
+            .v4t,
+            .v6,
+            .v6m,
+            .v6k,
+            => true,
+            else => false,
+        },
+        else => false,
+    };
+}
+
+test "usesThumb1" {
+    testing.expect(usesThumb1(builtin.Arch{ .arm = .v6m }));
+    testing.expect(!usesThumb1(builtin.Arch{ .arm = .v5 }));
+    //etc.
+
+    testing.expect(usesThumb1(builtin.Arch{ .armeb = .v6m }));
+    testing.expect(!usesThumb1(builtin.Arch{ .armeb = .v5 }));
+    //etc.
+
+    testing.expect(usesThumb1(builtin.Arch{ .thumb = .v5 }));
+    testing.expect(usesThumb1(builtin.Arch{ .thumb = .v5te }));
+    testing.expect(usesThumb1(builtin.Arch{ .thumb = .v4t }));
+    testing.expect(usesThumb1(builtin.Arch{ .thumb = .v6 }));
+    testing.expect(usesThumb1(builtin.Arch{ .thumb = .v6k }));
+    testing.expect(usesThumb1(builtin.Arch{ .thumb = .v6m }));
+    testing.expect(!usesThumb1(builtin.Arch{ .thumb = .v6t2 }));
+    //etc.
+
+    testing.expect(usesThumb1(builtin.Arch{ .thumbeb = .v5 }));
+    testing.expect(usesThumb1(builtin.Arch{ .thumbeb = .v5te }));
+    testing.expect(usesThumb1(builtin.Arch{ .thumbeb = .v4t }));
+    testing.expect(usesThumb1(builtin.Arch{ .thumbeb = .v6 }));
+    testing.expect(usesThumb1(builtin.Arch{ .thumbeb = .v6k }));
+    testing.expect(usesThumb1(builtin.Arch{ .thumbeb = .v6m }));
+    testing.expect(!usesThumb1(builtin.Arch{ .thumbeb = .v6t2 }));
+    //etc.
+
+    testing.expect(!usesThumb1(builtin.Arch{ .aarch64 = .v8 }));
+    testing.expect(!usesThumb1(builtin.Arch{ .aarch64_be = .v8 }));
+    testing.expect(!usesThumb1(builtin.Arch.x86_64));
+    testing.expect(!usesThumb1(builtin.Arch.riscv32));
+    //etc.
+}
 
 nakedcc fn __aeabi_uidivmod() void {
     @setRuntimeSafety(false);


### PR DESCRIPTION
The flag is for generating correct arm-thumb interwork veneers in the
assembly code __aeabi_{memcpy,memset,etc} functions.

Armv6m only does thumb code generation regardless of whether arm or
thumb is selected and armv6t2 uses the newer thumb 2 set. All other
versions that zig supports pre-armv7 need the veneers and hence the
flag. Armv5 is actually armv5t.

Relevant code from clang/lib/Basic/Targets/Arm.cpp

```c
bool ARMTargetInfo::isThumb() const {
  return ArchISA == llvm::ARM::ISAKind::THUMB;
  }

bool ARMTargetInfo::supportsThumb() const {
  return CPUAttr.count('T') || ArchVersion >= 6;
}

bool ARMTargetInfo::supportsThumb2() const {
  return CPUAttr.equals("6T2") ||
    (ArchVersion >= 7 && !CPUAttr.equals("8M_BASE"));
}
```

Also see

http://www.llvm.org/svn/llvm-project/llvm/trunk/lib/Target/ARM/ARM.td