### PR TITLE
llvm10/stage1: fix compile error on macOS Xcode 11.4

### DIFF
--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -378,7 +378,7 @@ static_assert((clang::Type::TypeClass)ZigClangType_ExtVector == clang::Type::Ext
 
 // Detect additions to the enum
 void ZigClang_detect_enum_StmtClass(clang::Stmt::StmtClass x) {
-    switch (x) {
+    switch (static_cast<ZigClangStmtClass>(x)) {
         case ZigClangStmt_NoStmtClass:
         case ZigClangStmt_GCCAsmStmtClass:
         case ZigClangStmt_MSAsmStmtClass:


### PR DESCRIPTION
clang is very strict with `-Werror`

```
../src/zig_clang.cpp:382:14: error: comparison of two values with different enumeration types in switch statement ('clang::Stmt::StmtClass' and 'ZigClangStmtClass') [-Werror,-Wenum-compare-switch]
        case ZigClangStmt_NoStmtClass:
             ^~~~~~~~~~~~~~~~~~~~~~~~
207 errors generated.
```