### PR TITLE
add missing const to pkg dependencies

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1054,7 +1054,7 @@ pub const Target = std.zig.CrossTarget;
 pub const Pkg = struct {
     name: []const u8,
     path: []const u8,
-    dependencies: ?[]Pkg = null,
+    dependencies: ?[]const Pkg = null,
 };
 
 const CSourceFile = struct {


### PR DESCRIPTION
Fixes #5183 

Pkg dependencies needed a `const` to make it work.