### PR TITLE
@floatCast for vectors, and allow safe casts from non-comptime integers.

### DIFF
--- a/test/stage1/behavior/cast.zig
+++ b/test/stage1/behavior/cast.zig
@@ -331,6 +331,46 @@ test "@intCast comptime_int" {
     expect(result == 1234);
 }
 
+test "@intCast of vector" {
+    const S = struct {
+        fn doTheTest() void {
+            var v: @Vector(8, u8) = [_]u8{0, 1, 2, 3, 4, 5, 6, 7};
+            var w = @intCast(u16, v);
+            comptime var i: usize = 0;
+            inline while (i < 8) : (i += 1) {
+                expect(w[i] == i);
+            }
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
+test "@floatCast of vector" {
+    const S = struct {
+        fn doTheTest() void {
+            {
+                var v: @Vector(8, f16) = [_]f16{0, 1, 2, 3, 4, 5, 6, 7};
+                var w = @floatCast(f32, v);
+                comptime var i: f32 = 0;
+                inline while (i < 8) : (i += 1) {
+                    expect(w[i] == i);
+                }
+            }
+            {
+                var v: @Vector(8, u16) = [_]u16{0, 1, 2, 3, 4, 5, 6, 7};
+                var w = @floatCast(f32, v);
+                comptime var i: f32 = 0;
+                inline while (i < 8) : (i += 1) {
+                    expect(w[i] == i);
+                }
+            }
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
 test "@floatCast comptime_int and comptime_float" {
     {
         const result = @floatCast(f16, 1234);


### PR DESCRIPTION
If the integer fits in the significand (including the signed bit because of a edge
case resulting from the difference between twos-complement and ones-complement),
then cast to float is lossless.

----

There is some overlap here between `@floatCast` and `@intToFloat`, the difference being that if this converts from int it must be lossless.