### PR TITLE
WasmAllocator: WebAssembly Memory Allocator 

### DIFF
--- a/std/heap.zig
+++ b/std/heap.zig
@@ -366,8 +366,6 @@ pub const WasmAllocator = struct {
         const result = self.start_ptr[adjusted_index..new_end_index];
         self.end_index = new_end_index;
 
-
-
         return result;
     }
 


### PR DESCRIPTION
This is a simple memory allocator based on the FixedBufferAllocator. It instead uses the "llvm.wasm.memory.grow.i32" intrinsic when the allocated memory is full. The is_last_item heuristic works really well here as WASM memory is linear and can only grow on one end.