### PR TITLE
std: improvements to linux constants

### DIFF
--- a/std/c/linux.zig
+++ b/std/c/linux.zig
@@ -1,8 +1,11 @@
 const std = @import("../std.zig");
+const maxInt = std.math.maxInt;
 usingnamespace std.c;
 
 extern "c" fn __errno_location() *c_int;
 pub const _errno = __errno_location;
+
+pub const MAP_FAILED = @intToPtr(*c_void, maxInt(usize));
 
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) c_int;
 pub extern "c" fn sched_getaffinity(pid: c_int, size: usize, set: *cpu_set_t) c_int;

--- a/std/os.zig
+++ b/std/os.zig
@@ -1961,7 +1961,7 @@ pub fn mmap(
 ) MMapError![]align(mem.page_size) u8 {
     const err = if (builtin.link_libc) blk: {
         const rc = std.c.mmap(ptr, length, prot, flags, fd, offset);
-        if (rc != MAP_FAILED) return @ptrCast([*]align(mem.page_size) u8, @alignCast(mem.page_size, rc))[0..length];
+        if (rc != std.c.MAP_FAILED) return @ptrCast([*]align(mem.page_size) u8, @alignCast(mem.page_size, rc))[0..length];
         break :blk @intCast(usize, system._errno().*);
     } else blk: {
         const rc = system.mmap(ptr, length, prot, flags, fd, offset);

--- a/std/os/bits/linux.zig
+++ b/std/os/bits/linux.zig
@@ -74,22 +74,31 @@ pub const PROT_EXEC = 4;
 pub const PROT_GROWSDOWN = 0x01000000;
 pub const PROT_GROWSUP = 0x02000000;
 
-pub const MAP_FAILED = @intToPtr(*c_void, maxInt(usize));
+/// Share changes
 pub const MAP_SHARED = 0x01;
+
+/// Changes are private
 pub const MAP_PRIVATE = 0x02;
+
+/// share + validate extension flags
+pub const MAP_SHARED_VALIDATE = 0x03;
+
+/// Mask for type of mapping
 pub const MAP_TYPE = 0x0f;
+
+/// Interpret addr exactly
 pub const MAP_FIXED = 0x10;
+
+/// don't use a file
 pub const MAP_ANONYMOUS = 0x20;
-pub const MAP_NORESERVE = 0x4000;
-pub const MAP_GROWSDOWN = 0x0100;
-pub const MAP_DENYWRITE = 0x0800;
-pub const MAP_EXECUTABLE = 0x1000;
-pub const MAP_LOCKED = 0x2000;
-pub const MAP_POPULATE = 0x8000;
-pub const MAP_NONBLOCK = 0x10000;
-pub const MAP_STACK = 0x20000;
-pub const MAP_HUGETLB = 0x40000;
-pub const MAP_FILE = 0;
+
+/// For anonymous mmap, memory could be uninitialized
+pub const MAP_UNINITIALIZED = 0x4000000;
+
+// MAP_ 0x0100 - 0x80000 flags are per architecture
+
+/// MAP_FIXED which doesn't unmap underlying mapping
+pub const MAP_FIXED_NOREPLACE = 0x100000;
 
 pub const F_OK = 0;
 pub const X_OK = 1;

--- a/std/os/bits/linux.zig
+++ b/std/os/bits/linux.zig
@@ -22,6 +22,36 @@ pub const STDIN_FILENO = 0;
 pub const STDOUT_FILENO = 1;
 pub const STDERR_FILENO = 2;
 
+/// Special value used to indicate openat should use the current working directory
+pub const AT_FDCWD = 100;
+
+/// Do not follow symbolic links
+pub const AT_SYMLINK_NOFOLLOW = 0x100;
+
+/// Remove directory instead of unlinking file
+pub const AT_REMOVEDIR = 0x200;
+
+/// Follow symbolic links.
+pub const AT_SYMLINK_FOLLOW = 0x400;
+
+/// Suppress terminal automount traversal
+pub const AT_NO_AUTOMOUNT = 0x800;
+
+/// Allow empty relative pathname
+pub const AT_EMPTY_PATH = 0x1000;
+
+/// Type of synchronisation required from statx()
+pub const AT_STATX_SYNC_TYPE = 0x6000;
+
+/// - Do whatever stat() does
+pub const AT_STATX_SYNC_AS_STAT = 0x0000;
+
+/// - Force the attributes to be sync'd with the server
+pub const AT_STATX_FORCE_SYNC = 0x2000;
+
+/// - Don't sync attributes with the server
+pub const AT_STATX_DONT_SYNC = 0x4000;
+
 pub const FUTEX_WAIT = 0;
 pub const FUTEX_WAKE = 1;
 pub const FUTEX_FD = 2;

--- a/std/os/bits/linux/arm64.zig
+++ b/std/os/bits/linux/arm64.zig
@@ -331,13 +331,6 @@ pub const F_GETOWN_EX = 16;
 
 pub const F_GETOWNER_UIDS = 17;
 
-pub const AT_FDCWD = -100;
-pub const AT_SYMLINK_NOFOLLOW = 0x100;
-pub const AT_REMOVEDIR = 0x200;
-pub const AT_SYMLINK_FOLLOW = 0x400;
-pub const AT_NO_AUTOMOUNT = 0x800;
-pub const AT_EMPTY_PATH = 0x1000;
-
 pub const VDSO_USEFUL = true;
 pub const VDSO_CGT_SYM = "__kernel_clock_gettime";
 pub const VDSO_CGT_VER = "LINUX_2.6.39";

--- a/std/os/bits/linux/arm64.zig
+++ b/std/os/bits/linux/arm64.zig
@@ -331,6 +331,36 @@ pub const F_GETOWN_EX = 16;
 
 pub const F_GETOWNER_UIDS = 17;
 
+/// stack-like segment
+pub const MAP_GROWSDOWN = 0x0100;
+
+/// ETXTBSY
+pub const MAP_DENYWRITE = 0x0800;
+
+/// mark it as an executable
+pub const MAP_EXECUTABLE = 0x1000;
+
+/// pages are locked
+pub const MAP_LOCKED = 0x2000;
+
+/// don't check for reservations
+pub const MAP_NORESERVE = 0x4000;
+
+/// populate (prefault) pagetables
+pub const MAP_POPULATE = 0x8000;
+
+/// do not block on IO
+pub const MAP_NONBLOCK = 0x10000;
+
+/// give out an address that is best suited for process/thread stacks
+pub const MAP_STACK = 0x20000;
+
+/// create a huge page mapping
+pub const MAP_HUGETLB = 0x40000;
+
+/// perform synchronous page faults for the mapping
+pub const MAP_SYNC = 0x80000;
+
 pub const VDSO_USEFUL = true;
 pub const VDSO_CGT_SYM = "__kernel_clock_gettime";
 pub const VDSO_CGT_VER = "LINUX_2.6.39";

--- a/std/os/bits/linux/x86_64.zig
+++ b/std/os/bits/linux/x86_64.zig
@@ -394,6 +394,39 @@ pub const F_GETOWN_EX = 16;
 
 pub const F_GETOWNER_UIDS = 17;
 
+/// only give out 32bit addresses
+pub const MAP_32BIT = 0x40;
+
+/// stack-like segment
+pub const MAP_GROWSDOWN = 0x0100;
+
+/// ETXTBSY
+pub const MAP_DENYWRITE = 0x0800;
+
+/// mark it as an executable
+pub const MAP_EXECUTABLE = 0x1000;
+
+/// pages are locked
+pub const MAP_LOCKED = 0x2000;
+
+/// don't check for reservations
+pub const MAP_NORESERVE = 0x4000;
+
+/// populate (prefault) pagetables
+pub const MAP_POPULATE = 0x8000;
+
+/// do not block on IO
+pub const MAP_NONBLOCK = 0x10000;
+
+/// give out an address that is best suited for process/thread stacks
+pub const MAP_STACK = 0x20000;
+
+/// create a huge page mapping
+pub const MAP_HUGETLB = 0x40000;
+
+/// perform synchronous page faults for the mapping
+pub const MAP_SYNC = 0x80000;
+
 pub const VDSO_USEFUL = true;
 pub const VDSO_CGT_SYM = "__vdso_clock_gettime";
 pub const VDSO_CGT_VER = "LINUX_2.6";

--- a/std/os/bits/linux/x86_64.zig
+++ b/std/os/bits/linux/x86_64.zig
@@ -394,13 +394,6 @@ pub const F_GETOWN_EX = 16;
 
 pub const F_GETOWNER_UIDS = 17;
 
-pub const AT_FDCWD = -100;
-pub const AT_SYMLINK_NOFOLLOW = 0x100;
-pub const AT_REMOVEDIR = 0x200;
-pub const AT_SYMLINK_FOLLOW = 0x400;
-pub const AT_NO_AUTOMOUNT = 0x800;
-pub const AT_EMPTY_PATH = 0x1000;
-
 pub const VDSO_USEFUL = true;
 pub const VDSO_CGT_SYM = "__vdso_clock_gettime";
 pub const VDSO_CGT_VER = "LINUX_2.6";


### PR DESCRIPTION
  -  `AT_` constants are the same across architectures
  - `MAP_` definitions now match the kernel
