### PR TITLE
Generate clearer size mismatch error message

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -501,7 +501,7 @@ pub const toSlice = @compileError("deprecated; use std.mem.spanZ");
 /// the constness of the input type. `[*c]` pointers are assumed to be 0-terminated,
 /// and assumed to not allow null.
 pub fn Span(comptime T: type) type {
-    switch(@typeInfo(T)) {
+    switch (@typeInfo(T)) {
         .Optional => |optional_info| {
             return ?Span(optional_info.child);
         },
@@ -1758,7 +1758,8 @@ fn BytesAsValueReturnType(comptime T: type, comptime B: type) type {
     if (comptime !trait.is(.Pointer)(B) or
         (meta.Child(B) != [size]u8 and meta.Child(B) != [size:0]u8))
     {
-        @compileError("expected *[N]u8 " ++ ", passed " ++ @typeName(B));
+        comptime var buf: [100]u8 = undefined;
+        @compileError(std.fmt.bufPrint(&buf, "expected *[{}]u8, passed " ++ @typeName(B), .{size}) catch unreachable);
     }
 
     const alignment = comptime meta.alignment(B);


### PR DESCRIPTION
Existing message:
```zig
error: expected *[N]u8 , passed *const [0:0]u8
```

Updated message:
```zig
error: expected *[4]u8, passed *const [0:0]u8
```