### PR TITLE
beginnings of implementing translate-c in userland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,6 +508,7 @@ set(ZIG_STD_FILES
     "heap.zig"
     "io.zig"
     "io/seekable_stream.zig"
+    "io/c_out_stream.zig"
     "json.zig"
     "lazy_init.zig"
     "linked_list.zig"

--- a/src-self-hosted/clang.zig
+++ b/src-self-hosted/clang.zig
@@ -959,3 +959,11 @@ pub const Stage2ErrorMsg = extern struct {
     offset: c_uint,
 };
 pub extern fn ZigClangErrorMsg_delete(ptr: [*c]Stage2ErrorMsg, len: usize) void;
+
+pub extern fn ZigClangLoadFromCommandLine(
+    args_begin: [*]?[*]const u8,
+    args_end: [*]?[*]const u8,
+    errors_ptr: *[*]Stage2ErrorMsg,
+    errors_len: *usize,
+    resources_path: [*c]const u8,
+) ?*ZigClangASTUnit;

--- a/src-self-hosted/clang.zig
+++ b/src-self-hosted/clang.zig
@@ -1,0 +1,944 @@
+pub const struct_ZigClangAPValue = @OpaqueType();
+pub const struct_ZigClangAPSInt = @OpaqueType();
+pub const struct_ZigClangASTContext = @OpaqueType();
+pub const struct_ZigClangASTUnit = @OpaqueType();
+pub const struct_ZigClangArraySubscriptExpr = @OpaqueType();
+pub const struct_ZigClangArrayType = @OpaqueType();
+pub const struct_ZigClangAttributedType = @OpaqueType();
+pub const struct_ZigClangBinaryOperator = @OpaqueType();
+pub const struct_ZigClangBreakStmt = @OpaqueType();
+pub const struct_ZigClangBuiltinType = @OpaqueType();
+pub const struct_ZigClangCStyleCastExpr = @OpaqueType();
+pub const struct_ZigClangCallExpr = @OpaqueType();
+pub const struct_ZigClangCaseStmt = @OpaqueType();
+pub const struct_ZigClangCompoundAssignOperator = @OpaqueType();
+pub const struct_ZigClangCompoundStmt = @OpaqueType();
+pub const struct_ZigClangConditionalOperator = @OpaqueType();
+pub const struct_ZigClangConstantArrayType = @OpaqueType();
+pub const struct_ZigClangContinueStmt = @OpaqueType();
+pub const struct_ZigClangDecayedType = @OpaqueType();
+pub const struct_ZigClangDecl = @OpaqueType();
+pub const struct_ZigClangDeclRefExpr = @OpaqueType();
+pub const struct_ZigClangDeclStmt = @OpaqueType();
+pub const struct_ZigClangDefaultStmt = @OpaqueType();
+pub const struct_ZigClangDiagnosticOptions = @OpaqueType();
+pub const struct_ZigClangDiagnosticsEngine = @OpaqueType();
+pub const struct_ZigClangDoStmt = @OpaqueType();
+pub const struct_ZigClangElaboratedType = @OpaqueType();
+pub const struct_ZigClangEnumConstantDecl = @OpaqueType();
+pub const struct_ZigClangEnumDecl = @OpaqueType();
+pub const struct_ZigClangEnumType = @OpaqueType();
+pub const struct_ZigClangExpr = @OpaqueType();
+pub const struct_ZigClangFieldDecl = @OpaqueType();
+pub const struct_ZigClangFileID = @OpaqueType();
+pub const struct_ZigClangForStmt = @OpaqueType();
+pub const struct_ZigClangFullSourceLoc = @OpaqueType();
+pub const struct_ZigClangFunctionDecl = @OpaqueType();
+pub const struct_ZigClangFunctionProtoType = @OpaqueType();
+pub const struct_ZigClangIfStmt = @OpaqueType();
+pub const struct_ZigClangImplicitCastExpr = @OpaqueType();
+pub const struct_ZigClangIncompleteArrayType = @OpaqueType();
+pub const struct_ZigClangIntegerLiteral = @OpaqueType();
+pub const struct_ZigClangMacroDefinitionRecord = @OpaqueType();
+pub const struct_ZigClangMemberExpr = @OpaqueType();
+pub const struct_ZigClangNamedDecl = @OpaqueType();
+pub const struct_ZigClangNone = @OpaqueType();
+pub const struct_ZigClangPCHContainerOperations = @OpaqueType();
+pub const struct_ZigClangParenExpr = @OpaqueType();
+pub const struct_ZigClangParenType = @OpaqueType();
+pub const struct_ZigClangParmVarDecl = @OpaqueType();
+pub const struct_ZigClangPointerType = @OpaqueType();
+pub const struct_ZigClangPreprocessedEntity = @OpaqueType();
+pub const struct_ZigClangRecordDecl = @OpaqueType();
+pub const struct_ZigClangRecordType = @OpaqueType();
+pub const struct_ZigClangReturnStmt = @OpaqueType();
+pub const struct_ZigClangSkipFunctionBodiesScope = @OpaqueType();
+pub const struct_ZigClangSourceManager = @OpaqueType();
+pub const struct_ZigClangSourceRange = @OpaqueType();
+pub const struct_ZigClangStmt = @OpaqueType();
+pub const struct_ZigClangStorageClass = @OpaqueType();
+pub const struct_ZigClangStringLiteral = @OpaqueType();
+pub const struct_ZigClangStringRef = @OpaqueType();
+pub const struct_ZigClangSwitchStmt = @OpaqueType();
+pub const struct_ZigClangTagDecl = @OpaqueType();
+pub const struct_ZigClangType = @OpaqueType();
+pub const struct_ZigClangTypedefNameDecl = @OpaqueType();
+pub const struct_ZigClangTypedefType = @OpaqueType();
+pub const struct_ZigClangUnaryExprOrTypeTraitExpr = @OpaqueType();
+pub const struct_ZigClangUnaryOperator = @OpaqueType();
+pub const struct_ZigClangValueDecl = @OpaqueType();
+pub const struct_ZigClangVarDecl = @OpaqueType();
+pub const struct_ZigClangWhileStmt = @OpaqueType();
+pub const ZigClangBO_PtrMemD = enum_ZigClangBO._PtrMemD;
+pub const ZigClangBO_PtrMemI = enum_ZigClangBO._PtrMemI;
+pub const ZigClangBO_Mul = enum_ZigClangBO._Mul;
+pub const ZigClangBO_Div = enum_ZigClangBO._Div;
+pub const ZigClangBO_Rem = enum_ZigClangBO._Rem;
+pub const ZigClangBO_Add = enum_ZigClangBO._Add;
+pub const ZigClangBO_Sub = enum_ZigClangBO._Sub;
+pub const ZigClangBO_Shl = enum_ZigClangBO._Shl;
+pub const ZigClangBO_Shr = enum_ZigClangBO._Shr;
+pub const ZigClangBO_Cmp = enum_ZigClangBO._Cmp;
+pub const ZigClangBO_LT = enum_ZigClangBO._LT;
+pub const ZigClangBO_GT = enum_ZigClangBO._GT;
+pub const ZigClangBO_LE = enum_ZigClangBO._LE;
+pub const ZigClangBO_GE = enum_ZigClangBO._GE;
+pub const ZigClangBO_EQ = enum_ZigClangBO._EQ;
+pub const ZigClangBO_NE = enum_ZigClangBO._NE;
+pub const ZigClangBO_And = enum_ZigClangBO._And;
+pub const ZigClangBO_Xor = enum_ZigClangBO._Xor;
+pub const ZigClangBO_Or = enum_ZigClangBO._Or;
+pub const ZigClangBO_LAnd = enum_ZigClangBO._LAnd;
+pub const ZigClangBO_LOr = enum_ZigClangBO._LOr;
+pub const ZigClangBO_Assign = enum_ZigClangBO._Assign;
+pub const ZigClangBO_MulAssign = enum_ZigClangBO._MulAssign;
+pub const ZigClangBO_DivAssign = enum_ZigClangBO._DivAssign;
+pub const ZigClangBO_RemAssign = enum_ZigClangBO._RemAssign;
+pub const ZigClangBO_AddAssign = enum_ZigClangBO._AddAssign;
+pub const ZigClangBO_SubAssign = enum_ZigClangBO._SubAssign;
+pub const ZigClangBO_ShlAssign = enum_ZigClangBO._ShlAssign;
+pub const ZigClangBO_ShrAssign = enum_ZigClangBO._ShrAssign;
+pub const ZigClangBO_AndAssign = enum_ZigClangBO._AndAssign;
+pub const ZigClangBO_XorAssign = enum_ZigClangBO._XorAssign;
+pub const ZigClangBO_OrAssign = enum_ZigClangBO._OrAssign;
+pub const ZigClangBO_Comma = enum_ZigClangBO._Comma;
+pub const enum_ZigClangBO = extern enum {
+    _PtrMemD,
+    _PtrMemI,
+    _Mul,
+    _Div,
+    _Rem,
+    _Add,
+    _Sub,
+    _Shl,
+    _Shr,
+    _Cmp,
+    _LT,
+    _GT,
+    _LE,
+    _GE,
+    _EQ,
+    _NE,
+    _And,
+    _Xor,
+    _Or,
+    _LAnd,
+    _LOr,
+    _Assign,
+    _MulAssign,
+    _DivAssign,
+    _RemAssign,
+    _AddAssign,
+    _SubAssign,
+    _ShlAssign,
+    _ShrAssign,
+    _AndAssign,
+    _XorAssign,
+    _OrAssign,
+    _Comma,
+};
+pub const ZigClangUO_PostInc = enum_ZigClangUO._PostInc;
+pub const ZigClangUO_PostDec = enum_ZigClangUO._PostDec;
+pub const ZigClangUO_PreInc = enum_ZigClangUO._PreInc;
+pub const ZigClangUO_PreDec = enum_ZigClangUO._PreDec;
+pub const ZigClangUO_AddrOf = enum_ZigClangUO._AddrOf;
+pub const ZigClangUO_Deref = enum_ZigClangUO._Deref;
+pub const ZigClangUO_Plus = enum_ZigClangUO._Plus;
+pub const ZigClangUO_Minus = enum_ZigClangUO._Minus;
+pub const ZigClangUO_Not = enum_ZigClangUO._Not;
+pub const ZigClangUO_LNot = enum_ZigClangUO._LNot;
+pub const ZigClangUO_Real = enum_ZigClangUO._Real;
+pub const ZigClangUO_Imag = enum_ZigClangUO._Imag;
+pub const ZigClangUO_Extension = enum_ZigClangUO._Extension;
+pub const ZigClangUO_Coawait = enum_ZigClangUO._Coawait;
+pub const enum_ZigClangUO = extern enum {
+    _PostInc,
+    _PostDec,
+    _PreInc,
+    _PreDec,
+    _AddrOf,
+    _Deref,
+    _Plus,
+    _Minus,
+    _Not,
+    _LNot,
+    _Real,
+    _Imag,
+    _Extension,
+    _Coawait,
+};
+pub const ZigClangType_Builtin = enum_ZigClangTypeClass.ZigClangType_Builtin;
+pub const ZigClangType_Complex = enum_ZigClangTypeClass.ZigClangType_Complex;
+pub const ZigClangType_Pointer = enum_ZigClangTypeClass.ZigClangType_Pointer;
+pub const ZigClangType_BlockPointer = enum_ZigClangTypeClass.ZigClangType_BlockPointer;
+pub const ZigClangType_LValueReference = enum_ZigClangTypeClass.ZigClangType_LValueReference;
+pub const ZigClangType_RValueReference = enum_ZigClangTypeClass.ZigClangType_RValueReference;
+pub const ZigClangType_MemberPointer = enum_ZigClangTypeClass.ZigClangType_MemberPointer;
+pub const ZigClangType_ConstantArray = enum_ZigClangTypeClass.ZigClangType_ConstantArray;
+pub const ZigClangType_IncompleteArray = enum_ZigClangTypeClass.ZigClangType_IncompleteArray;
+pub const ZigClangType_VariableArray = enum_ZigClangTypeClass.ZigClangType_VariableArray;
+pub const ZigClangType_DependentSizedArray = enum_ZigClangTypeClass.ZigClangType_DependentSizedArray;
+pub const ZigClangType_DependentSizedExtVector = enum_ZigClangTypeClass.ZigClangType_DependentSizedExtVector;
+pub const ZigClangType_DependentAddressSpace = enum_ZigClangTypeClass.ZigClangType_DependentAddressSpace;
+pub const ZigClangType_Vector = enum_ZigClangTypeClass.ZigClangType_Vector;
+pub const ZigClangType_DependentVector = enum_ZigClangTypeClass.ZigClangType_DependentVector;
+pub const ZigClangType_ExtVector = enum_ZigClangTypeClass.ZigClangType_ExtVector;
+pub const ZigClangType_FunctionProto = enum_ZigClangTypeClass.ZigClangType_FunctionProto;
+pub const ZigClangType_FunctionNoProto = enum_ZigClangTypeClass.ZigClangType_FunctionNoProto;
+pub const ZigClangType_UnresolvedUsing = enum_ZigClangTypeClass.ZigClangType_UnresolvedUsing;
+pub const ZigClangType_Paren = enum_ZigClangTypeClass.ZigClangType_Paren;
+pub const ZigClangType_Typedef = enum_ZigClangTypeClass.ZigClangType_Typedef;
+pub const ZigClangType_Adjusted = enum_ZigClangTypeClass.ZigClangType_Adjusted;
+pub const ZigClangType_Decayed = enum_ZigClangTypeClass.ZigClangType_Decayed;
+pub const ZigClangType_TypeOfExpr = enum_ZigClangTypeClass.ZigClangType_TypeOfExpr;
+pub const ZigClangType_TypeOf = enum_ZigClangTypeClass.ZigClangType_TypeOf;
+pub const ZigClangType_Decltype = enum_ZigClangTypeClass.ZigClangType_Decltype;
+pub const ZigClangType_UnaryTransform = enum_ZigClangTypeClass.ZigClangType_UnaryTransform;
+pub const ZigClangType_Record = enum_ZigClangTypeClass.ZigClangType_Record;
+pub const ZigClangType_Enum = enum_ZigClangTypeClass.ZigClangType_Enum;
+pub const ZigClangType_Elaborated = enum_ZigClangTypeClass.ZigClangType_Elaborated;
+pub const ZigClangType_Attributed = enum_ZigClangTypeClass.ZigClangType_Attributed;
+pub const ZigClangType_TemplateTypeParm = enum_ZigClangTypeClass.ZigClangType_TemplateTypeParm;
+pub const ZigClangType_SubstTemplateTypeParm = enum_ZigClangTypeClass.ZigClangType_SubstTemplateTypeParm;
+pub const ZigClangType_SubstTemplateTypeParmPack = enum_ZigClangTypeClass.ZigClangType_SubstTemplateTypeParmPack;
+pub const ZigClangType_TemplateSpecialization = enum_ZigClangTypeClass.ZigClangType_TemplateSpecialization;
+pub const ZigClangType_Auto = enum_ZigClangTypeClass.ZigClangType_Auto;
+pub const ZigClangType_DeducedTemplateSpecialization = enum_ZigClangTypeClass.ZigClangType_DeducedTemplateSpecialization;
+pub const ZigClangType_InjectedClassName = enum_ZigClangTypeClass.ZigClangType_InjectedClassName;
+pub const ZigClangType_DependentName = enum_ZigClangTypeClass.ZigClangType_DependentName;
+pub const ZigClangType_DependentTemplateSpecialization = enum_ZigClangTypeClass.ZigClangType_DependentTemplateSpecialization;
+pub const ZigClangType_PackExpansion = enum_ZigClangTypeClass.ZigClangType_PackExpansion;
+pub const ZigClangType_ObjCTypeParam = enum_ZigClangTypeClass.ZigClangType_ObjCTypeParam;
+pub const ZigClangType_ObjCObject = enum_ZigClangTypeClass.ZigClangType_ObjCObject;
+pub const ZigClangType_ObjCInterface = enum_ZigClangTypeClass.ZigClangType_ObjCInterface;
+pub const ZigClangType_ObjCObjectPointer = enum_ZigClangTypeClass.ZigClangType_ObjCObjectPointer;
+pub const ZigClangType_Pipe = enum_ZigClangTypeClass.ZigClangType_Pipe;
+pub const ZigClangType_Atomic = enum_ZigClangTypeClass.ZigClangType_Atomic;
+pub const enum_ZigClangTypeClass = extern enum {
+    ZigClangType_Builtin,
+    ZigClangType_Complex,
+    ZigClangType_Pointer,
+    ZigClangType_BlockPointer,
+    ZigClangType_LValueReference,
+    ZigClangType_RValueReference,
+    ZigClangType_MemberPointer,
+    ZigClangType_ConstantArray,
+    ZigClangType_IncompleteArray,
+    ZigClangType_VariableArray,
+    ZigClangType_DependentSizedArray,
+    ZigClangType_DependentSizedExtVector,
+    ZigClangType_DependentAddressSpace,
+    ZigClangType_Vector,
+    ZigClangType_DependentVector,
+    ZigClangType_ExtVector,
+    ZigClangType_FunctionProto,
+    ZigClangType_FunctionNoProto,
+    ZigClangType_UnresolvedUsing,
+    ZigClangType_Paren,
+    ZigClangType_Typedef,
+    ZigClangType_Adjusted,
+    ZigClangType_Decayed,
+    ZigClangType_TypeOfExpr,
+    ZigClangType_TypeOf,
+    ZigClangType_Decltype,
+    ZigClangType_UnaryTransform,
+    ZigClangType_Record,
+    ZigClangType_Enum,
+    ZigClangType_Elaborated,
+    ZigClangType_Attributed,
+    ZigClangType_TemplateTypeParm,
+    ZigClangType_SubstTemplateTypeParm,
+    ZigClangType_SubstTemplateTypeParmPack,
+    ZigClangType_TemplateSpecialization,
+    ZigClangType_Auto,
+    ZigClangType_DeducedTemplateSpecialization,
+    ZigClangType_InjectedClassName,
+    ZigClangType_DependentName,
+    ZigClangType_DependentTemplateSpecialization,
+    ZigClangType_PackExpansion,
+    ZigClangType_ObjCTypeParam,
+    ZigClangType_ObjCObject,
+    ZigClangType_ObjCInterface,
+    ZigClangType_ObjCObjectPointer,
+    ZigClangType_Pipe,
+    ZigClangType_Atomic,
+};
+pub const ZigClangStmt_NoStmtClass = enum_ZigClangStmtClass.ZigClangStmt_NoStmtClass;
+pub const ZigClangStmt_GCCAsmStmtClass = enum_ZigClangStmtClass.ZigClangStmt_GCCAsmStmtClass;
+pub const ZigClangStmt_MSAsmStmtClass = enum_ZigClangStmtClass.ZigClangStmt_MSAsmStmtClass;
+pub const ZigClangStmt_AttributedStmtClass = enum_ZigClangStmtClass.ZigClangStmt_AttributedStmtClass;
+pub const ZigClangStmt_BreakStmtClass = enum_ZigClangStmtClass.ZigClangStmt_BreakStmtClass;
+pub const ZigClangStmt_CXXCatchStmtClass = enum_ZigClangStmtClass.ZigClangStmt_CXXCatchStmtClass;
+pub const ZigClangStmt_CXXForRangeStmtClass = enum_ZigClangStmtClass.ZigClangStmt_CXXForRangeStmtClass;
+pub const ZigClangStmt_CXXTryStmtClass = enum_ZigClangStmtClass.ZigClangStmt_CXXTryStmtClass;
+pub const ZigClangStmt_CapturedStmtClass = enum_ZigClangStmtClass.ZigClangStmt_CapturedStmtClass;
+pub const ZigClangStmt_CompoundStmtClass = enum_ZigClangStmtClass.ZigClangStmt_CompoundStmtClass;
+pub const ZigClangStmt_ContinueStmtClass = enum_ZigClangStmtClass.ZigClangStmt_ContinueStmtClass;
+pub const ZigClangStmt_CoreturnStmtClass = enum_ZigClangStmtClass.ZigClangStmt_CoreturnStmtClass;
+pub const ZigClangStmt_CoroutineBodyStmtClass = enum_ZigClangStmtClass.ZigClangStmt_CoroutineBodyStmtClass;
+pub const ZigClangStmt_DeclStmtClass = enum_ZigClangStmtClass.ZigClangStmt_DeclStmtClass;
+pub const ZigClangStmt_DoStmtClass = enum_ZigClangStmtClass.ZigClangStmt_DoStmtClass;
+pub const ZigClangStmt_BinaryConditionalOperatorClass = enum_ZigClangStmtClass.ZigClangStmt_BinaryConditionalOperatorClass;
+pub const ZigClangStmt_ConditionalOperatorClass = enum_ZigClangStmtClass.ZigClangStmt_ConditionalOperatorClass;
+pub const ZigClangStmt_AddrLabelExprClass = enum_ZigClangStmtClass.ZigClangStmt_AddrLabelExprClass;
+pub const ZigClangStmt_ArrayInitIndexExprClass = enum_ZigClangStmtClass.ZigClangStmt_ArrayInitIndexExprClass;
+pub const ZigClangStmt_ArrayInitLoopExprClass = enum_ZigClangStmtClass.ZigClangStmt_ArrayInitLoopExprClass;
+pub const ZigClangStmt_ArraySubscriptExprClass = enum_ZigClangStmtClass.ZigClangStmt_ArraySubscriptExprClass;
+pub const ZigClangStmt_ArrayTypeTraitExprClass = enum_ZigClangStmtClass.ZigClangStmt_ArrayTypeTraitExprClass;
+pub const ZigClangStmt_AsTypeExprClass = enum_ZigClangStmtClass.ZigClangStmt_AsTypeExprClass;
+pub const ZigClangStmt_AtomicExprClass = enum_ZigClangStmtClass.ZigClangStmt_AtomicExprClass;
+pub const ZigClangStmt_BinaryOperatorClass = enum_ZigClangStmtClass.ZigClangStmt_BinaryOperatorClass;
+pub const ZigClangStmt_CompoundAssignOperatorClass = enum_ZigClangStmtClass.ZigClangStmt_CompoundAssignOperatorClass;
+pub const ZigClangStmt_BlockExprClass = enum_ZigClangStmtClass.ZigClangStmt_BlockExprClass;
+pub const ZigClangStmt_CXXBindTemporaryExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXBindTemporaryExprClass;
+pub const ZigClangStmt_CXXBoolLiteralExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXBoolLiteralExprClass;
+pub const ZigClangStmt_CXXConstructExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXConstructExprClass;
+pub const ZigClangStmt_CXXTemporaryObjectExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXTemporaryObjectExprClass;
+pub const ZigClangStmt_CXXDefaultArgExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXDefaultArgExprClass;
+pub const ZigClangStmt_CXXDefaultInitExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXDefaultInitExprClass;
+pub const ZigClangStmt_CXXDeleteExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXDeleteExprClass;
+pub const ZigClangStmt_CXXDependentScopeMemberExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXDependentScopeMemberExprClass;
+pub const ZigClangStmt_CXXFoldExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXFoldExprClass;
+pub const ZigClangStmt_CXXInheritedCtorInitExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXInheritedCtorInitExprClass;
+pub const ZigClangStmt_CXXNewExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXNewExprClass;
+pub const ZigClangStmt_CXXNoexceptExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXNoexceptExprClass;
+pub const ZigClangStmt_CXXNullPtrLiteralExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXNullPtrLiteralExprClass;
+pub const ZigClangStmt_CXXPseudoDestructorExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXPseudoDestructorExprClass;
+pub const ZigClangStmt_CXXScalarValueInitExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXScalarValueInitExprClass;
+pub const ZigClangStmt_CXXStdInitializerListExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXStdInitializerListExprClass;
+pub const ZigClangStmt_CXXThisExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXThisExprClass;
+pub const ZigClangStmt_CXXThrowExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXThrowExprClass;
+pub const ZigClangStmt_CXXTypeidExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXTypeidExprClass;
+pub const ZigClangStmt_CXXUnresolvedConstructExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXUnresolvedConstructExprClass;
+pub const ZigClangStmt_CXXUuidofExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXUuidofExprClass;
+pub const ZigClangStmt_CallExprClass = enum_ZigClangStmtClass.ZigClangStmt_CallExprClass;
+pub const ZigClangStmt_CUDAKernelCallExprClass = enum_ZigClangStmtClass.ZigClangStmt_CUDAKernelCallExprClass;
+pub const ZigClangStmt_CXXMemberCallExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXMemberCallExprClass;
+pub const ZigClangStmt_CXXOperatorCallExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXOperatorCallExprClass;
+pub const ZigClangStmt_UserDefinedLiteralClass = enum_ZigClangStmtClass.ZigClangStmt_UserDefinedLiteralClass;
+pub const ZigClangStmt_CStyleCastExprClass = enum_ZigClangStmtClass.ZigClangStmt_CStyleCastExprClass;
+pub const ZigClangStmt_CXXFunctionalCastExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXFunctionalCastExprClass;
+pub const ZigClangStmt_CXXConstCastExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXConstCastExprClass;
+pub const ZigClangStmt_CXXDynamicCastExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXDynamicCastExprClass;
+pub const ZigClangStmt_CXXReinterpretCastExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXReinterpretCastExprClass;
+pub const ZigClangStmt_CXXStaticCastExprClass = enum_ZigClangStmtClass.ZigClangStmt_CXXStaticCastExprClass;
+pub const ZigClangStmt_ObjCBridgedCastExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCBridgedCastExprClass;
+pub const ZigClangStmt_ImplicitCastExprClass = enum_ZigClangStmtClass.ZigClangStmt_ImplicitCastExprClass;
+pub const ZigClangStmt_CharacterLiteralClass = enum_ZigClangStmtClass.ZigClangStmt_CharacterLiteralClass;
+pub const ZigClangStmt_ChooseExprClass = enum_ZigClangStmtClass.ZigClangStmt_ChooseExprClass;
+pub const ZigClangStmt_CompoundLiteralExprClass = enum_ZigClangStmtClass.ZigClangStmt_CompoundLiteralExprClass;
+pub const ZigClangStmt_ConvertVectorExprClass = enum_ZigClangStmtClass.ZigClangStmt_ConvertVectorExprClass;
+pub const ZigClangStmt_CoawaitExprClass = enum_ZigClangStmtClass.ZigClangStmt_CoawaitExprClass;
+pub const ZigClangStmt_CoyieldExprClass = enum_ZigClangStmtClass.ZigClangStmt_CoyieldExprClass;
+pub const ZigClangStmt_DeclRefExprClass = enum_ZigClangStmtClass.ZigClangStmt_DeclRefExprClass;
+pub const ZigClangStmt_DependentCoawaitExprClass = enum_ZigClangStmtClass.ZigClangStmt_DependentCoawaitExprClass;
+pub const ZigClangStmt_DependentScopeDeclRefExprClass = enum_ZigClangStmtClass.ZigClangStmt_DependentScopeDeclRefExprClass;
+pub const ZigClangStmt_DesignatedInitExprClass = enum_ZigClangStmtClass.ZigClangStmt_DesignatedInitExprClass;
+pub const ZigClangStmt_DesignatedInitUpdateExprClass = enum_ZigClangStmtClass.ZigClangStmt_DesignatedInitUpdateExprClass;
+pub const ZigClangStmt_ExpressionTraitExprClass = enum_ZigClangStmtClass.ZigClangStmt_ExpressionTraitExprClass;
+pub const ZigClangStmt_ExtVectorElementExprClass = enum_ZigClangStmtClass.ZigClangStmt_ExtVectorElementExprClass;
+pub const ZigClangStmt_FixedPointLiteralClass = enum_ZigClangStmtClass.ZigClangStmt_FixedPointLiteralClass;
+pub const ZigClangStmt_FloatingLiteralClass = enum_ZigClangStmtClass.ZigClangStmt_FloatingLiteralClass;
+pub const ZigClangStmt_ConstantExprClass = enum_ZigClangStmtClass.ZigClangStmt_ConstantExprClass;
+pub const ZigClangStmt_ExprWithCleanupsClass = enum_ZigClangStmtClass.ZigClangStmt_ExprWithCleanupsClass;
+pub const ZigClangStmt_FunctionParmPackExprClass = enum_ZigClangStmtClass.ZigClangStmt_FunctionParmPackExprClass;
+pub const ZigClangStmt_GNUNullExprClass = enum_ZigClangStmtClass.ZigClangStmt_GNUNullExprClass;
+pub const ZigClangStmt_GenericSelectionExprClass = enum_ZigClangStmtClass.ZigClangStmt_GenericSelectionExprClass;
+pub const ZigClangStmt_ImaginaryLiteralClass = enum_ZigClangStmtClass.ZigClangStmt_ImaginaryLiteralClass;
+pub const ZigClangStmt_ImplicitValueInitExprClass = enum_ZigClangStmtClass.ZigClangStmt_ImplicitValueInitExprClass;
+pub const ZigClangStmt_InitListExprClass = enum_ZigClangStmtClass.ZigClangStmt_InitListExprClass;
+pub const ZigClangStmt_IntegerLiteralClass = enum_ZigClangStmtClass.ZigClangStmt_IntegerLiteralClass;
+pub const ZigClangStmt_LambdaExprClass = enum_ZigClangStmtClass.ZigClangStmt_LambdaExprClass;
+pub const ZigClangStmt_MSPropertyRefExprClass = enum_ZigClangStmtClass.ZigClangStmt_MSPropertyRefExprClass;
+pub const ZigClangStmt_MSPropertySubscriptExprClass = enum_ZigClangStmtClass.ZigClangStmt_MSPropertySubscriptExprClass;
+pub const ZigClangStmt_MaterializeTemporaryExprClass = enum_ZigClangStmtClass.ZigClangStmt_MaterializeTemporaryExprClass;
+pub const ZigClangStmt_MemberExprClass = enum_ZigClangStmtClass.ZigClangStmt_MemberExprClass;
+pub const ZigClangStmt_NoInitExprClass = enum_ZigClangStmtClass.ZigClangStmt_NoInitExprClass;
+pub const ZigClangStmt_OMPArraySectionExprClass = enum_ZigClangStmtClass.ZigClangStmt_OMPArraySectionExprClass;
+pub const ZigClangStmt_ObjCArrayLiteralClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCArrayLiteralClass;
+pub const ZigClangStmt_ObjCAvailabilityCheckExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCAvailabilityCheckExprClass;
+pub const ZigClangStmt_ObjCBoolLiteralExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCBoolLiteralExprClass;
+pub const ZigClangStmt_ObjCBoxedExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCBoxedExprClass;
+pub const ZigClangStmt_ObjCDictionaryLiteralClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCDictionaryLiteralClass;
+pub const ZigClangStmt_ObjCEncodeExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCEncodeExprClass;
+pub const ZigClangStmt_ObjCIndirectCopyRestoreExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCIndirectCopyRestoreExprClass;
+pub const ZigClangStmt_ObjCIsaExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCIsaExprClass;
+pub const ZigClangStmt_ObjCIvarRefExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCIvarRefExprClass;
+pub const ZigClangStmt_ObjCMessageExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCMessageExprClass;
+pub const ZigClangStmt_ObjCPropertyRefExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCPropertyRefExprClass;
+pub const ZigClangStmt_ObjCProtocolExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCProtocolExprClass;
+pub const ZigClangStmt_ObjCSelectorExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCSelectorExprClass;
+pub const ZigClangStmt_ObjCStringLiteralClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCStringLiteralClass;
+pub const ZigClangStmt_ObjCSubscriptRefExprClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCSubscriptRefExprClass;
+pub const ZigClangStmt_OffsetOfExprClass = enum_ZigClangStmtClass.ZigClangStmt_OffsetOfExprClass;
+pub const ZigClangStmt_OpaqueValueExprClass = enum_ZigClangStmtClass.ZigClangStmt_OpaqueValueExprClass;
+pub const ZigClangStmt_UnresolvedLookupExprClass = enum_ZigClangStmtClass.ZigClangStmt_UnresolvedLookupExprClass;
+pub const ZigClangStmt_UnresolvedMemberExprClass = enum_ZigClangStmtClass.ZigClangStmt_UnresolvedMemberExprClass;
+pub const ZigClangStmt_PackExpansionExprClass = enum_ZigClangStmtClass.ZigClangStmt_PackExpansionExprClass;
+pub const ZigClangStmt_ParenExprClass = enum_ZigClangStmtClass.ZigClangStmt_ParenExprClass;
+pub const ZigClangStmt_ParenListExprClass = enum_ZigClangStmtClass.ZigClangStmt_ParenListExprClass;
+pub const ZigClangStmt_PredefinedExprClass = enum_ZigClangStmtClass.ZigClangStmt_PredefinedExprClass;
+pub const ZigClangStmt_PseudoObjectExprClass = enum_ZigClangStmtClass.ZigClangStmt_PseudoObjectExprClass;
+pub const ZigClangStmt_ShuffleVectorExprClass = enum_ZigClangStmtClass.ZigClangStmt_ShuffleVectorExprClass;
+pub const ZigClangStmt_SizeOfPackExprClass = enum_ZigClangStmtClass.ZigClangStmt_SizeOfPackExprClass;
+pub const ZigClangStmt_StmtExprClass = enum_ZigClangStmtClass.ZigClangStmt_StmtExprClass;
+pub const ZigClangStmt_StringLiteralClass = enum_ZigClangStmtClass.ZigClangStmt_StringLiteralClass;
+pub const ZigClangStmt_SubstNonTypeTemplateParmExprClass = enum_ZigClangStmtClass.ZigClangStmt_SubstNonTypeTemplateParmExprClass;
+pub const ZigClangStmt_SubstNonTypeTemplateParmPackExprClass = enum_ZigClangStmtClass.ZigClangStmt_SubstNonTypeTemplateParmPackExprClass;
+pub const ZigClangStmt_TypeTraitExprClass = enum_ZigClangStmtClass.ZigClangStmt_TypeTraitExprClass;
+pub const ZigClangStmt_TypoExprClass = enum_ZigClangStmtClass.ZigClangStmt_TypoExprClass;
+pub const ZigClangStmt_UnaryExprOrTypeTraitExprClass = enum_ZigClangStmtClass.ZigClangStmt_UnaryExprOrTypeTraitExprClass;
+pub const ZigClangStmt_UnaryOperatorClass = enum_ZigClangStmtClass.ZigClangStmt_UnaryOperatorClass;
+pub const ZigClangStmt_VAArgExprClass = enum_ZigClangStmtClass.ZigClangStmt_VAArgExprClass;
+pub const ZigClangStmt_ForStmtClass = enum_ZigClangStmtClass.ZigClangStmt_ForStmtClass;
+pub const ZigClangStmt_GotoStmtClass = enum_ZigClangStmtClass.ZigClangStmt_GotoStmtClass;
+pub const ZigClangStmt_IfStmtClass = enum_ZigClangStmtClass.ZigClangStmt_IfStmtClass;
+pub const ZigClangStmt_IndirectGotoStmtClass = enum_ZigClangStmtClass.ZigClangStmt_IndirectGotoStmtClass;
+pub const ZigClangStmt_LabelStmtClass = enum_ZigClangStmtClass.ZigClangStmt_LabelStmtClass;
+pub const ZigClangStmt_MSDependentExistsStmtClass = enum_ZigClangStmtClass.ZigClangStmt_MSDependentExistsStmtClass;
+pub const ZigClangStmt_NullStmtClass = enum_ZigClangStmtClass.ZigClangStmt_NullStmtClass;
+pub const ZigClangStmt_OMPAtomicDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPAtomicDirectiveClass;
+pub const ZigClangStmt_OMPBarrierDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPBarrierDirectiveClass;
+pub const ZigClangStmt_OMPCancelDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPCancelDirectiveClass;
+pub const ZigClangStmt_OMPCancellationPointDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPCancellationPointDirectiveClass;
+pub const ZigClangStmt_OMPCriticalDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPCriticalDirectiveClass;
+pub const ZigClangStmt_OMPFlushDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPFlushDirectiveClass;
+pub const ZigClangStmt_OMPDistributeDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPDistributeDirectiveClass;
+pub const ZigClangStmt_OMPDistributeParallelForDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPDistributeParallelForDirectiveClass;
+pub const ZigClangStmt_OMPDistributeParallelForSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPDistributeParallelForSimdDirectiveClass;
+pub const ZigClangStmt_OMPDistributeSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPDistributeSimdDirectiveClass;
+pub const ZigClangStmt_OMPForDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPForDirectiveClass;
+pub const ZigClangStmt_OMPForSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPForSimdDirectiveClass;
+pub const ZigClangStmt_OMPParallelForDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPParallelForDirectiveClass;
+pub const ZigClangStmt_OMPParallelForSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPParallelForSimdDirectiveClass;
+pub const ZigClangStmt_OMPSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPSimdDirectiveClass;
+pub const ZigClangStmt_OMPTargetParallelForSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetParallelForSimdDirectiveClass;
+pub const ZigClangStmt_OMPTargetSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetSimdDirectiveClass;
+pub const ZigClangStmt_OMPTargetTeamsDistributeDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetTeamsDistributeDirectiveClass;
+pub const ZigClangStmt_OMPTargetTeamsDistributeParallelForDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetTeamsDistributeParallelForDirectiveClass;
+pub const ZigClangStmt_OMPTargetTeamsDistributeParallelForSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetTeamsDistributeParallelForSimdDirectiveClass;
+pub const ZigClangStmt_OMPTargetTeamsDistributeSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetTeamsDistributeSimdDirectiveClass;
+pub const ZigClangStmt_OMPTaskLoopDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTaskLoopDirectiveClass;
+pub const ZigClangStmt_OMPTaskLoopSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTaskLoopSimdDirectiveClass;
+pub const ZigClangStmt_OMPTeamsDistributeDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTeamsDistributeDirectiveClass;
+pub const ZigClangStmt_OMPTeamsDistributeParallelForDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTeamsDistributeParallelForDirectiveClass;
+pub const ZigClangStmt_OMPTeamsDistributeParallelForSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTeamsDistributeParallelForSimdDirectiveClass;
+pub const ZigClangStmt_OMPTeamsDistributeSimdDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTeamsDistributeSimdDirectiveClass;
+pub const ZigClangStmt_OMPMasterDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPMasterDirectiveClass;
+pub const ZigClangStmt_OMPOrderedDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPOrderedDirectiveClass;
+pub const ZigClangStmt_OMPParallelDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPParallelDirectiveClass;
+pub const ZigClangStmt_OMPParallelSectionsDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPParallelSectionsDirectiveClass;
+pub const ZigClangStmt_OMPSectionDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPSectionDirectiveClass;
+pub const ZigClangStmt_OMPSectionsDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPSectionsDirectiveClass;
+pub const ZigClangStmt_OMPSingleDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPSingleDirectiveClass;
+pub const ZigClangStmt_OMPTargetDataDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetDataDirectiveClass;
+pub const ZigClangStmt_OMPTargetDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetDirectiveClass;
+pub const ZigClangStmt_OMPTargetEnterDataDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetEnterDataDirectiveClass;
+pub const ZigClangStmt_OMPTargetExitDataDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetExitDataDirectiveClass;
+pub const ZigClangStmt_OMPTargetParallelDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetParallelDirectiveClass;
+pub const ZigClangStmt_OMPTargetParallelForDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetParallelForDirectiveClass;
+pub const ZigClangStmt_OMPTargetTeamsDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetTeamsDirectiveClass;
+pub const ZigClangStmt_OMPTargetUpdateDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTargetUpdateDirectiveClass;
+pub const ZigClangStmt_OMPTaskDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTaskDirectiveClass;
+pub const ZigClangStmt_OMPTaskgroupDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTaskgroupDirectiveClass;
+pub const ZigClangStmt_OMPTaskwaitDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTaskwaitDirectiveClass;
+pub const ZigClangStmt_OMPTaskyieldDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTaskyieldDirectiveClass;
+pub const ZigClangStmt_OMPTeamsDirectiveClass = enum_ZigClangStmtClass.ZigClangStmt_OMPTeamsDirectiveClass;
+pub const ZigClangStmt_ObjCAtCatchStmtClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCAtCatchStmtClass;
+pub const ZigClangStmt_ObjCAtFinallyStmtClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCAtFinallyStmtClass;
+pub const ZigClangStmt_ObjCAtSynchronizedStmtClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCAtSynchronizedStmtClass;
+pub const ZigClangStmt_ObjCAtThrowStmtClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCAtThrowStmtClass;
+pub const ZigClangStmt_ObjCAtTryStmtClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCAtTryStmtClass;
+pub const ZigClangStmt_ObjCAutoreleasePoolStmtClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCAutoreleasePoolStmtClass;
+pub const ZigClangStmt_ObjCForCollectionStmtClass = enum_ZigClangStmtClass.ZigClangStmt_ObjCForCollectionStmtClass;
+pub const ZigClangStmt_ReturnStmtClass = enum_ZigClangStmtClass.ZigClangStmt_ReturnStmtClass;
+pub const ZigClangStmt_SEHExceptStmtClass = enum_ZigClangStmtClass.ZigClangStmt_SEHExceptStmtClass;
+pub const ZigClangStmt_SEHFinallyStmtClass = enum_ZigClangStmtClass.ZigClangStmt_SEHFinallyStmtClass;
+pub const ZigClangStmt_SEHLeaveStmtClass = enum_ZigClangStmtClass.ZigClangStmt_SEHLeaveStmtClass;
+pub const ZigClangStmt_SEHTryStmtClass = enum_ZigClangStmtClass.ZigClangStmt_SEHTryStmtClass;
+pub const ZigClangStmt_CaseStmtClass = enum_ZigClangStmtClass.ZigClangStmt_CaseStmtClass;
+pub const ZigClangStmt_DefaultStmtClass = enum_ZigClangStmtClass.ZigClangStmt_DefaultStmtClass;
+pub const ZigClangStmt_SwitchStmtClass = enum_ZigClangStmtClass.ZigClangStmt_SwitchStmtClass;
+pub const ZigClangStmt_WhileStmtClass = enum_ZigClangStmtClass.ZigClangStmt_WhileStmtClass;
+pub const enum_ZigClangStmtClass = extern enum {
+    ZigClangStmt_NoStmtClass = 0,
+    ZigClangStmt_GCCAsmStmtClass = 1,
+    ZigClangStmt_MSAsmStmtClass = 2,
+    ZigClangStmt_AttributedStmtClass = 3,
+    ZigClangStmt_BreakStmtClass = 4,
+    ZigClangStmt_CXXCatchStmtClass = 5,
+    ZigClangStmt_CXXForRangeStmtClass = 6,
+    ZigClangStmt_CXXTryStmtClass = 7,
+    ZigClangStmt_CapturedStmtClass = 8,
+    ZigClangStmt_CompoundStmtClass = 9,
+    ZigClangStmt_ContinueStmtClass = 10,
+    ZigClangStmt_CoreturnStmtClass = 11,
+    ZigClangStmt_CoroutineBodyStmtClass = 12,
+    ZigClangStmt_DeclStmtClass = 13,
+    ZigClangStmt_DoStmtClass = 14,
+    ZigClangStmt_BinaryConditionalOperatorClass = 15,
+    ZigClangStmt_ConditionalOperatorClass = 16,
+    ZigClangStmt_AddrLabelExprClass = 17,
+    ZigClangStmt_ArrayInitIndexExprClass = 18,
+    ZigClangStmt_ArrayInitLoopExprClass = 19,
+    ZigClangStmt_ArraySubscriptExprClass = 20,
+    ZigClangStmt_ArrayTypeTraitExprClass = 21,
+    ZigClangStmt_AsTypeExprClass = 22,
+    ZigClangStmt_AtomicExprClass = 23,
+    ZigClangStmt_BinaryOperatorClass = 24,
+    ZigClangStmt_CompoundAssignOperatorClass = 25,
+    ZigClangStmt_BlockExprClass = 26,
+    ZigClangStmt_CXXBindTemporaryExprClass = 27,
+    ZigClangStmt_CXXBoolLiteralExprClass = 28,
+    ZigClangStmt_CXXConstructExprClass = 29,
+    ZigClangStmt_CXXTemporaryObjectExprClass = 30,
+    ZigClangStmt_CXXDefaultArgExprClass = 31,
+    ZigClangStmt_CXXDefaultInitExprClass = 32,
+    ZigClangStmt_CXXDeleteExprClass = 33,
+    ZigClangStmt_CXXDependentScopeMemberExprClass = 34,
+    ZigClangStmt_CXXFoldExprClass = 35,
+    ZigClangStmt_CXXInheritedCtorInitExprClass = 36,
+    ZigClangStmt_CXXNewExprClass = 37,
+    ZigClangStmt_CXXNoexceptExprClass = 38,
+    ZigClangStmt_CXXNullPtrLiteralExprClass = 39,
+    ZigClangStmt_CXXPseudoDestructorExprClass = 40,
+    ZigClangStmt_CXXScalarValueInitExprClass = 41,
+    ZigClangStmt_CXXStdInitializerListExprClass = 42,
+    ZigClangStmt_CXXThisExprClass = 43,
+    ZigClangStmt_CXXThrowExprClass = 44,
+    ZigClangStmt_CXXTypeidExprClass = 45,
+    ZigClangStmt_CXXUnresolvedConstructExprClass = 46,
+    ZigClangStmt_CXXUuidofExprClass = 47,
+    ZigClangStmt_CallExprClass = 48,
+    ZigClangStmt_CUDAKernelCallExprClass = 49,
+    ZigClangStmt_CXXMemberCallExprClass = 50,
+    ZigClangStmt_CXXOperatorCallExprClass = 51,
+    ZigClangStmt_UserDefinedLiteralClass = 52,
+    ZigClangStmt_CStyleCastExprClass = 53,
+    ZigClangStmt_CXXFunctionalCastExprClass = 54,
+    ZigClangStmt_CXXConstCastExprClass = 55,
+    ZigClangStmt_CXXDynamicCastExprClass = 56,
+    ZigClangStmt_CXXReinterpretCastExprClass = 57,
+    ZigClangStmt_CXXStaticCastExprClass = 58,
+    ZigClangStmt_ObjCBridgedCastExprClass = 59,
+    ZigClangStmt_ImplicitCastExprClass = 60,
+    ZigClangStmt_CharacterLiteralClass = 61,
+    ZigClangStmt_ChooseExprClass = 62,
+    ZigClangStmt_CompoundLiteralExprClass = 63,
+    ZigClangStmt_ConvertVectorExprClass = 64,
+    ZigClangStmt_CoawaitExprClass = 65,
+    ZigClangStmt_CoyieldExprClass = 66,
+    ZigClangStmt_DeclRefExprClass = 67,
+    ZigClangStmt_DependentCoawaitExprClass = 68,
+    ZigClangStmt_DependentScopeDeclRefExprClass = 69,
+    ZigClangStmt_DesignatedInitExprClass = 70,
+    ZigClangStmt_DesignatedInitUpdateExprClass = 71,
+    ZigClangStmt_ExpressionTraitExprClass = 72,
+    ZigClangStmt_ExtVectorElementExprClass = 73,
+    ZigClangStmt_FixedPointLiteralClass = 74,
+    ZigClangStmt_FloatingLiteralClass = 75,
+    ZigClangStmt_ConstantExprClass = 76,
+    ZigClangStmt_ExprWithCleanupsClass = 77,
+    ZigClangStmt_FunctionParmPackExprClass = 78,
+    ZigClangStmt_GNUNullExprClass = 79,
+    ZigClangStmt_GenericSelectionExprClass = 80,
+    ZigClangStmt_ImaginaryLiteralClass = 81,
+    ZigClangStmt_ImplicitValueInitExprClass = 82,
+    ZigClangStmt_InitListExprClass = 83,
+    ZigClangStmt_IntegerLiteralClass = 84,
+    ZigClangStmt_LambdaExprClass = 85,
+    ZigClangStmt_MSPropertyRefExprClass = 86,
+    ZigClangStmt_MSPropertySubscriptExprClass = 87,
+    ZigClangStmt_MaterializeTemporaryExprClass = 88,
+    ZigClangStmt_MemberExprClass = 89,
+    ZigClangStmt_NoInitExprClass = 90,
+    ZigClangStmt_OMPArraySectionExprClass = 91,
+    ZigClangStmt_ObjCArrayLiteralClass = 92,
+    ZigClangStmt_ObjCAvailabilityCheckExprClass = 93,
+    ZigClangStmt_ObjCBoolLiteralExprClass = 94,
+    ZigClangStmt_ObjCBoxedExprClass = 95,
+    ZigClangStmt_ObjCDictionaryLiteralClass = 96,
+    ZigClangStmt_ObjCEncodeExprClass = 97,
+    ZigClangStmt_ObjCIndirectCopyRestoreExprClass = 98,
+    ZigClangStmt_ObjCIsaExprClass = 99,
+    ZigClangStmt_ObjCIvarRefExprClass = 100,
+    ZigClangStmt_ObjCMessageExprClass = 101,
+    ZigClangStmt_ObjCPropertyRefExprClass = 102,
+    ZigClangStmt_ObjCProtocolExprClass = 103,
+    ZigClangStmt_ObjCSelectorExprClass = 104,
+    ZigClangStmt_ObjCStringLiteralClass = 105,
+    ZigClangStmt_ObjCSubscriptRefExprClass = 106,
+    ZigClangStmt_OffsetOfExprClass = 107,
+    ZigClangStmt_OpaqueValueExprClass = 108,
+    ZigClangStmt_UnresolvedLookupExprClass = 109,
+    ZigClangStmt_UnresolvedMemberExprClass = 110,
+    ZigClangStmt_PackExpansionExprClass = 111,
+    ZigClangStmt_ParenExprClass = 112,
+    ZigClangStmt_ParenListExprClass = 113,
+    ZigClangStmt_PredefinedExprClass = 114,
+    ZigClangStmt_PseudoObjectExprClass = 115,
+    ZigClangStmt_ShuffleVectorExprClass = 116,
+    ZigClangStmt_SizeOfPackExprClass = 117,
+    ZigClangStmt_StmtExprClass = 118,
+    ZigClangStmt_StringLiteralClass = 119,
+    ZigClangStmt_SubstNonTypeTemplateParmExprClass = 120,
+    ZigClangStmt_SubstNonTypeTemplateParmPackExprClass = 121,
+    ZigClangStmt_TypeTraitExprClass = 122,
+    ZigClangStmt_TypoExprClass = 123,
+    ZigClangStmt_UnaryExprOrTypeTraitExprClass = 124,
+    ZigClangStmt_UnaryOperatorClass = 125,
+    ZigClangStmt_VAArgExprClass = 126,
+    ZigClangStmt_ForStmtClass = 127,
+    ZigClangStmt_GotoStmtClass = 128,
+    ZigClangStmt_IfStmtClass = 129,
+    ZigClangStmt_IndirectGotoStmtClass = 130,
+    ZigClangStmt_LabelStmtClass = 131,
+    ZigClangStmt_MSDependentExistsStmtClass = 132,
+    ZigClangStmt_NullStmtClass = 133,
+    ZigClangStmt_OMPAtomicDirectiveClass = 134,
+    ZigClangStmt_OMPBarrierDirectiveClass = 135,
+    ZigClangStmt_OMPCancelDirectiveClass = 136,
+    ZigClangStmt_OMPCancellationPointDirectiveClass = 137,
+    ZigClangStmt_OMPCriticalDirectiveClass = 138,
+    ZigClangStmt_OMPFlushDirectiveClass = 139,
+    ZigClangStmt_OMPDistributeDirectiveClass = 140,
+    ZigClangStmt_OMPDistributeParallelForDirectiveClass = 141,
+    ZigClangStmt_OMPDistributeParallelForSimdDirectiveClass = 142,
+    ZigClangStmt_OMPDistributeSimdDirectiveClass = 143,
+    ZigClangStmt_OMPForDirectiveClass = 144,
+    ZigClangStmt_OMPForSimdDirectiveClass = 145,
+    ZigClangStmt_OMPParallelForDirectiveClass = 146,
+    ZigClangStmt_OMPParallelForSimdDirectiveClass = 147,
+    ZigClangStmt_OMPSimdDirectiveClass = 148,
+    ZigClangStmt_OMPTargetParallelForSimdDirectiveClass = 149,
+    ZigClangStmt_OMPTargetSimdDirectiveClass = 150,
+    ZigClangStmt_OMPTargetTeamsDistributeDirectiveClass = 151,
+    ZigClangStmt_OMPTargetTeamsDistributeParallelForDirectiveClass = 152,
+    ZigClangStmt_OMPTargetTeamsDistributeParallelForSimdDirectiveClass = 153,
+    ZigClangStmt_OMPTargetTeamsDistributeSimdDirectiveClass = 154,
+    ZigClangStmt_OMPTaskLoopDirectiveClass = 155,
+    ZigClangStmt_OMPTaskLoopSimdDirectiveClass = 156,
+    ZigClangStmt_OMPTeamsDistributeDirectiveClass = 157,
+    ZigClangStmt_OMPTeamsDistributeParallelForDirectiveClass = 158,
+    ZigClangStmt_OMPTeamsDistributeParallelForSimdDirectiveClass = 159,
+    ZigClangStmt_OMPTeamsDistributeSimdDirectiveClass = 160,
+    ZigClangStmt_OMPMasterDirectiveClass = 161,
+    ZigClangStmt_OMPOrderedDirectiveClass = 162,
+    ZigClangStmt_OMPParallelDirectiveClass = 163,
+    ZigClangStmt_OMPParallelSectionsDirectiveClass = 164,
+    ZigClangStmt_OMPSectionDirectiveClass = 165,
+    ZigClangStmt_OMPSectionsDirectiveClass = 166,
+    ZigClangStmt_OMPSingleDirectiveClass = 167,
+    ZigClangStmt_OMPTargetDataDirectiveClass = 168,
+    ZigClangStmt_OMPTargetDirectiveClass = 169,
+    ZigClangStmt_OMPTargetEnterDataDirectiveClass = 170,
+    ZigClangStmt_OMPTargetExitDataDirectiveClass = 171,
+    ZigClangStmt_OMPTargetParallelDirectiveClass = 172,
+    ZigClangStmt_OMPTargetParallelForDirectiveClass = 173,
+    ZigClangStmt_OMPTargetTeamsDirectiveClass = 174,
+    ZigClangStmt_OMPTargetUpdateDirectiveClass = 175,
+    ZigClangStmt_OMPTaskDirectiveClass = 176,
+    ZigClangStmt_OMPTaskgroupDirectiveClass = 177,
+    ZigClangStmt_OMPTaskwaitDirectiveClass = 178,
+    ZigClangStmt_OMPTaskyieldDirectiveClass = 179,
+    ZigClangStmt_OMPTeamsDirectiveClass = 180,
+    ZigClangStmt_ObjCAtCatchStmtClass = 181,
+    ZigClangStmt_ObjCAtFinallyStmtClass = 182,
+    ZigClangStmt_ObjCAtSynchronizedStmtClass = 183,
+    ZigClangStmt_ObjCAtThrowStmtClass = 184,
+    ZigClangStmt_ObjCAtTryStmtClass = 185,
+    ZigClangStmt_ObjCAutoreleasePoolStmtClass = 186,
+    ZigClangStmt_ObjCForCollectionStmtClass = 187,
+    ZigClangStmt_ReturnStmtClass = 188,
+    ZigClangStmt_SEHExceptStmtClass = 189,
+    ZigClangStmt_SEHFinallyStmtClass = 190,
+    ZigClangStmt_SEHLeaveStmtClass = 191,
+    ZigClangStmt_SEHTryStmtClass = 192,
+    ZigClangStmt_CaseStmtClass = 193,
+    ZigClangStmt_DefaultStmtClass = 194,
+    ZigClangStmt_SwitchStmtClass = 195,
+    ZigClangStmt_WhileStmtClass = 196,
+};
+pub const ZigClangCK_Dependent = enum_ZigClangCK._Dependent;
+pub const ZigClangCK_BitCast = enum_ZigClangCK._BitCast;
+pub const ZigClangCK_LValueBitCast = enum_ZigClangCK._LValueBitCast;
+pub const ZigClangCK_LValueToRValue = enum_ZigClangCK._LValueToRValue;
+pub const ZigClangCK_NoOp = enum_ZigClangCK._NoOp;
+pub const ZigClangCK_BaseToDerived = enum_ZigClangCK._BaseToDerived;
+pub const ZigClangCK_DerivedToBase = enum_ZigClangCK._DerivedToBase;
+pub const ZigClangCK_UncheckedDerivedToBase = enum_ZigClangCK._UncheckedDerivedToBase;
+pub const ZigClangCK_Dynamic = enum_ZigClangCK._Dynamic;
+pub const ZigClangCK_ToUnion = enum_ZigClangCK._ToUnion;
+pub const ZigClangCK_ArrayToPointerDecay = enum_ZigClangCK._ArrayToPointerDecay;
+pub const ZigClangCK_FunctionToPointerDecay = enum_ZigClangCK._FunctionToPointerDecay;
+pub const ZigClangCK_NullToPointer = enum_ZigClangCK._NullToPointer;
+pub const ZigClangCK_NullToMemberPointer = enum_ZigClangCK._NullToMemberPointer;
+pub const ZigClangCK_BaseToDerivedMemberPointer = enum_ZigClangCK._BaseToDerivedMemberPointer;
+pub const ZigClangCK_DerivedToBaseMemberPointer = enum_ZigClangCK._DerivedToBaseMemberPointer;
+pub const ZigClangCK_MemberPointerToBoolean = enum_ZigClangCK._MemberPointerToBoolean;
+pub const ZigClangCK_ReinterpretMemberPointer = enum_ZigClangCK._ReinterpretMemberPointer;
+pub const ZigClangCK_UserDefinedConversion = enum_ZigClangCK._UserDefinedConversion;
+pub const ZigClangCK_ConstructorConversion = enum_ZigClangCK._ConstructorConversion;
+pub const ZigClangCK_IntegralToPointer = enum_ZigClangCK._IntegralToPointer;
+pub const ZigClangCK_PointerToIntegral = enum_ZigClangCK._PointerToIntegral;
+pub const ZigClangCK_PointerToBoolean = enum_ZigClangCK._PointerToBoolean;
+pub const ZigClangCK_ToVoid = enum_ZigClangCK._ToVoid;
+pub const ZigClangCK_VectorSplat = enum_ZigClangCK._VectorSplat;
+pub const ZigClangCK_IntegralCast = enum_ZigClangCK._IntegralCast;
+pub const ZigClangCK_IntegralToBoolean = enum_ZigClangCK._IntegralToBoolean;
+pub const ZigClangCK_IntegralToFloating = enum_ZigClangCK._IntegralToFloating;
+pub const ZigClangCK_FixedPointCast = enum_ZigClangCK._FixedPointCast;
+pub const ZigClangCK_FixedPointToBoolean = enum_ZigClangCK._FixedPointToBoolean;
+pub const ZigClangCK_FloatingToIntegral = enum_ZigClangCK._FloatingToIntegral;
+pub const ZigClangCK_FloatingToBoolean = enum_ZigClangCK._FloatingToBoolean;
+pub const ZigClangCK_BooleanToSignedIntegral = enum_ZigClangCK._BooleanToSignedIntegral;
+pub const ZigClangCK_FloatingCast = enum_ZigClangCK._FloatingCast;
+pub const ZigClangCK_CPointerToObjCPointerCast = enum_ZigClangCK._CPointerToObjCPointerCast;
+pub const ZigClangCK_BlockPointerToObjCPointerCast = enum_ZigClangCK._BlockPointerToObjCPointerCast;
+pub const ZigClangCK_AnyPointerToBlockPointerCast = enum_ZigClangCK._AnyPointerToBlockPointerCast;
+pub const ZigClangCK_ObjCObjectLValueCast = enum_ZigClangCK._ObjCObjectLValueCast;
+pub const ZigClangCK_FloatingRealToComplex = enum_ZigClangCK._FloatingRealToComplex;
+pub const ZigClangCK_FloatingComplexToReal = enum_ZigClangCK._FloatingComplexToReal;
+pub const ZigClangCK_FloatingComplexToBoolean = enum_ZigClangCK._FloatingComplexToBoolean;
+pub const ZigClangCK_FloatingComplexCast = enum_ZigClangCK._FloatingComplexCast;
+pub const ZigClangCK_FloatingComplexToIntegralComplex = enum_ZigClangCK._FloatingComplexToIntegralComplex;
+pub const ZigClangCK_IntegralRealToComplex = enum_ZigClangCK._IntegralRealToComplex;
+pub const ZigClangCK_IntegralComplexToReal = enum_ZigClangCK._IntegralComplexToReal;
+pub const ZigClangCK_IntegralComplexToBoolean = enum_ZigClangCK._IntegralComplexToBoolean;
+pub const ZigClangCK_IntegralComplexCast = enum_ZigClangCK._IntegralComplexCast;
+pub const ZigClangCK_IntegralComplexToFloatingComplex = enum_ZigClangCK._IntegralComplexToFloatingComplex;
+pub const ZigClangCK_ARCProduceObject = enum_ZigClangCK._ARCProduceObject;
+pub const ZigClangCK_ARCConsumeObject = enum_ZigClangCK._ARCConsumeObject;
+pub const ZigClangCK_ARCReclaimReturnedObject = enum_ZigClangCK._ARCReclaimReturnedObject;
+pub const ZigClangCK_ARCExtendBlockObject = enum_ZigClangCK._ARCExtendBlockObject;
+pub const ZigClangCK_AtomicToNonAtomic = enum_ZigClangCK._AtomicToNonAtomic;
+pub const ZigClangCK_NonAtomicToAtomic = enum_ZigClangCK._NonAtomicToAtomic;
+pub const ZigClangCK_CopyAndAutoreleaseBlockObject = enum_ZigClangCK._CopyAndAutoreleaseBlockObject;
+pub const ZigClangCK_BuiltinFnToFnPtr = enum_ZigClangCK._BuiltinFnToFnPtr;
+pub const ZigClangCK_ZeroToOCLOpaqueType = enum_ZigClangCK._ZeroToOCLOpaqueType;
+pub const ZigClangCK_AddressSpaceConversion = enum_ZigClangCK._AddressSpaceConversion;
+pub const ZigClangCK_IntToOCLSampler = enum_ZigClangCK._IntToOCLSampler;
+pub const enum_ZigClangCK = extern enum {
+    _Dependent,
+    _BitCast,
+    _LValueBitCast,
+    _LValueToRValue,
+    _NoOp,
+    _BaseToDerived,
+    _DerivedToBase,
+    _UncheckedDerivedToBase,
+    _Dynamic,
+    _ToUnion,
+    _ArrayToPointerDecay,
+    _FunctionToPointerDecay,
+    _NullToPointer,
+    _NullToMemberPointer,
+    _BaseToDerivedMemberPointer,
+    _DerivedToBaseMemberPointer,
+    _MemberPointerToBoolean,
+    _ReinterpretMemberPointer,
+    _UserDefinedConversion,
+    _ConstructorConversion,
+    _IntegralToPointer,
+    _PointerToIntegral,
+    _PointerToBoolean,
+    _ToVoid,
+    _VectorSplat,
+    _IntegralCast,
+    _IntegralToBoolean,
+    _IntegralToFloating,
+    _FixedPointCast,
+    _FixedPointToBoolean,
+    _FloatingToIntegral,
+    _FloatingToBoolean,
+    _BooleanToSignedIntegral,
+    _FloatingCast,
+    _CPointerToObjCPointerCast,
+    _BlockPointerToObjCPointerCast,
+    _AnyPointerToBlockPointerCast,
+    _ObjCObjectLValueCast,
+    _FloatingRealToComplex,
+    _FloatingComplexToReal,
+    _FloatingComplexToBoolean,
+    _FloatingComplexCast,
+    _FloatingComplexToIntegralComplex,
+    _IntegralRealToComplex,
+    _IntegralComplexToReal,
+    _IntegralComplexToBoolean,
+    _IntegralComplexCast,
+    _IntegralComplexToFloatingComplex,
+    _ARCProduceObject,
+    _ARCConsumeObject,
+    _ARCReclaimReturnedObject,
+    _ARCExtendBlockObject,
+    _AtomicToNonAtomic,
+    _NonAtomicToAtomic,
+    _CopyAndAutoreleaseBlockObject,
+    _BuiltinFnToFnPtr,
+    _ZeroToOCLOpaqueType,
+    _AddressSpaceConversion,
+    _IntToOCLSampler,
+};
+pub const ZigClangAPValueUninitialized = enum_ZigClangAPValueKind.ZigClangAPValueUninitialized;
+pub const ZigClangAPValueInt = enum_ZigClangAPValueKind.ZigClangAPValueInt;
+pub const ZigClangAPValueFloat = enum_ZigClangAPValueKind.ZigClangAPValueFloat;
+pub const ZigClangAPValueComplexInt = enum_ZigClangAPValueKind.ZigClangAPValueComplexInt;
+pub const ZigClangAPValueComplexFloat = enum_ZigClangAPValueKind.ZigClangAPValueComplexFloat;
+pub const ZigClangAPValueLValue = enum_ZigClangAPValueKind.ZigClangAPValueLValue;
+pub const ZigClangAPValueVector = enum_ZigClangAPValueKind.ZigClangAPValueVector;
+pub const ZigClangAPValueArray = enum_ZigClangAPValueKind.ZigClangAPValueArray;
+pub const ZigClangAPValueStruct = enum_ZigClangAPValueKind.ZigClangAPValueStruct;
+pub const ZigClangAPValueUnion = enum_ZigClangAPValueKind.ZigClangAPValueUnion;
+pub const ZigClangAPValueMemberPointer = enum_ZigClangAPValueKind.ZigClangAPValueMemberPointer;
+pub const ZigClangAPValueAddrLabelDiff = enum_ZigClangAPValueKind.ZigClangAPValueAddrLabelDiff;
+pub const enum_ZigClangAPValueKind = extern enum {
+    ZigClangAPValueUninitialized,
+    ZigClangAPValueInt,
+    ZigClangAPValueFloat,
+    ZigClangAPValueComplexInt,
+    ZigClangAPValueComplexFloat,
+    ZigClangAPValueLValue,
+    ZigClangAPValueVector,
+    ZigClangAPValueArray,
+    ZigClangAPValueStruct,
+    ZigClangAPValueUnion,
+    ZigClangAPValueMemberPointer,
+    ZigClangAPValueAddrLabelDiff,
+};
+pub extern fn ZigClangSourceManager_getSpellingLoc(arg0: ?*const struct_ZigClangSourceManager, Loc: struct_ZigClangSourceLocation) struct_ZigClangSourceLocation;
+pub extern fn ZigClangSourceManager_getFilename(arg0: ?*const struct_ZigClangSourceManager, SpellingLoc: struct_ZigClangSourceLocation) [*c]const u8;
+pub extern fn ZigClangSourceManager_getSpellingLineNumber(arg0: ?*const struct_ZigClangSourceManager, Loc: struct_ZigClangSourceLocation) c_uint;
+pub extern fn ZigClangSourceManager_getSpellingColumnNumber(arg0: ?*const struct_ZigClangSourceManager, Loc: struct_ZigClangSourceLocation) c_uint;
+pub extern fn ZigClangSourceManager_getCharacterData(arg0: ?*const struct_ZigClangSourceManager, SL: struct_ZigClangSourceLocation) [*c]const u8;
+pub extern fn ZigClangASTContext_getPointerType(arg0: ?*const struct_ZigClangASTContext, T: struct_ZigClangQualType) struct_ZigClangQualType;
+pub extern fn ZigClangASTUnit_getASTContext(arg0: ?*struct_ZigClangASTUnit) ?*struct_ZigClangASTContext;
+pub extern fn ZigClangASTUnit_getSourceManager(arg0: ?*struct_ZigClangASTUnit) ?*struct_ZigClangSourceManager;
+pub extern fn ZigClangASTUnit_visitLocalTopLevelDecls(arg0: ?*struct_ZigClangASTUnit, context: ?*c_void, Fn: ?extern fn (?*c_void, ?*const struct_ZigClangDecl) bool) bool;
+pub extern fn ZigClangRecordType_getDecl(record_ty: ?*const struct_ZigClangRecordType) ?*const struct_ZigClangRecordDecl;
+pub extern fn ZigClangEnumType_getDecl(record_ty: ?*const struct_ZigClangEnumType) ?*const struct_ZigClangEnumDecl;
+pub extern fn ZigClangRecordDecl_getCanonicalDecl(record_decl: ?*const struct_ZigClangRecordDecl) ?*const struct_ZigClangTagDecl;
+pub extern fn ZigClangEnumDecl_getCanonicalDecl(arg0: ?*const struct_ZigClangEnumDecl) ?*const struct_ZigClangTagDecl;
+pub extern fn ZigClangTypedefNameDecl_getCanonicalDecl(arg0: ?*const struct_ZigClangTypedefNameDecl) ?*const struct_ZigClangTypedefNameDecl;
+pub extern fn ZigClangRecordDecl_getDefinition(arg0: ?*const struct_ZigClangRecordDecl) ?*const struct_ZigClangRecordDecl;
+pub extern fn ZigClangEnumDecl_getDefinition(arg0: ?*const struct_ZigClangEnumDecl) ?*const struct_ZigClangEnumDecl;
+pub extern fn ZigClangRecordDecl_getLocation(arg0: ?*const struct_ZigClangRecordDecl) struct_ZigClangSourceLocation;
+pub extern fn ZigClangEnumDecl_getLocation(arg0: ?*const struct_ZigClangEnumDecl) struct_ZigClangSourceLocation;
+pub extern fn ZigClangTypedefNameDecl_getLocation(arg0: ?*const struct_ZigClangTypedefNameDecl) struct_ZigClangSourceLocation;
+pub extern fn ZigClangRecordDecl_isUnion(record_decl: ?*const struct_ZigClangRecordDecl) bool;
+pub extern fn ZigClangRecordDecl_isStruct(record_decl: ?*const struct_ZigClangRecordDecl) bool;
+pub extern fn ZigClangRecordDecl_isAnonymousStructOrUnion(record_decl: ?*const struct_ZigClangRecordDecl) bool;
+pub extern fn ZigClangEnumDecl_getIntegerType(arg0: ?*const struct_ZigClangEnumDecl) struct_ZigClangQualType;
+pub extern fn ZigClangDecl_getName_bytes_begin(decl: ?*const struct_ZigClangDecl) [*c]const u8;
+pub extern fn ZigClangSourceLocation_eq(a: struct_ZigClangSourceLocation, b: struct_ZigClangSourceLocation) bool;
+pub extern fn ZigClangTypedefType_getDecl(arg0: ?*const struct_ZigClangTypedefType) ?*const struct_ZigClangTypedefNameDecl;
+pub extern fn ZigClangTypedefNameDecl_getUnderlyingType(arg0: ?*const struct_ZigClangTypedefNameDecl) struct_ZigClangQualType;
+pub extern fn ZigClangQualType_getCanonicalType(arg0: struct_ZigClangQualType) struct_ZigClangQualType;
+pub extern fn ZigClangQualType_getTypePtr(arg0: struct_ZigClangQualType) ?*const struct_ZigClangType;
+pub extern fn ZigClangQualType_addConst(arg0: [*c]struct_ZigClangQualType) void;
+pub extern fn ZigClangQualType_eq(arg0: struct_ZigClangQualType, arg1: struct_ZigClangQualType) bool;
+pub extern fn ZigClangQualType_isConstQualified(arg0: struct_ZigClangQualType) bool;
+pub extern fn ZigClangQualType_isVolatileQualified(arg0: struct_ZigClangQualType) bool;
+pub extern fn ZigClangQualType_isRestrictQualified(arg0: struct_ZigClangQualType) bool;
+pub extern fn ZigClangType_getTypeClass(self: ?*const struct_ZigClangType) enum_ZigClangTypeClass;
+pub extern fn ZigClangType_isVoidType(self: ?*const struct_ZigClangType) bool;
+pub extern fn ZigClangType_getTypeClassName(self: ?*const struct_ZigClangType) [*c]const u8;
+pub extern fn ZigClangStmt_getBeginLoc(self: ?*const struct_ZigClangStmt) struct_ZigClangSourceLocation;
+pub extern fn ZigClangStmt_getStmtClass(self: ?*const struct_ZigClangStmt) enum_ZigClangStmtClass;
+pub extern fn ZigClangStmt_classof_Expr(self: ?*const struct_ZigClangStmt) bool;
+pub extern fn ZigClangExpr_getStmtClass(self: ?*const struct_ZigClangExpr) enum_ZigClangStmtClass;
+pub extern fn ZigClangExpr_getType(self: ?*const struct_ZigClangExpr) struct_ZigClangQualType;
+pub extern fn ZigClangExpr_getBeginLoc(self: ?*const struct_ZigClangExpr) struct_ZigClangSourceLocation;
+pub extern fn ZigClangAPValue_getKind(self: ?*const struct_ZigClangAPValue) enum_ZigClangAPValueKind;
+pub extern fn ZigClangAPValue_getInt(self: ?*const struct_ZigClangAPValue) ?*const struct_ZigClangAPSInt;
+pub extern fn ZigClangAPValue_getArrayInitializedElts(self: ?*const struct_ZigClangAPValue) c_uint;
+pub extern fn ZigClangAPValue_getArrayInitializedElt(self: ?*const struct_ZigClangAPValue, i: c_uint) ?*const struct_ZigClangAPValue;
+pub extern fn ZigClangAPValue_getArrayFiller(self: ?*const struct_ZigClangAPValue) ?*const struct_ZigClangAPValue;
+pub extern fn ZigClangAPValue_getArraySize(self: ?*const struct_ZigClangAPValue) c_uint;
+pub extern fn ZigClangAPValue_getLValueBase(self: ?*const struct_ZigClangAPValue) struct_ZigClangAPValueLValueBase;
+pub extern fn ZigClangAPSInt_isSigned(self: ?*const struct_ZigClangAPSInt) bool;
+pub extern fn ZigClangAPSInt_isNegative(self: ?*const struct_ZigClangAPSInt) bool;
+pub extern fn ZigClangAPSInt_negate(self: ?*const struct_ZigClangAPSInt) ?*const struct_ZigClangAPSInt;
+pub extern fn ZigClangAPSInt_free(self: ?*const struct_ZigClangAPSInt) void;
+pub extern fn ZigClangAPSInt_getRawData(self: ?*const struct_ZigClangAPSInt) [*c]const u64;
+pub extern fn ZigClangAPSInt_getNumWords(self: ?*const struct_ZigClangAPSInt) c_uint;
+pub extern fn ZigClangAPValueLValueBase_dyn_cast_Expr(self: struct_ZigClangAPValueLValueBase) ?*const struct_ZigClangExpr;
+pub const ZigClangSourceLocation = struct_ZigClangSourceLocation;
+pub const ZigClangQualType = struct_ZigClangQualType;
+pub const ZigClangAPValueLValueBase = struct_ZigClangAPValueLValueBase;
+pub const ZigClangAPValue = struct_ZigClangAPValue;
+pub const ZigClangAPSInt = struct_ZigClangAPSInt;
+pub const ZigClangASTContext = struct_ZigClangASTContext;
+pub const ZigClangASTUnit = struct_ZigClangASTUnit;
+pub const ZigClangArraySubscriptExpr = struct_ZigClangArraySubscriptExpr;
+pub const ZigClangArrayType = struct_ZigClangArrayType;
+pub const ZigClangAttributedType = struct_ZigClangAttributedType;
+pub const ZigClangBinaryOperator = struct_ZigClangBinaryOperator;
+pub const ZigClangBreakStmt = struct_ZigClangBreakStmt;
+pub const ZigClangBuiltinType = struct_ZigClangBuiltinType;
+pub const ZigClangCStyleCastExpr = struct_ZigClangCStyleCastExpr;
+pub const ZigClangCallExpr = struct_ZigClangCallExpr;
+pub const ZigClangCaseStmt = struct_ZigClangCaseStmt;
+pub const ZigClangCompoundAssignOperator = struct_ZigClangCompoundAssignOperator;
+pub const ZigClangCompoundStmt = struct_ZigClangCompoundStmt;
+pub const ZigClangConditionalOperator = struct_ZigClangConditionalOperator;
+pub const ZigClangConstantArrayType = struct_ZigClangConstantArrayType;
+pub const ZigClangContinueStmt = struct_ZigClangContinueStmt;
+pub const ZigClangDecayedType = struct_ZigClangDecayedType;
+pub const ZigClangDecl = struct_ZigClangDecl;
+pub const ZigClangDeclRefExpr = struct_ZigClangDeclRefExpr;
+pub const ZigClangDeclStmt = struct_ZigClangDeclStmt;
+pub const ZigClangDefaultStmt = struct_ZigClangDefaultStmt;
+pub const ZigClangDiagnosticOptions = struct_ZigClangDiagnosticOptions;
+pub const ZigClangDiagnosticsEngine = struct_ZigClangDiagnosticsEngine;
+pub const ZigClangDoStmt = struct_ZigClangDoStmt;
+pub const ZigClangElaboratedType = struct_ZigClangElaboratedType;
+pub const ZigClangEnumConstantDecl = struct_ZigClangEnumConstantDecl;
+pub const ZigClangEnumDecl = struct_ZigClangEnumDecl;
+pub const ZigClangEnumType = struct_ZigClangEnumType;
+pub const ZigClangExpr = struct_ZigClangExpr;
+pub const ZigClangFieldDecl = struct_ZigClangFieldDecl;
+pub const ZigClangFileID = struct_ZigClangFileID;
+pub const ZigClangForStmt = struct_ZigClangForStmt;
+pub const ZigClangFullSourceLoc = struct_ZigClangFullSourceLoc;
+pub const ZigClangFunctionDecl = struct_ZigClangFunctionDecl;
+pub const ZigClangFunctionProtoType = struct_ZigClangFunctionProtoType;
+pub const ZigClangIfStmt = struct_ZigClangIfStmt;
+pub const ZigClangImplicitCastExpr = struct_ZigClangImplicitCastExpr;
+pub const ZigClangIncompleteArrayType = struct_ZigClangIncompleteArrayType;
+pub const ZigClangIntegerLiteral = struct_ZigClangIntegerLiteral;
+pub const ZigClangMacroDefinitionRecord = struct_ZigClangMacroDefinitionRecord;
+pub const ZigClangMemberExpr = struct_ZigClangMemberExpr;
+pub const ZigClangNamedDecl = struct_ZigClangNamedDecl;
+pub const ZigClangNone = struct_ZigClangNone;
+pub const ZigClangPCHContainerOperations = struct_ZigClangPCHContainerOperations;
+pub const ZigClangParenExpr = struct_ZigClangParenExpr;
+pub const ZigClangParenType = struct_ZigClangParenType;
+pub const ZigClangParmVarDecl = struct_ZigClangParmVarDecl;
+pub const ZigClangPointerType = struct_ZigClangPointerType;
+pub const ZigClangPreprocessedEntity = struct_ZigClangPreprocessedEntity;
+pub const ZigClangRecordDecl = struct_ZigClangRecordDecl;
+pub const ZigClangRecordType = struct_ZigClangRecordType;
+pub const ZigClangReturnStmt = struct_ZigClangReturnStmt;
+pub const ZigClangSkipFunctionBodiesScope = struct_ZigClangSkipFunctionBodiesScope;
+pub const ZigClangSourceManager = struct_ZigClangSourceManager;
+pub const ZigClangSourceRange = struct_ZigClangSourceRange;
+pub const ZigClangStmt = struct_ZigClangStmt;
+pub const ZigClangStorageClass = struct_ZigClangStorageClass;
+pub const ZigClangStringLiteral = struct_ZigClangStringLiteral;
+pub const ZigClangStringRef = struct_ZigClangStringRef;
+pub const ZigClangSwitchStmt = struct_ZigClangSwitchStmt;
+pub const ZigClangTagDecl = struct_ZigClangTagDecl;
+pub const ZigClangType = struct_ZigClangType;
+pub const ZigClangTypedefNameDecl = struct_ZigClangTypedefNameDecl;
+pub const ZigClangTypedefType = struct_ZigClangTypedefType;
+pub const ZigClangUnaryExprOrTypeTraitExpr = struct_ZigClangUnaryExprOrTypeTraitExpr;
+pub const ZigClangUnaryOperator = struct_ZigClangUnaryOperator;
+pub const ZigClangValueDecl = struct_ZigClangValueDecl;
+pub const ZigClangVarDecl = struct_ZigClangVarDecl;
+pub const ZigClangWhileStmt = struct_ZigClangWhileStmt;
+pub const ZigClangBO = enum_ZigClangBO;
+pub const ZigClangUO = enum_ZigClangUO;
+pub const ZigClangTypeClass = enum_ZigClangTypeClass;
+pub const ZigClangStmtClass = enum_ZigClangStmtClass;
+pub const ZigClangCK = enum_ZigClangCK;
+pub const ZigClangAPValueKind = enum_ZigClangAPValueKind;

--- a/src-self-hosted/clang.zig
+++ b/src-self-hosted/clang.zig
@@ -862,6 +862,7 @@ pub extern fn ZigClangAPSInt_free(self: ?*const struct_ZigClangAPSInt) void;
 pub extern fn ZigClangAPSInt_getRawData(self: ?*const struct_ZigClangAPSInt) [*c]const u64;
 pub extern fn ZigClangAPSInt_getNumWords(self: ?*const struct_ZigClangAPSInt) c_uint;
 pub extern fn ZigClangAPValueLValueBase_dyn_cast_Expr(self: struct_ZigClangAPValueLValueBase) ?*const struct_ZigClangExpr;
+pub extern fn ZigClangASTUnit_delete(arg0: ?*struct_ZigClangASTUnit) void;
 pub const ZigClangSourceLocation = struct_ZigClangSourceLocation;
 pub const ZigClangQualType = struct_ZigClangQualType;
 pub const ZigClangAPValueLValueBase = struct_ZigClangAPValueLValueBase;
@@ -942,3 +943,19 @@ pub const ZigClangTypeClass = enum_ZigClangTypeClass;
 pub const ZigClangStmtClass = enum_ZigClangStmtClass;
 pub const ZigClangCK = enum_ZigClangCK;
 pub const ZigClangAPValueKind = enum_ZigClangAPValueKind;
+
+pub const Stage2ErrorMsg = extern struct {
+    filename_ptr: ?[*]const u8,
+    filename_len: usize,
+    msg_ptr: [*]const u8,
+    msg_len: usize,
+    // valid until the ASTUnit is freed
+    source: ?[*]const u8,
+    // 0 based
+    line: c_uint,
+    // 0 based
+    column: c_uint,
+    // byte offset into source
+    offset: c_uint,
+};
+pub extern fn ZigClangErrorMsg_delete(ptr: [*c]Stage2ErrorMsg, len: usize) void;

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -858,7 +858,23 @@ fn cmdHelp(allocator: *Allocator, args: []const []const u8) !void {
     try stdout.write(usage);
 }
 
-const info_zen = @import("stage1.zig").info_zen;
+pub const info_zen =
+    \\
+    \\ * Communicate intent precisely.
+    \\ * Edge cases matter.
+    \\ * Favor reading code over writing code.
+    \\ * Only one obvious way to do things.
+    \\ * Runtime crashes are better than bugs.
+    \\ * Compile errors are better than runtime crashes.
+    \\ * Incremental improvements.
+    \\ * Avoid local maximums.
+    \\ * Reduce the amount one must remember.
+    \\ * Minimize energy spent on coding style.
+    \\ * Together we serve end users.
+    \\
+    \\
+;
+
 fn cmdZen(allocator: *Allocator, args: []const []const u8) !void {
     try stdout.write(info_zen);
 }

--- a/src-self-hosted/stage1.zig
+++ b/src-self-hosted/stage1.zig
@@ -88,10 +88,15 @@ export fn stage2_translate_c(
     out_ast.* = translate_c.translate(args_begin, args_end, switch (mode) {
         .import => translate_c.Mode.import,
         .translate => translate_c.Mode.translate,
-    }, &errors) catch |err| switch (err) {
+    }, &errors, resources_path) catch |err| switch (err) {
         error.Unimplemented => return Error.Unimplemented,
+        error.SemanticAnalyzeFail => {
+            out_errors_ptr.* = errors.ptr;
+            out_errors_len.* = errors.len;
+            return Error.CCompileErrors;
+        },
+        error.OutOfMemory => return Error.OutOfMemory,
     };
-
     return Error.None;
 }
 

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -10,6 +10,17 @@ pub const Mode = enum {
     translate,
 };
 
