### PR TITLE
avoid a register copy when fetching the stack pointer in _start

### DIFF
--- a/std/special/start.zig
+++ b/std/special/start.zig
@@ -35,13 +35,13 @@ nakedcc fn _start() noreturn {
 
     switch (builtin.arch) {
         .x86_64 => {
-            argc_ptr = asm ("lea (%%rsp), %[argc]"
-                : [argc] "=r" (-> [*]usize)
+            argc_ptr = asm (""
+                : [argc] "={rsp}" (-> [*]usize)
             );
         },
         .i386 => {
-            argc_ptr = asm ("lea (%%esp), %[argc]"
-                : [argc] "=r" (-> [*]usize)
+            argc_ptr = asm (""
+                : [argc] "={esp}" (-> [*]usize)
             );
         },
         .aarch64, .aarch64_be => {


### PR DESCRIPTION
Before:
```
~$ objdump --disassemble=_start test0

test0:     file format elf64-x86-64


Disassembly of section .text:

0000000000201200 <_start>:
  201200:       48 8d 04 24             lea    (%rsp),%rax
  201204:       48 89 05 15 0e 00 00    mov    %rax,0xe15(%rip)        # 202020 <argc_ptr>
  20120b:       e8 00 00 00 00          callq  201210 <std.special.posixCallMainAndExit>
```

After:
```
~$ objdump --disassemble=_start test1

test1:     file format elf64-x86-64


Disassembly of section .text:

0000000000201200 <_start>:
  201200:       48 89 25 19 0e 00 00    mov    %rsp,0xe19(%rip)        # 202020 <argc_ptr>
  201207:       e8 04 00 00 00          callq  201210 <std.special.posixCallMainAndExit>
```