### PR TITLE
Compile-time comparison of optionals (== / !=)

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16496,8 +16496,7 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
         (op1->value->type->data.maybe.child_type->id != ZigTypeIdPointer &&
         (op2->value->type->data.maybe.child_type->id != ZigTypeIdPointer)))
     {
-        assert(instr_is_comptime(op1) && instr_is_comptime(op2)); // fails???
-
+        assert(instr_is_comptime(op1) && instr_is_comptime(op2));
         if (instr_is_comptime(op1) && instr_is_comptime(op2)) {
             ZigValue *op1_val = ir_resolve_const(ira, op1, UndefBad);
             if (!op1_val)
@@ -16521,6 +16520,8 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
                         false,
                         op1_val->type);
 
+                op1_unwrapped->value->special = op1->value->special;
+
                 IrInstGen *op2_unwrapped = ir_build_optional_unwrap_ptr_gen(
                         ira,
                         &op2->base,
@@ -16528,12 +16529,13 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
                         true,
                         false,
                         op2_val->type);
+                op2_unwrapped->value->special = op2->value->special;
 
                 return ir_analyze_bin_op_cmp_seperate_ops(
                         ira,
                         bin_op_instruction,
                         op1_unwrapped,
-                        op1_unwrapped);
+                        op2_unwrapped);
             } else {
                 return ir_const_bool(ira, &bin_op_instruction->base.base, op_id != IrBinOpCmpEq);
             }

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16512,30 +16512,13 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
             if (!op1_val_child && !op2_val_child) {
                 return ir_const_bool(ira, &bin_op_instruction->base.base, op_id == IrBinOpCmpEq);
             } else if (op1_val_child && op2_val_child) {
-                IrInstGen *op1_unwrapped = ir_build_optional_unwrap_ptr_gen(
-                        ira,
-                        &op1->base,
-                        op1,
-                        true,
-                        false,
-                        op1_val->type);
-
-                op1_unwrapped->value->special = op1->value->special;
-
-                IrInstGen *op2_unwrapped = ir_build_optional_unwrap_ptr_gen(
-                        ira,
-                        &op2->base,
-                        op2,
-                        true,
-                        false,
-                        op2_val->type);
-                op2_unwrapped->value->special = op2->value->special;
-
+                op1->value = op1_val_child;
+                op2->value = op2_val_child;
                 return ir_analyze_bin_op_cmp_seperate_ops(
                         ira,
                         bin_op_instruction,
-                        op1_unwrapped,
-                        op2_unwrapped);
+                        op1,
+                        op2);
             } else {
                 return ir_const_bool(ira, &bin_op_instruction->base.base, op_id != IrBinOpCmpEq);
             }

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16504,7 +16504,6 @@ static IrInstGen *ir_analyze_bin_op_cmp(IrAnalyze *ira, IrInstSrcBinOp *bin_op_i
                (op1->value->type->data.maybe.child_type->id != ZigTypeIdPointer &&
                 (op2->value->type->data.maybe.child_type->id != ZigTypeIdPointer)))
     {
-        assert(instr_is_comptime(op1) && instr_is_comptime(op2));
         if (instr_is_comptime(op1) && instr_is_comptime(op2)) {
             ZigValue *op1_val = ir_resolve_const(ira, op1, UndefBad);
             if (!op1_val)
@@ -16527,7 +16526,8 @@ static IrInstGen *ir_analyze_bin_op_cmp(IrAnalyze *ira, IrInstSrcBinOp *bin_op_i
                 return ir_const_bool(ira, &bin_op_instruction->base.base, op_id != IrBinOpCmpEq);
             }
         }
-        zig_unreachable();
+        ir_add_error_node(ira, source_node, buf_sprintf("comparison of non-comptime, non-pointer optionals. TODO: allow runtime comparison of non-pointer optionals"));
+        return ira->codegen->invalid_inst_gen;
     } else if (op1->value->type->id == ZigTypeIdNull || op2->value->type->id == ZigTypeIdNull) {
         ZigType *non_null_type = (op1->value->type->id == ZigTypeIdNull) ? op2->value->type : op1->value->type;
         ir_add_error_node(ira, source_node, buf_sprintf("comparison of '%s' with null",

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16498,6 +16498,12 @@ static IrInstGen *ir_analyze_bin_op_cmp(IrAnalyze *ira, IrInstSrcBinOp *bin_op_i
         } else {
             return is_non_null;
         }
+    } else if (is_equality_cmp &&
+        (op1->value->type->id == ZigTypeIdOptional && op2->value->type->id == ZigTypeIdOptional) &&
+        (op1->value->type->data.maybe.child_type->id != ZigTypeIdPointer &&
+        (op2->value->type->data.maybe.child_type->id != ZigTypeIdPointer)))
+    {
+        zig_unreachable();
     } else if (op1->value->type->id == ZigTypeIdNull || op2->value->type->id == ZigTypeIdNull) {
         ZigType *non_null_type = (op1->value->type->id == ZigTypeIdNull) ? op2->value->type : op1->value->type;
         ir_add_error_node(ira, source_node, buf_sprintf("comparison of '%s' with null",

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16431,8 +16431,8 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
     if (is_equality_cmp && op1->value->type->id == ZigTypeIdNull && op2->value->type->id == ZigTypeIdNull) {
         return ir_const_bool(ira, &bin_op_instruction->base.base, (op_id == IrBinOpCmpEq));
     } else if (is_equality_cmp &&
-               ((op1->value->type->id == ZigTypeIdNull && op2->value->type->id == ZigTypeIdOptional) ||
-                (op2->value->type->id == ZigTypeIdNull && op1->value->type->id == ZigTypeIdOptional)))
+        ((op1->value->type->id == ZigTypeIdNull && op2->value->type->id == ZigTypeIdOptional) ||
+        (op2->value->type->id == ZigTypeIdNull && op1->value->type->id == ZigTypeIdOptional)))
     {
         IrInstGen *maybe_op;
         if (op1->value->type->id == ZigTypeIdNull) {
@@ -16459,10 +16459,10 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
             return is_non_null;
         }
     } else if (is_equality_cmp &&
-               ((op1->value->type->id == ZigTypeIdNull && op2->value->type->id == ZigTypeIdPointer &&
-                 op2->value->type->data.pointer.ptr_len == PtrLenC) ||
-                (op2->value->type->id == ZigTypeIdNull && op1->value->type->id == ZigTypeIdPointer &&
-                 op1->value->type->data.pointer.ptr_len == PtrLenC)))
+        ((op1->value->type->id == ZigTypeIdNull && op2->value->type->id == ZigTypeIdPointer &&
+             op2->value->type->data.pointer.ptr_len == PtrLenC) ||
+        (op2->value->type->id == ZigTypeIdNull && op1->value->type->id == ZigTypeIdPointer &&
+             op1->value->type->data.pointer.ptr_len == PtrLenC)))
     {
         IrInstGen *c_ptr_op;
         if (op1->value->type->id == ZigTypeIdNull) {
@@ -16492,9 +16492,9 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
             return is_non_null;
         }
     } else if (is_equality_cmp &&
-               (op1->value->type->id == ZigTypeIdOptional && op2->value->type->id == ZigTypeIdOptional) &&
-               (op1->value->type->data.maybe.child_type->id != ZigTypeIdPointer &&
-                (op2->value->type->data.maybe.child_type->id != ZigTypeIdPointer)))
+        (op1->value->type->id == ZigTypeIdOptional && op2->value->type->id == ZigTypeIdOptional) &&
+        (op1->value->type->data.maybe.child_type->id != ZigTypeIdPointer) &&
+        (op2->value->type->data.maybe.child_type->id != ZigTypeIdPointer))
     {
         if (instr_is_comptime(op1) && instr_is_comptime(op2)) {
             ZigValue *op1_val = ir_resolve_const(ira, op1, UndefBad);
@@ -16527,8 +16527,8 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
                                                         buf_ptr(&non_null_type->name)));
         return ira->codegen->invalid_inst_gen;
     } else if (is_equality_cmp && (
-            (op1->value->type->id == ZigTypeIdEnumLiteral && op2->value->type->id == ZigTypeIdUnion) ||
-            (op2->value->type->id == ZigTypeIdEnumLiteral && op1->value->type->id == ZigTypeIdUnion)))
+        (op1->value->type->id == ZigTypeIdEnumLiteral && op2->value->type->id == ZigTypeIdUnion) ||
+        (op2->value->type->id == ZigTypeIdEnumLiteral && op1->value->type->id == ZigTypeIdUnion)))
     {
         // Support equality comparison between a union's tag value and a enum literal
         IrInstGen *union_val = op1->value->type->id == ZigTypeIdUnion ? op1 : op2;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16672,7 +16672,7 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
 
     if (!operator_allowed) {
         ir_add_error_node(ira, source_node,
-                          buf_sprintf("operator not allowed for type '%s'", buf_ptr(&resolved_type->name)));
+            buf_sprintf("operator not allowed for type '%s'", buf_ptr(&resolved_type->name)));
         return ira->codegen->invalid_inst_gen;
     }
 
