### PR TITLE
Stack unwinding for the masses

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -388,7 +388,7 @@ static LLVMCallConv get_llvm_cc(CodeGen *g, CallingConvention cc) {
 }
 
 static void add_uwtable_attr(CodeGen *g, LLVMValueRef fn_val) {
-    if (g->zig_target->os == OsWindows) {
+    if (g->zig_target->os == OsLinux || g->zig_target->os == OsWindows) {
         addLLVMFnAttr(fn_val, "uwtable");
     }
 }

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -900,7 +900,7 @@ static void construct_linker_job_elf(LinkJob *lj) {
     CodeGen *g = lj->codegen;
 
     // Emit the eh_frame_hdr section beside the usual eh_frame. This is needed
-    // for libunwinder to detect the section in the ELF binary.
+    // for libunwind to detect the section in the ELF binary.
     lj->args.append("--eh-frame-hdr");
     lj->args.append("-error-limit=0");
 

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -899,6 +899,9 @@ static void add_rpath(LinkJob *lj, Buf *rpath) {
 static void construct_linker_job_elf(LinkJob *lj) {
     CodeGen *g = lj->codegen;
 
+    // Emit the eh_frame_hdr section beside the usual eh_frame. This is needed
+    // for libunwinder to detect the section in the ELF binary.
+    lj->args.append("--eh-frame-hdr");
     lj->args.append("-error-limit=0");
 
     if (g->linker_script) {

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -129,6 +129,7 @@ static const char *build_libunwind(CodeGen *parent) {
                 break;
             case SrcCpp:
                 c_file->args.append("-fno-rtti");
+                c_file->args.append("-fno-exceptions");
                 c_file->args.append("-I");
                 c_file->args.append(path_from_zig_lib(parent, "libcxx", "include"));
                 break;


### PR DESCRIPTION
### TLDR

Backtraces are now fully functional in release mode! :tada: 

Since the stack-walking strategy is not that reliable and since libunwind is always (? or most of the times? I didn't figure out that yet) linked in anyway why not use it?

This brief weekend project is my first attempt at writing some Zig code so please bear with me if the code is not that nice.

You may ask why I didn't roll my own unwinder... well I've got halfway trough (the whole `eh_frame` was perfectly parsed and all the opcodes executed) when all of a sudden I've realized that using libunwind would've been a better use of my time.

At the moment it's only been enabled for linux but should work pretty well on Apple's systems and/or BSDs, YMMV of course.

