### PR TITLE
Removes proc_raise from WASI implementation

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -416,7 +416,7 @@ pub const CallOptions = struct {
 /// therefore must be kept in sync with the compiler implementation.
 pub const TestFn = struct {
     name: []const u8,
-    func: fn()anyerror!void,
+    func: fn () anyerror!void,
 };
 
 /// This function type is used by the Zig language code generation and
@@ -443,8 +443,7 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace) noreturn
         },
         .wasi => {
             std.debug.warn("{}", .{msg});
-            _ = std.os.wasi.proc_raise(std.os.wasi.SIGABRT);
-            unreachable;
+            std.os.abort();
         },
         .uefi => {
             // TODO look into using the debug info and logging helpful messages

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -216,13 +216,6 @@ pub fn raise(sig: u8) RaiseError!void {
         }
     }
 
-    if (builtin.os == .wasi) {
-        switch (wasi.proc_raise(SIGABRT)) {
-            0 => return,
-            else => |err| return unexpectedErrno(err),
-        }
-    }
-
     if (builtin.os == .linux) {
         var set: linux.sigset_t = undefined;
         // block application signals

--- a/lib/std/os/wasi.zig
+++ b/lib/std/os/wasi.zig
@@ -67,7 +67,6 @@ pub extern "wasi_unstable" fn path_unlink_file(fd: fd_t, path: [*]const u8, path
 pub extern "wasi_unstable" fn poll_oneoff(in: *const subscription_t, out: *event_t, nsubscriptions: usize, nevents: *usize) errno_t;
 
 pub extern "wasi_unstable" fn proc_exit(rval: exitcode_t) noreturn;
-pub extern "wasi_unstable" fn proc_raise(sig: signal_t) errno_t;
 
 pub extern "wasi_unstable" fn random_get(buf: [*]u8, buf_len: usize) errno_t;
 


### PR DESCRIPTION
Fixes: #4068 

I'm not sure if I should take out `std.debug.warn("{}", .{msg});` in `builtin.default_panic`