### PR TITLE
make Address.getOsSockLen pub

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -341,7 +341,7 @@ pub const Address = extern union {
         return mem.eql(u8, a_bytes, b_bytes);
     }
 
-    fn getOsSockLen(self: Address) os.socklen_t {
+    pub fn getOsSockLen(self: Address) os.socklen_t {
         switch (self.any.family) {
             os.AF_INET => return @sizeOf(os.sockaddr_in),
             os.AF_INET6 => return @sizeOf(os.sockaddr_in6),


### PR DESCRIPTION
`getOsSockLen` is a nice function that an application can use to get length of a "standard" socket address.  This is the length that would need to be passed into a function such as `bind` or `accept`.  Example:
```zig
fn makeSock(listenAddr: *Address) !fd_t {
    // ...
    try os.bind(sockfd, &listenAddr.any, listenAddr.getOsSockLen());
    // ...
}

```