### PR TITLE
Explicit compile error message when using fd_t

### DIFF
--- a/std/os/bits.zig
+++ b/std/os/bits.zig
@@ -10,7 +10,7 @@ pub usingnamespace switch (builtin.os) {
     .netbsd => @import("bits/netbsd.zig"),
     .wasi => @import("bits/wasi.zig"),
     .windows => @import("bits/windows.zig"),
-    else => struct {},
+    else => @import("bits/unsupported.zig"),
 };
 
 pub const pthread_t = *@OpaqueType();

--- a/std/os/bits/unsupported.zig
+++ b/std/os/bits/unsupported.zig
@@ -1,0 +1,3 @@
+pub const fd_t = comptime {
+    @compileError("Unsupported OS");
+};


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/3019

```
# Before

/usr/local/Cellar/zig/live/lib/zig/std/fs/file.zig:14:15: error: container 'std.os' has no member called 'fd_t'
    handle: os.fd_t,
              ^

# After

/usr/local/Cellar/zig/live/lib/zig/std/os/bits/unsupported.zig:2:5: error: Unsupported OS
    @compileError("Unsupported OS");
    ^
/usr/local/Cellar/zig/live/lib/zig/std/fs/file.zig:14:15: note: referenced here
    handle: os.fd_t,
              ^
/usr/local/Cellar/zig/live/lib/zig/std/debug.zig:59:9: note: referenced here
        stderr_file = try io.getStdErr();
        ^
```

`os.fd_t` was the only common OS reference I could find.