### PR TITLE
Fix assignment to optional payload

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -15321,6 +15321,7 @@ static IrInstruction *ir_resolve_result(IrAnalyze *ira, IrInstruction *suspend_s
     if (actual_elem_type->id == ZigTypeIdOptional && value_type->id != ZigTypeIdOptional &&
             value_type->id != ZigTypeIdNull)
     {
+        result_loc_pass1->written = false;
         return ir_analyze_unwrap_optional_payload(ira, suspend_source_instr, result_loc, false, true);
     } else if (actual_elem_type->id == ZigTypeIdErrorUnion && value_type->id != ZigTypeIdErrorUnion) {
         if (value_type->id == ZigTypeIdErrorSet) {

--- a/test/stage1/behavior/misc.zig
+++ b/test/stage1/behavior/misc.zig
@@ -488,7 +488,7 @@ test "@typeName" {
         expect(mem.eql(u8, @typeName(i64), "i64"));
         expect(mem.eql(u8, @typeName(*usize), "*usize"));
         // https://github.com/ziglang/zig/issues/675
-        expectEqualSlices(u8, "behavior.misc.TypeFromFn(u8)", @typeName(TypeFromFn(u8)));
+        expect(mem.eql(u8, "behavior.misc.TypeFromFn(u8)", @typeName(TypeFromFn(u8))));
         expect(mem.eql(u8, @typeName(Struct), "Struct"));
         expect(mem.eql(u8, @typeName(Union), "Union"));
         expect(mem.eql(u8, @typeName(Enum), "Enum"));
@@ -720,4 +720,17 @@ test "global variable assignment with optional unwrapping with var initialized t
         @panic("bad");
     };
     expect(global_foo.* == 1234);
+}
+
+test "nested optional field in struct" {
+    const S2 = struct {
+        y: u8,
+    };
+    const S1 = struct {
+        x: ?S2,
+    };
+    var s = S1{
+        .x = S2{ .y = 127 },
+    };
+    expect(s.x.?.y == 127);
 }


### PR DESCRIPTION
My first foray into the wild result-location code was not that pleasant, for the love of whatever deity you believe in add some comments (and/or document how the mechanism works).

I have no damn clue about what `written` refers to but resetting it lets `EndExpr` do its job and write out the value into the result slot.

It's probably needed also in the if branch below since a similar unwrapping operation is performed.

Closes #3081