### PR TITLE
cmake: address new warnings from cmake-3.17

### DIFF
--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -56,6 +56,6 @@ FIND_AND_ADD_CLANG_LIB(clangCrossTU)
 FIND_AND_ADD_CLANG_LIB(clangIndex)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CLANG DEFAULT_MSG CLANG_LIBRARIES CLANG_INCLUDE_DIRS)
+find_package_handle_standard_args(clang DEFAULT_MSG CLANG_LIBRARIES CLANG_INCLUDE_DIRS)
 
 mark_as_advanced(CLANG_INCLUDE_DIRS CLANG_LIBRARIES CLANG_LIBDIRS)

--- a/cmake/Findlld.cmake
+++ b/cmake/Findlld.cmake
@@ -47,6 +47,6 @@ else()
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LLD DEFAULT_MSG LLD_LIBRARIES LLD_INCLUDE_DIRS)
+find_package_handle_standard_args(lld DEFAULT_MSG LLD_LIBRARIES LLD_INCLUDE_DIRS)
 
 mark_as_advanced(LLD_INCLUDE_DIRS LLD_LIBRARIES)

--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -120,6 +120,6 @@ link_directories("${CMAKE_PREFIX_PATH}/lib")
 link_directories("${LLVM_LIBDIRS}")
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LLVM DEFAULT_MSG LLVM_LIBRARIES LLVM_INCLUDE_DIRS)
+find_package_handle_standard_args(llvm DEFAULT_MSG LLVM_LIBRARIES LLVM_INCLUDE_DIRS)
 
 mark_as_advanced(LLVM_INCLUDE_DIRS LLVM_LIBRARIES LLVM_LIBDIRS)


### PR DESCRIPTION
Match package-name case from CMakeLists.txt .

New warning sample:

    The package name passed to `find_package_handle_standard_args` (LLVM) does
    not match the name of the calling package (llvm).  This can lead to
    problems in calling code that expects `find_package` result variables
    (e.g., `_FOUND`) to follow a certain pattern.