### PR TITLE
Add doc comments to alignment functions

### DIFF
--- a/std/mem.zig
+++ b/std/mem.zig
@@ -1481,7 +1481,7 @@ test "subArrayPtr" {
 }
 
 /// Round an address up to the nearest aligned address
-/// The alignment must be greater than 0.
+/// The alignment must be a power of 2 and greater than 0.
 pub fn alignForward(addr: usize, alignment: usize) usize {
     return alignBackward(addr + (alignment - 1), alignment);
 }
@@ -1502,8 +1502,9 @@ test "alignForward" {
 }
 
 /// Round an address up to the previous aligned address
-/// The alignment must be greater than 0.
+/// The alignment must be a power of 2 and greater than 0.
 pub fn alignBackward(addr: usize, alignment: usize) usize {
+    assert(@popCount(usize, alignment) == 1);
     // 000010000 // example addr
     // 000001111 // subtract 1
     // 111110000 // binary not
@@ -1511,7 +1512,7 @@ pub fn alignBackward(addr: usize, alignment: usize) usize {
 }
 
 /// Given an address and an alignment, return true if the address is a multiple of the alignment
-/// The alignment must be greater than 0.
+/// The alignment must be a power of 2 and greater than 0.
 pub fn isAligned(addr: usize, alignment: usize) bool {
     return alignBackward(addr, alignment) == addr;
 }

--- a/std/mem.zig
+++ b/std/mem.zig
@@ -1481,6 +1481,7 @@ test "subArrayPtr" {
 }
 
 /// Round an address up to the nearest aligned address
+/// The alignment must be greater than 0.
 pub fn alignForward(addr: usize, alignment: usize) usize {
     return alignBackward(addr + (alignment - 1), alignment);
 }
@@ -1500,6 +1501,8 @@ test "alignForward" {
     testing.expect(alignForward(17, 8) == 24);
 }
 
+/// Round an address up to the previous aligned address
+/// The alignment must be greater than 0.
 pub fn alignBackward(addr: usize, alignment: usize) usize {
     // 000010000 // example addr
     // 000001111 // subtract 1
@@ -1507,6 +1510,8 @@ pub fn alignBackward(addr: usize, alignment: usize) usize {
     return addr & ~(alignment - 1);
 }
 
+/// Given an address and an alignment, return true if the address is a multiple of the alignment
+/// The alignment must be greater than 0.
 pub fn isAligned(addr: usize, alignment: usize) bool {
     return alignBackward(addr, alignment) == addr;
 }


### PR DESCRIPTION
This patch fleshes out the doc comments for the alignment functions in std.mem, clarifying that they shouldn't be called with an alignment of 0. Closes #2774 