### PR TITLE
zig fmt: Fix relative paths with . and .. on Windows as well as forward slashes

### DIFF
--- a/lib/std/io/buffered_atomic_file.zig
+++ b/lib/std/io/buffered_atomic_file.zig
@@ -15,8 +15,12 @@ pub const BufferedAtomicFile = struct {
 
     /// TODO when https://github.com/ziglang/zig/issues/2761 is solved
     /// this API will not need an allocator
-    /// TODO integrate this with Dir API
-    pub fn create(allocator: *mem.Allocator, dest_path: []const u8) !*BufferedAtomicFile {
+    pub fn create(
+        allocator: *mem.Allocator,
+        dir: fs.Dir,
+        dest_path: []const u8,
+        atomic_file_options: fs.Dir.AtomicFileOptions,
+    ) !*BufferedAtomicFile {
         var self = try allocator.create(BufferedAtomicFile);
         self.* = BufferedAtomicFile{
             .atomic_file = undefined,
@@ -26,7 +30,7 @@ pub const BufferedAtomicFile = struct {
         };
         errdefer allocator.destroy(self);
 
-        self.atomic_file = try fs.cwd().atomicFile(dest_path, .{});
+        self.atomic_file = try dir.atomicFile(dest_path, atomic_file_options);
         errdefer self.atomic_file.deinit();
 
         self.file_stream = self.atomic_file.file.outStream();

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -318,11 +318,18 @@ const FmtError = error{
 } || fs.File.OpenError;
 
 fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {
-    if (fmt.seen.exists(file_path)) return;
-    try fmt.seen.put(file_path);
+    // get the real path here to avoid Windows failing on relative file paths with . or .. in them
+    var real_path = fs.realpathAlloc(fmt.allocator, file_path) catch |err| {
+        try stderr.print("unable to open '{}': {}\n", .{ file_path, err });
+        fmt.any_error = true;
+        return;
+    };
+    defer fmt.allocator.free(real_path);
 
-    const max = std.math.maxInt(usize);
-    const source_code = fs.cwd().readFileAlloc(fmt.allocator, file_path, max) catch |err| switch (err) {
+    if (fmt.seen.exists(real_path)) return;
+    try fmt.seen.put(real_path);
+
+    const source_code = fs.cwd().readFileAlloc(fmt.allocator, real_path, self_hosted_main.max_src_size) catch |err| switch (err) {
         error.IsDir, error.AccessDenied => {
             // TODO make event based (and dir.next())
             var dir = try fs.cwd().openDir(file_path, .{ .iterate = true });
@@ -332,7 +339,7 @@ fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {
 
             while (try dir_it.next()) |entry| {
                 if (entry.kind == .Directory or mem.endsWith(u8, entry.name, ".zig")) {
-                    const full_path = try fs.path.join(fmt.allocator, &[_][]const u8{ file_path, entry.name });
+                    const full_path = try fs.path.join(fmt.allocator, &[_][]const u8{ real_path, entry.name });
                     try fmtPath(fmt, full_path, check_mode);
                 }
             }
@@ -370,7 +377,7 @@ fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {
             fmt.any_error = true;
         }
     } else {
-        const baf = try io.BufferedAtomicFile.create(fmt.allocator, file_path);
+        const baf = try io.BufferedAtomicFile.create(fmt.allocator, real_path);
         defer baf.destroy();
 
         const anything_changed = try std.zig.render(fmt.allocator, baf.stream(), tree);

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -339,7 +339,7 @@ fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {
 
             while (try dir_it.next()) |entry| {
                 if (entry.kind == .Directory or mem.endsWith(u8, entry.name, ".zig")) {
-                    const full_path = try fs.path.join(fmt.allocator, &[_][]const u8{ real_path, entry.name });
+                    const full_path = try fs.path.join(fmt.allocator, &[_][]const u8{ file_path, entry.name });
                     try fmtPath(fmt, full_path, check_mode);
                 }
             }
@@ -377,7 +377,7 @@ fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {
             fmt.any_error = true;
         }
     } else {
-        const baf = try io.BufferedAtomicFile.create(fmt.allocator, real_path);
+        const baf = try io.BufferedAtomicFile.create(fmt.allocator, fs.cwd(), real_path, .{});
         defer baf.destroy();
 
         const anything_changed = try std.zig.render(fmt.allocator, baf.stream(), tree);


### PR DESCRIPTION
This is @squeek502's pull request #4655 with a couple of additional modifications.

@squeek502 does this look OK to you?

I also plan on looking into making "." and ".." work in the code that calls `NtCreateFile` but I agree with you that can be a separate issue.