### PR TITLE
Mmap debug info on linux

### DIFF
--- a/std/io.zig
+++ b/std/io.zig
@@ -36,6 +36,7 @@ pub fn getStdIn() GetStdIoErrs!File {
 }
 
 pub const SeekableStream = @import("io/seekable_stream.zig").SeekableStream;
+pub const SliceSeekableInStream = @import("io/seekable_stream.zig").SliceSeekableInStream;
 pub const COutStream = @import("io/c_out_stream.zig").COutStream;
 
 pub fn InStream(comptime ReadError: type) type {
@@ -1115,12 +1116,10 @@ pub fn Deserializer(comptime endian: builtin.Endian, comptime packing: Packing, 
         pub const Stream = InStream(Error);
 
         pub fn init(in_stream: *Stream) Self {
-            return Self{
-                .in_stream = switch (packing) {
-                    .Bit => BitInStream(endian, Stream.Error).init(in_stream),
-                    .Byte => in_stream,
-                },
-            };
+            return Self{ .in_stream = switch (packing) {
+                .Bit => BitInStream(endian, Stream.Error).init(in_stream),
+                .Byte => in_stream,
+            } };
         }
 
         pub fn alignToByte(self: *Self) void {
@@ -1326,12 +1325,10 @@ pub fn Serializer(comptime endian: builtin.Endian, comptime packing: Packing, co
         pub const Stream = OutStream(Error);
 
         pub fn init(out_stream: *Stream) Self {
-            return Self{
-                .out_stream = switch (packing) {
-                    .Bit => BitOutStream(endian, Stream.Error).init(out_stream),
-                    .Byte => out_stream,
-                },
-            };
+            return Self{ .out_stream = switch (packing) {
+                .Bit => BitOutStream(endian, Stream.Error).init(out_stream),
+                .Byte => out_stream,
+            } };
         }
 
         /// Flushes any unwritten bits to the stream

--- a/std/io/seekable_stream.zig
+++ b/std/io/seekable_stream.zig
@@ -30,3 +30,74 @@ pub fn SeekableStream(comptime SeekErrorType: type, comptime GetSeekPosErrorType
         }
     };
 }
+
+pub const SliceSeekableInStream = struct {
+    const Self = @This();
+    pub const Error = error{};
+    pub const SeekError = error{EndOfStream};
+    pub const GetSeekPosError = error{};
+    pub const Stream = InStream(Error);
+    pub const SeekableInStream = SeekableStream(SeekError, GetSeekPosError);
+
+    pub stream: Stream,
+    pub seekable_stream: SeekableInStream,
+
+    pos: usize,
+    slice: []const u8,
+
+    pub fn init(slice: []const u8) Self {
+        return Self{
+            .slice = slice,
+            .pos = 0,
+            .stream = Stream{ .readFn = readFn },
+            .seekable_stream = SeekableInStream{
+                .seekToFn = seekToFn,
+                .seekForwardFn = seekForwardFn,
+                .getEndPosFn = getEndPosFn,
+                .getPosFn = getPosFn,
+            },
+        };
+    }
+
+    fn readFn(in_stream: *Stream, dest: []u8) Error!usize {
+        const self = @fieldParentPtr(Self, "stream", in_stream);
+        const size = std.math.min(dest.len, self.slice.len - self.pos);
+        const end = self.pos + size;
+
+        std.mem.copy(u8, dest[0..size], self.slice[self.pos..end]);
+        self.pos = end;
+
+        return size;
+    }
+
+    fn seekToFn(in_stream: *SeekableInStream, pos: u64) SeekError!void {
+        const self = @fieldParentPtr(Self, "seekable_stream", in_stream);
+        const usize_pos = @intCast(usize, pos);
+        if (usize_pos >= self.slice.len) return error.EndOfStream;
+        self.pos = usize_pos;
+    }
+
+    fn seekForwardFn(in_stream: *SeekableInStream, amt: i64) SeekError!void {
+        const self = @fieldParentPtr(Self, "seekable_stream", in_stream);
+
+        if (amt < 0) {
+            const abs_amt = @intCast(usize, -amt);
+            if (abs_amt > self.pos) return error.EndOfStream;
+            self.pos -= abs_amt;
+        } else {
+            const usize_amt = @intCast(usize, amt);
+            if (self.pos + usize_amt >= self.slice.len) return error.EndOfStream;
+            self.pos += usize_amt;
+        }
+    }
+
+    fn getEndPosFn(in_stream: *SeekableInStream) GetSeekPosError!u64 {
+        const self = @fieldParentPtr(Self, "seekable_stream", in_stream);
+        return @intCast(u64, self.slice.len);
+    }
+
+    fn getPosFn(in_stream: *SeekableInStream) GetSeekPosError!u64 {
+        const self = @fieldParentPtr(Self, "seekable_stream", in_stream);
+        return @intCast(u64, self.pos);
+    }
+};


### PR DESCRIPTION
Closes #907.

This mmaps the executable into memory to seek and iterate over. This works much better given the type of access we are typically doing to process the debug info (lots of seeks). This is changed for all posix implementations.

With the following program:

```
pub fn main() void {
   @panic("error");
}
```

## Before patch

```
strace -c ./t
error
/home/me/src/zig/t.zig:2:5: 0x227ee6 in main (t)
    @panic("error");
    ^
/home/me/local/lib/zig/std/special/bootstrap.zig:111:22: 0x226f05 in std.special.posixCallMainAndExit (t)
            root.main();
                     ^
/home/me/local/lib/zig/std/special/bootstrap.zig:47:5: 0x226da0 in std.special._start (t)
    @noInlineCall(posixCallMainAndExit);
    ^
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 91.63    0.463258           2    186844           read
  8.19    0.041429           2     18510           lseek
  0.14    0.000712           4       160           write
  0.02    0.000080           6        13           mmap
  0.01    0.000053          13         4           openat
  0.00    0.000012           4         3           close
  0.00    0.000005           2         2           rt_sigprocmask
  0.00    0.000004           4         1           execve
  0.00    0.000003           3         1           fstat
  0.00    0.000003           3         1           ioctl
  0.00    0.000003           3         1           tkill
  0.00    0.000002           2         1           gettid
------ ----------- ----------- --------- --------- ----------------
100.00    0.505564                205541           total
fish: “strace -c ./t” terminated by signal SIGABRT (Abort)
```

## After patch

```
$ strace -c ./t-new
error
/home/me/src/zig/t-new.zig:2:5: 0x2281d6 in main (t-new)
    @panic("error");
    ^
/home/me/local/lib/zig/std/special/bootstrap.zig:111:22: 0x2271f5 in std.special.posixCallMainAndExit (t-new)
            root.main();
                     ^
/home/me/local/lib/zig/std/special/bootstrap.zig:47:5: 0x227090 in std.special._start (t-new)
    @noInlineCall(posixCallMainAndExit);
    ^
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 89.19    0.000066           4        14           mmap
  9.46    0.000007           0       160           write
  1.35    0.000001           0         3           close
  0.00    0.000000           0         3           read
  0.00    0.000000           0         1           fstat
  0.00    0.000000           0         2           rt_sigprocmask
  0.00    0.000000           0         1           ioctl
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           gettid
  0.00    0.000000           0         1           tkill
  0.00    0.000000           0         4           openat
------ ----------- ----------- --------- --------- ----------------
100.00    0.000074                   191           total
fish: “strace -c ./t-new” terminated by signal SIGABRT (Abort)
```

For larger binaries (such as when using `zig build`), the stack traces are now pretty instant. #2458 is likely less pressing.