### PR TITLE
Autogenerated syscall stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,6 +615,7 @@ set(ZIG_STD_FILES
     "os/linux/tls.zig"
     "os/linux/vdso.zig"
     "os/linux/x86_64.zig"
+    "os/linux/syscalls_x86_64.zig"
     "os/netbsd.zig"
     "os/netbsd/errno.zig"
     "os/path.zig"

--- a/gensyscalls.py
+++ b/gensyscalls.py
@@ -1,0 +1,132 @@
+import sys
+
+fil = open(sys.argv[1], 'r')
+sel_arch = sys.argv[2]
+
+template_call = "syscall{syscall_arg_count}({syscall_args})"
+template_basic = """pub fn {fn_name}{fn_params} {fn_return} {{
+    return {expr};
+}}
+"""
+template_noreturn = """pub fn {fn_name}{fn_params} {fn_return} {{
+    _ = {expr};
+    unreachable;
+}}
+"""
+
+def is_ptr_type(ty):
+    return ty[0] in {'*', '?'} or ty.startswith('[*]')
+
+def gen_return_cast_expr(expr_ty, expr):
+    if expr_ty == 'usize':
+        return expr
+    elif expr_ty in ['i8', 'i16', 'i32']:
+        return '@bitCast({}, @truncate(u{}, {}))'.format(expr_ty, expr_ty[1:], expr)
+    elif expr_ty in ['u8', 'u16', 'u32']:
+        return '@truncate({}, {})'.format(expr_ty, expr)
+    else:
+        print('Cannot handle return type \'{}\''.format(expr_ty))
+        sys.exit(1)
+
+def gen_param_cast_expr(expr_ty, expr, split_64):
+    if is_ptr_type(expr_ty):
+        return ['@ptrToInt({})'.format(expr)]
+    elif expr_ty in ['i8','i16','i32']:
+        return ['@bitCast(usize, isize({}))'.format(expr)]
+    elif expr_ty in ['u8','u16','u32']:
+        return ['usize({})'.format(expr)]
+    elif expr_ty in ['i64', 'u64']:
+        # Split the parameter into a hi/lo pair
+        if split_64:
+            if expr_ty[0] == 'i':
+                return ['@truncate(usize, @bitCast(u64, {}) >> 32)'.format(expr),
+                        '@truncate(usize, @bitCast(u64, {}))'.format(expr)]
+            else:
+                return ['@truncate(usize, {} >> 32)'.format(expr),
+                        '@truncate(usize, {})'.format(expr)]
+        else:
+            if expr_ty[0] == 'i':
+                return ['@bitCast(usize, {})'.format(expr)]
+            else:
+                return ['usize({})'.format(expr)]
+    elif expr_ty == 'isize':
+        return ['@bitCast(usize, {})'.format(expr)]
+    elif expr_ty == 'usize':
+        return [expr]
+    else:
+        print('Cannot handle param type \'{}\''.format(expr_ty))
+        sys.exit(1)
+
+print('''use @import("{}.zig");
+const std = @import("../../std.zig");
+const linux = std.os.linux;
+const sockaddr = linux.sockaddr;
+const socklen_t = linux.socklen_t;
+const iovec = linux.iovec;
+const iovec_const = linux.iovec_const;
+const sigset_t = linux.sigset_t;
+'''.format(sel_arch))
+
+for line in fil:
+    line = line.strip()
+
+    if len(line) == 0 or line[0] == '#':
+        continue
+
+    chunks = line.split('\t')
+
+    if len(chunks) < 5:
+        print('malformed entry:')
+        print(line)
+        sys.exit(1)
+
+    stub_name = chunks[0]
+    arch      = chunks[1]
+    syscall   = chunks[2]
+    params    = chunks[3]
+    return_ty = chunks[4]
+    flags     = chunks[5] if len(chunks) == 6 else ''
+
+    if arch.startswith('any'):
+        if len(arch) > 3 and ('64' in arch) != ('64' in sel_arch):
+            continue
+    elif arch != sel_arch:
+        continue
+
+    args = []
+
+    lpar = params.index('(')
+    rpar = params.index(')')
+    param_list_inner = params[lpar+1:rpar]
+
+    for param in param_list_inner.split(','):
+        if len(param) == 0:
+            continue
+
+        param_name = param.split(':')[0].strip()
+        param_type = param.split(':')[1].strip()
+
+        expr = gen_param_cast_expr(param_type, param_name, True)
+
+        if len(expr) > 1 and len(args) & 1 != 0:
+            args.append('0')
+
+        args.extend(expr)
+
+    has_return_ty = return_ty != 'noreturn'
+
+    call_str = template_call.format(**{
+        'syscall_arg_count': len(args),
+        'syscall_args': ', '.join(['SYS_' + syscall] + args)
+        })
+
+    template = template_basic if has_return_ty else template_noreturn
+
+    body = template.format(**{
+        'fn_name': stub_name,
+        'fn_params': params,
+        'fn_return': return_ty,
+        'expr': gen_return_cast_expr(return_ty, call_str) if has_return_ty else call_str
+        })
+
+    print(body)

--- a/std/os.zig
+++ b/std/os.zig
@@ -359,7 +359,7 @@ pub fn posix_preadv(fd: i32, iov: [*]const posix.iovec, count: usize, offset: u6
             }
         },
         builtin.Os.linux, builtin.Os.freebsd, Os.netbsd => while (true) {
-            const rc = posix.preadv(fd, iov, count, offset);
+            const rc = if (@sizeOf(usize) != 8) posix.preadv(fd, iov, count, @truncate(u32, offset >> 32), @truncate(u32, offset)) else posix.preadv(fd, iov, count, offset);
             const err = posix.getErrno(rc);
             switch (err) {
                 0 => return rc,
@@ -466,7 +466,7 @@ pub fn posix_pwritev(fd: i32, iov: [*]const posix.iovec_const, count: usize, off
             }
         },
         builtin.Os.linux, builtin.Os.freebsd, builtin.Os.netbsd => while (true) {
-            const rc = posix.pwritev(fd, iov, count, offset);
+            const rc = if (@sizeOf(usize) != 8) posix.pwritev(fd, iov, count, @truncate(u32, offset >> 32), @truncate(u32, offset)) else posix.pwritev(fd, iov, count, offset);
             const err = posix.getErrno(rc);
             switch (err) {
                 0 => return,

--- a/std/os/linux/syscalls_x86_64.zig
+++ b/std/os/linux/syscalls_x86_64.zig
@@ -1,0 +1,207 @@
+use @import("x86_64.zig");
+const std = @import("../../std.zig");
+const linux = std.os.linux;
+const sockaddr = linux.sockaddr;
+const socklen_t = linux.socklen_t;
+const iovec = linux.iovec;
+const iovec_const = linux.iovec_const;
+const sigset_t = linux.sigset_t;
+
+pub fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: u32, fd: i32, offset: usize) usize {
+    return syscall6(SYS_mmap, @ptrToInt(address), length, prot, usize(flags), @bitCast(usize, isize(fd)), offset);
+}
+
+pub fn mprotect(address: usize, length: usize, protection: usize) usize {
+    return syscall3(SYS_mprotect, address, length, protection);
+}
+
+pub fn munmap(address: usize, length: usize) usize {
+    return syscall2(SYS_munmap, address, length);
+}
+
+pub fn openat(dirfd: i32, path: [*]const u8, flags: u32, mode: usize) usize {
+    return syscall4(SYS_openat, @bitCast(usize, isize(dirfd)), @ptrToInt(path), usize(flags), mode);
+}
+
+pub fn creat(path: [*]const u8, perm: usize) usize {
+    return syscall2(SYS_creat, @ptrToInt(path), perm);
+}
+
+pub fn read(fd: i32, buf: [*]u8, count: usize) usize {
+    return syscall3(SYS_read, @bitCast(usize, isize(fd)), @ptrToInt(buf), count);
+}
+
+pub fn write(fd: i32, buf: [*]const u8, count: usize) usize {
+    return syscall3(SYS_write, @bitCast(usize, isize(fd)), @ptrToInt(buf), count);
+}
+
+pub fn close(fd: i32) usize {
+    return syscall1(SYS_close, @bitCast(usize, isize(fd)));
+}
+
+pub fn ioctl(fd: i32, ctl: i32, arg: usize) usize {
+    return syscall3(SYS_ioctl, @bitCast(usize, isize(fd)), @bitCast(usize, isize(ctl)), arg);
+}
+
+pub fn readlinkat(dirfd: i32, path: [*]const u8, buf_ptr: [*]u8, buf_len: usize) usize {
+    return syscall4(SYS_readlinkat, @bitCast(usize, isize(dirfd)), @ptrToInt(path), @ptrToInt(buf_ptr), buf_len);
+}
+
+pub fn mkdirat(dirfd: i32, path: [*]const u8, mode: u32) usize {
+    return syscall3(SYS_mkdirat, @bitCast(usize, isize(dirfd)), @ptrToInt(path), usize(mode));
+}
+
+pub fn symlinkat(existing: [*]const u8, newfd: i32, newpath: [*]const u8) usize {
+    return syscall3(SYS_symlinkat, @ptrToInt(existing), @bitCast(usize, isize(newfd)), @ptrToInt(newpath));
+}
+
+pub fn faccessat(dirfd: i32, path: [*]const u8, mode: u32) usize {
+    return syscall3(SYS_faccessat, @bitCast(usize, isize(dirfd)), @ptrToInt(path), usize(mode));
+}
+
+pub fn renameat(oldfd: i32, oldpath: [*]const u8, newfd: i32, newpath: [*]const u8) usize {
+    return syscall4(SYS_renameat, @bitCast(usize, isize(oldfd)), @ptrToInt(oldpath), @bitCast(usize, isize(newfd)), @ptrToInt(newpath));
+}
+
+pub fn unlinkat(dirfd: i32, path: [*]const u8, flags: u32) usize {
+    return syscall3(SYS_unlinkat, @bitCast(usize, isize(dirfd)), @ptrToInt(path), usize(flags));
+}
+
+pub fn fstatat(dirfd: i32, path: [*]const u8, stat_buf: *Stat, flags: u32) usize {
+    return syscall4(SYS_fstatat, @bitCast(usize, isize(dirfd)), @ptrToInt(path), @ptrToInt(stat_buf), usize(flags));
+}
+
+pub fn lseek(fd: i32, offset: i64, whence: usize) usize {
+    return syscall5(SYS_lseek, @bitCast(usize, isize(fd)), 0, @truncate(usize, @bitCast(u64, offset) >> 32), @truncate(usize, @bitCast(u64, offset)), whence);
+}
+
+pub fn pread(fd: i32, buf: [*]u8, count: usize, offset: i64) usize {
+    return syscall6(SYS_pread, @bitCast(usize, isize(fd)), @ptrToInt(buf), count, 0, @truncate(usize, @bitCast(u64, offset) >> 32), @truncate(usize, @bitCast(u64, offset)));
+}
+
+pub fn readv(fd: i32, iov: [*]const iovec, count: usize) usize {
+    return syscall3(SYS_readv, @bitCast(usize, isize(fd)), @ptrToInt(iov), count);
+}
+
+pub fn writev(fd: i32, iov: [*]const iovec_const, count: usize) usize {
+    return syscall3(SYS_writev, @bitCast(usize, isize(fd)), @ptrToInt(iov), count);
+}
+
+pub fn preadv(fd: i32, iov: [*]const iovec, count: usize, offset: u64) usize {
+    return syscall6(SYS_preadv, @bitCast(usize, isize(fd)), @ptrToInt(iov), count, 0, @truncate(usize, offset >> 32), @truncate(usize, offset));
+}
+
+pub fn pwritev(fd: i32, iov: [*]const iovec_const, count: usize, offset: u64) usize {
+    return syscall6(SYS_pwritev, @bitCast(usize, isize(fd)), @ptrToInt(iov), count, 0, @truncate(usize, offset >> 32), @truncate(usize, offset));
+}
+
+pub fn chdir(path: [*]const u8) usize {
+    return syscall1(SYS_chdir, @ptrToInt(path));
+}
+
+pub fn chroot(path: [*]const u8) usize {
+    return syscall1(SYS_chroot, @ptrToInt(path));
+}
+
+pub fn getcwd(path: [*]const u8, size: usize) usize {
+    return syscall2(SYS_getcwd, @ptrToInt(path), size);
+}
+
+pub fn getdents64(fd: i32, dirp: [*]u8, count: usize) usize {
+    return syscall3(SYS_getdents64, @bitCast(usize, isize(fd)), @ptrToInt(dirp), count);
+}
+
+pub fn futex4(uaddr: *const i32, futex_op: i32, val: i32, timeout: ?*timespec) usize {
+    return syscall4(SYS_futex, @ptrToInt(uaddr), @bitCast(usize, isize(futex_op)), @bitCast(usize, isize(val)), @ptrToInt(timeout));
+}
+
+pub fn getrandom(buf: [*]u8, count: usize, flags: u32) usize {
+    return syscall3(SYS_getrandom, @ptrToInt(buf), count, usize(flags));
+}
+
+pub fn clock_getres(clk_id: i32, tp: *timespec) usize {
+    return syscall2(SYS_clock_getres, @bitCast(usize, isize(clk_id)), @ptrToInt(tp));
+}
+
+pub fn clock_settime(clk_id: i32, tp: *const timespec) usize {
+    return syscall2(SYS_clock_settime, @bitCast(usize, isize(clk_id)), @ptrToInt(tp));
+}
+
+pub fn gettimeofday(tv: *timeval, tz: *timezone) usize {
+    return syscall2(SYS_gettimeofday, @ptrToInt(tv), @ptrToInt(tz));
+}
+
+pub fn settimeofday(tv: *const timeval, tz: *const timezone) usize {
+    return syscall2(SYS_settimeofday, @ptrToInt(tv), @ptrToInt(tz));
+}
+
+pub fn nanosleep(req: *const timespec, rem: ?*timespec) usize {
+    return syscall2(SYS_nanosleep, @ptrToInt(req), @ptrToInt(rem));
+}
+
+pub fn rt_sigprocmask(how: i32, set: *const sigset_t, oldset: ?*sigset_t, sigsetsize: usize) usize {
+    return syscall4(SYS_rt_sigprocmask, @bitCast(usize, isize(how)), @ptrToInt(set), @ptrToInt(oldset), sigsetsize);
+}
+
+pub fn getgid() u32 {
+    return @truncate(u32, syscall0(SYS_getgid));
+}
+
+pub fn getpid() i32 {
+    return @bitCast(i32, @truncate(u32, syscall0(SYS_getpid)));
+}
+
+pub fn dup3(oldfd: i32, newfd: i32, flags: i32) usize {
+    return syscall3(SYS_dup3, @bitCast(usize, isize(oldfd)), @bitCast(usize, isize(newfd)), @bitCast(usize, isize(flags)));
+}
+
+pub fn pipe2(fd: *[2]i32, flags: u32) usize {
+    return syscall2(SYS_pipe2, @ptrToInt(fd), usize(flags));
+}
+
+pub fn clone5(flags: u32, child_stack_ptr: usize, parent_tid: *i32, child_tid: *i32, newtls: usize) usize {
+    return syscall5(SYS_clone, usize(flags), child_stack_ptr, @ptrToInt(parent_tid), @ptrToInt(child_tid), newtls);
+}
+
+pub fn clone2(flags: u32, child_stack_ptr: usize) usize {
+    return syscall2(SYS_clone, usize(flags), child_stack_ptr);
+}
+
+pub fn execve(path: [*]const u8, argv: [*]const ?[*]const u8, envp: [*]const ?[*]const u8) usize {
+    return syscall3(SYS_execve, @ptrToInt(path), @ptrToInt(argv), @ptrToInt(envp));
+}
+
+pub fn kill(pid: i32, sig: i32) usize {
+    return syscall2(SYS_kill, @bitCast(usize, isize(pid)), @bitCast(usize, isize(sig)));
+}
+
+pub fn wait4(pid: i32, status: *i32, options: i32, rusage: usize) usize {
+    return syscall4(SYS_wait4, @bitCast(usize, isize(pid)), @ptrToInt(status), @bitCast(usize, isize(options)), rusage);
+}
+
+pub fn exit(status: i32) noreturn {
+    _ = syscall1(SYS_exit, @bitCast(usize, isize(status)));
+    unreachable;
+}
+
+pub fn exit_group(status: i32) noreturn {
+    _ = syscall1(SYS_exit_group, @bitCast(usize, isize(status)));
+    unreachable;
+}
+
+pub fn inotify_init1(flags: u32) usize {
+    return syscall1(SYS_inotify_init1, usize(flags));
+}
+
+pub fn inotify_add_watch(fd: i32, pathname: [*]const u8, mask: u32) usize {
+    return syscall3(SYS_inotify_add_watch, @bitCast(usize, isize(fd)), @ptrToInt(pathname), usize(mask));
+}
+
+pub fn inotify_rm_watch(fd: i32, wd: i32) usize {
+    return syscall2(SYS_inotify_rm_watch, @bitCast(usize, isize(fd)), @bitCast(usize, isize(wd)));
+}
+
+pub fn arch_prctl(code: i32, addr: usize) usize {
+    return syscall2(SYS_arch_prctl, @bitCast(usize, isize(code)), addr);
+}
+

--- a/std/os/linux/tls.zig
+++ b/std/os/linux/tls.zig
@@ -108,13 +108,13 @@ pub var tls_image: ?TLSImage = null;
 pub fn setThreadPointer(addr: usize) void {
     switch (builtin.arch) {
         .x86_64 => {
-            const rc = std.os.linux.syscall2(std.os.linux.SYS_arch_prctl, std.os.linux.ARCH_SET_FS, addr);
+            const rc = std.os.linux.syscalls.arch_prctl(std.os.linux.ARCH_SET_FS, addr);
             assert(rc == 0);
         },
         .aarch64 => {
             asm volatile (
                 \\ msr tpidr_el0, %[addr]
-                            :
+                :
                 : [addr] "r" (addr)
             );
         },

--- a/syscalls.txt
+++ b/syscalls.txt
@@ -1,0 +1,83 @@
+# <stub name> <architecture> <syscall name> <parameters> <return type> <flags>
+
+# memory management
+mmap2	any32	mmap2	(address: ?[*]u8, length: usize, prot: usize, flags: u32, fd: i32, offset: usize)	usize
+mmap	any64	mmap	(address: ?[*]u8, length: usize, prot: usize, flags: u32, fd: i32, offset: usize)	usize
+mprotect	any	mprotect	(address: usize, length: usize, protection: usize)	usize
+munmap	any	munmap	(address: usize, length: usize)	usize
+
+# file io
+openat	any	openat	(dirfd: i32, path: [*]const u8, flags: u32, mode: usize)	usize
+creat	any	creat	(path: [*]const u8, perm: usize)	usize
+read	any	read	(fd: i32, buf: [*]u8, count: usize)	usize
+write	any	write	(fd: i32, buf: [*]const u8, count: usize)	usize
+close	any	close	(fd: i32)	usize
+ioctl	any	ioctl	(fd: i32, ctl: i32, arg: usize)	usize
+
+readlinkat	any	readlinkat	(dirfd: i32, path: [*]const u8, buf_ptr: [*]u8, buf_len: usize)	usize
+mkdirat	any	mkdirat	(dirfd: i32, path: [*]const u8, mode: u32)	usize
+symlinkat	any	symlinkat	(existing: [*]const u8, newfd: i32, newpath: [*]const u8)	usize
+faccessat	any	faccessat	(dirfd: i32, path: [*]const u8, mode: u32)	usize
+renameat	any	renameat	(oldfd: i32, oldpath: [*]const u8, newfd: i32, newpath: [*]const u8)	usize
+unlinkat	any	unlinkat	(dirfd: i32, path: [*]const u8, flags: u32)	usize
+
+fstatat	any64	fstatat	(dirfd: i32, path: [*]const u8, stat_buf: *Stat, flags: u32)	usize
+fstatat64	any32	fstatat64	(dirfd: i32, path: [*]const u8, stat_buf: *Stat, flags: u32)	usize
+
+llseek	any32	_llseek	(fd: i32, offset_high: u32, offset_low: u32, result: *i64, whence: usize)	usize
+lseek	any32	lseek	(fd: i32, offset: i32, whence: usize)	usize
+lseek	any64	lseek	(fd: i32, offset: i64, whence: usize)	usize
+
+pread64	any32	pread64	(fd: i32, buf: [*]u8, count: usize, offset: i64)	usize
+pread	any64	pread	(fd: i32, buf: [*]u8, count: usize, offset: i64)	usize
+
+readv	any	readv	(fd: i32, iov: [*]const iovec, count: usize)	usize
+writev	any	writev	(fd: i32, iov: [*]const iovec_const, count: usize)	usize
+
+preadv	any32	preadv	(fd: i32, iov: [*]const iovec, count: usize, offset_low: u32, offset_hi: u32)	usize
+preadv	any64	preadv	(fd: i32, iov: [*]const iovec, count: usize, offset: u64)	usize
+
+pwritev	any32	pwritev	(fd: i32, iov: [*]const iovec_const, count: usize, offset_low: u32, offset_hi: u32)	usize
+pwritev	any64	pwritev	(fd: i32, iov: [*]const iovec_const, count: usize, offset: u64)	usize
+
+chdir	any	chdir	(path: [*]const u8)	usize
+chroot	any	chroot	(path: [*]const u8)	usize
+getcwd	any	getcwd	(path: [*]const u8, size: usize)	usize
+getdents64	any	getdents64	(fd: i32, dirp: [*]u8, count: usize)	usize
+
+futex4	any	futex	(uaddr: *const i32, futex_op: i32, val: i32, timeout: ?*timespec)	usize
+
+getrandom	any	getrandom	(buf: [*]u8, count: usize, flags: u32)	usize
+
+clock_getres	any	clock_getres	(clk_id: i32, tp: *timespec)	usize
+clock_settime	any	clock_settime	(clk_id: i32, tp: *const timespec)	usize
+
+gettimeofday	any	gettimeofday	(tv: *timeval, tz: *timezone)	usize
+settimeofday	any	settimeofday	(tv: *const timeval, tz: *const timezone)	usize
+
+nanosleep	any	nanosleep	(req: *const timespec, rem: ?*timespec)	usize
+
+rt_sigprocmask	any	rt_sigprocmask	(how: i32, set: *const sigset_t, oldset: ?*sigset_t, sigsetsize: usize)	usize
+
+getgid	any32	getgid32	()	u32
+getgid	any64	getgid	()	u32
+
+getpid	any	getpid	()	i32
+
+dup3	any	dup3	(oldfd: i32, newfd: i32, flags: i32)	usize
+pipe2	any	pipe2	(fd: *[2]i32, flags: u32)	usize
+clone5	any	clone	(flags: u32, child_stack_ptr: usize, parent_tid: *i32, child_tid: *i32, newtls: usize)	usize
+clone2	any	clone	(flags: u32, child_stack_ptr: usize)	usize
+execve	any	execve	(path: [*]const u8, argv: [*]const ?[*]const u8, envp: [*]const ?[*]const u8)	usize
+kill	any	kill	(pid: i32, sig: i32)	usize
+wait4	any	wait4	(pid: i32, status: *i32, options: i32, rusage: usize)	usize
+exit	any	exit	(status: i32)	noreturn
+exit_group	any	exit_group	(status: i32)	noreturn
+
+# inotify
+inotify_init1	any	inotify_init1	(flags: u32)	usize
+inotify_add_watch	any	inotify_add_watch	(fd: i32, pathname: [*]const u8, mask: u32)	usize
+inotify_rm_watch	any	inotify_rm_watch	(fd: i32, wd: i32)	usize
+
+# x86_64 specific
+arch_prctl	x86_64	arch_prctl	(code: i32, addr: usize)	usize


### PR DESCRIPTION
Up for discussion, I've only partially integrated it to give an idea of the end result.
A few open questions:
- What's the best place for the stubs to live
- Is the `syscalls` -> `linux` forwarding the right approach?
- What to do when some syscalls are missing:
  - `llseek` is only available on 32bit systems (let's export a `seek64` that wraps either that or `lseek`)
  - Architecture-specific ones can probably be accessed as `std.os.linux.syscalls.<name>`