### PR TITLE
os.zig: add ETIMEDOUT error case to read function

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -292,6 +292,7 @@ pub const ReadError = error{
     OperationAborted,
     BrokenPipe,
     ConnectionResetByPeer,
+    ConnectionTimedOut,
 
     /// This error occurs when no global event loop is configured,
     /// and reading from the file descriptor would block.
@@ -351,6 +352,7 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
             ENOBUFS => return error.SystemResources,
             ENOMEM => return error.SystemResources,
             ECONNRESET => return error.ConnectionResetByPeer,
+            ETIMEDOUT => return error.ConnectionTimedOut,
             else => |err| return unexpectedErrno(err),
         }
     }

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -837,6 +837,7 @@ pub const NativeTargetInfo = struct {
                 error.BrokenPipe => return error.UnableToReadElfFile,
                 error.Unseekable => return error.UnableToReadElfFile,
                 error.ConnectionResetByPeer => return error.UnableToReadElfFile,
+                error.ConnectionTimedOut => return error.UnableToReadElfFile,
                 error.Unexpected => return error.Unexpected,
                 error.InputOutput => return error.FileSystem,
             };

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -841,6 +841,7 @@ export fn stage2_libc_parse(stage1_libc: *Stage2LibCInstallation, libc_file_z: [
         error.EndOfStream => return .EndOfFile,
         error.IsDir => return .IsDir,
         error.ConnectionResetByPeer => unreachable,
+        error.ConnectionTimedOut => unreachable,
         error.OutOfMemory => return .OutOfMemory,
         error.Unseekable => unreachable,
         error.SharingViolation => return .SharingViolation,


### PR DESCRIPTION
According to documentation ETIMEDOUT (110) is a valid error code for the read function.  I just had my long-running  (been running for about 7 weeks) network program crash because it did not handle the ETIMEDOUT error code from "read".  Here's the end of its output/stacktrace:
```bash
...
unexpected errno: 110
/home/zig-linux-x86_64-0.5.0+153c6cf92/lib/zig/std/debug.zig:401:19: 0x20b712 in std.debug.writeCurrentStackTrace (punch-server-initiator)
    while (it.next()) |return_address| {
                  ^
/home/zig-linux-x86_64-0.5.0+153c6cf92/lib/zig/std/debug.zig:124:27: 0x209718 in std.debug.dumpCurrentStackTrace (punch-server-initiator)
    writeCurrentStackTrace(stderr, debug_info, detectTTYConfig(), start_addr) catch |err| {
                          ^
/home/zig-linux-x86_64-0.5.0+153c6cf92/lib/zig/std/os.zig:3478:40: 0x20c232 in std.os.unexpectedErrno (punch-server-initiator)
        std.debug.dumpCurrentStackTrace(null);
                                       ^
/home/zig-linux-x86_64-0.5.0+153c6cf92/lib/zig/std/os.zig:350:49: 0x22c67f in std.os.read (punch-server-initiator)
            else => |err| return unexpectedErrno(err),
                                                ^
/home/git/netpunch/netext.zig:120:19: 0x246728 in netext.read (punch-server-initiator)
    return os.read(fd, buf) catch |e| switch (e) {
                  ^

...
```