### PR TITLE
std.os: centralize is_posix and is_windows

### DIFF
--- a/std/heap.zig
+++ b/std/heap.zig
@@ -36,7 +36,7 @@ pub const DirectAllocator = struct {
     allocator: Allocator,
     heap_handle: ?HeapHandle,
 
-    const HeapHandle = if (builtin.os == Os.windows) os.windows.HANDLE else void;
+    const HeapHandle = if (os.is_windows) os.windows.HANDLE else void;
 
     pub fn init() DirectAllocator {
         return DirectAllocator{
@@ -44,7 +44,7 @@ pub const DirectAllocator = struct {
                 .reallocFn = realloc,
                 .shrinkFn = shrink,
             },
-            .heap_handle = if (builtin.os == Os.windows) null else {},
+            .heap_handle = if (os.is_windows) null else {},
         };
     }
 

--- a/std/io.zig
+++ b/std/io.zig
@@ -15,23 +15,20 @@ const fmt = std.fmt;
 const File = std.os.File;
 const testing = std.testing;
 
-const is_posix = builtin.os != builtin.Os.windows;
-const is_windows = builtin.os == builtin.Os.windows;
-
 const GetStdIoErrs = os.WindowsGetStdHandleErrs;
 
 pub fn getStdErr() GetStdIoErrs!File {
-    const handle = if (is_windows) try os.windowsGetStdHandle(os.windows.STD_ERROR_HANDLE) else if (is_posix) os.posix.STDERR_FILENO else unreachable;
+    const handle = if (os.is_windows) try os.windowsGetStdHandle(os.windows.STD_ERROR_HANDLE) else if (os.is_posix) os.posix.STDERR_FILENO else unreachable;
     return File.openHandle(handle);
 }
 
 pub fn getStdOut() GetStdIoErrs!File {
-    const handle = if (is_windows) try os.windowsGetStdHandle(os.windows.STD_OUTPUT_HANDLE) else if (is_posix) os.posix.STDOUT_FILENO else unreachable;
+    const handle = if (os.is_windows) try os.windowsGetStdHandle(os.windows.STD_OUTPUT_HANDLE) else if (os.is_posix) os.posix.STDOUT_FILENO else unreachable;
     return File.openHandle(handle);
 }
 
 pub fn getStdIn() GetStdIoErrs!File {
-    const handle = if (is_windows) try os.windowsGetStdHandle(os.windows.STD_INPUT_HANDLE) else if (is_posix) os.posix.STDIN_FILENO else unreachable;
+    const handle = if (os.is_windows) try os.windowsGetStdHandle(os.windows.STD_INPUT_HANDLE) else if (os.is_posix) os.posix.STDIN_FILENO else unreachable;
     return File.openHandle(handle);
 }
 

--- a/std/os.zig
+++ b/std/os.zig
@@ -1,8 +1,8 @@
 const std = @import("std.zig");
 const builtin = @import("builtin");
 const Os = builtin.Os;
-const is_windows = builtin.os == Os.windows;
-const is_posix = switch (builtin.os) {
+pub const is_windows = builtin.os == Os.windows;
+pub const is_posix = switch (builtin.os) {
     builtin.Os.linux, builtin.Os.macosx, builtin.Os.freebsd, builtin.Os.netbsd => true,
     else => false,
 };
@@ -1028,7 +1028,7 @@ pub const DeleteFileError = error{
 };
 
 pub fn deleteFile(file_path: []const u8) DeleteFileError!void {
-    if (builtin.os == Os.windows) {
+    if (is_windows) {
         const file_path_w = try windows_util.sliceToPrefixedFileW(file_path);
         return deleteFileW(&file_path_w);
     } else {
@@ -2125,7 +2125,7 @@ pub const ArgIteratorWindows = struct {
 };
 
 pub const ArgIterator = struct {
-    const InnerType = if (builtin.os == Os.windows) ArgIteratorWindows else ArgIteratorPosix;
+    const InnerType = if (is_windows) ArgIteratorWindows else ArgIteratorPosix;
 
     inner: InnerType,
 
@@ -2137,7 +2137,7 @@ pub const ArgIterator = struct {
 
     /// You must free the returned memory when done.
     pub fn next(self: *ArgIterator, allocator: *Allocator) ?(NextError![]u8) {
-        if (builtin.os == Os.windows) {
+        if (is_windows) {
             return self.inner.next(allocator);
         } else {
             return mem.dupe(allocator, u8, self.inner.next() orelse return null);

--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -15,12 +15,10 @@ const LinkedList = std.LinkedList;
 const windows_util = @import("windows/util.zig");
 const maxInt = std.math.maxInt;
 
-const is_windows = builtin.os == Os.windows;
-
 pub const ChildProcess = struct {
-    pub pid: if (is_windows) void else i32,
-    pub handle: if (is_windows) windows.HANDLE else void,
-    pub thread_handle: if (is_windows) windows.HANDLE else void,
+    pub pid: if (os.is_windows) void else i32,
+    pub handle: if (os.is_windows) windows.HANDLE else void,
+    pub thread_handle: if (os.is_windows) windows.HANDLE else void,
 
     pub allocator: *mem.Allocator,
 
@@ -40,16 +38,16 @@ pub const ChildProcess = struct {
     pub stderr_behavior: StdIo,
 
     /// Set to change the user id when spawning the child process.
-    pub uid: if (is_windows) void else ?u32,
+    pub uid: if (os.is_windows) void else ?u32,
 
     /// Set to change the group id when spawning the child process.
-    pub gid: if (is_windows) void else ?u32,
+    pub gid: if (os.is_windows) void else ?u32,
 
     /// Set to change the current working directory when spawning the child process.
     pub cwd: ?[]const u8,
 
-    err_pipe: if (is_windows) void else [2]i32,
-    llnode: if (is_windows) void else LinkedList(*ChildProcess).Node,
+    err_pipe: if (os.is_windows) void else [2]i32,
+    llnode: if (os.is_windows) void else LinkedList(*ChildProcess).Node,
 
     pub const SpawnError = error{
         ProcessFdQuotaExceeded,
@@ -99,9 +97,9 @@ pub const ChildProcess = struct {
             .term = null,
             .env_map = null,
             .cwd = null,
-            .uid = if (is_windows) {} else
+            .uid = if (os.is_windows) {} else
                 null,
-            .gid = if (is_windows) {} else
+            .gid = if (os.is_windows) {} else
                 null,
             .stdin = null,
             .stdout = null,
@@ -122,7 +120,7 @@ pub const ChildProcess = struct {
 
     /// On success must call `kill` or `wait`.
     pub fn spawn(self: *ChildProcess) !void {
-        if (is_windows) {
+        if (os.is_windows) {
             return self.spawnWindows();
         } else {
             return self.spawnPosix();
@@ -136,7 +134,7 @@ pub const ChildProcess = struct {
 
     /// Forcibly terminates child process and then cleans up all resources.
     pub fn kill(self: *ChildProcess) !Term {
-        if (is_windows) {
+        if (os.is_windows) {
             return self.killWindows(1);
         } else {
             return self.killPosix();
@@ -180,7 +178,7 @@ pub const ChildProcess = struct {
 
     /// Blocks until child process terminates and then cleans up all resources.
     pub fn wait(self: *ChildProcess) !Term {
-        if (is_windows) {
+        if (os.is_windows) {
             return self.waitWindows();
         } else {
             return self.waitPosix();


### PR DESCRIPTION
Currently `is_posix` and `is_windows` is redefined throughout std. `is_posix` being defined as `builtin.os != builtin.Os.windows` in many modules is problematic. This centralizes all that in `std.os.{is_windows,is_posix}` and lays the groundwork to define `std.os.is_wasi`.