### PR TITLE
reject types of automatic container layout in packed unions

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -1336,8 +1336,8 @@ static bool analyze_const_string(CodeGen *g, Scope *scope, AstNode *node, Buf **
     return true;
 }
 
-static Error emit_error_unless_type_allowed_in_packed_struct(CodeGen *g, ZigType *type_entry,
-        AstNode *source_node)
+static Error emit_error_unless_type_allowed_in_packed_container(CodeGen *g, ZigType *type_entry,
+        AstNode *source_node, const char* container_name)
 {
     Error err;
     switch (type_entry->id) {
@@ -1358,8 +1358,8 @@ static Error emit_error_unless_type_allowed_in_packed_struct(CodeGen *g, ZigType
         case ZigTypeIdFnFrame:
         case ZigTypeIdAnyFrame:
             add_node_error(g, source_node,
-                    buf_sprintf("type '%s' not allowed in packed struct; no guaranteed in-memory representation",
-                        buf_ptr(&type_entry->name)));
+                    buf_sprintf("type '%s' not allowed in packed %s; no guaranteed in-memory representation",
+                        buf_ptr(&type_entry->name), container_name));
             return ErrorSemanticAnalyzeFail;
         case ZigTypeIdVoid:
         case ZigTypeIdBool:
@@ -1371,14 +1371,14 @@ static Error emit_error_unless_type_allowed_in_packed_struct(CodeGen *g, ZigType
             return ErrorNone;
         case ZigTypeIdArray: {
             ZigType *elem_type = type_entry->data.array.child_type;
-            if ((err = emit_error_unless_type_allowed_in_packed_struct(g, elem_type, source_node)))
+            if ((err = emit_error_unless_type_allowed_in_packed_container(g, elem_type, source_node, container_name)))
                 return err;
             // TODO revisit this when doing https://github.com/ziglang/zig/issues/1512
             if (type_size(g, type_entry) * 8 == type_size_bits(g, type_entry))
                 return ErrorNone;
             add_node_error(g, source_node,
-                buf_sprintf("array of '%s' not allowed in packed struct due to padding bits",
-                    buf_ptr(&elem_type->name)));
+                buf_sprintf("array of '%s' not allowed in packed %s due to padding bits",
+                    buf_ptr(&elem_type->name), container_name));
             return ErrorSemanticAnalyzeFail;
         }
         case ZigTypeIdStruct:
@@ -1388,8 +1388,8 @@ static Error emit_error_unless_type_allowed_in_packed_struct(CodeGen *g, ZigType
                     return ErrorNone;
                 case ContainerLayoutAuto:
                     add_node_error(g, source_node,
-                        buf_sprintf("non-packed, non-extern struct '%s' not allowed in packed struct; no guaranteed in-memory representation",
-                            buf_ptr(&type_entry->name)));
+                        buf_sprintf("non-packed, non-extern struct '%s' not allowed in packed %s; no guaranteed in-memory representation",
+                            buf_ptr(&type_entry->name), container_name));
                     return ErrorSemanticAnalyzeFail;
             }
             zig_unreachable();
@@ -1400,8 +1400,8 @@ static Error emit_error_unless_type_allowed_in_packed_struct(CodeGen *g, ZigType
                     return ErrorNone;
                 case ContainerLayoutAuto:
                     add_node_error(g, source_node,
-                        buf_sprintf("non-packed, non-extern union '%s' not allowed in packed struct; no guaranteed in-memory representation",
-                            buf_ptr(&type_entry->name)));
+                        buf_sprintf("non-packed, non-extern union '%s' not allowed in packed %s; no guaranteed in-memory representation",
+                            buf_ptr(&type_entry->name), container_name));
                     return ErrorSemanticAnalyzeFail;
             }
             zig_unreachable();
