### PR TITLE
Translate-c default initialize non-extern variables to undefined

### DIFF
--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -609,7 +609,8 @@ fn visitVarDecl(c: *Context, var_decl: *const ZigClangVarDecl) Error!void {
         else
             try transCreateNodeUndefinedLiteral(c);
     } else if (storage_class != .Extern) {
-        return failDecl(c, var_decl_loc, checked_name, "non-extern variable has no initializer", .{});
+        eq_tok = try appendToken(c, .Equal, "=");
+        init_node = try transCreateNodeTypeIdentifier(c, "undefined");
     }
 
     const linksection_expr = blk: {

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -337,10 +337,11 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     cases.add("variables",
         \\extern int extern_var;
         \\static const int int_var = 13;
+        \\int foo;
     , &[_][]const u8{
         \\pub extern var extern_var: c_int;
-    ,
         \\pub const int_var: c_int = 13;
+        \\pub export var foo: c_int = undefined;
     });
 
     cases.add("const ptr initializer",


### PR DESCRIPTION
Closes #4647