### PR TITLE
ArrayList: ptrAt function returns pointer to item at given index

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -63,6 +63,11 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             return self.toSliceConst()[i];
         }
 
+        /// Safely access ptr to index i of the list.
+        pub fn ptrAt(self: Self, i: usize) *T {
+            return &self.toSlice()[i];
+        }
+
         /// Sets the value at index `i`, or returns `error.OutOfBounds` if
         /// the index is not in range.
         pub fn setOrError(self: Self, i: usize, item: T) !void {


### PR DESCRIPTION
Most of the time, I want to modify something in the list and lose 1 hour figuring out why it did nothing :)