### PR TITLE
cmake: support `make` and `make install`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ message("Configuring zig version ${ZIG_VERSION}")
 
 set(ZIG_STATIC off CACHE BOOL "Attempt to build a static zig executable (not compatible with glibc)")
 set(ZIG_STATIC_LLVM off CACHE BOOL "Prefer linking against static LLVM libraries")
-set(ZIG_SKIP_INSTALL_LIB_FILES off CACHE BOOL "Disable copying lib/ files to install prefix")
 set(ZIG_ENABLE_MEM_PROFILE off CACHE BOOL "Activate memory usage instrumentation")
 
 if(ZIG_STATIC)
@@ -608,19 +607,26 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 else()
     set(LIBUSERLAND_RELEASE_MODE "true")
 endif()
-if(ZIG_SKIP_INSTALL_LIB_FILES)
-    set(ZIG_BUILD_INSTALL_STEP "")
-else()
-    set(ZIG_BUILD_INSTALL_STEP "install")
+
+set(BUILD_LIBUSERLAND_ARGS "build"
+    --override-lib-dir "${CMAKE_SOURCE_DIR}/lib"
+    "-Doutput-dir=${CMAKE_BINARY_DIR}"
+    "-Drelease=${LIBUSERLAND_RELEASE_MODE}"
+    "-Dlib-files-only"
+    --prefix "${CMAKE_INSTALL_PREFIX}"
+    libuserland
+)
+
+# When using Visual Studio build system generator we default to libuserland install.
+if(MSVC)
+    set(ZIG_SKIP_INSTALL_LIB_FILES off CACHE BOOL "Disable copying lib/ files to install prefix")
+    if(NOT ZIG_SKIP_INSTALL_LIB_FILES)
+        set(BUILD_LIBUSERLAND_ARGS ${BUILD_LIBUSERLAND_ARGS} install)
+    endif()
 endif()
