### PR TITLE
Payload captures no longer alias the original value

### DIFF
--- a/test/stage1/behavior/if.zig
+++ b/test/stage1/behavior/if.zig
@@ -1,4 +1,6 @@
-const expect = @import("std").testing.expect;
+const std = @import("std");
+const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
 
 test "if statements" {
     shouldBeEqual(1, 1);
@@ -89,4 +91,19 @@ test "if prongs cast to expected type instead of peer type resolution" {
     };
     S.doTheTest(false);
     comptime S.doTheTest(false);
+}
+
+test "while copies its payload" {
+    const S = struct {
+        fn doTheTest() void {
+            var tmp: ?i32 = 10;
+            if (tmp) |value| {
+                // Modify the original variable
+                tmp = null;
+                expectEqual(@as(i32, 10), value);
+            } else unreachable;
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
 }

--- a/test/stage1/behavior/switch.zig
+++ b/test/stage1/behavior/switch.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const expect = std.testing.expect;
 const expectError = std.testing.expectError;
+const expectEqual = std.testing.expectEqual;
 
 test "switch with numbers" {
     testSwitchWithNumbers(13);
@@ -490,6 +491,27 @@ test "switch on error set with single else" {
         }
     };
 
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
+test "while copies its payload" {
+    const S = struct {
+        fn doTheTest() void {
+            var tmp: union(enum) {
+                A: u8,
+                B: u32,
+            } = .{ .A = 42 };
+            switch (tmp) {
+                .A => |value| {
+                    // Modify the original union
+                    tmp = .{ .B = 0x10101010 };
+                    expectEqual(@as(u8, 42), value);
+                },
+                else => unreachable,
+            }
+        }
+    };
     S.doTheTest();
     comptime S.doTheTest();
 }

--- a/test/stage1/behavior/while.zig
+++ b/test/stage1/behavior/while.zig
@@ -1,4 +1,5 @@
-const expect = @import("std").testing.expect;
+const std = @import("std");
+const expect = std.testing.expect;
 
 test "while loop" {
     var i: i32 = 0;
@@ -270,4 +271,19 @@ test "while error 2 break statements and an else" {
     };
     S.entry(true, false);
     comptime S.entry(true, false);
+}
+
+test "while copies its payload" {
+    const S = struct {
+        fn doTheTest() void {
+            var tmp: ?i32 = 10;
+            while (tmp) |value| {
+                // Modify the original variable
+                tmp = null;
+                expect(value == 10);
+            }
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
 }


### PR DESCRIPTION
Ad discussed with Andrew in #4443 I've changed the behavior of `for`/`if`/`while`/`switch` so that a "simple" capture (`|v|`) always creates a copy of the payload in a scope-local variable. If you need to modify the underlying memory just use a "ref" capture (`|*v|`).

I've added a few tests to make sure this new behavior is respected and I've run the stage1/std test suite and I've not spotted any regression. That's possibly a sign of how nobody expected the capture to behave like it did :P or maybe everybody knew that and worked around it.

Closes #4361 
Closes #2915 