### PR TITLE
Add default panic docs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,6 +32,20 @@ pub fn build(b: *Builder) !void {
     const docs_step = b.step("docs", "Build documentation");
     docs_step.dependOn(&docgen_cmd.step);
 
+    // option to generate docs for stdlib
+    // pulled from https://github.com/kristoff-it/zig-okredis
+    const build_stddocs = b.addSystemCommand(&[_][]const u8{
+        b.zig_exe,
+        "test",
+        "lib/std/std.zig",
+        "-femit-docs",
+        "-fno-emit-bin",
+        "--output-dir",
+        ".",
+    });
+    const stddoc_step = b.step("stddocs", "Build documentation for std.zig");
+    stddoc_step.dependOn(&build_stddocs.step);
+
     const test_step = b.step("test", "Run all the tests");
 
     // find the stage0 build artifacts because we're going to re-use config.h and zig_cpp library

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -523,6 +523,12 @@ pub const panic: PanicFn = if (@hasDecl(root, "panic")) root.panic else default_
 
 /// This function is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
+///
+/// On all platforms except for freestanding, WASI, and UEFI, this function
+/// captures a stack trace and prints it to stderr.
+///
+/// std.debug.panicExtra handles capturing a stack trace and printing messages
+/// and is called for every platform except for the platforms mentioned above.
 pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace) noreturn {
     @setCold(true);
     if (@hasDecl(root, "os") and @hasDecl(root.os, "panic")) {


### PR DESCRIPTION
I also added a command to build.zig to generate the docs for std.zig.

The comments on the default panic handler are probably not entirely sufficient or wholly accurate, so let me know what I should add or remove.