### PR TITLE
Read traceback data from external debug info

### DIFF
--- a/std/debug.zig
+++ b/std/debug.zig
@@ -1113,16 +1113,18 @@ fn openSelfDebugInfoMacOs(allocator: *mem.Allocator) !DebugInfo {
 
     const hdr_base = @ptrCast([*]u8, hdr);
     var ptr = hdr_base + @sizeOf(macho.mach_header_64);
-    var ncmd: u32 = hdr.ncmds;
-    const symtab = while (ncmd != 0) : (ncmd -= 1) {
-        const lc = @ptrCast(*std.macho.load_command, ptr);
-        switch (lc.cmd) {
-            std.macho.LC_SYMTAB => break @ptrCast(*std.macho.symtab_command, ptr),
-            else => {},
+    const symtab = blk: {
+        var ncmd = hdr.ncmds;
+        while (ncmd != 0) : (ncmd -= 1) {
+            const lc = @ptrCast(*std.macho.load_command, ptr);
+            switch (lc.cmd) {
+                std.macho.LC_SYMTAB => break :blk @ptrCast(*std.macho.symtab_command, ptr),
+                else => {},
+            }
+            ptr += lc.cmdsize;
+        } else {
+            return error.MissingDebugInfo;
         }
-        ptr += lc.cmdsize; // TODO https://github.com/ziglang/zig/issues/1403
-    } else {
-        return error.MissingDebugInfo;
     };
     const syms = @ptrCast([*]macho.nlist_64, @alignCast(@alignOf(macho.nlist_64), hdr_base + symtab.symoff))[0..symtab.nsyms];
     const strings = @ptrCast([*]u8, hdr_base + symtab.stroff)[0..symtab.strsize];
@@ -1692,16 +1694,18 @@ fn getLineNumberInfoMacOs(di: *DebugInfo, symbol: MachoSymbol, target_address: u
 
         const hdr_base = @ptrCast([*]const u8, hdr);
         var ptr = hdr_base + @sizeOf(macho.mach_header_64);
-        var ncmd: u32 = hdr.ncmds;
-        const segcmd = while (ncmd != 0) : (ncmd -= 1) {
-            const lc = @ptrCast(*const std.macho.load_command, ptr);
-            switch (lc.cmd) {
-                std.macho.LC_SEGMENT_64 => break @ptrCast(*const std.macho.segment_command_64, @alignCast(@alignOf(std.macho.segment_command_64), ptr)),
-                else => {},
+        const segcmd = blk: {
+            var ncmd = hdr.ncmds;
+            while (ncmd != 0) : (ncmd -= 1) {
+                const lc = @ptrCast(*const std.macho.load_command, ptr);
+                switch (lc.cmd) {
+                    std.macho.LC_SEGMENT_64 => break :blk @ptrCast(*const std.macho.segment_command_64, @alignCast(@alignOf(std.macho.segment_command_64), ptr)),
+                    else => {},
+                }
+                ptr += lc.cmdsize;
+            } else {
+                return error.MissingDebugInfo;
             }
-            ptr += lc.cmdsize; // TODO https://github.com/ziglang/zig/issues/1403
-        } else {
-            return error.MissingDebugInfo;
         };
         const sections = @ptrCast([*]const macho.section_64, @alignCast(@alignOf(macho.section_64), ptr + @sizeOf(std.macho.segment_command_64)))[0..segcmd.nsects];
         for (sections) |*sect| {

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -1375,6 +1375,30 @@ const Die = struct {
             else => error.InvalidDebugInfo,
         };
     }
+
+    fn getPcRange(self: Die) !?PcRange {
+        if (self.getAttrAddr(DW.AT_low_pc)) |low_pc| {
+            if (self.getAttr(DW.AT_high_pc)) |high_pc_value| {
+                const pc_end = switch (high_pc_value.*) {
+                    FormValue.Address => |value| value,
+                    FormValue.Const => |value| b: {
+                        const offset = try value.asUnsignedLe();
+                        break :b (low_pc + offset);
+                    },
+                    else => return error.InvalidDebugInfo,
+                };
+                return PcRange{
+                    .start = low_pc,
+                    .end = pc_end,
+                };
+            } else {
+                return null;
+            }
+        } else |err| {
+            if (err != error.MissingDebugInfo) return err;
+            return null;
+        }
+    }
 };
 
 const FileEntry = struct {
@@ -2118,29 +2142,7 @@ fn scanAllFunctions(di: *DwarfInfo) !void {
                         break :x null;
                     };
 
-                    const pc_range = x: {
-                        if (die_obj.getAttrAddr(DW.AT_low_pc)) |low_pc| {
-                            if (die_obj.getAttr(DW.AT_high_pc)) |high_pc_value| {
-                                const pc_end = switch (high_pc_value.*) {
-                                    FormValue.Address => |value| value,
-                                    FormValue.Const => |value| b: {
-                                        const offset = try value.asUnsignedLe();
-                                        break :b (low_pc + offset);
-                                    },
-                                    else => return error.InvalidDebugInfo,
-                                };
-                                break :x PcRange{
-                                    .start = low_pc,
-                                    .end = pc_end,
-                                };
-                            } else {
-                                break :x null;
-                            }
-                        } else |err| {
-                            if (err != error.MissingDebugInfo) return err;
-                            break :x null;
-                        }
-                    };
+                    const pc_range = try die_obj.getPcRange();
 
                     try di.func_list.append(Func{
                         .name = fn_name,
@@ -2189,29 +2191,7 @@ fn scanAllCompileUnits(di: *DwarfInfo) !void {
 
         if (compile_unit_die.tag_id != DW.TAG_compile_unit) return error.InvalidDebugInfo;
 
-        const pc_range = x: {
-            if (compile_unit_die.getAttrAddr(DW.AT_low_pc)) |low_pc| {
-                if (compile_unit_die.getAttr(DW.AT_high_pc)) |high_pc_value| {
-                    const pc_end = switch (high_pc_value.*) {
-                        FormValue.Address => |value| value,
-                        FormValue.Const => |value| b: {
-                            const offset = try value.asUnsignedLe();
-                            break :b (low_pc + offset);
-                        },
-                        else => return error.InvalidDebugInfo,
-                    };
-                    break :x PcRange{
-                        .start = low_pc,
-                        .end = pc_end,
-                    };
-                } else {
-                    break :x null;
-                }
-            } else |err| {
-                if (err != error.MissingDebugInfo) return err;
-                break :x null;
-            }
-        };
+        const pc_range = try compile_unit_die.getPcRange();
 
         try di.compile_unit_list.append(CompileUnit{
             .version = version,

--- a/std/debug.zig
+++ b/std/debug.zig
@@ -1509,6 +1509,7 @@ const LineNumberProgram = struct {
 
 fn readStringRaw(allocator: *mem.Allocator, in_stream: var) ![]u8 {
     var buf = ArrayList(u8).init(allocator);
+    errdefer buf.deinit();
     while (true) {
         const byte = try in_stream.readByte();
         if (byte == 0) break;
@@ -1639,6 +1640,7 @@ fn parseDie(di: *DwarfInfo, abbrev_table_offset: usize, is_64: bool) !?Die {
             const tag_id = try leb.readULEB128(u64, di.dwarf_in_stream);
             const has_children = (try di.dwarf_in_stream.readByte()) == DW.CHILDREN_yes;
             var attrs = ArrayList(Die.Attr).init(di.allocator);
+            errdefer attrs.deinit();
 
             while (true) {
                 const attr_id = try leb.readULEB128(u64, di.dwarf_in_stream);

--- a/std/elf.zig
+++ b/std/elf.zig
@@ -340,6 +340,11 @@ pub const Arch = enum {
     AArch64,
 };
 
+fn isString(elf: *Elf, str: []const u8) !bool {
+    if (!try elf.in_stream.checkBytes(str)) return false;
+    return try elf.in_stream.checkByte(0);
+}
+
 pub const SectionHeader = struct {
     name: u32,
     sh_type: u32,
@@ -355,16 +360,7 @@ pub const SectionHeader = struct {
     pub fn nameIs(elf_section: SectionHeader, elf: *Elf, name: []const u8) !bool {
         const name_offset = elf.string_section.offset + elf_section.name;
         try elf.seekable_stream.seekTo(name_offset);
-
-        for (name) |expected_c| {
-            const target_c = try elf.in_stream.readByte();
-            if (target_c == 0 or expected_c != target_c) return false;
-        }
-
-        const null_byte = try elf.in_stream.readByte();
-        if (null_byte == 0) return true;
-
-        return false;
+        return try isString(elf, name);
     }
 };
 

--- a/std/hash/crc.zig
+++ b/std/hash/crc.zig
@@ -10,9 +10,9 @@ const debug = std.debug;
 const testing = std.testing;
 
 pub const Polynomial = struct {
-    const IEEE = 0xedb88320;
-    const Castagnoli = 0x82f63b78;
-    const Koopman = 0xeb31d82e;
+    pub const IEEE = 0xedb88320;
+    pub const Castagnoli = 0x82f63b78;
+    pub const Koopman = 0xeb31d82e;
 };
 
 // IEEE is by far the most common CRC and so is aliased by default.

--- a/std/io.zig
+++ b/std/io.zig
@@ -209,6 +209,17 @@ pub fn InStream(comptime ReadError: type) type {
             }
         }
 
+        pub fn checkByte(self: *Self, byte: u8) !bool {
+            return (try self.readByte()) == byte;
+        }
+
+        pub fn checkBytes(self: *Self, bytes: []const u8) !bool {
+            for (bytes) |expected_c| {
+                if (!try self.checkByte(expected_c)) return false;
+            }
+            return true;
+        }
+
         pub fn readStruct(self: *Self, comptime T: type) !T {
             // Only extern and packed structs have defined in-memory layout.
             comptime assert(@typeInfo(T).Struct.layout != builtin.TypeInfo.ContainerLayout.Auto);


### PR DESCRIPTION
Part of #2300

Currently on top of #3005

To play with external debug info I've been using:

```zig
const std = @import("std");

pub fn main() void {
    std.debug.dumpCurrentStackTrace(@returnAddress());
}
```
and compiling+running with:
```
./bin/zig build-exe ../play.zig
objcopy --only-keep-debug play play.debug
objcopy --strip-all play play
objcopy --add-gnu-debuglink=play.debug play
./play
```