### PR TITLE
Added LineComment support when MultiLines are used in ArrayInit

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2223,6 +2223,12 @@ test "zig fmt: multiline string in array" {
         \\    ,
         \\        \\bbb
         \\    };
+        \\    const Bar = [][]const u8{ // comment here
+        \\        \\aaa
+        \\        \\
+        \\    , // and another comment can go here
+        \\        \\bbb
+        \\    };
         \\}
         \\
     );


### PR DESCRIPTION
When I added PR #2589, I forgot to add the LineComment support. This PR fixes that.

Also related to #2456.

