### PR TITLE
Making evented I/O work on macOS

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -616,14 +616,16 @@ pub const Loop = struct {
 
         self.workerRun();
 
-        switch (builtin.os.tag) {
-            .linux,
-            .macosx,
-            .freebsd,
-            .netbsd,
-            .dragonfly,
-            => self.fs_thread.wait(),
-            else => {},
+        if (!builtin.single_threaded) {
+            switch (builtin.os.tag) {
+                .linux,
+                .macosx,
+                .freebsd,
+                .netbsd,
+                .dragonfly,
+                => self.fs_thread.wait(),
+                else => {},
+            }
         }
 
         for (self.extra_threads) |extra_thread| {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2549,7 +2549,7 @@ pub fn connect(sockfd: fd_t, sock_addr: *const sockaddr, len: socklen_t) Connect
             EAFNOSUPPORT => return error.AddressFamilyNotSupported,
             EAGAIN, EINPROGRESS => {
                 const loop = std.event.Loop.instance orelse return error.WouldBlock;
-                loop.waitUntilFdWritableOrReadable(sockfd);
+                loop.waitUntilFdWritable(sockfd);
                 return getsockoptError(sockfd);
             },
             EALREADY => unreachable, // The socket is nonblocking and a previous connection attempt has not yet been completed.


### PR DESCRIPTION
This PR contains two reasonably solid fixes and one tentative fix that should be discussed first.

### Fix 1
Simple fix on a crash caused by a missing `builtin.single_threaded` check.

### Fix 2
Fixes a race condition crash based on `EV_ONESHOT` being erroneusly passed as a filter_flag (thanks JX7P from IRC, we were running in circles :D)

### Fix 3
As of now, when calling `connect` we were checking for the socket to be either readable or writable. In kqueue this doesn't seem to be possible, which exposes the problem that if the other host is not sending anything, the connection never becomes readable. This makes me question whether we really need to check for both conditions before proceeding. For example this deadlocks my Redis client because it's the client that's supposed to speak first. 
Related issue: #5278.

Thanks @haze @FireFox317 @SuperAuguste, chaplchapl and @alexnask .