### PR TITLE
std.testing.expectEqual: show differing pointer values

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -62,7 +62,7 @@ pub fn expectEqual(expected: var, actual: @typeOf(expected)) void {
                 builtin.TypeInfo.Pointer.Size.C,
                 => {
                     if (actual != expected) {
-                        std.debug.panic("expected {}, found {}", expected, actual);
+                        std.debug.panic("expected {*}, found {*}", expected, actual);
                     }
                 },
 


### PR DESCRIPTION
Show differing pointer values when comparing pointers instead of the
content they point to.

It's confusing for a test to say "expected S{.x = 1}, found S{.x = 1}"
as illustrated below when it was the pointers that differed.

There seems to be different rules for when a pointer is dereferenced by
the printing routine depending on its type. I don't fully grok this but
it's also illustrated below.

    const std = @import("std");

    const S = struct { x: u32 };

    // before: ...expected S{ .x = 1 }, found S{ .x = 1 }
    // after:  ...expected S@7ffcd20b7798, found S@7ffcd20b7790
    test "compare_ptr_to_struct" {
        var a = S{.x = 1};
        var b = S{.x = 1};
        std.testing.expectEqual(&a, &b);
    }

    // before: ...expected u32@7fff316ba31c, found u32@7fff316ba318
    // after:  ...expected u32@7ffecec622dc, found u32@7ffecec622d8
    test "compare_ptr_to_scalar" {
        var a: u32 = 1;
        var b: u32 = 1;
        std.testing.expectEqual(&a, &b);
    }