### PR TITLE
Fmt indentation, remove indent and start_col from rendering code

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1078,7 +1078,7 @@ pub fn bufPrint(buf: []u8, comptime fmt: []const u8, args: var) BufPrintError![]
 
 // Count the characters needed for format. Useful for preallocating memory
 pub fn count(comptime fmt: []const u8, args: var) u64 {
-    var counting_stream = std.io.countingOutStream(std.io.null_out_stream);
+    var counting_stream = std.io.countingOutStream(&std.io.null_out_stream);
     format(counting_stream.outStream(), fmt, args) catch |err| switch (err) {};
     return counting_stream.bytes_written;
 }

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -116,6 +116,15 @@ pub const bitInStream = @import("io/bit_in_stream.zig").bitInStream;
 pub const BitOutStream = @import("io/bit_out_stream.zig").BitOutStream;
 pub const bitOutStream = @import("io/bit_out_stream.zig").bitOutStream;
 
+pub const AutoIndentingStream = @import("io/auto_indenting_stream.zig").AutoIndentingStream;
+pub const autoIndentingStream = @import("io/auto_indenting_stream.zig").autoIndentingStream;
+
+pub const ChangeDetectionStream = @import("io/change_detection_stream.zig").ChangeDetectionStream;
+pub const changeDetectionStream = @import("io/change_detection_stream.zig").changeDetectionStream;
+
+pub const FindByteOutStream = @import("io/find_byte_out_stream.zig").FindByteOutStream;
+pub const findByteOutStream = @import("io/find_byte_out_stream.zig").findByteOutStream;
+
 pub const Packing = @import("io/serialization.zig").Packing;
 
 pub const Serializer = @import("io/serialization.zig").Serializer;
@@ -139,7 +148,7 @@ pub fn readFileAlloc(allocator: *mem.Allocator, path: []const u8) ![]u8 {
 }
 
 /// An OutStream that doesn't write to anything.
