### PR TITLE
ci/azure/on_master_success: adapt script for Microsoft's unannounced repo changes

### DIFF
--- a/ci/azure/on_master_success
+++ b/ci/azure/on_master_success
@@ -5,7 +5,7 @@ set +x
 
 set -e
 
-sudo apt-get update -y
+sudo apt-get update -y --allow-releaseinfo-chang
 sudo apt-get install -y curl jq
 
 OAUTH_TOKEN="$(cat "$DOWNLOADSECUREFILE_SECUREFILEPATH")"

--- a/ci/azure/on_master_success
+++ b/ci/azure/on_master_success
@@ -5,7 +5,7 @@ set +x
 
 set -e
 
-sudo apt-get update -y --allow-releaseinfo-chang
+sudo apt-get update -y --allow-releaseinfo-change
 sudo apt-get install -y curl jq
 
 OAUTH_TOKEN="$(cat "$DOWNLOADSECUREFILE_SECUREFILEPATH")"


### PR DESCRIPTION
TL;DR: Microsoft changed some of its repository metadata for their APT repo. This Ubuntu image we were using was not expecting that. `--allow-releaseinfo-change` is passed to `apt-get` so the script works like expected.