### PR TITLE
implement zeroes for non extern structs and native types

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -331,14 +331,7 @@ pub fn zeroes(comptime T: type) T {
             }
             return array;
         },
-        .Vector => |info| {
-            var vector: T = undefined;
-            for (vector) |*element| {
-                *element = zeroes(info.child);
-            }
-            return vector;
-        },
-        .ErrorUnion, .ErrorSet, .Union, .Fn, .BoundFn, .Type, .NoReturn, .Undefined, .Opaque, .Frame, .AnyFrame,  => {
+        .Vector, .ErrorUnion, .ErrorSet, .Union, .Fn, .BoundFn, .Type, .NoReturn, .Undefined, .Opaque, .Frame, .AnyFrame,  => {
             @compileError("Can't set a "++ @typeName(T) ++" to zero.");
         },
     }


### PR DESCRIPTION
It now allows setting pretty much anything which makes sense to zero. Also calls itself recursively on `struct`s.

Didn't know what to do with some types, including error unions. And I don't know how to test things that will fail to compile.