### PR TITLE
modify header precedence for zig cc, resolves intrinsics issues

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8292,8 +8292,8 @@ void add_cc_args(CodeGen *g, ZigList<const char *> &args, const char *out_dep_pa
         }
     }
 
-    //todo(dimenus): possibly break this up into separate lists
-    //appending libc headers before c_headers breaks intrinsics and other compiler specific items
+    //note(dimenus): appending libc headers before c_headers breaks intrinsics 
+    //and other compiler specific items
     // According to Rich Felker libc headers are supposed to go before C language headers.
     args.append("-isystem");
     args.append(buf_ptr(g->zig_c_headers_dir));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8292,15 +8292,18 @@ void add_cc_args(CodeGen *g, ZigList<const char *> &args, const char *out_dep_pa
         }
     }
 
+    //todo(dimenus): possibly break this up into separate lists
+    //appending libc headers before c_headers breaks intrinsics and other compiler specific items
+    // According to Rich Felker libc headers are supposed to go before C language headers.
+    args.append("-isystem");
+    args.append(buf_ptr(g->zig_c_headers_dir));
+
     for (size_t i = 0; i < g->libc_include_dir_len; i += 1) {
         Buf *include_dir = g->libc_include_dir_list[i];
         args.append("-isystem");
         args.append(buf_ptr(include_dir));
     }
 
-    // According to Rich Felker libc headers are supposed to go before C language headers.
-    args.append("-isystem");
-    args.append(buf_ptr(g->zig_c_headers_dir));
 
     if (g->zig_target->is_native) {
         args.append("-march=native");


### PR DESCRIPTION
This minor change reverts the previous decision to include libc header files before c language headers. The existing setup breaks intrinsics and other compiler specific implementations. The long term goal should probably be to split the c headers up.