### PR TITLE
std/hash: Revert crc32 api change

### DIFF
--- a/std/hash/benchmark.zig
+++ b/std/hash/benchmark.zig
@@ -47,11 +47,11 @@ const hashes = [_]Hash{
         .name = "adler32",
     },
     Hash{
-        .ty = hash.crc.Crc32WithPoly(.IEEE),
+        .ty = hash.crc.Crc32WithPoly(hash.crc.Polynomial.IEEE),
         .name = "crc32-slicing-by-8",
     },
     Hash{
-        .ty = hash.crc.Crc32SmallWithPoly(.IEEE),
+        .ty = hash.crc.Crc32SmallWithPoly(hash.crc.Polynomial.IEEE),
         .name = "crc32-half-byte-lookup",
     },
     Hash{

--- a/std/hash/crc.zig
+++ b/std/hash/crc.zig
@@ -9,17 +9,17 @@ const std = @import("../std.zig");
 const debug = std.debug;
 const testing = std.testing;
 
-pub const Polynomial = enum(u32) {
-    IEEE = 0xedb88320,
-    Castagnoli = 0x82f63b78,
-    Koopman = 0xeb31d82e,
+pub const Polynomial = struct {
+    pub const IEEE = 0xedb88320;
+    pub const Castagnoli = 0x82f63b78;
+    pub const Koopman = 0xeb31d82e;
 };
 
 // IEEE is by far the most common CRC and so is aliased by default.
-pub const Crc32 = Crc32WithPoly(.IEEE);
+pub const Crc32 = Crc32WithPoly(Polynomial.IEEE);
 
 // slicing-by-8 crc32 implementation.
-pub fn Crc32WithPoly(comptime poly: Polynomial) type {
+pub fn Crc32WithPoly(comptime poly: u32) type {
     return struct {
         const Self = @This();
         const lookup_tables = comptime block: {
@@ -31,7 +31,7 @@ pub fn Crc32WithPoly(comptime poly: Polynomial) type {
                 var j: usize = 0;
                 while (j < 8) : (j += 1) {
                     if (crc & 1 == 1) {
-                        crc = (crc >> 1) ^ @enumToInt(poly);
+                        crc = (crc >> 1) ^ poly;
                     } else {
                         crc = (crc >> 1);
                     }
@@ -100,7 +100,7 @@ pub fn Crc32WithPoly(comptime poly: Polynomial) type {
 }
 
 test "crc32 ieee" {
-    const Crc32Ieee = Crc32WithPoly(.IEEE);
+    const Crc32Ieee = Crc32WithPoly(Polynomial.IEEE);
 
     testing.expect(Crc32Ieee.hash("") == 0x00000000);
     testing.expect(Crc32Ieee.hash("a") == 0xe8b7be43);
@@ -108,7 +108,7 @@ test "crc32 ieee" {
 }
 
 test "crc32 castagnoli" {
-    const Crc32Castagnoli = Crc32WithPoly(.Castagnoli);
+    const Crc32Castagnoli = Crc32WithPoly(Polynomial.Castagnoli);
 
     testing.expect(Crc32Castagnoli.hash("") == 0x00000000);
     testing.expect(Crc32Castagnoli.hash("a") == 0xc1d04330);
@@ -116,7 +116,7 @@ test "crc32 castagnoli" {
 }
 
 // half-byte lookup table implementation.
-pub fn Crc32SmallWithPoly(comptime poly: Polynomial) type {
+pub fn Crc32SmallWithPoly(comptime poly: u32) type {
     return struct {
         const Self = @This();
         const lookup_table = comptime block: {
@@ -127,7 +127,7 @@ pub fn Crc32SmallWithPoly(comptime poly: Polynomial) type {
                 var j: usize = 0;
                 while (j < 8) : (j += 1) {
                     if (crc & 1 == 1) {
-                        crc = (crc >> 1) ^ @enumToInt(poly);
+                        crc = (crc >> 1) ^ poly;
                     } else {
                         crc = (crc >> 1);
                     }
@@ -164,7 +164,7 @@ pub fn Crc32SmallWithPoly(comptime poly: Polynomial) type {
 }
 
 test "small crc32 ieee" {
-    const Crc32Ieee = Crc32SmallWithPoly(.IEEE);
+    const Crc32Ieee = Crc32SmallWithPoly(Polynomial.IEEE);
 
     testing.expect(Crc32Ieee.hash("") == 0x00000000);
     testing.expect(Crc32Ieee.hash("a") == 0xe8b7be43);
@@ -172,7 +172,7 @@ test "small crc32 ieee" {
 }
 
 test "small crc32 castagnoli" {
-    const Crc32Castagnoli = Crc32SmallWithPoly(.Castagnoli);
+    const Crc32Castagnoli = Crc32SmallWithPoly(Polynomial.Castagnoli);
 
     testing.expect(Crc32Castagnoli.hash("") == 0x00000000);
     testing.expect(Crc32Castagnoli.hash("a") == 0xc1d04330);


### PR DESCRIPTION
This is user specified and the user doesn't necessarily have to use one
of the provided polynomials declared hence we can't use an enum.

Thanks @daurnimator for catching this.