### PR TITLE
Fix columns in array initializers being affected by multiline expressions

### DIFF
--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -565,6 +565,15 @@ pub const Node = struct {
         }
     }
 
+    pub fn findFirstWithId(self: *Node, id: Id) ?*Node {
+        if (self.id == id) return self;
+        var child_i: usize = 0;
+        while (self.iterate(child_i)) |child| : (child_i += 1) {
+            if (child.findFirstWithId(id)) |result| return result;
+        }
+        return null;
+    }
+
     pub fn dump(self: *Node, indent: usize) void {
         {
             var i: usize = 0;

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -890,15 +890,27 @@ fn renderExpression(
                         var i: usize = 0;
 
                         while (it.next()) |expr| : (i += 1) {
-                            if (expr.*.findFirstWithId(.MultilineStringLiteral) == null) {
-                                counting_stream.bytes_written = 0;
-                                var dummy_col: usize = 0;
-                                try renderExpression(allocator, &counting_stream.stream, tree, indent, &dummy_col, expr.*, Space.None);
-                                const width = @intCast(usize, counting_stream.bytes_written);
-                                const col = i % row_size;
-                                column_widths[col] = std.math.max(column_widths[col], width);
-                                expr_widths[i] = width;
+                            expr.*.dump(0);
+                            
+                            if (expr.*.findFirstWithId(.MultilineStringLiteral) != null
+                                or expr.*.findFirstWithId(.GroupedExpression) != null) {
+                                continue;
                             }
+                            
+                            if (expr.*.findFirstWithId(.SuffixOp)) |op| {
+                                const sfx_op = @fieldParentPtr(ast.Node.SuffixOp, "base", op);
+                                if (sfx_op.op == .ArrayInitializer) {
+                                    continue;
+                                }
+                            } 
+
+                            counting_stream.bytes_written = 0;
+                            var dummy_col: usize = 0;
+                            try renderExpression(allocator, &counting_stream.stream, tree, indent, &dummy_col, expr.*, Space.None);
+                            const width = @intCast(usize, counting_stream.bytes_written);
+                            const col = i % row_size;
+                            column_widths[col] = std.math.max(column_widths[col], width);
+                            expr_widths[i] = width;
                         }
 
                         var new_indent = indent + indent_delta;

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -890,13 +890,15 @@ fn renderExpression(
                         var i: usize = 0;
 
                         while (it.next()) |expr| : (i += 1) {
-                            counting_stream.bytes_written = 0;
-                            var dummy_col: usize = 0;
-                            try renderExpression(allocator, &counting_stream.stream, tree, indent, &dummy_col, expr.*, Space.None);
-                            const width = @intCast(usize, counting_stream.bytes_written);
-                            const col = i % row_size;
-                            column_widths[col] = std.math.max(column_widths[col], width);
-                            expr_widths[i] = width;
+                            if (expr.*.findFirstWithId(.MultilineStringLiteral) == null) {
+                                counting_stream.bytes_written = 0;
+                                var dummy_col: usize = 0;
+                                try renderExpression(allocator, &counting_stream.stream, tree, indent, &dummy_col, expr.*, Space.None);
+                                const width = @intCast(usize, counting_stream.bytes_written);
+                                const col = i % row_size;
+                                column_widths[col] = std.math.max(column_widths[col], width);
+                                expr_widths[i] = width;
+                            }
                         }
 
                         var new_indent = indent + indent_delta;


### PR DESCRIPTION
There's still some odd behaviour with grouped expressions and nested array initializers. I'll have some examples shortly.