### PR TITLE
Resolve lazy values when checking for definedness

### DIFF
--- a/test/stage1/behavior/sizeof_and_typeof.zig
+++ b/test/stage1/behavior/sizeof_and_typeof.zig
@@ -115,3 +115,12 @@ test "branching logic inside @typeOf" {
     comptime expect(T == i32);
     expect(S.data == 0);
 }
+
+fn fn1(alpha: bool) void {
+    const n: usize = 7;
+    const v = if (alpha) n else @sizeOf(usize);
+}
+
+test "lazy @sizeOf result is checked for definedness" {
+    const f = fn1;
+}


### PR DESCRIPTION
I think it makes sense to resolve the lazy value at that point and IMO is cleaner than having the caller do that every time before calling `value_is_all_undef`.

Fixes #3154