### PR TITLE
Turn std.rand.Random into a Mixin

### DIFF
--- a/lib/std/atomic/queue.zig
+++ b/lib/std/atomic/queue.zig
@@ -225,7 +225,7 @@ fn startPuts(ctx: *Context) u8 {
     var r = std.rand.DefaultPrng.init(0xdeadbeef);
     while (put_count != 0) : (put_count -= 1) {
         std.time.sleep(1); // let the os scheduler be our fuzz
-        const x = @bitCast(i32, r.random.scalar(u32));
+        const x = r.random.int(i32);
         const node = ctx.allocator.create(Queue(i32).Node) catch unreachable;
         node.* = Queue(i32).Node{
             .prev = undefined,

--- a/lib/std/atomic/queue.zig
+++ b/lib/std/atomic/queue.zig
@@ -225,7 +225,7 @@ fn startPuts(ctx: *Context) u8 {
     var r = std.rand.DefaultPrng.init(0xdeadbeef);
     while (put_count != 0) : (put_count -= 1) {
         std.time.sleep(1); // let the os scheduler be our fuzz
-        const x = r.random.int(i32);
+        const x = r.int(i32);
         const node = ctx.allocator.create(Queue(i32).Node) catch unreachable;
         node.* = Queue(i32).Node{
             .prev = undefined,

--- a/lib/std/atomic/stack.zig
+++ b/lib/std/atomic/stack.zig
@@ -152,7 +152,7 @@ fn startPuts(ctx: *Context) u8 {
     var r = std.rand.DefaultPrng.init(0xdeadbeef);
     while (put_count != 0) : (put_count -= 1) {
         std.time.sleep(1); // let the os scheduler be our fuzz
-        const x = @bitCast(i32, r.random.scalar(u32));
+        const x = r.random.int(i32);
         const node = ctx.allocator.create(Stack(i32).Node) catch unreachable;
         node.* = Stack(i32).Node{
             .next = undefined,

--- a/lib/std/atomic/stack.zig
+++ b/lib/std/atomic/stack.zig
@@ -152,7 +152,7 @@ fn startPuts(ctx: *Context) u8 {
     var r = std.rand.DefaultPrng.init(0xdeadbeef);
     while (put_count != 0) : (put_count -= 1) {
         std.time.sleep(1); // let the os scheduler be our fuzz
-        const x = r.random.int(i32);
+        const x = r.int(i32);
         const node = ctx.allocator.create(Stack(i32).Node) catch unreachable;
         node.* = Stack(i32).Node{
             .next = undefined,

--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -31,7 +31,7 @@ pub fn benchmarkHash(comptime Hash: var, comptime bytes: comptime_int) !u64 {
     var h = Hash.init();
 
     var block: [Hash.digest_length]u8 = undefined;
-    prng.random.bytes(block[0..]);
+    prng.bytes(block[0..]);
 
     var offset: usize = 0;
     var timer = try Timer.start();
@@ -58,10 +58,10 @@ pub fn benchmarkMac(comptime Mac: var, comptime bytes: comptime_int) !u64 {
     std.debug.assert(32 >= Mac.mac_length and 32 >= Mac.minimum_key_length);
 
     var in: [1 * MiB]u8 = undefined;
-    prng.random.bytes(in[0..]);
+    prng.bytes(in[0..]);
 
     var key: [32]u8 = undefined;
-    prng.random.bytes(key[0..]);
+    prng.bytes(key[0..]);
 
     var offset: usize = 0;
     var timer = try Timer.start();
@@ -83,10 +83,10 @@ pub fn benchmarkKeyExchange(comptime DhKeyExchange: var, comptime exchange_count
     std.debug.assert(DhKeyExchange.minimum_key_length >= DhKeyExchange.secret_length);
 
     var in: [DhKeyExchange.minimum_key_length]u8 = undefined;
-    prng.random.bytes(in[0..]);
+    prng.bytes(in[0..]);
 
     var out: [DhKeyExchange.minimum_key_length]u8 = undefined;
-    prng.random.bytes(out[0..]);
+    prng.bytes(out[0..]);
 
     var offset: usize = 0;
     var timer = try Timer.start();

--- a/lib/std/hash/benchmark.zig
+++ b/lib/std/hash/benchmark.zig
@@ -100,7 +100,7 @@ pub fn benchmarkHash(comptime H: var, bytes: usize) !Result {
     };
 
     var block: [block_size]u8 = undefined;
-    prng.random.bytes(block[0..]);
+    prng.bytes(block[0..]);
 
     var offset: usize = 0;
     var timer = try Timer.start();
@@ -122,7 +122,7 @@ pub fn benchmarkHash(comptime H: var, bytes: usize) !Result {
 pub fn benchmarkHashSmallKeys(comptime H: var, key_size: usize, bytes: usize) !Result {
     const key_count = bytes / key_size;
     var block: [block_size]u8 = undefined;
-    prng.random.bytes(block[0..]);
+    prng.bytes(block[0..]);
 
     var i: usize = 0;
     var timer = try Timer.start();

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -16,7 +16,7 @@ test "write a file, read it, then delete it" {
 
     var data: [1024]u8 = undefined;
     var prng = DefaultPrng.init(1234);
-    prng.random.bytes(data[0..]);
+    prng.bytes(data[0..]);
     const tmp_file_name = "temp_test_file.txt";
     {
         var file = try File.openWrite(tmp_file_name);

--- a/lib/std/math/big/rational.zig
+++ b/lib/std/math/big/rational.zig
@@ -766,7 +766,7 @@ test "big.rational set/to Float round-trip" {
     var prng = std.rand.DefaultPrng.init(0x5EED);
     var i: usize = 0;
     while (i < 512) : (i += 1) {
-        const r = prng.random.float(f64);
+        const r = prng.float(f64);
         try a.setFloat(f64, r);
         testing.expect((try a.toFloat(f64)) == r);
     }

--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -42,7 +42,7 @@ pub const Random = struct {
         return r.int(u1) != 0;
     }
 
-    /// Returns a random int `i` such that `0 <= i <= maxInt(T)`.
+    /// Returns a random int `i` such that `minInt(i) <= i <= maxInt(T)`.
     /// `i` is evenly distributed.
     pub fn int(r: *Random, comptime T: type) T {
         const UnsignedT = @IntType(false, T.bit_count);

--- a/lib/std/rand/ziggurat.zig
+++ b/lib/std/rand/ziggurat.zig
@@ -10,9 +10,8 @@
 
 const std = @import("../std.zig");
 const math = std.math;
-const Random = std.rand.Random;
 
-pub fn next_f64(random: *Random, comptime tables: ZigTable) f64 {
+pub fn next_f64(random: var, comptime tables: var) f64 {
     while (true) {
         // We manually construct a float from parts as we can avoid an extra random lookup here by
         // using the unused exponent for the lookup table entry.
@@ -59,8 +58,9 @@ pub const ZigTable = struct {
     pdf: fn (f64) f64,
     // whether the distribution is symmetric
     is_symmetric: bool,
+
     // fallback calculation in the case we are in the 0 block
-    zero_case: fn (*Random, f64) f64,
+    zero_case: fn (var, f64) f64,
 };
 
 // zigNorInit
@@ -70,7 +70,7 @@ fn ZigTableGen(
     comptime v: f64,
     comptime f: fn (f64) f64,
     comptime f_inv: fn (f64) f64,
-    comptime zero_case: fn (*Random, f64) f64,
+    comptime zero_case: fn (var, f64) f64,
 ) ZigTable {
     var tables: ZigTable = undefined;
 
@@ -110,7 +110,7 @@ fn norm_f(x: f64) f64 {
 fn norm_f_inv(y: f64) f64 {
     return math.sqrt(-2.0 * math.ln(y));
 }
-fn norm_zero_case(random: *Random, u: f64) f64 {
+fn norm_zero_case(random: var, u: f64) f64 {
     var x: f64 = 1;
     var y: f64 = 0;
 
@@ -130,7 +130,7 @@ test "ziggurant normal dist sanity" {
     var prng = std.rand.DefaultPrng.init(0);
     var i: usize = 0;
     while (i < 1000) : (i += 1) {
-        _ = prng.random.floatNorm(f64);
+        _ = prng.floatNorm(f64);
     }
 }
 
@@ -149,7 +149,7 @@ fn exp_f(x: f64) f64 {
 fn exp_f_inv(y: f64) f64 {
     return -math.ln(y);
 }
-fn exp_zero_case(random: *Random, _: f64) f64 {
+fn exp_zero_case(random: var, _: f64) f64 {
     return exp_r - math.ln(random.float(f64));
 }
 
@@ -157,7 +157,7 @@ test "ziggurant exp dist sanity" {
     var prng = std.rand.DefaultPrng.init(0);
     var i: usize = 0;
     while (i < 1000) : (i += 1) {
-        _ = prng.random.floatExp(f64);
+        _ = prng.floatExp(f64);
     }
 }
 

--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -1162,13 +1162,13 @@ test "sort fuzz testing" {
     const test_case_count = 10;
     var i: usize = 0;
     while (i < test_case_count) : (i += 1) {
-        fuzzTest(&prng.random);
+        fuzzTest(&prng);
     }
 }
 
 var fixed_buffer_mem: [100 * 1024]u8 = undefined;
 
-fn fuzzTest(rng: *std.rand.Random) void {
+fn fuzzTest(rng: var) void {
     const array_size = rng.range(usize, 0, 1000);
     var fixed_allocator = std.heap.FixedBufferAllocator.init(fixed_buffer_mem[0..]);
     var array = fixed_allocator.allocator.alloc(IdAndValue, array_size) catch unreachable;

--- a/src-self-hosted/compilation.zig
+++ b/src-self-hosted/compilation.zig
@@ -1230,7 +1230,7 @@ pub const Compilation = struct {
             const held = self.zig_compiler.prng.acquire();
             defer held.release();
 
-            held.value.random.bytes(rand_bytes[0..]);
+            held.value.bytes(rand_bytes[0..]);
         }
 
         var result: [12]u8 = undefined;

--- a/src-self-hosted/type.zig
+++ b/src-self-hosted/type.zig
@@ -1057,9 +1057,9 @@ fn hashAny(x: var, comptime seed: u64) u32 {
             comptime var rng = comptime std.rand.DefaultPrng.init(seed);
             const unsigned_x = @bitCast(@IntType(false, info.bits), x);
             if (info.bits <= 32) {
-                return @as(u32, unsigned_x) *% comptime rng.random.scalar(u32);
+                return @as(u32, unsigned_x) *% comptime rng.int(u32);
             } else {
-                return @truncate(u32, unsigned_x *% comptime rng.random.scalar(@typeOf(unsigned_x)));
+                return @truncate(u32, unsigned_x *% comptime rng.int(@typeOf(unsigned_x)));
             }
         },
         .Pointer => |info| {
@@ -1073,7 +1073,7 @@ fn hashAny(x: var, comptime seed: u64) u32 {
         .Enum => return hashAny(@enumToInt(x), seed),
         .Bool => {
             comptime var rng = comptime std.rand.DefaultPrng.init(seed);
-            const vals = comptime [2]u32{ rng.random.scalar(u32), rng.random.scalar(u32) };
+            const vals = comptime [2]u32{ rng.int(u32), rng.int(u32) };
             return vals[@boolToInt(x)];
         },
         .Optional => {

--- a/test/stage1/behavior/bugs/920.zig
+++ b/test/stage1/behavior/bugs/920.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 const math = std.math;
-const Random = std.rand.Random;
+
+const Random = struct {
+    fillFn: fn (r: *Random, buf: []u8) void,
+};
 
 const ZigTable = struct {
     r: f64,

--- a/test/standalone/guess_number/main.zig
+++ b/test/standalone/guess_number/main.zig
@@ -16,7 +16,7 @@ pub fn main() !void {
     const seed = std.mem.readIntNative(u64, &seed_bytes);
     var prng = std.rand.DefaultPrng.init(seed);
 
-    const answer = prng.random.range(u8, 0, 100) + 1;
+    const answer = prng.range(u8, 0, 100) + 1;
 
     while (true) {
         try stdout.print("\nGuess a number between 1 and 100: ");


### PR DESCRIPTION
After chatting in IRC, I spied that `std.rand.Random` was a great candidate to be the first of what I've started calling "Mixin"s in the standard library.

A "Mixin" is a new pattern where you have a function that takes a struct and returns a struct with *no* fields, intended to be used from the definition of another struct with `pub usingnamespace MyMixin(@This())`. This act of "mixing-in" adds "helper" methods to the struct you're currently defining, and are expect to take a `self: var` parameter and use method(s) from the mixed-into struct. In this case of `Random`, we expect the base struct to implement a method `bytes` that looks like `pub fn bytes(self: ........., buf: []u8) void) void`.

Compared to the existing pattern, a Mixin:
  - doesn't have the runtime requirement of a function pointer
  - allows the base functions to be either sync or async
  - allows the base functions (if they return an error union) to have differing error sets
  - sidesteps #591
  - allows optimisation (e.g. inlining) of the base function into the helper function