### PR TITLE
std: turn EAI_ constants into a non-exhaustive enum

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -185,7 +185,7 @@ pub extern "c" fn getaddrinfo(
     noalias service: [*:0]const u8,
     noalias hints: *const addrinfo,
     noalias res: **addrinfo,
-) c_int;
+) EAI;
 
 pub extern "c" fn freeaddrinfo(res: *addrinfo) void;
 
@@ -197,9 +197,9 @@ pub extern "c" fn getnameinfo(
     noalias serv: [*]u8,
     servlen: socklen_t,
     flags: u32,
-) c_int;
+) EAI;
 
-pub extern "c" fn gai_strerror(errcode: c_int) [*:0]const u8;
+pub extern "c" fn gai_strerror(errcode: EAI) [*:0]const u8;
 
 pub extern "c" fn poll(fds: [*]pollfd, nfds: nfds_t, timeout: c_int) c_int;
 

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -70,47 +70,52 @@ pub const AI_NUMERICHOST = 0x00000004;
 /// prevent service name resolution
 pub const AI_NUMERICSERV = 0x00001000;
 
-///  address family for hostname not supported
-pub const EAI_ADDRFAMILY = 1;
+pub const EAI = extern enum(c_int) {
+    /// address family for hostname not supported
+    ADDRFAMILY = 1,
 
-/// temporary failure in name resolution
-pub const EAI_AGAIN = 2;
+    /// temporary failure in name resolution
+    AGAIN = 2,
 
-/// invalid value for ai_flags
-pub const EAI_BADFLAGS = 3;
+    /// invalid value for ai_flags
+    BADFLAGS = 3,
 
-/// non-recoverable failure in name resolution
-pub const EAI_FAIL = 4;
+    /// non-recoverable failure in name resolution
+    FAIL = 4,
 
-/// ai_family not supported
-pub const EAI_FAMILY = 5;
+    /// ai_family not supported
+    FAMILY = 5,
 
-/// memory allocation failure
-pub const EAI_MEMORY = 6;
+    /// memory allocation failure
+    MEMORY = 6,
 
-/// no address associated with hostname
-pub const EAI_NODATA = 7;
+    /// no address associated with hostname
+    NODATA = 7,
 
-/// hostname nor servname provided, or not known
-pub const EAI_NONAME = 8;
+    /// hostname nor servname provided, or not known
+    NONAME = 8,
 
-/// servname not supported for ai_socktype
-pub const EAI_SERVICE = 9;
+    /// servname not supported for ai_socktype
+    SERVICE = 9,
 
-/// ai_socktype not supported
-pub const EAI_SOCKTYPE = 10;
+    /// ai_socktype not supported
+    SOCKTYPE = 10,
 
-/// system error returned in errno
-pub const EAI_SYSTEM = 11;
+    /// system error returned in errno
+    SYSTEM = 11,
 
-/// invalid value for hints
-pub const EAI_BADHINTS = 12;
+    /// invalid value for hints
+    BADHINTS = 12,
 
-/// resolved protocol is unknown
-pub const EAI_PROTOCOL = 13;
+    /// resolved protocol is unknown
+    PROTOCOL = 13,
 
-/// argument buffer overflow
-pub const EAI_OVERFLOW = 14;
+    /// argument buffer overflow
+    OVERFLOW = 14,
+
+    _,
+};
+
 pub const EAI_MAX = 15;
 
 pub const pthread_mutex_t = extern struct {

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -23,47 +23,51 @@ pub const pthread_attr_t = extern struct {
     __align: c_long,
 };
 
-/// address family for hostname not supported
-pub const EAI_ADDRFAMILY = 1;
+pub const EAI = extern enum(c_int) {
+    /// address family for hostname not supported
+    ADDRFAMILY = 1,
 
-/// name could not be resolved at this time
-pub const EAI_AGAIN = 2;
+    /// name could not be resolved at this time
+    AGAIN = 2,
 
-/// flags parameter had an invalid value
-pub const EAI_BADFLAGS = 3;
+    /// flags parameter had an invalid value
+    BADFLAGS = 3,
 
-/// non-recoverable failure in name resolution
-pub const EAI_FAIL = 4;
+    /// non-recoverable failure in name resolution
+    FAIL = 4,
 
-/// address family not recognized
-pub const EAI_FAMILY = 5;
+    /// address family not recognized
+    FAMILY = 5,
 
-/// memory allocation failure
-pub const EAI_MEMORY = 6;
+    /// memory allocation failure
+    MEMORY = 6,
 
-/// no address associated with hostname
-pub const EAI_NODATA = 7;
+    /// no address associated with hostname
+    NODATA = 7,
 
-/// name does not resolve
-pub const EAI_NONAME = 8;
+    /// name does not resolve
+    NONAME = 8,
 
-/// service not recognized for socket type
-pub const EAI_SERVICE = 9;
+    /// service not recognized for socket type
+    SERVICE = 9,
 
-/// intended socket type was not recognized
-pub const EAI_SOCKTYPE = 10;
+    /// intended socket type was not recognized
+    SOCKTYPE = 10,
 
-/// system error returned in errno
-pub const EAI_SYSTEM = 11;
+    /// system error returned in errno
+    SYSTEM = 11,
 
-/// invalid value for hints
-pub const EAI_BADHINTS = 12;
+    /// invalid value for hints
+    BADHINTS = 12,
 
-/// resolved protocol is unknown
-pub const EAI_PROTOCOL = 13;
+    /// resolved protocol is unknown
+    PROTOCOL = 13,
 
-/// argument buffer overflow
-pub const EAI_OVERFLOW = 14;
+    /// argument buffer overflow
+    OVERFLOW = 14,
+
+    _,
+};
 
 pub const EAI_MAX = 15;
 

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -32,25 +32,29 @@ pub const NI_NAMEREQD = 0x08;
 pub const NI_DGRAM = 0x10;
 pub const NI_NUMERICSCOPE = 0x100;
 
-pub const EAI_BADFLAGS = -1;
-pub const EAI_NONAME = -2;
-pub const EAI_AGAIN = -3;
-pub const EAI_FAIL = -4;
-pub const EAI_FAMILY = -6;
-pub const EAI_SOCKTYPE = -7;
-pub const EAI_SERVICE = -8;
-pub const EAI_MEMORY = -10;
-pub const EAI_SYSTEM = -11;
-pub const EAI_OVERFLOW = -12;
+pub const EAI = extern enum(c_int) {
+    BADFLAGS = -1,
+    NONAME = -2,
+    AGAIN = -3,
+    FAIL = -4,
+    FAMILY = -6,
+    SOCKTYPE = -7,
+    SERVICE = -8,
+    MEMORY = -10,
+    SYSTEM = -11,
+    OVERFLOW = -12,
 
-pub const EAI_NODATA = -5;
-pub const EAI_ADDRFAMILY = -9;
-pub const EAI_INPROGRESS = -100;
-pub const EAI_CANCELED = -101;
-pub const EAI_NOTCANCELED = -102;
-pub const EAI_ALLDONE = -103;
-pub const EAI_INTR = -104;
-pub const EAI_IDN_ENCODE = -105;
+    NODATA = -5,
+    ADDRFAMILY = -9,
+    INPROGRESS = -100,
+    CANCELED = -101,
+    NOTCANCELED = -102,
+    ALLDONE = -103,
+    INTR = -104,
+    IDN_ENCODE = -105,
+
+    _,
+};
 
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;
 pub extern "c" fn sched_getaffinity(pid: c_int, size: usize, set: *cpu_set_t) c_int;

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -452,18 +452,18 @@ pub fn getAddressList(allocator: *mem.Allocator, name: []const u8, port: u16) !*
         };
         var res: *os.addrinfo = undefined;
         switch (os.system.getaddrinfo(name_c.ptr, @ptrCast([*:0]const u8, port_c.ptr), &hints, &res)) {
-            0 => {},
-            c.EAI_ADDRFAMILY => return error.HostLacksNetworkAddresses,
-            c.EAI_AGAIN => return error.TemporaryNameServerFailure,
-            c.EAI_BADFLAGS => unreachable, // Invalid hints
-            c.EAI_FAIL => return error.NameServerFailure,
-            c.EAI_FAMILY => return error.AddressFamilyNotSupported,
-            c.EAI_MEMORY => return error.OutOfMemory,
-            c.EAI_NODATA => return error.HostLacksNetworkAddresses,
-            c.EAI_NONAME => return error.UnknownHostName,
-            c.EAI_SERVICE => return error.ServiceUnavailable,
-            c.EAI_SOCKTYPE => unreachable, // Invalid socket type requested in hints
-            c.EAI_SYSTEM => switch (os.errno(-1)) {
+            @intToEnum(os.system.EAI, 0) => {},
+            .ADDRFAMILY => return error.HostLacksNetworkAddresses,
+            .AGAIN => return error.TemporaryNameServerFailure,
+            .BADFLAGS => unreachable, // Invalid hints
+            .FAIL => return error.NameServerFailure,
+            .FAMILY => return error.AddressFamilyNotSupported,
+            .MEMORY => return error.OutOfMemory,
+            .NODATA => return error.HostLacksNetworkAddresses,
+            .NONAME => return error.UnknownHostName,
+            .SERVICE => return error.ServiceUnavailable,
+            .SOCKTYPE => unreachable, // Invalid socket type requested in hints
+            .SYSTEM => switch (os.errno(-1)) {
                 else => |e| return os.unexpectedErrno(e),
             },
             else => unreachable,


### PR DESCRIPTION
A proof of concept: would like to get agreement that this is the direction we want to go.
If merged I will follow up with a PR that does it for other things in the standard library.  