### PR TITLE
deduce type for mem.set and mem.secureZero

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6964,7 +6964,7 @@ mem.copy(u8, dest[0..byte_count], source[0..byte_count]);{#endsyntax#}</pre>
       </p>
       <p>There is also a standard library function for this:</p>
       <pre>{#syntax#}const mem = @import("std").mem;
-mem.set(u8, dest, c);{#endsyntax#}</pre>
+mem.set(dest, c);{#endsyntax#}</pre>
       {#header_close#}
 
       {#header_open|@mod#}

--- a/std/ascii.zig
+++ b/std/ascii.zig
@@ -137,7 +137,7 @@ const combinedTable = init: {
             u8(punct[i]) << @enumToInt(tIndex.Punct) |
             u8(graph[i]) << @enumToInt(tIndex.Graph);
     }
-    mem.set(u8, table[128..256], 0);
+    mem.set(table[128..256], 0);
     break :init table;
 };
 

--- a/std/crypto/blake2.zig
+++ b/std/crypto/blake2.zig
@@ -116,7 +116,7 @@ fn Blake2s(comptime out_len: usize) type {
         pub fn final(d: *Self, out: []u8) void {
             debug.assert(out.len >= out_len / 8);
 
-            mem.set(u8, d.buf[d.buf_len..], 0);
+            mem.set(d.buf[d.buf_len..], 0);
             d.t += d.buf_len;
             d.round(d.buf[0..], true);
 
@@ -351,7 +351,7 @@ fn Blake2b(comptime out_len: usize) type {
         }
 
         pub fn final(d: *Self, out: []u8) void {
-            mem.set(u8, d.buf[d.buf_len..], 0);
+            mem.set(d.buf[d.buf_len..], 0);
             d.t += d.buf_len;
             d.round(d.buf[0..], true);
 

--- a/std/crypto/hmac.zig
+++ b/std/crypto/hmac.zig
@@ -32,10 +32,10 @@ pub fn Hmac(comptime Hash: type) type {
             // Normalize key length to block size of hash
             if (key.len > Hash.block_length) {
                 Hash.hash(key, ctx.scratch[0..mac_length]);
-                mem.set(u8, ctx.scratch[mac_length..Hash.block_length], 0);
+                mem.set(ctx.scratch[mac_length..Hash.block_length], 0);
             } else if (key.len < Hash.block_length) {
                 mem.copy(u8, ctx.scratch[0..key.len], key);
-                mem.set(u8, ctx.scratch[key.len..Hash.block_length], 0);
+                mem.set(ctx.scratch[key.len..Hash.block_length], 0);
             } else {
                 mem.copy(u8, ctx.scratch[0..], key);
             }

--- a/std/crypto/md5.zig
+++ b/std/crypto/md5.zig
@@ -88,7 +88,7 @@ pub const Md5 = struct {
         debug.assert(out.len >= 16);
 
         // The buffer here will never be completely full.
-        mem.set(u8, d.buf[d.buf_len..], 0);
+        mem.set(d.buf[d.buf_len..], 0);
 
         // Append padding bits.
         d.buf[d.buf_len] = 0x80;
@@ -97,7 +97,7 @@ pub const Md5 = struct {
         // > 448 mod 512 so need to add an extra round to wrap around.
         if (64 - d.buf_len < 8) {
             d.round(d.buf[0..]);
-            mem.set(u8, d.buf[0..], 0);
+            mem.set(d.buf[0..], 0);
         }
 
         // Append message length.

--- a/std/crypto/poly1305.zig
+++ b/std/crypto/poly1305.zig
@@ -27,7 +27,7 @@ pub const Poly1305 = struct {
     c_idx: usize,
 
     fn secureZero(self: *Self) void {
-        std.mem.secureZero(u8, @ptrCast([*]u8, self)[0..@sizeOf(Poly1305)]);
+        std.mem.secureZero(@ptrCast([*]u8, self)[0..@sizeOf(Poly1305)]);
     }
 
     pub fn create(out: []u8, msg: []const u8, key: []const u8) void {

--- a/std/crypto/sha1.zig
+++ b/std/crypto/sha1.zig
@@ -85,7 +85,7 @@ pub const Sha1 = struct {
         debug.assert(out.len >= 20);
 
         // The buffer here will never be completely full.
-        mem.set(u8, d.buf[d.buf_len..], 0);
+        mem.set(d.buf[d.buf_len..], 0);
 
         // Append padding bits.
         d.buf[d.buf_len] = 0x80;
@@ -94,7 +94,7 @@ pub const Sha1 = struct {
         // > 448 mod 512 so need to add an extra round to wrap around.
         if (64 - d.buf_len < 8) {
             d.round(d.buf[0..]);
-            mem.set(u8, d.buf[0..], 0);
+            mem.set(d.buf[0..], 0);
         }
 
         // Append message length.

--- a/std/crypto/sha2.zig
+++ b/std/crypto/sha2.zig
@@ -140,7 +140,7 @@ fn Sha2_32(comptime params: Sha2Params32) type {
             debug.assert(out.len >= params.out_len / 8);
 
             // The buffer here will never be completely full.
-            mem.set(u8, d.buf[d.buf_len..], 0);
+            mem.set(d.buf[d.buf_len..], 0);
 
             // Append padding bits.
             d.buf[d.buf_len] = 0x80;
@@ -149,7 +149,7 @@ fn Sha2_32(comptime params: Sha2Params32) type {
             // > 448 mod 512 so need to add an extra round to wrap around.
             if (64 - d.buf_len < 8) {
                 d.round(d.buf[0..]);
-                mem.set(u8, d.buf[0..], 0);
+                mem.set(d.buf[0..], 0);
             }
 
             // Append message length.
@@ -482,7 +482,7 @@ fn Sha2_64(comptime params: Sha2Params64) type {
             debug.assert(out.len >= params.out_len / 8);
 
             // The buffer here will never be completely full.
-            mem.set(u8, d.buf[d.buf_len..], 0);
+            mem.set(d.buf[d.buf_len..], 0);
 
             // Append padding bits.
             d.buf[d.buf_len] = 0x80;
@@ -491,7 +491,7 @@ fn Sha2_64(comptime params: Sha2Params64) type {
             // > 896 mod 1024 so need to add an extra round to wrap around.
             if (128 - d.buf_len < 16) {
                 d.round(d.buf[0..]);
-                mem.set(u8, d.buf[0..], 0);
+                mem.set(d.buf[0..], 0);
             }
 
             // Append message length.

--- a/std/crypto/sha3.zig
+++ b/std/crypto/sha3.zig
@@ -27,7 +27,7 @@ fn Keccak(comptime bits: usize, comptime delim: u8) type {
         }
 
         pub fn reset(d: *Self) void {
-            mem.set(u8, d.s[0..], 0);
+            mem.set(d.s[0..], 0);
             d.offset = 0;
             d.rate = 200 - (bits / 4);
         }

--- a/std/crypto/x25519.zig
+++ b/std/crypto/x25519.zig
@@ -108,7 +108,7 @@ pub const X25519 = struct {
         t1.secureZero();
         z2.secureZero();
         z3.secureZero();
-        std.mem.secureZero(u8, e[0..]);
+        std.mem.secureZero(e[0..]);
 
         // Returns false if the output is all zero
         // (happens with some malicious public keys)
@@ -141,7 +141,7 @@ const Fe = struct {
     b: [10]i32,
 
     fn secureZero(self: *Fe) void {
-        std.mem.secureZero(u8, @ptrCast([*]u8, self)[0..@sizeOf(Fe)]);
+        std.mem.secureZero(@ptrCast([*]u8, self)[0..@sizeOf(Fe)]);
     }
 
     fn init0(h: *Fe) void {
@@ -554,7 +554,7 @@ const Fe = struct {
         writeIntSliceLittle(u32, s[24..28], (ut[7] >> 13) | (ut[8] << 12));
         writeIntSliceLittle(u32, s[28..], (ut[8] >> 20) | (ut[9] << 6));
 
-        std.mem.secureZero(i64, t[0..]);
+        std.mem.secureZero(t[0..]);
     }
 
     //  Parity check.  Returns 0 if even, 1 if odd

--- a/std/fmt.zig
+++ b/std/fmt.zig
@@ -759,11 +759,11 @@ fn formatIntUnsigned(
             leftover_padding -= 1;
             if (leftover_padding == 0) break;
         }
-        mem.set(u8, buf[0..index], '0');
+        mem.set(buf[0..index], '0');
         return output(context, buf);
     } else {
         const padded_buf = buf[index - padding ..];
-        mem.set(u8, padded_buf[0..padding], '0');
+        mem.set(padded_buf[0..padding], '0');
         return output(context, padded_buf);
     }
 }

--- a/std/hash/siphash.zig
+++ b/std/hash/siphash.zig
@@ -88,7 +88,7 @@ fn SipHash(comptime T: type, comptime c_rounds: usize, comptime d_rounds: usize)
 
         pub fn final(d: *Self) T {
             // Padding
-            mem.set(u8, d.buf[d.buf_len..], 0);
+            mem.set(d.buf[d.buf_len..], 0);
             d.buf[7] = d.msg_len;
             d.round(d.buf[0..]);
 

--- a/std/math/big/int.zig
+++ b/std/math/big/int.zig
@@ -807,7 +807,7 @@ pub const Int = struct {
         debug.assert(a.len >= b.len);
         debug.assert(r.len >= a.len + b.len);
 
-        mem.set(Limb, r[0 .. a.len + b.len], 0);
+        mem.set(r[0 .. a.len + b.len], 0);
 
         var i: usize = 0;
         while (i < a.len) : (i += 1) {
@@ -974,7 +974,7 @@ pub const Int = struct {
 
         // 1.
         q.metadata = n - t + 1;
-        mem.set(Limb, q.limbs[0..q.len()], 0);
+        mem.set(q.limbs[0..q.len()], 0);
 
         // 2.
         try tmp.shiftLeft(y.*, Limb.bit_count * (n - t));
@@ -1066,7 +1066,7 @@ pub const Int = struct {
         }
 
         r[limb_shift - 1] = carry;
-        mem.set(Limb, r[0 .. limb_shift - 1], 0);
+        mem.set(r[0 .. limb_shift - 1], 0);
     }
 
     /// r = a >> shift

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -248,16 +248,16 @@ pub fn copyBackwards(comptime T: type, dest: []T, source: []const T) void {
     }
 }
 
-pub fn set(comptime T: type, dest: []T, value: T) void {
+pub fn set(dest: var, value: @typeInfo(@typeOf(dest)).Pointer.child) void {
     for (dest) |*d|
         d.* = value;
 }
 
-pub fn secureZero(comptime T: type, s: []T) void {
+pub fn secureZero(s: var) void {
     // NOTE: We do not use a volatile slice cast here since LLVM cannot
     // see that it can be replaced by a memset.
     const ptr = @ptrCast([*]volatile u8, s.ptr);
-    const length = s.len * @sizeOf(T);
+    const length = s.len * @sizeOf(@typeInfo(@typeOf(s)).Pointer.child);
     @memset(ptr, 0, length);
 }
 
@@ -265,8 +265,8 @@ test "mem.secureZero" {
     var a = [_]u8{0xfe} ** 8;
     var b = [_]u8{0xfe} ** 8;
 
-    set(u8, a[0..], 0);
-    secureZero(u8, b[0..]);
+    set(a[0..], 0);
+    secureZero(b[0..]);
 
     testing.expectEqualSlices(u8, a[0..], b[0..]);
 }

--- a/std/os.zig
+++ b/std/os.zig
@@ -559,7 +559,7 @@ pub fn dup2(old_fd: fd_t, new_fd: fd_t) !void {
 /// TODO provide execveC which does not take an allocator
 pub fn execve(allocator: *mem.Allocator, argv_slice: []const []const u8, env_map: *const std.BufMap) !void {
     const argv_buf = try allocator.alloc(?[*]u8, argv_slice.len + 1);
-    mem.set(?[*]u8, argv_buf, null);
+    mem.set(argv_buf, null);
     defer {
         for (argv_buf) |arg| {
             const arg_buf = if (arg) |ptr| mem.toSlice(u8, ptr) else break;
@@ -615,7 +615,7 @@ pub fn execve(allocator: *mem.Allocator, argv_slice: []const []const u8, env_map
 pub fn createNullDelimitedEnvMap(allocator: *mem.Allocator, env_map: *const std.BufMap) ![]?[*]u8 {
     const envp_count = env_map.count();
     const envp_buf = try allocator.alloc(?[*]u8, envp_count + 1);
-    mem.set(?[*]u8, envp_buf, null);
+    mem.set(envp_buf, null);
     errdefer freeNullDelimitedEnvMap(allocator, envp_buf);
     {
         var it = env_map.iterator();

--- a/std/rand.zig
+++ b/std/rand.zig
@@ -818,7 +818,7 @@ pub const Isaac64 = struct {
     fn seed(self: *Isaac64, init_s: u64, comptime rounds: usize) void {
         // We ignore the multi-pass requirement since we don't currently expose full access to
         // seeding the self.m array completely.
-        mem.set(u64, self.m[0..], 0);
+        mem.set(self.m[0..], 0);
         self.m[0] = init_s;
 
         // prescrambled golden ratio constants
@@ -874,7 +874,7 @@ pub const Isaac64 = struct {
             }
         }
 
-        mem.set(u64, self.r[0..], 0);
+        mem.set(self.r[0..], 0);
         self.a = 0;
         self.b = 0;
         self.c = 0;

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -704,7 +704,7 @@ fn renderExpression(
                         // A place to store the width of each expression and its column's maximum
                         var widths = try allocator.alloc(usize, exprs.len + row_size);
                         defer allocator.free(widths);
-                        mem.set(usize, widths, 0);
+                        mem.set(widths, 0);
 
                         var expr_widths = widths[0 .. widths.len - row_size];
                         var column_widths = widths[widths.len - row_size ..];


### PR DESCRIPTION
Deduce type for `mem.set` and `mem.secureZero`
```zig
// current
mem.set(u8, buf, 0);
mem.secureZero(u8, buf);

// proposed
mem.set(buf, 0);
mem.secureZero(buf);
```

I've opted for a breaking change rather than creating a new method. 