### PR TITLE
Windows: Fix std.fs.realpath/os.realpathW for directories

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3077,7 +3077,7 @@ pub fn realpathW(pathname: [*:0]const u16, out_buffer: *[MAX_PATH_BYTES]u8) Real
         windows.FILE_SHARE_READ,
         null,
         windows.OPEN_EXISTING,
-        windows.FILE_ATTRIBUTE_NORMAL,
+        windows.FILE_FLAG_BACKUP_SEMANTICS,
         null,
     );
     defer windows.CloseHandle(h_file);


### PR DESCRIPTION
Fixes one of the cases in #4658. The rest are unaffected (still behave the same as before).

From the [CreateFileW docs](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew#directories):

> #### Directories
>
> To open a directory using CreateFile, specify the FILE_FLAG_BACKUP_SEMANTICS flag as part of dwFlagsAndAttributes. Appropriate security checks still apply when this flag is used without SE_BACKUP_NAME and SE_RESTORE_NAME privileges.

Before (using the test code/setup found in #4658):

```
C:\tmp>.\realpath.exe dir
path=dir
error: AccessDenied
C:\Users\Ryan\Programming\Zig\bin\lib\zig\std\os\windows.zig:81:31: 0x13fb88907 in std.os.windows.CreateFileW (realpath.obj)
            .ACCESS_DENIED => return error.AccessDenied,
                              ^
C:\Users\Ryan\Programming\Zig\bin\lib\zig\std\os.zig:3004:20: 0x13fb83e4f in std.os.realpathW (realpath.obj)
    const h_file = try windows.CreateFileW(
                   ^
C:\Users\Ryan\Programming\Zig\bin\lib\zig\std\os.zig:2965:9: 0x13fb83d97 in std.os.realpath (realpath.obj)
        return realpathW(&pathname_w, out_buffer);
        ^
C:\Users\Ryan\Programming\Zig\bin\lib\zig\std\fs.zig:1664:36: 0x13fb78861 in std.fs.realpathAlloc (realpath.obj)
    return mem.dupe(allocator, u8, try os.realpath(pathname, &buf));
                                   ^
C:\tmp\realpath.zig:7:21: 0x13fb62f62 in main (realpath.obj)
    var real_path = try std.fs.realpathAlloc(std.heap.page_allocator, args[1]);
```
```
C:\tmp>.\realpath.exe file
path=file
realpath=C:\tmp\file
```

After:
```
C:\tmp>.\realpath.exe dir
path=dir
realpath=C:\tmp\dir
```
```
C:\tmp>.\realpath.exe file
path=file
realpath=C:\tmp\file
```