### PR TITLE
Translate to NT-style name using "\\?\" prefix.

### DIFF
--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -327,21 +327,20 @@ pub const WindowsDynLib = struct {
     dll: windows.HMODULE,
 
     pub fn open(path: []const u8) !WindowsDynLib {
-        const path_w = try windows.sliceToPrefixedFileW(path);
+        const path_w = try windows.sliceToAltPrefixedFileW(path);
         return openW(path_w.span().ptr);
     }
 
     pub const openC = @compileError("deprecated: renamed to openZ");
 
     pub fn openZ(path_c: [*:0]const u8) !WindowsDynLib {
-        const path_w = try windows.cStrToPrefixedFileW(path_c);
+        const path_w = try windows.cStrToAltPrefixedFileW(path_c);
         return openW(path_w.span().ptr);
     }
 
     pub fn openW(path_w: [*:0]const u16) !WindowsDynLib {
         return WindowsDynLib{
-            // + 4 to skip over the \??\
-            .dll = try windows.LoadLibraryW(path_w + 4),
+            .dll = try windows.LoadLibraryW(path_w),
         };
     }
 

--- a/lib/std/os/windows/test.zig
+++ b/lib/std/os/windows/test.zig
@@ -1,0 +1,15 @@
+const std = @import("../../std.zig");
+const builtin = @import("builtin");
+const mem = std.mem;
+const windows = std.os.windows;
+const expect = std.testing.expect;
+
+test "sliceToAltPrefixedFileW" {
+    const rel_path = "fake/relative/path.txt";
+    const conv_rel_path = try windows.sliceToAltPrefixedFileW(rel_path);
+    expect(mem.eql(u16, conv_rel_path.span(), std.unicode.utf8ToUtf16LeStringLiteral("fake\\relative\\path.txt")));
+
+    const abs_path = "c:/absolute_path/should_be_supported.txt";
+    const conv_bas_path = try windows.sliceToAltPrefixedFileW(abs_path);
+    expect(mem.eql(u16, conv_bas_path.span(), std.unicode.utf8ToUtf16LeStringLiteral("\\\\?\\c:\\absolute_path\\should_be_supported.txt")));
+}


### PR DESCRIPTION
Fixes #5289

There is 2 differents prefix for NT-style name `\\?\` and `\??\`.
Which one is supported if any depends on the function, `LoadLibraryW` supports `\\?\`.