### PR TITLE
std: fix outdated valgrind module

### DIFF
--- a/lib/std/valgrind.zig
+++ b/lib/std/valgrind.zig
@@ -96,48 +96,48 @@ fn doClientRequestStmt(request: ClientRequest, a1: usize, a2: usize, a3: usize, 
 /// running under Valgrind which is running under another Valgrind,
 /// etc.
 pub fn runningOnValgrind() usize {
-    return doClientRequestExpr(0, ClientRequest.RunningOnValgrind, 0, 0, 0, 0, 0);
+    return doClientRequestExpr(0, .RunningOnValgrind, 0, 0, 0, 0, 0);
 }
 
 /// Discard translation of code in the slice qzz.  Useful if you are debugging
 /// a JITter or some such, since it provides a way to make sure valgrind will
 /// retranslate the invalidated area.  Returns no value.
 pub fn discardTranslations(qzz: []const u8) void {
-    doClientRequestStmt(ClientRequest.DiscardTranslations, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0);
+    doClientRequestStmt(.DiscardTranslations, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0);
 }
 
 pub fn innerThreads(qzz: [*]u8) void {
-    doClientRequestStmt(ClientRequest.InnerThreads, qzz, 0, 0, 0, 0);
+    doClientRequestStmt(.InnerThreads, qzz, 0, 0, 0, 0);
 }
 
 //pub fn printf(format: [*]const u8, args: ...) usize {
 //    return doClientRequestExpr(0,
-//        ClientRequest.PrintfValistByRef,
+//        .PrintfValistByRef,
 //        @ptrToInt(format), @ptrToInt(args),
 //        0, 0, 0);
 //}
 
 //pub fn printfBacktrace(format: [*]const u8, args: ...) usize {
 //    return doClientRequestExpr(0,
-//        ClientRequest.PrintfBacktraceValistByRef,
+//        .PrintfBacktraceValistByRef,
 //        @ptrToInt(format), @ptrToInt(args),
 //        0, 0, 0);
 //}
 
 pub fn nonSIMDCall0(func: fn (usize) usize) usize {
-    return doClientRequestExpr(0, ClientRequest.ClientCall0, @ptrToInt(func), 0, 0, 0, 0);
+    return doClientRequestExpr(0, .ClientCall0, @ptrToInt(func), 0, 0, 0, 0);
 }
 
 pub fn nonSIMDCall1(func: fn (usize, usize) usize, a1: usize) usize {
-    return doClientRequestExpr(0, ClientRequest.ClientCall1, @ptrToInt(func), a1, 0, 0, 0);
+    return doClientRequestExpr(0, .ClientCall1, @ptrToInt(func), a1, 0, 0, 0);
 }
 
 pub fn nonSIMDCall2(func: fn (usize, usize, usize) usize, a1: usize, a2: usize) usize {
-    return doClientRequestExpr(0, ClientRequest.ClientCall2, @ptrToInt(func), a1, a2, 0, 0);
+    return doClientRequestExpr(0, .ClientCall2, @ptrToInt(func), a1, a2, 0, 0);
 }
 
 pub fn nonSIMDCall3(func: fn (usize, usize, usize, usize) usize, a1: usize, a2: usize, a3: usize) usize {
-    return doClientRequestExpr(0, ClientRequest.ClientCall3, @ptrToInt(func), a1, a2, a3, 0);
+    return doClientRequestExpr(0, .ClientCall3, @ptrToInt(func), a1, a2, a3, 0);
 }
 
 /// Counts the number of errors that have been recorded by a tool.  Nb:
@@ -145,19 +145,19 @@ pub fn nonSIMDCall3(func: fn (usize, usize, usize, usize) usize, a1: usize, a2: 
 /// VG_(unique_error)() for them to be counted.
 pub fn countErrors() usize {
     return doClientRequestExpr(0, // default return
-        ClientRequest.CountErrors, 0, 0, 0, 0, 0);
+        .CountErrors, 0, 0, 0, 0, 0);
 }
 
 pub fn mallocLikeBlock(mem: []u8, rzB: usize, is_zeroed: bool) void {
-    doClientRequestStmt(ClientRequest.MalloclikeBlock, @ptrToInt(mem.ptr), mem.len, rzB, @boolToInt(is_zeroed), 0);
+    doClientRequestStmt(.MalloclikeBlock, @ptrToInt(mem.ptr), mem.len, rzB, @boolToInt(is_zeroed), 0);
 }
 
 pub fn resizeInPlaceBlock(oldmem: []u8, newsize: usize, rzB: usize) void {
-    doClientRequestStmt(ClientRequest.ResizeinplaceBlock, @ptrToInt(oldmem.ptr), oldmem.len, newsize, rzB, 0);
+    doClientRequestStmt(.ResizeinplaceBlock, @ptrToInt(oldmem.ptr), oldmem.len, newsize, rzB, 0);
 }
 
 pub fn freeLikeBlock(addr: [*]u8, rzB: usize) void {
-    doClientRequestStmt(ClientRequest.FreelikeBlock, @ptrToInt(addr), rzB, 0, 0, 0);
+    doClientRequestStmt(.FreelikeBlock, @ptrToInt(addr), rzB, 0, 0, 0);
 }
 
 /// Create a memory pool.
@@ -166,66 +166,66 @@ pub const MempoolFlags = extern enum {
     MetaPool = 2,
 };
 pub fn createMempool(pool: [*]u8, rzB: usize, is_zeroed: bool, flags: usize) void {
-    doClientRequestStmt(ClientRequest.CreateMempool, @ptrToInt(pool), rzB, @boolToInt(is_zeroed), flags, 0);
+    doClientRequestStmt(.CreateMempool, @ptrToInt(pool), rzB, @boolToInt(is_zeroed), flags, 0);
 }
 
 /// Destroy a memory pool.
 pub fn destroyMempool(pool: [*]u8) void {
-    doClientRequestStmt(ClientRequest.DestroyMempool, pool, 0, 0, 0, 0);
+    doClientRequestStmt(.DestroyMempool, pool, 0, 0, 0, 0);
 }
 
 /// Associate a piece of memory with a memory pool.
 pub fn mempoolAlloc(pool: [*]u8, mem: []u8) void {
-    doClientRequestStmt(ClientRequest.MempoolAlloc, @ptrToInt(pool), @ptrToInt(mem.ptr), mem.len, 0, 0);
+    doClientRequestStmt(.MempoolAlloc, @ptrToInt(pool), @ptrToInt(mem.ptr), mem.len, 0, 0);
 }
 
 /// Disassociate a piece of memory from a memory pool.
 pub fn mempoolFree(pool: [*]u8, addr: [*]u8) void {
-    doClientRequestStmt(ClientRequest.MempoolFree, @ptrToInt(pool), @ptrToInt(addr), 0, 0, 0);
+    doClientRequestStmt(.MempoolFree, @ptrToInt(pool), @ptrToInt(addr), 0, 0, 0);
 }
 
 /// Disassociate any pieces outside a particular range.
 pub fn mempoolTrim(pool: [*]u8, mem: []u8) void {
-    doClientRequestStmt(ClientRequest.MempoolTrim, @ptrToInt(pool), @ptrToInt(mem.ptr), mem.len, 0, 0);
+    doClientRequestStmt(.MempoolTrim, @ptrToInt(pool), @ptrToInt(mem.ptr), mem.len, 0, 0);
 }
 
 /// Resize and/or move a piece associated with a memory pool.
 pub fn moveMempool(poolA: [*]u8, poolB: [*]u8) void {
-    doClientRequestStmt(ClientRequest.MoveMempool, @ptrToInt(poolA), @ptrToInt(poolB), 0, 0, 0);
+    doClientRequestStmt(.MoveMempool, @ptrToInt(poolA), @ptrToInt(poolB), 0, 0, 0);
 }
 
 /// Resize and/or move a piece associated with a memory pool.
 pub fn mempoolChange(pool: [*]u8, addrA: [*]u8, mem: []u8) void {
-    doClientRequestStmt(ClientRequest.MempoolChange, @ptrToInt(pool), @ptrToInt(addrA), @ptrToInt(mem.ptr), mem.len, 0);
+    doClientRequestStmt(.MempoolChange, @ptrToInt(pool), @ptrToInt(addrA), @ptrToInt(mem.ptr), mem.len, 0);
 }
 
 /// Return if a mempool exists.
 pub fn mempoolExists(pool: [*]u8) bool {
-    return doClientRequestExpr(0, ClientRequest.MempoolExists, @ptrToInt(pool), 0, 0, 0, 0) != 0;
+    return doClientRequestExpr(0, .MempoolExists, @ptrToInt(pool), 0, 0, 0, 0) != 0;
 }
 
 /// Mark a piece of memory as being a stack. Returns a stack id.
 /// start is the lowest addressable stack byte, end is the highest
 /// addressable stack byte.
 pub fn stackRegister(stack: []u8) usize {
-    return doClientRequestExpr(0, ClientRequest.StackRegister, @ptrToInt(stack.ptr), @ptrToInt(stack.ptr) + stack.len, 0, 0, 0);
+    return doClientRequestExpr(0, .StackRegister, @ptrToInt(stack.ptr), @ptrToInt(stack.ptr) + stack.len, 0, 0, 0);
 }
 
 /// Unmark the piece of memory associated with a stack id as being a stack.
 pub fn stackDeregister(id: usize) void {
-    doClientRequestStmt(ClientRequest.StackDeregister, id, 0, 0, 0, 0);
+    doClientRequestStmt(.StackDeregister, id, 0, 0, 0, 0);
 }
 
 /// Change the start and end address of the stack id.
 /// start is the new lowest addressable stack byte, end is the new highest
 /// addressable stack byte.
 pub fn stackChange(id: usize, newstack: []u8) void {
-    doClientRequestStmt(ClientRequest.StackChange, id, @ptrToInt(newstack.ptr), @ptrToInt(newstack.ptr) + newstack.len, 0, 0);
+    doClientRequestStmt(.StackChange, id, @ptrToInt(newstack.ptr), @ptrToInt(newstack.ptr) + newstack.len, 0, 0);
 }
 
 // Load PDB debug info for Wine PE image_map.
 // pub fn loadPdbDebuginfo(fd, ptr, total_size, delta) void {
-//     doClientRequestStmt(ClientRequest.LoadPdbDebuginfo,
+//     doClientRequestStmt(.LoadPdbDebuginfo,
 //         fd, ptr, total_size, delta,
 //         0);
 // }
@@ -235,7 +235,7 @@ pub fn stackChange(id: usize, newstack: []u8) void {
 /// result will be dumped in there and is guaranteed to be zero
 /// terminated.  If no info is found, the first byte is set to zero.
 pub fn mapIpToSrcloc(addr: *const u8, buf64: [64]u8) usize {
-    return doClientRequestExpr(0, ClientRequest.MapIpToSrcloc, @ptrToInt(addr), @ptrToInt(&buf64[0]), 0, 0, 0);
+    return doClientRequestExpr(0, .MapIpToSrcloc, @ptrToInt(addr), @ptrToInt(&buf64[0]), 0, 0, 0);
 }
 
 /// Disable error reporting for this thread.  Behaves in a stack like
@@ -247,12 +247,12 @@ pub fn mapIpToSrcloc(addr: *const u8, buf64: [64]u8) usize {
 /// reporting.  Child threads do not inherit this setting from their
 /// parents -- they are always created with reporting enabled.
 pub fn disableErrorReporting() void {
-    doClientRequestStmt(ClientRequest.ChangeErrDisablement, 1, 0, 0, 0, 0);
+    doClientRequestStmt(.ChangeErrDisablement, 1, 0, 0, 0, 0);
 }
 
 /// Re-enable error reporting, (see disableErrorReporting())
 pub fn enableErrorReporting() void {
-    doClientRequestStmt(ClientRequest.ChangeErrDisablement, math.maxInt(usize), 0, 0, 0, 0);
+    doClientRequestStmt(.ChangeErrDisablement, math.maxInt(usize), 0, 0, 0, 0);
 }
 
 /// Execute a monitor command from the client program.
@@ -261,7 +261,7 @@ pub fn enableErrorReporting() void {
 /// If no connection is opened, output will go to the log output.
 /// Returns 1 if command not recognised, 0 otherwise.
 pub fn monitorCommand(command: [*]u8) bool {
-    return doClientRequestExpr(0, ClientRequest.GdbMonitorCommand, @ptrToInt(command.ptr), 0, 0, 0, 0) != 0;
+    return doClientRequestExpr(0, .GdbMonitorCommand, @ptrToInt(command.ptr), 0, 0, 0, 0) != 0;
 }
 
 pub const memcheck = @import("valgrind/memcheck.zig");

--- a/lib/std/valgrind.zig
+++ b/lib/std/valgrind.zig
@@ -99,6 +99,10 @@ pub fn runningOnValgrind() usize {
     return doClientRequestExpr(0, .RunningOnValgrind, 0, 0, 0, 0, 0);
 }
 
+test "works whether running on valgrind or not" {
+    _ = runningOnValgrind();
+}
+
 /// Discard translation of code in the slice qzz.  Useful if you are debugging
 /// a JITter or some such, since it provides a way to make sure valgrind will
 /// retranslate the invalidated area.  Returns no value.
@@ -266,3 +270,8 @@ pub fn monitorCommand(command: [*]u8) bool {
 
 pub const memcheck = @import("valgrind/memcheck.zig");
 pub const callgrind = @import("valgrind/callgrind.zig");
+
+test "" {
+    _ = @import("valgrind/memcheck.zig");
+    _ = @import("valgrind/callgrind.zig");
+}

--- a/lib/std/valgrind.zig
+++ b/lib/std/valgrind.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
-const math = @import("index.zig").math;
+const std = @import("std.zig");
+const math = std.math;
 
 pub fn doClientRequest(default: usize, request: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) usize {
     if (!builtin.valgrind_support) {
@@ -13,7 +14,7 @@ pub fn doClientRequest(default: usize, request: usize, a1: usize, a2: usize, a3:
                 \\ roll $29, %%edi ; roll $19, %%edi
                 \\ xchgl %%ebx,%%ebx
                 : [_] "={edx}" (-> usize)
-                : [_] "{eax}" (&[]usize{ request, a1, a2, a3, a4, a5 }),
+                : [_] "{eax}" (&[_]usize{ request, a1, a2, a3, a4, a5 }),
                   [_] "0" (default)
                 : "cc", "memory"
             );
@@ -24,7 +25,7 @@ pub fn doClientRequest(default: usize, request: usize, a1: usize, a2: usize, a3:
                 \\ rolq $61, %%rdi ; rolq $51, %%rdi
                 \\ xchgq %%rbx,%%rbx
                 : [_] "={rdx}" (-> usize)
-                : [_] "{rax}" (&[]usize{ request, a1, a2, a3, a4, a5 }),
+                : [_] "{rax}" (&[_]usize{ request, a1, a2, a3, a4, a5 }),
                   [_] "0" (default)
                 : "cc", "memory"
             );
@@ -263,5 +264,5 @@ pub fn monitorCommand(command: [*]u8) bool {
     return doClientRequestExpr(0, ClientRequest.GdbMonitorCommand, @ptrToInt(command.ptr), 0, 0, 0, 0) != 0;
 }
 
-pub const memcheck = @import("memcheck.zig");
-pub const callgrind = @import("callgrind.zig");
+pub const memcheck = @import("valgrind/memcheck.zig");
+pub const callgrind = @import("valgrind/callgrind.zig");

--- a/lib/std/valgrind/callgrind.zig
+++ b/lib/std/valgrind/callgrind.zig
@@ -1,4 +1,4 @@
-const std = @import("../index.zig");
+const std = @import("../std.zig");
 const valgrind = std.valgrind;
 
 pub const CallgrindClientRequest = extern enum {

--- a/lib/std/valgrind/callgrind.zig
+++ b/lib/std/valgrind/callgrind.zig
@@ -20,7 +20,7 @@ fn doCallgrindClientRequestStmt(request: CallgrindClientRequest, a1: usize, a2: 
 
 /// Dump current state of cost centers, and zero them afterwards
 pub fn dumpStats() void {
-    doCallgrindClientRequestStmt(CallgrindClientRequest.DumpStats, 0, 0, 0, 0, 0);
+    doCallgrindClientRequestStmt(.DumpStats, 0, 0, 0, 0, 0);
 }
 
 /// Dump current state of cost centers, and zero them afterwards.
@@ -28,12 +28,12 @@ pub fn dumpStats() void {
 /// the dump. This string is written as a description field into the
 /// profile data dump.
 pub fn dumpStatsAt(pos_str: [*]u8) void {
-    doCallgrindClientRequestStmt(CallgrindClientRequest.DumpStatsAt, @ptrToInt(pos_str), 0, 0, 0, 0);
+    doCallgrindClientRequestStmt(.DumpStatsAt, @ptrToInt(pos_str), 0, 0, 0, 0);
 }
 
 /// Zero cost centers
 pub fn zeroStats() void {
-    doCallgrindClientRequestStmt(CallgrindClientRequest.ZeroStats, 0, 0, 0, 0, 0);
+    doCallgrindClientRequestStmt(.ZeroStats, 0, 0, 0, 0, 0);
 }
 
 /// Toggles collection state.
@@ -41,7 +41,7 @@ pub fn zeroStats() void {
 /// should be noted or if they are to be ignored. Events are noted
 /// by increment of counters in a cost center
 pub fn toggleCollect() void {
-    doCallgrindClientRequestStmt(CallgrindClientRequest.ToggleCollect, 0, 0, 0, 0, 0);
+    doCallgrindClientRequestStmt(.ToggleCollect, 0, 0, 0, 0, 0);
 }
 
 /// Start full callgrind instrumentation if not already switched on.
@@ -49,7 +49,7 @@ pub fn toggleCollect() void {
 /// this will lead to an artificial cache warmup phase afterwards with
 /// cache misses which would not have happened in reality.
 pub fn startInstrumentation() void {
-    doCallgrindClientRequestStmt(CallgrindClientRequest.StartInstrumentation, 0, 0, 0, 0, 0);
+    doCallgrindClientRequestStmt(.StartInstrumentation, 0, 0, 0, 0, 0);
 }
 
 /// Stop full callgrind instrumentation if not already switched off.
@@ -60,5 +60,5 @@ pub fn startInstrumentation() void {
 /// To start Callgrind in this mode to ignore the setup phase, use
 /// the option "--instr-atstart=no".
 pub fn stopInstrumentation() void {
-    doCallgrindClientRequestStmt(CallgrindClientRequest.StopInstrumentation, 0, 0, 0, 0, 0);
+    doCallgrindClientRequestStmt(.StopInstrumentation, 0, 0, 0, 0, 0);
 }

--- a/lib/std/valgrind/memcheck.zig
+++ b/lib/std/valgrind/memcheck.zig
@@ -1,4 +1,4 @@
-const std = @import("../index.zig");
+const std = @import("../std.zig");
 const valgrind = std.valgrind;
 
 pub const MemCheckClientRequest = extern enum {

--- a/lib/std/valgrind/memcheck.zig
+++ b/lib/std/valgrind/memcheck.zig
@@ -125,7 +125,7 @@ const CountResult = struct {
 };
 
 pub fn countLeaks() CountResult {
-    var res = CountResult{
+    var res: CountResult = .{
         .leaked = 0,
         .dubious = 0,
         .reachable = 0,
@@ -136,7 +136,7 @@ pub fn countLeaks() CountResult {
 }
 
 pub fn countLeakBlocks() CountResult {
-    var res = CountResult{
+    var res: CountResult = .{
         .leaked = 0,
         .dubious = 0,
         .reachable = 0,

--- a/lib/std/valgrind/memcheck.zig
+++ b/lib/std/valgrind/memcheck.zig
@@ -1,4 +1,5 @@
 const std = @import("../std.zig");
+const testing = std.testing;
 const valgrind = std.valgrind;
 
 pub const MemCheckClientRequest = extern enum {
@@ -142,6 +143,18 @@ pub fn countLeaks() CountResult {
     return res;
 }
 
+test "countLeaks" {
+    testing.expectEqual(
+        @as(CountResult, .{
+            .leaked = 0,
+            .dubious = 0,
+            .reachable = 0,
+            .suppressed = 0,
+        }),
+        countLeaks(),
+    );
+}
+
 pub fn countLeakBlocks() CountResult {
     var res: CountResult = .{
         .leaked = 0,
@@ -158,6 +171,18 @@ pub fn countLeakBlocks() CountResult {
         0,
     );
     return res;
+}
+
+test "countLeakBlocks" {
+    testing.expectEqual(
+        @as(CountResult, .{
+            .leaked = 0,
+            .dubious = 0,
+            .reachable = 0,
+            .suppressed = 0,
+        }),
+        countLeakBlocks(),
+    );
 }
 
 /// Get the validity data for addresses zza and copy it

--- a/lib/std/valgrind/memcheck.zig
+++ b/lib/std/valgrind/memcheck.zig
@@ -131,7 +131,14 @@ pub fn countLeaks() CountResult {
         .reachable = 0,
         .suppressed = 0,
     };
-    doMemCheckClientRequestStmt(.CountLeaks, &res.leaked, &res.dubious, &res.reachable, &res.suppressed, 0);
+    doMemCheckClientRequestStmt(
+        .CountLeaks,
+        @ptrToInt(&res.leaked),
+        @ptrToInt(&res.dubious),
+        @ptrToInt(&res.reachable),
+        @ptrToInt(&res.suppressed),
+        0,
+    );
     return res;
 }
 
@@ -142,7 +149,14 @@ pub fn countLeakBlocks() CountResult {
         .reachable = 0,
         .suppressed = 0,
     };
-    doMemCheckClientRequestStmt(.CountLeakBlocks, &res.leaked, &res.dubious, &res.reachable, &res.suppressed, 0);
+    doMemCheckClientRequestStmt(
+        .CountLeakBlocks,
+        @ptrToInt(&res.leaked),
+        @ptrToInt(&res.dubious),
+        @ptrToInt(&res.reachable),
+        @ptrToInt(&res.suppressed),
+        0,
+    );
     return res;
 }
 

--- a/lib/std/valgrind/memcheck.zig
+++ b/lib/std/valgrind/memcheck.zig
@@ -31,7 +31,7 @@ fn doMemCheckClientRequestStmt(request: MemCheckClientRequest, a1: usize, a2: us
 /// This returns -1 when run on Valgrind and 0 otherwise.
 pub fn makeMemNoAccess(qzz: []u8) i1 {
     return @intCast(i1, doMemCheckClientRequestExpr(0, // default return
-        MemCheckClientRequest.MakeMemNoAccess, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0));
+        .MakeMemNoAccess, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0));
 }
 
 /// Similarly, mark memory at qzz.ptr as addressable but undefined
@@ -39,7 +39,7 @@ pub fn makeMemNoAccess(qzz: []u8) i1 {
 /// This returns -1 when run on Valgrind and 0 otherwise.
 pub fn makeMemUndefined(qzz: []u8) i1 {
     return @intCast(i1, doMemCheckClientRequestExpr(0, // default return
-        MemCheckClientRequest.MakeMemUndefined, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0));
+        .MakeMemUndefined, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0));
 }
 
 /// Similarly, mark memory at qzz.ptr as addressable and defined
@@ -47,7 +47,7 @@ pub fn makeMemUndefined(qzz: []u8) i1 {
 pub fn makeMemDefined(qzz: []u8) i1 {
     // This returns -1 when run on Valgrind and 0 otherwise.
     return @intCast(i1, doMemCheckClientRequestExpr(0, // default return
-        MemCheckClientRequest.MakeMemDefined, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0));
+        .MakeMemDefined, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0));
 }
 
 /// Similar to makeMemDefined except that addressability is
@@ -56,7 +56,7 @@ pub fn makeMemDefined(qzz: []u8) i1 {
 /// This returns -1 when run on Valgrind and 0 otherwise.
 pub fn makeMemDefinedIfAddressable(qzz: []u8) i1 {
     return @intCast(i1, doMemCheckClientRequestExpr(0, // default return
-        MemCheckClientRequest.MakeMemDefinedIfAddressable, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0));
+        .MakeMemDefinedIfAddressable, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0));
 }
 
 /// Create a block-description handle.  The description is an ascii
@@ -65,14 +65,14 @@ pub fn makeMemDefinedIfAddressable(qzz: []u8) i1 {
 /// properties of the memory range.
 pub fn createBlock(qzz: []u8, desc: [*]u8) usize {
     return doMemCheckClientRequestExpr(0, // default return
-        MemCheckClientRequest.CreateBlock, @ptrToInt(qzz.ptr), qzz.len, @ptrToInt(desc), 0, 0);
+        .CreateBlock, @ptrToInt(qzz.ptr), qzz.len, @ptrToInt(desc), 0, 0);
 }
 
 /// Discard a block-description-handle. Returns 1 for an
 /// invalid handle, 0 for a valid handle.
 pub fn discard(blkindex) bool {
     return doMemCheckClientRequestExpr(0, // default return
-        MemCheckClientRequest.Discard, 0, blkindex, 0, 0, 0) != 0;
+        .Discard, 0, blkindex, 0, 0, 0) != 0;
 }
 
 /// Check that memory at qzz.ptr is addressable for qzz.len bytes.
@@ -80,7 +80,7 @@ pub fn discard(blkindex) bool {
 /// error message and returns the address of the first offending byte.
 /// Otherwise it returns zero.
 pub fn checkMemIsAddressable(qzz: []u8) usize {
-    return doMemCheckClientRequestExpr(0, MemCheckClientRequest.CheckMemIsAddressable, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0);
+    return doMemCheckClientRequestExpr(0, .CheckMemIsAddressable, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0);
 }
 
 /// Check that memory at qzz.ptr is addressable and defined for
@@ -88,31 +88,31 @@ pub fn checkMemIsAddressable(qzz: []u8) usize {
 /// established, Valgrind prints an error message and returns the
 /// address of the first offending byte.  Otherwise it returns zero.
 pub fn checkMemIsDefined(qzz: []u8) usize {
-    return doMemCheckClientRequestExpr(0, MemCheckClientRequest.CheckMemIsDefined, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0);
+    return doMemCheckClientRequestExpr(0, .CheckMemIsDefined, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0);
 }
 
 /// Do a full memory leak check (like --leak-check=full) mid-execution.
 pub fn doLeakCheck() void {
-    doMemCheckClientRequestStmt(MemCheckClientRequest.DO_LEAK_CHECK, 0, 0, 0, 0, 0);
+    doMemCheckClientRequestStmt(.DO_LEAK_CHECK, 0, 0, 0, 0, 0);
 }
 
 /// Same as doLeakCheck() but only showing the entries for
 /// which there was an increase in leaked bytes or leaked nr of blocks
 /// since the previous leak search.
 pub fn doAddedLeakCheck() void {
-    doMemCheckClientRequestStmt(MemCheckClientRequest.DO_LEAK_CHECK, 0, 1, 0, 0, 0);
+    doMemCheckClientRequestStmt(.DO_LEAK_CHECK, 0, 1, 0, 0, 0);
 }
 
 /// Same as doAddedLeakCheck() but showing entries with
 /// increased or decreased leaked bytes/blocks since previous leak
 /// search.
 pub fn doChangedLeakCheck() void {
-    doMemCheckClientRequestStmt(MemCheckClientRequest.DO_LEAK_CHECK, 0, 2, 0, 0, 0);
+    doMemCheckClientRequestStmt(.DO_LEAK_CHECK, 0, 2, 0, 0, 0);
 }
 
 /// Do a summary memory leak check (like --leak-check=summary) mid-execution.
 pub fn doQuickLeakCheck() void {
-    doMemCheckClientRequestStmt(MemCheckClientRequest.DO_LEAK_CHECK, 1, 0, 0, 0, 0);
+    doMemCheckClientRequestStmt(.DO_LEAK_CHECK, 1, 0, 0, 0, 0);
 }
 
 /// Return number of leaked, dubious, reachable and suppressed bytes found by
@@ -131,7 +131,7 @@ pub fn countLeaks() CountResult {
         .reachable = 0,
         .suppressed = 0,
     };
-    doMemCheckClientRequestStmt(MemCheckClientRequest.CountLeaks, &res.leaked, &res.dubious, &res.reachable, &res.suppressed, 0);
+    doMemCheckClientRequestStmt(.CountLeaks, &res.leaked, &res.dubious, &res.reachable, &res.suppressed, 0);
     return res;
 }
 
@@ -142,7 +142,7 @@ pub fn countLeakBlocks() CountResult {
         .reachable = 0,
         .suppressed = 0,
     };
-    doMemCheckClientRequestStmt(MemCheckClientRequest.CountLeakBlocks, &res.leaked, &res.dubious, &res.reachable, &res.suppressed, 0);
+    doMemCheckClientRequestStmt(.CountLeakBlocks, &res.leaked, &res.dubious, &res.reachable, &res.suppressed, 0);
     return res;
 }
 
@@ -156,7 +156,7 @@ pub fn countLeakBlocks() CountResult {
 /// impossible to segfault your system by using this call.
 pub fn getVbits(zza: []u8, zzvbits: []u8) u2 {
     std.debug.assert(zzvbits.len >= zza.len / 8);
-    return @intCast(u2, doMemCheckClientRequestExpr(0, MemCheckClientRequest.GetVbits, @ptrToInt(zza.ptr), @ptrToInt(zzvbits), zza.len, 0, 0));
+    return @intCast(u2, doMemCheckClientRequestExpr(0, .GetVbits, @ptrToInt(zza.ptr), @ptrToInt(zzvbits), zza.len, 0, 0));
 }
 
 /// Set the validity data for addresses zza, copying it
@@ -169,17 +169,17 @@ pub fn getVbits(zza: []u8, zzvbits: []u8) u2 {
 /// impossible to segfault your system by using this call.
 pub fn setVbits(zzvbits: []u8, zza: []u8) u2 {
     std.debug.assert(zzvbits.len >= zza.len / 8);
-    return @intCast(u2, doMemCheckClientRequestExpr(0, MemCheckClientRequest.SetVbits, @ptrToInt(zza.ptr), @ptrToInt(zzvbits), zza.len, 0, 0));
+    return @intCast(u2, doMemCheckClientRequestExpr(0, .SetVbits, @ptrToInt(zza.ptr), @ptrToInt(zzvbits), zza.len, 0, 0));
 }
 
 /// Disable and re-enable reporting of addressing errors in the
 /// specified address range.
 pub fn disableAddrErrorReportingInRange(qzz: []u8) usize {
     return doMemCheckClientRequestExpr(0, // default return
-        MemCheckClientRequest.DisableAddrErrorReportingInRange, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0);
+        .DisableAddrErrorReportingInRange, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0);
 }
 
 pub fn enableAddrErrorReportingInRange(qzz: []u8) usize {
     return doMemCheckClientRequestExpr(0, // default return
-        MemCheckClientRequest.EnableAddrErrorReportingInRange, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0);
+        .EnableAddrErrorReportingInRange, @ptrToInt(qzz.ptr), qzz.len, 0, 0, 0);
 }


### PR DESCRIPTION
The valgrind module didn't get updated when std got moved around; and has apparently not been used since array literals changed. With this PR the valgrind module now works again on master.