### PR TITLE
Signed types for enum tags

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -1989,10 +1989,10 @@ static Error resolve_enum_zero_bits(CodeGen *g, ZigType *enum_type) {
                    !type_is_valid_extern_enum_tag(g, wanted_tag_int_type)) {
             enum_type->data.enumeration.is_invalid = true;
             ErrorMsg *msg = add_node_error(g, decl_node->data.container_decl.init_arg_expr,
-                buf_sprintf("'%s' is not a valid tag type for an extern union",
+                buf_sprintf("'%s' is not a valid tag type for an extern enum",
                             buf_ptr(&wanted_tag_int_type->name)));
             add_error_note(g, msg, decl_node->data.container_decl.init_arg_expr,
-                buf_sprintf("valid types are 'i8', 'c_int' and 'c_uint' or compatible types"));
+                buf_sprintf("any integral type of size 8, 16, 32, 64 or 128 bit is valid"));
         } else {
             tag_int_type = wanted_tag_int_type;
         }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -13,6 +13,19 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
+        "overflow in enum value allocation",
+        \\const Moo = enum(u8) {
+        \\    Last = 255,
+        \\    Over,
+        \\};
+        \\pub fn main() void {
+        \\  var y = Moo.Last;
+        \\}
+    ,
+        "tmp.zig:3:5: error: enumeration value 256 too large for type 'u8'",
+    );
+
+    cases.add(
         "attempt to cast enum literal to error",
         \\export fn entry() void {
         \\    switch (error.Hi) {
@@ -5383,8 +5396,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:12:20: note: referenced here",
     );
 
-    cases.add(
-        "specify enum tag type that is too small",
+    cases.add("specify enum tag type that is too small",
         \\const Small = enum (u2) {
         \\    One,
         \\    Two,
@@ -5396,9 +5408,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\export fn entry() void {
         \\    var x = Small.One;
         \\}
-    ,
-        "tmp.zig:6:5: error: enumeration value 4 too large for type 'u2'"
-    );
+    , "tmp.zig:6:5: error: enumeration value 4 too large for type 'u2'");
 
     cases.add(
         "specify non-integer enum tag type",
@@ -5506,8 +5516,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = MultipleChoice.C;
         \\}
     ,
-        "tmp.zig:6:9: error: enum tag value 60 already taken",
-        "tmp.zig:4:9: note: other occurrence here",
+        "tmp.zig:6:5: error: enum tag value 60 already taken",
+        "tmp.zig:4:5: note: other occurrence here",
     );
 
     cases.add(

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -5397,7 +5397,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var x = Small.One;
         \\}
     ,
-        "tmp.zig:1:21: error: 'u2' too small to hold all bits; must be at least 'u3'",
+        "tmp.zig:6:5: error: enumeration value 4 too large for type 'u2'"
     );
 
     cases.add(
@@ -5446,22 +5446,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
     ,
         "tmp.zig:10:31: error: expected type 'u2', found 'u3'",
-    );
-
-    cases.add(
-        "non unsigned integer enum tag type",
-        \\const Small = enum(i2) {
-        \\    One,
-        \\    Two,
-        \\    Three,
-        \\    Four,
-        \\};
-        \\
-        \\export fn entry() void {
-        \\    var y = Small.Two;
-        \\}
-    ,
-        "tmp.zig:1:20: error: expected unsigned integer, found 'i2'",
     );
 
     cases.add(

--- a/test/stage1/behavior/enum.zig
+++ b/test/stage1/behavior/enum.zig
@@ -938,3 +938,15 @@ test "enum literal in array literal" {
     expect(array[0] == .one);
     expect(array[1] == .two);
 }
+
+test "signed integer as enum tag" {
+    const SignedEnum = enum (i2) {
+        A0 = -1,
+        A1 =  0,
+        A2 =  1,
+    };
+
+    expect(@enumToInt(SignedEnum.A0) == -1);
+    expect(@enumToInt(SignedEnum.A1) ==  0);
+    expect(@enumToInt(SignedEnum.A2) ==  1);
+}

--- a/test/stage1/behavior/enum.zig
+++ b/test/stage1/behavior/enum.zig
@@ -940,13 +940,25 @@ test "enum literal in array literal" {
 }
 
 test "signed integer as enum tag" {
-    const SignedEnum = enum (i2) {
+    const SignedEnum = enum(i2) {
         A0 = -1,
-        A1 =  0,
-        A2 =  1,
+        A1 = 0,
+        A2 = 1,
     };
 
     expect(@enumToInt(SignedEnum.A0) == -1);
-    expect(@enumToInt(SignedEnum.A1) ==  0);
-    expect(@enumToInt(SignedEnum.A2) ==  1);
+    expect(@enumToInt(SignedEnum.A1) == 0);
+    expect(@enumToInt(SignedEnum.A2) == 1);
+}
+
+test "enum value allocation" {
+    const LargeEnum = enum(u32) {
+        A0 = 0x80000000,
+        A1,
+        A2,
+    };
+
+    expect(@enumToInt(LargeEnum.A0) == 0x80000000);
+    expect(@enumToInt(LargeEnum.A1) == 0x80000001);
+    expect(@enumToInt(LargeEnum.A2) == 0x80000002);
 }


### PR DESCRIPTION
Implements #641 

The first commit makes sure we produce a valid enum from the C ABI point of view, gcc has a extension where the value can be promoted to `long` but I decided to stick to ANSI C.

The `too small to hold all bits` check is gone, replaced by some simple overflow detection mechanism that's now correct for signed types too.

The enumerator value allocation is still starting from 0, no change on that front.

What I found extremely strange is that the value allocation doesn't follow the C semantics where the previous specified value is used as starting point. I can provide a patch to implement this semantic if you wish.