### PR TITLE
Don't ptrCast a result-location assignment to _

### DIFF
--- a/test/stage1/behavior/bitcast.zig
+++ b/test/stage1/behavior/bitcast.zig
@@ -146,3 +146,7 @@ test "comptime bitcast used in expression has the correct type" {
     };
     expect(@bitCast(u8, Foo{ .value = 0xF }) == 0xf);
 }
+
+test "bitcast result to _" {
+    _ = @bitCast(u8, @as(i8, 1));
+}


### PR DESCRIPTION
After #4010 doing `_ = @bitCast(...)` triggered a nonsensical compiler error.

Returning `parent_result_loc` makes sense here IMO as we just bubble-up the result location of `_`.