### PR TITLE
Partially implement cache hash API in zig

### DIFF
--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -349,13 +349,13 @@ pub const CacheHash = struct {
     /// Writing to the manifest file is the only way that this file can return an
     /// error.
     pub fn release(self: *@This()) !void {
-        debug.assert(self.manifest_file != null);
+        if (self.manifest_file) |file| {
+            if (self.manifest_dirty) {
+                try self.write_manifest();
+            }
 
-        if (self.manifest_dirty) {
-            try self.write_manifest();
+            file.close();
         }
-
-        self.manifest_file.?.close();
 
         for (self.files.items) |*file| {
             file.deinit(self.alloc);

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -186,6 +186,10 @@ pub const CacheHash = struct {
                 return error.InvalidFormat;
             }
 
+            if (cache_hash_file.path == null) {
+                cache_hash_file.path = try mem.dupe(self.alloc, u8, file_path);
+            }
+
             const this_file = fs.cwd().openFile(cache_hash_file.path.?, .{ .read = true }) catch {
                 return error.CacheUnavailable;
             };

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -258,7 +258,11 @@ pub const CacheHash = struct {
     }
 
     /// Add a file as a dependency of process being cached, after the initial hash has been
-    /// calculated. Returns the contents of the file, allocated with the given allocator.
+    /// calculated. This is useful for processes that don't know the all the files that
+    /// are depended on ahead of time. For example, a source file that can import other files
+    /// will need to be recompiled if the imported file is changed.
+    ///
+    /// Returns the contents of the file, allocated with the given allocator.
     pub fn addFilePostFetch(self: *@This(), otherAlloc: *mem.Allocator, file_path: []const u8) ![]u8 {
         debug.assert(self.manifest_file != null);
 
@@ -269,7 +273,9 @@ pub const CacheHash = struct {
     }
 
     /// Add a file as a dependency of process being cached, after the initial hash has been
-    /// calculated.
+    /// calculated. This is useful for processes that don't know the all the files that
+    /// are depended on ahead of time. For example, a source file that can import other files
+    /// will need to be recompiled if the imported file is changed.
     pub fn addFilePost(self: *@This(), file_path: []const u8) !void {
         const contents = try self.addFilePostFetch(self.alloc, file_path);
         self.alloc.free(contents);

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -182,8 +182,10 @@ pub const CacheHash = struct {
             if (file_path.len == 0) {
                 return error.InvalidFormat;
             }
-            if (cache_hash_file.path != null and !mem.eql(u8, file_path, cache_hash_file.path.?)) {
-                return error.InvalidFormat;
+            if (cache_hash_file.path) |p| {
+                if (!mem.eql(u8, file_path, p)) {
+                    return error.InvalidFormat;
+                }
             }
 
             if (cache_hash_file.path == null) {

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -139,7 +139,11 @@ pub const CacheHash = struct {
             const manifest_file_path = try fmt.allocPrint(self.alloc, "{}.txt", .{self.b64_digest});
             defer self.alloc.free(manifest_file_path);
 
-            self.manifest_file = try self.manifest_dir.createFile(manifest_file_path, .{ .read = true, .truncate = false });
+            self.manifest_file = try self.manifest_dir.createFile(manifest_file_path, .{
+                .read = true,
+                .truncate = false,
+                .lock = .Exclusive,
+            });
         }
 
         // TODO: Figure out a good max value?
@@ -213,7 +217,7 @@ pub const CacheHash = struct {
 
         if (any_file_changed) {
             // cache miss
-            // keep the manifest file open (TODO: with rw lock)
+            // keep the manifest file open
             // reset the hash
             self.blake3 = Blake3.init();
             self.blake3.update(&bin_digest);

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -1,6 +1,5 @@
 const Blake3 = @import("crypto.zig").Blake3;
 const fs = @import("fs.zig");
-const File = fs.File;
 const base64 = @import("base64.zig");
 const ArrayList = @import("array_list.zig").ArrayList;
 const debug = @import("debug.zig");
@@ -39,7 +38,7 @@ pub const CacheHash = struct {
     blake3: Blake3,
     manifest_dir: []const u8,
     manifest_file_path: ?[]const u8,
-    manifest_file: ?File,
+    manifest_file: ?fs.File,
     manifest_dirty: bool,
     force_check_manifest: bool,
     files: ArrayList(CacheHashFile),
@@ -295,7 +294,7 @@ pub const CacheHash = struct {
     }
 };
 
-fn hash_file(alloc: *Allocator, bin_digest: []u8, handle: *const File) !void {
+fn hash_file(alloc: *Allocator, bin_digest: []u8, handle: *const fs.File) !void {
     var blake3 = Blake3.init();
     var in_stream = handle.inStream().stream;
 

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -271,14 +271,13 @@ pub const CacheHash = struct {
     pub fn write_manifest(self: *@This()) !void {
         debug.assert(self.manifest_file != null);
 
-        var encoded_digest = try Buffer.initSize(self.alloc, BASE64_DIGEST_LEN);
-        defer encoded_digest.deinit();
+        var encoded_digest: [BASE64_DIGEST_LEN]u8 = undefined;
         var contents = try Buffer.init(self.alloc, "");
         defer contents.deinit();
 
         for (self.files.toSlice()) |file| {
-            base64_encoder.encode(encoded_digest.toSlice(), &file.bin_digest);
-            try contents.print("{} {} {} {}\n", .{ file.file_handle, file.stat.mtime, encoded_digest.toSlice(), file.path });
+            base64_encoder.encode(encoded_digest[0..], &file.bin_digest);
+            try contents.print("{} {} {} {}\n", .{ file.file_handle, file.stat.mtime, encoded_digest[0..], file.path });
         }
 
         try self.manifest_file.?.seekTo(0);

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -18,16 +18,11 @@ pub const File = struct {
     path: ?[]const u8,
     stat: fs.File.Stat,
     bin_digest: [BIN_DIGEST_LEN]u8,
-    contents: ?[]const u8,
 
     pub fn deinit(self: *@This(), alloc: *Allocator) void {
         if (self.path) |owned_slice| {
             alloc.free(owned_slice);
             self.path = null;
-        }
-        if (self.contents) |owned_slice| {
-            alloc.free(owned_slice);
-            self.contents = null;
         }
     }
 };
@@ -232,7 +227,7 @@ pub const CacheHash = struct {
         if (idx < input_file_count or idx == 0) {
             self.manifest_dirty = true;
             while (idx < input_file_count) : (idx += 1) {
-                var cache_hash_file = self.files.ptrAt(idx);
+                var cache_hash_file = &self.files.items[idx];
                 self.populate_file_hash(cache_hash_file) catch |err| {
                     self.manifest_file.?.close();
                     self.manifest_file = null;
@@ -318,7 +313,7 @@ fn hash_file(alloc: *Allocator, bin_digest: []u8, handle: *const fs.File) !void 
     blake3.final(bin_digest);
 }
 
-test "cache file and the recall it" {
+test "cache file and then recall it" {
     const cwd = fs.cwd();
 
     const temp_file = "test.txt";

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -44,7 +44,7 @@ pub const CacheHash = struct {
 
     pub fn init(alloc: *Allocator, manifest_dir_path: []const u8) !@This() {
         try fs.cwd().makePath(manifest_dir_path);
-        const manifest_dir = try fs.cwd().openDir(manifest_dir_path, .{ .iterate = true });
+        const manifest_dir = try fs.cwd().openDir(manifest_dir_path, .{});
 
         return CacheHash{
             .alloc = alloc,

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -148,7 +148,7 @@ pub const CacheHash = struct {
 
             var cache_hash_file: *File = undefined;
             if (idx < input_file_count) {
-                cache_hash_file = self.files.ptrAt(idx);
+                cache_hash_file = &self.files.items[idx];
             } else {
                 cache_hash_file = try self.files.addOne();
                 cache_hash_file.path = null;
@@ -213,7 +213,7 @@ pub const CacheHash = struct {
             self.blake3 = Blake3.init();
             self.blake3.update(&bin_digest);
             try self.files.resize(input_file_count);
-            for (self.files.toSlice()) |file| {
+            for (self.files.items) |file| {
                 self.blake3.update(&file.bin_digest);
             }
             return null;
@@ -308,7 +308,7 @@ pub const CacheHash = struct {
         var outStream = contents.outStream();
         defer contents.deinit();
 
-        for (self.files.toSlice()) |file| {
+        for (self.files.items) |file| {
             base64_encoder.encode(encoded_digest[0..], &file.bin_digest);
             try outStream.print("{} {} {} {}\n", .{ file.stat.inode, file.stat.mtime, encoded_digest[0..], file.path });
         }
@@ -332,7 +332,7 @@ pub const CacheHash = struct {
 
         self.manifest_file.?.close();
 
-        for (self.files.toSlice()) |*file| {
+        for (self.files.items) |*file| {
             file.deinit(self.alloc);
         }
         self.files.deinit();

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -117,7 +117,7 @@ pub const CacheHash = struct {
         }
     }
 
-    pub fn cache_file(self: *@This(), file_path: []const u8) !void {
+    pub fn addFile(self: *@This(), file_path: []const u8) !void {
         debug.assert(self.manifest_file == null);
 
         var cache_hash_file = try self.files.addOne();
@@ -344,7 +344,7 @@ test "cache file and the recall it" {
         ch.add(true);
         ch.add(@as(u16, 1234));
         ch.add("1234");
-        try ch.cache_file("test.txt");
+        try ch.addFile("test.txt");
 
         // There should be nothing in the cache
         debug.assert((try ch.hit(&digest1)) == false);
@@ -358,7 +358,7 @@ test "cache file and the recall it" {
         ch.add(true);
         ch.add(@as(u16, 1234));
         ch.add("1234");
-        try ch.cache_file("test.txt");
+        try ch.addFile("test.txt");
 
         // Cache hit! We just "built" the same file
         debug.assert((try ch.hit(&digest2)) == true);

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -358,10 +358,10 @@ test "cache file and then recall it" {
         ch.add(true);
         ch.add(@as(u16, 1234));
         ch.add("1234");
-        try ch.addFile("test.txt");
+        try ch.addFile(temp_file);
 
         // There should be nothing in the cache
-        debug.assert((try ch.hit()) == null);
+        testing.expectEqual(@as(?[64]u8, null), try ch.hit());
 
         digest1 = ch.final();
     }
@@ -372,13 +372,13 @@ test "cache file and then recall it" {
         ch.add(true);
         ch.add(@as(u16, 1234));
         ch.add("1234");
-        try ch.addFile("test.txt");
+        try ch.addFile(temp_file);
 
         // Cache hit! We just "built" the same file
         digest2 = (try ch.hit()).?;
     }
 
-    debug.assert(mem.eql(u8, digest1[0..], digest2[0..]));
+    testing.expectEqual(digest1, digest2);
 
     try cwd.deleteTree(temp_manifest_dir);
     try cwd.deleteFile(temp_file);
@@ -386,10 +386,10 @@ test "cache file and then recall it" {
 
 test "give problematic timestamp" {
     const now_ns = @intCast(i64, time.milliTimestamp() * time.millisecond);
-    debug.assert(is_problematic_timestamp(now_ns));
+    testing.expect(is_problematic_timestamp(now_ns));
 }
 
 test "give nonproblematic timestamp" {
     const now_ns = @intCast(i64, time.milliTimestamp() * time.millisecond) - 1000;
-    debug.assert(!is_problematic_timestamp(now_ns));
+    testing.expect(!is_problematic_timestamp(now_ns));
 }

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -242,7 +242,7 @@ pub const CacheHash = struct {
             return null;
         }
 
-        return try self.final();
+        return self.final();
     }
 
     pub fn populate_file_hash(self: *@This(), cache_hash_file: *File) !void {
@@ -259,7 +259,8 @@ pub const CacheHash = struct {
         self.blake3.update(&cache_hash_file.bin_digest);
     }
 
-    pub fn final(self: *@This()) ![BASE64_DIGEST_LEN]u8 {
+    /// Returns a base64 encoded hash of the inputs.
+    pub fn final(self: *@This()) [BASE64_DIGEST_LEN]u8 {
         debug.assert(self.manifest_file != null);
 
         var bin_digest: [BIN_DIGEST_LEN]u8 = undefined;
@@ -340,7 +341,7 @@ test "cache file and the recall it" {
         // There should be nothing in the cache
         debug.assert((try ch.hit()) == null);
 
-        digest1 = try ch.final();
+        digest1 = ch.final();
     }
     {
         var ch = try CacheHash.init(testing.allocator, temp_manifest_dir);

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -149,14 +149,9 @@ pub const CacheHash = struct {
             self.manifest_file = try self.manifest_dir.createFile(manifest_file_path, .{ .read = true, .truncate = false });
         }
 
-        // create a buffer instead of using readAllAlloc
-        // See: https://github.com/ziglang/zig/issues/4656
-        var file_buffer = try Buffer.initCapacity(self.alloc, 16 * 1024);
-        defer file_buffer.deinit();
-
         // TODO: Figure out a good max value?
-        try self.manifest_file.?.inStream().stream.readAllBuffer(&file_buffer, 16 * 1024);
-        const file_contents = file_buffer.toSliceConst();
+        const file_contents = try self.manifest_file.?.inStream().stream.readAllAlloc(self.alloc, 16 * 1024);
+        defer self.alloc.free(file_contents);
 
         const input_file_count = self.files.len;
         var any_file_changed = false;

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -319,9 +319,10 @@ fn hash_file(alloc: *Allocator, bin_digest: []u8, handle: *const fs.File) !void 
 test "cache file and the recall it" {
     const cwd = fs.cwd();
 
+    const temp_file = "test.txt";
     const temp_manifest_dir = "temp_manifest_dir";
 
-    try cwd.writeFile("test.txt", "Hello, world!\n");
+    try cwd.writeFile(temp_file, "Hello, world!\n");
 
     var digest1: [BASE64_DIGEST_LEN]u8 = undefined;
     var digest2: [BASE64_DIGEST_LEN]u8 = undefined;
@@ -356,4 +357,5 @@ test "cache file and the recall it" {
     debug.assert(mem.eql(u8, digest1[0..], digest2[0..]));
 
     try cwd.deleteTree(temp_manifest_dir);
+    try cwd.deleteFile(temp_file);
 }

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -11,10 +11,8 @@ const Allocator = mem.Allocator;
 const Buffer = @import("buffer.zig").Buffer;
 const os = @import("os.zig");
 
-const base64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-const base64_pad_char = '=';
-const encoder = base64.Base64Encoder.init(base64_alphabet, base64_pad_char);
-const decoder = base64.Base64Decoder.init(base64_alphabet, base64_pad_char);
+const base64_encoder = fs.base64_encoder;
+const base64_decoder = fs.base64_decoder;
 const BIN_DIGEST_LEN = 32;
 
 pub const CacheHashFile = struct {
@@ -107,7 +105,7 @@ pub const CacheHash = struct {
 
         const OUT_DIGEST_LEN = base64.Base64Encoder.calcSize(BIN_DIGEST_LEN);
         try self.b64_digest.resize(OUT_DIGEST_LEN);
-        encoder.encode(self.b64_digest.toSlice(), &bin_digest);
+        base64_encoder.encode(self.b64_digest.toSlice(), &bin_digest);
 
         if (self.files.toSlice().len == 0 and !self.force_check_manifest) {
             try out_digest.resize(OUT_DIGEST_LEN);
@@ -166,7 +164,7 @@ pub const CacheHash = struct {
 
             cache_hash_file.file_handle = fmt.parseInt(os.fd_t, file_handle_str, 10) catch return error.InvalidFormat;
             cache_hash_file.stat.mtime = fmt.parseInt(i64, mtime_nsec_str, 10) catch return error.InvalidFormat;
-            decoder.decode(&cache_hash_file.bin_digest, digest_str) catch return error.InvalidFormat;
+            base64_decoder.decode(&cache_hash_file.bin_digest, digest_str) catch return error.InvalidFormat;
 
             if (file_path.len == 0) {
                 return error.InvalidFormat;
@@ -255,7 +253,7 @@ pub const CacheHash = struct {
 
         const OUT_DIGEST_LEN = base64.Base64Encoder.calcSize(BIN_DIGEST_LEN);
         try out_digest.resize(OUT_DIGEST_LEN);
-        encoder.encode(out_digest.toSlice(), &bin_digest);
+        base64_encoder.encode(out_digest.toSlice(), &bin_digest);
     }
 
     pub fn write_manifest(self: *@This()) !void {
@@ -268,7 +266,7 @@ pub const CacheHash = struct {
         defer contents.deinit();
 
         for (self.files.toSlice()) |file| {
-            encoder.encode(encoded_digest.toSlice(), &file.bin_digest);
+            base64_encoder.encode(encoded_digest.toSlice(), &file.bin_digest);
             try contents.print("{} {} {} {}\n", .{ file.file_handle, file.stat.mtime, encoded_digest.toSlice(), file.path });
         }
 

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -103,6 +103,7 @@ pub const CacheHash = struct {
         var cache_hash_file = try self.files.addOne();
         cache_hash_file.path = try fs.path.resolve(self.alloc, &[_][]const u8{file_path});
         cache_hash_file.max_file_size = max_file_size;
+        cache_hash_file.contents = null;
 
         self.addSlice(cache_hash_file.path.?);
 
@@ -175,6 +176,7 @@ pub const CacheHash = struct {
                 cache_hash_file = try self.files.addOne();
                 cache_hash_file.path = null;
                 cache_hash_file.max_file_size = null;
+                cache_hash_file.contents = null;
             }
 
             var iter = mem.tokenize(line, " ");
@@ -301,6 +303,8 @@ pub const CacheHash = struct {
 
         var cache_hash_file = try self.files.addOne();
         cache_hash_file.path = try fs.path.resolve(self.alloc, &[_][]const u8{file_path});
+        cache_hash_file.max_file_size = max_file_size_opt;
+        cache_hash_file.contents = null;
 
         const contents = try self.populate_file_hash_fetch(otherAlloc, cache_hash_file);
 

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -15,6 +15,8 @@ const base64_decoder = fs.base64_decoder;
 const BIN_DIGEST_LEN = 48;
 const BASE64_DIGEST_LEN = base64.Base64Encoder.calcSize(BIN_DIGEST_LEN);
 
+const MANIFEST_FILE_SIZE_MAX = 50 * 1024 * 1024;
+
 pub const File = struct {
     path: ?[]const u8,
     stat: fs.File.Stat,
@@ -150,8 +152,7 @@ pub const CacheHash = struct {
             };
         }
 
-        // TODO: Figure out a good max value?
-        const file_contents = try self.manifest_file.?.inStream().readAllAlloc(self.alloc, 16 * 1024);
+        const file_contents = try self.manifest_file.?.inStream().readAllAlloc(self.alloc, MANIFEST_FILE_SIZE_MAX);
         defer self.alloc.free(file_contents);
 
         const input_file_count = self.files.items.len;

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -1,0 +1,329 @@
+const Blake3 = @import("crypto.zig").Blake3;
+const fs = @import("fs.zig");
+const File = fs.File;
+const base64 = @import("base64.zig");
+const ArrayList = @import("array_list.zig").ArrayList;
+const debug = @import("debug.zig");
+const testing = @import("testing.zig");
+const mem = @import("mem.zig");
+const fmt = @import("fmt.zig");
+const Allocator = mem.Allocator;
+const Buffer = @import("buffer.zig").Buffer;
+const os = @import("os.zig");
+
+const base64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+const base64_pad_char = '=';
+const encoder = base64.Base64Encoder.init(base64_alphabet, base64_pad_char);
+const decoder = base64.Base64Decoder.init(base64_alphabet, base64_pad_char);
+const BIN_DIGEST_LEN = 32;
+
+pub const CacheHashFile = struct {
+    path: ?[]const u8,
+    stat: fs.File.Stat,
+    file_handle: os.fd_t,
+    bin_digest: [BIN_DIGEST_LEN]u8,
+    contents: ?[]const u8,
+
+    pub fn deinit(self: *@This(), alloc: *Allocator) void {
+        if (self.path) |owned_slice| {
+            alloc.free(owned_slice);
+            self.path = null;
+        }
+        if (self.contents) |owned_slice| {
+            alloc.free(owned_slice);
+            self.contents = null;
+        }
+    }
+};
+
+pub const CacheHash = struct {
+    alloc: *Allocator,
+    blake3: Blake3,
+    manifest_dir: []const u8,
+    manifest_file_path: ?[]const u8,
+    manifest_file: ?File,
+    manifest_dirty: bool,
+    force_check_manifest: bool,
+    files: ArrayList(CacheHashFile),
+    b64_digest: ArrayList(u8),
+
+    pub fn init(alloc: *Allocator, manifest_dir_path: []const u8) !@This() {
+        return CacheHash{
+            .alloc = alloc,
+            .blake3 = Blake3.init(),
+            .manifest_dir = manifest_dir_path,
+            .manifest_file_path = null,
+            .manifest_file = null,
+            .manifest_dirty = false,
+            .force_check_manifest = false,
+            .files = ArrayList(CacheHashFile).init(alloc),
+            .b64_digest = ArrayList(u8).init(alloc),
+        };
+    }
+
+    pub fn cache_buf(self: *@This(), val: []const u8) !void {
+        debug.assert(self.manifest_file_path == null);
+
+        var temp_buffer = try self.alloc.alloc(u8, val.len + 1);
+        defer self.alloc.free(temp_buffer);
+
+        mem.copy(u8, temp_buffer, val);
+        temp_buffer[val.len] = 0;
+
+        self.blake3.update(temp_buffer);
+    }
+
+    pub fn cache_file(self: *@This(), file_path: []const u8) !void {
+        debug.assert(self.manifest_file_path == null);
+
+        var cache_hash_file = try self.files.addOne();
+        cache_hash_file.path = try fs.path.resolve(self.alloc, &[_][]const u8{file_path});
+
+        try self.cache_buf(cache_hash_file.path.?);
+    }
+
+    pub fn hit(self: *@This(), out_digest: *ArrayList(u8)) !bool {
+        debug.assert(self.manifest_file_path == null);
+
+        var bin_digest: [BIN_DIGEST_LEN]u8 = undefined;
+        self.blake3.final(&bin_digest);
+
+        const OUT_DIGEST_LEN = base64.Base64Encoder.calcSize(BIN_DIGEST_LEN);
+        try self.b64_digest.resize(OUT_DIGEST_LEN);
+        encoder.encode(self.b64_digest.toSlice(), &bin_digest);
+
+        if (self.files.toSlice().len == 0 and !self.force_check_manifest) {
+            try out_digest.resize(OUT_DIGEST_LEN);
+            mem.copy(u8, out_digest.toSlice(), self.b64_digest.toSlice());
+            return true;
+        }
+
+        self.blake3 = Blake3.init();
+        self.blake3.update(&bin_digest);
+
+        {
+            const manifest_file_path_slice = try fs.path.join(self.alloc, &[_][]const u8{ self.manifest_dir, self.b64_digest.toSlice() });
+            var path_buf = ArrayList(u8).fromOwnedSlice(self.alloc, manifest_file_path_slice);
+            defer path_buf.deinit();
+            try path_buf.appendSlice(".txt");
+
+            self.manifest_file_path = path_buf.toOwnedSlice();
+        }
+
+        const cwd = fs.cwd();
+
+        try cwd.makePath(self.manifest_dir);
+
+        // TODO: Open file with a file lock
+        self.manifest_file = try cwd.createFile(self.manifest_file_path.?, .{ .read = true, .truncate = false });
+
+        // TODO: Figure out a good max value?
+        const file_contents = try self.manifest_file.?.inStream().stream.readAllAlloc(self.alloc, 16 * 1024);
+        defer self.alloc.free(file_contents);
+
+        const input_file_count = self.files.len;
+        var any_file_changed = false;
+        var line_iter = mem.tokenize(file_contents, "\n");
+        var idx: usize = 0;
+        while (line_iter.next()) |line| {
+            defer idx += 1;
+
+            var cache_hash_file: *CacheHashFile = undefined;
+            if (idx < input_file_count) {
+                cache_hash_file = self.files.ptrAt(idx);
+            } else {
+                cache_hash_file = try self.files.addOne();
+                cache_hash_file.path = null;
+            }
+
+            var iter = mem.tokenize(line, " ");
+            const file_handle_str = iter.next() orelse return error.InvalidFormat;
+            const mtime_nsec_str = iter.next() orelse return error.InvalidFormat;
+            const digest_str = iter.next() orelse return error.InvalidFormat;
+            const file_path = iter.rest();
+
+            cache_hash_file.file_handle = fmt.parseInt(os.fd_t, file_handle_str, 10) catch return error.InvalidFormat;
+            cache_hash_file.stat.mtime = fmt.parseInt(i64, mtime_nsec_str, 10) catch return error.InvalidFormat;
+            decoder.decode(&cache_hash_file.bin_digest, digest_str) catch return error.InvalidFormat;
+
+            if (file_path.len == 0) {
+                return error.InvalidFormat;
+            }
+            if (cache_hash_file.path != null and !mem.eql(u8, file_path, cache_hash_file.path.?)) {
+                return error.InvalidFormat;
+            }
+            cache_hash_file.path = try mem.dupe(self.alloc, u8, file_path);
+
+            const this_file = cwd.openFile(cache_hash_file.path.?, .{ .read = true }) catch {
+                self.manifest_file.?.close();
+                self.manifest_file = null;
+                return error.CacheUnavailable;
+            };
+            defer this_file.close();
+            cache_hash_file.stat = try this_file.stat();
+            // TODO: check mtime
+            if (false) {} else {
+                self.manifest_dirty = true;
+
+                // TODO: check for problematic timestamp
+
+                var actual_digest: [32]u8 = undefined;
+                try hash_file(self.alloc, &actual_digest, &this_file);
+
+                if (!mem.eql(u8, &cache_hash_file.bin_digest, &actual_digest)) {
+                    mem.copy(u8, &cache_hash_file.bin_digest, &actual_digest);
+                    // keep going until we have the input file digests
+                    any_file_changed = true;
+                }
+            }
+
+            if (!any_file_changed) {
+                self.blake3.update(&cache_hash_file.bin_digest);
+            }
+        }
+
+        if (any_file_changed) {
+            // cache miss
+            // keep the manifest file open (TODO: with rw lock)
+            // reset the hash
+            self.blake3 = Blake3.init();
+            self.blake3.update(&bin_digest);
+            try self.files.resize(input_file_count);
+            for (self.files.toSlice()) |file| {
+                self.blake3.update(&file.bin_digest);
+            }
+            return false;
+        }
+
+        if (idx < input_file_count or idx == 0) {
+            self.manifest_dirty = true;
+            while (idx < input_file_count) : (idx += 1) {
+                var cache_hash_file = self.files.ptrAt(idx);
+                self.populate_file_hash(cache_hash_file) catch |err| {
+                    self.manifest_file.?.close();
+                    self.manifest_file = null;
+                    return error.CacheUnavailable;
+                };
+            }
+            return false;
+        }
+
+        try self.final(out_digest);
+        return true;
+    }
+
+    pub fn populate_file_hash(self: *@This(), cache_hash_file: *CacheHashFile) !void {
+        debug.assert(cache_hash_file.path != null);
+
+        const this_file = try fs.cwd().openFile(cache_hash_file.path.?, .{});
+        defer this_file.close();
+
+        cache_hash_file.stat = try this_file.stat();
+
+        // TODO: check for problematic timestamp
+
+        try hash_file(self.alloc, &cache_hash_file.bin_digest, &this_file);
+        self.blake3.update(&cache_hash_file.bin_digest);
+    }
+
+    pub fn final(self: *@This(), out_digest: *ArrayList(u8)) !void {
+        debug.assert(self.manifest_file_path != null);
+
+        var bin_digest: [BIN_DIGEST_LEN]u8 = undefined;
+        self.blake3.final(&bin_digest);
+
+        const OUT_DIGEST_LEN = base64.Base64Encoder.calcSize(BIN_DIGEST_LEN);
+        try out_digest.resize(OUT_DIGEST_LEN);
+        encoder.encode(out_digest.toSlice(), &bin_digest);
+    }
+
+    pub fn write_manifest(self: *@This()) !void {
+        debug.assert(self.manifest_file_path != null);
+
+        const OUT_DIGEST_LEN = base64.Base64Encoder.calcSize(BIN_DIGEST_LEN);
+        var encoded_digest = try Buffer.initSize(self.alloc, OUT_DIGEST_LEN);
+        defer encoded_digest.deinit();
+        var contents = try Buffer.init(self.alloc, "");
+        defer contents.deinit();
+
+        for (self.files.toSlice()) |file| {
+            encoder.encode(encoded_digest.toSlice(), &file.bin_digest);
+            try contents.print("{} {} {} {}\n", .{ file.file_handle, file.stat.mtime, encoded_digest.toSlice(), file.path });
+        }
+
+        try self.manifest_file.?.seekTo(0);
+        try self.manifest_file.?.writeAll(contents.toSlice());
+    }
+
+    pub fn release(self: *@This()) void {
+        debug.assert(self.manifest_file_path != null);
+
+        if (self.manifest_dirty) {
+            self.write_manifest() catch |err| {
+                debug.warn("Unable to write cache file '{}': {}\n", .{ self.manifest_file_path, err });
+            };
+        }
+
+        self.manifest_file.?.close();
+        if (self.manifest_file_path) |owned_slice| {
+            self.alloc.free(owned_slice);
+        }
+        for (self.files.toSlice()) |*file| {
+            file.deinit(self.alloc);
+        }
+        self.files.deinit();
+        self.b64_digest.deinit();
+    }
+};
+
+fn hash_file(alloc: *Allocator, bin_digest: []u8, handle: *const File) !void {
+    var blake3 = Blake3.init();
+    var in_stream = handle.inStream().stream;
+
+    const contents = try handle.inStream().stream.readAllAlloc(alloc, 64 * 1024);
+    defer alloc.free(contents);
+
+    blake3.update(contents);
+
+    blake3.final(bin_digest);
+}
+
+test "see if imported" {
+    const cwd = fs.cwd();
+
+    const temp_manifest_dir = "temp_manifest_dir";
+
+    try cwd.writeFile("test.txt", "Hello, world!\n");
+
+    var digest1 = try ArrayList(u8).initCapacity(testing.allocator, 32);
+    defer digest1.deinit();
+    var digest2 = try ArrayList(u8).initCapacity(testing.allocator, 32);
+    defer digest2.deinit();
+
+    {
+        var ch = try CacheHash.init(testing.allocator, temp_manifest_dir);
+        defer ch.release();
+
+        try ch.cache_buf("1234");
+        try ch.cache_file("test.txt");
+
+        // There should be nothing in the cache
+        debug.assert((try ch.hit(&digest1)) == false);
+
+        try ch.final(&digest1);
+    }
+    {
+        var ch = try CacheHash.init(testing.allocator, temp_manifest_dir);
+        defer ch.release();
+
+        try ch.cache_buf("1234");
+        try ch.cache_file("test.txt");
+
+        // Cache hit! We just "built" the same file
+        debug.assert((try ch.hit(&digest2)) == true);
+    }
+
+    debug.assert(mem.eql(u8, digest1.toSlice(), digest2.toSlice()));
+
+    try cwd.deleteTree(temp_manifest_dir);
+}

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -14,7 +14,7 @@ const base64_encoder = fs.base64_encoder;
 const base64_decoder = fs.base64_decoder;
 const BIN_DIGEST_LEN = 32;
 
-pub const CacheHashFile = struct {
+pub const File = struct {
     path: ?[]const u8,
     stat: fs.File.Stat,
     file_handle: os.fd_t,
@@ -41,7 +41,7 @@ pub const CacheHash = struct {
     manifest_file: ?fs.File,
     manifest_dirty: bool,
     force_check_manifest: bool,
-    files: ArrayList(CacheHashFile),
+    files: ArrayList(File),
     b64_digest: ArrayList(u8),
 
     pub fn init(alloc: *Allocator, manifest_dir_path: []const u8) !@This() {
@@ -53,7 +53,7 @@ pub const CacheHash = struct {
             .manifest_file = null,
             .manifest_dirty = false,
             .force_check_manifest = false,
-            .files = ArrayList(CacheHashFile).init(alloc),
+            .files = ArrayList(File).init(alloc),
             .b64_digest = ArrayList(u8).init(alloc),
         };
     }
@@ -147,7 +147,7 @@ pub const CacheHash = struct {
         while (line_iter.next()) |line| {
             defer idx += 1;
 
-            var cache_hash_file: *CacheHashFile = undefined;
+            var cache_hash_file: *File = undefined;
             if (idx < input_file_count) {
                 cache_hash_file = self.files.ptrAt(idx);
             } else {
@@ -230,7 +230,7 @@ pub const CacheHash = struct {
         return true;
     }
 
-    pub fn populate_file_hash(self: *@This(), cache_hash_file: *CacheHashFile) !void {
+    pub fn populate_file_hash(self: *@This(), cache_hash_file: *File) !void {
         debug.assert(cache_hash_file.path != null);
 
         const this_file = try fs.cwd().openFile(cache_hash_file.path.?, .{});

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -12,7 +12,7 @@ const os = @import("os.zig");
 
 const base64_encoder = fs.base64_encoder;
 const base64_decoder = fs.base64_decoder;
-const BIN_DIGEST_LEN = 32;
+const BIN_DIGEST_LEN = 48;
 const BASE64_DIGEST_LEN = base64.Base64Encoder.calcSize(BIN_DIGEST_LEN);
 
 pub const File = struct {
@@ -203,7 +203,7 @@ pub const CacheHash = struct {
 
                 // TODO: check for problematic timestamp
 
-                var actual_digest: [32]u8 = undefined;
+                var actual_digest: [BIN_DIGEST_LEN]u8 = undefined;
                 try hash_file(self.alloc, &actual_digest, &this_file);
 
                 if (!mem.eql(u8, &cache_hash_file.bin_digest, &actual_digest)) {

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -50,6 +50,12 @@ pub const base64_encoder = base64.Base64Encoder.init(
     base64.standard_pad_char,
 );
 
+/// Base64, replacing the standard `+/` with `-_` so that it can be used in a file name on any filesystem.
+pub const base64_decoder = base64.Base64Decoder.init(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
+    base64.standard_pad_char,
+);
+
 /// Whether or not async file system syscalls need a dedicated thread because the operating
 /// system does not support non-blocking I/O on the file system.
 pub const need_async_thread = std.io.is_async and switch (builtin.os.tag) {

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -44,17 +44,13 @@ pub const MAX_PATH_BYTES = switch (builtin.os.tag) {
     else => @compileError("Unsupported OS"),
 };
 
-/// Base64, replacing the standard `+/` with `-_` so that it can be used in a file name on any filesystem.
-pub const base64_encoder = base64.Base64Encoder.init(
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
-    base64.standard_pad_char,
-);
+pub const base64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
-/// Base64, replacing the standard `+/` with `-_` so that it can be used in a file name on any filesystem.
-pub const base64_decoder = base64.Base64Decoder.init(
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
-    base64.standard_pad_char,
-);
+/// Base64 encoder, replacing the standard `+/` with `-_` so that it can be used in a file name on any filesystem.
+pub const base64_encoder = base64.Base64Encoder.init(base64_alphabet, base64.standard_pad_char);
+
+/// Base64 decoder, replacing the standard `+/` with `-_` so that it can be used in a file name on any filesystem.
+pub const base64_decoder = base64.Base64Decoder.init(base64_alphabet, base64.standard_pad_char);
 
 /// Whether or not async file system syscalls need a dedicated thread because the operating
 /// system does not support non-blocking I/O on the file system.

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -29,6 +29,7 @@ pub const base64 = @import("base64.zig");
 pub const build = @import("build.zig");
 pub const builtin = @import("builtin.zig");
 pub const c = @import("c.zig");
+pub const cache_hash = @import("cache_hash.zig");
 pub const coff = @import("coff.zig");
 pub const crypto = @import("crypto.zig");
 pub const cstr = @import("cstr.zig");


### PR DESCRIPTION
Will close #4311 

This pull request translates the C++ `cache_hash` API into zig, under `std.cache_hash`. Currently it only supports adding files before hitting the cache, doesn't implement the many different `cache_*` functions, doesn't check files' modification times, and has a memory leak somewhere.

It's a start.

- [x] open manifest files with a lock
- ~`cache_*` functions~
  - ~`cache_buf` (will probably merge into `cache_val`)~
  - ~`cache_file`~
  - ~`cache_val(var)`~
    - ~Not sure if this is the way to go, or if I should copy the C API and make a function for every type~
- [x] Functions to add dependencies
  - [x] `CacheHash.add(value)`
  - [x] `CacheHash.addFile(path)`
  - [x] `CacheHash.addFile(path)` but after the initial hash has been computed
- [x] `cache_hit`
  - [ ] check file modification times
    - [ ] check for problematic timestamps
      - [ ] implement a cross-platform high resolution calendar timestamp function in `std.time`
- [ ] Make user pass in max file size to `addFile*` functions