### PR TITLE
More NetBSD bits

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -73,7 +73,6 @@ pub extern "c" fn abort() noreturn;
 pub extern "c" fn exit(code: c_int) noreturn;
 pub extern "c" fn isatty(fd: fd_t) c_int;
 pub extern "c" fn close(fd: fd_t) c_int;
-pub extern "c" fn fstat(fd: fd_t, buf: *Stat) c_int;
 pub extern "c" fn fstatat(dirfd: fd_t, path: [*:0]const u8, stat_buf: *Stat, flags: u32) c_int;
 pub extern "c" fn lseek(fd: fd_t, offset: off_t, whence: c_int) off_t;
 pub extern "c" fn open(path: [*:0]const u8, oflag: c_uint, ...) c_int;
@@ -86,7 +85,6 @@ pub extern "c" fn pread(fd: fd_t, buf: [*]u8, nbyte: usize, offset: u64) isize;
 pub extern "c" fn preadv(fd: c_int, iov: [*]const iovec, iovcnt: c_uint, offset: u64) isize;
 pub extern "c" fn writev(fd: c_int, iov: [*]const iovec_const, iovcnt: c_uint) isize;
 pub extern "c" fn pwritev(fd: c_int, iov: [*]const iovec_const, iovcnt: c_uint, offset: u64) isize;
-pub extern "c" fn stat(noalias path: [*:0]const u8, noalias buf: *Stat) c_int;
 pub extern "c" fn write(fd: fd_t, buf: [*]const u8, nbyte: usize) isize;
 pub extern "c" fn pwrite(fd: fd_t, buf: [*]const u8, nbyte: usize, offset: u64) isize;
 pub extern "c" fn mmap(addr: ?*align(page_size) c_void, len: usize, prot: c_uint, flags: c_uint, fd: fd_t, offset: u64) *c_void;
@@ -114,15 +112,10 @@ pub extern "c" fn dup2(old_fd: fd_t, new_fd: fd_t) c_int;
 pub extern "c" fn readlink(noalias path: [*:0]const u8, noalias buf: [*]u8, bufsize: usize) isize;
 pub extern "c" fn readlinkat(dirfd: fd_t, noalias path: [*:0]const u8, noalias buf: [*]u8, bufsize: usize) isize;
 pub extern "c" fn realpath(noalias file_name: [*:0]const u8, noalias resolved_name: [*]u8) ?[*:0]u8;
