### PR TITLE
Replace code occurences of --override-std-dir with --override-lib-dir

### DIFF
--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -1,4 +1,4 @@
-// zig run benchmark.zig --release-fast --override-std-dir ..
+// zig run benchmark.zig --release-fast --override-lib-dir ..
 
 const builtin = @import("builtin");
 const std = @import("../std.zig");

--- a/lib/std/hash/benchmark.zig
+++ b/lib/std/hash/benchmark.zig
@@ -1,4 +1,4 @@
-// zig run benchmark.zig --release-fast --override-std-dir ..
+// zig run benchmark.zig --release-fast --override-lib-dir ..
 
 const builtin = @import("builtin");
 const std = @import("std");

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -24,7 +24,7 @@ const dl = @import("dynamic_library.zig");
 const MAX_PATH_BYTES = std.fs.MAX_PATH_BYTES;
 
 comptime {
-    assert(@import("std") == std); // std lib tests require --override-std-dir
+    assert(@import("std") == std); // std lib tests require --override-lib-dir
 }
 
 pub const darwin = @import("os/darwin.zig");


### PR DESCRIPTION
Simple changes here. There were some remaining code occurrences of the "--override-std-dir" option which should be "--override-lib-dir" as of the std -> lib/std move.