### PR TITLE
stage1: move local native_libc.txt to global

### DIFF
--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -11,7 +11,6 @@
 #include "buffer.hpp"
 #include "error.hpp"
 
-Buf *get_stage1_cache_path(void);
 Error get_compiler_id(Buf **result);
 Buf *get_self_dynamic_linker_path(void);
 Buf *get_self_libc_path(void);
@@ -19,5 +18,7 @@ Buf *get_self_libc_path(void);
 Buf *get_zig_lib_dir(void);
 Buf *get_zig_special_dir(Buf *zig_lib_dir);
 Buf *get_zig_std_dir(Buf *zig_lib_dir);
+
+Buf *get_global_cache_dir(void);
 
 #endif

--- a/src/glibc.cpp
+++ b/src/glibc.cpp
@@ -173,7 +173,7 @@ Error glibc_build_dummies_and_maps(CodeGen *g, const ZigGLibCAbi *glibc_abi, con
 {
     Error err;
 
-    Buf *cache_dir = get_stage1_cache_path();
+    Buf *cache_dir = get_global_cache_dir();
     CacheHash *cache_hash = allocate<CacheHash>(1);
     Buf *manifest_dir = buf_sprintf("%s" OS_SEP CACHE_HASH_SUBDIR, buf_ptr(cache_dir));
     cache_init(cache_hash, manifest_dir);

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -1962,7 +1962,7 @@ static const char *get_def_lib(CodeGen *parent, const char *name, Buf *def_in_fi
         exit(1);
     }
 
-    Buf *cache_dir = get_stage1_cache_path();
+    Buf *cache_dir = get_global_cache_dir();
     Buf *o_dir = buf_sprintf("%s" OS_SEP CACHE_OUT_SUBDIR, buf_ptr(cache_dir));
     Buf *manifest_dir = buf_sprintf("%s" OS_SEP CACHE_HASH_SUBDIR, buf_ptr(cache_dir));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1184,7 +1184,7 @@ int main(int argc, char **argv) {
             Buf *cache_dir_buf;
             if (cache_dir == nullptr) {
                 if (cmd == CmdRun) {
-                    cache_dir_buf = get_stage1_cache_path();
+                    cache_dir_buf = get_global_cache_dir();
                 } else {
                     cache_dir_buf = buf_create_from_str(default_zig_cache_name);
                 }

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -1748,7 +1748,7 @@ static void utf16le_ptr_to_utf8(Buf *out, WCHAR *utf16le) {
 #endif
 
 // Ported from std.os.getAppDataDir
-Error os_get_cache_dir(Buf *out_path, const char *appname) {
+Error os_get_app_data_dir(Buf *out_path, const char *appname) {
 #if defined(ZIG_OS_WINDOWS)
     WCHAR *dir_path_ptr;
     switch (SHGetKnownFolderPath(FOLDERID_LocalAppData, KF_FLAG_CREATE, nullptr, &dir_path_ptr)) {

--- a/src/os.hpp
+++ b/src/os.hpp
@@ -150,7 +150,7 @@ bool os_is_sep(uint8_t c);
 
 Error ATTRIBUTE_MUST_USE os_self_exe_path(Buf *out_path);
 
-Error ATTRIBUTE_MUST_USE os_get_cache_dir(Buf *out_path, const char *appname);
+Error ATTRIBUTE_MUST_USE os_get_app_data_dir(Buf *out_path, const char *appname);
 
 Error ATTRIBUTE_MUST_USE os_get_win32_ucrt_include_path(ZigWindowsSDK *sdk, Buf *output_buf);
 Error ATTRIBUTE_MUST_USE os_get_win32_ucrt_lib_path(ZigWindowsSDK *sdk, Buf *output_buf, ZigLLVM_ArchType platform_type);


### PR DESCRIPTION
Automatic creation of `native_libc.txt` now occurs only in global
cache. Manual creation/placement into local cache is supported.

closes #3975