### PR TITLE
Remove elements from std.ArrayList while iterating over it

### DIFF
--- a/std/array_list.zig
+++ b/std/array_list.zig
@@ -233,17 +233,13 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             //
 
             pub inline fn swapRemove(it: *Iterator) T {
-                const removed_already = blk: {
-                    if (it.removed_index) |idx| {
-                        break :blk idx==it.next_index;
-                    } else {
-                        break :blk false;
-                    }
-                };
-                if (!removed_already) {
+                if (it.list.len == 0) @panic("attempt to remove element from empty list");
+
+                if (it.removed_index == null or
+                    it.removed_index.? != it.next_index)
+                {
                     if (it.next_index > 0) it.next_index -= 1;
                     it.removed_index = it.next_index;
-                    if (it.next_index >= it.list.len) @panic("attempt to remove element from empty list");
                     return it.list.swapRemove(it.next_index);
                 } else switch (builtin.mode) {
                     .ReleaseFast => unreachable,
@@ -252,16 +248,12 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             }
 
             pub inline fn orderedRemove(it: *Iterator) T {
-                const removed_already = blk: {
-                    if (it.removed_index) |idx| {
-                        break :blk idx==it.next_index;
-                    } else {
-                        break :blk false;
-                    }
-                };
-                if (!removed_already) {
+                if (it.list.len == 0) @panic("attempt to remove element from empty list");
+
+                if (it.removed_index == null or
+                    it.removed_index.? != it.next_index)
+                {
                     if (it.next_index > 0) it.next_index -= 1;
-                    if (it.next_index >= it.list.len) @panic("attempt to remove element from empty list");
                     it.removed_index = it.next_index;
                     return it.list.orderedRemove(it.next_index);
                 } else switch (builtin.mode) {

--- a/std/array_list.zig
+++ b/std/array_list.zig
@@ -229,7 +229,7 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
 
             //
             // NOTE: inlining these removal routines is important.
-            // Allows them to get with 1% of the performance of ArrayList.swapRemove/orderedRemove.
+            // It gains ~5% in debug mode, and ~8% in release-safe; within 1% of the performance of ArrayList.swapRemove/orderedRemove.
             //
 
             pub inline fn swapRemove(it: *Iterator) T {

--- a/std/array_list.zig
+++ b/std/array_list.zig
@@ -229,39 +229,18 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
                 it.removed_index = null;
             }
 
-            //
-            // NOTE: inlining these removal routines is important.
-            // It gains ~5% in debug mode, and ~8% in release-safe; within 1% of the performance of ArrayList.swapRemove/orderedRemove.
-            //
-            // Also note that you'd think that just checking for the index==0 in the removal routines would be
-            // good for making it illegal if next has not been called yet.
-            // But no, it is slower to do this for release-safe, and debug modes.
-            //
-
-            pub inline fn swapRemove(it: *Iterator) T {
-                const cursor = it.cursor orelse @panic("must call next at least once");
-                if (it.removed_index == null or
-                    it.removed_index.? != cursor
-                ) {
-                    it.removed_index = cursor;
-                    return it.list.swapRemove(cursor);
-                } else switch (builtin.mode) {
-                    .ReleaseFast => unreachable,
-                    else => @panic("removed element more than once"),
-                }
+            pub fn swapRemove(it: *Iterator) T {
+                var cursor = it.cursor.?; // must call .next() at least once
+                if (it.removed_index) |ri| assert(ri != cursor); // removed the same element more than once
+                it.removed_index = cursor;
+                return it.list.swapRemove(cursor);
             }
 
-            pub inline fn orderedRemove(it: *Iterator) T {
-                const cursor = it.cursor orelse @panic("must call next at least once");
-                if (it.removed_index == null or
-                    it.removed_index.? != cursor
-                ) {
-                    it.removed_index = cursor;
-                    return it.list.orderedRemove(cursor);
-                } else switch (builtin.mode) {
-                    .ReleaseFast => unreachable,
-                    else => @panic("removed element more than once"),
-                }
+            pub fn orderedRemove(it: *Iterator) T {
+                var cursor = it.cursor.?; // must call .next() at least once
+                if (it.removed_index) |ri| assert(ri != cursor); // removed the same element more than once
+                it.removed_index = cursor;
+                return it.list.orderedRemove(cursor);
             }
         };
 

--- a/std/array_list.zig
+++ b/std/array_list.zig
@@ -219,20 +219,23 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
                 // so we get the element at the same index a second time.
                 // the next element's index was incremented when we
                 // called `next` before, so we decrement it here, before we get the item.
-                const index = if (it.removed) it.next_index-1 else it.next_index;
-                it.removed = false;
+                // NOTE: volatile code! don't use a ternary if, or stack variable for new index here!
+                if (it.removed) {
+                    it.removed = false;
+                    it.next_index -= 1;
+                }
 
-                if (index >= it.list.len) return null;
-                const val = it.list.at(index);
+                if (it.next_index >= it.list.len) return null;
+                const val = it.list.at(it.next_index);
 
-                it.next_index = index+1;
+                it.next_index += 1;
 
                 return val;
             }
 
             pub fn reset(it: *Iterator) void {
                 it.next_index = 0;
-                it.removed = false;
+                it.removed = true;
             }
 
             pub fn swapRemove(it: *Iterator) T {

--- a/std/array_list.zig
+++ b/std/array_list.zig
@@ -233,6 +233,10 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             // NOTE: inlining these removal routines is important.
             // It gains ~5% in debug mode, and ~8% in release-safe; within 1% of the performance of ArrayList.swapRemove/orderedRemove.
             //
+            // Also note that you'd think that just checking for the index==0 in the removal routines would be
+            // good for making it illegal if next has not been called yet.
+            // But no, it is slower to do this for release-safe, and debug modes.
+            //
 
             pub inline fn swapRemove(it: *Iterator) T {
                 const cursor = it.cursor orelse @panic("must call next at least once");

--- a/std/http/headers.zig
+++ b/std/http/headers.zig
@@ -160,7 +160,7 @@ pub const Headers = struct {
     pub const Iterator = HeaderList.Iterator;
 
     pub fn iterator(self: Self) Iterator {
-        return self.data.iteratorConst();
+        return self.data.iterator();
     }
 
     pub fn append(self: *Self, name: []const u8, value: []const u8, never_index: ?bool) !void {

--- a/std/http/headers.zig
+++ b/std/http/headers.zig
@@ -133,7 +133,7 @@ pub const Headers = struct {
             self.index.deinit();
         }
         {
-            var it = self.data.iterator();
+            var it = self.data.iteratorConst();
             while (it.next()) |entry| {
                 entry.deinit();
             }
@@ -146,7 +146,7 @@ pub const Headers = struct {
         errdefer other.deinit();
         try other.data.ensureCapacity(self.data.count());
         try other.index.initCapacity(self.index.entries.len);
-        var it = self.data.iterator();
+        var it = self.data.iteratorConst();
         while (it.next()) |entry| {
             try other.append(entry.name, entry.value, entry.never_index);
         }
@@ -160,7 +160,7 @@ pub const Headers = struct {
     pub const Iterator = HeaderList.Iterator;
 
     pub fn iterator(self: Self) Iterator {
-        return self.data.iterator();
+        return self.data.iteratorConst();
     }
 
     pub fn append(self: *Self, name: []const u8, value: []const u8, never_index: ?bool) !void {
@@ -290,7 +290,7 @@ pub const Headers = struct {
         const dex = self.getIndices(name) orelse return null;
 
         const buf = try allocator.alloc(HeaderEntry, dex.count());
-        var it = dex.iterator();
+        var it = dex.iteratorConst();
         var n: usize = 0;
         while (it.next()) |idx| {
             buf[n] = self.data.at(idx);
@@ -315,7 +315,7 @@ pub const Headers = struct {
         // adapted from mem.join
         const total_len = blk: {
             var sum: usize = dex.count() - 1; // space for separator(s)
-            var it = dex.iterator();
+            var it = dex.iteratorConst();
             while (it.next()) |idx|
                 sum += self.data.at(idx).value.len;
             break :blk sum;
@@ -351,7 +351,7 @@ pub const Headers = struct {
             var it = self.data.iterator();
             while (it.next()) |entry| {
                 var dex = &self.index.get(entry.name).?.value;
-                dex.appendAssumeCapacity(it.count);
+                dex.appendAssumeCapacity(it.next_index);
             }
         }
     }

--- a/std/http/headers.zig
+++ b/std/http/headers.zig
@@ -351,7 +351,7 @@ pub const Headers = struct {
             var it = self.data.iterator();
             while (it.next()) |entry| {
                 var dex = &self.index.get(entry.name).?.value;
-                dex.appendAssumeCapacity(it.next_index);
+                dex.appendAssumeCapacity(it.cursor.?+1);
             }
         }
     }

--- a/std/http/headers.zig
+++ b/std/http/headers.zig
@@ -157,10 +157,10 @@ pub const Headers = struct {
         return self.data.count();
     }
 
-    pub const Iterator = HeaderList.Iterator;
+    pub const Iterator = HeaderList.IteratorConst;
 
     pub fn iterator(self: Self) Iterator {
-        return self.data.iterator();
+        return self.data.iteratorConst();
     }
 
     pub fn append(self: *Self, name: []const u8, value: []const u8, never_index: ?bool) !void {


### PR DESCRIPTION
You can now remove an element from a `std.ArrayList`, while iterating over one.

By ordered-removal:
```zig
var itr = list.iterator(); // this is a `std.ArrayList`.
while (itr.next()) |e| {
    // This visits every element, including the one we remove.
    if (e == 2) {
        var removed = itr.orderedRemove();
        assert(removed == e);
    }
}
// Array now contains: [0, 1, 3, 4].  (the 2 is gone.)
```
By swap-removal:
```zig
var itr = list.iterator(); // this is a `std.ArrayList`.
while (itr.next()) |e| {
    // This visits every element, including the one we remove.
    if (e == 2) {
        var removed = itr.swapRemove();
        assert(removed == e);
    }
}
// Array now contains: [0, 1, 4, 3].  (the 2 was replaced with the 4.)
```
If you only have a `*const std.ArrayList`, there's `.iteratorConst()`, which gives you an iterator with _only_ the old behavior - i.e: which cannot remove elements.