-pub fn translate(args_begin: [*]?[*]const u8, args_end: [*]?[*]const u8, mode: Mode) !*ast.Tree {
+pub const ClangErrMsg = Stage2ErrorMsg;
+
+pub fn translate(
+    args_begin: [*]?[*]const u8,
+    args_end: [*]?[*]const u8,
+    mode: Mode,
+    errors: *[]ClangErrMsg,
+) !*ast.Tree {
     return error.Unimplemented;
+}
+
+pub fn freeErrors(errors: []ClangErrMsg) void {
+    ZigClangErrorMsg_delete(errors.ptr, errors.len);
 }

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -17,7 +17,19 @@ pub fn translate(
     args_end: [*]?[*]const u8,
     mode: Mode,
     errors: *[]ClangErrMsg,
+    resources_path: [*]const u8,
 ) !*ast.Tree {
+    const ast_unit = ZigClangLoadFromCommandLine(
+        args_begin,
+        args_end,
+        &errors.ptr,
+        &errors.len,
+        resources_path,
+    ) orelse {
+        if (errors.len == 0) return error.OutOfMemory;
+        return error.SemanticAnalyzeFail;
+    };
+
     return error.Unimplemented;
 }
 

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -2,7 +2,14 @@
 // and stage2. Currently it's not used by anything, as it's not feature complete.
 
 const std = @import("std");
+const ast = std.zig.ast;
+use @import("clang.zig");
 
-export fn stage2_translate_c() void {
-    std.debug.panic("unimplemented");
+pub const Mode = enum {
+    import,
+    translate,
+};
+
+pub fn translate(args_begin: [*]?[*]const u8, args_end: [*]?[*]const u8, mode: Mode) !*ast.Tree {
+    return error.Unimplemented;
 }

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -3725,7 +3725,7 @@ static void analyze_fn_body(CodeGen *g, ZigFn *fn_table_entry) {
     }
     if (g->verbose_ir) {
         fprintf(stderr, "\n");
-        ast_render(g, stderr, fn_table_entry->body_node, 4);
+        ast_render(stderr, fn_table_entry->body_node, 4);
         fprintf(stderr, "\n{ // (IR)\n");
         ir_print(g, stderr, &fn_table_entry->ir_executable, 4);
         fprintf(stderr, "}\n");

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -247,4 +247,6 @@ Error create_c_object_cache(CodeGen *g, CacheHash **out_cache_hash, bool verbose
 LLVMTypeRef get_llvm_type(CodeGen *g, ZigType *type);
 ZigLLVMDIType *get_llvm_di_type(CodeGen *g, ZigType *type);
 
+void add_cc_args(CodeGen *g, ZigList<const char *> &args, const char *out_dep_path, bool translate_c);
+
 #endif

--- a/src/ast_render.cpp
+++ b/src/ast_render.cpp
@@ -296,7 +296,6 @@ void ast_print(FILE *f, AstNode *node, int indent) {
 
 
 struct AstRender {
-    CodeGen *codegen;
     int indent;
     int indent_size;
     FILE *f;
@@ -1170,9 +1169,8 @@ static void render_node_extra(AstRender *ar, AstNode *node, bool grouped) {
 }
 
 
-void ast_render(CodeGen *codegen, FILE *f, AstNode *node, int indent_size) {
+void ast_render(FILE *f, AstNode *node, int indent_size) {
     AstRender ar = {0};
-    ar.codegen = codegen;
     ar.f = f;
     ar.indent_size = indent_size;
     ar.indent = 0;

--- a/src/ast_render.hpp
+++ b/src/ast_render.hpp
@@ -15,6 +15,6 @@
 
 void ast_print(FILE *f, AstNode *node, int indent);
 
-void ast_render(CodeGen *codegen, FILE *f, AstNode *node, int indent_size);
+void ast_render(FILE *f, AstNode *node, int indent_size);
 
 #endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8155,6 +8155,11 @@ static void detect_libc(CodeGen *g) {
 
 // does not add the "cc" arg
 void add_cc_args(CodeGen *g, ZigList<const char *> &args, const char *out_dep_path, bool translate_c) {
+    if (translate_c) {
+        args.append("-x");
+        args.append("c");
+    }
+
     if (out_dep_path != nullptr) {
         args.append("-MD");
         args.append("-MV");
@@ -8166,13 +8171,6 @@ void add_cc_args(CodeGen *g, ZigList<const char *> &args, const char *out_dep_pa
     args.append("-fno-spell-checking");
 
     if (translate_c) {
-        // TODO these args shouldn't be special from the non-translate-c args, probably.
-        args.append("-nobuiltininc");
-        args.append("-nostdinc++");
-        if (g->libc_link_lib == nullptr) {
-            args.append("-nolibc");
-        }
-
         // this gives us access to preprocessing entities, presumably at
         // the cost of performance
         args.append("-Xclang");
@@ -8293,8 +8291,15 @@ void codegen_translate_c(CodeGen *g, Buf *full_path, FILE *out_file, bool use_us
     ZigList<const char *> clang_argv = {0};
     add_cc_args(g, clang_argv, nullptr, true);
 
-    clang_argv.append("-c");
     clang_argv.append(buf_ptr(full_path));
+
+    if (g->verbose_cc) {
+        fprintf(stderr, "clang");
+        for (size_t i = 0; i < clang_argv.length; i += 1) {
+            fprintf(stderr, " %s", clang_argv.at(i));
+        }
+        fprintf(stderr, "\n");
+    }
 
     clang_argv.append(nullptr); // to make the [start...end] argument work
 

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -12,6 +12,7 @@
 #include "errmsg.hpp"
 #include "target.hpp"
 #include "libc_installation.hpp"
+#include "userland.h"
 
 #include <stdio.h>
 
@@ -50,7 +51,7 @@ ZigPackage *codegen_create_package(CodeGen *g, const char *root_src_dir, const c
 void codegen_add_assembly(CodeGen *g, Buf *path);
 void codegen_add_object(CodeGen *g, Buf *object_path);
 
-AstNode *codegen_translate_c(CodeGen *g, Buf *path, bool use_userland_implementation);
+void codegen_translate_c(CodeGen *g, Buf *full_path, FILE *out_file, bool use_userland_implementation);
 
 Buf *codegen_generate_builtin_source(CodeGen *g);
 

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -50,6 +50,10 @@ const char *err_str(Error err) {
         case ErrorUnexpectedWriteFailure: return "unexpected write failure";
         case ErrorUnexpectedSeekFailure: return "unexpected seek failure";
         case ErrorUnexpectedFileTruncationFailure: return "unexpected file truncation failure";
+        case ErrorUnimplemented: return "unimplemented";
+        case ErrorOperationAborted: return "operation aborted";
+        case ErrorBrokenPipe: return "broken pipe";
+        case ErrorNoSpaceLeft: return "no space left";
     }
     return "(invalid error)";
 }

--- a/src/error.hpp
+++ b/src/error.hpp
@@ -8,49 +8,7 @@
 #ifndef ERROR_HPP
 #define ERROR_HPP
 
-enum Error {
-    ErrorNone,
-    ErrorNoMem,
-    ErrorInvalidFormat,
-    ErrorSemanticAnalyzeFail,
-    ErrorAccess,
-    ErrorInterrupted,
-    ErrorSystemResources,
-    ErrorFileNotFound,
-    ErrorFileSystem,
-    ErrorFileTooBig,
-    ErrorDivByZero,
-    ErrorOverflow,
-    ErrorPathAlreadyExists,
-    ErrorUnexpected,
-    ErrorExactDivRemainder,
-    ErrorNegativeDenominator,
-    ErrorShiftedOutOneBits,
-    ErrorCCompileErrors,
-    ErrorEndOfFile,
-    ErrorIsDir,
-    ErrorNotDir,
-    ErrorUnsupportedOperatingSystem,
-    ErrorSharingViolation,
-    ErrorPipeBusy,
-    ErrorPrimitiveTypeNotFound,
-    ErrorCacheUnavailable,
-    ErrorPathTooLong,
-    ErrorCCompilerCannotFindFile,
-    ErrorReadingDepFile,
-    ErrorInvalidDepFile,
-    ErrorMissingArchitecture,
-    ErrorMissingOperatingSystem,
-    ErrorUnknownArchitecture,
-    ErrorUnknownOperatingSystem,
-    ErrorUnknownABI,
-    ErrorInvalidFilename,
-    ErrorDiskQuota,
-    ErrorDiskSpace,
-    ErrorUnexpectedWriteFailure,
-    ErrorUnexpectedSeekFailure,
-    ErrorUnexpectedFileTruncationFailure,
-};
+#include "userland.h"
 
 const char *err_str(Error err);
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -19098,8 +19098,15 @@ static IrInstruction *ir_analyze_instruction_c_import(IrAnalyze *ira, IrInstruct
 
         add_cc_args(ira->codegen, clang_argv, buf_ptr(tmp_dep_file), true);
 
-        clang_argv.append("-c");
         clang_argv.append(buf_ptr(&tmp_c_file_path));
+
+        if (ira->codegen->verbose_cc) {
+            fprintf(stderr, "clang");
+            for (size_t i = 0; i < clang_argv.length; i += 1) {
+                fprintf(stderr, " %s", clang_argv.at(i));
+            }
+            fprintf(stderr, "\n");
+        }
 
         clang_argv.append(nullptr); // to make the [start...end] argument work
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1188,8 +1188,7 @@ int main(int argc, char **argv) {
                     zig_unreachable();
                 }
             } else if (cmd == CmdTranslateC || cmd == CmdTranslateCUserland) {
-                AstNode *root_node = codegen_translate_c(g, in_file_buf, cmd == CmdTranslateCUserland);
-                ast_render(g, stdout, root_node, 4);
+                codegen_translate_c(g, in_file_buf, stdout, cmd == CmdTranslateCUserland);
                 if (timing_info)
                     codegen_print_timing_report(g, stderr);
                 return EXIT_SUCCESS;

--- a/src/translate_c.cpp
+++ b/src/translate_c.cpp
@@ -5060,5 +5060,7 @@ Error parse_h_file(CodeGen *codegen, AstNode **out_root_node,
 
     *out_root_node = c->root;
 
+    ZigClangASTUnit_delete(ast_unit);
+
     return ErrorNone;
 }

--- a/src/translate_c.hpp
+++ b/src/translate_c.hpp
@@ -11,7 +11,9 @@
 
 #include "all_types.hpp"
 
-Error parse_h_file(CodeGen *codegen, AstNode **out_root_node, const char **args_begin, const char **args_end,
-        Stage2TranslateMode mode, ZigList<ErrorMsg *> *errors);
+Error parse_h_file(CodeGen *codegen, AstNode **out_root_node,
+        Stage2ErrorMsg **errors_ptr, size_t *errors_len,
+        const char **args_begin, const char **args_end,
+        Stage2TranslateMode mode, const char *resources_path);
 
 #endif

--- a/src/translate_c.hpp
+++ b/src/translate_c.hpp
@@ -11,7 +11,7 @@
 
 #include "all_types.hpp"
 
-Error parse_h_file(AstNode **out_root_node, ZigList<ErrorMsg *> *errors, const char *target_file,
-        CodeGen *codegen, Buf *tmp_dep_file);
+Error parse_h_file(CodeGen *codegen, AstNode **out_root_node, const char **args_begin, const char **args_end,
+        Stage2TranslateMode mode, ZigList<ErrorMsg *> *errors);
 
 #endif

--- a/src/userland.cpp
+++ b/src/userland.cpp
@@ -8,9 +8,16 @@
 #include <string.h>
 
 Error stage2_translate_c(struct Stage2Ast **out_ast,
-        const char **args_begin, const char **args_end, enum Stage2TranslateMode mode)
+        struct Stage2ErrorMsg **out_errors_ptr, size_t *out_errors_len,
+        const char **args_begin, const char **args_end, enum Stage2TranslateMode mode,
+        const char *resources_path)
 {
     const char *msg = "stage0 called stage2_translate_c";
+    stage2_panic(msg, strlen(msg));
+}
+
+void stage2_free_clang_errors(struct Stage2ErrorMsg *ptr, size_t len) {
+    const char *msg = "stage0 called stage2_free_clang_errors";
     stage2_panic(msg, strlen(msg));
 }
 

--- a/src/userland.cpp
+++ b/src/userland.cpp
@@ -2,11 +2,14 @@
 // src-self-hosted/stage1.zig
 
 #include "userland.h"
+#include "ast_render.hpp"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-void stage2_translate_c(void) {
+Error stage2_translate_c(struct Stage2Ast **out_ast,
+        const char **args_begin, const char **args_end, enum Stage2TranslateMode mode)
+{
     const char *msg = "stage0 called stage2_translate_c";
     stage2_panic(msg, strlen(msg));
 }
@@ -21,4 +24,9 @@ void stage2_panic(const char *ptr, size_t len) {
     fprintf(stderr, "\n");
     fflush(stderr);
     abort();
+}
+
+void stage2_render_ast(struct Stage2Ast *ast, FILE *output_file) {
+    const char *msg = "stage0 called stage2_render_ast";
+    stage2_panic(msg, strlen(msg));
 }

--- a/src/userland.h
+++ b/src/userland.h
@@ -9,6 +9,7 @@
 #define ZIG_USERLAND_H
 
 #include <stddef.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 #define ZIG_USERLAND_EXTERN_C extern "C"
@@ -16,10 +17,77 @@
 #define ZIG_USERLAND_EXTERN_C
 #endif
 
-ZIG_USERLAND_EXTERN_C void stage2_translate_c(void);
+#if defined(_MSC_VER)
+#define ZIG_USERLAND_ATTRIBUTE_NORETURN __declspec(noreturn)
+#else
+#define ZIG_USERLAND_ATTRIBUTE_NORETURN __attribute__((noreturn))
+#endif
+
+// The types and declarations in this file must match both those in userland.cpp and
+// src-self-hosted/stage1.zig.
+
+enum Error {
+    ErrorNone,
+    ErrorNoMem,
+    ErrorInvalidFormat,
+    ErrorSemanticAnalyzeFail,
+    ErrorAccess,
+    ErrorInterrupted,
+    ErrorSystemResources,
+    ErrorFileNotFound,
+    ErrorFileSystem,
+    ErrorFileTooBig,
+    ErrorDivByZero,
+    ErrorOverflow,
+    ErrorPathAlreadyExists,
+    ErrorUnexpected,
+    ErrorExactDivRemainder,
+    ErrorNegativeDenominator,
+    ErrorShiftedOutOneBits,
+    ErrorCCompileErrors,
+    ErrorEndOfFile,
+    ErrorIsDir,
+    ErrorNotDir,
+    ErrorUnsupportedOperatingSystem,
+    ErrorSharingViolation,
+    ErrorPipeBusy,
+    ErrorPrimitiveTypeNotFound,
+    ErrorCacheUnavailable,
+    ErrorPathTooLong,
+    ErrorCCompilerCannotFindFile,
+    ErrorReadingDepFile,
+    ErrorInvalidDepFile,
+    ErrorMissingArchitecture,
+    ErrorMissingOperatingSystem,
+    ErrorUnknownArchitecture,
+    ErrorUnknownOperatingSystem,
+    ErrorUnknownABI,
+    ErrorInvalidFilename,
+    ErrorDiskQuota,
+    ErrorDiskSpace,
+    ErrorUnexpectedWriteFailure,
+    ErrorUnexpectedSeekFailure,
+    ErrorUnexpectedFileTruncationFailure,
+    ErrorUnimplemented,
+    ErrorOperationAborted,
+    ErrorBrokenPipe,
+    ErrorNoSpaceLeft,
+};
+
+enum Stage2TranslateMode {
+    Stage2TranslateModeImport,
+    Stage2TranslateModeTranslate,
+};
+
+struct Stage2Ast;
+
+ZIG_USERLAND_EXTERN_C Error stage2_translate_c(struct Stage2Ast **out_ast,
+        const char **args_begin, const char **args_end, enum Stage2TranslateMode mode);
+
+ZIG_USERLAND_EXTERN_C void stage2_render_ast(struct Stage2Ast *ast, FILE *output_file);
 
 ZIG_USERLAND_EXTERN_C void stage2_zen(const char **ptr, size_t *len);
 
-ZIG_USERLAND_EXTERN_C void stage2_panic(const char *ptr, size_t len);
+ZIG_USERLAND_EXTERN_C ZIG_USERLAND_ATTRIBUTE_NORETURN void stage2_panic(const char *ptr, size_t len);
 
 #endif

--- a/src/userland.h
+++ b/src/userland.h
@@ -12,20 +12,21 @@
 #include <stdio.h>
 
 #ifdef __cplusplus
-#define ZIG_USERLAND_EXTERN_C extern "C"
+#define ZIG_EXTERN_C extern "C"
 #else
-#define ZIG_USERLAND_EXTERN_C
+#define ZIG_EXTERN_C
 #endif
 
 #if defined(_MSC_VER)
-#define ZIG_USERLAND_ATTRIBUTE_NORETURN __declspec(noreturn)
+#define ZIG_ATTRIBUTE_NORETURN __declspec(noreturn)
 #else
-#define ZIG_USERLAND_ATTRIBUTE_NORETURN __attribute__((noreturn))
+#define ZIG_ATTRIBUTE_NORETURN __attribute__((noreturn))
 #endif
 
-// The types and declarations in this file must match both those in userland.cpp and
-// src-self-hosted/stage1.zig.
+// ABI warning: the types and declarations in this file must match both those in
+// userland.cpp and src-self-hosted/stage1.zig.
 
+// ABI warning
 enum Error {
     ErrorNone,
     ErrorNoMem,
@@ -74,20 +75,43 @@ enum Error {
     ErrorNoSpaceLeft,
 };
 
+// ABI warning
 enum Stage2TranslateMode {
     Stage2TranslateModeImport,
     Stage2TranslateModeTranslate,
 };
 
+// ABI warning
+struct Stage2ErrorMsg {
+    const char *filename_ptr; // can be null
+    size_t filename_len;
+    const char *msg_ptr;
+    size_t msg_len;
+    const char *source; // valid until the ASTUnit is freed. can be null
+    unsigned line; // 0 based
+    unsigned column; // 0 based
+    unsigned offset; // byte offset into source
+};
+
+// ABI warning
 struct Stage2Ast;
 
-ZIG_USERLAND_EXTERN_C Error stage2_translate_c(struct Stage2Ast **out_ast,
-        const char **args_begin, const char **args_end, enum Stage2TranslateMode mode);
+// ABI warning
+ZIG_EXTERN_C enum Error stage2_translate_c(struct Stage2Ast **out_ast,
+        struct Stage2ErrorMsg **out_errors_ptr, size_t *out_errors_len,
+        const char **args_begin, const char **args_end, enum Stage2TranslateMode mode,
+        const char *resources_path);
 
-ZIG_USERLAND_EXTERN_C void stage2_render_ast(struct Stage2Ast *ast, FILE *output_file);
+// ABI warning
+ZIG_EXTERN_C void stage2_free_clang_errors(struct Stage2ErrorMsg *ptr, size_t len);
 
-ZIG_USERLAND_EXTERN_C void stage2_zen(const char **ptr, size_t *len);
+// ABI warning
+ZIG_EXTERN_C void stage2_render_ast(struct Stage2Ast *ast, FILE *output_file);
 
-ZIG_USERLAND_EXTERN_C ZIG_USERLAND_ATTRIBUTE_NORETURN void stage2_panic(const char *ptr, size_t len);
+// ABI warning
+ZIG_EXTERN_C void stage2_zen(const char **ptr, size_t *len);
+
+// ABI warning
+ZIG_EXTERN_C ZIG_ATTRIBUTE_NORETURN void stage2_panic(const char *ptr, size_t len);
 
 #endif

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -8,14 +8,9 @@
 #ifndef ZIG_ZIG_CLANG_H
 #define ZIG_ZIG_CLANG_H
 
+#include "userland.h"
 #include <inttypes.h>
 #include <stdbool.h>
-
-#ifdef __cplusplus
-#define ZIG_EXTERN_C extern "C"
-#else
-#define ZIG_EXTERN_C
-#endif
 
 // ATTENTION: If you modify this file, be sure to update the corresponding
 // extern function declarations in the self-hosted compiler file
@@ -499,6 +494,13 @@ ZIG_EXTERN_C const char* ZigClangSourceManager_getCharacterData(const struct Zig
         struct ZigClangSourceLocation SL);
 
 ZIG_EXTERN_C struct ZigClangQualType ZigClangASTContext_getPointerType(const struct ZigClangASTContext*, struct ZigClangQualType T);
+
+
+// Can return null.
+ZIG_EXTERN_C struct ZigClangASTUnit *ZigClangLoadFromCommandLine(const char **args_begin, const char **args_end,
+        struct Stage2ErrorMsg **errors_ptr, size_t *errors_len, const char *resources_path);
+ZIG_EXTERN_C void ZigClangASTUnit_delete(struct ZigClangASTUnit *);
+ZIG_EXTERN_C void ZigClangErrorMsg_delete(struct Stage2ErrorMsg *ptr, size_t len);
 
 ZIG_EXTERN_C struct ZigClangASTContext *ZigClangASTUnit_getASTContext(struct ZigClangASTUnit *);
 ZIG_EXTERN_C struct ZigClangSourceManager *ZigClangASTUnit_getSourceManager(struct ZigClangASTUnit *);

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -9,6 +9,7 @@
 #define ZIG_ZIG_CLANG_H
 
 #include <inttypes.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 #define ZIG_EXTERN_C extern "C"
@@ -17,8 +18,8 @@
 #endif
 
 // ATTENTION: If you modify this file, be sure to update the corresponding
-// extern function declarations in the self-hosted compiler.
-// Note: not yet, we don't have the corresponding clang.zig yet.
+// extern function declarations in the self-hosted compiler file
+// src-self-hosted/clang.zig.
 
 struct ZigClangSourceLocation {
     unsigned ID;
@@ -486,86 +487,86 @@ enum ZigClangAPValueKind {
     ZigClangAPValueAddrLabelDiff,
 };
 
-ZIG_EXTERN_C ZigClangSourceLocation ZigClangSourceManager_getSpellingLoc(const ZigClangSourceManager *,
-        ZigClangSourceLocation Loc);
-ZIG_EXTERN_C const char *ZigClangSourceManager_getFilename(const ZigClangSourceManager *,
-        ZigClangSourceLocation SpellingLoc);
-ZIG_EXTERN_C unsigned ZigClangSourceManager_getSpellingLineNumber(const ZigClangSourceManager *,
-        ZigClangSourceLocation Loc);
-ZIG_EXTERN_C unsigned ZigClangSourceManager_getSpellingColumnNumber(const ZigClangSourceManager *,
-        ZigClangSourceLocation Loc);
-ZIG_EXTERN_C const char* ZigClangSourceManager_getCharacterData(const ZigClangSourceManager *,
-        ZigClangSourceLocation SL);
+ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangSourceManager_getSpellingLoc(const struct ZigClangSourceManager *,
+        struct ZigClangSourceLocation Loc);
+ZIG_EXTERN_C const char *ZigClangSourceManager_getFilename(const struct ZigClangSourceManager *,
+        struct ZigClangSourceLocation SpellingLoc);
+ZIG_EXTERN_C unsigned ZigClangSourceManager_getSpellingLineNumber(const struct ZigClangSourceManager *,
+        struct ZigClangSourceLocation Loc);
+ZIG_EXTERN_C unsigned ZigClangSourceManager_getSpellingColumnNumber(const struct ZigClangSourceManager *,
+        struct ZigClangSourceLocation Loc);
+ZIG_EXTERN_C const char* ZigClangSourceManager_getCharacterData(const struct ZigClangSourceManager *,
+        struct ZigClangSourceLocation SL);
 
-ZIG_EXTERN_C ZigClangQualType ZigClangASTContext_getPointerType(const ZigClangASTContext*, ZigClangQualType T);
+ZIG_EXTERN_C struct ZigClangQualType ZigClangASTContext_getPointerType(const struct ZigClangASTContext*, struct ZigClangQualType T);
 
-ZIG_EXTERN_C ZigClangASTContext *ZigClangASTUnit_getASTContext(ZigClangASTUnit *);
-ZIG_EXTERN_C ZigClangSourceManager *ZigClangASTUnit_getSourceManager(ZigClangASTUnit *);
-ZIG_EXTERN_C bool ZigClangASTUnit_visitLocalTopLevelDecls(ZigClangASTUnit *, void *context, 
-    bool (*Fn)(void *context, const ZigClangDecl *decl));
+ZIG_EXTERN_C struct ZigClangASTContext *ZigClangASTUnit_getASTContext(struct ZigClangASTUnit *);
+ZIG_EXTERN_C struct ZigClangSourceManager *ZigClangASTUnit_getSourceManager(struct ZigClangASTUnit *);
+ZIG_EXTERN_C bool ZigClangASTUnit_visitLocalTopLevelDecls(struct ZigClangASTUnit *, void *context, 
+    bool (*Fn)(void *context, const struct ZigClangDecl *decl));
 
-ZIG_EXTERN_C const ZigClangRecordDecl *ZigClangRecordType_getDecl(const ZigClangRecordType *record_ty);
-ZIG_EXTERN_C const ZigClangEnumDecl *ZigClangEnumType_getDecl(const ZigClangEnumType *record_ty);
+ZIG_EXTERN_C const struct ZigClangRecordDecl *ZigClangRecordType_getDecl(const struct ZigClangRecordType *record_ty);
+ZIG_EXTERN_C const struct ZigClangEnumDecl *ZigClangEnumType_getDecl(const struct ZigClangEnumType *record_ty);
 
-ZIG_EXTERN_C const ZigClangTagDecl *ZigClangRecordDecl_getCanonicalDecl(const ZigClangRecordDecl *record_decl);
-ZIG_EXTERN_C const ZigClangTagDecl *ZigClangEnumDecl_getCanonicalDecl(const ZigClangEnumDecl *);
-ZIG_EXTERN_C const ZigClangTypedefNameDecl *ZigClangTypedefNameDecl_getCanonicalDecl(const ZigClangTypedefNameDecl *);
+ZIG_EXTERN_C const struct ZigClangTagDecl *ZigClangRecordDecl_getCanonicalDecl(const struct ZigClangRecordDecl *record_decl);
+ZIG_EXTERN_C const struct ZigClangTagDecl *ZigClangEnumDecl_getCanonicalDecl(const struct ZigClangEnumDecl *);
+ZIG_EXTERN_C const struct ZigClangTypedefNameDecl *ZigClangTypedefNameDecl_getCanonicalDecl(const struct ZigClangTypedefNameDecl *);
 
-ZIG_EXTERN_C const ZigClangRecordDecl *ZigClangRecordDecl_getDefinition(const ZigClangRecordDecl *);
-ZIG_EXTERN_C const ZigClangEnumDecl *ZigClangEnumDecl_getDefinition(const ZigClangEnumDecl *);
+ZIG_EXTERN_C const struct ZigClangRecordDecl *ZigClangRecordDecl_getDefinition(const struct ZigClangRecordDecl *);
+ZIG_EXTERN_C const struct ZigClangEnumDecl *ZigClangEnumDecl_getDefinition(const struct ZigClangEnumDecl *);
 
-ZIG_EXTERN_C ZigClangSourceLocation ZigClangRecordDecl_getLocation(const ZigClangRecordDecl *);
-ZIG_EXTERN_C ZigClangSourceLocation ZigClangEnumDecl_getLocation(const ZigClangEnumDecl *);
-ZIG_EXTERN_C ZigClangSourceLocation ZigClangTypedefNameDecl_getLocation(const ZigClangTypedefNameDecl *);
+ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangRecordDecl_getLocation(const struct ZigClangRecordDecl *);
+ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangEnumDecl_getLocation(const struct ZigClangEnumDecl *);
+ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangTypedefNameDecl_getLocation(const struct ZigClangTypedefNameDecl *);
 
-ZIG_EXTERN_C bool ZigClangRecordDecl_isUnion(const ZigClangRecordDecl *record_decl);
-ZIG_EXTERN_C bool ZigClangRecordDecl_isStruct(const ZigClangRecordDecl *record_decl);
-ZIG_EXTERN_C bool ZigClangRecordDecl_isAnonymousStructOrUnion(const ZigClangRecordDecl *record_decl);
+ZIG_EXTERN_C bool ZigClangRecordDecl_isUnion(const struct ZigClangRecordDecl *record_decl);
+ZIG_EXTERN_C bool ZigClangRecordDecl_isStruct(const struct ZigClangRecordDecl *record_decl);
+ZIG_EXTERN_C bool ZigClangRecordDecl_isAnonymousStructOrUnion(const struct ZigClangRecordDecl *record_decl);
 
-ZIG_EXTERN_C ZigClangQualType ZigClangEnumDecl_getIntegerType(const ZigClangEnumDecl *);
+ZIG_EXTERN_C struct ZigClangQualType ZigClangEnumDecl_getIntegerType(const struct ZigClangEnumDecl *);
 
-ZIG_EXTERN_C const char *ZigClangDecl_getName_bytes_begin(const ZigClangDecl *decl);
+ZIG_EXTERN_C const char *ZigClangDecl_getName_bytes_begin(const struct ZigClangDecl *decl);
 
-ZIG_EXTERN_C bool ZigClangSourceLocation_eq(ZigClangSourceLocation a, ZigClangSourceLocation b);
+ZIG_EXTERN_C bool ZigClangSourceLocation_eq(struct ZigClangSourceLocation a, struct ZigClangSourceLocation b);
 
-ZIG_EXTERN_C const ZigClangTypedefNameDecl *ZigClangTypedefType_getDecl(const ZigClangTypedefType *);
-ZIG_EXTERN_C ZigClangQualType ZigClangTypedefNameDecl_getUnderlyingType(const ZigClangTypedefNameDecl *);
+ZIG_EXTERN_C const struct ZigClangTypedefNameDecl *ZigClangTypedefType_getDecl(const struct ZigClangTypedefType *);
+ZIG_EXTERN_C struct ZigClangQualType ZigClangTypedefNameDecl_getUnderlyingType(const struct ZigClangTypedefNameDecl *);
 
-ZIG_EXTERN_C ZigClangQualType ZigClangQualType_getCanonicalType(ZigClangQualType);
-ZIG_EXTERN_C const ZigClangType *ZigClangQualType_getTypePtr(ZigClangQualType);
-ZIG_EXTERN_C void ZigClangQualType_addConst(ZigClangQualType *);
-ZIG_EXTERN_C bool ZigClangQualType_eq(ZigClangQualType, ZigClangQualType);
-ZIG_EXTERN_C bool ZigClangQualType_isConstQualified(ZigClangQualType);
-ZIG_EXTERN_C bool ZigClangQualType_isVolatileQualified(ZigClangQualType);
-ZIG_EXTERN_C bool ZigClangQualType_isRestrictQualified(ZigClangQualType);
+ZIG_EXTERN_C struct ZigClangQualType ZigClangQualType_getCanonicalType(struct ZigClangQualType);
+ZIG_EXTERN_C const struct ZigClangType *ZigClangQualType_getTypePtr(struct ZigClangQualType);
+ZIG_EXTERN_C void ZigClangQualType_addConst(struct ZigClangQualType *);
+ZIG_EXTERN_C bool ZigClangQualType_eq(struct ZigClangQualType, struct ZigClangQualType);
+ZIG_EXTERN_C bool ZigClangQualType_isConstQualified(struct ZigClangQualType);
+ZIG_EXTERN_C bool ZigClangQualType_isVolatileQualified(struct ZigClangQualType);
+ZIG_EXTERN_C bool ZigClangQualType_isRestrictQualified(struct ZigClangQualType);
 
-ZIG_EXTERN_C ZigClangTypeClass ZigClangType_getTypeClass(const ZigClangType *self);
-ZIG_EXTERN_C bool ZigClangType_isVoidType(const ZigClangType *self);
-ZIG_EXTERN_C const char *ZigClangType_getTypeClassName(const ZigClangType *self);
+ZIG_EXTERN_C enum ZigClangTypeClass ZigClangType_getTypeClass(const struct ZigClangType *self);
+ZIG_EXTERN_C bool ZigClangType_isVoidType(const struct ZigClangType *self);
+ZIG_EXTERN_C const char *ZigClangType_getTypeClassName(const struct ZigClangType *self);
 
-ZIG_EXTERN_C ZigClangSourceLocation ZigClangStmt_getBeginLoc(const ZigClangStmt *self);
-ZIG_EXTERN_C ZigClangStmtClass ZigClangStmt_getStmtClass(const ZigClangStmt *self);
-ZIG_EXTERN_C bool ZigClangStmt_classof_Expr(const ZigClangStmt *self);
+ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangStmt_getBeginLoc(const struct ZigClangStmt *self);
+ZIG_EXTERN_C enum ZigClangStmtClass ZigClangStmt_getStmtClass(const struct ZigClangStmt *self);
+ZIG_EXTERN_C bool ZigClangStmt_classof_Expr(const struct ZigClangStmt *self);
 
-ZIG_EXTERN_C ZigClangStmtClass ZigClangExpr_getStmtClass(const ZigClangExpr *self);
-ZIG_EXTERN_C ZigClangQualType ZigClangExpr_getType(const ZigClangExpr *self);
-ZIG_EXTERN_C ZigClangSourceLocation ZigClangExpr_getBeginLoc(const ZigClangExpr *self);
+ZIG_EXTERN_C enum ZigClangStmtClass ZigClangExpr_getStmtClass(const struct ZigClangExpr *self);
+ZIG_EXTERN_C struct ZigClangQualType ZigClangExpr_getType(const struct ZigClangExpr *self);
+ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangExpr_getBeginLoc(const struct ZigClangExpr *self);
 
-ZIG_EXTERN_C ZigClangAPValueKind ZigClangAPValue_getKind(const ZigClangAPValue *self);
-ZIG_EXTERN_C const ZigClangAPSInt *ZigClangAPValue_getInt(const ZigClangAPValue *self);
-ZIG_EXTERN_C unsigned ZigClangAPValue_getArrayInitializedElts(const ZigClangAPValue *self);
-ZIG_EXTERN_C const ZigClangAPValue *ZigClangAPValue_getArrayInitializedElt(const ZigClangAPValue *self, unsigned i);
-ZIG_EXTERN_C const ZigClangAPValue *ZigClangAPValue_getArrayFiller(const ZigClangAPValue *self);
-ZIG_EXTERN_C unsigned ZigClangAPValue_getArraySize(const ZigClangAPValue *self);
-ZIG_EXTERN_C ZigClangAPValueLValueBase ZigClangAPValue_getLValueBase(const ZigClangAPValue *self);
+ZIG_EXTERN_C enum ZigClangAPValueKind ZigClangAPValue_getKind(const struct ZigClangAPValue *self);
+ZIG_EXTERN_C const struct ZigClangAPSInt *ZigClangAPValue_getInt(const struct ZigClangAPValue *self);
+ZIG_EXTERN_C unsigned ZigClangAPValue_getArrayInitializedElts(const struct ZigClangAPValue *self);
+ZIG_EXTERN_C const struct ZigClangAPValue *ZigClangAPValue_getArrayInitializedElt(const struct ZigClangAPValue *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangAPValue *ZigClangAPValue_getArrayFiller(const struct ZigClangAPValue *self);
+ZIG_EXTERN_C unsigned ZigClangAPValue_getArraySize(const struct ZigClangAPValue *self);
+ZIG_EXTERN_C struct ZigClangAPValueLValueBase ZigClangAPValue_getLValueBase(const struct ZigClangAPValue *self);
 
-ZIG_EXTERN_C bool ZigClangAPSInt_isSigned(const ZigClangAPSInt *self);
-ZIG_EXTERN_C bool ZigClangAPSInt_isNegative(const ZigClangAPSInt *self);
-ZIG_EXTERN_C const ZigClangAPSInt *ZigClangAPSInt_negate(const ZigClangAPSInt *self);
-ZIG_EXTERN_C void ZigClangAPSInt_free(const ZigClangAPSInt *self);
-ZIG_EXTERN_C const uint64_t *ZigClangAPSInt_getRawData(const ZigClangAPSInt *self);
-ZIG_EXTERN_C unsigned ZigClangAPSInt_getNumWords(const ZigClangAPSInt *self);
+ZIG_EXTERN_C bool ZigClangAPSInt_isSigned(const struct ZigClangAPSInt *self);
+ZIG_EXTERN_C bool ZigClangAPSInt_isNegative(const struct ZigClangAPSInt *self);
+ZIG_EXTERN_C const struct ZigClangAPSInt *ZigClangAPSInt_negate(const struct ZigClangAPSInt *self);
+ZIG_EXTERN_C void ZigClangAPSInt_free(const struct ZigClangAPSInt *self);
+ZIG_EXTERN_C const uint64_t *ZigClangAPSInt_getRawData(const struct ZigClangAPSInt *self);
+ZIG_EXTERN_C unsigned ZigClangAPSInt_getNumWords(const struct ZigClangAPSInt *self);
 
-ZIG_EXTERN_C const ZigClangExpr *ZigClangAPValueLValueBase_dyn_cast_Expr(ZigClangAPValueLValueBase self);
+ZIG_EXTERN_C const struct ZigClangExpr *ZigClangAPValueLValueBase_dyn_cast_Expr(struct ZigClangAPValueLValueBase self);
 
 #endif

--- a/std/c.zig
+++ b/std/c.zig
@@ -12,6 +12,10 @@ pub use switch (builtin.os) {
 
 // TODO https://github.com/ziglang/zig/issues/265 on this whole file
 
+pub const FILE = @OpaqueType();
+pub extern "c" fn fwrite(ptr: [*]const u8, size_of_type: usize, item_count: usize, stream: *FILE) usize;
+pub extern "c" fn fread(ptr: [*]u8, size_of_type: usize, item_count: usize, stream: *FILE) usize;
+
 pub extern "c" fn abort() noreturn;
 pub extern "c" fn exit(code: c_int) noreturn;
 pub extern "c" fn isatty(fd: c_int) c_int;

--- a/std/c.zig
+++ b/std/c.zig
@@ -13,6 +13,8 @@ pub use switch (builtin.os) {
 // TODO https://github.com/ziglang/zig/issues/265 on this whole file
 
 pub const FILE = @OpaqueType();
+pub extern "c" fn fopen(filename: [*]const u8, modes: [*]const u8) ?*FILE;
+pub extern "c" fn fclose(stream: *FILE) c_int;
 pub extern "c" fn fwrite(ptr: [*]const u8, size_of_type: usize, item_count: usize, stream: *FILE) usize;
 pub extern "c" fn fread(ptr: [*]u8, size_of_type: usize, item_count: usize, stream: *FILE) usize;
 

--- a/std/io.zig
+++ b/std/io.zig
@@ -36,6 +36,7 @@ pub fn getStdIn() GetStdIoErrs!File {
 }
 
 pub const SeekableStream = @import("io/seekable_stream.zig").SeekableStream;
+pub const COutStream = @import("io/c_out_stream.zig").COutStream;
 
 pub fn InStream(comptime ReadError: type) type {
     return struct {
@@ -1089,8 +1090,10 @@ test "io.readLineSliceFrom" {
 }
 
 pub const Packing = enum {
-    Byte,   /// Pack data to byte alignment
-    Bit,    /// Pack data to bit alignment
+    /// Pack data to byte alignment
+    Byte,
+    /// Pack data to bit alignment
+    Bit,
 };
 
 /// Creates a deserializer that deserializes types from any stream.
@@ -1111,10 +1114,12 @@ pub fn Deserializer(comptime endian: builtin.Endian, comptime packing: Packing, 
         pub const Stream = InStream(Error);
 
         pub fn init(in_stream: *Stream) Self {
-            return Self{ .in_stream = switch (packing) {
-                .Bit => BitInStream(endian, Stream.Error).init(in_stream),
-                .Byte => in_stream,
-            } };
+            return Self{
+                .in_stream = switch (packing) {
+                    .Bit => BitInStream(endian, Stream.Error).init(in_stream),
+                    .Byte => in_stream,
+                },
+            };
         }
 
         pub fn alignToByte(self: *Self) void {
@@ -1281,7 +1286,7 @@ pub fn Deserializer(comptime endian: builtin.Endian, comptime packing: Packing, 
                         ptr.* = null;
                         return;
                     }
-                    
+
                     ptr.* = OC(undefined); //make it non-null so the following .? is guaranteed safe
                     const val_ptr = &ptr.*.?;
                     try self.deserializeInto(val_ptr);
@@ -1320,10 +1325,12 @@ pub fn Serializer(comptime endian: builtin.Endian, comptime packing: Packing, co
         pub const Stream = OutStream(Error);
 
         pub fn init(out_stream: *Stream) Self {
-            return Self{ .out_stream = switch (packing) {
-                .Bit => BitOutStream(endian, Stream.Error).init(out_stream),
-                .Byte => out_stream,
-            } };
+            return Self{
+                .out_stream = switch (packing) {
+                    .Bit => BitOutStream(endian, Stream.Error).init(out_stream),
+                    .Byte => out_stream,
+                },
+            };
         }
 
         /// Flushes any unwritten bits to the stream
@@ -1450,4 +1457,3 @@ test "import io tests" {
         _ = @import("io_test.zig");
     }
 }
-

--- a/std/io.zig
+++ b/std/io.zig
@@ -1092,6 +1092,7 @@ test "io.readLineSliceFrom" {
 pub const Packing = enum {
     /// Pack data to byte alignment
     Byte,
+
     /// Pack data to bit alignment
     Bit,
 };
@@ -1454,6 +1455,6 @@ pub fn Serializer(comptime endian: builtin.Endian, comptime packing: Packing, co
 
 test "import io tests" {
     comptime {
-        _ = @import("io_test.zig");
+        _ = @import("io/test.zig");
     }
 }

--- a/std/io/c_out_stream.zig
+++ b/std/io/c_out_stream.zig
@@ -1,0 +1,44 @@
+const std = @import("../std.zig");
+const OutStream = std.io.OutStream;
+const builtin = @import("builtin");
+const posix = std.os.posix;
+
+/// TODO make std.os.FILE use *FILE when linking libc and this just becomes
+/// std.io.FileOutStream because std.os.File.write would do this when linking
+/// libc.
+pub const COutStream = struct {
+    pub const Error = std.os.File.WriteError;
+    pub const Stream = OutStream(Error);
+
+    stream: Stream,
+    c_file: *std.c.FILE,
+
+    pub fn init(c_file: *std.c.FILE) COutStream {
+        return COutStream{
+            .c_file = c_file,
+            .stream = Stream{ .writeFn = writeFn },
+        };
+    }
+
+    fn writeFn(out_stream: *Stream, bytes: []const u8) Error!void {
+        const self = @fieldParentPtr(COutStream, "stream", out_stream);
+        const amt_written = std.c.fwrite(bytes.ptr, 1, bytes.len, self.c_file);
+        if (amt_written == bytes.len) return;
+        const errno = std.c._errno().*;
+        switch (errno) {
+            0 => unreachable,
+            posix.EINVAL => unreachable,
+            posix.EFAULT => unreachable,
+            posix.EAGAIN => unreachable, // this is a blocking API
+            posix.EBADF => unreachable, // always a race condition
+            posix.EDESTADDRREQ => unreachable, // connect was never called
+            posix.EDQUOT => return error.DiskQuota,
+            posix.EFBIG => return error.FileTooBig,
+            posix.EIO => return error.InputOutput,
+            posix.ENOSPC => return error.NoSpaceLeft,
+            posix.EPERM => return error.AccessDenied,
+            posix.EPIPE => return error.BrokenPipe,
+            else => return std.os.unexpectedErrorPosix(@intCast(usize, errno)),
+        }
+    }
+};

--- a/std/io/c_out_stream.zig
+++ b/std/io/c_out_stream.zig
@@ -24,6 +24,10 @@ pub const COutStream = struct {
         const self = @fieldParentPtr(COutStream, "stream", out_stream);
         const amt_written = std.c.fwrite(bytes.ptr, 1, bytes.len, self.c_file);
         if (amt_written == bytes.len) return;
+        // TODO errno on windows. should we have a posix layer for windows?
+        if (builtin.os == .windows) {
+            return error.InputOutput;
+        }
         const errno = std.c._errno().*;
         switch (errno) {
             0 => unreachable,

--- a/std/io/test.zig
+++ b/std/io/test.zig
@@ -1,4 +1,4 @@
-const std = @import("std.zig");
+const std = @import("../std.zig");
 const io = std.io;
 const meta = std.meta;
 const trait = std.trait;
@@ -588,4 +588,15 @@ test "Deserializer bad data" {
     try testBadData(.Little, .Byte);
     try testBadData(.Big, .Bit);
     try testBadData(.Little, .Bit);
+}
+
+test "c out stream" {
+    if (!builtin.link_libc) return error.SkipZigTest;
+
+    const filename = c"tmp_io_test_file.txt";
+    const out_file = std.c.fopen(filename, c"w") orelse return error.UnableToOpenTestFile;
+    defer std.os.deleteFileC(filename) catch {};
+
+    const out_stream = &io.COutStream.init(out_file).stream;
+    try out_stream.print("hi: {}\n", i32(123));
 }


### PR DESCRIPTION
With this, `zig translate-c-2` (the self-hosted one) is equivalent  to `zig translate-c` when there are C compilation errors.

However none of the actual translation is implemented. It's clear how to proceed, though.

![Screenshot_2019-04-21_20-21-23](https://user-images.githubusercontent.com/106511/56477401-0a663d80-6473-11e9-823a-9111b70f0050.png)
