### PR TITLE
Add check for null body in if, for and while

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -887,6 +887,11 @@ static AstNode *ast_parse_if_statement(ParseContext *pc) {
         body = ast_parse_assign_expr(pc);
     }
 
+    if (body == nullptr) {
+	Token *tok = eat_token(pc);
+        ast_error(pc, tok, "expected if body, found '%s'", token_name(tok->id));
+    }
+
     Token *err_payload = nullptr;
     AstNode *else_body = nullptr;
     if (eat_token_if(pc, TokenIdKeywordElse) != nullptr) {
@@ -991,6 +996,11 @@ static AstNode *ast_parse_for_statement(ParseContext *pc) {
         body = ast_parse_assign_expr(pc);
     }
 
+    if (body == nullptr) {
+	Token *tok = eat_token(pc);
+        ast_error(pc, tok, "expected loop body, found '%s'", token_name(tok->id));
+    }
+
     AstNode *else_body = nullptr;
     if (eat_token_if(pc, TokenIdKeywordElse) != nullptr) {
         else_body = ast_expect(pc, ast_parse_statement);
@@ -1018,6 +1028,11 @@ static AstNode *ast_parse_while_statement(ParseContext *pc) {
     if (body == nullptr) {
         requires_semi = true;
         body = ast_parse_assign_expr(pc);
+    }
+
+    if (body == nullptr) {
+	Token *tok = eat_token(pc);
+        ast_error(pc, tok, "expected loop body, found '%s'", token_name(tok->id));
     }
 
     Token *err_payload = nullptr;

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -204,6 +204,33 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
+        "empty while loop body",
+        \\export fn a() void {
+        \\    while(true);
+        \\}
+    ,
+        "tmp.zig:2:16: error: expected loop body, found ';'",
+    );
+
+    cases.add(
+        "empty for loop body",
+        \\export fn a() void {
+        \\    for(undefined) |x|;
+        \\}
+    ,
+        "tmp.zig:2:23: error: expected loop body, found ';'",
+    );
+
+    cases.add(
+        "empty if body",
+        \\export fn a() void {
+        \\    if(true);
+        \\}
+    ,
+        "tmp.zig:2:13: error: expected if body, found ';'",
+    );
+
+    cases.add(
         "import outside package path",
         \\comptime{
         \\    _ = @import("../a.zig");


### PR DESCRIPTION
This patch adds a check to the if, while loop and for loop parsing functions that checks if the body exists and if not emits an error. Fixes #2309 