### PR TITLE
Hash tooling changes

### DIFF
--- a/std/crypto/blake2.zig
+++ b/std/crypto/blake2.zig
@@ -269,8 +269,8 @@ pub const Blake2b512 = Blake2b(512);
 fn Blake2b(comptime out_len: usize) type {
     return struct {
         const Self = @This();
-        const block_length = 128;
-        const digest_length = out_len / 8;
+        pub const block_length = 128;
+        pub const digest_length = out_len / 8;
 
         const iv = [8]u64{
             0x6a09e667f3bcc908,

--- a/std/crypto/sha2.zig
+++ b/std/crypto/sha2.zig
@@ -420,8 +420,8 @@ pub const Sha512 = Sha2_64(Sha512Params);
 fn Sha2_64(comptime params: Sha2Params64) type {
     return struct {
         const Self = @This();
-        const block_length = 128;
-        const digest_length = params.out_len / 8;
+        pub const block_length = 128;
+        pub const digest_length = params.out_len / 8;
 
         s: [8]u64,
         // Streaming Cache

--- a/std/hash/crc.zig
+++ b/std/hash/crc.zig
@@ -9,17 +9,17 @@ const std = @import("../std.zig");
 const debug = std.debug;
 const testing = std.testing;
 
-pub const Polynomial = struct {
-    const IEEE = 0xedb88320;
-    const Castagnoli = 0x82f63b78;
-    const Koopman = 0xeb31d82e;
+pub const Polynomial = enum(u32) {
+    IEEE = 0xedb88320,
+    Castagnoli = 0x82f63b78,
+    Koopman = 0xeb31d82e,
 };
 
 // IEEE is by far the most common CRC and so is aliased by default.
-pub const Crc32 = Crc32WithPoly(Polynomial.IEEE);
+pub const Crc32 = Crc32WithPoly(.IEEE);
 
 // slicing-by-8 crc32 implementation.
-pub fn Crc32WithPoly(comptime poly: u32) type {
+pub fn Crc32WithPoly(comptime poly: Polynomial) type {
     return struct {
         const Self = @This();
         const lookup_tables = comptime block: {
@@ -31,7 +31,7 @@ pub fn Crc32WithPoly(comptime poly: u32) type {
                 var j: usize = 0;
                 while (j < 8) : (j += 1) {
                     if (crc & 1 == 1) {
-                        crc = (crc >> 1) ^ poly;
+                        crc = (crc >> 1) ^ @enumToInt(poly);
                     } else {
                         crc = (crc >> 1);
                     }
@@ -100,7 +100,7 @@ pub fn Crc32WithPoly(comptime poly: u32) type {
 }
 
 test "crc32 ieee" {
-    const Crc32Ieee = Crc32WithPoly(Polynomial.IEEE);
+    const Crc32Ieee = Crc32WithPoly(.IEEE);
 
     testing.expect(Crc32Ieee.hash("") == 0x00000000);
     testing.expect(Crc32Ieee.hash("a") == 0xe8b7be43);
@@ -108,7 +108,7 @@ test "crc32 ieee" {
 }
 
 test "crc32 castagnoli" {
-    const Crc32Castagnoli = Crc32WithPoly(Polynomial.Castagnoli);
+    const Crc32Castagnoli = Crc32WithPoly(.Castagnoli);
 
     testing.expect(Crc32Castagnoli.hash("") == 0x00000000);
     testing.expect(Crc32Castagnoli.hash("a") == 0xc1d04330);
@@ -116,7 +116,7 @@ test "crc32 castagnoli" {
 }
 
 // half-byte lookup table implementation.
-pub fn Crc32SmallWithPoly(comptime poly: u32) type {
+pub fn Crc32SmallWithPoly(comptime poly: Polynomial) type {
     return struct {
         const Self = @This();
         const lookup_table = comptime block: {
@@ -127,7 +127,7 @@ pub fn Crc32SmallWithPoly(comptime poly: u32) type {
                 var j: usize = 0;
                 while (j < 8) : (j += 1) {
                     if (crc & 1 == 1) {
-                        crc = (crc >> 1) ^ poly;
+                        crc = (crc >> 1) ^ @enumToInt(poly);
                     } else {
                         crc = (crc >> 1);
                     }
@@ -164,7 +164,7 @@ pub fn Crc32SmallWithPoly(comptime poly: u32) type {
 }
 
 test "small crc32 ieee" {
-    const Crc32Ieee = Crc32SmallWithPoly(Polynomial.IEEE);
+    const Crc32Ieee = Crc32SmallWithPoly(.IEEE);
 
     testing.expect(Crc32Ieee.hash("") == 0x00000000);
     testing.expect(Crc32Ieee.hash("a") == 0xe8b7be43);
@@ -172,7 +172,7 @@ test "small crc32 ieee" {
 }
 
 test "small crc32 castagnoli" {
-    const Crc32Castagnoli = Crc32SmallWithPoly(Polynomial.Castagnoli);
+    const Crc32Castagnoli = Crc32SmallWithPoly(.Castagnoli);
 
     testing.expect(Crc32Castagnoli.hash("") == 0x00000000);
     testing.expect(Crc32Castagnoli.hash("a") == 0xc1d04330);

--- a/std/hash/siphash.zig
+++ b/std/hash/siphash.zig
@@ -152,8 +152,8 @@ fn SipHash(comptime T: type, comptime c_rounds: usize, comptime d_rounds: usize)
 
         pub fn hash(key: []const u8, input: []const u8) T {
             var c = Self.init(key);
-            c.update(input);
-            return c.final();
+            @inlineCall(c.update, input);
+            return @inlineCall(c.final);
         }
     };
 }

--- a/std/hash/wyhash.zig
+++ b/std/hash/wyhash.zig
@@ -116,8 +116,8 @@ pub const Wyhash = struct {
 
     pub fn hash(seed: u64, input: []const u8) u64 {
         var c = Wyhash.init(seed);
-        c.update(input);
-        return c.final();
+        @inlineCall(c.update, input);
+        return @inlineCall(c.final);
     }
 };
 


### PR DESCRIPTION
Update the benchmarking scripts for hash/crypto functions. Adds some new hashes to them and small key throughput tests.

This gives moderate speed improvements when hashing small keys.
The crc/adler/fnv inlining did not provide enough speed up to warrant
the change.

Also, I've inlined some hashes since the speed seems better.

```
OLD:

wyhash
  small keys: 2277 MiB/s [c14617a1e3800000]
siphash(1,3)
  small keys:  937 MiB/s [b2919222ed400000]
siphash(2,4)
  small keys:  722 MiB/s [3c3d974cc2800000]
fnv1a
  small keys: 1580 MiB/s [70155e1cb7000000]
adler32
  small keys: 1898 MiB/s [00013883ef800000]
crc32-slicing-by-8
  small keys: 2323 MiB/s [0035bf3dcac00000]
crc32-half-byte-lookup
  small keys:  218 MiB/s [0035bf3dcac00000]

NEW:

wyhash
  small keys: 2775 MiB/s [c14617a1e3800000]
siphash(1,3)
  small keys: 1086 MiB/s [b2919222ed400000]
siphash(2,4)
  small keys:  789 MiB/s [3c3d974cc2800000]
fnv1a
  small keys: 1604 MiB/s [70155e1cb7000000]
adler32
  small keys: 1856 MiB/s [00013883ef800000]
crc32-slicing-by-8
  small keys: 2336 MiB/s [0035bf3dcac00000]
crc32-half-byte-lookup
  small keys:  218 MiB/s [0035bf3dcac00000]
```