### PR TITLE
improvements to zig's implementation of libc and WebAssembly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,7 +643,7 @@ set(ZIG_STD_FILES
     "special/bootstrap_lib.zig"
     "special/bootstrap_windows_tls.zig"
     "special/build_runner.zig"
-    "special/builtin.zig"
+    "special/c.zig"
     "special/compiler_rt.zig"
     "special/compiler_rt/stack_probe.zig"
     "special/compiler_rt/arm/aeabi_fcmp.zig"

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -1376,6 +1376,9 @@ bool target_is_single_threaded(const ZigTarget *target) {
 }
 
 ZigLLVM_EnvironmentType target_default_abi(ZigLLVM_ArchType arch, Os os) {
+    if (arch == ZigLLVM_wasm32 || arch == ZigLLVM_wasm64) {
+        return ZigLLVM_Musl;
+    }
     switch (os) {
         case OsFreestanding:
         case OsAnanas:
@@ -1490,6 +1493,7 @@ static const AvailableLibC libcs_available[] = {
     {ZigLLVM_systemz, OsLinux, ZigLLVM_Musl},
     {ZigLLVM_sparc, OsLinux, ZigLLVM_GNU},
     {ZigLLVM_sparcv9, OsLinux, ZigLLVM_GNU},
+    {ZigLLVM_wasm32, OsFreestanding, ZigLLVM_Musl},
     {ZigLLVM_x86_64, OsLinux, ZigLLVM_GNU},
     {ZigLLVM_x86_64, OsLinux, ZigLLVM_GNUX32},
     {ZigLLVM_x86_64, OsLinux, ZigLLVM_Musl},
@@ -1508,7 +1512,6 @@ bool target_can_build_libc(const ZigTarget *target) {
 }
 
 const char *target_libc_generic_name(const ZigTarget *target) {
-    assert(target->os == OsLinux);
     switch (target->abi) {
         case ZigLLVM_GNU:
         case ZigLLVM_GNUABIN32:
@@ -1520,6 +1523,7 @@ const char *target_libc_generic_name(const ZigTarget *target) {
         case ZigLLVM_Musl:
         case ZigLLVM_MuslEABI:
         case ZigLLVM_MuslEABIHF:
+        case ZigLLVM_UnknownEnvironment:
             return "musl";
         case ZigLLVM_CODE16:
         case ZigLLVM_EABI:
@@ -1530,7 +1534,6 @@ const char *target_libc_generic_name(const ZigTarget *target) {
         case ZigLLVM_Cygnus:
         case ZigLLVM_CoreCLR:
         case ZigLLVM_Simulator:
-        case ZigLLVM_UnknownEnvironment:
             zig_unreachable();
     }
     zig_unreachable();

--- a/std/special/c.zig
+++ b/std/special/c.zig
@@ -1,9 +1,25 @@
-// These functions are provided when not linking against libc because LLVM
-// sometimes generates code that calls them.
+// This is Zig's multi-target implementation of libc.
+// When builtin.link_libc is true, we need to export all the functions and
+// provide an entire C API.
+// Otherwise, only the functions which LLVM generates calls to need to be generated,
+// such as memcpy, memset, and some math functions.
 
 const std = @import("std");
 const builtin = @import("builtin");
 const maxInt = std.math.maxInt;
+
+const is_wasm = switch (builtin.arch) { .wasm32, .wasm64 => true, else => false};
+const is_freestanding = switch (builtin.os) { .freestanding => true, else => false };
+comptime {
+    if (is_freestanding and is_wasm) {
+        @export("_start", wasm_start, .Strong);
+    }
+}
+
+extern fn main(argc: c_int, argv: [*][*]u8) c_int;
+extern fn wasm_start() c_int {
+    return main(0, undefined);
+}
 
 // Avoid dragging in the runtime safety mechanisms into this .o file,
 // unless we're trying to test this file.


### PR DESCRIPTION
 * rename std/special/builtin.zig to std/special/c.zig
   not to be confused with `@import("builtin")` which is entirely
   different, this is zig's multi-target libc implementation.
 * WebAssembly: build-exe is for executables which have a main().
   build-lib is for building libraries of functions to use from,
   for example, a web browser environment.
   - for now pass --export-all for libraries when there are any
     C objects because we have no way to detect the list of exports
     when compiling C code.
   - stop passing --no-entry for executables. if you want --no-entry
     then use build-lib.
 * make the "musl" ABI the default ABI for wasm32-freestanding.
 * zig provides libc for wasm32-freestanding-musl.

Here's the example I played with, a trivial version of @triplefox's [gist](https://gist.github.com/triplefox/cb25c40ba6d8f1b25951f7f5d26c66af):

```c
#include <stdio.h>
int main(int argc, char **argv) {
    puts("hi");
    return 0;
}
```

```
[nix-shell:~/downloads/zig/build]$ ./zig build-exe --c-source foo.c -target wasm32-freestanding --library c --verbose-cc --verbose-link
zig cc -MD -MV -MF zig-cache/tmp/pKkfQaRld1ql-foo.o.d -nostdinc -fno-spell-checking -isystem /home/andy/downloads/zig/build/lib/zig/include -isystem /home/andy/downloads/zig/build/lib/zig/libc/include/wasm32-freestanding-musl -isystem /home/andy/downloads/zig/build/lib/zig/libc/include/generic-musl -isystem /home/andy/downloads/zig/build/lib/zig/libc/include/wasm32-freestanding-any -isystem /home/andy/downloads/zig/build/lib/zig/libc/include/any-freestanding-any -target wasm32-unknown-unknown-musl -ffreestanding -g -D_DEBUG -fstack-protector-strong --param ssp-buffer-size=4 -fno-omit-frame-pointer -o zig-cache/tmp/pKkfQaRld1ql-foo.o -c foo.c
lld -error-limit=0 --allow-undefined -o ./foo.wasm zig-cache/o/eSOKw-9lrwuVW4c7nOQw_Jvj4cUI3el1DpFjpbnP4E2fhJYglzOLv4qmZNTXG_Ed/foo.o /home/andy/.local/share/zig/stage1/o/4mJbpDu_phE8dDvDivFrMtk9w1CaGQ9xhJnSkJlZe9SGEkNdqr518e1qg503kXYF/libc.a /home/andy/.local/share/zig/stage1/o/75IN2lywulVJuIQNOolmAgCIOmk61Ujn0w2r19s4-Zqyb9M1vHOOlr8XhiF8sKGj/libcompiler_rt.a
[nix-shell:~/downloads/zig/build]$ wasm2wat foo.wasm 
(module
  (type (;0;) (func (param i32) (result i32)))
  (type (;1;) (func))
  (type (;2;) (func (param i32 i32) (result i32)))
  (type (;3;) (func (result i32)))
  (import "env" "puts" (func $puts (type 0)))
  (func $__wasm_call_ctors (type 1))
  (func $main (type 2) (param i32 i32) (result i32)
    (local i32 i32 i32 i32 i32 i32 i32)
    global.get 0
    local.set 2
    i32.const 16
    local.set 3
    local.get 2
    local.get 3
    i32.sub
    local.set 4
    local.get 4
    global.set 0
    i32.const 0
    local.set 5
    i32.const 1024
    local.set 6
    local.get 4
    local.get 0
    i32.store offset=12
    local.get 4
    local.get 1
    i32.store offset=8
    local.get 6
    call $puts
    drop
    i32.const 16
    local.set 7
    local.get 4
    local.get 7
    i32.add
    local.set 8
    local.get 8
    global.set 0
    local.get 5
    return)
  (func $_start (type 3) (result i32)
    (local i32 i32 i32)
    i32.const 0
    local.set 0
    local.get 0
    local.get 2
    call $main
    local.set 1
    local.get 1
    return)
  (table (;0;) 1 1 funcref)
  (memory (;0;) 2)
  (global (;0;) (mut i32) (i32.const 66576))
  (global (;1;) i32 (i32.const 66576))
  (global (;2;) i32 (i32.const 1027))
  (export "memory" (memory 0))
  (export "__heap_base" (global 1))
  (export "__data_end" (global 2))
  (export "_start" (func $_start))
  (data (;0;) (i32.const 1024) "hi\00"))
```

cc @shritesh 