### PR TITLE
Update all remaining uses of &outStream().stream

### DIFF
--- a/lib/std/hash/benchmark.zig
+++ b/lib/std/hash/benchmark.zig
@@ -172,9 +172,7 @@ fn mode(comptime x: comptime_int) comptime_int {
 }
 
 pub fn main() !void {
-    var stdout_file = std.io.getStdOut();
-    var stdout_out_stream = stdout_file.outStream();
-    const stdout = &stdout_out_stream.stream;
+    const stdout = std.io.getStdOut().outStream();
 
     var buffer: [1024]u8 = undefined;
     var fixed = std.heap.FixedBufferAllocator.init(buffer[0..]);

--- a/lib/std/unicode/throughput_test.zig
+++ b/lib/std/unicode/throughput_test.zig
@@ -2,7 +2,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 pub fn main() !void {
-    const stdout = &std.io.getStdOut().outStream().stream;
+    const stdout = std.io.getStdOut().outStream();
 
     const args = try std.process.argsAlloc(std.heap.page_allocator);
 

--- a/lib/std/zig/perf_test.zig
+++ b/lib/std/zig/perf_test.zig
@@ -24,7 +24,7 @@ pub fn main() !void {
     const mb_per_sec = bytes_per_sec / (1024 * 1024);
 
     var stdout_file = std.io.getStdOut();
-    const stdout = &stdout_file.outStream().stream;
+    const stdout = stdout_file.outStream();
     try stdout.print("{:.3} MiB/s, {} KiB used \n", .{ mb_per_sec, memory_used / 1024 });
 }
 

--- a/tools/merge_anal_dumps.zig
+++ b/tools/merge_anal_dumps.zig
@@ -23,7 +23,7 @@ pub fn main() anyerror!void {
     }
 
     const stdout = try std.io.getStdOut();
-    try dump.render(&stdout.outStream().stream);
+    try dump.render(stdout.outStream());
 }
 
 /// AST source node


### PR DESCRIPTION
Same sort of thing as https://github.com/ziglang/zig/pull/4919, just searched for all remaining `.stream` patterns and updated them to the new stream pattern.