### PR TITLE
zig-fmt: allow comptime blocks in containers

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2118,6 +2118,21 @@ test "zig fmt: error return" {
     );
 }
 
+test "zig fmt: comptime block in container" {
+    try testCanonical(
+        \\pub fn container() type {
+        \\    return struct {
+        \\        comptime {
+        \\            if (false) {
+        \\                unreachable;
+        \\            }
+        \\        }
+        \\    };
+        \\}
+        \\
+    );
+}
+
 const std = @import("std");
 const mem = std.mem;
 const warn = std.debug.warn;


### PR DESCRIPTION
For issue #2260 

The strategy for handling comptime blocks in a container seems to be the same as handling them at top level.

The issue also mentions top level fields which I'm going to take a look at now and probably submit as a separate pull request.

Meanwhile, this solution was surprisingly simple, so let me know if I missed something.