### PR TITLE
@Vector -> @Type(.Vector)

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1850,8 +1850,8 @@ test "null terminated array" {
       {#header_open|Vectors#}
       <p>
       A vector is a group of {#link|Integers#}, {#link|Floats#}, or {#link|Pointers#} which are operated on
-      in parallel using a single instruction ({#link|SIMD#}). Vector types are created with the builtin
-      function {#link|@Vector#}.
+      in parallel using a single instruction ({#link|SIMD#}). Vector types are created with the builtin function {#link|@Type#},
+      or using the shorthand as {#syntax#}std.meta.Vector{#endsyntax#}.
       </p>
       <p>
       TODO talk about C ABI interop
@@ -7934,7 +7934,7 @@ test "@setRuntimeSafety" {
       {#header_close#}
 
       {#header_open|@shuffle#}
-      <pre>{#syntax#}@shuffle(comptime E: type, a: @Vector(a_len, E), b: @Vector(b_len, E), comptime mask: @Vector(mask_len, i32)) @Vector(mask_len, E){#endsyntax#}</pre>
+      <pre>{#syntax#}@shuffle(comptime E: type, a: std.meta.Vector(a_len, E), b: std.meta.Vector(b_len, E), comptime mask: std.meta.Vector(mask_len, i32)) std.meta.Vector(mask_len, E){#endsyntax#}</pre>
       <p>
       Constructs a new {#link|vector|Vectors#} by selecting elements from {#syntax#}a{#endsyntax#} and
       {#syntax#}b{#endsyntax#} based on {#syntax#}mask{#endsyntax#}.
@@ -7990,7 +7990,7 @@ test "@setRuntimeSafety" {
       {#header_close#}
 
       {#header_open|@splat#}
-      <pre>{#syntax#}@splat(comptime len: u32, scalar: var) @Vector(len, @TypeOf(scalar)){#endsyntax#}</pre>
+      <pre>{#syntax#}@splat(comptime len: u32, scalar: var) std.meta.Vector(len, @TypeOf(scalar)){#endsyntax#}</pre>
       <p>
       Produces a vector of length {#syntax#}len{#endsyntax#} where each element is the value
       {#syntax#}scalar{#endsyntax#}:
@@ -8002,7 +8002,7 @@ const assert = std.debug.assert;
 test "vector @splat" {
     const scalar: u32 = 5;
     const result = @splat(4, scalar);
-    comptime assert(@TypeOf(result) == @Vector(4, u32));
+    comptime assert(@TypeOf(result) == std.meta.Vector(4, u32));
     assert(std.mem.eql(u32, &@as([4]u32, result), &[_]u32{ 5, 5, 5, 5 }));
 }
       {#code_end#}
@@ -8358,17 +8358,6 @@ fn foo(comptime T: type, ptr: *T) T {
       </p>
       <p>
       {#syntax#}@unionInit{#endsyntax#} forwards its {#link|result location|Result Location Semantics#} to {#syntax#}init_expr{#endsyntax#}.
-      </p>
-      {#header_close#}
-
-      {#header_open|@Vector#}
-      <pre>{#syntax#}@Vector(comptime len: u32, comptime ElemType: type) type{#endsyntax#}</pre>
-      <p>
-      This function returns a vector type for {#link|SIMD#}.
-      </p>
-      <p>
-      {#syntax#}ElemType{#endsyntax#} must be an {#link|integer|Integers#}, a {#link|float|Floats#}, or a
-      {#link|pointer|Pointers#}.
       </p>
       {#header_close#}
       {#header_close#}

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1670,9 +1670,9 @@ test "vector" {
         return error.SkipZigTest;
     }
 
-    const vbool: @Vector(4, bool) = [_]bool{ true, false, true, false };
-    const vi64: @Vector(4, i64) = [_]i64{ -2, -1, 0, 1 };
-    const vu64: @Vector(4, u64) = [_]u64{ 1000, 2000, 3000, 4000 };
+    const vbool: std.meta.Vector(4, bool) = [_]bool{ true, false, true, false };
+    const vi64: std.meta.Vector(4, i64) = [_]i64{ -2, -1, 0, 1 };
+    const vu64: std.meta.Vector(4, u64) = [_]u64{ 1000, 2000, 3000, 4000 };
 
     try testFmt("{ true, false, true, false }", "{}", .{vbool});
     try testFmt("{ -2, -1, 0, 1 }", "{}", .{vi64});

--- a/lib/std/hash/auto_hash.zig
+++ b/lib/std/hash/auto_hash.zig
@@ -359,13 +359,13 @@ test "testHash vector" {
     // Disabled because of #3317
     if (@import("builtin").arch == .mipsel or @import("builtin").arch == .mips) return error.SkipZigTest;
 
-    const a: @Vector(4, u32) = [_]u32{ 1, 2, 3, 4 };
-    const b: @Vector(4, u32) = [_]u32{ 1, 2, 3, 5 };
+    const a: meta.Vector(4, u32) = [_]u32{ 1, 2, 3, 4 };
+    const b: meta.Vector(4, u32) = [_]u32{ 1, 2, 3, 5 };
     testing.expect(testHash(a) == testHash(a));
     testing.expect(testHash(a) != testHash(b));
 
-    const c: @Vector(4, u31) = [_]u31{ 1, 2, 3, 4 };
-    const d: @Vector(4, u31) = [_]u31{ 1, 2, 3, 5 };
+    const c: meta.Vector(4, u31) = [_]u31{ 1, 2, 3, 4 };
+    const d: meta.Vector(4, u31) = [_]u31{ 1, 2, 3, 5 };
     testing.expect(testHash(c) == testHash(c));
     testing.expect(testHash(c) != testHash(d));
 }

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -650,3 +650,12 @@ pub fn IntType(comptime is_signed: bool, comptime bit_count: u16) type {
         },
     });
 }
+
+pub fn Vector(comptime len: u32, comptime child: type) type {
+    return @Type(TypeInfo{
+        .Vector = .{
+            .len = len,
+            .child = child,
+        },
+    });
+}

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -291,7 +291,7 @@ comptime {
                 @export(@import("compiler_rt/umodti3.zig").__umodti3, .{ .name = "__umodti3", .linkage = linkage });
             },
             .x86_64 => {
-                // The "ti" functions must use @Vector(2, u64) parameter types to adhere to the ABI
+                // The "ti" functions must use Vector(2, u64) parameter types to adhere to the ABI
                 // that LLVM expects compiler-rt to have.
                 @export(@import("compiler_rt/divti3.zig").__divti3_windows_x86_64, .{ .name = "__divti3", .linkage = linkage });
                 @export(@import("compiler_rt/modti3.zig").__modti3_windows_x86_64, .{ .name = "__modti3", .linkage = linkage });

--- a/lib/std/special/compiler_rt/divti3.zig
+++ b/lib/std/special/compiler_rt/divti3.zig
@@ -15,7 +15,7 @@ pub fn __divti3(a: i128, b: i128) callconv(.C) i128 {
     return (@bitCast(i128, r) ^ s) -% s;
 }
 
-const v128 = @Vector(2, u64);
+const v128 = @import("std").meta.Vector(2, u64);
 pub fn __divti3_windows_x86_64(a: v128, b: v128) callconv(.C) v128 {
     return @bitCast(v128, @call(.{ .modifier = .always_inline }, __divti3, .{
         @bitCast(i128, a),

--- a/lib/std/special/compiler_rt/modti3.zig
+++ b/lib/std/special/compiler_rt/modti3.zig
@@ -20,7 +20,7 @@ pub fn __modti3(a: i128, b: i128) callconv(.C) i128 {
     return (@bitCast(i128, r) ^ s_a) -% s_a; // negate if s == -1
 }
 
-const v128 = @Vector(2, u64);
+const v128 = @import("std").meta.Vector(2, u64);
 pub fn __modti3_windows_x86_64(a: v128, b: v128) callconv(.C) v128 {
     return @bitCast(v128, @call(.{ .modifier = .always_inline }, __modti3, .{
         @bitCast(i128, a),

--- a/lib/std/special/compiler_rt/multi3.zig
+++ b/lib/std/special/compiler_rt/multi3.zig
@@ -14,7 +14,7 @@ pub fn __multi3(a: i128, b: i128) callconv(.C) i128 {
     return r.all;
 }
 
-const v128 = @Vector(2, u64);
+const v128 = @import("std").meta.Vector(2, u64);
 pub fn __multi3_windows_x86_64(a: v128, b: v128) callconv(.C) v128 {
     return @bitCast(v128, @call(.{ .modifier = .always_inline }, __multi3, .{
         @bitCast(i128, a),

--- a/lib/std/special/compiler_rt/udivmodti4.zig
+++ b/lib/std/special/compiler_rt/udivmodti4.zig
@@ -7,7 +7,7 @@ pub fn __udivmodti4(a: u128, b: u128, maybe_rem: ?*u128) callconv(.C) u128 {
     return udivmod(u128, a, b, maybe_rem);
 }
 
-const v128 = @Vector(2, u64);
+const v128 = @import("std").meta.Vector(2, u64);
 pub fn __udivmodti4_windows_x86_64(a: v128, b: v128, maybe_rem: ?*u128) callconv(.C) v128 {
     @setRuntimeSafety(builtin.is_test);
     return @bitCast(v128, udivmod(u128, @bitCast(u128, a), @bitCast(u128, b), maybe_rem));

--- a/lib/std/special/compiler_rt/udivti3.zig
+++ b/lib/std/special/compiler_rt/udivti3.zig
@@ -6,7 +6,7 @@ pub fn __udivti3(a: u128, b: u128) callconv(.C) u128 {
     return udivmodti4.__udivmodti4(a, b, null);
 }
 
-const v128 = @Vector(2, u64);
+const v128 = @import("std").meta.Vector(2, u64);
 pub fn __udivti3_windows_x86_64(a: v128, b: v128) callconv(.C) v128 {
     @setRuntimeSafety(builtin.is_test);
     return udivmodti4.__udivmodti4_windows_x86_64(a, b, null);

--- a/lib/std/special/compiler_rt/umodti3.zig
+++ b/lib/std/special/compiler_rt/umodti3.zig
@@ -9,7 +9,7 @@ pub fn __umodti3(a: u128, b: u128) callconv(.C) u128 {
     return r;
 }
 
-const v128 = @Vector(2, u64);
+const v128 = @import("std").meta.Vector(2, u64);
 pub fn __umodti3_windows_x86_64(a: v128, b: v128) callconv(.C) v128 {
     return @bitCast(v128, @call(.{ .modifier = .always_inline }, __umodti3, .{
         @bitCast(u128, a),

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -488,8 +488,8 @@ pub const Target = struct {
 
                 /// Adds the specified feature set but not its dependencies.
                 pub fn addFeatureSet(set: *Set, other_set: Set) void {
-                    set.ints = @as(@Vector(usize_count, usize), set.ints) |
-                        @as(@Vector(usize_count, usize), other_set.ints);
+                    set.ints = @as(std.meta.Vector(usize_count, usize), set.ints) |
+                        @as(std.meta.Vector(usize_count, usize), other_set.ints);
                 }
 
                 /// Removes the specified feature but not its dependents.
@@ -501,8 +501,8 @@ pub const Target = struct {
 
                 /// Removes the specified feature but not its dependents.
                 pub fn removeFeatureSet(set: *Set, other_set: Set) void {
-                    set.ints = @as(@Vector(usize_count, usize), set.ints) &
-                        ~@as(@Vector(usize_count, usize), other_set.ints);
+                    set.ints = @as(std.meta.Vector(usize_count, usize), set.ints) &
+                        ~@as(std.meta.Vector(usize_count, usize), other_set.ints);
                 }
 
                 pub fn populateDependencies(set: *Set, all_features_list: []const Cpu.Feature) void {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -25426,6 +25426,10 @@ static ZigType *type_info_to_type(IrAnalyze *ira, IrInst *source_instr, ZigTypeI
             assert(payload->type == ir_type_info_get_type(ira, "Vector", nullptr));
             BigInt *len = get_const_field_lit_int(ira, source_instr->source_node, payload, "len", 0);
             ZigType *child_type = get_const_field_meta_type(ira, source_instr->source_node, payload, "child", 1);
+            Error err;
+            if ((err = ir_validate_vector_elem_type(ira, source_instr->source_node, child_type))) {
+                return ira->codegen->invalid_inst_gen->value->type;
+            }
             return get_vector_type(ira->codegen, bigint_as_u32(len), child_type);
         }
         case ZigTypeIdAnyFrame: {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -984,7 +984,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
 
     cases.add("store vector pointer with unknown runtime index",
         \\export fn entry() void {
-        \\    var v: @Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
+        \\    var v: @import("std").meta.Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
         \\
         \\    var i: u32 = 0;
         \\    storev(&v[i], 42);
@@ -999,7 +999,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
 
     cases.add("load vector pointer with unknown runtime index",
         \\export fn entry() void {
-        \\    var v: @Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
+        \\    var v: @import("std").meta.Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
         \\
         \\    var i: u32 = 0;
         \\    var x = loadv(&v[i]);
@@ -1885,8 +1885,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
 
     cases.addTest("comptime vector overflow shows the index",
         \\comptime {
-        \\    var a: @Vector(4, u8) = [_]u8{ 1, 2, 255, 4 };
-        \\    var b: @Vector(4, u8) = [_]u8{ 5, 6, 1, 8 };
+        \\    var a: @import("std").meta.Vector(4, u8) = [_]u8{ 1, 2, 255, 4 };
+        \\    var b: @import("std").meta.Vector(4, u8) = [_]u8{ 5, 6, 1, 8 };
         \\    var x = a + b;
         \\}
     , &[_][]const u8{
@@ -6846,8 +6846,8 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
 
     cases.addTest("@shuffle with selected index past first vector length",
         \\export fn entry() void {
-        \\    const v: @Vector(4, u32) = [4]u32{ 10, 11, 12, 13 };
-        \\    const x: @Vector(4, u32) = [4]u32{ 14, 15, 16, 17 };
+        \\    const v: @import("std").meta.Vector(4, u32) = [4]u32{ 10, 11, 12, 13 };
+        \\    const x: @import("std").meta.Vector(4, u32) = [4]u32{ 14, 15, 16, 17 };
         \\    var z = @shuffle(u32, v, x, [8]i32{ 0, 1, 2, 3, 7, 6, 5, 4 });
         \\}
     , &[_][]const u8{
@@ -6858,11 +6858,13 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
 
     cases.addTest("nested vectors",
         \\export fn entry() void {
-        \\    const V = @Vector(4, @Vector(4, u8));
-        \\    var v: V = undefined;
+        \\    const V1 = @import("std").meta.Vector(4, u8);
+        \\    const V2 = @Type(@import("builtin").TypeInfo{ .Vector = .{ .len = 4, .child = V1 } });
+        \\    var v: V2 = undefined;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:26: error: vector element type must be integer, float, bool, or pointer; '@Vector(4, u8)' is invalid",
+        "tmp.zig:3:49: error: vector element type must be integer, float, bool, or pointer; '@Vector(4, u8)' is invalid",
+        "tmp.zig:3:16: note: referenced here",
     });
 
     cases.addTest("bad @splat type",

--- a/test/runtime_safety.zig
+++ b/test/runtime_safety.zig
@@ -472,11 +472,11 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    @import("std").os.exit(126);
         \\}
         \\pub fn main() void {
-        \\    var a: @Vector(4, i32) = [_]i32{ 1, 2, 2147483643, 4 };
-        \\    var b: @Vector(4, i32) = [_]i32{ 5, 6, 7, 8 };
+        \\    var a: @import("std").meta.Vector(4, i32) = [_]i32{ 1, 2, 2147483643, 4 };
+        \\    var b: @import("std").meta.Vector(4, i32) = [_]i32{ 5, 6, 7, 8 };
         \\    const x = add(a, b);
         \\}
-        \\fn add(a: @Vector(4, i32), b: @Vector(4, i32)) @Vector(4, i32) {
+        \\fn add(a: @import("std").meta.Vector(4, i32), b: @import("std").meta.Vector(4, i32)) @import("std").meta.Vector(4, i32) {
         \\    return a + b;
         \\}
     );
@@ -486,11 +486,11 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    @import("std").os.exit(126);
         \\}
         \\pub fn main() void {
-        \\    var a: @Vector(4, u32) = [_]u32{ 1, 2, 8, 4 };
-        \\    var b: @Vector(4, u32) = [_]u32{ 5, 6, 7, 8 };
+        \\    var a: @import("std").meta.Vector(4, u32) = [_]u32{ 1, 2, 8, 4 };
+        \\    var b: @import("std").meta.Vector(4, u32) = [_]u32{ 5, 6, 7, 8 };
         \\    const x = sub(b, a);
         \\}
-        \\fn sub(a: @Vector(4, u32), b: @Vector(4, u32)) @Vector(4, u32) {
+        \\fn sub(a: @import("std").meta.Vector(4, u32), b: @import("std").meta.Vector(4, u32)) @import("std").meta.Vector(4, u32) {
         \\    return a - b;
         \\}
     );
@@ -500,11 +500,11 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    @import("std").os.exit(126);
         \\}
         \\pub fn main() void {
-        \\    var a: @Vector(4, u8) = [_]u8{ 1, 2, 200, 4 };
-        \\    var b: @Vector(4, u8) = [_]u8{ 5, 6, 2, 8 };
+        \\    var a: @import("std").meta.Vector(4, u8) = [_]u8{ 1, 2, 200, 4 };
+        \\    var b: @import("std").meta.Vector(4, u8) = [_]u8{ 5, 6, 2, 8 };
         \\    const x = mul(b, a);
         \\}
-        \\fn mul(a: @Vector(4, u8), b: @Vector(4, u8)) @Vector(4, u8) {
+        \\fn mul(a: @import("std").meta.Vector(4, u8), b: @import("std").meta.Vector(4, u8)) @import("std").meta.Vector(4, u8) {
         \\    return a * b;
         \\}
     );
@@ -514,10 +514,10 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    @import("std").os.exit(126);
         \\}
         \\pub fn main() void {
-        \\    var a: @Vector(4, i16) = [_]i16{ 1, -32768, 200, 4 };
+        \\    var a: @import("std").meta.Vector(4, i16) = [_]i16{ 1, -32768, 200, 4 };
         \\    const x = neg(a);
         \\}
-        \\fn neg(a: @Vector(4, i16)) @Vector(4, i16) {
+        \\fn neg(a: @import("std").meta.Vector(4, i16)) @import("std").meta.Vector(4, i16) {
         \\    return -a;
         \\}
     );
@@ -579,12 +579,12 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    @import("std").os.exit(126);
         \\}
         \\pub fn main() !void {
-        \\    var a: @Vector(4, i16) = [_]i16{ 1, 2, -32768, 4 };
-        \\    var b: @Vector(4, i16) = [_]i16{ 1, 2, -1, 4 };
+        \\    var a: @import("std").meta.Vector(4, i16) = [_]i16{ 1, 2, -32768, 4 };
+        \\    var b: @import("std").meta.Vector(4, i16) = [_]i16{ 1, 2, -1, 4 };
         \\    const x = div(a, b);
         \\    if (x[2] == 32767) return error.Whatever;
         \\}
-        \\fn div(a: @Vector(4, i16), b: @Vector(4, i16)) @Vector(4, i16) {
+        \\fn div(a: @import("std").meta.Vector(4, i16), b: @import("std").meta.Vector(4, i16)) @import("std").meta.Vector(4, i16) {
         \\    return @divTrunc(a, b);
         \\}
     );
@@ -658,11 +658,11 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    @import("std").os.exit(126);
         \\}
         \\pub fn main() void {
-        \\    var a: @Vector(4, i32) = [4]i32{111, 222, 333, 444};
-        \\    var b: @Vector(4, i32) = [4]i32{111, 0, 333, 444};
+        \\    var a: @import("std").meta.Vector(4, i32) = [4]i32{111, 222, 333, 444};
+        \\    var b: @import("std").meta.Vector(4, i32) = [4]i32{111, 0, 333, 444};
         \\    const x = div0(a, b);
         \\}
-        \\fn div0(a: @Vector(4, i32), b: @Vector(4, i32)) @Vector(4, i32) {
+        \\fn div0(a: @import("std").meta.Vector(4, i32), b: @import("std").meta.Vector(4, i32)) @import("std").meta.Vector(4, i32) {
         \\    return @divTrunc(a, b);
         \\}
     );
@@ -685,11 +685,11 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    @import("std").os.exit(126);
         \\}
         \\pub fn main() !void {
-        \\    var a: @Vector(4, i32) = [4]i32{111, 222, 333, 444};
-        \\    var b: @Vector(4, i32) = [4]i32{111, 222, 333, 441};
+        \\    var a: @import("std").meta.Vector(4, i32) = [4]i32{111, 222, 333, 444};
+        \\    var b: @import("std").meta.Vector(4, i32) = [4]i32{111, 222, 333, 441};
         \\    const x = divExact(a, b);
         \\}
-        \\fn divExact(a: @Vector(4, i32), b: @Vector(4, i32)) @Vector(4, i32) {
+        \\fn divExact(a: @import("std").meta.Vector(4, i32), b: @import("std").meta.Vector(4, i32)) @import("std").meta.Vector(4, i32) {
         \\    return @divExact(a, b);
         \\}
     );

--- a/test/stage1/behavior/byteswap.zig
+++ b/test/stage1/behavior/byteswap.zig
@@ -55,8 +55,8 @@ test "@byteSwap vectors" {
         fn t(
             comptime I: type,
             comptime n: comptime_int,
-            input: @Vector(n, I),
-            expected_vector: @Vector(n, I),
+            input: std.meta.Vector(n, I),
+            expected_vector: std.meta.Vector(n, I),
         ) void {
             const actual_output: [n]I = @byteSwap(I, input);
             const expected_output: [n]I = expected_vector;

--- a/test/stage1/behavior/floatop.zig
+++ b/test/stage1/behavior/floatop.zig
@@ -3,6 +3,7 @@ const expect = std.testing.expect;
 const math = std.math;
 const pi = std.math.pi;
 const e = std.math.e;
+const Vector = std.meta.Vector;
 
 const epsilon = 0.000001;
 
@@ -36,7 +37,7 @@ fn testSqrt() void {
     //    expect(@sqrt(a) == 7);
     //}
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
         var result = @sqrt(v);
         expect(math.approxEq(f32, @sqrt(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @sqrt(@as(f32, 2.2)), result[1], epsilon));
@@ -86,7 +87,7 @@ fn testSin() void {
         expect(@sin(a) == 0);
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
         var result = @sin(v);
         expect(math.approxEq(f32, @sin(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @sin(@as(f32, 2.2)), result[1], epsilon));
@@ -116,7 +117,7 @@ fn testCos() void {
         expect(@cos(a) == 1);
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
         var result = @cos(v);
         expect(math.approxEq(f32, @cos(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @cos(@as(f32, 2.2)), result[1], epsilon));
@@ -146,7 +147,7 @@ fn testExp() void {
         expect(@exp(a) == 1);
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
         var result = @exp(v);
         expect(math.approxEq(f32, @exp(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @exp(@as(f32, 2.2)), result[1], epsilon));
@@ -176,7 +177,7 @@ fn testExp2() void {
         expect(@exp2(a) == 4);
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
         var result = @exp2(v);
         expect(math.approxEq(f32, @exp2(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @exp2(@as(f32, 2.2)), result[1], epsilon));
@@ -208,7 +209,7 @@ fn testLog() void {
         expect(@log(a) == 1 or @log(a) == @bitCast(f64, @as(u64, 0x3ff0000000000000)));
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
         var result = @log(v);
         expect(math.approxEq(f32, @log(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @log(@as(f32, 2.2)), result[1], epsilon));
@@ -238,7 +239,7 @@ fn testLog2() void {
         expect(@log2(a) == 2);
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
         var result = @log2(v);
         expect(math.approxEq(f32, @log2(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @log2(@as(f32, 2.2)), result[1], epsilon));
@@ -268,7 +269,7 @@ fn testLog10() void {
         expect(@log10(a) == 3);
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
         var result = @log10(v);
         expect(math.approxEq(f32, @log10(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @log10(@as(f32, 2.2)), result[1], epsilon));
@@ -304,7 +305,7 @@ fn testFabs() void {
         expect(@fabs(b) == 2.5);
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
         var result = @fabs(v);
         expect(math.approxEq(f32, @fabs(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @fabs(@as(f32, -2.2)), result[1], epsilon));
@@ -334,7 +335,7 @@ fn testFloor() void {
         expect(@floor(a) == 3);
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
         var result = @floor(v);
         expect(math.approxEq(f32, @floor(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @floor(@as(f32, -2.2)), result[1], epsilon));
@@ -364,7 +365,7 @@ fn testCeil() void {
         expect(@ceil(a) == 4);
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
         var result = @ceil(v);
         expect(math.approxEq(f32, @ceil(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @ceil(@as(f32, -2.2)), result[1], epsilon));
@@ -394,7 +395,7 @@ fn testTrunc() void {
         expect(@trunc(a) == -3);
     }
     {
-        var v: @Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
+        var v: Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
         var result = @trunc(v);
         expect(math.approxEq(f32, @trunc(@as(f32, 1.1)), result[0], epsilon));
         expect(math.approxEq(f32, @trunc(@as(f32, -2.2)), result[1], epsilon));

--- a/test/stage1/behavior/math.zig
+++ b/test/stage1/behavior/math.zig
@@ -649,8 +649,8 @@ fn comptimeAdd(comptime a: comptime_int, comptime b: comptime_int) comptime_int 
 test "vector integer addition" {
     const S = struct {
         fn doTheTest() void {
-            var a: @Vector(4, i32) = [_]i32{ 1, 2, 3, 4 };
-            var b: @Vector(4, i32) = [_]i32{ 5, 6, 7, 8 };
+            var a: std.meta.Vector(4, i32) = [_]i32{ 1, 2, 3, 4 };
+            var b: std.meta.Vector(4, i32) = [_]i32{ 5, 6, 7, 8 };
             var result = a + b;
             var result_array: [4]i32 = result;
             const expected = [_]i32{ 6, 8, 10, 12 };
@@ -693,8 +693,8 @@ test "128-bit multiplication" {
 test "vector comparison" {
     const S = struct {
         fn doTheTest() void {
-            var a: @Vector(6, i32) = [_]i32{ 1, 3, -1, 5, 7, 9 };
-            var b: @Vector(6, i32) = [_]i32{ -1, 3, 0, 6, 10, -10 };
+            var a: std.meta.Vector(6, i32) = [_]i32{ 1, 3, -1, 5, 7, 9 };
+            var b: std.meta.Vector(6, i32) = [_]i32{ -1, 3, 0, 6, 10, -10 };
             expect(mem.eql(bool, &@as([6]bool, a < b), &[_]bool{ false, false, true, true, true, false }));
             expect(mem.eql(bool, &@as([6]bool, a <= b), &[_]bool{ false, true, true, true, true, false }));
             expect(mem.eql(bool, &@as([6]bool, a == b), &[_]bool{ false, true, false, false, false, false }));

--- a/test/stage1/behavior/shuffle.zig
+++ b/test/stage1/behavior/shuffle.zig
@@ -1,13 +1,14 @@
 const std = @import("std");
 const mem = std.mem;
 const expect = std.testing.expect;
+const Vector = std.meta.Vector;
 
 test "@shuffle" {
     const S = struct {
         fn doTheTest() void {
-            var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
-            var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
-            const mask: @Vector(4, i32) = [4]i32{ 0, ~@as(i32, 2), 3, ~@as(i32, 3) };
+            var v: Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
+            var x: Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
+            const mask: Vector(4, i32) = [4]i32{ 0, ~@as(i32, 2), 3, ~@as(i32, 3) };
             var res = @shuffle(i32, v, x, mask);
             expect(mem.eql(i32, &@as([4]i32, res), &[4]i32{ 2147483647, 3, 40, 4 }));
 
@@ -16,28 +17,28 @@ test "@shuffle" {
             expect(mem.eql(i32, &@as([4]i32, res), &[4]i32{ 2147483647, 3, 40, 4 }));
 
             // Undefined
-            const mask2: @Vector(4, i32) = [4]i32{ 3, 1, 2, 0 };
+            const mask2: Vector(4, i32) = [4]i32{ 3, 1, 2, 0 };
             res = @shuffle(i32, v, undefined, mask2);
             expect(mem.eql(i32, &@as([4]i32, res), &[4]i32{ 40, -2, 30, 2147483647 }));
 
             // Upcasting of b
-            var v2: @Vector(2, i32) = [2]i32{ 2147483647, undefined };
-            const mask3: @Vector(4, i32) = [4]i32{ ~@as(i32, 0), 2, ~@as(i32, 0), 3 };
+            var v2: Vector(2, i32) = [2]i32{ 2147483647, undefined };
+            const mask3: Vector(4, i32) = [4]i32{ ~@as(i32, 0), 2, ~@as(i32, 0), 3 };
             res = @shuffle(i32, x, v2, mask3);
             expect(mem.eql(i32, &@as([4]i32, res), &[4]i32{ 2147483647, 3, 2147483647, 4 }));
 
             // Upcasting of a
-            var v3: @Vector(2, i32) = [2]i32{ 2147483647, -2 };
-            const mask4: @Vector(4, i32) = [4]i32{ 0, ~@as(i32, 2), 1, ~@as(i32, 3) };
+            var v3: Vector(2, i32) = [2]i32{ 2147483647, -2 };
+            const mask4: Vector(4, i32) = [4]i32{ 0, ~@as(i32, 2), 1, ~@as(i32, 3) };
             res = @shuffle(i32, v3, x, mask4);
             expect(mem.eql(i32, &@as([4]i32, res), &[4]i32{ 2147483647, 3, -2, 4 }));
 
             // bool
             // Disabled because of #3317
             if (@import("builtin").arch != .mipsel and std.Target.current.cpu.arch != .mips) {
-                var x2: @Vector(4, bool) = [4]bool{ false, true, false, true };
-                var v4: @Vector(2, bool) = [2]bool{ true, false };
-                const mask5: @Vector(4, i32) = [4]i32{ 0, ~@as(i32, 1), 1, 2 };
+                var x2: Vector(4, bool) = [4]bool{ false, true, false, true };
+                var v4: Vector(2, bool) = [2]bool{ true, false };
+                const mask5: Vector(4, i32) = [4]i32{ 0, ~@as(i32, 1), 1, 2 };
                 var res2 = @shuffle(bool, x2, v4, mask5);
                 expect(mem.eql(bool, &@as([4]bool, res2), &[4]bool{ false, false, true, false }));
             }
@@ -45,9 +46,9 @@ test "@shuffle" {
             // TODO re-enable when LLVM codegen is fixed
             // https://github.com/ziglang/zig/issues/3246
             if (false) {
-                var x2: @Vector(3, bool) = [3]bool{ false, true, false };
-                var v4: @Vector(2, bool) = [2]bool{ true, false };
-                const mask5: @Vector(4, i32) = [4]i32{ 0, ~@as(i32, 1), 1, 2 };
+                var x2: Vector(3, bool) = [3]bool{ false, true, false };
+                var v4: Vector(2, bool) = [2]bool{ true, false };
+                const mask5: Vector(4, i32) = [4]i32{ 0, ~@as(i32, 1), 1, 2 };
                 var res2 = @shuffle(bool, x2, v4, mask5);
                 expect(mem.eql(bool, &@as([4]bool, res2), &[4]bool{ false, false, true, false }));
             }

--- a/test/stage1/behavior/type.zig
+++ b/test/stage1/behavior/type.zig
@@ -200,6 +200,9 @@ test "Type.Vector" {
         @Vector(0, u8),
         @Vector(4, u8),
         @Vector(8, *u8),
+        std.meta.Vector(0, u8),
+        std.meta.Vector(4, u8),
+        std.meta.Vector(8, *u8),
     });
 }
 

--- a/test/stage1/behavior/type_info.zig
+++ b/test/stage1/behavior/type_info.zig
@@ -296,7 +296,7 @@ test "type info: vectors" {
 }
 
 fn testVector() void {
-    const vec_info = @typeInfo(@Vector(4, i32));
+    const vec_info = @typeInfo(std.meta.Vector(4, i32));
     expect(vec_info == .Vector);
     expect(vec_info.Vector.len == 4);
     expect(vec_info.Vector.child == i32);

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -3,11 +3,12 @@ const mem = std.mem;
 const math = std.math;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
+const Vector = std.meta.Vector;
 
 test "implicit cast vector to array - bool" {
     const S = struct {
         fn doTheTest() void {
-            const a: @Vector(4, bool) = [_]bool{ true, false, true, false };
+            const a: Vector(4, bool) = [_]bool{ true, false, true, false };
             const result_array: [4]bool = a;
             expect(mem.eql(bool, &result_array, &[4]bool{ true, false, true, false }));
         }
@@ -19,12 +20,12 @@ test "implicit cast vector to array - bool" {
 test "vector wrap operators" {
     const S = struct {
         fn doTheTest() void {
-            var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
-            var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
+            var v: Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
+            var x: Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
             expect(mem.eql(i32, &@as([4]i32, v +% x), &[4]i32{ -2147483648, 2147483645, 33, 44 }));
             expect(mem.eql(i32, &@as([4]i32, v -% x), &[4]i32{ 2147483646, 2147483647, 27, 36 }));
             expect(mem.eql(i32, &@as([4]i32, v *% x), &[4]i32{ 2147483647, 2, 90, 160 }));
-            var z: @Vector(4, i32) = [4]i32{ 1, 2, 3, -2147483648 };
+            var z: Vector(4, i32) = [4]i32{ 1, 2, 3, -2147483648 };
             expect(mem.eql(i32, &@as([4]i32, -%z), &[4]i32{ -1, -2, -3, -2147483648 }));
         }
     };
@@ -35,8 +36,8 @@ test "vector wrap operators" {
 test "vector bin compares with mem.eql" {
     const S = struct {
         fn doTheTest() void {
-            var v: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
-            var x: @Vector(4, i32) = [4]i32{ 1, 2147483647, 30, 4 };
+            var v: Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
+            var x: Vector(4, i32) = [4]i32{ 1, 2147483647, 30, 4 };
             expect(mem.eql(bool, &@as([4]bool, v == x), &[4]bool{ false, false, true, false }));
             expect(mem.eql(bool, &@as([4]bool, v != x), &[4]bool{ true, true, false, true }));
             expect(mem.eql(bool, &@as([4]bool, v < x), &[4]bool{ false, true, false, false }));
@@ -52,8 +53,8 @@ test "vector bin compares with mem.eql" {
 test "vector int operators" {
     const S = struct {
         fn doTheTest() void {
-            var v: @Vector(4, i32) = [4]i32{ 10, 20, 30, 40 };
-            var x: @Vector(4, i32) = [4]i32{ 1, 2, 3, 4 };
+            var v: Vector(4, i32) = [4]i32{ 10, 20, 30, 40 };
+            var x: Vector(4, i32) = [4]i32{ 1, 2, 3, 4 };
             expect(mem.eql(i32, &@as([4]i32, v + x), &[4]i32{ 11, 22, 33, 44 }));
             expect(mem.eql(i32, &@as([4]i32, v - x), &[4]i32{ 9, 18, 27, 36 }));
             expect(mem.eql(i32, &@as([4]i32, v * x), &[4]i32{ 10, 40, 90, 160 }));
@@ -67,8 +68,8 @@ test "vector int operators" {
 test "vector float operators" {
     const S = struct {
         fn doTheTest() void {
-            var v: @Vector(4, f32) = [4]f32{ 10, 20, 30, 40 };
-            var x: @Vector(4, f32) = [4]f32{ 1, 2, 3, 4 };
+            var v: Vector(4, f32) = [4]f32{ 10, 20, 30, 40 };
+            var x: Vector(4, f32) = [4]f32{ 1, 2, 3, 4 };
             expect(mem.eql(f32, &@as([4]f32, v + x), &[4]f32{ 11, 22, 33, 44 }));
             expect(mem.eql(f32, &@as([4]f32, v - x), &[4]f32{ 9, 18, 27, 36 }));
             expect(mem.eql(f32, &@as([4]f32, v * x), &[4]f32{ 10, 40, 90, 160 }));
@@ -82,8 +83,8 @@ test "vector float operators" {
 test "vector bit operators" {
     const S = struct {
         fn doTheTest() void {
-            var v: @Vector(4, u8) = [4]u8{ 0b10101010, 0b10101010, 0b10101010, 0b10101010 };
-            var x: @Vector(4, u8) = [4]u8{ 0b11110000, 0b00001111, 0b10101010, 0b01010101 };
+            var v: Vector(4, u8) = [4]u8{ 0b10101010, 0b10101010, 0b10101010, 0b10101010 };
+            var x: Vector(4, u8) = [4]u8{ 0b11110000, 0b00001111, 0b10101010, 0b01010101 };
             expect(mem.eql(u8, &@as([4]u8, v ^ x), &[4]u8{ 0b01011010, 0b10100101, 0b00000000, 0b11111111 }));
             expect(mem.eql(u8, &@as([4]u8, v | x), &[4]u8{ 0b11111010, 0b10101111, 0b10101010, 0b11111111 }));
             expect(mem.eql(u8, &@as([4]u8, v & x), &[4]u8{ 0b10100000, 0b00001010, 0b10101010, 0b00000000 }));
@@ -96,7 +97,7 @@ test "vector bit operators" {
 test "implicit cast vector to array" {
     const S = struct {
         fn doTheTest() void {
-            var a: @Vector(4, i32) = [_]i32{ 1, 2, 3, 4 };
+            var a: Vector(4, i32) = [_]i32{ 1, 2, 3, 4 };
             var result_array: [4]i32 = a;
             result_array = a;
             expect(mem.eql(i32, &result_array, &[4]i32{ 1, 2, 3, 4 }));
@@ -109,7 +110,7 @@ test "implicit cast vector to array" {
 test "array to vector" {
     var foo: f32 = 3.14;
     var arr = [4]f32{ foo, 1.5, 0.0, 0.0 };
-    var vec: @Vector(4, f32) = arr;
+    var vec: Vector(4, f32) = arr;
 }
 
 test "vector casts of sizes not divisable by 8" {
@@ -119,22 +120,22 @@ test "vector casts of sizes not divisable by 8" {
     const S = struct {
         fn doTheTest() void {
             {
-                var v: @Vector(4, u3) = [4]u3{ 5, 2, 3, 0 };
+                var v: Vector(4, u3) = [4]u3{ 5, 2, 3, 0 };
                 var x: [4]u3 = v;
                 expect(mem.eql(u3, &x, &@as([4]u3, v)));
             }
             {
-                var v: @Vector(4, u2) = [4]u2{ 1, 2, 3, 0 };
+                var v: Vector(4, u2) = [4]u2{ 1, 2, 3, 0 };
                 var x: [4]u2 = v;
                 expect(mem.eql(u2, &x, &@as([4]u2, v)));
             }
             {
-                var v: @Vector(4, u1) = [4]u1{ 1, 0, 1, 0 };
+                var v: Vector(4, u1) = [4]u1{ 1, 0, 1, 0 };
                 var x: [4]u1 = v;
                 expect(mem.eql(u1, &x, &@as([4]u1, v)));
             }
             {
-                var v: @Vector(4, bool) = [4]bool{ false, false, true, false };
+                var v: Vector(4, bool) = [4]bool{ false, false, true, false };
                 var x: [4]bool = v;
                 expect(mem.eql(bool, &x, &@as([4]bool, v)));
             }
@@ -149,7 +150,7 @@ test "vector @splat" {
         fn doTheTest() void {
             var v: u32 = 5;
             var x = @splat(4, v);
-            expect(@TypeOf(x) == @Vector(4, u32));
+            expect(@TypeOf(x) == Vector(4, u32));
             var array_x: [4]u32 = x;
             expect(array_x[0] == 5);
             expect(array_x[1] == 5);
@@ -164,7 +165,7 @@ test "vector @splat" {
 test "load vector elements via comptime index" {
     const S = struct {
         fn doTheTest() void {
-            var v: @Vector(4, i32) = [_]i32{ 1, 2, 3, undefined };
+            var v: Vector(4, i32) = [_]i32{ 1, 2, 3, undefined };
             expect(v[0] == 1);
             expect(v[1] == 2);
             expect(loadv(&v[2]) == 3);
@@ -181,7 +182,7 @@ test "load vector elements via comptime index" {
 test "store vector elements via comptime index" {
     const S = struct {
         fn doTheTest() void {
-            var v: @Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
+            var v: Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
 
             v[2] = 42;
             expect(v[1] == 5);
@@ -204,7 +205,7 @@ test "store vector elements via comptime index" {
 test "load vector elements via runtime index" {
     const S = struct {
         fn doTheTest() void {
-            var v: @Vector(4, i32) = [_]i32{ 1, 2, 3, undefined };
+            var v: Vector(4, i32) = [_]i32{ 1, 2, 3, undefined };
             var i: u32 = 0;
             expect(v[i] == 1);
             i += 1;
@@ -221,7 +222,7 @@ test "load vector elements via runtime index" {
 test "store vector elements via runtime index" {
     const S = struct {
         fn doTheTest() void {
-            var v: @Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
+            var v: Vector(4, i32) = [_]i32{ 1, 5, 3, undefined };
             var i: u32 = 2;
             v[i] = 1;
             expect(v[1] == 5);
@@ -238,7 +239,7 @@ test "store vector elements via runtime index" {
 
 test "initialize vector which is a struct field" {
     const Vec4Obj = struct {
-        data: @Vector(4, f32),
+        data: Vector(4, f32),
     };
 
     const S = struct {
@@ -256,8 +257,8 @@ test "vector comparison operators" {
     const S = struct {
         fn doTheTest() void {
             {
-                const v1: @Vector(4, bool) = [_]bool{ true, false, true, false };
-                const v2: @Vector(4, bool) = [_]bool{ false, true, false, true };
+                const v1: Vector(4, bool) = [_]bool{ true, false, true, false };
+                const v2: Vector(4, bool) = [_]bool{ false, true, false, true };
                 expectEqual(@splat(4, true), v1 == v1);
                 expectEqual(@splat(4, false), v1 == v2);
                 expectEqual(@splat(4, true), v1 != v2);
@@ -265,7 +266,7 @@ test "vector comparison operators" {
             }
             {
                 const v1 = @splat(4, @as(u32, 0xc0ffeeee));
-                const v2: @Vector(4, c_uint) = v1;
+                const v2: Vector(4, c_uint) = v1;
                 const v3 = @splat(4, @as(u32, 0xdeadbeef));
                 expectEqual(@splat(4, true), v1 == v2);
                 expectEqual(@splat(4, false), v1 == v3);
@@ -280,7 +281,7 @@ test "vector comparison operators" {
 
 test "vector division operators" {
     const S = struct {
-        fn doTheTestDiv(comptime T: type, x: @Vector(4, T), y: @Vector(4, T)) void {
+        fn doTheTestDiv(comptime T: type, x: Vector(4, T), y: Vector(4, T)) void {
             if (!comptime std.meta.trait.isSignedInt(T)) {
                 const d0 = x / y;
                 for (@as([4]T, d0)) |v, i| {
@@ -301,7 +302,7 @@ test "vector division operators" {
             }
         }
 
-        fn doTheTestMod(comptime T: type, x: @Vector(4, T), y: @Vector(4, T)) void {
+        fn doTheTestMod(comptime T: type, x: Vector(4, T), y: Vector(4, T)) void {
             if ((!comptime std.meta.trait.isSignedInt(T)) and @typeInfo(T) != .Float) {
                 const r0 = x % y;
                 for (@as([4]T, r0)) |v, i| {
@@ -362,7 +363,7 @@ test "vector division operators" {
 
 test "vector bitwise not operator" {
     const S = struct {
-        fn doTheTestNot(comptime T: type, x: @Vector(4, T)) void {
+        fn doTheTestNot(comptime T: type, x: Vector(4, T)) void {
             var y = ~x;
             for (@as([4]T, y)) |v, i| {
                 expectEqual(~x[i], v);
@@ -392,8 +393,8 @@ test "vector shift operators" {
             const TX = @typeInfo(@TypeOf(x)).Array.child;
             const TY = @typeInfo(@TypeOf(y)).Array.child;
 
-            var xv = @as(@Vector(N, TX), x);
-            var yv = @as(@Vector(N, TY), y);
+            var xv = @as(Vector(N, TX), x);
+            var yv = @as(Vector(N, TY), y);
 
             var z0 = xv >> yv;
             for (@as([N]TX, z0)) |v, i| {
@@ -409,8 +410,8 @@ test "vector shift operators" {
             const TX = @typeInfo(@TypeOf(x)).Array.child;
             const TY = @typeInfo(@TypeOf(y)).Array.child;
 
-            var xv = @as(@Vector(N, TX), x);
-            var yv = @as(@Vector(N, TY), y);
+            var xv = @as(Vector(N, TX), x);
+            var yv = @as(Vector(N, TY), y);
 
             var z = if (dir == .Left) @shlExact(xv, yv) else @shrExact(xv, yv);
             for (@as([N]TX, z)) |v, i| {


### PR DESCRIPTION
Also fixes a bug where the vector child type wasn't validated in the `@Type` version.