### PR TITLE
fix std.mem.addNullByte and implement sentinel slicing

### DIFF
--- a/lib/std/buffer.zig
+++ b/lib/std/buffer.zig
@@ -82,11 +82,11 @@ pub const Buffer = struct {
     }
 
     pub fn toSlice(self: Buffer) [:0]u8 {
-        return self.list.toSlice()[0..self.len()];
+        return self.list.toSlice()[0..self.len() :0];
     }
 
     pub fn toSliceConst(self: Buffer) [:0]const u8 {
-        return self.list.toSliceConst()[0..self.len()];
+        return self.list.toSliceConst()[0..self.len() :0];
     }
 
     pub fn shrink(self: *Buffer, new_len: usize) void {

--- a/lib/std/cstr.zig
+++ b/lib/std/cstr.zig
@@ -31,13 +31,21 @@ fn testCStrFnsImpl() void {
     testing.expect(mem.len(u8, "123456789") == 9);
 }
 
-/// Returns a mutable slice with 1 more byte of length which is a null byte.
+/// Returns a mutable, null-terminated slice with the same length as `slice`.
 /// Caller owns the returned memory.
 pub fn addNullByte(allocator: *mem.Allocator, slice: []const u8) ![:0]u8 {
     const result = try allocator.alloc(u8, slice.len + 1);
     mem.copy(u8, result, slice);
     result[slice.len] = 0;
-    return result;
+    return result[0..slice.len :0];
+}
+
+test "addNullByte" {
+    var buf: [30]u8 = undefined;
+    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+    const slice = try addNullByte(allocator, "hello"[0..4]);
+    testing.expect(slice.len == 4);
+    testing.expect(slice[4] == 0);
 }
 
 pub const NullTerminated2DArray = struct {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -231,9 +231,10 @@ pub const Allocator = struct {
     pub fn free(self: *Allocator, memory: var) void {
         const Slice = @typeInfo(@TypeOf(memory)).Pointer;
         const bytes = @sliceToBytes(memory);
-        if (bytes.len == 0) return;
+        const bytes_len = bytes.len + @boolToInt(Slice.sentinel != null);
+        if (bytes_len == 0) return;
         const non_const_ptr = @intToPtr([*]u8, @ptrToInt(bytes.ptr));
-        const shrink_result = self.shrinkFn(self, non_const_ptr[0..bytes.len], Slice.alignment, 0, 1);
+        const shrink_result = self.shrinkFn(self, non_const_ptr[0..bytes_len], Slice.alignment, 0, 1);
         assert(shrink_result.len == 0);
     }
 };

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -364,11 +364,11 @@ pub fn len(comptime T: type, ptr: [*:0]const T) usize {
 }
 
 pub fn toSliceConst(comptime T: type, ptr: [*:0]const T) [:0]const T {
-    return ptr[0..len(T, ptr)];
+    return ptr[0..len(T, ptr) :0];
 }
 
 pub fn toSlice(comptime T: type, ptr: [*:0]T) [:0]T {
-    return ptr[0..len(T, ptr)];
+    return ptr[0..len(T, ptr) :0];
 }
 
 /// Returns true if all elements in a slice are equal to the scalar value provided

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -805,9 +805,9 @@ pub fn execvpeC(file: [*:0]const u8, child_argv: [*:null]const ?[*:0]const u8, e
         mem.copy(u8, &path_buf, search_path);
         path_buf[search_path.len] = '/';
         mem.copy(u8, path_buf[search_path.len + 1 ..], file_slice);
-        path_buf[search_path.len + file_slice.len + 1] = 0;
-        // TODO avoid @ptrCast here using slice syntax with https://github.com/ziglang/zig/issues/3770
-        err = execveC(@ptrCast([*:0]u8, &path_buf), child_argv, envp);
+        const path_len = search_path.len + file_slice.len + 1;
+        path_buf[path_len] = 0;
+        err = execveC(path_buf[0..path_len :0].ptr, child_argv, envp);
         switch (err) {
             error.AccessDenied => seen_eacces = true,
             error.FileNotFound, error.NotDir => {},
@@ -841,17 +841,13 @@ pub fn execvpe(
         const arg_buf = try allocator.alloc(u8, arg.len + 1);
         @memcpy(arg_buf.ptr, arg.ptr, arg.len);
         arg_buf[arg.len] = 0;
-
-        // TODO avoid @ptrCast using slice syntax with https://github.com/ziglang/zig/issues/3770
-        argv_buf[i] = @ptrCast([*:0]u8, arg_buf.ptr);
+        argv_buf[i] = arg_buf[0..arg.len :0].ptr;
     }
     argv_buf[argv_slice.len] = null;
+    const argv_ptr = argv_buf[0..argv_slice.len :null].ptr;
 
     const envp_buf = try createNullDelimitedEnvMap(allocator, env_map);
     defer freeNullDelimitedEnvMap(allocator, envp_buf);
-
-    // TODO avoid @ptrCast here using slice syntax with https://github.com/ziglang/zig/issues/3770
-    const argv_ptr = @ptrCast([*:null]?[*:0]u8, argv_buf.ptr);
 
     return execvpeC(argv_buf.ptr[0].?, argv_ptr, envp_buf.ptr);
 }
@@ -869,16 +865,13 @@ pub fn createNullDelimitedEnvMap(allocator: *mem.Allocator, env_map: *const std.
             @memcpy(env_buf.ptr, pair.key.ptr, pair.key.len);
             env_buf[pair.key.len] = '=';
             @memcpy(env_buf.ptr + pair.key.len + 1, pair.value.ptr, pair.value.len);
-            env_buf[env_buf.len - 1] = 0;
-
-            // TODO avoid @ptrCast here using slice syntax with https://github.com/ziglang/zig/issues/3770
-            envp_buf[i] = @ptrCast([*:0]u8, env_buf.ptr);
+            const len = env_buf.len - 1;
+            env_buf[len] = 0;
+            envp_buf[i] = env_buf[0..len :0].ptr;
         }
         assert(i == envp_count);
     }
-    // TODO avoid @ptrCast here using slice syntax with https://github.com/ziglang/zig/issues/3770
-    assert(envp_buf[envp_count] == null);
-    return @ptrCast([*:null]?[*:0]u8, envp_buf.ptr)[0..envp_count];
+    return envp_buf[0..envp_count :null];
 }
 
 pub fn freeNullDelimitedEnvMap(allocator: *mem.Allocator, envp_buf: []?[*:0]u8) void {

--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -1701,6 +1701,7 @@ pub const Node = struct {
             pub const Slice = struct {
                 start: *Node,
                 end: ?*Node,
+                sentinel: ?*Node,
             };
         };
 
@@ -1730,6 +1731,10 @@ pub const Node = struct {
 
                     if (range.end) |end| {
                         if (i < 1) return end;
+                        i -= 1;
+                    }
+                    if (range.sentinel) |sentinel| {
+                        if (i < 1) return sentinel;
                         i -= 1;
                     }
                 },

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -2331,7 +2331,7 @@ fn parsePrefixTypeOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node
 }
 
 /// SuffixOp
-///     <- LBRACKET Expr (DOT2 Expr?)? RBRACKET
+///     <- LBRACKET Expr (DOT2 (Expr (COLON Expr)?)?)? RBRACKET
 ///      / DOT IDENTIFIER
 ///      / DOTASTERISK
 ///      / DOTQUESTIONMARK
@@ -2349,11 +2349,16 @@ fn parseSuffixOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
 
             if (eatToken(it, .Ellipsis2) != null) {
                 const end_expr = try parseExpr(arena, it, tree);
+                const sentinel: ?*ast.Node = if (eatToken(it, .Colon) != null)
+                    try parseExpr(arena, it, tree)
+                else
+                    null;
                 break :blk OpAndToken{
                     .op = Op{
                         .Slice = Op.Slice{
                             .start = index_expr,
                             .end = end_expr,
+                            .sentinel = sentinel,
                         },
                     },
                     .token = try expectToken(it, tree, .RBracket),

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -419,10 +419,13 @@ test "zig fmt: pointer of unknown length" {
 test "zig fmt: spaces around slice operator" {
     try testCanonical(
         \\var a = b[c..d];
+        \\var a = b[c..d :0];
         \\var a = b[c + 1 .. d];
         \\var a = b[c + 1 ..];
         \\var a = b[c .. d + 1];
+        \\var a = b[c .. d + 1 :0];
         \\var a = b[c.a..d.e];
+        \\var a = b[c.a..d.e :0];
         \\
     );
 }

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -689,7 +689,13 @@ fn renderExpression(
                     try renderExpression(allocator, stream, tree, indent, start_col, range.start, after_start_space);
                     try renderToken(tree, stream, dotdot, indent, start_col, after_op_space); // ..
                     if (range.end) |end| {
-                        try renderExpression(allocator, stream, tree, indent, start_col, end, Space.None);
+                        const after_end_space = if (range.sentinel != null) Space.Space else Space.None;
+                        try renderExpression(allocator, stream, tree, indent, start_col, end, after_end_space);
+                    }
+                    if (range.sentinel) |sentinel| {
+                        const colon = tree.prevToken(sentinel.firstToken());
+                        try renderToken(tree, stream, colon, indent, start_col, Space.None); // :
+                        try renderExpression(allocator, stream, tree, indent, start_col, sentinel, Space.None);
                     }
                     return renderToken(tree, stream, suffix_op.rtoken, indent, start_col, space); // ]
                 },

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -810,6 +810,7 @@ struct AstNodeSliceExpr {
     AstNode *array_ref_expr;
     AstNode *start;
     AstNode *end;
+    AstNode *sentinel; // can be null
 };
 
 struct AstNodeFieldAccessExpr {
@@ -3388,6 +3389,7 @@ struct IrInstructionSliceSrc {
     IrInstruction *ptr;
     IrInstruction *start;
     IrInstruction *end;
+    IrInstruction *sentinel;
     ResultLoc *result_loc;
 };
 

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1779,6 +1779,7 @@ enum PanicMsgId {
     PanicMsgIdResumedFnPendingAwait,
     PanicMsgIdBadNoAsyncCall,
     PanicMsgIdResumeNotSuspendedFn,
+    PanicMsgIdBadSentinel,
 
     PanicMsgIdCount,
 };

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1425,7 +1425,12 @@ static void add_sentinel_check(CodeGen *g, LLVMValueRef sentinel_elem_ptr, ZigVa
     LLVMValueRef expected_sentinel = gen_const_val(g, sentinel, "");
 
     LLVMValueRef actual_sentinel = gen_load_untyped(g, sentinel_elem_ptr, 0, false, "");
-    LLVMValueRef ok_bit = LLVMBuildICmp(g->builder, LLVMIntEQ, actual_sentinel, expected_sentinel, "");
+    LLVMValueRef ok_bit;
+    if (sentinel->type->id == ZigTypeIdFloat) {
+        ok_bit = LLVMBuildFCmp(g->builder, LLVMRealOEQ, actual_sentinel, expected_sentinel, "");
+    } else {
+        ok_bit = LLVMBuildICmp(g->builder, LLVMIntEQ, actual_sentinel, expected_sentinel, "");
+    }
 
     LLVMBasicBlockRef fail_block = LLVMAppendBasicBlock(g->cur_fn_val, "SentinelFail");
     LLVMBasicBlockRef ok_block = LLVMAppendBasicBlock(g->cur_fn_val, "SentinelOk");

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -941,6 +941,8 @@ static Buf *panic_msg_buf(PanicMsgId msg_id) {
             return buf_create_from_str("async function called with noasync suspended");
         case PanicMsgIdResumeNotSuspendedFn:
             return buf_create_from_str("resumed a non-suspended function");
+        case PanicMsgIdBadSentinel:
+            return buf_create_from_str("sentinel mismatch");
     }
     zig_unreachable();
 }
@@ -1415,6 +1417,22 @@ static void add_bounds_check(CodeGen *g, LLVMValueRef target_val,
         LLVMValueRef upper_ok_val = LLVMBuildICmp(g->builder, upper_pred, target_val, upper_value, "");
         LLVMBuildCondBr(g->builder, upper_ok_val, ok_block, bounds_check_fail_block);
     }
+
+    LLVMPositionBuilderAtEnd(g->builder, ok_block);
+}
+
+static void add_sentinel_check(CodeGen *g, LLVMValueRef sentinel_elem_ptr, ZigValue *sentinel) {
+    LLVMValueRef expected_sentinel = gen_const_val(g, sentinel, "");
+
+    LLVMValueRef actual_sentinel = gen_load_untyped(g, sentinel_elem_ptr, 0, false, "");
+    LLVMValueRef ok_bit = LLVMBuildICmp(g->builder, LLVMIntEQ, actual_sentinel, expected_sentinel, "");
+
+    LLVMBasicBlockRef fail_block = LLVMAppendBasicBlock(g->cur_fn_val, "SentinelFail");
+    LLVMBasicBlockRef ok_block = LLVMAppendBasicBlock(g->cur_fn_val, "SentinelOk");
+    LLVMBuildCondBr(g->builder, ok_bit, ok_block, fail_block);
+
+    LLVMPositionBuilderAtEnd(g->builder, fail_block);
+    gen_safety_crash(g, PanicMsgIdBadSentinel);
 
     LLVMPositionBuilderAtEnd(g->builder, ok_block);
 }
@@ -5244,6 +5262,9 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutable *executable, IrInst
 
     bool want_runtime_safety = instruction->safety_check_on && ir_want_runtime_safety(g, &instruction->base);
 
+    ZigType *res_slice_ptr_type = instruction->base.value->type->data.structure.fields[slice_ptr_index]->type_entry;
+    ZigValue *sentinel = res_slice_ptr_type->data.pointer.sentinel;
+
     if (array_type->id == ZigTypeIdArray ||
         (array_type->id == ZigTypeIdPointer && array_type->data.pointer.ptr_len == PtrLenSingle))
     {
@@ -5265,6 +5286,15 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutable *executable, IrInst
                 LLVMValueRef array_end = LLVMConstInt(g->builtin_types.entry_usize->llvm_type,
                         array_type->data.array.len, false);
                 add_bounds_check(g, end_val, LLVMIntEQ, nullptr, LLVMIntULE, array_end);
+
+                if (sentinel != nullptr) {
+                    LLVMValueRef indices[] = {
+                        LLVMConstNull(g->builtin_types.entry_usize->llvm_type),
+                        end_val,
+                    };
+                    LLVMValueRef sentinel_elem_ptr = LLVMBuildInBoundsGEP(g->builder, array_ptr, indices, 2, "");
+                    add_sentinel_check(g, sentinel_elem_ptr, sentinel);
+                }
             }
         }
         if (!type_has_bits(array_type)) {
@@ -5297,6 +5327,10 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutable *executable, IrInst
 
         if (want_runtime_safety) {
             add_bounds_check(g, start_val, LLVMIntEQ, nullptr, LLVMIntULE, end_val);
+            if (sentinel != nullptr) {
+                LLVMValueRef sentinel_elem_ptr = LLVMBuildInBoundsGEP(g->builder, array_ptr, &end_val, 1, "");
+                add_sentinel_check(g, sentinel_elem_ptr, sentinel);
+            }
         }
 
         if (type_has_bits(array_type)) {
@@ -5337,18 +5371,24 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutable *executable, IrInst
             end_val = prev_end;
         }
 
+        LLVMValueRef src_ptr_ptr = LLVMBuildStructGEP(g->builder, array_ptr, (unsigned)ptr_index, "");
+        LLVMValueRef src_ptr = gen_load_untyped(g, src_ptr_ptr, 0, false, "");
+
         if (want_runtime_safety) {
             assert(prev_end);
             add_bounds_check(g, start_val, LLVMIntEQ, nullptr, LLVMIntULE, end_val);
             if (instruction->end) {
                 add_bounds_check(g, end_val, LLVMIntEQ, nullptr, LLVMIntULE, prev_end);
+
+                if (sentinel != nullptr) {
+                    LLVMValueRef sentinel_elem_ptr = LLVMBuildInBoundsGEP(g->builder, src_ptr, &end_val, 1, "");
+                    add_sentinel_check(g, sentinel_elem_ptr, sentinel);
+                }
             }
         }
 
-        LLVMValueRef src_ptr_ptr = LLVMBuildStructGEP(g->builder, array_ptr, (unsigned)ptr_index, "");
-        LLVMValueRef src_ptr = gen_load_untyped(g, src_ptr_ptr, 0, false, "");
         LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, tmp_struct_ptr, (unsigned)ptr_index, "");
-        LLVMValueRef slice_start_ptr = LLVMBuildInBoundsGEP(g->builder, src_ptr, &start_val, (unsigned)len_index, "");
+        LLVMValueRef slice_start_ptr = LLVMBuildInBoundsGEP(g->builder, src_ptr, &start_val, 1, "");
         gen_store_untyped(g, slice_start_ptr, ptr_field_ptr, 0, false);
 
         LLVMValueRef len_field_ptr = LLVMBuildStructGEP(g->builder, tmp_struct_ptr, (unsigned)len_index, "");

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -25122,14 +25122,16 @@ static IrInstruction *ir_analyze_instruction_slice(IrAnalyze *ira, IrInstruction
             if (array_type->data.pointer.ptr_len == PtrLenC) {
                 array_type = adjust_ptr_len(ira->codegen, array_type, PtrLenUnknown);
             }
-            non_sentinel_slice_ptr_type = array_type;
+            ZigType *maybe_sentineled_slice_ptr_type = array_type;
+            non_sentinel_slice_ptr_type = adjust_ptr_sentinel(ira->codegen, maybe_sentineled_slice_ptr_type, nullptr);
             if (!end) {
                 ir_add_error(ira, &instruction->base, buf_sprintf("slice of pointer must include end value"));
                 return ira->codegen->invalid_instruction;
             }
         }
     } else if (is_slice(array_type)) {
-        non_sentinel_slice_ptr_type = array_type->data.structure.fields[slice_ptr_index]->type_entry;
+        ZigType *maybe_sentineled_slice_ptr_type = array_type->data.structure.fields[slice_ptr_index]->type_entry;
+        non_sentinel_slice_ptr_type = adjust_ptr_sentinel(ira->codegen, maybe_sentineled_slice_ptr_type, nullptr);
         elem_type = non_sentinel_slice_ptr_type->data.pointer.child_type;
     } else {
         ir_add_error(ira, &instruction->base,

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,6 +2,17 @@ const tests = @import("tests.zig");
 const builtin = @import("builtin");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
+    cases.add("slice sentinel mismatch",
+        \\fn foo() [:0]u8 {
+        \\    var x: []u8 = undefined;
+        \\    return x;
+        \\}
+        \\comptime { _ = foo; }
+    , &[_][]const u8{
+        "tmp.zig:3:12: error: expected type '[:0]u8', found '[]u8'",
+        "tmp.zig:3:12: note: destination pointer requires a terminating '0' sentinel",
+    });
+
     cases.add("intToPtr with misaligned address",
         \\pub fn main() void {
         \\    var y = @intToPtr([*]align(4) u8, 5);

--- a/test/runtime_safety.zig
+++ b/test/runtime_safety.zig
@@ -1,12 +1,57 @@
 const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompareOutputContext) void {
-    cases.addRuntimeSafety("intToPtr with misaligned address",
+    cases.addRuntimeSafety("pointer slice sentinel mismatch",
+        \\const std = @import("std");
         \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
-        \\    if (@import("std").mem.eql(u8, message, "incorrect alignment")) {
-        \\        @import("std").os.exit(126); // good
+        \\    if (std.mem.eql(u8, message, "sentinel mismatch")) {
+        \\        std.process.exit(126); // good
         \\    }
-        \\    @import("std").os.exit(0); // test failed
+        \\    std.process.exit(0); // test failed
+        \\}
+        \\pub fn main() void {
+        \\    var buf: [4]u8 = undefined;
+        \\    const ptr = buf[0..].ptr;
+        \\    const slice = ptr[0..3 :0];
+        \\}
+    );
+
+    cases.addRuntimeSafety("slice slice sentinel mismatch",
+        \\const std = @import("std");
+        \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
+        \\    if (std.mem.eql(u8, message, "sentinel mismatch")) {
+        \\        std.process.exit(126); // good
+        \\    }
+        \\    std.process.exit(0); // test failed
+        \\}
+        \\pub fn main() void {
+        \\    var buf: [4]u8 = undefined;
+        \\    const slice = buf[0..];
+        \\    const slice2 = slice[0..3 :0];
+        \\}
+    );
+
+    cases.addRuntimeSafety("array slice sentinel mismatch",
+        \\const std = @import("std");
+        \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
+        \\    if (std.mem.eql(u8, message, "sentinel mismatch")) {
+        \\        std.process.exit(126); // good
+        \\    }
+        \\    std.process.exit(0); // test failed
+        \\}
+        \\pub fn main() void {
+        \\    var buf: [4]u8 = undefined;
+        \\    const slice = buf[0..3 :0];
+        \\}
+    );
+
+    cases.addRuntimeSafety("intToPtr with misaligned address",
+        \\const std = @import("std");
+        \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
+        \\    if (std.mem.eql(u8, message, "incorrect alignment")) {
+        \\        std.os.exit(126); // good
+        \\    }
+        \\    std.os.exit(0); // test failed
         \\}
         \\pub fn main() void {
         \\    var x: usize = 5;

--- a/test/runtime_safety.zig
+++ b/test/runtime_safety.zig
@@ -1,6 +1,34 @@
 const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompareOutputContext) void {
+    cases.addRuntimeSafety("slice sentinel mismatch - optional pointers",
+        \\const std = @import("std");
+        \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
+        \\    if (std.mem.eql(u8, message, "sentinel mismatch")) {
+        \\        std.process.exit(126); // good
+        \\    }
+        \\    std.process.exit(0); // test failed
+        \\}
+        \\pub fn main() void {
+        \\    var buf: [4]?*i32 = undefined;
+        \\    const slice = buf[0..3 :null];
+        \\}
+    );
+
+    cases.addRuntimeSafety("slice sentinel mismatch - floats",
+        \\const std = @import("std");
+        \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
+        \\    if (std.mem.eql(u8, message, "sentinel mismatch")) {
+        \\        std.process.exit(126); // good
+        \\    }
+        \\    std.process.exit(0); // test failed
+        \\}
+        \\pub fn main() void {
+        \\    var buf: [4]f32 = undefined;
+        \\    const slice = buf[0..3 :1.2];
+        \\}
+    );
+
     cases.addRuntimeSafety("pointer slice sentinel mismatch",
         \\const std = @import("std");
         \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {

--- a/test/stage1/behavior/slice.zig
+++ b/test/stage1/behavior/slice.zig
@@ -78,3 +78,22 @@ test "access len index of sentinel-terminated slice" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "obtaining a null terminated slice" {
+    // here we have a normal array
+    var buf: [50]u8 = undefined;
+
+    buf[0] = 'a';
+    buf[1] = 'b';
+    buf[2] = 'c';
+    buf[3] = 0;
+
+    // now we obtain a null terminated slice:
+    const ptr = buf[0..3 :0];
+
+    var runtime_len: usize = 3;
+    const ptr2 = buf[0..runtime_len :0];
+    // ptr2 is a null-terminated slice
+    comptime expect(@TypeOf(ptr2) == [:0]u8);
+    comptime expect(@TypeOf(ptr2[0..2]) == []u8);
+}


### PR DESCRIPTION
Closes #3770

checklist:
 * [x] add missing compile error for type coercing non-sentinel-terminated slice to sentinel-terminated slice
 * [x] fix `std.mem.addNullByte`
 * [x] implement #3770
 * [x] add runtime safety panic test for slicing arrays
 * [x] add runtime safety panic test for slicing pointers
 * [x] add runtime safety panic test for slicing slices
 * [x] slicing a sentinel-terminated pointer without this syntax yields a non-sentinel-terminated result.
 * [x] add runtime safety panic test when sentinel is float
 * [x] add runtime safety panic test when sentinel is optional pointer
 * [ ] ~index of a sentinel-terminated array which is comptime-known to be len, is a comptime-known value when loading. no-op with safety check when storing.~ moved to #3962
 * [ ] ~add compile error for sentinel assertion failed~ moved to #3963
 * [x] zig fmt new syntax
 * [x] fix test regressions
