### PR TITLE
Set target default to ZIG_TARGET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.5)
 
 if(NOT ZIG_TARGET)
 	string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" sysname)
-	set(ZIG_TARGET "${CMAKE_HOST_SYSTEM_PROCESSOR}-${sysname}")
+	set(ZIG_TARGET "${CMAKE_HOST_SYSTEM_PROCESSOR}-${sysname}-gnu")
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8.5)
 
+if(NOT ZIG_TARGET)
+	string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" sysname)
+	set(ZIG_TARGET "${CMAKE_HOST_SYSTEM_PROCESSOR}-${sysname}")
+endif()
+
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING
         "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -23,4 +23,6 @@
 
 #cmakedefine ZIG_ENABLE_MEM_PROFILE
 
+#define ZIG_TARGET "@ZIG_TARGET@"
+
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -956,7 +956,7 @@ static int main0(int argc, char **argv) {
 
     ZigTarget target;
     if (target_string == nullptr) {
-        get_native_target(&target);
+	target_string = ZIG_TARGET;
         if (target_glibc != nullptr) {
             fprintf(stderr, "-target-glibc provided but no -target parameter\n");
             return print_error_usage(arg0);


### PR DESCRIPTION
This will set the default target to compile for the host or for the target it was set to compile for. This is supposed to replicate what gcc allows you to do.