### PR TITLE
Don't install stage2 artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,16 @@ endif()
 
 set(ZIG_CPP_LIB_DIR "${CMAKE_BINARY_DIR}/zig_cpp")
 
+# Handle multi-config builds and place each into a common lib. The VS generator
+# for example will append a Debug folder by default if not explicitly specified.
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${ZIG_CPP_LIB_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${ZIG_CPP_LIB_DIR})
+foreach(CONFIG_TYPE ${CMAKE_CONFIGURATION_TYPES})
+    string(TOUPPER ${CONFIG_TYPE} CONFIG_TYPE)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${CONFIG_TYPE} ${ZIG_CPP_LIB_DIR})
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${CONFIG_TYPE} ${ZIG_CPP_LIB_DIR})
+endforeach(CONFIG_TYPE CMAKE_CONFIGURATION_TYPES)
+
 if(ZIG_FORCE_EXTERNAL_LLD)
     find_package(lld)
     include_directories(${LLVM_INCLUDE_DIRS})
@@ -257,7 +267,6 @@ else()
         embedded_lld_wasm
         embedded_lld_lib
     )
-    install(TARGETS embedded_lld_elf embedded_lld_coff embedded_lld_mingw embedded_lld_wasm embedded_lld_lib DESTINATION "${ZIG_CPP_LIB_DIR}")
 endif()
 
 # No patches have been applied to SoftFloat-3e

--- a/ci/azure/windows_upload
+++ b/ci/azure/windows_upload
@@ -6,7 +6,7 @@ set -e
 if [ "${BUILD_REASON}" != "PullRequest" ]; then
   cd "$ZIGBUILDDIR"
 
-  rm release/*.lib release/*.exe
+  rm release/*.exe
   mv ../LICENSE release/
   mv ../zig-cache/langref.html release/
   mv release/bin/zig.exe release/


### PR DESCRIPTION
We rely on the fact that libraries are installed to the cmake build
directory by default. The stage2 install works as per normal with these
changes.

Fixes #2220.