### PR TITLE
Fix std.os.unlinkatW for absolute paths

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1438,7 +1438,7 @@ pub fn unlinkatW(dirfd: fd_t, sub_path_w: [*:0]const u16, flags: u32) UnlinkatEr
 
     var attr = w.OBJECT_ATTRIBUTES{
         .Length = @sizeOf(w.OBJECT_ATTRIBUTES),
-        .RootDirectory = dirfd,
+        .RootDirectory = if (std.fs.path.isAbsoluteWindowsW(sub_path_w)) null else dirfd,
         .Attributes = 0, // Note we do not use OBJ_CASE_INSENSITIVE here.
         .ObjectName = &nt_name,
         .SecurityDescriptor = null,


### PR DESCRIPTION
RootDirectory can't be set in ObjectAttributes if ObjectName is an absolute path. Fixes #4606

---

This pattern was actually already present for all the other uses of `NtCreateFile`/`OBJECT_ATTRIBUTES`, so this was just an oversight.

https://github.com/ziglang/zig/blob/3c1432701129bacf95b944f0f86af2d96ae72c69/lib/std/os.zig#L2699
https://github.com/ziglang/zig/blob/76176104001420ea04840f9b31e706289e4ebf11/lib/std/fs.zig#L849