### PR TITLE
docs: Underline link when hovering over it

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8,7 +8,7 @@
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;
       }
-      a {
+      a:not(:hover) {
         text-decoration: none;
       }
       table, th, td {


### PR DESCRIPTION
In addition to the pointer, this gives some visual feedback to the user
that the element is interactive. This is a very common style pattern
across the web.