### PR TITLE
wasm: force single threaded

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -921,6 +921,10 @@ int main(int argc, char **argv) {
         }
     }
 
+    if (target_is_single_threaded(&target)) {
+        is_single_threaded = true;
+    }
+
     if (output_dir != nullptr && enable_cache == CacheOptOn) {
         fprintf(stderr, "`--output-dir` is incompatible with --cache on.\n");
         return print_error_usage(arg0);

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -1371,6 +1371,10 @@ bool target_is_wasm(const ZigTarget *target) {
     return target->arch == ZigLLVM_wasm32 || target->arch == ZigLLVM_wasm64;
 }
 
+bool target_is_single_threaded(const ZigTarget *target) {
+    return target_is_wasm(target);
+}
+
 ZigLLVM_EnvironmentType target_default_abi(ZigLLVM_ArchType arch, Os os) {
     switch (os) {
         case OsFreestanding:

--- a/src/target.hpp
+++ b/src/target.hpp
@@ -171,6 +171,7 @@ bool target_abi_is_musl(ZigLLVM_EnvironmentType abi);
 bool target_is_glibc(const ZigTarget *target);
 bool target_is_musl(const ZigTarget *target);
 bool target_is_wasm(const ZigTarget *target);
+bool target_is_single_threaded(const ZigTarget *target);
 
 uint32_t target_arch_pointer_bit_width(ZigLLVM_ArchType arch);
 


### PR DESCRIPTION
This introduces `target_is_single_threaded` and forces wasm to be single-threaded. As per https://github.com/ziglang/zig/pull/2268#pullrequestreview-226369160