### PR TITLE
Format multiline string litterals

### DIFF
--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -570,6 +570,15 @@ pub const Node = struct {
         }
     }
 
+    pub fn findFirstWithId(self: *Node, id: Id) ?*Node {
+        if (self.id == id) return self;
+        var child_i: usize = 0;
+        while (self.iterate(child_i)) |child| : (child_i += 1) {
+            if (child.findFirstWithId(id)) |result| return result;
+        }
+        return null;
+    }
+
     pub fn dump(self: *Node, indent: usize) void {
         {
             var i: usize = 0;


### PR DESCRIPTION
Sorry for the delay. This changes a lot of the rendering code for multiline string literals. 
Test I ran is hear https://gist.github.com/LakeByTheWoods/7c560f1d4dc5782ec97f6fe3b5a59918
(base.zig being the input, before.zig is formatted with code before this patch, after.zig is formatted with this patch). It's not a very extensive test as I was mostly focussed on the case in the issue.
I am yet to do tests on a larger code base (such as the zig library code) but plan to do so.