### PR TITLE
Correct signal bits for MIPS

### DIFF
--- a/lib/std/os/bits/linux/arm-eabi.zig
+++ b/lib/std/os/bits/linux/arm-eabi.zig
@@ -1,10 +1,11 @@
 // arm-eabi-specific declarations that are intended to be imported into the POSIX namespace.
-
-const std = @import("../../std.zig");
+const std = @import("../../../std.zig");
 const linux = std.os.linux;
 const socklen_t = linux.socklen_t;
 const iovec = linux.iovec;
 const iovec_const = linux.iovec_const;
+const stack_t = linux.stack_t;
+const sigset_t = linux.sigset_t;
 
 pub const SYS_restart_syscall = 0;
 pub const SYS_exit = 1;
@@ -563,6 +564,39 @@ pub const timeval = extern struct {
 pub const timezone = extern struct {
     tz_minuteswest: i32,
     tz_dsttime: i32,
+};
+
+pub const mcontext_t = extern struct {
+    trap_no: usize,
+    error_code: usize,
+    oldmask: usize,
+    arm_r0: usize,
+    arm_r1: usize,
+    arm_r2: usize,
+    arm_r3: usize,
+    arm_r4: usize,
+    arm_r5: usize,
+    arm_r6: usize,
+    arm_r7: usize,
+    arm_r8: usize,
+    arm_r9: usize,
+    arm_r10: usize,
+    arm_fp: usize,
+    arm_ip: usize,
+    arm_sp: usize,
+    arm_lr: usize,
+    arm_pc: usize,
+    arm_cpsr: usize,
+    fault_address: usize,
+};
+
+pub const ucontext_t = extern struct {
+    flags: usize,
+    link: *ucontext_t,
+    stack: stack_t,
+    mcontext: mcontext_t,
+    sigmask: sigset_t,
+    regspace: [64]u64,
 };
 
 pub const Elf_Symndx = u32;

--- a/lib/std/os/bits/linux/arm64.zig
+++ b/lib/std/os/bits/linux/arm64.zig
@@ -8,6 +8,8 @@ const iovec = linux.iovec;
 const iovec_const = linux.iovec_const;
 const uid_t = linux.uid_t;
 const gid_t = linux.gid_t;
+const stack_t = linux.stack_t;
+const sigset_t = linux.sigset_t;
 
 pub const SYS_io_setup = 0;
 pub const SYS_io_destroy = 1;
@@ -443,6 +445,25 @@ pub const timeval = extern struct {
 pub const timezone = extern struct {
     tz_minuteswest: i32,
     tz_dsttime: i32,
+};
+
+pub const mcontext_t = extern struct {
+    fault_address: usize,
+    regs: [31]usize,
+    sp: usize,
+    pc: usize,
+    pstate: usize,
+    // Make sure the field is correctly aligned since this area
+    // holds various FP/vector registers
+    reserved1: [256 * 16]u8 align(16),
+};
+
+pub const ucontext_t = extern struct {
+    flags: usize,
+    link: *ucontext_t,
+    stack: stack_t,
+    sigmask: sigset_t,
+    mcontext: mcontext_t,
 };
 
 pub const Elf_Symndx = u32;

--- a/lib/std/os/bits/linux/x86_64.zig
+++ b/lib/std/os/bits/linux/x86_64.zig
@@ -536,60 +536,6 @@ pub const timezone = extern struct {
 
 pub const Elf_Symndx = u32;
 
-pub const sigval = extern union {
-    int: i32,
-    ptr: *c_void,
-};
-
-pub const siginfo_t = extern struct {
-    signo: i32,
-    errno: i32,
-    code: i32,
-    fields: extern union {
-        pad: [128 - 2 * @sizeOf(c_int) - @sizeOf(c_long)]u8,
-        common: extern struct {
-            first: extern union {
-                piduid: extern struct {
-                    pid: pid_t,
-                    uid: uid_t,
-                },
-                timer: extern struct {
-                    timerid: i32,
-                    overrun: i32,
-                },
-            },
-            second: extern union {
-                value: sigval,
-                sigchld: extern struct {
-                    status: i32,
-                    utime: clock_t,
-                    stime: clock_t,
-                },
-            },
-        },
-        sigfault: extern struct {
-            addr: *c_void,
-            addr_lsb: i16,
-            first: extern union {
-                addr_bnd: extern struct {
-                    lower: *c_void,
-                    upper: *c_void,
-                },
-                pkey: u32,
-            },
-        },
-        sigpoll: extern struct {
-            band: isize,
-            fd: i32,
-        },
-        sigsys: extern struct {
-            call_addr: *c_void,
-            syscall: i32,
-            arch: u32,
-        },
-    },
-};
-
 pub const greg_t = usize;
 pub const gregset_t = [23]greg_t;
 pub const fpstate = extern struct {

--- a/lib/std/os/linux/arm-eabi.zig
+++ b/lib/std/os/linux/arm-eabi.zig
@@ -1,3 +1,5 @@
+usingnamespace @import("../bits.zig");
+
 pub fn syscall0(number: usize) usize {
     return asm volatile ("svc #0"
         : [ret] "={r0}" (-> usize)
@@ -92,5 +94,21 @@ pub extern fn clone(func: extern fn (arg: usize) u8, stack: usize, flags: u32, a
 pub extern fn getThreadPointer() usize {
     return asm volatile ("mrc p15, 0, %[ret], c13, c0, 3"
         : [ret] "=r" (-> usize)
+    );
+}
+
+pub nakedcc fn restore() void {
+    return asm volatile ("svc #0"
+        :
+        : [number] "{r7}" (usize(SYS_sigreturn))
+        : "memory"
+    );
+}
+
+pub nakedcc fn restore_rt() void {
+    return asm volatile ("svc #0"
+        :
+        : [number] "{r7}" (usize(SYS_rt_sigreturn))
+        : "memory"
     );
 }

--- a/lib/std/os/linux/arm64.zig
+++ b/lib/std/os/linux/arm64.zig
@@ -1,3 +1,5 @@
+usingnamespace @import("../bits.zig");
+
 pub fn syscall0(number: usize) usize {
     return asm volatile ("svc #0"
         : [ret] "={x0}" (-> usize)
@@ -85,3 +87,13 @@ pub fn syscall6(
 
 /// This matches the libc clone function.
 pub extern fn clone(func: extern fn (arg: usize) u8, stack: usize, flags: u32, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;
+
+pub const restore = restore_rt;
+
+pub nakedcc fn restore_rt() void {
+    return asm volatile ("svc #0"
+        :
+        : [number] "{x8}" (usize(SYS_rt_sigreturn))
+        : "memory", "cc"
+    );
+}

--- a/lib/std/os/linux/mipsel.zig
+++ b/lib/std/os/linux/mipsel.zig
@@ -1,3 +1,5 @@
+usingnamespace @import("../bits.zig");
+
 pub fn syscall0(number: usize) usize {
     return asm volatile (
         \\ syscall
@@ -122,3 +124,19 @@ pub fn syscall6(
 
 /// This matches the libc clone function.
 pub extern fn clone(func: extern fn (arg: usize) u8, stack: usize, flags: u32, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;
+
+pub nakedcc fn restore() void {
+    return asm volatile ("syscall"
+        :
+        : [number] "{$2}" (usize(SYS_sigreturn))
+        : "memory", "cc", "$7"
+    );
+}
+
+pub nakedcc fn restore_rt() void {
+    return asm volatile ("syscall"
+        :
+        : [number] "{$2}" (usize(SYS_rt_sigreturn))
+        : "memory", "cc", "$7"
+    );
+}

--- a/lib/std/os/linux/riscv64.zig
+++ b/lib/std/os/linux/riscv64.zig
@@ -1,3 +1,5 @@
+usingnamespace @import("../bits.zig");
+
 pub fn syscall0(number: usize) usize {
     return asm volatile ("ecall"
         : [ret] "={x10}" (-> usize)
@@ -84,3 +86,13 @@ pub fn syscall6(
 }
 
 pub extern fn clone(func: extern fn (arg: usize) u8, stack: usize, flags: u32, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;
+
+pub const restore = restore_rt;
+
+pub nakedcc fn restore_rt() void {
+    return asm volatile ("ecall"
+        :
+        : [number] "{x17}" (usize(SYS_rt_sigreturn))
+        : "memory"
+    );
+}

--- a/lib/std/os/linux/x86_64.zig
+++ b/lib/std/os/linux/x86_64.zig
@@ -88,10 +88,12 @@ pub fn syscall6(
 /// This matches the libc clone function.
 pub extern fn clone(func: extern fn (arg: usize) u8, stack: usize, flags: usize, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;
 
+pub const restore = restore_rt;
+
 pub nakedcc fn restore_rt() void {
     return asm volatile ("syscall"
         :
         : [number] "{rax}" (usize(SYS_rt_sigreturn))
-        : "rcx", "r11"
+        : "rcx", "r11", "memory"
     );
 }


### PR DESCRIPTION
Also enable the segfault handler for all the supported architectures
beside MIPS.