### PR TITLE
Add missing C dl_iterate_phdr function for FreeBSD

### DIFF
--- a/std/c/freebsd.zig
+++ b/std/c/freebsd.zig
@@ -7,3 +7,6 @@ pub const _errno = __error;
 pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) usize;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;
+
+pub const dl_iterate_phdr_callback = extern fn (info: *dl_phdr_info, size: usize, data: ?*c_void) c_int;
+pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*c_void) c_int;


### PR DESCRIPTION
`dl_iterate_phdr` was a missing function in `std.c.freebsd` needed to compile and run the `test-std` test on my machine. I only copied the signatures from `std.c.linux` and they seem to help get past the error I was having.

Sad to say though, the test stalls forever at this line of output on my system.

```
309/1218 event.channel.test "std-freebsd-x86_64-Debug-bare-multi std.event.Channel"...
```