### PR TITLE
Add condition to remove of prefix in file path

### DIFF
--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -339,9 +339,14 @@ pub const WindowsDynLib = struct {
     }
 
     pub fn openW(path_w: [*:0]const u16) !WindowsDynLib {
+        const stripped_path = if (mem.len(path_w) >= 4) blk: {
+            const prefix= &[_]u16{ '\\', '?', '?', '\\' };
+            break: blk if (mem.eql(u16, path_w[0..4], prefix)) path_w + 4 else path_w;
+        } else path_w;
+
         return WindowsDynLib{
             // + 4 to skip over the \??\
-            .dll = try windows.LoadLibraryW(path_w + 4),
+            .dll = try windows.LoadLibraryW(stripped_path),
         };
     }
 

--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -339,10 +339,7 @@ pub const WindowsDynLib = struct {
     }
 
     pub fn openW(path_w: [*:0]const u16) !WindowsDynLib {
-        const stripped_path = if (mem.len(path_w) >= 4) blk: {
-            const prefix= &[_]u16{ '\\', '?', '?', '\\' };
-            break: blk if (mem.eql(u16, path_w[0..4], prefix)) path_w + 4 else path_w;
-        } else path_w;
+        const stripped_path = if (mem.startsWith(u16, path_w[0..mem.len(path_w)], &[_]u16{ '\\', '?', '?', '\\' })) path_w + 4 else path_w;
 
         return WindowsDynLib{
             // + 4 to skip over the \??\


### PR DESCRIPTION
Fixes #5289

Was tested with the following cases:
```zig
test "Dynamic loading - absolute" {
    var abs_path_lib_backslash = try DynLib.open("d:\\devel\\zig-wk\\mountain-robot\\SDL2.dll");
    defer abs_path_lib_backslash.close();

    var abs_path_lib = try DynLib.open("d:/devel/zig-wk/mountain-robot/SDL2.dll");
    defer abs_path_lib.close();
}

test "Dynamic loading - relative" {
    var rel_path_lib_backslash = try DynLib.open(".\\SDL2.dll");
    defer rel_path_lib_backslash.close();

    var rel_path_lib = try DynLib.open("./SDL2.dll");
    defer rel_path_lib.close();
}

test "Dynamic loading - naked" {
    var no_path_lib = try DynLib.open("SDL2.dll");
    defer no_path_lib.close();
}

test "Dynamic loading - module" {
    var module_lib = try DynLib.open("SDL2");
    defer module_lib.close();
}
```
