### PR TITLE
Update std.event types to use the global event loop

### DIFF
--- a/lib/std/event/future.zig
+++ b/lib/std/event/future.zig
@@ -3,7 +3,6 @@ const assert = std.debug.assert;
 const testing = std.testing;
 const builtin = @import("builtin");
 const Lock = std.event.Lock;
-const Loop = std.event.Loop;
 
 /// This is a value that starts out unavailable, until resolve() is called
 /// While it is unavailable, functions suspend when they try to get() it,
@@ -23,9 +22,9 @@ pub fn Future(comptime T: type) type {
         const Self = @This();
         const Queue = std.atomic.Queue(anyframe);
 
-        pub fn init(loop: *Loop) Self {
+        pub fn init() Self {
             return Self{
-                .lock = Lock.initLocked(loop),
+                .lock = Lock.initLocked(),
                 .available = 0,
                 .data = undefined,
             };
@@ -90,17 +89,11 @@ test "std.event.Future" {
     // TODO provide a way to run tests in evented I/O mode
     if (!std.io.is_async) return error.SkipZigTest;
 
-    var loop: Loop = undefined;
-    try loop.initMultiThreaded();
-    defer loop.deinit();
-
-    const handle = async testFuture(&loop);
-
-    loop.run();
+    const handle = async testFuture();
 }
 
-fn testFuture(loop: *Loop) void {
-    var future = Future(i32).init(loop);
+fn testFuture() void {
+    var future = Future(i32).init();
 
     var a = async waitOnFuture(&future);
     var b = async waitOnFuture(&future);

--- a/lib/std/event/locked.zig
+++ b/lib/std/event/locked.zig
@@ -1,6 +1,5 @@
 const std = @import("../std.zig");
 const Lock = std.event.Lock;
-const Loop = std.event.Loop;
 
 /// Thread-safe async/await lock that protects one piece of data.
 /// Functions which are waiting for the lock are suspended, and
@@ -21,9 +20,9 @@ pub fn Locked(comptime T: type) type {
             }
         };
 
-        pub fn init(loop: *Loop, data: T) Self {
+        pub fn init(data: T) Self {
             return Self{
-                .lock = Lock.init(loop),
+                .lock = Lock.init(),
                 .private_data = data,
             };
         }
@@ -35,7 +34,7 @@ pub fn Locked(comptime T: type) type {
         pub async fn acquire(self: *Self) HeldLock {
             return HeldLock{
                 // TODO guaranteed allocation elision
-                .held = await (async self.lock.acquire() catch unreachable),
+                .held = self.lock.acquire(),
                 .value = &self.private_data,
             };
         }

--- a/lib/std/event/rwlocked.zig
+++ b/lib/std/event/rwlocked.zig
@@ -1,6 +1,5 @@
 const std = @import("../std.zig");
 const RwLock = std.event.RwLock;
-const Loop = std.event.Loop;
 
 /// Thread-safe async/await RW lock that protects one piece of data.
 /// Functions which are waiting for the lock are suspended, and
@@ -30,9 +29,9 @@ pub fn RwLocked(comptime T: type) type {
             }
         };
 
-        pub fn init(loop: *Loop, data: T) Self {
+        pub fn init(data: T) Self {
             return Self{
-                .lock = RwLock.init(loop),
+                .lock = RwLock.init(),
                 .locked_data = data,
             };
         }
@@ -43,14 +42,14 @@ pub fn RwLocked(comptime T: type) type {
 
         pub async fn acquireRead(self: *Self) HeldReadLock {
             return HeldReadLock{
-                .held = await (async self.lock.acquireRead() catch unreachable),
+                .held = self.lock.acquireRead(),
                 .value = &self.locked_data,
             };
         }
 
         pub async fn acquireWrite(self: *Self) HeldWriteLock {
             return HeldWriteLock{
-                .held = await (async self.lock.acquireWrite() catch unreachable),
+                .held = self.lock.acquireWrite(),
                 .value = &self.locked_data,
             };
         }


### PR DESCRIPTION
Also removes use of the event loop's allocator in rwlock and group as a part of #3539