### PR TITLE
Translate-c: Fix a segfault when to many errors are emitted

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8886,12 +8886,16 @@ void codegen_translate_c(CodeGen *g, Buf *full_path, FILE *out_file, bool use_us
     if (err == ErrorCCompileErrors && errors_len > 0) {
         for (size_t i = 0; i < errors_len; i += 1) {
             Stage2ErrorMsg *clang_err = &errors_ptr[i];
-            ErrorMsg *err_msg = err_msg_create_with_offset(
-                    clang_err->filename_ptr ?
-                        buf_create_from_mem(clang_err->filename_ptr, clang_err->filename_len) : buf_alloc(),
-                    clang_err->line, clang_err->column, clang_err->offset, clang_err->source,
-                    buf_create_from_mem(clang_err->msg_ptr, clang_err->msg_len));
-            print_err_msg(err_msg, g->err_color);
+
+            // Clang can emit "too many errors, stopping now", in which case `source` and `filename_ptr` are null
+            if (clang_err->source && clang_err->filename_ptr) {
+                ErrorMsg *err_msg = err_msg_create_with_offset(
+                        clang_err->filename_ptr ?
+                            buf_create_from_mem(clang_err->filename_ptr, clang_err->filename_len) : buf_alloc(),
+                        clang_err->line, clang_err->column, clang_err->offset, clang_err->source,
+                        buf_create_from_mem(clang_err->msg_ptr, clang_err->msg_len));
+                print_err_msg(err_msg, g->err_color);
+            }
         }
         exit(1);
     }


### PR DESCRIPTION
This was already fixed when doing `@cImport`, but not yet when
running `zig translate-c`.

Found this while looking into #3472