### PR TITLE
cmake: allow user to select static vs dynamic LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,11 @@ endif()
 message("Configuring zig version ${ZIG_VERSION}")
 
 set(ZIG_STATIC off CACHE BOOL "Attempt to build a static zig executable (not compatible with glibc)")
+set(ZIG_STATIC_LLVM off CACHE BOOL "Prefer linking against static LLVM libraries")
+
+if(ZIG_STATIC)
+    set(ZIG_STATIC_LLVM "on")
+endif()
 
 string(REGEX REPLACE "\\\\" "\\\\\\\\" ZIG_LIBC_LIB_DIR_ESCAPED "${ZIG_LIBC_LIB_DIR}")
 string(REGEX REPLACE "\\\\" "\\\\\\\\" ZIG_LIBC_STATIC_LIB_DIR_ESCAPED "${ZIG_LIBC_STATIC_LIB_DIR}")

--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -65,7 +65,7 @@ NEED_TARGET("WebAssembly")
 NEED_TARGET("X86")
 NEED_TARGET("XCore")
 
-if(NOT(CMAKE_BUILD_TYPE STREQUAL "Debug") OR ZIG_STATIC)
+if(ZIG_STATIC_LLVM)
   execute_process(
       COMMAND ${LLVM_CONFIG_EXE} --libfiles --link-static
       OUTPUT_VARIABLE LLVM_LIBRARIES_SPACES


### PR DESCRIPTION
Fixes #2340 
Supercedes #2270

This allows a user to opt in or out of a static/dynamic LLVM as they need.
It will let us remove patches that linux distributions apply to zig such as [this one](https://git.archlinux.org/svntogit/community.git/tree/trunk/force_dynamic_llvm.patch?h=packages/zig)