### PR TITLE
Move FailingAllocator deallocation count increment

### DIFF
--- a/std/debug/failing_allocator.zig
+++ b/std/debug/failing_allocator.zig
@@ -44,7 +44,6 @@ pub const FailingAllocator = struct {
         } else {
             self.allocated_bytes += new_size - old_mem.len;
         }
-        self.deallocations += 1;
         self.index += 1;
         return result;
     }
@@ -52,6 +51,7 @@ pub const FailingAllocator = struct {
     fn shrink(allocator: *mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         const self = @fieldParentPtr(FailingAllocator, "allocator", allocator);
         self.freed_bytes += old_mem.len - new_size;
+        self.deallocations += 1;
         return self.internal_allocator.shrinkFn(self.internal_allocator, old_mem, old_align, new_size, new_align);
     }
 };


### PR DESCRIPTION
**Note:** I'm not 100% certain that this is the correct solution, though I'm pretty sure that the current behavior is unintended, and this addresses that. I know that @andrewrk is super busy right now, so I thought opening this up for review would be better than nagging on IRC.

- If this is the correct solution, I can add a test block in `failing_allocator.zig` — there currently are none.
- If `deallocations` should also be incremented whenever space shrinks in `reallocFn`, I can update that.
- If the current behavior is in fact intended, please feel free to close!

---

The mem.Allocator interface was changed in 9c13e9b. FailingAllocator (along with other implementations) was updated accordingly, but its `deallocations` increment was removed from what is now `shrinkFn`. The result is that `index` and `deallocations` are always equal, both incremented inside `reallocFn`, and no deallocations are recorded on calls to `shrinkFn`. This change addresses that issue.

Note that currently, the only reference to FailingAllocator's `deallocations` field in the standard library is in std/zig/parser_test.zig.