### PR TITLE
WasmPageAllocator

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -252,6 +252,12 @@ extern fn @"llvm.wasm.memory.size.i32"(u32) u32;
 extern fn @"llvm.wasm.memory.grow.i32"(u32, u32) i32;
 
 const WasmPageAllocator = struct {
+    comptime {
+        if (!std.Target.current.isWasm()) {
+            @compileError("WasmPageAllocator is only available for wasm32 arch");
+        }
+    }
+
     const PageStatus = enum(u1) {
         used = 0,
         free = 1,
@@ -797,7 +803,7 @@ test "c_allocator" {
 }
 
 test "WasmPageAllocator internals" {
-    if (std.Target.current.isWasm()) {
+    if (comptime std.Target.current.isWasm()) {
         const none_free = WasmPageAllocator.PageStatus.none_free;
         std.debug.assert(none_free == WasmPageAllocator.conventional.data[0]); // Passes if this test runs first
         std.debug.assert(!WasmPageAllocator.extended.isInitialized()); // Passes if this test runs first

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -794,8 +794,10 @@ test "PageAllocator" {
     const allocator = page_allocator;
     try testAllocator(allocator);
     try testAllocatorAligned(allocator, 16);
-    try testAllocatorLargeAlignment(allocator);
-    try testAllocatorAlignedShrink(allocator);
+    if (!std.Target.current.isWasm()) {
+        try testAllocatorLargeAlignment(allocator);
+        try testAllocatorAlignedShrink(allocator);
+    }
 
     if (builtin.os == .windows) {
         // Trying really large alignment. As mentionned in the implementation,
@@ -832,7 +834,7 @@ test "ArenaAllocator" {
     try testAllocatorAlignedShrink(&arena_allocator.allocator);
 }
 
-var test_fixed_buffer_allocator_memory: [80000 * @sizeOf(u64)]u8 = undefined;
+var test_fixed_buffer_allocator_memory: [800000 * @sizeOf(u64)]u8 = undefined;
 test "FixedBufferAllocator" {
     var fixed_buffer_allocator = FixedBufferAllocator.init(test_fixed_buffer_allocator_memory[0..]);
 
@@ -955,8 +957,7 @@ fn testAllocatorAligned(allocator: *mem.Allocator, comptime alignment: u29) !voi
 fn testAllocatorLargeAlignment(allocator: *mem.Allocator) mem.Allocator.Error!void {
     //Maybe a platform's page_size is actually the same as or
     //  very near usize?
-    //if (mem.page_size << 2 > maxInt(usize)) return;
-    if (mem.page_size << 2 > 32768) return;
+    if (mem.page_size << 2 > maxInt(usize)) return;
 
     const USizeShift = @IntType(false, std.math.log2(usize.bit_count));
     const large_align = @as(u29, mem.page_size << 2);

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -334,12 +334,10 @@ const WasmPageAllocator = struct {
             return error.OutOfMemory;
         }
 
-        if (old_mem.len == 0) {
-            return alloc(allocator, new_size, new_align);
+        if (nPages(new_size) == nPages(old_mem.len)) {
+            return old_mem.ptr[0..new_size];
         } else if (new_size < old_mem.len) {
             return shrink(allocator, old_mem, old_align, new_size, new_align);
-        } else if (nPages(new_size) == nPages(old_mem.len)) {
-            return old_mem.ptr[0..new_size];
         } else {
             const new_mem = try alloc(allocator, new_size, new_align);
             std.mem.copy(u8, new_mem, old_mem);

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -379,8 +379,11 @@ const WasmPageAllocator = struct {
             }
 
             if (free_start < extendedOffset()) {
-                conventional.recycle(free_start, free_end - free_start);
-            } else {
+                const clamped_end = std.math.min(extendedOffset(), free_end);
+                conventional.recycle(free_start, clamped_end - free_start);
+            }
+
+            if (free_end > extendedOffset()) {
                 if (extended.totalPages() == 0) {
                     // Steal the last page from the memory currently being recycled
                     // TODO: would it be better if we use the first page instead?
@@ -390,7 +393,8 @@ const WasmPageAllocator = struct {
                     // Since this is the first page being freed and we consume it, assume *nothing* is free.
                     std.mem.set(u8, extended.bytes, FreeBlock.used);
                 }
-                extended.recycle(free_start - extendedOffset(), free_end - free_start);
+                const clamped_start = std.math.max(extendedOffset(), free_start);
+                extended.recycle(clamped_start - extendedOffset(), free_end - clamped_start);
             }
         }
 

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -257,6 +257,9 @@ test "" {
 }
 
 const WasmPageAllocator = struct {
+    // TODO: figure out why __heap_base cannot be found
+    var heap_base_wannabe: [256]u8 = undefined;
+
     const FreeBlock = struct {
         offset: usize = 0,
         packed_data: std.PackedIntSlice(u1) = std.PackedIntSlice(u1).init(&[_]u8{}, 0),
@@ -349,7 +352,8 @@ const WasmPageAllocator = struct {
 
         if (free_end > free_start) {
             if (conventional.totalPages() == 0) {
-                conventional.initData(__heap_base[0..@intCast(usize, @"llvm.wasm.memory.size.i32"(0) * std.mem.page_size)]);
+                //conventional.initData(__heap_base[0..@intCast(usize, @"llvm.wasm.memory.size.i32"(0) * std.mem.page_size)]);
+                conventional.initData(heap_base_wannabe[0..]);
             }
 
             if (free_start < conventional.totalPages()) {

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -325,7 +325,7 @@ const WasmPageAllocator = struct {
 
     var _conventional_data = [_]u128{0} ** 16;
     // Marking `conventional` as const saves ~40 bytes
-    var conventional = FreeBlock{ .data = &_conventional_data };
+    const conventional = FreeBlock{ .data = &_conventional_data };
     var extended = FreeBlock{ .data = &[_]u128{} };
 
     fn extendedOffset() usize {


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/3789

* [x] fuzz test
* [x] figure out large alignment tests — I turned off the alignment tests for wasm and updated the other semi-unrelated failures (giving 800K to FBA). The existing PageAllocator handles large alignment, but we've also discussed potentially simplifying them to only be page aligned.
* [x] optimize scan algorithm
* [x] ~import `__heap_base` properly~ — this is an internal detail of LLVM, plus having variable page size leads to unpredictable performance and behavior
* [x] optimize binary size