### PR TITLE
Allow Zig programs to implement their own startup (_start) for ELF ex…

### DIFF
--- a/std/special/start.zig
+++ b/std/special/start.zig
@@ -20,7 +20,7 @@ comptime {
     } else if (is_wasm and builtin.os == .freestanding) {
         @export("_start", wasm_freestanding_start, .Strong);
     } else {
-        @export("_start", _start, .Strong);
+        if (!@hasDecl(root, "_start")) @export("_start", _start, .Strong);
     }
 }
 


### PR DESCRIPTION
…ecutables.
```
/home/shawn/git/zig-simd/build/lib/zig/std/special/start.zig:23:40: error: exported symbol collision: '_start'
        @export("_start", _start, .Strong);
        ^
/home/shawn/git/zig-simd/build/d.zig:1:1: note: other symbol is here
pub export fn _start() void {
^
/home/shawn/git/zig-simd/build/lib/zig/std/special/start.zig:124:35: error: root source file has no member called 'main'
    switch (@typeInfo(@typeOf(root.main).ReturnType)) {
```
----

One line!