### PR TITLE
-rdynamic/--export-dynamic fixes

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -1646,6 +1646,10 @@ static void construct_linker_job_elf(LinkJob *lj) {
         lj->args.append("--eh-frame-hdr");
     }
 
+    if (g->linker_rdynamic) {
+        lj->args.append("--export-dynamic");
+    }
+
     lj->args.append("-m");
     lj->args.append(getLDMOption(g->zig_target));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -768,6 +768,11 @@ static int main0(int argc, char **argv) {
                     return EXIT_FAILURE;
                 }
                 dynamic_linker = buf_ptr(linker_args.at(i));
+            } else if (buf_eql_str(arg, "-E") ||
+                buf_eql_str(arg, "--export-dynamic") ||
+                buf_eql_str(arg, "-export-dynamic"))
+            {
+                rdynamic = true;
             } else {
                 fprintf(stderr, "warning: unsupported linker arg: %s\n", buf_ptr(arg));
             }


### PR DESCRIPTION
- `--export-dynamic` not getting set via `-rdynamic` in the ELF linker construction seems to have been a bug? Correct me if I'm wrong, or if `-rdynamic` should be handled in any of the other linker formats (right now `ZigLLVM_MachO` sends `-export_dynamic` and with this PR `ZigLLVM_ELF` sends `--export-dynamic`; `ZigLLVM_Wasm` and `ZigLLVM_COFF` ignore `-rdynamic`).
- As far as I can tell, `-rdynamic` and `-Wl,--export-dynamic` are essentially the same thing with regards to Zig. The difference in other compilers [is that `-rdynamic` doesn't set `--export-dynamic` if it doesn't need to for the target](https://stackoverflow.com/questions/17099281/is-there-any-difference-between-xlinker-export-dynamic-and-rdynamic)? If so, it seems like Zig would probably want to treat the `--export-dynamic` linker flag the same as `-rdynamic` (hence why I made the `--export-dynamic` linker flag set `rdynamic = true` in `zig cc` instead of adding a separate `export_dynamic` field).

Contributes towards https://github.com/ziglang/zig/issues/4784

---

EDIT:
> This is meant to fix `warning: unsupported linker arg: --export-dynamic` when doing `zig cc -Wl,--export-dynamic` or `zig cc -Wl,-E` (or other ways of passing linker args like `--for-linker`, but those [aren't supported by `zig cc` yet](https://github.com/ziglang/zig/issues/4784)). Full context is [here](https://github.com/luvit/luvi/issues/231#issuecomment-604227535)