### PR TITLE
mem.zeroes .Array improvements

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -341,11 +341,7 @@ pub fn zeroes(comptime T: type) T {
             }
         },
         .Array => |info| {
-            var array: T = undefined;
-            for (array) |*element| {
-                element.* = zeroes(info.child);
-            }
-            return array;
+            return [_]info.child{zeroes(info.child)} ** info.len;
         },
         .Vector,
         .ErrorUnion,


### PR DESCRIPTION
Before (when given an array with many elements):
```
zig\std\mem.zig:345:13: error: evaluation exceeded 1000
backwards branches
            for (array) |*element| {
            ^
```
related to https://github.com/ziglang/zig/issues/4847#issuecomment-605721461