### PR TITLE
std.time.Timer.lap: only read system time once

### DIFF
--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -153,7 +153,7 @@ pub const Timer = struct {
     }
 
     /// Reads the timer value since start or the last reset in nanoseconds
-    pub fn read(self: *Timer) u64 {
+    pub fn read(self: Timer) u64 {
         var clock = clockNative() - self.start_time;
         return nativeDurationToNanos(clock);
     }

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -155,7 +155,7 @@ pub const Timer = struct {
     /// Reads the timer value since start or the last reset in nanoseconds
     pub fn read(self: Timer) u64 {
         var clock = clockNative() - self.start_time;
-        return nativeDurationToNanos(clock);
+        return self.nativeDurationToNanos(clock);
     }
 
     /// Resets the timer value to 0/now.
@@ -166,7 +166,7 @@ pub const Timer = struct {
     /// Returns the current value of the timer in nanoseconds, then resets it
     pub fn lap(self: *Timer) u64 {
         var now = clockNative();
-        var lap_time = nativeDurationToNanos(now - self.start_time);
+        var lap_time = self.nativeDurationToNanos(now - self.start_time);
         self.start_time = now;
         return lap_time;
     }
@@ -183,7 +183,7 @@ pub const Timer = struct {
         return @intCast(u64, ts.tv_sec) * @as(u64, ns_per_s) + @intCast(u64, ts.tv_nsec);
     }
 
-    fn nativeDurationToNanos(duration: u64) u64 {
+    fn nativeDurationToNanos(self: Timer, duration: u64) u64 {
         if (builtin.os == .windows) {
             return @divFloor(duration * ns_per_s, self.frequency);
         }

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -155,13 +155,7 @@ pub const Timer = struct {
     /// Reads the timer value since start or the last reset in nanoseconds
     pub fn read(self: *Timer) u64 {
         var clock = clockNative() - self.start_time;
-        if (builtin.os == .windows) {
-            return @divFloor(clock * ns_per_s, self.frequency);
-        }
-        if (comptime std.Target.current.isDarwin()) {
-            return @divFloor(clock * self.frequency.numer, self.frequency.denom);
-        }
-        return clock;
+        return nativeDurationToNanos(clock);
     }
 
     /// Resets the timer value to 0/now.
@@ -172,7 +166,7 @@ pub const Timer = struct {
     /// Returns the current value of the timer in nanoseconds, then resets it
     pub fn lap(self: *Timer) u64 {
         var now = clockNative();
-        var lap_time = self.read();
+        var lap_time = nativeDurationToNanos(now - self.start_time);
         self.start_time = now;
         return lap_time;
     }
@@ -187,6 +181,16 @@ pub const Timer = struct {
         var ts: os.timespec = undefined;
         os.clock_gettime(monotonic_clock_id, &ts) catch unreachable;
         return @intCast(u64, ts.tv_sec) * @as(u64, ns_per_s) + @intCast(u64, ts.tv_nsec);
+    }
+
+    fn nativeDurationToNanos(duration: u64) u64 {
+        if (builtin.os == .windows) {
+            return @divFloor(duration * ns_per_s, self.frequency);
+        }
+        if (comptime std.Target.current.isDarwin()) {
+            return @divFloor(duration * self.frequency.numer, self.frequency.denom);
+        }
+        return duration;
     }
 };
 


### PR DESCRIPTION
Calling `Timer.lap` queried the system time twice; once to compute the lap time and once to reset the timer. This can lead to time discrepancies between actual and computed durations when summing the result of `Timer.lap` in a loop. This PR fixes that.