### PR TITLE
Put C ptr casts in grouped expression and do alignCast

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -195,4 +195,22 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\  return 0;
         \\}
     , "");
+
+    cases.add("cast from pointer to opaque type to struct",
+        \\#include <stdio.h>
+        \\typedef struct
+        \\{
+        \\    int i;
+        \\}
+        \\StructType,*StructPtrType;
+        \\
+        \\typedef struct OpaqueStruct OpaqueStructTypedef;
+        \\#define Macro(opaquePtr) 	(((StructPtrType)(opaquePtr))->i)
+        \\int main(int argc, char **argv) {
+        \\  StructType localStruct = {88};
+        \\  OpaqueStructTypedef *opaquePtrToLocal = &localStruct;
+        \\  printf("%d!\n", Macro(opaquePtrToLocal));
+        \\  return 0;
+        \\}
+    , "88!\n");
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1354,7 +1354,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     cases.add("macro pointer cast",
         \\#define NRF_GPIO ((NRF_GPIO_Type *) NRF_GPIO_BASE)
     , &[_][]const u8{
-        \\pub const NRF_GPIO = if (@typeInfo(@TypeOf(NRF_GPIO_BASE)) == .Pointer) @ptrCast([*c]NRF_GPIO_Type, NRF_GPIO_BASE) else if (@typeInfo(@TypeOf(NRF_GPIO_BASE)) == .Int) @intToPtr([*c]NRF_GPIO_Type, NRF_GPIO_BASE) else @as([*c]NRF_GPIO_Type, NRF_GPIO_BASE);
+        \\pub const NRF_GPIO = (if (@typeInfo(@TypeOf(NRF_GPIO_BASE)) == .Pointer) @ptrCast([*c]NRF_GPIO_Type, @alignCast(@alignOf([*c]NRF_GPIO_Type.Child), NRF_GPIO_BASE)) else if (@typeInfo(@TypeOf(NRF_GPIO_BASE)) == .Int) @intToPtr([*c]NRF_GPIO_Type, NRF_GPIO_BASE) else @as([*c]NRF_GPIO_Type, NRF_GPIO_BASE));
     });
 
     cases.add("basic macro function",
@@ -2538,11 +2538,11 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\#define FOO(bar) baz((void *)(baz))
         \\#define BAR (void*) a
     , &[_][]const u8{
-        \\pub inline fn FOO(bar: var) @TypeOf(baz(if (@typeInfo(@TypeOf(baz)) == .Pointer) @ptrCast(*c_void, baz) else if (@typeInfo(@TypeOf(baz)) == .Int) @intToPtr(*c_void, baz) else @as(*c_void, baz))) {
-        \\    return baz(if (@typeInfo(@TypeOf(baz)) == .Pointer) @ptrCast(*c_void, baz) else if (@typeInfo(@TypeOf(baz)) == .Int) @intToPtr(*c_void, baz) else @as(*c_void, baz));
+        \\pub inline fn FOO(bar: var) @TypeOf(baz((if (@typeInfo(@TypeOf(baz)) == .Pointer) @ptrCast(*c_void, @alignCast(@alignOf(*c_void.Child), baz)) else if (@typeInfo(@TypeOf(baz)) == .Int) @intToPtr(*c_void, baz) else @as(*c_void, baz)))) {
+        \\    return baz((if (@typeInfo(@TypeOf(baz)) == .Pointer) @ptrCast(*c_void, @alignCast(@alignOf(*c_void.Child), baz)) else if (@typeInfo(@TypeOf(baz)) == .Int) @intToPtr(*c_void, baz) else @as(*c_void, baz)));
         \\}
     ,
-        \\pub const BAR = if (@typeInfo(@TypeOf(a)) == .Pointer) @ptrCast(*c_void, a) else if (@typeInfo(@TypeOf(a)) == .Int) @intToPtr(*c_void, a) else @as(*c_void, a);
+        \\pub const BAR = (if (@typeInfo(@TypeOf(a)) == .Pointer) @ptrCast(*c_void, @alignCast(@alignOf(*c_void.Child), a)) else if (@typeInfo(@TypeOf(a)) == .Int) @intToPtr(*c_void, a) else @as(*c_void, a));
     });
 
     cases.add("macro conditional operator",
@@ -2704,4 +2704,20 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    return if (x > y) x else y;
         \\}
     });
+
+    cases.add("Make sure casts are grouped",
+        \\typedef struct
+        \\{
+        \\    int i;
+        \\}
+        \\*_XPrivDisplay;
+        \\typedef struct _XDisplay Display;
+        \\#define DefaultScreen(dpy) 	(((_XPrivDisplay)(dpy))->default_screen)
+        \\
+    , &[_][]const u8{
+        \\pub inline fn DefaultScreen(dpy: var) @TypeOf((if (@typeInfo(@TypeOf(dpy)) == .Pointer) @ptrCast(_XPrivDisplay, @alignCast(@alignOf(_XPrivDisplay.Child), dpy)) else if (@typeInfo(@TypeOf(dpy)) == .Int) @intToPtr(_XPrivDisplay, dpy) else @as(_XPrivDisplay, dpy)).*.default_screen) {
+        \\    return (if (@typeInfo(@TypeOf(dpy)) == .Pointer) @ptrCast(_XPrivDisplay, @alignCast(@alignOf(_XPrivDisplay.Child), dpy)) else if (@typeInfo(@TypeOf(dpy)) == .Int) @intToPtr(_XPrivDisplay, dpy) else @as(_XPrivDisplay, dpy)).*.default_screen;
+        \\}
+    });
+
 }


### PR DESCRIPTION
Trying to compile with Xlib the DefaultScreen macro (and other macros) were expanding from:
```
#define DefaultScreen(dpy) 	(((_XPrivDisplay)(dpy))->default_screen)
```
into
```
pub inline fn DefaultScreen(dpy: var) @TypeOf(if (@typeId(@TypeOf(dpy)) == .Pointer) @ptrCast(_XPrivDisplay, dpy) else if (@typeId(@TypeOf(dpy)) == .Int) @intToPtr(_XPrivDisplay, dpy) else @as(_XPrivDisplay, dpy).*.default_screen) {
    return if (@typeId(@TypeOf(dpy)) == .Pointer) @ptrCast(_XPrivDisplay, dpy) else if (@typeId(@TypeOf(dpy)) == .Int) @intToPtr(_XPrivDisplay, dpy) else @as(_XPrivDisplay, dpy).*.default_screen;
}
```
Notice how the `.*.default_screen` is only connected to the `@as()` cast?
Also as Display* is an opaque type it's alignment is 1, so the `@ptrCast()` was failing. As C style casts don't have checks for alignment we shouldn't either (at least, for code generated from C).