### PR TITLE
Fix FixedSizeFifo buffer type

### DIFF
--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -12,7 +12,7 @@ const testing = std.testing;
 pub fn FixedSizeFifo(comptime T: type) type {
     return struct {
         allocator: *Allocator,
-        buf: []u8,
+        buf: []T,
         head: usize,
         count: usize,
 


### PR DESCRIPTION
I assume that this was a simple oversight where the tests only completed successfully due to the type coincidentally being `u8`.