### PR TITLE
ci: bump ubuntu from 16.04 to 18.04

### DIFF
--- a/ci/azure/pipelines.yml
+++ b/ci/azure/pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     displayName: 'Build and test'
 - job: BuildLinux
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
 
   timeoutInMinutes: 360
 
@@ -53,7 +53,7 @@ jobs:
   strategy:
     maxParallel: 1
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   variables:
     version: $[ dependencies.BuildLinux.outputs['main.version'] ]
   steps:


### PR DESCRIPTION
18.04 is also an LTS version. There are plenty of reasons to stay up to date, but in particular: https://github.com/ziglang/zig/pull/3585#issuecomment-550050389