### PR TITLE
fix union initialization of type void

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3873,9 +3873,6 @@ static LLVMValueRef ir_render_union_field_ptr(CodeGen *g, IrExecutable *executab
 
     TypeUnionField *field = instruction->field;
 
-    if (!type_has_bits(field->type_entry))
-        return nullptr;
-
     LLVMValueRef union_ptr = ir_llvm_value(g, instruction->union_ptr);
     LLVMTypeRef field_type_ref = LLVMPointerType(get_llvm_type(g, field->type_entry), 0);
 
@@ -3907,6 +3904,9 @@ static LLVMValueRef ir_render_union_field_ptr(CodeGen *g, IrExecutable *executab
 
         LLVMPositionBuilderAtEnd(g->builder, ok_block);
     }
+
+    if (!type_has_bits(field->type_entry))
+        return nullptr;
 
     LLVMValueRef union_field_ptr = LLVMBuildStructGEP(g->builder, union_ptr,
             union_type->data.unionation.gen_union_index, "");

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -15626,6 +15626,12 @@ static IrInstruction *ir_analyze_store_ptr(IrAnalyze *ira, IrInstruction *source
     if (value == ira->codegen->invalid_instruction)
         return ira->codegen->invalid_instruction;
 
+    if (ptr->id == IrInstructionIdUnionFieldPtr && child_type->id == ZigTypeIdVoid) {
+        IrInstruction *result = ir_build_store_ptr(&ira->new_irb, source_instr->scope, source_instr->source_node, ptr, value);
+        result->value.type = ira->codegen->builtin_types.entry_void;
+        return result;
+    }
+
     switch (type_has_one_possible_value(ira->codegen, child_type)) {
         case OnePossibleValueInvalid:
             return ira->codegen->invalid_instruction;


### PR DESCRIPTION
- related #2602
- note function `make1()` is where the issue presents
- note function `make2()` is added for comparison purposes

#### reduction
```zig
const State = union(enum) {
    one: void,
    two: u32,
};

fn make1() State {
    return State{ .one = {} }; // regression: copy-elision-3
}

fn make2() State {
    return State{ .two = 99 };
}

export fn foobar() void {
    _ = make1(); 
    _ = make2();
}

const builtin = @import("builtin");
pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
    while (true) {}
}
```

#### broken IR (branch: copy-elision-3)
```
fn make1() { // (analyzed)
Entry_0:
    #8  | *State      | 3 | @ReturnPtr
    #9  | *void       | 0 | @UnionFieldPtr(&#8.one)
    #14 | State       | 0 | loadptr(#8)result=(null)
    #16 | State       | 0 | loadptr(#8)result=(null)
    #20 | noreturn    | - | return 
}

fn make2() { // (analyzed)
Entry_0:
    #8  | *State      | 3 | @ReturnPtr
    #9  | *u32        | 1 | @UnionFieldPtr(&#8.two)
    #13 | void        | - | *#9 = 99
    #15 | State       | 0 | loadptr(#8)result=(null)
    #17 | State       | 0 | loadptr(#8)result=(null)
    #21 | noreturn    | - | return 
}
```

#### broken LLVM-IR (branch: copy-elision-3)
```llvm
; Function Attrs: nobuiltin nounwind sspstrong
define internal fastcc void @make1(%State* nonnull sret) unnamed_addr #2 !dbg !48 {
Entry:
  ret void, !dbg !60
}

; Function Attrs: nobuiltin nounwind sspstrong
define internal fastcc void @make2(%State* nonnull sret) unnamed_addr #2 !dbg !62 {
Entry:
  %1 = getelementptr inbounds %State, %State* %0, i32 0, i32 1, !dbg !63
  store i1 true, i1* %1, !dbg !63
  %2 = getelementptr inbounds %State, %State* %0, i32 0, i32 0, !dbg !63
  store i32 99, i32* %2, align 4, !dbg !63
  ret void, !dbg !65
}
```

#### patched IR
```
fn make1() { // (analyzed)
Entry_0:
    #8  | *State      | 3 | @ReturnPtr
    #9  | *void       | 1 | @UnionFieldPtr(&#8.one)
    #12 | void        | - | *#9 = {}
    #14 | State       | 0 | loadptr(#8)result=(null)
    #16 | State       | 0 | loadptr(#8)result=(null)
    #20 | noreturn    | - | return 
}

fn make2() { // (analyzed)
Entry_0:
    #8  | *State      | 3 | @ReturnPtr
    #9  | *u32        | 1 | @UnionFieldPtr(&#8.two)
    #13 | void        | - | *#9 = 99
    #15 | State       | 0 | loadptr(#8)result=(null)
    #17 | State       | 0 | loadptr(#8)result=(null)
    #21 | noreturn    | - | return 
}
```

#### patched LLVM-IR
```llvm
; Function Attrs: nobuiltin nounwind sspstrong
define internal fastcc void @make1(%State* nonnull sret) unnamed_addr #2 !dbg !48 {
Entry:
  %1 = getelementptr inbounds %State, %State* %0, i32 0, i32 1, !dbg !60
  store i1 false, i1* %1, !dbg !60
  ret void, !dbg !62
}

; Function Attrs: nobuiltin nounwind sspstrong
define internal fastcc void @make2(%State* nonnull sret) unnamed_addr #2 !dbg !63 {
Entry:
  %1 = getelementptr inbounds %State, %State* %0, i32 0, i32 1, !dbg !64
  store i1 true, i1* %1, !dbg !64
  %2 = getelementptr inbounds %State, %State* %0, i32 0, i32 0, !dbg !64
  store i32 99, i32* %2, align 4, !dbg !64
  ret void, !dbg !66
}
```

#### reference IR (branch: master)
```
fn make1() { // (analyzed)
Entry_0:
    #8  | noreturn    | - | return State { .one = {}}
}

fn make2() { // (analyzed)
Entry_0:
    #9  | noreturn    | - | return State { .two = 99}
}
```

#### reference LLVM-IR (branch: master)
```llvm
@0 = internal unnamed_addr constant %State { i32 undef, i1 false }, align 4
@1 = internal unnamed_addr constant %State { i32 99, i1 true }, align 4

; Function Attrs: nobuiltin nounwind sspstrong
define internal fastcc void @make1(%State* nonnull sret) unnamed_addr #2 !dbg !48 {
Entry:
  %1 = bitcast %State* %0 to i8*, !dbg !60
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %1, i8* align 4 bitcast (%State* @0 to i8*), i64 8, i1 false), !dbg !60
  ret void, !dbg !60
}

; Function Attrs: nobuiltin nounwind sspstrong
define internal fastcc void @make2(%State* nonnull sret) unnamed_addr #2 !dbg !62 {
Entry:
  %1 = bitcast %State* %0 to i8*, !dbg !63
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %1, i8* align 4 bitcast (%State* @1 to i8*), i64 8, i1 false), !dbg !63
  ret void, !dbg !63
}
```