### PR TITLE
stage1: Handle errors when generating block IR

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -4610,7 +4610,9 @@ bool resolve_inferred_error_set(CodeGen *g, ZigType *err_set_type, AstNode *sour
             return false;
         } else if (infer_fn->anal_state == FnAnalStateReady) {
             analyze_fn_body(g, infer_fn);
-            if (err_set_type->data.error_set.incomplete) {
+            if (infer_fn->anal_state == FnAnalStateInvalid ||
+                err_set_type->data.error_set.incomplete)
+            {
                 assert(g->errors.length != 0);
                 return false;
             }

--- a/src/ast_render.cpp
+++ b/src/ast_render.cpp
@@ -571,7 +571,7 @@ static void render_node_extra(AstRender *ar, AstNode *node, bool grouped) {
             {
                 const char *defer_str = defer_string(node->data.defer.kind);
                 fprintf(ar->f, "%s ", defer_str);
-                render_node_grouped(ar, node->data.return_expr.expr);
+                render_node_grouped(ar, node->data.defer.expr);
                 break;
             }
         case NodeTypeVariableDeclaration:


### PR DESCRIPTION
Closes #5005

No idea on how to reproduce the error with less code.

No idea what `statement_value != irb->codegen->invalid_inst_src` was meant to do, there are no comments and git blame points to commits without an explanation.