-pub const null_out_stream = @as(NullOutStream, .{ .context = {} });
+pub var null_out_stream = @as(NullOutStream, .{ .context = {} });
 
 const NullOutStream = OutStream(void, error{}, dummyWrite);
 fn dummyWrite(context: void, data: []const u8) error{}!usize {

--- a/lib/std/io/auto_indenting_stream.zig
+++ b/lib/std/io/auto_indenting_stream.zig
@@ -1,0 +1,135 @@
+const std = @import("../std.zig");
+const io = std.io;
+const mem = std.mem;
+const assert = std.debug.assert;
+
+pub fn AutoIndentingStream(comptime indent_delta: u8, comptime OutStreamType: type) type {
+    return struct {
+        const Self = @This();
+        pub const Error = OutStreamType.Error;
+        pub const OutStream = io.OutStream(*Self, Error, write);
+
+        out_stream: *OutStreamType,
+        current_line_empty: bool = true,
+        indent_stack: [255]u8 = undefined,
+        indent_stack_top: u8 = 0,
+        indent_one_shot_count: u8 = 0, // automatically popped when applied
+        applied_indent: u8 = 0, // the most recently applied indent
+        indent_next_line: u8 = 0, // not used until the next line
+
+        pub fn init(out_stream: *OutStreamType) Self {
+            return Self{ .out_stream = out_stream };
+        }
+
+        pub fn outStream(self: *Self) OutStream {
+            return .{ .context = self };
+        }
+
+        pub fn write(self: *Self, bytes: []const u8) Error!usize {
+            if (bytes.len == 0)
+                return @as(usize, 0);
+
+            try self.applyIndent();
+            return self.writeNoIndent(bytes);
+        }
+
+        fn writeNoIndent(self: *Self, bytes: []const u8) Error!usize {
+            try self.out_stream.outStream().writeAll(bytes);
+            if (bytes[bytes.len - 1] == '\n')
+                self.resetLine();
+            return bytes.len;
+        }
+
+        pub fn insertNewline(self: *Self) Error!void {
+            _ = try self.writeNoIndent("\n");
+        }
+
+        fn resetLine(self: *Self) void {
+            self.current_line_empty = true;
+            self.indent_next_line = 0;
+        }
+
+        /// Insert a newline unless the current line is blank
+        pub fn maybeInsertNewline(self: *Self) Error!void {
+            if (!self.current_line_empty)
+                try self.insertNewline();
+        }
+
+        /// Push default indentation
+        pub fn pushIndent(self: *Self) void {
+            // Doesn't actually write any indentation. Just primes the stream to be able to write the correct indentation if it needs to.
+            self.pushIndentN(indent_delta);
+        }
+
+        /// Push an indent of arbitrary width
+        pub fn pushIndentN(self: *Self, n: u8) void {
+            assert(self.indent_stack_top < std.math.maxInt(u8));
+            self.indent_stack[self.indent_stack_top] = n;
+            self.indent_stack_top += 1;
+        }
+
+        /// Push an indent that is automatically popped after being applied
+        pub fn pushIndentOneShot(self: *Self) void {
+            self.indent_one_shot_count += 1;
+            self.pushIndent();
+        }
+
+        /// Turns all one-shot indents into regular indents
+        /// Returns number of indents that must now be manually popped
+        pub fn lockOneShotIndent(self: *Self) u8 {
+            var locked_count = self.indent_one_shot_count;
+            self.indent_one_shot_count = 0;
+            return locked_count;
+        }
+
+        /// Push an indent that should not take effect until the next line
+        pub fn pushIndentNextLine(self: *Self) void {
+            self.indent_next_line += 1;
+            self.pushIndent();
+        }
+
+        pub fn popIndent(self: *Self) void {
+            assert(self.indent_stack_top != 0);
+            self.indent_stack_top -= 1;
+            self.indent_next_line = std.math.min(self.indent_stack_top, self.indent_next_line); // Tentative indent may have been popped before there was a newline
+        }
+
+        /// Writes ' ' bytes if the current line is empty
+        fn applyIndent(self: *Self) Error!void {
+            const current_indent = self.currentIndent();
+            if (self.current_line_empty and current_indent > 0) {
+                try self.out_stream.outStream().writeByteNTimes(' ', current_indent);
+                self.applied_indent = current_indent;
+            }
+
+            self.indent_stack_top -= self.indent_one_shot_count;
+            self.indent_one_shot_count = 0;
+            self.current_line_empty = false;
+        }
+
+        /// Checks to see if the most recent indentation exceeds the currently pushed indents
+        pub fn isLineOverIndented(self: *Self) bool {
+            if (self.current_line_empty) return false;
+            return self.applied_indent > self.currentIndent();
+        }
+
+        fn currentIndent(self: *Self) u8 {
+            var indent_current: u8 = 0;
+            if (self.indent_stack_top > 0) {
+                const stack_top = self.indent_stack_top - self.indent_next_line;
+                for (self.indent_stack[0..stack_top]) |indent| {
+                    indent_current += indent;
+                }
+            }
+            return indent_current;
+        }
+    };
+}
+
+pub fn autoIndentingStream(
+    comptime indent_delta: u8,
+    underlying_stream: var,
+) AutoIndentingStream(indent_delta, @TypeOf(underlying_stream).Child) {
+    comptime assert(@typeInfo(@TypeOf(underlying_stream)) == .Pointer);
+    return AutoIndentingStream(indent_delta, @TypeOf(underlying_stream).Child).init(underlying_stream);
+}

--- a/lib/std/io/change_detection_stream.zig
+++ b/lib/std/io/change_detection_stream.zig
@@ -1,0 +1,58 @@
+const std = @import("../std.zig");
+const io = std.io;
+const mem = std.mem;
+const assert = std.debug.assert;
+
+pub fn ChangeDetectionStream(comptime OutStreamType: type) type {
+    return struct {
+        const Self = @This();
+        pub const Error = OutStreamType.Error;
+        pub const OutStream = io.OutStream(*Self, Error, write);
+
+        anything_changed: bool = false,
+        out_stream: *OutStreamType,
+        source_index: usize,
+        source: []const u8,
+
+        pub fn init(source: []const u8, out_stream: *OutStreamType) Self {
+            return Self{
+                .out_stream = out_stream,
+                .source_index = 0,
+                .source = source,
+            };
+        }
+
+        pub fn outStream(self: *Self) OutStream {
+            return .{ .context = self };
+        }
+
+        fn write(self: *Self, bytes: []const u8) Error!usize {
+            if (!self.anything_changed) {
+                const end = self.source_index + bytes.len;
+                if (end > self.source.len) {
+                    self.anything_changed = true;
+                } else {
+                    const src_slice = self.source[self.source_index..end];
+                    self.source_index += bytes.len;
+                    if (!mem.eql(u8, bytes, src_slice)) {
+                        self.anything_changed = true;
+                    }
+                }
+            }
+
+            return self.out_stream.outStream().write(bytes);
+        }
+
+        pub fn changeDetected(self: *Self) bool {
+            return self.anything_changed or (self.source_index != self.source.len);
+        }
+    };
+}
+
+pub fn changeDetectionStream(
+    source: []const u8,
+    underlying_stream: var,
+) ChangeDetectionStream(@TypeOf(underlying_stream).Child) {
+    comptime assert(@typeInfo(@TypeOf(underlying_stream)) == .Pointer);
+    return ChangeDetectionStream(@TypeOf(underlying_stream).Child).init(source, underlying_stream);
+}

--- a/lib/std/io/counting_out_stream.zig
+++ b/lib/std/io/counting_out_stream.zig
@@ -6,7 +6,7 @@ const testing = std.testing;
 pub fn CountingOutStream(comptime OutStreamType: type) type {
     return struct {
         bytes_written: u64,
-        child_stream: OutStreamType,
+        child_stream: *OutStreamType,
 
         pub const Error = OutStreamType.Error;
         pub const OutStream = io.OutStream(*Self, Error, write);
@@ -25,12 +25,12 @@ pub fn CountingOutStream(comptime OutStreamType: type) type {
     };
 }
 
-pub fn countingOutStream(child_stream: var) CountingOutStream(@TypeOf(child_stream)) {
+pub fn countingOutStream(child_stream: var) CountingOutStream(@TypeOf(child_stream).Child) {
     return .{ .bytes_written = 0, .child_stream = child_stream };
 }
 
 test "io.CountingOutStream" {
-    var counting_stream = countingOutStream(std.io.null_out_stream);
+    var counting_stream = countingOutStream(&std.io.null_out_stream);
     const stream = counting_stream.outStream();
 
     const bytes = "yay" ** 100;

--- a/lib/std/io/find_byte_out_stream.zig
+++ b/lib/std/io/find_byte_out_stream.zig
@@ -1,0 +1,44 @@
+const std = @import("../std.zig");
+const io = std.io;
+const assert = std.debug.assert;
+
+// An OutStream that returns whether the given character has been written to it.
+// The contents are not written to anything.
+pub fn FindByteOutStream(comptime OutStreamType: type) type {
+    return struct {
+        const Self = @This();
+        pub const Error = OutStreamType.Error;
+        pub const OutStream = io.OutStream(*Self, Error, write);
+
+        out_stream: *OutStreamType,
+        byte_found: bool,
+        byte: u8,
+
+        pub fn init(byte: u8, out_stream: *OutStreamType) Self {
+            return Self{
+                .out_stream = out_stream,
+                .byte = byte,
+                .byte_found = false,
+            };
+        }
+
+        pub fn outStream(self: *Self) OutStream {
+            return .{ .context = self };
+        }
+
+        fn write(self: *Self, bytes: []const u8) Error!usize {
+            if (!self.byte_found) {
+                self.byte_found = blk: {
+                    for (bytes) |b|
+                        if (b == self.byte) break :blk true;
+                    break :blk false;
+                };
+            }
+            return self.out_stream.outStream().write(bytes);
+        }
+    };
+}
+pub fn findByteOutStream(byte: u8, underlying_stream: var) FindByteOutStream(@TypeOf(underlying_stream).Child) {
+    comptime assert(@typeInfo(@TypeOf(underlying_stream)) == .Pointer);
+    return FindByteOutStream(@TypeOf(underlying_stream).Child).init(byte, underlying_stream);
+}

--- a/lib/std/io/out_stream.zig
+++ b/lib/std/io/out_stream.zig
@@ -13,6 +13,10 @@ pub fn OutStream(
         const Self = @This();
         pub const Error = WriteError;
 
+        pub fn outStream(self: *const Self) Self {
+            return self.*;
+        }
+
         pub fn write(self: Self, bytes: []const u8) Error!usize {
             return writeFn(self.context, bytes);
         }


### PR DESCRIPTION
This (I hope) will make dealing with indentation in zig fmt easier to work with. See #4580 
The auto indenting stream is more complicated than the original proposal to cover the edge cases of all the places zig wants to put indentation.

This implementation currently requires a change to Streams in general to make them easier to pipe ( proposal #4666). If there is a good way of doing the same thing in current zig then I'd be happy to go that direction instead (as the proposal would be a pretty big change).

Take note of the changes to a few of the test cases, I think I can make a case (pun intended) for them but am happy to go back to the old behaviour if it's desired. The main change is ArrayInitializers always try to indent their contents, even if there is no trailing comma.
