### PR TITLE
fix formatting in langref

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7354,91 +7354,91 @@ test "@setRuntimeSafety" {
       <pre>{#syntax#}@sqrt(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Performs the square root of a floating point number. Uses a dedicated hardware instruction
-      when available. Supports f16, f32, f64, and f128, as well as vectors.
+      when available. Supports {#syntax#}f16{#endsyntax#}, {#syntax#}f32{#endsyntax#}, {#syntax#}f64{#endsyntax#}, and {#syntax#}f128{#endsyntax#}, as well as vectors.
       </p>
       {#header_close#}
       {#header_open|@sin#}
       <pre>{#syntax#}@sin(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Sine trigometric function on a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@cos#}
       <pre>{#syntax#}@cos(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Cosine trigometric function on a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@exp#}
       <pre>{#syntax#}@exp(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Base-e exponential function on a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@exp2#}
       <pre>{#syntax#}@exp2(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Base-2 exponential function on a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@ln#}
       <pre>{#syntax#}@ln(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Returns the natural logarithm of a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@log2#}
       <pre>{#syntax#}@log2(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Returns the logarithm to the base 2 of a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@log10#}
       <pre>{#syntax#}@log10(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Returns the logarithm to the base 10 of a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@fabs#}
       <pre>{#syntax#}@fabs(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Returns the absolute value of a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@floor#}
       <pre>{#syntax#}@floor(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Returns the largest integral value not greater than the given floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@ceil#}
       <pre>{#syntax#}@ceil(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Returns the largest integral value not less than the given floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@trunc#}
       <pre>{#syntax#}@trunc(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Rounds the given floating point number to an integer, towards zero. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
       {#header_open|@round#}
       <pre>{#syntax#}@round(comptime T: type, value: T) T{#endsyntax#}</pre>
       <p>
       Rounds the given floating point number to an integer, away from zero. Uses a dedicated hardware instruction
-      when available. Currently supports f32 and f64.
+      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
       </p>
       {#header_close#}
 

--- a/std/special/c.zig
+++ b/std/special/c.zig
@@ -146,7 +146,7 @@ export fn bcmp(vl: [*]allowzero const u8, vr: [*]allowzero const u8, n: usize) i
     var index: usize = 0;
     while (index != n) : (index += 1) {
         if (vl[index] != vr[index]) {
-          return 1;
+            return 1;
         }
     }
 
@@ -254,32 +254,110 @@ export fn fmod(x: f64, y: f64) f64 {
 
 // TODO add intrinsics for these (and probably the double version too)
 // and have the math stuff use the intrinsic. same as @mod and @rem
-export fn floorf(x: f32) f32 {return math.floor(x);}
-export fn ceilf(x: f32) f32 {return math.ceil(x);}
-export fn floor(x: f64) f64 {return math.floor(x);}
-export fn ceil(x: f64) f64 {return math.ceil(x);}
-export fn fma(a: f64, b: f64, c: f64) f64 {return math.fma(f64, a, b, c);}
-export fn fmaf(a: f32, b: f32, c: f32) f32 {return math.fma(f32, a, b, c);}
-export fn sin(a: f64) f64 {return math.sin(a);}
-export fn sinf(a: f32) f32 {return math.sin(a);}
-export fn cos(a: f64) f64 {return math.cos(a);}
-export fn cosf(a: f32) f32 {return math.cos(a);}
-export fn exp(a: f64) f64 {return math.exp(a);}
-export fn expf(a: f32) f32 {return math.exp(a);}
-export fn exp2(a: f64) f64 {return math.exp2(a);}
-export fn exp2f(a: f32) f32 {return math.exp2(a);}
-export fn log(a: f64) f64 {return math.ln(a);}
-export fn logf(a: f32) f32 {return math.ln(a);}
-export fn log2(a: f64) f64 {return math.log2(a);}
-export fn log2f(a: f32) f32 {return math.log2(a);}
-export fn log10(a: f64) f64 {return math.log10(a);}
-export fn log10f(a: f32) f32 {return math.log10(a);}
-export fn fabs(a: f64) f64 {return math.fabs(a);}
-export fn fabsf(a: f32) f32 {return math.fabs(a);}
-export fn trunc(a: f64) f64 {return math.trunc(a);}
-export fn truncf(a: f32) f32 {return math.trunc(a);}
-export fn round(a: f64) f64 {return math.round(a);}
-export fn roundf(a: f32) f32 {return math.round(a);}
+export fn floorf(x: f32) f32 {
+    return math.floor(x);
+}
+
+export fn ceilf(x: f32) f32 {
+    return math.ceil(x);
+}
+
+export fn floor(x: f64) f64 {
+    return math.floor(x);
+}
+
+export fn ceil(x: f64) f64 {
+    return math.ceil(x);
+}
+
+export fn fma(a: f64, b: f64, c: f64) f64 {
+    return math.fma(f64, a, b, c);
+}
+
+export fn fmaf(a: f32, b: f32, c: f32) f32 {
+    return math.fma(f32, a, b, c);
+}
+
+export fn sin(a: f64) f64 {
+    return math.sin(a);
+}
+
+export fn sinf(a: f32) f32 {
+    return math.sin(a);
+}
+
+export fn cos(a: f64) f64 {
+    return math.cos(a);
+}
+
+export fn cosf(a: f32) f32 {
+    return math.cos(a);
+}
+
+export fn exp(a: f64) f64 {
+    return math.exp(a);
+}
+
+export fn expf(a: f32) f32 {
+    return math.exp(a);
+}
+
+export fn exp2(a: f64) f64 {
+    return math.exp2(a);
+}
+
+export fn exp2f(a: f32) f32 {
+    return math.exp2(a);
+}
+
+export fn log(a: f64) f64 {
+    return math.ln(a);
+}
+
+export fn logf(a: f32) f32 {
+    return math.ln(a);
+}
+
+export fn log2(a: f64) f64 {
+    return math.log2(a);
+}
+
+export fn log2f(a: f32) f32 {
+    return math.log2(a);
+}
+
+export fn log10(a: f64) f64 {
+    return math.log10(a);
+}
+
+export fn log10f(a: f32) f32 {
+    return math.log10(a);
+}
+
+export fn fabs(a: f64) f64 {
+    return math.fabs(a);
+}
+
+export fn fabsf(a: f32) f32 {
+    return math.fabs(a);
+}
+
+export fn trunc(a: f64) f64 {
+    return math.trunc(a);
+}
+
+export fn truncf(a: f32) f32 {
+    return math.trunc(a);
+}
+
+export fn round(a: f64) f64 {
+    return math.round(a);
+}
+
+export fn roundf(a: f32) f32 {
+    return math.round(a);
+}
+
 fn generic_fmod(comptime T: type, x: T, y: T) T {
     @setRuntimeSafety(false);
 


### PR DESCRIPTION
fixed formatting in `doc/langref.html.in` and in `std/special/c.zig`.