### PR TITLE
 sort.binarySearch: fix integer underflow (#4980) 

### DIFF
--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -10,16 +10,16 @@ pub fn binarySearch(comptime T: type, key: T, items: []const T, comptime compare
         return null;
 
     var left: usize = 0;
-    var right: usize = items.len - 1;
+    var right: usize = items.len;
 
-    while (left <= right) {
+    while (left < right) {
         // Avoid overflowing in the midpoint calculation
         const mid = left + (right - left) / 2;
         // Compare the key with the midpoint element
         switch (compareFn(key, items[mid])) {
             .eq => return mid,
             .gt => left = mid + 1,
-            .lt => right = mid - 1,
+            .lt => right = mid,
         }
     }
 

--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -6,9 +6,6 @@ const math = std.math;
 const builtin = @import("builtin");
 
 pub fn binarySearch(comptime T: type, key: T, items: []const T, comptime compareFn: fn (lhs: T, rhs: T) math.Order) ?usize {
-    if (items.len < 1)
-        return null;
-
     var left: usize = 0;
     var right: usize = items.len;
 

--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -48,6 +48,10 @@ test "std.sort.binarySearch" {
         binarySearch(u32, 1, &[_]u32{0}, S.order_u32),
     );
     testing.expectEqual(
+        @as(?usize, null),
+        binarySearch(u32, 0, &[_]u32{1}, S.order_u32),
+    );
+    testing.expectEqual(
         @as(?usize, 4),
         binarySearch(u32, 5, &[_]u32{ 1, 2, 3, 4, 5 }, S.order_u32),
     );


### PR DESCRIPTION
When the key was smaller than any value in the array, an error was occurring with the mid being zero and having 1 subtracted from it.

This fixes the issue and adds a test case.