### PR TITLE
Use the correct calling convention for AEABI intrinsics

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1292,10 +1292,6 @@ test "cstr" {
 }
 
 test "filesize" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     try testFmt("file size: 63MiB\n", "file size: {Bi}\n", .{@as(usize, 63 * 1024 * 1024)});
     try testFmt("file size: 66.06MB\n", "file size: {B:.2}\n", .{@as(usize, 63 * 1024 * 1024)});
 }
@@ -1330,10 +1326,6 @@ test "enum" {
 }
 
 test "float.scientific" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     try testFmt("f32: 1.34000003e+00", "f32: {e}", .{@as(f32, 1.34)});
     try testFmt("f32: 1.23400001e+01", "f32: {e}", .{@as(f32, 12.34)});
     try testFmt("f64: -1.234e+11", "f64: {e}", .{@as(f64, -12.34e10)});
@@ -1341,10 +1333,6 @@ test "float.scientific" {
 }
 
 test "float.scientific.precision" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     try testFmt("f64: 1.40971e-42", "f64: {e:.5}", .{@as(f64, 1.409706e-42)});
     try testFmt("f64: 1.00000e-09", "f64: {e:.5}", .{@as(f64, @bitCast(f32, @as(u32, 814313563)))});
     try testFmt("f64: 7.81250e-03", "f64: {e:.5}", .{@as(f64, @bitCast(f32, @as(u32, 1006632960)))});
@@ -1354,10 +1342,6 @@ test "float.scientific.precision" {
 }
 
 test "float.special" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     try testFmt("f64: nan", "f64: {}", .{math.nan_f64});
     // negative nan is not defined by IEE 754,
     // and ARM thus normalizes it to positive nan
@@ -1369,10 +1353,6 @@ test "float.special" {
 }
 
 test "float.decimal" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     try testFmt("f64: 152314000000000000000000000000", "f64: {d}", .{@as(f64, 1.52314e+29)});
     try testFmt("f32: 1.1", "f32: {d:.1}", .{@as(f32, 1.1234)});
     try testFmt("f32: 1234.57", "f32: {d:.2}", .{@as(f32, 1234.567)});
@@ -1391,10 +1371,6 @@ test "float.decimal" {
 }
 
 test "float.libc.sanity" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     try testFmt("f64: 0.00001", "f64: {d:.5}", .{@as(f64, @bitCast(f32, @as(u32, 916964781)))});
     try testFmt("f64: 0.00001", "f64: {d:.5}", .{@as(f64, @bitCast(f32, @as(u32, 925353389)))});
     try testFmt("f64: 0.10000", "f64: {d:.5}", .{@as(f64, @bitCast(f32, @as(u32, 1036831278)))});

