### PR TITLE
target: Implement OS version detection for OSX

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2764,6 +2764,7 @@ pub const SysCtlError = error{
     PermissionDenied,
     SystemResources,
     NameTooLong,
+    UnknownName,
 } || UnexpectedError;
 
 pub fn sysctl(
@@ -2779,6 +2780,7 @@ pub fn sysctl(
         EFAULT => unreachable,
         EPERM => return error.PermissionDenied,
         ENOMEM => return error.SystemResources,
+        ENOENT => return error.UnknownName,
         else => |err| return unexpectedErrno(err),
     }
 }
@@ -2795,6 +2797,7 @@ pub fn sysctlbynameC(
         EFAULT => unreachable,
         EPERM => return error.PermissionDenied,
         ENOMEM => return error.SystemResources,
+        ENOENT => return error.UnknownName,
         else => |err| return unexpectedErrno(err),
     }
 }

--- a/lib/std/thread.zig
+++ b/lib/std/thread.zig
@@ -382,7 +382,7 @@ pub const Thread = struct {
         var count_len: usize = @sizeOf(c_int);
         const name = if (comptime std.Target.current.isDarwin()) "hw.logicalcpu" else "hw.ncpu";
         os.sysctlbynameC(name, &count, &count_len, null, 0) catch |err| switch (err) {
-            error.NameTooLong => unreachable,
+            error.NameTooLong, error.UnknownName => unreachable,
             else => |e| return e,
         };
         return @intCast(usize, count);

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -225,7 +225,7 @@ pub const NativeTargetInfo = struct {
                 },
                 .macosx => {
                     var product_version: [32]u8 = undefined;
-                    var size: usize = @sizeOf(@TypeOf(product_version));
+                    var size: usize = product_version.len;
 
                     // The osproductversion sysctl was introduced first with
                     // High Sierra, thankfully that's also the baseline that Zig

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -224,7 +224,31 @@ pub const NativeTargetInfo = struct {
                     // TODO Detect native operating system version.
                 },
                 .macosx => {
-                    // TODO Detect native operating system version.
+                    var product_version: [32]u8 = undefined;
+                    var size: usize = @sizeOf(@TypeOf(product_version));
+
+                    // The osproductversion sysctl was introduced first with
+                    // High Sierra, thankfully that's also the baseline that Zig
+                    // supports
+                    std.os.sysctlbynameC(
+                        "kern.osproductversion",
+                        &product_version[0],
+                        &size,
+                        null,
+                        0,
+                    ) catch |err| switch (err) {
+                        error.UnknownName => unreachable,
+                        else => unreachable,
+                    };
+
+                    if (std.builtin.Version.parse(product_version[0..size])) |ver| {
+                        os.version_range.semver.min = ver;
+                        os.version_range.semver.max = ver;
+                    } else |err| switch (err) {
+                        error.Overflow => {},
+                        error.InvalidCharacter => {},
+                        error.InvalidVersion => {},
+                    }
                 },
                 .freebsd => {
                     // TODO Detect native operating system version.


### PR DESCRIPTION
If needed we can implement a fallback for some older versions using `kern.osrelease` and a table mapping the kernel version to the osx one (see [here](https://stackoverflow.com/questions/11072804/how-do-i-determine-the-os-version-at-runtime-in-os-x-or-ios-without-using-gesta) for more info).

Closes #4583