### PR TITLE
Support wasm module imports

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -495,6 +495,14 @@ static LLVMValueRef fn_llvm_value(CodeGen *g, ZigFn *fn_table_entry) {
             auto entry = g->exported_symbol_names.maybe_get(symbol_name);
             if (entry == nullptr) {
                 fn_table_entry->llvm_value = LLVMAddFunction(g->module, buf_ptr(symbol_name), fn_llvm_type);
+
+                if (target_is_wasm(g->zig_target)) {
+                    assert(fn_table_entry->proto_node->type == NodeTypeFnProto);
+                    AstNodeFnProto *fn_proto = &fn_table_entry->proto_node->data.fn_proto;
+                    if (fn_proto-> is_extern && fn_proto->lib_name != nullptr ) {
+                        addLLVMFnAttrStr(fn_table_entry->llvm_value, "wasm-import-module", buf_ptr(fn_proto->lib_name));
+                    }
+                }
             } else {
                 assert(entry->value->id == TldIdFn);
                 TldFn *tld_fn = reinterpret_cast<TldFn *>(entry->value);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -15828,13 +15828,6 @@ static void add_link_lib_symbol(IrAnalyze *ira, Buf *lib_name, Buf *symbol_name,
         ira->codegen->reported_bad_link_libc_error = true;
     }
 
-    bool is_wasi = buf_eql_str(lib_name, "wasi");
-    if (is_wasi && ira->codegen->zig_target->os != OsWASI) {
-        ir_add_error_node(ira, source_node,
-            buf_sprintf("linking against wasi library"));
-        ira->codegen->reported_bad_link_libc_error = true;
-    }
-
     LinkLib *link_lib = add_link_lib(ira->codegen, lib_name);
     for (size_t i = 0; i < link_lib->symbols.length; i += 1) {
         Buf *existing_symbol_name = link_lib->symbols.at(i);
@@ -15843,7 +15836,7 @@ static void add_link_lib_symbol(IrAnalyze *ira, Buf *lib_name, Buf *symbol_name,
         }
     }
 
-    if (!is_libc && !is_wasi && !ira->codegen->have_pic && !ira->codegen->reported_bad_link_libc_error) {
+    if (!is_libc && !target_is_wasm(ira->codegen->zig_target) && !ira->codegen->have_pic && !ira->codegen->reported_bad_link_libc_error) {
         ErrorMsg *msg = ir_add_error_node(ira, source_node,
             buf_sprintf("dependency on dynamic library '%s' requires enabling Position Independent Code",
                 buf_ptr(lib_name)));


### PR DESCRIPTION
Adds the `wasm-import-module` attribute to `extern` functions if the target is WASI.

This also removes the WASI specific linking error and instead allows wasm targets to have arbitrary extern libs.

Fixes #2274 