### PR TITLE
Fix dot init parsing

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1923,7 +1923,11 @@ static AstNode *ast_parse_anon_lit(ParseContext *pc) {
     }
 
     // anon container literal
-    return ast_parse_init_list(pc);
+    AstNode *res = ast_parse_init_list(pc);
+    if (res != nullptr)
+        return res;
+    put_back_token(pc);
+    return nullptr;
 }
 
 // AsmOutput <- COLON AsmOutputList AsmInput?

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,6 +2,18 @@ const tests = @import("tests.zig");
 const builtin = @import("builtin");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
+    cases.add("invalid float literal",
+        \\const std = @import("std");
+        \\
+        \\pub fn main() void {
+        \\    var bad_float :f32 = 0.0;
+        \\    bad_float = bad_float + .20;
+        \\    std.debug.assert(bad_float < 1.0);
+        \\})
+    , &[_][]const u8{
+        "tmp.zig:5:29: error: invalid token: '.'",
+    });
+
     cases.add("var args without c calling conv",
         \\fn foo(args: ...) void {}
         \\comptime {


### PR DESCRIPTION
Closes #3864
Closes #3889
#3889 doesn't work if there is a space between the dot and the number.