### PR TITLE
Change the default stdin behavior of RunStep to .Inherit

### DIFF
--- a/lib/std/build/run.zig
+++ b/lib/std/build/run.zig
@@ -29,6 +29,8 @@ pub const RunStep = struct {
     stdout_action: StdIoAction = .inherit,
     stderr_action: StdIoAction = .inherit,
 
+    stdin_behavior: std.ChildProcess.StdIo = .Inherit,
+
     expected_exit_code: u8 = 0,
 
     pub const StdIoAction = union(enum) {
@@ -159,7 +161,7 @@ pub const RunStep = struct {
         child.cwd = cwd;
         child.env_map = self.env_map orelse self.builder.env_map;
 
-        child.stdin_behavior = .Ignore;
+        child.stdin_behavior = self.stdin_behavior;
         child.stdout_behavior = stdIoActionToBehavior(self.stdout_action);
         child.stderr_behavior = stdIoActionToBehavior(self.stderr_action);
 


### PR DESCRIPTION
This behaves the same as stdout and stderr behavior which also
default to .inherit. Also adds a field to RunStep to change the behavior.

Since this is a breaking change, previous behavior can be restored by doing:
`RunStep.stdin_behavior = .Ignore`.