### PR TITLE
fix macOS stack trace regression

### DIFF
--- a/std/c/darwin.zig
+++ b/std/c/darwin.zig
@@ -37,7 +37,7 @@ const mach_hdr = if (@sizeOf(usize) == 8) mach_header_64 else mach_header;
 pub extern "c" var _mh_execute_header: mach_hdr = undefined;
 comptime {
     if (std.os.darwin.is_the_target) {
-        @export("__mh_execute_header", _mh_execute_header, .Weak);
+        @export("_mh_execute_header", _mh_execute_header, .Weak);
     }
 }
 


### PR DESCRIPTION
f8f054b354088eb9e76d9207972022bc1d3dfc28 exposes the issue where
macho symbol `__mh_execute_header` is weak exported with an extra
underscore and stack traces fail due to invalid header magic.

related #2700