### PR TITLE
Replace mem.page_size with mem.min_page_size and mem.max_page_size

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -1,6 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
-const page_size = std.mem.page_size;
+const min_page_size = std.mem.min_page_size;
 
 pub usingnamespace @import("os/bits.zig");
 
@@ -83,9 +83,9 @@ pub extern "c" fn pwritev(fd: c_int, iov: [*]const iovec_const, iovcnt: c_uint, 
 pub extern "c" fn stat(noalias path: [*]const u8, noalias buf: *Stat) c_int;
 pub extern "c" fn write(fd: fd_t, buf: [*]const u8, nbyte: usize) isize;
 pub extern "c" fn pwrite(fd: fd_t, buf: [*]const u8, nbyte: usize, offset: u64) isize;
-pub extern "c" fn mmap(addr: ?*align(page_size) c_void, len: usize, prot: c_uint, flags: c_uint, fd: fd_t, offset: u64) *c_void;
-pub extern "c" fn munmap(addr: *align(page_size) c_void, len: usize) c_int;
-pub extern "c" fn mprotect(addr: *align(page_size) c_void, len: usize, prot: c_uint) c_int;
+pub extern "c" fn mmap(addr: ?*align(min_page_size) c_void, len: usize, prot: c_uint, flags: c_uint, fd: fd_t, offset: u64) *c_void;
+pub extern "c" fn munmap(addr: *align(min_page_size) c_void, len: usize) c_int;
+pub extern "c" fn mprotect(addr: *align(min_page_size) c_void, len: usize, prot: c_uint) c_int;
 pub extern "c" fn unlink(path: [*]const u8) c_int;
 pub extern "c" fn unlinkat(dirfd: fd_t, path: [*]const u8, flags: c_uint) c_int;
 pub extern "c" fn getcwd(buf: [*]u8, size: usize) ?[*]u8;

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1031,7 +1031,7 @@ fn openSelfDebugInfoPosix(allocator: *mem.Allocator) !DwarfInfo {
     errdefer S.self_exe_file.close();
 
     const self_exe_len = math.cast(usize, try S.self_exe_file.getEndPos()) catch return error.DebugInfoTooLarge;
-    const self_exe_mmap_len = mem.alignForward(self_exe_len, mem.page_size);
+    const self_exe_mmap_len = mem.alignForward(self_exe_len, mem.min_page_size);
     const self_exe_mmap = try os.mmap(
         null,
         self_exe_mmap_len,
@@ -1135,7 +1135,7 @@ fn printLineFromFileAnyOs(out_stream: var, line_info: LineInfo) !void {
     defer f.close();
     // TODO fstat and make sure that the file has the correct size
 
-    var buf: [mem.page_size]u8 = undefined;
+    var buf: [mem.bufsiz]u8 = undefined;
     var line: usize = 1;
     var column: usize = 1;
     var abs_index: usize = 0;

--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -101,7 +101,7 @@ pub fn linkmap_iterator(phdrs: []elf.Phdr) !LinkMap.Iterator {
 pub const LinuxDynLib = struct {
     elf_lib: ElfLib,
     fd: i32,
-    memory: []align(mem.page_size) u8,
+    memory: []align(mem.min_page_size) u8,
 
     /// Trusts the file
     pub fn open(path: []const u8) !DynLib {
@@ -113,7 +113,7 @@ pub const LinuxDynLib = struct {
 
         const bytes = try os.mmap(
             null,
-            mem.alignForward(size, mem.page_size),
+            mem.alignForward(size, mem.min_page_size),
             os.PROT_READ | os.PROT_EXEC,
             os.MAP_PRIVATE,
             fd,

--- a/lib/std/event/fs.zig
+++ b/lib/std/event/fs.zig
@@ -692,7 +692,7 @@ pub fn readFile(allocator: *Allocator, file_path: []const u8, max_size: usize) !
     defer list.deinit();
 
     while (true) {
-        try list.ensureCapacity(list.len + mem.page_size);
+        try list.ensureCapacity(list.len + mem.bufsiz);
         const buf = list.items[list.len..];
         const buf_array = [_][]u8{buf};
         const amt = try preadv(allocator, fd, buf_array, list.len);

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -88,7 +88,7 @@ pub fn LinearFifo(
                 mem.copy(T, self.buf[0..self.count], self.buf[self.head..][0..self.count]);
                 self.head = 0;
             } else {
-                var tmp: [mem.page_size / 2 / @sizeOf(T)]T = undefined;
+                var tmp: [mem.bufsiz / @sizeOf(T)]T = undefined;
 
                 while (self.head != 0) {
                     const n = math.min(self.head, tmp.len);

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -139,7 +139,7 @@ pub fn updateFileMode(source_path: []const u8, dest_path: []const u8, mode: ?Fil
 
     const in_stream = &src_file.inStream().stream;
 
-    var buf: [mem.page_size * 6]u8 = undefined;
+    var buf: [mem.bufsiz]u8 = undefined;
     while (true) {
         const amt = try in_stream.readFull(buf[0..]);
         try atomic_file.file.write(buf[0..amt]);
@@ -166,7 +166,7 @@ pub fn copyFile(source_path: []const u8, dest_path: []const u8) !void {
     var atomic_file = try AtomicFile.init(dest_path, mode);
     defer atomic_file.deinit();
 
-    var buf: [mem.page_size]u8 = undefined;
+    var buf: [mem.bufsiz]u8 = undefined;
     while (true) {
         const amt = try in_stream.readFull(buf[0..]);
         try atomic_file.file.write(buf[0..amt]);
@@ -186,7 +186,7 @@ pub fn copyFileMode(source_path: []const u8, dest_path: []const u8, mode: File.M
     var atomic_file = try AtomicFile.init(dest_path, mode);
     defer atomic_file.deinit();
 
-    var buf: [mem.page_size * 6]u8 = undefined;
+    var buf: [mem.bufsiz]u8 = undefined;
     while (true) {
         const amt = try in_file.read(buf[0..]);
         try atomic_file.file.write(buf[0..amt]);

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -72,7 +72,7 @@ pub fn readFileAlloc(allocator: *mem.Allocator, path: []const u8) ![]u8 {
 }
 
 pub fn BufferedInStream(comptime Error: type) type {
-    return BufferedInStreamCustom(mem.page_size, Error);
+    return BufferedInStreamCustom(mem.bufsiz, Error);
 }
 
 pub fn BufferedInStreamCustom(comptime buffer_size: usize, comptime Error: type) type {
@@ -545,7 +545,7 @@ test "io.CountingOutStream" {
 }
 
 pub fn BufferedOutStream(comptime Error: type) type {
-    return BufferedOutStreamCustom(mem.page_size, Error);
+    return BufferedOutStreamCustom(mem.bufsiz, Error);
 }
 
 pub fn BufferedOutStreamCustom(comptime buffer_size: usize, comptime OutStreamError: type) type {

--- a/lib/std/io/in_stream.zig
+++ b/lib/std/io/in_stream.zig
@@ -78,7 +78,7 @@ pub fn InStream(comptime ReadError: type) type {
                     return;
                 }
 
-                const new_buf_size = math.min(max_size, actual_buf_len + mem.page_size);
+                const new_buf_size = math.min(max_size, actual_buf_len + mem.bufsiz);
                 if (new_buf_size == actual_buf_len) return error.StreamTooLong;
                 try buffer.resize(new_buf_size);
             }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -8,10 +8,17 @@ const meta = std.meta;
 const trait = meta.trait;
 const testing = std.testing;
 
-pub const page_size = switch (builtin.arch) {
+pub const min_page_size = switch (builtin.arch) {
     .wasm32, .wasm64 => 64 * 1024,
     else => 4 * 1024,
 };
+
+pub const max_page_size = switch (builtin.arch) {
+    else => min_page_size,
+};
+
+/// A good default size for buffers
+pub const bufsiz = min_page_size;
 
 pub const Allocator = struct {
     pub const Error = error{OutOfMemory};

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -9,11 +9,24 @@ const trait = meta.trait;
 const testing = std.testing;
 
 pub const min_page_size = switch (builtin.arch) {
+    .mips, .mipsel, .mips64, .mips64el => switch (builtin.os) {
+        else => 1024, // NEC VR41xx processors support as low as 1K page size
+        .linux => 4 * 1024, // Linux doesn't support < 4K pages
+    },
+    .sparcv9 => 8 * 1024,
     .wasm32, .wasm64 => 64 * 1024,
     else => 4 * 1024,
 };
 
 pub const max_page_size = switch (builtin.arch) {
+    .arm, .armeb => 16 * 1024 * 1024, // At least ARMv7 has optional support for 16M pages
+    .aarch64, .aarch64_be => 1 * 1024 * 1024 * 1024, // ARM64 supports 4K, 16K, 64K, 2M, 32M, 512M, 1G pages
+    .mips, .mipsel, .mips64, .mips64el => 64 * 1024, // Every MIPS III, MIPS IV, MIPS32 and MIPS64 processor supports 4K, 16K and 64K page sizes.
+    .powerpc64, .powerpc64le => 64 * 1024,
+    .s390x => 2 * 1024 * 1024 * 1024, // 4K, 1M, 2G pages
+    .sparcv9 => 16 * 1024 * 1024 * 1024, // 8K, 64K, 512K, 4M, 32M, 256M, 2G, 16G
+    .wasm32, .wasm64 => 64 * 1024,
+    .x86_64 => 1 * 1024 * 1024 * 1024, // 1G huge pages.
     else => min_page_size,
 };
 

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -618,12 +618,12 @@ test "PackedIntArray at end of available memory" {
 
     const allocator = std.heap.page_allocator;
 
-    const pages = try allocator.alignedAlloc(u8, std.mem.page_size * 2, std.mem.page_size);
+    const pages = try allocator.alignedAlloc(u8, std.mem.min_page_size * 2, std.mem.min_page_size);
     defer allocator.free(pages);
 
-    try std.os.mprotect(pages[std.mem.page_size..], std.os.PROT_NONE);
+    try std.os.mprotect(pages[std.mem.min_page_size..], std.os.PROT_NONE);
 
-    const pad = @ptrCast(*PackedArray, &pages[std.mem.page_size - @sizeOf(PackedArray)]);
+    const pad = @ptrCast(*PackedArray, &pages[std.mem.min_page_size - @sizeOf(PackedArray)]);
     pad.set(7, std.math.maxInt(u3));
 }
 
@@ -636,9 +636,9 @@ test "PackedIntSlice at end of available memory" {
 
     const allocator = std.heap.page_allocator;
 
-    var page = try allocator.alloc(u8, std.mem.page_size);
+    var page = try allocator.alloc(u8, std.mem.min_page_size);
     defer allocator.free(page);
 
-    var p = PackedSlice.init(page[std.mem.page_size - 2 ..], 1);
+    var p = PackedSlice.init(page[std.mem.min_page_size - 2 ..], 1);
     p.set(0, std.math.maxInt(u11));
 }

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -525,7 +525,7 @@ pub fn posixGetUserInfo(name: []const u8) !UserInfo {
         ReadGroupId,
     };
 
-    var buf: [std.mem.page_size]u8 = undefined;
+    var buf: [std.mem.bufsiz]u8 = undefined;
     var name_index: usize = 0;
     var state = State.Start;
     var uid: u32 = 0;

--- a/lib/std/special/start.zig
+++ b/lib/std/special/start.zig
@@ -150,9 +150,9 @@ fn posixCallMainAndExit() noreturn {
         //// problem is that it uses PROT_GROWSDOWN which prevents stores to addresses too far down
         //// the stack and requires "probing". So here we allocate our own stack.
         //const wanted_stack_size = gnu_stack_phdr.p_memsz;
-        //assert(wanted_stack_size % std.mem.page_size == 0);
+        //assert(wanted_stack_size % page_size == 0);
         //// Allocate an extra page as the guard page.
-        //const total_size = wanted_stack_size + std.mem.page_size;
+        //const total_size = wanted_stack_size + page_size;
         //const new_stack = std.os.mmap(
         //    null,
         //    total_size,
@@ -161,7 +161,7 @@ fn posixCallMainAndExit() noreturn {
         //    -1,
         //    0,
         //) catch @panic("out of memory");
-        //std.os.mprotect(new_stack[0..std.mem.page_size], std.os.PROT_NONE) catch {};
+        //std.os.mprotect(new_stack[0..page_size], std.os.PROT_NONE) catch {};
         //std.os.exit(@newStackCall(new_stack, callMainWithArgs, argc, argv, envp));
     }
 

--- a/lib/std/special/start.zig
+++ b/lib/std/special/start.zig
@@ -143,6 +143,17 @@ fn posixCallMainAndExit() noreturn {
             std.os.linux.tls.setThreadPointer(tp);
         }
 
+        var page_size:?usize = null;
+        var i: usize = 0;
+        while (auxv[i].a_type != std.elf.AT_NULL) : (i += 1) {
+            if (auxv[i].a_type == std.elf.AT_PAGESZ) {
+                page_size = auxv[i].a_un.a_val;
+                assert(page_size.? >= std.mem.min_page_size);
+                assert(page_size.? <= std.mem.max_page_size);
+                break;
+            }
+        }
+
         // TODO This is disabled because what should we do when linking libc and this code
         // does not execute? And also it's causing a test failure in stack traces in release modes.
 

--- a/lib/std/thread.zig
+++ b/lib/std/thread.zig
@@ -33,12 +33,12 @@ pub const Thread = struct {
     pub const Data = if (use_pthreads)
         struct {
             handle: Thread.Handle,
-            memory: []align(mem.page_size) u8,
+            memory: []align(mem.min_page_size) u8,
         }
     else switch (builtin.os) {
         .linux => struct {
             handle: Thread.Handle,
-            memory: []align(mem.page_size) u8,
+            memory: []align(mem.min_page_size) u8,
         },
         .windows => struct {
             handle: Thread.Handle,
@@ -229,11 +229,11 @@ pub const Thread = struct {
         var context_start_offset: usize = undefined;
         var tls_start_offset: usize = undefined;
         const mmap_len = blk: {
-            var l: usize = mem.page_size;
+            var l: usize = mem.min_page_size;
             // Allocate a guard page right after the end of the stack region
             guard_end_offset = l;
             // The stack itself, which grows downwards.
-            l = mem.alignForward(l + default_stack_size, mem.page_size);
+            l = mem.alignForward(l + default_stack_size, mem.min_page_size);
             stack_end_offset = l;
             // Above the stack, so that it can be in the same mmap call, put the Thread object.
             l = mem.alignForward(l, @alignOf(Thread));
@@ -259,7 +259,7 @@ pub const Thread = struct {
         // whole region right away
         const mmap_slice = os.mmap(
             null,
-            mem.alignForward(mmap_len, mem.page_size),
+            mem.alignForward(mmap_len, mem.min_page_size),
             os.PROT_NONE,
             os.MAP_PRIVATE | os.MAP_ANONYMOUS,
             -1,


### PR DESCRIPTION
This PR removes `mem.page_size` and replaces it with minimums and maximums. Originally I attempted to create a global variable `page_size`, but I realised that this would not work when zig's own startup routines are not used (e.g. when zig is used to create a static library). There is no linux syscall to get the current page size if you don't have access to the auxiliary vector, so a hacky solution would be required (e.g. using the knowledge that `madvise` returns `EINVAL` on non-page aligned arguments, and doing a search for the page size)

This PR introduces `mem.bufsiz` as a reasonable "default size" for buffers. The name is taken from the posix constant `BUFSIZ`.

Additionally, on linux we now `assert` that the page size in the auxiliary vector matches expectations.

Closes #2564