### PR TITLE
Fix dynamic library loading on Linux

### DIFF
--- a/std/dynamic_library.zig
+++ b/std/dynamic_library.zig
@@ -119,7 +119,7 @@ pub const LinuxDynLib = struct {
             null,
             size,
             linux.PROT_READ | linux.PROT_EXEC,
-            linux.MAP_PRIVATE | linux.MAP_LOCKED,
+            linux.MAP_PRIVATE,
             fd,
             0,
         );

--- a/test/build_examples.zig
+++ b/test/build_examples.zig
@@ -17,9 +17,7 @@ pub fn addCases(cases: *tests.BuildExamplesContext) void {
     cases.addBuildFile("test/standalone/use_alias/build.zig");
     cases.addBuildFile("test/standalone/brace_expansion/build.zig");
     cases.addBuildFile("test/standalone/empty_env/build.zig");
-    if (false) {
-        // TODO this test is disabled because it is failing on the CI server's linux. when this is fixed
-        // enable it for at least linux
+    if (builtin.os == builtin.Os.linux) {
         // TODO hook up the DynLib API for windows using LoadLibraryA
         // TODO figure out how to make this work on darwin - probably libSystem has dlopen/dlsym in it
         cases.addBuildFile("test/standalone/load_dynamic_library/build.zig");


### PR DESCRIPTION
After fiddling with `load_dynamic_library` which did not work on my machine either, I found that the shared library was too big to be mapped into memory, which resulted in `EAGAIN` after calling `mmap()`. 