### PR TITLE
Addresses #4280 : adds math.ceilPowerOfTwoPromote to std.HashMap.initCapacity

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -303,7 +303,8 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime hash: fn (key: K) u3
         }
 
         fn initCapacity(hm: *Self, capacity: usize) !void {
-            hm.entries = try hm.allocator.alloc(Entry, capacity);
+            const capacity_min = try math.cast(usize, math.ceilPowerOfTwoPromote(usize, capacity));
+            hm.entries = try hm.allocator.alloc(Entry, capacity_min);
             hm.size = 0;
             hm.max_distance_from_start_index = 0;
             for (hm.entries) |*entry| {

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -303,8 +303,7 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime hash: fn (key: K) u3
         }
 
         fn initCapacity(hm: *Self, capacity: usize) !void {
-            const capacity_min = try math.ceilPowerOfTwo(usize, capacity);
-            hm.entries = try hm.allocator.alloc(Entry, capacity_min);
+            hm.entries = try hm.allocator.alloc(Entry, optimizedCapacity(capacity));
             hm.size = 0;
             hm.max_distance_from_start_index = 0;
             for (hm.entries) |*entry| {

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -303,7 +303,7 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime hash: fn (key: K) u3
         }
 
         fn initCapacity(hm: *Self, capacity: usize) !void {
-            const capacity_min = try math.cast(usize, math.ceilPowerOfTwoPromote(usize, capacity));
+            const capacity_min = try math.ceilPowerOfTwo(usize, capacity);
             hm.entries = try hm.allocator.alloc(Entry, capacity_min);
             hm.size = 0;
             hm.max_distance_from_start_index = 0;


### PR DESCRIPTION
Addresses #4280 

Btw: the presence of `optimizedCapacity` was duly noted, but felt not applicable: `initCapacity` is often done with the background of "exactly known amount of items that will be put in next". So in all such cases "60% full" capacity would be a bit of an overuse of resources in my view. But mostly a gut feeling and could be argued either way.