### PR TITLE
cmake: improvements to cross-compiling for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,7 +365,7 @@ if(ZIG_STATIC)
     endif()
 else()
     if(MINGW)
-        set(EXE_LDFLAGS "${EXE_LDFLAGS} -lz3")
+        set(EXE_LDFLAGS "${EXE_LDFLAGS}")
     endif()
 endif()
 
@@ -429,11 +429,6 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 else()
     set(LIBSTAGE2_RELEASE_ARG --release-fast --strip)
 endif()
-if(WIN32)
-    set(LIBSTAGE2_WINDOWS_ARGS "-lntdll")
-else()
-    set(LIBSTAGE2_WINDOWS_ARGS "")
-endif()
 
 set(BUILD_LIBSTAGE2_ARGS "build-lib"
     "src-self-hosted/stage2.zig"
@@ -447,7 +442,6 @@ set(BUILD_LIBSTAGE2_ARGS "build-lib"
     --bundle-compiler-rt
     -fPIC
     -lc
-    ${LIBSTAGE2_WINDOWS_ARGS}
 )
 
 if("${ZIG_TARGET_TRIPLE}" STREQUAL "native")

--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -144,9 +144,7 @@ else()
         /mingw64/lib
         /c/msys64/mingw64/lib
         c:\\msys64\\mingw64\\lib)
-      if(LLVM_${_prettylibname_}_LIB)
-        set(LLVM_LIBRARIES ${LLVM_LIBRARIES} ${LLVM_${_prettylibname_}_LIB})
-      endif()
+      set(LLVM_LIBRARIES ${LLVM_LIBRARIES} ${LLVM_${_prettylibname_}_LIB})
     endmacro(FIND_AND_ADD_LLVM_LIB)
 
     # This list can be re-generated with `llvm-config --libfiles` and then
@@ -154,7 +152,6 @@ else()
     # `llvm-config` here because we are cross compiling.
     FIND_AND_ADD_LLVM_LIB(LLVMXRay)
     FIND_AND_ADD_LLVM_LIB(LLVMWindowsManifest)
-    FIND_AND_ADD_LLVM_LIB(LLVMTableGen)
     FIND_AND_ADD_LLVM_LIB(LLVMSymbolize)
     FIND_AND_ADD_LLVM_LIB(LLVMDebugInfoPDB)
     FIND_AND_ADD_LLVM_LIB(LLVMOrcJIT)

--- a/lib/libc/mingw/lib32/version.def
+++ b/lib/libc/mingw/lib32/version.def
@@ -1,0 +1,16 @@
+LIBRARY "VERSION.dll"
+EXPORTS
+GetFileVersionInfoA@16
+GetFileVersionInfoSizeA@8
+GetFileVersionInfoSizeW@8
+GetFileVersionInfoW@16
+VerFindFileA@32
+VerFindFileW@32
+VerInstallFileA@32
+VerInstallFileW@32
+VerLanguageNameA@12
+VerLanguageNameW@12
+VerQueryValueA@16
+VerQueryValueIndexA@24
+VerQueryValueIndexW@24
+VerQueryValueW@16

