### PR TITLE
added dynamic library loading via libdl

### DIFF
--- a/std/c/darwin.zig
+++ b/std/c/darwin.zig
@@ -57,7 +57,6 @@ pub fn sigaddset(set: *sigset_t, signo: u5) void {
 
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 
-pub extern "c" fn dlopen_preflight(path: [*]const u8) c_int;
 pub extern "c" fn dlopen(path: [*]const u8, mode: c_int) ?*c_void;
 pub extern "c" fn dlclose(handle: *c_void) c_int;
 pub extern "c" fn dlsym(handle: ?*c_void, symbol: [*]const u8) ?*c_void;

--- a/std/c/darwin.zig
+++ b/std/c/darwin.zig
@@ -56,3 +56,8 @@ pub fn sigaddset(set: *sigset_t, signo: u5) void {
 }
 
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
+
+pub extern "c" fn dlopen_preflight(path: [*]const u8) c_int;
+pub extern "c" fn dlopen(path: [*]const u8, mode: c_int) ?*c_void;
+pub extern "c" fn dlclose(handle: *c_void) c_int;
+pub extern "c" fn dlsym(handle: ?*c_void, symbol: [*]const u8) ?*c_void;

--- a/std/dynamic_library.zig
+++ b/std/dynamic_library.zig
@@ -11,7 +11,7 @@ const system = std.os.system;
 const maxInt = std.math.maxInt;
 
 pub const DynLib = switch (builtin.os) {
-    .linux => LinuxDynLib,
+    .linux => if (builtin.link_libc) DlDynlib else LinuxDynLib,
     .windows => WindowsDynLib,
     .macosx, .tvos, .watchos, .ios => DlDynlib,
     else => void,

--- a/std/dynamic_library.zig
+++ b/std/dynamic_library.zig
@@ -284,7 +284,7 @@ pub const DarwinDynLib = struct {
 
         // see https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlopen.3.html
         return DarwinDynLib{
-            .handle = darwin.dlopen(path, darwin.RTLD_LAZY) orelse {
+            .handle = darwin.dlopen(path.ptr, darwin.RTLD_LAZY) orelse {
                 return error.FileNotFound;
             },
         };

--- a/std/os/bits/darwin.zig
+++ b/std/os/bits/darwin.zig
@@ -1177,23 +1177,14 @@ pub fn S_IWHT(m: u32) bool {
 }
 
 pub const RTLD_LAZY = 0x1;
-
 pub const RTLD_NOW = 0x2;
-
 pub const RTLD_LOCAL = 0x4;
-
 pub const RTLD_GLOBAL = 0x8;
-
 pub const RTLD_NOLOAD = 0x10;
-
 pub const RTLD_NODELETE = 0x80;
-
 pub const RTLD_FIRST = 0x100;
 
 pub const RTLD_NEXT = @intToPtr(*c_void, ~maxInt(usize));
-
 pub const RTLD_DEFAULT = @intToPtr(*c_void, ~maxInt(usize) - 1);
-
 pub const RTLD_SELF = @intToPtr(*c_void, ~maxInt(usize) - 2);
-
 pub const RTLD_MAIN_ONLY = @intToPtr(*c_void, ~maxInt(usize) - 4);

--- a/std/os/bits/darwin.zig
+++ b/std/os/bits/darwin.zig
@@ -1175,3 +1175,25 @@ pub fn S_ISSOCK(m: u32) bool {
 pub fn S_IWHT(m: u32) bool {
     return m & S_IFMT == S_IFWHT;
 }
+
+pub const RTLD_LAZY = 0x1;
+
+pub const RTLD_NOW = 0x2;
+
+pub const RTLD_LOCAL = 0x4;
+
+pub const RTLD_GLOBAL = 0x8;
+
+pub const RTLD_NOLOAD = 0x10;
+
+pub const RTLD_NODELETE = 0x80;
+
+pub const RTLD_FIRST = 0x100;
+
+pub const RTLD_NEXT = @intToPtr(*c_void, ~maxInt(usize));
+
+pub const RTLD_DEFAULT = @intToPtr(*c_void, ~maxInt(usize) - 1);
+
+pub const RTLD_SELF = @intToPtr(*c_void, ~maxInt(usize) - 2);
+
+pub const RTLD_MAIN_ONLY = @intToPtr(*c_void, ~maxInt(usize) - 4);

--- a/std/os/bits/linux.zig
+++ b/std/os/bits/linux.zig
@@ -1,4 +1,4 @@
-const builtin = @import("builtin");
+ const builtin = @import("builtin");
 const std = @import("../../std.zig");
 const maxInt = std.math.maxInt;
 usingnamespace @import("../bits.zig");

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -19,10 +19,11 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/use_alias/build.zig");
     cases.addBuildFile("test/standalone/brace_expansion/build.zig");
     cases.addBuildFile("test/standalone/empty_env/build.zig");
-    if (builtin.os == builtin.Os.linux) {
-        // TODO hook up the DynLib API for windows using LoadLibraryA
-        // TODO figure out how to make this work on darwin - probably libSystem has dlopen/dlsym in it
-        cases.addBuildFile("test/standalone/load_dynamic_library/build.zig");
+    switch (builtin.os) {
+        .linux, .windows, .macosx, .tvos, .watchos, .ios => {
+            cases.addBuildFile("test/standalone/load_dynamic_library/build.zig");
+        },
+        else => {},
     }
 
     if (builtin.arch == builtin.Arch.x86_64) { // TODO add C ABI support for other architectures


### PR DESCRIPTION
i implemented dynamic library loading for darwin using dlsym. getting errors back is going to be somewhat involved as `dlerror` only returns strings. i'm also not sure if we should check to see if the library being loaded is compatible with the loading process using [`dlopen_preflight`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlopen_preflight.3.html#//apple_ref/doc/man/3/dlopen_preflight).

i also fixed a logic errors in the windows code for loading dll's. `DynLib.lookup` would return 0 instead of `null` if the symbol couldn't be found.