### PR TITLE
lib/std/os: handle exit() for bring-your-own-OS package

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -248,6 +248,9 @@ pub fn kill(pid: pid_t, sig: u8) KillError!void {
 
 /// Exits the program cleanly with the specified status code.
 pub fn exit(status: u8) noreturn {
+    if (@hasDecl(root, "os") and @hasDecl(root.os, "exit")) {
+        root.os.exit(status);
+    }
     if (builtin.link_libc) {
         system.exit(status);
     }


### PR DESCRIPTION
```zig
// allyourbase.zig
pub const os = @import("./olin/olin.zig");
const std = @import("std");

pub fn main() anyerror!void {
    std.debug.warn("All your base are belong to us.\n", .{});
    std.os.exit(1);
}
```

```zig
// olin/olin.zig
// ...

pub fn exit(status: u8) noreturn {
    runtime.exit(@intCast(i32, status));
}

// ...
```

```console
$ cwa -main-func _start allyourbase.wasm
All your base are belong to us.
2019/12/11 23:42:45 allyourbase.wasm: exit status 1
```