### PR TITLE
stage1: Respect the specified name for extern var

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2083,7 +2083,7 @@ struct CodeGen {
     HashMap<Scope *, ZigValue *, fn_eval_hash, fn_eval_eql> memoized_fn_eval_table;
     HashMap<ZigLLVMFnKey, LLVMValueRef, zig_llvm_fn_key_hash, zig_llvm_fn_key_eql> llvm_fn_table;
     HashMap<Buf *, Tld *, buf_hash, buf_eql_buf> exported_symbol_names;
-    HashMap<Buf *, Tld *, buf_hash, buf_eql_buf> external_prototypes;
+    HashMap<Buf *, Tld *, buf_hash, buf_eql_buf> external_symbol_names;
     HashMap<Buf *, ZigValue *, buf_hash, buf_eql_buf> string_literals_table;
     HashMap<const ZigType *, ZigValue *, type_ptr_hash, type_ptr_eql> type_info_cache;
     HashMap<const ZigType *, ZigValue *, type_ptr_hash, type_ptr_eql> one_possible_values;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -3498,7 +3498,7 @@ static void resolve_decl_fn(CodeGen *g, TldFn *tld_fn) {
             }
         } else {
             fn_table_entry->inferred_async_node = inferred_async_none;
-            g->external_prototypes.put_unique(tld_fn->base.name, &tld_fn->base);
+            g->external_symbol_names.put_unique(tld_fn->base.name, &tld_fn->base);
         }
 
         Scope *child_scope = fn_table_entry->fndef_scope ? &fn_table_entry->fndef_scope->base : tld_fn->base.parent_scope;
@@ -4046,6 +4046,10 @@ static void resolve_decl_var(CodeGen *g, TldVar *tld_var, bool allow_lazy) {
     if (is_export) {
         validate_export_var_type(g, type, source_node);
         add_var_export(g, tld_var->var, tld_var->var->name, GlobalLinkageIdStrong);
+    }
+
+    if (is_extern) {
+        g->external_symbol_names.put_unique(tld_var->base.name, &tld_var->base);
     }
 
     g->global_vars.append(tld_var);


### PR DESCRIPTION
This is a minimally-invasive patch, there are a few other problems I've noticed:
* `extern var` with an initializer get silently promoted to internal `var` declarations, this should be an error
* `extern` variables/fn are treated as global during the codegen but at the IR level they're treated as scoped variables, this means all the redefinition checks are useless.

Closes #4947