### PR TITLE
In langref: added space to distinguish headers, indented code blocks

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -225,15 +225,17 @@
       </p>
       {#header_close#}
 
+
+
       {#header_open|Hello World#}
 
       {#code_begin|exe|hello#}
-const std = @import("std");
-
-pub fn main() !void {
-    const stdout = std.io.getStdOut().outStream();
-    try stdout.print("Hello, {}!\n", .{"world"});
-}
+		const std = @import("std");
+		
+		pub fn main() !void {
+		    const stdout = std.io.getStdOut().outStream();
+		    try stdout.print("Hello, {}!\n", .{"world"});
+		}
       {#code_end#}
       <p>
       Usually you don't want to write to stdout. You want to write to stderr. And you
@@ -241,36 +243,40 @@ pub fn main() !void {
       to emit. For that you can use a simpler API:
       </p>
       {#code_begin|exe|hello#}
-const warn = @import("std").debug.warn;
-
-pub fn main() void {
-    warn("Hello, world!\n", .{});
-}
+		const warn = @import("std").debug.warn;
+		
+		pub fn main() void {
+		    warn("Hello, world!\n", .{});
+		}
       {#code_end#}
       <p>
       Note that you can leave off the {#syntax#}!{#endsyntax#} from the return type because {#syntax#}warn{#endsyntax#} cannot fail.
       </p>
       {#see_also|Values|@import|Errors|Root Source File#}
       {#header_close#}
+
+
       {#header_open|Comments#}
       {#code_begin|test|comments#}
-const assert = @import("std").debug.assert;
-
-test "comments" {
-    // Comments in Zig start with "//" and end at the next LF byte (end of line).
-    // The below line is a comment, and won't be executed.
-
-    //assert(false);
-
-    const x = true;  // another comment
-    assert(x);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "comments" {
+		    // Comments in Zig start with "//" and end at the next LF byte (end of line).
+		    // The below line is a comment, and won't be executed.
+		
+		    //assert(false);
+		
+		    const x = true;  // another comment
+		    assert(x);
+		}
       {#code_end#}
       <p>
       There are no multiline comments in Zig (e.g. like <code class="c">/* */</code>
       comments in C).  This helps allow Zig to have the property that each line
       of code can be tokenized out of context.
       </p>
+
+
       {#header_open|Doc comments#}
       <p>
       A doc comment is one that begins with exactly three slashes (i.e.
@@ -279,23 +285,23 @@ test "comments" {
       doc comment.  The doc comment documents whatever immediately follows it.
       </p>
       {#code_begin|syntax|doc_comments#}
-/// A structure for storing a timestamp, with nanosecond precision (this is a
-/// multiline doc comment).
-const Timestamp = struct {
-    /// The number of seconds since the epoch (this is also a doc comment).
-    seconds: i64,  // signed so we can represent pre-1970 (not a doc comment)
-    /// The number of nanoseconds past the second (doc comment again).
-    nanos: u32,
-
-    /// Returns a `Timestamp` struct representing the Unix epoch; that is, the
-    /// moment of 1970 Jan 1 00:00:00 UTC (this is a doc comment too).
-    pub fn unixEpoch() Timestamp {
-        return Timestamp{
-            .seconds = 0,
-            .nanos = 0,
-        };
-    }
-};
+		/// A structure for storing a timestamp, with nanosecond precision (this is a
+		/// multiline doc comment).
+		const Timestamp = struct {
+		    /// The number of seconds since the epoch (this is also a doc comment).
+		    seconds: i64,  // signed so we can represent pre-1970 (not a doc comment)
+		    /// The number of nanoseconds past the second (doc comment again).
+		    nanos: u32,
+		
+		    /// Returns a `Timestamp` struct representing the Unix epoch; that is, the
+		    /// moment of 1970 Jan 1 00:00:00 UTC (this is a doc comment too).
+		    pub fn unixEpoch() Timestamp {
+		        return Timestamp{
+		            .seconds = 0,
+		            .nanos = 0,
+		        };
+		    }
+		};
       {#code_end#}
       <p>
       Doc comments are only allowed in certain places; eventually, it will
@@ -304,63 +310,67 @@ const Timestamp = struct {
       </p>
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Values#}
       {#code_begin|exe|values#}
-// Top-level declarations are order-independent:
-const warn = std.debug.warn;
-const std = @import("std");
-const os = std.os;
-const assert = std.debug.assert;
-
-pub fn main() void {
-    // integers
-    const one_plus_one: i32 = 1 + 1;
-    warn("1 + 1 = {}\n", .{one_plus_one});
-
-    // floats
-    const seven_div_three: f32 = 7.0 / 3.0;
-    warn("7.0 / 3.0 = {}\n", .{seven_div_three});
-
-    // boolean
-    warn("{}\n{}\n{}\n", .{
-        true and false,
-        true or false,
-        !true,
-    });
-
-    // optional
-    var optional_value: ?[]const u8 = null;
-    assert(optional_value == null);
-
-    warn("\noptional 1\ntype: {}\nvalue: {}\n", .{
-        @typeName(@TypeOf(optional_value)),
-        optional_value,
-    });
-
-    optional_value = "hi";
-    assert(optional_value != null);
-
-    warn("\noptional 2\ntype: {}\nvalue: {}\n", .{
-        @typeName(@TypeOf(optional_value)),
-        optional_value,
-    });
-
-    // error union
-    var number_or_error: anyerror!i32 = error.ArgNotFound;
-
-    warn("\nerror union 1\ntype: {}\nvalue: {}\n", .{
-        @typeName(@TypeOf(number_or_error)),
-        number_or_error,
-    });
-
-    number_or_error = 1234;
-
-    warn("\nerror union 2\ntype: {}\nvalue: {}\n", .{
-        @typeName(@TypeOf(number_or_error)),
-        number_or_error,
-    });
-}
+		// Top-level declarations are order-independent:
+		const warn = std.debug.warn;
+		const std = @import("std");
+		const os = std.os;
+		const assert = std.debug.assert;
+		
+		pub fn main() void {
+		    // integers
+		    const one_plus_one: i32 = 1 + 1;
+		    warn("1 + 1 = {}\n", .{one_plus_one});
+		
+		    // floats
+		    const seven_div_three: f32 = 7.0 / 3.0;
+		    warn("7.0 / 3.0 = {}\n", .{seven_div_three});
+		
+		    // boolean
+		    warn("{}\n{}\n{}\n", .{
+		        true and false,
+		        true or false,
+		        !true,
+		    });
+		
+		    // optional
+		    var optional_value: ?[]const u8 = null;
+		    assert(optional_value == null);
+		
+		    warn("\noptional 1\ntype: {}\nvalue: {}\n", .{
+		        @typeName(@TypeOf(optional_value)),
+		        optional_value,
+		    });
+		
+		    optional_value = "hi";
+		    assert(optional_value != null);
+		
+		    warn("\noptional 2\ntype: {}\nvalue: {}\n", .{
+		        @typeName(@TypeOf(optional_value)),
+		        optional_value,
+		    });
+		
+		    // error union
+		    var number_or_error: anyerror!i32 = error.ArgNotFound;
+		
+		    warn("\nerror union 1\ntype: {}\nvalue: {}\n", .{
+		        @typeName(@TypeOf(number_or_error)),
+		        number_or_error,
+		    });
+		
+		    number_or_error = 1234;
+		
+		    warn("\nerror union 2\ntype: {}\nvalue: {}\n", .{
+		        @typeName(@TypeOf(number_or_error)),
+		        number_or_error,
+		    });
+		}
       {#code_end#}
+
+
       {#header_open|Primitive Types#}
       <div class="table-wrapper">
       <table>
@@ -552,6 +562,8 @@ pub fn main() void {
       </p>
       {#see_also|Integers|Floats|void|Errors|@Type#}
       {#header_close#}
+
+
       {#header_open|Primitive Values#}
       <div class="table-wrapper">
       <table>
@@ -579,6 +591,8 @@ pub fn main() void {
       </div>
       {#see_also|Optionals|undefined#}
       {#header_close#}
+
+
       {#header_open|String Literals and Character Literals#}
       <p>
       String literals are single-item constant {#link|Pointers#} to null-terminated UTF-8 encoded byte arrays.
@@ -593,22 +607,24 @@ pub fn main() void {
       and character literals.
       </p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-const mem = @import("std").mem;
-
-test "string literals" {
-    const bytes = "hello";
-    assert(@TypeOf(bytes) == *const [5:0]u8);
-    assert(bytes.len == 5);
-    assert(bytes[1] == 'e');
-    assert(bytes[5] == 0);
-    assert('e' == '\x65');
-    assert('\u{1f4a9}' == 128169);
-    assert('💯' == 128175);
-    assert(mem.eql(u8, "hello", "h\x65llo"));
-}
+		const assert = @import("std").debug.assert;
+		const mem = @import("std").mem;
+		
+		test "string literals" {
+		    const bytes = "hello";
+		    assert(@TypeOf(bytes) == *const [5:0]u8);
+		    assert(bytes.len == 5);
+		    assert(bytes[1] == 'e');
+		    assert(bytes[5] == 0);
+		    assert('e' == '\x65');
+		    assert('\u{1f4a9}' == 128169);
+		    assert('💯' == 128175);
+		    assert(mem.eql(u8, "hello", "h\x65llo"));
+		}
       {#code_end#}
       {#see_also|Arrays|Zig Test|Source Encoding#}
+
+
       {#header_open|Escape Sequences#}
       <div class="table-wrapper">
       <table>
@@ -656,6 +672,8 @@ test "string literals" {
       </div>
       <p>Note that the maximum valid Unicode point is {#syntax#}0x10ffff{#endsyntax#}.</p>
       {#header_close#}
+
+
       {#header_open|Multiline String Literals#}
       <p>
       Multiline string literals have no escapes and can span across multiple lines.
@@ -666,66 +684,70 @@ test "string literals" {
       the string literal continues.
       </p>
       {#code_begin|syntax#}
-const hello_world_in_c =
-    \\#include <stdio.h>
-    \\
-    \\int main(int argc, char **argv) {
-    \\    printf("hello world\n");
-    \\    return 0;
-    \\}
-;
+		const hello_world_in_c =
+		    \\#include <stdio.h>
+		    \\
+		    \\int main(int argc, char **argv) {
+		    \\    printf("hello world\n");
+		    \\    return 0;
+		    \\}
+		;
       {#code_end#}
       {#see_also|@embedFile#}
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Assignment#}
       <p>Use the {#syntax#}const{#endsyntax#} keyword to assign a value to an identifier:</p>
       {#code_begin|test_err|cannot assign to constant#}
-const x = 1234;
-
-fn foo() void {
-    // It works at global scope as well as inside functions.
-    const y = 5678;
-
-    // Once assigned, an identifier cannot be changed.
-    y += 1;
-}
-
-test "assignment" {
-    foo();
-}
+		const x = 1234;
+		
+		fn foo() void {
+		    // It works at global scope as well as inside functions.
+		    const y = 5678;
+		
+		    // Once assigned, an identifier cannot be changed.
+		    y += 1;
+		}
+		
+		test "assignment" {
+		    foo();
+		}
       {#code_end#}
       <p>{#syntax#}const{#endsyntax#} applies to all of the bytes that the identifier immediately addresses. {#link|Pointers#} have their own const-ness.</p>
       <p>If you need a variable that you can modify, use the {#syntax#}var{#endsyntax#} keyword:</p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "var" {
-    var y: i32 = 5678;
-
-    y += 1;
-
-    assert(y == 5679);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "var" {
+		    var y: i32 = 5678;
+		
+		    y += 1;
+		
+		    assert(y == 5679);
+		}
       {#code_end#}
       <p>Variables must be initialized:</p>
       {#code_begin|test_err#}
-test "initialization" {
-    var x: i32;
-
-    x = 1;
-}
+		test "initialization" {
+		    var x: i32;
+		
+		    x = 1;
+		}
       {#code_end#}
+
+
       {#header_open|undefined#}
       <p>Use {#syntax#}undefined{#endsyntax#} to leave variables uninitialized:</p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "init with undefined" {
-    var x: i32 = undefined;
-    x = 1;
-    assert(x == 1);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "init with undefined" {
+		    var x: i32 = undefined;
+		    x = 1;
+		    assert(x == 1);
+		}
       {#code_end#}
       <p>
       {#syntax#}undefined{#endsyntax#} can be {#link|coerced|Type Coercion#} to any type.
@@ -742,6 +764,8 @@ test "init with undefined" {
       {#header_close#}
       {#header_close#}
 
+
+
       {#header_open|Variables#}
       <p>
       A variable is a unit of {#link|Memory#} storage.
@@ -754,6 +778,8 @@ test "init with undefined" {
       {#syntax#}var{#endsyntax#} when declaring a variable. This causes less work for both
       humans and computers to do when reading code, and creates more optimization opportunities.
       </p>
+
+
       {#header_open|Global Variables#}
       <p>
       Global variables are considered to be a top level declaration, which means that they are
@@ -762,40 +788,40 @@ test "init with undefined" {
       {#syntax#}comptime{#endsyntax#}-known, otherwise it is runtime-known.
       </p>
       {#code_begin|test|global_variables#}
-var y: i32 = add(10, x);
-const x: i32 = add(12, 34);
-
-test "global variables" {
-    assert(x == 46);
-    assert(y == 56);
-}
-
-fn add(a: i32, b: i32) i32 {
-    return a + b;
-}
-
-const std = @import("std");
-const assert = std.debug.assert;
+		var y: i32 = add(10, x);
+		const x: i32 = add(12, 34);
+		
+		test "global variables" {
+		    assert(x == 46);
+		    assert(y == 56);
+		}
+		
+		fn add(a: i32, b: i32) i32 {
+		    return a + b;
+		}
+		
+		const std = @import("std");
+		const assert = std.debug.assert;
       {#code_end#}
       <p>
       Global variables may be declared inside a {#link|struct#}, {#link|union#}, or {#link|enum#}:
       </p>
       {#code_begin|test|namespaced_global#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "namespaced global variable" {
-    assert(foo() == 1235);
-    assert(foo() == 1236);
-}
-
-fn foo() i32 {
-    const S = struct {
-        var x: i32 = 1234;
-    };
-    S.x += 1;
-    return S.x;
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "namespaced global variable" {
+		    assert(foo() == 1235);
+		    assert(foo() == 1236);
+		}
+		
+		fn foo() i32 {
+		    const S = struct {
+		        var x: i32 = 1234;
+		    };
+		    S.x += 1;
+		    return S.x;
+		}
       {#code_end#}
       <p>
       The {#syntax#}extern{#endsyntax#} keyword can be used to link against a variable that is exported
@@ -806,28 +832,30 @@ fn foo() i32 {
       {#see_also|Exporting a C Library#}
       {#header_close#}
 
+
+
       {#header_open|Thread Local Variables#}
       <p>A variable may be specified to be a thread-local variable using the
       {#syntax#}threadlocal{#endsyntax#} keyword:</p>
       {#code_begin|test|tls#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-threadlocal var x: i32 = 1234;
-
-test "thread local storage" {
-    const thread1 = try std.Thread.spawn({}, testTls);
-    const thread2 = try std.Thread.spawn({}, testTls);
-    testTls({});
-    thread1.wait();
-    thread2.wait();
-}
-
-fn testTls(context: void) void {
-    assert(x == 1234);
-    x += 1;
-    assert(x == 1235);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		threadlocal var x: i32 = 1234;
+		
+		test "thread local storage" {
+		    const thread1 = try std.Thread.spawn({}, testTls);
+		    const thread2 = try std.Thread.spawn({}, testTls);
+		    testTls({});
+		    thread1.wait();
+		    thread2.wait();
+		}
+		
+		fn testTls(context: void) void {
+		    assert(x == 1234);
+		    x += 1;
+		    assert(x == 1235);
+		}
       {#code_end#}
       <p>
       For {#link|Single Threaded Builds#}, all thread local variables are treated as {#link|Global Variables#}.
@@ -836,6 +864,8 @@ fn testTls(context: void) void {
       Thread local variables may not be {#syntax#}const{#endsyntax#}.
       </p>
       {#header_close#}
+
+
 
       {#header_open|Local Variables#}
       <p>
@@ -854,45 +884,51 @@ fn testTls(context: void) void {
       {#syntax#}comptime{#endsyntax#} variables.
       </p>
       {#code_begin|test|comptime_vars#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "comptime vars" {
-    var x: i32 = 1;
-    comptime var y: i32 = 1;
-
-    x += 1;
-    y += 1;
-
-    assert(x == 2);
-    assert(y == 2);
-
-    if (y != 2) {
-        // This compile error never triggers because y is a comptime variable,
-        // and so `y != 2` is a comptime value, and this if is statically evaluated.
-        @compileError("wrong y value");
-    }
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "comptime vars" {
+		    var x: i32 = 1;
+		    comptime var y: i32 = 1;
+		
+		    x += 1;
+		    y += 1;
+		
+		    assert(x == 2);
+		    assert(y == 2);
+		
+		    if (y != 2) {
+		        // This compile error never triggers because y is a comptime variable,
+		        // and so `y != 2` is a comptime value, and this if is statically evaluated.
+		        @compileError("wrong y value");
+		    }
+		}
       {#code_end#}
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|Integers#}
+
+
       {#header_open|Integer Literals#}
       {#code_begin|syntax#}
-const decimal_int = 98222;
-const hex_int = 0xff;
-const another_hex_int = 0xFF;
-const octal_int = 0o755;
-const binary_int = 0b11110000;
-
-// underscores may be placed between two digits as a visual separator
-const one_billion = 1_000_000_000;
-const binary_mask = 0b1_1111_1111;
-const permissions = 0o7_5_5;
-const big_address = 0xFF80_0000_0000_0000;
+		const decimal_int = 98222;
+		const hex_int = 0xff;
+		const another_hex_int = 0xFF;
+		const octal_int = 0o755;
+		const binary_int = 0b11110000;
+		
+		// underscores may be placed between two digits as a visual separator
+		const one_billion = 1_000_000_000;
+		const binary_mask = 0b1_1111_1111;
+		const permissions = 0o7_5_5;
+		const big_address = 0xFF80_0000_0000_0000;
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Runtime Integer Values#}
       <p>
       Integer literals have no size limitation, and if any undefined behavior occurs,
@@ -903,9 +939,9 @@ const big_address = 0xFF80_0000_0000_0000;
       known size, and is vulnerable to undefined behavior.
       </p>
       {#code_begin|syntax#}
-fn divide(a: i32, b: i32) i32 {
-    return a / b;
-}
+		fn divide(a: i32, b: i32) i32 {
+		    return a / b;
+		}
       {#code_end#}
       <p>
       In this function, values {#syntax#}a{#endsyntax#} and {#syntax#}b{#endsyntax#} are known only at runtime,
@@ -926,6 +962,8 @@ fn divide(a: i32, b: i32) i32 {
       {#see_also|Wrapping Operations#}
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Floats#}
       <p>Zig has the following floating point types:</p>
       <ul>
@@ -935,6 +973,8 @@ fn divide(a: i32, b: i32) i32 {
           <li>{#syntax#}f128{#endsyntax#} - IEEE-754-2008 binary128</li>
           <li>{#syntax#}c_longdouble{#endsyntax#} - matches <code class="c">long double</code> for the target C ABI</li>
       </ul>
+
+
       {#header_open|Float Literals#}
       <p>
       Float literals have type {#syntax#}comptime_float{#endsyntax#} which is guaranteed to have
@@ -946,73 +986,79 @@ fn divide(a: i32, b: i32) i32 {
       and to any {#link|integer|Integers#} type when there is no fractional component.
       </p>
       {#code_begin|syntax#}
-const floating_point = 123.0E+77;
-const another_float = 123.0;
-const yet_another = 123.0e+77;
-
-const hex_floating_point = 0x103.70p-5;
-const another_hex_float = 0x103.70;
-const yet_another_hex_float = 0x103.70P-5;
-
-// underscores may be placed between two digits as a visual separator
-const lightspeed = 299_792_458.000_000;
-const nanosecond = 0.000_000_001;
-const more_hex = 0x1234_5678.9ABC_CDEFp-10;
+		const floating_point = 123.0E+77;
+		const another_float = 123.0;
+		const yet_another = 123.0e+77;
+		
+		const hex_floating_point = 0x103.70p-5;
+		const another_hex_float = 0x103.70;
+		const yet_another_hex_float = 0x103.70P-5;
+		
+		// underscores may be placed between two digits as a visual separator
+		const lightspeed = 299_792_458.000_000;
+		const nanosecond = 0.000_000_001;
+		const more_hex = 0x1234_5678.9ABC_CDEFp-10;
       {#code_end#}
       <p>
       There is no syntax for NaN, infinity, or negative infinity. For these special values,
       one must use the standard library:
       </p>
       {#code_begin|syntax#}
-const std = @import("std");
-
-const inf = std.math.inf(f32);
-const negative_inf = -std.math.inf(f64);
-const nan = std.math.nan(f128);
+		const std = @import("std");
+		
+		const inf = std.math.inf(f32);
+		const negative_inf = -std.math.inf(f64);
+		const nan = std.math.nan(f128);
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Floating Point Operations#}
       <p>By default floating point operations use {#syntax#}Strict{#endsyntax#} mode,
           but you can switch to {#syntax#}Optimized{#endsyntax#} mode on a per-block basis:</p>
       {#code_begin|obj|foo#}
-      {#code_release_fast#}
-const std = @import("std");
-const builtin = std.builtin;
-const big = @as(f64, 1 << 40);
-
-export fn foo_strict(x: f64) f64 {
-    return x + big - big;
-}
-
-export fn foo_optimized(x: f64) f64 {
-    @setFloatMode(.Optimized);
-    return x + big - big;
-}
+		      {#code_release_fast#}
+		const std = @import("std");
+		const builtin = std.builtin;
+		const big = @as(f64, 1 << 40);
+		
+		export fn foo_strict(x: f64) f64 {
+		    return x + big - big;
+		}
+		
+		export fn foo_optimized(x: f64) f64 {
+		    @setFloatMode(.Optimized);
+		    return x + big - big;
+		}
       {#code_end#}
       <p>For this test we have to separate code into two object files -
       otherwise the optimizer figures out all the values at compile-time,
       which operates in strict mode.</p>
       {#code_begin|exe|float_mode#}
-      {#code_link_object|foo#}
-const warn = @import("std").debug.warn;
-
-extern fn foo_strict(x: f64) f64;
-extern fn foo_optimized(x: f64) f64;
-
-pub fn main() void {
-    const x = 0.001;
-    warn("optimized = {}\n", .{foo_optimized(x)});
-    warn("strict = {}\n", .{foo_strict(x)});
-}
+		      {#code_link_object|foo#}
+		const warn = @import("std").debug.warn;
+		
+		extern fn foo_strict(x: f64) f64;
+		extern fn foo_optimized(x: f64) f64;
+		
+		pub fn main() void {
+		    const x = 0.001;
+		    warn("optimized = {}\n", .{foo_optimized(x)});
+		    warn("strict = {}\n", .{foo_strict(x)});
+		}
       {#code_end#}
       {#see_also|@setFloatMode|Division by Zero#}
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Operators#}
       <p>
       There is no operator overloading. When you see an operator in Zig, you know that
       it is doing something from this table, and nothing else.
       </p>
+
+
       {#header_open|Table of Operators#}
       <div class="table-wrapper">
       <table>
@@ -1636,6 +1682,8 @@ const B = error{Two};
       </table>
       </div>
       {#header_close#}
+
+
       {#header_open|Precedence#}
       <pre>{#syntax#}x() x[] x.y
 a!b
@@ -1652,179 +1700,187 @@ orelse catch
 = *= /= %= += -= <<= >>= &= ^= |={#endsyntax#}</pre>
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Arrays#}
       {#code_begin|test|arrays#}
-const assert = @import("std").debug.assert;
-const mem = @import("std").mem;
-
-// array literal
-const message = [_]u8{ 'h', 'e', 'l', 'l', 'o' };
-
-// get the size of an array
-comptime {
-    assert(message.len == 5);
-}
-
-// A string literal is a pointer to an array literal.
-const same_message = "hello";
-
-comptime {
-    assert(mem.eql(u8, &message, same_message));
-}
-
-test "iterate over an array" {
-    var sum: usize = 0;
-    for (message) |byte| {
-        sum += byte;
-    }
-    assert(sum == 'h' + 'e' + 'l' * 2 + 'o');
-}
-
-// modifiable array
-var some_integers: [100]i32 = undefined;
-
-test "modify an array" {
-    for (some_integers) |*item, i| {
-        item.* = @intCast(i32, i);
-    }
-    assert(some_integers[10] == 10);
-    assert(some_integers[99] == 99);
-}
-
-// array concatenation works if the values are known
-// at compile time
-const part_one = [_]i32{ 1, 2, 3, 4 };
-const part_two = [_]i32{ 5, 6, 7, 8 };
-const all_of_it = part_one ++ part_two;
-comptime {
-    assert(mem.eql(i32, &all_of_it, &[_]i32{ 1, 2, 3, 4, 5, 6, 7, 8 }));
-}
-
-// remember that string literals are arrays
-const hello = "hello";
-const world = "world";
-const hello_world = hello ++ " " ++ world;
-comptime {
-    assert(mem.eql(u8, hello_world, "hello world"));
-}
-
-// ** does repeating patterns
-const pattern = "ab" ** 3;
-comptime {
-    assert(mem.eql(u8, pattern, "ababab"));
-}
-
-// initialize an array to zero
-const all_zero = [_]u16{0} ** 10;
-
-comptime {
-    assert(all_zero.len == 10);
-    assert(all_zero[5] == 0);
-}
-
-// use compile-time code to initialize an array
-var fancy_array = init: {
-    var initial_value: [10]Point = undefined;
-    for (initial_value) |*pt, i| {
-        pt.* = Point{
-            .x = @intCast(i32, i),
-            .y = @intCast(i32, i) * 2,
-        };
-    }
-    break :init initial_value;
-};
-const Point = struct {
-    x: i32,
-    y: i32,
-};
-
-test "compile-time array initalization" {
-    assert(fancy_array[4].x == 4);
-    assert(fancy_array[4].y == 8);
-}
-
-// call a function to initialize an array
-var more_points = [_]Point{makePoint(3)} ** 10;
-fn makePoint(x: i32) Point {
-    return Point{
-        .x = x,
-        .y = x * 2,
-    };
-}
-test "array initialization with function calls" {
-    assert(more_points[4].x == 3);
-    assert(more_points[4].y == 6);
-    assert(more_points.len == 10);
-}
+		const assert = @import("std").debug.assert;
+		const mem = @import("std").mem;
+		
+		// array literal
+		const message = [_]u8{ 'h', 'e', 'l', 'l', 'o' };
+		
+		// get the size of an array
+		comptime {
+		    assert(message.len == 5);
+		}
+		
+		// A string literal is a pointer to an array literal.
+		const same_message = "hello";
+		
+		comptime {
+		    assert(mem.eql(u8, &message, same_message));
+		}
+		
+		test "iterate over an array" {
+		    var sum: usize = 0;
+		    for (message) |byte| {
+		        sum += byte;
+		    }
+		    assert(sum == 'h' + 'e' + 'l' * 2 + 'o');
+		}
+		
+		// modifiable array
+		var some_integers: [100]i32 = undefined;
+		
+		test "modify an array" {
+		    for (some_integers) |*item, i| {
+		        item.* = @intCast(i32, i);
+		    }
+		    assert(some_integers[10] == 10);
+		    assert(some_integers[99] == 99);
+		}
+		
+		// array concatenation works if the values are known
+		// at compile time
+		const part_one = [_]i32{ 1, 2, 3, 4 };
+		const part_two = [_]i32{ 5, 6, 7, 8 };
+		const all_of_it = part_one ++ part_two;
+		comptime {
+		    assert(mem.eql(i32, &all_of_it, &[_]i32{ 1, 2, 3, 4, 5, 6, 7, 8 }));
+		}
+		
+		// remember that string literals are arrays
+		const hello = "hello";
+		const world = "world";
+		const hello_world = hello ++ " " ++ world;
+		comptime {
+		    assert(mem.eql(u8, hello_world, "hello world"));
+		}
+		
+		// ** does repeating patterns
+		const pattern = "ab" ** 3;
+		comptime {
+		    assert(mem.eql(u8, pattern, "ababab"));
+		}
+		
+		// initialize an array to zero
+		const all_zero = [_]u16{0} ** 10;
+		
+		comptime {
+		    assert(all_zero.len == 10);
+		    assert(all_zero[5] == 0);
+		}
+		
+		// use compile-time code to initialize an array
+		var fancy_array = init: {
+		    var initial_value: [10]Point = undefined;
+		    for (initial_value) |*pt, i| {
+		        pt.* = Point{
+		            .x = @intCast(i32, i),
+		            .y = @intCast(i32, i) * 2,
+		        };
+		    }
+		    break :init initial_value;
+		};
+		const Point = struct {
+		    x: i32,
+		    y: i32,
+		};
+		
+		test "compile-time array initalization" {
+		    assert(fancy_array[4].x == 4);
+		    assert(fancy_array[4].y == 8);
+		}
+		
+		// call a function to initialize an array
+		var more_points = [_]Point{makePoint(3)} ** 10;
+		fn makePoint(x: i32) Point {
+		    return Point{
+		        .x = x,
+		        .y = x * 2,
+		    };
+		}
+		test "array initialization with function calls" {
+		    assert(more_points[4].x == 3);
+		    assert(more_points[4].y == 6);
+		    assert(more_points.len == 10);
+		}
       {#code_end#}
       {#see_also|for|Slices#}
+
+
 
       {#header_open|Anonymous List Literals#}
       <p>Similar to {#link|Enum Literals#} and {#link|Anonymous Struct Literals#}
       the type can be omitted from array literals:</p>
       {#code_begin|test|anon_list#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "anonymous list literal syntax" {
-    var array: [4]u8 = .{11, 22, 33, 44};
-    assert(array[0] == 11);
-    assert(array[1] == 22);
-    assert(array[2] == 33);
-    assert(array[3] == 44);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "anonymous list literal syntax" {
+		    var array: [4]u8 = .{11, 22, 33, 44};
+		    assert(array[0] == 11);
+		    assert(array[1] == 22);
+		    assert(array[2] == 33);
+		    assert(array[3] == 44);
+		}
       {#code_end#}
       <p>
       If there is no type in the result location then an anonymous list literal actually
       turns into a {#link|struct#} with numbered field names:
       </p>
       {#code_begin|test|infer_list_literal#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "fully anonymous list literal" {
-    dump(.{ @as(u32, 1234), @as(f64, 12.34), true, "hi"});
-}
-
-fn dump(args: var) void {
-    assert(args.@"0" == 1234);
-    assert(args.@"1" == 12.34);
-    assert(args.@"2");
-    assert(args.@"3"[0] == 'h');
-    assert(args.@"3"[1] == 'i');
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "fully anonymous list literal" {
+		    dump(.{ @as(u32, 1234), @as(f64, 12.34), true, "hi"});
+		}
+		
+		fn dump(args: var) void {
+		    assert(args.@"0" == 1234);
+		    assert(args.@"1" == 12.34);
+		    assert(args.@"2");
+		    assert(args.@"3"[0] == 'h');
+		    assert(args.@"3"[1] == 'i');
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|Multidimensional Arrays#}
       <p>
       Mutlidimensional arrays can be created by nesting arrays:
       </p>
       {#code_begin|test|multidimensional#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const mat4x4 = [4][4]f32{
-    [_]f32{ 1.0, 0.0, 0.0, 0.0 },
-    [_]f32{ 0.0, 1.0, 0.0, 1.0 },
-    [_]f32{ 0.0, 0.0, 1.0, 0.0 },
-    [_]f32{ 0.0, 0.0, 0.0, 1.0 },
-};
-test "multidimensional arrays" {
-    // Access the 2D array by indexing the outer array, and then the inner array.
-    assert(mat4x4[1][1] == 1.0);
-
-    // Here we iterate with for loops.
-    for (mat4x4) |row, row_index| {
-        for (row) |cell, column_index| {
-            if (row_index == column_index) {
-                assert(cell == 1.0);
-            }
-        }
-    }
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const mat4x4 = [4][4]f32{
+		    [_]f32{ 1.0, 0.0, 0.0, 0.0 },
+		    [_]f32{ 0.0, 1.0, 0.0, 1.0 },
+		    [_]f32{ 0.0, 0.0, 1.0, 0.0 },
+		    [_]f32{ 0.0, 0.0, 0.0, 1.0 },
+		};
+		test "multidimensional arrays" {
+		    // Access the 2D array by indexing the outer array, and then the inner array.
+		    assert(mat4x4[1][1] == 1.0);
+		
+		    // Here we iterate with for loops.
+		    for (mat4x4) |row, row_index| {
+		        for (row) |cell, column_index| {
+		            if (row_index == column_index) {
+		                assert(cell == 1.0);
+		            }
+		        }
+		    }
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|Sentinel-Terminated Arrays#}
       <p>
@@ -1832,20 +1888,22 @@ test "multidimensional arrays" {
       index corresponding to {#syntax#}len{#endsyntax#}.
       </p>
       {#code_begin|test|null_terminated_array#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "null terminated array" {
-    const array = [_:0]u8 {1, 2, 3, 4};
-
-    assert(@TypeOf(array) == [4:0]u8);
-    assert(array.len == 4);
-    assert(array[4] == 0);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "null terminated array" {
+		    const array = [_:0]u8 {1, 2, 3, 4};
+		
+		    assert(@TypeOf(array) == [4:0]u8);
+		    assert(array.len == 4);
+		    assert(array[4] == 0);
+		}
       {#code_end#}
       {#see_also|Sentinel-Terminated Pointers|Sentinel-Terminated Slices#}
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|Vectors#}
       <p>
@@ -1856,6 +1914,8 @@ test "null terminated array" {
       <p>
       TODO talk about C ABI interop
       </p>
+
+
       {#header_open|SIMD#}
       <p>
       TODO Zig's SIMD abilities are just beginning to be fleshed out. Here are some talking points to update the
@@ -1868,6 +1928,8 @@ test "null terminated array" {
       </p>
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|Pointers#}
       <p>
@@ -1910,39 +1972,39 @@ test "null terminated array" {
         </ul>
         <p>Use {#syntax#}&x{#endsyntax#} to obtain a single-item pointer:</p>
         {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "address of syntax" {
-    // Get the address of a variable:
-    const x: i32 = 1234;
-    const x_ptr = &x;
-
-    // Dereference a pointer:
-    assert(x_ptr.* == 1234);
-
-    // When you get the address of a const variable, you get a const pointer to a single item.
-    assert(@TypeOf(x_ptr) == *const i32);
-
-    // If you want to mutate the value, you'd need an address of a mutable variable:
-    var y: i32 = 5678;
-    const y_ptr = &y;
-    assert(@TypeOf(y_ptr) == *i32);
-    y_ptr.* += 1;
-    assert(y_ptr.* == 5679);
-}
-
-test "pointer array access" {
-    // Taking an address of an individual element gives a
-    // pointer to a single item. This kind of pointer
-    // does not support pointer arithmetic.
-    var array = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-    const ptr = &array[2];
-    assert(@TypeOf(ptr) == *u8);
-
-    assert(array[2] == 3);
-    ptr.* += 1;
-    assert(array[2] == 4);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "address of syntax" {
+		    // Get the address of a variable:
+		    const x: i32 = 1234;
+		    const x_ptr = &x;
+		
+		    // Dereference a pointer:
+		    assert(x_ptr.* == 1234);
+		
+		    // When you get the address of a const variable, you get a const pointer to a single item.
+		    assert(@TypeOf(x_ptr) == *const i32);
+		
+		    // If you want to mutate the value, you'd need an address of a mutable variable:
+		    var y: i32 = 5678;
+		    const y_ptr = &y;
+		    assert(@TypeOf(y_ptr) == *i32);
+		    y_ptr.* += 1;
+		    assert(y_ptr.* == 5679);
+		}
+		
+		test "pointer array access" {
+		    // Taking an address of an individual element gives a
+		    // pointer to a single item. This kind of pointer
+		    // does not support pointer arithmetic.
+		    var array = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+		    const ptr = &array[2];
+		    assert(@TypeOf(ptr) == *u8);
+		
+		    assert(array[2] == 3);
+		    ptr.* += 1;
+		    assert(array[2] == 4);
+		}
       {#code_end#}
       <p>
         In Zig, we generally prefer {#link|Slices#} rather than {#link|Sentinel-Terminated Pointers#}.
@@ -1954,74 +2016,76 @@ test "pointer array access" {
         we prefer slices to pointers.
       </p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "pointer slicing" {
-    var array = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-    const slice = array[2..4];
-    assert(slice.len == 2);
-
-    assert(array[3] == 4);
-    slice[1] += 1;
-    assert(array[3] == 5);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "pointer slicing" {
+		    var array = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+		    const slice = array[2..4];
+		    assert(slice.len == 2);
+		
+		    assert(array[3] == 4);
+		    slice[1] += 1;
+		    assert(array[3] == 5);
+		}
       {#code_end#}
       <p>Pointers work at compile-time too, as long as the code does not depend on
       an undefined memory layout:</p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "comptime pointers" {
-    comptime {
-        var x: i32 = 1;
-        const ptr = &x;
-        ptr.* += 1;
-        x += 1;
-        assert(ptr.* == 3);
-    }
-}
+		const assert = @import("std").debug.assert;
+		
+		test "comptime pointers" {
+		    comptime {
+		        var x: i32 = 1;
+		        const ptr = &x;
+		        ptr.* += 1;
+		        x += 1;
+		        assert(ptr.* == 3);
+		    }
+		}
       {#code_end#}
       <p>To convert an integer address into a pointer, use {#syntax#}@intToPtr{#endsyntax#}.
       To convert a pointer to an integer, use {#syntax#}@ptrToInt{#endsyntax#}:</p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "@ptrToInt and @intToPtr" {
-    const ptr = @intToPtr(*i32, 0xdeadbee0);
-    const addr = @ptrToInt(ptr);
-    assert(@TypeOf(addr) == usize);
-    assert(addr == 0xdeadbee0);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "@ptrToInt and @intToPtr" {
+		    const ptr = @intToPtr(*i32, 0xdeadbee0);
+		    const addr = @ptrToInt(ptr);
+		    assert(@TypeOf(addr) == usize);
+		    assert(addr == 0xdeadbee0);
+		}
       {#code_end#}
       <p>Zig is able to preserve memory addresses in comptime code, as long as
       the pointer is never dereferenced:</p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "comptime @intToPtr" {
-    comptime {
-        // Zig is able to do this at compile-time, as long as
-        // ptr is never dereferenced.
-        const ptr = @intToPtr(*i32, 0xdeadbee0);
-        const addr = @ptrToInt(ptr);
-        assert(@TypeOf(addr) == usize);
-        assert(addr == 0xdeadbee0);
-    }
-}
+		const assert = @import("std").debug.assert;
+		
+		test "comptime @intToPtr" {
+		    comptime {
+		        // Zig is able to do this at compile-time, as long as
+		        // ptr is never dereferenced.
+		        const ptr = @intToPtr(*i32, 0xdeadbee0);
+		        const addr = @ptrToInt(ptr);
+		        assert(@TypeOf(addr) == usize);
+		        assert(addr == 0xdeadbee0);
+		    }
+		}
       {#code_end#}
       {#see_also|Optional Pointers|@intToPtr|@ptrToInt|C Pointers|Pointers to Zero Bit Types#}
+
+
       {#header_open|volatile#}
       <p>Loads and stores are assumed to not have side effects. If a given load or store
       should have side effects, such as Memory Mapped Input/Output (MMIO), use {#syntax#}volatile{#endsyntax#}.
       In the following code, loads and stores with {#syntax#}mmio_ptr{#endsyntax#} are guaranteed to all happen
       and in the same order as in source code:</p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "volatile" {
-    const mmio_ptr = @intToPtr(*volatile u8, 0x12345678);
-    assert(@TypeOf(mmio_ptr) == *volatile u8);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "volatile" {
+		    const mmio_ptr = @intToPtr(*volatile u8, 0x12345678);
+		    assert(@TypeOf(mmio_ptr) == *volatile u8);
+		}
       {#code_end#}
       <p>
       Note that {#syntax#}volatile{#endsyntax#} is unrelated to concurrency and {#link|Atomics#}.
@@ -2035,28 +2099,30 @@ test "volatile" {
       conversions are not possible.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "pointer casting" {
-    const bytes align(@alignOf(u32)) = [_]u8{ 0x12, 0x12, 0x12, 0x12 };
-    const u32_ptr = @ptrCast(*const u32, &bytes);
-    assert(u32_ptr.* == 0x12121212);
-
-    // Even this example is contrived - there are better ways to do the above than
-    // pointer casting. For example, using a slice narrowing cast:
-    const u32_value = std.mem.bytesAsSlice(u32, bytes[0..])[0];
-    assert(u32_value == 0x12121212);
-
-    // And even another way, the most straightforward way to do it:
-    assert(@bitCast(u32, bytes) == 0x12121212);
-}
-
-test "pointer child type" {
-    // pointer types have a `child` field which tells you the type they point to.
-    assert((*u32).Child == u32);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "pointer casting" {
+		    const bytes align(@alignOf(u32)) = [_]u8{ 0x12, 0x12, 0x12, 0x12 };
+		    const u32_ptr = @ptrCast(*const u32, &bytes);
+		    assert(u32_ptr.* == 0x12121212);
+		
+		    // Even this example is contrived - there are better ways to do the above than
+		    // pointer casting. For example, using a slice narrowing cast:
+		    const u32_value = std.mem.bytesAsSlice(u32, bytes[0..])[0];
+		    assert(u32_value == 0x12121212);
+		
+		    // And even another way, the most straightforward way to do it:
+		    assert(@bitCast(u32, bytes) == 0x12121212);
+		}
+		
+		test "pointer child type" {
+		    // pointer types have a `child` field which tells you the type they point to.
+		    assert((*u32).Child == u32);
+		}
       {#code_end#}
+
+
       {#header_open|Alignment#}
       <p>
       Each type has an <strong>alignment</strong> - a number of bytes such that,
@@ -2073,18 +2139,18 @@ test "pointer child type" {
       alignment of the underlying type, it can be omitted from the type:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "variable alignment" {
-    var x: i32 = 1234;
-    const align_of_i32 = @alignOf(@TypeOf(x));
-    assert(@TypeOf(&x) == *i32);
-    assert(*i32 == *align(align_of_i32) i32);
-    if (std.Target.current.cpu.arch == .x86_64) {
-        assert((*i32).alignment == 4);
-    }
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "variable alignment" {
+		    var x: i32 = 1234;
+		    const align_of_i32 = @alignOf(@TypeOf(x));
+		    assert(@TypeOf(&x) == *i32);
+		    assert(*i32 == *align(align_of_i32) i32);
+		    if (std.Target.current.cpu.arch == .x86_64) {
+		        assert((*i32).alignment == 4);
+		    }
+		}
       {#code_end#}
       <p>In the same way that a {#syntax#}*i32{#endsyntax#} can be {#link|coerced|Type Coercion#} to a
           {#syntax#}*const i32{#endsyntax#}, a pointer with a larger alignment can be implicitly
@@ -2095,29 +2161,29 @@ test "variable alignment" {
       pointers to them get the specified alignment:
       </p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-var foo: u8 align(4) = 100;
-
-test "global variable alignment" {
-    assert(@TypeOf(&foo).alignment == 4);
-    assert(@TypeOf(&foo) == *align(4) u8);
-    const as_pointer_to_array: *[1]u8 = &foo;
-    const as_slice: []u8 = as_pointer_to_array;
-    assert(@TypeOf(as_slice) == []align(4) u8);
-}
-
-fn derp() align(@sizeOf(usize) * 2) i32 { return 1234; }
-fn noop1() align(1) void {}
-fn noop4() align(4) void {}
-
-test "function alignment" {
-    assert(derp() == 1234);
-    assert(@TypeOf(noop1) == fn() align(1) void);
-    assert(@TypeOf(noop4) == fn() align(4) void);
-    noop1();
-    noop4();
-}
+		const assert = @import("std").debug.assert;
+		
+		var foo: u8 align(4) = 100;
+		
+		test "global variable alignment" {
+		    assert(@TypeOf(&foo).alignment == 4);
+		    assert(@TypeOf(&foo) == *align(4) u8);
+		    const as_pointer_to_array: *[1]u8 = &foo;
+		    const as_slice: []u8 = as_pointer_to_array;
+		    assert(@TypeOf(as_slice) == []align(4) u8);
+		}
+		
+		fn derp() align(@sizeOf(usize) * 2) i32 { return 1234; }
+		fn noop1() align(1) void {}
+		fn noop4() align(4) void {}
+		
+		test "function alignment" {
+		    assert(derp() == 1234);
+		    assert(@TypeOf(noop1) == fn() align(1) void);
+		    assert(@TypeOf(noop4) == fn() align(4) void);
+		    noop1();
+		    noop4();
+		}
       {#code_end#}
       <p>
       If you have a pointer or a slice that has a small alignment, but you know that it actually
@@ -2126,20 +2192,22 @@ test "function alignment" {
       {#link|safety check|Incorrect Pointer Alignment#}:
       </p>
       {#code_begin|test_safety|incorrect alignment#}
-const std = @import("std");
-
-test "pointer alignment safety" {
-    var array align(4) = [_]u32{ 0x11111111, 0x11111111 };
-    const bytes = std.mem.sliceAsBytes(array[0..]);
-    std.debug.assert(foo(bytes) == 0x11111111);
-}
-fn foo(bytes: []u8) u32 {
-    const slice4 = bytes[1..5];
-    const int_slice = std.mem.bytesAsSlice(u32, @alignCast(4, slice4));
-    return int_slice[0];
-}
+		const std = @import("std");
+		
+		test "pointer alignment safety" {
+		    var array align(4) = [_]u32{ 0x11111111, 0x11111111 };
+		    const bytes = std.mem.sliceAsBytes(array[0..]);
+		    std.debug.assert(foo(bytes) == 0x11111111);
+		}
+		fn foo(bytes: []u8) u32 {
+		    const slice4 = bytes[1..5];
+		    const int_slice = std.mem.bytesAsSlice(u32, @alignCast(4, slice4));
+		    return int_slice[0];
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|allowzero#}
       <p>
@@ -2151,16 +2219,18 @@ fn foo(bytes: []u8) u32 {
       {#link|Pointer Cast Invalid Null#} panic:
       </p>
       {#code_begin|test|allowzero#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "allowzero" {
-    var zero: usize = 0;
-    var ptr = @intToPtr(*allowzero i32, zero);
-    assert(@ptrToInt(ptr) == 0);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "allowzero" {
+		    var zero: usize = 0;
+		    var ptr = @intToPtr(*allowzero i32, zero);
+		    assert(@ptrToInt(ptr) == 0);
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|Sentinel-Terminated Pointers#}
       <p>
@@ -2169,100 +2239,104 @@ test "allowzero" {
       against buffer overflow and overreads.
       </p>
       {#code_begin|exe_build_err#}
-      {#link_libc#}
-const std = @import("std");
-
-// This is also available as `std.c.printf`.
-pub extern "c" fn printf(format: [*:0]const u8, ...) c_int;
-
-pub fn main() anyerror!void {
-    _ = printf("Hello, world!\n"); // OK
-
-    const msg = "Hello, world!\n";
-    const non_null_terminated_msg: [msg.len]u8 = msg.*;
-    _ = printf(&non_null_terminated_msg);
-}
+		      {#link_libc#}
+		const std = @import("std");
+		
+		// This is also available as `std.c.printf`.
+		pub extern "c" fn printf(format: [*:0]const u8, ...) c_int;
+		
+		pub fn main() anyerror!void {
+		    _ = printf("Hello, world!\n"); // OK
+		
+		    const msg = "Hello, world!\n";
+		    const non_null_terminated_msg: [msg.len]u8 = msg.*;
+		    _ = printf(&non_null_terminated_msg);
+		}
       {#code_end#}
       {#see_also|Sentinel-Terminated Slices|Sentinel-Terminated Arrays#}
       {#header_close#}
       {#header_close#}
 
+
+
       {#header_open|Slices#}
       {#code_begin|test_safety|index out of bounds#}
-const assert = @import("std").debug.assert;
-
-test "basic slices" {
-    var array = [_]i32{ 1, 2, 3, 4 };
-    // A slice is a pointer and a length. The difference between an array and
-    // a slice is that the array's length is part of the type and known at
-    // compile-time, whereas the slice's length is known at runtime.
-    // Both can be accessed with the `len` field.
-    var known_at_runtime_zero: usize = 0;
-    const slice = array[known_at_runtime_zero..array.len];
-    assert(&slice[0] == &array[0]);
-    assert(slice.len == array.len);
-
-    // Using the address-of operator on a slice gives a pointer to a single
-    // item, while using the `ptr` field gives an unknown length pointer.
-    assert(@TypeOf(slice.ptr) == [*]i32);
-    assert(@TypeOf(&slice[0]) == *i32);
-    assert(@ptrToInt(slice.ptr) == @ptrToInt(&slice[0]));
-
-    // Slices have array bounds checking. If you try to access something out
-    // of bounds, you'll get a safety check failure:
-    slice[10] += 1;
-
-    // Note that `slice.ptr` does not invoke safety checking, while `&slice[0]`
-    // asserts that the slice has len >= 1.
-}
+		const assert = @import("std").debug.assert;
+		
+		test "basic slices" {
+		    var array = [_]i32{ 1, 2, 3, 4 };
+		    // A slice is a pointer and a length. The difference between an array and
+		    // a slice is that the array's length is part of the type and known at
+		    // compile-time, whereas the slice's length is known at runtime.
+		    // Both can be accessed with the `len` field.
+		    var known_at_runtime_zero: usize = 0;
+		    const slice = array[known_at_runtime_zero..array.len];
+		    assert(&slice[0] == &array[0]);
+		    assert(slice.len == array.len);
+		
+		    // Using the address-of operator on a slice gives a pointer to a single
+		    // item, while using the `ptr` field gives an unknown length pointer.
+		    assert(@TypeOf(slice.ptr) == [*]i32);
+		    assert(@TypeOf(&slice[0]) == *i32);
+		    assert(@ptrToInt(slice.ptr) == @ptrToInt(&slice[0]));
+		
+		    // Slices have array bounds checking. If you try to access something out
+		    // of bounds, you'll get a safety check failure:
+		    slice[10] += 1;
+		
+		    // Note that `slice.ptr` does not invoke safety checking, while `&slice[0]`
+		    // asserts that the slice has len >= 1.
+		}
       {#code_end#}
       <p>This is one reason we prefer slices to pointers.</p>
       {#code_begin|test|slices#}
-const std = @import("std");
-const assert = std.debug.assert;
-const mem = std.mem;
-const fmt = std.fmt;
-
-test "using slices for strings" {
-    // Zig has no concept of strings. String literals are const pointers to
-    // arrays of u8, and by convention parameters that are "strings" are
-    // expected to be UTF-8 encoded slices of u8.
-    // Here we coerce [5]u8 to []const u8
-    const hello: []const u8 = "hello";
-    const world: []const u8 = "世界";
-
-    var all_together: [100]u8 = undefined;
-    // You can use slice syntax on an array to convert an array into a slice.
-    const all_together_slice = all_together[0..];
-    // String concatenation example.
-    const hello_world = try fmt.bufPrint(all_together_slice, "{} {}", .{ hello, world });
-
-    // Generally, you can use UTF-8 and not worry about whether something is a
-    // string. If you don't need to deal with individual characters, no need
-    // to decode.
-    assert(mem.eql(u8, hello_world, "hello 世界"));
-}
-
-test "slice pointer" {
-    var array: [10]u8 = undefined;
-    const ptr = &array;
-
-    // You can use slicing syntax to convert a pointer into a slice:
-    const slice = ptr[0..5];
-    slice[2] = 3;
-    assert(slice[2] == 3);
-    // The slice is mutable because we sliced a mutable pointer.
-    // Furthermore, it is actually a pointer to an array, since the start
-    // and end indexes were both comptime-known.
-    assert(@TypeOf(slice) == *[5]u8);
-
-    // You can also slice a slice:
-    const slice2 = slice[2..3];
-    assert(slice2.len == 1);
-    assert(slice2[0] == 3);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		const mem = std.mem;
+		const fmt = std.fmt;
+		
+		test "using slices for strings" {
+		    // Zig has no concept of strings. String literals are const pointers to
+		    // arrays of u8, and by convention parameters that are "strings" are
+		    // expected to be UTF-8 encoded slices of u8.
+		    // Here we coerce [5]u8 to []const u8
+		    const hello: []const u8 = "hello";
+		    const world: []const u8 = "世界";
+		
+		    var all_together: [100]u8 = undefined;
+		    // You can use slice syntax on an array to convert an array into a slice.
+		    const all_together_slice = all_together[0..];
+		    // String concatenation example.
+		    const hello_world = try fmt.bufPrint(all_together_slice, "{} {}", .{ hello, world });
+		
+		    // Generally, you can use UTF-8 and not worry about whether something is a
+		    // string. If you don't need to deal with individual characters, no need
+		    // to decode.
+		    assert(mem.eql(u8, hello_world, "hello 世界"));
+		}
+		
+		test "slice pointer" {
+		    var array: [10]u8 = undefined;
+		    const ptr = &array;
+		
+		    // You can use slicing syntax to convert a pointer into a slice:
+		    const slice = ptr[0..5];
+		    slice[2] = 3;
+		    assert(slice[2] == 3);
+		    // The slice is mutable because we sliced a mutable pointer.
+		    // Furthermore, it is actually a pointer to an array, since the start
+		    // and end indexes were both comptime-known.
+		    assert(@TypeOf(slice) == *[5]u8);
+		
+		    // You can also slice a slice:
+		    const slice2 = slice[2..3];
+		    assert(slice2.len == 1);
+		    assert(slice2[0] == 3);
+		}
       {#code_end#}
       {#see_also|Pointers|for|Arrays#}
+
+
 
       {#header_open|Sentinel-Terminated Slices#}
       <p>
@@ -2272,157 +2346,161 @@ test "slice pointer" {
       access to the {#syntax#}len{#endsyntax#} index.
       </p>
       {#code_begin|test|null_terminated_slice#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "null terminated slice" {
-    const slice: [:0]const u8 = "hello";
-
-    assert(slice.len == 5);
-    assert(slice[5] == 0);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "null terminated slice" {
+		    const slice: [:0]const u8 = "hello";
+		
+		    assert(slice.len == 5);
+		    assert(slice[5] == 0);
+		}
       {#code_end#}
       {#see_also|Sentinel-Terminated Pointers|Sentinel-Terminated Arrays#}
       {#header_close#}
       {#header_close#}
 
+
+
       {#header_open|struct#}
       {#code_begin|test|structs#}
-// Declare a struct.
-// Zig gives no guarantees about the order of fields and the size of
-// the struct but the fields are guaranteed to be ABI-aligned.
-const Point = struct {
-    x: f32,
-    y: f32,
-};
-
-// Maybe we want to pass it to OpenGL so we want to be particular about
-// how the bytes are arranged.
-const Point2 = packed struct {
-    x: f32,
-    y: f32,
-};
-
-
-// Declare an instance of a struct.
-const p = Point {
-    .x = 0.12,
-    .y = 0.34,
-};
-
-// Maybe we're not ready to fill out some of the fields.
-var p2 = Point {
-    .x = 0.12,
-    .y = undefined,
-};
-
-// Structs can have methods
-// Struct methods are not special, they are only namespaced
-// functions that you can call with dot syntax.
-const Vec3 = struct {
-    x: f32,
-    y: f32,
-    z: f32,
-
-    pub fn init(x: f32, y: f32, z: f32) Vec3 {
-        return Vec3 {
-            .x = x,
-            .y = y,
-            .z = z,
-        };
-    }
-
-    pub fn dot(self: Vec3, other: Vec3) f32 {
-        return self.x * other.x + self.y * other.y + self.z * other.z;
-    }
-};
-
-const assert = @import("std").debug.assert;
-test "dot product" {
-    const v1 = Vec3.init(1.0, 0.0, 0.0);
-    const v2 = Vec3.init(0.0, 1.0, 0.0);
-    assert(v1.dot(v2) == 0.0);
-
-    // Other than being available to call with dot syntax, struct methods are
-    // not special. You can reference them as any other declaration inside
-    // the struct:
-    assert(Vec3.dot(v1, v2) == 0.0);
-}
-
-// Structs can have global declarations.
-// Structs can have 0 fields.
-const Empty = struct {
-    pub const PI = 3.14;
-};
-test "struct namespaced variable" {
-    assert(Empty.PI == 3.14);
-    assert(@sizeOf(Empty) == 0);
-
-    // you can still instantiate an empty struct
-    const does_nothing = Empty {};
-}
-
-// struct field order is determined by the compiler for optimal performance.
-// however, you can still calculate a struct base pointer given a field pointer:
-fn setYBasedOnX(x: *f32, y: f32) void {
-    const point = @fieldParentPtr(Point, "x", x);
-    point.y = y;
-}
-test "field parent pointer" {
-    var point = Point {
-        .x = 0.1234,
-        .y = 0.5678,
-    };
-    setYBasedOnX(&point.x, 0.9);
-    assert(point.y == 0.9);
-}
-
-// You can return a struct from a function. This is how we do generics
-// in Zig:
-fn LinkedList(comptime T: type) type {
-    return struct {
-        pub const Node = struct {
-            prev: ?*Node,
-            next: ?*Node,
-            data: T,
-        };
-
-        first: ?*Node,
-        last:  ?*Node,
-        len:   usize,
-    };
-}
-
-test "linked list" {
-    // Functions called at compile-time are memoized. This means you can
-    // do this:
-    assert(LinkedList(i32) == LinkedList(i32));
-
-    var list = LinkedList(i32) {
-        .first = null,
-        .last = null,
-        .len = 0,
-    };
-    assert(list.len == 0);
-
-    // Since types are first class values you can instantiate the type
-    // by assigning it to a variable:
-    const ListOfInts = LinkedList(i32);
-    assert(ListOfInts == LinkedList(i32));
-
-    var node = ListOfInts.Node {
-        .prev = null,
-        .next = null,
-        .data = 1234,
-    };
-    var list2 = LinkedList(i32) {
-        .first = &node,
-        .last = &node,
-        .len = 1,
-    };
-    assert(list2.first.?.data == 1234);
-}
+		// Declare a struct.
+		// Zig gives no guarantees about the order of fields and the size of
+		// the struct but the fields are guaranteed to be ABI-aligned.
+		const Point = struct {
+		    x: f32,
+		    y: f32,
+		};
+		
+		// Maybe we want to pass it to OpenGL so we want to be particular about
+		// how the bytes are arranged.
+		const Point2 = packed struct {
+		    x: f32,
+		    y: f32,
+		};
+		
+		
+		// Declare an instance of a struct.
+		const p = Point {
+		    .x = 0.12,
+		    .y = 0.34,
+		};
+		
+		// Maybe we're not ready to fill out some of the fields.
+		var p2 = Point {
+		    .x = 0.12,
+		    .y = undefined,
+		};
+		
+		// Structs can have methods
+		// Struct methods are not special, they are only namespaced
+		// functions that you can call with dot syntax.
+		const Vec3 = struct {
+		    x: f32,
+		    y: f32,
+		    z: f32,
+		
+		    pub fn init(x: f32, y: f32, z: f32) Vec3 {
+		        return Vec3 {
+		            .x = x,
+		            .y = y,
+		            .z = z,
+		        };
+		    }
+		
+		    pub fn dot(self: Vec3, other: Vec3) f32 {
+		        return self.x * other.x + self.y * other.y + self.z * other.z;
+		    }
+		};
+		
+		const assert = @import("std").debug.assert;
+		test "dot product" {
+		    const v1 = Vec3.init(1.0, 0.0, 0.0);
+		    const v2 = Vec3.init(0.0, 1.0, 0.0);
+		    assert(v1.dot(v2) == 0.0);
+		
+		    // Other than being available to call with dot syntax, struct methods are
+		    // not special. You can reference them as any other declaration inside
+		    // the struct:
+		    assert(Vec3.dot(v1, v2) == 0.0);
+		}
+		
+		// Structs can have global declarations.
+		// Structs can have 0 fields.
+		const Empty = struct {
+		    pub const PI = 3.14;
+		};
+		test "struct namespaced variable" {
+		    assert(Empty.PI == 3.14);
+		    assert(@sizeOf(Empty) == 0);
+		
+		    // you can still instantiate an empty struct
+		    const does_nothing = Empty {};
+		}
+		
+		// struct field order is determined by the compiler for optimal performance.
+		// however, you can still calculate a struct base pointer given a field pointer:
+		fn setYBasedOnX(x: *f32, y: f32) void {
+		    const point = @fieldParentPtr(Point, "x", x);
+		    point.y = y;
+		}
+		test "field parent pointer" {
+		    var point = Point {
+		        .x = 0.1234,
+		        .y = 0.5678,
+		    };
+		    setYBasedOnX(&point.x, 0.9);
+		    assert(point.y == 0.9);
+		}
+		
+		// You can return a struct from a function. This is how we do generics
+		// in Zig:
+		fn LinkedList(comptime T: type) type {
+		    return struct {
+		        pub const Node = struct {
+		            prev: ?*Node,
+		            next: ?*Node,
+		            data: T,
+		        };
+		
+		        first: ?*Node,
+		        last:  ?*Node,
+		        len:   usize,
+		    };
+		}
+		
+		test "linked list" {
+		    // Functions called at compile-time are memoized. This means you can
+		    // do this:
+		    assert(LinkedList(i32) == LinkedList(i32));
+		
+		    var list = LinkedList(i32) {
+		        .first = null,
+		        .last = null,
+		        .len = 0,
+		    };
+		    assert(list.len == 0);
+		
+		    // Since types are first class values you can instantiate the type
+		    // by assigning it to a variable:
+		    const ListOfInts = LinkedList(i32);
+		    assert(ListOfInts == LinkedList(i32));
+		
+		    var node = ListOfInts.Node {
+		        .prev = null,
+		        .next = null,
+		        .data = 1234,
+		    };
+		    var list2 = LinkedList(i32) {
+		        .first = &node,
+		        .last = &node,
+		        .len = 1,
+		    };
+		    assert(list2.first.?.data == 1234);
+		}
       {#code_end#}
+
+
 
       {#header_open|Default Field Values#}
       <p>
@@ -2430,21 +2508,23 @@ test "linked list" {
       are executed at {#link|comptime#}, and allow the field to be omitted in a struct literal expression:
       </p>
       {#code_begin|test#}
-const Foo = struct {
-    a: i32 = 1234,
-    b: i32,
-};
-
-test "default struct initialization fields" {
-    const x = Foo{
-        .b = 5,
-    };
-    if (x.a + x.b != 1239) {
-        @compileError("it's even comptime known!");
-    }
-}
+		const Foo = struct {
+		    a: i32 = 1234,
+		    b: i32,
+		};
+		
+		test "default struct initialization fields" {
+		    const x = Foo{
+		        .b = 5,
+		    };
+		    if (x.a + x.b != 1239) {
+		        @compileError("it's even comptime known!");
+		    }
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|extern struct#}
       <p>An {#syntax#}extern struct{#endsyntax#} has in-memory layout guaranteed to match the
@@ -2453,6 +2533,8 @@ test "default struct initialization fields" {
       use case should be solved with {#link|packed struct#} or normal {#link|struct#}.</p>
       {#see_also|extern union|extern enum#}
       {#header_close#}
+
+
 
       {#header_open|packed struct#}
       <p>
@@ -2479,94 +2561,94 @@ test "default struct initialization fields" {
       This even works at {#link|comptime#}:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const builtin = std.builtin;
-const assert = std.debug.assert;
-
-const Full = packed struct {
-    number: u16,
-};
-const Divided = packed struct {
-    half1: u8,
-    quarter3: u4,
-    quarter4: u4,
-};
-
-test "@bitCast between packed structs" {
-    doTheTest();
-    comptime doTheTest();
-}
-
-fn doTheTest() void {
-    assert(@sizeOf(Full) == 2);
-    assert(@sizeOf(Divided) == 2);
-    var full = Full{ .number = 0x1234 };
-    var divided = @bitCast(Divided, full);
-    switch (builtin.endian) {
-        .Big => {
-            assert(divided.half1 == 0x12);
-            assert(divided.quarter3 == 0x3);
-            assert(divided.quarter4 == 0x4);
-        },
-        .Little => {
-            assert(divided.half1 == 0x34);
-            assert(divided.quarter3 == 0x2);
-            assert(divided.quarter4 == 0x1);
-        },
-    }
-}
+		const std = @import("std");
+		const builtin = std.builtin;
+		const assert = std.debug.assert;
+		
+		const Full = packed struct {
+		    number: u16,
+		};
+		const Divided = packed struct {
+		    half1: u8,
+		    quarter3: u4,
+		    quarter4: u4,
+		};
+		
+		test "@bitCast between packed structs" {
+		    doTheTest();
+		    comptime doTheTest();
+		}
+		
+		fn doTheTest() void {
+		    assert(@sizeOf(Full) == 2);
+		    assert(@sizeOf(Divided) == 2);
+		    var full = Full{ .number = 0x1234 };
+		    var divided = @bitCast(Divided, full);
+		    switch (builtin.endian) {
+		        .Big => {
+		            assert(divided.half1 == 0x12);
+		            assert(divided.quarter3 == 0x3);
+		            assert(divided.quarter4 == 0x4);
+		        },
+		        .Little => {
+		            assert(divided.half1 == 0x34);
+		            assert(divided.quarter3 == 0x2);
+		            assert(divided.quarter4 == 0x1);
+		        },
+		    }
+		}
       {#code_end#}
       <p>
       Zig allows the address to be taken of a non-byte-aligned field:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const BitField = packed struct {
-    a: u3,
-    b: u3,
-    c: u2,
-};
-
-var foo = BitField{
-    .a = 1,
-    .b = 2,
-    .c = 3,
-};
-
-test "pointer to non-byte-aligned field" {
-    const ptr = &foo.b;
-    assert(ptr.* == 2);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const BitField = packed struct {
+		    a: u3,
+		    b: u3,
+		    c: u2,
+		};
+		
+		var foo = BitField{
+		    .a = 1,
+		    .b = 2,
+		    .c = 3,
+		};
+		
+		test "pointer to non-byte-aligned field" {
+		    const ptr = &foo.b;
+		    assert(ptr.* == 2);
+		}
       {#code_end#}
       <p>
       However, the pointer to a non-byte-aligned field has special properties and cannot
       be passed when a normal pointer is expected:
       </p>
       {#code_begin|test_err|expected type#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const BitField = packed struct {
-    a: u3,
-    b: u3,
-    c: u2,
-};
-
-var bit_field = BitField{
-    .a = 1,
-    .b = 2,
-    .c = 3,
-};
-
-test "pointer to non-bit-aligned field" {
-    assert(bar(&bit_field.b) == 2);
-}
-
-fn bar(x: *const u3) u3 {
-    return x.*;
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const BitField = packed struct {
+		    a: u3,
+		    b: u3,
+		    c: u2,
+		};
+		
+		var bit_field = BitField{
+		    .a = 1,
+		    .b = 2,
+		    .c = 3,
+		};
+		
+		test "pointer to non-bit-aligned field" {
+		    assert(bar(&bit_field.b) == 2);
+		}
+		
+		fn bar(x: *const u3) u3 {
+		    return x.*;
+		}
       {#code_end#}
       <p>
       In this case, the function {#syntax#}bar{#endsyntax#} cannot be called becuse the pointer
@@ -2576,50 +2658,50 @@ fn bar(x: *const u3) u3 {
       Pointers to non-ABI-aligned fields share the same address as the other fields within their host integer:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const BitField = packed struct {
-    a: u3,
-    b: u3,
-    c: u2,
-};
-
-var bit_field = BitField{
-    .a = 1,
-    .b = 2,
-    .c = 3,
-};
-
-test "pointer to non-bit-aligned field" {
-    assert(@ptrToInt(&bit_field.a) == @ptrToInt(&bit_field.b));
-    assert(@ptrToInt(&bit_field.a) == @ptrToInt(&bit_field.c));
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const BitField = packed struct {
+		    a: u3,
+		    b: u3,
+		    c: u2,
+		};
+		
+		var bit_field = BitField{
+		    .a = 1,
+		    .b = 2,
+		    .c = 3,
+		};
+		
+		test "pointer to non-bit-aligned field" {
+		    assert(@ptrToInt(&bit_field.a) == @ptrToInt(&bit_field.b));
+		    assert(@ptrToInt(&bit_field.a) == @ptrToInt(&bit_field.c));
+		}
       {#code_end#}
       <p>
       This can be observed with {#link|@bitOffsetOf#} and {#link|byteOffsetOf#}:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const BitField = packed struct {
-    a: u3,
-    b: u3,
-    c: u2,
-};
-
-test "pointer to non-bit-aligned field" {
-    comptime {
-        assert(@bitOffsetOf(BitField, "a") == 0);
-        assert(@bitOffsetOf(BitField, "b") == 3);
-        assert(@bitOffsetOf(BitField, "c") == 6);
-
-        assert(@byteOffsetOf(BitField, "a") == 0);
-        assert(@byteOffsetOf(BitField, "b") == 0);
-        assert(@byteOffsetOf(BitField, "c") == 0);
-    }
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const BitField = packed struct {
+		    a: u3,
+		    b: u3,
+		    c: u2,
+		};
+		
+		test "pointer to non-bit-aligned field" {
+		    comptime {
+		        assert(@bitOffsetOf(BitField, "a") == 0);
+		        assert(@bitOffsetOf(BitField, "b") == 3);
+		        assert(@bitOffsetOf(BitField, "c") == 6);
+		
+		        assert(@byteOffsetOf(BitField, "a") == 0);
+		        assert(@byteOffsetOf(BitField, "b") == 0);
+		        assert(@byteOffsetOf(BitField, "c") == 0);
+		    }
+		}
       {#code_end#}
       <p>
       Packed structs have 1-byte alignment. However if you have an overaligned pointer to a packed struct,
@@ -2627,15 +2709,15 @@ test "pointer to non-bit-aligned field" {
       <a href="https://github.com/ziglang/zig/issues/1994">a bug</a>:
       </p>
       {#code_begin|test_err#}
-const S = packed struct {
-    a: u32,
-    b: u32,
-};
-test "overaligned pointer to packed struct" {
-    var foo: S align(4) = undefined;
-    const ptr: *align(4) S = &foo;
-    const ptr_to_b: *u32 = &ptr.b;
-}
+		const S = packed struct {
+		    a: u32,
+		    b: u32,
+		};
+		test "overaligned pointer to packed struct" {
+		    var foo: S align(4) = undefined;
+		    const ptr: *align(4) S = &foo;
+		    const ptr_to_b: *u32 = &ptr.b;
+		}
       {#code_end#}
       <p>When this bug is fixed, the above test in the documentation will unexpectedly pass, which will
       cause the test suite to fail, notifying the bug fixer to update these docs.
@@ -2654,6 +2736,8 @@ test "overaligned pointer to packed struct" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|Struct Naming#}
       <p>Since all structs are anonymous, Zig infers the type name based on a few rules.</p>
       <ul>
@@ -2664,22 +2748,24 @@ test "overaligned pointer to packed struct" {
           <li>Otherwise, the struct gets a name such as <code>(anonymous struct at file.zig:7:38)</code>.</li>
       </ul>
       {#code_begin|exe|struct_name#}
-const std = @import("std");
-
-pub fn main() void {
-    const Foo = struct {};
-    std.debug.warn("variable: {}\n", .{@typeName(Foo)});
-    std.debug.warn("anonymous: {}\n", .{@typeName(struct {})});
-    std.debug.warn("function: {}\n", .{@typeName(List(i32))});
-}
-
-fn List(comptime T: type) type {
-    return struct {
-        x: T,
-    };
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    const Foo = struct {};
+		    std.debug.warn("variable: {}\n", .{@typeName(Foo)});
+		    std.debug.warn("anonymous: {}\n", .{@typeName(struct {})});
+		    std.debug.warn("function: {}\n", .{@typeName(List(i32))});
+		}
+		
+		fn List(comptime T: type) type {
+		    return struct {
+		        x: T,
+		    };
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|Anonymous Struct Literals#}
       <p>
@@ -2687,215 +2773,225 @@ fn List(comptime T: type) type {
       the struct literal will directly instantiate the result location, with no copy:
       </p>
       {#code_begin|test|struct_result#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const Point = struct {x: i32, y: i32};
-
-test "anonymous struct literal" {
-    var pt: Point = .{
-        .x = 13,
-        .y = 67,
-    };
-    assert(pt.x == 13);
-    assert(pt.y == 67);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const Point = struct {x: i32, y: i32};
+		
+		test "anonymous struct literal" {
+		    var pt: Point = .{
+		        .x = 13,
+		        .y = 67,
+		    };
+		    assert(pt.x == 13);
+		    assert(pt.y == 67);
+		}
       {#code_end#}
       <p>
       The struct type can be inferred. Here the result location does not include a type, and
       so Zig infers the type:
       </p>
       {#code_begin|test|struct_anon#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "fully anonymous struct" {
-    dump(.{
-        .int = @as(u32, 1234),
-        .float = @as(f64, 12.34),
-        .b = true,
-        .s = "hi",
-    });
-}
-
-fn dump(args: var) void {
-    assert(args.int == 1234);
-    assert(args.float == 12.34);
-    assert(args.b);
-    assert(args.s[0] == 'h');
-    assert(args.s[1] == 'i');
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "fully anonymous struct" {
+		    dump(.{
+		        .int = @as(u32, 1234),
+		        .float = @as(f64, 12.34),
+		        .b = true,
+		        .s = "hi",
+		    });
+		}
+		
+		fn dump(args: var) void {
+		    assert(args.int == 1234);
+		    assert(args.float == 12.34);
+		    assert(args.b);
+		    assert(args.s[0] == 'h');
+		    assert(args.s[1] == 'i');
+		}
       {#code_end#}
       {#header_close#}
       {#see_also|comptime|@fieldParentPtr#}
       {#header_close#}
+
+
       {#header_open|enum#}
       {#code_begin|test|enums#}
-const assert = @import("std").debug.assert;
-const mem = @import("std").mem;
-
-// Declare an enum.
-const Type = enum {
-    Ok,
-    NotOk,
-};
-
-// Declare a specific instance of the enum variant.
-const c = Type.Ok;
-
-// If you want access to the ordinal value of an enum, you
-// can specify the tag type.
-const Value = enum(u2) {
-    Zero,
-    One,
-    Two,
-};
-
-// Now you can cast between u2 and Value.
-// The ordinal value starts from 0, counting up for each member.
-test "enum ordinal value" {
-    assert(@enumToInt(Value.Zero) == 0);
-    assert(@enumToInt(Value.One) == 1);
-    assert(@enumToInt(Value.Two) == 2);
-}
-
-// You can override the ordinal value for an enum.
-const Value2 = enum(u32) {
-    Hundred = 100,
-    Thousand = 1000,
-    Million = 1000000,
-};
-test "set enum ordinal value" {
-    assert(@enumToInt(Value2.Hundred) == 100);
-    assert(@enumToInt(Value2.Thousand) == 1000);
-    assert(@enumToInt(Value2.Million) == 1000000);
-}
-
-// Enums can have methods, the same as structs and unions.
-// Enum methods are not special, they are only namespaced
-// functions that you can call with dot syntax.
-const Suit = enum {
-    Clubs,
-    Spades,
-    Diamonds,
-    Hearts,
-
-    pub fn isClubs(self: Suit) bool {
-        return self == Suit.Clubs;
-    }
-};
-test "enum method" {
-    const p = Suit.Spades;
-    assert(!p.isClubs());
-}
-
-// An enum variant of different types can be switched upon.
-const Foo = enum {
-    String,
-    Number,
-    None,
-};
-test "enum variant switch" {
-    const p = Foo.Number;
-    const what_is_it = switch (p) {
-        Foo.String => "this is a string",
-        Foo.Number => "this is a number",
-        Foo.None => "this is a none",
-    };
-    assert(mem.eql(u8, what_is_it, "this is a number"));
-}
-
-// @TagType can be used to access the integer tag type of an enum.
-const Small = enum {
-    One,
-    Two,
-    Three,
-    Four,
-};
-test "@TagType" {
-    assert(@TagType(Small) == u2);
-}
-
-// @typeInfo tells us the field count and the fields names:
-test "@typeInfo" {
-    assert(@typeInfo(Small).Enum.fields.len == 4);
-    assert(mem.eql(u8, @typeInfo(Small).Enum.fields[1].name, "Two"));
-}
-
-// @tagName gives a []const u8 representation of an enum value:
-test "@tagName" {
-    assert(mem.eql(u8, @tagName(Small.Three), "Three"));
-}
+		const assert = @import("std").debug.assert;
+		const mem = @import("std").mem;
+		
+		// Declare an enum.
+		const Type = enum {
+		    Ok,
+		    NotOk,
+		};
+		
+		// Declare a specific instance of the enum variant.
+		const c = Type.Ok;
+		
+		// If you want access to the ordinal value of an enum, you
+		// can specify the tag type.
+		const Value = enum(u2) {
+		    Zero,
+		    One,
+		    Two,
+		};
+		
+		// Now you can cast between u2 and Value.
+		// The ordinal value starts from 0, counting up for each member.
+		test "enum ordinal value" {
+		    assert(@enumToInt(Value.Zero) == 0);
+		    assert(@enumToInt(Value.One) == 1);
+		    assert(@enumToInt(Value.Two) == 2);
+		}
+		
+		// You can override the ordinal value for an enum.
+		const Value2 = enum(u32) {
+		    Hundred = 100,
+		    Thousand = 1000,
+		    Million = 1000000,
+		};
+		test "set enum ordinal value" {
+		    assert(@enumToInt(Value2.Hundred) == 100);
+		    assert(@enumToInt(Value2.Thousand) == 1000);
+		    assert(@enumToInt(Value2.Million) == 1000000);
+		}
+		
+		// Enums can have methods, the same as structs and unions.
+		// Enum methods are not special, they are only namespaced
+		// functions that you can call with dot syntax.
+		const Suit = enum {
+		    Clubs,
+		    Spades,
+		    Diamonds,
+		    Hearts,
+		
+		    pub fn isClubs(self: Suit) bool {
+		        return self == Suit.Clubs;
+		    }
+		};
+		test "enum method" {
+		    const p = Suit.Spades;
+		    assert(!p.isClubs());
+		}
+		
+		// An enum variant of different types can be switched upon.
+		const Foo = enum {
+		    String,
+		    Number,
+		    None,
+		};
+		test "enum variant switch" {
+		    const p = Foo.Number;
+		    const what_is_it = switch (p) {
+		        Foo.String => "this is a string",
+		        Foo.Number => "this is a number",
+		        Foo.None => "this is a none",
+		    };
+		    assert(mem.eql(u8, what_is_it, "this is a number"));
+		}
+		
+		// @TagType can be used to access the integer tag type of an enum.
+		const Small = enum {
+		    One,
+		    Two,
+		    Three,
+		    Four,
+		};
+		test "@TagType" {
+		    assert(@TagType(Small) == u2);
+		}
+		
+		// @typeInfo tells us the field count and the fields names:
+		test "@typeInfo" {
+		    assert(@typeInfo(Small).Enum.fields.len == 4);
+		    assert(mem.eql(u8, @typeInfo(Small).Enum.fields[1].name, "Two"));
+		}
+		
+		// @tagName gives a []const u8 representation of an enum value:
+		test "@tagName" {
+		    assert(mem.eql(u8, @tagName(Small.Three), "Three"));
+		}
       {#code_end#}
       {#see_also|@typeInfo|@tagName|@sizeOf#}
+
+
 
       {#header_open|extern enum#}
       <p>
       By default, enums are not guaranteed to be compatible with the C ABI:
       </p>
       {#code_begin|obj_err|parameter of type 'Foo' not allowed in function with calling convention 'C'#}
-const Foo = enum { A, B, C };
-export fn entry(foo: Foo) void { }
+		const Foo = enum { A, B, C };
+		export fn entry(foo: Foo) void { }
       {#code_end#}
       <p>
       For a C-ABI-compatible enum, use {#syntax#}extern enum{#endsyntax#}:
       </p>
       {#code_begin|obj#}
-const Foo = extern enum { A, B, C };
-export fn entry(foo: Foo) void { }
+		const Foo = extern enum { A, B, C };
+		export fn entry(foo: Foo) void { }
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|packed enum#}
       <p>By default, the size of enums is not guaranteed.</p>
       <p>{#syntax#}packed enum{#endsyntax#} causes the size of the enum to be the same as the size of the
       integer tag type of the enum:</p>
       {#code_begin|test#}
-const std = @import("std");
-
-test "packed enum" {
-    const Number = packed enum(u8) {
-        One,
-        Two,
-        Three,
-    };
-    std.debug.assert(@sizeOf(Number) == @sizeOf(u8));
-}
+		const std = @import("std");
+		
+		test "packed enum" {
+		    const Number = packed enum(u8) {
+		        One,
+		        Two,
+		        Three,
+		    };
+		    std.debug.assert(@sizeOf(Number) == @sizeOf(u8));
+		}
       {#code_end#}
       <p>This makes the enum eligible to be in a {#link|packed struct#}.</p>
       {#header_close#}
+
+
 
       {#header_open|Enum Literals#}
       <p>
       Enum literals allow specifying the name of an enum field without specifying the enum type:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const Color = enum {
-    Auto,
-    Off,
-    On,
-};
-
-test "enum literals" {
-    const color1: Color = .Auto;
-    const color2 = Color.Auto;
-    assert(color1 == color2);
-}
-
-test "switch using enum literals" {
-    const color = Color.On;
-    const result = switch (color) {
-        .Auto => false,
-        .On => true,
-        .Off => false,
-    };
-    assert(result);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const Color = enum {
+		    Auto,
+		    Off,
+		    On,
+		};
+		
+		test "enum literals" {
+		    const color1: Color = .Auto;
+		    const color2 = Color.Auto;
+		    assert(color1 == color2);
+		}
+		
+		test "switch using enum literals" {
+		    const color = Color.On;
+		    const result = switch (color) {
+		        .Auto => false,
+		        .On => true,
+		        .Off => false,
+		    };
+		    assert(result);
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|Non-exhaustive enum#}
       <p>
@@ -2910,34 +3006,36 @@ test "switch using enum literals" {
       with the difference being that it makes it a compile error if all the known tag names are not handled by the switch.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const Number = enum(u8) {
-    One,
-    Two,
-    Three,
-    _,
-};
-
-test "switch on non-exhaustive enum" {
-    const number = Number.One;
-    const result = switch (number) {
-        .One => true,
-        .Two,
-        .Three => false,
-        _ => false,
-    };
-    assert(result);
-    const is_one = switch (number) {
-        .One => true,
-        else => false,
-    };
-    assert(is_one);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const Number = enum(u8) {
+		    One,
+		    Two,
+		    Three,
+		    _,
+		};
+		
+		test "switch on non-exhaustive enum" {
+		    const number = Number.One;
+		    const result = switch (number) {
+		        .One => true,
+		        .Two,
+		        .Three => false,
+		        _ => false,
+		    };
+		    assert(result);
+		    const is_one = switch (number) {
+		        .One => true,
+		        else => false,
+		    };
+		    assert(is_one);
+		}
       {#code_end#}
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|union#}
       <p>
@@ -2951,32 +3049,32 @@ test "switch on non-exhaustive enum" {
       safety-checked {#link|Undefined Behavior#}:
       </p>
       {#code_begin|test_err|inactive union field#}
-const Payload = union {
-    Int: i64,
-    Float: f64,
-    Bool: bool,
-};
-test "simple union" {
-    var payload = Payload{ .Int = 1234 };
-    payload.Float = 12.34;
-}
+		const Payload = union {
+		    Int: i64,
+		    Float: f64,
+		    Bool: bool,
+		};
+		test "simple union" {
+		    var payload = Payload{ .Int = 1234 };
+		    payload.Float = 12.34;
+		}
       {#code_end#}
       <p>You can activate another field by assigning the entire union:</p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const Payload = union {
-    Int: i64,
-    Float: f64,
-    Bool: bool,
-};
-test "simple union" {
-    var payload = Payload{ .Int = 1234 };
-    assert(payload.Int == 1234);
-    payload = Payload{ .Float = 12.34 };
-    assert(payload.Float == 12.34);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const Payload = union {
+		    Int: i64,
+		    Float: f64,
+		    Bool: bool,
+		};
+		test "simple union" {
+		    var payload = Payload{ .Int = 1234 };
+		    assert(payload.Int == 1234);
+		    payload = Payload{ .Float = 12.34 };
+		    assert(payload.Float == 12.34);
+		}
       {#code_end#}
       <p>
       In order to use {#link|switch#} with a union, it must be a {#link|Tagged union#}.
@@ -2984,6 +3082,8 @@ test "simple union" {
       <p>
       To initialize a union when the tag is a {#link|comptime#}-known name, see {#link|@unionInit#}.
       </p>
+
+
 
       {#header_open|Tagged union#}
       <p>Unions can be declared with an enum tag type.
@@ -2993,118 +3093,120 @@ test "simple union" {
       Tagged unions coerce to their tag type: {#link|Type Coercion: unions and enums#}.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const ComplexTypeTag = enum {
-    Ok,
-    NotOk,
-};
-const ComplexType = union(ComplexTypeTag) {
-    Ok: u8,
-    NotOk: void,
-};
-
-test "switch on tagged union" {
-    const c = ComplexType{ .Ok = 42 };
-    assert(@as(ComplexTypeTag, c) == ComplexTypeTag.Ok);
-
-    switch (c) {
-        ComplexTypeTag.Ok => |value| assert(value == 42),
-        ComplexTypeTag.NotOk => unreachable,
-    }
-}
-
-test "@TagType" {
-    assert(@TagType(ComplexType) == ComplexTypeTag);
-}
-
-test "coerce to enum" {
-    const c1 = ComplexType{ .Ok = 42 };
-    const c2 = ComplexType.NotOk;
-
-    assert(c1 == .Ok);
-    assert(c2 == .NotOk);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const ComplexTypeTag = enum {
+		    Ok,
+		    NotOk,
+		};
+		const ComplexType = union(ComplexTypeTag) {
+		    Ok: u8,
+		    NotOk: void,
+		};
+		
+		test "switch on tagged union" {
+		    const c = ComplexType{ .Ok = 42 };
+		    assert(@as(ComplexTypeTag, c) == ComplexTypeTag.Ok);
+		
+		    switch (c) {
+		        ComplexTypeTag.Ok => |value| assert(value == 42),
+		        ComplexTypeTag.NotOk => unreachable,
+		    }
+		}
+		
+		test "@TagType" {
+		    assert(@TagType(ComplexType) == ComplexTypeTag);
+		}
+		
+		test "coerce to enum" {
+		    const c1 = ComplexType{ .Ok = 42 };
+		    const c2 = ComplexType.NotOk;
+		
+		    assert(c1 == .Ok);
+		    assert(c2 == .NotOk);
+		}
       {#code_end#}
       <p>In order to modify the payload of a tagged union in a switch expression,
       place a {#syntax#}*{#endsyntax#} before the variable name to make it a pointer:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const ComplexTypeTag = enum {
-    Ok,
-    NotOk,
-};
-const ComplexType = union(ComplexTypeTag) {
-    Ok: u8,
-    NotOk: void,
-};
-
-test "modify tagged union in switch" {
-    var c = ComplexType{ .Ok = 42 };
-    assert(@as(ComplexTypeTag, c) == ComplexTypeTag.Ok);
-
-    switch (c) {
-        ComplexTypeTag.Ok => |*value| value.* += 1,
-        ComplexTypeTag.NotOk => unreachable,
-    }
-
-    assert(c.Ok == 43);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const ComplexTypeTag = enum {
+		    Ok,
+		    NotOk,
+		};
+		const ComplexType = union(ComplexTypeTag) {
+		    Ok: u8,
+		    NotOk: void,
+		};
+		
+		test "modify tagged union in switch" {
+		    var c = ComplexType{ .Ok = 42 };
+		    assert(@as(ComplexTypeTag, c) == ComplexTypeTag.Ok);
+		
+		    switch (c) {
+		        ComplexTypeTag.Ok => |*value| value.* += 1,
+		        ComplexTypeTag.NotOk => unreachable,
+		    }
+		
+		    assert(c.Ok == 43);
+		}
       {#code_end#}
       <p>
       Unions can be made to infer the enum tag type.
       Further, unions can have methods just like structs and enums.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const Variant = union(enum) {
-    Int: i32,
-    Bool: bool,
-
-    // void can be omitted when inferring enum tag type.
-    None,
-
-    fn truthy(self: Variant) bool {
-        return switch (self) {
-            Variant.Int => |x_int| x_int != 0,
-            Variant.Bool => |x_bool| x_bool,
-            Variant.None => false,
-        };
-    }
-};
-
-test "union method" {
-    var v1 = Variant{ .Int = 1 };
-    var v2 = Variant{ .Bool = false };
-
-    assert(v1.truthy());
-    assert(!v2.truthy());
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const Variant = union(enum) {
+		    Int: i32,
+		    Bool: bool,
+		
+		    // void can be omitted when inferring enum tag type.
+		    None,
+		
+		    fn truthy(self: Variant) bool {
+		        return switch (self) {
+		            Variant.Int => |x_int| x_int != 0,
+		            Variant.Bool => |x_bool| x_bool,
+		            Variant.None => false,
+		        };
+		    }
+		};
+		
+		test "union method" {
+		    var v1 = Variant{ .Int = 1 };
+		    var v2 = Variant{ .Bool = false };
+		
+		    assert(v1.truthy());
+		    assert(!v2.truthy());
+		}
       {#code_end#}
       <p>
       {#link|@tagName#} can be used to return a {#link|comptime#}
       {#syntax#}[]const u8{#endsyntax#} value representing the field name:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const Small2 = union(enum) {
-    A: i32,
-    B: bool,
-    C: u8,
-};
-test "@tagName" {
-    assert(std.mem.eql(u8, @tagName(Small2.C), "C"));
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const Small2 = union(enum) {
+		    A: i32,
+		    B: bool,
+		    C: u8,
+		};
+		test "@tagName" {
+		    assert(std.mem.eql(u8, @tagName(Small2.C), "C"));
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|extern union#}
       <p>
@@ -3114,165 +3216,175 @@ test "@tagName" {
       {#see_also|extern struct#}
       {#header_close#}
 
+
+
       {#header_open|packed union#}
       <p>A {#syntax#}packed union{#endsyntax#} has well-defined in-memory layout and is eligible
       to be in a {#link|packed struct#}.
       {#header_close#}
 
+
+
       {#header_open|Anonymous Union Literals#}
       <p>{#link|Anonymous Struct Literals#} syntax can be used to initialize unions without specifying
       the type:</p>
       {#code_begin|test|anon_union#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const Number = union {
-    int: i32,
-    float: f64,
-};
-
-test "anonymous union literal syntax" {
-    var i: Number = .{.int = 42};
-    var f = makeNumber();
-    assert(i.int == 42);
-    assert(f.float == 12.34);
-}
-
-fn makeNumber() Number {
-    return .{.float = 12.34};
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const Number = union {
+		    int: i32,
+		    float: f64,
+		};
+		
+		test "anonymous union literal syntax" {
+		    var i: Number = .{.int = 42};
+		    var f = makeNumber();
+		    assert(i.int == 42);
+		    assert(f.float == 12.34);
+		}
+		
+		fn makeNumber() Number {
+		    return .{.float = 12.34};
+		}
       {#code_end#}
       {#header_close#}
 
       {#header_close#}
+
+
 
       {#header_open|blocks#}
       <p>
       Blocks are used to limit the scope of variable declarations:
       </p>
       {#code_begin|test_err|undeclared identifier#}
-test "access variable after block scope" {
-    {
-        var x: i32 = 1;
-    }
-    x += 1;
-}
+		test "access variable after block scope" {
+		    {
+		        var x: i32 = 1;
+		    }
+		    x += 1;
+		}
       {#code_end#}
       <p>Blocks are expressions. When labeled, {#syntax#}break{#endsyntax#} can be used
       to return a value from the block:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "labeled break from labeled block expression" {
-    var y: i32 = 123;
-
-    const x = blk: {
-        y += 1;
-        break :blk y;
-    };
-    assert(x == 124);
-    assert(y == 124);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "labeled break from labeled block expression" {
+		    var y: i32 = 123;
+		
+		    const x = blk: {
+		        y += 1;
+		        break :blk y;
+		    };
+		    assert(x == 124);
+		    assert(y == 124);
+		}
       {#code_end#}
       <p>Here, {#syntax#}blk{#endsyntax#} can be any name.</p>
       {#see_also|Labeled while|Labeled for#}
 
+
+
       {#header_open|Shadowing#}
       <p>It is never allowed for an identifier to "hide" another one by using the same name:</p>
       {#code_begin|test_err|redefinition#}
-const pi = 3.14;
-
-test "inside test block" {
-    // Let's even go inside another block
-    {
-        var pi: i32 = 1234;
-    }
-}
+		const pi = 3.14;
+		
+		test "inside test block" {
+		    // Let's even go inside another block
+		    {
+		        var pi: i32 = 1234;
+		    }
+		}
       {#code_end#}
       <p>
       Because of this, when you read Zig code you can rely on an identifier always meaning the same thing,
       within the scope it is defined. Note that you can, however use the same name if the scopes are separate:
       </p>
       {#code_begin|test#}
-test "separate scopes" {
-    {
-        const pi = 3.14;
-    }
-    {
-        var pi: bool = true;
-    }
-}
+		test "separate scopes" {
+		    {
+		        const pi = 3.14;
+		    }
+		    {
+		        var pi: bool = true;
+		    }
+		}
       {#code_end#}
       {#header_close#}
       {#header_close#}
 
+
+
       {#header_open|switch#}
       {#code_begin|test|switch#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "switch simple" {
-    const a: u64 = 10;
-    const zz: u64 = 103;
-
-    // All branches of a switch expression must be able to be coerced to a
-    // common type.
-    //
-    // Branches cannot fallthrough. If fallthrough behavior is desired, combine
-    // the cases and use an if.
-    const b = switch (a) {
-        // Multiple cases can be combined via a ','
-        1, 2, 3 => 0,
-
-        // Ranges can be specified using the ... syntax. These are inclusive
-        // both ends.
-        5...100 => 1,
-
-        // Branches can be arbitrarily complex.
-        101 => blk: {
-            const c: u64 = 5;
-            break :blk c * 2 + 1;
-        },
-
-        // Switching on arbitrary expressions is allowed as long as the
-        // expression is known at compile-time.
-        zz => zz,
-        comptime blk: {
-            const d: u32 = 5;
-            const e: u32 = 100;
-            break :blk d + e;
-        } => 107,
-
-        // The else branch catches everything not already captured.
-        // Else branches are mandatory unless the entire range of values
-        // is handled.
-        else => 9,
-    };
-
-    assert(b == 1);
-}
-
-// Switch expressions can be used outside a function:
-const os_msg = switch (std.Target.current.os.tag) {
-    .linux => "we found a linux user",
-    else => "not a linux user",
-};
-
-// Inside a function, switch statements implicitly are compile-time
-// evaluated if the target expression is compile-time known.
-test "switch inside function" {
-    switch (std.Target.current.os.tag) {
-        .fuchsia => {
-            // On an OS other than fuchsia, block is not even analyzed,
-            // so this compile error is not triggered.
-            // On fuchsia this compile error would be triggered.
-            @compileError("fuchsia not supported");
-        },
-        else => {},
-    }
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "switch simple" {
+		    const a: u64 = 10;
+		    const zz: u64 = 103;
+		
+		    // All branches of a switch expression must be able to be coerced to a
+		    // common type.
+		    //
+		    // Branches cannot fallthrough. If fallthrough behavior is desired, combine
+		    // the cases and use an if.
+		    const b = switch (a) {
+		        // Multiple cases can be combined via a ','
+		        1, 2, 3 => 0,
+		
+		        // Ranges can be specified using the ... syntax. These are inclusive
+		        // both ends.
+		        5...100 => 1,
+		
+		        // Branches can be arbitrarily complex.
+		        101 => blk: {
+		            const c: u64 = 5;
+		            break :blk c * 2 + 1;
+		        },
+		
+		        // Switching on arbitrary expressions is allowed as long as the
+		        // expression is known at compile-time.
+		        zz => zz,
+		        comptime blk: {
+		            const d: u32 = 5;
+		            const e: u32 = 100;
+		            break :blk d + e;
+		        } => 107,
+		
+		        // The else branch catches everything not already captured.
+		        // Else branches are mandatory unless the entire range of values
+		        // is handled.
+		        else => 9,
+		    };
+		
+		    assert(b == 1);
+		}
+		
+		// Switch expressions can be used outside a function:
+		const os_msg = switch (std.Target.current.os.tag) {
+		    .linux => "we found a linux user",
+		    else => "not a linux user",
+		};
+		
+		// Inside a function, switch statements implicitly are compile-time
+		// evaluated if the target expression is compile-time known.
+		test "switch inside function" {
+		    switch (std.Target.current.os.tag) {
+		        .fuchsia => {
+		            // On an OS other than fuchsia, block is not even analyzed,
+		            // so this compile error is not triggered.
+		            // On fuchsia this compile error would be triggered.
+		            @compileError("fuchsia not supported");
+		        },
+		        else => {},
+		    }
+		}
       {#code_end#}
       <p>
       {#syntax#}switch{#endsyntax#} can be used to capture the field values
@@ -3281,44 +3393,46 @@ test "switch inside function" {
       turning it into a pointer.
       </p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "switch on tagged union" {
-    const Point = struct {
-        x: u8,
-        y: u8,
-    };
-    const Item = union(enum) {
-        A: u32,
-        C: Point,
-        D,
-        E: u32,
-    };
-
-    var a = Item{ .C = Point{ .x = 1, .y = 2 } };
-
-    // Switching on more complex enums is allowed.
-    const b = switch (a) {
-        // A capture group is allowed on a match, and will return the enum
-        // value matched. If the payload types of both cases are the same
-        // they can be put into the same switch prong.
-        Item.A, Item.E => |item| item,
-
-        // A reference to the matched value can be obtained using `*` syntax.
-        Item.C => |*item| blk: {
-            item.*.x += 1;
-            break :blk 6;
-        },
-
-        // No else is required if the types cases was exhaustively handled
-        Item.D => 8,
-    };
-
-    assert(b == 6);
-    assert(a.C.x == 2);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "switch on tagged union" {
+		    const Point = struct {
+		        x: u8,
+		        y: u8,
+		    };
+		    const Item = union(enum) {
+		        A: u32,
+		        C: Point,
+		        D,
+		        E: u32,
+		    };
+		
+		    var a = Item{ .C = Point{ .x = 1, .y = 2 } };
+		
+		    // Switching on more complex enums is allowed.
+		    const b = switch (a) {
+		        // A capture group is allowed on a match, and will return the enum
+		        // value matched. If the payload types of both cases are the same
+		        // they can be put into the same switch prong.
+		        Item.A, Item.E => |item| item,
+		
+		        // A reference to the matched value can be obtained using `*` syntax.
+		        Item.C => |*item| blk: {
+		            item.*.x += 1;
+		            break :blk 6;
+		        },
+		
+		        // No else is required if the types cases was exhaustively handled
+		        Item.D => 8,
+		    };
+		
+		    assert(b == 6);
+		    assert(a.C.x == 2);
+		}
       {#code_end#}
       {#see_also|comptime|enum|@compileError|Compile Variables#}
+
+
 
       {#header_open|Exhaustive Switching#}
       <p>
@@ -3326,21 +3440,23 @@ test "switch on tagged union" {
       it must exhaustively list all the possible values. Failure to do so is a compile error:
       </p>
       {#code_begin|test_err|not handled in switch#}
-const Color = enum {
-    Auto,
-    Off,
-    On,
-};
-
-test "exhaustive switching" {
-    const color = Color.Off;
-    switch (color) {
-        Color.Auto => {},
-        Color.On => {},
-    }
-}
+		const Color = enum {
+		    Auto,
+		    Off,
+		    On,
+		};
+		
+		test "exhaustive switching" {
+		    const color = Color.Off;
+		    switch (color) {
+		        Color.Auto => {},
+		        Color.On => {},
+		    }
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|Switching with Enum Literals#}
       <p>
@@ -3348,27 +3464,29 @@ test "exhaustive switching" {
       repetitively specifying {#link|enum#} or {#link|union#} types:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const Color = enum {
-    Auto,
-    Off,
-    On,
-};
-
-test "enum literals with switch" {
-    const color = Color.Off;
-    const result = switch (color) {
-        .Auto => false,
-        .On => false,
-        .Off => true,
-    };
-    assert(result);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const Color = enum {
+		    Auto,
+		    Off,
+		    On,
+		};
+		
+		test "enum literals with switch" {
+		    const color = Color.Off;
+		    const result = switch (color) {
+		        .Auto => false,
+		        .On => false,
+		        .Off => true,
+		    };
+		    assert(result);
+		}
       {#code_end#}
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|while#}
       <p>
@@ -3376,70 +3494,70 @@ test "enum literals with switch" {
       some condition is no longer true.
       </p>
       {#code_begin|test|while#}
-const assert = @import("std").debug.assert;
-
-test "while basic" {
-    var i: usize = 0;
-    while (i < 10) {
-        i += 1;
-    }
-    assert(i == 10);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "while basic" {
+		    var i: usize = 0;
+		    while (i < 10) {
+		        i += 1;
+		    }
+		    assert(i == 10);
+		}
       {#code_end#}
       <p>
       Use {#syntax#}break{#endsyntax#} to exit a while loop early.
       </p>
       {#code_begin|test|while#}
-const assert = @import("std").debug.assert;
-
-test "while break" {
-    var i: usize = 0;
-    while (true) {
-        if (i == 10)
-            break;
-        i += 1;
-    }
-    assert(i == 10);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "while break" {
+		    var i: usize = 0;
+		    while (true) {
+		        if (i == 10)
+		            break;
+		        i += 1;
+		    }
+		    assert(i == 10);
+		}
       {#code_end#}
       <p>
       Use {#syntax#}continue{#endsyntax#} to jump back to the beginning of the loop.
       </p>
       {#code_begin|test|while#}
-const assert = @import("std").debug.assert;
-
-test "while continue" {
-    var i: usize = 0;
-    while (true) {
-        i += 1;
-        if (i < 10)
-            continue;
-        break;
-    }
-    assert(i == 10);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "while continue" {
+		    var i: usize = 0;
+		    while (true) {
+		        i += 1;
+		        if (i < 10)
+		            continue;
+		        break;
+		    }
+		    assert(i == 10);
+		}
       {#code_end#}
       <p>
       While loops support a continue expression which is executed when the loop
       is continued. The {#syntax#}continue{#endsyntax#} keyword respects this expression.
       </p>
       {#code_begin|test|while#}
-const assert = @import("std").debug.assert;
-
-test "while loop continue expression" {
-    var i: usize = 0;
-    while (i < 10) : (i += 1) {}
-    assert(i == 10);
-}
-
-test "while loop continue expression, more complicated" {
-    var i: usize = 1;
-    var j: usize = 1;
-    while (i * j < 2000) : ({ i *= 2; j *= 3; }) {
-        const my_ij = i * j;
-        assert(my_ij < 2000);
-    }
-}
+		const assert = @import("std").debug.assert;
+		
+		test "while loop continue expression" {
+		    var i: usize = 0;
+		    while (i < 10) : (i += 1) {}
+		    assert(i == 10);
+		}
+		
+		test "while loop continue expression, more complicated" {
+		    var i: usize = 1;
+		    var j: usize = 1;
+		    while (i * j < 2000) : ({ i *= 2; j *= 3; }) {
+		        const my_ij = i * j;
+		        assert(my_ij < 2000);
+		    }
+		}
       {#code_end#}
       <p>
       While loops are expressions. The result of the expression is the
@@ -3453,44 +3571,48 @@ test "while loop continue expression, more complicated" {
       evaluated.
       </p>
       {#code_begin|test|while#}
-const assert = @import("std").debug.assert;
-
-test "while else" {
-    assert(rangeHasNumber(0, 10, 5));
-    assert(!rangeHasNumber(0, 10, 15));
-}
-
-fn rangeHasNumber(begin: usize, end: usize, number: usize) bool {
-    var i = begin;
-    return while (i < end) : (i += 1) {
-        if (i == number) {
-            break true;
-        }
-    } else false;
-}
+		const assert = @import("std").debug.assert;
+		
+		test "while else" {
+		    assert(rangeHasNumber(0, 10, 5));
+		    assert(!rangeHasNumber(0, 10, 15));
+		}
+		
+		fn rangeHasNumber(begin: usize, end: usize, number: usize) bool {
+		    var i = begin;
+		    return while (i < end) : (i += 1) {
+		        if (i == number) {
+		            break true;
+		        }
+		    } else false;
+		}
       {#code_end#}
+
+
       {#header_open|Labeled while#}
       <p>When a {#syntax#}while{#endsyntax#} loop is labeled, it can be referenced from a {#syntax#}break{#endsyntax#}
               or {#syntax#}continue{#endsyntax#} from within a nested loop:</p>
       {#code_begin|test#}
-test "nested break" {
-    outer: while (true) {
-        while (true) {
-            break :outer;
-        }
-    }
-}
-
-test "nested continue" {
-    var i: usize = 0;
-    outer: while (i < 10) : (i += 1) {
-        while (true) {
-            continue :outer;
-        }
-    }
-}
+		test "nested break" {
+		    outer: while (true) {
+		        while (true) {
+		            break :outer;
+		        }
+		    }
+		}
+		
+		test "nested continue" {
+		    var i: usize = 0;
+		    outer: while (i < 10) : (i += 1) {
+		        while (true) {
+		            continue :outer;
+		        }
+		    }
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|while with Optionals#}
       <p>
       Just like {#link|if#} expressions, while loops can take an optional as the
@@ -3506,35 +3628,37 @@ test "nested continue" {
       be executed on the first null value encountered.
       </p>
       {#code_begin|test|while#}
-const assert = @import("std").debug.assert;
-
-test "while null capture" {
-    var sum1: u32 = 0;
-    numbers_left = 3;
-    while (eventuallyNullSequence()) |value| {
-        sum1 += value;
-    }
-    assert(sum1 == 3);
-
-    var sum2: u32 = 0;
-    numbers_left = 3;
-    while (eventuallyNullSequence()) |value| {
-        sum2 += value;
-    } else {
-        assert(sum2 == 3);
-    }
-}
-
-var numbers_left: u32 = undefined;
-fn eventuallyNullSequence() ?u32 {
-    return if (numbers_left == 0) null else blk: {
-        numbers_left -= 1;
-        break :blk numbers_left;
-    };
-}
-
+		const assert = @import("std").debug.assert;
+		
+		test "while null capture" {
+		    var sum1: u32 = 0;
+		    numbers_left = 3;
+		    while (eventuallyNullSequence()) |value| {
+		        sum1 += value;
+		    }
+		    assert(sum1 == 3);
+		
+		    var sum2: u32 = 0;
+		    numbers_left = 3;
+		    while (eventuallyNullSequence()) |value| {
+		        sum2 += value;
+		    } else {
+		        assert(sum2 == 3);
+		    }
+		}
+		
+		var numbers_left: u32 = undefined;
+		fn eventuallyNullSequence() ?u32 {
+		    return if (numbers_left == 0) null else blk: {
+		        numbers_left -= 1;
+		        break :blk numbers_left;
+		    };
+		}
+		
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|while with Error Unions#}
       <p>
@@ -3548,28 +3672,30 @@ fn eventuallyNullSequence() ?u32 {
       the while condition must have an {#link|Error Union Type#}.
       </p>
       {#code_begin|test|while#}
-const assert = @import("std").debug.assert;
-
-test "while error union capture" {
-    var sum1: u32 = 0;
-    numbers_left = 3;
-    while (eventuallyErrorSequence()) |value| {
-        sum1 += value;
-    } else |err| {
-        assert(err == error.ReachedZero);
-    }
-}
-
-var numbers_left: u32 = undefined;
-
-fn eventuallyErrorSequence() anyerror!u32 {
-    return if (numbers_left == 0) error.ReachedZero else blk: {
-        numbers_left -= 1;
-        break :blk numbers_left;
-    };
-}
+		const assert = @import("std").debug.assert;
+		
+		test "while error union capture" {
+		    var sum1: u32 = 0;
+		    numbers_left = 3;
+		    while (eventuallyErrorSequence()) |value| {
+		        sum1 += value;
+		    } else |err| {
+		        assert(err == error.ReachedZero);
+		    }
+		}
+		
+		var numbers_left: u32 = undefined;
+		
+		fn eventuallyErrorSequence() anyerror!u32 {
+		    return if (numbers_left == 0) error.ReachedZero else blk: {
+		        numbers_left -= 1;
+		        break :blk numbers_left;
+		    };
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|inline while#}
       <p>
@@ -3578,26 +3704,26 @@ fn eventuallyErrorSequence() anyerror!u32 {
       such as use types as first class values.
       </p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "inline while loop" {
-    comptime var i = 0;
-    var sum: usize = 0;
-    inline while (i < 3) : (i += 1) {
-        const T = switch (i) {
-            0 => f32,
-            1 => i8,
-            2 => bool,
-            else => unreachable,
-        };
-        sum += typeNameLength(T);
-    }
-    assert(sum == 9);
-}
-
-fn typeNameLength(comptime T: type) usize {
-    return @typeName(T).len;
-}
+		const assert = @import("std").debug.assert;
+		
+		test "inline while loop" {
+		    comptime var i = 0;
+		    var sum: usize = 0;
+		    inline while (i < 3) : (i += 1) {
+		        const T = switch (i) {
+		            0 => f32,
+		            1 => i8,
+		            2 => bool,
+		            else => unreachable,
+		        };
+		        sum += typeNameLength(T);
+		    }
+		    assert(sum == 9);
+		}
+		
+		fn typeNameLength(comptime T: type) usize {
+		    return @typeName(T).len;
+		}
       {#code_end#}
       <p>
       It is recommended to use {#syntax#}inline{#endsyntax#} loops only for one of these reasons:
@@ -3611,103 +3737,109 @@ fn typeNameLength(comptime T: type) usize {
       {#header_close#}
       {#see_also|if|Optionals|Errors|comptime|unreachable#}
       {#header_close#}
+
+
       {#header_open|for#}
       {#code_begin|test|for#}
-const assert = @import("std").debug.assert;
-
-test "for basics" {
-    const items = [_]i32 { 4, 5, 3, 4, 0 };
-    var sum: i32 = 0;
-
-    // For loops iterate over slices and arrays.
-    for (items) |value| {
-        // Break and continue are supported.
-        if (value == 0) {
-            continue;
-        }
-        sum += value;
-    }
-    assert(sum == 16);
-
-    // To iterate over a portion of a slice, reslice.
-    for (items[0..1]) |value| {
-        sum += value;
-    }
-    assert(sum == 20);
-
-    // To access the index of iteration, specify a second capture value.
-    // This is zero-indexed.
-    var sum2: i32 = 0;
-    for (items) |value, i| {
-        assert(@TypeOf(i) == usize);
-        sum2 += @intCast(i32, i);
-    }
-    assert(sum2 == 10);
-}
-
-test "for reference" {
-    var items = [_]i32 { 3, 4, 2 };
-
-    // Iterate over the slice by reference by
-    // specifying that the capture value is a pointer.
-    for (items) |*value| {
-        value.* += 1;
-    }
-
-    assert(items[0] == 4);
-    assert(items[1] == 5);
-    assert(items[2] == 3);
-}
-
-test "for else" {
-    // For allows an else attached to it, the same as a while loop.
-    var items = [_]?i32 { 3, 4, null, 5 };
-
-    // For loops can also be used as expressions.
-    // Similar to while loops, when you break from a for loop, the else branch is not evaluated.
-    var sum: i32 = 0;
-    const result = for (items) |value| {
-        if (value != null) {
-            sum += value.?;
-        }
-    } else blk: {
-        assert(sum == 12);
-        break :blk sum;
-    };
-    assert(result == 12);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "for basics" {
+		    const items = [_]i32 { 4, 5, 3, 4, 0 };
+		    var sum: i32 = 0;
+		
+		    // For loops iterate over slices and arrays.
+		    for (items) |value| {
+		        // Break and continue are supported.
+		        if (value == 0) {
+		            continue;
+		        }
+		        sum += value;
+		    }
+		    assert(sum == 16);
+		
+		    // To iterate over a portion of a slice, reslice.
+		    for (items[0..1]) |value| {
+		        sum += value;
+		    }
+		    assert(sum == 20);
+		
+		    // To access the index of iteration, specify a second capture value.
+		    // This is zero-indexed.
+		    var sum2: i32 = 0;
+		    for (items) |value, i| {
+		        assert(@TypeOf(i) == usize);
+		        sum2 += @intCast(i32, i);
+		    }
+		    assert(sum2 == 10);
+		}
+		
+		test "for reference" {
+		    var items = [_]i32 { 3, 4, 2 };
+		
+		    // Iterate over the slice by reference by
+		    // specifying that the capture value is a pointer.
+		    for (items) |*value| {
+		        value.* += 1;
+		    }
+		
+		    assert(items[0] == 4);
+		    assert(items[1] == 5);
+		    assert(items[2] == 3);
+		}
+		
+		test "for else" {
+		    // For allows an else attached to it, the same as a while loop.
+		    var items = [_]?i32 { 3, 4, null, 5 };
+		
+		    // For loops can also be used as expressions.
+		    // Similar to while loops, when you break from a for loop, the else branch is not evaluated.
+		    var sum: i32 = 0;
+		    const result = for (items) |value| {
+		        if (value != null) {
+		            sum += value.?;
+		        }
+		    } else blk: {
+		        assert(sum == 12);
+		        break :blk sum;
+		    };
+		    assert(result == 12);
+		}
       {#code_end#}
+
+
       {#header_open|Labeled for#}
       <p>When a {#syntax#}for{#endsyntax#} loop is labeled, it can be referenced from a {#syntax#}break{#endsyntax#}
               or {#syntax#}continue{#endsyntax#} from within a nested loop:</p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "nested break" {
-    var count: usize = 0;
-    outer: for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
-        for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
-            count += 1;
-            break :outer;
-        }
-    }
-    assert(count == 1);
-}
-
-test "nested continue" {
-    var count: usize = 0;
-    outer: for ([_]i32{ 1, 2, 3, 4, 5, 6, 7, 8 }) |_| {
-        for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
-            count += 1;
-            continue :outer;
-        }
-    }
-
-    assert(count == 8);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "nested break" {
+		    var count: usize = 0;
+		    outer: for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
+		        for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
+		            count += 1;
+		            break :outer;
+		        }
+		    }
+		    assert(count == 1);
+		}
+		
+		test "nested continue" {
+		    var count: usize = 0;
+		    outer: for ([_]i32{ 1, 2, 3, 4, 5, 6, 7, 8 }) |_| {
+		        for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
+		            count += 1;
+		            continue :outer;
+		        }
+		    }
+		
+		    assert(count == 8);
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|inline for#}
       <p>
       For loops can be inlined. This causes the loop to be unrolled, which
@@ -3717,26 +3849,26 @@ test "nested continue" {
       compile-time known.
       </p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "inline for loop" {
-    const nums = [_]i32{2, 4, 6};
-    var sum: usize = 0;
-    inline for (nums) |i| {
-        const T = switch (i) {
-            2 => f32,
-            4 => i8,
-            6 => bool,
-            else => unreachable,
-        };
-        sum += typeNameLength(T);
-    }
-    assert(sum == 9);
-}
-
-fn typeNameLength(comptime T: type) usize {
-    return @typeName(T).len;
-}
+		const assert = @import("std").debug.assert;
+		
+		test "inline for loop" {
+		    const nums = [_]i32{2, 4, 6};
+		    var sum: usize = 0;
+		    inline for (nums) |i| {
+		        const T = switch (i) {
+		            2 => f32,
+		            4 => i8,
+		            6 => bool,
+		            else => unreachable,
+		        };
+		        sum += typeNameLength(T);
+		    }
+		    assert(sum == 9);
+		}
+		
+		fn typeNameLength(comptime T: type) usize {
+		    return @typeName(T).len;
+		}
       {#code_end#}
       <p>
       It is recommended to use {#syntax#}inline{#endsyntax#} loops only for one of these reasons:
@@ -3750,197 +3882,203 @@ fn typeNameLength(comptime T: type) usize {
       {#header_close#}
       {#see_also|while|comptime|Arrays|Slices#}
       {#header_close#}
+
+
       {#header_open|if#}
       {#code_begin|test|if#}
-// If expressions have three uses, corresponding to the three types:
-// * bool
-// * ?T
-// * anyerror!T
-
-const assert = @import("std").debug.assert;
-
-test "if expression" {
-    // If expressions are used instead of a ternary expression.
-    const a: u32 = 5;
-    const b: u32 = 4;
-    const result = if (a != b) 47 else 3089;
-    assert(result == 47);
-}
-
-test "if boolean" {
-    // If expressions test boolean conditions.
-    const a: u32 = 5;
-    const b: u32 = 4;
-    if (a != b) {
-        assert(true);
-    } else if (a == 9) {
-        unreachable;
-    } else {
-        unreachable;
-    }
-}
-
-test "if optional" {
-    // If expressions test for null.
-
-    const a: ?u32 = 0;
-    if (a) |value| {
-        assert(value == 0);
-    } else {
-        unreachable;
-    }
-
-    const b: ?u32 = null;
-    if (b) |value| {
-        unreachable;
-    } else {
-        assert(true);
-    }
-
-    // The else is not required.
-    if (a) |value| {
-        assert(value == 0);
-    }
-
-    // To test against null only, use the binary equality operator.
-    if (b == null) {
-        assert(true);
-    }
-
-    // Access the value by reference using a pointer capture.
-    var c: ?u32 = 3;
-    if (c) |*value| {
-        value.* = 2;
-    }
-
-    if (c) |value| {
-        assert(value == 2);
-    } else {
-        unreachable;
-    }
-}
-
-test "if error union" {
-    // If expressions test for errors.
-    // Note the |err| capture on the else.
-
-    const a: anyerror!u32 = 0;
-    if (a) |value| {
-        assert(value == 0);
-    } else |err| {
-        unreachable;
-    }
-
-    const b: anyerror!u32 = error.BadValue;
-    if (b) |value| {
-        unreachable;
-    } else |err| {
-        assert(err == error.BadValue);
-    }
-
-    // The else and |err| capture is strictly required.
-    if (a) |value| {
-        assert(value == 0);
-    } else |_| {}
-
-    // To check only the error value, use an empty block expression.
-    if (b) |_| {} else |err| {
-        assert(err == error.BadValue);
-    }
-
-    // Access the value by reference using a pointer capture.
-    var c: anyerror!u32 = 3;
-    if (c) |*value| {
-        value.* = 9;
-    } else |err| {
-        unreachable;
-    }
-
-    if (c) |value| {
-        assert(value == 9);
-    } else |err| {
-        unreachable;
-    }
-}
+		// If expressions have three uses, corresponding to the three types:
+		// * bool
+		// * ?T
+		// * anyerror!T
+		
+		const assert = @import("std").debug.assert;
+		
+		test "if expression" {
+		    // If expressions are used instead of a ternary expression.
+		    const a: u32 = 5;
+		    const b: u32 = 4;
+		    const result = if (a != b) 47 else 3089;
+		    assert(result == 47);
+		}
+		
+		test "if boolean" {
+		    // If expressions test boolean conditions.
+		    const a: u32 = 5;
+		    const b: u32 = 4;
+		    if (a != b) {
+		        assert(true);
+		    } else if (a == 9) {
+		        unreachable;
+		    } else {
+		        unreachable;
+		    }
+		}
+		
+		test "if optional" {
+		    // If expressions test for null.
+		
+		    const a: ?u32 = 0;
+		    if (a) |value| {
+		        assert(value == 0);
+		    } else {
+		        unreachable;
+		    }
+		
+		    const b: ?u32 = null;
+		    if (b) |value| {
+		        unreachable;
+		    } else {
+		        assert(true);
+		    }
+		
+		    // The else is not required.
+		    if (a) |value| {
+		        assert(value == 0);
+		    }
+		
+		    // To test against null only, use the binary equality operator.
+		    if (b == null) {
+		        assert(true);
+		    }
+		
+		    // Access the value by reference using a pointer capture.
+		    var c: ?u32 = 3;
+		    if (c) |*value| {
+		        value.* = 2;
+		    }
+		
+		    if (c) |value| {
+		        assert(value == 2);
+		    } else {
+		        unreachable;
+		    }
+		}
+		
+		test "if error union" {
+		    // If expressions test for errors.
+		    // Note the |err| capture on the else.
+		
+		    const a: anyerror!u32 = 0;
+		    if (a) |value| {
+		        assert(value == 0);
+		    } else |err| {
+		        unreachable;
+		    }
+		
+		    const b: anyerror!u32 = error.BadValue;
+		    if (b) |value| {
+		        unreachable;
+		    } else |err| {
+		        assert(err == error.BadValue);
+		    }
+		
+		    // The else and |err| capture is strictly required.
+		    if (a) |value| {
+		        assert(value == 0);
+		    } else |_| {}
+		
+		    // To check only the error value, use an empty block expression.
+		    if (b) |_| {} else |err| {
+		        assert(err == error.BadValue);
+		    }
+		
+		    // Access the value by reference using a pointer capture.
+		    var c: anyerror!u32 = 3;
+		    if (c) |*value| {
+		        value.* = 9;
+		    } else |err| {
+		        unreachable;
+		    }
+		
+		    if (c) |value| {
+		        assert(value == 9);
+		    } else |err| {
+		        unreachable;
+		    }
+		}
       {#code_end#}
       {#see_also|Optionals|Errors#}
       {#header_close#}
+
+
       {#header_open|defer#}
       {#code_begin|test|defer#}
-const std = @import("std");
-const assert = std.debug.assert;
-const warn = std.debug.warn;
-
-// defer will execute an expression at the end of the current scope.
-fn deferExample() usize {
-    var a: usize = 1;
-
-    {
-        defer a = 2;
-        a = 1;
-    }
-    assert(a == 2);
-
-    a = 5;
-    return a;
-}
-
-test "defer basics" {
-    assert(deferExample() == 5);
-}
-
-// If multiple defer statements are specified, they will be executed in
-// the reverse order they were run.
-fn deferUnwindExample() void {
-    warn("\n", .{});
-
-    defer {
-        warn("1 ", .{});
-    }
-    defer {
-        warn("2 ", .{});
-    }
-    if (false) {
-        // defers are not run if they are never executed.
-        defer {
-            warn("3 ", .{});
-        }
-    }
-}
-
-test "defer unwinding" {
-    deferUnwindExample();
-}
-
-// The errdefer keyword is similar to defer, but will only execute if the
-// scope returns with an error.
-//
-// This is especially useful in allowing a function to clean up properly
-// on error, and replaces goto error handling tactics as seen in c.
-fn deferErrorExample(is_error: bool) !void {
-    warn("\nstart of function\n", .{});
-
-    // This will always be executed on exit
-    defer {
-        warn("end of function\n", .{});
-    }
-
-    errdefer {
-        warn("encountered an error!\n", .{});
-    }
-
-    if (is_error) {
-        return error.DeferError;
-    }
-}
-
-test "errdefer unwinding" {
-    deferErrorExample(false) catch {};
-    deferErrorExample(true) catch {};
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		const warn = std.debug.warn;
+		
+		// defer will execute an expression at the end of the current scope.
+		fn deferExample() usize {
+		    var a: usize = 1;
+		
+		    {
+		        defer a = 2;
+		        a = 1;
+		    }
+		    assert(a == 2);
+		
+		    a = 5;
+		    return a;
+		}
+		
+		test "defer basics" {
+		    assert(deferExample() == 5);
+		}
+		
+		// If multiple defer statements are specified, they will be executed in
+		// the reverse order they were run.
+		fn deferUnwindExample() void {
+		    warn("\n", .{});
+		
+		    defer {
+		        warn("1 ", .{});
+		    }
+		    defer {
+		        warn("2 ", .{});
+		    }
+		    if (false) {
+		        // defers are not run if they are never executed.
+		        defer {
+		            warn("3 ", .{});
+		        }
+		    }
+		}
+		
+		test "defer unwinding" {
+		    deferUnwindExample();
+		}
+		
+		// The errdefer keyword is similar to defer, but will only execute if the
+		// scope returns with an error.
+		//
+		// This is especially useful in allowing a function to clean up properly
+		// on error, and replaces goto error handling tactics as seen in c.
+		fn deferErrorExample(is_error: bool) !void {
+		    warn("\nstart of function\n", .{});
+		
+		    // This will always be executed on exit
+		    defer {
+		        warn("end of function\n", .{});
+		    }
+		
+		    errdefer {
+		        warn("encountered an error!\n", .{});
+		    }
+		
+		    if (is_error) {
+		        return error.DeferError;
+		    }
+		}
+		
+		test "errdefer unwinding" {
+		    deferErrorExample(false) catch {};
+		    deferErrorExample(true) catch {};
+		}
       {#code_end#}
       {#see_also|Errors#}
       {#header_close#}
+
+
       {#header_open|unreachable#}
       <p>
       In {#syntax#}Debug{#endsyntax#} and {#syntax#}ReleaseSafe{#endsyntax#} mode, and when using <code>zig test</code>,
@@ -3951,48 +4089,54 @@ test "errdefer unwinding" {
       will never be hit to perform optimizations. However, <code>zig test</code> even in {#syntax#}ReleaseFast{#endsyntax#} mode
                   still emits {#syntax#}unreachable{#endsyntax#} as calls to {#syntax#}panic{#endsyntax#}.
       </p>
+
+
       {#header_open|Basics#}
       {#code_begin|test#}
-// unreachable is used to assert that control flow will never happen upon a
-// particular location:
-test "basic math" {
-    const x = 1;
-    const y = 2;
-    if (x + y != 3) {
-        unreachable;
-    }
-}
+		// unreachable is used to assert that control flow will never happen upon a
+		// particular location:
+		test "basic math" {
+		    const x = 1;
+		    const y = 2;
+		    if (x + y != 3) {
+		        unreachable;
+		    }
+		}
       {#code_end#}
       <p>In fact, this is how assert is implemented:</p>
       {#code_begin|test_err#}
-fn assert(ok: bool) void {
-    if (!ok) unreachable; // assertion failure
-}
-
-// This test will fail because we hit unreachable.
-test "this will fail" {
-    assert(false);
-}
+		fn assert(ok: bool) void {
+		    if (!ok) unreachable; // assertion failure
+		}
+		
+		// This test will fail because we hit unreachable.
+		test "this will fail" {
+		    assert(false);
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|At Compile-Time#}
       {#code_begin|test_err|unreachable code#}
-const assert = @import("std").debug.assert;
-
-test "type of unreachable" {
-    comptime {
-        // The type of unreachable is noreturn.
-
-        // However this assertion will still fail because
-        // evaluating unreachable at compile-time is a compile error.
-
-        assert(@TypeOf(unreachable) == noreturn);
-    }
-}
+		const assert = @import("std").debug.assert;
+		
+		test "type of unreachable" {
+		    comptime {
+		        // The type of unreachable is noreturn.
+		
+		        // However this assertion will still fail because
+		        // evaluating unreachable at compile-time is a compile error.
+		
+		        assert(@TypeOf(unreachable) == noreturn);
+		    }
+		}
       {#code_end#}
       {#see_also|Zig Test|Build Mode|comptime#}
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|noreturn#}
       <p>
       {#syntax#}noreturn{#endsyntax#} is the type of:
@@ -4008,99 +4152,103 @@ test "type of unreachable" {
               the {#syntax#}noreturn{#endsyntax#} type is compatible with every other type. Consider:
       </p>
       {#code_begin|test#}
-fn foo(condition: bool, b: u32) void {
-    const a = if (condition) b else return;
-    @panic("do something with a");
-}
-test "noreturn" {
-    foo(false, 1);
-}
+		fn foo(condition: bool, b: u32) void {
+		    const a = if (condition) b else return;
+		    @panic("do something with a");
+		}
+		test "noreturn" {
+		    foo(false, 1);
+		}
       {#code_end#}
       <p>Another use case for {#syntax#}noreturn{#endsyntax#} is the {#syntax#}exit{#endsyntax#} function:</p>
       {#code_begin|test#}
-      {#target_windows#}
-pub extern "kernel32" fn ExitProcess(exit_code: c_uint) callconv(.Stdcall) noreturn;
-
-test "foo" {
-    const value = bar() catch ExitProcess(1);
-    assert(value == 1234);
-}
-
-fn bar() anyerror!u32 {
-    return 1234;
-}
-
-const assert = @import("std").debug.assert;
+		      {#target_windows#}
+		pub extern "kernel32" fn ExitProcess(exit_code: c_uint) callconv(.Stdcall) noreturn;
+		
+		test "foo" {
+		    const value = bar() catch ExitProcess(1);
+		    assert(value == 1234);
+		}
+		
+		fn bar() anyerror!u32 {
+		    return 1234;
+		}
+		
+		const assert = @import("std").debug.assert;
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Functions#}
       {#code_begin|test|functions#}
-const assert = @import("std").debug.assert;
-
-// Functions are declared like this
-fn add(a: i8, b: i8) i8 {
-    if (a == 0) {
-        return b;
-    }
-
-    return a + b;
-}
-
-// The export specifier makes a function externally visible in the generated
-// object file, and makes it use the C ABI.
-export fn sub(a: i8, b: i8) i8 { return a - b; }
-
-// The extern specifier is used to declare a function that will be resolved
-// at link time, when linking statically, or at runtime, when linking
-// dynamically.
-// The callconv specifier changes the calling convention of the function.
-extern "kernel32" fn ExitProcess(exit_code: u32) callconv(.Stdcall) noreturn;
-extern "c" fn atan2(a: f64, b: f64) f64;
-
-// The @setCold builtin tells the optimizer that a function is rarely called.
-fn abort() noreturn {
-    @setCold(true);
-    while (true) {}
-}
-
-// The naked calling convention makes a function not have any function prologue or epilogue.
-// This can be useful when integrating with assembly.
-fn _start() callconv(.Naked) noreturn {
-    abort();
-}
-
-// The inline specifier forces a function to be inlined at all call sites.
-// If the function cannot be inlined, it is a compile-time error.
-inline fn shiftLeftOne(a: u32) u32 {
-    return a << 1;
-}
-
-// The pub specifier allows the function to be visible when importing.
-// Another file can use @import and call sub2
-pub fn sub2(a: i8, b: i8) i8 { return a - b; }
-
-// Functions can be used as values and are equivalent to pointers.
-const call2_op = fn (a: i8, b: i8) i8;
-fn do_op(fn_call: call2_op, op1: i8, op2: i8) i8 {
-    return fn_call(op1, op2);
-}
-
-test "function" {
-    assert(do_op(add, 5, 6) == 11);
-    assert(do_op(sub2, 5, 6) == -1);
-}
+		const assert = @import("std").debug.assert;
+		
+		// Functions are declared like this
+		fn add(a: i8, b: i8) i8 {
+		    if (a == 0) {
+		        return b;
+		    }
+		
+		    return a + b;
+		}
+		
+		// The export specifier makes a function externally visible in the generated
+		// object file, and makes it use the C ABI.
+		export fn sub(a: i8, b: i8) i8 { return a - b; }
+		
+		// The extern specifier is used to declare a function that will be resolved
+		// at link time, when linking statically, or at runtime, when linking
+		// dynamically.
+		// The callconv specifier changes the calling convention of the function.
+		extern "kernel32" fn ExitProcess(exit_code: u32) callconv(.Stdcall) noreturn;
+		extern "c" fn atan2(a: f64, b: f64) f64;
+		
+		// The @setCold builtin tells the optimizer that a function is rarely called.
+		fn abort() noreturn {
+		    @setCold(true);
+		    while (true) {}
+		}
+		
+		// The naked calling convention makes a function not have any function prologue or epilogue.
+		// This can be useful when integrating with assembly.
+		fn _start() callconv(.Naked) noreturn {
+		    abort();
+		}
+		
+		// The inline specifier forces a function to be inlined at all call sites.
+		// If the function cannot be inlined, it is a compile-time error.
+		inline fn shiftLeftOne(a: u32) u32 {
+		    return a << 1;
+		}
+		
+		// The pub specifier allows the function to be visible when importing.
+		// Another file can use @import and call sub2
+		pub fn sub2(a: i8, b: i8) i8 { return a - b; }
+		
+		// Functions can be used as values and are equivalent to pointers.
+		const call2_op = fn (a: i8, b: i8) i8;
+		fn do_op(fn_call: call2_op, op1: i8, op2: i8) i8 {
+		    return fn_call(op1, op2);
+		}
+		
+		test "function" {
+		    assert(do_op(add, 5, 6) == 11);
+		    assert(do_op(sub2, 5, 6) == -1);
+		}
       {#code_end#}
       <p>Function values are like pointers:</p>
       {#code_begin|obj#}
-const assert = @import("std").debug.assert;
-
-comptime {
-    assert(@TypeOf(foo) == fn()void);
-    assert(@sizeOf(fn()void) == @sizeOf(?fn()void));
-}
-
-fn foo() void { }
+		const assert = @import("std").debug.assert;
+		
+		comptime {
+		    assert(@TypeOf(foo) == fn()void);
+		    assert(@sizeOf(fn()void) == @sizeOf(?fn()void));
+		}
+		
+		fn foo() void { }
       {#code_end#}
+
+
       {#header_open|Pass-by-value Parameters#}
       <p>
       Primitive types such as {#link|Integers#} and {#link|Floats#} passed as parameters
@@ -4115,29 +4263,31 @@ fn foo() void { }
       Zig decides will be faster. This is made possible, in part, by the fact that parameters are immutable.
       </p>
       {#code_begin|test#}
-const Point = struct {
-    x: i32,
-    y: i32,
-};
-
-fn foo(point: Point) i32 {
-    // Here, `point` could be a reference, or a copy. The function body
-    // can ignore the difference and treat it as a value. Be very careful
-    // taking the address of the parameter - it should be treated as if
-    // the address will become invalid when the function returns.
-    return point.x + point.y;
-}
-
-const assert = @import("std").debug.assert;
-
-test "pass struct to function" {
-    assert(foo(Point{ .x = 1, .y = 2 }) == 3);
-}
+		const Point = struct {
+		    x: i32,
+		    y: i32,
+		};
+		
+		fn foo(point: Point) i32 {
+		    // Here, `point` could be a reference, or a copy. The function body
+		    // can ignore the difference and treat it as a value. Be very careful
+		    // taking the address of the parameter - it should be treated as if
+		    // the address will become invalid when the function returns.
+		    return point.x + point.y;
+		}
+		
+		const assert = @import("std").debug.assert;
+		
+		test "pass struct to function" {
+		    assert(foo(Point{ .x = 1, .y = 2 }) == 3);
+		}
       {#code_end#}
       <p>
       For extern functions, Zig follows the C ABI for passing structs and unions by value.
       </p>
       {#header_close#}
+
+
       {#header_open|Function Parameter Type Inference#}
       <p>
       Function parameters can be declared with {#syntax#}var{#endsyntax#} in place of the type.
@@ -4145,34 +4295,40 @@ test "pass struct to function" {
       Use {#link|@TypeOf#} and {#link|@typeInfo#} to get information about the inferred type.
       </p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-fn addFortyTwo(x: var) @TypeOf(x) {
-    return x + 42;
-}
-
-test "fn type inference" {
-    assert(addFortyTwo(1) == 43);
-    assert(@TypeOf(addFortyTwo(1)) == comptime_int);
-    var y: i64 = 2;
-    assert(addFortyTwo(y) == 44);
-    assert(@TypeOf(addFortyTwo(y)) == i64);
-}
+		const assert = @import("std").debug.assert;
+		
+		fn addFortyTwo(x: var) @TypeOf(x) {
+		    return x + 42;
+		}
+		
+		test "fn type inference" {
+		    assert(addFortyTwo(1) == 43);
+		    assert(@TypeOf(addFortyTwo(1)) == comptime_int);
+		    var y: i64 = 2;
+		    assert(addFortyTwo(y) == 44);
+		    assert(@TypeOf(addFortyTwo(y)) == i64);
+		}
       {#code_end#}
 
       {#header_close#}
+
+
       {#header_open|Function Reflection#}
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "fn reflection" {
-    assert(@TypeOf(assert).ReturnType == void);
-    assert(@TypeOf(assert).is_var_args == false);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "fn reflection" {
+		    assert(@TypeOf(assert).ReturnType == void);
+		    assert(@TypeOf(assert).is_var_args == false);
+		}
       {#code_end#}
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Errors#}
+
+
       {#header_open|Error Set Type#}
       <p>
       An error set is like an {#link|enum#}.
@@ -4188,62 +4344,64 @@ test "fn reflection" {
       You can {#link|coerce|Type Coercion#} an error from a subset to a superset:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-
-const FileOpenError = error {
-    AccessDenied,
-    OutOfMemory,
-    FileNotFound,
-};
-
-const AllocationError = error {
-    OutOfMemory,
-};
-
-test "coerce subset to superset" {
-    const err = foo(AllocationError.OutOfMemory);
-    std.debug.assert(err == FileOpenError.OutOfMemory);
-}
-
-fn foo(err: AllocationError) FileOpenError {
-    return err;
-}
+		const std = @import("std");
+		
+		const FileOpenError = error {
+		    AccessDenied,
+		    OutOfMemory,
+		    FileNotFound,
+		};
+		
+		const AllocationError = error {
+		    OutOfMemory,
+		};
+		
+		test "coerce subset to superset" {
+		    const err = foo(AllocationError.OutOfMemory);
+		    std.debug.assert(err == FileOpenError.OutOfMemory);
+		}
+		
+		fn foo(err: AllocationError) FileOpenError {
+		    return err;
+		}
       {#code_end#}
       <p>
       But you cannot {#link|coerce|Type Coercion#} an error from a superset to a subset:
       </p>
       {#code_begin|test_err|not a member of destination error set#}
-const FileOpenError = error {
-    AccessDenied,
-    OutOfMemory,
-    FileNotFound,
-};
-
-const AllocationError = error {
-    OutOfMemory,
-};
-
-test "coerce superset to subset" {
-    foo(FileOpenError.OutOfMemory) catch {};
-}
-
-fn foo(err: FileOpenError) AllocationError {
-    return err;
-}
+		const FileOpenError = error {
+		    AccessDenied,
+		    OutOfMemory,
+		    FileNotFound,
+		};
+		
+		const AllocationError = error {
+		    OutOfMemory,
+		};
+		
+		test "coerce superset to subset" {
+		    foo(FileOpenError.OutOfMemory) catch {};
+		}
+		
+		fn foo(err: FileOpenError) AllocationError {
+		    return err;
+		}
       {#code_end#}
       <p>
       There is a shortcut for declaring an error set with only 1 value, and then getting that value:
       </p>
       {#code_begin|syntax#}
-const err = error.FileNotFound;
+		const err = error.FileNotFound;
       {#code_end#}
       <p>This is equivalent to:</p>
       {#code_begin|syntax#}
-const err = (error {FileNotFound}).FileNotFound;
+		const err = (error {FileNotFound}).FileNotFound;
       {#code_end#}
       <p>
       This becomes useful when using {#link|Inferred Error Sets#}.
       </p>
+
+
       {#header_open|The Global Error Set#}
       <p>{#syntax#}anyerror{#endsyntax#} refers to the global error set.
       This is the error set that contains all errors in the entire compilation unit.
@@ -4262,6 +4420,8 @@ const err = (error {FileNotFound}).FileNotFound;
       </p>
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Error Union Type#}
       <p>
       An error set type and normal type can be combined with the {#syntax#}!{#endsyntax#}
@@ -4272,46 +4432,46 @@ const err = (error {FileNotFound}).FileNotFound;
       Here is a function to parse a string into a 64-bit integer:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const maxInt = std.math.maxInt;
-
-pub fn parseU64(buf: []const u8, radix: u8) !u64 {
-    var x: u64 = 0;
-
-    for (buf) |c| {
-        const digit = charToDigit(c);
-
-        if (digit >= radix) {
-            return error.InvalidChar;
-        }
-
-        // x *= radix
-        if (@mulWithOverflow(u64, x, radix, &x)) {
-            return error.Overflow;
-        }
-
-        // x += digit
-        if (@addWithOverflow(u64, x, digit, &x)) {
-            return error.Overflow;
-        }
-    }
-
-    return x;
-}
-
-fn charToDigit(c: u8) u8 {
-    return switch (c) {
-        '0' ... '9' => c - '0',
-        'A' ... 'Z' => c - 'A' + 10,
-        'a' ... 'z' => c - 'a' + 10,
-        else => maxInt(u8),
-    };
-}
-
-test "parse u64" {
-    const result = try parseU64("1234", 10);
-    std.debug.assert(result == 1234);
-}
+		const std = @import("std");
+		const maxInt = std.math.maxInt;
+		
+		pub fn parseU64(buf: []const u8, radix: u8) !u64 {
+		    var x: u64 = 0;
+		
+		    for (buf) |c| {
+		        const digit = charToDigit(c);
+		
+		        if (digit >= radix) {
+		            return error.InvalidChar;
+		        }
+		
+		        // x *= radix
+		        if (@mulWithOverflow(u64, x, radix, &x)) {
+		            return error.Overflow;
+		        }
+		
+		        // x += digit
+		        if (@addWithOverflow(u64, x, digit, &x)) {
+		            return error.Overflow;
+		        }
+		    }
+		
+		    return x;
+		}
+		
+		fn charToDigit(c: u8) u8 {
+		    return switch (c) {
+		        '0' ... '9' => c - '0',
+		        'A' ... 'Z' => c - 'A' + 10,
+		        'a' ... 'z' => c - 'a' + 10,
+		        else => maxInt(u8),
+		    };
+		}
+		
+		test "parse u64" {
+		    const result = try parseU64("1234", 10);
+		    std.debug.assert(result == 1234);
+		}
       {#code_end#}
       <p>
       Notice the return type is {#syntax#}!u64{#endsyntax#}. This means that the function
@@ -4333,13 +4493,15 @@ test "parse u64" {
         <li>You know with complete certainty it will not return an error, so want to unconditionally unwrap it.</li>
         <li>You want to take a different action for each possible error.</li>
       </ul>
+
+
       {#header_open|catch#}
       <p>If you want to provide a default value, you can use the {#syntax#}catch{#endsyntax#} binary operator:</p>
       {#code_begin|syntax#}
-fn doAThing(str: []u8) void {
-    const number = parseU64(str, 10) catch 13;
-    // ...
-}
+		fn doAThing(str: []u8) void {
+		    const number = parseU64(str, 10) catch 13;
+		    // ...
+		}
       {#code_end#}
       <p>
       In this code, {#syntax#}number{#endsyntax#} will be equal to the successfully parsed string, or
@@ -4347,23 +4509,25 @@ fn doAThing(str: []u8) void {
               match the unwrapped error union type, or be of type {#syntax#}noreturn{#endsyntax#}.
       </p>
       {#header_close#}
+
+
       {#header_open|try#}
       <p>Let's say you wanted to return the error if you got one, otherwise continue with the
       function logic:</p>
       {#code_begin|syntax#}
-fn doAThing(str: []u8) !void {
-    const number = parseU64(str, 10) catch |err| return err;
-    // ...
-}
+		fn doAThing(str: []u8) !void {
+		    const number = parseU64(str, 10) catch |err| return err;
+		    // ...
+		}
       {#code_end#}
       <p>
       There is a shortcut for this. The {#syntax#}try{#endsyntax#} expression:
       </p>
       {#code_begin|syntax#}
-fn doAThing(str: []u8) !void {
-    const number = try parseU64(str, 10);
-    // ...
-}
+		fn doAThing(str: []u8) !void {
+		    const number = try parseU64(str, 10);
+		    // ...
+		}
       {#code_end#}
       <p>
       {#syntax#}try{#endsyntax#} evaluates an error union expression. If it is an error, it returns
@@ -4376,30 +4540,32 @@ fn doAThing(str: []u8) !void {
         In this case you can do this:
       </p>
       {#code_begin|syntax#}const number = parseU64("1234", 10) catch unreachable;{#code_end#}
-      <p>
-      Here we know for sure that "1234" will parse successfully. So we put the
-      {#syntax#}unreachable{#endsyntax#} value on the right hand side. {#syntax#}unreachable{#endsyntax#} generates
-      a panic in Debug and ReleaseSafe modes and undefined behavior in ReleaseFast mode. So, while we're debugging the
-      application, if there <em>was</em> a surprise error here, the application would crash
-      appropriately.
-      </p>
-      <p>
-      Finally, you may want to take a different action for every situation. For that, we combine
-      the {#link|if#} and {#link|switch#} expression:
-      </p>
-      {#code_begin|syntax#}
-fn doAThing(str: []u8) void {
-    if (parseU64(str, 10)) |number| {
-        doSomethingWithNumber(number);
-    } else |err| switch (err) {
-        error.Overflow => {
-            // handle overflow...
-        },
-        // we promise that InvalidChar won't happen (or crash in debug mode if it does)
-        error.InvalidChar => unreachable,
-    }
-}
+		      <p>
+		      Here we know for sure that "1234" will parse successfully. So we put the
+		      {#syntax#}unreachable{#endsyntax#} value on the right hand side. {#syntax#}unreachable{#endsyntax#} generates
+		      a panic in Debug and ReleaseSafe modes and undefined behavior in ReleaseFast mode. So, while we're debugging the
+		      application, if there <em>was</em> a surprise error here, the application would crash
+		      appropriately.
+		      </p>
+		      <p>
+		      Finally, you may want to take a different action for every situation. For that, we combine
+		      the {#link|if#} and {#link|switch#} expression:
+		      </p>
+		      {#code_begin|syntax#}
+		fn doAThing(str: []u8) void {
+		    if (parseU64(str, 10)) |number| {
+		        doSomethingWithNumber(number);
+		    } else |err| switch (err) {
+		        error.Overflow => {
+		            // handle overflow...
+		        },
+		        // we promise that InvalidChar won't happen (or crash in debug mode if it does)
+		        error.InvalidChar => unreachable,
+		    }
+		}
       {#code_end#}
+
+
       {#header_open|errdefer#}
       <p>
       The other component to error handling is defer statements.
@@ -4411,23 +4577,23 @@ fn doAThing(str: []u8) void {
       Example:
       </p>
       {#code_begin|syntax#}
-fn createFoo(param: i32) !Foo {
-    const foo = try tryToAllocateFoo();
-    // now we have allocated foo. we need to free it if the function fails.
-    // but we want to return it if the function succeeds.
-    errdefer deallocateFoo(foo);
-
-    const tmp_buf = allocateTmpBuffer() orelse return error.OutOfMemory;
-    // tmp_buf is truly a temporary resource, and we for sure want to clean it up
-    // before this block leaves scope
-    defer deallocateTmpBuffer(tmp_buf);
-
-    if (param > 1337) return error.InvalidParam;
-
-    // here the errdefer will not run since we're returning success from the function.
-    // but the defer will run!
-    return foo;
-}
+		fn createFoo(param: i32) !Foo {
+		    const foo = try tryToAllocateFoo();
+		    // now we have allocated foo. we need to free it if the function fails.
+		    // but we want to return it if the function succeeds.
+		    errdefer deallocateFoo(foo);
+		
+		    const tmp_buf = allocateTmpBuffer() orelse return error.OutOfMemory;
+		    // tmp_buf is truly a temporary resource, and we for sure want to clean it up
+		    // before this block leaves scope
+		    defer deallocateTmpBuffer(tmp_buf);
+		
+		    if (param > 1337) return error.InvalidParam;
+		
+		    // here the errdefer will not run since we're returning success from the function.
+		    // but the defer will run!
+		    return foo;
+		}
       {#code_end#}
       <p>
       The neat thing about this is that you get robust error handling without
@@ -4455,24 +4621,26 @@ fn createFoo(param: i32) !Foo {
       <p>An error union is created with the {#syntax#}!{#endsyntax#} binary operator.
       You can use compile-time reflection to access the child type of an error union:</p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "error union" {
-    var foo: anyerror!i32 = undefined;
-
-    // Coerce from child type of an error union:
-    foo = 1234;
-
-    // Coerce from an error set:
-    foo = error.SomeError;
-
-    // Use compile-time reflection to access the payload type of an error union:
-    comptime assert(@TypeOf(foo).Payload == i32);
-
-    // Use compile-time reflection to access the error set type of an error union:
-    comptime assert(@TypeOf(foo).ErrorSet == anyerror);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "error union" {
+		    var foo: anyerror!i32 = undefined;
+		
+		    // Coerce from child type of an error union:
+		    foo = 1234;
+		
+		    // Coerce from an error set:
+		    foo = error.SomeError;
+		
+		    // Use compile-time reflection to access the payload type of an error union:
+		    comptime assert(@TypeOf(foo).Payload == i32);
+		
+		    // Use compile-time reflection to access the error set type of an error union:
+		    comptime assert(@TypeOf(foo).ErrorSet == anyerror);
+		}
       {#code_end#}
+
+
       {#header_open|Merging Error Sets#}
       <p>
       Use the {#syntax#}||{#endsyntax#} operator to merge two error sets together. The resulting
@@ -4487,65 +4655,67 @@ test "error union" {
       files.
       </p>
       {#code_begin|test#}
-const A = error{
-    NotDir,
-
-    /// A doc comment
-    PathNotFound,
-};
-const B = error{
-    OutOfMemory,
-
-    /// B doc comment
-    PathNotFound,
-};
-
-const C = A || B;
-
-fn foo() C!void {
-    return error.NotDir;
-}
-
-test "merge error sets" {
-    if (foo()) {
-        @panic("unexpected");
-    } else |err| switch (err) {
-        error.OutOfMemory => @panic("unexpected"),
-        error.PathNotFound => @panic("unexpected"),
-        error.NotDir => {},
-    }
-}
+		const A = error{
+		    NotDir,
+		
+		    /// A doc comment
+		    PathNotFound,
+		};
+		const B = error{
+		    OutOfMemory,
+		
+		    /// B doc comment
+		    PathNotFound,
+		};
+		
+		const C = A || B;
+		
+		fn foo() C!void {
+		    return error.NotDir;
+		}
+		
+		test "merge error sets" {
+		    if (foo()) {
+		        @panic("unexpected");
+		    } else |err| switch (err) {
+		        error.OutOfMemory => @panic("unexpected"),
+		        error.PathNotFound => @panic("unexpected"),
+		        error.NotDir => {},
+		    }
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Inferred Error Sets#}
       <p>
       Because many functions in Zig return a possible error, Zig supports inferring the error set.
       To infer the error set for a function, use this syntax:
       </p>
 {#code_begin|test#}
-// With an inferred error set
-pub fn add_inferred(comptime T: type, a: T, b: T) !T {
-    var answer: T = undefined;
-    return if (@addWithOverflow(T, a, b, &answer)) error.Overflow else answer;
-}
-
-// With an explicit error set
-pub fn add_explicit(comptime T: type, a: T, b: T) Error!T {
-    var answer: T = undefined;
-    return if (@addWithOverflow(T, a, b, &answer)) error.Overflow else answer;
-}
-
-const Error = error {
-    Overflow,
-};
-
-const std = @import("std");
-
-test "inferred error set" {
-    if (add_inferred(u8, 255, 1)) |_| unreachable else |err| switch (err) {
-        error.Overflow => {}, // ok
-    }
-}
+		// With an inferred error set
+		pub fn add_inferred(comptime T: type, a: T, b: T) !T {
+		    var answer: T = undefined;
+		    return if (@addWithOverflow(T, a, b, &answer)) error.Overflow else answer;
+		}
+		
+		// With an explicit error set
+		pub fn add_explicit(comptime T: type, a: T, b: T) Error!T {
+		    var answer: T = undefined;
+		    return if (@addWithOverflow(T, a, b, &answer)) error.Overflow else answer;
+		}
+		
+		const Error = error {
+		    Overflow,
+		};
+		
+		const std = @import("std");
+		
+		test "inferred error set" {
+		    if (add_inferred(u8, 255, 1)) |_| unreachable else |err| switch (err) {
+		        error.Overflow => {}, // ok
+		    }
+		}
 {#code_end#}
       <p>
       When a function has an inferred error set, that function becomes generic and thus it becomes
@@ -4562,55 +4732,57 @@ test "inferred error set" {
       </p>
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Error Return Traces#}
       <p>
       Error Return Traces show all the points in the code that an error was returned to the calling function. This makes it practical to use {#link|try#} everywhere and then still be able to know what happened if an error ends up bubbling all the way out of your application.
       </p>
       {#code_begin|exe_err#}
-pub fn main() !void {
-    try foo(12);
-}
-
-fn foo(x: i32) !void {
-    if (x >= 5) {
-        try bar();
-    } else {
-        try bang2();
-    }
-}
-
-fn bar() !void {
-    if (baz()) {
-        try quux();
-    } else |err| switch (err) {
-        error.FileNotFound => try hello(),
-        else => try another(),
-    }
-}
-
-fn baz() !void {
-    try bang1();
-}
-
-fn quux() !void {
-    try bang2();
-}
-
-fn hello() !void {
-    try bang2();
-}
-
-fn another() !void {
-    try bang1();
-}
-
-fn bang1() !void {
-    return error.FileNotFound;
-}
-
-fn bang2() !void {
-    return error.PermissionDenied;
-}
+		pub fn main() !void {
+		    try foo(12);
+		}
+		
+		fn foo(x: i32) !void {
+		    if (x >= 5) {
+		        try bar();
+		    } else {
+		        try bang2();
+		    }
+		}
+		
+		fn bar() !void {
+		    if (baz()) {
+		        try quux();
+		    } else |err| switch (err) {
+		        error.FileNotFound => try hello(),
+		        else => try another(),
+		    }
+		}
+		
+		fn baz() !void {
+		    try bang1();
+		}
+		
+		fn quux() !void {
+		    try bang2();
+		}
+		
+		fn hello() !void {
+		    try bang2();
+		}
+		
+		fn another() !void {
+		    try bang1();
+		}
+		
+		fn bang1() !void {
+		    return error.FileNotFound;
+		}
+		
+		fn bang2() !void {
+		    return error.PermissionDenied;
+		}
       {#code_end#}
       <p>
       Look closely at this example. This is no stack trace.
@@ -4621,45 +4793,45 @@ fn bang2() !void {
       and then returns another one, from the switch statement. Error Return Traces make this clear, whereas a stack trace would look like this:
       </p>
       {#code_begin|exe_err#}
-pub fn main() void {
-    foo(12);
-}
-
-fn foo(x: i32) void {
-    if (x >= 5) {
-        bar();
-    } else {
-        bang2();
-    }
-}
-
-fn bar() void {
-    if (baz()) {
-        quux();
-    } else {
-        hello();
-    }
-}
-
-fn baz() bool {
-    return bang1();
-}
-
-fn quux() void {
-    bang2();
-}
-
-fn hello() void {
-    bang2();
-}
-
-fn bang1() bool {
-    return false;
-}
-
-fn bang2() void {
-    @panic("PermissionDenied");
-}
+		pub fn main() void {
+		    foo(12);
+		}
+		
+		fn foo(x: i32) void {
+		    if (x >= 5) {
+		        bar();
+		    } else {
+		        bang2();
+		    }
+		}
+		
+		fn bar() void {
+		    if (baz()) {
+		        quux();
+		    } else {
+		        hello();
+		    }
+		}
+		
+		fn baz() bool {
+		    return bang1();
+		}
+		
+		fn quux() void {
+		    bang2();
+		}
+		
+		fn hello() void {
+		    bang2();
+		}
+		
+		fn bang1() bool {
+		    return false;
+		}
+		
+		fn bang2() void {
+		    @panic("PermissionDenied");
+		}
       {#code_end#}
       <p>
       Here, the stack trace does not explain how the control
@@ -4685,6 +4857,8 @@ fn bang2() void {
         <li>An error makes its way to {#syntax#}catch unreachable{#endsyntax#} and you have not overridden the default panic handler</li>
         <li>Use {#link|errorReturnTrace#} to access the current return trace. You can use {#syntax#}std.debug.dumpStackTrace{#endsyntax#} to print it. This function returns comptime-known {#link|null#} when building without error return tracing support.</li>
       </ul>
+
+
       {#header_open|Implementation Details#}
       <p>
       To analyze performance cost, there are two cases:
@@ -4698,10 +4872,10 @@ fn bang2() void {
       This is to initialize this struct in the stack memory:
       </p>
       {#code_begin|syntax#}
-pub const StackTrace = struct {
-    index: usize,
-    instruction_addresses: [N]usize,
-};
+		pub const StackTrace = struct {
+		    index: usize,
+		    instruction_addresses: [N]usize,
+		};
       {#code_end#}
       <p>
       Here, N is the maximum function call depth as determined by call graph analysis. Recursion is ignored and counts for 2.
@@ -4716,11 +4890,11 @@ pub const StackTrace = struct {
       When generating the code for a function that returns an error, just before the {#syntax#}return{#endsyntax#} statement (only for the {#syntax#}return{#endsyntax#} statements that return errors), Zig generates a call to this function:
       </p>
       {#code_begin|syntax#}
-// marked as "no-inline" in LLVM IR
-fn __zig_return_error(stack_trace: *StackTrace) void {
-    stack_trace.instruction_addresses[stack_trace.index] = @returnAddress();
-    stack_trace.index = (stack_trace.index + 1) % N;
-}
+		// marked as "no-inline" in LLVM IR
+		fn __zig_return_error(stack_trace: *StackTrace) void {
+		    stack_trace.instruction_addresses[stack_trace.index] = @returnAddress();
+		    stack_trace.index = (stack_trace.index + 1) % N;
+		}
       {#code_end#}
       <p>
       The cost is 2 math operations plus some memory reads and writes. The memory accessed is constrained and should remain cached for the duration of the error return bubbling.
@@ -4733,6 +4907,8 @@ fn __zig_return_error(stack_trace: *StackTrace) void {
       {#header_close#}
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Optionals#}
       <p>
       One area that Zig provides safety without compromising efficiency or
@@ -4743,11 +4919,11 @@ fn __zig_return_error(stack_trace: *StackTrace) void {
       type by putting a question mark in front of it, like this:
       </p>
       {#code_begin|syntax#}
-// normal integer
-const normal_int: i32 = 1234;
-
-// optional integer
-const optional_int: ?i32 = 5678;
+		// normal integer
+		const normal_int: i32 = 1234;
+		
+		// optional integer
+		const optional_int: ?i32 = 5678;
       {#code_end#}
       <p>
       Now the variable {#syntax#}optional_int{#endsyntax#} could be an {#syntax#}i32{#endsyntax#}, or {#syntax#}null{#endsyntax#}.
@@ -4781,13 +4957,13 @@ struct Foo *do_a_thing(void) {
 }</code></pre>
       <p>Zig code</p>
       {#code_begin|syntax#}
-// malloc prototype included for reference
-extern fn malloc(size: size_t) ?*u8;
-
-fn doAThing() ?*Foo {
-    const ptr = malloc(1234) orelse return null;
-    // ...
-}
+		// malloc prototype included for reference
+		extern fn malloc(size: size_t) ?*u8;
+		
+		fn doAThing() ?*Foo {
+		    const ptr = malloc(1234) orelse return null;
+		    // ...
+		}
       {#code_end#}
       <p>
         Here, Zig is at least as convenient, if not more, than C. And, the type of "ptr"
@@ -4811,15 +4987,15 @@ fn doAThing() ?*Foo {
         In Zig you can accomplish the same thing:
       </p>
       {#code_begin|syntax#}
-fn doAThing(optional_foo: ?*Foo) void {
-    // do some stuff
-
-    if (optional_foo) |foo| {
-      doSomethingWithFoo(foo);
-    }
-
-    // do some stuff
-}
+		fn doAThing(optional_foo: ?*Foo) void {
+		    // do some stuff
+		
+		    if (optional_foo) |foo| {
+		      doSomethingWithFoo(foo);
+		    }
+		
+		    // do some stuff
+		}
       {#code_end#}
       <p>
       Once again, the notable thing here is that inside the if block,
@@ -4833,56 +5009,64 @@ fn doAThing(optional_foo: ?*Foo) void {
       The optimizer can sometimes make better decisions knowing that pointer arguments
       cannot be null.
       </p>
+
+
       {#header_open|Optional Type#}
       <p>An optional is created by putting {#syntax#}?{#endsyntax#} in front of a type. You can use compile-time
       reflection to access the child type of an optional:</p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "optional type" {
-    // Declare an optional and coerce from null:
-    var foo: ?i32 = null;
-
-    // Coerce from child type of an optional
-    foo = 1234;
-
-    // Use compile-time reflection to access the child type of the optional:
-    comptime assert(@TypeOf(foo).Child == i32);
-}
+		const assert = @import("std").debug.assert;
+		
+		test "optional type" {
+		    // Declare an optional and coerce from null:
+		    var foo: ?i32 = null;
+		
+		    // Coerce from child type of an optional
+		    foo = 1234;
+		
+		    // Use compile-time reflection to access the child type of the optional:
+		    comptime assert(@TypeOf(foo).Child == i32);
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|null#}
       <p>
       Just like {#link|undefined#}, {#syntax#}null{#endsyntax#} has its own type, and the only way to use it is to
       cast it to a different type:
       </p>
       {#code_begin|syntax#}
-const optional_value: ?i32 = null;
+		const optional_value: ?i32 = null;
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Optional Pointers#}
       <p>An optional pointer is guaranteed to be the same size as a pointer. The {#syntax#}null{#endsyntax#} of
       the optional is guaranteed to be address 0.</p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-test "optional pointers" {
-    // Pointers cannot be null. If you want a null pointer, use the optional
-    // prefix `?` to make the pointer type optional.
-    var ptr: ?*i32 = null;
-
-    var x: i32 = 1;
-    ptr = &x;
-
-    assert(ptr.?.* == 1);
-
-    // Optional pointers are the same size as normal pointers, because pointer
-    // value 0 is used as the null value.
-    assert(@sizeOf(?*i32) == @sizeOf(*i32));
-}
+		const assert = @import("std").debug.assert;
+		
+		test "optional pointers" {
+		    // Pointers cannot be null. If you want a null pointer, use the optional
+		    // prefix `?` to make the pointer type optional.
+		    var ptr: ?*i32 = null;
+		
+		    var x: i32 = 1;
+		    ptr = &x;
+		
+		    assert(ptr.?.* == 1);
+		
+		    // Optional pointers are the same size as normal pointers, because pointer
+		    // value 0 is used as the null value.
+		    assert(@sizeOf(?*i32) == @sizeOf(*i32));
+		}
       {#code_end#}
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Casting#}
       <p>
       A <strong>type cast</strong> converts a value of one type to another.
@@ -4891,32 +5075,36 @@ test "optional pointers" {
       There is also a third kind of type conversion called {#link|Peer Type Resolution#} for
       the case when a result type must be decided given multiple operand types.
       </p>
+
+
       {#header_open|Type Coercion#}
       <p>
       Type coercion occurs when one type is expected, but different type is provided:
       </p>
       {#code_begin|test#}
-test "type coercion - variable declaration" {
-    var a: u8 = 1;
-    var b: u16 = a;
-}
-
-test "type coercion - function call" {
-    var a: u8 = 1;
-    foo(a);
-}
-
-fn foo(b: u16) void {}
-
-test "type coercion - @as builtin" {
-    var a: u8 = 1;
-    var b = @as(u16, a);
-}
+		test "type coercion - variable declaration" {
+		    var a: u8 = 1;
+		    var b: u16 = a;
+		}
+		
+		test "type coercion - function call" {
+		    var a: u8 = 1;
+		    foo(a);
+		}
+		
+		fn foo(b: u16) void {}
+		
+		test "type coercion - @as builtin" {
+		    var a: u8 = 1;
+		    var b = @as(u16, a);
+		}
       {#code_end#}
       <p>
       Type coercions are only allowed when it is completely unambiguous how to get from one type to another,
       and the transformation is guaranteed to be safe. There is one exception, which is {#link|C Pointers#}.
       </p>
+
+
       {#header_open|Type Coercion: Stricter Qualification#}
       <p>
       Values which have the same representation at runtime can be cast to increase the strictness
@@ -4932,255 +5120,273 @@ test "type coercion - @as builtin" {
       These casts are no-ops at runtime since the value representation does not change.
       </p>
       {#code_begin|test#}
-test "type coercion - const qualification" {
-    var a: i32 = 1;
-    var b: *i32 = &a;
-    foo(b);
-}
-
-fn foo(a: *const i32) void {}
+		test "type coercion - const qualification" {
+		    var a: i32 = 1;
+		    var b: *i32 = &a;
+		    foo(b);
+		}
+		
+		fn foo(a: *const i32) void {}
       {#code_end#}
       <p>
       In addition, pointers coerce to const optional pointers:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-const mem = std.mem;
-
-test "cast *[1][*]const u8 to [*]const ?[*]const u8" {
-    const window_name = [1][*]const u8{"window name"};
-    const x: [*]const ?[*]const u8 = &window_name;
-    assert(mem.eql(u8, std.mem.spanZ(@ptrCast([*:0]const u8, x[0].?)), "window name"));
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		const mem = std.mem;
+		
+		test "cast *[1][*]const u8 to [*]const ?[*]const u8" {
+		    const window_name = [1][*]const u8{"window name"};
+		    const x: [*]const ?[*]const u8 = &window_name;
+		    assert(mem.eql(u8, std.mem.spanZ(@ptrCast([*:0]const u8, x[0].?)), "window name"));
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Type Coercion: Integer and Float Widening#}
       <p>
       {#link|Integers#} coerce to integer types which can represent every value of the old type, and likewise
       {#link|Floats#} coerce to float types which can represent every value of the old type.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-const mem = std.mem;
-
-test "integer widening" {
-    var a: u8 = 250;
-    var b: u16 = a;
-    var c: u32 = b;
-    var d: u64 = c;
-    var e: u64 = d;
-    var f: u128 = e;
-    assert(f == a);
-}
-
-test "implicit unsigned integer to signed integer" {
-    var a: u8 = 250;
-    var b: i16 = a;
-    assert(b == 250);
-}
-
-test "float widening" {
-    // Note: there is an open issue preventing this from working on aarch64:
-    // https://github.com/ziglang/zig/issues/3282
-    if (std.Target.current.cpu.arch == .aarch64) return error.SkipZigTest;
-
-    var a: f16 = 12.34;
-    var b: f32 = a;
-    var c: f64 = b;
-    var d: f128 = c;
-    assert(d == a);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		const mem = std.mem;
+		
+		test "integer widening" {
+		    var a: u8 = 250;
+		    var b: u16 = a;
+		    var c: u32 = b;
+		    var d: u64 = c;
+		    var e: u64 = d;
+		    var f: u128 = e;
+		    assert(f == a);
+		}
+		
+		test "implicit unsigned integer to signed integer" {
+		    var a: u8 = 250;
+		    var b: i16 = a;
+		    assert(b == 250);
+		}
+		
+		test "float widening" {
+		    // Note: there is an open issue preventing this from working on aarch64:
+		    // https://github.com/ziglang/zig/issues/3282
+		    if (std.Target.current.cpu.arch == .aarch64) return error.SkipZigTest;
+		
+		    var a: f16 = 12.34;
+		    var b: f32 = a;
+		    var c: f64 = b;
+		    var d: f128 = c;
+		    assert(d == a);
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Type Coercion: Arrays and Pointers#}
       {#code_begin|test|coerce_arrays_and_ptrs#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-// This cast exists primarily so that string literals can be
-// passed to functions that accept const slices. However
-// it is probably going to be removed from the language when
-// https://github.com/ziglang/zig/issues/265 is implemented.
-test "[N]T to []const T" {
-    var x1: []const u8 = "hello";
-    var x2: []const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
-    assert(std.mem.eql(u8, x1, x2));
-
-    var y: []const f32 = &[2]f32{ 1.2, 3.4 };
-    assert(y[0] == 1.2);
-}
-
-// Likewise, it works when the destination type is an error union.
-test "[N]T to E![]const T" {
-    var x1: anyerror![]const u8 = "hello";
-    var x2: anyerror![]const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
-    assert(std.mem.eql(u8, try x1, try x2));
-
-    var y: anyerror![]const f32 = &[2]f32{ 1.2, 3.4 };
-    assert((try y)[0] == 1.2);
-}
-
-// Likewise, it works when the destination type is an optional.
-test "[N]T to ?[]const T" {
-    var x1: ?[]const u8 = "hello";
-    var x2: ?[]const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
-    assert(std.mem.eql(u8, x1.?, x2.?));
-
-    var y: ?[]const f32 = &[2]f32{ 1.2, 3.4 };
-    assert(y.?[0] == 1.2);
-}
-
-// In this cast, the array length becomes the slice length.
-test "*[N]T to []T" {
-    var buf: [5]u8 = "hello".*;
-    const x: []u8 = &buf;
-    assert(std.mem.eql(u8, x, "hello"));
-
-    const buf2 = [2]f32{ 1.2, 3.4 };
-    const x2: []const f32 = &buf2;
-    assert(std.mem.eql(f32, x2, &[2]f32{ 1.2, 3.4 }));
-}
-
-// Single-item pointers to arrays can be coerced to
-// unknown length pointers.
-test "*[N]T to [*]T" {
-    var buf: [5]u8 = "hello".*;
-    const x: [*]u8 = &buf;
-    assert(x[4] == 'o');
-    // x[5] would be an uncaught out of bounds pointer dereference!
-}
-
-// Likewise, it works when the destination type is an optional.
-test "*[N]T to ?[*]T" {
-    var buf: [5]u8 = "hello".*;
-    const x: ?[*]u8 = &buf;
-    assert(x.?[4] == 'o');
-}
-
-// Single-item pointers can be cast to len-1 single-item arrays.
-test "*T to *[1]T" {
-    var x: i32 = 1234;
-    const y: *[1]i32 = &x;
-    const z: [*]i32 = y;
-    assert(z[0] == 1234);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		// This cast exists primarily so that string literals can be
+		// passed to functions that accept const slices. However
+		// it is probably going to be removed from the language when
+		// https://github.com/ziglang/zig/issues/265 is implemented.
+		test "[N]T to []const T" {
+		    var x1: []const u8 = "hello";
+		    var x2: []const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
+		    assert(std.mem.eql(u8, x1, x2));
+		
+		    var y: []const f32 = &[2]f32{ 1.2, 3.4 };
+		    assert(y[0] == 1.2);
+		}
+		
+		// Likewise, it works when the destination type is an error union.
+		test "[N]T to E![]const T" {
+		    var x1: anyerror![]const u8 = "hello";
+		    var x2: anyerror![]const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
+		    assert(std.mem.eql(u8, try x1, try x2));
+		
+		    var y: anyerror![]const f32 = &[2]f32{ 1.2, 3.4 };
+		    assert((try y)[0] == 1.2);
+		}
+		
+		// Likewise, it works when the destination type is an optional.
+		test "[N]T to ?[]const T" {
+		    var x1: ?[]const u8 = "hello";
+		    var x2: ?[]const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
+		    assert(std.mem.eql(u8, x1.?, x2.?));
+		
+		    var y: ?[]const f32 = &[2]f32{ 1.2, 3.4 };
+		    assert(y.?[0] == 1.2);
+		}
+		
+		// In this cast, the array length becomes the slice length.
+		test "*[N]T to []T" {
+		    var buf: [5]u8 = "hello".*;
+		    const x: []u8 = &buf;
+		    assert(std.mem.eql(u8, x, "hello"));
+		
+		    const buf2 = [2]f32{ 1.2, 3.4 };
+		    const x2: []const f32 = &buf2;
+		    assert(std.mem.eql(f32, x2, &[2]f32{ 1.2, 3.4 }));
+		}
+		
+		// Single-item pointers to arrays can be coerced to
+		// unknown length pointers.
+		test "*[N]T to [*]T" {
+		    var buf: [5]u8 = "hello".*;
+		    const x: [*]u8 = &buf;
+		    assert(x[4] == 'o');
+		    // x[5] would be an uncaught out of bounds pointer dereference!
+		}
+		
+		// Likewise, it works when the destination type is an optional.
+		test "*[N]T to ?[*]T" {
+		    var buf: [5]u8 = "hello".*;
+		    const x: ?[*]u8 = &buf;
+		    assert(x.?[4] == 'o');
+		}
+		
+		// Single-item pointers can be cast to len-1 single-item arrays.
+		test "*T to *[1]T" {
+		    var x: i32 = 1234;
+		    const y: *[1]i32 = &x;
+		    const z: [*]i32 = y;
+		    assert(z[0] == 1234);
+		}
       {#code_end#}
       {#see_also|C Pointers#}
       {#header_close#}
+
+
       {#header_open|Type Coercion: Optionals#}
       <p>
       The payload type of {#link|Optionals#}, as well as {#link|null#}, coerce to the optional type.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "coerce to optionals" {
-    const x: ?i32 = 1234;
-    const y: ?i32 = null;
-
-    assert(x.? == 1234);
-    assert(y == null);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "coerce to optionals" {
+		    const x: ?i32 = 1234;
+		    const y: ?i32 = null;
+		
+		    assert(x.? == 1234);
+		    assert(y == null);
+		}
       {#code_end#}
       <p>It works nested inside the {#link|Error Union Type#}, too:</p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "coerce to optionals wrapped in error union" {
-    const x: anyerror!?i32 = 1234;
-    const y: anyerror!?i32 = null;
-
-    assert((try x).? == 1234);
-    assert((try y) == null);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "coerce to optionals wrapped in error union" {
+		    const x: anyerror!?i32 = 1234;
+		    const y: anyerror!?i32 = null;
+		
+		    assert((try x).? == 1234);
+		    assert((try y) == null);
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Type Coercion: Error Unions#}
       <p>The payload type of an {#link|Error Union Type#} as well as the {#link|Error Set Type#}
       coerce to the error union type:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "coercion to error unions" {
-    const x: anyerror!i32 = 1234;
-    const y: anyerror!i32 = error.Failure;
-
-    assert((try x) == 1234);
-    std.testing.expectError(error.Failure, y);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "coercion to error unions" {
+		    const x: anyerror!i32 = 1234;
+		    const y: anyerror!i32 = error.Failure;
+		
+		    assert((try x) == 1234);
+		    std.testing.expectError(error.Failure, y);
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Type Coercion: Compile-Time Known Numbers#}
       <p>When a number is {#link|comptime#}-known to be representable in the destination type,
       it may be coerced:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "coercing large integer type to smaller one when value is comptime known to fit" {
-    const x: u64 = 255;
-    const y: u8 = x;
-    assert(y == 255);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "coercing large integer type to smaller one when value is comptime known to fit" {
+		    const x: u64 = 255;
+		    const y: u8 = x;
+		    assert(y == 255);
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Type Coercion: unions and enums#}
       <p>Tagged unions can be coerced to enums, and enums can be coerced to tagged unions
       when they are {#link|comptime#}-known to be a field of the union that has only one possible value, such as
       {#link|void#}:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const E = enum {
-    One,
-    Two,
-    Three,
-};
-
-const U = union(E) {
-    One: i32,
-    Two: f32,
-    Three,
-};
-
-test "coercion between unions and enums" {
-    var u = U{ .Two = 12.34 };
-    var e: E = u;
-    assert(e == E.Two);
-
-    const three = E.Three;
-    var another_u: U = three;
-    assert(another_u == E.Three);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const E = enum {
+		    One,
+		    Two,
+		    Three,
+		};
+		
+		const U = union(E) {
+		    One: i32,
+		    Two: f32,
+		    Three,
+		};
+		
+		test "coercion between unions and enums" {
+		    var u = U{ .Two = 12.34 };
+		    var e: E = u;
+		    assert(e == E.Two);
+		
+		    const three = E.Three;
+		    var another_u: U = three;
+		    assert(another_u == E.Three);
+		}
       {#code_end#}
       {#see_also|union|enum#}
       {#header_close#}
+
+
       {#header_open|Type Coercion: Zero Bit Types#}
       <p>{#link|Zero Bit Types#} may be coerced to single-item {#link|Pointers#},
       regardless of const.</p>
       <p>TODO document the reasoning for this</p>
       <p>TODO document whether vice versa should work and why</p>
       {#code_begin|test#}
-test "coercion of zero bit types" {
-    var x: void = {};
-    var y: *void = x;
-    //var z: void = y; // TODO
-}
+		test "coercion of zero bit types" {
+		    var x: void = {};
+		    var y: *void = x;
+		    //var z: void = y; // TODO
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Type Coercion: undefined#}
       <p>{#link|undefined#} can be cast to any type.</p>
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|Explicit Casts#}
       <p>
@@ -5209,6 +5415,8 @@ test "coercion of zero bit types" {
       </ul>
       {#header_close#}
 
+
+
       {#header_open|Peer Type Resolution#}
       <p>Peer Type Resolution occurs in these places:</p>
       <ul>
@@ -5224,101 +5432,103 @@ test "coercion of zero bit types" {
       some examples:
       </p>
       {#code_begin|test|peer_type_resolution#}
-const std = @import("std");
-const assert = std.debug.assert;
-const mem = std.mem;
-
-test "peer resolve int widening" {
-    var a: i8 = 12;
-    var b: i16 = 34;
-    var c = a + b;
-    assert(c == 46);
-    assert(@TypeOf(c) == i16);
-}
-
-test "peer resolve arrays of different size to const slice" {
-    assert(mem.eql(u8, boolToStr(true), "true"));
-    assert(mem.eql(u8, boolToStr(false), "false"));
-    comptime assert(mem.eql(u8, boolToStr(true), "true"));
-    comptime assert(mem.eql(u8, boolToStr(false), "false"));
-}
-fn boolToStr(b: bool) []const u8 {
-    return if (b) "true" else "false";
-}
-
-test "peer resolve array and const slice" {
-    testPeerResolveArrayConstSlice(true);
-    comptime testPeerResolveArrayConstSlice(true);
-}
-fn testPeerResolveArrayConstSlice(b: bool) void {
-    const value1 = if (b) "aoeu" else @as([]const u8, "zz");
-    const value2 = if (b) @as([]const u8, "zz") else "aoeu";
-    assert(mem.eql(u8, value1, "aoeu"));
-    assert(mem.eql(u8, value2, "zz"));
-}
-
-test "peer type resolution: ?T and T" {
-    assert(peerTypeTAndOptionalT(true, false).? == 0);
-    assert(peerTypeTAndOptionalT(false, false).? == 3);
-    comptime {
-        assert(peerTypeTAndOptionalT(true, false).? == 0);
-        assert(peerTypeTAndOptionalT(false, false).? == 3);
-    }
-}
-fn peerTypeTAndOptionalT(c: bool, b: bool) ?usize {
-    if (c) {
-        return if (b) null else @as(usize, 0);
-    }
-
-    return @as(usize, 3);
-}
-
-test "peer type resolution: *[0]u8 and []const u8" {
-    assert(peerTypeEmptyArrayAndSlice(true, "hi").len == 0);
-    assert(peerTypeEmptyArrayAndSlice(false, "hi").len == 1);
-    comptime {
-        assert(peerTypeEmptyArrayAndSlice(true, "hi").len == 0);
-        assert(peerTypeEmptyArrayAndSlice(false, "hi").len == 1);
-    }
-}
-fn peerTypeEmptyArrayAndSlice(a: bool, slice: []const u8) []const u8 {
-    if (a) {
-        return &[_]u8{};
-    }
-
-    return slice[0..1];
-}
-test "peer type resolution: *[0]u8, []const u8, and anyerror![]u8" {
-    {
-        var data = "hi".*;
-        const slice = data[0..];
-        assert((try peerTypeEmptyArrayAndSliceAndError(true, slice)).len == 0);
-        assert((try peerTypeEmptyArrayAndSliceAndError(false, slice)).len == 1);
-    }
-    comptime {
-        var data = "hi".*;
-        const slice = data[0..];
-        assert((try peerTypeEmptyArrayAndSliceAndError(true, slice)).len == 0);
-        assert((try peerTypeEmptyArrayAndSliceAndError(false, slice)).len == 1);
-    }
-}
-fn peerTypeEmptyArrayAndSliceAndError(a: bool, slice: []u8) anyerror![]u8 {
-    if (a) {
-        return &[_]u8{};
-    }
-
-    return slice[0..1];
-}
-
-test "peer type resolution: *const T and ?*T" {
-    const a = @intToPtr(*const usize, 0x123456780);
-    const b = @intToPtr(?*usize, 0x123456780);
-    assert(a == b);
-    assert(b == a);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		const mem = std.mem;
+		
+		test "peer resolve int widening" {
+		    var a: i8 = 12;
+		    var b: i16 = 34;
+		    var c = a + b;
+		    assert(c == 46);
+		    assert(@TypeOf(c) == i16);
+		}
+		
+		test "peer resolve arrays of different size to const slice" {
+		    assert(mem.eql(u8, boolToStr(true), "true"));
+		    assert(mem.eql(u8, boolToStr(false), "false"));
+		    comptime assert(mem.eql(u8, boolToStr(true), "true"));
+		    comptime assert(mem.eql(u8, boolToStr(false), "false"));
+		}
+		fn boolToStr(b: bool) []const u8 {
+		    return if (b) "true" else "false";
+		}
+		
+		test "peer resolve array and const slice" {
+		    testPeerResolveArrayConstSlice(true);
+		    comptime testPeerResolveArrayConstSlice(true);
+		}
+		fn testPeerResolveArrayConstSlice(b: bool) void {
+		    const value1 = if (b) "aoeu" else @as([]const u8, "zz");
+		    const value2 = if (b) @as([]const u8, "zz") else "aoeu";
+		    assert(mem.eql(u8, value1, "aoeu"));
+		    assert(mem.eql(u8, value2, "zz"));
+		}
+		
+		test "peer type resolution: ?T and T" {
+		    assert(peerTypeTAndOptionalT(true, false).? == 0);
+		    assert(peerTypeTAndOptionalT(false, false).? == 3);
+		    comptime {
+		        assert(peerTypeTAndOptionalT(true, false).? == 0);
+		        assert(peerTypeTAndOptionalT(false, false).? == 3);
+		    }
+		}
+		fn peerTypeTAndOptionalT(c: bool, b: bool) ?usize {
+		    if (c) {
+		        return if (b) null else @as(usize, 0);
+		    }
+		
+		    return @as(usize, 3);
+		}
+		
+		test "peer type resolution: *[0]u8 and []const u8" {
+		    assert(peerTypeEmptyArrayAndSlice(true, "hi").len == 0);
+		    assert(peerTypeEmptyArrayAndSlice(false, "hi").len == 1);
+		    comptime {
+		        assert(peerTypeEmptyArrayAndSlice(true, "hi").len == 0);
+		        assert(peerTypeEmptyArrayAndSlice(false, "hi").len == 1);
+		    }
+		}
+		fn peerTypeEmptyArrayAndSlice(a: bool, slice: []const u8) []const u8 {
+		    if (a) {
+		        return &[_]u8{};
+		    }
+		
+		    return slice[0..1];
+		}
+		test "peer type resolution: *[0]u8, []const u8, and anyerror![]u8" {
+		    {
+		        var data = "hi".*;
+		        const slice = data[0..];
+		        assert((try peerTypeEmptyArrayAndSliceAndError(true, slice)).len == 0);
+		        assert((try peerTypeEmptyArrayAndSliceAndError(false, slice)).len == 1);
+		    }
+		    comptime {
+		        var data = "hi".*;
+		        const slice = data[0..];
+		        assert((try peerTypeEmptyArrayAndSliceAndError(true, slice)).len == 0);
+		        assert((try peerTypeEmptyArrayAndSliceAndError(false, slice)).len == 1);
+		    }
+		}
+		fn peerTypeEmptyArrayAndSliceAndError(a: bool, slice: []u8) anyerror![]u8 {
+		    if (a) {
+		        return &[_]u8{};
+		    }
+		
+		    return slice[0..1];
+		}
+		
+		test "peer type resolution: *const T and ?*T" {
+		    const a = @intToPtr(*const usize, 0x123456780);
+		    const b = @intToPtr(?*usize, 0x123456780);
+		    assert(a == b);
+		    assert(b == a);
+		}
       {#code_end#}
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|Zero Bit Types#}
       <p>For some types, {#link|@sizeOf#} is 0:</p>
@@ -5337,11 +5547,11 @@ test "peer type resolution: *const T and ?*T" {
       not included in the final generated code:
       </p>
       {#code_begin|syntax#}
-export fn entry() void {
-    var x: void = {};
-    var y: void = {};
-    x = y;
-}
+		export fn entry() void {
+		    var x: void = {};
+		    var y: void = {};
+		    x = y;
+		}
       {#code_end#}
       <p>When this turns into machine code, there is no code generated in the
       body of {#syntax#}entry{#endsyntax#}, even in {#link|Debug#} mode. For example, on x86_64:</p>
@@ -5353,6 +5563,8 @@ export fn entry() void {
       <p>These assembly instructions do not have any code associated with the void values -
       they only perform the function call prologue and epilog.</p>
 
+
+
       {#header_open|void#}
       <p>
       {#syntax#}void{#endsyntax#} can be useful for instantiating generic types. For example, given a
@@ -5360,30 +5572,30 @@ export fn entry() void {
                       type to make it into a {#syntax#}Set{#endsyntax#}:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "turn HashMap into a set with void" {
-    var map = std.HashMap(i32, void, hash_i32, eql_i32).init(std.testing.allocator);
-    defer map.deinit();
-
-    _ = try map.put(1, {});
-    _ = try map.put(2, {});
-
-    assert(map.contains(2));
-    assert(!map.contains(3));
-
-    _ = map.remove(2);
-    assert(!map.contains(2));
-}
-
-fn hash_i32(x: i32) u32 {
-    return @bitCast(u32, x);
-}
-
-fn eql_i32(a: i32, b: i32) bool {
-    return a == b;
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "turn HashMap into a set with void" {
+		    var map = std.HashMap(i32, void, hash_i32, eql_i32).init(std.testing.allocator);
+		    defer map.deinit();
+		
+		    _ = try map.put(1, {});
+		    _ = try map.put(2, {});
+		
+		    assert(map.contains(2));
+		    assert(!map.contains(3));
+		
+		    _ = map.remove(2);
+		    assert(!map.contains(2));
+		}
+		
+		fn hash_i32(x: i32) u32 {
+		    return @bitCast(u32, x);
+		}
+		
+		fn eql_i32(a: i32, b: i32) bool {
+		    return a == b;
+		}
       {#code_end#}
       <p>Note that this is different from using a dummy value for the hash map value.
       By using {#syntax#}void{#endsyntax#} as the type of the value, the hash map entry type has no value field, and
@@ -5399,63 +5611,67 @@ fn eql_i32(a: i32, b: i32) bool {
       Expressions of type {#syntax#}void{#endsyntax#} are the only ones whose value can be ignored. For example:
       </p>
       {#code_begin|test_err|expression value is ignored#}
-test "ignoring expression value" {
-    foo();
-}
-
-fn foo() i32 {
-    return 1234;
-}
+		test "ignoring expression value" {
+		    foo();
+		}
+		
+		fn foo() i32 {
+		    return 1234;
+		}
       {#code_end#}
       <p>However, if the expression has type {#syntax#}void{#endsyntax#}, there will be no error. Function return values can also be explicitly ignored by assigning them to {#syntax#}_{#endsyntax#}. </p>
       {#code_begin|test#}
-test "void is ignored" {
-    returnsVoid();
-}
-
-test "explicitly ignoring expression value" {
-    _ = foo();
-}
-
-fn returnsVoid() void {}
-
-fn foo() i32 {
-    return 1234;
-}
+		test "void is ignored" {
+		    returnsVoid();
+		}
+		
+		test "explicitly ignoring expression value" {
+		    _ = foo();
+		}
+		
+		fn returnsVoid() void {}
+		
+		fn foo() i32 {
+		    return 1234;
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|Pointers to Zero Bit Types#}
       <p>Pointers to zero bit types also have zero bits. They always compare equal to each other:</p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "pointer to empty struct" {
-    const Empty = struct {};
-    var a = Empty{};
-    var b = Empty{};
-    var ptr_a = &a;
-    var ptr_b = &b;
-    comptime assert(ptr_a == ptr_b);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "pointer to empty struct" {
+		    const Empty = struct {};
+		    var a = Empty{};
+		    var b = Empty{};
+		    var ptr_a = &a;
+		    var ptr_b = &b;
+		    comptime assert(ptr_a == ptr_b);
+		}
       {#code_end#}
       <p>The type being pointed to can only ever be one value; therefore loads and stores are
       never generated. {#link|ptrToInt#} and {#link|intToPtr#} are not allowed:</p>
       {#code_begin|test_err#}
-const Empty = struct {};
-
-test "@ptrToInt for pointer to zero bit type" {
-    var a = Empty{};
-    _ = @ptrToInt(&a);
-}
-
-test "@intToPtr for pointer to zero bit type" {
-    _ = @intToPtr(*Empty, 0x1);
-}
+		const Empty = struct {};
+		
+		test "@ptrToInt for pointer to zero bit type" {
+		    var a = Empty{};
+		    _ = @ptrToInt(&a);
+		}
+		
+		test "@intToPtr for pointer to zero bit type" {
+		    _ = @intToPtr(*Empty, 0x1);
+		}
       {#code_end#}
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|Result Location Semantics#}
       <p>
@@ -5463,17 +5679,19 @@ test "@intToPtr for pointer to zero bit type" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|usingnamespace#}
       <p>
       {#syntax#}usingnamespace{#endsyntax#} is a top level declaration that imports all the public declarations of
       the operand, which must be a {#link|struct#}, {#link|union#}, or {#link|enum#}, into the current scope:
       </p>
       {#code_begin|test|usingnamespace#}
-usingnamespace @import("std");
-
-test "using std namespace" {
-    debug.assert(true);
-}
+		usingnamespace @import("std");
+		
+		test "using std namespace" {
+		    debug.assert(true);
+		}
       {#code_end#}
       <p>
       Instead of the above pattern, it is generally recommended to explicitly alias individual declarations.
@@ -5498,27 +5716,33 @@ pub usingnamespace @cImport({
       </p>
       {#header_close#}
 
+
+
       {#header_open|comptime#}
       <p>
       Zig places importance on the concept of whether an expression is known at compile-time.
       There are a few different places this concept is used, and these building blocks are used
       to keep the language small, readable, and powerful.
       </p>
+
+
       {#header_open|Introducing the Compile-Time Concept#}
+
+
       {#header_open|Compile-Time Parameters#}
       <p>
       Compile-time parameters is how Zig implements generics. It is compile-time duck typing.
       </p>
       {#code_begin|syntax#}
-fn max(comptime T: type, a: T, b: T) T {
-    return if (a > b) a else b;
-}
-fn gimmeTheBiggerFloat(a: f32, b: f32) f32 {
-    return max(f32, a, b);
-}
-fn gimmeTheBiggerInteger(a: u64, b: u64) u64 {
-    return max(u64, a, b);
-}
+		fn max(comptime T: type, a: T, b: T) T {
+		    return if (a > b) a else b;
+		}
+		fn gimmeTheBiggerFloat(a: f32, b: f32) f32 {
+		    return max(f32, a, b);
+		}
+		fn gimmeTheBiggerInteger(a: u64, b: u64) u64 {
+		    return max(u64, a, b);
+		}
       {#code_end#}
       <p>
       In Zig, types are first-class citizens. They can be assigned to variables, passed as parameters to functions,
@@ -5536,18 +5760,18 @@ fn gimmeTheBiggerInteger(a: u64, b: u64) u64 {
       For example, if we were to introduce another function to the above snippet:
       </p>
       {#code_begin|test_err|values of type 'type' must be comptime known#}
-fn max(comptime T: type, a: T, b: T) T {
-    return if (a > b) a else b;
-}
-test "try to pass a runtime type" {
-    foo(false);
-}
-fn foo(condition: bool) void {
-    const result = max(
-        if (condition) f32 else u64,
-        1234,
-        5678);
-}
+		fn max(comptime T: type, a: T, b: T) T {
+		    return if (a > b) a else b;
+		}
+		test "try to pass a runtime type" {
+		    foo(false);
+		}
+		fn foo(condition: bool) void {
+		    const result = max(
+		        if (condition) f32 else u64,
+		        1234,
+		        5678);
+		}
       {#code_end#}
       <p>
       This is an error because the programmer attempted to pass a value only known at run-time
@@ -5561,12 +5785,12 @@ fn foo(condition: bool) void {
       For example:
       </p>
       {#code_begin|test_err|operator not allowed for type 'bool'#}
-fn max(comptime T: type, a: T, b: T) T {
-    return if (a > b) a else b;
-}
-test "try to compare bools" {
-    _ = max(bool, true, false);
-}
+		fn max(comptime T: type, a: T, b: T) T {
+		    return if (a > b) a else b;
+		}
+		test "try to compare bools" {
+		    _ = max(bool, true, false);
+		}
       {#code_end#}
       <p>
       On the flip side, inside the function definition with the {#syntax#}comptime{#endsyntax#} parameter, the
@@ -5574,18 +5798,18 @@ test "try to compare bools" {
       if we wanted to:
       </p>
       {#code_begin|test#}
-fn max(comptime T: type, a: T, b: T) T {
-    if (T == bool) {
-        return a or b;
-    } else if (a > b) {
-        return a;
-    } else {
-        return b;
-    }
-}
-test "try to compare bools" {
-    @import("std").debug.assert(max(bool, false, true) == true);
-}
+		fn max(comptime T: type, a: T, b: T) T {
+		    if (T == bool) {
+		        return a or b;
+		    } else if (a > b) {
+		        return a;
+		    } else {
+		        return b;
+		    }
+		}
+		test "try to compare bools" {
+		    @import("std").debug.assert(max(bool, false, true) == true);
+		}
       {#code_end#}
       <p>
       This works because Zig implicitly inlines {#syntax#}if{#endsyntax#} expressions when the condition
@@ -5597,9 +5821,9 @@ test "try to compare bools" {
       this:
       </p>
       {#code_begin|syntax#}
-fn max(a: bool, b: bool) bool {
-    return a or b;
-}
+		fn max(a: bool, b: bool) bool {
+		    return a or b;
+		}
       {#code_end#}
       <p>
       All the code that dealt with compile-time known values is eliminated and we are left with only
@@ -5610,6 +5834,8 @@ fn max(a: bool, b: bool) bool {
       when the target expression is compile-time known.
       </p>
       {#header_close#}
+
+
       {#header_open|Compile-Time Variables#}
       <p>
       In Zig, the programmer can label variables as {#syntax#}comptime{#endsyntax#}. This guarantees to the compiler
@@ -5624,38 +5850,38 @@ fn max(a: bool, b: bool) bool {
       For example:
       </p>
       {#code_begin|test|comptime_vars#}
-const assert = @import("std").debug.assert;
-
-const CmdFn = struct {
-    name: []const u8,
-    func: fn(i32) i32,
-};
-
-const cmd_fns = [_]CmdFn{
-    CmdFn {.name = "one", .func = one},
-    CmdFn {.name = "two", .func = two},
-    CmdFn {.name = "three", .func = three},
-};
-fn one(value: i32) i32 { return value + 1; }
-fn two(value: i32) i32 { return value + 2; }
-fn three(value: i32) i32 { return value + 3; }
-
-fn performFn(comptime prefix_char: u8, start_value: i32) i32 {
-    var result: i32 = start_value;
-    comptime var i = 0;
-    inline while (i < cmd_fns.len) : (i += 1) {
-        if (cmd_fns[i].name[0] == prefix_char) {
-            result = cmd_fns[i].func(result);
-        }
-    }
-    return result;
-}
-
-test "perform fn" {
-    assert(performFn('t', 1) == 6);
-    assert(performFn('o', 0) == 1);
-    assert(performFn('w', 99) == 99);
-}
+		const assert = @import("std").debug.assert;
+		
+		const CmdFn = struct {
+		    name: []const u8,
+		    func: fn(i32) i32,
+		};
+		
+		const cmd_fns = [_]CmdFn{
+		    CmdFn {.name = "one", .func = one},
+		    CmdFn {.name = "two", .func = two},
+		    CmdFn {.name = "three", .func = three},
+		};
+		fn one(value: i32) i32 { return value + 1; }
+		fn two(value: i32) i32 { return value + 2; }
+		fn three(value: i32) i32 { return value + 3; }
+		
+		fn performFn(comptime prefix_char: u8, start_value: i32) i32 {
+		    var result: i32 = start_value;
+		    comptime var i = 0;
+		    inline while (i < cmd_fns.len) : (i += 1) {
+		        if (cmd_fns[i].name[0] == prefix_char) {
+		            result = cmd_fns[i].func(result);
+		        }
+		    }
+		    return result;
+		}
+		
+		test "perform fn" {
+		    assert(performFn('t', 1) == 6);
+		    assert(performFn('o', 0) == 1);
+		    assert(performFn('w', 99) == 99);
+		}
       {#code_end#}
       <p>
       This example is a bit contrived, because the compile-time evaluation component is unnecessary;
@@ -5664,31 +5890,31 @@ test "perform fn" {
           for the different values of {#syntax#}prefix_char{#endsyntax#} provided:
       </p>
       {#code_begin|syntax#}
-// From the line:
-// assert(performFn('t', 1) == 6);
-fn performFn(start_value: i32) i32 {
-    var result: i32 = start_value;
-    result = two(result);
-    result = three(result);
-    return result;
-}
+		// From the line:
+		// assert(performFn('t', 1) == 6);
+		fn performFn(start_value: i32) i32 {
+		    var result: i32 = start_value;
+		    result = two(result);
+		    result = three(result);
+		    return result;
+		}
       {#code_end#}
       {#code_begin|syntax#}
-// From the line:
-// assert(performFn('o', 0) == 1);
-fn performFn(start_value: i32) i32 {
-    var result: i32 = start_value;
-    result = one(result);
-    return result;
-}
+		// From the line:
+		// assert(performFn('o', 0) == 1);
+		fn performFn(start_value: i32) i32 {
+		    var result: i32 = start_value;
+		    result = one(result);
+		    return result;
+		}
       {#code_end#}
       {#code_begin|syntax#}
-// From the line:
-// assert(performFn('w', 99) == 99);
-fn performFn(start_value: i32) i32 {
-    var result: i32 = start_value;
-    return result;
-}
+		// From the line:
+		// assert(performFn('w', 99) == 99);
+		fn performFn(start_value: i32) i32 {
+		    var result: i32 = start_value;
+		    return result;
+		}
       {#code_end#}
       <p>
       Note that this happens even in a debug build; in a release build these generated functions still
@@ -5699,6 +5925,8 @@ fn performFn(start_value: i32) i32 {
       generated code, or a preprocessor to accomplish.
       </p>
       {#header_close#}
+
+
       {#header_open|Compile-Time Expressions#}
       <p>
       In Zig, it matters whether a given expression is known at compile-time or run-time. A programmer can
@@ -5706,13 +5934,13 @@ fn performFn(start_value: i32) i32 {
       If this cannot be accomplished, the compiler will emit an error. For example:
       </p>
       {#code_begin|test_err|unable to evaluate constant expression#}
-extern fn exit() noreturn;
-
-test "foo" {
-    comptime {
-        exit();
-    }
-}
+		extern fn exit() noreturn;
+		
+		test "foo" {
+		    comptime {
+		        exit();
+		    }
+		}
       {#code_end#}
       <p>
       It doesn't make sense that a program could call {#syntax#}exit(){#endsyntax#} (or any other external function)
@@ -5737,39 +5965,39 @@ test "foo" {
       Let's look at an example:
       </p>
       {#code_begin|test#}
-const assert = @import("std").debug.assert;
-
-fn fibonacci(index: u32) u32 {
-    if (index < 2) return index;
-    return fibonacci(index - 1) + fibonacci(index - 2);
-}
-
-test "fibonacci" {
-    // test fibonacci at run-time
-    assert(fibonacci(7) == 13);
-
-    // test fibonacci at compile-time
-    comptime {
-        assert(fibonacci(7) == 13);
-    }
-}
+		const assert = @import("std").debug.assert;
+		
+		fn fibonacci(index: u32) u32 {
+		    if (index < 2) return index;
+		    return fibonacci(index - 1) + fibonacci(index - 2);
+		}
+		
+		test "fibonacci" {
+		    // test fibonacci at run-time
+		    assert(fibonacci(7) == 13);
+		
+		    // test fibonacci at compile-time
+		    comptime {
+		        assert(fibonacci(7) == 13);
+		    }
+		}
       {#code_end#}
       <p>
       Imagine if we had forgotten the base case of the recursive function and tried to run the tests:
       </p>
       {#code_begin|test_err|operation caused overflow#}
-const assert = @import("std").debug.assert;
-
-fn fibonacci(index: u32) u32 {
-    //if (index < 2) return index;
-    return fibonacci(index - 1) + fibonacci(index - 2);
-}
-
-test "fibonacci" {
-    comptime {
-        assert(fibonacci(7) == 13);
-    }
-}
+		const assert = @import("std").debug.assert;
+		
+		fn fibonacci(index: u32) u32 {
+		    //if (index < 2) return index;
+		    return fibonacci(index - 1) + fibonacci(index - 2);
+		}
+		
+		test "fibonacci" {
+		    comptime {
+		        assert(fibonacci(7) == 13);
+		    }
+		}
       {#code_end#}
       <p>
       The compiler produces an error which is a stack trace from trying to evaluate the
@@ -5781,18 +6009,18 @@ test "fibonacci" {
       But what would have happened if we used a signed integer?
       </p>
       {#code_begin|test_err|evaluation exceeded 1000 backwards branches#}
-const assert = @import("std").debug.assert;
-
-fn fibonacci(index: i32) i32 {
-    //if (index < 2) return index;
-    return fibonacci(index - 1) + fibonacci(index - 2);
-}
-
-test "fibonacci" {
-    comptime {
-        assert(fibonacci(7) == 13);
-    }
-}
+		const assert = @import("std").debug.assert;
+		
+		fn fibonacci(index: i32) i32 {
+		    //if (index < 2) return index;
+		    return fibonacci(index - 1) + fibonacci(index - 2);
+		}
+		
+		test "fibonacci" {
+		    comptime {
+		        assert(fibonacci(7) == 13);
+		    }
+		}
       {#code_end#}
       <p>
       The compiler noticed that evaluating this function at compile-time took a long time,
@@ -5804,18 +6032,18 @@ test "fibonacci" {
       What if we fix the base case, but put the wrong value in the {#syntax#}assert{#endsyntax#} line?
       </p>
       {#code_begin|test_err|unable to evaluate constant expression#}
-const assert = @import("std").debug.assert;
-
-fn fibonacci(index: i32) i32 {
-    if (index < 2) return index;
-    return fibonacci(index - 1) + fibonacci(index - 2);
-}
-
-test "fibonacci" {
-    comptime {
-        assert(fibonacci(7) == 99999);
-    }
-}
+		const assert = @import("std").debug.assert;
+		
+		fn fibonacci(index: i32) i32 {
+		    if (index < 2) return index;
+		    return fibonacci(index - 1) + fibonacci(index - 2);
+		}
+		
+		test "fibonacci" {
+		    comptime {
+		        assert(fibonacci(7) == 99999);
+		    }
+		}
       {#code_end#}
       <p>
       What happened is Zig started interpreting the {#syntax#}assert{#endsyntax#} function with the
@@ -5831,41 +6059,41 @@ test "fibonacci" {
       initialize complex static data. For example:
       </p>
       {#code_begin|test#}
-const first_25_primes = firstNPrimes(25);
-const sum_of_first_25_primes = sum(&first_25_primes);
-
-fn firstNPrimes(comptime n: usize) [n]i32 {
-    var prime_list: [n]i32 = undefined;
-    var next_index: usize = 0;
-    var test_number: i32 = 2;
-    while (next_index < prime_list.len) : (test_number += 1) {
-        var test_prime_index: usize = 0;
-        var is_prime = true;
-        while (test_prime_index < next_index) : (test_prime_index += 1) {
-            if (test_number % prime_list[test_prime_index] == 0) {
-                is_prime = false;
-                break;
-            }
-        }
-        if (is_prime) {
-            prime_list[next_index] = test_number;
-            next_index += 1;
-        }
-    }
-    return prime_list;
-}
-
-fn sum(numbers: []const i32) i32 {
-    var result: i32 = 0;
-    for (numbers) |x| {
-        result += x;
-    }
-    return result;
-}
-
-test "variable values" {
-    @import("std").debug.assert(sum_of_first_25_primes == 1060);
-}
+		const first_25_primes = firstNPrimes(25);
+		const sum_of_first_25_primes = sum(&first_25_primes);
+		
+		fn firstNPrimes(comptime n: usize) [n]i32 {
+		    var prime_list: [n]i32 = undefined;
+		    var next_index: usize = 0;
+		    var test_number: i32 = 2;
+		    while (next_index < prime_list.len) : (test_number += 1) {
+		        var test_prime_index: usize = 0;
+		        var is_prime = true;
+		        while (test_prime_index < next_index) : (test_prime_index += 1) {
+		            if (test_number % prime_list[test_prime_index] == 0) {
+		                is_prime = false;
+		                break;
+		            }
+		        }
+		        if (is_prime) {
+		            prime_list[next_index] = test_number;
+		            next_index += 1;
+		        }
+		    }
+		    return prime_list;
+		}
+		
+		fn sum(numbers: []const i32) i32 {
+		    var result: i32 = 0;
+		    for (numbers) |x| {
+		        result += x;
+		    }
+		    return result;
+		}
+		
+		test "variable values" {
+		    @import("std").debug.assert(sum_of_first_25_primes == 1060);
+		}
       {#code_end#}
       <p>
       When we compile this program, Zig generates the constants
@@ -5880,6 +6108,8 @@ test "variable values" {
       </p>
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Generic Data Structures#}
       <p>
       Zig uses these capabilities to implement generic data structures without introducing any
@@ -5891,12 +6121,12 @@ test "variable values" {
           the type {#syntax#}i32{#endsyntax#}. In Zig we refer to the type as {#syntax#}List(i32){#endsyntax#}.
       </p>
       {#code_begin|syntax#}
-fn List(comptime T: type) type {
-    return struct {
-        items: []T,
-        len: usize,
-    };
-}
+		fn List(comptime T: type) type {
+		    return struct {
+		        items: []T,
+		        len: usize,
+		    };
+		}
       {#code_end#}
       <p>
       That's it. It's a function that returns an anonymous {#syntax#}struct{#endsyntax#}. For the purposes of error messages
@@ -5908,10 +6138,10 @@ fn List(comptime T: type) type {
       a name, we assign it to a constant:
       </p>
       {#code_begin|syntax#}
-const Node = struct {
-    next: *Node,
-    name: []u8,
-};
+		const Node = struct {
+		    next: *Node,
+		    name: []u8,
+		};
       {#code_end#}
       <p>
       This works because all top level declarations are order-independent, and as long as there isn't
@@ -5920,19 +6150,21 @@ const Node = struct {
       it works fine.
       </p>
       {#header_close#}
+
+
       {#header_open|Case Study: printf in Zig#}
       <p>
       Putting all of this together, let's see how {#syntax#}printf{#endsyntax#} works in Zig.
       </p>
       {#code_begin|exe|printf#}
-const warn = @import("std").debug.warn;
-
-const a_number: i32 = 1234;
-const a_string = "foobar";
-
-pub fn main() void {
-    warn("here is a string: '{}' here is a number: {}\n", .{a_string, a_number});
-}
+		const warn = @import("std").debug.warn;
+		
+		const a_number: i32 = 1234;
+		const a_string = "foobar";
+		
+		pub fn main() void {
+		    warn("here is a string: '{}' here is a number: {}\n", .{a_string, a_number});
+		}
       {#code_end#}
 
       <p>
@@ -5940,66 +6172,66 @@ pub fn main() void {
       </p>
 
       {#code_begin|syntax#}
-/// Calls print and then flushes the buffer.
-pub fn printf(self: *OutStream, comptime format: []const u8, args: var) anyerror!void {
-    const State = enum {
-        Start,
-        OpenBrace,
-        CloseBrace,
-    };
-
-    comptime var start_index: usize = 0;
-    comptime var state = State.Start;
-    comptime var next_arg: usize = 0;
-
-    inline for (format) |c, i| {
-        switch (state) {
-            State.Start => switch (c) {
-                '{' => {
-                    if (start_index < i) try self.write(format[start_index..i]);
-                    state = State.OpenBrace;
-                },
-                '}' => {
-                    if (start_index < i) try self.write(format[start_index..i]);
-                    state = State.CloseBrace;
-                },
-                else => {},
-            },
-            State.OpenBrace => switch (c) {
-                '{' => {
-                    state = State.Start;
-                    start_index = i;
-                },
-                '}' => {
-                    try self.printValue(args[next_arg]);
-                    next_arg += 1;
-                    state = State.Start;
-                    start_index = i + 1;
-                },
-                else => @compileError("Unknown format character: " ++ c),
-            },
-            State.CloseBrace => switch (c) {
-                '}' => {
-                    state = State.Start;
-                    start_index = i;
-                },
-                else => @compileError("Single '}' encountered in format string"),
-            },
-        }
-    }
-    comptime {
-        if (args.len != next_arg) {
-            @compileError("Unused arguments");
-        }
-        if (state != State.Start) {
-            @compileError("Incomplete format string: " ++ format);
-        }
-    }
-    if (start_index < format.len) {
-        try self.write(format[start_index..format.len]);
-    }
-    try self.flush();
-}
+		/// Calls print and then flushes the buffer.
+		pub fn printf(self: *OutStream, comptime format: []const u8, args: var) anyerror!void {
+		    const State = enum {
+		        Start,
+		        OpenBrace,
+		        CloseBrace,
+		    };
+		
+		    comptime var start_index: usize = 0;
+		    comptime var state = State.Start;
+		    comptime var next_arg: usize = 0;
+		
+		    inline for (format) |c, i| {
+		        switch (state) {
+		            State.Start => switch (c) {
+		                '{' => {
+		                    if (start_index < i) try self.write(format[start_index..i]);
+		                    state = State.OpenBrace;
+		                },
+		                '}' => {
+		                    if (start_index < i) try self.write(format[start_index..i]);
+		                    state = State.CloseBrace;
+		                },
+		                else => {},
+		            },
+		            State.OpenBrace => switch (c) {
+		                '{' => {
+		                    state = State.Start;
+		                    start_index = i;
+		                },
+		                '}' => {
+		                    try self.printValue(args[next_arg]);
+		                    next_arg += 1;
+		                    state = State.Start;
+		                    start_index = i + 1;
+		                },
+		                else => @compileError("Unknown format character: " ++ c),
+		            },
+		            State.CloseBrace => switch (c) {
+		                '}' => {
+		                    state = State.Start;
+		                    start_index = i;
+		                },
+		                else => @compileError("Single '}' encountered in format string"),
+		            },
+		        }
+		    }
+		    comptime {
+		        if (args.len != next_arg) {
+		            @compileError("Unused arguments");
+		        }
+		        if (state != State.Start) {
+		            @compileError("Incomplete format string: " ++ format);
+		        }
+		    }
+		    if (start_index < format.len) {
+		        try self.write(format[start_index..format.len]);
+		    }
+		    try self.flush();
+		}
       {#code_end#}
       <p>
       This is a proof of concept implementation; the actual function in the standard library has more
@@ -6013,50 +6245,50 @@ pub fn printf(self: *OutStream, comptime format: []const u8, args: var) anyerror
       and emits a function that actually looks like this:
       </p>
       {#code_begin|syntax#}
-pub fn printf(self: *OutStream, arg0: i32, arg1: []const u8) !void {
-    try self.write("here is a string: '");
-    try self.printValue(arg0);
-    try self.write("' here is a number: ");
-    try self.printValue(arg1);
-    try self.write("\n");
-    try self.flush();
-}
+		pub fn printf(self: *OutStream, arg0: i32, arg1: []const u8) !void {
+		    try self.write("here is a string: '");
+		    try self.printValue(arg0);
+		    try self.write("' here is a number: ");
+		    try self.printValue(arg1);
+		    try self.write("\n");
+		    try self.flush();
+		}
       {#code_end#}
       <p>
       {#syntax#}printValue{#endsyntax#} is a function that takes a parameter of any type, and does different things depending
       on the type:
       </p>
       {#code_begin|syntax#}
-pub fn printValue(self: *OutStream, value: var) !void {
-    switch (@typeInfo(@TypeOf(value))) {
-        .Int => {
-            return self.printInt(T, value);
-        },
-        .Float => {
-            return self.printFloat(T, value);
-        },
-        else => {
-            @compileError("Unable to print type '" ++ @typeName(T) ++ "'");
-        },
-    }
-}
+		pub fn printValue(self: *OutStream, value: var) !void {
+		    switch (@typeInfo(@TypeOf(value))) {
+		        .Int => {
+		            return self.printInt(T, value);
+		        },
+		        .Float => {
+		            return self.printFloat(T, value);
+		        },
+		        else => {
+		            @compileError("Unable to print type '" ++ @typeName(T) ++ "'");
+		        },
+		    }
+		}
       {#code_end#}
       <p>
       And now, what happens if we give too many arguments to {#syntax#}printf{#endsyntax#}?
       </p>
       {#code_begin|test_err|Unused arguments#}
-const warn = @import("std").debug.warn;
-
-const a_number: i32 = 1234;
-const a_string = "foobar";
-
-test "printf too many arguments" {
-    warn("here is a string: '{}' here is a number: {}\n", .{
-        a_string,
-        a_number,
-        a_number,
-    });
-}
+		const warn = @import("std").debug.warn;
+		
+		const a_number: i32 = 1234;
+		const a_string = "foobar";
+		
+		test "printf too many arguments" {
+		    warn("here is a string: '{}' here is a number: {}\n", .{
+		        a_string,
+		        a_number,
+		        a_number,
+		    });
+		}
       {#code_end#}
       <p>
       Zig gives programmers the tools needed to protect themselves against their own mistakes.
@@ -6066,15 +6298,15 @@ test "printf too many arguments" {
       only that it is a compile-time known value that can be coerced to a {#syntax#}[]const u8{#endsyntax#}:
       </p>
       {#code_begin|exe|printf#}
-const warn = @import("std").debug.warn;
-
-const a_number: i32 = 1234;
-const a_string = "foobar";
-const fmt = "here is a string: '{}' here is a number: {}\n";
-
-pub fn main() void {
-    warn(fmt, .{a_string, a_number});
-}
+		const warn = @import("std").debug.warn;
+		
+		const a_number: i32 = 1234;
+		const a_string = "foobar";
+		const fmt = "here is a string: '{}' here is a number: {}\n";
+		
+		pub fn main() void {
+		    warn(fmt, .{a_string, a_number});
+		}
       {#code_end#}
       <p>
       This works fine.
@@ -6087,6 +6319,8 @@ pub fn main() void {
       {#header_close#}
       {#see_also|inline while|inline for#}
       {#header_close#}
+
+
       {#header_open|Assembly#}
       <p>
       For some use cases, it may be necessary to directly control the machine code generated
@@ -6095,38 +6329,38 @@ pub fn main() void {
       using inline assembly:
       </p>
       {#code_begin|exe#}
-      {#target_linux_x86_64#}
-pub fn main() noreturn {
-    const msg = "hello world\n";
-    _ = syscall3(SYS_write, STDOUT_FILENO, @ptrToInt(msg), msg.len);
-    _ = syscall1(SYS_exit, 0);
-    unreachable;
-}
-
-pub const SYS_write = 1;
-pub const SYS_exit = 60;
-
-pub const STDOUT_FILENO = 1;
-
-pub fn syscall1(number: usize, arg1: usize) usize {
-    return asm volatile ("syscall"
-        : [ret] "={rax}" (-> usize)
-        : [number] "{rax}" (number),
-          [arg1] "{rdi}" (arg1)
-        : "rcx", "r11"
-    );
-}
-
-pub fn syscall3(number: usize, arg1: usize, arg2: usize, arg3: usize) usize {
-    return asm volatile ("syscall"
-        : [ret] "={rax}" (-> usize)
-        : [number] "{rax}" (number),
-          [arg1] "{rdi}" (arg1),
-          [arg2] "{rsi}" (arg2),
-          [arg3] "{rdx}" (arg3)
-        : "rcx", "r11"
-    );
-}
+		      {#target_linux_x86_64#}
+		pub fn main() noreturn {
+		    const msg = "hello world\n";
+		    _ = syscall3(SYS_write, STDOUT_FILENO, @ptrToInt(msg), msg.len);
+		    _ = syscall1(SYS_exit, 0);
+		    unreachable;
+		}
+		
+		pub const SYS_write = 1;
+		pub const SYS_exit = 60;
+		
+		pub const STDOUT_FILENO = 1;
+		
+		pub fn syscall1(number: usize, arg1: usize) usize {
+		    return asm volatile ("syscall"
+		        : [ret] "={rax}" (-> usize)
+		        : [number] "{rax}" (number),
+		          [arg1] "{rdi}" (arg1)
+		        : "rcx", "r11"
+		    );
+		}
+		
+		pub fn syscall3(number: usize, arg1: usize, arg2: usize, arg3: usize) usize {
+		    return asm volatile ("syscall"
+		        : [ret] "={rax}" (-> usize)
+		        : [number] "{rax}" (number),
+		          [arg1] "{rdi}" (arg1),
+		          [arg2] "{rsi}" (arg2),
+		          [arg3] "{rdx}" (arg3)
+		        : "rcx", "r11"
+		    );
+		}
       {#code_end#}
       <p>
       Dissecting the syntax:
@@ -6198,6 +6432,8 @@ volatile (
       section will be updated before 1.0.0 is released, with a conclusive statement about the status
       of AT&amp;T vs Intel/NASM syntax.
       </p>
+
+
       {#header_open|Output Constraints#}
       <p>
       Output constraints are still considered to be unstable in Zig, and
@@ -6212,6 +6448,8 @@ volatile (
       <a href="https://github.com/ziglang/zig/issues/215">issue #215</a>.
       </p>
       {#header_close#}
+
+
 
       {#header_open|Input Constraints#}
       <p>
@@ -6228,6 +6466,8 @@ volatile (
       </p>
       {#header_close#}
 
+
+
       {#header_open|Clobbers#}
       <p>
       Clobbers are the set of registers whose values will not be preserved by the execution of
@@ -6242,6 +6482,8 @@ volatile (
       </p>
       {#header_close#}
 
+
+
       {#header_open|Global Assembly#}
       <p>
       When an assembly expression occurs in a top level {#link|comptime#} block, this is
@@ -6255,34 +6497,38 @@ volatile (
       <code>%</code> as there are in inline assembly expressions.
       </p>
       {#code_begin|test|global-asm#}
-      {#target_linux_x86_64#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-comptime {
-    asm (
-        \\.global my_func;
-        \\.type my_func, @function;
-        \\my_func:
-        \\  lea (%rdi,%rsi,1),%eax
-        \\  retq
-    );
-}
-
-extern fn my_func(a: i32, b: i32) i32;
-
-test "global assembly" {
-    assert(my_func(12, 34) == 46);
-}
+		      {#target_linux_x86_64#}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		comptime {
+		    asm (
+		        \\.global my_func;
+		        \\.type my_func, @function;
+		        \\my_func:
+		        \\  lea (%rdi,%rsi,1),%eax
+		        \\  retq
+		    );
+		}
+		
+		extern fn my_func(a: i32, b: i32) i32;
+		
+		test "global assembly" {
+		    assert(my_func(12, 34) == 46);
+		}
       {#code_end#}
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|Atomics#}
       <p>TODO: @fence()</p>
       <p>TODO: @atomic rmw</p>
       <p>TODO: builtin atomic memory ordering enum</p>
       {#header_close#}
+
+
       {#header_open|Async Functions#}
       <p>
       When a function is called, a frame is pushed to the stack,
@@ -6299,6 +6545,8 @@ test "global assembly" {
       a <strong>suspension point</strong>. Async functions can be called the same as normal functions. A
       function call of an async function is a suspend point.
       </p>
+
+
       {#header_open|Suspend and Resume#}
       <p>
       At any point, a function may suspend itself. This causes control flow to
@@ -6306,22 +6554,22 @@ test "global assembly" {
       or resumer (in the case of subsequent suspensions).
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-var x: i32 = 1;
-
-test "suspend with no resume" {
-    var frame = async func();
-    assert(x == 2);
-}
-
-fn func() void {
-    x += 1;
-    suspend;
-    // This line is never reached because the suspend has no matching resume.
-    x += 1;
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		var x: i32 = 1;
+		
+		test "suspend with no resume" {
+		    var frame = async func();
+		    assert(x == 2);
+		}
+		
+		fn func() void {
+		    x += 1;
+		    suspend;
+		    // This line is never reached because the suspend has no matching resume.
+		    x += 1;
+		}
       {#code_end#}
       <p>
       In the same way that each allocation should have a corresponding free,
@@ -6332,30 +6580,32 @@ fn func() void {
       {#link|@frame#} provides access to the async function frame pointer.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-var the_frame: anyframe = undefined;
-var result = false;
-
-test "async function suspend with block" {
-    _ = async testSuspendBlock();
-    assert(!result);
-    resume the_frame;
-    assert(result);
-}
-
-fn testSuspendBlock() void {
-    suspend {
-        comptime assert(@TypeOf(@frame()) == *@Frame(testSuspendBlock));
-        the_frame = @frame();
-    }
-    result = true;
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		var the_frame: anyframe = undefined;
+		var result = false;
+		
+		test "async function suspend with block" {
+		    _ = async testSuspendBlock();
+		    assert(!result);
+		    resume the_frame;
+		    assert(result);
+		}
+		
+		fn testSuspendBlock() void {
+		    suspend {
+		        comptime assert(@TypeOf(@frame()) == *@Frame(testSuspendBlock));
+		        the_frame = @frame();
+		    }
+		    result = true;
+		}
       {#code_end#}
       <p>
       {#syntax#}suspend{#endsyntax#} causes a function to be {#syntax#}async{#endsyntax#}.
       </p>
+
+
 
       {#header_open|Resuming from Suspend Blocks#}
       <p>
@@ -6370,22 +6620,22 @@ fn testSuspendBlock() void {
       never returns to its resumer and continues executing.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "resume from suspend" {
-    var my_result: i32 = 1;
-    _ = async testResumeFromSuspend(&my_result);
-    std.debug.assert(my_result == 2);
-}
-fn testResumeFromSuspend(my_result: *i32) void {
-    suspend {
-        resume @frame();
-    }
-    my_result.* += 1;
-    suspend;
-    my_result.* += 1;
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "resume from suspend" {
+		    var my_result: i32 = 1;
+		    _ = async testResumeFromSuspend(&my_result);
+		    std.debug.assert(my_result == 2);
+		}
+		fn testResumeFromSuspend(my_result: *i32) void {
+		    suspend {
+		        resume @frame();
+		    }
+		    my_result.* += 1;
+		    suspend;
+		    my_result.* += 1;
+		}
       {#code_end#}
       <p>
       This is guaranteed to tail call, and therefore will not cause a new stack frame.
@@ -6393,39 +6643,41 @@ fn testResumeFromSuspend(my_result: *i32) void {
       {#header_close#}
       {#header_close#}
 
+
+
       {#header_open|Async and Await#}
       <p>
       In the same way that every {#syntax#}suspend{#endsyntax#} has a matching
       {#syntax#}resume{#endsyntax#}, every {#syntax#}async{#endsyntax#} has a matching {#syntax#}await{#endsyntax#}.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "async and await" {
-    // Here we have an exception where we do not match an async
-    // with an await. The test block is not async and so cannot
-    // have a suspend point in it.
-    // This is well-defined behavior, and everything is OK here.
-    // Note however that there would be no way to collect the
-    // return value of amain, if it were something other than void.
-    _ = async amain();
-}
-
-fn amain() void {
-    var frame = async func();
-    comptime assert(@TypeOf(frame) == @Frame(func));
-
-    const ptr: anyframe->void = &frame;
-    const any_ptr: anyframe = ptr;
-
-    resume any_ptr;
-    await ptr;
-}
-
-fn func() void {
-    suspend;
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "async and await" {
+		    // Here we have an exception where we do not match an async
+		    // with an await. The test block is not async and so cannot
+		    // have a suspend point in it.
+		    // This is well-defined behavior, and everything is OK here.
+		    // Note however that there would be no way to collect the
+		    // return value of amain, if it were something other than void.
+		    _ = async amain();
+		}
+		
+		fn amain() void {
+		    var frame = async func();
+		    comptime assert(@TypeOf(frame) == @Frame(func));
+		
+		    const ptr: anyframe->void = &frame;
+		    const any_ptr: anyframe = ptr;
+		
+		    resume any_ptr;
+		    await ptr;
+		}
+		
+		fn func() void {
+		    suspend;
+		}
       {#code_end#}
       <p>
       The {#syntax#}await{#endsyntax#} keyword is used to coordinate with an async function's
@@ -6443,45 +6695,45 @@ fn func() void {
       return value directly from the target function's frame.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-var the_frame: anyframe = undefined;
-var final_result: i32 = 0;
-
-test "async function await" {
-    seq('a');
-    _ = async amain();
-    seq('f');
-    resume the_frame;
-    seq('i');
-    assert(final_result == 1234);
-    assert(std.mem.eql(u8, &seq_points, "abcdefghi"));
-}
-fn amain() void {
-    seq('b');
-    var f = async another();
-    seq('e');
-    final_result = await f;
-    seq('h');
-}
-fn another() i32 {
-    seq('c');
-    suspend {
-        seq('d');
-        the_frame = @frame();
-    }
-    seq('g');
-    return 1234;
-}
-
-var seq_points = [_]u8{0} ** "abcdefghi".len;
-var seq_index: usize = 0;
-
-fn seq(c: u8) void {
-    seq_points[seq_index] = c;
-    seq_index += 1;
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		var the_frame: anyframe = undefined;
+		var final_result: i32 = 0;
+		
+		test "async function await" {
+		    seq('a');
+		    _ = async amain();
+		    seq('f');
+		    resume the_frame;
+		    seq('i');
+		    assert(final_result == 1234);
+		    assert(std.mem.eql(u8, &seq_points, "abcdefghi"));
+		}
+		fn amain() void {
+		    seq('b');
+		    var f = async another();
+		    seq('e');
+		    final_result = await f;
+		    seq('h');
+		}
+		fn another() i32 {
+		    seq('c');
+		    suspend {
+		        seq('d');
+		        the_frame = @frame();
+		    }
+		    seq('g');
+		    return 1234;
+		}
+		
+		var seq_points = [_]u8{0} ** "abcdefghi".len;
+		var seq_index: usize = 0;
+		
+		fn seq(c: u8) void {
+		    seq_points[seq_index] = c;
+		    seq_index += 1;
+		}
       {#code_end#}
       <p>
       In general, {#syntax#}suspend{#endsyntax#} is lower level than {#syntax#}await{#endsyntax#}. Most application
@@ -6490,144 +6742,146 @@ fn seq(c: u8) void {
       </p>
       {#header_close#}
 
+
+
       {#header_open|Async Function Example#}
       <p>
       Putting all of this together, here is an example of typical
       {#syntax#}async{#endsyntax#}/{#syntax#}await{#endsyntax#} usage:
       </p>
       {#code_begin|exe|async#}
-const std = @import("std");
-const Allocator = std.mem.Allocator;
-
-pub fn main() void {
-    _ = async amainWrap();
-
-    // Typically we would use an event loop to manage resuming async functions,
-    // but in this example we hard code what the event loop would do,
-    // to make things deterministic.
-    resume global_file_frame;
-    resume global_download_frame;
-}
-
-fn amainWrap() void {
-    amain() catch |e| {
-        std.debug.warn("{}\n", .{e});
-        if (@errorReturnTrace()) |trace| {
-            std.debug.dumpStackTrace(trace.*);
-        }
-        std.process.exit(1);
-    };
-}
-
-fn amain() !void {
-    const allocator = std.heap.page_allocator;
-    var download_frame = async fetchUrl(allocator, "https://example.com/");
-    var awaited_download_frame = false;
-    errdefer if (!awaited_download_frame) {
-        if (await download_frame) |r| allocator.free(r) else |_| {}
-    };
-
-    var file_frame = async readFile(allocator, "something.txt");
-    var awaited_file_frame = false;
-    errdefer if (!awaited_file_frame) {
-        if (await file_frame) |r| allocator.free(r) else |_| {}
-    };
-
-    awaited_file_frame = true;
-    const file_text = try await file_frame;
-    defer allocator.free(file_text);
-
-    awaited_download_frame = true;
-    const download_text = try await download_frame;
-    defer allocator.free(download_text);
-
-    std.debug.warn("download_text: {}\n", .{download_text});
-    std.debug.warn("file_text: {}\n", .{file_text});
-}
-
-var global_download_frame: anyframe = undefined;
-fn fetchUrl(allocator: *Allocator, url: []const u8) ![]u8 {
-    const result = try std.mem.dupe(allocator, u8, "this is the downloaded url contents");
-    errdefer allocator.free(result);
-    suspend {
-        global_download_frame = @frame();
-    }
-    std.debug.warn("fetchUrl returning\n", .{});
-    return result;
-}
-
-var global_file_frame: anyframe = undefined;
-fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
-    const result = try std.mem.dupe(allocator, u8, "this is the file contents");
-    errdefer allocator.free(result);
-    suspend {
-        global_file_frame = @frame();
-    }
-    std.debug.warn("readFile returning\n", .{});
-    return result;
-}
+		const std = @import("std");
+		const Allocator = std.mem.Allocator;
+		
+		pub fn main() void {
+		    _ = async amainWrap();
+		
+		    // Typically we would use an event loop to manage resuming async functions,
+		    // but in this example we hard code what the event loop would do,
+		    // to make things deterministic.
+		    resume global_file_frame;
+		    resume global_download_frame;
+		}
+		
+		fn amainWrap() void {
+		    amain() catch |e| {
+		        std.debug.warn("{}\n", .{e});
+		        if (@errorReturnTrace()) |trace| {
+		            std.debug.dumpStackTrace(trace.*);
+		        }
+		        std.process.exit(1);
+		    };
+		}
+		
+		fn amain() !void {
+		    const allocator = std.heap.page_allocator;
+		    var download_frame = async fetchUrl(allocator, "https://example.com/");
+		    var awaited_download_frame = false;
+		    errdefer if (!awaited_download_frame) {
+		        if (await download_frame) |r| allocator.free(r) else |_| {}
+		    };
+		
+		    var file_frame = async readFile(allocator, "something.txt");
+		    var awaited_file_frame = false;
+		    errdefer if (!awaited_file_frame) {
+		        if (await file_frame) |r| allocator.free(r) else |_| {}
+		    };
+		
+		    awaited_file_frame = true;
+		    const file_text = try await file_frame;
+		    defer allocator.free(file_text);
+		
+		    awaited_download_frame = true;
+		    const download_text = try await download_frame;
+		    defer allocator.free(download_text);
+		
+		    std.debug.warn("download_text: {}\n", .{download_text});
+		    std.debug.warn("file_text: {}\n", .{file_text});
+		}
+		
+		var global_download_frame: anyframe = undefined;
+		fn fetchUrl(allocator: *Allocator, url: []const u8) ![]u8 {
+		    const result = try std.mem.dupe(allocator, u8, "this is the downloaded url contents");
+		    errdefer allocator.free(result);
+		    suspend {
+		        global_download_frame = @frame();
+		    }
+		    std.debug.warn("fetchUrl returning\n", .{});
+		    return result;
+		}
+		
+		var global_file_frame: anyframe = undefined;
+		fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
+		    const result = try std.mem.dupe(allocator, u8, "this is the file contents");
+		    errdefer allocator.free(result);
+		    suspend {
+		        global_file_frame = @frame();
+		    }
+		    std.debug.warn("readFile returning\n", .{});
+		    return result;
+		}
       {#code_end#}
       <p>
       Now we remove the {#syntax#}suspend{#endsyntax#} and {#syntax#}resume{#endsyntax#} code, and
       observe the same behavior, with one tiny difference:
       </p>
       {#code_begin|exe|blocking#}
-const std = @import("std");
-const Allocator = std.mem.Allocator;
-
-pub fn main() void {
-    _ = async amainWrap();
-}
-
-fn amainWrap() void {
-    amain() catch |e| {
-        std.debug.warn("{}\n", .{e});
-        if (@errorReturnTrace()) |trace| {
-            std.debug.dumpStackTrace(trace.*);
-        }
-        std.process.exit(1);
-    };
-}
-
-fn amain() !void {
-    const allocator = std.heap.page_allocator;
-    var download_frame = async fetchUrl(allocator, "https://example.com/");
-    var awaited_download_frame = false;
-    errdefer if (!awaited_download_frame) {
-        if (await download_frame) |r| allocator.free(r) else |_| {}
-    };
-
-    var file_frame = async readFile(allocator, "something.txt");
-    var awaited_file_frame = false;
-    errdefer if (!awaited_file_frame) {
-        if (await file_frame) |r| allocator.free(r) else |_| {}
-    };
-
-    awaited_file_frame = true;
-    const file_text = try await file_frame;
-    defer allocator.free(file_text);
-
-    awaited_download_frame = true;
-    const download_text = try await download_frame;
-    defer allocator.free(download_text);
-
-    std.debug.warn("download_text: {}\n", .{download_text});
-    std.debug.warn("file_text: {}\n", .{file_text});
-}
-
-fn fetchUrl(allocator: *Allocator, url: []const u8) ![]u8 {
-    const result = try std.mem.dupe(allocator, u8, "this is the downloaded url contents");
-    errdefer allocator.free(result);
-    std.debug.warn("fetchUrl returning\n", .{});
-    return result;
-}
-
-fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
-    const result = try std.mem.dupe(allocator, u8, "this is the file contents");
-    errdefer allocator.free(result);
-    std.debug.warn("readFile returning\n", .{});
-    return result;
-}
+		const std = @import("std");
+		const Allocator = std.mem.Allocator;
+		
+		pub fn main() void {
+		    _ = async amainWrap();
+		}
+		
+		fn amainWrap() void {
+		    amain() catch |e| {
+		        std.debug.warn("{}\n", .{e});
+		        if (@errorReturnTrace()) |trace| {
+		            std.debug.dumpStackTrace(trace.*);
+		        }
+		        std.process.exit(1);
+		    };
+		}
+		
+		fn amain() !void {
+		    const allocator = std.heap.page_allocator;
+		    var download_frame = async fetchUrl(allocator, "https://example.com/");
+		    var awaited_download_frame = false;
+		    errdefer if (!awaited_download_frame) {
+		        if (await download_frame) |r| allocator.free(r) else |_| {}
+		    };
+		
+		    var file_frame = async readFile(allocator, "something.txt");
+		    var awaited_file_frame = false;
+		    errdefer if (!awaited_file_frame) {
+		        if (await file_frame) |r| allocator.free(r) else |_| {}
+		    };
+		
+		    awaited_file_frame = true;
+		    const file_text = try await file_frame;
+		    defer allocator.free(file_text);
+		
+		    awaited_download_frame = true;
+		    const download_text = try await download_frame;
+		    defer allocator.free(download_text);
+		
+		    std.debug.warn("download_text: {}\n", .{download_text});
+		    std.debug.warn("file_text: {}\n", .{file_text});
+		}
+		
+		fn fetchUrl(allocator: *Allocator, url: []const u8) ![]u8 {
+		    const result = try std.mem.dupe(allocator, u8, "this is the downloaded url contents");
+		    errdefer allocator.free(result);
+		    std.debug.warn("fetchUrl returning\n", .{});
+		    return result;
+		}
+		
+		fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
+		    const result = try std.mem.dupe(allocator, u8, "this is the file contents");
+		    errdefer allocator.free(result);
+		    std.debug.warn("readFile returning\n", .{});
+		    return result;
+		}
       {#code_end#}
       <p>
       Previously, the {#syntax#}fetchUrl{#endsyntax#} and {#syntax#}readFile{#endsyntax#} functions suspended,
@@ -6638,12 +6892,16 @@ fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
       {#header_close#}
 
       {#header_close#}
+
+
         {#header_open|Builtin Functions|2col#}
       <p>
       Builtin functions are provided by the compiler and are prefixed with <code>@</code>.
       The {#syntax#}comptime{#endsyntax#} keyword on a parameter means that the parameter must be known
       at compile time.
       </p>
+
+
       {#header_open|@addWithOverflow#}
       <pre>{#syntax#}@addWithOverflow(comptime T: type, a: T, b: T, result: *T) bool{#endsyntax#}</pre>
       <p>
@@ -6652,6 +6910,8 @@ fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
                   If no overflow or underflow occurs, returns {#syntax#}false{#endsyntax#}.
       </p>
       {#header_close#}
+
+
       {#header_open|@alignCast#}
       <pre>{#syntax#}@alignCast(comptime alignment: u29, ptr: var) var{#endsyntax#}</pre>
       <p>
@@ -6663,6 +6923,8 @@ fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
       to the generated code to make sure the pointer is aligned as promised.</p>
 
       {#header_close#}
+
+
       {#header_open|@alignOf#}
       <pre>{#syntax#}@alignOf(comptime T: type) comptime_int{#endsyntax#}</pre>
       <p>
@@ -6681,6 +6943,8 @@ comptime {
       {#see_also|Alignment#}
       {#header_close#}
 
+
+
       {#header_open|@as#}
       <pre>{#syntax#}@as(comptime T: type, expression) T{#endsyntax#}</pre>
       <p>
@@ -6688,6 +6952,8 @@ comptime {
       and is the preferred way to convert between types, whenever possible.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@asyncCall#}
       <pre>{#syntax#}@asyncCall(frame_buffer: []align(@alignOf(@Frame(anyAsyncFunction))) u8, result_ptr, function_ptr, args: ...) anyframe->T{#endsyntax#}</pre>
@@ -6707,29 +6973,31 @@ comptime {
       {#syntax#}await{#endsyntax#} will copy the result from {#syntax#}result_ptr{#endsyntax#}.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "async fn pointer in a struct field" {
-    var data: i32 = 1;
-    const Foo = struct {
-        bar: async fn (*i32) void,
-    };
-    var foo = Foo{ .bar = func };
-    var bytes: [64]u8 align(@alignOf(@Frame(func))) = undefined;
-    const f = @asyncCall(&bytes, {}, foo.bar, &data);
-    assert(data == 2);
-    resume f;
-    assert(data == 4);
-}
-
-async fn func(y: *i32) void {
-    defer y.* += 2;
-    y.* += 1;
-    suspend;
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "async fn pointer in a struct field" {
+		    var data: i32 = 1;
+		    const Foo = struct {
+		        bar: async fn (*i32) void,
+		    };
+		    var foo = Foo{ .bar = func };
+		    var bytes: [64]u8 align(@alignOf(@Frame(func))) = undefined;
+		    const f = @asyncCall(&bytes, {}, foo.bar, &data);
+		    assert(data == 2);
+		    resume f;
+		    assert(data == 4);
+		}
+		
+		async fn func(y: *i32) void {
+		    defer y.* += 2;
+		    y.* += 1;
+		    suspend;
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|@atomicLoad#}
       <pre>{#syntax#}@atomicLoad(comptime T: type, ptr: *const T, comptime ordering: builtin.AtomicOrder) T{#endsyntax#}</pre>
@@ -6741,6 +7009,8 @@ async fn func(y: *i32) void {
       an integer or an enum.
       </p>
       {#header_close#}
+
+
       {#header_open|@atomicRmw#}
       <pre>{#syntax#}@atomicRmw(comptime T: type, ptr: *T, comptime op: builtin.AtomicRmwOp, operand: T, comptime ordering: builtin.AtomicOrder) T{#endsyntax#}</pre>
       <p>
@@ -6767,6 +7037,8 @@ async fn func(y: *i32) void {
         <li>{#syntax#}.Min{#endsyntax#} - stores the operand if it is smaller. Supports integers and floats.</li>
       </ul>
       {#header_close#}
+
+
       {#header_open|@atomicStore#}
       <pre>{#syntax#}@atomicStore(comptime T: type, ptr: *T, value: T, comptime ordering: builtin.AtomicOrder) void{#endsyntax#}</pre>
       <p>
@@ -6777,6 +7049,8 @@ async fn func(y: *i32) void {
       an integer or an enum.
       </p>
       {#header_close#}
+
+
       {#header_open|@bitCast#}
       <pre>{#syntax#}@bitCast(comptime DestType: type, value: var) DestType{#endsyntax#}</pre>
       <p>
@@ -6800,6 +7074,8 @@ async fn func(y: *i32) void {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@bitOffsetOf#}
       <pre>{#syntax#}@bitOffsetOf(comptime T: type, comptime field_name: []const u8) comptime_int{#endsyntax#}</pre>
       <p>
@@ -6813,6 +7089,8 @@ async fn func(y: *i32) void {
       {#see_also|@byteOffsetOf#}
       {#header_close#}
 
+
+
       {#header_open|@boolToInt#}
       <pre>{#syntax#}@boolToInt(value: bool) u1{#endsyntax#}</pre>
       <p>
@@ -6824,6 +7102,8 @@ async fn func(y: *i32) void {
           instead of {#syntax#}u1{#endsyntax#}.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@bitSizeOf#}
       <pre>{#syntax#}@bitSizeOf(comptime T: type) comptime_int{#endsyntax#}</pre>
@@ -6838,6 +7118,8 @@ async fn func(y: *i32) void {
       {#see_also|@sizeOf|@typeInfo#}
       {#header_close#}
 
+
+
       {#header_open|@breakpoint#}
       <pre>{#syntax#}@breakpoint(){#endsyntax#}</pre>
       <p>
@@ -6849,6 +7131,8 @@ async fn func(y: *i32) void {
       </p>
 
       {#header_close#}
+
+
       {#header_open|@mulAdd#}
       <pre>{#syntax#}@mulAdd(comptime T: type, a: T, b: T, c: T) T{#endsyntax#}</pre>
       <p>
@@ -6859,6 +7143,8 @@ async fn func(y: *i32) void {
       Supports Floats and Vectors of floats.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@byteSwap#}
       <pre>{#syntax#}@byteSwap(comptime T: type, operand: T) T{#endsyntax#}</pre>
@@ -6878,6 +7164,8 @@ async fn func(y: *i32) void {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@bitReverse#}
       <pre>{#syntax#}@bitReverse(comptime T: type, integer: T) T{#endsyntax#}</pre>
       <p>{#syntax#}T{#endsyntax#} accepts any integer type.</p>
@@ -6890,6 +7178,8 @@ async fn func(y: *i32) void {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@byteOffsetOf#}
       <pre>{#syntax#}@byteOffsetOf(comptime T: type, comptime field_name: []const u8) comptime_int{#endsyntax#}</pre>
       <p>
@@ -6898,67 +7188,71 @@ async fn func(y: *i32) void {
       {#see_also|@bitOffsetOf#}
       {#header_close#}
 
+
+
       {#header_open|@call#}
       <pre>{#syntax#}@call(options: std.builtin.CallOptions, function: var, args: var) var{#endsyntax#}</pre>
       <p>
       Calls a function, in the same way that invoking an expression with parentheses does:
       </p>
       {#code_begin|test|call#}
-const assert = @import("std").debug.assert;
-
-test "noinline function call" {
-    assert(@call(.{}, add, .{3, 9}) == 12);
-}
-
-fn add(a: i32, b: i32) i32 {
-    return a + b;
-}
+		const assert = @import("std").debug.assert;
+		
+		test "noinline function call" {
+		    assert(@call(.{}, add, .{3, 9}) == 12);
+		}
+		
+		fn add(a: i32, b: i32) i32 {
+		    return a + b;
+		}
       {#code_end#}
       <p>
       {#syntax#}@call{#endsyntax#} allows more flexibility than normal function call syntax does. The
       {#syntax#}CallOptions{#endsyntax#} struct is reproduced here:
       </p>
       {#code_begin|syntax#}
-pub const CallOptions = struct {
-    modifier: Modifier = .auto,
-    stack: ?[]align(std.Target.stack_align) u8 = null,
-
-    pub const Modifier = enum {
-        /// Equivalent to function call syntax.
-        auto,
-
-        /// Equivalent to async keyword used with function call syntax.
-        async_kw,
-
-        /// Prevents tail call optimization. This guarantees that the return
-        /// address will point to the callsite, as opposed to the callsite's
-        /// callsite. If the call is otherwise required to be tail-called
-        /// or inlined, a compile error is emitted instead.
-        never_tail,
-
-        /// Guarantees that the call will not be inlined. If the call is
-        /// otherwise required to be inlined, a compile error is emitted instead.
-        never_inline,
-
-        /// Asserts that the function call will not suspend. This allows a
-        /// non-async function to call an async function.
-        no_async,
-
-        /// Guarantees that the call will be generated with tail call optimization.
-        /// If this is not possible, a compile error is emitted instead.
-        always_tail,
-
-        /// Guarantees that the call will inlined at the callsite.
-        /// If this is not possible, a compile error is emitted instead.
-        always_inline,
-
-        /// Evaluates the call at compile-time. If the call cannot be completed at
-        /// compile-time, a compile error is emitted instead.
-        compile_time,
-    };
-};
+		pub const CallOptions = struct {
+		    modifier: Modifier = .auto,
+		    stack: ?[]align(std.Target.stack_align) u8 = null,
+		
+		    pub const Modifier = enum {
+		        /// Equivalent to function call syntax.
+		        auto,
+		
+		        /// Equivalent to async keyword used with function call syntax.
+		        async_kw,
+		
+		        /// Prevents tail call optimization. This guarantees that the return
+		        /// address will point to the callsite, as opposed to the callsite's
+		        /// callsite. If the call is otherwise required to be tail-called
+		        /// or inlined, a compile error is emitted instead.
+		        never_tail,
+		
+		        /// Guarantees that the call will not be inlined. If the call is
+		        /// otherwise required to be inlined, a compile error is emitted instead.
+		        never_inline,
+		
+		        /// Asserts that the function call will not suspend. This allows a
+		        /// non-async function to call an async function.
+		        no_async,
+		
+		        /// Guarantees that the call will be generated with tail call optimization.
+		        /// If this is not possible, a compile error is emitted instead.
+		        always_tail,
+		
+		        /// Guarantees that the call will inlined at the callsite.
+		        /// If this is not possible, a compile error is emitted instead.
+		        always_inline,
+		
+		        /// Evaluates the call at compile-time. If the call cannot be completed at
+		        /// compile-time, a compile error is emitted instead.
+		        compile_time,
+		    };
+		};
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|@cDefine#}
       <pre>{#syntax#}@cDefine(comptime name: []u8, value){#endsyntax#}</pre>
@@ -6979,6 +7273,8 @@ pub const CallOptions = struct {
       <pre>{#syntax#}@cDefine("_GNU_SOURCE", {}){#endsyntax#}</pre>
       {#see_also|Import from C Header File|@cInclude|@cImport|@cUndef|void#}
       {#header_close#}
+
+
       {#header_open|@cImport#}
       <pre>{#syntax#}@cImport(expression) type{#endsyntax#}</pre>
       <p>
@@ -7004,6 +7300,8 @@ pub const CallOptions = struct {
       </ul>
       {#see_also|Import from C Header File|@cInclude|@cDefine|@cUndef#}
       {#header_close#}
+
+
       {#header_open|@cInclude#}
       <pre>{#syntax#}@cInclude(comptime path: []u8){#endsyntax#}</pre>
       <p>
@@ -7015,6 +7313,8 @@ pub const CallOptions = struct {
       </p>
       {#see_also|Import from C Header File|@cImport|@cDefine|@cUndef#}
       {#header_close#}
+
+
 
       {#header_open|@clz#}
       <pre>{#syntax#}@clz(comptime T: type, integer: T){#endsyntax#}</pre>
@@ -7034,6 +7334,8 @@ pub const CallOptions = struct {
       {#see_also|@ctz|@popCount#}
       {#header_close#}
 
+
+
       {#header_open|@cmpxchgStrong#}
       <pre>{#syntax#}@cmpxchgStrong(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
@@ -7041,15 +7343,15 @@ pub const CallOptions = struct {
       except atomic:
       </p>
       {#code_begin|syntax#}
-fn cmpxchgStrongButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {
-    const old_value = ptr.*;
-    if (old_value == expected_value) {
-        ptr.* = new_value;
-        return null;
-    } else {
-        return old_value;
-    }
-}
+		fn cmpxchgStrongButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {
+		    const old_value = ptr.*;
+		    if (old_value == expected_value) {
+		        ptr.* = new_value;
+		        return null;
+		    } else {
+		        return old_value;
+		    }
+		}
       {#code_end#}
       <p>
       If you are using cmpxchg in a loop, {#link|@cmpxchgWeak#} is the better choice, because it can be implemented
@@ -7062,6 +7364,8 @@ fn cmpxchgStrongButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_v
       <p>{#syntax#}@TypeOf(ptr).alignment{#endsyntax#} must be {#syntax#}>= @sizeOf(T).{#endsyntax#}</p>
       {#see_also|Compile Variables|cmpxchgWeak#}
       {#header_close#}
+
+
       {#header_open|@cmpxchgWeak#}
       <pre>{#syntax#}@cmpxchgWeak(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
@@ -7069,15 +7373,15 @@ fn cmpxchgStrongButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_v
       except atomic:
       </p>
       {#code_begin|syntax#}
-fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {
-    const old_value = ptr.*;
-    if (old_value == expected_value and usuallyTrueButSometimesFalse()) {
-        ptr.* = new_value;
-        return null;
-    } else {
-        return old_value;
-    }
-}
+		fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {
+		    const old_value = ptr.*;
+		    if (old_value == expected_value and usuallyTrueButSometimesFalse()) {
+		        ptr.* = new_value;
+		        return null;
+		    } else {
+		        return old_value;
+		    }
+		}
       {#code_end#}
       <p>
       If you are using cmpxchg in a loop, the sporadic failure will be no problem, and {#syntax#}cmpxchgWeak{#endsyntax#}
@@ -7092,6 +7396,8 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       {#see_also|Compile Variables|cmpxchgStrong#}
       {#header_close#}
 
+
+
       {#header_open|@compileError#}
       <pre>{#syntax#}@compileError(comptime msg: []u8){#endsyntax#}</pre>
       <p>
@@ -7104,6 +7410,8 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
               and {#syntax#}comptime{#endsyntax#} functions.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@compileLog#}
       <pre>{#syntax#}@compileLog(args: ...){#endsyntax#}</pre>
@@ -7121,20 +7429,20 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       compile-time executing code.
       </p>
       {#code_begin|test_err|found compile log statement#}
-const warn = @import("std").debug.warn;
-
-const num1 = blk: {
-    var val1: i32 = 99;
-    @compileLog("comptime val1 = ", val1);
-    val1 = val1 + 1;
-    break :blk val1;
-};
-
-test "main" {
-    @compileLog("comptime in main");
-
-    warn("Runtime in main, num1 = {}.\n", .{num1});
-}
+		const warn = @import("std").debug.warn;
+		
+		const num1 = blk: {
+		    var val1: i32 = 99;
+		    @compileLog("comptime val1 = ", val1);
+		    val1 = val1 + 1;
+		    break :blk val1;
+		};
+		
+		test "main" {
+		    @compileLog("comptime in main");
+		
+		    warn("Runtime in main, num1 = {}.\n", .{num1});
+		}
       {#code_end#}
       <p>
       will ouput:
@@ -7145,19 +7453,21 @@ test "main" {
       program compiles successfully and the generated executable prints:
       </p>
       {#code_begin|test#}
-const warn = @import("std").debug.warn;
-
-const num1 = blk: {
-    var val1: i32 = 99;
-    val1 = val1 + 1;
-    break :blk val1;
-};
-
-test "main" {
-    warn("Runtime in main, num1 = {}.\n", .{num1});
-}
+		const warn = @import("std").debug.warn;
+		
+		const num1 = blk: {
+		    var val1: i32 = 99;
+		    val1 = val1 + 1;
+		    break :blk val1;
+		};
+		
+		test "main" {
+		    warn("Runtime in main, num1 = {}.\n", .{num1});
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|@ctz#}
       <pre>{#syntax#}@ctz(comptime T: type, integer: T){#endsyntax#}</pre>
@@ -7177,6 +7487,8 @@ test "main" {
       {#see_also|@clz|@popCount#}
       {#header_close#}
 
+
+
       {#header_open|@cUndef#}
       <pre>{#syntax#}@cUndef(comptime name: []u8){#endsyntax#}</pre>
       <p>
@@ -7188,6 +7500,8 @@ test "main" {
       </p>
       {#see_also|Import from C Header File|@cImport|@cDefine|@cInclude#}
       {#header_close#}
+
+
 
       {#header_open|@divExact#}
       <pre>{#syntax#}@divExact(numerator: T, denominator: T) T{#endsyntax#}</pre>
@@ -7202,6 +7516,8 @@ test "main" {
       <p>For a function that returns a possible error code, use {#syntax#}@import("std").math.divExact{#endsyntax#}.</p>
       {#see_also|@divTrunc|@divFloor#}
       {#header_close#}
+
+
       {#header_open|@divFloor#}
       <pre>{#syntax#}@divFloor(numerator: T, denominator: T) T{#endsyntax#}</pre>
       <p>
@@ -7216,6 +7532,8 @@ test "main" {
       <p>For a function that returns a possible error code, use {#syntax#}@import("std").math.divFloor{#endsyntax#}.</p>
       {#see_also|@divTrunc|@divExact#}
       {#header_close#}
+
+
       {#header_open|@divTrunc#}
       <pre>{#syntax#}@divTrunc(numerator: T, denominator: T) T{#endsyntax#}</pre>
       <p>
@@ -7230,6 +7548,8 @@ test "main" {
       <p>For a function that returns a possible error code, use {#syntax#}@import("std").math.divTrunc{#endsyntax#}.</p>
       {#see_also|@divFloor|@divExact#}
       {#header_close#}
+
+
       {#header_open|@embedFile#}
       <pre>{#syntax#}@embedFile(comptime path: []const u8) *const [X:0]u8{#endsyntax#}</pre>
       <p>
@@ -7245,6 +7565,8 @@ test "main" {
       {#see_also|@import#}
       {#header_close#}
 
+
+
       {#header_open|@enumToInt#}
       <pre>{#syntax#}@enumToInt(enum_or_tagged_union: var) var{#endsyntax#}</pre>
       <p>
@@ -7257,6 +7579,8 @@ test "main" {
       </p>
       {#see_also|@intToEnum#}
       {#header_close#}
+
+
 
       {#header_open|@errorName#}
       <pre>{#syntax#}@errorName(err: anyerror) []const u8{#endsyntax#}</pre>
@@ -7271,6 +7595,8 @@ test "main" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@errorReturnTrace#}
       <pre>{#syntax#}@errorReturnTrace() ?*builtin.StackTrace{#endsyntax#}</pre>
       <p>
@@ -7279,6 +7605,8 @@ test "main" {
       stack trace object. Otherwise returns `null`.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@errorToInt#}
       <pre>{#syntax#}@errorToInt(err: var) std.meta.IntType(false, @sizeOf(anyerror) * 8){#endsyntax#}</pre>
@@ -7300,6 +7628,8 @@ test "main" {
       {#see_also|@intToError#}
       {#header_close#}
 
+
+
       {#header_open|@errSetCast#}
       <pre>{#syntax#}@errSetCast(comptime T: DestType, value: var) DestType{#endsyntax#}</pre>
       <p>
@@ -7307,6 +7637,8 @@ test "main" {
       which is not in the destination error set results in safety-protected {#link|Undefined Behavior#}.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@export#}
       <pre>{#syntax#}@export(target: var, comptime options: std.builtin.ExportOptions) void{#endsyntax#}</pre>
@@ -7320,20 +7652,20 @@ test "main" {
       the {#syntax#}export{#endsyntax#} keyword used on a function:
       </p>
       {#code_begin|obj#}
-comptime {
-    @export(internalName, .{ .name = "foo", .linkage = .Strong });
-}
-
-fn internalName() callconv(.C) void {}
+		comptime {
+		    @export(internalName, .{ .name = "foo", .linkage = .Strong });
+		}
+		
+		fn internalName() callconv(.C) void {}
       {#code_end#}
       <p>This is equivalent to:</p>
       {#code_begin|obj#}
-export fn foo() void {}
+		export fn foo() void {}
       {#code_end#}
       <p>Note that even when using {#syntax#}export{#endsyntax#}, {#syntax#}@"foo"{#endsyntax#} syntax can
       be used to choose any string for the symbol name:</p>
       {#code_begin|obj#}
-export fn @"A function name that is a complete sentence."() void {}
+		export fn @"A function name that is a complete sentence."() void {}
       {#code_end#}
       <p>
       When looking at the resulting object, you can see the symbol is used verbatim:
@@ -7341,6 +7673,8 @@ export fn @"A function name that is a complete sentence."() void {}
       <pre>00000000000001f0 T A function name that is a complete sentence.</pre>
       {#see_also|Exporting a C Library#}
       {#header_close#}
+
+
 
       {#header_open|@fence#}
       <pre>{#syntax#}@fence(order: AtomicOrder){#endsyntax#}</pre>
@@ -7353,31 +7687,35 @@ export fn @"A function name that is a complete sentence."() void {}
       {#see_also|Compile Variables#}
       {#header_close#}
 
+
+
       {#header_open|@field#}
       <pre>{#syntax#}@field(lhs: var, comptime field_name: []const u8) (field){#endsyntax#}</pre>
       <p>Performs field access by a compile-time string.
       </p>
        {#code_begin|test#}
-const std = @import("std");
-
-const Point = struct {
-    x: u32,
-    y: u32
-};
-
-test "field access by string" {
-    const assert = std.debug.assert;
-    var p = Point {.x = 0, .y = 0};
-
-    @field(p, "x") = 4;
-    @field(p, "y") = @field(p, "x") + 1;
-
-    assert(@field(p, "x") == 4);
-    assert(@field(p, "y") == 5);
-}
+		const std = @import("std");
+		
+		const Point = struct {
+		    x: u32,
+		    y: u32
+		};
+		
+		test "field access by string" {
+		    const assert = std.debug.assert;
+		    var p = Point {.x = 0, .y = 0};
+		
+		    @field(p, "x") = 4;
+		    @field(p, "y") = @field(p, "x") + 1;
+		
+		    assert(@field(p, "x") == 4);
+		    assert(@field(p, "y") == 5);
+		}
       {#code_end#}
 
       {#header_close#}
+
+
 
       {#header_open|@fieldParentPtr#}
       <pre>{#syntax#}@fieldParentPtr(comptime ParentType: type, comptime field_name: []const u8,
@@ -7387,6 +7725,8 @@ test "field access by string" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@floatCast#}
       <pre>{#syntax#}@floatCast(comptime DestType: type, value: var) DestType{#endsyntax#}</pre>
       <p>
@@ -7394,6 +7734,8 @@ test "field access by string" {
       numeric value to lose precision.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@floatToInt#}
       <pre>{#syntax#}@floatToInt(comptime DestType: type, float: var) DestType{#endsyntax#}</pre>
@@ -7406,6 +7748,8 @@ test "field access by string" {
       </p>
       {#see_also|@intToFloat#}
       {#header_close#}
+
+
 
       {#header_open|@frame#}
       <pre>{#syntax#}@frame() *@Frame(func){#endsyntax#}</pre>
@@ -7421,6 +7765,8 @@ test "field access by string" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@Frame#}
       <pre>{#syntax#}@Frame(func: var) type{#endsyntax#}</pre>
       <p>
@@ -7432,18 +7778,20 @@ test "field access by string" {
       allows one to, for example, heap-allocate an async function frame:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-
-test "heap allocated frame" {
-    const frame = try std.heap.page_allocator.create(@Frame(func));
-    frame.* = async func();
-}
-
-fn func() void {
-    suspend;
-}
+		const std = @import("std");
+		
+		test "heap allocated frame" {
+		    const frame = try std.heap.page_allocator.create(@Frame(func));
+		    frame.* = async func();
+		}
+		
+		fn func() void {
+		    suspend;
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|@frameAddress#}
       <pre>{#syntax#}@frameAddress() usize{#endsyntax#}</pre>
@@ -7460,6 +7808,8 @@ fn func() void {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@frameSize#}
       <pre>{#syntax#}@frameSize() usize{#endsyntax#}</pre>
       <p>
@@ -7471,6 +7821,8 @@ fn func() void {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@hasDecl#}
       <pre>{#syntax#}@hasDecl(comptime Container: type, comptime name: []const u8) bool{#endsyntax#}</pre>
       <p>
@@ -7478,31 +7830,33 @@ fn func() void {
       matching {#syntax#}name{#endsyntax#}.
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-const Foo = struct {
-    nope: i32,
-
-    pub var blah = "xxx";
-    const hi = 1;
-};
-
-test "@hasDecl" {
-    assert(@hasDecl(Foo, "blah"));
-
-    // Even though `hi` is private, @hasDecl returns true because this test is
-    // in the same file scope as Foo. It would return false if Foo was declared
-    // in a different file.
-    assert(@hasDecl(Foo, "hi"));
-
-    // @hasDecl is for declarations; not fields.
-    assert(!@hasDecl(Foo, "nope"));
-    assert(!@hasDecl(Foo, "nope1234"));
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		const Foo = struct {
+		    nope: i32,
+		
+		    pub var blah = "xxx";
+		    const hi = 1;
+		};
+		
+		test "@hasDecl" {
+		    assert(@hasDecl(Foo, "blah"));
+		
+		    // Even though `hi` is private, @hasDecl returns true because this test is
+		    // in the same file scope as Foo. It would return false if Foo was declared
+		    // in a different file.
+		    assert(@hasDecl(Foo, "hi"));
+		
+		    // @hasDecl is for declarations; not fields.
+		    assert(!@hasDecl(Foo, "nope"));
+		    assert(!@hasDecl(Foo, "nope1234"));
+		}
       {#code_end#}
       {#see_also|@hasField#}
       {#header_close#}
+
+
 
       {#header_open|@hasField#}
       <pre>{#syntax#}@hasField(comptime Container: type, comptime name: []const u8) bool{#endsyntax#}</pre>
@@ -7515,6 +7869,8 @@ test "@hasDecl" {
       </p>
       {#see_also|@hasDecl#}
       {#header_close#}
+
+
 
       {#header_open|@import#}
       <pre>{#syntax#}@import(comptime path: []u8) type{#endsyntax#}</pre>
@@ -7547,6 +7903,8 @@ test "@hasDecl" {
       {#see_also|Compile Variables|@embedFile#}
       {#header_close#}
 
+
+
       {#header_open|@intCast#}
       <pre>{#syntax#}@intCast(comptime DestType: type, int: var) DestType{#endsyntax#}</pre>
       <p>
@@ -7560,6 +7918,8 @@ test "@hasDecl" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@intToEnum#}
       <pre>{#syntax#}@intToEnum(comptime DestType: type, int_value: @TagType(DestType)) DestType{#endsyntax#}</pre>
       <p>
@@ -7571,6 +7931,8 @@ test "@hasDecl" {
       </p>
       {#see_also|@enumToInt#}
       {#header_close#}
+
+
 
       {#header_open|@intToError#}
       <pre>{#syntax#}@intToError(value: std.meta.IntType(false, @sizeOf(anyerror) * 8)) anyerror{#endsyntax#}</pre>
@@ -7588,12 +7950,16 @@ test "@hasDecl" {
       {#see_also|@errorToInt#}
       {#header_close#}
 
+
+
       {#header_open|@intToFloat#}
       <pre>{#syntax#}@intToFloat(comptime DestType: type, int: var) DestType{#endsyntax#}</pre>
       <p>
       Converts an integer to the closest floating point representation. To convert the other way, use {#link|@floatToInt#}. This cast is always safe.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@intToPtr#}
       <pre>{#syntax#}@intToPtr(comptime DestType: type, address: usize) DestType{#endsyntax#}</pre>
@@ -7605,6 +7971,8 @@ test "@hasDecl" {
       is zero, this invokes safety-checked {#link|Undefined Behavior#}.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@memcpy#}
       <pre>{#syntax#}@memcpy(noalias dest: [*]u8, noalias source: [*]const u8, byte_count: usize){#endsyntax#}</pre>
@@ -7625,6 +7993,8 @@ test "@hasDecl" {
 mem.copy(u8, dest[0..byte_count], source[0..byte_count]);{#endsyntax#}</pre>
       {#header_close#}
 
+
+
       {#header_open|@memset#}
       <pre>{#syntax#}@memset(dest: [*]u8, c: u8, byte_count: usize){#endsyntax#}</pre>
       <p>
@@ -7643,6 +8013,8 @@ mem.copy(u8, dest[0..byte_count], source[0..byte_count]);{#endsyntax#}</pre>
 mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_close#}
 
+
+
       {#header_open|@mod#}
       <pre>{#syntax#}@mod(numerator: T, denominator: T) T{#endsyntax#}</pre>
       <p>
@@ -7657,6 +8029,8 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#see_also|@rem#}
       {#header_close#}
 
+
+
       {#header_open|@mulWithOverflow#}
       <pre>{#syntax#}@mulWithOverflow(comptime T: type, a: T, b: T, result: *T) bool{#endsyntax#}</pre>
       <p>
@@ -7665,6 +8039,8 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
                   If no overflow or underflow occurs, returns {#syntax#}false{#endsyntax#}.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@OpaqueType#}
       <pre>{#syntax#}@OpaqueType() type{#endsyntax#}</pre>
@@ -7676,19 +8052,21 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       Example:
       </p>
       {#code_begin|test_err|expected type '*Derp', found '*Wat'#}
-const Derp = @OpaqueType();
-const Wat = @OpaqueType();
-
-extern fn bar(d: *Derp) void;
-fn foo(w: *Wat) callconv(.C) void {
-    bar(w);
-}
-
-test "call foo" {
-    foo(undefined);
-}
+		const Derp = @OpaqueType();
+		const Wat = @OpaqueType();
+		
+		extern fn bar(d: *Derp) void;
+		fn foo(w: *Wat) callconv(.C) void {
+		    bar(w);
+		}
+		
+		test "call foo" {
+		    foo(undefined);
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|@panic#}
       <pre>{#syntax#}@panic(message: []const u8) noreturn{#endsyntax#}</pre>
@@ -7708,6 +8086,8 @@ test "call foo" {
       {#see_also|Root Source File#}
       {#header_close#}
 
+
+
       {#header_open|@popCount#}
       <pre>{#syntax#}@popCount(comptime T: type, integer: T){#endsyntax#}</pre>
       <p>Counts the number of bits set in an integer.</p>
@@ -7720,6 +8100,8 @@ test "call foo" {
       {#see_also|@ctz|@clz#}
       {#header_close#}
 
+
+
       {#header_open|@ptrCast#}
       <pre>{#syntax#}@ptrCast(comptime DestType: type, value: var) DestType{#endsyntax#}</pre>
       <p>
@@ -7730,6 +8112,8 @@ test "call foo" {
       to a non-optional pointer invokes safety-checked {#link|Undefined Behavior#}.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@ptrToInt#}
       <pre>{#syntax#}@ptrToInt(value: var) usize{#endsyntax#}</pre>
@@ -7746,6 +8130,8 @@ test "call foo" {
 
       {#header_close#}
 
+
+
       {#header_open|@rem#}
       <pre>{#syntax#}@rem(numerator: T, denominator: T) T{#endsyntax#}</pre>
       <p>
@@ -7759,6 +8145,8 @@ test "call foo" {
       <p>For a function that returns an error code, see {#syntax#}@import("std").math.rem{#endsyntax#}.</p>
       {#see_also|@mod#}
       {#header_close#}
+
+
 
       {#header_open|@returnAddress#}
       <pre>{#syntax#}@returnAddress() usize{#endsyntax#}</pre>
@@ -7775,6 +8163,8 @@ test "call foo" {
       a calling function, the returned address will apply to the calling function.
       </p>
       {#header_close#}
+
+
       {#header_open|@setAlignStack#}
       <pre>{#syntax#}@setAlignStack(comptime alignment: u29){#endsyntax#}</pre>
       <p>
@@ -7782,12 +8172,16 @@ test "call foo" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@setCold#}
       <pre>{#syntax#}@setCold(is_cold: bool){#endsyntax#}</pre>
       <p>
       Tells the optimizer that a function is rarely called.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@setEvalBranchQuota#}
       <pre>{#syntax#}@setEvalBranchQuota(new_quota: usize){#endsyntax#}</pre>
@@ -7803,26 +8197,28 @@ test "call foo" {
       Example:
       </p>
       {#code_begin|test_err|evaluation exceeded 1000 backwards branches#}
-test "foo" {
-    comptime {
-        var i = 0;
-        while (i < 1001) : (i += 1) {}
-    }
-}
+		test "foo" {
+		    comptime {
+		        var i = 0;
+		        while (i < 1001) : (i += 1) {}
+		    }
+		}
       {#code_end#}
       <p>Now we use {#syntax#}@setEvalBranchQuota{#endsyntax#}:</p>
       {#code_begin|test#}
-test "foo" {
-    comptime {
-        @setEvalBranchQuota(1001);
-        var i = 0;
-        while (i < 1001) : (i += 1) {}
-    }
-}
+		test "foo" {
+		    comptime {
+		        @setEvalBranchQuota(1001);
+		        var i = 0;
+		        while (i < 1001) : (i += 1) {}
+		    }
+		}
       {#code_end#}
 
       {#see_also|comptime#}
       {#header_close#}
+
+
 
       {#header_open|@setFloatMode#}
       <pre>{#syntax#}@setFloatMode(mode: @import("builtin").FloatMode){#endsyntax#}</pre>
@@ -7830,10 +8226,10 @@ test "foo" {
       Sets the floating point mode of the current scope. Possible values are:
       </p>
       {#code_begin|syntax#}
-pub const FloatMode = enum {
-    Strict,
-    Optimized,
-};
+		pub const FloatMode = enum {
+		    Strict,
+		    Optimized,
+		};
       {#code_end#}
       <ul>
         <li>
@@ -7859,39 +8255,43 @@ pub const FloatMode = enum {
       {#see_also|Floating Point Operations#}
       {#header_close#}
 
+
+
       {#header_open|@setRuntimeSafety#}
       <pre>{#syntax#}@setRuntimeSafety(safety_on: bool){#endsyntax#}</pre>
       <p>
       Sets whether runtime safety checks are enabled for the scope that contains the function call.
       </p>
       {#code_begin|test_safety|integer overflow#}
-      {#code_release_fast#}
-test "@setRuntimeSafety" {
-    // The builtin applies to the scope that it is called in. So here, integer overflow
-    // will not be caught in ReleaseFast and ReleaseSmall modes:
-    // var x: u8 = 255;
-    // x += 1; // undefined behavior in ReleaseFast/ReleaseSmall modes.
-    {
-        // However this block has safety enabled, so safety checks happen here,
-        // even in ReleaseFast and ReleaseSmall modes.
-        @setRuntimeSafety(true);
-        var x: u8 = 255;
-        x += 1;
-
-        {
-            // The value can be overridden at any scope. So here integer overflow
-            // would not be caught in any build mode.
-            @setRuntimeSafety(false);
-            // var x: u8 = 255;
-            // x += 1; // undefined behavior in all build modes.
-        }
-    }
-}
+		      {#code_release_fast#}
+		test "@setRuntimeSafety" {
+		    // The builtin applies to the scope that it is called in. So here, integer overflow
+		    // will not be caught in ReleaseFast and ReleaseSmall modes:
+		    // var x: u8 = 255;
+		    // x += 1; // undefined behavior in ReleaseFast/ReleaseSmall modes.
+		    {
+		        // However this block has safety enabled, so safety checks happen here,
+		        // even in ReleaseFast and ReleaseSmall modes.
+		        @setRuntimeSafety(true);
+		        var x: u8 = 255;
+		        x += 1;
+		
+		        {
+		            // The value can be overridden at any scope. So here integer overflow
+		            // would not be caught in any build mode.
+		            @setRuntimeSafety(false);
+		            // var x: u8 = 255;
+		            // x += 1; // undefined behavior in all build modes.
+		        }
+		    }
+		}
       {#code_end#}
       <p>Note: it is <a href="https://github.com/ziglang/zig/issues/978">planned</a> to replace
       {#syntax#}@setRuntimeSafety{#endsyntax#} with <code>@optimizeFor</code></p>
 
       {#header_close#}
+
+
 
       {#header_open|@shlExact#}
       <pre>{#syntax#}@shlExact(value: T, shift_amt: Log2T) T{#endsyntax#}</pre>
@@ -7905,6 +8305,8 @@ test "@setRuntimeSafety" {
       </p>
       {#see_also|@shrExact|@shlWithOverflow#}
       {#header_close#}
+
+
 
       {#header_open|@shlWithOverflow#}
       <pre>{#syntax#}@shlWithOverflow(comptime T: type, a: T, shift_amt: Log2T, result: *T) bool{#endsyntax#}</pre>
@@ -7920,6 +8322,8 @@ test "@setRuntimeSafety" {
       {#see_also|@shlExact|@shrExact#}
       {#header_close#}
 
+
+
       {#header_open|@shrExact#}
       <pre>{#syntax#}@shrExact(value: T, shift_amt: Log2T) T{#endsyntax#}</pre>
       <p>
@@ -7932,6 +8336,8 @@ test "@setRuntimeSafety" {
       </p>
       {#see_also|@shlExact|@shlWithOverflow#}
       {#header_close#}
+
+
 
       {#header_open|@shuffle#}
       <pre>{#syntax#}@shuffle(comptime E: type, a: @Vector(a_len, E), b: @Vector(b_len, E), comptime mask: @Vector(mask_len, i32)) @Vector(mask_len, E){#endsyntax#}</pre>
@@ -7970,6 +8376,8 @@ test "@setRuntimeSafety" {
       {#see_also|SIMD#}
       {#header_close#}
 
+
+
       {#header_open|@sizeOf#}
       <pre>{#syntax#}@sizeOf(comptime T: type) comptime_int{#endsyntax#}</pre>
       <p>
@@ -7989,6 +8397,8 @@ test "@setRuntimeSafety" {
       {#see_also|@bitSizeOf|@typeInfo#}
       {#header_close#}
 
+
+
       {#header_open|@splat#}
       <pre>{#syntax#}@splat(comptime len: u32, scalar: var) @Vector(len, @TypeOf(scalar)){#endsyntax#}</pre>
       <p>
@@ -7996,15 +8406,15 @@ test "@setRuntimeSafety" {
       {#syntax#}scalar{#endsyntax#}:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "vector @splat" {
-    const scalar: u32 = 5;
-    const result = @splat(4, scalar);
-    comptime assert(@TypeOf(result) == @Vector(4, u32));
-    assert(std.mem.eql(u32, &@as([4]u32, result), &[_]u32{ 5, 5, 5, 5 }));
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "vector @splat" {
+		    const scalar: u32 = 5;
+		    const result = @splat(4, scalar);
+		    comptime assert(@TypeOf(result) == @Vector(4, u32));
+		    assert(std.mem.eql(u32, &@as([4]u32, result), &[_]u32{ 5, 5, 5, 5 }));
+		}
       {#code_end#}
       <p>
       {#syntax#}scalar{#endsyntax#} must be an {#link|integer|Integers#}, {#link|bool|Primitive Types#},
@@ -8012,6 +8422,8 @@ test "vector @splat" {
       </p>
       {#see_also|Vectors|@shuffle#}
       {#header_close#}
+
+
 
       {#header_open|@sqrt#}
       <pre>{#syntax#}@sqrt(value: var) @TypeOf(value){#endsyntax#}</pre>
@@ -8024,6 +8436,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@sin#}
       <pre>{#syntax#}@sin(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8035,6 +8449,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@cos#}
       <pre>{#syntax#}@cos(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8046,6 +8462,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@exp#}
       <pre>{#syntax#}@exp(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8057,6 +8475,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@exp2#}
       <pre>{#syntax#}@exp2(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8068,6 +8488,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@log#}
       <pre>{#syntax#}@log(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8079,6 +8501,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@log2#}
       <pre>{#syntax#}@log2(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8090,6 +8514,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@log10#}
       <pre>{#syntax#}@log10(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8101,6 +8527,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@fabs#}
       <pre>{#syntax#}@fabs(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8112,6 +8540,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@floor#}
       <pre>{#syntax#}@floor(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8123,6 +8553,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@ceil#}
       <pre>{#syntax#}@ceil(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8134,6 +8566,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@trunc#}
       <pre>{#syntax#}@trunc(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8145,6 +8579,8 @@ test "vector @splat" {
       <a href="https://github.com/ziglang/zig/issues/4026">some float operations are not yet implemented for all float types</a>.
       </p>
       {#header_close#}
+
+
       {#header_open|@round#}
       <pre>{#syntax#}@round(value: var) @TypeOf(value){#endsyntax#}</pre>
       <p>
@@ -8157,6 +8593,8 @@ test "vector @splat" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@subWithOverflow#}
       <pre>{#syntax#}@subWithOverflow(comptime T: type, a: T, b: T, result: *T) bool{#endsyntax#}</pre>
       <p>
@@ -8166,12 +8604,16 @@ test "vector @splat" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@tagName#}
       <pre>{#syntax#}@tagName(value: var) []const u8{#endsyntax#}</pre>
       <p>
       Converts an enum value or union value to a slice of bytes representing the name.</p><p>If the enum is non-exhaustive and the tag value does not map to a name, it invokes safety-checked {#link|Undefined Behavior#}.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@TagType#}
       <pre>{#syntax#}@TagType(T: type) type{#endsyntax#}</pre>
@@ -8183,6 +8625,8 @@ test "vector @splat" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@This#}
       <pre>{#syntax#}@This() type{#endsyntax#}</pre>
       <p>
@@ -8190,26 +8634,26 @@ test "vector @splat" {
       This can be useful for an anonymous struct that needs to refer to itself:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "@This()" {
-    var items = [_]i32{ 1, 2, 3, 4 };
-    const list = List(i32){ .items = items[0..] };
-    assert(list.length() == 4);
-}
-
-fn List(comptime T: type) type {
-    return struct {
-        const Self = @This();
-
-        items: []T,
-
-        fn length(self: Self) usize {
-            return self.items.len;
-        }
-    };
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "@This()" {
+		    var items = [_]i32{ 1, 2, 3, 4 };
+		    const list = List(i32){ .items = items[0..] };
+		    assert(list.length() == 4);
+		}
+		
+		fn List(comptime T: type) type {
+		    return struct {
+		        const Self = @This();
+		
+		        items: []T,
+		
+		        fn length(self: Self) usize {
+		            return self.items.len;
+		        }
+		    };
+		}
       {#code_end#}
       <p>
       When {#syntax#}@This(){#endsyntax#} is used at global scope, it returns a reference to the
@@ -8218,6 +8662,8 @@ fn List(comptime T: type) type {
       <a href="https://github.com/ziglang/zig/issues/1047">#1047</a> for details.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@truncate#}
       <pre>{#syntax#}@truncate(comptime T: type, integer: var) T{#endsyntax#}</pre>
@@ -8229,29 +8675,31 @@ fn List(comptime T: type) type {
       The following produces safety-checked {#link|Undefined Behavior#}:
       </p>
       {#code_begin|test_err|cast truncated bits#}
-test "integer cast panic" {
-    var a: u16 = 0xabcd;
-    var b: u8 = @intCast(u8, a);
-}
+		test "integer cast panic" {
+		    var a: u16 = 0xabcd;
+		    var b: u8 = @intCast(u8, a);
+		}
       {#code_end#}
       <p>
       However this is well defined and working code:
       </p>
       {#code_begin|test|truncate#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "integer truncation" {
-    var a: u16 = 0xabcd;
-    var b: u8 = @truncate(u8, a);
-    assert(b == 0xcd);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "integer truncation" {
+		    var a: u16 = 0xabcd;
+		    var b: u8 = @truncate(u8, a);
+		    assert(b == 0xcd);
+		}
       {#code_end#}
       <p>
       This function always truncates the significant bits of the integer, regardless
       of endianness on the target platform.
       </p>
       {#header_close#}
+
+
 
       {#header_open|@Type#}
       <pre>{#syntax#}@Type(comptime info: @import("builtin").TypeInfo) type{#endsyntax#}</pre>
@@ -8302,6 +8750,8 @@ test "integer truncation" {
           <li>{#link|struct#}</li>
       </ul>
       {#header_close#}
+
+
       {#header_open|@typeInfo#}
       <pre>{#syntax#}@typeInfo(comptime T: type) @import("std").builtin.TypeInfo{#endsyntax#}</pre>
       <p>
@@ -8314,6 +8764,8 @@ test "integer truncation" {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@typeName#}
       <pre>{#syntax#}@typeName(T: type) [N]u8{#endsyntax#}</pre>
       <p>
@@ -8322,6 +8774,8 @@ test "integer truncation" {
       </p>
 
       {#header_close#}
+
+
 
       {#header_open|@TypeOf#}
       <pre>{#syntax#}@TypeOf(...) type{#endsyntax#}</pre>
@@ -8333,22 +8787,24 @@ test "integer truncation" {
       The expressions are evaluated, however they are guaranteed to have no <em>runtime</em> side-effects:
       </p>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "no runtime side effects" {
-    var data: i32 = 0;
-    const T = @TypeOf(foo(i32, &data));
-    comptime assert(T == i32);
-    assert(data == 0);
-}
-
-fn foo(comptime T: type, ptr: *T) T {
-    ptr.* += 1;
-    return ptr.*;
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "no runtime side effects" {
+		    var data: i32 = 0;
+		    const T = @TypeOf(foo(i32, &data));
+		    comptime assert(T == i32);
+		    assert(data == 0);
+		}
+		
+		fn foo(comptime T: type, ptr: *T) T {
+		    ptr.* += 1;
+		    return ptr.*;
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|@unionInit#}
       <pre>{#syntax#}@unionInit(comptime Union: type, comptime active_field_name: []const u8, init_expr) Union{#endsyntax#}</pre>
@@ -8361,6 +8817,8 @@ fn foo(comptime T: type, ptr: *T) T {
       </p>
       {#header_close#}
 
+
+
       {#header_open|@Vector#}
       <pre>{#syntax#}@Vector(comptime len: u32, comptime ElemType: type) type{#endsyntax#}</pre>
       <p>
@@ -8372,6 +8830,8 @@ fn foo(comptime T: type, ptr: *T) T {
       </p>
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|Build Mode#}
       <p>
@@ -8387,13 +8847,13 @@ fn foo(comptime T: type, ptr: *T) T {
       To add standard build options to a <code>build.zig</code> file:
       </p>
       {#code_begin|syntax#}
-const Builder = @import("std").build.Builder;
-
-pub fn build(b: *Builder) void {
-    const exe = b.addExecutable("example", "example.zig");
-    exe.setBuildMode(b.standardReleaseOptions());
-    b.default_step.dependOn(&exe.step);
-}
+		const Builder = @import("std").build.Builder;
+		
+		pub fn build(b: *Builder) void {
+		    const exe = b.addExecutable("example", "example.zig");
+		    exe.setBuildMode(b.standardReleaseOptions());
+		    b.default_step.dependOn(&exe.step);
+		}
       {#code_end#}
       <p>
       This causes these options to be available:
@@ -8401,6 +8861,8 @@ pub fn build(b: *Builder) void {
       <pre><code class="shell">  -Drelease-safe=[bool] optimizations on and safety on
   -Drelease-fast=[bool] optimizations on and safety off
   -Drelease-small=[bool] size optimizations on and safety off</code></pre>
+
+
       {#header_open|Debug#}
       <pre><code class="shell">$ zig build-exe example.zig</code></pre>
       <ul>
@@ -8411,6 +8873,8 @@ pub fn build(b: *Builder) void {
         <li>No reproducible build requirement</li>
       </ul>
       {#header_close#}
+
+
       {#header_open|ReleaseFast#}
       <pre><code class="shell">$ zig build-exe example.zig --release-fast</code></pre>
       <ul>
@@ -8421,6 +8885,8 @@ pub fn build(b: *Builder) void {
         <li>Reproducible build</li>
       </ul>
       {#header_close#}
+
+
       {#header_open|ReleaseSafe#}
       <pre><code class="shell">$ zig build-exe example.zig --release-safe</code></pre>
       <ul>
@@ -8431,6 +8897,8 @@ pub fn build(b: *Builder) void {
         <li>Reproducible build</li>
       </ul>
       {#header_close#}
+
+
       {#header_open|ReleaseSmall#}
       <pre><code class="shell">$ zig build-exe example.zig --release-small</code></pre>
       <ul>
@@ -8444,6 +8912,8 @@ pub fn build(b: *Builder) void {
       {#see_also|Compile Variables|Zig Build System|Undefined Behavior#}
       {#header_close#}
 
+
+
       {#header_open|Single Threaded Builds#}
       <p>Zig has a compile option <code>--single-threaded</code> which has the following effects:</p>
       <ul>
@@ -8455,6 +8925,8 @@ pub fn build(b: *Builder) void {
           an empty data structure and all of its functions become no-ops.</li>
       </ul>
       {#header_close#}
+
+
 
       {#header_open|Undefined Behavior#}
       <p>
@@ -8470,93 +8942,105 @@ pub fn build(b: *Builder) void {
       When a safety check fails, Zig crashes with a stack trace, like this:
       </p>
       {#code_begin|test_err|reached unreachable code#}
-test "safety check" {
-    unreachable;
-}
+		test "safety check" {
+		    unreachable;
+		}
       {#code_end#}
+
+
       {#header_open|Reaching Unreachable Code#}
       <p>At compile-time:</p>
       {#code_begin|test_err|unable to evaluate constant expression#}
-comptime {
-    assert(false);
-}
-fn assert(ok: bool) void {
-    if (!ok) unreachable; // assertion failure
-}
+		comptime {
+		    assert(false);
+		}
+		fn assert(ok: bool) void {
+		    if (!ok) unreachable; // assertion failure
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    std.debug.assert(false);
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    std.debug.assert(false);
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Index out of Bounds#}
       <p>At compile-time:</p>
       {#code_begin|test_err|index 5 outside array of size 5#}
-comptime {
-    const array: [5]u8 = "hello".*;
-    const garbage = array[5];
-}
+		comptime {
+		    const array: [5]u8 = "hello".*;
+		    const garbage = array[5];
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-pub fn main() void {
-    var x = foo("hello");
-}
-
-fn foo(x: []const u8) u8 {
-    return x[5];
-}
+		pub fn main() void {
+		    var x = foo("hello");
+		}
+		
+		fn foo(x: []const u8) u8 {
+		    return x[5];
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Cast Negative Number to Unsigned Integer#}
       <p>At compile-time:</p>
       {#code_begin|test_err|cannot cast negative value -1 to unsigned integer type 'u32'#}
-comptime {
-    const value: i32 = -1;
-    const unsigned = @intCast(u32, value);
-}
+		comptime {
+		    const value: i32 = -1;
+		    const unsigned = @intCast(u32, value);
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    var value: i32 = -1;
-    var unsigned = @intCast(u32, value);
-    std.debug.warn("value: {}\n", .{unsigned});
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    var value: i32 = -1;
+		    var unsigned = @intCast(u32, value);
+		    std.debug.warn("value: {}\n", .{unsigned});
+		}
       {#code_end#}
       <p>
       To obtain the maximum value of an unsigned integer, use {#syntax#}std.math.maxInt{#endsyntax#}.
       </p>
       {#header_close#}
+
+
       {#header_open|Cast Truncates Data#}
       <p>At compile-time:</p>
       {#code_begin|test_err|integer value 300 cannot be coerced to type 'u8'#}
-comptime {
-    const spartan_count: u16 = 300;
-    const byte = @intCast(u8, spartan_count);
-}
+		comptime {
+		    const spartan_count: u16 = 300;
+		    const byte = @intCast(u8, spartan_count);
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    var spartan_count: u16 = 300;
-    const byte = @intCast(u8, spartan_count);
-    std.debug.warn("value: {}\n", .{byte});
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    var spartan_count: u16 = 300;
+		    const byte = @intCast(u8, spartan_count);
+		    std.debug.warn("value: {}\n", .{byte});
+		}
       {#code_end#}
       <p>
       To truncate bits, use {#link|@truncate#}.
       </p>
       {#header_close#}
+
+
       {#header_open|Integer Overflow#}
+
+
       {#header_open|Default Operations#}
       <p>The following operators can cause integer overflow:</p>
       <ul>
@@ -8571,22 +9055,24 @@ pub fn main() void {
       </ul>
       <p>Example with addition at compile-time:</p>
       {#code_begin|test_err|operation caused overflow#}
-comptime {
-    var byte: u8 = 255;
-    byte += 1;
-}
+		comptime {
+		    var byte: u8 = 255;
+		    byte += 1;
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    var byte: u8 = 255;
-    byte += 1;
-    std.debug.warn("value: {}\n", .{byte});
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    var byte: u8 = 255;
+		    byte += 1;
+		    std.debug.warn("value: {}\n", .{byte});
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Standard Library Math Functions#}
       <p>These functions provided by the standard library return possible errors.</p>
       <ul>
@@ -8600,20 +9086,22 @@ pub fn main() void {
       </ul>
       <p>Example of catching an overflow for addition:</p>
       {#code_begin|exe_err#}
-const math = @import("std").math;
-const warn = @import("std").debug.warn;
-pub fn main() !void {
-    var byte: u8 = 255;
-
-    byte = if (math.add(u8, byte, 1)) |result| result else |err| {
-        warn("unable to add one: {}\n", .{@errorName(err)});
-        return err;
-    };
-
-    warn("result: {}\n", .{byte});
-}
+		const math = @import("std").math;
+		const warn = @import("std").debug.warn;
+		pub fn main() !void {
+		    var byte: u8 = 255;
+		
+		    byte = if (math.add(u8, byte, 1)) |result| result else |err| {
+		        warn("unable to add one: {}\n", .{@errorName(err)});
+		        return err;
+		    };
+		
+		    warn("result: {}\n", .{byte});
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Builtin Overflow Functions#}
       <p>
       These builtins return a {#syntax#}bool{#endsyntax#} of whether or not overflow
@@ -8629,19 +9117,21 @@ pub fn main() !void {
       Example of {#link|@addWithOverflow#}:
       </p>
       {#code_begin|exe#}
-const warn = @import("std").debug.warn;
-pub fn main() void {
-    var byte: u8 = 255;
-
-    var result: u8 = undefined;
-    if (@addWithOverflow(u8, byte, 10, &result)) {
-        warn("overflowed result: {}\n", .{result});
-    } else {
-        warn("result: {}\n", .{result});
-    }
-}
+		const warn = @import("std").debug.warn;
+		pub fn main() void {
+		    var byte: u8 = 255;
+		
+		    var result: u8 = undefined;
+		    if (@addWithOverflow(u8, byte, 10, &result)) {
+		        warn("overflowed result: {}\n", .{result});
+		    } else {
+		        warn("result: {}\n", .{result});
+		    }
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Wrapping Operations#}
       <p>
       These operations have guaranteed wraparound semantics.
@@ -8653,342 +9143,366 @@ pub fn main() void {
           <li>{#syntax#}*%{#endsyntax#} (wraparound multiplication)</li>
       </ul>
       {#code_begin|test#}
-const std = @import("std");
-const assert = std.debug.assert;
-const minInt = std.math.minInt;
-const maxInt = std.math.maxInt;
-
-test "wraparound addition and subtraction" {
-    const x: i32 = maxInt(i32);
-    const min_val = x +% 1;
-    assert(min_val == minInt(i32));
-    const max_val = min_val -% 1;
-    assert(max_val == maxInt(i32));
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		const minInt = std.math.minInt;
+		const maxInt = std.math.maxInt;
+		
+		test "wraparound addition and subtraction" {
+		    const x: i32 = maxInt(i32);
+		    const min_val = x +% 1;
+		    assert(min_val == minInt(i32));
+		    const max_val = min_val -% 1;
+		    assert(max_val == maxInt(i32));
+		}
       {#code_end#}
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Exact Left Shift Overflow#}
       <p>At compile-time:</p>
       {#code_begin|test_err|operation caused overflow#}
-comptime {
-    const x = @shlExact(@as(u8, 0b01010101), 2);
-}
+		comptime {
+		    const x = @shlExact(@as(u8, 0b01010101), 2);
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    var x: u8 = 0b01010101;
-    var y = @shlExact(x, 2);
-    std.debug.warn("value: {}\n", .{y});
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    var x: u8 = 0b01010101;
+		    var y = @shlExact(x, 2);
+		    std.debug.warn("value: {}\n", .{y});
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Exact Right Shift Overflow#}
       <p>At compile-time:</p>
       {#code_begin|test_err|exact shift shifted out 1 bits#}
-comptime {
-    const x = @shrExact(@as(u8, 0b10101010), 2);
-}
+		comptime {
+		    const x = @shrExact(@as(u8, 0b10101010), 2);
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    var x: u8 = 0b10101010;
-    var y = @shrExact(x, 2);
-    std.debug.warn("value: {}\n", .{y});
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    var x: u8 = 0b10101010;
+		    var y = @shrExact(x, 2);
+		    std.debug.warn("value: {}\n", .{y});
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Division by Zero#}
       <p>At compile-time:</p>
       {#code_begin|test_err|division by zero#}
-comptime {
-    const a: i32 = 1;
-    const b: i32 = 0;
-    const c = a / b;
-}
+		comptime {
+		    const a: i32 = 1;
+		    const b: i32 = 0;
+		    const c = a / b;
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    var a: u32 = 1;
-    var b: u32 = 0;
-    var c = a / b;
-    std.debug.warn("value: {}\n", .{c});
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    var a: u32 = 1;
+		    var b: u32 = 0;
+		    var c = a / b;
+		    std.debug.warn("value: {}\n", .{c});
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Remainder Division by Zero#}
       <p>At compile-time:</p>
       {#code_begin|test_err|division by zero#}
-comptime {
-    const a: i32 = 10;
-    const b: i32 = 0;
-    const c = a % b;
-}
+		comptime {
+		    const a: i32 = 10;
+		    const b: i32 = 0;
+		    const c = a % b;
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    var a: u32 = 10;
-    var b: u32 = 0;
-    var c = a % b;
-    std.debug.warn("value: {}\n", .{c});
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    var a: u32 = 10;
+		    var b: u32 = 0;
+		    var c = a % b;
+		    std.debug.warn("value: {}\n", .{c});
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Exact Division Remainder#}
       <p>At compile-time:</p>
       {#code_begin|test_err|exact division had a remainder#}
-comptime {
-    const a: u32 = 10;
-    const b: u32 = 3;
-    const c = @divExact(a, b);
-}
+		comptime {
+		    const a: u32 = 10;
+		    const b: u32 = 3;
+		    const c = @divExact(a, b);
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    var a: u32 = 10;
-    var b: u32 = 3;
-    var c = @divExact(a, b);
-    std.debug.warn("value: {}\n", .{c});
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    var a: u32 = 10;
+		    var b: u32 = 3;
+		    var c = @divExact(a, b);
+		    std.debug.warn("value: {}\n", .{c});
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Attempt to Unwrap Null#}
       <p>At compile-time:</p>
       {#code_begin|test_err|unable to unwrap null#}
-comptime {
-    const optional_number: ?i32 = null;
-    const number = optional_number.?;
-}
+		comptime {
+		    const optional_number: ?i32 = null;
+		    const number = optional_number.?;
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    var optional_number: ?i32 = null;
-    var number = optional_number.?;
-    std.debug.warn("value: {}\n", .{number});
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    var optional_number: ?i32 = null;
+		    var number = optional_number.?;
+		    std.debug.warn("value: {}\n", .{number});
+		}
       {#code_end#}
       <p>One way to avoid this crash is to test for null instead of assuming non-null, with
       the {#syntax#}if{#endsyntax#} expression:</p>
       {#code_begin|exe|test#}
-const warn = @import("std").debug.warn;
-pub fn main() void {
-    const optional_number: ?i32 = null;
-
-    if (optional_number) |number| {
-        warn("got number: {}\n", .{number});
-    } else {
-        warn("it's null\n", .{});
-    }
-}
+		const warn = @import("std").debug.warn;
+		pub fn main() void {
+		    const optional_number: ?i32 = null;
+		
+		    if (optional_number) |number| {
+		        warn("got number: {}\n", .{number});
+		    } else {
+		        warn("it's null\n", .{});
+		    }
+		}
       {#code_end#}
       {#see_also|Optionals#}
       {#header_close#}
+
+
       {#header_open|Attempt to Unwrap Error#}
       <p>At compile-time:</p>
       {#code_begin|test_err|caught unexpected error 'UnableToReturnNumber'#}
-comptime {
-    const number = getNumberOrFail() catch unreachable;
-}
-
-fn getNumberOrFail() !i32 {
-    return error.UnableToReturnNumber;
-}
+		comptime {
+		    const number = getNumberOrFail() catch unreachable;
+		}
+		
+		fn getNumberOrFail() !i32 {
+		    return error.UnableToReturnNumber;
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    const number = getNumberOrFail() catch unreachable;
-    std.debug.warn("value: {}\n", .{number});
-}
-
-fn getNumberOrFail() !i32 {
-    return error.UnableToReturnNumber;
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    const number = getNumberOrFail() catch unreachable;
+		    std.debug.warn("value: {}\n", .{number});
+		}
+		
+		fn getNumberOrFail() !i32 {
+		    return error.UnableToReturnNumber;
+		}
       {#code_end#}
       <p>One way to avoid this crash is to test for an error instead of assuming a successful result, with
       the {#syntax#}if{#endsyntax#} expression:</p>
       {#code_begin|exe#}
-const warn = @import("std").debug.warn;
-
-pub fn main() void {
-    const result = getNumberOrFail();
-
-    if (result) |number| {
-        warn("got number: {}\n", .{number});
-    } else |err| {
-        warn("got error: {}\n", .{@errorName(err)});
-    }
-}
-
-fn getNumberOrFail() !i32 {
-    return error.UnableToReturnNumber;
-}
+		const warn = @import("std").debug.warn;
+		
+		pub fn main() void {
+		    const result = getNumberOrFail();
+		
+		    if (result) |number| {
+		        warn("got number: {}\n", .{number});
+		    } else |err| {
+		        warn("got error: {}\n", .{@errorName(err)});
+		    }
+		}
+		
+		fn getNumberOrFail() !i32 {
+		    return error.UnableToReturnNumber;
+		}
       {#code_end#}
       {#see_also|Errors#}
       {#header_close#}
+
+
       {#header_open|Invalid Error Code#}
       <p>At compile-time:</p>
       {#code_begin|test_err|integer value 11 represents no error#}
-comptime {
-    const err = error.AnError;
-    const number = @errorToInt(err) + 10;
-    const invalid_err = @intToError(number);
-}
+		comptime {
+		    const err = error.AnError;
+		    const number = @errorToInt(err) + 10;
+		    const invalid_err = @intToError(number);
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-pub fn main() void {
-    var err = error.AnError;
-    var number = @errorToInt(err) + 500;
-    var invalid_err = @intToError(number);
-    std.debug.warn("value: {}\n", .{number});
-}
+		const std = @import("std");
+		
+		pub fn main() void {
+		    var err = error.AnError;
+		    var number = @errorToInt(err) + 500;
+		    var invalid_err = @intToError(number);
+		    std.debug.warn("value: {}\n", .{number});
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Invalid Enum Cast#}
       <p>At compile-time:</p>
       {#code_begin|test_err|has no tag matching integer value 3#}
-const Foo = enum {
-    A,
-    B,
-    C,
-};
-comptime {
-    const a: u2 = 3;
-    const b = @intToEnum(Foo, a);
-}
+		const Foo = enum {
+		    A,
+		    B,
+		    C,
+		};
+		comptime {
+		    const a: u2 = 3;
+		    const b = @intToEnum(Foo, a);
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-const Foo = enum {
-    A,
-    B,
-    C,
-};
-
-pub fn main() void {
-    var a: u2 = 3;
-    var b = @intToEnum(Foo, a);
-    std.debug.warn("value: {}\n", .{@tagName(b)});
-}
+		const std = @import("std");
+		
+		const Foo = enum {
+		    A,
+		    B,
+		    C,
+		};
+		
+		pub fn main() void {
+		    var a: u2 = 3;
+		    var b = @intToEnum(Foo, a);
+		    std.debug.warn("value: {}\n", .{@tagName(b)});
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|Invalid Error Set Cast#}
       <p>At compile-time:</p>
       {#code_begin|test_err|error.B not a member of error set 'Set2'#}
-const Set1 = error{
-    A,
-    B,
-};
-const Set2 = error{
-    A,
-    C,
-};
-comptime {
-    _ = @errSetCast(Set2, Set1.B);
-}
+		const Set1 = error{
+		    A,
+		    B,
+		};
+		const Set2 = error{
+		    A,
+		    C,
+		};
+		comptime {
+		    _ = @errSetCast(Set2, Set1.B);
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-const Set1 = error{
-    A,
-    B,
-};
-const Set2 = error{
-    A,
-    C,
-};
-pub fn main() void {
-    foo(Set1.B);
-}
-fn foo(set1: Set1) void {
-    const x = @errSetCast(Set2, set1);
-    std.debug.warn("value: {}\n", .{x});
-}
+		const std = @import("std");
+		
+		const Set1 = error{
+		    A,
+		    B,
+		};
+		const Set2 = error{
+		    A,
+		    C,
+		};
+		pub fn main() void {
+		    foo(Set1.B);
+		}
+		fn foo(set1: Set1) void {
+		    const x = @errSetCast(Set2, set1);
+		    std.debug.warn("value: {}\n", .{x});
+		}
       {#code_end#}
       {#header_close#}
+
+
 
       {#header_open|Incorrect Pointer Alignment#}
       <p>At compile-time:</p>
       {#code_begin|test_err|pointer address 0x1 is not aligned to 4 bytes#}
-comptime {
-    const ptr = @intToPtr(*align(1) i32, 0x1);
-    const aligned = @alignCast(4, ptr);
-}
+		comptime {
+		    const ptr = @intToPtr(*align(1) i32, 0x1);
+		    const aligned = @alignCast(4, ptr);
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const mem = @import("std").mem;
-pub fn main() !void {
-    var array align(4) = [_]u32{ 0x11111111, 0x11111111 };
-    const bytes = mem.sliceAsBytes(array[0..]);
-    if (foo(bytes) != 0x11111111) return error.Wrong;
-}
-fn foo(bytes: []u8) u32 {
-    const slice4 = bytes[1..5];
-    const int_slice = mem.bytesAsSlice(u32, @alignCast(4, slice4));
-    return int_slice[0];
-}
+		const mem = @import("std").mem;
+		pub fn main() !void {
+		    var array align(4) = [_]u32{ 0x11111111, 0x11111111 };
+		    const bytes = mem.sliceAsBytes(array[0..]);
+		    if (foo(bytes) != 0x11111111) return error.Wrong;
+		}
+		fn foo(bytes: []u8) u32 {
+		    const slice4 = bytes[1..5];
+		    const int_slice = mem.bytesAsSlice(u32, @alignCast(4, slice4));
+		    return int_slice[0];
+		}
       {#code_end#}
       {#header_close#}
+
+
       {#header_open|Wrong Union Field Access#}
       <p>At compile-time:</p>
       {#code_begin|test_err|accessing union field 'float' while field 'int' is set#}
-comptime {
-    var f = Foo{ .int = 42 };
-    f.float = 12.34;
-}
-
-const Foo = union {
-    float: f32,
-    int: u32,
-};
+		comptime {
+		    var f = Foo{ .int = 42 };
+		    f.float = 12.34;
+		}
+		
+		const Foo = union {
+		    float: f32,
+		    int: u32,
+		};
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-const std = @import("std");
-
-const Foo = union {
-    float: f32,
-    int: u32,
-};
-
-pub fn main() void {
-    var f = Foo{ .int = 42 };
-    bar(&f);
-}
-
-fn bar(f: *Foo) void {
-    f.float = 12.34;
-    std.debug.warn("value: {}\n", .{f.float});
-}
+		const std = @import("std");
+		
+		const Foo = union {
+		    float: f32,
+		    int: u32,
+		};
+		
+		pub fn main() void {
+		    var f = Foo{ .int = 42 };
+		    bar(&f);
+		}
+		
+		fn bar(f: *Foo) void {
+		    f.float = 12.34;
+		    std.debug.warn("value: {}\n", .{f.float});
+		}
       {#code_end#}
       <p>
       This safety is not available for {#syntax#}extern{#endsyntax#} or {#syntax#}packed{#endsyntax#} unions.
@@ -8997,52 +9511,56 @@ fn bar(f: *Foo) void {
       To change the active field of a union, assign the entire union, like this:
       </p>
       {#code_begin|exe#}
-const std = @import("std");
-
-const Foo = union {
-    float: f32,
-    int: u32,
-};
-
-pub fn main() void {
-    var f = Foo{ .int = 42 };
-    bar(&f);
-}
-
-fn bar(f: *Foo) void {
-    f.* = Foo{ .float = 12.34 };
-    std.debug.warn("value: {}\n", .{f.float});
-}
+		const std = @import("std");
+		
+		const Foo = union {
+		    float: f32,
+		    int: u32,
+		};
+		
+		pub fn main() void {
+		    var f = Foo{ .int = 42 };
+		    bar(&f);
+		}
+		
+		fn bar(f: *Foo) void {
+		    f.* = Foo{ .float = 12.34 };
+		    std.debug.warn("value: {}\n", .{f.float});
+		}
       {#code_end#}
       <p>
       To change the active field of a union when a meaningful value for the field is not known,
       use {#link|undefined#}, like this:
       </p>
       {#code_begin|exe#}
-const std = @import("std");
-
-const Foo = union {
-    float: f32,
-    int: u32,
-};
-
-pub fn main() void {
-    var f = Foo{ .int = 42 };
-    f = Foo{ .float = undefined };
-    bar(&f);
-    std.debug.warn("value: {}\n", .{f.float});
-}
-
-fn bar(f: *Foo) void {
-    f.float = 12.34;
-}
+		const std = @import("std");
+		
+		const Foo = union {
+		    float: f32,
+		    int: u32,
+		};
+		
+		pub fn main() void {
+		    var f = Foo{ .int = 42 };
+		    f = Foo{ .float = undefined };
+		    bar(&f);
+		    std.debug.warn("value: {}\n", .{f.float});
+		}
+		
+		fn bar(f: *Foo) void {
+		    f.float = 12.34;
+		}
       {#code_end#}
       {#see_also|union|extern union#}
       {#header_close#}
 
+
+
       {#header_open|Out of Bounds Float to Integer Cast#}
       <p>TODO</p>
       {#header_close#}
+
+
 
       {#header_open|Pointer Cast Invalid Null#}
       <p>
@@ -9052,21 +9570,23 @@ fn bar(f: *Foo) void {
       </p>
       <p>At compile-time:</p>
       {#code_begin|test_err|null pointer casted to type#}
-comptime {
-    const opt_ptr: ?*i32 = null;
-    const ptr = @ptrCast(*i32, opt_ptr);
-}
+		comptime {
+		    const opt_ptr: ?*i32 = null;
+		    const ptr = @ptrCast(*i32, opt_ptr);
+		}
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-pub fn main() void {
-    var opt_ptr: ?*i32 = null;
-    var ptr = @ptrCast(*i32, opt_ptr);
-}
+		pub fn main() void {
+		    var opt_ptr: ?*i32 = null;
+		    var ptr = @ptrCast(*i32, opt_ptr);
+		}
       {#code_end#}
       {#header_close#}
 
       {#header_close#}
+
+
       {#header_open|Memory#}
       <p>
       The Zig language performs no memory management on behalf of the programmer. This is
@@ -9086,23 +9606,23 @@ pub fn main() void {
       their initialization functions:
       </p>
       {#code_begin|test|allocator#}
-const std = @import("std");
-const Allocator = std.mem.Allocator;
-const assert = std.debug.assert;
-
-test "using an allocator" {
-    var buffer: [100]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buffer).allocator;
-    const result = try concat(allocator, "foo", "bar");
-    assert(std.mem.eql(u8, "foobar", result));
-}
-
-fn concat(allocator: *Allocator, a: []const u8, b: []const u8) ![]u8 {
-    const result = try allocator.alloc(u8, a.len + b.len);
-    std.mem.copy(u8, result, a);
-    std.mem.copy(u8, result[a.len..], b);
-    return result;
-}
+		const std = @import("std");
+		const Allocator = std.mem.Allocator;
+		const assert = std.debug.assert;
+		
+		test "using an allocator" {
+		    var buffer: [100]u8 = undefined;
+		    const allocator = &std.heap.FixedBufferAllocator.init(&buffer).allocator;
+		    const result = try concat(allocator, "foo", "bar");
+		    assert(std.mem.eql(u8, "foobar", result));
+		}
+		
+		fn concat(allocator: *Allocator, a: []const u8, b: []const u8) ![]u8 {
+		    const result = try allocator.alloc(u8, a.len + b.len);
+		    std.mem.copy(u8, result, a);
+		    std.mem.copy(u8, result[a.len..], b);
+		    return result;
+		}
       {#code_end#}
       <p>
       In the above example, 100 bytes of stack memory are used to initialize a
@@ -9118,6 +9638,8 @@ fn concat(allocator: *Allocator, a: []const u8, b: []const u8) ![]u8 {
       with {#syntax#}std.heap.default_allocator{#endsyntax#}. However, it will still be recommended to
       follow the {#link|Choosing an Allocator#} guide.
       </p>
+
+
 
       {#header_open|Choosing an Allocator#}
       <p>What allocator to use depends on a number of factors. Here is a flow chart to help you decide:
@@ -9141,17 +9663,17 @@ fn concat(allocator: *Allocator, a: []const u8, b: []const u8) ![]u8 {
               such that it would make sense to free everything at once at the end?
               In this case, it is recommended to follow this pattern:
               {#code_begin|exe|cli_allocation#}
-const std = @import("std");
-
-pub fn main() !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-
-    const allocator = &arena.allocator;
-
-    const ptr = try allocator.create(i32);
-    std.debug.warn("ptr={*}\n", .{ptr});
-}
+		const std = @import("std");
+		
+		pub fn main() !void {
+		    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+		    defer arena.deinit();
+		
+		    const allocator = &arena.allocator;
+		
+		    const ptr = try allocator.create(i32);
+		    std.debug.warn("ptr={*}\n", .{ptr});
+		}
               {#code_end#}
               When using this kind of allocator, there is no need to free anything manually. Everything
               gets freed at once with the call to {#syntax#}arena.deinit(){#endsyntax#}.
@@ -9178,24 +9700,26 @@ pub fn main() !void {
       </ol>
       {#header_close#}
 
+
+
       {#header_open|Where are the bytes?#}
       <p>String literals such as {#syntax#}"foo"{#endsyntax#} are in the global constant data section.
       This is why it is an error to pass a string literal to a mutable slice, like this:
       </p>
       {#code_begin|test_err|expected type '[]u8'#}
-fn foo(s: []u8) void {}
-
-test "string literal to mutable slice" {
-    foo("hello");
-}
+		fn foo(s: []u8) void {}
+		
+		test "string literal to mutable slice" {
+		    foo("hello");
+		}
       {#code_end#}
       <p>However if you make the slice constant, then it works:</p>
       {#code_begin|test|strlit#}
-fn foo(s: []const u8) void {}
-
-test "string literal to constant slice" {
-    foo("hello");
-}
+		fn foo(s: []const u8) void {}
+		
+		test "string literal to constant slice" {
+		    foo("hello");
+		}
       {#code_end#}
       <p>
       Just like string literals, `const` declarations, when the value is known at {#link|comptime#},
@@ -9218,6 +9742,8 @@ test "string literal to constant slice" {
       <p>TODO: thread local variables</p>
       {#header_close#}
 
+
+
       {#header_open|Implementing an Allocator#}
       <p>Zig programmers can implement their own allocators by fulfilling the Allocator interface.
       In order to do this one must read carefully the documentation comments in std/mem.zig and
@@ -9231,6 +9757,8 @@ test "string literal to constant slice" {
       here.
       </p>
       {#header_close#}
+
+
 
       {#header_open|Heap Allocation Failure#}
       <p>
@@ -9273,6 +9801,8 @@ test "string literal to constant slice" {
       </ul>
       {#header_close#}
 
+
+
       {#header_open|Recursion#}
       <p>
       Recursion is a fundamental tool in modeling software. However it has an often-overlooked problem:
@@ -9289,6 +9819,8 @@ test "string literal to constant slice" {
       such protection, with some degree of cooperation from Zig code required.
       </p>
       {#header_close#}
+
+
 
       {#header_open|Lifetime and Ownership#}
       <p>
@@ -9321,6 +9853,8 @@ test "string literal to constant slice" {
       {#header_close#}
 
       {#header_close#}
+
+
       {#header_open|Compile Variables#}
       <p>
       Compile variables are accessible by importing the {#syntax#}"builtin"{#endsyntax#} package,
@@ -9328,8 +9862,8 @@ test "string literal to constant slice" {
       compile-time constants such as the current target, endianness, and release mode.
       </p>
       {#code_begin|syntax#}
-const builtin = @import("builtin");
-const separator = if (builtin.os == builtin.Os.windows) '\\' else '/';
+		const builtin = @import("builtin");
+		const separator = if (builtin.os == builtin.Os.windows) '\\' else '/';
       {#code_end#}
       <p>
       Example of what is imported with {#syntax#}@import("builtin"){#endsyntax#}:
@@ -9337,6 +9871,8 @@ const separator = if (builtin.os == builtin.Os.windows) '\\' else '/';
       {#builtin#}
       {#see_also|Build Mode#}
       {#header_close#}
+
+
       {#header_open|Root Source File#}
       <p>TODO: explain how root source file finds other files</p>
       <p>TODO: pub fn main</p>
@@ -9346,6 +9882,8 @@ const separator = if (builtin.os == builtin.Os.windows) '\\' else '/';
       <p>TODO: lazy analysis</p>
       <p>TODO: using comptime { _ = @import() }</p>
       {#header_close#}
+
+
       {#header_open|Zig Test#}
       <p>
       <code>zig test</code> is a tool that can be used to quickly build and run Zig code
@@ -9353,13 +9891,13 @@ const separator = if (builtin.os == builtin.Os.windows) '\\' else '/';
       is available for code to detect whether the current build is a test build.
       </p>
       {#code_begin|test|detect_test#}
-const std = @import("std");
-const builtin = std.builtin;
-const assert = std.debug.assert;
-
-test "builtin.is_test" {
-    assert(builtin.is_test);
-}
+		const std = @import("std");
+		const builtin = std.builtin;
+		const assert = std.debug.assert;
+		
+		test "builtin.is_test" {
+		    assert(builtin.is_test);
+		}
       {#code_end#}
       <p>
       Zig has lazy top level declaration analysis, which means that if a function is not called,
@@ -9367,10 +9905,10 @@ test "builtin.is_test" {
       compile error in a function because it is never called.
       </p>
       {#code_begin|test|unused_fn#}
-fn unused() i32 {
-    return "wrong return type";
-}
-test "unused function" { }
+		fn unused() i32 {
+		    return "wrong return type";
+		}
+		test "unused function" { }
       {#code_end#}
       <p>
       Note that, while in {#link|Debug#} and {#link|ReleaseSafe#} modes, {#link|unreachable#} emits a
@@ -9379,21 +9917,21 @@ test "unused function" { }
       simple as:
       </p>
       {#code_begin|syntax#}
-pub fn assert(ok: bool) void {
-    if (!ok) unreachable;
-}
+		pub fn assert(ok: bool) void {
+		    if (!ok) unreachable;
+		}
       {#code_end#}
       <p>
       This means that when testing in ReleaseFast or ReleaseSmall mode, {#syntax#}assert{#endsyntax#}
       is not sufficient to check the result of a computation:
       </p>
       {#code_begin|syntax#}
-const std = @import("std");
-const assert = std.debug.assert;
-
-test "assert in release fast mode" {
-    assert(false);
-}
+		const std = @import("std");
+		const assert = std.debug.assert;
+		
+		test "assert in release fast mode" {
+		    assert(false);
+		}
       {#code_end#}
       <p>
       When compiling this test in {#link|ReleaseFast#} mode, it invokes unchecked
@@ -9404,13 +9942,13 @@ test "assert in release fast mode" {
       Better practice for checking the output when testing is to use {#syntax#}std.testing.expect{#endsyntax#}:
       </p>
       {#code_begin|test_err|test failure#}
-      {#code_release_fast#}
-const std = @import("std");
-const expect = std.testing.expect;
-
-test "assert in release fast mode" {
-    expect(false);
-}
+		      {#code_release_fast#}
+		const std = @import("std");
+		const expect = std.testing.expect;
+		
+		test "assert in release fast mode" {
+		    expect(false);
+		}
       {#code_end#}
       <p>See the rest of the {#syntax#}std.testing{#endsyntax#} namespace for more available functions.</p>
       <p>
@@ -9421,11 +9959,15 @@ test "assert in release fast mode" {
       isolation.
       </p>
       {#header_close#}
+
+
       {#header_open|Zig Build System#}
       <p>TODO: explain purpose, it's supposed to replace make/cmake</p>
       <p>TODO: example of building a zig executable</p>
       <p>TODO: example of building a C library</p>
       {#header_close#}
+
+
       {#header_open|C#}
       <p>
       Although Zig is independent of C, and, unlike most other languages, does not depend on libc,
@@ -9434,6 +9976,8 @@ test "assert in release fast mode" {
       <p>
       There are a few ways that Zig facilitates C interop.
       </p>
+
+
       {#header_open|C Type Primitives#}
       <p>
       These have guaranteed C ABI compatibility and can be used like any other type.
@@ -9453,21 +9997,23 @@ test "assert in release fast mode" {
       {#see_also|Primitive Types#}
       {#header_close#}
 
+
+
       {#header_open|Import from C Header File#}
       <p>
       The {#syntax#}@cImport{#endsyntax#} builtin function can be used
       to directly import symbols from .h files:
       </p>
       {#code_begin|exe#}
-      {#link_libc#}
-const c = @cImport({
-    // See https://github.com/ziglang/zig/issues/515
-    @cDefine("_NO_CRT_STDIO_INLINE", "1");
-    @cInclude("stdio.h");
-});
-pub fn main() void {
-    _ = c.printf("hello\n");
-}
+		      {#link_libc#}
+		const c = @cImport({
+		    // See https://github.com/ziglang/zig/issues/515
+		    @cDefine("_NO_CRT_STDIO_INLINE", "1");
+		    @cInclude("stdio.h");
+		});
+		pub fn main() void {
+		    _ = c.printf("hello\n");
+		}
       {#code_end#}
       <p>
       The {#syntax#}@cImport{#endsyntax#} function takes an expression as a parameter.
@@ -9475,22 +10021,24 @@ pub fn main() void {
       preprocessor directives and include multiple .h files:
       </p>
       {#code_begin|syntax#}
-const builtin = @import("builtin");
-
-const c = @cImport({
-    @cDefine("NDEBUG", builtin.mode == .ReleaseFast);
-    if (something) {
-        @cDefine("_GNU_SOURCE", {});
-    }
-    @cInclude("stdlib.h");
-    if (something) {
-        @cUndef("_GNU_SOURCE");
-    }
-    @cInclude("soundio.h");
-});
+		const builtin = @import("builtin");
+		
+		const c = @cImport({
+		    @cDefine("NDEBUG", builtin.mode == .ReleaseFast);
+		    if (something) {
+		        @cDefine("_GNU_SOURCE", {});
+		    }
+		    @cInclude("stdlib.h");
+		    if (something) {
+		        @cUndef("_GNU_SOURCE");
+		    }
+		    @cInclude("soundio.h");
+		});
       {#code_end#}
       {#see_also|@cImport|@cInclude|@cDefine|@cUndef|@import#}
       {#header_close#}
+
+
 
       {#header_open|C Pointers#}
       <p>
@@ -9528,6 +10076,8 @@ const c = @cImport({
         <p>{#syntax#}ptr_to_struct_array[index].struct_member{#endsyntax#}</p>
       {#header_close#}
 
+
+
       {#header_open|Exporting a C Library#}
       <p>
       One of the primary use cases for Zig is exporting a library with the C ABI for other programming languages
@@ -9536,9 +10086,9 @@ const c = @cImport({
       </p>
       <p class="file">mathtest.zig</p>
       {#code_begin|syntax#}
-export fn add(a: i32, b: i32) i32 {
-    return a + b;
-}
+		export fn add(a: i32, b: i32) i32 {
+		    return a + b;
+		}
       {#code_end#}
       <p>To make a static library:</p>
       <pre><code class="shell">$ zig build-lib mathtest.zig
@@ -9559,23 +10109,23 @@ int main(int argc, char **argv) {
 }</code></pre>
       <p class="file">build.zig</p>
       {#code_begin|syntax#}
-const Builder = @import("std").build.Builder;
-
-pub fn build(b: *Builder) void {
-    const lib = b.addSharedLibrary("mathtest", "mathtest.zig", b.version(1, 0, 0));
-
-    const exe = b.addExecutable("test", null);
-    exe.addCSourceFile("test.c", &[_][]const u8{"-std=c99"});
-    exe.linkLibrary(lib);
-    exe.linkSystemLibrary("c");
-
-    b.default_step.dependOn(&exe.step);
-
-    const run_cmd = exe.run();
-
-    const test_step = b.step("test", "Test the program");
-    test_step.dependOn(&run_cmd.step);
-}
+		const Builder = @import("std").build.Builder;
+		
+		pub fn build(b: *Builder) void {
+		    const lib = b.addSharedLibrary("mathtest", "mathtest.zig", b.version(1, 0, 0));
+		
+		    const exe = b.addExecutable("test", null);
+		    exe.addCSourceFile("test.c", &[_][]const u8{"-std=c99"});
+		    exe.linkLibrary(lib);
+		    exe.linkSystemLibrary("c");
+		
+		    b.default_step.dependOn(&exe.step);
+		
+		    const run_cmd = exe.run();
+		
+		    const test_step = b.step("test", "Test the program");
+		    test_step.dependOn(&run_cmd.step);
+		}
       {#code_end#}
       <p class="file">terminal</p>
       <pre><code class="shell">$ zig build test
@@ -9583,27 +10133,29 @@ pub fn build(b: *Builder) void {
 </code></pre>
       {#see_also|export#}
       {#header_close#}
+
+
       {#header_open|Mixing Object Files#}
       <p>
       You can mix Zig object files with any other object files that respect the C ABI. Example:
       </p>
       <p class="file">base64.zig</p>
       {#code_begin|syntax#}
-const base64 = @import("std").base64;
-
-export fn decode_base_64(
-    dest_ptr: [*]u8,
-    dest_len: usize,
-    source_ptr: [*]const u8,
-    source_len: usize,
-) usize {
-    const src = source_ptr[0..source_len];
-    const dest = dest_ptr[0..dest_len];
-    const base64_decoder = base64.standard_decoder_unsafe;
-    const decoded_size = base64_decoder.calcSize(src);
-    base64_decoder.decode(dest[0..decoded_size], src);
-    return decoded_size;
-}
+		const base64 = @import("std").base64;
+		
+		export fn decode_base_64(
+		    dest_ptr: [*]u8,
+		    dest_len: usize,
+		    source_ptr: [*]const u8,
+		    source_len: usize,
+		) usize {
+		    const src = source_ptr[0..source_len];
+		    const dest = dest_ptr[0..dest_len];
+		    const base64_decoder = base64.standard_decoder_unsafe;
+		    const decoded_size = base64_decoder.calcSize(src);
+		    base64_decoder.decode(dest[0..decoded_size], src);
+		    return decoded_size;
+		}
       {#code_end#}
       <p class="file">test.c</p>
       <pre><code class="cpp">// This header is generated by zig from base64.zig
@@ -9624,17 +10176,17 @@ int main(int argc, char **argv) {
 }</code></pre>
       <p class="file">build.zig</p>
       {#code_begin|syntax#}
-const Builder = @import("std").build.Builder;
-
-pub fn build(b: *Builder) void {
-    const obj = b.addObject("base64", "base64.zig");
-
-    const exe = b.addExecutable("test", null);
-    exe.addCSourceFile("test.c", &[_][]const u8{"-std=c99"});
-    exe.addObject(obj);
-    exe.linkSystemLibrary("c");
-    exe.install();
-}
+		const Builder = @import("std").build.Builder;
+		
+		pub fn build(b: *Builder) void {
+		    const obj = b.addObject("base64", "base64.zig");
+		
+		    const exe = b.addExecutable("test", null);
+		    exe.addCSourceFile("test.c", &[_][]const u8{"-std=c99"});
+		    exe.addObject(obj);
+		    exe.linkSystemLibrary("c");
+		    exe.install();
+		}
       {#code_end#}
       <p class="file">terminal</p>
       <pre><code class="shell">$ zig build
@@ -9643,18 +10195,22 @@ all your base are belong to us</code></pre>
       {#see_also|Targets|Zig Build System#}
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|WebAssembly#}
       <p>Zig supports building for WebAssembly out of the box.</p>
+
+
       {#header_open|Freestanding#}
       <p>For host environments like the web browser and nodejs, build as a library using the freestanding OS target.
       Here's an example of running Zig code compiled to WebAssembly with nodejs.</p>
       {#code_begin|lib|math#}
-      {#target_wasm#}
-extern fn print(i32) void;
-
-export fn add(a: i32, b: i32) void {
-    print(a + b);
-}
+		      {#target_wasm#}
+		extern fn print(i32) void;
+		
+		export fn add(a: i32, b: i32) void {
+		    print(a + b);
+		}
       {#code_end#}
       {#header_close#}
       <p class="file">test.js</p>
@@ -9671,22 +10227,24 @@ WebAssembly.instantiate(typedArray, {
 });</code></pre>
     <pre><code>$ node test.js
 The result is 3</code></pre>
+
+
       {#header_open|WASI#}
       <p>Zig's support for WebAssembly System Interface (WASI) is under active development.
       Example of using the standard library and reading command line arguments:</p>
       {#code_begin|exe|wasi#}
-      {#target_wasi#}
-const std = @import("std");
-
-pub fn main() !void {
-    // TODO a better default allocator that isn't as wasteful!
-    const args = try std.process.argsAlloc(std.heap.page_allocator);
-    defer std.process.argsFree(std.heap.page_allocator, args);
-
-    for (args) |arg, i| {
-        std.debug.warn("{}: {}\n", .{i, arg});
-    }
-}
+		      {#target_wasi#}
+		const std = @import("std");
+		
+		pub fn main() !void {
+		    // TODO a better default allocator that isn't as wasteful!
+		    const args = try std.process.argsAlloc(std.heap.page_allocator);
+		    defer std.process.argsFree(std.heap.page_allocator, args);
+		
+		    for (args) |arg, i| {
+		        std.debug.warn("{}: {}\n", .{i, arg});
+		    }
+		}
       {#code_end#}
      <pre><code>$ wasmer run wasi.wasm 123 hello
 0: wasi.wasm
@@ -9694,6 +10252,8 @@ pub fn main() !void {
 2: hello</code></pre>
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Targets#}
       <p>
       Zig supports generating code for all targets that LLVM supports. Here is
@@ -9949,6 +10509,8 @@ Available libcs:
       <li>macOS x86_64</li>
       </ul>
       {#header_close#}
+
+
       {#header_open|Style Guide#}
       <p>
 These coding conventions are not enforced by the compiler, but they are shipped in
@@ -9956,6 +10518,8 @@ this documentation along with the compiler in order to provide a point of
 reference, should anyone wish to point to an authority on agreed upon Zig
 coding style.
       </p>
+
+
       {#header_open|Whitespace#}
       <ul>
         <li>
@@ -9972,6 +10536,8 @@ coding style.
         </li>
       </ul>
       {#header_close#}
+
+
       {#header_open|Names#}
       <p>
       Roughly speaking: {#syntax#}camelCaseFunctionName{#endsyntax#}, {#syntax#}TitleCaseTypeName{#endsyntax#},
@@ -10008,56 +10574,60 @@ coding style.
       {#syntax#}ENOENT{#endsyntax#}, follow the established convention.
       </p>
       {#header_close#}
+
+
       {#header_open|Examples#}
       {#code_begin|syntax#}
-const namespace_name = @import("dir_name/file_name.zig");
-var global_var: i32 = undefined;
-const const_name = 42;
-const primitive_type_alias = f32;
-const string_alias = []u8;
-
-const StructName = struct {
-    field: i32,
-};
-const StructAlias = StructName;
-
-fn functionName(param_name: TypeName) void {
-    var functionPointer = functionName;
-    functionPointer();
-    functionPointer = otherFunction;
-    functionPointer();
-}
-const functionAlias = functionName;
-
-fn ListTemplateFunction(comptime ChildType: type, comptime fixed_size: usize) type {
-    return List(ChildType, fixed_size);
-}
-
-fn ShortList(comptime T: type, comptime n: usize) type {
-    return struct {
-        field_name: [n]T,
-        fn methodName() void {}
-    };
-}
-
-// The word XML loses its casing when used in Zig identifiers.
-const xml_document =
-    \\<?xml version="1.0" encoding="UTF-8"?>
-    \\<document>
-    \\</document>
-;
-const XmlParser = struct {
-    field: i32,
-};
-
-// The initials BE (Big Endian) are just another word in Zig identifier names.
-fn readU32Be() u32 {}
+		const namespace_name = @import("dir_name/file_name.zig");
+		var global_var: i32 = undefined;
+		const const_name = 42;
+		const primitive_type_alias = f32;
+		const string_alias = []u8;
+		
+		const StructName = struct {
+		    field: i32,
+		};
+		const StructAlias = StructName;
+		
+		fn functionName(param_name: TypeName) void {
+		    var functionPointer = functionName;
+		    functionPointer();
+		    functionPointer = otherFunction;
+		    functionPointer();
+		}
+		const functionAlias = functionName;
+		
+		fn ListTemplateFunction(comptime ChildType: type, comptime fixed_size: usize) type {
+		    return List(ChildType, fixed_size);
+		}
+		
+		fn ShortList(comptime T: type, comptime n: usize) type {
+		    return struct {
+		        field_name: [n]T,
+		        fn methodName() void {}
+		    };
+		}
+		
+		// The word XML loses its casing when used in Zig identifiers.
+		const xml_document =
+		    \\<?xml version="1.0" encoding="UTF-8"?>
+		    \\<document>
+		    \\</document>
+		;
+		const XmlParser = struct {
+		    field: i32,
+		};
+		
+		// The initials BE (Big Endian) are just another word in Zig identifier names.
+		fn readU32Be() u32 {}
       {#code_end#}
       <p>
       See the Zig Standard Library for more examples.
       </p>
       {#header_close#}
       {#header_close#}
+
+
       {#header_open|Source Encoding#}
       <p>Zig source code is encoded in UTF-8. An invalid UTF-8 byte sequence results in a compile error.</p>
       <p>Throughout all zig source code (including in comments), some codepoints are never allowed:</p>
@@ -10069,16 +10639,22 @@ fn readU32Be() u32 {}
       <p>For some discussion on the rationale behind these design decisions, see <a href="https://github.com/ziglang/zig/issues/663">issue #663</a></p>
       {#header_close#}
 
+
+
       {#header_open|Keyword Reference#}
       <p>
       TODO the rest of the keywords. Most of these can just be links to the relevant section.
       </p>
+
+
       {#header_open|Keyword: pub#}
       <p>The {#syntax#}pub{#endsyntax#} in front of a top level declaration makes the
       declaration available to reference from a different file than the one it is declared in.</p>
       {#see_also|@import#}
       {#header_close#}
       {#header_close#}
+
+
 
       {#header_open|Grammar#}
       <pre><code>Root &lt;- skip ContainerMembers eof
@@ -10572,6 +11148,8 @@ keyword &lt;- KEYWORD_align / KEYWORD_and / KEYWORD_allowzero / KEYWORD_asm
          / KEYWORD_undefined / KEYWORD_union / KEYWORD_unreachable
          / KEYWORD_usingnamespace / KEYWORD_var / KEYWORD_volatile / KEYWORD_while</code></pre>
       {#header_close#}
+
+
       {#header_open|Zen#}
       <ul>
         <li>Communicate intent precisely.</li>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -230,12 +230,12 @@
       {#header_open|Hello World#}
 
       {#code_begin|exe|hello#}
-		const std = @import("std");
-		
-		pub fn main() !void {
-		    const stdout = std.io.getStdOut().outStream();
-		    try stdout.print("Hello, {}!\n", .{"world"});
-		}
+        const std = @import("std");
+        
+        pub fn main() !void {
+            const stdout = std.io.getStdOut().outStream();
+            try stdout.print("Hello, {}!\n", .{"world"});
+        }
       {#code_end#}
       <p>
       Usually you don't want to write to stdout. You want to write to stderr. And you
@@ -243,11 +243,11 @@
       to emit. For that you can use a simpler API:
       </p>
       {#code_begin|exe|hello#}
-		const warn = @import("std").debug.warn;
-		
-		pub fn main() void {
-		    warn("Hello, world!\n", .{});
-		}
+        const warn = @import("std").debug.warn;
+        
+        pub fn main() void {
+            warn("Hello, world!\n", .{});
+        }
       {#code_end#}
       <p>
       Note that you can leave off the {#syntax#}!{#endsyntax#} from the return type because {#syntax#}warn{#endsyntax#} cannot fail.
@@ -258,17 +258,17 @@
 
       {#header_open|Comments#}
       {#code_begin|test|comments#}
-		const assert = @import("std").debug.assert;
-		
-		test "comments" {
-		    // Comments in Zig start with "//" and end at the next LF byte (end of line).
-		    // The below line is a comment, and won't be executed.
-		
-		    //assert(false);
-		
-		    const x = true;  // another comment
-		    assert(x);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "comments" {
+            // Comments in Zig start with "//" and end at the next LF byte (end of line).
+            // The below line is a comment, and won't be executed.
+        
+            //assert(false);
+        
+            const x = true;  // another comment
+            assert(x);
+        }
       {#code_end#}
       <p>
       There are no multiline comments in Zig (e.g. like <code class="c">/* */</code>
@@ -285,23 +285,23 @@
       doc comment.  The doc comment documents whatever immediately follows it.
       </p>
       {#code_begin|syntax|doc_comments#}
-		/// A structure for storing a timestamp, with nanosecond precision (this is a
-		/// multiline doc comment).
-		const Timestamp = struct {
-		    /// The number of seconds since the epoch (this is also a doc comment).
-		    seconds: i64,  // signed so we can represent pre-1970 (not a doc comment)
-		    /// The number of nanoseconds past the second (doc comment again).
-		    nanos: u32,
-		
-		    /// Returns a `Timestamp` struct representing the Unix epoch; that is, the
-		    /// moment of 1970 Jan 1 00:00:00 UTC (this is a doc comment too).
-		    pub fn unixEpoch() Timestamp {
-		        return Timestamp{
-		            .seconds = 0,
-		            .nanos = 0,
-		        };
-		    }
-		};
+        /// A structure for storing a timestamp, with nanosecond precision (this is a
+        /// multiline doc comment).
+        const Timestamp = struct {
+            /// The number of seconds since the epoch (this is also a doc comment).
+            seconds: i64,  // signed so we can represent pre-1970 (not a doc comment)
+            /// The number of nanoseconds past the second (doc comment again).
+            nanos: u32,
+        
+            /// Returns a `Timestamp` struct representing the Unix epoch; that is, the
+            /// moment of 1970 Jan 1 00:00:00 UTC (this is a doc comment too).
+            pub fn unixEpoch() Timestamp {
+                return Timestamp{
+                    .seconds = 0,
+                    .nanos = 0,
+                };
+            }
+        };
       {#code_end#}
       <p>
       Doc comments are only allowed in certain places; eventually, it will
@@ -314,60 +314,60 @@
 
       {#header_open|Values#}
       {#code_begin|exe|values#}
-		// Top-level declarations are order-independent:
-		const warn = std.debug.warn;
-		const std = @import("std");
-		const os = std.os;
-		const assert = std.debug.assert;
-		
-		pub fn main() void {
-		    // integers
-		    const one_plus_one: i32 = 1 + 1;
-		    warn("1 + 1 = {}\n", .{one_plus_one});
-		
-		    // floats
-		    const seven_div_three: f32 = 7.0 / 3.0;
-		    warn("7.0 / 3.0 = {}\n", .{seven_div_three});
-		
-		    // boolean
-		    warn("{}\n{}\n{}\n", .{
-		        true and false,
-		        true or false,
-		        !true,
-		    });
-		
-		    // optional
-		    var optional_value: ?[]const u8 = null;
-		    assert(optional_value == null);
-		
-		    warn("\noptional 1\ntype: {}\nvalue: {}\n", .{
-		        @typeName(@TypeOf(optional_value)),
-		        optional_value,
-		    });
-		
-		    optional_value = "hi";
-		    assert(optional_value != null);
-		
-		    warn("\noptional 2\ntype: {}\nvalue: {}\n", .{
-		        @typeName(@TypeOf(optional_value)),
-		        optional_value,
-		    });
-		
-		    // error union
-		    var number_or_error: anyerror!i32 = error.ArgNotFound;
-		
-		    warn("\nerror union 1\ntype: {}\nvalue: {}\n", .{
-		        @typeName(@TypeOf(number_or_error)),
-		        number_or_error,
-		    });
-		
-		    number_or_error = 1234;
-		
-		    warn("\nerror union 2\ntype: {}\nvalue: {}\n", .{
-		        @typeName(@TypeOf(number_or_error)),
-		        number_or_error,
-		    });
-		}
+        // Top-level declarations are order-independent:
+        const warn = std.debug.warn;
+        const std = @import("std");
+        const os = std.os;
+        const assert = std.debug.assert;
+        
+        pub fn main() void {
+            // integers
+            const one_plus_one: i32 = 1 + 1;
+            warn("1 + 1 = {}\n", .{one_plus_one});
+        
+            // floats
+            const seven_div_three: f32 = 7.0 / 3.0;
+            warn("7.0 / 3.0 = {}\n", .{seven_div_three});
+        
+            // boolean
+            warn("{}\n{}\n{}\n", .{
+                true and false,
+                true or false,
+                !true,
+            });
+        
+            // optional
+            var optional_value: ?[]const u8 = null;
+            assert(optional_value == null);
+        
+            warn("\noptional 1\ntype: {}\nvalue: {}\n", .{
+                @typeName(@TypeOf(optional_value)),
+                optional_value,
+            });
+        
+            optional_value = "hi";
+            assert(optional_value != null);
+        
+            warn("\noptional 2\ntype: {}\nvalue: {}\n", .{
+                @typeName(@TypeOf(optional_value)),
+                optional_value,
+            });
+        
+            // error union
+            var number_or_error: anyerror!i32 = error.ArgNotFound;
+        
+            warn("\nerror union 1\ntype: {}\nvalue: {}\n", .{
+                @typeName(@TypeOf(number_or_error)),
+                number_or_error,
+            });
+        
+            number_or_error = 1234;
+        
+            warn("\nerror union 2\ntype: {}\nvalue: {}\n", .{
+                @typeName(@TypeOf(number_or_error)),
+                number_or_error,
+            });
+        }
       {#code_end#}
 
 
@@ -607,20 +607,20 @@
       and character literals.
       </p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		const mem = @import("std").mem;
-		
-		test "string literals" {
-		    const bytes = "hello";
-		    assert(@TypeOf(bytes) == *const [5:0]u8);
-		    assert(bytes.len == 5);
-		    assert(bytes[1] == 'e');
-		    assert(bytes[5] == 0);
-		    assert('e' == '\x65');
-		    assert('\u{1f4a9}' == 128169);
-		    assert('💯' == 128175);
-		    assert(mem.eql(u8, "hello", "h\x65llo"));
-		}
+        const assert = @import("std").debug.assert;
+        const mem = @import("std").mem;
+        
+        test "string literals" {
+            const bytes = "hello";
+            assert(@TypeOf(bytes) == *const [5:0]u8);
+            assert(bytes.len == 5);
+            assert(bytes[1] == 'e');
+            assert(bytes[5] == 0);
+            assert('e' == '\x65');
+            assert('\u{1f4a9}' == 128169);
+            assert('💯' == 128175);
+            assert(mem.eql(u8, "hello", "h\x65llo"));
+        }
       {#code_end#}
       {#see_also|Arrays|Zig Test|Source Encoding#}
 
@@ -684,14 +684,14 @@
       the string literal continues.
       </p>
       {#code_begin|syntax#}
-		const hello_world_in_c =
-		    \\#include <stdio.h>
-		    \\
-		    \\int main(int argc, char **argv) {
-		    \\    printf("hello world\n");
-		    \\    return 0;
-		    \\}
-		;
+        const hello_world_in_c =
+            \\#include <stdio.h>
+            \\
+            \\int main(int argc, char **argv) {
+            \\    printf("hello world\n");
+            \\    return 0;
+            \\}
+        ;
       {#code_end#}
       {#see_also|@embedFile#}
       {#header_close#}
@@ -701,53 +701,53 @@
       {#header_open|Assignment#}
       <p>Use the {#syntax#}const{#endsyntax#} keyword to assign a value to an identifier:</p>
       {#code_begin|test_err|cannot assign to constant#}
-		const x = 1234;
-		
-		fn foo() void {
-		    // It works at global scope as well as inside functions.
-		    const y = 5678;
-		
-		    // Once assigned, an identifier cannot be changed.
-		    y += 1;
-		}
-		
-		test "assignment" {
-		    foo();
-		}
+        const x = 1234;
+        
+        fn foo() void {
+            // It works at global scope as well as inside functions.
+            const y = 5678;
+        
+            // Once assigned, an identifier cannot be changed.
+            y += 1;
+        }
+        
+        test "assignment" {
+            foo();
+        }
       {#code_end#}
       <p>{#syntax#}const{#endsyntax#} applies to all of the bytes that the identifier immediately addresses. {#link|Pointers#} have their own const-ness.</p>
       <p>If you need a variable that you can modify, use the {#syntax#}var{#endsyntax#} keyword:</p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "var" {
-		    var y: i32 = 5678;
-		
-		    y += 1;
-		
-		    assert(y == 5679);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "var" {
+            var y: i32 = 5678;
+        
+            y += 1;
+        
+            assert(y == 5679);
+        }
       {#code_end#}
       <p>Variables must be initialized:</p>
       {#code_begin|test_err#}
-		test "initialization" {
-		    var x: i32;
-		
-		    x = 1;
-		}
+        test "initialization" {
+            var x: i32;
+        
+            x = 1;
+        }
       {#code_end#}
 
 
       {#header_open|undefined#}
       <p>Use {#syntax#}undefined{#endsyntax#} to leave variables uninitialized:</p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "init with undefined" {
-		    var x: i32 = undefined;
-		    x = 1;
-		    assert(x == 1);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "init with undefined" {
+            var x: i32 = undefined;
+            x = 1;
+            assert(x == 1);
+        }
       {#code_end#}
       <p>
       {#syntax#}undefined{#endsyntax#} can be {#link|coerced|Type Coercion#} to any type.
@@ -788,40 +788,40 @@
       {#syntax#}comptime{#endsyntax#}-known, otherwise it is runtime-known.
       </p>
       {#code_begin|test|global_variables#}
-		var y: i32 = add(10, x);
-		const x: i32 = add(12, 34);
-		
-		test "global variables" {
-		    assert(x == 46);
-		    assert(y == 56);
-		}
-		
-		fn add(a: i32, b: i32) i32 {
-		    return a + b;
-		}
-		
-		const std = @import("std");
-		const assert = std.debug.assert;
+        var y: i32 = add(10, x);
+        const x: i32 = add(12, 34);
+        
+        test "global variables" {
+            assert(x == 46);
+            assert(y == 56);
+        }
+        
+        fn add(a: i32, b: i32) i32 {
+            return a + b;
+        }
+        
+        const std = @import("std");
+        const assert = std.debug.assert;
       {#code_end#}
       <p>
       Global variables may be declared inside a {#link|struct#}, {#link|union#}, or {#link|enum#}:
       </p>
       {#code_begin|test|namespaced_global#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "namespaced global variable" {
-		    assert(foo() == 1235);
-		    assert(foo() == 1236);
-		}
-		
-		fn foo() i32 {
-		    const S = struct {
-		        var x: i32 = 1234;
-		    };
-		    S.x += 1;
-		    return S.x;
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "namespaced global variable" {
+            assert(foo() == 1235);
+            assert(foo() == 1236);
+        }
+        
+        fn foo() i32 {
+            const S = struct {
+                var x: i32 = 1234;
+            };
+            S.x += 1;
+            return S.x;
+        }
       {#code_end#}
       <p>
       The {#syntax#}extern{#endsyntax#} keyword can be used to link against a variable that is exported
@@ -838,24 +838,24 @@
       <p>A variable may be specified to be a thread-local variable using the
       {#syntax#}threadlocal{#endsyntax#} keyword:</p>
       {#code_begin|test|tls#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		threadlocal var x: i32 = 1234;
-		
-		test "thread local storage" {
-		    const thread1 = try std.Thread.spawn({}, testTls);
-		    const thread2 = try std.Thread.spawn({}, testTls);
-		    testTls({});
-		    thread1.wait();
-		    thread2.wait();
-		}
-		
-		fn testTls(context: void) void {
-		    assert(x == 1234);
-		    x += 1;
-		    assert(x == 1235);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        threadlocal var x: i32 = 1234;
+        
+        test "thread local storage" {
+            const thread1 = try std.Thread.spawn({}, testTls);
+            const thread2 = try std.Thread.spawn({}, testTls);
+            testTls({});
+            thread1.wait();
+            thread2.wait();
+        }
+        
+        fn testTls(context: void) void {
+            assert(x == 1234);
+            x += 1;
+            assert(x == 1235);
+        }
       {#code_end#}
       <p>
       For {#link|Single Threaded Builds#}, all thread local variables are treated as {#link|Global Variables#}.
@@ -884,25 +884,25 @@
       {#syntax#}comptime{#endsyntax#} variables.
       </p>
       {#code_begin|test|comptime_vars#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "comptime vars" {
-		    var x: i32 = 1;
-		    comptime var y: i32 = 1;
-		
-		    x += 1;
-		    y += 1;
-		
-		    assert(x == 2);
-		    assert(y == 2);
-		
-		    if (y != 2) {
-		        // This compile error never triggers because y is a comptime variable,
-		        // and so `y != 2` is a comptime value, and this if is statically evaluated.
-		        @compileError("wrong y value");
-		    }
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "comptime vars" {
+            var x: i32 = 1;
+            comptime var y: i32 = 1;
+        
+            x += 1;
+            y += 1;
+        
+            assert(x == 2);
+            assert(y == 2);
+        
+            if (y != 2) {
+                // This compile error never triggers because y is a comptime variable,
+                // and so `y != 2` is a comptime value, and this if is statically evaluated.
+                @compileError("wrong y value");
+            }
+        }
       {#code_end#}
       {#header_close#}
       {#header_close#}
@@ -914,17 +914,17 @@
 
       {#header_open|Integer Literals#}
       {#code_begin|syntax#}
-		const decimal_int = 98222;
-		const hex_int = 0xff;
-		const another_hex_int = 0xFF;
-		const octal_int = 0o755;
-		const binary_int = 0b11110000;
-		
-		// underscores may be placed between two digits as a visual separator
-		const one_billion = 1_000_000_000;
-		const binary_mask = 0b1_1111_1111;
-		const permissions = 0o7_5_5;
-		const big_address = 0xFF80_0000_0000_0000;
+        const decimal_int = 98222;
+        const hex_int = 0xff;
+        const another_hex_int = 0xFF;
+        const octal_int = 0o755;
+        const binary_int = 0b11110000;
+        
+        // underscores may be placed between two digits as a visual separator
+        const one_billion = 1_000_000_000;
+        const binary_mask = 0b1_1111_1111;
+        const permissions = 0o7_5_5;
+        const big_address = 0xFF80_0000_0000_0000;
       {#code_end#}
       {#header_close#}
 
@@ -939,9 +939,9 @@
       known size, and is vulnerable to undefined behavior.
       </p>
       {#code_begin|syntax#}
-		fn divide(a: i32, b: i32) i32 {
-		    return a / b;
-		}
+        fn divide(a: i32, b: i32) i32 {
+            return a / b;
+        }
       {#code_end#}
       <p>
       In this function, values {#syntax#}a{#endsyntax#} and {#syntax#}b{#endsyntax#} are known only at runtime,
@@ -986,29 +986,29 @@
       and to any {#link|integer|Integers#} type when there is no fractional component.
       </p>
       {#code_begin|syntax#}
-		const floating_point = 123.0E+77;
-		const another_float = 123.0;
-		const yet_another = 123.0e+77;
-		
-		const hex_floating_point = 0x103.70p-5;
-		const another_hex_float = 0x103.70;
-		const yet_another_hex_float = 0x103.70P-5;
-		
-		// underscores may be placed between two digits as a visual separator
-		const lightspeed = 299_792_458.000_000;
-		const nanosecond = 0.000_000_001;
-		const more_hex = 0x1234_5678.9ABC_CDEFp-10;
+        const floating_point = 123.0E+77;
+        const another_float = 123.0;
+        const yet_another = 123.0e+77;
+        
+        const hex_floating_point = 0x103.70p-5;
+        const another_hex_float = 0x103.70;
+        const yet_another_hex_float = 0x103.70P-5;
+        
+        // underscores may be placed between two digits as a visual separator
+        const lightspeed = 299_792_458.000_000;
+        const nanosecond = 0.000_000_001;
+        const more_hex = 0x1234_5678.9ABC_CDEFp-10;
       {#code_end#}
       <p>
       There is no syntax for NaN, infinity, or negative infinity. For these special values,
       one must use the standard library:
       </p>
       {#code_begin|syntax#}
-		const std = @import("std");
-		
-		const inf = std.math.inf(f32);
-		const negative_inf = -std.math.inf(f64);
-		const nan = std.math.nan(f128);
+        const std = @import("std");
+        
+        const inf = std.math.inf(f32);
+        const negative_inf = -std.math.inf(f64);
+        const nan = std.math.nan(f128);
       {#code_end#}
       {#header_close#}
 
@@ -1017,35 +1017,35 @@
       <p>By default floating point operations use {#syntax#}Strict{#endsyntax#} mode,
           but you can switch to {#syntax#}Optimized{#endsyntax#} mode on a per-block basis:</p>
       {#code_begin|obj|foo#}
-		      {#code_release_fast#}
-		const std = @import("std");
-		const builtin = std.builtin;
-		const big = @as(f64, 1 << 40);
-		
-		export fn foo_strict(x: f64) f64 {
-		    return x + big - big;
-		}
-		
-		export fn foo_optimized(x: f64) f64 {
-		    @setFloatMode(.Optimized);
-		    return x + big - big;
-		}
+              {#code_release_fast#}
+        const std = @import("std");
+        const builtin = std.builtin;
+        const big = @as(f64, 1 << 40);
+        
+        export fn foo_strict(x: f64) f64 {
+            return x + big - big;
+        }
+        
+        export fn foo_optimized(x: f64) f64 {
+            @setFloatMode(.Optimized);
+            return x + big - big;
+        }
       {#code_end#}
       <p>For this test we have to separate code into two object files -
       otherwise the optimizer figures out all the values at compile-time,
       which operates in strict mode.</p>
       {#code_begin|exe|float_mode#}
-		      {#code_link_object|foo#}
-		const warn = @import("std").debug.warn;
-		
-		extern fn foo_strict(x: f64) f64;
-		extern fn foo_optimized(x: f64) f64;
-		
-		pub fn main() void {
-		    const x = 0.001;
-		    warn("optimized = {}\n", .{foo_optimized(x)});
-		    warn("strict = {}\n", .{foo_strict(x)});
-		}
+              {#code_link_object|foo#}
+        const warn = @import("std").debug.warn;
+        
+        extern fn foo_strict(x: f64) f64;
+        extern fn foo_optimized(x: f64) f64;
+        
+        pub fn main() void {
+            const x = 0.001;
+            warn("optimized = {}\n", .{foo_optimized(x)});
+            warn("strict = {}\n", .{foo_strict(x)});
+        }
       {#code_end#}
       {#see_also|@setFloatMode|Division by Zero#}
       {#header_close#}
@@ -1704,108 +1704,108 @@ orelse catch
 
       {#header_open|Arrays#}
       {#code_begin|test|arrays#}
-		const assert = @import("std").debug.assert;
-		const mem = @import("std").mem;
-		
-		// array literal
-		const message = [_]u8{ 'h', 'e', 'l', 'l', 'o' };
-		
-		// get the size of an array
-		comptime {
-		    assert(message.len == 5);
-		}
-		
-		// A string literal is a pointer to an array literal.
-		const same_message = "hello";
-		
-		comptime {
-		    assert(mem.eql(u8, &message, same_message));
-		}
-		
-		test "iterate over an array" {
-		    var sum: usize = 0;
-		    for (message) |byte| {
-		        sum += byte;
-		    }
-		    assert(sum == 'h' + 'e' + 'l' * 2 + 'o');
-		}
-		
-		// modifiable array
-		var some_integers: [100]i32 = undefined;
-		
-		test "modify an array" {
-		    for (some_integers) |*item, i| {
-		        item.* = @intCast(i32, i);
-		    }
-		    assert(some_integers[10] == 10);
-		    assert(some_integers[99] == 99);
-		}
-		
-		// array concatenation works if the values are known
-		// at compile time
-		const part_one = [_]i32{ 1, 2, 3, 4 };
-		const part_two = [_]i32{ 5, 6, 7, 8 };
-		const all_of_it = part_one ++ part_two;
-		comptime {
-		    assert(mem.eql(i32, &all_of_it, &[_]i32{ 1, 2, 3, 4, 5, 6, 7, 8 }));
-		}
-		
-		// remember that string literals are arrays
-		const hello = "hello";
-		const world = "world";
-		const hello_world = hello ++ " " ++ world;
-		comptime {
-		    assert(mem.eql(u8, hello_world, "hello world"));
-		}
-		
-		// ** does repeating patterns
-		const pattern = "ab" ** 3;
-		comptime {
-		    assert(mem.eql(u8, pattern, "ababab"));
-		}
-		
-		// initialize an array to zero
-		const all_zero = [_]u16{0} ** 10;
-		
-		comptime {
-		    assert(all_zero.len == 10);
-		    assert(all_zero[5] == 0);
-		}
-		
-		// use compile-time code to initialize an array
-		var fancy_array = init: {
-		    var initial_value: [10]Point = undefined;
-		    for (initial_value) |*pt, i| {
-		        pt.* = Point{
-		            .x = @intCast(i32, i),
-		            .y = @intCast(i32, i) * 2,
-		        };
-		    }
-		    break :init initial_value;
-		};
-		const Point = struct {
-		    x: i32,
-		    y: i32,
-		};
-		
-		test "compile-time array initalization" {
-		    assert(fancy_array[4].x == 4);
-		    assert(fancy_array[4].y == 8);
-		}
-		
-		// call a function to initialize an array
-		var more_points = [_]Point{makePoint(3)} ** 10;
-		fn makePoint(x: i32) Point {
-		    return Point{
-		        .x = x,
-		        .y = x * 2,
-		    };
-		}
-		test "array initialization with function calls" {
-		    assert(more_points[4].x == 3);
-		    assert(more_points[4].y == 6);
-		    assert(more_points.len == 10);
-		}
+        const assert = @import("std").debug.assert;
+        const mem = @import("std").mem;
+        
+        // array literal
+        const message = [_]u8{ 'h', 'e', 'l', 'l', 'o' };
+        
+        // get the size of an array
+        comptime {
+            assert(message.len == 5);
+        }
+        
+        // A string literal is a pointer to an array literal.
+        const same_message = "hello";
+        
+        comptime {
+            assert(mem.eql(u8, &message, same_message));
+        }
+        
+        test "iterate over an array" {
+            var sum: usize = 0;
+            for (message) |byte| {
+                sum += byte;
+            }
+            assert(sum == 'h' + 'e' + 'l' * 2 + 'o');
+        }
+        
+        // modifiable array
+        var some_integers: [100]i32 = undefined;
+        
+        test "modify an array" {
+            for (some_integers) |*item, i| {
+                item.* = @intCast(i32, i);
+            }
+            assert(some_integers[10] == 10);
+            assert(some_integers[99] == 99);
+        }
+        
+        // array concatenation works if the values are known
+        // at compile time
+        const part_one = [_]i32{ 1, 2, 3, 4 };
+        const part_two = [_]i32{ 5, 6, 7, 8 };
+        const all_of_it = part_one ++ part_two;
+        comptime {
+            assert(mem.eql(i32, &all_of_it, &[_]i32{ 1, 2, 3, 4, 5, 6, 7, 8 }));
+        }
+        
+        // remember that string literals are arrays
+        const hello = "hello";
+        const world = "world";
+        const hello_world = hello ++ " " ++ world;
+        comptime {
+            assert(mem.eql(u8, hello_world, "hello world"));
+        }
+        
+        // ** does repeating patterns
+        const pattern = "ab" ** 3;
+        comptime {
+            assert(mem.eql(u8, pattern, "ababab"));
+        }
+        
+        // initialize an array to zero
+        const all_zero = [_]u16{0} ** 10;
+        
+        comptime {
+            assert(all_zero.len == 10);
+            assert(all_zero[5] == 0);
+        }
+        
+        // use compile-time code to initialize an array
+        var fancy_array = init: {
+            var initial_value: [10]Point = undefined;
+            for (initial_value) |*pt, i| {
+                pt.* = Point{
+                    .x = @intCast(i32, i),
+                    .y = @intCast(i32, i) * 2,
+                };
+            }
+            break :init initial_value;
+        };
+        const Point = struct {
+            x: i32,
+            y: i32,
+        };
+        
+        test "compile-time array initalization" {
+            assert(fancy_array[4].x == 4);
+            assert(fancy_array[4].y == 8);
+        }
+        
+        // call a function to initialize an array
+        var more_points = [_]Point{makePoint(3)} ** 10;
+        fn makePoint(x: i32) Point {
+            return Point{
+                .x = x,
+                .y = x * 2,
+            };
+        }
+        test "array initialization with function calls" {
+            assert(more_points[4].x == 3);
+            assert(more_points[4].y == 6);
+            assert(more_points.len == 10);
+        }
       {#code_end#}
       {#see_also|for|Slices#}
 
@@ -1815,36 +1815,36 @@ orelse catch
       <p>Similar to {#link|Enum Literals#} and {#link|Anonymous Struct Literals#}
       the type can be omitted from array literals:</p>
       {#code_begin|test|anon_list#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "anonymous list literal syntax" {
-		    var array: [4]u8 = .{11, 22, 33, 44};
-		    assert(array[0] == 11);
-		    assert(array[1] == 22);
-		    assert(array[2] == 33);
-		    assert(array[3] == 44);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "anonymous list literal syntax" {
+            var array: [4]u8 = .{11, 22, 33, 44};
+            assert(array[0] == 11);
+            assert(array[1] == 22);
+            assert(array[2] == 33);
+            assert(array[3] == 44);
+        }
       {#code_end#}
       <p>
       If there is no type in the result location then an anonymous list literal actually
       turns into a {#link|struct#} with numbered field names:
       </p>
       {#code_begin|test|infer_list_literal#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "fully anonymous list literal" {
-		    dump(.{ @as(u32, 1234), @as(f64, 12.34), true, "hi"});
-		}
-		
-		fn dump(args: var) void {
-		    assert(args.@"0" == 1234);
-		    assert(args.@"1" == 12.34);
-		    assert(args.@"2");
-		    assert(args.@"3"[0] == 'h');
-		    assert(args.@"3"[1] == 'i');
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "fully anonymous list literal" {
+            dump(.{ @as(u32, 1234), @as(f64, 12.34), true, "hi"});
+        }
+        
+        fn dump(args: var) void {
+            assert(args.@"0" == 1234);
+            assert(args.@"1" == 12.34);
+            assert(args.@"2");
+            assert(args.@"3"[0] == 'h');
+            assert(args.@"3"[1] == 'i');
+        }
       {#code_end#}
       {#header_close#}
 
@@ -1855,28 +1855,28 @@ orelse catch
       Mutlidimensional arrays can be created by nesting arrays:
       </p>
       {#code_begin|test|multidimensional#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const mat4x4 = [4][4]f32{
-		    [_]f32{ 1.0, 0.0, 0.0, 0.0 },
-		    [_]f32{ 0.0, 1.0, 0.0, 1.0 },
-		    [_]f32{ 0.0, 0.0, 1.0, 0.0 },
-		    [_]f32{ 0.0, 0.0, 0.0, 1.0 },
-		};
-		test "multidimensional arrays" {
-		    // Access the 2D array by indexing the outer array, and then the inner array.
-		    assert(mat4x4[1][1] == 1.0);
-		
-		    // Here we iterate with for loops.
-		    for (mat4x4) |row, row_index| {
-		        for (row) |cell, column_index| {
-		            if (row_index == column_index) {
-		                assert(cell == 1.0);
-		            }
-		        }
-		    }
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const mat4x4 = [4][4]f32{
+            [_]f32{ 1.0, 0.0, 0.0, 0.0 },
+            [_]f32{ 0.0, 1.0, 0.0, 1.0 },
+            [_]f32{ 0.0, 0.0, 1.0, 0.0 },
+            [_]f32{ 0.0, 0.0, 0.0, 1.0 },
+        };
+        test "multidimensional arrays" {
+            // Access the 2D array by indexing the outer array, and then the inner array.
+            assert(mat4x4[1][1] == 1.0);
+        
+            // Here we iterate with for loops.
+            for (mat4x4) |row, row_index| {
+                for (row) |cell, column_index| {
+                    if (row_index == column_index) {
+                        assert(cell == 1.0);
+                    }
+                }
+            }
+        }
       {#code_end#}
       {#header_close#}
 
@@ -1888,16 +1888,16 @@ orelse catch
       index corresponding to {#syntax#}len{#endsyntax#}.
       </p>
       {#code_begin|test|null_terminated_array#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "null terminated array" {
-		    const array = [_:0]u8 {1, 2, 3, 4};
-		
-		    assert(@TypeOf(array) == [4:0]u8);
-		    assert(array.len == 4);
-		    assert(array[4] == 0);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "null terminated array" {
+            const array = [_:0]u8 {1, 2, 3, 4};
+        
+            assert(@TypeOf(array) == [4:0]u8);
+            assert(array.len == 4);
+            assert(array[4] == 0);
+        }
       {#code_end#}
       {#see_also|Sentinel-Terminated Pointers|Sentinel-Terminated Slices#}
       {#header_close#}
@@ -1972,39 +1972,39 @@ orelse catch
         </ul>
         <p>Use {#syntax#}&x{#endsyntax#} to obtain a single-item pointer:</p>
         {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "address of syntax" {
-		    // Get the address of a variable:
-		    const x: i32 = 1234;
-		    const x_ptr = &x;
-		
-		    // Dereference a pointer:
-		    assert(x_ptr.* == 1234);
-		
-		    // When you get the address of a const variable, you get a const pointer to a single item.
-		    assert(@TypeOf(x_ptr) == *const i32);
-		
-		    // If you want to mutate the value, you'd need an address of a mutable variable:
-		    var y: i32 = 5678;
-		    const y_ptr = &y;
-		    assert(@TypeOf(y_ptr) == *i32);
-		    y_ptr.* += 1;
-		    assert(y_ptr.* == 5679);
-		}
-		
-		test "pointer array access" {
-		    // Taking an address of an individual element gives a
-		    // pointer to a single item. This kind of pointer
-		    // does not support pointer arithmetic.
-		    var array = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-		    const ptr = &array[2];
-		    assert(@TypeOf(ptr) == *u8);
-		
-		    assert(array[2] == 3);
-		    ptr.* += 1;
-		    assert(array[2] == 4);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "address of syntax" {
+            // Get the address of a variable:
+            const x: i32 = 1234;
+            const x_ptr = &x;
+        
+            // Dereference a pointer:
+            assert(x_ptr.* == 1234);
+        
+            // When you get the address of a const variable, you get a const pointer to a single item.
+            assert(@TypeOf(x_ptr) == *const i32);
+        
+            // If you want to mutate the value, you'd need an address of a mutable variable:
+            var y: i32 = 5678;
+            const y_ptr = &y;
+            assert(@TypeOf(y_ptr) == *i32);
+            y_ptr.* += 1;
+            assert(y_ptr.* == 5679);
+        }
+        
+        test "pointer array access" {
+            // Taking an address of an individual element gives a
+            // pointer to a single item. This kind of pointer
+            // does not support pointer arithmetic.
+            var array = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            const ptr = &array[2];
+            assert(@TypeOf(ptr) == *u8);
+        
+            assert(array[2] == 3);
+            ptr.* += 1;
+            assert(array[2] == 4);
+        }
       {#code_end#}
       <p>
         In Zig, we generally prefer {#link|Slices#} rather than {#link|Sentinel-Terminated Pointers#}.
@@ -2016,60 +2016,60 @@ orelse catch
         we prefer slices to pointers.
       </p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "pointer slicing" {
-		    var array = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-		    const slice = array[2..4];
-		    assert(slice.len == 2);
-		
-		    assert(array[3] == 4);
-		    slice[1] += 1;
-		    assert(array[3] == 5);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "pointer slicing" {
+            var array = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            const slice = array[2..4];
+            assert(slice.len == 2);
+        
+            assert(array[3] == 4);
+            slice[1] += 1;
+            assert(array[3] == 5);
+        }
       {#code_end#}
       <p>Pointers work at compile-time too, as long as the code does not depend on
       an undefined memory layout:</p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "comptime pointers" {
-		    comptime {
-		        var x: i32 = 1;
-		        const ptr = &x;
-		        ptr.* += 1;
-		        x += 1;
-		        assert(ptr.* == 3);
-		    }
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "comptime pointers" {
+            comptime {
+                var x: i32 = 1;
+                const ptr = &x;
+                ptr.* += 1;
+                x += 1;
+                assert(ptr.* == 3);
+            }
+        }
       {#code_end#}
       <p>To convert an integer address into a pointer, use {#syntax#}@intToPtr{#endsyntax#}.
       To convert a pointer to an integer, use {#syntax#}@ptrToInt{#endsyntax#}:</p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "@ptrToInt and @intToPtr" {
-		    const ptr = @intToPtr(*i32, 0xdeadbee0);
-		    const addr = @ptrToInt(ptr);
-		    assert(@TypeOf(addr) == usize);
-		    assert(addr == 0xdeadbee0);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "@ptrToInt and @intToPtr" {
+            const ptr = @intToPtr(*i32, 0xdeadbee0);
+            const addr = @ptrToInt(ptr);
+            assert(@TypeOf(addr) == usize);
+            assert(addr == 0xdeadbee0);
+        }
       {#code_end#}
       <p>Zig is able to preserve memory addresses in comptime code, as long as
       the pointer is never dereferenced:</p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "comptime @intToPtr" {
-		    comptime {
-		        // Zig is able to do this at compile-time, as long as
-		        // ptr is never dereferenced.
-		        const ptr = @intToPtr(*i32, 0xdeadbee0);
-		        const addr = @ptrToInt(ptr);
-		        assert(@TypeOf(addr) == usize);
-		        assert(addr == 0xdeadbee0);
-		    }
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "comptime @intToPtr" {
+            comptime {
+                // Zig is able to do this at compile-time, as long as
+                // ptr is never dereferenced.
+                const ptr = @intToPtr(*i32, 0xdeadbee0);
+                const addr = @ptrToInt(ptr);
+                assert(@TypeOf(addr) == usize);
+                assert(addr == 0xdeadbee0);
+            }
+        }
       {#code_end#}
       {#see_also|Optional Pointers|@intToPtr|@ptrToInt|C Pointers|Pointers to Zero Bit Types#}
 
@@ -2080,12 +2080,12 @@ orelse catch
       In the following code, loads and stores with {#syntax#}mmio_ptr{#endsyntax#} are guaranteed to all happen
       and in the same order as in source code:</p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "volatile" {
-		    const mmio_ptr = @intToPtr(*volatile u8, 0x12345678);
-		    assert(@TypeOf(mmio_ptr) == *volatile u8);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "volatile" {
+            const mmio_ptr = @intToPtr(*volatile u8, 0x12345678);
+            assert(@TypeOf(mmio_ptr) == *volatile u8);
+        }
       {#code_end#}
       <p>
       Note that {#syntax#}volatile{#endsyntax#} is unrelated to concurrency and {#link|Atomics#}.
@@ -2099,27 +2099,27 @@ orelse catch
       conversions are not possible.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "pointer casting" {
-		    const bytes align(@alignOf(u32)) = [_]u8{ 0x12, 0x12, 0x12, 0x12 };
-		    const u32_ptr = @ptrCast(*const u32, &bytes);
-		    assert(u32_ptr.* == 0x12121212);
-		
-		    // Even this example is contrived - there are better ways to do the above than
-		    // pointer casting. For example, using a slice narrowing cast:
-		    const u32_value = std.mem.bytesAsSlice(u32, bytes[0..])[0];
-		    assert(u32_value == 0x12121212);
-		
-		    // And even another way, the most straightforward way to do it:
-		    assert(@bitCast(u32, bytes) == 0x12121212);
-		}
-		
-		test "pointer child type" {
-		    // pointer types have a `child` field which tells you the type they point to.
-		    assert((*u32).Child == u32);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "pointer casting" {
+            const bytes align(@alignOf(u32)) = [_]u8{ 0x12, 0x12, 0x12, 0x12 };
+            const u32_ptr = @ptrCast(*const u32, &bytes);
+            assert(u32_ptr.* == 0x12121212);
+        
+            // Even this example is contrived - there are better ways to do the above than
+            // pointer casting. For example, using a slice narrowing cast:
+            const u32_value = std.mem.bytesAsSlice(u32, bytes[0..])[0];
+            assert(u32_value == 0x12121212);
+        
+            // And even another way, the most straightforward way to do it:
+            assert(@bitCast(u32, bytes) == 0x12121212);
+        }
+        
+        test "pointer child type" {
+            // pointer types have a `child` field which tells you the type they point to.
+            assert((*u32).Child == u32);
+        }
       {#code_end#}
 
 
@@ -2139,18 +2139,18 @@ orelse catch
       alignment of the underlying type, it can be omitted from the type:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "variable alignment" {
-		    var x: i32 = 1234;
-		    const align_of_i32 = @alignOf(@TypeOf(x));
-		    assert(@TypeOf(&x) == *i32);
-		    assert(*i32 == *align(align_of_i32) i32);
-		    if (std.Target.current.cpu.arch == .x86_64) {
-		        assert((*i32).alignment == 4);
-		    }
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "variable alignment" {
+            var x: i32 = 1234;
+            const align_of_i32 = @alignOf(@TypeOf(x));
+            assert(@TypeOf(&x) == *i32);
+            assert(*i32 == *align(align_of_i32) i32);
+            if (std.Target.current.cpu.arch == .x86_64) {
+                assert((*i32).alignment == 4);
+            }
+        }
       {#code_end#}
       <p>In the same way that a {#syntax#}*i32{#endsyntax#} can be {#link|coerced|Type Coercion#} to a
           {#syntax#}*const i32{#endsyntax#}, a pointer with a larger alignment can be implicitly
@@ -2161,29 +2161,29 @@ orelse catch
       pointers to them get the specified alignment:
       </p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		var foo: u8 align(4) = 100;
-		
-		test "global variable alignment" {
-		    assert(@TypeOf(&foo).alignment == 4);
-		    assert(@TypeOf(&foo) == *align(4) u8);
-		    const as_pointer_to_array: *[1]u8 = &foo;
-		    const as_slice: []u8 = as_pointer_to_array;
-		    assert(@TypeOf(as_slice) == []align(4) u8);
-		}
-		
-		fn derp() align(@sizeOf(usize) * 2) i32 { return 1234; }
-		fn noop1() align(1) void {}
-		fn noop4() align(4) void {}
-		
-		test "function alignment" {
-		    assert(derp() == 1234);
-		    assert(@TypeOf(noop1) == fn() align(1) void);
-		    assert(@TypeOf(noop4) == fn() align(4) void);
-		    noop1();
-		    noop4();
-		}
+        const assert = @import("std").debug.assert;
+        
+        var foo: u8 align(4) = 100;
+        
+        test "global variable alignment" {
+            assert(@TypeOf(&foo).alignment == 4);
+            assert(@TypeOf(&foo) == *align(4) u8);
+            const as_pointer_to_array: *[1]u8 = &foo;
+            const as_slice: []u8 = as_pointer_to_array;
+            assert(@TypeOf(as_slice) == []align(4) u8);
+        }
+        
+        fn derp() align(@sizeOf(usize) * 2) i32 { return 1234; }
+        fn noop1() align(1) void {}
+        fn noop4() align(4) void {}
+        
+        test "function alignment" {
+            assert(derp() == 1234);
+            assert(@TypeOf(noop1) == fn() align(1) void);
+            assert(@TypeOf(noop4) == fn() align(4) void);
+            noop1();
+            noop4();
+        }
       {#code_end#}
       <p>
       If you have a pointer or a slice that has a small alignment, but you know that it actually
@@ -2192,18 +2192,18 @@ orelse catch
       {#link|safety check|Incorrect Pointer Alignment#}:
       </p>
       {#code_begin|test_safety|incorrect alignment#}
-		const std = @import("std");
-		
-		test "pointer alignment safety" {
-		    var array align(4) = [_]u32{ 0x11111111, 0x11111111 };
-		    const bytes = std.mem.sliceAsBytes(array[0..]);
-		    std.debug.assert(foo(bytes) == 0x11111111);
-		}
-		fn foo(bytes: []u8) u32 {
-		    const slice4 = bytes[1..5];
-		    const int_slice = std.mem.bytesAsSlice(u32, @alignCast(4, slice4));
-		    return int_slice[0];
-		}
+        const std = @import("std");
+        
+        test "pointer alignment safety" {
+            var array align(4) = [_]u32{ 0x11111111, 0x11111111 };
+            const bytes = std.mem.sliceAsBytes(array[0..]);
+            std.debug.assert(foo(bytes) == 0x11111111);
+        }
+        fn foo(bytes: []u8) u32 {
+            const slice4 = bytes[1..5];
+            const int_slice = std.mem.bytesAsSlice(u32, @alignCast(4, slice4));
+            return int_slice[0];
+        }
       {#code_end#}
       {#header_close#}
 
@@ -2219,14 +2219,14 @@ orelse catch
       {#link|Pointer Cast Invalid Null#} panic:
       </p>
       {#code_begin|test|allowzero#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "allowzero" {
-		    var zero: usize = 0;
-		    var ptr = @intToPtr(*allowzero i32, zero);
-		    assert(@ptrToInt(ptr) == 0);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "allowzero" {
+            var zero: usize = 0;
+            var ptr = @intToPtr(*allowzero i32, zero);
+            assert(@ptrToInt(ptr) == 0);
+        }
       {#code_end#}
       {#header_close#}
 
@@ -2239,19 +2239,19 @@ orelse catch
       against buffer overflow and overreads.
       </p>
       {#code_begin|exe_build_err#}
-		      {#link_libc#}
-		const std = @import("std");
-		
-		// This is also available as `std.c.printf`.
-		pub extern "c" fn printf(format: [*:0]const u8, ...) c_int;
-		
-		pub fn main() anyerror!void {
-		    _ = printf("Hello, world!\n"); // OK
-		
-		    const msg = "Hello, world!\n";
-		    const non_null_terminated_msg: [msg.len]u8 = msg.*;
-		    _ = printf(&non_null_terminated_msg);
-		}
+              {#link_libc#}
+        const std = @import("std");
+        
+        // This is also available as `std.c.printf`.
+        pub extern "c" fn printf(format: [*:0]const u8, ...) c_int;
+        
+        pub fn main() anyerror!void {
+            _ = printf("Hello, world!\n"); // OK
+        
+            const msg = "Hello, world!\n";
+            const non_null_terminated_msg: [msg.len]u8 = msg.*;
+            _ = printf(&non_null_terminated_msg);
+        }
       {#code_end#}
       {#see_also|Sentinel-Terminated Slices|Sentinel-Terminated Arrays#}
       {#header_close#}
@@ -2261,78 +2261,78 @@ orelse catch
 
       {#header_open|Slices#}
       {#code_begin|test_safety|index out of bounds#}
-		const assert = @import("std").debug.assert;
-		
-		test "basic slices" {
-		    var array = [_]i32{ 1, 2, 3, 4 };
-		    // A slice is a pointer and a length. The difference between an array and
-		    // a slice is that the array's length is part of the type and known at
-		    // compile-time, whereas the slice's length is known at runtime.
-		    // Both can be accessed with the `len` field.
-		    var known_at_runtime_zero: usize = 0;
-		    const slice = array[known_at_runtime_zero..array.len];
-		    assert(&slice[0] == &array[0]);
-		    assert(slice.len == array.len);
-		
-		    // Using the address-of operator on a slice gives a pointer to a single
-		    // item, while using the `ptr` field gives an unknown length pointer.
-		    assert(@TypeOf(slice.ptr) == [*]i32);
-		    assert(@TypeOf(&slice[0]) == *i32);
-		    assert(@ptrToInt(slice.ptr) == @ptrToInt(&slice[0]));
-		
-		    // Slices have array bounds checking. If you try to access something out
-		    // of bounds, you'll get a safety check failure:
-		    slice[10] += 1;
-		
-		    // Note that `slice.ptr` does not invoke safety checking, while `&slice[0]`
-		    // asserts that the slice has len >= 1.
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "basic slices" {
+            var array = [_]i32{ 1, 2, 3, 4 };
+            // A slice is a pointer and a length. The difference between an array and
+            // a slice is that the array's length is part of the type and known at
+            // compile-time, whereas the slice's length is known at runtime.
+            // Both can be accessed with the `len` field.
+            var known_at_runtime_zero: usize = 0;
+            const slice = array[known_at_runtime_zero..array.len];
+            assert(&slice[0] == &array[0]);
+            assert(slice.len == array.len);
+        
+            // Using the address-of operator on a slice gives a pointer to a single
+            // item, while using the `ptr` field gives an unknown length pointer.
+            assert(@TypeOf(slice.ptr) == [*]i32);
+            assert(@TypeOf(&slice[0]) == *i32);
+            assert(@ptrToInt(slice.ptr) == @ptrToInt(&slice[0]));
+        
+            // Slices have array bounds checking. If you try to access something out
+            // of bounds, you'll get a safety check failure:
+            slice[10] += 1;
+        
+            // Note that `slice.ptr` does not invoke safety checking, while `&slice[0]`
+            // asserts that the slice has len >= 1.
+        }
       {#code_end#}
       <p>This is one reason we prefer slices to pointers.</p>
       {#code_begin|test|slices#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		const mem = std.mem;
-		const fmt = std.fmt;
-		
-		test "using slices for strings" {
-		    // Zig has no concept of strings. String literals are const pointers to
-		    // arrays of u8, and by convention parameters that are "strings" are
-		    // expected to be UTF-8 encoded slices of u8.
-		    // Here we coerce [5]u8 to []const u8
-		    const hello: []const u8 = "hello";
-		    const world: []const u8 = "世界";
-		
-		    var all_together: [100]u8 = undefined;
-		    // You can use slice syntax on an array to convert an array into a slice.
-		    const all_together_slice = all_together[0..];
-		    // String concatenation example.
-		    const hello_world = try fmt.bufPrint(all_together_slice, "{} {}", .{ hello, world });
-		
-		    // Generally, you can use UTF-8 and not worry about whether something is a
-		    // string. If you don't need to deal with individual characters, no need
-		    // to decode.
-		    assert(mem.eql(u8, hello_world, "hello 世界"));
-		}
-		
-		test "slice pointer" {
-		    var array: [10]u8 = undefined;
-		    const ptr = &array;
-		
-		    // You can use slicing syntax to convert a pointer into a slice:
-		    const slice = ptr[0..5];
-		    slice[2] = 3;
-		    assert(slice[2] == 3);
-		    // The slice is mutable because we sliced a mutable pointer.
-		    // Furthermore, it is actually a pointer to an array, since the start
-		    // and end indexes were both comptime-known.
-		    assert(@TypeOf(slice) == *[5]u8);
-		
-		    // You can also slice a slice:
-		    const slice2 = slice[2..3];
-		    assert(slice2.len == 1);
-		    assert(slice2[0] == 3);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        const mem = std.mem;
+        const fmt = std.fmt;
+        
+        test "using slices for strings" {
+            // Zig has no concept of strings. String literals are const pointers to
+            // arrays of u8, and by convention parameters that are "strings" are
+            // expected to be UTF-8 encoded slices of u8.
+            // Here we coerce [5]u8 to []const u8
+            const hello: []const u8 = "hello";
+            const world: []const u8 = "世界";
+        
+            var all_together: [100]u8 = undefined;
+            // You can use slice syntax on an array to convert an array into a slice.
+            const all_together_slice = all_together[0..];
+            // String concatenation example.
+            const hello_world = try fmt.bufPrint(all_together_slice, "{} {}", .{ hello, world });
+        
+            // Generally, you can use UTF-8 and not worry about whether something is a
+            // string. If you don't need to deal with individual characters, no need
+            // to decode.
+            assert(mem.eql(u8, hello_world, "hello 世界"));
+        }
+        
+        test "slice pointer" {
+            var array: [10]u8 = undefined;
+            const ptr = &array;
+        
+            // You can use slicing syntax to convert a pointer into a slice:
+            const slice = ptr[0..5];
+            slice[2] = 3;
+            assert(slice[2] == 3);
+            // The slice is mutable because we sliced a mutable pointer.
+            // Furthermore, it is actually a pointer to an array, since the start
+            // and end indexes were both comptime-known.
+            assert(@TypeOf(slice) == *[5]u8);
+        
+            // You can also slice a slice:
+            const slice2 = slice[2..3];
+            assert(slice2.len == 1);
+            assert(slice2[0] == 3);
+        }
       {#code_end#}
       {#see_also|Pointers|for|Arrays#}
 
@@ -2346,15 +2346,15 @@ orelse catch
       access to the {#syntax#}len{#endsyntax#} index.
       </p>
       {#code_begin|test|null_terminated_slice#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "null terminated slice" {
-		    const slice: [:0]const u8 = "hello";
-		
-		    assert(slice.len == 5);
-		    assert(slice[5] == 0);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "null terminated slice" {
+            const slice: [:0]const u8 = "hello";
+        
+            assert(slice.len == 5);
+            assert(slice[5] == 0);
+        }
       {#code_end#}
       {#see_also|Sentinel-Terminated Pointers|Sentinel-Terminated Arrays#}
       {#header_close#}
@@ -2364,140 +2364,140 @@ orelse catch
 
       {#header_open|struct#}
       {#code_begin|test|structs#}
-		// Declare a struct.
-		// Zig gives no guarantees about the order of fields and the size of
-		// the struct but the fields are guaranteed to be ABI-aligned.
-		const Point = struct {
-		    x: f32,
-		    y: f32,
-		};
-		
-		// Maybe we want to pass it to OpenGL so we want to be particular about
-		// how the bytes are arranged.
-		const Point2 = packed struct {
-		    x: f32,
-		    y: f32,
-		};
-		
-		
-		// Declare an instance of a struct.
-		const p = Point {
-		    .x = 0.12,
-		    .y = 0.34,
-		};
-		
-		// Maybe we're not ready to fill out some of the fields.
-		var p2 = Point {
-		    .x = 0.12,
-		    .y = undefined,
-		};
-		
-		// Structs can have methods
-		// Struct methods are not special, they are only namespaced
-		// functions that you can call with dot syntax.
-		const Vec3 = struct {
-		    x: f32,
-		    y: f32,
-		    z: f32,
-		
-		    pub fn init(x: f32, y: f32, z: f32) Vec3 {
-		        return Vec3 {
-		            .x = x,
-		            .y = y,
-		            .z = z,
-		        };
-		    }
-		
-		    pub fn dot(self: Vec3, other: Vec3) f32 {
-		        return self.x * other.x + self.y * other.y + self.z * other.z;
-		    }
-		};
-		
-		const assert = @import("std").debug.assert;
-		test "dot product" {
-		    const v1 = Vec3.init(1.0, 0.0, 0.0);
-		    const v2 = Vec3.init(0.0, 1.0, 0.0);
-		    assert(v1.dot(v2) == 0.0);
-		
-		    // Other than being available to call with dot syntax, struct methods are
-		    // not special. You can reference them as any other declaration inside
-		    // the struct:
-		    assert(Vec3.dot(v1, v2) == 0.0);
-		}
-		
-		// Structs can have global declarations.
-		// Structs can have 0 fields.
-		const Empty = struct {
-		    pub const PI = 3.14;
-		};
-		test "struct namespaced variable" {
-		    assert(Empty.PI == 3.14);
-		    assert(@sizeOf(Empty) == 0);
-		
-		    // you can still instantiate an empty struct
-		    const does_nothing = Empty {};
-		}
-		
-		// struct field order is determined by the compiler for optimal performance.
-		// however, you can still calculate a struct base pointer given a field pointer:
-		fn setYBasedOnX(x: *f32, y: f32) void {
-		    const point = @fieldParentPtr(Point, "x", x);
-		    point.y = y;
-		}
-		test "field parent pointer" {
-		    var point = Point {
-		        .x = 0.1234,
-		        .y = 0.5678,
-		    };
-		    setYBasedOnX(&point.x, 0.9);
-		    assert(point.y == 0.9);
-		}
-		
-		// You can return a struct from a function. This is how we do generics
-		// in Zig:
-		fn LinkedList(comptime T: type) type {
-		    return struct {
-		        pub const Node = struct {
-		            prev: ?*Node,
-		            next: ?*Node,
-		            data: T,
-		        };
-		
-		        first: ?*Node,
-		        last:  ?*Node,
-		        len:   usize,
-		    };
-		}
-		
-		test "linked list" {
-		    // Functions called at compile-time are memoized. This means you can
-		    // do this:
-		    assert(LinkedList(i32) == LinkedList(i32));
-		
-		    var list = LinkedList(i32) {
-		        .first = null,
-		        .last = null,
-		        .len = 0,
-		    };
-		    assert(list.len == 0);
-		
-		    // Since types are first class values you can instantiate the type
-		    // by assigning it to a variable:
-		    const ListOfInts = LinkedList(i32);
-		    assert(ListOfInts == LinkedList(i32));
-		
-		    var node = ListOfInts.Node {
-		        .prev = null,
-		        .next = null,
-		        .data = 1234,
-		    };
-		    var list2 = LinkedList(i32) {
-		        .first = &node,
-		        .last = &node,
-		        .len = 1,
-		    };
-		    assert(list2.first.?.data == 1234);
-		}
+        // Declare a struct.
+        // Zig gives no guarantees about the order of fields and the size of
+        // the struct but the fields are guaranteed to be ABI-aligned.
+        const Point = struct {
+            x: f32,
+            y: f32,
+        };
+        
+        // Maybe we want to pass it to OpenGL so we want to be particular about
+        // how the bytes are arranged.
+        const Point2 = packed struct {
+            x: f32,
+            y: f32,
+        };
+        
+        
+        // Declare an instance of a struct.
+        const p = Point {
+            .x = 0.12,
+            .y = 0.34,
+        };
+        
+        // Maybe we're not ready to fill out some of the fields.
+        var p2 = Point {
+            .x = 0.12,
+            .y = undefined,
+        };
+        
+        // Structs can have methods
+        // Struct methods are not special, they are only namespaced
+        // functions that you can call with dot syntax.
+        const Vec3 = struct {
+            x: f32,
+            y: f32,
+            z: f32,
+        
+            pub fn init(x: f32, y: f32, z: f32) Vec3 {
+                return Vec3 {
+                    .x = x,
+                    .y = y,
+                    .z = z,
+                };
+            }
+        
+            pub fn dot(self: Vec3, other: Vec3) f32 {
+                return self.x * other.x + self.y * other.y + self.z * other.z;
+            }
+        };
+        
+        const assert = @import("std").debug.assert;
+        test "dot product" {
+            const v1 = Vec3.init(1.0, 0.0, 0.0);
+            const v2 = Vec3.init(0.0, 1.0, 0.0);
+            assert(v1.dot(v2) == 0.0);
+        
+            // Other than being available to call with dot syntax, struct methods are
+            // not special. You can reference them as any other declaration inside
+            // the struct:
+            assert(Vec3.dot(v1, v2) == 0.0);
+        }
+        
+        // Structs can have global declarations.
+        // Structs can have 0 fields.
+        const Empty = struct {
+            pub const PI = 3.14;
+        };
+        test "struct namespaced variable" {
+            assert(Empty.PI == 3.14);
+            assert(@sizeOf(Empty) == 0);
+        
+            // you can still instantiate an empty struct
+            const does_nothing = Empty {};
+        }
+        
+        // struct field order is determined by the compiler for optimal performance.
+        // however, you can still calculate a struct base pointer given a field pointer:
+        fn setYBasedOnX(x: *f32, y: f32) void {
+            const point = @fieldParentPtr(Point, "x", x);
+            point.y = y;
+        }
+        test "field parent pointer" {
+            var point = Point {
+                .x = 0.1234,
+                .y = 0.5678,
+            };
+            setYBasedOnX(&point.x, 0.9);
+            assert(point.y == 0.9);
+        }
+        
+        // You can return a struct from a function. This is how we do generics
+        // in Zig:
+        fn LinkedList(comptime T: type) type {
+            return struct {
+                pub const Node = struct {
+                    prev: ?*Node,
+                    next: ?*Node,
+                    data: T,
+                };
+        
+                first: ?*Node,
+                last:  ?*Node,
+                len:   usize,
+            };
+        }
+        
+        test "linked list" {
+            // Functions called at compile-time are memoized. This means you can
+            // do this:
+            assert(LinkedList(i32) == LinkedList(i32));
+        
+            var list = LinkedList(i32) {
+                .first = null,
+                .last = null,
+                .len = 0,
+            };
+            assert(list.len == 0);
+        
+            // Since types are first class values you can instantiate the type
+            // by assigning it to a variable:
+            const ListOfInts = LinkedList(i32);
+            assert(ListOfInts == LinkedList(i32));
+        
+            var node = ListOfInts.Node {
+                .prev = null,
+                .next = null,
+                .data = 1234,
+            };
+            var list2 = LinkedList(i32) {
+                .first = &node,
+                .last = &node,
+                .len = 1,
+            };
+            assert(list2.first.?.data == 1234);
+        }
       {#code_end#}
 
 
@@ -2508,19 +2508,19 @@ orelse catch
       are executed at {#link|comptime#}, and allow the field to be omitted in a struct literal expression:
       </p>
       {#code_begin|test#}
-		const Foo = struct {
-		    a: i32 = 1234,
-		    b: i32,
-		};
-		
-		test "default struct initialization fields" {
-		    const x = Foo{
-		        .b = 5,
-		    };
-		    if (x.a + x.b != 1239) {
-		        @compileError("it's even comptime known!");
-		    }
-		}
+        const Foo = struct {
+            a: i32 = 1234,
+            b: i32,
+        };
+        
+        test "default struct initialization fields" {
+            const x = Foo{
+                .b = 5,
+            };
+            if (x.a + x.b != 1239) {
+                @compileError("it's even comptime known!");
+            }
+        }
       {#code_end#}
       {#header_close#}
 
@@ -2561,94 +2561,94 @@ orelse catch
       This even works at {#link|comptime#}:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const builtin = std.builtin;
-		const assert = std.debug.assert;
-		
-		const Full = packed struct {
-		    number: u16,
-		};
-		const Divided = packed struct {
-		    half1: u8,
-		    quarter3: u4,
-		    quarter4: u4,
-		};
-		
-		test "@bitCast between packed structs" {
-		    doTheTest();
-		    comptime doTheTest();
-		}
-		
-		fn doTheTest() void {
-		    assert(@sizeOf(Full) == 2);
-		    assert(@sizeOf(Divided) == 2);
-		    var full = Full{ .number = 0x1234 };
-		    var divided = @bitCast(Divided, full);
-		    switch (builtin.endian) {
-		        .Big => {
-		            assert(divided.half1 == 0x12);
-		            assert(divided.quarter3 == 0x3);
-		            assert(divided.quarter4 == 0x4);
-		        },
-		        .Little => {
-		            assert(divided.half1 == 0x34);
-		            assert(divided.quarter3 == 0x2);
-		            assert(divided.quarter4 == 0x1);
-		        },
-		    }
-		}
+        const std = @import("std");
+        const builtin = std.builtin;
+        const assert = std.debug.assert;
+        
+        const Full = packed struct {
+            number: u16,
+        };
+        const Divided = packed struct {
+            half1: u8,
+            quarter3: u4,
+            quarter4: u4,
+        };
+        
+        test "@bitCast between packed structs" {
+            doTheTest();
+            comptime doTheTest();
+        }
+        
+        fn doTheTest() void {
+            assert(@sizeOf(Full) == 2);
+            assert(@sizeOf(Divided) == 2);
+            var full = Full{ .number = 0x1234 };
+            var divided = @bitCast(Divided, full);
+            switch (builtin.endian) {
+                .Big => {
+                    assert(divided.half1 == 0x12);
+                    assert(divided.quarter3 == 0x3);
+                    assert(divided.quarter4 == 0x4);
+                },
+                .Little => {
+                    assert(divided.half1 == 0x34);
+                    assert(divided.quarter3 == 0x2);
+                    assert(divided.quarter4 == 0x1);
+                },
+            }
+        }
       {#code_end#}
       <p>
       Zig allows the address to be taken of a non-byte-aligned field:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const BitField = packed struct {
-		    a: u3,
-		    b: u3,
-		    c: u2,
-		};
-		
-		var foo = BitField{
-		    .a = 1,
-		    .b = 2,
-		    .c = 3,
-		};
-		
-		test "pointer to non-byte-aligned field" {
-		    const ptr = &foo.b;
-		    assert(ptr.* == 2);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const BitField = packed struct {
+            a: u3,
+            b: u3,
+            c: u2,
+        };
+        
+        var foo = BitField{
+            .a = 1,
+            .b = 2,
+            .c = 3,
+        };
+        
+        test "pointer to non-byte-aligned field" {
+            const ptr = &foo.b;
+            assert(ptr.* == 2);
+        }
       {#code_end#}
       <p>
       However, the pointer to a non-byte-aligned field has special properties and cannot
       be passed when a normal pointer is expected:
       </p>
       {#code_begin|test_err|expected type#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const BitField = packed struct {
-		    a: u3,
-		    b: u3,
-		    c: u2,
-		};
-		
-		var bit_field = BitField{
-		    .a = 1,
-		    .b = 2,
-		    .c = 3,
-		};
-		
-		test "pointer to non-bit-aligned field" {
-		    assert(bar(&bit_field.b) == 2);
-		}
-		
-		fn bar(x: *const u3) u3 {
-		    return x.*;
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const BitField = packed struct {
+            a: u3,
+            b: u3,
+            c: u2,
+        };
+        
+        var bit_field = BitField{
+            .a = 1,
+            .b = 2,
+            .c = 3,
+        };
+        
+        test "pointer to non-bit-aligned field" {
+            assert(bar(&bit_field.b) == 2);
+        }
+        
+        fn bar(x: *const u3) u3 {
+            return x.*;
+        }
       {#code_end#}
       <p>
       In this case, the function {#syntax#}bar{#endsyntax#} cannot be called becuse the pointer
@@ -2658,50 +2658,50 @@ orelse catch
       Pointers to non-ABI-aligned fields share the same address as the other fields within their host integer:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const BitField = packed struct {
-		    a: u3,
-		    b: u3,
-		    c: u2,
-		};
-		
-		var bit_field = BitField{
-		    .a = 1,
-		    .b = 2,
-		    .c = 3,
-		};
-		
-		test "pointer to non-bit-aligned field" {
-		    assert(@ptrToInt(&bit_field.a) == @ptrToInt(&bit_field.b));
-		    assert(@ptrToInt(&bit_field.a) == @ptrToInt(&bit_field.c));
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const BitField = packed struct {
+            a: u3,
+            b: u3,
+            c: u2,
+        };
+        
+        var bit_field = BitField{
+            .a = 1,
+            .b = 2,
+            .c = 3,
+        };
+        
+        test "pointer to non-bit-aligned field" {
+            assert(@ptrToInt(&bit_field.a) == @ptrToInt(&bit_field.b));
+            assert(@ptrToInt(&bit_field.a) == @ptrToInt(&bit_field.c));
+        }
       {#code_end#}
       <p>
       This can be observed with {#link|@bitOffsetOf#} and {#link|byteOffsetOf#}:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const BitField = packed struct {
-		    a: u3,
-		    b: u3,
-		    c: u2,
-		};
-		
-		test "pointer to non-bit-aligned field" {
-		    comptime {
-		        assert(@bitOffsetOf(BitField, "a") == 0);
-		        assert(@bitOffsetOf(BitField, "b") == 3);
-		        assert(@bitOffsetOf(BitField, "c") == 6);
-		
-		        assert(@byteOffsetOf(BitField, "a") == 0);
-		        assert(@byteOffsetOf(BitField, "b") == 0);
-		        assert(@byteOffsetOf(BitField, "c") == 0);
-		    }
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const BitField = packed struct {
+            a: u3,
+            b: u3,
+            c: u2,
+        };
+        
+        test "pointer to non-bit-aligned field" {
+            comptime {
+                assert(@bitOffsetOf(BitField, "a") == 0);
+                assert(@bitOffsetOf(BitField, "b") == 3);
+                assert(@bitOffsetOf(BitField, "c") == 6);
+        
+                assert(@byteOffsetOf(BitField, "a") == 0);
+                assert(@byteOffsetOf(BitField, "b") == 0);
+                assert(@byteOffsetOf(BitField, "c") == 0);
+            }
+        }
       {#code_end#}
       <p>
       Packed structs have 1-byte alignment. However if you have an overaligned pointer to a packed struct,
@@ -2709,15 +2709,15 @@ orelse catch
       <a href="https://github.com/ziglang/zig/issues/1994">a bug</a>:
       </p>
       {#code_begin|test_err#}
-		const S = packed struct {
-		    a: u32,
-		    b: u32,
-		};
-		test "overaligned pointer to packed struct" {
-		    var foo: S align(4) = undefined;
-		    const ptr: *align(4) S = &foo;
-		    const ptr_to_b: *u32 = &ptr.b;
-		}
+        const S = packed struct {
+            a: u32,
+            b: u32,
+        };
+        test "overaligned pointer to packed struct" {
+            var foo: S align(4) = undefined;
+            const ptr: *align(4) S = &foo;
+            const ptr_to_b: *u32 = &ptr.b;
+        }
       {#code_end#}
       <p>When this bug is fixed, the above test in the documentation will unexpectedly pass, which will
       cause the test suite to fail, notifying the bug fixer to update these docs.
@@ -2748,20 +2748,20 @@ orelse catch
           <li>Otherwise, the struct gets a name such as <code>(anonymous struct at file.zig:7:38)</code>.</li>
       </ul>
       {#code_begin|exe|struct_name#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    const Foo = struct {};
-		    std.debug.warn("variable: {}\n", .{@typeName(Foo)});
-		    std.debug.warn("anonymous: {}\n", .{@typeName(struct {})});
-		    std.debug.warn("function: {}\n", .{@typeName(List(i32))});
-		}
-		
-		fn List(comptime T: type) type {
-		    return struct {
-		        x: T,
-		    };
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            const Foo = struct {};
+            std.debug.warn("variable: {}\n", .{@typeName(Foo)});
+            std.debug.warn("anonymous: {}\n", .{@typeName(struct {})});
+            std.debug.warn("function: {}\n", .{@typeName(List(i32))});
+        }
+        
+        fn List(comptime T: type) type {
+            return struct {
+                x: T,
+            };
+        }
       {#code_end#}
       {#header_close#}
 
@@ -2773,44 +2773,44 @@ orelse catch
       the struct literal will directly instantiate the result location, with no copy:
       </p>
       {#code_begin|test|struct_result#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const Point = struct {x: i32, y: i32};
-		
-		test "anonymous struct literal" {
-		    var pt: Point = .{
-		        .x = 13,
-		        .y = 67,
-		    };
-		    assert(pt.x == 13);
-		    assert(pt.y == 67);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const Point = struct {x: i32, y: i32};
+        
+        test "anonymous struct literal" {
+            var pt: Point = .{
+                .x = 13,
+                .y = 67,
+            };
+            assert(pt.x == 13);
+            assert(pt.y == 67);
+        }
       {#code_end#}
       <p>
       The struct type can be inferred. Here the result location does not include a type, and
       so Zig infers the type:
       </p>
       {#code_begin|test|struct_anon#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "fully anonymous struct" {
-		    dump(.{
-		        .int = @as(u32, 1234),
-		        .float = @as(f64, 12.34),
-		        .b = true,
-		        .s = "hi",
-		    });
-		}
-		
-		fn dump(args: var) void {
-		    assert(args.int == 1234);
-		    assert(args.float == 12.34);
-		    assert(args.b);
-		    assert(args.s[0] == 'h');
-		    assert(args.s[1] == 'i');
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "fully anonymous struct" {
+            dump(.{
+                .int = @as(u32, 1234),
+                .float = @as(f64, 12.34),
+                .b = true,
+                .s = "hi",
+            });
+        }
+        
+        fn dump(args: var) void {
+            assert(args.int == 1234);
+            assert(args.float == 12.34);
+            assert(args.b);
+            assert(args.s[0] == 'h');
+            assert(args.s[1] == 'i');
+        }
       {#code_end#}
       {#header_close#}
       {#see_also|comptime|@fieldParentPtr#}
@@ -2819,101 +2819,101 @@ orelse catch
 
       {#header_open|enum#}
       {#code_begin|test|enums#}
-		const assert = @import("std").debug.assert;
-		const mem = @import("std").mem;
-		
-		// Declare an enum.
-		const Type = enum {
-		    Ok,
-		    NotOk,
-		};
-		
-		// Declare a specific instance of the enum variant.
-		const c = Type.Ok;
-		
-		// If you want access to the ordinal value of an enum, you
-		// can specify the tag type.
-		const Value = enum(u2) {
-		    Zero,
-		    One,
-		    Two,
-		};
-		
-		// Now you can cast between u2 and Value.
-		// The ordinal value starts from 0, counting up for each member.
-		test "enum ordinal value" {
-		    assert(@enumToInt(Value.Zero) == 0);
-		    assert(@enumToInt(Value.One) == 1);
-		    assert(@enumToInt(Value.Two) == 2);
-		}
-		
-		// You can override the ordinal value for an enum.
-		const Value2 = enum(u32) {
-		    Hundred = 100,
-		    Thousand = 1000,
-		    Million = 1000000,
-		};
-		test "set enum ordinal value" {
-		    assert(@enumToInt(Value2.Hundred) == 100);
-		    assert(@enumToInt(Value2.Thousand) == 1000);
-		    assert(@enumToInt(Value2.Million) == 1000000);
-		}
-		
-		// Enums can have methods, the same as structs and unions.
-		// Enum methods are not special, they are only namespaced
-		// functions that you can call with dot syntax.
-		const Suit = enum {
-		    Clubs,
-		    Spades,
-		    Diamonds,
-		    Hearts,
-		
-		    pub fn isClubs(self: Suit) bool {
-		        return self == Suit.Clubs;
-		    }
-		};
-		test "enum method" {
-		    const p = Suit.Spades;
-		    assert(!p.isClubs());
-		}
-		
-		// An enum variant of different types can be switched upon.
-		const Foo = enum {
-		    String,
-		    Number,
-		    None,
-		};
-		test "enum variant switch" {
-		    const p = Foo.Number;
-		    const what_is_it = switch (p) {
-		        Foo.String => "this is a string",
-		        Foo.Number => "this is a number",
-		        Foo.None => "this is a none",
-		    };
-		    assert(mem.eql(u8, what_is_it, "this is a number"));
-		}
-		
-		// @TagType can be used to access the integer tag type of an enum.
-		const Small = enum {
-		    One,
-		    Two,
-		    Three,
-		    Four,
-		};
-		test "@TagType" {
-		    assert(@TagType(Small) == u2);
-		}
-		
-		// @typeInfo tells us the field count and the fields names:
-		test "@typeInfo" {
-		    assert(@typeInfo(Small).Enum.fields.len == 4);
-		    assert(mem.eql(u8, @typeInfo(Small).Enum.fields[1].name, "Two"));
-		}
-		
-		// @tagName gives a []const u8 representation of an enum value:
-		test "@tagName" {
-		    assert(mem.eql(u8, @tagName(Small.Three), "Three"));
-		}
+        const assert = @import("std").debug.assert;
+        const mem = @import("std").mem;
+        
+        // Declare an enum.
+        const Type = enum {
+            Ok,
+            NotOk,
+        };
+        
+        // Declare a specific instance of the enum variant.
+        const c = Type.Ok;
+        
+        // If you want access to the ordinal value of an enum, you
+        // can specify the tag type.
+        const Value = enum(u2) {
+            Zero,
+            One,
+            Two,
+        };
+        
+        // Now you can cast between u2 and Value.
+        // The ordinal value starts from 0, counting up for each member.
+        test "enum ordinal value" {
+            assert(@enumToInt(Value.Zero) == 0);
+            assert(@enumToInt(Value.One) == 1);
+            assert(@enumToInt(Value.Two) == 2);
+        }
+        
+        // You can override the ordinal value for an enum.
+        const Value2 = enum(u32) {
+            Hundred = 100,
+            Thousand = 1000,
+            Million = 1000000,
+        };
+        test "set enum ordinal value" {
+            assert(@enumToInt(Value2.Hundred) == 100);
+            assert(@enumToInt(Value2.Thousand) == 1000);
+            assert(@enumToInt(Value2.Million) == 1000000);
+        }
+        
+        // Enums can have methods, the same as structs and unions.
+        // Enum methods are not special, they are only namespaced
+        // functions that you can call with dot syntax.
+        const Suit = enum {
+            Clubs,
+            Spades,
+            Diamonds,
+            Hearts,
+        
+            pub fn isClubs(self: Suit) bool {
+                return self == Suit.Clubs;
+            }
+        };
+        test "enum method" {
+            const p = Suit.Spades;
+            assert(!p.isClubs());
+        }
+        
+        // An enum variant of different types can be switched upon.
+        const Foo = enum {
+            String,
+            Number,
+            None,
+        };
+        test "enum variant switch" {
+            const p = Foo.Number;
+            const what_is_it = switch (p) {
+                Foo.String => "this is a string",
+                Foo.Number => "this is a number",
+                Foo.None => "this is a none",
+            };
+            assert(mem.eql(u8, what_is_it, "this is a number"));
+        }
+        
+        // @TagType can be used to access the integer tag type of an enum.
+        const Small = enum {
+            One,
+            Two,
+            Three,
+            Four,
+        };
+        test "@TagType" {
+            assert(@TagType(Small) == u2);
+        }
+        
+        // @typeInfo tells us the field count and the fields names:
+        test "@typeInfo" {
+            assert(@typeInfo(Small).Enum.fields.len == 4);
+            assert(mem.eql(u8, @typeInfo(Small).Enum.fields[1].name, "Two"));
+        }
+        
+        // @tagName gives a []const u8 representation of an enum value:
+        test "@tagName" {
+            assert(mem.eql(u8, @tagName(Small.Three), "Three"));
+        }
       {#code_end#}
       {#see_also|@typeInfo|@tagName|@sizeOf#}
 
@@ -2924,15 +2924,15 @@ orelse catch
       By default, enums are not guaranteed to be compatible with the C ABI:
       </p>
       {#code_begin|obj_err|parameter of type 'Foo' not allowed in function with calling convention 'C'#}
-		const Foo = enum { A, B, C };
-		export fn entry(foo: Foo) void { }
+        const Foo = enum { A, B, C };
+        export fn entry(foo: Foo) void { }
       {#code_end#}
       <p>
       For a C-ABI-compatible enum, use {#syntax#}extern enum{#endsyntax#}:
       </p>
       {#code_begin|obj#}
-		const Foo = extern enum { A, B, C };
-		export fn entry(foo: Foo) void { }
+        const Foo = extern enum { A, B, C };
+        export fn entry(foo: Foo) void { }
       {#code_end#}
       {#header_close#}
 
@@ -2943,16 +2943,16 @@ orelse catch
       <p>{#syntax#}packed enum{#endsyntax#} causes the size of the enum to be the same as the size of the
       integer tag type of the enum:</p>
       {#code_begin|test#}
-		const std = @import("std");
-		
-		test "packed enum" {
-		    const Number = packed enum(u8) {
-		        One,
-		        Two,
-		        Three,
-		    };
-		    std.debug.assert(@sizeOf(Number) == @sizeOf(u8));
-		}
+        const std = @import("std");
+        
+        test "packed enum" {
+            const Number = packed enum(u8) {
+                One,
+                Two,
+                Three,
+            };
+            std.debug.assert(@sizeOf(Number) == @sizeOf(u8));
+        }
       {#code_end#}
       <p>This makes the enum eligible to be in a {#link|packed struct#}.</p>
       {#header_close#}
@@ -2964,30 +2964,30 @@ orelse catch
       Enum literals allow specifying the name of an enum field without specifying the enum type:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const Color = enum {
-		    Auto,
-		    Off,
-		    On,
-		};
-		
-		test "enum literals" {
-		    const color1: Color = .Auto;
-		    const color2 = Color.Auto;
-		    assert(color1 == color2);
-		}
-		
-		test "switch using enum literals" {
-		    const color = Color.On;
-		    const result = switch (color) {
-		        .Auto => false,
-		        .On => true,
-		        .Off => false,
-		    };
-		    assert(result);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const Color = enum {
+            Auto,
+            Off,
+            On,
+        };
+        
+        test "enum literals" {
+            const color1: Color = .Auto;
+            const color2 = Color.Auto;
+            assert(color1 == color2);
+        }
+        
+        test "switch using enum literals" {
+            const color = Color.On;
+            const result = switch (color) {
+                .Auto => false,
+                .On => true,
+                .Off => false,
+            };
+            assert(result);
+        }
       {#code_end#}
       {#header_close#}
 
@@ -3006,31 +3006,31 @@ orelse catch
       with the difference being that it makes it a compile error if all the known tag names are not handled by the switch.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const Number = enum(u8) {
-		    One,
-		    Two,
-		    Three,
-		    _,
-		};
-		
-		test "switch on non-exhaustive enum" {
-		    const number = Number.One;
-		    const result = switch (number) {
-		        .One => true,
-		        .Two,
-		        .Three => false,
-		        _ => false,
-		    };
-		    assert(result);
-		    const is_one = switch (number) {
-		        .One => true,
-		        else => false,
-		    };
-		    assert(is_one);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const Number = enum(u8) {
+            One,
+            Two,
+            Three,
+            _,
+        };
+        
+        test "switch on non-exhaustive enum" {
+            const number = Number.One;
+            const result = switch (number) {
+                .One => true,
+                .Two,
+                .Three => false,
+                _ => false,
+            };
+            assert(result);
+            const is_one = switch (number) {
+                .One => true,
+                else => false,
+            };
+            assert(is_one);
+        }
       {#code_end#}
       {#header_close#}
       {#header_close#}
@@ -3049,32 +3049,32 @@ orelse catch
       safety-checked {#link|Undefined Behavior#}:
       </p>
       {#code_begin|test_err|inactive union field#}
-		const Payload = union {
-		    Int: i64,
-		    Float: f64,
-		    Bool: bool,
-		};
-		test "simple union" {
-		    var payload = Payload{ .Int = 1234 };
-		    payload.Float = 12.34;
-		}
+        const Payload = union {
+            Int: i64,
+            Float: f64,
+            Bool: bool,
+        };
+        test "simple union" {
+            var payload = Payload{ .Int = 1234 };
+            payload.Float = 12.34;
+        }
       {#code_end#}
       <p>You can activate another field by assigning the entire union:</p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const Payload = union {
-		    Int: i64,
-		    Float: f64,
-		    Bool: bool,
-		};
-		test "simple union" {
-		    var payload = Payload{ .Int = 1234 };
-		    assert(payload.Int == 1234);
-		    payload = Payload{ .Float = 12.34 };
-		    assert(payload.Float == 12.34);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const Payload = union {
+            Int: i64,
+            Float: f64,
+            Bool: bool,
+        };
+        test "simple union" {
+            var payload = Payload{ .Int = 1234 };
+            assert(payload.Int == 1234);
+            payload = Payload{ .Float = 12.34 };
+            assert(payload.Float == 12.34);
+        }
       {#code_end#}
       <p>
       In order to use {#link|switch#} with a union, it must be a {#link|Tagged union#}.
@@ -3093,116 +3093,116 @@ orelse catch
       Tagged unions coerce to their tag type: {#link|Type Coercion: unions and enums#}.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const ComplexTypeTag = enum {
-		    Ok,
-		    NotOk,
-		};
-		const ComplexType = union(ComplexTypeTag) {
-		    Ok: u8,
-		    NotOk: void,
-		};
-		
-		test "switch on tagged union" {
-		    const c = ComplexType{ .Ok = 42 };
-		    assert(@as(ComplexTypeTag, c) == ComplexTypeTag.Ok);
-		
-		    switch (c) {
-		        ComplexTypeTag.Ok => |value| assert(value == 42),
-		        ComplexTypeTag.NotOk => unreachable,
-		    }
-		}
-		
-		test "@TagType" {
-		    assert(@TagType(ComplexType) == ComplexTypeTag);
-		}
-		
-		test "coerce to enum" {
-		    const c1 = ComplexType{ .Ok = 42 };
-		    const c2 = ComplexType.NotOk;
-		
-		    assert(c1 == .Ok);
-		    assert(c2 == .NotOk);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const ComplexTypeTag = enum {
+            Ok,
+            NotOk,
+        };
+        const ComplexType = union(ComplexTypeTag) {
+            Ok: u8,
+            NotOk: void,
+        };
+        
+        test "switch on tagged union" {
+            const c = ComplexType{ .Ok = 42 };
+            assert(@as(ComplexTypeTag, c) == ComplexTypeTag.Ok);
+        
+            switch (c) {
+                ComplexTypeTag.Ok => |value| assert(value == 42),
+                ComplexTypeTag.NotOk => unreachable,
+            }
+        }
+        
+        test "@TagType" {
+            assert(@TagType(ComplexType) == ComplexTypeTag);
+        }
+        
+        test "coerce to enum" {
+            const c1 = ComplexType{ .Ok = 42 };
+            const c2 = ComplexType.NotOk;
+        
+            assert(c1 == .Ok);
+            assert(c2 == .NotOk);
+        }
       {#code_end#}
       <p>In order to modify the payload of a tagged union in a switch expression,
       place a {#syntax#}*{#endsyntax#} before the variable name to make it a pointer:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const ComplexTypeTag = enum {
-		    Ok,
-		    NotOk,
-		};
-		const ComplexType = union(ComplexTypeTag) {
-		    Ok: u8,
-		    NotOk: void,
-		};
-		
-		test "modify tagged union in switch" {
-		    var c = ComplexType{ .Ok = 42 };
-		    assert(@as(ComplexTypeTag, c) == ComplexTypeTag.Ok);
-		
-		    switch (c) {
-		        ComplexTypeTag.Ok => |*value| value.* += 1,
-		        ComplexTypeTag.NotOk => unreachable,
-		    }
-		
-		    assert(c.Ok == 43);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const ComplexTypeTag = enum {
+            Ok,
+            NotOk,
+        };
+        const ComplexType = union(ComplexTypeTag) {
+            Ok: u8,
+            NotOk: void,
+        };
+        
+        test "modify tagged union in switch" {
+            var c = ComplexType{ .Ok = 42 };
+            assert(@as(ComplexTypeTag, c) == ComplexTypeTag.Ok);
+        
+            switch (c) {
+                ComplexTypeTag.Ok => |*value| value.* += 1,
+                ComplexTypeTag.NotOk => unreachable,
+            }
+        
+            assert(c.Ok == 43);
+        }
       {#code_end#}
       <p>
       Unions can be made to infer the enum tag type.
       Further, unions can have methods just like structs and enums.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const Variant = union(enum) {
-		    Int: i32,
-		    Bool: bool,
-		
-		    // void can be omitted when inferring enum tag type.
-		    None,
-		
-		    fn truthy(self: Variant) bool {
-		        return switch (self) {
-		            Variant.Int => |x_int| x_int != 0,
-		            Variant.Bool => |x_bool| x_bool,
-		            Variant.None => false,
-		        };
-		    }
-		};
-		
-		test "union method" {
-		    var v1 = Variant{ .Int = 1 };
-		    var v2 = Variant{ .Bool = false };
-		
-		    assert(v1.truthy());
-		    assert(!v2.truthy());
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const Variant = union(enum) {
+            Int: i32,
+            Bool: bool,
+        
+            // void can be omitted when inferring enum tag type.
+            None,
+        
+            fn truthy(self: Variant) bool {
+                return switch (self) {
+                    Variant.Int => |x_int| x_int != 0,
+                    Variant.Bool => |x_bool| x_bool,
+                    Variant.None => false,
+                };
+            }
+        };
+        
+        test "union method" {
+            var v1 = Variant{ .Int = 1 };
+            var v2 = Variant{ .Bool = false };
+        
+            assert(v1.truthy());
+            assert(!v2.truthy());
+        }
       {#code_end#}
       <p>
       {#link|@tagName#} can be used to return a {#link|comptime#}
       {#syntax#}[]const u8{#endsyntax#} value representing the field name:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const Small2 = union(enum) {
-		    A: i32,
-		    B: bool,
-		    C: u8,
-		};
-		test "@tagName" {
-		    assert(std.mem.eql(u8, @tagName(Small2.C), "C"));
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const Small2 = union(enum) {
+            A: i32,
+            B: bool,
+            C: u8,
+        };
+        test "@tagName" {
+            assert(std.mem.eql(u8, @tagName(Small2.C), "C"));
+        }
       {#code_end#}
       {#header_close#}
 
@@ -3229,24 +3229,24 @@ orelse catch
       <p>{#link|Anonymous Struct Literals#} syntax can be used to initialize unions without specifying
       the type:</p>
       {#code_begin|test|anon_union#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const Number = union {
-		    int: i32,
-		    float: f64,
-		};
-		
-		test "anonymous union literal syntax" {
-		    var i: Number = .{.int = 42};
-		    var f = makeNumber();
-		    assert(i.int == 42);
-		    assert(f.float == 12.34);
-		}
-		
-		fn makeNumber() Number {
-		    return .{.float = 12.34};
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const Number = union {
+            int: i32,
+            float: f64,
+        };
+        
+        test "anonymous union literal syntax" {
+            var i: Number = .{.int = 42};
+            var f = makeNumber();
+            assert(i.int == 42);
+            assert(f.float == 12.34);
+        }
+        
+        fn makeNumber() Number {
+            return .{.float = 12.34};
+        }
       {#code_end#}
       {#header_close#}
 
@@ -3259,30 +3259,30 @@ orelse catch
       Blocks are used to limit the scope of variable declarations:
       </p>
       {#code_begin|test_err|undeclared identifier#}
-		test "access variable after block scope" {
-		    {
-		        var x: i32 = 1;
-		    }
-		    x += 1;
-		}
+        test "access variable after block scope" {
+            {
+                var x: i32 = 1;
+            }
+            x += 1;
+        }
       {#code_end#}
       <p>Blocks are expressions. When labeled, {#syntax#}break{#endsyntax#} can be used
       to return a value from the block:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "labeled break from labeled block expression" {
-		    var y: i32 = 123;
-		
-		    const x = blk: {
-		        y += 1;
-		        break :blk y;
-		    };
-		    assert(x == 124);
-		    assert(y == 124);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "labeled break from labeled block expression" {
+            var y: i32 = 123;
+        
+            const x = blk: {
+                y += 1;
+                break :blk y;
+            };
+            assert(x == 124);
+            assert(y == 124);
+        }
       {#code_end#}
       <p>Here, {#syntax#}blk{#endsyntax#} can be any name.</p>
       {#see_also|Labeled while|Labeled for#}
@@ -3292,28 +3292,28 @@ orelse catch
       {#header_open|Shadowing#}
       <p>It is never allowed for an identifier to "hide" another one by using the same name:</p>
       {#code_begin|test_err|redefinition#}
-		const pi = 3.14;
-		
-		test "inside test block" {
-		    // Let's even go inside another block
-		    {
-		        var pi: i32 = 1234;
-		    }
-		}
+        const pi = 3.14;
+        
+        test "inside test block" {
+            // Let's even go inside another block
+            {
+                var pi: i32 = 1234;
+            }
+        }
       {#code_end#}
       <p>
       Because of this, when you read Zig code you can rely on an identifier always meaning the same thing,
       within the scope it is defined. Note that you can, however use the same name if the scopes are separate:
       </p>
       {#code_begin|test#}
-		test "separate scopes" {
-		    {
-		        const pi = 3.14;
-		    }
-		    {
-		        var pi: bool = true;
-		    }
-		}
+        test "separate scopes" {
+            {
+                const pi = 3.14;
+            }
+            {
+                var pi: bool = true;
+            }
+        }
       {#code_end#}
       {#header_close#}
       {#header_close#}
@@ -3322,69 +3322,69 @@ orelse catch
 
       {#header_open|switch#}
       {#code_begin|test|switch#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "switch simple" {
-		    const a: u64 = 10;
-		    const zz: u64 = 103;
-		
-		    // All branches of a switch expression must be able to be coerced to a
-		    // common type.
-		    //
-		    // Branches cannot fallthrough. If fallthrough behavior is desired, combine
-		    // the cases and use an if.
-		    const b = switch (a) {
-		        // Multiple cases can be combined via a ','
-		        1, 2, 3 => 0,
-		
-		        // Ranges can be specified using the ... syntax. These are inclusive
-		        // both ends.
-		        5...100 => 1,
-		
-		        // Branches can be arbitrarily complex.
-		        101 => blk: {
-		            const c: u64 = 5;
-		            break :blk c * 2 + 1;
-		        },
-		
-		        // Switching on arbitrary expressions is allowed as long as the
-		        // expression is known at compile-time.
-		        zz => zz,
-		        comptime blk: {
-		            const d: u32 = 5;
-		            const e: u32 = 100;
-		            break :blk d + e;
-		        } => 107,
-		
-		        // The else branch catches everything not already captured.
-		        // Else branches are mandatory unless the entire range of values
-		        // is handled.
-		        else => 9,
-		    };
-		
-		    assert(b == 1);
-		}
-		
-		// Switch expressions can be used outside a function:
-		const os_msg = switch (std.Target.current.os.tag) {
-		    .linux => "we found a linux user",
-		    else => "not a linux user",
-		};
-		
-		// Inside a function, switch statements implicitly are compile-time
-		// evaluated if the target expression is compile-time known.
-		test "switch inside function" {
-		    switch (std.Target.current.os.tag) {
-		        .fuchsia => {
-		            // On an OS other than fuchsia, block is not even analyzed,
-		            // so this compile error is not triggered.
-		            // On fuchsia this compile error would be triggered.
-		            @compileError("fuchsia not supported");
-		        },
-		        else => {},
-		    }
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "switch simple" {
+            const a: u64 = 10;
+            const zz: u64 = 103;
+        
+            // All branches of a switch expression must be able to be coerced to a
+            // common type.
+            //
+            // Branches cannot fallthrough. If fallthrough behavior is desired, combine
+            // the cases and use an if.
+            const b = switch (a) {
+                // Multiple cases can be combined via a ','
+                1, 2, 3 => 0,
+        
+                // Ranges can be specified using the ... syntax. These are inclusive
+                // both ends.
+                5...100 => 1,
+        
+                // Branches can be arbitrarily complex.
+                101 => blk: {
+                    const c: u64 = 5;
+                    break :blk c * 2 + 1;
+                },
+        
+                // Switching on arbitrary expressions is allowed as long as the
+                // expression is known at compile-time.
+                zz => zz,
+                comptime blk: {
+                    const d: u32 = 5;
+                    const e: u32 = 100;
+                    break :blk d + e;
+                } => 107,
+        
+                // The else branch catches everything not already captured.
+                // Else branches are mandatory unless the entire range of values
+                // is handled.
+                else => 9,
+            };
+        
+            assert(b == 1);
+        }
+        
+        // Switch expressions can be used outside a function:
+        const os_msg = switch (std.Target.current.os.tag) {
+            .linux => "we found a linux user",
+            else => "not a linux user",
+        };
+        
+        // Inside a function, switch statements implicitly are compile-time
+        // evaluated if the target expression is compile-time known.
+        test "switch inside function" {
+            switch (std.Target.current.os.tag) {
+                .fuchsia => {
+                    // On an OS other than fuchsia, block is not even analyzed,
+                    // so this compile error is not triggered.
+                    // On fuchsia this compile error would be triggered.
+                    @compileError("fuchsia not supported");
+                },
+                else => {},
+            }
+        }
       {#code_end#}
       <p>
       {#syntax#}switch{#endsyntax#} can be used to capture the field values
@@ -3393,42 +3393,42 @@ orelse catch
       turning it into a pointer.
       </p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "switch on tagged union" {
-		    const Point = struct {
-		        x: u8,
-		        y: u8,
-		    };
-		    const Item = union(enum) {
-		        A: u32,
-		        C: Point,
-		        D,
-		        E: u32,
-		    };
-		
-		    var a = Item{ .C = Point{ .x = 1, .y = 2 } };
-		
-		    // Switching on more complex enums is allowed.
-		    const b = switch (a) {
-		        // A capture group is allowed on a match, and will return the enum
-		        // value matched. If the payload types of both cases are the same
-		        // they can be put into the same switch prong.
-		        Item.A, Item.E => |item| item,
-		
-		        // A reference to the matched value can be obtained using `*` syntax.
-		        Item.C => |*item| blk: {
-		            item.*.x += 1;
-		            break :blk 6;
-		        },
-		
-		        // No else is required if the types cases was exhaustively handled
-		        Item.D => 8,
-		    };
-		
-		    assert(b == 6);
-		    assert(a.C.x == 2);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "switch on tagged union" {
+            const Point = struct {
+                x: u8,
+                y: u8,
+            };
+            const Item = union(enum) {
+                A: u32,
+                C: Point,
+                D,
+                E: u32,
+            };
+        
+            var a = Item{ .C = Point{ .x = 1, .y = 2 } };
+        
+            // Switching on more complex enums is allowed.
+            const b = switch (a) {
+                // A capture group is allowed on a match, and will return the enum
+                // value matched. If the payload types of both cases are the same
+                // they can be put into the same switch prong.
+                Item.A, Item.E => |item| item,
+        
+                // A reference to the matched value can be obtained using `*` syntax.
+                Item.C => |*item| blk: {
+                    item.*.x += 1;
+                    break :blk 6;
+                },
+        
+                // No else is required if the types cases was exhaustively handled
+                Item.D => 8,
+            };
+        
+            assert(b == 6);
+            assert(a.C.x == 2);
+        }
       {#code_end#}
       {#see_also|comptime|enum|@compileError|Compile Variables#}
 
@@ -3440,19 +3440,19 @@ orelse catch
       it must exhaustively list all the possible values. Failure to do so is a compile error:
       </p>
       {#code_begin|test_err|not handled in switch#}
-		const Color = enum {
-		    Auto,
-		    Off,
-		    On,
-		};
-		
-		test "exhaustive switching" {
-		    const color = Color.Off;
-		    switch (color) {
-		        Color.Auto => {},
-		        Color.On => {},
-		    }
-		}
+        const Color = enum {
+            Auto,
+            Off,
+            On,
+        };
+        
+        test "exhaustive switching" {
+            const color = Color.Off;
+            switch (color) {
+                Color.Auto => {},
+                Color.On => {},
+            }
+        }
       {#code_end#}
       {#header_close#}
 
@@ -3464,24 +3464,24 @@ orelse catch
       repetitively specifying {#link|enum#} or {#link|union#} types:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const Color = enum {
-		    Auto,
-		    Off,
-		    On,
-		};
-		
-		test "enum literals with switch" {
-		    const color = Color.Off;
-		    const result = switch (color) {
-		        .Auto => false,
-		        .On => false,
-		        .Off => true,
-		    };
-		    assert(result);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const Color = enum {
+            Auto,
+            Off,
+            On,
+        };
+        
+        test "enum literals with switch" {
+            const color = Color.Off;
+            const result = switch (color) {
+                .Auto => false,
+                .On => false,
+                .Off => true,
+            };
+            assert(result);
+        }
       {#code_end#}
       {#header_close#}
       {#header_close#}
@@ -3494,70 +3494,70 @@ orelse catch
       some condition is no longer true.
       </p>
       {#code_begin|test|while#}
-		const assert = @import("std").debug.assert;
-		
-		test "while basic" {
-		    var i: usize = 0;
-		    while (i < 10) {
-		        i += 1;
-		    }
-		    assert(i == 10);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "while basic" {
+            var i: usize = 0;
+            while (i < 10) {
+                i += 1;
+            }
+            assert(i == 10);
+        }
       {#code_end#}
       <p>
       Use {#syntax#}break{#endsyntax#} to exit a while loop early.
       </p>
       {#code_begin|test|while#}
-		const assert = @import("std").debug.assert;
-		
-		test "while break" {
-		    var i: usize = 0;
-		    while (true) {
-		        if (i == 10)
-		            break;
-		        i += 1;
-		    }
-		    assert(i == 10);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "while break" {
+            var i: usize = 0;
+            while (true) {
+                if (i == 10)
+                    break;
+                i += 1;
+            }
+            assert(i == 10);
+        }
       {#code_end#}
       <p>
       Use {#syntax#}continue{#endsyntax#} to jump back to the beginning of the loop.
       </p>
       {#code_begin|test|while#}
-		const assert = @import("std").debug.assert;
-		
-		test "while continue" {
-		    var i: usize = 0;
-		    while (true) {
-		        i += 1;
-		        if (i < 10)
-		            continue;
-		        break;
-		    }
-		    assert(i == 10);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "while continue" {
+            var i: usize = 0;
+            while (true) {
+                i += 1;
+                if (i < 10)
+                    continue;
+                break;
+            }
+            assert(i == 10);
+        }
       {#code_end#}
       <p>
       While loops support a continue expression which is executed when the loop
       is continued. The {#syntax#}continue{#endsyntax#} keyword respects this expression.
       </p>
       {#code_begin|test|while#}
-		const assert = @import("std").debug.assert;
-		
-		test "while loop continue expression" {
-		    var i: usize = 0;
-		    while (i < 10) : (i += 1) {}
-		    assert(i == 10);
-		}
-		
-		test "while loop continue expression, more complicated" {
-		    var i: usize = 1;
-		    var j: usize = 1;
-		    while (i * j < 2000) : ({ i *= 2; j *= 3; }) {
-		        const my_ij = i * j;
-		        assert(my_ij < 2000);
-		    }
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "while loop continue expression" {
+            var i: usize = 0;
+            while (i < 10) : (i += 1) {}
+            assert(i == 10);
+        }
+        
+        test "while loop continue expression, more complicated" {
+            var i: usize = 1;
+            var j: usize = 1;
+            while (i * j < 2000) : ({ i *= 2; j *= 3; }) {
+                const my_ij = i * j;
+                assert(my_ij < 2000);
+            }
+        }
       {#code_end#}
       <p>
       While loops are expressions. The result of the expression is the
@@ -3571,21 +3571,21 @@ orelse catch
       evaluated.
       </p>
       {#code_begin|test|while#}
-		const assert = @import("std").debug.assert;
-		
-		test "while else" {
-		    assert(rangeHasNumber(0, 10, 5));
-		    assert(!rangeHasNumber(0, 10, 15));
-		}
-		
-		fn rangeHasNumber(begin: usize, end: usize, number: usize) bool {
-		    var i = begin;
-		    return while (i < end) : (i += 1) {
-		        if (i == number) {
-		            break true;
-		        }
-		    } else false;
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "while else" {
+            assert(rangeHasNumber(0, 10, 5));
+            assert(!rangeHasNumber(0, 10, 15));
+        }
+        
+        fn rangeHasNumber(begin: usize, end: usize, number: usize) bool {
+            var i = begin;
+            return while (i < end) : (i += 1) {
+                if (i == number) {
+                    break true;
+                }
+            } else false;
+        }
       {#code_end#}
 
 
@@ -3593,22 +3593,22 @@ orelse catch
       <p>When a {#syntax#}while{#endsyntax#} loop is labeled, it can be referenced from a {#syntax#}break{#endsyntax#}
               or {#syntax#}continue{#endsyntax#} from within a nested loop:</p>
       {#code_begin|test#}
-		test "nested break" {
-		    outer: while (true) {
-		        while (true) {
-		            break :outer;
-		        }
-		    }
-		}
-		
-		test "nested continue" {
-		    var i: usize = 0;
-		    outer: while (i < 10) : (i += 1) {
-		        while (true) {
-		            continue :outer;
-		        }
-		    }
-		}
+        test "nested break" {
+            outer: while (true) {
+                while (true) {
+                    break :outer;
+                }
+            }
+        }
+        
+        test "nested continue" {
+            var i: usize = 0;
+            outer: while (i < 10) : (i += 1) {
+                while (true) {
+                    continue :outer;
+                }
+            }
+        }
       {#code_end#}
       {#header_close#}
 
@@ -3628,33 +3628,33 @@ orelse catch
       be executed on the first null value encountered.
       </p>
       {#code_begin|test|while#}
-		const assert = @import("std").debug.assert;
-		
-		test "while null capture" {
-		    var sum1: u32 = 0;
-		    numbers_left = 3;
-		    while (eventuallyNullSequence()) |value| {
-		        sum1 += value;
-		    }
-		    assert(sum1 == 3);
-		
-		    var sum2: u32 = 0;
-		    numbers_left = 3;
-		    while (eventuallyNullSequence()) |value| {
-		        sum2 += value;
-		    } else {
-		        assert(sum2 == 3);
-		    }
-		}
-		
-		var numbers_left: u32 = undefined;
-		fn eventuallyNullSequence() ?u32 {
-		    return if (numbers_left == 0) null else blk: {
-		        numbers_left -= 1;
-		        break :blk numbers_left;
-		    };
-		}
-		
+        const assert = @import("std").debug.assert;
+        
+        test "while null capture" {
+            var sum1: u32 = 0;
+            numbers_left = 3;
+            while (eventuallyNullSequence()) |value| {
+                sum1 += value;
+            }
+            assert(sum1 == 3);
+        
+            var sum2: u32 = 0;
+            numbers_left = 3;
+            while (eventuallyNullSequence()) |value| {
+                sum2 += value;
+            } else {
+                assert(sum2 == 3);
+            }
+        }
+        
+        var numbers_left: u32 = undefined;
+        fn eventuallyNullSequence() ?u32 {
+            return if (numbers_left == 0) null else blk: {
+                numbers_left -= 1;
+                break :blk numbers_left;
+            };
+        }
+        
       {#code_end#}
       {#header_close#}
 
@@ -3672,26 +3672,26 @@ orelse catch
       the while condition must have an {#link|Error Union Type#}.
       </p>
       {#code_begin|test|while#}
-		const assert = @import("std").debug.assert;
-		
-		test "while error union capture" {
-		    var sum1: u32 = 0;
-		    numbers_left = 3;
-		    while (eventuallyErrorSequence()) |value| {
-		        sum1 += value;
-		    } else |err| {
-		        assert(err == error.ReachedZero);
-		    }
-		}
-		
-		var numbers_left: u32 = undefined;
-		
-		fn eventuallyErrorSequence() anyerror!u32 {
-		    return if (numbers_left == 0) error.ReachedZero else blk: {
-		        numbers_left -= 1;
-		        break :blk numbers_left;
-		    };
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "while error union capture" {
+            var sum1: u32 = 0;
+            numbers_left = 3;
+            while (eventuallyErrorSequence()) |value| {
+                sum1 += value;
+            } else |err| {
+                assert(err == error.ReachedZero);
+            }
+        }
+        
+        var numbers_left: u32 = undefined;
+        
+        fn eventuallyErrorSequence() anyerror!u32 {
+            return if (numbers_left == 0) error.ReachedZero else blk: {
+                numbers_left -= 1;
+                break :blk numbers_left;
+            };
+        }
       {#code_end#}
       {#header_close#}
 
@@ -3704,26 +3704,26 @@ orelse catch
       such as use types as first class values.
       </p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "inline while loop" {
-		    comptime var i = 0;
-		    var sum: usize = 0;
-		    inline while (i < 3) : (i += 1) {
-		        const T = switch (i) {
-		            0 => f32,
-		            1 => i8,
-		            2 => bool,
-		            else => unreachable,
-		        };
-		        sum += typeNameLength(T);
-		    }
-		    assert(sum == 9);
-		}
-		
-		fn typeNameLength(comptime T: type) usize {
-		    return @typeName(T).len;
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "inline while loop" {
+            comptime var i = 0;
+            var sum: usize = 0;
+            inline while (i < 3) : (i += 1) {
+                const T = switch (i) {
+                    0 => f32,
+                    1 => i8,
+                    2 => bool,
+                    else => unreachable,
+                };
+                sum += typeNameLength(T);
+            }
+            assert(sum == 9);
+        }
+        
+        fn typeNameLength(comptime T: type) usize {
+            return @typeName(T).len;
+        }
       {#code_end#}
       <p>
       It is recommended to use {#syntax#}inline{#endsyntax#} loops only for one of these reasons:
@@ -3741,69 +3741,69 @@ orelse catch
 
       {#header_open|for#}
       {#code_begin|test|for#}
-		const assert = @import("std").debug.assert;
-		
-		test "for basics" {
-		    const items = [_]i32 { 4, 5, 3, 4, 0 };
-		    var sum: i32 = 0;
-		
-		    // For loops iterate over slices and arrays.
-		    for (items) |value| {
-		        // Break and continue are supported.
-		        if (value == 0) {
-		            continue;
-		        }
-		        sum += value;
-		    }
-		    assert(sum == 16);
-		
-		    // To iterate over a portion of a slice, reslice.
-		    for (items[0..1]) |value| {
-		        sum += value;
-		    }
-		    assert(sum == 20);
-		
-		    // To access the index of iteration, specify a second capture value.
-		    // This is zero-indexed.
-		    var sum2: i32 = 0;
-		    for (items) |value, i| {
-		        assert(@TypeOf(i) == usize);
-		        sum2 += @intCast(i32, i);
-		    }
-		    assert(sum2 == 10);
-		}
-		
-		test "for reference" {
-		    var items = [_]i32 { 3, 4, 2 };
-		
-		    // Iterate over the slice by reference by
-		    // specifying that the capture value is a pointer.
-		    for (items) |*value| {
-		        value.* += 1;
-		    }
-		
-		    assert(items[0] == 4);
-		    assert(items[1] == 5);
-		    assert(items[2] == 3);
-		}
-		
-		test "for else" {
-		    // For allows an else attached to it, the same as a while loop.
-		    var items = [_]?i32 { 3, 4, null, 5 };
-		
-		    // For loops can also be used as expressions.
-		    // Similar to while loops, when you break from a for loop, the else branch is not evaluated.
-		    var sum: i32 = 0;
-		    const result = for (items) |value| {
-		        if (value != null) {
-		            sum += value.?;
-		        }
-		    } else blk: {
-		        assert(sum == 12);
-		        break :blk sum;
-		    };
-		    assert(result == 12);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "for basics" {
+            const items = [_]i32 { 4, 5, 3, 4, 0 };
+            var sum: i32 = 0;
+        
+            // For loops iterate over slices and arrays.
+            for (items) |value| {
+                // Break and continue are supported.
+                if (value == 0) {
+                    continue;
+                }
+                sum += value;
+            }
+            assert(sum == 16);
+        
+            // To iterate over a portion of a slice, reslice.
+            for (items[0..1]) |value| {
+                sum += value;
+            }
+            assert(sum == 20);
+        
+            // To access the index of iteration, specify a second capture value.
+            // This is zero-indexed.
+            var sum2: i32 = 0;
+            for (items) |value, i| {
+                assert(@TypeOf(i) == usize);
+                sum2 += @intCast(i32, i);
+            }
+            assert(sum2 == 10);
+        }
+        
+        test "for reference" {
+            var items = [_]i32 { 3, 4, 2 };
+        
+            // Iterate over the slice by reference by
+            // specifying that the capture value is a pointer.
+            for (items) |*value| {
+                value.* += 1;
+            }
+        
+            assert(items[0] == 4);
+            assert(items[1] == 5);
+            assert(items[2] == 3);
+        }
+        
+        test "for else" {
+            // For allows an else attached to it, the same as a while loop.
+            var items = [_]?i32 { 3, 4, null, 5 };
+        
+            // For loops can also be used as expressions.
+            // Similar to while loops, when you break from a for loop, the else branch is not evaluated.
+            var sum: i32 = 0;
+            const result = for (items) |value| {
+                if (value != null) {
+                    sum += value.?;
+                }
+            } else blk: {
+                assert(sum == 12);
+                break :blk sum;
+            };
+            assert(result == 12);
+        }
       {#code_end#}
 
 
@@ -3811,31 +3811,31 @@ orelse catch
       <p>When a {#syntax#}for{#endsyntax#} loop is labeled, it can be referenced from a {#syntax#}break{#endsyntax#}
               or {#syntax#}continue{#endsyntax#} from within a nested loop:</p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "nested break" {
-		    var count: usize = 0;
-		    outer: for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
-		        for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
-		            count += 1;
-		            break :outer;
-		        }
-		    }
-		    assert(count == 1);
-		}
-		
-		test "nested continue" {
-		    var count: usize = 0;
-		    outer: for ([_]i32{ 1, 2, 3, 4, 5, 6, 7, 8 }) |_| {
-		        for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
-		            count += 1;
-		            continue :outer;
-		        }
-		    }
-		
-		    assert(count == 8);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "nested break" {
+            var count: usize = 0;
+            outer: for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
+                for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
+                    count += 1;
+                    break :outer;
+                }
+            }
+            assert(count == 1);
+        }
+        
+        test "nested continue" {
+            var count: usize = 0;
+            outer: for ([_]i32{ 1, 2, 3, 4, 5, 6, 7, 8 }) |_| {
+                for ([_]i32{ 1, 2, 3, 4, 5 }) |_| {
+                    count += 1;
+                    continue :outer;
+                }
+            }
+        
+            assert(count == 8);
+        }
       {#code_end#}
       {#header_close#}
 
@@ -3849,26 +3849,26 @@ orelse catch
       compile-time known.
       </p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "inline for loop" {
-		    const nums = [_]i32{2, 4, 6};
-		    var sum: usize = 0;
-		    inline for (nums) |i| {
-		        const T = switch (i) {
-		            2 => f32,
-		            4 => i8,
-		            6 => bool,
-		            else => unreachable,
-		        };
-		        sum += typeNameLength(T);
-		    }
-		    assert(sum == 9);
-		}
-		
-		fn typeNameLength(comptime T: type) usize {
-		    return @typeName(T).len;
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "inline for loop" {
+            const nums = [_]i32{2, 4, 6};
+            var sum: usize = 0;
+            inline for (nums) |i| {
+                const T = switch (i) {
+                    2 => f32,
+                    4 => i8,
+                    6 => bool,
+                    else => unreachable,
+                };
+                sum += typeNameLength(T);
+            }
+            assert(sum == 9);
+        }
+        
+        fn typeNameLength(comptime T: type) usize {
+            return @typeName(T).len;
+        }
       {#code_end#}
       <p>
       It is recommended to use {#syntax#}inline{#endsyntax#} loops only for one of these reasons:
@@ -3886,116 +3886,116 @@ orelse catch
 
       {#header_open|if#}
       {#code_begin|test|if#}
-		// If expressions have three uses, corresponding to the three types:
-		// * bool
-		// * ?T
-		// * anyerror!T
-		
-		const assert = @import("std").debug.assert;
-		
-		test "if expression" {
-		    // If expressions are used instead of a ternary expression.
-		    const a: u32 = 5;
-		    const b: u32 = 4;
-		    const result = if (a != b) 47 else 3089;
-		    assert(result == 47);
-		}
-		
-		test "if boolean" {
-		    // If expressions test boolean conditions.
-		    const a: u32 = 5;
-		    const b: u32 = 4;
-		    if (a != b) {
-		        assert(true);
-		    } else if (a == 9) {
-		        unreachable;
-		    } else {
-		        unreachable;
-		    }
-		}
-		
-		test "if optional" {
-		    // If expressions test for null.
-		
-		    const a: ?u32 = 0;
-		    if (a) |value| {
-		        assert(value == 0);
-		    } else {
-		        unreachable;
-		    }
-		
-		    const b: ?u32 = null;
-		    if (b) |value| {
-		        unreachable;
-		    } else {
-		        assert(true);
-		    }
-		
-		    // The else is not required.
-		    if (a) |value| {
-		        assert(value == 0);
-		    }
-		
-		    // To test against null only, use the binary equality operator.
-		    if (b == null) {
-		        assert(true);
-		    }
-		
-		    // Access the value by reference using a pointer capture.
-		    var c: ?u32 = 3;
-		    if (c) |*value| {
-		        value.* = 2;
-		    }
-		
-		    if (c) |value| {
-		        assert(value == 2);
-		    } else {
-		        unreachable;
-		    }
-		}
-		
-		test "if error union" {
-		    // If expressions test for errors.
-		    // Note the |err| capture on the else.
-		
-		    const a: anyerror!u32 = 0;
-		    if (a) |value| {
-		        assert(value == 0);
-		    } else |err| {
-		        unreachable;
-		    }
-		
-		    const b: anyerror!u32 = error.BadValue;
-		    if (b) |value| {
-		        unreachable;
-		    } else |err| {
-		        assert(err == error.BadValue);
-		    }
-		
-		    // The else and |err| capture is strictly required.
-		    if (a) |value| {
-		        assert(value == 0);
-		    } else |_| {}
-		
-		    // To check only the error value, use an empty block expression.
-		    if (b) |_| {} else |err| {
-		        assert(err == error.BadValue);
-		    }
-		
-		    // Access the value by reference using a pointer capture.
-		    var c: anyerror!u32 = 3;
-		    if (c) |*value| {
-		        value.* = 9;
-		    } else |err| {
-		        unreachable;
-		    }
-		
-		    if (c) |value| {
-		        assert(value == 9);
-		    } else |err| {
-		        unreachable;
-		    }
-		}
+        // If expressions have three uses, corresponding to the three types:
+        // * bool
+        // * ?T
+        // * anyerror!T
+        
+        const assert = @import("std").debug.assert;
+        
+        test "if expression" {
+            // If expressions are used instead of a ternary expression.
+            const a: u32 = 5;
+            const b: u32 = 4;
+            const result = if (a != b) 47 else 3089;
+            assert(result == 47);
+        }
+        
+        test "if boolean" {
+            // If expressions test boolean conditions.
+            const a: u32 = 5;
+            const b: u32 = 4;
+            if (a != b) {
+                assert(true);
+            } else if (a == 9) {
+                unreachable;
+            } else {
+                unreachable;
+            }
+        }
+        
+        test "if optional" {
+            // If expressions test for null.
+        
+            const a: ?u32 = 0;
+            if (a) |value| {
+                assert(value == 0);
+            } else {
+                unreachable;
+            }
+        
+            const b: ?u32 = null;
+            if (b) |value| {
+                unreachable;
+            } else {
+                assert(true);
+            }
+        
+            // The else is not required.
+            if (a) |value| {
+                assert(value == 0);
+            }
+        
+            // To test against null only, use the binary equality operator.
+            if (b == null) {
+                assert(true);
+            }
+        
+            // Access the value by reference using a pointer capture.
+            var c: ?u32 = 3;
+            if (c) |*value| {
+                value.* = 2;
+            }
+        
+            if (c) |value| {
+                assert(value == 2);
+            } else {
+                unreachable;
+            }
+        }
+        
+        test "if error union" {
+            // If expressions test for errors.
+            // Note the |err| capture on the else.
+        
+            const a: anyerror!u32 = 0;
+            if (a) |value| {
+                assert(value == 0);
+            } else |err| {
+                unreachable;
+            }
+        
+            const b: anyerror!u32 = error.BadValue;
+            if (b) |value| {
+                unreachable;
+            } else |err| {
+                assert(err == error.BadValue);
+            }
+        
+            // The else and |err| capture is strictly required.
+            if (a) |value| {
+                assert(value == 0);
+            } else |_| {}
+        
+            // To check only the error value, use an empty block expression.
+            if (b) |_| {} else |err| {
+                assert(err == error.BadValue);
+            }
+        
+            // Access the value by reference using a pointer capture.
+            var c: anyerror!u32 = 3;
+            if (c) |*value| {
+                value.* = 9;
+            } else |err| {
+                unreachable;
+            }
+        
+            if (c) |value| {
+                assert(value == 9);
+            } else |err| {
+                unreachable;
+            }
+        }
       {#code_end#}
       {#see_also|Optionals|Errors#}
       {#header_close#}
@@ -4003,77 +4003,77 @@ orelse catch
 
       {#header_open|defer#}
       {#code_begin|test|defer#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		const warn = std.debug.warn;
-		
-		// defer will execute an expression at the end of the current scope.
-		fn deferExample() usize {
-		    var a: usize = 1;
-		
-		    {
-		        defer a = 2;
-		        a = 1;
-		    }
-		    assert(a == 2);
-		
-		    a = 5;
-		    return a;
-		}
-		
-		test "defer basics" {
-		    assert(deferExample() == 5);
-		}
-		
-		// If multiple defer statements are specified, they will be executed in
-		// the reverse order they were run.
-		fn deferUnwindExample() void {
-		    warn("\n", .{});
-		
-		    defer {
-		        warn("1 ", .{});
-		    }
-		    defer {
-		        warn("2 ", .{});
-		    }
-		    if (false) {
-		        // defers are not run if they are never executed.
-		        defer {
-		            warn("3 ", .{});
-		        }
-		    }
-		}
-		
-		test "defer unwinding" {
-		    deferUnwindExample();
-		}
-		
-		// The errdefer keyword is similar to defer, but will only execute if the
-		// scope returns with an error.
-		//
-		// This is especially useful in allowing a function to clean up properly
-		// on error, and replaces goto error handling tactics as seen in c.
-		fn deferErrorExample(is_error: bool) !void {
-		    warn("\nstart of function\n", .{});
-		
-		    // This will always be executed on exit
-		    defer {
-		        warn("end of function\n", .{});
-		    }
-		
-		    errdefer {
-		        warn("encountered an error!\n", .{});
-		    }
-		
-		    if (is_error) {
-		        return error.DeferError;
-		    }
-		}
-		
-		test "errdefer unwinding" {
-		    deferErrorExample(false) catch {};
-		    deferErrorExample(true) catch {};
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        const warn = std.debug.warn;
+        
+        // defer will execute an expression at the end of the current scope.
+        fn deferExample() usize {
+            var a: usize = 1;
+        
+            {
+                defer a = 2;
+                a = 1;
+            }
+            assert(a == 2);
+        
+            a = 5;
+            return a;
+        }
+        
+        test "defer basics" {
+            assert(deferExample() == 5);
+        }
+        
+        // If multiple defer statements are specified, they will be executed in
+        // the reverse order they were run.
+        fn deferUnwindExample() void {
+            warn("\n", .{});
+        
+            defer {
+                warn("1 ", .{});
+            }
+            defer {
+                warn("2 ", .{});
+            }
+            if (false) {
+                // defers are not run if they are never executed.
+                defer {
+                    warn("3 ", .{});
+                }
+            }
+        }
+        
+        test "defer unwinding" {
+            deferUnwindExample();
+        }
+        
+        // The errdefer keyword is similar to defer, but will only execute if the
+        // scope returns with an error.
+        //
+        // This is especially useful in allowing a function to clean up properly
+        // on error, and replaces goto error handling tactics as seen in c.
+        fn deferErrorExample(is_error: bool) !void {
+            warn("\nstart of function\n", .{});
+        
+            // This will always be executed on exit
+            defer {
+                warn("end of function\n", .{});
+            }
+        
+            errdefer {
+                warn("encountered an error!\n", .{});
+            }
+        
+            if (is_error) {
+                return error.DeferError;
+            }
+        }
+        
+        test "errdefer unwinding" {
+            deferErrorExample(false) catch {};
+            deferErrorExample(true) catch {};
+        }
       {#code_end#}
       {#see_also|Errors#}
       {#header_close#}
@@ -4093,44 +4093,44 @@ orelse catch
 
       {#header_open|Basics#}
       {#code_begin|test#}
-		// unreachable is used to assert that control flow will never happen upon a
-		// particular location:
-		test "basic math" {
-		    const x = 1;
-		    const y = 2;
-		    if (x + y != 3) {
-		        unreachable;
-		    }
-		}
+        // unreachable is used to assert that control flow will never happen upon a
+        // particular location:
+        test "basic math" {
+            const x = 1;
+            const y = 2;
+            if (x + y != 3) {
+                unreachable;
+            }
+        }
       {#code_end#}
       <p>In fact, this is how assert is implemented:</p>
       {#code_begin|test_err#}
-		fn assert(ok: bool) void {
-		    if (!ok) unreachable; // assertion failure
-		}
-		
-		// This test will fail because we hit unreachable.
-		test "this will fail" {
-		    assert(false);
-		}
+        fn assert(ok: bool) void {
+            if (!ok) unreachable; // assertion failure
+        }
+        
+        // This test will fail because we hit unreachable.
+        test "this will fail" {
+            assert(false);
+        }
       {#code_end#}
       {#header_close#}
 
 
       {#header_open|At Compile-Time#}
       {#code_begin|test_err|unreachable code#}
-		const assert = @import("std").debug.assert;
-		
-		test "type of unreachable" {
-		    comptime {
-		        // The type of unreachable is noreturn.
-		
-		        // However this assertion will still fail because
-		        // evaluating unreachable at compile-time is a compile error.
-		
-		        assert(@TypeOf(unreachable) == noreturn);
-		    }
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "type of unreachable" {
+            comptime {
+                // The type of unreachable is noreturn.
+        
+                // However this assertion will still fail because
+                // evaluating unreachable at compile-time is a compile error.
+        
+                assert(@TypeOf(unreachable) == noreturn);
+            }
+        }
       {#code_end#}
       {#see_also|Zig Test|Build Mode|comptime#}
       {#header_close#}
@@ -4152,100 +4152,100 @@ orelse catch
               the {#syntax#}noreturn{#endsyntax#} type is compatible with every other type. Consider:
       </p>
       {#code_begin|test#}
-		fn foo(condition: bool, b: u32) void {
-		    const a = if (condition) b else return;
-		    @panic("do something with a");
-		}
-		test "noreturn" {
-		    foo(false, 1);
-		}
+        fn foo(condition: bool, b: u32) void {
+            const a = if (condition) b else return;
+            @panic("do something with a");
+        }
+        test "noreturn" {
+            foo(false, 1);
+        }
       {#code_end#}
       <p>Another use case for {#syntax#}noreturn{#endsyntax#} is the {#syntax#}exit{#endsyntax#} function:</p>
       {#code_begin|test#}
-		      {#target_windows#}
-		pub extern "kernel32" fn ExitProcess(exit_code: c_uint) callconv(.Stdcall) noreturn;
-		
-		test "foo" {
-		    const value = bar() catch ExitProcess(1);
-		    assert(value == 1234);
-		}
-		
-		fn bar() anyerror!u32 {
-		    return 1234;
-		}
-		
-		const assert = @import("std").debug.assert;
+              {#target_windows#}
+        pub extern "kernel32" fn ExitProcess(exit_code: c_uint) callconv(.Stdcall) noreturn;
+        
+        test "foo" {
+            const value = bar() catch ExitProcess(1);
+            assert(value == 1234);
+        }
+        
+        fn bar() anyerror!u32 {
+            return 1234;
+        }
+        
+        const assert = @import("std").debug.assert;
       {#code_end#}
       {#header_close#}
 
 
       {#header_open|Functions#}
       {#code_begin|test|functions#}
-		const assert = @import("std").debug.assert;
-		
-		// Functions are declared like this
-		fn add(a: i8, b: i8) i8 {
-		    if (a == 0) {
-		        return b;
-		    }
-		
-		    return a + b;
-		}
-		
-		// The export specifier makes a function externally visible in the generated
-		// object file, and makes it use the C ABI.
-		export fn sub(a: i8, b: i8) i8 { return a - b; }
-		
-		// The extern specifier is used to declare a function that will be resolved
-		// at link time, when linking statically, or at runtime, when linking
-		// dynamically.
-		// The callconv specifier changes the calling convention of the function.
-		extern "kernel32" fn ExitProcess(exit_code: u32) callconv(.Stdcall) noreturn;
-		extern "c" fn atan2(a: f64, b: f64) f64;
-		
-		// The @setCold builtin tells the optimizer that a function is rarely called.
-		fn abort() noreturn {
-		    @setCold(true);
-		    while (true) {}
-		}
-		
-		// The naked calling convention makes a function not have any function prologue or epilogue.
-		// This can be useful when integrating with assembly.
-		fn _start() callconv(.Naked) noreturn {
-		    abort();
-		}
-		
-		// The inline specifier forces a function to be inlined at all call sites.
-		// If the function cannot be inlined, it is a compile-time error.
-		inline fn shiftLeftOne(a: u32) u32 {
-		    return a << 1;
-		}
-		
-		// The pub specifier allows the function to be visible when importing.
-		// Another file can use @import and call sub2
-		pub fn sub2(a: i8, b: i8) i8 { return a - b; }
-		
-		// Functions can be used as values and are equivalent to pointers.
-		const call2_op = fn (a: i8, b: i8) i8;
-		fn do_op(fn_call: call2_op, op1: i8, op2: i8) i8 {
-		    return fn_call(op1, op2);
-		}
-		
-		test "function" {
-		    assert(do_op(add, 5, 6) == 11);
-		    assert(do_op(sub2, 5, 6) == -1);
-		}
+        const assert = @import("std").debug.assert;
+        
+        // Functions are declared like this
+        fn add(a: i8, b: i8) i8 {
+            if (a == 0) {
+                return b;
+            }
+        
+            return a + b;
+        }
+        
+        // The export specifier makes a function externally visible in the generated
+        // object file, and makes it use the C ABI.
+        export fn sub(a: i8, b: i8) i8 { return a - b; }
+        
+        // The extern specifier is used to declare a function that will be resolved
+        // at link time, when linking statically, or at runtime, when linking
+        // dynamically.
+        // The callconv specifier changes the calling convention of the function.
+        extern "kernel32" fn ExitProcess(exit_code: u32) callconv(.Stdcall) noreturn;
+        extern "c" fn atan2(a: f64, b: f64) f64;
+        
+        // The @setCold builtin tells the optimizer that a function is rarely called.
+        fn abort() noreturn {
+            @setCold(true);
+            while (true) {}
+        }
+        
+        // The naked calling convention makes a function not have any function prologue or epilogue.
+        // This can be useful when integrating with assembly.
+        fn _start() callconv(.Naked) noreturn {
+            abort();
+        }
+        
+        // The inline specifier forces a function to be inlined at all call sites.
+        // If the function cannot be inlined, it is a compile-time error.
+        inline fn shiftLeftOne(a: u32) u32 {
+            return a << 1;
+        }
+        
+        // The pub specifier allows the function to be visible when importing.
+        // Another file can use @import and call sub2
+        pub fn sub2(a: i8, b: i8) i8 { return a - b; }
+        
+        // Functions can be used as values and are equivalent to pointers.
+        const call2_op = fn (a: i8, b: i8) i8;
+        fn do_op(fn_call: call2_op, op1: i8, op2: i8) i8 {
+            return fn_call(op1, op2);
+        }
+        
+        test "function" {
+            assert(do_op(add, 5, 6) == 11);
+            assert(do_op(sub2, 5, 6) == -1);
+        }
       {#code_end#}
       <p>Function values are like pointers:</p>
       {#code_begin|obj#}
-		const assert = @import("std").debug.assert;
-		
-		comptime {
-		    assert(@TypeOf(foo) == fn()void);
-		    assert(@sizeOf(fn()void) == @sizeOf(?fn()void));
-		}
-		
-		fn foo() void { }
+        const assert = @import("std").debug.assert;
+        
+        comptime {
+            assert(@TypeOf(foo) == fn()void);
+            assert(@sizeOf(fn()void) == @sizeOf(?fn()void));
+        }
+        
+        fn foo() void { }
       {#code_end#}
 
 
@@ -4263,24 +4263,24 @@ orelse catch
       Zig decides will be faster. This is made possible, in part, by the fact that parameters are immutable.
       </p>
       {#code_begin|test#}
-		const Point = struct {
-		    x: i32,
-		    y: i32,
-		};
-		
-		fn foo(point: Point) i32 {
-		    // Here, `point` could be a reference, or a copy. The function body
-		    // can ignore the difference and treat it as a value. Be very careful
-		    // taking the address of the parameter - it should be treated as if
-		    // the address will become invalid when the function returns.
-		    return point.x + point.y;
-		}
-		
-		const assert = @import("std").debug.assert;
-		
-		test "pass struct to function" {
-		    assert(foo(Point{ .x = 1, .y = 2 }) == 3);
-		}
+        const Point = struct {
+            x: i32,
+            y: i32,
+        };
+        
+        fn foo(point: Point) i32 {
+            // Here, `point` could be a reference, or a copy. The function body
+            // can ignore the difference and treat it as a value. Be very careful
+            // taking the address of the parameter - it should be treated as if
+            // the address will become invalid when the function returns.
+            return point.x + point.y;
+        }
+        
+        const assert = @import("std").debug.assert;
+        
+        test "pass struct to function" {
+            assert(foo(Point{ .x = 1, .y = 2 }) == 3);
+        }
       {#code_end#}
       <p>
       For extern functions, Zig follows the C ABI for passing structs and unions by value.
@@ -4295,19 +4295,19 @@ orelse catch
       Use {#link|@TypeOf#} and {#link|@typeInfo#} to get information about the inferred type.
       </p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		fn addFortyTwo(x: var) @TypeOf(x) {
-		    return x + 42;
-		}
-		
-		test "fn type inference" {
-		    assert(addFortyTwo(1) == 43);
-		    assert(@TypeOf(addFortyTwo(1)) == comptime_int);
-		    var y: i64 = 2;
-		    assert(addFortyTwo(y) == 44);
-		    assert(@TypeOf(addFortyTwo(y)) == i64);
-		}
+        const assert = @import("std").debug.assert;
+        
+        fn addFortyTwo(x: var) @TypeOf(x) {
+            return x + 42;
+        }
+        
+        test "fn type inference" {
+            assert(addFortyTwo(1) == 43);
+            assert(@TypeOf(addFortyTwo(1)) == comptime_int);
+            var y: i64 = 2;
+            assert(addFortyTwo(y) == 44);
+            assert(@TypeOf(addFortyTwo(y)) == i64);
+        }
       {#code_end#}
 
       {#header_close#}
@@ -4315,12 +4315,12 @@ orelse catch
 
       {#header_open|Function Reflection#}
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "fn reflection" {
-		    assert(@TypeOf(assert).ReturnType == void);
-		    assert(@TypeOf(assert).is_var_args == false);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "fn reflection" {
+            assert(@TypeOf(assert).ReturnType == void);
+            assert(@TypeOf(assert).is_var_args == false);
+        }
       {#code_end#}
       {#header_close#}
       {#header_close#}
@@ -4344,58 +4344,58 @@ orelse catch
       You can {#link|coerce|Type Coercion#} an error from a subset to a superset:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		
-		const FileOpenError = error {
-		    AccessDenied,
-		    OutOfMemory,
-		    FileNotFound,
-		};
-		
-		const AllocationError = error {
-		    OutOfMemory,
-		};
-		
-		test "coerce subset to superset" {
-		    const err = foo(AllocationError.OutOfMemory);
-		    std.debug.assert(err == FileOpenError.OutOfMemory);
-		}
-		
-		fn foo(err: AllocationError) FileOpenError {
-		    return err;
-		}
+        const std = @import("std");
+        
+        const FileOpenError = error {
+            AccessDenied,
+            OutOfMemory,
+            FileNotFound,
+        };
+        
+        const AllocationError = error {
+            OutOfMemory,
+        };
+        
+        test "coerce subset to superset" {
+            const err = foo(AllocationError.OutOfMemory);
+            std.debug.assert(err == FileOpenError.OutOfMemory);
+        }
+        
+        fn foo(err: AllocationError) FileOpenError {
+            return err;
+        }
       {#code_end#}
       <p>
       But you cannot {#link|coerce|Type Coercion#} an error from a superset to a subset:
       </p>
       {#code_begin|test_err|not a member of destination error set#}
-		const FileOpenError = error {
-		    AccessDenied,
-		    OutOfMemory,
-		    FileNotFound,
-		};
-		
-		const AllocationError = error {
-		    OutOfMemory,
-		};
-		
-		test "coerce superset to subset" {
-		    foo(FileOpenError.OutOfMemory) catch {};
-		}
-		
-		fn foo(err: FileOpenError) AllocationError {
-		    return err;
-		}
+        const FileOpenError = error {
+            AccessDenied,
+            OutOfMemory,
+            FileNotFound,
+        };
+        
+        const AllocationError = error {
+            OutOfMemory,
+        };
+        
+        test "coerce superset to subset" {
+            foo(FileOpenError.OutOfMemory) catch {};
+        }
+        
+        fn foo(err: FileOpenError) AllocationError {
+            return err;
+        }
       {#code_end#}
       <p>
       There is a shortcut for declaring an error set with only 1 value, and then getting that value:
       </p>
       {#code_begin|syntax#}
-		const err = error.FileNotFound;
+        const err = error.FileNotFound;
       {#code_end#}
       <p>This is equivalent to:</p>
       {#code_begin|syntax#}
-		const err = (error {FileNotFound}).FileNotFound;
+        const err = (error {FileNotFound}).FileNotFound;
       {#code_end#}
       <p>
       This becomes useful when using {#link|Inferred Error Sets#}.
@@ -4432,46 +4432,46 @@ orelse catch
       Here is a function to parse a string into a 64-bit integer:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const maxInt = std.math.maxInt;
-		
-		pub fn parseU64(buf: []const u8, radix: u8) !u64 {
-		    var x: u64 = 0;
-		
-		    for (buf) |c| {
-		        const digit = charToDigit(c);
-		
-		        if (digit >= radix) {
-		            return error.InvalidChar;
-		        }
-		
-		        // x *= radix
-		        if (@mulWithOverflow(u64, x, radix, &x)) {
-		            return error.Overflow;
-		        }
-		
-		        // x += digit
-		        if (@addWithOverflow(u64, x, digit, &x)) {
-		            return error.Overflow;
-		        }
-		    }
-		
-		    return x;
-		}
-		
-		fn charToDigit(c: u8) u8 {
-		    return switch (c) {
-		        '0' ... '9' => c - '0',
-		        'A' ... 'Z' => c - 'A' + 10,
-		        'a' ... 'z' => c - 'a' + 10,
-		        else => maxInt(u8),
-		    };
-		}
-		
-		test "parse u64" {
-		    const result = try parseU64("1234", 10);
-		    std.debug.assert(result == 1234);
-		}
+        const std = @import("std");
+        const maxInt = std.math.maxInt;
+        
+        pub fn parseU64(buf: []const u8, radix: u8) !u64 {
+            var x: u64 = 0;
+        
+            for (buf) |c| {
+                const digit = charToDigit(c);
+        
+                if (digit >= radix) {
+                    return error.InvalidChar;
+                }
+        
+                // x *= radix
+                if (@mulWithOverflow(u64, x, radix, &x)) {
+                    return error.Overflow;
+                }
+        
+                // x += digit
+                if (@addWithOverflow(u64, x, digit, &x)) {
+                    return error.Overflow;
+                }
+            }
+        
+            return x;
+        }
+        
+        fn charToDigit(c: u8) u8 {
+            return switch (c) {
+                '0' ... '9' => c - '0',
+                'A' ... 'Z' => c - 'A' + 10,
+                'a' ... 'z' => c - 'a' + 10,
+                else => maxInt(u8),
+            };
+        }
+        
+        test "parse u64" {
+            const result = try parseU64("1234", 10);
+            std.debug.assert(result == 1234);
+        }
       {#code_end#}
       <p>
       Notice the return type is {#syntax#}!u64{#endsyntax#}. This means that the function
@@ -4498,10 +4498,10 @@ orelse catch
       {#header_open|catch#}
       <p>If you want to provide a default value, you can use the {#syntax#}catch{#endsyntax#} binary operator:</p>
       {#code_begin|syntax#}
-		fn doAThing(str: []u8) void {
-		    const number = parseU64(str, 10) catch 13;
-		    // ...
-		}
+        fn doAThing(str: []u8) void {
+            const number = parseU64(str, 10) catch 13;
+            // ...
+        }
       {#code_end#}
       <p>
       In this code, {#syntax#}number{#endsyntax#} will be equal to the successfully parsed string, or
@@ -4515,19 +4515,19 @@ orelse catch
       <p>Let's say you wanted to return the error if you got one, otherwise continue with the
       function logic:</p>
       {#code_begin|syntax#}
-		fn doAThing(str: []u8) !void {
-		    const number = parseU64(str, 10) catch |err| return err;
-		    // ...
-		}
+        fn doAThing(str: []u8) !void {
+            const number = parseU64(str, 10) catch |err| return err;
+            // ...
+        }
       {#code_end#}
       <p>
       There is a shortcut for this. The {#syntax#}try{#endsyntax#} expression:
       </p>
       {#code_begin|syntax#}
-		fn doAThing(str: []u8) !void {
-		    const number = try parseU64(str, 10);
-		    // ...
-		}
+        fn doAThing(str: []u8) !void {
+            const number = try parseU64(str, 10);
+            // ...
+        }
       {#code_end#}
       <p>
       {#syntax#}try{#endsyntax#} evaluates an error union expression. If it is an error, it returns
@@ -4540,29 +4540,29 @@ orelse catch
         In this case you can do this:
       </p>
       {#code_begin|syntax#}const number = parseU64("1234", 10) catch unreachable;{#code_end#}
-		      <p>
-		      Here we know for sure that "1234" will parse successfully. So we put the
-		      {#syntax#}unreachable{#endsyntax#} value on the right hand side. {#syntax#}unreachable{#endsyntax#} generates
-		      a panic in Debug and ReleaseSafe modes and undefined behavior in ReleaseFast mode. So, while we're debugging the
-		      application, if there <em>was</em> a surprise error here, the application would crash
-		      appropriately.
-		      </p>
-		      <p>
-		      Finally, you may want to take a different action for every situation. For that, we combine
-		      the {#link|if#} and {#link|switch#} expression:
-		      </p>
-		      {#code_begin|syntax#}
-		fn doAThing(str: []u8) void {
-		    if (parseU64(str, 10)) |number| {
-		        doSomethingWithNumber(number);
-		    } else |err| switch (err) {
-		        error.Overflow => {
-		            // handle overflow...
-		        },
-		        // we promise that InvalidChar won't happen (or crash in debug mode if it does)
-		        error.InvalidChar => unreachable,
-		    }
-		}
+              <p>
+              Here we know for sure that "1234" will parse successfully. So we put the
+              {#syntax#}unreachable{#endsyntax#} value on the right hand side. {#syntax#}unreachable{#endsyntax#} generates
+              a panic in Debug and ReleaseSafe modes and undefined behavior in ReleaseFast mode. So, while we're debugging the
+              application, if there <em>was</em> a surprise error here, the application would crash
+              appropriately.
+              </p>
+              <p>
+              Finally, you may want to take a different action for every situation. For that, we combine
+              the {#link|if#} and {#link|switch#} expression:
+              </p>
+              {#code_begin|syntax#}
+        fn doAThing(str: []u8) void {
+            if (parseU64(str, 10)) |number| {
+                doSomethingWithNumber(number);
+            } else |err| switch (err) {
+                error.Overflow => {
+                    // handle overflow...
+                },
+                // we promise that InvalidChar won't happen (or crash in debug mode if it does)
+                error.InvalidChar => unreachable,
+            }
+        }
       {#code_end#}
 
 
@@ -4577,23 +4577,23 @@ orelse catch
       Example:
       </p>
       {#code_begin|syntax#}
-		fn createFoo(param: i32) !Foo {
-		    const foo = try tryToAllocateFoo();
-		    // now we have allocated foo. we need to free it if the function fails.
-		    // but we want to return it if the function succeeds.
-		    errdefer deallocateFoo(foo);
-		
-		    const tmp_buf = allocateTmpBuffer() orelse return error.OutOfMemory;
-		    // tmp_buf is truly a temporary resource, and we for sure want to clean it up
-		    // before this block leaves scope
-		    defer deallocateTmpBuffer(tmp_buf);
-		
-		    if (param > 1337) return error.InvalidParam;
-		
-		    // here the errdefer will not run since we're returning success from the function.
-		    // but the defer will run!
-		    return foo;
-		}
+        fn createFoo(param: i32) !Foo {
+            const foo = try tryToAllocateFoo();
+            // now we have allocated foo. we need to free it if the function fails.
+            // but we want to return it if the function succeeds.
+            errdefer deallocateFoo(foo);
+        
+            const tmp_buf = allocateTmpBuffer() orelse return error.OutOfMemory;
+            // tmp_buf is truly a temporary resource, and we for sure want to clean it up
+            // before this block leaves scope
+            defer deallocateTmpBuffer(tmp_buf);
+        
+            if (param > 1337) return error.InvalidParam;
+        
+            // here the errdefer will not run since we're returning success from the function.
+            // but the defer will run!
+            return foo;
+        }
       {#code_end#}
       <p>
       The neat thing about this is that you get robust error handling without
@@ -4621,23 +4621,23 @@ orelse catch
       <p>An error union is created with the {#syntax#}!{#endsyntax#} binary operator.
       You can use compile-time reflection to access the child type of an error union:</p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "error union" {
-		    var foo: anyerror!i32 = undefined;
-		
-		    // Coerce from child type of an error union:
-		    foo = 1234;
-		
-		    // Coerce from an error set:
-		    foo = error.SomeError;
-		
-		    // Use compile-time reflection to access the payload type of an error union:
-		    comptime assert(@TypeOf(foo).Payload == i32);
-		
-		    // Use compile-time reflection to access the error set type of an error union:
-		    comptime assert(@TypeOf(foo).ErrorSet == anyerror);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "error union" {
+            var foo: anyerror!i32 = undefined;
+        
+            // Coerce from child type of an error union:
+            foo = 1234;
+        
+            // Coerce from an error set:
+            foo = error.SomeError;
+        
+            // Use compile-time reflection to access the payload type of an error union:
+            comptime assert(@TypeOf(foo).Payload == i32);
+        
+            // Use compile-time reflection to access the error set type of an error union:
+            comptime assert(@TypeOf(foo).ErrorSet == anyerror);
+        }
       {#code_end#}
 
 
@@ -4655,34 +4655,34 @@ orelse catch
       files.
       </p>
       {#code_begin|test#}
-		const A = error{
-		    NotDir,
-		
-		    /// A doc comment
-		    PathNotFound,
-		};
-		const B = error{
-		    OutOfMemory,
-		
-		    /// B doc comment
-		    PathNotFound,
-		};
-		
-		const C = A || B;
-		
-		fn foo() C!void {
-		    return error.NotDir;
-		}
-		
-		test "merge error sets" {
-		    if (foo()) {
-		        @panic("unexpected");
-		    } else |err| switch (err) {
-		        error.OutOfMemory => @panic("unexpected"),
-		        error.PathNotFound => @panic("unexpected"),
-		        error.NotDir => {},
-		    }
-		}
+        const A = error{
+            NotDir,
+        
+            /// A doc comment
+            PathNotFound,
+        };
+        const B = error{
+            OutOfMemory,
+        
+            /// B doc comment
+            PathNotFound,
+        };
+        
+        const C = A || B;
+        
+        fn foo() C!void {
+            return error.NotDir;
+        }
+        
+        test "merge error sets" {
+            if (foo()) {
+                @panic("unexpected");
+            } else |err| switch (err) {
+                error.OutOfMemory => @panic("unexpected"),
+                error.PathNotFound => @panic("unexpected"),
+                error.NotDir => {},
+            }
+        }
       {#code_end#}
       {#header_close#}
 
@@ -4693,29 +4693,29 @@ orelse catch
       To infer the error set for a function, use this syntax:
       </p>
 {#code_begin|test#}
-		// With an inferred error set
-		pub fn add_inferred(comptime T: type, a: T, b: T) !T {
-		    var answer: T = undefined;
-		    return if (@addWithOverflow(T, a, b, &answer)) error.Overflow else answer;
-		}
-		
-		// With an explicit error set
-		pub fn add_explicit(comptime T: type, a: T, b: T) Error!T {
-		    var answer: T = undefined;
-		    return if (@addWithOverflow(T, a, b, &answer)) error.Overflow else answer;
-		}
-		
-		const Error = error {
-		    Overflow,
-		};
-		
-		const std = @import("std");
-		
-		test "inferred error set" {
-		    if (add_inferred(u8, 255, 1)) |_| unreachable else |err| switch (err) {
-		        error.Overflow => {}, // ok
-		    }
-		}
+        // With an inferred error set
+        pub fn add_inferred(comptime T: type, a: T, b: T) !T {
+            var answer: T = undefined;
+            return if (@addWithOverflow(T, a, b, &answer)) error.Overflow else answer;
+        }
+        
+        // With an explicit error set
+        pub fn add_explicit(comptime T: type, a: T, b: T) Error!T {
+            var answer: T = undefined;
+            return if (@addWithOverflow(T, a, b, &answer)) error.Overflow else answer;
+        }
+        
+        const Error = error {
+            Overflow,
+        };
+        
+        const std = @import("std");
+        
+        test "inferred error set" {
+            if (add_inferred(u8, 255, 1)) |_| unreachable else |err| switch (err) {
+                error.Overflow => {}, // ok
+            }
+        }
 {#code_end#}
       <p>
       When a function has an inferred error set, that function becomes generic and thus it becomes
@@ -4739,50 +4739,50 @@ orelse catch
       Error Return Traces show all the points in the code that an error was returned to the calling function. This makes it practical to use {#link|try#} everywhere and then still be able to know what happened if an error ends up bubbling all the way out of your application.
       </p>
       {#code_begin|exe_err#}
-		pub fn main() !void {
-		    try foo(12);
-		}
-		
-		fn foo(x: i32) !void {
-		    if (x >= 5) {
-		        try bar();
-		    } else {
-		        try bang2();
-		    }
-		}
-		
-		fn bar() !void {
-		    if (baz()) {
-		        try quux();
-		    } else |err| switch (err) {
-		        error.FileNotFound => try hello(),
-		        else => try another(),
-		    }
-		}
-		
-		fn baz() !void {
-		    try bang1();
-		}
-		
-		fn quux() !void {
-		    try bang2();
-		}
-		
-		fn hello() !void {
-		    try bang2();
-		}
-		
-		fn another() !void {
-		    try bang1();
-		}
-		
-		fn bang1() !void {
-		    return error.FileNotFound;
-		}
-		
-		fn bang2() !void {
-		    return error.PermissionDenied;
-		}
+        pub fn main() !void {
+            try foo(12);
+        }
+        
+        fn foo(x: i32) !void {
+            if (x >= 5) {
+                try bar();
+            } else {
+                try bang2();
+            }
+        }
+        
+        fn bar() !void {
+            if (baz()) {
+                try quux();
+            } else |err| switch (err) {
+                error.FileNotFound => try hello(),
+                else => try another(),
+            }
+        }
+        
+        fn baz() !void {
+            try bang1();
+        }
+        
+        fn quux() !void {
+            try bang2();
+        }
+        
+        fn hello() !void {
+            try bang2();
+        }
+        
+        fn another() !void {
+            try bang1();
+        }
+        
+        fn bang1() !void {
+            return error.FileNotFound;
+        }
+        
+        fn bang2() !void {
+            return error.PermissionDenied;
+        }
       {#code_end#}
       <p>
       Look closely at this example. This is no stack trace.
@@ -4793,45 +4793,45 @@ orelse catch
       and then returns another one, from the switch statement. Error Return Traces make this clear, whereas a stack trace would look like this:
       </p>
       {#code_begin|exe_err#}
-		pub fn main() void {
-		    foo(12);
-		}
-		
-		fn foo(x: i32) void {
-		    if (x >= 5) {
-		        bar();
-		    } else {
-		        bang2();
-		    }
-		}
-		
-		fn bar() void {
-		    if (baz()) {
-		        quux();
-		    } else {
-		        hello();
-		    }
-		}
-		
-		fn baz() bool {
-		    return bang1();
-		}
-		
-		fn quux() void {
-		    bang2();
-		}
-		
-		fn hello() void {
-		    bang2();
-		}
-		
-		fn bang1() bool {
-		    return false;
-		}
-		
-		fn bang2() void {
-		    @panic("PermissionDenied");
-		}
+        pub fn main() void {
+            foo(12);
+        }
+        
+        fn foo(x: i32) void {
+            if (x >= 5) {
+                bar();
+            } else {
+                bang2();
+            }
+        }
+        
+        fn bar() void {
+            if (baz()) {
+                quux();
+            } else {
+                hello();
+            }
+        }
+        
+        fn baz() bool {
+            return bang1();
+        }
+        
+        fn quux() void {
+            bang2();
+        }
+        
+        fn hello() void {
+            bang2();
+        }
+        
+        fn bang1() bool {
+            return false;
+        }
+        
+        fn bang2() void {
+            @panic("PermissionDenied");
+        }
       {#code_end#}
       <p>
       Here, the stack trace does not explain how the control
@@ -4872,10 +4872,10 @@ orelse catch
       This is to initialize this struct in the stack memory:
       </p>
       {#code_begin|syntax#}
-		pub const StackTrace = struct {
-		    index: usize,
-		    instruction_addresses: [N]usize,
-		};
+        pub const StackTrace = struct {
+            index: usize,
+            instruction_addresses: [N]usize,
+        };
       {#code_end#}
       <p>
       Here, N is the maximum function call depth as determined by call graph analysis. Recursion is ignored and counts for 2.
@@ -4890,11 +4890,11 @@ orelse catch
       When generating the code for a function that returns an error, just before the {#syntax#}return{#endsyntax#} statement (only for the {#syntax#}return{#endsyntax#} statements that return errors), Zig generates a call to this function:
       </p>
       {#code_begin|syntax#}
-		// marked as "no-inline" in LLVM IR
-		fn __zig_return_error(stack_trace: *StackTrace) void {
-		    stack_trace.instruction_addresses[stack_trace.index] = @returnAddress();
-		    stack_trace.index = (stack_trace.index + 1) % N;
-		}
+        // marked as "no-inline" in LLVM IR
+        fn __zig_return_error(stack_trace: *StackTrace) void {
+            stack_trace.instruction_addresses[stack_trace.index] = @returnAddress();
+            stack_trace.index = (stack_trace.index + 1) % N;
+        }
       {#code_end#}
       <p>
       The cost is 2 math operations plus some memory reads and writes. The memory accessed is constrained and should remain cached for the duration of the error return bubbling.
@@ -4919,11 +4919,11 @@ orelse catch
       type by putting a question mark in front of it, like this:
       </p>
       {#code_begin|syntax#}
-		// normal integer
-		const normal_int: i32 = 1234;
-		
-		// optional integer
-		const optional_int: ?i32 = 5678;
+        // normal integer
+        const normal_int: i32 = 1234;
+        
+        // optional integer
+        const optional_int: ?i32 = 5678;
       {#code_end#}
       <p>
       Now the variable {#syntax#}optional_int{#endsyntax#} could be an {#syntax#}i32{#endsyntax#}, or {#syntax#}null{#endsyntax#}.
@@ -4957,13 +4957,13 @@ struct Foo *do_a_thing(void) {
 }</code></pre>
       <p>Zig code</p>
       {#code_begin|syntax#}
-		// malloc prototype included for reference
-		extern fn malloc(size: size_t) ?*u8;
-		
-		fn doAThing() ?*Foo {
-		    const ptr = malloc(1234) orelse return null;
-		    // ...
-		}
+        // malloc prototype included for reference
+        extern fn malloc(size: size_t) ?*u8;
+        
+        fn doAThing() ?*Foo {
+            const ptr = malloc(1234) orelse return null;
+            // ...
+        }
       {#code_end#}
       <p>
         Here, Zig is at least as convenient, if not more, than C. And, the type of "ptr"
@@ -4987,15 +4987,15 @@ struct Foo *do_a_thing(void) {
         In Zig you can accomplish the same thing:
       </p>
       {#code_begin|syntax#}
-		fn doAThing(optional_foo: ?*Foo) void {
-		    // do some stuff
-		
-		    if (optional_foo) |foo| {
-		      doSomethingWithFoo(foo);
-		    }
-		
-		    // do some stuff
-		}
+        fn doAThing(optional_foo: ?*Foo) void {
+            // do some stuff
+        
+            if (optional_foo) |foo| {
+              doSomethingWithFoo(foo);
+            }
+        
+            // do some stuff
+        }
       {#code_end#}
       <p>
       Once again, the notable thing here is that inside the if block,
@@ -5015,18 +5015,18 @@ struct Foo *do_a_thing(void) {
       <p>An optional is created by putting {#syntax#}?{#endsyntax#} in front of a type. You can use compile-time
       reflection to access the child type of an optional:</p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "optional type" {
-		    // Declare an optional and coerce from null:
-		    var foo: ?i32 = null;
-		
-		    // Coerce from child type of an optional
-		    foo = 1234;
-		
-		    // Use compile-time reflection to access the child type of the optional:
-		    comptime assert(@TypeOf(foo).Child == i32);
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "optional type" {
+            // Declare an optional and coerce from null:
+            var foo: ?i32 = null;
+        
+            // Coerce from child type of an optional
+            foo = 1234;
+        
+            // Use compile-time reflection to access the child type of the optional:
+            comptime assert(@TypeOf(foo).Child == i32);
+        }
       {#code_end#}
       {#header_close#}
 
@@ -5037,7 +5037,7 @@ struct Foo *do_a_thing(void) {
       cast it to a different type:
       </p>
       {#code_begin|syntax#}
-		const optional_value: ?i32 = null;
+        const optional_value: ?i32 = null;
       {#code_end#}
       {#header_close#}
 
@@ -5046,22 +5046,22 @@ struct Foo *do_a_thing(void) {
       <p>An optional pointer is guaranteed to be the same size as a pointer. The {#syntax#}null{#endsyntax#} of
       the optional is guaranteed to be address 0.</p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		test "optional pointers" {
-		    // Pointers cannot be null. If you want a null pointer, use the optional
-		    // prefix `?` to make the pointer type optional.
-		    var ptr: ?*i32 = null;
-		
-		    var x: i32 = 1;
-		    ptr = &x;
-		
-		    assert(ptr.?.* == 1);
-		
-		    // Optional pointers are the same size as normal pointers, because pointer
-		    // value 0 is used as the null value.
-		    assert(@sizeOf(?*i32) == @sizeOf(*i32));
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "optional pointers" {
+            // Pointers cannot be null. If you want a null pointer, use the optional
+            // prefix `?` to make the pointer type optional.
+            var ptr: ?*i32 = null;
+        
+            var x: i32 = 1;
+            ptr = &x;
+        
+            assert(ptr.?.* == 1);
+        
+            // Optional pointers are the same size as normal pointers, because pointer
+            // value 0 is used as the null value.
+            assert(@sizeOf(?*i32) == @sizeOf(*i32));
+        }
       {#code_end#}
       {#header_close#}
       {#header_close#}
@@ -5082,22 +5082,22 @@ struct Foo *do_a_thing(void) {
       Type coercion occurs when one type is expected, but different type is provided:
       </p>
       {#code_begin|test#}
-		test "type coercion - variable declaration" {
-		    var a: u8 = 1;
-		    var b: u16 = a;
-		}
-		
-		test "type coercion - function call" {
-		    var a: u8 = 1;
-		    foo(a);
-		}
-		
-		fn foo(b: u16) void {}
-		
-		test "type coercion - @as builtin" {
-		    var a: u8 = 1;
-		    var b = @as(u16, a);
-		}
+        test "type coercion - variable declaration" {
+            var a: u8 = 1;
+            var b: u16 = a;
+        }
+        
+        test "type coercion - function call" {
+            var a: u8 = 1;
+            foo(a);
+        }
+        
+        fn foo(b: u16) void {}
+        
+        test "type coercion - @as builtin" {
+            var a: u8 = 1;
+            var b = @as(u16, a);
+        }
       {#code_end#}
       <p>
       Type coercions are only allowed when it is completely unambiguous how to get from one type to another,
@@ -5120,27 +5120,27 @@ struct Foo *do_a_thing(void) {
       These casts are no-ops at runtime since the value representation does not change.
       </p>
       {#code_begin|test#}
-		test "type coercion - const qualification" {
-		    var a: i32 = 1;
-		    var b: *i32 = &a;
-		    foo(b);
-		}
-		
-		fn foo(a: *const i32) void {}
+        test "type coercion - const qualification" {
+            var a: i32 = 1;
+            var b: *i32 = &a;
+            foo(b);
+        }
+        
+        fn foo(a: *const i32) void {}
       {#code_end#}
       <p>
       In addition, pointers coerce to const optional pointers:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		const mem = std.mem;
-		
-		test "cast *[1][*]const u8 to [*]const ?[*]const u8" {
-		    const window_name = [1][*]const u8{"window name"};
-		    const x: [*]const ?[*]const u8 = &window_name;
-		    assert(mem.eql(u8, std.mem.spanZ(@ptrCast([*:0]const u8, x[0].?)), "window name"));
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        const mem = std.mem;
+        
+        test "cast *[1][*]const u8 to [*]const ?[*]const u8" {
+            const window_name = [1][*]const u8{"window name"};
+            const x: [*]const ?[*]const u8 = &window_name;
+            assert(mem.eql(u8, std.mem.spanZ(@ptrCast([*:0]const u8, x[0].?)), "window name"));
+        }
       {#code_end#}
       {#header_close#}
 
@@ -5151,113 +5151,113 @@ struct Foo *do_a_thing(void) {
       {#link|Floats#} coerce to float types which can represent every value of the old type.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		const mem = std.mem;
-		
-		test "integer widening" {
-		    var a: u8 = 250;
-		    var b: u16 = a;
-		    var c: u32 = b;
-		    var d: u64 = c;
-		    var e: u64 = d;
-		    var f: u128 = e;
-		    assert(f == a);
-		}
-		
-		test "implicit unsigned integer to signed integer" {
-		    var a: u8 = 250;
-		    var b: i16 = a;
-		    assert(b == 250);
-		}
-		
-		test "float widening" {
-		    // Note: there is an open issue preventing this from working on aarch64:
-		    // https://github.com/ziglang/zig/issues/3282
-		    if (std.Target.current.cpu.arch == .aarch64) return error.SkipZigTest;
-		
-		    var a: f16 = 12.34;
-		    var b: f32 = a;
-		    var c: f64 = b;
-		    var d: f128 = c;
-		    assert(d == a);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        const mem = std.mem;
+        
+        test "integer widening" {
+            var a: u8 = 250;
+            var b: u16 = a;
+            var c: u32 = b;
+            var d: u64 = c;
+            var e: u64 = d;
+            var f: u128 = e;
+            assert(f == a);
+        }
+        
+        test "implicit unsigned integer to signed integer" {
+            var a: u8 = 250;
+            var b: i16 = a;
+            assert(b == 250);
+        }
+        
+        test "float widening" {
+            // Note: there is an open issue preventing this from working on aarch64:
+            // https://github.com/ziglang/zig/issues/3282
+            if (std.Target.current.cpu.arch == .aarch64) return error.SkipZigTest;
+        
+            var a: f16 = 12.34;
+            var b: f32 = a;
+            var c: f64 = b;
+            var d: f128 = c;
+            assert(d == a);
+        }
       {#code_end#}
       {#header_close#}
 
 
       {#header_open|Type Coercion: Arrays and Pointers#}
       {#code_begin|test|coerce_arrays_and_ptrs#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		// This cast exists primarily so that string literals can be
-		// passed to functions that accept const slices. However
-		// it is probably going to be removed from the language when
-		// https://github.com/ziglang/zig/issues/265 is implemented.
-		test "[N]T to []const T" {
-		    var x1: []const u8 = "hello";
-		    var x2: []const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
-		    assert(std.mem.eql(u8, x1, x2));
-		
-		    var y: []const f32 = &[2]f32{ 1.2, 3.4 };
-		    assert(y[0] == 1.2);
-		}
-		
-		// Likewise, it works when the destination type is an error union.
-		test "[N]T to E![]const T" {
-		    var x1: anyerror![]const u8 = "hello";
-		    var x2: anyerror![]const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
-		    assert(std.mem.eql(u8, try x1, try x2));
-		
-		    var y: anyerror![]const f32 = &[2]f32{ 1.2, 3.4 };
-		    assert((try y)[0] == 1.2);
-		}
-		
-		// Likewise, it works when the destination type is an optional.
-		test "[N]T to ?[]const T" {
-		    var x1: ?[]const u8 = "hello";
-		    var x2: ?[]const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
-		    assert(std.mem.eql(u8, x1.?, x2.?));
-		
-		    var y: ?[]const f32 = &[2]f32{ 1.2, 3.4 };
-		    assert(y.?[0] == 1.2);
-		}
-		
-		// In this cast, the array length becomes the slice length.
-		test "*[N]T to []T" {
-		    var buf: [5]u8 = "hello".*;
-		    const x: []u8 = &buf;
-		    assert(std.mem.eql(u8, x, "hello"));
-		
-		    const buf2 = [2]f32{ 1.2, 3.4 };
-		    const x2: []const f32 = &buf2;
-		    assert(std.mem.eql(f32, x2, &[2]f32{ 1.2, 3.4 }));
-		}
-		
-		// Single-item pointers to arrays can be coerced to
-		// unknown length pointers.
-		test "*[N]T to [*]T" {
-		    var buf: [5]u8 = "hello".*;
-		    const x: [*]u8 = &buf;
-		    assert(x[4] == 'o');
-		    // x[5] would be an uncaught out of bounds pointer dereference!
-		}
-		
-		// Likewise, it works when the destination type is an optional.
-		test "*[N]T to ?[*]T" {
-		    var buf: [5]u8 = "hello".*;
-		    const x: ?[*]u8 = &buf;
-		    assert(x.?[4] == 'o');
-		}
-		
-		// Single-item pointers can be cast to len-1 single-item arrays.
-		test "*T to *[1]T" {
-		    var x: i32 = 1234;
-		    const y: *[1]i32 = &x;
-		    const z: [*]i32 = y;
-		    assert(z[0] == 1234);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        // This cast exists primarily so that string literals can be
+        // passed to functions that accept const slices. However
+        // it is probably going to be removed from the language when
+        // https://github.com/ziglang/zig/issues/265 is implemented.
+        test "[N]T to []const T" {
+            var x1: []const u8 = "hello";
+            var x2: []const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
+            assert(std.mem.eql(u8, x1, x2));
+        
+            var y: []const f32 = &[2]f32{ 1.2, 3.4 };
+            assert(y[0] == 1.2);
+        }
+        
+        // Likewise, it works when the destination type is an error union.
+        test "[N]T to E![]const T" {
+            var x1: anyerror![]const u8 = "hello";
+            var x2: anyerror![]const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
+            assert(std.mem.eql(u8, try x1, try x2));
+        
+            var y: anyerror![]const f32 = &[2]f32{ 1.2, 3.4 };
+            assert((try y)[0] == 1.2);
+        }
+        
+        // Likewise, it works when the destination type is an optional.
+        test "[N]T to ?[]const T" {
+            var x1: ?[]const u8 = "hello";
+            var x2: ?[]const u8 = &[5]u8{ 'h', 'e', 'l', 'l', 111 };
+            assert(std.mem.eql(u8, x1.?, x2.?));
+        
+            var y: ?[]const f32 = &[2]f32{ 1.2, 3.4 };
+            assert(y.?[0] == 1.2);
+        }
+        
+        // In this cast, the array length becomes the slice length.
+        test "*[N]T to []T" {
+            var buf: [5]u8 = "hello".*;
+            const x: []u8 = &buf;
+            assert(std.mem.eql(u8, x, "hello"));
+        
+            const buf2 = [2]f32{ 1.2, 3.4 };
+            const x2: []const f32 = &buf2;
+            assert(std.mem.eql(f32, x2, &[2]f32{ 1.2, 3.4 }));
+        }
+        
+        // Single-item pointers to arrays can be coerced to
+        // unknown length pointers.
+        test "*[N]T to [*]T" {
+            var buf: [5]u8 = "hello".*;
+            const x: [*]u8 = &buf;
+            assert(x[4] == 'o');
+            // x[5] would be an uncaught out of bounds pointer dereference!
+        }
+        
+        // Likewise, it works when the destination type is an optional.
+        test "*[N]T to ?[*]T" {
+            var buf: [5]u8 = "hello".*;
+            const x: ?[*]u8 = &buf;
+            assert(x.?[4] == 'o');
+        }
+        
+        // Single-item pointers can be cast to len-1 single-item arrays.
+        test "*T to *[1]T" {
+            var x: i32 = 1234;
+            const y: *[1]i32 = &x;
+            const z: [*]i32 = y;
+            assert(z[0] == 1234);
+        }
       {#code_end#}
       {#see_also|C Pointers#}
       {#header_close#}
@@ -5268,29 +5268,29 @@ struct Foo *do_a_thing(void) {
       The payload type of {#link|Optionals#}, as well as {#link|null#}, coerce to the optional type.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "coerce to optionals" {
-		    const x: ?i32 = 1234;
-		    const y: ?i32 = null;
-		
-		    assert(x.? == 1234);
-		    assert(y == null);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "coerce to optionals" {
+            const x: ?i32 = 1234;
+            const y: ?i32 = null;
+        
+            assert(x.? == 1234);
+            assert(y == null);
+        }
       {#code_end#}
       <p>It works nested inside the {#link|Error Union Type#}, too:</p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "coerce to optionals wrapped in error union" {
-		    const x: anyerror!?i32 = 1234;
-		    const y: anyerror!?i32 = null;
-		
-		    assert((try x).? == 1234);
-		    assert((try y) == null);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "coerce to optionals wrapped in error union" {
+            const x: anyerror!?i32 = 1234;
+            const y: anyerror!?i32 = null;
+        
+            assert((try x).? == 1234);
+            assert((try y) == null);
+        }
       {#code_end#}
       {#header_close#}
 
@@ -5300,16 +5300,16 @@ struct Foo *do_a_thing(void) {
       coerce to the error union type:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "coercion to error unions" {
-		    const x: anyerror!i32 = 1234;
-		    const y: anyerror!i32 = error.Failure;
-		
-		    assert((try x) == 1234);
-		    std.testing.expectError(error.Failure, y);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "coercion to error unions" {
+            const x: anyerror!i32 = 1234;
+            const y: anyerror!i32 = error.Failure;
+        
+            assert((try x) == 1234);
+            std.testing.expectError(error.Failure, y);
+        }
       {#code_end#}
       {#header_close#}
 
@@ -5319,14 +5319,14 @@ struct Foo *do_a_thing(void) {
       it may be coerced:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "coercing large integer type to smaller one when value is comptime known to fit" {
-		    const x: u64 = 255;
-		    const y: u8 = x;
-		    assert(y == 255);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "coercing large integer type to smaller one when value is comptime known to fit" {
+            const x: u64 = 255;
+            const y: u8 = x;
+            assert(y == 255);
+        }
       {#code_end#}
       {#header_close#}
 
@@ -5337,30 +5337,30 @@ struct Foo *do_a_thing(void) {
       {#link|void#}:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const E = enum {
-		    One,
-		    Two,
-		    Three,
-		};
-		
-		const U = union(E) {
-		    One: i32,
-		    Two: f32,
-		    Three,
-		};
-		
-		test "coercion between unions and enums" {
-		    var u = U{ .Two = 12.34 };
-		    var e: E = u;
-		    assert(e == E.Two);
-		
-		    const three = E.Three;
-		    var another_u: U = three;
-		    assert(another_u == E.Three);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const E = enum {
+            One,
+            Two,
+            Three,
+        };
+        
+        const U = union(E) {
+            One: i32,
+            Two: f32,
+            Three,
+        };
+        
+        test "coercion between unions and enums" {
+            var u = U{ .Two = 12.34 };
+            var e: E = u;
+            assert(e == E.Two);
+        
+            const three = E.Three;
+            var another_u: U = three;
+            assert(another_u == E.Three);
+        }
       {#code_end#}
       {#see_also|union|enum#}
       {#header_close#}
@@ -5372,11 +5372,11 @@ struct Foo *do_a_thing(void) {
       <p>TODO document the reasoning for this</p>
       <p>TODO document whether vice versa should work and why</p>
       {#code_begin|test#}
-		test "coercion of zero bit types" {
-		    var x: void = {};
-		    var y: *void = x;
-		    //var z: void = y; // TODO
-		}
+        test "coercion of zero bit types" {
+            var x: void = {};
+            var y: *void = x;
+            //var z: void = y; // TODO
+        }
       {#code_end#}
       {#header_close#}
 
@@ -5432,98 +5432,98 @@ struct Foo *do_a_thing(void) {
       some examples:
       </p>
       {#code_begin|test|peer_type_resolution#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		const mem = std.mem;
-		
-		test "peer resolve int widening" {
-		    var a: i8 = 12;
-		    var b: i16 = 34;
-		    var c = a + b;
-		    assert(c == 46);
-		    assert(@TypeOf(c) == i16);
-		}
-		
-		test "peer resolve arrays of different size to const slice" {
-		    assert(mem.eql(u8, boolToStr(true), "true"));
-		    assert(mem.eql(u8, boolToStr(false), "false"));
-		    comptime assert(mem.eql(u8, boolToStr(true), "true"));
-		    comptime assert(mem.eql(u8, boolToStr(false), "false"));
-		}
-		fn boolToStr(b: bool) []const u8 {
-		    return if (b) "true" else "false";
-		}
-		
-		test "peer resolve array and const slice" {
-		    testPeerResolveArrayConstSlice(true);
-		    comptime testPeerResolveArrayConstSlice(true);
-		}
-		fn testPeerResolveArrayConstSlice(b: bool) void {
-		    const value1 = if (b) "aoeu" else @as([]const u8, "zz");
-		    const value2 = if (b) @as([]const u8, "zz") else "aoeu";
-		    assert(mem.eql(u8, value1, "aoeu"));
-		    assert(mem.eql(u8, value2, "zz"));
-		}
-		
-		test "peer type resolution: ?T and T" {
-		    assert(peerTypeTAndOptionalT(true, false).? == 0);
-		    assert(peerTypeTAndOptionalT(false, false).? == 3);
-		    comptime {
-		        assert(peerTypeTAndOptionalT(true, false).? == 0);
-		        assert(peerTypeTAndOptionalT(false, false).? == 3);
-		    }
-		}
-		fn peerTypeTAndOptionalT(c: bool, b: bool) ?usize {
-		    if (c) {
-		        return if (b) null else @as(usize, 0);
-		    }
-		
-		    return @as(usize, 3);
-		}
-		
-		test "peer type resolution: *[0]u8 and []const u8" {
-		    assert(peerTypeEmptyArrayAndSlice(true, "hi").len == 0);
-		    assert(peerTypeEmptyArrayAndSlice(false, "hi").len == 1);
-		    comptime {
-		        assert(peerTypeEmptyArrayAndSlice(true, "hi").len == 0);
-		        assert(peerTypeEmptyArrayAndSlice(false, "hi").len == 1);
-		    }
-		}
-		fn peerTypeEmptyArrayAndSlice(a: bool, slice: []const u8) []const u8 {
-		    if (a) {
-		        return &[_]u8{};
-		    }
-		
-		    return slice[0..1];
-		}
-		test "peer type resolution: *[0]u8, []const u8, and anyerror![]u8" {
-		    {
-		        var data = "hi".*;
-		        const slice = data[0..];
-		        assert((try peerTypeEmptyArrayAndSliceAndError(true, slice)).len == 0);
-		        assert((try peerTypeEmptyArrayAndSliceAndError(false, slice)).len == 1);
-		    }
-		    comptime {
-		        var data = "hi".*;
-		        const slice = data[0..];
-		        assert((try peerTypeEmptyArrayAndSliceAndError(true, slice)).len == 0);
-		        assert((try peerTypeEmptyArrayAndSliceAndError(false, slice)).len == 1);
-		    }
-		}
-		fn peerTypeEmptyArrayAndSliceAndError(a: bool, slice: []u8) anyerror![]u8 {
-		    if (a) {
-		        return &[_]u8{};
-		    }
-		
-		    return slice[0..1];
-		}
-		
-		test "peer type resolution: *const T and ?*T" {
-		    const a = @intToPtr(*const usize, 0x123456780);
-		    const b = @intToPtr(?*usize, 0x123456780);
-		    assert(a == b);
-		    assert(b == a);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        const mem = std.mem;
+        
+        test "peer resolve int widening" {
+            var a: i8 = 12;
+            var b: i16 = 34;
+            var c = a + b;
+            assert(c == 46);
+            assert(@TypeOf(c) == i16);
+        }
+        
+        test "peer resolve arrays of different size to const slice" {
+            assert(mem.eql(u8, boolToStr(true), "true"));
+            assert(mem.eql(u8, boolToStr(false), "false"));
+            comptime assert(mem.eql(u8, boolToStr(true), "true"));
+            comptime assert(mem.eql(u8, boolToStr(false), "false"));
+        }
+        fn boolToStr(b: bool) []const u8 {
+            return if (b) "true" else "false";
+        }
+        
+        test "peer resolve array and const slice" {
+            testPeerResolveArrayConstSlice(true);
+            comptime testPeerResolveArrayConstSlice(true);
+        }
+        fn testPeerResolveArrayConstSlice(b: bool) void {
+            const value1 = if (b) "aoeu" else @as([]const u8, "zz");
+            const value2 = if (b) @as([]const u8, "zz") else "aoeu";
+            assert(mem.eql(u8, value1, "aoeu"));
+            assert(mem.eql(u8, value2, "zz"));
+        }
+        
+        test "peer type resolution: ?T and T" {
+            assert(peerTypeTAndOptionalT(true, false).? == 0);
+            assert(peerTypeTAndOptionalT(false, false).? == 3);
+            comptime {
+                assert(peerTypeTAndOptionalT(true, false).? == 0);
+                assert(peerTypeTAndOptionalT(false, false).? == 3);
+            }
+        }
+        fn peerTypeTAndOptionalT(c: bool, b: bool) ?usize {
+            if (c) {
+                return if (b) null else @as(usize, 0);
+            }
+        
+            return @as(usize, 3);
+        }
+        
+        test "peer type resolution: *[0]u8 and []const u8" {
+            assert(peerTypeEmptyArrayAndSlice(true, "hi").len == 0);
+            assert(peerTypeEmptyArrayAndSlice(false, "hi").len == 1);
+            comptime {
+                assert(peerTypeEmptyArrayAndSlice(true, "hi").len == 0);
+                assert(peerTypeEmptyArrayAndSlice(false, "hi").len == 1);
+            }
+        }
+        fn peerTypeEmptyArrayAndSlice(a: bool, slice: []const u8) []const u8 {
+            if (a) {
+                return &[_]u8{};
+            }
+        
+            return slice[0..1];
+        }
+        test "peer type resolution: *[0]u8, []const u8, and anyerror![]u8" {
+            {
+                var data = "hi".*;
+                const slice = data[0..];
+                assert((try peerTypeEmptyArrayAndSliceAndError(true, slice)).len == 0);
+                assert((try peerTypeEmptyArrayAndSliceAndError(false, slice)).len == 1);
+            }
+            comptime {
+                var data = "hi".*;
+                const slice = data[0..];
+                assert((try peerTypeEmptyArrayAndSliceAndError(true, slice)).len == 0);
+                assert((try peerTypeEmptyArrayAndSliceAndError(false, slice)).len == 1);
+            }
+        }
+        fn peerTypeEmptyArrayAndSliceAndError(a: bool, slice: []u8) anyerror![]u8 {
+            if (a) {
+                return &[_]u8{};
+            }
+        
+            return slice[0..1];
+        }
+        
+        test "peer type resolution: *const T and ?*T" {
+            const a = @intToPtr(*const usize, 0x123456780);
+            const b = @intToPtr(?*usize, 0x123456780);
+            assert(a == b);
+            assert(b == a);
+        }
       {#code_end#}
       {#header_close#}
       {#header_close#}
@@ -5547,19 +5547,19 @@ struct Foo *do_a_thing(void) {
       not included in the final generated code:
       </p>
       {#code_begin|syntax#}
-		export fn entry() void {
-		    var x: void = {};
-		    var y: void = {};
-		    x = y;
-		}
+        export fn entry() void {
+            var x: void = {};
+            var y: void = {};
+            x = y;
+        }
       {#code_end#}
       <p>When this turns into machine code, there is no code generated in the
       body of {#syntax#}entry{#endsyntax#}, even in {#link|Debug#} mode. For example, on x86_64:</p>
       <pre><code>0000000000000010 &lt;entry&gt;:
-  10:	55                   	push   %rbp
-  11:	48 89 e5             	mov    %rsp,%rbp
-  14:	5d                   	pop    %rbp
-  15:	c3                   	retq   </code></pre>
+  10:    55                       push   %rbp
+  11:    48 89 e5                 mov    %rsp,%rbp
+  14:    5d                       pop    %rbp
+  15:    c3                       retq   </code></pre>
       <p>These assembly instructions do not have any code associated with the void values -
       they only perform the function call prologue and epilog.</p>
 
@@ -5572,30 +5572,30 @@ struct Foo *do_a_thing(void) {
                       type to make it into a {#syntax#}Set{#endsyntax#}:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "turn HashMap into a set with void" {
-		    var map = std.HashMap(i32, void, hash_i32, eql_i32).init(std.testing.allocator);
-		    defer map.deinit();
-		
-		    _ = try map.put(1, {});
-		    _ = try map.put(2, {});
-		
-		    assert(map.contains(2));
-		    assert(!map.contains(3));
-		
-		    _ = map.remove(2);
-		    assert(!map.contains(2));
-		}
-		
-		fn hash_i32(x: i32) u32 {
-		    return @bitCast(u32, x);
-		}
-		
-		fn eql_i32(a: i32, b: i32) bool {
-		    return a == b;
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "turn HashMap into a set with void" {
+            var map = std.HashMap(i32, void, hash_i32, eql_i32).init(std.testing.allocator);
+            defer map.deinit();
+        
+            _ = try map.put(1, {});
+            _ = try map.put(2, {});
+        
+            assert(map.contains(2));
+            assert(!map.contains(3));
+        
+            _ = map.remove(2);
+            assert(!map.contains(2));
+        }
+        
+        fn hash_i32(x: i32) u32 {
+            return @bitCast(u32, x);
+        }
+        
+        fn eql_i32(a: i32, b: i32) bool {
+            return a == b;
+        }
       {#code_end#}
       <p>Note that this is different from using a dummy value for the hash map value.
       By using {#syntax#}void{#endsyntax#} as the type of the value, the hash map entry type has no value field, and
@@ -5611,29 +5611,29 @@ struct Foo *do_a_thing(void) {
       Expressions of type {#syntax#}void{#endsyntax#} are the only ones whose value can be ignored. For example:
       </p>
       {#code_begin|test_err|expression value is ignored#}
-		test "ignoring expression value" {
-		    foo();
-		}
-		
-		fn foo() i32 {
-		    return 1234;
-		}
+        test "ignoring expression value" {
+            foo();
+        }
+        
+        fn foo() i32 {
+            return 1234;
+        }
       {#code_end#}
       <p>However, if the expression has type {#syntax#}void{#endsyntax#}, there will be no error. Function return values can also be explicitly ignored by assigning them to {#syntax#}_{#endsyntax#}. </p>
       {#code_begin|test#}
-		test "void is ignored" {
-		    returnsVoid();
-		}
-		
-		test "explicitly ignoring expression value" {
-		    _ = foo();
-		}
-		
-		fn returnsVoid() void {}
-		
-		fn foo() i32 {
-		    return 1234;
-		}
+        test "void is ignored" {
+            returnsVoid();
+        }
+        
+        test "explicitly ignoring expression value" {
+            _ = foo();
+        }
+        
+        fn returnsVoid() void {}
+        
+        fn foo() i32 {
+            return 1234;
+        }
       {#code_end#}
       {#header_close#}
 
@@ -5642,31 +5642,31 @@ struct Foo *do_a_thing(void) {
       {#header_open|Pointers to Zero Bit Types#}
       <p>Pointers to zero bit types also have zero bits. They always compare equal to each other:</p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "pointer to empty struct" {
-		    const Empty = struct {};
-		    var a = Empty{};
-		    var b = Empty{};
-		    var ptr_a = &a;
-		    var ptr_b = &b;
-		    comptime assert(ptr_a == ptr_b);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "pointer to empty struct" {
+            const Empty = struct {};
+            var a = Empty{};
+            var b = Empty{};
+            var ptr_a = &a;
+            var ptr_b = &b;
+            comptime assert(ptr_a == ptr_b);
+        }
       {#code_end#}
       <p>The type being pointed to can only ever be one value; therefore loads and stores are
       never generated. {#link|ptrToInt#} and {#link|intToPtr#} are not allowed:</p>
       {#code_begin|test_err#}
-		const Empty = struct {};
-		
-		test "@ptrToInt for pointer to zero bit type" {
-		    var a = Empty{};
-		    _ = @ptrToInt(&a);
-		}
-		
-		test "@intToPtr for pointer to zero bit type" {
-		    _ = @intToPtr(*Empty, 0x1);
-		}
+        const Empty = struct {};
+        
+        test "@ptrToInt for pointer to zero bit type" {
+            var a = Empty{};
+            _ = @ptrToInt(&a);
+        }
+        
+        test "@intToPtr for pointer to zero bit type" {
+            _ = @intToPtr(*Empty, 0x1);
+        }
       {#code_end#}
       {#header_close#}
       {#header_close#}
@@ -5687,11 +5687,11 @@ struct Foo *do_a_thing(void) {
       the operand, which must be a {#link|struct#}, {#link|union#}, or {#link|enum#}, into the current scope:
       </p>
       {#code_begin|test|usingnamespace#}
-		usingnamespace @import("std");
-		
-		test "using std namespace" {
-		    debug.assert(true);
-		}
+        usingnamespace @import("std");
+        
+        test "using std namespace" {
+            debug.assert(true);
+        }
       {#code_end#}
       <p>
       Instead of the above pattern, it is generally recommended to explicitly alias individual declarations.
@@ -5734,15 +5734,15 @@ pub usingnamespace @cImport({
       Compile-time parameters is how Zig implements generics. It is compile-time duck typing.
       </p>
       {#code_begin|syntax#}
-		fn max(comptime T: type, a: T, b: T) T {
-		    return if (a > b) a else b;
-		}
-		fn gimmeTheBiggerFloat(a: f32, b: f32) f32 {
-		    return max(f32, a, b);
-		}
-		fn gimmeTheBiggerInteger(a: u64, b: u64) u64 {
-		    return max(u64, a, b);
-		}
+        fn max(comptime T: type, a: T, b: T) T {
+            return if (a > b) a else b;
+        }
+        fn gimmeTheBiggerFloat(a: f32, b: f32) f32 {
+            return max(f32, a, b);
+        }
+        fn gimmeTheBiggerInteger(a: u64, b: u64) u64 {
+            return max(u64, a, b);
+        }
       {#code_end#}
       <p>
       In Zig, types are first-class citizens. They can be assigned to variables, passed as parameters to functions,
@@ -5760,18 +5760,18 @@ pub usingnamespace @cImport({
       For example, if we were to introduce another function to the above snippet:
       </p>
       {#code_begin|test_err|values of type 'type' must be comptime known#}
-		fn max(comptime T: type, a: T, b: T) T {
-		    return if (a > b) a else b;
-		}
-		test "try to pass a runtime type" {
-		    foo(false);
-		}
-		fn foo(condition: bool) void {
-		    const result = max(
-		        if (condition) f32 else u64,
-		        1234,
-		        5678);
-		}
+        fn max(comptime T: type, a: T, b: T) T {
+            return if (a > b) a else b;
+        }
+        test "try to pass a runtime type" {
+            foo(false);
+        }
+        fn foo(condition: bool) void {
+            const result = max(
+                if (condition) f32 else u64,
+                1234,
+                5678);
+        }
       {#code_end#}
       <p>
       This is an error because the programmer attempted to pass a value only known at run-time
@@ -5785,12 +5785,12 @@ pub usingnamespace @cImport({
       For example:
       </p>
       {#code_begin|test_err|operator not allowed for type 'bool'#}
-		fn max(comptime T: type, a: T, b: T) T {
-		    return if (a > b) a else b;
-		}
-		test "try to compare bools" {
-		    _ = max(bool, true, false);
-		}
+        fn max(comptime T: type, a: T, b: T) T {
+            return if (a > b) a else b;
+        }
+        test "try to compare bools" {
+            _ = max(bool, true, false);
+        }
       {#code_end#}
       <p>
       On the flip side, inside the function definition with the {#syntax#}comptime{#endsyntax#} parameter, the
@@ -5798,18 +5798,18 @@ pub usingnamespace @cImport({
       if we wanted to:
       </p>
       {#code_begin|test#}
-		fn max(comptime T: type, a: T, b: T) T {
-		    if (T == bool) {
-		        return a or b;
-		    } else if (a > b) {
-		        return a;
-		    } else {
-		        return b;
-		    }
-		}
-		test "try to compare bools" {
-		    @import("std").debug.assert(max(bool, false, true) == true);
-		}
+        fn max(comptime T: type, a: T, b: T) T {
+            if (T == bool) {
+                return a or b;
+            } else if (a > b) {
+                return a;
+            } else {
+                return b;
+            }
+        }
+        test "try to compare bools" {
+            @import("std").debug.assert(max(bool, false, true) == true);
+        }
       {#code_end#}
       <p>
       This works because Zig implicitly inlines {#syntax#}if{#endsyntax#} expressions when the condition
@@ -5821,9 +5821,9 @@ pub usingnamespace @cImport({
       this:
       </p>
       {#code_begin|syntax#}
-		fn max(a: bool, b: bool) bool {
-		    return a or b;
-		}
+        fn max(a: bool, b: bool) bool {
+            return a or b;
+        }
       {#code_end#}
       <p>
       All the code that dealt with compile-time known values is eliminated and we are left with only
@@ -5850,38 +5850,38 @@ pub usingnamespace @cImport({
       For example:
       </p>
       {#code_begin|test|comptime_vars#}
-		const assert = @import("std").debug.assert;
-		
-		const CmdFn = struct {
-		    name: []const u8,
-		    func: fn(i32) i32,
-		};
-		
-		const cmd_fns = [_]CmdFn{
-		    CmdFn {.name = "one", .func = one},
-		    CmdFn {.name = "two", .func = two},
-		    CmdFn {.name = "three", .func = three},
-		};
-		fn one(value: i32) i32 { return value + 1; }
-		fn two(value: i32) i32 { return value + 2; }
-		fn three(value: i32) i32 { return value + 3; }
-		
-		fn performFn(comptime prefix_char: u8, start_value: i32) i32 {
-		    var result: i32 = start_value;
-		    comptime var i = 0;
-		    inline while (i < cmd_fns.len) : (i += 1) {
-		        if (cmd_fns[i].name[0] == prefix_char) {
-		            result = cmd_fns[i].func(result);
-		        }
-		    }
-		    return result;
-		}
-		
-		test "perform fn" {
-		    assert(performFn('t', 1) == 6);
-		    assert(performFn('o', 0) == 1);
-		    assert(performFn('w', 99) == 99);
-		}
+        const assert = @import("std").debug.assert;
+        
+        const CmdFn = struct {
+            name: []const u8,
+            func: fn(i32) i32,
+        };
+        
+        const cmd_fns = [_]CmdFn{
+            CmdFn {.name = "one", .func = one},
+            CmdFn {.name = "two", .func = two},
+            CmdFn {.name = "three", .func = three},
+        };
+        fn one(value: i32) i32 { return value + 1; }
+        fn two(value: i32) i32 { return value + 2; }
+        fn three(value: i32) i32 { return value + 3; }
+        
+        fn performFn(comptime prefix_char: u8, start_value: i32) i32 {
+            var result: i32 = start_value;
+            comptime var i = 0;
+            inline while (i < cmd_fns.len) : (i += 1) {
+                if (cmd_fns[i].name[0] == prefix_char) {
+                    result = cmd_fns[i].func(result);
+                }
+            }
+            return result;
+        }
+        
+        test "perform fn" {
+            assert(performFn('t', 1) == 6);
+            assert(performFn('o', 0) == 1);
+            assert(performFn('w', 99) == 99);
+        }
       {#code_end#}
       <p>
       This example is a bit contrived, because the compile-time evaluation component is unnecessary;
@@ -5890,31 +5890,31 @@ pub usingnamespace @cImport({
           for the different values of {#syntax#}prefix_char{#endsyntax#} provided:
       </p>
       {#code_begin|syntax#}
-		// From the line:
-		// assert(performFn('t', 1) == 6);
-		fn performFn(start_value: i32) i32 {
-		    var result: i32 = start_value;
-		    result = two(result);
-		    result = three(result);
-		    return result;
-		}
+        // From the line:
+        // assert(performFn('t', 1) == 6);
+        fn performFn(start_value: i32) i32 {
+            var result: i32 = start_value;
+            result = two(result);
+            result = three(result);
+            return result;
+        }
       {#code_end#}
       {#code_begin|syntax#}
-		// From the line:
-		// assert(performFn('o', 0) == 1);
-		fn performFn(start_value: i32) i32 {
-		    var result: i32 = start_value;
-		    result = one(result);
-		    return result;
-		}
+        // From the line:
+        // assert(performFn('o', 0) == 1);
+        fn performFn(start_value: i32) i32 {
+            var result: i32 = start_value;
+            result = one(result);
+            return result;
+        }
       {#code_end#}
       {#code_begin|syntax#}
-		// From the line:
-		// assert(performFn('w', 99) == 99);
-		fn performFn(start_value: i32) i32 {
-		    var result: i32 = start_value;
-		    return result;
-		}
+        // From the line:
+        // assert(performFn('w', 99) == 99);
+        fn performFn(start_value: i32) i32 {
+            var result: i32 = start_value;
+            return result;
+        }
       {#code_end#}
       <p>
       Note that this happens even in a debug build; in a release build these generated functions still
@@ -5934,13 +5934,13 @@ pub usingnamespace @cImport({
       If this cannot be accomplished, the compiler will emit an error. For example:
       </p>
       {#code_begin|test_err|unable to evaluate constant expression#}
-		extern fn exit() noreturn;
-		
-		test "foo" {
-		    comptime {
-		        exit();
-		    }
-		}
+        extern fn exit() noreturn;
+        
+        test "foo" {
+            comptime {
+                exit();
+            }
+        }
       {#code_end#}
       <p>
       It doesn't make sense that a program could call {#syntax#}exit(){#endsyntax#} (or any other external function)
@@ -5965,39 +5965,39 @@ pub usingnamespace @cImport({
       Let's look at an example:
       </p>
       {#code_begin|test#}
-		const assert = @import("std").debug.assert;
-		
-		fn fibonacci(index: u32) u32 {
-		    if (index < 2) return index;
-		    return fibonacci(index - 1) + fibonacci(index - 2);
-		}
-		
-		test "fibonacci" {
-		    // test fibonacci at run-time
-		    assert(fibonacci(7) == 13);
-		
-		    // test fibonacci at compile-time
-		    comptime {
-		        assert(fibonacci(7) == 13);
-		    }
-		}
+        const assert = @import("std").debug.assert;
+        
+        fn fibonacci(index: u32) u32 {
+            if (index < 2) return index;
+            return fibonacci(index - 1) + fibonacci(index - 2);
+        }
+        
+        test "fibonacci" {
+            // test fibonacci at run-time
+            assert(fibonacci(7) == 13);
+        
+            // test fibonacci at compile-time
+            comptime {
+                assert(fibonacci(7) == 13);
+            }
+        }
       {#code_end#}
       <p>
       Imagine if we had forgotten the base case of the recursive function and tried to run the tests:
       </p>
       {#code_begin|test_err|operation caused overflow#}
-		const assert = @import("std").debug.assert;
-		
-		fn fibonacci(index: u32) u32 {
-		    //if (index < 2) return index;
-		    return fibonacci(index - 1) + fibonacci(index - 2);
-		}
-		
-		test "fibonacci" {
-		    comptime {
-		        assert(fibonacci(7) == 13);
-		    }
-		}
+        const assert = @import("std").debug.assert;
+        
+        fn fibonacci(index: u32) u32 {
+            //if (index < 2) return index;
+            return fibonacci(index - 1) + fibonacci(index - 2);
+        }
+        
+        test "fibonacci" {
+            comptime {
+                assert(fibonacci(7) == 13);
+            }
+        }
       {#code_end#}
       <p>
       The compiler produces an error which is a stack trace from trying to evaluate the
@@ -6009,18 +6009,18 @@ pub usingnamespace @cImport({
       But what would have happened if we used a signed integer?
       </p>
       {#code_begin|test_err|evaluation exceeded 1000 backwards branches#}
-		const assert = @import("std").debug.assert;
-		
-		fn fibonacci(index: i32) i32 {
-		    //if (index < 2) return index;
-		    return fibonacci(index - 1) + fibonacci(index - 2);
-		}
-		
-		test "fibonacci" {
-		    comptime {
-		        assert(fibonacci(7) == 13);
-		    }
-		}
+        const assert = @import("std").debug.assert;
+        
+        fn fibonacci(index: i32) i32 {
+            //if (index < 2) return index;
+            return fibonacci(index - 1) + fibonacci(index - 2);
+        }
+        
+        test "fibonacci" {
+            comptime {
+                assert(fibonacci(7) == 13);
+            }
+        }
       {#code_end#}
       <p>
       The compiler noticed that evaluating this function at compile-time took a long time,
@@ -6032,18 +6032,18 @@ pub usingnamespace @cImport({
       What if we fix the base case, but put the wrong value in the {#syntax#}assert{#endsyntax#} line?
       </p>
       {#code_begin|test_err|unable to evaluate constant expression#}
-		const assert = @import("std").debug.assert;
-		
-		fn fibonacci(index: i32) i32 {
-		    if (index < 2) return index;
-		    return fibonacci(index - 1) + fibonacci(index - 2);
-		}
-		
-		test "fibonacci" {
-		    comptime {
-		        assert(fibonacci(7) == 99999);
-		    }
-		}
+        const assert = @import("std").debug.assert;
+        
+        fn fibonacci(index: i32) i32 {
+            if (index < 2) return index;
+            return fibonacci(index - 1) + fibonacci(index - 2);
+        }
+        
+        test "fibonacci" {
+            comptime {
+                assert(fibonacci(7) == 99999);
+            }
+        }
       {#code_end#}
       <p>
       What happened is Zig started interpreting the {#syntax#}assert{#endsyntax#} function with the
@@ -6059,41 +6059,41 @@ pub usingnamespace @cImport({
       initialize complex static data. For example:
       </p>
       {#code_begin|test#}
-		const first_25_primes = firstNPrimes(25);
-		const sum_of_first_25_primes = sum(&first_25_primes);
-		
-		fn firstNPrimes(comptime n: usize) [n]i32 {
-		    var prime_list: [n]i32 = undefined;
-		    var next_index: usize = 0;
-		    var test_number: i32 = 2;
-		    while (next_index < prime_list.len) : (test_number += 1) {
-		        var test_prime_index: usize = 0;
-		        var is_prime = true;
-		        while (test_prime_index < next_index) : (test_prime_index += 1) {
-		            if (test_number % prime_list[test_prime_index] == 0) {
-		                is_prime = false;
-		                break;
-		            }
-		        }
-		        if (is_prime) {
-		            prime_list[next_index] = test_number;
-		            next_index += 1;
-		        }
-		    }
-		    return prime_list;
-		}
-		
-		fn sum(numbers: []const i32) i32 {
-		    var result: i32 = 0;
-		    for (numbers) |x| {
-		        result += x;
-		    }
-		    return result;
-		}
-		
-		test "variable values" {
-		    @import("std").debug.assert(sum_of_first_25_primes == 1060);
-		}
+        const first_25_primes = firstNPrimes(25);
+        const sum_of_first_25_primes = sum(&first_25_primes);
+        
+        fn firstNPrimes(comptime n: usize) [n]i32 {
+            var prime_list: [n]i32 = undefined;
+            var next_index: usize = 0;
+            var test_number: i32 = 2;
+            while (next_index < prime_list.len) : (test_number += 1) {
+                var test_prime_index: usize = 0;
+                var is_prime = true;
+                while (test_prime_index < next_index) : (test_prime_index += 1) {
+                    if (test_number % prime_list[test_prime_index] == 0) {
+                        is_prime = false;
+                        break;
+                    }
+                }
+                if (is_prime) {
+                    prime_list[next_index] = test_number;
+                    next_index += 1;
+                }
+            }
+            return prime_list;
+        }
+        
+        fn sum(numbers: []const i32) i32 {
+            var result: i32 = 0;
+            for (numbers) |x| {
+                result += x;
+            }
+            return result;
+        }
+        
+        test "variable values" {
+            @import("std").debug.assert(sum_of_first_25_primes == 1060);
+        }
       {#code_end#}
       <p>
       When we compile this program, Zig generates the constants
@@ -6121,12 +6121,12 @@ pub usingnamespace @cImport({
           the type {#syntax#}i32{#endsyntax#}. In Zig we refer to the type as {#syntax#}List(i32){#endsyntax#}.
       </p>
       {#code_begin|syntax#}
-		fn List(comptime T: type) type {
-		    return struct {
-		        items: []T,
-		        len: usize,
-		    };
-		}
+        fn List(comptime T: type) type {
+            return struct {
+                items: []T,
+                len: usize,
+            };
+        }
       {#code_end#}
       <p>
       That's it. It's a function that returns an anonymous {#syntax#}struct{#endsyntax#}. For the purposes of error messages
@@ -6138,10 +6138,10 @@ pub usingnamespace @cImport({
       a name, we assign it to a constant:
       </p>
       {#code_begin|syntax#}
-		const Node = struct {
-		    next: *Node,
-		    name: []u8,
-		};
+        const Node = struct {
+            next: *Node,
+            name: []u8,
+        };
       {#code_end#}
       <p>
       This works because all top level declarations are order-independent, and as long as there isn't
@@ -6157,14 +6157,14 @@ pub usingnamespace @cImport({
       Putting all of this together, let's see how {#syntax#}printf{#endsyntax#} works in Zig.
       </p>
       {#code_begin|exe|printf#}
-		const warn = @import("std").debug.warn;
-		
-		const a_number: i32 = 1234;
-		const a_string = "foobar";
-		
-		pub fn main() void {
-		    warn("here is a string: '{}' here is a number: {}\n", .{a_string, a_number});
-		}
+        const warn = @import("std").debug.warn;
+        
+        const a_number: i32 = 1234;
+        const a_string = "foobar";
+        
+        pub fn main() void {
+            warn("here is a string: '{}' here is a number: {}\n", .{a_string, a_number});
+        }
       {#code_end#}
 
       <p>
@@ -6172,66 +6172,66 @@ pub usingnamespace @cImport({
       </p>
 
       {#code_begin|syntax#}
-		/// Calls print and then flushes the buffer.
-		pub fn printf(self: *OutStream, comptime format: []const u8, args: var) anyerror!void {
-		    const State = enum {
-		        Start,
-		        OpenBrace,
-		        CloseBrace,
-		    };
-		
-		    comptime var start_index: usize = 0;
-		    comptime var state = State.Start;
-		    comptime var next_arg: usize = 0;
-		
-		    inline for (format) |c, i| {
-		        switch (state) {
-		            State.Start => switch (c) {
-		                '{' => {
-		                    if (start_index < i) try self.write(format[start_index..i]);
-		                    state = State.OpenBrace;
-		                },
-		                '}' => {
-		                    if (start_index < i) try self.write(format[start_index..i]);
-		                    state = State.CloseBrace;
-		                },
-		                else => {},
-		            },
-		            State.OpenBrace => switch (c) {
-		                '{' => {
-		                    state = State.Start;
-		                    start_index = i;
-		                },
-		                '}' => {
-		                    try self.printValue(args[next_arg]);
-		                    next_arg += 1;
-		                    state = State.Start;
-		                    start_index = i + 1;
-		                },
-		                else => @compileError("Unknown format character: " ++ c),
-		            },
-		            State.CloseBrace => switch (c) {
-		                '}' => {
-		                    state = State.Start;
-		                    start_index = i;
-		                },
-		                else => @compileError("Single '}' encountered in format string"),
-		            },
-		        }
-		    }
-		    comptime {
-		        if (args.len != next_arg) {
-		            @compileError("Unused arguments");
-		        }
-		        if (state != State.Start) {
-		            @compileError("Incomplete format string: " ++ format);
-		        }
-		    }
-		    if (start_index < format.len) {
-		        try self.write(format[start_index..format.len]);
-		    }
-		    try self.flush();
-		}
+        /// Calls print and then flushes the buffer.
+        pub fn printf(self: *OutStream, comptime format: []const u8, args: var) anyerror!void {
+            const State = enum {
+                Start,
+                OpenBrace,
+                CloseBrace,
+            };
+        
+            comptime var start_index: usize = 0;
+            comptime var state = State.Start;
+            comptime var next_arg: usize = 0;
+        
+            inline for (format) |c, i| {
+                switch (state) {
+                    State.Start => switch (c) {
+                        '{' => {
+                            if (start_index < i) try self.write(format[start_index..i]);
+                            state = State.OpenBrace;
+                        },
+                        '}' => {
+                            if (start_index < i) try self.write(format[start_index..i]);
+                            state = State.CloseBrace;
+                        },
+                        else => {},
+                    },
+                    State.OpenBrace => switch (c) {
+                        '{' => {
+                            state = State.Start;
+                            start_index = i;
+                        },
+                        '}' => {
+                            try self.printValue(args[next_arg]);
+                            next_arg += 1;
+                            state = State.Start;
+                            start_index = i + 1;
+                        },
+                        else => @compileError("Unknown format character: " ++ c),
+                    },
+                    State.CloseBrace => switch (c) {
+                        '}' => {
+                            state = State.Start;
+                            start_index = i;
+                        },
+                        else => @compileError("Single '}' encountered in format string"),
+                    },
+                }
+            }
+            comptime {
+                if (args.len != next_arg) {
+                    @compileError("Unused arguments");
+                }
+                if (state != State.Start) {
+                    @compileError("Incomplete format string: " ++ format);
+                }
+            }
+            if (start_index < format.len) {
+                try self.write(format[start_index..format.len]);
+            }
+            try self.flush();
+        }
       {#code_end#}
       <p>
       This is a proof of concept implementation; the actual function in the standard library has more
@@ -6245,50 +6245,50 @@ pub usingnamespace @cImport({
       and emits a function that actually looks like this:
       </p>
       {#code_begin|syntax#}
-		pub fn printf(self: *OutStream, arg0: i32, arg1: []const u8) !void {
-		    try self.write("here is a string: '");
-		    try self.printValue(arg0);
-		    try self.write("' here is a number: ");
-		    try self.printValue(arg1);
-		    try self.write("\n");
-		    try self.flush();
-		}
+        pub fn printf(self: *OutStream, arg0: i32, arg1: []const u8) !void {
+            try self.write("here is a string: '");
+            try self.printValue(arg0);
+            try self.write("' here is a number: ");
+            try self.printValue(arg1);
+            try self.write("\n");
+            try self.flush();
+        }
       {#code_end#}
       <p>
       {#syntax#}printValue{#endsyntax#} is a function that takes a parameter of any type, and does different things depending
       on the type:
       </p>
       {#code_begin|syntax#}
-		pub fn printValue(self: *OutStream, value: var) !void {
-		    switch (@typeInfo(@TypeOf(value))) {
-		        .Int => {
-		            return self.printInt(T, value);
-		        },
-		        .Float => {
-		            return self.printFloat(T, value);
-		        },
-		        else => {
-		            @compileError("Unable to print type '" ++ @typeName(T) ++ "'");
-		        },
-		    }
-		}
+        pub fn printValue(self: *OutStream, value: var) !void {
+            switch (@typeInfo(@TypeOf(value))) {
+                .Int => {
+                    return self.printInt(T, value);
+                },
+                .Float => {
+                    return self.printFloat(T, value);
+                },
+                else => {
+                    @compileError("Unable to print type '" ++ @typeName(T) ++ "'");
+                },
+            }
+        }
       {#code_end#}
       <p>
       And now, what happens if we give too many arguments to {#syntax#}printf{#endsyntax#}?
       </p>
       {#code_begin|test_err|Unused arguments#}
-		const warn = @import("std").debug.warn;
-		
-		const a_number: i32 = 1234;
-		const a_string = "foobar";
-		
-		test "printf too many arguments" {
-		    warn("here is a string: '{}' here is a number: {}\n", .{
-		        a_string,
-		        a_number,
-		        a_number,
-		    });
-		}
+        const warn = @import("std").debug.warn;
+        
+        const a_number: i32 = 1234;
+        const a_string = "foobar";
+        
+        test "printf too many arguments" {
+            warn("here is a string: '{}' here is a number: {}\n", .{
+                a_string,
+                a_number,
+                a_number,
+            });
+        }
       {#code_end#}
       <p>
       Zig gives programmers the tools needed to protect themselves against their own mistakes.
@@ -6298,15 +6298,15 @@ pub usingnamespace @cImport({
       only that it is a compile-time known value that can be coerced to a {#syntax#}[]const u8{#endsyntax#}:
       </p>
       {#code_begin|exe|printf#}
-		const warn = @import("std").debug.warn;
-		
-		const a_number: i32 = 1234;
-		const a_string = "foobar";
-		const fmt = "here is a string: '{}' here is a number: {}\n";
-		
-		pub fn main() void {
-		    warn(fmt, .{a_string, a_number});
-		}
+        const warn = @import("std").debug.warn;
+        
+        const a_number: i32 = 1234;
+        const a_string = "foobar";
+        const fmt = "here is a string: '{}' here is a number: {}\n";
+        
+        pub fn main() void {
+            warn(fmt, .{a_string, a_number});
+        }
       {#code_end#}
       <p>
       This works fine.
@@ -6329,38 +6329,38 @@ pub usingnamespace @cImport({
       using inline assembly:
       </p>
       {#code_begin|exe#}
-		      {#target_linux_x86_64#}
-		pub fn main() noreturn {
-		    const msg = "hello world\n";
-		    _ = syscall3(SYS_write, STDOUT_FILENO, @ptrToInt(msg), msg.len);
-		    _ = syscall1(SYS_exit, 0);
-		    unreachable;
-		}
-		
-		pub const SYS_write = 1;
-		pub const SYS_exit = 60;
-		
-		pub const STDOUT_FILENO = 1;
-		
-		pub fn syscall1(number: usize, arg1: usize) usize {
-		    return asm volatile ("syscall"
-		        : [ret] "={rax}" (-> usize)
-		        : [number] "{rax}" (number),
-		          [arg1] "{rdi}" (arg1)
-		        : "rcx", "r11"
-		    );
-		}
-		
-		pub fn syscall3(number: usize, arg1: usize, arg2: usize, arg3: usize) usize {
-		    return asm volatile ("syscall"
-		        : [ret] "={rax}" (-> usize)
-		        : [number] "{rax}" (number),
-		          [arg1] "{rdi}" (arg1),
-		          [arg2] "{rsi}" (arg2),
-		          [arg3] "{rdx}" (arg3)
-		        : "rcx", "r11"
-		    );
-		}
+              {#target_linux_x86_64#}
+        pub fn main() noreturn {
+            const msg = "hello world\n";
+            _ = syscall3(SYS_write, STDOUT_FILENO, @ptrToInt(msg), msg.len);
+            _ = syscall1(SYS_exit, 0);
+            unreachable;
+        }
+        
+        pub const SYS_write = 1;
+        pub const SYS_exit = 60;
+        
+        pub const STDOUT_FILENO = 1;
+        
+        pub fn syscall1(number: usize, arg1: usize) usize {
+            return asm volatile ("syscall"
+                : [ret] "={rax}" (-> usize)
+                : [number] "{rax}" (number),
+                  [arg1] "{rdi}" (arg1)
+                : "rcx", "r11"
+            );
+        }
+        
+        pub fn syscall3(number: usize, arg1: usize, arg2: usize, arg3: usize) usize {
+            return asm volatile ("syscall"
+                : [ret] "={rax}" (-> usize)
+                : [number] "{rax}" (number),
+                  [arg1] "{rdi}" (arg1),
+                  [arg2] "{rsi}" (arg2),
+                  [arg3] "{rdx}" (arg3)
+                : "rcx", "r11"
+            );
+        }
       {#code_end#}
       <p>
       Dissecting the syntax:
@@ -6497,25 +6497,25 @@ volatile (
       <code>%</code> as there are in inline assembly expressions.
       </p>
       {#code_begin|test|global-asm#}
-		      {#target_linux_x86_64#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		comptime {
-		    asm (
-		        \\.global my_func;
-		        \\.type my_func, @function;
-		        \\my_func:
-		        \\  lea (%rdi,%rsi,1),%eax
-		        \\  retq
-		    );
-		}
-		
-		extern fn my_func(a: i32, b: i32) i32;
-		
-		test "global assembly" {
-		    assert(my_func(12, 34) == 46);
-		}
+              {#target_linux_x86_64#}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        comptime {
+            asm (
+                \\.global my_func;
+                \\.type my_func, @function;
+                \\my_func:
+                \\  lea (%rdi,%rsi,1),%eax
+                \\  retq
+            );
+        }
+        
+        extern fn my_func(a: i32, b: i32) i32;
+        
+        test "global assembly" {
+            assert(my_func(12, 34) == 46);
+        }
       {#code_end#}
       {#header_close#}
       {#header_close#}
@@ -6554,22 +6554,22 @@ volatile (
       or resumer (in the case of subsequent suspensions).
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		var x: i32 = 1;
-		
-		test "suspend with no resume" {
-		    var frame = async func();
-		    assert(x == 2);
-		}
-		
-		fn func() void {
-		    x += 1;
-		    suspend;
-		    // This line is never reached because the suspend has no matching resume.
-		    x += 1;
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        var x: i32 = 1;
+        
+        test "suspend with no resume" {
+            var frame = async func();
+            assert(x == 2);
+        }
+        
+        fn func() void {
+            x += 1;
+            suspend;
+            // This line is never reached because the suspend has no matching resume.
+            x += 1;
+        }
       {#code_end#}
       <p>
       In the same way that each allocation should have a corresponding free,
@@ -6580,26 +6580,26 @@ volatile (
       {#link|@frame#} provides access to the async function frame pointer.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		var the_frame: anyframe = undefined;
-		var result = false;
-		
-		test "async function suspend with block" {
-		    _ = async testSuspendBlock();
-		    assert(!result);
-		    resume the_frame;
-		    assert(result);
-		}
-		
-		fn testSuspendBlock() void {
-		    suspend {
-		        comptime assert(@TypeOf(@frame()) == *@Frame(testSuspendBlock));
-		        the_frame = @frame();
-		    }
-		    result = true;
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        var the_frame: anyframe = undefined;
+        var result = false;
+        
+        test "async function suspend with block" {
+            _ = async testSuspendBlock();
+            assert(!result);
+            resume the_frame;
+            assert(result);
+        }
+        
+        fn testSuspendBlock() void {
+            suspend {
+                comptime assert(@TypeOf(@frame()) == *@Frame(testSuspendBlock));
+                the_frame = @frame();
+            }
+            result = true;
+        }
       {#code_end#}
       <p>
       {#syntax#}suspend{#endsyntax#} causes a function to be {#syntax#}async{#endsyntax#}.
@@ -6620,22 +6620,22 @@ volatile (
       never returns to its resumer and continues executing.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "resume from suspend" {
-		    var my_result: i32 = 1;
-		    _ = async testResumeFromSuspend(&my_result);
-		    std.debug.assert(my_result == 2);
-		}
-		fn testResumeFromSuspend(my_result: *i32) void {
-		    suspend {
-		        resume @frame();
-		    }
-		    my_result.* += 1;
-		    suspend;
-		    my_result.* += 1;
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "resume from suspend" {
+            var my_result: i32 = 1;
+            _ = async testResumeFromSuspend(&my_result);
+            std.debug.assert(my_result == 2);
+        }
+        fn testResumeFromSuspend(my_result: *i32) void {
+            suspend {
+                resume @frame();
+            }
+            my_result.* += 1;
+            suspend;
+            my_result.* += 1;
+        }
       {#code_end#}
       <p>
       This is guaranteed to tail call, and therefore will not cause a new stack frame.
@@ -6651,33 +6651,33 @@ volatile (
       {#syntax#}resume{#endsyntax#}, every {#syntax#}async{#endsyntax#} has a matching {#syntax#}await{#endsyntax#}.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "async and await" {
-		    // Here we have an exception where we do not match an async
-		    // with an await. The test block is not async and so cannot
-		    // have a suspend point in it.
-		    // This is well-defined behavior, and everything is OK here.
-		    // Note however that there would be no way to collect the
-		    // return value of amain, if it were something other than void.
-		    _ = async amain();
-		}
-		
-		fn amain() void {
-		    var frame = async func();
-		    comptime assert(@TypeOf(frame) == @Frame(func));
-		
-		    const ptr: anyframe->void = &frame;
-		    const any_ptr: anyframe = ptr;
-		
-		    resume any_ptr;
-		    await ptr;
-		}
-		
-		fn func() void {
-		    suspend;
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "async and await" {
+            // Here we have an exception where we do not match an async
+            // with an await. The test block is not async and so cannot
+            // have a suspend point in it.
+            // This is well-defined behavior, and everything is OK here.
+            // Note however that there would be no way to collect the
+            // return value of amain, if it were something other than void.
+            _ = async amain();
+        }
+        
+        fn amain() void {
+            var frame = async func();
+            comptime assert(@TypeOf(frame) == @Frame(func));
+        
+            const ptr: anyframe->void = &frame;
+            const any_ptr: anyframe = ptr;
+        
+            resume any_ptr;
+            await ptr;
+        }
+        
+        fn func() void {
+            suspend;
+        }
       {#code_end#}
       <p>
       The {#syntax#}await{#endsyntax#} keyword is used to coordinate with an async function's
@@ -6695,45 +6695,45 @@ volatile (
       return value directly from the target function's frame.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		var the_frame: anyframe = undefined;
-		var final_result: i32 = 0;
-		
-		test "async function await" {
-		    seq('a');
-		    _ = async amain();
-		    seq('f');
-		    resume the_frame;
-		    seq('i');
-		    assert(final_result == 1234);
-		    assert(std.mem.eql(u8, &seq_points, "abcdefghi"));
-		}
-		fn amain() void {
-		    seq('b');
-		    var f = async another();
-		    seq('e');
-		    final_result = await f;
-		    seq('h');
-		}
-		fn another() i32 {
-		    seq('c');
-		    suspend {
-		        seq('d');
-		        the_frame = @frame();
-		    }
-		    seq('g');
-		    return 1234;
-		}
-		
-		var seq_points = [_]u8{0} ** "abcdefghi".len;
-		var seq_index: usize = 0;
-		
-		fn seq(c: u8) void {
-		    seq_points[seq_index] = c;
-		    seq_index += 1;
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        var the_frame: anyframe = undefined;
+        var final_result: i32 = 0;
+        
+        test "async function await" {
+            seq('a');
+            _ = async amain();
+            seq('f');
+            resume the_frame;
+            seq('i');
+            assert(final_result == 1234);
+            assert(std.mem.eql(u8, &seq_points, "abcdefghi"));
+        }
+        fn amain() void {
+            seq('b');
+            var f = async another();
+            seq('e');
+            final_result = await f;
+            seq('h');
+        }
+        fn another() i32 {
+            seq('c');
+            suspend {
+                seq('d');
+                the_frame = @frame();
+            }
+            seq('g');
+            return 1234;
+        }
+        
+        var seq_points = [_]u8{0} ** "abcdefghi".len;
+        var seq_index: usize = 0;
+        
+        fn seq(c: u8) void {
+            seq_points[seq_index] = c;
+            seq_index += 1;
+        }
       {#code_end#}
       <p>
       In general, {#syntax#}suspend{#endsyntax#} is lower level than {#syntax#}await{#endsyntax#}. Most application
@@ -6750,138 +6750,138 @@ volatile (
       {#syntax#}async{#endsyntax#}/{#syntax#}await{#endsyntax#} usage:
       </p>
       {#code_begin|exe|async#}
-		const std = @import("std");
-		const Allocator = std.mem.Allocator;
-		
-		pub fn main() void {
-		    _ = async amainWrap();
-		
-		    // Typically we would use an event loop to manage resuming async functions,
-		    // but in this example we hard code what the event loop would do,
-		    // to make things deterministic.
-		    resume global_file_frame;
-		    resume global_download_frame;
-		}
-		
-		fn amainWrap() void {
-		    amain() catch |e| {
-		        std.debug.warn("{}\n", .{e});
-		        if (@errorReturnTrace()) |trace| {
-		            std.debug.dumpStackTrace(trace.*);
-		        }
-		        std.process.exit(1);
-		    };
-		}
-		
-		fn amain() !void {
-		    const allocator = std.heap.page_allocator;
-		    var download_frame = async fetchUrl(allocator, "https://example.com/");
-		    var awaited_download_frame = false;
-		    errdefer if (!awaited_download_frame) {
-		        if (await download_frame) |r| allocator.free(r) else |_| {}
-		    };
-		
-		    var file_frame = async readFile(allocator, "something.txt");
-		    var awaited_file_frame = false;
-		    errdefer if (!awaited_file_frame) {
-		        if (await file_frame) |r| allocator.free(r) else |_| {}
-		    };
-		
-		    awaited_file_frame = true;
-		    const file_text = try await file_frame;
-		    defer allocator.free(file_text);
-		
-		    awaited_download_frame = true;
-		    const download_text = try await download_frame;
-		    defer allocator.free(download_text);
-		
-		    std.debug.warn("download_text: {}\n", .{download_text});
-		    std.debug.warn("file_text: {}\n", .{file_text});
-		}
-		
-		var global_download_frame: anyframe = undefined;
-		fn fetchUrl(allocator: *Allocator, url: []const u8) ![]u8 {
-		    const result = try std.mem.dupe(allocator, u8, "this is the downloaded url contents");
-		    errdefer allocator.free(result);
-		    suspend {
-		        global_download_frame = @frame();
-		    }
-		    std.debug.warn("fetchUrl returning\n", .{});
-		    return result;
-		}
-		
-		var global_file_frame: anyframe = undefined;
-		fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
-		    const result = try std.mem.dupe(allocator, u8, "this is the file contents");
-		    errdefer allocator.free(result);
-		    suspend {
-		        global_file_frame = @frame();
-		    }
-		    std.debug.warn("readFile returning\n", .{});
-		    return result;
-		}
+        const std = @import("std");
+        const Allocator = std.mem.Allocator;
+        
+        pub fn main() void {
+            _ = async amainWrap();
+        
+            // Typically we would use an event loop to manage resuming async functions,
+            // but in this example we hard code what the event loop would do,
+            // to make things deterministic.
+            resume global_file_frame;
+            resume global_download_frame;
+        }
+        
+        fn amainWrap() void {
+            amain() catch |e| {
+                std.debug.warn("{}\n", .{e});
+                if (@errorReturnTrace()) |trace| {
+                    std.debug.dumpStackTrace(trace.*);
+                }
+                std.process.exit(1);
+            };
+        }
+        
+        fn amain() !void {
+            const allocator = std.heap.page_allocator;
+            var download_frame = async fetchUrl(allocator, "https://example.com/");
+            var awaited_download_frame = false;
+            errdefer if (!awaited_download_frame) {
+                if (await download_frame) |r| allocator.free(r) else |_| {}
+            };
+        
+            var file_frame = async readFile(allocator, "something.txt");
+            var awaited_file_frame = false;
+            errdefer if (!awaited_file_frame) {
+                if (await file_frame) |r| allocator.free(r) else |_| {}
+            };
+        
+            awaited_file_frame = true;
+            const file_text = try await file_frame;
+            defer allocator.free(file_text);
+        
+            awaited_download_frame = true;
+            const download_text = try await download_frame;
+            defer allocator.free(download_text);
+        
+            std.debug.warn("download_text: {}\n", .{download_text});
+            std.debug.warn("file_text: {}\n", .{file_text});
+        }
+        
+        var global_download_frame: anyframe = undefined;
+        fn fetchUrl(allocator: *Allocator, url: []const u8) ![]u8 {
+            const result = try std.mem.dupe(allocator, u8, "this is the downloaded url contents");
+            errdefer allocator.free(result);
+            suspend {
+                global_download_frame = @frame();
+            }
+            std.debug.warn("fetchUrl returning\n", .{});
+            return result;
+        }
+        
+        var global_file_frame: anyframe = undefined;
+        fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
+            const result = try std.mem.dupe(allocator, u8, "this is the file contents");
+            errdefer allocator.free(result);
+            suspend {
+                global_file_frame = @frame();
+            }
+            std.debug.warn("readFile returning\n", .{});
+            return result;
+        }
       {#code_end#}
       <p>
       Now we remove the {#syntax#}suspend{#endsyntax#} and {#syntax#}resume{#endsyntax#} code, and
       observe the same behavior, with one tiny difference:
       </p>
       {#code_begin|exe|blocking#}
-		const std = @import("std");
-		const Allocator = std.mem.Allocator;
-		
-		pub fn main() void {
-		    _ = async amainWrap();
-		}
-		
-		fn amainWrap() void {
-		    amain() catch |e| {
-		        std.debug.warn("{}\n", .{e});
-		        if (@errorReturnTrace()) |trace| {
-		            std.debug.dumpStackTrace(trace.*);
-		        }
-		        std.process.exit(1);
-		    };
-		}
-		
-		fn amain() !void {
-		    const allocator = std.heap.page_allocator;
-		    var download_frame = async fetchUrl(allocator, "https://example.com/");
-		    var awaited_download_frame = false;
-		    errdefer if (!awaited_download_frame) {
-		        if (await download_frame) |r| allocator.free(r) else |_| {}
-		    };
-		
-		    var file_frame = async readFile(allocator, "something.txt");
-		    var awaited_file_frame = false;
-		    errdefer if (!awaited_file_frame) {
-		        if (await file_frame) |r| allocator.free(r) else |_| {}
-		    };
-		
-		    awaited_file_frame = true;
-		    const file_text = try await file_frame;
-		    defer allocator.free(file_text);
-		
-		    awaited_download_frame = true;
-		    const download_text = try await download_frame;
-		    defer allocator.free(download_text);
-		
-		    std.debug.warn("download_text: {}\n", .{download_text});
-		    std.debug.warn("file_text: {}\n", .{file_text});
-		}
-		
-		fn fetchUrl(allocator: *Allocator, url: []const u8) ![]u8 {
-		    const result = try std.mem.dupe(allocator, u8, "this is the downloaded url contents");
-		    errdefer allocator.free(result);
-		    std.debug.warn("fetchUrl returning\n", .{});
-		    return result;
-		}
-		
-		fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
-		    const result = try std.mem.dupe(allocator, u8, "this is the file contents");
-		    errdefer allocator.free(result);
-		    std.debug.warn("readFile returning\n", .{});
-		    return result;
-		}
+        const std = @import("std");
+        const Allocator = std.mem.Allocator;
+        
+        pub fn main() void {
+            _ = async amainWrap();
+        }
+        
+        fn amainWrap() void {
+            amain() catch |e| {
+                std.debug.warn("{}\n", .{e});
+                if (@errorReturnTrace()) |trace| {
+                    std.debug.dumpStackTrace(trace.*);
+                }
+                std.process.exit(1);
+            };
+        }
+        
+        fn amain() !void {
+            const allocator = std.heap.page_allocator;
+            var download_frame = async fetchUrl(allocator, "https://example.com/");
+            var awaited_download_frame = false;
+            errdefer if (!awaited_download_frame) {
+                if (await download_frame) |r| allocator.free(r) else |_| {}
+            };
+        
+            var file_frame = async readFile(allocator, "something.txt");
+            var awaited_file_frame = false;
+            errdefer if (!awaited_file_frame) {
+                if (await file_frame) |r| allocator.free(r) else |_| {}
+            };
+        
+            awaited_file_frame = true;
+            const file_text = try await file_frame;
+            defer allocator.free(file_text);
+        
+            awaited_download_frame = true;
+            const download_text = try await download_frame;
+            defer allocator.free(download_text);
+        
+            std.debug.warn("download_text: {}\n", .{download_text});
+            std.debug.warn("file_text: {}\n", .{file_text});
+        }
+        
+        fn fetchUrl(allocator: *Allocator, url: []const u8) ![]u8 {
+            const result = try std.mem.dupe(allocator, u8, "this is the downloaded url contents");
+            errdefer allocator.free(result);
+            std.debug.warn("fetchUrl returning\n", .{});
+            return result;
+        }
+        
+        fn readFile(allocator: *Allocator, filename: []const u8) ![]u8 {
+            const result = try std.mem.dupe(allocator, u8, "this is the file contents");
+            errdefer allocator.free(result);
+            std.debug.warn("readFile returning\n", .{});
+            return result;
+        }
       {#code_end#}
       <p>
       Previously, the {#syntax#}fetchUrl{#endsyntax#} and {#syntax#}readFile{#endsyntax#} functions suspended,
@@ -6973,27 +6973,27 @@ comptime {
       {#syntax#}await{#endsyntax#} will copy the result from {#syntax#}result_ptr{#endsyntax#}.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "async fn pointer in a struct field" {
-		    var data: i32 = 1;
-		    const Foo = struct {
-		        bar: async fn (*i32) void,
-		    };
-		    var foo = Foo{ .bar = func };
-		    var bytes: [64]u8 align(@alignOf(@Frame(func))) = undefined;
-		    const f = @asyncCall(&bytes, {}, foo.bar, &data);
-		    assert(data == 2);
-		    resume f;
-		    assert(data == 4);
-		}
-		
-		async fn func(y: *i32) void {
-		    defer y.* += 2;
-		    y.* += 1;
-		    suspend;
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "async fn pointer in a struct field" {
+            var data: i32 = 1;
+            const Foo = struct {
+                bar: async fn (*i32) void,
+            };
+            var foo = Foo{ .bar = func };
+            var bytes: [64]u8 align(@alignOf(@Frame(func))) = undefined;
+            const f = @asyncCall(&bytes, {}, foo.bar, &data);
+            assert(data == 2);
+            resume f;
+            assert(data == 4);
+        }
+        
+        async fn func(y: *i32) void {
+            defer y.* += 2;
+            y.* += 1;
+            suspend;
+        }
       {#code_end#}
       {#header_close#}
 
@@ -7196,59 +7196,59 @@ comptime {
       Calls a function, in the same way that invoking an expression with parentheses does:
       </p>
       {#code_begin|test|call#}
-		const assert = @import("std").debug.assert;
-		
-		test "noinline function call" {
-		    assert(@call(.{}, add, .{3, 9}) == 12);
-		}
-		
-		fn add(a: i32, b: i32) i32 {
-		    return a + b;
-		}
+        const assert = @import("std").debug.assert;
+        
+        test "noinline function call" {
+            assert(@call(.{}, add, .{3, 9}) == 12);
+        }
+        
+        fn add(a: i32, b: i32) i32 {
+            return a + b;
+        }
       {#code_end#}
       <p>
       {#syntax#}@call{#endsyntax#} allows more flexibility than normal function call syntax does. The
       {#syntax#}CallOptions{#endsyntax#} struct is reproduced here:
       </p>
       {#code_begin|syntax#}
-		pub const CallOptions = struct {
-		    modifier: Modifier = .auto,
-		    stack: ?[]align(std.Target.stack_align) u8 = null,
-		
-		    pub const Modifier = enum {
-		        /// Equivalent to function call syntax.
-		        auto,
-		
-		        /// Equivalent to async keyword used with function call syntax.
-		        async_kw,
-		
-		        /// Prevents tail call optimization. This guarantees that the return
-		        /// address will point to the callsite, as opposed to the callsite's
-		        /// callsite. If the call is otherwise required to be tail-called
-		        /// or inlined, a compile error is emitted instead.
-		        never_tail,
-		
-		        /// Guarantees that the call will not be inlined. If the call is
-		        /// otherwise required to be inlined, a compile error is emitted instead.
-		        never_inline,
-		
-		        /// Asserts that the function call will not suspend. This allows a
-		        /// non-async function to call an async function.
-		        no_async,
-		
-		        /// Guarantees that the call will be generated with tail call optimization.
-		        /// If this is not possible, a compile error is emitted instead.
-		        always_tail,
-		
-		        /// Guarantees that the call will inlined at the callsite.
-		        /// If this is not possible, a compile error is emitted instead.
-		        always_inline,
-		
-		        /// Evaluates the call at compile-time. If the call cannot be completed at
-		        /// compile-time, a compile error is emitted instead.
-		        compile_time,
-		    };
-		};
+        pub const CallOptions = struct {
+            modifier: Modifier = .auto,
+            stack: ?[]align(std.Target.stack_align) u8 = null,
+        
+            pub const Modifier = enum {
+                /// Equivalent to function call syntax.
+                auto,
+        
+                /// Equivalent to async keyword used with function call syntax.
+                async_kw,
+        
+                /// Prevents tail call optimization. This guarantees that the return
+                /// address will point to the callsite, as opposed to the callsite's
+                /// callsite. If the call is otherwise required to be tail-called
+                /// or inlined, a compile error is emitted instead.
+                never_tail,
+        
+                /// Guarantees that the call will not be inlined. If the call is
+                /// otherwise required to be inlined, a compile error is emitted instead.
+                never_inline,
+        
+                /// Asserts that the function call will not suspend. This allows a
+                /// non-async function to call an async function.
+                no_async,
+        
+                /// Guarantees that the call will be generated with tail call optimization.
+                /// If this is not possible, a compile error is emitted instead.
+                always_tail,
+        
+                /// Guarantees that the call will inlined at the callsite.
+                /// If this is not possible, a compile error is emitted instead.
+                always_inline,
+        
+                /// Evaluates the call at compile-time. If the call cannot be completed at
+                /// compile-time, a compile error is emitted instead.
+                compile_time,
+            };
+        };
       {#code_end#}
       {#header_close#}
 
@@ -7343,15 +7343,15 @@ comptime {
       except atomic:
       </p>
       {#code_begin|syntax#}
-		fn cmpxchgStrongButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {
-		    const old_value = ptr.*;
-		    if (old_value == expected_value) {
-		        ptr.* = new_value;
-		        return null;
-		    } else {
-		        return old_value;
-		    }
-		}
+        fn cmpxchgStrongButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {
+            const old_value = ptr.*;
+            if (old_value == expected_value) {
+                ptr.* = new_value;
+                return null;
+            } else {
+                return old_value;
+            }
+        }
       {#code_end#}
       <p>
       If you are using cmpxchg in a loop, {#link|@cmpxchgWeak#} is the better choice, because it can be implemented
@@ -7373,15 +7373,15 @@ comptime {
       except atomic:
       </p>
       {#code_begin|syntax#}
-		fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {
-		    const old_value = ptr.*;
-		    if (old_value == expected_value and usuallyTrueButSometimesFalse()) {
-		        ptr.* = new_value;
-		        return null;
-		    } else {
-		        return old_value;
-		    }
-		}
+        fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {
+            const old_value = ptr.*;
+            if (old_value == expected_value and usuallyTrueButSometimesFalse()) {
+                ptr.* = new_value;
+                return null;
+            } else {
+                return old_value;
+            }
+        }
       {#code_end#}
       <p>
       If you are using cmpxchg in a loop, the sporadic failure will be no problem, and {#syntax#}cmpxchgWeak{#endsyntax#}
@@ -7429,20 +7429,20 @@ comptime {
       compile-time executing code.
       </p>
       {#code_begin|test_err|found compile log statement#}
-		const warn = @import("std").debug.warn;
-		
-		const num1 = blk: {
-		    var val1: i32 = 99;
-		    @compileLog("comptime val1 = ", val1);
-		    val1 = val1 + 1;
-		    break :blk val1;
-		};
-		
-		test "main" {
-		    @compileLog("comptime in main");
-		
-		    warn("Runtime in main, num1 = {}.\n", .{num1});
-		}
+        const warn = @import("std").debug.warn;
+        
+        const num1 = blk: {
+            var val1: i32 = 99;
+            @compileLog("comptime val1 = ", val1);
+            val1 = val1 + 1;
+            break :blk val1;
+        };
+        
+        test "main" {
+            @compileLog("comptime in main");
+        
+            warn("Runtime in main, num1 = {}.\n", .{num1});
+        }
       {#code_end#}
       <p>
       will ouput:
@@ -7453,17 +7453,17 @@ comptime {
       program compiles successfully and the generated executable prints:
       </p>
       {#code_begin|test#}
-		const warn = @import("std").debug.warn;
-		
-		const num1 = blk: {
-		    var val1: i32 = 99;
-		    val1 = val1 + 1;
-		    break :blk val1;
-		};
-		
-		test "main" {
-		    warn("Runtime in main, num1 = {}.\n", .{num1});
-		}
+        const warn = @import("std").debug.warn;
+        
+        const num1 = blk: {
+            var val1: i32 = 99;
+            val1 = val1 + 1;
+            break :blk val1;
+        };
+        
+        test "main" {
+            warn("Runtime in main, num1 = {}.\n", .{num1});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -7652,20 +7652,20 @@ comptime {
       the {#syntax#}export{#endsyntax#} keyword used on a function:
       </p>
       {#code_begin|obj#}
-		comptime {
-		    @export(internalName, .{ .name = "foo", .linkage = .Strong });
-		}
-		
-		fn internalName() callconv(.C) void {}
+        comptime {
+            @export(internalName, .{ .name = "foo", .linkage = .Strong });
+        }
+        
+        fn internalName() callconv(.C) void {}
       {#code_end#}
       <p>This is equivalent to:</p>
       {#code_begin|obj#}
-		export fn foo() void {}
+        export fn foo() void {}
       {#code_end#}
       <p>Note that even when using {#syntax#}export{#endsyntax#}, {#syntax#}@"foo"{#endsyntax#} syntax can
       be used to choose any string for the symbol name:</p>
       {#code_begin|obj#}
-		export fn @"A function name that is a complete sentence."() void {}
+        export fn @"A function name that is a complete sentence."() void {}
       {#code_end#}
       <p>
       When looking at the resulting object, you can see the symbol is used verbatim:
@@ -7694,23 +7694,23 @@ comptime {
       <p>Performs field access by a compile-time string.
       </p>
        {#code_begin|test#}
-		const std = @import("std");
-		
-		const Point = struct {
-		    x: u32,
-		    y: u32
-		};
-		
-		test "field access by string" {
-		    const assert = std.debug.assert;
-		    var p = Point {.x = 0, .y = 0};
-		
-		    @field(p, "x") = 4;
-		    @field(p, "y") = @field(p, "x") + 1;
-		
-		    assert(@field(p, "x") == 4);
-		    assert(@field(p, "y") == 5);
-		}
+        const std = @import("std");
+        
+        const Point = struct {
+            x: u32,
+            y: u32
+        };
+        
+        test "field access by string" {
+            const assert = std.debug.assert;
+            var p = Point {.x = 0, .y = 0};
+        
+            @field(p, "x") = 4;
+            @field(p, "y") = @field(p, "x") + 1;
+        
+            assert(@field(p, "x") == 4);
+            assert(@field(p, "y") == 5);
+        }
       {#code_end#}
 
       {#header_close#}
@@ -7778,16 +7778,16 @@ comptime {
       allows one to, for example, heap-allocate an async function frame:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		
-		test "heap allocated frame" {
-		    const frame = try std.heap.page_allocator.create(@Frame(func));
-		    frame.* = async func();
-		}
-		
-		fn func() void {
-		    suspend;
-		}
+        const std = @import("std");
+        
+        test "heap allocated frame" {
+            const frame = try std.heap.page_allocator.create(@Frame(func));
+            frame.* = async func();
+        }
+        
+        fn func() void {
+            suspend;
+        }
       {#code_end#}
       {#header_close#}
 
@@ -7830,28 +7830,28 @@ comptime {
       matching {#syntax#}name{#endsyntax#}.
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		const Foo = struct {
-		    nope: i32,
-		
-		    pub var blah = "xxx";
-		    const hi = 1;
-		};
-		
-		test "@hasDecl" {
-		    assert(@hasDecl(Foo, "blah"));
-		
-		    // Even though `hi` is private, @hasDecl returns true because this test is
-		    // in the same file scope as Foo. It would return false if Foo was declared
-		    // in a different file.
-		    assert(@hasDecl(Foo, "hi"));
-		
-		    // @hasDecl is for declarations; not fields.
-		    assert(!@hasDecl(Foo, "nope"));
-		    assert(!@hasDecl(Foo, "nope1234"));
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        const Foo = struct {
+            nope: i32,
+        
+            pub var blah = "xxx";
+            const hi = 1;
+        };
+        
+        test "@hasDecl" {
+            assert(@hasDecl(Foo, "blah"));
+        
+            // Even though `hi` is private, @hasDecl returns true because this test is
+            // in the same file scope as Foo. It would return false if Foo was declared
+            // in a different file.
+            assert(@hasDecl(Foo, "hi"));
+        
+            // @hasDecl is for declarations; not fields.
+            assert(!@hasDecl(Foo, "nope"));
+            assert(!@hasDecl(Foo, "nope1234"));
+        }
       {#code_end#}
       {#see_also|@hasField#}
       {#header_close#}
@@ -8052,17 +8052,17 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       Example:
       </p>
       {#code_begin|test_err|expected type '*Derp', found '*Wat'#}
-		const Derp = @OpaqueType();
-		const Wat = @OpaqueType();
-		
-		extern fn bar(d: *Derp) void;
-		fn foo(w: *Wat) callconv(.C) void {
-		    bar(w);
-		}
-		
-		test "call foo" {
-		    foo(undefined);
-		}
+        const Derp = @OpaqueType();
+        const Wat = @OpaqueType();
+        
+        extern fn bar(d: *Derp) void;
+        fn foo(w: *Wat) callconv(.C) void {
+            bar(w);
+        }
+        
+        test "call foo" {
+            foo(undefined);
+        }
       {#code_end#}
       {#header_close#}
 
@@ -8197,22 +8197,22 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       Example:
       </p>
       {#code_begin|test_err|evaluation exceeded 1000 backwards branches#}
-		test "foo" {
-		    comptime {
-		        var i = 0;
-		        while (i < 1001) : (i += 1) {}
-		    }
-		}
+        test "foo" {
+            comptime {
+                var i = 0;
+                while (i < 1001) : (i += 1) {}
+            }
+        }
       {#code_end#}
       <p>Now we use {#syntax#}@setEvalBranchQuota{#endsyntax#}:</p>
       {#code_begin|test#}
-		test "foo" {
-		    comptime {
-		        @setEvalBranchQuota(1001);
-		        var i = 0;
-		        while (i < 1001) : (i += 1) {}
-		    }
-		}
+        test "foo" {
+            comptime {
+                @setEvalBranchQuota(1001);
+                var i = 0;
+                while (i < 1001) : (i += 1) {}
+            }
+        }
       {#code_end#}
 
       {#see_also|comptime#}
@@ -8226,10 +8226,10 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       Sets the floating point mode of the current scope. Possible values are:
       </p>
       {#code_begin|syntax#}
-		pub const FloatMode = enum {
-		    Strict,
-		    Optimized,
-		};
+        pub const FloatMode = enum {
+            Strict,
+            Optimized,
+        };
       {#code_end#}
       <ul>
         <li>
@@ -8263,28 +8263,28 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       Sets whether runtime safety checks are enabled for the scope that contains the function call.
       </p>
       {#code_begin|test_safety|integer overflow#}
-		      {#code_release_fast#}
-		test "@setRuntimeSafety" {
-		    // The builtin applies to the scope that it is called in. So here, integer overflow
-		    // will not be caught in ReleaseFast and ReleaseSmall modes:
-		    // var x: u8 = 255;
-		    // x += 1; // undefined behavior in ReleaseFast/ReleaseSmall modes.
-		    {
-		        // However this block has safety enabled, so safety checks happen here,
-		        // even in ReleaseFast and ReleaseSmall modes.
-		        @setRuntimeSafety(true);
-		        var x: u8 = 255;
-		        x += 1;
-		
-		        {
-		            // The value can be overridden at any scope. So here integer overflow
-		            // would not be caught in any build mode.
-		            @setRuntimeSafety(false);
-		            // var x: u8 = 255;
-		            // x += 1; // undefined behavior in all build modes.
-		        }
-		    }
-		}
+              {#code_release_fast#}
+        test "@setRuntimeSafety" {
+            // The builtin applies to the scope that it is called in. So here, integer overflow
+            // will not be caught in ReleaseFast and ReleaseSmall modes:
+            // var x: u8 = 255;
+            // x += 1; // undefined behavior in ReleaseFast/ReleaseSmall modes.
+            {
+                // However this block has safety enabled, so safety checks happen here,
+                // even in ReleaseFast and ReleaseSmall modes.
+                @setRuntimeSafety(true);
+                var x: u8 = 255;
+                x += 1;
+        
+                {
+                    // The value can be overridden at any scope. So here integer overflow
+                    // would not be caught in any build mode.
+                    @setRuntimeSafety(false);
+                    // var x: u8 = 255;
+                    // x += 1; // undefined behavior in all build modes.
+                }
+            }
+        }
       {#code_end#}
       <p>Note: it is <a href="https://github.com/ziglang/zig/issues/978">planned</a> to replace
       {#syntax#}@setRuntimeSafety{#endsyntax#} with <code>@optimizeFor</code></p>
@@ -8406,15 +8406,15 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#syntax#}scalar{#endsyntax#}:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "vector @splat" {
-		    const scalar: u32 = 5;
-		    const result = @splat(4, scalar);
-		    comptime assert(@TypeOf(result) == @Vector(4, u32));
-		    assert(std.mem.eql(u32, &@as([4]u32, result), &[_]u32{ 5, 5, 5, 5 }));
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "vector @splat" {
+            const scalar: u32 = 5;
+            const result = @splat(4, scalar);
+            comptime assert(@TypeOf(result) == @Vector(4, u32));
+            assert(std.mem.eql(u32, &@as([4]u32, result), &[_]u32{ 5, 5, 5, 5 }));
+        }
       {#code_end#}
       <p>
       {#syntax#}scalar{#endsyntax#} must be an {#link|integer|Integers#}, {#link|bool|Primitive Types#},
@@ -8634,26 +8634,26 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       This can be useful for an anonymous struct that needs to refer to itself:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "@This()" {
-		    var items = [_]i32{ 1, 2, 3, 4 };
-		    const list = List(i32){ .items = items[0..] };
-		    assert(list.length() == 4);
-		}
-		
-		fn List(comptime T: type) type {
-		    return struct {
-		        const Self = @This();
-		
-		        items: []T,
-		
-		        fn length(self: Self) usize {
-		            return self.items.len;
-		        }
-		    };
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "@This()" {
+            var items = [_]i32{ 1, 2, 3, 4 };
+            const list = List(i32){ .items = items[0..] };
+            assert(list.length() == 4);
+        }
+        
+        fn List(comptime T: type) type {
+            return struct {
+                const Self = @This();
+        
+                items: []T,
+        
+                fn length(self: Self) usize {
+                    return self.items.len;
+                }
+            };
+        }
       {#code_end#}
       <p>
       When {#syntax#}@This(){#endsyntax#} is used at global scope, it returns a reference to the
@@ -8675,23 +8675,23 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       The following produces safety-checked {#link|Undefined Behavior#}:
       </p>
       {#code_begin|test_err|cast truncated bits#}
-		test "integer cast panic" {
-		    var a: u16 = 0xabcd;
-		    var b: u8 = @intCast(u8, a);
-		}
+        test "integer cast panic" {
+            var a: u16 = 0xabcd;
+            var b: u8 = @intCast(u8, a);
+        }
       {#code_end#}
       <p>
       However this is well defined and working code:
       </p>
       {#code_begin|test|truncate#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "integer truncation" {
-		    var a: u16 = 0xabcd;
-		    var b: u8 = @truncate(u8, a);
-		    assert(b == 0xcd);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "integer truncation" {
+            var a: u16 = 0xabcd;
+            var b: u8 = @truncate(u8, a);
+            assert(b == 0xcd);
+        }
       {#code_end#}
       <p>
       This function always truncates the significant bits of the integer, regardless
@@ -8787,20 +8787,20 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       The expressions are evaluated, however they are guaranteed to have no <em>runtime</em> side-effects:
       </p>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "no runtime side effects" {
-		    var data: i32 = 0;
-		    const T = @TypeOf(foo(i32, &data));
-		    comptime assert(T == i32);
-		    assert(data == 0);
-		}
-		
-		fn foo(comptime T: type, ptr: *T) T {
-		    ptr.* += 1;
-		    return ptr.*;
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "no runtime side effects" {
+            var data: i32 = 0;
+            const T = @TypeOf(foo(i32, &data));
+            comptime assert(T == i32);
+            assert(data == 0);
+        }
+        
+        fn foo(comptime T: type, ptr: *T) T {
+            ptr.* += 1;
+            return ptr.*;
+        }
       {#code_end#}
       {#header_close#}
 
@@ -8847,13 +8847,13 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       To add standard build options to a <code>build.zig</code> file:
       </p>
       {#code_begin|syntax#}
-		const Builder = @import("std").build.Builder;
-		
-		pub fn build(b: *Builder) void {
-		    const exe = b.addExecutable("example", "example.zig");
-		    exe.setBuildMode(b.standardReleaseOptions());
-		    b.default_step.dependOn(&exe.step);
-		}
+        const Builder = @import("std").build.Builder;
+        
+        pub fn build(b: *Builder) void {
+            const exe = b.addExecutable("example", "example.zig");
+            exe.setBuildMode(b.standardReleaseOptions());
+            b.default_step.dependOn(&exe.step);
+        }
       {#code_end#}
       <p>
       This causes these options to be available:
@@ -8942,29 +8942,29 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       When a safety check fails, Zig crashes with a stack trace, like this:
       </p>
       {#code_begin|test_err|reached unreachable code#}
-		test "safety check" {
-		    unreachable;
-		}
+        test "safety check" {
+            unreachable;
+        }
       {#code_end#}
 
 
       {#header_open|Reaching Unreachable Code#}
       <p>At compile-time:</p>
       {#code_begin|test_err|unable to evaluate constant expression#}
-		comptime {
-		    assert(false);
-		}
-		fn assert(ok: bool) void {
-		    if (!ok) unreachable; // assertion failure
-		}
+        comptime {
+            assert(false);
+        }
+        fn assert(ok: bool) void {
+            if (!ok) unreachable; // assertion failure
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    std.debug.assert(false);
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            std.debug.assert(false);
+        }
       {#code_end#}
       {#header_close#}
 
@@ -8972,20 +8972,20 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Index out of Bounds#}
       <p>At compile-time:</p>
       {#code_begin|test_err|index 5 outside array of size 5#}
-		comptime {
-		    const array: [5]u8 = "hello".*;
-		    const garbage = array[5];
-		}
+        comptime {
+            const array: [5]u8 = "hello".*;
+            const garbage = array[5];
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		pub fn main() void {
-		    var x = foo("hello");
-		}
-		
-		fn foo(x: []const u8) u8 {
-		    return x[5];
-		}
+        pub fn main() void {
+            var x = foo("hello");
+        }
+        
+        fn foo(x: []const u8) u8 {
+            return x[5];
+        }
       {#code_end#}
       {#header_close#}
 
@@ -8993,20 +8993,20 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Cast Negative Number to Unsigned Integer#}
       <p>At compile-time:</p>
       {#code_begin|test_err|cannot cast negative value -1 to unsigned integer type 'u32'#}
-		comptime {
-		    const value: i32 = -1;
-		    const unsigned = @intCast(u32, value);
-		}
+        comptime {
+            const value: i32 = -1;
+            const unsigned = @intCast(u32, value);
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    var value: i32 = -1;
-		    var unsigned = @intCast(u32, value);
-		    std.debug.warn("value: {}\n", .{unsigned});
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            var value: i32 = -1;
+            var unsigned = @intCast(u32, value);
+            std.debug.warn("value: {}\n", .{unsigned});
+        }
       {#code_end#}
       <p>
       To obtain the maximum value of an unsigned integer, use {#syntax#}std.math.maxInt{#endsyntax#}.
@@ -9017,20 +9017,20 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Cast Truncates Data#}
       <p>At compile-time:</p>
       {#code_begin|test_err|integer value 300 cannot be coerced to type 'u8'#}
-		comptime {
-		    const spartan_count: u16 = 300;
-		    const byte = @intCast(u8, spartan_count);
-		}
+        comptime {
+            const spartan_count: u16 = 300;
+            const byte = @intCast(u8, spartan_count);
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    var spartan_count: u16 = 300;
-		    const byte = @intCast(u8, spartan_count);
-		    std.debug.warn("value: {}\n", .{byte});
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            var spartan_count: u16 = 300;
+            const byte = @intCast(u8, spartan_count);
+            std.debug.warn("value: {}\n", .{byte});
+        }
       {#code_end#}
       <p>
       To truncate bits, use {#link|@truncate#}.
@@ -9055,20 +9055,20 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       </ul>
       <p>Example with addition at compile-time:</p>
       {#code_begin|test_err|operation caused overflow#}
-		comptime {
-		    var byte: u8 = 255;
-		    byte += 1;
-		}
+        comptime {
+            var byte: u8 = 255;
+            byte += 1;
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    var byte: u8 = 255;
-		    byte += 1;
-		    std.debug.warn("value: {}\n", .{byte});
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            var byte: u8 = 255;
+            byte += 1;
+            std.debug.warn("value: {}\n", .{byte});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9086,18 +9086,18 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       </ul>
       <p>Example of catching an overflow for addition:</p>
       {#code_begin|exe_err#}
-		const math = @import("std").math;
-		const warn = @import("std").debug.warn;
-		pub fn main() !void {
-		    var byte: u8 = 255;
-		
-		    byte = if (math.add(u8, byte, 1)) |result| result else |err| {
-		        warn("unable to add one: {}\n", .{@errorName(err)});
-		        return err;
-		    };
-		
-		    warn("result: {}\n", .{byte});
-		}
+        const math = @import("std").math;
+        const warn = @import("std").debug.warn;
+        pub fn main() !void {
+            var byte: u8 = 255;
+        
+            byte = if (math.add(u8, byte, 1)) |result| result else |err| {
+                warn("unable to add one: {}\n", .{@errorName(err)});
+                return err;
+            };
+        
+            warn("result: {}\n", .{byte});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9117,17 +9117,17 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       Example of {#link|@addWithOverflow#}:
       </p>
       {#code_begin|exe#}
-		const warn = @import("std").debug.warn;
-		pub fn main() void {
-		    var byte: u8 = 255;
-		
-		    var result: u8 = undefined;
-		    if (@addWithOverflow(u8, byte, 10, &result)) {
-		        warn("overflowed result: {}\n", .{result});
-		    } else {
-		        warn("result: {}\n", .{result});
-		    }
-		}
+        const warn = @import("std").debug.warn;
+        pub fn main() void {
+            var byte: u8 = 255;
+        
+            var result: u8 = undefined;
+            if (@addWithOverflow(u8, byte, 10, &result)) {
+                warn("overflowed result: {}\n", .{result});
+            } else {
+                warn("result: {}\n", .{result});
+            }
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9143,18 +9143,18 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
           <li>{#syntax#}*%{#endsyntax#} (wraparound multiplication)</li>
       </ul>
       {#code_begin|test#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		const minInt = std.math.minInt;
-		const maxInt = std.math.maxInt;
-		
-		test "wraparound addition and subtraction" {
-		    const x: i32 = maxInt(i32);
-		    const min_val = x +% 1;
-		    assert(min_val == minInt(i32));
-		    const max_val = min_val -% 1;
-		    assert(max_val == maxInt(i32));
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        const minInt = std.math.minInt;
+        const maxInt = std.math.maxInt;
+        
+        test "wraparound addition and subtraction" {
+            const x: i32 = maxInt(i32);
+            const min_val = x +% 1;
+            assert(min_val == minInt(i32));
+            const max_val = min_val -% 1;
+            assert(max_val == maxInt(i32));
+        }
       {#code_end#}
       {#header_close#}
       {#header_close#}
@@ -9163,19 +9163,19 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Exact Left Shift Overflow#}
       <p>At compile-time:</p>
       {#code_begin|test_err|operation caused overflow#}
-		comptime {
-		    const x = @shlExact(@as(u8, 0b01010101), 2);
-		}
+        comptime {
+            const x = @shlExact(@as(u8, 0b01010101), 2);
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    var x: u8 = 0b01010101;
-		    var y = @shlExact(x, 2);
-		    std.debug.warn("value: {}\n", .{y});
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            var x: u8 = 0b01010101;
+            var y = @shlExact(x, 2);
+            std.debug.warn("value: {}\n", .{y});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9183,19 +9183,19 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Exact Right Shift Overflow#}
       <p>At compile-time:</p>
       {#code_begin|test_err|exact shift shifted out 1 bits#}
-		comptime {
-		    const x = @shrExact(@as(u8, 0b10101010), 2);
-		}
+        comptime {
+            const x = @shrExact(@as(u8, 0b10101010), 2);
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    var x: u8 = 0b10101010;
-		    var y = @shrExact(x, 2);
-		    std.debug.warn("value: {}\n", .{y});
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            var x: u8 = 0b10101010;
+            var y = @shrExact(x, 2);
+            std.debug.warn("value: {}\n", .{y});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9203,22 +9203,22 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Division by Zero#}
       <p>At compile-time:</p>
       {#code_begin|test_err|division by zero#}
-		comptime {
-		    const a: i32 = 1;
-		    const b: i32 = 0;
-		    const c = a / b;
-		}
+        comptime {
+            const a: i32 = 1;
+            const b: i32 = 0;
+            const c = a / b;
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    var a: u32 = 1;
-		    var b: u32 = 0;
-		    var c = a / b;
-		    std.debug.warn("value: {}\n", .{c});
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            var a: u32 = 1;
+            var b: u32 = 0;
+            var c = a / b;
+            std.debug.warn("value: {}\n", .{c});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9226,22 +9226,22 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Remainder Division by Zero#}
       <p>At compile-time:</p>
       {#code_begin|test_err|division by zero#}
-		comptime {
-		    const a: i32 = 10;
-		    const b: i32 = 0;
-		    const c = a % b;
-		}
+        comptime {
+            const a: i32 = 10;
+            const b: i32 = 0;
+            const c = a % b;
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    var a: u32 = 10;
-		    var b: u32 = 0;
-		    var c = a % b;
-		    std.debug.warn("value: {}\n", .{c});
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            var a: u32 = 10;
+            var b: u32 = 0;
+            var c = a % b;
+            std.debug.warn("value: {}\n", .{c});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9249,22 +9249,22 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Exact Division Remainder#}
       <p>At compile-time:</p>
       {#code_begin|test_err|exact division had a remainder#}
-		comptime {
-		    const a: u32 = 10;
-		    const b: u32 = 3;
-		    const c = @divExact(a, b);
-		}
+        comptime {
+            const a: u32 = 10;
+            const b: u32 = 3;
+            const c = @divExact(a, b);
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    var a: u32 = 10;
-		    var b: u32 = 3;
-		    var c = @divExact(a, b);
-		    std.debug.warn("value: {}\n", .{c});
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            var a: u32 = 10;
+            var b: u32 = 3;
+            var c = @divExact(a, b);
+            std.debug.warn("value: {}\n", .{c});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9272,34 +9272,34 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Attempt to Unwrap Null#}
       <p>At compile-time:</p>
       {#code_begin|test_err|unable to unwrap null#}
-		comptime {
-		    const optional_number: ?i32 = null;
-		    const number = optional_number.?;
-		}
+        comptime {
+            const optional_number: ?i32 = null;
+            const number = optional_number.?;
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    var optional_number: ?i32 = null;
-		    var number = optional_number.?;
-		    std.debug.warn("value: {}\n", .{number});
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            var optional_number: ?i32 = null;
+            var number = optional_number.?;
+            std.debug.warn("value: {}\n", .{number});
+        }
       {#code_end#}
       <p>One way to avoid this crash is to test for null instead of assuming non-null, with
       the {#syntax#}if{#endsyntax#} expression:</p>
       {#code_begin|exe|test#}
-		const warn = @import("std").debug.warn;
-		pub fn main() void {
-		    const optional_number: ?i32 = null;
-		
-		    if (optional_number) |number| {
-		        warn("got number: {}\n", .{number});
-		    } else {
-		        warn("it's null\n", .{});
-		    }
-		}
+        const warn = @import("std").debug.warn;
+        pub fn main() void {
+            const optional_number: ?i32 = null;
+        
+            if (optional_number) |number| {
+                warn("got number: {}\n", .{number});
+            } else {
+                warn("it's null\n", .{});
+            }
+        }
       {#code_end#}
       {#see_also|Optionals#}
       {#header_close#}
@@ -9308,45 +9308,45 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Attempt to Unwrap Error#}
       <p>At compile-time:</p>
       {#code_begin|test_err|caught unexpected error 'UnableToReturnNumber'#}
-		comptime {
-		    const number = getNumberOrFail() catch unreachable;
-		}
-		
-		fn getNumberOrFail() !i32 {
-		    return error.UnableToReturnNumber;
-		}
+        comptime {
+            const number = getNumberOrFail() catch unreachable;
+        }
+        
+        fn getNumberOrFail() !i32 {
+            return error.UnableToReturnNumber;
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    const number = getNumberOrFail() catch unreachable;
-		    std.debug.warn("value: {}\n", .{number});
-		}
-		
-		fn getNumberOrFail() !i32 {
-		    return error.UnableToReturnNumber;
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            const number = getNumberOrFail() catch unreachable;
+            std.debug.warn("value: {}\n", .{number});
+        }
+        
+        fn getNumberOrFail() !i32 {
+            return error.UnableToReturnNumber;
+        }
       {#code_end#}
       <p>One way to avoid this crash is to test for an error instead of assuming a successful result, with
       the {#syntax#}if{#endsyntax#} expression:</p>
       {#code_begin|exe#}
-		const warn = @import("std").debug.warn;
-		
-		pub fn main() void {
-		    const result = getNumberOrFail();
-		
-		    if (result) |number| {
-		        warn("got number: {}\n", .{number});
-		    } else |err| {
-		        warn("got error: {}\n", .{@errorName(err)});
-		    }
-		}
-		
-		fn getNumberOrFail() !i32 {
-		    return error.UnableToReturnNumber;
-		}
+        const warn = @import("std").debug.warn;
+        
+        pub fn main() void {
+            const result = getNumberOrFail();
+        
+            if (result) |number| {
+                warn("got number: {}\n", .{number});
+            } else |err| {
+                warn("got error: {}\n", .{@errorName(err)});
+            }
+        }
+        
+        fn getNumberOrFail() !i32 {
+            return error.UnableToReturnNumber;
+        }
       {#code_end#}
       {#see_also|Errors#}
       {#header_close#}
@@ -9355,22 +9355,22 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Invalid Error Code#}
       <p>At compile-time:</p>
       {#code_begin|test_err|integer value 11 represents no error#}
-		comptime {
-		    const err = error.AnError;
-		    const number = @errorToInt(err) + 10;
-		    const invalid_err = @intToError(number);
-		}
+        comptime {
+            const err = error.AnError;
+            const number = @errorToInt(err) + 10;
+            const invalid_err = @intToError(number);
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		pub fn main() void {
-		    var err = error.AnError;
-		    var number = @errorToInt(err) + 500;
-		    var invalid_err = @intToError(number);
-		    std.debug.warn("value: {}\n", .{number});
-		}
+        const std = @import("std");
+        
+        pub fn main() void {
+            var err = error.AnError;
+            var number = @errorToInt(err) + 500;
+            var invalid_err = @intToError(number);
+            std.debug.warn("value: {}\n", .{number});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9378,31 +9378,31 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Invalid Enum Cast#}
       <p>At compile-time:</p>
       {#code_begin|test_err|has no tag matching integer value 3#}
-		const Foo = enum {
-		    A,
-		    B,
-		    C,
-		};
-		comptime {
-		    const a: u2 = 3;
-		    const b = @intToEnum(Foo, a);
-		}
+        const Foo = enum {
+            A,
+            B,
+            C,
+        };
+        comptime {
+            const a: u2 = 3;
+            const b = @intToEnum(Foo, a);
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		const Foo = enum {
-		    A,
-		    B,
-		    C,
-		};
-		
-		pub fn main() void {
-		    var a: u2 = 3;
-		    var b = @intToEnum(Foo, a);
-		    std.debug.warn("value: {}\n", .{@tagName(b)});
-		}
+        const std = @import("std");
+        
+        const Foo = enum {
+            A,
+            B,
+            C,
+        };
+        
+        pub fn main() void {
+            var a: u2 = 3;
+            var b = @intToEnum(Foo, a);
+            std.debug.warn("value: {}\n", .{@tagName(b)});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9411,37 +9411,37 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Invalid Error Set Cast#}
       <p>At compile-time:</p>
       {#code_begin|test_err|error.B not a member of error set 'Set2'#}
-		const Set1 = error{
-		    A,
-		    B,
-		};
-		const Set2 = error{
-		    A,
-		    C,
-		};
-		comptime {
-		    _ = @errSetCast(Set2, Set1.B);
-		}
+        const Set1 = error{
+            A,
+            B,
+        };
+        const Set2 = error{
+            A,
+            C,
+        };
+        comptime {
+            _ = @errSetCast(Set2, Set1.B);
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		const Set1 = error{
-		    A,
-		    B,
-		};
-		const Set2 = error{
-		    A,
-		    C,
-		};
-		pub fn main() void {
-		    foo(Set1.B);
-		}
-		fn foo(set1: Set1) void {
-		    const x = @errSetCast(Set2, set1);
-		    std.debug.warn("value: {}\n", .{x});
-		}
+        const std = @import("std");
+        
+        const Set1 = error{
+            A,
+            B,
+        };
+        const Set2 = error{
+            A,
+            C,
+        };
+        pub fn main() void {
+            foo(Set1.B);
+        }
+        fn foo(set1: Set1) void {
+            const x = @errSetCast(Set2, set1);
+            std.debug.warn("value: {}\n", .{x});
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9450,24 +9450,24 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Incorrect Pointer Alignment#}
       <p>At compile-time:</p>
       {#code_begin|test_err|pointer address 0x1 is not aligned to 4 bytes#}
-		comptime {
-		    const ptr = @intToPtr(*align(1) i32, 0x1);
-		    const aligned = @alignCast(4, ptr);
-		}
+        comptime {
+            const ptr = @intToPtr(*align(1) i32, 0x1);
+            const aligned = @alignCast(4, ptr);
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const mem = @import("std").mem;
-		pub fn main() !void {
-		    var array align(4) = [_]u32{ 0x11111111, 0x11111111 };
-		    const bytes = mem.sliceAsBytes(array[0..]);
-		    if (foo(bytes) != 0x11111111) return error.Wrong;
-		}
-		fn foo(bytes: []u8) u32 {
-		    const slice4 = bytes[1..5];
-		    const int_slice = mem.bytesAsSlice(u32, @alignCast(4, slice4));
-		    return int_slice[0];
-		}
+        const mem = @import("std").mem;
+        pub fn main() !void {
+            var array align(4) = [_]u32{ 0x11111111, 0x11111111 };
+            const bytes = mem.sliceAsBytes(array[0..]);
+            if (foo(bytes) != 0x11111111) return error.Wrong;
+        }
+        fn foo(bytes: []u8) u32 {
+            const slice4 = bytes[1..5];
+            const int_slice = mem.bytesAsSlice(u32, @alignCast(4, slice4));
+            return int_slice[0];
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9475,34 +9475,34 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_open|Wrong Union Field Access#}
       <p>At compile-time:</p>
       {#code_begin|test_err|accessing union field 'float' while field 'int' is set#}
-		comptime {
-		    var f = Foo{ .int = 42 };
-		    f.float = 12.34;
-		}
-		
-		const Foo = union {
-		    float: f32,
-		    int: u32,
-		};
+        comptime {
+            var f = Foo{ .int = 42 };
+            f.float = 12.34;
+        }
+        
+        const Foo = union {
+            float: f32,
+            int: u32,
+        };
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		const std = @import("std");
-		
-		const Foo = union {
-		    float: f32,
-		    int: u32,
-		};
-		
-		pub fn main() void {
-		    var f = Foo{ .int = 42 };
-		    bar(&f);
-		}
-		
-		fn bar(f: *Foo) void {
-		    f.float = 12.34;
-		    std.debug.warn("value: {}\n", .{f.float});
-		}
+        const std = @import("std");
+        
+        const Foo = union {
+            float: f32,
+            int: u32,
+        };
+        
+        pub fn main() void {
+            var f = Foo{ .int = 42 };
+            bar(&f);
+        }
+        
+        fn bar(f: *Foo) void {
+            f.float = 12.34;
+            std.debug.warn("value: {}\n", .{f.float});
+        }
       {#code_end#}
       <p>
       This safety is not available for {#syntax#}extern{#endsyntax#} or {#syntax#}packed{#endsyntax#} unions.
@@ -9511,45 +9511,45 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       To change the active field of a union, assign the entire union, like this:
       </p>
       {#code_begin|exe#}
-		const std = @import("std");
-		
-		const Foo = union {
-		    float: f32,
-		    int: u32,
-		};
-		
-		pub fn main() void {
-		    var f = Foo{ .int = 42 };
-		    bar(&f);
-		}
-		
-		fn bar(f: *Foo) void {
-		    f.* = Foo{ .float = 12.34 };
-		    std.debug.warn("value: {}\n", .{f.float});
-		}
+        const std = @import("std");
+        
+        const Foo = union {
+            float: f32,
+            int: u32,
+        };
+        
+        pub fn main() void {
+            var f = Foo{ .int = 42 };
+            bar(&f);
+        }
+        
+        fn bar(f: *Foo) void {
+            f.* = Foo{ .float = 12.34 };
+            std.debug.warn("value: {}\n", .{f.float});
+        }
       {#code_end#}
       <p>
       To change the active field of a union when a meaningful value for the field is not known,
       use {#link|undefined#}, like this:
       </p>
       {#code_begin|exe#}
-		const std = @import("std");
-		
-		const Foo = union {
-		    float: f32,
-		    int: u32,
-		};
-		
-		pub fn main() void {
-		    var f = Foo{ .int = 42 };
-		    f = Foo{ .float = undefined };
-		    bar(&f);
-		    std.debug.warn("value: {}\n", .{f.float});
-		}
-		
-		fn bar(f: *Foo) void {
-		    f.float = 12.34;
-		}
+        const std = @import("std");
+        
+        const Foo = union {
+            float: f32,
+            int: u32,
+        };
+        
+        pub fn main() void {
+            var f = Foo{ .int = 42 };
+            f = Foo{ .float = undefined };
+            bar(&f);
+            std.debug.warn("value: {}\n", .{f.float});
+        }
+        
+        fn bar(f: *Foo) void {
+            f.float = 12.34;
+        }
       {#code_end#}
       {#see_also|union|extern union#}
       {#header_close#}
@@ -9570,17 +9570,17 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       </p>
       <p>At compile-time:</p>
       {#code_begin|test_err|null pointer casted to type#}
-		comptime {
-		    const opt_ptr: ?*i32 = null;
-		    const ptr = @ptrCast(*i32, opt_ptr);
-		}
+        comptime {
+            const opt_ptr: ?*i32 = null;
+            const ptr = @ptrCast(*i32, opt_ptr);
+        }
       {#code_end#}
       <p>At runtime:</p>
       {#code_begin|exe_err#}
-		pub fn main() void {
-		    var opt_ptr: ?*i32 = null;
-		    var ptr = @ptrCast(*i32, opt_ptr);
-		}
+        pub fn main() void {
+            var opt_ptr: ?*i32 = null;
+            var ptr = @ptrCast(*i32, opt_ptr);
+        }
       {#code_end#}
       {#header_close#}
 
@@ -9606,23 +9606,23 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       their initialization functions:
       </p>
       {#code_begin|test|allocator#}
-		const std = @import("std");
-		const Allocator = std.mem.Allocator;
-		const assert = std.debug.assert;
-		
-		test "using an allocator" {
-		    var buffer: [100]u8 = undefined;
-		    const allocator = &std.heap.FixedBufferAllocator.init(&buffer).allocator;
-		    const result = try concat(allocator, "foo", "bar");
-		    assert(std.mem.eql(u8, "foobar", result));
-		}
-		
-		fn concat(allocator: *Allocator, a: []const u8, b: []const u8) ![]u8 {
-		    const result = try allocator.alloc(u8, a.len + b.len);
-		    std.mem.copy(u8, result, a);
-		    std.mem.copy(u8, result[a.len..], b);
-		    return result;
-		}
+        const std = @import("std");
+        const Allocator = std.mem.Allocator;
+        const assert = std.debug.assert;
+        
+        test "using an allocator" {
+            var buffer: [100]u8 = undefined;
+            const allocator = &std.heap.FixedBufferAllocator.init(&buffer).allocator;
+            const result = try concat(allocator, "foo", "bar");
+            assert(std.mem.eql(u8, "foobar", result));
+        }
+        
+        fn concat(allocator: *Allocator, a: []const u8, b: []const u8) ![]u8 {
+            const result = try allocator.alloc(u8, a.len + b.len);
+            std.mem.copy(u8, result, a);
+            std.mem.copy(u8, result[a.len..], b);
+            return result;
+        }
       {#code_end#}
       <p>
       In the above example, 100 bytes of stack memory are used to initialize a
@@ -9663,17 +9663,17 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
               such that it would make sense to free everything at once at the end?
               In this case, it is recommended to follow this pattern:
               {#code_begin|exe|cli_allocation#}
-		const std = @import("std");
-		
-		pub fn main() !void {
-		    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-		    defer arena.deinit();
-		
-		    const allocator = &arena.allocator;
-		
-		    const ptr = try allocator.create(i32);
-		    std.debug.warn("ptr={*}\n", .{ptr});
-		}
+        const std = @import("std");
+        
+        pub fn main() !void {
+            var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+            defer arena.deinit();
+        
+            const allocator = &arena.allocator;
+        
+            const ptr = try allocator.create(i32);
+            std.debug.warn("ptr={*}\n", .{ptr});
+        }
               {#code_end#}
               When using this kind of allocator, there is no need to free anything manually. Everything
               gets freed at once with the call to {#syntax#}arena.deinit(){#endsyntax#}.
@@ -9707,19 +9707,19 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       This is why it is an error to pass a string literal to a mutable slice, like this:
       </p>
       {#code_begin|test_err|expected type '[]u8'#}
-		fn foo(s: []u8) void {}
-		
-		test "string literal to mutable slice" {
-		    foo("hello");
-		}
+        fn foo(s: []u8) void {}
+        
+        test "string literal to mutable slice" {
+            foo("hello");
+        }
       {#code_end#}
       <p>However if you make the slice constant, then it works:</p>
       {#code_begin|test|strlit#}
-		fn foo(s: []const u8) void {}
-		
-		test "string literal to constant slice" {
-		    foo("hello");
-		}
+        fn foo(s: []const u8) void {}
+        
+        test "string literal to constant slice" {
+            foo("hello");
+        }
       {#code_end#}
       <p>
       Just like string literals, `const` declarations, when the value is known at {#link|comptime#},
@@ -9862,8 +9862,8 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       compile-time constants such as the current target, endianness, and release mode.
       </p>
       {#code_begin|syntax#}
-		const builtin = @import("builtin");
-		const separator = if (builtin.os == builtin.Os.windows) '\\' else '/';
+        const builtin = @import("builtin");
+        const separator = if (builtin.os == builtin.Os.windows) '\\' else '/';
       {#code_end#}
       <p>
       Example of what is imported with {#syntax#}@import("builtin"){#endsyntax#}:
@@ -9891,13 +9891,13 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       is available for code to detect whether the current build is a test build.
       </p>
       {#code_begin|test|detect_test#}
-		const std = @import("std");
-		const builtin = std.builtin;
-		const assert = std.debug.assert;
-		
-		test "builtin.is_test" {
-		    assert(builtin.is_test);
-		}
+        const std = @import("std");
+        const builtin = std.builtin;
+        const assert = std.debug.assert;
+        
+        test "builtin.is_test" {
+            assert(builtin.is_test);
+        }
       {#code_end#}
       <p>
       Zig has lazy top level declaration analysis, which means that if a function is not called,
@@ -9905,10 +9905,10 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       compile error in a function because it is never called.
       </p>
       {#code_begin|test|unused_fn#}
-		fn unused() i32 {
-		    return "wrong return type";
-		}
-		test "unused function" { }
+        fn unused() i32 {
+            return "wrong return type";
+        }
+        test "unused function" { }
       {#code_end#}
       <p>
       Note that, while in {#link|Debug#} and {#link|ReleaseSafe#} modes, {#link|unreachable#} emits a
@@ -9917,21 +9917,21 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       simple as:
       </p>
       {#code_begin|syntax#}
-		pub fn assert(ok: bool) void {
-		    if (!ok) unreachable;
-		}
+        pub fn assert(ok: bool) void {
+            if (!ok) unreachable;
+        }
       {#code_end#}
       <p>
       This means that when testing in ReleaseFast or ReleaseSmall mode, {#syntax#}assert{#endsyntax#}
       is not sufficient to check the result of a computation:
       </p>
       {#code_begin|syntax#}
-		const std = @import("std");
-		const assert = std.debug.assert;
-		
-		test "assert in release fast mode" {
-		    assert(false);
-		}
+        const std = @import("std");
+        const assert = std.debug.assert;
+        
+        test "assert in release fast mode" {
+            assert(false);
+        }
       {#code_end#}
       <p>
       When compiling this test in {#link|ReleaseFast#} mode, it invokes unchecked
@@ -9942,13 +9942,13 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       Better practice for checking the output when testing is to use {#syntax#}std.testing.expect{#endsyntax#}:
       </p>
       {#code_begin|test_err|test failure#}
-		      {#code_release_fast#}
-		const std = @import("std");
-		const expect = std.testing.expect;
-		
-		test "assert in release fast mode" {
-		    expect(false);
-		}
+              {#code_release_fast#}
+        const std = @import("std");
+        const expect = std.testing.expect;
+        
+        test "assert in release fast mode" {
+            expect(false);
+        }
       {#code_end#}
       <p>See the rest of the {#syntax#}std.testing{#endsyntax#} namespace for more available functions.</p>
       <p>
@@ -10005,15 +10005,15 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       to directly import symbols from .h files:
       </p>
       {#code_begin|exe#}
-		      {#link_libc#}
-		const c = @cImport({
-		    // See https://github.com/ziglang/zig/issues/515
-		    @cDefine("_NO_CRT_STDIO_INLINE", "1");
-		    @cInclude("stdio.h");
-		});
-		pub fn main() void {
-		    _ = c.printf("hello\n");
-		}
+              {#link_libc#}
+        const c = @cImport({
+            // See https://github.com/ziglang/zig/issues/515
+            @cDefine("_NO_CRT_STDIO_INLINE", "1");
+            @cInclude("stdio.h");
+        });
+        pub fn main() void {
+            _ = c.printf("hello\n");
+        }
       {#code_end#}
       <p>
       The {#syntax#}@cImport{#endsyntax#} function takes an expression as a parameter.
@@ -10021,19 +10021,19 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       preprocessor directives and include multiple .h files:
       </p>
       {#code_begin|syntax#}
-		const builtin = @import("builtin");
-		
-		const c = @cImport({
-		    @cDefine("NDEBUG", builtin.mode == .ReleaseFast);
-		    if (something) {
-		        @cDefine("_GNU_SOURCE", {});
-		    }
-		    @cInclude("stdlib.h");
-		    if (something) {
-		        @cUndef("_GNU_SOURCE");
-		    }
-		    @cInclude("soundio.h");
-		});
+        const builtin = @import("builtin");
+        
+        const c = @cImport({
+            @cDefine("NDEBUG", builtin.mode == .ReleaseFast);
+            if (something) {
+                @cDefine("_GNU_SOURCE", {});
+            }
+            @cInclude("stdlib.h");
+            if (something) {
+                @cUndef("_GNU_SOURCE");
+            }
+            @cInclude("soundio.h");
+        });
       {#code_end#}
       {#see_also|@cImport|@cInclude|@cDefine|@cUndef|@import#}
       {#header_close#}
@@ -10086,9 +10086,9 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       </p>
       <p class="file">mathtest.zig</p>
       {#code_begin|syntax#}
-		export fn add(a: i32, b: i32) i32 {
-		    return a + b;
-		}
+        export fn add(a: i32, b: i32) i32 {
+            return a + b;
+        }
       {#code_end#}
       <p>To make a static library:</p>
       <pre><code class="shell">$ zig build-lib mathtest.zig
@@ -10109,23 +10109,23 @@ int main(int argc, char **argv) {
 }</code></pre>
       <p class="file">build.zig</p>
       {#code_begin|syntax#}
-		const Builder = @import("std").build.Builder;
-		
-		pub fn build(b: *Builder) void {
-		    const lib = b.addSharedLibrary("mathtest", "mathtest.zig", b.version(1, 0, 0));
-		
-		    const exe = b.addExecutable("test", null);
-		    exe.addCSourceFile("test.c", &[_][]const u8{"-std=c99"});
-		    exe.linkLibrary(lib);
-		    exe.linkSystemLibrary("c");
-		
-		    b.default_step.dependOn(&exe.step);
-		
-		    const run_cmd = exe.run();
-		
-		    const test_step = b.step("test", "Test the program");
-		    test_step.dependOn(&run_cmd.step);
-		}
+        const Builder = @import("std").build.Builder;
+        
+        pub fn build(b: *Builder) void {
+            const lib = b.addSharedLibrary("mathtest", "mathtest.zig", b.version(1, 0, 0));
+        
+            const exe = b.addExecutable("test", null);
+            exe.addCSourceFile("test.c", &[_][]const u8{"-std=c99"});
+            exe.linkLibrary(lib);
+            exe.linkSystemLibrary("c");
+        
+            b.default_step.dependOn(&exe.step);
+        
+            const run_cmd = exe.run();
+        
+            const test_step = b.step("test", "Test the program");
+            test_step.dependOn(&run_cmd.step);
+        }
       {#code_end#}
       <p class="file">terminal</p>
       <pre><code class="shell">$ zig build test
@@ -10141,21 +10141,21 @@ int main(int argc, char **argv) {
       </p>
       <p class="file">base64.zig</p>
       {#code_begin|syntax#}
-		const base64 = @import("std").base64;
-		
-		export fn decode_base_64(
-		    dest_ptr: [*]u8,
-		    dest_len: usize,
-		    source_ptr: [*]const u8,
-		    source_len: usize,
-		) usize {
-		    const src = source_ptr[0..source_len];
-		    const dest = dest_ptr[0..dest_len];
-		    const base64_decoder = base64.standard_decoder_unsafe;
-		    const decoded_size = base64_decoder.calcSize(src);
-		    base64_decoder.decode(dest[0..decoded_size], src);
-		    return decoded_size;
-		}
+        const base64 = @import("std").base64;
+        
+        export fn decode_base_64(
+            dest_ptr: [*]u8,
+            dest_len: usize,
+            source_ptr: [*]const u8,
+            source_len: usize,
+        ) usize {
+            const src = source_ptr[0..source_len];
+            const dest = dest_ptr[0..dest_len];
+            const base64_decoder = base64.standard_decoder_unsafe;
+            const decoded_size = base64_decoder.calcSize(src);
+            base64_decoder.decode(dest[0..decoded_size], src);
+            return decoded_size;
+        }
       {#code_end#}
       <p class="file">test.c</p>
       <pre><code class="cpp">// This header is generated by zig from base64.zig
@@ -10176,17 +10176,17 @@ int main(int argc, char **argv) {
 }</code></pre>
       <p class="file">build.zig</p>
       {#code_begin|syntax#}
-		const Builder = @import("std").build.Builder;
-		
-		pub fn build(b: *Builder) void {
-		    const obj = b.addObject("base64", "base64.zig");
-		
-		    const exe = b.addExecutable("test", null);
-		    exe.addCSourceFile("test.c", &[_][]const u8{"-std=c99"});
-		    exe.addObject(obj);
-		    exe.linkSystemLibrary("c");
-		    exe.install();
-		}
+        const Builder = @import("std").build.Builder;
+        
+        pub fn build(b: *Builder) void {
+            const obj = b.addObject("base64", "base64.zig");
+        
+            const exe = b.addExecutable("test", null);
+            exe.addCSourceFile("test.c", &[_][]const u8{"-std=c99"});
+            exe.addObject(obj);
+            exe.linkSystemLibrary("c");
+            exe.install();
+        }
       {#code_end#}
       <p class="file">terminal</p>
       <pre><code class="shell">$ zig build
@@ -10205,12 +10205,12 @@ all your base are belong to us</code></pre>
       <p>For host environments like the web browser and nodejs, build as a library using the freestanding OS target.
       Here's an example of running Zig code compiled to WebAssembly with nodejs.</p>
       {#code_begin|lib|math#}
-		      {#target_wasm#}
-		extern fn print(i32) void;
-		
-		export fn add(a: i32, b: i32) void {
-		    print(a + b);
-		}
+              {#target_wasm#}
+        extern fn print(i32) void;
+        
+        export fn add(a: i32, b: i32) void {
+            print(a + b);
+        }
       {#code_end#}
       {#header_close#}
       <p class="file">test.js</p>
@@ -10233,18 +10233,18 @@ The result is 3</code></pre>
       <p>Zig's support for WebAssembly System Interface (WASI) is under active development.
       Example of using the standard library and reading command line arguments:</p>
       {#code_begin|exe|wasi#}
-		      {#target_wasi#}
-		const std = @import("std");
-		
-		pub fn main() !void {
-		    // TODO a better default allocator that isn't as wasteful!
-		    const args = try std.process.argsAlloc(std.heap.page_allocator);
-		    defer std.process.argsFree(std.heap.page_allocator, args);
-		
-		    for (args) |arg, i| {
-		        std.debug.warn("{}: {}\n", .{i, arg});
-		    }
-		}
+              {#target_wasi#}
+        const std = @import("std");
+        
+        pub fn main() !void {
+            // TODO a better default allocator that isn't as wasteful!
+            const args = try std.process.argsAlloc(std.heap.page_allocator);
+            defer std.process.argsFree(std.heap.page_allocator, args);
+        
+            for (args) |arg, i| {
+                std.debug.warn("{}: {}\n", .{i, arg});
+            }
+        }
       {#code_end#}
      <pre><code>$ wasmer run wasi.wasm 123 hello
 0: wasi.wasm
@@ -10578,48 +10578,48 @@ coding style.
 
       {#header_open|Examples#}
       {#code_begin|syntax#}
-		const namespace_name = @import("dir_name/file_name.zig");
-		var global_var: i32 = undefined;
-		const const_name = 42;
-		const primitive_type_alias = f32;
-		const string_alias = []u8;
-		
-		const StructName = struct {
-		    field: i32,
-		};
-		const StructAlias = StructName;
-		
-		fn functionName(param_name: TypeName) void {
-		    var functionPointer = functionName;
-		    functionPointer();
-		    functionPointer = otherFunction;
-		    functionPointer();
-		}
-		const functionAlias = functionName;
-		
-		fn ListTemplateFunction(comptime ChildType: type, comptime fixed_size: usize) type {
-		    return List(ChildType, fixed_size);
-		}
-		
-		fn ShortList(comptime T: type, comptime n: usize) type {
-		    return struct {
-		        field_name: [n]T,
-		        fn methodName() void {}
-		    };
-		}
-		
-		// The word XML loses its casing when used in Zig identifiers.
-		const xml_document =
-		    \\<?xml version="1.0" encoding="UTF-8"?>
-		    \\<document>
-		    \\</document>
-		;
-		const XmlParser = struct {
-		    field: i32,
-		};
-		
-		// The initials BE (Big Endian) are just another word in Zig identifier names.
-		fn readU32Be() u32 {}
+        const namespace_name = @import("dir_name/file_name.zig");
+        var global_var: i32 = undefined;
+        const const_name = 42;
+        const primitive_type_alias = f32;
+        const string_alias = []u8;
+        
+        const StructName = struct {
+            field: i32,
+        };
+        const StructAlias = StructName;
+        
+        fn functionName(param_name: TypeName) void {
+            var functionPointer = functionName;
+            functionPointer();
+            functionPointer = otherFunction;
+            functionPointer();
+        }
+        const functionAlias = functionName;
+        
+        fn ListTemplateFunction(comptime ChildType: type, comptime fixed_size: usize) type {
+            return List(ChildType, fixed_size);
+        }
+        
+        fn ShortList(comptime T: type, comptime n: usize) type {
+            return struct {
+                field_name: [n]T,
+                fn methodName() void {}
+            };
+        }
+        
+        // The word XML loses its casing when used in Zig identifiers.
+        const xml_document =
+            \\<?xml version="1.0" encoding="UTF-8"?>
+            \\<document>
+            \\</document>
+        ;
+        const XmlParser = struct {
+            field: i32,
+        };
+        
+        // The initials BE (Big Endian) are just another word in Zig identifier names.
+        fn readU32Be() u32 {}
       {#code_end#}
       <p>
       See the Zig Standard Library for more examples.


### PR DESCRIPTION
Not really a significant change on its own, but greatly improves source readability and facilitates further edits.