### PR TITLE
Correct @mulAdd's doc

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6828,8 +6828,11 @@ async fn func(y: *i32) void {
       {#header_open|@mulAdd#}
       <pre>{#syntax#}@mulAdd(comptime T: type, a: T, b: T, c: T) T{#endsyntax#}</pre>
       <p>
-      Fused multiply add (for floats), similar to {#syntax#}(a * b) + c{#endsyntax#}, except
+      Fused multiply add, similar to {#syntax#}(a * b) + c{#endsyntax#}, except
       only rounds once, and is thus more accurate.
+      </p>
+      <p>
+      Supports Floats and Vectors of floats.
       </p>
       {#header_close#}
 


### PR DESCRIPTION
```zig
const std = @import("std");
const warn = std.debug.warn;

pub fn main() void {
    var a: @Vector(3, f32) = [3]f32{ 1, 2, 3 };
    var b: @Vector(3, f32) = [3]f32{ 10, 20, 30 };
    var c: @Vector(3, f32) = [3]f32{ 5, 6, 7 };
    var d = @mulAdd(@Vector(3, f32), a, b, c);

    warn("{}\n", .{d[0]});
    warn("{}\n", .{d[1]});
    warn("{}\n", .{d[2]});
}
```

>1.5e+01
4.6e+01
9.7e+01