### PR TITLE
Update ziggurat.zig to use `random.int(u64)`

### DIFF
--- a/lib/std/rand/ziggurat.zig
+++ b/lib/std/rand/ziggurat.zig
@@ -16,7 +16,7 @@ pub fn next_f64(random: *Random, comptime tables: ZigTable) f64 {
     while (true) {
         // We manually construct a float from parts as we can avoid an extra random lookup here by
         // using the unused exponent for the lookup table entry.
-        const bits = random.scalar(u64);
+        const bits = random.int(u64);
         const i = @as(usize, bits & 0xff);
 
         const u = blk: {


### PR DESCRIPTION
Ziggurat rng was using deprecated `random.scalar(u64)` which was causing compile errors on calls to public facing stdlib APIs (randExp) on 0.6+, this fixed those errors.

Fixes https://github.com/ziglang/zig/issues/5084