### PR TITLE
translate-c: change OutOfMemory → ASTUnitFailure

### DIFF
--- a/src-self-hosted/stage1.zig
+++ b/src-self-hosted/stage1.zig
@@ -92,6 +92,7 @@ const Error = extern enum {
     InvalidCpuFeatures,
     InvalidLlvmCpuFeaturesFormat,
     UnknownApplicationBinaryInterface,
+    ASTUnitFailure,
 };
 
 const FILE = std.c.FILE;
@@ -114,6 +115,7 @@ export fn stage2_translate_c(
             out_errors_len.* = errors.len;
             return Error.CCompileErrors;
         },
+        error.ASTUnitFailure => return Error.ASTUnitFailure,
         error.OutOfMemory => return Error.OutOfMemory,
     };
     return Error.None;

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -264,7 +264,7 @@ pub fn translate(
         &errors.len,
         resources_path,
     ) orelse {
-        if (errors.len == 0) return error.OutOfMemory;
+        if (errors.len == 0) return error.ASTUnitFailure;
         return error.SemanticAnalyzeFail;
     };
     defer ZigClangASTUnit_delete(ast_unit);

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -64,6 +64,7 @@ const char *err_str(Error err) {
         case ErrorInvalidCpuFeatures: return "invalid CPU features";
         case ErrorInvalidLlvmCpuFeaturesFormat: return "invalid LLVM CPU features format";
         case ErrorUnknownApplicationBinaryInterface: return "unknown application binary interface";
+        case ErrorASTUnitFailure: return "ASTUnit failure";
     }
     return "(invalid error)";
 }

--- a/src/userland.h
+++ b/src/userland.h
@@ -84,6 +84,7 @@ enum Error {
     ErrorInvalidCpuFeatures,
     ErrorInvalidLlvmCpuFeaturesFormat,
     ErrorUnknownApplicationBinaryInterface,
+    ErrorASTUnitFailure,
 };
 
 // ABI warning


### PR DESCRIPTION
- return a better error when no diagnostics are available