### PR TITLE
std: the failing allocator didn't actually count allocations

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2215,7 +2215,7 @@ fn testTransform(source: []const u8, expected_source: []const u8) !void {
                         needed_alloc_count,
                         failing_allocator.allocated_bytes,
                         failing_allocator.freed_bytes,
-                        failing_allocator.index,
+                        failing_allocator.allocations,
                         failing_allocator.deallocations,
                     );
                     return error.MemoryLeakDetected;


### PR DESCRIPTION
Add a field `.allocations` to actually track the number of allocations.

Additionally, only increment `.deallocations` when memory is freed

Extracted from #2424
Closes #2310