### PR TITLE
Update wording of error set implicit casting in docs

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3787,7 +3787,7 @@ test "fn reflection" {
       However right now it is hard coded to be a {#syntax#}u16{#endsyntax#}. See <a href="https://github.com/ziglang/zig/issues/786">#768</a>.
       </p>
       <p>
-      You can {#link|implicitly cast|Implicit Casts#} an error from a subset to its superset:
+      You can {#link|implicitly cast|Implicit Casts#} an error from a subset to a superset:
       </p>
       {#code_begin|test#}
 const std = @import("std");


### PR DESCRIPTION
I found this wording kind of confusing because as far as I can tell there is not just *one* possible superset of an error, and moreover the error does not 'belong' to one specific superset, so 'its' is somewhat misleading.