### PR TITLE
std.json: cleanups

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1007,7 +1007,7 @@ pub const TokenStream = struct {
             }
         }
 
-        // Without this a bare number fails, becasue the streaming parser doesn't know it ended
+        // Without this a bare number fails, the streaming parser doesn't know the input ended
         try self.parser.feed(' ', &t1, &t2);
         self.i += 1;
 

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -364,10 +364,8 @@ test "std.meta.activeTag" {
 
 ///Given a tagged union type, and an enum, return the type of the union
 /// field corresponding to the enum tag.
-pub fn TagPayloadType(comptime U: type, tag: var) type {
-    const Tag = @TypeOf(tag);
+pub fn TagPayloadType(comptime U: type, tag: @TagType(U)) type {
     testing.expect(trait.is(builtin.TypeId.Union)(U));
-    testing.expect(trait.is(builtin.TypeId.Enum)(Tag));
 
     const info = @typeInfo(U).Union;
 


### PR DESCRIPTION
Builds on #3648

  - Uses more modern zig syntax/features
  - Implements the concept (from #3648) of tracking length in the tokenizer so we don't need an allocator for unescaping (I have a followup PR that takes advantage of this)