### PR TITLE
Translate C: Redo Add comment containing c source location for failed decls.

### DIFF
--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2346,8 +2346,10 @@ fn renderTokenOffset(
     }
 
     while (true) {
-        assert(loc.line != 0);
-        const newline_count = if (loc.line == 1) @as(u8, 1) else @as(u8, 2);
+        // translate-c doesn't generate correct newlines
+        // in generated code (loc.line == 0) so treat that case
+        // as though there was meant to be a newline between the tokens
+        const newline_count = if (loc.line <= 1) @as(u8, 1) else @as(u8, 2);
         try stream.writeByteNTimes('\n', newline_count);
         try stream.writeByteNTimes(' ', indent);
         try stream.writeAll(mem.trimRight(u8, tree.tokenSlicePtr(next_token), " "));

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -3058,6 +3058,7 @@ fn transCreateCompoundAssign(
         // common case
         // c: lhs += rhs
         // zig: lhs += rhs
+
         if ((is_mod or is_div) and is_signed) {
             const op_token = try appendToken(rp.c, .Equal, "=");
             const op_node = try rp.c.a().create(ast.Node.InfixOp);
@@ -4772,6 +4773,7 @@ pub fn failDecl(c: *Context, loc: ZigClangSourceLocation, name: []const u8, comp
     const msg_tok = try appendTokenFmt(c, .StringLiteral, "\"" ++ format ++ "\"", args);
     const rparen_tok = try appendToken(c, .RParen, ")");
     const semi_tok = try appendToken(c, .Semicolon, ";");
+    _ = try appendTokenFmt(c, .LineComment, "// {}", .{c.locStr(loc)});
 
     const msg_node = try c.a().create(ast.Node.StringLiteral);
     msg_node.* = ast.Node.StringLiteral{
@@ -5440,7 +5442,7 @@ fn parseCPrimaryExpr(c: *Context, it: *CTokenList.Iterator, source: []const u8, 
                 };
                 return &node.base;
             } else {
-                const token = try appendTokenFmt(c, .IntegerLiteral, "0x{x}", .{source[tok.start + 1 .. tok.end - 1]});
+                const token = try appendTokenFmt(c, .IntegerLiteral, "0x{x}", .{source[tok.start+1..tok.end-1]});
                 const node = try c.a().create(ast.Node.IntegerLiteral);
                 node.* = .{
                     .token = token,

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -5013,8 +5013,8 @@ fn transMacroDefine(c: *Context, it: *CTokenList.Iterator, source: []const u8, n
             c,
             source_loc,
             name,
-            "unable to translate C expr: unexpected token {}",
-            .{last.id},
+            "unable to translate C expr: unexpected token .{}",
+            .{@tagName(last.id)},
         );
 
     node.semicolon_token = try appendToken(c, .Semicolon, ";");
@@ -5123,8 +5123,8 @@ fn transMacroFnDefine(c: *Context, it: *CTokenList.Iterator, source: []const u8,
             c,
             source_loc,
             name,
-            "unable to translate C expr: unexpected token {}",
-            .{last.id},
+            "unable to translate C expr: unexpected token .{}",
+            .{@tagName(last.id)},
         );
     _ = try appendToken(c, .Semicolon, ";");
     const type_of_arg = if (expr.id != .Block) expr else blk: {
@@ -5658,8 +5658,8 @@ fn parseCPrimaryExpr(c: *Context, it: *CTokenList.Iterator, source: []const u8, 
                 c,
                 source_loc,
                 source[first_tok.start..first_tok.end],
-                "unable to translate C expr: unexpected token {}",
-                .{tok.id},
+                "unable to translate C expr: unexpected token .{}",
+                .{@tagName(tok.id)},
             );
             return error.ParseError;
         },


### PR DESCRIPTION
Redoes #4684 and fixes regression #5008 by removing assumption that line comments are on their own line.