### PR TITLE
Fix remaining variadic formatted prints

### DIFF
--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -125,9 +125,9 @@ fn mode(comptime x: comptime_int) comptime_int {
 fn printPad(stdout: var, s: []const u8) !void {
     var i: usize = 0;
     while (i < 12 - s.len) : (i += 1) {
-        try stdout.print(" ");
+        try stdout.print(" ", .{});
     }
-    try stdout.print("{}", s);
+    try stdout.print("{}", .{s});
 }
 
 pub fn main() !void {
@@ -142,7 +142,7 @@ pub fn main() !void {
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         if (std.mem.eql(u8, args[i], "--mode")) {
-            try stdout.print("{}\n", builtin.mode);
+            try stdout.print("{}\n", .{builtin.mode});
             return;
         } else if (std.mem.eql(u8, args[i], "--seed")) {
             i += 1;
@@ -174,7 +174,7 @@ pub fn main() !void {
         if (filter == null or std.mem.indexOf(u8, H.name, filter.?) != null) {
             const throughput = try benchmarkHash(H.ty, mode(32 * MiB));
             try printPad(stdout, H.name);
-            try stdout.print(": {} MiB/s\n", throughput / (1 * MiB));
+            try stdout.print(": {} MiB/s\n", .{throughput / (1 * MiB)});
         }
     }
 
@@ -182,7 +182,7 @@ pub fn main() !void {
         if (filter == null or std.mem.indexOf(u8, M.name, filter.?) != null) {
             const throughput = try benchmarkMac(M.ty, mode(128 * MiB));
             try printPad(stdout, M.name);
-            try stdout.print(": {} MiB/s\n", throughput / (1 * MiB));
+            try stdout.print(": {} MiB/s\n", .{throughput / (1 * MiB)});
         }
     }
 
@@ -190,7 +190,7 @@ pub fn main() !void {
         if (filter == null or std.mem.indexOf(u8, E.name, filter.?) != null) {
             const throughput = try benchmarkKeyExchange(E.ty, mode(1000));
             try printPad(stdout, E.name);
-            try stdout.print(": {} exchanges/s\n", throughput);
+            try stdout.print(": {} exchanges/s\n", .{throughput});
         }
     }
 }

--- a/lib/std/hash/benchmark.zig
+++ b/lib/std/hash/benchmark.zig
@@ -171,15 +171,6 @@ fn mode(comptime x: comptime_int) comptime_int {
     return if (builtin.mode == builtin.Mode.Debug) x / 64 else x;
 }
 
-// TODO(#1358): Replace with builtin formatted padding when available.
-fn printPad(stdout: var, s: []const u8) !void {
-    var i: usize = 0;
-    while (i < 12 - s.len) : (i += 1) {
-        try stdout.print(" ");
-    }
-    try stdout.print("{}", s);
-}
-
 pub fn main() !void {
     var stdout_file = std.io.getStdOut();
     var stdout_out_stream = stdout_file.outStream();
@@ -198,7 +189,7 @@ pub fn main() !void {
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         if (std.mem.eql(u8, args[i], "--mode")) {
-            try stdout.print("{}\n", builtin.mode);
+            try stdout.print("{}\n", .{builtin.mode});
             return;
         } else if (std.mem.eql(u8, args[i], "--seed")) {
             i += 1;
@@ -235,7 +226,7 @@ pub fn main() !void {
 
             key_size = try std.fmt.parseUnsigned(usize, args[i], 10);
             if (key_size > block_size) {
-                try stdout.print("key_size cannot exceed block size of {}\n", block_size);
+                try stdout.print("key_size cannot exceed block size of {}\n", .{block_size});
                 std.os.exit(1);
             }
         } else if (std.mem.eql(u8, args[i], "--iterative-only")) {
@@ -252,20 +243,20 @@ pub fn main() !void {
     inline for (hashes) |H| {
         if (filter == null or std.mem.indexOf(u8, H.name, filter.?) != null) {
             if (!test_iterative_only or H.has_iterative_api) {
-                try stdout.print("{}\n", H.name);
+                try stdout.print("{}\n", .{H.name});
 
                 // Always reseed prior to every call so we are hashing the same buffer contents.
                 // This allows easier comparison between different implementations.
                 if (H.has_iterative_api) {
                     prng.seed(seed);
                     const result = try benchmarkHash(H, count);
-                    try stdout.print("   iterative: {:4} MiB/s [{x:0<16}]\n", result.throughput / (1 * MiB), result.hash);
+                    try stdout.print("   iterative: {:4} MiB/s [{x:0<16}]\n", .{result.throughput / (1 * MiB), result.hash});
                 }
 
                 if (!test_iterative_only) {
                     prng.seed(seed);
                     const result_small = try benchmarkHashSmallKeys(H, key_size, count);
-                    try stdout.print("  small keys: {:4} MiB/s [{x:0<16}]\n", result_small.throughput / (1 * MiB), result_small.hash);
+                    try stdout.print("  small keys: {:4} MiB/s [{x:0<16}]\n", .{result_small.throughput / (1 * MiB), result_small.hash});
                 }
             }
         }

--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -35,7 +35,13 @@ pub const Guid = extern struct {
         output: fn (@TypeOf(context), []const u8) Errors!void,
     ) Errors!void {
         if (f.len == 0) {
-            return fmt.format(context, Errors, output, "{x:0>8}-{x:0>4}-{x:0>4}-{x:0>2}{x:0>2}-{x:0>12}", self.time_low, self.time_mid, self.time_high_and_version, self.clock_seq_high_and_reserved, self.clock_seq_low, self.node);
+            return fmt.format(context, Errors, output, "{x:0>8}-{x:0>4}-{x:0>4}-{x:0>2}{x:0>2}-{x:0>12}", .{
+                self.time_low,
+                self.time_mid,
+                self.time_high_and_version,
+                self.clock_seq_high_and_reserved,
+                self.clock_seq_low, self.node,
+            });
         } else {
             @compileError("Unknown format character: '" ++ f ++ "'");
         }

--- a/lib/std/special/c.zig
+++ b/lib/std/special/c.zig
@@ -81,7 +81,7 @@ test "strncmp" {
 pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
     if (builtin.is_test) {
         @setCold(true);
-        std.debug.panic("{}", msg);
+        std.debug.panic("{}", .{msg});
     }
     if (builtin.os != .freestanding and builtin.os != .other) {
         std.os.abort();

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -308,7 +308,7 @@ const __udivmoddi4 = @import("compiler_rt/udivmoddi4.zig").__udivmoddi4;
 pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
     @setCold(true);
     if (is_test) {
-        std.debug.panic("{}", msg);
+        std.debug.panic("{}", .{msg});
     } else {
         unreachable;
     }

--- a/lib/std/special/compiler_rt/ashrti3_test.zig
+++ b/lib/std/special/compiler_rt/ashrti3_test.zig
@@ -3,8 +3,8 @@ const testing = @import("std").testing;
 
 fn test__ashrti3(a: i128, b: i32, expected: i128) void {
     const x = __ashrti3(a, b);
-    // @import("std").debug.warn("got 0x{x}\nexp 0x{x}\n", @truncate(u64,
-    // @bitCast(u128, x) >> 64), @truncate(u64, @bitCast(u128, expected)) >> 64);
+    // @import("std").debug.warn("got 0x{x}\nexp 0x{x}\n", .{@truncate(u64,
+    // @bitCast(u128, x) >> 64), @truncate(u64, @bitCast(u128, expected)) >> 64});
     testing.expect(x == expected);
 }
 

--- a/lib/std/special/compiler_rt/fixdfdi_test.zig
+++ b/lib/std/special/compiler_rt/fixdfdi_test.zig
@@ -6,12 +6,12 @@ const warn = std.debug.warn;
 
 fn test__fixdfdi(a: f64, expected: i64) void {
     const x = __fixdfdi(a);
-    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u64, {x})\n", a, @bitCast(u64, a), x, x, expected, expected, @bitCast(u64, expected));
+    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u64, {x})\n", .{a, @bitCast(u64, a), x, x, expected, expected, @bitCast(u64, expected)});
     testing.expect(x == expected);
 }
 
 test "fixdfdi" {
-    //warn("\n");
+    //warn("\n", .{});
     test__fixdfdi(-math.f64_max, math.minInt(i64));
 
     test__fixdfdi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i64));

--- a/lib/std/special/compiler_rt/fixdfsi_test.zig
+++ b/lib/std/special/compiler_rt/fixdfsi_test.zig
@@ -6,12 +6,12 @@ const warn = std.debug.warn;
 
 fn test__fixdfsi(a: f64, expected: i32) void {
     const x = __fixdfsi(a);
-    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u64, {x})\n", a, @bitCast(u64, a), x, x, expected, expected, @bitCast(u32, expected));
+    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u64, {x})\n", .{a, @bitCast(u64, a), x, x, expected, expected, @bitCast(u32, expected)});
     testing.expect(x == expected);
 }
 
 test "fixdfsi" {
-    //warn("\n");
+    //warn("\n", .{});
     test__fixdfsi(-math.f64_max, math.minInt(i32));
 
     test__fixdfsi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i32));

--- a/lib/std/special/compiler_rt/fixdfti_test.zig
+++ b/lib/std/special/compiler_rt/fixdfti_test.zig
@@ -6,12 +6,12 @@ const warn = std.debug.warn;
 
 fn test__fixdfti(a: f64, expected: i128) void {
     const x = __fixdfti(a);
-    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u64, {x})\n", a, @bitCast(u64, a), x, x, expected, expected, @bitCast(u128, expected));
+    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u64, {x})\n", .{a, @bitCast(u64, a), x, x, expected, expected, @bitCast(u128, expected)});
     testing.expect(x == expected);
 }
 
 test "fixdfti" {
-    //warn("\n");
+    //warn("\n", .{});
     test__fixdfti(-math.f64_max, math.minInt(i128));
 
     test__fixdfti(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i128));

--- a/lib/std/special/compiler_rt/fixint_test.zig
+++ b/lib/std/special/compiler_rt/fixint_test.zig
@@ -8,7 +8,7 @@ const fixint = @import("fixint.zig").fixint;
 
 fn test__fixint(comptime fp_t: type, comptime fixint_t: type, a: fp_t, expected: fixint_t) void {
     const x = fixint(fp_t, fixint_t, a);
-    //warn("a={} x={}:{x} expected={}:{x})\n", a, x, x, expected, expected);
+    //warn("a={} x={}:{x} expected={}:{x})\n", .{a, x, x, expected, expected});
     testing.expect(x == expected);
 }
 

--- a/lib/std/special/compiler_rt/fixsfdi_test.zig
+++ b/lib/std/special/compiler_rt/fixsfdi_test.zig
@@ -6,12 +6,12 @@ const warn = std.debug.warn;
 
 fn test__fixsfdi(a: f32, expected: i64) void {
     const x = __fixsfdi(a);
-    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u32, {x})\n", a, @bitCast(u32, a), x, x, expected, expected, @bitCast(u64, expected));
+    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u32, {x})\n", .{a, @bitCast(u32, a), x, x, expected, expected, @bitCast(u64, expected)});
     testing.expect(x == expected);
 }
 
 test "fixsfdi" {
-    //warn("\n");
+    //warn("\n", .{});
     test__fixsfdi(-math.f32_max, math.minInt(i64));
 
     test__fixsfdi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i64));

--- a/lib/std/special/compiler_rt/fixsfsi_test.zig
+++ b/lib/std/special/compiler_rt/fixsfsi_test.zig
@@ -6,12 +6,12 @@ const warn = std.debug.warn;
 
 fn test__fixsfsi(a: f32, expected: i32) void {
     const x = __fixsfsi(a);
-    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u32, {x})\n", a, @bitCast(u32, a), x, x, expected, expected, @bitCast(u32, expected));
+    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u32, {x})\n", .{a, @bitCast(u32, a), x, x, expected, expected, @bitCast(u32, expected)});
     testing.expect(x == expected);
 }
 
 test "fixsfsi" {
-    //warn("\n");
+    //warn("\n", .{});
     test__fixsfsi(-math.f32_max, math.minInt(i32));
 
     test__fixsfsi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i32));

