### PR TITLE
Fix missing compile error on assign to slice and array parameters

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -225,10 +225,11 @@ fn findLLVM(b: *Builder, llvm_config_exe: []const u8) !LibraryDep {
                 if (fs.path.isAbsolute(lib_arg)) {
                     try result.libs.append(lib_arg);
                 } else {
+                    var lib_arg_copy = lib_arg;
                     if (mem.endsWith(u8, lib_arg, ".lib")) {
-                        lib_arg = lib_arg[0 .. lib_arg.len - 4];
+                        lib_arg_copy = lib_arg[0 .. lib_arg.len - 4];
                     }
-                    try result.system_libs.append(lib_arg);
+                    try result.system_libs.append(lib_arg_copy);
                 }
             }
         }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,6 +2,42 @@ const tests = @import("tests.zig");
 const std = @import("std");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
+    cases.addTest("reassign to array parameter",
+        \\fn reassign(a: [3]f32) void {
+        \\    a = [3]f32{4, 5, 6};
+        \\}
+        \\export fn entry() void {
+        \\    reassign(.{1, 2, 3});
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:2:16: error: cannot assign to constant"
+    });
+
+    cases.addTest("reassign to slice parameter",
+        \\pub fn reassign(s: []const u8) void {
+        \\    s = s[0..];
+        \\}
+        \\export fn entry() void {
+        \\    reassign("foo");
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:2:10: error: cannot assign to constant"
+    });
+
+    cases.addTest("reassign to struct parameter",
+        \\const S = struct {
+        \\    x: u32,
+        \\};
+        \\fn reassign(s: S) void {
+        \\    s = S{.x = 2};
+        \\}
+        \\export fn entry() void {
+        \\    reassign(S{.x = 3});
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:5:16: error: cannot assign to constant"
+    });
+
     cases.addTest("reference to const data",
         \\export fn foo() void {
         \\    var ptr = &[_]u8{0,0,0,0};

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -10,7 +10,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    reassign(.{1, 2, 3});
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:16: error: cannot assign to constant"
+        "tmp.zig:2:15: error: cannot assign to constant"
     });
 
     cases.addTest("reassign to slice parameter",
@@ -35,7 +35,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    reassign(S{.x = 3});
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:16: error: cannot assign to constant"
+        "tmp.zig:5:10: error: cannot assign to constant"
     });
 
     cases.addTest("reference to const data",

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -612,7 +612,7 @@ pub const StackTracesContext = struct {
 
             const stdout = child.stdout.?.inStream().readAllAlloc(b.allocator, max_stdout_size) catch unreachable;
             defer b.allocator.free(stdout);
-            const stderr = child.stderr.?.inStream().readAllAlloc(b.allocator, max_stdout_size) catch unreachable;
+            var stderr = child.stderr.?.inStream().readAllAlloc(b.allocator, max_stdout_size) catch unreachable;
             defer b.allocator.free(stderr);
 
             const term = child.wait() catch |err| {


### PR DESCRIPTION
~~Compile errors on structs and arrays point to the first element which makes me doubt how correct this fix is.~~

Closes #3800
Closes #4350
Closes #4015