### PR TITLE
stage1: implement a "TODO": const_values_equal for Error Unions

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5149,6 +5149,12 @@ static bool const_values_equal_array(CodeGen *g, ConstExprValue *a, ConstExprVal
 }
 
 bool const_values_equal(CodeGen *g, ConstExprValue *a, ConstExprValue *b) {
+    if (a == nullptr || b == nullptr) {
+        if (a == nullptr && b == nullptr)
+            return true;
+        else
+            return false;
+    }
     assert(a->type->id == b->type->id);
     assert(a->special == ConstValSpecialStatic);
     assert(b->special == ConstValSpecialStatic);
@@ -5231,7 +5237,8 @@ bool const_values_equal(CodeGen *g, ConstExprValue *a, ConstExprValue *b) {
                 return const_values_equal(g, a->data.x_optional, b->data.x_optional);
             }
         case ZigTypeIdErrorUnion:
-            zig_panic("TODO");
+            return const_values_equal(g, a->data.x_err_union.payload, b->data.x_err_union.payload) &&
+                   const_values_equal(g, a->data.x_err_union.error_set, b->data.x_err_union.error_set);
         case ZigTypeIdArgTuple:
             return a->data.x_arg_tuple.start_index == b->data.x_arg_tuple.start_index &&
                    a->data.x_arg_tuple.end_index == b->data.x_arg_tuple.end_index;


### PR DESCRIPTION
My unicode.zig stuff actually used this stuff and found out it wasn't complete.

The null checks at the top seem sensibible to me, but they could also be put inside
the conditional. It is payload that is often null.