### PR TITLE
stage1: fix root top-level-struct typename

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -996,7 +996,12 @@ static ZigType *get_root_container_type(CodeGen *g, const char *full_name, Buf *
     entry->data.structure.root_struct = root_struct;
     entry->data.structure.layout = ContainerLayoutAuto;
 
-    buf_init_from_str(&entry->name, full_name);
+    if (full_name[0] == '\0') {
+        buf_init_from_str(&entry->name, "(root)");
+    } else {
+        buf_init_from_str(&entry->name, full_name);
+    }
+
     return entry;
 }
 
@@ -3153,7 +3158,13 @@ static Error resolve_union_zero_bits(CodeGen *g, ZigType *union_type) {
     return ErrorNone;
 }
 
-static void get_fully_qualified_decl_name(Buf *buf, Tld *tld, bool is_test) {
+void append_namespace_qualification(CodeGen *g, Buf *buf, ZigType *container_type) {
+    if (g->root_import == container_type || buf_len(&container_type->name) == 0) return;
+    buf_append_buf(buf, &container_type->name);
+    buf_append_char(buf, NAMESPACE_SEP_CHAR);
+}
+
+static void get_fully_qualified_decl_name(CodeGen *g, Buf *buf, Tld *tld, bool is_test) {
     buf_resize(buf, 0);
 
     Scope *scope = tld->parent_scope;
@@ -3161,8 +3172,7 @@ static void get_fully_qualified_decl_name(Buf *buf, Tld *tld, bool is_test) {
         scope = scope->parent;
     }
     ScopeDecls *decls_scope = reinterpret_cast<ScopeDecls *>(scope);
-    buf_append_buf(buf, &decls_scope->container_type->name);
-    if (buf_len(buf) != 0) buf_append_char(buf, NAMESPACE_SEP_CHAR);
+    append_namespace_qualification(g, buf, decls_scope->container_type);
     if (is_test) {
         buf_append_str(buf, "test \"");
         buf_append_buf(buf, tld->name);
@@ -3285,7 +3295,7 @@ static void resolve_decl_fn(CodeGen *g, TldFn *tld_fn) {
         if (fn_proto->is_export || is_extern) {
             buf_init_from_buf(&fn_table_entry->symbol_name, tld_fn->base.name);
         } else {
-            get_fully_qualified_decl_name(&fn_table_entry->symbol_name, &tld_fn->base, false);
+            get_fully_qualified_decl_name(g, &fn_table_entry->symbol_name, &tld_fn->base, false);
         }
 
         if (fn_proto->is_export) {
@@ -3349,7 +3359,7 @@ static void resolve_decl_fn(CodeGen *g, TldFn *tld_fn) {
     } else if (source_node->type == NodeTypeTestDecl) {
         ZigFn *fn_table_entry = create_fn_raw(g, FnInlineAuto);
 
-        get_fully_qualified_decl_name(&fn_table_entry->symbol_name, &tld_fn->base, true);
+        get_fully_qualified_decl_name(g, &fn_table_entry->symbol_name, &tld_fn->base, true);
 
         tld_fn->fn_entry = fn_table_entry;
 

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -90,6 +90,7 @@ void init_tld(Tld *tld, TldId id, Buf *name, VisibMod visib_mod, AstNode *source
 ZigVar *add_variable(CodeGen *g, AstNode *source_node, Scope *parent_scope, Buf *name,
     bool is_const, ConstExprValue *init_value, Tld *src_tld, ZigType *var_type);
 ZigType *analyze_type_expr(CodeGen *g, Scope *scope, AstNode *node);
+void append_namespace_qualification(CodeGen *g, Buf *buf, ZigType *container_type);
 ZigFn *create_fn(CodeGen *g, AstNode *proto_node);
 ZigFn *create_fn_raw(CodeGen *g, FnInline inline_value);
 void init_fn_type_id(FnTypeId *fn_type_id, AstNode *proto_node, size_t param_count_alloc);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -7805,8 +7805,8 @@ static Buf *get_anon_type_name(CodeGen *codegen, IrExecutable *exec, const char 
 {
     if (exec->name) {
         ZigType *import = get_scope_import(scope);
-        Buf *namespace_name = buf_create_from_buf(&import->name);
-        if (buf_len(namespace_name) != 0) buf_append_char(namespace_name, NAMESPACE_SEP_CHAR);
+        Buf *namespace_name = buf_alloc();
+        append_namespace_qualification(codegen, namespace_name, import);
         buf_append_buf(namespace_name, exec->name);
         buf_init_from_buf(out_bare_name, exec->name);
         return namespace_name;
@@ -7820,8 +7820,8 @@ static Buf *get_anon_type_name(CodeGen *codegen, IrExecutable *exec, const char 
         return name;
     } else {
         ZigType *import = get_scope_import(scope);
-        Buf *namespace_name = buf_create_from_buf(&import->name);
-        if (buf_len(namespace_name) != 0) buf_append_char(namespace_name, NAMESPACE_SEP_CHAR);
+        Buf *namespace_name = buf_alloc();
+        append_namespace_qualification(codegen, namespace_name, import);
         buf_appendf(namespace_name, "%s:%" ZIG_PRI_usize ":%" ZIG_PRI_usize, kind_name,
                 source_node->line + 1, source_node->column + 1);
         buf_init_from_buf(out_bare_name, namespace_name);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -6639,4 +6639,16 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:2:18: error: opaque return type 'FooType' not allowed",
         "tmp.zig:1:1: note: declared here",
     );
+
+    // fixed bug #2032
+    cases.add(
+        "compile diagnostic string for top level decl type",
+        \\export fn entry() void {
+        \\    var foo: u32 = @This(){};
+        \\}
+    ,
+        "tmp.zig:2:27: error: expected type 'u32', found '(root)'",
+        "tmp.zig:1:1: note: (root) declared here",
+        "tmp.zig:2:5: note: referenced here",
+    );
 }


### PR DESCRIPTION
- during diagnostics the string representation for root was empty
  and now is populated with file basename
- retrofitted all other namespace-qualified type naming to elide
  prefixing with root

closes #2032

#### `foo.zig`
```
export fn entry() void {
    var y: u32 = @This(){};
}       
```

#### BEFORE
```
/Users/mike/project/zig/work/foo.zig:2:25: error: expected type 'u32', found ''
    var y: u32 = @This(){};
                        ^
/Users/mike/project/zig/work/foo.zig:1:1: note:  declared here
export fn entry() void {
^
/Users/mike/project/zig/work/foo.zig:2:5: note: referenced here
    var y: u32 = @This(){};
    ^
```

#### AFTER
```
/Users/mike/project/zig/work/foo.zig:2:25: error: expected type 'u32', found '(root)'
    var y: u32 = @This(){};
                        ^
/Users/mike/project/zig/work/foo.zig:1:1: note: (root) declared here
export fn entry() void {
^
/Users/mike/project/zig/work/foo.zig:2:5: note: referenced here
    var y: u32 = @This(){};
    ^
```