### PR TITLE
Make array types (quasi-)lazy

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -322,6 +322,7 @@ enum LazyValueId {
     LazyValueIdSliceType,
     LazyValueIdFnType,
     LazyValueIdErrUnionType,
+    LazyValueIdArrayType,
 };
 
 struct LazyValue {
@@ -353,6 +354,15 @@ struct LazyValueSliceType {
     bool is_const;
     bool is_volatile;
     bool is_allowzero;
+};
+
+struct LazyValueArrayType {
+    LazyValue base;
+
+    IrAnalyze *ira;
+    IrInstruction *sentinel; // can be null
+    IrInstruction *elem_type;
+    uint64_t length;
 };
 
 struct LazyValuePtrType {

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -791,3 +791,12 @@ test "struct with var field" {
     expect(pt.x == 1);
     expect(pt.y == 2);
 }
+
+test "self-referencing struct via array member" {
+    const T = struct {
+        children: [1]*@This(),
+    };
+    var x: T = undefined;
+    x = T{ .children = .{&x} };
+    expect(x.children[0] == &x);
+}


### PR DESCRIPTION
Fixes #3843

Quasi-lazy because the length field is resolved as soon as possible in order to implement the zero-bits/one-value tests.