### PR TITLE
Use LLVM path provided by homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ brew install cmake llvm@8
 brew outdated llvm@8 || brew upgrade llvm@8
 mkdir build
 cd build
-cmake .. -DCMAKE_PREFIX_PATH=/usr/local/Cellar/llvm/8.0.0_1
+cmake .. -DCMAKE_PREFIX_PATH=$(brew --prefix llvm)
 make install
 ```
 


### PR DESCRIPTION
The Cellar path changes on dot releases of LLVM and the current instructions fails with CMake saying `unable to find llvm-config`. This PR updates the instructions to fix that.