### PR TITLE
Add copy_file_range syscall for Linux

### DIFF
--- a/std/os/linux.zig
+++ b/std/os/linux.zig
@@ -263,6 +263,10 @@ pub fn pwrite(fd: i32, buf: [*]const u8, count: usize, offset: usize) usize {
     return syscall4(SYS_pwrite, @bitCast(usize, isize(fd)), @ptrToInt(buf), count, offset);
 }
 
+pub fn copy_file_range(fd_in: i32, off_in: ?*u64, fd_out: i32, off_out: ?*u64, len: usize, flags: u32) usize {
+    return syscall6(SYS_copy_file_range, @bitCast(usize, isize(fd_in)), @ptrToInt(off_in), @bitCast(usize, isize(fd_out)), @ptrToInt(off_out), len, flags);
+}
+
 // TODO https://github.com/ziglang/zig/issues/265
 pub fn rename(old: [*]const u8, new: [*]const u8) usize {
     if (@hasDecl(@This(), "SYS_rename")) {


### PR DESCRIPTION
Here is the code I used to test this:

```zig
const std = @import("std");
const os = std.os;
const File = std.fs.File;
const assert = std.debug.assert;

test "copy_file_range using offsets" {
    const src_file = try createInputFile();
    defer src_file.close();
    const dst_file = try File.openWrite("/tmp/out_file_1");
    defer dst_file.close();

    var off_in: isize = 200;
    var off_out: isize = 15;
    const len: usize = 100;
    const flags: u32 = 0;
    const result = os.linux.copy_file_range(src_file.handle, &off_in, dst_file.handle, &off_out, len, flags);
    const errno = os.linux.getErrno(result);

    assert(errno == 0);
    assert(result == 256 - 200);
    assert(off_in == 256);
    assert(off_out == 15 + (256 - 200));
}

test "copy_file_range using seek positions" {
    const src_file = try createInputFile();
    defer src_file.close();

    const dst_file = try File.openWrite("/tmp/out_file_2");
    defer dst_file.close();

    try src_file.seekTo(100);
    try dst_file.seekTo(5);

    const len: usize = 25;
    const flags: u32 = 0;
    const result = os.linux.copy_file_range(src_file.handle, null, dst_file.handle, null, len, flags);
    const errno = os.linux.getErrno(result);

    assert(errno == 0);
    assert(result == 25);
    assert((try src_file.getPos()) == 100 + 25);
    assert((try dst_file.getPos()) == 5 + 25);
}

/// Create a test file containing bytes 0-255 and open for reading.
fn createInputFile() !File {
    {
        const src_file = try File.openWrite("/tmp/in_file");
        defer src_file.close();

        var buf: [256]u8 = []u8{0} ** 256;
        for (buf) |*b, i| b.* = @intCast(u8, i);
        try src_file.write(buf);
    }

    return File.openRead("/tmp/in_file");
}
```

Closes #2563.