### PR TITLE
fix std.rb.Node.getParent to return optional

### DIFF
--- a/std/rb.zig
+++ b/std/rb.zig
@@ -93,7 +93,8 @@ pub const Node = struct {
         comptime {
             assert(@alignOf(*Node) >= 2);
         }
-        return @intToPtr(*Node, node.parent_and_color & ~mask);
+        const maybe_ptr = node.parent_and_color & ~mask;
+        return if (maybe_ptr == 0) null else @intToPtr(*Node, maybe_ptr);
     }
 
     fn setColor(node: *Node, color: Color) void {

--- a/std/std.zig
+++ b/std/std.zig
@@ -105,6 +105,7 @@ test "std" {
     _ = @import("packed_int_array.zig");
     _ = @import("priority_queue.zig");
     _ = @import("rand.zig");
+    _ = @import("rb.zig");
     _ = @import("sort.zig");
     _ = @import("testing.zig");
     _ = @import("thread.zig");


### PR DESCRIPTION
- handle case when pointer is null **before** `@intToPtr()`
- added `std.rb` to `zig build test-std` suite (somehow it was missing)

closes #2962