### PR TITLE
stage1 enhance IR print

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -4419,7 +4419,7 @@ static void analyze_fn_ir(CodeGen *g, ZigFn *fn, AstNode *return_type_node) {
 
     if (g->verbose_ir) {
         fprintf(stderr, "fn %s() { // (analyzed)\n", buf_ptr(&fn->symbol_name));
-        ir_print(g, stderr, &fn->analyzed_executable, 4, 2);
+        ir_print(g, stderr, &fn->analyzed_executable, 4, IrPassGen);
         fprintf(stderr, "}\n");
     }
     fn->anal_state = FnAnalStateComplete;
@@ -4452,8 +4452,8 @@ static void analyze_fn_body(CodeGen *g, ZigFn *fn_table_entry) {
     if (g->verbose_ir) {
         fprintf(stderr, "\n");
         ast_render(stderr, fn_table_entry->body_node, 4);
-        fprintf(stderr, "\n{ // (IR)\n");
-        ir_print(g, stderr, &fn_table_entry->ir_executable, 4, 1);
+        fprintf(stderr, "\nfn %s() { // (IR)\n", buf_ptr(&fn_table_entry->symbol_name));
+        ir_print(g, stderr, &fn_table_entry->ir_executable, 4, IrPassSrc);
         fprintf(stderr, "}\n");
     }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -10892,7 +10892,7 @@ ConstExprValue *ir_eval_const_value(CodeGen *codegen, Scope *scope, AstNode *nod
         fprintf(stderr, "\nSource: ");
         ast_render(stderr, node, 4);
         fprintf(stderr, "\n{ // (IR)\n");
-        ir_print(codegen, stderr, ir_executable, 2, 1);
+        ir_print(codegen, stderr, ir_executable, 2, IrPassSrc);
         fprintf(stderr, "}\n");
     }
     IrExecutable *analyzed_executable = allocate<IrExecutable>(1);
@@ -10913,7 +10913,7 @@ ConstExprValue *ir_eval_const_value(CodeGen *codegen, Scope *scope, AstNode *nod
 
     if (codegen->verbose_ir) {
         fprintf(stderr, "{ // (analyzed)\n");
-        ir_print(codegen, stderr, analyzed_executable, 2, 2);
+        ir_print(codegen, stderr, analyzed_executable, 2, IrPassGen);
         fprintf(stderr, "}\n");
     }
 

--- a/src/ir.hpp
+++ b/src/ir.hpp
@@ -10,6 +10,11 @@
 
 #include "all_types.hpp"
 
+enum IrPass {
+    IrPassSrc,
+    IrPassGen,
+};
+
 bool ir_gen(CodeGen *g, AstNode *node, Scope *scope, IrExecutable *ir_executable);
 bool ir_gen_fn(CodeGen *g, ZigFn *fn_entry);
 

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -22,7 +22,7 @@ using InstructionSet = HashMap<IrInstruction*, uint8_t, hash_instruction_ptr, in
 using InstructionList = ZigList<IrInstruction*>;
 
 struct IrPrint {
-    size_t pass_num;
+    IrPass pass;
     CodeGen *codegen;
     FILE *f;
     int indent;
@@ -391,7 +391,7 @@ static void ir_print_const_value(IrPrint *irp, ConstExprValue *const_val) {
 
 static void ir_print_var_instruction(IrPrint *irp, IrInstruction *instruction) {
     fprintf(irp->f, "#%" ZIG_PRI_usize "", instruction->debug_id);
-    if (irp->pass_num == 2 && irp->printed.maybe_get(instruction) == nullptr) {
+    if (irp->pass != IrPassSrc && irp->printed.maybe_get(instruction) == nullptr) {
         irp->printed.put(instruction, 0);
         irp->pending.append(instruction);
     }
@@ -2399,10 +2399,10 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction, bool 
     fprintf(irp->f, "\n");
 }
 
-void ir_print(CodeGen *codegen, FILE *f, IrExecutable *executable, int indent_size, size_t pass_num) {
+void ir_print(CodeGen *codegen, FILE *f, IrExecutable *executable, int indent_size, IrPass pass) {
     IrPrint ir_print = {};
     IrPrint *irp = &ir_print;
-    irp->pass_num = pass_num;
+    irp->pass = pass;
     irp->codegen = codegen;
     irp->f = f;
     irp->indent = indent_size;
@@ -2416,7 +2416,7 @@ void ir_print(CodeGen *codegen, FILE *f, IrExecutable *executable, int indent_si
         fprintf(irp->f, "%s_%" ZIG_PRI_usize ":\n", current_block->name_hint, current_block->debug_id);
         for (size_t instr_i = 0; instr_i < current_block->instruction_list.length; instr_i += 1) {
             IrInstruction *instruction = current_block->instruction_list.at(instr_i);
-            if (irp->pass_num == 2) {
+            if (irp->pass != IrPassSrc) {
                 irp->printed.put(instruction, 0);
                 irp->pending.clear();
             }
@@ -2430,10 +2430,10 @@ void ir_print(CodeGen *codegen, FILE *f, IrExecutable *executable, int indent_si
     irp->printed.deinit();
 }
 
-void ir_print_instruction(CodeGen *codegen, FILE *f, IrInstruction *instruction, int indent_size, size_t pass_num) {
+void ir_print_instruction(CodeGen *codegen, FILE *f, IrInstruction *instruction, int indent_size, IrPass pass) {
     IrPrint ir_print = {};
     IrPrint *irp = &ir_print;
-    irp->pass_num = pass_num;
+    irp->pass = pass;
     irp->codegen = codegen;
     irp->f = f;
     irp->indent = indent_size;

--- a/src/ir_print.hpp
+++ b/src/ir_print.hpp
@@ -12,7 +12,7 @@
 
 #include <stdio.h>
 
-void ir_print(CodeGen *codegen, FILE *f, IrExecutable *executable, int indent_size, size_t pass_num);
-void ir_print_instruction(CodeGen *codegen, FILE *f, IrInstruction *instruction, int indent_size, size_t pass_num);
+void ir_print(CodeGen *codegen, FILE *f, IrExecutable *executable, int indent_size, IrPass pass);
+void ir_print_instruction(CodeGen *codegen, FILE *f, IrInstruction *instruction, int indent_size, IrPass pass);
 
 #endif


### PR DESCRIPTION
- print `fn` name in pass1
- replace scalar with `enum IrPass` for clarity

This is a minor cosmetic change to help find first-pass functions.

#### BEFORE
```
{ // (IR)
Entry_0:
    #1  | ResetResult           | (unknown)   | - | ResetResult(none)
    #2  | ResetResult           | (unknown)   | - | ResetResult(none)
    #3  | ResetResult           | (unknown)   | - | ResetResult(none)
    #4  | Const                 | type        | 2 | u64
    #5  | EndExpr               | (unknown)   | - | EndExpr(result=none,value=u64)
    #6  | Const                 | bool        | 2 | false
...
```

#### DIFF
```diff
diff --git a/reduction.ir b/reduction.ir
index 76a0022..d9353c1 100644
--- a/reduction.ir
+++ b/reduction.ir
@@ -1,4 +1,4 @@
-{ // (IR)
+fn reduction() { // (IR)
 Entry_0:
     #1  | ResetResult           | (unknown)   | - | ResetResult(none)
     #2  | ResetResult           | (unknown)   | - | ResetResult(none)
```