### PR TITLE
Fix test in langref to assert against modified var

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3128,7 +3128,7 @@ test "while null capture" {
     while (eventuallyNullSequence()) |value| {
         sum2 += value;
     } else {
-        assert(sum1 == 3);
+        assert(sum2 == 3);
     }
 }
 


### PR DESCRIPTION
Looks like we should be checking the second modification instead of the first (unchanged) variable again.

Is there a zig warning for "variable modified but not read?" It would catch lingering copy/paste situations like this.