### PR TITLE
Refactor some debug stuff

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -379,16 +379,7 @@ fn printSourceAtAddressWindows(di: *DebugInfo, out_stream: var, relocated_addres
         }
     } else {
         // we have no information to add to the address
-        if (tty_color) {
-            try out_stream.print("???:?:?: ", .{});
-            setTtyColor(TtyColor.Dim);
-            try out_stream.print("0x{x} in ??? (???)", .{relocated_address});
-            setTtyColor(TtyColor.Reset);
-            try out_stream.print("\n\n\n", .{});
-        } else {
-            try out_stream.print("???:?:?: 0x{x} in ??? (???)\n\n\n", .{relocated_address});
-        }
-        return;
+        return printLineInfo(out_stream, null, relocated_address, "???", "???", tty_color, printLineFromFileAnyOs);
     };
 
     const mod = &di.modules[mod_index];
@@ -510,66 +501,15 @@ fn printSourceAtAddressWindows(di: *DebugInfo, out_stream: var, relocated_addres
         }
     };
 
-    if (tty_color) {
-        setTtyColor(TtyColor.White);
-        if (opt_line_info) |li| {
-            try out_stream.print("{}:{}:{}", .{ li.file_name, li.line, li.column });
-        } else {
-            try out_stream.print("???:?:?", .{});
-        }
-        setTtyColor(TtyColor.Reset);
-        try out_stream.print(": ", .{});
-        setTtyColor(TtyColor.Dim);
-        try out_stream.print("0x{x} in {} ({})", .{ relocated_address, symbol_name, obj_basename });
-        setTtyColor(TtyColor.Reset);
-
-        if (opt_line_info) |line_info| {
-            try out_stream.print("\n", .{});
-            if (printLineFromFileAnyOs(out_stream, line_info)) {
-                if (line_info.column == 0) {
-                    try out_stream.write("\n");
-                } else {
-                    {
-                        var col_i: usize = 1;
-                        while (col_i < line_info.column) : (col_i += 1) {
-                            try out_stream.writeByte(' ');
-                        }
-                    }
-                    setTtyColor(TtyColor.Green);
-                    try out_stream.write("^");
-                    setTtyColor(TtyColor.Reset);
-                    try out_stream.write("\n");
-                }
-            } else |err| switch (err) {
-                error.EndOfFile => {},
-                error.FileNotFound => {
-                    setTtyColor(TtyColor.Dim);
-                    try out_stream.write("file not found\n\n");
-                    setTtyColor(TtyColor.White);
-                },
-                else => return err,
-            }
-        } else {
-            try out_stream.print("\n\n\n", .{});
-        }
-    } else {
-        if (opt_line_info) |li| {
-            try out_stream.print("{}:{}:{}: 0x{x} in {} ({})\n\n\n", .{
-                li.file_name,
-                li.line,
-                li.column,
-                relocated_address,
-                symbol_name,
-                obj_basename,
-            });
-        } else {
-            try out_stream.print("???:?:?: 0x{x} in {} ({})\n\n\n", .{
-                relocated_address,
-                symbol_name,
-                obj_basename,
-            });
-        }
-    }
+    try printLineInfo(
+        out_stream,
+        opt_line_info,
+        relocated_address,
+        symbol_name,
+        obj_basename,
+        tty_color,
+        printLineFromFileAnyOs,
+    );
 }
 
 const TtyColor = enum {
@@ -605,7 +545,11 @@ fn setTtyColor(tty_color: TtyColor) void {
                 stderr_file.write(RESET) catch return;
             },
         }
