### PR TITLE
added custom format method for `WindowsVersion`

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -101,6 +101,36 @@ pub const Target = struct {
                     return @enumToInt(ver) >= @enumToInt(self.min) and @enumToInt(ver) <= @enumToInt(self.max);
                 }
             };
+
+            pub fn format(
+                self: WindowsVersion,
+                comptime fmt: []const u8,
+                options: std.fmt.FormatOptions,
+                out_stream: var,
+            ) !void {
+                if (fmt.len > 0 and fmt[0] == 's') { 
+                    if (
+                        @enumToInt(self) >= @enumToInt(WindowsVersion.nt4) and @enumToInt(self) <= @enumToInt(WindowsVersion.win10_19h1)
+                    ) {
+                        try std.fmt.format(out_stream, ".{}", .{@tagName(self)});
+                    } else {
+                        try std.fmt.format(out_stream,
+                            "@intToEnum(Target.Os.WindowsVersion, {})",
+                            .{ @enumToInt(self) }
+                        );
+                    }
+                } else {
+                    if (
+                        @enumToInt(self) >= @enumToInt(WindowsVersion.nt4) and @enumToInt(self) <= @enumToInt(WindowsVersion.win10_19h1)
+                    ) {
+                        try std.fmt.format(out_stream, "WindowsVersion.{}", .{@tagName(self)});
+                    } else {
+                        try std.fmt.format(out_stream, "WindowsVersion(", .{@typeName(@This())});
+                        try std.fmt.format(out_stream, "{}", .{@enumToInt(self)});
+                        try out_stream.writeAll(")");
+                    }
+                }
+            }
         };
 
         pub const LinuxVersionRange = struct {

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -514,14 +514,14 @@ pub const CrossTarget = struct {
             switch (self.getOsVersionMin()) {
                 .none => {},
                 .semver => |v| try result.outStream().print(".{}", .{v}),
-                .windows => |v| try result.outStream().print(".{}", .{@tagName(v)}),
+                .windows => |v| try result.outStream().print("{s}", .{v}),
             }
         }
         if (self.os_version_max) |max| {
             switch (max) {
                 .none => {},
                 .semver => |v| try result.outStream().print("...{}", .{v}),
-                .windows => |v| try result.outStream().print("...{}", .{@tagName(v)}),
+                .windows => |v| try result.outStream().print("..{s}", .{v}),
             }
         }
 

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -897,22 +897,6 @@ export fn stage2_libc_render(stage1_libc: *Stage2LibCInstallation, output_file: 
     return .None;
 }
 
-fn enumToString(value: var, type_name: []const u8) ![]const u8 {
-    switch (@typeInfo(@TypeOf(value))) {
-        .Enum => |e| {
-            if (e.is_exhaustive) {
-                return std.fmt.allocPrint(std.heap.c_allocator, ".{}", .{@tagName(value)});
-            } else {
-                return std.fmt.allocPrint(std.heap.c_allocator,
-                    "@intToEnum({}, {})",
-                    .{type_name, @enumToInt(value)}
-                );
-            }
-        },
-        else => unreachable 
-    }
-}
-
 // ABI warning
 const Stage2Target = extern struct {
     arch: c_int,
@@ -1130,13 +1114,13 @@ const Stage2Target = extern struct {
 
             .windows => try os_builtin_str_buffer.outStream().print(
                 \\ .windows = .{{
-                \\        .min = {},
-                \\        .max = {},
+                \\        .min = {s},
+                \\        .max = {s},
                 \\    }}}},
                 \\
             , .{
-                try enumToString(target.os.version_range.windows.min, "Target.Os.WindowsVersion"),
-                try enumToString(target.os.version_range.windows.max, "Target.Os.WindowsVersion")
+                target.os.version_range.windows.min,
+                target.os.version_range.windows.max
             }),
         }
         try os_builtin_str_buffer.appendSlice("};\n");


### PR DESCRIPTION
follow-up to #5003. introduces a custom format method to `WindowsVersion` which allows for cleaner code all-around. also fixes another error related to converting `WindowsVersion` to and from strings.