### PR TITLE
Recognize & skip the UTF-8 BOM

### DIFF
--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -407,9 +407,14 @@ void tokenize(Buf *buf, Tokenization *out) {
     t.buf = buf;
 
     out->line_offsets = allocate<ZigList<size_t>>(1);
-
     out->line_offsets->append(0);
-    for (t.pos = 0; t.pos < buf_len(t.buf); t.pos += 1) {
+
+    // Skip the UTF-8 BOM if present
+    if (buf_starts_with_mem(buf, "\xEF\xBB\xBF", 3)) {
+        t.pos += 3;
+    }
+
+    for (; t.pos < buf_len(t.buf); t.pos += 1) {
         uint8_t c = buf_ptr(t.buf)[t.pos];
         switch (t.state) {
             case TokenizeStateError:

--- a/std/zig/tokenizer.zig
+++ b/std/zig/tokenizer.zig
@@ -222,9 +222,11 @@ pub const Tokenizer = struct {
                 },
             };
         } else {
+            // Skip the UTF-8 BOM if present
+            const src_start = if (mem.startsWith(u8, buffer, "\xEF\xBB\xBF")) 3 else usize(0);
             return Tokenizer{
                 .buffer = buffer,
-                .index = 0,
+                .index = src_start,
                 .pending_invalid_token = null,
             };
         }
@@ -1452,6 +1454,13 @@ test "tokenizer - line comment followed by identifier" {
         Token.Id.LineComment,
         Token.Id.Identifier,
         Token.Id.Comma,
+    });
+}
+
+test "tokenizer - UTF-8 BOM is recognized and skipped" {
+    testTokenize("\xEF\xBB\xBFa;\n", [_]Token.Id{
+        Token.Id.Identifier,
+        Token.Id.Semicolon,
     });
 }
 


### PR DESCRIPTION
I was puzzled when a file downloaded from Godbolt kept telling me there were extraneous characters at the very beginning of the file. 