### PR TITLE
DragonFlyBSD tidyup

### DIFF
--- a/lib/std/atomic/queue.zig
+++ b/lib/std/atomic/queue.zig
@@ -152,9 +152,6 @@ const puts_per_thread = 500;
 const put_thread_count = 3;
 
 test "std.atomic.Queue" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     var plenty_of_memory = try std.heap.direct_allocator.alloc(u8, 300 * 1024);
     defer std.heap.direct_allocator.free(plenty_of_memory);
 

--- a/lib/std/atomic/stack.zig
+++ b/lib/std/atomic/stack.zig
@@ -86,9 +86,6 @@ const puts_per_thread = 500;
 const put_thread_count = 3;
 
 test "std.atomic.stack" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     var plenty_of_memory = try std.heap.direct_allocator.alloc(u8, 300 * 1024);
     defer std.heap.direct_allocator.free(plenty_of_memory);
 

--- a/lib/std/event/channel.zig
+++ b/lib/std/event/channel.zig
@@ -263,9 +263,6 @@ pub fn Channel(comptime T: type) type {
 }
 
 test "std.event.Channel" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded) return error.SkipZigTest;
 

--- a/lib/std/event/group.zig
+++ b/lib/std/event/group.zig
@@ -81,9 +81,6 @@ pub fn Group(comptime ReturnType: type) type {
 }
 
 test "std.event.Group" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded) return error.SkipZigTest;
 

--- a/lib/std/event/lock.zig
+++ b/lib/std/event/lock.zig
@@ -117,9 +117,6 @@ pub const Lock = struct {
 };
 
 test "std.event.Lock" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     // TODO https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded) return error.SkipZigTest;
 

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -424,7 +424,7 @@ pub const Dir = struct {
                         self.end_index = @intCast(usize, rc);
                     }
                     const darwin_entry = @ptrCast(*align(1) os.dirent, &self.buf[self.index]);
-                    const next_index = self.index + darwin_entry.d_reclen;
+                    const next_index = self.index + darwin_entry.reclen();
                     self.index = next_index;
 
                     const name = @ptrCast([*]u8, &darwin_entry.d_name)[0..darwin_entry.d_namlen];
@@ -473,7 +473,7 @@ pub const Dir = struct {
                         self.end_index = @intCast(usize, rc);
                     }
                     const freebsd_entry = @ptrCast(*align(1) os.dirent, &self.buf[self.index]);
-                    const next_index = self.index + freebsd_entry.d_reclen;
+                    const next_index = self.index + freebsd_entry.reclen();
                     self.index = next_index;
 
                     const name = @ptrCast([*]u8, &freebsd_entry.d_name)[0..freebsd_entry.d_namlen];
@@ -529,7 +529,7 @@ pub const Dir = struct {
                         self.end_index = rc;
                     }
                     const linux_entry = @ptrCast(*align(1) os.dirent64, &self.buf[self.index]);
-                    const next_index = self.index + linux_entry.d_reclen;
+                    const next_index = self.index + linux_entry.reclen();
                     self.index = next_index;
 
                     const name = mem.toSlice(u8, @ptrCast([*]u8, &linux_entry.d_name));

--- a/lib/std/mutex.zig
+++ b/lib/std/mutex.zig
@@ -130,9 +130,6 @@ const TestContext = struct {
 };
 
 test "std.Mutex" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     var plenty_of_memory = try std.heap.direct_allocator.alloc(u8, 300 * 1024);
     defer std.heap.direct_allocator.free(plenty_of_memory);
 

--- a/lib/std/os/bits/darwin.zig
+++ b/lib/std/os/bits/darwin.zig
@@ -128,7 +128,7 @@ pub const dirent = extern struct {
     d_type: u8,
     d_name: u8, // field address is address of first byte of name
 
-    pub fn reclen(self: dirent) usize {
+    pub fn reclen(self: dirent) u16 {
         return self.d_reclen;
     }
 };

--- a/lib/std/os/bits/dragonfly.zig
+++ b/lib/std/os/bits/dragonfly.zig
@@ -314,8 +314,8 @@ pub const dirent = extern struct {
     d_unused2: u32,
     d_name: [256]u8,
 
-    pub fn reclen(self: dirent) usize {
-        return (@byteOffsetOf(dirent, "d_name") + self.d_namlen + 1 + 7) & ~usize(7);
+    pub fn reclen(self: dirent) u16 {
+        return (@byteOffsetOf(dirent, "d_name") + self.d_namlen + 1 + 7) & ~u16(7);
     }
 };
 

--- a/lib/std/os/bits/freebsd.zig
+++ b/lib/std/os/bits/freebsd.zig
@@ -133,7 +133,7 @@ pub const dirent = extern struct {
     d_pad1: u16,
     d_name: [256]u8,
 
-    pub fn reclen(self: dirent) usize {
+    pub fn reclen(self: dirent) u16 {
         return self.d_reclen;
     }
 };

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -988,7 +988,7 @@ pub const dirent64 = extern struct {
     d_type: u8,
     d_name: u8, // field address is the address of first byte of name https://github.com/ziglang/zig/issues/173
 
-    pub fn reclen(self: dirent) usize {
+    pub fn reclen(self: dirent) u16 {
         return self.d_reclen;
     }
 };

--- a/lib/std/os/bits/netbsd.zig
+++ b/lib/std/os/bits/netbsd.zig
@@ -129,7 +129,7 @@ pub const dirent = extern struct {
     d_off: i64,
     d_name: [512]u8,
 
-    pub fn reclen(self: dirent) usize {
+    pub fn reclen(self: dirent) u16 {
         return self.d_reclen;
     }
 };

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -16,9 +16,6 @@ const AtomicRmwOp = builtin.AtomicRmwOp;
 const AtomicOrder = builtin.AtomicOrder;
 
 test "makePath, put some files in it, deleteTree" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     try fs.makePath(a, "os_test_tmp" ++ fs.path.sep_str ++ "b" ++ fs.path.sep_str ++ "c");
     try io.writeFile("os_test_tmp" ++ fs.path.sep_str ++ "b" ++ fs.path.sep_str ++ "c" ++ fs.path.sep_str ++ "file.txt", "nonsense");
     try io.writeFile("os_test_tmp" ++ fs.path.sep_str ++ "b" ++ fs.path.sep_str ++ "file2.txt", "blah");
@@ -31,9 +28,6 @@ test "makePath, put some files in it, deleteTree" {
 }
 
 test "access file" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     try fs.makePath(a, "os_test_tmp");
     if (File.access("os_test_tmp" ++ fs.path.sep_str ++ "file.txt")) |ok| {
         @panic("expected error");
@@ -101,9 +95,6 @@ test "cpu count" {
 }
 
 test "AtomicFile" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     var buffer: [1024]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(buffer[0..]).allocator;
     const test_out_file = "tmp_atomic_file_test_dest.txt";
@@ -124,9 +115,6 @@ test "AtomicFile" {
 }
 
 test "thread local storage" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     if (builtin.single_threaded) return error.SkipZigTest;
     const thread1 = try Thread.spawn({}, testTls);
     const thread2 = try Thread.spawn({}, testTls);

--- a/lib/std/statically_initialized_mutex.zig
+++ b/lib/std/statically_initialized_mutex.zig
@@ -61,9 +61,6 @@ pub const StaticallyInitializedMutex = switch (builtin.os) {
 };
 
 test "std.StaticallyInitializedMutex" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
-
     const TestContext = struct {
         data: i128,
 


### PR DESCRIPTION
- Lots of past errors no-longer apply

- Makes use of the struct dirent change, also change return types to u16??