### PR TITLE
linux: Correct pread64 syscall for ARM/MIPS

### DIFF
--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -45,10 +45,6 @@ fn testThreadIdFn(thread_id: *Thread.Id) void {
 }
 
 test "sendfile" {
-    if (std.Target.current.cpu.arch == .mipsel) {
-        // https://github.com/ziglang/zig/issues/4615
-        return error.SkipZigTest;
-    }
     try fs.makePath(a, "os_test_tmp");
     defer fs.deleteTree("os_test_tmp") catch {};
 


### PR DESCRIPTION
Why the test didn't fail on ARM? A matter of sheer luck, the register holding the other half of the offset was always zero in the tests.

Closes #4615