### PR TITLE
Expose file inode number on linux and file index on windows

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -28,8 +28,13 @@ pub const File = struct {
     pub const async_block_allowed_no = if (io.is_async) false else {};
 
     pub const Mode = os.mode_t;
+
+    /// The type that is used to represent the inode/file index number. On windows this is a
+    /// LARGE_INTEGER (i64), and on linux this is a u64.
     pub const INode = switch (builtin.os.tag) {
         .windows => os.windows.LARGE_INTEGER,
+        // TODO: Handle possibility of 128 bit numbers? ReFS on windows server 2012 uses a 128 bit file
+        // index. See https://docs.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
         else => u64,
     };
 
@@ -149,7 +154,16 @@ pub const File = struct {
     }
 
     pub const Stat = struct {
+        /// A number that the system uses to point to the file metadata. This number is not guaranteed to be
+        /// unique across time, as some file systems may reuse an inode after it's file has been deleted.
+        /// Some systems may change the inode of a file over time.
+        ///
+        /// On Linux, the inode _is_ structure that stores the metadata, and the inode _number_ is what
+        /// you see here: the index number of the inode.
+        ///
+        /// The FileIndex on Windows is similar. It is a number for a file that is unique to each filesystem.
         inode: INode,
+
         size: u64,
         mode: Mode,
 

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -29,15 +29,6 @@ pub const File = struct {
 
     pub const Mode = os.mode_t;
 
-    /// The type that is used to represent the inode/file index number. On windows this is a
-    /// LARGE_INTEGER (i64), and on linux this is a u64.
-    pub const INode = switch (builtin.os.tag) {
-        .windows => os.windows.LARGE_INTEGER,
-        // TODO: Handle possibility of 128 bit numbers? ReFS on windows server 2012 uses a 128 bit file
-        // index. See https://docs.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
-        else => os.ino_t,
-    };
-
     pub const default_mode = switch (builtin.os.tag) {
         .windows => 0,
         else => 0o666,
@@ -162,7 +153,7 @@ pub const File = struct {
         /// you see here: the index number of the inode.
         ///
         /// The FileIndex on Windows is similar. It is a number for a file that is unique to each filesystem.
-        inode: INode,
+        inode: os.ino_t,
 
         size: u64,
         mode: Mode,

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -35,7 +35,7 @@ pub const File = struct {
         .windows => os.windows.LARGE_INTEGER,
         // TODO: Handle possibility of 128 bit numbers? ReFS on windows server 2012 uses a 128 bit file
         // index. See https://docs.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
-        else => u64,
+        else => os.ino_t,
     };
 
     pub const default_mode = switch (builtin.os.tag) {

--- a/lib/std/os/bits/darwin.zig
+++ b/lib/std/os/bits/darwin.zig
@@ -53,6 +53,7 @@ pub const mach_timebase_info_data = extern struct {
 };
 
 pub const off_t = i64;
+pub const ino_t = u64;
 
 /// Renamed to Stat to not conflict with the stat function.
 /// atime, mtime, and ctime have functions to return `timespec`,
@@ -64,7 +65,7 @@ pub const Stat = extern struct {
     dev: i32,
     mode: u16,
     nlink: u16,
-    ino: u64,
+    ino: ino_t,
     uid: u32,
     gid: u32,
     rdev: i32,

--- a/lib/std/os/bits/dragonfly.zig
+++ b/lib/std/os/bits/dragonfly.zig
@@ -138,8 +138,10 @@ pub const MAP_SIZEALIGN = 262144;
 
 pub const PATH_MAX = 1024;
 
+pub const ino_t = c_ulong;
+
 pub const Stat = extern struct {
-    ino: c_ulong,
+    ino: ino_t,
     nlink: c_uint,
     dev: c_uint,
     mode: c_ushort,

--- a/lib/std/os/bits/freebsd.zig
+++ b/lib/std/os/bits/freebsd.zig
@@ -98,6 +98,7 @@ pub const msghdr_const = extern struct {
 };
 
 pub const off_t = i64;
+pub const ino_t = u64;
 
 /// Renamed to Stat to not conflict with the stat function.
 /// atime, mtime, and ctime have functions to return `timespec`,
@@ -107,7 +108,7 @@ pub const off_t = i64;
 /// methods to accomplish this.
 pub const Stat = extern struct {
     dev: u64,
-    ino: u64,
+    ino: ino_t,
     nlink: usize,
 
     mode: u16,

--- a/lib/std/os/bits/linux/x86_64.zig
+++ b/lib/std/os/bits/linux/x86_64.zig
@@ -481,6 +481,7 @@ pub const msghdr_const = extern struct {
 };
 
 pub const off_t = i64;
+pub const ino_t = u64;
 
 /// Renamed to Stat to not conflict with the stat function.
 /// atime, mtime, and ctime have functions to return `timespec`,
@@ -490,7 +491,7 @@ pub const off_t = i64;
 /// methods to accomplish this.
 pub const Stat = extern struct {
     dev: u64,
-    ino: u64,
+    ino: ino_t,
     nlink: usize,
 
     mode: u32,

--- a/lib/std/os/bits/netbsd.zig
+++ b/lib/std/os/bits/netbsd.zig
@@ -69,6 +69,7 @@ pub const msghdr_const = extern struct {
 };
 
 pub const off_t = i64;
+pub const ino_t = u64;
 
 /// Renamed to Stat to not conflict with the stat function.
 /// atime, mtime, and ctime have functions to return `timespec`,
@@ -79,7 +80,7 @@ pub const off_t = i64;
 pub const Stat = extern struct {
     dev: u64,
     mode: u32,
-    ino: u64,
+    ino: ino_t,
     nlink: usize,
 
     uid: u32,

--- a/lib/std/os/bits/wasi.zig
+++ b/lib/std/os/bits/wasi.zig
@@ -178,6 +178,7 @@ pub const FILESTAT_SET_MTIM: fstflags_t = 0x0004;
 pub const FILESTAT_SET_MTIM_NOW: fstflags_t = 0x0008;
 
 pub const inode_t = u64;
+pub const ino_t = inode_t;
 
 pub const linkcount_t = u32;
 

--- a/lib/std/os/bits/windows.zig
+++ b/lib/std/os/bits/windows.zig
@@ -4,6 +4,7 @@ usingnamespace @import("../windows/bits.zig");
 const ws2_32 = @import("../windows/ws2_32.zig");
 
 pub const fd_t = HANDLE;
+pub const ino_t = LARGE_INTEGER;
 pub const pid_t = HANDLE;
 pub const mode_t = u0;
 


### PR DESCRIPTION
Adds `.inode` to `fs.File.Stat`, and a type named `fs.File.INode` which is a u64 on linux and an i64 (LARGE_INTEGER) on windows.