### PR TITLE
Fix keyboard layout issue with help-modal

### DIFF
--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -1216,14 +1216,14 @@
 	}
 	var code = ev.charCode || ev.keyCode;
 	if(code == 27) {
-	    return "escape"
+	    return "Escape"
 	}
 	return String.fromCharCode(code)
     }
     
     function onWindowKeyDown(ev) {
         switch (getKeyValue(ev)) {
-            case "escape":
+            case "Escape":
                 if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
                 if (!domHelpModal.classList.contains("hidden")) {
                     domHelpModal.classList.add("hidden");

--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -1210,9 +1210,20 @@
         renderSearchCursor();
     }
 
+    function getKeyValue(ev) {
+	if("key" in ev && typeof ev.key != "undefined") {
+	    return ev.key
+	}
+	var code = ev.charCode || ev.keyCode;
+	if(code == 27) {
+	    return "escape"
+	}
+	return String.fromCharCode(code)
+    }
+    
     function onWindowKeyDown(ev) {
-        switch (ev.which) {
-            case 27:
+        switch (getKeyValue(ev)) {
+            case "escape":
                 if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
                 if (!domHelpModal.classList.contains("hidden")) {
                     domHelpModal.classList.add("hidden");
@@ -1220,7 +1231,7 @@
                     ev.stopPropagation();
                 }
                 break;
-            case 83:
+            case "s":
                 if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
                 domSearch.focus();
                 domSearch.select();
@@ -1228,7 +1239,7 @@
                 ev.stopPropagation();
                 startAsyncSearch();
                 break;
-            case 191:
+            case "?":
                 if (!ev.shiftKey || ev.ctrlKey || ev.altKey) return;
                 ev.preventDefault();
                 ev.stopPropagation();


### PR DESCRIPTION
Some keyboard layouts produces a different `ev.which` value in firefox
for ? than 191, eg. the Swedish QWERTY one produces 171. Chrome/chromium
doesn't have this issue. This fix is heavily inspired from rust's corresponding main.js.