### PR TITLE
various fixes for mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 if(NOT CMAKE_INSTALL_PREFIX)
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE STRING
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE STRING
       "Directory to install zig to" FORCE)
 endif()
 
@@ -6595,7 +6595,7 @@ set(ZIG_LIBCXX_FILES
 
 if(MSVC)
     set(MSVC_DIA_SDK_DIR "$ENV{VSINSTALLDIR}DIA SDK")
-    if (IS_DIRECTORY ${MSVC_DIA_SDK_DIR})
+    if(IS_DIRECTORY ${MSVC_DIA_SDK_DIR})
         set(ZIG_DIA_GUIDS_LIB "${MSVC_DIA_SDK_DIR}/lib/amd64/diaguids.lib")
         string(REGEX REPLACE "\\\\" "\\\\\\\\" ZIG_DIA_GUIDS_LIB_ESCAPED "${ZIG_DIA_GUIDS_LIB}")
     endif()
@@ -6634,20 +6634,18 @@ set(EXE_CFLAGS "-std=c++11")
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     if(MSVC)
         set(EXE_CFLAGS "${EXE_CFLAGS} /w")
-    elseif(MINGW)
-        set(EXE_CFLAGS "${EXE_CFLAGS} -Wall -Werror -Wno-error=format= -Wno-error=format -Wno-error=format-extra-args")
     else()
         set(EXE_CFLAGS "${EXE_CFLAGS} -Werror -Wall")
     endif()
 endif()
 
 if(MSVC)
-  set(EXE_CFLAGS "${EXE_CFLAGS}")
+    set(EXE_CFLAGS "${EXE_CFLAGS}")
 else()
-  set(EXE_CFLAGS "${EXE_CFLAGS} -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D_GNU_SOURCE -fvisibility-inlines-hidden -fno-exceptions -fno-rtti -Werror=strict-prototypes -Werror=old-style-definition -Werror=type-limits -Wno-missing-braces")
-  if(MINGW)
-      set(EXE_CFLAGS "${EXE_CFLAGS} -D__USE_MINGW_ANSI_STDIO -Wno-pedantic-ms-format")
-  endif()
+    set(EXE_CFLAGS "${EXE_CFLAGS} -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D_GNU_SOURCE -fvisibility-inlines-hidden -fno-exceptions -fno-rtti -Werror=strict-prototypes -Werror=old-style-definition -Werror=type-limits -Wno-missing-braces")
+    if(MINGW)
+        set(EXE_CFLAGS "${EXE_CFLAGS} -Wno-format")
+    endif()
 endif()
 
 set(OPTIMIZED_C_FLAGS "-std=c99 -O3")

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -128,7 +128,7 @@ static void os_spawn_process_posix(ZigList<const char *> &args, Termination *ter
 
 static void os_windows_create_command_line(Buf *command_line, ZigList<const char *> &args) {
     buf_resize(command_line, 0);
-    char *prefix = "\"";
+    const char *prefix = "\"";
     for (size_t arg_i = 0; arg_i < args.length; arg_i += 1) {
         const char *arg = args.at(arg_i);
         buf_append_str(command_line, prefix);


### PR DESCRIPTION
* suppresses warnings for invalid format strings
* fixes error caused by `-Wwrite-strings1`