### PR TITLE
make zig work on OSX via `-DZIG_WORKAROUND_4799=ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(ZIG_STATIC off CACHE BOOL "Attempt to build a static zig executable (not com
 set(ZIG_STATIC_LLVM off CACHE BOOL "Prefer linking against static LLVM libraries")
 set(ZIG_ENABLE_MEM_PROFILE off CACHE BOOL "Activate memory usage instrumentation")
 set(ZIG_PREFER_CLANG_CPP_DYLIB off CACHE BOOL "Try to link against -lclang-cpp")
+set(ZIG_WORKAROUND_4799 off CACHE BOOL "workaround for https://github.com/ziglang/zig/issues/4799")
 
 if(ZIG_STATIC)
     set(ZIG_STATIC_LLVM "on")
@@ -75,6 +76,11 @@ if(APPLE AND ZIG_STATIC)
     list(REMOVE_ITEM LLVM_LIBRARIES "-lz")
     find_library(ZLIB NAMES z zlib libz)
     list(APPEND LLVM_LIBRARIES "${ZLIB}")
+endif()
+
+if(APPLE AND ZIG_WORKAROUND_4799)
+  # eg: ${CMAKE_PREFIX_PATH} could be /usr/local/opt/llvm/
+  list(APPEND LLVM_LIBRARIES "-Wl,${CMAKE_PREFIX_PATH}/lib/libPolly.a" "-Wl,${CMAKE_PREFIX_PATH}/lib/libPollyPPCG.a" "-Wl,${CMAKE_PREFIX_PATH}/lib/libPollyISL.a")
 endif()
 
 set(ZIG_CPP_LIB_DIR "${CMAKE_BINARY_DIR}/zig_cpp")
@@ -380,6 +386,7 @@ add_library(zig_cpp STATIC ${ZIG_CPP_SOURCES})
 set_target_properties(zig_cpp PROPERTIES
     COMPILE_FLAGS ${EXE_CFLAGS}
 )
+
 target_link_libraries(zig_cpp LINK_PUBLIC
     ${CLANG_LIBRARIES}
     ${LLD_LIBRARIES}

--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ brew outdated llvm || brew upgrade llvm
 mkdir build
 cd build
 cmake .. -DCMAKE_PREFIX_PATH=$(brew --prefix llvm)
-make install
+make -j install
 ```
 
 You will now run into this issue:
 [homebrew and llvm 10 packages in apt.llvm.org are broken with undefined reference to getPollyPluginInfo](https://github.com/ziglang/zig/issues/4799)
+or this https://github.com/ziglang/zig/issues/5055, in which case try `-DZIG_WORKAROUND_4799=ON`
+
 
 Please help upstream LLVM and Homebrew solve this issue, there is nothing Zig
 can do about it. See that issue for a workaround you can do in the meantime.


### PR DESCRIPTION
@andrewrk 
* refs https://github.com/ziglang/zig/issues/5055
* refs https://github.com/ziglang/zig/issues/4799
(what i suggested in https://github.com/ziglang/zig/issues/5055#issuecomment-615518280)
after merging, could you tag a release (minor or patch, not sure) so that homebrew formula can avoid having to either patch or build from some arbitrary hash and instead use a tag?