### PR TITLE
Fix io tests

### DIFF
--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -141,6 +141,20 @@ test "null_out_stream" {
 }
 
 test "" {
+    _ = @import("io/bit_in_stream.zig");
+    _ = @import("io/bit_out_stream.zig");
+    _ = @import("io/buffered_atomic_file.zig");
+    _ = @import("io/buffered_in_stream.zig");
+    _ = @import("io/buffered_out_stream.zig");
+    _ = @import("io/c_out_stream.zig");
+    _ = @import("io/counting_out_stream.zig");
+    _ = @import("io/fixed_buffer_stream.zig");
+    _ = @import("io/in_stream.zig");
+    _ = @import("io/out_stream.zig");
+    _ = @import("io/peek_stream.zig");
+    _ = @import("io/seekable_stream.zig");
+    _ = @import("io/serialization.zig");
+    _ = @import("io/stream_source.zig");
     _ = @import("io/test.zig");
 }
 

--- a/lib/std/io/c_out_stream.zig
+++ b/lib/std/io/c_out_stream.zig
@@ -39,6 +39,6 @@ test "" {
         std.fs.cwd().deleteFileZ(filename) catch {};
     }
 
-    const out_stream = &cOutStream(out_file);
+    const out_stream = cOutStream(out_file);
     try out_stream.print("hi: {}\n", .{@as(i32, 123)});
 }

--- a/lib/std/io/c_out_stream.zig
+++ b/lib/std/io/c_out_stream.zig
@@ -36,9 +36,9 @@ test "" {
     const out_file = std.c.fopen(filename, "w") orelse return error.UnableToOpenTestFile;
     defer {
         _ = std.c.fclose(out_file);
-        fs.cwd().deleteFileZ(filename) catch {};
+        std.fs.cwd().deleteFileZ(filename) catch {};
     }
 
-    const out_stream = &io.COutStream.init(out_file).stream;
+    const out_stream = &cOutStream(out_file);
     try out_stream.print("hi: {}\n", .{@as(i32, 123)});
 }

--- a/lib/std/io/peek_stream.zig
+++ b/lib/std/io/peek_stream.zig
@@ -24,7 +24,7 @@ pub fn PeekStream(
             .Static => struct {
                 pub fn init(base: InStreamType) Self {
                     return .{
-                        .base = base,
+                        .unbuffered_in_stream = base,
                         .fifo = FifoType.init(),
                     };
                 }
@@ -32,7 +32,7 @@ pub fn PeekStream(
             .Slice => struct {
                 pub fn init(base: InStreamType, buf: []u8) Self {
                     return .{
-                        .base = base,
+                        .unbuffered_in_stream = base,
                         .fifo = FifoType.init(buf),
                     };
                 }
@@ -40,7 +40,7 @@ pub fn PeekStream(
             .Dynamic => struct {
                 pub fn init(base: InStreamType, allocator: *mem.Allocator) Self {
                     return .{
-                        .base = base,
+                        .unbuffered_in_stream = base,
                         .fifo = FifoType.init(allocator),
                     };
                 }
@@ -61,7 +61,7 @@ pub fn PeekStream(
             if (dest_index == dest.len) return dest_index;
 
             // ask the backing stream for more
-            dest_index += try self.base.read(dest[dest_index..]);
+            dest_index += try self.unbuffered_in_stream.read(dest[dest_index..]);
             return dest_index;
         }
 


### PR DESCRIPTION
While tracking down a compilation error in `serialization.zig`, I saw that a bunch of io files were not tested when running `zig build test-std`.

I added them in the existing `test "" ` block but I'm not sure if that's the best place or even the best way to do it.

`io/serialization.zig` and `io/peek_stream.zig` had some compilation error that I fixed too.