### PR TITLE
Optimize binary search algorithm

### DIFF
--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -868,39 +868,35 @@ fn findLastBackward(comptime T: type, items: []T, value: T, range: Range, lessTh
 }
 
 fn binaryFirst(comptime T: type, items: []T, value: T, range: Range, lessThan: fn (T, T) bool) usize {
-    var start = range.start;
-    var end = range.end - 1;
+    var curr = range.start;
+    var size = range.length();
     if (range.start >= range.end) return range.end;
-    while (start < end) {
-        const mid = start + (end - start) / 2;
-        if (lessThan(items[mid], value)) {
-            start = mid + 1;
-        } else {
-            end = mid;
+    while (size > 0) {
+        const offset = size % 2;
+
+        size /= 2;
+        const mid = items[curr + size];
+        if (lessThan(mid, value)) {
+            curr += size + offset;
         }
     }
-    if (start == range.end - 1 and lessThan(items[start], value)) {
-        start += 1;
-    }
-    return start;
+    return curr;
 }
 
 fn binaryLast(comptime T: type, items: []T, value: T, range: Range, lessThan: fn (T, T) bool) usize {
-    var start = range.start;
-    var end = range.end - 1;
+    var curr = range.start;
+    var size = range.length();
     if (range.start >= range.end) return range.end;
-    while (start < end) {
-        const mid = start + (end - start) / 2;
-        if (!lessThan(value, items[mid])) {
-            start = mid + 1;
-        } else {
-            end = mid;
+    while (size > 0) {
+        const offset = size % 2;
+
+        size /= 2;
+        const mid = items[curr + size];
+        if (!lessThan(value, mid)) {
+            curr += size + offset;
         }
     }
-    if (start == range.end - 1 and !lessThan(value, items[start])) {
-        start += 1;
-    }
-    return start;
+    return curr;
 }
 
 fn mergeInto(comptime T: type, from: []T, A: Range, B: Range, lessThan: fn (T, T) bool, into: []T) void {


### PR DESCRIPTION
### [Assembly result](https://godbolt.org/z/V6hGQ-)
- slightly tightens the loop
- merges 2 loop points to 1 jump
- "removes" cleanup — now part of the last loop iteration

### [Benchmarks](https://github.com/fengb/zig-sorts/tree/std-sort-improvements) using std.sort:

| MacBook Pro | std.sort (µs) | updated bsearch (µs) |
|:--- | ---:| ---:|
| presorted | 46.8 | 44.4 |
| mostly sorted | 305.4 | 267.7 |
| trending data | 423.0 | 366.8 |
| reversed | 165.3 | 137.6 |
| random | 560.4 | 510.6 |
| 10x data |  5738.3 | 4965.4 |

| Celeron / Linux  | std.sort (µs) | updated bsearch (µs) |
|:--- | ---:| ---:|
| presorted | 186.9 | 183.7 |
| mostly sorted | 905.3 | 807.4 |
| trending data | 977.8 | 839.9 |
| reversed | 653.9 | 547.0 |
| random | 1281.1 | 1154.6 |
| 10x data | 15060.1 | 12489.2 |