### PR TITLE
stage1: fix compile error on macOS Xcode 11.1

### DIFF
--- a/src/dump_analysis.cpp
+++ b/src/dump_analysis.cpp
@@ -44,7 +44,7 @@ static void jw_nl_indent(JsonWriter *jw) {
     assert(jw->state_index >= 1);
     fprintf(jw->f, "%s", jw->nl);
     for (size_t i = 0; i < jw->state_index - 1; i += 1) {
-        fprintf(jw->f, jw->one_indent);
+        fprintf(jw->f, "%s", jw->one_indent);
     }
 }
 


### PR DESCRIPTION
fix for:

```
ProductName:	Mac OS X
ProductVersion:	10.14.6
BuildVersion:	18G95

Xcode 11.1
Build version 11A1027
```

```
src/dump_analysis.cpp:47:24: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
        fprintf(jw->f, jw->one_indent);
                       ^~~~~~~~~~~~~~
src/dump_analysis.cpp:47:24: note: treat the string as an argument to avoid this
        fprintf(jw->f, jw->one_indent);
                       ^
                       "%s", 
1 error generated.
```