### PR TITLE
change the default ABI of riscv64-linux-musl

### DIFF
--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -100,7 +100,7 @@ static const bool assertions_on = false;
 
 LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Triple,
     const char *CPU, const char *Features, LLVMCodeGenOptLevel Level, LLVMRelocMode Reloc,
-    LLVMCodeModel CodeModel, bool function_sections)
+    LLVMCodeModel CodeModel, bool function_sections, ZigLLVMABIType float_abi, const char *abi_name)
 {
     Optional<Reloc::Model> RM;
     switch (Reloc){
@@ -147,6 +147,21 @@ LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Tri
 
     TargetOptions opt;
     opt.FunctionSections = function_sections;
+    switch (float_abi) {
+        case ZigLLVMABITypeDefault:
+            opt.FloatABIType = FloatABI::Default;
+            break;
+        case ZigLLVMABITypeSoft:
+            opt.FloatABIType = FloatABI::Soft;
+            break;
+        case ZigLLVMABITypeHard:
+            opt.FloatABIType = FloatABI::Hard;
+            break;
+    }
+
+    if (abi_name != nullptr) {
+        opt.MCOptions.ABIName = abi_name;
+    }
 
     TargetMachine *TM = reinterpret_cast<Target*>(T)->createTargetMachine(Triple, CPU, Features, opt, RM, CM,
             OL, JIT);

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -51,9 +51,16 @@ ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machi
         bool is_small, bool time_report,
         const char *asm_filename, const char *bin_filename, const char *llvm_ir_filename);
 
+
+enum ZigLLVMABIType {
+    ZigLLVMABITypeDefault, // Target-specific (either soft or hard depending on triple, etc).
+    ZigLLVMABITypeSoft,    // Soft float.
+    ZigLLVMABITypeHard     // Hard float.
+};
+
 ZIG_EXTERN_C LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Triple,
     const char *CPU, const char *Features, LLVMCodeGenOptLevel Level, LLVMRelocMode Reloc,
-    LLVMCodeModel CodeModel, bool function_sections);
+    LLVMCodeModel CodeModel, bool function_sections, ZigLLVMABIType float_abi, const char *abi_name);
 
 ZIG_EXTERN_C LLVMTypeRef ZigLLVMTokenTypeInContext(LLVMContextRef context_ref);
 

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -160,15 +160,14 @@ const test_targets = blk: {
             },
         },
 
-        // https://github.com/ziglang/zig/issues/4863
-        //TestTarget{
-        //    .target = .{
-        //        .cpu_arch = .riscv64,
-        //        .os_tag = .linux,
-        //        .abi = .musl,
-        //    },
-        //    .link_libc = true,
-        //},
+        TestTarget{
+            .target = .{
+                .cpu_arch = .riscv64,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .link_libc = true,
+        },
 
         // https://github.com/ziglang/zig/issues/3340
         //TestTarget{


### PR DESCRIPTION
Before, this would cause a link failure when mixing Zig and C code for
RISC-V targets.

Now, the ABIs match and Zig and C code can be mixed successfully.

I will file a follow-up issue for the ability to deal more explicitly
with ABIs.

closes #4863