### PR TITLE
Makes ArenaAllocator.deinit() not require a mutable reference.

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -533,7 +533,7 @@ pub const ArenaAllocator = struct {
         };
     }
 
-    pub fn deinit(self: *ArenaAllocator) void {
+    pub fn deinit(self: ArenaAllocator) void {
         var it = self.buffer_list.first;
         while (it) |node| {
             // this has to occur before the free because the free frees node


### PR DESCRIPTION
A tiny pull request changing a single character:
`ArenaAllocator.deinit` now does not require the allocator object to be mutable anymore