@@ -16706,26 +16706,26 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
         if (resolved_type->id != ZigTypeIdVector)
             return ir_evaluate_bin_op_cmp(ira, resolved_type, op1_val, op2_val, bin_op_instruction, op_id, one_possible_value);
         IrInstGen *result = ir_const(ira, &bin_op_instruction->base.base,
-                                     get_vector_type(ira->codegen, resolved_type->data.vector.len, ira->codegen->builtin_types.entry_bool));
+            get_vector_type(ira->codegen, resolved_type->data.vector.len, ira->codegen->builtin_types.entry_bool));
         result->value->data.x_array.data.s_none.elements =
                 ira->codegen->pass1_arena->allocate<ZigValue>(resolved_type->data.vector.len);
 
         expand_undef_array(ira->codegen, result->value);
         for (size_t i = 0;i < resolved_type->data.vector.len;i++) {
             IrInstGen *cur_res = ir_evaluate_bin_op_cmp(ira, resolved_type->data.vector.elem_type,
-                                                        &op1_val->data.x_array.data.s_none.elements[i],
-                                                        &op2_val->data.x_array.data.s_none.elements[i],
-                                                        bin_op_instruction, op_id, one_possible_value);
+                &op1_val->data.x_array.data.s_none.elements[i],
+                &op2_val->data.x_array.data.s_none.elements[i],
+                bin_op_instruction, op_id, one_possible_value);
             copy_const_val(ira->codegen, &result->value->data.x_array.data.s_none.elements[i], cur_res->value);
         }
         return result;
     }
 
     ZigType *res_type = (resolved_type->id == ZigTypeIdVector) ?
