### PR TITLE
std: Nicer way to access the PEB

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1083,8 +1083,26 @@ pub fn SetFileTime(
     }
 }
 
+pub fn teb() *TEB {
+    return switch (builtin.arch) {
+        .i386 => asm volatile (
+            \\ movl %%fs:0x18, %[ptr]
+            : [ptr] "=r" (-> *TEB)
+        ),
+        .x86_64 => asm volatile (
+            \\ movq %%gs:0x30, %[ptr]
+            : [ptr] "=r" (-> *TEB)
+        ),
+        .aarch64 => asm volatile (
+            \\ mov %[ptr], x18
+            : [ptr] "=r" (-> *TEB)
+        ),
+        else => @compileError("unsupported arch"),
+    };
+}
+
 pub fn peb() *PEB {
-    return ntdll.NtCurrentTeb().ProcessEnvironmentBlock;
+    return teb().ProcessEnvironmentBlock;
 }
 
 /// A file time is a 64-bit value that represents the number of 100-nanosecond

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1084,22 +1084,7 @@ pub fn SetFileTime(
 }
 
 pub fn peb() *PEB {
-    switch (builtin.arch) {
-        .i386 => {
-            return asm (
-                \\ mov %%fs:0x18, %[ptr]
-                \\ mov %%ds:0x30(%[ptr]), %[ptr]
-                : [ptr] "=r" (-> *PEB)
-            );
-        },
-        .x86_64 => {
-            return asm (
-                \\ mov %%gs:0x60, %[ptr]
-                : [ptr] "=r" (-> *PEB)
-            );
-        },
-        else => @compileError("unsupported architecture"),
-    }
+    return ntdll.NtCurrentTeb().ProcessEnvironmentBlock;
 }
 
 /// A file time is a 64-bit value that represents the number of 100-nanosecond

--- a/lib/std/os/windows/bits.zig
+++ b/lib/std/os/windows/bits.zig
@@ -1154,6 +1154,19 @@ const RTL_BITMAP = @OpaqueType();
 pub const PRTL_BITMAP = *RTL_BITMAP;
 const KAFFINITY = usize;
 
+pub const TEB = extern struct {
+    Reserved1: [12]PVOID,
+    ProcessEnvironmentBlock: *PEB,
+    Reserved2: [399]PVOID,
+    Reserved3: [1952]u8,
+    TlsSlots: [64]PVOID,
+    Reserved4: [8]u8,
+    Reserved5: [26]PVOID,
+    ReservedForOle: PVOID,
+    Reserved6: [4]PVOID,
+    TlsExpansionSlots: PVOID,
+};
+
 /// Process Environment Block
 /// Microsoft documentation of this is incomplete, the fields here are taken from various resources including:
 ///  - https://github.com/wine-mirror/wine/blob/1aff1e6a370ee8c0213a0fd4b220d121da8527aa/include/winternl.h#L269

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -16,7 +16,6 @@ pub extern "NtDll" fn NtQueryInformationFile(
     Length: ULONG,
     FileInformationClass: FILE_INFORMATION_CLASS,
 ) callconv(.Stdcall) NTSTATUS;
-pub extern "NtDll" fn NtCurrentTeb() callconv(.Stdcall) *TEB;
 
 pub extern "NtDll" fn NtQueryAttributesFile(
     ObjectAttributes: *OBJECT_ATTRIBUTES,

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -16,6 +16,7 @@ pub extern "NtDll" fn NtQueryInformationFile(
     Length: ULONG,
     FileInformationClass: FILE_INFORMATION_CLASS,
 ) callconv(.Stdcall) NTSTATUS;
+pub extern "NtDll" fn NtCurrentTeb() callconv(.Stdcall) *TEB;
 
 pub extern "NtDll" fn NtQueryAttributesFile(
     ObjectAttributes: *OBJECT_ATTRIBUTES,


### PR DESCRIPTION
Use the NtCurrentTeb API instead of using some inline asm, this is much
nicer and also more portable.

Closes #4645