### PR TITLE
Add support for IPv6 Address with alphanumeric scope IDs

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -123,6 +123,7 @@ pub extern "c" fn tcgetattr(fd: fd_t, termios_p: *termios) c_int;
 pub extern "c" fn tcsetattr(fd: fd_t, optional_action: TCSA, termios_p: *const termios) c_int;
 pub extern "c" fn fcntl(fd: fd_t, cmd: c_int, ...) c_int;
 pub extern "c" fn flock(fd: fd_t, operation: c_int) c_int;
+pub extern "c" fn ioctl(fd: fd_t, request: c_int, ...) c_int;
 pub extern "c" fn uname(buf: *utsname) c_int;
 
 pub extern "c" fn gethostname(name: [*]u8, len: usize) c_int;

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -204,7 +204,7 @@ pub const Address = extern union {
         var abbrv = false;
 
         var scope_id = false;
-        var scope_id_value: [16]u8 = undefined;
+        var scope_id_value: [os.IFNAMESIZE - 1]u8 = undefined;
         var scope_id_index: usize = 0;
 
         for (buf) |c, i| {
@@ -215,6 +215,10 @@ pub const Address = extern union {
                     (c >= 'a' and c <= 'z') or
                     (c == '-') or (c == '.') or (c == '_') or (c == '~'))
                 {
+                    if (scope_id_index >= scope_id_value.len) {
+                        return error.Overflow;
+                    }
+
                     scope_id_value[scope_id_index] = c;
                     scope_id_index += 1;
                 } else {

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -61,6 +61,7 @@ pub const Address = extern union {
             error.Incomplete,
             error.InvalidIpv4Mapping,
             => {},
+            else => return err,
         }
 
         return error.InvalidIPAddressFormat;
@@ -546,7 +547,7 @@ fn if_nametoindex(name: []const u8) !u32 {
     std.mem.copy(u8, &ifr.ifr_ifrn.name, name);
     ifr.ifr_ifrn.name[name.len] = 0;
 
-    std.os.ioctl(sockfd, os.linux.SIOCGIFINDEX, @ptrToInt(&ifr)) catch |err| {
+    os.ioctl(sockfd, os.linux.SIOCGIFINDEX, @ptrToInt(&ifr)) catch |err| {
         switch (err) {
             error.NoDevice => return error.InterfaceNotFound,
             else => return err,
@@ -1234,7 +1235,7 @@ fn linuxLookupNameFromNumericUnspec(
     name: []const u8,
     port: u16,
 ) !void {
-    const addr = try Address.parseIp(name, port);
+    const addr = try Address.resolveIp(name, port);
     (try addrs.addOne()).* = LookupAddr{ .addr = addr };
 }
 

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -547,7 +547,7 @@ fn if_nametoindex(name: []const u8) !u32 {
     std.mem.copy(u8, &ifr.ifr_ifrn.name, name);
     ifr.ifr_ifrn.name[name.len] = 0;
 
-    os.ioctl(sockfd, os.linux.SIOCGIFINDEX, @ptrToInt(&ifr)) catch |err| {
+    os.ioctl(sockfd, os.system.SIOCGIFINDEX, @ptrToInt(&ifr)) catch |err| {
         switch (err) {
             error.NoDevice => return error.InterfaceNotFound,
             else => return err,

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -273,7 +273,6 @@ pub const Address = extern union {
         }
 
         var resolved_scope_id: u32 = 0;
-        std.debug.warn("scope_id_value {} len {}\n", .{ scope_id_value, std.mem.len(scope_id_value) });
         if (scope_id_index > 0) {
             const scope_id_str = scope_id_value[0..scope_id_index];
             resolved_scope_id = std.fmt.parseInt(u32, scope_id_str, 10) catch |err| blk: {
@@ -528,10 +527,7 @@ fn if_nametoindex(name: []const u8) !u32 {
     defer os.close(sockfd);
 
     std.mem.copy(u8, &ifr.ifr_ifrn.name, name);
-    std.debug.warn("name={} name.len={} ifr_name={}\n", .{ name, name.len, ifr.ifr_ifrn.name });
     ifr.ifr_ifrn.name[name.len] = 0;
-
-    std.debug.warn("{} {} {}\n", .{ sockfd, os.linux.SIOCGIFINDEX, @ptrToInt(&ifr) });
 
     const rc = os.system.syscall3(
         os.linux.SYS_ioctl,
@@ -551,8 +547,6 @@ fn if_nametoindex(name: []const u8) !u32 {
         os.ENODEV => return error.InterfaceNotFound,
         else => {},
     }
-
-    std.debug.warn("ival={}, rest={}\n", .{ ifr.ifr_ifru.ifru_ivalue, ifr.ifr_ifru });
 
     return @bitCast(u32, ifr.ifr_ifru.ifru_ivalue);
 }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -534,7 +534,18 @@ fn if_nametoindex(name: []const u8) !u32 {
         @ptrToInt(&ifr),
     );
 
-    return ifr.ifr_ifru.ifru_ivalue;
+    switch (os.errno(rc)) {
+        os.EBADF => return error.BadFile,
+        os.EINTR => return error.CaughtSignal,
+        os.EINVAL => unreachable,
+        os.EIO => return error.FileSystem,
+        os.ENOTTY => unreachable,
+        os.ENXIO => unreachable,
+        os.ENODEV => return error.Unsupported,
+        else => {},
+    }
+
+    return @bitCast(u32, ifr.ifr_ifru.ifru_ivalue);
 }
 
 pub const AddressList = struct {

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -552,7 +552,7 @@ fn if_nametoindex(name: []const u8) !u32 {
         else => {},
     }
 
-    std.debug.warn("ival={}\n", .{ifr.ifr_ifru.ifru_ivalue});
+    std.debug.warn("ival={}, rest={}\n", .{ ifr.ifr_ifru.ifru_ivalue, ifr.ifr_ifru });
 
     return @bitCast(u32, ifr.ifr_ifru.ifru_ivalue);
 }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -273,10 +273,12 @@ pub const Address = extern union {
         }
 
         var resolved_scope_id: u32 = 0;
-        if (std.mem.len(scope_id_value) > 0) {
-            resolved_scope_id = std.fmt.parseInt(u32, &scope_id_value, 10) catch |err| blk: {
+        std.debug.warn("scope_id_value {} len {}\n", .{ scope_id_value, std.mem.len(scope_id_value) });
+        if (scope_id_index > 0) {
+            const scope_id_str = scope_id_value[0..scope_id_index];
+            resolved_scope_id = std.fmt.parseInt(u32, scope_id_str, 10) catch |err| blk: {
                 if (err != error.InvalidCharacter) return err;
-                break :blk try if_nametoindex(&scope_id_value);
+                break :blk try if_nametoindex(scope_id_str);
             };
         }
 

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -528,6 +528,10 @@ fn if_nametoindex(name: []const u8) !u32 {
     defer os.close(sockfd);
 
     std.mem.copy(u8, &ifr.ifr_ifrn.name, name);
+    std.debug.warn("name={} name.len={} ifr_name={}\n", .{ name, name.len, ifr.ifr_ifrn.name });
+    ifr.ifr_ifrn.name[name.len] = 0;
+
+    std.debug.warn("{} {} {}\n", .{ sockfd, os.linux.SIOCGIFINDEX, @ptrToInt(&ifr) });
 
     const rc = os.system.syscall3(
         os.linux.SYS_ioctl,

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -543,13 +543,16 @@ fn if_nametoindex(name: []const u8) !u32 {
     switch (os.errno(rc)) {
         os.EBADF => return error.BadFile,
         os.EINTR => return error.CaughtSignal,
-        os.EINVAL => unreachable,
         os.EIO => return error.FileSystem,
+        os.EINVAL => unreachable,
         os.ENOTTY => unreachable,
         os.ENXIO => unreachable,
-        os.ENODEV => return error.Unsupported,
+        // ioctl() sends ENODEV for an unknown scope id.
+        os.ENODEV => return error.InterfaceNotFound,
         else => {},
     }
+
+    std.debug.warn("ival={}\n", .{ifr.ifr_ifru.ifru_ivalue});
 
     return @bitCast(u32, ifr.ifr_ifru.ifru_ivalue);
 }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -184,7 +184,6 @@ pub const Address = extern union {
     }
 
     pub fn resolveIp6(buf: []const u8, port: u16) !Address {
-        // FIXME: implement if_nametoindex
         // FIXME: this is a very bad implementation, since it's only a copy
         // of parseIp6 with alphanumerical scope id support
         var result = Address{
@@ -205,7 +204,7 @@ pub const Address = extern union {
         var abbrv = false;
 
         var scope_id = false;
-        var scope_id_value: [32]u8 = undefined;
+        var scope_id_value: [16]u8 = undefined;
         var scope_id_index: usize = 0;
 
         for (buf) |c, i| {
@@ -273,10 +272,13 @@ pub const Address = extern union {
             return error.Incomplete;
         }
 
-        const resolved_scope_id = std.fmt.parseInt(u32, scope_id_value, 10) catch |err| blk: {
-            if (err != err.InvalidCharacter) return err;
-            break :blk if_nametoindex(scope_id_value);
-        };
+        var resolved_scope_id: u32 = 0;
+        if (std.mem.len(scope_id_value) > 0) {
+            resolved_scope_id = std.fmt.parseInt(u32, &scope_id_value, 10) catch |err| blk: {
+                if (err != error.InvalidCharacter) return err;
+                break :blk try if_nametoindex(&scope_id_value);
+            };
+        }
 
         result.in6.scope_id = resolved_scope_id;
 
@@ -523,7 +525,7 @@ fn if_nametoindex(name: []const u8) !u32 {
     var sockfd = try os.socket(os.AF_UNIX, os.SOCK_DGRAM | os.SOCK_CLOEXEC, 0);
     defer os.close(sockfd);
 
-    std.mem.copy(u8, ifr.ifr_ifrn.name, &name);
+    std.mem.copy(u8, &ifr.ifr_ifrn.name, name);
 
     const rc = os.system.syscall3(
         os.linux.SYS_ioctl,

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -209,8 +209,17 @@ pub const Address = extern union {
 
         for (buf) |c, i| {
             if (scope_id) {
-                scope_id_value[scope_id_index] = c;
-                scope_id_index += 1;
+                // Handling of percent-encoding should be for an URI library.
+                if ((c >= '0' and c <= '9') or
+                    (c >= 'A' and c <= 'Z') or
+                    (c >= 'a' and c <= 'z') or
+                    (c == '-') or (c == '.') or (c == '_') or (c == '~'))
+                {
+                    scope_id_value[scope_id_index] = c;
+                    scope_id_index += 1;
+                } else {
+                    return error.InvalidCharacter;
+                }
             } else if (c == ':') {
                 if (!saw_any_digits) {
                     if (abbrv) return error.InvalidCharacter; // ':::'
@@ -269,6 +278,10 @@ pub const Address = extern union {
         }
 
         if (!saw_any_digits and !abbrv) {
+            return error.Incomplete;
+        }
+
+        if (scope_id and scope_id_index == 0) {
             return error.Incomplete;
         }
 

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -546,24 +546,12 @@ fn if_nametoindex(name: []const u8) !u32 {
     std.mem.copy(u8, &ifr.ifr_ifrn.name, name);
     ifr.ifr_ifrn.name[name.len] = 0;
 
-    const rc = os.system.syscall3(
-        os.linux.SYS_ioctl,
-        @bitCast(usize, @as(isize, sockfd)),
-        os.linux.SIOCGIFINDEX,
-        @ptrToInt(&ifr),
-    );
-
-    switch (os.errno(rc)) {
-        os.EBADF => return error.BadFile,
-        os.EINTR => return error.CaughtSignal,
-        os.EIO => return error.FileSystem,
-        os.EINVAL => unreachable,
-        os.ENOTTY => unreachable,
-        os.ENXIO => unreachable,
-        // ioctl() sends ENODEV for an unknown scope id.
-        os.ENODEV => return error.InterfaceNotFound,
-        else => {},
-    }
+    std.os.ioctl(sockfd, os.linux.SIOCGIFINDEX, @ptrToInt(&ifr)) catch |err| {
+        switch (err) {
+            error.NoDevice => return error.InterfaceNotFound,
+            else => return err,
+        }
+    };
 
     return @bitCast(u32, ifr.ifr_ifru.ifru_ivalue);
 }

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -45,6 +45,17 @@ test "parse and render IPv6 addresses" {
     testing.expectError(error.Incomplete, net.Address.parseIp6("FF01:", 0));
     testing.expectError(error.InvalidIpv4Mapping, net.Address.parseIp6("::123.123.123.123", 0));
     testing.expectError(error.Incomplete, net.Address.resolveIp6("ff01::fb%", 0));
+    testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%wlp3s0s0s0s0s0s0s0s0", 0));
+    testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%12345678901234", 0));
+}
+
+test "invalid but parseable IPv6 scope ids" {
+    // Currently, resolveIp6 with alphanumerical scope IDs only works on Linux.
+    if (std.builtin.os.tag != .linux) {
+        return error.SkipZigTest;
+    }
+
+    testing.expectError(error.InterfaceNotFound, net.Address.resolveIp6("ff01::fb%123s45678901234", 0));
 }
 
 test "parse and render IPv4 addresses" {

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -29,8 +29,13 @@ test "parse and render IPv6 addresses" {
     };
     for (ips) |ip, i| {
         var addr = net.Address.parseIp6(ip, 0) catch unreachable;
+        var addr_via_resolve = net.Address.resolveIp6(ip, 0) catch unreachable;
+
         var newIp = std.fmt.bufPrint(buffer[0..], "{}", .{addr}) catch unreachable;
+        var newResolvedIp = std.fmt.bufPrint(buffer[0..], "{}", .{addr_via_resolve}) catch unreachable;
+
         std.testing.expect(std.mem.eql(u8, printed[i], newIp[1 .. newIp.len - 3]));
+        std.testing.expect(std.mem.eql(u8, printed[i], newResolvedIp[1 .. newResolvedIp.len - 3]));
     }
 
     testing.expectError(error.InvalidCharacter, net.Address.parseIp6(":::", 0));
@@ -39,6 +44,7 @@ test "parse and render IPv6 addresses" {
     testing.expectError(error.InvalidEnd, net.Address.parseIp6("FF01:0:0:0:0:0:0:FB:", 0));
     testing.expectError(error.Incomplete, net.Address.parseIp6("FF01:", 0));
     testing.expectError(error.InvalidIpv4Mapping, net.Address.parseIp6("::123.123.123.123", 0));
+    testing.expectError(error.Incomplete, net.Address.resolveIp6("ff01::fb%", 0));
 }
 
 test "parse and render IPv4 addresses" {

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -29,13 +29,14 @@ test "parse and render IPv6 addresses" {
     };
     for (ips) |ip, i| {
         var addr = net.Address.parseIp6(ip, 0) catch unreachable;
-        var addr_via_resolve = net.Address.resolveIp6(ip, 0) catch unreachable;
-
         var newIp = std.fmt.bufPrint(buffer[0..], "{}", .{addr}) catch unreachable;
-        var newResolvedIp = std.fmt.bufPrint(buffer[0..], "{}", .{addr_via_resolve}) catch unreachable;
-
         std.testing.expect(std.mem.eql(u8, printed[i], newIp[1 .. newIp.len - 3]));
-        std.testing.expect(std.mem.eql(u8, printed[i], newResolvedIp[1 .. newResolvedIp.len - 3]));
+
+        if (std.builtin.os.tag == .linux) {
+            var addr_via_resolve = net.Address.resolveIp6(ip, 0) catch unreachable;
+            var newResolvedIp = std.fmt.bufPrint(buffer[0..], "{}", .{addr_via_resolve}) catch unreachable;
+            std.testing.expect(std.mem.eql(u8, printed[i], newResolvedIp[1 .. newResolvedIp.len - 3]));
+        }
     }
 
     testing.expectError(error.InvalidCharacter, net.Address.parseIp6(":::", 0));
@@ -44,9 +45,11 @@ test "parse and render IPv6 addresses" {
     testing.expectError(error.InvalidEnd, net.Address.parseIp6("FF01:0:0:0:0:0:0:FB:", 0));
     testing.expectError(error.Incomplete, net.Address.parseIp6("FF01:", 0));
     testing.expectError(error.InvalidIpv4Mapping, net.Address.parseIp6("::123.123.123.123", 0));
-    testing.expectError(error.Incomplete, net.Address.resolveIp6("ff01::fb%", 0));
-    testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%wlp3s0s0s0s0s0s0s0s0", 0));
-    testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%12345678901234", 0));
+    if (std.builtin.os.tag == .linux) {
+        testing.expectError(error.Incomplete, net.Address.resolveIp6("ff01::fb%", 0));
+        testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%wlp3s0s0s0s0s0s0s0s0", 0));
+        testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%12345678901234", 0));
+    }
 }
 
 test "invalid but parseable IPv6 scope ids" {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4388,7 +4388,7 @@ pub fn tcsetattr(handle: fd_t, optional_action: TCSA, termios_p: termios) Termio
     }
 }
 
-pub fn ioctl(handle: fd_t, request: u32, arg: var) !void {
+pub fn ioctl(handle: fd_t, request: i32, arg: var) !void {
     switch (errno(system.ioctl(handle, request, arg))) {
         0 => {},
         EINVAL => unreachable,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2087,7 +2087,7 @@ pub fn isatty(handle: fd_t) bool {
     }
     if (builtin.os.tag == .linux) {
         var wsz: linux.winsize = undefined;
-        return linux.syscall3(.ioctl, @bitCast(usize, @as(isize, handle)), linux.TIOCGWINSZ, @ptrToInt(&wsz)) == 0;
+        return linux.ioctl(handle, linux.TIOCGWINSZ, @ptrToInt(&wsz)) == 0;
     }
     unreachable;
 }

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1725,7 +1725,7 @@ pub const ifmap = struct {
 
 pub const ifreq = extern union {
     ifr_ifrn: struct {
-        ifrn_name: [IFNAMESIZE]u8,
+        name: [IFNAMESIZE]u8,
     },
     ifr_ifru: struct {
         ifru_addr: sockaddr,
@@ -1734,8 +1734,8 @@ pub const ifreq = extern union {
         ifru_netmask: sockaddr,
         ifru_hwaddr: sockaddr,
         ifru_flags: i16,
-        ifru_ivalue: i16,
-        ifru_mtu: i16,
+        ifru_ivalue: i32,
+        ifru_mtu: i32,
         ifru_map: ifmap,
         ifru_slave: [IFNAMESIZE]u8,
         ifru_newname: [IFNAMESIZE]u8,

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1715,8 +1715,8 @@ pub const SIOCGIFINDEX = 0x8933;
 pub const IFNAMESIZE = 16;
 
 pub const ifmap = extern struct {
-    mem_start: c_ulong,
-    mem_end: c_ulong,
+    mem_start: u32,
+    mem_end: u32,
     base_addr: u16,
     irq: u8,
     dma: u8,
@@ -1739,6 +1739,6 @@ pub const ifreq = extern struct {
         ifru_map: ifmap,
         ifru_slave: [IFNAMESIZE]u8,
         ifru_newname: [IFNAMESIZE]u8,
-        ifru_data: [*c]u8,
+        ifru_data: ?[*]u8,
     },
 };

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1710,3 +1710,35 @@ pub const termios = extern struct {
     ispeed: speed_t,
     ospeed: speed_t,
 };
+
+pub const SIOCGIFINDEX = 0x8933;
+pub const IFNAMESIZE = 16;
+
+pub const ifmap = struct {
+    mem_start: u32,
+    mem_end: u32,
+    base_addr: i16,
+    irq: u8,
+    dma: u8,
+    port: u8,
+};
+
+pub const ifreq = extern union {
+    ifr_ifrn: struct {
+        ifrn_name: [IFNAMESIZE]u8,
+    },
+    ifr_ifru: struct {
+        ifru_addr: sockaddr,
+        ifru_dstaddr: sockaddr,
+        ifru_broadaddr: sockaddr,
+        ifru_netmask: sockaddr,
+        ifru_hwaddr: sockaddr,
+        ifru_flags: i16,
+        ifru_ivalue: i16,
+        ifru_mtu: i16,
+        ifru_map: ifmap,
+        ifru_slave: [IFNAMESIZE]u8,
+        ifru_newname: [IFNAMESIZE]u8,
+        ifru_data: [*:0]u8,
+    },
+};

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1717,7 +1717,7 @@ pub const IFNAMESIZE = 16;
 pub const ifmap = extern struct {
     mem_start: c_ulong,
     mem_end: c_ulong,
-    base_addr: c_ushort,
+    base_addr: u16,
     irq: u8,
     dma: u8,
     port: u8,
@@ -1733,7 +1733,7 @@ pub const ifreq = extern struct {
         ifru_broadaddr: sockaddr,
         ifru_netmask: sockaddr,
         ifru_hwaddr: sockaddr,
-        ifru_flags: c_short,
+        ifru_flags: i16,
         ifru_ivalue: i32,
         ifru_mtu: i32,
         ifru_map: ifmap,

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1714,31 +1714,31 @@ pub const termios = extern struct {
 pub const SIOCGIFINDEX = 0x8933;
 pub const IFNAMESIZE = 16;
 
-pub const ifmap = struct {
-    mem_start: u32,
-    mem_end: u32,
-    base_addr: i16,
+pub const ifmap = extern struct {
+    mem_start: c_ulong,
+    mem_end: c_ulong,
+    base_addr: c_ushort,
     irq: u8,
     dma: u8,
     port: u8,
 };
 
-pub const ifreq = extern union {
-    ifr_ifrn: struct {
+pub const ifreq = extern struct {
+    ifr_ifrn: extern union {
         name: [IFNAMESIZE]u8,
     },
-    ifr_ifru: struct {
+    ifr_ifru: extern union {
         ifru_addr: sockaddr,
         ifru_dstaddr: sockaddr,
         ifru_broadaddr: sockaddr,
         ifru_netmask: sockaddr,
         ifru_hwaddr: sockaddr,
-        ifru_flags: i16,
+        ifru_flags: c_short,
         ifru_ivalue: i32,
         ifru_mtu: i32,
         ifru_map: ifmap,
         ifru_slave: [IFNAMESIZE]u8,
         ifru_newname: [IFNAMESIZE]u8,
-        ifru_data: [*:0]u8,
+        ifru_data: [*c]u8,
     },
 };

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1737,8 +1737,8 @@ pub const ifreq = extern struct {
         ifru_ivalue: i32,
         ifru_mtu: i32,
         ifru_map: ifmap,
-        ifru_slave: [IFNAMESIZE]u8,
-        ifru_newname: [IFNAMESIZE]u8,
+        ifru_slave: [IFNAMESIZE - 1:0]u8,
+        ifru_newname: [IFNAMESIZE - 1:0]u8,
         ifru_data: ?[*]u8,
     },
 };

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1193,8 +1193,8 @@ pub fn tcsetattr(fd: fd_t, optional_action: TCSA, termios_p: *const termios) usi
     return ioctl(fd, TCSETS + @enumToInt(optional_action), @ptrToInt(termios_p));
 }
 
-pub fn ioctl(fd: fd_t, request: u32, arg: var) usize {
-    return syscall3(.ioctl, @bitCast(usize, @as(isize, fd)), request, arg);
+pub fn ioctl(fd: fd_t, request: i32, arg: var) usize {
+    return syscall3(.ioctl, @bitCast(usize, @as(isize, fd)), @bitCast(usize, @as(isize, request)), arg);
 }
 
 test "" {

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1193,6 +1193,10 @@ pub fn tcsetattr(fd: fd_t, optional_action: TCSA, termios_p: *const termios) usi
     return syscall3(.ioctl, @bitCast(usize, @as(isize, fd)), TCSETS + @enumToInt(optional_action), @ptrToInt(termios_p));
 }
 
+pub fn ioctl(fd: fd_t, request: u32, arg: var) usize {
+    return syscall3(.ioctl, @bitCast(usize, @as(isize, fd)), request, arg);
+}
+
 test "" {
     if (builtin.os.tag == .linux) {
         _ = @import("linux/test.zig");

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1186,11 +1186,11 @@ pub fn getrusage(who: i32, usage: *rusage) usize {
 }
 
 pub fn tcgetattr(fd: fd_t, termios_p: *termios) usize {
-    return syscall3(.ioctl, @bitCast(usize, @as(isize, fd)), TCGETS, @ptrToInt(termios_p));
+    return ioctl(fd, TCGETS, @ptrToInt(termios_p));
 }
 
 pub fn tcsetattr(fd: fd_t, optional_action: TCSA, termios_p: *const termios) usize {
-    return syscall3(.ioctl, @bitCast(usize, @as(isize, fd)), TCSETS + @enumToInt(optional_action), @ptrToInt(termios_p));
+    return ioctl(fd, TCSETS + @enumToInt(optional_action), @ptrToInt(termios_p));
 }
 
 pub fn ioctl(fd: fd_t, request: u32, arg: var) usize {


### PR DESCRIPTION
`std.net.Address.parseIp6` does not support alphanumerical scope IDs, which can be used by Unix systems, and so, could error easily (I hit it when resolvconf parsing was happening, one of my nameservers is IPv6).

This adds `std.net.Address.resolveIp`, which then uses `resolveIp6` so that the scope ID is correct. The split between parse and resolve is done because the function that does it, `if_nametoindex`(ported from musl, I don't know if other OSes do something differently to achieve this) does syscalls to translate the address string's scope ID into the interface ID, which then becomes the address' scope ID.

I do know that the implementation is ugly (having to use C types, for example, or how I basically copy-pasted `parseIp6` into `resolveIp6`, also not sure where the actual declaration for ifreq and related constants should go). I don't know how to make this more elegant, so I'm basically asking for help on that regard.