### PR TITLE
Fix formatting for multiline asm expressions

### DIFF
--- a/std/valgrind.zig
+++ b/std/valgrind.zig
@@ -12,7 +12,7 @@ pub fn doClientRequest(default: usize, request: usize, a1: usize, a2: usize, a3:
                 \\ roll $3,  %%edi ; roll $13, %%edi
                 \\ roll $29, %%edi ; roll $19, %%edi
                 \\ xchgl %%ebx,%%ebx
-                            : [_] "={edx}" (-> usize)
+                : [_] "={edx}" (-> usize)
                 : [_] "{eax}" (&[]usize{ request, a1, a2, a3, a4, a5 }),
                   [_] "0" (default)
                 : "cc", "memory"
@@ -23,7 +23,7 @@ pub fn doClientRequest(default: usize, request: usize, a1: usize, a2: usize, a3:
                 \\ rolq $3,  %%rdi ; rolq $13, %%rdi
                 \\ rolq $61, %%rdi ; rolq $51, %%rdi
                 \\ xchgq %%rbx,%%rbx
-                            : [_] "={rdx}" (-> usize)
+                : [_] "={rdx}" (-> usize)
                 : [_] "{rax}" (&[]usize{ request, a1, a2, a3, a4, a5 }),
                   [_] "0" (default)
                 : "cc", "memory"

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2129,6 +2129,47 @@ test "zig fmt: comptime block in container" {
     );
 }
 
+test "zig fmt: inline asm parameter alignment" {
+    try testCanonical(
+        \\pub fn main() void {
+        \\    asm volatile (
+        \\        \\ foo
+        \\        \\ bar
+        \\    );
+        \\    asm volatile (
+        \\        \\ foo
+        \\        \\ bar
+        \\        : [_] "" (-> usize),
+        \\          [_] "" (-> usize)
+        \\    );
+        \\    asm volatile (
+        \\        \\ foo
+        \\        \\ bar
+        \\        :
+        \\        : [_] "" (0),
+        \\          [_] "" (0)
+        \\    );
+        \\    asm volatile (
+        \\        \\ foo
+        \\        \\ bar
+        \\        :
+        \\        :
+        \\        : "", ""
+        \\    );
+        \\    asm volatile (
+        \\        \\ foo
+        \\        \\ bar
+        \\        : [_] "" (-> usize),
+        \\          [_] "" (-> usize)
+        \\        : [_] "" (0),
+        \\          [_] "" (0)
+        \\        : "", ""
+        \\    );
+        \\}
+        \\
+    );
+}
+
 const std = @import("std");
 const mem = std.mem;
 const warn = std.debug.warn;

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -1549,7 +1549,14 @@ fn renderExpression(
             try renderExpression(allocator, stream, tree, indent, start_col, asm_node.template, Space.Newline);
 
             const indent_once = indent + indent_delta;
-            try stream.writeByteNTimes(' ', indent_once);
+
+            if (asm_node.template.id == ast.Node.Id.MultilineStringLiteral) {
+                // After rendering a multiline string literal the cursor is
+                // already offset by indent
+                try stream.writeByteNTimes(' ', indent_delta);
+            } else {
+                try stream.writeByteNTimes(' ', indent_once);
+            }
 
             const colon1 = tree.nextToken(asm_node.template.lastToken());
             const indent_extra = indent_once + 2;


### PR DESCRIPTION
Having to check for `MultilineStringLiteral` every time is not that nice tho.