### PR TITLE
Fix the weird-ass crash on AArch64

### DIFF
--- a/ci/drone/linux_script
+++ b/ci/drone/linux_script
@@ -15,21 +15,6 @@ pip3 install s3cmd
 # This will affect the cmake command below.
 git config core.abbrev 9
 
-# This patch is a workaround for
-# https://github.com/ziglang/zig/issues/4822
-patch <<'END_PATCH'
---- CMakeLists.txt
-+++ CMakeLists.txt
-@@ -430,7 +430,6 @@ set(BUILD_LIBSTAGE2_ARGS "build-lib"
-     --cache on
-     --output-dir "${CMAKE_BINARY_DIR}"
-     ${LIBSTAGE2_RELEASE_ARG}
--    --bundle-compiler-rt
-     -fPIC
-     -lc
-     ${LIBSTAGE2_WINDOWS_ARGS}
-END_PATCH
-
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release "-DCMAKE_INSTALL_PREFIX=$DISTDIR" -DZIG_STATIC=ON -DCMAKE_PREFIX_PATH=/deps/local

--- a/lib/std/special/compiler_rt/floatunditf.zig
+++ b/lib/std/special/compiler_rt/floatunditf.zig
@@ -2,7 +2,7 @@ const builtin = @import("builtin");
 const is_test = builtin.is_test;
 const std = @import("std");
 
-pub fn __floatunditf(a: u128) callconv(.C) f128 {
+pub fn __floatunditf(a: u64) callconv(.C) f128 {
     @setRuntimeSafety(is_test);
 
     if (a == 0) {
@@ -14,11 +14,11 @@ pub fn __floatunditf(a: u128) callconv(.C) f128 {
     const exponent_bias = (1 << (exponent_bits - 1)) - 1;
     const implicit_bit = 1 << mantissa_bits;
 
-    const exp = (u128.bit_count - 1) - @clz(u128, a);
-    const shift = mantissa_bits - @intCast(u7, exp);
+    const exp: u128 = (u64.bit_count - 1) - @clz(u64, a);
+    const shift: u7 = mantissa_bits - @intCast(u7, exp);
 
-    var result: u128 align(16) = (a << shift) ^ implicit_bit;
-    result += (@intCast(u128, exp) + exponent_bias) << mantissa_bits;
+    var result: u128 = (@intCast(u128, a) << shift) ^ implicit_bit;
+    result += (exp + exponent_bias) << mantissa_bits;
 
     return @bitCast(f128, result);
 }

--- a/lib/std/special/compiler_rt/floatunditf_test.zig
+++ b/lib/std/special/compiler_rt/floatunditf_test.zig
@@ -1,6 +1,6 @@
 const __floatunditf = @import("floatunditf.zig").__floatunditf;
 
-fn test__floatunditf(a: u128, expected_hi: u64, expected_lo: u64) void {
+fn test__floatunditf(a: u64, expected_hi: u64, expected_lo: u64) void {
     const x = __floatunditf(a);
 
     const x_repr = @bitCast(u128, x);


### PR DESCRIPTION
## What

It turns out that adding our own implementation of `__addtf3` uncovered a (painfully obvious in hindsight) bug in another unrelated builtin.

## How

The main clue leading to this discovery was this piece of ASM:

```
mov  x19, x1                                
bl   0xffffa3b8e320 <__extendsftf2@plt>     
str  q0, [sp, #48]                          
mov  x0, x21                                
bl   0xffffa3b865b0 <__floatunditf@plt>     
ldr  q2, [sp, #48]                          
mov  v1.16b, v2.16b                         
str  q2, [sp, #80]                          
bl   0xffffa3b8e0b0 <__divtf3@plt>          
str  q0, [sp, #48]                          
mov  x0, x19                                
bl   0xffffa3b865b0 <__floatunditf@plt>     
str  q0, [sp, #64]                          
ldr  q4, [sp, #48]                          
mov  v1.16b, v4.16b                         
bl   0xffffa3b87fc0 <__letf2@plt>           
cmp  w0, #0x0                               
ldr  q6, [sp, #64]                          
ldr  q2, [sp, #80]                          
```

Can you spot the error? No? Because there's no error!
This is the code from `libstdc++`'s `Prime_rehash_policy::need_rehash` that's completely correct and indeed works just fine when linked against `libgcc` or LLVM's `compiler-rt`.

What prompted me to look at `__floatundidf` was this piece of code:
```
str  q0, [sp, #48]                          
mov  x0, x19                                
bl   0xffffa3b865b0 <__floatunditf@plt>    
```
As you can see it only setups `x0`, the first register used for passing arguments, and, being the `xN` registers 64-bit wide, that meant `x1` was actually filled with hot garbage! (Remember that `x0-x7` are scratch registers and are not saved across calls).

The fix is easy peasy, the big question looming over us is: are there any other mistakes like this?

Proudly closes #4822 