### PR TITLE
stage1: track filenames in tokens and AstNodes to ease debugging in gdb

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -958,6 +958,7 @@ struct AstNode {
     enum NodeType type;
     size_t line;
     size_t column;
+    char *filename;
     ZigType *owner;
     union {
         AstNodeFnDef fn_def;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -3869,7 +3869,7 @@ ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *resolved_path, Bu
     }
 
     Tokenization tokenization = {0};
-    tokenize(source_code, &tokenization);
+    tokenize(source_code, &tokenization, buf_ptr(resolved_path));
 
     if (tokenization.err) {
         ErrorMsg *err = err_msg_create_with_line(resolved_path, tokenization.err_line, tokenization.err_column,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -165,6 +165,7 @@ static AstNode *ast_create_node(ParseContext *pc, NodeType type, Token *first_to
     AstNode *node = ast_create_node_no_line_info(pc, type);
     node->line = first_token->start_line;
     node->column = first_token->start_column;
+    node->filename = first_token->filename;
     return node;
 }
 
@@ -173,6 +174,7 @@ static AstNode *ast_create_node_copy_line_info(ParseContext *pc, NodeType type, 
     AstNode *node = ast_create_node_no_line_info(pc, type);
     node->line = from->line;
     node->column = from->column;
+    node->filename = from->filename;
     return node;
 }
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -233,8 +233,9 @@ struct Tokenize {
     size_t pos;
     TokenizeState state;
     ZigList<Token> *tokens;
-    int line;
-    int column;
+    size_t line;
+    size_t column;
+    char *filename;
     Token *cur_tok;
     Tokenization *out;
     uint32_t radix;
@@ -283,6 +284,7 @@ static void begin_token(Tokenize *t, TokenId id) {
     token->start_line = t->line;
     token->start_column = t->column;
     token->start_pos = t->pos;
+    token->filename = t->filename;
 
     set_token_id(t, token, id);
 
@@ -399,11 +401,12 @@ static void invalid_char_error(Tokenize *t, uint8_t c) {
     tokenize_error(t, "invalid character: '\\x%02x'", c);
 }
 
-void tokenize(Buf *buf, Tokenization *out) {
+void tokenize(Buf *buf, Tokenization *out, char *source_filename) {
     Tokenize t = {0};
     t.out = out;
     t.tokens = out->tokens = allocate<ZigList<Token>>(1);
     t.buf = buf;
+    t.filename = source_filename;
 
     out->line_offsets = allocate<ZigList<size_t>>(1);
 

--- a/src/tokenizer.hpp
+++ b/src/tokenizer.hpp
@@ -158,6 +158,7 @@ struct Token {
     size_t end_pos;
     size_t start_line;
     size_t start_column;
+    char *filename;
 
     union {
         // TokenIdIntLiteral
@@ -186,7 +187,7 @@ struct Tokenization {
     size_t err_column;
 };
 
-void tokenize(Buf *buf, Tokenization *out_tokenization);
+void tokenize(Buf *buf, Tokenization *out_tokenization, char *source_filename);
 
 void print_tokens(Buf *buf, ZigList<Token> *tokens);
 


### PR DESCRIPTION
Also don't needlessly limit maximum lines/columns.