-                        get_vector_type(ira->codegen, resolved_type->data.vector.len, ira->codegen->builtin_types.entry_bool) :
-                        ira->codegen->builtin_types.entry_bool;
+        get_vector_type(ira->codegen, resolved_type->data.vector.len, ira->codegen->builtin_types.entry_bool) :
+        ira->codegen->builtin_types.entry_bool;
     return ir_build_bin_op_gen(ira, &bin_op_instruction->base.base, res_type,
-                               op_id, casted_op1, casted_op2, bin_op_instruction->safety_check_on);
+        op_id, casted_op1, casted_op2, bin_op_instruction->safety_check_on);
 }
 
 static IrInstGen *ir_analyze_bin_op_cmp(IrAnalyze *ira, IrInstSrcBinOp *bin_op_instruction) {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16460,9 +16460,9 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
         }
     } else if (is_equality_cmp &&
         ((op1->value->type->id == ZigTypeIdNull && op2->value->type->id == ZigTypeIdPointer &&
-             op2->value->type->data.pointer.ptr_len == PtrLenC) ||
+            op2->value->type->data.pointer.ptr_len == PtrLenC) ||
         (op2->value->type->id == ZigTypeIdNull && op1->value->type->id == ZigTypeIdPointer &&
-             op1->value->type->data.pointer.ptr_len == PtrLenC)))
+            op1->value->type->data.pointer.ptr_len == PtrLenC)))
     {
         IrInstGen *c_ptr_op;
         if (op1->value->type->id == ZigTypeIdNull) {
@@ -16479,8 +16479,8 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
             if (c_ptr_val->special == ConstValSpecialUndef)
                 return ir_const_undef(ira, &bin_op_instruction->base.base, ira->codegen->builtin_types.entry_bool);
             bool is_null = c_ptr_val->data.x_ptr.special == ConstPtrSpecialNull ||
-                           (c_ptr_val->data.x_ptr.special == ConstPtrSpecialHardCodedAddr &&
-                            c_ptr_val->data.x_ptr.data.hard_coded_addr.addr == 0);
+                (c_ptr_val->data.x_ptr.special == ConstPtrSpecialHardCodedAddr &&
+                    c_ptr_val->data.x_ptr.data.hard_coded_addr.addr == 0);
             bool bool_result = (op_id == IrBinOpCmpEq) ? is_null : !is_null;
             return ir_const_bool(ira, &bin_op_instruction->base.base, bool_result);
         }
@@ -16524,7 +16524,7 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
     } else if (op1->value->type->id == ZigTypeIdNull || op2->value->type->id == ZigTypeIdNull) {
         ZigType *non_null_type = (op1->value->type->id == ZigTypeIdNull) ? op2->value->type : op1->value->type;
         ir_add_error_node(ira, source_node, buf_sprintf("comparison of '%s' with null",
-                                                        buf_ptr(&non_null_type->name)));
+            buf_ptr(&non_null_type->name)));
         return ira->codegen->invalid_inst_gen;
     } else if (is_equality_cmp && (
         (op1->value->type->id == ZigTypeIdEnumLiteral && op2->value->type->id == ZigTypeIdUnion) ||
@@ -16536,10 +16536,10 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
 
         if (!is_tagged_union(union_val->value->type)) {
             ErrorMsg *msg = ir_add_error_node(ira, source_node,
-                                              buf_sprintf("comparison of union and enum literal is only valid for tagged union types"));
+                buf_sprintf("comparison of union and enum literal is only valid for tagged union types"));
             add_error_note(ira->codegen, msg, union_val->value->type->data.unionation.decl_node,
-                           buf_sprintf("type %s is not a tagged union",
-                                       buf_ptr(&union_val->value->type->name)));
+                buf_sprintf("type %s is not a tagged union",
+                    buf_ptr(&union_val->value->type->name)));
             return ira->codegen->invalid_inst_gen;
         }
 