-pub extern "c" fn sigprocmask(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
-pub extern "c" fn gettimeofday(noalias tv: ?*timeval, noalias tz: ?*timezone) c_int;
-pub extern "c" fn sigaction(sig: c_int, noalias act: *const Sigaction, noalias oact: ?*Sigaction) c_int;
-pub extern "c" fn nanosleep(rqtp: *const timespec, rmtp: ?*timespec) c_int;
 pub extern "c" fn setreuid(ruid: c_uint, euid: c_uint) c_int;
 pub extern "c" fn setregid(rgid: c_uint, egid: c_uint) c_int;
 pub extern "c" fn rmdir(path: [*:0]const u8) c_int;
 pub extern "c" fn getenv(name: [*:0]const u8) ?[*:0]u8;
-pub extern "c" fn getrusage(who: c_int, usage: *rusage) c_int;
 pub extern "c" fn sysctl(name: [*]const c_int, namelen: c_uint, oldp: ?*c_void, oldlenp: ?*usize, newp: ?*c_void, newlen: usize) c_int;
 pub extern "c" fn sysctlbyname(name: [*:0]const u8, oldp: ?*c_void, oldlenp: ?*usize, newp: ?*c_void, newlen: usize) c_int;
 pub extern "c" fn sysctlnametomib(name: [*:0]const u8, mibp: ?*c_int, sizep: ?*usize) c_int;
@@ -133,7 +126,6 @@ pub extern "c" fn uname(buf: *utsname) c_int;
 
 pub extern "c" fn gethostname(name: [*]u8, len: usize) c_int;
 pub extern "c" fn bind(socket: fd_t, address: ?*const sockaddr, address_len: socklen_t) c_int;
-pub extern "c" fn socket(domain: c_uint, sock_type: c_uint, protocol: c_uint) c_int;
 pub extern "c" fn socketpair(domain: c_uint, sock_type: c_uint, protocol: c_uint, sv: *[2]fd_t) c_int;
 pub extern "c" fn listen(sockfd: fd_t, backlog: c_uint) c_int;
 pub extern "c" fn getsockname(sockfd: fd_t, noalias addr: *sockaddr, noalias addrlen: *socklen_t) c_int;
@@ -161,12 +153,55 @@ pub extern fn recvfrom(
     noalias addrlen: ?*socklen_t,
 ) isize;
 
+pub usingnamespace switch (builtin.os.tag) {
+    .netbsd => struct {
+        pub const clock_getres = __clock_getres50;
+        pub const clock_gettime = __clock_gettime50;
+        pub const fstat = __fstat50;
+        pub const getdents = __getdents30;
+        pub const getrusage = __getrusage50;
+        pub const gettimeofday = __gettimeofday50;
+        pub const nanosleep = __nanosleep50;
+        pub const sched_yield = __libc_thr_yield;
+        pub const sigaction = __sigaction14;
+        pub const sigaltstack = __sigaltstack14;
+        pub const sigprocmask = __sigprocmask14;
+        pub const stat = __stat50;
+    },
+    .macosx, .ios, .watchos, .tvos => struct {
+        // XXX: close -> close$NOCANCEL
+        // XXX: getdirentries -> _getdirentries64
+        pub extern "c" fn clock_getres(clk_id: c_int, tp: *timespec) c_int;
+        pub extern "c" fn clock_gettime(clk_id: c_int, tp: *timespec) c_int;
+        pub const fstat = @"fstat$INODE64";
+        pub extern "c" fn getrusage(who: c_int, usage: *rusage) c_int;
+        pub extern "c" fn gettimeofday(noalias tv: ?*timeval, noalias tz: ?*timezone) c_int;
+        pub extern "c" fn nanosleep(rqtp: *const timespec, rmtp: ?*timespec) c_int;
+        pub extern "c" fn sched_yield() c_int;
+        pub extern "c" fn sigaction(sig: c_int, noalias act: *const Sigaction, noalias oact: ?*Sigaction) c_int;
+        pub extern "c" fn sigprocmask(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
+        pub extern "c" fn socket(domain: c_uint, sock_type: c_uint, protocol: c_uint) c_int;
+        pub extern "c" fn stat(noalias path: [*:0]const u8, noalias buf: *Stat) c_int;
+    },
+    else => struct {
+        pub extern "c" fn clock_getres(clk_id: c_int, tp: *timespec) c_int;
+        pub extern "c" fn clock_gettime(clk_id: c_int, tp: *timespec) c_int;
+        pub extern "c" fn fstat(fd: fd_t, buf: *Stat) c_int;
+        pub extern "c" fn getrusage(who: c_int, usage: *rusage) c_int;
+        pub extern "c" fn gettimeofday(noalias tv: ?*timeval, noalias tz: ?*timezone) c_int;
+        pub extern "c" fn nanosleep(rqtp: *const timespec, rmtp: ?*timespec) c_int;
+        pub extern "c" fn sched_yield() c_int;
+        pub extern "c" fn sigaction(sig: c_int, noalias act: *const Sigaction, noalias oact: ?*Sigaction) c_int;
+        pub extern "c" fn sigprocmask(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
+        pub extern "c" fn socket(domain: c_uint, sock_type: c_uint, protocol: c_uint) c_int;
+        pub extern "c" fn stat(noalias path: [*:0]const u8, noalias buf: *Stat) c_int;
+    },
+};
+
 pub extern "c" fn kill(pid: pid_t, sig: c_int) c_int;
 pub extern "c" fn getdirentries(fd: fd_t, buf_ptr: [*]u8, nbytes: usize, basep: *i64) isize;
 pub extern "c" fn setgid(ruid: c_uint, euid: c_uint) c_int;
 pub extern "c" fn setuid(uid: c_uint) c_int;
-pub extern "c" fn clock_gettime(clk_id: c_int, tp: *timespec) c_int;
-pub extern "c" fn clock_getres(clk_id: c_int, tp: *timespec) c_int;
 
 pub extern "c" fn aligned_alloc(alignment: usize, size: usize) ?*c_void;
 pub extern "c" fn malloc(usize) ?*c_void;
@@ -228,8 +263,6 @@ pub extern "c" fn dn_expand(
     exp_dn: [*:0]u8,
     length: c_int,
 ) c_int;
-
-pub extern "c" fn sched_yield() c_int;
 
 pub const PTHREAD_MUTEX_INITIALIZER = pthread_mutex_t{};
 pub extern "c" fn pthread_mutex_lock(mutex: *pthread_mutex_t) c_int;

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -21,7 +21,7 @@ pub extern "c" fn __sigprocmask14(how: c_int, noalias set: ?*const sigset_t, noa
 pub extern "c" fn __socket30(domain: c_uint, sock_type: c_uint, protocol: c_uint) c_int;
 pub extern "c" fn __gettimeofday50(noalias tv: ?*timeval, noalias tz: ?*timezone) c_int;
 pub extern "c" fn __getrusage50(who: c_int, usage: *rusage) c_int;
-// instead of sched_yield
+// libc aliases this as sched_yield
 pub extern "c" fn __libc_thr_yield() c_int;
 
 pub const pthread_mutex_t = extern struct {

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -10,36 +10,58 @@ pub const dl_iterate_phdr_callback = extern fn (info: *dl_phdr_info, size: usize
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*c_void) c_int;
 
 pub extern "c" fn __fstat50(fd: fd_t, buf: *Stat) c_int;
+pub extern "c" fn __stat50(path: [*:0]const u8, buf: *Stat) c_int;
 pub extern "c" fn __clock_gettime50(clk_id: c_int, tp: *timespec) c_int;
 pub extern "c" fn __clock_getres50(clk_id: c_int, tp: *timespec) c_int;
 pub extern "c" fn __getdents30(fd: c_int, buf_ptr: [*]u8, nbytes: usize) c_int;
 pub extern "c" fn __sigaltstack14(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
+pub extern "c" fn __nanosleep50(rqtp: *const timespec, rmtp: ?*timespec) c_int;
+pub extern "c" fn __sigaction14(sig: c_int, noalias act: *const Sigaction, noalias oact: ?*Sigaction) c_int;
+pub extern "c" fn __sigprocmask14(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
+pub extern "c" fn __socket30(domain: c_uint, sock_type: c_uint, protocol: c_uint) c_int;
+pub extern "c" fn __gettimeofday50(noalias tv: ?*timeval, noalias tz: ?*timezone) c_int;
+pub extern "c" fn __getrusage50(who: c_int, usage: *rusage) c_int;
+// instead of sched_yield
+pub extern "c" fn __libc_thr_yield() c_int;
 
 pub const pthread_mutex_t = extern struct {
-    ptm_magic: c_uint = 0x33330003,
-    ptm_errorcheck: padded_spin_t = 0,
-    ptm_unused: padded_spin_t = 0,
+    ptm_magic: u32 = 0x33330003,
+    ptm_errorcheck: padded_pthread_spin_t = 0,
+    ptm_ceiling: padded_pthread_spin_t = 0,
     ptm_owner: usize = 0,
     ptm_waiters: ?*u8 = null,
-    ptm_recursed: c_uint = 0,
+    ptm_recursed: u32 = 0,
     ptm_spare2: ?*c_void = null,
 };
+
 pub const pthread_cond_t = extern struct {
-    ptc_magic: c_uint = 0x55550005,
+    ptc_magic: u32 = 0x55550005,
     ptc_lock: pthread_spin_t = 0,
     ptc_waiters_first: ?*u8 = null,
     ptc_waiters_last: ?*u8 = null,
     ptc_mutex: ?*pthread_mutex_t = null,
     ptc_private: ?*c_void = null,
 };
-const pthread_spin_t = if (builtin.arch == .arm or .arch == .powerpc) c_int else u8;
-const padded_spin_t = switch (builtin.arch) {
-    .sparc, .sparcel, .sparcv9, .i386, .x86_64, .le64 => u32,
-    else => spin_t,
+
+const pthread_spin_t = switch (builtin.arch) {
+    .aarch64, .aarch64_be, .aarch64_32 => u8,
+    .mips, .mipsel, .mips64, .mips64el => u32,
+    .powerpc, .powerpc64, .powerpc64le => i32,
+    .i386, .x86_64 => u8,
+    .arm, .armeb, .thumb, .thumbeb => i32,
+    .sparc, .sparcel, .sparcv9 => u8,
+    .riscv32, .riscv64 => u32,
+    else => @compileError("undefined pthread_spin_t for this arch"),
+};
+
+const padded_pthread_spin_t = switch (builtin.arch) {
+    .i386, .x86_64 => u32,
+    .sparc, .sparcel, .sparcv9 => u32,
+    else => pthread_spin_t,
 };
 
 pub const pthread_attr_t = extern struct {
     pta_magic: u32,
-    pta_flags: c_int,
-    pta_private: *c_void,
+    pta_flags: i32,
+    pta_private: ?*c_void,
 };

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2553,14 +2553,7 @@ pub const FStatError = error{
 pub fn fstat(fd: fd_t) FStatError!Stat {
     var stat: Stat = undefined;
 
-    const symbol_name = if (comptime std.Target.current.isDarwin())
-        "fstat$INODE64"
-    else if (std.Target.current.os.tag == .netbsd)
-        "__fstat50"
-    else
-        "fstat";
-
-    switch (errno(@field(system, symbol_name)(fd, &stat))) {
+    switch (errno(system.fstat(fd, &stat))) {
         0 => return stat,
         EINVAL => unreachable,
         EBADF => unreachable, // Always a race condition.
@@ -3427,12 +3420,7 @@ pub fn clock_gettime(clk_id: i32, tp: *timespec) ClockGetTimeError!void {
         return;
     }
 
-    const symbol_name = if (std.Target.current.os.tag == .netbsd)
-        "__clock_gettime50"
-    else
-        "clock_gettime";
-
-    switch (errno(@field(system, symbol_name)(clk_id, tp))) {
+    switch (errno(system.clock_gettime(clk_id, tp))) {
         0 => return,
         EFAULT => unreachable,
         EINVAL => return error.UnsupportedClock,
@@ -3454,12 +3442,7 @@ pub fn clock_getres(clk_id: i32, res: *timespec) ClockGetTimeError!void {
         return;
     }
 
-    const symbol_name = if (std.Target.current.os.tag == .netbsd)
-        "__clock_getres50"
-    else
-        "clock_getres";
-
-    switch (errno(@field(system, symbol_name)(clk_id, res))) {
+    switch (errno(system.clock_getres(clk_id, res))) {
         0 => return,
         EFAULT => unreachable,
         EINVAL => return error.UnsupportedClock,
@@ -3525,12 +3508,7 @@ pub const SigaltstackError = error{
 } || UnexpectedError;
 
 pub fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) SigaltstackError!void {
-    const symbol_name = if (std.Target.current.os.tag == .netbsd)
-        "__sigaltstack14"
-    else
-        "sigaltstack";
-
-    switch (errno(@field(system, symbol_name)(ss, old_ss))) {
+    switch (errno(system.sigaltstack(ss, old_ss))) {
         0 => return,
         EFAULT => unreachable,
         EINVAL => unreachable,

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -813,13 +813,13 @@ pub const app_mask: sigset_t = [2]u32{ 0xfffffffc, 0x7fffffff } ++ [_]u32{0xffff
 pub const k_sigaction = if (is_mips)
     extern struct {
         flags: usize,
-        sigaction: ?extern fn (i32, *siginfo_t, *c_void) void,
+        sigaction: ?extern fn (i32, *siginfo_t, ?*c_void) void,
         mask: [4]u32,
         restorer: extern fn () void,
     }
 else
     extern struct {
-        sigaction: ?extern fn (i32, *siginfo_t, *c_void) void,
+        sigaction: ?extern fn (i32, *siginfo_t, ?*c_void) void,
         flags: usize,
         restorer: extern fn () void,
         mask: [2]u32,

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -827,15 +827,17 @@ else
 
 /// Renamed from `sigaction` to `Sigaction` to avoid conflict with the syscall.
 pub const Sigaction = extern struct {
-    sigaction: ?extern fn (i32, *siginfo_t, *c_void) void,
+    pub const sigaction_fn = fn (i32, *siginfo_t, ?*c_void) callconv(.C) void;
+    sigaction: ?sigaction_fn,
     mask: sigset_t,
     flags: u32,
     restorer: ?extern fn () void = null,
 };
 
-pub const SIG_ERR = @intToPtr(extern fn (i32, *siginfo_t, *c_void) void, maxInt(usize));
-pub const SIG_DFL = @intToPtr(?extern fn (i32, *siginfo_t, *c_void) void, 0);
-pub const SIG_IGN = @intToPtr(extern fn (i32, *siginfo_t, *c_void) void, 1);
+pub const SIG_ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
+pub const SIG_DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
+pub const SIG_IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
+
 pub const empty_sigset = [_]u32{0} ** sigset_t.len;
 
 pub const in_port_t = u16;

--- a/lib/std/os/bits/netbsd.zig
+++ b/lib/std/os/bits/netbsd.zig
@@ -1,12 +1,22 @@
 const std = @import("../../std.zig");
+const builtin = std.builtin;
 const maxInt = std.math.maxInt;
 
+pub const blkcnt_t = i64;
+pub const blksize_t = i32;
+pub const clock_t = u32;
+pub const dev_t = u64;
 pub const fd_t = i32;
-pub const pid_t = i32;
-pub const mode_t = u32;
+pub const gid_t = u32;
 pub const ino_t = u64;
+pub const mode_t = u32;
+pub const nlink_t = u32;
 pub const off_t = i64;
+pub const pid_t = i32;
 pub const socklen_t = u32;
+pub const time_t = i64;
+pub const uid_t = u32;
+pub const lwpid_t = i32;
 
 /// Renamed from `kevent` to `Kevent` to avoid conflict with function name.
 pub const Kevent = extern struct {
@@ -137,23 +147,20 @@ pub const msghdr_const = extern struct {
 /// in C, macros are used to hide the differences. Here we use
 /// methods to accomplish this.
 pub const Stat = extern struct {
-    dev: u64,
-    mode: u32,
+    dev: dev_t,
+    mode: mode_t,
     ino: ino_t,
-    nlink: usize,
-
-    uid: u32,
-    gid: u32,
-    rdev: u64,
-
+    nlink: nlink_t,
+    uid: uid_t,
+    gid: gid_t,
+    rdev: dev_t,
     atim: timespec,
     mtim: timespec,
     ctim: timespec,
     birthtim: timespec,
-
     size: off_t,
-    blocks: i64,
-    blksize: isize,
+    blocks: blkcnt_t,
+    blksize: blksize_t,
     flags: u32,
     gen: u32,
     __spare: [2]u32,
@@ -176,12 +183,14 @@ pub const timespec = extern struct {
     tv_nsec: isize,
 };
 
+pub const MAXNAMLEN = 511;
+
 pub const dirent = extern struct {
-    d_fileno: u64,
+    d_fileno: ino_t,
     d_reclen: u16,
     d_namlen: u16,
     d_type: u8,
-    d_name: [512]u8,
+    d_name: [MAXNAMLEN:0]u8,
 
     pub fn reclen(self: dirent) u16 {
         return self.d_reclen;
@@ -685,23 +694,74 @@ pub const winsize = extern struct {
 
 const NSIG = 32;
 
-pub const SIG_ERR = @intToPtr(extern fn (i32) void, maxInt(usize));
-pub const SIG_DFL = @intToPtr(extern fn (i32) void, 0);
-pub const SIG_IGN = @intToPtr(extern fn (i32) void, 1);
+pub const SIG_ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
+pub const SIG_DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
+pub const SIG_IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
 
 /// Renamed from `sigaction` to `Sigaction` to avoid conflict with the syscall.
 pub const Sigaction = extern struct {
+    pub const sigaction_fn = fn (i32, *siginfo_t, ?*c_void) callconv(.C) void;
     /// signal handler
-    __sigaction_u: extern union {
-        __sa_handler: extern fn (i32) void,
-        __sa_sigaction: extern fn (i32, *__siginfo, usize) void,
-    },
-
-    /// see signal options
-    sa_flags: u32,
-
+    sigaction: ?sigaction_fn,
     /// signal mask to apply
-    sa_mask: sigset_t,
+    mask: sigset_t,
+    /// signal options
+    flags: u32,
+};
+
+pub const sigval_t = extern union {
+    int: i32,
+    ptr: ?*c_void,
+};
+
+pub const siginfo_t = extern union {
+    pad: [128]u8,
+    info: _ksiginfo,
+};
+
+pub const _ksiginfo = extern struct {
+    signo: i32,
+    code: i32,
+    errno: i32,
+    // 64bit architectures insert 4bytes of padding here, this is done by
+    // correctly aligning the reason field
+    reason: extern union {
+        rt: extern struct {
+            pid: pid_t,
+            uid: uid_t,
+            value: sigval_t,
+        },
+        child: extern struct {
+            pid: pid_t,
+            uid: uid_t,
+            status: i32,
+            utime: clock_t,
+            stime: clock_t,
+        },
+        fault: extern struct {
+            addr: ?*c_void,
+            trap: i32,
+            trap2: i32,
+            trap3: i32,
+        },
+        poll: extern struct {
+            band: i32,
+            fd: i32,
+        },
+        syscall: extern struct {
+            sysnum: i32,
+            retval: [2]i32,
+            @"error": i32,
+            args: [8]u64,
+        },
+        ptrace_state: extern struct {
+            pe_report_event: i32,
+            option: extern union {
+                pe_other_pid: pid_t,
+                pe_lwp: lwpid_t,
+            },
+        },
+    } align(@sizeOf(usize)),
 };
 
 pub const _SIG_WORDS = 4;
@@ -722,6 +782,34 @@ pub inline fn _SIG_VALID(sig: usize) usize {
 
 pub const sigset_t = extern struct {
     __bits: [_SIG_WORDS]u32,
+};
+
+pub const empty_sigset = sigset_t{ .__bits = [_]u32{0} ** _SIG_WORDS };
+
+// XXX x86_64 specific
+pub const mcontext_t = extern struct {
+    gregs: [26]u64,
+    mc_tlsbase: u64,
+    fpregs: [512]u8 align(8),
+};
+
+pub const REG_RBP = 12;
+pub const REG_RIP = 21;
+pub const REG_RSP = 24;
+
+pub const ucontext_t = extern struct {
+    flags: u32,
+    link: ?*ucontext_t,
+    sigmask: sigset_t,
+    stack: stack_t,
+    mcontext: mcontext_t,
+    __pad: [switch (builtin.arch) {
+        .i386 => 4,
+        .mips, .mipsel, .mips64, .mips64el => 14,
+        .arm, .armeb, .thumb, .thumbeb => 1,
+        .sparc, .sparcel, .sparcv9 => if (@sizeOf(usize) == 4) 43 else 8,
+        else => 0,
+    }]u32,
 };
 
 pub const EPERM = 1; // Operation not permitted


### PR DESCRIPTION
* I've combed the libc sources and tried to find all the latest symbols. I'm not happy with the aliasing machinery (and it's even worse if you factor in the osx-renamed symbols) but that's the best we can do without shuffling around the definitions even more.

* The segfault handler is now enabled but only working for x86_64 (it's a matter of porting more `mcontext_t` definitions`)