### PR TITLE
Implicit conversion between Error payloads

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -1498,6 +1498,8 @@ test "zig fmt: error set declaration" {
         \\const Error = error{OutOfMemory};
         \\const Error = error{};
         \\
+        \\const Error = error{ OutOfMemory, OutOfTime };
+        \\
     );
 }
 

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1273,25 +1273,51 @@ fn renderExpression(
             }
 
             try renderToken(tree, stream, err_set_decl.error_token, indent, start_col, Space.None); // error
-            try renderToken(tree, stream, lbrace, indent, start_col, Space.Newline); // {
-            const new_indent = indent + indent_delta;
 
-            var it = err_set_decl.decls.iterator(0);
-            while (it.next()) |node| {
-                try stream.writeByteNTimes(' ', new_indent);
+            const src_has_trailing_comma = blk: {
+                const maybe_comma = tree.prevToken(err_set_decl.rbrace_token);
+                break :blk tree.tokens.at(maybe_comma).id == .Comma;
+            };
 
-                if (it.peek()) |next_node| {
-                    try renderExpression(allocator, stream, tree, new_indent, start_col, node.*, Space.None);
-                    try renderToken(tree, stream, tree.nextToken(node.*.lastToken()), new_indent, start_col, Space.Newline); // ,
+            if (src_has_trailing_comma) {
+                try renderToken(tree, stream, lbrace, indent, start_col, Space.Newline); // {
+                const new_indent = indent + indent_delta;
 
-                    try renderExtraNewline(tree, stream, start_col, next_node.*);
-                } else {
-                    try renderExpression(allocator, stream, tree, new_indent, start_col, node.*, Space.Comma);
+                var it = err_set_decl.decls.iterator(0);
+                while (it.next()) |node| {
+                    try stream.writeByteNTimes(' ', new_indent);
+
+                    if (it.peek()) |next_node| {
+                        try renderExpression(allocator, stream, tree, new_indent, start_col, node.*, Space.None);
+                        try renderToken(tree, stream, tree.nextToken(node.*.lastToken()), new_indent, start_col, Space.Newline); // ,
+
+                        try renderExtraNewline(tree, stream, start_col, next_node.*);
+                    } else {
+                        try renderExpression(allocator, stream, tree, new_indent, start_col, node.*, Space.Comma);
+                    }
                 }
-            }
 
-            try stream.writeByteNTimes(' ', indent);
-            return renderToken(tree, stream, err_set_decl.rbrace_token, indent, start_col, space); // }
+                try stream.writeByteNTimes(' ', indent);
+                return renderToken(tree, stream, err_set_decl.rbrace_token, indent, start_col, space); // }
+            } else {
+                try renderToken(tree, stream, lbrace, indent, start_col, Space.Space); // {
+
+                var it = err_set_decl.decls.iterator(0);
+                while (it.next()) |node| {
+                    if (it.peek()) |next_node| {
+                        try renderExpression(allocator, stream, tree, indent, start_col, node.*, Space.None);
+
+                        const comma_token = tree.nextToken(node.*.lastToken());
+                        assert(tree.tokens.at(comma_token).id == .Comma);
+                        try renderToken(tree, stream, comma_token, indent, start_col, Space.Space); // ,
+                        try renderExtraNewline(tree, stream, start_col, next_node.*);
+                    } else {
+                        try renderExpression(allocator, stream, tree, indent, start_col, node.*, Space.Space);
+                    }
+                }
+
+                return renderToken(tree, stream, err_set_decl.rbrace_token, indent, start_col, space); // }
+            }
         },
 
         .ErrorTag => {
@@ -1594,8 +1620,7 @@ fn renderExpression(
                 }
             } else {
                 var it = switch_case.items.iterator(0);
-                while (true) {
-                    const node = it.next().?;
+                while (it.next()) |node| {
                     if (it.peek()) |next_node| {
                         try renderExpression(allocator, stream, tree, indent, start_col, node.*, Space.None);
 
@@ -1606,7 +1631,6 @@ fn renderExpression(
                     } else {
                         try renderExpression(allocator, stream, tree, indent, start_col, node.*, Space.Comma);
                         try stream.writeByteNTimes(' ', indent);
-                        break;
                     }
                 }
             }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -12,6 +12,16 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:3:11: error: expected type 'struct:2:14', found 'struct:3:11'",
     });
 
+    cases.addTest("implicit payload conversion between incompatible error sets",
+        \\export fn entry() void {
+        \\    var x: anyerror!u16 = @as(u8, 2);
+        \\    var y: error{a}!u32 = x;
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:3:27: error: expected type 'error:3:12!u32', found 'anyerror!u16'",
+        "tmp.zig:3:27: note: cannot cast global error set into smaller set",
+    });
+
     cases.addTest("@tagName on invalid value of non-exhaustive enum",
         \\test "enum" {
         \\    const E = enum(u8) {A, B, _};
@@ -2887,7 +2897,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
     , &[_][]const u8{
         "tmp.zig:3:35: error: expected type 'SmallErrorSet!i32', found 'anyerror!i32'",
-        "tmp.zig:3:35: note: error set 'anyerror' cannot cast into error set 'SmallErrorSet'",
         "tmp.zig:3:35: note: cannot cast global error set into smaller set",
     });
 

--- a/test/stage1/behavior/error.zig
+++ b/test/stage1/behavior/error.zig
@@ -441,3 +441,24 @@ test "error payload type is correctly resolved" {
 
     expectEqual(MyIntWrapper{ .x = 42 }, try MyIntWrapper.create());
 }
+
+test "implicit casts between error union payloads" {
+    {
+        var a: anyerror!i16 = -3;
+        var b: anyerror!i16 = @as(i8, -3);
+        var c: anyerror!i32 = a;
+        expectEqual(@as(i16, -3), try a);
+        expectEqual(@as(i16, -3), try b);
+        expectEqual(@as(i32, -3), try c);
+    }
+    {
+        var a: error{a}!u32 = @as(u8, 10);
+        var b: error{a}!u64 = a;
+        var c: error{ a, b }!u64 = b;
+        var d: anyerror!u48 = a;
+        expectEqual(@as(u32, 10), try a);
+        expectEqual(@as(u64, 10), try b);
+        expectEqual(@as(u64, 10), try c);
+        expectEqual(@as(u48, 10), try d);
+    }
+}


### PR DESCRIPTION
~~Sadly this implementation suffers from the same problem as #4423, the use of `ir_get_ref` (in this PR I've used it directly, in that issue via `ir_analyze_struct_value_field_value`) makes the codegen stage trip an assertion since the value we're asking a reference to is not comptime-known.~~

~~@andrewrk can you have a look at that when you have some spare cycles? I have no idea if I'm misusing that IR instruction or it's a bug somewhere.~~

It turns out the `dummy_value` trick is back to bite our ass, this is ready to go, the conversion of function return values can be tracked in another ticket.

As a bonus there's yet another comma-related fix for `zig fmt`, yay.

Closes #2561