### PR TITLE
fixed coff header parsing

### DIFF
--- a/std/coff.zig
+++ b/std/coff.zig
@@ -39,6 +39,18 @@ pub const Coff = struct {
     guid: [16]u8,
     age: u32,
 
+    pub fn init(allocator: *mem.Allocator, in_file: File) Coff {
+        return Coff{
+            .in_file = in_file,
+            .allocator = allocator,
+            .coff_header = undefined,
+            .pe_header = undefined,
+            .sections = ArrayList(Section).init(allocator),
+            .guid = undefined,
+            .age = undefined,
+        };
+    }
+
     pub fn loadHeader(self: *Coff) !void {
         const pe_pointer_offset = 0x3C;
 

--- a/std/coff.zig
+++ b/std/coff.zig
@@ -142,10 +142,11 @@ pub const Coff = struct {
     }
 
     pub fn loadSections(self: *Coff) !void {
-        if (self.sections.len != 0)
+        if (self.sections.len == self.coff_header.number_of_sections)
             return;
 
         self.sections = ArrayList(Section).init(self.allocator);
+        try self.sections.ensureCapacity(self.coff_header.number_of_sections);
 
         var file_stream = self.in_file.inStream();
         const in = &file_stream.stream;

--- a/std/coff.zig
+++ b/std/coff.zig
@@ -145,7 +145,6 @@ pub const Coff = struct {
         if (self.sections.len == self.coff_header.number_of_sections)
             return;
 
-        self.sections = ArrayList(Section).init(self.allocator);
         try self.sections.ensureCapacity(self.coff_header.number_of_sections);
 
         var file_stream = self.in_file.inStream();

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -800,15 +800,7 @@ fn openSelfDebugInfoWindows(allocator: *mem.Allocator) !DebugInfo {
     defer self_file.close();
 
     const coff_obj = try allocator.create(coff.Coff);
-    coff_obj.* = coff.Coff{
-        .in_file = self_file,
-        .allocator = allocator,
-        .coff_header = undefined,
-        .pe_header = undefined,
-        .sections = ArrayList(coff.Section).init(allocator),
-        .guid = undefined,
-        .age = undefined,
-    };
+    coff_obj.* = coff.Coff.init(allocator, self_file);
 
     var di = DebugInfo{
         .coff = coff_obj,

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -805,7 +805,7 @@ fn openSelfDebugInfoWindows(allocator: *mem.Allocator) !DebugInfo {
         .allocator = allocator,
         .coff_header = undefined,
         .pe_header = undefined,
-        .sections = undefined,
+        .sections = ArrayList(coff.Section).init(allocator),
         .guid = undefined,
         .age = undefined,
     };


### PR DESCRIPTION
previously `coff.loadSections` was comparing a possibly uninitialized value against 0 which was always false, causing a segfault when zig tried to output an error trace. this PR fixes that and also preallocates space for the `Section` structs rather than allowing for possible reallocations.