### PR TITLE
Use fifo from std.io

### DIFF
--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -198,7 +198,7 @@ test "io.BufferedInStream" {
 
 /// Creates a stream which supports 'un-reading' data, so that it can be read again.
 /// This makes look-ahead style parsing much easier.
-pub fn PeekStream(comptime buffer_size: usize, comptime InStreamError: type) type {
+pub fn PeekStream(comptime buffer_type: usize, comptime InStreamError: type) type {
     return struct {
         const Self = @This();
         pub const Error = InStreamError;
@@ -209,55 +209,35 @@ pub fn PeekStream(comptime buffer_size: usize, comptime InStreamError: type) typ
 
         // Right now the look-ahead space is statically allocated, but a version with dynamic allocation
         // is not too difficult to derive from this.
-        buffer: [buffer_size]u8,
-        index: usize,
-        at_end: bool,
+        const FifoType = std.fifo.LinearFifo(u8, .{ .Static = buffer_size });
+        fifo: FifoType,
 
         pub fn init(base: *Stream) Self {
-            return Self{
+            return .{
                 .base = base,
-                .buffer = undefined,
-                .index = 0,
-                .at_end = false,
+                .fifo = FifoType.init(),
                 .stream = Stream{ .readFn = readFn },
             };
         }
 
-        pub fn putBackByte(self: *Self, byte: u8) void {
-            self.buffer[self.index] = byte;
-            self.index += 1;
+        pub fn putBackByte(self: *Self, byte: u8) !void {
+            try self.putBack(@ptrCast([*]const u8, &byte)[0..1]);
         }
 
-        pub fn putBack(self: *Self, bytes: []const u8) void {
-            var pos = bytes.len;
-            while (pos != 0) {
-                pos -= 1;
-                self.putBackByte(bytes[pos]);
-            }
+        pub fn putBack(self: *Self, bytes: []const u8) !void {
+            try self.fifo.unget(bytes);
         }
 
         fn readFn(in_stream: *Stream, dest: []u8) Error!usize {
             const self = @fieldParentPtr(Self, "stream", in_stream);
 
             // copy over anything putBack()'d
-            var pos: usize = 0;
-            while (pos < dest.len and self.index != 0) {
-                dest[pos] = self.buffer[self.index - 1];
-                self.index -= 1;
-                pos += 1;
-            }
-
-            if (pos == dest.len or self.at_end) {
-                return pos;
-            }
+            var dest_index = self.fifo.read(dest);
+            if (dest_index == dest.len) return dest_index;
 
             // ask the backing stream for more
-            const left = dest.len - pos;
-            const read = try self.base.read(dest[pos..]);
-            assert(read <= left);
-
-            self.at_end = (read < left);
-            return pos + read;
+            dest_index += try self.base.read(dest[dest_index..]);
+            return dest_index;
         }
     };
 }

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -570,52 +570,33 @@ pub fn BufferedOutStreamCustom(comptime buffer_size: usize, comptime OutStreamEr
 
         unbuffered_out_stream: *Stream,
 
-        buffer: [buffer_size]u8,
-        index: usize,
+        const FifoType = std.fifo.LinearFifo(u8, std.fifo.LinearFifoBufferType{ .Static = buffer_size });
+        fifo: FifoType,
 
         pub fn init(unbuffered_out_stream: *Stream) Self {
             return Self{
                 .unbuffered_out_stream = unbuffered_out_stream,
-                .buffer = undefined,
-                .index = 0,
+                .fifo = FifoType.init(),
                 .stream = Stream{ .writeFn = writeFn },
             };
         }
 
         pub fn flush(self: *Self) !void {
-            try self.unbuffered_out_stream.write(self.buffer[0..self.index]);
-            self.index = 0;
+            while (true) {
+                const slice = self.fifo.readableSlice(0);
+                if (slice.len == 0) break;
+                try self.unbuffered_out_stream.write(slice);
+                self.fifo.discard(slice.len);
+            }
         }
 
         fn writeFn(out_stream: *Stream, bytes: []const u8) Error!void {
             const self = @fieldParentPtr(Self, "stream", out_stream);
-
-            if (bytes.len == 1) {
-                // This is not required logic but a shorter path
-                // for single byte writes
-                self.buffer[self.index] = bytes[0];
-                self.index += 1;
-                if (self.index == buffer_size) {
-                    try self.flush();
-                }
-                return;
-            } else if (bytes.len >= self.buffer.len) {
+            if (bytes.len >= self.fifo.writableLength()) {
                 try self.flush();
                 return self.unbuffered_out_stream.write(bytes);
             }
-            var src_index: usize = 0;
-
-            while (src_index < bytes.len) {
-                const dest_space_left = self.buffer.len - self.index;
-                const copy_amt = math.min(dest_space_left, bytes.len - src_index);
-                mem.copy(u8, self.buffer[self.index..], bytes[src_index .. src_index + copy_amt]);
-                self.index += copy_amt;
-                assert(self.index <= self.buffer.len);
-                if (self.index == self.buffer.len) {
-                    try self.flush();
-                }
-                src_index += copy_amt;
-            }
+            self.fifo.writeAssumeCapacity(bytes);
         }
     };
 }

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -102,8 +102,8 @@ test "PeekStream" {
 
     var dest: [4]u8 = undefined;
 
-    ps.putBackByte(9);
-    ps.putBackByte(10);
+    try ps.putBackByte(9);
+    try ps.putBackByte(10);
 
     var read = try ps.stream.read(dest[0..4]);
     expect(read == 4);
@@ -119,8 +119,8 @@ test "PeekStream" {
     expect(read == 2);
     expect(mem.eql(u8, dest[0..2], bytes[6..8]));
 
-    ps.putBackByte(11);
-    ps.putBackByte(12);
+    try ps.putBackByte(11);
+    try ps.putBackByte(12);
 
     read = try ps.stream.read(dest[0..4]);
     expect(read == 2);

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -5,6 +5,7 @@ const meta = std.meta;
 const trait = std.trait;
 const DefaultPrng = std.rand.DefaultPrng;
 const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
 const expectError = std.testing.expectError;
 const mem = std.mem;
 const fs = std.fs;
@@ -47,8 +48,8 @@ test "write a file, read it, then delete it" {
         defer file.close();
 
         const file_size = try file.getEndPos();
-        const expected_file_size = "begin".len + data.len + "end".len;
-        expect(file_size == expected_file_size);
+        const expected_file_size: u64 = "begin".len + data.len + "end".len;
+        expectEqual(expected_file_size, file_size);
 
         var file_in_stream = file.inStream();
         var buf_stream = io.BufferedInStream(File.ReadError).init(&file_in_stream.stream);

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -98,7 +98,7 @@ test "SliceInStream" {
 test "PeekStream" {
     const bytes = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
     var ss = io.SliceInStream.init(&bytes);
-    var ps = io.PeekStream(2, io.SliceInStream.Error).init(&ss.stream);
+    var ps = io.PeekStream(.{ .Static = 2 }, io.SliceInStream.Error).init(&ss.stream);
 
     var dest: [4]u8 = undefined;
 


### PR DESCRIPTION
These were the pieces pulled out of #3644

They add some usages of `std.fifo.LinearFifo` to `std.io` replacing other home-grown buffering techniques. This PR is mainly a code deduplication.

  - use `LinearFifo` to implement `io.BufferedInStreamCustom`
  - use `LinearFifo` to implement `io.PeekStream`
  - let `PeekStream` have static/dynamic variants (this implements an outstanding TODO)
  - use `LinearFifo` to implement `io.BufferedOutStreamCustom`