### PR TITLE
Prevent unreachable when file ends with struct field

### DIFF
--- a/std/zig/parser_test.zig
+++ b/std/zig/parser_test.zig
@@ -2246,6 +2246,15 @@ test "zig fmt: if type expr" {
     );
 }
 
+test "zig fmt: file ends with struct field" {
+    try testTransform(
+        \\a: bool
+    ,
+        \\a: bool,
+        \\
+    );
+}
+
 const std = @import("std");
 const mem = std.mem;
 const warn = std.debug.warn;

--- a/std/zig/render.zig
+++ b/std/zig/render.zig
@@ -1898,7 +1898,7 @@ fn renderTokenOffset(
             return renderToken(tree, stream, token_index + 1, indent, start_col, Space.Newline);
         },
         else => {
-            if (tree.tokens.at(token_index + 2).id == Token.Id.MultilineStringLiteralLine) {
+            if (token_index + 2 < tree.tokens.len and tree.tokens.at(token_index + 2).id == Token.Id.MultilineStringLiteralLine) {
                 try stream.write(",");
                 return;
             } else {


### PR DESCRIPTION
Fixes #2813 

To demystify the original example program which triggers the problem:

```zig
_
```

This is grammatically valid and means "top-level struct field with no type or default value defined".

```
ContainerField <- IDENTIFIER (COLON TypeExpr)? (EQUAL Expr)?
```

This behavior was also triggered with the new test case:

```zig
a: bool
```

The renderer incorrectly assumed the number of remaining tokens in the file after the field.