### PR TITLE
Fix emit_raw build step regression with latest changes in Target/CrossTarget refactoring

### DIFF
--- a/lib/std/build/emit_raw.zig
+++ b/lib/std/build/emit_raw.zig
@@ -241,7 +241,7 @@ pub const InstallRawStep = struct {
         const self = @fieldParentPtr(Self, "step", step);
         const builder = self.builder;
 
-        if (self.artifact.target.getObjectFormat() != .elf) {
+        if (self.artifact.target.toTarget().getObjectFormat() != .elf) {
             warn("InstallRawStep only works with ELF format.\n", .{});
             return error.InvalidObjectFormat;
         }


### PR DESCRIPTION
Found when trying to build ZigGBA with latest master