### PR TITLE
[docs] Add libc dependency to Sentinel-Terminated Pointers example

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2157,6 +2157,7 @@ test "allowzero" {
       against buffer overflow and overreads.
       </p>
       {#code_begin|exe_build_err#}
+      {#link_libc#}
 const std = @import("std");
 
 // This is also available as `std.c.printf`.


### PR DESCRIPTION
Fixes `dependency on library c must be explicitly specified in the build command` error