### PR TITLE
Miscellaneous RISC-V related commits

### DIFF
--- a/std/os/bits/linux/riscv64.zig
+++ b/std/os/bits/linux/riscv64.zig
@@ -298,25 +298,25 @@ pub const SYS_fspick = 433;
 pub const SYS_pidfd_open = 434;
 pub const SYS_clone3 = 435;
 
-pub const O_CREAT = 0100;
-pub const O_EXCL = 0200;
-pub const O_NOCTTY = 0400;
-pub const O_TRUNC = 01000;
-pub const O_APPEND = 02000;
-pub const O_NONBLOCK = 04000;
-pub const O_DSYNC = 010000;
-pub const O_SYNC = 04010000;
-pub const O_RSYNC = 04010000;
-pub const O_DIRECTORY = 0200000;
-pub const O_NOFOLLOW = 0400000;
-pub const O_CLOEXEC = 02000000;
+pub const O_CREAT = 0o100;
+pub const O_EXCL = 0o200;
+pub const O_NOCTTY = 0o400;
+pub const O_TRUNC = 0o1000;
+pub const O_APPEND = 0o2000;
+pub const O_NONBLOCK = 0o4000;
+pub const O_DSYNC = 0o10000;
+pub const O_SYNC = 0o4010000;
+pub const O_RSYNC = 0o4010000;
+pub const O_DIRECTORY = 0o200000;
+pub const O_NOFOLLOW = 0o400000;
+pub const O_CLOEXEC = 0o2000000;
 
-pub const O_ASYNC = 020000;
-pub const O_DIRECT = 040000;
-pub const O_LARGEFILE = 0100000;
-pub const O_NOATIME = 01000000;
-pub const O_PATH = 010000000;
-pub const O_TMPFILE = 020200000;
+pub const O_ASYNC = 0o20000;
+pub const O_DIRECT = 0o40000;
+pub const O_LARGEFILE = 0o100000;
+pub const O_NOATIME = 0o1000000;
+pub const O_PATH = 0o10000000;
+pub const O_TMPFILE = 0o20200000;
 pub const O_NDELAY = O_NONBLOCK;
 
 pub const F_DUPFD = 0;
@@ -386,3 +386,5 @@ pub const Stat = extern struct {
         return self.ctim;
     }
 };
+
+pub const Elf_Symndx = u32;

--- a/std/os/linux.zig
+++ b/std/os/linux.zig
@@ -469,7 +469,7 @@ var vdso_clock_gettime = @ptrCast(?*const c_void, init_vdso_clock_gettime);
 const vdso_clock_gettime_ty = extern fn (i32, *timespec) usize;
 
 pub fn clock_gettime(clk_id: i32, tp: *timespec) usize {
-    if (VDSO_CGT_SYM.len != 0) {
+    if (@hasDecl(@This(), "VDSO_CGT_SYM")) {
         const ptr = @atomicLoad(?*const c_void, &vdso_clock_gettime, .Unordered);
         if (ptr) |fn_ptr| {
             const f = @ptrCast(vdso_clock_gettime_ty, fn_ptr);

--- a/std/os/linux/riscv64.zig
+++ b/std/os/linux/riscv64.zig
@@ -82,3 +82,5 @@ pub fn syscall6(
         : "memory"
     );
 }
+
+pub extern fn clone(func: extern fn (arg: usize) u8, stack: usize, flags: u32, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;

--- a/std/os/linux/tls.zig
+++ b/std/os/linux/tls.zig
@@ -89,6 +89,7 @@ const tls_tp_offset = switch (builtin.arch) {
 
 const tls_dtv_offset = switch (builtin.arch) {
     .mipsel => 0x8000,
+    .riscv32, .riscv64 => 0x800,
     else => 0,
 };
 


### PR DESCRIPTION
The RISC-V backend is unable to lower any conversion from/to `fp16`, nice.