### PR TITLE
stage1: enable PIC for libuserland

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -373,6 +373,7 @@ fn addLibUserlandStep(b: *Builder, mode: builtin.Mode) void {
     artifact.bundle_compiler_rt = true;
     artifact.setTarget(builtin.arch, builtin.os, builtin.abi);
     artifact.setBuildMode(mode);
+    artifact.force_pic = true;
     if (mode != .Debug) {
         artifact.strip = true;
     }

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1488,6 +1488,9 @@ pub const LibExeObjStep = struct {
 
     dynamic_linker: ?[]const u8 = null,
 
+    /// Position Independent Code
+    force_pic: ?bool = null,
+
     const LinkObject = union(enum) {
         StaticPath: []const u8,
         OtherStep: *LibExeObjStep,
@@ -2312,6 +2315,14 @@ pub const LibExeObjStep = struct {
         if (self.main_pkg_path) |dir| {
             try zig_args.append("--main-pkg-path");
             try zig_args.append(builder.pathFromRoot(dir));
+        }
+
+        if (self.force_pic) |pic| {
+            if (pic) {
+                try zig_args.append("-fPIC");
+            } else {
+                try zig_args.append("-fno-PIC");
+            }
         }
 
         if (self.kind == Kind.Test) {


### PR DESCRIPTION
we don't really have a way to determine whether the stage1
zig compiler requires PIC so to be safe we always enable it
when building libuserland.

fixes build on some configurations of alpine linux.