### PR TITLE
Fix a bug in build.zig

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2148,10 +2148,10 @@ pub const LibExeObjStep = struct {
             const build_output_dir = mem.trimRight(u8, output_dir_nl, "\r\n");
 
             if (self.output_dir) |output_dir| {
-                var src_dir = try std.fs.cwd().openDirTraverse(build_output_dir);
+                var src_dir = try std.fs.cwd().openDirList(build_output_dir);
                 defer src_dir.close();
 
-                var dest_dir = try std.fs.cwd().openDirList(output_dir);
+                var dest_dir = try std.fs.cwd().openDirTraverse(output_dir);
                 defer dest_dir.close();
 
                 var it = src_dir.iterate();

--- a/lib/std/os/bits/dragonfly.zig
+++ b/lib/std/os/bits/dragonfly.zig
@@ -283,6 +283,8 @@ pub const F_LOCK = 1;
 pub const F_TLOCK = 2;
 pub const F_TEST = 3;
 
+pub const FD_CLOEXEC = 1;
+
 pub const AT_FDCWD = -328243;
 pub const AT_SYMLINK_NOFOLLOW = 1;
 pub const AT_REMOVEDIR = 2;

--- a/lib/std/os/bits/freebsd.zig
+++ b/lib/std/os/bits/freebsd.zig
@@ -355,6 +355,8 @@ pub const F_GETOWN_EX = 16;
 
 pub const F_GETOWNER_UIDS = 17;
 
+pub const FD_CLOEXEC = 1;
+
 pub const SEEK_SET = 0;
 pub const SEEK_CUR = 1;
 pub const SEEK_END = 2;

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -136,6 +136,8 @@ pub const MAP_FIXED_NOREPLACE = 0x100000;
 /// For anonymous mmap, memory could be uninitialized
 pub const MAP_UNINITIALIZED = 0x4000000;
 
+pub const FD_CLOEXEC = 1;
+
 pub const F_OK = 0;
 pub const X_OK = 1;
 pub const W_OK = 2;

--- a/lib/std/os/bits/netbsd.zig
+++ b/lib/std/os/bits/netbsd.zig
@@ -312,6 +312,8 @@ pub const F_GETLK = 7;
 pub const F_SETLK = 8;
 pub const F_SETLKW = 9;
 
+pub const FD_CLOEXEC = 1;
+
 pub const SEEK_SET = 0;
 pub const SEEK_CUR = 1;
 pub const SEEK_END = 2;

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -588,6 +588,10 @@ pub fn waitpid(pid: pid_t, status: *u32, flags: u32) usize {
     return syscall4(SYS_wait4, @bitCast(usize, @as(isize, pid)), @ptrToInt(status), flags, 0);
 }
 
+pub fn fcntl(fd: fd_t, cmd: i32, arg: usize) usize {
+    return syscall3(SYS_fcntl, @bitCast(usize, @as(isize, fd)), @bitCast(usize, @as(isize, cmd)), arg);
+}
+
 var vdso_clock_gettime = @ptrCast(?*const c_void, init_vdso_clock_gettime);
 
 // We must follow the C calling convention when we call into the VDSO


### PR DESCRIPTION
A swapped `openDirTraverse`/`openDirList` caused some head scratching so I've added a runtime check to make sure this won't happen again.

@leroycep: I've added a `fcntl` wrapper here, there may be merge conflicts depending on what's merged before

@andrewrk, Feel free to take over the PR