### PR TITLE
Fix normalization of right-shifted BigInt at CT

### DIFF
--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -1410,12 +1410,19 @@ void bigint_shr(BigInt *dest, const BigInt *op1, const BigInt *op2) {
     }
 
     dest->digit_count = op1->digit_count - digit_shift_count;
-    dest->data.digits = allocate<uint64_t>(dest->digit_count);
+    uint64_t *digits;
+    if (dest->digit_count == 1) {
+        digits = &dest->data.digit;
+    } else {
+        digits = allocate<uint64_t>(dest->digit_count);
+        dest->data.digits = digits;
+    }
+
     uint64_t carry = 0;
     for (size_t op_digit_index = op1->digit_count - 1;;) {
         uint64_t digit = op1_digits[op_digit_index];
         size_t dest_digit_index = op_digit_index - digit_shift_count;
-        dest->data.digits[dest_digit_index] = carry | (digit >> leftover_shift_count);
+        digits[dest_digit_index] = carry | (digit >> leftover_shift_count);
         carry = digit << (64 - leftover_shift_count);
 
         if (dest_digit_index == 0) { break; }

--- a/test/stage1/behavior/bit_shifting.zig
+++ b/test/stage1/behavior/bit_shifting.zig
@@ -86,3 +86,11 @@ fn testShardedTable(comptime Key: type, comptime mask_bit_count: comptime_int, c
         expect(table.get(@intCast(Key, i)) == node);
     }
 }
+
+// #2225
+test "comptime shr of BigInt" {
+    comptime {
+        var n = 0xdeadbeef0000000000000000;
+        std.debug.assert(n >> 64 == 0xdeadbeef);
+    }
+}


### PR DESCRIPTION
The pointer value for the `digits` field was being treated as if it were
a limb.

Fixes #2225