### PR TITLE
fix: container member access `usingnamespace` decls fails

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -17673,8 +17673,7 @@ static IrInstruction *ir_analyze_container_member_access_inner(IrAnalyze *ira,
     if (!is_slice(bare_struct_type)) {
         ScopeDecls *container_scope = get_container_scope(bare_struct_type);
         assert(container_scope != nullptr);
-        auto entry = container_scope->decl_table.maybe_get(field_name);
-        Tld *tld = entry ? entry->value : nullptr;
+        auto tld = find_container_decl(ira->codegen, container_scope, field_name);
         if (tld) {
             if (tld->id == TldIdFn) {
                 resolve_top_level_decl(ira->codegen, tld, source_instr->source_node, false);

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -34,6 +34,7 @@ comptime {
     _ = @import("behavior/bugs/2692.zig");
     _ = @import("behavior/bugs/3046.zig");
     _ = @import("behavior/bugs/3112.zig");
+    _ = @import("behavior/bugs/3367.zig");
     _ = @import("behavior/bugs/394.zig");
     _ = @import("behavior/bugs/421.zig");
     _ = @import("behavior/bugs/529.zig");

--- a/test/stage1/behavior/bugs/3367.zig
+++ b/test/stage1/behavior/bugs/3367.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const expect = std.testing.expect;
+
+const Foo = struct {
+    usingnamespace Mixin;
+};
+
+const Mixin = struct {
+    pub fn two(self: Foo) void {}
+};
+
+test "container member access usingnamespace decls" {
+    var foo = Foo{};
+    foo.two();
+}


### PR DESCRIPTION
- decls brought in via `usingnamespace` were not always found
  because lookup was performed directly against decl_table and
  use_decls was never consulted
- fix to use find_container_decl() path instead
- closes #3367