### PR TITLE
Sets memory to undefined when freed from allocator

### DIFF
--- a/lib/std/http/headers.zig
+++ b/lib/std/http/headers.zig
@@ -172,7 +172,7 @@ pub const Headers = struct {
             var dex = HeaderIndexList.init(self.allocator);
             try dex.append(n - 1);
             errdefer dex.deinit();
-            _ = try self.index.put(name, dex);
+            _ = try self.index.put(name_dup, dex);
         }
         self.data.appendAssumeCapacity(entry);
     }


### PR DESCRIPTION
Closes #4087

This managed to find an obscure bug in http.headers! Fix included in this PR.