### PR TITLE
Avoid reading from /dev/urandom on NetBSD

### DIFF
--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -9,6 +9,7 @@ pub const _errno = __errno;
 pub const dl_iterate_phdr_callback = extern fn (info: *dl_phdr_info, size: usize, data: ?*c_void) c_int;
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*c_void) c_int;
 
+pub extern "c" fn arc4random_buf(buf: [*]u8, len: usize) void;
 pub extern "c" fn __fstat50(fd: fd_t, buf: *Stat) c_int;
 pub extern "c" fn __stat50(path: [*:0]const u8, buf: *Stat) c_int;
 pub extern "c" fn __clock_gettime50(clk_id: c_int, tp: *timespec) c_int;

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -153,6 +153,10 @@ pub fn getrandom(buffer: []u8) GetRandomError!void {
         }
         return;
     }
+    if (builtin.os.tag == .netbsd) {
+        netbsd.arc4random_buf(buffer.ptr, buffer.len);
+        return;
+    }
     if (builtin.os.tag == .wasi) {
         switch (wasi.random_get(buffer.ptr, buffer.len)) {
             0 => return,

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -1462,6 +1462,14 @@ static void init_rand() {
     unsigned seed;
     memcpy(&seed, ptr_random, sizeof(seed));
     srand(seed);
+#elif defined(ZIG_OS_FREEBSD) || defined(ZIG_OS_NETBSD)
+    unsigned seed;
+    size_t len = sizeof(seed);
+    int mib[2] = { CTL_KERN, KERN_ARND };
+    if (sysctl(mib, 2, &seed, &len, NULL, 0) != 0) {
+        zig_panic("unable to query random data from sysctl");
+    }
+    srand(seed);
 #else
     int fd = open("/dev/urandom", O_RDONLY|O_CLOEXEC);
     if (fd == -1) {


### PR DESCRIPTION
- In os.zig use the `arc4random_buf` libc function to implement `getrandom()`
- In os.cpp use `sysctl` to seed the RNG (do this on FreeBSD too, since there's no code path for FreeBSD and it's also reading from `/dev/urandom`)