### PR TITLE
Remove old-style @typeOf compatibility

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -114,17 +114,6 @@ test "zig fmt: trailing comma in fn parameter list" {
     );
 }
 
-// TODO: Remove condition after deprecating 'typeOf'. See https://github.com/ziglang/zig/issues/1348
-test "zig fmt: change @typeOf to @TypeOf" {
-    try testTransform(
-        \\const a = @typeOf(@as(usize, 10));
-        \\
-    ,
-        \\const a = @TypeOf(@as(usize, 10));
-        \\
-    );
-}
-
 // TODO: Remove nakedcc/stdcallcc once zig 0.6.0 is released. See https://github.com/ziglang/zig/pull/3977
 test "zig fmt: convert extern/nakedcc/stdcallcc into callconv(...)" {
     try testTransform(

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1359,12 +1359,7 @@ fn renderExpression(
         .BuiltinCall => {
             const builtin_call = @fieldParentPtr(ast.Node.BuiltinCall, "base", base);
 
-            // TODO: Remove condition after deprecating 'typeOf'. See https://github.com/ziglang/zig/issues/1348
-            if (mem.eql(u8, tree.tokenSlicePtr(tree.tokens.at(builtin_call.builtin_token)), "@typeOf")) {
-                try stream.writeAll("@TypeOf");
-            } else {
-                try renderToken(tree, stream, builtin_call.builtin_token, indent, start_col, Space.None); // @name
-            }
+            try renderToken(tree, stream, builtin_call.builtin_token, indent, start_col, Space.None); // @name
 
             const src_params_trailing_comma = blk: {
                 if (builtin_call.params.len < 2) break :blk false;


### PR DESCRIPTION
This PR removes zig fmt compatibility for old-style `@typeOf`.
Related to #3875
Closes #1348