### PR TITLE
std: fix StreamSource to disallow writing to a const buffer

### DIFF
--- a/lib/std/io/stream_source.zig
+++ b/lib/std/io/stream_source.zig
@@ -39,7 +39,7 @@ pub const StreamSource = union(enum) {
     pub fn write(self: *StreamSource, bytes: []const u8) WriteError!usize {
         switch (self.*) {
             .buffer => |*x| return x.write(bytes),
-            .const_buffer => |*x| return x.write(bytes),
+            .const_buffer => return error.AccessDenied,
             .file => |x| return x.write(bytes),
         }
     }


### PR DESCRIPTION
Fixes #5021

`AccessDenied` seemed the most relevant error in the `WriteError` set. I did the simplest thing for now to hopefully get a quick merge.