### PR TITLE
Fix generated docs of user code

### DIFF
--- a/src/dump_analysis.cpp
+++ b/src/dump_analysis.cpp
@@ -1218,6 +1218,10 @@ void zig_print_analysis_dump(CodeGen *g, FILE *f, const char *one_indent, const 
     jw_object_field(jw, "rootPkg");
     anal_dump_pkg_ref(&ctx, g->main_pkg);
 
+    // FIXME: Remove this ugly workaround.
+    //        Right now the code in docs/main.js relies on the root of the main package being itself.
+    g->main_pkg->package_table.put(buf_create_from_str("root"), g->main_pkg);
+
     // Poke the functions
     for (size_t i = 0; i < g->fn_defs.length; i += 1) {
         ZigFn *fn = g->fn_defs.at(i);


### PR DESCRIPTION
fff3c1fff4c3ebfcb2bd4f08a43ae7815b5c446b broke the docs generation for
own user code. This adds a workaround, because all the code in docs/main.js
is relying on the fact that the root package of the main package is the
root package itself.

Now at least people can get working docs for 0.6.0 release, @kristoff-it this should fix the docs generation in your project.