### PR TITLE
ir: More changes to sentinel-terminated const arrays

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5806,17 +5806,12 @@ ZigValue *get_the_one_possible_value(CodeGen *g, ZigType *type_entry) {
         // The elements array cannot be left unpopulated
         ZigType *array_type = result->type;
         ZigType *elem_type = array_type->data.array.child_type;
-        ZigValue *sentinel_value = array_type->data.array.sentinel;
-        const size_t elem_count = array_type->data.array.len + (sentinel_value != nullptr);
+        const size_t elem_count = array_type->data.array.len;
 
         result->data.x_array.data.s_none.elements = g->pass1_arena->allocate<ZigValue>(elem_count);
         for (size_t i = 0; i < elem_count; i += 1) {
             ZigValue *elem_val = &result->data.x_array.data.s_none.elements[i];
             copy_const_val(g, elem_val, get_the_one_possible_value(g, elem_type));
-        }
-        if (sentinel_value != nullptr) {
-            ZigValue *last_elem_val = &result->data.x_array.data.s_none.elements[elem_count - 1];
-            copy_const_val(g, last_elem_val, sentinel_value);
         }
     } else if (result->type->id == ZigTypeIdPointer) {
         result->data.x_ptr.special = ConstPtrSpecialRef;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -20578,11 +20578,6 @@ static IrInstGen *ir_analyze_instruction_elem_ptr(IrAnalyze *ira, IrInstSrcElemP
     }
 
     if (array_type->id == ZigTypeIdArray) {
-        if (array_type->data.array.len == 0) {
-            ir_add_error_node(ira, elem_ptr_instruction->base.base.source_node,
-                    buf_sprintf("index 0 outside array of size 0"));
-            return ira->codegen->invalid_inst_gen;
-        }
         ZigType *child_type = array_type->data.array.child_type;
         if (ptr_type->data.pointer.host_int_bytes == 0) {
             return_type = get_pointer_to_type_extra(ira->codegen, child_type,
@@ -27656,6 +27651,9 @@ static void buf_write_value_bytes_array(CodeGen *codegen, uint8_t *buf, ZigValue
         ZigValue *elem = &val->data.x_array.data.s_none.elements[elem_i];
         buf_write_value_bytes(codegen, &buf[buf_i], elem);
         buf_i += type_size(codegen, elem->type);
+    }
+    if (val->type->id == ZigTypeIdArray && val->type->data.array.sentinel != nullptr) {
+        buf_write_value_bytes(codegen, &buf[buf_i], val->type->data.array.sentinel);
     }
 }
 

--- a/test/stage1/behavior/array.zig
+++ b/test/stage1/behavior/array.zig
@@ -28,6 +28,24 @@ fn getArrayLen(a: []const u32) usize {
     return a.len;
 }
 
+test "array with sentinels" {
+    const S = struct {
+        fn doTheTest(is_ct: bool) void {
+            var zero_sized: [0:0xde]u8 = [_:0xde]u8{};
+            expectEqual(@as(u8, 0xde), zero_sized[0]);
+            // Disabled at runtime because of
+            // https://github.com/ziglang/zig/issues/4372
+            if (is_ct) {
+                var reinterpreted = @ptrCast(*[1]u8, &zero_sized);
+                expectEqual(@as(u8, 0xde), reinterpreted[0]);
+            }
+        }
+    };
+
+    S.doTheTest(false);
+    comptime S.doTheTest(true);
+}
+
 test "void arrays" {
     var array: [4]void = undefined;
     array[0] = void{};


### PR DESCRIPTION
* Don't add an extra slot for the sentinel. Most of the code keeps using
  the constant value from the type descriptor, let's harmonize all the
  code dealing with sentinels.

* Properly write out sentinel values when reinterpreting pointers at
  comptime.

* Allow the reading of the 0th element in a `[0:S]T` type.