### PR TITLE
Standard library: Fix a regression in loop.waitUntilFdWritableOrReadable

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -493,7 +493,7 @@ pub const Loop = struct {
     pub fn waitUntilFdWritableOrReadable(self: *Loop, fd: os.fd_t) void {
         switch (builtin.os.tag) {
             .linux => {
-                self.linuxWaitFd(@intCast(usize, fd), os.EPOLLET | os.EPOLLONESHOT | os.EPOLLOUT | os.EPOLLIN);
+                self.linuxWaitFd(fd, os.EPOLLET | os.EPOLLONESHOT | os.EPOLLOUT | os.EPOLLIN);
             },
             .macosx, .freebsd, .netbsd, .dragonfly => {
                 self.bsdWaitKev(@intCast(usize, fd), os.EVFILT_READ, os.EV_ONESHOT);


### PR DESCRIPTION
This broke async io on linux.
Regressed in 8ebcca6734e07aea29098ca4c63c0216b3099d0e