### PR TITLE
Fix issue with std.json incorrectly replacing forward slashes with a backslash

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -2670,6 +2670,8 @@ test "stringify string" {
     try teststringify("\"with unicode\\ud800\\udc00\"", "with unicode\u{10000}", StringifyOptions{ .string = .{ .String = .{ .escape_unicode = true } } });
     try teststringify("\"with unicode\u{10FFFF}\"", "with unicode\u{10FFFF}", StringifyOptions{});
     try teststringify("\"with unicode\\udbff\\udfff\"", "with unicode\u{10FFFF}", StringifyOptions{ .string = .{ .String = .{ .escape_unicode = true } } });
+    try teststringify("\"/\"", "/", StringifyOptions{});
+    try teststringify("\"\\/\"", "/", StringifyOptions{ .string = .{ .String = .{ .escape_solidus = true } } });
 }
 
 test "stringify tagged unions" {

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -2520,7 +2520,7 @@ pub fn stringify(
                                 if (options.string.String.escape_solidus) {
                                     try out_stream.writeAll("\\/");
                                 } else {
-                                    try out_stream.writeByte('\\');
+                                    try out_stream.writeByte('/');
                                 }
                             },
                             // control characters with short escapes


### PR DESCRIPTION
`std.json` incorrectly replaced `/` with a `\`, this pull request fixes that.