### PR TITLE
Use std.math.isPowerOfTwo across std lib

### DIFF
--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -157,8 +157,7 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime hash: fn (key: K) u3
         fn ensureCapacityExact(self: *Self, new_capacity: usize) !void {
             // capacity must always be a power of two to allow for modulo
             // optimization in the constrainIndex fn
-            const is_power_of_two = new_capacity & (new_capacity - 1) == 0;
-            assert(is_power_of_two);
+            assert(math.isPowerOfTwo(new_capacity));
 
             if (new_capacity <= self.entries.len) {
                 return;

--- a/std/math/big/int.zig
+++ b/std/math/big/int.zig
@@ -447,7 +447,7 @@ pub const Int = struct {
         }
 
         // Power of two: can do a single pass and use masks to extract digits.
-        if (base & (base - 1) == 0) {
+        if (math.isPowerOfTwo(base)) {
             const base_shift = math.log2_int(Limb, base);
 
             for (self.limbs[0..self.len()]) |limb| {

--- a/std/segmented_list.zig
+++ b/std/segmented_list.zig
@@ -80,9 +80,9 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
         const prealloc_exp = blk: {
             // we don't use the prealloc_exp constant when prealloc_item_count is 0.
             assert(prealloc_item_count != 0);
+            assert(std.math.isPowerOfTwo(prealloc_item_count));
 
             const value = std.math.log2_int(usize, prealloc_item_count);
-            assert((1 << value) == prealloc_item_count); // prealloc_item_count must be a power of 2
             break :blk @typeOf(1)(value);
         };
         const ShelfIndex = std.math.Log2Int(usize);


### PR DESCRIPTION
Noticed that `std.math.isPowerOfTwo` got added in https://github.com/ziglang/zig/pull/2525 and so I went through and tried to find all instances of that logic and replace it with a call to that function.

---

~~Only instance I found that I didn't replace is this one:~~

https://github.com/ziglang/zig/blob/b7811d32690a9f3b4912635e16e6aa5ace25362c/std/special/compiler_rt/udivmod.zig#L67

~~because it doesn't currently `@import("std")` and I wasn't sure if that was okay to add that to that file.~~

EDIT: Nevermind, it actually did `@import("std")`, just not at the top. Made that file use `std.math.isPowerOfTwo` as well.

EDIT#2: Left `compiler_rt/udivmod.zig` unchanged, see comments.