### PR TITLE
Zig cc: fix duplicate binaries when -o is not specified.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -916,6 +916,7 @@ static int main0(int argc, char **argv) {
             }
             if (emit_bin_override_path == nullptr) {
                 emit_bin_override_path = "a.out";
+                enable_cache = CacheOptOn;
             }
         } else {
             cmd = CmdBuild;


### PR DESCRIPTION
This closes #5036.

When the user specifies -o to zig cc, the cache is forced on. However, when -o was not specified, Zig overrode the binary name but did not enable the cache. It seems reasonable to enable it in this case as well, since 'a.out' is, afaik, just the default output name. Thus, it seems sensible to follow the behavior of setting a user-provided output name when setting the default.