### PR TITLE
fix uninitialized ZigValue

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -524,9 +524,10 @@ struct ZigValue {
         RuntimeHintSlice rh_slice;
     } data;
 
-    // uncomment these to find bugs. can't leave them uncommented because of a gcc-9 warning
-    //ZigValue(const ZigValue &other) = delete; // plz zero initialize with {}
+    // uncomment this to find bugs. can't leave it uncommented because of a gcc-9 warning
     //ZigValue& operator= (const ZigValue &other) = delete; // use copy_const_val
+
+    ZigValue(const ZigValue &other) = delete; // plz zero initialize with ZigValue val = {};
 
     // for use in debuggers
     void dump();

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -17009,7 +17009,7 @@ static IrInstGen *ir_analyze_bit_shift(IrAnalyze *ira, IrInstSrcBinOp *bin_op_in
             if (op2_val == nullptr)
                 return ira->codegen->invalid_inst_gen;
 
-            ZigValue bit_count_value;
+            ZigValue bit_count_value = {};
             init_const_usize(ira->codegen, &bit_count_value, bit_count);
 
             if (!value_cmp_numeric_val_all(op2_val, CmpLT, &bit_count_value)) {


### PR DESCRIPTION
Also uncomment deletion of the copy constructor that uncovered this bug.
It's the `operator=` that is generating warnings.