### PR TITLE
Fix Deserializer.alignToByte() and add test coverage

### DIFF
--- a/std/io.zig
+++ b/std/io.zig
@@ -1131,7 +1131,7 @@ pub fn Deserializer(comptime endian: builtin.Endian, comptime packing: Packing, 
         }
 
         pub fn alignToByte(self: *Self) void {
-            if (!is_packed) return;
+            if (packing == .Byte) return;
             self.in_stream.alignToByte();
         }
 

--- a/std/io/test.zig
+++ b/std/io/test.zig
@@ -417,6 +417,7 @@ fn testIntSerializerDeserializerInfNaN(
     const nan_check_f16 = try deserializer.deserialize(f16);
     const inf_check_f16 = try deserializer.deserialize(f16);
     const nan_check_f32 = try deserializer.deserialize(f32);
+    try deserializer.alignToByte();
     const inf_check_f32 = try deserializer.deserialize(f32);
     const nan_check_f64 = try deserializer.deserialize(f64);
     const inf_check_f64 = try deserializer.deserialize(f64);


### PR DESCRIPTION
Missed a spot during conversion from bool to enum for packing parameter.  Corrected and added test coverage.