### PR TITLE
[WIP] Fix some syscalls on arm64

### DIFF
--- a/std/c/linux.zig
+++ b/std/c/linux.zig
@@ -7,7 +7,7 @@ pub const _errno = __errno_location;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) c_int;
 pub extern "c" fn sched_getaffinity(pid: c_int, size: usize, set: *cpu_set_t) c_int;
 pub extern "c" fn eventfd(initval: c_uint, flags: c_uint) c_int;
-pub extern "c" fn epoll_ctl(epfd: fd_t, op: c_uint, fd: fd_t, event: *epoll_event) c_int;
+pub extern "c" fn epoll_ctl(epfd: fd_t, op: c_uint, fd: fd_t, event: ?*epoll_event) c_int;
 pub extern "c" fn epoll_create1(flags: c_uint) c_int;
 pub extern "c" fn epoll_wait(epfd: fd_t, events: [*]epoll_event, maxevents: c_uint, timeout: c_int) c_int;
 pub extern "c" fn epoll_pwait(

--- a/std/event/loop.zig
+++ b/std/event/loop.zig
@@ -421,7 +421,7 @@ pub const Loop = struct {
     }
 
     pub fn linuxRemoveFd(self: *Loop, fd: i32) void {
-        os.epoll_ctl(self.os_data.epollfd, os.linux.EPOLL_CTL_DEL, fd, undefined) catch {};
+        os.epoll_ctl(self.os_data.epollfd, os.linux.EPOLL_CTL_DEL, fd, null) catch {};
         self.finishOneEvent();
     }
 

--- a/std/os.zig
+++ b/std/os.zig
@@ -1509,7 +1509,7 @@ pub const EpollCtlError = error{
     Unexpected,
 };
 
-pub fn epoll_ctl(epfd: i32, op: u32, fd: i32, event: *epoll_event) EpollCtlError!void {
+pub fn epoll_ctl(epfd: i32, op: u32, fd: i32, event: ?*epoll_event) EpollCtlError!void {
     const rc = system.epoll_ctl(epfd, op, fd, event);
     switch (errno(rc)) {
         0 => return,

--- a/std/os/bits/linux.zig
+++ b/std/os/bits/linux.zig
@@ -762,16 +762,16 @@ pub const epoll_data = extern union {
 
 // On x86_64 the structure is packed so that it matches the definition of its
 // 32bit counterpart
-pub const epoll_event = if (builtin.arch != .x86_64)
-    extern struct {
+pub const epoll_event = switch (builtin.arch) {
+    .x86_64 => packed struct {
         events: u32,
         data: epoll_data,
-    }
-else
-    packed struct {
+    },
+    else => extern struct {
         events: u32,
         data: epoll_data,
-    };
+    },
+};
 
 pub const _LINUX_CAPABILITY_VERSION_1 = 0x19980330;
 pub const _LINUX_CAPABILITY_U32S_1 = 1;

--- a/std/os/bits/linux/arm64.zig
+++ b/std/os/bits/linux/arm64.zig
@@ -299,16 +299,16 @@ pub const O_NONBLOCK = 0o4000;
 pub const O_DSYNC = 0o10000;
 pub const O_SYNC = 0o4010000;
 pub const O_RSYNC = 0o4010000;
-pub const O_DIRECTORY = 0o200000;
-pub const O_NOFOLLOW = 0o400000;
+pub const O_DIRECTORY = 0o40000;
+pub const O_NOFOLLOW = 0o100000;
 pub const O_CLOEXEC = 0o2000000;
 
 pub const O_ASYNC = 0o20000;
-pub const O_DIRECT = 0o40000;
-pub const O_LARGEFILE = 0;
+pub const O_DIRECT = 0o200000;
+pub const O_LARGEFILE = 0o400000;
 pub const O_NOATIME = 0o1000000;
 pub const O_PATH = 0o10000000;
-pub const O_TMPFILE = 0o20200000;
+pub const O_TMPFILE = 0o20040000;
 pub const O_NDELAY = O_NONBLOCK;
 
 pub const F_DUPFD = 0;


### PR DESCRIPTION
My last PR for arm64 until it's added added to the CI (`qemu` is also fine, everything is better than having shit break every now and then when you're working on something else).

Speaking of `epoll_ctl`, I've changed the last argument to `null` instead of `undefined` to avoid a crash in qemu. The change is technically correct since every non-ancient kernel version is supposed not to touch the `event` argument at all.