### PR TITLE
stage1: guard against case-mismatched build types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,18 @@ if(NOT CMAKE_BUILD_TYPE)
         "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
+set(_list "Debug;Release;RelWithDebInfo;MinSizeRel")
+list(FIND _list ${CMAKE_BUILD_TYPE} _index)
+if(${_index} EQUAL -1)
+    string(REPLACE ";" ", " _list_pretty "${_list}")
+    message("::")
+    message(":: ERROR: Invalid build type: ${CMAKE_BUILD_TYPE}")
+    message("::")
+    message(":: valid types: { ${_list_pretty} }")
+    message("::")
+    message(FATAL_ERROR)
+endif()
+
 if(NOT CMAKE_INSTALL_PREFIX)
     set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE STRING
       "Directory to install zig to" FORCE)


### PR DESCRIPTION
- zig CMakeLists.txt CMAKE_BUILD_TYPE string comparisons are case-sensitive
- cmake itself is unclear about how tolerant it is for case-mismatches
- add CMAKE_BUILD_TYPE guard in CMakeLists.txt to force exact matches