### PR TITLE
Mention stdlib docs, or lack thereof

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,19 @@ Zig is an open-source programming language designed for **robustness**,
 ## Resources
 
  * [Introduction](https://ziglang.org/#Introduction)
- * [Download & Documentation](https://ziglang.org/download)
+ * [Download & Documentation](https://ziglang.org/download) (These docs function as the quick-reference guide.)
  * [Community](https://github.com/ziglang/zig/wiki/Community)
  * [Contributing](https://github.com/ziglang/zig/blob/master/CONTRIBUTING.md)
+
+## Standard Library Docs
+
+Documentation for the standard library doesn't exist yet, though there will be full docs by version 1.0.
+For now, you can search through `std/` for items of interest with a text editor.
+
+It isn't a priority right now as the focus on more on implementing features and getting stuff working well.
+
+If you have any questions on how parts of the stdlib work, you can always ask us about it; see the 'Community' resource above.
+
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Zig is an open-source programming language designed for **robustness**,
 
  * [Introduction](https://ziglang.org/#Introduction)
  * [Download & Documentation](https://ziglang.org/download) (These docs function as the quick-reference guide.)
+ * [Frequently Asked Questions](https://github.com/ziglang/zig/wiki/FAQ)
  * [Community](https://github.com/ziglang/zig/wiki/Community)
  * [Contributing](https://github.com/ziglang/zig/blob/master/CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Zig is an open-source programming language designed for **robustness**,
 Documentation for the standard library doesn't exist yet, though there will be full docs by version 1.0.
 For now, you can search through `std/` for items of interest with a text editor.
 
-It isn't a priority right now as the focus on more on implementing features and getting stuff working well.
+It isn't a priority right now as the focus is more on implementing features and getting stuff working well.
 
 If you have any questions on how parts of the stdlib work, you can always ask us about it; see the 'Community' resource above.
 


### PR DESCRIPTION
Also points out that the documentation in the downloads section also functions as the quick reference guide.

I can remove that if preferred though.