### PR TITLE
catch aliasing violations in memcpy() and std.mem.copy()

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7366,13 +7366,7 @@ fn add(a: i32, b: i32) i32 { return a + b; }
       </p>
       <p>
       This function is a low level intrinsic with no safety mechanisms. Most code
-      should not use this function, instead using something like this:
-      </p>
-      <pre>{#syntax#}for (source[0..byte_count]) |b, i| dest[i] = b;{#endsyntax#}</pre>
-      <p>
-      The optimizer is intelligent enough to turn the above snippet into a memcpy.
-      </p>
-      <p>There is also a standard library function for this:</p>
+      should not use this function, instead using the standard library function for this:</p>
       <pre>{#syntax#}const mem = @import("std").mem;
 mem.copy(u8, dest[0..byte_count], source[0..byte_count]);{#endsyntax#}</pre>
       {#header_close#}

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -112,7 +112,7 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             try self.ensureCapacity(self.len + 1);
             self.len += 1;
 
-            mem.copyBackwards(T, self.items[n + 1 .. self.len], self.items[n .. self.len - 1]);
+            mem.move(T, self.items[n + 1 .. self.len], self.items[n .. self.len - 1]);
             self.items[n] = item;
         }
 
@@ -122,8 +122,8 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             try self.ensureCapacity(self.len + items.len);
             self.len += items.len;
 
-            mem.copyBackwards(T, self.items[n + items.len .. self.len], self.items[n .. self.len - items.len]);
-            mem.copy(T, self.items[n .. n + items.len], items);
+            mem.move(T, self.items[n + items.len .. self.len], self.items[n .. self.len - items.len]);
+            mem.move(T, self.items[n .. n + items.len], items);
         }
 
         /// Extend the list by 1 element. Allocates more memory as

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -34,8 +34,7 @@ pub fn FixedSizeFifo(comptime T: type) type {
 
         pub fn realign(self: *Self) void {
             if (self.buf.len - self.head >= self.count) {
-                // this copy overlaps
-                mem.copy(T, self.buf[0..self.count], self.buf[self.head..][0..self.count]);
+                mem.move(T, self.buf[0..self.count], self.buf[self.head..][0..self.count]);
                 self.head = 0;
             } else {
                 var tmp: [mem.page_size / 2 / @sizeOf(T)]T = undefined;
@@ -44,8 +43,7 @@ pub fn FixedSizeFifo(comptime T: type) type {
                     const n = math.min(self.head, tmp.len);
                     const m = self.buf.len - n;
                     mem.copy(T, tmp[0..n], self.buf[0..n]);
-                    // this middle copy overlaps; the others here don't
-                    mem.copy(T, self.buf[0..m], self.buf[n..][0..m]);
+                    mem.move(T, self.buf[0..m], self.buf[n..][0..m]);
                     mem.copy(T, self.buf[m..], tmp[0..n]);
                     self.head -= n;
                 }

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -1060,8 +1060,8 @@ pub const Int = struct {
 
             // Shrink x, y such that the trailing zero limbs shared between are removed.
             if (ab_zero_limb_count != 0) {
-                std.mem.copy(Limb, x.limbs[0..], x.limbs[ab_zero_limb_count..]);
-                std.mem.copy(Limb, y.limbs[0..], y.limbs[ab_zero_limb_count..]);
+                std.mem.move(Limb, x.limbs[0..], x.limbs[ab_zero_limb_count..]);
+                std.mem.move(Limb, y.limbs[0..], y.limbs[ab_zero_limb_count..]);
                 x.metadata -= ab_zero_limb_count;
                 y.metadata -= ab_zero_limb_count;
             }


### PR DESCRIPTION
I ran some of the tests, but I suspect that there is some code that depends on the forward-copy behavior of the current std.mem.copy().