### PR TITLE
List out posix compatibles

### DIFF
--- a/std/io.zig
+++ b/std/io.zig
@@ -15,8 +15,11 @@ const fmt = std.fmt;
 const File = std.os.File;
 const testing = std.testing;
 
-const is_posix = builtin.os != builtin.Os.windows;
 const is_windows = builtin.os == builtin.Os.windows;
+const is_posix = switch (builtin.os) {
+    builtin.Os.linux, builtin.Os.macosx, builtin.Os.freebsd, builtin.Os.netbsd => true,
+    else => false,
+};
 
 const GetStdIoErrs = os.WindowsGetStdHandleErrs;
 

--- a/std/io.zig
+++ b/std/io.zig
@@ -17,7 +17,7 @@ const testing = std.testing;
 
 const is_windows = builtin.os == builtin.Os.windows;
 const is_posix = switch (builtin.os) {
-    builtin.Os.linux, builtin.Os.macosx, builtin.Os.freebsd, builtin.Os.netbsd => true,
+    .linux, .macosx, .freebsd, .netbsd => true,
     else => false,
 };
 

--- a/std/os.zig
+++ b/std/os.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const Os = builtin.Os;
 const is_windows = builtin.os == Os.windows;
 const is_posix = switch (builtin.os) {
-    builtin.Os.linux, builtin.Os.macosx, builtin.Os.freebsd, builtin.Os.netbsd => true,
+    .linux, .macosx, .freebsd, .netbsd => true,
     else => false,
 };
 const os = @This();

--- a/std/os/file.zig
+++ b/std/os/file.zig
@@ -13,7 +13,7 @@ const maxInt = std.math.maxInt;
 
 const is_windows = builtin.os == builtin.Os.windows;
 const is_posix = switch (builtin.os) {
-    builtin.Os.linux, builtin.Os.macosx, builtin.Os.freebsd, builtin.Os.netbsd => true,
+    .linux, .macosx, .freebsd, .netbsd => true,
     else => false,
 };
 

--- a/std/os/file.zig
+++ b/std/os/file.zig
@@ -11,8 +11,11 @@ const Os = builtin.Os;
 const windows_util = @import("windows/util.zig");
 const maxInt = std.math.maxInt;
 
-const is_posix = builtin.os != builtin.Os.windows;
 const is_windows = builtin.os == builtin.Os.windows;
+const is_posix = switch (builtin.os) {
+    builtin.Os.linux, builtin.Os.macosx, builtin.Os.freebsd, builtin.Os.netbsd => true,
+    else => false,
+};
 
 pub const File = struct {
     /// The OS-specific file descriptor or file handle.


### PR DESCRIPTION
This pulls them inline with the definition in `std/os.zig`. Currently, having `std.debug.warn` in the codebase causes blocking compile errors for non-posix systems like wasm32-freestanding.