### PR TITLE
Build archives using the K_DARWIN format when targeting osx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6707,8 +6707,6 @@ target_link_libraries(zig0 compiler)
 
 if(WIN32)
     set(LIBUSERLAND "${CMAKE_BINARY_DIR}/userland.lib")
-elseif(APPLE)
-    set(LIBUSERLAND "${CMAKE_BINARY_DIR}/userland.o")
 else()
     set(LIBUSERLAND "${CMAKE_BINARY_DIR}/libuserland.a")
 endif()

--- a/build.zig
+++ b/build.zig
@@ -385,17 +385,9 @@ const Context = struct {
 };
 
 fn addLibUserlandStep(b: *Builder) void {
-    // Sadly macOS requires hacks to work around the buggy MACH-O linker code.
-    const artifact = if (builtin.os == .macosx)
-        b.addObject("userland", "src-self-hosted/stage1.zig")
-    else
-        b.addStaticLibrary("userland", "src-self-hosted/stage1.zig");
+    const artifact = b.addStaticLibrary("userland", "src-self-hosted/stage1.zig");
     artifact.disable_gen_h = true;
-    if (builtin.os == .macosx) {
-        artifact.disable_stack_probing = true;
-    } else {
-        artifact.bundle_compiler_rt = true;
-    }
+    artifact.bundle_compiler_rt = true;
     artifact.setTarget(builtin.arch, builtin.os, builtin.abi);
     artifact.linkSystemLibrary("c");
     const libuserland_step = b.step("libuserland", "Build the userland compiler library for use in stage1");

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -776,14 +776,6 @@ static const char *get_libc_crt_file(CodeGen *parent, const char *file) {
 }
 
 static Buf *build_a_raw(CodeGen *parent_gen, const char *aname, Buf *full_path, OutType child_out_type) {
-    // The Mach-O LLD code is not well maintained, and trips an assertion
-    // when we link compiler_rt and libc.zig as libraries rather than objects.
-    // Here we workaround this by having compiler_rt and libc.zig be objects.
-    // TODO write our own linker. https://github.com/ziglang/zig/issues/1535
-    if (parent_gen->zig_target->os == OsMacOSX) {
-        child_out_type = OutTypeObj;
-    }
-
     CodeGen *child_gen = create_child_codegen(parent_gen, full_path, child_out_type,
             parent_gen->libc);
     codegen_set_out_name(child_gen, buf_create_from_str(aname));

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -1350,7 +1350,7 @@ static void init_rand() {
         zig_panic("unable to open /dev/urandom");
     }
     char bytes[sizeof(unsigned)];
-    size_t amt_read;
+    ssize_t amt_read;
     while ((amt_read = read(fd, bytes, sizeof(unsigned))) == -1) {
         if (errno == EINTR) continue;
         zig_panic("unable to read /dev/urandom");

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -877,6 +877,7 @@ bool ZigLLVMWriteArchive(const char *archive_name, const char **file_names, size
         case ZigLLVM_Linux:
             kind = object::Archive::K_GNU;
             break;
+        case ZigLLVM_MacOSX:
         case ZigLLVM_Darwin:
         case ZigLLVM_IOS:
             kind = object::Archive::K_DARWIN;


### PR DESCRIPTION
Closes #2421
Closes #1981
Removes all the horrible linking hacks for macos
Enables stack probes on macos

While lld Mach-O supports has its own share of problems this time it was not his fault heh

### What's next
- Is `system_linker_hack` still needed? I don't have a macos machine so please check this out
- `disable_stack_probing` is not needed anymore and it's described as a workaround, we may want to re-purpose it as a proper flag (`-fstack-check` and `-fno-stack-check` to be consistent with gcc & friends maybe?)