### PR TITLE
Resolve types in types_have_same_zig_comptime_repr

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -862,8 +862,8 @@ static bool types_have_same_zig_comptime_repr(CodeGen *codegen, ZigType *expecte
     if (expected == actual)
         return true;
 
-    // Resolve the types now as get_codegen_ptr_type calls type_has_bits, remove
-    // this hack once that's not necessary anymore
+    // Resolve the types now as get_codegen_ptr_type calls type_has_bits.
+    // (ideally get_codegen_ptr_type should also take a CodeGen parameter)
     assertNoError(type_resolve(codegen, expected, ResolveStatusZeroBitsKnown));
     assertNoError(type_resolve(codegen, actual, ResolveStatusZeroBitsKnown));
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -862,6 +862,11 @@ static bool types_have_same_zig_comptime_repr(CodeGen *codegen, ZigType *expecte
     if (expected == actual)
         return true;
 
+    // Resolve the types now as get_codegen_ptr_type calls type_has_bits, remove
+    // this hack once that's not necessary anymore
+    assertNoError(type_resolve(codegen, expected, ResolveStatusZeroBitsKnown));
+    assertNoError(type_resolve(codegen, actual, ResolveStatusZeroBitsKnown));
+
     if (get_codegen_ptr_type(expected) != nullptr && get_codegen_ptr_type(actual) != nullptr)
         return true;
 

--- a/test/stage1/behavior/cast.zig
+++ b/test/stage1/behavior/cast.zig
@@ -768,3 +768,10 @@ test "variable initialization uses result locations properly with regards to the
     const x: i32 = if (b) 1 else 2;
     expect(x == 1);
 }
+
+var global_struct: struct { f0: usize } = undefined;
+
+test "assignment to optional pointer result loc" {
+    var foo: struct { ptr: ?*c_void } = .{ .ptr = &global_struct };
+    expect(foo.ptr.? == @ptrCast(*c_void, &global_struct));
+}


### PR DESCRIPTION
Calling type_has_bits instead of type_has_bits2 makes the compiler crash
and burn if one of the two types passed in are not resolved yet.

Closes #4357