### PR TITLE
ArrayList and HashMap debug scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,6 +489,7 @@ set(ZIG_STD_FILES
     "cstr.zig"
     "debug.zig"
     "debug/failing_allocator.zig"
+    "debug/gdb_scripts.zig"
     "debug/leb128.zig"
     "dwarf.zig"
     "dynamic_library.zig"

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -21,6 +21,8 @@ const leb = @import("debug/leb128.zig");
 pub const FailingAllocator = @import("debug/failing_allocator.zig").FailingAllocator;
 pub const failing_allocator = &FailingAllocator.init(global_allocator, 0).allocator;
 
+pub const gdb_scripts = @import("debug/gdb_scripts.zig");
+
 pub const runtime_safety = switch (builtin.mode) {
     .Debug, .ReleaseSafe => true,
     .ReleaseFast, .ReleaseSmall => false,

--- a/std/debug/gdb_scripts.zig
+++ b/std/debug/gdb_scripts.zig
@@ -1,0 +1,27 @@
+const builtin = @import("builtin");
+
+pub const is_enabled = builtin.object_format == .elf and !builtin.strip_debug_info;
+
+pub fn load_python_script(comptime unique_qualified_name: []const u8, comptime program_text: []const u8) void {
+    if (!is_enabled) return;
+
+    const symbol_name = "__debug_script_" ++ unique_qualified_name;
+    const SECTION_SCRIPT_ID_PYTHON_TEXT = "\x04";
+    const section_content = SECTION_SCRIPT_ID_PYTHON_TEXT ++ unique_qualified_name ++ ".py\n" ++ program_text ++ "\x00";
+    _ = struct {
+        extern const storage linksection(".debug_gdb_scripts") = section_content;
+        comptime {
+            @export(symbol_name, storage, .Strong);
+        }
+    };
+}
+
+comptime {
+    if (is_enabled) {
+        // Stop the linker from garbage collecting the unused debug info.
+        asm (
+            \\.pushsection ".debug_gdb_scripts", "MS",@progbits,1
+            \\.popsection
+        );
+    }
+}


### PR DESCRIPTION
I added some gdb debug scripts to the std library, but the one for hash_map doesn't seem to work. it freezes when reading the `["used"]` member of hashmap entry objects. This also happens in the gdb cli if i just try to print an entry's `.used` with no python involved. i'm not sure what's going on there, but debugging debuggers is pretty discouraging, so i might just abandon this branch for a while.

see also https://github.com/ziglang/zig/issues/2685 which might be related. i'm not sure.