### PR TITLE
Translate C: Add comment containing c source location for failed decls

### DIFF
--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -4687,6 +4687,7 @@ pub fn failDecl(c: *Context, loc: ZigClangSourceLocation, name: []const u8, comp
     const msg_tok = try appendTokenFmt(c, .StringLiteral, "\"" ++ format ++ "\"", args);
     const rparen_tok = try appendToken(c, .RParen, ")");
     const semi_tok = try appendToken(c, .Semicolon, ";");
+    _ = try appendTokenFmt(c, .LineComment, "// {}", .{c.locStr(loc)});
 
     const msg_node = try c.a().create(ast.Node.StringLiteral);
     msg_node.* = ast.Node.StringLiteral{


### PR DESCRIPTION
Quality of life improvement for tracking down translate_c bugs.
Example output:
```
pub const NULL = @compileError("unable to translate C expr: expected ')'' here"); // /home/lachlan/zig/build/lib/zig/include/stddef.h:89:11
```
