### PR TITLE
Fix cross-compilation to i386-windows-msvc

### DIFF
--- a/test/tests.zig
+++ b/test/tests.zig
@@ -167,6 +167,16 @@ const test_targets = [_]TestTarget{
         .target = Target{
             .Cross = CrossTarget{
                 .os = .windows,
+                .arch = .i386,
+                .abi = .msvc,
+            },
+        },
+    },
+
+    TestTarget{
+        .target = Target{
+            .Cross = CrossTarget{
+                .os = .windows,
                 .arch = .x86_64,
                 .abi = .msvc,
             },


### PR DESCRIPTION
Use Mingw's .def files to build a .lib when possible and show an error otherwise.

In other words you now have to supply `.lib` files if you're linking against a non-system (or a system one whose `.def` file isn't distributed with Zig yet) library.

Fixes the last remaining cross compilation target, don't know what's needed to have it tested on the CI...