### PR TITLE
Add setUseTestEventedIo for test steps in build.zig

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1132,6 +1132,7 @@ pub const LibExeObjStep = struct {
     name_prefix: []const u8,
     filter: ?[]const u8,
     single_threaded: bool,
+    evented_io: bool = false,
     code_model: builtin.CodeModel = .default,
 
     root_src: ?FileSource,
@@ -1559,6 +1560,11 @@ pub const LibExeObjStep = struct {
         self.filter = text;
     }
 
+    pub fn setUseTestEventedIo(self: *LibExeObjStep, use_evented_io: bool) void {
+        assert(self.kind == Kind.Test);
+        self.evented_io = use_evented_io;
+    }
+
     pub fn addCSourceFile(self: *LibExeObjStep, file: []const u8, args: []const []const u8) void {
         self.addCSourceFileSource(.{
             .args = args,
@@ -1862,6 +1868,10 @@ pub const LibExeObjStep = struct {
         if (self.filter) |filter| {
             try zig_args.append("--test-filter");
             try zig_args.append(filter);
+        }
+
+        if (self.evented_io) {
+            try zig_args.append("--test-evented-io");
         }
 
         if (self.name_prefix.len != 0) {


### PR DESCRIPTION
It didn't seem like there was a way to run tests added in build.zig with evented io, if this was possible without these changes feel free to close