### PR TITLE
Translate-C changes

### DIFF
--- a/src-self-hosted/clang.zig
+++ b/src-self-hosted/clang.zig
@@ -43,6 +43,7 @@ pub const struct_ZigClangImplicitCastExpr = @OpaqueType();
 pub const struct_ZigClangIncompleteArrayType = @OpaqueType();
 pub const struct_ZigClangIntegerLiteral = @OpaqueType();
 pub const struct_ZigClangMacroDefinitionRecord = @OpaqueType();
+pub const struct_ZigClangMacroExpansion = @OpaqueType();
 pub const struct_ZigClangMacroQualifiedType = @OpaqueType();
 pub const struct_ZigClangMemberExpr = @OpaqueType();
 pub const struct_ZigClangNamedDecl = @OpaqueType();
@@ -889,6 +890,7 @@ pub const ZigClangImplicitCastExpr = struct_ZigClangImplicitCastExpr;
 pub const ZigClangIncompleteArrayType = struct_ZigClangIncompleteArrayType;
 pub const ZigClangIntegerLiteral = struct_ZigClangIntegerLiteral;
 pub const ZigClangMacroDefinitionRecord = struct_ZigClangMacroDefinitionRecord;
+pub const ZigClangMacroExpansion = struct_ZigClangMacroExpansion;
 pub const ZigClangMacroQualifiedType = struct_ZigClangMacroQualifiedType;
 pub const ZigClangMemberExpr = struct_ZigClangMemberExpr;
 pub const ZigClangNamedDecl = struct_ZigClangNamedDecl;
