### PR TITLE
Vector element access

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2575,6 +2575,7 @@ enum IrInstructionId {
     IrInstructionIdResume,
     IrInstructionIdSpillBegin,
     IrInstructionIdSpillEnd,
+    IrInstructionIdVectorExtractElem,
 };
 
 struct IrInstruction {
@@ -3900,6 +3901,13 @@ struct IrInstructionSpillEnd {
     IrInstruction base;
 
     IrInstructionSpillBegin *begin;
+};
+
+struct IrInstructionVectorExtractElem {
+    IrInstruction base;
+
+    IrInstruction *vector;
+    IrInstruction *index;
 };
 
 enum ResultLocId {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2426,6 +2426,7 @@ enum IrInstructionId {
     IrInstructionIdLoadPtr,
     IrInstructionIdLoadPtrGen,
     IrInstructionIdStorePtr,
+    IrInstructionIdVectorStoreElem,
     IrInstructionIdFieldPtr,
     IrInstructionIdStructFieldPtr,
     IrInstructionIdUnionFieldPtr,
@@ -2767,6 +2768,14 @@ struct IrInstructionStorePtr {
 
     bool allow_write_through_const;
     IrInstruction *ptr;
+    IrInstruction *value;
+};
+
+struct IrInstructionVectorStoreElem {
+    IrInstruction base;
+
+    IrInstruction *vector_ptr;
+    IrInstruction *index;
     IrInstruction *value;
 };
 

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1183,13 +1183,22 @@ struct FnTypeId {
 uint32_t fn_type_id_hash(FnTypeId*);
 bool fn_type_id_eql(FnTypeId *a, FnTypeId *b);
 
+static const uint32_t VECTOR_INDEX_NONE = UINT32_MAX;
+static const uint32_t VECTOR_INDEX_RUNTIME = UINT32_MAX - 1;
+
 struct ZigTypePointer {
     ZigType *child_type;
     ZigType *slice_parent;
+
     PtrLen ptr_len;
     uint32_t explicit_alignment; // 0 means use ABI alignment
+
     uint32_t bit_offset_in_host;
-    uint32_t host_int_bytes; // size of host integer. 0 means no host integer; this field is aligned
+    // size of host integer. 0 means no host integer; this field is aligned
+    // when vector_index != VECTOR_INDEX_NONE this is the len of the containing vector
+    uint32_t host_int_bytes;
+
+    uint32_t vector_index; // see the VECTOR_INDEX_* constants
     bool is_const;
     bool is_volatile;
     bool allow_zero;
@@ -1732,8 +1741,11 @@ struct TypeId {
             ZigType *child_type;
             PtrLen ptr_len;
             uint32_t alignment;
+
             uint32_t bit_offset_in_host;
             uint32_t host_int_bytes;
+
+            uint32_t vector_index;
             bool is_const;
             bool is_volatile;
             bool allow_zero;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -480,9 +480,10 @@ ZigType *get_fn_frame_type(CodeGen *g, ZigFn *fn) {
     return entry;
 }
 
-ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type, bool is_const,
+ZigType *get_pointer_to_type_extra2(CodeGen *g, ZigType *child_type, bool is_const,
         bool is_volatile, PtrLen ptr_len, uint32_t byte_alignment,
-        uint32_t bit_offset_in_host, uint32_t host_int_bytes, bool allow_zero)
+        uint32_t bit_offset_in_host, uint32_t host_int_bytes, bool allow_zero,
+        uint32_t vector_index)
 {
     assert(ptr_len != PtrLenC || allow_zero);
     assert(!type_is_invalid(child_type));
@@ -494,7 +495,7 @@ ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type, bool is_cons
             byte_alignment = 0;
     }
 
-    if (host_int_bytes != 0) {
+    if (host_int_bytes != 0 && vector_index == VECTOR_INDEX_NONE) {
         uint32_t child_type_bits = type_size_bits(g, child_type);
         if (host_int_bytes * 8 == child_type_bits) {
             assert(bit_offset_in_host == 0);
@@ -504,7 +505,9 @@ ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type, bool is_cons
 
     TypeId type_id = {};
     ZigType **parent_pointer = nullptr;
-    if (host_int_bytes != 0 || is_volatile || byte_alignment != 0 || ptr_len != PtrLenSingle || allow_zero) {
+    if (host_int_bytes != 0 || is_volatile || byte_alignment != 0 || ptr_len != PtrLenSingle ||
+        allow_zero || vector_index != VECTOR_INDEX_NONE)
+    {
         type_id.id = ZigTypeIdPointer;
         type_id.data.pointer.child_type = child_type;
         type_id.data.pointer.is_const = is_const;
@@ -514,6 +517,7 @@ ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type, bool is_cons
         type_id.data.pointer.host_int_bytes = host_int_bytes;
         type_id.data.pointer.ptr_len = ptr_len;
         type_id.data.pointer.allow_zero = allow_zero;
+        type_id.data.pointer.vector_index = vector_index;
 
         auto existing_entry = g->type_table.maybe_get(type_id);
         if (existing_entry)
@@ -540,19 +544,36 @@ ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type, bool is_cons
         allow_zero_str = allow_zero ? "allowzero " : "";
     }
     buf_resize(&entry->name, 0);
-    if (host_int_bytes == 0 && byte_alignment == 0) {
+    if (host_int_bytes == 0 && byte_alignment == 0 && vector_index == VECTOR_INDEX_NONE) {
         buf_appendf(&entry->name, "%s%s%s%s%s",
                 star_str, const_str, volatile_str, allow_zero_str, buf_ptr(&child_type->name));
-    } else if (host_int_bytes == 0) {
+    } else if (host_int_bytes == 0 && vector_index == VECTOR_INDEX_NONE) {
         buf_appendf(&entry->name, "%salign(%" PRIu32 ") %s%s%s%s", star_str, byte_alignment,
                 const_str, volatile_str, allow_zero_str, buf_ptr(&child_type->name));
     } else if (byte_alignment == 0) {
-        buf_appendf(&entry->name, "%salign(:%" PRIu32 ":%" PRIu32 ") %s%s%s%s", star_str,
-                bit_offset_in_host, host_int_bytes, const_str, volatile_str, allow_zero_str,
+        assert(vector_index == VECTOR_INDEX_NONE);
+        buf_appendf(&entry->name, "%salign(:%" PRIu32 ":%" PRIu32 ":%" PRIu32 ") %s%s%s%s",
+                star_str,
+                bit_offset_in_host, host_int_bytes, vector_index,
+                const_str, volatile_str, allow_zero_str,
+                buf_ptr(&child_type->name));
+    } else if (vector_index == VECTOR_INDEX_NONE) {
+        buf_appendf(&entry->name, "%salign(%" PRIu32 ":%" PRIu32 ":%" PRIu32 ") %s%s%s%s",
+                star_str, byte_alignment,
+                bit_offset_in_host, host_int_bytes,
+                const_str, volatile_str, allow_zero_str,
+                buf_ptr(&child_type->name));
+    } else if (vector_index == VECTOR_INDEX_RUNTIME) {
+        buf_appendf(&entry->name, "%salign(%" PRIu32 ":%" PRIu32 ":%" PRIu32 ":?) %s%s%s%s",
+                star_str, byte_alignment,
+                bit_offset_in_host, host_int_bytes,
+                const_str, volatile_str, allow_zero_str,
                 buf_ptr(&child_type->name));
     } else {
-        buf_appendf(&entry->name, "%salign(%" PRIu32 ":%" PRIu32 ":%" PRIu32 ") %s%s%s%s", star_str, byte_alignment,
-                bit_offset_in_host, host_int_bytes, const_str, volatile_str, allow_zero_str,
+        buf_appendf(&entry->name, "%salign(%" PRIu32 ":%" PRIu32 ":%" PRIu32 ":%" PRIu32 ") %s%s%s%s",
+                star_str, byte_alignment,
+                bit_offset_in_host, host_int_bytes, vector_index,
+                const_str, volatile_str, allow_zero_str,
                 buf_ptr(&child_type->name));
     }
 
@@ -581,6 +602,7 @@ ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type, bool is_cons
     entry->data.pointer.bit_offset_in_host = bit_offset_in_host;
     entry->data.pointer.host_int_bytes = host_int_bytes;
     entry->data.pointer.allow_zero = allow_zero;
+    entry->data.pointer.vector_index = vector_index;
 
     if (parent_pointer) {
         *parent_pointer = entry;
@@ -590,8 +612,17 @@ ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type, bool is_cons
     return entry;
 }
 
+ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type, bool is_const,
+        bool is_volatile, PtrLen ptr_len, uint32_t byte_alignment,
+        uint32_t bit_offset_in_host, uint32_t host_int_bytes, bool allow_zero)
+{
+    return get_pointer_to_type_extra2(g, child_type, is_const, is_volatile, ptr_len,
+            byte_alignment, bit_offset_in_host, host_int_bytes, allow_zero, VECTOR_INDEX_NONE);
+}
+
 ZigType *get_pointer_to_type(CodeGen *g, ZigType *child_type, bool is_const) {
-    return get_pointer_to_type_extra(g, child_type, is_const, false, PtrLenSingle, 0, 0, 0, false);
+    return get_pointer_to_type_extra2(g, child_type, is_const, false, PtrLenSingle, 0, 0, 0, false,
+            VECTOR_INDEX_NONE);
 }
 
 ZigType *get_optional_type(CodeGen *g, ZigType *child_type) {
@@ -6901,6 +6932,7 @@ uint32_t type_id_hash(TypeId x) {
                 (x.data.pointer.allow_zero ? (uint32_t)3324284834 : (uint32_t)3584904923) +
                 (((uint32_t)x.data.pointer.alignment) ^ (uint32_t)0x777fbe0e) +
                 (((uint32_t)x.data.pointer.bit_offset_in_host) ^ (uint32_t)2639019452) +
+                (((uint32_t)x.data.pointer.vector_index) ^ (uint32_t)0x19199716) +
                 (((uint32_t)x.data.pointer.host_int_bytes) ^ (uint32_t)529908881);
         case ZigTypeIdArray:
             return hash_ptr(x.data.array.child_type) +
@@ -6953,6 +6985,7 @@ bool type_id_eql(TypeId a, TypeId b) {
                 a.data.pointer.allow_zero == b.data.pointer.allow_zero &&
                 a.data.pointer.alignment == b.data.pointer.alignment &&
                 a.data.pointer.bit_offset_in_host == b.data.pointer.bit_offset_in_host &&
+                a.data.pointer.vector_index == b.data.pointer.vector_index &&
                 a.data.pointer.host_int_bytes == b.data.pointer.host_int_bytes;
         case ZigTypeIdArray:
             return a.data.array.child_type == b.data.array.child_type &&
@@ -8257,11 +8290,21 @@ static void resolve_llvm_types_pointer(CodeGen *g, ZigType *type, ResolveStatus 
 
     if (type->data.pointer.is_const || type->data.pointer.is_volatile ||
         type->data.pointer.explicit_alignment != 0 || type->data.pointer.ptr_len != PtrLenSingle ||
-        type->data.pointer.bit_offset_in_host != 0 || type->data.pointer.allow_zero)
+        type->data.pointer.bit_offset_in_host != 0 || type->data.pointer.allow_zero ||
+        type->data.pointer.vector_index != VECTOR_INDEX_NONE)
     {
         assertNoError(type_resolve(g, elem_type, ResolveStatusLLVMFwdDecl));
-        ZigType *peer_type = get_pointer_to_type_extra(g, elem_type, false, false,
-                PtrLenSingle, 0, 0, type->data.pointer.host_int_bytes, false);
+        ZigType *peer_type;
+        if (type->data.pointer.vector_index == VECTOR_INDEX_NONE) {
+            peer_type = get_pointer_to_type_extra2(g, elem_type, false, false,
+                PtrLenSingle, 0, 0, type->data.pointer.host_int_bytes, false,
+                VECTOR_INDEX_NONE);
+        } else {
+            uint32_t host_vec_len = type->data.pointer.host_int_bytes;
+            ZigType *host_vec_type = get_vector_type(g, host_vec_len, elem_type);
+            peer_type = get_pointer_to_type_extra2(g, host_vec_type, false, false,
+                PtrLenSingle, 0, 0, 0, false, VECTOR_INDEX_NONE);
+        }
         type->llvm_type = get_llvm_type(g, peer_type);
         type->llvm_di_type = get_llvm_di_type(g, peer_type);
         assertNoError(type_resolve(g, elem_type, wanted_resolve_status));

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -17,10 +17,14 @@ ErrorMsg *add_error_note(CodeGen *g, ErrorMsg *parent_msg, const AstNode *node, 
 ZigType *new_type_table_entry(ZigTypeId id);
 ZigType *get_fn_frame_type(CodeGen *g, ZigFn *fn);
 ZigType *get_pointer_to_type(CodeGen *g, ZigType *child_type, bool is_const);
-ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type, bool is_const,
-        bool is_volatile, PtrLen ptr_len,
+ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type,
+        bool is_const, bool is_volatile, PtrLen ptr_len,
         uint32_t byte_alignment, uint32_t bit_offset, uint32_t unaligned_bit_count,
         bool allow_zero);
+ZigType *get_pointer_to_type_extra2(CodeGen *g, ZigType *child_type,
+        bool is_const, bool is_volatile, PtrLen ptr_len,
+        uint32_t byte_alignment, uint32_t bit_offset, uint32_t unaligned_bit_count,
+        bool allow_zero, uint32_t vector_index);
 uint64_t type_size(CodeGen *g, ZigType *type_entry);
 uint64_t type_size_bits(CodeGen *g, ZigType *type_entry);
 ZigType *get_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6002,6 +6002,14 @@ static LLVMValueRef ir_render_spill_end(CodeGen *g, IrExecutable *executable, Ir
     zig_unreachable();
 }
 
+static LLVMValueRef ir_render_vector_extract_elem(CodeGen *g, IrExecutable *executable,
+        IrInstructionVectorExtractElem *instruction)
+{
+    LLVMValueRef vector = ir_llvm_value(g, instruction->vector);
+    LLVMValueRef index = ir_llvm_value(g, instruction->index);
+    return LLVMBuildExtractElement(g->builder, vector, index, "");
+}
+
 static void set_debug_location(CodeGen *g, IrInstruction *instruction) {
     AstNode *source_node = instruction->source_node;
     Scope *scope = instruction->scope;
@@ -6262,6 +6270,8 @@ static LLVMValueRef ir_render_instruction(CodeGen *g, IrExecutable *executable, 
             return ir_render_shuffle_vector(g, executable, (IrInstructionShuffleVector *) instruction);
         case IrInstructionIdSplatGen:
             return ir_render_splat(g, executable, (IrInstructionSplatGen *) instruction);
+        case IrInstructionIdVectorExtractElem:
+            return ir_render_vector_extract_elem(g, executable, (IrInstructionVectorExtractElem *) instruction);
     }
     zig_unreachable();
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3644,6 +3644,19 @@ static LLVMValueRef ir_render_store_ptr(CodeGen *g, IrExecutable *executable, Ir
     return nullptr;
 }
 
+static LLVMValueRef ir_render_vector_store_elem(CodeGen *g, IrExecutable *executable,
+        IrInstructionVectorStoreElem *instruction)
+{
+    LLVMValueRef vector_ptr = ir_llvm_value(g, instruction->vector_ptr);
+    LLVMValueRef index = ir_llvm_value(g, instruction->index);
+    LLVMValueRef value = ir_llvm_value(g, instruction->value);
+
+    LLVMValueRef loaded_vector = gen_load(g, vector_ptr, instruction->vector_ptr->value.type, "");
+    LLVMValueRef modified_vector = LLVMBuildInsertElement(g->builder, loaded_vector, value, index, "");
+    gen_store(g, modified_vector, vector_ptr, instruction->vector_ptr->value.type);
+    return nullptr;
+}
+
 static LLVMValueRef ir_render_var_ptr(CodeGen *g, IrExecutable *executable, IrInstructionVarPtr *instruction) {
     if (instruction->base.value.special != ConstValSpecialRuntime)
         return ir_llvm_value(g, &instruction->base);
@@ -6130,6 +6143,8 @@ static LLVMValueRef ir_render_instruction(CodeGen *g, IrExecutable *executable, 
             return ir_render_load_ptr(g, executable, (IrInstructionLoadPtrGen *)instruction);
         case IrInstructionIdStorePtr:
             return ir_render_store_ptr(g, executable, (IrInstructionStorePtr *)instruction);
+        case IrInstructionIdVectorStoreElem:
+            return ir_render_vector_store_elem(g, executable, (IrInstructionVectorStoreElem *)instruction);
         case IrInstructionIdVarPtr:
             return ir_render_var_ptr(g, executable, (IrInstructionVarPtr *)instruction);
         case IrInstructionIdReturnPtr:

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -17742,7 +17742,7 @@ static IrInstruction *ir_analyze_instruction_elem_ptr(IrAnalyze *ira, IrInstruct
                             zig_panic("TODO elem ptr on a slice has a null pointer");
                     }
                     return result;
-                } else if (array_type->id == ZigTypeIdArray) {
+                } else if (array_type->id == ZigTypeIdArray || array_type->id == ZigTypeIdVector) {
                     IrInstruction *result;
                     if (orig_array_ptr_val->data.x_ptr.mut == ConstPtrMutInfer) {
                         result = ir_build_elem_ptr(&ira->new_irb, elem_ptr_instruction->base.scope,

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -491,6 +491,10 @@ static constexpr IrInstructionId ir_instruction_id(IrInstructionStorePtr *) {
     return IrInstructionIdStorePtr;
 }
 
+static constexpr IrInstructionId ir_instruction_id(IrInstructionVectorStoreElem *) {
+    return IrInstructionIdVectorStoreElem;
+}
+
 static constexpr IrInstructionId ir_instruction_id(IrInstructionFieldPtr *) {
     return IrInstructionIdFieldPtr;
 }
@@ -1629,6 +1633,23 @@ static IrInstructionStorePtr *ir_build_store_ptr(IrBuilder *irb, Scope *scope, A
     ir_ref_instruction(value, irb->current_basic_block);
 
     return instruction;
+}
+
+static IrInstruction *ir_build_vector_store_elem(IrAnalyze *ira, IrInstruction *source_instruction,
+        IrInstruction *vector_ptr, IrInstruction *index, IrInstruction *value)
+{
+    IrInstructionVectorStoreElem *inst = ir_build_instruction<IrInstructionVectorStoreElem>(
+            &ira->new_irb, source_instruction->scope, source_instruction->source_node);
+    inst->base.value.type = ira->codegen->builtin_types.entry_void;
+    inst->vector_ptr = vector_ptr;
+    inst->index = index;
+    inst->value = value;
+
+    ir_ref_instruction(vector_ptr, ira->new_irb.current_basic_block);
+    ir_ref_instruction(index, ira->new_irb.current_basic_block);
+    ir_ref_instruction(value, ira->new_irb.current_basic_block);
+
+    return &inst->base;
 }
 
 static IrInstruction *ir_build_var_decl_src(IrBuilder *irb, Scope *scope, AstNode *source_node,
@@ -16123,6 +16144,24 @@ static IrInstruction *ir_analyze_store_ptr(IrAnalyze *ira, IrInstruction *source
         mark_comptime_value_escape(ira, source_instr, &value->value);
     }
 
+    // If this is a store to a pointer with a runtime-known vector index,
+    // we have to figure out the IrInstruction which represents the index and
+    // emit a IrInstructionVectorStoreElem, or emit a compile error
+    // explaining why it is impossible for this store to work. Which is that
+    // the pointer address is of the vector; without the element index being known
+    // we cannot properly perform the insertion.
+    if (ptr->value.type->data.pointer.vector_index == VECTOR_INDEX_RUNTIME) {
+        if (ptr->id == IrInstructionIdElemPtr) {
+            IrInstructionElemPtr *elem_ptr = (IrInstructionElemPtr *)ptr;
+            return ir_build_vector_store_elem(ira, source_instr, elem_ptr->array_ptr,
+                    elem_ptr->elem_index, value);
+        }
+        ir_add_error(ira, ptr,
+            buf_sprintf("unable to determine vector element index of type '%s'",
+                buf_ptr(&ptr->value.type->name)));
+        return ira->codegen->invalid_instruction;
+    }
+
     IrInstructionStorePtr *store_ptr = ir_build_store_ptr(&ira->new_irb, source_instr->scope,
             source_instr->source_node, ptr, value);
     return &store_ptr->base;
@@ -26050,6 +26089,7 @@ static IrInstruction *ir_analyze_instruction_base(IrAnalyze *ira, IrInstruction 
         case IrInstructionIdAwaitGen:
         case IrInstructionIdSplatGen:
         case IrInstructionIdVectorExtractElem:
+        case IrInstructionIdVectorStoreElem:
             zig_unreachable();
 
         case IrInstructionIdReturn:
@@ -26433,6 +26473,7 @@ bool ir_has_side_effects(IrInstruction *instruction) {
         case IrInstructionIdDeclVarSrc:
         case IrInstructionIdDeclVarGen:
         case IrInstructionIdStorePtr:
+        case IrInstructionIdVectorStoreElem:
         case IrInstructionIdCallSrc:
         case IrInstructionIdCallGen:
         case IrInstructionIdReturn:

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -12905,18 +12905,18 @@ static IrInstruction *ir_get_deref(IrAnalyze *ira, IrInstruction *source_instruc
         ResultLoc *result_loc)
 {
     Error err;
-    ZigType *type_entry = ptr->value.type;
-    if (type_is_invalid(type_entry))
+    ZigType *ptr_type = ptr->value.type;
+    if (type_is_invalid(ptr_type))
         return ira->codegen->invalid_instruction;
 
-    if (type_entry->id != ZigTypeIdPointer) {
+    if (ptr_type->id != ZigTypeIdPointer) {
         ir_add_error_node(ira, source_instruction->source_node,
             buf_sprintf("attempt to dereference non-pointer type '%s'",
-                buf_ptr(&type_entry->name)));
+                buf_ptr(&ptr_type->name)));
         return ira->codegen->invalid_instruction;
     }
 
-    ZigType *child_type = type_entry->data.pointer.child_type;
+    ZigType *child_type = ptr_type->data.pointer.child_type;
     // if the child type has one possible value, the deref is comptime
     switch (type_has_one_possible_value(ira->codegen, child_type)) {
         case OnePossibleValueInvalid:
@@ -12946,14 +12946,29 @@ static IrInstruction *ir_get_deref(IrAnalyze *ira, IrInstruction *source_instruc
             }
         }
     }
+
     // if the instruction is a const ref instruction we can skip it
     if (ptr->id == IrInstructionIdRef) {
         IrInstructionRef *ref_inst = reinterpret_cast<IrInstructionRef *>(ptr);
         return ref_inst->value;
     }
 
+    // If the instruction is a element pointer instruction to a vector, we emit
+    // vector element extract instruction rather than load pointer. If the
+    // pointer type has non-VECTOR_INDEX_RUNTIME value, it would have been
+    // possible to implement this in the codegen for IrInstructionLoadPtrGen.
+    // However if it has VECTOR_INDEX_RUNTIME then we must emit a compile error
+    // if the vector index cannot be determined right here, right now, because
+    // the type information does not contain enough information to actually
+    // perform a dereference.
+    if (ptr_type->data.pointer.vector_index == VECTOR_INDEX_RUNTIME) {
+        ir_add_error(ira, ptr,
+            buf_sprintf("unable to determine element index in order to dereference vector pointer"));
+        return ira->codegen->invalid_instruction;
+    }
+
     IrInstruction *result_loc_inst;
-    if (type_entry->data.pointer.host_int_bytes != 0 && handle_is_ptr(child_type)) {
+    if (ptr_type->data.pointer.host_int_bytes != 0 && handle_is_ptr(child_type)) {
         if (result_loc == nullptr) result_loc = no_result_loc();
         result_loc_inst = ir_resolve_result(ira, source_instruction, result_loc, child_type, nullptr,
                 true, false, true);
@@ -17486,6 +17501,9 @@ static IrInstruction *ir_analyze_instruction_elem_ptr(IrAnalyze *ira, IrInstruct
             return ir_get_const_ptr(ira, &elem_ptr_instruction->base, &ira->codegen->const_void_val,
                     ira->codegen->builtin_types.entry_void, ConstPtrMutComptimeConst, is_const, is_volatile, 0);
         }
+    } else if (array_type->id == ZigTypeIdVector) {
+        // This depends on whether the element index is comptime, so it is computed later.
+        return_type = nullptr;
     } else {
         ir_add_error_node(ira, elem_ptr_instruction->base.source_node,
                 buf_sprintf("array access of non-array type '%s'", buf_ptr(&array_type->name)));
@@ -17510,8 +17528,14 @@ static IrInstruction *ir_analyze_instruction_elem_ptr(IrAnalyze *ira, IrInstruct
             }
             safety_check_on = false;
         }
-
-        if (return_type->data.pointer.explicit_alignment != 0) {
+        if (array_type->id == ZigTypeIdVector) {
+            ZigType *elem_type = array_type->data.vector.elem_type;
+            uint32_t host_vec_len = array_type->data.vector.len;
+            return_type = get_pointer_to_type_extra2(ira->codegen, elem_type,
+                ptr_type->data.pointer.is_const, ptr_type->data.pointer.is_volatile,
+                elem_ptr_instruction->ptr_len,
+                get_ptr_align(ira->codegen, ptr_type), 0, host_vec_len, false, (uint32_t)index);
+        } else if (return_type->data.pointer.explicit_alignment != 0) {
             // figure out the largest alignment possible
 
             if ((err = type_resolve(ira->codegen, return_type->data.pointer.child_type, ResolveStatusSizeKnown)))
@@ -17740,6 +17764,14 @@ static IrInstruction *ir_analyze_instruction_elem_ptr(IrAnalyze *ira, IrInstruct
                 }
             }
         }
+    } else if (array_type->id == ZigTypeIdVector) {
+        // runtime known element index
+        ZigType *elem_type = array_type->data.vector.elem_type;
+        uint32_t host_vec_len = array_type->data.vector.len;
+        return_type = get_pointer_to_type_extra2(ira->codegen, elem_type,
+            ptr_type->data.pointer.is_const, ptr_type->data.pointer.is_volatile,
+            elem_ptr_instruction->ptr_len,
+            get_ptr_align(ira->codegen, ptr_type), 0, host_vec_len, false, VECTOR_INDEX_RUNTIME);
     } else {
         // runtime known element index
         switch (type_requires_comptime(ira->codegen, return_type)) {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -78,6 +78,8 @@ const char* ir_instruction_type_str(IrInstructionId id) {
             return "LoadPtrGen";
         case IrInstructionIdStorePtr:
             return "StorePtr";
+        case IrInstructionIdVectorStoreElem:
+            return "VectorStoreElem";
         case IrInstructionIdFieldPtr:
             return "FieldPtr";
         case IrInstructionIdStructFieldPtr:
@@ -787,6 +789,15 @@ static void ir_print_store_ptr(IrPrint *irp, IrInstructionStorePtr *instruction)
     fprintf(irp->f, "*");
     ir_print_var_instruction(irp, instruction->ptr);
     fprintf(irp->f, " = ");
+    ir_print_other_instruction(irp, instruction->value);
+}
+
+static void ir_print_vector_store_elem(IrPrint *irp, IrInstructionVectorStoreElem *instruction) {
+    fprintf(irp->f, "vector_ptr=");
+    ir_print_var_instruction(irp, instruction->vector_ptr);
+    fprintf(irp->f, ",index=");
+    ir_print_var_instruction(irp, instruction->index);
+    fprintf(irp->f, ",value=");
     ir_print_other_instruction(irp, instruction->value);
 }
 
@@ -2046,6 +2057,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction, bool 
             break;
         case IrInstructionIdStorePtr:
             ir_print_store_ptr(irp, (IrInstructionStorePtr *)instruction);
+            break;
+        case IrInstructionIdVectorStoreElem:
+            ir_print_vector_store_elem(irp, (IrInstructionVectorStoreElem *)instruction);
             break;
         case IrInstructionIdTypeOf:
             ir_print_typeof(irp, (IrInstructionTypeOf *)instruction);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -370,6 +370,8 @@ const char* ir_instruction_type_str(IrInstructionId id) {
             return "SpillBegin";
         case IrInstructionIdSpillEnd:
             return "SpillEnd";
+        case IrInstructionIdVectorExtractElem:
+            return "VectorExtractElem";
     }
     zig_unreachable();
 }
@@ -1969,6 +1971,14 @@ static void ir_print_spill_end(IrPrint *irp, IrInstructionSpillEnd *instruction)
     fprintf(irp->f, ")");
 }
 
+static void ir_print_vector_extract_elem(IrPrint *irp, IrInstructionVectorExtractElem *instruction) {
+    fprintf(irp->f, "@vectorExtractElem(");
+    ir_print_other_instruction(irp, instruction->vector);
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->index);
+    fprintf(irp->f, ")");
+}
+
 static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction, bool trailing) {
     ir_print_prefix(irp, instruction, trailing);
     switch (instruction->id) {
@@ -2465,6 +2475,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction, bool 
             break;
         case IrInstructionIdSpillEnd:
             ir_print_spill_end(irp, (IrInstructionSpillEnd *)instruction);
+            break;
+        case IrInstructionIdVectorExtractElem:
+            ir_print_vector_extract_elem(irp, (IrInstructionVectorExtractElem *)instruction);
             break;
     }
     fprintf(irp->f, "\n");

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3,6 +3,22 @@ const builtin = @import("builtin");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "dereference vector pointer with unknown runtime index",
+        \\export fn entry() void {
+        \\    var v: @Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
+        \\
+        \\    var i: u32 = 0;
+        \\    var x = loadv(&v[i]);
+        \\}
+        \\
+        \\fn loadv(ptr: var) i32 {
+        \\    return ptr.*;
+        \\}
+    ,
+        "tmp.zig:9:12: error: unable to determine vector element index of type '*align(16:0:4:?) i32",
+    );
+
+    cases.add(
         "using an unknown len ptr type instead of array",
         \\const resolutions = [*][*]const u8{
         \\    c"[320 240  ]",

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3,7 +3,23 @@ const builtin = @import("builtin");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
-        "dereference vector pointer with unknown runtime index",
+        "store vector pointer with unknown runtime index",
+        \\export fn entry() void {
+        \\    var v: @Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
+        \\
+        \\    var i: u32 = 0;
+        \\    storev(&v[i], 42);
+        \\}
+        \\
+        \\fn storev(ptr: var, val: i32) void {
+        \\    ptr.* = val;
+        \\}
+    ,
+        "tmp.zig:9:8: error: unable to determine vector element index of type '*align(16:0:4:?) i32",
+    );
+
+    cases.add(
+        "load vector pointer with unknown runtime index",
         \\export fn entry() void {
         \\    var v: @Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
         \\

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -199,3 +199,20 @@ test "store vector elements via comptime index" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "load vector elements via runtime index" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(4, i32) = [_]i32{ 1, 2, 3, undefined };
+            var i: u32 = 0;
+            expect(v[i] == 1);
+            i += 1;
+            expect(v[i] == 2);
+            i += 1;
+            expect(v[i] == 3);
+        }
+    };
+
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -174,5 +174,5 @@ test "load vector elements via comptime index" {
     };
 
     S.doTheTest();
-    //comptime S.doTheTest();
+    comptime S.doTheTest();
 }

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -159,3 +159,20 @@ test "vector @splat" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "load vector elements via comptime index" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(4, i32) = [_]i32{ 1, 2, 3, undefined };
+            expect(v[0] == 1);
+            expect(v[1] == 2);
+            expect(loadv(&v[2]) == 3);
+        }
+        fn loadv(ptr: var) i32 {
+            return ptr.*;
+        }
+    };
+
+    S.doTheTest();
+    //comptime S.doTheTest();
+}

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -176,3 +176,26 @@ test "load vector elements via comptime index" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "store vector elements via comptime index" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
+
+            v[2] = 42;
+            expect(v[1] == 5);
+            v[3] = -364;
+            expect(v[2] == 42);
+            expect(-364 == v[3]);
+
+            storev(&v[0], 100);
+            expect(v[0] == 100);
+        }
+        fn storev(ptr: var, x: i32) void {
+            ptr.* = x;
+        }
+    };
+
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -216,3 +216,21 @@ test "load vector elements via runtime index" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "store vector elements via runtime index" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
+            var i: u32 = 2;
+            v[i] = 1;
+            expect(v[1] == 5);
+            expect(v[2] == 1);
+            i += 1;
+            v[i] = -364;
+            expect(-364 == v[3]);
+        }
+    };
+
+    S.doTheTest();
+    comptime S.doTheTest();
+}


### PR DESCRIPTION
This is my re-implementation of the vector element access from #2945.

I went through all this trouble, but then I realized that I had already considered this when I typed up https://github.com/ziglang/zig/issues/903#issuecomment-459508820:

> [ ] field access / pointer access / array access when the vector is of pointer type
> [ ] compile error for trying to get a pointer to a vector element

Compile error for trying to get a pointer to a vector element? But why? In this PR you can see it works just fine.

Because, my friends, vectors can be vectors of pointers, in which case `x[y]` should produce a *new vector with each pointer dereferenced*, not access a single element.

So this was a waste of time. Element access of vectors can be implemented either as builtin functions `@vectorElemLoad` and `@vectorElemStore`, or even in userland, by bitcasting a vector to and from an array. But `x[y]` syntax is reserved for when you have a vector of pointers.

cc @shawnl 
cc @dimenus 