### PR TITLE
stage1: add linux XDG Base Directory support

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 static Buf saved_compiler_id = BUF_INIT;
-static Buf saved_app_data_dir = BUF_INIT;
+static Buf saved_cache_dir = BUF_INIT;
 static Buf saved_stage1_path = BUF_INIT;
 static Buf saved_lib_dir = BUF_INIT;
 static Buf saved_special_dir = BUF_INIT;
@@ -21,11 +21,11 @@ Buf *get_stage1_cache_path(void) {
         return &saved_stage1_path;
     }
     Error err;
-    if ((err = os_get_app_data_dir(&saved_app_data_dir, "zig"))) {
-        fprintf(stderr, "Unable to get app data dir: %s\n", err_str(err));
+    if ((err = os_get_cache_dir(&saved_cache_dir, "zig"))) {
+        fprintf(stderr, "Unable to get cache dir: %s\n", err_str(err));
         exit(1);
     }
-    os_path_join(&saved_app_data_dir, buf_create_from_str("stage1"), &saved_stage1_path);
+    os_path_join(&saved_cache_dir, buf_create_from_str("stage1"), &saved_stage1_path);
     return &saved_stage1_path;
 }
 

--- a/src/os.hpp
+++ b/src/os.hpp
@@ -150,7 +150,7 @@ bool os_is_sep(uint8_t c);
 
 Error ATTRIBUTE_MUST_USE os_self_exe_path(Buf *out_path);
 
-Error ATTRIBUTE_MUST_USE os_get_app_data_dir(Buf *out_path, const char *appname);
+Error ATTRIBUTE_MUST_USE os_get_cache_dir(Buf *out_path, const char *appname);
 
 Error ATTRIBUTE_MUST_USE os_get_win32_ucrt_include_path(ZigWindowsSDK *sdk, Buf *output_buf);
 Error ATTRIBUTE_MUST_USE os_get_win32_ucrt_lib_path(ZigWindowsSDK *sdk, Buf *output_buf, ZigLLVM_ArchType platform_type);


### PR DESCRIPTION
- define zig global cache based on XDG spec:

```
    if env XDG_CACHE_HOME {
        "$XDG_CACHE_HOME/zig"
    } else {
        "$HOME/.cache/zig"
    }
```

- old definition "$HOME/.local/share/zig" is retired
- closes #3573