### PR TITLE
Add LLD_LIBDIRS, similar to CLANG_LIBDIRS

### DIFF
--- a/cmake/Findlld.cmake
+++ b/cmake/Findlld.cmake
@@ -5,6 +5,7 @@
 # LLD_FOUND
 # LLD_INCLUDE_DIRS
 # LLD_LIBRARIES
+# LLD_LIBDIRS
 
 find_path(LLD_INCLUDE_DIRS NAMES lld/Common/Driver.h
     PATHS
@@ -24,6 +25,7 @@ else()
         string(TOUPPER ${_libname_} _prettylibname_)
         find_library(LLD_${_prettylibname_}_LIB NAMES ${_libname_}
             PATHS
+                ${LLD_LIBDIRS}
                 /usr/lib/llvm-10/lib
                 /usr/local/llvm100/lib
                 /mingw64/lib
@@ -49,4 +51,4 @@ endif()
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LLD DEFAULT_MSG LLD_LIBRARIES LLD_INCLUDE_DIRS)
 
-mark_as_advanced(LLD_INCLUDE_DIRS LLD_LIBRARIES)
+mark_as_advanced(LLD_INCLUDE_DIRS LLD_LIBRARIES LLD_LIBDIRS)


### PR DESCRIPTION
I needed this to build on FreeBSD CURRENT with llvm10 package installed, because there ended up being two copies of lld installed.