### PR TITLE
gethostname

### DIFF
--- a/std/c.zig
+++ b/std/c.zig
@@ -107,6 +107,7 @@ pub extern "c" fn sysctl(name: [*]const c_int, namelen: c_uint, oldp: ?*c_void, 
 pub extern "c" fn sysctlbyname(name: [*]const u8, oldp: ?*c_void, oldlenp: ?*usize, newp: ?*c_void, newlen: usize) c_int;
 pub extern "c" fn sysctlnametomib(name: [*]const u8, mibp: ?*c_int, sizep: ?*usize) c_int;
 
+pub extern "c" fn gethostname(name: [*]u8, len: usize) c_int;
 pub extern "c" fn bind(socket: fd_t, address: ?*const sockaddr, address_len: socklen_t) c_int;
 pub extern "c" fn socket(domain: c_uint, sock_type: c_uint, protocol: c_uint) c_int;
 pub extern "c" fn listen(sockfd: fd_t, backlog: c_uint) c_int;

--- a/std/net.zig
+++ b/std/net.zig
@@ -245,3 +245,11 @@ pub fn connectUnixSocket(path: []const u8) !std.fs.File {
 
     return std.fs.File.openHandle(sockfd);
 }
+
+pub const getHostName = os.gethostname;
+
+test "getHostName" {
+    var buf: [os.HOST_NAME_MAX]u8 = undefined;
+    const hostname = try getHostName(&buf);
+    expect(hostname.len != 0);
+}

--- a/std/net.zig
+++ b/std/net.zig
@@ -245,11 +245,3 @@ pub fn connectUnixSocket(path: []const u8) !std.fs.File {
 
     return std.fs.File.openHandle(sockfd);
 }
-
-pub const getHostName = os.gethostname;
-
-test "getHostName" {
-    var buf: [os.HOST_NAME_MAX]u8 = undefined;
-    const hostname = try getHostName(&buf);
-    expect(hostname.len != 0);
-}

--- a/std/os/bits/darwin.zig
+++ b/std/os/bits/darwin.zig
@@ -1175,3 +1175,4 @@ pub fn S_ISSOCK(m: u32) bool {
 pub fn S_IWHT(m: u32) bool {
     return m & S_IFMT == S_IFWHT;
 }
+pub const HOST_NAME_MAX = 72;

--- a/std/os/bits/freebsd.zig
+++ b/std/os/bits/freebsd.zig
@@ -935,3 +935,5 @@ pub fn S_ISSOCK(m: u32) bool {
 pub fn S_IWHT(m: u32) bool {
     return m & S_IFMT == S_IFWHT;
 }
+
+pub const HOST_NAME_MAX = 255;

--- a/std/os/bits/linux.zig
+++ b/std/os/bits/linux.zig
@@ -1175,3 +1175,13 @@ pub const IORING_REGISTER_FILES = 2;
 pub const IORING_UNREGISTER_FILES = 3;
 pub const IORING_REGISTER_EVENTFD = 4;
 pub const IORING_UNREGISTER_EVENTFD = 5;
+
+pub const utsname = extern struct {
+    sysname: [65]u8,
+    nodename: [65]u8,
+    release: [65]u8,
+    version: [65]u8,
+    machine: [65]u8,
+    domainname: [65]u8,
+};
+pub const HOST_NAME_MAX = 64;

--- a/std/os/bits/netbsd.zig
+++ b/std/os/bits/netbsd.zig
@@ -819,3 +819,5 @@ pub fn S_ISSOCK(m: u32) bool {
 pub fn S_IWHT(m: u32) bool {
     return m & S_IFMT == S_IFWHT;
 }
+
+pub const HOST_NAME_MAX = 255;

--- a/std/os/linux.zig
+++ b/std/os/linux.zig
@@ -965,6 +965,10 @@ pub fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) usize {
     return syscall2(SYS_sigaltstack, @ptrToInt(ss), @ptrToInt(old_ss));
 }
 
+pub fn uname(uts: *utsname) usize {
+    return syscall1(SYS_uname, @ptrToInt(uts));
+}
+
 // XXX: This should be weak
 extern const __ehdr_start: elf.Ehdr = undefined;
 

--- a/std/os/test.zig
+++ b/std/os/test.zig
@@ -210,3 +210,12 @@ test "dl_iterate_phdr" {
     expect(os.dl_iterate_phdr(usize, iter_fn, &counter) != 0);
     expect(counter != 0);
 }
+
+test "gethostname" {
+    if (os.windows.is_the_target)
+        return error.SkipZigTest;
+
+    var buf: [os.HOST_NAME_MAX]u8 = undefined;
+    const hostname = try os.gethostname(&buf);
+    expect(hostname.len != 0);
+}


### PR DESCRIPTION
This is a POSIX implementation, it's only API inside `std.os`. There's no "cross platform" API yet which would go in `std.net`.