### PR TITLE
windows: don't hard-code forward-slash paths

### DIFF
--- a/src-self-hosted/print_targets.zig
+++ b/src-self-hosted/print_targets.zig
@@ -75,7 +75,7 @@ pub fn cmdTargets(
         var dir = try std.fs.cwd().openDir(zig_lib_dir, .{});
         defer dir.close();
 
-        const vers_txt = try dir.readFileAlloc(allocator, "libc/glibc/vers.txt", 10 * 1024);
+        const vers_txt = try dir.readFileAlloc(allocator, "libc" ++ std.fs.path.sep_str ++ "glibc" ++ std.fs.path.sep_str ++ "vers.txt", 10 * 1024);
         defer allocator.free(vers_txt);
 
         var list = std.ArrayList(std.builtin.Version).init(allocator);


### PR DESCRIPTION
`zig targets` -> unable to list targets: BadPathName

after patch native triples look sane:
- windows10: `x86_64-windows.win8_1...win8_1-msvc`
- archlinux: `x86_64-linux.5.5.11...5.5.11-gnu.2.31`
- macos: `x86_64-macosx.10.15.4...10.15.4-gnu`