### PR TITLE
std: update for linux 5.4

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1114,10 +1114,16 @@ pub const io_uring_params = extern struct {
     flags: u32,
     sq_thread_cpu: u32,
     sq_thread_idle: u32,
-    resv: [5]u32,
+    features: u32,
+    resv: [4]u32,
     sq_off: io_sqring_offsets,
     cq_off: io_cqring_offsets,
 };
+
+// io_uring_params.features flags
+
+pub const IORING_FEAT_SINGLE_MMAP = 1 << 0;
+
 
 // io_uring_params.flags
 
@@ -1185,6 +1191,7 @@ pub const io_uring_sqe = extern struct {
         poll_events: u16,
         sync_range_flags: u32,
         msg_flags: u32,
+        timeout_flags: u32,
     };
     union1: union1,
     user_data: u64,
@@ -1217,6 +1224,7 @@ pub const IORING_OP_POLL_REMOVE = 7;
 pub const IORING_OP_SYNC_FILE_RANGE = 8;
 pub const IORING_OP_SENDMSG = 9;
 pub const IORING_OP_RECVMSG = 10;
+pub const IORING_OP_TIMEOUT = 11;
 
 // io_uring_sqe.fsync_flags
 pub const IORING_FSYNC_DATASYNC = (1 << 0);


### PR DESCRIPTION
It's almost linux release time again.

PR created by running `git log -p v5.3..v5.4-rc8 -- include/uapi arch/*/include/uapi` and checking for differences in defines that I remember we've brought into the standard library.