### PR TITLE
Added 'writeJson' to write_stream.zig:

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1407,6 +1407,7 @@ test "json.parser.dynamic" {
 
 test "import more json tests" {
     _ = @import("json/test.zig");
+    _ = @import("json/write_stream.zig");
 }
 
 test "write json then parse it" {

--- a/lib/std/json/write_stream.zig
+++ b/lib/std/json/write_stream.zig
@@ -198,7 +198,7 @@ pub fn WriteStream(comptime OutStream: type, comptime max_depth: usize) type {
         }
 
         /// Writes the complete json into the output stream
-        pub fn writeJson(self: *Self, json: std.json.Value) std.os.WriteError!void {
+        pub fn emitJson(self: *Self, json: std.json.Value) Stream.Error!void {
             switch (json) {
                 .Null => try self.emitNull(),
                 .Bool => |inner| try self.emitBool(inner),
@@ -209,7 +209,7 @@ pub fn WriteStream(comptime OutStream: type, comptime max_depth: usize) type {
                     try self.beginArray();
                     for (inner.toSliceConst()) |elem| {
                         try self.arrayElem();
-                        try self.writeJson(elem);
+                        try self.emitJson(elem);
                     }
                     try self.endArray();
                 },
@@ -218,7 +218,7 @@ pub fn WriteStream(comptime OutStream: type, comptime max_depth: usize) type {
                     var it = inner.iterator();
                     while (it.next()) |entry| {
                         try self.objectField(entry.key);
-                        try self.writeJson(entry.value);
+                        try self.emitJson(entry.value);
                     }
                     try self.endObject();
                 },

--- a/lib/std/json/write_stream.zig
+++ b/lib/std/json/write_stream.zig
@@ -200,12 +200,12 @@ pub fn WriteStream(comptime OutStream: type, comptime max_depth: usize) type {
         /// Writes the complete json into the output stream
         pub fn writeJson(self: *Self, json: std.json.Value) std.os.WriteError!void {
             switch (json) {
-                std.json.Value.Null => try self.emitNull(),
-                std.json.Value.Bool => |inner| try self.emitBool(inner),
-                std.json.Value.Integer => |inner| try self.emitNumber(inner),
-                std.json.Value.Float => |inner| try self.emitNumber(inner),
-                std.json.Value.String => |inner| try self.emitString(inner),
-                std.json.Value.Array => |inner| {
+                .Null => try self.emitNull(),
+                .Bool => |inner| try self.emitBool(inner),
+                .Integer => |inner| try self.emitNumber(inner),
+                .Float => |inner| try self.emitNumber(inner),
+                .String => |inner| try self.emitString(inner),
+                .Array => |inner| {
                     try self.beginArray();
                     for (inner.toSliceConst()) |elem| {
                         try self.arrayElem();
@@ -213,7 +213,7 @@ pub fn WriteStream(comptime OutStream: type, comptime max_depth: usize) type {
                     }
                     try self.endArray();
                 },
-                std.json.Value.Object => |inner| {
+                .Object => |inner| {
                     try self.beginObject();
                     var it = inner.iterator();
                     while (it.next()) |entry| {


### PR DESCRIPTION
Small addition to make writing a json value easier

The following program will print this to stdout:

```
{
 "object": {
  "one": 1,
  "two": 2.0e+00
 },
 "string": "This is a string",
 "array": [
  "Another string",
  1,
  3.14e+00
 ],
 "int": 10,
 "float": 3.14e+00
}
```

```
const std = @import("std");

pub fn main() anyerror!void {            
    const stdout_file = try std.io.getStdOut();
    var stdout = &stdout_file.outStream().stream;

    var w = std.json.WriteStream(@typeOf(stdout).Child, 10).init(stdout);
    try w.writeJson(try getJson(std.heap.direct_allocator));             
}                                                           

pub fn getJson(allocator: *std.mem.Allocator) !std.json.Value {
    var value = std.json.Value{ .Object = std.json.ObjectMap.init(allocator) };
    _ = try value.Object.put("string", std.json.Value{ .String = "This is a string" });
    _ = try value.Object.put("int", std.json.Value{ .Integer = @intCast(i64, 10) });   
    _ = try value.Object.put("float", std.json.Value{ .Float = 3.14 });             
    _ = try value.Object.put("array", try getJsonArray(allocator));    
    _ = try value.Object.put("object", try getJsonObject(allocator));
    return value;                                                    
}                

pub fn getJsonObject(allocator: *std.mem.Allocator) !std.json.Value {
    var value = std.json.Value{ .Object = std.json.ObjectMap.init(allocator) };
    _ = try value.Object.put("one", std.json.Value{ .Integer = @intCast(i64, 1) });
    _ = try value.Object.put("two", std.json.Value{ .Float = 2.0 });               
    return value;                                                   
}                

pub fn getJsonArray(allocator: *std.mem.Allocator) !std.json.Value {
    var value = std.json.Value{ .Array = std.json.Array.init(allocator) };
    var array = &value.Array;                                             
    _ = try array.append(std.json.Value{ .String = "Another string" });
    _ = try array.append(std.json.Value{ .Integer = @intCast(i64, 1) });
    _ = try array.append(std.json.Value{ .Float = 3.14 });              

    return value;                                         
}
```