### PR TITLE
Use correct compiler flags in MSVC bootstrap builds of Zig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ set(EMBEDDED_SOFTFLOAT_SOURCES
 add_library(embedded_softfloat STATIC ${EMBEDDED_SOFTFLOAT_SOURCES})
 if(MSVC)
     set_target_properties(embedded_softfloat PROPERTIES
-        COMPILE_FLAGS "-std=c99 /w"
+        COMPILE_FLAGS "/w /O2"
     )
 else()
     set_target_properties(embedded_softfloat PROPERTIES
@@ -315,7 +315,12 @@ include_directories(
 )
 
 # These have to go before the -Wno- flags
-set(EXE_CFLAGS "-std=c++14")
+if(MSVC)
+  set(EXE_CFLAGS "/std:c++14")
+else(MSVC)
+  set(EXE_CFLAGS "-std=c++14")
+endif(MSVC)
+
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     if(MSVC)
         set(EXE_CFLAGS "${EXE_CFLAGS} /w")
@@ -333,7 +338,11 @@ else()
     endif()
 endif()
 
-set(OPTIMIZED_C_FLAGS "-std=c99 -O3")
+if(MSVC)
+  set(OPTIMIZED_C_FLAGS "/O2")
+else(MSVC)
+  set(OPTIMIZED_C_FLAGS "-std=c99 -O3")
+endif(MSVC)
 
 set(EXE_LDFLAGS " ")
 if(MSVC)


### PR DESCRIPTION
https://github.com/ziglang/zig/issues/4877

The CMake build of Zig from C++ uses hand-set compiler flags which are
not compatible with the Microsoft C/C++ Optimizing Compiler (cl.exe)
used by Visual Studio.

This commit attempts to conform them to match the Clang/GCC options
under MSVC builds.

Note that CL does not have a concept of C99 or "-O3", and may imply
other optimizations in "/O2" than are implied by Clang/GCC "-O3".

Visual Studio 2019 documentation for cl.exe's optimization options:
https://docs.microsoft.com/en-us/cpp/build/reference/o-options-optimize-code?view=vs-2019

Visual Studio 2019 doc for cl.exe's C++ standard options:
https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=vs-2019