@@ -1410,8 +1410,8 @@ static Error emit_error_unless_type_allowed_in_packed_struct(CodeGen *g, ZigType
                 return ErrorNone;
             } else {
                 add_node_error(g, source_node,
-                    buf_sprintf("type '%s' not allowed in packed struct; no guaranteed in-memory representation",
-                        buf_ptr(&type_entry->name)));
+                    buf_sprintf("type '%s' not allowed in packed %s; no guaranteed in-memory representation",
+                        buf_ptr(&type_entry->name), container_name));
                 return ErrorSemanticAnalyzeFail;
             }
         case ZigTypeIdEnum: {
@@ -1420,14 +1420,26 @@ static Error emit_error_unless_type_allowed_in_packed_struct(CodeGen *g, ZigType
                 return ErrorNone;
             }
             ErrorMsg *msg = add_node_error(g, source_node,
-                buf_sprintf("type '%s' not allowed in packed struct; no guaranteed in-memory representation",
-                    buf_ptr(&type_entry->name)));
+                buf_sprintf("type '%s' not allowed in packed %s; no guaranteed in-memory representation",
+                    buf_ptr(&type_entry->name), container_name));
             add_error_note(g, msg, decl_node,
                     buf_sprintf("enum declaration does not specify an integer tag type"));
             return ErrorSemanticAnalyzeFail;
         }
     }
     zig_unreachable();
+}
+
+static Error emit_error_unless_type_allowed_in_packed_struct(CodeGen *g, ZigType *type_entry,
+    AstNode *source_node)
+{
+    return emit_error_unless_type_allowed_in_packed_container(g, type_entry, source_node, "struct");
+}
+
+static Error emit_error_unless_type_allowed_in_packed_union(CodeGen *g, ZigType *type_entry,
+    AstNode *source_node)
+{
+    return emit_error_unless_type_allowed_in_packed_container(g, type_entry, source_node, "union");
 }
 
 bool type_allowed_in_extern(CodeGen *g, ZigType *type_entry) {
@@ -2172,6 +2184,8 @@ static Error resolve_union_type(CodeGen *g, ZigType *union_type) {
     // set temporary flag
     union_type->data.unionation.resolve_loop_flag_other = true;
 
+    const bool is_packed = union_type->data.unionation.layout == ContainerLayoutPacked;
+
     for (uint32_t i = 0; i < field_count; i += 1) {
         TypeUnionField *union_field = &union_type->data.unionation.fields[i];
         ZigType *field_type = resolve_union_field_type(g, union_field);
@@ -2183,6 +2197,12 @@ static Error resolve_union_type(CodeGen *g, ZigType *union_type) {
         if ((err = type_resolve(g, field_type, ResolveStatusSizeKnown))) {
             union_type->data.unionation.resolve_status = ResolveStatusInvalid;
             return ErrorSemanticAnalyzeFail;
+        }
+        if (is_packed) {
+            if ((err = emit_error_unless_type_allowed_in_packed_union(g, field_type, union_field->decl_node))) {
+                union_type->data.unionation.resolve_status = ResolveStatusInvalid;
+                return err;
+            }
         }
 
         if (type_is_invalid(union_type))

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -6197,6 +6197,23 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     );
 
     cases.add(
+        "packed union with automatic layout field",
+        \\const Foo = struct {
+        \\    a: u32,
+        \\    b: f32,
+        \\};
+        \\const Payload = packed union {
+        \\    A: Foo,
+        \\    B: bool,
+        \\};
+        \\export fn entry() void {
+        \\    var a = Payload { .B = true };
+        \\}
+    ,
+        "tmp.zig:6:5: error: non-packed, non-extern struct 'Foo' not allowed in packed union; no guaranteed in-memory representation",
+    );
+
+    cases.add(
         "switch on union with no attached enum",
         \\const Payload = union {
         \\    A: i32,


### PR DESCRIPTION
Fixes #3040.
Also fixes #3053.

```
crash.zig:4:5: error: non-packed, non-extern struct 'std.array_list.AlignedArrayList(i32,null)' not allowed in packed union; no guaranteed in-memory representation
    list: List,
    ^
```

From the documentation, packed unions seemed to follow the same rules as packed structs so this will use the same code to check field types.