### PR TITLE
stage1/ir_print: show GenConst in trailing fahsion

### DIFF
--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -590,11 +590,6 @@ static void ir_print_const_value(CodeGen *g, FILE *f, ZigValue *const_val) {
 static void ir_print_other_inst_gen(IrPrintGen *irp, IrInstGen *inst) {
     if (inst == nullptr) {
         fprintf(irp->f, "(null)");
-        return;
-    }
-
-    if (inst->value->special != ConstValSpecialRuntime) {
-        ir_print_const_value(irp->codegen, irp->f, inst->value);
     } else {
         ir_print_var_gen(irp, inst);
     }


### PR DESCRIPTION
- show GenConst instructions in trailing fashion

#### baseline
```
fn entry() { // (analyzed)
Entry_0:
    #1  | GenReturnPtr          | *void       | 0 | @ReturnPtr
    #19 | GenStorePtr           | void        | - | *#12 = 99
    :12 | GenAlloca             | *u32        | 2 | Alloca(align=0,name=a)
    #20 | GenDeclVar            | void        | - | var a: u32 align(4) = #12
    #27 | GenReturn             | noreturn    | - | return {}
}
```

#### new
```diff
  fn entry() { // (analyzed)
  Entry_0:
      #1  | GenReturnPtr          | *void       | 0 | @ReturnPtr
!     #19 | GenStorePtr           | void        | - | *#12 = #18
      :12 | GenAlloca             | *u32        | 2 | Alloca(align=0,name=a)
!     :18 | GenConst              | u32         | 1 | 99
      #20 | GenDeclVar            | void        | - | var a: u32 align(4) = #12
!     #27 | GenReturn             | noreturn    | - | return #21
!     :21 | GenConst              | void        | 1 | {}
  }
```