### PR TITLE
src/ast_render.cpp: fix rendering of character literals <= 0x0f

### DIFF
--- a/src/ast_render.cpp
+++ b/src/ast_render.cpp
@@ -352,7 +352,7 @@ static void string_literal_escape(Buf *source, Buf *dest) {
         } else if (is_printable(c)) {
             buf_append_char(dest, c);
         } else {
-            buf_appendf(dest, "\\x%x", (int)c);
+            buf_appendf(dest, "\\x%02x", (int)c);
         }
     }
 }


### PR DESCRIPTION
using
```zig
const inc = @cImport(@cInclude("inc.h"));

const std = @import("std");

pub fn main() !void {
    const stdout_file = try std.io.getStdOut();
    try stdout_file.write(inc.FOO[0..1]);
}
```

and
```zig
#define FOO "\001"
```

I'm getting the error message
```
$ zig build-exe -isystem . test.zig
zig-cache/o/zMrL91aem5DwrYGz8zBUrsYxN-J6EscZxxdWrHs2vDQEeSSnPKJgHiij3_9z9X9i/cimport.zig:175:22: error: invalid digit: '"'
pub const FOO = c"\x1";
```

#2611 looks related.