### PR TITLE
Add mem.secureEql

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -356,6 +356,17 @@ pub fn eql(comptime T: type, a: []const T, b: []const T) bool {
     return true;
 }
 
+/// Compares two slices and returns whether they are equal. The time taken is
+/// a function of the length of the slices and is independent of the contents.
+pub fn secureEql(comptime T: type, a: []const T, b: []const T) bool {
+    if (a.len != b.len) return false;
+    var s: T = 0;
+    for (a) |_, i| {
+        s |= a[i] ^ b[i];
+    }
+    return s == 0;
+}
+
 pub fn len(comptime T: type, ptr: [*]const T) usize {
     var count: usize = 0;
     while (ptr[count] != 0) : (count += 1) {}


### PR DESCRIPTION
Constant-time comparisons prevent timing attacks in sensitive crypto code. For example, Go's [poly1305 implementation](https://github.com/golang/crypto/blob/f83a4685e1528a5ebee78469d2a3262e2d505b0b/poly1305/poly1305.go#L30) uses a constant-time routine to verify MACs. Now Zig users can do the same with `mem.secureEql`. (But since this is easy to forget, it may be prudent to add a `verify` function to Zig's `Poly1305` struct, and elsewhere.)

Currently this function only works on integer types. I imagine it could be made to work with other types as well, but I'm very new to Zig so I didn't attempt to do so.