### PR TITLE
cmake: do not needlessly build lld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,9 @@ option(ZIG_FORCE_EXTERNAL_LLD "If your system has the LLD patches use it instead
 
 find_package(llvm)
 find_package(clang)
+# This requires the header files too, which Ubuntu 19.04 does not have, but
+# Ubuntu 19.10 and Debian 10 and Fedora 29 have (install liblld-9-dev or lld-devel)
+find_package(lld)
 
 if(APPLE AND ZIG_STATIC)
     list(REMOVE_ITEM LLVM_LIBRARIES "-lz")
@@ -83,8 +86,7 @@ foreach(CONFIG_TYPE ${CMAKE_CONFIGURATION_TYPES})
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${CONFIG_TYPE} ${ZIG_CPP_LIB_DIR})
 endforeach(CONFIG_TYPE CMAKE_CONFIGURATION_TYPES)
 
-if(ZIG_FORCE_EXTERNAL_LLD)
-    find_package(lld)
+if(ZIG_FORCE_EXTERNAL_LLD OR LLD_INCLUDE_DIRS)
     include_directories(${LLVM_INCLUDE_DIRS})
     include_directories(${LLD_INCLUDE_DIRS})
     include_directories(${CLANG_INCLUDE_DIRS})

--- a/cmake/Findlld.cmake
+++ b/cmake/Findlld.cmake
@@ -8,6 +8,7 @@
 
 find_path(LLD_INCLUDE_DIRS NAMES lld/Common/Driver.h
     PATHS
+        /usr/lib/llvm-9/include
         /usr/lib/llvm-9.0/include
         /usr/local/llvm90/include
         /mingw64/include)
@@ -24,6 +25,7 @@ else()
         string(TOUPPER ${_libname_} _prettylibname_)
         find_library(LLD_${_prettylibname_}_LIB NAMES ${_libname_}
             PATHS
+                /usr/lib/llvm-9/lib
                 /usr/lib/llvm-9.0/lib
                 /usr/local/llvm90/lib
                 /mingw64/lib


### PR DESCRIPTION
As Debian/Ubuntu is now fixed and we have no upstream patches,
we should also consider removing lld completely from the tree.