### PR TITLE
stage1: Fix several bugs in constant generation

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -858,10 +858,12 @@ ZigType *get_slice_type(CodeGen *g, ZigType *ptr_type) {
     entry->data.structure.fields[slice_ptr_index]->type_entry = ptr_type;
     entry->data.structure.fields[slice_ptr_index]->src_index = slice_ptr_index;
     entry->data.structure.fields[slice_ptr_index]->gen_index = 0;
+    entry->data.structure.fields[slice_ptr_index]->offset = 0;
     entry->data.structure.fields[slice_len_index]->name = len_field_name;
     entry->data.structure.fields[slice_len_index]->type_entry = g->builtin_types.entry_usize;
     entry->data.structure.fields[slice_len_index]->src_index = slice_len_index;
     entry->data.structure.fields[slice_len_index]->gen_index = 1;
+    entry->data.structure.fields[slice_len_index]->offset = ptr_type->abi_size;
 
     entry->data.structure.fields_by_name.put(ptr_field_name, entry->data.structure.fields[slice_ptr_index]);
     entry->data.structure.fields_by_name.put(len_field_name, entry->data.structure.fields[slice_len_index]);

--- a/test/stage1/behavior/optional.zig
+++ b/test/stage1/behavior/optional.zig
@@ -1,4 +1,7 @@
-const expect = @import("std").testing.expect;
+const std = @import("std");
+const testing = std.testing;
+const expect = testing.expect;
+const expectEqual = testing.expectEqual;
 
 pub const EmptyStruct = struct {};
 
@@ -197,4 +200,36 @@ test "0-bit child type coerced to optional" {
     };
     S.doTheTest();
     comptime S.doTheTest();
+}
+
+test "array of optional unaligned types" {
+    const Enum = enum { one, two, three };
+
+    const SomeUnion = union(enum) {
+        Num: Enum,
+        Other: u32,
+    };
+
+    const values = [_]?SomeUnion{
+        SomeUnion{ .Num = .one },
+        SomeUnion{ .Num = .two },
+        SomeUnion{ .Num = .three },
+        SomeUnion{ .Num = .one },
+        SomeUnion{ .Num = .two },
+        SomeUnion{ .Num = .three },
+    };
+
+    // The index must be a runtime value
+    var i: usize = 0;
+    expectEqual(Enum.one, values[i].?.Num);
+    i += 1;
+    expectEqual(Enum.two, values[i].?.Num);
+    i += 1;
+    expectEqual(Enum.three, values[i].?.Num);
+    i += 1;
+    expectEqual(Enum.one, values[i].?.Num);
+    i += 1;
+    expectEqual(Enum.two, values[i].?.Num);
+    i += 1;
+    expectEqual(Enum.three, values[i].?.Num);
 }

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -825,3 +825,19 @@ test "self-referencing struct via array member" {
     x = T{ .children = .{&x} };
     expect(x.children[0] == &x);
 }
+
+test "struct with union field" {
+    const Value = struct {
+        ref: u32 = 2,
+        kind: union(enum) {
+            None: usize,
+            Bool: bool,
+        },
+    };
+
+    var True = Value{
+        .kind = .{ .Bool = true },
+    };
+    expectEqual(@as(u32, 2), True.ref);
+    expectEqual(true, True.kind.Bool);
+}


### PR DESCRIPTION
The codegen would sometimes change the LLVM type for some constants to
an unnamed structure in order to accomodate extra padding. This is fine
as long as the alignment of each field is still respected and it was not
the case for structure types, leading to ill-formed constants being
generated.

Optional types suffer from this to a lower extent as their layout is
quite lucky, the only missing piece was the tail padding.

Closes #4530
Closes #4594
Closes #4295
Closes my will to live