### PR TITLE
Fully static stage1 compiler on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,13 @@ if(NOT CMAKE_INSTALL_PREFIX)
       "Directory to install zig to" FORCE)
 endif()
 
+set(CMAKE_USER_MAKE_RULES_OVERRIDE
+   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/c_flag_overrides.cmake)
+set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX
+   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_flag_overrides.cmake)
+
 project(zig C CXX)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
-
 
 set(ZIG_VERSION_MAJOR 0)
 set(ZIG_VERSION_MINOR 5)

--- a/ci/azure/windows_install
+++ b/ci/azure/windows_install
@@ -6,5 +6,5 @@ set -e
 pacman -Su --needed --noconfirm
 pacman -S --needed --noconfirm wget p7zip python3-pip
 pip install s3cmd
-wget -nv "https://ziglang.org/deps/llvm%2bclang-9.0.0-win64-msvc-release.tar.xz"
-tar xf llvm+clang-9.0.0-win64-msvc-release.tar.xz
+wget -nv "https://ziglang.org/deps/llvm%2bclang-9.0.0-win64-msvc-mt.tar.xz"
+tar xf llvm+clang-9.0.0-win64-msvc-mt.tar.xz

--- a/ci/azure/windows_script.bat
+++ b/ci/azure/windows_script.bat
@@ -11,15 +11,14 @@ SET "MSYSTEM=%PREVMSYSTEM%"
 
 SET "ZIGBUILDDIR=%SRCROOT%\build"
 SET "ZIGINSTALLDIR=%ZIGBUILDDIR%\dist"
-SET "ZIGPREFIXPATH=%SRCROOT%\llvm+clang-9.0.0-win64-msvc-release"
+SET "ZIGPREFIXPATH=%SRCROOT%\llvm+clang-9.0.0-win64-msvc-mt"
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
 
 mkdir %ZIGBUILDDIR%
 cd %ZIGBUILDDIR%
-REM Here we use MinSizeRel instead of Release to work around https://github.com/ziglang/zig/issues/3024
-cmake.exe .. -Thost=x64 -G"Visual Studio 16 2019" -A x64 "-DCMAKE_INSTALL_PREFIX=%ZIGINSTALLDIR%" "-DCMAKE_PREFIX_PATH=%ZIGPREFIXPATH%" -DCMAKE_BUILD_TYPE=MinSizeRel || exit /b
-msbuild /maxcpucount /p:Configuration=MinSizeRel INSTALL.vcxproj || exit /b
+cmake.exe .. -Thost=x64 -G"Visual Studio 16 2019" -A x64 "-DCMAKE_INSTALL_PREFIX=%ZIGINSTALLDIR%" "-DCMAKE_PREFIX_PATH=%ZIGPREFIXPATH%" -DCMAKE_BUILD_TYPE=Release -DZIG_FORCE_EXTERNAL_LLD=ON || exit /b
+msbuild /maxcpucount /p:Configuration=Release INSTALL.vcxproj || exit /b
 
 "%ZIGINSTALLDIR%\bin\zig.exe" build test || exit /b
 

--- a/ci/azure/windows_script.bat
+++ b/ci/azure/windows_script.bat
@@ -17,7 +17,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliar
 
 mkdir %ZIGBUILDDIR%
 cd %ZIGBUILDDIR%
-cmake.exe .. -Thost=x64 -G"Visual Studio 16 2019" -A x64 "-DCMAKE_INSTALL_PREFIX=%ZIGINSTALLDIR%" "-DCMAKE_PREFIX_PATH=%ZIGPREFIXPATH%" -DCMAKE_BUILD_TYPE=Release -DZIG_FORCE_EXTERNAL_LLD=ON || exit /b
+cmake.exe .. -Thost=x64 -G"Visual Studio 16 2019" -A x64 "-DCMAKE_INSTALL_PREFIX=%ZIGINSTALLDIR%" "-DCMAKE_PREFIX_PATH=%ZIGPREFIXPATH%" -DCMAKE_BUILD_TYPE=Release || exit /b
 msbuild /maxcpucount /p:Configuration=Release INSTALL.vcxproj || exit /b
 
 "%ZIGINSTALLDIR%\bin\zig.exe" build test || exit /b

--- a/cmake/c_flag_overrides.cmake
+++ b/cmake/c_flag_overrides.cmake
@@ -1,0 +1,13 @@
+if(MSVC)
+    set(CMAKE_C_FLAGS_DEBUG_INIT
+        "/D_DEBUG /MTd /Zi /Ob0 /Od /RTC1")
+
+    set(CMAKE_C_FLAGS_MINSIZEREL_INIT
+        "/MT /O1 /Ob1 /D NDEBUG")
+
+    set(CMAKE_C_FLAGS_RELEASE_INIT
+        "/MT /O2 /Ob2 /D NDEBUG")
+
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT
+        "/MT /Zi /O2 /Ob1 /D NDEBUG")
+endif()

--- a/cmake/c_flag_overrides.cmake
+++ b/cmake/c_flag_overrides.cmake
@@ -6,7 +6,7 @@ if(MSVC)
         "/MT /O1 /Ob1 /D NDEBUG")
 
     set(CMAKE_C_FLAGS_RELEASE_INIT
-        "/MT /O2 /Ob2 /D NDEBUG")
+        "/MT /O2 /Ob1 /D NDEBUG")
 
     set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT
         "/MT /Zi /O2 /Ob1 /D NDEBUG")

--- a/cmake/cxx_flag_overrides.cmake
+++ b/cmake/cxx_flag_overrides.cmake
@@ -6,7 +6,7 @@ if(MSVC)
         "/MT /O1 /Ob1 /D NDEBUG")
 
     set(CMAKE_CXX_FLAGS_RELEASE_INIT
-        "/MT /O2 /Ob2 /D NDEBUG")
+        "/MT /O2 /Ob1 /D NDEBUG")
 
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT
         "/MT /Zi /O2 /Ob1 /D NDEBUG")

--- a/cmake/cxx_flag_overrides.cmake
+++ b/cmake/cxx_flag_overrides.cmake
@@ -1,0 +1,13 @@
+if(MSVC)
+    set(CMAKE_CXX_FLAGS_DEBUG_INIT
+        "/D_DEBUG /MTd /Zi /Ob0 /Od /RTC1")
+
+    set(CMAKE_CXX_FLAGS_MINSIZEREL_INIT
+        "/MT /O1 /Ob1 /D NDEBUG")
+
+    set(CMAKE_CXX_FLAGS_RELEASE_INIT
+        "/MT /O2 /Ob2 /D NDEBUG")
+
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT
+        "/MT /Zi /O2 /Ob1 /D NDEBUG")
+endif()


### PR DESCRIPTION
Continued from #3430. I made a separate pull request because the previous one was in @Sahnvour's private fork, which made it harder to collaborate on.

> Fixes #3391.

> This doesn't enable linking debug zig with release llvm yet but I still plan to do it soon.

The new tarball is uploaded, and I added a commit to use it. If the CI passes here then we should be good to go.