### PR TITLE
wasi: remove __wasi prefix and switch to "wasi_unstable" module

### DIFF
--- a/std/os/wasi.zig
+++ b/std/os/wasi.zig
@@ -92,17 +92,17 @@ pub fn getErrno(r: usize) usize {
 }
 
 pub fn exit(status: i32) noreturn {
-    __wasi_proc_exit(@bitCast(__wasi_exitcode_t, isize(status)));
+    proc_exit(@bitCast(exitcode_t, isize(status)));
 }
 
 pub fn write(fd: i32, buf: [*]const u8, count: usize) usize {
     var nwritten: usize = undefined;
 
-    const iovs = []__wasi_ciovec_t{__wasi_ciovec_t{
+    const iovs = []ciovec_t{ciovec_t{
         .buf = buf,
         .buf_len = count,
     }};
 
-    _ = __wasi_fd_write(@bitCast(__wasi_fd_t, isize(fd)), &iovs[0], iovs.len, &nwritten);
+    _ = fd_write(@bitCast(fd_t, isize(fd)), &iovs[0], iovs.len, &nwritten);
     return nwritten;
 }

--- a/std/os/wasi/core.zig
+++ b/std/os/wasi/core.zig
@@ -1,17 +1,17 @@
-pub const __wasi_errno_t = u16;
-pub const __wasi_exitcode_t = u32;
-pub const __wasi_fd_t = u32;
-pub const __wasi_signal_t = u8;
+pub const errno_t = u16;
+pub const exitcode_t = u32;
+pub const fd_t = u32;
+pub const signal_t = u8;
 
-pub const __wasi_ciovec_t = extern struct {
+pub const ciovec_t = extern struct {
     buf: [*]const u8,
     buf_len: usize,
 };
 
-pub const __WASI_SIGABRT: __wasi_signal_t = 6;
+pub const SIGABRT: signal_t = 6;
 
-pub extern "wasi" fn __wasi_proc_raise(sig: __wasi_signal_t) __wasi_errno_t;
+pub extern "wasi_unstable" fn proc_raise(sig: signal_t) errno_t;
 
-pub extern "wasi" fn __wasi_proc_exit(rval: __wasi_exitcode_t) noreturn;
+pub extern "wasi_unstable" fn proc_exit(rval: exitcode_t) noreturn;
 
-pub extern "wasi" fn __wasi_fd_write(fd: __wasi_fd_t, iovs: *const __wasi_ciovec_t, iovs_len: usize, nwritten: *usize) __wasi_errno_t;
+pub extern "wasi_unstable" fn fd_write(fd: fd_t, iovs: *const ciovec_t, iovs_len: usize, nwritten: *usize) errno_t;

--- a/std/special/bootstrap.zig
+++ b/std/special/bootstrap.zig
@@ -21,7 +21,7 @@ comptime {
 
 nakedcc fn _start() noreturn {
     if (builtin.os == builtin.Os.wasi) {
-        std.os.wasi.__wasi_proc_exit(callMain());
+        std.os.wasi.proc_exit(callMain());
     }
 
     switch (builtin.arch) {

--- a/std/special/panic.zig
+++ b/std/special/panic.zig
@@ -15,7 +15,7 @@ pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn
         },
         builtin.Os.wasi => {
             std.debug.warn("{}", msg);
-            _ = std.os.wasi.__wasi_proc_raise(std.os.wasi.__WASI_SIGABRT);
+            _ = std.os.wasi.proc_raise(std.os.wasi.SIGABRT);
             unreachable;
         },
         builtin.Os.uefi => {


### PR DESCRIPTION
Now that #2274 is passed, we can use the "wasi_unstable" module instead of the prefixed functions. Once wasi is standardized, we'll switch to "wasi" module.