### PR TITLE
Remove unused static_crt_dir field from libc config

### DIFF
--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -744,8 +744,6 @@ const Stage2LibCInstallation = extern struct {
     sys_include_dir_len: usize,
     crt_dir: [*:0]const u8,
     crt_dir_len: usize,
-    static_crt_dir: [*:0]const u8,
-    static_crt_dir_len: usize,
     msvc_lib_dir: [*:0]const u8,
     msvc_lib_dir_len: usize,
     kernel32_lib_dir: [*:0]const u8,
@@ -773,13 +771,6 @@ const Stage2LibCInstallation = extern struct {
             self.crt_dir = "";
             self.crt_dir_len = 0;
         }
-        if (libc.static_crt_dir) |s| {
-            self.static_crt_dir = s.ptr;
-            self.static_crt_dir_len = s.len;
-        } else {
-            self.static_crt_dir = "";
-            self.static_crt_dir_len = 0;
-        }
         if (libc.msvc_lib_dir) |s| {
             self.msvc_lib_dir = s.ptr;
             self.msvc_lib_dir_len = s.len;
@@ -806,9 +797,6 @@ const Stage2LibCInstallation = extern struct {
         }
         if (self.crt_dir_len != 0) {
             libc.crt_dir = self.crt_dir[0..self.crt_dir_len :0];
-        }
-        if (self.static_crt_dir_len != 0) {
-            libc.static_crt_dir = self.static_crt_dir[0..self.static_crt_dir_len :0];
         }
         if (self.msvc_lib_dir_len != 0) {
             libc.msvc_lib_dir = self.msvc_lib_dir[0..self.msvc_lib_dir_len :0];

--- a/src/stage2.cpp
+++ b/src/stage2.cpp
@@ -272,8 +272,6 @@ enum Error stage2_libc_parse(struct Stage2LibCInstallation *libc, const char *li
     libc->sys_include_dir_len = strlen(libc->sys_include_dir);
     libc->crt_dir = "";
     libc->crt_dir_len = strlen(libc->crt_dir);
-    libc->static_crt_dir = "";
-    libc->static_crt_dir_len = strlen(libc->static_crt_dir);
     libc->msvc_lib_dir = "";
     libc->msvc_lib_dir_len = strlen(libc->msvc_lib_dir);
     libc->kernel32_lib_dir = "";

--- a/src/stage2.h
+++ b/src/stage2.h
@@ -209,8 +209,6 @@ struct Stage2LibCInstallation {
     size_t sys_include_dir_len;
     const char *crt_dir;
     size_t crt_dir_len;
-    const char *static_crt_dir;
-    size_t static_crt_dir_len;
     const char *msvc_lib_dir;
     size_t msvc_lib_dir_len;
     const char *kernel32_lib_dir;


### PR DESCRIPTION
`static_crt_dir` doesn't seem to be read anywhere?