### PR TITLE
add missing check for a runtime known pointer in struct_field_ptr

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -17085,7 +17085,8 @@ static IrInstruction *ir_analyze_struct_field_ptr(IrAnalyze *ira, IrInstruction 
                 }
             }
             IrInstruction *result;
-            if (ptr_val->data.x_ptr.mut == ConstPtrMutInfer) {
+            if (ptr_val->data.x_ptr.mut == ConstPtrMutInfer ||
+                    ptr_val->data.x_ptr.mut == ConstPtrMutRuntimeVar) {
                 result = ir_build_struct_field_ptr(&ira->new_irb, source_instr->scope,
                         source_instr->source_node, struct_ptr, field);
                 result->value.type = ptr_type;


### PR DESCRIPTION
This adds a missing check in `ir_analyze_struct_field_ptr` which causes the compiler to hit an assert as can be seen in #3046.

The same pattern as in `ir_analyze_struct_field_ptr` can be seen in `ir_analyze_unwrap_err_code`. The check that was missing was the one at line 22602: 
```
if (ptr_val->data.x_ptr.mut != ConstPtrMutRuntimeVar && // <-- This line
    ptr_val->data.x_ptr.special != ConstPtrSpecialHardCodedAddr)
{
```
However when I added this same check in `ir_analyze_struct_field_ptr` on line 17069, it causes the compiler to segfault when building `stage1.zig`. But I'm pretty sure that that would be the correct solution.

Right now I added the check a bit 'deeper' into the function `ir_analyze_struct_field_ptr` and it passes the tests.