### PR TITLE
make >= 128-bit integer types 16-byte aligned

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -7273,7 +7273,6 @@ static void resolve_llvm_types(CodeGen *g, ZigType *type, ResolveStatus wanted_r
 
 LLVMTypeRef get_llvm_type(CodeGen *g, ZigType *type) {
     assertNoError(type_resolve(g, type, ResolveStatusLLVMFull));
-    assert(type->abi_size == 0 || type->abi_size == LLVMABISizeOfType(g->target_data_ref, type->llvm_type));
     return type->llvm_type;
 }
 

--- a/std/mutex.zig
+++ b/std/mutex.zig
@@ -122,7 +122,7 @@ else switch (builtin.os) {
     },
 };
 
-const TestContext = struct {
+const TestContext = packed struct {
     mutex: *Mutex,
     data: i128,
 

--- a/std/mutex.zig
+++ b/std/mutex.zig
@@ -122,7 +122,7 @@ else switch (builtin.os) {
     },
 };
 
-const TestContext = packed struct {
+const TestContext = struct {
     mutex: *Mutex,
     data: i128,
 

--- a/test/stage1/behavior/align.zig
+++ b/test/stage1/behavior/align.zig
@@ -167,6 +167,14 @@ test "@ptrCast preserves alignment of bigger source" {
     expect(@typeOf(ptr) == *align(16) u8);
 }
 
+fn give() anyerror!u128 {
+    return 3;
+}
+
+test "return error union with 128-bit integer" {
+    expect(3 == try give());
+}
+
 test "runtime known array index has best alignment possible" {
     // take full advantage of over-alignment
     var array align(4) = [_]u8{ 1, 2, 3, 4 };
@@ -249,6 +257,29 @@ test "size of extern struct with 128-bit field" {
             y: u8,
         }) == 32);
     }
+}
+
+const DefaultAligned = struct {
+    nevermind: u32,
+    badguy: i128,
+};
+
+test "read 128-bit field from default aligned struct in stack memory" {
+    var default_aligned = DefaultAligned {
+        .nevermind = 1,
+        .badguy = 12,
+    };
+    expect(12 == default_aligned.badguy);
+}
+
+var default_aligned_global = DefaultAligned {
+    .nevermind = 1,
+    .badguy = 12,
+};
+
+test "read 128-bit field from default aligned struct in global memory" {
+
+    expect(12 == default_aligned_global.badguy);
 }
 
 test "alignment of extern() void" {

--- a/test/stage1/behavior/align.zig
+++ b/test/stage1/behavior/align.zig
@@ -220,6 +220,20 @@ test "alignment of structs" {
     }) == @alignOf(usize));
 }
 
+test "alignment of 128-bit integer type" {
+    expect(@alignOf(u128) == 16);
+}
+
+test "alignment of struct with 128-bit field" {
+    expect(@alignOf(struct { x: u128}) == 16);
+}
+
+test "comptime alignment of struct with 128-bit field" {
+    comptime {
+        expect(@alignOf(struct { x: u128}) == 16);
+    }
+}
+
 test "alignment of extern() void" {
     var runtime_nothing = nothing;
     const casted1 = @ptrCast(*const u8, runtime_nothing);

--- a/test/stage1/behavior/align.zig
+++ b/test/stage1/behavior/align.zig
@@ -220,18 +220,28 @@ test "alignment of structs" {
     }) == @alignOf(usize));
 }
 
-test "alignment of 128-bit integer type" {
+test "alignment of >= 128-bit integer type" {
     expect(@alignOf(u128) == 16);
+    expect(@alignOf(u129) == 16);
 }
 
 test "alignment of struct with 128-bit field" {
-    expect(@alignOf(struct { x: u128}) == 16);
+    expect(@alignOf(struct {
+        x: u128,
+    }) == 16);
+
+    comptime {
+        expect(@alignOf(struct {
+            x: u128,
+        }) == 16);
+    }
 }
 
-test "comptime alignment of struct with 128-bit field" {
-    comptime {
-        expect(@alignOf(struct { x: u128}) == 16);
-    }
+test "size of struct with non-standard-LLVM alignment" {
+    expect(@sizeOf(struct {
+        x: u129,
+        y: u129,
+    }) == 64);
 }
 
 test "alignment of extern() void" {

--- a/test/stage1/behavior/align.zig
+++ b/test/stage1/behavior/align.zig
@@ -237,11 +237,18 @@ test "alignment of struct with 128-bit field" {
     }
 }
 
-test "size of struct with non-standard-LLVM alignment" {
-    expect(@sizeOf(struct {
-        x: u129,
-        y: u129,
-    }) == 64);
+test "size of extern struct with 128-bit field" {
+    expect(@sizeOf(extern struct {
+        x: u128,
+        y: u8,
+    }) == 32);
+
+    comptime {
+        expect(@sizeOf(extern struct {
+            x: u128,
+            y: u8,
+        }) == 32);
+    }
 }
 
 test "alignment of extern() void" {

--- a/test/stage1/behavior/align.zig
+++ b/test/stage1/behavior/align.zig
@@ -269,6 +269,7 @@ test "read 128-bit field from default aligned struct in stack memory" {
         .nevermind = 1,
         .badguy = 12,
     };
+    expect((@ptrToInt(&default_aligned.badguy) % 16) == 0);
     expect(12 == default_aligned.badguy);
 }
 
@@ -278,7 +279,7 @@ var default_aligned_global = DefaultAligned {
 };
 
 test "read 128-bit field from default aligned struct in global memory" {
-
+    expect((@ptrToInt(&default_aligned_global.badguy) % 16) == 0);
     expect(12 == default_aligned_global.badguy);
 }
 


### PR DESCRIPTION
This PR should resolve #2987 and make  >= 128-bit integer types 16-byte aligned. The alignment and size of those types are both changed accordingly.

Some caveats:

For some reason inside `get_llvm_type` I cannot assert that integer types are sized and aligned the same as calculated by the functions I introduce here, so I had to exclude them form those assertions. I am not sure why that is. It would be good to know.

There is also no test included yet since the example test @andrewrk provided in #2987 is currently disabled because of #2883. I did run that test locally and it worked.

Maybe this could be covered with a test somehow by asserting how structs are padded.