### PR TITLE
pass param as ref in ZigList::append

### DIFF
--- a/src/list.hpp
+++ b/src/list.hpp
@@ -15,7 +15,7 @@ struct ZigList {
     void deinit() {
         free(items);
     }
-    void append(T item) {
+    void append(const T& item) {
         ensure_capacity(length + 1);
         items[length++] = item;
     }


### PR DESCRIPTION
pass paramerer as const reference, not as value