### PR TITLE
Add support for code model selection

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1149,6 +1149,7 @@ pub const LibExeObjStep = struct {
     name_prefix: []const u8,
     filter: ?[]const u8,
     single_threaded: bool,
+    code_model: builtin.CodeModel = .default,
 
     root_src: ?FileSource,
     out_h_filename: []const u8,
@@ -1968,6 +1969,11 @@ pub const LibExeObjStep = struct {
         }
         if (self.disable_sanitize_c) {
             try zig_args.append("-fno-sanitize-c");
+        }
+
+        if (self.code_model != .default) {
+            try zig_args.append("-code-model");
+            try zig_args.append(@tagName(self.code_model));
         }
 
         switch (self.target) {

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -91,6 +91,21 @@ pub const AtomicRmwOp = enum {
     Min,
 };
 
+/// The code model puts constraints on the location of symbols and the size of code and data.
+/// The selection of a code model is a trade off on speed and restrictions that needs to be selected on a per application basis to meet its requirements.
+/// A slightly more detailed explanation can be found in (for example) the [System V Application Binary Interface (x86_64)](https://github.com/hjl-tools/x86-psABI/wiki/x86-64-psABI-1.0.pdf) 3.5.1.
+///
+/// This data structure is used by the Zig language code generation and
+/// therefore must be kept in sync with the compiler implementation.
+pub const CodeModel = enum {
+    default,
+    tiny,
+    small,
+    kernel,
+    medium,
+    large,
+};
+
 /// This data structure is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
 pub const Mode = enum {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1947,6 +1947,15 @@ enum BuildMode {
     BuildModeSmallRelease,
 };
 
+enum CodeModel {
+    CodeModelDefault,
+    CodeModelTiny,
+    CodeModelSmall,
+    CodeModelKernel,
+    CodeModelMedium,
+    CodeModelLarge,
+};
+
 enum EmitFileType {
     EmitFileTypeBinary,
     EmitFileTypeAssembly,
@@ -2235,6 +2244,7 @@ struct CodeGen {
     bool enable_dump_analysis;
     bool enable_doc_generation;
     bool disable_bin_generation;
+    CodeModel code_model;
 
     Buf *mmacosx_version_min;
     Buf *mios_version_min;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,6 +103,9 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  -D[macro]=[value]            define C [macro] to [value] (1 if [value] omitted)\n"
         "  -target-cpu [cpu]            target one specific CPU by name\n"
         "  -target-feature [features]   specify the set of CPU features to target\n"
+        "  -code-model [default|tiny|   set target code model\n"
+        "               small|kernel|\n"
+        "               medium|large]\n"
         "\n"
         "Link Options:\n"
         "  --bundle-compiler-rt         for static libraries, include compiler-rt symbols\n"
@@ -452,6 +455,7 @@ int main(int argc, char **argv) {
     bool function_sections = false;
     const char *cpu = nullptr;
     const char *features = nullptr;
+    CodeModel code_model = CodeModelDefault;
 
     ZigList<const char *> llvm_argv = {0};
     llvm_argv.append("zig (LLVM option parsing)");
@@ -768,6 +772,23 @@ int main(int argc, char **argv) {
                     clang_argv.append(argv[i]);
 
                     llvm_argv.append(argv[i]);
+                } else if (strcmp(arg, "-code-model") == 0) {
+                    if (strcmp(argv[i], "default") == 0) {
+                        code_model = CodeModelDefault;
+                    } else if (strcmp(argv[i], "tiny") == 0) {
+                        code_model = CodeModelTiny;
+                    } else if (strcmp(argv[i], "small") == 0) {
+                        code_model = CodeModelSmall;
+                    } else if (strcmp(argv[i], "kernel") == 0) {
+                        code_model = CodeModelKernel;
+                    } else if (strcmp(argv[i], "medium") == 0) {
+                        code_model = CodeModelMedium;
+                    } else if (strcmp(argv[i], "large") == 0) {
+                        code_model = CodeModelLarge;
+                    } else {
+                        fprintf(stderr, "-code-model options are 'default', 'tiny', 'small', 'kernel', 'medium', or 'large'\n");
+                        return print_error_usage(arg0);
+                    }
                 } else if (strcmp(arg, "--override-lib-dir") == 0) {
                     override_lib_dir = buf_create_from_str(argv[i]);
                 } else if (strcmp(arg, "--main-pkg-path") == 0) {
@@ -1170,6 +1191,7 @@ int main(int argc, char **argv) {
             codegen_set_errmsg_color(g, color);
             g->system_linker_hack = system_linker_hack;
             g->function_sections = function_sections;
+            g->code_model = code_model;
 
 
             for (size_t i = 0; i < lib_dirs.length; i += 1) {


### PR DESCRIPTION
This pull request allows the user to select the code model that is targeted through the `-code-model` compiler flag or the `LibExeObjStep.code_model` field.
It is exposed through `builtin.code_model`.

### Explanation:
In short the code model puts constraints on the location of symbols and the size of code and data.
The selection of a code model is a trade off on speed and restrictions that needs to be selected on a per application basis to meet its requirements.

A slightly more detailed explanation can be found in (for example) the [System V Application Binary Interface (x86_64)](https://github.com/hjl-tools/x86-psABI/wiki/x86-64-psABI-1.0.pdf) 3.5.1.

### Example:
An application compiled with the default amd64 code model (small) cannot be linked into negative address space because of the restrictions that it imposes.

#### Example for the linker error that would occur:
> lld: error: start.zig:96:(.text+0x1401): relocation R_X86_64_32 out of range: 18446744073707835024 is not in [0, 4294967295]

The same code targeting the large or kernel code models would be allowed to link.