### PR TITLE
fix noreturn function that may return.

### DIFF
--- a/lib/std/special/c.zig
+++ b/lib/std/special/c.zig
@@ -81,9 +81,11 @@ pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn
     if (builtin.is_test) {
         @setCold(true);
         std.debug.panic("{}", msg);
-    } else {
-        unreachable;
     }
+    if (builtin.os != .freestanding) {
+        std.os.abort();
+    }
+    while (true) {}
 }
 
 export fn memset(dest: ?[*]u8, c: u8, n: usize) ?[*]u8 {


### PR DESCRIPTION
we do not want undefined behavior here in --release-fast
and --release-small modes