### PR TITLE
Add command line options and build system support for specifying LLVM target cpu and features

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1894,6 +1894,9 @@ struct CodeGen {
 
     const char **clang_argv;
     size_t clang_argv_len;
+
+    const char *llvm_cpu;
+    const char *llvm_features;
 };
 
 struct ZigVar {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -93,7 +93,6 @@ static const char *symbols_that_llvm_depends_on[] = {
 };
 
 CodeGen *codegen_create(Buf *main_pkg_path, Buf *root_src_path, const ZigTarget *target,
-    const char *llvm_cpu, const char *llvm_features,
     OutType out_type, BuildMode build_mode, Buf *override_lib_dir, Buf *override_std_dir,
     ZigLibCInstallation *libc, Buf *cache_dir)
 {
@@ -105,9 +104,6 @@ CodeGen *codegen_create(Buf *main_pkg_path, Buf *root_src_path, const ZigTarget 
     g->libc = libc;
     g->zig_target = target;
     g->cache_dir = cache_dir;
-
-    g->llvm_cpu = llvm_cpu;
-    g->llvm_features = llvm_features;
 
     if (override_lib_dir == nullptr) {
         g->zig_lib_dir = get_zig_lib_dir();
@@ -222,14 +218,6 @@ void codegen_set_clang_argv(CodeGen *g, const char **args, size_t len) {
 void codegen_set_llvm_argv(CodeGen *g, const char **args, size_t len) {
     g->llvm_argv = args;
     g->llvm_argv_len = len;
-}
-
-void codegen_set_llvm_cpu(CodeGen *g, const char *llvm_cpu) {
-    g->llvm_cpu = llvm_cpu;
-}
-
-void codegen_set_llvm_features(CodeGen *g, const char *llvm_features) {
-    g->llvm_features = llvm_features;
 }
 
 void codegen_set_test_filter(CodeGen *g, Buf *filter) {

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -17,11 +17,13 @@
 #include <stdio.h>
 
 CodeGen *codegen_create(Buf *main_pkg_path, Buf *root_src_path, const ZigTarget *target,
-    OutType out_type, BuildMode build_mode, Buf *zig_lib_dir, Buf *override_std_dir,
+    const char *llvm_cpu, const char *llvm_features, OutType out_type, BuildMode build_mode, Buf *zig_lib_dir, Buf *override_std_dir,
     ZigLibCInstallation *libc, Buf *cache_dir);
 
 void codegen_set_clang_argv(CodeGen *codegen, const char **args, size_t len);
 void codegen_set_llvm_argv(CodeGen *codegen, const char **args, size_t len);
+void codegen_set_llvm_cpu(CodeGen *codegen, const char *llvm_cpu);
+void codegen_set_llvm_features(CodeGen *codegen, const char *llvm_features);
 void codegen_set_is_test(CodeGen *codegen, bool is_test);
 void codegen_set_each_lib_rpath(CodeGen *codegen, bool each_lib_rpath);
 

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -17,13 +17,11 @@
 #include <stdio.h>
 
 CodeGen *codegen_create(Buf *main_pkg_path, Buf *root_src_path, const ZigTarget *target,
-    const char *llvm_cpu, const char *llvm_features, OutType out_type, BuildMode build_mode, Buf *zig_lib_dir, Buf *override_std_dir,
+    OutType out_type, BuildMode build_mode, Buf *zig_lib_dir, Buf *override_std_dir,
     ZigLibCInstallation *libc, Buf *cache_dir);
 
 void codegen_set_clang_argv(CodeGen *codegen, const char **args, size_t len);
 void codegen_set_llvm_argv(CodeGen *codegen, const char **args, size_t len);
-void codegen_set_llvm_cpu(CodeGen *codegen, const char *llvm_cpu);
-void codegen_set_llvm_features(CodeGen *codegen, const char *llvm_features);
 void codegen_set_is_test(CodeGen *codegen, bool is_test);
 void codegen_set_each_lib_rpath(CodeGen *codegen, bool each_lib_rpath);
 

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -22,8 +22,9 @@ struct LinkJob {
 static CodeGen *create_child_codegen(CodeGen *parent_gen, Buf *root_src_path, OutType out_type,
         ZigLibCInstallation *libc)
 {
-    CodeGen *child_gen = codegen_create(nullptr, root_src_path, parent_gen->zig_target, out_type,
-        parent_gen->build_mode, parent_gen->zig_lib_dir, parent_gen->zig_std_dir, libc, get_stage1_cache_path());
+    CodeGen *child_gen = codegen_create(nullptr, root_src_path, parent_gen->zig_target, 
+        parent_gen->llvm_cpu, parent_gen->llvm_features, out_type, parent_gen->build_mode, 
+        parent_gen->zig_lib_dir, parent_gen->zig_std_dir, libc, get_stage1_cache_path());
     child_gen->disable_gen_h = true;
     child_gen->want_stack_check = WantStackCheckDisabled;
     child_gen->verbose_tokenize = parent_gen->verbose_tokenize;

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -22,7 +22,7 @@ struct LinkJob {
 static CodeGen *create_child_codegen(CodeGen *parent_gen, Buf *root_src_path, OutType out_type,
         ZigLibCInstallation *libc)
 {
-    CodeGen *child_gen = codegen_create(nullptr, root_src_path, parent_gen->zig_target, out_type, 
+    CodeGen *child_gen = codegen_create(nullptr, root_src_path, parent_gen->zig_target, out_type,
         parent_gen->build_mode, parent_gen->zig_lib_dir, parent_gen->zig_std_dir, libc, get_stage1_cache_path());
     child_gen->disable_gen_h = true;
     child_gen->want_stack_check = WantStackCheckDisabled;

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -22,9 +22,8 @@ struct LinkJob {
 static CodeGen *create_child_codegen(CodeGen *parent_gen, Buf *root_src_path, OutType out_type,
         ZigLibCInstallation *libc)
 {
-    CodeGen *child_gen = codegen_create(nullptr, root_src_path, parent_gen->zig_target, 
-        parent_gen->llvm_cpu, parent_gen->llvm_features, out_type, parent_gen->build_mode, 
-        parent_gen->zig_lib_dir, parent_gen->zig_std_dir, libc, get_stage1_cache_path());
+    CodeGen *child_gen = codegen_create(nullptr, root_src_path, parent_gen->zig_target, out_type, 
+        parent_gen->build_mode, parent_gen->zig_lib_dir, parent_gen->zig_std_dir, libc, get_stage1_cache_path());
     child_gen->disable_gen_h = true;
     child_gen->want_stack_check = WantStackCheckDisabled;
     child_gen->verbose_tokenize = parent_gen->verbose_tokenize;
@@ -35,6 +34,8 @@ static CodeGen *create_child_codegen(CodeGen *parent_gen, Buf *root_src_path, Ou
     child_gen->verbose_cimport = parent_gen->verbose_cimport;
     child_gen->verbose_cc = parent_gen->verbose_cc;
     child_gen->llvm_argv = parent_gen->llvm_argv;
+    child_gen->llvm_cpu = parent_gen->llvm_cpu;
+    child_gen->llvm_features = parent_gen->llvm_features;
     child_gen->dynamic_linker_path = parent_gen->dynamic_linker_path;
 
     codegen_set_strip(child_gen, parent_gen->strip_debug_symbols);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -524,7 +524,7 @@ int main(int argc, char **argv) {
             full_cache_dir = os_path_resolve(&cache_dir_buf, 1);
         }
 
-        CodeGen *g = codegen_create(main_pkg_path, build_runner_path, &target, llvm_cpu, llvm_features, OutTypeExe,
+        CodeGen *g = codegen_create(main_pkg_path, build_runner_path, &target, OutTypeExe,
                 BuildModeDebug, override_lib_dir, override_std_dir, nullptr, &full_cache_dir);
         g->valgrind_support = valgrind_support;
         g->enable_time_report = timing_info;
@@ -963,7 +963,7 @@ int main(int argc, char **argv) {
         return EXIT_SUCCESS;
     }
     case CmdBuiltin: {
-        CodeGen *g = codegen_create(main_pkg_path, nullptr, &target, llvm_cpu, llvm_features,
+        CodeGen *g = codegen_create(main_pkg_path, nullptr, &target, 
                 out_type, build_mode, override_lib_dir, override_std_dir, nullptr, nullptr);
         codegen_set_strip(g, strip);
         g->subsystem = subsystem;
@@ -1063,9 +1063,11 @@ int main(int argc, char **argv) {
             } else {
                 cache_dir_buf = buf_create_from_str(cache_dir);
             }
-            CodeGen *g = codegen_create(main_pkg_path, zig_root_source_file, &target, llvm_cpu, llvm_features, 
+            CodeGen *g = codegen_create(main_pkg_path, zig_root_source_file, &target, 
                     out_type, build_mode, override_lib_dir, override_std_dir, libc, cache_dir_buf);
             if (llvm_argv.length >= 2) codegen_set_llvm_argv(g, llvm_argv.items + 1, llvm_argv.length - 2);
+            g->llvm_cpu = llvm_cpu;
+            g->llvm_features = llvm_features;
             g->valgrind_support = valgrind_support;
             g->want_pic = want_pic;
             g->want_stack_check = want_stack_check;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -963,7 +963,7 @@ int main(int argc, char **argv) {
         return EXIT_SUCCESS;
     }
     case CmdBuiltin: {
-        CodeGen *g = codegen_create(main_pkg_path, nullptr, &target, 
+        CodeGen *g = codegen_create(main_pkg_path, nullptr, &target,
                 out_type, build_mode, override_lib_dir, override_std_dir, nullptr, nullptr);
         codegen_set_strip(g, strip);
         g->subsystem = subsystem;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,8 +84,8 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  -dirafter [dir]              same as -isystem but do it last\n"
         "  -isystem [dir]               add additional search path for other .h files\n"
         "  -mllvm [arg]                 forward an arg to LLVM's option processing\n"
-        "  --cpu [cpu]                  set the LLVM cpu option (-mcpu)\n"
-        "  --features [features]        set the LLVM cpu features option (-mattr)\n"
+        "  --llvm-cpu [cpu]             set the LLVM cpu option (-mcpu)\n"
+        "  --llvm-features [features]   set the LLVM cpu features option (-mattr)\n"
         "  --override-std-dir [arg]     use an alternate Zig standard library\n"
         "\n"
         "Link Options:\n"
@@ -749,9 +749,9 @@ int main(int argc, char **argv) {
                     clang_argv.append(argv[i]);
 
                     llvm_argv.append(argv[i]);
-                } else if (strcmp(arg, "--cpu") == 0) {
+                } else if (strcmp(arg, "--llvm-cpu") == 0) {
                     llvm_cpu = argv[i];
-                } else if (strcmp(arg, "--features") == 0) {
+                } else if (strcmp(arg, "--llvm-features") == 0) {
                     llvm_features = argv[i];
                 } else if (strcmp(arg, "--override-std-dir") == 0) {
                     override_std_dir = buf_create_from_str(argv[i]);

--- a/std/build.zig
+++ b/std/build.zig
@@ -965,6 +965,8 @@ pub const LibExeObjStep = struct {
     name_prefix: []const u8,
     filter: ?[]const u8,
     single_threaded: bool,
+    llvm_cpu: ?[]const u8,
+    llvm_features: ?[]const u8,
 
     root_src: ?[]const u8,
     out_h_filename: []const u8,
@@ -1071,6 +1073,8 @@ pub const LibExeObjStep = struct {
             .output_dir = null,
             .need_system_paths = false,
             .single_threaded = false,
+            .llvm_cpu = null,
+            .llvm_features = null,
         };
         self.computeOutFileNames();
         return self;
@@ -1239,6 +1243,14 @@ pub const LibExeObjStep = struct {
 
     pub fn setDisableGenH(self: *LibExeObjStep, value: bool) void {
         self.disable_gen_h = value;
+    }
+
+    pub fn setLlvmCpu(self: *LibExeObjStep, cpu: []const u8) void {
+        self.llvm_cpu = cpu;
+    }
+
+    pub fn setLlvmFeatures(self: *LibExeObjStep, features: []const u8) void {
+        self.llvm_features = features;
     }
 
     /// Unless setOutputDir was called, this function must be called only in
@@ -1443,6 +1455,16 @@ pub const LibExeObjStep = struct {
 
         if (self.single_threaded) {
             try zig_args.append("--single-threaded");
+        }
+
+        if (self.llvm_cpu) |llvm_cpu| {
+            try zig_args.append("--cpu");
+            try zig_args.append(llvm_cpu);
+        }
+        
+        if (self.llvm_features) |llvm_features| {
+            try zig_args.append("--features");
+            try zig_args.append(llvm_features);
         }
 
         switch (self.build_mode) {

--- a/std/build.zig
+++ b/std/build.zig
@@ -1458,12 +1458,12 @@ pub const LibExeObjStep = struct {
         }
 
         if (self.llvm_cpu) |llvm_cpu| {
-            try zig_args.append("--cpu");
+            try zig_args.append("--llvm-cpu");
             try zig_args.append(llvm_cpu);
         }
         
         if (self.llvm_features) |llvm_features| {
-            try zig_args.append("--features");
+            try zig_args.append("--llvm-features");
             try zig_args.append(llvm_features);
         }
 


### PR DESCRIPTION
As mentioned in #2051 ([in this comment specifically](https://github.com/ziglang/zig/issues/2051#issuecomment-471709577)), the Zig compiler currently does not allow the override of the LLVM cpu (-mcpu) and features (-mattr) options. This PR adds the command-line flags `--llvm-cpu` and `--llvm-features` to the build-* compiler commands. In addition, the build system has been updated to support these options as well. The strings accepted by the `--llvm-cpu` and `--llvm-features` options are equivalent to those accepted by clang and llc with `-mcpu` and `-mattr`, respectively.

This PR does not include a way of listing supported cpus or features of a given architecture. The easiest way to obtain such a list is to run `llc -march=<arch> -mcpu=help`, replacing `<arch>` with the desired architecture, i.e. `arm` or `avr`.