### PR TITLE
generated docs: log trace instead of error

### DIFF
--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -487,7 +487,7 @@
                     return value + "";
                 }
             default:
-                throw new Error("TODO implement getValueText for this type");
+                console.trace("TODO implement getValueText for this type:", zigAnalysis.typeKinds[typeObj.kind]);
         }
     }
 


### PR DESCRIPTION
When the error occurred for `getValueText` it could potentially omit
useful documentation since the page stops rendering.

For example, on the docs for `BloomFilter` the top level function for `BloomFilter`, doc comments for that function, and examples are missing on the page:
https://ziglang.org/documentation/master/std/#std;BloomFilter

In the console it should still have basically the same information.

Before:
<img width="578" alt="Screen Shot 2019-10-28 at 5 17 33 PM" src="https://user-images.githubusercontent.com/7284585/67727502-df6f2000-f9a6-11e9-96d6-e6a53230d7a0.png">


After:
<img width="665" alt="Screen Shot 2019-10-28 at 5 14 59 PM" src="https://user-images.githubusercontent.com/7284585/67727425-974ffd80-f9a6-11e9-85b3-c3bcd60872cf.png">

Here's the caniuse on trace that I found: https://caniuse.com/#search=trace

I figure since this is temporary anyways until types are implemented it shouldn't have too much impact even if one's browser doesn't support `console.trace`.
