### PR TITLE
fix compilation under mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,9 @@ if("${ZIG_TARGET_TRIPLE}" STREQUAL "native")
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   )
   set(ZIG_EXECUTABLE "${zig_BINARY_DIR}/zig")
+  if (WIN32)
+    set(ZIG_EXECUTABLE "${ZIG_EXECUTABLE}.exe")
+  endif()
 else()
   add_custom_target(zig_build_libstage2 ALL
       COMMAND "${ZIG_EXECUTABLE}" ${BUILD_LIBSTAGE2_ARGS}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8167,7 +8167,7 @@ test "vector @splat" {
       {#header_open|@tagName#}
       <pre>{#syntax#}@tagName(value: var) []const u8{#endsyntax#}</pre>
       <p>
-      Converts an enum value or union value to a slice of bytes representing the name.
+      Converts an enum value or union value to a slice of bytes representing the name. Not valid for unamed fields in non-exhaustive enums.
       </p>
       {#header_close#}
 

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8167,7 +8167,7 @@ test "vector @splat" {
       {#header_open|@tagName#}
       <pre>{#syntax#}@tagName(value: var) []const u8{#endsyntax#}</pre>
       <p>
-      Converts an enum value or union value to a slice of bytes representing the name. Not valid for unamed fields in non-exhaustive enums.
+      Converts an enum value or union value to a slice of bytes representing the name.</p><p>If the enum is non-exhaustive and the tag value does not map to a name, it invokes safety-checked {#link|Undefined Behavior#}.
       </p>
       {#header_close#}
 

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -897,6 +897,22 @@ export fn stage2_libc_render(stage1_libc: *Stage2LibCInstallation, output_file: 
     return .None;
 }
 
+fn enumToString(value: var, type_name: []const u8) ![]const u8 {
+    switch (@typeInfo(@TypeOf(value))) {
+        .Enum => |e| {
+            if (e.is_exhaustive) {
+                return std.fmt.allocPrint(std.heap.c_allocator, ".{}", .{@tagName(value)});
+            } else {
+                return std.fmt.allocPrint(std.heap.c_allocator,
+                    "@intToEnum({}, {})",
+                    .{type_name, @enumToInt(value)}
+                );
+            }
+        },
+        else => unreachable 
+    }
+}
+
 // ABI warning
 const Stage2Target = extern struct {
     arch: c_int,
@@ -1114,13 +1130,13 @@ const Stage2Target = extern struct {
 
             .windows => try os_builtin_str_buffer.outStream().print(
                 \\ .windows = .{{
-                \\        .min = .{},
-                \\        .max = .{},
+                \\        .min = {},
+                \\        .max = {},
                 \\    }}}},
                 \\
             , .{
-                @tagName(target.os.version_range.windows.min),
-                @tagName(target.os.version_range.windows.max),
+                try enumToString(target.os.version_range.windows.min, "Target.Os.WindowsVersion"),
+                try enumToString(target.os.version_range.windows.max, "Target.Os.WindowsVersion")
             }),
         }
         try os_builtin_str_buffer.appendSlice("};\n");


### PR DESCRIPTION
compilation under mingw was broken due to the lack of an .exe extension in the CMakefile and the use of `@tagName` on a non-exhaustive enum that was unnamed. i also added a note to the langref about how `@tagName` doesn't work on non-exhaustive fields.