### PR TITLE
clean up sleep() implementation

### DIFF
--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -9,16 +9,9 @@ pub const epoch = @import("time/epoch.zig");
 
 /// Spurious wakeups are possible and no precision of timing is guaranteed.
 pub fn sleep(nanoseconds: u64) void {
-    if (builtin.os == .windows) {
-        const ns_per_ms = ns_per_s / ms_per_s;
-        const big_ms_from_ns = nanoseconds / ns_per_ms;
-        const ms = math.cast(os.windows.DWORD, big_ms_from_ns) catch math.maxInt(os.windows.DWORD);
-        os.windows.kernel32.Sleep(ms);
-        return;
-    }
-    const s = nanoseconds / ns_per_s;
-    const ns = nanoseconds % ns_per_s;
-    std.os.nanosleep(s, ns);
+    var sec: u64 = nanoseconds / ns_per_s;
+    var nsec: u64 = nanoseconds % ns_per_s;
+    std.os.nanosleep(sec, nsec);
 }
 
 /// Get the posix timestamp, UTC, in seconds


### PR DESCRIPTION
This gets os-specific code out of time.zig where it does not belong.
It also fixes a bug where nanosleep might be passed an
out of range nsec argument. (however I am pretty sure that was
unreachable code)