--- a/lib/std/special/compiler_rt/fixsfti_test.zig
+++ b/lib/std/special/compiler_rt/fixsfti_test.zig
@@ -6,12 +6,12 @@ const warn = std.debug.warn;
 
 fn test__fixsfti(a: f32, expected: i128) void {
     const x = __fixsfti(a);
-    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u128, {x})\n", a, @bitCast(u32, a), x, x, expected, expected, @bitCast(u128, expected));
+    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u128, {x})\n", .{a, @bitCast(u32, a), x, x, expected, expected, @bitCast(u128, expected)});
     testing.expect(x == expected);
 }
 
 test "fixsfti" {
-    //warn("\n");
+    //warn("\n", .{});
     test__fixsfti(-math.f32_max, math.minInt(i128));
 
     test__fixsfti(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i128));

--- a/lib/std/special/compiler_rt/fixtfdi_test.zig
+++ b/lib/std/special/compiler_rt/fixtfdi_test.zig
@@ -6,12 +6,12 @@ const warn = std.debug.warn;
 
 fn test__fixtfdi(a: f128, expected: i64) void {
     const x = __fixtfdi(a);
-    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u64, {x})\n", a, @bitCast(u128, a), x, x, expected, expected, @bitCast(u64, expected));
+    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u64, {x})\n", .{a, @bitCast(u128, a), x, x, expected, expected, @bitCast(u64, expected)});
     testing.expect(x == expected);
 }
 
 test "fixtfdi" {
-    //warn("\n");
+    //warn("\n", .{});
     test__fixtfdi(-math.f128_max, math.minInt(i64));
 
     test__fixtfdi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i64));

