### PR TITLE
Generated docs: add parameter names to functions

### DIFF
--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -554,6 +554,16 @@
                         if (i != 0) {
                             payloadHtml += ', ';
                         }
+
+                        if (fnDecl != null && zigAnalysis.astNodes[fnDecl.src].fields != null) {
+                            var paramDeclIndex = zigAnalysis.astNodes[fnDecl.src].fields[i];
+                            var paramName = zigAnalysis.astNodes[paramDeclIndex].name;
+
+                            if (paramName != null) {
+                                payloadHtml += paramName + ': ';
+                            }
+                        }
+
                         var argTypeIndex = typeObj.args[i];
                         if (argTypeIndex != null) {
                             payloadHtml += typeIndexName(argTypeIndex, wantHtml, wantSubLink);

--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -776,14 +776,17 @@
 
         if (container.fields != null && container.fields.length !== 0) {
             resizeDomList(domListFields, container.fields.length, '<div></div>');
+
+            var containerNode = zigAnalysis.astNodes[container.src];
             for (var i = 0; i < container.fields.length; i += 1) {
-                var field = container.fields[i];
+                var fieldTypeIndex = container.fields[i];
+                var fieldNode = zigAnalysis.astNodes[containerNode.fields[i]];
                 var divDom = domListFields.children[i];
 
-                var html = '<pre>' + escapeHtml(field.name) + ": " +
-                    typeIndexName(field.type, true, true) + ',</pre>';
+                var html = '<pre>' + escapeHtml(fieldNode.name) + ": " +
+                    typeIndexName(fieldTypeIndex, true, true) + ',</pre>';
 
-                var docs = zigAnalysis.astNodes[field.src].docs;
+                var docs = fieldNode.docs;
                 if (docs != null) {
                     html += markdown(docs);
                 }

--- a/src/dump_analysis.cpp
+++ b/src/dump_analysis.cpp
@@ -964,6 +964,9 @@ static void anal_dump_node(AnalDumpCtx *ctx, const AstNode *node) {
         case NodeTypeStructField:
             name_buf = node->data.struct_field.name;
             break;
+        case NodeTypeParamDecl:
+            name_buf = node->data.param_decl.name;
+            break;
         default:
             name_buf = nullptr;
             break;
@@ -977,6 +980,9 @@ static void anal_dump_node(AnalDumpCtx *ctx, const AstNode *node) {
     switch (node->type) {
         case NodeTypeContainerDecl:
             fieldNodes = &node->data.container_decl.fields;
+            break;
+        case NodeTypeFnProto:
+            fieldNodes = &node->data.fn_proto.params;
             break;
         default:
             fieldNodes = nullptr;

--- a/src/dump_analysis.cpp
+++ b/src/dump_analysis.cpp
@@ -732,23 +732,6 @@ static void anal_dump_pointer_attrs(AnalDumpCtx *ctx, ZigType *ty) {
     anal_dump_type_ref(ctx, ty->data.pointer.child_type);
 }
 
-static void anal_dump_struct_field(AnalDumpCtx *ctx, const TypeStructField *struct_field) {
-    JsonWriter *jw = &ctx->jw;
-
-    jw_begin_object(jw);
-
-    jw_object_field(jw, "name");
-    jw_string(jw, buf_ptr(struct_field->name));
-
-    jw_object_field(jw, "type");
-    anal_dump_type_ref(ctx, struct_field->type_entry);
-
-    jw_object_field(jw, "src");
-    anal_dump_node_ref(ctx, struct_field->decl_node);
-
-    jw_end_object(jw);
-}
-
 static void anal_dump_type(AnalDumpCtx *ctx, ZigType *ty) {
     JsonWriter *jw = &ctx->jw;
     jw_array_elem(jw);
@@ -811,13 +794,16 @@ static void anal_dump_type(AnalDumpCtx *ctx, ZigType *ty) {
                 jw_end_array(jw);
             }
 
+            jw_object_field(jw, "src");
+            anal_dump_node_ref(ctx, ty->data.structure.decl_node);
+
             if (ty->data.structure.src_field_count != 0) {
                 jw_object_field(jw, "fields");
                 jw_begin_array(jw);
 
                 for(size_t i = 0; i < ty->data.structure.src_field_count; i += 1) {
                     jw_array_elem(jw);
-                    anal_dump_struct_field(ctx, &ty->data.structure.fields[i]);
+                    anal_dump_type_ref(ctx, ty->data.structure.fields[i].type_entry);
                 }
                 jw_end_array(jw);
             }
@@ -827,7 +813,6 @@ static void anal_dump_type(AnalDumpCtx *ctx, ZigType *ty) {
 
                 jw_object_field(jw, "file");
                 anal_dump_file_ref(ctx, path_buf);
-
             }
             break;
         }
@@ -972,6 +957,39 @@ static void anal_dump_node(AnalDumpCtx *ctx, const AstNode *node) {
     if (doc_comments_buf != nullptr && doc_comments_buf->list.length != 0) {
         jw_object_field(jw, "docs");
         jw_string(jw, buf_ptr(doc_comments_buf));
+    }
+
+    const Buf *name_buf;
+    switch (node->type) {
+        case NodeTypeStructField:
+            name_buf = node->data.struct_field.name;
+            break;
+        default:
+            name_buf = nullptr;
+            break;
+    }
+    if (name_buf != nullptr) {
+        jw_object_field(jw, "name");
+        jw_string(jw, buf_ptr(name_buf));
+    }
+
+    const ZigList<AstNode *> *fieldNodes;
+    switch (node->type) {
+        case NodeTypeContainerDecl:
+            fieldNodes = &node->data.container_decl.fields;
+            break;
+        default:
+            fieldNodes = nullptr;
+            break;
+    }
+    if (fieldNodes != nullptr) {
+        jw_object_field(jw, "fields");
+        jw_begin_array(jw);
+        for (size_t i = 0; i < fieldNodes->length; i += 1) {
+            jw_array_elem(jw);
+            anal_dump_node_ref(ctx, fieldNodes->at(i));
+        }
+        jw_end_array(jw);
     }
 
     jw_end_object(jw);


### PR DESCRIPTION
The type of a struct field is still stored in the types array, but the static information like name and docs of the fields are stored in the astNodes.