### PR TITLE
net: add reuse_address option to StreamServer

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -122,8 +122,8 @@ pub extern "c" fn listen(sockfd: fd_t, backlog: c_uint) c_int;
 pub extern "c" fn getsockname(sockfd: fd_t, noalias addr: *sockaddr, noalias addrlen: *socklen_t) c_int;
 pub extern "c" fn connect(sockfd: fd_t, sock_addr: *const sockaddr, addrlen: socklen_t) c_int;
 pub extern "c" fn accept4(sockfd: fd_t, addr: *sockaddr, addrlen: *socklen_t, flags: c_uint) c_int;
-pub extern "c" fn getsockopt(sockfd: fd_t, level: c_int, optname: c_int, optval: *c_void, optlen: *socklen_t) c_int;
-pub extern "c" fn setsockopt(sockfd: fd_t, level: c_int, optname: c_int, optval: *c_void, optlen: socklen_t) c_int;
+pub extern "c" fn getsockopt(sockfd: fd_t, level: c_uint, optname: c_uint, optval: *c_void, optlen: *socklen_t) c_int;
+pub extern "c" fn setsockopt(sockfd: fd_t, level: c_uint, optname: c_uint, optval: *c_void, optlen: socklen_t) c_int;
 pub extern "c" fn send(sockfd: fd_t, buf: *const c_void, len: usize, flags: u32) isize;
 pub extern "c" fn sendto(
     sockfd: fd_t,

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -122,8 +122,8 @@ pub extern "c" fn listen(sockfd: fd_t, backlog: c_uint) c_int;
 pub extern "c" fn getsockname(sockfd: fd_t, noalias addr: *sockaddr, noalias addrlen: *socklen_t) c_int;
 pub extern "c" fn connect(sockfd: fd_t, sock_addr: *const sockaddr, addrlen: socklen_t) c_int;
 pub extern "c" fn accept4(sockfd: fd_t, addr: *sockaddr, addrlen: *socklen_t, flags: c_uint) c_int;
-pub extern "c" fn getsockopt(sockfd: fd_t, level: c_uint, optname: c_uint, optval: *c_void, optlen: *socklen_t) c_int;
-pub extern "c" fn setsockopt(sockfd: fd_t, level: c_uint, optname: c_uint, optval: *c_void, optlen: socklen_t) c_int;
+pub extern "c" fn getsockopt(sockfd: fd_t, level: u32, optname: u32, optval: *c_void, optlen: *socklen_t) c_int;
+pub extern "c" fn setsockopt(sockfd: fd_t, level: u32, optname: u32, optval: *c_void, optlen: socklen_t) c_int;
 pub extern "c" fn send(sockfd: fd_t, buf: *const c_void, len: usize, flags: u32) isize;
 pub extern "c" fn sendto(
     sockfd: fd_t,

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -123,6 +123,7 @@ pub extern "c" fn getsockname(sockfd: fd_t, noalias addr: *sockaddr, noalias add
 pub extern "c" fn connect(sockfd: fd_t, sock_addr: *const sockaddr, addrlen: socklen_t) c_int;
 pub extern "c" fn accept4(sockfd: fd_t, addr: *sockaddr, addrlen: *socklen_t, flags: c_uint) c_int;
 pub extern "c" fn getsockopt(sockfd: fd_t, level: c_int, optname: c_int, optval: *c_void, optlen: *socklen_t) c_int;
+pub extern "c" fn setsockopt(sockfd: fd_t, level: c_int, optname: c_int, optval: *c_void, optlen: socklen_t) c_int;
 pub extern "c" fn send(sockfd: fd_t, buf: *const c_void, len: usize, flags: u32) isize;
 pub extern "c" fn sendto(
     sockfd: fd_t,

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1327,14 +1327,12 @@ pub const StreamServer = struct {
             self.sockfd = null;
         }
 
-        // TODO proper interface with errors in std.os
-        var optval: c_int = 1;
-
         if (self.options.reuse_address) {
-            _ = os.linux.setsockopt(
-                server.sockfd.?,
-                os.linux.SOL_SOCKET,
-                os.linux.SO_REUSEADDR,
+            var optval: c_int = 1;
+            try os.setsockopt(
+                self.sockfd.?,
+                os.SOL_SOCKET,
+                os.SO_REUSEADDR,
                 @ptrCast([*]const u8, &optval),
                 @sizeOf(c_int),
             );

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1283,6 +1283,7 @@ fn dnsParseCallback(ctx: dpc_ctx, rr: u8, data: []const u8, packet: []const u8) 
 pub const StreamServer = struct {
     /// Copied from `Options` on `init`.
     kernel_backlog: u32,
+    reuse_address: bool,
 
     /// `undefined` until `listen` returns successfully.
     listen_address: Address,
@@ -1305,6 +1306,7 @@ pub const StreamServer = struct {
         return StreamServer{
             .sockfd = null,
             .kernel_backlog = options.kernel_backlog,
+            .reuse_address = options.reuse_address,
             .listen_address = undefined,
         };
     }
@@ -1327,7 +1329,7 @@ pub const StreamServer = struct {
             self.sockfd = null;
         }
 
-        if (self.options.reuse_address) {
+        if (self.reuse_address) {
             var optval: c_int = 1;
             try os.setsockopt(
                 self.sockfd.?,

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1330,12 +1330,11 @@ pub const StreamServer = struct {
         }
 
         if (self.reuse_address) {
-            var opt = [_]u8{1} ** @sizeOf(c_int);
             try os.setsockopt(
                 self.sockfd.?,
                 os.SOL_SOCKET,
                 os.SO_REUSEADDR,
-                &opt,
+                &mem.toBytes(@as(c_int, 1)),
             );
         }
 

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1330,13 +1330,12 @@ pub const StreamServer = struct {
         }
 
         if (self.reuse_address) {
-            var optval: c_int = 1;
+            var opt = [_]u8{1} ** @sizeOf(c_int);
             try os.setsockopt(
                 self.sockfd.?,
                 os.SOL_SOCKET,
                 os.SO_REUSEADDR,
-                @ptrCast([*]const u8, &optval),
-                @sizeOf(c_int),
+                &opt,
             );
         }
 

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1294,6 +1294,9 @@ pub const StreamServer = struct {
         /// If more than this many connections pool in the kernel, clients will start
         /// seeing "Connection refused".
         kernel_backlog: u32 = 128,
+
+        /// Enable SO_REUSEADDR on the socket.
+        reuse_address: bool = false,
     };
 
     /// After this call succeeds, resources have been acquired and must
@@ -1322,6 +1325,19 @@ pub const StreamServer = struct {
         errdefer {
             os.close(sockfd);
             self.sockfd = null;
+        }
+
+        // TODO proper interface with errors in std.os
+        var optval: c_int = 1;
+
+        if (self.options.reuse_address) {
+            _ = os.linux.setsockopt(
+                server.sockfd.?,
+                os.linux.SOL_SOCKET,
+                os.linux.SO_REUSEADDR,
+                @ptrCast([*]const u8, &optval),
+                @sizeOf(c_int),
+            );
         }
 
         var socklen = address.getOsSockLen();

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3239,8 +3239,8 @@ pub fn sched_yield() SchedYieldError!void {
 }
 
 /// Set a socket's options.
-pub fn setsockopt(fd: fd_t, level: u32, optname: u32, optval: [*]const u8, optlen: socklen_t) !void {
-    switch (errno(system.setsockopt(fd, level, optname, optval, optlen))) {
+pub fn setsockopt(fd: fd_t, level: u32, optname: u32, opt: []const u8) !void {
+    switch (errno(system.setsockopt(fd, level, optname, opt.ptr, @intCast(socklen_t, opt.len)))) {
         0 => {},
         EBADF => unreachable,
         EINVAL => unreachable,
@@ -3248,7 +3248,6 @@ pub fn setsockopt(fd: fd_t, level: u32, optname: u32, optval: [*]const u8, optle
         EISCONN => return error.AlreadyConnected,
         ENOPROTOOPT => return error.InvalidProtocolOption,
         ENOTSOCK => return error.NotSocket,
-
         ENOMEM => return error.OutOfMemory,
         ENOBUFS => return error.SystemResources,
 

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3239,16 +3239,14 @@ pub fn sched_yield() SchedYieldError!void {
 }
 
 /// Set a socket's options.
-pub fn setsockopt(fd: fd_t, level: u32, optname: u32, optval: [*]const u8, optlen: socklen_t) SetSockOptError!void {
-    const rc = system.setsockopt();
-
+pub fn setsockopt(fd: fd_t, level: u32, optname: u32, optval: [*]const u8, optlen: socklen_t) !void {
     switch (errno(system.setsockopt(fd, level, optname, optval, optlen))) {
         0 => {},
         EBADF => unreachable,
         EINVAL => unreachable,
         EDOM => return error.TimeoutTooBig,
         EISCONN => return error.AlreadyConnected,
-        ENOPROTOOOPT => return error.InvalidProtocolOption,
+        ENOPROTOOPT => return error.InvalidProtocolOption,
         ENOTSOCK => return error.NotSocket,
 
         ENOMEM => return error.OutOfMemory,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3237,3 +3237,23 @@ pub fn sched_yield() SchedYieldError!void {
         else => return error.SystemCannotYield,
     }
 }
+
+/// Set a socket's options.
+pub fn setsockopt(fd: fd_t, level: u32, optname: u32, optval: [*]const u8, optlen: socklen_t) SetSockOptError!void {
+    const rc = system.setsockopt();
+
+    switch (errno(system.setsockopt(fd, level, optname, optval, optlen))) {
+        0 => {},
+        EBADF => unreachable,
+        EINVAL => unreachable,
+        EDOM => return error.TimeoutTooBig,
+        EISCONN => return error.AlreadyConnected,
+        ENOPROTOOOPT => return error.InvalidProtocolOption,
+        ENOTSOCK => return error.NotSocket,
+
+        ENOMEM => return error.OutOfMemory,
+        ENOBUFS => return error.SystemResources,
+
+        else => |err| return std.os.unexpectedErrno(err),
+    }
+}

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3244,13 +3244,10 @@ pub fn setsockopt(fd: fd_t, level: u32, optname: u32, opt: []const u8) !void {
         0 => {},
         EBADF => unreachable,
         EINVAL => unreachable,
-        EDOM => return error.TimeoutTooBig,
+        EFAULT => unreachable,
         EISCONN => return error.AlreadyConnected,
         ENOPROTOOPT => return error.InvalidProtocolOption,
-        ENOTSOCK => return error.NotSocket,
-        ENOMEM => return error.OutOfMemory,
-        ENOBUFS => return error.SystemResources,
-
-        else => |err| return std.os.unexpectedErrno(err),
+        ENOTSOCK => unreachable,
+        else => |err| return unexpectedErrno(err),
     }
 }


### PR DESCRIPTION
 - add `std.os.setsockopt`
 - "fix" setsockopt / getsockopt in `std.c` so their parameters align with the linux syscall parameters