### PR TITLE
Remove const on argsAlloc

### DIFF
--- a/std/process.zig
+++ b/std/process.zig
@@ -388,7 +388,7 @@ pub fn args() ArgIterator {
 }
 
 /// Caller must call argsFree on result.
-pub fn argsAlloc(allocator: *mem.Allocator) ![]const []u8 {
+pub fn argsAlloc(allocator: *mem.Allocator) ![][]u8 {
     if (builtin.os == .wasi) {
         var count: usize = undefined;
         var buf_size: usize = undefined;


### PR DESCRIPTION
I think the array returned by `argsAlloc` should be an array of strings, rather than a constant array of strings.