### PR TITLE
heap: make one global instance of DirectAllocator

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -16,10 +16,7 @@ const tmp_dir_name = "docgen_tmp";
 const test_out_path = tmp_dir_name ++ fs.path.sep_str ++ "test" ++ exe_ext;
 
 pub fn main() !void {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(std.heap.direct_allocator);
     defer arena.deinit();
 
     const allocator = &arena.allocator;

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8505,10 +8505,7 @@ fn concat(allocator: *Allocator, a: []const u8, b: []const u8) ![]u8 {
 const std = @import("std");
 
 pub fn main() !void {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(std.heap.direct_allocator);
     defer arena.deinit();
 
     const allocator = &arena.allocator;

--- a/libc/process_headers.zig
+++ b/libc/process_headers.zig
@@ -707,8 +707,7 @@ const TargetToHash = std.HashMap(DestTarget, []const u8, DestTarget.hash, DestTa
 const PathTable = std.AutoHashMap([]const u8, *TargetToHash);
 
 pub fn main() !void {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(std.heap.direct_allocator);
     const allocator = &arena.allocator;
     const args = try std.os.argsAlloc(allocator);
     var search_paths = std.ArrayList([]const u8).init(allocator);

--- a/src-self-hosted/dep_tokenizer.zig
+++ b/src-self-hosted/dep_tokenizer.zig
@@ -837,12 +837,11 @@ test "error prereq - continuation expecting end-of-line" {
 
 // - tokenize input, emit textual representation, and compare to expect
 fn depTokenizer(input: []const u8, expect: []const u8) !void {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    var arena_allocator = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena_allocator = std.heap.ArenaAllocator.init(std.heap.direct_allocator);
     const arena = &arena_allocator.allocator;
     defer arena_allocator.deinit();
 
-    var it = Tokenizer.init(&direct_allocator.allocator, input);
+    var it = Tokenizer.init(arena, input);
     var buffer = try std.Buffer.initSize(arena, 0);
     var i: usize = 0;
     while (true) {

--- a/std/atomic/queue.zig
+++ b/std/atomic/queue.zig
@@ -152,11 +152,8 @@ const puts_per_thread = 500;
 const put_thread_count = 3;
 
 test "std.atomic.Queue" {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var plenty_of_memory = try direct_allocator.allocator.alloc(u8, 300 * 1024);
-    defer direct_allocator.allocator.free(plenty_of_memory);
+    var plenty_of_memory = try std.heap.direct_allocator.alloc(u8, 300 * 1024);
+    defer std.heap.direct_allocator.free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
     var a = &fixed_buffer_allocator.allocator;

--- a/std/atomic/stack.zig
+++ b/std/atomic/stack.zig
@@ -86,11 +86,8 @@ const puts_per_thread = 500;
 const put_thread_count = 3;
 
 test "std.atomic.stack" {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var plenty_of_memory = try direct_allocator.allocator.alloc(u8, 300 * 1024);
-    defer direct_allocator.allocator.free(plenty_of_memory);
+    var plenty_of_memory = try std.heap.direct_allocator.alloc(u8, 300 * 1024);
+    defer std.heap.direct_allocator.free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
     var a = &fixed_buffer_allocator.allocator;

--- a/std/buf_map.zig
+++ b/std/buf_map.zig
@@ -83,10 +83,7 @@ pub const BufMap = struct {
 };
 
 test "BufMap" {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var bufmap = BufMap.init(&direct_allocator.allocator);
+    var bufmap = BufMap.init(std.heap.direct_allocator);
     defer bufmap.deinit();
 
     try bufmap.set("x", "1");

--- a/std/buf_set.zig
+++ b/std/buf_set.zig
@@ -65,10 +65,7 @@ pub const BufSet = struct {
 };
 
 test "BufSet" {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var bufset = BufSet.init(&direct_allocator.allocator);
+    var bufset = BufSet.init(std.heap.direct_allocator);
     defer bufset.deinit();
 
     try bufset.put("x");

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -2283,13 +2283,11 @@ var global_allocator_mem: [100 * 1024]u8 = undefined;
 
 /// TODO multithreaded awareness
 var debug_info_allocator: ?*mem.Allocator = null;
-var debug_info_direct_allocator: std.heap.DirectAllocator = undefined;
 var debug_info_arena_allocator: std.heap.ArenaAllocator = undefined;
 fn getDebugInfoAllocator() *mem.Allocator {
     if (debug_info_allocator) |a| return a;
 
-    debug_info_direct_allocator = std.heap.DirectAllocator.init();
-    debug_info_arena_allocator = std.heap.ArenaAllocator.init(&debug_info_direct_allocator.allocator);
+    debug_info_arena_allocator = std.heap.ArenaAllocator.init(std.heap.direct_allocator);
     debug_info_allocator = &debug_info_arena_allocator.allocator;
     return &debug_info_arena_allocator.allocator;
 }

--- a/std/event/channel.zig
+++ b/std/event/channel.zig
@@ -324,10 +324,7 @@ test "std.event.Channel" {
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded) return error.SkipZigTest;
 
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-
-    const allocator = &da.allocator;
+    const allocator = std.heap.direct_allocator;
 
     var loop: Loop = undefined;
     // TODO make a multi threaded test

--- a/std/event/fs.zig
+++ b/std/event/fs.zig
@@ -1310,10 +1310,7 @@ const test_tmp_dir = "std_event_fs_test";
 // TODO this test is disabled until the coroutine rewrite is finished.
 //test "write a file, watch it, write it again" {
 //    return error.SkipZigTest;
-//    var da = std.heap.DirectAllocator.init();
-//    defer da.deinit();
-//
-//    const allocator = &da.allocator;
+//    const allocator = std.heap.direct_allocator;
 //
 //    // TODO move this into event loop too
 //    try os.makePath(allocator, test_tmp_dir);

--- a/std/event/future.zig
+++ b/std/event/future.zig
@@ -88,10 +88,7 @@ test "std.event.Future" {
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded or builtin.os != builtin.Os.linux) return error.SkipZigTest;
 
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-
-    const allocator = &da.allocator;
+    const allocator = std.heap.direct_allocator;
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);

--- a/std/event/group.zig
+++ b/std/event/group.zig
@@ -125,10 +125,7 @@ test "std.event.Group" {
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded) return error.SkipZigTest;
 
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-
-    const allocator = &da.allocator;
+    const allocator = std.heap.direct_allocator;
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);

--- a/std/event/lock.zig
+++ b/std/event/lock.zig
@@ -126,10 +126,7 @@ test "std.event.Lock" {
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded) return error.SkipZigTest;
 
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-
-    const allocator = &da.allocator;
+    const allocator = std.heap.direct_allocator;
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);

--- a/std/event/loop.zig
+++ b/std/event/loop.zig
@@ -866,10 +866,7 @@ test "std.event.Loop - basic" {
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded or builtin.os != builtin.Os.linux) return error.SkipZigTest;
 
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-
-    const allocator = &da.allocator;
+    const allocator = std.heap.direct_allocator;
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);
@@ -882,10 +879,7 @@ test "std.event.Loop - call" {
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded or builtin.os != builtin.Os.linux) return error.SkipZigTest;
 
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-
-    const allocator = &da.allocator;
+    const allocator = std.heap.direct_allocator;
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);

--- a/std/event/rwlock.zig
+++ b/std/event/rwlock.zig
@@ -215,10 +215,7 @@ test "std.event.RwLock" {
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded or builtin.os != builtin.Os.linux) return error.SkipZigTest;
 
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-
-    const allocator = &da.allocator;
+    const allocator = std.heap.direct_allocator;
 
     var loop: Loop = undefined;
     try loop.initMultiThreaded(allocator);

--- a/std/hash_map.zig
+++ b/std/hash_map.zig
@@ -397,10 +397,7 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime hash: fn (key: K) u3
 }
 
 test "basic hash map usage" {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var map = AutoHashMap(i32, i32).init(&direct_allocator.allocator);
+    var map = AutoHashMap(i32, i32).init(std.heap.direct_allocator);
     defer map.deinit();
 
     testing.expect((try map.put(1, 11)) == null);
@@ -444,10 +441,7 @@ test "basic hash map usage" {
 }
 
 test "iterator hash map" {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var reset_map = AutoHashMap(i32, i32).init(&direct_allocator.allocator);
+    var reset_map = AutoHashMap(i32, i32).init(std.heap.direct_allocator);
     defer reset_map.deinit();
 
     try reset_map.putNoClobber(1, 11);
@@ -491,10 +485,7 @@ test "iterator hash map" {
 }
 
 test "ensure capacity" {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var map = AutoHashMap(i32, i32).init(&direct_allocator.allocator);
+    var map = AutoHashMap(i32, i32).init(std.heap.direct_allocator);
     defer map.deinit();
 
     try map.ensureCapacity(20);

--- a/std/mutex.zig
+++ b/std/mutex.zig
@@ -130,11 +130,8 @@ const TestContext = struct {
 };
 
 test "std.Mutex" {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var plenty_of_memory = try direct_allocator.allocator.alloc(u8, 300 * 1024);
-    defer direct_allocator.allocator.free(plenty_of_memory);
+    var plenty_of_memory = try std.heap.direct_allocator.alloc(u8, 300 * 1024);
+    defer std.heap.direct_allocator.free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
     var a = &fixed_buffer_allocator.allocator;

--- a/std/packed_int_array.zig
+++ b/std/packed_int_array.zig
@@ -603,8 +603,7 @@ test "PackedInt(Array/Slice)Endian" {
 }
 
 //@NOTE: Need to manually update this list as more posix os's get
-// added to DirectAllocator. Windows can be added too when DirectAllocator
-// switches to VirtualAlloc.
+// added to DirectAllocator.
 
 //These tests prove we aren't accidentally accessing memory past
 // the end of the array/slice by placing it at the end of a page
@@ -613,7 +612,7 @@ test "PackedInt(Array/Slice)Endian" {
 // don't account for the bounds.
 test "PackedIntArray at end of available memory" {
     switch (builtin.os) {
-        .linux, .macosx, .ios, .freebsd, .netbsd => {},
+        .linux, .macosx, .ios, .freebsd, .netbsd, .windows => {},
         else => return,
     }
     const PackedArray = PackedIntArray(u3, 8);
@@ -623,8 +622,7 @@ test "PackedIntArray at end of available memory" {
         p: PackedArray,
     };
 
-    var da = std.heap.DirectAllocator.init();
-    const allocator = &da.allocator;
+    const allocator = std.heap.direct_allocator;
 
     var pad = try allocator.create(Padded);
     defer allocator.destroy(pad);
@@ -633,13 +631,12 @@ test "PackedIntArray at end of available memory" {
 
 test "PackedIntSlice at end of available memory" {
     switch (builtin.os) {
-        .linux, .macosx, .ios, .freebsd, .netbsd => {},
+        .linux, .macosx, .ios, .freebsd, .netbsd, .windows => {},
         else => return,
     }
     const PackedSlice = PackedIntSlice(u11);
 
-    var da = std.heap.DirectAllocator.init();
-    const allocator = &da.allocator;
+    const allocator = std.heap.direct_allocator;
 
     var page = try allocator.alloc(u8, std.mem.page_size);
     defer allocator.free(page);

--- a/std/segmented_list.zig
+++ b/std/segmented_list.zig
@@ -334,9 +334,7 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
 }
 
 test "std.SegmentedList" {
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-    var a = &da.allocator;
+    var a = std.heap.direct_allocator;
 
     try testSegmentedList(0, a);
     try testSegmentedList(1, a);

--- a/std/special/build_runner.zig
+++ b/std/special/build_runner.zig
@@ -17,10 +17,7 @@ pub fn main() !void {
     // one shot program. We don't need to waste time freeing memory and finding places to squish
     // bytes into. So we free everything all at once at the very end.
 
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(std.heap.direct_allocator);
     defer arena.deinit();
 
     const allocator = &arena.allocator;

--- a/std/statically_initialized_mutex.zig
+++ b/std/statically_initialized_mutex.zig
@@ -80,11 +80,8 @@ test "std.StaticallyInitializedMutex" {
         }
     };
 
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var plenty_of_memory = try direct_allocator.allocator.alloc(u8, 300 * 1024);
-    defer direct_allocator.allocator.free(plenty_of_memory);
+    var plenty_of_memory = try std.heap.direct_allocator.alloc(u8, 300 * 1024);
+    defer std.heap.direct_allocator.free(plenty_of_memory);
 
     var fixed_buffer_allocator = std.heap.ThreadSafeFixedBufferAllocator.init(plenty_of_memory);
     var a = &fixed_buffer_allocator.allocator;

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -8,10 +8,7 @@ const ChildProcess = std.ChildProcess;
 var a: *std.mem.Allocator = undefined;
 
 pub fn main() !void {
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(std.heap.direct_allocator);
     defer arena.deinit();
 
     var arg_it = process.args();

--- a/test/stage1/behavior/cancel.zig
+++ b/test/stage1/behavior/cancel.zig
@@ -5,10 +5,7 @@ var defer_f2: bool = false;
 var defer_f3: bool = false;
 
 test "cancel forwards" {
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-
-    const p = async<&da.allocator> f1() catch unreachable;
+    const p = async<std.heap.direct_allocator> f1() catch unreachable;
     cancel p;
     std.testing.expect(defer_f1);
     std.testing.expect(defer_f2);
@@ -42,10 +39,7 @@ var defer_b3: bool = false;
 var defer_b4: bool = false;
 
 test "cancel backwards" {
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-
-    const p = async<&da.allocator> b1() catch unreachable;
+    const p = async<std.heap.direct_allocator> b1() catch unreachable;
     cancel p;
     std.testing.expect(defer_b1);
     std.testing.expect(defer_b2);

--- a/test/stage1/behavior/coroutine_await_struct.zig
+++ b/test/stage1/behavior/coroutine_await_struct.zig
@@ -10,11 +10,8 @@ var await_a_promise: promise = undefined;
 var await_final_result = Foo{ .x = 0 };
 
 test "coroutine await struct" {
-    var da = std.heap.DirectAllocator.init();
-    defer da.deinit();
-
     await_seq('a');
-    const p = async<&da.allocator> await_amain() catch unreachable;
+    const p = async<std.heap.direct_allocator> await_amain() catch unreachable;
     await_seq('f');
     resume await_a_promise;
     await_seq('i');

--- a/test/standalone/brace_expansion/main.zig
+++ b/test/standalone/brace_expansion/main.zig
@@ -182,10 +182,7 @@ pub fn main() !void {
     var stdin_file = try io.getStdIn();
     var stdout_file = try io.getStdOut();
 
-    var direct_allocator = std.heap.DirectAllocator.init();
-    defer direct_allocator.deinit();
-
-    var arena = std.heap.ArenaAllocator.init(&direct_allocator.allocator);
+    var arena = std.heap.ArenaAllocator.init(std.heap.direct_allocator);
     defer arena.deinit();
 
     global_allocator = &arena.allocator;


### PR DESCRIPTION
it is now stateless, so the de/init are not necessary anymore