--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -382,10 +382,6 @@ pub fn parseFloat(comptime T: type, s: []const u8) !T {
 }
 
 test "fmt.parseFloat" {
-    if (@import("builtin").arch == .arm) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const testing = std.testing;
     const expect = testing.expect;
     const expectEqual = testing.expectEqual;

--- a/lib/std/math/big/rational.zig
+++ b/lib/std/math/big/rational.zig
@@ -742,10 +742,6 @@ test "big.rational setFloatString" {
 }
 
 test "big.rational toFloat" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     var a = try Rational.init(al);
 
     // = 3.14159297943115234375
@@ -758,10 +754,6 @@ test "big.rational toFloat" {
 }
 
 test "big.rational set/to Float round-trip" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     var a = try Rational.init(al);
     var prng = std.rand.DefaultPrng.init(0x5EED);
     var i: usize = 0;

--- a/lib/std/math/complex/atan.zig
+++ b/lib/std/math/complex/atan.zig
@@ -130,10 +130,6 @@ test "complex.catan32" {
 }
 
 test "complex.catan64" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const a = Complex(f64).new(5, 3);
     const c = atan(a);
 

--- a/lib/std/math/complex/cosh.zig
+++ b/lib/std/math/complex/cosh.zig
@@ -165,10 +165,6 @@ test "complex.ccosh32" {
 }
 
 test "complex.ccosh64" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const a = Complex(f64).new(5, 3);
     const c = cosh(a);
 

--- a/lib/std/math/complex/exp.zig
+++ b/lib/std/math/complex/exp.zig
@@ -131,10 +131,6 @@ test "complex.cexp32" {
 }
 
 test "complex.cexp64" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const a = Complex(f64).new(5, 3);
     const c = exp(a);
 

--- a/lib/std/math/complex/sinh.zig
+++ b/lib/std/math/complex/sinh.zig
@@ -164,10 +164,6 @@ test "complex.csinh32" {
 }
 
 test "complex.csinh64" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const a = Complex(f64).new(5, 3);
     const c = sinh(a);
 

--- a/lib/std/math/complex/tanh.zig
+++ b/lib/std/math/complex/tanh.zig
@@ -113,10 +113,6 @@ test "complex.ctanh32" {
 }
 
 test "complex.ctanh64" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const a = Complex(f64).new(5, 3);
     const c = tanh(a);
 

--- a/lib/std/math/cos.zig
+++ b/lib/std/math/cos.zig
@@ -100,10 +100,6 @@ test "math.cos32" {
 }
 
 test "math.cos64" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const epsilon = 0.000001;
 
     expect(math.approxEq(f64, cos_(f64, 0.0), 1.0, epsilon));

--- a/lib/std/math/pow.zig
+++ b/lib/std/math/pow.zig
@@ -184,10 +184,6 @@ fn isOddInteger(x: f64) bool {
 }
 
 test "math.pow" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const epsilon = 0.000001;
 
     expect(math.approxEq(f32, pow(f32, 0.0, 3.3), 0.0, epsilon));
@@ -206,10 +202,6 @@ test "math.pow" {
 }
 
 test "math.pow.special" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const epsilon = 0.000001;
 
     expect(pow(f32, 4, 0.0) == 1.0);
@@ -252,10 +244,6 @@ test "math.pow.special" {
 }
 
 test "math.pow.overflow" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     expect(math.isPositiveInf(pow(f64, 2, 1 << 32)));
     expect(pow(f64, 2, -(1 << 32)) == 0);
     expect(math.isNegativeInf(pow(f64, -2, (1 << 32) + 1)));

--- a/lib/std/math/sin.zig
+++ b/lib/std/math/sin.zig
@@ -84,20 +84,12 @@ fn sin_(comptime T: type, x_: T) T {
 }
 
 test "math.sin" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     expect(sin(@as(f32, 0.0)) == sin_(f32, 0.0));
     expect(sin(@as(f64, 0.0)) == sin_(f64, 0.0));
     expect(comptime (math.sin(@as(f64, 2))) == math.sin(@as(f64, 2)));
 }
 
 test "math.sin32" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const epsilon = 0.000001;
 
     expect(math.approxEq(f32, sin_(f32, 0.0), 0.0, epsilon));
@@ -110,10 +102,6 @@ test "math.sin32" {
 }
 
 test "math.sin64" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const epsilon = 0.000001;
 
     expect(math.approxEq(f64, sin_(f64, 0.0), 0.0, epsilon));
@@ -126,10 +114,6 @@ test "math.sin64" {
 }
 
 test "math.sin32.special" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     expect(sin_(f32, 0.0) == 0.0);
     expect(sin_(f32, -0.0) == -0.0);
     expect(math.isNan(sin_(f32, math.inf(f32))));
@@ -138,10 +122,6 @@ test "math.sin32.special" {
 }
 
 test "math.sin64.special" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     expect(sin_(f64, 0.0) == 0.0);
     expect(sin_(f64, -0.0) == -0.0);
     expect(math.isNan(sin_(f64, math.inf(f64))));