@@ -16570,7 +16570,7 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
         }
 
         return ir_build_bin_op_gen(ira, &bin_op_instruction->base.base, ira->codegen->builtin_types.entry_bool,
-                                   op_id, casted_union, casted_val, bin_op_instruction->safety_check_on);
+            op_id, casted_union, casted_val, bin_op_instruction->safety_check_on);
     }
 
     if (op1->value->type->id == ZigTypeIdErrorSet && op2->value->type->id == ZigTypeIdErrorSet) {
@@ -16607,8 +16607,8 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
         if (!type_is_global_error_set(intersect_type)) {
             if (intersect_type->data.error_set.err_count == 0) {
                 ir_add_error_node(ira, source_node,
-                                  buf_sprintf("error sets '%s' and '%s' have no common errors",
-                                              buf_ptr(&op1->value->type->name), buf_ptr(&op2->value->type->name)));
+                    buf_sprintf("error sets '%s' and '%s' have no common errors",
+                        buf_ptr(&op1->value->type->name), buf_ptr(&op2->value->type->name)));
                 return ira->codegen->invalid_inst_gen;
             }
             if (op1->value->type->data.error_set.err_count == 1 && op2->value->type->data.error_set.err_count == 1) {
@@ -16647,7 +16647,7 @@ static IrInstGen *ir_analyze_bin_op_cmp_seperate_ops(IrAnalyze *ira, IrInstSrcBi
         }
 
         return ir_build_bin_op_gen(ira, &bin_op_instruction->base.base, ira->codegen->builtin_types.entry_bool,
-                                   op_id, op1, op2, bin_op_instruction->safety_check_on);
+            op_id, op1, op2, bin_op_instruction->safety_check_on);
     }
 
     if (type_is_numeric(op1->value->type) && type_is_numeric(op2->value->type)) {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -15,7 +15,6 @@
 #include "softfloat.hpp"
 #include "util.hpp"
 #include "mem_list.hpp"
-#include "all_types.hpp"
 
 #include <errno.h>
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16422,7 +16422,7 @@ static bool ir_is_cmp_allowed(IrBinOp op_id, ZigType *op_type) {
             return is_equality_cmp && ir_is_cmp_allowed(op_id, op_type->data.maybe.child_type);
     }
 }
-#include <cstdio>
+
 static IrInstGen *ir_analyze_bin_op_cmp(IrAnalyze *ira, IrInstSrcBinOp *bin_op_instruction) {
     IrInstGen *op1 = bin_op_instruction->op1->child;
     if (type_is_invalid(op1->value->type))

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -16422,7 +16422,7 @@ static bool ir_is_cmp_allowed(IrBinOp op_id, ZigType *op_type) {
             return is_equality_cmp && ir_is_cmp_allowed(op_id, op_type->data.maybe.child_type);
     }
 }
