### PR TITLE
Fixed Darwin-incompatible socket flags and unavailable system calls

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -131,6 +131,7 @@ pub extern "c" fn socketpair(domain: c_uint, sock_type: c_uint, protocol: c_uint
 pub extern "c" fn listen(sockfd: fd_t, backlog: c_uint) c_int;
 pub extern "c" fn getsockname(sockfd: fd_t, noalias addr: *sockaddr, noalias addrlen: *socklen_t) c_int;
 pub extern "c" fn connect(sockfd: fd_t, sock_addr: *const sockaddr, addrlen: socklen_t) c_int;
+pub extern "c" fn accept(sockfd: fd_t, addr: *sockaddr, addrlen: *socklen_t) c_int;
 pub extern "c" fn accept4(sockfd: fd_t, addr: *sockaddr, addrlen: *socklen_t, flags: c_uint) c_int;
 pub extern "c" fn getsockopt(sockfd: fd_t, level: u32, optname: u32, optval: ?*c_void, optlen: *socklen_t) c_int;
 pub extern "c" fn setsockopt(sockfd: fd_t, level: u32, optname: u32, optval: ?*const c_void, optlen: socklen_t) c_int;

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -361,19 +361,19 @@ pub const Address = extern union {
 fn getUnixSocketInitFlags() u16 {
     comptime {
         var flags = 0;
-        switch(builtin.os.tag) {
+        switch (builtin.os.tag) {
             .linux, .freebsd, .netbsd, .dragonfly => {
                 flags |= os.SOCK_CLOEXEC;
                 flags |= if (std.io.is_async) os.SOCK_NONBLOCK else 0;
             },
-            else => {}
+            else => {},
         }
 
         return flags;
     }
 }
 
-// These are primarily needed for UNIX-based platforms without 
+// These are primarily needed for UNIX-based platforms without
 // SOCK_CLOEXEC and SOCK_NONBLOCK flags when creating sockets
 // or accepting connections
 fn setUnixSocketFlags(sock: os.fd_t) os.FcntlError!void {
@@ -381,7 +381,7 @@ fn setUnixSocketFlags(sock: os.fd_t) os.FcntlError!void {
     fdflags |= os.FD_CLOEXEC;
     _ = try os.fcntl(sock, os.F_SETFD, fdflags);
 
-    if(std.io.is_async) {
+    if (std.io.is_async) {
         var flflags = try os.fcntl(sock, os.F_GETFL, 0);
         flflags |= os.O_NONBLOCK;
         _ = try os.fcntl(sock, os.F_SETFL, fdflags);
@@ -391,9 +391,9 @@ fn setUnixSocketFlags(sock: os.fd_t) os.FcntlError!void {
 pub fn connectUnixSocket(path: []const u8) !fs.File {
     const flags = os.SOCK_STREAM | getUnixSocketInitFlags();
     const sockfd = try os.socket(os.AF_UNIX, flags, 0);
-    
-    if(comptime builtin.os.tag.isDarwin()) {
-        try setUnixSocketFlags(sockfd); 
+
+    if (comptime builtin.os.tag.isDarwin()) {
+        try setUnixSocketFlags(sockfd);
     }
 
     errdefer os.close(sockfd);
@@ -440,7 +440,7 @@ pub fn tcpConnectToAddress(address: Address) !fs.File {
     const sock_flags = os.SOCK_STREAM | getUnixSocketInitFlags();
     const sockfd = try os.socket(address.any.family, sock_flags, os.IPPROTO_TCP);
 
-    if(comptime builtin.os.tag.isDarwin()) {
+    if (comptime builtin.os.tag.isDarwin()) {
         try setUnixSocketFlags(sockfd);
     }
 
@@ -1351,7 +1351,7 @@ pub const StreamServer = struct {
         const proto = if (address.any.family == os.AF_UNIX) @as(u32, 0) else os.IPPROTO_TCP;
         const sockfd = try os.socket(address.any.family, flags, proto);
 
-        if(comptime builtin.os.tag.isDarwin()) {
+        if (comptime builtin.os.tag.isDarwin()) {
             try setUnixSocketFlags(sockfd);
         }
 
@@ -1417,7 +1417,7 @@ pub const StreamServer = struct {
         var adr_len: os.socklen_t = @sizeOf(Address);
         var _accept: os.AcceptError!os.fd_t = undefined;
 
-        if(comptime builtin.os.tag.isDarwin()) {
+        if (comptime builtin.os.tag.isDarwin()) {
             try setUnixSocketFlags(self.sockfd.?);
             _accept = os.accept(self.sockfd.?, &accepted_addr.any, &adr_len);
         } else {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2294,12 +2294,51 @@ pub fn accept4(
     ///   description  of the `O_CLOEXEC` flag in `open` for reasons why this may be useful.
     flags: u32,
 ) AcceptError!fd_t {
+    if (comptime builtin.os.tag.isDarwin()) {
+        @compileError("accept4 not available for target Darwin, use accept");
+    }
+
+    return try _accept(sockfd, addr, addr_size, flags);
+}
+
+/// Accept a connection on a socket.
+/// If the application has a global event loop enabled, EAGAIN is handled
+/// via the event loop. Otherwise EAGAIN results in error.WouldBlock.
+pub fn accept(
+    /// This argument is a socket that has been created with `socket`, bound to a local address
+    /// with `bind`, and is listening for connections after a `listen`.
+    sockfd: fd_t,
+    /// This argument is a pointer to a sockaddr structure.  This structure is filled in with  the
+    /// address  of  the  peer  socket, as known to the communications layer.  The exact format of the
+    /// address returned addr is determined by the socket's address  family  (see  `socket`  and  the
+    /// respective  protocol  man  pages).
+    addr: *sockaddr,
+    /// This argument is a value-result argument: the caller must initialize it to contain  the
+    /// size (in bytes) of the structure pointed to by addr; on return it will contain the actual size
+    /// of the peer address.
+    ///
+    /// The returned address is truncated if the buffer provided is too small; in this  case,  `addr_size`
+    /// will return a value greater than was supplied to the call.
+    addr_size: *socklen_t,
+) AcceptError!fd_t {
+    return try _accept(sockfd, addr, addr_size, 0);
+}
+
+fn _accept(sockfd: fd_t, addr: *sockaddr, addr_size: *socklen_t, flags: u32) AcceptError!fd_t {
     while (true) {
-        const rc = system.accept4(sockfd, addr, addr_size, flags);
+        const rc = func: {
+            switch (comptime builtin.os.tag) {
+                .linux, .freebsd, .netbsd, .dragonfly =>
+                    break :func system.accept4(sockfd, addr, addr_size, flags)
+                .ios, .macosx, .watchos, .tvos =>
+                    break :func system.accept(sockfd, addr, addr_size),
+                else => @compileError("accept not available for target")
+            }
+        };
+
         switch (errno(rc)) {
             0 => return @intCast(fd_t, rc),
             EINTR => continue,
-
             EAGAIN => if (std.event.Loop.instance) |loop| {
                 loop.waitUntilFdReadable(sockfd);
                 continue;
@@ -2318,7 +2357,6 @@ pub fn accept4(
             EOPNOTSUPP => unreachable,
             EPROTO => return error.ProtocolFailure,
             EPERM => return error.BlockedByFirewall,
-
             else => |err| return unexpectedErrno(err),
         }
     }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -374,7 +374,7 @@ pub fn readv(fd: fd_t, iov: []const iovec) ReadError!usize {
         const first = iov[0];
         return read(fd, first.iov_base[0..first.iov_len]);
     }
-    
+
     const iov_count = math.cast(u31, iov.len) catch math.maxInt(u31);
     while (true) {
         // TODO handle the case when iov_len is too large and get rid of this @intCast
@@ -2328,11 +2328,13 @@ fn _accept(sockfd: fd_t, addr: *sockaddr, addr_size: *socklen_t, flags: u32) Acc
     while (true) {
         const rc = func: {
             switch (comptime builtin.os.tag) {
-                .linux, .freebsd, .netbsd, .dragonfly =>
-                    break :func system.accept4(sockfd, addr, addr_size, flags)
-                .ios, .macosx, .watchos, .tvos =>
-                    break :func system.accept(sockfd, addr, addr_size),
-                else => @compileError("accept not available for target")
+                .linux, .freebsd, .netbsd, .dragonfly => 
+                    break :func system.accept4(sockfd, addr, addr_size, flags),
+                .ios, .macosx, .watchos, .tvos => {
+                    assert(flags == 0);
+                    break :func system.accept(sockfd, addr, addr_size);
+                },
+                else => @compileError("accept not available for target"),
             }
         };
 


### PR DESCRIPTION
There is a couple of issues relating to using std.os.socket, std.os.accept4 and various std.net function using Darwin-incompatible flags this PR fixes.

- accept4 system call doesnt exist on Darwin, only on Linux and some BSDs. Added accept(3) system call so it can work on macOS in a hopefully DRY way so StreamServer will work.
- accept4 and accept is identical except the former takes SOCK_NONBLOCK and SOCK_CLOEXEC flags which also doesnt exist on Darwin. These will have to be set on the socket. Refactored std.net functions to use SOCK_NONBLOCK/SOCK_CLOEXEC on Linux and BSDs, but fall back to the "old" way of doing it on macOS, by setting FD_CLOEXEC and O_NONBLOCK after creation with fcntl.

Verified that this works on macOS with async after using the macOS async fix in #5233 