### PR TITLE
Fix std.math.absFloat

### DIFF
--- a/std/math.zig
+++ b/std/math.zig
@@ -482,7 +482,16 @@ fn testAbsInt() void {
     testing.expect((absInt(i32(10)) catch unreachable) == 10);
 }
 
-pub const absFloat = @import("fabs.zig").fabs;
+pub const absFloat = fabs;
+
+test "math.absFloat" {
+    testAbsFloat();
+    comptime testAbsFloat();
+}
+fn testAbsFloat() void {
+    testing.expect(absFloat(f32(-10.05)) == 10.05);
+    testing.expect(absFloat(f32(10.05)) == 10.05);
+}
 
 pub fn divTrunc(comptime T: type, numerator: T, denominator: T) !T {
     @setRuntimeSafety(false);


### PR DESCRIPTION
Fixes an incorrect import for std.math.absFloat
```
zig/lib/zig/std/math.zig:485:22: error: unable to find 'fabs.zig'
pub const absFloat = @import("fabs.zig").fabs;
```
fabs.zig is in the math directory and already imported.