### PR TITLE
Use narrowest field size when struct is packed

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -8156,7 +8156,7 @@ static void resolve_llvm_types_struct(CodeGen *g, ZigType *struct_type, ResolveS
 
     if (first_packed_bits_offset_misalign != SIZE_MAX) {
         size_t full_bit_count = packed_bits_offset - first_packed_bits_offset_misalign;
-        size_t full_abi_size = get_store_size_bytes(full_bit_count); //get_abi_size_bytes(full_bit_count, g->pointer_size_bytes);
+        size_t full_abi_size = get_store_size_bytes(full_bit_count);
         element_types[gen_field_index] = get_llvm_type_of_n_bytes(full_abi_size);
         gen_field_index += 1;
     }

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -2247,8 +2247,10 @@ static Error resolve_struct_type(CodeGen *g, ZigType *struct_type) {
     if (first_packed_bits_offset_misalign != SIZE_MAX) {
         size_t full_bit_count = packed_bits_offset - first_packed_bits_offset_misalign;
         size_t full_abi_size = get_abi_size_bytes(full_bit_count, g->pointer_size_bytes);
-        next_offset = next_field_offset(next_offset, abi_align, full_abi_size, abi_align);
-        host_int_bytes[gen_field_index] = full_abi_size;
+        size_t full_size = packed ? get_store_size_bytes(full_bit_count) : full_abi_size;
+
+        host_int_bytes[gen_field_index] = full_size;
+        next_offset = next_field_offset(next_offset, abi_align, full_size, abi_align);
         gen_field_index += 1;
     }
 
@@ -8154,7 +8156,7 @@ static void resolve_llvm_types_struct(CodeGen *g, ZigType *struct_type, ResolveS
 
     if (first_packed_bits_offset_misalign != SIZE_MAX) {
         size_t full_bit_count = packed_bits_offset - first_packed_bits_offset_misalign;
-        size_t full_abi_size = get_abi_size_bytes(full_bit_count, g->pointer_size_bytes);
+        size_t full_abi_size = get_store_size_bytes(full_bit_count); //get_abi_size_bytes(full_bit_count, g->pointer_size_bytes);
         element_types[gen_field_index] = get_llvm_type_of_n_bytes(full_abi_size);
         gen_field_index += 1;
     }


### PR DESCRIPTION
This is a work in progress, I'd like feedback in case I'm doing something really stupid.

get_abi_size will always return a multiple of the word size. When we're packed, we want to use the smallest store size in bytes possible.

I'm sure this isn't the right/best way to fix this, but it passes a few of my manual tests.

- [ ] Implement packed struct tests
- [ ] Style cleanup
