### PR TITLE
translate-c: emit alignCast when casting pointers

### DIFF
--- a/src/translate_c.cpp
+++ b/src/translate_c.cpp
@@ -709,15 +709,24 @@ static AstNode* trans_c_cast(Context *c, ZigClangSourceLocation source_location,
         return expr;
     }
     if (qual_type_is_ptr(dest_type) && qual_type_is_ptr(src_type)) {
-        AstNode *align_of_node = trans_create_node_builtin_fn_call_str(c, "alignOf");
-        align_of_node->data.fn_call_expr.params.append(trans_qual_type(c, dest_type, source_location));
-        AstNode *align_cast_node = trans_create_node_builtin_fn_call_str(c, "alignCast");
-        align_cast_node->data.fn_call_expr.params.append(align_of_node);
-        align_cast_node->data.fn_call_expr.params.append(expr);     
-        AstNode *ptr_cast_node = trans_create_node_builtin_fn_call_str(c, "ptrCast");
-        ptr_cast_node->data.fn_call_expr.params.append(trans_qual_type(c, dest_type, source_location));
-        ptr_cast_node->data.fn_call_expr.params.append(align_cast_node);
-        return ptr_cast_node;
+        unsigned int src_align = ZigClangASTContext_getTypeAlignIfKnown(c->ctx, src_type);
+        unsigned int dest_align = ZigClangASTContext_getTypeAlignIfKnown(c->ctx, dest_type);
+        if (src_align < dest_align) {
+            AstNode *align_of_node = trans_create_node_builtin_fn_call_str(c, "alignOf");
+            align_of_node->data.fn_call_expr.params.append(trans_qual_type(c, dest_type, source_location));
+            AstNode *align_cast_node = trans_create_node_builtin_fn_call_str(c, "alignCast");
+            align_cast_node->data.fn_call_expr.params.append(align_of_node);
+            align_cast_node->data.fn_call_expr.params.append(expr);     
+            AstNode *ptr_cast_node = trans_create_node_builtin_fn_call_str(c, "ptrCast");
+            ptr_cast_node->data.fn_call_expr.params.append(trans_qual_type(c, dest_type, source_location));
+            ptr_cast_node->data.fn_call_expr.params.append(align_cast_node);
+            return ptr_cast_node;   
+        } else {
+            AstNode *ptr_cast_node = trans_create_node_builtin_fn_call_str(c, "ptrCast");
+            ptr_cast_node->data.fn_call_expr.params.append(trans_qual_type(c, dest_type, source_location));
+            ptr_cast_node->data.fn_call_expr.params.append(expr);
+            return ptr_cast_node;
+        }
     }
     // TODO: maybe widen to increase size
     // TODO: maybe bitcast to change sign
@@ -4745,16 +4754,9 @@ static AstNode *parse_ctok_primary_expr(Context *c, CTokenize *ctok, size_t *tok
                 inner_if_then->data.fn_call_expr.params.append(node_to_cast);
                 AstNode *inner_if_else = trans_create_node_cast(c, inner_node, node_to_cast);
                 AstNode *inner_if = trans_create_node_if(c, inner_if_cond, inner_if_then, inner_if_else);
-
-                AstNode *align_of_node = trans_create_node_builtin_fn_call_str(c, "alignOf");
-                align_of_node->data.fn_call_expr.params.append(inner_node);
-                AstNode *align_cast_node = trans_create_node_builtin_fn_call_str(c, "alignCast");
-                align_cast_node->data.fn_call_expr.params.append(align_of_node);
-                align_cast_node->data.fn_call_expr.params.append(node_to_cast);     
                 AstNode *outer_if_then = trans_create_node_builtin_fn_call_str(c, "ptrCast");
                 outer_if_then->data.fn_call_expr.params.append(inner_node);
-                outer_if_then->data.fn_call_expr.params.append(align_cast_node);
-                
+                outer_if_then->data.fn_call_expr.params.append(node_to_cast);
                 return trans_create_node_if(c, outer_if_cond, outer_if_then, inner_if);
             }
         case CTokIdDot:

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -870,6 +870,10 @@ ZigClangQualType ZigClangASTContext_getPointerType(const ZigClangASTContext* sel
     return bitcast(reinterpret_cast<const clang::ASTContext *>(self)->getPointerType(bitcast(T)));
 }
 
+unsigned ZigClangASTContext_getTypeAlignIfKnown(const ZigClangASTContext* self, ZigClangQualType T) {
+    return reinterpret_cast<const clang::ASTContext *>(self)->getTypeAlignIfKnown(bitcast(T));
+}
+
 ZigClangASTContext *ZigClangASTUnit_getASTContext(ZigClangASTUnit *self) {
     clang::ASTContext *result = &reinterpret_cast<clang::ASTUnit *>(self)->getASTContext();
     return reinterpret_cast<ZigClangASTContext *>(result);

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -498,6 +498,7 @@ ZIG_EXTERN_C const char* ZigClangSourceManager_getCharacterData(const ZigClangSo
         ZigClangSourceLocation SL);
 
 ZIG_EXTERN_C ZigClangQualType ZigClangASTContext_getPointerType(const ZigClangASTContext*, ZigClangQualType T);
+ZIG_EXTERN_C unsigned ZigClangASTContext_getTypeAlignIfKnown(const ZigClangASTContext* self, ZigClangQualType T);
 
 ZIG_EXTERN_C ZigClangASTContext *ZigClangASTUnit_getASTContext(ZigClangASTUnit *);
 ZIG_EXTERN_C ZigClangSourceManager *ZigClangASTUnit_getSourceManager(ZigClangASTUnit *);


### PR DESCRIPTION
This small patch makes all pointer casts include an align cast as well. This isn't great, but I haven't quite worked out how to work out when they're needed. Tests still need to be changed.

Is there a simple way of running only the translate-c tests?