### PR TITLE
generated docs: vertically align fns with comments

### DIFF
--- a/lib/std/special/docs/index.html
+++ b/lib/std/special/docs/index.html
@@ -270,7 +270,6 @@
       }
       
       .docs td {
-        vertical-align: top;
         margin: 0;
         padding: 0.5em;
         max-width: 27em;


### PR DESCRIPTION
## Before
<img width="941" alt="Screen Shot 2019-10-25 at 6 38 07 PM" src="https://user-images.githubusercontent.com/7284585/67612499-f8ce5d00-f757-11e9-8b99-6236173729a0.png">

## After
<img width="957" alt="Screen Shot 2019-10-25 at 6 38 22 PM" src="https://user-images.githubusercontent.com/7284585/67612497-f10eb880-f757-11e9-8bc5-a2739581d694.png">

Screenshots from this page https://ziglang.org/documentation/master/std/#std;fs