### PR TITLE
Add error when too few arguments are provided to std.fmt

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -167,6 +167,10 @@ pub fn format(
                 '}' => {
                     const arg_to_print = comptime nextArg(&used_pos_args, maybe_pos_arg, &next_arg);
 
+                    if (arg_to_print >= args.len) {
+                        @compileError("Too few arguments");
+                    }
+
                     try formatType(
                         args[arg_to_print],
                         fmt[0..0],


### PR DESCRIPTION
Fixes #3349  
This is a simpler version of #3480