### PR TITLE
fix some nullptr dereferences on arm-linux-musleabhif

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1324,6 +1324,7 @@ struct ZigTypeFloat {
     size_t bit_count;
 };
 
+// Needs to have the same memory layout as ZigTypeVector
 struct ZigTypeArray {
     ZigType *child_type;
     uint64_t len;
@@ -1512,11 +1513,16 @@ struct ZigTypeBoundFn {
     ZigType *fn_type;
 };
 
+// Needs to have the same memory layout as ZigTypeArray
 struct ZigTypeVector {
     // The type must be a pointer, integer, bool, or float
     ZigType *elem_type;
-    uint32_t len;
+    uint64_t len;
+    size_t padding;
 };
+
+// A lot of code is relying on ZigTypeArray and ZigTypeVector having the same layout/size
+static_assert(sizeof(ZigTypeVector) == sizeof(ZigTypeArray), "Size of ZigTypeVector and ZigTypeArray do not match!");
 
 enum ZigTypeId {
     ZigTypeIdInvalid,

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -5156,6 +5156,7 @@ ZigType *get_vector_type(CodeGen *g, uint32_t len, ZigType *elem_type) {
     }
     entry->data.vector.len = len;
     entry->data.vector.elem_type = elem_type;
+    entry->data.vector.padding = 0;
 
     buf_resize(&entry->name, 0);
     buf_appendf(&entry->name, "@Vector(%u, %s)", len, buf_ptr(&elem_type->name));

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -1430,7 +1430,7 @@ void bigint_shr(BigInt *dest, const BigInt *op1, const BigInt *op2) {
         uint64_t digit = op1_digits[op_digit_index];
         size_t dest_digit_index = op_digit_index - digit_shift_count;
         digits[dest_digit_index] = carry | (digit >> leftover_shift_count);
-        carry = digit << (64 - leftover_shift_count);
+        carry = (leftover_shift_count != 0) ? (digit << (64 - leftover_shift_count)) : 0;
 
         if (dest_digit_index == 0) { break; }
         op_digit_index -= 1;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -714,7 +714,7 @@ static LLVMValueRef get_arithmetic_overflow_fn(CodeGen *g, ZigType *operand_type
     };
 
     if (operand_type->id == ZigTypeIdVector) {
-        sprintf(fn_name, "llvm.%s.with.overflow.v%" PRIu32 "i%" PRIu32, signed_str,
+        sprintf(fn_name, "llvm.%s.with.overflow.v%" PRIu64 "i%" PRIu32, signed_str,
                 operand_type->data.vector.len, int_type->data.integral.bit_count);
 
         LLVMTypeRef return_elem_types[] = {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -18982,7 +18982,7 @@ static IrInstGen *ir_analyze_async_call(IrAnalyze *ira, IrInst* source_instr, Zi
         if (type_is_invalid(result_loc->value->type) || result_loc->value->type->id == ZigTypeIdUnreachable) {
             return result_loc;
         }
-        result_loc = ir_implicit_cast2(ira, &call_result_loc->source_instruction->base, result_loc,
+        result_loc = ir_implicit_cast2(ira, source_instr, result_loc,
                 get_pointer_to_type(ira->codegen, frame_type, false));
         if (type_is_invalid(result_loc->value->type))
             return ira->codegen->invalid_inst_gen;
@@ -19967,14 +19967,16 @@ static IrInstGen *ir_analyze_call_extra(IrAnalyze *ira, IrInst* source_instr,
         return ira->codegen->invalid_inst_gen;
 
     IrInstGen *stack = nullptr;
+    IrInst *stack_src = nullptr;
     if (stack_is_non_null) {
         stack = ir_analyze_optional_value_payload_value(ira, source_instr, opt_stack, false);
         if (type_is_invalid(stack->value->type))
             return ira->codegen->invalid_inst_gen;
+        stack_src = &stack->base;
     }
 
     return ir_analyze_fn_call(ira, source_instr, fn, fn_type, fn_ref, first_arg_ptr, first_arg_ptr_src,
-        modifier, stack, &stack->base, false, args_ptr, args_len, nullptr, result_loc);
+        modifier, stack, stack_src, false, args_ptr, args_len, nullptr, result_loc);
 }
 
 static IrInstGen *ir_analyze_instruction_call_extra(IrAnalyze *ira, IrInstSrcCallExtra *instruction) {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -15953,7 +15953,7 @@ static IrInstGen *ir_analyze_bin_op_cmp_numeric(IrAnalyze *ira, IrInst *source_i
     if (op1->value->type->id == ZigTypeIdVector && op2->value->type->id == ZigTypeIdVector) {
         if (op1->value->type->data.vector.len != op2->value->type->data.vector.len) {
             ir_add_error(ira, source_instr,
-                buf_sprintf("vector length mismatch: %" PRIu32 " and %" PRIu32,
+                buf_sprintf("vector length mismatch: %" PRIu64 " and %" PRIu64,
                     op1->value->type->data.vector.len, op2->value->type->data.vector.len));
             return ira->codegen->invalid_inst_gen;
         }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1188,7 +1188,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    suspend;
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:5: error: expected type '*@Frame(bar)', found '*@Frame(foo)'",
+        "tmp.zig:3:13: error: expected type '*@Frame(bar)', found '*@Frame(foo)'",
     });
 
     cases.add("@Frame() of generic function",


### PR DESCRIPTION
closes #4889

there is probably a different reason why the `source_instruction` in `call_result_loc` is a nullptr, but this fixes the issue. which btw also breaks the test because the compile error is different.