+
 add_custom_target(zig_build_libuserland ALL
-    COMMAND zig0 build
-        --override-lib-dir "${CMAKE_SOURCE_DIR}/lib"
-        libuserland ${ZIG_BUILD_INSTALL_STEP}
-        "-Doutput-dir=${CMAKE_BINARY_DIR}"
-        "-Drelease=${LIBUSERLAND_RELEASE_MODE}"
-        "-Dlib-files-only"
-        --prefix "${CMAKE_INSTALL_PREFIX}"
+    COMMAND zig0 ${BUILD_LIBUSERLAND_ARGS}
     DEPENDS zig0
     BYPRODUCTS "${LIBUSERLAND}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
@@ -638,4 +644,15 @@ elseif(MINGW)
   target_link_libraries(zig ntdll)
 endif()
 add_dependencies(zig zig_build_libuserland)
+
 install(TARGETS zig DESTINATION bin)
+
+# CODE has no effect with Visual Studio build system generator.
+if(NOT MSVC)
+    get_target_property(zig0_BINARY_DIR zig0 BINARY_DIR)
+    install(CODE "set(zig0_EXE \"${zig0_BINARY_DIR}/zig0\")")
+    install(CODE "set(INSTALL_LIBUSERLAND_ARGS \"${BUILD_LIBUSERLAND_ARGS}\" install)")
+    install(CODE "set(BUILD_LIBUSERLAND_ARGS \"${BUILD_LIBUSERLAND_ARGS}\")")
+    install(CODE "set(CMAKE_SOURCE_DIR \"${CMAKE_SOURCE_DIR}\")")
+    install(SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/cmake/install.cmake)
+endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,23 +51,28 @@ knowledge of Zig internals.**
 
 ### Editing Source Code
 
-First, build the Stage 1 compiler as described in [the Building section](#building).
+First, build the Stage 1 compiler as described in [Building from Source](README.md#Building-from-Source).
 
-One modification you may want to make is adding `-DZIG_SKIP_INSTALL_LIB_FILES=ON`
-to the cmake line. If you use the build directory as a working directory to run
-tests with, zig will find the lib files in the source directory, and they will not
-be "installed" every time you run `make`. This will allow you to make modifications
-directly to the standard library, for example, and have them effective immediately.
-Note that if you already ran `make` or `make install` with the default cmake
-settings, there will already be a `lib/` directory in your build directory. When
-executed from the build directory, zig will find this instead of the source lib/
-directory. Remove the unwanted directory so that the desired one can be found.
+Zig locates lib files relative to executable path by searching up the
+filesystem tree for a sub-path of `lib/zig/std/std.zig` or `lib/std/std.zig`.
+Typically the former is an install and the latter a git working tree which
+contains the build directory.
+
+During development it is not necessary to perform installs when modifying
+stage1 or userland sources and in fact it is faster and simpler to run,
+test and debug from a git working tree.
+
+- `make` is typically sufficient to build zig during development iterations.
+- `make install` performs a build __and__ install.
+- `msbuild -p:Configuration=Release INSTALL.vcxproj` on Windows performs a
+build and install. To avoid install, pass cmake option `-DZIG_SKIP_INSTALL_LIB_FILES=ON`.
 
 To test changes, do the following from the build directory:
 
-1. Run `make install` (on POSIX) or
+1. Run `make` (on POSIX) or
    `msbuild -p:Configuration=Release INSTALL.vcxproj` (on Windows).
-2. `bin/zig build test` (on POSIX) or `bin\zig.exe build test` (on Windows).
+2. `$BUILD_DIR/zig build test` (on POSIX) or
+   `$BUILD_DIR/Release\zig.exe build test` (on Windows).
 
 That runs the whole test suite, which does a lot of extra testing that you
 likely won't always need, and can take upwards of 1 hour. This is what the
@@ -85,8 +90,8 @@ Another example is choosing a different set of things to test. For example,
 not the other ones. Combining this suggestion with the previous one, you could
 do this:
 
-`bin/zig build test-std -Dskip-release` (on POSIX) or
-`bin\zig.exe build test-std -Dskip-release` (on Windows).
+`$BUILD_DIR/bin/zig build test-std -Dskip-release` (on POSIX) or
+`$BUILD_DIR/Release\zig.exe build test-std -Dskip-release` (on Windows).
 
 This will run only the standard library tests, in debug mode only, for all
 targets (it will cross-compile the tests for non-native targets but not run

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,0 +1,37 @@
+message("-- Installing: ${CMAKE_INSTALL_PREFIX}/lib")
+
+if(NOT EXISTS ${zig0_EXE})
+    message("::")
+    message(":: ERROR: Executable not found")
+    message(":: (execute_process)")
+    message("::")
+    message(":: executable: ${zig0_EXE}")
+    message("::")
+    message(FATAL_ERROR)
+endif()
+
+execute_process(COMMAND ${zig0_EXE} ${INSTALL_LIBUSERLAND_ARGS}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    RESULT_VARIABLE _result
+)
+if(_result)
+    message("::")
+    message(":: ERROR: ${_result}")
+    message(":: (execute_process)")
+
+    string(REPLACE ";" " " s_INSTALL_LIBUSERLAND_ARGS "${INSTALL_LIBUSERLAND_ARGS}")
+    message("::")
+    message(":: argv: ${zig0_EXE} ${s_INSTALL_LIBUSERLAND_ARGS} install")
+
+    set(_args ${zig0_EXE} ${INSTALL_LIBUSERLAND_ARGS})
+    list(LENGTH _args _len)
+    math(EXPR _len "${_len} - 1")
+    message("::")
+    foreach(_i RANGE 0 ${_len})
+        list(GET _args ${_i} _arg)
+        message(":: argv[${_i}]: ${_arg}")
+    endforeach()
+
+    message("::")
+    message(FATAL_ERROR)
+endif()


### PR DESCRIPTION
(2nd attempt to get this right)

Reproduced the issue of linux/static builds in docker. The cause was two-fold:

1. my local environment has `.` in `$PATH` and removing that I was able to get the same failure
2. by invoking cmake `execute_process` via `install(CODE...)` there is really no decent chance to get an error code of the child process and we had no report when `zig0` was not found in path

The solution is:

1. force the script to use an absolute pathname to `zig0`
2. switch from `install(CODE...)` to `install(SCRIPT...)` and have the sub-script check for child process exit status explicitly. And some nice error messages should help avoid a repeat.

(the child process in question here was `zig0 build libuserland install ....`)

---

tested with stripped down `PATH` environment variable:

- macOS 10.15.2 w/ Xcode 11.3.1
- archlinux w/ gcc 9.2.0
- Windows 10 w/ msvc v16.5.0-pre.1.0

<br/>

- [x] `make` skips install { `bin`, `lib` }
- [x] `make install` installs { `bin`, `lib` }
- [x] `make` followed by `make install` installs { `bin`, `lib` }
- [x]  delete random files from install dir, `make install` re-installs missing files

#### not defined: `ZIG_SKIP_INSTALL_LIB_FILES`
- [x] `msbuild ... INSTALL.vcxproj` installs { `bin`, `lib` }
- [x]  delete random files from install dir, `msbuild ... INSTALL.vcxproj` re-installs missing files

#### defined: `ZIG_SKIP_INSTALL_LIB_FILES=ON`
- [x] `msbuild ... INSTALL.vcxproj` installs `bin`, skips `lib`