### PR TITLE
std/os/uefi: various improvements and some refactoring

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -273,10 +273,10 @@ pub fn exit(status: u8) noreturn {
         // exit() is only avaliable if exitBootServices() has not been called yet.
         // This call to exit should not fail, so we don't care about its return value.
         if (uefi.system_table.boot_services) |bs| {
-            _ = bs.exit(uefi.handle, status, 0, null);
+            _ = bs.exit(uefi.handle, @intToEnum(uefi.Status, status), 0, null);
         }
         // If we can't exit, reboot the system instead.
-        uefi.system_table.runtime_services.resetSystem(uefi.tables.ResetType.ResetCold, status, 0, null);
+        uefi.system_table.runtime_services.resetSystem(uefi.tables.ResetType.ResetCold, @intToEnum(uefi.Status, status), 0, null);
     }
     system.exit(status);
 }

--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -105,3 +105,6 @@ pub const TimeCapabilities = extern struct {
     /// If true, a time set operation clears the device's time below the resolution level.
     sets_to_zero: bool,
 };
+
+/// File Handle as specified in the EFI Shell Spec
+pub const FileHandle = *@OpaqueType();

--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -2,7 +2,7 @@
 pub const protocols = @import("uefi/protocols.zig");
 
 /// Status codes returned by EFI interfaces
-pub const status = @import("uefi/status.zig");
+pub const Status = @import("uefi/status.zig").Status;
 pub const tables = @import("uefi/tables.zig");
 
 const fmt = @import("std").fmt;

--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -32,7 +32,7 @@ pub const Guid = extern struct {
         options: fmt.FormatOptions,
         context: var,
         comptime Errors: type,
-        output: fn (@TypeOf(context), []const u8) Errors!void,
+        comptime output: fn (@TypeOf(context), []const u8) Errors!void,
     ) Errors!void {
         if (f.len == 0) {
             return fmt.format(context, Errors, output, "{x:0>8}-{x:0>4}-{x:0>4}-{x:0>2}{x:0>2}-{x:0>12}", .{

--- a/lib/std/os/uefi/protocols.zig
+++ b/lib/std/os/uefi/protocols.zig
@@ -87,3 +87,5 @@ pub const HIIPopupType = @import("protocols/hii_popup_protocol.zig").HIIPopupTyp
 pub const HIIPopupSelection = @import("protocols/hii_popup_protocol.zig").HIIPopupSelection;
 
 pub const RNGProtocol = @import("protocols/rng_protocol.zig").RNGProtocol;
+
+pub const ShellParametersProtocol = @import("protocols/shell_parameters_protocol.zig").ShellParametersProtocol;

--- a/lib/std/os/uefi/protocols.zig
+++ b/lib/std/os/uefi/protocols.zig
@@ -1,4 +1,5 @@
 pub const LoadedImageProtocol = @import("protocols/loaded_image_protocol.zig").LoadedImageProtocol;
+pub const loaded_image_device_path_protocol_guid = @import("protocols/loaded_image_protocol.zig").loaded_image_device_path_protocol_guid;
 
 pub const DevicePathProtocol = @import("protocols/device_path_protocol.zig").DevicePathProtocol;
 

--- a/lib/std/os/uefi/protocols.zig
+++ b/lib/std/os/uefi/protocols.zig
@@ -1,7 +1,15 @@
 pub const LoadedImageProtocol = @import("protocols/loaded_image_protocol.zig").LoadedImageProtocol;
 pub const loaded_image_device_path_protocol_guid = @import("protocols/loaded_image_protocol.zig").loaded_image_device_path_protocol_guid;
 
+pub const AcpiDevicePath = @import("protocols/device_path_protocol.zig").AcpiDevicePath;
+pub const BiosBootSpecificationDevicePath = @import("protocols/device_path_protocol.zig").BiosBootSpecificationDevicePath;
+pub const DevicePath = @import("protocols/device_path_protocol.zig").DevicePath;
 pub const DevicePathProtocol = @import("protocols/device_path_protocol.zig").DevicePathProtocol;
+pub const DevicePathType = @import("protocols/device_path_protocol.zig").DevicePathType;
+pub const EndDevicePath = @import("protocols/device_path_protocol.zig").EndDevicePath;
+pub const HardwareDevicePath = @import("protocols/device_path_protocol.zig").HardwareDevicePath;
+pub const MediaDevicePath = @import("protocols/device_path_protocol.zig").MediaDevicePath;
+pub const MessagingDevicePath = @import("protocols/device_path_protocol.zig").MessagingDevicePath;
 
 pub const SimpleFileSystemProtocol = @import("protocols/simple_file_system_protocol.zig").SimpleFileSystemProtocol;
 pub const FileProtocol = @import("protocols/file_protocol.zig").FileProtocol;

--- a/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
+++ b/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
@@ -1,21 +1,22 @@
 const uefi = @import("std").os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 
 /// Protocol for touchscreens
 pub const AbsolutePointerProtocol = extern struct {
-    _reset: extern fn (*const AbsolutePointerProtocol, bool) usize,
-    _get_state: extern fn (*const AbsolutePointerProtocol, *AbsolutePointerState) usize,
+    _reset: extern fn (*const AbsolutePointerProtocol, bool) Status,
+    _get_state: extern fn (*const AbsolutePointerProtocol, *AbsolutePointerState) Status,
     wait_for_input: Event,
     mode: *AbsolutePointerMode,
 
     /// Resets the pointer device hardware.
-    pub fn reset(self: *const AbsolutePointerProtocol, verify: bool) usize {
+    pub fn reset(self: *const AbsolutePointerProtocol, verify: bool) Status {
         return self._reset(self, verify);
     }
 
     /// Retrieves the current state of a pointer device.
-    pub fn getState(self: *const AbsolutePointerProtocol, state: *AbsolutePointerState) usize {
+    pub fn getState(self: *const AbsolutePointerProtocol, state: *AbsolutePointerState) Status {
         return self._get_state(self, state);
     }
 

--- a/lib/std/os/uefi/protocols/device_path_protocol.zig
+++ b/lib/std/os/uefi/protocols/device_path_protocol.zig
@@ -1,8 +1,8 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
 
-pub const DevicePathProtocol = extern struct {
-    type: u8,
+pub const DevicePathProtocol = packed struct {
+    type: DevicePathType,
     subtype: u8,
     length: u16,
 
@@ -13,5 +13,341 @@ pub const DevicePathProtocol = extern struct {
         .clock_seq_high_and_reserved = 0x8e,
         .clock_seq_low = 0x39,
         .node = [_]u8{ 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b },
+    };
+
+    pub fn getDevicePath(self: *const DevicePathProtocol) ?DevicePath {
+        return switch (self.type) {
+            .Hardware => blk: {
+                const hardware: ?HardwareDevicePath = switch (@intToEnum(HardwareDevicePath.Subtype, self.subtype)) {
+                    .Pci => .{ .Pci = @ptrCast(*const HardwareDevicePath.PciDevicePath, self) },
+                    .PcCard => .{ .PcCard = @ptrCast(*const HardwareDevicePath.PcCardDevicePath, self) },
+                    .MemoryMapped => .{ .MemoryMapped = @ptrCast(*const HardwareDevicePath.MemoryMappedDevicePath, self) },
+                    .Vendor => .{ .Vendor = @ptrCast(*const HardwareDevicePath.VendorDevicePath, self) },
+                    .Controller => .{ .Controller = @ptrCast(*const HardwareDevicePath.ControllerDevicePath, self) },
+                    .Bmc => .{ .Bmc = @ptrCast(*const HardwareDevicePath.BmcDevicePath, self) },
+                    _ => null,
+                };
+                break :blk if (hardware) |h| .{ .Hardware = h } else null;
+            },
+            .Acpi => blk: {
+                const acpi: ?AcpiDevicePath = switch (@intToEnum(AcpiDevicePath.Subtype, self.subtype)) {
+                    else => null, // TODO
+                };
+                break :blk if (acpi) |a| .{ .Acpi = a } else null;
+            },
+            .Messaging => blk: {
+                const messaging: ?MessagingDevicePath = switch (@intToEnum(MessagingDevicePath.Subtype, self.subtype)) {
+                    else => null, // TODO
+                };
+                break :blk if (messaging) |m| .{ .Messaging = m } else null;
+            },
+            .Media => blk: {
+                const media: ?MediaDevicePath = switch (@intToEnum(MediaDevicePath.Subtype, self.subtype)) {
+                    .HardDrive => .{ .HardDrive = @ptrCast(*const MediaDevicePath.HardDriveDevicePath, self) },
+                    .Cdrom => .{ .Cdrom = @ptrCast(*const MediaDevicePath.CdromDevicePath, self) },
+                    .Vendor => .{ .Vendor = @ptrCast(*const MediaDevicePath.VendorDevicePath, self) },
+                    .FilePath => .{ .FilePath = @ptrCast(*const MediaDevicePath.FilePathDevicePath, self) },
+                    .MediaProtocol => .{ .MediaProtocol = @ptrCast(*const MediaDevicePath.MediaProtocolDevicePath, self) },
+                    .PiwgFirmwareFile => .{ .PiwgFirmwareFile = @ptrCast(*const MediaDevicePath.PiwgFirmwareFileDevicePath, self) },
+                    .PiwgFirmwareVolume => .{ .PiwgFirmwareVolume = @ptrCast(*const MediaDevicePath.PiwgFirmwareVolumeDevicePath, self) },
+                    .RelativeOffsetRange => .{ .RelativeOffsetRange = @ptrCast(*const MediaDevicePath.RelativeOffsetRangeDevicePath, self) },
+                    .RamDisk => .{ .RamDisk = @ptrCast(*const MediaDevicePath.RamDiskDevicePath, self) },
+                    _ => null,
+                };
+                break :blk if (media) |m| .{ .Media = m } else null;
+            },
+            .BiosBootSpecification => blk: {
+                const bbs: ?BiosBootSpecificationDevicePath = switch (@intToEnum(BiosBootSpecificationDevicePath.Subtype, self.subtype)) {
+                    .BBS101 => .{ .BBS101 = @ptrCast(*const BiosBootSpecificationDevicePath.BBS101DevicePath, self) },
+                    _ => null,
+                };
+                break :blk if (bbs) |b| .{ .BiosBootSpecification = b } else null;
+            },
+            .End => blk: {
+                const end: ?EndDevicePath = switch (@intToEnum(EndDevicePath.Subtype, self.subtype)) {
+                    .EndEntire => .{ .EndEntire = @ptrCast(*const EndDevicePath.EndEntireDevicePath, self) },
+                    .EndThisInstance => .{ .EndThisInstance = @ptrCast(*const EndDevicePath.EndThisInstanceDevicePath, self) },
+                    _ => null,
+                };
+                break :blk if (end) |e| .{ .End = e } else null;
+            },
+            _ => null,
+        };
+    }
+};
+
+pub const DevicePath = union(DevicePathType) {
+    Hardware: HardwareDevicePath,
+    Acpi: AcpiDevicePath,
+    Messaging: MessagingDevicePath,
+    Media: MediaDevicePath,
+    BiosBootSpecification: BiosBootSpecificationDevicePath,
+    End: EndDevicePath,
+};
+
+pub const DevicePathType = extern enum(u8) {
+    Hardware = 0x01,
+    Acpi = 0x02,
+    Messaging = 0x03,
+    Media = 0x04,
+    BiosBootSpecification = 0x05,
+    End = 0x7f,
+    _,
+};
+
+pub const HardwareDevicePath = union(Subtype) {
+    Pci: *const PciDevicePath,
+    PcCard: *const PcCardDevicePath,
+    MemoryMapped: *const MemoryMappedDevicePath,
+    Vendor: *const VendorDevicePath,
+    Controller: *const ControllerDevicePath,
+    Bmc: *const BmcDevicePath,
+
+    pub const Subtype = extern enum(u8) {
+        Pci = 1,
+        PcCard = 2,
+        MemoryMapped = 3,
+        Vendor = 4,
+        Controller = 5,
+        Bmc = 6,
+        _,
+    };
+
+    pub const PciDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        // TODO
+    };
+
+    pub const PcCardDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        // TODO
+    };
+
+    pub const MemoryMappedDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        // TODO
+    };
+
+    pub const VendorDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        // TODO
+    };
+
+    pub const ControllerDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        // TODO
+    };
+
+    pub const BmcDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        // TODO
+    };
+};
+
+pub const AcpiDevicePath = union(Subtype) {
+    Acpi: void, // TODO
+    ExpandedAcpi: void, // TODO
+    Adr: void, // TODO
+    Nvdimm: void, // TODO
+
+    pub const Subtype = extern enum(u8) {
+        Acpi = 1,
+        ExpandedAcpi = 2,
+        Adr = 3,
+        Nvdimm = 4,
+        _,
+    };
+};
+
+pub const MessagingDevicePath = union(Subtype) {
+    Atapi: void, // TODO
+    Scsi: void, // TODO
+    FibreChannel: void, // TODO
+    FibreChannelEx: void, // TODO
+    @"1394": void, // TODO
+    Usb: void, // TODO
+    Sata: void, // TODO
+    UsbWwid: void, // TODO
+    Lun: void, // TODO
+    UsbClass: void, // TODO
+    I2o: void, // TODO
+    MacAddress: void, // TODO
+    Ipv4: void, // TODO
+    Ipv6: void, // TODO
+    Vlan: void, // TODO
+    InfiniBand: void, // TODO
+    Uart: void, // TODO
+    Vendor: void, // TODO
+
+    pub const Subtype = extern enum(u8) {
+        Atapi = 1,
+        Scsi = 2,
+        FibreChannel = 3,
+        FibreChannelEx = 21,
+        @"1394" = 4,
+        Usb = 5,
+        Sata = 18,
+        UsbWwid = 16,
+        Lun = 17,
+        UsbClass = 15,
+        I2o = 6,
+        MacAddress = 11,
+        Ipv4 = 12,
+        Ipv6 = 13,
+        Vlan = 20,
+        InfiniBand = 9,
+        Uart = 14,
+        Vendor = 10,
+        _,
+    };
+};
+
+pub const MediaDevicePath = union(Subtype) {
+    HardDrive: *const HardDriveDevicePath,
+    Cdrom: *const CdromDevicePath,
+    Vendor: *const VendorDevicePath,
+    FilePath: *const FilePathDevicePath,
+    MediaProtocol: *const MediaProtocolDevicePath,
+    PiwgFirmwareFile: *const PiwgFirmwareFileDevicePath,
+    PiwgFirmwareVolume: *const PiwgFirmwareVolumeDevicePath,
+    RelativeOffsetRange: *const RelativeOffsetRangeDevicePath,
+    RamDisk: *const RamDiskDevicePath,
+
+    pub const Subtype = extern enum(u8) {
+        HardDrive = 1,
+        Cdrom = 2,
+        Vendor = 3,
+        FilePath = 4,
+        MediaProtocol = 5,
+        PiwgFirmwareFile = 6,
+        PiwgFirmwareVolume = 7,
+        RelativeOffsetRange = 8,
+        RamDisk = 9,
+        _,
+    };
+
+    pub const HardDriveDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        // TODO
+    };
+
+    pub const CdromDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        // TODO
+    };
+
+    pub const VendorDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        // TODO
+    };
+
+    pub const FilePathDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+
+        pub fn getPath(self: *const FilePathDevicePath) [*:0]const u16 {
+            return @ptrCast([*:0]const u16, @alignCast(2, @ptrCast([*]const u8, self)) + @sizeOf(FilePathDevicePath));
+        }
+    };
+
+    pub const MediaProtocolDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        // TODO
+    };
+
+    pub const PiwgFirmwareFileDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+    };
+
+    pub const PiwgFirmwareVolumeDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+    };
+
+    pub const RelativeOffsetRangeDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        reserved: u32,
+        start: u64,
+        end: u64,
+    };
+
+    pub const RamDiskDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        start: u64,
+        end: u64,
+        disk_type: uefi.Guid,
+        instance: u16,
+    };
+};
+
+pub const BiosBootSpecificationDevicePath = union(Subtype) {
+    BBS101: *const BBS101DevicePath,
+
+    pub const Subtype = extern enum(u8) {
+        BBS101 = 1,
+        _,
+    };
+
+    pub const BBS101DevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+        device_type: u16,
+        status_flag: u16,
+
+        pub fn getDescription(self: *const BBS101DevicePath) [*:0]const u8 {
+            return @ptrCast([*:0]const u8, self) + @sizeOf(BBS101DevicePath);
+        }
+    };
+};
+
+pub const EndDevicePath = union(Subtype) {
+    EndEntire: *const EndEntireDevicePath,
+    EndThisInstance: *const EndThisInstanceDevicePath,
+
+    pub const Subtype = extern enum(u8) {
+        EndEntire = 0xff,
+        EndThisInstance = 0x01,
+        _,
+    };
+
+    pub const EndEntireDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
+    };
+
+    pub const EndThisInstanceDevicePath = packed struct {
+        type: DevicePathType,
+        subtype: Subtype,
+        length: u16,
     };
 };

