### PR TITLE
add arm64 CI

### DIFF
--- a/ci/arm/gitlab-ci.yml
+++ b/ci/arm/gitlab-ci.yml
@@ -1,0 +1,10 @@
+linux-arm64:
+  script:
+    - uname -a
+    - lscpu
+    - free -h
+    - mkdir build
+    - cd build
+    - PATH=/usr/lib/ccache:$PATH cmake .. -DCMAKE_BUILD_TYPE=Release -GNinja
+    - ninja install
+    - ./zig build --build-file ../build.zig test


### PR DESCRIPTION
I already have this set up and working with my own VPS for arm64 testing
at https://gitlab.com/shawnl1/zig/-/jobs
But that is a fork of zig, because I cannot setup the web hook, so that
it will trigger on commits (to any branch) and pull requests and also
show up in the PR interface with the other CIs.

So this also requires some manual coordination with Andrew

https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/github_integration.html

Andrew could also set up an official gitlab mirror, and then just authenticate the arm64 CI runner I've set up. That would probably be the easiest, using those instructions, and then PMing me with the authtication token:

https://docs.gitlab.com/runner/register/index.html.

> Please enter the gitlab-ci token for this runner