### PR TITLE
Tokenize `&&` and generate parse error

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -933,7 +933,9 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: var, source_token: Tok
             std.zig.Token.Id.BracketStarCBracket,
             => try writeEscaped(out, src[token.start..token.end]),
 
-            std.zig.Token.Id.Invalid => return parseError(
+            std.zig.Token.Id.AmpersandAmpersand,
+            std.zig.Token.Id.Invalid,
+            => return parseError(
                 docgen_tokenizer,
                 source_token,
                 "syntax error",

--- a/std/zig/ast.zig
+++ b/std/zig/ast.zig
@@ -113,6 +113,7 @@ pub const Tree = struct {
 
 pub const Error = union(enum) {
     InvalidToken: InvalidToken,
+    InvalidAmpersandAmpersand: InvalidAmpersandAmpersand,
     ExpectedContainerMembers: ExpectedContainerMembers,
     ExpectedStringLiteral: ExpectedStringLiteral,
     ExpectedIntegerLiteral: ExpectedIntegerLiteral,
@@ -161,6 +162,7 @@ pub const Error = union(enum) {
         switch (self.*) {
             // TODO https://github.com/ziglang/zig/issues/683
             @TagType(Error).InvalidToken => |*x| return x.render(tokens, stream),
+            @TagType(Error).InvalidAmpersandAmpersand => |*x| return x.render(tokens, stream),
             @TagType(Error).ExpectedContainerMembers => |*x| return x.render(tokens, stream),
             @TagType(Error).ExpectedStringLiteral => |*x| return x.render(tokens, stream),
             @TagType(Error).ExpectedIntegerLiteral => |*x| return x.render(tokens, stream),
@@ -211,6 +213,7 @@ pub const Error = union(enum) {
         switch (self.*) {
             // TODO https://github.com/ziglang/zig/issues/683
             @TagType(Error).InvalidToken => |x| return x.token,
+            @TagType(Error).InvalidAmpersandAmpersand => |x| return x.token,
             @TagType(Error).ExpectedContainerMembers => |x| return x.token,
             @TagType(Error).ExpectedStringLiteral => |x| return x.token,
             @TagType(Error).ExpectedIntegerLiteral => |x| return x.token,
@@ -291,6 +294,7 @@ pub const Error = union(enum) {
     pub const ExpectedDerefOrUnwrap = SingleTokenError("Expected pointer dereference or optional unwrap, found {}");
     pub const ExpectedSuffixOp = SingleTokenError("Expected pointer dereference, optional unwrap, or field access, found {}");
 
+    pub const InvalidAmpersandAmpersand = SimpleError("Invalid token '&&', 'and' performs boolean AND");
     pub const ExpectedParamType = SimpleError("Expected parameter type");
     pub const ExpectedPubItem = SimpleError("Pub must be followed by fn decl, var decl, or container member");
     pub const UnattachedDocComment = SimpleError("Unattached documentation comment");

--- a/std/zig/ast.zig
+++ b/std/zig/ast.zig
@@ -160,103 +160,101 @@ pub const Error = union(enum) {
 
     pub fn render(self: *const Error, tokens: *Tree.TokenList, stream: var) !void {
         switch (self.*) {
-            // TODO https://github.com/ziglang/zig/issues/683
-            @TagType(Error).InvalidToken => |*x| return x.render(tokens, stream),
-            @TagType(Error).InvalidAmpersandAmpersand => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedContainerMembers => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedStringLiteral => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedIntegerLiteral => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedPubItem => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedIdentifier => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedStatement => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedVarDeclOrFn => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedVarDecl => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedReturnType => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedAggregateKw => |*x| return x.render(tokens, stream),
-            @TagType(Error).UnattachedDocComment => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedEqOrSemi => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedSemiOrLBrace => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedSemiOrElse => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedLabelOrLBrace => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedLBrace => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedColonOrRParen => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedLabelable => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedInlinable => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedAsmOutputReturnOrType => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedCall => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedCallOrFnProto => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedSliceOrRBracket => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExtraAlignQualifier => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExtraConstQualifier => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExtraVolatileQualifier => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExtraAllowZeroQualifier => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedTypeExpr => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedPrimaryTypeExpr => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedParamType => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedExpr => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedPrimaryExpr => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedToken => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedCommaOrEnd => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedParamList => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedPayload => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedBlockOrAssignment => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedBlockOrExpression => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedExprOrAssignment => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedPrefixExpr => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedLoopExpr => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedDerefOrUnwrap => |*x| return x.render(tokens, stream),
-            @TagType(Error).ExpectedSuffixOp => |*x| return x.render(tokens, stream),
+            .InvalidToken => |*x| return x.render(tokens, stream),
+            .InvalidAmpersandAmpersand => |*x| return x.render(tokens, stream),
+            .ExpectedContainerMembers => |*x| return x.render(tokens, stream),
+            .ExpectedStringLiteral => |*x| return x.render(tokens, stream),
+            .ExpectedIntegerLiteral => |*x| return x.render(tokens, stream),
+            .ExpectedPubItem => |*x| return x.render(tokens, stream),
+            .ExpectedIdentifier => |*x| return x.render(tokens, stream),
+            .ExpectedStatement => |*x| return x.render(tokens, stream),
+            .ExpectedVarDeclOrFn => |*x| return x.render(tokens, stream),
+            .ExpectedVarDecl => |*x| return x.render(tokens, stream),
+            .ExpectedReturnType => |*x| return x.render(tokens, stream),
+            .ExpectedAggregateKw => |*x| return x.render(tokens, stream),
+            .UnattachedDocComment => |*x| return x.render(tokens, stream),
+            .ExpectedEqOrSemi => |*x| return x.render(tokens, stream),
+            .ExpectedSemiOrLBrace => |*x| return x.render(tokens, stream),
+            .ExpectedSemiOrElse => |*x| return x.render(tokens, stream),
+            .ExpectedLabelOrLBrace => |*x| return x.render(tokens, stream),
+            .ExpectedLBrace => |*x| return x.render(tokens, stream),
+            .ExpectedColonOrRParen => |*x| return x.render(tokens, stream),
+            .ExpectedLabelable => |*x| return x.render(tokens, stream),
+            .ExpectedInlinable => |*x| return x.render(tokens, stream),
+            .ExpectedAsmOutputReturnOrType => |*x| return x.render(tokens, stream),
+            .ExpectedCall => |*x| return x.render(tokens, stream),
+            .ExpectedCallOrFnProto => |*x| return x.render(tokens, stream),
+            .ExpectedSliceOrRBracket => |*x| return x.render(tokens, stream),
+            .ExtraAlignQualifier => |*x| return x.render(tokens, stream),
+            .ExtraConstQualifier => |*x| return x.render(tokens, stream),
+            .ExtraVolatileQualifier => |*x| return x.render(tokens, stream),
+            .ExtraAllowZeroQualifier => |*x| return x.render(tokens, stream),
+            .ExpectedTypeExpr => |*x| return x.render(tokens, stream),
+            .ExpectedPrimaryTypeExpr => |*x| return x.render(tokens, stream),
+            .ExpectedParamType => |*x| return x.render(tokens, stream),
+            .ExpectedExpr => |*x| return x.render(tokens, stream),
+            .ExpectedPrimaryExpr => |*x| return x.render(tokens, stream),
+            .ExpectedToken => |*x| return x.render(tokens, stream),
+            .ExpectedCommaOrEnd => |*x| return x.render(tokens, stream),
+            .ExpectedParamList => |*x| return x.render(tokens, stream),
+            .ExpectedPayload => |*x| return x.render(tokens, stream),
+            .ExpectedBlockOrAssignment => |*x| return x.render(tokens, stream),
+            .ExpectedBlockOrExpression => |*x| return x.render(tokens, stream),
+            .ExpectedExprOrAssignment => |*x| return x.render(tokens, stream),
+            .ExpectedPrefixExpr => |*x| return x.render(tokens, stream),
+            .ExpectedLoopExpr => |*x| return x.render(tokens, stream),
+            .ExpectedDerefOrUnwrap => |*x| return x.render(tokens, stream),
+            .ExpectedSuffixOp => |*x| return x.render(tokens, stream),
         }
     }
 
     pub fn loc(self: *const Error) TokenIndex {
         switch (self.*) {
-            // TODO https://github.com/ziglang/zig/issues/683
-            @TagType(Error).InvalidToken => |x| return x.token,
-            @TagType(Error).InvalidAmpersandAmpersand => |x| return x.token,
-            @TagType(Error).ExpectedContainerMembers => |x| return x.token,
-            @TagType(Error).ExpectedStringLiteral => |x| return x.token,
-            @TagType(Error).ExpectedIntegerLiteral => |x| return x.token,
-            @TagType(Error).ExpectedPubItem => |x| return x.token,
-            @TagType(Error).ExpectedIdentifier => |x| return x.token,
-            @TagType(Error).ExpectedStatement => |x| return x.token,
-            @TagType(Error).ExpectedVarDeclOrFn => |x| return x.token,
-            @TagType(Error).ExpectedVarDecl => |x| return x.token,
-            @TagType(Error).ExpectedReturnType => |x| return x.token,
-            @TagType(Error).ExpectedAggregateKw => |x| return x.token,
-            @TagType(Error).UnattachedDocComment => |x| return x.token,
-            @TagType(Error).ExpectedEqOrSemi => |x| return x.token,
-            @TagType(Error).ExpectedSemiOrLBrace => |x| return x.token,
-            @TagType(Error).ExpectedSemiOrElse => |x| return x.token,
-            @TagType(Error).ExpectedLabelOrLBrace => |x| return x.token,
-            @TagType(Error).ExpectedLBrace => |x| return x.token,
-            @TagType(Error).ExpectedColonOrRParen => |x| return x.token,
-            @TagType(Error).ExpectedLabelable => |x| return x.token,
-            @TagType(Error).ExpectedInlinable => |x| return x.token,
-            @TagType(Error).ExpectedAsmOutputReturnOrType => |x| return x.token,
-            @TagType(Error).ExpectedCall => |x| return x.node.firstToken(),
-            @TagType(Error).ExpectedCallOrFnProto => |x| return x.node.firstToken(),
-            @TagType(Error).ExpectedSliceOrRBracket => |x| return x.token,
-            @TagType(Error).ExtraAlignQualifier => |x| return x.token,
-            @TagType(Error).ExtraConstQualifier => |x| return x.token,
-            @TagType(Error).ExtraVolatileQualifier => |x| return x.token,
-            @TagType(Error).ExtraAllowZeroQualifier => |x| return x.token,
-            @TagType(Error).ExpectedTypeExpr => |x| return x.token,
-            @TagType(Error).ExpectedPrimaryTypeExpr => |x| return x.token,
-            @TagType(Error).ExpectedParamType => |x| return x.token,
-            @TagType(Error).ExpectedExpr => |x| return x.token,
-            @TagType(Error).ExpectedPrimaryExpr => |x| return x.token,
-            @TagType(Error).ExpectedToken => |x| return x.token,
-            @TagType(Error).ExpectedCommaOrEnd => |x| return x.token,
-            @TagType(Error).ExpectedParamList => |x| return x.token,
-            @TagType(Error).ExpectedPayload => |x| return x.token,
-            @TagType(Error).ExpectedBlockOrAssignment => |x| return x.token,
-            @TagType(Error).ExpectedBlockOrExpression => |x| return x.token,
-            @TagType(Error).ExpectedExprOrAssignment => |x| return x.token,
-            @TagType(Error).ExpectedPrefixExpr => |x| return x.token,
-            @TagType(Error).ExpectedLoopExpr => |x| return x.token,
-            @TagType(Error).ExpectedDerefOrUnwrap => |x| return x.token,
-            @TagType(Error).ExpectedSuffixOp => |x| return x.token,
+            .InvalidToken => |x| return x.token,
+            .InvalidAmpersandAmpersand => |x| return x.token,
+            .ExpectedContainerMembers => |x| return x.token,
+            .ExpectedStringLiteral => |x| return x.token,
+            .ExpectedIntegerLiteral => |x| return x.token,
+            .ExpectedPubItem => |x| return x.token,
+            .ExpectedIdentifier => |x| return x.token,
+            .ExpectedStatement => |x| return x.token,
+            .ExpectedVarDeclOrFn => |x| return x.token,
+            .ExpectedVarDecl => |x| return x.token,
+            .ExpectedReturnType => |x| return x.token,
+            .ExpectedAggregateKw => |x| return x.token,
+            .UnattachedDocComment => |x| return x.token,
+            .ExpectedEqOrSemi => |x| return x.token,
+            .ExpectedSemiOrLBrace => |x| return x.token,
+            .ExpectedSemiOrElse => |x| return x.token,
+            .ExpectedLabelOrLBrace => |x| return x.token,
+            .ExpectedLBrace => |x| return x.token,
+            .ExpectedColonOrRParen => |x| return x.token,
+            .ExpectedLabelable => |x| return x.token,
+            .ExpectedInlinable => |x| return x.token,
+            .ExpectedAsmOutputReturnOrType => |x| return x.token,
+            .ExpectedCall => |x| return x.node.firstToken(),
+            .ExpectedCallOrFnProto => |x| return x.node.firstToken(),
+            .ExpectedSliceOrRBracket => |x| return x.token,
+            .ExtraAlignQualifier => |x| return x.token,
+            .ExtraConstQualifier => |x| return x.token,
+            .ExtraVolatileQualifier => |x| return x.token,
+            .ExtraAllowZeroQualifier => |x| return x.token,
+            .ExpectedTypeExpr => |x| return x.token,
+            .ExpectedPrimaryTypeExpr => |x| return x.token,
+            .ExpectedParamType => |x| return x.token,
+            .ExpectedExpr => |x| return x.token,
+            .ExpectedPrimaryExpr => |x| return x.token,
+            .ExpectedToken => |x| return x.token,
+            .ExpectedCommaOrEnd => |x| return x.token,
+            .ExpectedParamList => |x| return x.token,
+            .ExpectedPayload => |x| return x.token,
+            .ExpectedBlockOrAssignment => |x| return x.token,
+            .ExpectedBlockOrExpression => |x| return x.token,
+            .ExpectedExprOrAssignment => |x| return x.token,
+            .ExpectedPrefixExpr => |x| return x.token,
+            .ExpectedLoopExpr => |x| return x.token,
+            .ExpectedDerefOrUnwrap => |x| return x.token,
+            .ExpectedSuffixOp => |x| return x.token,
         }
     }
 
@@ -1712,15 +1710,15 @@ pub const Node = struct {
             i -= 1;
 
             switch (self.op) {
-                @TagType(Op).Call => |*call_info| {
+                .Call => |*call_info| {
                     if (i < call_info.params.len) return call_info.params.at(i).*;
                     i -= call_info.params.len;
                 },
-                Op.ArrayAccess => |index_expr| {
+                .ArrayAccess => |index_expr| {
                     if (i < 1) return index_expr;
                     i -= 1;
                 },
-                @TagType(Op).Slice => |range| {
+                .Slice => |range| {
                     if (i < 1) return range.start;
                     i -= 1;
 
@@ -1729,16 +1727,16 @@ pub const Node = struct {
                         i -= 1;
                     }
                 },
-                Op.ArrayInitializer => |*exprs| {
+                .ArrayInitializer => |*exprs| {
                     if (i < exprs.len) return exprs.at(i).*;
                     i -= exprs.len;
                 },
-                Op.StructInitializer => |*fields| {
+                .StructInitializer => |*fields| {
                     if (i < fields.len) return fields.at(i).*;
                     i -= fields.len;
                 },
-                Op.UnwrapOptional,
-                Op.Deref,
+                .UnwrapOptional,
+                .Deref,
                 => {},
             }
 
@@ -1747,7 +1745,7 @@ pub const Node = struct {
 
         pub fn firstToken(self: *const SuffixOp) TokenIndex {
             switch (self.op) {
-                @TagType(Op).Call => |*call_info| if (call_info.async_attr) |async_attr| return async_attr.firstToken(),
+                .Call => |*call_info| if (call_info.async_attr) |async_attr| return async_attr.firstToken(),
                 else => {},
             }
             return self.lhs.firstToken();

--- a/std/zig/parse.zig
+++ b/std/zig/parse.zig
@@ -774,7 +774,7 @@ fn parseBoolAndExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node 
         arena,
         it,
         tree,
-        SimpleBinOpParseFn(.Keyword_and, Node.InfixOp.Op.BoolAnd),
+        parseAmpersandAmpersandOp,
         parseCompareExpr,
         .Infinitely,
     );
@@ -2688,6 +2688,18 @@ fn SimpleBinOpParseFn(comptime token: Token.Id, comptime op: Node.InfixOp.Op) No
 }
 
 // Helper parsers not included in the grammar
+
+fn parseAmpersandAmpersandOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
+    const op_parse_and = SimpleBinOpParseFn(.Keyword_and, Node.InfixOp.Op.BoolAnd);
+    const op_token = eatToken(it, .AmpersandAmpersand);
+    if (op_token != null) {
+        try tree.errors.push(AstError{
+            .InvalidAmpersandAmpersand = AstError.InvalidAmpersandAmpersand{ .token = it.index },
+        });
+        return error.ParseError;
+    }
+    return op_parse_and(arena, it, tree);
+}
 
 fn parseBuiltinCall(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
     const token = eatToken(it, .Builtin) orelse return null;

--- a/std/zig/tokenizer.zig
+++ b/std/zig/tokenizer.zig
@@ -126,6 +126,7 @@ pub const Token = struct {
         SlashEqual,
         Comma,
         Ampersand,
+        AmpersandAmpersand,
         AmpersandEqual,
         QuestionMark,
         AngleBracketLeft,
@@ -487,6 +488,10 @@ pub const Tokenizer = struct {
                 },
 
                 State.Ampersand => switch (c) {
+                    '&' => {
+                        result.id = Token.Id.AmpersandAmpersand;
+                        break;
+                    },
                     '=' => {
                         result.id = Token.Id.AmpersandEqual;
                         self.index += 1;


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/2660

1. Explicitly tokenize `&&`
2. Parse error whenever `&&` is used in a boolean statement — `error: Invalid token '&&', and' performs boolean AND`
3. Delete some unnecessary `@TagType` switches now that inferred enums are a thing