### PR TITLE
Replace ResolveStatusZeroBitsKnown with ResolveStatusAlignmentKnown

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16780,7 +16780,7 @@ static IrInstruction *ir_analyze_instruction_slice_type(IrAnalyze *ira,
         case ZigTypeIdPromise:
         case ZigTypeIdVector:
             {
-                if ((err = type_resolve(ira->codegen, child_type, ResolveStatusZeroBitsKnown)))
+                if ((err = type_resolve(ira->codegen, child_type, ResolveStatusAlignmentKnown)))
                     return ira->codegen->invalid_instruction;
                 ZigType *slice_ptr_type = get_pointer_to_type_extra(ira->codegen, child_type,
                         is_const, is_volatile, PtrLenUnknown, align_bytes, 0, 0, is_allow_zero);


### PR DESCRIPTION
This patch replaces `ResolveZeroBitsKnown` with `ResolveStatusAlignmentKnown` in `ir_analyze_instruction_slice_type` since whenever `get_pointer_to_type_extra` is called with non-zero alignment, the alignment should be known. This fixes #2616 

@LemonBoy and I are unsure if `ResolveStatusAlignmentKnown` should be used in all cases so feedback is welcome.