--- a/lib/std/math/tan.zig
+++ b/lib/std/math/tan.zig
@@ -91,10 +91,6 @@ test "math.tan32" {
 }
 
 test "math.tan64" {
-    if (builtin.os == .linux and builtin.arch == .arm and builtin.abi == .musleabihf) {
-        // TODO https://github.com/ziglang/zig/issues/3289
-        return error.SkipZigTest;
-    }
     const epsilon = 0.000001;
 
     expect(math.approxEq(f64, tan_(f64, 0.0), 0.0, epsilon));

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -181,62 +181,62 @@ comptime {
         @export("__aeabi_memcmp4", __aeabi_memcmp, linkage);
         @export("__aeabi_memcmp8", __aeabi_memcmp, linkage);
 
-        @export("__aeabi_f2d", @import("compiler_rt/extendXfYf2.zig").__extendsfdf2, linkage);
-        @export("__aeabi_i2d", @import("compiler_rt/floatsiXf.zig").__floatsidf, linkage);
-        @export("__aeabi_l2d", @import("compiler_rt/floatdidf.zig").__floatdidf, linkage);
-        @export("__aeabi_ui2d", @import("compiler_rt/floatunsidf.zig").__floatunsidf, linkage);
-        @export("__aeabi_ul2d", @import("compiler_rt/floatundidf.zig").__floatundidf, linkage);
-        @export("__aeabi_ui2f", @import("compiler_rt/floatunsisf.zig").__floatunsisf, linkage);
-        @export("__aeabi_ul2f", @import("compiler_rt/floatundisf.zig").__floatundisf, linkage);
+        @export("__aeabi_f2d", @import("compiler_rt/extendXfYf2.zig").__aeabi_f2d, linkage);
+        @export("__aeabi_i2d", @import("compiler_rt/floatsiXf.zig").__aeabi_i2d, linkage);
+        @export("__aeabi_l2d", @import("compiler_rt/floatdidf.zig").__aeabi_l2d, linkage);
+        @export("__aeabi_ui2d", @import("compiler_rt/floatunsidf.zig").__aeabi_ui2d, linkage);
+        @export("__aeabi_ul2d", @import("compiler_rt/floatundidf.zig").__aeabi_ul2d, linkage);
+        @export("__aeabi_ui2f", @import("compiler_rt/floatunsisf.zig").__aeabi_ui2f, linkage);
+        @export("__aeabi_ul2f", @import("compiler_rt/floatundisf.zig").__aeabi_ul2f, linkage);
 
-        @export("__aeabi_fneg", @import("compiler_rt/negXf2.zig").__negsf2, linkage);
-        @export("__aeabi_dneg", @import("compiler_rt/negXf2.zig").__negdf2, linkage);
+        @export("__aeabi_fneg", @import("compiler_rt/negXf2.zig").__aeabi_fneg, linkage);
+        @export("__aeabi_dneg", @import("compiler_rt/negXf2.zig").__aeabi_dneg, linkage);
 
-        @export("__aeabi_fmul", @import("compiler_rt/mulXf3.zig").__mulsf3, linkage);
-        @export("__aeabi_dmul", @import("compiler_rt/mulXf3.zig").__muldf3, linkage);
+        @export("__aeabi_fmul", @import("compiler_rt/mulXf3.zig").__aeabi_fmul, linkage);
+        @export("__aeabi_dmul", @import("compiler_rt/mulXf3.zig").__aeabi_dmul, linkage);
 
-        @export("__aeabi_d2h", @import("compiler_rt/truncXfYf2.zig").__truncdfhf2, linkage);
+        @export("__aeabi_d2h", @import("compiler_rt/truncXfYf2.zig").__aeabi_d2h, linkage);
 
-        @export("__aeabi_f2ulz", @import("compiler_rt/fixunssfdi.zig").__fixunssfdi, linkage);
-        @export("__aeabi_d2ulz", @import("compiler_rt/fixunsdfdi.zig").__fixunsdfdi, linkage);
+        @export("__aeabi_f2ulz", @import("compiler_rt/fixunssfdi.zig").__aeabi_f2ulz, linkage);
+        @export("__aeabi_d2ulz", @import("compiler_rt/fixunsdfdi.zig").__aeabi_d2ulz, linkage);
 
-        @export("__aeabi_f2lz", @import("compiler_rt/fixsfdi.zig").__fixsfdi, linkage);
-        @export("__aeabi_d2lz", @import("compiler_rt/fixdfdi.zig").__fixdfdi, linkage);
+        @export("__aeabi_f2lz", @import("compiler_rt/fixsfdi.zig").__aeabi_f2lz, linkage);
+        @export("__aeabi_d2lz", @import("compiler_rt/fixdfdi.zig").__aeabi_d2lz, linkage);
 
-        @export("__aeabi_d2uiz", @import("compiler_rt/fixunsdfsi.zig").__fixunsdfsi, linkage);
+        @export("__aeabi_d2uiz", @import("compiler_rt/fixunsdfsi.zig").__aeabi_d2uiz, linkage);
 
-        @export("__aeabi_h2f", @import("compiler_rt/extendXfYf2.zig").__extendhfsf2, linkage);
-        @export("__aeabi_f2h", @import("compiler_rt/truncXfYf2.zig").__truncsfhf2, linkage);
+        @export("__aeabi_h2f", @import("compiler_rt/extendXfYf2.zig").__aeabi_h2f, linkage);
+        @export("__aeabi_f2h", @import("compiler_rt/truncXfYf2.zig").__aeabi_f2h, linkage);
 
-        @export("__aeabi_i2f", @import("compiler_rt/floatsiXf.zig").__floatsisf, linkage);
-        @export("__aeabi_d2f", @import("compiler_rt/truncXfYf2.zig").__truncdfsf2, linkage);
+        @export("__aeabi_i2f", @import("compiler_rt/floatsiXf.zig").__aeabi_i2f, linkage);
+        @export("__aeabi_d2f", @import("compiler_rt/truncXfYf2.zig").__aeabi_d2f, linkage);
 
-        @export("__aeabi_fadd", @import("compiler_rt/addXf3.zig").__addsf3, linkage);
-        @export("__aeabi_dadd", @import("compiler_rt/addXf3.zig").__adddf3, linkage);
-        @export("__aeabi_fsub", @import("compiler_rt/addXf3.zig").__subsf3, linkage);
-        @export("__aeabi_dsub", @import("compiler_rt/addXf3.zig").__subdf3, linkage);
+        @export("__aeabi_fadd", @import("compiler_rt/addXf3.zig").__aeabi_fadd, linkage);
+        @export("__aeabi_dadd", @import("compiler_rt/addXf3.zig").__aeabi_dadd, linkage);
+        @export("__aeabi_fsub", @import("compiler_rt/addXf3.zig").__aeabi_fsub, linkage);
+        @export("__aeabi_dsub", @import("compiler_rt/addXf3.zig").__aeabi_dsub, linkage);
 
-        @export("__aeabi_f2uiz", @import("compiler_rt/fixunssfsi.zig").__fixunssfsi, linkage);
+        @export("__aeabi_f2uiz", @import("compiler_rt/fixunssfsi.zig").__aeabi_f2uiz, linkage);
 
-        @export("__aeabi_f2iz", @import("compiler_rt/fixsfsi.zig").__fixsfsi, linkage);
-        @export("__aeabi_d2iz", @import("compiler_rt/fixdfsi.zig").__fixdfsi, linkage);
+        @export("__aeabi_f2iz", @import("compiler_rt/fixsfsi.zig").__aeabi_f2iz, linkage);
+        @export("__aeabi_d2iz", @import("compiler_rt/fixdfsi.zig").__aeabi_d2iz, linkage);
 
-        @export("__aeabi_fdiv", @import("compiler_rt/divsf3.zig").__divsf3, linkage);
-        @export("__aeabi_ddiv", @import("compiler_rt/divdf3.zig").__divdf3, linkage);
+        @export("__aeabi_fdiv", @import("compiler_rt/divsf3.zig").__aeabi_fdiv, linkage);
+        @export("__aeabi_ddiv", @import("compiler_rt/divdf3.zig").__aeabi_ddiv, linkage);
 
         @export("__aeabi_fcmpeq", @import("compiler_rt/arm/aeabi_fcmp.zig").__aeabi_fcmpeq, linkage);
         @export("__aeabi_fcmplt", @import("compiler_rt/arm/aeabi_fcmp.zig").__aeabi_fcmplt, linkage);
         @export("__aeabi_fcmple", @import("compiler_rt/arm/aeabi_fcmp.zig").__aeabi_fcmple, linkage);
         @export("__aeabi_fcmpge", @import("compiler_rt/arm/aeabi_fcmp.zig").__aeabi_fcmpge, linkage);
         @export("__aeabi_fcmpgt", @import("compiler_rt/arm/aeabi_fcmp.zig").__aeabi_fcmpgt, linkage);
-        @export("__aeabi_fcmpun", @import("compiler_rt/comparesf2.zig").__unordsf2, linkage);
+        @export("__aeabi_fcmpun", @import("compiler_rt/comparesf2.zig").__aeabi_fcmpun, linkage);
 
         @export("__aeabi_dcmpeq", @import("compiler_rt/arm/aeabi_dcmp.zig").__aeabi_dcmpeq, linkage);
         @export("__aeabi_dcmplt", @import("compiler_rt/arm/aeabi_dcmp.zig").__aeabi_dcmplt, linkage);
         @export("__aeabi_dcmple", @import("compiler_rt/arm/aeabi_dcmp.zig").__aeabi_dcmple, linkage);
         @export("__aeabi_dcmpge", @import("compiler_rt/arm/aeabi_dcmp.zig").__aeabi_dcmpge, linkage);
         @export("__aeabi_dcmpgt", @import("compiler_rt/arm/aeabi_dcmp.zig").__aeabi_dcmpgt, linkage);
-        @export("__aeabi_dcmpun", @import("compiler_rt/comparedf2.zig").__unorddf2, linkage);
+        @export("__aeabi_dcmpun", @import("compiler_rt/comparedf2.zig").__aeabi_dcmpun, linkage);
     }
     if (builtin.os == .windows) {
         // Default stack-probe functions emitted by LLVM

--- a/lib/std/special/compiler_rt/addXf3.zig
+++ b/lib/std/special/compiler_rt/addXf3.zig
@@ -33,6 +33,26 @@ pub fn __subtf3(a: f128, b: f128) callconv(.C) f128 {
     return addXf3(f128, a, neg_b);
 }
 
+pub fn __aeabi_fadd(a: f32, b: f32) callconv(.AAPCS) f32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __addsf3, .{ a, b });
+}
+
+pub fn __aeabi_dadd(a: f64, b: f64) callconv(.AAPCS) f64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __adddf3, .{ a, b });
+}
+
+pub fn __aeabi_fsub(a: f32, b: f32) callconv(.AAPCS) f32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __subsf3, .{ a, b });
+}
+
+pub fn __aeabi_dsub(a: f64, b: f64) callconv(.AAPCS) f64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __subdf3, .{ a, b });
+}
+
 // TODO: restore inline keyword, see: https://github.com/ziglang/zig/issues/2154
 fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     const Z = @IntType(false, T.bit_count);

