### PR TITLE
std: fix sendfile on macOS and FreeBSD

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -63,8 +63,8 @@ pub const sf_hdtr = extern struct {
 };
 
 pub extern "c" fn sendfile(
-    out_fd: fd_t,
     in_fd: fd_t,
+    out_fd: fd_t,
     offset: off_t,
     len: *off_t,
     sf_hdtr: ?*sf_hdtr,

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -15,9 +15,9 @@ pub const sf_hdtr = extern struct {
     trl_cnt: c_int,
 };
 pub extern "c" fn sendfile(
-    out_fd: fd_t,
     in_fd: fd_t,
-    offset: ?*off_t,
+    out_fd: fd_t,
+    offset: off_t,
     nbytes: usize,
     sf_hdtr: ?*sf_hdtr,
     sbytes: ?*off_t,


### PR DESCRIPTION
- fix c.freebsd.sendfile to use use off_t value
- fix std.os.sendfile/FreeBSD to use correct in/out fd_t
- fix std.os.sendfile/macOS to use correct in/out fd_t
- undo 1141bfb21b82f8d3fc353e968a591f2ad9aaa571 (no longer needed)