@@ -1128,3 +1130,5 @@ pub extern fn ZigClangCompoundAssignOperator_getBeginLoc(*const ZigClangCompound
 pub extern fn ZigClangCompoundAssignOperator_getOpcode(*const ZigClangCompoundAssignOperator) ZigClangBO;
 pub extern fn ZigClangCompoundAssignOperator_getLHS(*const ZigClangCompoundAssignOperator) *const ZigClangExpr;
 pub extern fn ZigClangCompoundAssignOperator_getRHS(*const ZigClangCompoundAssignOperator) *const ZigClangExpr;
+
+pub extern fn ZigClangMacroExpansion_getDefinition(*const ZigClangMacroExpansion) *const ZigClangMacroDefinitionRecord;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1036,8 +1036,15 @@ struct AstNodeFloatLiteral {
     bool overflow;
 };
 
+enum IntLiteralFormat {
+    IntLiteralFormatNone,
+    IntLiteralFormatHex,
+    IntLiteralFormatOctal,
+};
+
 struct AstNodeIntLiteral {
     BigInt *bigint;
+    IntLiteralFormat format = IntLiteralFormatNone;
 };
 
 struct AstNodeStructValueField {
@@ -2129,6 +2136,7 @@ struct CodeGen {
     bool verbose_llvm_ir;
     bool verbose_cimport;
     bool verbose_cc;
+    bool quiet_translate_c;
     bool error_during_imports;
     bool generate_error_name_table;
     bool enable_cache; // mutually exclusive with output_dir

--- a/src/ast_render.cpp
+++ b/src/ast_render.cpp
@@ -615,8 +615,21 @@ static void render_node_extra(AstRender *ar, AstNode *node, bool grouped) {
             {
                 Buf rendered_buf = BUF_INIT;
                 buf_resize(&rendered_buf, 0);
-                bigint_append_buf(&rendered_buf, node->data.int_literal.bigint, 10);
-                fprintf(ar->f, "%s", buf_ptr(&rendered_buf));
+
+                switch (node->data.int_literal.format) {
+                    case IntLiteralFormatHex:
+                        bigint_append_buf(&rendered_buf, node->data.int_literal.bigint, 16);
+                        fprintf(ar->f, "0x%s", buf_ptr(&rendered_buf));
+                        break;
+                    case IntLiteralFormatOctal:
+                        bigint_append_buf(&rendered_buf, node->data.int_literal.bigint, 8);
+                        fprintf(ar->f, "0o%s", buf_ptr(&rendered_buf));
+                        break;
+                    case IntLiteralFormatNone:
+                        bigint_append_buf(&rendered_buf, node->data.int_literal.bigint, 10);
+                        fprintf(ar->f, "%s", buf_ptr(&rendered_buf));
+                        break;
+                }
             }
             break;
         case NodeTypeStringLiteral:

--- a/src/c_tokenizer.hpp
+++ b/src/c_tokenizer.hpp
@@ -17,6 +17,7 @@ enum CTokId {
     CTokIdNumLitInt,
     CTokIdNumLitFloat,
     CTokIdSymbol,
+    CTokIdPlus,
     CTokIdMinus,
     CTokIdLParen,
     CTokIdRParen,
@@ -26,7 +27,11 @@ enum CTokId {
     CTokIdBang,
     CTokIdTilde,
     CTokIdShl,
+    CTokIdShr,
     CTokIdLt,
+    CTokIdGt,
+    CTokIdInc,
+    CTokIdDec,
 };
 
 enum CNumLitSuffix {
@@ -38,9 +43,16 @@ enum CNumLitSuffix {
     CNumLitSuffixLLU,
 };
 
+enum CNumLitFormat {
+    CNumLitFormatNone,
+    CNumLitFormatHex,
+    CNumLitFormatOctal,
+};
+
 struct CNumLitInt {
     uint64_t x;
     CNumLitSuffix suffix;
+    CNumLitFormat format;
 };
 
 struct CTok {
@@ -81,6 +93,9 @@ enum CTokState {
     CTokStateNumLitIntSuffixLL,
     CTokStateNumLitIntSuffixUL,
     CTokStateGotLt,
+    CTokStateGotGt,
+    CTokStateGotPlus,
+    CTokStateGotMinus,
 };
 
 struct CTokenize {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,6 +93,7 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  --verbose-llvm-ir            enable compiler debug output for LLVM IR\n"
         "  --verbose-cimport            enable compiler debug output for C imports\n"
         "  --verbose-cc                 enable compiler debug output for C compilation\n"
+        "  --quiet-translate-c          disable translate C warnings\n"
         "  -dirafter [dir]              add directory to AFTER include search path\n"
         "  -isystem [dir]               add directory to SYSTEM include search path\n"
         "  -I[dir]                      add directory to include search path\n"
@@ -479,6 +480,7 @@ int main(int argc, char **argv) {
     bool verbose_llvm_ir = false;
     bool verbose_cimport = false;
     bool verbose_cc = false;
+    bool quiet_translate_c = false;
     ErrColor color = ErrColorAuto;
     CacheOpt enable_cache = CacheOptAuto;
     Buf *dynamic_linker = nullptr;
@@ -692,6 +694,8 @@ int main(int argc, char **argv) {
                 verbose_cimport = true;
             } else if (strcmp(arg, "--verbose-cc") == 0) {
                 verbose_cc = true;
+            } else if (strcmp(arg, "--quiet-translate-c") == 0) {
+                quiet_translate_c = true;
             } else if (strcmp(arg, "-rdynamic") == 0) {
                 rdynamic = true;
             } else if (strcmp(arg, "--each-lib-rpath") == 0) {
@@ -886,7 +890,7 @@ int main(int argc, char **argv) {
                 } else if (strcmp(arg, "--linker-script") == 0) {
                     linker_script = argv[i];
                 } else if (strcmp(arg, "--version-script") == 0) {
-                    version_script = buf_create_from_str(argv[i]); 
+                    version_script = buf_create_from_str(argv[i]);
                 } else if (strcmp(arg, "-target-glibc") == 0) {
                     target_glibc = argv[i];
                 } else if (strcmp(arg, "-rpath") == 0) {
@@ -1212,7 +1216,7 @@ int main(int argc, char **argv) {
             codegen_set_lib_version(g, ver_major, ver_minor, ver_patch);
             g->want_single_threaded = want_single_threaded;
             codegen_set_linker_script(g, linker_script);
-            g->version_script_path = version_script; 
+            g->version_script_path = version_script;
             if (each_lib_rpath)
                 codegen_set_each_lib_rpath(g, each_lib_rpath);
 
@@ -1228,6 +1232,7 @@ int main(int argc, char **argv) {
             g->verbose_llvm_ir = verbose_llvm_ir;
             g->verbose_cimport = verbose_cimport;
             g->verbose_cc = verbose_cc;
+            g->quiet_translate_c = quiet_translate_c;
             g->output_dir = output_dir;
             g->disable_gen_h = disable_gen_h;
             g->bundle_compiler_rt = bundle_compiler_rt;

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2605,6 +2605,11 @@ struct ZigClangSourceLocation ZigClangMacroDefinitionRecord_getSourceRange_getEn
     return bitcast(casted->getSourceRange().getEnd());
 }
 
+const struct ZigClangMacroDefinitionRecord *ZigClangMacroExpansion_getDefinition(const struct ZigClangMacroExpansion *self) {
+    auto casted = reinterpret_cast<const clang::MacroExpansion *>(self);
+    return reinterpret_cast<const struct ZigClangMacroDefinitionRecord *>(casted->getDefinition());
+}
+
 ZigClangRecordDecl_field_iterator ZigClangRecordDecl_field_begin(const struct ZigClangRecordDecl *self) {
     auto casted = reinterpret_cast<const clang::RecordDecl *>(self);
     return bitcast(casted->field_begin());

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -112,6 +112,7 @@ struct ZigClangImplicitCastExpr;
 struct ZigClangIncompleteArrayType;
 struct ZigClangIntegerLiteral;
 struct ZigClangMacroDefinitionRecord;
+struct ZigClangMacroExpansion;
 struct ZigClangMacroQualifiedType;
 struct ZigClangMemberExpr;
 struct ZigClangNamedDecl;
@@ -1105,6 +1106,8 @@ ZIG_EXTERN_C const struct ZigClangExpr *ZigClangParenExpr_getSubExpr(const struc
 ZIG_EXTERN_C const char *ZigClangMacroDefinitionRecord_getName_getNameStart(const struct ZigClangMacroDefinitionRecord *);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangMacroDefinitionRecord_getSourceRange_getBegin(const struct ZigClangMacroDefinitionRecord *);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangMacroDefinitionRecord_getSourceRange_getEnd(const struct ZigClangMacroDefinitionRecord *);
+
+ZIG_EXTERN_C const struct ZigClangMacroDefinitionRecord *ZigClangMacroExpansion_getDefinition(const struct ZigClangMacroExpansion *);
 
 ZIG_EXTERN_C bool ZigClangFieldDecl_isBitField(const struct ZigClangFieldDecl *);
 ZIG_EXTERN_C struct ZigClangQualType ZigClangFieldDecl_getType(const struct ZigClangFieldDecl *);


### PR DESCRIPTION
This adds/fixes a few things I ran into while translating some MCU headers:

1. Enables warnings by default and adds a flag to disable it
2. Adds support for right shift, add, and sub operations
3. Adds warnings when a macro is not processed
4. Adds a "format" to the `AstNodeIntLiteral` so hex / octal format can be retained when translating.

For example

```c
#define PERIPH_BASE               (0x40000000UL) /*!< Base address of : AHB/APB Peripherals                                                   */
#define D3_AHB1PERIPH_BASE       (PERIPH_BASE + 0x18020000UL)
#define RCC_BASE              (D3_AHB1PERIPH_BASE + 0x4400UL)
```

Now translates to

```zig
pub const PERIPH_BASE = @as(c_ulong, 0x40000000);
pub const D3_AHB1PERIPH_BASE = PERIPH_BASE + @as(c_ulong, 0x18020000);
pub const RCC_BASE = D3_AHB1PERIPH_BASE + @as(c_ulong, 0x4400);
``` 

vs just

```zig
pub const PERIPH_BASE = @as(c_ulong, 1073741824);
// The other's are missing
```