### PR TITLE
Fix #3012 os.getrandom fill buffer

### DIFF
--- a/std/io.zig
+++ b/std/io.zig
@@ -146,7 +146,7 @@ pub fn InStream(comptime ReadError: type) type {
 
         /// Same as `readFull` but end of stream returns `error.EndOfStream`.
         pub fn readNoEof(self: *Self, buf: []u8) !void {
-            const amt_read = try self.read(buf);
+            const amt_read = try self.readFull(buf);
             if (amt_read < buf.len) return error.EndOfStream;
         }
 

--- a/std/os.zig
+++ b/std/os.zig
@@ -128,7 +128,7 @@ pub fn getrandom(buf: []u8) GetRandomError!void {
             };
 
             if (err != 0) {
-                switch (e) {
+                switch (err) {
                     EINVAL => unreachable,
                     EFAULT => unreachable,
                     EINTR => continue,

--- a/std/os.zig
+++ b/std/os.zig
@@ -109,7 +109,7 @@ pub fn getrandom(buf: []u8) GetRandomError!void {
         const use_c = std.c.versionCheck(builtin.Version{ .major = 2, .minor = 25, .patch = 0 }).ok;
 
         while (num_read < buf.len) {
-            var err: u12 = 0;
+            var err: u16 = 0;
 
             const res: usize = if (use_c) blk: {
                 const result = std.c.getrandom(buff.ptr, buff.len, 0);
@@ -123,7 +123,7 @@ pub fn getrandom(buf: []u8) GetRandomError!void {
             } else blk: {
                 const result = linux.getrandom(buff.ptr, buff.len, 0);
 
-                err = linux.getErrno(result);
+                err = @intcast(u16, linux.getErrno(result));
 
                 break :blk result;
             };

--- a/std/os.zig
+++ b/std/os.zig
@@ -100,10 +100,6 @@ pub const GetRandomError = OpenError;
 /// appropriate OS-specific library call. Otherwise it uses the zig standard
 /// library implementation.
 pub fn getrandom(buf: []u8) GetRandomError!void {
-    if (buf.len == 0) {
-        return;
-    }
-
     if (windows.is_the_target) {
         return windows.RtlGenRandom(buf);
     }

--- a/std/os.zig
+++ b/std/os.zig
@@ -145,7 +145,7 @@ pub fn getrandom(buf: []u8) GetRandomError!void {
                 }
             } else {
                 total_read += num_read;
-                buf_slice = buf_slice[total_read..];
+                buf_slice = buf_slice[num_read..];
             }
         }
     }

--- a/std/os.zig
+++ b/std/os.zig
@@ -123,7 +123,7 @@ pub fn getrandom(buf: []u8) GetRandomError!void {
             } else blk: {
                 const result = linux.getrandom(buff.ptr, buff.len, 0);
 
-                err = @intcast(u16, linux.getErrno(result));
+                err = @intCast(u16, linux.getErrno(result));
 
                 break :blk result;
             };


### PR DESCRIPTION
Fixes #3012 

This makes the change suggested by @andrewrk. It also modifies the Linux and FreeBSD code that uses `getrandom` based upon the documentation:

Note that the FreeBSD and Linux code also needs updating in the case of always filling the buffer:

[**FreeBSD**](https://www.freebsd.org/cgi/man.cgi?query=getrandom&sektion=2&manpath=freebsd-release-ports):

```
RETURN VALUES
     Upon successful completion, the number of bytes which were	actually read
     is	returned.  For requests	larger than 256	bytes, this can	be fewer bytes
     than were requested.  Otherwise, -1 is returned and the global variable
     errno is set to indicate the error.
```

[**Linux**](http://man7.org/linux/man-pages/man2/getrandom.2.html):

```
RETURN VALUE
       On success, getrandom() returns the number of bytes that were copied
       to the buffer buf.  This may be less than the number of bytes
       requested via buflen if either GRND_RANDOM was specified in flags and
       insufficient entropy was present in the random source or the system
       call was interrupted by a signal.

       On error, -1 is returned, and errno is set appropriately.
```

I've tested the FreeBSD change, but not the Linux change as I don't have a Linux system handy.