--- a/lib/libc/mingw/misc/___mb_cur_max_func.c
+++ b/lib/libc/mingw/misc/___mb_cur_max_func.c
@@ -1,0 +1,18 @@
+/**
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file is part of the mingw-w64 runtime package.
+ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
+ */
+
+#include <_mingw.h>
+
+extern int* __MINGW_IMP_SYMBOL(__mb_cur_max);
+
+int __cdecl ___mb_cur_max_func(void);
+int __cdecl ___mb_cur_max_func(void)
+{
+    return *__MINGW_IMP_SYMBOL(__mb_cur_max);
+}
+
+typedef int __cdecl (*_f___mb_cur_max_func)(void);
+_f___mb_cur_max_func __MINGW_IMP_SYMBOL(___mb_cur_max_func) = ___mb_cur_max_func;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2259,6 +2259,7 @@ struct CodeGen {
     size_t version_minor;
     size_t version_patch;
     const char *linker_script;
+    size_t stack_size_override;
 
     BuildMode build_mode;
     OutType out_type;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10597,6 +10597,7 @@ static Error check_cache(CodeGen *g, Buf *manifest_dir, Buf *digest) {
     cache_int(ch, g->linker_allow_shlib_undefined);
     cache_bool(ch, g->linker_z_nodelete);
     cache_bool(ch, g->linker_z_defs);
+    cache_usize(ch, g->stack_size_override);
 
     // gen_c_objects appends objects to g->link_objects which we want to include in the hash
     gen_c_objects(g);

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -72,7 +72,7 @@ static const char *msvcrt_common_src[] = {
 
 static const char *msvcrt_i386_src[] = {
     "misc" OS_SEP "lc_locale_func.c",
-
+    "misc" OS_SEP "___mb_cur_max_func.c",
 };
 
 static const char *msvcrt_other_src[] = {

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -1840,7 +1840,8 @@ static void construct_linker_job_elf(LinkJob *lj) {
 
     if (g->out_type == OutTypeExe) {
         lj->args.append("-z");
-        lj->args.append("stack-size=16777216"); // default to 16 MiB
+        size_t stack_size = (g->stack_size_override == 0) ? 16777216 : g->stack_size_override;
+        lj->args.append(buf_ptr(buf_sprintf("stack-size=%" ZIG_PRI_usize, stack_size)));
     }
 
     if (g->linker_script) {
@@ -2479,7 +2480,8 @@ static void construct_linker_job_coff(LinkJob *lj) {
 
     if (g->out_type == OutTypeExe) {
         // TODO compile time stack upper bound detection
-        lj->args.append("-STACK:16777216");
+        size_t stack_size = (g->stack_size_override == 0) ? 16777216 : g->stack_size_override;
+        lj->args.append(buf_ptr(buf_sprintf("-STACK:%" ZIG_PRI_usize, stack_size)));
     }
 
     coff_append_machine_arg(g, &lj->args);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -453,6 +453,7 @@ static int main0(int argc, char **argv) {
     OptionalBool linker_allow_shlib_undefined = OptionalBoolNull;
     bool linker_z_nodelete = false;
     bool linker_z_defs = false;
+    size_t stack_size_override = 0;
 
     ZigList<const char *> llvm_argv = {0};
     llvm_argv.append("zig (LLVM option parsing)");
@@ -848,6 +849,27 @@ static int main0(int argc, char **argv) {
                 } else {
                     fprintf(stderr, "warning: unsupported linker arg: -z %s\n", buf_ptr(z_arg));
                 }
+            } else if (buf_eql_str(arg, "--major-image-version")) {
+                i += 1;
+                if (i >= linker_args.length) {
+                    fprintf(stderr, "expected linker arg after '%s'\n", buf_ptr(arg));
+                    return EXIT_FAILURE;
+                }
+                ver_major = atoi(buf_ptr(linker_args.at(i)));
+            } else if (buf_eql_str(arg, "--minor-image-version")) {
+                i += 1;
+                if (i >= linker_args.length) {
+                    fprintf(stderr, "expected linker arg after '%s'\n", buf_ptr(arg));
+                    return EXIT_FAILURE;
+                }
+                ver_minor = atoi(buf_ptr(linker_args.at(i)));
+            } else if (buf_eql_str(arg, "--stack")) {
+                i += 1;
+                if (i >= linker_args.length) {
+                    fprintf(stderr, "expected linker arg after '%s'\n", buf_ptr(arg));
+                    return EXIT_FAILURE;
+                }
+                stack_size_override = atoi(buf_ptr(linker_args.at(i)));
             } else {
                 fprintf(stderr, "warning: unsupported linker arg: %s\n", buf_ptr(arg));
             }
@@ -1573,6 +1595,7 @@ static int main0(int argc, char **argv) {
             g->linker_allow_shlib_undefined = linker_allow_shlib_undefined;
             g->linker_z_nodelete = linker_z_nodelete;
             g->linker_z_defs = linker_z_defs;
+            g->stack_size_override = stack_size_override;
 
             if (override_soname) {
                 g->override_soname = buf_create_from_str(override_soname);

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -37,7 +37,9 @@
 #include <fcntl.h>
 #include <ntsecapi.h>
 
+#if defined(_MSC_VER)
 typedef SSIZE_T ssize_t;
+#endif
 #else
 #define ZIG_OS_POSIX
 

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -50,7 +50,9 @@ enum ZigClangAPValueKind {
 struct ZigClangAPValue {
     enum ZigClangAPValueKind Kind;
     // experimentally-derived size of clang::APValue::DataType
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32) && defined(__i386__)
+    char Data[68];
+#elif defined(_WIN32) && defined(_MSC_VER)
     char Data[52];
 #elif defined(__i386__)
     char Data[48];


### PR DESCRIPTION
 * don't unconditionally pass -lz3 for mingw builds. If mingw builds
   require this then the llvm-config executable should put it as part of
   --system-libs. If there is a bug and it does not do that, and we need
   a workaround, then the workaround should be an explicit cmake option.
 * don't link libstage2.a against -lntdll. This causes zig to set
   `builtin.link_mode == .Dynamic` and include the TLS definitions,
   which then collide with the mingw-w64 symbols. This should probably
   be addressed separately, but for now this solves the problem and
   there is no reason to link a static library against a DLL.
 * Findllvm.cmake no longer treats the libraries as "optional" and will
   emit a cmake error if one is not found. Additionally, the
   not-required LLVM library LLVMTableGen is omitted.