### PR TITLE
fmt: Fix relative paths with . and .. on Windows

### DIFF
--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -315,11 +315,18 @@ const FmtError = error{
 } || fs.File.OpenError;
 
 fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {
-    if (fmt.seen.exists(file_path)) return;
-    try fmt.seen.put(file_path);
+    // get the real path here to avoid Windows failing on relative file paths with . or .. in them
+    var real_path = fs.realpathAlloc(fmt.allocator, file_path) catch |err| {
+        try stderr.print("unable to open '{}': {}\n", .{ file_path, err });
+        fmt.any_error = true;
+        return;
+    };
+    defer fmt.allocator.free(real_path);
 
-    const max = std.math.maxInt(usize);
-    const source_code = fs.cwd().readFileAlloc(fmt.allocator, file_path, max) catch |err| switch (err) {
+    if (fmt.seen.exists(real_path)) return;
+    try fmt.seen.put(real_path);
+
+    const source_code = fs.cwd().readFileAlloc(fmt.allocator, real_path, self_hosted_main.max_src_size) catch |err| switch (err) {
         error.IsDir, error.AccessDenied => {
             // TODO make event based (and dir.next())
             var dir = try fs.cwd().openDir(file_path, .{ .iterate = true });
@@ -329,7 +336,7 @@ fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {
 
             while (try dir_it.next()) |entry| {
                 if (entry.kind == .Directory or mem.endsWith(u8, entry.name, ".zig")) {
-                    const full_path = try fs.path.join(fmt.allocator, &[_][]const u8{ file_path, entry.name });
+                    const full_path = try fs.path.join(fmt.allocator, &[_][]const u8{ real_path, entry.name });
                     try fmtPath(fmt, full_path, check_mode);
                 }
             }
@@ -367,7 +374,7 @@ fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {
             fmt.any_error = true;
         }
     } else {
-        const baf = try io.BufferedAtomicFile.create(fmt.allocator, file_path);
+        const baf = try io.BufferedAtomicFile.create(fmt.allocator, real_path);
         defer baf.destroy();
 
         const anything_changed = try std.zig.render(fmt.allocator, baf.stream(), tree);


### PR DESCRIPTION
This is one possible fix for #4605. It's sort-of a band-aid fix due to `NtCreateFile` failing on paths with `.` or `..` in them, so this resolves the paths via `realpath` before formatting them. The other possible fix would be to allow `.` and `..` to be passed to `NtCreateFile` callers and deal with them appropriately within those functions (see https://github.com/ziglang/zig/issues/4659).

Note: using `realpath` has a potential side-benefit of avoiding double-formatting paths that would resolve to the same path, since the real path is now used in the `seen` map (so `zig fmt ./test.zig test.zig` will now skip the second path since they both resolve to the same path).

On Windows, here is before:
```
> zig fmt .\test.zig
unable to open '.\test.zig': error.FileNotFound
> zig fmt ./test.zig
unable to open './test.zig': error.BadPathName
```
and after:
```
> zig fmt .\test.zig
.\test.zig
> zig fmt ./test.zig
unable to open './test.zig': error.BadPathName
```

Closes #4605 if merged.

---

EDIT: See https://github.com/ziglang/zig/pull/4655#issuecomment-605705535 for "an attempt to make it easier to make a decision about [merging this]"