### PR TITLE
cmake: improve building without git repository

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,18 @@ find_program(GIT_EXE NAMES git)
 if(GIT_EXE)
     execute_process(
         COMMAND ${GIT_EXE} -C ${CMAKE_SOURCE_DIR} name-rev HEAD --tags --name-only --no-undefined --always
+        RESULT_VARIABLE EXIT_STATUS
         OUTPUT_VARIABLE ZIG_GIT_REV
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(ZIG_GIT_REV MATCHES "\\^0$")
-        if(NOT("${ZIG_GIT_REV}" STREQUAL "${ZIG_VERSION}^0"))
-            message("WARNING: Tag does not match configured Zig version")
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET)
+    if(EXIT_STATUS EQUAL "0")
+        if(ZIG_GIT_REV MATCHES "\\^0$")
+            if(NOT("${ZIG_GIT_REV}" STREQUAL "${ZIG_VERSION}^0"))
+                message("WARNING: Tag does not match configured Zig version")
+            endif()
+        else()
+            set(ZIG_VERSION "${ZIG_VERSION}+${ZIG_GIT_REV}")
         endif()
-    else()
-        set(ZIG_VERSION "${ZIG_VERSION}+${ZIG_GIT_REV}")
     endif()
 endif()
 message("Configuring zig version ${ZIG_VERSION}")


### PR DESCRIPTION
- quiet `fatal: not a git repository` message
- if git probe fails skip ZIG_VERSION modification
- verified `RESULT_VARIABLE` and `ERROR_QUIET` are supported in cmake `2.8.5`
- tested on macos/linux/windows10

#### output BEFORE/AFTER
```diff
diff --git a/cmake.log b/cmake.log
index d97e672..4816e34 100644
--- a/cmake.log
+++ b/cmake.log
@@ -1,2 +1 @@
-fatal: not a git repository (or any of the parent directories): .git
-Configuring zig version 0.4.0+
+Configuring zig version 0.4.0
```