### PR TITLE
fix build on macOS + xcode + clang

### DIFF
--- a/src/stack_report.cpp
+++ b/src/stack_report.cpp
@@ -95,7 +95,7 @@ static void tree_print(FILE *f, ZigType *ty, size_t indent) {
     fprintf(f, "\"");
 
     start_peer(f, indent);
-    fprintf(f, "\"size\": \"%" ZIG_PRI_u64 "\"", ty->abi_size);
+    fprintf(f, "\"size\": \"%" ZIG_PRI_usize "\"", ty->abi_size);
 
     switch (ty->id) {
         case ZigTypeIdFnFrame:


### PR DESCRIPTION
```
../src/stack_report.cpp:98:50: error: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Werror,-Wformat]
    fprintf(f, "\"size\": \"%" ZIG_PRI_u64 "\"", ty->abi_size);
                            ~~~~~~~~~~~~~~       ^~~~~~~~~~~~
```