### PR TITLE
lib/std/io: let the bring-your-own OS package handle stdio

### DIFF
--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -56,13 +56,13 @@ fn getStdErrHandle() os.fd_t {
     }
 
     if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdErrHandle")) {
-        return root.os.io.getStdOutHandle();
+        return root.os.io.getStdErrHandle();
     }
 
     return os.STDERR_FILENO;
 }
 
-pub fn getStdErr() file {
+pub fn getStdErr() File {
     return File.openHandle(getStdErrHandle());
 }
 

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -38,6 +38,11 @@ pub fn getStdOut() File {
     if (builtin.os == .windows) {
         return File.openHandle(os.windows.peb().ProcessParameters.hStdOutput);
     }
+
+    if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdOut")) {
+        return File{ .handle = root.os.io.getStdOut() };
+    }
+
     return File.openHandle(os.STDOUT_FILENO);
 }
 
@@ -45,6 +50,11 @@ pub fn getStdErr() File {
     if (builtin.os == .windows) {
         return File.openHandle(os.windows.peb().ProcessParameters.hStdError);
     }
+
+    if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdErr")) {
+        return File{ .handle = root.os.io.getStdErr() };
+    }
+
     return File.openHandle(os.STDERR_FILENO);
 }
 
@@ -52,6 +62,11 @@ pub fn getStdIn() File {
     if (builtin.os == .windows) {
         return File.openHandle(os.windows.peb().ProcessParameters.hStdInput);
     }
+
+    if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdIn")) {
+        return File{ .handle = root.os.io.getStdIn() };
+    }
+
     return File.openHandle(os.STDIN_FILENO);
 }
 

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -34,40 +34,52 @@ else
     Mode.blocking;
 pub const is_async = mode != .blocking;
 
-pub fn getStdOut() File {
+fn getStdOutHandle() os.fd_t {
     if (builtin.os == .windows) {
-        return File.openHandle(os.windows.peb().ProcessParameters.hStdOutput);
+        return os.windows.peb().ProcessParameters.hStdOutput;
     }
 
-    if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdOut")) {
-        return File{ .handle = root.os.io.getStdOut() };
+    if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdOutHandle")) {
+        return root.os.io.getStdOutHandle();
     }
 
-    return File.openHandle(os.STDOUT_FILENO);
+    return os.STDOUT_FILENO;
 }
 
-pub fn getStdErr() File {
+pub fn getStdOut() File {
+    return File.openHandle(getStdOutHandle());
+}
+
+fn getStdErrHandle() os.fd_t {
     if (builtin.os == .windows) {
-        return File.openHandle(os.windows.peb().ProcessParameters.hStdError);
+        return os.windows.peb().ProcessParameters.hStdError;
     }
 
-    if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdErr")) {
-        return File{ .handle = root.os.io.getStdErr() };
+    if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdErrHandle")) {
+        return root.os.io.getStdOutHandle();
     }
 
-    return File.openHandle(os.STDERR_FILENO);
+    return os.STDERR_FILENO;
+}
+
+pub fn getStdErr() file {
+    return File.openHandle(getStdErrHandle());
+}
+
+fn getStdInHandle() os.fd_t {
+    if (builtin.os == .windows) {
+        return os.windows.peb().ProcessParameters.hStdInput;
+    }
+
+    if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdInHandle")) {
+        return root.os.io.getStdInHandle();
+    }
+
+    return os.STDIN_FILENO;
 }
 
 pub fn getStdIn() File {
-    if (builtin.os == .windows) {
-        return File.openHandle(os.windows.peb().ProcessParameters.hStdInput);
-    }
-
-    if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdIn")) {
-        return File{ .handle = root.os.io.getStdIn() };
-    }
-
-    return File.openHandle(os.STDIN_FILENO);
+    return File.openHandle(getStdInHandle());
 }
 
 pub const SeekableStream = @import("io/seekable_stream.zig").SeekableStream;


### PR DESCRIPTION
This lets you do things like this in the custom OS package:

```zig
pub const io = struct {
    pub fn getStdIn() bits.fd_t {
        if (bits.STDIN_FILENO == -1) {
            bits.STDIN_FILENO = resource.io_get_stdin();
        }

        return bits.STDIN_FILENO;
    }

    pub fn getStdErr() bits.fd_t {
        if (bits.STDERR_FILENO == -1) {
            bits.STDERR_FILENO = resource.io_get_stderr();
        }

        return bits.STDERR_FILENO;
    }

    pub fn getStdOut() bits.fd_t {
        if (bits.STDOUT_FILENO == -1) {
            bits.STDOUT_FILENO = resource.io_get_stdout();
        }

        return bits.STDOUT_FILENO;
    }
};
```