### PR TITLE
Encapsulate bigint representation, assert on cast data loss

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -1036,7 +1036,7 @@ static bool analyze_const_align(CodeGen *g, Scope *scope, AstNode *node, uint32_
     if (type_is_invalid(align_result->type))
         return false;
 
-    uint32_t align_bytes = bigint_as_unsigned(&align_result->data.x_bigint);
+    uint32_t align_bytes = bigint_as_u32(&align_result->data.x_bigint);
     if (align_bytes == 0) {
         add_node_error(g, node, buf_sprintf("alignment must be >= 1"));
         return false;
@@ -1068,7 +1068,7 @@ static bool analyze_const_string(CodeGen *g, Scope *scope, AstNode *node, Buf **
         return true;
     }
     expand_undef_array(g, array_val);
-    size_t len = bigint_as_unsigned(&len_field->data.x_bigint);
+    size_t len = bigint_as_usize(&len_field->data.x_bigint);
     Buf *result = buf_alloc();
     buf_resize(result, len);
     for (size_t i = 0; i < len; i += 1) {
@@ -1078,7 +1078,7 @@ static bool analyze_const_string(CodeGen *g, Scope *scope, AstNode *node, Buf **
             add_node_error(g, node, buf_sprintf("use of undefined value"));
             return false;
         }
-        uint64_t big_c = bigint_as_unsigned(&char_val->data.x_bigint);
+        uint64_t big_c = bigint_as_u64(&char_val->data.x_bigint);
         assert(big_c <= UINT8_MAX);
         uint8_t c = (uint8_t)big_c;
         buf_ptr(result)[i] = c;
@@ -5976,7 +5976,7 @@ void render_const_value(CodeGen *g, Buf *buf, ConstExprValue *const_val) {
             {
                 if (is_slice(type_entry)) {
                     ConstExprValue *len_val = &const_val->data.x_struct.fields[slice_len_index];
-                    size_t len = bigint_as_unsigned(&len_val->data.x_bigint);
+                    size_t len = bigint_as_usize(&len_val->data.x_bigint);
 
                     ConstExprValue *ptr_val = &const_val->data.x_struct.fields[slice_ptr_index];
                     if (ptr_val->special == ConstValSpecialUndef) {

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -15,6 +15,8 @@
 #include <limits>
 #include <algorithm>
 
+static uint64_t bigint_as_unsigned(const BigInt *bigint);
+
 static void bigint_normalize(BigInt *dest) {
     const uint64_t *digits = bigint_ptr(dest);
 
@@ -1660,7 +1662,7 @@ size_t bigint_clz(const BigInt *bi, size_t bit_count) {
     return count;
 }
 
-uint64_t bigint_as_unsigned(const BigInt *bigint) {
+static uint64_t bigint_as_unsigned(const BigInt *bigint) {
     assert(!bigint->is_negative);
     if (bigint->digit_count == 0) {
         return 0;
@@ -1669,6 +1671,25 @@ uint64_t bigint_as_unsigned(const BigInt *bigint) {
     } else {
         zig_unreachable();
     }
+}
+
+uint64_t bigint_as_u64(const BigInt *bigint)
+{
+    return bigint_as_unsigned(bigint);
+}
+
+uint32_t bigint_as_u32(const BigInt *bigint) {
+    uint64_t value64 = bigint_as_unsigned(bigint);
+    uint32_t value32 = (uint32_t)value64;
+    assert (value64 == value32);
+    return value32;
+}
+
+size_t bigint_as_usize(const BigInt *bigint) {
+    uint64_t value64 = bigint_as_unsigned(bigint);
+    size_t valueUsize = (size_t)value64;
+    assert (value64 == valueUsize);
+    return valueUsize;
 }
 
 int64_t bigint_as_signed(const BigInt *bigint) {

--- a/src/bigint.hpp
+++ b/src/bigint.hpp
@@ -36,7 +36,10 @@ void bigint_init_bigfloat(BigInt *dest, const BigFloat *op);
 void bigint_init_data(BigInt *dest, const uint64_t *digits, size_t digit_count, bool is_negative);
 
 // panics if number won't fit
-uint64_t bigint_as_unsigned(const BigInt *bigint);
+uint64_t bigint_as_u64(const BigInt *bigint);
+uint32_t bigint_as_u32(const BigInt *bigint);
+size_t bigint_as_usize(const BigInt *bigint);
+
 int64_t bigint_as_signed(const BigInt *bigint);
 
 static inline const uint64_t *bigint_ptr(const BigInt *bigint) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2872,7 +2872,7 @@ static void add_error_range_check(CodeGen *g, ZigType *err_set_type, ZigType *in
         eval_min_max_value_int(g, int_type, &biggest_possible_err_val, true);
 
         if (bigint_fits_in_bits(&biggest_possible_err_val, 64, false) &&
-            bigint_as_unsigned(&biggest_possible_err_val) < g->errors_by_index.length)
+            bigint_as_usize(&biggest_possible_err_val) < g->errors_by_index.length)
         {
             ok_bit = neq_zero_bit;
         } else {


### PR DESCRIPTION
There are a number of places in the code where `uint64_t` is being implicitly cast to smaller integer types such as `uint32_t`.  This happens when the value of `bigint_as_unsigned` is assigned to a `uint32_t`.   However it's not obvious from the call site that `bigint_as_unsigned` is returning a `uint64_t` which makes it easy to make this mistake.

Instead, I've removed `bigint_as_unsigned` from the header file, and replaced it with:
* `bigint_as_u32`
* `bigint_as_u64`
* `bigint_as_usize`

The caller doesn't care whether bigint uses a `uint64_t` under the hood, they just want to be able to retrieve type-specific values and assert when the value is out-of-range.
