### PR TITLE
self-hosted translate-c: fix Xcode 10.2.1 error

### DIFF
--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -800,7 +800,7 @@ static_assert((clang::APValue::ValueKind)ZigClangAPValueAddrLabelDiff == clang::
 
 
 void ZigClang_detect_enum_DeclKind(clang::Decl::Kind x) {
-    switch (x) {
+    switch ((ZigClangDeclKind)x) {
         case ZigClangDeclAccessSpec:
         case ZigClangDeclBlock:
         case ZigClangDeclCaptured:


### PR DESCRIPTION
Xcode 10.2.1 clang elevates comparison of different enum types from
warning to error.