### PR TITLE
DirectAllocator: reduce the amount of redundant memcpy calls on Windows

### DIFF
--- a/std/heap.zig
+++ b/std/heap.zig
@@ -139,11 +139,7 @@ pub const DirectAllocator = struct {
                     return shrink(allocator, old_mem, old_align, new_size, new_align);
                 }
                 const result = try alloc(allocator, new_size, new_align);
-                if (result.len >= old_mem.len) {
-                    mem.copy(u8, result, old_mem);
-                } else {
-                    @memcpy(result.ptr, old_mem.ptr, new_size);
-                }
+                @memcpy(result.ptr, old_mem.ptr, std.math.min(old_mem.len, result.len));
                 _ = os.posix.munmap(@ptrToInt(old_mem.ptr), old_mem.len);
                 return result;
             },
@@ -274,11 +270,7 @@ pub const ArenaAllocator = struct {
             return error.OutOfMemory;
         } else {
             const result = try alloc(allocator, new_size, new_align);
-            if (result.len >= old_mem.len) {
-                mem.copy(u8, result, old_mem);
-            } else {
-                @memcpy(result.ptr, old_mem.ptr, new_size);
-            }
+            @memcpy(result.ptr, old_mem.ptr, std.math.min(old_mem.len, result.len));
             return result;
         }
     }
@@ -336,11 +328,7 @@ pub const FixedBufferAllocator = struct {
             return error.OutOfMemory;
         } else {
             const result = try alloc(allocator, new_size, new_align);
-            if (result.len >= old_mem.len) {
-                mem.copy(u8, result, old_mem);
-            } else {
-                @memcpy(result.ptr, old_mem.ptr, new_size);
-            }
+            @memcpy(result.ptr, old_mem.ptr, std.math.min(old_mem.len, result.len));
             return result;
         }
     }
@@ -483,11 +471,7 @@ pub const ThreadSafeFixedBufferAllocator = blk: {
                     return error.OutOfMemory;
                 } else {
                     const result = try alloc(allocator, new_size, new_align);
-                    if (result.len >= old_mem.len) {
-                        mem.copy(u8, result, old_mem);
-                    } else {
-                        @memcpy(result.ptr, old_mem.ptr, new_size);
-                    }
+                    @memcpy(result.ptr, old_mem.ptr, std.math.min(old_mem.len, result.len));
                     return result;
                 }
             }


### PR DESCRIPTION
This is a follow-up to #2312

Previously the memory would be copied to a different aligned address in some cases where the old offset could have been used. This fixes it so that it will always try to use the old offset when possible, and only uses a different offset if the old one is truly invalid (not aligned or not enough space to store the alloc at the old offset).

Also changed the realloc memory copy calls to use `std.math.min` as mentioned here: https://github.com/ziglang/zig/pull/2312#issuecomment-486509294