### PR TITLE
Add documentation on function parameter type inference.

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3887,6 +3887,29 @@ test "pass struct to function" {
       For extern functions, Zig follows the C ABI for passing structs and unions by value.
       </p>
       {#header_close#}
+      {#header_open|Function Parameter Type Inference#}
+      <p> 
+      Function parameters can be declared with {#syntax#}var{#endsyntax#} in place of the type. 
+      In this case the parameter types will be inferred when the function is called.
+      Use {#link|@typeOf#} and {#link|@typeInfo#} to get information about the inferred type.
+      </p>
+      {#code_begin|test#}
+const assert = @import("std").debug.assert;
+
+fn addFortyTwo(x: var) @typeOf(x) {
+    return x + 42;
+}
+
+test "fn type inference" {
+    assert(addFortyTwo(1) == 43);
+    assert(@typeOf(addFortyTwo(1)) == comptime_int);
+    var y: i64 = 2;
+    assert(addFortyTwo(y) == 44);
+    assert(@typeOf(addFortyTwo(y)) == i64);
+}
+      {#code_end#}
+      
+      {#header_close#}
       {#header_open|Function Reflection#}
       {#code_begin|test#}
 const assert = @import("std").debug.assert;


### PR DESCRIPTION
First pass at #3366 

I'm afraid I couldn't (easily) get the documentation generator to work so I haven't looked at the output to confirm it looks sensible. I tried to run it without building the compiler but it didn't seem to work with the downloaded 0.5.0 version I have.

Criticism welcome.