### PR TITLE
mingw improvements

### DIFF
--- a/src/os.cpp
+++ b/src/os.cpp
@@ -1130,7 +1130,7 @@ Error os_get_cwd(Buf *out_cwd) {
 bool ATTRIBUTE_MUST_USE os_is_cygwin_pty(int fd) {
 #if defined(ZIG_OS_WINDOWS)
     HANDLE handle = (HANDLE)_get_osfhandle(fd);
-    
+
     // Cygwin/msys's pty is a pipe.
     if (handle == INVALID_HANDLE_VALUE || GetFileType(handle) != FILE_TYPE_PIPE) {
         return false;
@@ -1138,7 +1138,7 @@ bool ATTRIBUTE_MUST_USE os_is_cygwin_pty(int fd) {
 
     int size = sizeof(FILE_NAME_INFO) + sizeof(WCHAR) * MAX_PATH;
     WCHAR *p = NULL;
-    
+
     FILE_NAME_INFO *nameinfo = (FILE_NAME_INFO *)allocate<char>(size);
     if (nameinfo == NULL) {
         return false;
@@ -1179,13 +1179,13 @@ bool ATTRIBUTE_MUST_USE os_is_cygwin_pty(int fd) {
     free(nameinfo);
     return (p != NULL);
 #else
-    return false
+    return false;
 #endif
 }
 
 bool os_stderr_tty(void) {
 #if defined(ZIG_OS_WINDOWS)
-    return _isatty(_fileno(stderr)) != 0 || os_is_cygwin_pty(_fileno(stderr));
+    return _isatty(fileno(stderr)) != 0 || os_is_cygwin_pty(fileno(stderr));
 #elif defined(ZIG_OS_POSIX)
     return isatty(STDERR_FILENO) != 0;
 #else

--- a/src/os.hpp
+++ b/src/os.hpp
@@ -89,6 +89,11 @@ struct Termination {
 #define OsFile int
 #endif
 
+#if defined(ZIG_OS_WINDOWS)
+#undef fileno
+#define fileno _fileno
+#endif
+
 struct OsTimeStamp {
     uint64_t sec;
     uint64_t nsec;

--- a/src/os.hpp
+++ b/src/os.hpp
@@ -11,6 +11,7 @@
 #include "list.hpp"
 #include "buffer.hpp"
 #include "error.hpp"
+#include "target.hpp"
 #include "zig_llvm.h"
 #include "windows_sdk.h"
 
@@ -151,6 +152,8 @@ Error ATTRIBUTE_MUST_USE os_get_app_data_dir(Buf *out_path, const char *appname)
 Error ATTRIBUTE_MUST_USE os_get_win32_ucrt_include_path(ZigWindowsSDK *sdk, Buf *output_buf);
 Error ATTRIBUTE_MUST_USE os_get_win32_ucrt_lib_path(ZigWindowsSDK *sdk, Buf *output_buf, ZigLLVM_ArchType platform_type);
 Error ATTRIBUTE_MUST_USE os_get_win32_kern32_path(ZigWindowsSDK *sdk, Buf *output_buf, ZigLLVM_ArchType platform_type);
+
+bool ATTRIBUTE_MUST_USE os_is_cygwin_pty(int fd);
 
 Error ATTRIBUTE_MUST_USE os_self_exe_shared_libs(ZigList<Buf *> &paths);
 

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -1507,7 +1507,7 @@ bool target_is_single_threaded(const ZigTarget *target) {
 static ZigLLVM_EnvironmentType target_get_win32_abi() {
     FILE* files[] = { stdin, stdout, stderr, nullptr };
     for (int i = 0; files[i] != nullptr; i++) {
-        if (os_is_cygwin_pty(_fileno(files[i]))) {
+        if (os_is_cygwin_pty(fileno(files[i]))) {
             return ZigLLVM_GNU;
         }
     }

--- a/std/os/windows.zig
+++ b/std/os/windows.zig
@@ -827,12 +827,11 @@ pub fn sliceToPrefixedSuffixedFileW(s: []const u8, comptime suffix: []const u16)
     // > converting the name to an NT-style name, except when using the "\\?\"
     // > prefix as detailed in the following sections.
     // from https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#maximum-path-length-limitation
-    // Because we want the larger maximum path length for absolute paths, we
-    // disallow forward slashes in zig std lib file functions on Windows.
     for (s) |byte| {
         switch (byte) {
             '*', '?', '"', '<', '>', '|' => return error.BadPathName,
-            else => if (builtin.abi == .msvc and byte == '/') return error.BadPathName,
+            '/' => if (builtin.abi == .msvc) return error.BadPathName,
+            else => {},
         }
     }
     const start_index = if (mem.startsWith(u8, s, "\\\\") or !std.fs.path.isAbsolute(s)) 0 else blk: {


### PR DESCRIPTION
* ~~adds a CI job for MinGW/MSYS2 that builds and runs tests only~~
  * ~~no artifacts are published to the download page; see next point~~
* adds runtime (for the zig compiler) detection of C ABI on windows
  * if `stdin`, `stdout`, or `stderr` are cygwin/msys pty's the ABI is assumed to be GNU
* accepts `/` in file paths when targeting non-msvc
  * `\` is still the actual path seperator as passing `/` causes errors with the windows API