### PR TITLE
improvements to build-lib use case of WebAssembly

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8548,7 +8548,7 @@ static void gen_root_source(CodeGen *g) {
     }
     report_errors_and_maybe_exit(g);
 
-    if (!g->is_test_build && g->zig_target->os != OsFreestanding &&
+    if (!g->is_test_build && (g->zig_target->os != OsFreestanding || target_is_wasm(g->zig_target)) &&
         g->zig_target->os != OsUefi &&
         !g->have_c_main && !g->have_winmain && !g->have_winmain_crt_startup &&
         ((g->have_pub_main && g->out_type == OutTypeObj) || g->out_type == OutTypeExe))

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -947,8 +947,6 @@ bool target_allows_addr_zero(const ZigTarget *target) {
 const char *target_o_file_ext(const ZigTarget *target) {
     if (target->abi == ZigLLVM_MSVC || target->os == OsWindows || target->os == OsUefi) {
         return ".obj";
-    } else if (target_is_wasm(target)) {
-        return ".wasm";
     } else {
         return ".o";
     }
@@ -975,7 +973,7 @@ const char *target_exe_file_ext(const ZigTarget *target) {
 }
 
 const char *target_lib_file_prefix(const ZigTarget *target) {
-    if (target->os == OsWindows || target->os == OsUefi) {
+    if (target->os == OsWindows || target->os == OsUefi || target_is_wasm(target)) {
         return "";
     } else {
         return "lib";
@@ -985,6 +983,9 @@ const char *target_lib_file_prefix(const ZigTarget *target) {
 const char *target_lib_file_ext(const ZigTarget *target, bool is_static,
         size_t version_major, size_t version_minor, size_t version_patch)
 {
+    if (target_is_wasm(target)) {
+        return ".wasm";
+    }
     if (target->os == OsWindows || target->os == OsUefi) {
         if (is_static) {
             return ".lib";

--- a/std/special/bootstrap.zig
+++ b/std/special/bootstrap.zig
@@ -25,20 +25,24 @@ nakedcc fn _start() noreturn {
     }
 
     switch (builtin.arch) {
-        builtin.Arch.x86_64 => {
+        .x86_64 => {
             argc_ptr = asm ("lea (%%rsp), %[argc]"
                 : [argc] "=r" (-> [*]usize)
             );
         },
-        builtin.Arch.i386 => {
+        .i386 => {
             argc_ptr = asm ("lea (%%esp), %[argc]"
                 : [argc] "=r" (-> [*]usize)
             );
         },
-        builtin.Arch.aarch64, builtin.Arch.aarch64_be => {
+        .aarch64, .aarch64_be => {
             argc_ptr = asm ("mov %[argc], sp"
                 : [argc] "=r" (-> [*]usize)
             );
+        },
+        .wasm32, .wasm64 => {
+            _ = callMain();
+            while (true) {}
         },
         else => @compileError("unsupported arch"),
     }

--- a/std/special/c.zig
+++ b/std/special/c.zig
@@ -11,7 +11,7 @@ const maxInt = std.math.maxInt;
 const is_wasm = switch (builtin.arch) { .wasm32, .wasm64 => true, else => false};
 const is_freestanding = switch (builtin.os) { .freestanding => true, else => false };
 comptime {
-    if (is_freestanding and is_wasm) {
+    if (is_freestanding and is_wasm and builtin.link_libc) {
         @export("_start", wasm_start, .Strong);
     }
 }

--- a/std/special/c.zig
+++ b/std/special/c.zig
@@ -17,8 +17,8 @@ comptime {
 }
 
 extern fn main(argc: c_int, argv: [*][*]u8) c_int;
-extern fn wasm_start() c_int {
-    return main(0, undefined);
+extern fn wasm_start() void {
+    _ = main(0, undefined);
 }
 
 // Avoid dragging in the runtime safety mechanisms into this .o file,


### PR DESCRIPTION
 * build-exe does include the startup code that supplies _start for the
   wasm32-freestanding target. Previously this did not occur because
   of logic excluding "freestanding".
 * build-lib for wasm32-freestanding target gets linked by LLD. To avoid
   infinite recursion, compiler_rt and zig libc are built as objects
   rather than libraries.
   - no "lib" prefix and ".wasm" extension instead of ".a". Rather than
   build-lib foo.zig producing "libfoo.a", now it produces "foo.wasm".
 * go back to using `.o` extension for webassembly objects
 * zig libc only provides _start symbol for wasm when linking libc.