### PR TITLE
Reject undefined as type

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -981,6 +981,17 @@ ZigType *analyze_type_expr(CodeGen *g, Scope *scope, AstNode *node) {
         return g->builtin_types.entry_invalid;
 
     assert(result->special != ConstValSpecialRuntime);
+    // Reject undefined as valid `type` type even though the specification
+    // allows it to be casted to anything.
+    // See also ir_resolve_type()
+    if (result->special == ConstValSpecialUndef) {
+        add_node_error(g, node,
+            buf_sprintf("expected type 'type', found '%s'",
+                buf_ptr(&g->builtin_types.entry_undef->name)));
+        return g->builtin_types.entry_invalid;
+    }
+
+    assert(result->data.x_type != nullptr);
     return result->data.x_type;
 }
 

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3,6 +3,23 @@ const builtin = @import("builtin");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "undefined as field type is rejected",
+        \\const Foo = struct {
+        \\    a: undefined,
+        \\};
+        \\const Bar = union {
+        \\    a: undefined,
+        \\};
+        \\pub fn main() void {
+        \\    const foo: Foo = undefined;
+        \\    const bar: Bar = undefined;
+        \\}
+    ,
+        "tmp.zig:2:8: error: expected type 'type', found '(undefined)'",
+        "tmp.zig:5:8: error: expected type 'type', found '(undefined)'",
+    );
+
+    cases.add(
         "@hasDecl with non-container",
         \\export fn entry() void {
         \\    _ = @hasDecl(i32, "hi");


### PR DESCRIPTION
Make analyze_type_expr behave like ir_resolve_type when the user tries
to use `undefined` as a type.

Perhaps it's better to amend the specification (and the compiler) and make `undefined` castable to everything but `type`.

Closes #2436