### PR TITLE
Trivial fixup for test case

### DIFF
--- a/std/std.zig
+++ b/std/std.zig
@@ -99,4 +99,6 @@ test "std" {
     _ = @import("unicode.zig");
     _ = @import("valgrind.zig");
     _ = @import("zig.zig");
+
+    _ = @import("debug/leb128.zig");
 }


### PR DESCRIPTION
The *Mem variants cannot return EndOfStream and are generally unsafe to
use.
Proper order of checks, try both the variants and make sure they return
the same error/result.
Run the leb128.zig tests.