### PR TITLE
Use a binary search for insertion sort

### DIFF
--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -6,17 +6,18 @@ const math = std.math;
 const builtin = @import("builtin");
 
 /// Stable in-place sort. O(n) best case, O(pow(n, 2)) worst case. O(1) memory (no allocator required).
-pub fn insertionSort(comptime T: type, items: []T, lessThan: fn (lhs: T, rhs: T) bool) void {
-    {
-        var i: usize = 1;
-        while (i < items.len) : (i += 1) {
-            const x = items[i];
-            var j: usize = i;
-            while (j > 0 and lessThan(x, items[j - 1])) : (j -= 1) {
-                items[j] = items[j - 1];
-            }
-            items[j] = x;
-        }
+/// Uses binary search, which can be up to 2x better
+pub fn insertionSort(comptime T: type, items: []T, lessThan: fn (T, T) bool) void {
+    var i: usize = 1;
+    while (i < items.len) : (i += 1) {
+        // Skip search / copy on already sorted pairs
+        if (!lessThan(items[i], items[i - 1])) continue;
+
+        const val = items[i];
+        const ins = binaryLast(T, items, val, Range{ .start = 0, .end = i }, lessThan);
+        // TODO: switch to memmove once that's available
+        std.mem.copyBackwards(T, items[ins + 1 ..], items[ins..i]);
+        items[ins] = val;
     }
 }
 


### PR DESCRIPTION
I was exploring Grailsort and it uses binary insertion sort. There's a noticeable bump in performance once I pushed it into std.sort:

|  | std.sort<br>Iterative&nbsp;(µs) | std.sort<br>Binary&nbsp;(µs) | <br>ΔTime | | Insertion&nbsp;Sort<br>Iterative&nbsp;(µs) | Insertion&nbsp;Sort<br>Binary&nbsp;(µs) |
|:--- | ---:| ---:| ---:| -- | ---:| ---:|
| Presorted | 59.5 | 53.9 | -9.4% | | 19.4 | 18.8
| Mostly sorted | 310.1 | 259.9 | -16.2% | | 1608.3 | 1042.4
| Trending upward | 408.6 | 369.6 | -9.5% | | 1349.4 | 1137.2
| Reverse sorted | 168.8 | 161.6 | -4.3% | | 24885.2 | 12981.5
| Fully random | 525.7 | 500.3 | -4.8% | | 12292.0 | 6682.2
| 10x bigger | 5454.7 | 4944.3 | -9.4% | | 1251844.5 | 629395.6

On my woefully underpowered Celeron, binary insertion sort tends to be slower — possibly due to cache issues. But std.sort is still better (probably because its blocksize of 512 easily fits into cache):

|  | std.sort<br>Iterative&nbsp;(µs) | std.sort<br>Binary&nbsp;(µs) | <br>ΔTime | | Insertion&nbsp;Sort<br>Iterative&nbsp;(µs) | Insertion&nbsp;Sort<br>Binary&nbsp;(µs) |
|:--- | ---:| ---:| ---:| -- | ---:| ---:|
| Presorted | 186.5 | 182.7 | -2.0% | | 76.5 | 48.6
| Mostly sorted | 904.6 | 826.9 | -8.6% | | 5855.1 | 6407.0
| Trending upward | 964.8 | 850.0 | -11.9% | | 4848.0 | 5549.1
| Reverse sorted | 652.4 | 582.8 | -10.7% | | 91491.2 | 92167.1
| Fully random | 1269.8 | 1192.3 | -6.1% | | 45636.6 | 46520.3
| 10x bigger | 14905.9 | 13040.5 | -12.5% | | 4676179.2 | 4578888.1

Benchmark data from https://github.com/fengb/zig-sorts