--- a/lib/std/special/compiler_rt/arm/aeabi_dcmp.zig
+++ b/lib/std/special/compiler_rt/arm/aeabi_dcmp.zig
@@ -2,8 +2,6 @@
 //
 // https://github.com/llvm/llvm-project/commit/d674d96bc56c0f377879d01c9d8dfdaaa7859cdb/compiler-rt/lib/builtins/arm/aeabi_dcmp.S
 
-const compiler_rt_armhf_target = false; // TODO
-
 const ConditionalOperator = enum {
     Eq,
     Lt,
@@ -42,22 +40,11 @@ pub fn __aeabi_dcmpgt() callconv(.Naked) noreturn {
     unreachable;
 }
 
-inline fn convert_dcmp_args_to_df2_args() void {
-    asm volatile (
-        \\ vmov      d0, r0, r1
-        \\ vmov      d1, r2, r3
-    );
-}
-
 fn aeabi_dcmp(comptime cond: ConditionalOperator) void {
     @setRuntimeSafety(false);
     asm volatile (
         \\ push      { r4, lr }
     );
-
-    if (compiler_rt_armhf_target) {
-        convert_dcmp_args_to_df2_args();
-    }
 
     switch (cond) {
         .Eq => asm volatile (

--- a/lib/std/special/compiler_rt/arm/aeabi_fcmp.zig
+++ b/lib/std/special/compiler_rt/arm/aeabi_fcmp.zig
@@ -2,8 +2,6 @@
 //
 // https://github.com/llvm/llvm-project/commit/d674d96bc56c0f377879d01c9d8dfdaaa7859cdb/compiler-rt/lib/builtins/arm/aeabi_fcmp.S
 
-const compiler_rt_armhf_target = false; // TODO
-
 const ConditionalOperator = enum {
     Eq,
     Lt,
@@ -42,22 +40,11 @@ pub fn __aeabi_fcmpgt() callconv(.Naked) noreturn {
     unreachable;
 }
 
-inline fn convert_fcmp_args_to_sf2_args() void {
-    asm volatile (
-        \\ vmov      s0, r0
-        \\ vmov      s1, r1
-    );
-}
-
 fn aeabi_fcmp(comptime cond: ConditionalOperator) void {
     @setRuntimeSafety(false);
     asm volatile (
         \\ push      { r4, lr }
     );
-
-    if (compiler_rt_armhf_target) {
-        convert_fcmp_args_to_sf2_args();
-    }
 
     switch (cond) {
         .Eq => asm volatile (

--- a/lib/std/special/compiler_rt/comparedf2.zig
+++ b/lib/std/special/compiler_rt/comparedf2.zig
@@ -117,6 +117,11 @@ pub fn __gtdf2(a: fp_t, b: fp_t) callconv(.C) c_int {
     return __gedf2(a, b);
 }
 
+pub fn __aeabi_dcmpun(a: fp_t, b: fp_t) callconv(.AAPCS) c_int {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __unorddf2, .{ a, b });
+}
+
 test "import comparedf2" {
     _ = @import("comparedf2_test.zig");
 }

--- a/lib/std/special/compiler_rt/comparesf2.zig
+++ b/lib/std/special/compiler_rt/comparesf2.zig
@@ -117,6 +117,11 @@ pub fn __gtsf2(a: fp_t, b: fp_t) callconv(.C) c_int {
     return __gesf2(a, b);
 }
 
+pub fn __aeabi_fcmpun(a: fp_t, b: fp_t) callconv(.AAPCS) c_int {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __unordsf2, .{ a, b });
+}
+
 test "import comparesf2" {
     _ = @import("comparesf2_test.zig");
 }

--- a/lib/std/special/compiler_rt/divdf3.zig
+++ b/lib/std/special/compiler_rt/divdf3.zig
@@ -323,6 +323,11 @@ fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     return 1 - shift;
 }
 
+pub fn __aeabi_ddiv(a: f64, b: f64) callconv(.AAPCS) f64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __divdf3, .{ a, b });
+}
+
 test "import divdf3" {
     _ = @import("divdf3_test.zig");
 }

--- a/lib/std/special/compiler_rt/divsf3.zig
+++ b/lib/std/special/compiler_rt/divsf3.zig
@@ -196,6 +196,11 @@ fn normalize(comptime T: type, significand: *@IntType(false, T.bit_count)) i32 {
     return 1 - shift;
 }
 
+pub fn __aeabi_fdiv(a: f32, b: f32) callconv(.AAPCS) f32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __divsf3, .{ a, b });
+}
+
 test "import divsf3" {
     _ = @import("divsf3_test.zig");
 }

--- a/lib/std/special/compiler_rt/extendXfYf2.zig
+++ b/lib/std/special/compiler_rt/extendXfYf2.zig
@@ -18,6 +18,16 @@ pub fn __extendhfsf2(a: u16) callconv(.C) f32 {
     return @call(.{ .modifier = .always_inline }, extendXfYf2, .{ f32, f16, a });
 }
 
+pub fn __aeabi_h2f(arg: u16) callconv(.AAPCS) f32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __extendhfsf2, .{arg});
+}
+
+pub fn __aeabi_f2d(arg: f32) callconv(.AAPCS) f64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __extendsfdf2, .{arg});
+}
+
 const CHAR_BIT = 8;
 
 fn extendXfYf2(comptime dst_t: type, comptime src_t: type, a: @IntType(false, @typeInfo(src_t).Float.bits)) dst_t {

--- a/lib/std/special/compiler_rt/fixdfdi.zig
+++ b/lib/std/special/compiler_rt/fixdfdi.zig
@@ -6,6 +6,11 @@ pub fn __fixdfdi(a: f64) callconv(.C) i64 {
     return fixint(f64, i64, a);
 }
 
+pub fn __aeabi_d2lz(arg: f64) callconv(.AAPCS) i64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __fixdfdi, .{arg});
+}
+
 test "import fixdfdi" {
     _ = @import("fixdfdi_test.zig");
 }

