### PR TITLE
improvements to std.fs, std.os

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -50,7 +50,7 @@ pub fn main() !void {
     var tokenizer = Tokenizer.init(in_file_name, input_file_bytes);
     var toc = try genToc(allocator, &tokenizer);
 
-    try fs.makePath(allocator, tmp_dir_name);
+    try fs.cwd().makePath(tmp_dir_name);
     defer fs.deleteTree(tmp_dir_name) catch {};
 
     try genHtml(allocator, &tokenizer, &toc, &buffered_out_stream.stream, zig_exe);

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -763,7 +763,7 @@ pub const Builder = struct {
     }
 
     pub fn makePath(self: *Builder, path: []const u8) !void {
-        fs.makePath(self.allocator, self.pathFromRoot(path)) catch |err| {
+        fs.cwd().makePath(self.pathFromRoot(path)) catch |err| {
             warn("Unable to create path {}: {}\n", .{ path, @errorName(err) });
             return err;
         };
@@ -2311,7 +2311,7 @@ pub const InstallDirStep = struct {
             const rel_path = entry.path[full_src_dir.len + 1 ..];
             const dest_path = try fs.path.join(self.builder.allocator, &[_][]const u8{ dest_prefix, rel_path });
             switch (entry.kind) {
-                .Directory => try fs.makePath(self.builder.allocator, dest_path),
+                .Directory => try fs.cwd().makePath(dest_path),
                 .File => try self.builder.updateFile(entry.path, dest_path),
                 else => continue,
             }

--- a/lib/std/build/write_file.zig
+++ b/lib/std/build/write_file.zig
@@ -74,7 +74,7 @@ pub const WriteFileStep = struct {
             &hash_basename,
         });
         // TODO replace with something like fs.makePathAndOpenDir
-        fs.makePath(self.builder.allocator, self.output_dir) catch |err| {
+        fs.cwd().makePath(self.output_dir) catch |err| {
             warn("unable to make path {}: {}\n", .{ self.output_dir, @errorName(err) });
             return err;
         };

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -101,6 +101,7 @@ pub extern "c" fn faccessat(dirfd: fd_t, path: [*:0]const u8, mode: c_uint, flag
 pub extern "c" fn pipe(fds: *[2]fd_t) c_int;
 pub extern "c" fn pipe2(fds: *[2]fd_t, flags: u32) c_int;
 pub extern "c" fn mkdir(path: [*:0]const u8, mode: c_uint) c_int;
+pub extern "c" fn mkdirat(dirfd: fd_t, path: [*:0]const u8, mode: u32) c_int;
 pub extern "c" fn symlink(existing: [*:0]const u8, new: [*:0]const u8) c_int;
 pub extern "c" fn rename(old: [*:0]const u8, new: [*:0]const u8) c_int;
 pub extern "c" fn chdir(path: [*:0]const u8) c_int;

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -75,6 +75,7 @@ pub extern "c" fn isatty(fd: fd_t) c_int;
 pub extern "c" fn close(fd: fd_t) c_int;
 pub extern "c" fn fstat(fd: fd_t, buf: *Stat) c_int;
 pub extern "c" fn @"fstat$INODE64"(fd: fd_t, buf: *Stat) c_int;
+pub extern "c" fn fstatat(dirfd: fd_t, path: [*:0]const u8, stat_buf: *Stat, flags: u32) c_int;
 pub extern "c" fn lseek(fd: fd_t, offset: off_t, whence: c_int) off_t;
 pub extern "c" fn open(path: [*:0]const u8, oflag: c_uint, ...) c_int;
 pub extern "c" fn openat(fd: c_int, path: [*:0]const u8, oflag: c_uint, ...) c_int;

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -105,6 +105,7 @@ pub extern "c" fn mkdirat(dirfd: fd_t, path: [*:0]const u8, mode: u32) c_int;
 pub extern "c" fn symlink(existing: [*:0]const u8, new: [*:0]const u8) c_int;
 pub extern "c" fn rename(old: [*:0]const u8, new: [*:0]const u8) c_int;
 pub extern "c" fn chdir(path: [*:0]const u8) c_int;
+pub extern "c" fn fchdir(fd: fd_t) c_int;
 pub extern "c" fn execve(path: [*:0]const u8, argv: [*:null]const ?[*:0]const u8, envp: [*:null]const ?[*:0]const u8) c_int;
 pub extern "c" fn dup(fd: fd_t) c_int;
 pub extern "c" fn dup2(old_fd: fd_t, new_fd: fd_t) c_int;

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -706,7 +706,6 @@ pub const Dir = struct {
     /// Call `File.close` to release the resource.
     /// Asserts that the path parameter has no null bytes.
     pub fn openFile(self: Dir, sub_path: []const u8, flags: File.OpenFlags) File.OpenError!File {
-        if (std.debug.runtime_safety) for (sub_path) |byte| assert(byte != 0);
         if (builtin.os.tag == .windows) {
             const path_w = try os.windows.sliceToPrefixedFileW(sub_path);
             return self.openFileW(&path_w, flags);
@@ -756,7 +755,6 @@ pub const Dir = struct {
     /// Call `File.close` on the result when done.
     /// Asserts that the path parameter has no null bytes.
     pub fn createFile(self: Dir, sub_path: []const u8, flags: File.CreateFlags) File.OpenError!File {
-        if (std.debug.runtime_safety) for (sub_path) |byte| assert(byte != 0);
         if (builtin.os.tag == .windows) {
             const path_w = try os.windows.sliceToPrefixedFileW(sub_path);
             return self.createFileW(&path_w, flags);
@@ -909,7 +907,6 @@ pub const Dir = struct {
     ///
     /// Asserts that the path parameter has no null bytes.
     pub fn openDirTraverse(self: Dir, sub_path: []const u8) OpenError!Dir {
-        if (std.debug.runtime_safety) for (sub_path) |byte| assert(byte != 0);
         if (builtin.os.tag == .windows) {
             const sub_path_w = try os.windows.sliceToPrefixedFileW(sub_path);
             return self.openDirTraverseW(&sub_path_w);
@@ -927,7 +924,6 @@ pub const Dir = struct {
     ///
     /// Asserts that the path parameter has no null bytes.
     pub fn openDirList(self: Dir, sub_path: []const u8) OpenError!Dir {
-        if (std.debug.runtime_safety) for (sub_path) |byte| assert(byte != 0);
         if (builtin.os.tag == .windows) {
             const sub_path_w = try os.windows.sliceToPrefixedFileW(sub_path);
             return self.openDirListW(&sub_path_w);
@@ -1091,7 +1087,6 @@ pub const Dir = struct {
     /// To delete a directory recursively, see `deleteTree`.
     /// Asserts that the path parameter has no null bytes.
     pub fn deleteDir(self: Dir, sub_path: []const u8) DeleteDirError!void {
-        if (std.debug.runtime_safety) for (sub_path) |byte| assert(byte != 0);
         if (builtin.os.tag == .windows) {
             const sub_path_w = try os.windows.sliceToPrefixedFileW(sub_path);
             return self.deleteDirW(&sub_path_w);
@@ -1121,7 +1116,6 @@ pub const Dir = struct {
     /// The return value is a slice of `buffer`, from index `0`.
     /// Asserts that the path parameter has no null bytes.
     pub fn readLink(self: Dir, sub_path: []const u8, buffer: *[MAX_PATH_BYTES]u8) ![]u8 {
-        if (std.debug.runtime_safety) for (sub_path) |byte| assert(byte != 0);
         const sub_path_c = try os.toPosixPath(sub_path);
         return self.readLinkC(&sub_path_c, buffer);
     }

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -890,6 +890,10 @@ pub const Dir = struct {
         try os.mkdiratC(self.fd, sub_path, default_new_dir_mode);
     }
 
+    pub fn changeTo(self: Dir) !void {
+        try os.fchdir(self.fd);
+    }
+
     /// Deprecated; call `openDirList` directly.
     pub fn openDir(self: Dir, sub_path: []const u8) OpenError!Dir {
         return self.openDirList(sub_path);

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -882,6 +882,14 @@ pub const Dir = struct {
         }
     }
 
+    pub fn makeDir(self: Dir, sub_path: []const u8) !void {
+        try os.mkdirat(self.fd, sub_path, default_new_dir_mode);
+    }
+
+    pub fn makeDirC(self: Dir, sub_path: [*:0]const u8) !void {
+        try os.mkdiratC(self.fd, sub_path, default_new_dir_mode);
+    }
+
     /// Deprecated; call `openDirList` directly.
     pub fn openDir(self: Dir, sub_path: []const u8) OpenError!Dir {
         return self.openDirList(sub_path);

--- a/lib/std/fs/watch.zig
+++ b/lib/std/fs/watch.zig
@@ -618,11 +618,10 @@ test "write a file, watch it, write it again" {
     // TODO re-enable this test
     if (true) return error.SkipZigTest;
 
-    const allocator = std.heap.page_allocator;
-
-    try os.makePath(allocator, test_tmp_dir);
+    try fs.cwd().makePath(test_tmp_dir);
     defer os.deleteTree(test_tmp_dir) catch {};
 
+    const allocator = std.heap.page_allocator;
     return testFsWatch(&allocator);
 }
 

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3818,12 +3818,14 @@ pub fn sendfile(
                 switch (err) {
                     0 => return amt,
 
-                    EBADF => unreachable, // Always a race condition.
                     EFAULT => unreachable, // Segmentation fault.
                     EINVAL => unreachable,
                     ENOTCONN => unreachable, // `out_fd` is an unconnected socket.
 
-                    ENOTSUP, ENOTSOCK, ENOSYS => break :sf,
+                    // On macOS version 10.14.6, I observed Darwin return EBADF when
+                    // using sendfile on a valid open file descriptor of a file
+                    // system file.
+                    ENOTSUP, ENOTSOCK, ENOSYS, EBADF => break :sf,
 
                     EINTR => if (amt != 0) return amt else continue,
 

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1355,7 +1355,6 @@ pub const UnlinkatError = UnlinkError || error{
 /// Delete a file name and possibly the file it refers to, based on an open directory handle.
 /// Asserts that the path parameter has no null bytes.
 pub fn unlinkat(dirfd: fd_t, file_path: []const u8, flags: u32) UnlinkatError!void {
-    if (std.debug.runtime_safety) for (file_path) |byte| assert(byte != 0);
     if (builtin.os.tag == .windows) {
         const file_path_w = try windows.sliceToPrefixedFileW(file_path);
         return unlinkatW(dirfd, &file_path_w, flags);
@@ -3241,6 +3240,7 @@ pub fn sched_getaffinity(pid: pid_t) SchedGetAffinityError!cpu_set_t {
 /// Used to convert a slice to a null terminated slice on the stack.
 /// TODO https://github.com/ziglang/zig/issues/287
 pub fn toPosixPath(file_path: []const u8) ![PATH_MAX - 1:0]u8 {
+    if (std.debug.runtime_safety) assert(std.mem.indexOfScalar(u8, file_path, 0) == null);
     var path_with_null: [PATH_MAX - 1:0]u8 = undefined;
     // >= rather than > to make room for the null byte
     if (file_path.len >= PATH_MAX) return error.NameTooLong;

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1706,6 +1706,20 @@ pub fn chdirC(dir_path: [*:0]const u8) ChangeCurDirError!void {
     }
 }
 
+pub fn fchdir(dirfd: fd_t) ChangeCurDirError!void {
+    while (true) {
+        switch (errno(system.fchdir(dirfd))) {
+            0 => return,
+            EACCES => return error.AccessDenied,
+            EBADF => unreachable,
+            ENOTDIR => return error.NotDir,
+            EINTR => continue,
+            EIO => return error.FileSystem,
+            else => |err| return unexpectedErrno(err),
+        }
+    }
+}
+
 pub const ReadLinkError = error{
     AccessDenied,
     FileSystem,

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -76,6 +76,10 @@ pub fn chdir(path: [*:0]const u8) usize {
     return syscall1(SYS_chdir, @ptrToInt(path));
 }
 
+pub fn fchdir(fd: fd_t) usize {
+    return syscall1(SYS_fchdir, @bitCast(usize, @as(isize, fd)));
+}
+
 pub fn chroot(path: [*:0]const u8) usize {
     return syscall1(SYS_chroot, @ptrToInt(path));
 }

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -45,7 +45,7 @@ fn testThreadIdFn(thread_id: *Thread.Id) void {
 }
 
 test "sendfile" {
-    try fs.makePath(a, "os_test_tmp");
+    try fs.cwd().makePath("os_test_tmp");
     defer fs.deleteTree("os_test_tmp") catch {};
 
     var dir = try fs.cwd().openDirList("os_test_tmp");
@@ -74,7 +74,9 @@ test "sendfile" {
 
     const header1 = "header1\n";
     const header2 = "second header\n";
-    var headers = [_]os.iovec_const{
+    const trailer1 = "trailer1\n";
+    const trailer2 = "second trailer\n";
+    var hdtr = [_]os.iovec_const{
         .{
             .iov_base = header1,
             .iov_len = header1.len,
@@ -83,11 +85,6 @@ test "sendfile" {
             .iov_base = header2,
             .iov_len = header2.len,
         },
-    };
-
-    const trailer1 = "trailer1\n";
-    const trailer2 = "second trailer\n";
-    var trailers = [_]os.iovec_const{
         .{
             .iov_base = trailer1,
             .iov_len = trailer1.len,
@@ -99,57 +96,14 @@ test "sendfile" {
     };
 
     var written_buf: [header1.len + header2.len + 10 + trailer1.len + trailer2.len]u8 = undefined;
-    try sendfileAll(dest_file.handle, src_file.handle, 1, 10, &headers, &trailers, 0);
-
+    try dest_file.writeFileAll(src_file, .{
+        .in_offset = 1,
+        .in_len = 10,
+        .headers_and_trailers = &hdtr,
+        .header_count = 2,
+    });
     try dest_file.preadAll(&written_buf, 0);
     expect(mem.eql(u8, &written_buf, "header1\nsecond header\nine1\nsecontrailer1\nsecond trailer\n"));
-}
-
-fn sendfileAll(
-    out_fd: os.fd_t,
-    in_fd: os.fd_t,
-    offset: u64,
-    count: usize,
-    headers: []os.iovec_const,
-    trailers: []os.iovec_const,
-    flags: u32,
-) os.SendFileError!void {
-    var amt: usize = undefined;
-    hdrs: {
-        var i: usize = 0;
-        while (i < headers.len) {
-            amt = try os.sendfile(out_fd, in_fd, offset, count, headers[i..], trailers, flags);
-            while (amt >= headers[i].iov_len) {
-                amt -= headers[i].iov_len;
-                i += 1;
-                if (i >= headers.len) break :hdrs;
-            }
-            headers[i].iov_base += amt;
-            headers[i].iov_len -= amt;
-        }
-    }
-    var off = amt;
-    while (off < count) {
-        amt = try os.sendfile(out_fd, in_fd, offset + off, count - off, &[0]os.iovec_const{}, trailers, flags);
-        off += amt;
-    }
-    amt = off - count;
-    var i: usize = 0;
-    while (i < trailers.len) {
-        while (amt >= headers[i].iov_len) {
-            amt -= trailers[i].iov_len;
-            i += 1;
-            if (i >= trailers.len) return;
-        }
-        trailers[i].iov_base += amt;
-        trailers[i].iov_len -= amt;
-        if (std.Target.current.os.tag == .windows) {
-            amt = try os.writev(out_fd, trailers[i..]);
-        } else {
-            // Here we must use send because it's the only way to give the flags.
-            amt = try os.send(out_fd, trailers[i].iov_base[0..trailers[i].iov_len], flags);
-        }
-    }
 }
 
 test "std.Thread.getCurrentId" {

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -16,7 +16,7 @@ const AtomicRmwOp = builtin.AtomicRmwOp;
 const AtomicOrder = builtin.AtomicOrder;
 
 test "makePath, put some files in it, deleteTree" {
-    try fs.makePath(a, "os_test_tmp" ++ fs.path.sep_str ++ "b" ++ fs.path.sep_str ++ "c");
+    try fs.cwd().makePath("os_test_tmp" ++ fs.path.sep_str ++ "b" ++ fs.path.sep_str ++ "c");
     try io.writeFile("os_test_tmp" ++ fs.path.sep_str ++ "b" ++ fs.path.sep_str ++ "c" ++ fs.path.sep_str ++ "file.txt", "nonsense");
     try io.writeFile("os_test_tmp" ++ fs.path.sep_str ++ "b" ++ fs.path.sep_str ++ "file2.txt", "blah");
     try fs.deleteTree("os_test_tmp");
@@ -28,7 +28,7 @@ test "makePath, put some files in it, deleteTree" {
 }
 
 test "access file" {
-    try fs.makePath(a, "os_test_tmp");
+    try fs.cwd().makePath("os_test_tmp");
     if (fs.cwd().access("os_test_tmp" ++ fs.path.sep_str ++ "file.txt", .{})) |ok| {
         @panic("expected error");
     } else |err| {

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -337,7 +337,7 @@ pub fn GetQueuedCompletionStatus(
 }
 
 pub fn CloseHandle(hObject: HANDLE) void {
-    assert(kernel32.CloseHandle(hObject) != 0);
+    assert(ntdll.NtClose(hObject) == .SUCCESS);
 }
 
 pub fn FindClose(hFindFile: HANDLE) void {
@@ -586,23 +586,74 @@ pub fn MoveFileExW(old_path: [*:0]const u16, new_path: [*:0]const u16, flags: DW
 }
 
 pub const CreateDirectoryError = error{
+    NameTooLong,
     PathAlreadyExists,
     FileNotFound,
+    NoDevice,
+    AccessDenied,
     Unexpected,
 };
 
-pub fn CreateDirectory(pathname: []const u8, attrs: ?*SECURITY_ATTRIBUTES) CreateDirectoryError!void {
+/// Returns an open directory handle which the caller is responsible for closing with `CloseHandle`.
+pub fn CreateDirectory(dir: ?HANDLE, pathname: []const u8, sa: ?*SECURITY_ATTRIBUTES) CreateDirectoryError!HANDLE {
     const pathname_w = try sliceToPrefixedFileW(pathname);
-    return CreateDirectoryW(&pathname_w, attrs);
+    return CreateDirectoryW(dir, &pathname_w, sa);
 }
 
-pub fn CreateDirectoryW(pathname: [*:0]const u16, attrs: ?*SECURITY_ATTRIBUTES) CreateDirectoryError!void {
-    if (kernel32.CreateDirectoryW(pathname, attrs) == 0) {
-        switch (kernel32.GetLastError()) {
-            .ALREADY_EXISTS => return error.PathAlreadyExists,
-            .PATH_NOT_FOUND => return error.FileNotFound,
-            else => |err| return unexpectedError(err),
-        }
+/// Same as `CreateDirectory` except takes a WTF-16 encoded path.
+pub fn CreateDirectoryW(
+    dir: ?HANDLE,
+    sub_path_w: [*:0]const u16,
+    sa: ?*SECURITY_ATTRIBUTES,
+) CreateDirectoryError!HANDLE {
+    const path_len_bytes = math.cast(u16, mem.toSliceConst(u16, sub_path_w).len * 2) catch |err| switch (err) {
+        error.Overflow => return error.NameTooLong,
+    };
+    var nt_name = UNICODE_STRING{
+        .Length = path_len_bytes,
+        .MaximumLength = path_len_bytes,
+        .Buffer = @intToPtr([*]u16, @ptrToInt(sub_path_w)),
+    };
+
+    if (sub_path_w[0] == '.' and sub_path_w[1] == 0) {
+        // Windows does not recognize this, but it does work with empty string.
+        nt_name.Length = 0;
+    }
+
+    var attr = OBJECT_ATTRIBUTES{
+        .Length = @sizeOf(OBJECT_ATTRIBUTES),
+        .RootDirectory = if (std.fs.path.isAbsoluteWindowsW(sub_path_w)) null else dir,
+        .Attributes = 0, // Note we do not use OBJ_CASE_INSENSITIVE here.
+        .ObjectName = &nt_name,
+        .SecurityDescriptor = if (sa) |ptr| ptr.lpSecurityDescriptor else null,
+        .SecurityQualityOfService = null,
+    };
+    var io: IO_STATUS_BLOCK = undefined;
+    var result_handle: HANDLE = undefined;
+    const rc = ntdll.NtCreateFile(
+        &result_handle,
+        GENERIC_READ | SYNCHRONIZE,
+        &attr,
+        &io,
+        null,
+        FILE_ATTRIBUTE_NORMAL,
+        FILE_SHARE_READ,
+        FILE_CREATE,
+        FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT,
+        null,
+        0,
+    );
+    switch (rc) {
+        .SUCCESS => return result_handle,
+        .OBJECT_NAME_INVALID => unreachable,
+        .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
+        .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
+        .NO_MEDIA_IN_DEVICE => return error.NoDevice,
+        .INVALID_PARAMETER => unreachable,
+        .ACCESS_DENIED => return error.AccessDenied,
+        .OBJECT_PATH_SYNTAX_BAD => unreachable,
+        .OBJECT_NAME_COLLISION => return error.PathAlreadyExists,
+        else => return unexpectedStatus(rc),
     }
 }
 

--- a/src-self-hosted/compilation.zig
+++ b/src-self-hosted/compilation.zig
@@ -1179,7 +1179,7 @@ pub const Compilation = struct {
         defer self.gpa().free(zig_dir_path);
 
         const tmp_dir = try fs.path.join(self.arena(), &[_][]const u8{ zig_dir_path, comp_dir_name[0..] });
-        try fs.makePath(self.gpa(), tmp_dir);
+        try fs.cwd().makePath(tmp_dir);
         return tmp_dir;
     }
 

--- a/src-self-hosted/test.zig
+++ b/src-self-hosted/test.zig
@@ -56,7 +56,7 @@ pub const TestContext = struct {
         self.zig_lib_dir = try introspect.resolveZigLibDir(allocator);
         errdefer allocator.free(self.zig_lib_dir);
 
-        try std.fs.makePath(allocator, tmp_dir_name);
+        try std.fs.cwd().makePath(tmp_dir_name);
         errdefer std.fs.deleteTree(tmp_dir_name) catch {};
     }
 
@@ -85,7 +85,7 @@ pub const TestContext = struct {
         const file1_path = try std.fs.path.join(allocator, [_][]const u8{ tmp_dir_name, file_index, file1 });
 
         if (std.fs.path.dirname(file1_path)) |dirname| {
-            try std.fs.makePath(allocator, dirname);
+            try std.fs.cwd().makePath(dirname);
         }
 
         // TODO async I/O
@@ -119,7 +119,7 @@ pub const TestContext = struct {
 
         const output_file = try std.fmt.allocPrint(allocator, "{}-out{}", .{ file1_path, (Target{ .Native = {} }).exeFileExt() });
         if (std.fs.path.dirname(file1_path)) |dirname| {
-            try std.fs.makePath(allocator, dirname);
+            try std.fs.cwd().makePath(dirname);
         }
 
         // TODO async I/O

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -37,7 +37,7 @@ pub fn main() !void {
     };
     for (test_fns) |testFn| {
         try fs.deleteTree(dir_path);
-        try fs.makeDir(dir_path);
+        try fs.cwd().makeDir(dir_path);
         try testFn(zig_exe, dir_path);
     }
 }


### PR DESCRIPTION
This is @daurnimator's #4184 merged into a branch, and then the following things on top of it:

* improve `std.fs.AtomicFile` to use sendfile()
  - also fix AtomicFile cleanup not destroying tmp files under some
    error conditions
* improve `std.fs.updateFile` to take advantage of the new `makePath`
  which no longer needs an Allocator.
* rename std.fs.makeDir to std.fs.makeDirAbsolute
* rename std.fs.Dir.makeDirC to std.fs.Dir.makeDirZ
* add `std.fs.Dir.makeDirW` and provide Windows implementation of
  std.os.mkdirat. `std.os.windows.CreateDirectory` is now implemented
  by calling ntdll, supports an optional root directory handle,
  and returns an open directory handle. Its error set has a few more
  errors in it.
* rename `std.fs.Dir.changeTo` to `std.fs.Dir.setAsCwd`
* fix `std.fs.File.writevAll` and related functions when len 0 iovecs
  supplied.
* introduce `std.fs.File.writeFileAll`, exposing a convenient
  cross-platform API on top of sendfile().
* `NoDevice` added to `std.os.MakeDirError` error set.
* `std.os.fchdir` gets a smaller error set.
* `std.os.windows.CloseHandle` is implemented with ntdll call rather than
  kernel32.

