### PR TITLE
Don't save/restore stack on newStackCall to noreturn function

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4209,15 +4209,19 @@ static LLVMValueRef ir_render_call(CodeGen *g, IrExecutable *executable, IrInstr
     } else if (instruction->modifier == CallModifierAsync) {
         zig_panic("TODO @asyncCall of non-async function");
     } else {
-        LLVMValueRef stacksave_fn_val = get_stacksave_fn_val(g);
-        LLVMValueRef stackrestore_fn_val = get_stackrestore_fn_val(g);
-
         LLVMValueRef new_stack_addr = get_new_stack_addr(g, ir_llvm_value(g, instruction->new_stack));
-        LLVMValueRef old_stack_ref = LLVMBuildCall(g->builder, stacksave_fn_val, nullptr, 0, "");
+        LLVMValueRef old_stack_ref;
+        if (src_return_type->id != ZigTypeIdUnreachable) {
+            LLVMValueRef stacksave_fn_val = get_stacksave_fn_val(g);
+            old_stack_ref = LLVMBuildCall(g->builder, stacksave_fn_val, nullptr, 0, "");
+        }
         gen_set_stack_pointer(g, new_stack_addr);
         result = ZigLLVMBuildCall(g->builder, fn_val,
                 gen_param_values.items, (unsigned)gen_param_values.length, llvm_cc, fn_inline, "");
-        LLVMBuildCall(g->builder, stackrestore_fn_val, &old_stack_ref, 1, "");
+        if (src_return_type->id != ZigTypeIdUnreachable) {
+            LLVMValueRef stackrestore_fn_val = get_stackrestore_fn_val(g);
+            LLVMBuildCall(g->builder, stackrestore_fn_val, &old_stack_ref, 1, "");
+        }
     }
 
     if (src_return_type->id == ZigTypeIdUnreachable) {
@@ -10405,4 +10409,3 @@ void codegen_switch_sub_prog_node(CodeGen *g, Stage2ProgressNode *node) {
     }
     g->sub_progress_node = node;
 }
-


### PR DESCRIPTION
This fixes, for instance, undefined behavior on freestanding with multiboot.

This changes generated code for
```zig
export nakedcc fn start() noreturn {
    @newStackCall(stack[0..], kmain, asm("" : [a] "={eax}" (->u32)), @inlineCall(multiboot.parse));
}
```
from 
```asm
start:
        movl    __unnamed_7, %ecx
        movl    __unnamed_7+4, %edx
        addl    %edx, %ecx
        movl    %ecx, %edx
        andl    $15, %edx
        subl    %edx, %ecx
        movl    %esp, %edx
        movl    %ecx, %esp
        movl    %eax, %ecx
        movl    %edx, -4(%ebp)
        movl    %ebx, %edx
        calll   kmain
        movl    -4(%ebp), %eax
        movl    %eax, %esp
```

to 

```asm
start:
; Optimized: no longer stores old stack on newStackCall to function with return type `noreturn`
; Fixed: no longer contains UB in the form of illegal access to undefined EBP register

; Moves the address of the stack into %ecx
        movl     __unnamed_7, %ecx
; Moves the size of the stack into %edx
        movl    __unnamed_7+4, %edx
; Adds Stack size to address (leaving top of stack in %ecx)
        addl    %edx, %ecx
; Moves top of stack to %edx
        movl    %ecx, %edx
; Ensures 16-byte... alignment... despite the fact that that's already done
; with .p2align at the stack declaration. This is just a minor issue 
; with optimization
        andl    $15, %edx
        subl    %edx, %ecx
; Actually set the stack
        movl    %ecx, %esp
; Set multiboot magic and info params, jump to kmain
        movl    %eax, %ecx
        movl    %ebx, %edx
        calll   kmain
```

(commentary mine; metadata removed to improve readability)