### PR TITLE
Two fixes for the price of one

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -864,6 +864,7 @@ pub const Dir = struct {
             .OBJECT_NAME_INVALID => unreachable,
             .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
             .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
+            .NO_MEDIA_IN_DEVICE => return error.FileNotFound,
             .INVALID_PARAMETER => unreachable,
             .SHARING_VIOLATION => return error.SharingViolation,
             .ACCESS_DENIED => return error.AccessDenied,

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3,6 +3,18 @@ const builtin = @import("builtin");
 const Target = @import("std").Target;
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
+    cases.addTest("slice to pointer conversion mismatch",
+        \\pub fn bytesAsSlice(bytes: var) [*]align(1) const u16 {
+        \\    return @ptrCast([*]align(1) const u16, bytes.ptr)[0..1];
+        \\}
+        \\test "bytesAsSlice" {
+        \\    const bytes = [_]u8{ 0xDE, 0xAD, 0xBE, 0xEF };
+        \\    const slice = bytesAsSlice(bytes[0..]);
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:2:54: error: expected type '[*]align(1) const u16', found '[]align(1) const u16'",
+    });
+
     cases.addTest("access invalid @typeInfo decl",
         \\const A = B;
         \\test "Crash" {

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -677,8 +677,10 @@ pub const StackTracesContext = struct {
             const got: []const u8 = got_result: {
                 var buf = try Buffer.initSize(b.allocator, 0);
                 defer buf.deinit();
-                var bytes = stderr.toSliceConst();
-                if (bytes.len != 0 and bytes[bytes.len - 1] == '\n') bytes = bytes[0 .. bytes.len - 1];
+                const bytes = if (stderr.endsWith("\n"))
+                    stderr.toSliceConst()[0 .. stderr.len() - 1]
+                else
+                    stderr.toSliceConst()[0..stderr.len()];
                 var it = mem.separate(bytes, "\n");
                 process_lines: while (it.next()) |line| {
                     if (line.len == 0) continue;


### PR DESCRIPTION
* The type checking done by creating a temporary dummy object is nightmare fuel (it's also deeply wrong for every type that requires some invariant to hold, such as structure types having a non-null `fields` pointer). But that's better than a segfault and hopefully won't be carried over into stage1.
* This check caught a bug in `tests.zig`, yay!