### PR TITLE
adds std.json.Value.eql method

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1201,6 +1201,36 @@ pub const Value = union(enum) {
         w.one_indent = one_indent;
         try w.emitJson(self);
     }
+
+    /// json.Value equality comparison: for `.Array`s and `.Object`s, equal
+    /// sizes are prerequisite before further probing into their contents.
+    pub fn eql(self: Value, other: Value) bool {
+        if (std.meta.activeTag(self) == std.meta.activeTag(other)) switch (self) {
+            .Null => return true,
+            .Bool => |self_bool| return self_bool == other.Bool,
+            .Integer => |self_int| return self_int == other.Integer,
+            .Float => |self_float| return self_float == other.Float, // TODO: reconsider if/when std.math gets a dedicated float eql
+            .String => |self_string| return mem.eql(u8, self_string, other.String),
+
+            .Array => |self_array| if (self_array.len == other.Array.len) {
+                for (self_array.items[0..self_array.len]) |self_array_item, i|
+                    if (!eql(self_array_item, other.Array.items[i]))
+                        return false;
+                return true;
+            },
+
+            .Object => |self_object| if (self_object.count() == other.Object.count()) {
+                var hash_map_iter = self_object.iterator();
+                while (hash_map_iter.next()) |item| {
+                    if (other.Object.getValue(item.key)) |other_value| {
+                        if (!eql(item.value, other_value)) return false;
+                    } else return false;
+                }
+                return true;
+            },
+        };
+        return false;
+    }
 };
 
 /// A non-stream JSON parser which constructs a tree of Value's.

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1205,7 +1205,9 @@ pub const Value = union(enum) {
     /// json.Value equality comparison: for `.Array`s and `.Object`s, equal
     /// sizes are prerequisite before further probing into their contents.
     pub fn eql(self: Value, other: Value) bool {
-        if (std.meta.activeTag(self) == std.meta.activeTag(other)) switch (self) {
+        if (std.meta.activeTag(self) != std.meta.activeTag(other))
+            return false;
+        switch (self) {
             .Null => return true,
             .Bool => |self_bool| return self_bool == other.Bool,
             .Integer => |self_int| return self_int == other.Integer,
@@ -1233,7 +1235,7 @@ pub const Value = union(enum) {
                 return true;
             },
         };
-        return false;
+        unreachable;
     }
 };
 

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1209,12 +1209,14 @@ pub const Value = union(enum) {
             .Null => return true,
             .Bool => |self_bool| return self_bool == other.Bool,
             .Integer => |self_int| return self_int == other.Integer,
-            .Float => |self_float| return self_float == other.Float, // TODO: reconsider if/when std.math gets a dedicated float eql
+            .Float => |self_float| return self_float == other.Float,
             .String => |self_string| return mem.eql(u8, self_string, other.String),
 
-            .Array => |self_array| if (self_array.len == other.Array.len) {
+            .Array => |self_array| {
+                if (self_array.len != other.Array.len)
+                    return false;
                 for (self_array.items[0..self_array.len]) |self_array_item, i|
-                    if (!eql(self_array_item, other.Array.items[i]))
+                    if (!self_array_item.eql(other.Array.items[i]))
                         return false;
                 return true;
             },
@@ -1223,7 +1225,7 @@ pub const Value = union(enum) {
                 var hash_map_iter = self_object.iterator();
                 while (hash_map_iter.next()) |item| {
                     if (other.Object.getValue(item.key)) |other_value| {
-                        if (!eql(item.value, other_value)) return false;
+                        if (!item.value.eql(other_value)) return false;
                     } else return false;
                 }
                 return true;

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1221,7 +1221,9 @@ pub const Value = union(enum) {
                 return true;
             },
 
-            .Object => |self_object| if (self_object.count() == other.Object.count()) {
+            .Object => |self_object| {
+                if (self_object.count() != other.Object.count())
+                    return false;
                 var hash_map_iter = self_object.iterator();
                 while (hash_map_iter.next()) |item| {
                     if (other.Object.getValue(item.key)) |other_value| {


### PR DESCRIPTION
This is occasionally useful as some JSON schemas/protocols allow `any`-(JSON)-typed ID-ish/key-ish fields ([example](https://en.wikipedia.org/wiki/JSON-RPC#Usage)). Their implementer will soon need a corresponding `JSON-any` matcher, and here it is.