### PR TITLE
Stop using std.Buffer in places that don't make sense

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,6 @@ const BufMap = std.BufMap;
 const warn = std.debug.warn;
 const mem = std.mem;
 const ArrayList = std.ArrayList;
-const Buffer = std.Buffer;
 const io = std.io;
 const fs = std.fs;
 const InstallDirectoryOptions = std.build.InstallDirectoryOptions;

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -248,6 +248,17 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             if (self.len == 0) return null;
             return self.pop();
         }
+
+        pub fn startsWith(self: Self, m: []const T) bool {
+            if (self.len < m.len) return false;
+            return mem.eql(T, self.items[0..m.len], m);
+        }
+
+        pub fn endsWith(self: Self, m: []const T) bool {
+            if (self.len < m.len) return false;
+            const start = self.len - m.len;
+            return mem.eql(T, self.items[start..self.len], m);
+        }
     };
 }
 

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -249,6 +249,10 @@ pub fn AlignedArrayList(comptime T: type, comptime alignment: ?u29) type {
             return self.pop();
         }
 
+        pub fn eql(self: Self, m: []const T) bool {
+            return mem.eql(T, self.toSliceConst(), m);
+        }
+
         pub fn startsWith(self: Self, m: []const T) bool {
             if (self.len < m.len) return false;
             return mem.eql(T, self.items[0..m.len], m);

--- a/lib/std/buffer.zig
+++ b/lib/std/buffer.zig
@@ -133,7 +133,7 @@ pub const Buffer = struct {
 
     pub fn startsWith(self: Buffer, m: []const u8) bool {
         if (self.len() < m.len) return false;
-        return mem.eql(u8, self.list.items[0..m.len], m);
+        return self.list.startsWith(m);
     }
 
     pub fn endsWith(self: Buffer, m: []const u8) bool {

--- a/lib/std/build/run.zig
+++ b/lib/std/build/run.zig
@@ -185,7 +185,7 @@ pub const RunStep = struct {
         };
 
         var stderr: []const u8 = undefined;
-        switch (self.stdout_behavior) {
+        switch (self.stderr_action) {
             .expect_exact, .expect_matches => {
                 var stderr_file_in_stream = child.stderr.?.inStream();
                 stderr = stderr_file_in_stream.stream.readAllAlloc(self.builder.allocator, max_stdout_size) catch unreachable;

--- a/lib/std/build/run.zig
+++ b/lib/std/build/run.zig
@@ -9,7 +9,6 @@ const mem = std.mem;
 const process = std.process;
 const ArrayList = std.ArrayList;
 const BufMap = std.BufMap;
-const Buffer = std.Buffer;
 const warn = std.debug.warn;
 
 const max_stdout_size = 1 * 1024 * 1024; // 1 MiB

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1633,10 +1633,10 @@ test "hexToBytes" {
 test "formatIntValue with comptime_int" {
     const value: comptime_int = 123456789123456789;
 
-    var buf = try std.Buffer.init(std.testing.allocator, "");
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
-    try formatIntValue(value, "", FormatOptions{}, &buf, @TypeOf(std.Buffer.append).ReturnType.ErrorSet, std.Buffer.append);
-    std.testing.expect(mem.eql(u8, buf.toSlice(), "123456789123456789"));
+    try formatIntValue(value, "", FormatOptions{}, &buf, @TypeOf(std.ArrayList(u8).appendSlice).ReturnType.ErrorSet, std.ArrayList(u8).appendSlice);
+    std.testing.expect(mem.eql(u8, buf.toSliceConst(), "123456789123456789"));
 }
 
 test "formatType max_depth" {
@@ -1688,24 +1688,24 @@ test "formatType max_depth" {
     inst.a = &inst;
     inst.tu.ptr = &inst.tu;
 
-    var buf0 = try std.Buffer.init(std.testing.allocator, "");
+    var buf0 = std.ArrayList(u8).init(std.testing.allocator);
     defer buf0.deinit();
-    try formatType(inst, "", FormatOptions{}, &buf0, @TypeOf(std.Buffer.append).ReturnType.ErrorSet, std.Buffer.append, 0);
+    try formatType(inst, "", FormatOptions{}, &buf0, @TypeOf(std.ArrayList(u8).appendSlice).ReturnType.ErrorSet, std.ArrayList(u8).appendSlice, 0);
     std.testing.expect(mem.eql(u8, buf0.toSlice(), "S{ ... }"));
 
-    var buf1 = try std.Buffer.init(std.testing.allocator, "");
+    var buf1 = std.ArrayList(u8).init(std.testing.allocator);
     defer buf1.deinit();
-    try formatType(inst, "", FormatOptions{}, &buf1, @TypeOf(std.Buffer.append).ReturnType.ErrorSet, std.Buffer.append, 1);
+    try formatType(inst, "", FormatOptions{}, &buf1, @TypeOf(std.ArrayList(u8).appendSlice).ReturnType.ErrorSet, std.ArrayList(u8).appendSlice, 1);
     std.testing.expect(mem.eql(u8, buf1.toSlice(), "S{ .a = S{ ... }, .tu = TU{ ... }, .e = E.Two, .vec = (10.200,2.220) }"));
 
-    var buf2 = try std.Buffer.init(std.testing.allocator, "");
+    var buf2 = std.ArrayList(u8).init(std.testing.allocator);
     defer buf2.deinit();
-    try formatType(inst, "", FormatOptions{}, &buf2, @TypeOf(std.Buffer.append).ReturnType.ErrorSet, std.Buffer.append, 2);
+    try formatType(inst, "", FormatOptions{}, &buf2, @TypeOf(std.ArrayList(u8).appendSlice).ReturnType.ErrorSet, std.ArrayList(u8).appendSlice, 2);
     std.testing.expect(mem.eql(u8, buf2.toSlice(), "S{ .a = S{ .a = S{ ... }, .tu = TU{ ... }, .e = E.Two, .vec = (10.200,2.220) }, .tu = TU{ .ptr = TU{ ... } }, .e = E.Two, .vec = (10.200,2.220) }"));
 
-    var buf3 = try std.Buffer.init(std.testing.allocator, "");
+    var buf3 = std.ArrayList(u8).init(std.testing.allocator);
     defer buf3.deinit();
-    try formatType(inst, "", FormatOptions{}, &buf3, @TypeOf(std.Buffer.append).ReturnType.ErrorSet, std.Buffer.append, 3);
+    try formatType(inst, "", FormatOptions{}, &buf3, @TypeOf(std.ArrayList(u8).appendSlice).ReturnType.ErrorSet, std.ArrayList(u8).appendSlice, 3);
     std.testing.expect(mem.eql(u8, buf3.toSlice(), "S{ .a = S{ .a = S{ .a = S{ ... }, .tu = TU{ ... }, .e = E.Two, .vec = (10.200,2.220) }, .tu = TU{ .ptr = TU{ ... } }, .e = E.Two, .vec = (10.200,2.220) }, .tu = TU{ .ptr = TU{ .ptr = TU{ ... } } }, .e = E.Two, .vec = (10.200,2.220) }"));
 }
 

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -9,7 +9,6 @@ const mem = std.mem;
 const process = std.process;
 const Allocator = mem.Allocator;
 const ArrayList = std.ArrayList;
-const Buffer = std.Buffer;
 
 const c = @import("c.zig");
 const introspect = @import("introspect.zig");

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -566,14 +566,13 @@ pub const StackTracesContext = struct {
             }
             child.spawn() catch |err| debug.panic("Unable to spawn {}: {}\n", .{ full_exe_path, @errorName(err) });
 
-            var stdout = Buffer.initNull(b.allocator);
-            var stderr = Buffer.initNull(b.allocator);
-
             var stdout_file_in_stream = child.stdout.?.inStream();
             var stderr_file_in_stream = child.stderr.?.inStream();
 
-            stdout_file_in_stream.stream.readAllBuffer(&stdout, max_stdout_size) catch unreachable;
-            stderr_file_in_stream.stream.readAllBuffer(&stderr, max_stdout_size) catch unreachable;
+            const stdout = stdout_file_in_stream.stream.readAllAlloc(b.allocator, max_stdout_size) catch unreachable;
+            defer b.allocator.free(stdout);
+            const stderr = stderr_file_in_stream.stream.readAllAlloc(b.allocator, max_stdout_size) catch unreachable;
+            defer b.allocator.free(stderr);
 
             const term = child.wait() catch |err| {
                 debug.panic("Unable to spawn {}: {}\n", .{ full_exe_path, @errorName(err) });
@@ -616,11 +615,8 @@ pub const StackTracesContext = struct {
             const got: []const u8 = got_result: {
                 var buf = try Buffer.initSize(b.allocator, 0);
                 defer buf.deinit();
-                const bytes = if (stderr.endsWith("\n"))
-                    stderr.toSliceConst()[0 .. stderr.len() - 1]
-                else
-                    stderr.toSliceConst()[0..stderr.len()];
-                var it = mem.separate(bytes, "\n");
+                if (stderr.len != 0 and stderr[stderr.len - 1] == '\n') stderr = stderr[0 .. stderr.len - 1];
+                var it = mem.separate(stderr, "\n");
                 process_lines: while (it.next()) |line| {
                     if (line.len == 0) continue;
                     const delims = [_][]const u8{ ":", ":", ":", " in " };


### PR DESCRIPTION
I imagine due to its name, `std.Buffer` is used in many places that it shouldn't be. (Related: #4385)
This PR moves many use-sites over to more-correct APIs