### PR TITLE
Add top level docs for structs, enums and unions

### DIFF
--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -144,11 +144,14 @@
 
         var decl = zigAnalysis.types[pkg.main];
         curNav.declObjs = [decl];
+        curNav.childDeclObjs = [decl];
+        var lastParentDecl = null;
         for (var i = 0; i < curNav.declNames.length; i += 1) {
             var childDecl = findSubDecl(decl, curNav.declNames[i]);
             if (childDecl == null) {
                 return render404();
             }
+            lastParentDecl = childDecl;
             var container = getDeclContainerType(childDecl);
             if (container == null) {
                 if (i + 1 === curNav.declNames.length) {
@@ -181,6 +184,7 @@
             }
         } else {
             renderType(lastDecl);
+            renderTopLevelDecl(lastParentDecl);
         }
     }
 
@@ -738,6 +742,14 @@
                 } else {
                     return typeObj.name;
                 }
+        }
+    }
+
+    function renderTopLevelDecl(decl) {
+        var node = zigAnalysis.astNodes[decl.src];
+        if (node.docs != null) {
+            domTldDocs.innerHTML = markdown(node.docs);
+            domTldDocs.classList.remove("hidden");
         }
     }
 


### PR DESCRIPTION
Issue #3408. Adds top level docs for structs, enums and unions. Seemed quite easy so I might be doing it in a naive way. If so, no worries! 