### PR TITLE
Add support for external links and URL to markdown parser.

### DIFF
--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -1498,6 +1498,22 @@
                 }
             ];
 
+            // Links, images and inner links don't use the same marker to wrap their content.
+            const linksFormat = [
+                {
+                    prefix: "[",
+                    regex: /\[([^\]]*)\]\(([^\)]*)\)/,
+                    urlIndex: 2, // Index in the match that contains the link URL
+                    textIndex: 1 // Index in the match that contains the link text
+                },
+                {
+                    prefix: "h",
+                    regex: /http[s]?:\/\/[^\s]+/,
+                    urlIndex: 0,
+                    textIndex: 0
+                }
+            ];
+
             const stack = [];
 
             var innerHTML = "";
@@ -1548,6 +1564,29 @@
                     currentRun += innerText[i];
                     in_code = true;
                 } else {
+                    var foundMatches = false;
+
+                    for (var j = 0; j < linksFormat.length; j++) {
+                        const linkFmt = linksFormat[j];
+
+                        if (linkFmt.prefix == innerText[i]) {
+                            var remaining = innerText.substring(i);
+                            var matches = remaining.match(linkFmt.regex);
+
+                            if (matches) {
+                                flushRun();
+                                innerHTML += ' <a href="' + matches[linkFmt.urlIndex] + '">' + matches[linkFmt.textIndex] + '</a> ';
+                                i += matches[0].length; // Skip the fragment we just consumed
+                                foundMatches = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (foundMatches) {
+                        continue;
+                    }
+
                     var any = false;
                     for (var idx = (stack.length > 0 ? -1 : 0); idx < formats.length; idx++) {
                         const fmt = idx >= 0 ? formats[idx] : stack[stack.length - 1];


### PR DESCRIPTION
Partially solves #3411.
Internal links are still missing.