### PR TITLE
fix float ops with respect to vectors

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8130,8 +8130,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
-      {#header_open|@ln#}
-      <pre>{#syntax#}@ln(value: var) @TypeOf(value){#endsyntax#}</pre>
+      {#header_open|@log#}
+      <pre>{#syntax#}@log(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Returns the natural logarithm of a floating point number. Uses a dedicated hardware instruction
       when available.

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8076,94 +8076,146 @@ test "vector @splat" {
       {#header_close#}
 
       {#header_open|@sqrt#}
-      <pre>{#syntax#}@sqrt(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@sqrt(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Performs the square root of a floating point number. Uses a dedicated hardware instruction
-      when available. Supports {#syntax#}f16{#endsyntax#}, {#syntax#}f32{#endsyntax#}, {#syntax#}f64{#endsyntax#}, and {#syntax#}f128{#endsyntax#}, as well as vectors.
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@sin#}
-      <pre>{#syntax#}@sin(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@sin(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Sine trigometric function on a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@cos#}
-      <pre>{#syntax#}@cos(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@cos(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Cosine trigometric function on a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@exp#}
-      <pre>{#syntax#}@exp(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@exp(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Base-e exponential function on a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@exp2#}
-      <pre>{#syntax#}@exp2(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@exp2(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Base-2 exponential function on a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@ln#}
-      <pre>{#syntax#}@ln(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@ln(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Returns the natural logarithm of a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@log2#}
-      <pre>{#syntax#}@log2(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@log2(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Returns the logarithm to the base 2 of a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@log10#}
-      <pre>{#syntax#}@log10(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@log10(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Returns the logarithm to the base 10 of a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@fabs#}
-      <pre>{#syntax#}@fabs(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@fabs(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Returns the absolute value of a floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@floor#}
-      <pre>{#syntax#}@floor(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@floor(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
-      Returns the largest integral value not greater than the given floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      Returns the largest integral value not greater than the given floating point number.
+      Uses a dedicated hardware instruction when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@ceil#}
-      <pre>{#syntax#}@ceil(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@ceil(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
-      Returns the largest integral value not less than the given floating point number. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      Returns the largest integral value not less than the given floating point number.
+      Uses a dedicated hardware instruction when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@trunc#}
-      <pre>{#syntax#}@trunc(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@trunc(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
-      Rounds the given floating point number to an integer, towards zero. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      Rounds the given floating point number to an integer, towards zero.
+      Uses a dedicated hardware instruction when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
       {#header_open|@round#}
-      <pre>{#syntax#}@round(comptime T: type, value: T) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@round(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
       Rounds the given floating point number to an integer, away from zero. Uses a dedicated hardware instruction
-      when available. Currently supports {#syntax#}f32{#endsyntax#} and {#syntax#}f64{#endsyntax#}.
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats, with the caveat that
+      <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
 

--- a/lib/std/math/sqrt.zig
+++ b/lib/std/math/sqrt.zig
@@ -12,12 +12,12 @@ const maxInt = std.math.maxInt;
 ///  - sqrt(+-0)   = +-0
 ///  - sqrt(x)     = nan if x < 0
 ///  - sqrt(nan)   = nan
-pub fn sqrt(x: var) (if (@typeId(@TypeOf(x)) == TypeId.Int) @IntType(false, @TypeOf(x).bit_count / 2) else @TypeOf(x)) {
+/// TODO Decide if all this logic should be implemented directly in the @sqrt bultin function.
+pub fn sqrt(x: var) Sqrt(@TypeOf(x)) {
     const T = @TypeOf(x);
-    switch (@typeId(T)) {
-        TypeId.ComptimeFloat => return @as(T, @sqrt(f64, x)), // TODO upgrade to f128
-        TypeId.Float => return @sqrt(T, x),
-        TypeId.ComptimeInt => comptime {
+    switch (@typeInfo(T)) {
+        .Float, .ComptimeFloat => return @sqrt(x),
+        .ComptimeInt => comptime {
             if (x > maxInt(u128)) {
                 @compileError("sqrt not implemented for comptime_int greater than 128 bits");
             }
@@ -26,81 +26,9 @@ pub fn sqrt(x: var) (if (@typeId(@TypeOf(x)) == TypeId.Int) @IntType(false, @Typ
             }
             return @as(T, sqrt_int(u128, x));
         },
-        TypeId.Int => return sqrt_int(T, x),
+        .Int => return sqrt_int(T, x),
         else => @compileError("sqrt not implemented for " ++ @typeName(T)),
     }
-}
-
-test "math.sqrt" {
-    expect(sqrt(@as(f16, 0.0)) == @sqrt(f16, 0.0));
-    expect(sqrt(@as(f32, 0.0)) == @sqrt(f32, 0.0));
-    expect(sqrt(@as(f64, 0.0)) == @sqrt(f64, 0.0));
-}
-
-test "math.sqrt16" {
-    const epsilon = 0.000001;
-
-    expect(@sqrt(f16, 0.0) == 0.0);
-    expect(math.approxEq(f16, @sqrt(f16, 2.0), 1.414214, epsilon));
-    expect(math.approxEq(f16, @sqrt(f16, 3.6), 1.897367, epsilon));
-    expect(@sqrt(f16, 4.0) == 2.0);
-    expect(math.approxEq(f16, @sqrt(f16, 7.539840), 2.745877, epsilon));
-    expect(math.approxEq(f16, @sqrt(f16, 19.230934), 4.385309, epsilon));
-    expect(@sqrt(f16, 64.0) == 8.0);
-    expect(math.approxEq(f16, @sqrt(f16, 64.1), 8.006248, epsilon));
-    expect(math.approxEq(f16, @sqrt(f16, 8942.230469), 94.563370, epsilon));
-}
-
-test "math.sqrt32" {
-    const epsilon = 0.000001;
-
-    expect(@sqrt(f32, 0.0) == 0.0);
-    expect(math.approxEq(f32, @sqrt(f32, 2.0), 1.414214, epsilon));
-    expect(math.approxEq(f32, @sqrt(f32, 3.6), 1.897367, epsilon));
-    expect(@sqrt(f32, 4.0) == 2.0);
-    expect(math.approxEq(f32, @sqrt(f32, 7.539840), 2.745877, epsilon));
-    expect(math.approxEq(f32, @sqrt(f32, 19.230934), 4.385309, epsilon));
-    expect(@sqrt(f32, 64.0) == 8.0);
-    expect(math.approxEq(f32, @sqrt(f32, 64.1), 8.006248, epsilon));
-    expect(math.approxEq(f32, @sqrt(f32, 8942.230469), 94.563370, epsilon));
-}
-
-test "math.sqrt64" {
-    const epsilon = 0.000001;
-
-    expect(@sqrt(f64, 0.0) == 0.0);
-    expect(math.approxEq(f64, @sqrt(f64, 2.0), 1.414214, epsilon));
-    expect(math.approxEq(f64, @sqrt(f64, 3.6), 1.897367, epsilon));
-    expect(@sqrt(f64, 4.0) == 2.0);
-    expect(math.approxEq(f64, @sqrt(f64, 7.539840), 2.745877, epsilon));
-    expect(math.approxEq(f64, @sqrt(f64, 19.230934), 4.385309, epsilon));
-    expect(@sqrt(f64, 64.0) == 8.0);
-    expect(math.approxEq(f64, @sqrt(f64, 64.1), 8.006248, epsilon));
-    expect(math.approxEq(f64, @sqrt(f64, 8942.230469), 94.563367, epsilon));
-}
-
-test "math.sqrt16.special" {
-    expect(math.isPositiveInf(@sqrt(f16, math.inf(f16))));
-    expect(@sqrt(f16, 0.0) == 0.0);
-    expect(@sqrt(f16, -0.0) == -0.0);
-    expect(math.isNan(@sqrt(f16, -1.0)));
-    expect(math.isNan(@sqrt(f16, math.nan(f16))));
-}
-
-test "math.sqrt32.special" {
-    expect(math.isPositiveInf(@sqrt(f32, math.inf(f32))));
-    expect(@sqrt(f32, 0.0) == 0.0);
-    expect(@sqrt(f32, -0.0) == -0.0);
-    expect(math.isNan(@sqrt(f32, -1.0)));
-    expect(math.isNan(@sqrt(f32, math.nan(f32))));
-}
-
-test "math.sqrt64.special" {
-    expect(math.isPositiveInf(@sqrt(f64, math.inf(f64))));
-    expect(@sqrt(f64, 0.0) == 0.0);
-    expect(@sqrt(f64, -0.0) == -0.0);
-    expect(math.isNan(@sqrt(f64, -1.0)));
-    expect(math.isNan(@sqrt(f64, math.nan(f64))));
 }
 
 fn sqrt_int(comptime T: type, value: T) @IntType(false, T.bit_count / 2) {
@@ -134,3 +62,12 @@ test "math.sqrt_int" {
     expect(sqrt_int(u32, 9) == 3);
     expect(sqrt_int(u32, 10) == 3);
 }
+
+/// Returns the return type `sqrt` will return given an operand of type `T`.
+pub fn Sqrt(comptime T: type) type {
+    return switch (@typeInfo(T)) {
+        .Int => |int| @IntType(false, int.bits / 2),
+        else => T,
+    };
+}
+

--- a/lib/std/special/c.zig
+++ b/lib/std/special/c.zig
@@ -728,6 +728,29 @@ export fn sqrt(x: f64) f64 {
     return @bitCast(f64, uz);
 }
 
+test "sqrt" {
+    const epsilon = 0.000001;
+
+    std.testing.expect(sqrt(0.0) == 0.0);
+    std.testing.expect(std.math.approxEq(f64, sqrt(2.0), 1.414214, epsilon));
+    std.testing.expect(std.math.approxEq(f64, sqrt(3.6), 1.897367, epsilon));
+    std.testing.expect(sqrt(4.0) == 2.0);
+    std.testing.expect(std.math.approxEq(f64, sqrt(7.539840), 2.745877, epsilon));
+    std.testing.expect(std.math.approxEq(f64, sqrt(19.230934), 4.385309, epsilon));
+    std.testing.expect(sqrt(64.0) == 8.0);
+    std.testing.expect(std.math.approxEq(f64, sqrt(64.1), 8.006248, epsilon));
+    std.testing.expect(std.math.approxEq(f64, sqrt(8942.230469), 94.563367, epsilon));
+}
+
+test "sqrt special" {
+    std.testing.expect(std.math.isPositiveInf(sqrt(std.math.inf(f64))));
+    std.testing.expect(sqrt(0.0) == 0.0);
+    std.testing.expect(sqrt(-0.0) == -0.0);
+    std.testing.expect(std.math.isNan(sqrt(-1.0)));
+    std.testing.expect(std.math.isNan(sqrt(std.math.nan(f64))));
+}
+
+
 export fn sqrtf(x: f32) f32 {
     const tiny: f32 = 1.0e-30;
     const sign: i32 = @bitCast(i32, @as(u32, 0x80000000));
@@ -803,3 +826,26 @@ export fn sqrtf(x: f32) f32 {
     ix += m << 23;
     return @bitCast(f32, ix);
 }
+
+test "sqrtf" {
+    const epsilon = 0.000001;
+
+    std.testing.expect(sqrtf(0.0) == 0.0);
+    std.testing.expect(std.math.approxEq(f32, sqrtf(2.0), 1.414214, epsilon));
+    std.testing.expect(std.math.approxEq(f32, sqrtf(3.6), 1.897367, epsilon));
+    std.testing.expect(sqrtf(4.0) == 2.0);
+    std.testing.expect(std.math.approxEq(f32, sqrtf(7.539840), 2.745877, epsilon));
+    std.testing.expect(std.math.approxEq(f32, sqrtf(19.230934), 4.385309, epsilon));
+    std.testing.expect(sqrtf(64.0) == 8.0);
+    std.testing.expect(std.math.approxEq(f32, sqrtf(64.1), 8.006248, epsilon));
+    std.testing.expect(std.math.approxEq(f32, sqrtf(8942.230469), 94.563370, epsilon));
+}
+
+test "sqrtf special" {
+    std.testing.expect(std.math.isPositiveInf(sqrtf(std.math.inf(f32))));
+    std.testing.expect(sqrtf(0.0) == 0.0);
+    std.testing.expect(sqrtf(-0.0) == -0.0);
+    std.testing.expect(std.math.isNan(sqrtf(-1.0)));
+    std.testing.expect(std.math.isNan(sqrtf(std.math.nan(f32))));
+}
+

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -3840,9 +3840,8 @@ struct IrInstructionAddImplicitReturnType {
 struct IrInstructionFloatOp {
     IrInstruction base;
 
-    BuiltinFnId op;
-    IrInstruction *type;
-    IrInstruction *op1;
+    BuiltinFnId fn_id;
+    IrInstruction *operand;
 };
 
 struct IrInstructionCheckRuntimeScope {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1680,7 +1680,7 @@ enum BuiltinFnId {
     BuiltinFnIdCos,
     BuiltinFnIdExp,
     BuiltinFnIdExp2,
-    BuiltinFnIdLn,
+    BuiltinFnIdLog,
     BuiltinFnIdLog2,
     BuiltinFnIdLog10,
     BuiltinFnIdFabs,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -764,7 +764,7 @@ static LLVMValueRef get_float_fn(CodeGen *g, ZigType *type_entry, ZigLLVMFnId fn
         name = "fma";
         num_args = 3;
     } else if (fn_id == ZigLLVMFnIdFloatOp) {
-        name = float_op_to_name(op, true);
+        name = float_op_to_name(op);
         num_args = 1;
     } else {
         zig_unreachable();
@@ -8205,7 +8205,7 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdCos, "cos", 1);
     create_builtin_fn(g, BuiltinFnIdExp, "exp", 1);
     create_builtin_fn(g, BuiltinFnIdExp2, "exp2", 1);
-    create_builtin_fn(g, BuiltinFnIdLn, "ln", 1);
+    create_builtin_fn(g, BuiltinFnIdLog, "log", 1);
     create_builtin_fn(g, BuiltinFnIdLog2, "log2", 1);
     create_builtin_fn(g, BuiltinFnIdLog10, "log10", 1);
     create_builtin_fn(g, BuiltinFnIdFabs, "fabs", 1);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5785,10 +5785,9 @@ static LLVMValueRef ir_render_atomic_store(CodeGen *g, IrExecutable *executable,
 }
 
 static LLVMValueRef ir_render_float_op(CodeGen *g, IrExecutable *executable, IrInstructionFloatOp *instruction) {
-    LLVMValueRef op = ir_llvm_value(g, instruction->op1);
-    assert(instruction->base.value->type->id == ZigTypeIdFloat);
-    LLVMValueRef fn_val = get_float_fn(g, instruction->base.value->type, ZigLLVMFnIdFloatOp, instruction->op);
-    return LLVMBuildCall(g->builder, fn_val, &op, 1, "");
+    LLVMValueRef operand = ir_llvm_value(g, instruction->operand);
+    LLVMValueRef fn_val = get_float_fn(g, instruction->base.value->type, ZigLLVMFnIdFloatOp, instruction->fn_id);
+    return LLVMBuildCall(g->builder, fn_val, &operand, 1, "");
 }
 
 static LLVMValueRef ir_render_mul_add(CodeGen *g, IrExecutable *executable, IrInstructionMulAdd *instruction) {
@@ -8201,20 +8200,20 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdDivFloor, "divFloor", 2);
     create_builtin_fn(g, BuiltinFnIdRem, "rem", 2);
     create_builtin_fn(g, BuiltinFnIdMod, "mod", 2);
-    create_builtin_fn(g, BuiltinFnIdSqrt, "sqrt", 2);
-    create_builtin_fn(g, BuiltinFnIdSin, "sin", 2);
-    create_builtin_fn(g, BuiltinFnIdCos, "cos", 2);
-    create_builtin_fn(g, BuiltinFnIdExp, "exp", 2);
-    create_builtin_fn(g, BuiltinFnIdExp2, "exp2", 2);
-    create_builtin_fn(g, BuiltinFnIdLn, "ln", 2);
-    create_builtin_fn(g, BuiltinFnIdLog2, "log2", 2);
-    create_builtin_fn(g, BuiltinFnIdLog10, "log10", 2);
-    create_builtin_fn(g, BuiltinFnIdFabs, "fabs", 2);
-    create_builtin_fn(g, BuiltinFnIdFloor, "floor", 2);
-    create_builtin_fn(g, BuiltinFnIdCeil, "ceil", 2);
-    create_builtin_fn(g, BuiltinFnIdTrunc, "trunc", 2);
-    create_builtin_fn(g, BuiltinFnIdNearbyInt, "nearbyInt", 2);
-    create_builtin_fn(g, BuiltinFnIdRound, "round", 2);
+    create_builtin_fn(g, BuiltinFnIdSqrt, "sqrt", 1);
+    create_builtin_fn(g, BuiltinFnIdSin, "sin", 1);
+    create_builtin_fn(g, BuiltinFnIdCos, "cos", 1);
+    create_builtin_fn(g, BuiltinFnIdExp, "exp", 1);
+    create_builtin_fn(g, BuiltinFnIdExp2, "exp2", 1);
+    create_builtin_fn(g, BuiltinFnIdLn, "ln", 1);
+    create_builtin_fn(g, BuiltinFnIdLog2, "log2", 1);
+    create_builtin_fn(g, BuiltinFnIdLog10, "log10", 1);
+    create_builtin_fn(g, BuiltinFnIdFabs, "fabs", 1);
+    create_builtin_fn(g, BuiltinFnIdFloor, "floor", 1);
+    create_builtin_fn(g, BuiltinFnIdCeil, "ceil", 1);
+    create_builtin_fn(g, BuiltinFnIdTrunc, "trunc", 1);
+    create_builtin_fn(g, BuiltinFnIdNearbyInt, "nearbyInt", 1);
+    create_builtin_fn(g, BuiltinFnIdRound, "round", 1);
     create_builtin_fn(g, BuiltinFnIdMulAdd, "mulAdd", 4);
     create_builtin_fn(g, BuiltinFnIdNewStackCall, "newStackCall", SIZE_MAX);
     create_builtin_fn(g, BuiltinFnIdAsyncCall, "asyncCall", SIZE_MAX);

--- a/src/ir.hpp
+++ b/src/ir.hpp
@@ -33,7 +33,7 @@ bool ir_has_side_effects(IrInstruction *instruction);
 struct IrAnalyze;
 ZigValue *const_ptr_pointee(IrAnalyze *ira, CodeGen *codegen, ZigValue *const_val,
         AstNode *source_node);
-const char *float_op_to_name(BuiltinFnId op, bool llvm_name);
+const char *float_op_to_name(BuiltinFnId op);
 
 // for debugging purposes
 void dbg_ir_break(const char *src_file, uint32_t line);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2005,15 +2005,8 @@ static void ir_print_add_implicit_return_type(IrPrint *irp, IrInstructionAddImpl
 }
 
 static void ir_print_float_op(IrPrint *irp, IrInstructionFloatOp *instruction) {
-
-    fprintf(irp->f, "@%s(", float_op_to_name(instruction->op, false));
-    if (instruction->type != nullptr) {
-        ir_print_other_instruction(irp, instruction->type);
-    } else {
-        fprintf(irp->f, "null");
-    }
-    fprintf(irp->f, ",");
-    ir_print_other_instruction(irp, instruction->op1);
+    fprintf(irp->f, "@%s(", float_op_to_name(instruction->fn_id, false));
+    ir_print_other_instruction(irp, instruction->operand);
     fprintf(irp->f, ")");
 }
 

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2005,7 +2005,7 @@ static void ir_print_add_implicit_return_type(IrPrint *irp, IrInstructionAddImpl
 }
 
 static void ir_print_float_op(IrPrint *irp, IrInstructionFloatOp *instruction) {
-    fprintf(irp->f, "@%s(", float_op_to_name(instruction->fn_id, false));
+    fprintf(irp->f, "@%s(", float_op_to_name(instruction->fn_id));
     ir_print_other_instruction(irp, instruction->operand);
     fprintf(irp->f, ")");
 }

--- a/test/stage1/behavior/floatop.zig
+++ b/test/stage1/behavior/floatop.zig
@@ -4,6 +4,8 @@ const math = std.math;
 const pi = std.math.pi;
 const e = std.math.e;
 
+const epsilon = 0.000001;
+
 test "@sqrt" {
     comptime testSqrt();
     testSqrt();
@@ -17,6 +19,8 @@ fn testSqrt() void {
     {
         var a: f32 = 9;
         expect(@sqrt(a) == 3);
+        var b: f32 = 1.1;
+        expect(math.approxEq(f32, @sqrt(b), 1.0488088481701516, epsilon));
     }
     {
         var a: f64 = 25;
@@ -31,12 +35,18 @@ fn testSqrt() void {
     //    var a: f128 = 49;
     //    expect(@sqrt(a) == 7);
     //}
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, 2.2, 3.3, 4.4};
+        var result = @sqrt(v);
+        expect(math.approxEq(f32, @sqrt(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @sqrt(@as(f32, 2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @sqrt(@as(f32, 3.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @sqrt(@as(f32, 4.4)), result[3], epsilon));
+    }
 }
 
 test "more @sqrt f16 tests" {
     // TODO these are not all passing at comptime
-    const epsilon = 0.000001;
-
     expect(@sqrt(@as(f16, 0.0)) == 0.0);
     expect(math.approxEq(f16, @sqrt(@as(f16, 2.0)), 1.414214, epsilon));
     expect(math.approxEq(f16, @sqrt(@as(f16, 3.6)), 1.897367, epsilon));
@@ -61,8 +71,12 @@ test "@sin" {
 }
 
 fn testSin() void {
-    // TODO test f16, f128, and c_longdouble
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
+    {
+        var a: f16 = 0;
+        expect(@sin(a) == 0);
+    }
     {
         var a: f32 = 0;
         expect(@sin(a) == 0);
@@ -70,6 +84,14 @@ fn testSin() void {
     {
         var a: f64 = 0;
         expect(@sin(a) == 0);
+    }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, 2.2, 3.3, 4.4};
+        var result = @sin(v);
+        expect(math.approxEq(f32, @sin(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @sin(@as(f32, 2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @sin(@as(f32, 3.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @sin(@as(f32, 4.4)), result[3], epsilon));
     }
 }
 
@@ -79,8 +101,12 @@ test "@cos" {
 }
 
 fn testCos() void {
-    // TODO test f16, f128, and c_longdouble
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
+    {
+        var a: f16 = 0;
+        expect(@cos(a) == 1);
+    }
     {
         var a: f32 = 0;
         expect(@cos(a) == 1);
@@ -88,6 +114,14 @@ fn testCos() void {
     {
         var a: f64 = 0;
         expect(@cos(a) == 1);
+    }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, 2.2, 3.3, 4.4};
+        var result = @cos(v);
+        expect(math.approxEq(f32, @cos(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @cos(@as(f32, 2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @cos(@as(f32, 3.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @cos(@as(f32, 4.4)), result[3], epsilon));
     }
 }
 
@@ -97,8 +131,12 @@ test "@exp" {
 }
 
 fn testExp() void {
-    // TODO test f16, f128, and c_longdouble
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
+    {
+        var a: f16 = 0;
+        expect(@exp(a) == 1);
+    }
     {
         var a: f32 = 0;
         expect(@exp(a) == 1);
@@ -106,6 +144,14 @@ fn testExp() void {
     {
         var a: f64 = 0;
         expect(@exp(a) == 1);
+    }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, 2.2, 0.3, 0.4};
+        var result = @exp(v);
+        expect(math.approxEq(f32, @exp(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @exp(@as(f32, 2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @exp(@as(f32, 0.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @exp(@as(f32, 0.4)), result[3], epsilon));
     }
 }
 
@@ -115,8 +161,12 @@ test "@exp2" {
 }
 
 fn testExp2() void {
-    // TODO test f16, f128, and c_longdouble
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
+    {
+        var a: f16 = 2;
+        expect(@exp2(a) == 4);
+    }
     {
         var a: f32 = 2;
         expect(@exp2(a) == 4);
@@ -125,25 +175,45 @@ fn testExp2() void {
         var a: f64 = 2;
         expect(@exp2(a) == 4);
     }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, 2.2, 0.3, 0.4};
+        var result = @exp2(v);
+        expect(math.approxEq(f32, @exp2(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @exp2(@as(f32, 2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @exp2(@as(f32, 0.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @exp2(@as(f32, 0.4)), result[3], epsilon));
+    }
 }
 
-test "@ln" {
+test "@log" {
     // Old musl (and glibc?), and our current math.ln implementation do not return 1
     // so also accept those values.
-    comptime testLn();
-    testLn();
+    comptime testLog();
+    testLog();
 }
 
-fn testLn() void {
-    // TODO test f16, f128, and c_longdouble
+fn testLog() void {
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
     {
+        var a: f16 = e;
+        expect(math.approxEq(f16, @log(a), 1, epsilon));
+    }
+    {
         var a: f32 = e;
-        expect(@ln(a) == 1 or @ln(a) == @bitCast(f32, @as(u32, 0x3f7fffff)));
+        expect(@log(a) == 1 or @log(a) == @bitCast(f32, @as(u32, 0x3f7fffff)));
     }
     {
         var a: f64 = e;
-        expect(@ln(a) == 1 or @ln(a) == @bitCast(f64, @as(u64, 0x3ff0000000000000)));
+        expect(@log(a) == 1 or @log(a) == @bitCast(f64, @as(u64, 0x3ff0000000000000)));
+    }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, 2.2, 0.3, 0.4};
+        var result = @log(v);
+        expect(math.approxEq(f32, @log(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @log(@as(f32, 2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @log(@as(f32, 0.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @log(@as(f32, 0.4)), result[3], epsilon));
     }
 }
 
@@ -153,8 +223,12 @@ test "@log2" {
 }
 
 fn testLog2() void {
-    // TODO test f16, f128, and c_longdouble
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
+    {
+        var a: f16 = 4;
+        expect(@log2(a) == 2);
+    }
     {
         var a: f32 = 4;
         expect(@log2(a) == 2);
@@ -162,6 +236,14 @@ fn testLog2() void {
     {
         var a: f64 = 4;
         expect(@log2(a) == 2);
+    }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, 2.2, 0.3, 0.4};
+        var result = @log2(v);
+        expect(math.approxEq(f32, @log2(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @log2(@as(f32, 2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @log2(@as(f32, 0.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @log2(@as(f32, 0.4)), result[3], epsilon));
     }
 }
 
@@ -171,8 +253,12 @@ test "@log10" {
 }
 
 fn testLog10() void {
-    // TODO test f16, f128, and c_longdouble
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
+    {
+        var a: f16 = 100;
+        expect(@log10(a) == 2);
+    }
     {
         var a: f32 = 100;
         expect(@log10(a) == 2);
@@ -180,6 +266,14 @@ fn testLog10() void {
     {
         var a: f64 = 1000;
         expect(@log10(a) == 3);
+    }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, 2.2, 0.3, 0.4};
+        var result = @log10(v);
+        expect(math.approxEq(f32, @log10(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @log10(@as(f32, 2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @log10(@as(f32, 0.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @log10(@as(f32, 0.4)), result[3], epsilon));
     }
 }
 
@@ -189,8 +283,14 @@ test "@fabs" {
 }
 
 fn testFabs() void {
-    // TODO test f16, f128, and c_longdouble
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
+    {
+        var a: f16 = -2.5;
+        var b: f16 = 2.5;
+        expect(@fabs(a) == 2.5);
+        expect(@fabs(b) == 2.5);
+    }
     {
         var a: f32 = -2.5;
         var b: f32 = 2.5;
@@ -203,6 +303,14 @@ fn testFabs() void {
         expect(@fabs(a) == 2.5);
         expect(@fabs(b) == 2.5);
     }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, -2.2, 0.3, -0.4};
+        var result = @fabs(v);
+        expect(math.approxEq(f32, @fabs(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @fabs(@as(f32, -2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @fabs(@as(f32, 0.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @fabs(@as(f32, -0.4)), result[3], epsilon));
+    }
 }
 
 test "@floor" {
@@ -211,8 +319,12 @@ test "@floor" {
 }
 
 fn testFloor() void {
-    // TODO test f16, f128, and c_longdouble
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
+    {
+        var a: f16 = 2.1;
+        expect(@floor(a) == 2);
+    }
     {
         var a: f32 = 2.1;
         expect(@floor(a) == 2);
@@ -220,6 +332,14 @@ fn testFloor() void {
     {
         var a: f64 = 3.5;
         expect(@floor(a) == 3);
+    }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, -2.2, 0.3, -0.4};
+        var result = @floor(v);
+        expect(math.approxEq(f32, @floor(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @floor(@as(f32, -2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @floor(@as(f32, 0.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @floor(@as(f32, -0.4)), result[3], epsilon));
     }
 }
 
@@ -229,8 +349,12 @@ test "@ceil" {
 }
 
 fn testCeil() void {
-    // TODO test f16, f128, and c_longdouble
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
+    {
+        var a: f16 = 2.1;
+        expect(@ceil(a) == 3);
+    }
     {
         var a: f32 = 2.1;
         expect(@ceil(a) == 3);
@@ -238,6 +362,14 @@ fn testCeil() void {
     {
         var a: f64 = 3.5;
         expect(@ceil(a) == 4);
+    }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, -2.2, 0.3, -0.4};
+        var result = @ceil(v);
+        expect(math.approxEq(f32, @ceil(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @ceil(@as(f32, -2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @ceil(@as(f32, 0.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @ceil(@as(f32, -0.4)), result[3], epsilon));
     }
 }
 
@@ -247,8 +379,12 @@ test "@trunc" {
 }
 
 fn testTrunc() void {
-    // TODO test f16, f128, and c_longdouble
+    // TODO test f128, and c_longdouble
     // https://github.com/ziglang/zig/issues/4026
+    {
+        var a: f16 = 2.1;
+        expect(@trunc(a) == 2);
+    }
     {
         var a: f32 = 2.1;
         expect(@trunc(a) == 2);
@@ -257,10 +393,18 @@ fn testTrunc() void {
         var a: f64 = -3.5;
         expect(@trunc(a) == -3);
     }
+    {
+        var v: @Vector(4, f32) = [_]f32{1.1, -2.2, 0.3, -0.4};
+        var result = @trunc(v);
+        expect(math.approxEq(f32, @trunc(@as(f32, 1.1)), result[0], epsilon));
+        expect(math.approxEq(f32, @trunc(@as(f32, -2.2)), result[1], epsilon));
+        expect(math.approxEq(f32, @trunc(@as(f32, 0.3)), result[2], epsilon));
+        expect(math.approxEq(f32, @trunc(@as(f32, -0.4)), result[3], epsilon));
+    }
 }
 
 // TODO This is waiting on library support for the Windows build (not sure why the other's don't need it)
-//test "@nearbyInt" {
+//test "@nearbyint" {
 //    comptime testNearbyInt();
 //    testNearbyInt();
 //}
@@ -270,10 +414,10 @@ fn testTrunc() void {
 //    // https://github.com/ziglang/zig/issues/4026
 //    {
 //        var a: f32 = 2.1;
-//        expect(@nearbyInt(a) == 2);
+//        expect(@nearbyint(a) == 2);
 //    }
 //    {
 //        var a: f64 = -3.75;
-//        expect(@nearbyInt(a) == -4);
+//        expect(@nearbyint(a) == -4);
 //    }
 //}

--- a/test/stage1/behavior/floatop.zig
+++ b/test/stage1/behavior/floatop.zig
@@ -1,6 +1,8 @@
-const expect = @import("std").testing.expect;
-const pi = @import("std").math.pi;
-const e = @import("std").math.e;
+const std = @import("std");
+const expect = std.testing.expect;
+const math = std.math;
+const pi = std.math.pi;
+const e = std.math.e;
 
 test "@sqrt" {
     comptime testSqrt();
@@ -10,25 +12,47 @@ test "@sqrt" {
 fn testSqrt() void {
     {
         var a: f16 = 4;
-        expect(@sqrt(f16, a) == 2);
+        expect(@sqrt(a) == 2);
     }
     {
         var a: f32 = 9;
-        expect(@sqrt(f32, a) == 3);
+        expect(@sqrt(a) == 3);
     }
     {
         var a: f64 = 25;
-        expect(@sqrt(f64, a) == 5);
+        expect(@sqrt(a) == 5);
     }
     {
         const a: comptime_float = 25.0;
-        expect(@sqrt(comptime_float, a) == 5.0);
+        expect(@sqrt(a) == 5.0);
     }
-    // Waiting on a c.zig implementation
+    // TODO https://github.com/ziglang/zig/issues/4026
     //{
     //    var a: f128 = 49;
-    //    expect(@sqrt(f128, a) == 7);
+    //    expect(@sqrt(a) == 7);
     //}
+}
+
+test "more @sqrt f16 tests" {
+    // TODO these are not all passing at comptime
+    const epsilon = 0.000001;
+
+    expect(@sqrt(@as(f16, 0.0)) == 0.0);
+    expect(math.approxEq(f16, @sqrt(@as(f16, 2.0)), 1.414214, epsilon));
+    expect(math.approxEq(f16, @sqrt(@as(f16, 3.6)), 1.897367, epsilon));
+    expect(@sqrt(@as(f16, 4.0)) == 2.0);
+    expect(math.approxEq(f16, @sqrt(@as(f16, 7.539840)), 2.745877, epsilon));
+    expect(math.approxEq(f16, @sqrt(@as(f16, 19.230934)), 4.385309, epsilon));
+    expect(@sqrt(@as(f16, 64.0)) == 8.0);
+    expect(math.approxEq(f16, @sqrt(@as(f16, 64.1)), 8.006248, epsilon));
+    expect(math.approxEq(f16, @sqrt(@as(f16, 8942.230469)), 94.563370, epsilon));
+
+    // special cases
+    expect(math.isPositiveInf(@sqrt(@as(f16, math.inf(f16)))));
+    expect(@sqrt(@as(f16, 0.0)) == 0.0);
+    expect(@sqrt(@as(f16, -0.0)) == -0.0);
+    expect(math.isNan(@sqrt(@as(f16, -1.0))));
+    expect(math.isNan(@sqrt(@as(f16, math.nan(f16)))));
 }
 
 test "@sin" {
@@ -37,26 +61,16 @@ test "@sin" {
 }
 
 fn testSin() void {
-    // TODO - this is actually useful and should be implemented
-    // (all the trig functions for f16)
-    // but will probably wait till self-hosted
-    //{
-    //    var a: f16 = pi;
-    //    expect(@sin(f16, a/2) == 1);
-    //}
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = 0;
-        expect(@sin(f32, a) == 0);
+        expect(@sin(a) == 0);
     }
     {
         var a: f64 = 0;
-        expect(@sin(f64, a) == 0);
+        expect(@sin(a) == 0);
     }
-    // TODO
-    //{
-    //    var a: f16 = pi;
-    //    expect(@sqrt(f128, a/2) == 1);
-    //}
 }
 
 test "@cos" {
@@ -65,13 +79,15 @@ test "@cos" {
 }
 
 fn testCos() void {
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = 0;
-        expect(@cos(f32, a) == 1);
+        expect(@cos(a) == 1);
     }
     {
         var a: f64 = 0;
-        expect(@cos(f64, a) == 1);
+        expect(@cos(a) == 1);
     }
 }
 
@@ -81,13 +97,15 @@ test "@exp" {
 }
 
 fn testExp() void {
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = 0;
-        expect(@exp(f32, a) == 1);
+        expect(@exp(a) == 1);
     }
     {
         var a: f64 = 0;
-        expect(@exp(f64, a) == 1);
+        expect(@exp(a) == 1);
     }
 }
 
@@ -97,13 +115,15 @@ test "@exp2" {
 }
 
 fn testExp2() void {
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = 2;
-        expect(@exp2(f32, a) == 4);
+        expect(@exp2(a) == 4);
     }
     {
         var a: f64 = 2;
-        expect(@exp2(f64, a) == 4);
+        expect(@exp2(a) == 4);
     }
 }
 
@@ -115,13 +135,15 @@ test "@ln" {
 }
 
 fn testLn() void {
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = e;
-        expect(@ln(f32, a) == 1 or @ln(f32, a) == @bitCast(f32, @as(u32, 0x3f7fffff)));
+        expect(@ln(a) == 1 or @ln(a) == @bitCast(f32, @as(u32, 0x3f7fffff)));
     }
     {
         var a: f64 = e;
-        expect(@ln(f64, a) == 1 or @ln(f64, a) == @bitCast(f64, @as(u64, 0x3ff0000000000000)));
+        expect(@ln(a) == 1 or @ln(a) == @bitCast(f64, @as(u64, 0x3ff0000000000000)));
     }
 }
 
@@ -131,13 +153,15 @@ test "@log2" {
 }
 
 fn testLog2() void {
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = 4;
-        expect(@log2(f32, a) == 2);
+        expect(@log2(a) == 2);
     }
     {
         var a: f64 = 4;
-        expect(@log2(f64, a) == 2);
+        expect(@log2(a) == 2);
     }
 }
 
@@ -147,13 +171,15 @@ test "@log10" {
 }
 
 fn testLog10() void {
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = 100;
-        expect(@log10(f32, a) == 2);
+        expect(@log10(a) == 2);
     }
     {
         var a: f64 = 1000;
-        expect(@log10(f64, a) == 3);
+        expect(@log10(a) == 3);
     }
 }
 
@@ -163,17 +189,19 @@ test "@fabs" {
 }
 
 fn testFabs() void {
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = -2.5;
         var b: f32 = 2.5;
-        expect(@fabs(f32, a) == 2.5);
-        expect(@fabs(f32, b) == 2.5);
+        expect(@fabs(a) == 2.5);
+        expect(@fabs(b) == 2.5);
     }
     {
         var a: f64 = -2.5;
         var b: f64 = 2.5;
-        expect(@fabs(f64, a) == 2.5);
-        expect(@fabs(f64, b) == 2.5);
+        expect(@fabs(a) == 2.5);
+        expect(@fabs(b) == 2.5);
     }
 }
 
@@ -183,13 +211,15 @@ test "@floor" {
 }
 
 fn testFloor() void {
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = 2.1;
-        expect(@floor(f32, a) == 2);
+        expect(@floor(a) == 2);
     }
     {
         var a: f64 = 3.5;
-        expect(@floor(f64, a) == 3);
+        expect(@floor(a) == 3);
     }
 }
 
@@ -199,13 +229,15 @@ test "@ceil" {
 }
 
 fn testCeil() void {
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = 2.1;
-        expect(@ceil(f32, a) == 3);
+        expect(@ceil(a) == 3);
     }
     {
         var a: f64 = 3.5;
-        expect(@ceil(f64, a) == 4);
+        expect(@ceil(a) == 4);
     }
 }
 
@@ -215,29 +247,33 @@ test "@trunc" {
 }
 
 fn testTrunc() void {
+    // TODO test f16, f128, and c_longdouble
+    // https://github.com/ziglang/zig/issues/4026
     {
         var a: f32 = 2.1;
-        expect(@trunc(f32, a) == 2);
+        expect(@trunc(a) == 2);
     }
     {
         var a: f64 = -3.5;
-        expect(@trunc(f64, a) == -3);
+        expect(@trunc(a) == -3);
     }
 }
 
-// This is waiting on library support for the Windows build (not sure why the other's don't need it)
+// TODO This is waiting on library support for the Windows build (not sure why the other's don't need it)
 //test "@nearbyInt" {
 //    comptime testNearbyInt();
 //    testNearbyInt();
 //}
 
 //fn testNearbyInt() void {
+//    // TODO test f16, f128, and c_longdouble
+//    // https://github.com/ziglang/zig/issues/4026
 //    {
 //        var a: f32 = 2.1;
-//        expect(@nearbyInt(f32, a) == 2);
+//        expect(@nearbyInt(a) == 2);
 //    }
 //    {
 //        var a: f64 = -3.75;
-//        expect(@nearbyInt(f64, a) == -4);
+//        expect(@nearbyInt(a) == -4);
 //    }
 //}

--- a/test/stage1/behavior/math.zig
+++ b/test/stage1/behavior/math.zig
@@ -587,12 +587,12 @@ test "@sqrt" {
 
     const x = 14.0;
     const y = x * x;
-    const z = @sqrt(@TypeOf(y), y);
+    const z = @sqrt(y);
     comptime expect(z == x);
 }
 
 fn testSqrt(comptime T: type, x: T) void {
-    expect(@sqrt(T, x * x) == x);
+    expect(@sqrt(x * x) == x);
 }
 
 test "comptime_int param and return" {


### PR DESCRIPTION
also remove the redundant type parameter

checklist:
 * [ ] add test coverage for vector operations of float ops

See related issue #4026

Example code:

```zig
const std = @import("std");

export fn foo(a: f32, b: f32) f32 {
    var v: @Vector(4, f32) = [_]f32{a, 2.0, b, 4.0};
    const computed = @splat(4, @as(f32, 1.0)) / @sqrt(v);
    return computed[0] + computed[1] + computed[2] + computed[3];
}

// to make the assembly smaller
pub fn panic(msg: []const u8, stack_trace: ?*std.builtin.StackTrace) noreturn {
    @breakpoint();
    unreachable;
}
```

```
$ ./zig build-obj test2.zig --release-fast

$ objdump -d test2.o -Mintel

test2.o:     file format elf64-x86-64


Disassembly of section .text:

0000000000000000 <foo>:
   0:	c4 e3 79 21 05 00 00 	vinsertps xmm0,xmm0,DWORD PTR [rip+0x0],0x10        # a <foo+0xa>
   7:	00 00 10 
   a:	c4 e3 79 21 c1 20    	vinsertps xmm0,xmm0,xmm1,0x20
  10:	c4 e3 79 21 05 00 00 	vinsertps xmm0,xmm0,DWORD PTR [rip+0x0],0x30        # 1a <foo+0x1a>
  17:	00 00 30 
  1a:	c5 f8 51 c0          	vsqrtps xmm0,xmm0
  1e:	c4 e2 79 18 0d 00 00 	vbroadcastss xmm1,DWORD PTR [rip+0x0]        # 27 <foo+0x27>
  25:	00 00 
  27:	c5 f0 5e c0          	vdivps xmm0,xmm1,xmm0
  2b:	c5 fa 16 c8          	vmovshdup xmm1,xmm0
  2f:	c5 fa 58 c9          	vaddss xmm1,xmm0,xmm1
  33:	c4 e3 79 05 d0 01    	vpermilpd xmm2,xmm0,0x1
  39:	c5 ea 58 c9          	vaddss xmm1,xmm2,xmm1
  3d:	c4 e3 79 04 c0 e7    	vpermilps xmm0,xmm0,0xe7
  43:	c5 fa 58 c1          	vaddss xmm0,xmm0,xmm1
  47:	c3                   	ret    
```