### PR TITLE
stage1: Prevent the creation of illegal pointer types

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -578,6 +578,7 @@ ZigType *get_pointer_to_type_extra2(CodeGen *g, ZigType *child_type, bool is_con
     }
     switch (ptr_len) {
         case PtrLenSingle:
+            assert(sentinel == nullptr);
             buf_appendf(&entry->name, "*");
             break;
         case PtrLenUnknown:

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -21078,7 +21078,7 @@ static ZigType *adjust_ptr_len(CodeGen *g, ZigType *ptr_type, PtrLen ptr_len) {
             ptr_type->data.pointer.allow_zero,
             ptr_type->data.pointer.vector_index,
             ptr_type->data.pointer.inferred_struct_field,
-            ptr_type->data.pointer.sentinel);
+            (ptr_len != PtrLenUnknown) ? nullptr : ptr_type->data.pointer.sentinel);
 }
 
 static ZigType *adjust_ptr_allow_zero(CodeGen *g, ZigType *ptr_type, bool allow_zero) {

--- a/test/stage1/behavior/pointers.zig
+++ b/test/stage1/behavior/pointers.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
-const expect = std.testing.expect;
-const expectError = std.testing.expectError;
+const testing = std.testing;
+const expect = testing.expect;
+const expectError = testing.expectError;
 
 test "dereference pointer" {
     comptime testDerefPtr();
@@ -330,4 +331,9 @@ test "@ptrToInt on null optional at comptime" {
         const pointer = @intToPtr(?*u8, 0xf00);
         comptime expect(0xf00 == @ptrToInt(pointer));
     }
+}
+
+test "indexing array with sentinel returns correct type" {
+    var s: [:0]const u8 = "abc";
+    testing.expectEqualSlices(u8, "*const u8", @typeName(@TypeOf(&s[0])));
 }


### PR DESCRIPTION
Changing the pointer length from Unknown to Single/C now resets the
sentinel value too.

Closes #5134