### PR TITLE
fix heap allocators when shrinking an object but growing its alignment

### DIFF
--- a/std/heap.zig
+++ b/std/heap.zig
@@ -609,7 +609,7 @@ test "ArenaAllocator" {
     try testAllocatorAlignedShrink(&arena_allocator.allocator);
 }
 
-var test_fixed_buffer_allocator_memory: [30000 * @sizeOf(usize)]u8 = undefined;
+var test_fixed_buffer_allocator_memory: [40000 * @sizeOf(usize)]u8 = undefined;
 test "FixedBufferAllocator" {
     var fixed_buffer_allocator = FixedBufferAllocator.init(test_fixed_buffer_allocator_memory[0..]);
 


### PR DESCRIPTION
This is the same fix as https://github.com/andrewrk/zig-general-purpose-allocator/pull/3 but for the std heap allocators.

Before the changes in this PR, the added test case would fail for each of the allocators with a stack trace like:

```
Test 3/6 ArenaAllocator...reached unreachable code
/home/ryan/Programming/zig/zig/build/lib/zig/std/debug.zig:169:14: 0x20402c in ??? (test)
    if (!ok) unreachable; // assertion failure
             ^
/home/ryan/Programming/zig/zig/build/lib/zig/std/mem.zig:231:11: 0x20bb05 in ??? (test)
    assert(dest.len >= source.len);
          ^
/home/ryan/Programming/zig/zig/build/lib/zig/std/heap.zig:258:25: 0x2099d3 in ??? (test)
                mem.copy(u8, result, old_mem);
                        ^
```