### PR TITLE
Don't use SSE on freestanding

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8465,7 +8465,12 @@ static void init(CodeGen *g) {
         // uses as base cpu.
         // TODO https://github.com/ziglang/zig/issues/2883
         target_specific_cpu_args = "pentium4";
-        target_specific_features = "";
+        if (g->zig_target->os == OsFreestanding) {
+            target_specific_features = "-sse";
+        }
+        else {
+            target_specific_features = "";
+        }
     } else {
         target_specific_cpu_args = "";
         target_specific_features = "";


### PR DESCRIPTION
A better solution might be to have an option to disable/enable SSE/SIMD within the current scope, but this at least results in functional code.