### PR TITLE
adds to std.build.RunStep a repeatedly-asked-for helper/utility method: RunStep.addAllCurrentArgsFollowing("--")

### DIFF
--- a/lib/std/build/run.zig
+++ b/lib/std/build/run.zig
@@ -299,4 +299,21 @@ pub const RunStep = struct {
             }
         }
     }
+
+    /// Goes through all current process args and `addArg`s those that follow the
+    /// first occurrence of `marker_arg` (by convention, typically "--"), if any.
+    fn addAllCurrentArgsFollowing(self: *RunStep, marker_arg: []const u8) void {
+        var args = process.args(); // we iterate all current args...
+        var should_add = false; // `true`d upon the first `marker_arg`
+
+        while (args.next(self.builder.allocator)) |arg_or_err| {
+            const arg = arg_or_err catch unreachable;
+            defer self.builder.allocator.free(arg);
+            if (should_add) {
+                self.addArg(arg); // addArg already `mem.dupe`s
+            } else {
+                should_add = mem.eql(u8, arg, marker_arg);
+            }
+        }
+    }
 };


### PR DESCRIPTION
Newcomers occasionally get quickly used to `zig run my.zig -- arg1 arg2 arg3` (utilizing that very common pattern of `--` pass-through args) and then later wonder "why `zig build run` doesn't allow the same, that's inconsistent" and in any event a mild surprise event, triggering the common question.

Doubtlessly in many custom `build.zig`s around, such logic is then hand-coded time and again.

The proposal of this PR is a helper method for `RunStep`, whose call site looks immediately self-explanatory to the reader of a project's custom `build.zig`: 

```zig
    const run_cmd = prog_atem.run();
    run_cmd.addAllCurrentArgsFollowing("--");
```

Bit of a wordy name but there's all kinds of various "arg" usages around the whole Builder complex so I figured the name should explicate what sorts of args are meant: those passed to the _current_ `zig build` process.

This PR doesn't touch the "default build.zig template" that `zig init-exe` creates.. but as a suggestion, I believe it would be most helpful and least disruptive to include-the-call-but-commented-out.