### PR TITLE
translate-c: add test case for GLib mistranslation

### DIFF
--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2409,4 +2409,17 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn c() void {}
         \\pub fn foo() void {}
     });
+
+    cases.add("typedeffed return/argument in function pointer member of typedeffed struct",
+        \\typedef struct _Foo Foo;
+        \\typedef int A;
+        \\typedef int B;
+        \\struct _Foo { A (*func)(B b); };
+    , &[_][]const u8{
+        \\pub const B = c_int;
+        \\pub const A = c_int;
+        \\pub const struct__Foo = extern struct {
+        \\    func: ?extern fn (B) A,
+        \\};
+    });
 }


### PR DESCRIPTION
`giochannel.h` gets translated into syntactically invalid Zig code.
This test is a reduced form of the failing code.

If someone has the time to guide me through fixing it, that would be really nice!
I'm not familiar with the compiler internals, but would like to become able to help fix any issues I come across as a user of the compiler.

I'm writing a fediverse client using Zig and GTK, so I'm bound to encounter translate-c issues. :)