### PR TITLE
debug: Improve the frame-walking strategy

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -238,6 +238,13 @@ pub const Target = union(enum) {
             };
         }
 
+        pub fn isRISCV(arch: Arch) bool {
+            return switch (arch) {
+                .riscv32, .riscv64 => true,
+                else => false,
+            };
+        }
+
         pub fn isMIPS(arch: Arch) bool {
             return switch (arch) {
                 .mips, .mipsel, .mips64, .mips64el => true,
@@ -594,6 +601,8 @@ pub const Target = union(enum) {
                 }
 
                 pub fn populateDependencies(set: *Set, all_features_list: []const Cpu.Feature) void {
+                    @setEvalBranchQuota(1000000);
+
                     var old = set.ints;
                     while (true) {
                         for (all_features_list) |feature, index_usize| {


### PR DESCRIPTION
Clean up the code a bit and introduce a few checks meant to avoid
overshooting the end of the frame chain.
The code is now stable enough not to cause panics during the call frame
walking.