### PR TITLE
stage1: check for null in buf_ptr()

### DIFF
--- a/src/buffer.hpp
+++ b/src/buffer.hpp
@@ -27,6 +27,7 @@ Buf *buf_sprintf(const char *format, ...)
 Buf *buf_vprintf(const char *format, va_list ap);
 
 static inline size_t buf_len(Buf *buf) {
+    assert(buf);
     assert(buf->list.length);
     return buf->list.length - 1;
 }

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -18613,7 +18613,7 @@ static Error ir_make_type_info_decls(IrAnalyze *ira, IrInstruction *source_instr
                         true, false, PtrLenUnknown,
                         0, 0, 0, false);
                     fn_decl_fields[6].type = get_optional_type(ira->codegen, get_slice_type(ira->codegen, u8_ptr));
-                    if (fn_node->is_extern && buf_len(fn_node->lib_name) > 0) {
+                    if (fn_node->is_extern && fn_node->lib_name && buf_len(fn_node->lib_name) > 0) {
                         fn_decl_fields[6].data.x_optional = create_const_vals(1);
                         ConstExprValue *lib_name = create_const_str_lit(ira->codegen, fn_node->lib_name);
                         init_const_slice(ira->codegen, fn_decl_fields[6].data.x_optional, lib_name, 0, buf_len(fn_node->lib_name), true);


### PR DESCRIPTION
reported on IRC:

<tralamazza> hi andrewrk, I'm trying my hand at zig for embedded. I'm trying to avoid asm, while doing the startup code I think I stepped into a compiler bug (or at least crash) https://zig.godbolt.org/z/ACOnoy

const Foo = struct { // packed makes no difference
    extern fn bar() void;
};

comptime {
    const info = @typeInfo(Foo);
}

Which results in this backtrace:

Program received signal SIGSEGV, Segmentation fault.
0x0000555555db05e6 in buf_len (buf=0x0) at ../src/buffer.hpp:30
30	    assert(buf->list.length);
(gdb) bt
0  0x0000555555db05e6 in buf_len (buf=0x0) at ../src/buffer.hpp:30
1  0x0000555555df5876 in ir_make_type_info_decls (ira=0x5555581ad8f0, source_instr=0x5555581ad280, out_val=0x55555820a950,
    decls_scope=0x5555581aded0) at ../src/ir.cpp:18616
2  0x0000555555df7ecc in ir_make_type_info_value (ira=0x5555581ad8f0, source_instr=0x5555581ad280, type_entry=0x5555581addd0,
    out=0x7fffffffd4f8) at ../src/ir.cpp:19236
3  0x0000555555df874e in ir_analyze_instruction_type_info (ira=0x5555581ad8f0, instruction=0x5555581ad280) at ../src/ir.cpp:19380
4  0x0000555555e080b2 in ir_analyze_instruction_nocast (ira=0x5555581ad8f0, instruction=0x5555581ad280) at ../src/ir.cpp:23529
5  0x0000555555e084c9 in ir_analyze_instruction (ira=0x5555581ad8f0, old_instruction=0x5555581ad280) at ../src/ir.cpp:23617
6  0x0000555555e087bb in ir_analyze (codegen=0x555558151b00, old_exec=0x5555581acce0, new_exec=0x5555581ad7f0,
    expected_type=0x5555581694a0, expected_type_source_node=0x0) at ../src/ir.cpp:23668
7  0x0000555555dd7665 in ir_eval_const_value (codegen=0x555558151b00, scope=0x55555819be50, node=0x55555819c5b0,
    expected_type=0x5555581694a0, backward_branch_count=0x7fffffffd6e8, backward_branch_quota=0x7fffffffd6f0, fn_entry=0x0,
    c_import_buf=0x0, source_node=0x55555819c5b0, exec_name=0x0, parent_exec=0x0, expected_type_source_node=0x0) at ../src/ir.cpp:10507
8  0x0000555555e47df7 in analyze_const_value (g=0x555558151b00, scope=0x55555819be50, node=0x55555819c5b0, type_entry=0x5555581694a0,
    type_name=0x0) at ../src/analyze.cpp:971
9  0x0000555555e4df17 in resolve_decl_comptime (g=0x555558151b00, tld_comptime=0x55555819c7f0) at ../src/analyze.cpp:2839
10 0x0000555555e4f3ad in resolve_top_level_decl (g=0x555558151b00, tld=0x55555819c7f0, source_node=0x0) at ../src/analyze.cpp:3299
11 0x0000555555e514dd in semantic_analyze (g=0x555558151b00) at ../src/analyze.cpp:3994
12 0x0000555555da7ea7 in gen_root_source (g=0x555558151b00) at ../src/codegen.cpp:8644
13 0x0000555555dab8b9 in codegen_build_and_link (g=0x555558151b00) at ../src/codegen.cpp:9591
14 0x0000555555d83cf3 in main (argc=3, argv=0x7fffffffded8) at ../src/main.cpp:1144