### PR TITLE
cmake: Honor LLVM_DIR in the findLLVM script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,8 @@ option(ZIG_TEST_COVERAGE "Build Zig with test coverage instrumentation" OFF)
 # git log -p -- deps/lld
 option(ZIG_FORCE_EXTERNAL_LLD "If your system has the LLD patches use it instead of the embedded LLD" OFF)
 
-find_package(llvm)
-find_package(clang)
+find_package(llvm REQUIRED)
+find_package(clang REQUIRED)
 
 if(APPLE AND ZIG_STATIC)
     list(REMOVE_ITEM LLVM_LIBRARIES "-lz")
@@ -69,7 +69,7 @@ foreach(CONFIG_TYPE ${CMAKE_CONFIGURATION_TYPES})
 endforeach(CONFIG_TYPE CMAKE_CONFIGURATION_TYPES)
 
 if(ZIG_FORCE_EXTERNAL_LLD)
-    find_package(lld)
+    find_package(lld REQUIRED)
     include_directories(${LLVM_INCLUDE_DIRS})
     include_directories(${LLD_INCLUDE_DIRS})
     include_directories(${CLANG_INCLUDE_DIRS})

--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -36,28 +36,31 @@ if(MSVC)
   )
 
 else()
-  find_path(CLANG_INCLUDE_DIRS NAMES clang/Frontend/ASTUnit.h
-      PATHS
-          /usr/lib/llvm/8/include
-          /usr/lib/llvm-8/include
-          /usr/lib/llvm-8.0/include
-          /usr/local/llvm80/include
-          /mingw64/include)
+  find_path(CLANG_INCLUDE_DIRS
+    NAMES clang/Frontend/ASTUnit.h
+    PATHS
+    ${LLVM_INCLUDE_DIRS}
+    /usr/lib/llvm/8/include
+    /usr/lib/llvm-8/include
+    /usr/lib/llvm-8.0/include
+    /usr/local/llvm80/include
+    /mingw64/include)
 
   macro(FIND_AND_ADD_CLANG_LIB _libname_)
       string(TOUPPER ${_libname_} _prettylibname_)
-      find_library(CLANG_${_prettylibname_}_LIB NAMES ${_libname_}
+      find_library(CLANG_${_prettylibname_}_LIB
+          NAMES ${_libname_}
           PATHS
-              ${CLANG_LIBDIRS}
-              /usr/lib/llvm/8/lib
-              /usr/lib/llvm-8/lib
-              /usr/lib/llvm-8.0/lib
-              /usr/local/llvm80/lib
-              /mingw64/lib
-              /c/msys64/mingw64/lib
-              c:\\msys64\\mingw64\\lib)
+          ${LLVM_LIBDIRS}
+          /usr/lib/llvm/8/lib
+          /usr/lib/llvm-8/lib
+          /usr/lib/llvm-8.0/lib
+          /usr/local/llvm80/lib
+          /mingw64/lib
+          /c/msys64/mingw64/lib
+          c:\\msys64\\mingw64\\lib)
       if(CLANG_${_prettylibname_}_LIB)
-          set(CLANG_LIBRARIES ${CLANG_LIBRARIES} ${CLANG_${_prettylibname_}_LIB})
+        set(CLANG_LIBRARIES ${CLANG_LIBRARIES} ${CLANG_${_prettylibname_}_LIB})
       endif()
   endmacro(FIND_AND_ADD_CLANG_LIB)
 

--- a/cmake/Findlld.cmake
+++ b/cmake/Findlld.cmake
@@ -8,12 +8,14 @@
 
 find_path(LLD_INCLUDE_DIRS NAMES lld/Common/Driver.h
     PATHS
+        ${LLVM_INCLUDE_DIRS}
         /usr/lib/llvm-8.0/include
         /usr/local/llvm80/include
         /mingw64/include)
 
 find_library(LLD_LIBRARY NAMES lld-8.0 lld80 lld
     PATHS
+        ${LLVM_LIBDIRS}
         /usr/lib/llvm-8.0/lib
         /usr/local/llvm80/lib
 )
@@ -24,6 +26,7 @@ else()
         string(TOUPPER ${_libname_} _prettylibname_)
         find_library(LLD_${_prettylibname_}_LIB NAMES ${_libname_}
             PATHS
+                ${LLVM_LIBDIRS}
                 /usr/lib/llvm-8.0/lib
                 /usr/local/llvm80/lib
                 /mingw64/lib


### PR DESCRIPTION
Allow the user to set a custom path where llvm, clang and lld are built
without having to muck too much with the build system.