### PR TITLE
LLVM10 changes

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -564,8 +564,7 @@ static LLVMValueRef make_fn_llvm_value(CodeGen *g, ZigFn *fn) {
     add_uwtable_attr(g, llvm_fn);
     addLLVMFnAttr(llvm_fn, "nobuiltin");
     if (codegen_have_frame_pointer(g) && fn->fn_inline != FnInlineAlways) {
-        ZigLLVMAddFunctionAttr(llvm_fn, "no-frame-pointer-elim", "true");
-        ZigLLVMAddFunctionAttr(llvm_fn, "no-frame-pointer-elim-non-leaf", nullptr);
+        ZigLLVMAddFunctionAttr(llvm_fn, "frame-pointer", "all");
     }
     if (fn->section_name) {
         LLVMSetSection(llvm_fn, buf_ptr(fn->section_name));
@@ -1128,8 +1127,7 @@ static LLVMValueRef get_add_error_return_trace_addr_fn(CodeGen *g) {
     // on any architecture.
     addLLVMArgAttr(fn_val, (unsigned)0, "nonnull");
     if (codegen_have_frame_pointer(g)) {
-        ZigLLVMAddFunctionAttr(fn_val, "no-frame-pointer-elim", "true");
-        ZigLLVMAddFunctionAttr(fn_val, "no-frame-pointer-elim-non-leaf", nullptr);
+        ZigLLVMAddFunctionAttr(fn_val, "frame-pointer", "all");
     }
 
     LLVMBasicBlockRef entry_block = LLVMAppendBasicBlock(fn_val, "Entry");
@@ -1206,8 +1204,7 @@ static LLVMValueRef get_return_err_fn(CodeGen *g) {
     addLLVMFnAttr(fn_val, "nounwind");
     add_uwtable_attr(g, fn_val);
     if (codegen_have_frame_pointer(g)) {
-        ZigLLVMAddFunctionAttr(fn_val, "no-frame-pointer-elim", "true");
-        ZigLLVMAddFunctionAttr(fn_val, "no-frame-pointer-elim-non-leaf", nullptr);
+        ZigLLVMAddFunctionAttr(fn_val, "frame-pointer", "all");
     }
 
     // this is above the ZigLLVMClearCurrentDebugLocation
@@ -1290,8 +1287,7 @@ static LLVMValueRef get_safety_crash_err_fn(CodeGen *g) {
     addLLVMFnAttr(fn_val, "nounwind");
     add_uwtable_attr(g, fn_val);
     if (codegen_have_frame_pointer(g)) {
-        ZigLLVMAddFunctionAttr(fn_val, "no-frame-pointer-elim", "true");
-        ZigLLVMAddFunctionAttr(fn_val, "no-frame-pointer-elim-non-leaf", nullptr);
+        ZigLLVMAddFunctionAttr(fn_val, "frame-pointer", "all");
     }
     // Not setting alignment here. See the comment above about
     // "Cannot getTypeInfo() on a type that is unsized!"
@@ -4995,8 +4991,7 @@ static LLVMValueRef get_enum_tag_name_function(CodeGen *g, ZigType *enum_type) {
     addLLVMFnAttr(fn_val, "nounwind");
     add_uwtable_attr(g, fn_val);
     if (codegen_have_frame_pointer(g)) {
-        ZigLLVMAddFunctionAttr(fn_val, "no-frame-pointer-elim", "true");
-        ZigLLVMAddFunctionAttr(fn_val, "no-frame-pointer-elim-non-leaf", nullptr);
+        ZigLLVMAddFunctionAttr(fn_val, "frame-pointer", "all");
     }
 
     LLVMBasicBlockRef prev_block = LLVMGetInsertBlock(g->builder);

--- a/test/stack_traces.zig
+++ b/test/stack_traces.zig
@@ -41,6 +41,21 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\    try foo();
         \\}
     ;
+    const source_dumpCurrentStackTrace =
+        \\const std = @import("std");
+        \\
+        \\fn bar() void {
+        \\    std.debug.dumpCurrentStackTrace(@returnAddress());
+        \\}
+        \\fn foo() void {
+        \\    bar();
+        \\}
+        \\pub fn main() u8 {
+        \\    foo();
+        \\    return 1;
+        \\}
+    ;
+
     // zig fmt: off
     switch (builtin.os) {
         .freebsd => {
@@ -49,25 +64,25 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in main (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.main (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -76,7 +91,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_try_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in foo (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -86,7 +101,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.main (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -96,11 +111,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -109,7 +124,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_try_try_return_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in make_error (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -125,7 +140,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in std.start.main (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -141,11 +156,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -156,25 +171,25 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in main (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.posixCallMainAndExit (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -183,7 +198,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_try_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in foo (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -193,7 +208,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.posixCallMainAndExit (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -203,11 +218,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -216,7 +231,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_try_try_return_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in make_error (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -232,7 +247,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in std.start.posixCallMainAndExit (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -248,12 +263,44 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
+                },
+            );
+            cases.addCase(
+                "dumpCurrentStackTrace",
+                source_dumpCurrentStackTrace,
+                [_][]const u8{
+                // debug
+                \\source.zig:7:8: [address] in foo (test)
+                    \\    bar();
+                    \\       ^
+                    \\source.zig:10:8: [address] in main (test)
+                    \\    foo();
+                    \\       ^
+                    \\start.zig:247:29: [address] in std.start.posixCallMainAndExit (test)
+                    \\            return root.main();
+                    \\                            ^
+                    \\start.zig:114:5: [address] in std.start._start (test)
+                    \\    @call(.{ .modifier = .never_inline }, posixCallMainAndExit, .{});
+                    \\    ^
+                    \\
+                ,
+                // release-safe
+                \\start.zig:114:5: [address] in std.start._start (test)
+                    \\    @call(.{ .modifier = .never_inline }, posixCallMainAndExit, .{});
+                    \\    ^
+                    \\
+                ,
+                // release-fast
+                \\
+                ,
+                // release-small
+                \\
                 },
             );
         },
@@ -263,25 +310,25 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in _main.0 (test.o)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in _main (test.o)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -290,7 +337,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_try_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in _foo (test.o)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -300,7 +347,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in _main (test.o)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -310,11 +357,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -323,7 +370,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_try_try_return_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in _make_error (test.o)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -339,7 +386,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in _main (test.o)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -355,11 +402,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -370,7 +417,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in main (test.obj)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -380,11 +427,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // --disabled-- results in segmenetation fault
                 "",
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -406,11 +453,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // --disabled-- results in segmenetation fault
                 "",
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -438,11 +485,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // --disabled-- results in segmenetation fault
                 "",
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );

--- a/test/stage1/behavior/atomics.zig
+++ b/test/stage1/behavior/atomics.zig
@@ -146,7 +146,9 @@ fn testAtomicStore() void {
 }
 
 test "atomicrmw with floats" {
-    if (builtin.arch == .aarch64 or builtin.arch == .arm)
+    if (builtin.arch == .aarch64 or
+        builtin.arch == .arm or
+        builtin.arch == .riscv64)
         return;
     testAtomicRmwFloat();
 }

--- a/test/stage1/behavior/cast.zig
+++ b/test/stage1/behavior/cast.zig
@@ -261,10 +261,6 @@ fn testPeerErrorAndArray2(x: u8) anyerror![]const u8 {
 }
 
 test "@floatToInt" {
-    if (@import("builtin").arch == .riscv64) {
-        // TODO: https://github.com/ziglang/zig/issues/3338
-        return error.SkipZigTest;
-    }
     testFloatToInts();
     comptime testFloatToInts();
 }

--- a/test/stage1/behavior/math.zig
+++ b/test/stage1/behavior/math.zig
@@ -7,10 +7,6 @@ const minInt = std.math.minInt;
 const mem = std.mem;
 
 test "division" {
-    if (@import("builtin").arch == .riscv64) {
-        // TODO: https://github.com/ziglang/zig/issues/3338
-        return error.SkipZigTest;
-    }
     testDivision();
     comptime testDivision();
 }
@@ -578,10 +574,6 @@ fn remdiv(comptime T: type) void {
 }
 
 test "@sqrt" {
-    if (@import("builtin").arch == .riscv64) {
-        // TODO: https://github.com/ziglang/zig/issues/3338
-        return error.SkipZigTest;
-    }
     testSqrt(f64, 12.0);
     comptime testSqrt(f64, 12.0);
     testSqrt(f32, 13.0);
@@ -627,10 +619,6 @@ test "vector integer addition" {
 }
 
 test "NaN comparison" {
-    if (@import("builtin").arch == .riscv64) {
-        // TODO: https://github.com/ziglang/zig/issues/3338
-        return error.SkipZigTest;
-    }
     if (std.Target.current.isWindows()) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;

--- a/test/stage1/behavior/widening.zig
+++ b/test/stage1/behavior/widening.zig
@@ -19,10 +19,6 @@ test "implicit unsigned integer to signed integer" {
 }
 
 test "float widening" {
-    if (@import("builtin").arch == .riscv64) {
-        // TODO:
-        return error.SkipZigTest;
-    }
     var a: f16 = 12.34;
     var b: f32 = a;
     var c: f64 = b;
@@ -35,10 +31,6 @@ test "float widening" {
 test "float widening f16 to f128" {
     // TODO https://github.com/ziglang/zig/issues/3282
     if (@import("builtin").arch == .aarch64) return error.SkipZigTest;
-    if (@import("builtin").arch == .riscv64) {
-        // TODO: https://github.com/ziglang/zig/issues/3338
-        return error.SkipZigTest;
-    }
 
     var x: f16 = 12.34;
     var y: f128 = x;


### PR DESCRIPTION
# Nothing to see here, move along

* Solves the mysterious lack of stack traces, turns out LLVM [changed](https://prereleases.llvm.org/10.0.0/rc1/docs/ReleaseNotes.html) [some tags](https://reviews.llvm.org/D71863) a while ago and now the old ones the codegen used to use are silently ignored.
* I've added some more stack-traces test, please adapt it to other platforms than linux too.
* RISCV64-linux is now working quite well:
  - #3338 can be closed
  - We can't use the `baseline_rv64` CPU as-is since lld doesn't support some relocations/relaxations, the trick is to pass an additional `-relax` to the default feature set. The feature set API is so damn awkward to use that I had to give up after wrestling with it for a while.
  - The instruction selector chokes on this pattern (cc @luismarques)
```
Cannot select: 0x55d93f824958: i32,ch = AtomicSwap<(load store seq_cst 4 on %ir.x)> 0x55d93f940c48, FrameIndex:i64<0>, Constant:i32<1065353216>, atomics.zig:157:9
  0x55d93f7602a0: i64 = FrameIndex<0>
  0x55d93f940cb0: i32 = Constant<1065353216>
In function: behavior.atomics.testAtomicRmwFloat
```

And don't forget that #508 can probably be closed too (and its workaround reverted) :tada: 