### PR TITLE
Improvements to std.fifo

### DIFF
--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -273,6 +273,20 @@ pub fn LinearFifo(
             }
         }
 
+        /// Write a single item to the fifo
+        pub fn writeItem(self: *Self, item: T) !void {
+            try self.ensureUnusedCapacity(1);
+
+            var tail = self.head + self.count;
+            if (powers_of_two) {
+                tail &= self.buf.len - 1;
+            } else {
+                tail %= self.buf.len;
+            }
+            self.buf[tail] = byte;
+            self.update(1);
+        }
+
         /// Appends the data in `src` to the fifo.
         /// Allocates more memory as necessary
         pub fn write(self: *Self, src: []const T) !void {

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -10,6 +10,8 @@ const assert = debug.assert;
 const testing = std.testing;
 
 pub fn FixedSizeFifo(comptime T: type) type {
+    const autoalign = false;
+
     return struct {
         allocator: *Allocator,
         buf: []T,
@@ -106,8 +108,6 @@ pub fn FixedSizeFifo(comptime T: type) type {
         pub fn readableSlice(self: Self, offset: usize) []const T {
             return self.readableSliceMut(offset);
         }
-
-        const autoalign = false;
 
         /// Discard first `count` bytes of readable data
         pub fn discard(self: *Self, count: usize) void {

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -193,7 +193,8 @@ pub fn FixedSizeFifo(comptime T: type) type {
             self.count += count;
         }
 
-        /// Appends the data in `src` to the fifo. You must
+        /// Appends the data in `src` to the fifo.
+        /// You must have ensured there is enough space.
         pub fn writeAssumeCapacity(self: *Self, src: []const T) void {
             assert(self.writableLength() >= src.len);
 

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -203,8 +203,8 @@ pub fn LinearFifo(
             return c;
         }
 
-        /// Read data from the fifo into `dst`, returns slice of bytes copied (subslice of `dst`)
-        pub fn read(self: *Self, dst: []T) []T {
+        /// Read data from the fifo into `dst`, returns number of bytes copied.
+        pub fn read(self: *Self, dst: []T) usize {
             var dst_left = dst;
 
             while (dst_left.len > 0) {
@@ -216,7 +216,7 @@ pub fn LinearFifo(
                 dst_left = dst_left[n..];
             }
 
-            return dst[0 .. dst.len - dst_left.len];
+            return dst.len - dst_left.len;
         }
 
         /// Returns number of bytes available in fifo
@@ -384,7 +384,7 @@ test "LinearFifo(u8, .Dynamic)" {
     {
         try fifo.unget("prependedstring");
         var result: [30]u8 = undefined;
-        testing.expectEqualSlices(u8, "prependedstringabcdefghij", fifo.read(&result));
+        testing.expectEqualSlices(u8, "prependedstringabcdefghij", result[0..fifo.read(&result)]);
     }
 
     fifo.shrink(0);
@@ -392,7 +392,7 @@ test "LinearFifo(u8, .Dynamic)" {
     {
         try fifo.print("{}, {}!", "Hello", "World");
         var result: [30]u8 = undefined;
-        testing.expectEqualSlices(u8, "Hello, World!", fifo.read(&result));
+        testing.expectEqualSlices(u8, "Hello, World!", result[0..fifo.read(&result)]);
         testing.expectEqual(@as(usize, 0), fifo.readableLength());
     }
 }

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -78,9 +78,8 @@ pub fn LinearFifo(
             },
         };
 
-        pub fn deinit(self: *Self) void {
+        pub fn deinit(self: Self) void {
             if (buffer_type == .Dynamic) self.allocator.free(self.buf);
-            self.* = undefined;
         }
 
         pub fn realign(self: *Self) void {

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -9,7 +9,7 @@ const debug = std.debug;
 const assert = debug.assert;
 const testing = std.testing;
 
-pub const FifoBufferType = union(enum) {
+pub const LinearFifoBufferType = union(enum) {
     /// The buffer is internal to the fifo; it is of the specified size.
     Static: usize,
 
@@ -20,9 +20,9 @@ pub const FifoBufferType = union(enum) {
     Dynamic,
 };
 
-pub fn FixedSizeFifo(
+pub fn LinearFifo(
     comptime T: type,
-    comptime buffer_type: FifoBufferType,
+    comptime buffer_type: LinearFifoBufferType,
 ) type {
     const autoalign = false;
 
@@ -332,8 +332,8 @@ pub fn FixedSizeFifo(
     };
 }
 
-test "FixedSizeFifo(u8, .Dynamic)" {
-    var fifo = FixedSizeFifo(u8, .Dynamic).init(debug.global_allocator);
+test "LinearFifo(u8, .Dynamic)" {
+    var fifo = LinearFifo(u8, .Dynamic).init(debug.global_allocator);
     defer fifo.deinit();
 
     try fifo.write("HELLO");
@@ -397,10 +397,10 @@ test "FixedSizeFifo(u8, .Dynamic)" {
     }
 }
 
-test "FixedSizeFifo" {
+test "LinearFifo" {
     inline for ([_]type{ u1, u8, u16, u64 }) |T| {
-        inline for ([_]FifoBufferType{ FifoBufferType{ .Static = 32 }, .Slice, .Dynamic }) |bt| {
-            const FifoType = FixedSizeFifo(T, bt);
+        inline for ([_]LinearFifoBufferType{ LinearFifoBufferType{ .Static = 32 }, .Slice, .Dynamic }) |bt| {
+            const FifoType = LinearFifo(T, bt);
             var buf: if (bt == .Slice) [32]T else void = undefined;
             var fifo = switch (bt) {
                 .Static => FifoType.init(),

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -300,18 +300,18 @@ pub fn LinearFifo(
         else
             struct {};
 
-        /// Make `count` bytes available before the current read location
-        fn rewind(self: *Self, size: usize) void {
-            assert(self.writableLength() >= size);
+        /// Make `count` items available before the current read location
+        fn rewind(self: *Self, count: usize) void {
+            assert(self.writableLength() >= count);
 
-            var head = self.head + (self.buf.len - size);
+            var head = self.head + (self.buf.len - count);
             if (powers_of_two) {
                 head &= self.buf.len - 1;
             } else {
                 head %= self.buf.len;
             }
             self.head = head;
-            self.count += size;
+            self.count += count;
         }
 
         /// Place data back into the read stream

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -311,9 +311,13 @@ pub fn LinearFifo(
             self.rewind(src.len);
 
             const slice = self.readableSliceMut(0);
-            mem.copy(T, slice, src[0..slice.len]);
-            const slice2 = self.readableSliceMut(slice.len);
-            mem.copy(T, slice2, src[slice.len..]);
+            if (src.len < slice.len) {
+                mem.copy(T, slice, src);
+            } else {
+                mem.copy(T, slice, src[0..slice.len]);
+                const slice2 = self.readableSliceMut(slice.len);
+                mem.copy(T, slice2, src[slice.len..]);
+            }
         }
 
         /// Peek at the item at `offset`
@@ -385,6 +389,9 @@ test "LinearFifo(u8, .Dynamic)" {
         try fifo.unget("prependedstring");
         var result: [30]u8 = undefined;
         testing.expectEqualSlices(u8, "prependedstringabcdefghij", result[0..fifo.read(&result)]);
+        try fifo.unget("b");
+        try fifo.unget("a");
+        testing.expectEqualSlices(u8, "ab", result[0..fifo.read(&result)]);
     }
 
     fifo.shrink(0);

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -145,16 +145,13 @@ pub fn LinearFifo(
         fn readableSliceMut(self: SliceSelfArg, offset: usize) []T {
             if (offset > self.count) return [_]T{};
 
-            const start = self.head + offset;
+            var start = self.head + offset;
             if (start >= self.buf.len) {
-                return self.buf[start - self.buf.len ..][0 .. self.count - offset];
+                start -= self.buf.len;
+                return self.buf[start..self.count - offset];
             } else {
-                const end: usize = self.head + self.count;
-                if (end >= self.buf.len) {
-                    return self.buf[start..self.buf.len];
-                } else {
-                    return self.buf[start..end];
-                }
+                const end = math.min(self.head + self.count, self.buf.len);
+                return self.buf[start..end];
             }
         }
 


### PR DESCRIPTION
  - fixes support for non-`u8` types
  - adds additional modes: Static, Slice and Dynamic
  - rename to `LinearFifo`
  - implement `std.io.Buffered{In,Out}Stream` using fifo (these will slowly undergo a transformation, this seemed like a basic starting point)