### PR TITLE
make slice types a packed struct

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -684,7 +684,7 @@ ZigType *get_slice_type(CodeGen *g, ZigType *ptr_type) {
     Buf *len_field_name = buf_create_from_str("len");
 
     entry->data.structure.resolve_status = ResolveStatusSizeKnown;
-    entry->data.structure.layout = ContainerLayoutAuto;
+    entry->data.structure.layout = ContainerLayoutPacked;
     entry->data.structure.is_slice = true;
     entry->data.structure.src_field_count = element_count;
     entry->data.structure.gen_field_count = element_count;

--- a/test/stage1/behavior/slice.zig
+++ b/test/stage1/behavior/slice.zig
@@ -54,3 +54,9 @@ test "comptime slices are disambiguated" {
     expect(sliceSum([]u8{ 1, 2 }) == 3);
     expect(sliceSum([]u8{ 3, 4 }) == 7);
 }
+
+test "slice in packed struct" {
+    const S = packed struct {
+        s: []u8,
+    };
+}


### PR DESCRIPTION
Closes #2201.

I'm not aware of anything that would prohibit this change, so I went ahead and made it. As I see it, having packed slices works all the time and can not be worse than auto layout, so we can just make it a default.