### PR TITLE
stage1: fix cmake regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 2.8.5)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING
-        "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+        "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
-set(_list "Debug;Release;RelWithDebInfo;MinSizeRel")
+set(_list "None;Debug;Release;RelWithDebInfo;MinSizeRel")
 list(FIND _list ${CMAKE_BUILD_TYPE} _index)
 if(${_index} EQUAL -1)
     string(REPLACE ";" ", " _list_pretty "${_list}")


### PR DESCRIPTION
- add `None` as a valid CMAKE_BUILD_TYPE
- this is a legitimate setting used by packagers

regression was caused by c6df5deb3450e0d8a2ba449c34a0bd195fbce8ec