### PR TITLE
Wasi run tests

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1064,6 +1064,9 @@ pub const LibExeObjStep = struct {
     /// Uses system QEMU installation to run cross compiled foreign architecture build artifacts.
     enable_qemu: bool = false,
 
+    /// Uses system Wasmtime installation to run cross compiled wasm/wasi build artifacts.
+    enable_wasmtime: bool = false,
+
     /// After following the steps in https://github.com/ziglang/zig/wiki/Updating-libc#glibc,
     /// this will be the directory $glibc-build-dir/install/glibcs
     /// Given the example of the aarch64 target, this is the directory
@@ -1859,6 +1862,11 @@ pub const LibExeObjStep = struct {
                 try zig_args.append("--test-cmd-bin");
             },
             .wine => |bin_name| if (self.enable_wine) {
+                try zig_args.append("--test-cmd");
+                try zig_args.append(bin_name);
+                try zig_args.append("--test-cmd-bin");
+            },
+            .wasmtime => |bin_name| if (self.enable_wasmtime) {
                 try zig_args.append("--test-cmd");
                 try zig_args.append(bin_name);
                 try zig_args.append("--test-cmd-bin");

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -213,7 +213,8 @@ pub fn assert(ok: bool) void {
 
 pub fn panic(comptime format: []const u8, args: ...) noreturn {
     @setCold(true);
-    const first_trace_addr = @returnAddress();
+    // TODO: remove conditional once wasi / LLVM defines __builtin_return_address
+    const first_trace_addr = if (builtin.os == .wasi) null else @returnAddress();
     panicExtra(null, first_trace_addr, format, args);
 }
 

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -33,7 +33,7 @@ fn cShrink(self: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new
 
 /// This allocator makes a syscall directly for every allocation and free.
 /// Thread-safe and lock-free.
-pub const direct_allocator = &direct_allocator_state;
+pub const direct_allocator = if (builtin.arch == .wasm32) wasm_allocator else &direct_allocator_state;
 var direct_allocator_state = Allocator{
     .reallocFn = DirectAllocator.realloc,
     .shrinkFn = DirectAllocator.shrink,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1522,7 +1522,7 @@ pub fn isatty(handle: fd_t) bool {
         return system.isatty(handle) != 0;
     }
     if (builtin.os == .wasi) {
-        @compileError("TODO implement std.os.isatty for WASI");
+        return system.isatty(handle);
     }
     if (builtin.os == .linux) {
         var wsz: linux.winsize = undefined;

--- a/lib/std/os/bits/wasi.zig
+++ b/lib/std/os/bits/wasi.zig
@@ -138,7 +138,7 @@ pub const FDFLAG_NONBLOCK: fdflags_t = 0x0004;
 pub const FDFLAG_RSYNC: fdflags_t = 0x0008;
 pub const FDFLAG_SYNC: fdflags_t = 0x0010;
 
-const fdstat_t = extern struct {
+pub const fdstat_t = extern struct {
     fs_filetype: filetype_t,
     fs_flags: fdflags_t,
     fs_rights_base: rights_t,

--- a/lib/std/os/bits/wasi.zig
+++ b/lib/std/os/bits/wasi.zig
@@ -298,6 +298,7 @@ pub const subscription_t = extern struct {
 };
 
 pub const timestamp_t = u64;
+pub const time_t = i64; // match https://github.com/CraneStation/wasi-libc
 
 pub const userdata_t = u64;
 
@@ -305,3 +306,8 @@ pub const whence_t = u8;
 pub const WHENCE_CUR: whence_t = 0;
 pub const WHENCE_END: whence_t = 1;
 pub const WHENCE_SET: whence_t = 2;
+
+pub const timespec = extern struct {
+    tv_sec: time_t,
+    tv_nsec: isize,
+};

--- a/lib/std/os/wasi.zig
+++ b/lib/std/os/wasi.zig
@@ -90,8 +90,8 @@ pub fn clock_getres(clock_id: i32, res: *timespec) errno_t {
         return err;
     }
     res.* = .{
-        .tv_sec = @intCast(i64, ts / 1000000000),
-        .tv_nsec = @intCast(isize, ts % 1000000000),
+        .tv_sec = @intCast(i64, ts / std.time.ns_per_s),
+        .tv_nsec = @intCast(isize, ts % std.time.ns_per_s),
     };
     return 0;
 }
@@ -103,8 +103,8 @@ pub fn clock_gettime(clock_id: i32, tp: *timespec) errno_t {
         return err;
     }
     tp.* = .{
-        .tv_sec = @intCast(i64, ts / 1000000000),
-        .tv_nsec = @intCast(isize, ts % 1000000000),
+        .tv_sec = @intCast(i64, ts / std.time.ns_per_s),
+        .tv_nsec = @intCast(isize, ts % std.time.ns_per_s),
     };
     return 0;
 }

--- a/lib/std/os/wasi.zig
+++ b/lib/std/os/wasi.zig
@@ -108,3 +108,22 @@ pub fn clock_gettime(clock_id: i32, tp: *timespec) errno_t {
     };
     return 0;
 }
+
+pub fn isatty(fd: fd_t) bool {
+    var statbuf: fdstat_t = undefined;
+    const err = fd_fdstat_get(fd, &statbuf);
+    if (err != 0) {
+        // errno = err;
+        return false;
+    }
+
+    // A tty is a character device that we can't seek or tell on.
+    if (statbuf.fs_filetype != FILETYPE_CHARACTER_DEVICE or
+        (statbuf.fs_rights_base & (RIGHT_FD_SEEK | RIGHT_FD_TELL)) != 0)
+    {
+        // errno = ENOTTY;
+        return false;
+    }
+
+    return true;
+}

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -611,6 +611,7 @@ pub const Target = union(enum) {
         native,
         qemu: []const u8,
         wine: []const u8,
+        wasmtime: []const u8,
         unavailable,
     };
 
@@ -645,6 +646,13 @@ pub const Target = union(enum) {
             switch (self.getArchPtrBitWidth()) {
                 32 => return Executor{ .wine = "wine" },
                 64 => return Executor{ .wine = "wine64" },
+                else => return .unavailable,
+            }
+        }
+
+        if (self.isWasm()) {
+            switch (self.getArchPtrBitWidth()) {
+                32 => return Executor{ .wasmtime = "wasmtime" },
                 else => return .unavailable,
             }
         }


### PR DESCRIPTION
This patches in some missing functionality into `std.os.wasi` to get tests compiling and running.

```
$ zig test prototypes/wavesynth/src/main.zig -target wasm32-wasi --test-cmd wasmtime --test-cmd-bin
1/3 test "Note.parse"...OK
2/3 test "Note.toFreq"...OK
3/3 test "Note.format"...OK
All tests passed.
```