### PR TITLE
Support string concatenation in Translate-C

### DIFF
--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -5782,6 +5782,18 @@ fn parseCSuffixOpExpr(c: *Context, it: *CTokenList.Iterator, source: []const u8,
                 op_id = .Mod;
                 op_token = try appendToken(c, .Percent, "%");
             },
+            .StringLiteral => {
+                op_id = .ArrayCat;
+                op_token = try appendToken(c, .PlusPlus, "++");
+
+                _ = it.prev();
+            },
+            .Identifier => {
+                op_id = .ArrayCat;
+                op_token = try appendToken(c, .PlusPlus, "++");
+
+                _ = it.prev();
+            },
             else => {
                 _ = it.prev();
                 return node;

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2808,4 +2808,43 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    return if (x > y) x else y;
         \\}
     });
+
+    cases.add("string concatenation in macros",
+        \\#define FOO "hello"
+        \\#define BAR FOO " world"
+        \\#define BAZ "oh, " FOO
+    , &[_][]const u8{
+        \\pub const FOO = "hello";
+    ,
+        \\pub const BAR = FOO ++ " world";
+    ,
+        \\pub const BAZ = "oh, " ++ FOO;
+    });
+
+    cases.add("string concatenation in macros: two defines",
+        \\#define FOO "hello"
+        \\#define BAZ " world"
+        \\#define BAR FOO BAZ
+    , &[_][]const u8{
+        \\pub const FOO = "hello";
+    ,
+        \\pub const BAZ = " world";
+    ,
+        \\pub const BAR = FOO ++ BAZ;
+    });
+
+    cases.add("string concatenation in macros: two strings",
+        \\#define FOO "a" "b"
+        \\#define BAR FOO "c"
+    , &[_][]const u8{
+        \\pub const FOO = "a" ++ "b";
+    ,
+        \\pub const BAR = FOO ++ "c";
+    });
+
+    cases.add("string concatenation in macros: three strings",
+        \\#define FOO "a" "b" "c"
+    , &[_][]const u8{
+        \\pub const FOO = "a" ++ ("b" ++ "c");
+    });
 }


### PR DESCRIPTION
This PR adds support for string concatenation in macro definitions to translate-c.

Example:
```
#define FOO "hello"
#define BAR FOO " world"
```
translates to
```
pub const FOO = "hello";
pub const BAR = FOO ++ " world";
```

This is accomplished by assuming that a concatenation is being performed if an identifier or string literal directly follows an expression when searching for a suffix operator.

This closes #4465.