### PR TITLE
Elide evaluation of tautological integral comparisons

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -3450,23 +3450,27 @@ static IrInstruction *ir_build_err_to_int(IrBuilder *irb, Scope *scope, AstNode 
 }
 
 static IrInstruction *ir_build_check_switch_prongs(IrBuilder *irb, Scope *scope, AstNode *source_node,
-        IrInstruction *target_value, IrInstructionCheckSwitchProngsRange *ranges, size_t range_count,
-        bool have_else_prong)
+        IrInstruction *target_value)
 {
     IrInstructionCheckSwitchProngs *instruction = ir_build_instruction<IrInstructionCheckSwitchProngs>(
             irb, scope, source_node);
     instruction->target_value = target_value;
+
+    return &instruction->base;
+}
+
+static void ir_finish_check_switch_prongs(IrBuilder *irb, IrInstructionCheckSwitchProngs * instruction,
+        IrInstructionCheckSwitchProngsRange *ranges, size_t range_count, bool have_else_prong)
+{
     instruction->ranges = ranges;
     instruction->range_count = range_count;
     instruction->have_else_prong = have_else_prong;
 
-    ir_ref_instruction(target_value, irb->current_basic_block);
+    ir_ref_instruction(instruction->target_value, irb->current_basic_block);
     for (size_t i = 0; i < range_count; i += 1) {
         ir_ref_instruction(ranges[i].start, irb->current_basic_block);
         ir_ref_instruction(ranges[i].end, irb->current_basic_block);
     }
-
-    return &instruction->base;
 }
 
 static IrInstruction *ir_build_check_statement_is_void(IrBuilder *irb, Scope *scope, AstNode *source_node,
@@ -8076,6 +8080,7 @@ static IrInstruction *ir_gen_switch_expr(IrBuilder *irb, Scope *scope, AstNode *
     ZigList<IrInstructionCheckSwitchProngsRange> check_ranges = {0};
 
     IrInstructionSwitchElseVar *switch_else_var = nullptr;
+    IrInstruction *switch_prongs_void = ir_build_check_switch_prongs(irb, scope, node, target_value);
 
     ResultLocPeerParent *peer_parent = allocate<ResultLocPeerParent>(1);
     peer_parent->base.id = ResultLocIdPeerParent;
@@ -8248,7 +8253,7 @@ static IrInstruction *ir_gen_switch_expr(IrBuilder *irb, Scope *scope, AstNode *
 
     }
 
-    IrInstruction *switch_prongs_void = ir_build_check_switch_prongs(irb, scope, node, target_value,
+    ir_finish_check_switch_prongs(irb, (IrInstructionCheckSwitchProngs *)switch_prongs_void,
             check_ranges.items, check_ranges.length, else_prong != nullptr);
 
     IrInstruction *br_instruction;

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -6546,4 +6546,40 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     , &[_][]const u8{
         "tmp.zig:2:27: error: type 'u32' does not support array initialization",
     });
+
+    cases.add("overeager elision of tautological comparison pos eq",
+        \\export fn entry() void {
+        \\    var x: u8 = undefined;
+        \\    if (255 == x) @compileError("this branch should be analyzed");
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:3:19: error: this branch should be analyzed",
+    });
+
+    cases.add("overeager elision of tautological comparison pos neq",
+        \\export fn entry() void {
+        \\    var x: u8 = undefined;
+        \\    if (x != 255) {} else @compileError("this branch should be analyzed");
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:3:27: error: this branch should be analyzed",
+    });
+
+    cases.add("overeager elision of tautological comparison pos gte",
+        \\export fn entry() void {
+        \\    var x: u8 = undefined;
+        \\    if (255 >= x) @compileError("this branch should be analyzed");
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:3:19: error: this branch should be analyzed",
+    });
+
+    cases.add("overeager elision of tautological comparison neg gt",
+        \\export fn entry() void {
+        \\    var x: i8 = undefined;
+        \\    if (x > -128) {} else @compileError("this branch should be analyzed");
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:3:27: error: this branch should be analyzed",
+    });
 }

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -100,6 +100,7 @@ comptime {
     _ = @import("behavior/switch_prong_err_enum.zig");
     _ = @import("behavior/switch_prong_implicit_cast.zig");
     _ = @import("behavior/syntax.zig");
+    _ = @import("behavior/tautological_int_comparison.zig");
     _ = @import("behavior/this.zig");
     _ = @import("behavior/truncate.zig");
     _ = @import("behavior/try.zig");

--- a/test/stage1/behavior/tautological_int_comparison.zig
+++ b/test/stage1/behavior/tautological_int_comparison.zig
@@ -1,0 +1,47 @@
+const expect = @import("std").testing.expect;
+
+// https://github.com/ziglang/zig/issues/2146
+test "tautological integral comparisons" {
+    var u: u4 = undefined;
+    var i: i4 = undefined;
+
+    if (u > 15) @compileLog("analyzed impossible branch");
+    if (u >= 16) @compileLog("analyzed impossible branch");
+    if (u < 16) {} else @compileLog("analyzed impossible branch");
+    if (u <= 15) {} else @compileLog("analyzed impossible branch");
+
+    if (15 < u) @compileLog("analyzed impossible branch");
+    if (16 <= u) @compileLog("analyzed impossible branch");
+    if (16 > u) {} else @compileLog("analyzed impossible branch");
+    if (15 >= u) {} else @compileLog("analyzed impossible branch");
+
+    if (i < -8) @compileLog("analyzed impossible branch");
+    if (i <= -9) @compileLog("analyzed impossible branch");
+    if (i >= -8) {} else @compileLog("analyzed impossible branch");
+    if (i > -9) {} else @compileLog("analyzed impossible branch");
+
+    if (-8 > i) @compileLog("analyzed impossible branch");
+    if (-9 >= i) @compileLog("analyzed impossible branch");
+    if (-8 <= i) {} else @compileLog("analyzed impossible branch");
+    if (-9 < i) {} else @compileLog("analyzed impossible branch");
+
+    if (u < comptime largeConstant()) {} else @compileLog("analyzed impossible branch");
+    if (u >= comptime largeConstant()) @compileLog("analyzed impossible branch");
+    if (i <= comptime signedConstant()) @compileLog("analyzed impossible branch");
+    if (i > comptime signedConstant()) {} else @compileLog("analyzed impossible branch");
+
+    const large_constant: u32 = 16;
+    const signed_constant: i32 = -9;
+    if (u < large_constant) {} else @compileLog("analyzed impossible branch");
+    if (u >= large_constant) @compileLog("analyzed impossible branch");
+    if (i <= signed_constant) @compileLog("analyzed impossible branch");
+    if (i > signed_constant) {} else @compileLog("analyzed impossible branch");
+}
+
+fn largeConstant() u32 {
+    return 16;
+}
+
+fn signedConstant() i32 {
+    return -9;
+}


### PR DESCRIPTION
This change introduced a bug (see below), so this is a WIP.

Fixes #2146 

## Language changes

A [tautological](https://en.wikipedia.org/wiki/Tautology_(logic)) comparison between integers -- that is, a comparison whose outcome is known without even knowing both values -- will result in the correct boolean value at compile time. This can result in preventing the semantic analysis of one branch of a conditional statement, for example. See [use cases](https://github.com/ziglang/zig/issues/2146).

An integral comparison is considered a tautology if all of the following are true:

- one of the operands has a value known at compile time
- the comptime-known value would take too many bits to fit into the other operand's type

The compiler already handles some kinds of tautologies, like `false == true` and `-13 >= some_unsigned_var`. This change just extends that feature to cover cases based on type size.

## Notes

I added a few cases involving numbers on the "edge" of a type (e.g. the maximum value which can be represented in a u8 or i4), but it might be a good idea to automatically generate these comparisons to try to catch all such potential edge cases. (I was always inspired by the test which [checks all possible places an allocation could/should fail in the parser](https://github.com/ziglang/zig/blob/5951b79af40212754071157596b8aebbe2414ffb/lib/std/zig/parser_test.zig#L2790-L2817).)

## Bugs

After this change, the test [`compile-error switch with overlapping case ranges`](https://github.com/ziglang/zig/blob/a3f6a58c7785e7958f9d0b96d54356944bf34e32/test/compile_errors.zig#L311-L321) fails -- the compiler starts accepting overlapping ranges in a switch. I don't know why yet.