### PR TITLE
Shift error message now says "fixed-width integer type" instead of just "integer type"

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16974,7 +16974,7 @@ static IrInstGen *ir_analyze_bit_shift(IrAnalyze *ira, IrInstSrcBinOp *bin_op_in
 
         if (!instr_is_comptime(op2)) {
             ir_add_error(ira, &bin_op_instruction->base.base,
-                buf_sprintf("LHS of shift must be an integer type, or RHS must be compile-time known"));
+                buf_sprintf("LHS of shift must be a fixed-width integer type, or RHS must be compile-time known"));
             return ira->codegen->invalid_inst_gen;
         }
 

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -5925,7 +5925,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return 0x11 << x;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:17: error: LHS of shift must be an integer type, or RHS must be compile-time known",
+        "tmp.zig:2:17: error: LHS of shift must be a fixed-width integer type, or RHS must be compile-time known",
     });
 
     cases.add("shifting RHS is log2 of LHS int bit width",


### PR DESCRIPTION
This changes the error message of of ir_analyze_bit_shift to now be more accurate. Previously, it was phrased as "LHS of shift must be an integer type", but `comptime_int`s were still not allowed. It is more correct for the message to say "fixed-width integer type". 