### PR TITLE
fix std.fmt to handle std.SegmentedList

### DIFF
--- a/std/fmt.zig
+++ b/std/fmt.zig
@@ -425,6 +425,9 @@ pub fn formatType(
             if (info.child == u8) {
                 return formatText(value, fmt, options, context, Errors, output);
             }
+            if (value.len == 0) {
+                return format(context, Errors, output, "[0]{}", @typeName(T.Child));
+            }
             return format(context, Errors, output, "{}@{x}", @typeName(T.Child), @ptrToInt(&value));
         },
         .Fn => {


### PR DESCRIPTION
- add guards for use of prealloc_exp in SegmentedList
- define prealloc_exp even when invalid because std.fmt comptime
  triggers lazy-init
- fix std.fmt to print arrays of length 0 as style "[0]<typename>"
  because `<typename>@address` is n/a without address

This reduction was chosen because issue manifested for use-case from `ntgg` getting an error formatting AST tree (which uses `SegmentedList`).

#### reduction.zig
```zig
const std = @import("std");

pub fn main() !void {
    const source = 
        \\const warn = @import("std").debug.warn;
        \\pub fn main() void {
        \\    warn("hello world\n");
        \\}
        \\
    ;

    const tree = try std.zig.parse(std.heap.direct_allocator, source); 
    std.debug.warn("{}\n", tree);
}
```

#### broken output: `zig run reduction.zig`
```
/opt/zig/lib/zig/std/debug.zig:206:14: error: unable to evaluate constant expression
    if (!ok) unreachable; // assertion failure
             ^
/opt/zig/lib/zig/std/segmented_list.zig:82:19: note: called from here
            assert(prealloc_item_count != 0);
                  ^
/opt/zig/lib/zig/std/segmented_list.zig:80:35: note: called from here
        const prealloc_exp = blk: {
                                  ^
/opt/zig/lib/zig/std/segmented_list.zig:160:59: error: expected type 'u6', found 'usize'
            if (new_capacity <= usize(1) << (prealloc_exp + self.dynamic_segments.len)) {
                                                          ^
/opt/zig/lib/zig/std/segmented_list.zig:160:59: error: expected type 'u6', found 'usize'
            if (new_capacity <= usize(1) << (prealloc_exp + self.dynamic_segments.len)) {
                                                          ^
/opt/zig/lib/zig/std/segmented_list.zig:160:59: error: expected type 'u6', found 'usize'
            if (new_capacity <= usize(1) << (prealloc_exp + self.dynamic_segments.len)) {
                                                          ^
```

#### fixed output: `zig run reduction.zig`
```
Tree{ .source = const warn = @import("std").debug.warn;
pub fn main() void {
    warn("hello world\n");
}
, .tokens = std.segmented_list.SegmentedList(std.zig.tokenizer.Token,64){ .prealloc_segment = Token@10ff9a028, .dynamic_segments = [*]std.zig.tokenizer.Token@0, .allocator = Allocator{ .reallocFn = fn(*std.mem.Allocator, []u8, u29, usize, u29) std.mem.Error![]u8@10fecf180, .shrinkFn = fn(*std.mem.Allocator, []u8, u29, usize, u29) []u8@10fecf360 }, .len = 26 }, .root_node = Root{ .base = Node{ .id = Id.Root }, .doc_comments = null, .decls = std.segmented_list.SegmentedList(*std.zig.ast.Node,4){ .prealloc_segment = *std.zig.ast.Node@10ff9a6a8, .dynamic_segments = [*]*std.zig.ast.Node@0, .allocator = Allocator{ ... }, .len = 2 }, .eof_token = 25 }, .arena_allocator = ArenaAllocator{ .allocator = Allocator{ .reallocFn = fn(*std.mem.Allocator, []u8, u29, usize, u29) std.mem.Error![]u8@10fecf180, .shrinkFn = fn(*std.mem.Allocator, []u8, u29, usize, u29) []u8@10fecf360 }, .child_allocator = Allocator{ .reallocFn = fn(*std.mem.Allocator, []u8, u29, usize, u29) std.mem.Error![]u8@10feb5d80, .shrinkFn = fn(*std.mem.Allocator, []u8, u29, usize, u29) []u8@10feb5fd0 }, .buffer_list = std.linked_list.SinglyLinkedList([]u8){ .first = Node{ ... } }, .end_index = 2568 }, .errors = std.segmented_list.SegmentedList(std.zig.ast.Error,0){ .prealloc_segment = [0]Error, .dynamic_segments = [*]std.zig.ast.Error@0, .allocator = Allocator{ .reallocFn = fn(*std.mem.Allocator, []u8, u29, usize, u29) std.mem.Error![]u8@10fecf180, .shrinkFn = fn(*std.mem.Allocator, []u8, u29, usize, u29) []u8@10fecf360 }, .len = 0 } }
```