### PR TITLE
dl_iterate_phdr implementation

### DIFF
--- a/std/c/linux.zig
+++ b/std/c/linux.zig
@@ -1,3 +1,4 @@
+const linux = @import("../os/linux.zig");
 pub use @import("../os/linux/errno.zig");
 
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) c_int;
@@ -12,4 +13,5 @@ pub const pthread_attr_t = extern struct {
 /// See std.elf for constants for this
 pub extern fn getauxval(__type: c_ulong) c_ulong;
 
-pub extern fn dl_iterate_phdr(callback: *const c_void, data: ?*c_void) i32;
+pub const dl_iterate_phdr_callback = extern fn (info: *linux.dl_phdr_info, size: usize, data: ?*c_void) c_int;
+pub extern fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*c_void) c_int;

--- a/std/c/linux.zig
+++ b/std/c/linux.zig
@@ -11,3 +11,5 @@ pub const pthread_attr_t = extern struct {
 
 /// See std.elf for constants for this
 pub extern fn getauxval(__type: c_ulong) c_ulong;
+
+pub extern fn dl_iterate_phdr(callback: *const c_void, data: ?*c_void) i32;

--- a/std/elf.zig
+++ b/std/elf.zig
@@ -877,6 +877,11 @@ pub const Phdr = switch (@sizeOf(usize)) {
     8 => Elf64_Phdr,
     else => @compileError("expected pointer size of 32 or 64"),
 };
+pub const Dyn = switch (@sizeOf(usize)) {
+    4 => Elf32_Dyn,
+    8 => Elf64_Dyn,
+    else => @compileError("expected pointer size of 32 or 64"),
+};
 pub const Shdr = switch (@sizeOf(usize)) {
     4 => Elf32_Shdr,
     8 => Elf64_Shdr,

--- a/std/os/linux.zig
+++ b/std/os/linux.zig
@@ -4,6 +4,7 @@ const builtin = @import("builtin");
 const maxInt = std.math.maxInt;
 const elf = std.elf;
 const vdso = @import("linux/vdso.zig");
+const dl = @import("../dynamic_library.zig");
 pub use switch (builtin.arch) {
     builtin.Arch.x86_64 => @import("linux/x86_64.zig"),
     builtin.Arch.i386 => @import("linux/i386.zig"),
@@ -1537,33 +1538,32 @@ pub const dirent64 = extern struct {
 
 pub const dl_phdr_info = extern struct {
     dlpi_addr: usize,
-    dlpi_name: [*c]const u8,
-    dlpi_phdr: [*c]*c_void,
+    dlpi_name: ?[*]const u8,
+    dlpi_phdr: [*]elf.Phdr,
     dlpi_phnum: u16,
 };
-
-const DynLib = @import("../dynamic_library.zig");
 
 // XXX: This should be weak
 extern const __ehdr_start: elf.Ehdr = undefined;
 
-pub fn dl_iterate_phdr(callback: extern fn (info: *dl_phdr_info, size: usize, data: ?*c_void) i32, data: ?*c_void) isize {
+pub fn dl_iterate_phdr(comptime T: type, callback: extern fn (info: *dl_phdr_info, size: usize, data: ?*T) i32, data: ?*T) isize {
     if (builtin.link_libc) {
-        return std.c.dl_iterate_phdr(@ptrCast(*const c_void, callback), data);
+        return std.c.dl_iterate_phdr(@ptrCast(std.c.dl_iterate_phdr_callback, callback), @ptrCast(?*c_void, data));
     }
 
     const elf_base = @ptrToInt(&__ehdr_start);
     const n_phdr = __ehdr_start.e_phnum;
     const phdrs = (@intToPtr([*]elf.Phdr, elf_base + __ehdr_start.e_phoff))[0..n_phdr];
 
-    var it = DynLib.linkmap_iterator(phdrs) catch return 0;
+    var it = dl.linkmap_iterator(phdrs) catch return 0;
+
+    // The executable has no dynamic link segment, create a single entry for
+    // the whole ELF image
     if (it.end()) {
-        // The executable has no dynamic link infos, create a single info
-        // struct for the whole ELF image
         var info = dl_phdr_info{
             .dlpi_addr = elf_base,
             .dlpi_name = c"/proc/self/exe",
-            .dlpi_phdr = @intToPtr([*c]*c_void, elf_base + __ehdr_start.e_phoff),
+            .dlpi_phdr = @intToPtr([*]elf.Phdr, elf_base + __ehdr_start.e_phoff),
             .dlpi_phnum = __ehdr_start.e_phnum,
         };
 
@@ -1573,22 +1573,25 @@ pub fn dl_iterate_phdr(callback: extern fn (info: *dl_phdr_info, size: usize, da
     // Last return value from the callback function
     var last_r: isize = 0;
     while (it.next()) |entry| {
-        var info = dl_phdr_info{
-            .dlpi_addr = entry.l_addr,
-            .dlpi_name = entry.l_name,
-            .dlpi_phdr = 0,
-            .dlpi_phnum = 0,
-        };
+        var dlpi_phdr: usize = undefined;
+        var dlpi_phnum: u16 = undefined;
 
         if (entry.l_addr != 0) {
             const elf_header = @intToPtr(*elf.Ehdr, entry.l_addr);
-            info.dlpi_phdr = @intToPtr([*c]*c_void, entry.l_addr + elf_header.e_phoff);
-            info.dlpi_phnum = elf_header.e_phnum;
+            dlpi_phdr = entry.l_addr + elf_header.e_phoff;
+            dlpi_phnum = elf_header.e_phnum;
         } else {
             // This is the running ELF image
-            info.dlpi_phdr = @intToPtr([*c]*c_void, elf_base + __ehdr_start.e_phoff);
-            info.dlpi_phnum = __ehdr_start.e_phnum;
+            dlpi_phdr = elf_base + __ehdr_start.e_phoff;
+            dlpi_phnum = __ehdr_start.e_phnum;
         }
+
+        var info = dl_phdr_info{
+            .dlpi_addr = entry.l_addr,
+            .dlpi_name = entry.l_name,
+            .dlpi_phdr = @intToPtr([*]elf.Phdr, dlpi_phdr),
+            .dlpi_phnum = dlpi_phnum,
+        };
 
         last_r = callback(&info, @sizeOf(dl_phdr_info), data);
         if (last_r != 0) break;

--- a/std/os/linux/test.zig
+++ b/std/os/linux/test.zig
@@ -1,6 +1,8 @@
 const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const linux = std.os.linux;
+const mem = std.mem;
+const elf = std.elf;
 const expect = std.testing.expect;
 
 test "getpid" {
@@ -41,4 +43,43 @@ test "timer" {
 
     // TODO implicit cast from *[N]T to [*]T
     err = linux.epoll_wait(@intCast(i32, epoll_fd), @ptrCast([*]linux.epoll_event, &events), 8, -1);
+}
+
+export fn iter_fn(info: *linux.dl_phdr_info, size: usize, data: ?*usize) i32 {
+    var counter = data.?;
+    // Count how many libraries are loaded
+    counter.* += usize(1);
+
+    // The image should contain at least a PT_LOAD segment
+    if (info.dlpi_phnum < 1) return -1;
+
+    // Quick & dirty validation of the phdr pointers, make sure we're not
+    // pointing to some random gibberish
+    var i: usize = 0;
+    var found_load = false;
+    while (i < info.dlpi_phnum) : (i += 1) {
+        const phdr = info.dlpi_phdr[i];
+
+        if (phdr.p_type != elf.PT_LOAD) continue;
+
+        // Find the ELF header
+        const elf_header = @intToPtr(*elf.Ehdr, phdr.p_vaddr - phdr.p_offset);
+        // Validate the magic
+        if (!mem.eql(u8, elf_header.e_ident[0..], "\x7fELF")) return -1;
+        // Consistency check
+        if (elf_header.e_phnum != info.dlpi_phnum) return -1;
+
+        found_load = true;
+        break;
+    }
+
+    if (!found_load) return -1;
+
+    return 42;
+}
+
+test "dl_iterate_phdr" {
+    var counter: usize = 0;
+    expect(linux.dl_iterate_phdr(usize, iter_fn, &counter) != 0);
+    expect(counter != 0);
 }


### PR DESCRIPTION
Also comes with a libc-less version that _should_ work just fine in most cases.
I guess the code is portable enough to work on *BSDs too, I'd be happy to move it out of the linux namespace if somebody tests it.

I didn't manage to mark the `__ehdr_entry` as weak, similar to how you'd do with this C declaration:
```c
extern const char __ehdr_start __attribute__((weak));
```

I'll squash the spurious commit once the review is over.
