### PR TITLE
fix stage1 to build on macOS + xcode/clang

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -25673,8 +25673,8 @@ static Error ir_resolve_lazy_raw(AstNode *source_node, ConstExprValue *val) {
                 }
             }
 
-            uint64_t abi_size;
-            uint64_t size_in_bits;
+            size_t abi_size;
+            size_t size_in_bits;
             if ((err = type_val_resolve_abi_size(ira->codegen, source_node, &lazy_size_of->target_type->value,
                             &abi_size, &size_in_bits)))
             {


### PR DESCRIPTION
macOS build breaks as of 10541c8fc88875cb51df0a5fdeda20847133e676