--- a/lib/std/special/compiler_rt/fixdfsi.zig
+++ b/lib/std/special/compiler_rt/fixdfsi.zig
@@ -6,6 +6,11 @@ pub fn __fixdfsi(a: f64) callconv(.C) i32 {
     return fixint(f64, i32, a);
 }
 
+pub fn __aeabi_d2iz(a: f64) callconv(.AAPCS) i32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __fixdfsi, .{a});
+}
+
 test "import fixdfsi" {
     _ = @import("fixdfsi_test.zig");
 }

--- a/lib/std/special/compiler_rt/fixsfdi.zig
+++ b/lib/std/special/compiler_rt/fixsfdi.zig
@@ -6,6 +6,11 @@ pub fn __fixsfdi(a: f32) callconv(.C) i64 {
     return fixint(f32, i64, a);
 }
 
+pub fn __aeabi_f2lz(arg: f32) callconv(.AAPCS) i64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __fixsfdi, .{arg});
+}
+
 test "import fixsfdi" {
     _ = @import("fixsfdi_test.zig");
 }

--- a/lib/std/special/compiler_rt/fixsfsi.zig
+++ b/lib/std/special/compiler_rt/fixsfsi.zig
@@ -6,6 +6,11 @@ pub fn __fixsfsi(a: f32) callconv(.C) i32 {
     return fixint(f32, i32, a);
 }
 
