### PR TITLE
Fix accept function API

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1478,10 +1478,9 @@ pub const AcceptError = error{
 
 /// Accept a connection on a socket. `fd` must be opened in blocking mode.
 /// See also `accept4_async`.
-pub fn accept4(fd: i32, addr: *sockaddr, flags: u32) AcceptError!i32 {
+pub fn accept4(fd: i32, addr: *sockaddr, addrSize: *usize, flags: u32) AcceptError!i32 {
     while (true) {
-        var sockaddr_size = u32(@sizeOf(sockaddr));
-        const rc = system.accept4(fd, addr, &sockaddr_size, flags);
+        const rc = system.accept4(fd, addr, addrSize, flags);
         switch (errno(rc)) {
             0 => return @intCast(i32, rc),
             EINTR => continue,
@@ -1506,10 +1505,9 @@ pub fn accept4(fd: i32, addr: *sockaddr, flags: u32) AcceptError!i32 {
 
 /// This is the same as `accept4` except `fd` is expected to be non-blocking.
 /// Returns -1 if would block.
-pub fn accept4_async(fd: i32, addr: *sockaddr, flags: u32) AcceptError!i32 {
+pub fn accept4_async(fd: i32, addr: *sockaddr, addrSize: *usize, flags: u32) AcceptError!i32 {
     while (true) {
-        var sockaddr_size = u32(@sizeOf(sockaddr));
-        const rc = system.accept4(fd, addr, &sockaddr_size, flags);
+        const rc = system.accept4(fd, addr, addrSize, flags);
         switch (errno(rc)) {
             0 => return @intCast(i32, rc),
             EINTR => continue,


### PR DESCRIPTION
The sockaddr pointer and size of the accept function points to a data structure that can only be determined at runtime.  Typical usage of the socket API is for UDP/TCP IPv4 and IPv6 sockets, which use sockaddr_in and sockaddr_in6, however, this address can be a struct of any format specific to the communication layer.  And some sockets can actually support multiple address types simultaneously (i.e. `sockaddr_in` and `sockaddr_in6`) in which case the app may want to have access to the size of the returned sockaddr.  Operating systems can even support custom protocols where they use custom sockaddr data structures.  In this case the standard library would have no knowledge of the actual size of the sockaddr being passed into the accept function.  In this case the standard library should defer to the app to pass in the size of their structure.

This also removes the ability for the application to pass `null` in for the sockaddr pointer.  With the current implementation, if the app passes `null` then the standard library will pass in an invalid size and cause a segfault.