### PR TITLE
translate-c: Properly translate C multicharacter literals

### DIFF
--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -5387,12 +5387,24 @@ fn parseCPrimaryExpr(c: *Context, it: *CTokenList.Iterator, source: []const u8, 
     switch (tok.id) {
         .CharLiteral => {
             const first_tok = it.list.at(0);
-            const token = try appendToken(c, .CharLiteral, try zigifyEscapeSequences(c, source[tok.start..tok.end], source[first_tok.start..first_tok.end], source_loc));
-            const node = try c.a().create(ast.Node.CharLiteral);
-            node.* = .{
-                .token = token,
-            };
-            return &node.base;
+            if (
+                (source[tok.start+1] == '\\' and tok.end - tok.start == 4)
+                or (source[tok.start+1] != '\\' and tok.end - tok.start == 3)
+            ) {
+                const token = try appendToken(c, .CharLiteral, try zigifyEscapeSequences(c, source[tok.start..tok.end], source[first_tok.start..first_tok.end], source_loc));
+                const node = try c.a().create(ast.Node.CharLiteral);
+                node.* = .{
+                    .token = token,
+                };
+                return &node.base;
+            } else {
+                const token = try appendTokenFmt(c, .IntegerLiteral, "0x{x}", .{source[tok.start+1..tok.end-1]});
+                const node = try c.a().create(ast.Node.IntegerLiteral);
+                node.* = .{
+                    .token = token,
+                };
+                return &node.base;
+            }
         },
         .StringLiteral => {
             const first_tok = it.list.at(0);

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -5387,10 +5387,7 @@ fn parseCPrimaryExpr(c: *Context, it: *CTokenList.Iterator, source: []const u8, 
     switch (tok.id) {
         .CharLiteral => {
             const first_tok = it.list.at(0);
-            if (
-                (source[tok.start+1] == '\\' and tok.end - tok.start == 4)
-                or (source[tok.start+1] != '\\' and tok.end - tok.start == 3)
-            ) {
+            if (source[tok.start] != '\'' or source[tok.start + 1] == '\\' or tok.end - tok.start == 3) {
                 const token = try appendToken(c, .CharLiteral, try zigifyEscapeSequences(c, source[tok.start..tok.end], source[first_tok.start..first_tok.end], source_loc));
                 const node = try c.a().create(ast.Node.CharLiteral);
                 node.* = .{

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2847,4 +2847,10 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     , &[_][]const u8{
         \\pub const FOO = "a" ++ ("b" ++ "c");
     });
+
+    cases.add("multibyte character literals",
+        \\#define FOO 'abcd'
+    , &[_][]const u8{
+        \\pub const FOO = 0x61626364;
+    });
 }


### PR DESCRIPTION
Closes #4194.
This is my first pull request, so I hope that I did everything properly!