--- a/lib/std/os/uefi/protocols/edid_override_protocol.zig
+++ b/lib/std/os/uefi/protocols/edid_override_protocol.zig
@@ -1,14 +1,15 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
 const Handle = uefi.Handle;
+const Status = uefi.Status;
 
 /// Override EDID information
 pub const EdidOverrideProtocol = extern struct {
-    _get_edid: extern fn (*const EdidOverrideProtocol, Handle, *u32, *usize, *?[*]u8) usize,
+    _get_edid: extern fn (*const EdidOverrideProtocol, Handle, *u32, *usize, *?[*]u8) Status,
 
     /// Returns policy information and potentially a replacement EDID for the specified video output device.
     /// attributes must be align(4)
-    pub fn getEdid(self: *const EdidOverrideProtocol, handle: Handle, attributes: *EdidOverrideProtocolAttributes, edid_size: *usize, edid: *?[*]u8) usize {
+    pub fn getEdid(self: *const EdidOverrideProtocol, handle: Handle, attributes: *EdidOverrideProtocolAttributes, edid_size: *usize, edid: *?[*]u8) Status {
         return self._get_edid(self, handle, attributes, edid_size, edid);
     }
 

--- a/lib/std/os/uefi/protocols/file_protocol.zig
+++ b/lib/std/os/uefi/protocols/file_protocol.zig
@@ -1,47 +1,48 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
 const Time = uefi.Time;
+const Status = uefi.Status;
 
 pub const FileProtocol = extern struct {
     revision: u64,
-    _open: extern fn (*const FileProtocol, **const FileProtocol, *u16, u64, u64) usize,
-    _close: extern fn (*const FileProtocol) usize,
-    _delete: extern fn (*const FileProtocol) usize,
-    _read: extern fn (*const FileProtocol, *usize, *c_void) usize,
-    _write: extern fn (*const FileProtocol, *usize, *c_void) usize,
-    _get_info: extern fn (*const FileProtocol, *Guid, *usize, *c_void) usize,
-    _set_info: extern fn (*const FileProtocol, *Guid, usize, *c_void) usize,
-    _flush: extern fn (*const FileProtocol) usize,
+    _open: extern fn (*const FileProtocol, **const FileProtocol, *u16, u64, u64) Status,
+    _close: extern fn (*const FileProtocol) Status,
+    _delete: extern fn (*const FileProtocol) Status,
+    _read: extern fn (*const FileProtocol, *usize, *c_void) Status,
+    _write: extern fn (*const FileProtocol, *usize, *c_void) Status,
+    _get_info: extern fn (*const FileProtocol, *Guid, *usize, *c_void) Status,
+    _set_info: extern fn (*const FileProtocol, *Guid, usize, *c_void) Status,
+    _flush: extern fn (*const FileProtocol) Status,
 
-    pub fn open(self: *const FileProtocol, new_handle: **const FileProtocol, file_name: *u16, open_mode: u64, attributes: u64) usize {
+    pub fn open(self: *const FileProtocol, new_handle: **const FileProtocol, file_name: *u16, open_mode: u64, attributes: u64) Status {
         return self._open(self, new_handle, file_name, open_mode, attributes);
     }
 
-    pub fn close(self: *const FileProtocol) usize {
+    pub fn close(self: *const FileProtocol) Status {
         return self._close(self);
     }
 
-    pub fn delete(self: *const FileProtocol) usize {
+    pub fn delete(self: *const FileProtocol) Status {
         return self._delete(self);
     }
 
-    pub fn read(self: *const FileProtocol, buffer_size: *usize, buffer: *c_void) usize {
+    pub fn read(self: *const FileProtocol, buffer_size: *usize, buffer: *c_void) Status {
         return self._read(self, buffer_size, buffer);
     }
 
-    pub fn write(self: *const FileProtocol, buffer_size: *usize, buffer: *c_void) usize {
+    pub fn write(self: *const FileProtocol, buffer_size: *usize, buffer: *c_void) Status {
         return self._write(self, buffer_size, buffer);
     }
 
-    pub fn get_info(self: *const FileProtocol, information_type: *Guid, buffer_size: *usize, buffer: *c_void) usize {
+    pub fn get_info(self: *const FileProtocol, information_type: *Guid, buffer_size: *usize, buffer: *c_void) Status {
         return self._get_info(self, information_type, buffer_size, buffer);
     }
 
-    pub fn set_info(self: *const FileProtocol, information_type: *Guid, buffer_size: usize, buffer: *c_void) usize {
+    pub fn set_info(self: *const FileProtocol, information_type: *Guid, buffer_size: usize, buffer: *c_void) Status {
         return self._set_info(self, information_type, buffer_size, buffer);
     }
 
-    pub fn flush(self: *const FileProtocol) usize {
+    pub fn flush(self: *const FileProtocol) Status {
         return self._flush(self);
     }
 

--- a/lib/std/os/uefi/protocols/graphics_output_protocol.zig
+++ b/lib/std/os/uefi/protocols/graphics_output_protocol.zig
@@ -1,25 +1,26 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 
 /// Graphics output
 pub const GraphicsOutputProtocol = extern struct {
-    _query_mode: extern fn (*const GraphicsOutputProtocol, u32, *usize, **GraphicsOutputModeInformation) usize,
-    _set_mode: extern fn (*const GraphicsOutputProtocol, u32) usize,
-    _blt: extern fn (*const GraphicsOutputProtocol, ?[*]GraphicsOutputBltPixel, GraphicsOutputBltOperation, usize, usize, usize, usize, usize, usize, usize) usize,
+    _query_mode: extern fn (*const GraphicsOutputProtocol, u32, *usize, **GraphicsOutputModeInformation) Status,
+    _set_mode: extern fn (*const GraphicsOutputProtocol, u32) Status,
+    _blt: extern fn (*const GraphicsOutputProtocol, ?[*]GraphicsOutputBltPixel, GraphicsOutputBltOperation, usize, usize, usize, usize, usize, usize, usize) Status,
     mode: *GraphicsOutputProtocolMode,
 
     /// Returns information for an available graphics mode that the graphics device and the set of active video output devices supports.
-    pub fn queryMode(self: *const GraphicsOutputProtocol, mode: u32, size_of_info: *usize, info: **GraphicsOutputModeInformation) usize {
+    pub fn queryMode(self: *const GraphicsOutputProtocol, mode: u32, size_of_info: *usize, info: **GraphicsOutputModeInformation) Status {
         return self._query_mode(self, mode, size_of_info, info);
     }
 
     /// Set the video device into the specified mode and clears the visible portions of the output display to black.
-    pub fn setMode(self: *const GraphicsOutputProtocol, mode: u32) usize {
+    pub fn setMode(self: *const GraphicsOutputProtocol, mode: u32) Status {
         return self._set_mode(self, mode);
     }
 
     /// Blt a rectangle of pixels on the graphics screen. Blt stands for BLock Transfer.
-    pub fn blt(self: *const GraphicsOutputProtocol, blt_buffer: ?[*]GraphicsOutputBltPixel, blt_operation: GraphicsOutputBltOperation, source_x: usize, source_y: usize, destination_x: usize, destination_y: usize, width: usize, height: usize, delta: usize) usize {
+    pub fn blt(self: *const GraphicsOutputProtocol, blt_buffer: ?[*]GraphicsOutputBltPixel, blt_operation: GraphicsOutputBltOperation, source_x: usize, source_y: usize, destination_x: usize, destination_y: usize, width: usize, height: usize, delta: usize) Status {
         return self._blt(self, blt_buffer, blt_operation, source_x, source_y, destination_x, destination_y, width, height, delta);
     }
 

--- a/lib/std/os/uefi/protocols/hii_database_protocol.zig
+++ b/lib/std/os/uefi/protocols/hii_database_protocol.zig
@@ -1,38 +1,39 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 const hii = uefi.protocols.hii;
 
 /// Database manager for HII-related data structures.
 pub const HIIDatabaseProtocol = extern struct {
-    _new_package_list: usize, // TODO
-    _remove_package_list: extern fn (*const HIIDatabaseProtocol, hii.HIIHandle) usize,
-    _update_package_list: extern fn (*const HIIDatabaseProtocol, hii.HIIHandle, *const hii.HIIPackageList) usize,
-    _list_package_lists: extern fn (*const HIIDatabaseProtocol, u8, ?*const Guid, *usize, [*]hii.HIIHandle) usize,
-    _export_package_lists: extern fn (*const HIIDatabaseProtocol, ?hii.HIIHandle, *usize, *hii.HIIPackageList) usize,
-    _register_package_notify: usize, // TODO
-    _unregister_package_notify: usize, // TODO
-    _find_keyboard_layouts: usize, // TODO
-    _get_keyboard_layout: usize, // TODO
-    _set_keyboard_layout: usize, // TODO
-    _get_package_list_handle: usize, // TODO
+    _new_package_list: Status, // TODO
+    _remove_package_list: extern fn (*const HIIDatabaseProtocol, hii.HIIHandle) Status,
+    _update_package_list: extern fn (*const HIIDatabaseProtocol, hii.HIIHandle, *const hii.HIIPackageList) Status,
+    _list_package_lists: extern fn (*const HIIDatabaseProtocol, u8, ?*const Guid, *usize, [*]hii.HIIHandle) Status,
+    _export_package_lists: extern fn (*const HIIDatabaseProtocol, ?hii.HIIHandle, *usize, *hii.HIIPackageList) Status,
+    _register_package_notify: Status, // TODO
+    _unregister_package_notify: Status, // TODO
+    _find_keyboard_layouts: Status, // TODO
+    _get_keyboard_layout: Status, // TODO
+    _set_keyboard_layout: Status, // TODO
+    _get_package_list_handle: Status, // TODO
 
     /// Removes a package list from the HII database.
-    pub fn removePackageList(self: *const HIIDatabaseProtocol, handle: hii.HIIHandle) usize {
+    pub fn removePackageList(self: *const HIIDatabaseProtocol, handle: hii.HIIHandle) Status {
         return self._remove_package_list(self, handle);
     }
 
     /// Update a package list in the HII database.
-    pub fn updatePackageList(self: *const HIIDatabaseProtocol, handle: hii.HIIHandle, buffer: *const hii.HIIPackageList) usize {
+    pub fn updatePackageList(self: *const HIIDatabaseProtocol, handle: hii.HIIHandle, buffer: *const hii.HIIPackageList) Status {
         return self._update_package_list(self, handle, buffer);
     }
 
     /// Determines the handles that are currently active in the database.
-    pub fn listPackageLists(self: *const HIIDatabaseProtocol, package_type: u8, package_guid: ?*const Guid, buffer_length: *usize, handles: [*]hii.HIIHandle) usize {
+    pub fn listPackageLists(self: *const HIIDatabaseProtocol, package_type: u8, package_guid: ?*const Guid, buffer_length: *usize, handles: [*]hii.HIIHandle) Status {
         return self._list_package_lists(self, package_type, package_guid, buffer_length, handles);
     }
 
     /// Exports the contents of one or all package lists in the HII database into a buffer.
-    pub fn exportPackageLists(self: *const HIIDatabaseProtocol, handle: ?hii.HIIHandle, buffer_size: *usize, buffer: *hii.HIIPackageList) usize {
+    pub fn exportPackageLists(self: *const HIIDatabaseProtocol, handle: ?hii.HIIHandle, buffer_size: *usize, buffer: *hii.HIIPackageList) Status {
         return self._export_package_lists(self, handle, buffer_size, buffer);
     }
 

--- a/lib/std/os/uefi/protocols/hii_popup_protocol.zig
+++ b/lib/std/os/uefi/protocols/hii_popup_protocol.zig
@@ -1,14 +1,15 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 const hii = uefi.protocols.hii;
 
 /// Display a popup window
 pub const HIIPopupProtocol = extern struct {
     revision: u64,
-    _create_popup: extern fn (*const HIIPopupProtocol, HIIPopupStyle, HIIPopupType, hii.HIIHandle, u16, ?*HIIPopupSelection) usize,
+    _create_popup: extern fn (*const HIIPopupProtocol, HIIPopupStyle, HIIPopupType, hii.HIIHandle, u16, ?*HIIPopupSelection) Status,
 
     /// Displays a popup window.
-    pub fn createPopup(self: *const HIIPopupProtocol, style: HIIPopupStyle, popup_type: HIIPopupType, handle: hii.HIIHandle, msg: u16, user_selection: ?*HIIPopupSelection) usize {
+    pub fn createPopup(self: *const HIIPopupProtocol, style: HIIPopupStyle, popup_type: HIIPopupType, handle: hii.HIIHandle, msg: u16, user_selection: ?*HIIPopupSelection) Status {
         return self._create_popup(self, style, popup_type, handle, msg, user_selection);
     }
 

--- a/lib/std/os/uefi/protocols/ip6_config_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_config_protocol.zig
@@ -1,26 +1,27 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;
+const Status = uefi.Status;
 
 pub const Ip6ConfigProtocol = extern struct {
-    _set_data: extern fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, usize, *const c_void) usize,
-    _get_data: extern fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, *usize, ?*const c_void) usize,
-    _register_data_notify: extern fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) usize,
-    _unregister_data_notify: extern fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) usize,
+    _set_data: extern fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, usize, *const c_void) Status,
+    _get_data: extern fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, *usize, ?*const c_void) Status,
+    _register_data_notify: extern fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) Status,
+    _unregister_data_notify: extern fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) Status,
 
-    pub fn setData(self: *const Ip6ConfigProtocol, data_type: Ip6ConfigDataType, data_size: usize, data: *const c_void) usize {
+    pub fn setData(self: *const Ip6ConfigProtocol, data_type: Ip6ConfigDataType, data_size: usize, data: *const c_void) Status {
         return self._set_data(self, data_type, data_size, data);
     }
 
-    pub fn getData(self: *const Ip6ConfigProtocol, data_type: Ip6ConfigDataType, data_size: *usize, data: ?*const c_void) usize {
+    pub fn getData(self: *const Ip6ConfigProtocol, data_type: Ip6ConfigDataType, data_size: *usize, data: ?*const c_void) Status {
         return self._get_data(self, data_type, data_size, data);
     }
 
-    pub fn registerDataNotify(self: *const Ip6ConfigProtocol, data_type: Ip6ConfigDataType, event: Event) usize {
+    pub fn registerDataNotify(self: *const Ip6ConfigProtocol, data_type: Ip6ConfigDataType, event: Event) Status {
         return self._register_data_notify(self, data_type, event);
     }
 
-    pub fn unregisterDataNotify(self: *const Ip6ConfigProtocol, data_type: Ip6ConfigDataType, event: Event) usize {
+    pub fn unregisterDataNotify(self: *const Ip6ConfigProtocol, data_type: Ip6ConfigDataType, event: Event) Status {
         return self._unregister_data_notify(self, data_type, event);
     }
 

--- a/lib/std/os/uefi/protocols/ip6_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_protocol.zig
@@ -1,63 +1,64 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;
+const Status = uefi.Status;
 const MacAddress = uefi.protocols.MacAddress;
 const ManagedNetworkConfigData = uefi.protocols.ManagedNetworkConfigData;
 const SimpleNetworkMode = uefi.protocols.SimpleNetworkMode;
 
 pub const Ip6Protocol = extern struct {
-    _get_mode_data: extern fn (*const Ip6Protocol, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) usize,
-    _configure: extern fn (*const Ip6Protocol, ?*const Ip6ConfigData) usize,
-    _groups: extern fn (*const Ip6Protocol, bool, ?*const Ip6Address) usize,
-    _routes: extern fn (*const Ip6Protocol, bool, ?*const Ip6Address, u8, ?*const Ip6Address) usize,
-    _neighbors: extern fn (*const Ip6Protocol, bool, *const Ip6Address, ?*const MacAddress, u32, bool) usize,
-    _transmit: extern fn (*const Ip6Protocol, *Ip6CompletionToken) usize,
-    _receive: extern fn (*const Ip6Protocol, *Ip6CompletionToken) usize,
-    _cancel: extern fn (*const Ip6Protocol, ?*Ip6CompletionToken) usize,
-    _poll: extern fn (*const Ip6Protocol) usize,
+    _get_mode_data: extern fn (*const Ip6Protocol, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) Status,
+    _configure: extern fn (*const Ip6Protocol, ?*const Ip6ConfigData) Status,
+    _groups: extern fn (*const Ip6Protocol, bool, ?*const Ip6Address) Status,
+    _routes: extern fn (*const Ip6Protocol, bool, ?*const Ip6Address, u8, ?*const Ip6Address) Status,
+    _neighbors: extern fn (*const Ip6Protocol, bool, *const Ip6Address, ?*const MacAddress, u32, bool) Status,
+    _transmit: extern fn (*const Ip6Protocol, *Ip6CompletionToken) Status,
+    _receive: extern fn (*const Ip6Protocol, *Ip6CompletionToken) Status,
+    _cancel: extern fn (*const Ip6Protocol, ?*Ip6CompletionToken) Status,
+    _poll: extern fn (*const Ip6Protocol) Status,
 
     /// Gets the current operational settings for this instance of the EFI IPv6 Protocol driver.
-    pub fn getModeData(self: *const Ip6Protocol, ip6_mode_data: ?*Ip6ModeData, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) usize {
+    pub fn getModeData(self: *const Ip6Protocol, ip6_mode_data: ?*Ip6ModeData, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {
         return self._get_mode_data(self, ip6_mode_data, mnp_config_data, snp_mode_data);
     }
 
     /// Assign IPv6 address and other configuration parameter to this EFI IPv6 Protocol driver instance.
-    pub fn configure(self: *const Ip6Protocol, ip6_config_data: ?*const Ip6ConfigData) usize {
+    pub fn configure(self: *const Ip6Protocol, ip6_config_data: ?*const Ip6ConfigData) Status {
         return self._configure(self, ip6_config_data);
     }
 
     /// Joins and leaves multicast groups.
-    pub fn groups(self: *const Ip6Protocol, join_flag: bool, group_address: ?*const Ip6Address) usize {
+    pub fn groups(self: *const Ip6Protocol, join_flag: bool, group_address: ?*const Ip6Address) Status {
         return self._groups(self, join_flag, group_address);
     }
 
     /// Adds and deletes routing table entries.
-    pub fn routes(self: *const Ip6Protocol, delete_route: bool, destination: ?*const Ip6Address, prefix_length: u8, gateway_address: ?*const Ip6Address) usize {
+    pub fn routes(self: *const Ip6Protocol, delete_route: bool, destination: ?*const Ip6Address, prefix_length: u8, gateway_address: ?*const Ip6Address) Status {
         return self._routes(self, delete_route, destination, prefix_length, gateway_address);
     }
 
     /// Add or delete Neighbor cache entries.
-    pub fn neighbors(self: *const Ip6Protocol, delete_flag: bool, target_ip6_address: *const Ip6Address, target_link_address: ?*const MacAddress, timeout: u32, override: bool) usize {
+    pub fn neighbors(self: *const Ip6Protocol, delete_flag: bool, target_ip6_address: *const Ip6Address, target_link_address: ?*const MacAddress, timeout: u32, override: bool) Status {
         return self._neighbors(self, delete_flag, target_ip6_address, target_link_address, timeout, override);
     }
 
     /// Places outgoing data packets into the transmit queue.
-    pub fn transmit(self: *const Ip6Protocol, token: *Ip6CompletionToken) usize {
+    pub fn transmit(self: *const Ip6Protocol, token: *Ip6CompletionToken) Status {
         return self._transmit(self, token);
     }
 
     /// Places a receiving request into the receiving queue.
-    pub fn receive(self: *const Ip6Protocol, token: *Ip6CompletionToken) usize {
+    pub fn receive(self: *const Ip6Protocol, token: *Ip6CompletionToken) Status {
         return self._receive(self, token);
     }
 
     /// Abort an asynchronous transmits or receive request.
-    pub fn cancel(self: *const Ip6Protocol, token: ?*Ip6CompletionToken) usize {
+    pub fn cancel(self: *const Ip6Protocol, token: ?*Ip6CompletionToken) Status {
         return self._cancel(self, token);
     }
 
     /// Polls for incoming data packets and processes outgoing data packets.
-    pub fn poll(self: *const Ip6Protocol) usize {
+    pub fn poll(self: *const Ip6Protocol) Status {
         return self._poll(self);
     }
 
@@ -138,6 +139,6 @@ pub const Ip6IcmpType = extern struct {
 
 pub const Ip6CompletionToken = extern struct {
     event: Event,
-    status: usize,
+    status: Status,
     packet: *c_void, // union TODO
 };

--- a/lib/std/os/uefi/protocols/ip6_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_service_binding_protocol.zig
@@ -1,16 +1,17 @@
 const uefi = @import("std").os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 
 pub const Ip6ServiceBindingProtocol = extern struct {
-    _create_child: extern fn (*const Ip6ServiceBindingProtocol, *?Handle) usize,
-    _destroy_child: extern fn (*const Ip6ServiceBindingProtocol, Handle) usize,
+    _create_child: extern fn (*const Ip6ServiceBindingProtocol, *?Handle) Status,
+    _destroy_child: extern fn (*const Ip6ServiceBindingProtocol, Handle) Status,
 
-    pub fn createChild(self: *const Ip6ServiceBindingProtocol, handle: *?Handle) usize {
+    pub fn createChild(self: *const Ip6ServiceBindingProtocol, handle: *?Handle) Status {
         return self._create_child(self, handle);
     }
 
-    pub fn destroyChild(self: *const Ip6ServiceBindingProtocol, handle: Handle) usize {
+    pub fn destroyChild(self: *const Ip6ServiceBindingProtocol, handle: Handle) Status {
         return self._destroy_child(self, handle);
     }
 

--- a/lib/std/os/uefi/protocols/loaded_image_protocol.zig
+++ b/lib/std/os/uefi/protocols/loaded_image_protocol.zig
@@ -1,6 +1,7 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
 const Handle = uefi.Handle;
+const Status = uefi.Status;
 const SystemTable = uefi.tables.SystemTable;
 const MemoryType = uefi.tables.MemoryType;
 const DevicePathProtocol = uefi.protocols.DevicePathProtocol;
@@ -18,10 +19,10 @@ pub const LoadedImageProtocol = extern struct {
     image_size: u64,
     image_code_type: MemoryType,
     image_data_type: MemoryType,
-    _unload: extern fn (*const LoadedImageProtocol, Handle) usize,
+    _unload: extern fn (*const LoadedImageProtocol, Handle) Status,
 
     /// Unloads an image from memory.
-    pub fn unload(self: *const LoadedImageProtocol, handle: Handle) usize {
+    pub fn unload(self: *const LoadedImageProtocol, handle: Handle) Status {
         return self._unload(self, handle);
     }
 

--- a/lib/std/os/uefi/protocols/loaded_image_protocol.zig
+++ b/lib/std/os/uefi/protocols/loaded_image_protocol.zig
@@ -13,7 +13,7 @@ pub const LoadedImageProtocol = extern struct {
     file_path: *DevicePathProtocol,
     reserved: *c_void,
     load_options_size: u32,
-    load_options: *c_void,
+    load_options: ?*c_void,
     image_base: [*]u8,
     image_size: u64,
     image_code_type: MemoryType,
@@ -33,4 +33,13 @@ pub const LoadedImageProtocol = extern struct {
         .clock_seq_low = 0x3f,
         .node = [_]u8{ 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b },
     };
+};
+
+pub const loaded_image_device_path_protocol_guid align(8) = Guid{
+    .time_low = 0xbc62157e,
+    .time_mid = 0x3e33,
+    .time_high_and_version = 0x4fec,
+    .clock_seq_high_and_reserved = 0x99,
+    .clock_seq_low = 0x20,
+    .node = [_]u8{ 0x2d, 0x3b, 0x36, 0xd7, 0x50, 0xdf },
 };

--- a/lib/std/os/uefi/protocols/managed_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/managed_network_protocol.zig
@@ -1,60 +1,61 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;
+const Status = uefi.Status;
 const Time = uefi.Time;
 const SimpleNetworkMode = uefi.protocols.SimpleNetworkMode;
 const MacAddress = uefi.protocols.MacAddress;
 
 pub const ManagedNetworkProtocol = extern struct {
-    _get_mode_data: extern fn (*const ManagedNetworkProtocol, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) usize,
-    _configure: extern fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkConfigData) usize,
-    _mcast_ip_to_mac: extern fn (*const ManagedNetworkProtocol, bool, *const c_void, *MacAddress) usize,
-    _groups: extern fn (*const ManagedNetworkProtocol, bool, ?*const MacAddress) usize,
-    _transmit: extern fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) usize,
-    _receive: extern fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) usize,
-    _cancel: extern fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkCompletionToken) usize,
+    _get_mode_data: extern fn (*const ManagedNetworkProtocol, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) Status,
+    _configure: extern fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkConfigData) Status,
+    _mcast_ip_to_mac: extern fn (*const ManagedNetworkProtocol, bool, *const c_void, *MacAddress) Status,
+    _groups: extern fn (*const ManagedNetworkProtocol, bool, ?*const MacAddress) Status,
+    _transmit: extern fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) Status,
+    _receive: extern fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) Status,
+    _cancel: extern fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkCompletionToken) Status,
     _poll: extern fn (*const ManagedNetworkProtocol) usize,
 
     /// Returns the operational parameters for the current MNP child driver.
     /// May also support returning the underlying SNP driver mode data.
-    pub fn getModeData(self: *const ManagedNetworkProtocol, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) usize {
+    pub fn getModeData(self: *const ManagedNetworkProtocol, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {
         return self._get_mode_data(self, mnp_config_data, snp_mode_data);
     }
 
     /// Sets or clears the operational parameters for the MNP child driver.
-    pub fn configure(self: *const ManagedNetworkProtocol, mnp_config_data: ?*const ManagedNetworkConfigData) usize {
+    pub fn configure(self: *const ManagedNetworkProtocol, mnp_config_data: ?*const ManagedNetworkConfigData) Status {
         return self._configure(self, mnp_config_data);
     }
 
     /// Translates an IP multicast address to a hardware (MAC) multicast address.
     /// This function may be unsupported in some MNP implementations.
-    pub fn mcastIpToMac(self: *const ManagedNetworkProtocol, ipv6flag: bool, ipaddress: *const c_void, mac_address: *MacAddress) usize {
+    pub fn mcastIpToMac(self: *const ManagedNetworkProtocol, ipv6flag: bool, ipaddress: *const c_void, mac_address: *MacAddress) Status {
         return self._mcast_ip_to_mac(self, ipv6flag, ipaddress);
     }
 
     /// Enables and disables receive filters for multicast address.
     /// This function may be unsupported in some MNP implementations.
-    pub fn groups(self: *const ManagedNetworkProtocol, join_flag: bool, mac_address: ?*const MacAddress) usiz {
+    pub fn groups(self: *const ManagedNetworkProtocol, join_flag: bool, mac_address: ?*const MacAddress) Status {
         return self._groups(self, join_flag, mac_address);
     }
 
     /// Places asynchronous outgoing data packets into the transmit queue.
-    pub fn transmit(self: *const ManagedNetworkProtocol, token: *const ManagedNetworkCompletionToken) usize {
+    pub fn transmit(self: *const ManagedNetworkProtocol, token: *const ManagedNetworkCompletionToken) Status {
         return self._transmit(self, token);
     }
 
     /// Places an asynchronous receiving request into the receiving queue.
-    pub fn receive(self: *const ManagedNetworkProtocol, token: *const ManagedNetworkCompletionToken) usize {
+    pub fn receive(self: *const ManagedNetworkProtocol, token: *const ManagedNetworkCompletionToken) Status {
         return self._receive(self, token);
     }
 
     /// Aborts an asynchronous transmit or receive request.
-    pub fn cancel(self: *const ManagedNetworkProtocol, token: ?*const ManagedNetworkCompletionToken) usize {
+    pub fn cancel(self: *const ManagedNetworkProtocol, token: ?*const ManagedNetworkCompletionToken) Status {
         return self._cancel(self, token);
     }
 
     /// Polls for incoming data packets and processes outgoing data packets.
-    pub fn poll(self: *const ManagedNetworkProtocol) usize {
+    pub fn poll(self: *const ManagedNetworkProtocol) Status {
         return self._poll(self);
     }
 
@@ -83,7 +84,7 @@ pub const ManagedNetworkConfigData = extern struct {
 
 pub const ManagedNetworkCompletionToken = extern struct {
     event: Event,
-    status: usize,
+    status: Status,
     packet: extern union {
         RxData: *ManagedNetworkReceiveData,
         TxData: *ManagedNetworkTransmitData,

--- a/lib/std/os/uefi/protocols/managed_network_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/managed_network_service_binding_protocol.zig
@@ -1,16 +1,17 @@
 const uefi = @import("std").os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 
 pub const ManagedNetworkServiceBindingProtocol = extern struct {
-    _create_child: extern fn (*const ManagedNetworkServiceBindingProtocol, *?Handle) usize,
-    _destroy_child: extern fn (*const ManagedNetworkServiceBindingProtocol, Handle) usize,
+    _create_child: extern fn (*const ManagedNetworkServiceBindingProtocol, *?Handle) Status,
+    _destroy_child: extern fn (*const ManagedNetworkServiceBindingProtocol, Handle) Status,
 
-    pub fn createChild(self: *const ManagedNetworkServiceBindingProtocol, handle: *?Handle) usize {
+    pub fn createChild(self: *const ManagedNetworkServiceBindingProtocol, handle: *?Handle) Status {
         return self._create_child(self, handle);
     }
 
-    pub fn destroyChild(self: *const ManagedNetworkServiceBindingProtocol, handle: Handle) usize {
+    pub fn destroyChild(self: *const ManagedNetworkServiceBindingProtocol, handle: Handle) Status {
         return self._destroy_child(self, handle);
     }
 

--- a/lib/std/os/uefi/protocols/rng_protocol.zig
+++ b/lib/std/os/uefi/protocols/rng_protocol.zig
@@ -1,18 +1,19 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 
 /// Random Number Generator protocol
 pub const RNGProtocol = extern struct {
-    _get_info: extern fn (*const RNGProtocol, *usize, [*]align(8) Guid) usize,
-    _get_rng: extern fn (*const RNGProtocol, ?*align(8) const Guid, usize, [*]u8) usize,
+    _get_info: extern fn (*const RNGProtocol, *usize, [*]align(8) Guid) Status,
+    _get_rng: extern fn (*const RNGProtocol, ?*align(8) const Guid, usize, [*]u8) Status,
 
     /// Returns information about the random number generation implementation.
-    pub fn getInfo(self: *const RNGProtocol, list_size: *usize, list: [*]align(8) Guid) usize {
+    pub fn getInfo(self: *const RNGProtocol, list_size: *usize, list: [*]align(8) Guid) Status {
         return self._get_info(self, list_size, list);
     }
 
     /// Produces and returns an RNG value using either the default or specified RNG algorithm.
-    pub fn getRNG(self: *const RNGProtocol, algo: ?*align(8) const Guid, value_length: usize, value: [*]u8) usize {
+    pub fn getRNG(self: *const RNGProtocol, algo: ?*align(8) const Guid, value_length: usize, value: [*]u8) Status {
         return self._get_rng(self, algo, value_length, value);
     }
 

--- a/lib/std/os/uefi/protocols/shell_parameters_protocol.zig
+++ b/lib/std/os/uefi/protocols/shell_parameters_protocol.zig
@@ -1,0 +1,20 @@
+const uefi = @import("std").os.uefi;
+const Guid = uefi.Guid;
+const FileHandle = uefi.FileHandle;
+
+pub const ShellParametersProtocol = extern struct {
+    argv: [*][*:0]const u16,
+    argc: usize,
+    stdin: FileHandle,
+    stdout: FileHandle,
+    stderr: FileHandle,
+
+    pub const guid align(8) = Guid{
+        .time_low = 0x752f3136,
+        .time_mid = 0x4e16,
+        .time_high_and_version = 0x4fdc,
+        .clock_seq_high_and_reserved = 0xa2,
+        .clock_seq_low = 0x2a,
+        .node = [_]u8{ 0xe5, 0xf4, 0x68, 0x12, 0xf4, 0xca },
+    };
+};

--- a/lib/std/os/uefi/protocols/simple_file_system_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_file_system_protocol.zig
@@ -1,12 +1,13 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
 const FileProtocol = uefi.protocols.FileProtocol;
+const Status = uefi.Status;
 
 const SimpleFileSystemProtocol = extern struct {
     revision: u64,
-    _open_volume: extern fn (*const SimpleFileSystemProtocol, **const FileProtocol) usize,
+    _open_volume: extern fn (*const SimpleFileSystemProtocol, **const FileProtocol) Status,
 
-    pub fn openVolume(self: *const SimpleFileSystemProtocol, root: **const FileProtocol) usize {
+    pub fn openVolume(self: *const SimpleFileSystemProtocol, root: **const FileProtocol) Status {
         return self._open_volume(self, root);
     }
 

--- a/lib/std/os/uefi/protocols/simple_file_system_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_file_system_protocol.zig
@@ -3,7 +3,7 @@ const Guid = uefi.Guid;
 const FileProtocol = uefi.protocols.FileProtocol;
 const Status = uefi.Status;
 
-const SimpleFileSystemProtocol = extern struct {
+pub const SimpleFileSystemProtocol = extern struct {
     revision: u64,
     _open_volume: extern fn (*const SimpleFileSystemProtocol, **const FileProtocol) Status,
 

--- a/lib/std/os/uefi/protocols/simple_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_network_protocol.zig
@@ -1,87 +1,88 @@
 const uefi = @import("std").os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 
 pub const SimpleNetworkProtocol = extern struct {
     revision: u64,
-    _start: extern fn (*const SimpleNetworkProtocol) usize,
-    _stop: extern fn (*const SimpleNetworkProtocol) usize,
-    _initialize: extern fn (*const SimpleNetworkProtocol, usize, usize) usize,
-    _reset: extern fn (*const SimpleNetworkProtocol, bool) usize,
-    _shutdown: extern fn (*const SimpleNetworkProtocol) usize,
-    _receive_filters: extern fn (*const SimpleNetworkProtocol, SimpleNetworkReceiveFilter, SimpleNetworkReceiveFilter, bool, usize, ?[*]const MacAddress) usize,
-    _station_address: extern fn (*const SimpleNetworkProtocol, bool, ?*const MacAddress) usize,
-    _statistics: extern fn (*const SimpleNetworkProtocol, bool, ?*usize, ?*NetworkStatistics) usize,
-    _mcast_ip_to_mac: extern fn (*const SimpleNetworkProtocol, bool, *const c_void, *MacAddress) usize,
-    _nvdata: extern fn (*const SimpleNetworkProtocol, bool, usize, usize, [*]u8) usize,
-    _get_status: extern fn (*const SimpleNetworkProtocol, *SimpleNetworkInterruptStatus, ?*?[*]u8) usize,
-    _transmit: extern fn (*const SimpleNetworkProtocol, usize, usize, [*]const u8, ?*const MacAddress, ?*const MacAddress, ?*const u16) usize,
-    _receive: extern fn (*const SimpleNetworkProtocol, ?*usize, *usize, [*]u8, ?*MacAddress, ?*MacAddress, ?*u16) usize,
+    _start: extern fn (*const SimpleNetworkProtocol) Status,
+    _stop: extern fn (*const SimpleNetworkProtocol) Status,
+    _initialize: extern fn (*const SimpleNetworkProtocol, usize, usize) Status,
+    _reset: extern fn (*const SimpleNetworkProtocol, bool) Status,
+    _shutdown: extern fn (*const SimpleNetworkProtocol) Status,
+    _receive_filters: extern fn (*const SimpleNetworkProtocol, SimpleNetworkReceiveFilter, SimpleNetworkReceiveFilter, bool, usize, ?[*]const MacAddress) Status,
+    _station_address: extern fn (*const SimpleNetworkProtocol, bool, ?*const MacAddress) Status,
+    _statistics: extern fn (*const SimpleNetworkProtocol, bool, ?*usize, ?*NetworkStatistics) Status,
+    _mcast_ip_to_mac: extern fn (*const SimpleNetworkProtocol, bool, *const c_void, *MacAddress) Status,
+    _nvdata: extern fn (*const SimpleNetworkProtocol, bool, usize, usize, [*]u8) Status,
+    _get_status: extern fn (*const SimpleNetworkProtocol, *SimpleNetworkInterruptStatus, ?*?[*]u8) Status,
+    _transmit: extern fn (*const SimpleNetworkProtocol, usize, usize, [*]const u8, ?*const MacAddress, ?*const MacAddress, ?*const u16) Status,
+    _receive: extern fn (*const SimpleNetworkProtocol, ?*usize, *usize, [*]u8, ?*MacAddress, ?*MacAddress, ?*u16) Status,
     wait_for_packet: Event,
     mode: *SimpleNetworkMode,
 
     /// Changes the state of a network interface from "stopped" to "started".
-    pub fn start(self: *const SimpleNetworkProtocol) usize {
+    pub fn start(self: *const SimpleNetworkProtocol) Status {
         return self._start(self);
     }
 
     /// Changes the state of a network interface from "started" to "stopped".
-    pub fn stop(self: *const SimpleNetworkProtocol) usize {
+    pub fn stop(self: *const SimpleNetworkProtocol) Status {
         return self._stop(self);
     }
 
     /// Resets a network adapter and allocates the transmit and receive buffers required by the network interface.
-    pub fn initialize(self: *const SimpleNetworkProtocol, extra_rx_buffer_size: usize, extra_tx_buffer_size: usize) usize {
+    pub fn initialize(self: *const SimpleNetworkProtocol, extra_rx_buffer_size: usize, extra_tx_buffer_size: usize) Status {
         return self._initialize(self, extra_rx_buffer_size, extra_tx_buffer_size);
     }
 
     /// Resets a network adapter and reinitializes it with the parameters that were provided in the previous call to initialize().
-    pub fn reset(self: *const SimpleNetworkProtocol, extended_verification: bool) usize {
+    pub fn reset(self: *const SimpleNetworkProtocol, extended_verification: bool) Status {
         return self._reset(self, extended_verification);
     }
 
     /// Resets a network adapter and leaves it in a state that is safe for another driver to initialize.
-    pub fn shutdown(self: *const SimpleNetworkProtocol) usize {
+    pub fn shutdown(self: *const SimpleNetworkProtocol) Status {
         return self._shutdown(self);
     }
 
     /// Manages the multicast receive filters of a network interface.
-    pub fn receiveFilters(self: *const SimpleNetworkProtocol, enable: SimpleNetworkReceiveFilter, disable: SimpleNetworkReceiveFilter, reset_mcast_filter: bool, mcast_filter_cnt: usize, mcast_filter: ?[*]const MacAddress) usize {
+    pub fn receiveFilters(self: *const SimpleNetworkProtocol, enable: SimpleNetworkReceiveFilter, disable: SimpleNetworkReceiveFilter, reset_mcast_filter: bool, mcast_filter_cnt: usize, mcast_filter: ?[*]const MacAddress) Status {
         return self._receive_filters(self, enable, disable, reset_mcast_filter, mcast_filter_cnt, mcast_filter);
     }
 
     /// Modifies or resets the current station address, if supported.
-    pub fn stationAddress(self: *const SimpleNetworkProtocol, reset: bool, new: ?*const MacAddress) usize {
+    pub fn stationAddress(self: *const SimpleNetworkProtocol, reset: bool, new: ?*const MacAddress) Status {
         return self._station_address(self, reset, new);
     }
 
     /// Resets or collects the statistics on a network interface.
-    pub fn statistics(self: *const SimpleNetworkProtocol, reset_: bool, statistics_size: ?*usize, statistics_table: ?*NetworkStatistics) usize {
+    pub fn statistics(self: *const SimpleNetworkProtocol, reset_: bool, statistics_size: ?*usize, statistics_table: ?*NetworkStatistics) Status {
         return self._statistics(self, reset_, statistics_size, statistics_table);
     }
 
     /// Converts a multicast IP address to a multicast HW MAC address.
-    pub fn mcastIpToMac(self: *const SimpleNetworkProtocol, ipv6: bool, ip: *const c_void, mac: *MacAddress) usize {
+    pub fn mcastIpToMac(self: *const SimpleNetworkProtocol, ipv6: bool, ip: *const c_void, mac: *MacAddress) Status {
         return self._mcast_ip_to_mac(self, ipv6, ip, mac);
     }
 
     /// Performs read and write operations on the NVRAM device attached to a network interface.
-    pub fn nvdata(self: *const SimpleNetworkProtocol, read_write: bool, offset: usize, buffer_size: usize, buffer: [*]u8) usize {
+    pub fn nvdata(self: *const SimpleNetworkProtocol, read_write: bool, offset: usize, buffer_size: usize, buffer: [*]u8) Status {
         return self._nvdata(self, read_write, offset, buffer_size, buffer);
     }
 
     /// Reads the current interrupt status and recycled transmit buffer status from a network interface.
-    pub fn getStatus(self: *const SimpleNetworkProtocol, interrupt_status: *SimpleNetworkInterruptStatus, tx_buf: ?*?[*]u8) usize {
+    pub fn getStatus(self: *const SimpleNetworkProtocol, interrupt_status: *SimpleNetworkInterruptStatus, tx_buf: ?*?[*]u8) Status {
         return self._get_status(self, interrupt_status, tx_buf);
     }
 
     /// Places a packet in the transmit queue of a network interface.
-    pub fn transmit(self: *const SimpleNetworkProtocol, header_size: usize, buffer_size: usize, buffer: [*]const u8, src_addr: ?*const MacAddress, dest_addr: ?*const MacAddress, protocol: ?*const u16) usize {
+    pub fn transmit(self: *const SimpleNetworkProtocol, header_size: usize, buffer_size: usize, buffer: [*]const u8, src_addr: ?*const MacAddress, dest_addr: ?*const MacAddress, protocol: ?*const u16) Status {
         return self._transmit(self, header_size, buffer_size, buffer, src_addr, dest_addr, protocol);
     }
 
     /// Receives a packet from a network interface.
-    pub fn receive(self: *const SimpleNetworkProtocol, header_size: ?*usize, buffer_size: *usize, buffer: [*]u8, src_addr: ?*MacAddress, dest_addr: ?*MacAddress, protocol: ?*u16) usize {
+    pub fn receive(self: *const SimpleNetworkProtocol, header_size: ?*usize, buffer_size: *usize, buffer: [*]u8, src_addr: ?*MacAddress, dest_addr: ?*MacAddress, protocol: ?*u16) Status {
         return self._receive(self, header_size, buffer_size, buffer, src_addr, dest_addr, protocol);
     }
 

--- a/lib/std/os/uefi/protocols/simple_pointer_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_pointer_protocol.zig
@@ -1,21 +1,22 @@
 const uefi = @import("std").os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 
 /// Protocol for mice
 pub const SimplePointerProtocol = struct {
-    _reset: extern fn (*const SimplePointerProtocol, bool) usize,
-    _get_state: extern fn (*const SimplePointerProtocol, *SimplePointerState) usize,
+    _reset: extern fn (*const SimplePointerProtocol, bool) Status,
+    _get_state: extern fn (*const SimplePointerProtocol, *SimplePointerState) Status,
     wait_for_input: Event,
     mode: *SimplePointerMode,
 
     /// Resets the pointer device hardware.
-    pub fn reset(self: *const SimplePointerProtocol, verify: bool) usize {
+    pub fn reset(self: *const SimplePointerProtocol, verify: bool) Status {
         return self._reset(self, verify);
     }
 
     /// Retrieves the current state of a pointer device.
-    pub fn getState(self: *const SimplePointerProtocol, state: *SimplePointerState) usize {
+    pub fn getState(self: *const SimplePointerProtocol, state: *SimplePointerState) Status {
         return self._get_state(self, state);
     }
 

--- a/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
@@ -1,38 +1,39 @@
 const uefi = @import("std").os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 
 /// Character input devices, e.g. Keyboard
 pub const SimpleTextInputExProtocol = extern struct {
-    _reset: extern fn (*const SimpleTextInputExProtocol, bool) usize,
-    _read_key_stroke_ex: extern fn (*const SimpleTextInputExProtocol, *KeyData) usize,
+    _reset: extern fn (*const SimpleTextInputExProtocol, bool) Status,
+    _read_key_stroke_ex: extern fn (*const SimpleTextInputExProtocol, *KeyData) Status,
     wait_for_key_ex: Event,
-    _set_state: extern fn (*const SimpleTextInputExProtocol, *const u8) usize,
-    _register_key_notify: extern fn (*const SimpleTextInputExProtocol, *const KeyData, extern fn (*const KeyData) usize, **c_void) usize,
-    _unregister_key_notify: extern fn (*const SimpleTextInputExProtocol, *const c_void) usize,
+    _set_state: extern fn (*const SimpleTextInputExProtocol, *const u8) Status,
+    _register_key_notify: extern fn (*const SimpleTextInputExProtocol, *const KeyData, extern fn (*const KeyData) usize, **c_void) Status,
+    _unregister_key_notify: extern fn (*const SimpleTextInputExProtocol, *const c_void) Status,
 
     /// Resets the input device hardware.
-    pub fn reset(self: *const SimpleTextInputExProtocol, verify: bool) usize {
+    pub fn reset(self: *const SimpleTextInputExProtocol, verify: bool) Status {
         return self._reset(self, verify);
     }
 
     /// Reads the next keystroke from the input device.
-    pub fn readKeyStrokeEx(self: *const SimpleTextInputExProtocol, key_data: *KeyData) usize {
+    pub fn readKeyStrokeEx(self: *const SimpleTextInputExProtocol, key_data: *KeyData) Status {
         return self._read_key_stroke_ex(self, key_data);
     }
 
     /// Set certain state for the input device.
-    pub fn setState(self: *const SimpleTextInputExProtocol, state: *const u8) usize {
+    pub fn setState(self: *const SimpleTextInputExProtocol, state: *const u8) Status {
         return self._set_state(self, state);
     }
 
     /// Register a notification function for a particular keystroke for the input device.
-    pub fn registerKeyNotify(self: *const SimpleTextInputExProtocol, key_data: *const KeyData, notify: extern fn (*const KeyData) usize, handle: **c_void) usize {
+    pub fn registerKeyNotify(self: *const SimpleTextInputExProtocol, key_data: *const KeyData, notify: extern fn (*const KeyData) usize, handle: **c_void) Status {
         return self._register_key_notify(self, key_data, notify, handle);
     }
 
     /// Remove the notification that was previously registered.
-    pub fn unregisterKeyNotify(self: *const SimpleTextInputExProtocol, handle: *const c_void) usize {
+    pub fn unregisterKeyNotify(self: *const SimpleTextInputExProtocol, handle: *const c_void) Status {
         return self._unregister_key_notify(self, handle);
     }
 

--- a/lib/std/os/uefi/protocols/simple_text_input_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_input_protocol.zig
@@ -2,20 +2,21 @@ const uefi = @import("std").os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const InputKey = uefi.protocols.InputKey;
+const Status = uefi.Status;
 
 /// Character input devices, e.g. Keyboard
 pub const SimpleTextInputProtocol = extern struct {
     _reset: extern fn (*const SimpleTextInputProtocol, bool) usize,
-    _read_key_stroke: extern fn (*const SimpleTextInputProtocol, *InputKey) usize,
+    _read_key_stroke: extern fn (*const SimpleTextInputProtocol, *InputKey) Status,
     wait_for_key: Event,
 
     /// Resets the input device hardware.
-    pub fn reset(self: *const SimpleTextInputProtocol, verify: bool) usize {
+    pub fn reset(self: *const SimpleTextInputProtocol, verify: bool) Status {
         return self._reset(self, verify);
     }
 
     /// Reads the next keystroke from the input device.
-    pub fn readKeyStroke(self: *const SimpleTextInputProtocol, input_key: *InputKey) usize {
+    pub fn readKeyStroke(self: *const SimpleTextInputProtocol, input_key: *InputKey) Status {
         return self._read_key_stroke(self, input_key);
     }
 

--- a/lib/std/os/uefi/protocols/simple_text_output_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_output_protocol.zig
@@ -1,61 +1,62 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 
 /// Character output devices
 pub const SimpleTextOutputProtocol = extern struct {
-    _reset: extern fn (*const SimpleTextOutputProtocol, bool) usize,
-    _output_string: extern fn (*const SimpleTextOutputProtocol, [*:0]const u16) usize,
-    _test_string: extern fn (*const SimpleTextOutputProtocol, [*:0]const u16) usize,
-    _query_mode: extern fn (*const SimpleTextOutputProtocol, usize, *usize, *usize) usize,
-    _set_mode: extern fn (*const SimpleTextOutputProtocol, usize) usize,
-    _set_attribute: extern fn (*const SimpleTextOutputProtocol, usize) usize,
-    _clear_screen: extern fn (*const SimpleTextOutputProtocol) usize,
-    _set_cursor_position: extern fn (*const SimpleTextOutputProtocol, usize, usize) usize,
-    _enable_cursor: extern fn (*const SimpleTextOutputProtocol, bool) usize,
+    _reset: extern fn (*const SimpleTextOutputProtocol, bool) Status,
+    _output_string: extern fn (*const SimpleTextOutputProtocol, [*:0]const u16) Status,
+    _test_string: extern fn (*const SimpleTextOutputProtocol, [*:0]const u16) Status,
+    _query_mode: extern fn (*const SimpleTextOutputProtocol, usize, *usize, *usize) Status,
+    _set_mode: extern fn (*const SimpleTextOutputProtocol, usize) Status,
+    _set_attribute: extern fn (*const SimpleTextOutputProtocol, usize) Status,
+    _clear_screen: extern fn (*const SimpleTextOutputProtocol) Status,
+    _set_cursor_position: extern fn (*const SimpleTextOutputProtocol, usize, usize) Status,
+    _enable_cursor: extern fn (*const SimpleTextOutputProtocol, bool) Status,
     mode: *SimpleTextOutputMode,
 
     /// Resets the text output device hardware.
-    pub fn reset(self: *const SimpleTextOutputProtocol, verify: bool) usize {
+    pub fn reset(self: *const SimpleTextOutputProtocol, verify: bool) Status {
         return self._reset(self, verify);
     }
 
     /// Writes a string to the output device.
-    pub fn outputString(self: *const SimpleTextOutputProtocol, msg: [*:0]const u16) usize {
+    pub fn outputString(self: *const SimpleTextOutputProtocol, msg: [*:0]const u16) Status {
         return self._output_string(self, msg);
     }
 
     /// Verifies that all characters in a string can be output to the target device.
-    pub fn testString(self: *const SimpleTextOutputProtocol, msg: [*:0]const u16) usize {
+    pub fn testString(self: *const SimpleTextOutputProtocol, msg: [*:0]const u16) Status {
         return self._test_string(self, msg);
     }
 
     /// Returns information for an available text mode that the output device(s) supports.
-    pub fn queryMode(self: *const SimpleTextOutputProtocol, mode_number: usize, columns: *usize, rows: *usize) usize {
+    pub fn queryMode(self: *const SimpleTextOutputProtocol, mode_number: usize, columns: *usize, rows: *usize) Status {
         return self._query_mode(self, mode_number, columns, rows);
     }
 
     /// Sets the output device(s) to a specified mode.
-    pub fn setMode(self: *const SimpleTextOutputProtocol, mode_number: usize) usize {
+    pub fn setMode(self: *const SimpleTextOutputProtocol, mode_number: usize) Status {
         return self._set_mode(self, mode_number);
     }
 
     /// Sets the background and foreground colors for the outputString() and clearScreen() functions.
-    pub fn setAttribute(self: *const SimpleTextOutputProtocol, attribute: usize) usize {
+    pub fn setAttribute(self: *const SimpleTextOutputProtocol, attribute: usize) Status {
         return self._set_attribute(self, attribute);
     }
 
     /// Clears the output device(s) display to the currently selected background color.
-    pub fn clearScreen(self: *const SimpleTextOutputProtocol) usize {
+    pub fn clearScreen(self: *const SimpleTextOutputProtocol) Status {
         return self._clear_screen(self);
     }
 
     /// Sets the current coordinates of the cursor position.
-    pub fn setCursorPosition(self: *const SimpleTextOutputProtocol, column: usize, row: usize) usize {
+    pub fn setCursorPosition(self: *const SimpleTextOutputProtocol, column: usize, row: usize) Status {
         return self._set_cursor_position(self, column, row);
     }
 
     /// Makes the cursor visible or invisible.
-    pub fn enableCursor(self: *const SimpleTextOutputProtocol, visible: bool) usize {
+    pub fn enableCursor(self: *const SimpleTextOutputProtocol, visible: bool) Status {
         return self._enable_cursor(self, visible);
     }
 

--- a/lib/std/os/uefi/protocols/udp6_protocol.zig
+++ b/lib/std/os/uefi/protocols/udp6_protocol.zig
@@ -1,6 +1,7 @@
 const uefi = @import("std").os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;
+const Status = uefi.Status;
 const Time = uefi.Time;
 const Ip6ModeData = uefi.protocols.Ip6ModeData;
 const Ip6Address = uefi.protocols.Ip6Address;
@@ -8,39 +9,39 @@ const ManagedNetworkConfigData = uefi.protocols.ManagedNetworkConfigData;
 const SimpleNetworkMode = uefi.protocols.SimpleNetworkMode;
 
 pub const Udp6Protocol = extern struct {
-    _get_mode_data: extern fn (*const Udp6Protocol, ?*Udp6ConfigData, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) usize,
-    _configure: extern fn (*const Udp6Protocol, ?*const Udp6ConfigData) usize,
-    _groups: extern fn (*const Udp6Protocol, bool, ?*const Ip6Address) usize,
-    _transmit: extern fn (*const Udp6Protocol, *Udp6CompletionToken) usize,
-    _receive: extern fn (*const Udp6Protocol, *Udp6CompletionToken) usize,
-    _cancel: extern fn (*const Udp6Protocol, ?*Udp6CompletionToken) usize,
-    _poll: extern fn (*const Udp6Protocol) usize,
+    _get_mode_data: extern fn (*const Udp6Protocol, ?*Udp6ConfigData, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) Status,
+    _configure: extern fn (*const Udp6Protocol, ?*const Udp6ConfigData) Status,
+    _groups: extern fn (*const Udp6Protocol, bool, ?*const Ip6Address) Status,
+    _transmit: extern fn (*const Udp6Protocol, *Udp6CompletionToken) Status,
+    _receive: extern fn (*const Udp6Protocol, *Udp6CompletionToken) Status,
+    _cancel: extern fn (*const Udp6Protocol, ?*Udp6CompletionToken) Status,
+    _poll: extern fn (*const Udp6Protocol) Status,
 
-    pub fn getModeData(self: *const Udp6Protocol, udp6_config_data: ?*Udp6ConfigData, ip6_mode_data: ?*Ip6ModeData, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) usize {
+    pub fn getModeData(self: *const Udp6Protocol, udp6_config_data: ?*Udp6ConfigData, ip6_mode_data: ?*Ip6ModeData, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {
         return self._get_mode_data(self, udp6_config_data, ip6_mode_data, mnp_config_data, snp_mode_data);
     }
 
-    pub fn configure(self: *const Udp6Protocol, udp6_config_data: ?*const Udp6ConfigData) usize {
+    pub fn configure(self: *const Udp6Protocol, udp6_config_data: ?*const Udp6ConfigData) Status {
         return self._configure(self, udp6_config_data);
     }
 
-    pub fn groups(self: *const Udp6Protocol, join_flag: bool, multicast_address: ?*const Ip6Address) usize {
+    pub fn groups(self: *const Udp6Protocol, join_flag: bool, multicast_address: ?*const Ip6Address) Status {
         return self._groups(self, join_flag, multicast_address);
     }
 
-    pub fn transmit(self: *const Udp6Protocol, token: *Udp6CompletionToken) usize {
+    pub fn transmit(self: *const Udp6Protocol, token: *Udp6CompletionToken) Status {
         return self._transmit(self, token);
     }
 
-    pub fn receive(self: *const Udp6Protocol, token: *Udp6CompletionToken) usize {
+    pub fn receive(self: *const Udp6Protocol, token: *Udp6CompletionToken) Status {
         return self._receive(self, token);
     }
 
-    pub fn cancel(self: *const Udp6Protocol, token: ?*Udp6CompletionToken) usize {
+    pub fn cancel(self: *const Udp6Protocol, token: ?*Udp6CompletionToken) Status {
         return self._cancel(self, token);
     }
 
-    pub fn poll(self: *const Udp6Protocol) usize {
+    pub fn poll(self: *const Udp6Protocol) Status {
         return self._poll(self);
     }
 
@@ -70,7 +71,7 @@ pub const Udp6ConfigData = extern struct {
 
 pub const Udp6CompletionToken = extern struct {
     event: Event,
-    status: usize,
+    Status: usize,
     packet: extern union {
         RxData: *Udp6ReceiveData,
         TxData: *Udp6TransmitData,

--- a/lib/std/os/uefi/protocols/udp6_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/udp6_service_binding_protocol.zig
@@ -1,16 +1,17 @@
 const uefi = @import("std").os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;
+const Status = uefi.Status;
 
 pub const Udp6ServiceBindingProtocol = extern struct {
-    _create_child: extern fn (*const Udp6ServiceBindingProtocol, *?Handle) usize,
-    _destroy_child: extern fn (*const Udp6ServiceBindingProtocol, Handle) usize,
+    _create_child: extern fn (*const Udp6ServiceBindingProtocol, *?Handle) Status,
+    _destroy_child: extern fn (*const Udp6ServiceBindingProtocol, Handle) Status,
 
-    pub fn createChild(self: *const Udp6ServiceBindingProtocol, handle: *?Handle) usize {
+    pub fn createChild(self: *const Udp6ServiceBindingProtocol, handle: *?Handle) Status {
         return self._create_child(self, handle);
     }
 
-    pub fn destroyChild(self: *const Udp6ServiceBindingProtocol, handle: Handle) usize {
+    pub fn destroyChild(self: *const Udp6ServiceBindingProtocol, handle: Handle) Status {
         return self._destroy_child(self, handle);
     }
 

--- a/lib/std/os/uefi/status.zig
+++ b/lib/std/os/uefi/status.zig
@@ -1,124 +1,142 @@
 const high_bit = 1 << @typeInfo(usize).Int.bits - 1;
 
-/// The operation completed successfully.
-pub const success: usize = 0;
+pub const Status = extern enum(usize) {
+    /// The operation completed successfully.
+    Success = 0,
 
-/// The image failed to load.
-pub const load_error: usize = high_bit | 1;
+    /// The image failed to load.
+    LoadError = high_bit | 1,
 
-/// A parameter was incorrect.
-pub const invalid_parameter: usize = high_bit | 2;
+    /// A parameter was incorrect.
+    InvalidParameter = high_bit | 2,
 
-/// The operation is not supported.
-pub const unsupported: usize = high_bit | 3;
+    /// The operation is not supported.
+    Unsupported = high_bit | 3,
 
-/// The buffer was not the proper size for the request.
-pub const bad_buffer_size: usize = high_bit | 4;
+    /// The buffer was not the proper size for the request.
+    BadBufferSize = high_bit | 4,
 
-/// The buffer is not large enough to hold the requested data. The required buffer size is returned in the appropriate parameter when this error occurs.
-pub const buffer_too_small: usize = high_bit | 5;
+    /// The buffer is not large enough to hold the requested data. The required buffer size is returned in the appropriate parameter when this error occurs.
+    BufferTooSmall = high_bit | 5,
 
-/// There is no data pending upon return.
-pub const not_ready: usize = high_bit | 6;
+    /// There is no data pending upon return.
+    NotReady = high_bit | 6,
 
-/// The physical device reported an error while attempting the operation.
-pub const device_error: usize = high_bit | 7;
+    /// The physical device reported an error while attempting the operation.
+    DeviceError = high_bit | 7,
 
-/// The device cannot be written to.
-pub const write_protected: usize = high_bit | 8;
+    /// The device cannot be written to.
+    WriteProtected = high_bit | 8,
 
-/// A resource has run out.
-pub const out_of_resources: usize = high_bit | 9;
+    /// A resource has run out.
+    OutOfResources = high_bit | 9,
 
-/// An inconstancy was detected on the file system causing the operating to fail.
-pub const volume_corrupted: usize = high_bit | 10;
+    /// An inconstancy was detected on the file system causing the operating to fail.
+    VolumeCorrupted = high_bit | 10,
 
-/// There is no more space on the file system.
-pub const volume_full: usize = high_bit | 11;
+    /// There is no more space on the file system.
+    VolumeFull = high_bit | 11,
 
-/// The device does not contain any medium to perform the operation.
-pub const no_media: usize = high_bit | 12;
+    /// The device does not contain any medium to perform the operation.
+    NoMedia = high_bit | 12,
 
-/// The medium in the device has changed since the last access.
-pub const media_changed: usize = high_bit | 13;
+    /// The medium in the device has changed since the last access.
+    MediaChanged = high_bit | 13,
 
-/// The item was not found.
-pub const not_found: usize = high_bit | 14;
+    /// The item was not found.
+    NotFound = high_bit | 14,
 
-/// Access was denied.
-pub const access_denied: usize = high_bit | 15;
+    /// Access was denied.
+    AccessDenied = high_bit | 15,
 
-/// The server was not found or did not respond to the request.
-pub const no_response: usize = high_bit | 16;
+    /// The server was not found or did not respond to the request.
+    NoResponse = high_bit | 16,
 
-/// A mapping to a device does not exist.
-pub const no_mapping: usize = high_bit | 17;
+    /// A mapping to a device does not exist.
+    NoMapping = high_bit | 17,
 
-/// The timeout time expired.
-pub const timeout: usize = high_bit | 18;
+    /// The timeout time expired.
+    Timeout = high_bit | 18,
 
-/// The protocol has not been started.
-pub const not_started: usize = high_bit | 19;
+    /// The protocol has not been started.
+    NotStarted = high_bit | 19,
 
-/// The protocol has already been started.
-pub const already_started: usize = high_bit | 20;
+    /// The protocol has already been started.
+    AlreadyStarted = high_bit | 20,
 
-/// The operation was aborted.
-pub const aborted: usize = high_bit | 21;
+    /// The operation was aborted.
+    Aborted = high_bit | 21,
 
-/// An ICMP error occurred during the network operation.
-pub const icmp_error: usize = high_bit | 22;
+    /// An ICMP error occurred during the network operation.
+    IcmpError = high_bit | 22,
 
-/// A TFTP error occurred during the network operation.
-pub const tftp_error: usize = high_bit | 23;
+    /// A TFTP error occurred during the network operation.
+    TftpError = high_bit | 23,
 
-/// A protocol error occurred during the network operation.
-pub const protocol_error: usize = high_bit | 24;
+    /// A protocol error occurred during the network operation.
+    ProtocolError = high_bit | 24,
 
-/// The function encountered an internal version that was incompatible with a version requested by the caller.
-pub const incompatible_version: usize = high_bit | 25;
+    /// The function encountered an internal version that was incompatible with a version requested by the caller.
+    IncompatibleVersion = high_bit | 25,
 
-/// The function was not performed due to a security violation.
-pub const security_violation: usize = high_bit | 26;
+    /// The function was not performed due to a security violation.
+    SecurityViolation = high_bit | 26,
 
-/// A CRC error was detected.
-pub const crc_error: usize = high_bit | 27;
+    /// A CRC error was detected.
+    CrcError = high_bit | 27,
 
-/// Beginning or end of media was reached
-pub const end_of_media: usize = high_bit | 28;
+    /// Beginning or end of media was reached
+    EndOfMedia = high_bit | 28,
 
-/// The end of the file was reached.
-pub const end_of_file: usize = high_bit | 31;
+    /// The end of the file was reached.
+    EndOfFile = high_bit | 31,
 
-/// The language specified was invalid.
-pub const invalid_language: usize = high_bit | 32;
+    /// The language specified was invalid.
+    InvalidLanguage = high_bit | 32,
 
-/// The security status of the data is unknown or compromised and the data must be updated or replaced to restore a valid security status.
-pub const compromised_data: usize = high_bit | 33;
+    /// The security status of the data is unknown or compromised and the data must be updated or replaced to restore a valid security status.
+    CompromisedData = high_bit | 33,
 
-/// There is an address conflict address allocation
-pub const ip_address_conflict: usize = high_bit | 34;
+    /// There is an address conflict address allocation
+    IpAddressConflict = high_bit | 34,
 
-/// A HTTP error occurred during the network operation.
-pub const http_error: usize = high_bit | 35;
+    /// A HTTP error occurred during the network operation.
+    HttpError = high_bit | 35,
 
-/// The string contained one or more characters that the device could not render and were skipped.
-pub const warn_unknown_glyph: usize = 1;
+    NetworkUnreachable = high_bit | 100,
 
-/// The handle was closed, but the file was not deleted.
-pub const warn_delete_failure: usize = 2;
+    HostUnreachable = high_bit | 101,
 
-/// The handle was closed, but the data to the file was not flushed properly.
-pub const warn_write_failure: usize = 3;
+    ProtocolUnreachable = high_bit | 102,
 
-/// The resulting buffer was too small, and the data was truncated to the buffer size.
-pub const warn_buffer_too_small: usize = 4;
+    PortUnreachable = high_bit | 103,
 
-/// The data has not been updated within the timeframe set by localpolicy for this type of data.
-pub const warn_stale_data: usize = 5;
+    ConnectionFin = high_bit | 104,
 
-/// The resulting buffer contains UEFI-compliant file system.
-pub const warn_file_system: usize = 6;
+    ConnectionReset = high_bit | 105,
 
-/// The operation will be processed across a system reset.
-pub const warn_reset_required: usize = 7;
+    ConnectionRefused = high_bit | 106,
+
+    /// The string contained one or more characters that the device could not render and were skipped.
+    WarnUnknownGlyph = 1,
+
+    /// The handle was closed, but the file was not deleted.
+    WarnDeleteFailure = 2,
+
+    /// The handle was closed, but the data to the file was not flushed properly.
+    WarnWriteFailure = 3,
+
+    /// The resulting buffer was too small, and the data was truncated to the buffer size.
+    WarnBufferTooSmall = 4,
+
+    /// The data has not been updated within the timeframe set by localpolicy for this type of data.
+    WarnStaleData = 5,
+
+    /// The resulting buffer contains UEFI-compliant file system.
+    WarnFileSystem = 6,
+
+    /// The operation will be processed across a system reset.
+    WarnResetRequired = 7,
+
+    _,
+};

--- a/lib/std/os/uefi/tables.zig
+++ b/lib/std/os/uefi/tables.zig
@@ -1,3 +1,4 @@
+pub const AllocateType = @import("tables/boot_services.zig").AllocateType;
 pub const BootServices = @import("tables/boot_services.zig").BootServices;
 pub const ConfigurationTable = @import("tables/configuration_table.zig").ConfigurationTable;
 pub const global_variable align(8) = @import("tables/runtime_services.zig").global_variable;

--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -2,6 +2,7 @@ const uefi = @import("std").os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const Handle = uefi.Handle;
+const Status = uefi.Status;
 const TableHeader = uefi.tables.TableHeader;
 const DevicePathProtocol = uefi.protocols.DevicePathProtocol;
 
@@ -26,105 +27,105 @@ pub const BootServices = extern struct {
     restoreTpl: extern fn (usize) void,
 
     /// Allocates memory pages from the system.
-    allocatePages: extern fn (AllocateType, MemoryType, usize, *[*]align(4096) u8) usize,
+    allocatePages: extern fn (AllocateType, MemoryType, usize, *[*]align(4096) u8) Status,
 
     /// Frees memory pages.
-    freePages: extern fn ([*]align(4096) u8, usize) usize,
+    freePages: extern fn ([*]align(4096) u8, usize) Status,
 
     /// Returns the current memory map.
-    getMemoryMap: extern fn (*usize, [*]MemoryDescriptor, *usize, *usize, *u32) usize,
+    getMemoryMap: extern fn (*usize, [*]MemoryDescriptor, *usize, *usize, *u32) Status,
 
     /// Allocates pool memory.
-    allocatePool: extern fn (MemoryType, usize, *[*]align(8) u8) usize,
+    allocatePool: extern fn (MemoryType, usize, *[*]align(8) u8) Status,
 
     /// Returns pool memory to the system.
-    freePool: extern fn ([*]align(8) u8) usize,
+    freePool: extern fn ([*]align(8) u8) Status,
 
     /// Creates an event.
-    createEvent: extern fn (u32, usize, ?extern fn (Event, ?*c_void) void, ?*const c_void, *Event) usize,
+    createEvent: extern fn (u32, usize, ?extern fn (Event, ?*c_void) void, ?*const c_void, *Event) Status,
 
     /// Sets the type of timer and the trigger time for a timer event.
-    setTimer: extern fn (Event, TimerDelay, u64) usize,
+    setTimer: extern fn (Event, TimerDelay, u64) Status,
 
     /// Stops execution until an event is signaled.
-    waitForEvent: extern fn (usize, [*]const Event, *usize) usize,
+    waitForEvent: extern fn (usize, [*]const Event, *usize) Status,
 
     /// Signals an event.
-    signalEvent: extern fn (Event) usize,
+    signalEvent: extern fn (Event) Status,
 
     /// Closes an event.
-    closeEvent: extern fn (Event) usize,
+    closeEvent: extern fn (Event) Status,
 
     /// Checks whether an event is in the signaled state.
-    checkEvent: extern fn (Event) usize,
+    checkEvent: extern fn (Event) Status,
 
-    installProtocolInterface: usize, // TODO
-    reinstallProtocolInterface: usize, // TODO
-    uninstallProtocolInterface: usize, // TODO
+    installProtocolInterface: Status, // TODO
+    reinstallProtocolInterface: Status, // TODO
+    uninstallProtocolInterface: Status, // TODO
 
     /// Queries a handle to determine if it supports a specified protocol.
-    handleProtocol: extern fn (Handle, *align(8) const Guid, *?*c_void) usize,
+    handleProtocol: extern fn (Handle, *align(8) const Guid, *?*c_void) Status,
 
     reserved: *c_void,
 
-    registerProtocolNotify: usize, // TODO
+    registerProtocolNotify: Status, // TODO
 
     /// Returns an array of handles that support a specified protocol.
-    locateHandle: extern fn (LocateSearchType, ?*align(8) const Guid, ?*const c_void, *usize, [*]Handle) usize,
+    locateHandle: extern fn (LocateSearchType, ?*align(8) const Guid, ?*const c_void, *usize, [*]Handle) Status,
 
-    locateDevicePath: usize, // TODO
-    installConfigurationTable: usize, // TODO
+    locateDevicePath: Status, // TODO
+    installConfigurationTable: Status, // TODO
 
     /// Loads an EFI image into memory.
-    loadImage: extern fn (bool, Handle, ?*const DevicePathProtocol, ?[*]const u8, usize, *?Handle) usize,
+    loadImage: extern fn (bool, Handle, ?*const DevicePathProtocol, ?[*]const u8, usize, *?Handle) Status,
 
     /// Transfers control to a loaded image's entry point.
-    startImage: extern fn (Handle, ?*usize, ?*[*]u16) usize,
+    startImage: extern fn (Handle, ?*usize, ?*[*]u16) Status,
 
     /// Terminates a loaded EFI image and returns control to boot services.
-    exit: extern fn (Handle, usize, usize, ?*const c_void) usize,
+    exit: extern fn (Handle, Status, usize, ?*const c_void) Status,
 
     /// Unloads an image.
-    unloadImage: extern fn (Handle) usize,
+    unloadImage: extern fn (Handle) Status,
 
     /// Terminates all boot services.
-    exitBootServices: extern fn (Handle, usize) usize,
+    exitBootServices: extern fn (Handle, usize) Status,
 
     /// Returns a monotonically increasing count for the platform.
-    getNextMonotonicCount: extern fn (*u64) usize,
+    getNextMonotonicCount: extern fn (*u64) Status,
 
     /// Induces a fine-grained stall.
-    stall: extern fn (usize) usize,
+    stall: extern fn (usize) Status,
 
     /// Sets the system's watchdog timer.
-    setWatchdogTimer: extern fn (usize, u64, usize, ?[*]const u16) usize,
+    setWatchdogTimer: extern fn (usize, u64, usize, ?[*]const u16) Status,
 
-    connectController: usize, // TODO
-    disconnectController: usize, // TODO
+    connectController: Status, // TODO
+    disconnectController: Status, // TODO
 
     /// Queries a handle to determine if it supports a specified protocol.
-    openProtocol: extern fn (Handle, *align(8) const Guid, *?*c_void, ?Handle, ?Handle, OpenProtocolAttributes) usize,
+    openProtocol: extern fn (Handle, *align(8) const Guid, *?*c_void, ?Handle, ?Handle, OpenProtocolAttributes) Status,
 
     /// Closes a protocol on a handle that was opened using openProtocol().
-    closeProtocol: extern fn (Handle, *align(8) const Guid, Handle, ?Handle) usize,
+    closeProtocol: extern fn (Handle, *align(8) const Guid, Handle, ?Handle) Status,
 
     /// Retrieves the list of agents that currently have a protocol interface opened.
-    openProtocolInformation: extern fn (Handle, *align(8) const Guid, *[*]ProtocolInformationEntry, *usize) usize,
+    openProtocolInformation: extern fn (Handle, *align(8) const Guid, *[*]ProtocolInformationEntry, *usize) Status,
 
     /// Retrieves the list of protocol interface GUIDs that are installed on a handle in a buffer allocated from pool.
-    protocolsPerHandle: extern fn (Handle, *[*]*align(8) const Guid, *usize) usize,
+    protocolsPerHandle: extern fn (Handle, *[*]*align(8) const Guid, *usize) Status,
 
     /// Returns an array of handles that support the requested protocol in a buffer allocated from pool.
-    locateHandleBuffer: extern fn (LocateSearchType, ?*align(8) const Guid, ?*const c_void, *usize, *[*]Handle) usize,
+    locateHandleBuffer: extern fn (LocateSearchType, ?*align(8) const Guid, ?*const c_void, *usize, *[*]Handle) Status,
 
     /// Returns the first protocol instance that matches the given protocol.
-    locateProtocol: extern fn (*align(8) const Guid, ?*const c_void, *?*c_void) usize,
+    locateProtocol: extern fn (*align(8) const Guid, ?*const c_void, *?*c_void) Status,
 
-    installMultipleProtocolInterfaces: usize, // TODO
-    uninstallMultipleProtocolInterfaces: usize, // TODO
+    installMultipleProtocolInterfaces: Status, // TODO
+    uninstallMultipleProtocolInterfaces: Status, // TODO
 
     /// Computes and returns a 32-bit CRC for a data buffer.
-    calculateCrc32: extern fn ([*]const u8, usize, *u32) usize,
+    calculateCrc32: extern fn ([*]const u8, usize, *u32) Status,
 
     /// Copies the contents of one buffer to another buffer
     copyMem: extern fn ([*]u8, [*]const u8, usize) void,
@@ -132,7 +133,7 @@ pub const BootServices = extern struct {
     /// Fills a buffer with a specified value
     setMem: extern fn ([*]u8, usize, u8) void,
 
-    createEventEx: usize, // TODO
+    createEventEx: Status, // TODO
 
     pub const signature: u64 = 0x56524553544f4f42;
 

--- a/lib/std/os/uefi/tables/runtime_services.zig
+++ b/lib/std/os/uefi/tables/runtime_services.zig
@@ -3,6 +3,7 @@ const Guid = uefi.Guid;
 const TableHeader = uefi.tables.TableHeader;
 const Time = uefi.Time;
 const TimeCapabilities = uefi.TimeCapabilities;
+const Status = uefi.Status;
 
 /// Runtime services are provided by the firmware before and after exitBootServices has been called.
 ///
@@ -16,31 +17,31 @@ pub const RuntimeServices = extern struct {
     hdr: TableHeader,
 
     /// Returns the current time and date information, and the time-keeping capabilities of the hardware platform.
-    getTime: extern fn (*uefi.Time, ?*TimeCapabilities) usize,
+    getTime: extern fn (*uefi.Time, ?*TimeCapabilities) Status,
 
-    setTime: usize, // TODO
-    getWakeupTime: usize, // TODO
-    setWakeupTime: usize, // TODO
-    setVirtualAddressMap: usize, // TODO
-    convertPointer: usize, // TODO
+    setTime: Status, // TODO
+    getWakeupTime: Status, // TODO
+    setWakeupTime: Status, // TODO
+    setVirtualAddressMap: Status, // TODO
+    convertPointer: Status, // TODO
 
     /// Returns the value of a variable.
-    getVariable: extern fn ([*:0]const u16, *align(8) const Guid, ?*u32, *usize, ?*c_void) usize,
+    getVariable: extern fn ([*:0]const u16, *align(8) const Guid, ?*u32, *usize, ?*c_void) Status,
 
     /// Enumerates the current variable names.
-    getNextVariableName: extern fn (*usize, [*:0]u16, *align(8) Guid) usize,
+    getNextVariableName: extern fn (*usize, [*:0]u16, *align(8) Guid) Status,
 
     /// Sets the value of a variable.
-    setVariable: extern fn ([*:0]const u16, *align(8) const Guid, u32, usize, *c_void) usize,
+    setVariable: extern fn ([*:0]const u16, *align(8) const Guid, u32, usize, *c_void) Status,
 
-    getNextHighMonotonicCount: usize, // TODO
+    getNextHighMonotonicCount: Status, // TODO
 
     /// Resets the entire platform.
-    resetSystem: extern fn (ResetType, usize, usize, ?*const c_void) noreturn,
+    resetSystem: extern fn (ResetType, Status, usize, ?*const c_void) noreturn,
 
-    updateCapsule: usize, // TODO
-    queryCapsuleCapabilities: usize, // TODO
-    queryVariableInfo: usize, // TODO
+    updateCapsule: Status, // TODO
+    queryCapsuleCapabilities: Status, // TODO
+    queryVariableInfo: Status, // TODO
 
     pub const signature: u64 = 0x56524553544e5552;
 };

--- a/lib/std/os/uefi/tables/runtime_services.zig
+++ b/lib/std/os/uefi/tables/runtime_services.zig
@@ -28,7 +28,7 @@ pub const RuntimeServices = extern struct {
     getVariable: extern fn ([*:0]const u16, *align(8) const Guid, ?*u32, *usize, ?*c_void) usize,
 
     /// Enumerates the current variable names.
-    getNextVariableName: extern fn (*usize, [*]u16, *align(8) Guid) usize,
+    getNextVariableName: extern fn (*usize, [*:0]u16, *align(8) Guid) usize,
 
     /// Sets the value of a variable.
     setVariable: extern fn ([*:0]const u16, *align(8) const Guid, u32, usize, *c_void) usize,


### PR DESCRIPTION
- Various function signatures added or updated:
  - BootServices: raiseTpl, restoreTpl, allocatePages, freePages, allocatePool, locateHandle, getNextMonotonicCount, protocolsPerHandle, calculateCrc32, copyMem, setMem
  - RuntimeServices: getNextVariableName
- Added shell parameters protocol
- Improvements to loaded image protocol, device path protocol, file protocol
- Switched all Statuses to a new non-exhaustive enum uefi.Status.

cc @Heppokoyuki