### PR TITLE
Add initCapacity for buffer & arraylist

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -40,6 +40,14 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
                 .allocator = allocator,
             };
         }
+        
+        /// Initialize with capacity to hold at least num elements.
+        /// Deinitialize with `deinit` or use `toOwnedSlice`.
+        pub fn initCapacity(allocator: *Allocator, num: usize) !Self {
+            var self = Self.init(allocator);
+            try self.ensureCapacity(num);
+            return self;
+        }
 
         /// Release all allocated memory.
         pub fn deinit(self: Self) void {
@@ -269,6 +277,15 @@ test "std.ArrayList.init" {
 
     testing.expect(list.count() == 0);
     testing.expect(list.capacity() == 0);
+}
+
+test "std.ArrayList.initCapacity" {
+    var bytes: [1024]u8 = undefined;
+    const allocator = &std.heap.FixedBufferAllocator.init(bytes[0..]).allocator;
+    var list = try ArrayList(i8).initCapacity(allocator, 200);
+    defer list.deinit();
+    testing.expect(list.count() == 0);
+    testing.expect(list.capacity() >= 200);
 }
 
 test "std.ArrayList.basic" {

--- a/lib/std/buffer.zig
+++ b/lib/std/buffer.zig
@@ -16,11 +16,20 @@ pub const Buffer = struct {
         mem.copy(u8, self.list.items, m);
         return self;
     }
-
+    
+    /// Initialize memory to size bytes of undefined values.
     /// Must deinitialize with deinit.
     pub fn initSize(allocator: *Allocator, size: usize) !Buffer {
         var self = initNull(allocator);
         try self.resize(size);
+        return self;
+    }
+    
+    /// Initialize with capacity to hold at least num bytes.
+    /// Must deinitialize with deinit.
+    pub fn initCapacity(allocator: *Allocator, num: usize) !Buffer {
+        var self = Buffer{ .list = try ArrayList(u8).initCapacity(allocator, num + 1) };
+        self.list.appendAssumeCapacity(0);
         return self;
     }
 
@@ -98,6 +107,13 @@ pub const Buffer = struct {
     pub fn len(self: Buffer) usize {
         return self.list.len - 1;
     }
+    
+    pub fn capacity(self: Buffer) usize {
+        return if (self.list.items.len > 0)
+            self.list.items.len - 1
+        else
+            0;
+    }
 
     pub fn append(self: *Buffer, m: []const u8) !void {
         const old_len = self.len();
@@ -155,4 +171,22 @@ test "simple Buffer" {
 
     try buf2.resize(4);
     testing.expect(buf.startsWith(buf2.toSlice()));
+}
+
+test "Buffer.initSize" {
+    var buf = try Buffer.initSize(debug.global_allocator, 3);
+    testing.expect(buf.len() == 3);
+    try buf.append("hello");
+    testing.expect(mem.eql(u8, buf.toSliceConst()[3..], "hello"));
+}
+
+test "Buffer.initCapacity" {
+    var buf = try Buffer.initCapacity(debug.global_allocator, 10);
+    testing.expect(buf.len() == 0);
+    testing.expect(buf.capacity() >= 10);
+    const old_cap = buf.capacity();
+    try buf.append("hello");
+    testing.expect(buf.len() == 5);
+    testing.expect(buf.capacity() == old_cap);
+    testing.expect(mem.eql(u8, buf.toSliceConst(), "hello"));
 }


### PR DESCRIPTION
Allows preallocation of ArrayList and Buffer at initialization to reduce future allocations.

All in all, adds:
- pub fn ArrayList.initCapacity(*Allocator,usize) !Self
- test "std.ArrayList.initCapacity"
- pub fn Buffer.initCapacity(*Allocator,usize) !Buffer
- pub fn Buffer.capacity() usize (returns 0 when list capacity is 0 instead of neg overflow, otherwise returns list capacity - 1)
- test "Buffer.initSize"
- test "Buffer.initCapacity"

And thanks to mikdusan for help with this.

Fixes #3740 