### PR TITLE
beginnings of (non-LLVM) self-hosted machine code generation and linking

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1345,8 +1345,10 @@ pub const Dir = struct {
         mode: File.Mode = File.default_mode,
     };
 
-    /// `dest_path` must remain valid for the lifetime of `AtomicFile`.
-    /// Call `AtomicFile.finish` to atomically replace `dest_path` with contents.
+    /// Directly access the `.file` field, and then call `AtomicFile.finish`
+    /// to atomically replace `dest_path` with contents.
+    /// Always call `AtomicFile.deinit` to clean up, regardless of whether `AtomicFile.finish` succeeded.
+    /// `dest_path` must remain valid until `AtomicFile.deinit` is called.
     pub fn atomicFile(self: Dir, dest_path: []const u8, options: AtomicFileOptions) !AtomicFile {
         if (path.dirname(dest_path)) |dirname| {
             const dir = try self.openDir(dirname, .{});

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -93,7 +93,7 @@ pub const File = struct {
         /// This means that a process that does not respect the locking API can still get access
         /// to the file, despite the lock.
         ///
-        /// Windows' file locks are mandatory, and any process attempting to access the file will
+        /// Windows's file locks are mandatory, and any process attempting to access the file will
         /// receive an error.
         ///
         /// [1]: https://www.kernel.org/doc/Documentation/filesystems/mandatory-locking.txt

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2027,7 +2027,13 @@ test "sliceAsBytes and bytesAsSlice back" {
 /// Round an address up to the nearest aligned address
 /// The alignment must be a power of 2 and greater than 0.
 pub fn alignForward(addr: usize, alignment: usize) usize {
-    return alignBackward(addr + (alignment - 1), alignment);
+    return alignForwardGeneric(usize, addr, alignment);
+}
+
+/// Round an address up to the nearest aligned address
+/// The alignment must be a power of 2 and greater than 0.
+pub fn alignForwardGeneric(comptime T: type, addr: T, alignment: T) T {
+    return alignBackwardGeneric(T, addr + (alignment - 1), alignment);
 }
 
 test "alignForward" {
@@ -2048,7 +2054,13 @@ test "alignForward" {
 /// Round an address up to the previous aligned address
 /// The alignment must be a power of 2 and greater than 0.
 pub fn alignBackward(addr: usize, alignment: usize) usize {
-    assert(@popCount(usize, alignment) == 1);
+    return alignBackwardGeneric(usize, addr, alignment);
+}
+
+/// Round an address up to the previous aligned address
+/// The alignment must be a power of 2 and greater than 0.
+pub fn alignBackwardGeneric(comptime T: type, addr: T, alignment: T) T {
+    assert(@popCount(T, alignment) == 1);
     // 000010000 // example addr
     // 000001111 // subtract 1
     // 111110000 // binary not

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2061,7 +2061,7 @@ pub fn alignBackward(addr: usize, alignment: usize) usize {
 /// The alignment must be a power of 2 and greater than 0.
 pub fn alignBackwardGeneric(comptime T: type, addr: T, alignment: T) T {
     assert(@popCount(T, alignment) == 1);
-    // 000010000 // example addr
+    // 000010000 // example alignment
     // 000001111 // subtract 1
     // 111110000 // binary not
     return addr & ~(alignment - 1);

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -378,8 +378,8 @@ const Function = struct {
                             return self.fail(src, "TODO handle a larger string constant", .{});
 
                         // Emit the string literal directly into the code; jump over it.
-                        const offset = self.code.items.len;
                         try self.genRelativeFwdJump(src, smaller_len);
+                        const offset = self.code.items.len;
                         try self.code.appendSlice(bytes);
                         return MCValue{ .embedded_in_code = offset };
                     },

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -4,6 +4,7 @@ const assert = std.debug.assert;
 const ir = @import("ir.zig");
 const Type = @import("type.zig").Type;
 const Value = @import("value.zig").Value;
+const Target = std.Target;
 
 pub const ErrorMsg = struct {
     byte_offset: usize,
@@ -69,6 +70,9 @@ const Function = struct {
         immediate: u64,
         /// The constant was emitted into the code, at this offset.
         embedded_in_code: usize,
+        /// The value is in a target-specific register. The value can
+        /// be @intToEnum casted to the respective Reg enum.
+        register: usize,
     };
 
     fn genFuncInst(self: *Function, inst: *ir.Inst) !MCValue {
@@ -108,14 +112,9 @@ const Function = struct {
                     try self.code.resize(self.code.items.len + 2);
                     self.code.items[self.code.items.len - 2] = 0xeb;
                     self.code.items[self.code.items.len - 1] = @intCast(u8, amount);
-                } else if (amount <= std.math.maxInt(u16)) {
-                    try self.code.resize(self.code.items.len + 3);
-                    self.code.items[self.code.items.len - 3] = 0xe9; // jmp rel16
-                    const imm_ptr = self.code.items[self.code.items.len - 2 ..][0..2];
-                    mem.writeIntLittle(u16, imm_ptr, @intCast(u16, amount));
                 } else {
                     try self.code.resize(self.code.items.len + 5);
-                    self.code.items[self.code.items.len - 5] = 0xea; // jmp rel32
+                    self.code.items[self.code.items.len - 5] = 0xe9; // jmp rel32
                     const imm_ptr = self.code.items[self.code.items.len - 4 ..][0..4];
                     mem.writeIntLittle(u32, imm_ptr, amount);
                 }
@@ -125,7 +124,104 @@ const Function = struct {
     }
 
     fn genAsm(self: *Function, inst: *ir.Inst.Assembly) !MCValue {
-        return self.fail(inst.base.src, "TODO machine code gen assembly", .{});
+        // TODO convert to inline function
+        switch (self.module.target.cpu.arch) {
+            .arm => return self.genAsmArch(.arm, inst),
+            .armeb => return self.genAsmArch(.armeb, inst),
+            .aarch64 => return self.genAsmArch(.aarch64, inst),
+            .aarch64_be => return self.genAsmArch(.aarch64_be, inst),
+            .aarch64_32 => return self.genAsmArch(.aarch64_32, inst),
+            .arc => return self.genAsmArch(.arc, inst),
+            .avr => return self.genAsmArch(.avr, inst),
+            .bpfel => return self.genAsmArch(.bpfel, inst),
+            .bpfeb => return self.genAsmArch(.bpfeb, inst),
+            .hexagon => return self.genAsmArch(.hexagon, inst),
+            .mips => return self.genAsmArch(.mips, inst),
+            .mipsel => return self.genAsmArch(.mipsel, inst),
+            .mips64 => return self.genAsmArch(.mips64, inst),
+            .mips64el => return self.genAsmArch(.mips64el, inst),
+            .msp430 => return self.genAsmArch(.msp430, inst),
+            .powerpc => return self.genAsmArch(.powerpc, inst),
+            .powerpc64 => return self.genAsmArch(.powerpc64, inst),
+            .powerpc64le => return self.genAsmArch(.powerpc64le, inst),
+            .r600 => return self.genAsmArch(.r600, inst),
+            .amdgcn => return self.genAsmArch(.amdgcn, inst),
+            .riscv32 => return self.genAsmArch(.riscv32, inst),
+            .riscv64 => return self.genAsmArch(.riscv64, inst),
+            .sparc => return self.genAsmArch(.sparc, inst),
+            .sparcv9 => return self.genAsmArch(.sparcv9, inst),
+            .sparcel => return self.genAsmArch(.sparcel, inst),
+            .s390x => return self.genAsmArch(.s390x, inst),
+            .tce => return self.genAsmArch(.tce, inst),
+            .tcele => return self.genAsmArch(.tcele, inst),
+            .thumb => return self.genAsmArch(.thumb, inst),
+            .thumbeb => return self.genAsmArch(.thumbeb, inst),
+            .i386 => return self.genAsmArch(.i386, inst),
+            .x86_64 => return self.genAsmArch(.x86_64, inst),
+            .xcore => return self.genAsmArch(.xcore, inst),
+            .nvptx => return self.genAsmArch(.nvptx, inst),
+            .nvptx64 => return self.genAsmArch(.nvptx64, inst),
+            .le32 => return self.genAsmArch(.le32, inst),
+            .le64 => return self.genAsmArch(.le64, inst),
+            .amdil => return self.genAsmArch(.amdil, inst),
+            .amdil64 => return self.genAsmArch(.amdil64, inst),
+            .hsail => return self.genAsmArch(.hsail, inst),
+            .hsail64 => return self.genAsmArch(.hsail64, inst),
+            .spir => return self.genAsmArch(.spir, inst),
+            .spir64 => return self.genAsmArch(.spir64, inst),
+            .kalimba => return self.genAsmArch(.kalimba, inst),
+            .shave => return self.genAsmArch(.shave, inst),
+            .lanai => return self.genAsmArch(.lanai, inst),
+            .wasm32 => return self.genAsmArch(.wasm32, inst),
+            .wasm64 => return self.genAsmArch(.wasm64, inst),
+            .renderscript32 => return self.genAsmArch(.renderscript32, inst),
+            .renderscript64 => return self.genAsmArch(.renderscript64, inst),
+            .ve => return self.genAsmArch(.ve, inst),
+        }
+    }
+
+    fn genAsmArch(self: *Function, comptime arch: Target.Cpu.Arch, inst: *ir.Inst.Assembly) !MCValue {
+        if (arch != .x86_64 and arch != .i386) {
+            return self.fail(inst.base.src, "TODO implement inline asm support for more architectures", .{});
+        }
+        if (!mem.eql(u8, inst.args.asm_source, "syscall")) {
+            return self.fail(inst.base.src, "TODO implement support for more x86 assembly instructions", .{});
+        }
+        for (inst.args.inputs) |input, i| {
+            if (input.len < 3 or input[0] != '{' or input[input.len - 1] != '}') {
+                return self.fail(inst.base.src, "unrecognized asm input constraint: '{}'", .{input});
+            }
+            const reg_name = input[1 .. input.len - 1];
+            const reg = parseRegName(arch, reg_name) orelse
+                return self.fail(inst.base.src, "unrecognized register: '{}'", .{reg_name});
+            const arg = try self.resolveInst(inst.args.args[i]);
+            try self.genSetReg(inst.base.src, arch, reg, arg);
+        }
+
+        if (inst.args.output) |output| {
+            if (output.len < 4 or output[0] != '=' or output[1] != '{' or output[output.len - 1] != '}') {
+                return self.fail(inst.base.src, "unrecognized asm output constraint: '{}'", .{output});
+            }
+            const reg_name = output[2 .. output.len - 1];
+            const reg = parseRegName(arch, reg_name) orelse
+                return self.fail(inst.base.src, "unrecognized register: '{}'", .{reg_name});
+            return MCValue{ .register = @enumToInt(reg) };
+        } else {
+            return MCValue.none;
+        }
+    }
+
+    fn genSetReg(self: *Function, src: usize, comptime arch: Target.Cpu.Arch, reg: Reg(arch), mcv: MCValue) !void {
+        switch (arch) {
+            .x86_64 => switch (reg) {
+                .rax => return self.fail(src, "TODO implement genSetReg for x86_64 'rax'", .{}),
+                .rdi => return self.fail(src, "TODO implement genSetReg for x86_64 'rdi'", .{}),
+                .rsi => return self.fail(src, "TODO implement genSetReg for x86_64 'rsi'", .{}),
+                .rdx => return self.fail(src, "TODO implement genSetReg for x86_64 'rdx'", .{}),
+                else => return self.fail(src, "TODO implement genSetReg for x86_64 '{}'", .{@tagName(reg)}),
+            },
+            else => return self.fail(src, "TODO implement genSetReg for more architectures", .{}),
+        }
     }
 
     fn genPtrToInt(self: *Function, inst: *ir.Inst.PtrToInt) !MCValue {
@@ -192,3 +288,112 @@ const Function = struct {
         return error.CodegenFail;
     }
 };
+
+fn Reg(comptime arch: Target.Cpu.Arch) type {
+    return switch (arch) {
+        .i386 => enum {
+            eax,
+            ebx,
+            ecx,
+            edx,
+            ebp,
+            esp,
+            esi,
+            edi,
+
+            ax,
+            bx,
+            cx,
+            dx,
+            bp,
+            sp,
+            si,
+            di,
+
+            ah,
+            bh,
+            ch,
+            dh,
+
+            al,
+            bl,
+            cl,
+            dl,
+        },
+        .x86_64 => enum {
+            rax,
+            rbx,
+            rcx,
+            rdx,
+            rbp,
+            rsp,
+            rsi,
+            rdi,
+            r8,
+            r9,
+            r10,
+            r11,
+            r12,
+            r13,
+            r14,
+            r15,
+
+            eax,
+            ebx,
+            ecx,
+            edx,
+            ebp,
+            esp,
+            esi,
+            edi,
+            r8d,
+            r9d,
+            r10d,
+            r11d,
+            r12d,
+            r13d,
+            r14d,
+            r15d,
+
+            ax,
+            bx,
+            cx,
+            dx,
+            bp,
+            sp,
+            si,
+            di,
+            r8w,
+            r9w,
+            r10w,
+            r11w,
+            r12w,
+            r13w,
+            r14w,
+            r15w,
+
+            ah,
+            bh,
+            ch,
+            dh,
+
+            al,
+            bl,
+            cl,
+            dl,
+            r8b,
+            r9b,
+            r10b,
+            r11b,
+            r12b,
+            r13b,
+            r14b,
+            r15b,
+        },
+        else => @compileError("TODO add more register enums"),
+    };
+}
+
+fn parseRegName(comptime arch: Target.Cpu.Arch, name: []const u8) ?Reg(arch) {
+    return std.meta.stringToEnum(Reg(arch), name);
+}

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -1,447 +1,137 @@
 const std = @import("std");
-const Compilation = @import("compilation.zig").Compilation;
-const llvm = @import("llvm.zig");
-const c = @import("c.zig");
-const ir = @import("ir.zig");
-const Value = @import("value.zig").Value;
-const Type = @import("type.zig").Type;
-const Scope = @import("scope.zig").Scope;
-const util = @import("util.zig");
-const event = std.event;
+const mem = std.mem;
 const assert = std.debug.assert;
-const DW = std.dwarf;
-const maxInt = std.math.maxInt;
+const ir = @import("ir.zig");
+const Type = @import("type.zig").Type;
+const Value = @import("value.zig").Value;
 
-pub async fn renderToLlvm(comp: *Compilation, fn_val: *Value.Fn, code: *ir.Code) Compilation.BuildError!void {
-    fn_val.base.ref();
-    defer fn_val.base.deref(comp);
-    defer code.destroy(comp.gpa());
+pub const ErrorMsg = struct {
+    byte_offset: usize,
+    msg: []const u8,
+};
 
-    var output_path = try comp.createRandomOutputPath(comp.target.oFileExt());
-    errdefer output_path.deinit();
+pub const Symbol = struct {
+    errors: []ErrorMsg,
 
-    const llvm_handle = try comp.zig_compiler.getAnyLlvmContext();
-    defer llvm_handle.release(comp.zig_compiler);
-
-    const context = llvm_handle.node.data;
-
-    const module = llvm.ModuleCreateWithNameInContext(comp.name.span(), context) orelse return error.OutOfMemory;
-    defer llvm.DisposeModule(module);
-
-    llvm.SetTarget(module, comp.llvm_triple.span());
-    llvm.SetDataLayout(module, comp.target_layout_str);
-
-    if (comp.target.getObjectFormat() == .coff) {
-        llvm.AddModuleCodeViewFlag(module);
-    } else {
-        llvm.AddModuleDebugInfoFlag(module);
-    }
-
-    const builder = llvm.CreateBuilderInContext(context) orelse return error.OutOfMemory;
-    defer llvm.DisposeBuilder(builder);
-
-    const dibuilder = llvm.CreateDIBuilder(module, true) orelse return error.OutOfMemory;
-    defer llvm.DisposeDIBuilder(dibuilder);
-
-    // Don't use ZIG_VERSION_STRING here. LLVM misparses it when it includes
-    // the git revision.
-    const producer = try std.fmt.allocPrintZ(&code.arena.allocator, "zig {}.{}.{}", .{
-        @as(u32, c.ZIG_VERSION_MAJOR),
-        @as(u32, c.ZIG_VERSION_MINOR),
-        @as(u32, c.ZIG_VERSION_PATCH),
-    });
-    const flags = "";
-    const runtime_version = 0;
-    const compile_unit_file = llvm.CreateFile(
-        dibuilder,
-        comp.name.span(),
-        comp.root_package.root_src_dir.span(),
-    ) orelse return error.OutOfMemory;
-    const is_optimized = comp.build_mode != .Debug;
-    const compile_unit = llvm.CreateCompileUnit(
-        dibuilder,
-        DW.LANG_C99,
-        compile_unit_file,
-        producer,
-        is_optimized,
-        flags,
-        runtime_version,
-        "",
-        0,
-        !comp.strip,
-    ) orelse return error.OutOfMemory;
-
-    var ofile = ObjectFile{
-        .comp = comp,
-        .module = module,
-        .builder = builder,
-        .dibuilder = dibuilder,
-        .context = context,
-        .lock = event.Lock.init(),
-        .arena = &code.arena.allocator,
-    };
-
-    try renderToLlvmModule(&ofile, fn_val, code);
-
-    // TODO module level assembly
-    //if (buf_len(&g->global_asm) != 0) {
-    //    LLVMSetModuleInlineAsm(g->module, buf_ptr(&g->global_asm));
-    //}
-
-    llvm.DIBuilderFinalize(dibuilder);
-
-    if (comp.verbose_llvm_ir) {
-        std.debug.warn("raw module:\n", .{});
-        llvm.DumpModule(ofile.module);
-    }
-
-    // verify the llvm module when safety is on
-    if (std.debug.runtime_safety) {
-        var error_ptr: ?[*:0]u8 = null;
-        _ = llvm.VerifyModule(ofile.module, llvm.AbortProcessAction, &error_ptr);
-    }
-
-    const is_small = comp.build_mode == .ReleaseSmall;
-    const is_debug = comp.build_mode == .Debug;
-
-    var err_msg: [*:0]u8 = undefined;
-    // TODO integrate this with evented I/O
-    if (llvm.TargetMachineEmitToFile(
-        comp.target_machine,
-        module,
-        output_path.span(),
-        llvm.EmitBinary,
-        &err_msg,
-        is_debug,
-        is_small,
-    )) {
-        if (std.debug.runtime_safety) {
-            std.debug.panic("unable to write object file {}: {s}\n", .{ output_path.span(), err_msg });
+    pub fn deinit(self: *Symbol, allocator: *mem.Allocator) void {
+        for (self.errors) |err| {
+            allocator.free(err.msg);
         }
-        return error.WritingObjectFileFailed;
-    }
-    //validate_inline_fns(g); TODO
-    fn_val.containing_object = output_path;
-    if (comp.verbose_llvm_ir) {
-        std.debug.warn("optimized module:\n", .{});
-        llvm.DumpModule(ofile.module);
-    }
-    if (comp.verbose_link) {
-        std.debug.warn("created {}\n", .{output_path.span()});
-    }
-}
-
-pub const ObjectFile = struct {
-    comp: *Compilation,
-    module: *llvm.Module,
-    builder: *llvm.Builder,
-    dibuilder: *llvm.DIBuilder,
-    context: *llvm.Context,
-    lock: event.Lock,
-    arena: *std.mem.Allocator,
-
-    fn gpa(self: *ObjectFile) *std.mem.Allocator {
-        return self.comp.gpa();
+        allocator.free(self.errors);
+        self.* = undefined;
     }
 };
 
-pub fn renderToLlvmModule(ofile: *ObjectFile, fn_val: *Value.Fn, code: *ir.Code) !void {
-    // TODO audit more of codegen.cpp:fn_llvm_value and port more logic
-    const llvm_fn_type = try fn_val.base.typ.getLlvmType(ofile.arena, ofile.context);
-    const llvm_fn = llvm.AddFunction(
-        ofile.module,
-        fn_val.symbol_name.span(),
-        llvm_fn_type,
-    ) orelse return error.OutOfMemory;
+pub fn generateSymbol(typed_value: ir.TypedValue, module: ir.Module, code: *std.ArrayList(u8)) !Symbol {
+    switch (typed_value.ty.zigTypeTag()) {
+        .Fn => {
+            const index = typed_value.val.cast(Value.Payload.Function).?.index;
+            const module_fn = module.fns[index];
 
-    const want_fn_safety = fn_val.block_scope.?.safety.get(ofile.comp);
-    if (want_fn_safety and ofile.comp.haveLibC()) {
-        try addLLVMFnAttr(ofile, llvm_fn, "sspstrong");
-        try addLLVMFnAttrStr(ofile, llvm_fn, "stack-protector-buffer-size", "4");
-    }
+            var function = Function{
+                .module = &module,
+                .mod_fn = &module_fn,
+                .code = code,
+                .inst_table = std.AutoHashMap(*ir.Inst, Function.MCValue).init(code.allocator),
+                .errors = std.ArrayList(ErrorMsg).init(code.allocator),
+                .constants = std.ArrayList(ir.TypedValue).init(code.allocator),
+            };
+            defer function.inst_table.deinit();
+            defer function.errors.deinit();
 
-    // TODO
-    //if (fn_val.align_stack) |align_stack| {
-    //    try addLLVMFnAttrInt(ofile, llvm_fn, "alignstack", align_stack);
-    //}
-
-    const fn_type = fn_val.base.typ.cast(Type.Fn).?;
-    const fn_type_normal = &fn_type.key.data.Normal;
-
-    try addLLVMFnAttr(ofile, llvm_fn, "nounwind");
-    //add_uwtable_attr(g, fn_table_entry->llvm_value);
-    try addLLVMFnAttr(ofile, llvm_fn, "nobuiltin");
-
-    //if (g->build_mode == BuildModeDebug && fn_table_entry->fn_inline != FnInlineAlways) {
-    //    ZigLLVMAddFunctionAttr(fn_table_entry->llvm_value, "no-frame-pointer-elim", "true");
-    //    ZigLLVMAddFunctionAttr(fn_table_entry->llvm_value, "no-frame-pointer-elim-non-leaf", nullptr);
-    //}
-
-    //if (fn_table_entry->section_name) {
-    //    LLVMSetSection(fn_table_entry->llvm_value, buf_ptr(fn_table_entry->section_name));
-    //}
-    //if (fn_table_entry->align_bytes > 0) {
-    //    LLVMSetAlignment(fn_table_entry->llvm_value, (unsigned)fn_table_entry->align_bytes);
-    //} else {
-    //    // We'd like to set the best alignment for the function here, but on Darwin LLVM gives
-    //    // "Cannot getTypeInfo() on a type that is unsized!" assertion failure when calling
-    //    // any of the functions for getting alignment. Not specifying the alignment should
-    //    // use the ABI alignment, which is fine.
-    //}
-
-    //if (!type_has_bits(return_type)) {
-    //    // nothing to do
-    //} else if (type_is_codegen_pointer(return_type)) {
-    //    addLLVMAttr(fn_table_entry->llvm_value, 0, "nonnull");
-    //} else if (handle_is_ptr(return_type) &&
-    //        calling_convention_does_first_arg_return(fn_type->data.fn.fn_type_id.cc))
-    //{
-    //    addLLVMArgAttr(fn_table_entry->llvm_value, 0, "sret");
-    //    addLLVMArgAttr(fn_table_entry->llvm_value, 0, "nonnull");
-    //}
-
-    // TODO set parameter attributes
-
-    // TODO
-    //uint32_t err_ret_trace_arg_index = get_err_ret_trace_arg_index(g, fn_table_entry);
-    //if (err_ret_trace_arg_index != UINT32_MAX) {
-    //    addLLVMArgAttr(fn_table_entry->llvm_value, (unsigned)err_ret_trace_arg_index, "nonnull");
-    //}
-
-    const cur_ret_ptr = if (fn_type_normal.return_type.handleIsPtr()) llvm.GetParam(llvm_fn, 0) else null;
-
-    // build all basic blocks
-    for (code.basic_block_list.span()) |bb| {
-        bb.llvm_block = llvm.AppendBasicBlockInContext(
-            ofile.context,
-            llvm_fn,
-            bb.name_hint,
-        ) orelse return error.OutOfMemory;
-    }
-    const entry_bb = code.basic_block_list.at(0);
-    llvm.PositionBuilderAtEnd(ofile.builder, entry_bb.llvm_block);
-
-    llvm.ClearCurrentDebugLocation(ofile.builder);
-
-    // TODO set up error return tracing
-    // TODO allocate temporary stack values
-
-    const var_list = fn_type.non_key.Normal.variable_list.span();
-    // create debug variable declarations for variables and allocate all local variables
-    for (var_list) |var_scope, i| {
-        const var_type = switch (var_scope.data) {
-            .Const => unreachable,
-            .Param => |param| param.typ,
-        };
-        //    if (!type_has_bits(var->value->type)) {
-        //        continue;
-        //    }
-        //    if (ir_get_var_is_comptime(var))
-        //        continue;
-        //    if (type_requires_comptime(var->value->type))
-        //        continue;
-        //    if (var->src_arg_index == SIZE_MAX) {
-        //        var->value_ref = build_alloca(g, var->value->type, buf_ptr(&var->name), var->align_bytes);
-
-        //        var->di_loc_var = ZigLLVMCreateAutoVariable(g->dbuilder, get_di_scope(g, var->parent_scope),
-        //                buf_ptr(&var->name), import->di_file, (unsigned)(var->decl_node->line + 1),
-        //                var->value->type->di_type, !g->strip_debug_symbols, 0);
-
-        //    } else {
-        // it's a parameter
-        //        assert(var->gen_arg_index != SIZE_MAX);
-        //        TypeTableEntry *gen_type;
-        //        FnGenParamInfo *gen_info = &fn_table_entry->type_entry->data.fn.gen_param_info[var->src_arg_index];
-
-        if (var_type.handleIsPtr()) {
-            //            if (gen_info->is_byval) {
-            //                gen_type = var->value->type;
-            //            } else {
-            //                gen_type = gen_info->type;
-            //            }
-            var_scope.data.Param.llvm_value = llvm.GetParam(llvm_fn, @intCast(c_uint, i));
-        } else {
-            //            gen_type = var->value->type;
-            var_scope.data.Param.llvm_value = try renderAlloca(ofile, var_type, var_scope.name, .Abi);
-        }
-        //        if (var->decl_node) {
-        //            var->di_loc_var = ZigLLVMCreateParameterVariable(g->dbuilder, get_di_scope(g, var->parent_scope),
-        //                    buf_ptr(&var->name), import->di_file,
-        //                    (unsigned)(var->decl_node->line + 1),
-        //                    gen_type->di_type, !g->strip_debug_symbols, 0, (unsigned)(var->gen_arg_index + 1));
-        //        }
-
-        //    }
-    }
-
-    // TODO finishing error return trace setup. we have to do this after all the allocas.
-
-    // create debug variable declarations for parameters
-    // rely on the first variables in the variable_list being parameters.
-    //size_t next_var_i = 0;
-    for (fn_type.key.data.Normal.params) |param, i| {
-        //FnGenParamInfo *info = &fn_table_entry->type_entry->data.fn.gen_param_info[param_i];
-        //if (info->gen_index == SIZE_MAX)
-        //    continue;
-        const scope_var = var_list[i];
-        //assert(variable->src_arg_index != SIZE_MAX);
-        //next_var_i += 1;
-        //assert(variable);
-        //assert(variable->value_ref);
-
-        if (!param.typ.handleIsPtr()) {
-            //clear_debug_source_node(g);
-            const llvm_param = llvm.GetParam(llvm_fn, @intCast(c_uint, i));
-            _ = try renderStoreUntyped(
-                ofile,
-                llvm_param,
-                scope_var.data.Param.llvm_value,
-                .Abi,
-                .Non,
-            );
-        }
-
-        //if (variable->decl_node) {
-        //    gen_var_debug_decl(g, variable);
-        //}
-    }
-
-    for (code.basic_block_list.span()) |current_block| {
-        llvm.PositionBuilderAtEnd(ofile.builder, current_block.llvm_block);
-        for (current_block.instruction_list.span()) |instruction| {
-            if (instruction.ref_count == 0 and !instruction.hasSideEffects()) continue;
-
-            instruction.llvm_value = try instruction.render(ofile, fn_val);
-        }
-        current_block.llvm_exit_block = llvm.GetInsertBlock(ofile.builder);
+            for (module_fn.body) |inst| {
+                const new_inst = function.genFuncInst(inst) catch |err| switch (err) {
+                    error.CodegenFail => {
+                        assert(function.errors.items.len != 0);
+                        break;
+                    },
+                    else => |e| return e,
+                };
+                try function.inst_table.putNoClobber(inst, new_inst);
+            }
+            return Symbol{ .errors = function.errors.toOwnedSlice() };
+        },
+        else => @panic("TODO implement generateSymbol for non-function types"),
     }
 }
 
-fn addLLVMAttr(
-    ofile: *ObjectFile,
-    val: *llvm.Value,
-    attr_index: llvm.AttributeIndex,
-    attr_name: []const u8,
-) !void {
-    const kind_id = llvm.GetEnumAttributeKindForName(attr_name.ptr, attr_name.len);
-    assert(kind_id != 0);
-    const llvm_attr = llvm.CreateEnumAttribute(ofile.context, kind_id, 0) orelse return error.OutOfMemory;
-    llvm.AddAttributeAtIndex(val, attr_index, llvm_attr);
-}
+const Function = struct {
+    module: *const ir.Module,
+    mod_fn: *const ir.Module.Fn,
+    code: *std.ArrayList(u8),
+    inst_table: std.AutoHashMap(*ir.Inst, MCValue),
+    /// Constants are embedded within functions (at the end, after `ret`)
+    /// so that they are independently updateable.
+    /// This is a list of constants that must be appended to the symbol after `ret`.
+    constants: std.ArrayList(ir.TypedValue),
+    errors: std.ArrayList(ErrorMsg),
 
-fn addLLVMAttrStr(
-    ofile: *ObjectFile,
-    val: *llvm.Value,
-    attr_index: llvm.AttributeIndex,
-    attr_name: []const u8,
-    attr_val: []const u8,
-) !void {
-    const llvm_attr = llvm.CreateStringAttribute(
-        ofile.context,
-        attr_name.ptr,
-        @intCast(c_uint, attr_name.len),
-        attr_val.ptr,
-        @intCast(c_uint, attr_val.len),
-    ) orelse return error.OutOfMemory;
-    llvm.AddAttributeAtIndex(val, attr_index, llvm_attr);
-}
-
-fn addLLVMAttrInt(
-    val: *llvm.Value,
-    attr_index: llvm.AttributeIndex,
-    attr_name: []const u8,
-    attr_val: u64,
-) !void {
-    const kind_id = llvm.GetEnumAttributeKindForName(attr_name.ptr, attr_name.len);
-    assert(kind_id != 0);
-    const llvm_attr = llvm.CreateEnumAttribute(ofile.context, kind_id, attr_val) orelse return error.OutOfMemory;
-    llvm.AddAttributeAtIndex(val, attr_index, llvm_attr);
-}
-
-fn addLLVMFnAttr(ofile: *ObjectFile, fn_val: *llvm.Value, attr_name: []const u8) !void {
-    return addLLVMAttr(ofile, fn_val, maxInt(llvm.AttributeIndex), attr_name);
-}
-
-fn addLLVMFnAttrStr(ofile: *ObjectFile, fn_val: *llvm.Value, attr_name: []const u8, attr_val: []const u8) !void {
-    return addLLVMAttrStr(ofile, fn_val, maxInt(llvm.AttributeIndex), attr_name, attr_val);
-}
-
-fn addLLVMFnAttrInt(ofile: *ObjectFile, fn_val: *llvm.Value, attr_name: []const u8, attr_val: u64) !void {
-    return addLLVMAttrInt(ofile, fn_val, maxInt(llvm.AttributeIndex), attr_name, attr_val);
-}
-
-fn renderLoadUntyped(
-    ofile: *ObjectFile,
-    ptr: *llvm.Value,
-    alignment: Type.Pointer.Align,
-    vol: Type.Pointer.Vol,
-    name: [*:0]const u8,
-) !*llvm.Value {
-    const result = llvm.BuildLoad(ofile.builder, ptr, name) orelse return error.OutOfMemory;
-    switch (vol) {
-        .Non => {},
-        .Volatile => llvm.SetVolatile(result, 1),
-    }
-    llvm.SetAlignment(result, resolveAlign(ofile, alignment, llvm.GetElementType(llvm.TypeOf(ptr))));
-    return result;
-}
-
-fn renderLoad(ofile: *ObjectFile, ptr: *llvm.Value, ptr_type: *Type.Pointer, name: [*:0]const u8) !*llvm.Value {
-    return renderLoadUntyped(ofile, ptr, ptr_type.key.alignment, ptr_type.key.vol, name);
-}
-
-pub fn getHandleValue(ofile: *ObjectFile, ptr: *llvm.Value, ptr_type: *Type.Pointer) !?*llvm.Value {
-    const child_type = ptr_type.key.child_type;
-    if (!child_type.hasBits()) {
-        return null;
-    }
-    if (child_type.handleIsPtr()) {
-        return ptr;
-    }
-    return try renderLoad(ofile, ptr, ptr_type, "");
-}
-
-pub fn renderStoreUntyped(
-    ofile: *ObjectFile,
-    value: *llvm.Value,
-    ptr: *llvm.Value,
-    alignment: Type.Pointer.Align,
-    vol: Type.Pointer.Vol,
-) !*llvm.Value {
-    const result = llvm.BuildStore(ofile.builder, value, ptr) orelse return error.OutOfMemory;
-    switch (vol) {
-        .Non => {},
-        .Volatile => llvm.SetVolatile(result, 1),
-    }
-    llvm.SetAlignment(result, resolveAlign(ofile, alignment, llvm.TypeOf(value)));
-    return result;
-}
-
-pub fn renderStore(
-    ofile: *ObjectFile,
-    value: *llvm.Value,
-    ptr: *llvm.Value,
-    ptr_type: *Type.Pointer,
-) !*llvm.Value {
-    return renderStoreUntyped(ofile, value, ptr, ptr_type.key.alignment, ptr_type.key.vol);
-}
-
-pub fn renderAlloca(
-    ofile: *ObjectFile,
-    var_type: *Type,
-    name: []const u8,
-    alignment: Type.Pointer.Align,
-) !*llvm.Value {
-    const llvm_var_type = try var_type.getLlvmType(ofile.arena, ofile.context);
-    const name_with_null = try std.cstr.addNullByte(ofile.arena, name);
-    const result = llvm.BuildAlloca(ofile.builder, llvm_var_type, @ptrCast([*:0]const u8, name_with_null.ptr)) orelse return error.OutOfMemory;
-    llvm.SetAlignment(result, resolveAlign(ofile, alignment, llvm_var_type));
-    return result;
-}
-
-pub fn resolveAlign(ofile: *ObjectFile, alignment: Type.Pointer.Align, llvm_type: *llvm.Type) u32 {
-    return switch (alignment) {
-        .Abi => return llvm.ABIAlignmentOfType(ofile.comp.target_data_ref, llvm_type),
-        .Override => |a| a,
+    const MCValue = union(enum) {
+        none,
+        unreach,
+        /// A pointer-sized integer that fits in a register.
+        immediate: u64,
+        /// Refers to the index into `constants` field of `Function`.
+        local_const_ptr: usize,
     };
-}
+
+    fn genFuncInst(self: *Function, inst: *ir.Inst) !MCValue {
+        switch (inst.tag) {
+            .unreach => return self.genPanic(inst.src),
+            .constant => unreachable, // excluded from function bodies
+            .assembly => return self.genAsm(inst.cast(ir.Inst.Assembly).?),
+            .ptrtoint => return self.genPtrToInt(inst.cast(ir.Inst.PtrToInt).?),
+        }
+    }
+
+    fn genPanic(self: *Function, src: usize) !MCValue {
+        // TODO change this to call the panic function
+        switch (self.module.target.cpu.arch) {
+            .i386, .x86_64 => {
+                try self.code.append(0xcc); // x86 int3
+            },
+            else => return self.fail(src, "TODO implement panic for {}", .{self.module.target.cpu.arch}),
+        }
+        return .unreach;
+    }
+
+    fn genAsm(self: *Function, inst: *ir.Inst.Assembly) !MCValue {
+        return self.fail(inst.base.src, "TODO machine code gen assembly", .{});
+    }
+
+    fn genPtrToInt(self: *Function, inst: *ir.Inst.PtrToInt) !MCValue {
+        // no-op
+        return self.resolveInst(inst.args.ptr);
+    }
+
+    fn resolveInst(self: *Function, inst: *ir.Inst) !MCValue {
+        if (inst.cast(ir.Inst.Constant)) |const_inst| {
+            switch (inst.ty.zigTypeTag()) {
+                .Int => {
+                    const info = inst.ty.intInfo(self.module.target);
+                    const ptr_bits = self.module.target.cpu.arch.ptrBitWidth();
+                    if (info.bits > ptr_bits or info.signed) {
+                        return self.fail(inst.src, "TODO const int bigger than ptr and signed int", .{});
+                    }
+                    return MCValue{ .immediate = const_inst.val.toUnsignedInt() };
+                },
+                else => return self.fail(inst.src, "TODO implement const of type '{}'", .{inst.ty}),
+            }
+        } else {
+            return self.inst_table.getValue(inst).?;
+        }
+    }
+
+    fn fail(self: *Function, src: usize, comptime format: []const u8, args: var) error{ CodegenFail, OutOfMemory } {
+        @setCold(true);
+        const msg = try std.fmt.allocPrint(self.errors.allocator, format, args);
+        {
+            errdefer self.errors.allocator.free(msg);
+            (try self.errors.addOne()).* = .{
+                .byte_offset = src,
+                .msg = msg,
+            };
+        }
+        return error.CodegenFail;
+    }
+};

--- a/src-self-hosted/ir.zig
+++ b/src-self-hosted/ir.zig
@@ -24,6 +24,7 @@ pub const Inst = struct {
         constant,
         assembly,
         ptrtoint,
+        bitcast,
     };
 
     pub fn cast(base: *Inst, comptime T: type) ?*T {
@@ -45,6 +46,7 @@ pub const Inst = struct {
 
             .assembly,
             .ptrtoint,
+            .bitcast,
             => null,
         };
     }
@@ -82,6 +84,15 @@ pub const Inst = struct {
         base: Inst,
         args: struct {
             ptr: *Inst,
+        },
+    };
+
+    pub const BitCast = struct {
+        pub const base_tag = Tag.bitcast;
+
+        base: Inst,
+        args: struct {
+            operand: *Inst,
         },
     };
 };
@@ -234,7 +245,7 @@ const Analyze = struct {
     fn resolveConstString(self: *Analyze, func: ?*Fn, old_inst: *text.Inst) ![]u8 {
         const new_inst = try self.resolveInst(func, old_inst);
         const wanted_type = Type.initTag(.const_slice_u8);
-        const coerced_inst = try self.coerce(wanted_type, new_inst);
+        const coerced_inst = try self.coerce(func, wanted_type, new_inst);
         const val = try self.resolveConstValue(coerced_inst);
         return val.toAllocatedBytes(&self.arena.allocator);
     }
@@ -242,7 +253,7 @@ const Analyze = struct {
     fn resolveType(self: *Analyze, func: ?*Fn, old_inst: *text.Inst) !Type {
         const new_inst = try self.resolveInst(func, old_inst);
         const wanted_type = Type.initTag(.@"type");
-        const coerced_inst = try self.coerce(wanted_type, new_inst);
+        const coerced_inst = try self.coerce(func, wanted_type, new_inst);
         const val = try self.resolveConstValue(coerced_inst);
         return val.toType();
     }
@@ -409,6 +420,7 @@ const Analyze = struct {
             .primitive => return self.analyzeInstPrimitive(func, old_inst.cast(text.Inst.Primitive).?),
             .fntype => return self.analyzeInstFnType(func, old_inst.cast(text.Inst.FnType).?),
             .intcast => return self.analyzeInstIntCast(func, old_inst.cast(text.Inst.IntCast).?),
+            .bitcast => return self.analyzeInstBitCast(func, old_inst.cast(text.Inst.BitCast).?),
         }
     }
 
@@ -472,7 +484,7 @@ const Analyze = struct {
     fn analyzeInstAs(self: *Analyze, func: ?*Fn, as: *text.Inst.As) InnerError!*Inst {
         const dest_type = try self.resolveType(func, as.positionals.dest_type);
         const new_inst = try self.resolveInst(func, as.positionals.value);
-        return self.coerce(dest_type, new_inst);
+        return self.coerce(func, dest_type, new_inst);
     }
 
     fn analyzeInstPtrToInt(self: *Analyze, func: ?*Fn, ptrtoint: *text.Inst.PtrToInt) InnerError!*Inst {
@@ -545,10 +557,16 @@ const Analyze = struct {
         }
 
         if (dest_is_comptime_int or new_inst.value() != null) {
-            return self.coerce(dest_type, new_inst);
+            return self.coerce(func, dest_type, new_inst);
         }
 
         return self.fail(intcast.base.src, "TODO implement analyze widen or shorten int", .{});
+    }
+
+    fn analyzeInstBitCast(self: *Analyze, func: ?*Fn, inst: *text.Inst.BitCast) InnerError!*Inst {
+        const dest_type = try self.resolveType(func, inst.positionals.dest_type);
+        const operand = try self.resolveInst(func, inst.positionals.operand);
+        return self.bitcast(func, dest_type, operand);
     }
 
     fn analyzeInstDeref(self: *Analyze, func: ?*Fn, deref: *text.Inst.Deref) InnerError!*Inst {
@@ -583,7 +601,8 @@ const Analyze = struct {
             elem.* = try self.resolveConstString(func, assembly.kw_args.clobbers[i]);
         }
         for (args) |*elem, i| {
-            elem.* = try self.resolveInst(func, assembly.kw_args.args[i]);
+            const arg = try self.resolveInst(func, assembly.kw_args.args[i]);
+            elem.* = try self.coerce(func, Type.initTag(.usize), arg);
         }
 
         const f = try self.requireFunctionBody(func, assembly.base.src);
@@ -602,10 +621,14 @@ const Analyze = struct {
         return self.addNewInstArgs(f, unreach.base.src, Type.initTag(.noreturn), Inst.Unreach, {});
     }
 
-    fn coerce(self: *Analyze, dest_type: Type, inst: *Inst) !*Inst {
+    fn coerce(self: *Analyze, func: ?*Fn, dest_type: Type, inst: *Inst) !*Inst {
+        // If the types are the same, we can return the operand.
+        if (dest_type.eql(inst.ty))
+            return inst;
+
         const in_memory_result = coerceInMemoryAllowed(dest_type, inst.ty);
         if (in_memory_result == .ok) {
-            return self.bitcast(dest_type, inst);
+            return self.bitcast(func, dest_type, inst);
         }
 
         // *[N]T to []T
@@ -634,12 +657,14 @@ const Analyze = struct {
         return self.fail(inst.src, "TODO implement type coercion", .{});
     }
 
-    fn bitcast(self: *Analyze, dest_type: Type, inst: *Inst) !*Inst {
+    fn bitcast(self: *Analyze, func: ?*Fn, dest_type: Type, inst: *Inst) !*Inst {
         if (inst.value()) |val| {
             // Keep the comptime Value representation; take the new type.
             return self.constInst(inst.src, .{ .ty = dest_type, .val = val });
         }
-        return self.fail(inst.src, "TODO implement runtime bitcast", .{});
+        // TODO validate the type size and other compile errors
+        const f = try self.requireFunctionBody(func, inst.src);
+        return self.addNewInstArgs(f, inst.src, dest_type, Inst.BitCast, Inst.Args(Inst.BitCast){ .operand = inst });
     }
 
     fn coerceArrayPtrToSlice(self: *Analyze, dest_type: Type, inst: *Inst) !*Inst {
@@ -713,7 +738,7 @@ pub fn main() anyerror!void {
         std.process.exit(1);
     }
 
-    const output_zir = false;
+    const output_zir = true;
     if (output_zir) {
         var new_zir_module = try text.emit_zir(allocator, analyzed_module);
         defer new_zir_module.deinit(allocator);

--- a/src-self-hosted/link.zig
+++ b/src-self-hosted/link.zig
@@ -1,576 +1,589 @@
 const std = @import("std");
 const mem = std.mem;
-const c = @import("c.zig");
-const Compilation = @import("compilation.zig").Compilation;
-const Target = std.Target;
-const ObjectFormat = Target.ObjectFormat;
-const LibCInstallation = @import("libc_installation.zig").LibCInstallation;
 const assert = std.debug.assert;
-const util = @import("util.zig");
+const Allocator = std.mem.Allocator;
+const ir = @import("ir.zig");
+const fs = std.fs;
+const elf = std.elf;
 
-const Context = struct {
-    comp: *Compilation,
-    arena: std.heap.ArenaAllocator,
-    args: std.ArrayList([*:0]const u8),
-    link_in_crt: bool,
+const executable_mode = 0o755;
+const default_entry_addr = 0x8000000;
 
-    link_err: error{OutOfMemory}!void,
-    link_msg: std.ArrayListSentineled(u8, 0),
+/// Attempts incremental linking, if the file already exists.
+/// If incremental linking fails, falls back to truncating the file and rewriting it.
+/// A malicious file is detected as incremental link failure and does not cause Illegal Behavior.
+/// This operation is not atomic.
+pub fn updateExecutableFilePath(allocator: *Allocator, module: ir.Module, dir: fs.Dir, sub_path: []const u8) !void {
+    const file = try dir.createFile(sub_path, .{ .truncate = false, .read = true, .mode = executable_mode });
+    defer file.close();
 
-    libc: *LibCInstallation,
-    out_file_path: std.ArrayListSentineled(u8, 0),
+    return updateExecutableFile(allocator, module, file);
+}
+
+/// Atomically overwrites the old file, if present.
+pub fn writeExecutableFilePath(allocator: *Allocator, module: ir.Module, dir: fs.Dir, sub_path: []const u8) !void {
+    const af = try dir.atomicFile(sub_path, .{ .mode = executable_mode });
+    defer af.deinit();
+
+    try writeExecutableFile(allocator, module, af.file);
+    try af.finish();
+}
+
+/// Attempts incremental linking, if the file already exists.
+/// If incremental linking fails, falls back to truncating the file and rewriting it.
+/// Returns an error if `file` is not already open with +read +write +seek abilities.
+/// A malicious file is detected as incremental link failure and does not cause Illegal Behavior.
+/// This operation is not atomic.
+pub fn updateExecutableFile(allocator: *Allocator, module: ir.Module, file: fs.File) !void {
+    updateExecutableFileInner(allocator, module, file) catch |err| switch (err) {
+        error.IncrFailed => {
+            return writeExecutableFile(allocator, module, file);
+        },
+        else => |e| return e,
+    };
+}
+
+const Update = struct {
+    file: fs.File,
+    module: *const ir.Module,
+
+    /// Stored in native-endian format, depending on target endianness needs to be bswapped on read/write.
+    /// Same order as in the file.
+    sections: std.ArrayList(elf.Elf64_Shdr),
+    shdr_table_offset: ?u64,
+
+    /// Stored in native-endian format, depending on target endianness needs to be bswapped on read/write.
+    /// Same order as in the file.
+    program_headers: std.ArrayList(elf.Elf64_Phdr),
+    phdr_table_offset: ?u64,
+    /// The index into the program headers of a PT_LOAD program header with Read and Execute flags
+    phdr_load_re_index: ?u16,
+    entry_addr: ?u64,
+
+    shstrtab: std.ArrayList(u8),
+    shstrtab_index: ?u16,
+
+    text_section_index: ?u16,
+    symtab_section_index: ?u16,
+
+    /// Key: index into strtab. Value: index into symbols.
+    symbol_table: std.AutoHashMap(usize, usize),
+    /// The same order as in the file
+    symbols: std.ArrayList(elf.Elf64_Sym),
+    /// Sorted by address, index into symbols
+    symbols_by_addr: std.ArrayList(usize),
+
+    fn deinit(self: *Update) void {
+        self.sections.deinit();
+        self.program_headers.deinit();
+        self.shstrtab.deinit();
+        self.symbol_table.deinit();
+        self.symbols.deinit();
+        self.symbols_by_addr.deinit();
+    }
+
+    // `expand_num / expand_den` is the factor of padding when allocation
+    const alloc_num = 4;
+    const alloc_den = 3;
+
+    /// Returns end pos of collision, if any.
+    fn detectAllocCollision(self: *Update, start: u64, size: u64) ?u64 {
+        const small_ptr = self.module.target.cpu.arch.ptrBitWidth() == 32;
+        const ehdr_size: u64 = if (small_ptr) @sizeOf(elf.Elf32_Ehdr) else @sizeOf(elf.Elf64_Ehdr);
+        if (start < ehdr_size)
+            return ehdr_size;
+
+        const end = start + satMul(size, alloc_num) / alloc_den;
+
+        if (self.shdr_table_offset) |off| {
+            const shdr_size: u64 = if (small_ptr) @sizeOf(elf.Elf32_Shdr) else @sizeOf(elf.Elf64_Shdr);
+            const tight_size = self.sections.items.len * shdr_size;
+            const increased_size = satMul(tight_size, alloc_num) / alloc_den;
+            const test_end = off + increased_size;
+            if (end > off and start < test_end) {
+                return test_end;
+            }
+        }
+
+        if (self.phdr_table_offset) |off| {
+            const phdr_size: u64 = if (small_ptr) @sizeOf(elf.Elf32_Phdr) else @sizeOf(elf.Elf64_Phdr);
+            const tight_size = self.sections.items.len * phdr_size;
+            const increased_size = satMul(tight_size, alloc_num) / alloc_den;
+            const test_end = off + increased_size;
+            if (end > off and start < test_end) {
+                return test_end;
+            }
+        }
+
+        for (self.sections.items) |section| {
+            const increased_size = satMul(section.sh_size, alloc_num) / alloc_den;
+            const test_end = section.sh_offset + increased_size;
+            if (end > section.sh_offset and start < test_end) {
+                return test_end;
+            }
+        }
+        for (self.program_headers.items) |program_header| {
+            const increased_size = satMul(program_header.p_filesz, alloc_num) / alloc_den;
+            const test_end = program_header.p_offset + increased_size;
+            if (end > program_header.p_offset and start < test_end) {
+                return test_end;
+            }
+        }
+        return null;
+    }
+
+    fn allocatedSize(self: *Update, start: u64) u64 {
+        var min_pos: u64 = std.math.maxInt(u64);
+        if (self.shdr_table_offset) |off| {
+            if (off > start and off < min_pos) min_pos = off;
+        }
+        if (self.phdr_table_offset) |off| {
+            if (off > start and off < min_pos) min_pos = off;
+        }
+        for (self.sections.items) |section| {
+            if (section.sh_offset <= start) continue;
+            if (section.sh_offset < min_pos) min_pos = section.sh_offset;
+        }
+        for (self.program_headers.items) |program_header| {
+            if (program_header.p_offset <= start) continue;
+            if (program_header.p_offset < min_pos) min_pos = program_header.p_offset;
+        }
+        return min_pos;
+    }
+
+    fn findFreeSpace(self: *Update, object_size: u64, min_alignment: u16) u64 {
+        var start: u64 = 0;
+        while (self.detectAllocCollision(start, object_size)) |item_end| {
+            start = mem.alignForwardGeneric(u64, item_end, min_alignment);
+        }
+        return start;
+    }
+
+    fn makeString(self: *Update, bytes: []const u8) !u32 {
+        const result = self.shstrtab.items.len;
+        try self.shstrtab.appendSlice(bytes);
+        return @intCast(u32, result);
+    }
+
+    fn perform(self: *Update) !void {
+        const ptr_width: enum { p32, p64 } = switch (self.module.target.cpu.arch.ptrBitWidth()) {
+            32 => .p32,
+            64 => .p64,
+            else => return error.UnsupportedArchitecture,
+        };
+        const small_ptr = switch (ptr_width) {
+            .p32 => true,
+            .p64 => false,
+        };
+        // This means the entire read-only executable program code needs to be rewritten.
+        var phdr_load_re_dirty = false;
+        var phdr_table_dirty = false;
+        var shdr_table_dirty = false;
+        var shstrtab_dirty = false;
+        var symtab_dirty = false;
+
+        if (self.phdr_load_re_index == null) {
+            self.phdr_load_re_index = @intCast(u16, self.program_headers.items.len);
+            const file_size = 256 * 1024;
+            const p_align = 0x1000;
+            const off = self.findFreeSpace(file_size, p_align);
+            try self.program_headers.append(.{
+                .p_type = elf.PT_LOAD,
+                .p_offset = off,
+                .p_filesz = file_size,
+                .p_vaddr = default_entry_addr,
+                .p_paddr = default_entry_addr,
+                .p_memsz = 0,
+                .p_align = 0x1000,
+                .p_flags = elf.PF_X | elf.PF_R,
+            });
+            self.entry_addr = default_entry_addr;
+            phdr_load_re_dirty = true;
+            phdr_table_dirty = true;
+        }
+        if (self.sections.items.len == 0) {
+            // There must always be a null section in index 0
+            try self.sections.append(.{
+                .sh_name = 0,
+                .sh_type = 0,
+                .sh_flags = 0,
+                .sh_addr = 0,
+                .sh_offset = 0,
+                .sh_size = 0,
+                .sh_link = 0,
+                .sh_info = 0,
+                .sh_addralign = 0,
+                .sh_entsize = 0,
+            });
+            shdr_table_dirty = true;
+        }
+        if (self.shstrtab_index == null) {
+            self.shstrtab_index = @intCast(u16, self.sections.items.len);
+            const off = self.findFreeSpace(self.shstrtab.items.len, 1);
+            try self.sections.append(.{
+                .sh_name = try self.makeString(".shstrtab"),
+                .sh_type = elf.SHT_STRTAB,
+                .sh_flags = 0,
+                .sh_addr = 0,
+                .sh_offset = off,
+                .sh_size = self.shstrtab.items.len,
+                .sh_link = 0,
+                .sh_info = 0,
+                .sh_addralign = 1,
+                .sh_entsize = 0,
+            });
+            shstrtab_dirty = true;
+            shdr_table_dirty = true;
+        }
+        if (self.text_section_index == null) {
+            self.text_section_index = @intCast(u16, self.sections.items.len);
+            const phdr = &self.program_headers.items[self.phdr_load_re_index.?];
+
+            try self.sections.append(.{
+                .sh_name = try self.makeString(".text"),
+                .sh_type = elf.SHT_PROGBITS,
+                .sh_flags = elf.SHF_ALLOC | elf.SHF_EXECINSTR,
+                .sh_addr = phdr.p_vaddr,
+                .sh_offset = phdr.p_offset,
+                .sh_size = phdr.p_filesz,
+                .sh_link = 0,
+                .sh_info = 0,
+                .sh_addralign = phdr.p_align,
+                .sh_entsize = 0,
+            });
+            shdr_table_dirty = true;
+        }
+        if (self.symtab_section_index == null) {
+            self.symtab_section_index = @intCast(u16, self.sections.items.len);
+            const min_align: u16 = if (small_ptr) @alignOf(elf.Elf32_Sym) else @alignOf(elf.Elf64_Sym);
+            const each_size: u64 = if (small_ptr) @sizeOf(elf.Elf32_Sym) else @sizeOf(elf.Elf64_Sym);
+            const file_size = self.module.exports.len * each_size;
+            const off = self.findFreeSpace(file_size, min_align);
+
+            try self.sections.append(.{
+                .sh_name = try self.makeString(".symtab"),
+                .sh_type = elf.SHT_SYMTAB,
+                .sh_flags = 0,
+                .sh_addr = 0,
+                .sh_offset = off,
+                .sh_size = file_size,
+                // The section header index of the associated string table.
+                .sh_link = self.shstrtab_index.?,
+                // One greater than the symbol table index of the last local symbol (binding STB_LOCAL).
+                .sh_info = @intCast(u32, self.module.exports.len),
+                .sh_addralign = min_align,
+                .sh_entsize = each_size,
+            });
+            symtab_dirty = true;
+            shdr_table_dirty = true;
+        }
+        const shsize: u64 = switch (ptr_width) {
+            .p32 => @sizeOf(elf.Elf32_Shdr),
+            .p64 => @sizeOf(elf.Elf64_Shdr),
+        };
+        const shalign: u16 = switch (ptr_width) {
+            .p32 => @alignOf(elf.Elf32_Shdr),
+            .p64 => @alignOf(elf.Elf64_Shdr),
+        };
+        if (self.shdr_table_offset == null) {
+            self.shdr_table_offset = self.findFreeSpace(self.sections.items.len * shsize, shalign);
+            shdr_table_dirty = true;
+        }
+        const phsize: u64 = switch (ptr_width) {
+            .p32 => @sizeOf(elf.Elf32_Phdr),
+            .p64 => @sizeOf(elf.Elf64_Phdr),
+        };
+        const phalign: u16 = switch (ptr_width) {
+            .p32 => @alignOf(elf.Elf32_Phdr),
+            .p64 => @alignOf(elf.Elf64_Phdr),
+        };
+        if (self.phdr_table_offset == null) {
+            self.phdr_table_offset = self.findFreeSpace(self.program_headers.items.len * phsize, phalign);
+            phdr_table_dirty = true;
+        }
+        const foreign_endian = self.module.target.cpu.arch.endian() != std.Target.current.cpu.arch.endian();
+        if (phdr_table_dirty) {
+            const allocated_size = self.allocatedSize(self.phdr_table_offset.?);
+            const needed_size = self.program_headers.items.len * phsize;
+
+            if (needed_size > allocated_size) {
+                self.phdr_table_offset = self.findFreeSpace(needed_size, phalign);
+            }
+
+            const allocator = self.program_headers.allocator;
+            switch (ptr_width) {
+                .p32 => {
+                    const buf = try allocator.alloc(elf.Elf32_Phdr, self.program_headers.items.len);
+                    defer allocator.free(buf);
+
+                    for (buf) |*phdr, i| {
+                        phdr.* = .{
+                            .p_type = self.program_headers.items[i].p_type,
+                            .p_flags = self.program_headers.items[i].p_flags,
+                            .p_offset = @intCast(u32, self.program_headers.items[i].p_offset),
+                            .p_vaddr = @intCast(u32, self.program_headers.items[i].p_vaddr),
+                            .p_paddr = @intCast(u32, self.program_headers.items[i].p_paddr),
+                            .p_filesz = @intCast(u32, self.program_headers.items[i].p_filesz),
+                            .p_memsz = @intCast(u32, self.program_headers.items[i].p_memsz),
+                            .p_align = @intCast(u32, self.program_headers.items[i].p_align),
+                        };
+                        if (foreign_endian) {
+                            bswapAllFields(elf.Elf32_Phdr, phdr);
+                        }
+                    }
+                    try self.file.pwriteAll(mem.sliceAsBytes(buf), self.phdr_table_offset.?);
+                },
+                .p64 => {
+                    const buf = try allocator.alloc(elf.Elf64_Phdr, self.program_headers.items.len);
+                    defer allocator.free(buf);
+
+                    for (buf) |*phdr, i| {
+                        phdr.* = .{
+                            .p_type = self.program_headers.items[i].p_type,
+                            .p_flags = self.program_headers.items[i].p_flags,
+                            .p_offset = self.program_headers.items[i].p_offset,
+                            .p_vaddr = self.program_headers.items[i].p_vaddr,
+                            .p_paddr = self.program_headers.items[i].p_paddr,
+                            .p_filesz = self.program_headers.items[i].p_filesz,
+                            .p_memsz = self.program_headers.items[i].p_memsz,
+                            .p_align = self.program_headers.items[i].p_align,
+                        };
+                        if (foreign_endian) {
+                            bswapAllFields(elf.Elf64_Phdr, phdr);
+                        }
+                    }
+                    try self.file.pwriteAll(mem.sliceAsBytes(buf), self.phdr_table_offset.?);
+                },
+            }
+        }
+        if (shdr_table_dirty) {
+            const allocated_size = self.allocatedSize(self.shdr_table_offset.?);
+            const needed_size = self.sections.items.len * phsize;
+
+            if (needed_size > allocated_size) {
+                self.shdr_table_offset = self.findFreeSpace(needed_size, phalign);
+            }
+
+            const allocator = self.sections.allocator;
+            switch (ptr_width) {
+                .p32 => {
+                    const buf = try allocator.alloc(elf.Elf32_Shdr, self.sections.items.len);
+                    defer allocator.free(buf);
+
+                    for (buf) |*shdr, i| {
+                        shdr.* = .{
+                            .sh_name = self.sections.items[i].sh_name,
+                            .sh_type = self.sections.items[i].sh_type,
+                            .sh_flags = @intCast(u32, self.sections.items[i].sh_flags),
+                            .sh_addr = @intCast(u32, self.sections.items[i].sh_addr),
+                            .sh_offset = @intCast(u32, self.sections.items[i].sh_offset),
+                            .sh_size = @intCast(u32, self.sections.items[i].sh_size),
+                            .sh_link = self.sections.items[i].sh_link,
+                            .sh_info = self.sections.items[i].sh_info,
+                            .sh_addralign = @intCast(u32, self.sections.items[i].sh_addralign),
+                            .sh_entsize = @intCast(u32, self.sections.items[i].sh_entsize),
+                        };
+                        if (foreign_endian) {
+                            bswapAllFields(elf.Elf32_Shdr, shdr);
+                        }
+                    }
+                    try self.file.pwriteAll(mem.sliceAsBytes(buf), self.shdr_table_offset.?);
+                },
+                .p64 => {
+                    const buf = try allocator.alloc(elf.Elf64_Shdr, self.sections.items.len);
+                    defer allocator.free(buf);
+
+                    for (buf) |*shdr, i| {
+                        shdr.* = .{
+                            .sh_name = self.sections.items[i].sh_name,
+                            .sh_type = self.sections.items[i].sh_type,
+                            .sh_flags = self.sections.items[i].sh_flags,
+                            .sh_addr = self.sections.items[i].sh_addr,
+                            .sh_offset = self.sections.items[i].sh_offset,
+                            .sh_size = self.sections.items[i].sh_size,
+                            .sh_link = self.sections.items[i].sh_link,
+                            .sh_info = self.sections.items[i].sh_info,
+                            .sh_addralign = self.sections.items[i].sh_addralign,
+                            .sh_entsize = self.sections.items[i].sh_entsize,
+                        };
+                        if (foreign_endian) {
+                            bswapAllFields(elf.Elf64_Shdr, shdr);
+                        }
+                    }
+                    try self.file.pwriteAll(mem.sliceAsBytes(buf), self.shdr_table_offset.?);
+                },
+            }
+        }
+        if (shstrtab_dirty) {
+            try self.file.pwriteAll(self.shstrtab.items, self.sections.items[self.shstrtab_index.?].sh_offset);
+        }
+        try self.writeCodeAndSymbols();
+        try self.writeElfHeader();
+        // TODO find end pos and truncate
+    }
+
+    fn writeElfHeader(self: *Update) !void {
+        var hdr_buf: [@sizeOf(elf.Elf64_Ehdr)]u8 = undefined;
+
+        var index: usize = 0;
+        hdr_buf[0..4].* = "\x7fELF".*;
+        index += 4;
+
+        const ptr_width: enum { p32, p64 } = switch (self.module.target.cpu.arch.ptrBitWidth()) {
+            32 => .p32,
+            64 => .p64,
+            else => return error.UnsupportedArchitecture,
+        };
+        hdr_buf[index] = switch (ptr_width) {
+            .p32 => elf.ELFCLASS32,
+            .p64 => elf.ELFCLASS64,
+        };
+        index += 1;
+
+        const endian = self.module.target.cpu.arch.endian();
+        hdr_buf[index] = switch (endian) {
+            .Little => elf.ELFDATA2LSB,
+            .Big => elf.ELFDATA2MSB,
+        };
+        index += 1;
+
+        hdr_buf[index] = 1; // ELF version
+        index += 1;
+
+        // OS ABI, often set to 0 regardless of target platform
+        // ABI Version, possibly used by glibc but not by static executables
+        // padding
+        mem.set(u8, hdr_buf[index..][0..9], 0);
+        index += 9;
+
+        assert(index == 16);
+
+        mem.writeInt(u16, hdr_buf[index..][0..2], @enumToInt(elf.ET.EXEC), endian);
+        index += 2;
+
+        const machine = self.module.target.cpu.arch.toElfMachine();
+        mem.writeInt(u16, hdr_buf[index..][0..2], @enumToInt(machine), endian);
+        index += 2;
+
+        // ELF Version, again
+        mem.writeInt(u32, hdr_buf[index..][0..4], 1, endian);
+        index += 4;
+
+        switch (ptr_width) {
+            .p32 => {
+                // e_entry
+                mem.writeInt(u32, hdr_buf[index..][0..4], @intCast(u32, self.entry_addr.?), endian);
+                index += 4;
+
+                // e_phoff
+                mem.writeInt(u32, hdr_buf[index..][0..4], @intCast(u32, self.phdr_table_offset.?), endian);
+                index += 4;
+
+                // e_shoff
+                mem.writeInt(u32, hdr_buf[index..][0..4], @intCast(u32, self.shdr_table_offset.?), endian);
+                index += 4;
+            },
+            .p64 => {
+                // e_entry
+                mem.writeInt(u64, hdr_buf[index..][0..8], self.entry_addr.?, endian);
+                index += 8;
+
+                // e_phoff
+                mem.writeInt(u64, hdr_buf[index..][0..8], self.phdr_table_offset.?, endian);
+                index += 8;
+
+                // e_shoff
+                mem.writeInt(u64, hdr_buf[index..][0..8], self.shdr_table_offset.?, endian);
+                index += 8;
+            },
+        }
+
+        const e_flags = 0;
+        mem.writeInt(u32, hdr_buf[index..][0..4], e_flags, endian);
+        index += 4;
+
+        const e_ehsize: u16 = switch (ptr_width) {
+            .p32 => @sizeOf(elf.Elf32_Ehdr),
+            .p64 => @sizeOf(elf.Elf64_Ehdr),
+        };
+        mem.writeInt(u16, hdr_buf[index..][0..2], e_ehsize, endian);
+        index += 2;
+
+        const e_phentsize: u16 = switch (ptr_width) {
+            .p32 => @sizeOf(elf.Elf32_Phdr),
+            .p64 => @sizeOf(elf.Elf64_Phdr),
+        };
+        mem.writeInt(u16, hdr_buf[index..][0..2], e_phentsize, endian);
+        index += 2;
+
+        const e_phnum = @intCast(u16, self.program_headers.items.len);
+        mem.writeInt(u16, hdr_buf[index..][0..2], e_phnum, endian);
+        index += 2;
+
+        const e_shentsize: u16 = switch (ptr_width) {
+            .p32 => @sizeOf(elf.Elf32_Shdr),
+            .p64 => @sizeOf(elf.Elf64_Shdr),
+        };
+        mem.writeInt(u16, hdr_buf[index..][0..2], e_shentsize, endian);
+        index += 2;
+
+        const e_shnum = @intCast(u16, self.sections.items.len);
+        mem.writeInt(u16, hdr_buf[index..][0..2], e_shnum, endian);
+        index += 2;
+
+        mem.writeInt(u16, hdr_buf[index..][0..2], self.shstrtab_index.?, endian);
+        index += 2;
+
+        assert(index == e_ehsize);
+
+        try self.file.pwriteAll(hdr_buf[0..index], 0);
+    }
+
+    fn writeCodeAndSymbols(self: *Update) !void {
+        @panic("TODO writeCodeAndSymbols");
+    }
 };
 
-pub fn link(comp: *Compilation) !void {
-    var ctx = Context{
-        .comp = comp,
-        .arena = std.heap.ArenaAllocator.init(comp.gpa()),
-        .args = undefined,
-        .link_in_crt = comp.haveLibC() and comp.kind == .Exe,
-        .link_err = {},
-        .link_msg = undefined,
-        .libc = undefined,
-        .out_file_path = undefined,
+/// Truncates the existing file contents and overwrites the contents.
+/// Returns an error if `file` is not already open with +read +write +seek abilities.
+pub fn writeExecutableFile(allocator: *Allocator, module: ir.Module, file: fs.File) !void {
+    var update = Update{
+        .file = file,
+        .module = &module,
+        .sections = std.ArrayList(elf.Elf64_Shdr).init(allocator),
+        .shdr_table_offset = null,
+        .program_headers = std.ArrayList(elf.Elf64_Phdr).init(allocator),
+        .phdr_table_offset = null,
+        .phdr_load_re_index = null,
+        .entry_addr = null,
+        .shstrtab = std.ArrayList(u8).init(allocator),
+        .shstrtab_index = null,
+        .text_section_index = null,
+        .symtab_section_index = null,
+
+        .symbol_table = std.AutoHashMap(usize, usize).init(allocator),
+        .symbols = std.ArrayList(elf.Elf64_Sym).init(allocator),
+        .symbols_by_addr = std.ArrayList(usize).init(allocator),
     };
-    defer ctx.arena.deinit();
-    ctx.args = std.ArrayList([*:0]const u8).init(&ctx.arena.allocator);
-    ctx.link_msg = std.ArrayListSentineled(u8, 0).initNull(&ctx.arena.allocator);
+    defer update.deinit();
 
-    ctx.out_file_path = try std.ArrayListSentineled(u8, 0).init(&ctx.arena.allocator, comp.name.span());
-    switch (comp.kind) {
-        .Exe => {
-            try ctx.out_file_path.append(comp.target.exeFileExt());
-        },
-        .Lib => {
-            try ctx.out_file_path.append(if (comp.is_static) comp.target.staticLibSuffix() else comp.target.dynamicLibSuffix());
-        },
-        .Obj => {
-            try ctx.out_file_path.append(comp.target.oFileExt());
-        },
-    }
-
-    // even though we're calling LLD as a library it thinks the first
-    // argument is its own exe name
-    try ctx.args.append("lld");
-
-    if (comp.haveLibC()) {
-        // TODO https://github.com/ziglang/zig/issues/3190
-        var libc = ctx.comp.override_libc orelse blk: {
-            @panic("this code has bitrotted");
-            //switch (comp.target) {
-            //    Target.Native => {
-            //        break :blk comp.zig_compiler.getNativeLibC() catch return error.LibCRequiredButNotProvidedOrFound;
-            //    },
-            //    else => return error.LibCRequiredButNotProvidedOrFound,
-            //}
-        };
-        ctx.libc = libc;
-    }
-
-    try constructLinkerArgs(&ctx);
-
-    if (comp.verbose_link) {
-        for (ctx.args.span()) |arg, i| {
-            const space = if (i == 0) "" else " ";
-            std.debug.warn("{}{s}", .{ space, arg });
-        }
-        std.debug.warn("\n", .{});
-    }
-
-    const extern_ofmt = toExternObjectFormatType(comp.target.getObjectFormat());
-    const args_slice = ctx.args.span();
-
-    {
-        // LLD is not thread-safe, so we grab a global lock.
-        const held = comp.zig_compiler.lld_lock.acquire();
-        defer held.release();
-
-        // Not evented I/O. LLD does its own multithreading internally.
-        if (!ZigLLDLink(extern_ofmt, args_slice.ptr, args_slice.len, linkDiagCallback, @ptrCast(*c_void, &ctx))) {
-            if (!ctx.link_msg.isNull()) {
-                // TODO capture these messages and pass them through the system, reporting them through the
-                // event system instead of printing them directly here.
-                // perhaps try to parse and understand them.
-                std.debug.warn("{}\n", .{ctx.link_msg.span()});
-            }
-            return error.LinkFailed;
-        }
-    }
+    return update.perform();
 }
 
-extern fn ZigLLDLink(
-    oformat: c.ZigLLVM_ObjectFormatType,
-    args: [*]const [*]const u8,
-    arg_count: usize,
-    append_diagnostic: extern fn (*c_void, [*]const u8, usize) void,
-    context: *c_void,
-) bool;
+/// Returns error.IncrFailed if incremental update could not be performed.
+fn updateExecutableFileInner(allocator: *Allocator, module: ir.Module, file: fs.File) !void {
+    //var ehdr_buf: [@sizeOf(elf.Elf64_Ehdr)]u8 = undefined;
 
-fn linkDiagCallback(context: *c_void, ptr: [*]const u8, len: usize) callconv(.C) void {
-    const ctx = @ptrCast(*Context, @alignCast(@alignOf(Context), context));
-    ctx.link_err = linkDiagCallbackErrorable(ctx, ptr[0..len]);
+    // TODO implement incremental linking
+    return error.IncrFailed;
 }
 
-fn linkDiagCallbackErrorable(ctx: *Context, msg: []const u8) !void {
-    if (ctx.link_msg.isNull()) {
-        try ctx.link_msg.resize(0);
-    }
-    try ctx.link_msg.append(msg);
+/// Saturating multiplication
+fn satMul(a: var, b: var) @TypeOf(a, b) {
+    const T = @TypeOf(a, b);
+    return std.math.mul(T, a, b) catch std.math.maxInt(T);
 }
 
-fn toExternObjectFormatType(ofmt: ObjectFormat) c.ZigLLVM_ObjectFormatType {
-    return switch (ofmt) {
-        .unknown => .ZigLLVM_UnknownObjectFormat,
-        .coff => .ZigLLVM_COFF,
-        .elf => .ZigLLVM_ELF,
-        .macho => .ZigLLVM_MachO,
-        .wasm => .ZigLLVM_Wasm,
-    };
-}
-
-fn constructLinkerArgs(ctx: *Context) !void {
-    switch (ctx.comp.target.getObjectFormat()) {
-        .unknown => unreachable,
-        .coff => return constructLinkerArgsCoff(ctx),
-        .elf => return constructLinkerArgsElf(ctx),
-        .macho => return constructLinkerArgsMachO(ctx),
-        .wasm => return constructLinkerArgsWasm(ctx),
-    }
-}
-
-fn constructLinkerArgsElf(ctx: *Context) !void {
-    // TODO commented out code in this function
-    //if (g->linker_script) {
-    //    lj->args.append("-T");
-    //    lj->args.append(g->linker_script);
-    //}
-    try ctx.args.append("--gc-sections");
-    if (ctx.comp.link_eh_frame_hdr) {
-        try ctx.args.append("--eh-frame-hdr");
-    }
-
-    //lj->args.append("-m");
-    //lj->args.append(getLDMOption(&g->zig_target));
-
-    //bool is_lib = g->out_type == OutTypeLib;
-    //bool shared = !g->is_static && is_lib;
-    //Buf *soname = nullptr;
-    if (ctx.comp.is_static) {
-        //if (util.isArmOrThumb(ctx.comp.target)) {
-        //    try ctx.args.append("-Bstatic");
-        //} else {
-        //    try ctx.args.append("-static");
-        //}
-    }
-    //} else if (shared) {
-    //    lj->args.append("-shared");
-
-    //    if (buf_len(&lj->out_file) == 0) {
-    //        buf_appendf(&lj->out_file, "lib%s.so.%" ZIG_PRI_usize ".%" ZIG_PRI_usize ".%" ZIG_PRI_usize "",
-    //                buf_ptr(g->root_out_name), g->version_major, g->version_minor, g->version_patch);
-    //    }
-    //    soname = buf_sprintf("lib%s.so.%" ZIG_PRI_usize "", buf_ptr(g->root_out_name), g->version_major);
-    //}
-
-    try ctx.args.append("-o");
-    try ctx.args.append(ctx.out_file_path.span());
-
-    if (ctx.link_in_crt) {
-        const crt1o = if (ctx.comp.is_static) "crt1.o" else "Scrt1.o";
-        try addPathJoin(ctx, ctx.libc.crt_dir.?, crt1o);
-        try addPathJoin(ctx, ctx.libc.crt_dir.?, "crti.o");
-    }
-
-    if (ctx.comp.haveLibC()) {
-        try ctx.args.append("-L");
-        // TODO addNullByte should probably return [:0]u8
-        try ctx.args.append(@ptrCast([*:0]const u8, (try std.cstr.addNullByte(&ctx.arena.allocator, ctx.libc.crt_dir.?)).ptr));
-
-        //if (!ctx.comp.is_static) {
-        //    const dl = blk: {
-        //        //if (ctx.libc.dynamic_linker_path) |dl| break :blk dl;
-        //        //if (util.getDynamicLinkerPath(ctx.comp.target)) |dl| break :blk dl;
-        //        return error.LibCMissingDynamicLinker;
-        //    };
-        //    try ctx.args.append("-dynamic-linker");
-        //    try ctx.args.append(@ptrCast([*:0]const u8, (try std.cstr.addNullByte(&ctx.arena.allocator, dl)).ptr));
-        //}
-    }
-
-    //if (shared) {
-    //    lj->args.append("-soname");
-    //    lj->args.append(buf_ptr(soname));
-    //}
-
-    // .o files
-    for (ctx.comp.link_objects) |link_object| {
-        const link_obj_with_null = try std.cstr.addNullByte(&ctx.arena.allocator, link_object);
-        try ctx.args.append(@ptrCast([*:0]const u8, link_obj_with_null.ptr));
-    }
-    try addFnObjects(ctx);
-
-    //if (g->out_type == OutTypeExe || g->out_type == OutTypeLib) {
-    //    if (g->libc_link_lib == nullptr) {
-    //        Buf *builtin_o_path = build_o(g, "builtin");
-    //        lj->args.append(buf_ptr(builtin_o_path));
-    //    }
-
-    //    // sometimes libgcc is missing stuff, so we still build compiler_rt and rely on weak linkage
-    //    Buf *compiler_rt_o_path = build_compiler_rt(g);
-    //    lj->args.append(buf_ptr(compiler_rt_o_path));
-    //}
-
-    //for (size_t i = 0; i < g->link_libs_list.length; i += 1) {
-    //    LinkLib *link_lib = g->link_libs_list.at(i);
-    //    if (buf_eql_str(link_lib->name, "c")) {
-    //        continue;
-    //    }
-    //    Buf *arg;
-    //    if (buf_starts_with_str(link_lib->name, "/") || buf_ends_with_str(link_lib->name, ".a") ||
-    //        buf_ends_with_str(link_lib->name, ".so"))
-    //    {
-    //        arg = link_lib->name;
-    //    } else {
-    //        arg = buf_sprintf("-l%s", buf_ptr(link_lib->name));
-    //    }
-    //    lj->args.append(buf_ptr(arg));
-    //}
-
-    // libc dep
-    if (ctx.comp.haveLibC()) {
-        if (ctx.comp.is_static) {
-            try ctx.args.append("--start-group");
-            try ctx.args.append("-lgcc");
-            try ctx.args.append("-lgcc_eh");
-            try ctx.args.append("-lc");
-            try ctx.args.append("-lm");
-            try ctx.args.append("--end-group");
-        } else {
-            try ctx.args.append("-lgcc");
-            try ctx.args.append("--as-needed");
-            try ctx.args.append("-lgcc_s");
-            try ctx.args.append("--no-as-needed");
-            try ctx.args.append("-lc");
-            try ctx.args.append("-lm");
-            try ctx.args.append("-lgcc");
-            try ctx.args.append("--as-needed");
-            try ctx.args.append("-lgcc_s");
-            try ctx.args.append("--no-as-needed");
-        }
-    }
-
-    // crt end
-    if (ctx.link_in_crt) {
-        try addPathJoin(ctx, ctx.libc.crt_dir.?, "crtn.o");
-    }
-
-    //if (ctx.comp.target != Target.Native) {
-    //    try ctx.args.append("--allow-shlib-undefined");
-    //}
-}
-
-fn addPathJoin(ctx: *Context, dirname: []const u8, basename: []const u8) !void {
-    const full_path = try std.fs.path.join(&ctx.arena.allocator, &[_][]const u8{ dirname, basename });
-    const full_path_with_null = try std.cstr.addNullByte(&ctx.arena.allocator, full_path);
-    try ctx.args.append(@ptrCast([*:0]const u8, full_path_with_null.ptr));
-}
-
-fn constructLinkerArgsCoff(ctx: *Context) !void {
-    try ctx.args.append("-NOLOGO");
-
-    if (!ctx.comp.strip) {
-        try ctx.args.append("-DEBUG");
-    }
-
-    switch (ctx.comp.target.cpu.arch) {
-        .i386 => try ctx.args.append("-MACHINE:X86"),
-        .x86_64 => try ctx.args.append("-MACHINE:X64"),
-        .aarch64 => try ctx.args.append("-MACHINE:ARM"),
-        else => return error.UnsupportedLinkArchitecture,
-    }
-
-    const is_library = ctx.comp.kind == .Lib;
-
-    const out_arg = try std.fmt.allocPrint(&ctx.arena.allocator, "-OUT:{}\x00", .{ctx.out_file_path.span()});
-    try ctx.args.append(@ptrCast([*:0]const u8, out_arg.ptr));
-
-    if (ctx.comp.haveLibC()) {
-        try ctx.args.append(@ptrCast([*:0]const u8, (try std.fmt.allocPrint(&ctx.arena.allocator, "-LIBPATH:{}\x00", .{ctx.libc.msvc_lib_dir.?})).ptr));
-        try ctx.args.append(@ptrCast([*:0]const u8, (try std.fmt.allocPrint(&ctx.arena.allocator, "-LIBPATH:{}\x00", .{ctx.libc.kernel32_lib_dir.?})).ptr));
-        try ctx.args.append(@ptrCast([*:0]const u8, (try std.fmt.allocPrint(&ctx.arena.allocator, "-LIBPATH:{}\x00", .{ctx.libc.crt_dir.?})).ptr));
-    }
-
-    if (ctx.link_in_crt) {
-        const lib_str = if (ctx.comp.is_static) "lib" else "";
-        const d_str = if (ctx.comp.build_mode == .Debug) "d" else "";
-
-        if (ctx.comp.is_static) {
-            const cmt_lib_name = try std.fmt.allocPrint(&ctx.arena.allocator, "libcmt{}.lib\x00", .{d_str});
-            try ctx.args.append(@ptrCast([*:0]const u8, cmt_lib_name.ptr));
-        } else {
-            const msvcrt_lib_name = try std.fmt.allocPrint(&ctx.arena.allocator, "msvcrt{}.lib\x00", .{d_str});
-            try ctx.args.append(@ptrCast([*:0]const u8, msvcrt_lib_name.ptr));
-        }
-
-        const vcruntime_lib_name = try std.fmt.allocPrint(&ctx.arena.allocator, "{}vcruntime{}.lib\x00", .{
-            lib_str,
-            d_str,
-        });
-        try ctx.args.append(@ptrCast([*:0]const u8, vcruntime_lib_name.ptr));
-
-        const crt_lib_name = try std.fmt.allocPrint(&ctx.arena.allocator, "{}ucrt{}.lib\x00", .{ lib_str, d_str });
-        try ctx.args.append(@ptrCast([*:0]const u8, crt_lib_name.ptr));
-
-        // Visual C++ 2015 Conformance Changes
-        // https://msdn.microsoft.com/en-us/library/bb531344.aspx
-        try ctx.args.append("legacy_stdio_definitions.lib");
-
-        // msvcrt depends on kernel32
-        try ctx.args.append("kernel32.lib");
-    } else {
-        try ctx.args.append("-NODEFAULTLIB");
-        if (!is_library) {
-            try ctx.args.append("-ENTRY:WinMainCRTStartup");
-        }
-    }
-
-    if (is_library and !ctx.comp.is_static) {
-        try ctx.args.append("-DLL");
-    }
-
-    for (ctx.comp.link_objects) |link_object| {
-        const link_obj_with_null = try std.cstr.addNullByte(&ctx.arena.allocator, link_object);
-        try ctx.args.append(@ptrCast([*:0]const u8, link_obj_with_null.ptr));
-    }
-    try addFnObjects(ctx);
-
-    switch (ctx.comp.kind) {
-        .Exe, .Lib => {
-            if (!ctx.comp.haveLibC()) {
-                @panic("TODO");
-            }
-        },
-        .Obj => {},
-    }
-}
-
-fn constructLinkerArgsMachO(ctx: *Context) !void {
-    try ctx.args.append("-demangle");
-
-    if (ctx.comp.linker_rdynamic) {
-        try ctx.args.append("-export_dynamic");
-    }
-
-    const is_lib = ctx.comp.kind == .Lib;
-    const shared = !ctx.comp.is_static and is_lib;
-    if (ctx.comp.is_static) {
-        try ctx.args.append("-static");
-    } else {
-        try ctx.args.append("-dynamic");
-    }
-
-    try ctx.args.append("-arch");
-    try ctx.args.append(util.getDarwinArchString(ctx.comp.target));
-
-    const platform = try DarwinPlatform.get(ctx.comp);
-    switch (platform.kind) {
-        .MacOS => try ctx.args.append("-macosx_version_min"),
-        .IPhoneOS => try ctx.args.append("-iphoneos_version_min"),
-        .IPhoneOSSimulator => try ctx.args.append("-ios_simulator_version_min"),
-    }
-    const ver_str = try std.fmt.allocPrint(&ctx.arena.allocator, "{}.{}.{}\x00", .{
-        platform.major,
-        platform.minor,
-        platform.micro,
-    });
-    try ctx.args.append(@ptrCast([*:0]const u8, ver_str.ptr));
-
-    if (ctx.comp.kind == .Exe) {
-        if (ctx.comp.is_static) {
-            try ctx.args.append("-no_pie");
-        } else {
-            try ctx.args.append("-pie");
-        }
-    }
-
-    try ctx.args.append("-o");
-    try ctx.args.append(ctx.out_file_path.span());
-
-    if (shared) {
-        try ctx.args.append("-headerpad_max_install_names");
-    } else if (ctx.comp.is_static) {
-        try ctx.args.append("-lcrt0.o");
-    } else {
-        switch (platform.kind) {
-            .MacOS => {
-                if (platform.versionLessThan(10, 5)) {
-                    try ctx.args.append("-lcrt1.o");
-                } else if (platform.versionLessThan(10, 6)) {
-                    try ctx.args.append("-lcrt1.10.5.o");
-                } else if (platform.versionLessThan(10, 8)) {
-                    try ctx.args.append("-lcrt1.10.6.o");
-                }
-            },
-            .IPhoneOS => {
-                if (ctx.comp.target.cpu.arch == .aarch64) {
-                    // iOS does not need any crt1 files for arm64
-                } else if (platform.versionLessThan(3, 1)) {
-                    try ctx.args.append("-lcrt1.o");
-                } else if (platform.versionLessThan(6, 0)) {
-                    try ctx.args.append("-lcrt1.3.1.o");
-                }
-            },
-            .IPhoneOSSimulator => {}, // no crt1.o needed
-        }
-    }
-
-    for (ctx.comp.link_objects) |link_object| {
-        const link_obj_with_null = try std.cstr.addNullByte(&ctx.arena.allocator, link_object);
-        try ctx.args.append(@ptrCast([*:0]const u8, link_obj_with_null.ptr));
-    }
-    try addFnObjects(ctx);
-
-    // TODO
-    //if (ctx.comp.target == Target.Native) {
-    //    for (ctx.comp.link_libs_list.span()) |lib| {
-    //        if (mem.eql(u8, lib.name, "c")) {
-    //            // on Darwin, libSystem has libc in it, but also you have to use it
-    //            // to make syscalls because the syscall numbers are not documented
-    //            // and change between versions.
-    //            // so we always link against libSystem
-    //            try ctx.args.append("-lSystem");
-    //        } else {
-    //            if (mem.indexOfScalar(u8, lib.name, '/') == null) {
-    //                const arg = try std.fmt.allocPrint(&ctx.arena.allocator, "-l{}\x00", .{lib.name});
-    //                try ctx.args.append(@ptrCast([*:0]const u8, arg.ptr));
-    //            } else {
-    //                const arg = try std.cstr.addNullByte(&ctx.arena.allocator, lib.name);
-    //                try ctx.args.append(@ptrCast([*:0]const u8, arg.ptr));
-    //            }
-    //        }
-    //    }
-    //} else {
-    //    try ctx.args.append("-undefined");
-    //    try ctx.args.append("dynamic_lookup");
-    //}
-
-    if (platform.kind == .MacOS) {
-        if (platform.versionLessThan(10, 5)) {
-            try ctx.args.append("-lgcc_s.10.4");
-        } else if (platform.versionLessThan(10, 6)) {
-            try ctx.args.append("-lgcc_s.10.5");
-        }
-    } else {
-        @panic("TODO");
-    }
-}
-
-fn constructLinkerArgsWasm(ctx: *Context) void {
-    @panic("TODO");
-}
-
-fn addFnObjects(ctx: *Context) !void {
-    const held = ctx.comp.fn_link_set.acquire();
-    defer held.release();
-
-    var it = held.value.first;
-    while (it) |node| {
-        const fn_val = node.data orelse {
-            // handle the tombstone. See Value.Fn.destroy.
-            it = node.next;
-            held.value.remove(node);
-            ctx.comp.gpa().destroy(node);
-            continue;
-        };
-        try ctx.args.append(fn_val.containing_object.span());
-        it = node.next;
-    }
-}
-
-const DarwinPlatform = struct {
-    kind: Kind,
-    major: u32,
-    minor: u32,
-    micro: u32,
-
-    const Kind = enum {
-        MacOS,
-        IPhoneOS,
-        IPhoneOSSimulator,
-    };
-
-    fn get(comp: *Compilation) !DarwinPlatform {
-        var result: DarwinPlatform = undefined;
-        const ver_str = switch (comp.darwin_version_min) {
-            .MacOS => |ver| blk: {
-                result.kind = .MacOS;
-                break :blk ver;
-            },
-            .Ios => |ver| blk: {
-                result.kind = .IPhoneOS;
-                break :blk ver;
-            },
-            .None => blk: {
-                assert(comp.target.os.tag == .macosx);
-                result.kind = .MacOS;
-                break :blk "10.14";
-            },
-        };
-
-        var had_extra: bool = undefined;
-        try darwinGetReleaseVersion(
-            ver_str,
-            &result.major,
-            &result.minor,
-            &result.micro,
-            &had_extra,
-        );
-        if (had_extra or result.major != 10 or result.minor >= 100 or result.micro >= 100) {
-            return error.InvalidDarwinVersionString;
-        }
-
-        if (result.kind == .IPhoneOS) {
-            switch (comp.target.cpu.arch) {
-                .i386,
-                .x86_64,
-                => result.kind = .IPhoneOSSimulator,
-                else => {},
-            }
-        }
-        return result;
-    }
-
-    fn versionLessThan(self: DarwinPlatform, major: u32, minor: u32) bool {
-        if (self.major < major)
-            return true;
-        if (self.major > major)
-            return false;
-        if (self.minor < minor)
-            return true;
-        return false;
-    }
-};
-
-/// Parse (([0-9]+)(.([0-9]+)(.([0-9]+)?))?)? and return the
-/// grouped values as integers. Numbers which are not provided are set to 0.
-/// return true if the entire string was parsed (9.2), or all groups were
-/// parsed (10.3.5extrastuff).
-fn darwinGetReleaseVersion(str: []const u8, major: *u32, minor: *u32, micro: *u32, had_extra: *bool) !void {
-    major.* = 0;
-    minor.* = 0;
-    micro.* = 0;
-    had_extra.* = false;
-
-    if (str.len == 0)
-        return error.InvalidDarwinVersionString;
-
-    var start_pos: usize = 0;
-    for ([_]*u32{ major, minor, micro }) |v| {
-        const dot_pos = mem.indexOfScalarPos(u8, str, start_pos, '.');
-        const end_pos = dot_pos orelse str.len;
-        v.* = std.fmt.parseUnsigned(u32, str[start_pos..end_pos], 10) catch return error.InvalidDarwinVersionString;
-        start_pos = (dot_pos orelse return) + 1;
-        if (start_pos == str.len) return;
-    }
-    had_extra.* = true;
+fn bswapAllFields(comptime S: type, ptr: *S) void {
+    @panic("TODO implement bswapAllFields");
 }

--- a/src-self-hosted/link.zig
+++ b/src-self-hosted/link.zig
@@ -7,7 +7,11 @@ const fs = std.fs;
 const elf = std.elf;
 const codegen = @import("codegen.zig");
 
-const executable_mode = 0o755;
+/// On common systems with a 0o022 umask, 0o777 will still result in a file created
+/// with 0o755 permissions, but it works appropriately if the system is configured
+/// more leniently. As another data point, C's fopen seems to open files with the
+/// 666 mode.
+const executable_mode = 0o777;
 const default_entry_addr = 0x8000000;
 
 pub const ErrorMsg = struct {

--- a/src-self-hosted/value.zig
+++ b/src-self-hosted/value.zig
@@ -264,6 +264,56 @@ pub const Value = extern union {
         }
     }
 
+    /// Asserts the value is an integer and it fits in a u64
+    pub fn toUnsignedInt(self: Value) u64 {
+        switch (self.tag()) {
+            .ty,
+            .u8_type,
+            .i8_type,
+            .isize_type,
+            .usize_type,
+            .c_short_type,
+            .c_ushort_type,
+            .c_int_type,
+            .c_uint_type,
+            .c_long_type,
+            .c_ulong_type,
+            .c_longlong_type,
+            .c_ulonglong_type,
+            .c_longdouble_type,
+            .f16_type,
+            .f32_type,
+            .f64_type,
+            .f128_type,
+            .c_void_type,
+            .bool_type,
+            .void_type,
+            .type_type,
+            .anyerror_type,
+            .comptime_int_type,
+            .comptime_float_type,
+            .noreturn_type,
+            .fn_naked_noreturn_no_args_type,
+            .single_const_pointer_to_comptime_int_type,
+            .const_slice_u8_type,
+            .void_value,
+            .noreturn_value,
+            .bool_true,
+            .bool_false,
+            .function,
+            .ref,
+            .ref_val,
+            .bytes,
+            => unreachable,
+
+            .zero => return 0,
+
+            .int_u64 => return self.cast(Payload.Int_u64).?.int,
+            .int_i64 => return @intCast(u64, self.cast(Payload.Int_u64).?.int),
+            .int_big => return self.cast(Payload.IntBig).?.big_int.to(u64) catch unreachable,
+        }
+    }
+
     /// Asserts the value is an integer, and the destination type is ComptimeInt or Int.
     pub fn intFitsInType(self: Value, ty: Type, target: Target) bool {
         switch (self.tag()) {


### PR DESCRIPTION
This is the beginning of a self-hosted incremental linker (#1535) as well as pure Zig backend.

Here's a demo:

#### hello.zir

```
@0 = str("Hello, world!\n")
@1 = primitive(noreturn)
@2 = primitive(usize)
@3 = fntype([], @1, cc=Naked)
@4 = int(0)
@5 = int(1)
@6 = int(231)
@7 = str("len")

@8 = fn(@3, {
  %0 = as(@2, @5) ; SYS_write
  %1 = as(@2, @5) ; STDOUT_FILENO
  %2 = ptrtoint(@0) ; msg ptr
  %3 = fieldptr(@0, @7) ; msg len ptr
  %4 = deref(%3) ; msg len
  %sysoutreg = str("={rax}")
  %rax = str("{rax}")
  %rdi = str("{rdi}")
  %rsi = str("{rsi}")
  %rdx = str("{rdx}")
  %rcx = str("rcx")
  %r11 = str("r11")
  %memory = str("memory")
  %syscall = str("syscall")
  %5 = asm(%syscall, @2,
    volatile=1,
    output=%sysoutreg,
    inputs=[%rax, %rdi, %rsi, %rdx],
    clobbers=[%rcx, %r11, %memory],
    args=[%0, %1, %2, %4])

  %6 = as(@2, @6) ;SYS_exit_group
  %7 = as(@2, @4) ;exit code
  %8 = asm(%syscall, @2,
    volatile=1,
    output=%sysoutreg,
    inputs=[%rax, %rdi],
    clobbers=[%rcx, %r11, %memory],
    args=[%6, %7])

  %9 = unreachable()
})

@9 = str("_start")
@10 = export(@9, @8)
```

Now run the example program:

```
[nix-shell:~/dev/zig/build]$ ./ir hello.zir 
@0 = str("Hello, world!\n")
@1 = str("{rax}")
@2 = str("{rdi}")
@3 = str("{rsi}")
@4 = str("{rdx}")
@5 = str("rcx")
@6 = str("r11")
@7 = str("memory")
@8 = primitive(usize)
@9 = int(1)
@10 = as(@8, @9)
@11 = primitive(usize)
@12 = int(1)
@13 = as(@11, @12)
@14 = primitive(usize)
@15 = int(14)
@16 = as(@14, @15)
@17 = str("syscall")
@18 = primitive(usize)
@19 = str("={rax}")
@20 = str("{rax}")
@21 = str("{rdi}")
@22 = str("rcx")
@23 = str("r11")
@24 = str("memory")
@25 = primitive(usize)
@26 = int(231)
@27 = as(@25, @26)
@28 = primitive(usize)
@29 = int(0)
@30 = as(@28, @29)
@31 = str("syscall")
@32 = primitive(usize)
@33 = str("={rax}")
@34 = primitive(noreturn)
@35 = fntype([], @34, cc=Naked)
@36 = fn(@35, {
  %0 = ptrtoint(@0)
  %1 = asm(@17, @18, volatile=1, output=@19, inputs=[@1, @2, @3, @4], clobbers=[@5, @6, @7], args=[@10, @13, %0, @16])
  %2 = asm(@31, @32, volatile=1, output=@33, inputs=[@20, @21], clobbers=[@22, @23, @24], args=[@27, @30])
  %3 = unreachable()
})
@37 = str("_start")
@38 = export(@37, @36)
```

This example code renders back to ZIR after semantic analysis is complete, and also creates `a.out`:

```
[nix-shell:~/dev/zig/build]$ ./a.out 
Hello, world!

[nix-shell:~/dev/zig/build]$ strace ./a.out 
execve("./a.out", ["./a.out"], 0x7ffef9ea81a0 /* 128 vars */) = 0
write(1, "Hello, world!\n", 14Hello, world!
)         = 14
exit_group(0)                           = ?
+++ exited with 0 +++

[nix-shell:~/dev/zig/build]$ objdump -d a.out 

a.out:     file format elf64-x86-64


Disassembly of section .text:

0000000008000000 <_start>:
 8000000:	eb 0e                	jmp    8000010 <_start+0x10>
 8000002:	48                   	rex.W
 8000003:	65 6c                	gs insb (%dx),%es:(%rdi)
 8000005:	6c                   	insb   (%dx),%es:(%rdi)
 8000006:	6f                   	outsl  %ds:(%rsi),(%dx)
 8000007:	2c 20                	sub    $0x20,%al
 8000009:	77 6f                	ja     800007a <_start+0x7a>
 800000b:	72 6c                	jb     8000079 <_start+0x79>
 800000d:	64 21 0a             	and    %ecx,%fs:(%rdx)
 8000010:	b8 01 00 00 00       	mov    $0x1,%eax
 8000015:	bf 01 00 00 00       	mov    $0x1,%edi
 800001a:	48 8d 35 e1 ff ff ff 	lea    -0x1f(%rip),%rsi        # 8000002 <_start+0x2>
 8000021:	ba 0e 00 00 00       	mov    $0xe,%edx
 8000026:	0f 05                	syscall 
 8000028:	b8 e7 00 00 00       	mov    $0xe7,%eax
 800002d:	31 ff                	xor    %edi,%edi
 800002f:	0f 05                	syscall 
 8000031:	cc                   	int3   
```

Here you can see the "Hello, World!" string is embedded directly into the function. That's not necessarily how it is going to work in the future.

### A plan for incremental recompilation

I do have a plan for incremental compilation now (only applicable to debug mode):

The idea is that every top level declaration in zig maps to an ELF symbol. All functions are generated with Position Independent Code. Part of what the cache stores is a mapping from zig top level decl to the decls that depend on it directly.

When a file is detected as changed, we then re-parse the AST of that file looking for AST changes per decl. Now we have a set of decls that is changed. Follow the dependency tree, regenerating decls.

Now we have a set of regenerated decls, and each one maps directly to a symbol in the ELF file. So we only have to go modify symbols in the ELF file that correspond to changed decls.

### Next steps

 * Hook this up to tests right away
 * Make it work for PE (Portable Executable) as well
 * Figure out how comptime code & control flow will work with ZIR code.
 * Start reworking the frontend to integrate with the backend
 * Language Server
 * Set up performance and resource usage testing & tracking
 * Iterate on incremental compilation
 * Async I/O /  taking advantage of multiple threads
 * Emit DWARF info
