### PR TITLE
std.debug: colour improvements

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -944,7 +944,7 @@ fn genHtml(allocator: *mem.Allocator, tokenizer: *Tokenizer, toc: *Toc, out: var
     var code_progress_index: usize = 0;
 
     var env_map = try os.getEnvMap(allocator);
-    try env_map.set("ZIG_DEBUG_COLOR", "1");
+    try env_map.set("ZIG_DEBUG_COLOR", "always");
 
     const builtin_code = try getBuiltinCode(allocator, &env_map, zig_exe);
 

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -743,22 +743,6 @@ fn printLineInfo(
             symbol_name,
             compile_unit_name,
         );
-        if (printLineFromFile(out_stream, line_info)) {
-            if (line_info.column == 0) {
-                try out_stream.write("\n");
-            } else {
-                {
-                    var col_i: usize = 1;
-                    while (col_i < line_info.column) : (col_i += 1) {
-                        try out_stream.writeByte(' ');
-                    }
-                }
-                try out_stream.write(GREEN ++ "^" ++ RESET ++ "\n");
-            }
-        } else |err| switch (err) {
-            error.EndOfFile => {},
-            else => return err,
-        }
     } else {
         try out_stream.print(
             "{}:{}:{}: 0x{x} in {} ({})\n",
@@ -769,6 +753,27 @@ fn printLineInfo(
             symbol_name,
             compile_unit_name,
         );
+    }
+
+    if (printLineFromFile(out_stream, line_info)) {
+        if (line_info.column == 0) {
+            try out_stream.write("\n");
+        } else {
+            {
+                var col_i: usize = 1;
+                while (col_i < line_info.column) : (col_i += 1) {
+                    try out_stream.writeByte(' ');
+                }
+            }
+            if (tty_color) {
+                try out_stream.write(GREEN ++ "^" ++ RESET ++ "\n");
+            } else {
+                try out_stream.write("^\n");
+            }
+        }
+    } else |err| switch (err) {
+        error.EndOfFile => {},
+        else => return err,
     }
 }
 

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -73,7 +73,14 @@ pub fn getSelfDebugInfo() !*DebugInfo {
 fn wantTtyColor() bool {
     var bytes: [128]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(bytes[0..]).allocator;
-    return if (std.os.getEnvVarOwned(allocator, "ZIG_DEBUG_COLOR")) |_| true else |_| stderr_file.isTty();
+    if (std.os.getEnvVarOwned(allocator, "ZIG_DEBUG_COLOR")) |sval| {
+        if (mem.eql(u8, sval, "always")) {
+            return true;
+        } else if (mem.eql(u8, sval, "never")) {
+            return false;
+        }
+    } else |_| {}
+    return stderr_file.isTty();
 }
 
 /// Tries to print the current stack trace to stderr, unbuffered, and ignores any error returned.


### PR DESCRIPTION
Previously, ZIG_DEBUG_COLOR's presence or absence was used. Instead,
parsing the actual value (if present) allows turning off colour in stack
traces, for example.