### PR TITLE
Fix conversion of extern fn with body

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7399,7 +7399,7 @@ comptime {
     @export(internalName, .{ .name = "foo", .linkage = .Strong });
 }
 
-extern fn internalName() void {}
+fn internalName() callconv(.C) void {}
       {#code_end#}
       <p>This is equivalent to:</p>
       {#code_begin|obj#}

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -92,10 +92,12 @@ test "zig fmt: convert extern/nakedcc/stdcallcc into callconv(...)" {
         \\nakedcc fn foo1() void {}
         \\stdcallcc fn foo2() void {}
         \\extern fn foo3() void {}
+        \\extern "mylib" fn foo4() void {}
     ,
         \\fn foo1() callconv(.Naked) void {}
         \\fn foo2() callconv(.Stdcall) void {}
         \\fn foo3() callconv(.C) void {}
+        \\fn foo4() callconv(.C) void {}
         \\
     );
 }

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1396,6 +1396,7 @@ fn renderExpression(
                     try renderToken(tree, stream, extern_export_inline_token, indent, start_col, Space.Space); // extern/export
                 } else {
                     cc_rewrite_str = ".C";
+                    fn_proto.lib_name = null;
                 }
             }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -689,6 +689,9 @@ static AstNode *ast_parse_top_level_decl(ParseContext *pc, VisibMod visib_mod, B
 
             AstNode *res = fn_proto;
             if (body != nullptr) {
+                if (fn_proto->data.fn_proto.is_extern) {
+                    ast_error(pc, first, "Extern functions have no body");
+                }
                 res = ast_create_node_copy_line_info(pc, NodeTypeFnDef, fn_proto);
                 res->data.fn_def.fn_proto = fn_proto;
                 res->data.fn_def.body = body;

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3,6 +3,14 @@ const builtin = @import("builtin");
 const Target = @import("std").Target;
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
+    cases.addTest("reject extern function definitions with body",
+        \\extern "c" fn definitelyNotInLibC(a: i32, b: i32) i32 {
+        \\    return a + b;
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:1:1: error: Extern functions have no body",
+    });
+
     cases.addTest("duplicate field in anonymous struct literal",
         \\export fn entry() void {
         \\    const anon = .{


### PR DESCRIPTION
Stopgap measure for 0.6 release, #4500 is to be merged after the release is cut.

Closes #4473