### PR TITLE
Fix windows create process retry/path search

### DIFF
--- a/std/os/windows.zig
+++ b/std/os/windows.zig
@@ -632,6 +632,7 @@ pub fn GetEnvironmentVariableW(lpName: LPWSTR, lpBuffer: LPWSTR, nSize: DWORD) G
 
 pub const CreateProcessError = error{
     FileNotFound,
+    AccessDenied,
     InvalidName,
     Unexpected,
 };
@@ -663,6 +664,7 @@ pub fn CreateProcessW(
         switch (kernel32.GetLastError()) {
             ERROR.FILE_NOT_FOUND => return error.FileNotFound,
             ERROR.PATH_NOT_FOUND => return error.FileNotFound,
+            ERROR.ACCESS_DENIED => return error.AccessDenied,
             ERROR.INVALID_PARAMETER => unreachable,
             ERROR.INVALID_NAME => return error.InvalidName,
             else => |err| return unexpectedError(err),


### PR DESCRIPTION
Windows works a bit different than linux when it comes to searching for executables.

Windows uses the `PATHEXT` environment variable to iterate through a list of extensions to try when searching for executables.

For example, if you're trying to execute program `foo`, windows will search for `foo.EXT` where `EXT` is any one of the semi-colon separated entries in `PATHEXT`.  So if `PATHEXT` is `.EXE;.BAT.COM.CMD` then it will search for:

* `foo.EXE`
* `foo.BAT`
* `foo.COM`
* `foo.CMD`

in that order.  Note that it will check each extension in each PATH directory entry before moving to the next PATH directory entry.

I also modified the "CreateProcess" retry loop to continue the retry loop even when "access denied" errors are encountered.

Note that I discovered this issue while running my project at https://github.com/bettertools/git-extra

```
> cd src_zig
> zig build
> out\git-fetchout.exe origin master
```