### PR TITLE
slicing with comptime start and end indexes results in pointer-to-array

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2093,8 +2093,9 @@ var foo: u8 align(4) = 100;
 test "global variable alignment" {
     assert(@TypeOf(&foo).alignment == 4);
     assert(@TypeOf(&foo) == *align(4) u8);
-    const slice = @as(*[1]u8, &foo)[0..];
-    assert(@TypeOf(slice) == []align(4) u8);
+    const as_pointer_to_array: *[1]u8 = &foo;
+    const as_slice: []u8 = as_pointer_to_array;
+    assert(@TypeOf(as_slice) == []align(4) u8);
 }
 
 fn derp() align(@sizeOf(usize) * 2) i32 { return 1234; }
@@ -2187,7 +2188,8 @@ test "basic slices" {
     // a slice is that the array's length is part of the type and known at
     // compile-time, whereas the slice's length is known at runtime.
     // Both can be accessed with the `len` field.
-    const slice = array[0..array.len];
+    var known_at_runtime_zero: usize = 0;
+    const slice = array[known_at_runtime_zero..array.len];
     assert(&slice[0] == &array[0]);
     assert(slice.len == array.len);
 
@@ -2207,13 +2209,15 @@ test "basic slices" {
       {#code_end#}
       <p>This is one reason we prefer slices to pointers.</p>
       {#code_begin|test|slices#}
-const assert = @import("std").debug.assert;
-const mem = @import("std").mem;
-const fmt = @import("std").fmt;
+const std = @import("std");
+const assert = std.debug.assert;
+const mem = std.mem;
+const fmt = std.fmt;
 
 test "using slices for strings" {
-    // Zig has no concept of strings. String literals are arrays of u8, and
-    // in general the string type is []u8 (slice of u8).
+    // Zig has no concept of strings. String literals are const pointers to
+    // arrays of u8, and by convention parameters that are "strings" are
+    // expected to be UTF-8 encoded slices of u8.
     // Here we coerce [5]u8 to []const u8
     const hello: []const u8 = "hello";
     const world: []const u8 = "世界";
@@ -2222,7 +2226,7 @@ test "using slices for strings" {
     // You can use slice syntax on an array to convert an array into a slice.
     const all_together_slice = all_together[0..];
     // String concatenation example.
-    const hello_world = try fmt.bufPrint(all_together_slice, "{} {}", .{hello, world});
+    const hello_world = try fmt.bufPrint(all_together_slice, "{} {}", .{ hello, world });
 
     // Generally, you can use UTF-8 and not worry about whether something is a
     // string. If you don't need to deal with individual characters, no need
@@ -2239,22 +2243,14 @@ test "slice pointer" {
     slice[2] = 3;
     assert(slice[2] == 3);
     // The slice is mutable because we sliced a mutable pointer.
-    assert(@TypeOf(slice) == []u8);
+    // Furthermore, it is actually a pointer to an array, since the start
+    // and end indexes were both comptime-known.
+    assert(@TypeOf(slice) == *[5]u8);
 
     // You can also slice a slice:
     const slice2 = slice[2..3];
     assert(slice2.len == 1);
     assert(slice2[0] == 3);
-}
-
-test "slice widening" {
-    // Zig supports slice widening and slice narrowing. Cast a slice of u8
-    // to a slice of anything else, and Zig will perform the length conversion.
-    const array align(@alignOf(u32)) = [_]u8{ 0x12, 0x12, 0x12, 0x12, 0x13, 0x13, 0x13, 0x13 };
-    const slice = mem.bytesAsSlice(u32, array[0..]);
-    assert(slice.len == 2);
-    assert(slice[0] == 0x12121212);
-    assert(slice[1] == 0x13131313);
 }
       {#code_end#}
       {#see_also|Pointers|for|Arrays#}

--- a/lib/std/crypto/aes.zig
+++ b/lib/std/crypto/aes.zig
@@ -15,10 +15,10 @@ fn rotw(w: u32) u32 {
 
 // Encrypt one block from src into dst, using the expanded key xk.
 fn encryptBlock(xk: []const u32, dst: []u8, src: []const u8) void {
-    var s0 = mem.readIntSliceBig(u32, src[0..4]);
-    var s1 = mem.readIntSliceBig(u32, src[4..8]);
-    var s2 = mem.readIntSliceBig(u32, src[8..12]);
-    var s3 = mem.readIntSliceBig(u32, src[12..16]);
+    var s0 = mem.readIntBig(u32, src[0..4]);
+    var s1 = mem.readIntBig(u32, src[4..8]);
+    var s2 = mem.readIntBig(u32, src[8..12]);
+    var s3 = mem.readIntBig(u32, src[12..16]);
 
     // First round just XORs input with key.
     s0 ^= xk[0];
@@ -58,18 +58,18 @@ fn encryptBlock(xk: []const u32, dst: []u8, src: []const u8) void {
     s2 ^= xk[k + 2];
     s3 ^= xk[k + 3];
 
-    mem.writeIntSliceBig(u32, dst[0..4], s0);
-    mem.writeIntSliceBig(u32, dst[4..8], s1);
-    mem.writeIntSliceBig(u32, dst[8..12], s2);
-    mem.writeIntSliceBig(u32, dst[12..16], s3);
+    mem.writeIntBig(u32, dst[0..4], s0);
+    mem.writeIntBig(u32, dst[4..8], s1);
+    mem.writeIntBig(u32, dst[8..12], s2);
+    mem.writeIntBig(u32, dst[12..16], s3);
 }
 
 // Decrypt one block from src into dst, using the expanded key xk.
 pub fn decryptBlock(xk: []const u32, dst: []u8, src: []const u8) void {
-    var s0 = mem.readIntSliceBig(u32, src[0..4]);
-    var s1 = mem.readIntSliceBig(u32, src[4..8]);
-    var s2 = mem.readIntSliceBig(u32, src[8..12]);
-    var s3 = mem.readIntSliceBig(u32, src[12..16]);
+    var s0 = mem.readIntBig(u32, src[0..4]);
+    var s1 = mem.readIntBig(u32, src[4..8]);
+    var s2 = mem.readIntBig(u32, src[8..12]);
+    var s3 = mem.readIntBig(u32, src[12..16]);
 
     // First round just XORs input with key.
     s0 ^= xk[0];
@@ -109,10 +109,10 @@ pub fn decryptBlock(xk: []const u32, dst: []u8, src: []const u8) void {
     s2 ^= xk[k + 2];
     s3 ^= xk[k + 3];
 
-    mem.writeIntSliceBig(u32, dst[0..4], s0);
-    mem.writeIntSliceBig(u32, dst[4..8], s1);
-    mem.writeIntSliceBig(u32, dst[8..12], s2);
-    mem.writeIntSliceBig(u32, dst[12..16], s3);
+    mem.writeIntBig(u32, dst[0..4], s0);
+    mem.writeIntBig(u32, dst[4..8], s1);
+    mem.writeIntBig(u32, dst[8..12], s2);
+    mem.writeIntBig(u32, dst[12..16], s3);
 }
 
 fn xorBytes(dst: []u8, a: []const u8, b: []const u8) usize {
@@ -154,8 +154,8 @@ fn AES(comptime keysize: usize) type {
             var n: usize = 0;
             while (n < src.len) {
                 ctx.encrypt(keystream[0..], ctrbuf[0..]);
-                var ctr_i = std.mem.readIntSliceBig(u128, ctrbuf[0..]);
-                std.mem.writeIntSliceBig(u128, ctrbuf[0..], ctr_i +% 1);
+                var ctr_i = std.mem.readIntBig(u128, ctrbuf[0..]);
+                std.mem.writeIntBig(u128, ctrbuf[0..], ctr_i +% 1);
 
                 n += xorBytes(dst[n..], src[n..], &keystream);
             }
@@ -251,7 +251,7 @@ fn expandKey(key: []const u8, enc: []u32, dec: []u32) void {
     var i: usize = 0;
     var nk = key.len / 4;
     while (i < nk) : (i += 1) {
-        enc[i] = mem.readIntSliceBig(u32, key[4 * i .. 4 * i + 4]);
+        enc[i] = mem.readIntBig(u32, key[4 * i ..][0..4]);
     }
     while (i < enc.len) : (i += 1) {
         var t = enc[i - 1];

--- a/lib/std/crypto/blake2.zig
+++ b/lib/std/crypto/blake2.zig
@@ -123,8 +123,7 @@ fn Blake2s(comptime out_len: usize) type {
             const rr = d.h[0 .. out_len / 32];
 
             for (rr) |s, j| {
-                // TODO https://github.com/ziglang/zig/issues/863
-                mem.writeIntSliceLittle(u32, out[4 * j .. 4 * j + 4], s);
+                mem.writeIntLittle(u32, out[4 * j ..][0..4], s);
             }
         }
 
@@ -135,8 +134,7 @@ fn Blake2s(comptime out_len: usize) type {
             var v: [16]u32 = undefined;
 
             for (m) |*r, i| {
-                // TODO https://github.com/ziglang/zig/issues/863
-                r.* = mem.readIntSliceLittle(u32, b[4 * i .. 4 * i + 4]);
+                r.* = mem.readIntLittle(u32, b[4 * i ..][0..4]);
             }
 
             var k: usize = 0;
@@ -358,8 +356,7 @@ fn Blake2b(comptime out_len: usize) type {
             const rr = d.h[0 .. out_len / 64];
 
             for (rr) |s, j| {
-                // TODO https://github.com/ziglang/zig/issues/863
-                mem.writeIntSliceLittle(u64, out[8 * j .. 8 * j + 8], s);
+                mem.writeIntLittle(u64, out[8 * j ..][0..8], s);
             }
         }
 
@@ -370,7 +367,7 @@ fn Blake2b(comptime out_len: usize) type {
             var v: [16]u64 = undefined;
 
             for (m) |*r, i| {
-                r.* = mem.readIntSliceLittle(u64, b[8 * i .. 8 * i + 8]);
+                r.* = mem.readIntLittle(u64, b[8 * i ..][0..8]);
             }
 
             var k: usize = 0;

--- a/lib/std/crypto/chacha20.zig
+++ b/lib/std/crypto/chacha20.zig
@@ -61,8 +61,7 @@ fn salsa20_wordtobyte(out: []u8, input: [16]u32) void {
     }
 
     for (x) |_, i| {
-        // TODO https://github.com/ziglang/zig/issues/863
-        mem.writeIntSliceLittle(u32, out[4 * i .. 4 * i + 4], x[i] +% input[i]);
+        mem.writeIntLittle(u32, out[4 * i ..][0..4], x[i] +% input[i]);
     }
 }
 
@@ -73,10 +72,10 @@ fn chaCha20_internal(out: []u8, in: []const u8, key: [8]u32, counter: [4]u32) vo
 
     const c = "expand 32-byte k";
     const constant_le = [_]u32{
-        mem.readIntSliceLittle(u32, c[0..4]),
-        mem.readIntSliceLittle(u32, c[4..8]),
-        mem.readIntSliceLittle(u32, c[8..12]),
-        mem.readIntSliceLittle(u32, c[12..16]),
+        mem.readIntLittle(u32, c[0..4]),
+        mem.readIntLittle(u32, c[4..8]),
+        mem.readIntLittle(u32, c[8..12]),
+        mem.readIntLittle(u32, c[12..16]),
     };
 
     mem.copy(u32, ctx[0..], constant_le[0..4]);
@@ -120,19 +119,19 @@ pub fn chaCha20IETF(out: []u8, in: []const u8, counter: u32, key: [32]u8, nonce:
     var k: [8]u32 = undefined;
     var c: [4]u32 = undefined;
 
-    k[0] = mem.readIntSliceLittle(u32, key[0..4]);
-    k[1] = mem.readIntSliceLittle(u32, key[4..8]);
-    k[2] = mem.readIntSliceLittle(u32, key[8..12]);
-    k[3] = mem.readIntSliceLittle(u32, key[12..16]);
-    k[4] = mem.readIntSliceLittle(u32, key[16..20]);
-    k[5] = mem.readIntSliceLittle(u32, key[20..24]);
-    k[6] = mem.readIntSliceLittle(u32, key[24..28]);
-    k[7] = mem.readIntSliceLittle(u32, key[28..32]);
+    k[0] = mem.readIntLittle(u32, key[0..4]);
+    k[1] = mem.readIntLittle(u32, key[4..8]);
+    k[2] = mem.readIntLittle(u32, key[8..12]);
+    k[3] = mem.readIntLittle(u32, key[12..16]);
+    k[4] = mem.readIntLittle(u32, key[16..20]);
+    k[5] = mem.readIntLittle(u32, key[20..24]);
+    k[6] = mem.readIntLittle(u32, key[24..28]);
+    k[7] = mem.readIntLittle(u32, key[28..32]);
 
     c[0] = counter;
-    c[1] = mem.readIntSliceLittle(u32, nonce[0..4]);
-    c[2] = mem.readIntSliceLittle(u32, nonce[4..8]);
-    c[3] = mem.readIntSliceLittle(u32, nonce[8..12]);
+    c[1] = mem.readIntLittle(u32, nonce[0..4]);
+    c[2] = mem.readIntLittle(u32, nonce[4..8]);
+    c[3] = mem.readIntLittle(u32, nonce[8..12]);
     chaCha20_internal(out, in, k, c);
 }
 
@@ -147,19 +146,19 @@ pub fn chaCha20With64BitNonce(out: []u8, in: []const u8, counter: u64, key: [32]
     var k: [8]u32 = undefined;
     var c: [4]u32 = undefined;
 
-    k[0] = mem.readIntSliceLittle(u32, key[0..4]);
-    k[1] = mem.readIntSliceLittle(u32, key[4..8]);
-    k[2] = mem.readIntSliceLittle(u32, key[8..12]);
-    k[3] = mem.readIntSliceLittle(u32, key[12..16]);
-    k[4] = mem.readIntSliceLittle(u32, key[16..20]);
-    k[5] = mem.readIntSliceLittle(u32, key[20..24]);
-    k[6] = mem.readIntSliceLittle(u32, key[24..28]);
-    k[7] = mem.readIntSliceLittle(u32, key[28..32]);
+    k[0] = mem.readIntLittle(u32, key[0..4]);
+    k[1] = mem.readIntLittle(u32, key[4..8]);
+    k[2] = mem.readIntLittle(u32, key[8..12]);
+    k[3] = mem.readIntLittle(u32, key[12..16]);
+    k[4] = mem.readIntLittle(u32, key[16..20]);
+    k[5] = mem.readIntLittle(u32, key[20..24]);
+    k[6] = mem.readIntLittle(u32, key[24..28]);
+    k[7] = mem.readIntLittle(u32, key[28..32]);
 
     c[0] = @truncate(u32, counter);
     c[1] = @truncate(u32, counter >> 32);
-    c[2] = mem.readIntSliceLittle(u32, nonce[0..4]);
-    c[3] = mem.readIntSliceLittle(u32, nonce[4..8]);
+    c[2] = mem.readIntLittle(u32, nonce[0..4]);
+    c[3] = mem.readIntLittle(u32, nonce[4..8]);
 
     const block_size = (1 << 6);
     // The full block size is greater than the address space on a 32bit machine
@@ -463,8 +462,8 @@ pub fn chacha20poly1305Seal(dst: []u8, plaintext: []const u8, data: []const u8, 
         mac.update(zeros[0..padding]);
     }
     var lens: [16]u8 = undefined;
-    mem.writeIntSliceLittle(u64, lens[0..8], data.len);
-    mem.writeIntSliceLittle(u64, lens[8..16], plaintext.len);
+    mem.writeIntLittle(u64, lens[0..8], data.len);
+    mem.writeIntLittle(u64, lens[8..16], plaintext.len);
     mac.update(lens[0..]);
     mac.final(dst[plaintext.len..]);
 }
@@ -500,8 +499,8 @@ pub fn chacha20poly1305Open(dst: []u8, msgAndTag: []const u8, data: []const u8, 
         mac.update(zeros[0..padding]);
     }
     var lens: [16]u8 = undefined;
-    mem.writeIntSliceLittle(u64, lens[0..8], data.len);
-    mem.writeIntSliceLittle(u64, lens[8..16], ciphertext.len);
+    mem.writeIntLittle(u64, lens[0..8], data.len);
+    mem.writeIntLittle(u64, lens[8..16], ciphertext.len);
     mac.update(lens[0..]);
     var computedTag: [16]u8 = undefined;
     mac.final(computedTag[0..]);

--- a/lib/std/crypto/md5.zig
+++ b/lib/std/crypto/md5.zig
@@ -112,8 +112,7 @@ pub const Md5 = struct {
         d.round(d.buf[0..]);
 
         for (d.s) |s, j| {
-            // TODO https://github.com/ziglang/zig/issues/863
-            mem.writeIntSliceLittle(u32, out[4 * j .. 4 * j + 4], s);
+            mem.writeIntLittle(u32, out[4 * j ..][0..4], s);
         }
     }
 

--- a/lib/std/crypto/poly1305.zig
+++ b/lib/std/crypto/poly1305.zig
@@ -3,11 +3,11 @@
 // https://monocypher.org/
 
 const std = @import("../std.zig");
-const builtin = @import("builtin");
+const builtin = std.builtin;
 
 const Endian = builtin.Endian;
-const readIntSliceLittle = std.mem.readIntSliceLittle;
-const writeIntSliceLittle = std.mem.writeIntSliceLittle;
+const readIntLittle = std.mem.readIntLittle;
+const writeIntLittle = std.mem.writeIntLittle;
 
 pub const Poly1305 = struct {
     const Self = @This();
@@ -59,19 +59,19 @@ pub const Poly1305 = struct {
         {
             var i: usize = 0;
             while (i < 1) : (i += 1) {
-                ctx.r[0] = readIntSliceLittle(u32, key[0..4]) & 0x0fffffff;
+                ctx.r[0] = readIntLittle(u32, key[0..4]) & 0x0fffffff;
             }
         }
         {
             var i: usize = 1;
             while (i < 4) : (i += 1) {
-                ctx.r[i] = readIntSliceLittle(u32, key[i * 4 .. i * 4 + 4]) & 0x0ffffffc;
+                ctx.r[i] = readIntLittle(u32, key[i * 4 ..][0..4]) & 0x0ffffffc;
             }
         }
         {
             var i: usize = 0;
             while (i < 4) : (i += 1) {
-                ctx.pad[i] = readIntSliceLittle(u32, key[i * 4 + 16 .. i * 4 + 16 + 4]);
+                ctx.pad[i] = readIntLittle(u32, key[i * 4 + 16 ..][0..4]);
             }
         }
 
@@ -168,10 +168,10 @@ pub const Poly1305 = struct {
         const nb_blocks = nmsg.len >> 4;
         var i: usize = 0;
         while (i < nb_blocks) : (i += 1) {
-            ctx.c[0] = readIntSliceLittle(u32, nmsg[0..4]);
-            ctx.c[1] = readIntSliceLittle(u32, nmsg[4..8]);
-            ctx.c[2] = readIntSliceLittle(u32, nmsg[8..12]);
-            ctx.c[3] = readIntSliceLittle(u32, nmsg[12..16]);
+            ctx.c[0] = readIntLittle(u32, nmsg[0..4]);
+            ctx.c[1] = readIntLittle(u32, nmsg[4..8]);
+            ctx.c[2] = readIntLittle(u32, nmsg[8..12]);
+            ctx.c[3] = readIntLittle(u32, nmsg[12..16]);
             polyBlock(ctx);
             nmsg = nmsg[16..];
         }
@@ -210,11 +210,10 @@ pub const Poly1305 = struct {
         const uu2 = (uu1 >> 32) + ctx.h[2] + ctx.pad[2]; // <= 2_00000000
         const uu3 = (uu2 >> 32) + ctx.h[3] + ctx.pad[3]; // <= 2_00000000
 
-        // TODO https://github.com/ziglang/zig/issues/863
-        writeIntSliceLittle(u32, out[0..], @truncate(u32, uu0));
-        writeIntSliceLittle(u32, out[4..], @truncate(u32, uu1));
-        writeIntSliceLittle(u32, out[8..], @truncate(u32, uu2));
-        writeIntSliceLittle(u32, out[12..], @truncate(u32, uu3));
+        writeIntLittle(u32, out[0..4], @truncate(u32, uu0));
+        writeIntLittle(u32, out[4..8], @truncate(u32, uu1));
+        writeIntLittle(u32, out[8..12], @truncate(u32, uu2));
+        writeIntLittle(u32, out[12..16], @truncate(u32, uu3));
 
         ctx.secureZero();
     }

--- a/lib/std/crypto/sha1.zig
+++ b/lib/std/crypto/sha1.zig
@@ -109,8 +109,7 @@ pub const Sha1 = struct {
         d.round(d.buf[0..]);
 
         for (d.s) |s, j| {
-            // TODO https://github.com/ziglang/zig/issues/863
-            mem.writeIntSliceBig(u32, out[4 * j .. 4 * j + 4], s);
+            mem.writeIntBig(u32, out[4 * j ..][0..4], s);
         }
     }
 

--- a/lib/std/crypto/sha2.zig
+++ b/lib/std/crypto/sha2.zig
@@ -167,8 +167,7 @@ fn Sha2_32(comptime params: Sha2Params32) type {
             const rr = d.s[0 .. params.out_len / 32];
 
             for (rr) |s, j| {
-                // TODO https://github.com/ziglang/zig/issues/863
-                mem.writeIntSliceBig(u32, out[4 * j .. 4 * j + 4], s);
+                mem.writeIntBig(u32, out[4 * j ..][0..4], s);
             }
         }
 
@@ -509,8 +508,7 @@ fn Sha2_64(comptime params: Sha2Params64) type {
             const rr = d.s[0 .. params.out_len / 64];
 
             for (rr) |s, j| {
-                // TODO https://github.com/ziglang/zig/issues/863
-                mem.writeIntSliceBig(u64, out[8 * j .. 8 * j + 8], s);
+                mem.writeIntBig(u64, out[8 * j ..][0..8], s);
             }
         }
 

--- a/lib/std/crypto/sha3.zig
+++ b/lib/std/crypto/sha3.zig
@@ -120,7 +120,7 @@ fn keccak_f(comptime F: usize, d: []u8) void {
     var c = [_]u64{0} ** 5;
 
     for (s) |*r, i| {
-        r.* = mem.readIntSliceLittle(u64, d[8 * i .. 8 * i + 8]);
+        r.* = mem.readIntLittle(u64, d[8 * i ..][0..8]);
     }
 
     comptime var x: usize = 0;
@@ -167,8 +167,7 @@ fn keccak_f(comptime F: usize, d: []u8) void {
     }
 
     for (s) |r, i| {
-        // TODO https://github.com/ziglang/zig/issues/863
-        mem.writeIntSliceLittle(u64, d[8 * i .. 8 * i + 8], r);
+        mem.writeIntLittle(u64, d[8 * i ..][0..8], r);
     }
 }
 

--- a/lib/std/crypto/x25519.zig
+++ b/lib/std/crypto/x25519.zig
@@ -7,8 +7,8 @@ const builtin = @import("builtin");
 const fmt = std.fmt;
 
 const Endian = builtin.Endian;
-const readIntSliceLittle = std.mem.readIntSliceLittle;
-const writeIntSliceLittle = std.mem.writeIntSliceLittle;
+const readIntLittle = std.mem.readIntLittle;
+const writeIntLittle = std.mem.writeIntLittle;
 
 // Based on Supercop's ref10 implementation.
 pub const X25519 = struct {
@@ -255,16 +255,16 @@ const Fe = struct {
 
         var t: [10]i64 = undefined;
 
-        t[0] = readIntSliceLittle(u32, s[0..4]);
-        t[1] = @as(u32, readIntSliceLittle(u24, s[4..7])) << 6;
-        t[2] = @as(u32, readIntSliceLittle(u24, s[7..10])) << 5;
-        t[3] = @as(u32, readIntSliceLittle(u24, s[10..13])) << 3;
-        t[4] = @as(u32, readIntSliceLittle(u24, s[13..16])) << 2;
-        t[5] = readIntSliceLittle(u32, s[16..20]);
-        t[6] = @as(u32, readIntSliceLittle(u24, s[20..23])) << 7;
-        t[7] = @as(u32, readIntSliceLittle(u24, s[23..26])) << 5;
-        t[8] = @as(u32, readIntSliceLittle(u24, s[26..29])) << 4;
-        t[9] = (@as(u32, readIntSliceLittle(u24, s[29..32])) & 0x7fffff) << 2;
+        t[0] = readIntLittle(u32, s[0..4]);
+        t[1] = @as(u32, readIntLittle(u24, s[4..7])) << 6;
+        t[2] = @as(u32, readIntLittle(u24, s[7..10])) << 5;
+        t[3] = @as(u32, readIntLittle(u24, s[10..13])) << 3;
+        t[4] = @as(u32, readIntLittle(u24, s[13..16])) << 2;
+        t[5] = readIntLittle(u32, s[16..20]);
+        t[6] = @as(u32, readIntLittle(u24, s[20..23])) << 7;
+        t[7] = @as(u32, readIntLittle(u24, s[23..26])) << 5;
+        t[8] = @as(u32, readIntLittle(u24, s[26..29])) << 4;
+        t[9] = (@as(u32, readIntLittle(u24, s[29..32])) & 0x7fffff) << 2;
 
         carry1(h, t[0..]);
     }
@@ -544,15 +544,14 @@ const Fe = struct {
             ut[i] = @bitCast(u32, @intCast(i32, t[i]));
         }
 
-        // TODO https://github.com/ziglang/zig/issues/863
-        writeIntSliceLittle(u32, s[0..4], (ut[0] >> 0) | (ut[1] << 26));
-        writeIntSliceLittle(u32, s[4..8], (ut[1] >> 6) | (ut[2] << 19));
-        writeIntSliceLittle(u32, s[8..12], (ut[2] >> 13) | (ut[3] << 13));
-        writeIntSliceLittle(u32, s[12..16], (ut[3] >> 19) | (ut[4] << 6));
-        writeIntSliceLittle(u32, s[16..20], (ut[5] >> 0) | (ut[6] << 25));
-        writeIntSliceLittle(u32, s[20..24], (ut[6] >> 7) | (ut[7] << 19));
-        writeIntSliceLittle(u32, s[24..28], (ut[7] >> 13) | (ut[8] << 12));
-        writeIntSliceLittle(u32, s[28..], (ut[8] >> 20) | (ut[9] << 6));
+        writeIntLittle(u32, s[0..4], (ut[0] >> 0) | (ut[1] << 26));
+        writeIntLittle(u32, s[4..8], (ut[1] >> 6) | (ut[2] << 19));
+        writeIntLittle(u32, s[8..12], (ut[2] >> 13) | (ut[3] << 13));
+        writeIntLittle(u32, s[12..16], (ut[3] >> 19) | (ut[4] << 6));
+        writeIntLittle(u32, s[16..20], (ut[5] >> 0) | (ut[6] << 25));
+        writeIntLittle(u32, s[20..24], (ut[6] >> 7) | (ut[7] << 19));
+        writeIntLittle(u32, s[24..28], (ut[7] >> 13) | (ut[8] << 12));
+        writeIntLittle(u32, s[28..32], (ut[8] >> 20) | (ut[9] << 6));
 
         std.mem.secureZero(i64, t[0..]);
     }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1223,7 +1223,8 @@ test "slice" {
         try testFmt("slice: abc\n", "slice: {}\n", .{value});
     }
     {
-        const value = @intToPtr([*]align(1) const []const u8, 0xdeadbeef)[0..0];
+        var runtime_zero: usize = 0;
+        const value = @intToPtr([*]align(1) const []const u8, 0xdeadbeef)[runtime_zero..runtime_zero];
         try testFmt("slice: []const u8@deadbeef\n", "slice: {}\n", .{value});
     }
 

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -360,7 +360,7 @@ pub const Dir = struct {
                     if (self.index >= self.end_index) {
                         const rc = os.system.getdirentries(
                             self.dir.fd,
-                            self.buf[0..].ptr,
+                            &self.buf,
                             self.buf.len,
                             &self.seek,
                         );

--- a/lib/std/hash/auto_hash.zig
+++ b/lib/std/hash/auto_hash.zig
@@ -40,7 +40,9 @@ pub fn hashPointer(hasher: var, key: var, comptime strat: HashStrategy) void {
             .DeepRecursive => hashArray(hasher, key, .DeepRecursive),
         },
 
-        .Many, .C, => switch (strat) {
+        .Many,
+        .C,
+        => switch (strat) {
             .Shallow => hash(hasher, @ptrToInt(key), .Shallow),
             else => @compileError(
                 \\ unknown-length pointers and C pointers cannot be hashed deeply.
@@ -236,9 +238,11 @@ test "hash slice shallow" {
     defer std.testing.allocator.destroy(array1);
     array1.* = [_]u32{ 1, 2, 3, 4, 5, 6 };
     const array2 = [_]u32{ 1, 2, 3, 4, 5, 6 };
-    const a = array1[0..];
-    const b = array2[0..];
-    const c = array1[0..3];
+    // TODO audit deep/shallow - maybe it has the wrong behavior with respect to array pointers and slices
+    var runtime_zero: usize = 0;
+    const a = array1[runtime_zero..];
+    const b = array2[runtime_zero..];
+    const c = array1[runtime_zero..3];
     testing.expect(testHashShallow(a) == testHashShallow(a));
     testing.expect(testHashShallow(a) != testHashShallow(array1));
     testing.expect(testHashShallow(a) != testHashShallow(b));

--- a/lib/std/hash/siphash.zig
+++ b/lib/std/hash/siphash.zig
@@ -39,8 +39,8 @@ fn SipHashStateless(comptime T: type, comptime c_rounds: usize, comptime d_round
         pub fn init(key: []const u8) Self {
             assert(key.len >= 16);
 
-            const k0 = mem.readIntSliceLittle(u64, key[0..8]);
-            const k1 = mem.readIntSliceLittle(u64, key[8..16]);
+            const k0 = mem.readIntLittle(u64, key[0..8]);
+            const k1 = mem.readIntLittle(u64, key[8..16]);
 
             var d = Self{
                 .v0 = k0 ^ 0x736f6d6570736575,
@@ -111,7 +111,7 @@ fn SipHashStateless(comptime T: type, comptime c_rounds: usize, comptime d_round
         fn round(self: *Self, b: []const u8) void {
             assert(b.len == 8);
 
-            const m = mem.readIntSliceLittle(u64, b[0..]);
+            const m = mem.readIntLittle(u64, b[0..8]);
             self.v3 ^= m;
 
             // TODO this is a workaround, should be able to supply the value without a separate variable

--- a/lib/std/hash/wyhash.zig
+++ b/lib/std/hash/wyhash.zig
@@ -11,7 +11,7 @@ const primes = [_]u64{
 
 fn read_bytes(comptime bytes: u8, data: []const u8) u64 {
     const T = std.meta.IntType(false, 8 * bytes);
-    return mem.readIntSliceLittle(T, data[0..bytes]);
+    return mem.readIntLittle(T, data[0..bytes]);
 }
 
 fn read_8bytes_swapped(data: []const u8) u64 {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -560,7 +560,7 @@ pub fn span(ptr: var) Span(@TypeOf(ptr)) {
 
 test "span" {
     var array: [5]u16 = [_]u16{ 1, 2, 3, 4, 5 };
-    const ptr = array[0..2 :3].ptr;
+    const ptr = @as([*:3]u16, array[0..2 :3]);
     testing.expect(eql(u16, span(ptr), &[_]u16{ 1, 2 }));
     testing.expect(eql(u16, span(&array), &[_]u16{ 1, 2, 3, 4, 5 }));
 }
@@ -602,7 +602,7 @@ test "len" {
         testing.expect(len(&array) == 5);
         testing.expect(len(array[0..3]) == 3);
         array[2] = 0;
-        const ptr = array[0..2 :0].ptr;
+        const ptr = @as([*:0]u16, array[0..2 :0]);
         testing.expect(len(ptr) == 2);
     }
     {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -824,8 +824,7 @@ pub const readIntBig = switch (builtin.endian) {
 pub fn readIntSliceNative(comptime T: type, bytes: []const u8) T {
     const n = @divExact(T.bit_count, 8);
     assert(bytes.len >= n);
-    // TODO https://github.com/ziglang/zig/issues/863
-    return readIntNative(T, @ptrCast(*const [n]u8, bytes.ptr));
+    return readIntNative(T, bytes[0..n]);
 }
 
 /// Asserts that bytes.len >= T.bit_count / 8. Reads the integer starting from index 0
@@ -863,8 +862,7 @@ pub fn readInt(comptime T: type, bytes: *const [@divExact(T.bit_count, 8)]u8, en
 pub fn readIntSlice(comptime T: type, bytes: []const u8, endian: builtin.Endian) T {
     const n = @divExact(T.bit_count, 8);
     assert(bytes.len >= n);
-    // TODO https://github.com/ziglang/zig/issues/863
-    return readInt(T, @ptrCast(*const [n]u8, bytes.ptr), endian);
+    return readInt(T, bytes[0..n], endian);
 }
 
 test "comptime read/write int" {

--- a/lib/std/meta/trait.zig
+++ b/lib/std/meta/trait.zig
@@ -230,9 +230,10 @@ pub fn isSingleItemPtr(comptime T: type) bool {
 
 test "std.meta.trait.isSingleItemPtr" {
     const array = [_]u8{0} ** 10;
-    testing.expect(isSingleItemPtr(@TypeOf(&array[0])));
-    testing.expect(!isSingleItemPtr(@TypeOf(array)));
-    testing.expect(!isSingleItemPtr(@TypeOf(array[0..1])));
+    comptime testing.expect(isSingleItemPtr(@TypeOf(&array[0])));
+    comptime testing.expect(!isSingleItemPtr(@TypeOf(array)));
+    var runtime_zero: usize = 0;
+    testing.expect(!isSingleItemPtr(@TypeOf(array[runtime_zero..1])));
 }
 
 pub fn isManyItemPtr(comptime T: type) bool {
@@ -259,7 +260,8 @@ pub fn isSlice(comptime T: type) bool {
 
 test "std.meta.trait.isSlice" {
     const array = [_]u8{0} ** 10;
-    testing.expect(isSlice(@TypeOf(array[0..])));
+    var runtime_zero: usize = 0;
+    testing.expect(isSlice(@TypeOf(array[runtime_zero..])));
     testing.expect(!isSlice(@TypeOf(array)));
     testing.expect(!isSlice(@TypeOf(&array[0])));
 }
@@ -276,7 +278,7 @@ pub fn isIndexable(comptime T: type) bool {
 
 test "std.meta.trait.isIndexable" {
     const array = [_]u8{0} ** 10;
-    const slice = array[0..];
+    const slice = @as([]const u8, &array);
 
     testing.expect(isIndexable(@TypeOf(array)));
     testing.expect(isIndexable(@TypeOf(&array)));

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -957,8 +957,10 @@ fn linuxLookupNameFromDns(
         }
     }
 
-    var hack: usize = 0; // TODO remove this hack
-    var ap = [2][]u8{ apbuf[0][0..hack], apbuf[1][0..hack] };
+    var ap = [2][]u8{ apbuf[0], apbuf[1] };
+    ap[0].len = 0;
+    ap[1].len = 0;
+
     try resMSendRc(qp[0..nq], ap[0..nq], apbuf[0..nq], rc);
 
     var i: usize = 0;

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -612,8 +612,7 @@ fn linuxLookupName(
         } else {
             mem.copy(u8, &sa6.addr, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff");
             mem.copy(u8, &da6.addr, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff");
-            // TODO https://github.com/ziglang/zig/issues/863
-            mem.writeIntNative(u32, @ptrCast(*[4]u8, da6.addr[12..].ptr), addr.addr.in.addr);
+            mem.writeIntNative(u32, da6.addr[12..], addr.addr.in.addr);
             da4.addr = addr.addr.in.addr;
             da = @ptrCast(*os.sockaddr, &da4);
             dalen = @sizeOf(os.sockaddr_in);
@@ -821,7 +820,7 @@ fn linuxLookupNameFromHosts(
             // Skip to the delimiter in the stream, to fix parsing
             try stream.skipUntilDelimiterOrEof('\n');
             // Use the truncated line. A truncated comment or hostname will be handled correctly.
-            break :blk line_buf[0..];
+            break :blk @as([]u8, &line_buf); // TODO the cast should not be necessary
         },
         else => |e| return e,
     }) |line| {
@@ -958,7 +957,8 @@ fn linuxLookupNameFromDns(
         }
     }
 
-    var ap = [2][]u8{ apbuf[0][0..0], apbuf[1][0..0] };
+    var hack: usize = 0; // TODO remove this hack
+    var ap = [2][]u8{ apbuf[0][0..hack], apbuf[1][0..hack] };
     try resMSendRc(qp[0..nq], ap[0..nq], apbuf[0..nq], rc);
 
     var i: usize = 0;
@@ -1015,7 +1015,7 @@ fn getResolvConf(allocator: *mem.Allocator, rc: *ResolvConf) !void {
             // Skip to the delimiter in the stream, to fix parsing
             try stream.skipUntilDelimiterOrEof('\n');
             // Give an empty line to the while loop, which will be skipped.
-            break :blk line_buf[0..0];
+            break :blk @as([]u8, line_buf[0..0]); // TODO the cast should not be necessary
         },
         else => |e| return e,
     }) |line| {

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1276,7 +1276,15 @@ pub fn unexpectedError(err: Win32Error) std.os.UnexpectedError {
         // 614 is the length of the longest windows error desciption
         var buf_u16: [614]u16 = undefined;
         var buf_u8: [614]u8 = undefined;
-        var len = kernel32.FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, null, err, MAKELANGID(LANG.NEUTRAL, SUBLANG.DEFAULT), buf_u16[0..].ptr, buf_u16.len / @sizeOf(TCHAR), null);
+        const len = kernel32.FormatMessageW(
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            null,
+            err,
+            MAKELANGID(LANG.NEUTRAL, SUBLANG.DEFAULT),
+            &buf_u16,
+            buf_u16.len / @sizeOf(TCHAR),
+            null,
+        );
         _ = std.unicode.utf16leToUtf8(&buf_u8, buf_u16[0..len]) catch unreachable;
         std.debug.warn("error.Unexpected: GetLastError({}): {}\n", .{ @enumToInt(err), buf_u8[0..len] });
         std.debug.dumpCurrentStackTrace(null);

--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -5,7 +5,7 @@
 // ```
 // var buf: [8]u8 = undefined;
 // try std.crypto.randomBytes(buf[0..]);
-// const seed = mem.readIntSliceLittle(u64, buf[0..8]);
+// const seed = mem.readIntLittle(u64, buf[0..8]);
 //
 // var r = DefaultPrng.init(seed);
 //

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -251,12 +251,12 @@ pub const Utf16LeIterator = struct {
     pub fn nextCodepoint(it: *Utf16LeIterator) !?u21 {
         assert(it.i <= it.bytes.len);
         if (it.i == it.bytes.len) return null;
-        const c0: u21 = mem.readIntSliceLittle(u16, it.bytes[it.i .. it.i + 2]);
+        const c0: u21 = mem.readIntLittle(u16, it.bytes[it.i..][0..2]);
         if (c0 & ~@as(u21, 0x03ff) == 0xd800) {
             // surrogate pair
             it.i += 2;
             if (it.i >= it.bytes.len) return error.DanglingSurrogateHalf;
-            const c1: u21 = mem.readIntSliceLittle(u16, it.bytes[it.i .. it.i + 2]);
+            const c1: u21 = mem.readIntLittle(u16, it.bytes[it.i..][0..2]);
             if (c1 & ~@as(u21, 0x03ff) != 0xdc00) return error.ExpectedSecondSurrogateHalf;
             it.i += 2;
             return 0x10000 + (((c0 & 0x03ff) << 10) | (c1 & 0x03ff));
@@ -630,11 +630,11 @@ test "utf8ToUtf16LeWithNull" {
     }
 }
 
-/// Converts a UTF-8 string literal into a UTF-16LE string literal. 
-pub fn utf8ToUtf16LeStringLiteral(comptime utf8: []const u8) *const [calcUtf16LeLen(utf8) :0] u16 {
+/// Converts a UTF-8 string literal into a UTF-16LE string literal.
+pub fn utf8ToUtf16LeStringLiteral(comptime utf8: []const u8) *const [calcUtf16LeLen(utf8):0]u16 {
     comptime {
         const len: usize = calcUtf16LeLen(utf8);
-        var utf16le: [len :0]u16 = [_ :0]u16{0} ** len;
+        var utf16le: [len:0]u16 = [_:0]u16{0} ** len;
         const utf16le_len = utf8ToUtf16Le(&utf16le, utf8[0..]) catch |err| @compileError(err);
         assert(len == utf16le_len);
         return &utf16le;
@@ -660,8 +660,8 @@ fn calcUtf16LeLen(utf8: []const u8) usize {
 }
 
 test "utf8ToUtf16LeStringLiteral" {
-{
-        const bytes = [_:0]u16{ 0x41 };
+    {
+        const bytes = [_:0]u16{0x41};
         const utf16 = utf8ToUtf16LeStringLiteral("A");
         testing.expectEqualSlices(u16, &bytes, utf16);
         testing.expect(utf16[1] == 0);
@@ -673,19 +673,19 @@ test "utf8ToUtf16LeStringLiteral" {
         testing.expect(utf16[2] == 0);
     }
     {
-        const bytes = [_:0]u16{ 0x02FF };
+        const bytes = [_:0]u16{0x02FF};
         const utf16 = utf8ToUtf16LeStringLiteral("\u{02FF}");
         testing.expectEqualSlices(u16, &bytes, utf16);
         testing.expect(utf16[1] == 0);
     }
     {
-        const bytes = [_:0]u16{ 0x7FF };
+        const bytes = [_:0]u16{0x7FF};
         const utf16 = utf8ToUtf16LeStringLiteral("\u{7FF}");
         testing.expectEqualSlices(u16, &bytes, utf16);
         testing.expect(utf16[1] == 0);
     }
     {
-        const bytes = [_:0]u16{ 0x801 };
+        const bytes = [_:0]u16{0x801};
         const utf16 = utf8ToUtf16LeStringLiteral("\u{801}");
         testing.expectEqualSlices(u16, &bytes, utf16);
         testing.expect(utf16[1] == 0);

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -128,7 +128,7 @@ export fn stage2_translate_c(
     args_end: [*]?[*]const u8,
     resources_path: [*:0]const u8,
 ) Error {
-    var errors = @as([*]translate_c.ClangErrMsg, undefined)[0..0];
+    var errors: []translate_c.ClangErrMsg = &[0]translate_c.ClangErrMsg{};
     out_ast.* = translate_c.translate(std.heap.c_allocator, args_begin, args_end, &errors, resources_path) catch |err| switch (err) {
         error.SemanticAnalyzeFail => {
             out_errors_ptr.* = errors.ptr;

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -1744,20 +1744,18 @@ fn writeEscapedString(buf: []u8, s: []const u8) void {
 // Returns either a string literal or a slice of `buf`.
 fn escapeChar(c: u8, char_buf: *[4]u8) []const u8 {
     return switch (c) {
-        '\"' => "\\\""[0..],
-        '\'' => "\\'"[0..],
-        '\\' => "\\\\"[0..],
-        '\n' => "\\n"[0..],
-        '\r' => "\\r"[0..],
-        '\t' => "\\t"[0..],
-        else => {
-            // Handle the remaining escapes Zig doesn't support by turning them
-            // into their respective hex representation
-            if (std.ascii.isCntrl(c))
-                return std.fmt.bufPrint(char_buf[0..], "\\x{x:0<2}", .{c}) catch unreachable
-            else
-                return std.fmt.bufPrint(char_buf[0..], "{c}", .{c}) catch unreachable;
-        },
+        '\"' => "\\\"",
+        '\'' => "\\'",
+        '\\' => "\\\\",
+        '\n' => "\\n",
+        '\r' => "\\r",
+        '\t' => "\\t",
+        // Handle the remaining escapes Zig doesn't support by turning them
+        // into their respective hex representation
+        else => if (std.ascii.isCntrl(c))
+            std.fmt.bufPrint(char_buf, "\\x{x:0<2}", .{c}) catch unreachable
+        else
+            std.fmt.bufPrint(char_buf, "{c}", .{c}) catch unreachable,
     };
 }
 

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -231,6 +231,7 @@ enum ConstPtrSpecial {
     // The pointer is a reference to a single object.
     ConstPtrSpecialRef,
     // The pointer points to an element in an underlying array.
+    // Not to be confused with ConstPtrSpecialSubArray.
     ConstPtrSpecialBaseArray,
     // The pointer points to a field in an underlying struct.
     ConstPtrSpecialBaseStruct,
@@ -257,6 +258,10 @@ enum ConstPtrSpecial {
     // types to be the same, so all optionals of pointer types use x_ptr
     // instead of x_optional.
     ConstPtrSpecialNull,
+    // The pointer points to a sub-array (not an individual element).
+    // Not to be confused with ConstPtrSpecialBaseArray. However, it uses the same
+    // union payload struct (base_array).
+    ConstPtrSpecialSubArray,
 };
 
 enum ConstPtrMut {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -3711,6 +3711,7 @@ struct IrInstGenSlice {
     IrInstGen *start;
     IrInstGen *end;
     IrInstGen *result_loc;
+    ZigValue *sentinel;
     bool safety_check_on;
 };
 

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -4486,7 +4486,14 @@ static uint32_t get_async_frame_align_bytes(CodeGen *g) {
 }
 
 uint32_t get_ptr_align(CodeGen *g, ZigType *type) {
-    ZigType *ptr_type = get_src_ptr_type(type);
+    ZigType *ptr_type;
+    if (type->id == ZigTypeIdStruct) {
+        assert(type->data.structure.special == StructSpecialSlice);
+        TypeStructField *ptr_field = type->data.structure.fields[slice_ptr_index];
+        ptr_type = resolve_struct_field_type(g, ptr_field);
+    } else {
+        ptr_type = get_src_ptr_type(type);
+    }
     if (ptr_type->id == ZigTypeIdPointer) {
         return (ptr_type->data.pointer.explicit_alignment == 0) ?
             get_abi_alignment(g, ptr_type->data.pointer.child_type) : ptr_type->data.pointer.explicit_alignment;
@@ -4503,8 +4510,15 @@ uint32_t get_ptr_align(CodeGen *g, ZigType *type) {
     }
 }
 
-bool get_ptr_const(ZigType *type) {
-    ZigType *ptr_type = get_src_ptr_type(type);
+bool get_ptr_const(CodeGen *g, ZigType *type) {
+    ZigType *ptr_type;
+    if (type->id == ZigTypeIdStruct) {
+        assert(type->data.structure.special == StructSpecialSlice);
+        TypeStructField *ptr_field = type->data.structure.fields[slice_ptr_index];
+        ptr_type = resolve_struct_field_type(g, ptr_field);
+    } else {
+        ptr_type = get_src_ptr_type(type);
+    }
     if (ptr_type->id == ZigTypeIdPointer) {
         return ptr_type->data.pointer.is_const;
     } else if (ptr_type->id == ZigTypeIdFn) {

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5280,6 +5280,11 @@ static uint32_t hash_const_val_ptr(ZigValue *const_val) {
             hash_val += hash_ptr(const_val->data.x_ptr.data.base_array.array_val);
             hash_val += hash_size(const_val->data.x_ptr.data.base_array.elem_index);
             return hash_val;
+        case ConstPtrSpecialSubArray:
+            hash_val += (uint32_t)2643358777;
+            hash_val += hash_ptr(const_val->data.x_ptr.data.base_array.array_val);
+            hash_val += hash_size(const_val->data.x_ptr.data.base_array.elem_index);
+            return hash_val;
         case ConstPtrSpecialBaseStruct:
             hash_val += (uint32_t)3518317043;
             hash_val += hash_ptr(const_val->data.x_ptr.data.base_struct.struct_val);
@@ -6746,6 +6751,7 @@ bool const_values_equal_ptr(ZigValue *a, ZigValue *b) {
                 return false;
             return true;
         case ConstPtrSpecialBaseArray:
+        case ConstPtrSpecialSubArray:
             if (a->data.x_ptr.data.base_array.array_val != b->data.x_ptr.data.base_array.array_val) {
                 return false;
             }
@@ -7003,6 +7009,7 @@ static void render_const_val_ptr(CodeGen *g, Buf *buf, ZigValue *const_val, ZigT
             render_const_value(g, buf, const_ptr_pointee(nullptr, g, const_val, nullptr));
             return;
         case ConstPtrSpecialBaseArray:
+        case ConstPtrSpecialSubArray:
             buf_appendf(buf, "*");
             // TODO we need a source node for const_ptr_pointee because it can generate compile errors
             render_const_value(g, buf, const_ptr_pointee(nullptr, g, const_val, nullptr));

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -791,7 +791,10 @@ ZigType *get_array_type(CodeGen *g, ZigType *child_type, uint64_t array_size, Zi
         return existing_entry->value;
     }
 
-    assert(type_is_resolved(child_type, ResolveStatusSizeKnown));
+    Error err;
+    if ((err = type_resolve(g, child_type, ResolveStatusSizeKnown))) {
+        codegen_report_errors_and_exit(g);
+    }
 
     ZigType *entry = new_type_table_entry(ZigTypeIdArray);
 

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -76,7 +76,7 @@ void resolve_top_level_decl(CodeGen *g, Tld *tld, AstNode *source_node, bool all
 
 ZigType *get_src_ptr_type(ZigType *type);
 uint32_t get_ptr_align(CodeGen *g, ZigType *type);
-bool get_ptr_const(ZigType *type);
+bool get_ptr_const(CodeGen *g, ZigType *type);
 ZigType *validate_var_type(CodeGen *g, AstNode *source_node, ZigType *type_entry);
 ZigType *container_ref_type(ZigType *type_entry);
 bool type_is_complete(ZigType *type_entry);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5425,17 +5425,9 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutableGen *executable, IrI
         return nullptr;
     }
 
-    ZigValue *sentinel = nullptr;
-    if (result_type->id == ZigTypeIdPointer) {
-        ZigType *result_array_type = result_type->data.pointer.child_type;
-        ir_assert(result_array_type->id == ZigTypeIdArray, &instruction->base);
-        sentinel = result_array_type->data.array.sentinel;
-    } else if (result_type->id == ZigTypeIdStruct) {
-        ZigType *res_slice_ptr_type = result_type->data.structure.fields[slice_ptr_index]->type_entry;
-        sentinel = res_slice_ptr_type->data.pointer.sentinel;
-    } else {
-        zig_unreachable();
-    }
+    // This is not whether the result type has a sentinel, but whether there should be a sentinel check,
+    // e.g. if they used [a..b :s] syntax.
+    ZigValue *sentinel = instruction->sentinel;
 
     if (array_type->id == ZigTypeIdArray ||
         (array_type->id == ZigTypeIdPointer && array_type->data.pointer.ptr_len == PtrLenSingle))

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5418,8 +5418,6 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutableGen *executable, IrI
     ZigType *array_type = array_ptr_type->data.pointer.child_type;
     LLVMValueRef array_ptr = get_handle_value(g, array_ptr_ptr, array_type, array_ptr_type);
 
-    LLVMValueRef tmp_struct_ptr = ir_llvm_value(g, instruction->result_loc);
-
     bool want_runtime_safety = instruction->safety_check_on && ir_want_runtime_safety(g, &instruction->base);
 
     ZigType *result_type = instruction->base.value->type;
@@ -5472,6 +5470,8 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutableGen *executable, IrI
             }
         }
         if (!type_has_bits(g, array_type)) {
+            LLVMValueRef tmp_struct_ptr = ir_llvm_value(g, instruction->result_loc);
+
             LLVMValueRef len_field_ptr = LLVMBuildStructGEP(g->builder, tmp_struct_ptr, slice_len_index, "");
 
             // TODO if runtime safety is on, store 0xaaaaaaa in ptr field
@@ -5486,20 +5486,20 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutableGen *executable, IrI
         };
         LLVMValueRef slice_start_ptr = LLVMBuildInBoundsGEP(g->builder, array_ptr, indices, 2, "");
         if (result_type->id == ZigTypeIdPointer) {
+            ir_assert(instruction->result_loc == nullptr, &instruction->base);
             LLVMTypeRef result_ptr_type = get_llvm_type(g, result_type);
-            LLVMValueRef bitcasted = LLVMBuildBitCast(g->builder, slice_start_ptr, result_ptr_type, "");
-            gen_store_untyped(g, bitcasted, tmp_struct_ptr, 0, false);
-            return slice_start_ptr;
+            return LLVMBuildBitCast(g->builder, slice_start_ptr, result_ptr_type, "");
         } else {
+            LLVMValueRef tmp_struct_ptr = ir_llvm_value(g, instruction->result_loc);
             LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, tmp_struct_ptr, slice_ptr_index, "");
             gen_store_untyped(g, slice_start_ptr, ptr_field_ptr, 0, false);
 
             LLVMValueRef len_field_ptr = LLVMBuildStructGEP(g->builder, tmp_struct_ptr, slice_len_index, "");
             LLVMValueRef len_value = LLVMBuildNSWSub(g->builder, end_val, start_val, "");
             gen_store_untyped(g, len_value, len_field_ptr, 0, false);
-        }
 
-        return tmp_struct_ptr;
+            return tmp_struct_ptr;
+        }
     } else if (array_type->id == ZigTypeIdPointer) {
         assert(array_type->data.pointer.ptr_len != PtrLenSingle);
         LLVMValueRef start_val = ir_llvm_value(g, instruction->start);
@@ -5515,12 +5515,12 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutableGen *executable, IrI
 
         LLVMValueRef slice_start_ptr = LLVMBuildInBoundsGEP(g->builder, array_ptr, &start_val, 1, "");
         if (result_type->id == ZigTypeIdPointer) {
+            ir_assert(instruction->result_loc == nullptr, &instruction->base);
             LLVMTypeRef result_ptr_type = get_llvm_type(g, result_type);
-            LLVMValueRef bitcasted = LLVMBuildBitCast(g->builder, slice_start_ptr, result_ptr_type, "");
-            gen_store_untyped(g, bitcasted, tmp_struct_ptr, 0, false);
-            return bitcasted;
+            return LLVMBuildBitCast(g->builder, slice_start_ptr, result_ptr_type, "");
         }
 
+        LLVMValueRef tmp_struct_ptr = ir_llvm_value(g, instruction->result_loc);
         if (type_has_bits(g, array_type)) {
             size_t gen_ptr_index = result_type->data.structure.fields[slice_ptr_index]->gen_index;
             LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, tmp_struct_ptr, gen_ptr_index, "");
@@ -5537,9 +5537,6 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutableGen *executable, IrI
         assert(array_type->data.structure.special == StructSpecialSlice);
         assert(LLVMGetTypeKind(LLVMTypeOf(array_ptr)) == LLVMPointerTypeKind);
         assert(LLVMGetTypeKind(LLVMGetElementType(LLVMTypeOf(array_ptr))) == LLVMStructTypeKind);
-        if (result_type->id != ZigTypeIdPointer) {
-            assert(LLVMGetTypeKind(LLVMGetElementType(LLVMTypeOf(tmp_struct_ptr))) == LLVMStructTypeKind);
-        }
 
         size_t ptr_index = array_type->data.structure.fields[slice_ptr_index]->gen_index;
         assert(ptr_index != SIZE_MAX);
@@ -5578,11 +5575,11 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutableGen *executable, IrI
 
         LLVMValueRef slice_start_ptr = LLVMBuildInBoundsGEP(g->builder, src_ptr, &start_val, 1, "");
         if (result_type->id == ZigTypeIdPointer) {
+            ir_assert(instruction->result_loc == nullptr, &instruction->base);
             LLVMTypeRef result_ptr_type = get_llvm_type(g, result_type);
-            LLVMValueRef bitcasted = LLVMBuildBitCast(g->builder, slice_start_ptr, result_ptr_type, "");
-            gen_store_untyped(g, bitcasted, tmp_struct_ptr, 0, false);
-            return bitcasted;
+            return LLVMBuildBitCast(g->builder, slice_start_ptr, result_ptr_type, "");
         } else {
+            LLVMValueRef tmp_struct_ptr = ir_llvm_value(g, instruction->result_loc);
             LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, tmp_struct_ptr, (unsigned)ptr_index, "");
             gen_store_untyped(g, slice_start_ptr, ptr_field_ptr, 0, false);
 
@@ -6676,7 +6673,6 @@ static LLVMValueRef gen_const_ptr_array_recursive(CodeGen *g, ZigValue *array_co
         };
         return LLVMConstInBoundsGEP(base_ptr, indices, 2);
     } else {
-        assert(parent->id == ConstParentIdScalar);
         return base_ptr;
     }
 }
@@ -6904,6 +6900,7 @@ static LLVMValueRef gen_const_val_ptr(CodeGen *g, ZigValue *const_val, const cha
                 return const_val->llvm_value;
             }
         case ConstPtrSpecialBaseArray:
+        case ConstPtrSpecialSubArray:
             {
                 ZigValue *array_const_val = const_val->data.x_ptr.data.base_array.array_val;
                 assert(array_const_val->type->id == ZigTypeIdArray);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5530,9 +5530,16 @@ static LLVMValueRef ir_render_slice(CodeGen *g, IrExecutableGen *executable, IrI
         }
 
         LLVMValueRef tmp_struct_ptr = ir_llvm_value(g, instruction->result_loc);
+
         size_t gen_ptr_index = result_type->data.structure.fields[slice_ptr_index]->gen_index;
         LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, tmp_struct_ptr, gen_ptr_index, "");
         gen_store_untyped(g, slice_start_ptr, ptr_field_ptr, 0, false);
+
+        size_t gen_len_index = result_type->data.structure.fields[slice_len_index]->gen_index;
+        LLVMValueRef len_field_ptr = LLVMBuildStructGEP(g->builder, tmp_struct_ptr, gen_len_index, "");
+        LLVMValueRef len_value = LLVMBuildNSWSub(g->builder, end_val, start_val, "");
+        gen_store_untyped(g, len_value, len_field_ptr, 0, false);
+
         return tmp_struct_ptr;
 
     } else if (array_type->id == ZigTypeIdStruct) {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -3732,7 +3732,8 @@ static IrInstSrc *ir_build_slice_src(IrBuilderSrc *irb, Scope *scope, AstNode *s
 }
 
 static IrInstGen *ir_build_slice_gen(IrAnalyze *ira, IrInst *source_instruction, ZigType *slice_type,
-    IrInstGen *ptr, IrInstGen *start, IrInstGen *end, bool safety_check_on, IrInstGen *result_loc)
+    IrInstGen *ptr, IrInstGen *start, IrInstGen *end, bool safety_check_on, IrInstGen *result_loc,
+    ZigValue *sentinel)
 {
     IrInstGenSlice *instruction = ir_build_inst_gen<IrInstGenSlice>(
             &ira->new_irb, source_instruction->scope, source_instruction->source_node);
@@ -3742,6 +3743,7 @@ static IrInstGen *ir_build_slice_gen(IrAnalyze *ira, IrInst *source_instruction,
     instruction->end = end;
     instruction->safety_check_on = safety_check_on;
     instruction->result_loc = result_loc;
+    instruction->sentinel = sentinel;
 
     ir_ref_inst_gen(ptr, ira->new_irb.current_basic_block);
     ir_ref_inst_gen(start, ira->new_irb.current_basic_block);
@@ -26667,7 +26669,7 @@ done_with_return_type:
     }
 
     return ir_build_slice_gen(ira, &instruction->base.base, return_type, ptr_ptr,
-            casted_start, end, instruction->safety_check_on, result_loc);
+            casted_start, end, instruction->safety_check_on, result_loc, sentinel_val);
 }
 
 static IrInstGen *ir_analyze_instruction_has_field(IrAnalyze *ira, IrInstSrcHasField *instruction) {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -14633,7 +14633,7 @@ static IrInstGen *ir_analyze_cast(IrAnalyze *ira, IrInst *source_instr,
         return ir_analyze_widen_or_shorten(ira, source_instr, value, wanted_type);
     }
 
-    // *[N]T to ?[]const T
+    // *[N]T to ?[]T
     if (wanted_type->id == ZigTypeIdOptional &&
         is_slice(wanted_type->data.maybe.child_type) &&
         actual_type->id == ZigTypeIdPointer &&

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -26249,6 +26249,7 @@ static IrInstGen *ir_analyze_instruction_slice(IrAnalyze *ira, IrInstSrcSlice *i
         end = nullptr;
     }
 
+    ZigValue *slice_sentinel_val = nullptr;
     ZigType *non_sentinel_slice_ptr_type;
     ZigType *elem_type;
 
@@ -26299,6 +26300,7 @@ static IrInstGen *ir_analyze_instruction_slice(IrAnalyze *ira, IrInstSrcSlice *i
         }
     } else if (is_slice(array_type)) {
         ZigType *maybe_sentineled_slice_ptr_type = array_type->data.structure.fields[slice_ptr_index]->type_entry;
+        slice_sentinel_val = maybe_sentineled_slice_ptr_type->data.pointer.sentinel;
         non_sentinel_slice_ptr_type = adjust_ptr_sentinel(ira->codegen, maybe_sentineled_slice_ptr_type, nullptr);
         elem_type = non_sentinel_slice_ptr_type->data.pointer.child_type;
     } else {
@@ -26376,6 +26378,8 @@ static IrInstGen *ir_analyze_instruction_slice(IrAnalyze *ira, IrInstSrcSlice *i
                     PtrLenSingle, ptr_byte_alignment, 0, 0, false);
             goto done_with_return_type;
         }
+    } else if (array_sentinel == nullptr && end == nullptr) {
+        array_sentinel = slice_sentinel_val;
     }
     if (array_sentinel != nullptr) {
         // TODO deal with non-abi-alignment here

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -292,7 +292,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\pub export fn main() c_int {
         \\    var array = [_]u32{ 1, 7, 3, 2, 0, 9, 4, 8, 6, 5 };
         \\
-        \\    c.qsort(@ptrCast(?*c_void, array[0..].ptr), @intCast(c_ulong, array.len), @sizeOf(i32), compare_fn);
+        \\    c.qsort(@ptrCast(?*c_void, &array), @intCast(c_ulong, array.len), @sizeOf(i32), compare_fn);
         \\
         \\    for (array) |item, i| {
         \\        if (item != i) {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1903,17 +1903,16 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:7:15: error: switch must handle all possibilities",
     });
 
-    // TODO uncomment before merging branch
-    //cases.add("reading past end of pointer casted array",
-    //    \\comptime {
-    //    \\    const array: [4]u8 = "aoeu".*;
-    //    \\    const sub_array = array[1..];
-    //    \\    const int_ptr = @ptrCast(*const u24, sub_array);
-    //    \\    const deref = int_ptr.*;
-    //    \\}
-    //, &[_][]const u8{
-    //    "tmp.zig:5:26: error: attempt to read 4 bytes from [4]u8 at index 1 which is 3 bytes",
-    //});
+    cases.add("reading past end of pointer casted array",
+        \\comptime {
+        \\    const array: [4]u8 = "aoeu".*;
+        \\    const sub_array = array[1..];
+        \\    const int_ptr = @ptrCast(*const u24, sub_array);
+        \\    const deref = int_ptr.*;
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:5:26: error: attempt to read 4 bytes from [4]u8 at index 1 which is 3 bytes",
+    });
 
     cases.add("error note for function parameter incompatibility",
         \\fn do_the_thing(func: fn (arg: i32) void) void {}

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -103,18 +103,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:3:23: error: pointer to size 0 type has no address",
     });
 
-    cases.addTest("slice to pointer conversion mismatch",
-        \\pub fn bytesAsSlice(bytes: var) [*]align(1) const u16 {
-        \\    return @ptrCast([*]align(1) const u16, bytes.ptr)[0..1];
-        \\}
-        \\test "bytesAsSlice" {
-        \\    const bytes = [_]u8{ 0xDE, 0xAD, 0xBE, 0xEF };
-        \\    const slice = bytesAsSlice(bytes[0..]);
-        \\}
-    , &[_][]const u8{
-        "tmp.zig:2:54: error: expected type '[*]align(1) const u16', found '[]align(1) const u16'",
-    });
-
     cases.addTest("access invalid @typeInfo decl",
         \\const A = B;
         \\test "Crash" {
@@ -1915,16 +1903,17 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:7:15: error: switch must handle all possibilities",
     });
 
-    cases.add("reading past end of pointer casted array",
-        \\comptime {
-        \\    const array: [4]u8 = "aoeu".*;
-        \\    const slice = array[1..];
-        \\    const int_ptr = @ptrCast(*const u24, slice.ptr);
-        \\    const deref = int_ptr.*;
-        \\}
-    , &[_][]const u8{
-        "tmp.zig:5:26: error: attempt to read 4 bytes from [4]u8 at index 1 which is 3 bytes",
-    });
+    // TODO uncomment before merging branch
+    //cases.add("reading past end of pointer casted array",
+    //    \\comptime {
+    //    \\    const array: [4]u8 = "aoeu".*;
+    //    \\    const sub_array = array[1..];
+    //    \\    const int_ptr = @ptrCast(*const u24, sub_array);
+    //    \\    const deref = int_ptr.*;
+    //    \\}
+    //, &[_][]const u8{
+    //    "tmp.zig:5:26: error: attempt to read 4 bytes from [4]u8 at index 1 which is 3 bytes",
+    //});
 
     cases.add("error note for function parameter incompatibility",
         \\fn do_the_thing(func: fn (arg: i32) void) void {}

--- a/test/runtime_safety.zig
+++ b/test/runtime_safety.zig
@@ -69,7 +69,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\}
         \\pub fn main() void {
         \\    var buf: [4]u8 = undefined;
-        \\    const ptr = buf[0..].ptr;
+        \\    const ptr: [*]u8 = &buf;
         \\    const slice = ptr[0..3 :0];
         \\}
     );

--- a/test/stage1/behavior/align.zig
+++ b/test/stage1/behavior/align.zig
@@ -5,10 +5,17 @@ const builtin = @import("builtin");
 var foo: u8 align(4) = 100;
 
 test "global variable alignment" {
-    expect(@TypeOf(&foo).alignment == 4);
-    expect(@TypeOf(&foo) == *align(4) u8);
-    const slice = @as(*[1]u8, &foo)[0..];
-    expect(@TypeOf(slice) == []align(4) u8);
+    comptime expect(@TypeOf(&foo).alignment == 4);
+    comptime expect(@TypeOf(&foo) == *align(4) u8);
+    {
+        const slice = @as(*[1]u8, &foo)[0..];
+        comptime expect(@TypeOf(slice) == *align(4) [1]u8);
+    }
+    {
+        var runtime_zero: usize = 0;
+        const slice = @as(*[1]u8, &foo)[runtime_zero..];
+        comptime expect(@TypeOf(slice) == []align(4) u8);
+    }
 }
 
 fn derp() align(@sizeOf(usize) * 2) i32 {

--- a/test/stage1/behavior/align.zig
+++ b/test/stage1/behavior/align.zig
@@ -171,18 +171,19 @@ test "runtime known array index has best alignment possible" {
 
     // because pointer is align 2 and u32 align % 2 == 0 we can assume align 2
     var smaller align(2) = [_]u32{ 1, 2, 3, 4 };
-    comptime expect(@TypeOf(smaller[0..]) == []align(2) u32);
-    comptime expect(@TypeOf(smaller[0..].ptr) == [*]align(2) u32);
-    testIndex(smaller[0..].ptr, 0, *align(2) u32);
-    testIndex(smaller[0..].ptr, 1, *align(2) u32);
-    testIndex(smaller[0..].ptr, 2, *align(2) u32);
-    testIndex(smaller[0..].ptr, 3, *align(2) u32);
+    var runtime_zero: usize = 0;
+    comptime expect(@TypeOf(smaller[runtime_zero..]) == []align(2) u32);
+    comptime expect(@TypeOf(smaller[runtime_zero..].ptr) == [*]align(2) u32);
+    testIndex(smaller[runtime_zero..].ptr, 0, *align(2) u32);
+    testIndex(smaller[runtime_zero..].ptr, 1, *align(2) u32);
+    testIndex(smaller[runtime_zero..].ptr, 2, *align(2) u32);
+    testIndex(smaller[runtime_zero..].ptr, 3, *align(2) u32);
 
     // has to use ABI alignment because index known at runtime only
-    testIndex2(array[0..].ptr, 0, *u8);
-    testIndex2(array[0..].ptr, 1, *u8);
-    testIndex2(array[0..].ptr, 2, *u8);
-    testIndex2(array[0..].ptr, 3, *u8);
+    testIndex2(array[runtime_zero..].ptr, 0, *u8);
+    testIndex2(array[runtime_zero..].ptr, 1, *u8);
+    testIndex2(array[runtime_zero..].ptr, 2, *u8);
+    testIndex2(array[runtime_zero..].ptr, 3, *u8);
 }
 fn testIndex(smaller: [*]align(2) u32, index: usize, comptime T: type) void {
     comptime expect(@TypeOf(&smaller[index]) == T);

--- a/test/stage1/behavior/cast.zig
+++ b/test/stage1/behavior/cast.zig
@@ -435,7 +435,8 @@ fn incrementVoidPtrValue(value: ?*c_void) void {
 
 test "implicit cast from [*]T to ?*c_void" {
     var a = [_]u8{ 3, 2, 1 };
-    incrementVoidPtrArray(a[0..].ptr, 3);
+    var runtime_zero: usize = 0;
+    incrementVoidPtrArray(a[runtime_zero..].ptr, 3);
     expect(std.mem.eql(u8, &a, &[_]u8{ 4, 3, 2 }));
 }
 

--- a/test/stage1/behavior/eval.zig
+++ b/test/stage1/behavior/eval.zig
@@ -524,7 +524,7 @@ test "comptime slice of slice preserves comptime var" {
 test "comptime slice of pointer preserves comptime var" {
     comptime {
         var buff: [10]u8 = undefined;
-        var a = buff[0..].ptr;
+        var a = @ptrCast([*]u8, &buff);
         a[0..1][0] = 1;
         expect(buff[0..][0..][0] == 1);
     }

--- a/test/stage1/behavior/misc.zig
+++ b/test/stage1/behavior/misc.zig
@@ -102,8 +102,8 @@ test "memcpy and memset intrinsics" {
     var foo: [20]u8 = undefined;
     var bar: [20]u8 = undefined;
 
-    @memset(foo[0..].ptr, 'A', foo.len);
-    @memcpy(bar[0..].ptr, foo[0..].ptr, bar.len);
+    @memset(&foo, 'A', foo.len);
+    @memcpy(&bar, &foo, bar.len);
 
     if (bar[11] != 'A') unreachable;
 }
@@ -565,12 +565,16 @@ test "volatile load and store" {
     expect(ptr.* == 1235);
 }
 
-test "slice string literal has type []const u8" {
+test "slice string literal has correct type" {
     comptime {
-        expect(@TypeOf("aoeu"[0..]) == []const u8);
+        expect(@TypeOf("aoeu"[0..]) == *const [4:0]u8);
         const array = [_]i32{ 1, 2, 3, 4 };
-        expect(@TypeOf(array[0..]) == []const i32);
+        expect(@TypeOf(array[0..]) == *const [4]i32);
     }
+    var runtime_zero: usize = 0;
+    expect(@TypeOf("aoeu"[runtime_zero..]) == [:0]const u8);
+    const array = [_]i32{ 1, 2, 3, 4 };
+    expect(@TypeOf(array[runtime_zero..]) == []const u8);
 }
 
 test "pointer child field" {

--- a/test/stage1/behavior/misc.zig
+++ b/test/stage1/behavior/misc.zig
@@ -572,9 +572,9 @@ test "slice string literal has correct type" {
         expect(@TypeOf(array[0..]) == *const [4]i32);
     }
     var runtime_zero: usize = 0;
-    expect(@TypeOf("aoeu"[runtime_zero..]) == [:0]const u8);
+    comptime expect(@TypeOf("aoeu"[runtime_zero..]) == [:0]const u8);
     const array = [_]i32{ 1, 2, 3, 4 };
-    expect(@TypeOf(array[runtime_zero..]) == []const u8);
+    comptime expect(@TypeOf(array[runtime_zero..]) == []const i32);
 }
 
 test "pointer child field" {

--- a/test/stage1/behavior/pointers.zig
+++ b/test/stage1/behavior/pointers.zig
@@ -159,12 +159,13 @@ test "allowzero pointer and slice" {
     var opt_ptr: ?[*]allowzero i32 = ptr;
     expect(opt_ptr != null);
     expect(@ptrToInt(ptr) == 0);
-    var slice = ptr[0..10];
-    expect(@TypeOf(slice) == []allowzero i32);
+    var runtime_zero: usize = 0;
+    var slice = ptr[runtime_zero..10];
+    comptime expect(@TypeOf(slice) == []allowzero i32);
     expect(@ptrToInt(&slice[5]) == 20);
 
-    expect(@typeInfo(@TypeOf(ptr)).Pointer.is_allowzero);
-    expect(@typeInfo(@TypeOf(slice)).Pointer.is_allowzero);
+    comptime expect(@typeInfo(@TypeOf(ptr)).Pointer.is_allowzero);
+    comptime expect(@typeInfo(@TypeOf(slice)).Pointer.is_allowzero);
 }
 
 test "assign null directly to C pointer and test null equality" {

--- a/test/stage1/behavior/ptrcast.zig
+++ b/test/stage1/behavior/ptrcast.zig
@@ -13,7 +13,7 @@ fn testReinterpretBytesAsInteger() void {
         builtin.Endian.Little => 0xab785634,
         builtin.Endian.Big => 0x345678ab,
     };
-    expect(@ptrCast(*align(1) const u32, bytes[1..5].ptr).* == expected);
+    expect(@ptrCast(*align(1) const u32, bytes[1..5]).* == expected);
 }
 
 test "reinterpret bytes of an array into an extern struct" {

--- a/test/stage1/behavior/slice.zig
+++ b/test/stage1/behavior/slice.zig
@@ -130,3 +130,82 @@ test "empty array to slice" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "@ptrCast slice to pointer" {
+    const S = struct {
+        fn doTheTest() void {
+            var array align(@alignOf(u16)) = [5]u8{ 0xff, 0xff, 0xff, 0xff, 0xff };
+            var slice: []u8 = &array;
+            var ptr = @ptrCast(*u16, slice);
+            expect(ptr.* == 65535);
+        }
+    };
+
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
+test "slicing producing an array" {
+    const S = struct {
+        fn doTheTest() void {
+            testArray();
+            testArrayZ();
+            testPointer();
+            testPointerZ();
+            testSlice();
+            testSliceZ();
+        }
+
+        fn testArray() void {
+            var array = [5]u8{ 1, 2, 3, 4, 5 };
+            var slice = array[1..3];
+            comptime expect(@TypeOf(slice) == *[2]u8);
+            expect(slice[0] == 2);
+            expect(slice[1] == 3);
+        }
+
+        fn testArrayZ() void {
+            var array = [5:0]u8{ 1, 2, 3, 4, 5 };
+            comptime expect(@TypeOf(array[1..3]) == *[2]u8);
+            comptime expect(@TypeOf(array[1..5]) == *[4:0]u8);
+            comptime expect(@TypeOf(array[1..]) == *[4:0]u8);
+            comptime expect(@TypeOf(array[1..3 :4]) == *[2:4]u8);
+        }
+
+        fn testPointer() void {
+            var array = [5]u8{ 1, 2, 3, 4, 5 };
+            var pointer: [*]u8 = &array;
+            var slice = pointer[1..3];
+            comptime expect(@TypeOf(slice) == *[2]u8);
+            expect(slice[0] == 2);
+            expect(slice[1] == 3);
+        }
+
+        fn testPointerZ() void {
+            var array = [5:0]u8{ 1, 2, 3, 4, 5 };
+            var pointer: [*:0]u8 = &array;
+            comptime expect(@TypeOf(pointer[1..3]) == *[2]u8);
+            comptime expect(@TypeOf(pointer[1..3 :4]) == *[2:4]u8);
+        }
+
+        fn testSlice() void {
+            var array = [5]u8{ 1, 2, 3, 4, 5 };
+            var src_slice: []u8 = &array;
+            var slice = src_slice[1..3];
+            comptime expect(@TypeOf(slice) == *[2]u8);
+            expect(slice[0] == 2);
+            expect(slice[1] == 3);
+        }
+
+        fn testSliceZ() void {
+            var array = [5:0]u8{ 1, 2, 3, 4, 5 };
+            var slice: [:0]u8 = &array;
+            comptime expect(@TypeOf(slice[1..3]) == *[2]u8);
+            comptime expect(@TypeOf(slice[1..]) == [:0]u8);
+            comptime expect(@TypeOf(slice[1..3 :4]) == *[2:4]u8);
+        }
+    };
+
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/slice.zig
+++ b/test/stage1/behavior/slice.zig
@@ -145,15 +145,21 @@ test "@ptrCast slice to pointer" {
     comptime S.doTheTest();
 }
 
-test "slicing producing an array" {
+test "slice syntax resulting in pointer-to-array" {
     const S = struct {
         fn doTheTest() void {
             testArray();
             testArrayZ();
+            testArray0();
+            testArrayAlign();
             testPointer();
             testPointerZ();
+            testPointer0();
+            testPointerAlign();
             testSlice();
             testSliceZ();
+            testSlice0();
+            testSliceAlign();
         }
 
         fn testArray() void {
@@ -172,6 +178,28 @@ test "slicing producing an array" {
             comptime expect(@TypeOf(array[1..3 :4]) == *[2:4]u8);
         }
 
+        fn testArray0() void {
+            {
+                var array = [0]u8{};
+                var slice = array[0..0];
+                comptime expect(@TypeOf(slice) == *[0]u8);
+            }
+            {
+                var array = [0:0]u8{};
+                var slice = array[0..0];
+                comptime expect(@TypeOf(slice) == *[0:0]u8);
+                expect(slice[0] == 0);
+            }
+        }
+
+        fn testArrayAlign() void {
+            var array align(4) = [5]u8{ 1, 2, 3, 4, 5 };
+            var slice = array[4..5];
+            comptime expect(@TypeOf(slice) == *align(4) [1]u8);
+            expect(slice[0] == 5);
+            comptime expect(@TypeOf(array[0..2]) == *align(4) [2]u8);
+        }
+
         fn testPointer() void {
             var array = [5]u8{ 1, 2, 3, 4, 5 };
             var pointer: [*]u8 = &array;
@@ -186,6 +214,22 @@ test "slicing producing an array" {
             var pointer: [*:0]u8 = &array;
             comptime expect(@TypeOf(pointer[1..3]) == *[2]u8);
             comptime expect(@TypeOf(pointer[1..3 :4]) == *[2:4]u8);
+        }
+
+        fn testPointer0() void {
+            var pointer: [*]u0 = &[1]u0{0};
+            var slice = pointer[0..1];
+            comptime expect(@TypeOf(slice) == *[1]u0);
+            expect(slice[0] == 0);
+        }
+
+        fn testPointerAlign() void {
+            var array align(4) = [5]u8{ 1, 2, 3, 4, 5 };
+            var pointer: [*]align(4) u8 = &array;
+            var slice = pointer[4..5];
+            comptime expect(@TypeOf(slice) == *align(4) [1]u8);
+            expect(slice[0] == 5);
+            comptime expect(@TypeOf(pointer[0..2]) == *align(4) [2]u8);
         }
 
         fn testSlice() void {
@@ -203,6 +247,30 @@ test "slicing producing an array" {
             comptime expect(@TypeOf(slice[1..3]) == *[2]u8);
             comptime expect(@TypeOf(slice[1..]) == [:0]u8);
             comptime expect(@TypeOf(slice[1..3 :4]) == *[2:4]u8);
+        }
+
+        fn testSlice0() void {
+            {
+                var array = [0]u8{};
+                var src_slice: []u8 = &array;
+                var slice = src_slice[0..0];
+                comptime expect(@TypeOf(slice) == *[0]u8);
+            }
+            {
+                var array = [0:0]u8{};
+                var src_slice: [:0]u8 = &array;
+                var slice = src_slice[0..0];
+                comptime expect(@TypeOf(slice) == *[0]u8);
+            }
+        }
+
+        fn testSliceAlign() void {
+            var array align(4) = [5]u8{ 1, 2, 3, 4, 5 };
+            var src_slice: []align(4) u8 = &array;
+            var slice = src_slice[4..5];
+            comptime expect(@TypeOf(slice) == *align(4) [1]u8);
+            expect(slice[0] == 5);
+            comptime expect(@TypeOf(src_slice[0..2]) == *align(4) [2]u8);
         }
     };
 

--- a/test/stage1/behavior/slice.zig
+++ b/test/stage1/behavior/slice.zig
@@ -10,7 +10,7 @@ test "compile time slice of pointer to hard coded address" {
     expect(@ptrToInt(x) == 0x1000);
     expect(x.len == 0x500);
 
-    expect(@ptrToInt(y.ptr) == 0x1100);
+    expect(@ptrToInt(y) == 0x1100);
     expect(y.len == 0x400);
 }
 

--- a/test/stage1/behavior/slice.zig
+++ b/test/stage1/behavior/slice.zig
@@ -7,7 +7,7 @@ const mem = std.mem;
 const x = @intToPtr([*]i32, 0x1000)[0..0x500];
 const y = x[0x100..];
 test "compile time slice of pointer to hard coded address" {
-    expect(@ptrToInt(x.ptr) == 0x1000);
+    expect(@ptrToInt(x) == 0x1000);
     expect(x.len == 0x500);
 
     expect(@ptrToInt(y.ptr) == 0x1100);
@@ -47,7 +47,9 @@ test "C pointer slice access" {
     var buf: [10]u32 = [1]u32{42} ** 10;
     const c_ptr = @ptrCast([*c]const u32, &buf);
 
-    comptime expectEqual([]const u32, @TypeOf(c_ptr[0..1]));
+    var runtime_zero: usize = 0;
+    comptime expectEqual([]const u32, @TypeOf(c_ptr[runtime_zero..1]));
+    comptime expectEqual(*const [1]u32, @TypeOf(c_ptr[0..1]));
 
     for (c_ptr[0..5]) |*cl| {
         expectEqual(@as(u32, 42), cl.*);
@@ -107,7 +109,9 @@ test "obtaining a null terminated slice" {
     const ptr2 = buf[0..runtime_len :0];
     // ptr2 is a null-terminated slice
     comptime expect(@TypeOf(ptr2) == [:0]u8);
-    comptime expect(@TypeOf(ptr2[0..2]) == []u8);
+    comptime expect(@TypeOf(ptr2[0..2]) == *[2]u8);
+    var runtime_zero: usize = 0;
+    comptime expect(@TypeOf(ptr2[runtime_zero..2]) == []u8);
 }
 
 test "empty array to slice" {

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -409,8 +409,8 @@ const Bitfields = packed struct {
 test "native bit field understands endianness" {
     var all: u64 = 0x7765443322221111;
     var bytes: [8]u8 = undefined;
-    @memcpy(bytes[0..].ptr, @ptrCast([*]u8, &all), 8);
-    var bitfields = @ptrCast(*Bitfields, bytes[0..].ptr).*;
+    @memcpy(&bytes, @ptrCast([*]u8, &all), 8);
+    var bitfields = @ptrCast(*Bitfields, &bytes).*;
 
     expect(bitfields.f1 == 0x1111);
     expect(bitfields.f2 == 0x2222);


### PR DESCRIPTION
This implements #863. Big checklist before this can be merged.

### Unify slices and single-item-pointer-to-array
 * [x] make slices support `@ptrCast`
 * [ ] add `.ptr` property to single-pointer-to-array which decays it into `[*]`
 * [ ] peer type resolution for slice and single-pointer-to-array (example: `[]u8` and `*const [2:0]u8`  should be `[]const u8`)
 * [ ] peer type resolution for optional slice and single-pointer-to-array (example: `lib/std/net.zig:819:60: error: incompatible types: '*[512]u8' and '?[]u8'`)

### Add Behavioral Tests
 * [x] `@ptrCast` slice to pointer
 * [x] slice array
 * [x] slice array, array is 0 bits
 * [x] slice array, sentinel
 * [x] slice array, array is 0 len, sentinel
 * [x] slice pointer
 * [x] slice pointer, pointer is 0 bits
 * [x] slice pointer, sentinel
 * [x] slice slice
 * [x] comptime slice array
 * [x] comptime slice array, elem is 0 bits
 * [x] comptime slice array, elem is 0 bits, sentinel
 * [x] comptime slice pointer
 * [x] comptime slice pointer, elem is 0 bits
 * [x] comptime slice pointer, elem is 0 bits, sentinel
 * [x] comptime slice slice
 * [x] comptime slice slice, elem is 0 bits
 * [x] comptime slice slice, elem is 0 bits, sentinel
 * [x] slice array, preserve alignment
 * [x] slice pointer, preserve alignment
 * [x] slice slice, preserve alignment
 * [x] slice with comptime start and end and a sentinel

### Follow-up Items
 * [x] grep for "863" and do all the fixups that are now possible
 * [x] `    var hack: usize = 0; // TODO remove this hack`
 * [x] fix regressed compile error test "reading past end of pointer casted array"