### PR TITLE
Generate compilable code for array inits

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -3,6 +3,22 @@ const tests = @import("tests.zig");
 const nl = std.cstr.line_sep;
 
 pub fn addCases(cases: *tests.RunTranslatedCContext) void {
+    cases.add("array initializer",
+        \\#include <stdlib.h>
+        \\int main(int argc, char **argv) {
+        \\    int a0[4] = {1};
+        \\    int a1[4] = {1,2,3,4};
+        \\    int s0 = 0, s1 = 0;
+        \\    for (int i = 0; i < 4; i++) {
+        \\        s0 += a0[i];
+        \\        s1 += a1[i];
+        \\    }
+        \\    if (s0 != 1) abort();
+        \\    if (s1 != 10) abort();
+        \\    return 0;
+        \\}
+    , "");
+
     cases.add("forward declarations",
         \\#include <stdlib.h>
         \\int foo(int);

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -18,7 +18,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\static const uuid_t UUID_NULL __attribute__ ((unused)) = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
     , &[_][]const u8{
         \\pub const uuid_t = [16]u8;
-        \\pub const UUID_NULL: uuid_t = .{
+        \\pub const UUID_NULL: uuid_t = [16]u8{
         \\    @bitCast(u8, @truncate(i8, @as(c_int, 0))),
         \\    @bitCast(u8, @truncate(i8, @as(c_int, 0))),
         \\    @bitCast(u8, @truncate(i8, @as(c_int, 0))),
@@ -87,7 +87,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    .x = @as(c_int, 1),
         \\};
         \\pub export var ub: union_unnamed_1 = union_unnamed_1{
-        \\    .c = .{
+        \\    .c = [4]u8{
         \\        @bitCast(u8, @truncate(i8, @as(c_int, 'a'))),
         \\        @bitCast(u8, @truncate(i8, @as(c_int, 'b'))),
         \\        @bitCast(u8, @truncate(i8, @as(c_int, 'b'))),
@@ -1118,12 +1118,12 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     , &[_][]const u8{
         \\pub fn foo() callconv(.C) void {
-        \\    var arr: [10]u8 = .{
+        \\    var arr: [10]u8 = [1]u8{
         \\        @bitCast(u8, @truncate(i8, @as(c_int, 1))),
-        \\    } ++ .{0} ** 9;
-        \\    var arr1: [10][*c]u8 = .{
+        \\    } ++ [1]u8{0} ** 9;
+        \\    var arr1: [10][*c]u8 = [1][*c]u8{
         \\        null,
-        \\    } ++ .{null} ** 9;
+        \\    } ++ [1][*c]u8{null} ** 9;
         \\}
     });
 
@@ -1570,7 +1570,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     cases.add("undefined array global",
         \\int array[100] = {};
     , &[_][]const u8{
-        \\pub export var array: [100]c_int = .{0} ** 100;
+        \\pub export var array: [100]c_int = [1]c_int{0} ** 100;
     });
 
     cases.add("restrict -> noalias",
@@ -1904,7 +1904,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    return array[index];
         \\}
     , &[_][]const u8{
-        \\pub export var array: [100]c_int = .{0} ** 100;
+        \\pub export var array: [100]c_int = [1]c_int{0} ** 100;
         \\pub export fn foo(arg_index: c_int) c_int {
         \\    var index = arg_index;
         \\    return array[@intCast(c_uint, index)];


### PR DESCRIPTION
The compiler still doesn't like too much the newfangled anonymous arrays
so let's use the old-style declarations.

Closes #4181