### PR TITLE
std.json.Value: added dumpStream(), utilize WriteStream for dump()

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -45,6 +45,7 @@ var stderr_file_out_stream: File.OutStream = undefined;
 
 var stderr_stream: ?*io.OutStream(File.WriteError) = null;
 var stderr_mutex = std.Mutex.init();
+
 pub fn warn(comptime fmt: []const u8, args: ...) void {
     const held = stderr_mutex.acquire();
     defer held.release();
@@ -62,6 +63,10 @@ pub fn getStderrStream() !*io.OutStream(File.WriteError) {
         stderr_stream = st;
         return st;
     }
+}
+
+pub fn getStderrMutex() *std.Mutex {
+    return &stderr_mutex;
 }
 
 /// TODO multithreaded awareness

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -898,7 +898,7 @@ pub const TokenStream = struct {
             }
         }
 
-        if(self.parser.complete){
+        if (self.parser.complete) {
             return null;
         } else {
             return error.UnexpectedEndOfJson;
@@ -1012,119 +1012,39 @@ pub const Value = union(enum) {
     Object: ObjectMap,
 
     pub fn dump(self: Value) void {
-        switch (self) {
-            Value.Null => {
-                debug.warn("null");
-            },
-            Value.Bool => |inner| {
-                debug.warn("{}", inner);
-            },
-            Value.Integer => |inner| {
-                debug.warn("{}", inner);
-            },
-            Value.Float => |inner| {
-                debug.warn("{:.5}", inner);
-            },
-            Value.String => |inner| {
-                debug.warn("\"{}\"", inner);
-            },
-            Value.Array => |inner| {
-                var not_first = false;
-                debug.warn("[");
-                for (inner.toSliceConst()) |value| {
-                    if (not_first) {
-                        debug.warn(",");
-                    }
-                    not_first = true;
-                    value.dump();
-                }
-                debug.warn("]");
-            },
-            Value.Object => |inner| {
-                var not_first = false;
-                debug.warn("{{");
-                var it = inner.iterator();
+        var held = std.debug.getStderrMutex().acquire();
+        defer held.release();
 
-                while (it.next()) |entry| {
-                    if (not_first) {
-                        debug.warn(",");
-                    }
-                    not_first = true;
-                    debug.warn("\"{}\":", entry.key);
-                    entry.value.dump();
-                }
-                debug.warn("}}");
-            },
-        }
+        const stderr = std.debug.getStderrStream() catch return;
+        self.dumpStream(stderr, 1024) catch return;
     }
 
-    pub fn dumpIndent(self: Value, indent: usize) void {
+    pub fn dumpIndent(self: Value, comptime indent: usize) void {
         if (indent == 0) {
             self.dump();
         } else {
-            self.dumpIndentLevel(indent, 0);
+            var held = std.debug.getStderrMutex().acquire();
+            defer held.release();
+
+            const stderr = std.debug.getStderrStream() catch return;
+            self.dumpStreamIndent(indent, stderr, 1024) catch return;
         }
     }
 
-    fn dumpIndentLevel(self: Value, indent: usize, level: usize) void {
-        switch (self) {
-            Value.Null => {
-                debug.warn("null");
-            },
-            Value.Bool => |inner| {
-                debug.warn("{}", inner);
-            },
-            Value.Integer => |inner| {
-                debug.warn("{}", inner);
-            },
-            Value.Float => |inner| {
-                debug.warn("{:.5}", inner);
-            },
-            Value.String => |inner| {
-                debug.warn("\"{}\"", inner);
-            },
-            Value.Array => |inner| {
-                var not_first = false;
-                debug.warn("[\n");
-
-                for (inner.toSliceConst()) |value| {
-                    if (not_first) {
-                        debug.warn(",\n");
-                    }
-                    not_first = true;
-                    padSpace(level + indent);
-                    value.dumpIndentLevel(indent, level + indent);
-                }
-                debug.warn("\n");
-                padSpace(level);
-                debug.warn("]");
-            },
-            Value.Object => |inner| {
-                var not_first = false;
-                debug.warn("{{\n");
-                var it = inner.iterator();
-
-                while (it.next()) |entry| {
-                    if (not_first) {
-                        debug.warn(",\n");
-                    }
-                    not_first = true;
-                    padSpace(level + indent);
-                    debug.warn("\"{}\": ", entry.key);
-                    entry.value.dumpIndentLevel(indent, level + indent);
-                }
-                debug.warn("\n");
-                padSpace(level);
-                debug.warn("}}");
-            },
-        }
+    pub fn dumpStream(self: @This(), stream: var, comptime max_depth: usize) !void {
+        var w = std.json.WriteStream(@typeOf(stream).Child, max_depth).init(stream);
+        w.newline = "";
+        w.one_indent = "";
+        w.space = "";
+        try w.emitJson(self);
     }
 
-    fn padSpace(indent: usize) void {
-        var i: usize = 0;
-        while (i < indent) : (i += 1) {
-            debug.warn(" ");
-        }
+    pub fn dumpStreamIndent(self: @This(), comptime indent: usize, stream: var, comptime max_depth: usize) !void {
+        var one_indent = " " ** indent;
+
+        var w = std.json.WriteStream(@typeOf(stream).Child, max_depth).init(stream);
+        w.one_indent = one_indent;
+        try w.emitJson(self);
     }
 };
 

--- a/lib/std/json/write_stream.zig
+++ b/lib/std/json/write_stream.zig
@@ -27,6 +27,9 @@ pub fn WriteStream(comptime OutStream: type, comptime max_depth: usize) type {
         /// The string used as a newline character.
         newline: []const u8 = "\n",
 
+        /// The string used as spacing.
+        space: []const u8 = " ",
+
         stream: *OutStream,
         state_index: usize,
         state: [max_depth]State,
@@ -87,7 +90,8 @@ pub fn WriteStream(comptime OutStream: type, comptime max_depth: usize) type {
                     self.pushState(.Value);
                     try self.indent();
                     try self.writeEscapedString(name);
-                    try self.stream.write(": ");
+                    try self.stream.write(":");
+                    try self.stream.write(self.space);
                 },
             }
         }


### PR DESCRIPTION
Added a helper method to std.json.Value to print to an OutStream. Also refactored the dump() method to utilize WriteStream.

Fixes https://github.com/ziglang/zig/issues/3008

```{"object":{"one":1,"two":2.0e+00},"string":"This is a string","array":["Another string",1,3.14e+00],"int":10,"float":3.14e+00}```

```
const std = @import("std");

pub fn main() anyerror!void {
    const stdout_file = try std.io.getStdOut();
    var stdout = &stdout_file.outStream().stream;

    var json = try getJson(std.heap.direct_allocator);
    try json.dumpStream(stdout, 100);
}

pub fn getJson(allocator: *std.mem.Allocator) !std.json.Value {
    var value = std.json.Value{ .Object = std.json.ObjectMap.init(allocator) };
    _ = try value.Object.put("string", std.json.Value{ .String = "This is a string" });
    _ = try value.Object.put("int", std.json.Value{ .Integer = @intCast(i64, 10) });
    _ = try value.Object.put("float", std.json.Value{ .Float = 3.14 });
    _ = try value.Object.put("array", try getJsonArray(allocator));
    _ = try value.Object.put("object", try getJsonObject(allocator));
    return value;
}

pub fn getJsonObject(allocator: *std.mem.Allocator) !std.json.Value {
    var value = std.json.Value{ .Object = std.json.ObjectMap.init(allocator) };
    _ = try value.Object.put("one", std.json.Value{ .Integer = @intCast(i64, 1) });
    _ = try value.Object.put("two", std.json.Value{ .Float = 2.0 });
    return value;
}

pub fn getJsonArray(allocator: *std.mem.Allocator) !std.json.Value {
    var value = std.json.Value{ .Array = std.json.Array.init(allocator) };
    var array = &value.Array;
    _ = try array.append(std.json.Value{ .String = "Another string" });
    _ = try array.append(std.json.Value{ .Integer = @intCast(i64, 1) });
    _ = try array.append(std.json.Value{ .Float = 3.14 });

    return value;
}
```