### PR TITLE
Add WaitForSingleObject function to std.os.windows

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -188,6 +188,10 @@ pub const WaitForSingleObjectError = error{
     Unexpected,
 };
 
+pub fn WaitForSingleObject(handle: HANDLE, milliseconds: DWORD) WaitForSingleObjectError!void {
+    return WaitForSingleObjectEx(handle, milliseconds, false);
+}
+
 pub fn WaitForSingleObjectEx(handle: HANDLE, milliseconds: DWORD, alertable: bool) WaitForSingleObjectError!void {
     switch (kernel32.WaitForSingleObjectEx(handle, milliseconds, @boolToInt(alertable))) {
         WAIT_ABANDONED => return error.WaitAbandoned,


### PR DESCRIPTION
Add the `WaitForSingleObject` function to the `std.os.windows` high-level zig API.  According to [Microsoft Docs](https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject), `WaitForSingleObjectEx` is required to enter an "alertable wait state" so it follows that `WaitForSingleObject` must enter a non-alertable wait state.
