### PR TITLE
net: add bindUnixSocket

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -342,6 +342,7 @@ fn createUnixAddress(path: []const u8) !os.sockaddr_un {
     };
     if (path.len > sock_addr.path.len) return error.NameTooLong;
     std.mem.copy(u8, &sock_addr.path, path);
+    return sock_addr;
 }
 
 pub fn connectUnixSocket(path: []const u8) !fs.File {

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -340,7 +340,7 @@ pub fn connectUnixSocket(path: []const u8) !fs.File {
     mem.copy(u8, &sock_addr.path, path);
 
     const size = @intCast(u32, @sizeOf(os.sockaddr_un) - sock_addr.path.len + path.len);
-    try os.connect(sockfd, &sock_addr, size);
+    try os.connect(sockfd, @ptrCast(*os.sockaddr, &sock_addr), size);
 
     return fs.File.openHandle(sockfd);
 }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -335,7 +335,7 @@ fn createUnixSocket() !os.fd_t {
     );
 }
 
-fn createUnixAddress(path: []const u8) !os.sockaddr_un {
+pub fn createUnixAddress(path: []const u8) !os.sockaddr_un {
     var sock_addr = std.os.sockaddr_un{
         .family = std.os.AF_UNIX,
         .path = undefined,


### PR DESCRIPTION
- fix `connectUnixSocket` (missing ptr cast)
- add `bindUnixSocket`, `createUnixAddress`

I was planning on making a `UnixListener` with the same interface as `TcpListener`, but I was unsure about if it should be done (feedback on that would be welcome).