### PR TITLE
Add enum to addBuildOption

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1678,6 +1678,16 @@ pub const LibExeObjStep = struct {
 
     pub fn addBuildOption(self: *LibExeObjStep, comptime T: type, name: []const u8, value: T) void {
         const out = self.build_options_contents.outStream();
+        switch (@typeInfo(T)) {
+            .Enum => |enum_info| {
+                out.print("const {} = enum {{\n", .{@typeName(T)}) catch unreachable;
+                inline for (enum_info.fields) |field| {
+                    out.print("    {},\n", .{ field.name }) catch unreachable;
+                }
+                out.print("}};\n", .{}) catch unreachable;
+            },
+            else => {},
+        }
         out.print("pub const {} = {};\n", .{ name, value }) catch unreachable;
     }
 


### PR DESCRIPTION
Add the ability to add enums to the build options.
Needed to define the enum in the build options file, then can define the public enum literal.