### PR TITLE
Add break after digit_value check in TokenizeStateCharCode

### DIFF
--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -1097,6 +1097,7 @@ void tokenize(Buf *buf, Tokenization *out) {
                     uint32_t digit_value = get_digit_value(c);
                     if (digit_value >= t.radix) {
                         tokenize_error(&t, "invalid digit: '%c'", c);
+                        break;
                     }
                     t.char_code *= t.radix;
                     t.char_code += digit_value;


### PR DESCRIPTION
This patch adds a break after checking if the `digit_value` is >= the current radix. This means it won't continue processing the invalid digit and trip the assertion and makes it print

> error: invalid digit: '"'
const a = "\x0";

when given the example code in #2476. Fixes #2476 