### PR TITLE
ir: Fix codegen of ?*T types where T is zero-sized

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5789,6 +5789,7 @@ ZigValue *get_the_one_possible_value(CodeGen *g, ZigType *type_entry) {
     ZigValue *result = g->pass1_arena->create<ZigValue>();
     result->type = type_entry;
     result->special = ConstValSpecialStatic;
+
     if (result->type->id == ZigTypeIdStruct) {
         // The fields array cannot be left unpopulated
         const ZigType *struct_type = result->type;
@@ -5799,6 +5800,22 @@ ZigValue *get_the_one_possible_value(CodeGen *g, ZigType *type_entry) {
             ZigType *field_type = resolve_struct_field_type(g, field);
             assert(field_type != nullptr);
             result->data.x_struct.fields[i] = get_the_one_possible_value(g, field_type);
+        }
+    } else if (result->type->id == ZigTypeIdArray) {
+        // The elements array cannot be left unpopulated
+        ZigType *array_type = result->type;
+        ZigType *elem_type = array_type->data.array.child_type;
+        ZigValue *sentinel_value = array_type->data.array.sentinel;
+        const size_t elem_count = array_type->data.array.len + (sentinel_value != nullptr);
+
+        result->data.x_array.data.s_none.elements = g->pass1_arena->allocate<ZigValue>(elem_count);
+        for (size_t i = 0; i < elem_count; i += 1) {
+            ZigValue *elem_val = &result->data.x_array.data.s_none.elements[i];
+            copy_const_val(g, elem_val, get_the_one_possible_value(g, elem_type));
+        }
+        if (sentinel_value != nullptr) {
+            ZigValue *last_elem_val = &result->data.x_array.data.s_none.elements[elem_count - 1];
+            copy_const_val(g, last_elem_val, sentinel_value);
         }
     } else if (result->type->id == ZigTypeIdPointer) {
         result->data.x_ptr.special = ConstPtrSpecialRef;
@@ -9525,6 +9542,23 @@ void copy_const_val(CodeGen *g, ZigValue *dest, ZigValue *src) {
         copy_const_val(g, dest->data.x_optional, src->data.x_optional);
         dest->data.x_optional->parent.id = ConstParentIdOptionalPayload;
         dest->data.x_optional->parent.data.p_optional_payload.optional_val = dest;
+    }
+}
+
+bool optional_value_is_null(ZigValue *val) {
+    assert(val->special == ConstValSpecialStatic);
+    if (get_src_ptr_type(val->type) != nullptr) {
+        if (val->data.x_ptr.special == ConstPtrSpecialNull) {
+            return true;
+        } else if (val->data.x_ptr.special == ConstPtrSpecialHardCodedAddr) {
+            return val->data.x_ptr.data.hard_coded_addr.addr == 0;
+        } else {
+            return false;
+        }
+    } else if (is_opt_err_set(val->type)) {
+        return val->data.x_err_set == nullptr;
+    } else {
+        return val->data.x_optional == nullptr;
     }
 }
 

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -197,6 +197,7 @@ size_t type_id_index(ZigType *entry);
 ZigType *get_generic_fn_type(CodeGen *g, FnTypeId *fn_type_id);
 LinkLib *create_link_lib(Buf *name);
 LinkLib *add_link_lib(CodeGen *codegen, Buf *lib);
+bool optional_value_is_null(ZigValue *val);
 
 uint32_t get_abi_alignment(CodeGen *g, ZigType *type_entry);
 ZigType *get_align_amt_type(CodeGen *g);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6900,8 +6900,18 @@ check: switch (const_val->special) {
         case ZigTypeIdOptional:
             {
                 ZigType *child_type = type_entry->data.maybe.child_type;
+
                 if (get_src_ptr_type(type_entry) != nullptr) {
-                    return gen_const_val_ptr(g, const_val, name);
+                    bool has_bits;
+                    if ((err = type_has_bits2(g, child_type, &has_bits)))
+                        codegen_report_errors_and_exit(g);
+
+                    if (has_bits)
+                        return gen_const_val_ptr(g, const_val, name);
+
+                    // No bits, treat this value as a boolean
+                    const unsigned bool_val = optional_value_is_null(const_val) ? 0 : 1;
+                    return LLVMConstInt(LLVMInt1Type(), bool_val, false);
                 } else if (child_type->id == ZigTypeIdErrorSet) {
                     return gen_const_val_err_set(g, const_val, name);
                 } else if (!type_has_bits(g, child_type)) {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -15434,23 +15434,6 @@ static bool resolve_cmp_op_id(IrBinOp op_id, Cmp cmp) {
     }
 }
 
-static bool optional_value_is_null(ZigValue *val) {
-    assert(val->special == ConstValSpecialStatic);
-    if (get_src_ptr_type(val->type) != nullptr) {
-        if (val->data.x_ptr.special == ConstPtrSpecialNull) {
-            return true;
-        } else if (val->data.x_ptr.special == ConstPtrSpecialHardCodedAddr) {
-            return val->data.x_ptr.data.hard_coded_addr.addr == 0;
-        } else {
-            return false;
-        }
-    } else if (is_opt_err_set(val->type)) {
-        return val->data.x_err_set == nullptr;
-    } else {
-        return val->data.x_optional == nullptr;
-    }
-}
-
 static void set_optional_value_to_null(ZigValue *val) {
     assert(val->special == ConstValSpecialStatic);
     if (val->type->id == ZigTypeIdNull) return; // nothing to do
@@ -17539,7 +17522,14 @@ static IrInstGen *ir_analyze_instruction_decl_var(IrAnalyze *ira, IrInstSrcDeclV
 
     ZigValue *init_val = nullptr;
     if (instr_is_comptime(var_ptr) && var_ptr->value->data.x_ptr.mut != ConstPtrMutRuntimeVar) {
-        init_val = const_ptr_pointee(ira, ira->codegen, var_ptr->value, decl_var_instruction->base.base.source_node);
+        ZigValue *ptr_val = ir_resolve_const(ira, var_ptr, UndefBad);
+        if (ptr_val == nullptr)
+            return ira->codegen->invalid_inst_gen;
+
+        init_val = const_ptr_pointee(ira, ira->codegen, ptr_val, decl_var_instruction->base.base.source_node);
+        if (init_val == nullptr)
+            return ira->codegen->invalid_inst_gen;
+
         if (is_comptime_var) {
             if (var->gen_is_const) {
                 var->const_value = init_val;

--- a/test/stage1/behavior/optional.zig
+++ b/test/stage1/behavior/optional.zig
@@ -175,3 +175,26 @@ test "0-bit child type coerced to optional return ptr result location" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "0-bit child type coerced to optional" {
+    const S = struct {
+        fn doTheTest() void {
+            var it: Foo = .{
+                .list = undefined,
+            };
+            expect(it.foo() != null);
+        }
+
+        const Empty = struct {};
+        const Foo = struct {
+            list: [10]Empty,
+
+            fn foo(self: *Foo) ?*Empty {
+                const data = &self.list[0];
+                return data;
+            }
+        };
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}


### PR DESCRIPTION
* Fix codegen for optional types that decay to a pointer, the type
  behaves as a boolean
* Fix comptime evaluation of zero-sized arrays, always initialize the
  internal array elements

Closes #4673