### PR TITLE
Check if /dev/urandom is a character device

### DIFF
--- a/std/os.zig
+++ b/std/os.zig
@@ -135,7 +135,7 @@ fn getRandomBytesDevURandom(buf: []u8) !void {
 
     const st = try fstat(fd);
     if (!system.S_ISCHR(st.mode)) {
-        return error.Unexpected;
+        return error.NoDevice;
     }
 
     const stream = &std.fs.File.openHandle(fd).inStream().stream;

--- a/std/os.zig
+++ b/std/os.zig
@@ -134,7 +134,7 @@ fn getRandomBytesDevURandom(buf: []u8) !void {
     defer close(fd);
 
     const st = try fstat(fd);
-    if (!system.S_ISCHR(st.mode)) {
+    if (!S_ISCHR(st.mode)) {
         return error.NoDevice;
     }
 

--- a/std/os.zig
+++ b/std/os.zig
@@ -133,6 +133,11 @@ fn getRandomBytesDevURandom(buf: []u8) !void {
     const fd = try openC(c"/dev/urandom", O_RDONLY | O_CLOEXEC, 0);
     defer close(fd);
 
+    const st = try fstat(fd);
+    if (!S_ISCHR(st.mode)) {
+        return OpenError.Unexpected;
+    }
+
     const stream = &std.fs.File.openHandle(fd).inStream().stream;
     stream.readNoEof(buf) catch return error.Unexpected;
 }

--- a/std/os.zig
+++ b/std/os.zig
@@ -134,8 +134,8 @@ fn getRandomBytesDevURandom(buf: []u8) !void {
     defer close(fd);
 
     const st = try fstat(fd);
-    if (!S_ISCHR(st.mode)) {
-        return OpenError.Unexpected;
+    if (!system.S_ISCHR(st.mode)) {
+        return error.Unexpected;
     }
 
     const stream = &std.fs.File.openHandle(fd).inStream().stream;

--- a/std/os/bits/darwin.zig
+++ b/std/os/bits/darwin.zig
@@ -1131,9 +1131,18 @@ pub const S_IFWHT = 0o160000;
 pub const S_ISUID = 0o4000;
 pub const S_ISGID = 0o2000;
 pub const S_ISVTX = 0o1000;
+pub const S_IRWXU = 0o700;
 pub const S_IRUSR = 0o400;
 pub const S_IWUSR = 0o200;
 pub const S_IXUSR = 0o100;
+pub const S_IRWXG = 0o070;
+pub const S_IRGRP = 0o040;
+pub const S_IWGRP = 0o020;
+pub const S_IXGRP = 0o010;
+pub const S_IRWXO = 0o007;
+pub const S_IROTH = 0o004;
+pub const S_IWOTH = 0o002;
+pub const S_IXOTH = 0o001;
 
 pub fn S_ISFIFO(m: u32) bool {
     return m & S_IFMT == S_IFIFO;

--- a/std/os/bits/darwin.zig
+++ b/std/os/bits/darwin.zig
@@ -1116,3 +1116,53 @@ pub const stack_t = extern struct {
     ss_size: isize,
     ss_flags: i32,
 };
+
+pub const S_IFMT = 0o170000;
+
+pub const S_IFIFO = 0o010000;
+pub const S_IFCHR = 0o020000;
+pub const S_IFDIR = 0o040000;
+pub const S_IFBLK = 0o060000;
+pub const S_IFREG = 0o100000;
+pub const S_IFLNK = 0o120000;
+pub const S_IFSOCK = 0o140000;
+pub const S_IFWHT = 0o160000;
+
+pub const S_ISUID = 0o4000;
+pub const S_ISGID = 0o2000;
+pub const S_ISVTX = 0o1000;
+pub const S_IRUSR = 0o400;
+pub const S_IWUSR = 0o200;
+pub const S_IXUSR = 0o100;
+
+pub fn S_ISFIFO(m: u32) bool {
+    return m & S_IFMT == S_IFIFO;
+}
+
+pub fn S_ISCHR(m: u32) bool {
+    return m & S_IFMT == S_IFCHR;
+}
+
+pub fn S_ISDIR(m: u32) bool {
+    return m & S_IFMT == S_IFDIR;
+}
+
+pub fn S_ISBLK(m: u32) bool {
+    return m & S_IFMT == S_IFBLK;
+}
+
+pub fn S_ISREG(m: u32) bool {
+    return m & S_IFMT == S_IFREG;
+}
+
+pub fn S_ISLNK(m: u32) bool {
+    return m & S_IFMT == S_IFLNK;
+}
+
+pub fn S_ISSOCK(m: u32) bool {
+    return m & S_IFMT == S_IFSOCK;
+}
+
+pub fn S_IWHT(m: u32) bool {
+    return m & S_IFMT == S_IFWHT;
+}

--- a/std/os/bits/freebsd.zig
+++ b/std/os/bits/freebsd.zig
@@ -876,3 +876,62 @@ pub const stack_t = extern struct {
     ss_size: isize,
     ss_flags: i32,
 };
+
+pub const S_IFMT = 0o170000;
+
+pub const S_IFIFO = 0o010000;
+pub const S_IFCHR = 0o020000;
+pub const S_IFDIR = 0o040000;
+pub const S_IFBLK = 0o060000;
+pub const S_IFREG = 0o100000;
+pub const S_IFLNK = 0o120000;
+pub const S_IFSOCK = 0o140000;
+pub const S_IFWHT = 0o160000;
+
+pub const S_ISUID = 0o4000;
+pub const S_ISGID = 0o2000;
+pub const S_ISVTX = 0o1000;
+pub const S_IRWXU = 0o700;
+pub const S_IRUSR = 0o400;
+pub const S_IWUSR = 0o200;
+pub const S_IXUSR = 0o100;
+pub const S_IRWXG = 0o070;
+pub const S_IRGRP = 0o040;
+pub const S_IWGRP = 0o020;
+pub const S_IXGRP = 0o010;
+pub const S_IRWXO = 0o007;
+pub const S_IROTH = 0o004;
+pub const S_IWOTH = 0o002;
+pub const S_IXOTH = 0o001;
+
+pub fn S_ISFIFO(m: u32) bool {
+    return m & S_IFMT == S_IFIFO;
+}
+
+pub fn S_ISCHR(m: u32) bool {
+    return m & S_IFMT == S_IFCHR;
+}
+
+pub fn S_ISDIR(m: u32) bool {
+    return m & S_IFMT == S_IFDIR;
+}
+
+pub fn S_ISBLK(m: u32) bool {
+    return m & S_IFMT == S_IFBLK;
+}
+
+pub fn S_ISREG(m: u32) bool {
+    return m & S_IFMT == S_IFREG;
+}
+
+pub fn S_ISLNK(m: u32) bool {
+    return m & S_IFMT == S_IFLNK;
+}
+
+pub fn S_ISSOCK(m: u32) bool {
+    return m & S_IFMT == S_IFSOCK;
+}
+
+pub fn S_IWHT(m: u32) bool {
+    return m & S_IFMT == S_IFWHT;
+}

--- a/std/os/darwin.zig
+++ b/std/os/darwin.zig
@@ -5,3 +5,4 @@ pub const is_the_target = switch (builtin.os) {
     else => false,
 };
 pub usingnamespace std.c;
+pub usingnamespace @import("bits.zig");

--- a/std/os/freebsd.zig
+++ b/std/os/freebsd.zig
@@ -2,3 +2,4 @@ const std = @import("../std.zig");
 const builtin = @import("builtin");
 pub const is_the_target = builtin.os == .freebsd;
 pub usingnamespace std.c;
+pub usingnamespace @import("bits.zig");


### PR DESCRIPTION
Fixes #1626 by checking if `/dev/urandom` is a valid character device before using it.

[libsodium](https://github.com/jedisct1/libsodium/blob/master/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c#L203) has a slightly different check in some cases where it checks `S_ISNAM() or S_ISCHR()`, but `S_ISNAM` (`XENIX named special file with two subtypes`) isn't currently defined in Zig's standard library and I'm not sure if we need it since it seems specific to a tiny subset of systems...

I'm also not sure what error to return in the case that `/dev/urandom` isn;t a character device - I just return `Unexpected` for now, but might it be better to add a more specific error?