--- a/lib/std/special/compiler_rt/fixtfsi_test.zig
+++ b/lib/std/special/compiler_rt/fixtfsi_test.zig
@@ -6,12 +6,12 @@ const warn = std.debug.warn;
 
 fn test__fixtfsi(a: f128, expected: i32) void {
     const x = __fixtfsi(a);
-    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u32, {x})\n", a, @bitCast(u128, a), x, x, expected, expected, @bitCast(u32, expected));
+    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u32, {x})\n", .{a, @bitCast(u128, a), x, x, expected, expected, @bitCast(u32, expected)});
     testing.expect(x == expected);
 }
 
 test "fixtfsi" {
-    //warn("\n");
+    //warn("\n", .{});
     test__fixtfsi(-math.f128_max, math.minInt(i32));
 
     test__fixtfsi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i32));

--- a/lib/std/special/compiler_rt/fixtfti_test.zig
+++ b/lib/std/special/compiler_rt/fixtfti_test.zig
@@ -6,12 +6,12 @@ const warn = std.debug.warn;
 
 fn test__fixtfti(a: f128, expected: i128) void {
     const x = __fixtfti(a);
-    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u128, {x})\n", a, @bitCast(u128, a), x, x, expected, expected, @bitCast(u128, expected));
+    //warn("a={}:{x} x={}:{x} expected={}:{x}:@as(u128, {x})\n", .{a, @bitCast(u128, a), x, x, expected, expected, @bitCast(u128, expected)});
     testing.expect(x == expected);
 }
 
 test "fixtfti" {
-    //warn("\n");
+    //warn("\n", .{});
     test__fixtfti(-math.f128_max, math.minInt(i128));
 
     test__fixtfti(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i128));

