### PR TITLE
fix behavior test with --test-evented-io on windows

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -251,6 +251,10 @@ pub const File = struct {
     pub const PReadError = os.PReadError;
 
     pub fn read(self: File, buffer: []u8) ReadError!usize {
+        if (builtin.os.tag == .windows) {
+            const enable_async_io = std.io.is_async and !self.async_block_allowed;
+            return windows.ReadFile(self.handle, buffer, null, enable_async_io);
+        }
         if (need_async_thread and self.io_mode == .blocking and !self.async_block_allowed) {
             return std.event.Loop.instance.?.read(self.handle, buffer);
         } else {
@@ -271,6 +275,10 @@ pub const File = struct {
     }
 
     pub fn pread(self: File, buffer: []u8, offset: u64) PReadError!usize {
+        if (builtin.os.tag == .windows) {
+            const enable_async_io = std.io.is_async and !self.async_block_allowed;
+            return windows.ReadFile(self.handle, buffer, offset, enable_async_io);
+        }
         if (need_async_thread and self.io_mode == .blocking and !self.async_block_allowed) {
             return std.event.Loop.instance.?.pread(self.handle, buffer, offset);
         } else {
@@ -362,6 +370,10 @@ pub const File = struct {
     pub const PWriteError = os.PWriteError;
 
     pub fn write(self: File, bytes: []const u8) WriteError!usize {
+        if (builtin.os.tag == .windows) {
+            const enable_async_io = std.io.is_async and !self.async_block_allowed;
+            return windows.WriteFile(self.handle, bytes, null, enable_async_io);
+        }
         if (need_async_thread and self.io_mode == .blocking and !self.async_block_allowed) {
             return std.event.Loop.instance.?.write(self.handle, bytes);
         } else {
@@ -377,6 +389,10 @@ pub const File = struct {
     }
 
     pub fn pwrite(self: File, bytes: []const u8, offset: u64) PWriteError!usize {
+        if (builtin.os.tag == .windows) {
+            const enable_async_io = std.io.is_async and !self.async_block_allowed;
+            return windows.WriteFile(self.handle, bytes, offset, enable_async_io);
+        }
         if (need_async_thread and self.io_mode == .blocking and !self.async_block_allowed) {
             return std.event.Loop.instance.?.pwrite(self.handle, bytes, offset);
         } else {

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -42,10 +42,12 @@ fn getStdOutHandle() os.fd_t {
     return os.STDOUT_FILENO;
 }
 
+// TODO: async stdout on windows (https://github.com/ziglang/zig/pull/4816#issuecomment-604521023)
 pub fn getStdOut() File {
     return File{
         .handle = getStdOutHandle(),
         .io_mode = .blocking,
+        .async_block_allowed = if (builtin.os.tag == .windows) File.async_block_allowed_yes else File.async_block_allowed_no,
     };
 }
 
@@ -81,10 +83,12 @@ fn getStdInHandle() os.fd_t {
     return os.STDIN_FILENO;
 }
 
+// TODO: async stdin on windows (https://github.com/ziglang/zig/pull/4816#issuecomment-604521023)
 pub fn getStdIn() File {
     return File{
         .handle = getStdInHandle(),
         .io_mode = .blocking,
+        .async_block_allowed = if (builtin.os.tag == .windows) File.async_block_allowed_yes else File.async_block_allowed_no,
     };
 }
 

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -305,7 +305,7 @@ pub const ReadError = error{
 /// For POSIX the limit is `math.maxInt(isize)`.
 pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
     if (builtin.os.tag == .windows) {
-        return windows.ReadFile(fd, buf, null);
+        return windows.ReadFile(fd, buf, null, false);
     }
 
     if (builtin.os.tag == .wasi and !builtin.link_libc) {
@@ -407,7 +407,7 @@ pub const PReadError = ReadError || error{Unseekable};
 /// used to perform the I/O. `error.WouldBlock` is not possible on Windows.
 pub fn pread(fd: fd_t, buf: []u8, offset: u64) PReadError!usize {
     if (builtin.os.tag == .windows) {
-        return windows.ReadFile(fd, buf, offset);
+        return windows.ReadFile(fd, buf, offset, false);
     }
 
     while (true) {
@@ -583,7 +583,7 @@ pub const WriteError = error{
 /// The corresponding POSIX limit is `math.maxInt(isize)`.
 pub fn write(fd: fd_t, bytes: []const u8) WriteError!usize {
     if (builtin.os.tag == .windows) {
-        return windows.WriteFile(fd, bytes, null);
+        return windows.WriteFile(fd, bytes, null, false);
     }
 
     if (builtin.os.tag == .wasi and !builtin.link_libc) {
@@ -708,7 +708,7 @@ pub const PWriteError = WriteError || error{Unseekable};
 /// The corresponding POSIX limit is `math.maxInt(isize)`.
 pub fn pwrite(fd: fd_t, bytes: []const u8, offset: u64) PWriteError!usize {
     if (std.Target.current.os.tag == .windows) {
-        return windows.WriteFile(fd, bytes, offset);
+        return windows.WriteFile(fd, bytes, offset, false);
     }
 
     // Prevent EINVAL.
@@ -1651,7 +1651,7 @@ pub fn renameatW(
     ReplaceIfExists: windows.BOOLEAN,
 ) RenameError!void {
     const access_mask = windows.SYNCHRONIZE | windows.GENERIC_WRITE | windows.DELETE;
-    const src_fd = try windows.OpenFileW(old_dir_fd, old_path, null, access_mask, windows.FILE_OPEN);
+    const src_fd = try windows.OpenFileW(old_dir_fd, old_path, null, access_mask, windows.FILE_OPEN, false);
     defer windows.CloseHandle(src_fd);
 
     const struct_buf_len = @sizeOf(windows.FILE_RENAME_INFORMATION) + (MAX_PATH_BYTES - 1);

--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -470,7 +470,7 @@ pub const Pdb = struct {
     msf: Msf,
 
     pub fn openFile(self: *Pdb, coff_ptr: *coff.Coff, file_name: []u8) !void {
-        self.in_file = try fs.cwd().openFile(file_name, .{});
+        self.in_file = try fs.cwd().openFile(file_name, .{ .always_blocking = true });
         self.allocator = coff_ptr.allocator;
         self.coff = coff_ptr;
 


### PR DESCRIPTION
async io for stdin/out/err is not possible on windows using `CreateIoCompletionPort`. For now always make stdin/out/err blocking.

**Simple file async io works:**
```zig
const std = @import("std");

pub const io_mode = .evented;

pub fn main() !void {
    const test_file = try std.fs.cwd().openFile("test.txt", .{});
    var buf: [256]u8 = undefined;
    const amt = try test_file.read(buf[0..]);
    std.debug.warn("read: {}\n", .{buf[0..amt]});
}
```
Fixed #3717

Edit: See this link why async io on stdin/out/err is not possible on windows: https://tim.mcnamara.nz/post/176613307022/iocp-and-stdio