### PR TITLE
stage1: consolodate interning

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2021,12 +2021,19 @@ struct CodeGen {
         ZigType *entry_any_frame;
     } builtin_types;
 
-    struct {
+    struct Intern {
         ZigValue x_undefined;
         ZigValue x_void;
         ZigValue x_null;
         ZigValue x_unreachable;
-    } intern_values;
+        ZigValue zero_byte;
+
+        ZigValue *for_undefined();
+        ZigValue *for_void();
+        ZigValue *for_null();
+        ZigValue *for_unreachable();
+        ZigValue *for_zero_byte();
+    } intern;
 
     ZigType *align_amt_type;
     ZigType *stack_trace_type;
@@ -2050,8 +2057,6 @@ struct CodeGen {
     IrInstruction *invalid_instruction;
     IrInstruction *unreach_instruction;
 
-    ZigValue const_zero_byte;
-    ZigValue const_void_val;
     ZigValue panic_msg_vals[PanicMsgIdCount];
 
     // The function definitions this module includes.

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5647,7 +5647,7 @@ void init_const_str_lit(CodeGen *g, ZigValue *const_val, Buf *str) {
     // first we build the underlying array
     ZigValue *array_val = create_const_vals(1);
     array_val->special = ConstValSpecialStatic;
-    array_val->type = get_array_type(g, g->builtin_types.entry_u8, buf_len(str), &g->const_zero_byte);
+    array_val->type = get_array_type(g, g->builtin_types.entry_u8, buf_len(str), g->intern.for_zero_byte());
     array_val->data.x_array.special = ConstArraySpecialBuf;
     array_val->data.x_array.data.s_buf = str;
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8010,28 +8010,35 @@ static void define_builtin_types(CodeGen *g) {
 
 static void define_intern_values(CodeGen *g) {
     {
-        auto& value = g->intern_values.x_undefined;
+        auto& value = g->intern.x_undefined;
         value.type = g->builtin_types.entry_undef;
         value.global_refs = allocate<ConstGlobalRefs>(1, "ConstGlobalRefs.undefined");
         value.special = ConstValSpecialStatic;
     }
     {
-        auto& value = g->intern_values.x_void;
+        auto& value = g->intern.x_void;
         value.type = g->builtin_types.entry_void;
         value.global_refs = allocate<ConstGlobalRefs>(1, "ConstGlobalRefs.void");
         value.special = ConstValSpecialStatic;
     }
     {
-        auto& value = g->intern_values.x_null;
+        auto& value = g->intern.x_null;
         value.type = g->builtin_types.entry_null;
         value.global_refs = allocate<ConstGlobalRefs>(1, "ConstGlobalRefs.null");
         value.special = ConstValSpecialStatic;
     }
     {
-        auto& value = g->intern_values.x_unreachable;
+        auto& value = g->intern.x_unreachable;
         value.type = g->builtin_types.entry_unreachable;
         value.global_refs = allocate<ConstGlobalRefs>(1, "ConstGlobalRefs.unreachable");
         value.special = ConstValSpecialStatic;
+    }
+    {
+        auto& value = g->intern.zero_byte;
+        value.type = g->builtin_types.entry_u8;
+        value.global_refs = allocate<ConstGlobalRefs>(1, "ConstGlobalRefs.zero_byte");
+        value.special = ConstValSpecialStatic;
+        bigint_init_unsigned(&value.data.x_bigint, 0);
     }
 }
 
@@ -8668,15 +8675,6 @@ static void init(CodeGen *g) {
     g->unreach_instruction->value = allocate<ZigValue>(1, "ZigValue");
     g->unreach_instruction->value->type = g->builtin_types.entry_unreachable;
     g->unreach_instruction->value->global_refs = allocate<ConstGlobalRefs>(1);
-
-    g->const_void_val.special = ConstValSpecialStatic;
-    g->const_void_val.type = g->builtin_types.entry_void;
-    g->const_void_val.global_refs = allocate<ConstGlobalRefs>(1);
-
-    g->const_zero_byte.special = ConstValSpecialStatic;
-    g->const_zero_byte.type = g->builtin_types.entry_u8;
-    g->const_zero_byte.global_refs = allocate<ConstGlobalRefs>(1);
-    bigint_init_unsigned(&g->const_zero_byte.data.x_bigint, 0);
 
     {
         ConstGlobalRefs *global_refs = allocate<ConstGlobalRefs>(PanicMsgIdCount);
@@ -10563,4 +10561,39 @@ void codegen_switch_sub_prog_node(CodeGen *g, Stage2ProgressNode *node) {
         stage2_progress_end(g->sub_progress_node);
     }
     g->sub_progress_node = node;
+}
+
+ZigValue *CodeGen::Intern::for_undefined() {
+#ifdef ZIG_ENABLE_MEM_PROFILE
+    memprof_intern_count.x_undefined += 1;
+#endif
+    return &this->x_undefined;
+}
+
+ZigValue *CodeGen::Intern::for_void() {
+#ifdef ZIG_ENABLE_MEM_PROFILE
+    memprof_intern_count.x_void += 1;
+#endif
+    return &this->x_void;
+}
+
+ZigValue *CodeGen::Intern::for_null() {
+#ifdef ZIG_ENABLE_MEM_PROFILE
+    memprof_intern_count.x_null += 1;
+#endif
+    return &this->x_null;
+}
+
+ZigValue *CodeGen::Intern::for_unreachable() {
+#ifdef ZIG_ENABLE_MEM_PROFILE
+    memprof_intern_count.x_unreachable += 1;
+#endif
+    return &this->x_unreachable;
+}
+
+ZigValue *CodeGen::Intern::for_zero_byte() {
+#ifdef ZIG_ENABLE_MEM_PROFILE
+    memprof_intern_count.zero_byte += 1;
+#endif
+    return &this->zero_byte;
 }

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -1235,7 +1235,7 @@ static IrInstruction *ir_build_const_void(IrBuilder *irb, Scope *scope, AstNode 
 #endif
     IrInstructionConst *const_instruction = ir_create_instruction_noval<IrInstructionConst>(irb, scope, source_node);
     ir_instruction_append(irb->current_basic_block, &const_instruction->base);
-    const_instruction->base.value = &irb->codegen->intern_values.x_void;
+    const_instruction->base.value = irb->codegen->intern.for_void();
     return &const_instruction->base;
 }
 
@@ -1245,7 +1245,7 @@ static IrInstruction *ir_build_const_undefined(IrBuilder *irb, Scope *scope, Ast
 #endif
     IrInstructionConst *const_instruction = ir_create_instruction_noval<IrInstructionConst>(irb, scope, source_node);
     ir_instruction_append(irb->current_basic_block, &const_instruction->base);
-    const_instruction->base.value = &irb->codegen->intern_values.x_undefined;
+    const_instruction->base.value = irb->codegen->intern.for_undefined();
     return &const_instruction->base;
 }
 
@@ -1279,7 +1279,7 @@ static IrInstruction *ir_build_const_null(IrBuilder *irb, Scope *scope, AstNode 
 #endif
     IrInstructionConst *const_instruction = ir_create_instruction_noval<IrInstructionConst>(irb, scope, source_node);
     ir_instruction_append(irb->current_basic_block, &const_instruction->base);
-    const_instruction->base.value = &irb->codegen->intern_values.x_null;
+    const_instruction->base.value = irb->codegen->intern.for_null();
     return &const_instruction->base;
 }
 
@@ -11464,7 +11464,7 @@ static IrInstruction *ir_const_unreachable(IrAnalyze *ira, IrInstruction *source
     memprof_intern_count.x_unreachable += 1;
 #endif
     IrInstruction *result = ir_const_noval(ira, source_instruction);
-    result->value = &ira->codegen->intern_values.x_unreachable;
+    result->value = ira->codegen->intern.for_unreachable();
     return result;
 }
 
@@ -11473,7 +11473,7 @@ static IrInstruction *ir_const_void(IrAnalyze *ira, IrInstruction *source_instru
     memprof_intern_count.x_void += 1;
 #endif
     IrInstruction *result = ir_const_noval(ira, source_instruction);
-    result->value = &ira->codegen->intern_values.x_void;
+    result->value = ira->codegen->intern.for_void();
     return result;
 }
 
@@ -18493,7 +18493,7 @@ static IrInstruction *ir_analyze_instruction_elem_ptr(IrAnalyze *ira, IrInstruct
         if (var) {
             return ir_get_var_ptr(ira, &elem_ptr_instruction->base, var);
         } else {
-            return ir_get_const_ptr(ira, &elem_ptr_instruction->base, &ira->codegen->const_void_val,
+            return ir_get_const_ptr(ira, &elem_ptr_instruction->base, ira->codegen->intern.for_void(),
                     ira->codegen->builtin_types.entry_void, ConstPtrMutComptimeConst, is_const, is_volatile, 0);
         }
     } else if (array_type->id == ZigTypeIdVector) {
@@ -21856,7 +21856,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, IrInstruction *source_instr
         case ZigTypeIdNull:
         case ZigTypeIdArgTuple:
         case ZigTypeIdOpaque:
-            result = &ira->codegen->const_void_val;
+            result = ira->codegen->intern.for_void();
             break;
         case ZigTypeIdInt:
             {

--- a/src/memory_profiling.cpp
+++ b/src/memory_profiling.cpp
@@ -141,6 +141,7 @@ void memprof_dump_stats(FILE *file) {
     fprintf(stderr, "void: interned %zu times\n", memprof_intern_count.x_void);
     fprintf(stderr, "null: interned %zu times\n", memprof_intern_count.x_null);
     fprintf(stderr, "unreachable: interned %zu times\n", memprof_intern_count.x_unreachable);
+    fprintf(stderr, "zero_byte: interned %zu times\n", memprof_intern_count.zero_byte);
 }
 
 #endif

--- a/src/memory_profiling.hpp
+++ b/src/memory_profiling.hpp
@@ -18,6 +18,7 @@ struct MemprofInternCount {
     size_t x_void;
     size_t x_null;
     size_t x_unreachable;
+    size_t zero_byte;
 };
 extern MemprofInternCount memprof_intern_count;
 


### PR DESCRIPTION
- merge const_void_val → intern_values.x_void
- move const_zero_byte → intern_values.zero_byte
- wrap intern access

#### BEFORE
```
undefined: interned 3124 times
void: interned 3973372 times
null: interned 3533 times
unreachable: interned 5344 times
```

#### AFTER
```
undefined: interned 6256 times
void: interned 7948434 times
null: interned 7062 times
unreachable: interned 10686 times
zero_byte: interned 6601 times
```