### PR TITLE
stage1: fix compile error on macOS Xcode 11.2

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7710,13 +7710,6 @@ struct GlobalLinkageValue {
     const char *name;
 };
 
-static const GlobalLinkageValue global_linkage_values[] = {
-    {GlobalLinkageIdInternal, "Internal"},
-    {GlobalLinkageIdStrong, "Strong"},
-    {GlobalLinkageIdWeak, "Weak"},
-    {GlobalLinkageIdLinkOnce, "LinkOnce"},
-};
-
 static void add_fp_entry(CodeGen *g, const char *name, uint32_t bit_count, LLVMTypeRef type_ref,
         ZigType **field)
 {


### PR DESCRIPTION
src/codegen.cpp:7713:33: error: unused variable 'global_linkage_values' [-Werror,-Wunused-const-variable]
static const GlobalLinkageValue global_linkage_values[] = {