### PR TITLE
json: disallow overlong and out-of-range UTF-8

### DIFF
--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -27,6 +27,20 @@ fn err(comptime s: []const u8) void {
     } else |_| {}
 }
 
+fn utf8Error(comptime s: []const u8) void {
+    std.testing.expect(!std.json.validate(s));
+
+    var mem_buffer: [1024 * 20]u8 = undefined;
+    const allocator = &std.heap.FixedBufferAllocator.init(&mem_buffer).allocator;
+    var p = std.json.Parser.init(allocator, false);
+
+    if (p.parse(s)) |_| {
+        unreachable;
+    } else |e| {
+        std.testing.expect(e == error.InvalidUtf8Byte);
+    }
+}
+
 fn any(comptime s: []const u8) void {
     _ = std.json.validate(s);
 
@@ -1935,4 +1949,56 @@ test "i_structure_UTF-8_BOM_empty_object" {
     any(
         \\ï»¿{}
     );
+}
+
+test "truncated UTF-8 sequence" {
+    utf8Error("\"\xc2\"");
+    utf8Error("\"\xdf\"");
+    utf8Error("\"\xed\xa0\"");
+    utf8Error("\"\xf0\x80\"");
+    utf8Error("\"\xf0\x80\x80\"");
+}
+
+test "invalid continuation byte" {
+    utf8Error("\"\xc2\x00\"");
+    utf8Error("\"\xc2\x7f\"");
+    utf8Error("\"\xc2\xc0\"");
+    utf8Error("\"\xc3\xc1\"");
+    utf8Error("\"\xc4\xf5\"");
+    utf8Error("\"\xc5\xff\"");
+    utf8Error("\"\xe4\x80\x00\"");
+    utf8Error("\"\xe5\x80\x10\"");
+    utf8Error("\"\xe6\x80\xc0\"");
+    utf8Error("\"\xe7\x80\xf5\"");
+    utf8Error("\"\xe8\x00\x80\"");
+    utf8Error("\"\xf2\x00\x80\x80\"");
+    utf8Error("\"\xf0\x80\x00\x80\"");
+    utf8Error("\"\xf1\x80\xc0\x80\"");
+    utf8Error("\"\xf2\x80\x80\x00\"");
+    utf8Error("\"\xf3\x80\x80\xc0\"");
+    utf8Error("\"\xf4\x80\x80\xf5\"");
+}
+
+test "disallowed overlong form" {
+    utf8Error("\"\xc0\x80\"");
+    utf8Error("\"\xc0\x90\"");
+    utf8Error("\"\xc1\x80\"");
+    utf8Error("\"\xc1\x90\"");
+    utf8Error("\"\xe0\x80\x80\"");
+    utf8Error("\"\xf0\x80\x80\x80\"");
+}
+
+test "out of UTF-16 range" {
+    utf8Error("\"\xf4\x90\x80\x80\"");
+    utf8Error("\"\xf5\x80\x80\x80\"");
+    utf8Error("\"\xf6\x80\x80\x80\"");
+    utf8Error("\"\xf7\x80\x80\x80\"");
+    utf8Error("\"\xf8\x80\x80\x80\"");
+    utf8Error("\"\xf9\x80\x80\x80\"");
+    utf8Error("\"\xfa\x80\x80\x80\"");
+    utf8Error("\"\xfb\x80\x80\x80\"");
+    utf8Error("\"\xfc\x80\x80\x80\"");
+    utf8Error("\"\xfd\x80\x80\x80\"");
+    utf8Error("\"\xfe\x80\x80\x80\"");
+    utf8Error("\"\xff\x80\x80\x80\"");
 }


### PR DESCRIPTION
Fixes #2379

Today we done learn a thing or two about UTF-8 and JSON! If you are curious about the encoding-related details, please see my commit message 💀 🔨 

## Changes

- Overhaul the std/json parser states related to multibyte sequences, using [this official table of valid UTF-8 byte sequences](https://unicode.org/versions/corrigendum1.html) as the guiding map. The parser now correctly disallows "overlong" encoding and codepoints beyond UTF-16 range.
- Add several test cases to cover the above as well as some preexisting functionality.

## Notes

_and preëmption of awkward feels_

- Some of the reported failures in #2379 (truncated byte sequences) were already passing and didn't need to be addressed.
- The `\uDEAD` case in #2379 was already intentionally being allowed. See my comment on that issue for details, and #1774, #2565 for related discussion.
- I aimed to favor readability over size/speed. `--emit asm` shows me that `0x80...0xBF =>` adds 10-ish instructions over a bitwise op, but I figured an optimizing stage2 will take care of that someday. I added `sequence_first_byte` instead of reusing an existing field. I'm open to changing any of that.
- The new state enum names might look cheesy, and unlike the other numbered states they count up instead of down. However, after consideration, I thought it was the most sensible way to map to [the table of valid UTF-8 byte sequences](https://unicode.org/versions/corrigendum1.html).
- Apologies, I didn't understand the naming convention of the tests in std/json/test.zig. I can fix it if desired.