### PR TITLE
fix compile error when building zig w/ clang

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -23280,10 +23280,16 @@ static void ir_eval_float_op(IrAnalyze *ira, IrInstructionFloatOp *source_instr,
     BuiltinFnId fop = source_instr->op;
     unsigned bits;
 
-    if (float_type->id == ZigTypeIdComptimeFloat) {
+    switch (float_type->id) {
+    case ZigTypeIdComptimeFloat:
         bits = 128;
-    } else if (float_type->id == ZigTypeIdFloat)
+        break;
+    case ZigTypeIdFloat:
         bits = float_type->data.floating.bit_count;
+        break;
+    default:
+        zig_unreachable();
+    }
 
     switch (bits) {
     case 16: {


### PR DESCRIPTION
errors as reported on macOS w/ Xcode 10.1, 10.2 and 11.0:

src/ir.cpp:23285:16: error: variable 'bits' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
    } else if (float_type->id == ZigTypeIdFloat)
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/ir.cpp:23288:13: note: uninitialized use occurs here
    switch (bits) {
            ^~~~
src/ir.cpp:23285:12: note: remove the 'if' if its condition is always true
    } else if (float_type->id == ZigTypeIdFloat)
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/ir.cpp:23281:18: note: initialize the variable 'bits' to silence this warning
    unsigned bits;