### PR TITLE
stage1: AstNodes cannot be casted, but are rather accessed via a union.

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -18141,7 +18141,7 @@ static Error ir_make_type_info_defs(IrAnalyze *ira, IrInstruction *source_instr,
                         return ErrorSemanticAnalyzeFail;
                     }
 
-                    AstNodeFnProto *fn_node = (AstNodeFnProto *)(fn_entry->proto_node);
+                    AstNodeFnProto *fn_node = &fn_entry->proto_node->data.fn_proto;
 
                     ConstExprValue *fn_def_val = create_const_vals(1);
                     fn_def_val->special = ConstValSpecialStatic;


### PR DESCRIPTION
Unlike IrInstruction[Foo]s, which all start with:
    IrInstruction base;
AstNodes do not work like this, and instead use a pointer to their
specializations. The code assumed otherwise.