### PR TITLE
ir: Various fixes for comptime ptr handling

### DIFF
--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -3,6 +3,15 @@ const builtin = @import("builtin");
 const Target = @import("std").Target;
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
+    cases.addTest("@ptrToInt with pointer to zero-sized type",
+        \\export fn entry() void {
+        \\    var pointer: ?*u0 = null;
+        \\    var x = @ptrToInt(pointer);
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:3:23: error: pointer to size 0 type has no address",
+    });
+
     cases.addTest("slice to pointer conversion mismatch",
         \\pub fn bytesAsSlice(bytes: var) [*]align(1) const u16 {
         \\    return @ptrCast([*]align(1) const u16, bytes.ptr)[0..1];

--- a/test/stage1/behavior/pointers.zig
+++ b/test/stage1/behavior/pointers.zig
@@ -318,3 +318,15 @@ test "pointer arithmetic affects the alignment" {
         expect(@typeInfo(@TypeOf(ptr4)).Pointer.alignment == 4);
     }
 }
+
+test "@ptrToInt on null optional at comptime" {
+    {
+        const pointer = @intToPtr(?*u8, 0x000);
+        const x = @ptrToInt(pointer);
+        comptime expect(0 == @ptrToInt(pointer));
+    }
+    {
+        const pointer = @intToPtr(?*u8, 0xf00);
+        comptime expect(0xf00 == @ptrToInt(pointer));
+    }
+}


### PR DESCRIPTION
* Correctly fold ptrToInt on optional types
* Generate null as ConstPtrSpecialNull in intToPtr
* Correctly stop ptrToInt on ?*T where T is zero-sized

Closes #4535