### PR TITLE
align src for IrInstructionArrayToVector

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5362,7 +5362,8 @@ static LLVMValueRef ir_render_vector_to_array(CodeGen *g, IrExecutable *executab
     LLVMValueRef vector = ir_llvm_value(g, instruction->vector);
     LLVMValueRef casted_ptr = LLVMBuildBitCast(g->builder, result_loc,
             LLVMPointerType(get_llvm_type(g, instruction->vector->value.type), 0), "");
-    gen_store_untyped(g, vector, casted_ptr, get_ptr_align(g, instruction->result_loc->value.type), false);
+    uint32_t alignment = get_ptr_align(g, instruction->result_loc->value.type);
+    gen_store_untyped(g, vector, casted_ptr, alignment, false);
     return result_loc;
 }
 
@@ -5375,7 +5376,10 @@ static LLVMValueRef ir_render_array_to_vector(CodeGen *g, IrExecutable *executab
     LLVMValueRef array_ptr = ir_llvm_value(g, instruction->array);
     LLVMValueRef casted_ptr = LLVMBuildBitCast(g->builder, array_ptr,
             LLVMPointerType(get_llvm_type(g, vector_type), 0), "");
-    return gen_load_untyped(g, casted_ptr, 0, false, "");
+    ZigType *array_type = instruction->array->value.type;
+    assert(array_type->id == ZigTypeIdArray);
+    uint32_t alignment = get_abi_alignment(g, array_type->data.array.child_type);
+    return gen_load_untyped(g, casted_ptr, alignment, false, "");
 }
 
 static LLVMValueRef ir_render_assert_zero(CodeGen *g, IrExecutable *executable,


### PR DESCRIPTION
closes #2942

#### reduction.zig - executable segfaults
```zig
pub fn main() void {
    var foo: f32 = 3.14;
    var arr = [4]f32 { foo, 1.5, 0.0, 0.0 };
    var vec: @Vector(4, f32) = arr;
}
```

- what follows is llvm-ir comparison of broken vs. fixed
- hint: last load operation uses incorrect alignment 16

#### llvm-ir diff
```diff
--- broken.ll	2019-07-24 13:13:00.467787038 -0400
+++ fixed.ll	2019-07-24 13:13:04.055156465 -0400
@@ -16,7 +16,7 @@
   store float 0.000000e+00, float* %4, align 4, !dbg !11376
   call void @llvm.dbg.declare(metadata [4 x float]* %arr, metadata !11368, metadata !DIExpression()), !dbg !11377
   %5 = bitcast [4 x float]* %arr to <4 x float>*, !dbg !11378
-  %6 = load <4 x float>, <4 x float>* %5, align 16, !dbg !11378
+  %6 = load <4 x float>, <4 x float>* %5, align 4, !dbg !11378
   store <4 x float> %6, <4 x float>* %vec, align 16, !dbg !11379
   call void @llvm.dbg.declare(metadata <4 x float>* %vec, metadata !11370, metadata !DIExpression()), !dbg !11379
   ret void, !dbg !11380
```

#### broken llvm-ir
```ll
define internal fastcc void @main.0() unnamed_addr #0 !dbg !11362 {
Entry:
  %foo = alloca float, align 4
  %arr = alloca [4 x float], align 4
  %vec = alloca <4 x float>, align 16
  store float 0x40091EB860000000, float* %foo, align 4, !dbg !11372
  call void @llvm.dbg.declare(metadata float* %foo, metadata !11365, metadata !DIExpression()), !dbg !11372
  %0 = getelementptr inbounds [4 x float], [4 x float]* %arr, i64 0, i64 0, !dbg !11373
  %1 = load float, float* %foo, align 4, !dbg !11373
  store float %1, float* %0, align 4, !dbg !11373
  %2 = getelementptr inbounds [4 x float], [4 x float]* %arr, i64 0, i64 1, !dbg !11374
  %3 = getelementptr inbounds [4 x float], [4 x float]* %arr, i64 0, i64 2, !dbg !11375
  %4 = getelementptr inbounds [4 x float], [4 x float]* %arr, i64 0, i64 3, !dbg !11376
  store float 1.500000e+00, float* %2, align 4, !dbg !11374
  store float 0.000000e+00, float* %3, align 4, !dbg !11375
  store float 0.000000e+00, float* %4, align 4, !dbg !11376
  call void @llvm.dbg.declare(metadata [4 x float]* %arr, metadata !11368, metadata !DIExpression()), !dbg !11377
  %5 = bitcast [4 x float]* %arr to <4 x float>*, !dbg !11378
  %6 = load <4 x float>, <4 x float>* %5, align 16, !dbg !11378
  store <4 x float> %6, <4 x float>* %vec, align 16, !dbg !11379
  call void @llvm.dbg.declare(metadata <4 x float>* %vec, metadata !11370, metadata !DIExpression()), !dbg !11379
  ret void, !dbg !11380
}
```
#### fixed llvm-ir
```ll
define internal fastcc void @main.0() unnamed_addr #0 !dbg !11362 {
Entry:
  %foo = alloca float, align 4
  %arr = alloca [4 x float], align 4
  %vec = alloca <4 x float>, align 16
  store float 0x40091EB860000000, float* %foo, align 4, !dbg !11372
  call void @llvm.dbg.declare(metadata float* %foo, metadata !11365, metadata !DIExpression()), !dbg !11372
  %0 = getelementptr inbounds [4 x float], [4 x float]* %arr, i64 0, i64 0, !dbg !11373
  %1 = load float, float* %foo, align 4, !dbg !11373
  store float %1, float* %0, align 4, !dbg !11373
  %2 = getelementptr inbounds [4 x float], [4 x float]* %arr, i64 0, i64 1, !dbg !11374
  %3 = getelementptr inbounds [4 x float], [4 x float]* %arr, i64 0, i64 2, !dbg !11375
  %4 = getelementptr inbounds [4 x float], [4 x float]* %arr, i64 0, i64 3, !dbg !11376
  store float 1.500000e+00, float* %2, align 4, !dbg !11374
  store float 0.000000e+00, float* %3, align 4, !dbg !11375
  store float 0.000000e+00, float* %4, align 4, !dbg !11376
  call void @llvm.dbg.declare(metadata [4 x float]* %arr, metadata !11368, metadata !DIExpression()), !dbg !11377
  %5 = bitcast [4 x float]* %arr to <4 x float>*, !dbg !11378
  %6 = load <4 x float>, <4 x float>* %5, align 4, !dbg !11378
  store <4 x float> %6, <4 x float>* %vec, align 16, !dbg !11379
  call void @llvm.dbg.declare(metadata <4 x float>* %vec, metadata !11370, metadata !DIExpression()), !dbg !11379
  ret void, !dbg !11380
}
```

