### PR TITLE
Remove `async fn`

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10256,9 +10256,7 @@ WhileContinueExpr &lt;- COLON LPAREN AssignExpr RPAREN
 LinkSection &lt;- KEYWORD_linksection LPAREN Expr RPAREN
 
 # Fn specific
-FnCC
-    &lt;- KEYWORD_extern
-     / KEYWORD_async
+FnCC &lt;- KEYWORD_extern
 
 ParamDecl &lt;- (KEYWORD_noalias / KEYWORD_comptime)? (IDENTIFIER COLON)? ParamType
 

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6713,7 +6713,7 @@ const assert = std.debug.assert;
 test "async fn pointer in a struct field" {
     var data: i32 = 1;
     const Foo = struct {
-        bar: async fn (*i32) void,
+        bar: fn (*i32) callconv(.Async) void,
     };
     var foo = Foo{ .bar = func };
     var bytes: [64]u8 align(@alignOf(@Frame(func))) = undefined;
@@ -6723,7 +6723,7 @@ test "async fn pointer in a struct field" {
     assert(data == 4);
 }
 
-async fn func(y: *i32) void {
+fn func(y: *i32) void {
     defer y.* += 2;
     y.* += 1;
     suspend;

--- a/lib/std/event/channel.zig
+++ b/lib/std/event/channel.zig
@@ -105,7 +105,7 @@ pub fn Channel(comptime T: type) type {
 
         /// await this function to get an item from the channel. If the buffer is empty, the frame will
         /// complete when the next item is put in the channel.
-        pub async fn get(self: *SelfChannel) T {
+        pub fn get(self: *SelfChannel) T {
             // TODO https://github.com/ziglang/zig/issues/2765
             var result: T = undefined;
             var my_tick_node = Loop.NextTickNode.init(@frame());
@@ -125,7 +125,7 @@ pub fn Channel(comptime T: type) type {
             return result;
         }
 
-        //pub async fn select(comptime EnumUnion: type, channels: ...) EnumUnion {
+        //pub fn select(comptime EnumUnion: type, channels: ...) EnumUnion {
         //    assert(@memberCount(EnumUnion) == channels.len); // enum union and channels mismatch
         //    assert(channels.len != 0); // enum unions cannot have 0 fields
         //    if (channels.len == 1) {
@@ -306,7 +306,7 @@ test "std.event.Channel wraparound" {
     testing.expectEqual(@as(i32, 7), channel.get());
 }
 
-async fn testChannelGetter(channel: *Channel(i32)) void {
+fn testChannelGetter(channel: *Channel(i32)) void {
     const value1 = channel.get();
     testing.expect(value1 == 1234);
 
@@ -322,11 +322,11 @@ async fn testChannelGetter(channel: *Channel(i32)) void {
     await last_put;
 }
 
-async fn testChannelPutter(channel: *Channel(i32)) void {
+fn testChannelPutter(channel: *Channel(i32)) void {
     channel.put(1234);
     channel.put(4567);
 }
 
-async fn testPut(channel: *Channel(i32), value: i32) void {
+fn testPut(channel: *Channel(i32), value: i32) void {
     channel.put(value);
 }

--- a/lib/std/event/future.zig
+++ b/lib/std/event/future.zig
@@ -34,7 +34,7 @@ pub fn Future(comptime T: type) type {
         /// Obtain the value. If it's not available, wait until it becomes
         /// available.
         /// Thread-safe.
-        pub async fn get(self: *Self) *T {
+        pub fn get(self: *Self) *T {
             if (@atomicLoad(Available, &self.available, .SeqCst) == .Finished) {
                 return &self.data;
             }
@@ -59,7 +59,7 @@ pub fn Future(comptime T: type) type {
         /// should start working on the data.
         /// It's not required to call start() before resolve() but it can be useful since
         /// this method is thread-safe.
-        pub async fn start(self: *Self) ?*T {
+        pub fn start(self: *Self) ?*T {
             const state = @cmpxchgStrong(Available, &self.available, .NotStarted, .Started, .SeqCst, .SeqCst) orelse return null;
             switch (state) {
                 .Started => {

--- a/lib/std/event/group.zig
+++ b/lib/std/event/group.zig
@@ -84,7 +84,7 @@ pub fn Group(comptime ReturnType: type) type {
         /// Wait for all the calls and promises of the group to complete.
         /// Thread-safe.
         /// Safe to call any number of times.
-        pub async fn wait(self: *Self) ReturnType {
+        pub fn wait(self: *Self) ReturnType {
             const held = self.lock.acquire();
             defer held.release();
 
@@ -128,7 +128,7 @@ test "std.event.Group" {
     const handle = async testGroup(std.heap.page_allocator);
 }
 
-async fn testGroup(allocator: *Allocator) void {
+fn testGroup(allocator: *Allocator) void {
     var count: usize = 0;
     var group = Group(void).init(allocator);
     var sleep_a_little_frame = async sleepALittle(&count);
@@ -146,19 +146,19 @@ async fn testGroup(allocator: *Allocator) void {
     testing.expectError(error.ItBroke, another.wait());
 }
 
-async fn sleepALittle(count: *usize) void {
+fn sleepALittle(count: *usize) void {
     std.time.sleep(1 * std.time.millisecond);
     _ = @atomicRmw(usize, count, .Add, 1, .SeqCst);
 }
 
-async fn increaseByTen(count: *usize) void {
+fn increaseByTen(count: *usize) void {
     var i: usize = 0;
     while (i < 10) : (i += 1) {
         _ = @atomicRmw(usize, count, .Add, 1, .SeqCst);
     }
 }
 
-async fn doSomethingThatFails() anyerror!void {}
-async fn somethingElse() anyerror!void {
+fn doSomethingThatFails() anyerror!void {}
+fn somethingElse() anyerror!void {
     return error.ItBroke;
 }

--- a/lib/std/event/lock.zig
+++ b/lib/std/event/lock.zig
@@ -89,7 +89,7 @@ pub const Lock = struct {
         while (self.queue.get()) |node| resume node.data;
     }
 
-    pub async fn acquire(self: *Lock) Held {
+    pub fn acquire(self: *Lock) Held {
         var my_tick_node = Loop.NextTickNode.init(@frame());
 
         errdefer _ = self.queue.remove(&my_tick_node); // TODO test canceling an acquire
@@ -135,7 +135,7 @@ test "std.event.Lock" {
     testing.expectEqualSlices(i32, &expected_result, &shared_test_data);
 }
 
-async fn testLock(lock: *Lock) void {
+fn testLock(lock: *Lock) void {
     var handle1 = async lockRunner(lock);
     var tick_node1 = Loop.NextTickNode{
         .prev = undefined,
@@ -168,7 +168,7 @@ async fn testLock(lock: *Lock) void {
 var shared_test_data = [1]i32{0} ** 10;
 var shared_test_index: usize = 0;
 
-async fn lockRunner(lock: *Lock) void {
+fn lockRunner(lock: *Lock) void {
     suspend; // resumed by onNextTick
 
     var i: usize = 0;

--- a/lib/std/event/locked.zig
+++ b/lib/std/event/locked.zig
@@ -31,7 +31,7 @@ pub fn Locked(comptime T: type) type {
             self.lock.deinit();
         }
 
-        pub async fn acquire(self: *Self) HeldLock {
+        pub fn acquire(self: *Self) HeldLock {
             return HeldLock{
                 // TODO guaranteed allocation elision
                 .held = self.lock.acquire(),

--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -503,7 +503,7 @@ pub const Loop = struct {
         }
     }
 
-    pub async fn bsdWaitKev(self: *Loop, ident: usize, filter: i16, fflags: u32) void {
+    pub fn bsdWaitKev(self: *Loop, ident: usize, filter: i16, fflags: u32) void {
         var resume_node = ResumeNode.Basic{
             .base = ResumeNode{
                 .id = ResumeNode.Id.Basic,
@@ -1247,14 +1247,4 @@ test "std.event.Loop - basic" {
     defer loop.deinit();
 
     loop.run();
-}
-
-fn testEventLoop() i32 {
-    return 1234;
-}
-
-fn testEventLoop2(h: anyframe->i32, did_it: *bool) void {
-    const value = await h;
-    testing.expect(value == 1234);
-    did_it.* = true;
 }

--- a/lib/std/event/rwlock.zig
+++ b/lib/std/event/rwlock.zig
@@ -97,7 +97,7 @@ pub const RwLock = struct {
         while (self.reader_queue.get()) |node| resume node.data;
     }
 
-    pub async fn acquireRead(self: *RwLock) HeldRead {
+    pub fn acquireRead(self: *RwLock) HeldRead {
         _ = @atomicRmw(usize, &self.reader_lock_count, .Add, 1, .SeqCst);
 
         suspend {
@@ -130,7 +130,7 @@ pub const RwLock = struct {
         return HeldRead{ .lock = self };
     }
 
-    pub async fn acquireWrite(self: *RwLock) HeldWrite {
+    pub fn acquireWrite(self: *RwLock) HeldWrite {
         suspend {
             var my_tick_node = Loop.NextTickNode{
                 .data = @frame(),
@@ -226,7 +226,7 @@ test "std.event.RwLock" {
     testing.expectEqualSlices(i32, expected_result, shared_test_data);
 }
 
-async fn testLock(allocator: *Allocator, lock: *RwLock) void {
+fn testLock(allocator: *Allocator, lock: *RwLock) void {
     var read_nodes: [100]Loop.NextTickNode = undefined;
     for (read_nodes) |*read_node| {
         const frame = allocator.create(@Frame(readRunner)) catch @panic("memory");
@@ -260,7 +260,7 @@ var shared_test_data = [1]i32{0} ** 10;
 var shared_test_index: usize = 0;
 var shared_count: usize = 0;
 
-async fn writeRunner(lock: *RwLock) void {
+fn writeRunner(lock: *RwLock) void {
     suspend; // resumed by onNextTick
 
     var i: usize = 0;
@@ -278,7 +278,7 @@ async fn writeRunner(lock: *RwLock) void {
     }
 }
 
-async fn readRunner(lock: *RwLock) void {
+fn readRunner(lock: *RwLock) void {
     suspend; // resumed by onNextTick
     std.time.sleep(1);
 

--- a/lib/std/event/rwlocked.zig
+++ b/lib/std/event/rwlocked.zig
@@ -40,14 +40,14 @@ pub fn RwLocked(comptime T: type) type {
             self.lock.deinit();
         }
 
-        pub async fn acquireRead(self: *Self) HeldReadLock {
+        pub fn acquireRead(self: *Self) HeldReadLock {
             return HeldReadLock{
                 .held = self.lock.acquireRead(),
                 .value = &self.locked_data,
             };
         }
 
-        pub async fn acquireWrite(self: *Self) HeldWriteLock {
+        pub fn acquireWrite(self: *Self) HeldWriteLock {
             return HeldWriteLock{
                 .held = self.lock.acquireWrite(),
                 .value = &self.locked_data,

--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -34,7 +34,7 @@ pub fn main() anyerror!void {
                     std.heap.page_allocator.free(async_frame_buffer);
                     async_frame_buffer = try std.heap.page_allocator.alignedAlloc(u8, std.Target.stack_align, size);
                 }
-                const casted_fn = @ptrCast(async fn () anyerror!void, test_fn.func);
+                const casted_fn = @ptrCast(fn () callconv(.Async) anyerror!void, test_fn.func);
                 break :blk await @asyncCall(async_frame_buffer, {}, casted_fn);
             },
             .blocking => {

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -225,7 +225,7 @@ inline fn initEventLoopAndCallMain() u8 {
     return @call(.{ .modifier = .always_inline }, callMain, .{});
 }
 
-async fn callMainAsync(loop: *std.event.Loop) u8 {
+fn callMainAsync(loop: *std.event.Loop) callconv(.Async) u8 {
     // This prevents the event loop from terminating at least until main() has returned.
     loop.beginOneEvent();
     defer loop.finishOneEvent();

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -1196,16 +1196,6 @@ fn parseSuffixExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
     const maybe_async = eatToken(it, .Keyword_async);
     if (maybe_async) |async_token| {
         const token_fn = eatToken(it, .Keyword_fn);
-        if (token_fn != null) {
-            // HACK: If we see the keyword `fn`, then we assume that
-            //       we are parsing an async fn proto, and not a call.
-            //       We therefore put back all tokens consumed by the async
-            //       prefix...
-            putBackToken(it, token_fn.?);
-            putBackToken(it, async_token);
-            return parsePrimaryTypeExpr(arena, it, tree);
-        }
-        // TODO: Implement hack for parsing `async fn ...` in ast_parse_suffix_expr
         var res = try expectNode(arena, it, tree, parsePrimaryTypeExpr, .{
             .ExpectedPrimaryTypeExpr = .{ .token = it.index },
         });
@@ -1782,12 +1772,10 @@ fn parseCallconv(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
 ///     <- KEYWORD_nakedcc
 ///      / KEYWORD_stdcallcc
 ///      / KEYWORD_extern
-///      / KEYWORD_async
 fn parseFnCC(arena: *Allocator, it: *TokenIterator, tree: *Tree) ?FnCC {
     if (eatToken(it, .Keyword_nakedcc)) |token| return FnCC{ .CC = token };
     if (eatToken(it, .Keyword_stdcallcc)) |token| return FnCC{ .CC = token };
     if (eatToken(it, .Keyword_extern)) |token| return FnCC{ .Extern = token };
-    if (eatToken(it, .Keyword_async)) |token| return FnCC{ .CC = token };
     return null;
 }
 

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -252,10 +252,10 @@ test "zig fmt: anon list literal syntax" {
 test "zig fmt: async function" {
     try testCanonical(
         \\pub const Server = struct {
-        \\    handleRequestFn: async fn (*Server, *const std.net.Address, File) void,
+        \\    handleRequestFn: fn (*Server, *const std.net.Address, File) callconv(.Async) void,
         \\};
         \\test "hi" {
-        \\    var ptr = @ptrCast(async fn (i32) void, other);
+        \\    var ptr = @ptrCast(fn (i32) callconv(.Async) void, other);
         \\}
         \\
     );
@@ -453,9 +453,9 @@ test "zig fmt: aligned struct field" {
 
 test "zig fmt: preserve space between async fn definitions" {
     try testCanonical(
-        \\async fn a() void {}
+        \\fn a() callconv(.Async) void {}
         \\
-        \\async fn b() void {}
+        \\fn b() callconv(.Async) void {}
         \\
     );
 }
@@ -1515,7 +1515,7 @@ test "zig fmt: line comments in struct initializer" {
 
 test "zig fmt: first line comment in struct initializer" {
     try testCanonical(
-        \\pub async fn acquire(self: *Self) HeldLock {
+        \\pub fn acquire(self: *Self) callconv(.Async) HeldLock {
         \\    return HeldLock{
         \\        // guaranteed allocation elision
         \\        .held = self.lock.acquire(),
@@ -2500,7 +2500,7 @@ test "zig fmt: inline asm" {
 
 test "zig fmt: async functions" {
     try testCanonical(
-        \\async fn simpleAsyncFn() void {
+        \\fn simpleAsyncFn() callconv(.Async) void {
         \\    const a = async a.b();
         \\    x += 1;
         \\    suspend;

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -41,7 +41,7 @@ const usage =
 
 const Command = struct {
     name: []const u8,
-    exec: async fn (*Allocator, []const []const u8) anyerror!void,
+    exec: fn (*Allocator, []const []const u8) callconv(.Async) anyerror!void,
 };
 
 pub fn main() !void {
@@ -714,7 +714,7 @@ const FmtError = error{
     CurrentWorkingDirectoryUnlinked,
 } || fs.File.OpenError;
 
-async fn fmtPath(fmt: *Fmt, file_path_ref: []const u8, check_mode: bool) FmtError!void {
+fn fmtPath(fmt: *Fmt, file_path_ref: []const u8, check_mode: bool) FmtError!void {
     const stderr_file = io.getStdErr();
     const stderr = stderr_file.outStream();
 

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -718,7 +718,6 @@ struct AstNodeFnProto {
     Buf doc_comments;
 
     FnInline fn_inline;
-    bool is_async;
 
     VisibMod visib_mod;
     bool auto_err_set;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -1528,8 +1528,6 @@ ZigType *get_generic_fn_type(CodeGen *g, FnTypeId *fn_type_id) {
 }
 
 CallingConvention cc_from_fn_proto(AstNodeFnProto *fn_proto) {
-    if (fn_proto->is_async)
-        return CallingConventionAsync;
     // Compatible with the C ABI
     if (fn_proto->is_extern || fn_proto->is_export)
         return CallingConventionC;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1524,17 +1524,6 @@ static AstNode *ast_parse_error_union_expr(ParseContext *pc) {
 static AstNode *ast_parse_suffix_expr(ParseContext *pc) {
     Token *async_token = eat_token_if(pc, TokenIdKeywordAsync);
     if (async_token) {
-        if (eat_token_if(pc, TokenIdKeywordFn) != nullptr) {
-            // HACK: If we see the keyword `fn`, then we assume that
-            //       we are parsing an async fn proto, and not a call.
-            //       We therefore put back all tokens consumed by the async
-            //       prefix...
-            put_back_token(pc);
-            put_back_token(pc);
-
-            return ast_parse_primary_type_expr(pc);
-        }
-
         AstNode *child = ast_expect(pc, ast_parse_primary_type_expr);
         while (true) {
             AstNode *suffix = ast_parse_suffix_op(pc);
@@ -2187,15 +2176,9 @@ static AstNode *ast_parse_callconv(ParseContext *pc) {
     return res;
 }
 
-// FnCC
-//     <- KEYWORD_extern
-//      / KEYWORD_async
+// FnCC <- KEYWORD_extern
 static Optional<AstNodeFnProto> ast_parse_fn_cc(ParseContext *pc) {
     AstNodeFnProto res = {};
-    if (eat_token_if(pc, TokenIdKeywordAsync) != nullptr) {
-        res.is_async = true;
-        return Optional<AstNodeFnProto>::some(res);
-    }
     if (eat_token_if(pc, TokenIdKeywordExtern) != nullptr) {
         res.is_extern = true;
         return Optional<AstNodeFnProto>::some(res);

--- a/test/runtime_safety.zig
+++ b/test/runtime_safety.zig
@@ -282,7 +282,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    var ptr = other;
         \\    var frame = @asyncCall(&bytes, {}, ptr);
         \\}
-        \\async fn other() void {
+        \\fn other() callconv(.Async) void {
         \\    suspend;
         \\}
     );
@@ -874,16 +874,16 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    return &failing_frame;
         \\}
         \\
-        \\async fn failing() anyerror!void {
+        \\fn failing() anyerror!void {
         \\    suspend;
         \\    return second();
         \\}
         \\
-        \\async fn second() anyerror!void {
+        \\fn second() callconv(.Async) anyerror!void {
         \\    return error.Fail;
         \\}
         \\
-        \\async fn printTrace(p: anyframe->anyerror!void) void {
+        \\fn printTrace(p: anyframe->anyerror!void) void {
         \\    (await p) catch unreachable;
         \\}
     );

--- a/test/stage1/behavior/async_fn.zig
+++ b/test/stage1/behavior/async_fn.zig
@@ -112,12 +112,12 @@ test "@frameSize" {
     const S = struct {
         fn doTheTest() void {
             {
-                var ptr = @ptrCast(async fn (i32) void, other);
+                var ptr = @ptrCast(fn (i32) callconv(.Async) void, other);
                 const size = @frameSize(ptr);
                 expect(size == @sizeOf(@Frame(other)));
             }
             {
-                var ptr = @ptrCast(async fn () void, first);
+                var ptr = @ptrCast(fn () callconv(.Async) void, first);
                 const size = @frameSize(ptr);
                 expect(size == @sizeOf(@Frame(first)));
             }
@@ -184,7 +184,7 @@ test "coroutine suspend with block" {
 
 var a_promise: anyframe = undefined;
 var global_result = false;
-async fn testSuspendBlock() void {
+fn testSuspendBlock() void {
     suspend {
         comptime expect(@TypeOf(@frame()) == *@Frame(testSuspendBlock));
         a_promise = @frame();
@@ -209,14 +209,14 @@ test "coroutine await" {
     expect(await_final_result == 1234);
     expect(std.mem.eql(u8, &await_points, "abcdefghi"));
 }
-async fn await_amain() void {
+fn await_amain() void {
     await_seq('b');
     var p = async await_another();
     await_seq('e');
     await_final_result = await p;
     await_seq('h');
 }
-async fn await_another() i32 {
+fn await_another() i32 {
     await_seq('c');
     suspend {
         await_seq('d');
@@ -243,14 +243,14 @@ test "coroutine await early return" {
     expect(early_final_result == 1234);
     expect(std.mem.eql(u8, &early_points, "abcdef"));
 }
-async fn early_amain() void {
+fn early_amain() void {
     early_seq('b');
     var p = async early_another();
     early_seq('d');
     early_final_result = await p;
     early_seq('e');
 }
-async fn early_another() i32 {
+fn early_another() i32 {
     early_seq('c');
     return 1234;
 }
@@ -266,7 +266,7 @@ fn early_seq(c: u8) void {
 test "async function with dot syntax" {
     const S = struct {
         var y: i32 = 1;
-        async fn foo() void {
+        fn foo() void {
             y += 1;
             suspend;
         }
@@ -278,7 +278,7 @@ test "async function with dot syntax" {
 test "async fn pointer in a struct field" {
     var data: i32 = 1;
     const Foo = struct {
-        bar: async fn (*i32) void,
+        bar: fn (*i32) callconv(.Async) void,
     };
     var foo = Foo{ .bar = simpleAsyncFn2 };
     var bytes: [64]u8 align(16) = undefined;
@@ -295,7 +295,7 @@ fn doTheAwait(f: anyframe->void) void {
     await f;
 }
 
-async fn simpleAsyncFn2(y: *i32) void {
+fn simpleAsyncFn2(y: *i32) void {
     defer y.* += 2;
     y.* += 1;
     suspend;
@@ -303,11 +303,11 @@ async fn simpleAsyncFn2(y: *i32) void {
 
 test "@asyncCall with return type" {
     const Foo = struct {
-        bar: async fn () i32,
+        bar: fn () callconv(.Async) i32,
 
         var global_frame: anyframe = undefined;
 
-        async fn middle() i32 {
+        fn middle() i32 {
             return afunc();
         }
 
@@ -339,7 +339,7 @@ test "async fn with inferred error set" {
             std.testing.expectError(error.Fail, result);
         }
 
-        async fn middle() !void {
+        fn middle() callconv(.Async) !void {
             var f = async middle2();
             return await f;
         }
@@ -376,11 +376,11 @@ fn nonFailing() (anyframe->anyerror!void) {
     Static.frame = async suspendThenFail();
     return &Static.frame;
 }
-async fn suspendThenFail() anyerror!void {
+fn suspendThenFail() anyerror!void {
     suspend;
     return error.Fail;
 }
-async fn printTrace(p: anyframe->(anyerror!void)) void {
+fn printTrace(p: anyframe->(anyerror!void)) void {
     (await p) catch |e| {
         std.testing.expect(e == error.Fail);
         if (@errorReturnTrace()) |trace| {
@@ -397,7 +397,7 @@ test "break from suspend" {
     const p = async testBreakFromSuspend(&my_result);
     std.testing.expect(my_result == 2);
 }
-async fn testBreakFromSuspend(my_result: *i32) void {
+fn testBreakFromSuspend(my_result: *i32) void {
     suspend {
         resume @frame();
     }
@@ -826,7 +826,7 @@ test "cast fn to async fn when it is inferred to be async" {
         var ok = false;
 
         fn doTheTest() void {
-            var ptr: async fn () i32 = undefined;
+            var ptr: fn () callconv(.Async) i32 = undefined;
             ptr = func;
             var buf: [100]u8 align(16) = undefined;
             var result: i32 = undefined;
@@ -854,7 +854,7 @@ test "cast fn to async fn when it is inferred to be async, awaited directly" {
         var ok = false;
 
         fn doTheTest() void {
-            var ptr: async fn () i32 = undefined;
+            var ptr: fn () callconv(.Async) i32 = undefined;
             ptr = func;
             var buf: [100]u8 align(16) = undefined;
             var result: i32 = undefined;
@@ -959,7 +959,7 @@ test "@asyncCall with comptime-known function, but not awaited directly" {
             std.testing.expectError(error.Fail, result);
         }
 
-        async fn middle() !void {
+        fn middle() !void {
             var f = async middle2();
             return await f;
         }
@@ -993,7 +993,7 @@ test "@asyncCall with actual frame instead of byte buffer" {
 
 test "@asyncCall using the result location inside the frame" {
     const S = struct {
-        async fn simple2(y: *i32) i32 {
+        fn simple2(y: *i32) i32 {
             defer y.* += 2;
             y.* += 1;
             suspend;
@@ -1005,7 +1005,7 @@ test "@asyncCall using the result location inside the frame" {
     };
     var data: i32 = 1;
     const Foo = struct {
-        bar: async fn (*i32) i32,
+        bar: fn (*i32) callconv(.Async) i32,
     };
     var foo = Foo{ .bar = S.simple2 };
     var bytes: [64]u8 align(16) = undefined;
@@ -1115,7 +1115,7 @@ test "await used in expression and awaiting fn with no suspend but async calling
             const sum = (await f1) + (await f2);
             expect(sum == 10);
         }
-        async fn add(a: i32, b: i32) i32 {
+        fn add(a: i32, b: i32) callconv(.Async) i32 {
             return a + b;
         }
     };
@@ -1130,7 +1130,7 @@ test "await used in expression after a fn call" {
             sum = foo() + await f1;
             expect(sum == 8);
         }
-        async fn add(a: i32, b: i32) i32 {
+        fn add(a: i32, b: i32) i32 {
             return a + b;
         }
         fn foo() i32 {
@@ -1147,7 +1147,7 @@ test "async fn call used in expression after a fn call" {
             sum = foo() + add(3, 4);
             expect(sum == 8);
         }
-        async fn add(a: i32, b: i32) i32 {
+        fn add(a: i32, b: i32) i32 {
             return a + b;
         }
         fn foo() i32 {
@@ -1403,7 +1403,7 @@ test "async function call resolves target fn frame, runtime func" {
         fn foo() anyerror!void {
             const stack_size = 1000;
             var stack_frame: [stack_size]u8 align(std.Target.stack_align) = undefined;
-            var func: async fn () anyerror!void = bar;
+            var func: fn () callconv(.Async) anyerror!void = bar;
             return await @asyncCall(&stack_frame, {}, func);
         }
 

--- a/test/stage1/behavior/await_struct.zig
+++ b/test/stage1/behavior/await_struct.zig
@@ -18,14 +18,14 @@ test "coroutine await struct" {
     expect(await_final_result.x == 1234);
     expect(std.mem.eql(u8, &await_points, "abcdefghi"));
 }
-async fn await_amain() void {
+fn await_amain() void {
     await_seq('b');
     var p = async await_another();
     await_seq('e');
     await_final_result = await p;
     await_seq('h');
 }
-async fn await_another() Foo {
+fn await_another() Foo {
     await_seq('c');
     suspend {
         await_seq('d');


### PR DESCRIPTION
It's redundant with `callconv(.Async)` now.