### PR TITLE
unembed ConstExprValue from IrInstruction and intern 1-possible-value types

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2021,6 +2021,13 @@ struct CodeGen {
         ZigType *entry_any_frame;
     } builtin_types;
 
+    struct {
+        ZigValue x_undefined;
+        ZigValue x_void;
+        ZigValue x_null;
+        ZigValue x_unreachable;
+    } intern_values;
+
     ZigType *align_amt_type;
     ZigType *stack_trace_type;
     ZigType *err_tag_type;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -32,7 +32,7 @@ struct ErrorTableEntry;
 struct BuiltinFnEntry;
 struct TypeStructField;
 struct CodeGen;
-struct ConstExprValue;
+struct ZigValue;
 struct IrInstruction;
 struct IrInstructionCast;
 struct IrInstructionAllocaGen;
@@ -130,38 +130,38 @@ struct ConstParent {
 
     union {
         struct {
-            ConstExprValue *array_val;
+            ZigValue *array_val;
             size_t elem_index;
         } p_array;
         struct {
-            ConstExprValue *struct_val;
+            ZigValue *struct_val;
             size_t field_index;
         } p_struct;
         struct {
-            ConstExprValue *err_union_val;
+            ZigValue *err_union_val;
         } p_err_union_code;
         struct {
-            ConstExprValue *err_union_val;
+            ZigValue *err_union_val;
         } p_err_union_payload;
         struct {
-            ConstExprValue *optional_val;
+            ZigValue *optional_val;
         } p_optional_payload;
         struct {
-            ConstExprValue *union_val;
+            ZigValue *union_val;
         } p_union;
         struct {
-            ConstExprValue *scalar_val;
+            ZigValue *scalar_val;
         } p_scalar;
     } data;
 };
 
 struct ConstStructValue {
-    ConstExprValue **fields;
+    ZigValue **fields;
 };
 
 struct ConstUnionValue {
     BigInt tag;
-    ConstExprValue *payload;
+    ZigValue *payload;
 };
 
 enum ConstArraySpecial {
@@ -174,7 +174,7 @@ struct ConstArrayValue {
     ConstArraySpecial special;
     union {
         struct {
-            ConstExprValue *elements;
+            ZigValue *elements;
         } s_none;
         Buf *s_buf;
     } data;
@@ -235,24 +235,24 @@ struct ConstPtrValue {
 
     union {
         struct {
-            ConstExprValue *pointee;
+            ZigValue *pointee;
         } ref;
         struct {
-            ConstExprValue *array_val;
+            ZigValue *array_val;
             size_t elem_index;
         } base_array;
         struct {
-            ConstExprValue *struct_val;
+            ZigValue *struct_val;
             size_t field_index;
         } base_struct;
         struct {
-            ConstExprValue *err_union_val;
+            ZigValue *err_union_val;
         } base_err_union_code;
         struct {
-            ConstExprValue *err_union_val;
+            ZigValue *err_union_val;
         } base_err_union_payload;
         struct {
-            ConstExprValue *optional_val;
+            ZigValue *optional_val;
         } base_optional_payload;
         struct {
             uint64_t addr;
@@ -264,8 +264,8 @@ struct ConstPtrValue {
 };
 
 struct ConstErrValue {
-    ConstExprValue *error_set;
-    ConstExprValue *payload;
+    ZigValue *error_set;
+    ZigValue *payload;
 };
 
 struct ConstBoundFnValue {
@@ -406,7 +406,7 @@ struct LazyValueErrUnionType {
     Buf *type_name;
 };
 
-struct ConstExprValue {
+struct ZigValue {
     ZigType *type;
     ConstValSpecial special;
     ConstParent parent;
@@ -423,7 +423,7 @@ struct ConstExprValue {
         bool x_bool;
         ConstBoundFnValue x_bound_fn;
         ZigType *x_type;
-        ConstExprValue *x_optional;
+        ZigValue *x_optional;
         ConstErrValue x_err_union;
         ErrorTableEntry *x_err_set;
         BigInt x_enum_tag;
@@ -443,8 +443,8 @@ struct ConstExprValue {
     } data;
 
     // uncomment these to find bugs. can't leave them uncommented because of a gcc-9 warning
-    //ConstExprValue(const ConstExprValue &other) = delete; // plz zero initialize with {}
-    //ConstExprValue& operator= (const ConstExprValue &other) = delete; // use copy_const_val
+    //ZigValue(const ZigValue &other) = delete; // plz zero initialize with {}
+    //ZigValue& operator= (const ZigValue &other) = delete; // use copy_const_val
 };
 
 enum ReturnKnowledge {
@@ -525,7 +525,7 @@ struct TldCompTime {
 struct TldUsingNamespace {
     Tld base;
 
-    ConstExprValue *using_namespace_value;
+    ZigValue *using_namespace_value;
 };
 
 struct TypeEnumField {
@@ -538,7 +538,7 @@ struct TypeEnumField {
 struct TypeUnionField {
     Buf *name;
     ZigType *type_entry; // available after ResolveStatusSizeKnown
-    ConstExprValue *type_val; // available after ResolveStatusZeroBitsKnown
+    ZigValue *type_val; // available after ResolveStatusZeroBitsKnown
     TypeEnumField *enum_field;
     AstNode *decl_node;
     uint32_t gen_index;
@@ -1171,7 +1171,7 @@ struct FnTypeParamInfo {
 struct GenericFnTypeId {
     CodeGen *codegen;
     ZigFn *fn_entry;
-    ConstExprValue *params;
+    ZigValue *params;
     size_t param_count;
 };
 
@@ -1213,7 +1213,7 @@ struct ZigTypePointer {
     // This can be null. If it is non-null, it means the pointer is terminated by this
     // sentinel value. This is most commonly used for C-style strings, with a 0 byte
     // to specify the length of the memory pointed to.
-    ConstExprValue *sentinel;
+    ZigValue *sentinel;
 
     PtrLen ptr_len;
     uint32_t explicit_alignment; // 0 means use ABI alignment
@@ -1242,18 +1242,18 @@ struct ZigTypeFloat {
 struct ZigTypeArray {
     ZigType *child_type;
     uint64_t len;
-    ConstExprValue *sentinel;
+    ZigValue *sentinel;
 };
 
 struct TypeStructField {
     Buf *name;
     ZigType *type_entry; // available after ResolveStatusSizeKnown
-    ConstExprValue *type_val; // available after ResolveStatusZeroBitsKnown
+    ZigValue *type_val; // available after ResolveStatusZeroBitsKnown
     size_t src_index;
     size_t gen_index;
     size_t offset; // byte offset from beginning of struct
     AstNode *decl_node;
-    ConstExprValue *init_val; // null and then memoized
+    ZigValue *init_val; // null and then memoized
     uint32_t bit_offset_in_host; // offset from the memory at gen_index
     uint32_t host_int_bytes; // size of host integer
     uint32_t align;
@@ -1515,7 +1515,7 @@ struct ZigType {
     ZigType *any_frame_parent;
     // If we generate a constant name value for this type, we memoize it here.
     // The type of this is array
-    ConstExprValue *cached_const_name_val;
+    ZigValue *cached_const_name_val;
 
     OnePossibleValue one_possible_value;
     // Known after ResolveStatusAlignmentKnown.
@@ -1771,7 +1771,7 @@ struct TypeId {
             CodeGen *codegen;
             ZigType *child_type;
             InferredStructField *inferred_struct_field;
-            ConstExprValue *sentinel;
+            ZigValue *sentinel;
             PtrLen ptr_len;
             uint32_t alignment;
 
@@ -1787,7 +1787,7 @@ struct TypeId {
             CodeGen *codegen;
             ZigType *child_type;
             uint64_t size;
-            ConstExprValue *sentinel;
+            ZigValue *sentinel;
         } array;
         struct {
             bool is_signed;
@@ -1960,13 +1960,13 @@ struct CodeGen {
     HashMap<FnTypeId *, ZigType *, fn_type_id_hash, fn_type_id_eql> fn_type_table;
     HashMap<Buf *, ErrorTableEntry *, buf_hash, buf_eql_buf> error_table;
     HashMap<GenericFnTypeId *, ZigFn *, generic_fn_type_id_hash, generic_fn_type_id_eql> generic_table;
-    HashMap<Scope *, ConstExprValue *, fn_eval_hash, fn_eval_eql> memoized_fn_eval_table;
+    HashMap<Scope *, ZigValue *, fn_eval_hash, fn_eval_eql> memoized_fn_eval_table;
     HashMap<ZigLLVMFnKey, LLVMValueRef, zig_llvm_fn_key_hash, zig_llvm_fn_key_eql> llvm_fn_table;
     HashMap<Buf *, Tld *, buf_hash, buf_eql_buf> exported_symbol_names;
     HashMap<Buf *, Tld *, buf_hash, buf_eql_buf> external_prototypes;
-    HashMap<Buf *, ConstExprValue *, buf_hash, buf_eql_buf> string_literals_table;
-    HashMap<const ZigType *, ConstExprValue *, type_ptr_hash, type_ptr_eql> type_info_cache;
-    HashMap<const ZigType *, ConstExprValue *, type_ptr_hash, type_ptr_eql> one_possible_values;
+    HashMap<Buf *, ZigValue *, buf_hash, buf_eql_buf> string_literals_table;
+    HashMap<const ZigType *, ZigValue *, type_ptr_hash, type_ptr_eql> type_info_cache;
+    HashMap<const ZigType *, ZigValue *, type_ptr_hash, type_ptr_eql> one_possible_values;
 
     ZigList<Tld *> resolve_queue;
     size_t resolve_queue_index;
@@ -2043,9 +2043,9 @@ struct CodeGen {
     IrInstruction *invalid_instruction;
     IrInstruction *unreach_instruction;
 
-    ConstExprValue const_zero_byte;
-    ConstExprValue const_void_val;
-    ConstExprValue panic_msg_vals[PanicMsgIdCount];
+    ZigValue const_zero_byte;
+    ZigValue const_void_val;
+    ZigValue panic_msg_vals[PanicMsgIdCount];
 
     // The function definitions this module includes.
     ZigList<ZigFn *> fn_defs;
@@ -2163,7 +2163,7 @@ struct CodeGen {
 
 struct ZigVar {
     const char *name;
-    ConstExprValue *const_value;
+    ZigValue *const_value;
     ZigType *var_type;
     LLVMValueRef value_ref;
     IrInstruction *is_comptime;
@@ -2202,7 +2202,7 @@ struct ErrorTableEntry {
     ZigType *set_with_only_this_in_it;
     // If we generate a constant error name value for this error, we memoize it here.
     // The type of this is array
-    ConstExprValue *cached_error_name_val;
+    ZigValue *cached_error_name_val;
 };
 
 enum ScopeId {
@@ -2621,7 +2621,7 @@ struct IrInstruction {
     Scope *scope;
     AstNode *source_node;
     LLVMValueRef llvm_value;
-    ConstExprValue value;
+    ZigValue value;
     uint32_t debug_id;
     // if ref_count is zero and the instruction has no side effects,
     // the instruction can be omitted in codegen

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2621,7 +2621,7 @@ struct IrInstruction {
     Scope *scope;
     AstNode *source_node;
     LLVMValueRef llvm_value;
-    ZigValue value;
+    ZigValue *value;
     uint32_t debug_id;
     // if ref_count is zero and the instruction has no side effects,
     // the instruction can be omitted in codegen

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -511,7 +511,7 @@ static void append_ptr_type_attrs(Buf *type_name, ZigType *ptr_type) {
 ZigType *get_pointer_to_type_extra2(CodeGen *g, ZigType *child_type, bool is_const,
         bool is_volatile, PtrLen ptr_len, uint32_t byte_alignment,
         uint32_t bit_offset_in_host, uint32_t host_int_bytes, bool allow_zero,
-        uint32_t vector_index, InferredStructField *inferred_struct_field, ConstExprValue *sentinel)
+        uint32_t vector_index, InferredStructField *inferred_struct_field, ZigValue *sentinel)
 {
     assert(ptr_len != PtrLenC || allow_zero);
     assert(!type_is_invalid(child_type));
@@ -760,7 +760,7 @@ ZigType *get_error_union_type(CodeGen *g, ZigType *err_set_type, ZigType *payloa
     return entry;
 }
 
-ZigType *get_array_type(CodeGen *g, ZigType *child_type, uint64_t array_size, ConstExprValue *sentinel) {
+ZigType *get_array_type(CodeGen *g, ZigType *child_type, uint64_t array_size, ZigValue *sentinel) {
     TypeId type_id = {};
     type_id.id = ZigTypeIdArray;
     type_id.data.array.codegen = g;
@@ -956,7 +956,7 @@ bool calling_convention_allows_zig_types(CallingConvention cc) {
 
 ZigType *get_stack_trace_type(CodeGen *g) {
     if (g->stack_trace_type == nullptr) {
-        ConstExprValue *stack_trace_type_val = get_builtin_value(g, "StackTrace");
+        ZigValue *stack_trace_type_val = get_builtin_value(g, "StackTrace");
         assert(stack_trace_type_val->type->id == ZigTypeIdMetaType);
 
         g->stack_trace_type = stack_trace_type_val->data.x_type;
@@ -1095,7 +1095,7 @@ ZigType *get_partial_container_type(CodeGen *g, Scope *scope, ContainerKind kind
     return entry;
 }
 
-ConstExprValue *analyze_const_value(CodeGen *g, Scope *scope, AstNode *node, ZigType *type_entry,
+ZigValue *analyze_const_value(CodeGen *g, Scope *scope, AstNode *node, ZigType *type_entry,
         Buf *type_name, UndefAllowed undef)
 {
     size_t backward_branch_count = 0;
@@ -1105,8 +1105,8 @@ ConstExprValue *analyze_const_value(CodeGen *g, Scope *scope, AstNode *node, Zig
             nullptr, nullptr, node, type_name, nullptr, nullptr, undef);
 }
 
-Error type_val_resolve_zero_bits(CodeGen *g, ConstExprValue *type_val, ZigType *parent_type,
-        ConstExprValue *parent_type_val, bool *is_zero_bits)
+Error type_val_resolve_zero_bits(CodeGen *g, ZigValue *type_val, ZigType *parent_type,
+        ZigValue *parent_type_val, bool *is_zero_bits)
 {
     Error err;
     if (type_val->special != ConstValSpecialLazy) {
@@ -1160,7 +1160,7 @@ Error type_val_resolve_zero_bits(CodeGen *g, ConstExprValue *type_val, ZigType *
     zig_unreachable();
 }
 
-Error type_val_resolve_is_opaque_type(CodeGen *g, ConstExprValue *type_val, bool *is_opaque_type) {
+Error type_val_resolve_is_opaque_type(CodeGen *g, ZigValue *type_val, bool *is_opaque_type) {
     if (type_val->special != ConstValSpecialLazy) {
         assert(type_val->special == ConstValSpecialStatic);
         if (type_val->data.x_type == g->builtin_types.entry_var) {
@@ -1186,7 +1186,7 @@ Error type_val_resolve_is_opaque_type(CodeGen *g, ConstExprValue *type_val, bool
     zig_unreachable();
 }
 
-static ReqCompTime type_val_resolve_requires_comptime(CodeGen *g, ConstExprValue *type_val) {
+static ReqCompTime type_val_resolve_requires_comptime(CodeGen *g, ZigValue *type_val) {
     if (type_val->special != ConstValSpecialLazy) {
         return type_requires_comptime(g, type_val->data.x_type);
     }
@@ -1244,7 +1244,7 @@ static ReqCompTime type_val_resolve_requires_comptime(CodeGen *g, ConstExprValue
     zig_unreachable();
 }
 
-Error type_val_resolve_abi_size(CodeGen *g, AstNode *source_node, ConstExprValue *type_val,
+Error type_val_resolve_abi_size(CodeGen *g, AstNode *source_node, ZigValue *type_val,
         size_t *abi_size, size_t *size_in_bits)
 {
     Error err;
@@ -1311,7 +1311,7 @@ start_over:
     zig_unreachable();
 }
 
-Error type_val_resolve_abi_align(CodeGen *g, ConstExprValue *type_val, uint32_t *abi_align) {
+Error type_val_resolve_abi_align(CodeGen *g, ZigValue *type_val, uint32_t *abi_align) {
     Error err;
     if (type_val->special != ConstValSpecialLazy) {
         assert(type_val->special == ConstValSpecialStatic);
@@ -1356,7 +1356,7 @@ Error type_val_resolve_abi_align(CodeGen *g, ConstExprValue *type_val, uint32_t 
     zig_unreachable();
 }
 
-static OnePossibleValue type_val_resolve_has_one_possible_value(CodeGen *g, ConstExprValue *type_val) {
+static OnePossibleValue type_val_resolve_has_one_possible_value(CodeGen *g, ZigValue *type_val) {
     if (type_val->special != ConstValSpecialLazy) {
         return type_has_one_possible_value(g, type_val->data.x_type);
     }
@@ -1398,7 +1398,7 @@ static OnePossibleValue type_val_resolve_has_one_possible_value(CodeGen *g, Cons
 }
 
 ZigType *analyze_type_expr(CodeGen *g, Scope *scope, AstNode *node) {
-    ConstExprValue *result = analyze_const_value(g, scope, node, g->builtin_types.entry_type,
+    ZigValue *result = analyze_const_value(g, scope, node, g->builtin_types.entry_type,
             nullptr, UndefBad);
     if (type_is_invalid(result->type))
         return g->builtin_types.entry_invalid;
@@ -1451,7 +1451,7 @@ void init_fn_type_id(FnTypeId *fn_type_id, AstNode *proto_node, size_t param_cou
 }
 
 static bool analyze_const_align(CodeGen *g, Scope *scope, AstNode *node, uint32_t *result) {
-    ConstExprValue *align_result = analyze_const_value(g, scope, node, get_align_amt_type(g),
+    ZigValue *align_result = analyze_const_value(g, scope, node, get_align_amt_type(g),
             nullptr, UndefBad);
     if (type_is_invalid(align_result->type))
         return false;
@@ -1474,15 +1474,15 @@ static bool analyze_const_string(CodeGen *g, Scope *scope, AstNode *node, Buf **
     ZigType *ptr_type = get_pointer_to_type_extra(g, g->builtin_types.entry_u8, true, false,
             PtrLenUnknown, 0, 0, 0, false);
     ZigType *str_type = get_slice_type(g, ptr_type);
-    ConstExprValue *result_val = analyze_const_value(g, scope, node, str_type, nullptr, UndefBad);
+    ZigValue *result_val = analyze_const_value(g, scope, node, str_type, nullptr, UndefBad);
     if (type_is_invalid(result_val->type))
         return false;
 
-    ConstExprValue *ptr_field = result_val->data.x_struct.fields[slice_ptr_index];
-    ConstExprValue *len_field = result_val->data.x_struct.fields[slice_len_index];
+    ZigValue *ptr_field = result_val->data.x_struct.fields[slice_ptr_index];
+    ZigValue *len_field = result_val->data.x_struct.fields[slice_len_index];
 
     assert(ptr_field->data.x_ptr.special == ConstPtrSpecialBaseArray);
-    ConstExprValue *array_val = ptr_field->data.x_ptr.data.base_array.array_val;
+    ZigValue *array_val = ptr_field->data.x_ptr.data.base_array.array_val;
     if (array_val->data.x_array.special == ConstArraySpecialBuf) {
         *out_buffer = array_val->data.x_array.data.s_buf;
         return true;
@@ -1493,7 +1493,7 @@ static bool analyze_const_string(CodeGen *g, Scope *scope, AstNode *node, Buf **
     buf_resize(result, len);
     for (size_t i = 0; i < len; i += 1) {
         size_t new_index = ptr_field->data.x_ptr.data.base_array.elem_index + i;
-        ConstExprValue *char_val = &array_val->data.x_array.data.s_none.elements[new_index];
+        ZigValue *char_val = &array_val->data.x_array.data.s_none.elements[new_index];
         if (char_val->special == ConstValSpecialUndef) {
             add_node_error(g, node, buf_sprintf("use of undefined value"));
             return false;
@@ -2621,7 +2621,7 @@ static Error resolve_enum_zero_bits(CodeGen *g, ZigType *enum_type) {
 
         if (tag_value != nullptr) {
             // A user-specified value is available
-            ConstExprValue *result = analyze_const_value(g, scope, tag_value, tag_int_type,
+            ZigValue *result = analyze_const_value(g, scope, tag_value, tag_int_type,
                     nullptr, UndefBad);
             if (type_is_invalid(result->type)) {
                 enum_type->data.enumeration.resolve_status = ResolveStatusInvalid;
@@ -2756,7 +2756,7 @@ static Error resolve_struct_zero_bits(CodeGen *g, ZigType *struct_type) {
             return ErrorSemanticAnalyzeFail;
         }
 
-        ConstExprValue *field_type_val;
+        ZigValue *field_type_val;
         if (decl_node->type == NodeTypeContainerDecl) {
             field_type_val = analyze_const_value(g, scope,
                     field_node->data.struct_field.type, g->builtin_types.entry_type, nullptr, LazyOkNoUndef);
@@ -3051,7 +3051,7 @@ static Error resolve_union_zero_bits(CodeGen *g, ZigType *union_type) {
                 return ErrorSemanticAnalyzeFail;
             }
         } else {
-            ConstExprValue *field_type_val = analyze_const_value(g, scope,
+            ZigValue *field_type_val = analyze_const_value(g, scope,
                     field_node->data.struct_field.type, g->builtin_types.entry_type, nullptr, LazyOkNoUndef);
             if (type_is_invalid(field_type_val->type)) {
                 union_type->data.unionation.resolve_status = ResolveStatusInvalid;
@@ -3117,7 +3117,7 @@ static Error resolve_union_zero_bits(CodeGen *g, ZigType *union_type) {
             // In a second pass we will fill in the unspecified ones.
             if (tag_value != nullptr) {
                 ZigType *tag_int_type = tag_type->data.enumeration.tag_int_type;
-                ConstExprValue *result = analyze_const_value(g, scope, tag_value, tag_int_type,
+                ZigValue *result = analyze_const_value(g, scope, tag_value, tag_int_type,
                         nullptr, UndefBad);
                 if (type_is_invalid(result->type)) {
                     union_type->data.unionation.resolve_status = ResolveStatusInvalid;
@@ -3545,7 +3545,7 @@ void init_tld(Tld *tld, TldId id, Buf *name, VisibMod visib_mod, AstNode *source
     tld->parent_scope = parent_scope;
 }
 
-void update_compile_var(CodeGen *g, Buf *name, ConstExprValue *value) {
+void update_compile_var(CodeGen *g, Buf *name, ZigValue *value) {
     Tld *tld = get_container_scope(g->compile_var_import)->decl_table.get(name);
     resolve_top_level_decl(g, tld, tld->source_node, false);
     assert(tld->id == TldIdVar);
@@ -3717,7 +3717,7 @@ ZigType *validate_var_type(CodeGen *g, AstNode *source_node, ZigType *type_entry
 // Set name to nullptr to make the variable anonymous (not visible to programmer).
 // TODO merge with definition of add_local_var in ir.cpp
 ZigVar *add_variable(CodeGen *g, AstNode *source_node, Scope *parent_scope, Buf *name,
-    bool is_const, ConstExprValue *const_value, Tld *src_tld, ZigType *var_type)
+    bool is_const, ZigValue *const_value, Tld *src_tld, ZigType *var_type)
 {
     Error err;
     assert(const_value != nullptr);
@@ -3815,7 +3815,7 @@ static void resolve_decl_var(CodeGen *g, TldVar *tld_var, bool allow_lazy) {
 
     assert(!is_export || !is_extern);
 
-    ConstExprValue *init_value = nullptr;
+    ZigValue *init_value = nullptr;
 
     // TODO more validation for types that can't be used for export/extern variables
     ZigType *implicit_type = nullptr;
@@ -3853,7 +3853,7 @@ static void resolve_decl_var(CodeGen *g, TldVar *tld_var, bool allow_lazy) {
     ZigType *type = explicit_type ? explicit_type : implicit_type;
     assert(type != nullptr); // should have been caught by the parser
 
-    ConstExprValue *init_val = (init_value != nullptr) ? init_value : create_const_runtime(type);
+    ZigValue *init_val = (init_value != nullptr) ? init_value : create_const_runtime(type);
 
     tld_var->var = add_variable(g, source_node, tld_var->base.parent_scope, var_decl->symbol,
             is_const, init_val, &tld_var->base, type);
@@ -3900,7 +3900,7 @@ static void add_symbols_from_container(CodeGen *g, TldUsingNamespace *src_using_
         }
     }
 
-    ConstExprValue *use_expr = src_using_namespace->using_namespace_value;
+    ZigValue *use_expr = src_using_namespace->using_namespace_value;
     if (type_is_invalid(use_expr->type)) {
         dest_decls_scope->any_imports_failed = true;
         return;
@@ -3977,7 +3977,7 @@ static void preview_use_decl(CodeGen *g, TldUsingNamespace *using_namespace, Sco
 
     using_namespace->base.resolution = TldResolutionResolving;
     assert(using_namespace->base.source_node->type == NodeTypeUsingNamespace);
-    ConstExprValue *result = analyze_const_value(g, &dest_decls_scope->base,
+    ZigValue *result = analyze_const_value(g, &dest_decls_scope->base,
         using_namespace->base.source_node->data.using_namespace.expr, g->builtin_types.entry_type,
         nullptr, UndefBad);
     using_namespace->using_namespace_value = result;
@@ -5029,12 +5029,12 @@ bool fn_type_id_eql(FnTypeId *a, FnTypeId *b) {
     return true;
 }
 
-static uint32_t hash_const_val_error_set(ConstExprValue *const_val) {
+static uint32_t hash_const_val_error_set(ZigValue *const_val) {
     assert(const_val->data.x_err_set != nullptr);
     return const_val->data.x_err_set->value ^ 2630160122;
 }
 
-static uint32_t hash_const_val_ptr(ConstExprValue *const_val) {
+static uint32_t hash_const_val_ptr(ZigValue *const_val) {
     uint32_t hash_val = 0;
     switch (const_val->data.x_ptr.mut) {
         case ConstPtrMutRuntimeVar:
@@ -5095,7 +5095,7 @@ static uint32_t hash_const_val_ptr(ConstExprValue *const_val) {
     zig_unreachable();
 }
 
-static uint32_t hash_const_val(ConstExprValue *const_val) {
+static uint32_t hash_const_val(ZigValue *const_val) {
     assert(const_val->special == ConstValSpecialStatic);
     switch (const_val->type->id) {
         case ZigTypeIdOpaque:
@@ -5224,7 +5224,7 @@ uint32_t generic_fn_type_id_hash(GenericFnTypeId *id) {
     uint32_t result = 0;
     result += hash_ptr(id->fn_entry);
     for (size_t i = 0; i < id->param_count; i += 1) {
-        ConstExprValue *generic_param = &id->params[i];
+        ZigValue *generic_param = &id->params[i];
         if (generic_param->special != ConstValSpecialRuntime) {
             result += hash_const_val(generic_param);
             result += hash_ptr(generic_param->type);
@@ -5238,8 +5238,8 @@ bool generic_fn_type_id_eql(GenericFnTypeId *a, GenericFnTypeId *b) {
     if (a->fn_entry != b->fn_entry) return false;
     if (a->param_count != b->param_count) return false;
     for (size_t i = 0; i < a->param_count; i += 1) {
-        ConstExprValue *a_val = &a->params[i];
-        ConstExprValue *b_val = &b->params[i];
+        ZigValue *a_val = &a->params[i];
+        ZigValue *b_val = &b->params[i];
         if (a_val->type != b_val->type) return false;
         if (a_val->special != ConstValSpecialRuntime && b_val->special != ConstValSpecialRuntime) {
             assert(a_val->special == ConstValSpecialStatic);
@@ -5254,7 +5254,7 @@ bool generic_fn_type_id_eql(GenericFnTypeId *a, GenericFnTypeId *b) {
     return true;
 }
 
-static bool can_mutate_comptime_var_state(ConstExprValue *value) {
+static bool can_mutate_comptime_var_state(ZigValue *value) {
     assert(value != nullptr);
     switch (value->type->id) {
         case ZigTypeIdInvalid:
@@ -5562,12 +5562,12 @@ OnePossibleValue type_has_one_possible_value(CodeGen *g, ZigType *type_entry) {
     zig_unreachable();
 }
 
-ConstExprValue *get_the_one_possible_value(CodeGen *g, ZigType *type_entry) {
+ZigValue *get_the_one_possible_value(CodeGen *g, ZigType *type_entry) {
     auto entry = g->one_possible_values.maybe_get(type_entry);
     if (entry != nullptr) {
         return entry->value;
     }
-    ConstExprValue *result = create_const_vals(1);
+    ZigValue *result = create_const_vals(1);
     result->type = type_entry;
     result->special = ConstValSpecialStatic;
     g->one_possible_values.put(type_entry, result);
@@ -5637,15 +5637,15 @@ ReqCompTime type_requires_comptime(CodeGen *g, ZigType *ty) {
     zig_unreachable();
 }
 
-void init_const_str_lit(CodeGen *g, ConstExprValue *const_val, Buf *str) {
+void init_const_str_lit(CodeGen *g, ZigValue *const_val, Buf *str) {
     auto entry = g->string_literals_table.maybe_get(str);
     if (entry != nullptr) {
-        memcpy(const_val, entry->value, sizeof(ConstExprValue));
+        memcpy(const_val, entry->value, sizeof(ZigValue));
         return;
     }
 
     // first we build the underlying array
-    ConstExprValue *array_val = create_const_vals(1);
+    ZigValue *array_val = create_const_vals(1);
     array_val->special = ConstValSpecialStatic;
     array_val->type = get_array_type(g, g->builtin_types.entry_u8, buf_len(str), &g->const_zero_byte);
     array_val->data.x_array.special = ConstArraySpecialBuf;
@@ -5661,71 +5661,71 @@ void init_const_str_lit(CodeGen *g, ConstExprValue *const_val, Buf *str) {
     g->string_literals_table.put(str, const_val);
 }
 
-ConstExprValue *create_const_str_lit(CodeGen *g, Buf *str) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_str_lit(CodeGen *g, Buf *str) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_str_lit(g, const_val, str);
     return const_val;
 }
 
-void init_const_bigint(ConstExprValue *const_val, ZigType *type, const BigInt *bigint) {
+void init_const_bigint(ZigValue *const_val, ZigType *type, const BigInt *bigint) {
     const_val->special = ConstValSpecialStatic;
     const_val->type = type;
     bigint_init_bigint(&const_val->data.x_bigint, bigint);
 }
 
-ConstExprValue *create_const_bigint(ZigType *type, const BigInt *bigint) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_bigint(ZigType *type, const BigInt *bigint) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_bigint(const_val, type, bigint);
     return const_val;
 }
 
 
-void init_const_unsigned_negative(ConstExprValue *const_val, ZigType *type, uint64_t x, bool negative) {
+void init_const_unsigned_negative(ZigValue *const_val, ZigType *type, uint64_t x, bool negative) {
     const_val->special = ConstValSpecialStatic;
     const_val->type = type;
     bigint_init_unsigned(&const_val->data.x_bigint, x);
     const_val->data.x_bigint.is_negative = negative;
 }
 
-ConstExprValue *create_const_unsigned_negative(ZigType *type, uint64_t x, bool negative) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_unsigned_negative(ZigType *type, uint64_t x, bool negative) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_unsigned_negative(const_val, type, x, negative);
     return const_val;
 }
 
-void init_const_usize(CodeGen *g, ConstExprValue *const_val, uint64_t x) {
+void init_const_usize(CodeGen *g, ZigValue *const_val, uint64_t x) {
     return init_const_unsigned_negative(const_val, g->builtin_types.entry_usize, x, false);
 }
 
-ConstExprValue *create_const_usize(CodeGen *g, uint64_t x) {
+ZigValue *create_const_usize(CodeGen *g, uint64_t x) {
     return create_const_unsigned_negative(g->builtin_types.entry_usize, x, false);
 }
 
-void init_const_signed(ConstExprValue *const_val, ZigType *type, int64_t x) {
+void init_const_signed(ZigValue *const_val, ZigType *type, int64_t x) {
     const_val->special = ConstValSpecialStatic;
     const_val->type = type;
     bigint_init_signed(&const_val->data.x_bigint, x);
 }
 
-ConstExprValue *create_const_signed(ZigType *type, int64_t x) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_signed(ZigType *type, int64_t x) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_signed(const_val, type, x);
     return const_val;
 }
 
-void init_const_null(ConstExprValue *const_val, ZigType *type) {
+void init_const_null(ZigValue *const_val, ZigType *type) {
     const_val->special = ConstValSpecialStatic;
     const_val->type = type;
     const_val->data.x_optional = nullptr;
 }
 
-ConstExprValue *create_const_null(ZigType *type) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_null(ZigType *type) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_null(const_val, type);
     return const_val;
 }
 
-void init_const_float(ConstExprValue *const_val, ZigType *type, double value) {
+void init_const_float(ZigValue *const_val, ZigType *type, double value) {
     const_val->special = ConstValSpecialStatic;
     const_val->type = type;
     if (type->id == ZigTypeIdComptimeFloat) {
@@ -5752,61 +5752,61 @@ void init_const_float(ConstExprValue *const_val, ZigType *type, double value) {
     }
 }
 
-ConstExprValue *create_const_float(ZigType *type, double value) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_float(ZigType *type, double value) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_float(const_val, type, value);
     return const_val;
 }
 
-void init_const_enum(ConstExprValue *const_val, ZigType *type, const BigInt *tag) {
+void init_const_enum(ZigValue *const_val, ZigType *type, const BigInt *tag) {
     const_val->special = ConstValSpecialStatic;
     const_val->type = type;
     bigint_init_bigint(&const_val->data.x_enum_tag, tag);
 }
 
-ConstExprValue *create_const_enum(ZigType *type, const BigInt *tag) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_enum(ZigType *type, const BigInt *tag) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_enum(const_val, type, tag);
     return const_val;
 }
 
 
-void init_const_bool(CodeGen *g, ConstExprValue *const_val, bool value) {
+void init_const_bool(CodeGen *g, ZigValue *const_val, bool value) {
     const_val->special = ConstValSpecialStatic;
     const_val->type = g->builtin_types.entry_bool;
     const_val->data.x_bool = value;
 }
 
-ConstExprValue *create_const_bool(CodeGen *g, bool value) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_bool(CodeGen *g, bool value) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_bool(g, const_val, value);
     return const_val;
 }
 
-void init_const_runtime(ConstExprValue *const_val, ZigType *type) {
+void init_const_runtime(ZigValue *const_val, ZigType *type) {
     const_val->special = ConstValSpecialRuntime;
     const_val->type = type;
 }
 
-ConstExprValue *create_const_runtime(ZigType *type) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_runtime(ZigType *type) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_runtime(const_val, type);
     return const_val;
 }
 
-void init_const_type(CodeGen *g, ConstExprValue *const_val, ZigType *type_value) {
+void init_const_type(CodeGen *g, ZigValue *const_val, ZigType *type_value) {
     const_val->special = ConstValSpecialStatic;
     const_val->type = g->builtin_types.entry_type;
     const_val->data.x_type = type_value;
 }
 
-ConstExprValue *create_const_type(CodeGen *g, ZigType *type_value) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_type(CodeGen *g, ZigType *type_value) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_type(g, const_val, type_value);
     return const_val;
 }
 
-void init_const_slice(CodeGen *g, ConstExprValue *const_val, ConstExprValue *array_val,
+void init_const_slice(CodeGen *g, ZigValue *const_val, ZigValue *array_val,
         size_t start, size_t len, bool is_const)
 {
     assert(array_val->type->id == ZigTypeIdArray);
@@ -5823,13 +5823,13 @@ void init_const_slice(CodeGen *g, ConstExprValue *const_val, ConstExprValue *arr
     init_const_usize(g, const_val->data.x_struct.fields[slice_len_index], len);
 }
 
-ConstExprValue *create_const_slice(CodeGen *g, ConstExprValue *array_val, size_t start, size_t len, bool is_const) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_slice(CodeGen *g, ZigValue *array_val, size_t start, size_t len, bool is_const) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_slice(g, const_val, array_val, start, len, is_const);
     return const_val;
 }
 
-void init_const_ptr_array(CodeGen *g, ConstExprValue *const_val, ConstExprValue *array_val,
+void init_const_ptr_array(CodeGen *g, ZigValue *const_val, ZigValue *array_val,
         size_t elem_index, bool is_const, PtrLen ptr_len)
 {
     assert(array_val->type->id == ZigTypeIdArray);
@@ -5843,28 +5843,28 @@ void init_const_ptr_array(CodeGen *g, ConstExprValue *const_val, ConstExprValue 
     const_val->data.x_ptr.data.base_array.elem_index = elem_index;
 }
 
-ConstExprValue *create_const_ptr_array(CodeGen *g, ConstExprValue *array_val, size_t elem_index, bool is_const,
+ZigValue *create_const_ptr_array(CodeGen *g, ZigValue *array_val, size_t elem_index, bool is_const,
         PtrLen ptr_len)
 {
-    ConstExprValue *const_val = create_const_vals(1);
+    ZigValue *const_val = create_const_vals(1);
     init_const_ptr_array(g, const_val, array_val, elem_index, is_const, ptr_len);
     return const_val;
 }
 
-void init_const_ptr_ref(CodeGen *g, ConstExprValue *const_val, ConstExprValue *pointee_val, bool is_const) {
+void init_const_ptr_ref(CodeGen *g, ZigValue *const_val, ZigValue *pointee_val, bool is_const) {
     const_val->special = ConstValSpecialStatic;
     const_val->type = get_pointer_to_type(g, pointee_val->type, is_const);
     const_val->data.x_ptr.special = ConstPtrSpecialRef;
     const_val->data.x_ptr.data.ref.pointee = pointee_val;
 }
 
-ConstExprValue *create_const_ptr_ref(CodeGen *g, ConstExprValue *pointee_val, bool is_const) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_ptr_ref(CodeGen *g, ZigValue *pointee_val, bool is_const) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_ptr_ref(g, const_val, pointee_val, is_const);
     return const_val;
 }
 
-void init_const_ptr_hard_coded_addr(CodeGen *g, ConstExprValue *const_val, ZigType *pointee_type,
+void init_const_ptr_hard_coded_addr(CodeGen *g, ZigValue *const_val, ZigType *pointee_type,
         size_t addr, bool is_const)
 {
     const_val->special = ConstValSpecialStatic;
@@ -5873,47 +5873,47 @@ void init_const_ptr_hard_coded_addr(CodeGen *g, ConstExprValue *const_val, ZigTy
     const_val->data.x_ptr.data.hard_coded_addr.addr = addr;
 }
 
-ConstExprValue *create_const_ptr_hard_coded_addr(CodeGen *g, ZigType *pointee_type,
+ZigValue *create_const_ptr_hard_coded_addr(CodeGen *g, ZigType *pointee_type,
         size_t addr, bool is_const)
 {
-    ConstExprValue *const_val = create_const_vals(1);
+    ZigValue *const_val = create_const_vals(1);
     init_const_ptr_hard_coded_addr(g, const_val, pointee_type, addr, is_const);
     return const_val;
 }
 
-void init_const_arg_tuple(CodeGen *g, ConstExprValue *const_val, size_t arg_index_start, size_t arg_index_end) {
+void init_const_arg_tuple(CodeGen *g, ZigValue *const_val, size_t arg_index_start, size_t arg_index_end) {
     const_val->special = ConstValSpecialStatic;
     const_val->type = g->builtin_types.entry_arg_tuple;
     const_val->data.x_arg_tuple.start_index = arg_index_start;
     const_val->data.x_arg_tuple.end_index = arg_index_end;
 }
 
-ConstExprValue *create_const_arg_tuple(CodeGen *g, size_t arg_index_start, size_t arg_index_end) {
-    ConstExprValue *const_val = create_const_vals(1);
+ZigValue *create_const_arg_tuple(CodeGen *g, size_t arg_index_start, size_t arg_index_end) {
+    ZigValue *const_val = create_const_vals(1);
     init_const_arg_tuple(g, const_val, arg_index_start, arg_index_end);
     return const_val;
 }
 
 
-ConstExprValue *create_const_vals(size_t count) {
+ZigValue *create_const_vals(size_t count) {
     ConstGlobalRefs *global_refs = allocate<ConstGlobalRefs>(count, "ConstGlobalRefs");
-    ConstExprValue *vals = allocate<ConstExprValue>(count, "ConstExprValue");
+    ZigValue *vals = allocate<ZigValue>(count, "ZigValue");
     for (size_t i = 0; i < count; i += 1) {
         vals[i].global_refs = &global_refs[i];
     }
     return vals;
 }
 
-ConstExprValue **alloc_const_vals_ptrs(size_t count) {
+ZigValue **alloc_const_vals_ptrs(size_t count) {
     return realloc_const_vals_ptrs(nullptr, 0, count);
 }
 
-ConstExprValue **realloc_const_vals_ptrs(ConstExprValue **ptr, size_t old_count, size_t new_count) {
+ZigValue **realloc_const_vals_ptrs(ZigValue **ptr, size_t old_count, size_t new_count) {
     assert(new_count >= old_count);
 
     size_t new_item_count = new_count - old_count;
-    ConstExprValue **result = reallocate(ptr, old_count, new_count, "ConstExprValue*");
-    ConstExprValue *vals = create_const_vals(new_item_count);
+    ZigValue **result = reallocate(ptr, old_count, new_count, "ZigValue*");
+    ZigValue *vals = create_const_vals(new_item_count);
     for (size_t i = old_count; i < new_count; i += 1) {
         result[i] = &vals[i - old_count];
     }
@@ -6456,7 +6456,7 @@ bool ir_get_var_is_comptime(ZigVar *var) {
     return var->is_comptime->value.data.x_bool;
 }
 
-bool const_values_equal_ptr(ConstExprValue *a, ConstExprValue *b) {
+bool const_values_equal_ptr(ZigValue *a, ZigValue *b) {
     if (a->data.x_ptr.special != b->data.x_ptr.special)
         return false;
     switch (a->data.x_ptr.special) {
@@ -6527,7 +6527,7 @@ bool const_values_equal_ptr(ConstExprValue *a, ConstExprValue *b) {
     zig_unreachable();
 }
 
-static bool const_values_equal_array(CodeGen *g, ConstExprValue *a, ConstExprValue *b, size_t len) {
+static bool const_values_equal_array(CodeGen *g, ZigValue *a, ZigValue *b, size_t len) {
     assert(a->data.x_array.special != ConstArraySpecialUndef);
     assert(b->data.x_array.special != ConstArraySpecialUndef);
     if (a->data.x_array.special == ConstArraySpecialBuf &&
@@ -6538,8 +6538,8 @@ static bool const_values_equal_array(CodeGen *g, ConstExprValue *a, ConstExprVal
     expand_undef_array(g, a);
     expand_undef_array(g, b);
 
-    ConstExprValue *a_elems = a->data.x_array.data.s_none.elements;
-    ConstExprValue *b_elems = b->data.x_array.data.s_none.elements;
+    ZigValue *a_elems = a->data.x_array.data.s_none.elements;
+    ZigValue *b_elems = b->data.x_array.data.s_none.elements;
 
     for (size_t i = 0; i < len; i += 1) {
         if (!const_values_equal(g, &a_elems[i], &b_elems[i]))
@@ -6549,7 +6549,7 @@ static bool const_values_equal_array(CodeGen *g, ConstExprValue *a, ConstExprVal
     return true;
 }
 
-bool const_values_equal(CodeGen *g, ConstExprValue *a, ConstExprValue *b) {
+bool const_values_equal(CodeGen *g, ZigValue *a, ZigValue *b) {
     if (a->type->id != b->type->id) return false;
     assert(a->special == ConstValSpecialStatic);
     assert(b->special == ConstValSpecialStatic);
@@ -6623,8 +6623,8 @@ bool const_values_equal(CodeGen *g, ConstExprValue *a, ConstExprValue *b) {
         }
         case ZigTypeIdStruct:
             for (size_t i = 0; i < a->type->data.structure.src_field_count; i += 1) {
-                ConstExprValue *field_a = a->data.x_struct.fields[i];
-                ConstExprValue *field_b = b->data.x_struct.fields[i];
+                ZigValue *field_a = a->data.x_struct.fields[i];
+                ZigValue *field_b = b->data.x_struct.fields[i];
                 if (!const_values_equal(g, field_a, field_b))
                     return false;
             }
@@ -6695,7 +6695,7 @@ void eval_min_max_value_int(CodeGen *g, ZigType *int_type, BigInt *bigint, bool 
     }
 }
 
-void eval_min_max_value(CodeGen *g, ZigType *type_entry, ConstExprValue *const_val, bool is_max) {
+void eval_min_max_value(CodeGen *g, ZigType *type_entry, ZigValue *const_val, bool is_max) {
     if (type_entry->id == ZigTypeIdInt) {
         const_val->special = ConstValSpecialStatic;
         eval_min_max_value_int(g, type_entry, &const_val->data.x_bigint, is_max);
@@ -6709,7 +6709,7 @@ void eval_min_max_value(CodeGen *g, ZigType *type_entry, ConstExprValue *const_v
     }
 }
 
-static void render_const_val_ptr(CodeGen *g, Buf *buf, ConstExprValue *const_val, ZigType *type_entry) {
+static void render_const_val_ptr(CodeGen *g, Buf *buf, ZigValue *const_val, ZigType *type_entry) {
     if (type_entry->id == ZigTypeIdPointer && type_entry->data.pointer.child_type->id == ZigTypeIdOpaque) {
         buf_append_buf(buf, &type_entry->name);
         return;
@@ -6752,7 +6752,7 @@ static void render_const_val_ptr(CodeGen *g, Buf *buf, ConstExprValue *const_val
     zig_unreachable();
 }
 
-static void render_const_val_err_set(CodeGen *g, Buf *buf, ConstExprValue *const_val, ZigType *type_entry) {
+static void render_const_val_err_set(CodeGen *g, Buf *buf, ZigValue *const_val, ZigType *type_entry) {
     if (const_val->data.x_err_set == nullptr) {
         buf_append_str(buf, "null");
     } else {
@@ -6760,7 +6760,7 @@ static void render_const_val_err_set(CodeGen *g, Buf *buf, ConstExprValue *const
     }
 }
 
-static void render_const_val_array(CodeGen *g, Buf *buf, Buf *type_name, ConstExprValue *const_val, uint64_t start, uint64_t len) {
+static void render_const_val_array(CodeGen *g, Buf *buf, Buf *type_name, ZigValue *const_val, uint64_t start, uint64_t len) {
     ConstArrayValue *array = &const_val->data.x_array;
     switch (array->special) {
         case ConstArraySpecialUndef:
@@ -6784,7 +6784,7 @@ static void render_const_val_array(CodeGen *g, Buf *buf, Buf *type_name, ConstEx
             return;
         }
         case ConstArraySpecialNone: {
-            ConstExprValue *base = &array->data.s_none.elements[start];
+            ZigValue *base = &array->data.s_none.elements[start];
             assert(start + len <= const_val->type->data.array.len);
 
             buf_appendf(buf, "%s{", buf_ptr(type_name));
@@ -6799,7 +6799,7 @@ static void render_const_val_array(CodeGen *g, Buf *buf, Buf *type_name, ConstEx
     zig_unreachable();
 }
 
-void render_const_value(CodeGen *g, Buf *buf, ConstExprValue *const_val) {
+void render_const_value(CodeGen *g, Buf *buf, ZigValue *const_val) {
     switch (const_val->special) {
         case ConstValSpecialRuntime:
             buf_appendf(buf, "(runtime value)");
@@ -6927,17 +6927,17 @@ void render_const_value(CodeGen *g, Buf *buf, ConstExprValue *const_val) {
         case ZigTypeIdStruct:
             {
                 if (is_slice(type_entry)) {
-                    ConstExprValue *len_val = const_val->data.x_struct.fields[slice_len_index];
+                    ZigValue *len_val = const_val->data.x_struct.fields[slice_len_index];
                     size_t len = bigint_as_usize(&len_val->data.x_bigint);
 
-                    ConstExprValue *ptr_val = const_val->data.x_struct.fields[slice_ptr_index];
+                    ZigValue *ptr_val = const_val->data.x_struct.fields[slice_ptr_index];
                     if (ptr_val->special == ConstValSpecialUndef) {
                         assert(len == 0);
                         buf_appendf(buf, "((%s)(undefined))[0..0]", buf_ptr(&type_entry->name));
                         return;
                     }
                     assert(ptr_val->data.x_ptr.special == ConstPtrSpecialBaseArray);
-                    ConstExprValue *array = ptr_val->data.x_ptr.data.base_array.array_val;
+                    ZigValue *array = ptr_val->data.x_ptr.data.base_array.array_val;
                     size_t start = ptr_val->data.x_ptr.data.base_array.elem_index;
 
                     render_const_val_array(g, buf, &type_entry->name, array, start, len);
@@ -7206,7 +7206,7 @@ bool zig_llvm_fn_key_eql(ZigLLVMFnKey a, ZigLLVMFnKey b) {
     zig_unreachable();
 }
 
-static void init_const_undefined(CodeGen *g, ConstExprValue *const_val) {
+static void init_const_undefined(CodeGen *g, ZigValue *const_val) {
     Error err;
     ZigType *wanted_type = const_val->type;
     if (wanted_type->id == ZigTypeIdArray) {
@@ -7221,7 +7221,7 @@ static void init_const_undefined(CodeGen *g, ConstExprValue *const_val) {
         size_t field_count = wanted_type->data.structure.src_field_count;
         const_val->data.x_struct.fields = alloc_const_vals_ptrs(field_count);
         for (size_t i = 0; i < field_count; i += 1) {
-            ConstExprValue *field_val = const_val->data.x_struct.fields[i];
+            ZigValue *field_val = const_val->data.x_struct.fields[i];
             field_val->type = resolve_struct_field_type(g, wanted_type->data.structure.fields[i]);
             assert(field_val->type);
             init_const_undefined(g, field_val);
@@ -7234,14 +7234,14 @@ static void init_const_undefined(CodeGen *g, ConstExprValue *const_val) {
     }
 }
 
-void expand_undef_struct(CodeGen *g, ConstExprValue *const_val) {
+void expand_undef_struct(CodeGen *g, ZigValue *const_val) {
     if (const_val->special == ConstValSpecialUndef) {
         init_const_undefined(g, const_val);
     }
 }
 
 // Canonicalize the array value as ConstArraySpecialNone
-void expand_undef_array(CodeGen *g, ConstExprValue *const_val) {
+void expand_undef_array(CodeGen *g, ZigValue *const_val) {
     size_t elem_count;
     ZigType *elem_type;
     if (const_val->type->id == ZigTypeIdArray) {
@@ -7264,7 +7264,7 @@ void expand_undef_array(CodeGen *g, ConstExprValue *const_val) {
             const_val->data.x_array.special = ConstArraySpecialNone;
             const_val->data.x_array.data.s_none.elements = create_const_vals(elem_count);
             for (size_t i = 0; i < elem_count; i += 1) {
-                ConstExprValue *element_val = &const_val->data.x_array.data.s_none.elements[i];
+                ZigValue *element_val = &const_val->data.x_array.data.s_none.elements[i];
                 element_val->type = elem_type;
                 init_const_undefined(g, element_val);
                 element_val->parent.id = ConstParentIdArray;
@@ -7283,7 +7283,7 @@ void expand_undef_array(CodeGen *g, ConstExprValue *const_val) {
             assert(elem_count == buf_len(buf));
             const_val->data.x_array.data.s_none.elements = create_const_vals(elem_count);
             for (size_t i = 0; i < elem_count; i += 1) {
-                ConstExprValue *this_char = &const_val->data.x_array.data.s_none.elements[i];
+                ZigValue *this_char = &const_val->data.x_array.data.s_none.elements[i];
                 this_char->special = ConstValSpecialStatic;
                 this_char->type = g->builtin_types.entry_u8;
                 bigint_init_unsigned(&this_char->data.x_bigint, (uint8_t)buf_ptr(buf)[i]);
@@ -7541,12 +7541,12 @@ bool err_ptr_eql(const ErrorTableEntry *a, const ErrorTableEntry *b) {
     return a == b;
 }
 
-ConstExprValue *get_builtin_value(CodeGen *codegen, const char *name) {
+ZigValue *get_builtin_value(CodeGen *codegen, const char *name) {
     Tld *tld = get_container_scope(codegen->compile_var_import)->decl_table.get(buf_create_from_str(name));
     resolve_top_level_decl(codegen, tld, nullptr, false);
     assert(tld->id == TldIdVar);
     TldVar *tld_var = (TldVar *)tld;
-    ConstExprValue *var_value = tld_var->var->const_value;
+    ZigValue *var_value = tld_var->var->const_value;
     assert(var_value != nullptr);
     return var_value;
 }
@@ -7733,9 +7733,9 @@ uint32_t get_host_int_bytes(CodeGen *g, ZigType *struct_type, TypeStructField *f
 }
 
 Error ensure_const_val_repr(IrAnalyze *ira, CodeGen *codegen, AstNode *source_node,
-        ConstExprValue *const_val, ZigType *wanted_type)
+        ZigValue *const_val, ZigType *wanted_type)
 {
-    ConstExprValue ptr_val = {};
+    ZigValue ptr_val = {};
     ptr_val.special = ConstValSpecialStatic;
     ptr_val.type = get_pointer_to_type(codegen, wanted_type, true);
     ptr_val.data.x_ptr.mut = ConstPtrMutComptimeConst;

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -195,6 +195,11 @@ void bigint_init_bigint(BigInt *dest, const BigInt *src) {
     memcpy(dest->data.digits, src->data.digits, sizeof(uint64_t) * dest->digit_count);
 }
 
+void bigint_deinit(BigInt *bi) {
+    if (bi->digit_count > 1)
+        deallocate<uint64_t>(bi->data.digits, bi->digit_count);
+}
+
 void bigint_init_bigfloat(BigInt *dest, const BigFloat *op) {
     float128_t zero;
     ui32_to_f128M(0, &zero);

--- a/src/bigint.hpp
+++ b/src/bigint.hpp
@@ -34,6 +34,7 @@ void bigint_init_signed(BigInt *dest, int64_t x);
 void bigint_init_bigint(BigInt *dest, const BigInt *src);
 void bigint_init_bigfloat(BigInt *dest, const BigFloat *op);
 void bigint_init_data(BigInt *dest, const uint64_t *digits, size_t digit_count, bool is_negative);
+void bigint_deinit(BigInt *bi);
 
 // panics if number won't fit
 uint64_t bigint_as_u64(const BigInt *bigint);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8008,6 +8008,33 @@ static void define_builtin_types(CodeGen *g) {
     }
 }
 
+static void define_intern_values(CodeGen *g) {
+    {
+        auto& value = g->intern_values.x_undefined;
+        value.type = g->builtin_types.entry_undef;
+        value.global_refs = allocate<ConstGlobalRefs>(1, "ConstGlobalRefs.undefined");
+        value.special = ConstValSpecialStatic;
+    }
+    {
+        auto& value = g->intern_values.x_void;
+        value.type = g->builtin_types.entry_void;
+        value.global_refs = allocate<ConstGlobalRefs>(1, "ConstGlobalRefs.void");
+        value.special = ConstValSpecialStatic;
+    }
+    {
+        auto& value = g->intern_values.x_null;
+        value.type = g->builtin_types.entry_null;
+        value.global_refs = allocate<ConstGlobalRefs>(1, "ConstGlobalRefs.null");
+        value.special = ConstValSpecialStatic;
+    }
+    {
+        auto& value = g->intern_values.x_unreachable;
+        value.type = g->builtin_types.entry_unreachable;
+        value.global_refs = allocate<ConstGlobalRefs>(1, "ConstGlobalRefs.unreachable");
+        value.special = ConstValSpecialStatic;
+    }
+}
+
 static BuiltinFnEntry *create_builtin_fn(CodeGen *g, BuiltinFnId id, const char *name, size_t count) {
     BuiltinFnEntry *builtin_fn = allocate<BuiltinFnEntry>(1);
     buf_init_from_str(&builtin_fn->name, name);
@@ -8629,6 +8656,7 @@ static void init(CodeGen *g) {
     g->dummy_di_file = nullptr;
 
     define_builtin_types(g);
+    define_intern_values(g);
 
     IrInstruction *sentinel_instructions = allocate<IrInstruction>(2);
     g->invalid_instruction = &sentinel_instructions[0];

--- a/src/dump_analysis.cpp
+++ b/src/dump_analysis.cpp
@@ -361,9 +361,9 @@ struct AnalDumpCtx {
 };
 
 static uint32_t anal_dump_get_type_id(AnalDumpCtx *ctx, ZigType *ty);
-static void anal_dump_value(AnalDumpCtx *ctx, AstNode *source_node, ZigType *ty, ConstExprValue *value);
+static void anal_dump_value(AnalDumpCtx *ctx, AstNode *source_node, ZigType *ty, ZigValue *value);
 
-static void anal_dump_poke_value(AnalDumpCtx *ctx, AstNode *source_node, ZigType *ty, ConstExprValue *value) {
+static void anal_dump_poke_value(AnalDumpCtx *ctx, AstNode *source_node, ZigType *ty, ZigValue *value) {
     Error err;
     if (value->type != ty) {
         return;
@@ -660,7 +660,7 @@ static void anal_dump_file(AnalDumpCtx *ctx, Buf *file) {
     jw_string(jw, buf_ptr(file));
 }
 
-static void anal_dump_value(AnalDumpCtx *ctx, AstNode *source_node, ZigType *ty, ConstExprValue *value) {
+static void anal_dump_value(AnalDumpCtx *ctx, AstNode *source_node, ZigType *ty, ZigValue *value) {
     Error err;
 
     if (value->type != ty) {
@@ -1249,7 +1249,7 @@ void zig_print_analysis_dump(CodeGen *g, FILE *f, const char *one_indent, const 
                 }
                 scope = scope->parent;
             }
-            ConstExprValue *result = entry->value;
+            ZigValue *result = entry->value;
 
             assert(fn != nullptr);
 

--- a/src/hash_map.hpp
+++ b/src/hash_map.hpp
@@ -23,10 +23,10 @@ public:
     }
 
     struct Entry {
-        bool used;
-        int distance_from_start_index;
         K key;
         V value;
+        bool used;
+        int distance_from_start_index;
     };
 
     void clear() {
@@ -187,10 +187,10 @@ private:
                     if (distance_from_start_index > _max_distance_from_start_index)
                         _max_distance_from_start_index = distance_from_start_index;
                     *entry = {
-                        true,
-                        distance_from_start_index,
                         key,
                         value,
+                        true,
+                        distance_from_start_index,
                     };
                     key = tmp.key;
                     value = tmp.value;
@@ -208,10 +208,10 @@ private:
             if (distance_from_start_index > _max_distance_from_start_index)
                 _max_distance_from_start_index = distance_from_start_index;
             *entry = {
-                true,
-                distance_from_start_index,
                 key,
                 value,
+                true,
+                distance_from_start_index,
             };
             return;
         }

--- a/src/ir.hpp
+++ b/src/ir.hpp
@@ -18,12 +18,12 @@ enum IrPass {
 bool ir_gen(CodeGen *g, AstNode *node, Scope *scope, IrExecutable *ir_executable);
 bool ir_gen_fn(CodeGen *g, ZigFn *fn_entry);
 
-ConstExprValue *ir_eval_const_value(CodeGen *codegen, Scope *scope, AstNode *node,
+ZigValue *ir_eval_const_value(CodeGen *codegen, Scope *scope, AstNode *node,
         ZigType *expected_type, size_t *backward_branch_count, size_t *backward_branch_quota,
         ZigFn *fn_entry, Buf *c_import_buf, AstNode *source_node, Buf *exec_name,
         IrExecutable *parent_exec, AstNode *expected_type_source_node, UndefAllowed undef);
 
-Error ir_resolve_lazy(CodeGen *codegen, AstNode *source_node, ConstExprValue *val);
+Error ir_resolve_lazy(CodeGen *codegen, AstNode *source_node, ZigValue *val);
 
 ZigType *ir_analyze(CodeGen *g, IrExecutable *old_executable, IrExecutable *new_executable,
         ZigType *expected_type, AstNode *expected_type_source_node);
@@ -31,7 +31,7 @@ ZigType *ir_analyze(CodeGen *g, IrExecutable *old_executable, IrExecutable *new_
 bool ir_has_side_effects(IrInstruction *instruction);
 
 struct IrAnalyze;
-ConstExprValue *const_ptr_pointee(IrAnalyze *ira, CodeGen *codegen, ConstExprValue *const_val,
+ZigValue *const_ptr_pointee(IrAnalyze *ira, CodeGen *codegen, ZigValue *const_val,
         AstNode *source_node);
 const char *float_op_to_name(BuiltinFnId op, bool llvm_name);
 

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -389,7 +389,7 @@ static void ir_print_indent(IrPrint *irp) {
 static void ir_print_prefix(IrPrint *irp, IrInstruction *instruction, bool trailing) {
     ir_print_indent(irp);
     const char mark = trailing ? ':' : '#';
-    const char *type_name = instruction->value.type ? buf_ptr(&instruction->value.type->name) : "(unknown)";
+    const char *type_name = instruction->value->type ? buf_ptr(&instruction->value->type->name) : "(unknown)";
     const char *ref_count = ir_has_side_effects(instruction) ?
         "-" : buf_ptr(buf_sprintf("%" PRIu32 "", instruction->ref_count));
     fprintf(irp->f, "%c%-3" PRIu32 "| %-22s| %-12s| %-2s| ", mark, instruction->debug_id,
@@ -417,8 +417,8 @@ static void ir_print_other_instruction(IrPrint *irp, IrInstruction *instruction)
         return;
     }
 
-    if (instruction->value.special != ConstValSpecialRuntime) {
-        ir_print_const_value(irp, &instruction->value);
+    if (instruction->value->special != ConstValSpecialRuntime) {
+        ir_print_const_value(irp, instruction->value);
     } else {
         ir_print_var_instruction(irp, instruction);
     }
@@ -438,7 +438,7 @@ static void ir_print_return(IrPrint *irp, IrInstructionReturn *instruction) {
 }
 
 static void ir_print_const(IrPrint *irp, IrInstructionConst *const_instruction) {
-    ir_print_const_value(irp, &const_instruction->base.value);
+    ir_print_const_value(irp, const_instruction->base.value);
 }
 
 static const char *ir_bin_op_id_str(IrBinOp op_id) {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -396,7 +396,7 @@ static void ir_print_prefix(IrPrint *irp, IrInstruction *instruction, bool trail
         ir_instruction_type_str(instruction->id), type_name, ref_count);
 }
 
-static void ir_print_const_value(IrPrint *irp, ConstExprValue *const_val) {
+static void ir_print_const_value(IrPrint *irp, ZigValue *const_val) {
     Buf buf = BUF_INIT;
     buf_resize(&buf, 0);
     render_const_value(irp->codegen, &buf, const_val);
@@ -2576,7 +2576,7 @@ void ir_print_instruction(CodeGen *codegen, FILE *f, IrInstruction *instruction,
     ir_print_instruction(irp, instruction, false);
 }
 
-void ir_print_const_expr(CodeGen *codegen, FILE *f, ConstExprValue *value, int indent_size, IrPass pass) {
+void ir_print_const_expr(CodeGen *codegen, FILE *f, ZigValue *value, int indent_size, IrPass pass) {
     IrPrint ir_print = {};
     IrPrint *irp = &ir_print;
     irp->pass = pass;

--- a/src/ir_print.hpp
+++ b/src/ir_print.hpp
@@ -14,7 +14,7 @@
 
 void ir_print(CodeGen *codegen, FILE *f, IrExecutable *executable, int indent_size, IrPass pass);
 void ir_print_instruction(CodeGen *codegen, FILE *f, IrInstruction *instruction, int indent_size, IrPass pass);
-void ir_print_const_expr(CodeGen *codegen, FILE *f, ConstExprValue *value, int indent_size, IrPass pass);
+void ir_print_const_expr(CodeGen *codegen, FILE *f, ZigValue *value, int indent_size, IrPass pass);
 
 const char* ir_instruction_type_str(IrInstructionId id);
 

--- a/src/memory_profiling.cpp
+++ b/src/memory_profiling.cpp
@@ -6,6 +6,8 @@
 
 #ifdef ZIG_ENABLE_MEM_PROFILE
 
+MemprofInternCount memprof_intern_count;
+
 static bool str_eql_str(const char *a, const char *b) {
     return strcmp(a, b) == 0;
 }
@@ -28,7 +30,6 @@ struct CountAndSize {
 ZigList<const char *> unknown_names = {};
 HashMap<const char *, CountAndSize, str_hash, str_eql_str> usage_table = {};
 bool table_active = false;
-
 
 static const char *get_default_name(const char *name_or_null, size_t type_size) {
     if (name_or_null != nullptr) return name_or_null;
@@ -134,6 +135,12 @@ void memprof_dump_stats(FILE *file) {
 
     list.deinit();
     table_active = true;
+
+    fprintf(stderr, "\n");
+    fprintf(stderr, "undefined: interned %zu times\n", memprof_intern_count.x_undefined);
+    fprintf(stderr, "void: interned %zu times\n", memprof_intern_count.x_void);
+    fprintf(stderr, "null: interned %zu times\n", memprof_intern_count.x_null);
+    fprintf(stderr, "unreachable: interned %zu times\n", memprof_intern_count.x_unreachable);
 }
 
 #endif

--- a/src/memory_profiling.hpp
+++ b/src/memory_profiling.hpp
@@ -13,6 +13,14 @@
 #include <stddef.h>
 #include <stdio.h>
 
+struct MemprofInternCount {
+    size_t x_undefined;
+    size_t x_void;
+    size_t x_null;
+    size_t x_unreachable;
+};
+extern MemprofInternCount memprof_intern_count;
+
 void memprof_init(void);
 
 void memprof_alloc(const char *name, size_t item_count, size_t type_size);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -121,18 +121,18 @@ SplitIterator memSplit(Slice<uint8_t> buffer, Slice<uint8_t> split_bytes) {
 
 void zig_pretty_print_bytes(FILE *f, double n) {
     if (n > 1024.0 * 1024.0 * 1024.0) {
-        fprintf(f, "%.02f GiB", n / 1024.0 / 1024.0 / 1024.0);
+        fprintf(f, "%.03f GiB", n / 1024.0 / 1024.0 / 1024.0);
         return;
     }
     if (n > 1024.0 * 1024.0) {
-        fprintf(f, "%.02f MiB", n / 1024.0 / 1024.0);
+        fprintf(f, "%.03f MiB", n / 1024.0 / 1024.0);
         return;
     }
     if (n > 1024.0) {
-        fprintf(f, "%.02f KiB", n / 1024.0);
+        fprintf(f, "%.03f KiB", n / 1024.0);
         return;
     }
-    fprintf(f, "%.02f bytes", n );
+    fprintf(f, "%.03f bytes", n );
     return;
 }
 


### PR DESCRIPTION
- this PR has 3 commits
- memory report with maximum resident size for (uncached) test is as follows:

host: macOS 10.15.1
command: `gtime -v zig -fmem-report --cache off --output-dir zig-cache -fmem-report test lib/std/std.zig`

#### commit: rename ConstExprValue → ZigValue
```
Const: 7073345 items, 144 bytes each, total 971.38 MiB
ConstGlobalRefs: 18701697 items, 24 bytes each, total 428.05 MiB
ResetResult: 1750877 items, 152 bytes each, total 253.80 MiB
ZigValue: 3150835 items, 80 bytes each, total 240.39 MiB
Unknown_8: 29310030 items, 8 bytes each, total 223.62 MiB
EndExpr: 1383963 items, 160 bytes each, total 211.18 MiB
VarPtr: 1147147 items, 160 bytes each, total 175.04 MiB
Unknown_64: 2211102 items, 64 bytes each, total 134.95 MiB
IrBasicBlock: 811038 items, 120 bytes each, total 92.82 MiB
LoadPtr: 572389 items, 152 bytes each, total 82.97 MiB
...
Maximum resident set size (kbytes): 4815564
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:24.82
```

#### commit: unembed ZigValue from IrInstruction
```
ZigValue: 18714968 items, 80 bytes each, total 1.39 GiB
Const: 7073345 items, 72 bytes each, total 485.69 MiB
ConstGlobalRefs: 18701697 items, 24 bytes each, total 428.05 MiB
Unknown_8: 29310030 items, 8 bytes each, total 223.62 MiB
Unknown_64: 2211102 items, 64 bytes each, total 134.95 MiB
ResetResult: 1750877 items, 80 bytes each, total 133.58 MiB
EndExpr: 1383963 items, 88 bytes each, total 116.15 MiB
VarPtr: 1147147 items, 88 bytes each, total 96.27 MiB
IrBasicBlock: 811038 items, 120 bytes each, total 92.82 MiB
Unknown_40: 1905533 items, 40 bytes each, total 72.69 MiB
...
Maximum resident set size (kbytes): 4985284
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.69
```

#### commit: const interning for 1-possible-value types
```
ZigValue: 14729595 items, 80 bytes each, total 1.097 GiB
Const: 7073345 items, 72 bytes each, total 485.688 MiB
ConstGlobalRefs: 14716324 items, 24 bytes each, total 336.830 MiB
Unknown_8: 29310030 items, 8 bytes each, total 223.618 MiB
Unknown_64: 2211102 items, 64 bytes each, total 134.955 MiB
ResetResult: 1750877 items, 80 bytes each, total 133.581 MiB
EndExpr: 1383963 items, 88 bytes each, total 116.147 MiB
VarPtr: 1147147 items, 88 bytes each, total 96.272 MiB
IrBasicBlock: 811038 items, 120 bytes each, total 92.816 MiB
Unknown_40: 1905533 items, 40 bytes each, total 72.690 MiB
...
undefined: interned 3124 times
void: interned 3973372 times
null: interned 3533 times
unreachable: interned 5344 times
...
Maximum resident set size (kbytes): 4535756
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.12
```

net maximum RSS savings for PR: `273 MiB`