### PR TITLE
Fix double close in openElfDebugInfo

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -378,6 +378,7 @@ pub fn printSourceAtAddress(debug_info: *DebugInfo, out_stream: var, address: us
     return noasync printSourceAtAddressPosix(debug_info, out_stream, address, tty_config);
 }
 
+/// TODO resources https://github.com/ziglang/zig/issues/4353
 fn printSourceAtAddressWindows(
     di: *DebugInfo,
     out_stream: var,
@@ -604,6 +605,7 @@ pub const TTY = struct {
     };
 };
 
+/// TODO resources https://github.com/ziglang/zig/issues/4353
 fn populateModule(di: *DebugInfo, mod: *Module) !void {
     if (mod.populated)
         return;
@@ -755,6 +757,7 @@ pub const OpenSelfDebugInfoError = error{
     UnsupportedOperatingSystem,
 };
 
+/// TODO resources https://github.com/ziglang/zig/issues/4353
 /// TODO once https://github.com/ziglang/zig/issues/3157 is fully implemented,
 /// make this `noasync fn` and remove the individual noasync calls.
 pub fn openSelfDebugInfo(allocator: *mem.Allocator) !DebugInfo {
@@ -963,6 +966,7 @@ pub fn openDwarfDebugInfo(di: *DwarfInfo, allocator: *mem.Allocator) !void {
     try di.scanAllCompileUnits();
 }
 
+/// TODO resources https://github.com/ziglang/zig/issues/4353
 pub fn openElfDebugInfo(
     allocator: *mem.Allocator,
     data: []u8,
@@ -1001,6 +1005,7 @@ pub fn openElfDebugInfo(
     return di;
 }
 
+/// TODO resources https://github.com/ziglang/zig/issues/4353
 fn openSelfDebugInfoPosix(allocator: *mem.Allocator) !DwarfInfo {
     var exe_file = try fs.openSelfExe();
     errdefer exe_file.close();
@@ -1020,6 +1025,7 @@ fn openSelfDebugInfoPosix(allocator: *mem.Allocator) !DwarfInfo {
     return openElfDebugInfo(allocator, exe_mmap);
 }
 
+/// TODO resources https://github.com/ziglang/zig/issues/4353
 fn openSelfDebugInfoMacOs(allocator: *mem.Allocator) !DebugInfo {
     const hdr = &std.c._mh_execute_header;
     assert(hdr.magic == std.macho.MH_MAGIC_64);
@@ -2072,6 +2078,7 @@ fn getAbbrevTableEntry(abbrev_table: *const AbbrevTable, abbrev_code: u64) ?*con
     return null;
 }
 
+/// TODO resources https://github.com/ziglang/zig/issues/4353
 fn getLineNumberInfoMacOs(di: *DebugInfo, symbol: MachoSymbol, address: usize) !LineInfo {
     const ofile = symbol.ofile orelse return error.MissingDebugInfo;
     const gop = try di.ofiles.getOrPut(ofile);

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -997,8 +997,6 @@ pub fn openElfDebugInfo(
             null,
     };
 
-    efile.close();
-
     try openDwarfDebugInfo(&di, allocator);
     return di;
 }


### PR DESCRIPTION
Fixes a double free. But one problem.. 

```zig
const std = @import("std");
const LeakCountAllocator = std.testing.LeakCountAllocator;

pub fn main() !void {
    const stderr = &std.io.getStdErr().outStream().stream;
    var leakAlloc = LeakCountAllocator.init(std.heap.page_allocator);
    defer leakAlloc.validate() catch {};
    
    var di = try std.debug.openSelfDebugInfo(&leakAlloc.allocator);
    try std.debug.printSourceAtAddress(&di, stderr, showMyTrace(), std.debug.detectTTYConfig());
    
    std.debug.warn("Done!\n", .{});
}

noinline fn showMyTrace() usize {
    return @returnAddress();
}
```

It's full of other leaks..
```
rocknest@Acer:/mnt/f/zig/1$ ./tracetest
/mnt/f/zig/1/tracetest.zig:10:64: 0x22ae55 in main (tracetest)
    try std.debug.printSourceAtAddress(&di, stderr, showMyTrace(), std.debug.detectTTYConfig());
                                                               ^
Done!
error - detected leaked allocations without matching free: 11059
```

Maybe `openSelfDebugInfo` should have a doc comment saying 'allocator has to be an instance of ArenaAllocator' or create an arena right inside the function. 