### PR TITLE
translate-c: add support for MacroQualified definitions

### DIFF
--- a/src-self-hosted/clang.zig
+++ b/src-self-hosted/clang.zig
@@ -42,6 +42,7 @@ pub const struct_ZigClangImplicitCastExpr = @OpaqueType();
 pub const struct_ZigClangIncompleteArrayType = @OpaqueType();
 pub const struct_ZigClangIntegerLiteral = @OpaqueType();
 pub const struct_ZigClangMacroDefinitionRecord = @OpaqueType();
+pub const struct_ZigClangMacroQualifiedType = @OpaqueType();
 pub const struct_ZigClangMemberExpr = @OpaqueType();
 pub const struct_ZigClangNamedDecl = @OpaqueType();
 pub const struct_ZigClangNone = @OpaqueType();
@@ -831,6 +832,7 @@ pub const ZigClangImplicitCastExpr = struct_ZigClangImplicitCastExpr;
 pub const ZigClangIncompleteArrayType = struct_ZigClangIncompleteArrayType;
 pub const ZigClangIntegerLiteral = struct_ZigClangIntegerLiteral;
 pub const ZigClangMacroDefinitionRecord = struct_ZigClangMacroDefinitionRecord;
+pub const ZigClangMacroQualifiedType = struct_ZigClangMacroQualifiedType;
 pub const ZigClangMemberExpr = struct_ZigClangMemberExpr;
 pub const ZigClangNamedDecl = struct_ZigClangNamedDecl;
 pub const ZigClangNone = struct_ZigClangNone;
@@ -936,6 +938,8 @@ pub extern fn ZigClangParenType_getInnerType(*const ZigClangParenType) ZigClangQ
 pub extern fn ZigClangElaboratedType_getNamedType(*const ZigClangElaboratedType) ZigClangQualType;
 
 pub extern fn ZigClangAttributedType_getEquivalentType(*const ZigClangAttributedType) ZigClangQualType;
+
+pub extern fn ZigClangMacroQualifiedType_getModifiedType(*const ZigClangMacroQualifiedType) ZigClangQualType;
 
 pub extern fn ZigClangCStyleCastExpr_getBeginLoc(*const ZigClangCStyleCastExpr) ZigClangSourceLocation;
 pub extern fn ZigClangCStyleCastExpr_getSubExpr(*const ZigClangCStyleCastExpr) *const ZigClangExpr;

--- a/src/translate_c.cpp
+++ b/src/translate_c.cpp
@@ -1213,6 +1213,11 @@ static AstNode *trans_type(Context *c, const ZigClangType *ty, ZigClangSourceLoc
                 const ZigClangAttributedType *attributed_ty = reinterpret_cast<const ZigClangAttributedType *>(ty);
                 return trans_qual_type(c, ZigClangAttributedType_getEquivalentType(attributed_ty), source_loc);
             }
+        case ZigClangType_MacroQualified:
+            {
+                const ZigClangMacroQualifiedType *macroqualified_ty = reinterpret_cast<const ZigClangMacroQualifiedType *>(ty);
+                return trans_qual_type(c, ZigClangMacroQualifiedType_getModifiedType(macroqualified_ty), source_loc);
+            }
         case ZigClangType_IncompleteArray:
             {
                 const ZigClangIncompleteArrayType *incomplete_array_ty = reinterpret_cast<const ZigClangIncompleteArrayType *>(ty);
@@ -1262,7 +1267,6 @@ static AstNode *trans_type(Context *c, const ZigClangType *ty, ZigClangSourceLoc
         case ZigClangType_DeducedTemplateSpecialization:
         case ZigClangType_DependentAddressSpace:
         case ZigClangType_DependentVector:
-        case ZigClangType_MacroQualified:
             emit_warning(c, source_loc, "unsupported type: '%s'", ZigClangType_getTypeClassName(ty));
             return nullptr;
     }

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2214,6 +2214,11 @@ struct ZigClangQualType ZigClangAttributedType_getEquivalentType(const struct Zi
     return bitcast(casted->getEquivalentType());
 }
 
+struct ZigClangQualType ZigClangMacroQualifiedType_getModifiedType(const struct ZigClangMacroQualifiedType *self) {
+    auto casted = reinterpret_cast<const clang::MacroQualifiedType *>(self);
+    return bitcast(casted->getModifiedType());
+}
+
 struct ZigClangQualType ZigClangElaboratedType_getNamedType(const struct ZigClangElaboratedType *self) {
     auto casted = reinterpret_cast<const clang::ElaboratedType *>(self);
     return bitcast(casted->getNamedType());

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -112,6 +112,7 @@ struct ZigClangImplicitCastExpr;
 struct ZigClangIncompleteArrayType;
 struct ZigClangIntegerLiteral;
 struct ZigClangMacroDefinitionRecord;
+struct ZigClangMacroQualifiedType;
 struct ZigClangMemberExpr;
 struct ZigClangNamedDecl;
 struct ZigClangNone;
@@ -1003,6 +1004,8 @@ ZIG_EXTERN_C const struct ZigClangNamedDecl *ZigClangDeclRefExpr_getFoundDecl(co
 ZIG_EXTERN_C struct ZigClangQualType ZigClangParenType_getInnerType(const struct ZigClangParenType *);
 
 ZIG_EXTERN_C struct ZigClangQualType ZigClangAttributedType_getEquivalentType(const struct ZigClangAttributedType *);
+
+ZIG_EXTERN_C struct ZigClangQualType ZigClangMacroQualifiedType_getModifiedType(const struct ZigClangMacroQualifiedType *);
 
 ZIG_EXTERN_C struct ZigClangQualType ZigClangElaboratedType_getNamedType(const struct ZigClangElaboratedType *);
 ZIG_EXTERN_C enum ZigClangElaboratedTypeKeyword ZigClangElaboratedType_getKeyword(const struct ZigClangElaboratedType *);

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1814,6 +1814,15 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\
     );
 
+    if (builtin.os != builtin.Os.windows) {
+        // sysv_abi not currently supported on windows
+        cases.add("Macro qualified functions",
+            \\void __attribute__((sysv_abi)) foo(void);
+        ,
+            \\pub extern fn foo() void;
+        );
+    }
+
     /////////////// Cases for only stage1 because stage2 behavior is better ////////////////
     cases.addC("Parameterless function prototypes",
         \\void foo() {}


### PR DESCRIPTION
@gruebite hit the TODO when importing [Godot](https://github.com/GodotNativeTools/godot_headers/blob/4fa11f8c2a8029df7d6f30904297afcb42c4906c/gdnative/gdnative.h#L51-L52)
