### PR TITLE
added -- to pass args to zig build commands

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -54,6 +54,7 @@ pub const Builder = struct {
     is_release: bool,
     override_lib_dir: ?[]const u8,
     vcpkg_root: VcpkgRoot,
+    args: ?[][]const u8,
     pkg_config_pkg_list: ?(PkgConfigError![]const PkgConfigPkg) = null,
 
     const PkgConfigError = error{
@@ -160,6 +161,7 @@ pub const Builder = struct {
             .override_lib_dir = null,
             .install_path = undefined,
             .vcpkg_root = VcpkgRoot{ .Unattempted = {} },
+            .args = null,
         };
         try self.top_level_steps.append(&self.install_tls);
         try self.top_level_steps.append(&self.uninstall_tls);

--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -98,6 +98,10 @@ pub fn main() !void {
                 builder.verbose_cimport = true;
             } else if (mem.eql(u8, arg, "--verbose-cc")) {
                 builder.verbose_cc = true;
+            } else if (mem.eql(u8, arg, "--")) {
+                var arg_slice = try process.argsAlloc(allocator);
+                builder.args = arg_slice[arg_it.index..];
+                break;
             } else {
                 warn("Unrecognized argument: {}\n\n", .{arg});
                 return usageAndErr(builder, false, stderr_stream);


### PR DESCRIPTION
this adds the `args` field to the `Builder` struct to access extra command line args similar to `zig run`.