### PR TITLE
cmake: support `make` and `make install`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ message("Configuring zig version ${ZIG_VERSION}")
 
 set(ZIG_STATIC off CACHE BOOL "Attempt to build a static zig executable (not compatible with glibc)")
 set(ZIG_STATIC_LLVM off CACHE BOOL "Prefer linking against static LLVM libraries")
-set(ZIG_SKIP_INSTALL_LIB_FILES off CACHE BOOL "Disable copying lib/ files to install prefix")
 set(ZIG_ENABLE_MEM_PROFILE off CACHE BOOL "Activate memory usage instrumentation")
 
 if(ZIG_STATIC)
@@ -608,19 +607,26 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 else()
     set(LIBUSERLAND_RELEASE_MODE "true")
 endif()
-if(ZIG_SKIP_INSTALL_LIB_FILES)
-    set(ZIG_BUILD_INSTALL_STEP "")
-else()
-    set(ZIG_BUILD_INSTALL_STEP "install")
-endif()
-add_custom_target(zig_build_libuserland ALL
-    COMMAND zig0 build
+
+set(BUILD_LIBUSERLAND_COMMAND zig0 build
         --override-lib-dir "${CMAKE_SOURCE_DIR}/lib"
-        libuserland ${ZIG_BUILD_INSTALL_STEP}
         "-Doutput-dir=${CMAKE_BINARY_DIR}"
         "-Drelease=${LIBUSERLAND_RELEASE_MODE}"
         "-Dlib-files-only"
         --prefix "${CMAKE_INSTALL_PREFIX}"
+        libuserland
+)
+
+# When using Visual Studio build system generator we default to libuserland install.
+if(MSVC)
+    set(ZIG_SKIP_INSTALL_LIB_FILES off CACHE BOOL "Disable copying lib/ files to install prefix")
+    if(NOT ZIG_SKIP_INSTALL_LIB_FILES)
+        set(BUILD_LIBUSERLAND_COMMAND ${BUILD_LIBUSERLAND_COMMAND} install)
+    endif()
+endif()
+
+add_custom_target(zig_build_libuserland ALL
+    COMMAND ${BUILD_LIBUSERLAND_COMMAND}
     DEPENDS zig0
     BYPRODUCTS "${LIBUSERLAND}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
@@ -638,4 +644,9 @@ elseif(MINGW)
   target_link_libraries(zig ntdll)
 endif()
 add_dependencies(zig zig_build_libuserland)
+
 install(TARGETS zig DESTINATION bin)
+
+# CODE has no effect with Visual Studio build system generator
+install(CODE "message(\"-- Installing: /opt/zig/lib\")")
+install(CODE "execute_process(COMMAND ${BUILD_LIBUSERLAND_COMMAND} install)")


### PR DESCRIPTION
- `make` or `ninja` will not build but not install
- `make install` or `ninja install` will build __and__ install

Only for build system generator Visual Studio, specify the following
to disable installation of lib files:

    ZIG_SKIP_INSTALL_LIB_FILES =ON

---

tested on:

- macOS 10.15.2 w/ Xcode 11.3
- archlinux w/ gcc 9.2.0
- Windows 10 w/ msvc v16.5.0-pre.1.0

<br/>

- [x] `make` skips install { `bin`, `lib` }
- [x] `make install` installs { `bin`, `lib` }
- [x] `make` followed by `make install` installs { `bin`, `lib` }
- [x]  delete random files from install dir, `make install` re-installs missing files

#### not defined: `ZIG_SKIP_INSTALL_LIB_FILES`
- [x] `msbuild ... INSTALL.vcxproj` installs { `bin`, `lib` }
- [x]  delete random files from install dir, `msbuild ... INSTALL.vcxproj` re-installs missing files

#### defined: `ZIG_SKIP_INSTALL_LIB_FILES=ON`
- [x] `msbuild ... INSTALL.vcxproj` installs `bin`, skips `lib`
