### PR TITLE
Do not invoke UB in BigInt shr operations

### DIFF
--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -1395,7 +1395,7 @@ void bigint_shr(BigInt *dest, const BigInt *op1, const BigInt *op2) {
     uint64_t shift_amt = bigint_as_unsigned(op2);
 
     if (op1->digit_count == 1) {
-        dest->data.digit = op1_digits[0] >> shift_amt;
+        dest->data.digit = (shift_amt < 64) ? op1_digits[0] >> shift_amt : 0;
         dest->digit_count = 1;
         dest->is_negative = op1->is_negative;
         bigint_normalize(dest);

--- a/test/stage1/behavior/bit_shifting.zig
+++ b/test/stage1/behavior/bit_shifting.zig
@@ -90,7 +90,9 @@ fn testShardedTable(comptime Key: type, comptime mask_bit_count: comptime_int, c
 // #2225
 test "comptime shr of BigInt" {
     comptime {
-        var n = 0xdeadbeef0000000000000000;
-        std.debug.assert(n >> 64 == 0xdeadbeef);
+        var n0 = 0xdeadbeef0000000000000000;
+        std.debug.assert(n0 >> 64 == 0xdeadbeef);
+        var n1 = 17908056155735594659;
+        std.debug.assert(n1 >> 64 == 0);
     }
 }


### PR DESCRIPTION
Shifting a value of type T by an amount that's greater or equal to the
size of the type itself is UB.

Spotted by @tgschultz