### PR TITLE
Enable the test `standalone/global_linkage`

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -11,6 +11,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/main_pkg_path/build.zig");
     cases.addBuildFile("test/standalone/shared_library/build.zig");
     cases.addBuildFile("test/standalone/mix_o_files/build.zig");
+    cases.addBuildFile("test/standalone/global_linkage/build.zig");
     cases.addBuildFile("test/standalone/static_c_lib/build.zig");
     cases.addBuildFile("test/standalone/issue_339/build.zig");
     cases.addBuildFile("test/standalone/issue_794/build.zig");

--- a/test/standalone/global_linkage/build.zig
+++ b/test/standalone/global_linkage/build.zig
@@ -2,19 +2,15 @@ const Builder = @import("std").build.Builder;
 
 pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();
-    const target = b.standardTargetOptions(null);
 
     const obj1 = b.addStaticLibrary("obj1", "obj1.zig");
     obj1.setBuildMode(mode);
-    obj1.setTheTarget(target);
 
     const obj2 = b.addStaticLibrary("obj2", "obj2.zig");
     obj2.setBuildMode(mode);
-    obj2.setTheTarget(target);
 
     const main = b.addTest("main.zig");
     main.setBuildMode(mode);
-    main.setTheTarget(target);
     main.linkLibrary(obj1);
     main.linkLibrary(obj2);
 


### PR DESCRIPTION
This test was added to the source tree in c39d7a6, but has never been referenced from anywhere. I figured the author of the test forgot to update `standalone.zig`.