### PR TITLE
respect subsystem flag in all cases

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -2711,12 +2711,12 @@ void add_fn_export(CodeGen *g, ZigFn *fn_table_entry, Buf *symbol_name, GlobalLi
     if (ccc) {
         if (buf_eql_str(symbol_name, "main") && g->libc_link_lib != nullptr) {
             g->have_c_main = true;
-            g->subsystem = TargetSubsystemConsole;
+            g->subsystem = g->subsystem == TargetSubsystemAuto ? TargetSubsystemConsole : g->subsystem;
         } else if (buf_eql_str(symbol_name, "WinMain") &&
             g->zig_target->os == OsWindows)
         {
             g->have_winmain = true;
-            g->subsystem = TargetSubsystemWindows;
+            g->subsystem = g->subsystem == TargetSubsystemAuto ? TargetSubsystemWindows : g->subsystem;
         } else if (buf_eql_str(symbol_name, "WinMainCRTStartup") &&
             g->zig_target->os == OsWindows)
         {
@@ -3937,7 +3937,7 @@ ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *resolved_path, Bu
                 if (is_pub) {
                     if (buf_eql_str(proto_name, "main")) {
                         g->have_pub_main = true;
-                        g->subsystem = TargetSubsystemConsole;
+                        g->subsystem = g->subsystem == TargetSubsystemAuto ? TargetSubsystemConsole : g->subsystem;
                     } else if (buf_eql_str(proto_name, "panic")) {
                         g->have_pub_panic = true;
                     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7988,7 +7988,7 @@ static void init(CodeGen *g) {
     }
 
     if (g->is_test_build) {
-        g->subsystem = TargetSubsystemConsole;
+        g->subsystem = g->subsystem == TargetSubsystemAuto ? TargetSubsystemConsole : g->subsystem;
     }
 
     assert(g->root_out_name);


### PR DESCRIPTION
previously the `--subsystem [subsystem]` flag was being overwritten by zig's subsystem detection. this patch changes that behavior so target subsystems passed in take precedence over the subsystem zig detects.