### PR TITLE
A few steps towards AArch64 & ARM passing the behavior tests

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3706,7 +3706,8 @@ static LLVMValueRef get_new_stack_addr(CodeGen *g, LLVMValueRef new_stack) {
 
     LLVMValueRef ptr_addr = LLVMBuildPtrToInt(g->builder, ptr_value, LLVMTypeOf(len_value), "");
     LLVMValueRef end_addr = LLVMBuildNUWAdd(g->builder, ptr_addr, len_value, "");
-    LLVMValueRef align_amt = LLVMConstInt(LLVMTypeOf(end_addr), get_abi_alignment(g, g->builtin_types.entry_usize), false);
+    const unsigned alignment_factor = ZigLLVMDataLayoutGetStackAlignment(g->target_data_ref);
+    LLVMValueRef align_amt = LLVMConstInt(LLVMTypeOf(end_addr), alignment_factor, false);
     LLVMValueRef align_adj = LLVMBuildURem(g->builder, end_addr, align_amt, "");
     return LLVMBuildNUWSub(g->builder, end_addr, align_adj, "");
 }

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -149,6 +149,10 @@ LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Tri
     return reinterpret_cast<LLVMTargetMachineRef>(TM);
 }
 
+unsigned ZigLLVMDataLayoutGetStackAlignment(LLVMTargetDataRef TD) {
+    return unwrap(TD)->getStackAlignment();
+}
+
 bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
         const char *filename, ZigLLVM_EmitOutputType output_type, char **error_message, bool is_debug,
         bool is_small, bool time_report)

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -469,4 +469,6 @@ ZIG_EXTERN_C void ZigLLVMGetNativeTarget(enum ZigLLVM_ArchType *arch_type, enum 
         enum ZigLLVM_VendorType *vendor_type, enum ZigLLVM_OSType *os_type, enum ZigLLVM_EnvironmentType *environ_type,
         enum ZigLLVM_ObjectFormatType *oformat);
 
+ZIG_EXTERN_C unsigned ZigLLVMDataLayoutGetStackAlignment(LLVMTargetDataRef TD);
+
 #endif

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -106,5 +106,5 @@ comptime {
     _ = @import("behavior/vector.zig");
     _ = @import("behavior/void.zig");
     _ = @import("behavior/while.zig");
-    _ = @import("behavior/widening.zig");
+    // _ = @import("behavior/widening.zig");
 }

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -72,7 +72,9 @@ comptime {
     _ = @import("behavior/misc.zig");
     _ = @import("behavior/muladd.zig");
     _ = @import("behavior/namespace_depends_on_compile_var.zig");
-    _ = @import("behavior/new_stack_call.zig");
+    // See #3268
+    if (@import("builtin").arch != .aarch64)
+        _ = @import("behavior/new_stack_call.zig");
     _ = @import("behavior/null.zig");
     _ = @import("behavior/optional.zig");
     _ = @import("behavior/pointers.zig");
@@ -106,5 +108,5 @@ comptime {
     _ = @import("behavior/vector.zig");
     _ = @import("behavior/void.zig");
     _ = @import("behavior/while.zig");
-    // _ = @import("behavior/widening.zig");
+    _ = @import("behavior/widening.zig");
 }

--- a/test/stage1/behavior/error.zig
+++ b/test/stage1/behavior/error.zig
@@ -361,7 +361,8 @@ test "nested catch" {
 test "implicit cast to optional to error union to return result loc" {
     const S = struct {
         fn entry() void {
-            if (func(undefined)) |opt| {
+            var x: Foo = undefined;
+            if (func(&x)) |opt| {
                 expect(opt != null);
             } else |_| @panic("expected non error");
         }

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -658,3 +658,15 @@ test "struct field init with catch" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "packed struct with non-ABI-aligned field" {
+    const S = packed struct {
+        x: u9,
+        y: u183,
+    };
+    var s: S = undefined;
+    s.x = 1;
+    s.y = 42;
+    expect(s.x == 1);
+    expect(s.y == 42);
+}

--- a/test/stage1/behavior/widening.zig
+++ b/test/stage1/behavior/widening.zig
@@ -23,5 +23,7 @@ test "float widening" {
     var b: f32 = a;
     var c: f64 = b;
     var d: f128 = c;
-    expect(d == a);
+    expect(a == b);
+    expect(b == c);
+    expect(c == d);
 }


### PR DESCRIPTION
* The first commit fixes a nasty problem: sometimes the integer types storage size are different from their effective bit-count (eg. `i1` is 1 byte), on AArch64 we'd sometimes create bigger fields than expected. The commit fixes the problem by codegen'ing those fields as arrays of bytes (clang does the same, check out `CGRecordLayoutBuilder`) to avoid any problem.

* The second commit does jack shit because of #3268 but at least stops aligning the stack to a multiple of 8 on AArch64 (the stack alignment is 16).

* The third commit is needed because of #3268 and because the ARM backend doesn't lower the `f16` vs `f128` comparison.

* The fourth commit is quite nice, the only reason the test didn't fail on x64 is that `rdi` is always set to a non-zero value before entering the test function and that's accidentally passed through to `func`. This doesn't happen on ARM tho, `r0` is sometimes zero and the test fails.

Yes, the `LLVMValueRef` to array conversion is awful but works, if anybody loves stage1 enough to care feel free to rewrite it.