### PR TITLE
generated docs: move color to box-shadow CSS prop

### DIFF
--- a/lib/std/special/docs/index.html
+++ b/lib/std/special/docs/index.html
@@ -331,8 +331,7 @@
         border-bottom-color: #c6cbd1;
         border: solid 0.0625em;
         border-radius: 0.1875em;
-        box-shadow-color: #c6cbd1;
-        box-shadow: inset 0 -0.0625em 0;
+        box-shadow: inset 0 -0.0625em 0 #c6cbd1;
         cursor: default;
       }
       


### PR DESCRIPTION
Docs on `box-shadow` CSS prop: https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow

That property allows for a color to be specified on it, so moved the color that was specified on the invalid property onto it: https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#color
