### PR TITLE
std/build.zig: fix stack checking option

### DIFF
--- a/std/build.zig
+++ b/std/build.zig
@@ -1802,7 +1802,7 @@ pub const LibExeObjStep = struct {
             try zig_args.append("--bundle-compiler-rt");
         }
         if (self.disable_stack_probing) {
-            try zig_args.append("--disable-stack-probing");
+            try zig_args.append("-fno-stack-check");
         }
 
         switch (self.target) {


### PR DESCRIPTION
fix regression in 2c0280ba085893984007706fb40c7b291f43074d