### PR TITLE
compiler-rt: Support thumb versions older than armv6

### DIFF
--- a/std/special/compiler_rt.zig
+++ b/std/special/compiler_rt.zig
@@ -405,15 +405,15 @@ const use_thumb_1 = usesThumb1(builtin.arch);
 
 fn usesThumb1(arch: builtin.Arch) bool {
     return switch (arch) {
-        .arm => switch (arch.arm) {
+        .arm => |sub_arch| switch (sub_arch) {
             .v6m => true,
             else => false,
         },
-        .armeb => switch (arch.armeb) {
+        .armeb => |sub_arch| switch (sub_arch) {
             .v6m => true,
             else => false,
         },
-        .thumb => switch (arch.thumb) {
+        .thumb => |sub_arch| switch (sub_arch) {
             .v5,
             .v5te,
             .v4t,
@@ -423,7 +423,7 @@ fn usesThumb1(arch: builtin.Arch) bool {
             => true,
             else => false,
         },
-        .thumbeb => switch (arch.thumbeb) {
+        .thumbeb => |sub_arch| switch (sub_arch) {
             .v5,
             .v5te,
             .v4t,
@@ -475,18 +475,12 @@ const use_thumb_1_pre_armv6 = usesThumb1PreArmv6(builtin.arch);
 
 fn usesThumb1PreArmv6(arch: builtin.Arch) bool {
     return switch (arch) {
-        .thumb => switch (arch.thumb) {
-            .v5,
-            .v5te,
-            .v4t,
-            => true,
+        .thumb => |sub_arch| switch (sub_arch) {
+            .v5, .v5te, .v4t => true,
             else => false,
         },
-        .thumbeb => switch (arch.thumbeb) {
-            .v5,
-            .v5te,
-            .v4t,
-            => true,
+        .thumbeb => |sub_arch| switch (sub_arch) {
+            .v5, .v5te, .v4t => true,
             else => false,
         },
         else => false,


### PR DESCRIPTION
This PR fixes #2738 by adding versions of `__aeabi_memset` and `__aeabi_memclr` which use instructions supported on thumbv4. It replaces the register-register movs in `__aeabi_memset` with a XOR swap, and it replaces the mov in `__aeabi_memclr` with an `adds` instruction.

I'd appreciate it if someone more familiar with the ARM ABI/assembly language could review this -- as it stands, I've confirmed a trivial program now compiles without errors, but I'm not sure how to check if the functions I changed actually behave correctly in all situations.