### PR TITLE
Add hotpath for BufferedOutStream

### DIFF
--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -592,7 +592,14 @@ pub fn BufferedOutStreamCustom(comptime buffer_size: usize, comptime OutStreamEr
         fn writeFn(out_stream: *Stream, bytes: []const u8) Error!void {
             const self = @fieldParentPtr(Self, "stream", out_stream);
 
-            if (bytes.len >= self.buffer.len) {
+            if (bytes.len == 1) {
+                self.buffer[self.index] = bytes[0];
+                self.index += 1;
+                if (self.index == buffer_size) {
+                    try self.flush();
+                }
+                return;
+            } else if (bytes.len >= self.buffer.len) {
                 try self.flush();
                 return self.unbuffered_out_stream.write(bytes);
             }

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -593,6 +593,8 @@ pub fn BufferedOutStreamCustom(comptime buffer_size: usize, comptime OutStreamEr
             const self = @fieldParentPtr(Self, "stream", out_stream);
 
             if (bytes.len == 1) {
+                // This is not required logic but a shorter path
+                // for single byte writes
                 self.buffer[self.index] = bytes[0];
                 self.index += 1;
                 if (self.index == buffer_size) {


### PR DESCRIPTION
Same concept as #3845 just for writes.  Improves the read write cycle from ~90MB/s to ~120MB/s.
Before
```
904396800 bytes (904 MB, 862 MiB) copied, 9.99809 s, 90.5 MB/s
```
After
```
1220345856 bytes (1.2 GB, 1.1 GiB) copied, 9.99803 s, 122 MB/s
```


To test run in release fast:

```zig
const std = @import("std");
const net = std.net;
const File = std.fs.File;

pub fn main() anyerror!void {
    const allocator = std.heap.direct_allocator;
    const req_listen_addr = try net.Address.parseIp4("127.0.0.1", 9002);
    var server = net.StreamServer.init(.{});
    defer server.deinit();
    try server.listen(req_listen_addr);
    std.debug.warn("listening at {}\n", server.listen_address);
    const conn = try server.accept();
    std.debug.warn("connected to {}\n", conn.address);
    try echoBufferedInStream(conn);
}

pub fn echoBufferedInStream(conn: net.StreamServer.Connection) !void {
    std.debug.warn("echoBufferedInStream\n");
    const in_stream = &std.io.BufferedInStream(File.ReadError).init(
        &conn.file.inStream().stream).stream;
    const out_stream = &std.io.BufferedOutStream(File.WriteError).init(
        &conn.file.outStream().stream).stream;
    while (true) {
        var c = try in_stream.readByte();
        try out_stream.writeByte(c);
    }
}
```

Then in another shell run `dd bs=64k count=10G if=/dev/zero iflag=count_bytes | nc -v -N 127.0.0.1 9002 > /dev/null`

The gain here scales. Using findings from #3840 I'm able to echo with a `readByte`, `writeByte` loop at around  `500MB/s` (it is 250MB/s before this change).