### PR TITLE
look for clang-cpp shared lib when it exists

### DIFF
--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -8,54 +8,72 @@
 # CLANG_LIBDIRS
 
 find_path(CLANG_INCLUDE_DIRS NAMES clang/Frontend/ASTUnit.h
-    PATHS
-        /usr/lib/llvm/10/include
-        /usr/lib/llvm-10/include
-        /usr/lib/llvm-10.0/include
-        /usr/local/llvm100/include
-        /usr/local/llvm10/include
-        /mingw64/include)
+  PATHS
+    /usr/lib/llvm/10/include
+    /usr/lib/llvm-10/include
+    /usr/lib/llvm-10.0/include
+    /usr/local/llvm100/include
+    /usr/local/llvm10/include
+    /mingw64/include
+)
 
-macro(FIND_AND_ADD_CLANG_LIB _libname_)
+if(NOT ZIG_STATIC_LLVM)
+  find_library(CLANG_CPP_DYLIB
+    NAMES
+      clang-cpp-10.0
+      clang-cpp100
+      clang-cpp
+    PATHS
+      ${CLANG_LIBDIRS}
+      /usr/lib/llvm-10/lib
+      /usr/local/llvm100/lib
+      /usr/local/llvm10/lib
+  )
+endif()
+
+if(CLANG_CPP_DYLIB)
+  set(CLANG_LIBRARIES ${CLANG_CPP_DYLIB})
+else()
+  macro(FIND_AND_ADD_CLANG_LIB _libname_)
     string(TOUPPER ${_libname_} _prettylibname_)
     find_library(CLANG_${_prettylibname_}_LIB NAMES ${_libname_}
-        PATHS
-            ${CLANG_LIBDIRS}
-            /usr/lib/llvm/10/lib
-            /usr/lib/llvm-10/lib
-            /usr/lib/llvm-10.0/lib
-            /usr/local/llvm100/lib
-            /usr/local/llvm10/lib
-            /mingw64/lib
-            /c/msys64/mingw64/lib
-            c:\\msys64\\mingw64\\lib)
-    if(CLANG_${_prettylibname_}_LIB)
-        set(CLANG_LIBRARIES ${CLANG_LIBRARIES} ${CLANG_${_prettylibname_}_LIB})
-    endif()
-endmacro(FIND_AND_ADD_CLANG_LIB)
+      PATHS
+        ${CLANG_LIBDIRS}
+        /usr/lib/llvm/10/lib
+        /usr/lib/llvm-10/lib
+        /usr/lib/llvm-10.0/lib
+        /usr/local/llvm100/lib
+        /usr/local/llvm10/lib
+        /mingw64/lib
+        /c/msys64/mingw64/lib
+        c:\\msys64\\mingw64\\lib
+    )
+    set(CLANG_LIBRARIES ${CLANG_LIBRARIES} ${CLANG_${_prettylibname_}_LIB})
+  endmacro(FIND_AND_ADD_CLANG_LIB)
 
-FIND_AND_ADD_CLANG_LIB(clangFrontendTool)
-FIND_AND_ADD_CLANG_LIB(clangCodeGen)
-FIND_AND_ADD_CLANG_LIB(clangFrontend)
-FIND_AND_ADD_CLANG_LIB(clangDriver)
-FIND_AND_ADD_CLANG_LIB(clangSerialization)
-FIND_AND_ADD_CLANG_LIB(clangSema)
-FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerFrontend)
-FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerCheckers)
-FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerCore)
-FIND_AND_ADD_CLANG_LIB(clangAnalysis)
-FIND_AND_ADD_CLANG_LIB(clangASTMatchers)
-FIND_AND_ADD_CLANG_LIB(clangAST)
-FIND_AND_ADD_CLANG_LIB(clangParse)
-FIND_AND_ADD_CLANG_LIB(clangSema)
-FIND_AND_ADD_CLANG_LIB(clangBasic)
-FIND_AND_ADD_CLANG_LIB(clangEdit)
-FIND_AND_ADD_CLANG_LIB(clangLex)
-FIND_AND_ADD_CLANG_LIB(clangARCMigrate)
-FIND_AND_ADD_CLANG_LIB(clangRewriteFrontend)
-FIND_AND_ADD_CLANG_LIB(clangRewrite)
-FIND_AND_ADD_CLANG_LIB(clangCrossTU)
-FIND_AND_ADD_CLANG_LIB(clangIndex)
+  FIND_AND_ADD_CLANG_LIB(clangFrontendTool)
+  FIND_AND_ADD_CLANG_LIB(clangCodeGen)
+  FIND_AND_ADD_CLANG_LIB(clangFrontend)
+  FIND_AND_ADD_CLANG_LIB(clangDriver)
+  FIND_AND_ADD_CLANG_LIB(clangSerialization)
+  FIND_AND_ADD_CLANG_LIB(clangSema)
+  FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerFrontend)
+  FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerCheckers)
+  FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerCore)
+  FIND_AND_ADD_CLANG_LIB(clangAnalysis)
+  FIND_AND_ADD_CLANG_LIB(clangASTMatchers)
+  FIND_AND_ADD_CLANG_LIB(clangAST)
+  FIND_AND_ADD_CLANG_LIB(clangParse)
+  FIND_AND_ADD_CLANG_LIB(clangSema)
+  FIND_AND_ADD_CLANG_LIB(clangBasic)
+  FIND_AND_ADD_CLANG_LIB(clangEdit)
+  FIND_AND_ADD_CLANG_LIB(clangLex)
+  FIND_AND_ADD_CLANG_LIB(clangARCMigrate)
+  FIND_AND_ADD_CLANG_LIB(clangRewriteFrontend)
+  FIND_AND_ADD_CLANG_LIB(clangRewrite)
+  FIND_AND_ADD_CLANG_LIB(clangCrossTU)
+  FIND_AND_ADD_CLANG_LIB(clangIndex)
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(clang DEFAULT_MSG CLANG_LIBRARIES CLANG_INCLUDE_DIRS)


### PR DESCRIPTION
This is a much less invasive change than #4992. It makes zig build successfully against homebrew's  clang package.

#4992 is blocked on an apt.llvm.org packaging issue, as well as the docker images giving this error:

```
Configuring zig version 0.5.0+2be2bcdcb
CMake Error at /deps/local/lib/cmake/llvm/LLVMExports.cmake:1293 (message):
  The imported target "llvm-tblgen" references the file

     "/deps/local/bin/llvm-tblgen"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/deps/local/lib/cmake/llvm/LLVMExports.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  /deps/local/lib/cmake/llvm/LLVMConfig.cmake:256 (include)
  /deps/local/lib/cmake/clang/ClangConfig.cmake:10 (find_package)
  CMakeLists.txt:66 (find_package)
```

So the cmake-based configuration is really a no-go. I also don't like how non-standard that is.

See #4799. The homebrew parts of this are solved by this PR, however, the issue remains open due to https://bugs.llvm.org/show_bug.cgi?id=44870.