### PR TITLE
prefer C++ compiler builtins for BREAKPOINT

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -30,8 +30,6 @@
 
 #else
 
-#include <signal.h>
-
 #define ATTRIBUTE_COLD         __attribute__((cold))
 #define ATTRIBUTE_PRINTF(a, b) __attribute__((format(printf, a, b)))
 #define ATTRIBUTE_RETURNS_NOALIAS __attribute__((__malloc__))
@@ -40,7 +38,12 @@
 
 #if defined(__MINGW32__) || defined(__MINGW64__)
 #define BREAKPOINT __debugbreak()
+#elif defined(__clang__)
+#define BREAKPOINT __builtin_debugtrap()
+#elif defined(__GNUC__)
+#define BREAKPOINT __builtin_trap()
 #else
+#include <signal.h>
 #define BREAKPOINT raise(SIGTRAP)
 #endif
 


### PR DESCRIPTION
Fix breakpoints on macOS to trap EXC_BREAKPOINT with correct
source location when using lldb. Old behavior with `raise(SIGTRAP)`
traps SIGTRAP and incorrect source location.

Fix breakpoints on archlinux to trap SIGILL with correct source
location when using gdb. Old behavior with `raise(SIGTRAP)`
traps SIGTRAP and (sometimes) incorrect source location with
very shallow (break in main) stack.

when building stage1:
- w/ clang, use `__builtin_debugtrap()`
- w/ gcc, use `__builtin_trap()`
- else use `raise(SIGTRAP)`

<br/>

#### breakpoint on macOS before:
```
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGTRAP
  * frame #0: 0x00007fff6a83c7fa libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007fff6a8f9bc1 libsystem_pthread.dylib`pthread_kill + 432
    frame #2: 0x00007fff6a7533a2 libsystem_c.dylib`raise + 26
    frame #3: 0x0000000100001a2b zig0`main(argc=1, argv=0x00007ffeefbff978) at main.cpp:331:1
    frame #4: 0x00007fff6a6f57fd libdyld.dylib`start + 1
    frame #5: 0x00007fff6a6f57fd libdyld.dylib`start + 1
```

<br/>

#### breakpoint on macOS after:
```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BREAKPOINT (code=EXC_I386_BPT, subcode=0x0)
  * frame #0: 0x0000000100001a42 zig0`main(argc=1, argv=0x00007ffeefbff960) at main.cpp:337:18
    frame #1: 0x00007fff6a6f57fd libdyld.dylib`start + 1
```

<br/>

#### breakpoint on archlinux before:
```
#0  0x00007ffff7f837b5 in raise () from /usr/lib/libpthread.so.0
#1  0x00005555566a45aa in main (argc=1, argv=0x7fffffffea58) at ../src/main.cpp:331
```

<br/>

#### breakpoint on archlinux after:
```
#0  main (argc=1, argv=0x7fffffffea58) at ../src/main.cpp:331
```

<br/>

- tested on macOS 10.15.2 w/ Xcode 11.3 and lldb
- tested on archlinux w/ gcc 9.2 and gdb
