### PR TITLE
zig build system: correctly handle multiple output artifacts

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -106,6 +106,7 @@ pub extern "c" fn mkdir(path: [*:0]const u8, mode: c_uint) c_int;
 pub extern "c" fn mkdirat(dirfd: fd_t, path: [*:0]const u8, mode: u32) c_int;
 pub extern "c" fn symlink(existing: [*:0]const u8, new: [*:0]const u8) c_int;
 pub extern "c" fn rename(old: [*:0]const u8, new: [*:0]const u8) c_int;
+pub extern "c" fn renameat(olddirfd: fd_t, old: [*:0]const u8, newdirfd: fd_t, new: [*:0]const u8) c_int;
 pub extern "c" fn chdir(path: [*:0]const u8) c_int;
 pub extern "c" fn fchdir(fd: fd_t) c_int;
 pub extern "c" fn execve(path: [*:0]const u8, argv: [*:null]const ?[*:0]const u8, envp: [*:null]const ?[*:0]const u8) c_int;

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -567,12 +567,20 @@ test "span" {
 
 /// Takes a pointer to an array, an array, a sentinel-terminated pointer,
 /// or a slice, and returns the length.
+/// In the case of a sentinel-terminated array, it scans the array
+/// for a sentinel and uses that for the length, rather than using the array length.
 pub fn len(ptr: var) usize {
     return switch (@typeInfo(@TypeOf(ptr))) {
-        .Array => |info| info.len,
+        .Array => |info| if (info.sentinel) |sentinel|
+            indexOfSentinel(info.child, sentinel, &ptr)
+        else
+            info.len,
         .Pointer => |info| switch (info.size) {
             .One => switch (@typeInfo(info.child)) {
-                .Array => |x| x.len,
+                .Array => |x| if (x.sentinel) |sentinel|
+                    indexOfSentinel(x.child, sentinel, ptr)
+                else
+                    ptr.len,
                 else => @compileError("invalid type given to std.mem.length"),
             },
             .Many => if (info.sentinel) |sentinel|
@@ -596,6 +604,12 @@ test "len" {
         array[2] = 0;
         const ptr = array[0..2 :0].ptr;
         testing.expect(len(ptr) == 2);
+    }
+    {
+        var array: [5:0]u16 = [_]u16{ 1, 2, 3, 4, 5 };
+        testing.expect(len(&array) == 5);
+        array[2] = 0;
+        testing.expect(len(&array) == 2);
     }
 }
 

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -606,7 +606,7 @@ test "len" {
         testing.expect(len(ptr) == 2);
     }
     {
-        var array: [5:0]u16 = [_]u16{ 1, 2, 3, 4, 5 };
+        var array: [5:0]u16 = [_:0]u16{ 1, 2, 3, 4, 5 };
         testing.expect(len(&array) == 5);
         array[2] = 0;
         testing.expect(len(&array) == 2);

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -116,7 +116,7 @@ pub const Allocator = struct {
     pub fn allocSentinel(self: *Allocator, comptime Elem: type, n: usize, comptime sentinel: Elem) Error![:sentinel]Elem {
         var ptr = try self.alloc(Elem, n + 1);
         ptr[n] = sentinel;
-        return ptr[0 .. n :sentinel];
+        return ptr[0..n :sentinel];
     }
 
     pub fn alignedAlloc(

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1683,6 +1683,11 @@ pub fn renameatW(
     switch (rc) {
         .SUCCESS => return,
         .INVALID_HANDLE => unreachable,
+        .INVALID_PARAMETER => unreachable,
+        .OBJECT_PATH_SYNTAX_BAD => unreachable,
+        .ACCESS_DENIED => return error.AccessDenied,
+        .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
+        .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
         else => return windows.unexpectedStatus(rc),
     }
 }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1650,7 +1650,7 @@ pub fn renameatW(
     new_path_w: [*:0]const u16,
     ReplaceIfExists: windows.BOOLEAN,
 ) RenameError!void {
-    const access_mask = windows.SYNCHRONIZE | windows.GENERIC_WRITE;
+    const access_mask = windows.SYNCHRONIZE | windows.GENERIC_WRITE | windows.DELETE;
     const src_fd = try windows.OpenFileW(old_dir_fd, old_path, null, access_mask, windows.FILE_OPEN);
     defer windows.CloseHandle(src_fd);
 
@@ -1664,7 +1664,7 @@ pub fn renameatW(
 
     rename_info.* = .{
         .ReplaceIfExists = ReplaceIfExists,
-        .RootDirectory = if (std.fs.path.isAbsoluteWindowsW(new_path_w)) null else new_dir_fd,
+        .RootDirectory = if (old_dir_fd == new_dir_fd or std.fs.path.isAbsoluteWindowsW(new_path_w)) null else new_dir_fd,
         .FileNameLength = @intCast(u32, new_path.len * 2), // already checked error.NameTooLong
         .FileName = undefined,
     };

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1664,7 +1664,7 @@ pub fn renameatW(
 
     rename_info.* = .{
         .ReplaceIfExists = ReplaceIfExists,
-        .RootDirectory = if (old_dir_fd == new_dir_fd or std.fs.path.isAbsoluteWindowsW(new_path_w)) null else new_dir_fd,
+        .RootDirectory = if (std.fs.path.isAbsoluteWindowsW(new_path_w)) null else new_dir_fd,
         .FileNameLength = @intCast(u32, new_path.len * 2), // already checked error.NameTooLong
         .FileName = undefined,
     };

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -461,13 +461,11 @@ pub fn ftruncate(fd: fd_t, length: u64) TruncateError!void {
         );
 
         switch (rc) {
-            .SUCCESS => {},
+            .SUCCESS => return,
             .INVALID_HANDLE => unreachable, // Handle not open for writing
             .ACCESS_DENIED => return error.CannotTruncate,
             else => return windows.unexpectedStatus(rc),
         }
-
-        return;
     }
 
     while (true) {
@@ -852,6 +850,7 @@ pub const OpenError = error{
 
 /// Open and possibly create a file. Keeps trying if it gets interrupted.
 /// See also `openC`.
+/// TODO support windows
 pub fn open(file_path: []const u8, flags: u32, perm: usize) OpenError!fd_t {
     const file_path_c = try toPosixPath(file_path);
     return openC(&file_path_c, flags, perm);
@@ -859,6 +858,7 @@ pub fn open(file_path: []const u8, flags: u32, perm: usize) OpenError!fd_t {
 
 /// Open and possibly create a file. Keeps trying if it gets interrupted.
 /// See also `open`.
+/// TODO support windows
 pub fn openC(file_path: [*:0]const u8, flags: u32, perm: usize) OpenError!fd_t {
     while (true) {
         const rc = system.open(file_path, flags, perm);
@@ -892,6 +892,7 @@ pub fn openC(file_path: [*:0]const u8, flags: u32, perm: usize) OpenError!fd_t {
 /// Open and possibly create a file. Keeps trying if it gets interrupted.
 /// `file_path` is relative to the open directory handle `dir_fd`.
 /// See also `openatC`.
+/// TODO support windows
 pub fn openat(dir_fd: fd_t, file_path: []const u8, flags: u32, mode: mode_t) OpenError!fd_t {
     const file_path_c = try toPosixPath(file_path);
     return openatC(dir_fd, &file_path_c, flags, mode);
@@ -900,6 +901,7 @@ pub fn openat(dir_fd: fd_t, file_path: []const u8, flags: u32, mode: mode_t) Ope
 /// Open and possibly create a file. Keeps trying if it gets interrupted.
 /// `file_path` is relative to the open directory handle `dir_fd`.
 /// See also `openat`.
+/// TODO support windows
 pub fn openatC(dir_fd: fd_t, file_path: [*:0]const u8, flags: u32, mode: mode_t) OpenError!fd_t {
     while (true) {
         const rc = system.openat(dir_fd, file_path, flags, mode);
@@ -1527,6 +1529,9 @@ const RenameError = error{
     RenameAcrossMountPoints,
     InvalidUtf8,
     BadPathName,
+    NoDevice,
+    SharingViolation,
+    PipeBusy,
 } || UnexpectedError;
 
 /// Change the name or location of a file.
@@ -1578,6 +1583,108 @@ pub fn renameC(old_path: [*:0]const u8, new_path: [*:0]const u8) RenameError!voi
 pub fn renameW(old_path: [*:0]const u16, new_path: [*:0]const u16) RenameError!void {
     const flags = windows.MOVEFILE_REPLACE_EXISTING | windows.MOVEFILE_WRITE_THROUGH;
     return windows.MoveFileExW(old_path, new_path, flags);
+}
+
+/// Change the name or location of a file based on an open directory handle.
+pub fn renameat(
+    old_dir_fd: fd_t,
+    old_path: []const u8,
+    new_dir_fd: fd_t,
+    new_path: []const u8,
+) RenameError!void {
+    if (builtin.os.tag == .windows) {
+        const old_path_w = try windows.sliceToPrefixedFileW(old_path);
+        const new_path_w = try windows.sliceToPrefixedFileW(new_path);
+        return renameatW(old_dir_fd, &old_path_w, new_dir_fd, &new_path_w, windows.TRUE);
+    } else {
+        const old_path_c = try toPosixPath(old_path);
+        const new_path_c = try toPosixPath(new_path);
+        return renameatZ(old_dir_fd, &old_path_c, new_dir_fd, &new_path_c);
+    }
+}
+
+/// Same as `renameat` except the parameters are null-terminated byte arrays.
+pub fn renameatZ(
+    old_dir_fd: fd_t,
+    old_path: [*:0]const u8,
+    new_dir_fd: fd_t,
+    new_path: [*:0]const u8,
+) RenameError!void {
+    if (builtin.os.tag == .windows) {
+        const old_path_w = try windows.cStrToPrefixedFileW(old_path);
+        const new_path_w = try windows.cStrToPrefixedFileW(new_path);
+        return renameatW(old_dir_fd, &old_path_w, new_dir_fd, &new_path_w, windows.TRUE);
+    }
+
+    switch (errno(system.renameat(old_dir_fd, old_path, new_dir_fd, new_path))) {
+        0 => return,
+        EACCES => return error.AccessDenied,
+        EPERM => return error.AccessDenied,
+        EBUSY => return error.FileBusy,
+        EDQUOT => return error.DiskQuota,
+        EFAULT => unreachable,
+        EINVAL => unreachable,
+        EISDIR => return error.IsDir,
+        ELOOP => return error.SymLinkLoop,
+        EMLINK => return error.LinkQuotaExceeded,
+        ENAMETOOLONG => return error.NameTooLong,
+        ENOENT => return error.FileNotFound,
+        ENOTDIR => return error.NotDir,
+        ENOMEM => return error.SystemResources,
+        ENOSPC => return error.NoSpaceLeft,
+        EEXIST => return error.PathAlreadyExists,
+        ENOTEMPTY => return error.PathAlreadyExists,
+        EROFS => return error.ReadOnlyFileSystem,
+        EXDEV => return error.RenameAcrossMountPoints,
+        else => |err| return unexpectedErrno(err),
+    }
+}
+
+/// Same as `renameat` except the parameters are null-terminated UTF16LE encoded byte arrays.
+/// Assumes target is Windows.
+/// TODO these args can actually be slices when using ntdll. audit the rest of the W functions too.
+pub fn renameatW(
+    old_dir_fd: fd_t,
+    old_path: [*:0]const u16,
+    new_dir_fd: fd_t,
+    new_path_w: [*:0]const u16,
+    ReplaceIfExists: windows.BOOLEAN,
+) RenameError!void {
+    const access_mask = windows.SYNCHRONIZE | windows.GENERIC_WRITE;
+    const src_fd = try windows.OpenFileW(old_dir_fd, old_path, null, access_mask, windows.FILE_OPEN);
+    defer windows.CloseHandle(src_fd);
+
+    const struct_buf_len = @sizeOf(windows.FILE_RENAME_INFORMATION) + (MAX_PATH_BYTES - 1);
+    var rename_info_buf: [struct_buf_len]u8 align(@alignOf(windows.FILE_RENAME_INFORMATION)) = undefined;
+    const new_path = mem.span(new_path_w);
+    const struct_len = @sizeOf(windows.FILE_RENAME_INFORMATION) - 1 + new_path.len * 2;
+    if (struct_len > struct_buf_len) return error.NameTooLong;
+
+    const rename_info = @ptrCast(*windows.FILE_RENAME_INFORMATION, &rename_info_buf);
+
+    rename_info.* = .{
+        .ReplaceIfExists = ReplaceIfExists,
+        .RootDirectory = if (std.fs.path.isAbsoluteWindowsW(new_path_w)) null else new_dir_fd,
+        .FileNameLength = @intCast(u32, new_path.len * 2), // already checked error.NameTooLong
+        .FileName = undefined,
+    };
+    std.mem.copy(u16, @as([*]u16, &rename_info.FileName)[0..new_path.len], new_path);
+
+    var io_status_block: windows.IO_STATUS_BLOCK = undefined;
+
+    const rc = windows.ntdll.NtSetInformationFile(
+        src_fd,
+        &io_status_block,
+        rename_info,
+        @intCast(u32, struct_len), // already checked for error.NameTooLong
+        .FileRenameInformation,
+    );
+
+    switch (rc) {
+        .SUCCESS => return,
+        .INVALID_HANDLE => unreachable,
+        else => return windows.unexpectedStatus(rc),
+    }
 }
 
 pub const MakeDirError = error{
@@ -3125,6 +3232,7 @@ pub fn realpathC(pathname: [*:0]const u8, out_buffer: *[MAX_PATH_BYTES]u8) RealP
 }
 
 /// Same as `realpath` except `pathname` is null-terminated and UTF16LE-encoded.
+/// TODO use ntdll for better semantics
 pub fn realpathW(pathname: [*:0]const u16, out_buffer: *[MAX_PATH_BYTES]u8) RealPathError![]u8 {
     const h_file = try windows.CreateFileW(
         pathname,

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -465,17 +465,17 @@ pub fn renameat(oldfd: i32, oldpath: [*]const u8, newfd: i32, newpath: [*]const 
         return syscall4(
             SYS_renameat,
             @bitCast(usize, @as(isize, oldfd)),
-            @ptrToInt(old),
+            @ptrToInt(oldpath),
             @bitCast(usize, @as(isize, newfd)),
-            @ptrToInt(new),
+            @ptrToInt(newpath),
         );
     } else {
         return syscall5(
             SYS_renameat2,
             @bitCast(usize, @as(isize, oldfd)),
-            @ptrToInt(old),
+            @ptrToInt(oldpath),
             @bitCast(usize, @as(isize, newfd)),
-            @ptrToInt(new),
+            @ptrToInt(newpath),
             0,
         );
     }

--- a/lib/std/os/windows/bits.zig
+++ b/lib/std/os/windows/bits.zig
@@ -242,6 +242,13 @@ pub const FILE_NAME_INFORMATION = extern struct {
     FileName: [1]WCHAR,
 };
 
+pub const FILE_RENAME_INFORMATION = extern struct {
+    ReplaceIfExists: BOOLEAN,
+    RootDirectory: ?HANDLE,
+    FileNameLength: ULONG,
+    FileName: [1]WCHAR,
+};
+
 pub const IO_STATUS_BLOCK = extern struct {
     // "DUMMYUNIONNAME" expands to "u"
     u: extern union {

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -566,6 +566,7 @@ static const char *build_libc_object(CodeGen *parent_gen, const char *name, CFil
         Stage2ProgressNode *progress_node)
 {
     CodeGen *child_gen = create_child_codegen(parent_gen, nullptr, OutTypeObj, nullptr, name, progress_node);
+    child_gen->root_out_name = buf_create_from_str(name);
     ZigList<CFile *> c_source_files = {0};
     c_source_files.append(c_file);
     child_gen->c_source_files = c_source_files;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1290,6 +1290,7 @@ static int main0(int argc, char **argv) {
                     if (g->enable_cache) {
 #if defined(ZIG_OS_WINDOWS)
                         buf_replace(&g->bin_file_output_path, '/', '\\');
+                        buf_replace(g->output_dir, '/', '\\');
 #endif
                         if (final_output_dir_step != nullptr) {
                             Buf *dest_basename = buf_alloc();
@@ -1303,7 +1304,7 @@ static int main0(int argc, char **argv) {
                                 return main_exit(root_progress_node, EXIT_FAILURE);
                             }
                         } else {
-                            if (g->emit_bin && printf("%s\n", buf_ptr(&g->bin_file_output_path)) < 0)
+                            if (printf("%s\n", buf_ptr(g->output_dir)) < 0)
                                 return main_exit(root_progress_node, EXIT_FAILURE);
                         }
                     }


### PR DESCRIPTION
Previously the zig build system incorrectly assumed that the only build
artifact was a binary. Now, when you enable the cache, only the output
dir is printed to stdout, and the zig build system iterates over the
files in that directory, copying them to the output directory.

To support this change:

 * Add `std.os.renameat`, `std.os.renameatZ`, and `std.os.renameatW`.
 * Fix `std.os.linux.renameat` not compiling due to typos.
 * Deprecate `std.fs.updateFile` and `std.fs.updateFileMode`.
 * Add `std.fs.Dir.updateFile`, which supports using open directory
   handles for both the source and destination paths, as well as an
   options parameter which allows overriding the mode.
 * Update `std.fs.AtomicFile` to support operating based on an open
   directory handle. Instead of `std.fs.AtomicFile.init`, use
   `std.fs.Dir.atomicFile`.
 * `std.fs.AtomicFile` deinit() better handles the situation when the
    rename fails but the temporary file still exists, by still
    attempting to remove the temporary file.
 * `std.fs.Dir.openFileWindows` is moved to `std.os.windows.OpenFileW`.
 * `std.os.RenameError` gains the error codes `NoDevice`,
   `SharingViolation`, and `PipeBusy` which have been observed from
   Windows.

Closes #4733