### PR TITLE
[WIP] added function for getting zig triple as string

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -202,7 +202,7 @@ CodeGen *codegen_create(Buf *main_pkg_path, Buf *root_src_path, const ZigTarget 
         g->link_libs_list.append(g->libc_link_lib);
     }
 
-    get_target_triple(&g->triple_str, g->zig_target);
+    get_target_triple(&g->triple_str, g->zig_target, true);
     g->pointer_size_bytes = target_arch_pointer_bit_width(g->zig_target->arch) / 8;
 
     if (!target_has_debug_info(g->zig_target)) {
@@ -8309,7 +8309,7 @@ static void detect_libc(CodeGen *g) {
         !target_os_is_darwin(g->zig_target->os))
     {
         Buf triple_buf = BUF_INIT;
-        get_target_triple(&triple_buf, g->zig_target);
+        get_target_triple(&triple_buf, g->zig_target, false);
         fprintf(stderr,
             "Zig is unable to provide a libc for the chosen target '%s'.\n"
             "The target is non-native, so Zig also cannot use the native libc installation.\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,6 +147,10 @@ static int print_target_list(FILE *f) {
     ZigTarget native;
     get_native_target(&native);
 
+    Buf native_target = BUF_INIT;
+    get_target_triple(&native_target, &native, false);
+    fprintf(f, "Native Target:\n  %s\n\n", buf_ptr(&native_target));
+
     fprintf(f, "Architectures:\n");
     size_t arch_count = target_arch_count();
     for (size_t arch_i = 0; arch_i < arch_count; arch_i += 1) {
@@ -937,7 +941,7 @@ int main(int argc, char **argv) {
 
     if (target_requires_pic(&target, have_libc) && want_pic == WantPICDisabled) {
         Buf triple_buf = BUF_INIT;
-        get_target_triple(&triple_buf, &target);
+        get_target_triple(&triple_buf, &target, false);
         fprintf(stderr, "`--disable-pic` is incompatible with target '%s'\n", buf_ptr(&triple_buf));
         return print_error_usage(arg0);
     }

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -714,14 +714,22 @@ void init_all_targets(void) {
     LLVMInitializeAllAsmParsers();
 }
 
-void get_target_triple(Buf *triple, const ZigTarget *target) {
+void get_target_triple(Buf *triple, const ZigTarget *target, bool full_triple) {
     buf_resize(triple, 0);
-    buf_appendf(triple, "%s%s-%s-%s-%s",
+    if (full_triple) {
+        buf_appendf(triple, "%s%s-%s-%s-%s",
             ZigLLVMGetArchTypeName(target->arch),
             ZigLLVMGetSubArchTypeName(target->sub_arch),
             ZigLLVMGetVendorTypeName(target->vendor),
             ZigLLVMGetOSTypeName(get_llvm_os_type(target->os)),
             ZigLLVMGetEnvironmentTypeName(target->abi));
+    } else {
+        buf_appendf(triple, "%s%s-%s-%s",
+            ZigLLVMGetArchTypeName(target->arch),
+            ZigLLVMGetSubArchTypeName(target->sub_arch),
+            ZigLLVMGetOSTypeName(get_llvm_os_type(target->os)),
+            ZigLLVMGetEnvironmentTypeName(target->abi));
+    }
 }
 
 bool target_os_is_darwin(Os os) {

--- a/src/target.hpp
+++ b/src/target.hpp
@@ -139,7 +139,7 @@ const char *target_oformat_name(ZigLLVM_ObjectFormatType oformat);
 ZigLLVM_ObjectFormatType target_object_format(const ZigTarget *target);
 
 void get_native_target(ZigTarget *target);
-void get_target_triple(Buf *triple, const ZigTarget *target);
+void get_target_triple(Buf *triple, const ZigTarget *target, bool full_triple);
 
 void init_all_targets(void);
 


### PR DESCRIPTION
because zig triples are different from llvm triple (no vendor field) i added a function for getting the zig version of a target triple as a `Buffer`. i also modified the `zig target` command to output the native target before listing other available targets.