### PR TITLE
std: fix posix Thread.spawn to accept all startFn types

### DIFF
--- a/lib/std/thread.zig
+++ b/lib/std/thread.zig
@@ -266,9 +266,7 @@ pub const Thread = struct {
                         if (info.bits != 8) {
                             @compileError(bad_startfn_ret);
                         }
-                        // pthreads don't support exit status, ignore value
-                        _ = startFn(arg);
-                        return null;
+                        return @intToPtr(?*c_void, startFn(arg));
                     },
                     .ErrorUnion => |info| {
                         if (info.payload != void) {


### PR DESCRIPTION
It seems posix implementation of `std.Thread.spawn()` doesn't accept all the different `startFn` types as windows and linux implementations do. Eg. if I have `startFn` that returns `!void`, it works on windows, but on osx compiler gives me this:
```
/Users/mitkus/bin/zig/lib/zig/std/thread.zig:259:32: error: error is discarded
                    _ = startFn(@ptrCast(*const Context, @alignCast(@alignOf(Context), ctx)).*);
```

This PR fixes this by using mostly the same `startFn` invoke logic as other platforms.