### PR TITLE
stage1: fix lost argv[0]

### DIFF
--- a/src/zig_clang_driver.cpp
+++ b/src/zig_clang_driver.cpp
@@ -421,7 +421,7 @@ int ZigClang_main(int argc_, const char **argv_) {
     ApplyQAOverride(argv, OverrideStr, SavedStrings);
   }
 
-  std::string Path = GetExecutablePath(argv[0], CanonicalPrefixes);
+  std::string Path = GetExecutablePath(argv_[0], CanonicalPrefixes);
 
   IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts =
       CreateAndPopulateDiagOpts(argv);


### PR DESCRIPTION
- bug presented on FreeBSD when `/proc` filesystem is not mounted
- bogus `cc` was used as exename, causing incorrect executable spawn
- llvm::sys::fs::getMainExecutable() has platform-specific code
  to get exename and fallback is to use param argv0
- linux fallback is rare because `/proc` is usually mounted
- *BSD fallback is not rare because `/proc` is often not mounted
- macOS doesn't ever fallback: bug cannot present
- windows doesn't ever fallback: bug cannot present
- other Posix will always present