### PR TITLE
WIP: Add evented write support

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -408,7 +408,7 @@ pub fn OutputFormat(comptime mode: std.io.Mode) type {
                 .Union => {
                     if (comptime std.meta.trait.hasFn("format")(T)) {
                         // WARNING: API changed, added is_async param
-                        return value.format(fmt, options, context, Errors, outputFn, is_async);
+                        //return value.format(fmt, options, context, Errors, outputFn, is_async);
                     }
 
                     try output(context, Errors, outputFn, @typeName(T));

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -407,8 +407,8 @@ pub fn OutputFormat(comptime mode: std.io.Mode) type {
                 },
                 .Union => {
                     if (comptime std.meta.trait.hasFn("format")(T)) {
-                        // FIXME
-                        //return value.format(fmt, options, context, Errors, outputFn);
+                        // WARNING: API changed, added is_async param
+                        return value.format(fmt, options, context, Errors, outputFn, is_async);
                     }
 
                     try output(context, Errors, outputFn, @typeName(T));

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -271,13 +271,15 @@ pub const Address = extern union {
         options: std.fmt.FormatOptions,
         context: var,
         comptime Errors: type,
-        output: fn (@TypeOf(context), []const u8) Errors!void,
+        outputFn: if (std.io.is_async) async fn (@TypeOf(context), []const u8) Errors!void
+                  else fn (@TypeOf(context), []const u8) Errors!void,
     ) !void {
+        comptime const output = std.fmt.output; // TODO: A partial fn would be nice
         switch (self.any.family) {
             os.AF_INET => {
                 const port = mem.bigToNative(u16, self.in.port);
                 const bytes = @ptrCast(*const [4]u8, &self.in.addr);
-                try std.fmt.format(context, Errors, output, "{}.{}.{}.{}:{}", .{
+                try std.fmt.format(context, Errors, outputFn, "{}.{}.{}.{}:{}", .{
                     bytes[0],
                     bytes[1],
                     bytes[2],
@@ -288,7 +290,7 @@ pub const Address = extern union {
             os.AF_INET6 => {
                 const port = mem.bigToNative(u16, self.in6.port);
                 if (mem.eql(u8, self.in6.addr[0..12], &[_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff })) {
-                    try std.fmt.format(context, Errors, output, "[::ffff:{}.{}.{}.{}]:{}", .{
+                    try std.fmt.format(context, Errors, outputFn, "[::ffff:{}.{}.{}.{}]:{}", .{
                         self.in6.addr[12],
                         self.in6.addr[13],
                         self.in6.addr[14],
@@ -308,30 +310,30 @@ pub const Address = extern union {
                         break :blk buf;
                     },
                 };
-                try output(context, "[");
+                try output(context, Errors, outputFn, "[");
                 var i: usize = 0;
                 var abbrv = false;
                 while (i < native_endian_parts.len) : (i += 1) {
                     if (native_endian_parts[i] == 0) {
                         if (!abbrv) {
-                            try output(context, if (i == 0) "::" else ":");
+                            try output(context, Errors, outputFn, if (i == 0) "::" else ":");
                             abbrv = true;
                         }
                         continue;
                     }
-                    try std.fmt.format(context, Errors, output, "{x}", .{native_endian_parts[i]});
+                    try std.fmt.format(context, Errors, outputFn, "{x}", .{native_endian_parts[i]});
                     if (i != native_endian_parts.len - 1) {
-                        try output(context, ":");
+                        try output(context, Errors, outputFn, ":");
                     }
                 }
-                try std.fmt.format(context, Errors, output, "]:{}", .{port});
+                try std.fmt.format(context, Errors, outputFn, "]:{}", .{port});
             },
             os.AF_UNIX => {
                 if (!has_unix_sockets) {
                     unreachable;
                 }
 
-                try std.fmt.format(context, Errors, output, "{}", .{&self.un.path});
+                try std.fmt.format(context, Errors, outputFn, "{}", .{&self.un.path});
             },
             else => unreachable,
         }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -453,6 +453,7 @@ pub const WriteError = error{
     BrokenPipe,
     SystemResources,
     OperationAborted,
+    ConnectionResetByPeer,
 
     /// This error occurs when no global event loop is configured,
     /// and reading from the file descriptor would block.
@@ -524,6 +525,7 @@ pub fn writeMode(fd: fd_t, bytes: []const u8, comptime io_mode: std.io.Mode) Wri
             ENOSPC => return error.NoSpaceLeft,
             EPERM => return error.AccessDenied,
             EPIPE => return error.BrokenPipe,
+            ECONNRESET => return error.ConnectionResetByPeer,
             else => |err| return unexpectedErrno(err),
         }
     }


### PR DESCRIPTION
This is for #3557. "It works" but currently disables the ability to use a custom `value.format`.

It just adds separate "sync" functions while leaving the default functions async when using `.evented` mode. 

The `value.format` needs to have another parameter so it can select which output functions to use, ~~this compiles and runs but it reaches unreachable code so something's not right there (so I've disabled it for now).~~ Edit: The error appears to be unrelated.

I'm not sure what the implications of wrapping every output fn.

Also this is probably not the best way to do it so feel free to close this.

Edit: By "it works" I mean a simple StreamServer using .evented.