### PR TITLE
os.fstatat

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2584,9 +2584,9 @@ pub fn fstat(fd: fd_t) FStatError!Stat {
     }
 }
 
-const FStatAtError = FStatError || error{NameTooLong};
+pub const FStatAtError = FStatError || error{NameTooLong, FileNotFound};
 
-pub fn fstatat(dirfd: fd_t, pathname: []const u8, flags: u32) FStatAtError![]Stat {
+pub fn fstatat(dirfd: fd_t, pathname: []const u8, flags: u32) FStatAtError!Stat {
     const pathname_c = try toPosixPath(pathname);
     return fstatatZ(dirfd, &pathname_c, flags);
 }


### PR DESCRIPTION
Fix definition of `fstatat`.

Trying to do this PR "properly" has resulted in a deep deep rabbit hole that looks like it will extend for a while.... posting this small piece so it can be a little less broken in the 0.6.0 release.