### PR TITLE
Fix typos: "seperate" to "separate"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,7 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  -mllvm [arg]                 (unsupported) forward an arg to LLVM's option processing\n"
         "  --override-std-dir [arg]     override path to Zig standard library\n"
         "  --override-lib-dir [arg]     override path to Zig lib library\n"
-        "  -ffunction-sections          places each function in a seperate section\n"
+        "  -ffunction-sections          places each function in a separate section\n"
         "\n"
         "Link Options:\n"
         "  --bundle-compiler-rt         for static libraries, include compiler-rt symbols\n"

--- a/std/http/headers.zig
+++ b/std/http/headers.zig
@@ -299,7 +299,7 @@ pub const Headers = struct {
         return buf;
     }
 
-    /// Returns all headers with the given name as a comma seperated string.
+    /// Returns all headers with the given name as a comma separated string.
     ///
     /// Useful for HTTP headers that follow RFC-7230 section 3.2.2:
     ///   A recipient MAY combine multiple header fields with the same field


### PR DESCRIPTION
Fixes #3236