### PR TITLE
Fix for @Type not picking up the sentinel value

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -23065,7 +23065,7 @@ static Error get_const_field_sentinel(IrAnalyze *ira, IrInstruction *source_inst
     if (field_val == nullptr)
         return ErrorSemanticAnalyzeFail;
 
-    IrInstruction *field_inst = ir_const(ira, source_instr, field_val->type);
+    IrInstruction *field_inst = ir_const_move(ira, source_instr, field_val);
     IrInstruction *casted_field_inst = ir_implicit_cast(ira, field_inst,
             get_optional_type(ira->codegen, elem_type));
     if (type_is_invalid(casted_field_inst->value->type))

--- a/test/stage1/behavior/type.zig
+++ b/test/stage1/behavior/type.zig
@@ -144,3 +144,30 @@ test "@Type create slice with null sentinel" {
     });
     testing.expect(Slice == []align(8) const *i32);
 }
+test "@Type picks up the sentinel value from TypeInfo" {
+    testTypes(&[_]type{
+        [11:0]u8,                            [4:10]u8,
+        [*:0]u8,                             [*:0]const u8,
+        [*:0]volatile u8,                    [*:0]const volatile u8,
+        [*:0]align(4) u8,                    [*:0]align(4) const u8,
+        [*:0]align(4) volatile u8,           [*:0]align(4) const volatile u8,
+        [*:0]align(8) u8,                    [*:0]align(8) const u8,
+        [*:0]align(8) volatile u8,           [*:0]align(8) const volatile u8,
+        [*:0]allowzero u8,                   [*:0]allowzero const u8,
+        [*:0]allowzero volatile u8,          [*:0]allowzero const volatile u8,
+        [*:0]allowzero align(4) u8,          [*:0]allowzero align(4) const u8,
+        [*:0]allowzero align(4) volatile u8, [*:0]allowzero align(4) const volatile u8,
+        [*:5]allowzero align(4) volatile u8, [*:5]allowzero align(4) const volatile u8,
+        [:0]u8,                              [:0]const u8,
+        [:0]volatile u8,                     [:0]const volatile u8,
+        [:0]align(4) u8,                     [:0]align(4) const u8,
+        [:0]align(4) volatile u8,            [:0]align(4) const volatile u8,
+        [:0]align(8) u8,                     [:0]align(8) const u8,
+        [:0]align(8) volatile u8,            [:0]align(8) const volatile u8,
+        [:0]allowzero u8,                    [:0]allowzero const u8,
+        [:0]allowzero volatile u8,           [:0]allowzero const volatile u8,
+        [:0]allowzero align(4) u8,           [:0]allowzero align(4) const u8,
+        [:0]allowzero align(4) volatile u8,  [:0]allowzero align(4) const volatile u8,
+        [:4]allowzero align(4) volatile u8,  [:4]allowzero align(4) const volatile u8,
+    });
+}


### PR DESCRIPTION
The code converted the whole TypeInfo payload into an optional type
instead of using the "sentinel" field value.

Fixes #3828