### PR TITLE
implement anonymous struct literals and anonymous list literals

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1734,6 +1734,43 @@ test "array initialization with function calls" {
       {#code_end#}
       {#see_also|for|Slices#}
 
+      {#header_open|Anonymous List Literals#}
+      <p>Similar to {#link|Enum Literals#} and {#link|Anonymous Struct Literals#}
+      the type can be omitted from array literals:</p>
+      {#code_begin|test|anon_list#}
+const std = @import("std");
+const assert = std.debug.assert;
+
+test "anonymous list literal syntax" {
+    var array: [4]u8 = .{11, 22, 33, 44};
+    assert(array[0] == 11);
+    assert(array[1] == 22);
+    assert(array[2] == 33);
+    assert(array[3] == 44);
+}
+      {#code_end#}
+      <p>
+      If there is no type in the result location then an anonymous list literal actually
+      turns into a {#link|struct#} with numbered field names:
+      </p>
+      {#code_begin|test|infer_list_literal#}
+const std = @import("std");
+const assert = std.debug.assert;
+
+test "fully anonymous list literal" {
+    dump(.{ @as(u32, 1234), @as(f64, 12.34), true, "hi"});
+}
+
+fn dump(args: var) void {
+    assert(args.@"0" == 1234);
+    assert(args.@"1" == 12.34);
+    assert(args.@"2");
+    assert(args.@"3"[0] == 'h');
+    assert(args.@"3"[1] == 'i');
+}
+      {#code_end#}
+      {#header_close#}
+
       {#header_open|Multidimensional Arrays#}
       <p>
       Mutlidimensional arrays can be created by nesting arrays:
@@ -2526,7 +2563,8 @@ test "overaligned pointer to packed struct" {
       Don't worry, there will be a good solution for this use case in zig.
       </p>
       {#header_close#}
-      {#header_open|struct Naming#}
+
+      {#header_open|Struct Naming#}
       <p>Since all structs are anonymous, Zig infers the type name based on a few rules.</p>
       <ul>
           <li>If the struct is in the initialization expression of a variable, it gets named after
@@ -2549,6 +2587,53 @@ fn List(comptime T: type) type {
     return struct {
         x: T,
     };
+}
+      {#code_end#}
+      {#header_close#}
+
+      {#header_open|Anonymous Struct Literals#}
+      <p>
+      Zig allows omitting the struct type of a literal. When the result is {#link|coerced|Type Coercion#},
+      the struct literal will directly instantiate the result location, with no copy:
+      </p>
+      {#code_begin|test|struct_result#}
+const std = @import("std");
+const assert = std.debug.assert;
+
+const Point = struct {x: i32, y: i32};
+
+test "anonymous struct literal" {
+    var pt: Point = .{
+        .x = 13,
+        .y = 67,
+    };
+    assert(pt.x == 13);
+    assert(pt.y == 67);
+}
+      {#code_end#}
+      <p>
+      The struct type can be inferred. Here the result location does not include a type, and
+      so Zig infers the type:
+      </p>
+      {#code_begin|test|struct_anon#}
+const std = @import("std");
+const assert = std.debug.assert;
+
+test "fully anonymous struct" {
+    dump(.{
+        .int = @as(u32, 1234),
+        .float = @as(f64, 12.34),
+        .b = true,
+        .s = "hi",
+    });
+}
+
+fn dump(args: var) void {
+    assert(args.int == 1234);
+    assert(args.float == 12.34);
+    assert(args.b);
+    assert(args.s[0] == 'h');
+    assert(args.s[1] == 'i');
 }
       {#code_end#}
       {#header_close#}
@@ -2906,6 +2991,32 @@ test "@tagName" {
       <p>A {#syntax#}packed union{#endsyntax#} has well-defined in-memory layout and is eligible
       to be in a {#link|packed struct#}.
       {#header_close#}
+
+      {#header_open|Anonymous Union Literals#}
+      <p>{#link|Anonymous Struct Literals#} syntax can be used to initialize unions without specifying
+      the type:</p>
+      {#code_begin|test|anon_union#}
+const std = @import("std");
+const assert = std.debug.assert;
+
+const Number = union {
+    int: i32,
+    float: f64,
+};
+
+test "anonymous union literal syntax" {
+    var i: Number = .{.int = 42};
+    var f = makeNumber();
+    assert(i.int == 42);
+    assert(f.float == 12.34);
+}
+
+fn makeNumber() Number {
+    return .{.float = 12.34};
+}
+      {#code_end#}
+      {#header_close#}
+
       {#header_close#}
 
       {#header_open|blocks#}

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -90,40 +90,11 @@ pub const Mode = enum {
     ReleaseSmall,
 };
 
-/// This data structure is used by the Zig language code generation and
-/// therefore must be kept in sync with the compiler implementation.
-pub const TypeId = enum {
-    Type,
-    Void,
-    Bool,
-    NoReturn,
-    Int,
-    Float,
-    Pointer,
-    Array,
-    Struct,
-    ComptimeFloat,
-    ComptimeInt,
-    Undefined,
-    Null,
-    Optional,
-    ErrorUnion,
-    ErrorSet,
-    Enum,
-    Union,
-    Fn,
-    BoundFn,
-    ArgTuple,
-    Opaque,
-    Frame,
-    AnyFrame,
-    Vector,
-    EnumLiteral,
-};
+pub const TypeId = @TagType(TypeInfo);
 
 /// This data structure is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
-pub const TypeInfo = union(TypeId) {
+pub const TypeInfo = union(enum) {
     Type: void,
     Void: void,
     Bool: void,

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -1,3 +1,20 @@
+test "zig fmt: anon struct literal syntax" {
+    try testCanonical(
+        \\const x = .{
+        \\    .a = b,
+        \\    .c = d,
+        \\};
+        \\
+    );
+}
+
+test "zig fmt: anon list literal syntax" {
+    try testCanonical(
+        \\const x = .{ a, b, c };
+        \\
+    );
+}
+
 test "zig fmt: async function" {
     try testCanonical(
         \\pub const Server = struct {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1187,9 +1187,21 @@ bool fn_type_id_eql(FnTypeId *a, FnTypeId *b);
 static const uint32_t VECTOR_INDEX_NONE = UINT32_MAX;
 static const uint32_t VECTOR_INDEX_RUNTIME = UINT32_MAX - 1;
 
+struct InferredStructField {
+    ZigType *inferred_struct_type;
+    Buf *field_name;
+};
+
 struct ZigTypePointer {
     ZigType *child_type;
     ZigType *slice_parent;
+
+    // Anonymous struct literal syntax uses this when the result location has
+    // no type in it. This field is null if this pointer does not refer to
+    // a field of a currently-being-inferred struct type.
+    // When this is non-null, the pointer is pointing to the base of the inferred
+    // struct.
+    InferredStructField *inferred_struct_field;
 
     PtrLen ptr_len;
     uint32_t explicit_alignment; // 0 means use ABI alignment
@@ -1743,6 +1755,7 @@ struct TypeId {
     union {
         struct {
             ZigType *child_type;
+            InferredStructField *inferred_struct_field;
             PtrLen ptr_len;
             uint32_t alignment;
 

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1237,6 +1237,7 @@ struct TypeStructField {
 enum ResolveStatus {
     ResolveStatusUnstarted,
     ResolveStatusInvalid,
+    ResolveStatusBeingInferred,
     ResolveStatusZeroBitsKnown,
     ResolveStatusAlignmentKnown,
     ResolveStatusSizeKnown,
@@ -1285,6 +1286,7 @@ struct ZigTypeStruct {
     bool requires_comptime;
     bool resolve_loop_flag_zero_bits;
     bool resolve_loop_flag_other;
+    bool is_inferred;
 };
 
 struct ZigTypeOptional {
@@ -2812,7 +2814,7 @@ struct IrInstructionElemPtr {
 
     IrInstruction *array_ptr;
     IrInstruction *elem_index;
-    IrInstruction *init_array_type;
+    AstNode *init_array_type_source_node;
     PtrLen ptr_len;
     bool safety_check_on;
 };
@@ -2909,11 +2911,11 @@ struct IrInstructionResizeSlice {
 struct IrInstructionContainerInitList {
     IrInstruction base;
 
-    IrInstruction *container_type;
     IrInstruction *elem_type;
     size_t item_count;
     IrInstruction **elem_result_loc_list;
     IrInstruction *result_loc;
+    AstNode *init_array_type_source_node;
 };
 
 struct IrInstructionContainerInitFieldsField {
@@ -2926,7 +2928,6 @@ struct IrInstructionContainerInitFieldsField {
 struct IrInstructionContainerInitFields {
     IrInstruction base;
 
-    IrInstruction *container_type;
     size_t field_count;
     IrInstructionContainerInitFieldsField *fields;
     IrInstruction *result_loc;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5857,15 +5857,9 @@ ConstExprValue *create_const_arg_tuple(CodeGen *g, size_t arg_index_start, size_
 
 
 ConstExprValue *create_const_vals(size_t count) {
-    return realloc_const_vals(nullptr, 0, count);
-}
-
-ConstExprValue *realloc_const_vals(ConstExprValue *base, size_t old_count, size_t new_count) {
-    ConstGlobalRefs *old_global_refs = (base == nullptr) ? nullptr : base->global_refs;
-    ConstGlobalRefs *global_refs = reallocate<ConstGlobalRefs>(old_global_refs, old_count,
-            new_count, "ConstGlobalRefs");
-    ConstExprValue *vals = reallocate<ConstExprValue>(base, old_count, new_count, "ConstExprValue");
-    for (size_t i = old_count; i < new_count; i += 1) {
+    ConstGlobalRefs *global_refs = allocate<ConstGlobalRefs>(count, "ConstGlobalRefs");
+    ConstExprValue *vals = allocate<ConstExprValue>(count, "ConstExprValue");
+    for (size_t i = 0; i < count; i += 1) {
         vals[i].global_refs = &global_refs[i];
     }
     return vals;

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -175,7 +175,6 @@ void init_const_arg_tuple(CodeGen *g, ConstExprValue *const_val, size_t arg_inde
 ConstExprValue *create_const_arg_tuple(CodeGen *g, size_t arg_index_start, size_t arg_index_end);
 
 ConstExprValue *create_const_vals(size_t count);
-ConstExprValue *realloc_const_vals(ConstExprValue *base, size_t old_count, size_t new_count);
 
 ZigType *make_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits);
 void expand_undef_array(CodeGen *g, ConstExprValue *const_val);

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -24,7 +24,7 @@ ZigType *get_pointer_to_type_extra(CodeGen *g, ZigType *child_type,
 ZigType *get_pointer_to_type_extra2(CodeGen *g, ZigType *child_type,
         bool is_const, bool is_volatile, PtrLen ptr_len,
         uint32_t byte_alignment, uint32_t bit_offset, uint32_t unaligned_bit_count,
-        bool allow_zero, uint32_t vector_index);
+        bool allow_zero, uint32_t vector_index, InferredStructField *inferred_struct_field);
 uint64_t type_size(CodeGen *g, ZigType *type_entry);
 uint64_t type_size_bits(CodeGen *g, ZigType *type_entry);
 ZigType *get_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits);
@@ -175,6 +175,7 @@ void init_const_arg_tuple(CodeGen *g, ConstExprValue *const_val, size_t arg_inde
 ConstExprValue *create_const_arg_tuple(CodeGen *g, size_t arg_index_start, size_t arg_index_end);
 
 ConstExprValue *create_const_vals(size_t count);
+ConstExprValue *realloc_const_vals(ConstExprValue *base, size_t old_count, size_t new_count);
 
 ZigType *make_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits);
 void expand_undef_array(CodeGen *g, ConstExprValue *const_val);

--- a/src/ast_render.cpp
+++ b/src/ast_render.cpp
@@ -821,7 +821,9 @@ static void render_node_extra(AstRender *ar, AstNode *node, bool grouped) {
                 break;
             }
         case NodeTypeContainerInitExpr:
-            render_node_ungrouped(ar, node->data.container_init_expr.type);
+            if (node->data.container_init_expr.type != nullptr) {
+                render_node_ungrouped(ar, node->data.container_init_expr.type);
+            }
             if (node->data.container_init_expr.kind == ContainerInitKindStruct) {
                 fprintf(ar->f, "{\n");
                 ar->indent += ar->indent_size;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -6151,7 +6151,11 @@ static IrInstruction *ir_gen_container_init_expr(IrBuilder *irb, Scope *scope, A
         init_array_type_source_node = container_type->source_node;
     } else {
         child_result_loc = parent_result_loc;
-        init_array_type_source_node = parent_result_loc->source_instruction->source_node;
+        if (parent_result_loc->source_instruction != nullptr) {
+            init_array_type_source_node = parent_result_loc->source_instruction->source_node;
+        } else {
+            init_array_type_source_node = node;
+        }
     }
 
     switch (kind) {
@@ -15933,6 +15937,10 @@ static IrInstruction *ir_analyze_instruction_resolve_result(IrAnalyze *ira,
         if (instruction->result_loc->id == ResultLocIdCast) {
             implicit_elem_type = ir_resolve_type(ira,
                     instruction->result_loc->source_instruction->child);
+            if (type_is_invalid(implicit_elem_type))
+                return ira->codegen->invalid_instruction;
+        } else if (instruction->result_loc->id == ResultLocIdReturn) {
+            implicit_elem_type = ira->explicit_return_type;
             if (type_is_invalid(implicit_elem_type))
                 return ira->codegen->invalid_instruction;
         } else {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -731,7 +731,6 @@ static void ir_print_phi(IrPrint *irp, IrInstructionPhi *phi_instruction) {
 }
 
 static void ir_print_container_init_list(IrPrint *irp, IrInstructionContainerInitList *instruction) {
-    ir_print_other_instruction(irp, instruction->container_type);
     fprintf(irp->f, "{");
     if (instruction->item_count > 50) {
         fprintf(irp->f, "...(%" ZIG_PRI_usize " items)...", instruction->item_count);
@@ -743,11 +742,11 @@ static void ir_print_container_init_list(IrPrint *irp, IrInstructionContainerIni
             ir_print_other_instruction(irp, result_loc);
         }
     }
-    fprintf(irp->f, "}");
+    fprintf(irp->f, "}result=");
+    ir_print_other_instruction(irp, instruction->result_loc);
 }
 
 static void ir_print_container_init_fields(IrPrint *irp, IrInstructionContainerInitFields *instruction) {
-    ir_print_other_instruction(irp, instruction->container_type);
     fprintf(irp->f, "{");
     for (size_t i = 0; i < instruction->field_count; i += 1) {
         IrInstructionContainerInitFieldsField *field = &instruction->fields[i];
@@ -755,7 +754,8 @@ static void ir_print_container_init_fields(IrPrint *irp, IrInstructionContainerI
         fprintf(irp->f, "%s.%s = ", comma, buf_ptr(field->name));
         ir_print_other_instruction(irp, field->result_loc);
     }
-    fprintf(irp->f, "} // container init");
+    fprintf(irp->f, "}result=");
+    ir_print_other_instruction(irp, instruction->result_loc);
 }
 
 static void ir_print_unreachable(IrPrint *irp, IrInstructionUnreachable *instruction) {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3,6 +3,23 @@ const builtin = @import("builtin");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "missing const in slice with nested array type",
+        \\const Geo3DTex2D = struct { vertices: [][2]f32 };
+        \\pub fn getGeo3DTex2D() Geo3DTex2D {
+        \\    return Geo3DTex2D{
+        \\        .vertices = [_][2]f32{
+        \\            [_]f32{ -0.5, -0.5},
+        \\        },
+        \\    };
+        \\}
+        \\export fn entry() void {
+        \\    var geo_data = getGeo3DTex2D();
+        \\}
+    ,
+        "tmp.zig:4:30: error: expected type '[][2]f32', found '[1][2]f32'",
+    );
+
+    cases.add(
         "slicing of global undefined pointer",
         \\var buf: *[1]u8 = undefined;
         \\export fn entry() void {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -216,9 +216,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const obj = AstObject{ .lhsExpr = lhsExpr };
         \\}
     ,
-        "tmp.zig:4:19: error: union 'AstObject' depends on itself",
-        "tmp.zig:2:5: note: while checking this field",
+        "tmp.zig:1:17: error: struct 'LhsExpr' depends on itself",
         "tmp.zig:5:5: note: while checking this field",
+        "tmp.zig:2:5: note: while checking this field",
     );
 
     cases.add(

--- a/test/stage1/behavior/array.zig
+++ b/test/stage1/behavior/array.zig
@@ -298,3 +298,17 @@ test "implicit cast zero sized array ptr to slice" {
     const c: []const u8 = &b;
     expect(c.len == 0);
 }
+
+test "anonymous list literal syntax" {
+    const S = struct {
+        fn doTheTest() void {
+            var array: [4]u8 = .{1, 2, 3, 4};
+            expect(array[0] == 1);
+            expect(array[1] == 2);
+            expect(array[2] == 3);
+            expect(array[3] == 4);
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/async_fn.zig
+++ b/test/stage1/behavior/async_fn.zig
@@ -1214,7 +1214,7 @@ test "spill target expr in a for loop" {
         }
 
         const Foo = struct {
-            slice: []i32,
+            slice: []const i32,
         };
 
         fn atest(foo: *Foo) i32 {
@@ -1245,7 +1245,7 @@ test "spill target expr in a for loop, with a var decl in the loop body" {
         }
 
         const Foo = struct {
-            slice: []i32,
+            slice: []const i32,
         };
 
         fn atest(foo: *Foo) i32 {

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -729,3 +729,25 @@ test "anonymous struct literal syntax" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "fully anonymous struct" {
+    const S = struct {
+        fn doTheTest() void {
+            dump(.{
+                .int = @as(u32, 1234),
+                .float = @as(f64, 12.34),
+                .b = true,
+                .s = "hi",
+            });
+        }
+        fn dump(args: var) void {
+            expect(args.int == 1234);
+            expect(args.float == 12.34);
+            expect(args.b);
+            expect(args.s[0] == 'h');
+            expect(args.s[1] == 'i');
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -709,3 +709,23 @@ test "packed struct field passed to generic function" {
     var loaded = S.genericReadPackedField(&p.b);
     expect(loaded == 29);
 }
+
+test "anonymous struct literal syntax" {
+    const S = struct {
+        const Point = struct {
+            x: i32,
+            y: i32,
+        };
+
+        fn doTheTest() void {
+            var p: Point = .{
+                .x = 1,
+                .y = 2,
+            };
+            expect(p.x == 1);
+            expect(p.y == 2);
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -751,3 +751,20 @@ test "fully anonymous struct" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "fully anonymous list literal" {
+    const S = struct {
+        fn doTheTest() void {
+            dump(.{ @as(u32, 1234), @as(f64, 12.34), true, "hi"});
+        }
+        fn dump(args: var) void {
+            expect(args.@"0" == 1234);
+            expect(args.@"1" == 12.34);
+            expect(args.@"2");
+            expect(args.@"3"[0] == 'h');
+            expect(args.@"3"[1] == 'i');
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/union.zig
+++ b/test/stage1/behavior/union.zig
@@ -559,9 +559,13 @@ test "anonymous union literal syntax" {
 
         fn doTheTest() void {
             var i: Number = .{.int = 42};
-            var f: Number = .{.float = 12.34};
+            var f = makeNumber();
             expect(i.int == 42);
             expect(f.float == 12.34);
+        }
+
+        fn makeNumber() Number {
+            return .{.float = 12.34};
         }
     };
     S.doTheTest();

--- a/test/stage1/behavior/union.zig
+++ b/test/stage1/behavior/union.zig
@@ -549,3 +549,21 @@ test "initialize global array of union" {
     expect(glbl_array[0].U0 == 1);
     expect(glbl_array[1].U1 == 2);
 }
+
+test "anonymous union literal syntax" {
+    const S = struct {
+        const Number = union {
+            int: i32,
+            float: f64,
+        };
+
+        fn doTheTest() void {
+            var i: Number = .{.int = 42};
+            var f: Number = .{.float = 12.34};
+            expect(i.int == 42);
+            expect(f.float == 12.34);
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}


### PR DESCRIPTION
This implements stage1 parser support for anonymous struct literal
syntax (see #685), as well as semantic analysis support for anonymous
struct literals and anonymous list literals (see #208). The semantic
analysis works when there is a type coercion in the result location;
inferring the struct type based on the values in the literal is not
implemented yet. Also remaining to do is zig fmt support for this new
syntax and documentation updates.

### Merge Checklist

 * [x] add a behavior test case for unions
 * [x] add a behavior test case for anon list literal syntax
 * [x] update self-hosted / zig fmt to handle anon struct literal syntax and anon list literal syntax
 * [x] implement struct type inference based on the literal values when the result location of an anon struct literal does not have a type coercion
 * [x] add compile error test for https://github.com/ziglang/zig/pull/3652#issuecomment-552592658
 * [x] implement anon list literal when the result location does not have a type coercion. this will make an anon struct type with field names numbered with indexes.
 * [x] update documentation and grammar

### Future Related Work

 * make `zig fmt` convert `Foo{.a = b}` to `@as(Foo, .{.a = b})`, wait 1 release cycle, and remove the deprecated old syntax. If this looks bad to you, consider that most struct literals will look like this: `const foo: Foo = .{.a = b};`.
 * remove var args, and take advantage of anonymous list literals instead. #208
 * add syntax to destructure array initialization lists (#498)