+pub fn __aeabi_f2iz(a: f32) callconv(.AAPCS) i32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __fixsfsi, .{a});
+}
+
 test "import fixsfsi" {
     _ = @import("fixsfsi_test.zig");
 }

--- a/lib/std/special/compiler_rt/fixunsdfdi.zig
+++ b/lib/std/special/compiler_rt/fixunsdfdi.zig
@@ -6,6 +6,11 @@ pub fn __fixunsdfdi(a: f64) callconv(.C) u64 {
     return fixuint(f64, u64, a);
 }
 
+pub fn __aeabi_d2ulz(a: f64) callconv(.AAPCS) u64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __fixunsdfdi, .{a});
+}
+
 test "import fixunsdfdi" {
     _ = @import("fixunsdfdi_test.zig");
 }

--- a/lib/std/special/compiler_rt/fixunsdfsi.zig
+++ b/lib/std/special/compiler_rt/fixunsdfsi.zig
@@ -6,6 +6,11 @@ pub fn __fixunsdfsi(a: f64) callconv(.C) u32 {
     return fixuint(f64, u32, a);
 }
 
+pub fn __aeabi_d2uiz(arg: f64) callconv(.AAPCS) u32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __fixunsdfsi, .{arg});
+}
+
 test "import fixunsdfsi" {
     _ = @import("fixunsdfsi_test.zig");
 }

