### PR TITLE
Fix compilation of updateTimes on 32bit platforms

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -279,12 +279,12 @@ pub const File = struct {
         }
         const times = [2]os.timespec{
             os.timespec{
-                .tv_sec = @divFloor(atime, std.time.ns_per_s),
-                .tv_nsec = @mod(atime, std.time.ns_per_s),
+                .tv_sec = math.cast(isize, @divFloor(atime, std.time.ns_per_s)) catch maxInt(isize),
+                .tv_nsec = math.cast(isize, @mod(atime, std.time.ns_per_s)) catch maxInt(isize),
             },
             os.timespec{
-                .tv_sec = @divFloor(mtime, std.time.ns_per_s),
-                .tv_nsec = @mod(mtime, std.time.ns_per_s),
+                .tv_sec = math.cast(isize, @divFloor(mtime, std.time.ns_per_s)) catch maxInt(isize),
+                .tv_nsec = math.cast(isize, @mod(mtime, std.time.ns_per_s)) catch maxInt(isize),
             },
         };
         try os.futimens(self.handle, &times);

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -629,3 +629,21 @@ test "File seek ops" {
     try file.seekTo(1234);
     std.testing.expect((try file.getPos()) == 1234);
 }
+
+test "updateTimes" {
+    const tmp_file_name = "just_a_temporary_file.txt";
+    var file = try File.openWrite(tmp_file_name);
+    defer {
+        file.close();
+        std.fs.deleteFile(tmp_file_name) catch {};
+    }
+    var stat_old = try file.stat();
+    // Set atime and mtime to 5s before
+    try file.updateTimes(
+        stat_old.atime - 5 * std.time.ns_per_s,
+        stat_old.mtime - 5 * std.time.ns_per_s,
+    );
+    var stat_new = try file.stat();
+    std.testing.expect(stat_new.atime < stat_old.atime);
+    std.testing.expect(stat_new.mtime < stat_old.mtime);
+}


### PR DESCRIPTION
Add a test to avoid regressions.

Fixes #3412