### PR TITLE
Unicode escapes: support u{N...}

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -566,7 +566,7 @@ test "string literals" {
     assert(normal_bytes.len == 5);
     assert(normal_bytes[1] == 'e');
     assert('e' == '\x65');
-    assert('\U01f4a9' == 128169);
+    assert('\u{1f4a9}' == 128169);
     assert(mem.eql(u8, "hello", "h\x65llo"));
 
     // A C string literal is a null terminated pointer.
@@ -616,12 +616,8 @@ test "string literals" {
           <td>hexadecimal 8-bit character code (2 digits)</td>
         </tr>
         <tr>
-            <td><code>\uNNNN</code></td>
-          <td>hexadecimal 16-bit Unicode character code UTF-8 encoded (4 digits)</td>
-        </tr>
-        <tr>
-            <td><code>\UNNNNNN</code></td>
-          <td>hexadecimal 24-bit Unicode character code UTF-8 encoded (6 digits)</td>
+            <td><code>\u{NNNNNN}</code></td>
+          <td>hexadecimal Unicode character code UTF-8 encoded (1 or more digits)</td>
         </tr>
       </table>
       </div>
@@ -10008,8 +10004,7 @@ eof &lt;- !.
 hex &lt;- [0-9a-fA-F]
 char_escape
     &lt;- "\\x" hex hex
-     / "\\u" hex hex hex hex
-     / "\\U" hex hex hex hex hex hex
+     / "\\u{" hex+ "}"
      / "\\" [nr\\t'"]
 char_char
     &lt;- char_escape

--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -68,7 +68,7 @@ test "zig fmt: enum literal inside array literal" {
 
 test "zig fmt: character literal larger than u8" {
     try testCanonical(
-        \\const x = '\U01f4a9';
+        \\const x = '\u{01f4a9}';
         \\
     );
 }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -5415,6 +5415,24 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
+        "invalid legacy unicode escape",
+        \\export fn entry() void {
+        \\    const a = '\U1234';
+        \\}
+    ,
+        "tmp.zig:2:17: error: invalid character: 'U'",
+    );
+
+    cases.add(
+        "invalid empty unicode escape",
+        \\export fn entry() void {
+        \\    const a = '\u{}';
+        \\}
+    ,
+        "tmp.zig:2:19: error: empty unicode escape sequence",
+    );
+
+    cases.add(
         "non-printable invalid character",
         "\xff\xfe" ++
             \\fn test() bool {\r

--- a/test/stage1/behavior/misc.zig
+++ b/test/stage1/behavior/misc.zig
@@ -189,7 +189,7 @@ test "string escapes" {
     expect(mem.eql(u8, "\r", "\x0d"));
     expect(mem.eql(u8, "\t", "\x09"));
     expect(mem.eql(u8, "\\", "\x5c"));
-    expect(mem.eql(u8, "\u1234\u0069", "\xe1\x88\xb4\x69"));
+    expect(mem.eql(u8, "\u{1234}\u{069}\u{1}", "\xe1\x88\xb4\x69\x01"));
 }
 
 test "multiline string" {
@@ -695,7 +695,7 @@ test "thread local variable" {
 }
 
 test "unicode escape in character literal" {
-    var a: u24 = '\U01f4a9';
+    var a: u24 = '\u{01f4a9}';
     expect(a == 128169);
 }
 


### PR DESCRIPTION
Closes #2129 

## TODO

- [x] stage2 tokenizer
- [x] stage2 parser test
- [x] stage1 tokenizer
- [x] behavior tests
- [x] update documentation examples and grammar
- [x] update grammar in zig-spec https://github.com/ziglang/zig-spec/pull/8

## Notes

- Any number of digits (one or more) is allowed in the braces. The stage1 tokenizer retains upper limit on character value of `0x10ffff`.
- The old `\uNNNN` and `\UNNNNNN` syntaxes were removed.