### PR TITLE
Don't install zig_cpp lib for stage2 target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6650,7 +6650,6 @@ add_library(zig_cpp STATIC ${ZIG_CPP_SOURCES})
 set_target_properties(zig_cpp PROPERTIES
     COMPILE_FLAGS ${EXE_CFLAGS}
 )
-install(TARGETS zig_cpp DESTINATION "${ZIG_CPP_LIB_DIR}")
 
 add_library(opt_c_util STATIC ${OPTIMIZED_C_SOURCES})
 set_target_properties(opt_c_util PROPERTIES


### PR DESCRIPTION
Missed in last commit. See #2220.

Tested this in a clean environment and this is definitely the last library.