### PR TITLE
stage1: housekeeping

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -3379,7 +3379,7 @@ static void get_fully_qualified_decl_name(CodeGen *g, Buf *buf, Tld *tld, bool i
     }
 }
 
-ZigFn *create_fn_raw(CodeGen *g, FnInline inline_value) {
+static ZigFn *create_fn_raw(CodeGen *g, FnInline inline_value) {
     ZigFn *fn_entry = heap::c_allocator.create<ZigFn>();
     fn_entry->ir_executable = heap::c_allocator.create<IrExecutableSrc>();
 
@@ -6111,7 +6111,7 @@ ZigValue **realloc_const_vals_ptrs(CodeGen *g, ZigValue **ptr, size_t old_count,
     assert(new_count >= old_count);
 
     size_t new_item_count = new_count - old_count;
-    ZigValue **result = heap::c_allocator.reallocate(ptr, old_count, new_count);
+    ZigValue **result = g->pass1_arena->reallocate(ptr, old_count, new_count);
     ZigValue *vals = g->pass1_arena->allocate<ZigValue>(new_item_count);
     for (size_t i = old_count; i < new_count; i += 1) {
         result[i] = &vals[i - old_count];

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -104,7 +104,6 @@ ZigVar *add_variable(CodeGen *g, AstNode *source_node, Scope *parent_scope, Buf 
 ZigType *analyze_type_expr(CodeGen *g, Scope *scope, AstNode *node);
 void append_namespace_qualification(CodeGen *g, Buf *buf, ZigType *container_type);
 ZigFn *create_fn(CodeGen *g, AstNode *proto_node);
-ZigFn *create_fn_raw(CodeGen *g, FnInline inline_value);
 void init_fn_type_id(FnTypeId *fn_type_id, AstNode *proto_node, CallingConvention cc, size_t param_count_alloc);
 AstNode *get_param_decl_node(ZigFn *fn_entry, size_t index);
 Error ATTRIBUTE_MUST_USE type_resolve(CodeGen *g, ZigType *type_entry, ResolveStatus status);


### PR DESCRIPTION
- use consistent allocator in `realloc_const_vals_ptrs()`
- unexport `create_fn_raw()`