### PR TITLE
fix findllvm and findclang for Fedora 32

### DIFF
--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -38,6 +38,7 @@ if(MSVC)
 else()
   find_path(CLANG_INCLUDE_DIRS NAMES clang/Frontend/ASTUnit.h
       PATHS
+          /usr/include/llvm9.0
           /usr/lib/llvm/9/include
           /usr/lib/llvm-9/include
           /usr/lib/llvm-9.0/include
@@ -49,6 +50,7 @@ else()
       find_library(CLANG_${_prettylibname_}_LIB NAMES ${_libname_}
           PATHS
               ${CLANG_LIBDIRS}
+              /usr/lib64/llvm9.0/lib
               /usr/lib/llvm/9/lib
               /usr/lib/llvm-9/lib
               /usr/lib/llvm-9.0/lib

--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -8,7 +8,7 @@
 # LLVM_LIBDIRS
 
 find_program(LLVM_CONFIG_EXE
-    NAMES llvm-config-9 llvm-config-9.0 llvm-config90 llvm-config
+    NAMES llvm-config-9.0-64 llvm-config-9.0 llvm-config90 llvm-config
     PATHS
         "/mingw64/bin"
         "/c/msys64/mingw64/bin"


### PR DESCRIPTION
I upgraded my workstation to Fedora 32 beta which ships with LLVM/Clang 10.

You can install 9.0 with `dnf install llvm9.0-devel clang9.0-devel` but the cmake scripts need to be adapted.