### PR TITLE
exchanged a division by 2 for a bit shift right

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -200,7 +200,8 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             var better_capacity = self.capacity();
             if (better_capacity >= new_capacity) return;
             while (true) {
-                // + has greater precedence than >> does.
+                // + has greater precedence than >> does, so the
+                // parentheses are needed.
                 better_capacity += (better_capacity >> 1) + 8;
                 if (better_capacity >= new_capacity) break;
             }

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -58,7 +58,7 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             return self.items[0..self.len];
         }
 
-        /// Safely access index i of the list. 
+        /// Safely access index i of the list.
         pub fn at(self: Self, i: usize) T {
             return self.toSliceConst()[i];
         }
@@ -200,7 +200,8 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             var better_capacity = self.capacity();
             if (better_capacity >= new_capacity) return;
             while (true) {
-                better_capacity += better_capacity / 2 + 8;
+                // + has greater precedence than >> does.
+                better_capacity += (better_capacity >> 1) + 8;
                 if (better_capacity >= new_capacity) break;
             }
             self.items = try self.allocator.realloc(self.items, better_capacity);


### PR DESCRIPTION
Let me know what you guys think. I compiled a small example and ran through it with GDB on a debug executable, and the assembly changed compared to division by 2 version, but I have not looked at an optimized executable.