### PR TITLE
SIMD enablement

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7952,6 +7952,25 @@ pub const TypeInfo = union(TypeId) {
       {#link|pointer|Pointers#}.
       </p>
       {#header_close#}
+
+      {#header_open|@shuffle#}
+      <pre>{#syntax#}@shuffle(comptime ElemType: type, a: @Vector(mask.len, ElemType), b: @Vector(mask.len, ElemType), comptime mask: @Vector(_, u32)) @Vector(mask.len, ElemType){#endsyntax#}</pre>
+      <p>
+      Does the {#syntax#}shufflevector{#endsyntax#} instruction. Each element in {#syntax#}comptime{#endsyntax#}
+      (and always {#syntax#}i32{#endsyntax#}) {#syntax#}mask{#endsyntax#} selects a element from either {#syntax#}a{#endsyntax#} or {#syntax#}b{#endsyntax#}.
+      Positive numbers select from {#syntax#}a{#endsyntax#} (starting at 0), while negative values select
+      from {#syntax#}b{#endsyntax#} (starting at -1 and going down). It is recommended to use the {#syntax#}~{#endsyntax#}
+      operator from indexes from b so that both indexes can start from 0 (i.e. ~0 is -1). If either the {#syntax#}mask{#endsyntax#}
+      value or the value from {#syntax#}a{#endsyntax#} or {#syntax#}b{#endsyntax#} that it selects are {#syntax#}undefined{#endsyntax#}
+      then the resulting value is {#syntax#}undefined{#endsyntax#}. Also see {#link|SIMD#} and
+      the relevent <a href="https://llvm.org/docs/LangRef.html#i-shufflevector">LLVM Documentation on
+      {#syntax#}shufflevector{#endsyntax#}</a>, although note that the mask values are interpreted differently than in LLVM-IR. Also unlike LLVM-IR, the number of elements in {#syntax#}a{#endsyntax#} and {#syntax#}b{#endsyntax#} do not have to match. If you wish to select from {#syntax#}undefined{#endsyntax#} you must select the first element only (which yields {#syntax#}undefined{#endsyntax#}), or populate a vector with {#syntax#}undefined{#endsyntax#}.
+      </p>
+      <p>
+      {#syntax#}ElemType{#endsyntax#} must be an {#link|integer|Integers#}, a {#link|float|Floats#}, or a
+      {#link|pointer|Pointers#}. The mask may be any vector length that the target supports, and its' length determines the result length.
+      </p>
+      {#header_close#}
       {#header_close#}
 
       {#header_open|Build Mode#}

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2208,14 +2208,15 @@ enum IrInstructionId {
     IrInstructionIdPhi,
     IrInstructionIdUnOp,
     IrInstructionIdBinOp,
-    IrInstructionIdLoadPtr,
+    IrInstructionIdLoad,
     IrInstructionIdLoadPtrGen,
-    IrInstructionIdStorePtr,
+    IrInstructionIdStore,
+    IrInstructionIdExtractInsert,
     IrInstructionIdBoolVectorToBool,
     IrInstructionIdFieldPtr,
     IrInstructionIdStructFieldPtr,
     IrInstructionIdUnionFieldPtr,
-    IrInstructionIdElemPtr,
+    IrInstructionIdElem,
     IrInstructionIdVarPtr,
     IrInstructionIdReturnPtr,
     IrInstructionIdCallSrc,
@@ -2529,10 +2530,21 @@ struct IrInstructionBinOp {
     bool safety_check_on;
 };
 
-struct IrInstructionLoadPtr {
+struct IrInstructionLoad {
     IrInstruction base;
 
     IrInstruction *ptr;
+};
+
+struct IrInstructionExtractInsert {
+    IrInstruction base;
+
+    IrInstruction *agg;
+    IrInstruction *index;
+    // nullptr if Extract
+    IrInstruction *value;
+    // only used if Extract
+    IrInstruction *result_loc;
 };
 
 struct IrInstructionLoadPtrGen {
@@ -2542,7 +2554,7 @@ struct IrInstructionLoadPtrGen {
     IrInstruction *result_loc;
 };
 
-struct IrInstructionStorePtr {
+struct IrInstructionStore {
     IrInstruction base;
 
     IrInstruction *ptr;
@@ -2575,7 +2587,7 @@ struct IrInstructionUnionFieldPtr {
     TypeUnionField *field;
 };
 
-struct IrInstructionElemPtr {
+struct IrInstructionElem {
     IrInstruction base;
 
     IrInstruction *array_ptr;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1626,6 +1626,7 @@ struct ZigLLVMFnKey {
         } overflow_arithmetic;
         struct {
             uint32_t bit_count;
+            uint32_t vector_len; // 0 means not a vector
         } bswap;
         struct {
             uint32_t bit_count;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -323,7 +323,7 @@ struct ConstExprValue {
         BigInt x_enum_tag;
         ConstStructValue x_struct;
         ConstUnionValue x_union;
-        ConstArrayValue x_array;
+        ConstArrayValue x_array; // also vectors
         ConstPtrValue x_ptr;
         ConstArgTuple x_arg_tuple;
         Buf *x_enum_literal;
@@ -2210,6 +2210,7 @@ enum IrInstructionId {
     IrInstructionIdLoadPtr,
     IrInstructionIdLoadPtrGen,
     IrInstructionIdStorePtr,
+    IrInstructionIdBoolVectorToBool,
     IrInstructionIdFieldPtr,
     IrInstructionIdStructFieldPtr,
     IrInstructionIdUnionFieldPtr,
@@ -2581,6 +2582,14 @@ struct IrInstructionElemPtr {
     IrInstruction *init_array_type;
     PtrLen ptr_len;
     bool safety_check_on;
+};
+
+struct IrInstructionBoolVectorToBool {
+    IrInstruction base;
+
+    bool is_any; // else is all
+    bool is_function_ptr; // This is a function, even if it is not supported as a function pointer
+    IrInstruction *vector;
 };
 
 struct IrInstructionVarPtr {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1478,6 +1478,7 @@ enum BuiltinFnId {
     BuiltinFnIdIntToEnum,
     BuiltinFnIdIntType,
     BuiltinFnIdVectorType,
+    BuiltinFnIdShuffle,
     BuiltinFnIdSetCold,
     BuiltinFnIdSetRuntimeSafety,
     BuiltinFnIdSetFloatMode,
@@ -2265,6 +2266,7 @@ enum IrInstructionId {
     IrInstructionIdBoolToInt,
     IrInstructionIdIntType,
     IrInstructionIdVectorType,
+    IrInstructionIdShuffleVector,
     IrInstructionIdBoolNot,
     IrInstructionIdMemset,
     IrInstructionIdMemcpy,
@@ -3593,6 +3595,15 @@ struct IrInstructionVectorToArray {
 
     IrInstruction *vector;
     IrInstruction *result_loc;
+};
+
+struct IrInstructionShuffleVector {
+    IrInstruction base;
+
+    IrInstruction *scalar_type;
+    IrInstruction *a;
+    IrInstruction *b;
+    IrInstruction *mask; // This is in zig-format, not llvm format
 };
 
 struct IrInstructionAssertZero {

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -4021,6 +4021,7 @@ ZigType *get_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits) {
 bool is_valid_vector_elem_type(ZigType *elem_type) {
     return elem_type->id == ZigTypeIdInt ||
         elem_type->id == ZigTypeIdFloat ||
+        elem_type->id == ZigTypeIdBool ||
         get_codegen_ptr_type(elem_type) != nullptr;
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4226,6 +4226,35 @@ static LLVMValueRef ir_render_ctz(CodeGen *g, IrExecutable *executable, IrInstru
     return gen_widen_or_shorten(g, false, int_type, instruction->base.value.type, wrong_size_int);
 }
 
+static LLVMValueRef ir_render_shuffle_vector(CodeGen *g, IrExecutable *executable, IrInstructionShuffleVector *instruction) {
+    uint64_t len_a = instruction->a->value.type->data.vector.len,
+        len_c = instruction->mask->value.type->data.vector.len;
+
+    // LLVM uses integers larger than the length of the first array to
+    // index into the second array. This was deemed unnecessarily fragile
+    // when changing code, so Zig uses negative numbers to index the
+    // second vector. These start at -1 and go down, and are easiest to use
+    // with the ~ operator. Here we convert between the two formats.
+    IrInstruction *mask = instruction->mask;
+    LLVMValueRef *values = allocate<LLVMValueRef>(len_c);
+    for (uint64_t i = 0;i < len_c;i++) {
+        if (mask->value.data.x_array.data.s_none.elements[i].special == ConstValSpecialUndef) {
+            values[i] = LLVMGetUndef(LLVMInt32Type());
+        } else {
+            int64_t v = bigint_as_signed(&mask->value.data.x_array.data.s_none.elements[i].data.x_bigint);
+            if (v < 0)
+                v = (uint32_t)~v + (uint32_t)len_a;
+            values[i] = LLVMConstInt(LLVMInt32Type(), v, false);
+        }
+    }
+
+    return LLVMBuildShuffleVector(g->builder,
+        ir_llvm_value(g, instruction->a),
+        ir_llvm_value(g, instruction->b),
+        LLVMConstVector(values, len_c),
+        "");
+}
+
 static LLVMValueRef ir_render_pop_count(CodeGen *g, IrExecutable *executable, IrInstructionPopCount *instruction) {
     ZigType *int_type = instruction->op->value.type;
     LLVMValueRef fn_val = get_int_builtin_fn(g, int_type, BuiltinFnIdPopCount);
@@ -5809,6 +5838,8 @@ static LLVMValueRef ir_render_instruction(CodeGen *g, IrExecutable *executable, 
             return ir_render_resize_slice(g, executable, (IrInstructionResizeSlice *)instruction);
         case IrInstructionIdPtrOfArrayToSlice:
             return ir_render_ptr_of_array_to_slice(g, executable, (IrInstructionPtrOfArrayToSlice *)instruction);
+        case IrInstructionIdShuffleVector:
+            return ir_render_shuffle_vector(g, executable, (IrInstructionShuffleVector *) instruction);
     }
     zig_unreachable();
 }
@@ -7363,6 +7394,7 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdCompileLog, "compileLog", SIZE_MAX);
     create_builtin_fn(g, BuiltinFnIdIntType, "IntType", 2); // TODO rename to Int
     create_builtin_fn(g, BuiltinFnIdVectorType, "Vector", 2);
+    create_builtin_fn(g, BuiltinFnIdShuffle, "shuffle", 4);
     create_builtin_fn(g, BuiltinFnIdSetCold, "setCold", 1);
     create_builtin_fn(g, BuiltinFnIdSetRuntimeSafety, "setRuntimeSafety", 1);
     create_builtin_fn(g, BuiltinFnIdSetFloatMode, "setFloatMode", 1);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -25513,16 +25513,42 @@ static IrInstruction *ir_analyze_instruction_float_op(IrAnalyze *ira, IrInstruct
 }
 
 static IrInstruction *ir_analyze_instruction_bswap(IrAnalyze *ira, IrInstructionBswap *instruction) {
-    ZigType *int_type = ir_resolve_int_type(ira, instruction->type->child);
-    if (type_is_invalid(int_type))
+    IrInstruction *op = instruction->op->child;
+    ZigType *type_expr = ir_resolve_type(ira, instruction->type->child);
+    if (type_is_invalid(type_expr))
         return ira->codegen->invalid_instruction;
 
-    IrInstruction *op = ir_implicit_cast(ira, instruction->op->child, int_type);
+    if (type_expr->id != ZigTypeIdInt) {
+        ir_add_error(ira, instruction->type,
+            buf_sprintf("expected integer type, found '%s'", buf_ptr(&type_expr->name)));
+        if (type_expr->id == ZigTypeIdVector &&
+            type_expr->data.vector.elem_type->id == ZigTypeIdInt)
+            ir_add_error(ira, instruction->type,
+                buf_sprintf("represent vectors with their scalar types, i.e. '%s'",
+                    buf_ptr(&type_expr->data.vector.elem_type->name)));
+        return ira->codegen->invalid_instruction;
+    }
+    ZigType *int_type = type_expr;
+
+    ZigType *expr_type = op->value.type;
+    bool is_vector = expr_type->id == ZigTypeIdVector;
+    ZigType *ret_type = int_type;
+    if (is_vector)
+        ret_type = get_vector_type(ira->codegen, expr_type->data.vector.len, int_type);
+
+    op = ir_implicit_cast(ira, instruction->op->child, ret_type);
     if (type_is_invalid(op->value.type))
         return ira->codegen->invalid_instruction;
 
     if (int_type->data.integral.bit_count == 0) {
-        IrInstruction *result = ir_const(ira, &instruction->base, int_type);
+        IrInstruction *result = ir_const(ira, &instruction->base, ret_type);
+        if (is_vector) {
+            expand_undef_array(ira->codegen, &result->value);
+            result->value.data.x_array.data.s_none.elements =
+                allocate<ConstExprValue>(expr_type->data.vector.len);
+            for (unsigned i = 0; i < expr_type->data.vector.len; i++)
+                bigint_init_unsigned(&result->value.data.x_array.data.s_none.elements[i].data.x_bigint, 0);
+        }
         bigint_init_unsigned(&result->value.data.x_bigint, 0);
         return result;
     }
@@ -25542,20 +25568,36 @@ static IrInstruction *ir_analyze_instruction_bswap(IrAnalyze *ira, IrInstruction
         if (val == nullptr)
             return ira->codegen->invalid_instruction;
         if (val->special == ConstValSpecialUndef)
-            return ir_const_undef(ira, &instruction->base, int_type);
+            return ir_const_undef(ira, &instruction->base, ret_type);
 
-        IrInstruction *result = ir_const(ira, &instruction->base, int_type);
+        IrInstruction *result = ir_const(ira, &instruction->base, ret_type);
         size_t buf_size = int_type->data.integral.bit_count / 8;
         uint8_t *buf = allocate_nonzero<uint8_t>(buf_size);
-        bigint_write_twos_complement(&val->data.x_bigint, buf, int_type->data.integral.bit_count, true);
-        bigint_read_twos_complement(&result->value.data.x_bigint, buf, int_type->data.integral.bit_count, false,
-                int_type->data.integral.is_signed);
+        if (is_vector) {
+            expand_undef_array(ira->codegen, &result->value);
+            result->value.data.x_array.data.s_none.elements =
+                allocate<ConstExprValue>(expr_type->data.vector.len);
+            for (unsigned i = 0; i < expr_type->data.vector.len; i++) {
+                ConstExprValue *cur = &val->data.x_array.data.s_none.elements[i];
+                result->value.data.x_array.data.s_none.elements[i].special = cur->special;
+                if (cur->special == ConstValSpecialUndef)
+                    continue;
+                bigint_write_twos_complement(&cur->data.x_bigint, buf, int_type->data.integral.bit_count, true);
+                bigint_read_twos_complement(&result->value.data.x_array.data.s_none.elements[i].data.x_bigint,
+                        buf, int_type->data.integral.bit_count, false,
+                        int_type->data.integral.is_signed);
+            }
+        } else {
+            bigint_write_twos_complement(&val->data.x_bigint, buf, int_type->data.integral.bit_count, true);
+            bigint_read_twos_complement(&result->value.data.x_bigint, buf, int_type->data.integral.bit_count, false,
+                    int_type->data.integral.is_signed);
+        }
         return result;
     }
 
     IrInstruction *result = ir_build_bswap(&ira->new_irb, instruction->base.scope,
             instruction->base.source_node, nullptr, op);
-    result->value.type = int_type;
+    result->value.type = ret_type;
     return result;
 }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -716,6 +716,10 @@ static constexpr IrInstructionId ir_instruction_id(IrInstructionVectorType *) {
     return IrInstructionIdVectorType;
 }
 
+static constexpr IrInstructionId ir_instruction_id(IrInstructionShuffleVector *) {
+    return IrInstructionIdShuffleVector;
+}
+
 static constexpr IrInstructionId ir_instruction_id(IrInstructionBoolNot *) {
     return IrInstructionIdBoolNot;
 }
@@ -2311,6 +2315,23 @@ static IrInstruction *ir_build_vector_type(IrBuilder *irb, Scope *scope, AstNode
 
     ir_ref_instruction(len, irb->current_basic_block);
     ir_ref_instruction(elem_type, irb->current_basic_block);
+
+    return &instruction->base;
+}
+
+static IrInstruction *ir_build_shuffle_vector(IrBuilder *irb, Scope *scope, AstNode *source_node,
+    IrInstruction *scalar_type, IrInstruction *a, IrInstruction *b, IrInstruction *mask)
+{
+    IrInstructionShuffleVector *instruction = ir_build_instruction<IrInstructionShuffleVector>(irb, scope, source_node);
+    instruction->scalar_type = scalar_type;
+    instruction->a = a;
+    instruction->b = b;
+    instruction->mask = mask;
+
+    ir_ref_instruction(scalar_type, irb->current_basic_block);
+    ir_ref_instruction(a, irb->current_basic_block);
+    ir_ref_instruction(b, irb->current_basic_block);
+    ir_ref_instruction(mask, irb->current_basic_block);
 
     return &instruction->base;
 }
@@ -5041,6 +5062,32 @@ static IrInstruction *ir_gen_builtin_fn_call(IrBuilder *irb, Scope *scope, AstNo
 
                 IrInstruction *vector_type = ir_build_vector_type(irb, scope, node, arg0_value, arg1_value);
                 return ir_lval_wrap(irb, scope, vector_type, lval, result_loc);
+            }
+        case BuiltinFnIdShuffle:
+            {
+                AstNode *arg0_node = node->data.fn_call_expr.params.at(0);
+                IrInstruction *arg0_value = ir_gen_node(irb, arg0_node, scope);
+                if (arg0_value == irb->codegen->invalid_instruction)
+                    return arg0_value;
+
+                AstNode *arg1_node = node->data.fn_call_expr.params.at(1);
+                IrInstruction *arg1_value = ir_gen_node(irb, arg1_node, scope);
+                if (arg1_value == irb->codegen->invalid_instruction)
+                    return arg1_value;
+
+                AstNode *arg2_node = node->data.fn_call_expr.params.at(2);
+                IrInstruction *arg2_value = ir_gen_node(irb, arg2_node, scope);
+                if (arg2_value == irb->codegen->invalid_instruction)
+                    return arg2_value;
+
+                AstNode *arg3_node = node->data.fn_call_expr.params.at(3);
+                IrInstruction *arg3_value = ir_gen_node(irb, arg3_node, scope);
+                if (arg3_value == irb->codegen->invalid_instruction)
+                    return arg3_value;
+
+                IrInstruction *shuffle_vector = ir_build_shuffle_vector(irb, scope, node,
+                    arg0_value, arg1_value, arg2_value, arg3_value);
+                return ir_lval_wrap(irb, scope, shuffle_vector, lval, result_loc);
             }
         case BuiltinFnIdMemcpy:
             {
@@ -22014,6 +22061,201 @@ static IrInstruction *ir_analyze_instruction_vector_type(IrAnalyze *ira, IrInstr
     return ir_const_type(ira, &instruction->base, vector_type);
 }
 
+static IrInstruction *mask_type_fail(IrAnalyze *ira, IrInstruction *mask) {
+    ir_add_error(ira, mask,
+        buf_sprintf("@shuffle mask operand must be a vector of signed 32-bit integers, got '%s'.",
+            buf_ptr(&mask->value.type->name)));
+    return ira->codegen->invalid_instruction;
+}
+
+static IrInstruction *ir_analyze_instruction_shuffle_vector(IrAnalyze *ira, IrInstructionShuffleVector *instruction) {
+    ZigType *scalar_type = ir_resolve_type(ira, instruction->scalar_type);
+    assert(scalar_type);
+    if (type_is_invalid(scalar_type))
+        return ira->codegen->invalid_instruction;
+
+    IrInstruction *a = instruction->a->child;
+    IrInstruction *b = instruction->b->child;
+    IrInstruction *mask = instruction->mask->child;
+    assert(a && b && mask);
+
+    if (scalar_type->id != ZigTypeIdInt &&
+        scalar_type->id != ZigTypeIdFloat &&
+        scalar_type->id != ZigTypeIdPointer) {
+        ir_add_error(ira, instruction->scalar_type,
+            buf_sprintf("@shuffle type argument must be int, float or pointer, not '%s'",
+                buf_ptr(&scalar_type->name)));
+        return ira->codegen->invalid_instruction;
+    }
+
+    ZigType *mask_type = mask->value.type;
+    if (type_is_invalid(mask_type))
+        return ira->codegen->invalid_instruction;
+
+    if (mask_type->id == ZigTypeIdArray) {
+        ZigType *cast = allocate<ZigType>(1);
+        cast->id = ZigTypeIdVector;
+        cast->data.vector.len = mask_type->data.array.len;
+        cast->data.vector.elem_type = mask_type->data.array.child_type;
+        mask = ir_implicit_cast(ira, mask, cast);
+        if (type_is_invalid(mask->value.type))
+            return mask_type_fail(ira, mask);
+        mask_type = mask->value.type;
+    }
+
+    if (mask_type->id != ZigTypeIdVector)
+        return mask_type_fail(ira, mask);
+
+    ZigType *mask_scalar_type = mask_type->data.array.child_type;
+    if (mask_scalar_type->id != ZigTypeIdInt)
+        return mask_type_fail(ira, mask);
+
+    if (mask_scalar_type->data.integral.bit_count != 32 ||
+        mask_scalar_type->data.integral.is_signed == false)
+        return mask_type_fail(ira, mask);
+
+    if (a->value.type->id != ZigTypeIdVector && a->value.type->id != ZigTypeIdUndefined) {
+        ir_add_error(ira, a,
+            buf_sprintf("expected vector of element type '%s' got '%s'",
+                buf_ptr(&scalar_type->name),
+                buf_ptr(&a->value.type->name)));
+        return ira->codegen->invalid_instruction;
+    }
+
+    if (b->value.type->id != ZigTypeIdVector && b->value.type->id != ZigTypeIdUndefined) {
+        ir_add_error(ira, b,
+            buf_sprintf("expected vector of element type '%s' got '%s'",
+                buf_ptr(&scalar_type->name),
+                buf_ptr(&b->value.type->name)));
+        return ira->codegen->invalid_instruction;
+    }
+
+    if (a->value.type->id == ZigTypeIdUndefined && b->value.type->id == ZigTypeIdUndefined) {
+        ir_add_error(ira, b,
+            buf_sprintf("both vectors cannot be undefined"));
+        return ira->codegen->invalid_instruction;
+    }
+
+    uint64_t len_a = a->value.type->data.vector.len, len_b = b->value.type->data.vector.len,
+        len_c = mask->value.type->data.vector.len;
+    // The 1 here is a bit of a hack. Undef is a value that is useful, and
+    // sometimes you want to populate the result with a few undefs.
+    if (a->value.type->id == ZigTypeIdUndefined) {
+        a = ir_const_undef(ira, a, b->value.type);
+        len_a = 1;
+    } else if (b->value.type->id == ZigTypeIdUndefined) {
+        b = ir_const_undef(ira, b, a->value.type);
+        len_b = 1;
+    }
+
+    if (a->value.type != b->value.type) {
+        if (a->value.type->data.vector.elem_type == b->value.type->data.vector.elem_type) {
+            uint32_t a_len = a->value.type->data.vector.len, b_len = b->value.type->data.vector.len,
+                max_len = max(a_len, b_len), min_len = min(a_len, b_len);
+            bool expand_b = b_len < a_len;
+            IrInstruction *expand_mask = ir_const(ira, &instruction->base,
+                get_vector_type(ira->codegen, max_len, ira->codegen->builtin_types.entry_i32));
+            expand_mask->value.data.x_array.data.s_none.elements = create_const_vals(max_len);
+            uint32_t i = 0;
+            for (; i < min_len; i++)
+                bigint_init_unsigned(&expand_mask->value.data.x_array.data.s_none.elements[i].data.x_bigint, i);
+            for (; i < max_len; i++)
+                bigint_init_signed(&expand_mask->value.data.x_array.data.s_none.elements[i].data.x_bigint, -1);
+            IrInstruction *undef = ir_const_undef(ira, &instruction->base,
+                get_vector_type(ira->codegen, min_len, scalar_type));
+            if (expand_b) {
+                if (instr_is_comptime(b)) {
+                    b->value.data.x_array.data.s_none.elements =
+                        reallocate<ConstExprValue>(b->value.data.x_array.data.s_none.elements,
+                        b->value.type->data.vector.len, a_len);
+                } else {
+                    b = ir_build_shuffle_vector(&ira->new_irb,
+                        instruction->base.scope, instruction->base.source_node,
+                        instruction->scalar_type, b, undef, expand_mask);
+                    b->value.special = ConstValSpecialRuntime;
+                }
+                b->value.type = get_vector_type(ira->codegen, max_len, scalar_type);
+            } else {
+                if (instr_is_comptime(a)) {
+                    a->value.data.x_array.data.s_none.elements =
+                        reallocate<ConstExprValue>(a->value.data.x_array.data.s_none.elements,
+                        a->value.type->data.vector.len, b_len);
+                } else {
+                    a = ir_build_shuffle_vector(&ira->new_irb,
+                        instruction->base.scope, instruction->base.source_node,
+                        instruction->scalar_type, a, undef, expand_mask);
+                    a->value.special = ConstValSpecialRuntime;
+                }
+                a->value.type = get_vector_type(ira->codegen, max_len, scalar_type);
+            }
+        } else {
+            ir_add_error(ira, b,
+                buf_sprintf("type '%s' does not match '%s'",
+                    buf_ptr(&a->value.type->name),
+                    buf_ptr(&b->value.type->name)));
+            return ira->codegen->invalid_instruction;
+        }
+    }
+    ConstExprValue *mask_val = ir_resolve_const(ira, mask, UndefOk);
+    if (!mask_val) {
+        ir_add_error(ira, mask,
+            buf_sprintf("mask must be comptime"));
+        return ira->codegen->invalid_instruction;
+    }
+    for (uint32_t i = 0;i < mask->value.type->data.vector.len;i++) {
+        if (mask->value.data.x_array.data.s_none.elements[i].special == ConstValSpecialUndef)
+            continue;
+        int64_t v = bigint_as_signed(&mask->value.data.x_array.data.s_none.elements[i].data.x_bigint);
+        if (v >= 0 && (uint64_t)v > len_a) {
+            if ((uint64_t)v > len_a + len_b)
+                ir_add_error(ira, a,
+                    buf_sprintf("mask index out of bounds"));
+            else
+                ir_add_error(ira, a,
+                    buf_sprintf("mask index out of bounds. "
+                        "Selections from the second array are specified with negative numbers."));
+        } else if (v < 0 && (uint64_t)~v > len_b)
+            ir_add_error(ira, b,
+                buf_sprintf("mask index out of bounds"));
+        else
+            continue;
+        return ira->codegen->invalid_instruction;
+    }
+
+    ZigType *result_type = get_vector_type(ira->codegen, len_c, scalar_type);
+    if (instr_is_comptime(a) &&
+        instr_is_comptime(b)) {
+        IrInstruction *result = ir_const(ira, &instruction->base, result_type);
+        result->value.data.x_array.data.s_none.elements = create_const_vals(len_c);
+        for (uint32_t i = 0;i < mask->value.type->data.vector.len;i++) {
+            if (mask->value.data.x_array.data.s_none.elements[i].special == ConstValSpecialUndef)
+                result->value.data.x_array.data.s_none.elements[i].special =
+                    ConstValSpecialUndef;
+            int64_t v = bigint_as_signed(&mask->value.data.x_array.data.s_none.elements[i].data.x_bigint);
+            if (v >= 0)
+                result->value.data.x_array.data.s_none.elements[i] =
+                    a->value.data.x_array.data.s_none.elements[v];
+            else if (v < 0)
+                result->value.data.x_array.data.s_none.elements[i] =
+                    b->value.data.x_array.data.s_none.elements[~v];
+            else
+                zig_unreachable();
+            result->value.data.x_array.data.s_none.elements[i].special =
+                ConstValSpecialStatic;
+        }
+        result->value.special = ConstValSpecialStatic;
+        return result;
+    }
+
+    // All static analysis passed, and not comptime
+    IrInstruction *result = ir_build_shuffle_vector(&ira->new_irb,
+        instruction->base.scope, instruction->base.source_node,
+        instruction->scalar_type, a, b, mask);
+    result->value.type = result_type;
+    result->value.special = ConstValSpecialRuntime;
+    return result;
+}
+
 static IrInstruction *ir_analyze_instruction_bool_not(IrAnalyze *ira, IrInstructionBoolNot *instruction) {
     IrInstruction *value = instruction->value->child;
     if (type_is_invalid(value->value.type))
@@ -25609,6 +25851,8 @@ static IrInstruction *ir_analyze_instruction_base(IrAnalyze *ira, IrInstruction 
             return ir_analyze_instruction_int_type(ira, (IrInstructionIntType *)instruction);
         case IrInstructionIdVectorType:
             return ir_analyze_instruction_vector_type(ira, (IrInstructionVectorType *)instruction);
+        case IrInstructionIdShuffleVector:
+            return ir_analyze_instruction_shuffle_vector(ira, (IrInstructionShuffleVector *)instruction);
         case IrInstructionIdBoolNot:
             return ir_analyze_instruction_bool_not(ira, (IrInstructionBoolNot *)instruction);
         case IrInstructionIdMemset:
@@ -25951,6 +26195,7 @@ bool ir_has_side_effects(IrInstruction *instruction) {
         case IrInstructionIdTruncate:
         case IrInstructionIdIntType:
         case IrInstructionIdVectorType:
+        case IrInstructionIdShuffleVector:
         case IrInstructionIdBoolNot:
         case IrInstructionIdSliceSrc:
         case IrInstructionIdMemberCount:

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -12152,34 +12152,82 @@ static IrInstruction *ir_analyze_enum_to_union(IrAnalyze *ira, IrInstruction *so
 static IrInstruction *ir_analyze_widen_or_shorten(IrAnalyze *ira, IrInstruction *source_instr,
         IrInstruction *target, ZigType *wanted_type)
 {
-    assert(wanted_type->id == ZigTypeIdInt || wanted_type->id == ZigTypeIdFloat);
+    bool is_vector = wanted_type->id == ZigTypeIdVector;
+    ZigType *wanted_scalar_type = is_vector ? wanted_type->data.vector.elem_type : wanted_type;
+    assert(wanted_scalar_type->id == ZigTypeIdInt || wanted_scalar_type->id == ZigTypeIdFloat);
+    assert((target->value.type->id == ZigTypeIdVector) == is_vector);
+    if (is_vector) {
+        assert(target->value.type->data.vector.len == wanted_type->data.vector.len);
+    }
 
     if (instr_is_comptime(target)) {
-        ConstExprValue *val = ir_resolve_const(ira, target, UndefBad);
+        ConstExprValue *val = ir_resolve_const(ira, target, UndefOk);
         if (!val)
             return ira->codegen->invalid_instruction;
-        if (wanted_type->id == ZigTypeIdInt) {
-            if (bigint_cmp_zero(&val->data.x_bigint) == CmpLT && !wanted_type->data.integral.is_signed) {
-                ir_add_error(ira, source_instr,
-                    buf_sprintf("attempt to cast negative value to unsigned integer"));
-                return ira->codegen->invalid_instruction;
-            }
-            if (!bigint_fits_in_bits(&val->data.x_bigint, wanted_type->data.integral.bit_count,
-                    wanted_type->data.integral.is_signed))
-            {
-                ir_add_error(ira, source_instr,
-                    buf_sprintf("cast from '%s' to '%s' truncates bits",
-                        buf_ptr(&target->value.type->name), buf_ptr(&wanted_type->name)));
-                return ira->codegen->invalid_instruction;
-            }
-        }
         IrInstruction *result = ir_const(ira, source_instr, wanted_type);
-        result->value.type = wanted_type;
-        if (wanted_type->id == ZigTypeIdInt) {
-            bigint_init_bigint(&result->value.data.x_bigint, &val->data.x_bigint);
+        if (wanted_scalar_type->id == ZigTypeIdInt || wanted_scalar_type->id == ZigTypeIdFloat) {
+            uint32_t i = 0;
+            uint32_t vector_len = 1;
+            ConstExprValue *sval = val;
+            if (is_vector) {
+                vector_len = val->type->data.vector.len;
+                expand_undef_array(ira->codegen, &result->value);
+                result->value.data.x_array.data.s_none.elements =
+                    allocate<ConstExprValue>(vector_len);
+                sval = &val->data.x_array.data.s_none.elements[0];
+            }
+            while (i < vector_len) {
+                if (sval->special == ConstValSpecialUndef) {
+                    if (is_vector) {
+                        result->value.data.x_array.data.s_none.elements[i].special = ConstValSpecialUndef;
+                        sval = &val->data.x_array.data.s_none.elements[++i];
+                    } else {
+                        result->value.special = ConstValSpecialUndef;
+                    }
+                    continue;
+                }
+                if (wanted_scalar_type->id == ZigTypeIdInt) {
+                    if (bigint_cmp_zero(&sval->data.x_bigint) == CmpLT && !wanted_scalar_type->data.integral.is_signed) {
+                        ir_add_error(ira, source_instr,
+                            buf_sprintf("attempt to cast negative value to unsigned integer"));
+                        return ira->codegen->invalid_instruction;
+                    }
+                    if (!bigint_fits_in_bits(&sval->data.x_bigint, wanted_scalar_type->data.integral.bit_count,
+                            wanted_scalar_type->data.integral.is_signed))
+                    {
+                        ir_add_error(ira, source_instr,
+                            buf_sprintf("cast from '%s' to '%s' truncates bits",
+                                buf_ptr(&target->value.type->name), buf_ptr(&wanted_type->name)));
+                        return ira->codegen->invalid_instruction;
+                    }
+                }
+                if (is_vector) {
+                    // float_init_float requires this to be set
+                    result->value.data.x_array.data.s_none.elements[i].type = wanted_scalar_type;
+                    if (wanted_scalar_type->id == ZigTypeIdInt) {
+                        bigint_init_bigint(&result->value.data.x_array.data.s_none.elements[i].data.x_bigint,
+                            &sval->data.x_bigint);
+                    } else if (wanted_scalar_type->id == ZigTypeIdFloat) {
+                        float_init_float(&result->value.data.x_array.data.s_none.elements[i], sval);
+                    } else {
+                        zig_unreachable();
+                    }
+                    result->value.data.x_array.data.s_none.elements[i].special = ConstValSpecialStatic;
+                    sval = &val->data.x_array.data.s_none.elements[++i];
+                } else if (wanted_type->id == ZigTypeIdInt) {
+                    bigint_init_bigint(&result->value.data.x_bigint, &sval->data.x_bigint);
+                    break;
+                } else if (wanted_type->id == ZigTypeIdFloat) {
+                    float_init_float(&result->value, sval);
+                    break;
+                } else {
+                    zig_unreachable();
+                }
+            }
         } else {
-            float_init_float(&result->value, val);
+            zig_unreachable();
         }
+        result->value.type = wanted_type;
         return result;
     }
 
@@ -12190,7 +12238,17 @@ static IrInstruction *ir_analyze_widen_or_shorten(IrAnalyze *ira, IrInstruction 
         assert(wanted_type->id == ZigTypeIdInt);
         assert(type_has_bits(target->value.type));
         ir_build_assert_zero(ira, source_instr, target);
-        IrInstruction *result = ir_const_unsigned(ira, source_instr, 0);
+        IrInstruction *result;
+        if (is_vector) {
+            result = ir_const_type(ira, source_instr, wanted_type);
+            result->value.data.x_array.data.s_none.elements =
+                    allocate<ConstExprValue>(wanted_type->data.vector.len);
+            for (uint32_t i = 0; i < wanted_type->data.vector.len; i++) {
+                bigint_init_unsigned(&result->value.data.x_array.data.s_none.elements[i].data.x_bigint, 0);
+            }
+        } else {
+            result = ir_const_unsigned(ira, source_instr, 0);
+        }
         result->value.type = wanted_type;
         return result;
     }
@@ -12667,6 +12725,11 @@ static IrInstruction *ir_analyze_cast(IrAnalyze *ira, IrInstruction *source_inst
         return ira->codegen->invalid_instruction;
     }
 
+    bool actual_is_vector = actual_type->id == ZigTypeIdVector;
+    bool wanted_is_vector = wanted_type->id == ZigTypeIdVector;
+    ZigType *actual_scalar_type = actual_is_vector ? actual_type->data.vector.elem_type : actual_type;
+    ZigType *wanted_scalar_type = wanted_is_vector ? wanted_type->data.vector.elem_type : wanted_type;
+
     // perfect match or non-const to const
     ConstCastOnly const_cast_result = types_match_const_cast_only(ira, wanted_type, actual_type,
             source_node, false);
@@ -12821,6 +12884,30 @@ static IrInstruction *ir_analyze_cast(IrAnalyze *ira, IrInstruction *source_inst
         return ir_analyze_widen_or_shorten(ira, source_instr, value, wanted_type);
     }
 
+    // widening of vectors
+    // These are separate (while identical) as I am still not sure if this should not implicitely cast,
+    // but only explicitely cast. (i.e. with @cast, or @as, or @Vector(4, i32)(foo)),
+    // as they are more expensive than scalar zext/sext/fext operations.
+    if (wanted_is_vector &&
+        actual_is_vector) {
+        if (wanted_scalar_type->id == ZigTypeIdInt &&
+            actual_scalar_type->id == ZigTypeIdInt) {
+            if (wanted_scalar_type->data.integral.is_signed == actual_scalar_type->data.integral.is_signed &&
+                wanted_scalar_type->data.integral.bit_count >= actual_scalar_type->data.integral.is_signed) {
+                return ir_analyze_widen_or_shorten(ira, source_instr, value, wanted_type);
+            }
+            if (wanted_scalar_type->data.integral.is_signed &&
+                !actual_scalar_type->data.integral.is_signed &&
+                wanted_scalar_type->data.integral.bit_count > actual_scalar_type->data.integral.bit_count) {
+                return ir_analyze_widen_or_shorten(ira, source_instr, value, wanted_type);
+            }
+        }
+        if (wanted_scalar_type->id == ZigTypeIdFloat &&
+            actual_scalar_type->id == ZigTypeIdFloat &&
+            wanted_scalar_type->data.floating.bit_count >= actual_scalar_type->data.floating.bit_count) {
+            return ir_analyze_widen_or_shorten(ira, source_instr, value, wanted_type);
+        }
+    }
 
     // cast from [N]T to []const T
     // TODO: once https://github.com/ziglang/zig/issues/265 lands, remove this
@@ -21818,8 +21905,12 @@ static IrInstruction *ir_analyze_instruction_truncate(IrAnalyze *ira, IrInstruct
     if (type_is_invalid(dest_type))
         return ira->codegen->invalid_instruction;
 
-    if (dest_type->id != ZigTypeIdInt &&
-        dest_type->id != ZigTypeIdComptimeInt)
+    bool dest_is_vector = dest_type->id == ZigTypeIdVector;
+    ZigType *dest_scalar_type = dest_is_vector ? dest_type->data.vector.elem_type : dest_type;
+
+    if (!(dest_type->id == ZigTypeIdInt ||
+          dest_type->id == ZigTypeIdComptimeInt ||
+          (dest_is_vector && dest_scalar_type->id == ZigTypeIdInt)))
     {
         ir_add_error(ira, dest_type_value, buf_sprintf("expected integer type, found '%s'", buf_ptr(&dest_type->name)));
         return ira->codegen->invalid_instruction;
@@ -21830,10 +21921,24 @@ static IrInstruction *ir_analyze_instruction_truncate(IrAnalyze *ira, IrInstruct
     if (type_is_invalid(src_type))
         return ira->codegen->invalid_instruction;
 
-    if (src_type->id != ZigTypeIdInt &&
-        src_type->id != ZigTypeIdComptimeInt)
+    bool src_is_vector = src_type->id == ZigTypeIdVector;
+    ZigType *src_scalar_type = src_is_vector ? src_type->data.vector.elem_type : src_type;
+
+    if (!(src_type->id == ZigTypeIdInt ||
+          src_type->id == ZigTypeIdComptimeInt ||
+          (src_is_vector && src_scalar_type->id == ZigTypeIdInt)))
     {
         ir_add_error(ira, target, buf_sprintf("expected integer type, found '%s'", buf_ptr(&src_type->name)));
+        return ira->codegen->invalid_instruction;
+    }
+
+    bool is_vector = src_is_vector;
+    if ((dest_is_vector != src_is_vector) ||
+        (is_vector &&
+         dest_type->data.vector.len != src_type->data.vector.len))
+    {
+        ir_add_error(ira, target, buf_sprintf("incompatible vector conversion from '%s' to '%s'",
+            buf_ptr(&src_type->name), buf_ptr(&dest_type->name)));
         return ira->codegen->invalid_instruction;
     }
 
@@ -21847,22 +21952,49 @@ static IrInstruction *ir_analyze_instruction_truncate(IrAnalyze *ira, IrInstruct
             return ira->codegen->invalid_instruction;
 
         IrInstruction *result = ir_const(ira, &instruction->base, dest_type);
-        bigint_truncate(&result->value.data.x_bigint, &val->data.x_bigint,
-                dest_type->data.integral.bit_count, dest_type->data.integral.is_signed);
+        if (is_vector) {
+            result->value.data.x_array.data.s_none.elements =
+                allocate<ConstExprValue>(dest_type->data.vector.len);
+            for (uint32_t i = 0; i < dest_type->data.vector.len; i++) {
+                ConstExprValue *val = &target->value.data.x_array.data.s_none.elements[i];
+                ConstExprValue *result_val = &result->value.data.x_array.data.s_none.elements[i];
+                bigint_truncate(&result_val->data.x_bigint,
+                    &val->data.x_bigint,
+                    dest_scalar_type->data.integral.bit_count,
+                    dest_scalar_type->data.integral.is_signed);
+                result_val->special = ConstValSpecialStatic;
+                result_val->type = dest_scalar_type;
+            }
+        } else {
+            bigint_truncate(&result->value.data.x_bigint, &val->data.x_bigint,
+                    dest_type->data.integral.bit_count, dest_type->data.integral.is_signed);
+        }
         return result;
     }
 
-    if (src_type->data.integral.bit_count == 0 || dest_type->data.integral.bit_count == 0) {
+    if (src_scalar_type->data.integral.bit_count == 0 || dest_scalar_type->data.integral.bit_count == 0) {
         IrInstruction *result = ir_const(ira, &instruction->base, dest_type);
-        bigint_init_unsigned(&result->value.data.x_bigint, 0);
+        if (is_vector) {
+            result->value.data.x_array.data.s_none.elements =
+                allocate<ConstExprValue>(dest_type->data.vector.len);
+            for (uint32_t i = 0; i < dest_type->data.vector.len; i++) {
+                ConstExprValue *result_val = &result->value.data.x_array.data.s_none.elements[i];
+                bigint_init_unsigned(&result_val->data.x_bigint, 0);
+                result_val->special = ConstValSpecialStatic;
+                result_val->type = dest_scalar_type;
+            }
+        } else {
+            bigint_init_unsigned(&result->value.data.x_bigint, 0);
+        }
         return result;
     }
 
-    if (src_type->data.integral.is_signed != dest_type->data.integral.is_signed) {
+    if (src_scalar_type->data.integral.is_signed != dest_scalar_type->data.integral.is_signed) {
         const char *sign_str = dest_type->data.integral.is_signed ? "signed" : "unsigned";
-        ir_add_error(ira, target, buf_sprintf("expected %s integer type, found '%s'", sign_str, buf_ptr(&src_type->name)));
+        const char *vector_str = is_vector ? "vector" : "integer";
+        ir_add_error(ira, target, buf_sprintf("expected %s %s type, found '%s'", sign_str, vector_str, buf_ptr(&src_type->name)));
         return ira->codegen->invalid_instruction;
-    } else if (src_type->data.integral.bit_count < dest_type->data.integral.bit_count) {
+    } else if (src_scalar_type->data.integral.bit_count < dest_scalar_type->data.integral.bit_count) {
         ir_add_error(ira, target, buf_sprintf("type '%s' has fewer bits than destination type '%s'",
                     buf_ptr(&src_type->name), buf_ptr(&dest_type->name)));
         return ira->codegen->invalid_instruction;

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -849,6 +849,18 @@ static void ir_print_vector_type(IrPrint *irp, IrInstructionVectorType *instruct
     fprintf(irp->f, ")");
 }
 
+static void ir_print_shuffle_vector(IrPrint *irp, IrInstructionShuffleVector *instruction) {
+    fprintf(irp->f, "@shuffle(");
+    ir_print_other_instruction(irp, instruction->scalar_type);
+    fprintf(irp->f, ", ");
+    ir_print_other_instruction(irp, instruction->a);
+    fprintf(irp->f, ", ");
+    ir_print_other_instruction(irp, instruction->b);
+    fprintf(irp->f, ", ");
+    ir_print_other_instruction(irp, instruction->mask);
+    fprintf(irp->f, ")");
+}
+
 static void ir_print_bool_not(IrPrint *irp, IrInstructionBoolNot *instruction) {
     fprintf(irp->f, "! ");
     ir_print_other_instruction(irp, instruction->value);
@@ -1852,6 +1864,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdVectorType:
             ir_print_vector_type(irp, (IrInstructionVectorType *)instruction);
+            break;
+        case IrInstructionIdShuffleVector:
+            ir_print_shuffle_vector(irp, (IrInstructionShuffleVector *)instruction);
             break;
         case IrInstructionIdBoolNot:
             ir_print_bool_not(irp, (IrInstructionBoolNot *)instruction);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -421,6 +421,15 @@ static void ir_print_typeof(IrPrint *irp, IrInstructionTypeOf *instruction) {
     fprintf(irp->f, ")");
 }
 
+static void ir_print_bool_vector_to_bool(IrPrint *irp, IrInstructionBoolVectorToBool *instruction) {
+    fprintf(irp->f, "(");
+    ir_print_other_instruction(irp, instruction->vector);
+    if (instruction->is_any)
+        fprintf(irp->f, ").any()");
+    else
+        fprintf(irp->f, ").all()");
+}
+
 static void ir_print_field_ptr(IrPrint *irp, IrInstructionFieldPtr *instruction) {
     if (instruction->field_name_buffer) {
         fprintf(irp->f, "fieldptr ");
@@ -1717,6 +1726,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdTypeOf:
             ir_print_typeof(irp, (IrInstructionTypeOf *)instruction);
+            break;
+        case IrInstructionIdBoolVectorToBool:
+            ir_print_bool_vector_to_bool(irp, (IrInstructionBoolVectorToBool *)instruction);
             break;
         case IrInstructionIdFieldPtr:
             ir_print_field_ptr(irp, (IrInstructionFieldPtr *)instruction);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -377,7 +377,7 @@ static void ir_print_unreachable(IrPrint *irp, IrInstructionUnreachable *instruc
     fprintf(irp->f, "unreachable");
 }
 
-static void ir_print_elem_ptr(IrPrint *irp, IrInstructionElemPtr *instruction) {
+static void ir_print_elem_ptr(IrPrint *irp, IrInstructionElem *instruction) {
     fprintf(irp->f, "&");
     ir_print_other_instruction(irp, instruction->array_ptr);
     fprintf(irp->f, "[");
@@ -396,7 +396,18 @@ static void ir_print_return_ptr(IrPrint *irp, IrInstructionReturnPtr *instructio
     fprintf(irp->f, "@ReturnPtr");
 }
 
-static void ir_print_load_ptr(IrPrint *irp, IrInstructionLoadPtr *instruction) {
+static void ir_print_extractinsert(IrPrint *irp, IrInstructionExtractInsert *instruction) {
+    if (instruction->value) {
+        ir_print_other_instruction(irp, instruction->value);
+        fprintf(irp->f, " = ");
+    }
+    ir_print_other_instruction(irp, instruction->agg);
+    fprintf(irp->f, "[");
+    ir_print_other_instruction(irp, instruction->index);
+    fprintf(irp->f, "]");
+}
+
+static void ir_print_load_ptr(IrPrint *irp, IrInstructionLoad *instruction) {
     ir_print_other_instruction(irp, instruction->ptr);
     fprintf(irp->f, ".*");
 }
@@ -408,7 +419,7 @@ static void ir_print_load_ptr_gen(IrPrint *irp, IrInstructionLoadPtrGen *instruc
     ir_print_other_instruction(irp, instruction->result_loc);
 }
 
-static void ir_print_store_ptr(IrPrint *irp, IrInstructionStorePtr *instruction) {
+static void ir_print_store_ptr(IrPrint *irp, IrInstructionStore *instruction) {
     fprintf(irp->f, "*");
     ir_print_var_instruction(irp, instruction->ptr);
     fprintf(irp->f, " = ");
@@ -1706,8 +1717,8 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
         case IrInstructionIdUnreachable:
             ir_print_unreachable(irp, (IrInstructionUnreachable *)instruction);
             break;
-        case IrInstructionIdElemPtr:
-            ir_print_elem_ptr(irp, (IrInstructionElemPtr *)instruction);
+        case IrInstructionIdElem:
+            ir_print_elem_ptr(irp, (IrInstructionElem *)instruction);
             break;
         case IrInstructionIdVarPtr:
             ir_print_var_ptr(irp, (IrInstructionVarPtr *)instruction);
@@ -1715,14 +1726,17 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
         case IrInstructionIdReturnPtr:
             ir_print_return_ptr(irp, (IrInstructionReturnPtr *)instruction);
             break;
-        case IrInstructionIdLoadPtr:
-            ir_print_load_ptr(irp, (IrInstructionLoadPtr *)instruction);
+        case IrInstructionIdExtractInsert:
+            ir_print_extractinsert(irp, (IrInstructionExtractInsert *)instruction);
+            break;
+        case IrInstructionIdLoad:
+            ir_print_load_ptr(irp, (IrInstructionLoad *)instruction);
             break;
         case IrInstructionIdLoadPtrGen:
             ir_print_load_ptr_gen(irp, (IrInstructionLoadPtrGen *)instruction);
             break;
-        case IrInstructionIdStorePtr:
-            ir_print_store_ptr(irp, (IrInstructionStorePtr *)instruction);
+        case IrInstructionIdStore:
+            ir_print_store_ptr(irp, (IrInstructionStore *)instruction);
             break;
         case IrInstructionIdTypeOf:
             ir_print_typeof(irp, (IrInstructionTypeOf *)instruction);

--- a/std/math/fma.zig
+++ b/std/math/fma.zig
@@ -3,6 +3,7 @@
 //
 // https://git.musl-libc.org/cgit/musl/tree/src/math/fmaf.c
 // https://git.musl-libc.org/cgit/musl/tree/src/math/fma.c
+// https://git.musl-libc.org/cgit/musl/tree/src/math/fmal.c
 
 const std = @import("../std.zig");
 const math = std.math;
@@ -13,6 +14,7 @@ pub fn fma(comptime T: type, x: T, y: T, z: T) T {
     return switch (T) {
         f32 => fma32(x, y, z),
         f64 => fma64(x, y, z),
+        f128 => fma128(x, y, z),
         else => @compileError("fma not implemented for " ++ @typeName(T)),
     };
 }

--- a/test/stage1/behavior/byteswap.zig
+++ b/test/stage1/behavior/byteswap.zig
@@ -6,6 +6,11 @@ test "@byteSwap" {
     testByteSwap();
 }
 
+test "@byteSwap on vectors" {
+    comptime testVectorByteSwap();
+    testVectorByteSwap();
+}
+
 fn testByteSwap() void {
     expect(@byteSwap(u0, 0) == 0);
     expect(@byteSwap(u8, 0x12) == 0x12);
@@ -29,4 +34,10 @@ fn testByteSwap() void {
     expect(@byteSwap(i64, @bitCast(i64, u64(0x123456789abcdef1))) == @bitCast(i64, u64(0xf1debc9a78563412)));
     expect(@byteSwap(i128, @bitCast(i128, u128(0x123456789abcdef11121314151617181))) ==
         @bitCast(i128, u128(0x8171615141312111f1debc9a78563412)));
+}
+
+fn testVectorByteSwap() void {
+    expect((@byteSwap(u8, @Vector(2, u8)([2]u8{0x12, 0x13})) == @Vector(2, u8)([2]u8{0x12, 0x13})).all);
+    expect((@byteSwap(u16, @Vector(2, u16)([2]u16{0x1234, 0x2345})) == @Vector(2, u16)([2]u16{0x3412, 0x4523})).all);
+    expect((@byteSwap(u24, @Vector(2, u24)([2]u24{0x123456, 0x234567})) == @Vector(2, u24)([2]u24{0x563412, 0x674523})).all);
 }

--- a/test/stage1/behavior/shuffle.zig
+++ b/test/stage1/behavior/shuffle.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+const mem = std.mem;
+const expect = std.testing.expect;
+
+test "@shuffle" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
+            var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
+            const mask: @Vector(4, i32) = [4]i32{ 0, ~i32(2), 3, ~i32(3)};
+            var res = @shuffle(i32, v, x, mask);
+            expect(mem.eql(i32, ([4]i32)(res), [4]i32{ 2147483647, 3, 40, 4 }));
+
+            // Implicit cast from array (of mask)
+            res = @shuffle(i32, v, x, [4]i32{ 0, ~i32(2), 3, ~i32(3)});
+            expect(mem.eql(i32, ([4]i32)(res), [4]i32{ 2147483647, 3, 40, 4 }));
+
+            // Undefined
+            const mask2: @Vector(4, i32) = [4]i32{ 3, 1, 2, 0};
+            res = @shuffle(i32, v, undefined, mask2);
+            expect(mem.eql(i32, ([4]i32)(res), [4]i32{ 40, -2, 30, 2147483647}));
+
+            // Upcasting of b
+            var v2: @Vector(2, i32) = [2]i32{ 2147483647, undefined};
+            const mask3: @Vector(4, i32) = [4]i32{ ~i32(0), 2, ~i32(0), 3};
+            res = @shuffle(i32, x, v2, mask3);
+            expect(mem.eql(i32, ([4]i32)(res), [4]i32{ 2147483647, 3, 2147483647, 4 }));
+
+            // Upcasting of a
+            var v3: @Vector(2, i32) = [2]i32{ 2147483647, -2};
+            const mask4: @Vector(4, i32) = [4]i32{ 0, ~i32(2), 1, ~i32(3)};
+            res = @shuffle(i32, v3, x, mask4);
+            expect(mem.eql(i32, ([4]i32)(res), [4]i32{ 2147483647, 3, -2, 4 }));
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -74,3 +74,17 @@ test "implicit cast vector to array" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "vector shuffle" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
+            var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
+            const mask: @Vector(4, i32) = [4]i32{ 0, ~i32(2), 3, ~i32(3)};
+            var res = @shuffle(i32, v, x, mask);
+            expect(mem.eql(i32, ([4]i32)(res), [4]i32{ 2147483647, 3, 40, 4 }));
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -138,3 +138,58 @@ test "vector bin compares with .all() and any()" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "vector upcast" {
+    const S = struct {
+        fn doTheTest() void {
+            {
+              const v: @Vector(4, i16) = [4]i16{ 21, -2, 30, 40};
+              const x: @Vector(4, i32) = @Vector(4, i32)(v);
+              expect((x == @Vector(4, i32)([4]i32{ 21, -2, 30, 40})).all);
+              expect(x[0] == 21);
+              expect(x[1] == -2);
+              expect(x[2] == 30);
+              expect(x[3] == 40);
+            }
+
+            {
+              const v: @Vector(4, u16) = [4]u16{ 21, 2, 30, 40};
+              const x: @Vector(4, u32) = @Vector(4, u32)(v);
+              expect((x == @Vector(4, u32)([4]u32{ 21, 2, 30, 40})).all);
+              expect(x[0] == 21);
+              expect(x[1] == 2);
+              expect(x[2] == 30);
+              expect(x[3] == 40);
+            }
+
+            {
+              const v: @Vector(4, f16) = [4]f16{ 21, -2, 30, 40};
+              const x: @Vector(4, f32) = @Vector(4, f32)(v);
+              expect((x == @Vector(4, f32)([4]f32{ 21, -2, 30, 40})).all);
+              expect(x[0] == 21);
+              expect(x[1] == -2);
+              expect(x[2] == 30);
+              expect(x[3] == 40);
+            }
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
+
+test "vector truncate" {
+    const S = struct {
+        fn doTheTest() void {
+            const v: @Vector(4, i32) = [4]i32{ 21, -2, 30, 40};
+            const x: @Vector(4, i16) = @truncate(@Vector(4, i16), v);
+            expect((x == @Vector(4, i16)([4]i16{ 21, -2, 30, 40})).all);
+            expect(x[0] == 21);
+            expect(x[1] == -2);
+            expect(x[2] == 30);
+            expect(x[3] == 40);
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -88,3 +88,53 @@ test "vector shuffle" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "implicit cast vector to array - bool" {
+    const S = struct {
+        fn doTheTest() void {
+            const a: @Vector(4, bool) = [_]bool{ true, false, true, false };
+            const result_array: [4]bool = a;
+            expect(mem.eql(bool, result_array, [4]bool{ true, false, true, false }));
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
+test "vector bin compares without mem.eql" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
+            var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 30, 4 };
+            expect(mem.eql(bool, ([4]bool)(v == x), [4]bool{ false, false,  true, false}));
+            expect(mem.eql(bool, ([4]bool)(v != x), [4]bool{  true,  true, false,  true}));
+            expect(mem.eql(bool, ([4]bool)(v  < x), [4]bool{ false,  true, false, false}));
+            expect(mem.eql(bool, ([4]bool)(v  > x), [4]bool{  true, false, false,  true}));
+            expect(mem.eql(bool, ([4]bool)(v <= x), [4]bool{ false,  true,  true, false}));
+            expect(mem.eql(bool, ([4]bool)(v >= x), [4]bool{  true, false,  true,  true}));
+        }
+    };
+    // FIXME vector bools have one-bit width, while array bools have 1 byte width,
+    // but what this test is meant to test for is passing.
+    //S.doTheTest();
+    comptime S.doTheTest();
+}
+
+test "vector bin compares with .all() and any()" {
+    const S = struct {
+        fn doTheTest() void {
+            comptime var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
+            comptime var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 30, 4 };
+            expect(((v == x) == @Vector(4, bool)([4]bool{ false, false,  true, false})).all);
+            expect(((v != x) == @Vector(4, bool)([4]bool{  true,  true, false,  true})).all);
+            expect(((v  < x) == @Vector(4, bool)([4]bool{ false,  true, false, false})).all);
+            expect(((v  > x) == @Vector(4, bool)([4]bool{  true, false, false,  true})).all);
+            expect(((v <= x) == @Vector(4, bool)([4]bool{ false,  true,  true, false})).all);
+            expect(((v >= x) == @Vector(4, bool)([4]bool{  true, false,  true,  true})).all);
+            expect(@Vector(4, bool)([4]bool{ false, false, false, false}).any == false);
+            expect(@Vector(4, bool)([4]bool{ true, false, false, false}).any);
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/vector_access.zig
+++ b/test/stage1/behavior/vector_access.zig
@@ -1,0 +1,37 @@
+const expect = @import("std").testing.expect;
+
+test "vector access elements - load" {
+    {
+        var a: @Vector(4, i32) = [_]i32{ 1, 2, 3, undefined };
+        expect(a[2] == 3);
+        expect(a[1] == i32(2));
+        expect(3 == a[2]);
+    }
+
+    comptime {
+        comptime var a: @Vector(4, i32) = [_]i32{ 1, 2, 3, undefined };
+        expect(a[0] == 1);
+        expect(a[1] == i32(2));
+        expect(3 == a[2]);
+    }
+}
+
+
+test "vector access elements - store" {
+    {
+        var a: @Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
+        a[2] = 1;
+        expect(a[1] == 5);
+        expect(a[2] == i32(1));
+        a[3] = -364;
+        expect(-364 == a[3]);
+    }
+
+    comptime {
+        comptime var a: @Vector(4, i32) = [_]i32{ 1, 2, 3, undefined };
+        a[2] = 5;
+        expect(a[2] == i32(5));
+        a[3] = -364;
+        expect(-364 == a[3]);
+    }
+}


### PR DESCRIPTION
There are some rough parts here:

 * should shuffle a and b arguments implicitly cast from arrays? (I think not, as it wouldn't be useful, and it would have higher alignment requirements than regular arrays).
 * the `all()` and `any()` builtin functions on vectors of bools does not take parentheses. (We can open a tracking bug for this).
 * no compiler error tests for the out-of-bounds vector access.

But what is here works, and perhaps should be merged to remove merge pain. I plan on doing much more work, and getting some MVP/POC stuff out soon, to show how useful this stuff is.

Again, review one patch at a time. The github review interface does not really support that, which is a shame.