### PR TITLE
Update ErrorUnion thread spawn result to return null instead of 0

### DIFF
--- a/lib/std/thread.zig
+++ b/lib/std/thread.zig
@@ -280,7 +280,7 @@ pub const Thread = struct {
                                 std.debug.dumpStackTrace(trace.*);
                             }
                         };
-                        return 0;
+                        return null;
                     },
                     else => @compileError(bad_startfn_ret),
                 }


### PR DESCRIPTION
Without this, spawning a `Thread` with a `startFn` with a error union result type would result in:
```
Semantic Analysis [772/1221] /Users/haze/zig/lib/zig/std/thread.zig:283:32: error: expected type '*c_void', found 'comptime_int'
                        return 0;
```