### PR TITLE
stage1: add @shuffle() shufflevector support

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7798,6 +7798,25 @@ pub const TypeInfo = union(TypeId) {
       {#link|pointer|Pointers#}.
       </p>
       {#header_close#}
+
+      {#header_open|@shuffle#}
+      <pre>{#syntax#}@shuffle(comptime ElemType: type, a: @Vector(mask.len, ElemType), b: @Vector(mask.len, ElemType), comptime mask: @Vector(_, u32)) @Vector(mask.len, ElemType){#endsyntax#}</pre>
+      <p>
+      Does the {#syntax#}shufflevector{#endsyntax#} instruction. Each element in {#syntax#}comptime{#endsyntax#}
+      (and always {#syntax#}i32{#endsyntax#}) {#syntax#}mask{#endsyntax#} select a element from either {#syntax#}a{#endsyntax#} or {#syntax#}b{#endsyntax#}.
+      Positive number select from {#syntax#}a{#endsyntax#} (starting at 0), while negative values select
+      from {#syntax#}b{#endsyntax#} (starting at -1 and going down). It is recommended to use the {#syntax#}~{#endsyntax#}
+      operator from indexes from b so that both indexes can start from 0 (i.e. ~0 is -1). If either the {#syntax#}mask{#endsyntax#}
+      value or the value from {#syntax#}a{#endsyntax#} or {#syntax#}b{#endsyntax#} that it selects are {#syntax#}undefined{#endsyntax#}
+      then the resulting value is {#syntax#}undefined{#endsyntax#}. Also see {#link|SIMD#} and
+      the relevent <a href="https://llvm.org/docs/LangRef.html#i-shufflevector">LLVM Documentation on
+      {#syntax#}shufflevector{#endsyntax#}</a>, although note that the mask values are interpreted differently than in LLVM-IR.
+      </p>
+      <p>
+      {#syntax#}ElemType{#endsyntax#} must be an {#link|integer|Integers#}, a {#link|float|Floats#}, or a
+      {#link|pointer|Pointers#}. The mask may be any vector length that the target supports, and its' length determines the result length.
+      </p>
+      {#header_close#}
       {#header_close#}
 
       {#header_open|Build Mode#}

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1475,6 +1475,7 @@ enum BuiltinFnId {
     BuiltinFnIdIntToEnum,
     BuiltinFnIdIntType,
     BuiltinFnIdVectorType,
+    BuiltinFnIdShuffle,
     BuiltinFnIdSetCold,
     BuiltinFnIdSetRuntimeSafety,
     BuiltinFnIdSetFloatMode,
@@ -2259,6 +2260,7 @@ enum IrInstructionId {
     IrInstructionIdBoolToInt,
     IrInstructionIdIntType,
     IrInstructionIdVectorType,
+    IrInstructionIdShuffleVector,
     IrInstructionIdBoolNot,
     IrInstructionIdMemset,
     IrInstructionIdMemcpy,
@@ -3578,6 +3580,15 @@ struct IrInstructionVectorToArray {
 
     IrInstruction *vector;
     IrInstruction *result_loc;
+};
+
+struct IrInstructionShuffleVector {
+    IrInstruction base;
+
+    IrInstruction *scalar_type;
+    IrInstruction *a;
+    IrInstruction *b;
+    IrInstruction *mask; // This is in zig-format, not llvm format
 };
 
 struct IrInstructionAssertZero {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -849,6 +849,18 @@ static void ir_print_vector_type(IrPrint *irp, IrInstructionVectorType *instruct
     fprintf(irp->f, ")");
 }
 
+static void ir_print_shuffle_vector(IrPrint *irp, IrInstructionShuffleVector *instruction) {
+    fprintf(irp->f, "@shuffle(");
+    ir_print_other_instruction(irp, instruction->scalar_type);
+    fprintf(irp->f, ", ");
+    ir_print_other_instruction(irp, instruction->a);
+    fprintf(irp->f, ", ");
+    ir_print_other_instruction(irp, instruction->b);
+    fprintf(irp->f, ", ");
+    ir_print_other_instruction(irp, instruction->mask);
+    fprintf(irp->f, ")");
+}
+
 static void ir_print_bool_not(IrPrint *irp, IrInstructionBoolNot *instruction) {
     fprintf(irp->f, "! ");
     ir_print_other_instruction(irp, instruction->value);
@@ -1832,6 +1844,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdVectorType:
             ir_print_vector_type(irp, (IrInstructionVectorType *)instruction);
+            break;
+        case IrInstructionIdShuffleVector:
+            ir_print_shuffle_vector(irp, (IrInstructionShuffleVector *)instruction);
             break;
         case IrInstructionIdBoolNot:
             ir_print_bool_not(irp, (IrInstructionBoolNot *)instruction);

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -74,3 +74,17 @@ test "implicit cast vector to array" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "vector shuffle" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
+            var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
+            const mask: @Vector(4, i32) = [4]i32{ 0, ~i32(2), 3, ~i32(3)};
+            var res = @shuffle(i32, v, x, mask);
+            expect(mem.eql(i32, ([4]i32)(res), [4]i32{ 2147483647, 3, 40, 4 }));
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}


### PR DESCRIPTION
I changed the semantics of the mask operand, to make it a little more
flexible. There is no real danger in this because it is a compile-error
if you do it the LLVM way (and there is an appropriate error to tell you
this).