--- a/lib/std/zig/perf_test.zig
+++ b/lib/std/zig/perf_test.zig
@@ -25,7 +25,7 @@ pub fn main() !void {
 
     var stdout_file = std.io.getStdOut();
     const stdout = &stdout_file.outStream().stream;
-    try stdout.print("{:.3} MiB/s, {} KiB used \n", mb_per_sec, memory_used / 1024);
+    try stdout.print("{:.3} MiB/s, {} KiB used \n", .{mb_per_sec, memory_used / 1024});
 }
 
 fn testOnce() usize {

--- a/src-self-hosted/dep_tokenizer.zig
+++ b/src-self-hosted/dep_tokenizer.zig
@@ -894,7 +894,7 @@ fn printSection(out: var, label: []const u8, bytes: []const u8) !void {
 
 fn printLabel(out: var, label: []const u8, bytes: []const u8) !void {
     var buf: [80]u8 = undefined;
-    var text = try std.fmt.bufPrint(buf[0..], "{} {} bytes ", label, bytes.len);
+    var text = try std.fmt.bufPrint(buf[0..], "{} {} bytes ", .{label, bytes.len});
     try out.write(text);
     var i: usize = text.len;
     const end = 79;

--- a/src-self-hosted/test.zig
+++ b/src-self-hosted/test.zig
@@ -81,7 +81,7 @@ pub const TestContext = struct {
         msg: []const u8,
     ) !void {
         var file_index_buf: [20]u8 = undefined;
-        const file_index = try std.fmt.bufPrint(file_index_buf[0..], "{}", self.file_index.incr());
+        const file_index = try std.fmt.bufPrint(file_index_buf[0..], "{}", .{self.file_index.incr()});
         const file1_path = try std.fs.path.join(allocator, [_][]const u8{ tmp_dir_name, file_index, file1 });
 
         if (std.fs.path.dirname(file1_path)) |dirname| {
@@ -114,10 +114,10 @@ pub const TestContext = struct {
         expected_output: []const u8,
     ) !void {
         var file_index_buf: [20]u8 = undefined;
-        const file_index = try std.fmt.bufPrint(file_index_buf[0..], "{}", self.file_index.incr());
+        const file_index = try std.fmt.bufPrint(file_index_buf[0..], "{}", .{self.file_index.incr()});
         const file1_path = try std.fs.path.join(allocator, [_][]const u8{ tmp_dir_name, file_index, file1 });
 
-        const output_file = try std.fmt.allocPrint(allocator, "{}-out{}", file1_path, (Target{ .Native = {} }).exeFileExt());
+        const output_file = try std.fmt.allocPrint(allocator, "{}-out{}", .{ file1_path, (Target{ .Native = {} }).exeFileExt() });
         if (std.fs.path.dirname(file1_path)) |dirname| {
             try std.fs.makePath(allocator, dirname);
         }
@@ -214,21 +214,20 @@ pub const TestContext = struct {
                         }
                     }
                 }
-                std.debug.warn(
-                    "\n=====source:=======\n{}\n====expected:========\n{}:{}:{}: error: {}\n",
+                std.debug.warn("\n=====source:=======\n{}\n====expected:========\n{}:{}:{}: error: {}\n", .{
                     source,
                     path,
                     line,
                     column,
                     text,
-                );
-                std.debug.warn("\n====found:========\n");
+                });
+                std.debug.warn("\n====found:========\n", .{});
                 const stderr = std.io.getStdErr();
                 for (msgs) |msg| {
                     defer msg.destroy();
                     try msg.printToFile(stderr, errmsg.Color.Auto);
                 }
-                std.debug.warn("============\n");
+                std.debug.warn("============\n", .{});
                 return error.TestFailed;
             },
         }

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -330,11 +330,11 @@ pub fn translate(
     tree.root_node.eof_token = try appendToken(&context, .Eof, "");
     tree.source = source_buffer.toOwnedSlice();
     if (false) {
-        std.debug.warn("debug source:\n{}\n==EOF==\ntokens:\n", tree.source);
+        std.debug.warn("debug source:\n{}\n==EOF==\ntokens:\n", .{tree.source});
         var i: usize = 0;
         while (i < tree.tokens.len) : (i += 1) {
             const token = tree.tokens.at(i);
-            std.debug.warn("{}\n", token);
+            std.debug.warn("{}\n", .{token});
         }
     }
     return tree;

--- a/src-self-hosted/type.zig
+++ b/src-self-hosted/type.zig
@@ -162,7 +162,7 @@ pub const Type = struct {
     }
 
     pub fn dump(base: *const Type) void {
-        std.debug.warn("{}", @tagName(base.id));
+        std.debug.warn("{}", .{@tagName(base.id)});
     }
 
     fn init(base: *Type, comp: *Compilation, id: Id, name: []const u8) void {

--- a/tools/process_headers.zig
+++ b/tools/process_headers.zig
@@ -270,7 +270,7 @@ pub fn main() !void {
         if (std.mem.eql(u8, args[arg_i], "--help"))
             usageAndExit(args[0]);
         if (arg_i + 1 >= args.len) {
-            std.debug.warn("expected argument after '{}'\n", args[arg_i]);
+            std.debug.warn("expected argument after '{}'\n", .{args[arg_i]});
             usageAndExit(args[0]);
         }
 
@@ -283,7 +283,7 @@ pub fn main() !void {
             assert(opt_abi == null);
             opt_abi = args[arg_i + 1];
         } else {
-            std.debug.warn("unrecognized argument: {}\n", args[arg_i]);
+            std.debug.warn("unrecognized argument: {}\n", .{args[arg_i]});
             usageAndExit(args[0]);
         }
 
@@ -297,10 +297,10 @@ pub fn main() !void {
     else if (std.mem.eql(u8, abi_name, "glibc"))
         LibCVendor.glibc
     else {
-        std.debug.warn("unrecognized C ABI: {}\n", abi_name);
+        std.debug.warn("unrecognized C ABI: {}\n", .{abi_name});
         usageAndExit(args[0]);
     };
-    const generic_name = try std.fmt.allocPrint(allocator, "generic-{}", abi_name);
+    const generic_name = try std.fmt.allocPrint(allocator, "generic-{}", .{abi_name});
 
     // TODO compiler crashed when I wrote this the canonical way
     var libc_targets: []const LibCTarget = undefined;
@@ -365,12 +365,11 @@ pub fn main() !void {
                             if (gop.found_existing) {
                                 max_bytes_saved += raw_bytes.len;
                                 gop.kv.value.hit_count += 1;
-                                std.debug.warn(
-                                    "duplicate: {} {} ({Bi:2})\n",
+                                std.debug.warn("duplicate: {} {} ({Bi:2})\n", .{
                                     libc_target.name,
                                     rel_path,
                                     raw_bytes.len,
-                                );
+                                });
                             } else {
                                 gop.kv.value = Contents{
                                     .bytes = trimmed,
@@ -388,16 +387,16 @@ pub fn main() !void {
                             };
                             assert((try target_to_hash.put(dest_target, hash)) == null);
                         },
-                        else => std.debug.warn("warning: weird file: {}\n", full_path),
+                        else => std.debug.warn("warning: weird file: {}\n", .{full_path}),
                     }
                 }
             }
             break;
         } else {
-            std.debug.warn("warning: libc target not found: {}\n", libc_target.name);
+            std.debug.warn("warning: libc target not found: {}\n", .{libc_target.name});
         }
     }
-    std.debug.warn("summary: {Bi:2} could be reduced to {Bi:2}\n", total_bytes, total_bytes - max_bytes_saved);
+    std.debug.warn("summary: {Bi:2} could be reduced to {Bi:2}\n", .{total_bytes, total_bytes - max_bytes_saved});
     try std.fs.makePath(allocator, out_dir);
 
     var missed_opportunity_bytes: usize = 0;
@@ -426,7 +425,7 @@ pub fn main() !void {
                 if (contender.hit_count > 1) {
                     const this_missed_bytes = contender.hit_count * contender.bytes.len;
                     missed_opportunity_bytes += this_missed_bytes;
-                    std.debug.warn("Missed opportunity ({Bi:2}): {}\n", this_missed_bytes, path_kv.key);
+                    std.debug.warn("Missed opportunity ({Bi:2}): {}\n", .{this_missed_bytes, path_kv.key});
                 } else break;
             }
         }
@@ -440,13 +439,11 @@ pub fn main() !void {
                 .specific => |a| @tagName(a),
                 else => @tagName(dest_target.arch),
             };
-            const out_subpath = try std.fmt.allocPrint(
-                allocator,
-                "{}-{}-{}",
+            const out_subpath = try std.fmt.allocPrint(allocator, "{}-{}-{}", .{
                 arch_name,
                 @tagName(dest_target.os),
                 @tagName(dest_target.abi),
-            );
+            });
             const full_path = try std.fs.path.join(allocator, [_][]const u8{ out_dir, out_subpath, path_kv.key });
             try std.fs.makePath(allocator, std.fs.path.dirname(full_path).?);
             try std.io.writeFile(full_path, contents.bytes);
@@ -455,10 +452,10 @@ pub fn main() !void {
 }
 
 fn usageAndExit(arg0: []const u8) noreturn {
-    std.debug.warn("Usage: {} [--search-path <dir>] --out <dir> --abi <name>\n", arg0);
-    std.debug.warn("--search-path can be used any number of times.\n");
-    std.debug.warn("    subdirectories of search paths look like, e.g. x86_64-linux-gnu\n");
-    std.debug.warn("--out is a dir that will be created, and populated with the results\n");
-    std.debug.warn("--abi is either musl or glibc\n");
+    std.debug.warn("Usage: {} [--search-path <dir>] --out <dir> --abi <name>\n", .{arg0});
+    std.debug.warn("--search-path can be used any number of times.\n", .{});
+    std.debug.warn("    subdirectories of search paths look like, e.g. x86_64-linux-gnu\n", .{});
+    std.debug.warn("--out is a dir that will be created, and populated with the results\n", .{});
+    std.debug.warn("--abi is either musl or glibc\n", .{});
     std.process.exit(1);
 }

--- a/tools/update_glibc.zig
+++ b/tools/update_glibc.zig
@@ -155,7 +155,7 @@ pub fn main() !void {
         const fn_set = &target_funcs_gop.kv.value.list;
 
         for (lib_names) |lib_name, lib_name_index| {
-            const basename = try fmt.allocPrint(allocator, "lib{}.abilist", lib_name);
+            const basename = try fmt.allocPrint(allocator, "lib{}.abilist", .{lib_name});
             const abi_list_filename = blk: {
                 if (abi_list.targets[0].abi == .gnuabi64 and std.mem.eql(u8, lib_name, "c")) {
                     break :blk try fs.path.join(allocator, [_][]const u8{ prefix, abi_list.path, "n64", basename });
@@ -177,7 +177,7 @@ pub fn main() !void {
                 break :blk try fs.path.join(allocator, [_][]const u8{ prefix, abi_list.path, basename });
             };
             const contents = std.io.readFileAlloc(allocator, abi_list_filename) catch |err| {
-                std.debug.warn("unable to open {}: {}\n", abi_list_filename, err);
+                std.debug.warn("unable to open {}: {}\n", .{abi_list_filename, err});
                 std.process.exit(1);
             };
             var lines_it = std.mem.tokenize(contents, "\n");
@@ -235,7 +235,7 @@ pub fn main() !void {
         const vers_txt = &buffered.stream;
         for (global_ver_list) |name, i| {
             _ = global_ver_set.put(name, i) catch unreachable;
-            try vers_txt.print("{}\n", name);
+            try vers_txt.print("{}\n", .{name});
         }
         try buffered.flush();
     }
@@ -248,7 +248,7 @@ pub fn main() !void {
         for (global_fn_list) |name, i| {
             const kv = global_fn_set.get(name).?;
             kv.value.index = i;
-            try fns_txt.print("{} {}\n", name, kv.value.lib);
+            try fns_txt.print("{} {}\n", .{name, kv.value.lib});
         }
         try buffered.flush();
     }
@@ -282,7 +282,7 @@ pub fn main() !void {
             const fn_vers_list = &target_functions.get(@ptrToInt(abi_list)).?.value.fn_vers_list;
             for (abi_list.targets) |target, it_i| {
                 if (it_i != 0) try abilist_txt.writeByte(' ');
-                try abilist_txt.print("{}-linux-{}", @tagName(target.arch), @tagName(target.abi));
+                try abilist_txt.print("{}-linux-{}", .{@tagName(target.arch), @tagName(target.abi)});
             }
             try abilist_txt.writeByte('\n');
             // next, each line implicitly corresponds to a function
@@ -293,7 +293,7 @@ pub fn main() !void {
                 };
                 for (kv.value.toSliceConst()) |ver_index, it_i| {
                     if (it_i != 0) try abilist_txt.writeByte(' ');
-                    try abilist_txt.print("{d}", ver_index);
+                    try abilist_txt.print("{d}", .{ver_index});
                 }
                 try abilist_txt.writeByte('\n');
             }


### PR DESCRIPTION
Used a series of regex searches to try to find as many instances of the old pattern as I could and update them. Not positive I got them all, but this should hopefully cover most.

Notes:
- I verified as many as I could by running/testing them, but some, like in `src-self-hosted`, have other errors that need to be fixed
- Some were in comments, but I went ahead and updated those anyway
- `printPad` was unused in `std/hash/benchmark.zig` so I just deleted it
- I left out `std/heap/logging_allocator.zig` since its covered by #4121