### PR TITLE
Add sendmmsg syscall wrapper

### DIFF
--- a/std/c/freebsd.zig
+++ b/std/c/freebsd.zig
@@ -58,6 +58,23 @@ pub const msghdr = extern struct {
     msg_flags: i32,
 };
 
+pub const msghdr_const = extern struct {
+    /// optional address
+    msg_name: ?*const sockaddr,
+    /// size of address
+    msg_namelen: socklen_t,
+    /// scatter/gather array
+    msg_iov: [*]iovec_const,
+    /// # elements in msg_iov
+    msg_iovlen: i32,
+    /// ancillary data
+    msg_control: ?*c_void,
+    /// ancillary data buffer len
+    msg_controllen: socklen_t,
+    /// flags on received message
+    msg_flags: i32,
+};
+
 pub const Stat = extern struct {
     dev: u64,
     ino: u64,

--- a/std/c/freebsd.zig
+++ b/std/c/freebsd.zig
@@ -42,14 +42,19 @@ pub const pthread_attr_t = extern struct {
 };
 
 pub const msghdr = extern struct {
-    msg_name: *u8,
+    /// optional address
+    msg_name: ?*sockaddr,
+    /// size of address
     msg_namelen: socklen_t,
-    msg_iov: *iovec,
+    /// scatter/gather array
+    msg_iov: [*]iovec,
+    /// # elements in msg_iov
     msg_iovlen: i32,
-    __pad1: i32,
-    msg_control: *u8,
+    /// ancillary data
+    msg_control: ?*c_void,
+    /// ancillary data buffer len
     msg_controllen: socklen_t,
-    __pad2: socklen_t,
+    /// flags on received message
     msg_flags: i32,
 };
 

--- a/std/c/netbsd.zig
+++ b/std/c/netbsd.zig
@@ -42,14 +42,19 @@ pub const pthread_attr_t = extern struct {
 };
 
 pub const msghdr = extern struct {
-    msg_name: *u8,
+    /// optional address
+    msg_name: ?*sockaddr,
+    /// size of address
     msg_namelen: socklen_t,
-    msg_iov: *iovec,
+    /// scatter/gather array
+    msg_iov: [*]iovec,
+    /// # elements in msg_iov
     msg_iovlen: i32,
-    __pad1: i32,
-    msg_control: *u8,
+    /// ancillary data
+    msg_control: ?*c_void,
+    /// ancillary data buffer len
     msg_controllen: socklen_t,
-    __pad2: socklen_t,
+    /// flags on received message
     msg_flags: i32,
 };
 

--- a/std/c/netbsd.zig
+++ b/std/c/netbsd.zig
@@ -58,6 +58,23 @@ pub const msghdr = extern struct {
     msg_flags: i32,
 };
 
+pub const msghdr_const = extern struct {
+    /// optional address
+    msg_name: ?*const sockaddr,
+    /// size of address
+    msg_namelen: socklen_t,
+    /// scatter/gather array
+    msg_iov: [*]iovec_const,
+    /// # elements in msg_iov
+    msg_iovlen: i32,
+    /// ancillary data
+    msg_control: ?*c_void,
+    /// ancillary data buffer len
+    msg_controllen: socklen_t,
+    /// flags on received message
+    msg_flags: i32,
+};
+
 pub const Stat = extern struct {
     dev: u64,
     mode: u32,

--- a/std/os/linux.zig
+++ b/std/os/linux.zig
@@ -1213,7 +1213,7 @@ pub fn getsockopt(fd: i32, level: u32, optname: u32, noalias optval: [*]u8, noal
     return syscall5(SYS_getsockopt, @bitCast(usize, isize(fd)), level, optname, @ptrToInt(optval), @ptrToInt(optlen));
 }
 
-pub fn sendmsg(fd: i32, msg: *const msghdr, flags: u32) usize {
+pub fn sendmsg(fd: i32, msg: *msghdr_const, flags: u32) usize {
     return syscall3(SYS_sendmsg, @bitCast(usize, isize(fd)), @ptrToInt(msg), flags);
 }
 

--- a/std/os/linux/arm64.zig
+++ b/std/os/linux/arm64.zig
@@ -415,12 +415,12 @@ pub fn syscall6(
 pub extern fn clone(func: extern fn (arg: usize) u8, stack: usize, flags: u32, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;
 
 pub const msghdr = extern struct {
-    msg_name: *u8,
+    msg_name: ?*sockaddr,
     msg_namelen: socklen_t,
-    msg_iov: *iovec,
+    msg_iov: [*]iovec,
     msg_iovlen: i32,
     __pad1: i32,
-    msg_control: *u8,
+    msg_control: ?*c_void,
     msg_controllen: socklen_t,
     __pad2: socklen_t,
     msg_flags: i32,

--- a/std/os/linux/arm64.zig
+++ b/std/os/linux/arm64.zig
@@ -2,6 +2,7 @@ const std = @import("../../std.zig");
 const linux = std.os.linux;
 const socklen_t = linux.socklen_t;
 const iovec = linux.iovec;
+const iovec_const = linux.iovec_const;
 
 pub const SYS_io_setup = 0;
 pub const SYS_io_destroy = 1;
@@ -418,6 +419,18 @@ pub const msghdr = extern struct {
     msg_name: ?*sockaddr,
     msg_namelen: socklen_t,
     msg_iov: [*]iovec,
+    msg_iovlen: i32,
+    __pad1: i32,
+    msg_control: ?*c_void,
+    msg_controllen: socklen_t,
+    __pad2: socklen_t,
+    msg_flags: i32,
+};
+
+pub const msghdr_const = extern struct {
+    msg_name: ?*const sockaddr,
+    msg_namelen: socklen_t,
+    msg_iov: [*]iovec_const,
     msg_iovlen: i32,
     __pad1: i32,
     msg_control: ?*c_void,

--- a/std/os/linux/x86_64.zig
+++ b/std/os/linux/x86_64.zig
@@ -1,5 +1,6 @@
 const std = @import("../../std.zig");
 const linux = std.os.linux;
+const sockaddr = linux.sockaddr;
 const socklen_t = linux.socklen_t;
 const iovec = linux.iovec;
 
@@ -483,12 +484,12 @@ pub nakedcc fn restore_rt() void {
 }
 
 pub const msghdr = extern struct {
-    msg_name: *u8,
+    msg_name: ?*sockaddr,
     msg_namelen: socklen_t,
-    msg_iov: *iovec,
+    msg_iov: [*]iovec,
     msg_iovlen: i32,
     __pad1: i32,
-    msg_control: *u8,
+    msg_control: ?*c_void,
     msg_controllen: socklen_t,
     __pad2: socklen_t,
     msg_flags: i32,

--- a/std/os/linux/x86_64.zig
+++ b/std/os/linux/x86_64.zig
@@ -3,6 +3,7 @@ const linux = std.os.linux;
 const sockaddr = linux.sockaddr;
 const socklen_t = linux.socklen_t;
 const iovec = linux.iovec;
+const iovec_const = linux.iovec_const;
 
 pub const SYS_read = 0;
 pub const SYS_write = 1;
@@ -487,6 +488,18 @@ pub const msghdr = extern struct {
     msg_name: ?*sockaddr,
     msg_namelen: socklen_t,
     msg_iov: [*]iovec,
+    msg_iovlen: i32,
+    __pad1: i32,
+    msg_control: ?*c_void,
+    msg_controllen: socklen_t,
+    __pad2: socklen_t,
+    msg_flags: i32,
+};
+
+pub const msghdr_const = extern struct {
+    msg_name: ?*const sockaddr,
+    msg_namelen: socklen_t,
+    msg_iov: [*]iovec_const,
     msg_iovlen: i32,
     __pad1: i32,
     msg_control: ?*c_void,


### PR DESCRIPTION
Includes some cleanups of `msghdr` definition.

Open questions:
  - is working around kernel bugs/oddities in syscall wrappers as I've done expected/wanted?
  - having e.g. both `iovec` and `iovec_const`; both `msghdr` and `msghdr_const` gets messy. What can the zig language do to make this less annoying?



Tested with this snippet:
```zig
test "sendmmsg" {
    const fd = try std.os.posixSocket(linux.AF_INET, linux.SOCK_DGRAM, 0);
    defer std.os.close(fd);

    std.debug.warn("sendmmsg {}\n", linux.sendmmsg(fd, &[]linux.mmsghdr_const{}, 0, 0));

    const name = std.net.Address.initIp4(try std.net.parseIp4("192.0.2.1"), 80).os_addr; // part of TEST-NET-1 see RFC 5737
    const namelen = @sizeOf(linux.sockaddr_in);

    const iovecs1 = []linux.iovec_const{linux.iovec_const{ .iov_base = &"hello", .iov_len = 2 }};
    const iovecs2 = blk: {
        const mmap_len = 1<<30;
        const mmap_addr = linux.mmap(null, mmap_len, linux.PROT_READ, linux.MAP_PRIVATE | linux.MAP_ANONYMOUS, -1, 0);
        if (mmap_addr == linux.MAP_FAILED) unreachable;
        const mmap_ptr = @intToPtr([*]u8, mmap_addr);
        break :blk []linux.iovec_const{
            linux.iovec_const{ .iov_base = mmap_ptr, .iov_len = mmap_len },
            linux.iovec_const{ .iov_base = mmap_ptr, .iov_len = mmap_len },
            linux.iovec_const{ .iov_base = mmap_ptr, .iov_len = mmap_len },
        };
    };
    const iovecs3 = []linux.iovec_const{linux.iovec_const{ .iov_base = &("world"**(1<<20)), .iov_len = 5*(1<<20) }};
    const msgvec = []linux.mmsghdr_const{
        linux.mmsghdr_const{
            .msg_hdr = linux.msghdr_const{
                .msg_name = &name,
                .msg_namelen = namelen,
                .msg_iov = &iovecs1,
                .msg_iovlen = iovecs1.len,
                .__pad1 = 0,
                .msg_control = null,
                .msg_controllen = 0,
                .__pad2 = 0,
                .msg_flags = 0,
            },
            .msg_len = undefined,
        },
        linux.mmsghdr_const{
            .msg_hdr = linux.msghdr_const{
                .msg_name = &name,
                .msg_namelen = namelen,
                .msg_iov = &iovecs2,
                .msg_iovlen = iovecs2.len,
                .__pad1 = 0,
                .msg_control = null,
                .msg_controllen = 0,
                .__pad2 = 0,
                .msg_flags = 0,
            },
            .msg_len = undefined,
        },
        linux.mmsghdr_const{
            .msg_hdr = linux.msghdr_const{
                .msg_name = &name,
                .msg_namelen = namelen,
                .msg_iov = &iovecs3,
                .msg_iovlen = iovecs3.len,
                .__pad1 = 0,
                .msg_control = null,
                .msg_controllen = 0,
                .__pad2 = 0,
                .msg_flags = 0,
            },
            .msg_len = undefined,
        },
    };
    std.debug.warn("sendmmsg {}\n", linux.sendmmsg(fd, &msgvec, msgvec.len, 0));
}
```