### PR TITLE
Support returning `!u8` from main

### DIFF
--- a/test/build_examples.zig
+++ b/test/build_examples.zig
@@ -7,6 +7,8 @@ pub fn addCases(cases: *tests.BuildExamplesContext) void {
     cases.addC("example/hello_world/hello_libc.zig");
     cases.add("example/cat/main.zig");
     cases.add("example/guess_number/main.zig");
+    cases.add("test/standalone/main_return_error/error_u8.zig");
+    cases.add("test/standalone/main_return_error/error_u8_non_zero.zig");
     cases.addBuildFile("test/standalone/main_pkg_path/build.zig");
     cases.addBuildFile("example/shared_library/build.zig");
     cases.addBuildFile("example/mix_o_files/build.zig");

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2213,7 +2213,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "wrong return type for main",
         \\pub fn main() f32 { }
     ,
-        "error: expected return type of main to be 'u8', 'noreturn', 'void', or '!void'",
+        "error: expected return type of main to be 'u8', 'noreturn', 'void', '!void', or '!u8'",
     );
 
     cases.add(
@@ -2221,7 +2221,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\pub fn main() ??void {
         \\}
     ,
-        "error: expected return type of main to be 'u8', 'noreturn', 'void', or '!void'",
+        "error: expected return type of main to be 'u8', 'noreturn', 'void', '!void', or '!u8'",
     );
 
     cases.add(

--- a/test/standalone/main_return_error/error_u8.zig
+++ b/test/standalone/main_return_error/error_u8.zig
@@ -1,0 +1,7 @@
+const Err = error {
+    Foo
+};
+
+pub fn main() !u8 {
+    return Err.Foo;
+}

--- a/test/standalone/main_return_error/error_u8_non_zero.zig
+++ b/test/standalone/main_return_error/error_u8_non_zero.zig
@@ -1,0 +1,8 @@
+const Err = error { Foo };
+
+fn foo() u8 { var x = @intCast(u8, 9); return x; }
+
+pub fn main() !u8 {
+    if (foo() == 7) return Err.Foo;
+    return 123;
+}


### PR DESCRIPTION
This patch assigns the return value of `root.main()` to a variable to allow returning `!u8` from a program's main function.

Fixes #2721 and #2662