### PR TITLE
std interface reform (#1829): simple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,6 +516,7 @@ set(ZIG_STD_FILES
     "hash/siphash.zig"
     "hash_map.zig"
     "heap.zig"
+    "interface.zig"
     "io.zig"
     "io/seekable_stream.zig"
     "io/c_out_stream.zig"

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -43,7 +43,7 @@ pub fn main() !void {
 
     var file_in_stream = in_file.inStreamAdapter();
 
-    const input_file_bytes = try file_in_stream.stream.readAllAlloc(allocator, max_doc_file_size);
+    const input_file_bytes = try file_in_stream.inStream().readAllAlloc(allocator, max_doc_file_size);
 
     var file_out_stream = out_file.outStreamAdapter();
     var buffered_out_stream = io.BufferedOutStream(os.File.WriteError).init(file_out_stream.outStream());
@@ -327,7 +327,7 @@ fn genToc(allocator: mem.Allocator, tokenizer: *Tokenizer) !Toc {
     defer toc_buf.deinit();
 
     var toc_buf_adapter = io.BufferOutStream.init(&toc_buf);
-    var toc = &toc_buf_adapter.stream;
+    var toc = toc_buf_adapter.outStream();
 
     var nodes = std.ArrayList(Node).init(allocator);
     defer nodes.deinit();

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -17,10 +17,10 @@ pub fn main() !void {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(direct_allocator.allocator());
     defer arena.deinit();
 
-    const allocator = &arena.allocator;
+    const allocator = arena.allocator();
 
     var args_it = os.args();
 

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -41,11 +41,11 @@ pub fn main() !void {
     var out_file = try os.File.openWrite(out_file_name);
     defer out_file.close();
 
-    var file_in_stream = in_file.inStream();
+    var file_in_stream = in_file.inStreamAdapter();
 
     const input_file_bytes = try file_in_stream.stream.readAllAlloc(allocator, max_doc_file_size);
 
-    var file_out_stream = out_file.outStream();
+    var file_out_stream = out_file.outStreamAdapter();
     var buffered_out_stream = io.BufferedOutStream(os.File.WriteError).init(&file_out_stream.stream);
 
     var tokenizer = Tokenizer.init(in_file_name, input_file_bytes);

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -316,7 +316,7 @@ const Action = enum {
     Close,
 };
 
-fn genToc(allocator: *mem.Allocator, tokenizer: *Tokenizer) !Toc {
+fn genToc(allocator: mem.Allocator, tokenizer: *Tokenizer) !Toc {
     var urls = std.HashMap([]const u8, Token, mem.hash_slice_u8, mem.eql_slice_u8).init(allocator);
     errdefer urls.deinit();
 
@@ -569,7 +569,7 @@ fn genToc(allocator: *mem.Allocator, tokenizer: *Tokenizer) !Toc {
     };
 }
 
-fn urlize(allocator: *mem.Allocator, input: []const u8) ![]u8 {
+fn urlize(allocator: mem.Allocator, input: []const u8) ![]u8 {
     var buf = try std.Buffer.initSize(allocator, 0);
     defer buf.deinit();
 
@@ -589,7 +589,7 @@ fn urlize(allocator: *mem.Allocator, input: []const u8) ![]u8 {
     return buf.toOwnedSlice();
 }
 
-fn escapeHtml(allocator: *mem.Allocator, input: []const u8) ![]u8 {
+fn escapeHtml(allocator: mem.Allocator, input: []const u8) ![]u8 {
     var buf = try std.Buffer.initSize(allocator, 0);
     defer buf.deinit();
 
@@ -635,7 +635,7 @@ test "term color" {
     testing.expectEqualSlices(u8, "A<span class=\"t32\">green</span>B", result);
 }
 
-fn termColor(allocator: *mem.Allocator, input: []const u8) ![]u8 {
+fn termColor(allocator: mem.Allocator, input: []const u8) ![]u8 {
     var buf = try std.Buffer.initSize(allocator, 0);
     defer buf.deinit();
 
@@ -947,7 +947,7 @@ fn tokenizeAndPrint(docgen_tokenizer: *Tokenizer, out: var, source_token: Token)
     return tokenizeAndPrintRaw(docgen_tokenizer, out, source_token, raw_src);
 }
 
-fn genHtml(allocator: *mem.Allocator, tokenizer: *Tokenizer, toc: *Toc, out: var, zig_exe: []const u8) !void {
+fn genHtml(allocator: mem.Allocator, tokenizer: *Tokenizer, toc: *Toc, out: var, zig_exe: []const u8) !void {
     var code_progress_index: usize = 0;
 
     var env_map = try os.getEnvMap(allocator);
@@ -1448,7 +1448,7 @@ fn genHtml(allocator: *mem.Allocator, tokenizer: *Tokenizer, toc: *Toc, out: var
     }
 }
 
-fn exec(allocator: *mem.Allocator, env_map: *std.BufMap, args: []const []const u8) !os.ChildProcess.ExecResult {
+fn exec(allocator: mem.Allocator, env_map: *std.BufMap, args: []const []const u8) !os.ChildProcess.ExecResult {
     const result = try os.ChildProcess.exec(allocator, args, null, env_map, max_doc_file_size);
     switch (result.term) {
         os.ChildProcess.Term.Exited => |exit_code| {
@@ -1473,7 +1473,7 @@ fn exec(allocator: *mem.Allocator, env_map: *std.BufMap, args: []const []const u
     return result;
 }
 
-fn getBuiltinCode(allocator: *mem.Allocator, env_map: *std.BufMap, zig_exe: []const u8) ![]const u8 {
+fn getBuiltinCode(allocator: mem.Allocator, env_map: *std.BufMap, zig_exe: []const u8) ![]const u8 {
     const result = try exec(allocator, env_map, []const []const u8{
         zig_exe,
         "builtin",

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -46,7 +46,7 @@ pub fn main() !void {
     const input_file_bytes = try file_in_stream.stream.readAllAlloc(allocator, max_doc_file_size);
 
     var file_out_stream = out_file.outStreamAdapter();
-    var buffered_out_stream = io.BufferedOutStream(os.File.WriteError).init(&file_out_stream.stream);
+    var buffered_out_stream = io.BufferedOutStream(os.File.WriteError).init(file_out_stream.outStream());
 
     var tokenizer = Tokenizer.init(in_file_name, input_file_bytes);
     var toc = try genToc(allocator, &tokenizer);
@@ -54,7 +54,7 @@ pub fn main() !void {
     try os.makePath(allocator, tmp_dir_name);
     defer os.deleteTree(allocator, tmp_dir_name) catch {};
 
-    try genHtml(allocator, &tokenizer, &toc, &buffered_out_stream.stream, zig_exe);
+    try genHtml(allocator, &tokenizer, &toc, buffered_out_stream.outStream(), zig_exe);
     try buffered_out_stream.flush();
 }
 
@@ -574,7 +574,7 @@ fn urlize(allocator: mem.Allocator, input: []const u8) ![]u8 {
     defer buf.deinit();
 
     var buf_adapter = io.BufferOutStream.init(&buf);
-    var out = &buf_adapter.stream;
+    var out = buf_adapter.outStream();
     for (input) |c| {
         switch (c) {
             'a'...'z', 'A'...'Z', '_', '-', '0'...'9' => {
@@ -594,7 +594,7 @@ fn escapeHtml(allocator: mem.Allocator, input: []const u8) ![]u8 {
     defer buf.deinit();
 
     var buf_adapter = io.BufferOutStream.init(&buf);
-    var out = &buf_adapter.stream;
+    var out = buf_adapter.outStream();
     try writeEscaped(out, input);
     return buf.toOwnedSlice();
 }
@@ -640,7 +640,7 @@ fn termColor(allocator: mem.Allocator, input: []const u8) ![]u8 {
     defer buf.deinit();
 
     var buf_adapter = io.BufferOutStream.init(&buf);
-    var out = &buf_adapter.stream;
+    var out = buf_adapter.outStream();
     var number_start_index: usize = undefined;
     var first_number: usize = undefined;
     var second_number: usize = undefined;

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5973,7 +5973,7 @@ const assert = std.debug.assert;
 
 test "resume from suspend" {
     var buf: [500]u8 = undefined;
-    var a = &std.heap.FixedBufferAllocator.init(buf[0..]).allocator;
+    var a = std.heap.FixedBufferAllocator.init(buf[0..]).allocator();
     var my_result: i32 = 1;
     const p = try async<a> testResumeFromSuspend(&my_result);
     cancel p;
@@ -8396,7 +8396,7 @@ const assert = std.debug.assert;
 
 test "using an allocator" {
     var buffer: [100]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buffer).allocator;
+    const allocator = std.heap.FixedBufferAllocator.init(&buffer).allocator();
     const result = try concat(allocator, "foo", "bar");
     assert(std.mem.eql(u8, "foobar", result));
 }
@@ -8452,10 +8452,10 @@ pub fn main() !void {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(direct_allocator.allocator());
     defer arena.deinit();
 
-    const allocator = &arena.allocator;
+    const allocator = arena.allocator();
 
     const ptr = try allocator.create(i32);
     std.debug.warn("ptr={*}\n", ptr);

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5873,7 +5873,7 @@ const assert = std.debug.assert;
 var x: i32 = 1;
 
 test "create a coroutine and cancel it" {
-    const p = try async<std.debug.global_allocator> simpleAsyncFn();
+    const p = try async<&std.debug.global_allocator> simpleAsyncFn();
     comptime assert(@typeOf(p) == promise->void);
     cancel p;
     assert(x == 2);
@@ -5895,7 +5895,7 @@ const assert = std.debug.assert;
 
 test "coroutine suspend, resume, cancel" {
     seq('a');
-    const p = try async<std.debug.global_allocator> testAsyncSeq();
+    const p = try async<&std.debug.global_allocator> testAsyncSeq();
     seq('c');
     resume p;
     seq('f');
@@ -5930,7 +5930,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 test "coroutine suspend with block" {
-    const p = try async<std.debug.global_allocator> testSuspendBlock();
+    const p = try async<&std.debug.global_allocator> testSuspendBlock();
     std.debug.assert(!result);
     resume a_promise;
     std.debug.assert(result);
@@ -5975,7 +5975,7 @@ test "resume from suspend" {
     var buf: [500]u8 = undefined;
     var a = std.heap.FixedBufferAllocator.init(buf[0..]).allocator();
     var my_result: i32 = 1;
-    const p = try async<a> testResumeFromSuspend(&my_result);
+    const p = try async<&a> testResumeFromSuspend(&my_result);
     cancel p;
     std.debug.assert(my_result == 2);
 }
@@ -6025,7 +6025,7 @@ var final_result: i32 = 0;
 
 test "coroutine await" {
     seq('a');
-    const p = async<std.debug.global_allocator> amain() catch unreachable;
+    const p = async<&std.debug.global_allocator> amain() catch unreachable;
     seq('f');
     resume a_promise;
     seq('i');

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5840,8 +5840,8 @@ test "global assembly" {
       which has these fields:
       </p>
       <ul>
-          <li>{#syntax#}allocFn: fn (self: Allocator, byte_count: usize, alignment: u29) Error![]u8{#endsyntax#} - where {#syntax#}Error{#endsyntax#} can be any error set.</li>
-          <li>{#syntax#}freeFn: fn (self: Allocator, old_mem: []u8) void{#endsyntax#}</li>
+          <li>{#syntax#}allocFn: fn (self: *const Allocator, byte_count: usize, alignment: u29) Error![]u8{#endsyntax#} - where {#syntax#}Error{#endsyntax#} can be any error set.</li>
+          <li>{#syntax#}freeFn: fn (self: *const Allocator, old_mem: []u8) void{#endsyntax#}</li>
       </ul>
       <p>
       You may notice that this corresponds to the {#syntax#}std.mem.Allocator{#endsyntax#} interface.
@@ -5878,7 +5878,7 @@ test "create a coroutine and cancel it" {
     cancel p;
     assert(x == 2);
 }
-async<*std.mem.Allocator> fn simpleAsyncFn() void {
+async<*const std.mem.Allocator> fn simpleAsyncFn() void {
     x += 1;
 }
       {#code_end#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5840,8 +5840,8 @@ test "global assembly" {
       which has these fields:
       </p>
       <ul>
-          <li>{#syntax#}allocFn: fn (self: *Allocator, byte_count: usize, alignment: u29) Error![]u8{#endsyntax#} - where {#syntax#}Error{#endsyntax#} can be any error set.</li>
-          <li>{#syntax#}freeFn: fn (self: *Allocator, old_mem: []u8) void{#endsyntax#}</li>
+          <li>{#syntax#}allocFn: fn (self: Allocator, byte_count: usize, alignment: u29) Error![]u8{#endsyntax#} - where {#syntax#}Error{#endsyntax#} can be any error set.</li>
+          <li>{#syntax#}freeFn: fn (self: Allocator, old_mem: []u8) void{#endsyntax#}</li>
       </ul>
       <p>
       You may notice that this corresponds to the {#syntax#}std.mem.Allocator{#endsyntax#} interface.
@@ -8385,8 +8385,8 @@ pub fn main() void {
       C has a default allocator - <code>malloc</code>, <code>realloc</code>, and <code>free</code>.
       When linking against libc, Zig exposes this allocator with {#syntax#}std.heap.c_allocator{#endsyntax#}.
       However, by convention, there is no default allocator in Zig. Instead, functions which need to
-      allocate accept an {#syntax#}*Allocator{#endsyntax#} parameter. Likewise, data structures such as
-      {#syntax#}std.ArrayList{#endsyntax#} accept an {#syntax#}*Allocator{#endsyntax#} parameter in
+      allocate accept an {#syntax#}Allocator{#endsyntax#} parameter. Likewise, data structures such as
+      {#syntax#}std.ArrayList{#endsyntax#} accept an {#syntax#}Allocator{#endsyntax#} parameter in
       their initialization functions:
       </p>
       {#code_begin|test|allocator#}
@@ -8401,7 +8401,7 @@ test "using an allocator" {
     assert(std.mem.eql(u8, "foobar", result));
 }
 
-fn concat(allocator: *Allocator, a: []const u8, b: []const u8) ![]u8 {
+fn concat(allocator: Allocator, a: []const u8, b: []const u8) ![]u8 {
     const result = try allocator.alloc(u8, a.len + b.len);
     std.mem.copy(u8, result, a);
     std.mem.copy(u8, result[a.len..], b);
@@ -8429,7 +8429,7 @@ fn concat(allocator: *Allocator, a: []const u8, b: []const u8) ![]u8 {
       </p>
       <ol>
           <li>
-              Are you making a library? In this case, best to accept an {#syntax#}*Allocator{#endsyntax#}
+              Are you making a library? In this case, best to accept an {#syntax#}Allocator{#endsyntax#}
               as a parameter and allow your library's users to decide what allocator to use.
           </li>
           <li>Are you linking libc? In this case, {#syntax#}std.heap.c_allocator{#endsyntax#} is likely
@@ -8613,7 +8613,7 @@ test "string literal to constant slice" {
       <p>
       For example, the function's documentation may say "caller owns the returned memory", in which case
       the code that calls the function must have a plan for when to free that memory. Probably in this situation,
-      the function will accept an {#syntax#}*Allocator{#endsyntax#} parameter.
+      the function will accept an {#syntax#}Allocator{#endsyntax#} parameter.
       </p>
       <p>
       Sometimes the lifetime of a pointer may be more complicated. For example, when using

--- a/example/guess_number/main.zig
+++ b/example/guess_number/main.zig
@@ -6,7 +6,7 @@ const os = std.os;
 
 pub fn main() !void {
     var stdout_file = try io.getStdOut();
-    const stdout = &stdout_file.outStreamAdapter().stream;
+    const stdout = stdout_file.outStreamAdapter().outStream();
 
     try stdout.print("Welcome to the Guess Number Game in Zig.\n");
 

--- a/example/guess_number/main.zig
+++ b/example/guess_number/main.zig
@@ -18,7 +18,7 @@ pub fn main() !void {
     const seed = std.mem.readIntNative(u64, &seed_bytes);
     var prng = std.rand.DefaultPrng.init(seed);
 
-    const answer = prng.random.range(u8, 0, 100) + 1;
+    const answer = prng.random().range(u8, 0, 100) + 1;
 
     while (true) {
         try stdout.print("\nGuess a number between 1 and 100: ");

--- a/example/guess_number/main.zig
+++ b/example/guess_number/main.zig
@@ -6,7 +6,7 @@ const os = std.os;
 
 pub fn main() !void {
     var stdout_file = try io.getStdOut();
-    const stdout = &stdout_file.outStream().stream;
+    const stdout = &stdout_file.outStreamAdapter().stream;
 
     try stdout.print("Welcome to the Guess Number Game in Zig.\n");
 

--- a/libc/process_headers.zig
+++ b/libc/process_headers.zig
@@ -708,8 +708,8 @@ const PathTable = std.AutoHashMap([]const u8, *TargetToHash);
 
 pub fn main() !void {
     var direct_allocator = std.heap.DirectAllocator.init();
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
-    const allocator = &arena.allocator;
+    var arena = std.heap.ArenaAllocator.init(direct_allocator.allocator());
+    const allocator = arena.allocator();
     const args = try std.os.argsAlloc(allocator);
     var search_paths = std.ArrayList([]const u8).init(allocator);
     var opt_out_dir: ?[]const u8 = null;

--- a/src-self-hosted/arg.zig
+++ b/src-self-hosted/arg.zig
@@ -31,7 +31,7 @@ fn argInAllowedSet(maybe_set: ?[]const []const u8, arg: []const u8) bool {
 }
 
 // Modifies the current argument index during iteration
-fn readFlagArguments(allocator: *Allocator, args: []const []const u8, required: usize, allowed_set: ?[]const []const u8, index: *usize) !FlagArg {
+fn readFlagArguments(allocator: Allocator, args: []const []const u8, required: usize, allowed_set: ?[]const []const u8, index: *usize) !FlagArg {
     switch (required) {
         0 => return FlagArg{ .None = undefined }, // TODO: Required to force non-tag but value?
         1 => {
@@ -80,7 +80,7 @@ pub const Args = struct {
     flags: HashMapFlags,
     positionals: ArrayList([]const u8),
 
-    pub fn parse(allocator: *Allocator, comptime spec: []const Flag, args: []const []const u8) !Args {
+    pub fn parse(allocator: Allocator, comptime spec: []const Flag, args: []const []const u8) !Args {
         var parsed = Args{
             .flags = HashMapFlags.init(allocator),
             .positionals = ArrayList([]const u8).init(allocator),

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -46,7 +46,7 @@ pub async fn renderToLlvm(comp: *Compilation, fn_val: *Value.Fn, code: *ir.Code)
     // Don't use ZIG_VERSION_STRING here. LLVM misparses it when it includes
     // the git revision.
     const producer = try std.Buffer.allocPrint(
-        &code.arena.allocator,
+        code.arena.allocator(),
         "zig {}.{}.{}",
         u32(c.ZIG_VERSION_MAJOR),
         u32(c.ZIG_VERSION_MINOR),
@@ -80,7 +80,7 @@ pub async fn renderToLlvm(comp: *Compilation, fn_val: *Value.Fn, code: *ir.Code)
         .dibuilder = dibuilder,
         .context = context,
         .lock = event.Lock.init(comp.loop),
-        .arena = &code.arena.allocator,
+        .arena = code.arena.allocator(),
     };
 
     try renderToLlvmModule(&ofile, fn_val, code);

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -142,9 +142,9 @@ pub const ObjectFile = struct {
     dibuilder: *llvm.DIBuilder,
     context: *llvm.Context,
     lock: event.Lock,
-    arena: *std.mem.Allocator,
+    arena: std.mem.Allocator,
 
-    fn gpa(self: *ObjectFile) *std.mem.Allocator {
+    fn gpa(self: *ObjectFile) std.mem.Allocator {
         return self.comp.gpa();
     }
 };

--- a/src-self-hosted/compilation.zig
+++ b/src-self-hosted/compilation.zig
@@ -348,7 +348,7 @@ pub const Compilation = struct {
         zig_lib_dir: []const u8,
     ) !*Compilation {
         var optional_comp: ?*Compilation = null;
-        const handle = try async<zig_compiler.loop.allocator> createAsync(
+        const handle = try async<&zig_compiler.loop.allocator> createAsync(
             &optional_comp,
             zig_compiler,
             name,
@@ -1471,7 +1471,7 @@ async fn generateDeclFnProto(comp: *Compilation, fn_decl: *Decl.Fn) !void {
 // TODO these are hacks which should probably be solved by the language
 fn getAwaitResult(allocator: Allocator, handle: var) @typeInfo(@typeOf(handle)).Promise.child.? {
     var result: ?@typeInfo(@typeOf(handle)).Promise.child.? = null;
-    cancel (async<allocator> getAwaitResultAsync(handle, &result) catch unreachable);
+    cancel (async<&allocator> getAwaitResultAsync(handle, &result) catch unreachable);
     return result.?;
 }
 

--- a/src-self-hosted/compilation.zig
+++ b/src-self-hosted/compilation.zig
@@ -101,7 +101,7 @@ pub const ZigCompiler = struct {
     }
 
     /// Must be called only once, ever. Sets global state.
-    pub fn setLlvmArgv(allocator: *Allocator, llvm_argv: []const []const u8) !void {
+    pub fn setLlvmArgv(allocator: Allocator, llvm_argv: []const []const u8) !void {
         if (llvm_argv.len != 0) {
             var c_compatible_args = try std.cstr.NullTerminated2DArray.fromSlices(allocator, [][]const []const u8{
                 [][]const u8{"zig (LLVM option parsing)"},
@@ -1178,12 +1178,12 @@ pub const Compilation = struct {
     }
 
     /// General Purpose Allocator. Must free when done.
-    fn gpa(self: Compilation) *mem.Allocator {
+    fn gpa(self: Compilation) mem.Allocator {
         return self.loop.allocator;
     }
 
     /// Arena Allocator. Automatically freed when the Compilation is destroyed.
-    fn arena(self: *Compilation) *mem.Allocator {
+    fn arena(self: *Compilation) mem.Allocator {
         return &self.arena_allocator.allocator;
     }
 
@@ -1383,7 +1383,7 @@ async fn addFnToLinkSet(comp: *Compilation, fn_val: *Value.Fn) void {
     held.value.append(fn_val.link_set_node);
 }
 
-fn getZigDir(allocator: *mem.Allocator) ![]u8 {
+fn getZigDir(allocator: mem.Allocator) ![]u8 {
     return os.getAppDataDir(allocator, "zig");
 }
 
@@ -1469,7 +1469,7 @@ async fn generateDeclFnProto(comp: *Compilation, fn_decl: *Decl.Fn) !void {
 }
 
 // TODO these are hacks which should probably be solved by the language
-fn getAwaitResult(allocator: *Allocator, handle: var) @typeInfo(@typeOf(handle)).Promise.child.? {
+fn getAwaitResult(allocator: Allocator, handle: var) @typeInfo(@typeOf(handle)).Promise.child.? {
     var result: ?@typeInfo(@typeOf(handle)).Promise.child.? = null;
     cancel (async<allocator> getAwaitResultAsync(handle, &result) catch unreachable);
     return result.?;

--- a/src-self-hosted/compilation.zig
+++ b/src-self-hosted/compilation.zig
@@ -1184,7 +1184,7 @@ pub const Compilation = struct {
 
     /// Arena Allocator. Automatically freed when the Compilation is destroyed.
     fn arena(self: *Compilation) mem.Allocator {
-        return &self.arena_allocator.allocator;
+        return self.arena_allocator.allocator();
     }
 
     /// If the temporary directory for this compilation has not been created, it creates it.

--- a/src-self-hosted/compilation.zig
+++ b/src-self-hosted/compilation.zig
@@ -1235,7 +1235,7 @@ pub const Compilation = struct {
             const held = await (async self.zig_compiler.prng.acquire() catch unreachable);
             defer held.release();
 
-            held.value.random.bytes(rand_bytes[0..]);
+            held.value.random().bytes(rand_bytes[0..]);
         }
 
         var result: [12]u8 = undefined;

--- a/src-self-hosted/errmsg.zig
+++ b/src-self-hosted/errmsg.zig
@@ -282,7 +282,7 @@ pub const Msg = struct {
             Color.On => true,
             Color.Off => false,
         };
-        var stream = &file.outStream().stream;
+        var stream = &file.outStreamAdapter().stream;
         return msg.printToStream(stream, color_on);
     }
 };

--- a/src-self-hosted/errmsg.zig
+++ b/src-self-hosted/errmsg.zig
@@ -46,7 +46,7 @@ pub const Msg = struct {
     const PathAndTree = struct {
         span: Span,
         tree: *ast.Tree,
-        allocator: *mem.Allocator,
+        allocator: mem.Allocator,
     };
 
     const ScopeAndComp = struct {
@@ -56,7 +56,7 @@ pub const Msg = struct {
     };
 
     const Cli = struct {
-        allocator: *mem.Allocator,
+        allocator: mem.Allocator,
     };
 
     pub fn destroy(self: *Msg) void {
@@ -80,7 +80,7 @@ pub const Msg = struct {
         }
     }
 
-    fn getAllocator(self: *const Msg) *mem.Allocator {
+    fn getAllocator(self: *const Msg) mem.Allocator {
         switch (self.data) {
             Data.Cli => |cli| return cli.allocator,
             Data.PathAndTree => |path_and_tree| {
@@ -191,7 +191,7 @@ pub const Msg = struct {
     /// Caller owns returned Msg and must free with `allocator`
     /// allocator will additionally be used for printing messages later.
     pub fn createFromParseError(
-        allocator: *mem.Allocator,
+        allocator: mem.Allocator,
         parse_error: *const ast.Error,
         tree: *ast.Tree,
         realpath: []const u8,

--- a/src-self-hosted/errmsg.zig
+++ b/src-self-hosted/errmsg.zig
@@ -163,7 +163,7 @@ pub const Msg = struct {
         const realpath_copy = try mem.dupe(comp.gpa(), u8, tree_scope.root().realpath);
         errdefer comp.gpa().free(realpath_copy);
 
-        var out_stream = &std.io.BufferOutStream.init(text_buf).outStream();
+        var out_stream = std.io.BufferOutStream.init(&text_buf).outStream();
         try parse_error.render(&tree_scope.tree.tokens, out_stream);
 
         const msg = try comp.gpa().create(Msg);
@@ -203,7 +203,7 @@ pub const Msg = struct {
         const realpath_copy = try mem.dupe(allocator, u8, realpath);
         errdefer allocator.free(realpath_copy);
 
-        var out_stream = &std.io.BufferOutStream.init(text_buf).outStream();
+        var out_stream = std.io.BufferOutStream.init(&text_buf).outStream();
         try parse_error.render(&tree.tokens, out_stream);
 
         const msg = try allocator.create(Msg);

--- a/src-self-hosted/errmsg.zig
+++ b/src-self-hosted/errmsg.zig
@@ -163,7 +163,7 @@ pub const Msg = struct {
         const realpath_copy = try mem.dupe(comp.gpa(), u8, tree_scope.root().realpath);
         errdefer comp.gpa().free(realpath_copy);
 
-        var out_stream = &std.io.BufferOutStream.init(&text_buf).stream;
+        var out_stream = &std.io.BufferOutStream.init(text_buf).outStream();
         try parse_error.render(&tree_scope.tree.tokens, out_stream);
 
         const msg = try comp.gpa().create(Msg);
@@ -203,7 +203,7 @@ pub const Msg = struct {
         const realpath_copy = try mem.dupe(allocator, u8, realpath);
         errdefer allocator.free(realpath_copy);
 
-        var out_stream = &std.io.BufferOutStream.init(&text_buf).stream;
+        var out_stream = &std.io.BufferOutStream.init(text_buf).outStream();
         try parse_error.render(&tree.tokens, out_stream);
 
         const msg = try allocator.create(Msg);

--- a/src-self-hosted/errmsg.zig
+++ b/src-self-hosted/errmsg.zig
@@ -282,7 +282,7 @@ pub const Msg = struct {
             Color.On => true,
             Color.Off => false,
         };
-        var stream = &file.outStreamAdapter().stream;
+        var stream = file.outStreamAdapter().outStream();
         return msg.printToStream(stream, color_on);
     }
 };

--- a/src-self-hosted/introspect.zig
+++ b/src-self-hosted/introspect.zig
@@ -7,7 +7,7 @@ const os = std.os;
 const warn = std.debug.warn;
 
 /// Caller must free result
-pub fn testZigInstallPrefix(allocator: *mem.Allocator, test_path: []const u8) ![]u8 {
+pub fn testZigInstallPrefix(allocator: mem.Allocator, test_path: []const u8) ![]u8 {
     const test_zig_dir = try os.path.join(allocator, [][]const u8{ test_path, "lib", "zig" });
     errdefer allocator.free(test_zig_dir);
 
@@ -21,7 +21,7 @@ pub fn testZigInstallPrefix(allocator: *mem.Allocator, test_path: []const u8) ![
 }
 
 /// Caller must free result
-pub fn findZigLibDir(allocator: *mem.Allocator) ![]u8 {
+pub fn findZigLibDir(allocator: mem.Allocator) ![]u8 {
     const self_exe_path = try os.selfExeDirPathAlloc(allocator);
     defer allocator.free(self_exe_path);
 
@@ -42,7 +42,7 @@ pub fn findZigLibDir(allocator: *mem.Allocator) ![]u8 {
     return error.FileNotFound;
 }
 
-pub fn resolveZigLibDir(allocator: *mem.Allocator) ![]u8 {
+pub fn resolveZigLibDir(allocator: mem.Allocator) ![]u8 {
     return findZigLibDir(allocator) catch |err| {
         warn(
             \\Unable to find zig lib directory: {}.
@@ -55,6 +55,6 @@ pub fn resolveZigLibDir(allocator: *mem.Allocator) ![]u8 {
 }
 
 /// Caller must free result
-pub fn resolveZigCacheDir(allocator: *mem.Allocator) ![]u8 {
+pub fn resolveZigCacheDir(allocator: mem.Allocator) ![]u8 {
     return std.mem.dupe(allocator, u8, "zig-cache");
 }

--- a/src-self-hosted/ir.zig
+++ b/src-self-hosted/ir.zig
@@ -964,7 +964,7 @@ pub const Code = struct {
     tree_scope: *Scope.AstTree,
 
     /// allocator is comp.gpa()
-    pub fn destroy(self: *Code, allocator: *Allocator) void {
+    pub fn destroy(self: *Code, allocator: Allocator) void {
         self.arena.deinit();
         allocator.destroy(self);
     }
@@ -1762,7 +1762,7 @@ pub const Builder = struct {
         }
     }
 
-    fn arena(self: *Builder) *Allocator {
+    fn arena(self: *Builder) Allocator {
         return &self.code.arena.allocator;
     }
 

--- a/src-self-hosted/ir.zig
+++ b/src-self-hosted/ir.zig
@@ -1028,7 +1028,7 @@ pub const Builder = struct {
             .return_type = null,
             .tree_scope = tree_scope,
         };
-        code.basic_block_list = std.ArrayList(*BasicBlock).init(&code.arena.allocator);
+        code.basic_block_list = std.ArrayList(*BasicBlock).init(code.arena.allocator());
         errdefer code.destroy(comp.gpa());
 
         return Builder{
@@ -1763,7 +1763,7 @@ pub const Builder = struct {
     }
 
     fn arena(self: *Builder) Allocator {
-        return &self.code.arena.allocator;
+        return self.code.arena.allocator();
     }
 
     fn buildExtra(

--- a/src-self-hosted/libc_installation.zig
+++ b/src-self-hosted/libc_installation.zig
@@ -30,7 +30,7 @@ pub const LibCInstallation = struct {
         self: *LibCInstallation,
         allocator: std.mem.Allocator,
         libc_file: []const u8,
-        stderr: *std.io.OutStream(std.os.File.WriteError),
+        stderr: std.io.OutStream(std.os.File.WriteError),
     ) !void {
         self.initEmpty();
 
@@ -100,7 +100,7 @@ pub const LibCInstallation = struct {
         }
     }
 
-    pub fn render(self: *const LibCInstallation, out: *std.io.OutStream(std.os.File.WriteError)) !void {
+    pub fn render(self: *const LibCInstallation, out: std.io.OutStream(std.os.File.WriteError)) !void {
         @setEvalBranchQuota(4000);
         try out.print(
             \\# The directory that contains `stdlib.h`.

--- a/src-self-hosted/libc_installation.zig
+++ b/src-self-hosted/libc_installation.zig
@@ -251,7 +251,7 @@ pub const LibCInstallation = struct {
 
         for (searches) |search| {
             result_buf.shrink(0);
-            const stream = &std.io.BufferOutStream.init(&result_buf).stream;
+            const stream = std.io.BufferOutStream.init(&result_buf).outStream();
             try stream.print("{}\\Include\\{}\\ucrt", search.path, search.version);
 
             const stdlib_path = try std.os.path.join(
@@ -278,7 +278,7 @@ pub const LibCInstallation = struct {
 
         for (searches) |search| {
             result_buf.shrink(0);
-            const stream = &std.io.BufferOutStream.init(&result_buf).stream;
+            const stream = std.io.BufferOutStream.init(&result_buf).outStream();
             try stream.print("{}\\Lib\\{}\\ucrt\\", search.path, search.version);
             switch (builtin.arch) {
                 builtin.Arch.i386 => try stream.write("x86"),
@@ -356,7 +356,7 @@ pub const LibCInstallation = struct {
 
         for (searches) |search| {
             result_buf.shrink(0);
-            const stream = &std.io.BufferOutStream.init(&result_buf).stream;
+            const stream = std.io.BufferOutStream.init(&result_buf).outStream();
             try stream.print("{}\\Lib\\{}\\um\\", search.path, search.version);
             switch (builtin.arch) {
                 builtin.Arch.i386 => try stream.write("x86\\"),

--- a/src-self-hosted/libc_installation.zig
+++ b/src-self-hosted/libc_installation.zig
@@ -28,7 +28,7 @@ pub const LibCInstallation = struct {
 
     pub fn parse(
         self: *LibCInstallation,
-        allocator: *std.mem.Allocator,
+        allocator: std.mem.Allocator,
         libc_file: []const u8,
         stderr: *std.io.OutStream(std.os.File.WriteError),
     ) !void {

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -45,7 +45,7 @@ const usage =
 
 const Command = struct {
     name: []const u8,
-    exec: fn (*Allocator, []const []const u8) anyerror!void,
+    exec: fn (Allocator, []const []const u8) anyerror!void,
 };
 
 pub fn main() !void {
@@ -250,7 +250,7 @@ const args_build_generic = []Flag{
     Flag.Arg1("--ver-patch"),
 };
 
-fn buildOutputType(allocator: *Allocator, args: []const []const u8, out_type: Compilation.Kind) !void {
+fn buildOutputType(allocator: Allocator, args: []const []const u8, out_type: Compilation.Kind) !void {
     var flags = try Args.parse(allocator, args_build_generic, args);
     defer flags.deinit();
 
@@ -494,15 +494,15 @@ async fn processBuildEvents(comp: *Compilation, color: errmsg.Color) void {
     }
 }
 
-fn cmdBuildExe(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdBuildExe(allocator: Allocator, args: []const []const u8) !void {
     return buildOutputType(allocator, args, Compilation.Kind.Exe);
 }
 
-fn cmdBuildLib(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdBuildLib(allocator: Allocator, args: []const []const u8) !void {
     return buildOutputType(allocator, args, Compilation.Kind.Lib);
 }
 
-fn cmdBuildObj(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdBuildObj(allocator: Allocator, args: []const []const u8) !void {
     return buildOutputType(allocator, args, Compilation.Kind.Obj);
 }
 
@@ -543,7 +543,7 @@ const Fmt = struct {
     const SeenMap = std.HashMap([]const u8, void, mem.hash_slice_u8, mem.eql_slice_u8);
 };
 
-fn parseLibcPaths(allocator: *Allocator, libc: *LibCInstallation, libc_paths_file: []const u8) void {
+fn parseLibcPaths(allocator: Allocator, libc: *LibCInstallation, libc_paths_file: []const u8) void {
     libc.parse(allocator, libc_paths_file, stderr) catch |err| {
         stderr.print(
             "Unable to parse libc path file '{}': {}.\n" ++
@@ -555,7 +555,7 @@ fn parseLibcPaths(allocator: *Allocator, libc: *LibCInstallation, libc_paths_fil
     };
 }
 
-fn cmdLibC(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdLibC(allocator: Allocator, args: []const []const u8) !void {
     switch (args.len) {
         0 => {},
         1 => {
@@ -590,7 +590,7 @@ async fn findLibCAsync(zig_compiler: *ZigCompiler) void {
     libc.render(stdout) catch os.exit(1);
 }
 
-fn cmdFmt(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdFmt(allocator: Allocator, args: []const []const u8) !void {
     var flags = try Args.parse(allocator, args_fmt_spec, args);
     defer flags.deinit();
 
@@ -808,7 +808,7 @@ async fn fmtPath(fmt: *Fmt, file_path_ref: []const u8, check_mode: bool) FmtErro
 
 // cmd:targets /////////////////////////////////////////////////////////////////////////////////////
 
-fn cmdTargets(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdTargets(allocator: Allocator, args: []const []const u8) !void {
     try stdout.write("Architectures:\n");
     {
         comptime var i: usize = 0;
@@ -848,13 +848,13 @@ fn cmdTargets(allocator: *Allocator, args: []const []const u8) !void {
     }
 }
 
-fn cmdVersion(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdVersion(allocator: Allocator, args: []const []const u8) !void {
     try stdout.print("{}\n", std.cstr.toSliceConst(c.ZIG_VERSION_STRING));
 }
 
 const args_test_spec = []Flag{Flag.Bool("--help")};
 
-fn cmdHelp(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdHelp(allocator: Allocator, args: []const []const u8) !void {
     try stdout.write(usage);
 }
 
@@ -875,7 +875,7 @@ pub const info_zen =
     \\
 ;
 
-fn cmdZen(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdZen(allocator: Allocator, args: []const []const u8) !void {
     try stdout.write(info_zen);
 }
 
@@ -888,7 +888,7 @@ const usage_internal =
     \\
 ;
 
-fn cmdInternal(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdInternal(allocator: Allocator, args: []const []const u8) !void {
     if (args.len == 0) {
         try stderr.write(usage_internal);
         os.exit(1);
@@ -910,7 +910,7 @@ fn cmdInternal(allocator: *Allocator, args: []const []const u8) !void {
     try stderr.write(usage_internal);
 }
 
-fn cmdInternalBuildInfo(allocator: *Allocator, args: []const []const u8) !void {
+fn cmdInternalBuildInfo(allocator: Allocator, args: []const []const u8) !void {
     try stdout.print(
         \\ZIG_CMAKE_BINARY_DIR {}
         \\ZIG_CXX_COMPILER     {}
@@ -939,7 +939,7 @@ const CliPkg = struct {
     children: ArrayList(*CliPkg),
     parent: ?*CliPkg,
 
-    pub fn init(allocator: *mem.Allocator, name: []const u8, path: []const u8, parent: ?*CliPkg) !*CliPkg {
+    pub fn init(allocator: mem.Allocator, name: []const u8, path: []const u8, parent: ?*CliPkg) !*CliPkg {
         var pkg = try allocator.create(CliPkg);
         pkg.* = CliPkg{
             .name = name,

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -21,8 +21,8 @@ const errmsg = @import("errmsg.zig");
 const LibCInstallation = @import("libc_installation.zig").LibCInstallation;
 
 var stderr_file: os.File = undefined;
-var stderr: *io.OutStream(os.File.WriteError) = undefined;
-var stdout: *io.OutStream(os.File.WriteError) = undefined;
+var stderr: io.OutStream(os.File.WriteError) = undefined;
+var stdout: io.OutStream(os.File.WriteError) = undefined;
 
 pub const max_src_size = 2 * 1024 * 1024 * 1024; // 2 GiB
 

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -56,11 +56,11 @@ pub fn main() !void {
 
     var stdout_file = try std.io.getStdOut();
     var stdout_out_stream = stdout_file.outStreamAdapter();
-    stdout = &stdout_out_stream.stream;
+    stdout = stdout_out_stream.outStream();
 
     stderr_file = try std.io.getStdErr();
     var stderr_out_stream = stderr_file.outStreamAdapter();
-    stderr = &stderr_out_stream.stream;
+    stderr = stderr_out_stream.outStream();
 
     const args = try os.argsAlloc(allocator);
     // TODO I'm getting  unreachable code here, which shouldn't happen

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -55,11 +55,11 @@ pub fn main() !void {
     const allocator = std.heap.c_allocator;
 
     var stdout_file = try std.io.getStdOut();
-    var stdout_out_stream = stdout_file.outStream();
+    var stdout_out_stream = stdout_file.outStreamAdapter();
     stdout = &stdout_out_stream.stream;
 
     stderr_file = try std.io.getStdErr();
-    var stderr_out_stream = stderr_file.outStream();
+    var stderr_out_stream = stderr_file.outStreamAdapter();
     stderr = &stderr_out_stream.stream;
 
     const args = try os.argsAlloc(allocator);
@@ -620,7 +620,7 @@ fn cmdFmt(allocator: Allocator, args: []const []const u8) !void {
         }
 
         var stdin_file = try io.getStdIn();
-        var stdin = stdin_file.inStream();
+        var stdin = stdin_file.inStreamAdapter();
 
         const source_code = try stdin.stream.readAllAlloc(allocator, max_src_size);
         defer allocator.free(source_code);

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -622,7 +622,7 @@ fn cmdFmt(allocator: Allocator, args: []const []const u8) !void {
         var stdin_file = try io.getStdIn();
         var stdin = stdin_file.inStreamAdapter();
 
-        const source_code = try stdin.stream.readAllAlloc(allocator, max_src_size);
+        const source_code = try stdin.inStream().readAllAlloc(allocator, max_src_size);
         defer allocator.free(source_code);
 
         const tree = std.zig.parse(allocator, source_code) catch |err| {
@@ -798,7 +798,7 @@ async fn fmtPath(fmt: *Fmt, file_path_ref: []const u8, check_mode: bool) FmtErro
         const baf = try io.BufferedAtomicFile.create(fmt.loop.allocator, file_path);
         defer baf.destroy();
 
-        const anything_changed = try std.zig.render(fmt.loop.allocator, baf.stream(), tree);
+        const anything_changed = try std.zig.render(fmt.loop.allocator, baf.outStream(), tree);
         if (anything_changed) {
             try stderr.print("{}\n", file_path);
             try baf.finish();

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -464,7 +464,7 @@ fn buildOutputType(allocator: Allocator, args: []const []const u8, out_type: Com
     comp.link_objects = link_objects;
 
     comp.start();
-    const process_build_events_handle = try async<loop.allocator> processBuildEvents(comp, color);
+    const process_build_events_handle = try async<&loop.allocator> processBuildEvents(comp, color);
     defer cancel process_build_events_handle;
     loop.run();
 }
@@ -576,7 +576,7 @@ fn cmdLibC(allocator: Allocator, args: []const []const u8) !void {
     var zig_compiler = try ZigCompiler.init(&loop);
     defer zig_compiler.deinit();
 
-    const handle = try async<loop.allocator> findLibCAsync(&zig_compiler);
+    const handle = try async<&loop.allocator> findLibCAsync(&zig_compiler);
     defer cancel handle;
 
     loop.run();
@@ -661,7 +661,7 @@ fn cmdFmt(allocator: Allocator, args: []const []const u8) !void {
     defer loop.deinit();
 
     var result: FmtError!void = undefined;
-    const main_handle = try async<allocator> asyncFmtMainChecked(
+    const main_handle = try async<&allocator> asyncFmtMainChecked(
         &result,
         &loop,
         &flags,

--- a/src-self-hosted/package.zig
+++ b/src-self-hosted/package.zig
@@ -14,7 +14,7 @@ pub const Package = struct {
 
     /// makes internal copies of root_src_dir and root_src_path
     /// allocator should be an arena allocator because Package never frees anything
-    pub fn create(allocator: *mem.Allocator, root_src_dir: []const u8, root_src_path: []const u8) !*Package {
+    pub fn create(allocator: mem.Allocator, root_src_dir: []const u8, root_src_path: []const u8) !*Package {
         const ptr = try allocator.create(Package);
         ptr.* = Package{
             .root_src_dir = try Buffer.init(allocator, root_src_dir),

--- a/src-self-hosted/stage1.zig
+++ b/src-self-hosted/stage1.zig
@@ -353,7 +353,7 @@ fn printErrMsgToFile(
     try parse_error.render(&tree.tokens, out_stream);
     const text = text_buf.toOwnedSlice();
 
-    const stream = &file.outStreamAdapter().stream;
+    const stream = file.outStreamAdapter().outStream();
     if (!color_on) {
         try stream.print(
             "{}:{}:{}: error: {}\n",

--- a/src-self-hosted/stage1.zig
+++ b/src-self-hosted/stage1.zig
@@ -392,5 +392,5 @@ const Flag = arg.Flag;
 const errmsg = @import("errmsg.zig");
 
 var stderr_file: os.File = undefined;
-var stderr: *io.OutStream(os.File.WriteError) = undefined;
-var stdout: *io.OutStream(os.File.WriteError) = undefined;
+var stderr: io.OutStream(os.File.WriteError) = undefined;
+var stdout: io.OutStream(os.File.WriteError) = undefined;

--- a/src-self-hosted/stage1.zig
+++ b/src-self-hosted/stage1.zig
@@ -105,7 +105,7 @@ export fn stage2_free_clang_errors(errors_ptr: [*]translate_c.ClangErrMsg, error
 }
 
 export fn stage2_render_ast(tree: *ast.Tree, output_file: *FILE) Error {
-    const c_out_stream = &std.io.COutStream.init(output_file).stream;
+    const c_out_stream = std.io.COutStream.init(output_file).outStream();
     _ = std.zig.render(std.heap.c_allocator, c_out_stream, tree) catch |e| switch (e) {
         error.SystemResources => return Error.SystemResources,
         error.OperationAborted => return Error.OperationAborted,
@@ -145,11 +145,11 @@ fn fmtMain(argc: c_int, argv: [*]const [*]const u8) !void {
 
     var stdout_file = try std.io.getStdOut();
     var stdout_out_stream = stdout_file.outStreamAdapter();
-    stdout = &stdout_out_stream.stream;
+    stdout = stdout_out_stream.outStream();
 
     stderr_file = try std.io.getStdErr();
     var stderr_out_stream = stderr_file.outStreamAdapter();
-    stderr = &stderr_out_stream.stream;
+    stderr = stderr_out_stream.outStream();
 
     const args = args_list.toSliceConst();
     var flags = try Args.parse(allocator, self_hosted_main.args_fmt_spec, args[2..]);
@@ -349,7 +349,7 @@ fn printErrMsgToFile(
     const end_loc = tree.tokenLocationPtr(first_token.end, last_token);
 
     var text_buf = try std.Buffer.initSize(allocator, 0);
-    var out_stream = &std.io.BufferOutStream.init(&text_buf).stream;
+    var out_stream = &std.io.BufferOutStream.init(text_buf).outStream();
     try parse_error.render(&tree.tokens, out_stream);
     const text = text_buf.toOwnedSlice();
 

--- a/src-self-hosted/stage1.zig
+++ b/src-self-hosted/stage1.zig
@@ -144,11 +144,11 @@ fn fmtMain(argc: c_int, argv: [*]const [*]const u8) !void {
     }
 
     var stdout_file = try std.io.getStdOut();
-    var stdout_out_stream = stdout_file.outStream();
+    var stdout_out_stream = stdout_file.outStreamAdapter();
     stdout = &stdout_out_stream.stream;
 
     stderr_file = try std.io.getStdErr();
-    var stderr_out_stream = stderr_file.outStream();
+    var stderr_out_stream = stderr_file.outStreamAdapter();
     stderr = &stderr_out_stream.stream;
 
     const args = args_list.toSliceConst();
@@ -181,7 +181,7 @@ fn fmtMain(argc: c_int, argv: [*]const [*]const u8) !void {
         }
 
         var stdin_file = try io.getStdIn();
-        var stdin = stdin_file.inStream();
+        var stdin = stdin_file.inStreamAdapter();
 
         const source_code = try stdin.stream.readAllAlloc(allocator, self_hosted_main.max_src_size);
         defer allocator.free(source_code);
@@ -353,7 +353,7 @@ fn printErrMsgToFile(
     try parse_error.render(&tree.tokens, out_stream);
     const text = text_buf.toOwnedSlice();
 
-    const stream = &file.outStream().stream;
+    const stream = &file.outStreamAdapter().stream;
     if (!color_on) {
         try stream.print(
             "{}:{}:{}: error: {}\n",

--- a/src-self-hosted/stage1.zig
+++ b/src-self-hosted/stage1.zig
@@ -183,7 +183,7 @@ fn fmtMain(argc: c_int, argv: [*]const [*]const u8) !void {
         var stdin_file = try io.getStdIn();
         var stdin = stdin_file.inStreamAdapter();
 
-        const source_code = try stdin.stream.readAllAlloc(allocator, self_hosted_main.max_src_size);
+        const source_code = try stdin.inStream().readAllAlloc(allocator, self_hosted_main.max_src_size);
         defer allocator.free(source_code);
 
         const tree = std.zig.parse(allocator, source_code) catch |err| {
@@ -307,7 +307,7 @@ fn fmtPath(fmt: *Fmt, file_path_ref: []const u8, check_mode: bool) FmtError!void
         const baf = try io.BufferedAtomicFile.create(fmt.allocator, file_path);
         defer baf.destroy();
 
-        const anything_changed = try std.zig.render(fmt.allocator, baf.stream(), tree);
+        const anything_changed = try std.zig.render(fmt.allocator, baf.outStream(), tree);
         if (anything_changed) {
             try stderr.print("{}\n", file_path);
             try baf.finish();

--- a/src-self-hosted/stage1.zig
+++ b/src-self-hosted/stage1.zig
@@ -319,13 +319,13 @@ const Fmt = struct {
     seen: SeenMap,
     any_error: bool,
     color: errmsg.Color,
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
 
     const SeenMap = std.HashMap([]const u8, void, mem.hash_slice_u8, mem.eql_slice_u8);
 };
 
 fn printErrMsgToFile(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     parse_error: *const ast.Error,
     tree: *ast.Tree,
     path: []const u8,

--- a/src-self-hosted/stage1.zig
+++ b/src-self-hosted/stage1.zig
@@ -349,7 +349,7 @@ fn printErrMsgToFile(
     const end_loc = tree.tokenLocationPtr(first_token.end, last_token);
 
     var text_buf = try std.Buffer.initSize(allocator, 0);
-    var out_stream = &std.io.BufferOutStream.init(text_buf).outStream();
+    var out_stream = std.io.BufferOutStream.init(&text_buf).outStream();
     try parse_error.render(&tree.tokens, out_stream);
     const text = text_buf.toOwnedSlice();
 

--- a/src-self-hosted/target.zig
+++ b/src-self-hosted/target.zig
@@ -128,7 +128,7 @@ pub const Target = union(enum) {
         // using the target triple `wasm32-unknown-unknown-unknown`.
         const env_name = if (self.isWasm()) "wasm" else @tagName(self.getAbi());
 
-        var out = &std.io.BufferOutStream.init(result).outStream();
+        var out = std.io.BufferOutStream.init(&result).outStream();
         try out.print("{}-unknown-{}-{}", @tagName(self.getArch()), @tagName(self.getOs()), env_name);
 
         return result;

--- a/src-self-hosted/target.zig
+++ b/src-self-hosted/target.zig
@@ -128,7 +128,7 @@ pub const Target = union(enum) {
         // using the target triple `wasm32-unknown-unknown-unknown`.
         const env_name = if (self.isWasm()) "wasm" else @tagName(self.getAbi());
 
-        var out = &std.io.BufferOutStream.init(&result).stream;
+        var out = &std.io.BufferOutStream.init(result).outStream();
         try out.print("{}-unknown-{}-{}", @tagName(self.getArch()), @tagName(self.getOs()), env_name);
 
         return result;

--- a/src-self-hosted/target.zig
+++ b/src-self-hosted/target.zig
@@ -112,7 +112,7 @@ pub const Target = union(enum) {
         llvm.InitializeAllAsmParsers();
     }
 
-    pub fn getTriple(self: Target, allocator: *std.mem.Allocator) !std.Buffer {
+    pub fn getTriple(self: Target, allocator: std.mem.Allocator) !std.Buffer {
         var result = try std.Buffer.initSize(allocator, 0);
         errdefer result.deinit();
 

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -109,7 +109,7 @@ const Context = struct {
     mode: Mode,
 
     fn a(c: *Context) std.mem.Allocator {
-        return &c.tree.arena_allocator.allocator;
+        return c.tree.arena_allocator.allocator();
     }
 
     /// Convert a null-terminated C string to a slice allocated in the arena
@@ -151,7 +151,7 @@ pub fn translate(
 
     var tree_arena = std.heap.ArenaAllocator.init(backing_allocator);
     errdefer tree_arena.deinit();
-    var arena = &tree_arena.allocator;
+    var arena = tree_arena.allocator();
 
     const root_node = try arena.create(ast.Node.Root);
     root_node.* = ast.Node.Root{
@@ -171,7 +171,7 @@ pub fn translate(
         .errors = ast.Tree.ErrorList.init(arena),
     };
     tree.arena_allocator = tree_arena;
-    arena = &tree.arena_allocator.allocator;
+    arena = tree.arena_allocator.allocator();
 
     var source_buffer = try std.Buffer.initSize(arena, 0);
 

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -108,7 +108,7 @@ const Context = struct {
     global_scope: *Scope.Root,
     mode: Mode,
 
-    fn a(c: *Context) *std.mem.Allocator {
+    fn a(c: *Context) std.mem.Allocator {
         return &c.tree.arena_allocator.allocator;
     }
 
@@ -130,7 +130,7 @@ const Context = struct {
 };
 
 pub fn translate(
-    backing_allocator: *std.mem.Allocator,
+    backing_allocator: std.mem.Allocator,
     args_begin: [*]?[*]const u8,
     args_end: [*]?[*]const u8,
     mode: Mode,

--- a/src-self-hosted/type.zig
+++ b/src-self-hosted/type.zig
@@ -425,7 +425,7 @@ pub const Type = struct {
             var name_buf = try std.Buffer.initSize(comp.gpa(), 0);
             defer name_buf.deinit();
 
-            const name_stream = &std.io.BufferOutStream.init(&name_buf).stream;
+            const name_stream = std.io.BufferOutStream.init(&name_buf).outStream();
 
             switch (key.data) {
                 Kind.Generic => |generic| {

--- a/src-self-hosted/type.zig
+++ b/src-self-hosted/type.zig
@@ -50,7 +50,7 @@ pub const Type = struct {
 
     pub fn getLlvmType(
         base: *Type,
-        allocator: *Allocator,
+        allocator: Allocator,
         llvm_context: *llvm.Context,
     ) (error{OutOfMemory}!*llvm.Type) {
         switch (base.id) {
@@ -218,7 +218,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Struct, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *Struct, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -496,7 +496,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Fn, allocator: *Allocator, llvm_context: *llvm.Context) !*llvm.Type {
+        pub fn getLlvmType(self: *Fn, allocator: Allocator, llvm_context: *llvm.Context) !*llvm.Type {
             const normal = &self.key.data.Normal;
             const llvm_return_type = switch (normal.return_type.id) {
                 Type.Id.Void => llvm.VoidTypeInContext(llvm_context) orelse return error.OutOfMemory,
@@ -559,7 +559,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Bool, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *Bool, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -658,7 +658,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Int, allocator: *Allocator, llvm_context: *llvm.Context) !*llvm.Type {
+        pub fn getLlvmType(self: *Int, allocator: Allocator, llvm_context: *llvm.Context) !*llvm.Type {
             return llvm.IntTypeInContext(llvm_context, self.key.bit_count) orelse return error.OutOfMemory;
         }
     };
@@ -670,7 +670,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Float, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *Float, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -836,7 +836,7 @@ pub const Type = struct {
             return self;
         }
 
-        pub fn getLlvmType(self: *Pointer, allocator: *Allocator, llvm_context: *llvm.Context) !*llvm.Type {
+        pub fn getLlvmType(self: *Pointer, allocator: Allocator, llvm_context: *llvm.Context) !*llvm.Type {
             const elem_llvm_type = try self.key.child_type.getLlvmType(allocator, llvm_context);
             return llvm.PointerType(elem_llvm_type, 0) orelse return error.OutOfMemory;
         }
@@ -904,7 +904,7 @@ pub const Type = struct {
             return self;
         }
 
-        pub fn getLlvmType(self: *Array, allocator: *Allocator, llvm_context: *llvm.Context) !*llvm.Type {
+        pub fn getLlvmType(self: *Array, allocator: Allocator, llvm_context: *llvm.Context) !*llvm.Type {
             const elem_llvm_type = try self.key.elem_type.getLlvmType(allocator, llvm_context);
             return llvm.ArrayType(elem_llvm_type, @intCast(c_uint, self.key.len)) orelse return error.OutOfMemory;
         }
@@ -917,7 +917,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Vector, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *Vector, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -981,7 +981,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Optional, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *Optional, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -993,7 +993,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *ErrorUnion, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *ErrorUnion, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -1005,7 +1005,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *ErrorSet, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *ErrorSet, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -1017,7 +1017,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Enum, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *Enum, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -1029,7 +1029,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Union, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *Union, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -1041,7 +1041,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *BoundFn, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *BoundFn, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -1061,7 +1061,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Opaque, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *Opaque, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };
@@ -1073,7 +1073,7 @@ pub const Type = struct {
             comp.gpa().destroy(self);
         }
 
-        pub fn getLlvmType(self: *Promise, allocator: *Allocator, llvm_context: *llvm.Context) *llvm.Type {
+        pub fn getLlvmType(self: *Promise, allocator: Allocator, llvm_context: *llvm.Context) *llvm.Type {
             @panic("TODO");
         }
     };

--- a/src-self-hosted/type.zig
+++ b/src-self-hosted/type.zig
@@ -432,7 +432,7 @@ pub const Type = struct {
                     self.non_key = NonKey{ .Generic = {} };
                     switch (generic.cc) {
                         CallingConvention.Async => |async_allocator_type| {
-                            try name_stream.print("async<{}> ", async_allocator_type.name);
+                            try name_stream.print("async<&{}> ", async_allocator_type.name);
                         },
                         else => {
                             const cc_str = ccFnTypeStr(generic.cc);

--- a/src-self-hosted/type.zig
+++ b/src-self-hosted/type.zig
@@ -1085,9 +1085,9 @@ fn hashAny(x: var, comptime seed: u64) u32 {
             comptime var rng = comptime std.rand.DefaultPrng.init(seed);
             const unsigned_x = @bitCast(@IntType(false, info.bits), x);
             if (info.bits <= 32) {
-                return u32(unsigned_x) *% comptime rng.random.scalar(u32);
+                return u32(unsigned_x) *% comptime rng.random().scalar(u32);
             } else {
-                return @truncate(u32, unsigned_x *% comptime rng.random.scalar(@typeOf(unsigned_x)));
+                return @truncate(u32, unsigned_x *% comptime rng.random().scalar(@typeOf(unsigned_x)));
             }
         },
         builtin.TypeId.Pointer => |info| {
@@ -1101,7 +1101,7 @@ fn hashAny(x: var, comptime seed: u64) u32 {
         builtin.TypeId.Enum => return hashAny(@enumToInt(x), seed),
         builtin.TypeId.Bool => {
             comptime var rng = comptime std.rand.DefaultPrng.init(seed);
-            const vals = comptime [2]u32{ rng.random.scalar(u32), rng.random.scalar(u32) };
+            const vals = comptime [2]u32{ rng.random().scalar(u32), rng.random().scalar(u32) };
             return vals[@boolToInt(x)];
         },
         builtin.TypeId.Optional => {

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -879,7 +879,7 @@ ZigType *get_fn_type(CodeGen *g, FnTypeId *fn_type_id) {
     buf_resize(&fn_type->name, 0);
     if (fn_type->data.fn.fn_type_id.cc == CallingConventionAsync) {
         assert(fn_type_id->async_allocator_type != nullptr);
-        buf_appendf(&fn_type->name, "async<%s> ", buf_ptr(&fn_type_id->async_allocator_type->name));
+        buf_appendf(&fn_type->name, "async<&%s> ", buf_ptr(&fn_type_id->async_allocator_type->name));
     } else {
         const char *cc_str = calling_convention_fn_type_str(fn_type->data.fn.fn_type_id.cc);
         buf_appendf(&fn_type->name, "%s", cc_str);

--- a/std/array_list.zig
+++ b/std/array_list.zig
@@ -18,10 +18,10 @@ pub fn AlignedArrayList(comptime T: type, comptime A: u29) type {
         /// you uninitialized memory.
         items: []align(A) T,
         len: usize,
-        allocator: *Allocator,
+        allocator: Allocator,
 
         /// Deinitialize with `deinit` or use `toOwnedSlice`.
-        pub fn init(allocator: *Allocator) Self {
+        pub fn init(allocator: Allocator) Self {
             return Self{
                 .items = []align(A) T{},
                 .len = 0,
@@ -69,7 +69,7 @@ pub fn AlignedArrayList(comptime T: type, comptime A: u29) type {
         /// ArrayList takes ownership of the passed in slice. The slice must have been
         /// allocated with `allocator`.
         /// Deinitialize with `deinit` or use `toOwnedSlice`.
-        pub fn fromOwnedSlice(allocator: *Allocator, slice: []align(A) T) Self {
+        pub fn fromOwnedSlice(allocator: Allocator, slice: []align(A) T) Self {
             return Self{
                 .items = slice,
                 .len = slice.len,

--- a/std/array_list.zig
+++ b/std/array_list.zig
@@ -221,7 +221,7 @@ pub fn AlignedArrayList(comptime T: type, comptime A: u29) type {
 
 test "std.ArrayList.init" {
     var bytes: [1024]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(bytes[0..]).allocator;
+    const allocator = std.heap.FixedBufferAllocator.init(bytes[0..]).allocator();
 
     var list = ArrayList(i32).init(allocator);
     defer list.deinit();
@@ -232,7 +232,7 @@ test "std.ArrayList.init" {
 
 test "std.ArrayList.basic" {
     var bytes: [1024]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(bytes[0..]).allocator;
+    const allocator = std.heap.FixedBufferAllocator.init(bytes[0..]).allocator();
 
     var list = ArrayList(i32).init(allocator);
     defer list.deinit();

--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -159,7 +159,7 @@ test "std.atomic.Queue" {
     defer direct_allocator.allocator.free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
-    var a = &fixed_buffer_allocator.allocator;
+    var a = fixed_buffer_allocator.allocator();
 
     var queue = Queue(i32).init();
     var context = Context{

--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -135,7 +135,7 @@ pub fn Queue(comptime T: type) type {
 }
 
 const Context = struct {
-    allocator: *std.mem.Allocator,
+    allocator: std.mem.Allocator,
     queue: *Queue(i32),
     put_sum: isize,
     get_sum: isize,

--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -311,7 +311,7 @@ test "std.atomic.Queue dump" {
 
     // Test empty stream
     sos.reset();
-    try queue.dumpToStream(SliceOutStream.Error, &sos.stream);
+    try queue.dumpToStream(SliceOutStream.Error, &sos.outStream());
     expect(mem.eql(u8, buffer[0..sos.pos],
         \\head: (null)
         \\tail: (null)
@@ -327,7 +327,7 @@ test "std.atomic.Queue dump" {
     queue.put(&node_0);
 
     sos.reset();
-    try queue.dumpToStream(SliceOutStream.Error, &sos.stream);
+    try queue.dumpToStream(SliceOutStream.Error, sos.outStream());
 
     var expected = try std.fmt.bufPrint(expected_buffer[0..],
         \\head: 0x{x}=1
@@ -347,7 +347,7 @@ test "std.atomic.Queue dump" {
     queue.put(&node_1);
 
     sos.reset();
-    try queue.dumpToStream(SliceOutStream.Error, &sos.stream);
+    try queue.dumpToStream(SliceOutStream.Error, sos.outStream());
 
     expected = try std.fmt.bufPrint(expected_buffer[0..],
         \\head: 0x{x}=1

--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -221,7 +221,7 @@ fn startPuts(ctx: *Context) u8 {
     var r = std.rand.DefaultPrng.init(0xdeadbeef);
     while (put_count != 0) : (put_count -= 1) {
         std.os.time.sleep(1); // let the os scheduler be our fuzz
-        const x = @bitCast(i32, r.random.scalar(u32));
+        const x = @bitCast(i32, r.random().scalar(u32));
         const node = ctx.allocator.create(Queue(i32).Node) catch unreachable;
         node.* = Queue(i32).Node{
             .prev = undefined,

--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -111,9 +111,9 @@ pub fn Queue(comptime T: type) type {
             self.dumpToStream(Error, stderr) catch return;
         }
 
-        pub fn dumpToStream(self: *Self, comptime Error: type, stream: *std.io.OutStream(Error)) Error!void {
+        pub fn dumpToStream(self: *Self, comptime Error: type, stream: std.io.OutStream(Error)) Error!void {
             const S = struct {
-                fn dumpRecursive(s: *std.io.OutStream(Error), optional_node: ?*Node, indent: usize) Error!void {
+                fn dumpRecursive(s: std.io.OutStream(Error), optional_node: ?*Node, indent: usize) Error!void {
                     try s.writeByteNTimes(' ', indent);
                     if (optional_node) |node| {
                         try s.print("0x{x}={}\n", @ptrToInt(node), node.data);

--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -311,7 +311,7 @@ test "std.atomic.Queue dump" {
 
     // Test empty stream
     sos.reset();
-    try queue.dumpToStream(SliceOutStream.Error, &sos.outStream());
+    try queue.dumpToStream(SliceOutStream.Error, sos.outStream());
     expect(mem.eql(u8, buffer[0..sos.pos],
         \\head: (null)
         \\tail: (null)

--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -155,8 +155,8 @@ test "std.atomic.Queue" {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var plenty_of_memory = try direct_allocator.allocator.alloc(u8, 300 * 1024);
-    defer direct_allocator.allocator.free(plenty_of_memory);
+    var plenty_of_memory = try direct_allocator.allocator().alloc(u8, 300 * 1024);
+    defer direct_allocator.allocator().free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
     var a = fixed_buffer_allocator.allocator();

--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -105,7 +105,7 @@ pub fn Queue(comptime T: type) type {
 
         pub fn dump(self: *Self) void {
             var stderr_file = std.io.getStdErr() catch return;
-            const stderr = &stderr_file.outStreamAdapter().stream;
+            const stderr = stderr_file.outStreamAdapter().outStream();
             const Error = @typeInfo(@typeOf(stderr)).Pointer.child.Error;
 
             self.dumpToStream(Error, stderr) catch return;

--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -105,7 +105,7 @@ pub fn Queue(comptime T: type) type {
 
         pub fn dump(self: *Self) void {
             var stderr_file = std.io.getStdErr() catch return;
-            const stderr = &stderr_file.outStream().stream;
+            const stderr = &stderr_file.outStreamAdapter().stream;
             const Error = @typeInfo(@typeOf(stderr)).Pointer.child.Error;
 
             self.dumpToStream(Error, stderr) catch return;

--- a/std/atomic/stack.zig
+++ b/std/atomic/stack.zig
@@ -155,7 +155,7 @@ fn startPuts(ctx: *Context) u8 {
     var r = std.rand.DefaultPrng.init(0xdeadbeef);
     while (put_count != 0) : (put_count -= 1) {
         std.os.time.sleep(1); // let the os scheduler be our fuzz
-        const x = @bitCast(i32, r.random.scalar(u32));
+        const x = @bitCast(i32, r.random().scalar(u32));
         const node = ctx.allocator.create(Stack(i32).Node) catch unreachable;
         node.* = Stack(i32).Node{
             .next = undefined,

--- a/std/atomic/stack.zig
+++ b/std/atomic/stack.zig
@@ -70,7 +70,7 @@ pub fn Stack(comptime T: type) type {
 
 const std = @import("../std.zig");
 const Context = struct {
-    allocator: *std.mem.Allocator,
+    allocator: std.mem.Allocator,
     stack: *Stack(i32),
     put_sum: isize,
     get_sum: isize,

--- a/std/atomic/stack.zig
+++ b/std/atomic/stack.zig
@@ -93,7 +93,7 @@ test "std.atomic.stack" {
     defer direct_allocator.allocator.free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
-    var a = &fixed_buffer_allocator.allocator;
+    var a = fixed_buffer_allocator.allocator();
 
     var stack = Stack(i32).init();
     var context = Context{

--- a/std/atomic/stack.zig
+++ b/std/atomic/stack.zig
@@ -89,8 +89,8 @@ test "std.atomic.stack" {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var plenty_of_memory = try direct_allocator.allocator.alloc(u8, 300 * 1024);
-    defer direct_allocator.allocator.free(plenty_of_memory);
+    var plenty_of_memory = try direct_allocator.allocator().alloc(u8, 300 * 1024);
+    defer direct_allocator.allocator().free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
     var a = fixed_buffer_allocator.allocator();

--- a/std/buf_map.zig
+++ b/std/buf_map.zig
@@ -11,7 +11,7 @@ pub const BufMap = struct {
 
     const BufMapHashMap = HashMap([]const u8, []const u8, mem.hash_slice_u8, mem.eql_slice_u8);
 
-    pub fn init(allocator: *Allocator) BufMap {
+    pub fn init(allocator: Allocator) BufMap {
         var self = BufMap{ .hash_map = BufMapHashMap.init(allocator) };
         return self;
     }

--- a/std/buf_map.zig
+++ b/std/buf_map.zig
@@ -86,7 +86,7 @@ test "BufMap" {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var bufmap = BufMap.init(&direct_allocator.allocator);
+    var bufmap = BufMap.init(direct_allocator.allocator());
     defer bufmap.deinit();
 
     try bufmap.set("x", "1");

--- a/std/buf_set.zig
+++ b/std/buf_set.zig
@@ -68,7 +68,7 @@ test "BufSet" {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var bufset = BufSet.init(&direct_allocator.allocator);
+    var bufset = BufSet.init(direct_allocator.allocator());
     defer bufset.deinit();
 
     try bufset.put("x");

--- a/std/buf_set.zig
+++ b/std/buf_set.zig
@@ -9,7 +9,7 @@ pub const BufSet = struct {
 
     const BufSetHashMap = HashMap([]const u8, void, mem.hash_slice_u8, mem.eql_slice_u8);
 
-    pub fn init(a: *Allocator) BufSet {
+    pub fn init(a: Allocator) BufSet {
         var self = BufSet{ .hash_map = BufSetHashMap.init(a) };
         return self;
     }
@@ -49,7 +49,7 @@ pub const BufSet = struct {
         return self.hash_map.iterator();
     }
 
-    pub fn allocator(self: *const BufSet) *Allocator {
+    pub fn allocator(self: *const BufSet) Allocator {
         return self.hash_map.allocator;
     }
 

--- a/std/buffer.zig
+++ b/std/buffer.zig
@@ -11,14 +11,14 @@ pub const Buffer = struct {
     list: ArrayList(u8),
 
     /// Must deinitialize with deinit.
-    pub fn init(allocator: *Allocator, m: []const u8) !Buffer {
+    pub fn init(allocator: Allocator, m: []const u8) !Buffer {
         var self = try initSize(allocator, m.len);
         mem.copy(u8, self.list.items, m);
         return self;
     }
 
     /// Must deinitialize with deinit.
-    pub fn initSize(allocator: *Allocator, size: usize) !Buffer {
+    pub fn initSize(allocator: Allocator, size: usize) !Buffer {
         var self = initNull(allocator);
         try self.resize(size);
         return self;
@@ -28,7 +28,7 @@ pub const Buffer = struct {
     /// None of the other operations are valid until you do one of these:
     /// * ::replaceContents
     /// * ::resize
-    pub fn initNull(allocator: *Allocator) Buffer {
+    pub fn initNull(allocator: Allocator) Buffer {
         return Buffer{ .list = ArrayList(u8).init(allocator) };
     }
 
@@ -40,7 +40,7 @@ pub const Buffer = struct {
     /// Buffer takes ownership of the passed in slice. The slice must have been
     /// allocated with `allocator`.
     /// Must deinitialize with deinit.
-    pub fn fromOwnedSlice(allocator: *Allocator, slice: []u8) !Buffer {
+    pub fn fromOwnedSlice(allocator: Allocator, slice: []u8) !Buffer {
         var self = Buffer{ .list = ArrayList(u8).fromOwnedSlice(allocator, slice) };
         try self.list.append(0);
         return self;
@@ -55,7 +55,7 @@ pub const Buffer = struct {
         return result;
     }
 
-    pub fn allocPrint(allocator: *Allocator, comptime format: []const u8, args: ...) !Buffer {
+    pub fn allocPrint(allocator: Allocator, comptime format: []const u8, args: ...) !Buffer {
         const countSize = struct {
             fn countSize(size: *usize, bytes: []const u8) (error{}!void) {
                 size.* += bytes.len;

--- a/std/build.zig
+++ b/std/build.zig
@@ -1268,7 +1268,7 @@ pub const LibExeObjStep = struct {
     }
 
     pub fn addBuildOption(self: *LibExeObjStep, comptime T: type, name: []const u8, value: T) void {
-        const out = &std.io.BufferOutStream.init(&self.build_options_contents).stream;
+        const out = &std.io.BufferOutStream.init(self.build_options_contents).outStream();
         out.print("pub const {} = {};\n", name, value) catch unreachable;
     }
 

--- a/std/build.zig
+++ b/std/build.zig
@@ -1268,7 +1268,7 @@ pub const LibExeObjStep = struct {
     }
 
     pub fn addBuildOption(self: *LibExeObjStep, comptime T: type, name: []const u8, value: T) void {
-        const out = &std.io.BufferOutStream.init(self.build_options_contents).outStream();
+        const out = std.io.BufferOutStream.init(&self.build_options_contents).outStream();
         out.print("pub const {} = {};\n", name, value) catch unreachable;
     }
 

--- a/std/build.zig
+++ b/std/build.zig
@@ -760,7 +760,7 @@ pub const Builder = struct {
         var stdout = std.Buffer.initNull(self.allocator);
         defer std.Buffer.deinit(&stdout);
 
-        var stdout_file_in_stream = child.stdout.?.inStream();
+        var stdout_file_in_stream = child.stdout.?.inStreamAdapter();
         try stdout_file_in_stream.stream.readAllBuffer(&stdout, max_output_size);
 
         const term = child.wait() catch |err| std.debug.panic("unable to spawn {}: {}", argv[0], err);

--- a/std/build.zig
+++ b/std/build.zig
@@ -22,7 +22,7 @@ pub const Builder = struct {
     install_tls: TopLevelStep,
     have_uninstall_step: bool,
     have_install_step: bool,
-    allocator: *Allocator,
+    allocator: Allocator,
     native_system_lib_paths: ArrayList([]const u8),
     native_system_include_dirs: ArrayList([]const u8),
     native_system_rpaths: ArrayList([]const u8),
@@ -93,7 +93,7 @@ pub const Builder = struct {
         description: []const u8,
     };
 
-    pub fn init(allocator: *Allocator, zig_exe: []const u8, build_root: []const u8, cache_root: []const u8) Builder {
+    pub fn init(allocator: Allocator, zig_exe: []const u8, build_root: []const u8, cache_root: []const u8) Builder {
         const env_map = allocator.create(BufMap) catch unreachable;
         env_map.* = os.getEnvMap(allocator) catch unreachable;
         var self = Builder{
@@ -799,7 +799,7 @@ const CrossTarget = struct {
     os: builtin.Os,
     abi: builtin.Abi,
 
-    pub fn zigTriple(cross_target: CrossTarget, allocator: *Allocator) []u8 {
+    pub fn zigTriple(cross_target: CrossTarget, allocator: Allocator) []u8 {
         return std.fmt.allocPrint(
             allocator,
             "{}{}-{}-{}",
@@ -810,7 +810,7 @@ const CrossTarget = struct {
         ) catch unreachable;
     }
 
-    pub fn linuxTriple(cross_target: CrossTarget, allocator: *Allocator) []u8 {
+    pub fn linuxTriple(cross_target: CrossTarget, allocator: Allocator) []u8 {
         return std.fmt.allocPrint(
             allocator,
             "{}-{}-{}",
@@ -1858,7 +1858,7 @@ pub const Step = struct {
     loop_flag: bool,
     done_flag: bool,
 
-    pub fn init(name: []const u8, allocator: *Allocator, makeFn: fn (*Step) anyerror!void) Step {
+    pub fn init(name: []const u8, allocator: Allocator, makeFn: fn (*Step) anyerror!void) Step {
         return Step{
             .name = name,
             .makeFn = makeFn,
@@ -1867,7 +1867,7 @@ pub const Step = struct {
             .done_flag = false,
         };
     }
-    pub fn initNoOp(name: []const u8, allocator: *Allocator) Step {
+    pub fn initNoOp(name: []const u8, allocator: Allocator) Step {
         return init(name, allocator, makeNoOp);
     }
 
@@ -1885,7 +1885,7 @@ pub const Step = struct {
     fn makeNoOp(self: *Step) anyerror!void {}
 };
 
-fn doAtomicSymLinks(allocator: *Allocator, output_path: []const u8, filename_major_only: []const u8, filename_name_only: []const u8) !void {
+fn doAtomicSymLinks(allocator: Allocator, output_path: []const u8, filename_major_only: []const u8, filename_name_only: []const u8) !void {
     const out_dir = os.path.dirname(output_path) orelse ".";
     const out_basename = os.path.basename(output_path);
     // sym link for libfoo.so.1 to libfoo.so.1.2.3

--- a/std/build.zig
+++ b/std/build.zig
@@ -761,7 +761,7 @@ pub const Builder = struct {
         defer std.Buffer.deinit(&stdout);
 
         var stdout_file_in_stream = child.stdout.?.inStreamAdapter();
-        try stdout_file_in_stream.stream.readAllBuffer(&stdout, max_output_size);
+        try stdout_file_in_stream.inStream().readAllBuffer(&stdout, max_output_size);
 
         const term = child.wait() catch |err| std.debug.panic("unable to spawn {}: {}", argv[0], err);
         switch (term) {

--- a/std/coff.zig
+++ b/std/coff.zig
@@ -77,7 +77,7 @@ pub const Coff = struct {
         try self.loadOptionalHeader(&file_stream);
     }
 
-    fn loadOptionalHeader(self: *Coff, file_stream: os.File.InStreamAdapter) !void {
+    fn loadOptionalHeader(self: *Coff, file_stream: *os.File.InStreamAdapter) !void {
         const in = file_stream.inStream();
         self.pe_header.magic = try in.readIntLittle(u16);
         // For now we're only interested in finding the reference to the .pdb,

--- a/std/coff.zig
+++ b/std/coff.zig
@@ -77,7 +77,7 @@ pub const Coff = struct {
         try self.loadOptionalHeader(&file_stream);
     }
 
-    fn loadOptionalHeader(self: *Coff, file_stream: *os.File.InStreamAdapter) !void {
+    fn loadOptionalHeader(self: *Coff, file_stream: os.File.InStreamAdapter) !void {
         const in = file_stream.inStream();
         self.pe_header.magic = try in.readIntLittle(u16);
         // For now we're only interested in finding the reference to the .pdb,

--- a/std/coff.zig
+++ b/std/coff.zig
@@ -42,7 +42,7 @@ pub const Coff = struct {
         const pe_pointer_offset = 0x3C;
 
         var file_stream = self.in_file.inStreamAdapter();
-        const in = &file_stream.stream;
+        const in = file_stream.inStream();
 
         var magic: [2]u8 = undefined;
         try in.readNoEof(magic[0..]);
@@ -78,7 +78,7 @@ pub const Coff = struct {
     }
 
     fn loadOptionalHeader(self: *Coff, file_stream: *os.File.InStream) !void {
-        const in = &file_stream.stream;
+        const in = file_stream.inStream();
         self.pe_header.magic = try in.readIntLittle(u16);
         // For now we're only interested in finding the reference to the .pdb,
         // so we'll skip most of this header, which size is different in 32
@@ -116,7 +116,7 @@ pub const Coff = struct {
         try self.in_file.seekTo(file_offset + debug_dir.size);
 
         var file_stream = self.in_file.inStreamAdapter();
-        const in = &file_stream.stream;
+        const in = file_stream.inStream();
 
         var cv_signature: [4]u8 = undefined; // CodeView signature
         try in.readNoEof(cv_signature[0..]);
@@ -147,7 +147,7 @@ pub const Coff = struct {
         self.sections = ArrayList(Section).init(self.allocator);
 
         var file_stream = self.in_file.inStreamAdapter();
-        const in = &file_stream.stream;
+        const in = file_stream.inStream();
 
         var name: [8]u8 = undefined;
 

--- a/std/coff.zig
+++ b/std/coff.zig
@@ -29,7 +29,7 @@ pub const CoffError = error{
 
 pub const Coff = struct {
     in_file: os.File,
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
 
     coff_header: CoffHeader,
     pe_header: OptionalHeader,

--- a/std/coff.zig
+++ b/std/coff.zig
@@ -41,7 +41,7 @@ pub const Coff = struct {
     pub fn loadHeader(self: *Coff) !void {
         const pe_pointer_offset = 0x3C;
 
-        var file_stream = self.in_file.inStream();
+        var file_stream = self.in_file.inStreamAdapter();
         const in = &file_stream.stream;
 
         var magic: [2]u8 = undefined;
@@ -115,7 +115,7 @@ pub const Coff = struct {
         const file_offset = debug_dir.virtual_address - header.virtual_address + header.pointer_to_raw_data;
         try self.in_file.seekTo(file_offset + debug_dir.size);
 
-        var file_stream = self.in_file.inStream();
+        var file_stream = self.in_file.inStreamAdapter();
         const in = &file_stream.stream;
 
         var cv_signature: [4]u8 = undefined; // CodeView signature
@@ -146,7 +146,7 @@ pub const Coff = struct {
 
         self.sections = ArrayList(Section).init(self.allocator);
 
-        var file_stream = self.in_file.inStream();
+        var file_stream = self.in_file.inStreamAdapter();
         const in = &file_stream.stream;
 
         var name: [8]u8 = undefined;

--- a/std/coff.zig
+++ b/std/coff.zig
@@ -77,7 +77,7 @@ pub const Coff = struct {
         try self.loadOptionalHeader(&file_stream);
     }
 
-    fn loadOptionalHeader(self: *Coff, file_stream: *os.File.InStream) !void {
+    fn loadOptionalHeader(self: *Coff, file_stream: *os.File.InStreamAdapter) !void {
         const in = file_stream.inStream();
         self.pe_header.magic = try in.readIntLittle(u16);
         // For now we're only interested in finding the reference to the .pdb,

--- a/std/crypto/throughput_test.zig
+++ b/std/crypto/throughput_test.zig
@@ -135,7 +135,7 @@ pub fn main() !void {
 
     var buffer: [1024]u8 = undefined;
     var fixed = std.heap.FixedBufferAllocator.init(buffer[0..]);
-    const args = try std.os.argsAlloc(&fixed.allocator);
+    const args = try std.os.argsAlloc(fixed.allocator());
 
     var filter: ?[]u8 = "";
 

--- a/std/crypto/throughput_test.zig
+++ b/std/crypto/throughput_test.zig
@@ -29,7 +29,7 @@ pub fn benchmarkHash(comptime Hash: var, comptime bytes: comptime_int) !u64 {
     var h = Hash.init();
 
     var block: [Hash.digest_length]u8 = undefined;
-    prng.random.bytes(block[0..]);
+    prng.random().bytes(block[0..]);
 
     var offset: usize = 0;
     var timer = try Timer.start();
@@ -56,10 +56,10 @@ pub fn benchmarkMac(comptime Mac: var, comptime bytes: comptime_int) !u64 {
     std.debug.assert(32 >= Mac.mac_length and 32 >= Mac.minimum_key_length);
 
     var in: [1 * MiB]u8 = undefined;
-    prng.random.bytes(in[0..]);
+    prng.random().bytes(in[0..]);
 
     var key: [32]u8 = undefined;
-    prng.random.bytes(key[0..]);
+    prng.random().bytes(key[0..]);
 
     var offset: usize = 0;
     var timer = try Timer.start();
@@ -81,10 +81,10 @@ pub fn benchmarkKeyExchange(comptime DhKeyExchange: var, comptime exchange_count
     std.debug.assert(DhKeyExchange.minimum_key_length >= DhKeyExchange.secret_length);
 
     var in: [DhKeyExchange.minimum_key_length]u8 = undefined;
-    prng.random.bytes(in[0..]);
+    prng.random().bytes(in[0..]);
 
     var out: [DhKeyExchange.minimum_key_length]u8 = undefined;
-    prng.random.bytes(out[0..]);
+    prng.random().bytes(out[0..]);
 
     var offset: usize = 0;
     var timer = try Timer.start();

--- a/std/crypto/throughput_test.zig
+++ b/std/crypto/throughput_test.zig
@@ -131,7 +131,7 @@ fn printPad(stdout: var, s: []const u8) !void {
 pub fn main() !void {
     var stdout_file = try std.io.getStdOut();
     var stdout_out_stream = stdout_file.outStreamAdapter();
-    const stdout = &stdout_out_stream.stream;
+    const stdout = stdout_out_stream.outStream();
 
     var buffer: [1024]u8 = undefined;
     var fixed = std.heap.FixedBufferAllocator.init(buffer[0..]);

--- a/std/crypto/throughput_test.zig
+++ b/std/crypto/throughput_test.zig
@@ -130,7 +130,7 @@ fn printPad(stdout: var, s: []const u8) !void {
 
 pub fn main() !void {
     var stdout_file = try std.io.getStdOut();
-    var stdout_out_stream = stdout_file.outStream();
+    var stdout_out_stream = stdout_file.outStreamAdapter();
     const stdout = &stdout_out_stream.stream;
 
     var buffer: [1024]u8 = undefined;

--- a/std/cstr.zig
+++ b/std/cstr.zig
@@ -48,7 +48,7 @@ fn testCStrFnsImpl() void {
 
 /// Returns a mutable slice with 1 more byte of length which is a null byte.
 /// Caller owns the returned memory.
-pub fn addNullByte(allocator: *mem.Allocator, slice: []const u8) ![]u8 {
+pub fn addNullByte(allocator: mem.Allocator, slice: []const u8) ![]u8 {
     const result = try allocator.alloc(u8, slice.len + 1);
     mem.copy(u8, result, slice);
     result[slice.len] = 0;
@@ -56,13 +56,13 @@ pub fn addNullByte(allocator: *mem.Allocator, slice: []const u8) ![]u8 {
 }
 
 pub const NullTerminated2DArray = struct {
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     byte_count: usize,
     ptr: ?[*]?[*]u8,
 
     /// Takes N lists of strings, concatenates the lists together, and adds a null terminator
     /// Caller must deinit result
-    pub fn fromSlices(allocator: *mem.Allocator, slices: []const []const []const u8) !NullTerminated2DArray {
+    pub fn fromSlices(allocator: mem.Allocator, slices: []const []const []const u8) !NullTerminated2DArray {
         var new_len: usize = 1; // 1 for the list null
         var byte_count: usize = 0;
         for (slices) |slice| {

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -582,15 +582,15 @@ fn populateModule(di: *DebugInfo, mod: *Module) !void {
 
     const modi = di.pdb.getStreamById(mod.mod_info.ModuleSymStream) orelse return error.MissingDebugInfo;
 
-    const signature = try modi.stream.readIntLittle(u32);
+    const signature = try modi.inStream().readIntLittle(u32);
     if (signature != 4)
         return error.InvalidDebugInfo;
 
     mod.symbols = try allocator.alloc(u8, mod.mod_info.SymByteSize - 4);
-    try modi.stream.readNoEof(mod.symbols);
+    try modi.inStream().readNoEof(mod.symbols);
 
     mod.subsect_info = try allocator.alloc(u8, mod.mod_info.C13ByteSize);
-    try modi.stream.readNoEof(mod.subsect_info);
+    try modi.inStream().readNoEof(mod.subsect_info);
 
     var sect_offset: usize = 0;
     var skip_len: usize = undefined;
@@ -816,19 +816,19 @@ fn openSelfDebugInfoWindows(allocator: mem.Allocator) !DebugInfo {
     try di.pdb.openFile(di.coff, path);
 
     var pdb_stream = di.pdb.getStream(pdb.StreamType.Pdb) orelse return error.InvalidDebugInfo;
-    const version = try pdb_stream.stream.readIntLittle(u32);
-    const signature = try pdb_stream.stream.readIntLittle(u32);
-    const age = try pdb_stream.stream.readIntLittle(u32);
+    const version = try pdb_stream.inStream().readIntLittle(u32);
+    const signature = try pdb_stream.inStream().readIntLittle(u32);
+    const age = try pdb_stream.inStream().readIntLittle(u32);
     var guid: [16]u8 = undefined;
-    try pdb_stream.stream.readNoEof(guid[0..]);
+    try pdb_stream.inStream().readNoEof(guid[0..]);
     if (!mem.eql(u8, di.coff.guid, guid) or di.coff.age != age)
         return error.InvalidDebugInfo;
     // We validated the executable and pdb match.
 
     const string_table_index = str_tab_index: {
-        const name_bytes_len = try pdb_stream.stream.readIntLittle(u32);
+        const name_bytes_len = try pdb_stream.inStream().readIntLittle(u32);
         const name_bytes = try allocator.alloc(u8, name_bytes_len);
-        try pdb_stream.stream.readNoEof(name_bytes);
+        try pdb_stream.inStream().readNoEof(name_bytes);
 
         const HashTableHeader = packed struct {
             Size: u32,
@@ -838,7 +838,7 @@ fn openSelfDebugInfoWindows(allocator: mem.Allocator) !DebugInfo {
                 return cap * 2 / 3 + 1;
             }
         };
-        const hash_tbl_hdr = try pdb_stream.stream.readStruct(HashTableHeader);
+        const hash_tbl_hdr = try pdb_stream.inStream().readStruct(HashTableHeader);
         if (hash_tbl_hdr.Capacity == 0)
             return error.InvalidDebugInfo;
 
@@ -856,8 +856,8 @@ fn openSelfDebugInfoWindows(allocator: mem.Allocator) !DebugInfo {
         };
         const bucket_list = try allocator.alloc(Bucket, present.len);
         for (present) |_| {
-            const name_offset = try pdb_stream.stream.readIntLittle(u32);
-            const name_index = try pdb_stream.stream.readIntLittle(u32);
+            const name_offset = try pdb_stream.inStream().readIntLittle(u32);
+            const name_index = try pdb_stream.inStream().readIntLittle(u32);
             const name = mem.toSlice(u8, name_bytes.ptr + name_offset);
             if (mem.eql(u8, name, "/names")) {
                 break :str_tab_index name_index;
@@ -872,7 +872,7 @@ fn openSelfDebugInfoWindows(allocator: mem.Allocator) !DebugInfo {
     const dbi = di.pdb.dbi;
 
     // Dbi Header
-    const dbi_stream_header = try dbi.stream.readStruct(pdb.DbiStreamHeader);
+    const dbi_stream_header = try dbi.inStream().readStruct(pdb.DbiStreamHeader);
     const mod_info_size = dbi_stream_header.ModInfoSize;
     const section_contrib_size = dbi_stream_header.SectionContributionSize;
 
@@ -881,7 +881,7 @@ fn openSelfDebugInfoWindows(allocator: mem.Allocator) !DebugInfo {
     // Module Info Substream
     var mod_info_offset: usize = 0;
     while (mod_info_offset != mod_info_size) {
-        const mod_info = try dbi.stream.readStruct(pdb.ModInfo);
+        const mod_info = try dbi.inStream().readStruct(pdb.ModInfo);
         var this_record_len: usize = @sizeOf(pdb.ModInfo);
 
         const module_name = try dbi.readNullTermString(allocator);
@@ -919,14 +919,14 @@ fn openSelfDebugInfoWindows(allocator: mem.Allocator) !DebugInfo {
     var sect_contribs = ArrayList(pdb.SectionContribEntry).init(allocator);
     var sect_cont_offset: usize = 0;
     if (section_contrib_size != 0) {
-        const ver = @intToEnum(pdb.SectionContrSubstreamVersion, try dbi.stream.readIntLittle(u32));
+        const ver = @intToEnum(pdb.SectionContrSubstreamVersion, try dbi.inStream().readIntLittle(u32));
         if (ver != pdb.SectionContrSubstreamVersion.Ver60)
             return error.InvalidDebugInfo;
         sect_cont_offset += @sizeOf(u32);
     }
     while (sect_cont_offset != section_contrib_size) {
         const entry = try sect_contribs.addOne();
-        entry.* = try dbi.stream.readStruct(pdb.SectionContribEntry);
+        entry.* = try dbi.inStream().readStruct(pdb.SectionContribEntry);
         sect_cont_offset += @sizeOf(pdb.SectionContribEntry);
 
         if (sect_cont_offset > section_contrib_size)

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -53,7 +53,7 @@ pub fn getStderrStream() !*io.OutStream(os.File.WriteError) {
         return st;
     } else {
         stderr_file = try io.getStdErr();
-        stderr_file_out_stream = stderr_file.outStream();
+        stderr_file_out_stream = stderr_file.outStreamAdapter();
         const st = &stderr_file_out_stream.stream;
         stderr_stream = st;
         return st;

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -977,8 +977,8 @@ pub fn openDwarfDebugInfo(di: *DwarfInfo, allocator: mem.Allocator) !void {
 
 pub fn openElfDebugInfo(
     allocator: mem.Allocator,
-    elf_seekable_stream: *DwarfSeekableStream,
-    elf_in_stream: *DwarfInStream,
+    elf_seekable_stream: DwarfSeekableStream,
+    elf_in_stream: DwarfInStream,
 ) !DwarfInfo {
     var efile: elf.Elf = undefined;
     try efile.openStream(allocator, elf_seekable_stream, elf_in_stream);
@@ -1028,9 +1028,9 @@ fn openSelfDebugInfoLinux(allocator: mem.Allocator) !DwarfInfo {
     return openElfDebugInfo(
         allocator,
         // TODO https://github.com/ziglang/zig/issues/764
-        @ptrCast(*DwarfSeekableStream, &S.self_exe_mmap_seekable.seekable_stream),
+        @bitCast(DwarfSeekableStream, S.self_exe_mmap_seekable.seekableStream()),
         // TODO https://github.com/ziglang/zig/issues/764
-        @ptrCast(*DwarfInStream, &S.self_exe_mmap_seekable.stream),
+        @bitCast(DwarfInStream, S.self_exe_mmap_seekable.inStream()),
     );
 }
 
@@ -1168,8 +1168,8 @@ pub const DwarfSeekableStream = io.SeekableStream(anyerror, anyerror);
 pub const DwarfInStream = io.InStream(anyerror);
 
 pub const DwarfInfo = struct {
-    dwarf_seekable_stream: *DwarfSeekableStream,
-    dwarf_in_stream: *DwarfInStream,
+    dwarf_seekable_stream: DwarfSeekableStream,
+    dwarf_in_stream: DwarfInStream,
     endian: builtin.Endian,
     debug_info: Section,
     debug_abbrev: Section,

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -37,7 +37,7 @@ const Module = struct {
 /// Tries to write to stderr, unbuffered, and ignores any error returned.
 /// Does not append a newline.
 var stderr_file: os.File = undefined;
-var stderr_file_out_stream: os.File.OutStream = undefined;
+var stderr_file_out_stream: os.File.OutStreamAdapter = undefined;
 
 var stderr_stream: ?*io.OutStream(os.File.WriteError) = null;
 var stderr_mutex = std.Mutex.init();

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -54,7 +54,7 @@ pub fn getStderrStream() !*io.OutStream(os.File.WriteError) {
     } else {
         stderr_file = try io.getStdErr();
         stderr_file_out_stream = stderr_file.outStreamAdapter();
-        const st = &stderr_file_out_stream.stream;
+        const st = stderr_file_out_stream.outStream();
         stderr_stream = st;
         return st;
     }
@@ -845,10 +845,10 @@ fn openSelfDebugInfoWindows(allocator: mem.Allocator) !DebugInfo {
         if (hash_tbl_hdr.Size > HashTableHeader.maxLoad(hash_tbl_hdr.Capacity))
             return error.InvalidDebugInfo;
 
-        const present = try readSparseBitVector(&pdb_stream.stream, allocator);
+        const present = try readSparseBitVector(pdb_stream.inStream(), allocator);
         if (present.len != hash_tbl_hdr.Size)
             return error.InvalidDebugInfo;
-        const deleted = try readSparseBitVector(&pdb_stream.stream, allocator);
+        const deleted = try readSparseBitVector(pdb_stream.inStream(), allocator);
 
         const Bucket = struct {
             first: u32,

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -39,7 +39,7 @@ const Module = struct {
 var stderr_file: os.File = undefined;
 var stderr_file_out_stream: os.File.OutStreamAdapter = undefined;
 
-var stderr_stream: ?*io.OutStream(os.File.WriteError) = null;
+var stderr_stream: ?io.OutStream(os.File.WriteError) = null;
 var stderr_mutex = std.Mutex.init();
 pub fn warn(comptime fmt: []const u8, args: ...) void {
     const held = stderr_mutex.acquire();
@@ -48,7 +48,7 @@ pub fn warn(comptime fmt: []const u8, args: ...) void {
     stderr.print(fmt, args) catch return;
 }
 
-pub fn getStderrStream() !*io.OutStream(os.File.WriteError) {
+pub fn getStderrStream() !io.OutStream(os.File.WriteError) {
     if (stderr_stream) |st| {
         return st;
     } else {
@@ -2254,7 +2254,7 @@ fn readStringMem(ptr: *[*]const u8) []const u8 {
     return result;
 }
 
-fn readInitialLength(comptime E: type, in_stream: *io.InStream(E), is_64: *bool) !u64 {
+fn readInitialLength(comptime E: type, in_stream: io.InStream(E), is_64: *bool) !u64 {
     const first_32_bits = try in_stream.readIntLittle(u32);
     is_64.* = (first_32_bits == 0xffffffff);
     if (is_64.*) {

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -16,7 +16,7 @@ const maxInt = std.math.maxInt;
 const leb = @import("debug/leb128.zig");
 
 pub const FailingAllocator = @import("debug/failing_allocator.zig").FailingAllocator;
-pub const failing_allocator = &FailingAllocator.init(global_allocator, 0).allocator;
+pub const failing_allocator = FailingAllocator.init(global_allocator, 0).allocator();
 
 pub const runtime_safety = switch (builtin.mode) {
     builtin.Mode.Debug, builtin.Mode.ReleaseSafe => true,
@@ -74,7 +74,7 @@ pub fn getSelfDebugInfo() !*DebugInfo {
 
 fn wantTtyColor() bool {
     var bytes: [128]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(bytes[0..]).allocator;
+    const allocator = std.heap.FixedBufferAllocator.init(bytes[0..]).allocator();
     return if (std.os.getEnvVarOwned(allocator, "ZIG_DEBUG_COLOR")) |_| true else |_| stderr_file.isTty();
 }
 
@@ -2266,7 +2266,7 @@ fn readInitialLength(comptime E: type, in_stream: *io.InStream(E), is_64: *bool)
 }
 
 /// This should only be used in temporary test programs.
-pub const global_allocator = &global_fixed_allocator.allocator;
+pub const global_allocator = global_fixed_allocator.allocator();
 var global_fixed_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(global_allocator_mem[0..]);
 var global_allocator_mem: [100 * 1024]u8 = undefined;
 
@@ -2278,7 +2278,7 @@ fn getDebugInfoAllocator() mem.Allocator {
     if (debug_info_allocator) |a| return a;
 
     debug_info_direct_allocator = std.heap.DirectAllocator.init();
-    debug_info_arena_allocator = std.heap.ArenaAllocator.init(&debug_info_direct_allocator.allocator);
-    debug_info_allocator = &debug_info_arena_allocator.allocator;
-    return &debug_info_arena_allocator.allocator;
+    debug_info_arena_allocator = std.heap.ArenaAllocator.init(debug_info_direct_allocator.allocator());
+    debug_info_allocator = debug_info_arena_allocator.allocator();
+    return debug_info_arena_allocator.allocator();
 }

--- a/std/debug/failing_allocator.zig
+++ b/std/debug/failing_allocator.zig
@@ -25,7 +25,7 @@ pub const FailingAllocator = struct {
     }
 
     fn realloc(a: *const mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) mem.Allocator.Error![]u8 {
-        const self = a.implCast(FailingAllocator);
+        const self = a.iface.implCast(FailingAllocator);
 
         if (self.index == self.fail_index) {
             return error.OutOfMemory;
@@ -51,19 +51,18 @@ pub const FailingAllocator = struct {
     }
 
     fn shrink(a: *const mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
-        const self = a.implCast(FailingAllocator);
-        
+        const self = a.iface.implCast(FailingAllocator);
+
         const r = self.internal_allocator.shrinkFn(&self.internal_allocator, old_mem, old_align, new_size, new_align);
         self.freed_bytes += old_mem.len - r.len;
         if (new_size == 0)
             self.deallocations += 1;
         return r;
     }
-    
-    
+
     pub fn allocator(self: *FailingAllocator) mem.Allocator {
-        return mem.Allocator {
-            .impl = mem.Allocator.ifaceCast(self),
+        return mem.Allocator{
+            .iface = mem.Allocator.Iface.init(self),
             .reallocFn = realloc,
             .shrinkFn = shrink,
         };

--- a/std/debug/failing_allocator.zig
+++ b/std/debug/failing_allocator.zig
@@ -24,7 +24,7 @@ pub const FailingAllocator = struct {
         };
     }
 
-    fn realloc(a: mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+    fn realloc(a: mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) mem.Allocator.Error![]u8 {
         const self = a.implCast(FailingAllocator);
 
         if (self.index == self.fail_index) {

--- a/std/debug/failing_allocator.zig
+++ b/std/debug/failing_allocator.zig
@@ -24,14 +24,14 @@ pub const FailingAllocator = struct {
         };
     }
 
-    fn realloc(a: mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) mem.Allocator.Error![]u8 {
+    fn realloc(a: *const mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) mem.Allocator.Error![]u8 {
         const self = a.implCast(FailingAllocator);
 
         if (self.index == self.fail_index) {
             return error.OutOfMemory;
         }
         const result = try self.internal_allocator.reallocFn(
-            self.internal_allocator,
+            &self.internal_allocator,
             old_mem,
             old_align,
             new_size,
@@ -50,10 +50,10 @@ pub const FailingAllocator = struct {
         return result;
     }
 
-    fn shrink(a: mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
+    fn shrink(a: *const mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         const self = a.implCast(FailingAllocator);
         
-        const r = self.internal_allocator.shrinkFn(self.internal_allocator, old_mem, old_align, new_size, new_align);
+        const r = self.internal_allocator.shrinkFn(&self.internal_allocator, old_mem, old_align, new_size, new_align);
         self.freed_bytes += old_mem.len - r.len;
         if (new_size == 0)
             self.deallocations += 1;

--- a/std/debug/failing_allocator.zig
+++ b/std/debug/failing_allocator.zig
@@ -7,13 +7,13 @@ pub const FailingAllocator = struct {
     allocator: mem.Allocator,
     index: usize,
     fail_index: usize,
-    internal_allocator: *mem.Allocator,
+    internal_allocator: mem.Allocator,
     allocated_bytes: usize,
     freed_bytes: usize,
     allocations: usize,
     deallocations: usize,
 
-    pub fn init(allocator: *mem.Allocator, fail_index: usize) FailingAllocator {
+    pub fn init(allocator: mem.Allocator, fail_index: usize) FailingAllocator {
         return FailingAllocator{
             .internal_allocator = allocator,
             .fail_index = fail_index,
@@ -29,7 +29,7 @@ pub const FailingAllocator = struct {
         };
     }
 
-    fn realloc(allocator: *mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+    fn realloc(allocator: mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
         const self = @fieldParentPtr(FailingAllocator, "allocator", allocator);
         if (self.index == self.fail_index) {
             return error.OutOfMemory;
@@ -54,7 +54,7 @@ pub const FailingAllocator = struct {
         return result;
     }
 
-    fn shrink(allocator: *mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
+    fn shrink(allocator: mem.Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         const self = @fieldParentPtr(FailingAllocator, "allocator", allocator);
         const r = self.internal_allocator.shrinkFn(self.internal_allocator, old_mem, old_align, new_size, new_align);
         self.freed_bytes += old_mem.len - r.len;

--- a/std/debug/failing_allocator.zig
+++ b/std/debug/failing_allocator.zig
@@ -12,9 +12,9 @@ pub const FailingAllocator = struct {
     allocations: usize,
     deallocations: usize,
 
-    pub fn init(allocator: mem.Allocator, fail_index: usize) FailingAllocator {
+    pub fn init(internal_allocator: mem.Allocator, fail_index: usize) FailingAllocator {
         return FailingAllocator{
-            .internal_allocator = allocator,
+            .internal_allocator = internal_allocator,
             .fail_index = fail_index,
             .index = 0,
             .allocated_bytes = 0,
@@ -61,8 +61,8 @@ pub const FailingAllocator = struct {
     }
     
     
-    pub fn allocator(self: *FailingAllocator) Allocator {
-        return Allocator {
+    pub fn allocator(self: *FailingAllocator) mem.Allocator {
+        return mem.Allocator {
             .impl = mem.Allocator.ifaceCast(self),
             .reallocFn = realloc,
             .shrinkFn = shrink,

--- a/std/debug/leb128.zig
+++ b/std/debug/leb128.zig
@@ -122,17 +122,17 @@ pub fn readILEB128Mem(comptime T: type, ptr: *[*]const u8) !T {
 
 fn test_read_stream_ileb128(comptime T: type, encoded: []const u8) !T {
     var in_stream = std.io.SliceInStream.init(encoded);
-    return try readILEB128(T, &in_stream.stream);
+    return try readILEB128(T, in_stream.inStream());
 }
 
 fn test_read_stream_uleb128(comptime T: type, encoded: []const u8) !T {
     var in_stream = std.io.SliceInStream.init(encoded);
-    return try readULEB128(T, &in_stream.stream);
+    return try readULEB128(T, in_stream.inStream());
 }
 
 fn test_read_ileb128(comptime T: type, encoded: []const u8) !T {
     var in_stream = std.io.SliceInStream.init(encoded);
-    const v1 = readILEB128(T, &in_stream.stream);
+    const v1 = readILEB128(T, in_stream.inStream());
     var in_ptr = encoded.ptr;
     const v2 = readILEB128Mem(T, &in_ptr);
     testing.expectEqual(v1, v2);
@@ -141,7 +141,7 @@ fn test_read_ileb128(comptime T: type, encoded: []const u8) !T {
 
 fn test_read_uleb128(comptime T: type, encoded: []const u8) !T {
     var in_stream = std.io.SliceInStream.init(encoded);
-    const v1 = readULEB128(T, &in_stream.stream);
+    const v1 = readULEB128(T, in_stream.inStream());
     var in_ptr = encoded.ptr;
     const v2 = readULEB128Mem(T, &in_ptr);
     testing.expectEqual(v1, v2);
@@ -153,7 +153,7 @@ fn test_read_ileb128_seq(comptime T: type, comptime N: usize, encoded: []const u
     var in_ptr = encoded.ptr;
     var i: usize = 0;
     while (i < N) : (i += 1) {
-        const v1 = readILEB128(T, &in_stream.stream);
+        const v1 = readILEB128(T, in_stream.inStream());
         const v2 = readILEB128Mem(T, &in_ptr);
         testing.expectEqual(v1, v2);
     }
@@ -164,7 +164,7 @@ fn test_read_uleb128_seq(comptime T: type, comptime N: usize, encoded: []const u
     var in_ptr = encoded.ptr;
     var i: usize = 0;
     while (i < N) : (i += 1) {
-        const v1 = readULEB128(T, &in_stream.stream);
+        const v1 = readULEB128(T, in_stream.inStream());
         const v2 = readULEB128Mem(T, &in_ptr);
         testing.expectEqual(v1, v2);
     }

--- a/std/dynamic_library.zig
+++ b/std/dynamic_library.zig
@@ -109,7 +109,7 @@ pub const LinuxDynLib = struct {
     map_size: usize,
 
     /// Trusts the file
-    pub fn open(allocator: *mem.Allocator, path: []const u8) !DynLib {
+    pub fn open(allocator: mem.Allocator, path: []const u8) !DynLib {
         const fd = try std.os.posixOpen(path, 0, linux.O_RDONLY | linux.O_CLOEXEC);
         errdefer std.os.close(fd);
 
@@ -252,10 +252,10 @@ fn checkver(def_arg: *elf.Verdef, vsym_arg: i32, vername: []const u8, strings: [
 }
 
 pub const WindowsDynLib = struct {
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     dll: windows.HMODULE,
 
-    pub fn open(allocator: *mem.Allocator, path: []const u8) !WindowsDynLib {
+    pub fn open(allocator: mem.Allocator, path: []const u8) !WindowsDynLib {
         const wpath = try win_util.sliceToPrefixedFileW(path);
 
         return WindowsDynLib{

--- a/std/elf.zig
+++ b/std/elf.zig
@@ -382,7 +382,7 @@ pub const Elf = struct {
     pub fn openStream(
         elf: *Elf,
         allocator: mem.Allocator,
-        seekable_stream: *io.SeekableStream(anyerror, anyerror),
+        seekable_stream: io.SeekableStream(anyerror, anyerror),
         in: io.InStream(anyerror),
     ) !void {
         elf.auto_close_stream = false;

--- a/std/elf.zig
+++ b/std/elf.zig
@@ -353,7 +353,7 @@ pub const SectionHeader = struct {
 };
 
 pub const Elf = struct {
-    seekable_stream: *io.SeekableStream(anyerror, anyerror),
+    seekable_stream: io.SeekableStream(anyerror, anyerror),
     in_stream: io.InStream(anyerror),
     auto_close_stream: bool,
     is_64: bool,

--- a/std/elf.zig
+++ b/std/elf.zig
@@ -354,7 +354,7 @@ pub const SectionHeader = struct {
 
 pub const Elf = struct {
     seekable_stream: *io.SeekableStream(anyerror, anyerror),
-    in_stream: *io.InStream(anyerror),
+    in_stream: io.InStream(anyerror),
     auto_close_stream: bool,
     is_64: bool,
     endian: builtin.Endian,
@@ -383,7 +383,7 @@ pub const Elf = struct {
         elf: *Elf,
         allocator: mem.Allocator,
         seekable_stream: *io.SeekableStream(anyerror, anyerror),
-        in: *io.InStream(anyerror),
+        in: io.InStream(anyerror),
     ) !void {
         elf.auto_close_stream = false;
         elf.allocator = allocator;

--- a/std/elf.zig
+++ b/std/elf.zig
@@ -366,22 +366,22 @@ pub const Elf = struct {
     string_section_index: usize,
     string_section: *SectionHeader,
     section_headers: []SectionHeader,
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     prealloc_file: os.File,
 
     /// Call close when done.
-    pub fn openPath(elf: *Elf, allocator: *mem.Allocator, path: []const u8) !void {
+    pub fn openPath(elf: *Elf, allocator: mem.Allocator, path: []const u8) !void {
         @compileError("TODO implement");
     }
 
     /// Call close when done.
-    pub fn openFile(elf: *Elf, allocator: *mem.Allocator, file: os.File) !void {
+    pub fn openFile(elf: *Elf, allocator: mem.Allocator, file: os.File) !void {
         @compileError("TODO implement");
     }
 
     pub fn openStream(
         elf: *Elf,
-        allocator: *mem.Allocator,
+        allocator: mem.Allocator,
         seekable_stream: *io.SeekableStream(anyerror, anyerror),
         in: *io.InStream(anyerror),
     ) !void {

--- a/std/event/channel.zig
+++ b/std/event/channel.zig
@@ -337,10 +337,10 @@ test "std.event.Channel" {
     const channel = try Channel(i32).create(&loop, 0);
     defer channel.destroy();
 
-    const handle = try async<allocator> testChannelGetter(&loop, channel);
+    const handle = try async<&allocator> testChannelGetter(&loop, channel);
     defer cancel handle;
 
-    const putter = try async<allocator> testChannelPutter(channel);
+    const putter = try async<&allocator> testChannelPutter(channel);
     defer cancel putter;
 
     loop.run();

--- a/std/event/channel.zig
+++ b/std/event/channel.zig
@@ -327,7 +327,7 @@ test "std.event.Channel" {
     var da = std.heap.DirectAllocator.init();
     defer da.deinit();
 
-    const allocator = &da.allocator;
+    const allocator = da.allocator();
 
     var loop: Loop = undefined;
     // TODO make a multi threaded test

--- a/std/event/fs.zig
+++ b/std/event/fs.zig
@@ -1404,15 +1404,15 @@ pub const OutStream = struct {
     }
 
     async<*mem.Allocator> fn writeFn(out_stream: Stream, bytes: []const u8) Error!void {
-        const self = out_stream.implCast(OutStream);
+        const self = out_stream.iface.implCast(OutStream);
         const offset = self.offset;
         self.offset += bytes.len;
         return await (async pwritev(self.loop, self.fd, [][]const u8{bytes}, offset) catch unreachable);
     }
-    
+
     pub fn outStream(self: *OutStream) Stream {
-        return Stream {
-            .impl = Stream.ifaceCast(self),
+        return Stream{
+            .iface = Stream.Iface.init(self),
             .writeFn = writeFn,
         };
     }
@@ -1436,15 +1436,15 @@ pub const InStream = struct {
     }
 
     async<*mem.Allocator> fn readFn(in_stream: Stream, bytes: []u8) Error!usize {
-        const self = in_stream.implCast(InStream);
+        const self = in_stream.iface.implCast(InStream);
         const amt = try await (async preadv(self.loop, self.fd, [][]u8{bytes}, self.offset) catch unreachable);
         self.offset += amt;
         return amt;
     }
-    
+
     pub fn inStream(self: *InStream) Stream {
-        return Stream {
-            .impl = Stream.ifaceCast(self),
+        return Stream{
+            .iface = Stream.Iface.init(self),
             .readFn = readFn,
         };
     }

--- a/std/event/fs.zig
+++ b/std/event/fs.zig
@@ -1435,7 +1435,7 @@ pub const InStream = struct {
         };
     }
 
-    async<*mem.Allocator> fn readFn(in_stream: *Stream, bytes: []u8) Error!usize {
+    async<*mem.Allocator> fn readFn(in_stream: Stream, bytes: []u8) Error!usize {
         const self = in_stream.implCast(InStream);
         const amt = try await (async preadv(self.loop, self.fd, [][]u8{bytes}, self.offset) catch unreachable);
         self.offset += amt;

--- a/std/event/fs.zig
+++ b/std/event/fs.zig
@@ -791,7 +791,7 @@ pub fn Watch(comptime V: type) type {
                     errdefer os.close(inotify_fd);
 
                     var result: *Self = undefined;
-                    _ = try async<loop.allocator> linuxEventPutter(inotify_fd, channel, &result);
+                    _ = try async<&loop.allocator> linuxEventPutter(inotify_fd, channel, &result);
                     return result;
                 },
 
@@ -1328,7 +1328,7 @@ const test_tmp_dir = "std_event_fs_test";
 //    defer loop.deinit();
 //
 //    var result: anyerror!void = error.ResultNeverWritten;
-//    const handle = try async<allocator> testFsWatchCantFail(&loop, &result);
+//    const handle = try async<&allocator> testFsWatchCantFail(&loop, &result);
 //    defer cancel handle;
 //
 //    loop.run();

--- a/std/event/fs.zig
+++ b/std/event/fs.zig
@@ -1317,7 +1317,7 @@ const test_tmp_dir = "std_event_fs_test";
 //    var da = std.heap.DirectAllocator.init();
 //    defer da.deinit();
 //
-//    const allocator = &da.allocator;
+//    const allocator = da.allocator();
 //
 //    // TODO move this into event loop too
 //    try os.makePath(allocator, test_tmp_dir);

--- a/std/event/future.zig
+++ b/std/event/future.zig
@@ -97,7 +97,7 @@ test "std.event.Future" {
     try loop.initMultiThreaded(allocator);
     defer loop.deinit();
 
-    const handle = try async<allocator> testFuture(&loop);
+    const handle = try async<&allocator> testFuture(&loop);
     defer cancel handle;
 
     loop.run();

--- a/std/event/future.zig
+++ b/std/event/future.zig
@@ -91,7 +91,7 @@ test "std.event.Future" {
     var da = std.heap.DirectAllocator.init();
     defer da.deinit();
 
-    const allocator = &da.allocator;
+    const allocator = da.allocator();
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);

--- a/std/event/group.zig
+++ b/std/event/group.zig
@@ -128,7 +128,7 @@ test "std.event.Group" {
     var da = std.heap.DirectAllocator.init();
     defer da.deinit();
 
-    const allocator = &da.allocator;
+    const allocator = da.allocator();
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);

--- a/std/event/group.zig
+++ b/std/event/group.zig
@@ -78,7 +78,7 @@ pub fn Group(comptime ReturnType: type) type {
                 }
             };
             var node: *Stack.Node = undefined;
-            const handle = try async<self.lock.loop.allocator> S.asyncFunc(&node, args);
+            const handle = try async<&self.lock.loop.allocator> S.asyncFunc(&node, args);
             node.* = Stack.Node{
                 .next = undefined,
                 .data = handle,
@@ -134,7 +134,7 @@ test "std.event.Group" {
     try loop.initMultiThreaded(allocator);
     defer loop.deinit();
 
-    const handle = try async<allocator> testGroup(&loop);
+    const handle = try async<&allocator> testGroup(&loop);
     defer cancel handle;
 
     loop.run();

--- a/std/event/lock.zig
+++ b/std/event/lock.zig
@@ -129,7 +129,7 @@ test "std.event.Lock" {
     var da = std.heap.DirectAllocator.init();
     defer da.deinit();
 
-    const allocator = &da.allocator;
+    const allocator = da.allocator();
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);

--- a/std/event/lock.zig
+++ b/std/event/lock.zig
@@ -138,7 +138,7 @@ test "std.event.Lock" {
     var lock = Lock.init(&loop);
     defer lock.deinit();
 
-    const handle = try async<allocator> testLock(&loop, &lock);
+    const handle = try async<&allocator> testLock(&loop, &lock);
     defer cancel handle;
     loop.run();
 

--- a/std/event/loop.zig
+++ b/std/event/loop.zig
@@ -869,7 +869,7 @@ test "std.event.Loop - basic" {
     var da = std.heap.DirectAllocator.init();
     defer da.deinit();
 
-    const allocator = &da.allocator;
+    const allocator = da.allocator();
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);
@@ -885,7 +885,7 @@ test "std.event.Loop - call" {
     var da = std.heap.DirectAllocator.init();
     defer da.deinit();
 
-    const allocator = &da.allocator;
+    const allocator = da.allocator();
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);

--- a/std/event/loop.zig
+++ b/std/event/loop.zig
@@ -594,7 +594,7 @@ pub const Loop = struct {
             }
         };
         var handle: promise->@typeOf(func).ReturnType = undefined;
-        return async<self.allocator> S.asyncFunc(self, &handle, args);
+        return async<&self.allocator> S.asyncFunc(self, &handle, args);
     }
 
     /// Awaiting a yield lets the event loop run, starting any unstarted async operations.

--- a/std/event/loop.zig
+++ b/std/event/loop.zig
@@ -12,7 +12,7 @@ const windows = os.windows;
 const maxInt = std.math.maxInt;
 
 pub const Loop = struct {
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     next_tick_queue: std.atomic.Queue(promise),
     os_data: OsData,
     final_resume_node: ResumeNode,
@@ -88,7 +88,7 @@ pub const Loop = struct {
     /// After initialization, call run().
     /// TODO copy elision / named return values so that the threads referencing *Loop
     /// have the correct pointer value.
-    pub fn initSingleThreaded(self: *Loop, allocator: *mem.Allocator) !void {
+    pub fn initSingleThreaded(self: *Loop, allocator: mem.Allocator) !void {
         return self.initInternal(allocator, 1);
     }
 
@@ -97,7 +97,7 @@ pub const Loop = struct {
     /// After initialization, call run().
     /// TODO copy elision / named return values so that the threads referencing *Loop
     /// have the correct pointer value.
-    pub fn initMultiThreaded(self: *Loop, allocator: *mem.Allocator) !void {
+    pub fn initMultiThreaded(self: *Loop, allocator: mem.Allocator) !void {
         if (builtin.single_threaded) @compileError("initMultiThreaded unavailable when building in single-threaded mode");
         const core_count = try os.cpuCount(allocator);
         return self.initInternal(allocator, core_count);
@@ -105,7 +105,7 @@ pub const Loop = struct {
 
     /// Thread count is the total thread count. The thread pool size will be
     /// max(thread_count - 1, 0)
-    fn initInternal(self: *Loop, allocator: *mem.Allocator, thread_count: usize) !void {
+    fn initInternal(self: *Loop, allocator: mem.Allocator, thread_count: usize) !void {
         self.* = Loop{
             .pending_event_count = 1,
             .allocator = allocator,

--- a/std/event/net.zig
+++ b/std/event/net.zig
@@ -345,13 +345,13 @@ pub const OutStream = struct {
     }
 
     async<*mem.Allocator> fn writeFn(out_stream: Stream, bytes: []const u8) Error!void {
-        const self = out_stream.implCast(OutStream);
+        const self = out_stream.iface.implCast(OutStream);
         return await (async write(self.loop, self.fd, bytes) catch unreachable);
     }
     
     pub fn outStream(self: *OutStream) Stream {
         return Stream {
-            .impl = Stream.ifaceCast(self),
+            .iface = Stream.Iface.init(self),
             .writeFn = writeFn,
         };
     }
@@ -372,13 +372,13 @@ pub const InStream = struct {
     }
 
     async<*mem.Allocator> fn readFn(in_stream: Stream, bytes: []u8) Error!usize {
-        const self = in_stream.implCast(InStream);
+        const self = in_stream.iface.implCast(InStream);
         return await (async read(self.loop, self.fd, bytes) catch unreachable);
     }
     
     pub fn outStream(self: *InStream) Stream {
         return Stream {
-            .impl = Stream.ifaceCast(self),
+            .iface = Stream.Iface.init(self),
             .readFn = readFn,
         };
     }

--- a/std/event/net.zig
+++ b/std/event/net.zig
@@ -344,7 +344,7 @@ pub const OutStream = struct {
         };
     }
 
-    async<*mem.Allocator> fn writeFn(out_stream: *Stream, bytes: []const u8) Error!void {
+    async<*mem.Allocator> fn writeFn(out_stream: Stream, bytes: []const u8) Error!void {
         const self = out_stream.implCast(OutStream);
         return await (async write(self.loop, self.fd, bytes) catch unreachable);
     }
@@ -371,7 +371,7 @@ pub const InStream = struct {
         };
     }
 
-    async<*mem.Allocator> fn readFn(in_stream: *Stream, bytes: []u8) Error!usize {
+    async<*mem.Allocator> fn readFn(in_stream: Stream, bytes: []u8) Error!usize {
         const self = in_stream.implCast(InStream);
         return await (async read(self.loop, self.fd, bytes) catch unreachable);
     }

--- a/std/event/net.zig
+++ b/std/event/net.zig
@@ -298,7 +298,7 @@ test "listen on a port, send bytes, receive bytes" {
             const addr = _addr.*; // TODO https://github.com/ziglang/zig/issues/1592
             var socket = _socket; // TODO https://github.com/ziglang/zig/issues/1592
 
-            const stream = &socket.outStreamAdapter().stream;
+            const stream = socket.outStreamAdapter().outStream();
             try stream.print("hello from server\n");
         }
     };

--- a/std/event/net.zig
+++ b/std/event/net.zig
@@ -298,7 +298,7 @@ test "listen on a port, send bytes, receive bytes" {
             const addr = _addr.*; // TODO https://github.com/ziglang/zig/issues/1592
             var socket = _socket; // TODO https://github.com/ziglang/zig/issues/1592
 
-            const stream = &socket.outStream().stream;
+            const stream = &socket.outStreamAdapter().stream;
             try stream.print("hello from server\n");
         }
     };

--- a/std/event/rwlock.zig
+++ b/std/event/rwlock.zig
@@ -218,7 +218,7 @@ test "std.event.RwLock" {
     var da = std.heap.DirectAllocator.init();
     defer da.deinit();
 
-    const allocator = &da.allocator;
+    const allocator = da.allocator();
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);

--- a/std/event/rwlock.zig
+++ b/std/event/rwlock.zig
@@ -227,7 +227,7 @@ test "std.event.RwLock" {
     var lock = RwLock.init(&loop);
     defer lock.deinit();
 
-    const handle = try async<allocator> testLock(&loop, &lock);
+    const handle = try async<&allocator> testLock(&loop, &lock);
     defer cancel handle;
     loop.run();
 

--- a/std/fmt.zig
+++ b/std/fmt.zig
@@ -914,7 +914,7 @@ pub fn bufPrint(buf: []u8, comptime fmt: []const u8, args: ...) ![]u8 {
 
 pub const AllocPrintError = error{OutOfMemory};
 
-pub fn allocPrint(allocator: *mem.Allocator, comptime fmt: []const u8, args: ...) AllocPrintError![]u8 {
+pub fn allocPrint(allocator: mem.Allocator, comptime fmt: []const u8, args: ...) AllocPrintError![]u8 {
     var size: usize = 0;
     format(&size, error{}, countSize, fmt, args) catch |err| switch (err) {};
     const buf = try allocator.alloc(u8, size);

--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -502,7 +502,7 @@ pub fn getAutoHashFn(comptime K: type) (fn (K) u32) {
     return struct {
         fn hash(key: K) u32 {
             comptime var rng = comptime std.rand.DefaultPrng.init(0);
-            return autoHash(key, &rng.random(), u32);
+            return autoHash(key, comptime &rng.random(), u32);
         }
     }.hash;
 }

--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -502,7 +502,7 @@ pub fn getAutoHashFn(comptime K: type) (fn (K) u32) {
     return struct {
         fn hash(key: K) u32 {
             comptime var rng = comptime std.rand.DefaultPrng.init(0);
-            return autoHash(key, &rng.random, u32);
+            return autoHash(key, &rng.random(), u32);
         }
     }.hash;
 }

--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -378,7 +378,7 @@ test "basic hash map usage" {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var map = AutoHashMap(i32, i32).init(&direct_allocator.allocator);
+    var map = AutoHashMap(i32, i32).init(direct_allocator.allocator());
     defer map.deinit();
 
     testing.expect((try map.put(1, 11)) == null);
@@ -421,7 +421,7 @@ test "iterator hash map" {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var reset_map = AutoHashMap(i32, i32).init(&direct_allocator.allocator);
+    var reset_map = AutoHashMap(i32, i32).init(direct_allocator.allocator());
     defer reset_map.deinit();
 
     testing.expect((try reset_map.put(1, 11)) == null);
@@ -468,7 +468,7 @@ test "ensure capacity" {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var map = AutoHashMap(i32, i32).init(&direct_allocator.allocator);
+    var map = AutoHashMap(i32, i32).init(direct_allocator.allocator());
     defer map.deinit();
 
     try map.ensureCapacity(20);

--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -19,7 +19,7 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime hash: fn (key: K) u3
         entries: []Entry,
         size: usize,
         max_distance_from_start_index: usize,
-        allocator: *Allocator,
+        allocator: Allocator,
         // this is used to detect bugs where a hashtable is edited while an iterator is running.
         modification_count: debug_u32,
 
@@ -75,7 +75,7 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime hash: fn (key: K) u3
             }
         };
 
-        pub fn init(allocator: *Allocator) Self {
+        pub fn init(allocator: Allocator) Self {
             return Self{
                 .entries = []Entry{},
                 .allocator = allocator,

--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -502,7 +502,7 @@ pub fn getAutoHashFn(comptime K: type) (fn (K) u32) {
     return struct {
         fn hash(key: K) u32 {
             comptime var rng = comptime std.rand.DefaultPrng.init(0);
-            return autoHash(key, comptime &rng.random(), u32);
+            return autoHash(key, comptime rng.random(), u32);
         }
     }.hash;
 }
@@ -516,7 +516,7 @@ pub fn getAutoEqlFn(comptime K: type) (fn (K, K) bool) {
 }
 
 // TODO improve these hash functions
-pub fn autoHash(key: var, comptime rng: *std.rand.Random, comptime HashInt: type) HashInt {
+pub fn autoHash(key: var, comptime rng: std.rand.Random, comptime HashInt: type) HashInt {
     switch (@typeInfo(@typeOf(key))) {
         builtin.TypeId.NoReturn,
         builtin.TypeId.Opaque,

--- a/std/heap.zig
+++ b/std/heap.zig
@@ -11,8 +11,7 @@ const maxInt = std.math.maxInt;
 
 const Allocator = mem.Allocator;
 
-pub const c_allocator = c_allocator_state;
-var c_allocator_state = Allocator{
+pub const c_allocator = comptime Allocator{
     .impl = null,
     .reallocFn = cRealloc,
     .shrinkFn = cShrink,

--- a/std/heap.zig
+++ b/std/heap.zig
@@ -13,18 +13,19 @@ const Allocator = mem.Allocator;
 
 pub const c_allocator = &c_allocator_state;
 var c_allocator_state = Allocator{
+    .impl = null,
     .reallocFn = cRealloc,
     .shrinkFn = cShrink,
 };
 
-fn cRealloc(self: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+fn cRealloc(self: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
     assert(new_align <= @alignOf(c_longdouble));
     const old_ptr = if (old_mem.len == 0) null else @ptrCast(*c_void, old_mem.ptr);
     const buf = c.realloc(old_ptr, new_size) orelse return error.OutOfMemory;
     return @ptrCast([*]u8, buf)[0..new_size];
 }
 
-fn cShrink(self: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
+fn cShrink(self: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
     const old_ptr = @ptrCast(*c_void, old_mem.ptr);
     const buf = c.realloc(old_ptr, new_size) orelse return old_mem[0..new_size];
     return @ptrCast([*]u8, buf)[0..new_size];
@@ -33,21 +34,13 @@ fn cShrink(self: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new
 /// This allocator makes a syscall directly for every allocation and free.
 /// Thread-safe and lock-free.
 pub const DirectAllocator = struct {
-    allocator: Allocator,
-
     pub fn init() DirectAllocator {
-        return DirectAllocator{
-            .allocator = Allocator{
-                .reallocFn = realloc,
-                .shrinkFn = shrink,
-            },
-        };
+        return DirectAllocator{};
     }
 
     pub fn deinit(self: *DirectAllocator) void {}
 
-    fn alloc(allocator: *Allocator, n: usize, alignment: u29) error{OutOfMemory}![]u8 {
-        const self = @fieldParentPtr(DirectAllocator, "allocator", allocator);
+    fn alloc(a: Allocator, n: usize, alignment: u29) Allocator.Error![]u8 {
         if (n == 0)
             return (([*]u8)(undefined))[0..0];
 
@@ -134,7 +127,7 @@ pub const DirectAllocator = struct {
         }
     }
 
-    fn shrink(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
+    fn shrink(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         switch (builtin.os) {
             Os.linux, Os.macosx, Os.ios, Os.freebsd, Os.netbsd => {
                 const base_addr = @ptrToInt(old_mem.ptr);
@@ -177,13 +170,13 @@ pub const DirectAllocator = struct {
         }
     }
 
-    fn realloc(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+    fn realloc(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
         switch (builtin.os) {
             Os.linux, Os.macosx, Os.ios, Os.freebsd, Os.netbsd => {
                 if (new_size <= old_mem.len and new_align <= old_align) {
-                    return shrink(allocator, old_mem, old_align, new_size, new_align);
+                    return shrink(a, old_mem, old_align, new_size, new_align);
                 }
-                const result = try alloc(allocator, new_size, new_align);
+                const result = try alloc(a, new_size, new_align);
                 if (old_mem.len != 0) {
                     @memcpy(result.ptr, old_mem.ptr, std.math.min(old_mem.len, result.len));
                     _ = os.posix.munmap(@ptrToInt(old_mem.ptr), old_mem.len);
@@ -192,11 +185,11 @@ pub const DirectAllocator = struct {
             },
             .windows => {
                 if (old_mem.len == 0) {
-                    return alloc(allocator, new_size, new_align);
+                    return alloc(a, new_size, new_align);
                 }
 
                 if (new_size <= old_mem.len and new_align <= old_align) {
-                    return shrink(allocator, old_mem, old_align, new_size, new_align);
+                    return shrink(a, old_mem, old_align, new_size, new_align);
                 }
 
                 const w = os.windows;
@@ -206,7 +199,7 @@ pub const DirectAllocator = struct {
                     // Current allocation doesn't satisfy the new alignment.
                     // For now we'll do a new one no matter what, but maybe
                     // there is something smarter to do instead.
-                    const result = try alloc(allocator, new_size, new_align);
+                    const result = try alloc(a, new_size, new_align);
                     assert(old_mem.len != 0);
                     @memcpy(result.ptr, old_mem.ptr, std.math.min(old_mem.len, result.len));
                     if (w.VirtualFree(old_mem.ptr, 0, w.MEM_RELEASE) == 0) unreachable;
@@ -234,7 +227,7 @@ pub const DirectAllocator = struct {
                 ) orelse {
                     // Committing new pages at the end of the existing allocation
                     // failed, we need to try a new one.
-                    const new_alloc_mem = try alloc(allocator, new_size, new_align);
+                    const new_alloc_mem = try alloc(a, new_size, new_align);
                     @memcpy(new_alloc_mem.ptr, old_mem.ptr, old_mem.len);
                     if (w.VirtualFree(old_mem.ptr, 0, w.MEM_RELEASE) == 0) unreachable;
 
@@ -247,21 +240,24 @@ pub const DirectAllocator = struct {
             else => @compileError("Unsupported OS"),
         }
     }
+    
+    pub fn allocator(self: *DirectAllocator) Allocator {
+        return Allocator {
+            .impl = null,
+            .reallocFn = realloc,
+            .shrinkFn = shrink,
+        };
+    } 
 };
 
 pub const HeapAllocator = switch (builtin.os) {
     .windows => struct {
-        allocator: Allocator,
         heap_handle: ?HeapHandle,
 
         const HeapHandle = os.windows.HANDLE;
 
         pub fn init() HeapAllocator {
             return HeapAllocator{
-                .allocator = Allocator{
-                    .reallocFn = realloc,
-                    .shrinkFn = shrink,
-                },
                 .heap_handle = null,
             };
         }
@@ -272,8 +268,7 @@ pub const HeapAllocator = switch (builtin.os) {
             }
         }
 
-        fn alloc(allocator: *Allocator, n: usize, alignment: u29) error{OutOfMemory}![]u8 {
-            const self = @fieldParentPtr(HeapAllocator, "allocator", allocator);
+        fn alloc(self: *HeapAllocator, n: usize, alignment: u29) error{OutOfMemory}![]u8 {
             if (n == 0)
                 return (([*]u8)(undefined))[0..0];
 
@@ -294,8 +289,8 @@ pub const HeapAllocator = switch (builtin.os) {
             return @intToPtr([*]u8, adjusted_addr)[0..n];
         }
 
-        fn shrink(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
-            return realloc(allocator, old_mem, old_align, new_size, new_align) catch {
+        fn shrink(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
+            return realloc(a, old_mem, old_align, new_size, new_align) catch {
                 const old_adjusted_addr = @ptrToInt(old_mem.ptr);
                 const old_record_addr = old_adjusted_addr + old_mem.len;
                 const root_addr = @intToPtr(*align(1) usize, old_record_addr).*;
@@ -306,10 +301,11 @@ pub const HeapAllocator = switch (builtin.os) {
             };
         }
 
-        fn realloc(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
-            if (old_mem.len == 0) return alloc(allocator, new_size, new_align);
+        fn realloc(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+            const self = a.implCast(HeapAllocator);
+            
+            if (old_mem.len == 0) return self.alloc(new_size, new_align);
 
-            const self = @fieldParentPtr(HeapAllocator, "allocator", allocator);
             const old_adjusted_addr = @ptrToInt(old_mem.ptr);
             const old_record_addr = old_adjusted_addr + old_mem.len;
             const root_addr = @intToPtr(*align(1) usize, old_record_addr).*;
@@ -344,6 +340,14 @@ pub const HeapAllocator = switch (builtin.os) {
             @intToPtr(*align(1) usize, new_record_addr).* = new_root_addr;
             return @intToPtr([*]u8, new_adjusted_addr)[0..new_size];
         }
+        
+        pub fn allocator(self: *HeapAllocator) Allocator {
+            return Allocator {
+                .impl = Allocator.ifaceCast(self),
+                .reallocFn = realloc,
+                .shrinkFn = shrink,
+            };
+        }
     },
     else => @compileError("Unsupported OS"),
 };
@@ -351,20 +355,14 @@ pub const HeapAllocator = switch (builtin.os) {
 /// This allocator takes an existing allocator, wraps it, and provides an interface
 /// where you can allocate without freeing, and then free it all together.
 pub const ArenaAllocator = struct {
-    pub allocator: Allocator,
-
-    child_allocator: *Allocator,
+    child_allocator: Allocator,
     buffer_list: std.LinkedList([]u8),
     end_index: usize,
 
     const BufNode = std.LinkedList([]u8).Node;
 
-    pub fn init(child_allocator: *Allocator) ArenaAllocator {
+    pub fn init(child_allocator: Allocator) ArenaAllocator {
         return ArenaAllocator{
-            .allocator = Allocator{
-                .reallocFn = realloc,
-                .shrinkFn = shrink,
-            },
             .child_allocator = child_allocator,
             .buffer_list = std.LinkedList([]u8).init(),
             .end_index = 0,
@@ -402,8 +400,8 @@ pub const ArenaAllocator = struct {
         return buf_node;
     }
 
-    fn alloc(allocator: *Allocator, n: usize, alignment: u29) ![]u8 {
-        const self = @fieldParentPtr(ArenaAllocator, "allocator", allocator);
+    fn alloc(a: Allocator, n: usize, alignment: u29) ![]u8 {
+        const self = a.implCast(ArenaAllocator);
 
         var cur_node = if (self.buffer_list.last) |last_node| last_node else try self.createNode(0, n + alignment);
         while (true) {
@@ -422,40 +420,42 @@ pub const ArenaAllocator = struct {
         }
     }
 
-    fn realloc(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+    fn realloc(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
         if (new_size <= old_mem.len and new_align <= new_size) {
             // We can't do anything with the memory, so tell the client to keep it.
             return error.OutOfMemory;
         } else {
-            const result = try alloc(allocator, new_size, new_align);
+            const result = try alloc(a, new_size, new_align);
             @memcpy(result.ptr, old_mem.ptr, std.math.min(old_mem.len, result.len));
             return result;
         }
     }
 
-    fn shrink(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
+    fn shrink(allocator: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         return old_mem[0..new_size];
+    }
+    
+    pub fn allocator(self: *ArenaAllocator) Allocator {
+        return Allocator {
+            .impl = Allocator.ifaceCast(self),
+            .reallocFn = realloc,
+            .shrinkFn = shrink,
+        };
     }
 };
 
 pub const FixedBufferAllocator = struct {
-    allocator: Allocator,
     end_index: usize,
     buffer: []u8,
 
     pub fn init(buffer: []u8) FixedBufferAllocator {
         return FixedBufferAllocator{
-            .allocator = Allocator{
-                .reallocFn = realloc,
-                .shrinkFn = shrink,
-            },
             .buffer = buffer,
             .end_index = 0,
         };
     }
 
-    fn alloc(allocator: *Allocator, n: usize, alignment: u29) ![]u8 {
-        const self = @fieldParentPtr(FixedBufferAllocator, "allocator", allocator);
+    fn alloc(self: *FixedBufferAllocator, n: usize, alignment: u29) ![]u8 {
         const addr = @ptrToInt(self.buffer.ptr) + self.end_index;
         const adjusted_addr = mem.alignForward(addr, alignment);
         const adjusted_index = self.end_index + (adjusted_addr - addr);
@@ -469,8 +469,9 @@ pub const FixedBufferAllocator = struct {
         return result;
     }
 
-    fn realloc(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
-        const self = @fieldParentPtr(FixedBufferAllocator, "allocator", allocator);
+    fn realloc(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+        const self = a.implCast(FixedBufferAllocator);
+        
         assert(old_mem.len <= self.end_index);
         if (old_mem.ptr == self.buffer.ptr + self.end_index - old_mem.len and
             mem.alignForward(@ptrToInt(old_mem.ptr), new_align) == @ptrToInt(old_mem.ptr))
@@ -485,14 +486,22 @@ pub const FixedBufferAllocator = struct {
             // We can't do anything with the memory, so tell the client to keep it.
             return error.OutOfMemory;
         } else {
-            const result = try alloc(allocator, new_size, new_align);
+            const result = try alloc(new_size, new_align);
             @memcpy(result.ptr, old_mem.ptr, std.math.min(old_mem.len, result.len));
             return result;
         }
     }
 
-    fn shrink(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
+    fn shrink(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         return old_mem[0..new_size];
+    }
+    
+    pub fn allocator(self: *FixedBufferAllocator) Allocator {
+        return Allocator {
+            .impl = Allocator.ifaceCast(self),
+            .reallocFn = realloc,
+            .shrinkFn = shrink,
+        };
     }
 };
 
@@ -501,19 +510,14 @@ pub const FixedBufferAllocator = struct {
 extern fn @"llvm.wasm.memory.size.i32"(u32) u32;
 extern fn @"llvm.wasm.memory.grow.i32"(u32, u32) i32;
 
-pub const wasm_allocator = &wasm_allocator_state.allocator;
+pub const wasm_allocator = &wasm_allocator_state.allocator();
 var wasm_allocator_state = WasmAllocator{
-    .allocator = Allocator{
-        .reallocFn = WasmAllocator.realloc,
-        .shrinkFn = WasmAllocator.shrink,
-    },
     .start_ptr = undefined,
     .num_pages = 0,
     .end_index = 0,
 };
 
 const WasmAllocator = struct {
-    allocator: Allocator,
     start_ptr: [*]u8,
     num_pages: usize,
     end_index: usize,
@@ -524,9 +528,7 @@ const WasmAllocator = struct {
         }
     }
 
-    fn alloc(allocator: *Allocator, size: usize, alignment: u29) ![]u8 {
-        const self = @fieldParentPtr(WasmAllocator, "allocator", allocator);
-
+    fn alloc(self: *WasmAllocator, size: usize, alignment: u29) ![]u8 {
         const addr = @ptrToInt(self.start_ptr) + self.end_index;
         const adjusted_addr = mem.alignForward(addr, alignment);
         const adjusted_index = self.end_index + (adjusted_addr - addr);
@@ -555,25 +557,24 @@ const WasmAllocator = struct {
     }
 
     // Check if memory is the last "item" and is aligned correctly
-    fn is_last_item(allocator: *Allocator, memory: []u8, alignment: u29) bool {
-        const self = @fieldParentPtr(WasmAllocator, "allocator", allocator);
+    fn is_last_item(self: *WasmAllocator, memory: []u8, alignment: u29) bool {
         return memory.ptr == self.start_ptr + self.end_index - memory.len and mem.alignForward(@ptrToInt(memory.ptr), alignment) == @ptrToInt(memory.ptr);
     }
 
-    fn realloc(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
-        const self = @fieldParentPtr(WasmAllocator, "allocator", allocator);
+    fn realloc(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+        const self = a.implCast(WasmAllocator);
 
         // Initialize start_ptr at the first realloc
         if (self.num_pages == 0) {
             self.start_ptr = @intToPtr([*]u8, @intCast(usize, @"llvm.wasm.memory.size.i32"(0)) * os.page_size);
         }
 
-        if (is_last_item(allocator, old_mem, new_align)) {
+        if (self.is_last_item(old_mem, new_align)) {
             const start_index = self.end_index - old_mem.len;
             const new_end_index = start_index + new_size;
 
             if (new_end_index > self.num_pages * os.page_size) {
-                _ = try alloc(allocator, new_end_index - self.end_index, new_align);
+                _ = try self.alloc(new_end_index - self.end_index, new_align);
             }
             const result = self.start_ptr[start_index..new_end_index];
 
@@ -582,14 +583,22 @@ const WasmAllocator = struct {
         } else if (new_size <= old_mem.len and new_align <= old_align) {
             return error.OutOfMemory;
         } else {
-            const result = try alloc(allocator, new_size, new_align);
+            const result = try self.alloc(new_size, new_align);
             mem.copy(u8, result, old_mem);
             return result;
         }
     }
 
-    fn shrink(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
+    fn shrink(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         return old_mem[0..new_size];
+    }
+    
+    pub fn allocator(self: *WasmAllocator) Allocator {
+        return Allocator {
+            .impl = Allocator.ifaceCast(self),
+            .reallocFn = realloc,
+            .shrinkFn = shrink,
+        };
     }
 };
 
@@ -599,23 +608,17 @@ pub const ThreadSafeFixedBufferAllocator = blk: {
     } else {
         // lock free
         break :blk struct {
-            allocator: Allocator,
             end_index: usize,
             buffer: []u8,
 
             pub fn init(buffer: []u8) ThreadSafeFixedBufferAllocator {
                 return ThreadSafeFixedBufferAllocator{
-                    .allocator = Allocator{
-                        .reallocFn = realloc,
-                        .shrinkFn = shrink,
-                    },
                     .buffer = buffer,
                     .end_index = 0,
                 };
             }
 
-            fn alloc(allocator: *Allocator, n: usize, alignment: u29) ![]u8 {
-                const self = @fieldParentPtr(ThreadSafeFixedBufferAllocator, "allocator", allocator);
+            fn alloc(self: *ThreadSafeFixedBufferAllocator, n: usize, alignment: u29) ![]u8 {
                 var end_index = @atomicLoad(usize, &self.end_index, builtin.AtomicOrder.SeqCst);
                 while (true) {
                     const addr = @ptrToInt(self.buffer.ptr) + end_index;
@@ -629,33 +632,39 @@ pub const ThreadSafeFixedBufferAllocator = blk: {
                 }
             }
 
-            fn realloc(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+            fn realloc(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+                const self = a.implCast(ThreadSafeFixedBufferAllocator);
+                
                 if (new_size <= old_mem.len and new_align <= old_align) {
                     // We can't do anything useful with the memory, tell the client to keep it.
                     return error.OutOfMemory;
                 } else {
-                    const result = try alloc(allocator, new_size, new_align);
+                    const result = try self.alloc(new_size, new_align);
                     @memcpy(result.ptr, old_mem.ptr, std.math.min(old_mem.len, result.len));
                     return result;
                 }
             }
 
-            fn shrink(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
+            fn shrink(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
                 return old_mem[0..new_size];
+            }
+            
+            pub fn allocator(self: *ThreadSafeFixedBufferAllocator) Allocator {
+                return Allocator {
+                    .impl = Allocator.ifaceCast(self),
+                    .reallocFn = realloc,
+                    .shrinkFn = shrink,
+                };
             }
         };
     }
 };
 
-pub fn stackFallback(comptime size: usize, fallback_allocator: *Allocator) StackFallbackAllocator(size) {
+pub fn stackFallback(comptime size: usize, fallback_allocator: Allocator) StackFallbackAllocator(size) {
     return StackFallbackAllocator(size){
         .buffer = undefined,
         .fallback_allocator = fallback_allocator,
         .fixed_buffer_allocator = undefined,
-        .allocator = Allocator{
-            .reallocFn = StackFallbackAllocator(size).realloc,
-            .shrinkFn = StackFallbackAllocator(size).shrink,
-        },
     };
 }
 
@@ -664,22 +673,22 @@ pub fn StackFallbackAllocator(comptime size: usize) type {
         const Self = @This();
 
         buffer: [size]u8,
-        allocator: Allocator,
-        fallback_allocator: *Allocator,
+        fallback_allocator: Allocator,
         fixed_buffer_allocator: FixedBufferAllocator,
 
-        pub fn get(self: *Self) *Allocator {
+        pub fn get(self: *Self) Allocator {
             self.fixed_buffer_allocator = FixedBufferAllocator.init(self.buffer[0..]);
-            return &self.allocator;
+            return self.allocator();
         }
 
-        fn realloc(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
-            const self = @fieldParentPtr(Self, "allocator", allocator);
+        fn realloc(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
+            const self = a.impleCast(Self);
+            
             const in_buffer = @ptrToInt(old_mem.ptr) >= @ptrToInt(&self.buffer) and
                 @ptrToInt(old_mem.ptr) < @ptrToInt(&self.buffer) + self.buffer.len;
             if (in_buffer) {
                 return FixedBufferAllocator.realloc(
-                    &self.fixed_buffer_allocator.allocator,
+                    self.fixed_buffer_allocator.allocator(),
                     old_mem,
                     old_align,
                     new_size,
@@ -705,13 +714,13 @@ pub fn StackFallbackAllocator(comptime size: usize) type {
             );
         }
 
-        fn shrink(allocator: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
-            const self = @fieldParentPtr(Self, "allocator", allocator);
+        fn shrink(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
+            const self = a.implCast(Self);
             const in_buffer = @ptrToInt(old_mem.ptr) >= @ptrToInt(&self.buffer) and
                 @ptrToInt(old_mem.ptr) < @ptrToInt(&self.buffer) + self.buffer.len;
             if (in_buffer) {
                 return FixedBufferAllocator.shrink(
-                    &self.fixed_buffer_allocator.allocator,
+                    self.fixed_buffer_allocator.allocator(),
                     old_mem,
                     old_align,
                     new_size,
@@ -725,6 +734,14 @@ pub fn StackFallbackAllocator(comptime size: usize) type {
                 new_size,
                 new_align,
             );
+        }
+        
+        pub fn allocator(self: *Self) Allocator {
+            return Allocator {
+                .impl = Allocator.ifaceCast(self),
+                .reallocFn = realloc,
+                .shrinkFn = shrink,
+            };
         }
     };
 }
@@ -741,7 +758,7 @@ test "DirectAllocator" {
     var direct_allocator = DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    const allocator = &direct_allocator.allocator;
+    const allocator = direct_allocator.allocator();
     try testAllocator(allocator);
     try testAllocatorAligned(allocator, 16);
     try testAllocatorLargeAlignment(allocator);
@@ -764,7 +781,7 @@ test "HeapAllocator" {
         var heap_allocator = HeapAllocator.init();
         defer heap_allocator.deinit();
 
-        const allocator = &heap_allocator.allocator;
+        const allocator = heap_allocator.allocator();
         try testAllocator(allocator);
         try testAllocatorAligned(allocator, 16);
         try testAllocatorLargeAlignment(allocator);
@@ -776,23 +793,23 @@ test "ArenaAllocator" {
     var direct_allocator = DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var arena_allocator = ArenaAllocator.init(&direct_allocator.allocator);
+    var arena_allocator = ArenaAllocator.init(direct_allocator.allocator());
     defer arena_allocator.deinit();
 
-    try testAllocator(&arena_allocator.allocator);
-    try testAllocatorAligned(&arena_allocator.allocator, 16);
-    try testAllocatorLargeAlignment(&arena_allocator.allocator);
-    try testAllocatorAlignedShrink(&arena_allocator.allocator);
+    try testAllocator(arena_allocator.allocator());
+    try testAllocatorAligned(arena_allocator.allocator(), 16);
+    try testAllocatorLargeAlignment(arena_allocator.allocator());
+    try testAllocatorAlignedShrink(arena_allocator.allocator());
 }
 
 var test_fixed_buffer_allocator_memory: [80000 * @sizeOf(u64)]u8 = undefined;
 test "FixedBufferAllocator" {
     var fixed_buffer_allocator = FixedBufferAllocator.init(test_fixed_buffer_allocator_memory[0..]);
 
-    try testAllocator(&fixed_buffer_allocator.allocator);
-    try testAllocatorAligned(&fixed_buffer_allocator.allocator, 16);
-    try testAllocatorLargeAlignment(&fixed_buffer_allocator.allocator);
-    try testAllocatorAlignedShrink(&fixed_buffer_allocator.allocator);
+    try testAllocator(fixed_buffer_allocator.allocator());
+    try testAllocatorAligned(fixed_buffer_allocator.allocator(), 16);
+    try testAllocatorLargeAlignment(fixed_buffer_allocator.allocator());
+    try testAllocatorAlignedShrink(fixed_buffer_allocator.allocator());
 }
 
 test "FixedBufferAllocator Reuse memory on realloc" {
@@ -801,22 +818,22 @@ test "FixedBufferAllocator Reuse memory on realloc" {
     {
         var fixed_buffer_allocator = FixedBufferAllocator.init(small_fixed_buffer[0..]);
 
-        var slice0 = try fixed_buffer_allocator.allocator.alloc(u8, 5);
+        var slice0 = try fixed_buffer_allocator.allocator().alloc(u8, 5);
         testing.expect(slice0.len == 5);
-        var slice1 = try fixed_buffer_allocator.allocator.realloc(slice0, 10);
+        var slice1 = try fixed_buffer_allocator.allocator().realloc(slice0, 10);
         testing.expect(slice1.ptr == slice0.ptr);
         testing.expect(slice1.len == 10);
-        testing.expectError(error.OutOfMemory, fixed_buffer_allocator.allocator.realloc(slice1, 11));
+        testing.expectError(error.OutOfMemory, fixed_buffer_allocator.allocator().realloc(slice1, 11));
     }
     // check that we don't re-use the memory if it's not the most recent block
     {
         var fixed_buffer_allocator = FixedBufferAllocator.init(small_fixed_buffer[0..]);
 
-        var slice0 = try fixed_buffer_allocator.allocator.alloc(u8, 2);
+        var slice0 = try fixed_buffer_allocator.allocator().alloc(u8, 2);
         slice0[0] = 1;
         slice0[1] = 2;
-        var slice1 = try fixed_buffer_allocator.allocator.alloc(u8, 2);
-        var slice2 = try fixed_buffer_allocator.allocator.realloc(slice0, 4);
+        var slice1 = try fixed_buffer_allocator.allocator().alloc(u8, 2);
+        var slice2 = try fixed_buffer_allocator.allocator().realloc(slice0, 4);
         testing.expect(slice0.ptr != slice2.ptr);
         testing.expect(slice1.ptr != slice2.ptr);
         testing.expect(slice2[0] == 1);
@@ -827,13 +844,13 @@ test "FixedBufferAllocator Reuse memory on realloc" {
 test "ThreadSafeFixedBufferAllocator" {
     var fixed_buffer_allocator = ThreadSafeFixedBufferAllocator.init(test_fixed_buffer_allocator_memory[0..]);
 
-    try testAllocator(&fixed_buffer_allocator.allocator);
-    try testAllocatorAligned(&fixed_buffer_allocator.allocator, 16);
-    try testAllocatorLargeAlignment(&fixed_buffer_allocator.allocator);
-    try testAllocatorAlignedShrink(&fixed_buffer_allocator.allocator);
+    try testAllocator(fixed_buffer_allocator.allocator());
+    try testAllocatorAligned(fixed_buffer_allocator.allocator(), 16);
+    try testAllocatorLargeAlignment(fixed_buffer_allocator.allocator());
+    try testAllocatorAlignedShrink(fixed_buffer_allocator.allocator());
 }
 
-fn testAllocator(allocator: *mem.Allocator) !void {
+fn testAllocator(allocator: Allocator) !void {
     var slice = try allocator.alloc(*i32, 100);
     testing.expect(slice.len == 100);
     for (slice) |*item, i| {
@@ -861,7 +878,7 @@ fn testAllocator(allocator: *mem.Allocator) !void {
     allocator.free(slice);
 }
 
-fn testAllocatorAligned(allocator: *mem.Allocator, comptime alignment: u29) !void {
+fn testAllocatorAligned(allocator: Allocator, comptime alignment: u29) !void {
     // initial
     var slice = try allocator.alignedAlloc(u8, alignment, 10);
     testing.expect(slice.len == 10);
@@ -885,7 +902,7 @@ fn testAllocatorAligned(allocator: *mem.Allocator, comptime alignment: u29) !voi
     testing.expect(slice.len == 0);
 }
 
-fn testAllocatorLargeAlignment(allocator: *mem.Allocator) mem.Allocator.Error!void {
+fn testAllocatorLargeAlignment(allocator: Allocator) Allocator.Error!void {
     //Maybe a platform's page_size is actually the same as or
     //  very near usize?
     if (os.page_size << 2 > maxInt(usize)) return;
@@ -914,9 +931,9 @@ fn testAllocatorLargeAlignment(allocator: *mem.Allocator) mem.Allocator.Error!vo
     allocator.free(slice);
 }
 
-fn testAllocatorAlignedShrink(allocator: *mem.Allocator) mem.Allocator.Error!void {
+fn testAllocatorAlignedShrink(allocator: Allocator) Allocator.Error!void {
     var debug_buffer: [1000]u8 = undefined;
-    const debug_allocator = &FixedBufferAllocator.init(&debug_buffer).allocator;
+    const debug_allocator = FixedBufferAllocator.init(&debug_buffer).allocator();
 
     const alloc_size = os.page_size * 2 + 50;
     var slice = try allocator.alignedAlloc(u8, 16, alloc_size);

--- a/std/heap.zig
+++ b/std/heap.zig
@@ -12,7 +12,7 @@ const maxInt = std.math.maxInt;
 const Allocator = mem.Allocator;
 
 pub const c_allocator = comptime Allocator{
-    .impl = null,
+    .iface = Allocator.Iface.none(),
     .reallocFn = cRealloc,
     .shrinkFn = cShrink,
 };
@@ -239,14 +239,14 @@ pub const DirectAllocator = struct {
             else => @compileError("Unsupported OS"),
         }
     }
-    
+
     pub fn allocator(self: *DirectAllocator) Allocator {
-        return Allocator {
-            .impl = null,
+        return Allocator{
+            .iface = Allocator.Iface.none(),
             .reallocFn = realloc,
             .shrinkFn = shrink,
         };
-    } 
+    }
 };
 
 pub const HeapAllocator = switch (builtin.os) {
@@ -301,8 +301,8 @@ pub const HeapAllocator = switch (builtin.os) {
         }
 
         fn realloc(a: *const Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
-            const self = a.implCast(HeapAllocator);
-            
+            const self = a.iface.implCast(HeapAllocator);
+
             if (old_mem.len == 0) return self.alloc(new_size, new_align);
 
             const old_adjusted_addr = @ptrToInt(old_mem.ptr);
@@ -339,10 +339,10 @@ pub const HeapAllocator = switch (builtin.os) {
             @intToPtr(*align(1) usize, new_record_addr).* = new_root_addr;
             return @intToPtr([*]u8, new_adjusted_addr)[0..new_size];
         }
-        
+
         pub fn allocator(self: *HeapAllocator) Allocator {
-            return Allocator {
-                .impl = Allocator.ifaceCast(self),
+            return Allocator{
+                .iface = Allocator.Iface.init(self),
                 .reallocFn = realloc,
                 .shrinkFn = shrink,
             };
@@ -400,7 +400,7 @@ pub const ArenaAllocator = struct {
     }
 
     fn alloc(a: *const Allocator, n: usize, alignment: u29) ![]u8 {
-        const self = a.implCast(ArenaAllocator);
+        const self = a.iface.implCast(ArenaAllocator);
 
         var cur_node = if (self.buffer_list.last) |last_node| last_node else try self.createNode(0, n + alignment);
         while (true) {
@@ -433,10 +433,10 @@ pub const ArenaAllocator = struct {
     fn shrink(a: *const Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         return old_mem[0..new_size];
     }
-    
+
     pub fn allocator(self: *ArenaAllocator) Allocator {
-        return Allocator {
-            .impl = Allocator.ifaceCast(self),
+        return Allocator{
+            .iface = Allocator.Iface.init(self),
             .reallocFn = realloc,
             .shrinkFn = shrink,
         };
@@ -469,8 +469,8 @@ pub const FixedBufferAllocator = struct {
     }
 
     fn realloc(a: *const Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) Allocator.Error![]u8 {
-        const self = a.implCast(FixedBufferAllocator);
-        
+        const self = a.iface.implCast(FixedBufferAllocator);
+
         assert(old_mem.len <= self.end_index);
         if (old_mem.ptr == self.buffer.ptr + self.end_index - old_mem.len and
             mem.alignForward(@ptrToInt(old_mem.ptr), new_align) == @ptrToInt(old_mem.ptr))
@@ -494,10 +494,10 @@ pub const FixedBufferAllocator = struct {
     fn shrink(a: *const Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         return old_mem[0..new_size];
     }
-    
+
     pub fn allocator(self: *FixedBufferAllocator) Allocator {
-        return Allocator {
-            .impl = Allocator.ifaceCast(self),
+        return Allocator{
+            .iface = Allocator.Iface.init(self),
             .reallocFn = realloc,
             .shrinkFn = shrink,
         };
@@ -561,7 +561,7 @@ const WasmAllocator = struct {
     }
 
     fn realloc(a: *const Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) Allocator.Error![]u8 {
-        const self = a.implCast(WasmAllocator);
+        const self = a.iface.implCast(WasmAllocator);
 
         // Initialize start_ptr at the first realloc
         if (self.num_pages == 0) {
@@ -591,10 +591,10 @@ const WasmAllocator = struct {
     fn shrink(a: *const Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         return old_mem[0..new_size];
     }
-    
+
     pub fn allocator(self: *WasmAllocator) Allocator {
-        return Allocator {
-            .impl = Allocator.ifaceCast(self),
+        return Allocator{
+            .iface = Allocator.Iface.init(self),
             .reallocFn = realloc,
             .shrinkFn = shrink,
         };
@@ -632,8 +632,8 @@ pub const ThreadSafeFixedBufferAllocator = blk: {
             }
 
             fn realloc(a: *const Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) Allocator.Error![]u8 {
-                const self = a.implCast(ThreadSafeFixedBufferAllocator);
-                
+                const self = a.iface.implCast(ThreadSafeFixedBufferAllocator);
+
                 if (new_size <= old_mem.len and new_align <= old_align) {
                     // We can't do anything useful with the memory, tell the client to keep it.
                     return error.OutOfMemory;
@@ -647,10 +647,10 @@ pub const ThreadSafeFixedBufferAllocator = blk: {
             fn shrink(a: *const Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
                 return old_mem[0..new_size];
             }
-            
+
             pub fn allocator(self: *ThreadSafeFixedBufferAllocator) Allocator {
-                return Allocator {
-                    .impl = Allocator.ifaceCast(self),
+                return Allocator{
+                    .iface = Allocator.Iface.init(self),
                     .reallocFn = realloc,
                     .shrinkFn = shrink,
                 };
@@ -681,8 +681,8 @@ pub fn StackFallbackAllocator(comptime size: usize) type {
         }
 
         fn realloc(a: *const Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) Allocator.Error![]u8 {
-            const self = a.implCast(Self);
-            
+            const self = a.iface.implCast(Self);
+
             const in_buffer = @ptrToInt(old_mem.ptr) >= @ptrToInt(&self.buffer) and
                 @ptrToInt(old_mem.ptr) < @ptrToInt(&self.buffer) + self.buffer.len;
             if (in_buffer) {
@@ -714,7 +714,7 @@ pub fn StackFallbackAllocator(comptime size: usize) type {
         }
 
         fn shrink(a: *const Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
-            const self = a.implCast(Self);
+            const self = a.iface.implCast(Self);
             const in_buffer = @ptrToInt(old_mem.ptr) >= @ptrToInt(&self.buffer) and
                 @ptrToInt(old_mem.ptr) < @ptrToInt(&self.buffer) + self.buffer.len;
             if (in_buffer) {
@@ -734,10 +734,10 @@ pub fn StackFallbackAllocator(comptime size: usize) type {
                 new_align,
             );
         }
-        
+
         pub fn allocator(self: *Self) Allocator {
-            return Allocator {
-                .impl = Allocator.ifaceCast(self),
+            return Allocator{
+                .iface = Allocator.Iface.init(self),
                 .reallocFn = realloc,
                 .shrinkFn = shrink,
             };

--- a/std/heap.zig
+++ b/std/heap.zig
@@ -682,7 +682,7 @@ pub fn StackFallbackAllocator(comptime size: usize) type {
         }
 
         fn realloc(a: Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) Allocator.Error![]u8 {
-            const self = a.impleCast(Self);
+            const self = a.implCast(Self);
             
             const in_buffer = @ptrToInt(old_mem.ptr) >= @ptrToInt(&self.buffer) and
                 @ptrToInt(old_mem.ptr) < @ptrToInt(&self.buffer) + self.buffer.len;

--- a/std/heap.zig
+++ b/std/heap.zig
@@ -11,7 +11,7 @@ const maxInt = std.math.maxInt;
 
 const Allocator = mem.Allocator;
 
-pub const c_allocator = &c_allocator_state;
+pub const c_allocator = c_allocator_state;
 var c_allocator_state = Allocator{
     .impl = null,
     .reallocFn = cRealloc,
@@ -510,7 +510,7 @@ pub const FixedBufferAllocator = struct {
 extern fn @"llvm.wasm.memory.size.i32"(u32) u32;
 extern fn @"llvm.wasm.memory.grow.i32"(u32, u32) i32;
 
-pub const wasm_allocator = &wasm_allocator_state.allocator();
+pub const wasm_allocator = wasm_allocator_state.allocator();
 var wasm_allocator_state = WasmAllocator{
     .start_ptr = undefined,
     .num_pages = 0,

--- a/std/interface.zig
+++ b/std/interface.zig
@@ -1,0 +1,25 @@
+pub fn Interface() type {
+    const Impl = @OpaqueType();
+
+    return struct {
+        const Self = @This();
+
+        impl: ?*Impl,
+
+        pub fn none() Self {
+            return Self{ .impl = null };
+        }
+
+        pub fn init(ptr: var) Self {
+            const T = @typeOf(ptr);
+            if (@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway, use .none)");
+            return Self{ .impl = @ptrCast(*Impl, ptr) };
+        }
+
+        pub fn implCast(self: *const Self, comptime T: type) *T {
+            if (@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
+            const aligned = @alignCast(@alignOf(T), self.impl);
+            return @ptrCast(*T, aligned);
+        }
+    };
+}

--- a/std/io.zig
+++ b/std/io.zig
@@ -428,7 +428,7 @@ test "io.BufferedInStream" {
         }
 
         fn readFn(in_stream: Stream, dest: []u8) Error!usize {
-            const self = in_stream.implCast(OneByteReadInStream);
+            const self = in_stream.implCast(@This());
             if (self.str.len <= self.curr or dest.len == 0)
                 return 0;
 
@@ -437,7 +437,7 @@ test "io.BufferedInStream" {
             return 1;
         }
         
-        pub fn inStream(self: *OneByteReadInStream) Stream {
+        pub fn inStream(self: *@This()) Stream {
             return Stream {
                 .impl = Stream.ifaceCast(self),
                 .readFn = readFn,
@@ -1065,7 +1065,7 @@ pub fn BitOutStream(endian: builtin.Endian, comptime Error: type) type {
 
 pub const BufferedAtomicFile = struct {
     atomic_file: os.AtomicFile,
-    file_stream: os.File.OutStream,
+    file_stream: os.File.OutStreamAdapter,
     buffered_stream: BufferedOutStream(os.File.WriteError),
     allocator: mem.Allocator,
 

--- a/std/io.zig
+++ b/std/io.zig
@@ -345,7 +345,7 @@ pub fn BufferedInStreamCustom(comptime buffer_size: usize, comptime Error: type)
         const Self = @This();
         const Stream = InStream(Error);
         
-        unbuffered_in_stream: *Stream,
+        unbuffered_in_stream: Stream,
 
         buffer: [buffer_size]u8,
         start_index: usize,
@@ -858,7 +858,7 @@ pub fn BufferedOutStreamCustom(comptime buffer_size: usize, comptime OutStreamEr
         buffer: [buffer_size]u8,
         index: usize,
 
-        pub fn init(unbuffered_out_stream: *Stream) Self {
+        pub fn init(unbuffered_out_stream: Stream) Self {
             return Self{
                 .unbuffered_out_stream = unbuffered_out_stream,
                 .buffer = undefined,
@@ -1196,11 +1196,11 @@ pub fn Deserializer(comptime endian: builtin.Endian, comptime packing: Packing, 
     return struct {
         const Self = @This();
 
-        in_stream: if (packing == .Bit) BitInStream(endian, Stream.Error) else *Stream,
+        in_stream: if (packing == .Bit) BitInStream(endian, Stream.Error) else Stream,
 
         pub const Stream = InStream(Error);
 
-        pub fn init(in_stream: *Stream) Self {
+        pub fn init(in_stream: Stream) Self {
             return Self{
                 .in_stream = switch (packing) {
                     .Bit => BitInStream(endian, Stream.Error).init(in_stream),
@@ -1407,11 +1407,11 @@ pub fn Serializer(comptime endian: builtin.Endian, comptime packing: Packing, co
     return struct {
         const Self = @This();
 
-        out_stream: if (packing == .Bit) BitOutStream(endian, Stream.Error) else *Stream,
+        out_stream: if (packing == .Bit) BitOutStream(endian, Stream.Error) else Stream,
 
         pub const Stream = OutStream(Error);
 
-        pub fn init(out_stream: *Stream) Self {
+        pub fn init(out_stream: Stream) Self {
             return Self{
                 .out_stream = switch (packing) {
                     .Bit => BitOutStream(endian, Stream.Error).init(out_stream),

--- a/std/io.zig
+++ b/std/io.zig
@@ -819,7 +819,7 @@ pub fn CountingOutStream(comptime OutStreamError: type) type {
         }
 
         fn writeFn(out_stream: Stream, bytes: []const u8) OutStreamError!void {
-            const self = out_stream.implCast(CountingOutStream);
+            const self = out_stream.implCast(Self);
             try self.child_stream.write(bytes);
             self.bytes_written += bytes.len;
         }
@@ -896,7 +896,7 @@ pub fn BufferedOutStreamCustom(comptime buffer_size: usize, comptime OutStreamEr
         pub fn outStream(self: *Self) Stream {
             return Stream {
                 .impl = Stream.ifaceCast(self),
-                .readFn = readFn,
+                .writeFn = writeFn,
             };
         }
     };
@@ -923,7 +923,7 @@ pub const BufferOutStream = struct {
     pub fn outStream(self: *BufferOutStream) Stream {
         return Stream {
             .impl = Stream.ifaceCast(self),
-            .readFn = readFn,
+            .writeFn = writeFn,
         };
     }
 };

--- a/std/io.zig
+++ b/std/io.zig
@@ -44,7 +44,7 @@ pub fn InStream(comptime ReadError: type) type {
         const Self = @This();
         pub const Error = ReadError;
         pub const InStreamImpl = ?*@OpaqueType();
-        
+
         impl: InStreamImpl,
 
         /// Return the number of bytes read. If the number read is smaller than buf.len, it
@@ -213,14 +213,14 @@ pub fn InStream(comptime ReadError: type) type {
             try self.readNoEof(@sliceToBytes(res[0..]));
             return res[0];
         }
-        
+
         /// Cast the original type to the implementation pointer
         pub fn ifaceCast(ptr: var) InStreamImpl {
             const T = @typeOf(ptr);
             if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway, use null)");
             return @ptrCast(InStreamImpl, ptr);
         }
-        
+
         /// Cast the implementation pointer back to the original type
         pub fn implCast(in: InStreamImpl, comptime T: type) *T {
             if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
@@ -236,7 +236,7 @@ pub fn OutStream(comptime WriteError: type) type {
         const Self = @This();
         pub const Error = WriteError;
         pub const OutStreamImpl = ?*@OpaqueType();
-        
+
         impl: OutStreamImpl,
 
         writeFn: fn (self: Self, bytes: []const u8) Error!void,
@@ -293,14 +293,14 @@ pub fn OutStream(comptime WriteError: type) type {
             mem.writeInt(T, &bytes, value, endian);
             return self.writeFn(self, bytes);
         }
-        
+
         /// Cast the original type to the implementation pointer
         pub fn ifaceCast(ptr: var) OutStreamImpl {
             const T = @typeOf(ptr);
             if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway, use null)");
             return @ptrCast(OutStreamImpl, ptr);
         }
-        
+
         /// Cast the implementation pointer back to the original type
         pub fn implCast(out: OutStreamImpl, comptime T: type) *T {
             if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
@@ -442,8 +442,8 @@ test "io.BufferedInStream" {
 
     const str = "This is a test";
     var one_byte_stream = OneByteReadInStream.init(str);
-    var buf_in_stream = BufferedInStream(OneByteReadInStream.Error).init(&one_byte_stream.stream);
-    const stream = &buf_in_stream.stream;
+    var buf_in_stream = BufferedInStream(OneByteReadInStream.Error).init(one_byte_stream.inStream());
+    const stream = buf_in_stream.inStream();
 
     const res = try stream.readAllAlloc(allocator, str.len + 1);
     testing.expectEqualSlices(u8, str, res);
@@ -748,7 +748,7 @@ test "io.SliceOutStream" {
 }
 
 var null_out_stream_state = NullOutStream.init();
-pub const null_out_stream = &null_out_stream_state.stream;
+pub const null_out_stream = null_out_stream_state.outStream();
 
 /// An OutStream that doesn't write to anything.
 pub const NullOutStream = struct {
@@ -1058,7 +1058,7 @@ pub const BufferedAtomicFile = struct {
 pub fn readLine(buf: *std.Buffer) ![]u8 {
     var stdin = try getStdIn();
     var stdin_stream = stdin.inStreamAdapter();
-    return readLineFrom(&stdin_stream.stream, buf);
+    return readLineFrom(stdin_stream.inStream(), buf);
 }
 
 /// Reads all characters until the next newline into buf, and returns
@@ -1100,7 +1100,7 @@ test "io.readLineFrom" {
 pub fn readLineSlice(slice: []u8) ![]u8 {
     var stdin = try getStdIn();
     var stdin_stream = stdin.inStreamAdapter();
-    return readLineSliceFrom(&stdin_stream.stream, slice);
+    return readLineSliceFrom(stdin_stream.inStream(), slice);
 }
 
 /// Reads all characters until the next newline into slice, and returns

--- a/std/io.zig
+++ b/std/io.zig
@@ -331,7 +331,7 @@ pub fn readFileAllocAligned(allocator: mem.Allocator, path: []const u8, comptime
     const buf = try allocator.alignedAlloc(u8, A, size);
     errdefer allocator.free(buf);
 
-    var adapter = file.inStream();
+    var adapter = file.inStreamAdapter();
     try adapter.stream.readNoEof(buf[0..size]);
     return buf;
 }
@@ -1034,7 +1034,7 @@ pub const BufferedAtomicFile = struct {
         self.atomic_file = try os.AtomicFile.init(dest_path, os.File.default_mode);
         errdefer self.atomic_file.deinit();
 
-        self.file_stream = self.atomic_file.file.outStream();
+        self.file_stream = self.atomic_file.file.outStreamAdapter();
         self.buffered_stream = BufferedOutStream(os.File.WriteError).init(&self.file_stream.stream);
         return self;
     }
@@ -1057,7 +1057,7 @@ pub const BufferedAtomicFile = struct {
 
 pub fn readLine(buf: *std.Buffer) ![]u8 {
     var stdin = try getStdIn();
-    var stdin_stream = stdin.inStream();
+    var stdin_stream = stdin.inStreamAdapter();
     return readLineFrom(&stdin_stream.stream, buf);
 }
 
@@ -1099,7 +1099,7 @@ test "io.readLineFrom" {
 
 pub fn readLineSlice(slice: []u8) ![]u8 {
     var stdin = try getStdIn();
-    var stdin_stream = stdin.inStream();
+    var stdin_stream = stdin.inStreamAdapter();
     return readLineSliceFrom(&stdin_stream.stream, slice);
 }
 

--- a/std/io.zig
+++ b/std/io.zig
@@ -76,7 +76,7 @@ pub fn InStream(comptime ReadError: type) type {
         /// memory would be greater than `max_size`, returns `error.StreamTooLong`.
         /// Caller owns returned memory.
         /// If this function returns an error, the contents from the stream read so far are lost.
-        pub fn readAllAlloc(self: *Self, allocator: *mem.Allocator, max_size: usize) ![]u8 {
+        pub fn readAllAlloc(self: *Self, allocator: mem.Allocator, max_size: usize) ![]u8 {
             var buf = Buffer.initNull(allocator);
             defer buf.deinit();
 
@@ -110,7 +110,7 @@ pub fn InStream(comptime ReadError: type) type {
         /// memory would be greater than `max_size`, returns `error.StreamTooLong`.
         /// Caller owns returned memory.
         /// If this function returns an error, the contents from the stream read so far are lost.
-        pub fn readUntilDelimiterAlloc(self: *Self, allocator: *mem.Allocator, delimiter: u8, max_size: usize) ![]u8 {
+        pub fn readUntilDelimiterAlloc(self: *Self, allocator: mem.Allocator, delimiter: u8, max_size: usize) ![]u8 {
             var buf = Buffer.initNull(allocator);
             defer buf.deinit();
 
@@ -282,12 +282,12 @@ pub fn writeFile(path: []const u8, data: []const u8) !void {
 }
 
 /// On success, caller owns returned buffer.
-pub fn readFileAlloc(allocator: *mem.Allocator, path: []const u8) ![]u8 {
+pub fn readFileAlloc(allocator: mem.Allocator, path: []const u8) ![]u8 {
     return readFileAllocAligned(allocator, path, @alignOf(u8));
 }
 
 /// On success, caller owns returned buffer.
-pub fn readFileAllocAligned(allocator: *mem.Allocator, path: []const u8, comptime A: u29) ![]align(A) u8 {
+pub fn readFileAllocAligned(allocator: mem.Allocator, path: []const u8, comptime A: u29) ![]align(A) u8 {
     var file = try File.openRead(path);
     defer file.close();
 
@@ -982,9 +982,9 @@ pub const BufferedAtomicFile = struct {
     atomic_file: os.AtomicFile,
     file_stream: os.File.OutStream,
     buffered_stream: BufferedOutStream(os.File.WriteError),
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
 
-    pub fn create(allocator: *mem.Allocator, dest_path: []const u8) !*BufferedAtomicFile {
+    pub fn create(allocator: mem.Allocator, dest_path: []const u8) !*BufferedAtomicFile {
         // TODO with well defined copy elision we don't need this allocation
         var self = try allocator.create(BufferedAtomicFile);
         self.* = BufferedAtomicFile{

--- a/std/io.zig
+++ b/std/io.zig
@@ -332,7 +332,7 @@ pub fn readFileAllocAligned(allocator: mem.Allocator, path: []const u8, comptime
     errdefer allocator.free(buf);
 
     var adapter = file.inStreamAdapter();
-    try adapter.stream.readNoEof(buf[0..size]);
+    try adapter.inStream().readNoEof(buf[0..size]);
     return buf;
 }
 
@@ -1084,7 +1084,7 @@ pub const BufferedAtomicFile = struct {
         errdefer self.atomic_file.deinit();
 
         self.file_stream = self.atomic_file.file.outStreamAdapter();
-        self.buffered_stream = BufferedOutStream(os.File.WriteError).init(&self.file_stream.stream);
+        self.buffered_stream = BufferedOutStream(os.File.WriteError).init(self.file_stream.outStream());
         return self;
     }
 
@@ -1138,7 +1138,7 @@ test "io.readLineFrom" {
         \\Line 22
         \\Line 333
     );
-    const stream = &mem_stream.stream;
+    const stream = mem_stream.inStream();
 
     testing.expectEqualSlices(u8, "Line 1", try readLineFrom(stream, &buf));
     testing.expectEqualSlices(u8, "Line 22", try readLineFrom(stream, &buf));
@@ -1169,7 +1169,7 @@ test "io.readLineSliceFrom" {
         \\Line 22
         \\Line 333
     );
-    const stream = &mem_stream.stream;
+    const stream = mem_stream.inStream();
 
     testing.expectEqualSlices(u8, "Line 1", try readLineSliceFrom(stream, buf[0..]));
     testing.expectError(error.OutOfMemory, readLineSliceFrom(stream, buf[0..]));

--- a/std/io.zig
+++ b/std/io.zig
@@ -222,7 +222,7 @@ pub fn InStream(comptime ReadError: type) type {
         }
 
         /// Cast the implementation pointer back to the original type
-        pub fn implCast(in: InStreamImpl, comptime T: type) *T {
+        pub fn implCast(in: Self, comptime T: type) *T {
             if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
             assert(in.impl != null);
             const aligned = @alignCast(@alignOf(T), in.impl);
@@ -302,7 +302,7 @@ pub fn OutStream(comptime WriteError: type) type {
         }
 
         /// Cast the implementation pointer back to the original type
-        pub fn implCast(out: OutStreamImpl, comptime T: type) *T {
+        pub fn implCast(out: Self, comptime T: type) *T {
             if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
             assert(out.impl != null);
             const aligned = @alignCast(@alignOf(T), out.impl);
@@ -759,7 +759,7 @@ pub const SliceOutStream = struct {
     pub fn outStream(self: *SliceOutStream) Stream {
         return Stream {
             .impl = Stream.ifaceCast(self),
-            .readFn = readFn,
+            .writeFn = writeFn,
         };
     }
 };
@@ -790,7 +790,7 @@ pub const NullOutStream = struct {
     pub fn outStream(self: *NullOutStream) Stream {
         return Stream {
             .impl = null,
-            .readFn = readFn,
+            .writeFn = writeFn,
         };
     }
 };
@@ -827,7 +827,7 @@ pub fn CountingOutStream(comptime OutStreamError: type) type {
         pub fn outStream(self: *Self) Stream {
             return Stream {
                 .impl = Stream.ifaceCast(self),
-                .readFn = readFn,
+                .writeFn = writeFn,
             };
         }
     };
@@ -905,7 +905,6 @@ pub fn BufferedOutStreamCustom(comptime buffer_size: usize, comptime OutStreamEr
 /// Implementation of OutStream trait for Buffer
 pub const BufferOutStream = struct {
     buffer: *Buffer,
-    stream: Stream,
 
     pub const Error = error{OutOfMemory};
     pub const Stream = OutStream(Error);

--- a/std/io.zig
+++ b/std/io.zig
@@ -402,7 +402,7 @@ test "io.BufferedInStream" {
     };
 
     var buf: [100]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(buf[0..]).allocator;
+    const allocator = std.heap.FixedBufferAllocator.init(buf[0..]).allocator();
 
     const str = "This is a test";
     var one_byte_stream = OneByteReadInStream.init(str);
@@ -1045,7 +1045,7 @@ pub fn readLineFrom(stream: var, buf: *std.Buffer) ![]u8 {
 
 test "io.readLineFrom" {
     var bytes: [128]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(bytes[0..]).allocator;
+    const allocator = std.heap.FixedBufferAllocator.init(bytes[0..]).allocator();
 
     var buf = try std.Buffer.initSize(allocator, 0);
     var mem_stream = SliceInStream.init(

--- a/std/io.zig
+++ b/std/io.zig
@@ -43,9 +43,9 @@ pub fn InStream(comptime ReadError: type) type {
     return struct {
         const Self = @This();
         pub const Error = ReadError;
-        pub const InStreamImpl = ?*@OpaqueType();
+        pub const Iface = std.Interface();
 
-        impl: InStreamImpl,
+        iface: Iface,
 
         /// Return the number of bytes read. If the number read is smaller than buf.len, it
         /// means the stream reached the end. Reaching the end of a stream is not an error
@@ -213,21 +213,6 @@ pub fn InStream(comptime ReadError: type) type {
             try self.readNoEof(@sliceToBytes(res[0..]));
             return res[0];
         }
-
-        /// Cast the original type to the implementation pointer
-        pub fn ifaceCast(ptr: var) InStreamImpl {
-            const T = @typeOf(ptr);
-            if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway, use null)");
-            return @ptrCast(InStreamImpl, ptr);
-        }
-
-        /// Cast the implementation pointer back to the original type
-        pub fn implCast(in: Self, comptime T: type) *T {
-            if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
-            assert(in.impl != null);
-            const aligned = @alignCast(@alignOf(T), in.impl);
-            return @ptrCast(*T, aligned);
-        }
     };
 }
 
@@ -235,9 +220,9 @@ pub fn OutStream(comptime WriteError: type) type {
     return struct {
         const Self = @This();
         pub const Error = WriteError;
-        pub const OutStreamImpl = ?*@OpaqueType();
+        pub const Iface = std.Interface();
 
-        impl: OutStreamImpl,
+        iface: Iface,
 
         writeFn: fn (self: Self, bytes: []const u8) Error!void,
 
@@ -293,21 +278,6 @@ pub fn OutStream(comptime WriteError: type) type {
             mem.writeInt(T, &bytes, value, endian);
             return self.writeFn(self, bytes);
         }
-
-        /// Cast the original type to the implementation pointer
-        pub fn ifaceCast(ptr: var) OutStreamImpl {
-            const T = @typeOf(ptr);
-            if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway, use null)");
-            return @ptrCast(OutStreamImpl, ptr);
-        }
-
-        /// Cast the implementation pointer back to the original type
-        pub fn implCast(out: Self, comptime T: type) *T {
-            if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
-            assert(out.impl != null);
-            const aligned = @alignCast(@alignOf(T), out.impl);
-            return @ptrCast(*T, aligned);
-        }
     };
 }
 
@@ -344,7 +314,7 @@ pub fn BufferedInStreamCustom(comptime buffer_size: usize, comptime Error: type)
     return struct {
         const Self = @This();
         const Stream = InStream(Error);
-        
+
         unbuffered_in_stream: Stream,
 
         buffer: [buffer_size]u8,
@@ -366,7 +336,7 @@ pub fn BufferedInStreamCustom(comptime buffer_size: usize, comptime Error: type)
         }
 
         fn readFn(in_stream: Stream, dest: []u8) !usize {
-            const self = in_stream.implCast(Self);
+            const self = in_stream.iface.implCast(Self);
 
             var dest_index: usize = 0;
             while (true) {
@@ -402,10 +372,10 @@ pub fn BufferedInStreamCustom(comptime buffer_size: usize, comptime Error: type)
                 dest_index += copy_amount;
             }
         }
-        
+
         pub fn inStream(self: *Self) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .readFn = readFn,
             };
         }
@@ -428,7 +398,7 @@ test "io.BufferedInStream" {
         }
 
         fn readFn(in_stream: Stream, dest: []u8) Error!usize {
-            const self = in_stream.implCast(@This());
+            const self = in_stream.iface.implCast(@This());
             if (self.str.len <= self.curr or dest.len == 0)
                 return 0;
 
@@ -436,10 +406,10 @@ test "io.BufferedInStream" {
             self.curr += 1;
             return 1;
         }
-        
+
         pub fn inStream(self: *@This()) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .readFn = readFn,
             };
         }
@@ -496,7 +466,7 @@ pub fn PeekStream(comptime buffer_size: usize, comptime InStreamError: type) typ
         }
 
         fn readFn(in_stream: Stream, dest: []u8) Error!usize {
-            const self = in_stream.implCast(Self);
+            const self = in_stream.iface.implCast(Self);
 
             // copy over anything putBack()'d
             var pos: usize = 0;
@@ -518,10 +488,10 @@ pub fn PeekStream(comptime buffer_size: usize, comptime InStreamError: type) typ
             self.at_end = (read < left);
             return pos + read;
         }
-        
+
         pub fn inStream(self: *Self) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .readFn = readFn,
             };
         }
@@ -544,7 +514,7 @@ pub const SliceInStream = struct {
     }
 
     fn readFn(in_stream: Stream, dest: []u8) Error!usize {
-        const self = in_stream.implCast(Self);
+        const self = in_stream.iface.implCast(Self);
         const size = math.min(dest.len, self.slice.len - self.pos);
         const end = self.pos + size;
 
@@ -553,10 +523,10 @@ pub const SliceInStream = struct {
 
         return size;
     }
-    
+
     pub fn inStream(self: *Self) Stream {
-        return Stream {
-            .impl = Stream.ifaceCast(self),
+        return Stream{
+            .iface = Stream.Iface.init(self),
             .readFn = readFn,
         };
     }
@@ -688,7 +658,7 @@ pub fn BitInStream(endian: builtin.Endian, comptime Error: type) type {
         }
 
         pub fn read(self_stream: Stream, buffer: []u8) Error!usize {
-            var self = self_stream.implCast(Self);
+            var self = self_stream.iface.implCast(Self);
 
             var out_bits: usize = undefined;
             var out_bits_total = usize(0);
@@ -704,10 +674,10 @@ pub fn BitInStream(endian: builtin.Endian, comptime Error: type) type {
 
             return self.in_stream.read(buffer);
         }
-        
+
         pub fn inStream(self: *Self) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .readFn = readFn,
             };
         }
@@ -739,7 +709,7 @@ pub const SliceOutStream = struct {
     }
 
     fn writeFn(out_stream: Stream, bytes: []const u8) Error!void {
-        const self = out_stream.implCast(SliceOutStream);
+        const self = out_stream.iface.implCast(SliceOutStream);
 
         assert(self.pos <= self.slice.len);
 
@@ -755,10 +725,10 @@ pub const SliceOutStream = struct {
             return Error.OutOfSpace;
         }
     }
-    
+
     pub fn outStream(self: *SliceOutStream) Stream {
-        return Stream {
-            .impl = Stream.ifaceCast(self),
+        return Stream{
+            .iface = Stream.Iface.init(self),
             .writeFn = writeFn,
         };
     }
@@ -786,10 +756,10 @@ pub const NullOutStream = struct {
     }
 
     fn writeFn(out_stream: Stream, bytes: []const u8) Error!void {}
-    
+
     pub fn outStream(self: *NullOutStream) Stream {
-        return Stream {
-            .impl = null,
+        return Stream{
+            .iface = Stream.Iface.none(),
             .writeFn = writeFn,
         };
     }
@@ -819,14 +789,14 @@ pub fn CountingOutStream(comptime OutStreamError: type) type {
         }
 
         fn writeFn(out_stream: Stream, bytes: []const u8) OutStreamError!void {
-            const self = out_stream.implCast(Self);
+            const self = out_stream.iface.implCast(Self);
             try self.child_stream.write(bytes);
             self.bytes_written += bytes.len;
         }
-        
+
         pub fn outStream(self: *Self) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .writeFn = writeFn,
             };
         }
@@ -872,7 +842,7 @@ pub fn BufferedOutStreamCustom(comptime buffer_size: usize, comptime OutStreamEr
         }
 
         fn writeFn(out_stream: Stream, bytes: []const u8) !void {
-            const self = out_stream.implCast(Self);
+            const self = out_stream.iface.implCast(Self);
 
             if (bytes.len >= self.buffer.len) {
                 try self.flush();
@@ -892,10 +862,10 @@ pub fn BufferedOutStreamCustom(comptime buffer_size: usize, comptime OutStreamEr
                 src_index += copy_amt;
             }
         }
-        
+
         pub fn outStream(self: *Self) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .writeFn = writeFn,
             };
         }
@@ -916,13 +886,13 @@ pub const BufferOutStream = struct {
     }
 
     fn writeFn(out_stream: Stream, bytes: []const u8) !void {
-        const self = out_stream.implCast(BufferOutStream);
+        const self = out_stream.iface.implCast(BufferOutStream);
         return self.buffer.append(bytes);
     }
-    
+
     pub fn outStream(self: *BufferOutStream) Stream {
-        return Stream {
-            .impl = Stream.ifaceCast(self),
+        return Stream{
+            .iface = Stream.Iface.init(self),
             .writeFn = writeFn,
         };
     }
@@ -1041,7 +1011,7 @@ pub fn BitOutStream(endian: builtin.Endian, comptime Error: type) type {
         }
 
         pub fn write(self_stream: Stream, buffer: []const u8) Error!void {
-            var self = self_stream.implCast(Self);
+            var self = self_stream.iface.implCast(Self);
 
             //@NOTE: I'm not sure this is a good idea, maybe flushBits should be forced
             if (self.bit_count > 0) {
@@ -1052,10 +1022,10 @@ pub fn BitOutStream(endian: builtin.Endian, comptime Error: type) type {
 
             return self.out_stream.write(buffer);
         }
-        
+
         pub fn outStream(self: *Self) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .readFn = readFn,
             };
         }

--- a/std/io/c_out_stream.zig
+++ b/std/io/c_out_stream.zig
@@ -19,7 +19,7 @@ pub const COutStream = struct {
     }
 
     fn writeFn(out_stream: Stream, bytes: []const u8) Error!void {
-        const self = out_stream.implCast(COutStream);
+        const self = out_stream.iface.implCast(COutStream);
         const amt_written = std.c.fwrite(bytes.ptr, 1, bytes.len, self.c_file);
         if (amt_written == bytes.len) return;
         // TODO errno on windows. should we have a posix layer for windows?
@@ -43,10 +43,10 @@ pub const COutStream = struct {
             else => return std.os.unexpectedErrorPosix(@intCast(usize, errno)),
         }
     }
-    
+
     pub fn outStream(self: *COutStream) Stream {
-        return Stream {
-            .impl = Stream.ifaceCast(self),
+        return Stream{
+            .iface = Stream.Iface.init(self),
             .writeFn = writeFn,
         };
     }

--- a/std/io/seekable_stream.zig
+++ b/std/io/seekable_stream.zig
@@ -6,27 +6,43 @@ pub fn SeekableStream(comptime SeekErrorType: type, comptime GetSeekPosErrorType
         const Self = @This();
         pub const SeekError = SeekErrorType;
         pub const GetSeekPosError = GetSeekPosErrorType;
+        pub const SeekableStreamImpl = ?*@OpaqueType();
 
-        seekToFn: fn (self: *Self, pos: u64) SeekError!void,
-        seekForwardFn: fn (self: *Self, pos: i64) SeekError!void,
+        seekToFn: fn (self: Self, pos: u64) SeekError!void,
+        seekForwardFn: fn (self: Self, pos: i64) SeekError!void,
 
-        getPosFn: fn (self: *Self) GetSeekPosError!u64,
-        getEndPosFn: fn (self: *Self) GetSeekPosError!u64,
+        getPosFn: fn (self: Self) GetSeekPosError!u64,
+        getEndPosFn: fn (self: Self) GetSeekPosError!u64,
 
-        pub fn seekTo(self: *Self, pos: u64) SeekError!void {
+        pub fn seekTo(self: Self, pos: u64) SeekError!void {
             return self.seekToFn(self, pos);
         }
 
-        pub fn seekForward(self: *Self, amt: i64) SeekError!void {
+        pub fn seekForward(self: Self, amt: i64) SeekError!void {
             return self.seekForwardFn(self, amt);
         }
 
-        pub fn getEndPos(self: *Self) GetSeekPosError!u64 {
+        pub fn getEndPos(self: Self) GetSeekPosError!u64 {
             return self.getEndPosFn(self);
         }
 
-        pub fn getPos(self: *Self) GetSeekPosError!u64 {
+        pub fn getPos(self: Self) GetSeekPosError!u64 {
             return self.getPosFn(self);
+        }
+        
+        /// Cast the original type to the implementation pointer
+        pub fn ifaceCast(ptr: var) SeekableStreamImpl {
+            const T = @typeOf(ptr);
+            if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway, use null)");
+            return @ptrCast(SeekableStreamImpl, ptr);
+        }
+        
+        /// Cast the implementation pointer back to the original type
+        pub fn implCast(seek: SeekableStreamImpl, comptime T: type) *T {
+            if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
+            assert(seek.impl != null);
+            const aligned = @alignCast(@alignOf(T), seek.impl);
+            return @ptrCast(*T, aligned);
         }
     };
 }
@@ -39,9 +55,6 @@ pub const SliceSeekableInStream = struct {
     pub const Stream = InStream(Error);
     pub const SeekableInStream = SeekableStream(SeekError, GetSeekPosError);
 
-    pub stream: Stream,
-    pub seekable_stream: SeekableInStream,
-
     pos: usize,
     slice: []const u8,
 
@@ -49,18 +62,11 @@ pub const SliceSeekableInStream = struct {
         return Self{
             .slice = slice,
             .pos = 0,
-            .stream = Stream{ .readFn = readFn },
-            .seekable_stream = SeekableInStream{
-                .seekToFn = seekToFn,
-                .seekForwardFn = seekForwardFn,
-                .getEndPosFn = getEndPosFn,
-                .getPosFn = getPosFn,
-            },
         };
     }
 
-    fn readFn(in_stream: *Stream, dest: []u8) Error!usize {
-        const self = @fieldParentPtr(Self, "stream", in_stream);
+    fn readFn(in_stream: Stream, dest: []u8) Error!usize {
+        const self = in_stream.implCast(SliceSeekableInStream);
         const size = std.math.min(dest.len, self.slice.len - self.pos);
         const end = self.pos + size;
 
@@ -70,15 +76,15 @@ pub const SliceSeekableInStream = struct {
         return size;
     }
 
-    fn seekToFn(in_stream: *SeekableInStream, pos: u64) SeekError!void {
-        const self = @fieldParentPtr(Self, "seekable_stream", in_stream);
+    fn seekToFn(in_stream: SeekableInStream, pos: u64) SeekError!void {
+        const self = in_stream.implCast(SliceSeekableInStream);
         const usize_pos = @intCast(usize, pos);
         if (usize_pos >= self.slice.len) return error.EndOfStream;
         self.pos = usize_pos;
     }
 
-    fn seekForwardFn(in_stream: *SeekableInStream, amt: i64) SeekError!void {
-        const self = @fieldParentPtr(Self, "seekable_stream", in_stream);
+    fn seekForwardFn(in_stream: SeekableInStream, amt: i64) SeekError!void {
+        const self = in_stream.implCast(SliceSeekableInStream);
 
         if (amt < 0) {
             const abs_amt = @intCast(usize, -amt);
@@ -91,13 +97,30 @@ pub const SliceSeekableInStream = struct {
         }
     }
 
-    fn getEndPosFn(in_stream: *SeekableInStream) GetSeekPosError!u64 {
-        const self = @fieldParentPtr(Self, "seekable_stream", in_stream);
+    fn getEndPosFn(in_stream: SeekableInStream) GetSeekPosError!u64 {
+        const self = in_stream.implCast(SliceSeekableInStream);
         return @intCast(u64, self.slice.len);
     }
 
-    fn getPosFn(in_stream: *SeekableInStream) GetSeekPosError!u64 {
-        const self = @fieldParentPtr(Self, "seekable_stream", in_stream);
+    fn getPosFn(in_stream: SeekableInStream) GetSeekPosError!u64 {
+        const self = in_stream.implCast(SliceSeekableInStream);
         return @intCast(u64, self.pos);
+    }
+    
+    pub fn inStream(self: *Self) Stream {
+        return Stream {
+            .impl = Stream.ifaceCast(self),
+            .readFn = readFn,
+        };
+    }
+    
+    pub fn seekableStream(self: Self) SeekableInStream {
+        return SeekableInStream {
+            .impl = Stream.ifaceCast(self),
+            .seekToFn = seekToFn,
+            .seekForwardFn = seekForwardFn,
+            .getPosFn = getPosFn,
+            .getEndPosFn = getEndPosFn,
+        };
     }
 };

--- a/std/io/test.zig
+++ b/std/io/test.zig
@@ -49,7 +49,7 @@ test "write a file, read it, then delete it" {
 
         var file_in_stream = file.inStreamAdapter();
         var buf_stream = io.BufferedInStream(os.File.ReadError).init(file_in_stream.inStream());
-        const st = buf_stream.outStream();
+        const st = buf_stream.inStream();
         const contents = try st.readAllAlloc(allocator, 2 * 1024);
         defer allocator.free(contents);
 

--- a/std/io/test.zig
+++ b/std/io/test.zig
@@ -15,7 +15,7 @@ test "write a file, read it, then delete it" {
 
     var data: [1024]u8 = undefined;
     var prng = DefaultPrng.init(1234);
-    prng.random.bytes(data[0..]);
+    prng.random().bytes(data[0..]);
     const tmp_file_name = "temp_test_file.txt";
     {
         var file = try os.File.openWrite(tmp_file_name);

--- a/std/io/test.zig
+++ b/std/io/test.zig
@@ -11,7 +11,7 @@ const builtin = @import("builtin");
 
 test "write a file, read it, then delete it" {
     var raw_bytes: [200 * 1024]u8 = undefined;
-    var allocator = &std.heap.FixedBufferAllocator.init(raw_bytes[0..]).allocator;
+    var allocator = std.heap.FixedBufferAllocator.init(raw_bytes[0..]).allocator();
 
     var data: [1024]u8 = undefined;
     var prng = DefaultPrng.init(1234);
@@ -62,7 +62,7 @@ test "write a file, read it, then delete it" {
 
 test "BufferOutStream" {
     var bytes: [100]u8 = undefined;
-    var allocator = &std.heap.FixedBufferAllocator.init(bytes[0..]).allocator;
+    var allocator = std.heap.FixedBufferAllocator.init(bytes[0..]).allocator();
 
     var buffer = try std.Buffer.initSize(allocator, 0);
     var buf_stream = &std.io.BufferOutStream.init(&buffer).stream;

--- a/std/io/test.zig
+++ b/std/io/test.zig
@@ -21,7 +21,7 @@ test "write a file, read it, then delete it" {
         var file = try os.File.openWrite(tmp_file_name);
         defer file.close();
 
-        var file_out_stream = file.outStream();
+        var file_out_stream = file.outStreamAdapter();
         var buf_stream = io.BufferedOutStream(os.File.WriteError).init(&file_out_stream.stream);
         const st = &buf_stream.stream;
         try st.print("begin");
@@ -47,7 +47,7 @@ test "write a file, read it, then delete it" {
         const expected_file_size = "begin".len + data.len + "end".len;
         expect(file_size == expected_file_size);
 
-        var file_in_stream = file.inStream();
+        var file_in_stream = file.inStreamAdapter();
         var buf_stream = io.BufferedInStream(os.File.ReadError).init(&file_in_stream.stream);
         const st = &buf_stream.stream;
         const contents = try st.readAllAlloc(allocator, 2 * 1024);
@@ -276,7 +276,7 @@ test "BitStreams with File Stream" {
         var file = try os.File.openWrite(tmp_file_name);
         defer file.close();
 
-        var file_out = file.outStream();
+        var file_out = file.outStreamAdapter();
         var file_out_stream = &file_out.stream;
         const OutError = os.File.WriteError;
         var bit_stream = io.BitOutStream(builtin.endian, OutError).init(file_out_stream);
@@ -293,7 +293,7 @@ test "BitStreams with File Stream" {
         var file = try os.File.openRead(tmp_file_name);
         defer file.close();
 
-        var file_in = file.inStream();
+        var file_in = file.inStreamAdapter();
         var file_in_stream = &file_in.stream;
         const InError = os.File.ReadError;
         var bit_stream = io.BitInStream(builtin.endian, InError).init(file_in_stream);

--- a/std/json.zig
+++ b/std/json.zig
@@ -1129,7 +1129,7 @@ pub const Value = union(enum) {
 
 // A non-stream JSON parser which constructs a tree of Value's.
 pub const Parser = struct {
-    allocator: *Allocator,
+    allocator: Allocator,
     state: State,
     copy_strings: bool,
     // Stores parent nodes and un-combined Values.
@@ -1142,7 +1142,7 @@ pub const Parser = struct {
         Simple,
     };
 
-    pub fn init(allocator: *Allocator, copy_strings: bool) Parser {
+    pub fn init(allocator: Allocator, copy_strings: bool) Parser {
         return Parser{
             .allocator = allocator,
             .state = State.Simple,
@@ -1180,7 +1180,7 @@ pub const Parser = struct {
 
     // Even though p.allocator exists, we take an explicit allocator so that allocation state
     // can be cleaned up on error correctly during a `parse` on call.
-    fn transition(p: *Parser, allocator: *Allocator, input: []const u8, i: usize, token: Token) !void {
+    fn transition(p: *Parser, allocator: Allocator, input: []const u8, i: usize, token: Token) !void {
         switch (p.state) {
             State.ObjectKey => switch (token.id) {
                 Token.Id.ObjectEnd => {
@@ -1334,7 +1334,7 @@ pub const Parser = struct {
         }
     }
 
-    fn parseString(p: *Parser, allocator: *Allocator, token: Token, input: []const u8, i: usize) !Value {
+    fn parseString(p: *Parser, allocator: Allocator, token: Token, input: []const u8, i: usize) !Value {
         // TODO: We don't strictly have to copy values which do not contain any escape
         // characters if flagged with the option.
         const slice = token.slice(input, i);

--- a/std/json.zig
+++ b/std/json.zig
@@ -1167,7 +1167,7 @@ pub const Parser = struct {
         errdefer arena.deinit();
 
         while (try s.next()) |token| {
-            try p.transition(&arena.allocator, input, s.i - 1, token);
+            try p.transition(arena.allocator(), input, s.i - 1, token);
         }
 
         debug.assert(p.stack.len == 1);

--- a/std/linked_list.zig
+++ b/std/linked_list.zig
@@ -190,7 +190,7 @@ pub fn LinkedList(comptime T: type) type {
         ///
         /// Returns:
         ///     A pointer to the new node.
-        pub fn allocateNode(list: *Self, allocator: *Allocator) !*Node {
+        pub fn allocateNode(list: *Self, allocator: Allocator) !*Node {
             return allocator.create(Node);
         }
 
@@ -199,7 +199,7 @@ pub fn LinkedList(comptime T: type) type {
         /// Arguments:
         ///     node: Pointer to the node to deallocate.
         ///     allocator: Dynamic memory allocator.
-        pub fn destroyNode(list: *Self, node: *Node, allocator: *Allocator) void {
+        pub fn destroyNode(list: *Self, node: *Node, allocator: Allocator) void {
             allocator.destroy(node);
         }
 
@@ -211,7 +211,7 @@ pub fn LinkedList(comptime T: type) type {
         ///
         /// Returns:
         ///     A pointer to the new node.
-        pub fn createNode(list: *Self, data: T, allocator: *Allocator) !*Node {
+        pub fn createNode(list: *Self, data: T, allocator: Allocator) !*Node {
             var node = try list.allocateNode(allocator);
             node.* = Node.init(data);
             return node;

--- a/std/math/big/int.zig
+++ b/std/math/big/int.zig
@@ -32,7 +32,7 @@ pub const Int = struct {
     pub const default_capacity = 4;
 
     /// Allocator used by the Int when requesting memory.
-    allocator: ?*Allocator,
+    allocator: ?Allocator,
 
     /// Raw digits. These are:
     ///
@@ -49,14 +49,14 @@ pub const Int = struct {
 
     /// Creates a new Int. default_capacity limbs will be allocated immediately.
     /// Int will be zeroed.
-    pub fn init(allocator: *Allocator) !Int {
+    pub fn init(allocator: Allocator) !Int {
         return try Int.initCapacity(allocator, default_capacity);
     }
 
     /// Creates a new Int. Int will be set to `value`.
     ///
     /// This is identical to an `init`, followed by a `set`.
-    pub fn initSet(allocator: *Allocator, value: var) !Int {
+    pub fn initSet(allocator: Allocator, value: var) !Int {
         var s = try Int.init(allocator);
         try s.set(value);
         return s;
@@ -64,7 +64,7 @@ pub const Int = struct {
 
     /// Creates a new Int with a specific capacity. If capacity < default_capacity then the
     /// default capacity will be used instead.
-    pub fn initCapacity(allocator: *Allocator, capacity: usize) !Int {
+    pub fn initCapacity(allocator: Allocator, capacity: usize) !Int {
         return Int{
             .allocator = allocator,
             .metadata = 1,
@@ -432,7 +432,7 @@ pub const Int = struct {
     /// Converts self to a string in the requested base. Memory is allocated from the provided
     /// allocator and not the one present in self.
     /// TODO make this call format instead of the other way around
-    pub fn toString(self: Int, allocator: *Allocator, base: u8) ![]const u8 {
+    pub fn toString(self: Int, allocator: Allocator, base: u8) ![]const u8 {
         if (base < 2 or base > 16) {
             return error.InvalidBase;
         }
@@ -952,7 +952,7 @@ pub const Int = struct {
     // Handbook of Applied Cryptography, 14.20
     //
     // x = qy + r where 0 <= r < y
-    fn divN(allocator: *Allocator, q: *Int, r: *Int, x: *Int, y: *Int) !void {
+    fn divN(allocator: Allocator, q: *Int, r: *Int, x: *Int, y: *Int) !void {
         debug.assert(y.len() >= 2);
         debug.assert(x.len() >= y.len());
         debug.assert(q.limbs.len >= x.len() + y.len() - 1);

--- a/std/math/big/int.zig
+++ b/std/math/big/int.zig
@@ -1199,7 +1199,7 @@ pub const Int = struct {
 
 var buffer: [64 * 8192]u8 = undefined;
 var fixed = std.heap.FixedBufferAllocator.init(buffer[0..]);
-const al = &fixed.allocator;
+const al = fixed.allocator();
 
 test "big.int comptime_int set" {
     comptime var s = 0xefffffff00000001eeeeeeefaaaaaaab;

--- a/std/math/big/rational.zig
+++ b/std/math/big/rational.zig
@@ -30,7 +30,7 @@ pub const Rational = struct {
 
     /// Create a new Rational. A small amount of memory will be allocated on initialization.
     /// This will be 2 * Int.default_capacity.
-    pub fn init(a: *Allocator) !Rational {
+    pub fn init(a: Allocator) !Rational {
         return Rational{
             .p = try Int.init(a),
             .q = try Int.initSet(a, 1),

--- a/std/math/big/rational.zig
+++ b/std/math/big/rational.zig
@@ -758,7 +758,7 @@ test "big.rational set/to Float round-trip" {
     var prng = std.rand.DefaultPrng.init(0x5EED);
     var i: usize = 0;
     while (i < 512) : (i += 1) {
-        const r = prng.random.float(f64);
+        const r = prng.random().float(f64);
         try a.setFloat(f64, r);
         testing.expect((try a.toFloat(f64)) == r);
     }

--- a/std/math/big/rational.zig
+++ b/std/math/big/rational.zig
@@ -589,7 +589,7 @@ fn gcdLehmer(r: *Int, xa: Int, ya: Int) !void {
 
 var buffer: [64 * 8192]u8 = undefined;
 var fixed = std.heap.FixedBufferAllocator.init(buffer[0..]);
-var al = &fixed.allocator;
+var al = fixed.allocator();
 
 test "big.rational gcd non-one small" {
     var a = try Int.initSet(al, 17);

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -11,11 +11,11 @@ const testing = std.testing;
 //@NOTE: The Fns shouldn't need to take `*const Allocator` once coroutine rewrite (#2377) is complete.
 // just `Allocator`.
 pub const Allocator = struct {
-    pub const AllocatorImpl = ?*@OpaqueType();
     pub const Error = error{OutOfMemory};
-    
-    impl: AllocatorImpl,
-    
+    pub const Iface = std.Interface();
+
+    iface: Iface,
+
     /// Realloc is used to modify the size or alignment of an existing allocation,
     /// as well as to provide the allocator with an opportunity to move an allocation
     /// to a better location.
@@ -210,21 +210,6 @@ pub const Allocator = struct {
         const non_const_ptr = @intToPtr([*]u8, @ptrToInt(bytes.ptr));
         const shrink_result = self.shrinkFn(&self, non_const_ptr[0..bytes.len], Slice.alignment, 0, 1);
         assert(shrink_result.len == 0);
-    }
-    
-    /// Cast the original type to the implementation pointer
-    pub fn ifaceCast(ptr: var) AllocatorImpl {
-        const T = @typeOf(ptr);
-        if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway, use null)");
-        return @ptrCast(AllocatorImpl, ptr);
-    }
-
-    /// Cast the implementation pointer back to the original type
-    pub fn implCast(allocator: Allocator, comptime T: type) *T {
-        if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
-        debug.assert(allocator.impl != null);
-        const aligned = @alignCast(@alignOf(T), allocator.impl);
-        return @ptrCast(*T, aligned);
     }
 };
 

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -1003,7 +1003,7 @@ pub fn join(allocator: Allocator, separator: []const u8, slices: []const []const
 
 test "mem.join" {
     var buf: [1024]u8 = undefined;
-    const a = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+    const a = std.heap.FixedBufferAllocator.init(&buf).allocator();
     testing.expect(eql(u8, try join(a, ",", [][]const u8{ "a", "b", "c" }), "a,b,c"));
     testing.expect(eql(u8, try join(a, ",", [][]const u8{"a"}), "a"));
     testing.expect(eql(u8, try join(a, ",", [][]const u8{ "a", "", "b", "", "c" }), "a,,b,,c"));

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -366,7 +366,7 @@ pub fn allEqual(comptime T: type, slice: []const T, scalar: T) bool {
 }
 
 /// Copies ::m to newly allocated memory. Caller is responsible to free it.
-pub fn dupe(allocator: *Allocator, comptime T: type, m: []const T) ![]T {
+pub fn dupe(allocator: Allocator, comptime T: type, m: []const T) ![]T {
     const new_buf = try allocator.alloc(T, m.len);
     copy(T, new_buf, m);
     return new_buf;
@@ -975,7 +975,7 @@ pub const SplitIterator = struct {
 
 /// Naively combines a series of slices with a separator.
 /// Allocates memory for the result, which must be freed by the caller.
-pub fn join(allocator: *Allocator, separator: []const u8, slices: []const []const u8) ![]u8 {
+pub fn join(allocator: Allocator, separator: []const u8, slices: []const []const u8) ![]u8 {
     if (slices.len == 0) return (([*]u8)(undefined))[0..0];
 
     const total_len = blk: {

--- a/std/mutex.zig
+++ b/std/mutex.zig
@@ -133,8 +133,8 @@ test "std.Mutex" {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var plenty_of_memory = try direct_allocator.allocator.alloc(u8, 300 * 1024);
-    defer direct_allocator.allocator.free(plenty_of_memory);
+    var plenty_of_memory = try direct_allocator.allocator().alloc(u8, 300 * 1024);
+    defer direct_allocator.allocator().free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
     var a = fixed_buffer_allocator.allocator();

--- a/std/mutex.zig
+++ b/std/mutex.zig
@@ -137,7 +137,7 @@ test "std.Mutex" {
     defer direct_allocator.allocator.free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
-    var a = &fixed_buffer_allocator.allocator;
+    var a = fixed_buffer_allocator.allocator();
 
     var mutex = Mutex.init();
     defer mutex.deinit();

--- a/std/os.zig
+++ b/std/os.zig
@@ -575,7 +575,7 @@ pub fn posixDup2(old_fd: i32, new_fd: i32) !void {
     }
 }
 
-pub fn createNullDelimitedEnvMap(allocator: *Allocator, env_map: *const BufMap) ![]?[*]u8 {
+pub fn createNullDelimitedEnvMap(allocator: Allocator, env_map: *const BufMap) ![]?[*]u8 {
     const envp_count = env_map.count();
     const envp_buf = try allocator.alloc(?[*]u8, envp_count + 1);
     mem.set(?[*]u8, envp_buf, null);
@@ -598,7 +598,7 @@ pub fn createNullDelimitedEnvMap(allocator: *Allocator, env_map: *const BufMap) 
     return envp_buf;
 }
 
-pub fn freeNullDelimitedEnvMap(allocator: *Allocator, envp_buf: []?[*]u8) void {
+pub fn freeNullDelimitedEnvMap(allocator: Allocator, envp_buf: []?[*]u8) void {
     for (envp_buf) |env| {
         const env_buf = if (env) |ptr| ptr[0 .. cstr.len(ptr) + 1] else break;
         allocator.free(env_buf);
@@ -611,7 +611,7 @@ pub fn freeNullDelimitedEnvMap(allocator: *Allocator, envp_buf: []?[*]u8) void {
 /// pointers after the args and after the environment variables.
 /// `argv[0]` is the executable path.
 /// This function also uses the PATH environment variable to get the full path to the executable.
-pub fn posixExecve(argv: []const []const u8, env_map: *const BufMap, allocator: *Allocator) !void {
+pub fn posixExecve(argv: []const []const u8, env_map: *const BufMap, allocator: Allocator) !void {
     const argv_buf = try allocator.alloc(?[*]u8, argv.len + 1);
     mem.set(?[*]u8, argv_buf, null);
     defer {
@@ -740,7 +740,7 @@ pub fn getBaseAddress() usize {
 
 /// Caller must free result when done.
 /// TODO make this go through libc when we have it
-pub fn getEnvMap(allocator: *Allocator) !BufMap {
+pub fn getEnvMap(allocator: Allocator) !BufMap {
     var result = BufMap.init(allocator);
     errdefer result.deinit();
 
@@ -850,7 +850,7 @@ pub const GetEnvVarOwnedError = error{
 
 /// Caller must free returned memory.
 /// TODO make this go through libc when we have it
-pub fn getEnvVarOwned(allocator: *mem.Allocator, key: []const u8) GetEnvVarOwnedError![]u8 {
+pub fn getEnvVarOwned(allocator: mem.Allocator, key: []const u8) GetEnvVarOwnedError![]u8 {
     if (is_windows) {
         const key_with_null = try std.unicode.utf8ToUtf16LeWithNull(allocator, key);
         defer allocator.free(key_with_null);
@@ -897,7 +897,7 @@ test "os.getEnvVarOwned" {
 }
 
 /// Caller must free the returned memory.
-pub fn getCwdAlloc(allocator: *Allocator) ![]u8 {
+pub fn getCwdAlloc(allocator: Allocator) ![]u8 {
     var buf: [MAX_PATH_BYTES]u8 = undefined;
     return mem.dupe(allocator, u8, try getCwd(&buf));
 }
@@ -1026,7 +1026,7 @@ pub fn symLinkPosix(existing_path: []const u8, new_path: []const u8) PosixSymLin
 const b64_fs_encoder = base64.Base64Encoder.init("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_", base64.standard_pad_char);
 
 /// TODO remove the allocator requirement from this API
-pub fn atomicSymLink(allocator: *Allocator, existing_path: []const u8, new_path: []const u8) !void {
+pub fn atomicSymLink(allocator: Allocator, existing_path: []const u8, new_path: []const u8) !void {
     if (symLink(existing_path, new_path)) {
         return;
     } else |err| switch (err) {
@@ -1349,7 +1349,7 @@ pub fn makeDirPosix(dir_path: []const u8) !void {
 /// Calls makeDir recursively to make an entire path. Returns success if the path
 /// already exists and is a directory.
 /// TODO determine if we can remove the allocator requirement from this function
-pub fn makePath(allocator: *Allocator, full_path: []const u8) !void {
+pub fn makePath(allocator: Allocator, full_path: []const u8) !void {
     const resolved_path = try path.resolve(allocator, [][]const u8{full_path});
     defer allocator.free(resolved_path);
 
@@ -1491,7 +1491,7 @@ const DeleteTreeError = error{
 };
 
 /// TODO determine if we can remove the allocator requirement
-pub fn deleteTree(allocator: *Allocator, full_path: []const u8) DeleteTreeError!void {
+pub fn deleteTree(allocator: Allocator, full_path: []const u8) DeleteTreeError!void {
     start_over: while (true) {
         var got_access_denied = false;
         // First, try deleting the item as a file. This way we don't follow sym links.
@@ -1563,7 +1563,7 @@ pub fn deleteTree(allocator: *Allocator, full_path: []const u8) DeleteTreeError!
 
 pub const Dir = struct {
     handle: Handle,
-    allocator: *Allocator,
+    allocator: Allocator,
 
     pub const Handle = switch (builtin.os) {
         Os.macosx, Os.ios, Os.freebsd, Os.netbsd => struct {
@@ -1629,7 +1629,7 @@ pub const Dir = struct {
     };
 
     /// TODO remove the allocator requirement from this API
-    pub fn open(allocator: *Allocator, dir_path: []const u8) OpenError!Dir {
+    pub fn open(allocator: Allocator, dir_path: []const u8) OpenError!Dir {
         return Dir{
             .allocator = allocator,
             .handle = switch (builtin.os) {
@@ -2050,7 +2050,7 @@ pub const ArgIteratorWindows = struct {
     }
 
     /// You must free the returned memory when done.
-    pub fn next(self: *ArgIteratorWindows, allocator: *Allocator) ?(NextError![]u8) {
+    pub fn next(self: *ArgIteratorWindows, allocator: Allocator) ?(NextError![]u8) {
         // march forward over whitespace
         while (true) : (self.index += 1) {
             const byte = self.cmd_line[self.index];
@@ -2103,7 +2103,7 @@ pub const ArgIteratorWindows = struct {
         }
     }
 
-    fn internalNext(self: *ArgIteratorWindows, allocator: *Allocator) NextError![]u8 {
+    fn internalNext(self: *ArgIteratorWindows, allocator: Allocator) NextError![]u8 {
         var buf = try Buffer.initSize(allocator, 0);
         defer buf.deinit();
 
@@ -2192,7 +2192,7 @@ pub const ArgIterator = struct {
     pub const NextError = ArgIteratorWindows.NextError;
 
     /// You must free the returned memory when done.
-    pub fn next(self: *ArgIterator, allocator: *Allocator) ?(NextError![]u8) {
+    pub fn next(self: *ArgIterator, allocator: Allocator) ?(NextError![]u8) {
         if (builtin.os == Os.windows) {
             return self.inner.next(allocator);
         } else {
@@ -2217,7 +2217,7 @@ pub fn args() ArgIterator {
 }
 
 /// Caller must call argsFree on result.
-pub fn argsAlloc(allocator: *mem.Allocator) ![]const []u8 {
+pub fn argsAlloc(allocator: mem.Allocator) ![]const []u8 {
     if (builtin.os == Os.wasi) {
         var count: usize = undefined;
         var buf_size: usize = undefined;
@@ -2282,7 +2282,7 @@ pub fn argsAlloc(allocator: *mem.Allocator) ![]const []u8 {
     return result_slice_list;
 }
 
-pub fn argsFree(allocator: *mem.Allocator, args_alloc: []const []u8) void {
+pub fn argsFree(allocator: mem.Allocator, args_alloc: []const []u8) void {
     if (builtin.os == Os.wasi) {
         const last_item = args_alloc[args_alloc.len - 1];
         const last_byte_addr = @ptrToInt(last_item.ptr) + last_item.len + 1; // null terminated
@@ -2452,7 +2452,7 @@ pub fn selfExePath(out_buffer: *[MAX_PATH_BYTES]u8) ![]u8 {
 
 /// `selfExeDirPath` except allocates the result on the heap.
 /// Caller owns returned memory.
-pub fn selfExeDirPathAlloc(allocator: *Allocator) ![]u8 {
+pub fn selfExeDirPathAlloc(allocator: Allocator) ![]u8 {
     var buf: [MAX_PATH_BYTES]u8 = undefined;
     return mem.dupe(allocator, u8, try selfExeDirPath(&buf));
 }
@@ -3339,7 +3339,7 @@ pub const CpuCountError = error{
     Unexpected,
 };
 
-pub fn cpuCount(fallback_allocator: *mem.Allocator) CpuCountError!usize {
+pub fn cpuCount(fallback_allocator: mem.Allocator) CpuCountError!usize {
     switch (builtin.os) {
         builtin.Os.macosx, builtin.Os.freebsd, builtin.Os.netbsd => {
             var count: c_int = undefined;

--- a/std/os.zig
+++ b/std/os.zig
@@ -3166,7 +3166,7 @@ pub fn spawnThread(context: var, comptime startFn: var) SpawnThreadError!*Thread
         const bytes_ptr = windows.HeapAlloc(heap_handle, 0, byte_count) orelse return SpawnThreadError.OutOfMemory;
         errdefer assert(windows.HeapFree(heap_handle, 0, bytes_ptr) != 0);
         const bytes = @ptrCast([*]u8, bytes_ptr)[0..byte_count];
-        const outer_context = std.heap.FixedBufferAllocator.init(bytes).allocator.create(WinThread.OuterContext) catch unreachable;
+        const outer_context = std.heap.FixedBufferAllocator.init(bytes).allocator().create(WinThread.OuterContext) catch unreachable;
         outer_context.* = WinThread.OuterContext{
             .thread = Thread{
                 .data = Thread.Data{

--- a/std/os.zig
+++ b/std/os.zig
@@ -168,7 +168,7 @@ fn getRandomBytesDevURandom(buf: []u8) !void {
     const fd = try posixOpenC(c"/dev/urandom", posix.O_RDONLY | posix.O_CLOEXEC, 0);
     defer close(fd);
 
-    const stream = &File.openHandle(fd).inStream().stream;
+    const stream = &File.openHandle(fd).inStreamAdapter().stream;
     stream.readNoEof(buf) catch |err| switch (err) {
         error.EndOfStream => unreachable,
         error.OperationAborted => unreachable,
@@ -1136,7 +1136,7 @@ pub fn copyFile(source_path: []const u8, dest_path: []const u8) !void {
     defer in_file.close();
 
     const mode = try in_file.mode();
-    const in_stream = &in_file.inStream().stream;
+    const in_stream = &in_file.inStreamAdapter().stream;
 
     var atomic_file = try AtomicFile.init(dest_path, mode);
     defer atomic_file.deinit();

--- a/std/os.zig
+++ b/std/os.zig
@@ -168,7 +168,7 @@ fn getRandomBytesDevURandom(buf: []u8) !void {
     const fd = try posixOpenC(c"/dev/urandom", posix.O_RDONLY | posix.O_CLOEXEC, 0);
     defer close(fd);
 
-    const stream = &File.openHandle(fd).inStreamAdapter().stream;
+    const stream = File.openHandle(fd).inStreamAdapter().inStream();
     stream.readNoEof(buf) catch |err| switch (err) {
         error.EndOfStream => unreachable,
         error.OperationAborted => unreachable,
@@ -1136,7 +1136,7 @@ pub fn copyFile(source_path: []const u8, dest_path: []const u8) !void {
     defer in_file.close();
 
     const mode = try in_file.mode();
-    const in_stream = &in_file.inStreamAdapter().stream;
+    const in_stream = in_file.inStreamAdapter().inStream();
 
     var atomic_file = try AtomicFile.init(dest_path, mode);
     defer atomic_file.deinit();

--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -212,8 +212,8 @@ pub const ChildProcess = struct {
         defer Buffer.deinit(&stdout);
         defer Buffer.deinit(&stderr);
 
-        var stdout_file_in_stream = child.stdout.?.inStream();
-        var stderr_file_in_stream = child.stderr.?.inStream();
+        var stdout_file_in_stream = child.stdout.?.inStreamAdapter();
+        var stderr_file_in_stream = child.stderr.?.inStreamAdapter();
 
         try stdout_file_in_stream.stream.readAllBuffer(&stdout, max_output_size);
         try stderr_file_in_stream.stream.readAllBuffer(&stderr, max_output_size);
@@ -809,11 +809,11 @@ fn forkChildErrReport(fd: i32, err: ChildProcess.SpawnError) noreturn {
 const ErrInt = @IntType(false, @sizeOf(anyerror) * 8);
 
 fn writeIntFd(fd: i32, value: ErrInt) !void {
-    const stream = &os.File.openHandle(fd).outStream().stream;
+    const stream = &os.File.openHandle(fd).outStreamAdapter().stream;
     stream.writeIntNative(ErrInt, value) catch return error.SystemResources;
 }
 
 fn readIntFd(fd: i32) !ErrInt {
-    const stream = &os.File.openHandle(fd).inStream().stream;
+    const stream = &os.File.openHandle(fd).inStreamAdapter().stream;
     return stream.readIntNative(ErrInt) catch return error.SystemResources;
 }

--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -703,7 +703,7 @@ fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) 
     var buf = try Buffer.initSize(allocator, 0);
     defer buf.deinit();
 
-    var buf_stream = &io.BufferOutStream.init(&buf).stream;
+    var buf_stream = io.BufferOutStream.init(&buf).ouStream();
 
     for (argv) |arg, arg_i| {
         if (arg_i != 0) try buf.appendByte(' ');

--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -22,7 +22,7 @@ pub const ChildProcess = struct {
     pub handle: if (is_windows) windows.HANDLE else void,
     pub thread_handle: if (is_windows) windows.HANDLE else void,
 
-    pub allocator: *mem.Allocator,
+    pub allocator: mem.Allocator,
 
     pub stdin: ?os.File,
     pub stdout: ?os.File,
@@ -86,7 +86,7 @@ pub const ChildProcess = struct {
 
     /// First argument in argv is the executable.
     /// On success must call deinit.
-    pub fn init(argv: []const []const u8, allocator: *mem.Allocator) !*ChildProcess {
+    pub fn init(argv: []const []const u8, allocator: mem.Allocator) !*ChildProcess {
         const child = try allocator.create(ChildProcess);
         child.* = ChildProcess{
             .allocator = allocator,
@@ -195,7 +195,7 @@ pub const ChildProcess = struct {
 
     /// Spawns a child process, waits for it, collecting stdout and stderr, and then returns.
     /// If it succeeds, the caller owns result.stdout and result.stderr memory.
-    pub fn exec(allocator: *mem.Allocator, argv: []const []const u8, cwd: ?[]const u8, env_map: ?*const BufMap, max_output_size: usize) !ExecResult {
+    pub fn exec(allocator: mem.Allocator, argv: []const []const u8, cwd: ?[]const u8, env_map: ?*const BufMap, max_output_size: usize) !ExecResult {
         const child = try ChildProcess.init(argv, allocator);
         defer child.deinit();
 
@@ -699,7 +699,7 @@ fn windowsCreateProcess(app_name: [*]u16, cmd_line: [*]u16, envp_ptr: ?[*]u16, c
 
 /// Caller must dealloc.
 /// Guarantees a null byte at result[result.len].
-fn windowsCreateCommandLine(allocator: *mem.Allocator, argv: []const []const u8) ![]u8 {
+fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) ![]u8 {
     var buf = try Buffer.initSize(allocator, 0);
     defer buf.deinit();
 

--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -814,6 +814,6 @@ fn writeIntFd(fd: i32, value: ErrInt) !void {
 }
 
 fn readIntFd(fd: i32) !ErrInt {
-    const stream = &os.File.openHandle(fd).inStreamAdapter().stream;
+    const stream = os.File.openHandle(fd).inStreamAdapter().inStream();
     return stream.readIntNative(ErrInt) catch return error.SystemResources;
 }

--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -809,7 +809,7 @@ fn forkChildErrReport(fd: i32, err: ChildProcess.SpawnError) noreturn {
 const ErrInt = @IntType(false, @sizeOf(anyerror) * 8);
 
 fn writeIntFd(fd: i32, value: ErrInt) !void {
-    const stream = &os.File.openHandle(fd).outStreamAdapter().stream;
+    const stream = os.File.openHandle(fd).outStreamAdapter().outStream();
     stream.writeIntNative(ErrInt, value) catch return error.SystemResources;
 }
 

--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -215,8 +215,8 @@ pub const ChildProcess = struct {
         var stdout_file_in_stream = child.stdout.?.inStreamAdapter();
         var stderr_file_in_stream = child.stderr.?.inStreamAdapter();
 
-        try stdout_file_in_stream.stream.readAllBuffer(&stdout, max_output_size);
-        try stderr_file_in_stream.stream.readAllBuffer(&stderr, max_output_size);
+        try stdout_file_in_stream.inStream().readAllBuffer(&stdout, max_output_size);
+        try stderr_file_in_stream.inStream().readAllBuffer(&stderr, max_output_size);
 
         return ExecResult{
             .term = try child.wait(),

--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -703,7 +703,7 @@ fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) 
     var buf = try Buffer.initSize(allocator, 0);
     defer buf.deinit();
 
-    var buf_stream = io.BufferOutStream.init(&buf).ouStream();
+    var buf_stream = io.BufferOutStream.init(&buf).outStream();
 
     for (argv) |arg, arg_i| {
         if (arg_i != 0) try buf.appendByte(' ');

--- a/std/os/file.zig
+++ b/std/os/file.zig
@@ -428,37 +428,37 @@ pub const File = struct {
         }
     }
 
-    pub fn inStreamAdapter(file: File) InStream {
-        return InStream{
+    pub fn inStreamAdapter(file: File) InStreamAdapter {
+        return InStreamAdapter{
             .file = file,
         };
     }
 
-    pub fn outStreamAdapter(file: File) OutStream {
-        return OutStream{
+    pub fn outStreamAdapter(file: File) OutStreamAdapter {
+        return OutStreamAdapter{
             .file = file,
         };
     }
 
-    pub fn seekableStreamAdapter(file: File) SeekableStream {
-        return SeekableStream{
+    pub fn seekableStreamAdapter(file: File) SeekableStreamAdapter {
+        return SeekableStreamAdapter{
             .file = file,
         };
     }
 
     /// Implementation of io.InStream trait for File
-    pub const InStream = struct {
+    pub const InStreamAdapter = struct {
         file: File,
 
         pub const Error = ReadError;
         pub const Stream = io.InStream(Error);
 
         fn readFn(in_stream: Stream, buffer: []u8) Error!usize {
-            const self = in_stream.implCast(InStream);
+            const self = in_stream.implCast(InStreamAdapter);
             return self.file.read(buffer);
         }
         
-        pub fn inStream(self: *InStream) Stream {
+        pub fn inStream(self: *InStreamAdapter) Stream {
             return Stream {
                 .impl = Stream.ifaceCast(self),
                 .readFn = readFn,
@@ -467,18 +467,18 @@ pub const File = struct {
     };
 
     /// Implementation of io.OutStream trait for File
-    pub const OutStream = struct {
+    pub const OutStreamAdapter = struct {
         file: File,
 
         pub const Error = WriteError;
         pub const Stream = io.OutStream(Error);
 
         fn writeFn(out_stream: Stream, bytes: []const u8) Error!void {
-            const self = out_stream.implCast(OutStream);
+            const self = out_stream.implCast(OutStreamAdapter);
             return self.file.write(bytes);
         }
         
-        pub fn outStream(self: *OutStream) Stream {
+        pub fn outStream(self: *OutStreamAdapter) Stream {
             return Stream {
                 .impl = Stream.ifaceCast(self),
                 .writeFn = writeFn,
@@ -487,32 +487,32 @@ pub const File = struct {
     };
 
     /// Implementation of io.SeekableStream trait for File
-    pub const SeekableStream = struct {
+    pub const SeekableStreamAdapter = struct {
         file: File,
 
         pub const Stream = io.SeekableStream(SeekError, GetSeekPosError);
 
         pub fn seekToFn(seekable_stream: Stream, pos: u64) SeekError!void {
-            const self = seekable_stream.implCast(SeekableStream);
+            const self = seekable_stream.implCast(SeekableStreamAdapter);
             return self.file.seekTo(pos);
         }
 
         pub fn seekForwardFn(seekable_stream: Stream, amt: i64) SeekError!void {
-            const self = seekable_stream.implCast(SeekableStream);
+            const self = seekable_stream.implCast(SeekableStreamAdapter);
             return self.file.seekForward(amt);
         }
 
         pub fn getEndPosFn(seekable_stream: Stream) GetSeekPosError!u64 {
-            const self = seekable_stream.implCast(SeekableStream);
+            const self = seekable_stream.implCast(SeekableStreamAdapter);
             return self.file.getEndPos();
         }
 
         pub fn getPosFn(seekable_stream: Stream) GetSeekPosError!u64 {
-            const self = seekable_stream.implCast(SeekableStream);
+            const self = seekable_stream.implCast(SeekableStreamAdapter);
             return self.file.getPos();
         }
         
-        pub fn seekableStream(self: *SeekableStream) Stream {
+        pub fn seekableStream(self: *SeekableStreamAdapter) Stream {
             return Stream {
                 .impl = Stream.ifaceCast(self),
                 .seekToFn = SeekableStream.seekToFn,

--- a/std/os/file.zig
+++ b/std/os/file.zig
@@ -428,19 +428,19 @@ pub const File = struct {
         }
     }
 
-    pub fn inStreamHandle(file: File) InStream {
+    pub fn inStreamAdapter(file: File) InStream {
         return InStream{
             .file = file,
         };
     }
 
-    pub fn outStreamHandle(file: File) OutStream {
+    pub fn outStreamAdapter(file: File) OutStream {
         return OutStream{
             .file = file,
         };
     }
 
-    pub fn seekableStreamHandle(file: File) SeekableStream {
+    pub fn seekableStreamAdapter(file: File) SeekableStream {
         return SeekableStream{
             .file = file,
         };
@@ -478,7 +478,7 @@ pub const File = struct {
             return self.file.write(bytes);
         }
         
-        pub fn inStream(self: *OutStream) Stream {
+        pub fn outStream(self: *OutStream) Stream {
             return Stream {
                 .impl = Stream.ifaceCast(self),
                 .writeFn = writeFn,

--- a/std/os/file.zig
+++ b/std/os/file.zig
@@ -454,13 +454,13 @@ pub const File = struct {
         pub const Stream = io.InStream(Error);
 
         fn readFn(in_stream: Stream, buffer: []u8) Error!usize {
-            const self = in_stream.implCast(InStreamAdapter);
+            const self = in_stream.iface.implCast(InStreamAdapter);
             return self.file.read(buffer);
         }
-        
+
         pub fn inStream(self: *InStreamAdapter) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .readFn = readFn,
             };
         }
@@ -474,13 +474,13 @@ pub const File = struct {
         pub const Stream = io.OutStream(Error);
 
         fn writeFn(out_stream: Stream, bytes: []const u8) Error!void {
-            const self = out_stream.implCast(OutStreamAdapter);
+            const self = out_stream.iface.implCast(OutStreamAdapter);
             return self.file.write(bytes);
         }
-        
+
         pub fn outStream(self: *OutStreamAdapter) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .writeFn = writeFn,
             };
         }
@@ -493,28 +493,28 @@ pub const File = struct {
         pub const Stream = io.SeekableStream(SeekError, GetSeekPosError);
 
         pub fn seekToFn(seekable_stream: Stream, pos: u64) SeekError!void {
-            const self = seekable_stream.implCast(SeekableStreamAdapter);
+            const self = seekable_stream.iface.implCast(SeekableStreamAdapter);
             return self.file.seekTo(pos);
         }
 
         pub fn seekForwardFn(seekable_stream: Stream, amt: i64) SeekError!void {
-            const self = seekable_stream.implCast(SeekableStreamAdapter);
+            const self = seekable_stream.iface.implCast(SeekableStreamAdapter);
             return self.file.seekForward(amt);
         }
 
         pub fn getEndPosFn(seekable_stream: Stream) GetSeekPosError!u64 {
-            const self = seekable_stream.implCast(SeekableStreamAdapter);
+            const self = seekable_stream.iface.implCast(SeekableStreamAdapter);
             return self.file.getEndPos();
         }
 
         pub fn getPosFn(seekable_stream: Stream) GetSeekPosError!u64 {
-            const self = seekable_stream.implCast(SeekableStreamAdapter);
+            const self = seekable_stream.iface.implCast(SeekableStreamAdapter);
             return self.file.getPos();
         }
-        
+
         pub fn seekableStream(self: *SeekableStreamAdapter) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .seekToFn = SeekableStream.seekToFn,
                 .seekForwardFn = SeekableStream.seekForwardFn,
                 .getPosFn = SeekableStream.getPosFn,

--- a/std/os/get_app_data_dir.zig
+++ b/std/os/get_app_data_dir.zig
@@ -62,7 +62,7 @@ fn utf16lePtrSlice(ptr: [*]const u16) []const u16 {
 
 test "std.os.getAppDataDir" {
     var buf: [512]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(buf[0..]).allocator;
+    const allocator = std.heap.FixedBufferAllocator.init(buf[0..]).allocator();
 
     // We can't actually validate the result
     _ = getAppDataDir(allocator, "zig") catch return;

--- a/std/os/get_app_data_dir.zig
+++ b/std/os/get_app_data_dir.zig
@@ -11,7 +11,7 @@ pub const GetAppDataDirError = error{
 
 /// Caller owns returned memory.
 /// TODO determine if we can remove the allocator requirement
-pub fn getAppDataDir(allocator: *mem.Allocator, appname: []const u8) GetAppDataDirError![]u8 {
+pub fn getAppDataDir(allocator: mem.Allocator, appname: []const u8) GetAppDataDirError![]u8 {
     switch (builtin.os) {
         builtin.Os.windows => {
             var dir_path_ptr: [*]u16 = undefined;

--- a/std/os/path.zig
+++ b/std/os/path.zig
@@ -36,7 +36,7 @@ pub fn isSep(byte: u8) bool {
 
 /// This is different from mem.join in that the separator will not be repeated if
 /// it is found at the end or beginning of a pair of consecutive paths.
-fn joinSep(allocator: *Allocator, separator: u8, paths: []const []const u8) ![]u8 {
+fn joinSep(allocator: Allocator, separator: u8, paths: []const []const u8) ![]u8 {
     if (paths.len == 0) return (([*]u8)(undefined))[0..0];
 
     const total_len = blk: {
@@ -81,13 +81,13 @@ pub const join = if (is_windows) joinWindows else joinPosix;
 
 /// Naively combines a series of paths with the native path seperator.
 /// Allocates memory for the result, which must be freed by the caller.
-pub fn joinWindows(allocator: *Allocator, paths: []const []const u8) ![]u8 {
+pub fn joinWindows(allocator: Allocator, paths: []const []const u8) ![]u8 {
     return joinSep(allocator, sep_windows, paths);
 }
 
 /// Naively combines a series of paths with the native path seperator.
 /// Allocates memory for the result, which must be freed by the caller.
-pub fn joinPosix(allocator: *Allocator, paths: []const []const u8) ![]u8 {
+pub fn joinPosix(allocator: Allocator, paths: []const []const u8) ![]u8 {
     return joinSep(allocator, sep_posix, paths);
 }
 
@@ -377,7 +377,7 @@ fn asciiEqlIgnoreCase(s1: []const u8, s2: []const u8) bool {
 }
 
 /// On Windows, this calls `resolveWindows` and on POSIX it calls `resolvePosix`.
-pub fn resolve(allocator: *Allocator, paths: []const []const u8) ![]u8 {
+pub fn resolve(allocator: Allocator, paths: []const []const u8) ![]u8 {
     if (is_windows) {
         return resolveWindows(allocator, paths);
     } else {
@@ -393,7 +393,7 @@ pub fn resolve(allocator: *Allocator, paths: []const []const u8) ![]u8 {
 /// Path separators are canonicalized to '\\' and drives are canonicalized to capital letters.
 /// Note: all usage of this function should be audited due to the existence of symlinks.
 /// Without performing actual syscalls, resolving `..` could be incorrect.
-pub fn resolveWindows(allocator: *Allocator, paths: []const []const u8) ![]u8 {
+pub fn resolveWindows(allocator: Allocator, paths: []const []const u8) ![]u8 {
     if (paths.len == 0) {
         assert(is_windows); // resolveWindows called on non windows can't use getCwd
         return os.getCwdAlloc(allocator);
@@ -574,7 +574,7 @@ pub fn resolveWindows(allocator: *Allocator, paths: []const []const u8) ![]u8 {
 /// If all paths are relative it uses the current working directory as a starting point.
 /// Note: all usage of this function should be audited due to the existence of symlinks.
 /// Without performing actual syscalls, resolving `..` could be incorrect.
-pub fn resolvePosix(allocator: *Allocator, paths: []const []const u8) ![]u8 {
+pub fn resolvePosix(allocator: Allocator, paths: []const []const u8) ![]u8 {
     if (paths.len == 0) {
         assert(!is_windows); // resolvePosix called on windows can't use getCwd
         return os.getCwdAlloc(allocator);
@@ -964,7 +964,7 @@ fn testBasenameWindows(input: []const u8, expected_output: []const u8) void {
 /// resolve to the same path (after calling `resolve` on each), a zero-length
 /// string is returned.
 /// On Windows this canonicalizes the drive to a capital letter and paths to `\\`.
-pub fn relative(allocator: *Allocator, from: []const u8, to: []const u8) ![]u8 {
+pub fn relative(allocator: Allocator, from: []const u8, to: []const u8) ![]u8 {
     if (is_windows) {
         return relativeWindows(allocator, from, to);
     } else {
@@ -972,7 +972,7 @@ pub fn relative(allocator: *Allocator, from: []const u8, to: []const u8) ![]u8 {
     }
 }
 
-pub fn relativeWindows(allocator: *Allocator, from: []const u8, to: []const u8) ![]u8 {
+pub fn relativeWindows(allocator: Allocator, from: []const u8, to: []const u8) ![]u8 {
     const resolved_from = try resolveWindows(allocator, [][]const u8{from});
     defer allocator.free(resolved_from);
 
@@ -1045,7 +1045,7 @@ pub fn relativeWindows(allocator: *Allocator, from: []const u8, to: []const u8) 
     return []u8{};
 }
 
-pub fn relativePosix(allocator: *Allocator, from: []const u8, to: []const u8) ![]u8 {
+pub fn relativePosix(allocator: Allocator, from: []const u8, to: []const u8) ![]u8 {
     const resolved_from = try resolvePosix(allocator, [][]const u8{from});
     defer allocator.free(resolved_from);
 
@@ -1276,7 +1276,7 @@ pub fn real(out_buffer: *[os.MAX_PATH_BYTES]u8, pathname: []const u8) RealError!
 }
 
 /// `real`, except caller must free the returned memory.
-pub fn realAlloc(allocator: *Allocator, pathname: []const u8) ![]u8 {
+pub fn realAlloc(allocator: Allocator, pathname: []const u8) ![]u8 {
     var buf: [os.MAX_PATH_BYTES]u8 = undefined;
     return mem.dupe(allocator, u8, try real(&buf, pathname));
 }

--- a/std/os/path.zig
+++ b/std/os/path.zig
@@ -93,14 +93,14 @@ pub fn joinPosix(allocator: Allocator, paths: []const []const u8) ![]u8 {
 
 fn testJoinWindows(paths: []const []const u8, expected: []const u8) void {
     var buf: [1024]u8 = undefined;
-    const a = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+    const a = std.heap.FixedBufferAllocator.init(&buf).allocator();
     const actual = joinWindows(a, paths) catch @panic("fail");
     testing.expectEqualSlices(u8, expected, actual);
 }
 
 fn testJoinPosix(paths: []const []const u8, expected: []const u8) void {
     var buf: [1024]u8 = undefined;
-    const a = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+    const a = std.heap.FixedBufferAllocator.init(&buf).allocator();
     const actual = joinPosix(a, paths) catch @panic("fail");
     testing.expectEqualSlices(u8, expected, actual);
 }

--- a/std/os/test.zig
+++ b/std/os/test.zig
@@ -94,7 +94,7 @@ test "cpu count" {
 
 test "AtomicFile" {
     var buffer: [1024]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(buffer[0..]).allocator;
+    const allocator = std.heap.FixedBufferAllocator.init(buffer[0..]).allocator();
     const test_out_file = "tmp_atomic_file_test_dest.txt";
     const test_content =
         \\ hello!

--- a/std/os/windows/util.zig
+++ b/std/os/windows/util.zig
@@ -164,7 +164,7 @@ pub fn windowsOpen(
 }
 
 /// Caller must free result.
-pub fn createWindowsEnvBlock(allocator: *mem.Allocator, env_map: *const BufMap) ![]u16 {
+pub fn createWindowsEnvBlock(allocator: mem.Allocator, env_map: *const BufMap) ![]u16 {
     // count bytes needed
     const max_chars_needed = x: {
         var max_chars_needed: usize = 4; // 4 for the final 4 null bytes

--- a/std/packed_int_array.zig
+++ b/std/packed_int_array.zig
@@ -624,7 +624,7 @@ test "PackedIntArray at end of available memory" {
     };
 
     var da = std.heap.DirectAllocator.init();
-    const allocator = &da.allocator;
+    const allocator = da.allocator();
 
     var pad = try allocator.create(Padded);
     defer allocator.destroy(pad);
@@ -639,7 +639,7 @@ test "PackedIntSlice at end of available memory" {
     const PackedSlice = PackedIntSlice(u11);
 
     var da = std.heap.DirectAllocator.init();
-    const allocator = &da.allocator;
+    const allocator = da.allocator();
 
     var page = try allocator.alloc(u8, std.os.page_size);
     defer allocator.free(page);

--- a/std/pdb.zig
+++ b/std/pdb.zig
@@ -593,7 +593,6 @@ const MsfStream = struct {
     block_size: u32,
 
     /// Implementation of InStream trait for Pdb.MsfStream
-
     pub const Error = @typeOf(read).ReturnType.ErrorSet;
     pub const Stream = io.InStream(Error);
 
@@ -684,13 +683,13 @@ const MsfStream = struct {
     }
 
     fn readFn(in_stream: Stream, buffer: []u8) Error!usize {
-        const self = in_stream.implCast(MsfStream);
+        const self = in_stream.iface.implCast(MsfStream);
         return self.read(buffer);
     }
-    
+
     pub fn inStream(self: *MsfStream) Stream {
-        return Stream {
-            .impl = Stream.ifaceCast(self),
+        return Stream{
+            .iface = Stream.Iface.init(self),
             .readFn = readFn,
         };
     }

--- a/std/pdb.zig
+++ b/std/pdb.zig
@@ -494,7 +494,7 @@ const Msf = struct {
 
     fn openFile(self: *Msf, allocator: mem.Allocator, file: os.File) !void {
         var file_stream = file.inStreamAdapter();
-        const in = &file_stream.stream;
+        const in = file_stream.inStream();
 
         const superblock = try in.readStruct(SuperBlock);
 
@@ -608,7 +608,7 @@ const MsfStream = struct {
         };
 
         var file_stream = file.inStreamAdapter();
-        const in = &file_stream.stream;
+        const in = file_stream.inStream();
         try file.seekTo(pos);
 
         var i: u32 = 0;
@@ -638,7 +638,7 @@ const MsfStream = struct {
 
         try self.in_file.seekTo(block * self.block_size + offset);
         var file_stream = self.in_file.inStreamAdapter();
-        const in = &file_stream.stream;
+        const in = file_stream.inStream();
 
         var size: usize = 0;
         for (buffer) |*byte| {

--- a/std/pdb.zig
+++ b/std/pdb.zig
@@ -522,7 +522,7 @@ const Msf = struct {
 
         const stream_sizes = try allocator.alloc(u32, stream_count);
         for (stream_sizes) |*s| {
-            const size = try self.directory.stream.readIntLittle(u32);
+            const size = try self.directory.inStream().readIntLittle(u32);
             s.* = blockCountFromSize(size, superblock.BlockSize);
         }
 
@@ -691,7 +691,7 @@ const MsfStream = struct {
     pub fn inStream(self: *MsfStream) Stream {
         return Stream {
             .impl = Stream.ifaceCast(self),
-            .writeFn = writeFn,
+            .readFn = readFn,
         };
     }
 };

--- a/std/pdb.zig
+++ b/std/pdb.zig
@@ -460,7 +460,7 @@ pub const PDBStringTableHeader = packed struct {
 
 pub const Pdb = struct {
     in_file: os.File,
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     coff: *coff.Coff,
     string_table: *MsfStream,
     dbi: *MsfStream,
@@ -492,7 +492,7 @@ const Msf = struct {
     directory: MsfStream,
     streams: []MsfStream,
 
-    fn openFile(self: *Msf, allocator: *mem.Allocator, file: os.File) !void {
+    fn openFile(self: *Msf, allocator: mem.Allocator, file: os.File) !void {
         var file_stream = file.inStream();
         const in = &file_stream.stream;
 
@@ -598,7 +598,7 @@ const MsfStream = struct {
     pub const Error = @typeOf(read).ReturnType.ErrorSet;
     pub const Stream = io.InStream(Error);
 
-    fn init(block_size: u32, block_count: u32, pos: u64, file: os.File, allocator: *mem.Allocator) !MsfStream {
+    fn init(block_size: u32, block_count: u32, pos: u64, file: os.File, allocator: mem.Allocator) !MsfStream {
         var stream = MsfStream{
             .in_file = file,
             .pos = 0,
@@ -619,7 +619,7 @@ const MsfStream = struct {
         return stream;
     }
 
-    fn readNullTermString(self: *MsfStream, allocator: *mem.Allocator) ![]u8 {
+    fn readNullTermString(self: *MsfStream, allocator: mem.Allocator) ![]u8 {
         var list = ArrayList(u8).init(allocator);
         defer list.deinit();
         while (true) {

--- a/std/pdb.zig
+++ b/std/pdb.zig
@@ -493,7 +493,7 @@ const Msf = struct {
     streams: []MsfStream,
 
     fn openFile(self: *Msf, allocator: mem.Allocator, file: os.File) !void {
-        var file_stream = file.inStream();
+        var file_stream = file.inStreamAdapter();
         const in = &file_stream.stream;
 
         const superblock = try in.readStruct(SuperBlock);
@@ -607,7 +607,7 @@ const MsfStream = struct {
             .stream = Stream{ .readFn = readFn },
         };
 
-        var file_stream = file.inStream();
+        var file_stream = file.inStreamAdapter();
         const in = &file_stream.stream;
         try file.seekTo(pos);
 
@@ -637,7 +637,7 @@ const MsfStream = struct {
         var offset = self.pos % self.block_size;
 
         try self.in_file.seekTo(block * self.block_size + offset);
-        var file_stream = self.in_file.inStream();
+        var file_stream = self.in_file.inStreamAdapter();
         const in = &file_stream.stream;
 
         var size: usize = 0;

--- a/std/priority_queue.zig
+++ b/std/priority_queue.zig
@@ -10,10 +10,10 @@ pub fn PriorityQueue(comptime T: type) type {
 
         items: []T,
         len: usize,
-        allocator: *Allocator,
+        allocator: Allocator,
         compareFn: fn (a: T, b: T) bool,
 
-        pub fn init(allocator: *Allocator, compareFn: fn (a: T, b: T) bool) Self {
+        pub fn init(allocator: Allocator, compareFn: fn (a: T, b: T) bool) Self {
             return Self{
                 .items = []T{},
                 .len = 0,
@@ -119,7 +119,7 @@ pub fn PriorityQueue(comptime T: type) type {
         /// PriorityQueue takes ownership of the passed in slice. The slice must have been
         /// allocated with `allocator`.
         /// Deinitialize with `deinit`.
-        pub fn fromOwnedSlice(allocator: *Allocator, compareFn: fn (a: T, b: T) bool, items: []T) Self {
+        pub fn fromOwnedSlice(allocator: Allocator, compareFn: fn (a: T, b: T) bool, items: []T) Self {
             var queue = Self{
                 .items = items,
                 .len = items.len,

--- a/std/rand.zig
+++ b/std/rand.zig
@@ -30,9 +30,9 @@ pub const DefaultPrng = Xoroshiro128;
 pub const DefaultCsprng = Isaac64;
 
 pub const Random = struct {
-    pub const RandomImpl = ?*@OpaqueType();
-    
-    impl: RandomImpl,
+    pub const Iface = std.Interface();
+    iface: Iface,
+
     fillFn: fn (r: Random, buf: []u8) void,
 
     /// Read random bytes into the specified buffer until full.
@@ -276,21 +276,6 @@ pub const Random = struct {
             mem.swap(T, &buf[i], &buf[j]);
         }
     }
-    
-    /// Cast the original type to the implementation pointer
-    pub fn ifaceCast(ptr: var) RandomImpl {
-        const T = @typeOf(ptr);
-        if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway, use null)");
-        return @ptrCast(RandomImpl, ptr);
-    }
-    
-    /// Cast the implementation pointer back to the original type
-    pub fn implCast(r: Random, comptime T: type) *T {
-        if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
-        assert(r.impl != null);
-        const aligned = @alignCast(@alignOf(T), r.impl);
-        return @ptrCast(*T, aligned);
-    }
 };
 
 /// Convert a random integer 0 <= random_int <= maxValue(T),
@@ -318,16 +303,16 @@ const SequentialPrng = struct {
     }
 
     fn fill(r: Random, buf: []u8) void {
-        const self = r.implCast(SequentialPrng);
+        const self = r.iface.implCast(SequentialPrng);
         for (buf) |*b| {
             b.* = self.next_value;
         }
         self.next_value +%= 1;
     }
-    
+
     pub fn random(self: *Self) Random {
-        return Random {
-            .impl = Random.ifaceCast(self),
+        return Random{
+            .iface = Random.Iface.init(self),
             .fillFn = fill,
         };
     }
@@ -395,7 +380,6 @@ test "Random intLessThan" {
     @setEvalBranchQuota(100000);
     testRandomIntLessThan();
     comptime testRandomIntLessThan();
-    
 }
 fn testRandomIntLessThan() void {
     var r = SequentialPrng.init();
@@ -418,14 +402,14 @@ fn testRandomIntLessThan() void {
     expect(r.random().intRangeLessThan(u8, 0, 0x80) == 0x7f);
     r.next_value = 0xff;
     expect(r.random().intRangeLessThan(u8, 0x7f, 0xff) == 0xfe);
-    
+
     r.next_value = 0xff;
     expect(r.random().intRangeLessThan(i8, 0, 0x40) == 0x3f);
     r.next_value = 0xff;
     expect(r.random().intRangeLessThan(i8, -0x40, 0x40) == 0x3f);
     r.next_value = 0xff;
     expect(r.random().intRangeLessThan(i8, -0x80, 0) == -1);
-    
+
     r.next_value = 0xff;
     expect(r.random().intRangeLessThan(i3, -4, 0) == -1);
     r.next_value = 0xff;
@@ -583,7 +567,7 @@ pub const Pcg = struct {
     }
 
     fn fill(r: Random, buf: []u8) void {
-        const self = r.implCast(Pcg);
+        const self = r.iface.implCast(Pcg);
 
         var i: usize = 0;
         const aligned_len = buf.len - (buf.len & 7);
@@ -607,10 +591,10 @@ pub const Pcg = struct {
             }
         }
     }
-    
+
     pub fn random(self: *Pcg) Random {
-        return Random {
-            .impl = Random.ifaceCast(self),
+        return Random{
+            .iface = Random.Iface.init(self),
             .fillFn = fill,
         };
     }
@@ -640,7 +624,6 @@ test "pcg sequence" {
 //
 // PRNG
 pub const Xoroshiro128 = struct {
-
     s: [2]u64,
 
     pub fn init(init_s: u64) Xoroshiro128 {
@@ -698,7 +681,7 @@ pub const Xoroshiro128 = struct {
     }
 
     fn fill(r: Random, buf: []u8) void {
-        const self = r.implCast(Xoroshiro128);
+        const self = r.iface.implCast(Xoroshiro128);
 
         var i: usize = 0;
         const aligned_len = buf.len - (buf.len & 7);
@@ -722,10 +705,10 @@ pub const Xoroshiro128 = struct {
             }
         }
     }
-    
+
     pub fn random(self: *Xoroshiro128) Random {
-        return Random {
-            .impl = Random.ifaceCast(self),
+        return Random{
+            .iface = Random.Iface.init(self),
             .fillFn = fill,
         };
     }
@@ -772,7 +755,6 @@ test "xoroshiro sequence" {
 // Follows the general idea of the implementation from here with a few shortcuts.
 // https://doc.rust-lang.org/rand/src/rand/prng/isaac64.rs.html
 pub const Isaac64 = struct {
-
     r: [256]u64,
     m: [256]u64,
     a: u64,
@@ -912,7 +894,7 @@ pub const Isaac64 = struct {
     }
 
     fn fill(r: Random, buf: []u8) void {
-        const self = r.implCast(Isaac64);
+        const self = r.iface.implCast(Isaac64);
 
         var i: usize = 0;
         const aligned_len = buf.len - (buf.len & 7);
@@ -936,10 +918,10 @@ pub const Isaac64 = struct {
             }
         }
     }
-    
+
     pub fn random(self: *Isaac64) Random {
-        return Random {
-            .impl = Random.ifaceCast(self),
+        return Random{
+            .iface = Random.Iface.init(self),
             .fillFn = fill,
         };
     }

--- a/std/rand.zig
+++ b/std/rand.zig
@@ -279,20 +279,18 @@ pub const Random = struct {
     
     /// Cast the original type to the implementation pointer
     pub fn ifaceCast(ptr: var) RandomImpl {
+        const T = @typeOf(ptr);
         if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway, use null)");
-        debug.assert(ptr != null);
         return @ptrCast(RandomImpl, ptr);
     }
     
     /// Cast the implementation pointer back to the original type
     pub fn implCast(r: *Random, comptime T: type) *T {
         if(@alignOf(T) == 0) @compileError("0-Bit implementations can't be casted (and casting is unnecessary anyway)");
-        debug.assert(r.impl != null);
+        assert(r.impl != null);
         const aligned = @alignCast(@alignOf(T), r.impl);
         return @ptrCast(*T, aligned);
     }
-    
-    
 };
 
 /// Convert a random integer 0 <= random_int <= maxValue(T),
@@ -394,9 +392,11 @@ fn testRandomBoolean() void {
 }
 
 test "Random intLessThan" {
-    @setEvalBranchQuota(10000);
+    @setEvalBranchQuota(100000);
     testRandomIntLessThan();
-    comptime testRandomIntLessThan();
+    //@BUG: Infinite loop in comptime evaluation. Unknown cause.
+    //comptime testRandomIntLessThan();
+    
 }
 fn testRandomIntLessThan() void {
     var r = SequentialPrng.init();
@@ -419,14 +419,14 @@ fn testRandomIntLessThan() void {
     expect(r.random().intRangeLessThan(u8, 0, 0x80) == 0x7f);
     r.next_value = 0xff;
     expect(r.random().intRangeLessThan(u8, 0x7f, 0xff) == 0xfe);
-
+    
     r.next_value = 0xff;
     expect(r.random().intRangeLessThan(i8, 0, 0x40) == 0x3f);
     r.next_value = 0xff;
     expect(r.random().intRangeLessThan(i8, -0x40, 0x40) == 0x3f);
     r.next_value = 0xff;
     expect(r.random().intRangeLessThan(i8, -0x80, 0) == -1);
-
+    
     r.next_value = 0xff;
     expect(r.random().intRangeLessThan(i3, -4, 0) == -1);
     r.next_value = 0xff;
@@ -436,7 +436,8 @@ fn testRandomIntLessThan() void {
 test "Random intAtMost" {
     @setEvalBranchQuota(10000);
     testRandomIntAtMost();
-    comptime testRandomIntAtMost();
+    //@BUG: Infinite loop in comptime evaluation. Unknown cause.
+    //comptime comptime testRandomIntAtMost();
 }
 fn testRandomIntAtMost() void {
     var r = SequentialPrng.init();

--- a/std/rand/ziggurat.zig
+++ b/std/rand/ziggurat.zig
@@ -130,7 +130,7 @@ test "ziggurant normal dist sanity" {
     var prng = std.rand.DefaultPrng.init(0);
     var i: usize = 0;
     while (i < 1000) : (i += 1) {
-        _ = prng.random.floatNorm(f64);
+        _ = prng.random().floatNorm(f64);
     }
 }
 
@@ -157,7 +157,7 @@ test "ziggurant exp dist sanity" {
     var prng = std.rand.DefaultPrng.init(0);
     var i: usize = 0;
     while (i < 1000) : (i += 1) {
-        _ = prng.random.floatExp(f64);
+        _ = prng.random().floatExp(f64);
     }
 }
 

--- a/std/rand/ziggurat.zig
+++ b/std/rand/ziggurat.zig
@@ -12,7 +12,7 @@ const std = @import("../std.zig");
 const math = std.math;
 const Random = std.rand.Random;
 
-pub fn next_f64(random: *Random, comptime tables: ZigTable) f64 {
+pub fn next_f64(random: Random, comptime tables: ZigTable) f64 {
     while (true) {
         // We manually construct a float from parts as we can avoid an extra random lookup here by
         // using the unused exponent for the lookup table entry.
@@ -60,7 +60,7 @@ pub const ZigTable = struct {
     // whether the distribution is symmetric
     is_symmetric: bool,
     // fallback calculation in the case we are in the 0 block
-    zero_case: fn (*Random, f64) f64,
+    zero_case: fn (Random, f64) f64,
 };
 
 // zigNorInit
@@ -70,7 +70,7 @@ fn ZigTableGen(
     comptime v: f64,
     comptime f: fn (f64) f64,
     comptime f_inv: fn (f64) f64,
-    comptime zero_case: fn (*Random, f64) f64,
+    comptime zero_case: fn (Random, f64) f64,
 ) ZigTable {
     var tables: ZigTable = undefined;
 
@@ -110,7 +110,7 @@ fn norm_f(x: f64) f64 {
 fn norm_f_inv(y: f64) f64 {
     return math.sqrt(-2.0 * math.ln(y));
 }
-fn norm_zero_case(random: *Random, u: f64) f64 {
+fn norm_zero_case(random: Random, u: f64) f64 {
     var x: f64 = 1;
     var y: f64 = 0;
 
@@ -149,7 +149,7 @@ fn exp_f(x: f64) f64 {
 fn exp_f_inv(y: f64) f64 {
     return -math.ln(y);
 }
-fn exp_zero_case(random: *Random, _: f64) f64 {
+fn exp_zero_case(random: Random, _: f64) f64 {
     return exp_r - math.ln(random.float(f64));
 }
 

--- a/std/segmented_list.zig
+++ b/std/segmented_list.zig
@@ -336,7 +336,7 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
 test "std.SegmentedList" {
     var da = std.heap.DirectAllocator.init();
     defer da.deinit();
-    var a = &da.allocator;
+    var a = da.allocator();
 
     try testSegmentedList(0, a);
     try testSegmentedList(1, a);

--- a/std/segmented_list.zig
+++ b/std/segmented_list.zig
@@ -89,7 +89,7 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
 
         prealloc_segment: [prealloc_item_count]T,
         dynamic_segments: [][*]T,
-        allocator: *Allocator,
+        allocator: Allocator,
         len: usize,
 
         pub const prealloc_count = prealloc_item_count;
@@ -103,7 +103,7 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
         }
 
         /// Deinitialize with `deinit`
-        pub fn init(allocator: *Allocator) Self {
+        pub fn init(allocator: Allocator) Self {
             return Self{
                 .allocator = allocator,
                 .len = 0,
@@ -346,7 +346,7 @@ test "std.SegmentedList" {
     try testSegmentedList(16, a);
 }
 
-fn testSegmentedList(comptime prealloc: usize, allocator: *Allocator) !void {
+fn testSegmentedList(comptime prealloc: usize, allocator: Allocator) !void {
     var list = SegmentedList(i32, prealloc).init(allocator);
     defer list.deinit();
 

--- a/std/sort.zig
+++ b/std/sort.zig
@@ -1166,7 +1166,7 @@ test "sort fuzz testing" {
     const test_case_count = 10;
     var i: usize = 0;
     while (i < test_case_count) : (i += 1) {
-        fuzzTest(&prng.random);
+        fuzzTest(&prng.random());
     }
 }
 

--- a/std/sort.zig
+++ b/std/sort.zig
@@ -1175,7 +1175,7 @@ var fixed_buffer_mem: [100 * 1024]u8 = undefined;
 fn fuzzTest(rng: std.rand.Random) void {
     const array_size = rng.range(usize, 0, 1000);
     var fixed_allocator = std.heap.FixedBufferAllocator.init(fixed_buffer_mem[0..]);
-    var array = fixed_allocator.allocator.alloc(IdAndValue, array_size) catch unreachable;
+    var array = fixed_allocator.allocator().alloc(IdAndValue, array_size) catch unreachable;
     // populate with random data
     for (array) |*item, index| {
         item.id = index;

--- a/std/sort.zig
+++ b/std/sort.zig
@@ -1166,13 +1166,13 @@ test "sort fuzz testing" {
     const test_case_count = 10;
     var i: usize = 0;
     while (i < test_case_count) : (i += 1) {
-        fuzzTest(&prng.random());
+        fuzzTest(prng.random());
     }
 }
 
 var fixed_buffer_mem: [100 * 1024]u8 = undefined;
 
-fn fuzzTest(rng: *std.rand.Random) void {
+fn fuzzTest(rng: std.rand.Random) void {
     const array_size = rng.range(usize, 0, 1000);
     var fixed_allocator = std.heap.FixedBufferAllocator.init(fixed_buffer_mem[0..]);
     var array = fixed_allocator.allocator.alloc(IdAndValue, array_size) catch unreachable;

--- a/std/special/build_runner.zig
+++ b/std/special/build_runner.zig
@@ -19,10 +19,10 @@ pub fn main() !void {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(direct_allocator.allocator());
     defer arena.deinit();
 
-    const allocator = &arena.allocator;
+    const allocator = arena.allocator();
 
     // skip my own exe name
     _ = arg_it.skip();

--- a/std/special/build_runner.zig
+++ b/std/special/build_runner.zig
@@ -48,14 +48,14 @@ pub fn main() !void {
     var prefix: ?[]const u8 = null;
 
     var stderr_file = io.getStdErr();
-    var stderr_file_stream: os.File.OutStream = undefined;
+    var stderr_file_stream: os.File.OutStreamAdapter = undefined;
     var stderr_stream = if (stderr_file) |f| x: {
         stderr_file_stream = f.outStreamAdapter();
         break :x stderr_file_stream.outStream();
     } else |err| err;
 
     var stdout_file = io.getStdOut();
-    var stdout_file_stream: os.File.OutStream = undefined;
+    var stdout_file_stream: os.File.OutStreamAdapter = undefined;
     var stdout_stream = if (stdout_file) |f| x: {
         stdout_file_stream = f.outStreamAdapter();
         break :x stdout_file_stream.outStream();

--- a/std/special/build_runner.zig
+++ b/std/special/build_runner.zig
@@ -51,7 +51,7 @@ pub fn main() !void {
     var stderr_file_stream: os.File.OutStream = undefined;
     var stderr_stream = if (stderr_file) |f| x: {
         stderr_file_stream = f.outStreamAdapter();
-        break :x &stderr_file_stream.stream;
+        break :x stderr_file_stream.outStream();
     } else |err| err;
 
     var stdout_file = io.getStdOut();

--- a/std/special/build_runner.zig
+++ b/std/special/build_runner.zig
@@ -50,14 +50,14 @@ pub fn main() !void {
     var stderr_file = io.getStdErr();
     var stderr_file_stream: os.File.OutStream = undefined;
     var stderr_stream = if (stderr_file) |f| x: {
-        stderr_file_stream = f.outStream();
+        stderr_file_stream = f.outStreamAdapter();
         break :x &stderr_file_stream.stream;
     } else |err| err;
 
     var stdout_file = io.getStdOut();
     var stdout_file_stream: os.File.OutStream = undefined;
     var stdout_stream = if (stdout_file) |f| x: {
-        stdout_file_stream = f.outStream();
+        stdout_file_stream = f.outStreamAdapter();
         break :x &stdout_file_stream.stream;
     } else |err| err;
 

--- a/std/special/build_runner.zig
+++ b/std/special/build_runner.zig
@@ -58,7 +58,7 @@ pub fn main() !void {
     var stdout_file_stream: os.File.OutStream = undefined;
     var stdout_stream = if (stdout_file) |f| x: {
         stdout_file_stream = f.outStreamAdapter();
-        break :x &stdout_file_stream.stream;
+        break :x stdout_file_stream.outStream();
     } else |err| err;
 
     while (arg_it.next(allocator)) |err_or_arg| {

--- a/std/statically_initialized_mutex.zig
+++ b/std/statically_initialized_mutex.zig
@@ -87,7 +87,7 @@ test "std.StaticallyInitializedMutex" {
     defer direct_allocator.allocator.free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
-    var a = &fixed_buffer_allocator.allocator;
+    var a = fixed_buffer_allocator.allocator();
 
     var context = TestContext{ .data = 0 };
 

--- a/std/statically_initialized_mutex.zig
+++ b/std/statically_initialized_mutex.zig
@@ -83,8 +83,8 @@ test "std.StaticallyInitializedMutex" {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var plenty_of_memory = try direct_allocator.allocator.alloc(u8, 300 * 1024);
-    defer direct_allocator.allocator.free(plenty_of_memory);
+    var plenty_of_memory = try direct_allocator.allocator().alloc(u8, 300 * 1024);
+    defer direct_allocator.allocator().free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
     var a = fixed_buffer_allocator.allocator();

--- a/std/std.zig
+++ b/std/std.zig
@@ -7,6 +7,7 @@ pub const Buffer = @import("buffer.zig").Buffer;
 pub const BufferOutStream = @import("io.zig").BufferOutStream;
 pub const DynLib = @import("dynamic_library.zig").DynLib;
 pub const HashMap = @import("hash_map.zig").HashMap;
+pub const Interface = @import("interface.zig").Interface;
 pub const LinkedList = @import("linked_list.zig").LinkedList;
 pub const Mutex = @import("mutex.zig").Mutex;
 pub const PackedIntArrayEndian = @import("packed_int_array.zig").PackedIntArrayEndian;

--- a/std/unicode.zig
+++ b/std/unicode.zig
@@ -465,7 +465,7 @@ fn testDecode(bytes: []const u8) !u32 {
 }
 
 /// Caller must free returned memory.
-pub fn utf16leToUtf8Alloc(allocator: *mem.Allocator, utf16le: []const u16) ![]u8 {
+pub fn utf16leToUtf8Alloc(allocator: mem.Allocator, utf16le: []const u16) ![]u8 {
     var result = std.ArrayList(u8).init(allocator);
     // optimistically guess that it will all be ascii.
     try result.ensureCapacity(utf16le.len);
@@ -544,7 +544,7 @@ test "utf16leToUtf8" {
 
 /// TODO support codepoints bigger than 16 bits
 /// TODO type for null terminated pointer
-pub fn utf8ToUtf16LeWithNull(allocator: *mem.Allocator, utf8: []const u8) ![]u16 {
+pub fn utf8ToUtf16LeWithNull(allocator: mem.Allocator, utf8: []const u8) ![]u16 {
     var result = std.ArrayList(u16).init(allocator);
     // optimistically guess that it will not require surrogate pairs
     try result.ensureCapacity(utf8.len + 1);

--- a/std/zig/bench.zig
+++ b/std/zig/bench.zig
@@ -30,7 +30,7 @@ pub fn main() !void {
 
 fn testOnce() usize {
     var fixed_buf_alloc = std.heap.FixedBufferAllocator.init(fixed_buffer_mem[0..]);
-    var allocator = &fixed_buf_alloc.allocator;
+    var allocator = fixed_buf_alloc.allocator();
     _ = std.zig.parse(allocator, source) catch @panic("parse failure");
     return fixed_buf_alloc.end_index;
 }

--- a/std/zig/bench.zig
+++ b/std/zig/bench.zig
@@ -24,7 +24,7 @@ pub fn main() !void {
     const mb_per_sec = bytes_per_sec / (1024 * 1024);
 
     var stdout_file = try std.io.getStdOut();
-    const stdout = &stdout_file.outStreamAdapter().stream;
+    const stdout = stdout_file.outStreamAdapter().outStream();
     try stdout.print("{.3} MiB/s, {} KiB used \n", mb_per_sec, memory_used / 1024);
 }
 

--- a/std/zig/bench.zig
+++ b/std/zig/bench.zig
@@ -24,7 +24,7 @@ pub fn main() !void {
     const mb_per_sec = bytes_per_sec / (1024 * 1024);
 
     var stdout_file = try std.io.getStdOut();
-    const stdout = &stdout_file.outStream().stream;
+    const stdout = &stdout_file.outStreamAdapter().stream;
     try stdout.print("{.3} MiB/s, {} KiB used \n", mb_per_sec, memory_used / 1024);
 }
 

--- a/std/zig/parse.zig
+++ b/std/zig/parse.zig
@@ -33,7 +33,7 @@ pub fn parse(allocator: Allocator, source: []const u8) !*Tree {
         break :blk tree;
     };
     errdefer tree.deinit();
-    const arena = &tree.arena_allocator.allocator;
+    const arena = tree.arena_allocator.allocator();
 
     tree.tokens = ast.Tree.TokenList.init(arena);
     tree.errors = ast.Tree.ErrorList.init(arena);

--- a/std/zig/parse.zig
+++ b/std/zig/parse.zig
@@ -22,7 +22,7 @@ pub fn parse(allocator: Allocator, source: []const u8) !*Tree {
         // https://github.com/ziglang/zig/commit/cb4fb14b6e66bd213575f69eec9598be8394fae6
         var arena = std.heap.ArenaAllocator.init(allocator);
         errdefer arena.deinit();
-        const tree = try arena.allocator.create(ast.Tree);
+        const tree = try arena.allocator().create(ast.Tree);
         tree.* = ast.Tree{
             .source = source,
             .root_node = undefined,

--- a/std/zig/parse_string_literal.zig
+++ b/std/zig/parse_string_literal.zig
@@ -15,7 +15,7 @@ pub const ParseStringLiteralError = error{
 
 /// caller owns returned memory
 pub fn parseStringLiteral(
-    allocator: *std.mem.Allocator,
+    allocator: std.mem.Allocator,
     bytes: []const u8,
     bad_index: *usize, // populated if error.InvalidCharacter is returned
 ) ParseStringLiteralError![]u8 {

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2180,7 +2180,7 @@ var fixed_buffer_mem: [100 * 1024]u8 = undefined;
 
 fn testParse(source: []const u8, allocator: mem.Allocator, anything_changed: *bool) ![]u8 {
     var stderr_file = try io.getStdErr();
-    var stderr = &stderr_file.outStream().stream;
+    var stderr = &stderr_file.outStreamAdapter().stream;
 
     const tree = try std.zig.parse(allocator, source);
     defer tree.deinit();

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2215,7 +2215,7 @@ fn testParse(source: []const u8, allocator: mem.Allocator, anything_changed: *bo
     errdefer buffer.deinit();
 
     var buffer_out_stream = io.BufferOutStream.init(&buffer);
-    anything_changed.* = try std.zig.render(allocator, &buffer_out_stream.stream, tree);
+    anything_changed.* = try std.zig.render(allocator, buffer_out_stream.outStream(), tree);
     return buffer.toOwnedSlice();
 }
 

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -159,7 +159,7 @@ test "zig fmt: spaces around slice operator" {
 test "zig fmt: async call in if condition" {
     try testCanonical(
         \\comptime {
-        \\    if (async<a> b()) {
+        \\    if (async<&a> b()) {
         \\        a();
         \\    }
         \\}
@@ -2065,7 +2065,7 @@ test "zig fmt: coroutines" {
         \\}
         \\
         \\test "coroutine suspend, resume, cancel" {
-        \\    const p: promise = try async<std.debug.global_allocator> testAsyncSeq();
+        \\    const p: promise = try async<&std.debug.global_allocator> testAsyncSeq();
         \\    resume p;
         \\    cancel p;
         \\}

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2180,7 +2180,7 @@ var fixed_buffer_mem: [100 * 1024]u8 = undefined;
 
 fn testParse(source: []const u8, allocator: mem.Allocator, anything_changed: *bool) ![]u8 {
     var stderr_file = try io.getStdErr();
-    var stderr = &stderr_file.outStreamAdapter().stream;
+    var stderr = stderr_file.outStreamAdapter().outStream();
 
     const tree = try std.zig.parse(allocator, source);
     defer tree.deinit();

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -86,7 +86,7 @@ test "zig fmt: doc comments on param decl" {
     try testCanonical(
         \\pub const Allocator = struct {
         \\    shrinkFn: fn (
-        \\        self: *Allocator,
+        \\        self: Allocator,
         \\        /// Guaranteed to be the same as what was returned from most recent call to
         \\        /// `allocFn`, `reallocFn`, or `shrinkFn`.
         \\        old_mem: []u8,
@@ -2178,7 +2178,7 @@ const maxInt = std.math.maxInt;
 
 var fixed_buffer_mem: [100 * 1024]u8 = undefined;
 
-fn testParse(source: []const u8, allocator: *mem.Allocator, anything_changed: *bool) ![]u8 {
+fn testParse(source: []const u8, allocator: mem.Allocator, anything_changed: *bool) ![]u8 {
     var stderr_file = try io.getStdErr();
     var stderr = &stderr_file.outStream().stream;
 

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2240,7 +2240,7 @@ fn testTransform(source: []const u8, expected_source: []const u8) !void {
             return error.TestFailed;
         }
         std.testing.expect(anything_changed == changes_expected);
-        failing_allocator.allocator.free(result_source);
+        failing_allocator.allocator().free(result_source);
         break :x failing_allocator.index;
     };
 

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2223,9 +2223,9 @@ fn testTransform(source: []const u8, expected_source: []const u8) !void {
     const needed_alloc_count = x: {
         // Try it once with unlimited memory, make sure it works
         var fixed_allocator = std.heap.FixedBufferAllocator.init(fixed_buffer_mem[0..]);
-        var failing_allocator = std.debug.FailingAllocator.init(&fixed_allocator.allocator, maxInt(usize));
+        var failing_allocator = std.debug.FailingAllocator.init(fixed_allocator.allocator(), maxInt(usize));
         var anything_changed: bool = undefined;
-        const result_source = try testParse(source, &failing_allocator.allocator, &anything_changed);
+        const result_source = try testParse(source, failing_allocator.allocator(), &anything_changed);
         if (!mem.eql(u8, result_source, expected_source)) {
             warn("\n====== expected this output: =========\n");
             warn("{}", expected_source);
@@ -2247,9 +2247,9 @@ fn testTransform(source: []const u8, expected_source: []const u8) !void {
     var fail_index: usize = 0;
     while (fail_index < needed_alloc_count) : (fail_index += 1) {
         var fixed_allocator = std.heap.FixedBufferAllocator.init(fixed_buffer_mem[0..]);
-        var failing_allocator = std.debug.FailingAllocator.init(&fixed_allocator.allocator, fail_index);
+        var failing_allocator = std.debug.FailingAllocator.init(fixed_allocator.allocator(), fail_index);
         var anything_changed: bool = undefined;
-        if (testParse(source, &failing_allocator.allocator, &anything_changed)) |_| {
+        if (testParse(source, failing_allocator.allocator(), &anything_changed)) |_| {
             return error.NondeterministicMemoryUsage;
         } else |err| switch (err) {
             error.OutOfMemory => {

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -28,7 +28,7 @@ pub fn render(allocator: mem.Allocator, stream: var, tree: *ast.Tree) (@typeOf(s
         source: []const u8,
 
         fn write(iface_stream: Stream, bytes: []const u8) StreamError!void {
-            const self = iface_stream.implCast(MyStream);
+            const self = iface_stream.iface.implCast(MyStream);
 
             if (!self.anything_changed_ptr.*) {
                 const end = self.source_index + bytes.len;
@@ -45,10 +45,10 @@ pub fn render(allocator: mem.Allocator, stream: var, tree: *ast.Tree) (@typeOf(s
 
             try self.child_stream.write(bytes);
         }
-        
+
         pub fn outStream(self: *MyStream) Stream {
-            return Stream {
-                .impl = Stream.ifaceCast(self),
+            return Stream{
+                .iface = Stream.Iface.init(self),
                 .writeFn = write,
             };
         }
@@ -2094,7 +2094,7 @@ const FindByteOutStream = struct {
     }
 
     fn writeFn(out_stream: Stream, bytes: []const u8) Error!void {
-        const self = out_stream.implCast(Self);
+        const self = out_stream.iface.implCast(Self);
         if (self.byte_found) return;
         self.byte_found = blk: {
             for (bytes) |b|
@@ -2102,10 +2102,10 @@ const FindByteOutStream = struct {
             break :blk false;
         };
     }
-    
+
     pub fn outStream(self: *Self) Stream {
-        return Stream {
-            .impl = Stream.ifaceCast(self),
+        return Stream{
+            .iface = Stream.Iface.init(self),
             .writeFn = writeFn,
         };
     }

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -13,15 +13,13 @@ pub const Error = error{
 };
 
 /// Returns whether anything changed
-pub fn render(allocator: mem.Allocator, stream: var, tree: *ast.Tree) (@typeOf(stream).Child.Error || Error)!bool {
-    comptime assert(@typeId(@typeOf(stream)) == builtin.TypeId.Pointer);
-
+pub fn render(allocator: mem.Allocator, stream: var, tree: *ast.Tree) (@typeOf(stream).Error || Error)!bool {
     var anything_changed: bool = false;
 
     // make a passthrough stream that checks whether something changed
     const MyStream = struct {
         const MyStream = @This();
-        const StreamError = @typeOf(stream).Child.Error;
+        const StreamError = @typeOf(stream).Error;
         const Stream = std.io.OutStream(StreamError);
 
         anything_changed_ptr: *bool,
@@ -75,7 +73,7 @@ fn renderRoot(
     allocator: mem.Allocator,
     stream: var,
     tree: *ast.Tree,
-) (@typeOf(stream).Child.Error || Error)!void {
+) (@typeOf(stream).Error || Error)!void {
     var tok_it = tree.tokens.iterator(0);
 
     // render all the line comments at the beginning of the file
@@ -137,7 +135,7 @@ fn renderRoot(
     }
 }
 
-fn renderExtraNewline(tree: *ast.Tree, stream: var, start_col: *usize, node: *ast.Node) @typeOf(stream).Child.Error!void {
+fn renderExtraNewline(tree: *ast.Tree, stream: var, start_col: *usize, node: *ast.Node) @typeOf(stream).Error!void {
     const first_token = node.firstToken();
     var prev_token = first_token;
     while (tree.tokens.at(prev_token - 1).id == Token.Id.DocComment) {
@@ -151,7 +149,7 @@ fn renderExtraNewline(tree: *ast.Tree, stream: var, start_col: *usize, node: *as
     }
 }
 
-fn renderTopLevelDecl(allocator: mem.Allocator, stream: var, tree: *ast.Tree, indent: usize, start_col: *usize, decl: *ast.Node) (@typeOf(stream).Child.Error || Error)!void {
+fn renderTopLevelDecl(allocator: mem.Allocator, stream: var, tree: *ast.Tree, indent: usize, start_col: *usize, decl: *ast.Node) (@typeOf(stream).Error || Error)!void {
     switch (decl.id) {
         ast.Node.Id.FnProto => {
             const fn_proto = @fieldParentPtr(ast.Node.FnProto, "base", decl);
@@ -238,7 +236,7 @@ fn renderExpression(
     start_col: *usize,
     base: *ast.Node,
     space: Space,
-) (@typeOf(stream).Child.Error || Error)!void {
+) (@typeOf(stream).Error || Error)!void {
     switch (base.id) {
         ast.Node.Id.Identifier => {
             const identifier = @fieldParentPtr(ast.Node.Identifier, "base", base);
@@ -1718,7 +1716,7 @@ fn renderVarDecl(
     indent: usize,
     start_col: *usize,
     var_decl: *ast.Node.VarDecl,
-) (@typeOf(stream).Child.Error || Error)!void {
+) (@typeOf(stream).Error || Error)!void {
     if (var_decl.visib_token) |visib_token| {
         try renderToken(tree, stream, visib_token, indent, start_col, Space.Space); // pub
     }
@@ -1791,7 +1789,7 @@ fn renderParamDecl(
     start_col: *usize,
     base: *ast.Node,
     space: Space,
-) (@typeOf(stream).Child.Error || Error)!void {
+) (@typeOf(stream).Error || Error)!void {
     const param_decl = @fieldParentPtr(ast.Node.ParamDecl, "base", base);
 
     try renderDocComments(tree, stream, param_decl, indent, start_col);
@@ -1820,7 +1818,7 @@ fn renderStatement(
     indent: usize,
     start_col: *usize,
     base: *ast.Node,
-) (@typeOf(stream).Child.Error || Error)!void {
+) (@typeOf(stream).Error || Error)!void {
     switch (base.id) {
         ast.Node.Id.VarDecl => {
             const var_decl = @fieldParentPtr(ast.Node.VarDecl, "base", base);
@@ -1859,7 +1857,7 @@ fn renderTokenOffset(
     start_col: *usize,
     space: Space,
     token_skip_bytes: usize,
-) (@typeOf(stream).Child.Error || Error)!void {
+) (@typeOf(stream).Error || Error)!void {
     if (space == Space.BlockStart) {
         if (start_col.* < indent + indent_delta)
             return renderToken(tree, stream, token_index, indent, start_col, Space.Space);
@@ -2032,7 +2030,7 @@ fn renderToken(
     indent: usize,
     start_col: *usize,
     space: Space,
-) (@typeOf(stream).Child.Error || Error)!void {
+) (@typeOf(stream).Error || Error)!void {
     return renderTokenOffset(tree, stream, token_index, indent, start_col, space, 0);
 }
 
@@ -2042,7 +2040,7 @@ fn renderDocComments(
     node: var,
     indent: usize,
     start_col: *usize,
-) (@typeOf(stream).Child.Error || Error)!void {
+) (@typeOf(stream).Error || Error)!void {
     const comment = node.doc_comments orelse return;
     var it = comment.lines.iterator(0);
     const first_token = node.firstToken();

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -13,7 +13,7 @@ pub const Error = error{
 };
 
 /// Returns whether anything changed
-pub fn render(allocator: *mem.Allocator, stream: var, tree: *ast.Tree) (@typeOf(stream).Child.Error || Error)!bool {
+pub fn render(allocator: mem.Allocator, stream: var, tree: *ast.Tree) (@typeOf(stream).Child.Error || Error)!bool {
     comptime assert(@typeId(@typeOf(stream)) == builtin.TypeId.Pointer);
 
     var anything_changed: bool = false;
@@ -67,7 +67,7 @@ pub fn render(allocator: *mem.Allocator, stream: var, tree: *ast.Tree) (@typeOf(
 }
 
 fn renderRoot(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     stream: var,
     tree: *ast.Tree,
 ) (@typeOf(stream).Child.Error || Error)!void {
@@ -146,7 +146,7 @@ fn renderExtraNewline(tree: *ast.Tree, stream: var, start_col: *usize, node: *as
     }
 }
 
-fn renderTopLevelDecl(allocator: *mem.Allocator, stream: var, tree: *ast.Tree, indent: usize, start_col: *usize, decl: *ast.Node) (@typeOf(stream).Child.Error || Error)!void {
+fn renderTopLevelDecl(allocator: mem.Allocator, stream: var, tree: *ast.Tree, indent: usize, start_col: *usize, decl: *ast.Node) (@typeOf(stream).Child.Error || Error)!void {
     switch (decl.id) {
         ast.Node.Id.FnProto => {
             const fn_proto = @fieldParentPtr(ast.Node.FnProto, "base", decl);
@@ -226,7 +226,7 @@ fn renderTopLevelDecl(allocator: *mem.Allocator, stream: var, tree: *ast.Tree, i
 }
 
 fn renderExpression(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     stream: var,
     tree: *ast.Tree,
     indent: usize,
@@ -1707,7 +1707,7 @@ fn renderExpression(
 }
 
 fn renderVarDecl(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     stream: var,
     tree: *ast.Tree,
     indent: usize,
@@ -1779,7 +1779,7 @@ fn renderVarDecl(
 }
 
 fn renderParamDecl(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     stream: var,
     tree: *ast.Tree,
     indent: usize,
@@ -1809,7 +1809,7 @@ fn renderParamDecl(
 }
 
 fn renderStatement(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     stream: var,
     tree: *ast.Tree,
     indent: usize,

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -9,7 +9,7 @@ pub fn main() !void {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(direct_allocator.allocator());
     defer arena.deinit();
 
     var arg_it = os.args();
@@ -17,7 +17,7 @@ pub fn main() !void {
     // skip my own exe name
     _ = arg_it.skip();
 
-    a = &arena.allocator;
+    a = arena.allocator();
 
     const zig_exe_rel = try (arg_it.next(a) orelse {
         std.debug.warn("Expected first argument to be path to zig compiler\n");

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const os = std.os;
 const testing = std.testing;
 
-var a: *std.mem.Allocator = undefined;
+var a: std.mem.Allocator = undefined;
 
 pub fn main() !void {
     var direct_allocator = std.heap.DirectAllocator.init();

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -19,7 +19,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\
             \\pub fn main() void {
             \\    privateFunction();
-            \\    const stdout = &(getStdOut() catch unreachable).outStreamAdapter().stream;
+            \\    const stdout = (getStdOut() catch unreachable).outStreamAdapter().outStream();
             \\    stdout.print("OK 2\n") catch unreachable;
             \\}
             \\
@@ -34,7 +34,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\// purposefully conflicting function with main.zig
             \\// but it's private so it should be OK
             \\fn privateFunction() void {
-            \\    const stdout = &(getStdOut() catch unreachable).outStreamAdapter().stream;
+            \\    const stdout = (getStdOut() catch unreachable).outStreamAdapter().outStream();
             \\    stdout.print("OK 1\n") catch unreachable;
             \\}
             \\
@@ -60,7 +60,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         tc.addSourceFile("foo.zig",
             \\use @import("std").io;
             \\pub fn foo_function() void {
-            \\    const stdout = &(getStdOut() catch unreachable).outStreamAdapter().stream;
+            \\    const stdout = (getStdOut() catch unreachable).outStreamAdapter().outStream();
             \\    stdout.print("OK\n") catch unreachable;
             \\}
         );
@@ -71,7 +71,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\
             \\pub fn bar_function() void {
             \\    if (foo_function()) {
-            \\        const stdout = &(getStdOut() catch unreachable).outStreamAdapter().stream;
+            \\        const stdout = (getStdOut() catch unreachable).outStreamAdapter().outStream();
             \\        stdout.print("OK\n") catch unreachable;
             \\    }
             \\}
@@ -103,7 +103,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\pub const a_text = "OK\n";
             \\
             \\pub fn ok() void {
-            \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
+            \\    const stdout = (io.getStdOut() catch unreachable).outStreamAdapter().outStream();
             \\    stdout.print(b_text) catch unreachable;
             \\}
         );
@@ -121,7 +121,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\const io = @import("std").io;
         \\
         \\pub fn main() void {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
+        \\    const stdout = (io.getStdOut() catch unreachable).outStreamAdapter().outStream();
         \\    stdout.print("Hello, world!\n{d4} {x3} {c}\n", u32(12), u16(0x12), u8('a')) catch unreachable;
         \\}
     , "Hello, world!\n0012 012 a\n");
@@ -264,7 +264,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    var x_local : i32 = print_ok(x);
         \\}
         \\fn print_ok(val: @typeOf(x)) @typeOf(foo) {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
+        \\    const stdout = (io.getStdOut() catch unreachable).outStreamAdapter().outStream();
         \\    stdout.print("OK\n") catch unreachable;
         \\    return 0;
         \\}
@@ -346,7 +346,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\pub fn main() void {
         \\    const bar = Bar {.field2 = 13,};
         \\    const foo = Foo {.field1 = bar,};
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
+        \\    const stdout = (io.getStdOut() catch unreachable).outStreamAdapter().outStream();
         \\    if (!foo.method()) {
         \\        stdout.print("BAD\n") catch unreachable;
         \\    }
@@ -360,7 +360,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
     cases.add("defer with only fallthrough",
         \\const io = @import("std").io;
         \\pub fn main() void {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
+        \\    const stdout = (io.getStdOut() catch unreachable).outStreamAdapter().outStream();
         \\    stdout.print("before\n") catch unreachable;
         \\    defer stdout.print("defer1\n") catch unreachable;
         \\    defer stdout.print("defer2\n") catch unreachable;
@@ -373,7 +373,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\const io = @import("std").io;
         \\const os = @import("std").os;
         \\pub fn main() void {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
+        \\    const stdout = (io.getStdOut() catch unreachable).outStreamAdapter().outStream();
         \\    stdout.print("before\n") catch unreachable;
         \\    defer stdout.print("defer1\n") catch unreachable;
         \\    defer stdout.print("defer2\n") catch unreachable;
@@ -390,7 +390,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    do_test() catch return;
         \\}
         \\fn do_test() !void {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
+        \\    const stdout = (io.getStdOut() catch unreachable).outStreamAdapter().outStream();
         \\    stdout.print("before\n") catch unreachable;
         \\    defer stdout.print("defer1\n") catch unreachable;
         \\    errdefer stdout.print("deferErr\n") catch unreachable;
@@ -409,7 +409,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    do_test() catch return;
         \\}
         \\fn do_test() !void {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
+        \\    const stdout = (io.getStdOut() catch unreachable).outStreamAdapter().outStream();
         \\    stdout.print("before\n") catch unreachable;
         \\    defer stdout.print("defer1\n") catch unreachable;
         \\    errdefer stdout.print("deferErr\n") catch unreachable;
@@ -426,7 +426,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\const io = @import("std").io;
             \\
             \\pub fn main() void {
-            \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
+            \\    const stdout = (io.getStdOut() catch unreachable).outStreamAdapter().outStream();
             \\    stdout.print(foo_txt) catch unreachable;
             \\}
         , "1234\nabcd\n");

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -447,7 +447,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\    var args_it = os.args();
             \\    var stdout_file = try io.getStdOut();
             \\    var stdout_adapter = stdout_file.outStreamAdapter();
-            \\    const stdout = &stdout_adapter.stream;
+            \\    const stdout = stdout_adapter.outStream();
             \\    var index: usize = 0;
             \\    _ = args_it.skip();
             \\    while (args_it.next(allocator)) |arg_or_err| : (index += 1) {
@@ -488,7 +488,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\    var args_it = os.args();
             \\    var stdout_file = try io.getStdOut();
             \\    var stdout_adapter = stdout_file.outStreamAdapter();
-            \\    const stdout = &stdout_adapter.stream;
+            \\    const stdout = stdout_adapter.outStream();
             \\    var index: usize = 0;
             \\    _ = args_it.skip();
             \\    while (args_it.next(allocator)) |arg_or_err| : (index += 1) {

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -19,7 +19,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\
             \\pub fn main() void {
             \\    privateFunction();
-            \\    const stdout = &(getStdOut() catch unreachable).outStream().stream;
+            \\    const stdout = &(getStdOut() catch unreachable).outStreamAdapter().stream;
             \\    stdout.print("OK 2\n") catch unreachable;
             \\}
             \\
@@ -34,7 +34,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\// purposefully conflicting function with main.zig
             \\// but it's private so it should be OK
             \\fn privateFunction() void {
-            \\    const stdout = &(getStdOut() catch unreachable).outStream().stream;
+            \\    const stdout = &(getStdOut() catch unreachable).outStreamAdapter().stream;
             \\    stdout.print("OK 1\n") catch unreachable;
             \\}
             \\
@@ -60,7 +60,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         tc.addSourceFile("foo.zig",
             \\use @import("std").io;
             \\pub fn foo_function() void {
-            \\    const stdout = &(getStdOut() catch unreachable).outStream().stream;
+            \\    const stdout = &(getStdOut() catch unreachable).outStreamAdapter().stream;
             \\    stdout.print("OK\n") catch unreachable;
             \\}
         );
@@ -71,7 +71,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\
             \\pub fn bar_function() void {
             \\    if (foo_function()) {
-            \\        const stdout = &(getStdOut() catch unreachable).outStream().stream;
+            \\        const stdout = &(getStdOut() catch unreachable).outStreamAdapter().stream;
             \\        stdout.print("OK\n") catch unreachable;
             \\    }
             \\}
@@ -103,7 +103,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\pub const a_text = "OK\n";
             \\
             \\pub fn ok() void {
-            \\    const stdout = &(io.getStdOut() catch unreachable).outStream().stream;
+            \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
             \\    stdout.print(b_text) catch unreachable;
             \\}
         );
@@ -121,7 +121,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\const io = @import("std").io;
         \\
         \\pub fn main() void {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStream().stream;
+        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
         \\    stdout.print("Hello, world!\n{d4} {x3} {c}\n", u32(12), u16(0x12), u8('a')) catch unreachable;
         \\}
     , "Hello, world!\n0012 012 a\n");
@@ -264,7 +264,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    var x_local : i32 = print_ok(x);
         \\}
         \\fn print_ok(val: @typeOf(x)) @typeOf(foo) {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStream().stream;
+        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
         \\    stdout.print("OK\n") catch unreachable;
         \\    return 0;
         \\}
@@ -346,7 +346,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\pub fn main() void {
         \\    const bar = Bar {.field2 = 13,};
         \\    const foo = Foo {.field1 = bar,};
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStream().stream;
+        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
         \\    if (!foo.method()) {
         \\        stdout.print("BAD\n") catch unreachable;
         \\    }
@@ -360,7 +360,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
     cases.add("defer with only fallthrough",
         \\const io = @import("std").io;
         \\pub fn main() void {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStream().stream;
+        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
         \\    stdout.print("before\n") catch unreachable;
         \\    defer stdout.print("defer1\n") catch unreachable;
         \\    defer stdout.print("defer2\n") catch unreachable;
@@ -373,7 +373,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\const io = @import("std").io;
         \\const os = @import("std").os;
         \\pub fn main() void {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStream().stream;
+        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
         \\    stdout.print("before\n") catch unreachable;
         \\    defer stdout.print("defer1\n") catch unreachable;
         \\    defer stdout.print("defer2\n") catch unreachable;
@@ -390,7 +390,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    do_test() catch return;
         \\}
         \\fn do_test() !void {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStream().stream;
+        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
         \\    stdout.print("before\n") catch unreachable;
         \\    defer stdout.print("defer1\n") catch unreachable;
         \\    errdefer stdout.print("deferErr\n") catch unreachable;
@@ -409,7 +409,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    do_test() catch return;
         \\}
         \\fn do_test() !void {
-        \\    const stdout = &(io.getStdOut() catch unreachable).outStream().stream;
+        \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
         \\    stdout.print("before\n") catch unreachable;
         \\    defer stdout.print("defer1\n") catch unreachable;
         \\    errdefer stdout.print("deferErr\n") catch unreachable;
@@ -426,7 +426,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\const io = @import("std").io;
             \\
             \\pub fn main() void {
-            \\    const stdout = &(io.getStdOut() catch unreachable).outStream().stream;
+            \\    const stdout = &(io.getStdOut() catch unreachable).outStreamAdapter().stream;
             \\    stdout.print(foo_txt) catch unreachable;
             \\}
         , "1234\nabcd\n");
@@ -446,7 +446,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\pub fn main() !void {
             \\    var args_it = os.args();
             \\    var stdout_file = try io.getStdOut();
-            \\    var stdout_adapter = stdout_file.outStream();
+            \\    var stdout_adapter = stdout_file.outStreamAdapter();
             \\    const stdout = &stdout_adapter.stream;
             \\    var index: usize = 0;
             \\    _ = args_it.skip();
@@ -487,7 +487,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\pub fn main() !void {
             \\    var args_it = os.args();
             \\    var stdout_file = try io.getStdOut();
-            \\    var stdout_adapter = stdout_file.outStream();
+            \\    var stdout_adapter = stdout_file.outStreamAdapter();
             \\    const stdout = &stdout_adapter.stream;
             \\    var index: usize = 0;
             \\    _ = args_it.skip();

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1564,7 +1564,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\export fn entry() void {
         \\    var buf: [500]u8 = undefined;
         \\    var a = std.heap.FixedBufferAllocator.init(buf[0..]).allocator();
-        \\    const p = (async<a> foo()) catch unreachable;
+        \\    const p = (async<&a> foo()) catch unreachable;
         \\    cancel p;
         \\}
         \\
@@ -1619,7 +1619,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "returning error from void async function",
         \\const std = @import("std",);
         \\export fn entry() void {
-        \\    const p = async<std.debug.global_allocator> amain() catch unreachable;
+        \\    const p = async<&std.debug.global_allocator> amain() catch unreachable;
         \\}
         \\async fn amain() void {
         \\    return error.ShouldBeCompileError;

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1563,7 +1563,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() void {
         \\    var buf: [500]u8 = undefined;
-        \\    var a = &std.heap.FixedBufferAllocator.init(buf[0..]).allocator;
+        \\    var a = std.heap.FixedBufferAllocator.init(buf[0..]).allocator();
         \\    const p = (async<a> foo()) catch unreachable;
         \\    cancel p;
         \\}

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -4042,9 +4042,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "method call with first arg type wrong container",
         \\pub const List = struct {
         \\    len: usize,
-        \\    allocator: *Allocator,
+        \\    allocator: Allocator,
         \\
-        \\    pub fn init(allocator: *Allocator) List {
+        \\    pub fn init(allocator: Allocator) List {
         \\        return List {
         \\            .len = 0,
         \\            .allocator = allocator,
@@ -4065,7 +4065,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    x.init();
         \\}
     ,
-        "tmp.zig:23:5: error: expected type '*Allocator', found '*List'",
+        "tmp.zig:23:5: error: expected type 'Allocator', found '*List'",
     );
 
     cases.add(

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -4061,11 +4061,11 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\};
         \\
         \\export fn foo() void {
-        \\    var x = List.init(&global_allocator);
+        \\    var x = List.init(global_allocator);
         \\    x.init();
         \\}
     ,
-        "tmp.zig:23:5: error: expected type 'Allocator', found '*List'",
+        "tmp.zig:23:5: error: expected type 'Allocator', found 'List'",
     );
 
     cases.add(
@@ -5122,7 +5122,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\
         \\export fn entry() void {
         \\    const a = MdNode.Header {
-        \\        .text = MdText.init(&std.debug.global_allocator),
+        \\        .text = MdText.init(std.debug.global_allocator),
         \\        .weight = HeaderWeight.H1,
         \\    };
         \\}

--- a/test/runtime_safety.zig
+++ b/test/runtime_safety.zig
@@ -486,12 +486,12 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\pub fn main() void {
         \\    const p = nonFailing();
         \\    resume p;
-        \\    const p2 = async<std.debug.global_allocator> printTrace(p) catch unreachable;
+        \\    const p2 = async<&std.debug.global_allocator> printTrace(p) catch unreachable;
         \\    cancel p2;
         \\}
         \\
         \\fn nonFailing() promise->anyerror!void {
-        \\    return async<std.debug.global_allocator> failing() catch unreachable;
+        \\    return async<&std.debug.global_allocator> failing() catch unreachable;
         \\}
         \\
         \\async fn failing() anyerror!void {

--- a/test/stage1/behavior/bugs/1851.zig
+++ b/test/stage1/behavior/bugs/1851.zig
@@ -7,7 +7,7 @@ test "allocation and looping over 3-byte integer" {
     expect(@alignOf(u24) == 4);
     expect(@alignOf([1]u24) == 4);
     var buffer: [100]u8 = undefined;
-    const a = &std.heap.FixedBufferAllocator.init(&buffer).allocator;
+    const a = std.heap.FixedBufferAllocator.init(&buffer).allocator();
 
     var x = a.alloc(u24, 2) catch unreachable;
     expect(x.len == 2);

--- a/test/stage1/behavior/bugs/920.zig
+++ b/test/stage1/behavior/bugs/920.zig
@@ -9,10 +9,10 @@ const ZigTable = struct {
 
     pdf: fn (f64) f64,
     is_symmetric: bool,
-    zero_case: fn (*Random, f64) f64,
+    zero_case: fn (Random, f64) f64,
 };
 
-fn ZigTableGen(comptime is_symmetric: bool, comptime r: f64, comptime v: f64, comptime f: fn (f64) f64, comptime f_inv: fn (f64) f64, comptime zero_case: fn (*Random, f64) f64) ZigTable {
+fn ZigTableGen(comptime is_symmetric: bool, comptime r: f64, comptime v: f64, comptime f: fn (f64) f64, comptime f_inv: fn (f64) f64, comptime zero_case: fn (Random, f64) f64) ZigTable {
     var tables: ZigTable = undefined;
 
     tables.is_symmetric = is_symmetric;
@@ -45,7 +45,7 @@ fn norm_f(x: f64) f64 {
 fn norm_f_inv(y: f64) f64 {
     return math.sqrt(-2.0 * math.ln(y));
 }
-fn norm_zero_case(random: *Random, u: f64) f64 {
+fn norm_zero_case(random: Random, u: f64) f64 {
     return 0.0;
 }
 

--- a/test/stage1/behavior/cancel.zig
+++ b/test/stage1/behavior/cancel.zig
@@ -8,7 +8,7 @@ test "cancel forwards" {
     var da = std.heap.DirectAllocator.init();
     defer da.deinit();
 
-    const p = async<&da.allocator> f1() catch unreachable;
+    const p = async<&da.allocator()> f1() catch unreachable;
     cancel p;
     std.testing.expect(defer_f1);
     std.testing.expect(defer_f2);
@@ -45,7 +45,7 @@ test "cancel backwards" {
     var da = std.heap.DirectAllocator.init();
     defer da.deinit();
 
-    const p = async<&da.allocator> b1() catch unreachable;
+    const p = async<&da.allocator()> b1() catch unreachable;
     cancel p;
     std.testing.expect(defer_b1);
     std.testing.expect(defer_b2);

--- a/test/stage1/behavior/coroutine_await_struct.zig
+++ b/test/stage1/behavior/coroutine_await_struct.zig
@@ -14,7 +14,7 @@ test "coroutine await struct" {
     defer da.deinit();
 
     await_seq('a');
-    const p = async<&da.allocator> await_amain() catch unreachable;
+    const p = async<&da.allocator()> await_amain() catch unreachable;
     await_seq('f');
     resume await_a_promise;
     await_seq('i');

--- a/test/stage1/behavior/coroutines.zig
+++ b/test/stage1/behavior/coroutines.zig
@@ -216,13 +216,13 @@ test "error return trace across suspend points - early return" {
 
 test "error return trace across suspend points - async return" {
     const p = nonFailing();
-    const p2 = try async<std.debug.global_allocator> printTrace(p);
+    const p2 = try async<&std.debug.global_allocator> printTrace(p);
     resume p;
     cancel p2;
 }
 
 fn nonFailing() (promise->anyerror!void) {
-    return async<std.debug.global_allocator> suspendThenFail() catch unreachable;
+    return async<&std.debug.global_allocator> suspendThenFail() catch unreachable;
 }
 async fn suspendThenFail() anyerror!void {
     suspend;
@@ -244,7 +244,7 @@ test "break from suspend" {
     var buf: [500]u8 = undefined;
     var a = std.heap.FixedBufferAllocator.init(buf[0..]).allocator();
     var my_result: i32 = 1;
-    const p = try async<a> testBreakFromSuspend(&my_result);
+    const p = try async<&a> testBreakFromSuspend(&my_result);
     cancel p;
     std.testing.expect(my_result == 2);
 }

--- a/test/stage1/behavior/coroutines.zig
+++ b/test/stage1/behavior/coroutines.zig
@@ -242,7 +242,7 @@ async fn printTrace(p: promise->(anyerror!void)) void {
 
 test "break from suspend" {
     var buf: [500]u8 = undefined;
-    var a = &std.heap.FixedBufferAllocator.init(buf[0..]).allocator;
+    var a = std.heap.FixedBufferAllocator.init(buf[0..]).allocator();
     var my_result: i32 = 1;
     const p = try async<a> testBreakFromSuspend(&my_result);
     cancel p;

--- a/test/standalone/brace_expansion/main.zig
+++ b/test/standalone/brace_expansion/main.zig
@@ -193,7 +193,7 @@ pub fn main() !void {
     var stdin_buf = try Buffer.initSize(global_allocator, 0);
     defer stdin_buf.deinit();
 
-    var stdin_adapter = stdin_file.inStream();
+    var stdin_adapter = stdin_file.inStreamAdapter();
     try stdin_adapter.stream.readAllBuffer(&stdin_buf, maxInt(usize));
 
     var result_buf = try Buffer.initSize(global_allocator, 0);

--- a/test/standalone/brace_expansion/main.zig
+++ b/test/standalone/brace_expansion/main.zig
@@ -194,7 +194,7 @@ pub fn main() !void {
     defer stdin_buf.deinit();
 
     var stdin_adapter = stdin_file.inStreamAdapter();
-    try stdin_adapter.stream.readAllBuffer(&stdin_buf, maxInt(usize));
+    try stdin_adapter.inStream().readAllBuffer(&stdin_buf, maxInt(usize));
 
     var result_buf = try Buffer.initSize(global_allocator, 0);
     defer result_buf.deinit();

--- a/test/standalone/brace_expansion/main.zig
+++ b/test/standalone/brace_expansion/main.zig
@@ -185,10 +185,10 @@ pub fn main() !void {
     var direct_allocator = std.heap.DirectAllocator.init();
     defer direct_allocator.deinit();
 
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(direct_allocator.allocator());
     defer arena.deinit();
 
-    global_allocator = &arena.allocator;
+    global_allocator = arena.allocator();
 
     var stdin_buf = try Buffer.initSize(global_allocator, 0);
     defer stdin_buf.deinit();

--- a/test/standalone/brace_expansion/main.zig
+++ b/test/standalone/brace_expansion/main.zig
@@ -16,7 +16,7 @@ const Token = union(enum) {
     Eof,
 };
 
-var global_allocator: *mem.Allocator = undefined;
+var global_allocator: mem.Allocator = undefined;
 
 fn tokenize(input: []const u8) !ArrayList(Token) {
     const State = enum {

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -314,8 +314,8 @@ pub const CompareOutputContext = struct {
             var stdout = Buffer.initNull(b.allocator);
             var stderr = Buffer.initNull(b.allocator);
 
-            var stdout_file_in_stream = child.stdout.?.inStream();
-            var stderr_file_in_stream = child.stderr.?.inStream();
+            var stdout_file_in_stream = child.stdout.?.inStreamAdapter();
+            var stderr_file_in_stream = child.stderr.?.inStreamAdapter();
 
             stdout_file_in_stream.stream.readAllBuffer(&stdout, max_stdout_size) catch unreachable;
             stderr_file_in_stream.stream.readAllBuffer(&stderr, max_stdout_size) catch unreachable;
@@ -682,8 +682,8 @@ pub const CompileErrorContext = struct {
             var stdout_buf = Buffer.initNull(b.allocator);
             var stderr_buf = Buffer.initNull(b.allocator);
 
-            var stdout_file_in_stream = child.stdout.?.inStream();
-            var stderr_file_in_stream = child.stderr.?.inStream();
+            var stdout_file_in_stream = child.stdout.?.inStreamAdapter();
+            var stderr_file_in_stream = child.stderr.?.inStreamAdapter();
 
             stdout_file_in_stream.stream.readAllBuffer(&stdout_buf, max_stdout_size) catch unreachable;
             stderr_file_in_stream.stream.readAllBuffer(&stderr_buf, max_stdout_size) catch unreachable;
@@ -989,8 +989,8 @@ pub const TranslateCContext = struct {
             var stdout_buf = Buffer.initNull(b.allocator);
             var stderr_buf = Buffer.initNull(b.allocator);
 
-            var stdout_file_in_stream = child.stdout.?.inStream();
-            var stderr_file_in_stream = child.stderr.?.inStream();
+            var stdout_file_in_stream = child.stdout.?.inStreamAdapter();
+            var stderr_file_in_stream = child.stderr.?.inStreamAdapter();
 
             stdout_file_in_stream.stream.readAllBuffer(&stdout_buf, max_stdout_size) catch unreachable;
             stderr_file_in_stream.stream.readAllBuffer(&stderr_buf, max_stdout_size) catch unreachable;

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -317,8 +317,8 @@ pub const CompareOutputContext = struct {
             var stdout_file_in_stream = child.stdout.?.inStreamAdapter();
             var stderr_file_in_stream = child.stderr.?.inStreamAdapter();
 
-            stdout_file_in_stream.stream.readAllBuffer(&stdout, max_stdout_size) catch unreachable;
-            stderr_file_in_stream.stream.readAllBuffer(&stderr, max_stdout_size) catch unreachable;
+            stdout_file_in_stream.inStream().readAllBuffer(&stdout, max_stdout_size) catch unreachable;
+            stderr_file_in_stream.inStream().readAllBuffer(&stderr, max_stdout_size) catch unreachable;
 
             const term = child.wait() catch |err| {
                 debug.panic("Unable to spawn {}: {}\n", full_exe_path, @errorName(err));
@@ -685,8 +685,8 @@ pub const CompileErrorContext = struct {
             var stdout_file_in_stream = child.stdout.?.inStreamAdapter();
             var stderr_file_in_stream = child.stderr.?.inStreamAdapter();
 
-            stdout_file_in_stream.stream.readAllBuffer(&stdout_buf, max_stdout_size) catch unreachable;
-            stderr_file_in_stream.stream.readAllBuffer(&stderr_buf, max_stdout_size) catch unreachable;
+            stdout_file_in_stream.inStream().readAllBuffer(&stdout_buf, max_stdout_size) catch unreachable;
+            stderr_file_in_stream.inStream().readAllBuffer(&stderr_buf, max_stdout_size) catch unreachable;
 
             const term = child.wait() catch |err| {
                 debug.panic("Unable to spawn {}: {}\n", zig_args.items[0], @errorName(err));
@@ -992,8 +992,8 @@ pub const TranslateCContext = struct {
             var stdout_file_in_stream = child.stdout.?.inStreamAdapter();
             var stderr_file_in_stream = child.stderr.?.inStreamAdapter();
 
-            stdout_file_in_stream.stream.readAllBuffer(&stdout_buf, max_stdout_size) catch unreachable;
-            stderr_file_in_stream.stream.readAllBuffer(&stderr_buf, max_stdout_size) catch unreachable;
+            stdout_file_in_stream.inStream().readAllBuffer(&stdout_buf, max_stdout_size) catch unreachable;
+            stderr_file_in_stream.inStream().readAllBuffer(&stderr_buf, max_stdout_size) catch unreachable;
 
             const term = child.wait() catch |err| {
                 debug.panic("Unable to spawn {}: {}\n", zig_args.toSliceConst()[0], @errorName(err));


### PR DESCRIPTION
A much simpler pattern than #2533. It has but two advantages over the current pattern:

 - It will optimize better
 - Interfaces can be copied