### PR TITLE
Documentation for the Build System

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -9595,10 +9595,95 @@ test "assert in release fast mode" {
       </p>
       {#header_close#}
       {#header_open|Zig Build System#}
-      <p>TODO: explain purpose, it's supposed to replace make/cmake</p>
-      <p>TODO: example of building a zig executable</p>
-      <p>TODO: example of building a C library</p>
-      {#header_close#}
+The Zig Build System is a replacement for make/cmake.
+
+      {#header_open|Basic Executable#}
+
+      <p>initialize a `zig build` application in the current directory</p>
+      <pre><code class="shell">
+$ zig init-exe
+Created build.zig
+Created src/main.zig
+
+Next, try `zig build --help` or `zig build run`
+      </code></pre>
+
+      {#code_begin|syntax|main#}
+const std = @import("std");
+
+pub fn main() anyerror!void {
+    std.debug.warn("All your base are belong to us.\n", .{});
+}
+      {#code_end#}
+      {#code_begin|syntax|builder#}
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const exe = b.addExecutable("example", "main.zig");
+    exe.setBuildMode(mode);
+
+    const run_cmd = exe.run();
+
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    b.default_step.dependOn(&exe.step);
+    b.installArtifact(exe);
+}
+      {#code_end#}
+
+      <p><code>zig build run<code> will now run the executable</p>
+      <pre><code class="shell"> 
+$ zig build run
+All your base are belong to us.
+      </code></pre>
+
+      {#header_close#} <!-- Basic Executable -->
+
+      {#header_open|Basic Library#}
+
+      <p>initialize a `zig build` library in the current directory</p>
+      <pre><code class="shell">
+$ zig init-exe
+Created build.zig
+Created src/main.zig
+
+Next, try `zig build --help` or `zig build test`
+      </code></pre>
+
+      {#code_begin|syntax|main#}
+const std = @import("std");
+const testing = std.testing;
+
+export fn add(a: i32, b: i32) i32 {
+    return a + b;
+}
+
+test "basic add functionality" {
+    testing.expect(add(3, 7) == 10);
+}
+      {#code_end#}
+
+      {#code_begin|syntax|builder#}
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const lib = b.addStaticLibrary("test", "src/main.zig");
+    lib.setBuildMode(mode);
+    lib.install();
+
+    var main_tests = b.addTest("src/main.zig");
+    main_tests.setBuildMode(mode);
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&main_tests.step);
+}
+      {#code_end#}
+      {#header_close#} <!-- Basic Library -->
+
+      {#header_close#} <!-- Zig Build System -->
       {#header_open|C#}
       <p>
       Although Zig is independent of C, and, unlike most other languages, does not depend on libc,

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -259,11 +259,13 @@ pub const Builder = struct {
         }));
     }
 
+    /// Add a `.so` shared library to the build outputs
     pub fn addSharedLibrary(self: *Builder, name: []const u8, root_src: ?[]const u8, ver: Version) *LibExeObjStep {
         const root_src_param = if (root_src) |p| @as(FileSource, .{ .path = p }) else null;
         return LibExeObjStep.createSharedLibrary(self, name, root_src_param, ver);
     }
 
+    /// Add a `.a` static library to the build outputs
     pub fn addStaticLibrary(self: *Builder, name: []const u8, root_src: ?[]const u8) *LibExeObjStep {
         const root_src_param = if (root_src) |p| @as(FileSource, .{ .path = p }) else null;
         return LibExeObjStep.createStaticLibrary(self, name, root_src_param);
@@ -1395,6 +1397,8 @@ pub const LibExeObjStep = struct {
         });
     }
 
+    /// Override the build Target.
+    /// The default target is the host system.
     pub fn setTheTarget(self: *LibExeObjStep, target: Target) void {
         self.target = target;
         self.computeOutFileNames();
@@ -1408,6 +1412,8 @@ pub const LibExeObjStep = struct {
         };
     }
 
+    /// Override the build output directory.
+    /// The default output directory is the current directory.
     pub fn setOutputDir(self: *LibExeObjStep, dir: []const u8) void {
         self.output_dir = self.builder.dupePath(dir);
     }
@@ -1416,7 +1422,7 @@ pub const LibExeObjStep = struct {
         self.builder.installArtifact(self);
     }
 
-    pub fn installRaw(self: *LibExeObjStep, dest_filename: [] const u8) void {
+    pub fn installRaw(self: *LibExeObjStep, dest_filename: []const u8) void {
         self.builder.installRaw(self, dest_filename);
     }
 
@@ -1438,6 +1444,8 @@ pub const LibExeObjStep = struct {
         return run_step;
     }
 
+    /// Override the `--linker-script` argument.
+    /// By default the operating system's linker script is used.
     pub fn setLinkerScriptPath(self: *LibExeObjStep, path: []const u8) void {
         self.linker_script = path;
     }
@@ -1617,6 +1625,7 @@ pub const LibExeObjStep = struct {
         self.filter = text;
     }
 
+    /// Add a C source code file to the build.
     pub fn addCSourceFile(self: *LibExeObjStep, file: []const u8, args: []const []const u8) void {
         self.addCSourceFileSource(.{
             .args = args,
@@ -1637,10 +1646,12 @@ pub const LibExeObjStep = struct {
         self.link_objects.append(LinkObject{ .CSourceFile = c_source_file }) catch unreachable;
     }
 
+    /// Enable compiler debug output for linking
     pub fn setVerboseLink(self: *LibExeObjStep, value: bool) void {
         self.verbose_link = value;
     }
 
+    /// Enable compiler debug output for C compilation
     pub fn setVerboseCC(self: *LibExeObjStep, value: bool) void {
         self.verbose_cc = value;
     }
@@ -1730,6 +1741,7 @@ pub const LibExeObjStep = struct {
         self.link_objects.append(LinkObject{ .StaticPath = self.builder.dupe(path) }) catch unreachable;
     }
 
+    /// Add a dependency on an object file.
     pub fn addObject(self: *LibExeObjStep, obj: *LibExeObjStep) void {
         assert(obj.kind == Kind.Obj);
         self.linkLibraryOrObject(obj);
@@ -1744,10 +1756,12 @@ pub const LibExeObjStep = struct {
         self.include_dirs.append(IncludeDir{ .RawPathSystem = self.builder.dupe(path) }) catch unreachable;
     }
 
+    /// Add a `-I` or `-isystem` path.
     pub fn addIncludeDir(self: *LibExeObjStep, path: []const u8) void {
         self.include_dirs.append(IncludeDir{ .RawPath = self.builder.dupe(path) }) catch unreachable;
     }
 
+    /// Add a `-L` path.
     pub fn addLibPath(self: *LibExeObjStep, path: []const u8) void {
         self.lib_paths.append(self.builder.dupe(path)) catch unreachable;
     }
@@ -1809,6 +1823,7 @@ pub const LibExeObjStep = struct {
         self.exec_cmd_args = args;
     }
 
+    /// Pass `--system-linker-hack`
     pub fn enableSystemLinkerHack(self: *LibExeObjStep) void {
         self.system_linker_hack = true;
     }


### PR DESCRIPTION
I've added both examples from `zig init-exe` and `zig init-lib`, Also some comments to `std/build.zig` methods for the stdlib docs.

However, docgen doesn't support building snippets with custom build scripts so these are only syntax checked.