### PR TITLE
std/special: expose callMain

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -424,6 +424,10 @@ pub const panic: PanicFn = if (@hasDecl(root, "panic")) root.panic else default_
 /// therefore must be kept in sync with the compiler implementation.
 pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace) noreturn {
     @setCold(true);
+    if (@hasDecl(root, "os") and @hasDecl(root.os, "panic")) {
+        root.os.panic(msg, error_return_trace);
+        unreachable;
+    }
     switch (os) {
         .freestanding => {
             while (true) {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -198,6 +198,10 @@ pub fn abort() noreturn {
     if (builtin.os == .uefi) {
         exit(0); // TODO choose appropriate exit code
     }
+    if (builtin.os == .wasi) {
+        @breakpoint();
+        exit(1);
+    }
 
     system.abort();
 }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -187,19 +187,19 @@ pub fn abort() noreturn {
         }
         windows.kernel32.ExitProcess(3);
     }
-    if (builtin.link_libc) {
-        system.abort();
+    if (!builtin.link_libc and builtin.os == .linux) {
+        raise(SIGABRT) catch {};
+
+        // TODO the rest of the implementation of abort() from musl libc here
+
+        raise(SIGKILL) catch {};
+        exit(127);
     }
     if (builtin.os == .uefi) {
         exit(0); // TODO choose appropriate exit code
     }
 
-    raise(SIGABRT) catch {};
-
-    // TODO the rest of the implementation of abort() from musl libc here
-
-    raise(SIGKILL) catch {};
-    exit(127);
+    system.abort();
 }
 
 pub const RaiseError = UnexpectedError;

--- a/lib/std/special.zig
+++ b/lib/std/special.zig
@@ -1,0 +1,1 @@
+pub const start = @import("special/start.zig");

--- a/lib/std/special/c.zig
+++ b/lib/std/special/c.zig
@@ -83,7 +83,7 @@ pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn
         @setCold(true);
         std.debug.panic("{}", msg);
     }
-    if (builtin.os != .freestanding) {
+    if (builtin.os != .freestanding and builtin.os != .other) {
         std.os.abort();
     }
     while (true) {}

--- a/lib/std/special/start.zig
+++ b/lib/std/special/start.zig
@@ -17,6 +17,7 @@ const is_mips = switch (builtin.arch) {
     .mips, .mipsel, .mips64, .mips64el => true,
     else => false,
 };
+const start_sym_name = if (is_mips) "__start" else "_start";
 
 comptime {
     if (builtin.output_mode == .Lib and builtin.link_mode == .Dynamic) {
@@ -34,14 +35,10 @@ comptime {
             }
         } else if (builtin.os == .uefi) {
             if (!@hasDecl(root, "EfiMain")) @export("EfiMain", EfiMain, .Strong);
-        } else if (builtin.os != .freestanding) {
-            if (is_mips) {
-                if (!@hasDecl(root, "__start")) @export("__start", _start, .Strong);
-            } else {
-                if (!@hasDecl(root, "_start")) @export("_start", _start, .Strong);
-            }
-        } else if (is_wasm) {
-            if (!@hasDecl(root, "_start")) @export("_start", wasm_freestanding_start, .Strong);
+        } else if (is_wasm and builtin.os == .freestanding) {
+            if (!@hasDecl(root, start_sym_name)) @export(start_sym_name, wasm_freestanding_start, .Strong);
+        } else if (builtin.os != .other and builtin.os != .freestanding) {
+            if (!@hasDecl(root, start_sym_name)) @export(start_sym_name, _start, .Strong);
         }
     }
 }

--- a/lib/std/special/start.zig
+++ b/lib/std/special/start.zig
@@ -244,7 +244,7 @@ async fn callMainAsync(loop: *std.event.Loop) u8 {
 
 // This is not marked inline because it is called with @asyncCall when
 // there is an event loop.
-fn callMain() u8 {
+pub fn callMain() u8 {
     switch (@typeInfo(@TypeOf(root.main).ReturnType)) {
         .NoReturn => {
             root.main();

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -65,6 +65,7 @@ pub const time = @import("time.zig");
 pub const unicode = @import("unicode.zig");
 pub const valgrind = @import("valgrind.zig");
 pub const zig = @import("zig.zig");
+pub const special = @import("special.zig");
 
 test "" {
     meta.refAllDecls(@This());


### PR DESCRIPTION
Other fixes added to fix issues found in development.

This allows the bring-your-own-OS support to specify a custom entrypoint with `root.os._start`.