### PR TITLE
rb: fix rb.Node.getLast() that never worked

### DIFF
--- a/lib/std/rb.zig
+++ b/lib/std/rb.zig
@@ -123,7 +123,8 @@ pub const Node = struct {
         return node;
     }
 
-    fn getLast(node: *Node) *Node {
+    fn getLast(nodeconst: *Node) *Node {
+        var node = nodeconst;
         while (node.right) |right| {
             node = right;
         }


### PR DESCRIPTION
It tries to modify a argument, and those are const. `getFirst()` was fixed, but getLast never was.

Sorry I forgot to push this to the branch that just got merged.