### PR TITLE
Fix comptime bitcast inside an expression

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -14822,6 +14822,10 @@ static IrInstruction *ir_resolve_result_raw(IrAnalyze *ira, IrInstruction *suspe
                 bitcasted_value = nullptr;
             }
 
+            if (bitcasted_value == nullptr || type_is_invalid(bitcasted_value->value.type)) {
+                return bitcasted_value;
+            }
+
             IrInstruction *parent_result_loc = ir_resolve_result(ira, suspend_source_instr, result_bit_cast->parent,
                     dest_type, bitcasted_value, force_runtime, non_null_comptime, true);
             if (parent_result_loc == nullptr || type_is_invalid(parent_result_loc->value.type) ||

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1083,6 +1083,15 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
+        "@bitCast with different sizes inside an expression",
+        \\export fn entry() void {
+        \\    var foo = (@bitCast(u8, f32(1.0)) == 0xf);
+        \\}
+    ,
+        "tmp.zig:2:25: error: destination type 'u8' has size 1 but source type 'f32' has size 4",
+    );
+
+    cases.add(
         "attempted `&&`",
         \\export fn entry(a: bool, b: bool) i32 {
         \\    if (a && b) {

--- a/test/stage1/behavior/bitcast.zig
+++ b/test/stage1/behavior/bitcast.zig
@@ -139,3 +139,10 @@ test "bitcast packed struct literal to byte" {
     const casted = @bitCast(u8, Foo{ .value = 0xF });
     expect(casted == 0xf);
 }
+
+test "comptime bitcast used in expression has the correct type" {
+    const Foo = packed struct {
+        value: u8,
+    };
+    expect(@bitCast(u8, Foo{ .value = 0xF }) == 0xf);
+}


### PR DESCRIPTION
Fixes #3099 

Also adds a compile error test, because before this fix a bitcast in an expression resulted in 2 of the same compile errors instead of 1.

Edit: Tests pass, MacOS lost connection