### PR TITLE
std.zig.render: fix newlines before DocComments

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -373,6 +373,35 @@ test "zig fmt: correctly move doc comments on struct fields" {
     );
 }
 
+test "zig fmt: correctly space struct fields with doc comments" {
+    try testTransform(
+        \\pub const S = struct {
+        \\    /// A
+        \\    a: u8,
+        \\    /// B
+        \\    /// B (cont)
+        \\    b: u8,
+        \\
+        \\
+        \\    /// C
+        \\    c: u8,
+        \\};
+        \\
+        ,
+        \\pub const S = struct {
+        \\    /// A
+        \\    a: u8,
+        \\    /// B
+        \\    /// B (cont)
+        \\    b: u8,
+        \\
+        \\    /// C
+        \\    c: u8,
+        \\};
+        \\
+    );
+}
+
 test "zig fmt: doc comments on param decl" {
     try testCanonical(
         \\pub const Allocator = struct {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -187,12 +187,16 @@ fn renderExtraNewline(tree: *ast.Tree, stream: var, start_col: *usize, node: *as
     const first_token = node.firstToken();
     var prev_token = first_token;
     if (prev_token == 0) return;
+    var newline_threshold: usize = 2;
     while (tree.tokens.at(prev_token - 1).id == .DocComment) {
+        if (tree.tokenLocation(tree.tokens.at(prev_token - 1).end, prev_token).line == 1) {
+            newline_threshold += 1;
+        }
         prev_token -= 1;
     }
     const prev_token_end = tree.tokens.at(prev_token - 1).end;
     const loc = tree.tokenLocation(prev_token_end, first_token);
-    if (loc.line >= 2) {
+    if (loc.line >= newline_threshold) {
         try stream.writeByte('\n');
         start_col.* = 0;
     }


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/4598.

## Bug
`zig fmt` would always put new lines between struct fields if they had doc comments.

The function to insert extra lines is called between AST nodes. Inside that function, it looks up the tokens, and if there are 2 or more line breaks between the node's first token and the previous token, it inserts (keeps) the extra line. Because the nodes don't take comments into account, it walks back the previous token index to include any `DocComment`s — it's interested in the distance to the previous struct field, not to the field's own doc comments. 

The problem occurred because doc comments weren't taken into account when comparing the number of line breaks. If a field has a doc comment, it would _always_ be at least 2 line breaks to the previous struct field, so it would always get an extra line.

I believe it also affected some other cases, like top level declarations with multiple-line doc comments.

## Fix
If the previous token is further back because doc comments have been skipped, increase the extra line threshold by the number of doc comments that have been skipped.

There is a somewhat hacky conditional to only increment the threshold if the doc comment was on the line immediately above the node. This is to handle trailing doc comments:
```
const ONE = 1; /// trailing comment

const TWO = 2;
```
otherwise the extra space would be lost here. 