### PR TITLE
stage1: fix regression

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -6111,7 +6111,7 @@ ZigValue **realloc_const_vals_ptrs(CodeGen *g, ZigValue **ptr, size_t old_count,
     assert(new_count >= old_count);
 
     size_t new_item_count = new_count - old_count;
-    ZigValue **result = g->pass1_arena->reallocate(ptr, old_count, new_count);
+    ZigValue **result = heap::c_allocator.reallocate(ptr, old_count, new_count);
     ZigValue *vals = g->pass1_arena->allocate<ZigValue>(new_item_count);
     for (size_t i = old_count; i < new_count; i += 1) {
         result[i] = &vals[i - old_count];


### PR DESCRIPTION
suspect: 371c21aa70fc61ef703e34079ce6de6c52ec91df

Two different branches passed their own tests, but combined I now get a segfault on `zig build --help`. Now I'm second-guessing if 371c21aa70fc61ef703e34079ce6de6c52ec91df was correct. The other commit is debcc79d56a40f77b92e243b4e344fc9385bd405 .

While I work on this, I'll leave PR ready as a draft until we decide what to do.

For context, memory is saved by allocating `ZigValue`s to an arena. But now that I think about it, the container array is not the same thing. So it's not safe to free until proven so.