--- a/lib/std/special/compiler_rt/fixunssfdi.zig
+++ b/lib/std/special/compiler_rt/fixunssfdi.zig
@@ -6,6 +6,11 @@ pub fn __fixunssfdi(a: f32) callconv(.C) u64 {
     return fixuint(f32, u64, a);
 }
 
+pub fn __aeabi_f2ulz(a: f32) callconv(.AAPCS) u64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __fixunssfdi, .{a});
+}
+
 test "import fixunssfdi" {
     _ = @import("fixunssfdi_test.zig");
 }

--- a/lib/std/special/compiler_rt/fixunssfsi.zig
+++ b/lib/std/special/compiler_rt/fixunssfsi.zig
@@ -6,6 +6,11 @@ pub fn __fixunssfsi(a: f32) callconv(.C) u32 {
     return fixuint(f32, u32, a);
 }
 
+pub fn __aeabi_f2uiz(a: f32) callconv(.AAPCS) u32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __fixunssfsi, .{a});
+}
+
 test "import fixunssfsi" {
     _ = @import("fixunssfsi_test.zig");
 }

--- a/lib/std/special/compiler_rt/floatdidf.zig
+++ b/lib/std/special/compiler_rt/floatdidf.zig
@@ -17,6 +17,11 @@ pub fn __floatdidf(a: i64) callconv(.C) f64 {
     return (high - twop52) + @bitCast(f64, low);
 }
 
+pub fn __aeabi_l2d(arg: i64) callconv(.AAPCS) f64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __floatdidf, .{arg});
+}
+
 test "import floatdidf" {
     _ = @import("floatdidf_test.zig");
 }

--- a/lib/std/special/compiler_rt/floatsiXf.zig
+++ b/lib/std/special/compiler_rt/floatsiXf.zig
@@ -68,6 +68,16 @@ pub fn __floatsitf(arg: i32) callconv(.C) f128 {
     return @call(.{ .modifier = .always_inline }, floatsiXf, .{ f128, arg });
 }
 
+pub fn __aeabi_i2d(arg: i32) callconv(.AAPCS) f64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __floatsidf, .{arg});
+}
+
+pub fn __aeabi_i2f(arg: i32) callconv(.AAPCS) f32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __floatsisf, .{arg});
+}
+
 fn test_one_floatsitf(a: i32, expected: u128) void {
     const r = __floatsitf(a);
     std.testing.expect(@bitCast(u128, r) == expected);

--- a/lib/std/special/compiler_rt/floatundidf.zig
+++ b/lib/std/special/compiler_rt/floatundidf.zig
@@ -19,6 +19,11 @@ pub fn __floatundidf(a: u64) callconv(.C) f64 {
     return (@bitCast(f64, high) - twop84_plus_twop52) + @bitCast(f64, low);
 }
 
+pub fn __aeabi_ul2d(arg: u64) callconv(.AAPCS) f64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __floatundidf, .{arg});
+}
+
 test "import floatundidf" {
     _ = @import("floatundidf_test.zig");
 }

--- a/lib/std/special/compiler_rt/floatundisf.zig
+++ b/lib/std/special/compiler_rt/floatundisf.zig
@@ -4,7 +4,7 @@ const maxInt = std.math.maxInt;
 
 const FLT_MANT_DIG = 24;
 
