### PR TITLE
Add compile error for @atomicRmw on enum not being an .Xchg

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -25824,6 +25824,12 @@ static IrInstruction *ir_analyze_instruction_atomic_rmw(IrAnalyze *ira, IrInstru
         }
     }
 
+    if (operand_type->id == ZigTypeIdEnum && op != AtomicRmwOp_xchg) {
+        ir_add_error(ira, instruction->op,
+            buf_sprintf("@atomicRmw on enum only works with .Xchg"));
+        return ira->codegen->invalid_instruction;
+    }
+
     IrInstruction *operand = instruction->operand->child;
     if (type_is_invalid(operand->value.type))
         return ira->codegen->invalid_instruction;

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3,6 +3,22 @@ const builtin = @import("builtin");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.add(
+        "atomicrmw with enum op not .Xchg",
+        \\export fn entry() void {
+        \\    const E = enum(u8) {
+        \\        a,
+        \\        b,
+        \\        c,
+        \\        d,
+        \\    };
+        \\    var x: E = .a;
+        \\    _ = @atomicRmw(E, &x, .Add, .b, .SeqCst);
+        \\}
+    ,
+        "tmp.zig:9:27: error: @atomicRmw on enum only works with .Xchg",
+    );
+
+    cases.add(
         "atomic orderings of atomicStore Acquire or AcqRel",
         \\export fn entry() void {
         \\    var x: u32 = 0;


### PR DESCRIPTION
As discussed in  #3675