### PR TITLE
Fix crash due to command line argument parsing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -785,7 +785,11 @@ int main(int argc, char **argv) {
                         if (argv[i][0] == '-') {
                             c_file->args.append(argv[i]);
                             i += 1;
-                            continue;
+                            if (i < argc) {
+                                continue;
+                            }
+
+                            break;
                         } else {
                             c_file->source_path = argv[i];
                             c_source_files.append(c_file);


### PR DESCRIPTION
zig --help -> ok
zig --help --c-source -> ok
zig --c-source --help -> crash [fixed]

'i' was being incremented without regard for the 'argc' limit, so
we were running off the end of 'argv'.