-
+#include <cstdio>
 static IrInstGen *ir_analyze_bin_op_cmp(IrAnalyze *ira, IrInstSrcBinOp *bin_op_instruction) {
     IrInstGen *op1 = bin_op_instruction->op1->child;
     if (type_is_invalid(op1->value->type))
@@ -16514,14 +16514,14 @@ static IrInstGen *ir_analyze_bin_op_cmp(IrAnalyze *ira, IrInstSrcBinOp *bin_op_i
             if (!op2_val)
                 return ira->codegen->invalid_inst_gen;
 
-            ZigValue *op1_val_child = op1_val->data.x_optional;
-            ZigValue *op2_val_child = op2_val->data.x_optional;
+            bool op1_is_null = optional_value_is_null(op1_val);
+            bool op2_is_null = optional_value_is_null(op2_val);
 
-            if (!op1_val_child && !op2_val_child) {
+            if (op1_is_null && op2_is_null) {
                 return ir_const_bool(ira, &bin_op_instruction->base.base, op_id == IrBinOpCmpEq);
-            } else if (op1_val_child && op2_val_child) {
-                op1->value = op1_val_child;
-                op2->value = op2_val_child;
+            } else if (!op1_is_null && !op2_is_null) {
+                op1->value = op1->value->data.x_optional;
+                op2->value = op2->value->data.x_optional;
                 return ir_analyze_bin_op_cmp(ira, bin_op_instruction);
             } else {
                 return ir_const_bool(ira, &bin_op_instruction->base.base, op_id != IrBinOpCmpEq);

--- a/test/stage1/behavior/optional.zig
+++ b/test/stage1/behavior/optional.zig
@@ -30,26 +30,28 @@ fn testNullPtrsEql() void {
 }
 
 test "equality compare nullable integers" {
-    testNullableIntEql();
+
     comptime testNullableIntEql();
 }
 
 fn testNullableIntEql() void {
-    var a: ?i32 = 10;
-    var b: ?i32 = 20;
-    var n: ?i32 = null;
+    comptime {
+        var a: ?i32 = 10;
+        var b: ?i32 = 20;
+        var n: ?i32 = null;
 
-    expect(a == a);
-    expect(n == n);
-    expect(a != n);
-    expect(a != b);
+        expect(a == a);
+        expect(n == n);
+        expect(a != n);
+        expect(a != b);
 
-    var ao: ??i32 = a;
-    var no: ??i32 = n;
+        var ao: ??i32 = a;
+        var no: ??i32 = n;
 
-    expect(ao == ao);
-    expect(no == no);
-    expect(ao != no);
+        expect(ao == ao);
+        expect(no == no);
+        expect(ao != no);
+    }
 }
 
 test "address of unwrap optional" {

--- a/test/stage1/behavior/optional.zig
+++ b/test/stage1/behavior/optional.zig
@@ -30,12 +30,12 @@ fn testNullPtrsEql() void {
 }
 
 test "equality compare nullable integers" {
-
+    testNullableIntEql(); // uncomment when runtime checking is complete
     comptime testNullableIntEql();
 }
 
 fn testNullableIntEql() void {
-    comptime {
+    comptime { // these do not work at runtime yet. remove comptime when implementation of runtime comparison is done
         var a: ?i32 = 10;
         var b: ?i32 = 20;
         var n: ?i32 = null;

--- a/test/stage1/behavior/optional.zig
+++ b/test/stage1/behavior/optional.zig
@@ -30,7 +30,7 @@ fn testNullPtrsEql() void {
 }
 
 test "equality compare nullable integers" {
-    testNullableIntEql(); // uncomment when runtime checking is complete
+     // testNullableIntEql(); uncomment when runtime checking is complete
     comptime testNullableIntEql();
 }
 

--- a/test/stage1/behavior/optional.zig
+++ b/test/stage1/behavior/optional.zig
@@ -29,6 +29,29 @@ fn testNullPtrsEql() void {
     expect(&number == x);
 }
 
+test "equality compare nullable integers" {
+    testNullableIntEql();
+    comptime testNullableIntEql();
+}
+
+fn testNullableIntEql() void {
+    var a: ?i32 = 10;
+    var b: ?i32 = 20;
+    var n: ?i32 = null;
+
+    expect(a == a);
+    expect(n == n);
+    expect(a != n);
+    expect(a != b);
+
+    var ao: ??i32 = a;
+    var no: ??i32 = n;
+
+    expect(ao == ao);
+    expect(no == no);
+    expect(ao != no);
+}
+
 test "address of unwrap optional" {
     const S = struct {
         const Foo = struct {


### PR DESCRIPTION
This will allow code like this to function at compile time, partially implementing #1332:

```rust
const x: ?i32 = get_some_optional();
const y: ?i32 = get_another_optional();
if (x == y) {
    do_a_thing();
}

if (x != y) {
    do_another_thing();
}
```
Which currently only works for optional pointers.
I will work on making this runtime soon. 

One thing I am not completely sure about: when calling `ir_analyze_optional_value_payload_value()`, I am not sure if it should be given `op1/op2->base`, or `bin_op_instruction->base.base` for the `source_instr` parameter. 