### PR TITLE
Forward framework dirs to embedded clang in addition to linker on macOS

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -784,7 +784,9 @@ int main(int argc, char **argv) {
                 } else if (strcmp(arg, "--library-path") == 0 || strcmp(arg, "-L") == 0) {
                     lib_dirs.append(argv[i]);
                 } else if (strcmp(arg, "-F") == 0) {
-                    framework_dirs.append(argv[i]);
+                    framework_dirs.append(argv[i]); // embedded linker
+                    clang_argv.append("-iframework"); // embedded clang
+                    clang_argv.append(argv[i]);
                 } else if (strcmp(arg, "--library") == 0 || strcmp(arg, "-l") == 0) {
                     if (strcmp(argv[i], "c") == 0)
                         have_libc = true;


### PR DESCRIPTION
### Problem

It seems that the default system/framework paths on macOS is a bit off currently (issue #2319 , #2208). Figuring out the best way to determine these paths is a bit over my head but while trying to work around the issue I do think I've encountered a bug in how zig passes arguments to `zig cc`:

It seems like if you use `exe.addFrameworkDir(path)`, the path is only forwarded to the linker (`-F path`), not the embedded clang (`-iframework path`).

### Proposed solution

Forward the argument to embedded clang in addition to the linker.

Feel free to close this if my reasoning is wrong :)

### To reproduce

Here is an example project: https://github.com/gustavolsson/zig-sokol-test

I'm trying to build the OpenGL app on macOS (old one 10.13.16) and get zig cc errors about Cocoa.h not being found. I want to work around the issue by explicitly specifying the path to Cocoa.framework on my specific machine, `/System/Library/Frameworks`, using `exe.addFrameworkDir(...)`:
```
exe.addFrameworkDir("/System/Library/Frameworks");
exe.linkFramework("Cocoa");
exe.linkFramework("OpenGL");
exe.enableSystemLinkerHack(); // Uses system linker instead of embedded ldd, I think...

const c_args = [2][]const u8{
    "-ObjC",
    "-fobjc-arc",
};
exe.addCSourceFile("src/sokol.c", c_args);
exe.addCSourceFile("src/clear-sapp.c", c_args);
```
(Note that I also enable the system linker hack because once `zig cc` succeeds the linking crashes due to MachO problems, which is way over my head and I want to show that the proposed fix manages to build the code)

I get the following error:
<pre>
In file included from /Users/gustav/Documents/Development/zig-ws/zig-sokol-test/src/sokol.c:10:
/Users/gustav/Documents/Development/zig-ws/zig-sokol-test/src/sokol_app.h:1088:10: fatal error:
      'Cocoa/Cocoa.h' file not found
#include <Cocoa/Cocoa.h>
         ^~~~~~~~~~~~~~~
1 error generated.

The following command failed:
/usr/local/Cellar/zig/HEAD-9a18db8/bin/zig cc -MD -MV -MF /Users/gustav/Documents/Development/zig-ws/zig-sokol-test/zig-cache/tmp/Ede7tHOXwhUx-sokol.o.d -nostdinc -fno-spell-checking -isystem /usr/local/Cellar/zig/HEAD-9a18db8/lib/zig/include -isystem /usr/include -march=native -g -fno-omit-frame-pointer -D_DEBUG -fstack-protector-strong --param ssp-buffer-size=4
-fPIC -o /Users/gustav/Documents/Development/zig-ws/zig-sokol-test/zig-cache/tmp/Ede7tHOXwhUx-sokol.o -c /Users/gustav/Documents/Development/zig-ws/zig-sokol-test/src/sokol.c -ObjC -fobjc-arc

The following command exited with error code 1:
/usr/local/Cellar/zig/HEAD-9a18db8/bin/zig build-exe --c-source -ObjC -fobjc-arc /Users/gustav/Documents/Development/zig-ws/zig-sokol-test/src/sokol.c --c-source -ObjC -fobjc-arc /Users/gustav/Documents/Development/zig-ws/zig-sokol-test/src/clear-sapp.c --cache-dir /Users/gustav/Documents/Development/zig-ws/zig-sokol-test/zig-cache --name zig-sokol-test
<b>-F /System/Library/Frameworks</b> -framework OpenGL -framework Cocoa --system-linker-hack --cache on

Build failed. The following command failed:
...
</pre>

Note that the `zig cc` command does not include `-iframework /System/Library/Frameworks` even though it exists in the zig build-exe command.

After the proposed change in main.cpp I can successfully build the app. `zig build --verbose-cc` outputs the following:
<pre>
/Users/gustav/Documents/Development/zig-ws/zig/build/bin/zig cc -MD -MV -MF /Users/gustav/Documents/Development/zig-ws/zig-sokol-test/zig-cache/tmp/B8D6I_DPJVzG-sokol.o.d -nostdinc -fno-spell-checking -isystem /Users/gustav/Documents/Development/zig-ws/zig/build/lib/zig/include -isystem /usr/include -march=native -g -fno-omit-frame-pointer -D_DEBUG -fstack-protector-strong --param ssp-buffer-size=4
-fPIC <b>-iframework /System/Library/Frameworks</b> -o /Users/gustav/Documents/Development/zig-ws/zig-sokol-test/zig-cache/tmp/B8D6I_DPJVzG-sokol.o -c /Users/gustav/Documents/Development/zig-ws/zig-sokol-test/src/sokol.c -ObjC -fobjc-arc
</pre>