### PR TITLE
Get more of the tests passing for FreeBSD

### DIFF
--- a/ci/srht/freebsd_script
+++ b/ci/srht/freebsd_script
@@ -28,7 +28,7 @@ release/bin/zig build test-stack-traces
 release/bin/zig build test-cli
 release/bin/zig build test-asm-link
 release/bin/zig build test-runtime-safety
-release/bin/zig build test-translate-c
+# release/bin/zig build test-translate-c
 release/bin/zig build test-gen-h
 release/bin/zig build test-compile-errors
 release/bin/zig build docs

--- a/ci/srht/freebsd_script
+++ b/ci/srht/freebsd_script
@@ -22,7 +22,7 @@ release/bin/zig build test-fmt
 release/bin/zig build test-behavior
 # release/bin/zig build test-std
 release/bin/zig build test-compiler-rt
-release/bin/zig build test-compare-output
+# release/bin/zig build test-compare-output
 release/bin/zig build test-standalone
 release/bin/zig build test-stack-traces
 release/bin/zig build test-cli

--- a/ci/srht/freebsd_script
+++ b/ci/srht/freebsd_script
@@ -23,7 +23,7 @@ release/bin/zig build test-behavior
 # release/bin/zig build test-std
 release/bin/zig build test-compiler-rt
 # release/bin/zig build test-compare-output
-release/bin/zig build test-standalone
+# release/bin/zig build test-standalone
 release/bin/zig build test-stack-traces
 release/bin/zig build test-cli
 release/bin/zig build test-asm-link

--- a/ci/srht/freebsd_script
+++ b/ci/srht/freebsd_script
@@ -18,7 +18,20 @@ cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_INSTALL_PREFIX=$(pwd)/release -DZIG_STATIC=ON
 make $JOBS install
 
-release/bin/zig build test
+release/bin/zig build test-fmt
+release/bin/zig build test-behavior
+# release/bin/zig build test-std
+release/bin/zig build test-compiler-rt
+release/bin/zig build test-compare-output
+release/bin/zig build test-standalone
+release/bin/zig build test-stack-traces
+release/bin/zig build test-cli
+release/bin/zig build test-asm-link
+release/bin/zig build test-runtime-safety
+release/bin/zig build test-translate-c
+release/bin/zig build test-gen-h
+release/bin/zig build test-compile-errors
+release/bin/zig build docs
 
 if [ -f ~/.s3cfg ]; then
   mv ../LICENSE release/

--- a/ci/srht/freebsd_script
+++ b/ci/srht/freebsd_script
@@ -18,14 +18,11 @@ cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_INSTALL_PREFIX=$(pwd)/release -DZIG_STATIC=ON
 make $JOBS install
 
-# TODO test everything. right now it's skipping stuff including docs
-# because for some reason @cImport is failing on the CI server.
-release/bin/zig build --build-file ../build.zig test-behavior -Dskip-release
+release/bin/zig build test
 
 if [ -f ~/.s3cfg ]; then
   mv ../LICENSE release/
-  # TODO re-enable this
-  #mv ../zig-cache/langref.html release/
+  mv ../zig-cache/langref.html release/
   mv release/bin/zig release/
   rmdir release/bin
 

--- a/ci/srht/freebsd_script
+++ b/ci/srht/freebsd_script
@@ -56,7 +56,8 @@ release/bin/zig build test-gen-h
 
 if [ -f ~/.s3cfg ]; then
   mv ../LICENSE release/
-  mv ../zig-cache/langref.html release/
+  # Enable when `release/bin/zig build docs` passes without "out of memory" or failures
+  #mv ../zig-cache/langref.html release/
   mv release/bin/zig release/
   rmdir release/bin
 

--- a/ci/srht/freebsd_script
+++ b/ci/srht/freebsd_script
@@ -20,17 +20,36 @@ make $JOBS install
 
 release/bin/zig build test-fmt
 release/bin/zig build test-behavior
+
+# This test is disabled because it triggers "out of memory" on the sr.ht CI service.
+# See https://github.com/ziglang/zig/issues/3210
 # release/bin/zig build test-std
+
 release/bin/zig build test-compiler-rt
+
+# This test is disabled because it triggers "out of memory" on the sr.ht CI service.
+# See https://github.com/ziglang/zig/issues/3210
 # release/bin/zig build test-compare-output
+
+# This test is disabled because it triggers "out of memory" on the sr.ht CI service.
+# See https://github.com/ziglang/zig/issues/3210
 # release/bin/zig build test-standalone
+
 release/bin/zig build test-stack-traces
 release/bin/zig build test-cli
 release/bin/zig build test-asm-link
 release/bin/zig build test-runtime-safety
+
+# This test is disabled because it triggers "out of memory" on the sr.ht CI service.
+# See https://github.com/ziglang/zig/issues/3210
 # release/bin/zig build test-translate-c
+
 release/bin/zig build test-gen-h
-release/bin/zig build test-compile-errors
+
+# This test is disabled because it triggers "out of memory" on the sr.ht CI service.
+# See https://github.com/ziglang/zig/issues/3210
+# release/bin/zig build test-compile-errors
+
 release/bin/zig build docs
 
 if [ -f ~/.s3cfg ]; then

--- a/ci/srht/freebsd_script
+++ b/ci/srht/freebsd_script
@@ -50,7 +50,9 @@ release/bin/zig build test-gen-h
 # See https://github.com/ziglang/zig/issues/3210
 # release/bin/zig build test-compile-errors
 
-release/bin/zig build docs
+# This test is disabled because it triggers "out of memory" on the sr.ht CI service.
+# See https://github.com/ziglang/zig/issues/3210
+# release/bin/zig build docs
 
 if [ -f ~/.s3cfg ]; then
   mv ../LICENSE release/

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -1774,6 +1774,10 @@ static void construct_linker_job_elf(LinkJob *lj) {
                 lj->args.append("-lgcc_s");
                 lj->args.append("--no-as-needed");
             }
+
+            if (g->zig_target->os == OsFreeBSD) {
+                lj->args.append("-lpthread");
+            }
         } else if (target_is_glibc(g->zig_target)) {
             if (target_supports_libunwind(g->zig_target)) {
                 lj->args.append(build_libunwind(g));

--- a/test/standalone/mix_o_files/test.c
+++ b/test/standalone/mix_o_files/test.c
@@ -3,6 +3,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <stdint.h>
 
 extern int *x_ptr;
 


### PR DESCRIPTION
These changes were necessary to get all of the tests, both with `-Dskip-release` and not, passing for FreeBSD.

This should hopefully check the respecting box in issue #1759 and get the wheels rolling.