### PR TITLE
Add caching headers to tarballs on s3

### DIFF
--- a/ci/azure/linux_script
+++ b/ci/azure/linux_script
@@ -28,7 +28,7 @@ if [ "${BUILD_REASON}" != "PullRequest" ]; then
   docker run -i --mount type=bind,source="$ARTIFACTSDIR",target=/z ziglang/static-base:llvm8-1 -j2 $BUILD_SOURCEVERSION
   TARBALL="$(ls $ARTIFACTSDIR)"
   mv "$DOWNLOADSECUREFILE_SECUREFILEPATH" "$HOME/.s3cfg"
-  s3cmd put -P "$ARTIFACTSDIR/$TARBALL" s3://ziglang.org/builds/
+  s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" "$ARTIFACTSDIR/$TARBALL" s3://ziglang.org/builds/
 
   SHASUM=$(sha256sum $ARTIFACTSDIR/$TARBALL | cut '-d ' -f1)
   BYTESIZE=$(wc -c < $ARTIFACTSDIR/$TARBALL)

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -62,7 +62,7 @@ else
   cd $HOME
   tar cfJ "$CACHE_BASENAME.tar.xz" "$CACHE_BASENAME"
   cp "$DOWNLOADSECUREFILE_SECUREFILEPATH" "$HOME/.s3cfg"
-  s3cmd put -P "$CACHE_BASENAME.tar.xz" "s3://ziglang.org/builds/$CACHE_BASENAME.tar.xz"
+  s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" "$CACHE_BASENAME.tar.xz" "s3://ziglang.org/builds/$CACHE_BASENAME.tar.xz"
 fi
 
 cd $ZIGDIR
@@ -85,7 +85,7 @@ if [ "${BUILD_REASON}" != "PullRequest" ]; then
   tar cfJ "$TARBALL" "$DIRNAME"
 
   mv "$DOWNLOADSECUREFILE_SECUREFILEPATH" "$HOME/.s3cfg"
-  s3cmd put -P "$TARBALL" s3://ziglang.org/builds/
+  s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" "$TARBALL" s3://ziglang.org/builds/
 
   SHASUM=$(shasum -a 256 $TARBALL | cut '-d ' -f1)
   BYTESIZE=$(wc -c < $TARBALL)

--- a/ci/azure/update_download_page
+++ b/ci/azure/update_download_page
@@ -35,7 +35,7 @@ env
 "../$ZIG" run update-download-page.zig
 
 mv "$DOWNLOADSECUREFILE_SECUREFILEPATH" "$HOME/.s3cfg"
-s3cmd put -P "../$SRC_TARBALL" s3://ziglang.org/builds/
+s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" "../$SRC_TARBALL" s3://ziglang.org/builds/
 s3cmd put -P "../$LANGREF" s3://ziglang.org/documentation/master/index.html --add-header="Cache-Control: max-age=0, must-revalidate"
 s3cmd put -P www/download/index.html s3://ziglang.org/download/index.html --add-header="Cache-Control: max-age=0, must-revalidate"
 s3cmd put -P www/download/index.json s3://ziglang.org/download/index.json --add-header="Cache-Control: max-age=0, must-revalidate"

--- a/ci/azure/windows_upload
+++ b/ci/azure/windows_upload
@@ -19,7 +19,7 @@ if [ "${BUILD_REASON}" != "PullRequest" ]; then
   7z a "$TARBALL" "$DIRNAME"
 
   mv "$DOWNLOADSECUREFILE_SECUREFILEPATH" "$HOME/.s3cfg"
-  s3cmd put -P "$TARBALL" s3://ziglang.org/builds/
+  s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" "$TARBALL" s3://ziglang.org/builds/
 
   SHASUM=$(sha256sum $TARBALL | cut '-d ' -f1)
   BYTESIZE=$(wc -c < $TARBALL)

--- a/ci/srht/freebsd_script
+++ b/ci/srht/freebsd_script
@@ -36,7 +36,7 @@ if [ -f ~/.s3cfg ]; then
   mv release "$DIRNAME"
   tar cfJ "$TARBALL" "$DIRNAME"
 
-  s3cmd put -P "$TARBALL" s3://ziglang.org/builds/
+  s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" "$TARBALL" s3://ziglang.org/builds/
 
   SHASUM=$(shasum -a 256 $TARBALL | cut '-d ' -f1)
   BYTESIZE=$(wc -c < $TARBALL)


### PR DESCRIPTION
Got here from [Andrew's tweet](https://twitter.com/andy_kelley/status/1136019748926435328), excuse the nosiness.

This could be done at s3's or cf's configuration level, but since headers are being set explicitly for other files I assume that's not the case. CloudFront will keep files for 24h by default if no header or setting changed that.