### PR TITLE
WASI: implement argsAlloc and argsFree

### DIFF
--- a/std/os.zig
+++ b/std/os.zig
@@ -2176,7 +2176,7 @@ pub fn argsAlloc(allocator: *mem.Allocator) ![]const []u8 {
 
         const args_sizes_get_ret = os.wasi.args_sizes_get(&count, &buf_size);
         if (args_sizes_get_ret != os.wasi.ESUCCESS) {
-            return error.ArgsSizesGetFailed;
+            return unexpectedErrorPosix(args_sizes_get_ret);
         }
 
         var argv = try allocator.alloc([*]u8, count);
@@ -2185,7 +2185,7 @@ pub fn argsAlloc(allocator: *mem.Allocator) ![]const []u8 {
         var argv_buf = try allocator.alloc(u8, buf_size);
         const args_get_ret = os.wasi.args_get(argv.ptr, argv_buf.ptr);
         if (args_get_ret != os.wasi.ESUCCESS) {
-            return error.ArgsGetFailed;
+            return unexpectedErrorPosix(args_get_ret);
         }
 
         var result_slice = try allocator.alloc([]u8, count);

--- a/std/os.zig
+++ b/std/os.zig
@@ -2135,6 +2135,7 @@ pub const ArgIterator = struct {
 
     pub fn init() ArgIterator {
         if (builtin.os == Os.wasi) {
+            // TODO: Figure out a compatible interface accomodating WASI
             @compileError("ArgIterator is not yet supported in WASI. Use argsAlloc and argsFree instead.");
         }
 

--- a/std/os.zig
+++ b/std/os.zig
@@ -2174,13 +2174,19 @@ pub fn argsAlloc(allocator: *mem.Allocator) ![]const []u8 {
         var count: usize = undefined;
         var buf_size: usize = undefined;
 
-        _ = os.wasi.args_sizes_get(&count, &buf_size);
+        const args_sizes_get_ret = os.wasi.args_sizes_get(&count, &buf_size);
+        if (args_sizes_get_ret != os.wasi.ESUCCESS) {
+            return error.ArgsSizesGetFailed;
+        }
 
         var argv = try allocator.alloc([*]u8, count);
         defer allocator.free(argv);
 
         var argv_buf = try allocator.alloc(u8, buf_size);
-        _ = os.wasi.args_get(argv.ptr, argv_buf.ptr);
+        const args_get_ret = os.wasi.args_get(argv.ptr, argv_buf.ptr);
+        if (args_get_ret != os.wasi.ESUCCESS) {
+            return error.ArgsGetFailed;
+        }
 
         var result_slice = try allocator.alloc([]u8, count);
         

--- a/std/os/wasi.zig
+++ b/std/os/wasi.zig
@@ -1,7 +1,7 @@
 pub use @import("wasi/core.zig");
 
 // Based on https://github.com/CraneStation/wasi-sysroot/blob/wasi/libc-bottom-half/headers/public/wasi/core.h
-// and https://github.com/CraneStation/wasmtime/blob/master/docs/WASI-api.md
+// and https://github.com/WebAssembly/WASI/blob/master/design/WASI-core.md
 
 pub const STDIN_FILENO = 0;
 pub const STDOUT_FILENO = 1;

--- a/std/os/wasi/core.zig
+++ b/std/os/wasi/core.zig
@@ -10,6 +10,9 @@ pub const ciovec_t = extern struct {
 
 pub const SIGABRT: signal_t = 6;
 
+pub extern "wasi_unstable" fn args_get(argv: [*][*]u8, argv_buf: [*]u8) errno_t;
+pub extern "wasi_unstable" fn args_sizes_get(argc: *usize, argv_buf_size: *usize) errno_t;
+
 pub extern "wasi_unstable" fn proc_raise(sig: signal_t) errno_t;
 
 pub extern "wasi_unstable" fn proc_exit(rval: exitcode_t) noreturn;


### PR DESCRIPTION
Implementing ArgIterator for WASI would require introducing a `free` function to the internally allocated buffer so I've simply introduced a compileError for WASI.