### PR TITLE
Fixes to docs markdown parser

### DIFF
--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -1380,6 +1380,8 @@
     }
 
     function markdown(input) {
+        try {
+        
         const raw_lines = input.split('\n'); // zig allows no '\r', so we don't need to split on CR
         const lines = [];
 
@@ -1432,7 +1434,7 @@
                     line.type = "ul";
                     line.text = line.text.substr(1);
                 }
-                else if (line.text.match(/\d+\./)) {
+                else if (line.text.match(/^\d+\..*$/)) { // if line starts with {number}{dot}
                     const match = line.text.match(/(\d+)\./);
                     line.type = "ul";
                     line.text = line.text.substr(match[0].length);
@@ -1662,6 +1664,13 @@
         }
 
         return html;
+        
+        } catch (er) {
+            setTimeout(function() {
+                throw er;
+            }, 1);
+            return escapeHtml(input);
+        }
     }
 
     function activateSelectedResult() {


### PR DESCRIPTION
Fixes #3722

Markdown parser seems a bit buggy so it makes sense to wrap it in a `try catch` and provide a fallback. Exceptions are rethrown into the global scope.