-pub extern fn __floatundisf(arg: u64) f32 {
+pub fn __floatundisf(arg: u64) callconv(.C) f32 {
     @setRuntimeSafety(builtin.is_test);
 
     if (arg == 0) return 0;
@@ -54,6 +54,11 @@ pub extern fn __floatundisf(arg: u64) f32 {
     const result: u32 = ((e + 127) << 23) | // exponent
         @truncate(u32, a & 0x007FFFFF); // mantissa
     return @bitCast(f32, result);
+}
+
+pub fn __aeabi_ul2f(arg: u64) callconv(.AAPCS) f32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __floatundisf, .{arg});
 }
 
 fn test__floatundisf(a: u64, expected: f32) void {

--- a/lib/std/special/compiler_rt/floatunsidf.zig
+++ b/lib/std/special/compiler_rt/floatunsidf.zig
@@ -18,6 +18,11 @@ pub fn __floatunsidf(arg: u32) callconv(.C) f64 {
     return @bitCast(f64, mant | (exp + 1023) << 52);
 }
 
+pub fn __aeabi_ui2d(arg: u32) callconv(.AAPCS) f64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __floatunsidf, .{arg});
+}
+
 fn test_one_floatunsidf(a: u32, expected: u64) void {
     const r = __floatunsidf(a);
     std.testing.expect(@bitCast(u64, r) == expected);

--- a/lib/std/special/compiler_rt/floatunsisf.zig
+++ b/lib/std/special/compiler_rt/floatunsisf.zig
@@ -6,7 +6,7 @@ const significandBits = 23;
 const exponentBias = 127;
 const implicitBit = @as(u32, 1) << significandBits;
 
-pub extern fn __floatunsisf(arg: u32) f32 {
+pub fn __floatunsisf(arg: u32) callconv(.C) f32 {
     @setRuntimeSafety(builtin.is_test);
 
     if (arg == 0) return 0.0;
@@ -36,6 +36,11 @@ pub extern fn __floatunsisf(arg: u32) f32 {
     result += (exp + exponentBias) << significandBits;
 
     return @bitCast(f32, result);
+}
+
+pub fn __aeabi_ui2f(arg: u32) callconv(.AAPCS) f32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __floatunsisf, .{arg});
 }
 
 fn test_one_floatunsisf(a: u32, expected: u32) void {

--- a/lib/std/special/compiler_rt/mulXf3.zig
+++ b/lib/std/special/compiler_rt/mulXf3.zig
@@ -16,6 +16,16 @@ pub fn __mulsf3(a: f32, b: f32) callconv(.C) f32 {
     return mulXf3(f32, a, b);
 }
 
+pub fn __aeabi_fmul(a: f32, b: f32) callconv(.C) f32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __mulsf3, .{ a, b });
+}
+
+pub fn __aeabi_dmul(a: f64, b: f64) callconv(.C) f64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __muldf3, .{ a, b });
+}
+
 fn mulXf3(comptime T: type, a: T, b: T) T {
     @setRuntimeSafety(builtin.is_test);
     const Z = @IntType(false, T.bit_count);

--- a/lib/std/special/compiler_rt/negXf2.zig
+++ b/lib/std/special/compiler_rt/negXf2.zig
@@ -8,6 +8,16 @@ pub fn __negdf2(a: f64) callconv(.C) f64 {
     return negXf2(f64, a);
 }
 
+pub fn __aeabi_fneg(arg: f32) callconv(.AAPCS) f32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __negsf2, .{arg});
+}
+
+pub fn __aeabi_dneg(arg: f64) callconv(.AAPCS) f64 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __negdf2, .{arg});
+}
+
 fn negXf2(comptime T: type, a: T) T {
     const Z = @IntType(false, T.bit_count);
 

--- a/lib/std/special/compiler_rt/truncXfYf2.zig
+++ b/lib/std/special/compiler_rt/truncXfYf2.zig
@@ -20,6 +20,21 @@ pub fn __truncdfsf2(a: f64) callconv(.C) f32 {
     return truncXfYf2(f32, f64, a);
 }
 
+pub fn __aeabi_d2f(a: f64) callconv(.AAPCS) f32 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __truncdfsf2, .{a});
+}
+
+pub fn __aeabi_d2h(a: f64) callconv(.AAPCS) u16 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __truncdfhf2, .{a});
+}
+
+pub fn __aeabi_f2h(a: f32) callconv(.AAPCS) u16 {
+    @setRuntimeSafety(false);
+    return @call(.{ .modifier = .always_inline }, __truncsfhf2, .{a});
+}
+
 inline fn truncXfYf2(comptime dst_t: type, comptime src_t: type, a: src_t) dst_t {
     const src_rep_t = @IntType(false, @typeInfo(src_t).Float.bits);
     const dst_rep_t = @IntType(false, @typeInfo(dst_t).Float.bits);


### PR DESCRIPTION
Closes #3289 and should be the last step to have everything working correctly when the hard-fp ABI is selected.