### PR TITLE
Sync grammar documentation with spec

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -9443,8 +9443,6 @@ PrimaryExpr
 
 IfExpr &lt;- IfPrefix Expr (KEYWORD_else Payload? Expr)?
 
-LabeledExpr &lt;- BlockLabel? (Block / LoopExpr)
-
 Block &lt;- LBRACE Statement* RBRACE
 
 LoopExpr &lt;- KEYWORD_inline? (ForExpr / WhileExpr)
@@ -9452,6 +9450,8 @@ LoopExpr &lt;- KEYWORD_inline? (ForExpr / WhileExpr)
 ForExpr &lt;- ForPrefix Expr (KEYWORD_else Expr)?
 
 WhileExpr &lt;- WhilePrefix Expr (KEYWORD_else Payload? Expr)?
+
+CurlySuffixExpr &lt;- TypeExpr InitList?
 
 InitList
     &lt;- LBRACE FieldInit (COMMA FieldInit)* COMMA? RBRACE


### PR DESCRIPTION
A couple things didn't get carried over to the documentation:

- Remove rule `LabeledExpr`
- Add rule `CurlySuffixExpr`