### PR TITLE
same_global_refs=false in ir_analyze_array_mult - closes #2916

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -14597,7 +14597,7 @@ static IrInstruction *ir_analyze_array_mult(IrAnalyze *ira, IrInstructionBinOp *
     for (uint64_t x = 0; x < mult_amt; x += 1) {
         for (uint64_t y = 0; y < old_array_len; y += 1) {
             copy_const_val(&out_val->data.x_array.data.s_none.elements[i],
-                &array_val->data.x_array.data.s_none.elements[y], true);
+                &array_val->data.x_array.data.s_none.elements[y], false);
             i += 1;
         }
     }


### PR DESCRIPTION
In this reduction `bad()` isolates the issue behaviour -- an llvm global constant is created with `.num` values `{ 13, 13, 13 }` and **desired** values are `{ 11, 12, 13 }`.

#### reduction.zig
```zig
const Foo = struct {
    num: u64,
};  
    
export fn bad() void {
    var rt_bad = comptime block_bad: {
        var ct_bad = [_]Foo{ Foo{ .num = 11 }} ** 3;
        ct_bad[1].num = 12;
        ct_bad[2].num = 13;
        break :block_bad ct_bad;
    };
}
        
export fn good() void { 
    var rt_good = comptime block_good: {
        var ct_good = [_]Foo{ Foo{ .num = 11 }, Foo{ .num = 11 }, Foo{ .num = 11 }};
        ct_good[1].num = 12;
        ct_good[2].num = 13;
        break :block_good ct_good;
    }; 
}       
        
const builtin = @import("builtin");
pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
    while (true) {}
}
```

#### llvm-ir (master branch)
- global `@1` is bad
- global `@2` is good
```ir
@1 = internal unnamed_addr constant [3 x %Foo] [%Foo { i64 13 }, %Foo { i64 13 }, %Foo { i64 13 }], align 8
@2 = internal unnamed_addr constant [3 x %Foo] [%Foo { i64 11 }, %Foo { i64 12 }, %Foo { i64 13 }], align 8
```
#### llvm-ir (PR branch)
```ir
@1 = internal unnamed_addr constant [3 x %Foo] [%Foo { i64 11 }, %Foo { i64 12 }, %Foo { i64 13 }], align 8
@2 = internal unnamed_addr constant [3 x %Foo] [%Foo { i64 11 }, %Foo { i64 12 }, %Foo { i64 13 }], align 8
```