### PR TITLE
Fix comment typo RFC8529 -> RFC8259

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -136,7 +136,7 @@ pub const Token = union(enum) {
 /// they are encountered. No copies or allocations are performed during parsing and the entire
 /// parsing state requires ~40-50 bytes of stack space.
 ///
-/// Conforms strictly to RFC8529.
+/// Conforms strictly to RFC8259.
 ///
 /// For a non-byte based wrapper, consider using TokenStream instead.
 pub const StreamingParser = struct {


### PR DESCRIPTION
Ref: https://tools.ietf.org/html/rfc8259