### PR TITLE
introduce operating system version ranges as part of the target; self-host native dynamic linker detection and native glibc version detection

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -298,7 +298,7 @@ fn configureStage2(b: *Builder, exe: var, ctx: Context) !void {
     }
     dependOnLib(b, exe, ctx.llvm);
 
-    if (exe.target.getOs() == .linux) {
+    if (exe.target.getOsTag() == .linux) {
         try addCxxKnownPath(b, ctx, exe, "libstdc++.a",
             \\Unable to determine path to libstdc++.a
             \\On Fedora, install libstdc++-static and try again.

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -1146,10 +1146,10 @@ fn genHtml(allocator: *mem.Allocator, tokenizer: *Tokenizer, toc: *Toc, out: var
                             return parseError(tokenizer, code.source_token, "example failed to compile", .{});
 
                         if (code.target_str) |triple| {
-                            if ((mem.startsWith(u8, triple, "wasm32") or
+                            if (mem.startsWith(u8, triple, "wasm32") or
                                 mem.startsWith(u8, triple, "riscv64-linux") or
-                                mem.startsWith(u8, triple, "x86_64-linux")) and
-                                (std.Target.current.os.tag != .linux or std.Target.current.cpu.arch != .x86_64))
+                                (mem.startsWith(u8, triple, "x86_64-linux") and
+                                std.Target.current.os.tag != .linux or std.Target.current.cpu.arch != .x86_64))
                             {
                                 // skip execution
                                 try out.print("</code></pre>\n", .{});

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -10,8 +10,8 @@ const testing = std.testing;
 
 const max_doc_file_size = 10 * 1024 * 1024;
 
-const exe_ext = @as(std.build.Target, std.build.Target.Native).exeFileExt();
-const obj_ext = @as(std.build.Target, std.build.Target.Native).oFileExt();
+const exe_ext = @as(std.zig.CrossTarget, .{}).exeFileExt();
+const obj_ext = @as(std.zig.CrossTarget, .{}).oFileExt();
 const tmp_dir_name = "docgen_tmp";
 const test_out_path = tmp_dir_name ++ fs.path.sep_str ++ "test" ++ exe_ext;
 

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -965,7 +965,8 @@ const nan = std.math.nan(f128);
           but you can switch to {#syntax#}Optimized{#endsyntax#} mode on a per-block basis:</p>
       {#code_begin|obj|foo#}
       {#code_release_fast#}
-const builtin = @import("builtin");
+const std = @import("std");
+const builtin = std.builtin;
 const big = @as(f64, 1 << 40);
 
 export fn foo_strict(x: f64) f64 {
@@ -2063,15 +2064,15 @@ test "pointer child type" {
       alignment of the underlying type, it can be omitted from the type:
       </p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-const builtin = @import("builtin");
+const std = @import("std");
+const assert = std.debug.assert;
 
 test "variable alignment" {
     var x: i32 = 1234;
     const align_of_i32 = @alignOf(@TypeOf(x));
     assert(@TypeOf(&x) == *i32);
     assert(*i32 == *align(align_of_i32) i32);
-    if (builtin.arch == builtin.Arch.x86_64) {
+    if (std.Target.current.cpu.arch == .x86_64) {
         assert((*i32).alignment == 4);
     }
 }
@@ -2474,7 +2475,7 @@ test "default struct initialization fields" {
       </p>
       {#code_begin|test#}
 const std = @import("std");
-const builtin = @import("builtin");
+const builtin = std.builtin;
 const assert = std.debug.assert;
 
 const Full = packed struct {
@@ -3204,8 +3205,8 @@ test "separate scopes" {
 
       {#header_open|switch#}
       {#code_begin|test|switch#}
-const assert = @import("std").debug.assert;
-const builtin = @import("builtin");
+const std = @import("std");
+const assert = std.debug.assert;
 
 test "switch simple" {
     const a: u64 = 10;
@@ -3249,16 +3250,16 @@ test "switch simple" {
 }
 
 // Switch expressions can be used outside a function:
-const os_msg = switch (builtin.os) {
-    builtin.Os.linux => "we found a linux user",
+const os_msg = switch (std.Target.current.os.tag) {
+    .linux => "we found a linux user",
     else => "not a linux user",
 };
 
 // Inside a function, switch statements implicitly are compile-time
 // evaluated if the target expression is compile-time known.
 test "switch inside function" {
-    switch (builtin.os) {
-        builtin.Os.fuchsia => {
+    switch (std.Target.current.os.tag) {
+        .fuchsia => {
             // On an OS other than fuchsia, block is not even analyzed,
             // so this compile error is not triggered.
             // On fuchsia this compile error would be triggered.
@@ -7364,8 +7365,6 @@ test "main" {
       the {#syntax#}export{#endsyntax#} keyword used on a function:
       </p>
       {#code_begin|obj#}
-const builtin = @import("builtin");
-
 comptime {
     @export(internalName, .{ .name = "foo", .linkage = .Strong });
 }
@@ -9397,7 +9396,7 @@ const separator = if (builtin.os == builtin.Os.windows) '\\' else '/';
       </p>
       {#code_begin|test|detect_test#}
 const std = @import("std");
-const builtin = @import("builtin");
+const builtin = std.builtin;
 const assert = std.debug.assert;
 
 test "builtin.is_test" {
@@ -9715,7 +9714,8 @@ WebAssembly.instantiate(typedArray, {
     <pre><code>$ node test.js
 The result is 3</code></pre>
       {#header_open|WASI#}
-      <p>Zig's support for WebAssembly System Interface (WASI) is under active development. Example of using the standard library and reading command line arguments:</p>
+      <p>Zig's support for WebAssembly System Interface (WASI) is under active development.
+      Example of using the standard library and reading command line arguments:</p>
       {#code_begin|exe|wasi#}
       {#target_wasi#}
 const std = @import("std");

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1039,9 +1039,10 @@ pub const Builder = struct {
 };
 
 test "builder.findProgram compiles" {
-    var buf: [50000]u8 = undefined;
-    var fba = std.heap.FixedBufferAllocator.init(&buf);
-    const builder = try Builder.create(&fba.allocator, "zig", "zig-cache", "zig-cache");
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+
+    const builder = try Builder.create(&arena.allocator, "zig", "zig-cache", "zig-cache");
     defer builder.destroy();
     _ = builder.findProgram(&[_][]const u8{}, &[_][]const u8{}) catch null;
 }

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1141,7 +1141,7 @@ pub const LibExeObjStep = struct {
     out_pdb_filename: []const u8,
     packages: ArrayList(Pkg),
     build_options_contents: std.Buffer,
-    system_linker_hack: bool,
+    system_linker_hack: bool = false,
 
     object_src: []const u8,
 
@@ -1273,7 +1273,6 @@ pub const LibExeObjStep = struct {
             .object_src = undefined,
             .build_options_contents = std.Buffer.initSize(builder.allocator, 0) catch unreachable,
             .c_std = Builder.CStd.C99,
-            .system_linker_hack = false,
             .override_lib_dir = null,
             .main_pkg_path = null,
             .exec_cmd_args = null,

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1177,8 +1177,6 @@ pub const LibExeObjStep = struct {
     /// that contains the path `aarch64-linux-gnu/lib/ld-linux-aarch64.so.1`.
     glibc_multi_install_dir: ?[]const u8 = null,
 
-    dynamic_linker: ?[]const u8 = null,
-
     /// Position Independent Code
     force_pic: ?bool = null,
 
@@ -1978,16 +1976,16 @@ pub const LibExeObjStep = struct {
                 }
                 try zig_args.append(mcpu_buffer.toSliceConst());
             }
+
+            if (self.target.dynamic_linker.get()) |dynamic_linker| {
+                try zig_args.append("--dynamic-linker");
+                try zig_args.append(dynamic_linker);
+            }
         }
 
         if (self.linker_script) |linker_script| {
             zig_args.append("--linker-script") catch unreachable;
             zig_args.append(builder.pathFromRoot(linker_script)) catch unreachable;
-        }
-
-        if (self.dynamic_linker) |dynamic_linker| {
-            try zig_args.append("--dynamic-linker");
-            try zig_args.append(dynamic_linker);
         }
 
         if (self.version_script) |version_script| {

--- a/lib/std/build/run.zig
+++ b/lib/std/build/run.zig
@@ -82,7 +82,7 @@ pub const RunStep = struct {
 
         var key: []const u8 = undefined;
         var prev_path: ?[]const u8 = undefined;
-        if (builtin.os == .windows) {
+        if (builtin.os.tag == .windows) {
             key = "Path";
             prev_path = env_map.get(key);
             if (prev_path == null) {

--- a/lib/std/build/translate_c.zig
+++ b/lib/std/build/translate_c.zig
@@ -14,7 +14,7 @@ pub const TranslateCStep = struct {
     source: build.FileSource,
     output_dir: ?[]const u8,
     out_basename: []const u8,
-    target: std.Target = .Native,
+    target: build.Target = .Native,
 
     pub fn create(builder: *Builder, source: build.FileSource) *TranslateCStep {
         const self = builder.allocator.create(TranslateCStep) catch unreachable;
@@ -39,7 +39,7 @@ pub const TranslateCStep = struct {
         ) catch unreachable;
     }
 
-    pub fn setTarget(self: *TranslateCStep, target: std.Target) void {
+    pub fn setTarget(self: *TranslateCStep, target: build.Target) void {
         self.target = target;
     }
 

--- a/lib/std/build/translate_c.zig
+++ b/lib/std/build/translate_c.zig
@@ -7,6 +7,7 @@ const LibExeObjStep = build.LibExeObjStep;
 const CheckFileStep = build.CheckFileStep;
 const fs = std.fs;
 const mem = std.mem;
+const CrossTarget = std.zig.CrossTarget;
 
 pub const TranslateCStep = struct {
     step: Step,
@@ -14,7 +15,7 @@ pub const TranslateCStep = struct {
     source: build.FileSource,
     output_dir: ?[]const u8,
     out_basename: []const u8,
-    target: build.Target = .Native,
+    target: CrossTarget = CrossTarget{},
 
     pub fn create(builder: *Builder, source: build.FileSource) *TranslateCStep {
         const self = builder.allocator.create(TranslateCStep) catch unreachable;
@@ -39,7 +40,7 @@ pub const TranslateCStep = struct {
         ) catch unreachable;
     }
 
-    pub fn setTarget(self: *TranslateCStep, target: build.Target) void {
+    pub fn setTarget(self: *TranslateCStep, target: CrossTarget) void {
         self.target = target;
     }
 
@@ -63,12 +64,9 @@ pub const TranslateCStep = struct {
         try argv_list.append("--cache");
         try argv_list.append("on");
 
-        switch (self.target) {
-            .Native => {},
-            .Cross => {
-                try argv_list.append("-target");
-                try argv_list.append(try self.target.zigTriple(self.builder.allocator));
-            },
+        if (!self.target.isNative()) {
+            try argv_list.append("-target");
+            try argv_list.append(try self.target.zigTriple(self.builder.allocator));
         }
 
         try argv_list.append(self.source.getPath(self.builder));

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -429,6 +429,29 @@ pub const Version = struct {
             .patch = try std.fmt.parseInt(u32, it.next() orelse "0", 10),
         };
     }
+
+    pub fn format(
+        self: Version,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        context: var,
+        comptime Error: type,
+        comptime output: fn (@TypeOf(context), []const u8) Error!void,
+    ) Error!void {
+        if (fmt.len == 0) {
+            if (self.patch == 0) {
+                if (self.minor == 0) {
+                    return std.fmt.format(context, Error, output, "{}", .{self.major});
+                } else {
+                    return std.fmt.format(context, Error, output, "{}.{}", .{ self.major, self.minor });
+                }
+            } else {
+                return std.fmt.format(context, Error, output, "{}.{}.{}", .{ self.major, self.minor, self.patch });
+            }
+        } else {
+            @compileError("Unknown format string: '" ++ fmt ++ "'");
+        }
+    }
 };
 
 /// This data structure is used by the Zig language code generation and

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -398,7 +398,37 @@ pub const LinkMode = enum {
 pub const Version = struct {
     major: u32,
     minor: u32,
-    patch: u32,
+    patch: u32 = 0,
+
+    pub const Range = struct {
+        min: Version,
+        max: Version,
+
+        pub fn includesVersion(self: LinuxVersionRange, ver: Version) bool {
+            if (self.min.compare(ver) == .gt) return false;
+            if (self.max.compare(ver) == .lt) return false;
+            return true;
+        }
+    };
+
+    pub fn order(lhs: Version, rhs: version) std.math.Order {
+        if (lhs.major < rhs.major) return .lt;
+        if (lhs.major > rhs.major) return .gt;
+        if (lhs.minor < rhs.minor) return .lt;
+        if (lhs.minor > rhs.minor) return .gt;
+        if (lhs.patch < rhs.patch) return .lt;
+        if (lhs.patch > rhs.patch) return .gt;
+        return .eq;
+    }
+
+    pub fn parse(text: []const u8) !Version {
+        var it = std.mem.separate(text, ".");
+        return Version{
+            .major = try std.fmt.parseInt(u32, it.next() orelse return error.InvalidVersion, 10),
+            .minor = try std.fmt.parseInt(u32, it.next() orelse "0", 10),
+            .patch = try std.fmt.parseInt(u32, it.next() orelse "0", 10),
+        };
+    }
 };
 
 /// This data structure is used by the Zig language code generation and

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -411,7 +411,7 @@ pub const Version = struct {
         }
     };
 
-    pub fn order(lhs: Version, rhs: version) std.math.Order {
+    pub fn order(lhs: Version, rhs: Version) std.math.Order {
         if (lhs.major < rhs.major) return .lt;
         if (lhs.major > rhs.major) return .gt;
         if (lhs.minor < rhs.minor) return .lt;
@@ -504,7 +504,7 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace) noreturn
         root.os.panic(msg, error_return_trace);
         unreachable;
     }
-    switch (os) {
+    switch (os.tag) {
         .freestanding => {
             while (true) {
                 @breakpoint();

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -108,6 +108,7 @@ pub extern "c" fn execve(path: [*:0]const u8, argv: [*:null]const ?[*:0]const u8
 pub extern "c" fn dup(fd: fd_t) c_int;
 pub extern "c" fn dup2(old_fd: fd_t, new_fd: fd_t) c_int;
 pub extern "c" fn readlink(noalias path: [*:0]const u8, noalias buf: [*]u8, bufsize: usize) isize;
+pub extern "c" fn readlinkat(dirfd: fd_t, noalias path: [*:0]const u8, noalias buf: [*]u8, bufsize: usize) isize;
 pub extern "c" fn realpath(noalias file_name: [*:0]const u8, noalias resolved_name: [*]u8) ?[*:0]u8;
 pub extern "c" fn sigprocmask(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
 pub extern "c" fn gettimeofday(noalias tv: ?*timeval, noalias tz: ?*timezone) c_int;

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -125,6 +125,7 @@ pub extern "c" fn sysctlnametomib(name: [*:0]const u8, mibp: ?*c_int, sizep: ?*u
 pub extern "c" fn tcgetattr(fd: fd_t, termios_p: *termios) c_int;
 pub extern "c" fn tcsetattr(fd: fd_t, optional_action: TCSA, termios_p: *const termios) c_int;
 pub extern "c" fn fcntl(fd: fd_t, cmd: c_int, ...) c_int;
+pub extern "c" fn uname(buf: *utsname) c_int;
 
 pub extern "c" fn gethostname(name: [*]u8, len: usize) c_int;
 pub extern "c" fn bind(socket: fd_t, address: ?*const sockaddr, address_len: socklen_t) c_int;

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -94,7 +94,7 @@ pub const pthread_cond_t = extern struct {
     size: [__SIZEOF_PTHREAD_COND_T]u8 align(@alignOf(usize)) = [_]u8{0} ** __SIZEOF_PTHREAD_COND_T,
 };
 const __SIZEOF_PTHREAD_COND_T = 48;
-const __SIZEOF_PTHREAD_MUTEX_T = if (builtin.os == .fuchsia) 40 else switch (builtin.abi) {
+const __SIZEOF_PTHREAD_MUTEX_T = if (builtin.os.tag == .fuchsia) 40 else switch (builtin.abi) {
     .musl, .musleabi, .musleabihf => if (@sizeOf(usize) == 8) 40 else 24,
     .gnu, .gnuabin32, .gnuabi64, .gnueabi, .gnueabihf, .gnux32 => switch (builtin.arch) {
         .aarch64 => 48,

--- a/lib/std/cstr.zig
+++ b/lib/std/cstr.zig
@@ -4,8 +4,8 @@ const debug = std.debug;
 const mem = std.mem;
 const testing = std.testing;
 
-pub const line_sep = switch (builtin.os) {
-    builtin.Os.windows => "\r\n",
+pub const line_sep = switch (builtin.os.tag) {
+    .windows => "\r\n",
     else => "\n",
 };
 

--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -11,7 +11,7 @@ const system = std.os.system;
 const maxInt = std.math.maxInt;
 const max = std.math.max;
 
-pub const DynLib = switch (builtin.os) {
+pub const DynLib = switch (builtin.os.tag) {
     .linux => if (builtin.link_libc) DlDynlib else ElfDynLib,
     .windows => WindowsDynLib,
     .macosx, .tvos, .watchos, .ios, .freebsd => DlDynlib,
@@ -390,7 +390,7 @@ pub const DlDynlib = struct {
 };
 
 test "dynamic_library" {
-    const libname = switch (builtin.os) {
+    const libname = switch (builtin.os.tag) {
         .linux, .freebsd => "invalid_so.so",
         .windows => "invalid_dll.dll",
         .macosx, .tvos, .watchos, .ios => "invalid_dylib.dylib",

--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -82,12 +82,12 @@ pub fn linkmap_iterator(phdrs: []elf.Phdr) !LinkMap.Iterator {
         for (dyn_table) |*dyn| {
             switch (dyn.d_tag) {
                 elf.DT_DEBUG => {
-                    const r_debug = @intToPtr(*RDebug, dyn.d_un.d_ptr);
+                    const r_debug = @intToPtr(*RDebug, dyn.d_val);
                     if (r_debug.r_version != 1) return error.InvalidExe;
                     break :init r_debug.r_map;
                 },
                 elf.DT_PLTGOT => {
-                    const got_table = @intToPtr([*]usize, dyn.d_un.d_ptr);
+                    const got_table = @intToPtr([*]usize, dyn.d_val);
                     // The address to the link_map structure is stored in the
                     // second slot
                     break :init @intToPtr(?*LinkMap, got_table[1]);

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -349,16 +349,6 @@ pub const Elf = struct {
     program_headers: []ProgramHeader,
     allocator: *mem.Allocator,
 
-    /// Call close when done.
-    pub fn openPath(allocator: *mem.Allocator, path: []const u8) !Elf {
-        @compileError("TODO implement");
-    }
-
-    /// Call close when done.
-    pub fn openFile(allocator: *mem.Allocator, file: File) !Elf {
-        @compileError("TODO implement");
-    }
-
     pub fn openStream(
         allocator: *mem.Allocator,
         seekable_stream: *io.SeekableStream(anyerror, anyerror),
@@ -554,6 +544,21 @@ pub const Elf = struct {
 };
 
 pub const EI_NIDENT = 16;
+
+pub const EI_CLASS = 4;
+pub const ELFCLASSNONE = 0;
+pub const ELFCLASS32 = 1;
+pub const ELFCLASS64 = 2;
+pub const ELFCLASSNUM = 3;
+
+pub const EI_DATA = 5;
+pub const ELFDATANONE = 0;
+pub const ELFDATA2LSB = 1;
+pub const ELFDATA2MSB = 2;
+pub const ELFDATANUM = 3;
+
+pub const EI_VERSION = 6;
+
 pub const Elf32_Half = u16;
 pub const Elf64_Half = u16;
 pub const Elf32_Word = u32;

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -708,17 +708,11 @@ pub const Elf64_Rela = extern struct {
 };
 pub const Elf32_Dyn = extern struct {
     d_tag: Elf32_Sword,
-    d_un: extern union {
-        d_val: Elf32_Word,
-        d_ptr: Elf32_Addr,
-    },
+    d_val: Elf32_Addr,
 };
 pub const Elf64_Dyn = extern struct {
     d_tag: Elf64_Sxword,
-    d_un: extern union {
-        d_val: Elf64_Xword,
-        d_ptr: Elf64_Addr,
-    },
+    d_val: Elf64_Addr,
 };
 pub const Elf32_Verdef = extern struct {
     vd_version: Elf32_Half,

--- a/lib/std/event/channel.zig
+++ b/lib/std/event/channel.zig
@@ -273,7 +273,7 @@ test "std.event.Channel" {
     if (builtin.single_threaded) return error.SkipZigTest;
 
     // https://github.com/ziglang/zig/issues/3251
-    if (builtin.os == .freebsd) return error.SkipZigTest;
+    if (builtin.os.tag == .freebsd) return error.SkipZigTest;
 
     var channel: Channel(i32) = undefined;
     channel.init(&[0]i32{});

--- a/lib/std/event/future.zig
+++ b/lib/std/event/future.zig
@@ -86,7 +86,7 @@ test "std.event.Future" {
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded) return error.SkipZigTest;
     // https://github.com/ziglang/zig/issues/3251
-    if (builtin.os == .freebsd) return error.SkipZigTest;
+    if (builtin.os.tag == .freebsd) return error.SkipZigTest;
     // TODO provide a way to run tests in evented I/O mode
     if (!std.io.is_async) return error.SkipZigTest;
 

--- a/lib/std/event/lock.zig
+++ b/lib/std/event/lock.zig
@@ -123,7 +123,7 @@ test "std.event.Lock" {
     if (builtin.single_threaded) return error.SkipZigTest;
 
     // TODO https://github.com/ziglang/zig/issues/3251
-    if (builtin.os == .freebsd) return error.SkipZigTest;
+    if (builtin.os.tag == .freebsd) return error.SkipZigTest;
 
     var lock = Lock.init();
     defer lock.deinit();

--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -34,7 +34,7 @@ pub const Loop = struct {
         handle: anyframe,
         overlapped: Overlapped,
 
-        pub const overlapped_init = switch (builtin.os) {
+        pub const overlapped_init = switch (builtin.os.tag) {
             .windows => windows.OVERLAPPED{
                 .Internal = 0,
                 .InternalHigh = 0,
@@ -52,7 +52,7 @@ pub const Loop = struct {
             EventFd,
         };
 
-        pub const EventFd = switch (builtin.os) {
+        pub const EventFd = switch (builtin.os.tag) {
             .macosx, .freebsd, .netbsd, .dragonfly => KEventFd,
             .linux => struct {
                 base: ResumeNode,
@@ -71,7 +71,7 @@ pub const Loop = struct {
             kevent: os.Kevent,
         };
 
-        pub const Basic = switch (builtin.os) {
+        pub const Basic = switch (builtin.os.tag) {
             .macosx, .freebsd, .netbsd, .dragonfly => KEventBasic,
             .linux => struct {
                 base: ResumeNode,
@@ -173,7 +173,7 @@ pub const Loop = struct {
     const wakeup_bytes = [_]u8{0x1} ** 8;
 
     fn initOsData(self: *Loop, extra_thread_count: usize) InitOsDataError!void {
-        switch (builtin.os) {
+        switch (builtin.os.tag) {
             .linux => {
                 self.os_data.fs_queue = std.atomic.Queue(Request).init();
                 self.os_data.fs_queue_item = 0;
@@ -404,7 +404,7 @@ pub const Loop = struct {
     }
 
     fn deinitOsData(self: *Loop) void {
-        switch (builtin.os) {
+        switch (builtin.os.tag) {
             .linux => {
                 noasync os.close(self.os_data.final_eventfd);
                 while (self.available_eventfd_resume_nodes.pop()) |node| noasync os.close(node.data.eventfd);
@@ -568,7 +568,7 @@ pub const Loop = struct {
             };
             const eventfd_node = &resume_stack_node.data;
             eventfd_node.base.handle = next_tick_node.data;
-            switch (builtin.os) {
+            switch (builtin.os.tag) {
                 .macosx, .freebsd, .netbsd, .dragonfly => {
                     const kevent_array = @as(*const [1]os.Kevent, &eventfd_node.kevent);
                     const empty_kevs = &[0]os.Kevent{};
@@ -628,7 +628,7 @@ pub const Loop = struct {
 
         self.workerRun();
 
-        switch (builtin.os) {
+        switch (builtin.os.tag) {
             .linux,
             .macosx,
             .freebsd,
@@ -678,7 +678,7 @@ pub const Loop = struct {
         const prev = @atomicRmw(usize, &self.pending_event_count, AtomicRmwOp.Sub, 1, AtomicOrder.SeqCst);
         if (prev == 1) {
             // cause all the threads to stop
-            switch (builtin.os) {
+            switch (builtin.os.tag) {
                 .linux => {
                     self.posixFsRequest(&self.os_data.fs_end_request);
                     // writing 8 bytes to an eventfd cannot fail
@@ -902,7 +902,7 @@ pub const Loop = struct {
                 self.finishOneEvent();
             }
 
-            switch (builtin.os) {
+            switch (builtin.os.tag) {
                 .linux => {
                     // only process 1 event so we don't steal from other threads
                     var events: [1]os.linux.epoll_event = undefined;
@@ -989,7 +989,7 @@ pub const Loop = struct {
     fn posixFsRequest(self: *Loop, request_node: *Request.Node) void {
         self.beginOneEvent(); // finished in posixFsRun after processing the msg
         self.os_data.fs_queue.put(request_node);
-        switch (builtin.os) {
+        switch (builtin.os.tag) {
             .macosx, .freebsd, .netbsd, .dragonfly => {
                 const fs_kevs = @as(*const [1]os.Kevent, &self.os_data.fs_kevent_wake);
                 const empty_kevs = &[0]os.Kevent{};
@@ -1018,7 +1018,7 @@ pub const Loop = struct {
     // https://github.com/ziglang/zig/issues/3157
     fn posixFsRun(self: *Loop) void {
         while (true) {
-            if (builtin.os == .linux) {
+            if (builtin.os.tag == .linux) {
                 @atomicStore(i32, &self.os_data.fs_queue_item, 0, .SeqCst);
             }
             while (self.os_data.fs_queue.get()) |node| {
@@ -1053,7 +1053,7 @@ pub const Loop = struct {
                 }
                 self.finishOneEvent();
             }
-            switch (builtin.os) {
+            switch (builtin.os.tag) {
                 .linux => {
                     const rc = os.linux.futex_wait(&self.os_data.fs_queue_item, os.linux.FUTEX_WAIT, 0, null);
                     switch (os.linux.getErrno(rc)) {
@@ -1071,7 +1071,7 @@ pub const Loop = struct {
         }
     }
 
-    const OsData = switch (builtin.os) {
+    const OsData = switch (builtin.os.tag) {
         .linux => LinuxOsData,
         .macosx, .freebsd, .netbsd, .dragonfly => KEventData,
         .windows => struct {

--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -382,7 +382,7 @@ pub fn parseFloat(comptime T: type, s: []const u8) !T {
 }
 
 test "fmt.parseFloat" {
-    if (std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -29,7 +29,7 @@ pub const File = struct {
 
     pub const Mode = os.mode_t;
 
-    pub const default_mode = switch (builtin.os) {
+    pub const default_mode = switch (builtin.os.tag) {
         .windows => 0,
         else => 0o666,
     };
@@ -83,7 +83,7 @@ pub const File = struct {
 
     /// Test whether ANSI escape codes will be treated as such.
     pub fn supportsAnsiEscapeCodes(self: File) bool {
-        if (builtin.os == .windows) {
+        if (builtin.os.tag == .windows) {
             return os.isCygwinPty(self.handle);
         }
         if (self.isTty()) {
@@ -128,7 +128,7 @@ pub const File = struct {
 
     /// TODO: integrate with async I/O
     pub fn getEndPos(self: File) GetPosError!u64 {
-        if (builtin.os == .windows) {
+        if (builtin.os.tag == .windows) {
             return windows.GetFileSizeEx(self.handle);
         }
         return (try self.stat()).size;
@@ -138,7 +138,7 @@ pub const File = struct {
 
     /// TODO: integrate with async I/O
     pub fn mode(self: File) ModeError!Mode {
-        if (builtin.os == .windows) {
+        if (builtin.os.tag == .windows) {
             return {};
         }
         return (try self.stat()).mode;
@@ -162,7 +162,7 @@ pub const File = struct {
 
     /// TODO: integrate with async I/O
     pub fn stat(self: File) StatError!Stat {
-        if (builtin.os == .windows) {
+        if (builtin.os.tag == .windows) {
             var io_status_block: windows.IO_STATUS_BLOCK = undefined;
             var info: windows.FILE_ALL_INFORMATION = undefined;
             const rc = windows.ntdll.NtQueryInformationFile(self.handle, &io_status_block, &info, @sizeOf(windows.FILE_ALL_INFORMATION), .FileAllInformation);
@@ -209,7 +209,7 @@ pub const File = struct {
         /// last modification timestamp in nanoseconds
         mtime: i64,
     ) UpdateTimesError!void {
-        if (builtin.os == .windows) {
+        if (builtin.os.tag == .windows) {
             const atime_ft = windows.nanoSecondsToFileTime(atime);
             const mtime_ft = windows.nanoSecondsToFileTime(mtime);
             return windows.SetFileTime(self.handle, null, &atime_ft, &mtime_ft);

--- a/lib/std/fs/get_app_data_dir.zig
+++ b/lib/std/fs/get_app_data_dir.zig
@@ -13,7 +13,7 @@ pub const GetAppDataDirError = error{
 /// Caller owns returned memory.
 /// TODO determine if we can remove the allocator requirement
 pub fn getAppDataDir(allocator: *mem.Allocator, appname: []const u8) GetAppDataDirError![]u8 {
-    switch (builtin.os) {
+    switch (builtin.os.tag) {
         .windows => {
             var dir_path_ptr: [*:0]u16 = undefined;
             switch (os.windows.shell32.SHGetKnownFolderPath(

--- a/lib/std/fs/watch.zig
+++ b/lib/std/fs/watch.zig
@@ -42,7 +42,7 @@ pub fn Watch(comptime V: type) type {
         os_data: OsData,
         allocator: *Allocator,
 
-        const OsData = switch (builtin.os) {
+        const OsData = switch (builtin.os.tag) {
             // TODO https://github.com/ziglang/zig/issues/3778
             .macosx, .freebsd, .netbsd, .dragonfly => KqOsData,
             .linux => LinuxOsData,
@@ -121,7 +121,7 @@ pub fn Watch(comptime V: type) type {
             const self = try allocator.create(Self);
             errdefer allocator.destroy(self);
 
-            switch (builtin.os) {
+            switch (builtin.os.tag) {
                 .linux => {
                     const inotify_fd = try os.inotify_init1(os.linux.IN_NONBLOCK | os.linux.IN_CLOEXEC);
                     errdefer os.close(inotify_fd);
@@ -172,7 +172,7 @@ pub fn Watch(comptime V: type) type {
 
         /// All addFile calls and removeFile calls must have completed.
         pub fn deinit(self: *Self) void {
-            switch (builtin.os) {
+            switch (builtin.os.tag) {
                 .macosx, .freebsd, .netbsd, .dragonfly => {
                     // TODO we need to cancel the frames before destroying the lock
                     self.os_data.table_lock.deinit();
@@ -223,7 +223,7 @@ pub fn Watch(comptime V: type) type {
         }
 
         pub fn addFile(self: *Self, file_path: []const u8, value: V) !?V {
-            switch (builtin.os) {
+            switch (builtin.os.tag) {
                 .macosx, .freebsd, .netbsd, .dragonfly => return addFileKEvent(self, file_path, value),
                 .linux => return addFileLinux(self, file_path, value),
                 .windows => return addFileWindows(self, file_path, value),

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -36,7 +36,7 @@ fn cShrink(self: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new
 /// Thread-safe and lock-free.
 pub const page_allocator = if (std.Target.current.isWasm())
     &wasm_page_allocator_state
-else if (std.Target.current.getOs() == .freestanding)
+else if (std.Target.current.os.tag == .freestanding)
     root.os.heap.page_allocator
 else
     &page_allocator_state;
@@ -57,7 +57,7 @@ const PageAllocator = struct {
     fn alloc(allocator: *Allocator, n: usize, alignment: u29) error{OutOfMemory}![]u8 {
         if (n == 0) return &[0]u8{};
 
-        if (builtin.os == .windows) {
+        if (builtin.os.tag == .windows) {
             const w = os.windows;
 
             // Although officially it's at least aligned to page boundary,
@@ -143,7 +143,7 @@ const PageAllocator = struct {
 
     fn shrink(allocator: *Allocator, old_mem_unaligned: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
         const old_mem = @alignCast(mem.page_size, old_mem_unaligned);
-        if (builtin.os == .windows) {
+        if (builtin.os.tag == .windows) {
             const w = os.windows;
             if (new_size == 0) {
                 // From the docs:
@@ -183,7 +183,7 @@ const PageAllocator = struct {
 
     fn realloc(allocator: *Allocator, old_mem_unaligned: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
         const old_mem = @alignCast(mem.page_size, old_mem_unaligned);
-        if (builtin.os == .windows) {
+        if (builtin.os.tag == .windows) {
             if (old_mem.len == 0) {
                 return alloc(allocator, new_size, new_align);
             }
@@ -412,7 +412,7 @@ const WasmPageAllocator = struct {
     }
 };
 
-pub const HeapAllocator = switch (builtin.os) {
+pub const HeapAllocator = switch (builtin.os.tag) {
     .windows => struct {
         allocator: Allocator,
         heap_handle: ?HeapHandle,
@@ -855,7 +855,7 @@ test "PageAllocator" {
         try testAllocatorAlignedShrink(allocator);
     }
 
-    if (builtin.os == .windows) {
+    if (builtin.os.tag == .windows) {
         // Trying really large alignment. As mentionned in the implementation,
         // VirtualAlloc returns 64K aligned addresses. We want to make sure
         // PageAllocator works beyond that, as it's not tested by
@@ -868,7 +868,7 @@ test "PageAllocator" {
 }
 
 test "HeapAllocator" {
-    if (builtin.os == .windows) {
+    if (builtin.os.tag == .windows) {
         var heap_allocator = HeapAllocator.init();
         defer heap_allocator.deinit();
 

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -35,7 +35,7 @@ else
 pub const is_async = mode != .blocking;
 
 fn getStdOutHandle() os.fd_t {
-    if (builtin.os == .windows) {
+    if (builtin.os.tag == .windows) {
         return os.windows.peb().ProcessParameters.hStdOutput;
     }
 
@@ -54,7 +54,7 @@ pub fn getStdOut() File {
 }
 
 fn getStdErrHandle() os.fd_t {
-    if (builtin.os == .windows) {
+    if (builtin.os.tag == .windows) {
         return os.windows.peb().ProcessParameters.hStdError;
     }
 
@@ -74,7 +74,7 @@ pub fn getStdErr() File {
 }
 
 fn getStdInHandle() os.fd_t {
-    if (builtin.os == .windows) {
+    if (builtin.os.tag == .windows) {
         return os.windows.peb().ProcessParameters.hStdInput;
     }
 

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -544,7 +544,7 @@ fn testSerializerDeserializer(comptime endian: builtin.Endian, comptime packing:
 }
 
 test "Serializer/Deserializer generic" {
-    if (std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/math/fabs.zig
+++ b/lib/std/math/fabs.zig
@@ -95,7 +95,7 @@ test "math.fabs64.special" {
 }
 
 test "math.fabs128.special" {
-    if (std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/math/isinf.zig
+++ b/lib/std/math/isinf.zig
@@ -74,7 +74,7 @@ pub fn isNegativeInf(x: var) bool {
 }
 
 test "math.isInf" {
-    if (std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }
@@ -97,7 +97,7 @@ test "math.isInf" {
 }
 
 test "math.isPositiveInf" {
-    if (std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }
@@ -120,7 +120,7 @@ test "math.isPositiveInf" {
 }
 
 test "math.isNegativeInf" {
-    if (std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/math/isnan.zig
+++ b/lib/std/math/isnan.zig
@@ -16,7 +16,7 @@ pub fn isSignalNan(x: var) bool {
 }
 
 test "math.isNan" {
-    if (std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/mutex.zig
+++ b/lib/std/mutex.zig
@@ -73,7 +73,7 @@ pub const Mutex = if (builtin.single_threaded)
             return self.tryAcquire() orelse @panic("deadlock detected");
         }
     }
-else if (builtin.os == .windows)
+else if (builtin.os.tag == .windows)
 // https://locklessinc.com/articles/keyed_events/
     extern union {
         locked: u8,
@@ -161,7 +161,7 @@ else if (builtin.os == .windows)
             }
         };
     }
-else if (builtin.link_libc or builtin.os == .linux)
+else if (builtin.link_libc or builtin.os.tag == .linux)
 // stack-based version of https://github.com/Amanieu/parking_lot/blob/master/core/src/word_lock.rs
     struct {
         state: usize,

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -501,7 +501,7 @@ pub fn getAddressList(allocator: *mem.Allocator, name: []const u8, port: u16) !*
 
         return result;
     }
-    if (builtin.os == .linux) {
+    if (builtin.os.tag == .linux) {
         const flags = std.c.AI_NUMERICSERV;
         const family = os.AF_UNSPEC;
         var lookup_addrs = std.ArrayList(LookupAddr).init(allocator);

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -63,7 +63,7 @@ test "parse and render IPv4 addresses" {
 }
 
 test "resolve DNS" {
-    if (std.builtin.os == .windows) {
+    if (std.builtin.os.tag == .windows) {
         // DNS resolution not implemented on Windows yet.
         return error.SkipZigTest;
     }
@@ -81,7 +81,7 @@ test "resolve DNS" {
 test "listen on a port, send bytes, receive bytes" {
     if (!std.io.is_async) return error.SkipZigTest;
 
-    if (std.builtin.os != .linux) {
+    if (std.builtin.os.tag != .linux) {
         // TODO build abstractions for other operating systems
         return error.SkipZigTest;
     }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -650,7 +650,7 @@ pub fn writev(fd: fd_t, iov: []const iovec_const) WriteError!void {
 /// On Windows, if the application has a global event loop enabled, I/O Completion Ports are
 /// used to perform the I/O. `error.WouldBlock` is not possible on Windows.
 pub fn pwrite(fd: fd_t, bytes: []const u8, offset: u64) WriteError!void {
-    if (comptime std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         return windows.WriteFile(fd, bytes, offset);
     }
 
@@ -739,7 +739,7 @@ pub fn pwritev(fd: fd_t, iov: []const iovec_const, offset: u64) WriteError!void 
         }
     }
 
-    if (comptime std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         var off = offset;
         for (iov) |item| {
             try pwrite(fd, item.iov_base[0..item.iov_len], off);

--- a/lib/std/os/bits.zig
+++ b/lib/std/os/bits.zig
@@ -3,10 +3,10 @@
 //! Root source files can define `os.bits` and these will additionally be added
 //! to the namespace.
 
-const builtin = @import("builtin");
+const std = @import("std");
 const root = @import("root");
 
-pub usingnamespace switch (builtin.os) {
+pub usingnamespace switch (std.Target.current.os.tag) {
     .macosx, .ios, .tvos, .watchos => @import("bits/darwin.zig"),
     .dragonfly => @import("bits/dragonfly.zig"),
     .freebsd => @import("bits/freebsd.zig"),

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1070,7 +1070,7 @@ pub fn tcsetattr(fd: fd_t, optional_action: TCSA, termios_p: *const termios) usi
 }
 
 test "" {
-    if (builtin.os == .linux) {
+    if (builtin.os.tag == .linux) {
         _ = @import("linux/test.zig");
     }
 }

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -53,7 +53,7 @@ test "std.Thread.getCurrentId" {
     thread.wait();
     if (Thread.use_pthreads) {
         expect(thread_current_id == thread_id);
-    } else if (builtin.os == .windows) {
+    } else if (builtin.os.tag == .windows) {
         expect(Thread.getCurrentId() != thread_current_id);
     } else {
         // If the thread completes very quickly, then thread_id can be 0. See the
@@ -151,7 +151,7 @@ test "realpath" {
 }
 
 test "sigaltstack" {
-    if (builtin.os == .windows or builtin.os == .wasi) return error.SkipZigTest;
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return error.SkipZigTest;
 
     var st: os.stack_t = undefined;
     try os.sigaltstack(null, &st);
@@ -204,7 +204,7 @@ fn iter_fn(info: *dl_phdr_info, size: usize, counter: *usize) IterFnError!void {
 }
 
 test "dl_iterate_phdr" {
-    if (builtin.os == .windows or builtin.os == .wasi or builtin.os == .macosx)
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi or builtin.os.tag == .macosx)
         return error.SkipZigTest;
 
     var counter: usize = 0;
@@ -213,7 +213,7 @@ test "dl_iterate_phdr" {
 }
 
 test "gethostname" {
-    if (builtin.os == .windows)
+    if (builtin.os.tag == .windows)
         return error.SkipZigTest;
 
     var buf: [os.HOST_NAME_MAX]u8 = undefined;
@@ -222,7 +222,7 @@ test "gethostname" {
 }
 
 test "pipe" {
-    if (builtin.os == .windows)
+    if (builtin.os.tag == .windows)
         return error.SkipZigTest;
 
     var fds = try os.pipe();
@@ -241,7 +241,7 @@ test "argsAlloc" {
 
 test "memfd_create" {
     // memfd_create is linux specific.
-    if (builtin.os != .linux) return error.SkipZigTest;
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
     const fd = std.os.memfd_create("test", 0) catch |err| switch (err) {
         // Related: https://github.com/ziglang/zig/issues/4019
         error.SystemOutdated => return error.SkipZigTest,
@@ -258,7 +258,7 @@ test "memfd_create" {
 }
 
 test "mmap" {
-    if (builtin.os == .windows)
+    if (builtin.os.tag == .windows)
         return error.SkipZigTest;
 
     // Simple mmap() call with non page-aligned size
@@ -353,7 +353,7 @@ test "mmap" {
 }
 
 test "getenv" {
-    if (builtin.os == .windows) {
+    if (builtin.os.tag == .windows) {
         expect(os.getenvW(&[_:0]u16{ 'B', 'O', 'G', 'U', 'S', 0x11, 0x22, 0x33, 0x44, 0x55 }) == null);
     } else {
         expect(os.getenvZ("BOGUSDOESNOTEXISTENVVAR") == null);

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -593,7 +593,7 @@ test "PackedInt(Array/Slice)Endian" {
 // after this one is not mapped and will cause a segfault if we
 // don't account for the bounds.
 test "PackedIntArray at end of available memory" {
-    switch (builtin.os) {
+    switch (builtin.os.tag) {
         .linux, .macosx, .ios, .freebsd, .netbsd, .windows => {},
         else => return,
     }
@@ -612,7 +612,7 @@ test "PackedIntArray at end of available memory" {
 }
 
 test "PackedIntSlice at end of available memory" {
-    switch (builtin.os) {
+    switch (builtin.os.tag) {
         .linux, .macosx, .ios, .freebsd, .netbsd, .windows => {},
         else => return,
     }

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -609,6 +609,10 @@ pub fn getBaseAddress() usize {
 }
 
 /// Caller owns the result value and each inner slice.
+/// TODO Remove the `Allocator` requirement from this API, which will remove the `Allocator`
+/// requirement from `std.zig.system.NativeTargetInfo.detect`. Most likely this will require
+/// introducing a new, lower-level function which takes a callback function, and then this
+/// function which takes an allocator can exist on top of it.
 pub fn getSelfExeSharedLibPaths(allocator: *Allocator) error{OutOfMemory}![][:0]u8 {
     switch (builtin.link_mode) {
         .Static => return &[_][:0]u8{},

--- a/lib/std/reset_event.zig
+++ b/lib/std/reset_event.zig
@@ -16,7 +16,7 @@ pub const ResetEvent = struct {
 
     pub const OsEvent = if (builtin.single_threaded)
         DebugEvent
-    else if (builtin.link_libc and builtin.os != .windows and builtin.os != .linux)
+    else if (builtin.link_libc and builtin.os.tag != .windows and builtin.os.tag != .linux)
         PosixEvent
     else
         AtomicEvent;
@@ -106,7 +106,7 @@ const PosixEvent = struct {
     fn deinit(self: *PosixEvent) void {
         // on dragonfly, *destroy() functions can return EINVAL
         // for statically initialized pthread structures
-        const err = if (builtin.os == .dragonfly) os.EINVAL else 0;
+        const err = if (builtin.os.tag == .dragonfly) os.EINVAL else 0;
 
         const retm = c.pthread_mutex_destroy(&self.mutex);
         assert(retm == 0 or retm == err);
@@ -215,7 +215,7 @@ const AtomicEvent = struct {
         }
     }
 
-    pub const Futex = switch (builtin.os) {
+    pub const Futex = switch (builtin.os.tag) {
         .windows => WindowsFutex,
         .linux => LinuxFutex,
         else => SpinFutex,

--- a/lib/std/special/c.zig
+++ b/lib/std/special/c.zig
@@ -17,7 +17,7 @@ const is_msvc = switch (builtin.abi) {
     .msvc => true,
     else => false,
 };
-const is_freestanding = switch (builtin.os) {
+const is_freestanding = switch (builtin.os.tag) {
     .freestanding => true,
     else => false,
 };
@@ -81,7 +81,7 @@ pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn
         @setCold(true);
         std.debug.panic("{}", .{msg});
     }
-    if (builtin.os != .freestanding and builtin.os != .other) {
+    if (builtin.os.tag != .freestanding and builtin.os.tag != .other) {
         std.os.abort();
     }
     while (true) {}
@@ -178,11 +178,11 @@ test "test_bcmp" {
 comptime {
     if (builtin.mode != builtin.Mode.ReleaseFast and
         builtin.mode != builtin.Mode.ReleaseSmall and
-        builtin.os != builtin.Os.windows)
+        builtin.os.tag != .windows)
     {
         @export(__stack_chk_fail, .{ .name = "__stack_chk_fail" });
     }
-    if (builtin.os == builtin.Os.linux) {
+    if (builtin.os.tag == .linux) {
         @export(clone, .{ .name = "clone" });
     }
 }

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -2,10 +2,7 @@ const std = @import("std");
 const builtin = std.builtin;
 const is_test = builtin.is_test;
 
-const is_gnu = switch (builtin.abi) {
-    .gnu, .gnuabin32, .gnuabi64, .gnueabi, .gnueabihf, .gnux32 => true,
-    else => false,
-};
+const is_gnu = std.Target.current.abi.isGnu();
 const is_mingw = builtin.os.tag == .windows and is_gnu;
 
 comptime {
@@ -289,7 +286,7 @@ comptime {
             else => {},
         }
     } else {
-        if (std.Target.current.isGnuLibC()) {
+        if (std.Target.current.isGnuLibC() and builtin.link_libc) {
             @export(__stack_chk_guard, .{ .name = "__stack_chk_guard", .linkage = linkage });
         }
         @export(@import("compiler_rt/divti3.zig").__divti3, .{ .name = "__divti3", .linkage = linkage });

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -1,11 +1,12 @@
-const builtin = @import("builtin");
+const std = @import("std");
+const builtin = std.builtin;
 const is_test = builtin.is_test;
 
 const is_gnu = switch (builtin.abi) {
     .gnu, .gnuabin32, .gnuabi64, .gnueabi, .gnueabihf, .gnux32 => true,
     else => false,
 };
-const is_mingw = builtin.os == .windows and is_gnu;
+const is_mingw = builtin.os.tag == .windows and is_gnu;
 
 comptime {
     const linkage = if (is_test) builtin.GlobalLinkage.Internal else builtin.GlobalLinkage.Weak;
@@ -180,7 +181,7 @@ comptime {
         @export(@import("compiler_rt/arm.zig").__aeabi_memclr, .{ .name = "__aeabi_memclr4", .linkage = linkage });
         @export(@import("compiler_rt/arm.zig").__aeabi_memclr, .{ .name = "__aeabi_memclr8", .linkage = linkage });
 
-        if (builtin.os == .linux) {
+        if (builtin.os.tag == .linux) {
             @export(@import("compiler_rt/arm.zig").__aeabi_read_tp, .{ .name = "__aeabi_read_tp", .linkage = linkage });
         }
 
@@ -250,7 +251,7 @@ comptime {
         @export(@import("compiler_rt/aullrem.zig")._aullrem, .{ .name = "\x01__aullrem", .linkage = strong_linkage });
     }
 
-    if (builtin.os == .windows) {
+    if (builtin.os.tag == .windows) {
         // Default stack-probe functions emitted by LLVM
         if (is_mingw) {
             @export(@import("compiler_rt/stack_probe.zig")._chkstk, .{ .name = "_alloca", .linkage = strong_linkage });
@@ -288,7 +289,7 @@ comptime {
             else => {},
         }
     } else {
-        if (builtin.glibc_version != null) {
+        if (std.Target.current.isGnuLibC()) {
             @export(__stack_chk_guard, .{ .name = "__stack_chk_guard", .linkage = linkage });
         }
         @export(@import("compiler_rt/divti3.zig").__divti3, .{ .name = "__divti3", .linkage = linkage });
@@ -307,7 +308,7 @@ comptime {
 pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
     @setCold(true);
     if (is_test) {
-        @import("std").debug.panic("{}", .{msg});
+        std.debug.panic("{}", .{msg});
     } else {
         unreachable;
     }

--- a/lib/std/special/compiler_rt/addXf3_test.zig
+++ b/lib/std/special/compiler_rt/addXf3_test.zig
@@ -31,7 +31,7 @@ fn test__addtf3(a: f128, b: f128, expected_hi: u64, expected_lo: u64) void {
 }
 
 test "addtf3" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }
@@ -75,7 +75,7 @@ fn test__subtf3(a: f128, b: f128, expected_hi: u64, expected_lo: u64) void {
 }
 
 test "subtf3" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/compiler_rt/extendXfYf2_test.zig
+++ b/lib/std/special/compiler_rt/extendXfYf2_test.zig
@@ -90,7 +90,7 @@ test "extendhfsf2" {
     test__extendhfsf2(0x7f00, 0x7fe00000); // sNaN
     // On x86 the NaN becomes quiet because the return is pushed on the x87
     // stack due to ABI requirements
-    if (builtin.arch != .i386 and builtin.os == .windows)
+    if (builtin.arch != .i386 and builtin.os.tag == .windows)
         test__extendhfsf2(0x7c01, 0x7f802000); // sNaN
 
     test__extendhfsf2(0, 0); // 0

--- a/lib/std/special/compiler_rt/fixtfdi_test.zig
+++ b/lib/std/special/compiler_rt/fixtfdi_test.zig
@@ -11,7 +11,7 @@ fn test__fixtfdi(a: f128, expected: i64) void {
 }
 
 test "fixtfdi" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/compiler_rt/fixtfsi_test.zig
+++ b/lib/std/special/compiler_rt/fixtfsi_test.zig
@@ -11,7 +11,7 @@ fn test__fixtfsi(a: f128, expected: i32) void {
 }
 
 test "fixtfsi" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/compiler_rt/fixtfti_test.zig
+++ b/lib/std/special/compiler_rt/fixtfti_test.zig
@@ -11,7 +11,7 @@ fn test__fixtfti(a: f128, expected: i128) void {
 }
 
 test "fixtfti" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/compiler_rt/fixunstfdi_test.zig
+++ b/lib/std/special/compiler_rt/fixunstfdi_test.zig
@@ -7,7 +7,7 @@ fn test__fixunstfdi(a: f128, expected: u64) void {
 }
 
 test "fixunstfdi" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/compiler_rt/fixunstfsi_test.zig
+++ b/lib/std/special/compiler_rt/fixunstfsi_test.zig
@@ -9,7 +9,7 @@ fn test__fixunstfsi(a: f128, expected: u32) void {
 const inf128 = @bitCast(f128, @as(u128, 0x7fff0000000000000000000000000000));
 
 test "fixunstfsi" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/compiler_rt/fixunstfti_test.zig
+++ b/lib/std/special/compiler_rt/fixunstfti_test.zig
@@ -9,7 +9,7 @@ fn test__fixunstfti(a: f128, expected: u128) void {
 const inf128 = @bitCast(f128, @as(u128, 0x7fff0000000000000000000000000000));
 
 test "fixunstfti" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/compiler_rt/floattitf_test.zig
+++ b/lib/std/special/compiler_rt/floattitf_test.zig
@@ -7,7 +7,7 @@ fn test__floattitf(a: i128, expected: f128) void {
 }
 
 test "floattitf" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/compiler_rt/floatuntitf_test.zig
+++ b/lib/std/special/compiler_rt/floatuntitf_test.zig
@@ -7,7 +7,7 @@ fn test__floatuntitf(a: u128, expected: f128) void {
 }
 
 test "floatuntitf" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/compiler_rt/mulXf3_test.zig
+++ b/lib/std/special/compiler_rt/mulXf3_test.zig
@@ -44,7 +44,7 @@ fn makeNaN128(rand: u64) f128 {
     return float_result;
 }
 test "multf3" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/compiler_rt/truncXfYf2.zig
+++ b/lib/std/special/compiler_rt/truncXfYf2.zig
@@ -1,23 +1,23 @@
 const std = @import("std");
 
 pub fn __truncsfhf2(a: f32) callconv(.C) u16 {
-    return @bitCast(u16, truncXfYf2(f16, f32, a));
+    return @bitCast(u16, @call(.{ .modifier = .always_inline }, truncXfYf2, .{ f16, f32, a }));
 }
 
 pub fn __truncdfhf2(a: f64) callconv(.C) u16 {
-    return @bitCast(u16, truncXfYf2(f16, f64, a));
+    return @bitCast(u16, @call(.{ .modifier = .always_inline }, truncXfYf2, .{ f16, f64, a }));
 }
 
 pub fn __trunctfsf2(a: f128) callconv(.C) f32 {
-    return truncXfYf2(f32, f128, a);
+    return @call(.{ .modifier = .always_inline }, truncXfYf2, .{ f32, f128, a });
 }
 
 pub fn __trunctfdf2(a: f128) callconv(.C) f64 {
-    return truncXfYf2(f64, f128, a);
+    return @call(.{ .modifier = .always_inline }, truncXfYf2, .{ f64, f128, a });
 }
 
 pub fn __truncdfsf2(a: f64) callconv(.C) f32 {
-    return truncXfYf2(f32, f64, a);
+    return @call(.{ .modifier = .always_inline }, truncXfYf2, .{ f32, f64, a });
 }
 
 pub fn __aeabi_d2f(a: f64) callconv(.AAPCS) f32 {
@@ -35,7 +35,7 @@ pub fn __aeabi_f2h(a: f32) callconv(.AAPCS) u16 {
     return @call(.{ .modifier = .always_inline }, __truncsfhf2, .{a});
 }
 
-inline fn truncXfYf2(comptime dst_t: type, comptime src_t: type, a: src_t) dst_t {
+fn truncXfYf2(comptime dst_t: type, comptime src_t: type, a: src_t) dst_t {
     const src_rep_t = std.meta.IntType(false, @typeInfo(src_t).Float.bits);
     const dst_rep_t = std.meta.IntType(false, @typeInfo(dst_t).Float.bits);
     const srcSigBits = std.math.floatMantissaBits(src_t);

--- a/lib/std/special/compiler_rt/truncXfYf2_test.zig
+++ b/lib/std/special/compiler_rt/truncXfYf2_test.zig
@@ -151,7 +151,7 @@ fn test__trunctfsf2(a: f128, expected: u32) void {
 }
 
 test "trunctfsf2" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }
@@ -190,7 +190,7 @@ fn test__trunctfdf2(a: f128, expected: u64) void {
 }
 
 test "trunctfdf2" {
-    if (@import("std").Target.current.isWindows()) {
+    if (@import("std").Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }

--- a/lib/std/special/init-exe/build.zig
+++ b/lib/std/special/init-exe/build.zig
@@ -1,8 +1,18 @@
 const Builder = @import("std").build.Builder;
 
 pub fn build(b: *Builder) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard release options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const mode = b.standardReleaseOptions();
+
     const exe = b.addExecutable("$", "src/main.zig");
+    exe.setTarget(target);
     exe.setBuildMode(mode);
     exe.install();
 

--- a/lib/std/special/init-exe/src/main.zig
+++ b/lib/std/special/init-exe/src/main.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
 
 pub fn main() anyerror!void {
-    std.debug.warn("All your base are belong to us.\n", .{});
+    std.debug.warn("All your codebase are belong to us.\n", .{});
 }

--- a/lib/std/spinlock.zig
+++ b/lib/std/spinlock.zig
@@ -46,7 +46,7 @@ pub const SpinLock = struct {
         // and yielding for 380-410 iterations was found to be
         // a nice sweet spot. Posix systems on the other hand,
         // especially linux, perform better by yielding the thread.
-        switch (builtin.os) {
+        switch (builtin.os.tag) {
             .windows => loopHint(400),
             else => std.os.sched_yield() catch loopHint(1),
         }

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -12,7 +12,7 @@ const start_sym_name = if (builtin.arch.isMIPS()) "__start" else "_start";
 
 comptime {
     if (builtin.output_mode == .Lib and builtin.link_mode == .Dynamic) {
-        if (builtin.os == .windows and !@hasDecl(root, "_DllMainCRTStartup")) {
+        if (builtin.os.tag == .windows and !@hasDecl(root, "_DllMainCRTStartup")) {
             @export(_DllMainCRTStartup, .{ .name = "_DllMainCRTStartup" });
         }
     } else if (builtin.output_mode == .Exe or @hasDecl(root, "main")) {
@@ -20,17 +20,17 @@ comptime {
             if (@typeInfo(@TypeOf(root.main)).Fn.calling_convention != .C) {
                 @export(main, .{ .name = "main", .linkage = .Weak });
             }
-        } else if (builtin.os == .windows) {
+        } else if (builtin.os.tag == .windows) {
             if (!@hasDecl(root, "WinMain") and !@hasDecl(root, "WinMainCRTStartup") and
                 !@hasDecl(root, "wWinMain") and !@hasDecl(root, "wWinMainCRTStartup"))
             {
                 @export(WinMainCRTStartup, .{ .name = "WinMainCRTStartup" });
             }
-        } else if (builtin.os == .uefi) {
+        } else if (builtin.os.tag == .uefi) {
             if (!@hasDecl(root, "EfiMain")) @export(EfiMain, .{ .name = "EfiMain" });
-        } else if (builtin.arch.isWasm() and builtin.os == .freestanding) {
+        } else if (builtin.arch.isWasm() and builtin.os.tag == .freestanding) {
             if (!@hasDecl(root, start_sym_name)) @export(wasm_freestanding_start, .{ .name = start_sym_name });
-        } else if (builtin.os != .other and builtin.os != .freestanding) {
+        } else if (builtin.os.tag != .other and builtin.os.tag != .freestanding) {
             if (!@hasDecl(root, start_sym_name)) @export(_start, .{ .name = start_sym_name });
         }
     }
@@ -78,7 +78,7 @@ fn EfiMain(handle: uefi.Handle, system_table: *uefi.tables.SystemTable) callconv
 }
 
 fn _start() callconv(.Naked) noreturn {
-    if (builtin.os == builtin.Os.wasi) {
+    if (builtin.os.tag == .wasi) {
         // This is marked inline because for some reason LLVM in release mode fails to inline it,
         // and we want fewer call frames in stack traces.
         std.os.wasi.proc_exit(@call(.{ .modifier = .always_inline }, callMain, .{}));
@@ -133,7 +133,7 @@ fn WinMainCRTStartup() callconv(.Stdcall) noreturn {
 
 // TODO https://github.com/ziglang/zig/issues/265
 fn posixCallMainAndExit() noreturn {
-    if (builtin.os == builtin.Os.freebsd) {
+    if (builtin.os.tag == .freebsd) {
         @setAlignStack(16);
     }
     const argc = starting_stack_ptr[0];
@@ -144,7 +144,7 @@ fn posixCallMainAndExit() noreturn {
     while (envp_optional[envp_count]) |_| : (envp_count += 1) {}
     const envp = @ptrCast([*][*:0]u8, envp_optional)[0..envp_count];
 
-    if (builtin.os == .linux) {
+    if (builtin.os.tag == .linux) {
         // Find the beginning of the auxiliary vector
         const auxv = @ptrCast([*]std.elf.Auxv, @alignCast(@alignOf(usize), envp.ptr + envp_count + 1));
         std.os.linux.elf_aux_maybe = auxv;

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1084,16 +1084,16 @@ pub const Target = struct {
         }
     }
 
-    /// The result will be a slice of `buffer`, pointing at position 0.
+    /// The result will be a byte index *pointing at the final byte*. In other words, length minus one.
     /// A return value of `null` means the concept of a dynamic linker is not meaningful for that target.
-    pub fn standardDynamicLinkerPath(self: Target, buffer: *[255]u8) ?[]u8 {
+    pub fn standardDynamicLinkerPath(self: Target, buffer: *[255]u8) ?u8 {
         const S = struct {
-            fn print(b: *[255]u8, comptime fmt: []const u8, args: var) []u8 {
-                return std.fmt.bufPrint(b, fmt, args) catch unreachable;
+            fn print(b: *[255]u8, comptime fmt: []const u8, args: var) u8 {
+                return @intCast(u8, (std.fmt.bufPrint(b, fmt, args) catch unreachable).len - 1);
             }
-            fn copy(b: *[255]u8, s: []const u8) []u8 {
+            fn copy(b: *[255]u8, s: []const u8) u8 {
                 mem.copy(u8, b, s);
-                return b[0..s.len];
+                return @intCast(u8, s.len - 1);
             }
         };
         const print = S.print;

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1207,6 +1207,31 @@ pub const Target = struct {
                 => return error.UnknownDynamicLinkerPath,
             },
 
+            .ananas,
+            .cloudabi,
+            .fuchsia,
+            .kfreebsd,
+            .lv2,
+            .openbsd,
+            .solaris,
+            .haiku,
+            .minix,
+            .rtems,
+            .nacl,
+            .cnk,
+            .aix,
+            .cuda,
+            .nvcl,
+            .amdhsa,
+            .ps4,
+            .elfiamcu,
+            .mesa3d,
+            .contiki,
+            .amdpal,
+            .hermit,
+            .hurd,
+            => return error.UnknownDynamicLinkerPath,
+
             .freestanding,
             .ios,
             .tvos,
@@ -1216,9 +1241,8 @@ pub const Target = struct {
             .windows,
             .emscripten,
             .other,
+            .wasi,
             => return error.TargetHasNoDynamicLinker,
-
-            else => return error.UnknownDynamicLinkerPath,
         }
     }
 };

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1151,7 +1151,16 @@ pub const Target = struct {
                 .mipsel,
                 .mips64,
                 .mips64el,
-                => return error.UnknownDynamicLinkerPath,
+                => {
+                    const lib_suffix = switch (self.abi) {
+                        .gnuabin32, .gnux32 => "32",
+                        .gnuabi64 => "64",
+                        else => "",
+                    };
+                    const is_nan_2008 = mips.featureSetHas(self.cpu.features, .nan2008);
+                    const loader = if (is_nan_2008) "ld-linux-mipsn8.so.1" else "ld.so.1";
+                    return std.fmt.allocPrint0(a, "/lib{}/{}", .{ lib_suffix, loader });
+                },
 
                 .powerpc => return mem.dupeZ(a, u8, "/lib/ld.so.1"),
                 .powerpc64, .powerpc64le => return mem.dupeZ(a, u8, "/lib64/ld64.so.2"),

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -11,143 +11,48 @@ pub const Target = struct {
     os: Os,
     abi: Abi,
 
-    /// The version ranges here represent the minimum OS version to be supported
-    /// and the maximum OS version to be supported. The default values represent
-    /// the range that the Zig Standard Library bases its abstractions on.
-    ///
-    /// The minimum version of the range is the main setting to tweak for a target.
-    /// Usually, the maximum target OS version will remain the default, which is
-    /// the latest released version of the OS.
-    ///
-    /// To test at compile time if the target is guaranteed to support a given OS feature,
-    /// one should check that the minimum version of the range is greater than or equal to
-    /// the version the feature was introduced in.
-    ///
-    /// To test at compile time if the target certainly will not support a given OS feature,
-    /// one should check that the maximum version of the range is less than the version the
-    /// feature was introduced in.
-    ///
-    /// If neither of these cases apply, a runtime check should be used to determine if the
-    /// target supports a given OS feature.
-    ///
-    /// Binaries built with a given maximum version will continue to function on newer operating system
-    /// versions. However, such a binary may not take full advantage of the newer operating system APIs.
-    pub const Os = union(enum) {
-        freestanding,
-        ananas,
-        cloudabi,
-        dragonfly,
-        freebsd: Version.Range,
-        fuchsia,
-        ios,
-        kfreebsd,
-        linux: LinuxVersionRange,
-        lv2,
-        macosx: Version.Range,
-        netbsd: Version.Range,
-        openbsd: Version.Range,
-        solaris,
-        windows: WindowsVersion.Range,
-        haiku,
-        minix,
-        rtems,
-        nacl,
-        cnk,
-        aix,
-        cuda,
-        nvcl,
-        amdhsa,
-        ps4,
-        elfiamcu,
-        tvos,
-        watchos,
-        mesa3d,
-        contiki,
-        amdpal,
-        hermit,
-        hurd,
-        wasi,
-        emscripten,
-        uefi,
-        other,
+    pub const Os = struct {
+        tag: Tag,
+        version_range: VersionRange,
 
-        /// See the documentation for `Os` for an explanation of the default version range.
-        pub fn defaultVersionRange(tag: @TagType(Os)) Os {
-            switch (tag) {
-                .freestanding => return .freestanding,
-                .ananas => return .ananas,
-                .cloudabi => return .cloudabi,
-                .dragonfly => return .dragonfly,
-                .freebsd => return .{
-                    .freebsd = Version.Range{
-                        .min = .{ .major = 12, .minor = 0 },
-                        .max = .{ .major = 12, .minor = 1 },
-                    },
-                },
-                .fuchsia => return .fuchsia,
-                .ios => return .ios,
-                .kfreebsd => return .kfreebsd,
-                .linux => return .{
-                    .linux = .{
-                        .range = .{
-                            .min = .{ .major = 3, .minor = 16 },
-                            .max = .{ .major = 5, .minor = 5, .patch = 5 },
-                        },
-                        .glibc = .{ .major = 2, .minor = 17 },
-                    },
-                },
-                .lv2 => return .lv2,
-                .macosx => return .{
-                    .min = .{ .major = 10, .minor = 13 },
-                    .max = .{ .major = 10, .minor = 15, .patch = 3 },
-                },
-                .netbsd => return .{
-                    .min = .{ .major = 8, .minor = 0 },
-                    .max = .{ .major = 9, .minor = 0 },
-                },
-                .openbsd => return .{
-                    .min = .{ .major = 6, .minor = 6 },
-                    .max = .{ .major = 6, .minor = 6 },
-                },
-                solaris => return .solaris,
-                windows => return .{
-                    .windows = .{
-                        .min = .win8_1,
-                        .max = .win10_19h1,
-                    },
-                },
-                haiku => return .haiku,
-                minix => return .minix,
-                rtems => return .rtems,
-                nacl => return .nacl,
-                cnk => return .cnk,
-                aix => return .aix,
-                cuda => return .cuda,
-                nvcl => return .nvcl,
-                amdhsa => return .amdhsa,
-                ps4 => return .ps4,
-                elfiamcu => return .elfiamcu,
-                tvos => return .tvos,
-                watchos => return .watchos,
-                mesa3d => return .mesa3d,
-                contiki => return .contiki,
-                amdpal => return .amdpal,
-                hermit => return .hermit,
-                hurd => return .hurd,
-                wasi => return .wasi,
-                emscripten => return .emscripten,
-                uefi => return .uefi,
-                other => return .other,
-            }
-        }
-
-        pub const LinuxVersionRange = struct {
-            range: Version.Range,
-            glibc: Version,
-
-            pub fn includesVersion(self: LinuxVersionRange, ver: Version) bool {
-                return self.range.includesVersion(ver);
-            }
+        pub const Tag = enum {
+            freestanding,
+            ananas,
+            cloudabi,
+            dragonfly,
+            freebsd,
+            fuchsia,
+            ios,
+            kfreebsd,
+            linux,
+            lv2,
+            macosx,
+            netbsd,
+            openbsd,
+            solaris,
+            windows,
+            haiku,
+            minix,
+            rtems,
+            nacl,
+            cnk,
+            aix,
+            cuda,
+            nvcl,
+            amdhsa,
+            ps4,
+            elfiamcu,
+            tvos,
+            watchos,
+            mesa3d,
+            contiki,
+            amdpal,
+            hermit,
+            hurd,
+            wasi,
+            emscripten,
+            uefi,
+            other,
         };
 
         /// Based on NTDDI version constants from
@@ -178,29 +83,137 @@ pub const Target = struct {
                     return @enumToInt(ver) >= @enumToInt(self.min) and @enumToInt(ver) <= @enumToInt(self.max);
                 }
             };
+        };
 
-            pub fn nameToTag(name: []const u8) ?WindowsVersion {
-                const info = @typeInfo(WindowsVersion);
-                inline for (info.Enum.fields) |field| {
-                    if (mem.eql(u8, name, field.name)) {
-                        return @field(WindowsVersion, field.name);
-                    }
+        pub const LinuxVersionRange = struct {
+            range: Version.Range,
+            glibc: Version,
+
+            pub fn includesVersion(self: LinuxVersionRange, ver: Version) bool {
+                return self.range.includesVersion(ver);
+            }
+        };
+
+        /// The version ranges here represent the minimum OS version to be supported
+        /// and the maximum OS version to be supported. The default values represent
+        /// the range that the Zig Standard Library bases its abstractions on.
+        ///
+        /// The minimum version of the range is the main setting to tweak for a target.
+        /// Usually, the maximum target OS version will remain the default, which is
+        /// the latest released version of the OS.
+        ///
+        /// To test at compile time if the target is guaranteed to support a given OS feature,
+        /// one should check that the minimum version of the range is greater than or equal to
+        /// the version the feature was introduced in.
+        ///
+        /// To test at compile time if the target certainly will not support a given OS feature,
+        /// one should check that the maximum version of the range is less than the version the
+        /// feature was introduced in.
+        ///
+        /// If neither of these cases apply, a runtime check should be used to determine if the
+        /// target supports a given OS feature.
+        ///
+        /// Binaries built with a given maximum version will continue to function on newer operating system
+        /// versions. However, such a binary may not take full advantage of the newer operating system APIs.
+        pub const VersionRange = union {
+            none: void,
+            semver: Version.Range,
+            linux: LinuxVersionRange,
+            windows: WindowsVersion.Range,
+
+            /// The default `VersionRange` represents the range that the Zig Standard Library
+            /// bases its abstractions on.
+            pub fn default(tag: Tag) VersionRange {
+                switch (tag) {
+                    .freestanding,
+                    .ananas,
+                    .cloudabi,
+                    .dragonfly,
+                    .fuchsia,
+                    .ios,
+                    .kfreebsd,
+                    .lv2,
+                    .solaris,
+                    .haiku,
+                    .minix,
+                    .rtems,
+                    .nacl,
+                    .cnk,
+                    .aix,
+                    .cuda,
+                    .nvcl,
+                    .amdhsa,
+                    .ps4,
+                    .elfiamcu,
+                    .tvos,
+                    .watchos,
+                    .mesa3d,
+                    .contiki,
+                    .amdpal,
+                    .hermit,
+                    .hurd,
+                    .wasi,
+                    .emscripten,
+                    .uefi,
+                    .other,
+                    => return .{ .none = {} },
+
+                    .freebsd => return .{
+                        .semver = Version.Range{
+                            .min = .{ .major = 12, .minor = 0 },
+                            .max = .{ .major = 12, .minor = 1 },
+                        },
+                    },
+                    .macosx => return .{
+                        .semver = .{
+                            .min = .{ .major = 10, .minor = 13 },
+                            .max = .{ .major = 10, .minor = 15, .patch = 3 },
+                        },
+                    },
+                    .netbsd => return .{
+                        .semver = .{
+                            .min = .{ .major = 8, .minor = 0 },
+                            .max = .{ .major = 9, .minor = 0 },
+                        },
+                    },
+                    .openbsd => return .{
+                        .semver = .{
+                            .min = .{ .major = 6, .minor = 6 },
+                            .max = .{ .major = 6, .minor = 6 },
+                        },
+                    },
+
+                    .linux => return .{
+                        .linux = .{
+                            .range = .{
+                                .min = .{ .major = 3, .minor = 16 },
+                                .max = .{ .major = 5, .minor = 5, .patch = 5 },
+                            },
+                            .glibc = .{ .major = 2, .minor = 17 },
+                        },
+                    },
+
+                    .windows => return .{
+                        .windows = .{
+                            .min = .win8_1,
+                            .max = .win10_19h1,
+                        },
+                    },
                 }
-                return null;
             }
         };
 
         pub fn parse(text: []const u8) !Os {
             var it = mem.separate(text, ".");
             const os_name = it.next().?;
-            const tag = nameToTag(os_name) orelse return error.UnknownOperatingSystem;
+            const tag = std.meta.stringToEnum(Tag, os_name) orelse return error.UnknownOperatingSystem;
             const version_text = it.rest();
             const S = struct {
                 fn parseNone(s: []const u8) !void {
                     if (s.len != 0) return error.InvalidOperatingSystemVersion;
                 }
-                fn parseSemVer(s: []const u8, default: Version.Range) !Version.Range {
-                    if (s.len == 0) return default;
+                fn parseSemVer(s: []const u8, d_range: Version.Range) !Version.Range {
+                    if (s.len == 0) return d_range;
                     var range_it = mem.separate(s, "...");
 
                     const min_text = range_it.next().?;
@@ -212,7 +225,7 @@ pub const Target = struct {
 
                     const max_text = range_it.next() orelse return Version.Range{
                         .min = min_ver,
-                        .max = default.max,
+                        .max = d_range.max,
                     };
                     const max_ver = Version.parse(max_text) catch |err| switch (err) {
                         error.Overflow => return error.InvalidOperatingSystemVersion,
@@ -222,79 +235,93 @@ pub const Target = struct {
 
                     return Version.Range{ .min = min_ver, .max = max_ver };
                 }
-                fn parseWindows(s: []const u8, default: WindowsVersion.Range) !WindowsVersion.Range {
-                    if (s.len == 0) return default;
+                fn parseWindows(s: []const u8, d_range: WindowsVersion.Range) !WindowsVersion.Range {
+                    if (s.len == 0) return d_range;
                     var range_it = mem.separate(s, "...");
 
                     const min_text = range_it.next().?;
-                    const min_ver = WindowsVersion.nameToTag(min_text) orelse
+                    const min_ver = std.meta.stringToEnum(WindowsVersion, min_text) orelse
                         return error.InvalidOperatingSystemVersion;
 
                     const max_text = range_it.next() orelse return WindowsVersion.Range{
                         .min = min_ver,
-                        .max = default.max,
+                        .max = d_range.max,
                     };
-                    const max_ver = WindowsVersion.nameToTag(max_text) orelse
+                    const max_ver = std.meta.stringToEnum(WindowsVersion, max_text) orelse
                         return error.InvalidOperatingSystemVersion;
 
                     return WindowsVersion.Range{ .min = min_ver, .max = max_ver };
                 }
             };
-            const default = defaultVersionRange(tag);
+            const d_range = VersionRange.default(tag);
             switch (tag) {
-                .freestanding => return Os{ .freestanding = try S.parseNone(version_text) },
-                .ananas => return Os{ .ananas = try S.parseNone(version_text) },
-                .cloudabi => return Os{ .cloudabi = try S.parseNone(version_text) },
-                .dragonfly => return Os{ .dragonfly = try S.parseNone(version_text) },
-                .freebsd => return Os{ .freebsd = try S.parseSemVer(version_text, default.freebsd) },
-                .fuchsia => return Os{ .fuchsia = try S.parseNone(version_text) },
-                .ios => return Os{ .ios = try S.parseNone(version_text) },
-                .kfreebsd => return Os{ .kfreebsd = try S.parseNone(version_text) },
+                .freestanding,
+                .ananas,
+                .cloudabi,
+                .dragonfly,
+                .fuchsia,
+                .ios,
+                .kfreebsd,
+                .lv2,
+                .solaris,
+                .haiku,
+                .minix,
+                .rtems,
+                .nacl,
+                .cnk,
+                .aix,
+                .cuda,
+                .nvcl,
+                .amdhsa,
+                .ps4,
+                .elfiamcu,
+                .tvos,
+                .watchos,
+                .mesa3d,
+                .contiki,
+                .amdpal,
+                .hermit,
+                .hurd,
+                .wasi,
+                .emscripten,
+                .uefi,
+                .other,
+                => return Os{
+                    .tag = tag,
+                    .version_range = .{ .none = try S.parseNone(version_text) },
+                },
+
+                .freebsd,
+                .macosx,
+                .netbsd,
+                .openbsd,
+                => return Os{
+                    .tag = tag,
+                    .version_range = .{ .semver = try S.parseSemVer(version_text, d_range.semver) },
+                },
+
                 .linux => return Os{
-                    .linux = .{
-                        .range = try S.parseSemVer(version_text, default.linux.range),
-                        .glibc = default.linux.glibc,
+                    .tag = tag,
+                    .version_range = .{
+                        .linux = .{
+                            .range = try S.parseSemVer(version_text, d_range.linux.range),
+                            .glibc = d_range.linux.glibc,
+                        },
                     },
                 },
-                .lv2 => return Os{ .lv2 = try S.parseNone(version_text) },
-                .macosx => return Os{ .macosx = try S.parseSemVer(version_text, default.macosx) },
-                .netbsd => return Os{ .netbsd = try S.parseSemVer(version_text, default.netbsd) },
-                .openbsd => return Os{ .openbsd = try S.parseSemVer(version_text, default.openbsd) },
-                .solaris => return Os{ .solaris = try S.parseNone(version_text) },
-                .windows => return Os{ .windows = try S.parseWindows(version_text, default.windows) },
-                .haiku => return Os{ .haiku = try S.parseNone(version_text) },
-                .minix => return Os{ .minix = try S.parseNone(version_text) },
-                .rtems => return Os{ .rtems = try S.parseNone(version_text) },
-                .nacl => return Os{ .nacl = try S.parseNone(version_text) },
-                .cnk => return Os{ .cnk = try S.parseNone(version_text) },
-                .aix => return Os{ .aix = try S.parseNone(version_text) },
-                .cuda => return Os{ .cuda = try S.parseNone(version_text) },
-                .nvcl => return Os{ .nvcl = try S.parseNone(version_text) },
-                .amdhsa => return Os{ .amdhsa = try S.parseNone(version_text) },
-                .ps4 => return Os{ .ps4 = try S.parseNone(version_text) },
-                .elfiamcu => return Os{ .elfiamcu = try S.parseNone(version_text) },
-                .tvos => return Os{ .tvos = try S.parseNone(version_text) },
-                .watchos => return Os{ .watchos = try S.parseNone(version_text) },
-                .mesa3d => return Os{ .mesa3d = try S.parseNone(version_text) },
-                .contiki => return Os{ .contiki = try S.parseNone(version_text) },
-                .amdpal => return Os{ .amdpal = try S.parseNone(version_text) },
-                .hermit => return Os{ .hermit = try S.parseNone(version_text) },
-                .hurd => return Os{ .hurd = try S.parseNone(version_text) },
-                .wasi => return Os{ .wasi = try S.parseNone(version_text) },
-                .emscripten => return Os{ .emscripten = try S.parseNone(version_text) },
-                .uefi => return Os{ .uefi = try S.parseNone(version_text) },
-                .other => return Os{ .other = try S.parseNone(version_text) },
+
+                .windows => return Os{
+                    .tag = tag,
+                    .version_range = .{ .windows = try S.parseWindows(version_text, d_range.windows) },
+                },
             }
         }
 
-        pub fn nameToTag(name: []const u8) ?@TagType(Os) {
-            const info = @typeInfo(Os);
-            inline for (info.Union.fields) |field| {
-                if (mem.eql(u8, name, field.name)) {
-                    return @field(Os, field.name);
-                }
-            }
-            return null;
+        pub fn defaultVersionRange(tag: Tag) Os {
+            return .{
+                .tag = tag,
+                .version_range = VersionRange.default(tag),
+            };
         }
     };
 
@@ -339,11 +366,10 @@ pub const Target = struct {
         macabi,
 
         pub fn default(arch: Cpu.Arch, target_os: Os) Abi {
-            switch (arch) {
-                .wasm32, .wasm64 => return .musl,
-                else => {},
+            if (arch.isWasm()) {
+                return .musl;
             }
-            switch (target_os) {
+            switch (target_os.tag) {
                 .freestanding,
                 .ananas,
                 .cloudabi,
@@ -388,37 +414,16 @@ pub const Target = struct {
             }
         }
 
-        pub fn nameToTag(text: []const u8) ?Abi {
-            const info = @typeInfo(Abi);
-            inline for (info.Enum.fields) |field| {
-                if (mem.eql(u8, text, field.name)) {
-                    return @field(Abi, field.name);
-                }
-            }
-            return null;
-        }
-
-        pub fn parse(text: []const u8, os: *Os) !Abi {
-            var it = mem.separate(text, ".");
-            const tag = nameToTag(it.next().?) orelse return error.UnknownApplicationBinaryInterface;
-            const version_text = it.rest();
-            if (version_text.len != 0) {
-                if (@as(@TagType(Os), os.*) == .linux and tag.isGnu()) {
-                    os.linux.glibc = Version.parse(version_text) catch |err| switch (err) {
-                        error.Overflow => return error.InvalidGlibcVersion,
-                        error.InvalidCharacter => return error.InvalidGlibcVersion,
-                        error.InvalidVersion => return error.InvalidGlibcVersion,
-                    };
-                } else {
-                    return error.InvalidAbiVersion;
-                }
-            }
-            return tag;
-        }
-
         pub fn isGnu(abi: Abi) bool {
             return switch (abi) {
                 .gnu, .gnuabin32, .gnuabi64, .gnueabi, .gnueabihf, .gnux32 => true,
+                else => false,
+            };
+        }
+
+        pub fn isMusl(abi: Abi) bool {
+            return switch (abi) {
+                .musl, .musleabi, .musleabihf => true,
                 else => false,
             };
         }
@@ -909,15 +914,15 @@ pub const Target = struct {
     /// TODO add OS version ranges and glibc version
     pub fn zigTriple(self: Target, allocator: *mem.Allocator) ![]u8 {
         return std.fmt.allocPrint(allocator, "{}-{}-{}", .{
-            @tagName(self.getArch()),
-            @tagName(self.os),
+            @tagName(self.cpu.arch),
+            @tagName(self.os.tag),
             @tagName(self.abi),
         });
     }
 
     /// Returned slice must be freed by the caller.
     pub fn vcpkgTriplet(allocator: *mem.Allocator, target: Target, linkage: std.build.VcpkgLinkage) ![]const u8 {
-        const arch = switch (target.getArch()) {
+        const arch = switch (target.cpu.arch) {
             .i386 => "x86",
             .x86_64 => "x64",
 
@@ -957,16 +962,16 @@ pub const Target = struct {
 
     pub fn zigTripleNoSubArch(self: Target, allocator: *mem.Allocator) ![]u8 {
         return std.fmt.allocPrint(allocator, "{}-{}-{}", .{
-            @tagName(self.getArch()),
-            @tagName(self.os),
+            @tagName(self.cpu.arch),
+            @tagName(self.os.tag),
             @tagName(self.abi),
         });
     }
 
     pub fn linuxTriple(self: Target, allocator: *mem.Allocator) ![]u8 {
         return std.fmt.allocPrint(allocator, "{}-{}-{}", .{
-            @tagName(self.getArch()),
-            @tagName(self.os),
+            @tagName(self.cpu.arch),
+            @tagName(self.os.tag),
             @tagName(self.abi),
         });
     }
@@ -1017,11 +1022,28 @@ pub const Target = struct {
         diags.arch = arch;
 
         const os_name = it.next() orelse return error.MissingOperatingSystem;
-        var os = try Os.parse(os_name); // var because Abi.parse can update linux.glibc version
+        var os = try Os.parse(os_name);
         diags.os = os;
 
-        const abi_name = it.next();
-        const abi = if (abi_name) |n| try Abi.parse(n, &os) else Abi.default(arch, os);
+        const opt_abi_text = it.next();
+        const abi = if (opt_abi_text) |abi_text| blk: {
+            var abi_it = mem.separate(abi_text, ".");
+            const abi = std.meta.stringToEnum(Abi, abi_it.next().?) orelse
+                return error.UnknownApplicationBinaryInterface;
+            const abi_ver_text = abi_it.rest();
+            if (abi_ver_text.len != 0) {
+                if (os.tag == .linux and abi.isGnu()) {
+                    os.version_range.linux.glibc = Version.parse(abi_ver_text) catch |err| switch (err) {
+                        error.Overflow => return error.InvalidAbiVersion,
+                        error.InvalidCharacter => return error.InvalidAbiVersion,
+                        error.InvalidVersion => return error.InvalidAbiVersion,
+                    };
+                } else {
+                    return error.InvalidAbiVersion;
+                }
+            }
+            break :blk abi;
+        } else Abi.default(arch, os);
         diags.abi = abi;
 
         if (it.next() != null) return error.UnexpectedExtraField;
@@ -1130,25 +1152,6 @@ pub const Target = struct {
         }
     }
 
-    /// Deprecated; access the `os` field directly.
-    pub fn getOs(self: Target) @TagType(Os) {
-        return self.os;
-    }
-
-    /// Deprecated; access the `cpu` field directly.
-    pub fn getCpu(self: Target) Cpu {
-        return self.cpu;
-    }
-
-    /// Deprecated; access the `abi` field directly.
-    pub fn getAbi(self: Target) Abi {
-        return self.abi;
-    }
-
-    pub fn getArch(self: Target) Cpu.Arch {
-        return self.cpu.arch;
-    }
-
     pub fn getObjectFormat(self: Target) ObjectFormat {
         if (self.isWindows() or self.isUefi()) {
             return .coff;
@@ -1170,28 +1173,25 @@ pub const Target = struct {
     }
 
     pub fn isMusl(self: Target) bool {
-        return switch (self.abi) {
-            .musl, .musleabi, .musleabihf => true,
-            else => false,
-        };
+        return self.abi.isMusl();
     }
 
     pub fn isDarwin(self: Target) bool {
-        return switch (self.os) {
+        return switch (self.os.tag) {
             .ios, .macosx, .watchos, .tvos => true,
             else => false,
         };
     }
 
     pub fn isWindows(self: Target) bool {
-        return switch (self.os) {
+        return switch (self.os.tag) {
             .windows => true,
             else => false,
         };
     }
 
     pub fn isLinux(self: Target) bool {
-        return switch (self.os) {
+        return switch (self.os.tag) {
             .linux => true,
             else => false,
         };
@@ -1205,38 +1205,39 @@ pub const Target = struct {
     }
 
     pub fn isDragonFlyBSD(self: Target) bool {
-        return switch (self.os) {
+        return switch (self.os.tag) {
             .dragonfly => true,
             else => false,
         };
     }
 
     pub fn isUefi(self: Target) bool {
-        return switch (self.os) {
+        return switch (self.os.tag) {
             .uefi => true,
             else => false,
         };
     }
 
     pub fn isWasm(self: Target) bool {
-        return switch (self.getArch()) {
-            .wasm32, .wasm64 => true,
-            else => false,
-        };
+        return self.cpu.arch.isWasm();
     }
 
     pub fn isFreeBSD(self: Target) bool {
-        return switch (self.os) {
+        return switch (self.os.tag) {
             .freebsd => true,
             else => false,
         };
     }
 
     pub fn isNetBSD(self: Target) bool {
-        return switch (self.os) {
+        return switch (self.os.tag) {
             .netbsd => true,
             else => false,
         };
+    }
+
+    pub fn isGnuLibC(self: Target) bool {
+        return self.os.tag == .linux and self.abi.isGnu();
     }
 
     pub fn wantSharedLibSymLinks(self: Target) bool {
@@ -1248,7 +1249,7 @@ pub const Target = struct {
     }
 
     pub fn getArchPtrBitWidth(self: Target) u32 {
-        switch (self.getArch()) {
+        switch (self.cpu.arch) {
             .avr,
             .msp430,
             => return 16,
@@ -1323,8 +1324,8 @@ pub const Target = struct {
         if (@as(@TagType(Target), self) == .Native) return .native;
 
         // If the target OS matches the host OS, we can use QEMU to emulate a foreign architecture.
-        if (self.os == builtin.os) {
-            return switch (self.getArch()) {
+        if (self.os.tag == builtin.os.tag) {
+            return switch (self.cpu.arch) {
                 .aarch64 => Executor{ .qemu = "qemu-aarch64" },
                 .aarch64_be => Executor{ .qemu = "qemu-aarch64_be" },
                 .arm => Executor{ .qemu = "qemu-arm" },
@@ -1381,13 +1382,10 @@ pub const Target = struct {
     }
 
     pub fn hasDynamicLinker(self: Target) bool {
-        switch (self.getArch()) {
-            .wasm32,
-            .wasm64,
-            => return false,
-            else => {},
+        if (self.cpu.arch.isWasm()) {
+            return false;
         }
-        switch (self.os) {
+        switch (self.os.tag) {
             .freestanding,
             .ios,
             .tvos,
@@ -1424,7 +1422,7 @@ pub const Target = struct {
             defer result.deinit();
 
             var is_arm = false;
-            switch (self.getArch()) {
+            switch (self.cpu.arch) {
                 .arm, .thumb => {
                     try result.append("arm");
                     is_arm = true;
@@ -1442,11 +1440,11 @@ pub const Target = struct {
             return result.toOwnedSlice();
         }
 
-        switch (self.os) {
+        switch (self.os.tag) {
             .freebsd => return mem.dupeZ(a, u8, "/libexec/ld-elf.so.1"),
             .netbsd => return mem.dupeZ(a, u8, "/libexec/ld.elf_so"),
             .dragonfly => return mem.dupeZ(a, u8, "/libexec/ld-elf.so.2"),
-            .linux => switch (self.getArch()) {
+            .linux => switch (self.cpu.arch) {
                 .i386,
                 .sparc,
                 .sparcel,
@@ -1539,7 +1537,7 @@ test "Target.parse" {
             .cpu_features = "x86_64-sse-sse2-avx-cx8",
         });
 
-        std.testing.expect(target.os == .linux);
+        std.testing.expect(target.os.tag == .linux);
         std.testing.expect(target.abi == .gnu);
         std.testing.expect(target.cpu.arch == .x86_64);
         std.testing.expect(!Target.x86.featureSetHas(target.cpu.features, .sse));
@@ -1554,10 +1552,29 @@ test "Target.parse" {
             .cpu_features = "generic+v8a",
         });
 
-        std.testing.expect(target.os == .linux);
+        std.testing.expect(target.os.tag == .linux);
         std.testing.expect(target.abi == .musleabihf);
         std.testing.expect(target.cpu.arch == .arm);
         std.testing.expect(target.cpu.model == &Target.arm.cpu.generic);
         std.testing.expect(Target.arm.featureSetHas(target.cpu.features, .v8a));
+    }
+    {
+        const target = try Target.parse(.{
+            .arch_os_abi = "aarch64-linux.3.10...4.4.1-gnu.2.27",
+            .cpu_features = "generic+v8a",
+        });
+
+        std.testing.expect(target.cpu.arch == .aarch64);
+        std.testing.expect(target.os.tag == .linux);
+        std.testing.expect(target.os.version_range.linux.min.major == 3);
+        std.testing.expect(target.os.version_range.linux.min.minor == 10);
+        std.testing.expect(target.os.version_range.linux.min.patch == 0);
+        std.testing.expect(target.os.version_range.linux.max.major == 4);
+        std.testing.expect(target.os.version_range.linux.max.minor == 4);
+        std.testing.expect(target.os.version_range.linux.max.patch == 1);
+        std.testing.expect(target.os.version_range.linux.glibc.major == 2);
+        std.testing.expect(target.os.version_range.linux.glibc.minor == 27);
+        std.testing.expect(target.os.version_range.linux.glibc.patch == 0);
+        std.testing.expect(target.abi == .gnu);
     }
 }

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -147,7 +147,6 @@ pub const Target = struct {
                     .cloudabi,
                     .dragonfly,
                     .fuchsia,
-                    .ios,
                     .kfreebsd,
                     .lv2,
                     .solaris,
@@ -162,8 +161,6 @@ pub const Target = struct {
                     .amdhsa,
                     .ps4,
                     .elfiamcu,
-                    .tvos,
-                    .watchos,
                     .mesa3d,
                     .contiki,
                     .amdpal,
@@ -185,6 +182,24 @@ pub const Target = struct {
                         .semver = .{
                             .min = .{ .major = 10, .minor = 13 },
                             .max = .{ .major = 10, .minor = 15, .patch = 3 },
+                        },
+                    },
+                    .ios => return .{
+                        .semver = .{
+                            .min = .{ .major = 12, .minor = 0 },
+                            .max = .{ .major = 13, .minor = 4, .patch = 0 },
+                        },
+                    },
+                    .watchos => return .{
+                        .semver = .{
+                            .min = .{ .major = 6, .minor = 0 },
+                            .max = .{ .major = 6, .minor = 2, .patch = 0 },
+                        },
+                    },
+                    .tvos => return .{
+                        .semver = .{
+                            .min = .{ .major = 13, .minor = 0 },
+                            .max = .{ .major = 13, .minor = 4, .patch = 0 },
                         },
                     },
                     .netbsd => return .{

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -91,6 +91,7 @@ pub const Target = struct {
             win10_rs4 = 0x0A000005,
             win10_rs5 = 0x0A000006,
             win10_19h1 = 0x0A000007,
+            _,
 
             pub const Range = struct {
                 min: WindowsVersion,

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1215,8 +1215,8 @@ pub const Target = struct {
             .uefi,
             .windows,
             .emscripten,
-            .other,
             .wasi,
+            .other,
             => return null,
 
             // TODO go over each item in this list and either move it to the above list, or

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -1,5 +1,3 @@
-const builtin = @import("builtin");
-const TypeId = builtin.TypeId;
 const std = @import("std.zig");
 
 pub const LeakCountAllocator = @import("testing/leak_count_allocator.zig").LeakCountAllocator;
@@ -65,16 +63,16 @@ pub fn expectEqual(expected: var, actual: @TypeOf(expected)) void {
 
         .Pointer => |pointer| {
             switch (pointer.size) {
-                builtin.TypeInfo.Pointer.Size.One,
-                builtin.TypeInfo.Pointer.Size.Many,
-                builtin.TypeInfo.Pointer.Size.C,
+                .One,
+                .Many,
+                .C,
                 => {
                     if (actual != expected) {
                         std.debug.panic("expected {*}, found {*}", .{ expected, actual });
                     }
                 },
 
-                builtin.TypeInfo.Pointer.Size.Slice => {
+                .Slice => {
                     if (actual.ptr != expected.ptr) {
                         std.debug.panic("expected slice ptr {}, found {}", .{ expected.ptr, actual.ptr });
                     }

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -1,5 +1,5 @@
-const builtin = @import("builtin");
 const std = @import("std.zig");
+const builtin = std.builtin;
 const assert = std.debug.assert;
 const testing = std.testing;
 const os = std.os;
@@ -7,10 +7,12 @@ const math = std.math;
 
 pub const epoch = @import("time/epoch.zig");
 
+const is_windows = std.Target.current.os.tag == .windows;
+
 /// Spurious wakeups are possible and no precision of timing is guaranteed.
 /// TODO integrate with evented I/O
 pub fn sleep(nanoseconds: u64) void {
-    if (builtin.os == .windows) {
+    if (is_windows) {
         const ns_per_ms = ns_per_s / ms_per_s;
         const big_ms_from_ns = nanoseconds / ns_per_ms;
         const ms = math.cast(os.windows.DWORD, big_ms_from_ns) catch math.maxInt(os.windows.DWORD);
@@ -31,7 +33,7 @@ pub fn timestamp() u64 {
 /// Get the posix timestamp, UTC, in milliseconds
 /// TODO audit this function. is it possible to return an error?
 pub fn milliTimestamp() u64 {
-    if (builtin.os == .windows) {
+    if (is_windows) {
         //FileTime has a granularity of 100 nanoseconds
         //  and uses the NTFS/Windows epoch
         var ft: os.windows.FILETIME = undefined;
@@ -42,7 +44,7 @@ pub fn milliTimestamp() u64 {
         const ft64 = (@as(u64, ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
         return @divFloor(ft64, hns_per_ms) - -epoch_adj;
     }
-    if (builtin.os == .wasi and !builtin.link_libc) {
+    if (builtin.os.tag == .wasi and !builtin.link_libc) {
         var ns: os.wasi.timestamp_t = undefined;
 
         // TODO: Verify that precision is ignored
@@ -102,7 +104,7 @@ pub const Timer = struct {
     ///if we used resolution's value when performing the
     ///  performance counter calc on windows/darwin, it would
     ///  be less precise
-    frequency: switch (builtin.os) {
+    frequency: switch (builtin.os.tag) {
         .windows => u64,
         .macosx, .ios, .tvos, .watchos => os.darwin.mach_timebase_info_data,
         else => void,
@@ -127,7 +129,7 @@ pub const Timer = struct {
     pub fn start() Error!Timer {
         var self: Timer = undefined;
 
-        if (builtin.os == .windows) {
+        if (is_windows) {
             self.frequency = os.windows.QueryPerformanceFrequency();
             self.resolution = @divFloor(ns_per_s, self.frequency);
             self.start_time = os.windows.QueryPerformanceCounter();
@@ -172,7 +174,7 @@ pub const Timer = struct {
     }
 
     fn clockNative() u64 {
-        if (builtin.os == .windows) {
+        if (is_windows) {
             return os.windows.QueryPerformanceCounter();
         }
         if (comptime std.Target.current.isDarwin()) {
@@ -184,7 +186,7 @@ pub const Timer = struct {
     }
 
     fn nativeDurationToNanos(self: Timer, duration: u64) u64 {
-        if (builtin.os == .windows) {
+        if (is_windows) {
             return @divFloor(duration * ns_per_s, self.frequency);
         }
         if (comptime std.Target.current.isDarwin()) {

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -6,11 +6,8 @@ pub const parseStringLiteral = @import("zig/parse_string_literal.zig").parseStri
 pub const render = @import("zig/render.zig").render;
 pub const ast = @import("zig/ast.zig");
 pub const system = @import("zig/system.zig");
+pub const CrossTarget = @import("zig/cross_target.zig").CrossTarget;
 
-test "std.zig tests" {
-    _ = @import("zig/ast.zig");
-    _ = @import("zig/parse.zig");
-    _ = @import("zig/render.zig");
-    _ = @import("zig/tokenizer.zig");
-    _ = @import("zig/parse_string_literal.zig");
+test "" {
+    @import("std").meta.refAllDecls(@This());
 }

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -1,0 +1,766 @@
+const std = @import("../std.zig");
+const assert = std.debug.assert;
+const Target = std.Target;
+const mem = std.mem;
+
+/// Contains all the same data as `Target`, additionally introducing the concept of "the native target".
+/// The purpose of this abstraction is to provide meaningful and unsurprising defaults.
+pub const CrossTarget = struct {
+    /// `null` means native.
+    cpu_arch: ?Target.Cpu.Arch = null,
+
+    /// If `cpu_arch` is native, `null` means native. Otherwise it means baseline.
+    /// If this is non-null, `cpu_arch` must be specified.
+    cpu_model: ?*const Target.Cpu.Model = null,
+
+    /// Sparse set of CPU features to add to the set from `cpu_model`.
+    /// If this is non-empty, `cpu_arch` must be specified.
+    cpu_features_add: Target.Cpu.Feature.Set = Target.Cpu.Feature.Set.empty,
+
+    /// Sparse set of CPU features to remove from the set from `cpu_model`.
+    /// If this is non-empty, `cpu_arch` must be specified.
+    cpu_features_sub: Target.Cpu.Feature.Set = Target.Cpu.Feature.Set.empty,
+
+    /// `null` means native.
+    os_tag: ?Target.Os.Tag = null,
+
+    /// `null` means the default version range for `os_tag`. If `os_tag` is `null` (native)
+    /// then `null` for this field means native.
+    os_version_min: ?OsVersion = null,
+
+    /// When cross compiling, `null` means default (latest known OS version).
+    /// When `os_tag` is native, `null` means equal to the native OS version.
+    os_version_max: ?OsVersion = null,
+
+    /// `null` means the native C ABI, if `os_tag` is native, otherwise it means the default C ABI.
+    abi: ?Target.Abi = null,
+
+    /// `null` means default when cross compiling, or native when os_tag is native.
+    /// If `isGnuLibC()` is `false`, this must be `null` and is ignored.
+    glibc_version: ?SemVer = null,
+
+    pub const OsVersion = union(enum) {
+        none: void,
+        semver: SemVer,
+        windows: Target.Os.WindowsVersion,
+    };
+
+    pub const SemVer = std.builtin.Version;
+
+    pub fn fromTarget(target: Target) CrossTarget {
+        var result: CrossTarget = .{
+            .cpu_arch = target.cpu.arch,
+            .cpu_model = target.cpu.model,
+            .os_tag = target.os.tag,
+            .os_version_min = undefined,
+            .os_version_max = undefined,
+            .abi = target.abi,
+            .glibc_version = if (target.isGnuLibC())
+                target.os.version_range.linux.glibc
+            else
+                null,
+        };
+        result.updateOsVersionRange(target.os);
+
+        const all_features = target.cpu.arch.allFeaturesList();
+        var cpu_model_set = target.cpu.model.features;
+        cpu_model_set.populateDependencies(all_features);
+        {
+            // The "add" set is the full set with the CPU Model set removed.
+            const add_set = &result.cpu_features_add;
+            add_set.* = target.cpu.features;
+            add_set.removeFeatureSet(cpu_model_set);
+        }
+        {
+            // The "sub" set is the features that are on in CPU Model set and off in the full set.
+            const sub_set = &result.cpu_features_sub;
+            sub_set.* = cpu_model_set;
+            sub_set.removeFeatureSet(target.cpu.features);
+        }
+        return result;
+    }
+
+    fn updateOsVersionRange(self: *CrossTarget, os: Target.Os) void {
+        switch (os.tag) {
+            .freestanding,
+            .ananas,
+            .cloudabi,
+            .dragonfly,
+            .fuchsia,
+            .ios,
+            .kfreebsd,
+            .lv2,
+            .solaris,
+            .haiku,
+            .minix,
+            .rtems,
+            .nacl,
+            .cnk,
+            .aix,
+            .cuda,
+            .nvcl,
+            .amdhsa,
+            .ps4,
+            .elfiamcu,
+            .tvos,
+            .watchos,
+            .mesa3d,
+            .contiki,
+            .amdpal,
+            .hermit,
+            .hurd,
+            .wasi,
+            .emscripten,
+            .uefi,
+            .other,
+            => {
+                self.os_version_min = .{ .none = {} };
+                self.os_version_max = .{ .none = {} };
+            },
+
+            .freebsd,
+            .macosx,
+            .netbsd,
+            .openbsd,
+            => {
+                self.os_version_min = .{ .semver = os.version_range.semver.min };
+                self.os_version_max = .{ .semver = os.version_range.semver.max };
+            },
+
+            .linux => {
+                self.os_version_min = .{ .semver = os.version_range.linux.range.min };
+                self.os_version_max = .{ .semver = os.version_range.linux.range.max };
+            },
+
+            .windows => {
+                self.os_version_min = .{ .windows = os.version_range.windows.min };
+                self.os_version_max = .{ .windows = os.version_range.windows.max };
+            },
+        }
+    }
+
+    pub fn toTarget(self: CrossTarget) Target {
+        return .{
+            .cpu = self.getCpu(),
+            .os = self.getOs(),
+            .abi = self.getAbi(),
+        };
+    }
+
+    pub const ParseOptions = struct {
+        /// This is sometimes called a "triple". It looks roughly like this:
+        ///     riscv64-linux-musl
+        /// The fields are, respectively:
+        /// * CPU Architecture
+        /// * Operating System (and optional version range)
+        /// * C ABI (optional, with optional glibc version)
+        /// The string "native" can be used for CPU architecture as well as Operating System.
+        /// If the CPU Architecture is specified as "native", then the Operating System and C ABI may be omitted.
+        arch_os_abi: []const u8 = "native",
+
+        /// Looks like "name+a+b-c-d+e", where "name" is a CPU Model name, "a", "b", and "e"
+        /// are examples of CPU features to add to the set, and "c" and "d" are examples of CPU features
+        /// to remove from the set.
+        /// The following special strings are recognized for CPU Model name:
+        /// * "baseline" - The "default" set of CPU features for cross-compiling. A conservative set
+        ///                of features that is expected to be supported on most available hardware.
+        /// * "native"   - The native CPU model is to be detected when compiling.
+        /// If this field is not provided (`null`), then the value will depend on the
+        /// parsed CPU Architecture. If native, then this will be "native". Otherwise, it will be "baseline".
+        cpu_features: ?[]const u8 = null,
+
+        /// If this is provided, the function will populate some information about parsing failures,
+        /// so that user-friendly error messages can be delivered.
+        diagnostics: ?*Diagnostics = null,
+
+        pub const Diagnostics = struct {
+            /// If the architecture was determined, this will be populated.
+            arch: ?Target.Cpu.Arch = null,
+
+            /// If the OS tag was determined, this will be populated.
+            os_tag: ?Target.Os.Tag = null,
+
+            /// If the ABI was determined, this will be populated.
+            abi: ?Target.Abi = null,
+
+            /// If the CPU name was determined, this will be populated.
+            cpu_name: ?[]const u8 = null,
+
+            /// If error.UnknownCpuFeature is returned, this will be populated.
+            unknown_feature_name: ?[]const u8 = null,
+        };
+    };
+
+    pub fn parse(args: ParseOptions) !CrossTarget {
+        var dummy_diags: ParseOptions.Diagnostics = undefined;
+        const diags = args.diagnostics orelse &dummy_diags;
+
+        // Start with everything initialized to default values.
+        var result: CrossTarget = .{};
+
+        var it = mem.separate(args.arch_os_abi, "-");
+        const arch_name = it.next().?;
+        const arch_is_native = mem.eql(u8, arch_name, "native");
+        if (!arch_is_native) {
+            result.cpu_arch = std.meta.stringToEnum(Target.Cpu.Arch, arch_name) orelse
+                return error.UnknownArchitecture;
+        }
+        const arch = result.getCpuArch();
+        diags.arch = arch;
+
+        if (it.next()) |os_text| {
+            try parseOs(&result, diags, os_text);
+        } else if (!arch_is_native) {
+            return error.MissingOperatingSystem;
+        }
+
+        const opt_abi_text = it.next();
+        if (opt_abi_text) |abi_text| {
+            var abi_it = mem.separate(abi_text, ".");
+            const abi = std.meta.stringToEnum(Target.Abi, abi_it.next().?) orelse
+                return error.UnknownApplicationBinaryInterface;
+            diags.abi = abi;
+
+            const abi_ver_text = abi_it.rest();
+            if (abi_it.next() != null) {
+                if (result.isGnuLibC()) {
+                    result.glibc_version = SemVer.parse(abi_ver_text) catch |err| switch (err) {
+                        error.Overflow => return error.InvalidAbiVersion,
+                        error.InvalidCharacter => return error.InvalidAbiVersion,
+                        error.InvalidVersion => return error.InvalidAbiVersion,
+                    };
+                } else {
+                    return error.InvalidAbiVersion;
+                }
+            }
+        }
+
+        if (it.next() != null) return error.UnexpectedExtraField;
+
+        if (args.cpu_features) |cpu_features| {
+            const all_features = arch.allFeaturesList();
+            var index: usize = 0;
+            while (index < cpu_features.len and
+                cpu_features[index] != '+' and
+                cpu_features[index] != '-')
+            {
+                index += 1;
+            }
+            const cpu_name = cpu_features[0..index];
+            diags.cpu_name = cpu_name;
+
+            const add_set = &result.cpu_features_add;
+            const sub_set = &result.cpu_features_sub;
+            if (mem.eql(u8, cpu_name, "native")) {
+                result.cpu_model = null;
+            } else if (mem.eql(u8, cpu_name, "baseline")) {
+                result.cpu_model = Target.Cpu.Model.baseline(arch);
+            } else {
+                result.cpu_model = try arch.parseCpuModel(cpu_name);
+            }
+
+            while (index < cpu_features.len) {
+                const op = cpu_features[index];
+                const set = switch (op) {
+                    '+' => add_set,
+                    '-' => sub_set,
+                    else => unreachable,
+                };
+                index += 1;
+                const start = index;
+                while (index < cpu_features.len and
+                    cpu_features[index] != '+' and
+                    cpu_features[index] != '-')
+                {
+                    index += 1;
+                }
+                const feature_name = cpu_features[start..index];
+                for (all_features) |feature, feat_index_usize| {
+                    const feat_index = @intCast(Target.Cpu.Feature.Set.Index, feat_index_usize);
+                    if (mem.eql(u8, feature_name, feature.name)) {
+                        set.addFeature(feat_index);
+                        break;
+                    }
+                } else {
+                    diags.unknown_feature_name = feature_name;
+                    return error.UnknownCpuFeature;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    pub fn getCpu(self: CrossTarget) Target.Cpu {
+        if (self.cpu_arch) |arch| {
+            if (self.cpu_model) |model| {
+                var adjusted_model = model.toCpu(arch);
+                self.updateCpuFeatures(&adjusted_model.features);
+                return adjusted_model;
+            } else {
+                var adjusted_baseline = Target.Cpu.baseline(arch);
+                self.updateCpuFeatures(&adjusted_baseline.features);
+                return adjusted_baseline;
+            }
+        } else {
+            assert(self.cpu_model == null);
+            assert(self.cpu_features_sub.isEmpty());
+            assert(self.cpu_features_add.isEmpty());
+            // This works when doing `zig build` because Zig generates a build executable using
+            // native CPU model & features. However this will not be accurate otherwise, and
+            // will need to be integrated with `std.zig.system.NativeTargetInfo.detect`.
+            return Target.current.cpu;
+        }
+    }
+
+    pub fn getCpuArch(self: CrossTarget) Target.Cpu.Arch {
+        return self.cpu_arch orelse Target.current.cpu.arch;
+    }
+
+    pub fn getCpuModel(self: CrossTarget) *const Target.Cpu.Model {
+        if (self.cpu_model) |cpu_model| return cpu_model;
+        return self.getCpu().model;
+    }
+
+    pub fn getCpuFeatures(self: CrossTarget) Target.Cpu.Feature.Set {
+        return self.getCpu().features;
+    }
+
+    pub fn getOs(self: CrossTarget) Target.Os {
+        // `Target.current.os` works when doing `zig build` because Zig generates a build executable using
+        // native OS version range. However this will not be accurate otherwise, and
+        // will need to be integrated with `std.zig.system.NativeTargetInfo.detect`.
+        var adjusted_os = if (self.os_tag) |os_tag| Target.Os.defaultVersionRange(os_tag) else Target.current.os;
+
+        if (self.os_version_min) |min| switch (min) {
+            .none => {},
+            .semver => |semver| switch (self.getOsTag()) {
+                .linux => adjusted_os.version_range.linux.range.min = semver,
+                else => adjusted_os.version_range.semver.min = semver,
+            },
+            .windows => |win_ver| adjusted_os.version_range.windows.min = win_ver,
+        };
+
+        if (self.os_version_max) |max| switch (max) {
+            .none => {},
+            .semver => |semver| switch (self.getOsTag()) {
+                .linux => adjusted_os.version_range.linux.range.max = semver,
+                else => adjusted_os.version_range.semver.max = semver,
+            },
+            .windows => |win_ver| adjusted_os.version_range.windows.max = win_ver,
+        };
+
+        if (self.glibc_version) |glibc| {
+            assert(self.isGnuLibC());
+            adjusted_os.version_range.linux.glibc = glibc;
+        }
+
+        return adjusted_os;
+    }
+
+    pub fn getOsTag(self: CrossTarget) Target.Os.Tag {
+        return self.os_tag orelse Target.current.os.tag;
+    }
+
+    pub fn getOsVersionMin(self: CrossTarget) OsVersion {
+        if (self.os_version_min) |version_min| return version_min;
+        var tmp: CrossTarget = undefined;
+        tmp.updateOsVersionRange(self.getOs());
+        return tmp.os_version_min.?;
+    }
+
+    pub fn getOsVersionMax(self: CrossTarget) OsVersion {
+        if (self.os_version_max) |version_max| return version_max;
+        var tmp: CrossTarget = undefined;
+        tmp.updateOsVersionRange(self.getOs());
+        return tmp.os_version_max.?;
+    }
+
+    pub fn getAbi(self: CrossTarget) Target.Abi {
+        if (self.abi) |abi| return abi;
+
+        if (self.isNativeOs()) {
+            // This works when doing `zig build` because Zig generates a build executable using
+            // native CPU model & features. However this will not be accurate otherwise, and
+            // will need to be integrated with `std.zig.system.NativeTargetInfo.detect`.
+            return Target.current.abi;
+        }
+
+        return Target.Abi.default(self.getCpuArch(), self.getOs());
+    }
+
+    pub fn isFreeBSD(self: CrossTarget) bool {
+        return self.getOsTag() == .freebsd;
+    }
+
+    pub fn isDarwin(self: CrossTarget) bool {
+        return self.getOsTag().isDarwin();
+    }
+
+    pub fn isNetBSD(self: CrossTarget) bool {
+        return self.getOsTag() == .netbsd;
+    }
+
+    pub fn isUefi(self: CrossTarget) bool {
+        return self.getOsTag() == .uefi;
+    }
+
+    pub fn isDragonFlyBSD(self: CrossTarget) bool {
+        return self.getOsTag() == .dragonfly;
+    }
+
+    pub fn isLinux(self: CrossTarget) bool {
+        return self.getOsTag() == .linux;
+    }
+
+    pub fn isWindows(self: CrossTarget) bool {
+        return self.getOsTag() == .windows;
+    }
+
+    pub fn oFileExt(self: CrossTarget) [:0]const u8 {
+        return self.getAbi().oFileExt();
+    }
+
+    pub fn exeFileExt(self: CrossTarget) [:0]const u8 {
+        return Target.exeFileExtSimple(self.getCpuArch(), self.getOsTag());
+    }
+
+    pub fn staticLibSuffix(self: CrossTarget) [:0]const u8 {
+        return Target.staticLibSuffix_cpu_arch_abi(self.getCpuArch(), self.getAbi());
+    }
+
+    pub fn dynamicLibSuffix(self: CrossTarget) [:0]const u8 {
+        return self.getOsTag().dynamicLibSuffix();
+    }
+
+    pub fn libPrefix(self: CrossTarget) [:0]const u8 {
+        return Target.libPrefix_cpu_arch_abi(self.getCpuArch(), self.getAbi());
+    }
+
+    pub fn isNativeCpu(self: CrossTarget) bool {
+        return self.cpu_arch == null and self.cpu_model == null and
+            self.cpu_features_sub.isEmpty() and self.cpu_features_add.isEmpty();
+    }
+
+    pub fn isNativeOs(self: CrossTarget) bool {
+        return self.os_tag == null and self.os_version_min == null and self.os_version_max == null;
+    }
+
+    pub fn isNativeAbi(self: CrossTarget) bool {
+        return self.abi == null and self.glibc_version == null;
+    }
+
+    pub fn isNative(self: CrossTarget) bool {
+        return self.isNativeCpu() and self.isNativeOs() and self.isNativeAbi();
+    }
+
+    pub fn zigTriple(self: CrossTarget, allocator: *mem.Allocator) error{OutOfMemory}![:0]u8 {
+        if (self.isNative()) {
+            return mem.dupeZ(allocator, u8, "native");
+        }
+
+        const arch_name = if (self.isNativeCpu()) "native" else @tagName(self.getCpuArch());
+        const os_name = if (self.os_tag) |os_tag| @tagName(os_tag) else "native";
+
+        var result = try std.Buffer.allocPrint(allocator, "{}-{}", .{ arch_name, os_name });
+        defer result.deinit();
+
+        // The zig target syntax does not allow specifying a max os version with no min, so
+        // if either are present, we need the min.
+        if (self.os_version_min != null or self.os_version_max != null) {
+            switch (self.getOsVersionMin()) {
+                .none => {},
+                .semver => |v| try result.print(".{}", .{v}),
+                .windows => |v| try result.print(".{}", .{@tagName(v)}),
+            }
+        }
+        if (self.os_version_max) |max| {
+            switch (max) {
+                .none => {},
+                .semver => |v| try result.print("...{}", .{v}),
+                .windows => |v| try result.print("...{}", .{@tagName(v)}),
+            }
+        }
+
+        if (self.abi) |abi| {
+            try result.print("-{}", .{@tagName(abi)});
+            if (self.glibc_version) |v| {
+                try result.print(".{}", .{v});
+            }
+        } else {
+            assert(self.glibc_version == null);
+        }
+
+        return result.toOwnedSlice();
+    }
+
+    pub fn allocDescription(self: CrossTarget, allocator: *mem.Allocator) ![:0]u8 {
+        // TODO is there anything else worthy of the description that is not
+        // already captured in the triple?
+        return self.zigTriple(allocator);
+    }
+
+    pub fn linuxTriple(self: CrossTarget, allocator: *mem.Allocator) ![:0]u8 {
+        return Target.linuxTripleSimple(allocator, self.getCpuArch(), self.getOsTag(), self.getAbi());
+    }
+
+    pub fn wantSharedLibSymLinks(self: CrossTarget) bool {
+        return self.getOsTag() != .windows;
+    }
+
+    pub const VcpkgLinkage = std.builtin.LinkMode;
+
+    /// Returned slice must be freed by the caller.
+    pub fn vcpkgTriplet(self: CrossTarget, allocator: *mem.Allocator, linkage: VcpkgLinkage) ![:0]u8 {
+        const arch = switch (self.getCpuArch()) {
+            .i386 => "x86",
+            .x86_64 => "x64",
+
+            .arm,
+            .armeb,
+            .thumb,
+            .thumbeb,
+            .aarch64_32,
+            => "arm",
+
+            .aarch64,
+            .aarch64_be,
+            => "arm64",
+
+            else => return error.UnsupportedVcpkgArchitecture,
+        };
+
+        const os = switch (self.getOsTag()) {
+            .windows => "windows",
+            .linux => "linux",
+            .macosx => "macos",
+            else => return error.UnsupportedVcpkgOperatingSystem,
+        };
+
+        const static_suffix = switch (linkage) {
+            .Static => "-static",
+            .Dynamic => "",
+        };
+
+        return std.fmt.allocPrint0(allocator, "{}-{}{}", .{ arch, os, static_suffix });
+    }
+
+    pub const Executor = union(enum) {
+        native,
+        qemu: []const u8,
+        wine: []const u8,
+        wasmtime: []const u8,
+        unavailable,
+    };
+
+    pub fn getExternalExecutor(self: CrossTarget) Executor {
+        const os_tag = self.getOsTag();
+        const cpu_arch = self.getCpuArch();
+
+        // If the target OS matches the host OS, we can use QEMU to emulate a foreign architecture.
+        if (os_tag == Target.current.os.tag) {
+            return switch (cpu_arch) {
+                .aarch64 => Executor{ .qemu = "qemu-aarch64" },
+                .aarch64_be => Executor{ .qemu = "qemu-aarch64_be" },
+                .arm => Executor{ .qemu = "qemu-arm" },
+                .armeb => Executor{ .qemu = "qemu-armeb" },
+                .i386 => Executor{ .qemu = "qemu-i386" },
+                .mips => Executor{ .qemu = "qemu-mips" },
+                .mipsel => Executor{ .qemu = "qemu-mipsel" },
+                .mips64 => Executor{ .qemu = "qemu-mips64" },
+                .mips64el => Executor{ .qemu = "qemu-mips64el" },
+                .powerpc => Executor{ .qemu = "qemu-ppc" },
+                .powerpc64 => Executor{ .qemu = "qemu-ppc64" },
+                .powerpc64le => Executor{ .qemu = "qemu-ppc64le" },
+                .riscv32 => Executor{ .qemu = "qemu-riscv32" },
+                .riscv64 => Executor{ .qemu = "qemu-riscv64" },
+                .s390x => Executor{ .qemu = "qemu-s390x" },
+                .sparc => Executor{ .qemu = "qemu-sparc" },
+                .x86_64 => Executor{ .qemu = "qemu-x86_64" },
+                else => return .unavailable,
+            };
+        }
+
+        switch (os_tag) {
+            .windows => switch (cpu_arch.ptrBitWidth()) {
+                32 => return Executor{ .wine = "wine" },
+                64 => return Executor{ .wine = "wine64" },
+                else => return .unavailable,
+            },
+            .wasi => switch (cpu_arch.ptrBitWidth()) {
+                32 => return Executor{ .wasmtime = "wasmtime" },
+                else => return .unavailable,
+            },
+            else => return .unavailable,
+        }
+    }
+
+    pub fn isGnuLibC(self: CrossTarget) bool {
+        return Target.isGnuLibC_os_tag_abi(self.getOsTag(), self.getAbi());
+    }
+
+    pub fn setGnuLibCVersion(self: CrossTarget, major: u32, minor: u32, patch: u32) void {
+        assert(self.isGnuLibC());
+        self.glibc_version = SemVer{ .major = major, .minor = minor, .patch = patch };
+    }
+
+    fn updateCpuFeatures(self: CrossTarget, set: *Target.Cpu.Feature.Set) void {
+        set.removeFeatureSet(self.cpu_features_sub);
+        set.addFeatureSet(self.cpu_features_add);
+        set.populateDependencies(self.getCpuArch().allFeaturesList());
+        set.removeFeatureSet(self.cpu_features_sub);
+    }
+
+    fn parseOs(result: *CrossTarget, diags: *ParseOptions.Diagnostics, text: []const u8) !void {
+        var it = mem.separate(text, ".");
+        const os_name = it.next().?;
+        const os_is_native = mem.eql(u8, os_name, "native");
+        if (!os_is_native) {
+            result.os_tag = std.meta.stringToEnum(Target.Os.Tag, os_name) orelse
+                return error.UnknownOperatingSystem;
+        }
+        const tag = result.getOsTag();
+        diags.os_tag = tag;
+
+        const version_text = it.rest();
+        if (it.next() == null) return;
+
+        switch (tag) {
+            .freestanding,
+            .ananas,
+            .cloudabi,
+            .dragonfly,
+            .fuchsia,
+            .ios,
+            .kfreebsd,
+            .lv2,
+            .solaris,
+            .haiku,
+            .minix,
+            .rtems,
+            .nacl,
+            .cnk,
+            .aix,
+            .cuda,
+            .nvcl,
+            .amdhsa,
+            .ps4,
+            .elfiamcu,
+            .tvos,
+            .watchos,
+            .mesa3d,
+            .contiki,
+            .amdpal,
+            .hermit,
+            .hurd,
+            .wasi,
+            .emscripten,
+            .uefi,
+            .other,
+            => return error.InvalidOperatingSystemVersion,
+
+            .freebsd,
+            .macosx,
+            .netbsd,
+            .openbsd,
+            .linux,
+            => {
+                var range_it = mem.separate(version_text, "...");
+
+                const min_text = range_it.next().?;
+                const min_ver = SemVer.parse(min_text) catch |err| switch (err) {
+                    error.Overflow => return error.InvalidOperatingSystemVersion,
+                    error.InvalidCharacter => return error.InvalidOperatingSystemVersion,
+                    error.InvalidVersion => return error.InvalidOperatingSystemVersion,
+                };
+                result.os_version_min = .{ .semver = min_ver };
+
+                const max_text = range_it.next() orelse return;
+                const max_ver = SemVer.parse(max_text) catch |err| switch (err) {
+                    error.Overflow => return error.InvalidOperatingSystemVersion,
+                    error.InvalidCharacter => return error.InvalidOperatingSystemVersion,
+                    error.InvalidVersion => return error.InvalidOperatingSystemVersion,
+                };
+                result.os_version_max = .{ .semver = max_ver };
+            },
+
+            .windows => {
+                var range_it = mem.separate(version_text, "...");
+
+                const min_text = range_it.next().?;
+                const min_ver = std.meta.stringToEnum(Target.Os.WindowsVersion, min_text) orelse
+                    return error.InvalidOperatingSystemVersion;
+                result.os_version_min = .{ .windows = min_ver };
+
+                const max_text = range_it.next() orelse return;
+                const max_ver = std.meta.stringToEnum(Target.Os.WindowsVersion, max_text) orelse
+                    return error.InvalidOperatingSystemVersion;
+                result.os_version_max = .{ .windows = max_ver };
+            },
+        }
+    }
+};
+
+test "CrossTarget.parse" {
+    {
+        const cross_target = try CrossTarget.parse(.{
+            .arch_os_abi = "x86_64-linux-gnu",
+            .cpu_features = "x86_64-sse-sse2-avx-cx8",
+        });
+        const target = cross_target.toTarget();
+
+        std.testing.expect(target.os.tag == .linux);
+        std.testing.expect(target.abi == .gnu);
+        std.testing.expect(target.cpu.arch == .x86_64);
+        std.testing.expect(!Target.x86.featureSetHas(target.cpu.features, .sse));
+        std.testing.expect(!Target.x86.featureSetHas(target.cpu.features, .avx));
+        std.testing.expect(!Target.x86.featureSetHas(target.cpu.features, .cx8));
+        std.testing.expect(Target.x86.featureSetHas(target.cpu.features, .cmov));
+        std.testing.expect(Target.x86.featureSetHas(target.cpu.features, .fxsr));
+
+        const text = try cross_target.zigTriple(std.testing.allocator);
+        defer std.testing.allocator.free(text);
+        std.testing.expectEqualSlices(u8, "x86_64-linux-gnu", text);
+    }
+    {
+        const cross_target = try CrossTarget.parse(.{
+            .arch_os_abi = "arm-linux-musleabihf",
+            .cpu_features = "generic+v8a",
+        });
+        const target = cross_target.toTarget();
+
+        std.testing.expect(target.os.tag == .linux);
+        std.testing.expect(target.abi == .musleabihf);
+        std.testing.expect(target.cpu.arch == .arm);
+        std.testing.expect(target.cpu.model == &Target.arm.cpu.generic);
+        std.testing.expect(Target.arm.featureSetHas(target.cpu.features, .v8a));
+
+        const text = try cross_target.zigTriple(std.testing.allocator);
+        defer std.testing.allocator.free(text);
+        std.testing.expectEqualSlices(u8, "arm-linux-musleabihf", text);
+    }
+    {
+        const cross_target = try CrossTarget.parse(.{
+            .arch_os_abi = "aarch64-linux.3.10...4.4.1-gnu.2.27",
+            .cpu_features = "generic+v8a",
+        });
+        const target = cross_target.toTarget();
+
+        std.testing.expect(target.cpu.arch == .aarch64);
+        std.testing.expect(target.os.tag == .linux);
+        std.testing.expect(target.os.version_range.linux.range.min.major == 3);
+        std.testing.expect(target.os.version_range.linux.range.min.minor == 10);
+        std.testing.expect(target.os.version_range.linux.range.min.patch == 0);
+        std.testing.expect(target.os.version_range.linux.range.max.major == 4);
+        std.testing.expect(target.os.version_range.linux.range.max.minor == 4);
+        std.testing.expect(target.os.version_range.linux.range.max.patch == 1);
+        std.testing.expect(target.os.version_range.linux.glibc.major == 2);
+        std.testing.expect(target.os.version_range.linux.glibc.minor == 27);
+        std.testing.expect(target.os.version_range.linux.glibc.patch == 0);
+        std.testing.expect(target.abi == .gnu);
+
+        const text = try cross_target.zigTriple(std.testing.allocator);
+        defer std.testing.allocator.free(text);
+        std.testing.expectEqualSlices(u8, "aarch64-linux.3.10...4.4.1-gnu.2.27", text);
+    }
+}

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -88,7 +88,6 @@ pub const CrossTarget = struct {
             .cloudabi,
             .dragonfly,
             .fuchsia,
-            .ios,
             .kfreebsd,
             .lv2,
             .solaris,
@@ -103,8 +102,6 @@ pub const CrossTarget = struct {
             .amdhsa,
             .ps4,
             .elfiamcu,
-            .tvos,
-            .watchos,
             .mesa3d,
             .contiki,
             .amdpal,
@@ -121,8 +118,11 @@ pub const CrossTarget = struct {
 
             .freebsd,
             .macosx,
+            .ios,
             .netbsd,
             .openbsd,
+            .tvos,
+            .watchos,
             => {
                 self.os_version_min = .{ .semver = os.version_range.semver.min };
                 self.os_version_max = .{ .semver = os.version_range.semver.max };

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -10,8 +10,7 @@ pub const CrossTarget = struct {
     /// `null` means native. If this is `null` then `cpu_model` must be `null`.
     cpu_arch: ?Target.Cpu.Arch = null,
 
-    /// `null` means native.
-    /// If this is non-null, `cpu_arch` must be specified.
+    /// `null` means native. If this is non-null, `cpu_arch` must be specified.
     cpu_model: ?*const Target.Cpu.Model = null,
 
     /// Sparse set of CPU features to add to the set from `cpu_model`.
@@ -301,6 +300,10 @@ pub const CrossTarget = struct {
                     return error.UnknownCpuFeature;
                 }
             }
+        } else if (arch_is_native) {
+            result.cpu_model = null;
+        } else {
+            result.cpu_model = Target.Cpu.Model.baseline(arch);
         }
 
         return result;
@@ -725,6 +728,15 @@ pub const CrossTarget = struct {
 };
 
 test "CrossTarget.parse" {
+    {
+        const cross_target = try CrossTarget.parse(.{
+            .arch_os_abi = "aarch64-linux",
+            .cpu_features = "native",
+        });
+
+        std.testing.expect(cross_target.cpu_arch.? == .aarch64);
+        std.testing.expect(cross_target.cpu_model == null);
+    }
     {
         const cross_target = try CrossTarget.parse(.{ .arch_os_abi = "native" });
 

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -7,19 +7,17 @@ const mem = std.mem;
 /// The purpose of this abstraction is to provide meaningful and unsurprising defaults.
 /// This struct does reference any resources and it is copyable.
 pub const CrossTarget = struct {
-    /// `null` means native.
+    /// `null` means native. If this is `null` then `cpu_model` must be `null`.
     cpu_arch: ?Target.Cpu.Arch = null,
 
-    /// If `cpu_arch` is native, `null` means native. Otherwise it means baseline.
+    /// `null` means native.
     /// If this is non-null, `cpu_arch` must be specified.
     cpu_model: ?*const Target.Cpu.Model = null,
 
     /// Sparse set of CPU features to add to the set from `cpu_model`.
-    /// If this is non-empty, `cpu_arch` must be specified.
     cpu_features_add: Target.Cpu.Feature.Set = Target.Cpu.Feature.Set.empty,
 
     /// Sparse set of CPU features to remove from the set from `cpu_model`.
-    /// If this is non-empty, `cpu_arch` must be specified.
     cpu_features_sub: Target.Cpu.Feature.Set = Target.Cpu.Feature.Set.empty,
 
     /// `null` means native.
@@ -33,12 +31,12 @@ pub const CrossTarget = struct {
     /// When `os_tag` is native, `null` means equal to the native OS version.
     os_version_max: ?OsVersion = null,
 
-    /// `null` means the native C ABI, if `os_tag` is native, otherwise it means the default C ABI.
-    abi: ?Target.Abi = null,
-
     /// `null` means default when cross compiling, or native when os_tag is native.
     /// If `isGnuLibC()` is `false`, this must be `null` and is ignored.
     glibc_version: ?SemVer = null,
+
+    /// `null` means the native C ABI, if `os_tag` is native, otherwise it means the default C ABI.
+    abi: ?Target.Abi = null,
 
     /// When `os_tag` is `null`, then `null` means native. Otherwise it means the standard path
     /// based on the `os_tag`.
@@ -146,6 +144,7 @@ pub const CrossTarget = struct {
         }
     }
 
+    /// TODO deprecated, use `std.zig.system.NativeTargetInfo.detect`.
     pub fn toTarget(self: CrossTarget) Target {
         return .{
             .cpu = self.getCpu(),
@@ -307,6 +306,7 @@ pub const CrossTarget = struct {
         return result;
     }
 
+    /// TODO deprecated, use `std.zig.system.NativeTargetInfo.detect`.
     pub fn getCpu(self: CrossTarget) Target.Cpu {
         if (self.cpu_arch) |arch| {
             if (self.cpu_model) |model| {
@@ -342,6 +342,7 @@ pub const CrossTarget = struct {
         return self.getCpu().features;
     }
 
+    /// TODO deprecated, use `std.zig.system.NativeTargetInfo.detect`.
     pub fn getOs(self: CrossTarget) Target.Os {
         // `Target.current.os` works when doing `zig build` because Zig generates a build executable using
         // native OS version range. However this will not be accurate otherwise, and
@@ -378,6 +379,7 @@ pub const CrossTarget = struct {
         return self.os_tag orelse Target.current.os.tag;
     }
 
+    /// TODO deprecated, use `std.zig.system.NativeTargetInfo.detect`.
     pub fn getOsVersionMin(self: CrossTarget) OsVersion {
         if (self.os_version_min) |version_min| return version_min;
         var tmp: CrossTarget = undefined;
@@ -385,6 +387,7 @@ pub const CrossTarget = struct {
         return tmp.os_version_min.?;
     }
 
+    /// TODO deprecated, use `std.zig.system.NativeTargetInfo.detect`.
     pub fn getOsVersionMax(self: CrossTarget) OsVersion {
         if (self.os_version_max) |version_max| return version_max;
         var tmp: CrossTarget = undefined;
@@ -392,6 +395,7 @@ pub const CrossTarget = struct {
         return tmp.os_version_max.?;
     }
 
+    /// TODO deprecated, use `std.zig.system.NativeTargetInfo.detect`.
     pub fn getAbi(self: CrossTarget) Target.Abi {
         if (self.abi) |abi| return abi;
 

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -754,7 +754,7 @@ test "CrossTarget.parse" {
         });
 
         std.testing.expect(cross_target.cpu_arch.? == .aarch64);
-        std.testing.expect(cross_target.cpu_model == null);
+        std.testing.expect(cross_target.cpu_model == .native);
     }
     {
         const cross_target = try CrossTarget.parse(.{ .arch_os_abi = "native" });

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -1,11 +1,14 @@
 const std = @import("../std.zig");
+const elf = std.elf;
 const mem = std.mem;
+const fs = std.fs;
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
 const assert = std.debug.assert;
 const process = std.process;
+const Target = std.Target;
 
-const is_windows = std.Target.current.isWindows();
+const is_windows = Target.current.os.tag == .windows;
 
 pub const NativePaths = struct {
     include_dirs: ArrayList([:0]u8),
@@ -77,7 +80,7 @@ pub const NativePaths = struct {
         }
 
         if (!is_windows) {
-            const triple = try std.Target.current.linuxTriple(allocator);
+            const triple = try Target.current.linuxTriple(allocator);
 
             // TODO: $ ld --verbose | grep SEARCH_DIR
             // the output contains some paths that end with lib64, maybe include them too?
@@ -161,3 +164,326 @@ pub const NativePaths = struct {
         try array.append(item);
     }
 };
+
+pub const NativeTargetInfo = struct {
+    target: Target,
+    dynamic_linker: ?[:0]u8,
+
+    pub const DetectError = error{
+        OutOfMemory,
+        FileSystem,
+        SystemResources,
+        SymLinkLoop,
+        ProcessFdQuotaExceeded,
+        SystemFdQuotaExceeded,
+        DeviceBusy,
+    };
+
+    /// Detects the native CPU model & features, operating system & version, and C ABI & dynamic linker.
+    /// On Linux, this is additionally responsible for detecting the native glibc version when applicable.
+    pub fn detect(allocator: *Allocator) DetectError!NativeTargetInfo {
+        const arch = Target.current.cpu.arch;
+        const os_tag = Target.current.os.tag;
+
+        // TODO Detect native CPU model & features. Until that is implemented we hard code baseline.
+        const cpu = Target.Cpu.baseline(arch);
+
+        // TODO Detect native operating system version. Until that is implemented we use the minimum version
+        // of the default range.
+        const os = Target.Os.defaultVersionRange(os_tag);
+
+        return detectAbiAndDynamicLinker(allocator, cpu, os);
+    }
+
+    /// Must be the same `Allocator` passed to `detect`.
+    pub fn deinit(self: *NativeTargetInfo, allocator: *Allocator) void {
+        if (self.dynamic_linker) |dl| allocator.free(dl);
+        self.* = undefined;
+    }
+
+    /// First we attempt to use the executable's own binary. If it is dynamically
+    /// linked, then it should answer both the C ABI question and the dynamic linker question.
+    /// If it is statically linked, then we try /usr/bin/env. If that does not provide the answer, then
+    /// we fall back to the defaults.
+    fn detectAbiAndDynamicLinker(
+        allocator: *Allocator,
+        cpu: Target.Cpu,
+        os: Target.Os,
+    ) DetectError!NativeTargetInfo {
+        if (!comptime Target.current.hasDynamicLinker()) {
+            return defaultAbiAndDynamicLinker(allocator, cpu, os);
+        }
+        // The current target's ABI cannot be relied on for this. For example, we may build the zig
+        // compiler for target riscv64-linux-musl and provide a tarball for users to download.
+        // A user could then run that zig compiler on riscv64-linux-gnu. This use case is well-defined
+        // and supported by Zig. But that means that we must detect the system ABI here rather than
+        // relying on `Target.current`.
+        const LdInfo = struct {
+            ld_path: []u8,
+            abi: Target.Abi,
+        };
+        var ld_info_list = std.ArrayList(LdInfo).init(allocator);
+        defer {
+            for (ld_info_list.toSlice()) |ld_info| allocator.free(ld_info.ld_path);
+            ld_info_list.deinit();
+        }
+
+        const all_abis = comptime blk: {
+            assert(@enumToInt(Target.Abi.none) == 0);
+            const fields = std.meta.fields(Target.Abi)[1..];
+            var array: [fields.len]Target.Abi = undefined;
+            inline for (fields) |field, i| {
+                array[i] = @field(Target.Abi, field.name);
+            }
+            break :blk array;
+        };
+        for (all_abis) |abi| {
+            // This may be a nonsensical parameter. We detect this with error.UnknownDynamicLinkerPath and
+            // skip adding it to `ld_info_list`.
+            const target: Target = .{
+                .cpu = cpu,
+                .os = os,
+                .abi = abi,
+            };
+            const standard_ld_path = target.getStandardDynamicLinkerPath(allocator) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.UnknownDynamicLinkerPath, error.TargetHasNoDynamicLinker => continue,
+            };
+            errdefer allocator.free(standard_ld_path);
+            try ld_info_list.append(.{
+                .ld_path = standard_ld_path,
+                .abi = abi,
+            });
+        }
+
+        // Best case scenario: the executable is dynamically linked, and we can iterate
+        // over our own shared objects and find a dynamic linker.
+        self_exe: {
+            const lib_paths = try std.process.getSelfExeSharedLibPaths(allocator);
+            defer allocator.free(lib_paths);
+
+            var found_ld_info: LdInfo = undefined;
+            var found_ld_path: [:0]const u8 = undefined;
+
+            // Look for dynamic linker.
+            // This is O(N^M) but typical case here is N=2 and M=10.
+            find_ld: for (lib_paths) |lib_path| {
+                for (ld_info_list.toSlice()) |ld_info| {
+                    const standard_ld_basename = fs.path.basename(ld_info.ld_path);
+                    if (std.mem.endsWith(u8, lib_path, standard_ld_basename)) {
+                        found_ld_info = ld_info;
+                        found_ld_path = lib_path;
+                        break :find_ld;
+                    }
+                }
+            } else break :self_exe;
+
+            // Look for glibc version.
+            var os_adjusted = os;
+            if (Target.current.os.tag == .linux and found_ld_info.abi.isGnu()) {
+                for (lib_paths) |lib_path| {
+                    if (std.mem.endsWith(u8, lib_path, glibc_so_basename)) {
+                        os_adjusted.version_range.linux.glibc = glibcVerFromSO(lib_path) catch |err| switch (err) {
+                            error.UnrecognizedGnuLibCFileName => continue,
+                            error.InvalidGnuLibCVersion => continue,
+                            error.GnuLibCVersionUnavailable => continue,
+                            else => |e| return e,
+                        };
+                        break;
+                    }
+                }
+            }
+
+            return NativeTargetInfo{
+                .target = .{
+                    .cpu = cpu,
+                    .os = os_adjusted,
+                    .abi = found_ld_info.abi,
+                },
+                .dynamic_linker = try mem.dupeZ(allocator, u8, found_ld_path),
+            };
+        }
+
+        // If Zig is statically linked, such as via distributed binary static builds, the above
+        // trick won't work. The next thing we fall back to is the same thing, but for /usr/bin/env.
+        // Since that path is hard-coded into the shebang line of many portable scripts, it's a
+        // reasonably reliable path to check for.
+        return abiAndDynamicLinkerFromUsrBinEnv(allocator, cpu, os) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.FileSystem => return error.FileSystem,
+            error.SystemResources => return error.SystemResources,
+            error.SymLinkLoop => return error.SymLinkLoop,
+            error.ProcessFdQuotaExceeded => return error.ProcessFdQuotaExceeded,
+            error.SystemFdQuotaExceeded => return error.SystemFdQuotaExceeded,
+            error.DeviceBusy => return error.DeviceBusy,
+
+            error.UnableToReadElfFile,
+            error.ElfNotADynamicExecutable,
+            error.InvalidElfProgramHeaders,
+            error.InvalidElfClass,
+            error.InvalidElfVersion,
+            error.InvalidElfEndian,
+            error.InvalidElfFile,
+            error.InvalidElfMagic,
+            error.UsrBinEnvNotAvailable,
+            error.Unexpected,
+            // Finally, we fall back on the standard path.
+            => defaultAbiAndDynamicLinker(allocator, cpu, os),
+        };
+    }
+
+    const glibc_so_basename = "libc.so.6";
+
+    fn glibcVerFromSO(so_path: [:0]const u8) !std.builtin.Version {
+        var link_buf: [std.os.PATH_MAX]u8 = undefined;
+        const link_name = std.os.readlinkC(so_path.ptr, &link_buf) catch |err| switch (err) {
+            error.AccessDenied => return error.GnuLibCVersionUnavailable,
+            error.FileSystem => return error.FileSystem,
+            error.SymLinkLoop => return error.SymLinkLoop,
+            error.NameTooLong => unreachable,
+            error.FileNotFound => return error.GnuLibCVersionUnavailable,
+            error.SystemResources => return error.SystemResources,
+            error.NotDir => return error.GnuLibCVersionUnavailable,
+            error.Unexpected => return error.GnuLibCVersionUnavailable,
+        };
+        // example: "libc-2.3.4.so"
+        // example: "libc-2.27.so"
+        const prefix = "libc-";
+        const suffix = ".so";
+        if (!mem.startsWith(u8, link_name, prefix) or !mem.endsWith(u8, link_name, suffix)) {
+            return error.UnrecognizedGnuLibCFileName;
+        }
+        // chop off "libc-" and ".so"
+        const link_name_chopped = link_name[prefix.len .. link_name.len - suffix.len];
+        return std.builtin.Version.parse(link_name_chopped) catch |err| switch (err) {
+            error.Overflow => return error.InvalidGnuLibCVersion,
+            error.InvalidCharacter => return error.InvalidGnuLibCVersion,
+            error.InvalidVersion => return error.InvalidGnuLibCVersion,
+        };
+    }
+
+    fn abiAndDynamicLinkerFromUsrBinEnv(
+        allocator: *Allocator,
+        cpu: Target.Cpu,
+        os: Target.Os,
+    ) !NativeTargetInfo {
+        const env_file = std.fs.openFileAbsoluteC("/usr/bin/env", .{}) catch |err| switch (err) {
+            error.NoSpaceLeft => unreachable,
+            error.NameTooLong => unreachable,
+            error.PathAlreadyExists => unreachable,
+            error.SharingViolation => unreachable,
+            error.InvalidUtf8 => unreachable,
+            error.BadPathName => unreachable,
+            error.PipeBusy => unreachable,
+
+            error.IsDir => return error.UsrBinEnvNotAvailable,
+            error.NotDir => return error.UsrBinEnvNotAvailable,
+            error.AccessDenied => return error.UsrBinEnvNotAvailable,
+            error.NoDevice => return error.UsrBinEnvNotAvailable,
+            error.FileNotFound => return error.UsrBinEnvNotAvailable,
+            error.FileTooBig => return error.UsrBinEnvNotAvailable,
+
+            else => |e| return e,
+        };
+        var hdr_buf: [@sizeOf(elf.Elf64_Ehdr)]u8 align(@alignOf(elf.Elf64_Ehdr)) = undefined;
+        const hdr_bytes_len = try wrapRead(env_file.pread(&hdr_buf, 0));
+        if (hdr_bytes_len < @sizeOf(elf.Elf32_Ehdr)) return error.InvalidElfFile;
+        const hdr32 = @ptrCast(*elf.Elf32_Ehdr, &hdr_buf);
+        const hdr64 = @ptrCast(*elf.Elf64_Ehdr, &hdr_buf);
+        if (!mem.eql(u8, hdr32.e_ident[0..4], "\x7fELF")) return error.InvalidElfMagic;
+        const elf_endian: std.builtin.Endian = switch (hdr32.e_ident[elf.EI_DATA]) {
+            elf.ELFDATA2LSB => .Little,
+            elf.ELFDATA2MSB => .Big,
+            else => return error.InvalidElfEndian,
+        };
+        const need_bswap = elf_endian != std.builtin.endian;
+        if (hdr32.e_ident[elf.EI_VERSION] != 1) return error.InvalidElfVersion;
+
+        const is_64 = switch (hdr32.e_ident[elf.EI_CLASS]) {
+            elf.ELFCLASS32 => false,
+            elf.ELFCLASS64 => true,
+            else => return error.InvalidElfClass,
+        };
+        var phoff = elfInt(is_64, need_bswap, hdr32.e_phoff, hdr64.e_phoff);
+        const phentsize = elfInt(is_64, need_bswap, hdr32.e_phentsize, hdr64.e_phentsize);
+        const phnum = elfInt(is_64, need_bswap, hdr32.e_phnum, hdr64.e_phnum);
+        const shstrndx = elfInt(is_64, need_bswap, hdr32.e_shstrndx, hdr64.e_shstrndx);
+
+        const ph_total_size = std.math.mul(u32, phentsize, phnum) catch |err| switch (err) {
+            error.Overflow => return error.InvalidElfProgramHeaders,
+        };
+        var ph_buf: [16 * @sizeOf(elf.Elf64_Phdr)]u8 align(@alignOf(elf.Elf64_Phdr)) = undefined;
+        var ph_i: u16 = 0;
+        while (ph_i < phnum) {
+            // Reserve some bytes so that we can deref the 64-bit struct fields even when the ELF file is 32-bits.
+            const reserve = @sizeOf(elf.Elf64_Phdr) - @sizeOf(elf.Elf32_Phdr);
+            const read_byte_len = try wrapRead(env_file.pread(ph_buf[0 .. ph_buf.len - reserve], phoff));
+            if (read_byte_len < phentsize) return error.ElfNotADynamicExecutable;
+            var buf_i: usize = 0;
+            while (buf_i < read_byte_len and ph_i < phnum) : ({
+                ph_i += 1;
+                phoff += phentsize;
+                buf_i += phentsize;
+            }) {
+                const ph32 = @ptrCast(*elf.Elf32_Phdr, @alignCast(@alignOf(elf.Elf32_Phdr), &ph_buf[buf_i]));
+                const ph64 = @ptrCast(*elf.Elf64_Phdr, @alignCast(@alignOf(elf.Elf64_Phdr), &ph_buf[buf_i]));
+                const p_type = elfInt(is_64, need_bswap, ph32.p_type, ph64.p_type);
+                switch (p_type) {
+                    elf.PT_INTERP => {
+                        std.debug.warn("found PT_INTERP\n", .{});
+                    },
+                    elf.PT_DYNAMIC => {
+                        std.debug.warn("found PT_DYNAMIC\n", .{});
+                    },
+                    else => continue,
+                }
+            }
+        }
+
+        return error.OutOfMemory; // TODO
+    }
+
+    fn wrapRead(res: std.os.ReadError!usize) !usize {
+        return res catch |err| switch (err) {
+            error.OperationAborted => unreachable, // Windows-only
+            error.WouldBlock => unreachable, // Did not request blocking mode
+            error.SystemResources => return error.SystemResources,
+            error.IsDir => return error.UnableToReadElfFile,
+            error.BrokenPipe => return error.UnableToReadElfFile,
+            error.ConnectionResetByPeer => return error.UnableToReadElfFile,
+            error.Unexpected => return error.Unexpected,
+            error.InputOutput => return error.FileSystem,
+        };
+    }
+
+    fn defaultAbiAndDynamicLinker(allocator: *Allocator, cpu: Target.Cpu, os: Target.Os) !NativeTargetInfo {
+        const target: Target = .{
+            .cpu = cpu,
+            .os = os,
+            .abi = Target.Abi.default(cpu.arch, os),
+        };
+        return @as(NativeTargetInfo, .{
+            .target = target,
+            .dynamic_linker = target.getStandardDynamicLinkerPath(allocator) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.UnknownDynamicLinkerPath, error.TargetHasNoDynamicLinker => null,
+            },
+        });
+    }
+};
+
+fn elfInt(is_64: bool, need_bswap: bool, int_32: var, int_64: var) @TypeOf(int_64) {
+    if (is_64) {
+        if (need_bswap) {
+            return @byteSwap(@TypeOf(int_64), int_64);
+        } else {
+            return int_64;
+        }
+    } else {
+        if (need_bswap) {
+            return @byteSwap(@TypeOf(int_32), int_32);
+        } else {
+            return int_32;
+        }
+    }
+}

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -192,21 +192,14 @@ pub const NativeTargetInfo = struct {
     /// TODO Remove the Allocator requirement from this function.
     pub fn detect(allocator: *Allocator, cross_target: CrossTarget) DetectError!NativeTargetInfo {
         const cpu = blk: {
-            if (cross_target.cpu_arch) |arch| {
-                if (cross_target.cpu_model) |model| {
-                    var adjusted_model = model.toCpu(arch);
-                    cross_target.updateCpuFeatures(&adjusted_model.features);
-                    break :blk adjusted_model;
-                } else {
-                    // TODO Detect native CPU model. Until that is implemented we use baseline.
-                    var adjusted_baseline = Target.Cpu.baseline(arch);
-                    cross_target.updateCpuFeatures(&adjusted_baseline.features);
-                    break :blk adjusted_baseline;
-                }
+            const arch = cross_target.getCpuArch();
+            if (cross_target.cpu_model) |model| {
+                var adjusted_model = model.toCpu(arch);
+                cross_target.updateCpuFeatures(&adjusted_model.features);
+                break :blk adjusted_model;
             } else {
-                assert(cross_target.cpu_model == null);
                 // TODO Detect native CPU model & features. Until that is implemented we use baseline.
-                var adjusted_baseline = Target.Cpu.baseline(Target.current.cpu.arch);
+                var adjusted_baseline = Target.Cpu.baseline(arch);
                 cross_target.updateCpuFeatures(&adjusted_baseline.features);
                 break :blk adjusted_baseline;
             }

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -274,7 +274,8 @@ pub const NativeTargetInfo = struct {
         const is_linux = Target.current.os.tag == .linux;
         const have_all_info = cross_target.dynamic_linker.get() != null and
             cross_target.abi != null and (!is_linux or cross_target.abi.?.isGnu());
-        if (!native_target_has_ld or have_all_info) {
+        const os_is_non_native = cross_target.os_tag != null;
+        if (!native_target_has_ld or have_all_info or os_is_non_native) {
             return defaultAbiAndDynamicLinker(cpu, os, cross_target);
         }
         // The current target's ABI cannot be relied on for this. For example, we may build the zig

--- a/src-self-hosted/c_int.zig
+++ b/src-self-hosted/c_int.zig
@@ -70,7 +70,7 @@ pub const CInt = struct {
 
     pub fn sizeInBits(cint: CInt, self: Target) u32 {
         const arch = self.getArch();
-        switch (self.getOs()) {
+        switch (self.os.tag) {
             .freestanding, .other => switch (self.getArch()) {
                 .msp430 => switch (cint.id) {
                     .Short,

--- a/src-self-hosted/clang.zig
+++ b/src-self-hosted/clang.zig
@@ -1050,7 +1050,7 @@ pub const struct_ZigClangExprEvalResult = extern struct {
 
 pub const struct_ZigClangAPValue = extern struct {
     Kind: ZigClangAPValueKind,
-    Data: if (builtin.os == .windows and builtin.abi == .msvc) [52]u8 else [68]u8,
+    Data: if (builtin.os.tag == .windows and builtin.abi == .msvc) [52]u8 else [68]u8,
 };
 pub extern fn ZigClangVarDecl_getTypeSourceInfo_getType(self: *const struct_ZigClangVarDecl) struct_ZigClangQualType;
 

--- a/src-self-hosted/introspect.zig
+++ b/src-self-hosted/introspect.zig
@@ -1,18 +1,10 @@
-// Introspection and determination of system libraries needed by zig.
+//! Introspection and determination of system libraries needed by zig.
 
 const std = @import("std");
 const mem = std.mem;
 const fs = std.fs;
 
 const warn = std.debug.warn;
-
-pub fn detectDynamicLinker(allocator: *mem.Allocator, target: std.Target) ![:0]u8 {
-    if (target == .Native) {
-        return @import("libc_installation.zig").detectNativeDynamicLinker(allocator);
-    } else {
-        return target.getStandardDynamicLinkerPath(allocator);
-    }
-}
 
 /// Caller must free result
 pub fn testZigInstallPrefix(allocator: *mem.Allocator, test_path: []const u8) ![]u8 {

--- a/src-self-hosted/link.zig
+++ b/src-self-hosted/link.zig
@@ -515,7 +515,7 @@ const DarwinPlatform = struct {
                 break :blk ver;
             },
             .None => blk: {
-                assert(comp.target.getOs() == .macosx);
+                assert(comp.target.os.tag == .macosx);
                 result.kind = .MacOS;
                 break :blk "10.14";
             },
@@ -534,7 +534,7 @@ const DarwinPlatform = struct {
         }
 
         if (result.kind == .IPhoneOS) {
-            switch (comp.target.getArch()) {
+            switch (comp.target.cpu.arch) {
                 .i386,
                 .x86_64,
                 => result.kind = .IPhoneOSSimulator,

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -79,9 +79,9 @@ pub fn main() !void {
     } else if (mem.eql(u8, cmd, "libc")) {
         return cmdLibC(allocator, cmd_args);
     } else if (mem.eql(u8, cmd, "targets")) {
-        // TODO figure out the current target rather than using the target that was specified when
-        // compiling the compiler
-        return @import("print_targets.zig").cmdTargets(allocator, cmd_args, stdout, Target.current);
+        const info = try std.zig.system.NativeTargetInfo.detect(allocator);
+        defer info.deinit(allocator);
+        return @import("print_targets.zig").cmdTargets(allocator, cmd_args, stdout, info.target);
     } else if (mem.eql(u8, cmd, "version")) {
         return cmdVersion(allocator, cmd_args);
     } else if (mem.eql(u8, cmd, "zen")) {

--- a/src-self-hosted/print_targets.zig
+++ b/src-self-hosted/print_targets.zig
@@ -124,7 +124,7 @@ pub fn cmdTargets(
 
     try jws.objectField("os");
     try jws.beginArray();
-    inline for (@typeInfo(Target.Os).Enum.fields) |field| {
+    inline for (@typeInfo(Target.Os.Tag).Enum.fields) |field| {
         try jws.arrayElem();
         try jws.emitString(field.name);
     }
@@ -201,16 +201,16 @@ pub fn cmdTargets(
         try jws.objectField("cpu");
         try jws.beginObject();
         try jws.objectField("arch");
-        try jws.emitString(@tagName(native_target.getArch()));
+        try jws.emitString(@tagName(native_target.cpu.arch));
 
         try jws.objectField("name");
-        const cpu = native_target.getCpu();
+        const cpu = native_target.cpu;
         try jws.emitString(cpu.model.name);
 
         {
             try jws.objectField("features");
             try jws.beginArray();
-            for (native_target.getArch().allFeaturesList()) |feature, i_usize| {
+            for (native_target.cpu.arch.allFeaturesList()) |feature, i_usize| {
                 const index = @intCast(Target.Cpu.Feature.Set.Index, i_usize);
                 if (cpu.features.isEnabled(index)) {
                     try jws.arrayElem();
@@ -222,9 +222,9 @@ pub fn cmdTargets(
         try jws.endObject();
     }
     try jws.objectField("os");
-    try jws.emitString(@tagName(native_target.getOs()));
+    try jws.emitString(@tagName(native_target.os.tag));
     try jws.objectField("abi");
-    try jws.emitString(@tagName(native_target.getAbi()));
+    try jws.emitString(@tagName(native_target.abi));
     // TODO implement native glibc version detection in self-hosted
     try jws.endObject();
 

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -679,7 +679,7 @@ fn stage2TargetParse(
 ) !void {
     const target: CrossTarget = if (zig_triple_oz) |zig_triple_z| blk: {
         const zig_triple = mem.toSliceConst(u8, zig_triple_z);
-        const mcpu = if (mcpu_oz) |mcpu_z| mem.toSliceConst(u8, mcpu_z) else "baseline";
+        const mcpu = if (mcpu_oz) |mcpu_z| mem.toSliceConst(u8, mcpu_z) else null;
         var diags: CrossTarget.ParseOptions.Diagnostics = .{};
         break :blk CrossTarget.parse(.{
             .arch_os_abi = zig_triple,

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -1029,7 +1029,7 @@ const Stage2Target = extern struct {
             .netbsd,
             .openbsd,
             => try os_builtin_str_buffer.print(
-                \\.semver = .{{
+                \\ .semver = .{{
                 \\        .min = .{{
                 \\            .major = {},
                 \\            .minor = {},
@@ -1041,6 +1041,7 @@ const Stage2Target = extern struct {
                 \\            .patch = {},
                 \\        }},
                 \\    }}}},
+                \\
             , .{
                 target.os.version_range.semver.min.major,
                 target.os.version_range.semver.min.minor,
@@ -1052,7 +1053,7 @@ const Stage2Target = extern struct {
             }),
 
             .linux => try os_builtin_str_buffer.print(
-                \\.linux = .{{
+                \\ .linux = .{{
                 \\        .range = .{{
                 \\            .min = .{{
                 \\                .major = {},
@@ -1087,10 +1088,11 @@ const Stage2Target = extern struct {
             }),
 
             .windows => try os_builtin_str_buffer.print(
-                \\.semver = .{{
+                \\ .windows = .{{
                 \\        .min = .{},
                 \\        .max = .{},
                 \\    }}}},
+                \\
             , .{
                 @tagName(target.os.version_range.windows.min),
                 @tagName(target.os.version_range.windows.max),

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -1170,8 +1170,8 @@ fn crossTargetToTarget(cross_target: CrossTarget, dynamic_linker_ptr: *?[*:0]u8)
     }
     if (!have_native_dl) {
         var buf: [255]u8 = undefined;
-        dynamic_linker_ptr.* = if (adjusted_target.standardDynamicLinkerPath(&buf)) |s|
-            try mem.dupeZ(std.heap.c_allocator, u8, s)
+        dynamic_linker_ptr.* = if (adjusted_target.standardDynamicLinkerPath(&buf)) |m|
+            try mem.dupeZ(std.heap.c_allocator, u8, buf[0 .. @as(usize, m) + 1])
         else
             null;
     }

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -668,7 +668,6 @@ export fn stage2_target_parse(
         error.ProcessFdQuotaExceeded => return .ProcessFdQuotaExceeded,
         error.SystemFdQuotaExceeded => return .SystemFdQuotaExceeded,
         error.DeviceBusy => return .DeviceBusy,
-        error.UnknownDynamicLinkerPath => return .UnknownDynamicLinkerPath,
     };
     return .None;
 }
@@ -1174,6 +1173,7 @@ fn crossTargetToTarget(cross_target: CrossTarget, dynamic_linker_ptr: *?[*:0]u8)
             std.heap.c_allocator,
         ) catch |err| switch (err) {
             error.TargetHasNoDynamicLinker => null,
+            error.UnknownDynamicLinkerPath => null,
             else => |e| return e,
         };
     }

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -1137,9 +1137,9 @@ fn enumInt(comptime Enum: type, int: c_int) Enum {
 /// TODO self-host this function
 fn crossTargetToTarget(cross_target: CrossTarget, dynamic_linker_ptr: *?[*:0]u8) !Target {
     var adjusted_target = cross_target.toTarget();
-    if (cross_target.isNativeCpu() or cross_target.isNativeOs()) {
+    if (cross_target.cpu_arch == null or cross_target.os_tag == null) {
         const detected_info = try std.zig.system.NativeTargetInfo.detect(std.heap.c_allocator);
-        if (cross_target.isNativeCpu()) {
+        if (cross_target.cpu_arch == null) {
             adjusted_target.cpu = detected_info.target.cpu;
 
             // TODO We want to just use detected_info.target but implementing
@@ -1151,7 +1151,7 @@ fn crossTargetToTarget(cross_target: CrossTarget, dynamic_linker_ptr: *?[*:0]u8)
             const arch = std.Target.current.cpu.arch;
             adjusted_target.cpu = try detectNativeCpuWithLLVM(arch, llvm_cpu_name, llvm_cpu_features);
         }
-        if (cross_target.isNativeOs()) {
+        if (cross_target.os_tag == null) {
             adjusted_target.os = detected_info.target.os;
 
             if (detected_info.dynamic_linker) |dl| {

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -1154,7 +1154,7 @@ fn enumInt(comptime Enum: type, int: c_int) Enum {
 
 fn crossTargetToTarget(cross_target: CrossTarget, dynamic_linker_ptr: *?[*:0]u8) !Target {
     var info = try std.zig.system.NativeTargetInfo.detect(std.heap.c_allocator, cross_target);
-    if (cross_target.cpu_arch == null or cross_target.cpu_model == null) {
+    if (cross_target.cpu_arch == null or cross_target.cpu_model == .native) {
         // TODO We want to just use detected_info.target but implementing
         // CPU model & feature detection is todo so here we rely on LLVM.
         const llvm = @import("llvm.zig");

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -1163,6 +1163,7 @@ fn crossTargetToTarget(cross_target: CrossTarget, dynamic_linker_ptr: *?[*:0]u8)
         const arch = std.Target.current.cpu.arch;
         info.target.cpu = try detectNativeCpuWithLLVM(arch, llvm_cpu_name, llvm_cpu_features);
         cross_target.updateCpuFeatures(&info.target.cpu.features);
+        info.target.cpu.arch = cross_target.getCpuArch();
     }
     if (info.dynamic_linker.get()) |dl| {
         dynamic_linker_ptr.* = try mem.dupeZ(std.heap.c_allocator, u8, dl);

--- a/src-self-hosted/util.zig
+++ b/src-self-hosted/util.zig
@@ -34,25 +34,3 @@ pub fn initializeAllTargets() void {
     llvm.InitializeAllAsmPrinters();
     llvm.InitializeAllAsmParsers();
 }
-
-pub fn getTriple(allocator: *std.mem.Allocator, self: std.Target) !std.Buffer {
-    var result = try std.Buffer.initSize(allocator, 0);
-    errdefer result.deinit();
-
-    // LLVM WebAssembly output support requires the target to be activated at
-    // build type with -DCMAKE_LLVM_EXPIERMENTAL_TARGETS_TO_BUILD=WebAssembly.
-    //
-    // LLVM determines the output format based on the abi suffix,
-    // defaulting to an object based on the architecture. The default format in
-    // LLVM 6 sets the wasm arch output incorrectly to ELF. We need to
-    // explicitly set this ourself in order for it to work.
-    //
-    // This is fixed in LLVM 7 and you will be able to get wasm output by
-    // using the target triple `wasm32-unknown-unknown-unknown`.
-    const env_name = if (self.isWasm()) "wasm" else @tagName(self.getAbi());
-
-    var out = &std.io.BufferOutStream.init(&result).stream;
-    try out.print("{}-unknown-{}-{}", .{ @tagName(self.getArch()), @tagName(self.getOs()), env_name });
-
-    return result;
-}

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2255,7 +2255,6 @@ struct CodeGen {
     Buf *test_name_prefix;
     Buf *zig_lib_dir;
     Buf *zig_std_dir;
-    Buf *dynamic_linker_path;
     Buf *version_script_path;
 
     const char **llvm_argv;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2250,8 +2250,6 @@ struct CodeGen {
     bool test_is_evented;
     CodeModel code_model;
 
-    Buf *mmacosx_version_min;
-    Buf *mios_version_min;
     Buf *root_out_name;
     Buf *test_filter;
     Buf *test_name_prefix;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -3963,7 +3963,7 @@ static void resolve_decl_var(CodeGen *g, TldVar *tld_var, bool allow_lazy) {
 
     // TODO more validation for types that can't be used for export/extern variables
     ZigType *implicit_type = nullptr;
-    if (explicit_type != nullptr && explicit_type->id == ZigTypeIdInvalid) {
+    if (explicit_type != nullptr && type_is_invalid(explicit_type)) {
         implicit_type = explicit_type;
     } else if (var_decl->expr) {
         init_value = analyze_const_value(g, tld_var->base.parent_scope, var_decl->expr, explicit_type,

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -6734,8 +6734,6 @@ static bool const_values_equal_array(CodeGen *g, ZigValue *a, ZigValue *b, size_
 
 bool const_values_equal(CodeGen *g, ZigValue *a, ZigValue *b) {
     if (a->type->id != b->type->id) return false;
-    assert(a->special == ConstValSpecialStatic);
-    assert(b->special == ConstValSpecialStatic);
     if (a->type == b->type) {
         switch (type_has_one_possible_value(g, a->type)) {
             case OnePossibleValueInvalid:
@@ -6746,6 +6744,11 @@ bool const_values_equal(CodeGen *g, ZigValue *a, ZigValue *b) {
                 return true;
         }
     }
+    if (a->special == ConstValSpecialUndef || b->special == ConstValSpecialUndef) {
+        return a->special == b->special;
+    }
+    assert(a->special == ConstValSpecialStatic);
+    assert(b->special == ConstValSpecialStatic);
     switch (a->type->id) {
         case ZigTypeIdOpaque:
             zig_unreachable();

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -35,8 +35,6 @@ LinkLib *codegen_add_link_lib(CodeGen *codegen, Buf *lib);
 void codegen_add_framework(CodeGen *codegen, const char *name);
 void codegen_add_rpath(CodeGen *codegen, const char *name);
 void codegen_set_rdynamic(CodeGen *g, bool rdynamic);
-void codegen_set_mmacosx_version_min(CodeGen *g, Buf *mmacosx_version_min);
-void codegen_set_mios_version_min(CodeGen *g, Buf *mios_version_min);
 void codegen_set_linker_script(CodeGen *g, const char *linker_script);
 void codegen_set_test_filter(CodeGen *g, Buf *filter);
 void codegen_set_test_name_prefix(CodeGen *g, Buf *prefix);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -4,31 +4,6 @@
 
 #include <stdio.h>
 
-Buf *get_self_libc_path(void) {
-    static Buf saved_libc_path = BUF_INIT;
-    static bool searched_for_libc = false;
-
-    for (;;) {
-        if (saved_libc_path.list.length != 0) {
-            return &saved_libc_path;
-        }
-        if (searched_for_libc)
-            return nullptr;
-        ZigList<Buf *> lib_paths = {};
-        Error err;
-        if ((err = os_self_exe_shared_libs(lib_paths)))
-            return nullptr;
-        for (size_t i = 0; i < lib_paths.length; i += 1) {
-            Buf *lib_path = lib_paths.at(i);
-            if (buf_ends_with_str(lib_path, "libc.so.6")) {
-                buf_init_from_buf(&saved_libc_path, lib_path);
-                return &saved_libc_path;
-            }
-        }
-        searched_for_libc = true;
-    }
-}
-
 Error get_compiler_id(Buf **result) {
     static Buf saved_compiler_id = BUF_INIT;
 

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -12,7 +12,6 @@
 #include "error.hpp"
 
 Error get_compiler_id(Buf **result);
-Buf *get_self_libc_path(void);
 
 Buf *get_zig_lib_dir(void);
 Buf *get_zig_special_dir(Buf *zig_lib_dir);

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -81,6 +81,8 @@ const char *err_str(Error err) {
         case ErrorWindowsSdkNotFound: return "Windows SDK not found";
         case ErrorUnknownDynamicLinkerPath: return "unknown dynamic linker path";
         case ErrorTargetHasNoDynamicLinker: return "target has no dynamic linker";
+        case ErrorInvalidAbiVersion: return "invalid C ABI version";
+        case ErrorInvalidOperatingSystemVersion: return "invalid operating system version";
     }
     return "(invalid error)";
 }

--- a/src/glibc.cpp
+++ b/src/glibc.cpp
@@ -55,7 +55,7 @@ Error glibc_load_metadata(ZigGLibCAbi **out_result, Buf *zig_lib_dir, bool verbo
             Optional<Slice<uint8_t>> opt_component = SplitIterator_next(&it);
             if (!opt_component.is_some) break;
             Buf *ver_buf = buf_create_from_slice(opt_component.value);
-            ZigGLibCVersion *this_ver = glibc_abi->all_versions.add_one();
+            Stage2SemVer *this_ver = glibc_abi->all_versions.add_one();
             if ((err = target_parse_glibc_version(this_ver, buf_ptr(ver_buf)))) {
                 if (verbose) {
                     fprintf(stderr, "Unable to parse glibc version '%s': %s\n", buf_ptr(ver_buf), err_str(err));
@@ -186,9 +186,9 @@ Error glibc_build_dummies_and_maps(CodeGen *g, const ZigGLibCAbi *glibc_abi, con
     cache_buf(cache_hash, compiler_id);
     cache_int(cache_hash, target->arch);
     cache_int(cache_hash, target->abi);
-    cache_int(cache_hash, target->glibc_version->major);
-    cache_int(cache_hash, target->glibc_version->minor);
-    cache_int(cache_hash, target->glibc_version->patch);
+    cache_int(cache_hash, target->glibc_or_darwin_version->major);
+    cache_int(cache_hash, target->glibc_or_darwin_version->minor);
+    cache_int(cache_hash, target->glibc_or_darwin_version->patch);
 
     Buf digest = BUF_INIT;
     buf_resize(&digest, 0);
@@ -224,10 +224,10 @@ Error glibc_build_dummies_and_maps(CodeGen *g, const ZigGLibCAbi *glibc_abi, con
 
     uint8_t target_ver_index = 0;
     for (;target_ver_index < glibc_abi->all_versions.length; target_ver_index += 1) {
-        const ZigGLibCVersion *this_ver = &glibc_abi->all_versions.at(target_ver_index);
-        if (this_ver->major == target->glibc_version->major &&
-            this_ver->minor == target->glibc_version->minor &&
-            this_ver->patch == target->glibc_version->patch)
+        const Stage2SemVer *this_ver = &glibc_abi->all_versions.at(target_ver_index);
+        if (this_ver->major == target->glibc_or_darwin_version->major &&
+            this_ver->minor == target->glibc_or_darwin_version->minor &&
+            this_ver->patch == target->glibc_or_darwin_version->patch)
         {
             break;
         }
@@ -235,9 +235,9 @@ Error glibc_build_dummies_and_maps(CodeGen *g, const ZigGLibCAbi *glibc_abi, con
     if (target_ver_index == glibc_abi->all_versions.length) {
         if (verbose) {
             fprintf(stderr, "Unrecognized glibc version: %d.%d.%d\n",
-                   target->glibc_version->major,
-                   target->glibc_version->minor,
-                   target->glibc_version->patch);
+                   target->glibc_or_darwin_version->major,
+                   target->glibc_or_darwin_version->minor,
+                   target->glibc_or_darwin_version->patch);
         }
         return ErrorUnknownABI;
     }
@@ -246,7 +246,7 @@ Error glibc_build_dummies_and_maps(CodeGen *g, const ZigGLibCAbi *glibc_abi, con
     Buf *map_contents = buf_alloc();
 
     for (uint8_t ver_i = 0; ver_i < glibc_abi->all_versions.length; ver_i += 1) {
-        const ZigGLibCVersion *ver = &glibc_abi->all_versions.at(ver_i);
+        const Stage2SemVer *ver = &glibc_abi->all_versions.at(ver_i);
         if (ver->patch == 0) {
             buf_appendf(map_contents, "GLIBC_%d.%d { };\n", ver->major, ver->minor);
         } else {
@@ -294,7 +294,7 @@ Error glibc_build_dummies_and_maps(CodeGen *g, const ZigGLibCAbi *glibc_abi, con
                 uint8_t ver_index = ver_list->versions[ver_i];
 
                 Buf *stub_name;
-                const ZigGLibCVersion *ver = &glibc_abi->all_versions.at(ver_index);
+                const Stage2SemVer *ver = &glibc_abi->all_versions.at(ver_index);
                 const char *sym_name = buf_ptr(libc_fn->name);
                 if (ver->patch == 0) {
                     stub_name = buf_sprintf("%s_%d_%d", sym_name, ver->major, ver->minor);

--- a/src/glibc.hpp
+++ b/src/glibc.hpp
@@ -43,9 +43,6 @@ Error glibc_load_metadata(ZigGLibCAbi **out_result, Buf *zig_lib_dir, bool verbo
 Error glibc_build_dummies_and_maps(CodeGen *codegen, const ZigGLibCAbi *glibc_abi, const ZigTarget *target,
         Buf **out_dir, bool verbose, Stage2ProgressNode *progress_node);
 
-// returns ErrorUnknownABI when glibc is not the native libc
-Error glibc_detect_native_version(ZigGLibCVersion *glibc_ver);
-
 size_t glibc_lib_count(void);
 const ZigGLibCLib *glibc_lib_enum(size_t index);
 const ZigGLibCLib *glibc_lib_find(const char *name);

--- a/src/glibc.hpp
+++ b/src/glibc.hpp
@@ -32,7 +32,7 @@ struct ZigGLibCAbi {
     Buf *abi_txt_path;
     Buf *vers_txt_path;
     Buf *fns_txt_path;
-    ZigList<ZigGLibCVersion> all_versions;
+    ZigList<Stage2SemVer> all_versions;
     ZigList<ZigGLibCFn> all_functions;
     // The value is a pointer to all_functions.length items and each item is an index
     // into all_functions.

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -2371,99 +2371,6 @@ static void construct_linker_job_coff(LinkJob *lj) {
     }
 }
 
-
-// Parse (([0-9]+)(.([0-9]+)(.([0-9]+)?))?)? and return the
-// grouped values as integers. Numbers which are not provided are set to 0.
-// return true if the entire string was parsed (9.2), or all groups were
-// parsed (10.3.5extrastuff).
-static bool darwin_get_release_version(const char *str, int *major, int *minor, int *micro, bool *had_extra) {
-    *had_extra = false;
-
-    *major = 0;
-    *minor = 0;
-    *micro = 0;
-
-    if (*str == '\0')
-        return false;
-
-    char *end;
-    *major = (int)strtol(str, &end, 10);
-    if (*str != '\0' && *end == '\0')
-        return true;
-    if (*end != '.')
-        return false;
-
-    str = end + 1;
-    *minor = (int)strtol(str, &end, 10);
-    if (*str != '\0' && *end == '\0')
-        return true;
-    if (*end != '.')
-        return false;
-
-    str = end + 1;
-    *micro = (int)strtol(str, &end, 10);
-    if (*str != '\0' && *end == '\0')
-        return true;
-    if (str == end)
-        return false;
-    *had_extra = true;
-    return true;
-}
-
-enum DarwinPlatformKind {
-    MacOS,
-    IPhoneOS,
-    IPhoneOSSimulator,
-};
-
-struct DarwinPlatform {
-    DarwinPlatformKind kind;
-    int major;
-    int minor;
-    int micro;
-};
-
-static void get_darwin_platform(LinkJob *lj, DarwinPlatform *platform) {
-    CodeGen *g = lj->codegen;
-
-    if (g->mmacosx_version_min) {
-        platform->kind = MacOS;
-    } else if (g->mios_version_min) {
-        platform->kind = IPhoneOS;
-    } else if (g->zig_target->os == OsMacOSX) {
-        platform->kind = MacOS;
-        g->mmacosx_version_min = buf_create_from_str("10.14");
-    } else {
-        zig_panic("unable to infer -mmacosx-version-min or -mios-version-min");
-    }
-
-    bool had_extra;
-    if (platform->kind == MacOS) {
-        if (!darwin_get_release_version(buf_ptr(g->mmacosx_version_min),
-                    &platform->major, &platform->minor, &platform->micro, &had_extra) ||
-                had_extra || platform->major != 10 || platform->minor >= 100 || platform->micro >= 100)
-        {
-            zig_panic("invalid -mmacosx-version-min");
-        }
-    } else if (platform->kind == IPhoneOS) {
-        if (!darwin_get_release_version(buf_ptr(g->mios_version_min),
-                    &platform->major, &platform->minor, &platform->micro, &had_extra) ||
-                had_extra || platform->major >= 10 || platform->minor >= 100 || platform->micro >= 100)
-        {
-            zig_panic("invalid -mios-version-min");
-        }
-    } else {
-        zig_unreachable();
-    }
-
-    if (platform->kind == IPhoneOS &&
-        (g->zig_target->arch == ZigLLVM_x86 ||
-         g->zig_target->arch == ZigLLVM_x86_64))
-    {
-        platform->kind = IPhoneOSSimulator;
-    }
-}
-
 static void construct_linker_job_macho(LinkJob *lj) {
     CodeGen *g = lj->codegen;
 
@@ -2507,25 +2414,25 @@ static void construct_linker_job_macho(LinkJob *lj) {
     lj->args.append("-arch");
     lj->args.append(get_darwin_arch_string(g->zig_target));
 
-    DarwinPlatform platform;
-    get_darwin_platform(lj, &platform);
-    switch (platform.kind) {
-        case MacOS:
+    if (g->zig_target->glibc_or_darwin_version != nullptr) {
+        if (g->zig_target->os == OsMacOSX) {
             lj->args.append("-macosx_version_min");
-            break;
-        case IPhoneOS:
-            lj->args.append("-iphoneos_version_min");
-            break;
-        case IPhoneOSSimulator:
-            lj->args.append("-ios_simulator_version_min");
-            break;
+        } else if (g->zig_target->os == OsIOS) {
+            if (g->zig_target->arch == ZigLLVM_x86 || g->zig_target->arch == ZigLLVM_x86_64) {
+                lj->args.append("-ios_simulator_version_min");
+            } else {
+                lj->args.append("-iphoneos_version_min");
+            }
+        }
+        Buf *version_string = buf_sprintf("%d.%d.%d",
+            g->zig_target->glibc_or_darwin_version->major,
+            g->zig_target->glibc_or_darwin_version->minor,
+            g->zig_target->glibc_or_darwin_version->patch);
+        lj->args.append(buf_ptr(version_string));
+
+        lj->args.append("-sdk_version");
+        lj->args.append(buf_ptr(version_string));
     }
-    Buf *version_string = buf_sprintf("%d.%d.%d", platform.major, platform.minor, platform.micro);
-    lj->args.append(buf_ptr(version_string));
-
-    lj->args.append("-sdk_version");
-    lj->args.append(buf_ptr(version_string));
-
 
     if (g->out_type == OutTypeExe) {
         lj->args.append("-pie");

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -1751,9 +1751,9 @@ static void construct_linker_job_elf(LinkJob *lj) {
         }
 
         if (g->have_dynamic_link && (is_dyn_lib || g->out_type == OutTypeExe)) {
-            assert(g->dynamic_linker_path != nullptr);
+            assert(g->zig_target->dynamic_linker != nullptr);
             lj->args.append("-dynamic-linker");
-            lj->args.append(buf_ptr(g->dynamic_linker_path));
+            lj->args.append(g->zig_target->dynamic_linker);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -500,7 +500,10 @@ static int main0(int argc, char **argv) {
         os_path_join(get_zig_special_dir(zig_lib_dir), buf_create_from_str("build_runner.zig"), build_runner_path);
 
         ZigTarget target;
-        get_native_target(&target);
+        if ((err = target_parse_triple(&target, "native", nullptr))) {
+            fprintf(stderr, "Unable to get native target: %s\n", err_str(err));
+            return EXIT_FAILURE;
+        }
 
         Buf *build_file_buf = buf_create_from_str((build_file != nullptr) ? build_file : "build.zig");
         Buf build_file_abs = os_path_resolve(&build_file_buf, 1);
@@ -1337,7 +1340,10 @@ static int main0(int argc, char **argv) {
                 return main_exit(root_progress_node, EXIT_SUCCESS);
             } else if (cmd == CmdTest) {
                 ZigTarget native;
-                get_native_target(&native);
+                if ((err = target_parse_triple(&native, "native", nullptr))) {
+                    fprintf(stderr, "Unable to get native target: %s\n", err_str(err));
+                    return EXIT_FAILURE;
+                }
 
                 g->enable_cache = get_cache_opt(enable_cache, output_dir == nullptr);
                 codegen_build_and_link(g);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,8 +127,6 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  --subsystem [subsystem]      (windows) /SUBSYSTEM:<subsystem> to the linker\n"
         "  -F[dir]                      (darwin) add search path for frameworks\n"
         "  -framework [name]            (darwin) link against framework\n"
-        "  -mios-version-min [ver]      (darwin) set iOS deployment target\n"
-        "  -mmacosx-version-min [ver]   (darwin) set Mac OS X deployment target\n"
         "  --ver-major [ver]            dynamic library semver major version\n"
         "  --ver-minor [ver]            dynamic library semver minor version\n"
         "  --ver-patch [ver]            dynamic library semver patch version\n"
@@ -414,8 +412,6 @@ static int main0(int argc, char **argv) {
     bool have_libc = false;
     const char *target_string = nullptr;
     bool rdynamic = false;
-    const char *mmacosx_version_min = nullptr;
-    const char *mios_version_min = nullptr;
     const char *linker_script = nullptr;
     Buf *version_script = nullptr;
     ZigList<const char *> rpath_list = {0};
@@ -844,10 +840,6 @@ static int main0(int argc, char **argv) {
                     cache_dir = argv[i];
                 } else if (strcmp(arg, "-target") == 0) {
                     target_string = argv[i];
-                } else if (strcmp(arg, "-mmacosx-version-min") == 0) {
-                    mmacosx_version_min = argv[i];
-                } else if (strcmp(arg, "-mios-version-min") == 0) {
-                    mios_version_min = argv[i];
                 } else if (strcmp(arg, "-framework") == 0) {
                     frameworks.append(argv[i]);
                 } else if (strcmp(arg, "--linker-script") == 0) {
@@ -1240,18 +1232,6 @@ static int main0(int argc, char **argv) {
             }
 
             codegen_set_rdynamic(g, rdynamic);
-            if (mmacosx_version_min && mios_version_min) {
-                fprintf(stderr, "-mmacosx-version-min and -mios-version-min options not allowed together\n");
-                return main_exit(root_progress_node, EXIT_FAILURE);
-            }
-
-            if (mmacosx_version_min) {
-                codegen_set_mmacosx_version_min(g, buf_create_from_str(mmacosx_version_min));
-            }
-
-            if (mios_version_min) {
-                codegen_set_mios_version_min(g, buf_create_from_str(mios_version_min));
-            }
 
             if (test_filter) {
                 codegen_set_test_filter(g, buf_create_from_str(test_filter));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -401,7 +401,7 @@ static int main0(int argc, char **argv) {
     bool link_eh_frame_hdr = false;
     ErrColor color = ErrColorAuto;
     CacheOpt enable_cache = CacheOptAuto;
-    Buf *dynamic_linker = nullptr;
+    const char *dynamic_linker = nullptr;
     const char *libc_txt = nullptr;
     ZigList<const char *> clang_argv = {0};
     ZigList<const char *> lib_dirs = {0};
@@ -496,7 +496,7 @@ static int main0(int argc, char **argv) {
         os_path_join(get_zig_special_dir(zig_lib_dir), buf_create_from_str("build_runner.zig"), build_runner_path);
 
         ZigTarget target;
-        if ((err = target_parse_triple(&target, "native", nullptr))) {
+        if ((err = target_parse_triple(&target, "native", nullptr, nullptr))) {
             fprintf(stderr, "Unable to get native target: %s\n", err_str(err));
             return EXIT_FAILURE;
         }
@@ -766,7 +766,7 @@ static int main0(int argc, char **argv) {
                 } else if (strcmp(arg, "--name") == 0) {
                     out_name = argv[i];
                 } else if (strcmp(arg, "--dynamic-linker") == 0) {
-                    dynamic_linker = buf_create_from_str(argv[i]);
+                    dynamic_linker = argv[i];
                 } else if (strcmp(arg, "--libc") == 0) {
                     libc_txt = argv[i];
                 } else if (strcmp(arg, "-D") == 0) {
@@ -968,7 +968,7 @@ static int main0(int argc, char **argv) {
     init_all_targets();
 
     ZigTarget target;
-    if ((err = target_parse_triple(&target, target_string, mcpu))) {
+    if ((err = target_parse_triple(&target, target_string, mcpu, dynamic_linker))) {
         fprintf(stderr, "invalid target: %s\n"
                 "See `%s targets` to display valid targets.\n", err_str(err), arg0);
         return print_error_usage(arg0);
@@ -1193,7 +1193,6 @@ static int main0(int argc, char **argv) {
 
             codegen_set_strip(g, strip);
             g->is_dynamic = is_dynamic;
-            g->dynamic_linker_path = dynamic_linker;
             g->verbose_tokenize = verbose_tokenize;
             g->verbose_ast = verbose_ast;
             g->verbose_link = verbose_link;
@@ -1320,7 +1319,7 @@ static int main0(int argc, char **argv) {
                 return main_exit(root_progress_node, EXIT_SUCCESS);
             } else if (cmd == CmdTest) {
                 ZigTarget native;
-                if ((err = target_parse_triple(&native, "native", nullptr))) {
+                if ((err = target_parse_triple(&native, "native", nullptr, nullptr))) {
                     fprintf(stderr, "Unable to get native target: %s\n", err_str(err));
                     return EXIT_FAILURE;
                 }

--- a/src/stage2.cpp
+++ b/src/stage2.cpp
@@ -100,13 +100,11 @@ Error stage2_target_parse(struct ZigTarget *target, const char *zig_triple, cons
         if (mcpu == nullptr) {
             target->llvm_cpu_name = ZigLLVMGetHostCPUName();
             target->llvm_cpu_features = ZigLLVMGetNativeFeatures();
-            target->builtin_str = "Target.Cpu.baseline(arch);\n";
             target->cache_hash = "native\n\n";
         } else if (strcmp(mcpu, "baseline") == 0) {
             target->is_native = false;
             target->llvm_cpu_name = "";
             target->llvm_cpu_features = "";
-            target->builtin_str = "Target.Cpu.baseline(arch);\n";
             target->cache_hash = "baseline\n\n";
         } else {
             const char *msg = "stage0 can't handle CPU/features in the target";
@@ -148,7 +146,6 @@ Error stage2_target_parse(struct ZigTarget *target, const char *zig_triple, cons
             const char *msg = "stage0 can't handle CPU/features in the target";
             stage2_panic(msg, strlen(msg));
         }
-        target->builtin_str = "Target.Cpu.baseline(arch);\n";
         target->cache_hash = "\n\n";
     }
 
@@ -183,11 +180,6 @@ enum Error stage2_libc_render(struct Stage2LibCInstallation *self, FILE *file) {
 
 enum Error stage2_libc_find_native(struct Stage2LibCInstallation *libc) {
     const char *msg = "stage0 called stage2_libc_find_native";
-    stage2_panic(msg, strlen(msg));
-}
-
-enum Error stage2_detect_dynamic_linker(const struct ZigTarget *target, char **out_ptr, size_t *out_len) {
-    const char *msg = "stage0 called stage2_detect_dynamic_linker";
     stage2_panic(msg, strlen(msg));
 }
 

--- a/src/stage2.cpp
+++ b/src/stage2.cpp
@@ -191,7 +191,9 @@ static void get_native_target(ZigTarget *target) {
     }
 }
 
-Error stage2_target_parse(struct ZigTarget *target, const char *zig_triple, const char *mcpu) {
+Error stage2_target_parse(struct ZigTarget *target, const char *zig_triple, const char *mcpu,
+        const char *dynamic_linker)
+{
     Error err;
 
     if (zig_triple == nullptr) {
@@ -249,6 +251,9 @@ Error stage2_target_parse(struct ZigTarget *target, const char *zig_triple, cons
         target->cache_hash = "\n\n";
     }
 
+    if (dynamic_linker != nullptr) {
+        target->dynamic_linker = dynamic_linker;
+    }
     return ErrorNone;
 }
 

--- a/src/stage2.cpp
+++ b/src/stage2.cpp
@@ -186,7 +186,7 @@ static void get_native_target(ZigTarget *target) {
         target->abi = target_default_abi(target->arch, target->os);
     }
     if (target_is_glibc(target)) {
-        target->glibc_version = heap::c_allocator.create<ZigGLibCVersion>();
+        target->glibc_or_darwin_version = heap::c_allocator.create<Stage2SemVer>();
         target_init_default_glibc_version(target);
     }
 }

--- a/src/stage2.cpp
+++ b/src/stage2.cpp
@@ -91,6 +91,106 @@ void stage2_progress_complete_one(Stage2ProgressNode *node) {}
 void stage2_progress_disable_tty(Stage2Progress *progress) {}
 void stage2_progress_update_node(Stage2ProgressNode *node, size_t completed_count, size_t estimated_total_items){}
 
+static Os get_zig_os_type(ZigLLVM_OSType os_type) {
+    switch (os_type) {
+        case ZigLLVM_UnknownOS:
+            return OsFreestanding;
+        case ZigLLVM_Ananas:
+            return OsAnanas;
+        case ZigLLVM_CloudABI:
+            return OsCloudABI;
+        case ZigLLVM_DragonFly:
+            return OsDragonFly;
+        case ZigLLVM_FreeBSD:
+            return OsFreeBSD;
+        case ZigLLVM_Fuchsia:
+            return OsFuchsia;
+        case ZigLLVM_IOS:
+            return OsIOS;
+        case ZigLLVM_KFreeBSD:
+            return OsKFreeBSD;
+        case ZigLLVM_Linux:
+            return OsLinux;
+        case ZigLLVM_Lv2:
+            return OsLv2;
+        case ZigLLVM_Darwin:
+        case ZigLLVM_MacOSX:
+            return OsMacOSX;
+        case ZigLLVM_NetBSD:
+            return OsNetBSD;
+        case ZigLLVM_OpenBSD:
+            return OsOpenBSD;
+        case ZigLLVM_Solaris:
+            return OsSolaris;
+        case ZigLLVM_Win32:
+            return OsWindows;
+        case ZigLLVM_Haiku:
+            return OsHaiku;
+        case ZigLLVM_Minix:
+            return OsMinix;
+        case ZigLLVM_RTEMS:
+            return OsRTEMS;
+        case ZigLLVM_NaCl:
+            return OsNaCl;
+        case ZigLLVM_CNK:
+            return OsCNK;
+        case ZigLLVM_AIX:
+            return OsAIX;
+        case ZigLLVM_CUDA:
+            return OsCUDA;
+        case ZigLLVM_NVCL:
+            return OsNVCL;
+        case ZigLLVM_AMDHSA:
+            return OsAMDHSA;
+        case ZigLLVM_PS4:
+            return OsPS4;
+        case ZigLLVM_ELFIAMCU:
+            return OsELFIAMCU;
+        case ZigLLVM_TvOS:
+            return OsTvOS;
+        case ZigLLVM_WatchOS:
+            return OsWatchOS;
+        case ZigLLVM_Mesa3D:
+            return OsMesa3D;
+        case ZigLLVM_Contiki:
+            return OsContiki;
+        case ZigLLVM_AMDPAL:
+            return OsAMDPAL;
+        case ZigLLVM_HermitCore:
+            return OsHermitCore;
+        case ZigLLVM_Hurd:
+            return OsHurd;
+        case ZigLLVM_WASI:
+            return OsWASI;
+        case ZigLLVM_Emscripten:
+            return OsEmscripten;
+    }
+    zig_unreachable();
+}
+
+static void get_native_target(ZigTarget *target) {
+    // first zero initialize
+    *target = {};
+
+    ZigLLVM_OSType os_type;
+    ZigLLVM_ObjectFormatType oformat; // ignored; based on arch/os
+    ZigLLVMGetNativeTarget(
+            &target->arch,
+            &target->vendor,
+            &os_type,
+            &target->abi,
+            &oformat);
+    target->os = get_zig_os_type(os_type);
+    target->is_native = true;
+    if (target->abi == ZigLLVM_UnknownEnvironment) {
+        target->abi = target_default_abi(target->arch, target->os);
+    }
+    if (target_is_glibc(target)) {
+        target->glibc_version = heap::c_allocator.create<ZigGLibCVersion>();
+        target_init_default_glibc_version(target);
+    }
+}
+
 Error stage2_target_parse(struct ZigTarget *target, const char *zig_triple, const char *mcpu) {
     Error err;
 

--- a/src/stage2.h
+++ b/src/stage2.h
@@ -103,6 +103,8 @@ enum Error {
     ErrorWindowsSdkNotFound,
     ErrorUnknownDynamicLinkerPath,
     ErrorTargetHasNoDynamicLinker,
+    ErrorInvalidAbiVersion,
+    ErrorInvalidOperatingSystemVersion,
 };
 
 // ABI warning
@@ -290,13 +292,11 @@ struct ZigTarget {
 
     const char *llvm_cpu_name;
     const char *llvm_cpu_features;
-    const char *builtin_str;
+    const char *cpu_builtin_str;
     const char *cache_hash;
+    const char *os_builtin_str;
+    const char *dynamic_linker;
 };
-
-// ABI warning
-ZIG_EXTERN_C enum Error stage2_detect_dynamic_linker(const struct ZigTarget *target,
-        char **out_ptr, size_t *out_len);
 
 // ABI warning
 ZIG_EXTERN_C enum Error stage2_target_parse(struct ZigTarget *target, const char *zig_triple, const char *mcpu);

--- a/src/stage2.h
+++ b/src/stage2.h
@@ -270,13 +270,11 @@ enum Os {
 };
 
 // ABI warning
-struct ZigGLibCVersion {
-    uint32_t major; // always 2
+struct Stage2SemVer {
+    uint32_t major;
     uint32_t minor;
     uint32_t patch;
 };
-
-struct Stage2TargetData;
 
 // ABI warning
 struct ZigTarget {
@@ -288,7 +286,8 @@ struct ZigTarget {
 
     bool is_native;
 
-    struct ZigGLibCVersion *glibc_version; // null means default
+    // null means default. this is double-purposed to be darwin min version
+    struct Stage2SemVer *glibc_or_darwin_version;
 
     const char *llvm_cpu_name;
     const char *llvm_cpu_features;

--- a/src/stage2.h
+++ b/src/stage2.h
@@ -298,7 +298,8 @@ struct ZigTarget {
 };
 
 // ABI warning
-ZIG_EXTERN_C enum Error stage2_target_parse(struct ZigTarget *target, const char *zig_triple, const char *mcpu);
+ZIG_EXTERN_C enum Error stage2_target_parse(struct ZigTarget *target, const char *zig_triple, const char *mcpu,
+        const char *dynamic_linker);
 
 
 // ABI warning

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -287,83 +287,6 @@ ZigLLVM_OSType get_llvm_os_type(Os os_type) {
     zig_unreachable();
 }
 
-static Os get_zig_os_type(ZigLLVM_OSType os_type) {
-    switch (os_type) {
-        case ZigLLVM_UnknownOS:
-            return OsFreestanding;
-        case ZigLLVM_Ananas:
-            return OsAnanas;
-        case ZigLLVM_CloudABI:
-            return OsCloudABI;
-        case ZigLLVM_DragonFly:
-            return OsDragonFly;
-        case ZigLLVM_FreeBSD:
-            return OsFreeBSD;
-        case ZigLLVM_Fuchsia:
-            return OsFuchsia;
-        case ZigLLVM_IOS:
-            return OsIOS;
-        case ZigLLVM_KFreeBSD:
-            return OsKFreeBSD;
-        case ZigLLVM_Linux:
-            return OsLinux;
-        case ZigLLVM_Lv2:
-            return OsLv2;
-        case ZigLLVM_Darwin:
-        case ZigLLVM_MacOSX:
-            return OsMacOSX;
-        case ZigLLVM_NetBSD:
-            return OsNetBSD;
-        case ZigLLVM_OpenBSD:
-            return OsOpenBSD;
-        case ZigLLVM_Solaris:
-            return OsSolaris;
-        case ZigLLVM_Win32:
-            return OsWindows;
-        case ZigLLVM_Haiku:
-            return OsHaiku;
-        case ZigLLVM_Minix:
-            return OsMinix;
-        case ZigLLVM_RTEMS:
-            return OsRTEMS;
-        case ZigLLVM_NaCl:
-            return OsNaCl;
-        case ZigLLVM_CNK:
-            return OsCNK;
-        case ZigLLVM_AIX:
-            return OsAIX;
-        case ZigLLVM_CUDA:
-            return OsCUDA;
-        case ZigLLVM_NVCL:
-            return OsNVCL;
-        case ZigLLVM_AMDHSA:
-            return OsAMDHSA;
-        case ZigLLVM_PS4:
-            return OsPS4;
-        case ZigLLVM_ELFIAMCU:
-            return OsELFIAMCU;
-        case ZigLLVM_TvOS:
-            return OsTvOS;
-        case ZigLLVM_WatchOS:
-            return OsWatchOS;
-        case ZigLLVM_Mesa3D:
-            return OsMesa3D;
-        case ZigLLVM_Contiki:
-            return OsContiki;
-        case ZigLLVM_AMDPAL:
-            return OsAMDPAL;
-        case ZigLLVM_HermitCore:
-            return OsHermitCore;
-        case ZigLLVM_Hurd:
-            return OsHurd;
-        case ZigLLVM_WASI:
-            return OsWASI;
-        case ZigLLVM_Emscripten:
-            return OsEmscripten;
-    }
-    zig_unreachable();
-}
-
 const char *target_os_name(Os os_type) {
     switch (os_type) {
         case OsFreestanding:
@@ -445,29 +368,6 @@ Error target_parse_glibc_version(ZigGLibCVersion *glibc_ver, const char *text) {
         glibc_ver->patch = strtoul(buf_ptr(buf_create_from_slice(opt_component.value)), nullptr, 10);
     }
     return ErrorNone;
-}
-
-void get_native_target(ZigTarget *target) {
-    // first zero initialize
-    *target = {};
-
-    ZigLLVM_OSType os_type;
-    ZigLLVM_ObjectFormatType oformat; // ignored; based on arch/os
-    ZigLLVMGetNativeTarget(
-            &target->arch,
-            &target->vendor,
-            &os_type,
-            &target->abi,
-            &oformat);
-    target->os = get_zig_os_type(os_type);
-    target->is_native = true;
-    if (target->abi == ZigLLVM_UnknownEnvironment) {
-        target->abi = target_default_abi(target->arch, target->os);
-    }
-    if (target_is_glibc(target)) {
-        target->glibc_version = heap::c_allocator.create<ZigGLibCVersion>();
-        target_init_default_glibc_version(target);
-    }
 }
 
 void target_init_default_glibc_version(ZigTarget *target) {

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -410,8 +410,8 @@ Error target_parse_abi(ZigLLVM_EnvironmentType *out_abi, const char *abi_ptr, si
     return ErrorUnknownABI;
 }
 
-Error target_parse_triple(ZigTarget *target, const char *triple, const char *mcpu) {
-    return stage2_target_parse(target, triple, mcpu);
+Error target_parse_triple(ZigTarget *target, const char *triple, const char *mcpu, const char *dynamic_linker) {
+    return stage2_target_parse(target, triple, mcpu, dynamic_linker);
 }
 
 const char *target_arch_name(ZigLLVM_ArchType arch) {

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -347,7 +347,7 @@ const char *target_abi_name(ZigLLVM_EnvironmentType abi) {
     return ZigLLVMGetEnvironmentTypeName(abi);
 }
 
-Error target_parse_glibc_version(ZigGLibCVersion *glibc_ver, const char *text) {
+Error target_parse_glibc_version(Stage2SemVer *glibc_ver, const char *text) {
     glibc_ver->major = 2;
     glibc_ver->minor = 0;
     glibc_ver->patch = 0;
@@ -371,7 +371,7 @@ Error target_parse_glibc_version(ZigGLibCVersion *glibc_ver, const char *text) {
 }
 
 void target_init_default_glibc_version(ZigTarget *target) {
-    *target->glibc_version = {2, 17, 0};
+    *target->glibc_or_darwin_version = {2, 17, 0};
 }
 
 Error target_parse_arch(ZigLLVM_ArchType *out_arch, const char *arch_ptr, size_t arch_len) {

--- a/src/target.hpp
+++ b/src/target.hpp
@@ -46,7 +46,7 @@ Error target_parse_arch(ZigLLVM_ArchType *arch, const char *arch_ptr, size_t arc
 Error target_parse_os(Os *os, const char *os_ptr, size_t os_len);
 Error target_parse_abi(ZigLLVM_EnvironmentType *abi, const char *abi_ptr, size_t abi_len);
 
-Error target_parse_glibc_version(ZigGLibCVersion *out, const char *text);
+Error target_parse_glibc_version(Stage2SemVer *out, const char *text);
 void target_init_default_glibc_version(ZigTarget *target);
 
 size_t target_arch_count(void);

--- a/src/target.hpp
+++ b/src/target.hpp
@@ -73,7 +73,6 @@ ZigLLVM_ObjectFormatType target_oformat_enum(size_t index);
 const char *target_oformat_name(ZigLLVM_ObjectFormatType oformat);
 ZigLLVM_ObjectFormatType target_object_format(const ZigTarget *target);
 
-void get_native_target(ZigTarget *target);
 void target_triple_llvm(Buf *triple, const ZigTarget *target);
 void target_triple_zig(Buf *triple, const ZigTarget *target);
 

--- a/src/target.hpp
+++ b/src/target.hpp
@@ -41,7 +41,7 @@ enum CIntType {
     CIntTypeCount,
 };
 
-Error target_parse_triple(ZigTarget *target, const char *triple, const char *mcpu);
+Error target_parse_triple(ZigTarget *target, const char *triple, const char *mcpu, const char *dynamic_linker);
 Error target_parse_arch(ZigLLVM_ArchType *arch, const char *arch_ptr, size_t arch_len);
 Error target_parse_os(Os *os, const char *os_ptr, size_t os_len);
 Error target_parse_abi(ZigLLVM_EnvironmentType *abi, const char *abi_ptr, size_t abi_len);

--- a/test/assemble_and_link.zig
+++ b/test/assemble_and_link.zig
@@ -1,8 +1,8 @@
-const builtin = @import("builtin");
+const std = @import("std");
 const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompareOutputContext) void {
-    if (builtin.os == builtin.Os.linux and builtin.arch == builtin.Arch.x86_64) {
+    if (std.Target.current.os.tag == .linux and std.Target.current.cpu.arch == .x86_64) {
         cases.addAsm("hello world linux x86_64",
             \\.text
             \\.globl _start

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const testing = std.testing;
 const process = std.process;
 const fs = std.fs;
@@ -97,7 +96,7 @@ fn testZigInitExe(zig_exe: []const u8, dir_path: []const u8) !void {
 }
 
 fn testGodboltApi(zig_exe: []const u8, dir_path: []const u8) anyerror!void {
-    if (builtin.os != .linux or builtin.arch != .x86_64) return;
+    if (std.Target.current.os.tag != .linux or std.Target.current.cpu.arch != .x86_64) return;
 
     const example_zig_path = try fs.path.join(a, &[_][]const u8{ dir_path, "example.zig" });
     const example_s_path = try fs.path.join(a, &[_][]const u8{ dir_path, "example.s" });

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -92,7 +92,7 @@ fn testZigInitLib(zig_exe: []const u8, dir_path: []const u8) !void {
 fn testZigInitExe(zig_exe: []const u8, dir_path: []const u8) !void {
     _ = try exec(dir_path, &[_][]const u8{ zig_exe, "init-exe" });
     const run_result = try exec(dir_path, &[_][]const u8{ zig_exe, "build", "run" });
-    testing.expect(std.mem.eql(u8, run_result.stderr, "All your base are belong to us.\n"));
+    testing.expect(std.mem.eql(u8, run_result.stderr, "All your codebase are belong to us.\n"));
 }
 
 fn testGodboltApi(zig_exe: []const u8, dir_path: []const u8) anyerror!void {

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -1,4 +1,3 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const os = std.os;
 const tests = @import("tests.zig");
@@ -131,8 +130,8 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
     , "Hello, world!\n  12  12 a\n");
 
     cases.addC("number literals",
-        \\const builtin = @import("builtin");
-        \\const is_windows = builtin.os == builtin.Os.windows;
+        \\const std = @import("std");
+        \\const is_windows = std.Target.current.os.tag == .windows;
         \\const c = @cImport({
         \\    if (is_windows) {
         \\        // See https://github.com/ziglang/zig/issues/515
@@ -306,8 +305,8 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
     , "");
 
     cases.addC("casting between float and integer types",
-        \\const builtin = @import("builtin");
-        \\const is_windows = builtin.os == builtin.Os.windows;
+        \\const std = @import("std");
+        \\const is_windows = std.Target.current.os.tag == .windows;
         \\const c = @cImport({
         \\    if (is_windows) {
         \\        // See https://github.com/ziglang/zig/issues/515

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1,5 +1,5 @@
 const tests = @import("tests.zig");
-const Target = @import("std").Target;
+const std = @import("std");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
     cases.addTest("type mismatch with tuple concatenation",
@@ -386,12 +386,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         , &[_][]const u8{
             "tmp.zig:3:5: error: target arch 'wasm32' does not support calling with a new stack",
         });
-        tc.target = tests.Target{
-            .Cross = .{
-                .cpu = Target.Cpu.baseline(.wasm32),
-                .os = Target.Os.defaultVersionRange(.wasi),
-                .abi = .none,
-            },
+        tc.target = std.zig.CrossTarget{
+            .cpu_arch = .wasm32,
+            .os_tag = .wasi,
+            .abi = .none,
         };
         break :x tc;
     });
@@ -787,12 +785,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         , &[_][]const u8{
             "tmp.zig:2:14: error: could not find 'foo' in the inputs or outputs",
         });
-        tc.target = tests.Target{
-            .Cross = .{
-                .cpu = Target.Cpu.baseline(.x86_64),
-                .os = Target.Os.defaultVersionRange(.linux),
-                .abi = .gnu,
-            },
+        tc.target = std.zig.CrossTarget{
+            .cpu_arch = .x86_64,
+            .os_tag = .linux,
+            .abi = .gnu,
         };
         break :x tc;
     });
@@ -1452,7 +1448,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:2:18: error: invalid operands to binary expression: 'error{A}' and 'error{B}'",
     });
 
-    if (Target.current.os.tag == .linux) {
+    if (std.Target.current.os.tag == .linux) {
         cases.addTest("implicit dependency on libc",
             \\extern "c" fn exit(u8) void;
             \\export fn entry() void {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1,5 +1,4 @@
 const tests = @import("tests.zig");
-const builtin = @import("builtin");
 const Target = @import("std").Target;
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
@@ -387,10 +386,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         , &[_][]const u8{
             "tmp.zig:3:5: error: target arch 'wasm32' does not support calling with a new stack",
         });
-        tc.target = Target{
+        tc.target = tests.Target{
             .Cross = .{
                 .cpu = Target.Cpu.baseline(.wasm32),
-                .os = .wasi,
+                .os = Target.Os.defaultVersionRange(.wasi),
                 .abi = .none,
             },
         };
@@ -788,10 +787,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         , &[_][]const u8{
             "tmp.zig:2:14: error: could not find 'foo' in the inputs or outputs",
         });
-        tc.target = Target{
+        tc.target = tests.Target{
             .Cross = .{
                 .cpu = Target.Cpu.baseline(.x86_64),
-                .os = .linux,
+                .os = Target.Os.defaultVersionRange(.linux),
                 .abi = .gnu,
             },
         };
@@ -1453,7 +1452,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:2:18: error: invalid operands to binary expression: 'error{A}' and 'error{B}'",
     });
 
-    if (builtin.os == builtin.Os.linux) {
+    if (Target.current.os.tag == .linux) {
         cases.addTest("implicit dependency on libc",
             \\extern "c" fn exit(u8) void;
             \\export fn entry() void {

--- a/test/src/translate_c.zig
+++ b/test/src/translate_c.zig
@@ -19,7 +19,7 @@ pub const TranslateCContext = struct {
         sources: ArrayList(SourceFile),
         expected_lines: ArrayList([]const u8),
         allow_warnings: bool,
-        target: std.Target = .Native,
+        target: build.Target = .Native,
 
         const SourceFile = struct {
             filename: []const u8,
@@ -75,7 +75,7 @@ pub const TranslateCContext = struct {
     pub fn addWithTarget(
         self: *TranslateCContext,
         name: []const u8,
-        target: std.Target,
+        target: build.Target,
         source: []const u8,
         expected_lines: []const []const u8,
     ) void {

--- a/test/src/translate_c.zig
+++ b/test/src/translate_c.zig
@@ -7,6 +7,7 @@ const fmt = std.fmt;
 const mem = std.mem;
 const fs = std.fs;
 const warn = std.debug.warn;
+const CrossTarget = std.zig.CrossTarget;
 
 pub const TranslateCContext = struct {
     b: *build.Builder,
@@ -19,7 +20,7 @@ pub const TranslateCContext = struct {
         sources: ArrayList(SourceFile),
         expected_lines: ArrayList([]const u8),
         allow_warnings: bool,
-        target: build.Target = .Native,
+        target: CrossTarget = CrossTarget{},
 
         const SourceFile = struct {
             filename: []const u8,
@@ -75,7 +76,7 @@ pub const TranslateCContext = struct {
     pub fn addWithTarget(
         self: *TranslateCContext,
         name: []const u8,
-        target: build.Target,
+        target: CrossTarget,
         source: []const u8,
         expected_lines: []const []const u8,
     ) void {

--- a/test/stack_traces.zig
+++ b/test/stack_traces.zig
@@ -1,4 +1,3 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const os = std.os;
 const tests = @import("tests.zig");
@@ -43,32 +42,32 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
     ;
 
-    switch (builtin.os) {
+    switch (builtin.os.tag) {
         .freebsd => {
             cases.addCase(
                 "return",
                 source_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in main (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.main (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -77,7 +76,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_try_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in foo (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -87,7 +86,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.main (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -97,11 +96,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -110,7 +109,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_try_try_return_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in make_error (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -126,7 +125,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in std.start.main (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -142,11 +141,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -157,25 +156,25 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in main (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.posixCallMainAndExit (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -184,7 +183,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_try_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in foo (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -194,7 +193,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in std.start.posixCallMainAndExit (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -204,11 +203,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -217,7 +216,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_try_try_return_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in make_error (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -233,7 +232,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-safe
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:12:5: [address] in std.start.posixCallMainAndExit (test)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -249,11 +248,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -278,11 +277,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -311,11 +310,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -356,11 +355,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\
                 ,
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -371,7 +370,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 source_return,
                 [_][]const u8{
                 // debug
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\source.zig:4:5: [address] in main (test.obj)
                     \\    return error.TheSkyIsFalling;
                     \\    ^
@@ -381,11 +380,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // --disabled-- results in segmenetation fault
                 "",
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -407,11 +406,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // --disabled-- results in segmenetation fault
                 "",
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );
@@ -439,11 +438,11 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 // --disabled-- results in segmenetation fault
                 "",
                 // release-fast
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 ,
                 // release-small
-                    \\error: TheSkyIsFalling
+                \\error: TheSkyIsFalling
                     \\
                 },
             );

--- a/test/stack_traces.zig
+++ b/test/stack_traces.zig
@@ -42,7 +42,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
     ;
 
-    switch (builtin.os.tag) {
+    switch (std.Target.current.os.tag) {
         .freebsd => {
             cases.addCase(
                 "return",

--- a/test/stage1/behavior/asm.zig
+++ b/test/stage1/behavior/asm.zig
@@ -1,9 +1,10 @@
 const std = @import("std");
-const config = @import("builtin");
 const expect = std.testing.expect;
 
+const is_x86_64_linux = std.Target.current.cpu.arch == .x86_64 and std.Target.current.os.tag == .linux;
+
 comptime {
-    if (config.arch == config.Arch.x86_64 and config.os == config.Os.linux) {
+    if (is_x86_64_linux) {
         asm (
             \\.globl this_is_my_alias;
             \\.type this_is_my_alias, @function;
@@ -13,7 +14,7 @@ comptime {
 }
 
 test "module level assembly" {
-    if (config.arch == config.Arch.x86_64 and config.os == config.Os.linux) {
+    if (is_x86_64_linux) {
         expect(this_is_my_alias() == 1234);
     }
 }

--- a/test/stage1/behavior/byteswap.zig
+++ b/test/stage1/behavior/byteswap.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const expect = std.testing.expect;
-const builtin = @import("builtin");
 
 test "@byteSwap integers" {
     const ByteSwapIntTest = struct {
@@ -41,10 +40,10 @@ test "@byteSwap integers" {
 
 test "@byteSwap vectors" {
     // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
+    if (std.Target.current.os.tag == .dragonfly) return error.SkipZigTest;
 
     // https://github.com/ziglang/zig/issues/3317
-    if (builtin.arch == .mipsel) return error.SkipZigTest;
+    if (std.Target.current.cpu.arch == .mipsel) return error.SkipZigTest;
 
     const ByteSwapVectorTest = struct {
         fn run() void {

--- a/test/stage1/behavior/math.zig
+++ b/test/stage1/behavior/math.zig
@@ -529,7 +529,7 @@ test "comptime_int xor" {
 }
 
 test "f128" {
-    if (std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }
@@ -631,7 +631,7 @@ test "NaN comparison" {
         // TODO: https://github.com/ziglang/zig/issues/3338
         return error.SkipZigTest;
     }
-    if (std.Target.current.isWindows()) {
+    if (std.Target.current.os.tag == .windows) {
         // TODO https://github.com/ziglang/zig/issues/508
         return error.SkipZigTest;
     }
@@ -666,14 +666,14 @@ test "128-bit multiplication" {
 test "vector comparison" {
     const S = struct {
         fn doTheTest() void {
-            var a: @Vector(6, i32) = [_]i32{1, 3, -1, 5, 7, 9};
-            var b: @Vector(6, i32) = [_]i32{-1, 3, 0, 6, 10, -10};
-            expect(mem.eql(bool, &@as([6]bool, a < b), &[_]bool{false, false, true, true, true, false}));
-            expect(mem.eql(bool, &@as([6]bool, a <= b), &[_]bool{false, true, true, true, true, false}));
-            expect(mem.eql(bool, &@as([6]bool, a == b), &[_]bool{false, true, false, false, false, false}));
-            expect(mem.eql(bool, &@as([6]bool, a != b), &[_]bool{true, false, true, true, true, true}));
-            expect(mem.eql(bool, &@as([6]bool, a > b), &[_]bool{true, false, false, false, false, true}));
-            expect(mem.eql(bool, &@as([6]bool, a >= b), &[_]bool{true, true, false, false, false, true}));
+            var a: @Vector(6, i32) = [_]i32{ 1, 3, -1, 5, 7, 9 };
+            var b: @Vector(6, i32) = [_]i32{ -1, 3, 0, 6, 10, -10 };
+            expect(mem.eql(bool, &@as([6]bool, a < b), &[_]bool{ false, false, true, true, true, false }));
+            expect(mem.eql(bool, &@as([6]bool, a <= b), &[_]bool{ false, true, true, true, true, false }));
+            expect(mem.eql(bool, &@as([6]bool, a == b), &[_]bool{ false, true, false, false, false, false }));
+            expect(mem.eql(bool, &@as([6]bool, a != b), &[_]bool{ true, false, true, true, true, true }));
+            expect(mem.eql(bool, &@as([6]bool, a > b), &[_]bool{ true, false, false, false, false, true }));
+            expect(mem.eql(bool, &@as([6]bool, a >= b), &[_]bool{ true, true, false, false, false, true }));
         }
     };
     S.doTheTest();

--- a/test/stage1/behavior/namespace_depends_on_compile_var.zig
+++ b/test/stage1/behavior/namespace_depends_on_compile_var.zig
@@ -1,5 +1,5 @@
-const builtin = @import("builtin");
-const expect = @import("std").testing.expect;
+const std = @import("std");
+const expect = std.testing.expect;
 
 test "namespace depends on compile var" {
     if (some_namespace.a_bool) {
@@ -8,7 +8,7 @@ test "namespace depends on compile var" {
         expect(!some_namespace.a_bool);
     }
 }
-const some_namespace = switch (builtin.os) {
-    builtin.Os.linux => @import("namespace_depends_on_compile_var/a.zig"),
+const some_namespace = switch (std.builtin.os.tag) {
+    .linux => @import("namespace_depends_on_compile_var/a.zig"),
     else => @import("namespace_depends_on_compile_var/b.zig"),
 };

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const mem = std.mem;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
-const builtin = @import("builtin");
 
 test "implicit cast vector to array - bool" {
     const S = struct {
@@ -114,7 +113,7 @@ test "array to vector" {
 
 test "vector casts of sizes not divisable by 8" {
     // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
+    if (std.Target.current.os.tag == .dragonfly) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() void {

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -18,10 +18,10 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/use_alias/build.zig");
     cases.addBuildFile("test/standalone/brace_expansion/build.zig");
     cases.addBuildFile("test/standalone/empty_env/build.zig");
-    if (std.Target.current.getOs() != .wasi) {
+    if (std.Target.current.os.tag != .wasi) {
         cases.addBuildFile("test/standalone/load_dynamic_library/build.zig");
     }
-    if (std.Target.current.getArch() == .x86_64) { // TODO add C ABI support for other architectures
+    if (std.Target.current.cpu.arch == .x86_64) { // TODO add C ABI support for other architectures
         cases.addBuildFile("test/stage1/c_abi/build.zig");
     }
 }

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -31,7 +31,7 @@ pub const RunTranslatedCContext = @import("src/run_translated_c.zig").RunTransla
 pub const CompareOutputContext = @import("src/compare_output.zig").CompareOutputContext;
 
 const TestTarget = struct {
-    target: Target = .Native,
+    target: build.Target = .Native,
     mode: builtin.Mode = .Debug,
     link_libc: bool = false,
     single_threaded: bool = false,

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -3,7 +3,7 @@ const builtin = std.builtin;
 const debug = std.debug;
 const warn = debug.warn;
 const build = std.build;
-pub const Target = build.Target;
+const CrossTarget = std.zig.CrossTarget;
 const Buffer = std.Buffer;
 const io = std.io;
 const fs = std.fs;
@@ -30,7 +30,7 @@ pub const RunTranslatedCContext = @import("src/run_translated_c.zig").RunTransla
 pub const CompareOutputContext = @import("src/compare_output.zig").CompareOutputContext;
 
 const TestTarget = struct {
-    target: build.Target = .Native,
+    target: CrossTarget = @as(CrossTarget, .{}),
     mode: builtin.Mode = .Debug,
     link_libc: bool = false,
     single_threaded: bool = false,
@@ -52,105 +52,85 @@ const test_targets = blk: {
         },
 
         TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.x86_64),
-                    .os = std.Target.Os.defaultVersionRange(.linux),
-                    .abi = .none,
-                },
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .linux,
+                .abi = .none,
             },
         },
         TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.x86_64),
-                    .os = std.Target.Os.defaultVersionRange(.linux),
-                    .abi = .gnu,
-                },
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .linux,
+                .abi = .gnu,
             },
             .link_libc = true,
         },
         TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.x86_64),
-                    .os = std.Target.Os.defaultVersionRange(.linux),
-                    .abi = .musl,
-                },
-            },
-            .link_libc = true,
-        },
-
-        TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.i386),
-                    .os = std.Target.Os.defaultVersionRange(.linux),
-                    .abi = .none,
-                },
-            },
-        },
-        TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.i386),
-                    .os = std.Target.Os.defaultVersionRange(.linux),
-                    .abi = .musl,
-                },
-            },
-            .link_libc = true,
-        },
-
-        TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.aarch64),
-                    .os = std.Target.Os.defaultVersionRange(.linux),
-                    .abi = .none,
-                },
-            },
-        },
-        TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.aarch64),
-                    .os = std.Target.Os.defaultVersionRange(.linux),
-                    .abi = .musl,
-                },
-            },
-            .link_libc = true,
-        },
-        TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.aarch64),
-                    .os = std.Target.Os.defaultVersionRange(.linux),
-                    .abi = .gnu,
-                },
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .linux,
+                .abi = .musl,
             },
             .link_libc = true,
         },
 
         TestTarget{
             .target = .{
-                .Cross = std.Target.parse(.{
-                    .arch_os_abi = "arm-linux-none",
-                    .cpu_features = "generic+v8a",
-                }) catch unreachable,
+                .cpu_arch = .i386,
+                .os_tag = .linux,
+                .abi = .none,
             },
         },
         TestTarget{
             .target = .{
-                .Cross = std.Target.parse(.{
-                    .arch_os_abi = "arm-linux-musleabihf",
-                    .cpu_features = "generic+v8a",
-                }) catch unreachable,
+                .cpu_arch = .i386,
+                .os_tag = .linux,
+                .abi = .musl,
             },
+            .link_libc = true,
+        },
+
+        TestTarget{
+            .target = .{
+                .cpu_arch = .aarch64,
+                .os_tag = .linux,
+                .abi = .none,
+            },
+        },
+        TestTarget{
+            .target = .{
+                .cpu_arch = .aarch64,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .link_libc = true,
+        },
+        TestTarget{
+            .target = .{
+                .cpu_arch = .aarch64,
+                .os_tag = .linux,
+                .abi = .gnu,
+            },
+            .link_libc = true,
+        },
+
+        TestTarget{
+            .target = CrossTarget.parse(.{
+                .arch_os_abi = "arm-linux-none",
+                .cpu_features = "generic+v8a",
+            }) catch unreachable,
+        },
+        TestTarget{
+            .target = CrossTarget.parse(.{
+                .arch_os_abi = "arm-linux-musleabihf",
+                .cpu_features = "generic+v8a",
+            }) catch unreachable,
             .link_libc = true,
         },
         // TODO https://github.com/ziglang/zig/issues/3287
         //TestTarget{
-        //    .target = std.Target.parse(.{
+        //    .target = CrossTarget.parse(.{
         //        .arch_os_abi = "arm-linux-gnueabihf",
         //        .cpu_features = "generic+v8a",
         //    }) catch unreachable,
@@ -158,75 +138,61 @@ const test_targets = blk: {
         //},
 
         TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.mipsel),
-                    .os = std.Target.Os.defaultVersionRange(.linux),
-                    .abi = .none,
-                },
+            .target = .{
+                .cpu_arch = .mipsel,
+                .os_tag = .linux,
+                .abi = .none,
             },
         },
         TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.mipsel),
-                    .os = std.Target.Os.defaultVersionRange(.linux),
-                    .abi = .musl,
-                },
+            .target = .{
+                .cpu_arch = .mipsel,
+                .os_tag = .linux,
+                .abi = .musl,
             },
             .link_libc = true,
         },
 
         TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.x86_64),
-                    .os = std.Target.Os.defaultVersionRange(.macosx),
-                    .abi = .gnu,
-                },
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .macosx,
+                .abi = .gnu,
             },
             // TODO https://github.com/ziglang/zig/issues/3295
             .disable_native = true,
         },
 
         TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.i386),
-                    .os = std.Target.Os.defaultVersionRange(.windows),
-                    .abi = .msvc,
-                },
+            .target = .{
+                .cpu_arch = .i386,
+                .os_tag = .windows,
+                .abi = .msvc,
             },
         },
 
         TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.x86_64),
-                    .os = std.Target.Os.defaultVersionRange(.windows),
-                    .abi = .msvc,
-                },
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .windows,
+                .abi = .msvc,
             },
         },
 
         TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.i386),
-                    .os = std.Target.Os.defaultVersionRange(.windows),
-                    .abi = .gnu,
-                },
+            .target = .{
+                .cpu_arch = .i386,
+                .os_tag = .windows,
+                .abi = .gnu,
             },
             .link_libc = true,
         },
 
         TestTarget{
-            .target = Target{
-                .Cross = .{
-                    .cpu = std.Target.Cpu.baseline(.x86_64),
-                    .os = std.Target.Os.defaultVersionRange(.windows),
-                    .abi = .gnu,
-                },
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .windows,
+                .abi = .gnu,
             },
             .link_libc = true,
         },
@@ -435,13 +401,13 @@ pub fn addPkgTests(
     const step = b.step(b.fmt("test-{}", .{name}), desc);
 
     for (test_targets) |test_target| {
-        if (skip_non_native and test_target.target != .Native)
+        if (skip_non_native and !test_target.target.isNative())
             continue;
 
         if (skip_libc and test_target.link_libc)
             continue;
 
-        if (test_target.link_libc and test_target.target.getTarget().osRequiresLibC()) {
+        if (test_target.link_libc and test_target.target.getOs().requiresLibC()) {
             // This would be a redundant test.
             continue;
         }
@@ -451,8 +417,8 @@ pub fn addPkgTests(
 
         const ArchTag = @TagType(builtin.Arch);
         if (test_target.disable_native and
-            test_target.target.getOs() == std.Target.current.os.tag and
-            test_target.target.getArch() == std.Target.current.cpu.arch)
+            test_target.target.getOsTag() == std.Target.current.os.tag and
+            test_target.target.getCpuArch() == std.Target.current.cpu.arch)
         {
             continue;
         }
@@ -462,17 +428,14 @@ pub fn addPkgTests(
         } else false;
         if (!want_this_mode) continue;
 
-        const libc_prefix = if (test_target.target.getTarget().osRequiresLibC())
+        const libc_prefix = if (test_target.target.getOs().requiresLibC())
             ""
         else if (test_target.link_libc)
             "c"
         else
             "bare";
 
-        const triple_prefix = if (test_target.target == .Native)
-            @as([]const u8, "native")
-        else
-            test_target.target.zigTriple(b.allocator) catch unreachable;
+        const triple_prefix = test_target.target.zigTriple(b.allocator) catch unreachable;
 
         const these_tests = b.addTest(root_src);
         const single_threaded_txt = if (test_target.single_threaded) "single" else "multi";
@@ -486,7 +449,7 @@ pub fn addPkgTests(
         these_tests.single_threaded = test_target.single_threaded;
         these_tests.setFilter(test_filter);
         these_tests.setBuildMode(test_target.mode);
-        these_tests.setTheTarget(test_target.target);
+        these_tests.setTarget(test_target.target);
         if (test_target.link_libc) {
             these_tests.linkSystemLibrary("c");
         }
@@ -716,7 +679,7 @@ pub const CompileErrorContext = struct {
         link_libc: bool,
         is_exe: bool,
         is_test: bool,
-        target: Target = .Native,
+        target: CrossTarget = CrossTarget{},
 
         const SourceFile = struct {
             filename: []const u8,
@@ -808,12 +771,9 @@ pub const CompileErrorContext = struct {
             zig_args.append("--output-dir") catch unreachable;
             zig_args.append(b.pathFromRoot(b.cache_root)) catch unreachable;
 
-            switch (self.case.target) {
-                .Native => {},
-                .Cross => {
-                    try zig_args.append("-target");
-                    try zig_args.append(try self.case.target.zigTriple(b.allocator));
-                },
+            if (!self.case.target.isNative()) {
+                try zig_args.append("-target");
+                try zig_args.append(try self.case.target.zigTriple(b.allocator));
             }
 
             switch (self.build_mode) {

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -56,7 +56,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = .linux,
+                    .os = Target.Os.defaultVersionRange(.linux),
                     .abi = .none,
                 },
             },
@@ -65,7 +65,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = .linux,
+                    .os = Target.Os.defaultVersionRange(.linux),
                     .abi = .gnu,
                 },
             },
@@ -75,7 +75,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = .linux,
+                    .os = Target.Os.defaultVersionRange(.linux),
                     .abi = .musl,
                 },
             },
@@ -86,7 +86,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.i386),
-                    .os = .linux,
+                    .os = Target.Os.defaultVersionRange(.linux),
                     .abi = .none,
                 },
             },
@@ -95,7 +95,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.i386),
-                    .os = .linux,
+                    .os = Target.Os.defaultVersionRange(.linux),
                     .abi = .musl,
                 },
             },
@@ -106,7 +106,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.aarch64),
-                    .os = .linux,
+                    .os = Target.Os.defaultVersionRange(.linux),
                     .abi = .none,
                 },
             },
@@ -115,7 +115,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.aarch64),
-                    .os = .linux,
+                    .os = Target.Os.defaultVersionRange(.linux),
                     .abi = .musl,
                 },
             },
@@ -125,7 +125,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.aarch64),
-                    .os = .linux,
+                    .os = Target.Os.defaultVersionRange(.linux),
                     .abi = .gnu,
                 },
             },
@@ -158,7 +158,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.mipsel),
-                    .os = .linux,
+                    .os = Target.Os.defaultVersionRange(.linux),
                     .abi = .none,
                 },
             },
@@ -167,7 +167,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.mipsel),
-                    .os = .linux,
+                    .os = Target.Os.defaultVersionRange(.linux),
                     .abi = .musl,
                 },
             },
@@ -178,7 +178,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = .macosx,
+                    .os = Target.Os.defaultVersionRange(.macosx),
                     .abi = .gnu,
                 },
             },
@@ -190,7 +190,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.i386),
-                    .os = .windows,
+                    .os = Target.Os.defaultVersionRange(.windows),
                     .abi = .msvc,
                 },
             },
@@ -200,7 +200,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = .windows,
+                    .os = Target.Os.defaultVersionRange(.windows),
                     .abi = .msvc,
                 },
             },
@@ -210,7 +210,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.i386),
-                    .os = .windows,
+                    .os = Target.Os.defaultVersionRange(.windows),
                     .abi = .gnu,
                 },
             },
@@ -221,7 +221,7 @@ const test_targets = blk: {
             .target = Target{
                 .Cross = CrossTarget{
                     .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = .windows,
+                    .os = Target.Os.defaultVersionRange(.windows),
                     .abi = .gnu,
                 },
             },

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1,16 +1,15 @@
 const std = @import("std");
+const builtin = std.builtin;
 const debug = std.debug;
 const warn = debug.warn;
 const build = std.build;
 pub const Target = build.Target;
-pub const CrossTarget = build.CrossTarget;
 const Buffer = std.Buffer;
 const io = std.io;
 const fs = std.fs;
 const mem = std.mem;
 const fmt = std.fmt;
 const ArrayList = std.ArrayList;
-const builtin = @import("builtin");
 const Mode = builtin.Mode;
 const LibExeObjStep = build.LibExeObjStep;
 
@@ -54,18 +53,18 @@ const test_targets = blk: {
 
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = Target.Os.defaultVersionRange(.linux),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.x86_64),
+                    .os = std.Target.Os.defaultVersionRange(.linux),
                     .abi = .none,
                 },
             },
         },
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = Target.Os.defaultVersionRange(.linux),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.x86_64),
+                    .os = std.Target.Os.defaultVersionRange(.linux),
                     .abi = .gnu,
                 },
             },
@@ -73,9 +72,9 @@ const test_targets = blk: {
         },
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = Target.Os.defaultVersionRange(.linux),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.x86_64),
+                    .os = std.Target.Os.defaultVersionRange(.linux),
                     .abi = .musl,
                 },
             },
@@ -84,18 +83,18 @@ const test_targets = blk: {
 
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.i386),
-                    .os = Target.Os.defaultVersionRange(.linux),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.i386),
+                    .os = std.Target.Os.defaultVersionRange(.linux),
                     .abi = .none,
                 },
             },
         },
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.i386),
-                    .os = Target.Os.defaultVersionRange(.linux),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.i386),
+                    .os = std.Target.Os.defaultVersionRange(.linux),
                     .abi = .musl,
                 },
             },
@@ -104,18 +103,18 @@ const test_targets = blk: {
 
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.aarch64),
-                    .os = Target.Os.defaultVersionRange(.linux),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.aarch64),
+                    .os = std.Target.Os.defaultVersionRange(.linux),
                     .abi = .none,
                 },
             },
         },
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.aarch64),
-                    .os = Target.Os.defaultVersionRange(.linux),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.aarch64),
+                    .os = std.Target.Os.defaultVersionRange(.linux),
                     .abi = .musl,
                 },
             },
@@ -123,9 +122,9 @@ const test_targets = blk: {
         },
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.aarch64),
-                    .os = Target.Os.defaultVersionRange(.linux),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.aarch64),
+                    .os = std.Target.Os.defaultVersionRange(.linux),
                     .abi = .gnu,
                 },
             },
@@ -133,21 +132,25 @@ const test_targets = blk: {
         },
 
         TestTarget{
-            .target = Target.parse(.{
-                .arch_os_abi = "arm-linux-none",
-                .cpu_features = "generic+v8a",
-            }) catch unreachable,
+            .target = .{
+                .Cross = std.Target.parse(.{
+                    .arch_os_abi = "arm-linux-none",
+                    .cpu_features = "generic+v8a",
+                }) catch unreachable,
+            },
         },
         TestTarget{
-            .target = Target.parse(.{
-                .arch_os_abi = "arm-linux-musleabihf",
-                .cpu_features = "generic+v8a",
-            }) catch unreachable,
+            .target = .{
+                .Cross = std.Target.parse(.{
+                    .arch_os_abi = "arm-linux-musleabihf",
+                    .cpu_features = "generic+v8a",
+                }) catch unreachable,
+            },
             .link_libc = true,
         },
         // TODO https://github.com/ziglang/zig/issues/3287
         //TestTarget{
-        //    .target = Target.parse(.{
+        //    .target = std.Target.parse(.{
         //        .arch_os_abi = "arm-linux-gnueabihf",
         //        .cpu_features = "generic+v8a",
         //    }) catch unreachable,
@@ -156,18 +159,18 @@ const test_targets = blk: {
 
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.mipsel),
-                    .os = Target.Os.defaultVersionRange(.linux),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.mipsel),
+                    .os = std.Target.Os.defaultVersionRange(.linux),
                     .abi = .none,
                 },
             },
         },
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.mipsel),
-                    .os = Target.Os.defaultVersionRange(.linux),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.mipsel),
+                    .os = std.Target.Os.defaultVersionRange(.linux),
                     .abi = .musl,
                 },
             },
@@ -176,9 +179,9 @@ const test_targets = blk: {
 
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = Target.Os.defaultVersionRange(.macosx),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.x86_64),
+                    .os = std.Target.Os.defaultVersionRange(.macosx),
                     .abi = .gnu,
                 },
             },
@@ -188,9 +191,9 @@ const test_targets = blk: {
 
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.i386),
-                    .os = Target.Os.defaultVersionRange(.windows),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.i386),
+                    .os = std.Target.Os.defaultVersionRange(.windows),
                     .abi = .msvc,
                 },
             },
@@ -198,9 +201,9 @@ const test_targets = blk: {
 
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = Target.Os.defaultVersionRange(.windows),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.x86_64),
+                    .os = std.Target.Os.defaultVersionRange(.windows),
                     .abi = .msvc,
                 },
             },
@@ -208,9 +211,9 @@ const test_targets = blk: {
 
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.i386),
-                    .os = Target.Os.defaultVersionRange(.windows),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.i386),
+                    .os = std.Target.Os.defaultVersionRange(.windows),
                     .abi = .gnu,
                 },
             },
@@ -219,9 +222,9 @@ const test_targets = blk: {
 
         TestTarget{
             .target = Target{
-                .Cross = CrossTarget{
-                    .cpu = Target.Cpu.baseline(.x86_64),
-                    .os = Target.Os.defaultVersionRange(.windows),
+                .Cross = .{
+                    .cpu = std.Target.Cpu.baseline(.x86_64),
+                    .os = std.Target.Os.defaultVersionRange(.windows),
                     .abi = .gnu,
                 },
             },
@@ -438,7 +441,7 @@ pub fn addPkgTests(
         if (skip_libc and test_target.link_libc)
             continue;
 
-        if (test_target.link_libc and test_target.target.osRequiresLibC()) {
+        if (test_target.link_libc and test_target.target.getTarget().osRequiresLibC()) {
             // This would be a redundant test.
             continue;
         }
@@ -448,8 +451,8 @@ pub fn addPkgTests(
 
         const ArchTag = @TagType(builtin.Arch);
         if (test_target.disable_native and
-            test_target.target.getOs() == builtin.os and
-            test_target.target.getArch() == builtin.arch)
+            test_target.target.getOs() == std.Target.current.os.tag and
+            test_target.target.getArch() == std.Target.current.cpu.arch)
         {
             continue;
         }
@@ -459,7 +462,7 @@ pub fn addPkgTests(
         } else false;
         if (!want_this_mode) continue;
 
-        const libc_prefix = if (test_target.target.osRequiresLibC())
+        const libc_prefix = if (test_target.target.getTarget().osRequiresLibC())
             ""
         else if (test_target.link_libc)
             "c"
@@ -469,7 +472,7 @@ pub fn addPkgTests(
         const triple_prefix = if (test_target.target == .Native)
             @as([]const u8, "native")
         else
-            test_target.target.zigTripleNoSubArch(b.allocator) catch unreachable;
+            test_target.target.zigTriple(b.allocator) catch unreachable;
 
         const these_tests = b.addTest(root_src);
         const single_threaded_txt = if (test_target.single_threaded) "single" else "multi";
@@ -660,7 +663,7 @@ pub const StackTracesContext = struct {
                     const delims = [_][]const u8{ ":", ":", ":", " in " };
                     var marks = [_]usize{0} ** 4;
                     // offset search past `[drive]:` on windows
-                    var pos: usize = if (builtin.os == .windows) 2 else 0;
+                    var pos: usize = if (std.Target.current.os.tag == .windows) 2 else 0;
                     for (delims) |delim, i| {
                         marks[i] = mem.indexOfPos(u8, line, pos, delim) orelse {
                             try buf.append(line);

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1,6 +1,6 @@
 const tests = @import("tests.zig");
 const std = @import("std");
-const Target = std.Target;
+const CrossTarget = std.zig.CrossTarget;
 
 pub fn addCases(cases: *tests.TranslateCContext) void {
     cases.add("macro line continuation",
@@ -665,7 +665,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     });
 
-    if (Target.current.os.tag != .windows) {
+    if (std.Target.current.os.tag != .windows) {
         // Windows treats this as an enum with type c_int
         cases.add("big negative enum init values when C ABI supports long long enums",
             \\enum EnumWithInits {
@@ -1064,7 +1064,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     });
 
-    if (Target.current.os.tag != .windows) {
+    if (std.Target.current.os.tag != .windows) {
         // sysv_abi not currently supported on windows
         cases.add("Macro qualified functions",
             \\void __attribute__((sysv_abi)) foo(void);
@@ -1094,11 +1094,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     });
 
     cases.addWithTarget("Calling convention", .{
-        .Cross = .{
-            .cpu = Target.Cpu.baseline(.i386),
-            .os = Target.Os.defaultVersionRange(.linux),
-            .abi = .none,
-        },
+        .cpu_arch = .i386,
+        .os_tag = .linux,
+        .abi = .none,
     },
         \\void __attribute__((fastcall)) foo1(float *a);
         \\void __attribute__((stdcall)) foo2(float *a);
@@ -1113,12 +1111,10 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub fn foo5(a: [*c]f32) callconv(.Thiscall) void;
     });
 
-    cases.addWithTarget("Calling convention", .{
-        .Cross = Target.parse(.{
-            .arch_os_abi = "arm-linux-none",
-            .cpu_features = "generic+v8_5a",
-        }) catch unreachable,
-    },
+    cases.addWithTarget("Calling convention", CrossTarget.parse(.{
+        .arch_os_abi = "arm-linux-none",
+        .cpu_features = "generic+v8_5a",
+    }) catch unreachable,
         \\void __attribute__((pcs("aapcs"))) foo1(float *a);
         \\void __attribute__((pcs("aapcs-vfp"))) foo2(float *a);
     , &[_][]const u8{
@@ -1126,12 +1122,10 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub fn foo2(a: [*c]f32) callconv(.AAPCSVFP) void;
     });
 
-    cases.addWithTarget("Calling convention", .{
-        .Cross = Target.parse(.{
-            .arch_os_abi = "aarch64-linux-none",
-            .cpu_features = "generic+v8_5a",
-        }) catch unreachable,
-    },
+    cases.addWithTarget("Calling convention", CrossTarget.parse(.{
+        .arch_os_abi = "aarch64-linux-none",
+        .cpu_features = "generic+v8_5a",
+    }) catch unreachable,
         \\void __attribute__((aarch64_vector_pcs)) foo1(float *a);
     , &[_][]const u8{
         \\pub fn foo1(a: [*c]f32) callconv(.Vectorcall) void;
@@ -1600,7 +1594,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     });
 
-    if (Target.current.os.tag != .windows) {
+    if (std.Target.current.os.tag != .windows) {
         // When clang uses the <arch>-windows-none triple it behaves as MSVC and
         // interprets the inner `struct Bar` as an anonymous structure
         cases.add("type referenced struct",

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1,6 +1,6 @@
 const tests = @import("tests.zig");
-const builtin = @import("builtin");
-const Target = @import("std").Target;
+const std = @import("std");
+const Target = std.Target;
 
 pub fn addCases(cases: *tests.TranslateCContext) void {
     cases.add("macro line continuation",
@@ -665,7 +665,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     });
 
-    if (builtin.os != builtin.Os.windows) {
+    if (Target.current.os.tag != .windows) {
         // Windows treats this as an enum with type c_int
         cases.add("big negative enum init values when C ABI supports long long enums",
             \\enum EnumWithInits {
@@ -1064,7 +1064,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     });
 
-    if (builtin.os != builtin.Os.windows) {
+    if (Target.current.os.tag != .windows) {
         // sysv_abi not currently supported on windows
         cases.add("Macro qualified functions",
             \\void __attribute__((sysv_abi)) foo(void);
@@ -1093,10 +1093,10 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const fn1 = ?fn (u8) callconv(.C) void;
     });
 
-    cases.addWithTarget("Calling convention", tests.Target{
+    cases.addWithTarget("Calling convention", .{
         .Cross = .{
             .cpu = Target.Cpu.baseline(.i386),
-            .os = .linux,
+            .os = Target.Os.defaultVersionRange(.linux),
             .abi = .none,
         },
     },
@@ -1113,10 +1113,12 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub fn foo5(a: [*c]f32) callconv(.Thiscall) void;
     });
 
-    cases.addWithTarget("Calling convention", Target.parse(.{
-        .arch_os_abi = "arm-linux-none",
-        .cpu_features = "generic+v8_5a",
-    }) catch unreachable,
+    cases.addWithTarget("Calling convention", .{
+        .Cross = Target.parse(.{
+            .arch_os_abi = "arm-linux-none",
+            .cpu_features = "generic+v8_5a",
+        }) catch unreachable,
+    },
         \\void __attribute__((pcs("aapcs"))) foo1(float *a);
         \\void __attribute__((pcs("aapcs-vfp"))) foo2(float *a);
     , &[_][]const u8{
@@ -1124,10 +1126,12 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub fn foo2(a: [*c]f32) callconv(.AAPCSVFP) void;
     });
 
-    cases.addWithTarget("Calling convention", Target.parse(.{
-        .arch_os_abi = "aarch64-linux-none",
-        .cpu_features = "generic+v8_5a",
-    }) catch unreachable,
+    cases.addWithTarget("Calling convention", .{
+        .Cross = Target.parse(.{
+            .arch_os_abi = "aarch64-linux-none",
+            .cpu_features = "generic+v8_5a",
+        }) catch unreachable,
+    },
         \\void __attribute__((aarch64_vector_pcs)) foo1(float *a);
     , &[_][]const u8{
         \\pub fn foo1(a: [*c]f32) callconv(.Vectorcall) void;
@@ -1596,7 +1600,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     });
 
-    if (builtin.os != .windows) {
+    if (Target.current.os.tag != .windows) {
         // When clang uses the <arch>-windows-none triple it behaves as MSVC and
         // interprets the inner `struct Bar` as an anonymous structure
         cases.add("type referenced struct",


### PR DESCRIPTION
### Commit Details

  * introduce `std.zig.CrossTarget` which is distinct from `std.Target`. `std.zig.CrossTarget` wraps `std.Target` so that it can be annotated as "the native target" or an explicitly specified target.
 * `std.Target.Os` is moved to `std.Target.Os.Tag`. The former is now a struct which has the tag as well as version range information.
 * `std.elf` gains some more ELF header constants.
 * `std.Target.parse` gains the ability to parse operating system version ranges as well as glibc version.
 * Added `std.Target.isGnuLibC()`.
 * self-hosted dynamic linker detection and glibc version detection. This also adds the improved logic using `/usr/bin/env` rather than invoking the system C compiler to find the dynamic linker when zig is statically linked. Related: #2084
   Note: this `/usr/bin/env` code is work-in-progress.
 * `-target-glibc` CLI option is removed in favor of the new `-target` syntax. Example: `-target x86_64-linux-gnu.2.27`

closes #1907

### What this means for Zig programmers

`comptime` code will have access to exactly which version(s) of an OS are being targeted.

Updated syntax for `-target` to take into account OS version ranges:

```
# still valid. default version range
-target x86_64-windows-msvc

# minimum windows version: XP
# maximum windows version: 10
-target x86_64-windows.xp...win10-msvc

# minimum windows version: 7
# maximum windows version: latest
-target x86_64-windows.win7-msvc

# linux example
-target aarch64-linux.3.16...5.3.1-musl

# specifying glibc version
-target mipsel-linux.4.10-gnu.2.1
```

Here's what it will look like to populate a `std.Target`:

```diff
-        tc.target = tests.Target{
-            .Cross = .{
-                .cpu = Target.Cpu.baseline(.x86_64),
-                .os = Target.Os.defaultVersionRange(.linux),
-                .abi = .gnu,
-            },
+        tc.target = std.zig.CrossTarget{
+            .cpu_arch = .x86_64,
+            .os_tag = .linux,
+            .abi = .gnu,
```

Code that used `Target.parse` need not be updated.

Checking for the OS when doing conditional compilation:

Option 1: easy, might get deprecated in the future:

```diff
--- a/lib/std/build/run.zig
+++ b/lib/std/build/run.zig
@@ -82,7 +82,7 @@ pub const RunStep = struct {
 
         var key: []const u8 = undefined;
         var prev_path: ?[]const u8 = undefined;
-        if (builtin.os == .windows) {
+        if (builtin.os.tag == .windows) {
             key = "Path";
             prev_path = env_map.get(key);
             if (prev_path == null) {
```

Option 2, more verbose, less likely to be deprecated in the future:

```diff
--- a/test/stage1/behavior/byteswap.zig
+++ b/test/stage1/behavior/byteswap.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const expect = std.testing.expect;
-const builtin = @import("builtin");
 
 test "@byteSwap integers" {
     const ByteSwapIntTest = struct {
@@ -41,10 +40,10 @@ test "@byteSwap integers" {
 
 test "@byteSwap vectors" {
     // https://github.com/ziglang/zig/issues/3563
-    if (builtin.os == .dragonfly) return error.SkipZigTest;
+    if (std.Target.current.os.tag == .dragonfly) return error.SkipZigTest;
 
     // https://github.com/ziglang/zig/issues/3317
-    if (builtin.arch == .mipsel) return error.SkipZigTest;
+    if (std.Target.current.cpu.arch == .mipsel) return error.SkipZigTest;
 
     const ByteSwapVectorTest = struct {
         fn run() void {
```

### Checklist:

 * [x] complete the fallback `/usr/bin/env` ELF implementation
 * [x] remove stage1 code for dynamic linker detection and glibc version detection
 * [x] improve the std.Target.zigTriple function to render os version info
 * [x] update zig build
 * [x] update codebase to the new std.Target API
 * [x] remove `-mmacos_version_min` and related features since it can now be automatically handled by the target OS version range feature
 * [ ] ~implement operating system version detection, which sets the min and max both to that value~ done for linux; others will become contributor friendly issues.
 * [x] support `-target native-native-gnu` and `-mcpu=native`.
 * [ ] ~move `-mcpu` to be part of the target triple~ will open separate proposal for this
 * [x] improve `Builder.standardTargetOptions` API and allow specifying a different default target, so that e.g. `native-native-gnu` could be the default for a given project on windows (as chosen by build.zig).
 * [x] add dynamic linker path to CrossTarget and Target
 * [x]  #4578
 * [x] merge `std.zig.CrossTarget.toTarget` and `std.zig.system.NativeTargetInfo.detect`.
 * [x] test a static build on alpine linux and make sure it detects the native ABI and dynamic linker (#2084)

### Follow-up Items

 * Take advantage of this feature and merge #4131! 