### PR TITLE
Fix f64 variants of math.cosh and math.sinh to accept negative inputs.

### DIFF
--- a/lib/std/math/cosh.zig
+++ b/lib/std/math/cosh.zig
@@ -56,7 +56,7 @@ fn cosh32(x: f32) f32 {
 
 fn cosh64(x: f64) f64 {
     const u = @bitCast(u64, x);
-    const w = @intCast(u32, u >> 32);
+    const w = @intCast(u32, u >> 32) & (maxInt(u32) >> 1);
     const ax = @bitCast(f64, u & (maxInt(u64) >> 1));
 
     // TODO: Shouldn't need this explicit check.
@@ -99,6 +99,10 @@ test "math.cosh32" {
     expect(math.approxEq(f32, cosh32(0.2), 1.020067, epsilon));
     expect(math.approxEq(f32, cosh32(0.8923), 1.425225, epsilon));
     expect(math.approxEq(f32, cosh32(1.5), 2.352410, epsilon));
+    expect(math.approxEq(f32, cosh32(-0.0), 1.0, epsilon));
+    expect(math.approxEq(f32, cosh32(-0.2), 1.020067, epsilon));
+    expect(math.approxEq(f32, cosh32(-0.8923), 1.425225, epsilon));
+    expect(math.approxEq(f32, cosh32(-1.5), 2.352410, epsilon));
 }
 
 test "math.cosh64" {
@@ -108,6 +112,10 @@ test "math.cosh64" {
     expect(math.approxEq(f64, cosh64(0.2), 1.020067, epsilon));
     expect(math.approxEq(f64, cosh64(0.8923), 1.425225, epsilon));
     expect(math.approxEq(f64, cosh64(1.5), 2.352410, epsilon));
+    expect(math.approxEq(f64, cosh64(-0.0), 1.0, epsilon));
+    expect(math.approxEq(f64, cosh64(-0.2), 1.020067, epsilon));
+    expect(math.approxEq(f64, cosh64(-0.8923), 1.425225, epsilon));
+    expect(math.approxEq(f64, cosh64(-1.5), 2.352410, epsilon));
 }
 
 test "math.cosh32.special" {

--- a/lib/std/math/sinh.zig
+++ b/lib/std/math/sinh.zig
@@ -62,7 +62,7 @@ fn sinh32(x: f32) f32 {
 
 fn sinh64(x: f64) f64 {
     const u = @bitCast(u64, x);
-    const w = @intCast(u32, u >> 32);
+    const w = @intCast(u32, u >> 32) & (maxInt(u32) >> 1);
     const ax = @bitCast(f64, u & (maxInt(u64) >> 1));
 
     if (x == 0.0 or math.isNan(x)) {
@@ -104,6 +104,10 @@ test "math.sinh32" {
     expect(math.approxEq(f32, sinh32(0.2), 0.201336, epsilon));
     expect(math.approxEq(f32, sinh32(0.8923), 1.015512, epsilon));
     expect(math.approxEq(f32, sinh32(1.5), 2.129279, epsilon));
+    expect(math.approxEq(f32, sinh32(-0.0), -0.0, epsilon));
+    expect(math.approxEq(f32, sinh32(-0.2), -0.201336, epsilon));
+    expect(math.approxEq(f32, sinh32(-0.8923), -1.015512, epsilon));
+    expect(math.approxEq(f32, sinh32(-1.5), -2.129279, epsilon));
 }
 
 test "math.sinh64" {
@@ -113,6 +117,10 @@ test "math.sinh64" {
     expect(math.approxEq(f64, sinh64(0.2), 0.201336, epsilon));
     expect(math.approxEq(f64, sinh64(0.8923), 1.015512, epsilon));
     expect(math.approxEq(f64, sinh64(1.5), 2.129279, epsilon));
+    expect(math.approxEq(f64, sinh64(-0.0), -0.0, epsilon));
+    expect(math.approxEq(f64, sinh64(-0.2), -0.201336, epsilon));
+    expect(math.approxEq(f64, sinh64(-0.8923), -1.015512, epsilon));
+    expect(math.approxEq(f64, sinh64(-1.5), -2.129279, epsilon));
 }
 
 test "math.sinh32.special" {


### PR DESCRIPTION
This addresses the issue reported here:

https://github.com/ziglang/zig/issues/5168

I noticed that the same issue also appears in sinh while writing more tests around the code I have been writing.