-    } else {
+
+        return;
+    }
+
+    if (builtin.os == .windows) {
         const S = struct {
             var attrs: windows.WORD = undefined;
             var init_attrs = false;
@@ -711,12 +655,7 @@ fn printSourceAtAddressMacOs(di: *DebugInfo, out_stream: var, address: usize, tt
     const adjusted_addr = 0x100000000 + (address - base_addr);
 
     const symbol = machoSearchSymbols(di.symbols, adjusted_addr) orelse {
-        if (tty_color) {
-            try out_stream.print("???:?:?: " ++ DIM ++ "0x{x} in ??? (???)" ++ RESET ++ "\n\n\n", .{address});
-        } else {
-            try out_stream.print("???:?:?: 0x{x} in ??? (???)\n\n\n", .{address});
-        }
-        return;
+        return printLineInfo(out_stream, null, address, "???", "???", tty_color, printLineFromFileAnyOs);
     };
 
     const symbol_name = mem.toSliceConst(u8, @ptrCast([*:0]const u8, di.strings.ptr + symbol.nlist.n_strx));
@@ -724,29 +663,22 @@ fn printSourceAtAddressMacOs(di: *DebugInfo, out_stream: var, address: usize, tt
         const ofile_path = mem.toSliceConst(u8, @ptrCast([*:0]const u8, di.strings.ptr + ofile.n_strx));
         break :blk fs.path.basename(ofile_path);
     } else "???";
-    if (getLineNumberInfoMacOs(di, symbol.*, adjusted_addr)) |line_info| {
-        defer line_info.deinit();
-        try printLineInfo(
-            out_stream,
-            line_info,
-            address,
-            symbol_name,
-            compile_unit_name,
-            tty_color,
-            printLineFromFileAnyOs,
-        );
-    } else |err| switch (err) {
-        error.MissingDebugInfo, error.InvalidDebugInfo => {
-            if (tty_color) {
-                try out_stream.print("???:?:?: " ++ DIM ++ "0x{x} in {} ({})" ++ RESET ++ "\n\n\n", .{
-                    address, symbol_name, compile_unit_name,
-                });
-            } else {
-                try out_stream.print("???:?:?: 0x{x} in {} ({})\n\n\n", .{ address, symbol_name, compile_unit_name });
-            }
-        },
+
+    const line_info = getLineNumberInfoMacOs(di, symbol.*, adjusted_addr) catch |err| switch (err) {
+        error.MissingDebugInfo, error.InvalidDebugInfo => null,
         else => return err,
-    }
+    };
+    defer if (line_info) |li| li.deinit();
+
+    try printLineInfo(
+        out_stream,
+        line_info,
+        address,
+        symbol_name,
+        compile_unit_name,
+        tty_color,
+        printLineFromFileAnyOs,
+    );
 }
 
 pub fn printSourceAtAddressPosix(debug_info: *DebugInfo, out_stream: var, address: usize, tty_color: bool) !void {
@@ -755,47 +687,46 @@ pub fn printSourceAtAddressPosix(debug_info: *DebugInfo, out_stream: var, addres
 
 fn printLineInfo(
     out_stream: var,
-    line_info: LineInfo,
+    line_info: ?LineInfo,
     address: usize,
     symbol_name: []const u8,
     compile_unit_name: []const u8,
     tty_color: bool,
     comptime printLineFromFile: var,
 ) !void {
-    if (tty_color) {
-        try out_stream.print(WHITE ++ "{}:{}:{}" ++ RESET ++ ": " ++ DIM ++ "0x{x} in {} ({})" ++ RESET ++ "\n", .{
-            line_info.file_name,
-            line_info.line,
-            line_info.column,
-            address,
-            symbol_name,
-            compile_unit_name,
-        });
-        if (printLineFromFile(out_stream, line_info)) {
-            if (line_info.column == 0) {
-                try out_stream.write("\n");
-            } else {
-                {
-                    var col_i: usize = 1;
-                    while (col_i < line_info.column) : (col_i += 1) {
-                        try out_stream.writeByte(' ');
-                    }
-                }
-                try out_stream.write(GREEN ++ "^" ++ RESET ++ "\n");
+    if (tty_color) setTtyColor(.White);
+
+    if (line_info) |*li| {
+        try out_stream.print("{}:{}:{}", .{ li.file_name, li.line, li.column });
+    } else {
+        try out_stream.print("???:?:?", .{});
+    }
+
+    if (tty_color) setTtyColor(.Reset);
+    try out_stream.write(": ");
+    if (tty_color) setTtyColor(.Dim);
+    try out_stream.print("0x{x} in {} ({})", .{ address, symbol_name, compile_unit_name });
+    if (tty_color) setTtyColor(.Reset);
+    try out_stream.write("\n");
+
+    // Show the matching source code line if possible
+    if (line_info) |li| {
+        if (printLineFromFile(out_stream, li)) {
+            if (li.column > 0) {
+                // The caret already takes one char
+                const space_needed = @intCast(usize, li.column - 1);
+
+                try out_stream.writeByteNTimes(' ', space_needed);
+                if (tty_color) setTtyColor(.Green);
+                try out_stream.write("^");
+                if (tty_color) setTtyColor(.Reset);
             }
+            try out_stream.write("\n");
         } else |err| switch (err) {
             error.EndOfFile, error.FileNotFound => {},
+            error.BadPathName => {},
             else => return err,
         }
-    } else {
-        try out_stream.print("{}:{}:{}: 0x{x} in {} ({})\n", .{
-            line_info.file_name,
-            line_info.line,
-            line_info.column,
-            address,
-            symbol_name,
-            compile_unit_name,
-        });
     }
 }
 
@@ -1240,38 +1171,26 @@ pub const DwarfInfo = struct {
         comptime printLineFromFile: var,
     ) !void {
         const compile_unit = self.findCompileUnit(address) catch {
-            if (tty_color) {
-                try out_stream.print("???:?:?: " ++ DIM ++ "0x{x} in ??? (???)" ++ RESET ++ "\n\n\n", .{address});
-            } else {
-                try out_stream.print("???:?:?: 0x{x} in ??? (???)\n\n\n", .{address});
-            }
-            return;
+            return printLineInfo(out_stream, null, address, "???", "???", tty_color, printLineFromFile);
         };
+
         const compile_unit_name = try compile_unit.die.getAttrString(self, DW.AT_name);
-        if (self.getLineNumberInfo(compile_unit.*, address)) |line_info| {
-            defer line_info.deinit();
-            const symbol_name = self.getSymbolName(address) orelse "???";
-            try printLineInfo(
-                out_stream,
-                line_info,
-                address,
-                symbol_name,
-                compile_unit_name,
-                tty_color,
-                printLineFromFile,
-            );
-        } else |err| switch (err) {
-            error.MissingDebugInfo, error.InvalidDebugInfo => {
-                if (tty_color) {
-                    try out_stream.print("???:?:?: " ++ DIM ++ "0x{x} in ??? ({})" ++ RESET ++ "\n\n\n", .{
-                        address, compile_unit_name,
-                    });
-                } else {
-                    try out_stream.print("???:?:?: 0x{x} in ??? ({})\n\n\n", .{ address, compile_unit_name });
-                }
-            },
+        const symbol_name = self.getSymbolName(address) orelse "???";
+        const line_info = self.getLineNumberInfo(compile_unit.*, address) catch |err| switch (err) {
+            error.MissingDebugInfo, error.InvalidDebugInfo => null,
             else => return err,
-        }
+        };
+        defer if (line_info) |li| li.deinit();
+
+        try printLineInfo(
+            out_stream,
+            line_info,
+            address,
+            symbol_name,
+            compile_unit_name,
+            tty_color,
+            printLineFromFile,
+        );
     }
 
     fn getSymbolName(di: *DwarfInfo, address: u64) ?[]const u8 {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -711,7 +711,7 @@ fn printLineInfo(
 
     // Show the matching source code line if possible
     if (line_info) |li| {
-        if (printLineFromFile(out_stream, li)) {
+        if (noasync printLineFromFile(out_stream, li)) {
             if (li.column > 0) {
                 // The caret already takes one char
                 const space_needed = @intCast(usize, li.column - 1);

--- a/lib/std/io/out_stream.zig
+++ b/lib/std/io/out_stream.zig
@@ -45,10 +45,14 @@ pub fn OutStream(comptime WriteError: type) type {
         }
 
         pub fn writeByteNTimes(self: *Self, byte: u8, n: usize) Error!void {
-            const slice = @as(*const [1]u8, &byte)[0..];
-            var i: usize = 0;
-            while (i < n) : (i += 1) {
-                try self.writeFn(self, slice);
+            var bytes: [256]u8 = undefined;
+            mem.set(u8, bytes[0..], byte);
+
+            var remaining: usize = n;
+            while (remaining > 0) {
+                const to_write = std.math.min(remaining, bytes.len);
+                try self.writeFn(self, bytes[0..to_write]);
+                remaining -= to_write;
             }
         }
 

--- a/test/stack_traces.zig
+++ b/test/stack_traces.zig
@@ -51,11 +51,15 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in main (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\
                 ,
                 // release-safe
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.main (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\
                 ,
                 // release-fast
@@ -74,13 +78,21 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in foo (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in main (test)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-safe
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.main (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in std.start.main (test)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-fast
@@ -99,17 +111,33 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                     \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in make_error (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in bar (test)
+                    \\    return make_error();
+                    \\    ^
                     \\source.zig:4:5: [address] in foo (test)
+                    \\    try bar();
+                    \\    ^
                     \\source.zig:16:5: [address] in main (test)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-safe
                     \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in std.start.main (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in std.start.main (test)
+                    \\    return make_error();
+                    \\    ^
                     \\source.zig:4:5: [address] in std.start.main (test)
+                    \\    try bar();
+                    \\    ^
                     \\source.zig:16:5: [address] in std.start.main (test)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-fast
@@ -130,11 +158,15 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in main (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\
                 ,
                 // release-safe
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.posixCallMainAndExit (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\
                 ,
                 // release-fast
@@ -153,13 +185,21 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in foo (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in main (test)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-safe
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.posixCallMainAndExit (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in std.start.posixCallMainAndExit (test)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-fast
@@ -178,17 +218,33 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                     \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in make_error (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in bar (test)
+                    \\    return make_error();
+                    \\    ^
                     \\source.zig:4:5: [address] in foo (test)
+                    \\    try bar();
+                    \\    ^
                     \\source.zig:16:5: [address] in main (test)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-safe
                     \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in std.start.posixCallMainAndExit (test)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in std.start.posixCallMainAndExit (test)
+                    \\    return make_error();
+                    \\    ^
                     \\source.zig:4:5: [address] in std.start.posixCallMainAndExit (test)
+                    \\    try bar();
+                    \\    ^
                     \\source.zig:16:5: [address] in std.start.posixCallMainAndExit (test)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-fast
@@ -209,11 +265,15 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in _main.0 (test.o)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\
                 ,
                 // release-safe
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in _main (test.o)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\
                 ,
                 // release-fast
@@ -232,13 +292,21 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in _foo (test.o)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in _main.0 (test.o)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-safe
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in _main (test.o)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in _main (test.o)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-fast
@@ -257,17 +325,33 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                     \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in _make_error (test.o)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in _bar (test.o)
+                    \\    return make_error();
+                    \\    ^
                     \\source.zig:4:5: [address] in _foo (test.o)
+                    \\    try bar();
+                    \\    ^
                     \\source.zig:16:5: [address] in _main.0 (test.o)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-safe
                     \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in _main (test.o)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in _main (test.o)
+                    \\    return make_error();
+                    \\    ^
                     \\source.zig:4:5: [address] in _main (test.o)
+                    \\    try bar();
+                    \\    ^
                     \\source.zig:16:5: [address] in _main (test.o)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-fast
@@ -288,6 +372,8 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                     \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in main (test.obj)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\
                 ,
                 // release-safe
@@ -309,7 +395,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                 \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in foo (test.obj)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in main (test.obj)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-safe
@@ -331,9 +421,17 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // debug
                 \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in make_error (test.obj)
+                    \\    return error.TheSkyIsFalling;
+                    \\    ^
                     \\source.zig:8:5: [address] in bar (test.obj)
+                    \\    return make_error();
+                    \\    ^
                     \\source.zig:4:5: [address] in foo (test.obj)
+                    \\    try bar();
+                    \\    ^
                     \\source.zig:16:5: [address] in main (test.obj)
+                    \\    try foo();
+                    \\    ^
                     \\
                 ,
                 // release-safe


### PR DESCRIPTION
Reboot of #3080 with a twist

* Factor out some repetitive code here and there
* Try to always print as much info as possible
* Always show the offending line of code no matter if the color is enabled or not (that was weird)
* Handle `BadPathName` (exes compiled on linux retain the native paths in the pdb) gracefully. This means you can now have error traces for windows binaries run on wine.
* Don't print the empty lines when there's no source code to show, this is a bit of a personal preference (but also makes the code simpler ;) )