### PR TITLE
Fixed an integer overflow in zig fmt

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2267,6 +2267,32 @@ test "zig fmt: file ends with struct field" {
     );
 }
 
+test "zig fmt: comments at several places in struct init" {
+    try testTransform(
+        \\var bar = Bar{
+        \\    .x = 10, // test
+        \\    .y = "test" 
+        \\    // test
+        \\};
+        \\
+    ,
+        \\var bar = Bar{
+        \\    .x = 10, // test
+        \\    .y = "test", // test
+        \\};
+        \\
+    );
+
+    try testCanonical(
+        \\var bar = Bar{ // test
+        \\    .x = 10, // test
+        \\    .y = "test",
+        \\    // test
+        \\};
+        \\
+    );
+}
+
 const std = @import("std");
 const mem = std.mem;
 const warn = std.debug.warn;

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -2020,7 +2020,13 @@ fn renderTokenOffset(
 
                     const after_comment_token = tree.tokens.at(token_index + offset);
                     const next_line_indent = switch (after_comment_token.id) {
-                        Token.Id.RParen, Token.Id.RBrace, Token.Id.RBracket => indent - indent_delta,
+                        Token.Id.RParen, Token.Id.RBrace, Token.Id.RBracket => blk: {
+                            if (indent > indent_delta) {
+                                break :blk indent - indent_delta;
+                            } else {
+                                break :blk 0;
+                            }
+                        },
                         else => indent,
                     };
                     try stream.writeByteNTimes(' ', next_line_indent);


### PR DESCRIPTION
Formatting the following code caused an integer overflow:
```
var bar = Bar{
    .x = 10, // test
    .y = "test" 
    // test
};
```
This was because the comma was missing after the `.y = "test"`. It transforms to the following code:
```
var bar = Bar{
    .x = 10, // test
    .y = "test", // test
};
```
But it is still possible to write the following code with the formatting being changed:
```
var bar = Bar{
    .x = 10, // test
    .y = "test",
    // test
};
```