### PR TITLE
inline ConstGlobalRefs into ZigValue

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -313,12 +313,6 @@ struct RuntimeHintSlice {
     uint64_t len;
 };
 
-struct ConstGlobalRefs {
-    LLVMValueRef llvm_value;
-    LLVMValueRef llvm_global;
-    uint32_t align;
-};
-
 enum LazyValueId {
     LazyValueIdInvalid,
     LazyValueIdAlignOf,
@@ -409,8 +403,10 @@ struct LazyValueErrUnionType {
 struct ZigValue {
     ZigType *type;
     ConstValSpecial special;
+    uint32_t llvm_align;
     ConstParent parent;
-    ConstGlobalRefs *global_refs;
+    LLVMValueRef llvm_value;
+    LLVMValueRef llvm_global;
 
     union {
         // populated if special == ConstValSpecialStatic

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5909,12 +5909,7 @@ ZigValue *create_const_arg_tuple(CodeGen *g, size_t arg_index_start, size_t arg_
 
 
 ZigValue *create_const_vals(size_t count) {
-    ConstGlobalRefs *global_refs = allocate<ConstGlobalRefs>(count, "ConstGlobalRefs");
-    ZigValue *vals = allocate<ZigValue>(count, "ZigValue");
-    for (size_t i = 0; i < count; i += 1) {
-        vals[i].global_refs = &global_refs[i];
-    }
-    return vals;
+    return allocate<ZigValue>(count, "ZigValue");
 }
 
 ZigValue **alloc_const_vals_ptrs(size_t count) {
@@ -6492,20 +6487,14 @@ bool const_values_equal_ptr(ZigValue *a, ZigValue *b) {
                 return false;
             return true;
         case ConstPtrSpecialBaseArray:
-            if (a->data.x_ptr.data.base_array.array_val != b->data.x_ptr.data.base_array.array_val &&
-                a->data.x_ptr.data.base_array.array_val->global_refs !=
-                b->data.x_ptr.data.base_array.array_val->global_refs)
-            {
+            if (a->data.x_ptr.data.base_array.array_val != b->data.x_ptr.data.base_array.array_val) {
                 return false;
             }
             if (a->data.x_ptr.data.base_array.elem_index != b->data.x_ptr.data.base_array.elem_index)
                 return false;
             return true;
         case ConstPtrSpecialBaseStruct:
-            if (a->data.x_ptr.data.base_struct.struct_val != b->data.x_ptr.data.base_struct.struct_val &&
-                a->data.x_ptr.data.base_struct.struct_val->global_refs !=
-                b->data.x_ptr.data.base_struct.struct_val->global_refs)
-            {
+            if (a->data.x_ptr.data.base_struct.struct_val != b->data.x_ptr.data.base_struct.struct_val) {
                 return false;
             }
             if (a->data.x_ptr.data.base_struct.field_index != b->data.x_ptr.data.base_struct.field_index)
@@ -6513,27 +6502,21 @@ bool const_values_equal_ptr(ZigValue *a, ZigValue *b) {
             return true;
         case ConstPtrSpecialBaseErrorUnionCode:
             if (a->data.x_ptr.data.base_err_union_code.err_union_val !=
-                b->data.x_ptr.data.base_err_union_code.err_union_val &&
-                a->data.x_ptr.data.base_err_union_code.err_union_val->global_refs !=
-                b->data.x_ptr.data.base_err_union_code.err_union_val->global_refs)
+                b->data.x_ptr.data.base_err_union_code.err_union_val)
             {
                 return false;
             }
             return true;
         case ConstPtrSpecialBaseErrorUnionPayload:
             if (a->data.x_ptr.data.base_err_union_payload.err_union_val !=
-                b->data.x_ptr.data.base_err_union_payload.err_union_val &&
-                a->data.x_ptr.data.base_err_union_payload.err_union_val->global_refs !=
-                b->data.x_ptr.data.base_err_union_payload.err_union_val->global_refs)
+                b->data.x_ptr.data.base_err_union_payload.err_union_val)
             {
                 return false;
             }
             return true;
         case ConstPtrSpecialBaseOptionalPayload:
             if (a->data.x_ptr.data.base_optional_payload.optional_val !=
-                b->data.x_ptr.data.base_optional_payload.optional_val &&
-                a->data.x_ptr.data.base_optional_payload.optional_val->global_refs !=
-                b->data.x_ptr.data.base_optional_payload.optional_val->global_refs)
+                b->data.x_ptr.data.base_optional_payload.optional_val)
             {
                 return false;
             }

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -11401,8 +11401,12 @@ static void copy_const_val(ZigValue *dest, ZigValue *src) {
         dest->data.x_struct.fields = alloc_const_vals_ptrs(dest->type->data.structure.src_field_count);
         for (size_t i = 0; i < dest->type->data.structure.src_field_count; i += 1) {
             copy_const_val(dest->data.x_struct.fields[i], src->data.x_struct.fields[i]);
-        }
-    }
+            dest->data.x_struct.fields[i]->parent.id = ConstParentIdStruct;
+            dest->data.x_struct.fields[i]->parent.data.p_struct.struct_val = dest;
+            dest->data.x_struct.fields[i]->parent.data.p_struct.field_index = i;
+         }
+     }
+    dest->parent.id = ConstParentIdNone;
 }
 
 static bool eval_const_expr_implicit_cast(IrAnalyze *ira, IrInstruction *source_instr,
@@ -17672,7 +17676,6 @@ static IrInstruction *ir_analyze_fn_call(IrAnalyze *ira, IrInstructionCallSrc *c
 
         IrInstruction *new_instruction = ir_const(ira, &call_instruction->base, result->type);
         copy_const_val(new_instruction->value, result);
-        new_instruction->value->type = return_type;
         return ir_finish_anal(ira, new_instruction);
     }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -11524,6 +11524,14 @@ static IrInstruction *ir_const_noval(IrAnalyze *ira, IrInstruction *old_instruct
     return &const_instruction->base;
 }
 
+// This function initializes the new IrInstruction with the provided ZigValue,
+// rather than creating a new one.
+static IrInstruction *ir_const_move(IrAnalyze *ira, IrInstruction *old_instruction, ZigValue *val) {
+    IrInstruction *result = ir_const_noval(ira, old_instruction);
+    result->value = val;
+    return result;
+}
+
 static IrInstruction *ir_resolve_cast(IrAnalyze *ira, IrInstruction *source_instr, IrInstruction *value,
         ZigType *wanted_type, CastOp cast_op)
 {
@@ -14335,9 +14343,7 @@ static IrInstruction *ir_analyze_instruction_return(IrAnalyze *ira, IrInstructio
 }
 
 static IrInstruction *ir_analyze_instruction_const(IrAnalyze *ira, IrInstructionConst *instruction) {
-    IrInstruction *result = ir_const(ira, &instruction->base, nullptr);
-    copy_const_val(result->value, instruction->base.value);
-    return result;
+    return ir_const_move(ira, &instruction->base, instruction->base.value);
 }
 
 static IrInstruction *ir_analyze_bin_op_bool(IrAnalyze *ira, IrInstructionBinOp *bin_op_instruction) {
@@ -17674,8 +17680,7 @@ static IrInstruction *ir_analyze_fn_call(IrAnalyze *ira, IrInstructionCallSrc *c
             }
         }
 
-        IrInstruction *new_instruction = ir_const(ira, &call_instruction->base, result->type);
-        copy_const_val(new_instruction->value, result);
+        IrInstruction *new_instruction = ir_const_move(ira, &call_instruction->base, result);
         return ir_finish_anal(ira, new_instruction);
     }
 

--- a/test/stage1/behavior/bugs/1607.zig
+++ b/test/stage1/behavior/bugs/1607.zig
@@ -10,6 +10,6 @@ fn checkAddress(s: []const u8) void {
 }
 
 test "slices pointing at the same address as global array." {
-    checkAddress(a);
-    comptime checkAddress(a);
+    checkAddress(&a);
+    comptime checkAddress(&a);
 }

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -783,7 +783,7 @@ test "struct with var field" {
         x: var,
         y: var,
     };
-    const pt = Point {
+    const pt = Point{
         .x = 1,
         .y = 2,
     };


### PR DESCRIPTION
Having ConstGlobalRefs be a pointer in ZigValue was a hack that caused
plenty of bugs. It was used to work around difficulties in type coercing
array values into slices.

However, after #3787 is merged, array values no longer type coerce into
slices, and so this provided an opportunity to clean up the code.

This has the nice effect of reducing stage1 peak RAM usage during the
std lib tests from 3.443 GiB to 3.405 GiB (saving 39 MiB).