### PR TITLE
std.HashMap: add public ensureCapacity fn

### DIFF
--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -181,8 +181,13 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime hash: fn (key: K) u3
 
         /// Returns the kv pair that was already there.
         pub fn put(self: *Self, key: K, value: V) !?KV {
-            self.incrementModificationCount();
             try self.autoCapacity();
+            return putAssumeCapacity(self, key, value);
+        }
+
+        pub fn putAssumeCapacity(self: *Self, key: K, value: V) ?KV {
+            assert(self.count() < self.entries.len);
+            self.incrementModificationCount();
 
             const put_result = self.internalPut(key);
             put_result.new_entry.kv.value = value;

--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -158,7 +158,7 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime hash: fn (key: K) u3
         /// Sets the capacity to the new capacity if the new
         /// capacity is greater than the current capacity.
         /// New capacity must be a power of two.
-        pub fn ensureCapacityExact(self: *Self, new_capacity: usize) !void {
+        fn ensureCapacityExact(self: *Self, new_capacity: usize) !void {
             const is_power_of_two = new_capacity & (new_capacity-1) == 0;
             assert(is_power_of_two);
 

--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -141,8 +141,15 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime hash: fn (key: K) u3
             if (new_capacity <= self.entries.len) {
                 return;
             }
+            // make sure capacity is a power of two
+            var capacity = new_capacity;
+            const is_power_of_two = capacity & (capacity-1) == 0;
+            if (!is_power_of_two) {
+                const pow = math.log2_int_ceil(usize, capacity);
+                capacity = math.pow(usize, 2, pow);
+            }
             const old_entries = self.entries;
-            try self.initCapacity(new_capacity);
+            try self.initCapacity(capacity);
             if (old_entries.len > 0) {
                 // dump all of the old elements into the new table
                 for (old_entries) |*old_entry| {


### PR DESCRIPTION
A stab at #2339 for feedback. Closes #2339 if accepted.

---

Adds public functions:
- `ensureCapacity`: Increases capacity so that the hash map will be at most 60% full when expected_count items are put into it
- `putAssumeCapacity`: Puts a key/value into the map without being able to fail

Notes:
- ~~To truly ensure that no allocations will happen during `put` calls, `ensureCapacity` needs to be called with a larger capacity than absolutely necessary, as `autoCapacity` will double the capacity if it ever gets 60% full.~~ 
  + No longer true, see comments and https://github.com/ziglang/zig/pull/2404/commits/4d42275d03a3f24beca2d93e02ff12e52a48a91b
- Not sure how to write tests for these changes.