### PR TITLE
improve std.zig.parse performance using flat arrays for AST nodes and tokens

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -776,7 +776,7 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: var, source_token: Tok
         next_tok_is_fn = false;
 
         const token = tokenizer.next();
-        try writeEscaped(out, src[index..token.start]);
+        try writeEscaped(out, src[index..token.loc.start]);
         switch (token.id) {
             .Eof => break,
 
@@ -827,13 +827,13 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: var, source_token: Tok
             .Keyword_while,
             => {
                 try out.writeAll("<span class=\"tok-kw\">");
-                try writeEscaped(out, src[token.start..token.end]);
+                try writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
             .Keyword_fn => {
                 try out.writeAll("<span class=\"tok-kw\">");
-                try writeEscaped(out, src[token.start..token.end]);
+                try writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
                 next_tok_is_fn = true;
             },
@@ -844,7 +844,7 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: var, source_token: Tok
             .Keyword_false,
             => {
                 try out.writeAll("<span class=\"tok-null\">");
-                try writeEscaped(out, src[token.start..token.end]);
+                try writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
@@ -853,13 +853,13 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: var, source_token: Tok
             .CharLiteral,
             => {
                 try out.writeAll("<span class=\"tok-str\">");
-                try writeEscaped(out, src[token.start..token.end]);
+                try writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
             .Builtin => {
                 try out.writeAll("<span class=\"tok-builtin\">");
-                try writeEscaped(out, src[token.start..token.end]);
+                try writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
@@ -869,34 +869,34 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: var, source_token: Tok
             .ShebangLine,
             => {
                 try out.writeAll("<span class=\"tok-comment\">");
-                try writeEscaped(out, src[token.start..token.end]);
+                try writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
             .Identifier => {
                 if (prev_tok_was_fn) {
                     try out.writeAll("<span class=\"tok-fn\">");
-                    try writeEscaped(out, src[token.start..token.end]);
+                    try writeEscaped(out, src[token.loc.start..token.loc.end]);
                     try out.writeAll("</span>");
                 } else {
                     const is_int = blk: {
-                        if (src[token.start] != 'i' and src[token.start] != 'u')
+                        if (src[token.loc.start] != 'i' and src[token.loc.start] != 'u')
                             break :blk false;
-                        var i = token.start + 1;
-                        if (i == token.end)
+                        var i = token.loc.start + 1;
+                        if (i == token.loc.end)
                             break :blk false;
-                        while (i != token.end) : (i += 1) {
+                        while (i != token.loc.end) : (i += 1) {
                             if (src[i] < '0' or src[i] > '9')
                                 break :blk false;
                         }
                         break :blk true;
                     };
-                    if (is_int or isType(src[token.start..token.end])) {
+                    if (is_int or isType(src[token.loc.start..token.loc.end])) {
                         try out.writeAll("<span class=\"tok-type\">");
-                        try writeEscaped(out, src[token.start..token.end]);
+                        try writeEscaped(out, src[token.loc.start..token.loc.end]);
                         try out.writeAll("</span>");
                     } else {
-                        try writeEscaped(out, src[token.start..token.end]);
+                        try writeEscaped(out, src[token.loc.start..token.loc.end]);
                     }
                 }
             },
@@ -905,7 +905,7 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: var, source_token: Tok
             .FloatLiteral,
             => {
                 try out.writeAll("<span class=\"tok-number\">");
-                try writeEscaped(out, src[token.start..token.end]);
+                try writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
@@ -963,7 +963,7 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: var, source_token: Tok
             .AngleBracketAngleBracketRight,
             .AngleBracketAngleBracketRightEqual,
             .Tilde,
-            => try writeEscaped(out, src[token.start..token.end]),
+            => try writeEscaped(out, src[token.loc.start..token.loc.end]),
 
             .Invalid, .Invalid_ampersands => return parseError(
                 docgen_tokenizer,
@@ -972,7 +972,7 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: var, source_token: Tok
                 .{},
             ),
         }
-        index = token.end;
+        index = token.loc.end;
     }
     try out.writeAll("</code>");
 }

--- a/lib/std/heap/arena_allocator.zig
+++ b/lib/std/heap/arena_allocator.zig
@@ -47,12 +47,8 @@ pub const ArenaAllocator = struct {
 
     fn createNode(self: *ArenaAllocator, prev_len: usize, minimum_size: usize) !*BufNode {
         const actual_min_size = minimum_size + @sizeOf(BufNode);
-        var len = prev_len;
-        while (true) {
-            len += len / 2;
-            len += mem.page_size - @rem(len, mem.page_size);
-            if (len >= actual_min_size) break;
-        }
+        const big_enough_len = prev_len + actual_min_size;
+        const len = big_enough_len + big_enough_len / 2;
         const buf = try self.child_allocator.alignedAlloc(u8, @alignOf(BufNode), len);
         const buf_node_slice = mem.bytesAsSlice(BufNode, buf[0..@sizeOf(BufNode)]);
         const buf_node = &buf_node_slice[0];

--- a/lib/std/heap/arena_allocator.zig
+++ b/lib/std/heap/arena_allocator.zig
@@ -46,7 +46,7 @@ pub const ArenaAllocator = struct {
     }
 
     fn createNode(self: *ArenaAllocator, prev_len: usize, minimum_size: usize) !*BufNode {
-        const actual_min_size = minimum_size + @sizeOf(BufNode);
+        const actual_min_size = minimum_size + (@sizeOf(BufNode) + 16);
         const big_enough_len = prev_len + actual_min_size;
         const len = big_enough_len + big_enough_len / 2;
         const buf = try self.child_allocator.alignedAlloc(u8, @alignOf(BufNode), len);

--- a/lib/std/linked_list.zig
+++ b/lib/std/linked_list.zig
@@ -49,6 +49,26 @@ pub fn SinglyLinkedList(comptime T: type) type {
                 node.next = next_node.next;
                 return next_node;
             }
+
+            /// Iterate over the singly-linked list from this node, until the final node is found.
+            /// This operation is O(N).
+            pub fn findLast(node: *Node) *Node {
+                var it = node;
+                while (true) {
+                    it = it.next orelse return it;
+                }
+            }
+
+            /// Iterate over each next node, returning the count of all nodes except the starting one.
+            /// This operation is O(N).
+            pub fn countChildren(node: *const Node) usize {
+                var count: usize = 0;
+                var it: ?*const Node = node;
+                while (it) |n| : (it = n.next) {
+                    count += 1;
+                }
+                return count;
+            }
         };
 
         first: ?*Node = null,
@@ -86,6 +106,16 @@ pub fn SinglyLinkedList(comptime T: type) type {
             const first = list.first orelse return null;
             list.first = first.next;
             return first;
+        }
+
+        /// Iterate over all nodes, returning the count.
+        /// This operation is O(N).
+        pub fn len(list: Self) usize {
+            if (list.first) |n| {
+                return 1 + n.countChildren();
+            } else {
+                return 0;
+            }
         }
     };
 }

--- a/lib/std/linked_list.zig
+++ b/lib/std/linked_list.zig
@@ -121,27 +121,20 @@ pub fn SinglyLinkedList(comptime T: type) type {
 }
 
 test "basic SinglyLinkedList test" {
-    const allocator = testing.allocator;
-    var list = SinglyLinkedList(u32).init();
+    const L = SinglyLinkedList(u32);
+    var list = L{};
 
-    var one = try list.createNode(1, allocator);
-    var two = try list.createNode(2, allocator);
-    var three = try list.createNode(3, allocator);
-    var four = try list.createNode(4, allocator);
-    var five = try list.createNode(5, allocator);
-    defer {
-        list.destroyNode(one, allocator);
-        list.destroyNode(two, allocator);
-        list.destroyNode(three, allocator);
-        list.destroyNode(four, allocator);
-        list.destroyNode(five, allocator);
-    }
+    var one = L.Node{.data = 1};
+    var two = L.Node{.data = 2};
+    var three = L.Node{.data = 3};
+    var four = L.Node{.data = 4};
+    var five = L.Node{.data = 5};
 
-    list.prepend(two); // {2}
-    list.insertAfter(two, five); // {2, 5}
-    list.prepend(one); // {1, 2, 5}
-    list.insertAfter(two, three); // {1, 2, 3, 5}
-    list.insertAfter(three, four); // {1, 2, 3, 4, 5}
+    list.prepend(&two); // {2}
+    two.insertAfter(&five); // {2, 5}
+    list.prepend(&one); // {1, 2, 5}
+    two.insertAfter(&three); // {1, 2, 3, 5}
+    three.insertAfter(&four); // {1, 2, 3, 4, 5}
 
     // Traverse forwards.
     {
@@ -154,7 +147,7 @@ test "basic SinglyLinkedList test" {
     }
 
     _ = list.popFirst(); // {2, 3, 4, 5}
-    _ = list.remove(five); // {2, 3, 4}
+    _ = list.remove(&five); // {2, 3, 4}
     _ = two.removeNext(); // {2, 4}
 
     testing.expect(list.first.?.data == 2);

--- a/lib/std/linked_list.zig
+++ b/lib/std/linked_list.zig
@@ -21,6 +21,8 @@ pub fn SinglyLinkedList(comptime T: type) type {
             next: ?*Node = null,
             data: T,
 
+            pub const Data = T;
+
             pub fn init(data: T) Node {
                 return Node{
                     .data = data,
@@ -50,25 +52,6 @@ pub fn SinglyLinkedList(comptime T: type) type {
         };
 
         first: ?*Node = null,
-
-        /// Initialize a linked list.
-        ///
-        /// Returns:
-        ///     An empty linked list.
-        pub fn init() Self {
-            return Self{
-                .first = null,
-            };
-        }
-
-        /// Insert a new node after an existing one.
-        ///
-        /// Arguments:
-        ///     node: Pointer to a node in the list.
-        ///     new_node: Pointer to the new node to insert.
-        pub fn insertAfter(list: *Self, node: *Node, new_node: *Node) void {
-            node.insertAfter(new_node);
-        }
 
         /// Insert a new node at the head.
         ///
@@ -103,40 +86,6 @@ pub fn SinglyLinkedList(comptime T: type) type {
             const first = list.first orelse return null;
             list.first = first.next;
             return first;
-        }
-
-        /// Allocate a new node.
-        ///
-        /// Arguments:
-        ///     allocator: Dynamic memory allocator.
-        ///
-        /// Returns:
-        ///     A pointer to the new node.
-        pub fn allocateNode(list: *Self, allocator: *Allocator) !*Node {
-            return allocator.create(Node);
-        }
-
-        /// Deallocate a node.
-        ///
-        /// Arguments:
-        ///     node: Pointer to the node to deallocate.
-        ///     allocator: Dynamic memory allocator.
-        pub fn destroyNode(list: *Self, node: *Node, allocator: *Allocator) void {
-            allocator.destroy(node);
-        }
-
-        /// Allocate and initialize a node and its data.
-        ///
-        /// Arguments:
-        ///     data: The data to put inside the node.
-        ///     allocator: Dynamic memory allocator.
-        ///
-        /// Returns:
-        ///     A pointer to the new node.
-        pub fn createNode(list: *Self, data: T, allocator: *Allocator) !*Node {
-            var node = try list.allocateNode(allocator);
-            node.* = Node.init(data);
-            return node;
         }
     };
 }

--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -658,7 +658,7 @@ pub const Xoroshiro128 = struct {
         self.s[1] = s1;
     }
 
-    fn seed(self: *Xoroshiro128, init_s: u64) void {
+    pub fn seed(self: *Xoroshiro128, init_s: u64) void {
         // Xoroshiro requires 128-bits of seed.
         var gen = SplitMix64.init(init_s);
 

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -320,10 +320,11 @@ fn printWithVisibleNewlines(source: []const u8) void {
 }
 
 fn printLine(line: []const u8) void {
-    switch (line[line.len - 1]) {
+    if (line.len != 0) switch (line[line.len - 1]) {
         ' ', '\t' => warn("{}⏎\n", .{line}), // Carriage return symbol,
-        else => warn("{}\n", .{line}),
-    }
+        else => {},
+    };
+    warn("{}\n", .{line});
 }
 
 test "" {

--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -36,7 +36,7 @@ pub const Tree = struct {
         return self.tokenSlicePtr(self.tokens[token_index]);
     }
 
-    pub fn tokenSlicePtr(self: *Tree, token: *const Token) []const u8 {
+    pub fn tokenSlicePtr(self: *Tree, token: Token) []const u8 {
         return self.source[token.start..token.end];
     }
 
@@ -89,7 +89,7 @@ pub const Tree = struct {
         return self.tokensOnSameLinePtr(self.tokens[token1_index], self.tokens[token2_index]);
     }
 
-    pub fn tokensOnSameLinePtr(self: *Tree, token1: *const Token, token2: *const Token) bool {
+    pub fn tokensOnSameLinePtr(self: *Tree, token1: Token, token2: Token) bool {
         return mem.indexOfScalar(u8, self.source[token1.end..token2.start], '\n') == null;
     }
 

--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -18,8 +18,6 @@ pub const Tree = struct {
 
     arena: std.heap.ArenaAllocator.State,
     gpa: *mem.Allocator,
-    /// This keeps track of slices of memory that must be freed on deinit.
-    owned_memory: [][]u8,
 
     /// translate-c uses this to avoid having to emit correct newlines
     /// TODO get rid of this hack
@@ -28,10 +26,6 @@ pub const Tree = struct {
     pub fn deinit(self: *Tree) void {
         self.gpa.free(self.tokens);
         self.gpa.free(self.errors);
-        for (self.owned_memory) |list| {
-            self.gpa.free(list);
-        }
-        self.gpa.free(self.owned_memory);
         self.arena.promote(self.gpa).deinit();
     }
 

--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -401,7 +401,6 @@ pub const Node = struct {
     /// All the child Node types use this same Iterator state for their iteration.
     pub const Iterator = struct {
         parent_node: *const Node,
-        node: ?*LinkedList(*Node).Node,
         index: usize,
 
         pub fn next(it: *Iterator) ?*Node {
@@ -648,7 +647,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const Root) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Root, it: *Node.Iterator) ?*Node {
@@ -702,7 +701,7 @@ pub const Node = struct {
         semicolon_token: TokenIndex,
 
         pub fn iterate(self: *const VarDecl) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const VarDecl, it: *Node.Iterator) ?*Node {
@@ -756,7 +755,7 @@ pub const Node = struct {
         semicolon_token: TokenIndex,
 
         pub fn iterate(self: *const Use) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Use, it: *Node.Iterator) ?*Node {
@@ -797,13 +796,17 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const ErrorSetDecl) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const ErrorSetDecl, it: *Node.Iterator) ?*Node {
-            const decl = it.node orelse return null;
-            it.node = decl.next;
-            return decl.data;
+            var i = it.index;
+            it.index += 1;
+
+            if (i < self.decls_len) return self.declsConst()[i];
+            i -= self.decls_len;
+
+            return null;
         }
 
         pub fn firstToken(self: *const ErrorSetDecl) TokenIndex {
@@ -857,7 +860,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const ContainerDecl) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const ContainerDecl, it: *Node.Iterator) ?*Node {
@@ -914,7 +917,7 @@ pub const Node = struct {
         align_expr: ?*Node,
 
         pub fn iterate(self: *const ContainerField) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const ContainerField, it: *Node.Iterator) ?*Node {
@@ -966,7 +969,7 @@ pub const Node = struct {
         name_token: TokenIndex,
 
         pub fn iterate(self: *const ErrorTag) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const ErrorTag, it: *Node.Iterator) ?*Node {
@@ -995,7 +998,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const Identifier) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Identifier, it: *Node.Iterator) ?*Node {
@@ -1050,7 +1053,7 @@ pub const Node = struct {
             };
 
             pub fn iterate(self: *const ParamDecl) Node.Iterator {
-                return .{ .parent_node = &self.base, .index = 0, .node = null };
+                return .{ .parent_node = &self.base, .index = 0 };
             }
 
             pub fn iterateNext(self: *const ParamDecl, it: *Node.Iterator) ?*Node {
@@ -1098,7 +1101,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const FnProto) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const FnProto, it: *Node.Iterator) ?*Node {
@@ -1189,7 +1192,7 @@ pub const Node = struct {
         };
 
         pub fn iterate(self: *const AnyFrameType) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const AnyFrameType, it: *Node.Iterator) ?*Node {
@@ -1234,7 +1237,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const Block) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Block, it: *Node.Iterator) ?*Node {
@@ -1281,7 +1284,7 @@ pub const Node = struct {
         expr: *Node,
 
         pub fn iterate(self: *const Defer) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Defer, it: *Node.Iterator) ?*Node {
@@ -1310,7 +1313,7 @@ pub const Node = struct {
         expr: *Node,
 
         pub fn iterate(self: *const Comptime) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Comptime, it: *Node.Iterator) ?*Node {
@@ -1338,7 +1341,7 @@ pub const Node = struct {
         expr: *Node,
 
         pub fn iterate(self: *const Nosuspend) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Nosuspend, it: *Node.Iterator) ?*Node {
@@ -1367,7 +1370,7 @@ pub const Node = struct {
         rpipe: TokenIndex,
 
         pub fn iterate(self: *const Payload) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Payload, it: *Node.Iterator) ?*Node {
@@ -1397,7 +1400,7 @@ pub const Node = struct {
         rpipe: TokenIndex,
 
         pub fn iterate(self: *const PointerPayload) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const PointerPayload, it: *Node.Iterator) ?*Node {
@@ -1428,7 +1431,7 @@ pub const Node = struct {
         rpipe: TokenIndex,
 
         pub fn iterate(self: *const PointerIndexPayload) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const PointerIndexPayload, it: *Node.Iterator) ?*Node {
@@ -1462,7 +1465,7 @@ pub const Node = struct {
         body: *Node,
 
         pub fn iterate(self: *const Else) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Else, it: *Node.Iterator) ?*Node {
@@ -1510,7 +1513,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const Switch) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Switch, it: *Node.Iterator) ?*Node {
@@ -1520,11 +1523,8 @@ pub const Node = struct {
             if (i < 1) return self.expr;
             i -= 1;
 
-            if (it.node) |child| {
-                it.index -= 1;
-                it.node = child.next;
-                return child.data;
-            }
+            if (i < self.cases_len) return self.casesConst()[i];
+            i -= self.cases_len;
 
             return null;
         }
@@ -1572,7 +1572,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const SwitchCase) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const SwitchCase, it: *Node.Iterator) ?*Node {
@@ -1621,7 +1621,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const SwitchElse) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const SwitchElse, it: *Node.Iterator) ?*Node {
@@ -1649,7 +1649,7 @@ pub const Node = struct {
         @"else": ?*Else,
 
         pub fn iterate(self: *const While) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const While, it: *Node.Iterator) ?*Node {
@@ -1712,7 +1712,7 @@ pub const Node = struct {
         @"else": ?*Else,
 
         pub fn iterate(self: *const For) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const For, it: *Node.Iterator) ?*Node {
@@ -1766,7 +1766,7 @@ pub const Node = struct {
         @"else": ?*Else,
 
         pub fn iterate(self: *const If) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const If, it: *Node.Iterator) ?*Node {
@@ -1859,7 +1859,7 @@ pub const Node = struct {
         };
 
         pub fn iterate(self: *const InfixOp) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const InfixOp, it: *Node.Iterator) ?*Node {
@@ -1982,7 +1982,7 @@ pub const Node = struct {
         };
 
         pub fn iterate(self: *const PrefixOp) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const PrefixOp, it: *Node.Iterator) ?*Node {
@@ -2045,7 +2045,7 @@ pub const Node = struct {
         expr: *Node,
 
         pub fn iterate(self: *const FieldInitializer) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const FieldInitializer, it: *Node.Iterator) ?*Node {
@@ -2086,7 +2086,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const ArrayInitializer) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const ArrayInitializer, it: *Node.Iterator) ?*Node {
@@ -2144,7 +2144,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const ArrayInitializerDot) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const ArrayInitializerDot, it: *Node.Iterator) ?*Node {
@@ -2199,7 +2199,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const StructInitializer) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const StructInitializer, it: *Node.Iterator) ?*Node {
@@ -2257,7 +2257,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const StructInitializerDot) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const StructInitializerDot, it: *Node.Iterator) ?*Node {
@@ -2313,7 +2313,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const Call) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null};
+            return .{ .parent_node = &self.base, .index = 0};
         }
 
         pub fn iterateNext(self: *const Call, it: *Node.Iterator) ?*Node {
@@ -2373,7 +2373,7 @@ pub const Node = struct {
         };
 
         pub fn iterate(self: *const SuffixOp) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null};
+            return .{ .parent_node = &self.base, .index = 0};
         }
 
         pub fn iterateNext(self: *const SuffixOp, it: *Node.Iterator) ?*Node {
@@ -2425,7 +2425,7 @@ pub const Node = struct {
         rparen: TokenIndex,
 
         pub fn iterate(self: *const GroupedExpression) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const GroupedExpression, it: *Node.Iterator) ?*Node {
@@ -2460,7 +2460,7 @@ pub const Node = struct {
         };
 
         pub fn iterate(self: *const ControlFlowExpression) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const ControlFlowExpression, it: *Node.Iterator) ?*Node {
@@ -2513,7 +2513,7 @@ pub const Node = struct {
         body: ?*Node,
 
         pub fn iterate(self: *const Suspend) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Suspend, it: *Node.Iterator) ?*Node {
@@ -2546,7 +2546,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const IntegerLiteral) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const IntegerLiteral, it: *Node.Iterator) ?*Node {
@@ -2568,7 +2568,7 @@ pub const Node = struct {
         name: TokenIndex,
 
         pub fn iterate(self: *const EnumLiteral) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const EnumLiteral, it: *Node.Iterator) ?*Node {
@@ -2589,7 +2589,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const FloatLiteral) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const FloatLiteral, it: *Node.Iterator) ?*Node {
@@ -2624,7 +2624,7 @@ pub const Node = struct {
         }
 
         pub fn iterate(self: *const BuiltinCall) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const BuiltinCall, it: *Node.Iterator) ?*Node {
@@ -2665,7 +2665,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const StringLiteral) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const StringLiteral, it: *Node.Iterator) ?*Node {
@@ -2681,14 +2681,24 @@ pub const Node = struct {
         }
     };
 
+    /// The string literal tokens appear directly in memory after MultilineStringLiteral.
     pub const MultilineStringLiteral = struct {
         base: Node = Node{ .id = .MultilineStringLiteral },
-        lines: LineList,
+        lines_len: TokenIndex,
 
-        pub const LineList = LinkedList(TokenIndex);
+        /// After this the caller must initialize the lines list.
+        pub fn alloc(allocator: *mem.Allocator, lines_len: NodeIndex) !*MultilineStringLiteral {
+            const bytes = try allocator.alignedAlloc(u8, @alignOf(MultilineStringLiteral), sizeInBytes(lines_len));
+            return @ptrCast(*MultilineStringLiteral, bytes.ptr);
+        }
+
+        pub fn free(self: *MultilineStringLiteral, allocator: *mem.Allocator) void {
+            const bytes = @ptrCast([*]u8, self)[0..sizeInBytes(self.lines_len)];
+            allocator.free(bytes);
+        }
 
         pub fn iterate(self: *const MultilineStringLiteral) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const MultilineStringLiteral, it: *Node.Iterator) ?*Node {
@@ -2696,14 +2706,25 @@ pub const Node = struct {
         }
 
         pub fn firstToken(self: *const MultilineStringLiteral) TokenIndex {
-            return self.lines.first.?.data;
+            return self.linesConst()[0];
         }
 
         pub fn lastToken(self: *const MultilineStringLiteral) TokenIndex {
-            var node = self.lines.first.?;
-            while (true) {
-                node = node.next orelse return node.data;
-            }
+            return self.linesConst()[self.lines_len - 1];
+        }
+
+        pub fn lines(self: *MultilineStringLiteral) []TokenIndex {
+            const decls_start = @ptrCast([*]u8, self) + @sizeOf(MultilineStringLiteral);
+            return @ptrCast([*]TokenIndex, decls_start)[0..self.lines_len];
+        }
+
+        pub fn linesConst(self: *const MultilineStringLiteral) []const TokenIndex {
+            const decls_start = @ptrCast([*]const u8, self) + @sizeOf(MultilineStringLiteral);
+            return @ptrCast([*]const TokenIndex, decls_start)[0..self.lines_len];
+        }
+
+        fn sizeInBytes(lines_len: NodeIndex) usize {
+            return @sizeOf(MultilineStringLiteral) + @sizeOf(TokenIndex) * @as(usize, lines_len);
         }
     };
 
@@ -2712,7 +2733,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const CharLiteral) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const CharLiteral, it: *Node.Iterator) ?*Node {
@@ -2733,7 +2754,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const BoolLiteral) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const BoolLiteral, it: *Node.Iterator) ?*Node {
@@ -2754,7 +2775,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const NullLiteral) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const NullLiteral, it: *Node.Iterator) ?*Node {
@@ -2775,7 +2796,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const UndefinedLiteral) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const UndefinedLiteral, it: *Node.Iterator) ?*Node {
@@ -2815,7 +2836,7 @@ pub const Node = struct {
             };
 
             pub fn iterate(self: *const Output) Node.Iterator {
-                return .{ .parent_node = &self.base, .index = 0, .node = null };
+                return .{ .parent_node = &self.base, .index = 0 };
             }
 
             pub fn iterateNext(self: *const Output, it: *Node.Iterator) ?*Node {
@@ -2859,7 +2880,7 @@ pub const Node = struct {
             rparen: TokenIndex,
 
             pub fn iterate(self: *const Input) Node.Iterator {
-                return .{ .parent_node = &self.base, .index = 0, .node = null };
+                return .{ .parent_node = &self.base, .index = 0 };
             }
 
             pub fn iterateNext(self: *const Input, it: *Node.Iterator) ?*Node {
@@ -2889,7 +2910,7 @@ pub const Node = struct {
 
 
         pub fn iterate(self: *const Asm) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null};
+            return .{ .parent_node = &self.base, .index = 0};
         }
 
         pub fn iterateNext(self: *const Asm, it: *Node.Iterator) ?*Node {
@@ -2932,7 +2953,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const Unreachable) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const Unreachable, it: *Node.Iterator) ?*Node {
@@ -2953,7 +2974,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const ErrorType) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const ErrorType, it: *Node.Iterator) ?*Node {
@@ -2974,7 +2995,7 @@ pub const Node = struct {
         token: TokenIndex,
 
         pub fn iterate(self: *const VarType) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const VarType, it: *Node.Iterator) ?*Node {
@@ -2997,7 +3018,7 @@ pub const Node = struct {
         pub const LineList = LinkedList(TokenIndex);
 
         pub fn iterate(self: *const DocComment) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const DocComment, it: *Node.Iterator) ?*Node {
@@ -3024,7 +3045,7 @@ pub const Node = struct {
         body_node: *Node,
 
         pub fn iterate(self: *const TestDecl) Node.Iterator {
-            return .{ .parent_node = &self.base, .index = 0, .node = null };
+            return .{ .parent_node = &self.base, .index = 0 };
         }
 
         pub fn iterateNext(self: *const TestDecl, it: *Node.Iterator) ?*Node {

--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -2067,11 +2067,23 @@ pub const Node = struct {
         }
     };
 
+    /// Elements occur directly in memory after ArrayInitializer.
     pub const ArrayInitializer = struct {
         base: Node = Node{ .id = .ArrayInitializer },
         rtoken: TokenIndex,
+        list_len: NodeIndex,
         lhs: *Node,
-        list: []*Node,
+
+        /// After this the caller must initialize the fields_and_decls list.
+        pub fn alloc(allocator: *mem.Allocator, list_len: NodeIndex) !*ArrayInitializer {
+            const bytes = try allocator.alignedAlloc(u8, @alignOf(ArrayInitializer), sizeInBytes(list_len));
+            return @ptrCast(*ArrayInitializer, bytes.ptr);
+        }
+
+        pub fn free(self: *ArrayInitializer, allocator: *mem.Allocator) void {
+            const bytes = @ptrCast([*]u8, self)[0..sizeInBytes(self.list_len)];
+            allocator.free(bytes);
+        }
 
         pub fn iterate(self: *const ArrayInitializer) Node.Iterator {
             return .{ .parent_node = &self.base, .index = 0, .node = null };
@@ -2084,8 +2096,8 @@ pub const Node = struct {
             if (i < 1) return self.lhs;
             i -= 1;
 
-            if (i < self.list.len) return self.list[i];
-            i -= self.list.len;
+            if (i < self.list_len) return self.listConst()[i];
+            i -= self.list_len;
 
             return null;
         }
@@ -2097,13 +2109,39 @@ pub const Node = struct {
         pub fn lastToken(self: *const ArrayInitializer) TokenIndex {
             return self.rtoken;
         }
+
+        pub fn list(self: *ArrayInitializer) []*Node {
+            const decls_start = @ptrCast([*]u8, self) + @sizeOf(ArrayInitializer);
+            return @ptrCast([*]*Node, decls_start)[0..self.list_len];
+        }
+
+        pub fn listConst(self: *const ArrayInitializer) []const *Node {
+            const decls_start = @ptrCast([*]const u8, self) + @sizeOf(ArrayInitializer);
+            return @ptrCast([*]const *Node, decls_start)[0..self.list_len];
+        }
+
+        fn sizeInBytes(list_len: NodeIndex) usize {
+            return @sizeOf(ArrayInitializer) + @sizeOf(*Node) * @as(usize, list_len);
+        }
     };
 
+    /// Elements occur directly in memory after ArrayInitializerDot.
     pub const ArrayInitializerDot = struct {
         base: Node = Node{ .id = .ArrayInitializerDot },
         dot: TokenIndex,
         rtoken: TokenIndex,
-        list: []*Node,
+        list_len: NodeIndex,
+
+        /// After this the caller must initialize the fields_and_decls list.
+        pub fn alloc(allocator: *mem.Allocator, list_len: NodeIndex) !*ArrayInitializerDot {
+            const bytes = try allocator.alignedAlloc(u8, @alignOf(ArrayInitializerDot), sizeInBytes(list_len));
+            return @ptrCast(*ArrayInitializerDot, bytes.ptr);
+        }
+
+        pub fn free(self: *ArrayInitializerDot, allocator: *mem.Allocator) void {
+            const bytes = @ptrCast([*]u8, self)[0..sizeInBytes(self.list_len)];
+            allocator.free(bytes);
+        }
 
         pub fn iterate(self: *const ArrayInitializerDot) Node.Iterator {
             return .{ .parent_node = &self.base, .index = 0, .node = null };
@@ -2113,8 +2151,8 @@ pub const Node = struct {
             var i = it.index;
             it.index += 1;
 
-            if (i < self.list.len) return self.list[i];
-            i -= self.list.len;
+            if (i < self.list_len) return self.listConst()[i];
+            i -= self.list_len;
 
             return null;
         }
@@ -2126,13 +2164,39 @@ pub const Node = struct {
         pub fn lastToken(self: *const ArrayInitializerDot) TokenIndex {
             return self.rtoken;
         }
+
+        pub fn list(self: *ArrayInitializerDot) []*Node {
+            const decls_start = @ptrCast([*]u8, self) + @sizeOf(ArrayInitializerDot);
+            return @ptrCast([*]*Node, decls_start)[0..self.list_len];
+        }
+
+        pub fn listConst(self: *const ArrayInitializerDot) []const *Node {
+            const decls_start = @ptrCast([*]const u8, self) + @sizeOf(ArrayInitializerDot);
+            return @ptrCast([*]const *Node, decls_start)[0..self.list_len];
+        }
+
+        fn sizeInBytes(list_len: NodeIndex) usize {
+            return @sizeOf(ArrayInitializerDot) + @sizeOf(*Node) * @as(usize, list_len);
+        }
     };
 
+    /// Elements occur directly in memory after StructInitializer.
     pub const StructInitializer = struct {
         base: Node = Node{ .id = .StructInitializer },
         rtoken: TokenIndex,
+        list_len: NodeIndex,
         lhs: *Node,
-        list: []*Node,
+
+        /// After this the caller must initialize the fields_and_decls list.
+        pub fn alloc(allocator: *mem.Allocator, list_len: NodeIndex) !*StructInitializer {
+            const bytes = try allocator.alignedAlloc(u8, @alignOf(StructInitializer), sizeInBytes(list_len));
+            return @ptrCast(*StructInitializer, bytes.ptr);
+        }
+
+        pub fn free(self: *StructInitializer, allocator: *mem.Allocator) void {
+            const bytes = @ptrCast([*]u8, self)[0..sizeInBytes(self.list_len)];
+            allocator.free(bytes);
+        }
 
         pub fn iterate(self: *const StructInitializer) Node.Iterator {
             return .{ .parent_node = &self.base, .index = 0, .node = null };
@@ -2145,8 +2209,8 @@ pub const Node = struct {
             if (i < 1) return self.lhs;
             i -= 1;
 
-            if (i < self.list.len) return self.list[i];
-            i -= self.list.len;
+            if (i < self.list_len) return self.listConst()[i];
+            i -= self.list_len;
 
             return null;
         }
@@ -2158,13 +2222,39 @@ pub const Node = struct {
         pub fn lastToken(self: *const StructInitializer) TokenIndex {
             return self.rtoken;
         }
+
+        pub fn list(self: *StructInitializer) []*Node {
+            const decls_start = @ptrCast([*]u8, self) + @sizeOf(StructInitializer);
+            return @ptrCast([*]*Node, decls_start)[0..self.list_len];
+        }
+
+        pub fn listConst(self: *const StructInitializer) []const *Node {
+            const decls_start = @ptrCast([*]const u8, self) + @sizeOf(StructInitializer);
+            return @ptrCast([*]const *Node, decls_start)[0..self.list_len];
+        }
+
+        fn sizeInBytes(list_len: NodeIndex) usize {
+            return @sizeOf(StructInitializer) + @sizeOf(*Node) * @as(usize, list_len);
+        }
     };
 
+    /// Elements occur directly in memory after StructInitializerDot.
     pub const StructInitializerDot = struct {
         base: Node = Node{ .id = .StructInitializerDot },
         dot: TokenIndex,
         rtoken: TokenIndex,
-        list: []*Node,
+        list_len: NodeIndex,
+
+        /// After this the caller must initialize the fields_and_decls list.
+        pub fn alloc(allocator: *mem.Allocator, list_len: NodeIndex) !*StructInitializerDot {
+            const bytes = try allocator.alignedAlloc(u8, @alignOf(StructInitializerDot), sizeInBytes(list_len));
+            return @ptrCast(*StructInitializerDot, bytes.ptr);
+        }
+
+        pub fn free(self: *StructInitializerDot, allocator: *mem.Allocator) void {
+            const bytes = @ptrCast([*]u8, self)[0..sizeInBytes(self.list_len)];
+            allocator.free(bytes);
+        }
 
         pub fn iterate(self: *const StructInitializerDot) Node.Iterator {
             return .{ .parent_node = &self.base, .index = 0, .node = null };
@@ -2174,8 +2264,8 @@ pub const Node = struct {
             var i = it.index;
             it.index += 1;
 
-            if (i < self.list.len) return self.list[i];
-            i -= self.list.len;
+            if (i < self.list_len) return self.listConst()[i];
+            i -= self.list_len;
 
             return null;
         }
@@ -2186,6 +2276,20 @@ pub const Node = struct {
 
         pub fn lastToken(self: *const StructInitializerDot) TokenIndex {
             return self.rtoken;
+        }
+
+        pub fn list(self: *StructInitializerDot) []*Node {
+            const decls_start = @ptrCast([*]u8, self) + @sizeOf(StructInitializerDot);
+            return @ptrCast([*]*Node, decls_start)[0..self.list_len];
+        }
+
+        pub fn listConst(self: *const StructInitializerDot) []const *Node {
+            const decls_start = @ptrCast([*]const u8, self) + @sizeOf(StructInitializerDot);
+            return @ptrCast([*]const *Node, decls_start)[0..self.list_len];
+        }
+
+        fn sizeInBytes(list_len: NodeIndex) usize {
+            return @sizeOf(StructInitializerDot) + @sizeOf(*Node) * @as(usize, list_len);
         }
     };
 

--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -18,6 +18,8 @@ pub const Tree = struct {
 
     arena: std.heap.ArenaAllocator.State,
     gpa: *mem.Allocator,
+    /// This keeps track of slices of memory that must be freed on deinit.
+    owned_memory: [][]u8,
 
     /// translate-c uses this to avoid having to emit correct newlines
     /// TODO get rid of this hack
@@ -26,6 +28,10 @@ pub const Tree = struct {
     pub fn deinit(self: *Tree) void {
         self.gpa.free(self.tokens);
         self.gpa.free(self.errors);
+        for (self.owned_memory) |list| {
+            self.gpa.free(list);
+        }
+        self.gpa.free(self.owned_memory);
         self.arena.promote(self.gpa).deinit();
     }
 

--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -1,7 +1,6 @@
 const std = @import("../std.zig");
 const assert = std.debug.assert;
 const testing = std.testing;
-const LinkedList = std.SinglyLinkedList;
 const mem = std.mem;
 const Token = std.zig.Token;
 
@@ -3013,9 +3012,10 @@ pub const Node = struct {
 
     pub const DocComment = struct {
         base: Node = Node{ .id = .DocComment },
-        lines: LineList,
-
-        pub const LineList = LinkedList(TokenIndex);
+        /// Points to the first doc comment token. API users are expected to iterate over the
+        /// tokens array, looking for more doc comments, ignoring line comments, and stopping
+        /// at the first other token.
+        first_line: TokenIndex,
 
         pub fn iterate(self: *const DocComment) Node.Iterator {
             return .{ .parent_node = &self.base, .index = 0 };
@@ -3026,14 +3026,13 @@ pub const Node = struct {
         }
 
         pub fn firstToken(self: *const DocComment) TokenIndex {
-            return self.lines.first.?.data;
+            return self.first_line;
         }
 
+        /// Returns the first doc comment line. Be careful, this may not be the desired behavior,
+        /// which would require the tokens array.
         pub fn lastToken(self: *const DocComment) TokenIndex {
-            var node = self.lines.first.?;
-            while (true) {
-                node = node.next orelse return node.data;
-            }
+            return self.first_line;
         }
     };
 

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -6,6 +6,7 @@ const Node = ast.Node;
 const Tree = ast.Tree;
 const AstError = ast.Error;
 const TokenIndex = ast.TokenIndex;
+const NodeIndex = ast.NodeIndex;
 const Token = std.zig.Token;
 
 pub const Error = error{ParseError} || Allocator.Error;
@@ -70,7 +71,8 @@ const Parser = struct {
         // invalid tokens as it can so this can only be the EOF
         const eof_token = p.eatToken(.Eof).?;
 
-        const node = try Node.Root.create(&p.arena.allocator, decls.len, eof_token);
+        const decls_len = @intCast(NodeIndex, decls.len);
+        const node = try Node.Root.create(&p.arena.allocator, decls_len, eof_token);
         std.mem.copy(*Node, node.decls(), decls);
 
         return node;
@@ -545,13 +547,15 @@ const Parser = struct {
         else
             R{ .Explicit = return_type_expr.? };
 
-        const fn_proto_node = try Node.FnProto.alloc(&p.arena.allocator, params.len);
+        const params_len = @intCast(NodeIndex, params.len);
+
+        const fn_proto_node = try Node.FnProto.alloc(&p.arena.allocator, params_len);
         fn_proto_node.* = .{
             .doc_comments = null,
             .visib_token = null,
             .fn_token = fn_token,
             .name_token = name_token,
-            .params_len = params.len,
+            .params_len = params_len,
             .return_type = return_type,
             .var_args_token = var_args_token,
             .extern_export_inline_token = null,
@@ -1195,11 +1199,13 @@ const Parser = struct {
 
         const rbrace = try p.expectToken(.RBrace);
 
-        const block_node = try Node.Block.alloc(&p.arena.allocator, statements.items.len);
+        const statements_len = @intCast(NodeIndex, statements.items.len);
+
+        const block_node = try Node.Block.alloc(&p.arena.allocator, statements_len);
         block_node.* = .{
             .label = null,
             .lbrace = lbrace,
-            .statements_len = statements.items.len,
+            .statements_len = statements_len,
             .rbrace = rbrace,
         };
         std.mem.copy(*Node, block_node.statements(), statements.items);
@@ -2844,12 +2850,13 @@ const Parser = struct {
         defer p.gpa.free(members);
         const rbrace = try p.expectToken(.RBrace);
 
-        const node = try Node.ContainerDecl.alloc(&p.arena.allocator, members.len);
+        const members_len = @intCast(NodeIndex, members.len);
+        const node = try Node.ContainerDecl.alloc(&p.arena.allocator, members_len);
         node.* = .{
             .layout_token = null,
             .kind_token = container_decl_type.kind_token,
             .init_arg_expr = container_decl_type.init_arg_expr,
-            .fields_and_decls_len = members.len,
+            .fields_and_decls_len = members_len,
             .lbrace_token = lbrace,
             .rbrace_token = rbrace,
         };

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -3296,11 +3296,9 @@ const Parser = struct {
             .index = p.tok_i,
             .ptr = &p.tokens[p.tok_i],
         };
-        if (p.tokens[p.tok_i].id == .Eof) {
-            return result;
-        }
         p.tok_i += 1;
         assert(result.ptr.id != .LineComment);
+        if (p.tok_i >= p.tokens.len) return result;
 
         while (true) {
             const next_tok = p.tokens[p.tok_i];

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -1318,12 +1318,13 @@ const Parser = struct {
                 const next = (try p.parseFieldInit()) orelse break;
                 try init_list.append(next);
             }
-            const node = try p.arena.allocator.create(Node.StructInitializer);
+            const node = try Node.StructInitializer.alloc(&p.arena.allocator, init_list.items.len);
             node.* = .{
                 .lhs = lhs,
                 .rtoken = try p.expectToken(.RBrace),
-                .list = try p.arena.allocator.dupe(*Node, init_list.items),
+                .list_len = init_list.items.len,
             };
+            std.mem.copy(*Node, node.list(), init_list.items);
             return &node.base;
         }
 
@@ -1333,12 +1334,13 @@ const Parser = struct {
                 const next = (try p.parseExpr()) orelse break;
                 try init_list.append(next);
             }
-            const node = try p.arena.allocator.create(Node.ArrayInitializer);
+            const node = try Node.ArrayInitializer.alloc(&p.arena.allocator, init_list.items.len);
             node.* = .{
                 .lhs = lhs,
                 .rtoken = try p.expectToken(.RBrace),
-                .list = try p.arena.allocator.dupe(*Node, init_list.items),
+                .list_len = init_list.items.len,
             };
+            std.mem.copy(*Node, node.list(), init_list.items);
             return &node.base;
         }
 
@@ -1346,7 +1348,7 @@ const Parser = struct {
         node.* = .{
             .lhs = lhs,
             .rtoken = try p.expectToken(.RBrace),
-            .list = &[0]*Node{},
+            .list_len = 0,
         };
         return &node.base;
     }
@@ -1366,12 +1368,13 @@ const Parser = struct {
                 const next = (try p.parseFieldInit()) orelse break;
                 try init_list.append(next);
             }
-            const node = try p.arena.allocator.create(Node.StructInitializerDot);
+            const node = try Node.StructInitializerDot.alloc(&p.arena.allocator, init_list.items.len);
             node.* = .{
                 .dot = dot,
                 .rtoken = try p.expectToken(.RBrace),
-                .list = try p.arena.allocator.dupe(*Node, init_list.items),
+                .list_len = init_list.items.len,
             };
+            std.mem.copy(*Node, node.list(), init_list.items);
             return &node.base;
         }
 
@@ -1381,12 +1384,13 @@ const Parser = struct {
                 const next = (try p.parseExpr()) orelse break;
                 try init_list.append(next);
             }
-            const node = try p.arena.allocator.create(Node.ArrayInitializerDot);
+            const node = try Node.ArrayInitializerDot.alloc(&p.arena.allocator, init_list.items.len);
             node.* = .{
                 .dot = dot,
                 .rtoken = try p.expectToken(.RBrace),
-                .list = try p.arena.allocator.dupe(*Node, init_list.items),
+                .list_len = init_list.items.len,
             };
+            std.mem.copy(*Node, node.list(), init_list.items);
             return &node.base;
         }
 
@@ -1394,7 +1398,7 @@ const Parser = struct {
         node.* = .{
             .dot = dot,
             .rtoken = try p.expectToken(.RBrace),
-            .list = &[0]*Node{},
+            .list_len = 0,
         };
         return &node.base;
     }

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -7,3303 +7,3349 @@ const Tree = ast.Tree;
 const AstError = ast.Error;
 const TokenIndex = ast.TokenIndex;
 const Token = std.zig.Token;
-const TokenIterator = Tree.TokenList.Iterator;
 
 pub const Error = error{ParseError} || Allocator.Error;
 
 /// Result should be freed with tree.deinit() when there are
 /// no more references to any of the tokens or nodes.
-pub fn parse(allocator: *Allocator, source: []const u8) Allocator.Error!*Tree {
-    const tree = blk: {
-        // This block looks unnecessary, but is a "foot-shield" to prevent the SegmentedLists
-        // from being initialized with a pointer to this `arena`, which is created on
-        // the stack. Following code should instead refer to `&tree.arena_allocator`, a
-        // pointer to data which lives safely on the heap and will outlive `parse`. See:
-        // https://github.com/ziglang/zig/commit/cb4fb14b6e66bd213575f69eec9598be8394fae6
-        var arena = std.heap.ArenaAllocator.init(allocator);
-        errdefer arena.deinit();
-        const tree = try arena.allocator.create(ast.Tree);
-        tree.* = .{
-            .source = source,
-            .root_node = undefined,
-            .arena_allocator = arena,
-            .tokens = undefined,
-            .errors = undefined,
-        };
-        break :blk tree;
-    };
-    errdefer tree.deinit();
-    const arena = &tree.arena_allocator.allocator;
-
-    tree.tokens = ast.Tree.TokenList.init(arena);
-    tree.errors = ast.Tree.ErrorList.init(arena);
+pub fn parse(gpa: *Allocator, source: []const u8) Allocator.Error!*Tree {
+    // TODO optimization idea: ensureCapacity on the tokens list and
+    // then appendAssumeCapacity inside the loop.
+    var tokens = std.ArrayList(Token).init(gpa);
+    defer tokens.deinit();
 
     var tokenizer = std.zig.Tokenizer.init(source);
     while (true) {
-        const tree_token = try tree.tokens.addOne();
+        const tree_token = try tokens.addOne();
         tree_token.* = tokenizer.next();
         if (tree_token.id == .Eof) break;
     }
-    var it = tree.tokens.iterator(0);
 
-    while (it.peek().?.id == .LineComment) _ = it.next();
+    var parser: Parser = .{
+        .source = source,
+        .arena = std.heap.ArenaAllocator.init(gpa),
+        .gpa = gpa,
+        .tokens = tokens.items,
+        .errors = .{},
+        .tok_i = 0,
+    };
+    defer parser.errors.deinit(gpa);
+    errdefer parser.arena.deinit();
 
-    tree.root_node = try parseRoot(arena, &it, tree);
+    while (tokens.items[parser.tok_i].id == .LineComment) parser.tok_i += 1;
 
+    const root_node = try parser.parseRoot();
+
+    const tree = try parser.arena.allocator.create(Tree);
+    tree.* = .{
+        .gpa = gpa,
+        .source = source,
+        .tokens = tokens.toOwnedSlice(),
+        .errors = parser.errors.toOwnedSlice(gpa),
+        .root_node = root_node,
+        .arena = parser.arena.state,
+    };
     return tree;
 }
 
-/// Root <- skip ContainerMembers eof
-fn parseRoot(arena: *Allocator, it: *TokenIterator, tree: *Tree) Allocator.Error!*Node.Root {
-    const node = try arena.create(Node.Root);
-    node.* = .{
-        .decls = try parseContainerMembers(arena, it, tree, true),
-        // parseContainerMembers will try to skip as much
-        // invalid tokens as it can so this can only be the EOF
-        .eof_token = eatToken(it, .Eof).?,
-    };
-    return node;
-}
+/// Represents in-progress parsing, will be converted to an ast.Tree after completion.
+const Parser = struct {
+    arena: std.heap.ArenaAllocator,
+    gpa: *Allocator,
+    source: []const u8,
+    tokens: []const Token,
+    tok_i: TokenIndex,
+    errors: std.ArrayListUnmanaged(AstError),
 
-/// ContainerMembers
-///     <- TestDecl ContainerMembers
-///      / TopLevelComptime ContainerMembers
-///      / KEYWORD_pub? TopLevelDecl ContainerMembers
-///      / ContainerField COMMA ContainerMembers
-///      / ContainerField
-///      /
-fn parseContainerMembers(arena: *Allocator, it: *TokenIterator, tree: *Tree, top_level: bool) !Node.Root.DeclList {
-    var list = Node.Root.DeclList.init(arena);
+    /// Root <- skip ContainerMembers eof
+    fn parseRoot(p: *Parser) Allocator.Error!*Node.Root {
+        const node = try p.arena.allocator.create(Node.Root);
+        node.* = .{
+            .decls = try parseContainerMembers(p, true),
+            // parseContainerMembers will try to skip as much
+            // invalid tokens as it can so this can only be the EOF
+            .eof_token = p.eatToken(.Eof).?,
+        };
+        return node;
+    }
 
-    var field_state: union(enum) {
-        /// no fields have been seen
-        none,
-        /// currently parsing fields
-        seen,
-        /// saw fields and then a declaration after them.
-        /// payload is first token of previous declaration.
-        end: TokenIndex,
-        /// ther was a declaration between fields, don't report more errors
-        err,
-    } = .none;
+    fn llpush(
+        p: *Parser,
+        comptime T: type,
+        it: *?*std.SinglyLinkedList(T).Node,
+        data: T,
+    ) !*?*std.SinglyLinkedList(T).Node {
+        const llnode = try p.arena.allocator.create(std.SinglyLinkedList(T).Node);
+        llnode.* = .{ .data = data };
+        it.* = llnode;
+        return &llnode.next;
+    }
 
-    while (true) {
-        if (try parseContainerDocComments(arena, it, tree)) |node| {
-            try list.push(node);
-            continue;
-        }
+    /// ContainerMembers
+    ///     <- TestDecl ContainerMembers
+    ///      / TopLevelComptime ContainerMembers
+    ///      / KEYWORD_pub? TopLevelDecl ContainerMembers
+    ///      / ContainerField COMMA ContainerMembers
+    ///      / ContainerField
+    ///      /
+    fn parseContainerMembers(p: *Parser, top_level: bool) !Node.Root.DeclList {
+        var list = Node.Root.DeclList{};
+        var list_it = &list.first;
 
-        const doc_comments = try parseDocComment(arena, it, tree);
+        var field_state: union(enum) {
+            /// no fields have been seen
+            none,
+            /// currently parsing fields
+            seen,
+            /// saw fields and then a declaration after them.
+            /// payload is first token of previous declaration.
+            end: TokenIndex,
+            /// ther was a declaration between fields, don't report more errors
+            err,
+        } = .none;
 
-        if (parseTestDecl(arena, it, tree) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.ParseError => {
-                findNextContainerMember(it);
+        while (true) {
+            if (try p.parseContainerDocComments()) |node| {
+                list_it = try p.llpush(*Node, list_it, node);
                 continue;
-            },
-        }) |node| {
-            if (field_state == .seen) {
-                field_state = .{ .end = node.firstToken() };
             }
-            node.cast(Node.TestDecl).?.doc_comments = doc_comments;
-            try list.push(node);
-            continue;
-        }
 
-        if (parseTopLevelComptime(arena, it, tree) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.ParseError => {
-                findNextContainerMember(it);
+            const doc_comments = try p.parseDocComment();
+
+            if (p.parseTestDecl() catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.ParseError => {
+                    p.findNextContainerMember();
+                    continue;
+                },
+            }) |node| {
+                if (field_state == .seen) {
+                    field_state = .{ .end = node.firstToken() };
+                }
+                node.cast(Node.TestDecl).?.doc_comments = doc_comments;
+                list_it = try p.llpush(*Node, list_it, node);
                 continue;
-            },
-        }) |node| {
-            if (field_state == .seen) {
-                field_state = .{ .end = node.firstToken() };
             }
-            node.cast(Node.Comptime).?.doc_comments = doc_comments;
-            try list.push(node);
-            continue;
-        }
 
-        const visib_token = eatToken(it, .Keyword_pub);
-
-        if (parseTopLevelDecl(arena, it, tree) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.ParseError => {
-                findNextContainerMember(it);
+            if (p.parseTopLevelComptime() catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.ParseError => {
+                    p.findNextContainerMember();
+                    continue;
+                },
+            }) |node| {
+                if (field_state == .seen) {
+                    field_state = .{ .end = node.firstToken() };
+                }
+                node.cast(Node.Comptime).?.doc_comments = doc_comments;
+                list_it = try p.llpush(*Node, list_it, node);
                 continue;
-            },
-        }) |node| {
-            if (field_state == .seen) {
-                field_state = .{ .end = visib_token orelse node.firstToken() };
             }
-            switch (node.id) {
-                .FnProto => {
-                    node.cast(Node.FnProto).?.doc_comments = doc_comments;
-                    node.cast(Node.FnProto).?.visib_token = visib_token;
+
+            const visib_token = p.eatToken(.Keyword_pub);
+
+            if (p.parseTopLevelDecl() catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.ParseError => {
+                    p.findNextContainerMember();
+                    continue;
                 },
-                .VarDecl => {
-                    node.cast(Node.VarDecl).?.doc_comments = doc_comments;
-                    node.cast(Node.VarDecl).?.visib_token = visib_token;
-                },
-                .Use => {
-                    node.cast(Node.Use).?.doc_comments = doc_comments;
-                    node.cast(Node.Use).?.visib_token = visib_token;
-                },
-                else => unreachable,
-            }
-            try list.push(node);
-            if (try parseAppendedDocComment(arena, it, tree, node.lastToken())) |appended_comment| {
+            }) |node| {
+                if (field_state == .seen) {
+                    field_state = .{ .end = visib_token orelse node.firstToken() };
+                }
                 switch (node.id) {
-                    .FnProto => {},
-                    .VarDecl => node.cast(Node.VarDecl).?.doc_comments = appended_comment,
-                    .Use => node.cast(Node.Use).?.doc_comments = appended_comment,
+                    .FnProto => {
+                        node.cast(Node.FnProto).?.doc_comments = doc_comments;
+                        node.cast(Node.FnProto).?.visib_token = visib_token;
+                    },
+                    .VarDecl => {
+                        node.cast(Node.VarDecl).?.doc_comments = doc_comments;
+                        node.cast(Node.VarDecl).?.visib_token = visib_token;
+                    },
+                    .Use => {
+                        node.cast(Node.Use).?.doc_comments = doc_comments;
+                        node.cast(Node.Use).?.visib_token = visib_token;
+                    },
                     else => unreachable,
                 }
-            }
-            continue;
-        }
-
-        if (visib_token != null) {
-            try tree.errors.push(.{
-                .ExpectedPubItem = .{ .token = it.index },
-            });
-            // ignore this pub
-            continue;
-        }
-
-        if (parseContainerField(arena, it, tree) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.ParseError => {
-                // attempt to recover
-                findNextContainerMember(it);
+                list_it = try p.llpush(*Node, list_it, node);
+                if (try p.parseAppendedDocComment(node.lastToken())) |appended_comment| {
+                    switch (node.id) {
+                        .FnProto => {},
+                        .VarDecl => node.cast(Node.VarDecl).?.doc_comments = appended_comment,
+                        .Use => node.cast(Node.Use).?.doc_comments = appended_comment,
+                        else => unreachable,
+                    }
+                }
                 continue;
-            },
-        }) |node| {
-            switch (field_state) {
-                .none => field_state = .seen,
-                .err, .seen => {},
-                .end => |tok| {
-                    try tree.errors.push(.{
-                        .DeclBetweenFields = .{ .token = tok },
-                    });
-                    // continue parsing, error will be reported later
-                    field_state = .err;
-                },
             }
 
-            const field = node.cast(Node.ContainerField).?;
-            field.doc_comments = doc_comments;
-            try list.push(node);
-            const comma = eatToken(it, .Comma) orelse {
-                // try to continue parsing
-                const index = it.index;
-                findNextContainerMember(it);
-                const next = it.peek().?.id;
-                switch (next) {
-                    .Eof => break,
-                    else => {
-                        if (next == .RBrace) {
-                            if (!top_level) break;
-                            _ = nextToken(it);
-                        }
+            if (visib_token != null) {
+                try p.errors.append(p.gpa, .{
+                    .ExpectedPubItem = .{ .token = p.tok_i },
+                });
+                // ignore this pub
+                continue;
+            }
 
-                        // add error and continue
-                        try tree.errors.push(.{
-                            .ExpectedToken = .{ .token = index, .expected_id = .Comma },
+            if (p.parseContainerField() catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.ParseError => {
+                    // attempt to recover
+                    p.findNextContainerMember();
+                    continue;
+                },
+            }) |node| {
+                switch (field_state) {
+                    .none => field_state = .seen,
+                    .err, .seen => {},
+                    .end => |tok| {
+                        try p.errors.append(p.gpa, .{
+                            .DeclBetweenFields = .{ .token = tok },
                         });
-                        continue;
+                        // continue parsing, error will be reported later
+                        field_state = .err;
                     },
                 }
-            };
-            if (try parseAppendedDocComment(arena, it, tree, comma)) |appended_comment|
-                field.doc_comments = appended_comment;
-            continue;
-        }
 
-        // Dangling doc comment
-        if (doc_comments != null) {
-            try tree.errors.push(.{
-                .UnattachedDocComment = .{ .token = doc_comments.?.firstToken() },
-            });
-        }
+                const field = node.cast(Node.ContainerField).?;
+                field.doc_comments = doc_comments;
+                list_it = try p.llpush(*Node, list_it, node);
+                const comma = p.eatToken(.Comma) orelse {
+                    // try to continue parsing
+                    const index = p.tok_i;
+                    p.findNextContainerMember();
+                    const next = p.tokens[p.tok_i].id;
+                    switch (next) {
+                        .Eof => break,
+                        else => {
+                            if (next == .RBrace) {
+                                if (!top_level) break;
+                                _ = p.nextToken();
+                            }
 
-        const next = it.peek().?.id;
-        switch (next) {
-            .Eof => break,
-            .Keyword_comptime => {
-                _ = nextToken(it);
-                try tree.errors.push(.{
-                    .ExpectedBlockOrField = .{ .token = it.index },
+                            // add error and continue
+                            try p.errors.append(p.gpa, .{
+                                .ExpectedToken = .{ .token = index, .expected_id = .Comma },
+                            });
+                            continue;
+                        },
+                    }
+                };
+                if (try p.parseAppendedDocComment(comma)) |appended_comment|
+                    field.doc_comments = appended_comment;
+                continue;
+            }
+
+            // Dangling doc comment
+            if (doc_comments != null) {
+                try p.errors.append(p.gpa, .{
+                    .UnattachedDocComment = .{ .token = doc_comments.?.firstToken() },
                 });
-            },
-            else => {
-                const index = it.index;
-                if (next == .RBrace) {
-                    if (!top_level) break;
-                    _ = nextToken(it);
-                }
+            }
 
-                // this was likely not supposed to end yet,
-                // try to find the next declaration
-                findNextContainerMember(it);
-                try tree.errors.push(.{
-                    .ExpectedContainerMembers = .{ .token = index },
+            const next = p.tokens[p.tok_i].id;
+            switch (next) {
+                .Eof => break,
+                .Keyword_comptime => {
+                    _ = p.nextToken();
+                    try p.errors.append(p.gpa, .{
+                        .ExpectedBlockOrField = .{ .token = p.tok_i },
+                    });
+                },
+                else => {
+                    const index = p.tok_i;
+                    if (next == .RBrace) {
+                        if (!top_level) break;
+                        _ = p.nextToken();
+                    }
+
+                    // this was likely not supposed to end yet,
+                    // try to find the next declaration
+                    p.findNextContainerMember();
+                    try p.errors.append(p.gpa, .{
+                        .ExpectedContainerMembers = .{ .token = index },
+                    });
+                },
+            }
+        }
+
+        return list;
+    }
+
+    /// Attempts to find next container member by searching for certain tokens
+    fn findNextContainerMember(p: *Parser) void {
+        var level: u32 = 0;
+        while (true) {
+            const tok = p.nextToken();
+            switch (tok.ptr.id) {
+                // any of these can start a new top level declaration
+                .Keyword_test,
+                .Keyword_comptime,
+                .Keyword_pub,
+                .Keyword_export,
+                .Keyword_extern,
+                .Keyword_inline,
+                .Keyword_noinline,
+                .Keyword_usingnamespace,
+                .Keyword_threadlocal,
+                .Keyword_const,
+                .Keyword_var,
+                .Keyword_fn,
+                .Identifier,
+                => {
+                    if (level == 0) {
+                        p.putBackToken(tok.index);
+                        return;
+                    }
+                },
+                .Comma, .Semicolon => {
+                    // this decl was likely meant to end here
+                    if (level == 0) {
+                        return;
+                    }
+                },
+                .LParen, .LBracket, .LBrace => level += 1,
+                .RParen, .RBracket => {
+                    if (level != 0) level -= 1;
+                },
+                .RBrace => {
+                    if (level == 0) {
+                        // end of container, exit
+                        p.putBackToken(tok.index);
+                        return;
+                    }
+                    level -= 1;
+                },
+                .Eof => {
+                    p.putBackToken(tok.index);
+                    return;
+                },
+                else => {},
+            }
+        }
+    }
+
+    /// Attempts to find the next statement by searching for a semicolon
+    fn findNextStmt(p: *Parser) void {
+        var level: u32 = 0;
+        while (true) {
+            const tok = p.nextToken();
+            switch (tok.ptr.id) {
+                .LBrace => level += 1,
+                .RBrace => {
+                    if (level == 0) {
+                        p.putBackToken(tok.index);
+                        return;
+                    }
+                    level -= 1;
+                },
+                .Semicolon => {
+                    if (level == 0) {
+                        return;
+                    }
+                },
+                .Eof => {
+                    p.putBackToken(tok.index);
+                    return;
+                },
+                else => {},
+            }
+        }
+    }
+
+    /// Eat a multiline container doc comment
+    fn parseContainerDocComments(p: *Parser) !?*Node {
+        var lines = Node.DocComment.LineList{};
+        var lines_it: *?*Node.DocComment.LineList.Node = &lines.first;
+
+        while (p.eatToken(.ContainerDocComment)) |line| {
+            lines_it = try p.llpush(TokenIndex, lines_it, line);
+        }
+
+        if (lines.first == null) return null;
+
+        const node = try p.arena.allocator.create(Node.DocComment);
+        node.* = .{
+            .lines = lines,
+        };
+        return &node.base;
+    }
+
+    /// TestDecl <- KEYWORD_test STRINGLITERALSINGLE Block
+    fn parseTestDecl(p: *Parser) !?*Node {
+        const test_token = p.eatToken(.Keyword_test) orelse return null;
+        const name_node = try p.expectNode(parseStringLiteralSingle, .{
+            .ExpectedStringLiteral = .{ .token = p.tok_i },
+        });
+        const block_node = try p.expectNode(parseBlock, .{
+            .ExpectedLBrace = .{ .token = p.tok_i },
+        });
+
+        const test_node = try p.arena.allocator.create(Node.TestDecl);
+        test_node.* = .{
+            .doc_comments = null,
+            .test_token = test_token,
+            .name = name_node,
+            .body_node = block_node,
+        };
+        return &test_node.base;
+    }
+
+    /// TopLevelComptime <- KEYWORD_comptime BlockExpr
+    fn parseTopLevelComptime(p: *Parser) !?*Node {
+        const tok = p.eatToken(.Keyword_comptime) orelse return null;
+        const lbrace = p.eatToken(.LBrace) orelse {
+            p.putBackToken(tok);
+            return null;
+        };
+        p.putBackToken(lbrace);
+        const block_node = try p.expectNode(parseBlockExpr, .{
+            .ExpectedLabelOrLBrace = .{ .token = p.tok_i },
+        });
+
+        const comptime_node = try p.arena.allocator.create(Node.Comptime);
+        comptime_node.* = .{
+            .doc_comments = null,
+            .comptime_token = tok,
+            .expr = block_node,
+        };
+        return &comptime_node.base;
+    }
+
+    /// TopLevelDecl
+    ///     <- (KEYWORD_export / KEYWORD_extern STRINGLITERALSINGLE? / (KEYWORD_inline / KEYWORD_noinline))? FnProto (SEMICOLON / Block)
+    ///      / (KEYWORD_export / KEYWORD_extern STRINGLITERALSINGLE?)? KEYWORD_threadlocal? VarDecl
+    ///      / KEYWORD_usingnamespace Expr SEMICOLON
+    fn parseTopLevelDecl(p: *Parser) !?*Node {
+        var lib_name: ?*Node = null;
+        const extern_export_inline_token = blk: {
+            if (p.eatToken(.Keyword_export)) |token| break :blk token;
+            if (p.eatToken(.Keyword_extern)) |token| {
+                lib_name = try p.parseStringLiteralSingle();
+                break :blk token;
+            }
+            if (p.eatToken(.Keyword_inline)) |token| break :blk token;
+            if (p.eatToken(.Keyword_noinline)) |token| break :blk token;
+            break :blk null;
+        };
+
+        if (try p.parseFnProto()) |node| {
+            const fn_node = node.cast(Node.FnProto).?;
+            fn_node.*.extern_export_inline_token = extern_export_inline_token;
+            fn_node.*.lib_name = lib_name;
+            if (p.eatToken(.Semicolon)) |_| return node;
+
+            if (try p.expectNodeRecoverable(parseBlock, .{
+                // since parseBlock only return error.ParseError on
+                // a missing '}' we can assume this function was
+                // supposed to end here.
+                .ExpectedSemiOrLBrace = .{ .token = p.tok_i },
+            })) |body_node| {
+                fn_node.body_node = body_node;
+            }
+            return node;
+        }
+
+        if (extern_export_inline_token) |token| {
+            if (p.tokens[token].id == .Keyword_inline or
+                p.tokens[token].id == .Keyword_noinline)
+            {
+                try p.errors.append(p.gpa, .{
+                    .ExpectedFn = .{ .token = p.tok_i },
                 });
-            },
+                return error.ParseError;
+            }
         }
-    }
 
-    return list;
-}
+        const thread_local_token = p.eatToken(.Keyword_threadlocal);
 
-/// Attempts to find next container member by searching for certain tokens
-fn findNextContainerMember(it: *TokenIterator) void {
-    var level: u32 = 0;
-    while (true) {
-        const tok = nextToken(it);
-        switch (tok.ptr.id) {
-            // any of these can start a new top level declaration
-            .Keyword_test,
-            .Keyword_comptime,
-            .Keyword_pub,
-            .Keyword_export,
-            .Keyword_extern,
-            .Keyword_inline,
-            .Keyword_noinline,
-            .Keyword_usingnamespace,
-            .Keyword_threadlocal,
-            .Keyword_const,
-            .Keyword_var,
-            .Keyword_fn,
-            .Identifier,
-            => {
-                if (level == 0) {
-                    putBackToken(it, tok.index);
-                    return;
-                }
-            },
-            .Comma, .Semicolon => {
-                // this decl was likely meant to end here
-                if (level == 0) {
-                    return;
-                }
-            },
-            .LParen, .LBracket, .LBrace => level += 1,
-            .RParen, .RBracket => {
-                if (level != 0) level -= 1;
-            },
-            .RBrace => {
-                if (level == 0) {
-                    // end of container, exit
-                    putBackToken(it, tok.index);
-                    return;
-                }
-                level -= 1;
-            },
-            .Eof => {
-                putBackToken(it, tok.index);
-                return;
-            },
-            else => {},
+        if (try p.parseVarDecl()) |node| {
+            var var_decl = node.cast(Node.VarDecl).?;
+            var_decl.*.thread_local_token = thread_local_token;
+            var_decl.*.comptime_token = null;
+            var_decl.*.extern_export_token = extern_export_inline_token;
+            var_decl.*.lib_name = lib_name;
+            return node;
         }
-    }
-}
 
-/// Attempts to find the next statement by searching for a semicolon
-fn findNextStmt(it: *TokenIterator) void {
-    var level: u32 = 0;
-    while (true) {
-        const tok = nextToken(it);
-        switch (tok.ptr.id) {
-            .LBrace => level += 1,
-            .RBrace => {
-                if (level == 0) {
-                    putBackToken(it, tok.index);
-                    return;
-                }
-                level -= 1;
-            },
-            .Semicolon => {
-                if (level == 0) {
-                    return;
-                }
-            },
-            .Eof => {
-                putBackToken(it, tok.index);
-                return;
-            },
-            else => {},
-        }
-    }
-}
-
-/// Eat a multiline container doc comment
-fn parseContainerDocComments(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    var lines = Node.DocComment.LineList.init(arena);
-    while (eatToken(it, .ContainerDocComment)) |line| {
-        try lines.push(line);
-    }
-
-    if (lines.len == 0) return null;
-
-    const node = try arena.create(Node.DocComment);
-    node.* = .{
-        .lines = lines,
-    };
-    return &node.base;
-}
-
-/// TestDecl <- KEYWORD_test STRINGLITERALSINGLE Block
-fn parseTestDecl(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const test_token = eatToken(it, .Keyword_test) orelse return null;
-    const name_node = try expectNode(arena, it, tree, parseStringLiteralSingle, .{
-        .ExpectedStringLiteral = .{ .token = it.index },
-    });
-    const block_node = try expectNode(arena, it, tree, parseBlock, .{
-        .ExpectedLBrace = .{ .token = it.index },
-    });
-
-    const test_node = try arena.create(Node.TestDecl);
-    test_node.* = .{
-        .doc_comments = null,
-        .test_token = test_token,
-        .name = name_node,
-        .body_node = block_node,
-    };
-    return &test_node.base;
-}
-
-/// TopLevelComptime <- KEYWORD_comptime BlockExpr
-fn parseTopLevelComptime(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const tok = eatToken(it, .Keyword_comptime) orelse return null;
-    const lbrace = eatToken(it, .LBrace) orelse {
-        putBackToken(it, tok);
-        return null;
-    };
-    putBackToken(it, lbrace);
-    const block_node = try expectNode(arena, it, tree, parseBlockExpr, .{
-        .ExpectedLabelOrLBrace = .{ .token = it.index },
-    });
-
-    const comptime_node = try arena.create(Node.Comptime);
-    comptime_node.* = .{
-        .doc_comments = null,
-        .comptime_token = tok,
-        .expr = block_node,
-    };
-    return &comptime_node.base;
-}
-
-/// TopLevelDecl
-///     <- (KEYWORD_export / KEYWORD_extern STRINGLITERALSINGLE? / (KEYWORD_inline / KEYWORD_noinline))? FnProto (SEMICOLON / Block)
-///      / (KEYWORD_export / KEYWORD_extern STRINGLITERALSINGLE?)? KEYWORD_threadlocal? VarDecl
-///      / KEYWORD_usingnamespace Expr SEMICOLON
-fn parseTopLevelDecl(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    var lib_name: ?*Node = null;
-    const extern_export_inline_token = blk: {
-        if (eatToken(it, .Keyword_export)) |token| break :blk token;
-        if (eatToken(it, .Keyword_extern)) |token| {
-            lib_name = try parseStringLiteralSingle(arena, it, tree);
-            break :blk token;
-        }
-        if (eatToken(it, .Keyword_inline)) |token| break :blk token;
-        if (eatToken(it, .Keyword_noinline)) |token| break :blk token;
-        break :blk null;
-    };
-
-    if (try parseFnProto(arena, it, tree)) |node| {
-        const fn_node = node.cast(Node.FnProto).?;
-        fn_node.*.extern_export_inline_token = extern_export_inline_token;
-        fn_node.*.lib_name = lib_name;
-        if (eatToken(it, .Semicolon)) |_| return node;
-
-        if (try expectNodeRecoverable(arena, it, tree, parseBlock, .{
-            // since parseBlock only return error.ParseError on
-            // a missing '}' we can assume this function was
-            // supposed to end here.
-            .ExpectedSemiOrLBrace = .{ .token = it.index },
-        })) |body_node| {
-            fn_node.body_node = body_node;
-        }
-        return node;
-    }
-
-    if (extern_export_inline_token) |token| {
-        if (tree.tokens.at(token).id == .Keyword_inline or
-            tree.tokens.at(token).id == .Keyword_noinline)
-        {
-            try tree.errors.push(.{
-                .ExpectedFn = .{ .token = it.index },
+        if (thread_local_token != null) {
+            try p.errors.append(p.gpa, .{
+                .ExpectedVarDecl = .{ .token = p.tok_i },
             });
+            // ignore this and try again;
             return error.ParseError;
         }
-    }
 
-    const thread_local_token = eatToken(it, .Keyword_threadlocal);
-
-    if (try parseVarDecl(arena, it, tree)) |node| {
-        var var_decl = node.cast(Node.VarDecl).?;
-        var_decl.*.thread_local_token = thread_local_token;
-        var_decl.*.comptime_token = null;
-        var_decl.*.extern_export_token = extern_export_inline_token;
-        var_decl.*.lib_name = lib_name;
-        return node;
-    }
-
-    if (thread_local_token != null) {
-        try tree.errors.push(.{
-            .ExpectedVarDecl = .{ .token = it.index },
-        });
-        // ignore this and try again;
-        return error.ParseError;
-    }
-
-    if (extern_export_inline_token) |token| {
-        try tree.errors.push(.{
-            .ExpectedVarDeclOrFn = .{ .token = it.index },
-        });
-        // ignore this and try again;
-        return error.ParseError;
-    }
-
-    return try parseUse(arena, it, tree);
-}
-
-/// FnProto <- KEYWORD_fn IDENTIFIER? LPAREN ParamDeclList RPAREN ByteAlign? LinkSection? EXCLAMATIONMARK? (KEYWORD_var / TypeExpr)
-fn parseFnProto(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    // TODO: Remove once extern/async fn rewriting is
-    var is_async = false;
-    var is_extern = false;
-    const cc_token: ?usize = blk: {
-        if (eatToken(it, .Keyword_extern)) |token| {
-            is_extern = true;
-            break :blk token;
-        }
-        if (eatToken(it, .Keyword_async)) |token| {
-            is_async = true;
-            break :blk token;
-        }
-        break :blk null;
-    };
-    const fn_token = eatToken(it, .Keyword_fn) orelse {
-        if (cc_token) |token|
-            putBackToken(it, token);
-        return null;
-    };
-    const name_token = eatToken(it, .Identifier);
-    const lparen = try expectToken(it, tree, .LParen);
-    const params = try parseParamDeclList(arena, it, tree);
-    const rparen = try expectToken(it, tree, .RParen);
-    const align_expr = try parseByteAlign(arena, it, tree);
-    const section_expr = try parseLinkSection(arena, it, tree);
-    const callconv_expr = try parseCallconv(arena, it, tree);
-    const exclamation_token = eatToken(it, .Bang);
-
-    const return_type_expr = (try parseVarType(arena, it, tree)) orelse
-        try expectNodeRecoverable(arena, it, tree, parseTypeExpr, .{
-        // most likely the user forgot to specify the return type.
-        // Mark return type as invalid and try to continue.
-        .ExpectedReturnType = .{ .token = it.index },
-    });
-
-    // TODO https://github.com/ziglang/zig/issues/3750
-    const R = Node.FnProto.ReturnType;
-    const return_type = if (return_type_expr == null)
-        R{ .Invalid = rparen }
-    else if (exclamation_token != null)
-        R{ .InferErrorSet = return_type_expr.? }
-    else
-        R{ .Explicit = return_type_expr.? };
-
-    const var_args_token = if (params.len > 0) blk: {
-        const param_type = params.at(params.len - 1).*.cast(Node.ParamDecl).?.param_type;
-        break :blk if (param_type == .var_args) param_type.var_args else null;
-    } else
-        null;
-
-    const fn_proto_node = try arena.create(Node.FnProto);
-    fn_proto_node.* = .{
-        .doc_comments = null,
-        .visib_token = null,
-        .fn_token = fn_token,
-        .name_token = name_token,
-        .params = params,
-        .return_type = return_type,
-        .var_args_token = var_args_token,
-        .extern_export_inline_token = null,
-        .body_node = null,
-        .lib_name = null,
-        .align_expr = align_expr,
-        .section_expr = section_expr,
-        .callconv_expr = callconv_expr,
-        .is_extern_prototype = is_extern,
-        .is_async = is_async,
-    };
-
-    return &fn_proto_node.base;
-}
-
-/// VarDecl <- (KEYWORD_const / KEYWORD_var) IDENTIFIER (COLON TypeExpr)? ByteAlign? LinkSection? (EQUAL Expr)? SEMICOLON
-fn parseVarDecl(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const mut_token = eatToken(it, .Keyword_const) orelse
-        eatToken(it, .Keyword_var) orelse
-        return null;
-
-    const name_token = try expectToken(it, tree, .Identifier);
-    const type_node = if (eatToken(it, .Colon) != null)
-        try expectNode(arena, it, tree, parseTypeExpr, .{
-            .ExpectedTypeExpr = .{ .token = it.index },
-        })
-    else
-        null;
-    const align_node = try parseByteAlign(arena, it, tree);
-    const section_node = try parseLinkSection(arena, it, tree);
-    const eq_token = eatToken(it, .Equal);
-    const init_node = if (eq_token != null) blk: {
-        break :blk try expectNode(arena, it, tree, parseExpr, .{
-            .ExpectedExpr = .{ .token = it.index },
-        });
-    } else null;
-    const semicolon_token = try expectToken(it, tree, .Semicolon);
-
-    const node = try arena.create(Node.VarDecl);
-    node.* = .{
-        .doc_comments = null,
-        .visib_token = null,
-        .thread_local_token = null,
-        .name_token = name_token,
-        .eq_token = eq_token,
-        .mut_token = mut_token,
-        .comptime_token = null,
-        .extern_export_token = null,
-        .lib_name = null,
-        .type_node = type_node,
-        .align_node = align_node,
-        .section_node = section_node,
-        .init_node = init_node,
-        .semicolon_token = semicolon_token,
-    };
-    return &node.base;
-}
-
-/// ContainerField <- KEYWORD_comptime? IDENTIFIER (COLON TypeExpr ByteAlign?)? (EQUAL Expr)?
-fn parseContainerField(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const comptime_token = eatToken(it, .Keyword_comptime);
-    const name_token = eatToken(it, .Identifier) orelse {
-        if (comptime_token) |t| putBackToken(it, t);
-        return null;
-    };
-
-    var align_expr: ?*Node = null;
-    var type_expr: ?*Node = null;
-    if (eatToken(it, .Colon)) |_| {
-        if (eatToken(it, .Keyword_var)) |var_tok| {
-            const node = try arena.create(ast.Node.VarType);
-            node.* = .{ .token = var_tok };
-            type_expr = &node.base;
-        } else {
-            type_expr = try expectNode(arena, it, tree, parseTypeExpr, .{
-                .ExpectedTypeExpr = .{ .token = it.index },
+        if (extern_export_inline_token) |token| {
+            try p.errors.append(p.gpa, .{
+                .ExpectedVarDeclOrFn = .{ .token = p.tok_i },
             });
-            align_expr = try parseByteAlign(arena, it, tree);
+            // ignore this and try again;
+            return error.ParseError;
         }
+
+        return p.parseUse();
     }
 
-    const value_expr = if (eatToken(it, .Equal)) |_|
-        try expectNode(arena, it, tree, parseExpr, .{
-            .ExpectedExpr = .{ .token = it.index },
-        })
-    else
-        null;
+    /// FnProto <- KEYWORD_fn IDENTIFIER? LPAREN ParamDeclList RPAREN ByteAlign? LinkSection? EXCLAMATIONMARK? (KEYWORD_var / TypeExpr)
+    fn parseFnProto(p: *Parser) !?*Node {
+        // TODO: Remove once extern/async fn rewriting is
+        var is_async = false;
+        var is_extern = false;
+        const cc_token: ?TokenIndex = blk: {
+            if (p.eatToken(.Keyword_extern)) |token| {
+                is_extern = true;
+                break :blk token;
+            }
+            if (p.eatToken(.Keyword_async)) |token| {
+                is_async = true;
+                break :blk token;
+            }
+            break :blk null;
+        };
+        const fn_token = p.eatToken(.Keyword_fn) orelse {
+            if (cc_token) |token|
+                p.putBackToken(token);
+            return null;
+        };
+        var var_args_token: ?TokenIndex = null;
+        const name_token = p.eatToken(.Identifier);
+        const lparen = try p.expectToken(.LParen);
+        const params = try p.parseParamDeclList(&var_args_token);
+        const rparen = try p.expectToken(.RParen);
+        const align_expr = try p.parseByteAlign();
+        const section_expr = try p.parseLinkSection();
+        const callconv_expr = try p.parseCallconv();
+        const exclamation_token = p.eatToken(.Bang);
 
-    const node = try arena.create(Node.ContainerField);
-    node.* = .{
-        .doc_comments = null,
-        .comptime_token = comptime_token,
-        .name_token = name_token,
-        .type_expr = type_expr,
-        .value_expr = value_expr,
-        .align_expr = align_expr,
-    };
-    return &node.base;
-}
-
-/// Statement
-///     <- KEYWORD_comptime? VarDecl
-///      / KEYWORD_comptime BlockExprStatement
-///      / KEYWORD_nosuspend BlockExprStatement
-///      / KEYWORD_suspend (SEMICOLON / BlockExprStatement)
-///      / KEYWORD_defer BlockExprStatement
-///      / KEYWORD_errdefer Payload? BlockExprStatement
-///      / IfStatement
-///      / LabeledStatement
-///      / SwitchExpr
-///      / AssignExpr SEMICOLON
-fn parseStatement(arena: *Allocator, it: *TokenIterator, tree: *Tree) Error!?*Node {
-    const comptime_token = eatToken(it, .Keyword_comptime);
-
-    const var_decl_node = try parseVarDecl(arena, it, tree);
-    if (var_decl_node) |node| {
-        const var_decl = node.cast(Node.VarDecl).?;
-        var_decl.comptime_token = comptime_token;
-        return node;
-    }
-
-    if (comptime_token) |token| {
-        const block_expr = try expectNode(arena, it, tree, parseBlockExprStatement, .{
-            .ExpectedBlockOrAssignment = .{ .token = it.index },
+        const return_type_expr = (try p.parseVarType()) orelse
+            try p.expectNodeRecoverable(parseTypeExpr, .{
+            // most likely the user forgot to specify the return type.
+            // Mark return type as invalid and try to continue.
+            .ExpectedReturnType = .{ .token = p.tok_i },
         });
 
-        const node = try arena.create(Node.Comptime);
-        node.* = .{
+        // TODO https://github.com/ziglang/zig/issues/3750
+        const R = Node.FnProto.ReturnType;
+        const return_type = if (return_type_expr == null)
+            R{ .Invalid = rparen }
+        else if (exclamation_token != null)
+            R{ .InferErrorSet = return_type_expr.? }
+        else
+            R{ .Explicit = return_type_expr.? };
+
+        const fn_proto_node = try p.arena.allocator.create(Node.FnProto);
+        fn_proto_node.* = .{
             .doc_comments = null,
-            .comptime_token = token,
-            .expr = block_expr,
+            .visib_token = null,
+            .fn_token = fn_token,
+            .name_token = name_token,
+            .params = params,
+            .return_type = return_type,
+            .var_args_token = var_args_token,
+            .extern_export_inline_token = null,
+            .body_node = null,
+            .lib_name = null,
+            .align_expr = align_expr,
+            .section_expr = section_expr,
+            .callconv_expr = callconv_expr,
+            .is_extern_prototype = is_extern,
+            .is_async = is_async,
         };
-        return &node.base;
+
+        return &fn_proto_node.base;
     }
 
-    if (eatToken(it, .Keyword_nosuspend)) |nosuspend_token| {
-        const block_expr = try expectNode(arena, it, tree, parseBlockExprStatement, .{
-            .ExpectedBlockOrAssignment = .{ .token = it.index },
-        });
+    /// VarDecl <- (KEYWORD_const / KEYWORD_var) IDENTIFIER (COLON TypeExpr)? ByteAlign? LinkSection? (EQUAL Expr)? SEMICOLON
+    fn parseVarDecl(p: *Parser) !?*Node {
+        const mut_token = p.eatToken(.Keyword_const) orelse
+            p.eatToken(.Keyword_var) orelse
+            return null;
 
-        const node = try arena.create(Node.Nosuspend);
-        node.* = .{
-            .nosuspend_token = nosuspend_token,
-            .expr = block_expr,
-        };
-        return &node.base;
-    }
-
-    if (eatToken(it, .Keyword_suspend)) |suspend_token| {
-        const semicolon = eatToken(it, .Semicolon);
-
-        const body_node = if (semicolon == null) blk: {
-            break :blk try expectNode(arena, it, tree, parseBlockExprStatement, .{
-                .ExpectedBlockOrExpression = .{ .token = it.index },
-            });
-        } else null;
-
-        const node = try arena.create(Node.Suspend);
-        node.* = .{
-            .suspend_token = suspend_token,
-            .body = body_node,
-        };
-        return &node.base;
-    }
-
-    const defer_token = eatToken(it, .Keyword_defer) orelse eatToken(it, .Keyword_errdefer);
-    if (defer_token) |token| {
-        const payload = if (tree.tokens.at(token).id == .Keyword_errdefer)
-            try parsePayload(arena, it, tree)
+        const name_token = try p.expectToken(.Identifier);
+        const type_node = if (p.eatToken(.Colon) != null)
+            try p.expectNode(parseTypeExpr, .{
+                .ExpectedTypeExpr = .{ .token = p.tok_i },
+            })
         else
             null;
-        const expr_node = try expectNode(arena, it, tree, parseBlockExprStatement, .{
-            .ExpectedBlockOrExpression = .{ .token = it.index },
-        });
-        const node = try arena.create(Node.Defer);
+        const align_node = try p.parseByteAlign();
+        const section_node = try p.parseLinkSection();
+        const eq_token = p.eatToken(.Equal);
+        const init_node = if (eq_token != null) blk: {
+            break :blk try p.expectNode(parseExpr, .{
+                .ExpectedExpr = .{ .token = p.tok_i },
+            });
+        } else null;
+        const semicolon_token = try p.expectToken(.Semicolon);
+
+        const node = try p.arena.allocator.create(Node.VarDecl);
         node.* = .{
-            .defer_token = token,
-            .expr = expr_node,
-            .payload = payload,
+            .doc_comments = null,
+            .visib_token = null,
+            .thread_local_token = null,
+            .name_token = name_token,
+            .eq_token = eq_token,
+            .mut_token = mut_token,
+            .comptime_token = null,
+            .extern_export_token = null,
+            .lib_name = null,
+            .type_node = type_node,
+            .align_node = align_node,
+            .section_node = section_node,
+            .init_node = init_node,
+            .semicolon_token = semicolon_token,
         };
         return &node.base;
     }
 
-    if (try parseIfStatement(arena, it, tree)) |node| return node;
-    if (try parseLabeledStatement(arena, it, tree)) |node| return node;
-    if (try parseSwitchExpr(arena, it, tree)) |node| return node;
-    if (try parseAssignExpr(arena, it, tree)) |node| {
-        _ = try expectTokenRecoverable(it, tree, .Semicolon);
-        return node;
-    }
-
-    return null;
-}
-
-/// IfStatement
-///     <- IfPrefix BlockExpr ( KEYWORD_else Payload? Statement )?
-///      / IfPrefix AssignExpr ( SEMICOLON / KEYWORD_else Payload? Statement )
-fn parseIfStatement(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const if_node = (try parseIfPrefix(arena, it, tree)) orelse return null;
-    const if_prefix = if_node.cast(Node.If).?;
-
-    const block_expr = (try parseBlockExpr(arena, it, tree));
-    const assign_expr = if (block_expr == null)
-        try expectNode(arena, it, tree, parseAssignExpr, .{
-            .ExpectedBlockOrAssignment = .{ .token = it.index },
-        })
-    else
-        null;
-
-    const semicolon = if (assign_expr != null) eatToken(it, .Semicolon) else null;
-
-    const else_node = if (semicolon == null) blk: {
-        const else_token = eatToken(it, .Keyword_else) orelse break :blk null;
-        const payload = try parsePayload(arena, it, tree);
-        const else_body = try expectNode(arena, it, tree, parseStatement, .{
-            .InvalidToken = .{ .token = it.index },
-        });
-
-        const node = try arena.create(Node.Else);
-        node.* = .{
-            .else_token = else_token,
-            .payload = payload,
-            .body = else_body,
+    /// ContainerField <- KEYWORD_comptime? IDENTIFIER (COLON TypeExpr ByteAlign?)? (EQUAL Expr)?
+    fn parseContainerField(p: *Parser) !?*Node {
+        const comptime_token = p.eatToken(.Keyword_comptime);
+        const name_token = p.eatToken(.Identifier) orelse {
+            if (comptime_token) |t| p.putBackToken(t);
+            return null;
         };
 
-        break :blk node;
-    } else null;
+        var align_expr: ?*Node = null;
+        var type_expr: ?*Node = null;
+        if (p.eatToken(.Colon)) |_| {
+            if (p.eatToken(.Keyword_var)) |var_tok| {
+                const node = try p.arena.allocator.create(ast.Node.VarType);
+                node.* = .{ .token = var_tok };
+                type_expr = &node.base;
+            } else {
+                type_expr = try p.expectNode(parseTypeExpr, .{
+                    .ExpectedTypeExpr = .{ .token = p.tok_i },
+                });
+                align_expr = try p.parseByteAlign();
+            }
+        }
 
-    if (block_expr) |body| {
-        if_prefix.body = body;
-        if_prefix.@"else" = else_node;
-        return if_node;
+        const value_expr = if (p.eatToken(.Equal)) |_|
+            try p.expectNode(parseExpr, .{
+                .ExpectedExpr = .{ .token = p.tok_i },
+            })
+        else
+            null;
+
+        const node = try p.arena.allocator.create(Node.ContainerField);
+        node.* = .{
+            .doc_comments = null,
+            .comptime_token = comptime_token,
+            .name_token = name_token,
+            .type_expr = type_expr,
+            .value_expr = value_expr,
+            .align_expr = align_expr,
+        };
+        return &node.base;
     }
 
-    if (assign_expr) |body| {
-        if_prefix.body = body;
-        if (semicolon != null) return if_node;
-        if (else_node != null) {
+    /// Statement
+    ///     <- KEYWORD_comptime? VarDecl
+    ///      / KEYWORD_comptime BlockExprStatement
+    ///      / KEYWORD_nosuspend BlockExprStatement
+    ///      / KEYWORD_suspend (SEMICOLON / BlockExprStatement)
+    ///      / KEYWORD_defer BlockExprStatement
+    ///      / KEYWORD_errdefer Payload? BlockExprStatement
+    ///      / IfStatement
+    ///      / LabeledStatement
+    ///      / SwitchExpr
+    ///      / AssignExpr SEMICOLON
+    fn parseStatement(p: *Parser) Error!?*Node {
+        const comptime_token = p.eatToken(.Keyword_comptime);
+
+        const var_decl_node = try p.parseVarDecl();
+        if (var_decl_node) |node| {
+            const var_decl = node.cast(Node.VarDecl).?;
+            var_decl.comptime_token = comptime_token;
+            return node;
+        }
+
+        if (comptime_token) |token| {
+            const block_expr = try p.expectNode(parseBlockExprStatement, .{
+                .ExpectedBlockOrAssignment = .{ .token = p.tok_i },
+            });
+
+            const node = try p.arena.allocator.create(Node.Comptime);
+            node.* = .{
+                .doc_comments = null,
+                .comptime_token = token,
+                .expr = block_expr,
+            };
+            return &node.base;
+        }
+
+        if (p.eatToken(.Keyword_nosuspend)) |nosuspend_token| {
+            const block_expr = try p.expectNode(parseBlockExprStatement, .{
+                .ExpectedBlockOrAssignment = .{ .token = p.tok_i },
+            });
+
+            const node = try p.arena.allocator.create(Node.Nosuspend);
+            node.* = .{
+                .nosuspend_token = nosuspend_token,
+                .expr = block_expr,
+            };
+            return &node.base;
+        }
+
+        if (p.eatToken(.Keyword_suspend)) |suspend_token| {
+            const semicolon = p.eatToken(.Semicolon);
+
+            const body_node = if (semicolon == null) blk: {
+                break :blk try p.expectNode(parseBlockExprStatement, .{
+                    .ExpectedBlockOrExpression = .{ .token = p.tok_i },
+                });
+            } else null;
+
+            const node = try p.arena.allocator.create(Node.Suspend);
+            node.* = .{
+                .suspend_token = suspend_token,
+                .body = body_node,
+            };
+            return &node.base;
+        }
+
+        const defer_token = p.eatToken(.Keyword_defer) orelse p.eatToken(.Keyword_errdefer);
+        if (defer_token) |token| {
+            const payload = if (p.tokens[token].id == .Keyword_errdefer)
+                try p.parsePayload()
+            else
+                null;
+            const expr_node = try p.expectNode(parseBlockExprStatement, .{
+                .ExpectedBlockOrExpression = .{ .token = p.tok_i },
+            });
+            const node = try p.arena.allocator.create(Node.Defer);
+            node.* = .{
+                .defer_token = token,
+                .expr = expr_node,
+                .payload = payload,
+            };
+            return &node.base;
+        }
+
+        if (try p.parseIfStatement()) |node| return node;
+        if (try p.parseLabeledStatement()) |node| return node;
+        if (try p.parseSwitchExpr()) |node| return node;
+        if (try p.parseAssignExpr()) |node| {
+            _ = try p.expectTokenRecoverable(.Semicolon);
+            return node;
+        }
+
+        return null;
+    }
+
+    /// IfStatement
+    ///     <- IfPrefix BlockExpr ( KEYWORD_else Payload? Statement )?
+    ///      / IfPrefix AssignExpr ( SEMICOLON / KEYWORD_else Payload? Statement )
+    fn parseIfStatement(p: *Parser) !?*Node {
+        const if_node = (try p.parseIfPrefix()) orelse return null;
+        const if_prefix = if_node.cast(Node.If).?;
+
+        const block_expr = (try p.parseBlockExpr());
+        const assign_expr = if (block_expr == null)
+            try p.expectNode(parseAssignExpr, .{
+                .ExpectedBlockOrAssignment = .{ .token = p.tok_i },
+            })
+        else
+            null;
+
+        const semicolon = if (assign_expr != null) p.eatToken(.Semicolon) else null;
+
+        const else_node = if (semicolon == null) blk: {
+            const else_token = p.eatToken(.Keyword_else) orelse break :blk null;
+            const payload = try p.parsePayload();
+            const else_body = try p.expectNode(parseStatement, .{
+                .InvalidToken = .{ .token = p.tok_i },
+            });
+
+            const node = try p.arena.allocator.create(Node.Else);
+            node.* = .{
+                .else_token = else_token,
+                .payload = payload,
+                .body = else_body,
+            };
+
+            break :blk node;
+        } else null;
+
+        if (block_expr) |body| {
+            if_prefix.body = body;
             if_prefix.@"else" = else_node;
             return if_node;
         }
-        try tree.errors.push(.{
-            .ExpectedSemiOrElse = .{ .token = it.index },
-        });
+
+        if (assign_expr) |body| {
+            if_prefix.body = body;
+            if (semicolon != null) return if_node;
+            if (else_node != null) {
+                if_prefix.@"else" = else_node;
+                return if_node;
+            }
+            try p.errors.append(p.gpa, .{
+                .ExpectedSemiOrElse = .{ .token = p.tok_i },
+            });
+        }
+
+        return if_node;
     }
 
-    return if_node;
-}
+    /// LabeledStatement <- BlockLabel? (Block / LoopStatement)
+    fn parseLabeledStatement(p: *Parser) !?*Node {
+        var colon: TokenIndex = undefined;
+        const label_token = p.parseBlockLabel(&colon);
 
-/// LabeledStatement <- BlockLabel? (Block / LoopStatement)
-fn parseLabeledStatement(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    var colon: TokenIndex = undefined;
-    const label_token = parseBlockLabel(arena, it, tree, &colon);
+        if (try p.parseBlock()) |node| {
+            node.cast(Node.Block).?.label = label_token;
+            return node;
+        }
 
-    if (try parseBlock(arena, it, tree)) |node| {
-        node.cast(Node.Block).?.label = label_token;
-        return node;
+        if (try p.parseLoopStatement()) |node| {
+            if (node.cast(Node.For)) |for_node| {
+                for_node.label = label_token;
+            } else if (node.cast(Node.While)) |while_node| {
+                while_node.label = label_token;
+            } else unreachable;
+            return node;
+        }
+
+        if (label_token != null) {
+            try p.errors.append(p.gpa, .{
+                .ExpectedLabelable = .{ .token = p.tok_i },
+            });
+            return error.ParseError;
+        }
+
+        return null;
     }
 
-    if (try parseLoopStatement(arena, it, tree)) |node| {
-        if (node.cast(Node.For)) |for_node| {
-            for_node.label = label_token;
-        } else if (node.cast(Node.While)) |while_node| {
-            while_node.label = label_token;
-        } else unreachable;
-        return node;
-    }
+    /// LoopStatement <- KEYWORD_inline? (ForStatement / WhileStatement)
+    fn parseLoopStatement(p: *Parser) !?*Node {
+        const inline_token = p.eatToken(.Keyword_inline);
 
-    if (label_token != null) {
-        try tree.errors.push(.{
-            .ExpectedLabelable = .{ .token = it.index },
+        if (try p.parseForStatement()) |node| {
+            node.cast(Node.For).?.inline_token = inline_token;
+            return node;
+        }
+
+        if (try p.parseWhileStatement()) |node| {
+            node.cast(Node.While).?.inline_token = inline_token;
+            return node;
+        }
+        if (inline_token == null) return null;
+
+        // If we've seen "inline", there should have been a "for" or "while"
+        try p.errors.append(p.gpa, .{
+            .ExpectedInlinable = .{ .token = p.tok_i },
         });
         return error.ParseError;
     }
 
-    return null;
-}
+    /// ForStatement
+    ///     <- ForPrefix BlockExpr ( KEYWORD_else Statement )?
+    ///      / ForPrefix AssignExpr ( SEMICOLON / KEYWORD_else Statement )
+    fn parseForStatement(p: *Parser) !?*Node {
+        const node = (try p.parseForPrefix()) orelse return null;
+        const for_prefix = node.cast(Node.For).?;
 
-/// LoopStatement <- KEYWORD_inline? (ForStatement / WhileStatement)
-fn parseLoopStatement(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const inline_token = eatToken(it, .Keyword_inline);
+        if (try p.parseBlockExpr()) |block_expr_node| {
+            for_prefix.body = block_expr_node;
 
-    if (try parseForStatement(arena, it, tree)) |node| {
-        node.cast(Node.For).?.inline_token = inline_token;
-        return node;
-    }
+            if (p.eatToken(.Keyword_else)) |else_token| {
+                const statement_node = try p.expectNode(parseStatement, .{
+                    .InvalidToken = .{ .token = p.tok_i },
+                });
 
-    if (try parseWhileStatement(arena, it, tree)) |node| {
-        node.cast(Node.While).?.inline_token = inline_token;
-        return node;
-    }
-    if (inline_token == null) return null;
+                const else_node = try p.arena.allocator.create(Node.Else);
+                else_node.* = .{
+                    .else_token = else_token,
+                    .payload = null,
+                    .body = statement_node,
+                };
+                for_prefix.@"else" = else_node;
 
-    // If we've seen "inline", there should have been a "for" or "while"
-    try tree.errors.push(.{
-        .ExpectedInlinable = .{ .token = it.index },
-    });
-    return error.ParseError;
-}
-
-/// ForStatement
-///     <- ForPrefix BlockExpr ( KEYWORD_else Statement )?
-///      / ForPrefix AssignExpr ( SEMICOLON / KEYWORD_else Statement )
-fn parseForStatement(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const node = (try parseForPrefix(arena, it, tree)) orelse return null;
-    const for_prefix = node.cast(Node.For).?;
-
-    if (try parseBlockExpr(arena, it, tree)) |block_expr_node| {
-        for_prefix.body = block_expr_node;
-
-        if (eatToken(it, .Keyword_else)) |else_token| {
-            const statement_node = try expectNode(arena, it, tree, parseStatement, .{
-                .InvalidToken = .{ .token = it.index },
-            });
-
-            const else_node = try arena.create(Node.Else);
-            else_node.* = .{
-                .else_token = else_token,
-                .payload = null,
-                .body = statement_node,
-            };
-            for_prefix.@"else" = else_node;
+                return node;
+            }
 
             return node;
         }
 
-        return node;
-    }
+        if (try p.parseAssignExpr()) |assign_expr| {
+            for_prefix.body = assign_expr;
 
-    if (try parseAssignExpr(arena, it, tree)) |assign_expr| {
-        for_prefix.body = assign_expr;
+            if (p.eatToken(.Semicolon) != null) return node;
 
-        if (eatToken(it, .Semicolon) != null) return node;
+            if (p.eatToken(.Keyword_else)) |else_token| {
+                const statement_node = try p.expectNode(parseStatement, .{
+                    .ExpectedStatement = .{ .token = p.tok_i },
+                });
 
-        if (eatToken(it, .Keyword_else)) |else_token| {
-            const statement_node = try expectNode(arena, it, tree, parseStatement, .{
-                .ExpectedStatement = .{ .token = it.index },
+                const else_node = try p.arena.allocator.create(Node.Else);
+                else_node.* = .{
+                    .else_token = else_token,
+                    .payload = null,
+                    .body = statement_node,
+                };
+                for_prefix.@"else" = else_node;
+                return node;
+            }
+
+            try p.errors.append(p.gpa, .{
+                .ExpectedSemiOrElse = .{ .token = p.tok_i },
             });
-
-            const else_node = try arena.create(Node.Else);
-            else_node.* = .{
-                .else_token = else_token,
-                .payload = null,
-                .body = statement_node,
-            };
-            for_prefix.@"else" = else_node;
-            return node;
-        }
-
-        try tree.errors.push(.{
-            .ExpectedSemiOrElse = .{ .token = it.index },
-        });
-
-        return node;
-    }
-
-    return null;
-}
-
-/// WhileStatement
-///     <- WhilePrefix BlockExpr ( KEYWORD_else Payload? Statement )?
-///      / WhilePrefix AssignExpr ( SEMICOLON / KEYWORD_else Payload? Statement )
-fn parseWhileStatement(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const node = (try parseWhilePrefix(arena, it, tree)) orelse return null;
-    const while_prefix = node.cast(Node.While).?;
-
-    if (try parseBlockExpr(arena, it, tree)) |block_expr_node| {
-        while_prefix.body = block_expr_node;
-
-        if (eatToken(it, .Keyword_else)) |else_token| {
-            const payload = try parsePayload(arena, it, tree);
-
-            const statement_node = try expectNode(arena, it, tree, parseStatement, .{
-                .InvalidToken = .{ .token = it.index },
-            });
-
-            const else_node = try arena.create(Node.Else);
-            else_node.* = .{
-                .else_token = else_token,
-                .payload = payload,
-                .body = statement_node,
-            };
-            while_prefix.@"else" = else_node;
 
             return node;
         }
 
-        return node;
+        return null;
     }
 
-    if (try parseAssignExpr(arena, it, tree)) |assign_expr_node| {
-        while_prefix.body = assign_expr_node;
+    /// WhileStatement
+    ///     <- WhilePrefix BlockExpr ( KEYWORD_else Payload? Statement )?
+    ///      / WhilePrefix AssignExpr ( SEMICOLON / KEYWORD_else Payload? Statement )
+    fn parseWhileStatement(p: *Parser) !?*Node {
+        const node = (try p.parseWhilePrefix()) orelse return null;
+        const while_prefix = node.cast(Node.While).?;
 
-        if (eatToken(it, .Semicolon) != null) return node;
+        if (try p.parseBlockExpr()) |block_expr_node| {
+            while_prefix.body = block_expr_node;
 
-        if (eatToken(it, .Keyword_else)) |else_token| {
-            const payload = try parsePayload(arena, it, tree);
+            if (p.eatToken(.Keyword_else)) |else_token| {
+                const payload = try p.parsePayload();
 
-            const statement_node = try expectNode(arena, it, tree, parseStatement, .{
-                .ExpectedStatement = .{ .token = it.index },
-            });
+                const statement_node = try p.expectNode(parseStatement, .{
+                    .InvalidToken = .{ .token = p.tok_i },
+                });
 
-            const else_node = try arena.create(Node.Else);
-            else_node.* = .{
-                .else_token = else_token,
-                .payload = payload,
-                .body = statement_node,
-            };
-            while_prefix.@"else" = else_node;
+                const else_node = try p.arena.allocator.create(Node.Else);
+                else_node.* = .{
+                    .else_token = else_token,
+                    .payload = payload,
+                    .body = statement_node,
+                };
+                while_prefix.@"else" = else_node;
+
+                return node;
+            }
+
             return node;
         }
 
-        try tree.errors.push(.{
-            .ExpectedSemiOrElse = .{ .token = it.index },
-        });
+        if (try p.parseAssignExpr()) |assign_expr_node| {
+            while_prefix.body = assign_expr_node;
 
-        return node;
+            if (p.eatToken(.Semicolon) != null) return node;
+
+            if (p.eatToken(.Keyword_else)) |else_token| {
+                const payload = try p.parsePayload();
+
+                const statement_node = try p.expectNode(parseStatement, .{
+                    .ExpectedStatement = .{ .token = p.tok_i },
+                });
+
+                const else_node = try p.arena.allocator.create(Node.Else);
+                else_node.* = .{
+                    .else_token = else_token,
+                    .payload = payload,
+                    .body = statement_node,
+                };
+                while_prefix.@"else" = else_node;
+                return node;
+            }
+
+            try p.errors.append(p.gpa, .{
+                .ExpectedSemiOrElse = .{ .token = p.tok_i },
+            });
+
+            return node;
+        }
+
+        return null;
     }
 
-    return null;
-}
-
-/// BlockExprStatement
-///     <- BlockExpr
-///      / AssignExpr SEMICOLON
-fn parseBlockExprStatement(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    if (try parseBlockExpr(arena, it, tree)) |node| return node;
-    if (try parseAssignExpr(arena, it, tree)) |node| {
-        _ = try expectTokenRecoverable(it, tree, .Semicolon);
-        return node;
-    }
-    return null;
-}
-
-/// BlockExpr <- BlockLabel? Block
-fn parseBlockExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) Error!?*Node {
-    var colon: TokenIndex = undefined;
-    const label_token = parseBlockLabel(arena, it, tree, &colon);
-    const block_node = (try parseBlock(arena, it, tree)) orelse {
-        if (label_token) |label| {
-            putBackToken(it, label + 1); // ":"
-            putBackToken(it, label); // IDENTIFIER
+    /// BlockExprStatement
+    ///     <- BlockExpr
+    ///      / AssignExpr SEMICOLON
+    fn parseBlockExprStatement(p: *Parser) !?*Node {
+        if (try p.parseBlockExpr()) |node| return node;
+        if (try p.parseAssignExpr()) |node| {
+            _ = try p.expectTokenRecoverable(.Semicolon);
+            return node;
         }
         return null;
-    };
-    block_node.cast(Node.Block).?.label = label_token;
-    return block_node;
-}
-
-/// AssignExpr <- Expr (AssignOp Expr)?
-fn parseAssignExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parseBinOpExpr(arena, it, tree, parseAssignOp, parseExpr, .Once);
-}
-
-/// Expr <- KEYWORD_try* BoolOrExpr
-fn parseExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) Error!?*Node {
-    return parsePrefixOpExpr(arena, it, tree, parseTry, parseBoolOrExpr);
-}
-
-/// BoolOrExpr <- BoolAndExpr (KEYWORD_or BoolAndExpr)*
-fn parseBoolOrExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parseBinOpExpr(
-        arena,
-        it,
-        tree,
-        SimpleBinOpParseFn(.Keyword_or, Node.InfixOp.Op.BoolOr),
-        parseBoolAndExpr,
-        .Infinitely,
-    );
-}
-
-/// BoolAndExpr <- CompareExpr (KEYWORD_and CompareExpr)*
-fn parseBoolAndExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parseBinOpExpr(
-        arena,
-        it,
-        tree,
-        SimpleBinOpParseFn(.Keyword_and, .BoolAnd),
-        parseCompareExpr,
-        .Infinitely,
-    );
-}
-
-/// CompareExpr <- BitwiseExpr (CompareOp BitwiseExpr)?
-fn parseCompareExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parseBinOpExpr(arena, it, tree, parseCompareOp, parseBitwiseExpr, .Once);
-}
-
-/// BitwiseExpr <- BitShiftExpr (BitwiseOp BitShiftExpr)*
-fn parseBitwiseExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parseBinOpExpr(arena, it, tree, parseBitwiseOp, parseBitShiftExpr, .Infinitely);
-}
-
-/// BitShiftExpr <- AdditionExpr (BitShiftOp AdditionExpr)*
-fn parseBitShiftExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parseBinOpExpr(arena, it, tree, parseBitShiftOp, parseAdditionExpr, .Infinitely);
-}
-
-/// AdditionExpr <- MultiplyExpr (AdditionOp MultiplyExpr)*
-fn parseAdditionExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parseBinOpExpr(arena, it, tree, parseAdditionOp, parseMultiplyExpr, .Infinitely);
-}
-
-/// MultiplyExpr <- PrefixExpr (MultiplyOp PrefixExpr)*
-fn parseMultiplyExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parseBinOpExpr(arena, it, tree, parseMultiplyOp, parsePrefixExpr, .Infinitely);
-}
-
-/// PrefixExpr <- PrefixOp* PrimaryExpr
-fn parsePrefixExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parsePrefixOpExpr(arena, it, tree, parsePrefixOp, parsePrimaryExpr);
-}
-
-/// PrimaryExpr
-///     <- AsmExpr
-///      / IfExpr
-///      / KEYWORD_break BreakLabel? Expr?
-///      / KEYWORD_comptime Expr
-///      / KEYWORD_nosuspend Expr
-///      / KEYWORD_continue BreakLabel?
-///      / KEYWORD_resume Expr
-///      / KEYWORD_return Expr?
-///      / BlockLabel? LoopExpr
-///      / Block
-///      / CurlySuffixExpr
-fn parsePrimaryExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    if (try parseAsmExpr(arena, it, tree)) |node| return node;
-    if (try parseIfExpr(arena, it, tree)) |node| return node;
-
-    if (eatToken(it, .Keyword_break)) |token| {
-        const label = try parseBreakLabel(arena, it, tree);
-        const expr_node = try parseExpr(arena, it, tree);
-        const node = try arena.create(Node.ControlFlowExpression);
-        node.* = .{
-            .ltoken = token,
-            .kind = .{ .Break = label },
-            .rhs = expr_node,
-        };
-        return &node.base;
     }
 
-    if (eatToken(it, .Keyword_comptime)) |token| {
-        const expr_node = try expectNode(arena, it, tree, parseExpr, .{
-            .ExpectedExpr = .{ .token = it.index },
-        });
-        const node = try arena.create(Node.Comptime);
-        node.* = .{
-            .doc_comments = null,
-            .comptime_token = token,
-            .expr = expr_node,
-        };
-        return &node.base;
-    }
-
-    if (eatToken(it, .Keyword_nosuspend)) |token| {
-        const expr_node = try expectNode(arena, it, tree, parseExpr, .{
-            .ExpectedExpr = .{ .token = it.index },
-        });
-        const node = try arena.create(Node.Nosuspend);
-        node.* = .{
-            .nosuspend_token = token,
-            .expr = expr_node,
-        };
-        return &node.base;
-    }
-
-    if (eatToken(it, .Keyword_continue)) |token| {
-        const label = try parseBreakLabel(arena, it, tree);
-        const node = try arena.create(Node.ControlFlowExpression);
-        node.* = .{
-            .ltoken = token,
-            .kind = .{ .Continue = label },
-            .rhs = null,
-        };
-        return &node.base;
-    }
-
-    if (eatToken(it, .Keyword_resume)) |token| {
-        const expr_node = try expectNode(arena, it, tree, parseExpr, .{
-            .ExpectedExpr = .{ .token = it.index },
-        });
-        const node = try arena.create(Node.PrefixOp);
-        node.* = .{
-            .op_token = token,
-            .op = .Resume,
-            .rhs = expr_node,
-        };
-        return &node.base;
-    }
-
-    if (eatToken(it, .Keyword_return)) |token| {
-        const expr_node = try parseExpr(arena, it, tree);
-        const node = try arena.create(Node.ControlFlowExpression);
-        node.* = .{
-            .ltoken = token,
-            .kind = .Return,
-            .rhs = expr_node,
-        };
-        return &node.base;
-    }
-
-    var colon: TokenIndex = undefined;
-    const label = parseBlockLabel(arena, it, tree, &colon);
-    if (try parseLoopExpr(arena, it, tree)) |node| {
-        if (node.cast(Node.For)) |for_node| {
-            for_node.label = label;
-        } else if (node.cast(Node.While)) |while_node| {
-            while_node.label = label;
-        } else unreachable;
-        return node;
-    }
-    if (label) |token| {
-        putBackToken(it, token + 1); // ":"
-        putBackToken(it, token); // IDENTIFIER
-    }
-
-    if (try parseBlock(arena, it, tree)) |node| return node;
-    if (try parseCurlySuffixExpr(arena, it, tree)) |node| return node;
-
-    return null;
-}
-
-/// IfExpr <- IfPrefix Expr (KEYWORD_else Payload? Expr)?
-fn parseIfExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parseIf(arena, it, tree, parseExpr);
-}
-
-/// Block <- LBRACE Statement* RBRACE
-fn parseBlock(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const lbrace = eatToken(it, .LBrace) orelse return null;
-
-    var statements = Node.Block.StatementList.init(arena);
-    while (true) {
-        const statement = (parseStatement(arena, it, tree) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.ParseError => {
-                // try to skip to the next statement
-                findNextStmt(it);
-                continue;
-            },
-        }) orelse break;
-        try statements.push(statement);
-    }
-
-    const rbrace = try expectToken(it, tree, .RBrace);
-
-    const block_node = try arena.create(Node.Block);
-    block_node.* = .{
-        .label = null,
-        .lbrace = lbrace,
-        .statements = statements,
-        .rbrace = rbrace,
-    };
-
-    return &block_node.base;
-}
-
-/// LoopExpr <- KEYWORD_inline? (ForExpr / WhileExpr)
-fn parseLoopExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const inline_token = eatToken(it, .Keyword_inline);
-
-    if (try parseForExpr(arena, it, tree)) |node| {
-        node.cast(Node.For).?.inline_token = inline_token;
-        return node;
-    }
-
-    if (try parseWhileExpr(arena, it, tree)) |node| {
-        node.cast(Node.While).?.inline_token = inline_token;
-        return node;
-    }
-
-    if (inline_token == null) return null;
-
-    // If we've seen "inline", there should have been a "for" or "while"
-    try tree.errors.push(.{
-        .ExpectedInlinable = .{ .token = it.index },
-    });
-    return error.ParseError;
-}
-
-/// ForExpr <- ForPrefix Expr (KEYWORD_else Expr)?
-fn parseForExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const node = (try parseForPrefix(arena, it, tree)) orelse return null;
-    const for_prefix = node.cast(Node.For).?;
-
-    const body_node = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    for_prefix.body = body_node;
-
-    if (eatToken(it, .Keyword_else)) |else_token| {
-        const body = try expectNode(arena, it, tree, parseExpr, .{
-            .ExpectedExpr = .{ .token = it.index },
-        });
-
-        const else_node = try arena.create(Node.Else);
-        else_node.* = .{
-            .else_token = else_token,
-            .payload = null,
-            .body = body,
-        };
-
-        for_prefix.@"else" = else_node;
-    }
-
-    return node;
-}
-
-/// WhileExpr <- WhilePrefix Expr (KEYWORD_else Payload? Expr)?
-fn parseWhileExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const node = (try parseWhilePrefix(arena, it, tree)) orelse return null;
-    const while_prefix = node.cast(Node.While).?;
-
-    const body_node = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    while_prefix.body = body_node;
-
-    if (eatToken(it, .Keyword_else)) |else_token| {
-        const payload = try parsePayload(arena, it, tree);
-        const body = try expectNode(arena, it, tree, parseExpr, .{
-            .ExpectedExpr = .{ .token = it.index },
-        });
-
-        const else_node = try arena.create(Node.Else);
-        else_node.* = .{
-            .else_token = else_token,
-            .payload = payload,
-            .body = body,
-        };
-
-        while_prefix.@"else" = else_node;
-    }
-
-    return node;
-}
-
-/// CurlySuffixExpr <- TypeExpr InitList?
-fn parseCurlySuffixExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const type_expr = (try parseTypeExpr(arena, it, tree)) orelse return null;
-    const suffix_op = (try parseInitList(arena, it, tree)) orelse return type_expr;
-    suffix_op.lhs.node = type_expr;
-    return &suffix_op.base;
-}
-
-/// InitList
-///     <- LBRACE FieldInit (COMMA FieldInit)* COMMA? RBRACE
-///      / LBRACE Expr (COMMA Expr)* COMMA? RBRACE
-///      / LBRACE RBRACE
-fn parseInitList(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node.SuffixOp {
-    const lbrace = eatToken(it, .LBrace) orelse return null;
-    var init_list = Node.SuffixOp.Op.InitList.init(arena);
-
-    const op: Node.SuffixOp.Op = blk: {
-        if (try parseFieldInit(arena, it, tree)) |field_init| {
-            try init_list.push(field_init);
-            while (eatToken(it, .Comma)) |_| {
-                const next = (try parseFieldInit(arena, it, tree)) orelse break;
-                try init_list.push(next);
+    /// BlockExpr <- BlockLabel? Block
+    fn parseBlockExpr(p: *Parser) Error!?*Node {
+        var colon: TokenIndex = undefined;
+        const label_token = p.parseBlockLabel(&colon);
+        const block_node = (try p.parseBlock()) orelse {
+            if (label_token) |label| {
+                p.putBackToken(label + 1); // ":"
+                p.putBackToken(label); // IDENTIFIER
             }
-            break :blk .{ .StructInitializer = init_list };
-        }
-
-        if (try parseExpr(arena, it, tree)) |expr| {
-            try init_list.push(expr);
-            while (eatToken(it, .Comma)) |_| {
-                const next = (try parseExpr(arena, it, tree)) orelse break;
-                try init_list.push(next);
-            }
-            break :blk .{ .ArrayInitializer = init_list };
-        }
-
-        break :blk .{ .StructInitializer = init_list };
-    };
-
-    const node = try arena.create(Node.SuffixOp);
-    node.* = .{
-        .lhs = .{ .node = undefined }, // set by caller
-        .op = op,
-        .rtoken = try expectToken(it, tree, .RBrace),
-    };
-    return node;
-}
-
-/// TypeExpr <- PrefixTypeOp* ErrorUnionExpr
-fn parseTypeExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) Error!?*Node {
-    return parsePrefixOpExpr(arena, it, tree, parsePrefixTypeOp, parseErrorUnionExpr);
-}
-
-/// ErrorUnionExpr <- SuffixExpr (EXCLAMATIONMARK TypeExpr)?
-fn parseErrorUnionExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const suffix_expr = (try parseSuffixExpr(arena, it, tree)) orelse return null;
-
-    if (try SimpleBinOpParseFn(.Bang, Node.InfixOp.Op.ErrorUnion)(arena, it, tree)) |node| {
-        const error_union = node.cast(Node.InfixOp).?;
-        const type_expr = try expectNode(arena, it, tree, parseTypeExpr, .{
-            .ExpectedTypeExpr = .{ .token = it.index },
-        });
-        error_union.lhs = suffix_expr;
-        error_union.rhs = type_expr;
-        return node;
+            return null;
+        };
+        block_node.cast(Node.Block).?.label = label_token;
+        return block_node;
     }
 
-    return suffix_expr;
-}
+    /// AssignExpr <- Expr (AssignOp Expr)?
+    fn parseAssignExpr(p: *Parser) !?*Node {
+        return p.parseBinOpExpr(parseAssignOp, parseExpr, .Once);
+    }
 
-/// SuffixExpr
-///     <- KEYWORD_async PrimaryTypeExpr SuffixOp* FnCallArguments
-///      / PrimaryTypeExpr (SuffixOp / FnCallArguments)*
-fn parseSuffixExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const maybe_async = eatToken(it, .Keyword_async);
-    if (maybe_async) |async_token| {
-        const token_fn = eatToken(it, .Keyword_fn);
-        if (token_fn != null) {
-            // TODO: remove this hack when async fn rewriting is
-            // HACK: If we see the keyword `fn`, then we assume that
-            //       we are parsing an async fn proto, and not a call.
-            //       We therefore put back all tokens consumed by the async
-            //       prefix...
-            putBackToken(it, token_fn.?);
-            putBackToken(it, async_token);
-            return parsePrimaryTypeExpr(arena, it, tree);
+    /// Expr <- KEYWORD_try* BoolOrExpr
+    fn parseExpr(p: *Parser) Error!?*Node {
+        return p.parsePrefixOpExpr(parseTry, parseBoolOrExpr);
+    }
+
+    /// BoolOrExpr <- BoolAndExpr (KEYWORD_or BoolAndExpr)*
+    fn parseBoolOrExpr(p: *Parser) !?*Node {
+        return p.parseBinOpExpr(
+            SimpleBinOpParseFn(.Keyword_or, Node.InfixOp.Op.BoolOr),
+            parseBoolAndExpr,
+            .Infinitely,
+        );
+    }
+
+    /// BoolAndExpr <- CompareExpr (KEYWORD_and CompareExpr)*
+    fn parseBoolAndExpr(p: *Parser) !?*Node {
+        return p.parseBinOpExpr(
+            SimpleBinOpParseFn(.Keyword_and, .BoolAnd),
+            parseCompareExpr,
+            .Infinitely,
+        );
+    }
+
+    /// CompareExpr <- BitwiseExpr (CompareOp BitwiseExpr)?
+    fn parseCompareExpr(p: *Parser) !?*Node {
+        return p.parseBinOpExpr(parseCompareOp, parseBitwiseExpr, .Once);
+    }
+
+    /// BitwiseExpr <- BitShiftExpr (BitwiseOp BitShiftExpr)*
+    fn parseBitwiseExpr(p: *Parser) !?*Node {
+        return p.parseBinOpExpr(parseBitwiseOp, parseBitShiftExpr, .Infinitely);
+    }
+
+    /// BitShiftExpr <- AdditionExpr (BitShiftOp AdditionExpr)*
+    fn parseBitShiftExpr(p: *Parser) !?*Node {
+        return p.parseBinOpExpr(parseBitShiftOp, parseAdditionExpr, .Infinitely);
+    }
+
+    /// AdditionExpr <- MultiplyExpr (AdditionOp MultiplyExpr)*
+    fn parseAdditionExpr(p: *Parser) !?*Node {
+        return p.parseBinOpExpr(parseAdditionOp, parseMultiplyExpr, .Infinitely);
+    }
+
+    /// MultiplyExpr <- PrefixExpr (MultiplyOp PrefixExpr)*
+    fn parseMultiplyExpr(p: *Parser) !?*Node {
+        return p.parseBinOpExpr(parseMultiplyOp, parsePrefixExpr, .Infinitely);
+    }
+
+    /// PrefixExpr <- PrefixOp* PrimaryExpr
+    fn parsePrefixExpr(p: *Parser) !?*Node {
+        return p.parsePrefixOpExpr(parsePrefixOp, parsePrimaryExpr);
+    }
+
+    /// PrimaryExpr
+    ///     <- AsmExpr
+    ///      / IfExpr
+    ///      / KEYWORD_break BreakLabel? Expr?
+    ///      / KEYWORD_comptime Expr
+    ///      / KEYWORD_nosuspend Expr
+    ///      / KEYWORD_continue BreakLabel?
+    ///      / KEYWORD_resume Expr
+    ///      / KEYWORD_return Expr?
+    ///      / BlockLabel? LoopExpr
+    ///      / Block
+    ///      / CurlySuffixExpr
+    fn parsePrimaryExpr(p: *Parser) !?*Node {
+        if (try p.parseAsmExpr()) |node| return node;
+        if (try p.parseIfExpr()) |node| return node;
+
+        if (p.eatToken(.Keyword_break)) |token| {
+            const label = try p.parseBreakLabel();
+            const expr_node = try p.parseExpr();
+            const node = try p.arena.allocator.create(Node.ControlFlowExpression);
+            node.* = .{
+                .ltoken = token,
+                .kind = .{ .Break = label },
+                .rhs = expr_node,
+            };
+            return &node.base;
         }
-        var res = try expectNode(arena, it, tree, parsePrimaryTypeExpr, .{
-            .ExpectedPrimaryTypeExpr = .{ .token = it.index },
-        });
 
-        while (try parseSuffixOp(arena, it, tree)) |node| {
-            switch (node.id) {
-                .SuffixOp => node.cast(Node.SuffixOp).?.lhs = .{ .node = res },
-                .InfixOp => node.cast(Node.InfixOp).?.lhs = res,
-                else => unreachable,
-            }
-            res = node;
-        }
-
-        const params = (try parseFnCallArguments(arena, it, tree)) orelse {
-            try tree.errors.push(.{
-                .ExpectedParamList = .{ .token = it.index },
+        if (p.eatToken(.Keyword_comptime)) |token| {
+            const expr_node = try p.expectNode(parseExpr, .{
+                .ExpectedExpr = .{ .token = p.tok_i },
             });
-            // ignore this, continue parsing
-            return res;
-        };
-        const node = try arena.create(Node.SuffixOp);
-        node.* = .{
-            .lhs = .{ .node = res },
-            .op = .{
-                .Call = .{
-                    .params = params.list,
-                    .async_token = async_token,
-                },
-            },
-            .rtoken = params.rparen,
-        };
-        return &node.base;
-    }
-    if (try parsePrimaryTypeExpr(arena, it, tree)) |expr| {
-        var res = expr;
+            const node = try p.arena.allocator.create(Node.Comptime);
+            node.* = .{
+                .doc_comments = null,
+                .comptime_token = token,
+                .expr = expr_node,
+            };
+            return &node.base;
+        }
 
+        if (p.eatToken(.Keyword_nosuspend)) |token| {
+            const expr_node = try p.expectNode(parseExpr, .{
+                .ExpectedExpr = .{ .token = p.tok_i },
+            });
+            const node = try p.arena.allocator.create(Node.Nosuspend);
+            node.* = .{
+                .nosuspend_token = token,
+                .expr = expr_node,
+            };
+            return &node.base;
+        }
+
+        if (p.eatToken(.Keyword_continue)) |token| {
+            const label = try p.parseBreakLabel();
+            const node = try p.arena.allocator.create(Node.ControlFlowExpression);
+            node.* = .{
+                .ltoken = token,
+                .kind = .{ .Continue = label },
+                .rhs = null,
+            };
+            return &node.base;
+        }
+
+        if (p.eatToken(.Keyword_resume)) |token| {
+            const expr_node = try p.expectNode(parseExpr, .{
+                .ExpectedExpr = .{ .token = p.tok_i },
+            });
+            const node = try p.arena.allocator.create(Node.PrefixOp);
+            node.* = .{
+                .op_token = token,
+                .op = .Resume,
+                .rhs = expr_node,
+            };
+            return &node.base;
+        }
+
+        if (p.eatToken(.Keyword_return)) |token| {
+            const expr_node = try p.parseExpr();
+            const node = try p.arena.allocator.create(Node.ControlFlowExpression);
+            node.* = .{
+                .ltoken = token,
+                .kind = .Return,
+                .rhs = expr_node,
+            };
+            return &node.base;
+        }
+
+        var colon: TokenIndex = undefined;
+        const label = p.parseBlockLabel(&colon);
+        if (try p.parseLoopExpr()) |node| {
+            if (node.cast(Node.For)) |for_node| {
+                for_node.label = label;
+            } else if (node.cast(Node.While)) |while_node| {
+                while_node.label = label;
+            } else unreachable;
+            return node;
+        }
+        if (label) |token| {
+            p.putBackToken(token + 1); // ":"
+            p.putBackToken(token); // IDENTIFIER
+        }
+
+        if (try p.parseBlock()) |node| return node;
+        if (try p.parseCurlySuffixExpr()) |node| return node;
+
+        return null;
+    }
+
+    /// IfExpr <- IfPrefix Expr (KEYWORD_else Payload? Expr)?
+    fn parseIfExpr(p: *Parser) !?*Node {
+        return p.parseIf(parseExpr);
+    }
+
+    /// Block <- LBRACE Statement* RBRACE
+    fn parseBlock(p: *Parser) !?*Node {
+        const lbrace = p.eatToken(.LBrace) orelse return null;
+
+        var statements = Node.Block.StatementList{};
+        var statements_it = &statements.first;
         while (true) {
-            if (try parseSuffixOp(arena, it, tree)) |node| {
+            const statement = (p.parseStatement() catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.ParseError => {
+                    // try to skip to the next statement
+                    p.findNextStmt();
+                    continue;
+                },
+            }) orelse break;
+            statements_it = try p.llpush(*Node, statements_it, statement);
+        }
+
+        const rbrace = try p.expectToken(.RBrace);
+
+        const block_node = try p.arena.allocator.create(Node.Block);
+        block_node.* = .{
+            .label = null,
+            .lbrace = lbrace,
+            .statements = statements,
+            .rbrace = rbrace,
+        };
+
+        return &block_node.base;
+    }
+
+    /// LoopExpr <- KEYWORD_inline? (ForExpr / WhileExpr)
+    fn parseLoopExpr(p: *Parser) !?*Node {
+        const inline_token = p.eatToken(.Keyword_inline);
+
+        if (try p.parseForExpr()) |node| {
+            node.cast(Node.For).?.inline_token = inline_token;
+            return node;
+        }
+
+        if (try p.parseWhileExpr()) |node| {
+            node.cast(Node.While).?.inline_token = inline_token;
+            return node;
+        }
+
+        if (inline_token == null) return null;
+
+        // If we've seen "inline", there should have been a "for" or "while"
+        try p.errors.append(p.gpa, .{
+            .ExpectedInlinable = .{ .token = p.tok_i },
+        });
+        return error.ParseError;
+    }
+
+    /// ForExpr <- ForPrefix Expr (KEYWORD_else Expr)?
+    fn parseForExpr(p: *Parser) !?*Node {
+        const node = (try p.parseForPrefix()) orelse return null;
+        const for_prefix = node.cast(Node.For).?;
+
+        const body_node = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+        for_prefix.body = body_node;
+
+        if (p.eatToken(.Keyword_else)) |else_token| {
+            const body = try p.expectNode(parseExpr, .{
+                .ExpectedExpr = .{ .token = p.tok_i },
+            });
+
+            const else_node = try p.arena.allocator.create(Node.Else);
+            else_node.* = .{
+                .else_token = else_token,
+                .payload = null,
+                .body = body,
+            };
+
+            for_prefix.@"else" = else_node;
+        }
+
+        return node;
+    }
+
+    /// WhileExpr <- WhilePrefix Expr (KEYWORD_else Payload? Expr)?
+    fn parseWhileExpr(p: *Parser) !?*Node {
+        const node = (try p.parseWhilePrefix()) orelse return null;
+        const while_prefix = node.cast(Node.While).?;
+
+        const body_node = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+        while_prefix.body = body_node;
+
+        if (p.eatToken(.Keyword_else)) |else_token| {
+            const payload = try p.parsePayload();
+            const body = try p.expectNode(parseExpr, .{
+                .ExpectedExpr = .{ .token = p.tok_i },
+            });
+
+            const else_node = try p.arena.allocator.create(Node.Else);
+            else_node.* = .{
+                .else_token = else_token,
+                .payload = payload,
+                .body = body,
+            };
+
+            while_prefix.@"else" = else_node;
+        }
+
+        return node;
+    }
+
+    /// CurlySuffixExpr <- TypeExpr InitList?
+    fn parseCurlySuffixExpr(p: *Parser) !?*Node {
+        const type_expr = (try p.parseTypeExpr()) orelse return null;
+        const suffix_op = (try p.parseInitList()) orelse return type_expr;
+        suffix_op.lhs.node = type_expr;
+        return &suffix_op.base;
+    }
+
+    /// InitList
+    ///     <- LBRACE FieldInit (COMMA FieldInit)* COMMA? RBRACE
+    ///      / LBRACE Expr (COMMA Expr)* COMMA? RBRACE
+    ///      / LBRACE RBRACE
+    fn parseInitList(p: *Parser) !?*Node.SuffixOp {
+        const lbrace = p.eatToken(.LBrace) orelse return null;
+        var init_list = Node.SuffixOp.Op.InitList{};
+        var init_list_it = &init_list.first;
+
+        const op: Node.SuffixOp.Op = blk: {
+            if (try p.parseFieldInit()) |field_init| {
+                init_list_it = try p.llpush(*Node, init_list_it, field_init);
+                while (p.eatToken(.Comma)) |_| {
+                    const next = (try p.parseFieldInit()) orelse break;
+                    init_list_it = try p.llpush(*Node, init_list_it, next);
+                }
+                break :blk .{ .StructInitializer = init_list };
+            }
+
+            if (try p.parseExpr()) |expr| {
+                init_list_it = try p.llpush(*Node, init_list_it, expr);
+                while (p.eatToken(.Comma)) |_| {
+                    const next = (try p.parseExpr()) orelse break;
+                    init_list_it = try p.llpush(*Node, init_list_it, next);
+                }
+                break :blk .{ .ArrayInitializer = init_list };
+            }
+
+            break :blk .{ .StructInitializer = init_list };
+        };
+
+        const node = try p.arena.allocator.create(Node.SuffixOp);
+        node.* = .{
+            .lhs = .{ .node = undefined }, // set by caller
+            .op = op,
+            .rtoken = try p.expectToken(.RBrace),
+        };
+        return node;
+    }
+
+    /// TypeExpr <- PrefixTypeOp* ErrorUnionExpr
+    fn parseTypeExpr(p: *Parser) Error!?*Node {
+        return p.parsePrefixOpExpr(parsePrefixTypeOp, parseErrorUnionExpr);
+    }
+
+    /// ErrorUnionExpr <- SuffixExpr (EXCLAMATIONMARK TypeExpr)?
+    fn parseErrorUnionExpr(p: *Parser) !?*Node {
+        const suffix_expr = (try p.parseSuffixExpr()) orelse return null;
+
+        if (try SimpleBinOpParseFn(.Bang, Node.InfixOp.Op.ErrorUnion)(p)) |node| {
+            const error_union = node.cast(Node.InfixOp).?;
+            const type_expr = try p.expectNode(parseTypeExpr, .{
+                .ExpectedTypeExpr = .{ .token = p.tok_i },
+            });
+            error_union.lhs = suffix_expr;
+            error_union.rhs = type_expr;
+            return node;
+        }
+
+        return suffix_expr;
+    }
+
+    /// SuffixExpr
+    ///     <- KEYWORD_async PrimaryTypeExpr SuffixOp* FnCallArguments
+    ///      / PrimaryTypeExpr (SuffixOp / FnCallArguments)*
+    fn parseSuffixExpr(p: *Parser) !?*Node {
+        const maybe_async = p.eatToken(.Keyword_async);
+        if (maybe_async) |async_token| {
+            const token_fn = p.eatToken(.Keyword_fn);
+            if (token_fn != null) {
+                // TODO: remove this hack when async fn rewriting is
+                // HACK: If we see the keyword `fn`, then we assume that
+                //       we are parsing an async fn proto, and not a call.
+                //       We therefore put back all tokens consumed by the async
+                //       prefix...
+                p.putBackToken(token_fn.?);
+                p.putBackToken(async_token);
+                return p.parsePrimaryTypeExpr();
+            }
+            var res = try p.expectNode(parsePrimaryTypeExpr, .{
+                .ExpectedPrimaryTypeExpr = .{ .token = p.tok_i },
+            });
+
+            while (try p.parseSuffixOp()) |node| {
                 switch (node.id) {
                     .SuffixOp => node.cast(Node.SuffixOp).?.lhs = .{ .node = res },
                     .InfixOp => node.cast(Node.InfixOp).?.lhs = res,
                     else => unreachable,
                 }
                 res = node;
-                continue;
             }
-            if (try parseFnCallArguments(arena, it, tree)) |params| {
-                const call = try arena.create(Node.SuffixOp);
-                call.* = .{
-                    .lhs = .{ .node = res },
-                    .op = .{
-                        .Call = .{
-                            .params = params.list,
-                            .async_token = null,
-                        },
+
+            const params = (try p.parseFnCallArguments()) orelse {
+                try p.errors.append(p.gpa, .{
+                    .ExpectedParamList = .{ .token = p.tok_i },
+                });
+                // ignore this, continue parsing
+                return res;
+            };
+            const node = try p.arena.allocator.create(Node.SuffixOp);
+            node.* = .{
+                .lhs = .{ .node = res },
+                .op = .{
+                    .Call = .{
+                        .params = params.list,
+                        .async_token = async_token,
                     },
-                    .rtoken = params.rparen,
-                };
-                res = &call.base;
-                continue;
-            }
-            break;
+                },
+                .rtoken = params.rparen,
+            };
+            return &node.base;
         }
-        return res;
+        if (try p.parsePrimaryTypeExpr()) |expr| {
+            var res = expr;
+
+            while (true) {
+                if (try p.parseSuffixOp()) |node| {
+                    switch (node.id) {
+                        .SuffixOp => node.cast(Node.SuffixOp).?.lhs = .{ .node = res },
+                        .InfixOp => node.cast(Node.InfixOp).?.lhs = res,
+                        else => unreachable,
+                    }
+                    res = node;
+                    continue;
+                }
+                if (try p.parseFnCallArguments()) |params| {
+                    const call = try p.arena.allocator.create(Node.SuffixOp);
+                    call.* = .{
+                        .lhs = .{ .node = res },
+                        .op = .{
+                            .Call = .{
+                                .params = params.list,
+                                .async_token = null,
+                            },
+                        },
+                        .rtoken = params.rparen,
+                    };
+                    res = &call.base;
+                    continue;
+                }
+                break;
+            }
+            return res;
+        }
+
+        return null;
     }
 
-    return null;
-}
+    /// PrimaryTypeExpr
+    ///     <- BUILTINIDENTIFIER FnCallArguments
+    ///      / CHAR_LITERAL
+    ///      / ContainerDecl
+    ///      / DOT IDENTIFIER
+    ///      / ErrorSetDecl
+    ///      / FLOAT
+    ///      / FnProto
+    ///      / GroupedExpr
+    ///      / LabeledTypeExpr
+    ///      / IDENTIFIER
+    ///      / IfTypeExpr
+    ///      / INTEGER
+    ///      / KEYWORD_comptime TypeExpr
+    ///      / KEYWORD_error DOT IDENTIFIER
+    ///      / KEYWORD_false
+    ///      / KEYWORD_null
+    ///      / KEYWORD_anyframe
+    ///      / KEYWORD_true
+    ///      / KEYWORD_undefined
+    ///      / KEYWORD_unreachable
+    ///      / STRINGLITERAL
+    ///      / SwitchExpr
+    fn parsePrimaryTypeExpr(p: *Parser) !?*Node {
+        if (try p.parseBuiltinCall()) |node| return node;
+        if (p.eatToken(.CharLiteral)) |token| {
+            const node = try p.arena.allocator.create(Node.CharLiteral);
+            node.* = .{
+                .token = token,
+            };
+            return &node.base;
+        }
+        if (try p.parseContainerDecl()) |node| return node;
+        if (try p.parseAnonLiteral()) |node| return node;
+        if (try p.parseErrorSetDecl()) |node| return node;
+        if (try p.parseFloatLiteral()) |node| return node;
+        if (try p.parseFnProto()) |node| return node;
+        if (try p.parseGroupedExpr()) |node| return node;
+        if (try p.parseLabeledTypeExpr()) |node| return node;
+        if (try p.parseIdentifier()) |node| return node;
+        if (try p.parseIfTypeExpr()) |node| return node;
+        if (try p.parseIntegerLiteral()) |node| return node;
+        if (p.eatToken(.Keyword_comptime)) |token| {
+            const expr = (try p.parseTypeExpr()) orelse return null;
+            const node = try p.arena.allocator.create(Node.Comptime);
+            node.* = .{
+                .doc_comments = null,
+                .comptime_token = token,
+                .expr = expr,
+            };
+            return &node.base;
+        }
+        if (p.eatToken(.Keyword_error)) |token| {
+            const period = try p.expectTokenRecoverable(.Period);
+            const identifier = try p.expectNodeRecoverable(parseIdentifier, .{
+                .ExpectedIdentifier = .{ .token = p.tok_i },
+            });
+            const global_error_set = try p.createLiteral(Node.ErrorType, token);
+            if (period == null or identifier == null) return global_error_set;
 
-/// PrimaryTypeExpr
-///     <- BUILTINIDENTIFIER FnCallArguments
-///      / CHAR_LITERAL
-///      / ContainerDecl
-///      / DOT IDENTIFIER
-///      / ErrorSetDecl
-///      / FLOAT
-///      / FnProto
-///      / GroupedExpr
-///      / LabeledTypeExpr
-///      / IDENTIFIER
-///      / IfTypeExpr
-///      / INTEGER
-///      / KEYWORD_comptime TypeExpr
-///      / KEYWORD_error DOT IDENTIFIER
-///      / KEYWORD_false
-///      / KEYWORD_null
-///      / KEYWORD_anyframe
-///      / KEYWORD_true
-///      / KEYWORD_undefined
-///      / KEYWORD_unreachable
-///      / STRINGLITERAL
-///      / SwitchExpr
-fn parsePrimaryTypeExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    if (try parseBuiltinCall(arena, it, tree)) |node| return node;
-    if (eatToken(it, .CharLiteral)) |token| {
-        const node = try arena.create(Node.CharLiteral);
+            const node = try p.arena.allocator.create(Node.InfixOp);
+            node.* = .{
+                .op_token = period.?,
+                .lhs = global_error_set,
+                .op = .Period,
+                .rhs = identifier.?,
+            };
+            return &node.base;
+        }
+        if (p.eatToken(.Keyword_false)) |token| return p.createLiteral(Node.BoolLiteral, token);
+        if (p.eatToken(.Keyword_null)) |token| return p.createLiteral(Node.NullLiteral, token);
+        if (p.eatToken(.Keyword_anyframe)) |token| {
+            const node = try p.arena.allocator.create(Node.AnyFrameType);
+            node.* = .{
+                .anyframe_token = token,
+                .result = null,
+            };
+            return &node.base;
+        }
+        if (p.eatToken(.Keyword_true)) |token| return p.createLiteral(Node.BoolLiteral, token);
+        if (p.eatToken(.Keyword_undefined)) |token| return p.createLiteral(Node.UndefinedLiteral, token);
+        if (p.eatToken(.Keyword_unreachable)) |token| return p.createLiteral(Node.Unreachable, token);
+        if (try p.parseStringLiteral()) |node| return node;
+        if (try p.parseSwitchExpr()) |node| return node;
+
+        return null;
+    }
+
+    /// ContainerDecl <- (KEYWORD_extern / KEYWORD_packed)? ContainerDeclAuto
+    fn parseContainerDecl(p: *Parser) !?*Node {
+        const layout_token = p.eatToken(.Keyword_extern) orelse
+            p.eatToken(.Keyword_packed);
+
+        const node = (try p.parseContainerDeclAuto()) orelse {
+            if (layout_token) |token|
+                p.putBackToken(token);
+            return null;
+        };
+        node.cast(Node.ContainerDecl).?.*.layout_token = layout_token;
+        return node;
+    }
+
+    /// ErrorSetDecl <- KEYWORD_error LBRACE IdentifierList RBRACE
+    fn parseErrorSetDecl(p: *Parser) !?*Node {
+        const error_token = p.eatToken(.Keyword_error) orelse return null;
+        if (p.eatToken(.LBrace) == null) {
+            // Might parse as `KEYWORD_error DOT IDENTIFIER` later in PrimaryTypeExpr, so don't error
+            p.putBackToken(error_token);
+            return null;
+        }
+        const decls = try p.parseErrorTagList();
+        const rbrace = try p.expectToken(.RBrace);
+
+        const node = try p.arena.allocator.create(Node.ErrorSetDecl);
         node.* = .{
-            .token = token,
+            .error_token = error_token,
+            .decls = decls,
+            .rbrace_token = rbrace,
         };
         return &node.base;
     }
-    if (try parseContainerDecl(arena, it, tree)) |node| return node;
-    if (try parseAnonLiteral(arena, it, tree)) |node| return node;
-    if (try parseErrorSetDecl(arena, it, tree)) |node| return node;
-    if (try parseFloatLiteral(arena, it, tree)) |node| return node;
-    if (try parseFnProto(arena, it, tree)) |node| return node;
-    if (try parseGroupedExpr(arena, it, tree)) |node| return node;
-    if (try parseLabeledTypeExpr(arena, it, tree)) |node| return node;
-    if (try parseIdentifier(arena, it, tree)) |node| return node;
-    if (try parseIfTypeExpr(arena, it, tree)) |node| return node;
-    if (try parseIntegerLiteral(arena, it, tree)) |node| return node;
-    if (eatToken(it, .Keyword_comptime)) |token| {
-        const expr = (try parseTypeExpr(arena, it, tree)) orelse return null;
-        const node = try arena.create(Node.Comptime);
-        node.* = .{
-            .doc_comments = null,
-            .comptime_token = token,
-            .expr = expr,
-        };
-        return &node.base;
-    }
-    if (eatToken(it, .Keyword_error)) |token| {
-        const period = try expectTokenRecoverable(it, tree, .Period);
-        const identifier = try expectNodeRecoverable(arena, it, tree, parseIdentifier, .{
-            .ExpectedIdentifier = .{ .token = it.index },
+
+    /// GroupedExpr <- LPAREN Expr RPAREN
+    fn parseGroupedExpr(p: *Parser) !?*Node {
+        const lparen = p.eatToken(.LParen) orelse return null;
+        const expr = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
         });
-        const global_error_set = try createLiteral(arena, Node.ErrorType, token);
-        if (period == null or identifier == null) return global_error_set;
+        const rparen = try p.expectToken(.RParen);
 
-        const node = try arena.create(Node.InfixOp);
+        const node = try p.arena.allocator.create(Node.GroupedExpression);
         node.* = .{
-            .op_token = period.?,
-            .lhs = global_error_set,
-            .op = .Period,
-            .rhs = identifier.?,
+            .lparen = lparen,
+            .expr = expr,
+            .rparen = rparen,
         };
         return &node.base;
     }
-    if (eatToken(it, .Keyword_false)) |token| return createLiteral(arena, Node.BoolLiteral, token);
-    if (eatToken(it, .Keyword_null)) |token| return createLiteral(arena, Node.NullLiteral, token);
-    if (eatToken(it, .Keyword_anyframe)) |token| {
-        const node = try arena.create(Node.AnyFrameType);
-        node.* = .{
-            .anyframe_token = token,
-            .result = null,
-        };
-        return &node.base;
+
+    /// IfTypeExpr <- IfPrefix TypeExpr (KEYWORD_else Payload? TypeExpr)?
+    fn parseIfTypeExpr(p: *Parser) !?*Node {
+        return p.parseIf(parseTypeExpr);
     }
-    if (eatToken(it, .Keyword_true)) |token| return createLiteral(arena, Node.BoolLiteral, token);
-    if (eatToken(it, .Keyword_undefined)) |token| return createLiteral(arena, Node.UndefinedLiteral, token);
-    if (eatToken(it, .Keyword_unreachable)) |token| return createLiteral(arena, Node.Unreachable, token);
-    if (try parseStringLiteral(arena, it, tree)) |node| return node;
-    if (try parseSwitchExpr(arena, it, tree)) |node| return node;
 
-    return null;
-}
+    /// LabeledTypeExpr
+    ///     <- BlockLabel Block
+    ///      / BlockLabel? LoopTypeExpr
+    fn parseLabeledTypeExpr(p: *Parser) !?*Node {
+        var colon: TokenIndex = undefined;
+        const label = p.parseBlockLabel(&colon);
 
-/// ContainerDecl <- (KEYWORD_extern / KEYWORD_packed)? ContainerDeclAuto
-fn parseContainerDecl(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const layout_token = eatToken(it, .Keyword_extern) orelse
-        eatToken(it, .Keyword_packed);
+        if (label) |token| {
+            if (try p.parseBlock()) |node| {
+                node.cast(Node.Block).?.label = token;
+                return node;
+            }
+        }
 
-    const node = (try parseContainerDeclAuto(arena, it, tree)) orelse {
-        if (layout_token) |token|
-            putBackToken(it, token);
-        return null;
-    };
-    node.cast(Node.ContainerDecl).?.*.layout_token = layout_token;
-    return node;
-}
-
-/// ErrorSetDecl <- KEYWORD_error LBRACE IdentifierList RBRACE
-fn parseErrorSetDecl(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const error_token = eatToken(it, .Keyword_error) orelse return null;
-    if (eatToken(it, .LBrace) == null) {
-        // Might parse as `KEYWORD_error DOT IDENTIFIER` later in PrimaryTypeExpr, so don't error
-        putBackToken(it, error_token);
-        return null;
-    }
-    const decls = try parseErrorTagList(arena, it, tree);
-    const rbrace = try expectToken(it, tree, .RBrace);
-
-    const node = try arena.create(Node.ErrorSetDecl);
-    node.* = .{
-        .error_token = error_token,
-        .decls = decls,
-        .rbrace_token = rbrace,
-    };
-    return &node.base;
-}
-
-/// GroupedExpr <- LPAREN Expr RPAREN
-fn parseGroupedExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const lparen = eatToken(it, .LParen) orelse return null;
-    const expr = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    const rparen = try expectToken(it, tree, .RParen);
-
-    const node = try arena.create(Node.GroupedExpression);
-    node.* = .{
-        .lparen = lparen,
-        .expr = expr,
-        .rparen = rparen,
-    };
-    return &node.base;
-}
-
-/// IfTypeExpr <- IfPrefix TypeExpr (KEYWORD_else Payload? TypeExpr)?
-fn parseIfTypeExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    return parseIf(arena, it, tree, parseTypeExpr);
-}
-
-/// LabeledTypeExpr
-///     <- BlockLabel Block
-///      / BlockLabel? LoopTypeExpr
-fn parseLabeledTypeExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    var colon: TokenIndex = undefined;
-    const label = parseBlockLabel(arena, it, tree, &colon);
-
-    if (label) |token| {
-        if (try parseBlock(arena, it, tree)) |node| {
-            node.cast(Node.Block).?.label = token;
+        if (try p.parseLoopTypeExpr()) |node| {
+            switch (node.id) {
+                .For => node.cast(Node.For).?.label = label,
+                .While => node.cast(Node.While).?.label = label,
+                else => unreachable,
+            }
             return node;
         }
-    }
 
-    if (try parseLoopTypeExpr(arena, it, tree)) |node| {
-        switch (node.id) {
-            .For => node.cast(Node.For).?.label = label,
-            .While => node.cast(Node.While).?.label = label,
-            else => unreachable,
+        if (label) |token| {
+            p.putBackToken(colon);
+            p.putBackToken(token);
         }
-        return node;
+        return null;
     }
 
-    if (label) |token| {
-        putBackToken(it, colon);
-        putBackToken(it, token);
-    }
-    return null;
-}
+    /// LoopTypeExpr <- KEYWORD_inline? (ForTypeExpr / WhileTypeExpr)
+    fn parseLoopTypeExpr(p: *Parser) !?*Node {
+        const inline_token = p.eatToken(.Keyword_inline);
 
-/// LoopTypeExpr <- KEYWORD_inline? (ForTypeExpr / WhileTypeExpr)
-fn parseLoopTypeExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const inline_token = eatToken(it, .Keyword_inline);
-
-    if (try parseForTypeExpr(arena, it, tree)) |node| {
-        node.cast(Node.For).?.inline_token = inline_token;
-        return node;
-    }
-
-    if (try parseWhileTypeExpr(arena, it, tree)) |node| {
-        node.cast(Node.While).?.inline_token = inline_token;
-        return node;
-    }
-
-    if (inline_token == null) return null;
-
-    // If we've seen "inline", there should have been a "for" or "while"
-    try tree.errors.push(.{
-        .ExpectedInlinable = .{ .token = it.index },
-    });
-    return error.ParseError;
-}
-
-/// ForTypeExpr <- ForPrefix TypeExpr (KEYWORD_else TypeExpr)?
-fn parseForTypeExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const node = (try parseForPrefix(arena, it, tree)) orelse return null;
-    const for_prefix = node.cast(Node.For).?;
-
-    const type_expr = try expectNode(arena, it, tree, parseTypeExpr, .{
-        .ExpectedTypeExpr = .{ .token = it.index },
-    });
-    for_prefix.body = type_expr;
-
-    if (eatToken(it, .Keyword_else)) |else_token| {
-        const else_expr = try expectNode(arena, it, tree, parseTypeExpr, .{
-            .ExpectedTypeExpr = .{ .token = it.index },
-        });
-
-        const else_node = try arena.create(Node.Else);
-        else_node.* = .{
-            .else_token = else_token,
-            .payload = null,
-            .body = else_expr,
-        };
-
-        for_prefix.@"else" = else_node;
-    }
-
-    return node;
-}
-
-/// WhileTypeExpr <- WhilePrefix TypeExpr (KEYWORD_else Payload? TypeExpr)?
-fn parseWhileTypeExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const node = (try parseWhilePrefix(arena, it, tree)) orelse return null;
-    const while_prefix = node.cast(Node.While).?;
-
-    const type_expr = try expectNode(arena, it, tree, parseTypeExpr, .{
-        .ExpectedTypeExpr = .{ .token = it.index },
-    });
-    while_prefix.body = type_expr;
-
-    if (eatToken(it, .Keyword_else)) |else_token| {
-        const payload = try parsePayload(arena, it, tree);
-
-        const else_expr = try expectNode(arena, it, tree, parseTypeExpr, .{
-            .ExpectedTypeExpr = .{ .token = it.index },
-        });
-
-        const else_node = try arena.create(Node.Else);
-        else_node.* = .{
-            .else_token = else_token,
-            .payload = null,
-            .body = else_expr,
-        };
-
-        while_prefix.@"else" = else_node;
-    }
-
-    return node;
-}
-
-/// SwitchExpr <- KEYWORD_switch LPAREN Expr RPAREN LBRACE SwitchProngList RBRACE
-fn parseSwitchExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const switch_token = eatToken(it, .Keyword_switch) orelse return null;
-    _ = try expectToken(it, tree, .LParen);
-    const expr_node = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    _ = try expectToken(it, tree, .RParen);
-    _ = try expectToken(it, tree, .LBrace);
-    const cases = try parseSwitchProngList(arena, it, tree);
-    const rbrace = try expectToken(it, tree, .RBrace);
-
-    const node = try arena.create(Node.Switch);
-    node.* = .{
-        .switch_token = switch_token,
-        .expr = expr_node,
-        .cases = cases,
-        .rbrace = rbrace,
-    };
-    return &node.base;
-}
-
-/// AsmExpr <- KEYWORD_asm KEYWORD_volatile? LPAREN Expr AsmOutput? RPAREN
-fn parseAsmExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const asm_token = eatToken(it, .Keyword_asm) orelse return null;
-    const volatile_token = eatToken(it, .Keyword_volatile);
-    _ = try expectToken(it, tree, .LParen);
-    const template = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-
-    const node = try arena.create(Node.Asm);
-    node.* = .{
-        .asm_token = asm_token,
-        .volatile_token = volatile_token,
-        .template = template,
-        .outputs = Node.Asm.OutputList.init(arena),
-        .inputs = Node.Asm.InputList.init(arena),
-        .clobbers = Node.Asm.ClobberList.init(arena),
-        .rparen = undefined,
-    };
-
-    try parseAsmOutput(arena, it, tree, node);
-    node.rparen = try expectToken(it, tree, .RParen);
-    return &node.base;
-}
-
-/// DOT IDENTIFIER
-fn parseAnonLiteral(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const dot = eatToken(it, .Period) orelse return null;
-
-    // anon enum literal
-    if (eatToken(it, .Identifier)) |name| {
-        const node = try arena.create(Node.EnumLiteral);
-        node.* = .{
-            .dot = dot,
-            .name = name,
-        };
-        return &node.base;
-    }
-
-    // anon container literal
-    if (try parseInitList(arena, it, tree)) |node| {
-        node.lhs = .{ .dot = dot };
-        return &node.base;
-    }
-
-    putBackToken(it, dot);
-    return null;
-}
-
-/// AsmOutput <- COLON AsmOutputList AsmInput?
-fn parseAsmOutput(arena: *Allocator, it: *TokenIterator, tree: *Tree, asm_node: *Node.Asm) !void {
-    if (eatToken(it, .Colon) == null) return;
-    asm_node.outputs = try parseAsmOutputList(arena, it, tree);
-    try parseAsmInput(arena, it, tree, asm_node);
-}
-
-/// AsmOutputItem <- LBRACKET IDENTIFIER RBRACKET STRINGLITERAL LPAREN (MINUSRARROW TypeExpr / IDENTIFIER) RPAREN
-fn parseAsmOutputItem(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node.AsmOutput {
-    const lbracket = eatToken(it, .LBracket) orelse return null;
-    const name = try expectNode(arena, it, tree, parseIdentifier, .{
-        .ExpectedIdentifier = .{ .token = it.index },
-    });
-    _ = try expectToken(it, tree, .RBracket);
-
-    const constraint = try expectNode(arena, it, tree, parseStringLiteral, .{
-        .ExpectedStringLiteral = .{ .token = it.index },
-    });
-
-    _ = try expectToken(it, tree, .LParen);
-    const kind: Node.AsmOutput.Kind = blk: {
-        if (eatToken(it, .Arrow) != null) {
-            const return_ident = try expectNode(arena, it, tree, parseTypeExpr, .{
-                .ExpectedTypeExpr = .{ .token = it.index },
-            });
-            break :blk .{ .Return = return_ident };
+        if (try p.parseForTypeExpr()) |node| {
+            node.cast(Node.For).?.inline_token = inline_token;
+            return node;
         }
-        const variable = try expectNode(arena, it, tree, parseIdentifier, .{
-            .ExpectedIdentifier = .{ .token = it.index },
-        });
-        break :blk .{ .Variable = variable.cast(Node.Identifier).? };
-    };
-    const rparen = try expectToken(it, tree, .RParen);
 
-    const node = try arena.create(Node.AsmOutput);
-    node.* = .{
-        .lbracket = lbracket,
-        .symbolic_name = name,
-        .constraint = constraint,
-        .kind = kind,
-        .rparen = rparen,
-    };
-    return node;
-}
+        if (try p.parseWhileTypeExpr()) |node| {
+            node.cast(Node.While).?.inline_token = inline_token;
+            return node;
+        }
 
-/// AsmInput <- COLON AsmInputList AsmClobbers?
-fn parseAsmInput(arena: *Allocator, it: *TokenIterator, tree: *Tree, asm_node: *Node.Asm) !void {
-    if (eatToken(it, .Colon) == null) return;
-    asm_node.inputs = try parseAsmInputList(arena, it, tree);
-    try parseAsmClobbers(arena, it, tree, asm_node);
-}
+        if (inline_token == null) return null;
 
-/// AsmInputItem <- LBRACKET IDENTIFIER RBRACKET STRINGLITERAL LPAREN Expr RPAREN
-fn parseAsmInputItem(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node.AsmInput {
-    const lbracket = eatToken(it, .LBracket) orelse return null;
-    const name = try expectNode(arena, it, tree, parseIdentifier, .{
-        .ExpectedIdentifier = .{ .token = it.index },
-    });
-    _ = try expectToken(it, tree, .RBracket);
-
-    const constraint = try expectNode(arena, it, tree, parseStringLiteral, .{
-        .ExpectedStringLiteral = .{ .token = it.index },
-    });
-
-    _ = try expectToken(it, tree, .LParen);
-    const expr = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    const rparen = try expectToken(it, tree, .RParen);
-
-    const node = try arena.create(Node.AsmInput);
-    node.* = .{
-        .lbracket = lbracket,
-        .symbolic_name = name,
-        .constraint = constraint,
-        .expr = expr,
-        .rparen = rparen,
-    };
-    return node;
-}
-
-/// AsmClobbers <- COLON StringList
-/// StringList <- (STRINGLITERAL COMMA)* STRINGLITERAL?
-fn parseAsmClobbers(arena: *Allocator, it: *TokenIterator, tree: *Tree, asm_node: *Node.Asm) !void {
-    if (eatToken(it, .Colon) == null) return;
-    asm_node.clobbers = try ListParseFn(
-        Node.Asm.ClobberList,
-        parseStringLiteral,
-    )(arena, it, tree);
-}
-
-/// BreakLabel <- COLON IDENTIFIER
-fn parseBreakLabel(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    _ = eatToken(it, .Colon) orelse return null;
-    return try expectNode(arena, it, tree, parseIdentifier, .{
-        .ExpectedIdentifier = .{ .token = it.index },
-    });
-}
-
-/// BlockLabel <- IDENTIFIER COLON
-fn parseBlockLabel(arena: *Allocator, it: *TokenIterator, tree: *Tree, colon_token: *TokenIndex) ?TokenIndex {
-    const identifier = eatToken(it, .Identifier) orelse return null;
-    if (eatToken(it, .Colon)) |colon| {
-        colon_token.* = colon;
-        return identifier;
-    }
-    putBackToken(it, identifier);
-    return null;
-}
-
-/// FieldInit <- DOT IDENTIFIER EQUAL Expr
-fn parseFieldInit(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const period_token = eatToken(it, .Period) orelse return null;
-    const name_token = eatToken(it, .Identifier) orelse {
-        // Because of anon literals `.{` is also valid.
-        putBackToken(it, period_token);
-        return null;
-    };
-    const eq_token = eatToken(it, .Equal) orelse {
-        // `.Name` may also be an enum literal, which is a later rule.
-        putBackToken(it, name_token);
-        putBackToken(it, period_token);
-        return null;
-    };
-    const expr_node = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-
-    const node = try arena.create(Node.FieldInitializer);
-    node.* = .{
-        .period_token = period_token,
-        .name_token = name_token,
-        .expr = expr_node,
-    };
-    return &node.base;
-}
-
-/// WhileContinueExpr <- COLON LPAREN AssignExpr RPAREN
-fn parseWhileContinueExpr(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    _ = eatToken(it, .Colon) orelse return null;
-    _ = try expectToken(it, tree, .LParen);
-    const node = try expectNode(arena, it, tree, parseAssignExpr, .{
-        .ExpectedExprOrAssignment = .{ .token = it.index },
-    });
-    _ = try expectToken(it, tree, .RParen);
-    return node;
-}
-
-/// LinkSection <- KEYWORD_linksection LPAREN Expr RPAREN
-fn parseLinkSection(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    _ = eatToken(it, .Keyword_linksection) orelse return null;
-    _ = try expectToken(it, tree, .LParen);
-    const expr_node = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    _ = try expectToken(it, tree, .RParen);
-    return expr_node;
-}
-
-/// CallConv <- KEYWORD_callconv LPAREN Expr RPAREN
-fn parseCallconv(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    _ = eatToken(it, .Keyword_callconv) orelse return null;
-    _ = try expectToken(it, tree, .LParen);
-    const expr_node = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    _ = try expectToken(it, tree, .RParen);
-    return expr_node;
-}
-
-/// ParamDecl <- (KEYWORD_noalias / KEYWORD_comptime)? (IDENTIFIER COLON)? ParamType
-fn parseParamDecl(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const doc_comments = try parseDocComment(arena, it, tree);
-    const noalias_token = eatToken(it, .Keyword_noalias);
-    const comptime_token = if (noalias_token == null) eatToken(it, .Keyword_comptime) else null;
-    const name_token = blk: {
-        const identifier = eatToken(it, .Identifier) orelse break :blk null;
-        if (eatToken(it, .Colon) != null) break :blk identifier;
-        putBackToken(it, identifier); // ParamType may also be an identifier
-        break :blk null;
-    };
-    const param_type = (try parseParamType(arena, it, tree)) orelse {
-        // Only return cleanly if no keyword, identifier, or doc comment was found
-        if (noalias_token == null and
-            comptime_token == null and
-            name_token == null and
-            doc_comments == null) return null;
-        try tree.errors.push(.{
-            .ExpectedParamType = .{ .token = it.index },
+        // If we've seen "inline", there should have been a "for" or "while"
+        try p.errors.append(p.gpa, .{
+            .ExpectedInlinable = .{ .token = p.tok_i },
         });
         return error.ParseError;
-    };
+    }
 
-    const param_decl = try arena.create(Node.ParamDecl);
-    param_decl.* = .{
-        .doc_comments = doc_comments,
-        .comptime_token = comptime_token,
-        .noalias_token = noalias_token,
-        .name_token = name_token,
-        .param_type = param_type,
-    };
-    return &param_decl.base;
-}
+    /// ForTypeExpr <- ForPrefix TypeExpr (KEYWORD_else TypeExpr)?
+    fn parseForTypeExpr(p: *Parser) !?*Node {
+        const node = (try p.parseForPrefix()) orelse return null;
+        const for_prefix = node.cast(Node.For).?;
 
-/// ParamType
-///     <- KEYWORD_var
-///      / DOT3
-///      / TypeExpr
-fn parseParamType(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?Node.ParamDecl.ParamType {
-    // TODO cast from tuple to error union is broken
-    const P = Node.ParamDecl.ParamType;
-    if (try parseVarType(arena, it, tree)) |node| return P{ .var_type = node };
-    if (eatToken(it, .Ellipsis3)) |token| return P{ .var_args = token };
-    if (try parseTypeExpr(arena, it, tree)) |node| return P{ .type_expr = node };
-    return null;
-}
-
-/// IfPrefix <- KEYWORD_if LPAREN Expr RPAREN PtrPayload?
-fn parseIfPrefix(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const if_token = eatToken(it, .Keyword_if) orelse return null;
-    _ = try expectToken(it, tree, .LParen);
-    const condition = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    _ = try expectToken(it, tree, .RParen);
-    const payload = try parsePtrPayload(arena, it, tree);
-
-    const node = try arena.create(Node.If);
-    node.* = .{
-        .if_token = if_token,
-        .condition = condition,
-        .payload = payload,
-        .body = undefined, // set by caller
-        .@"else" = null,
-    };
-    return &node.base;
-}
-
-/// WhilePrefix <- KEYWORD_while LPAREN Expr RPAREN PtrPayload? WhileContinueExpr?
-fn parseWhilePrefix(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const while_token = eatToken(it, .Keyword_while) orelse return null;
-
-    _ = try expectToken(it, tree, .LParen);
-    const condition = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    _ = try expectToken(it, tree, .RParen);
-
-    const payload = try parsePtrPayload(arena, it, tree);
-    const continue_expr = try parseWhileContinueExpr(arena, it, tree);
-
-    const node = try arena.create(Node.While);
-    node.* = .{
-        .label = null,
-        .inline_token = null,
-        .while_token = while_token,
-        .condition = condition,
-        .payload = payload,
-        .continue_expr = continue_expr,
-        .body = undefined, // set by caller
-        .@"else" = null,
-    };
-    return &node.base;
-}
-
-/// ForPrefix <- KEYWORD_for LPAREN Expr RPAREN PtrIndexPayload
-fn parseForPrefix(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const for_token = eatToken(it, .Keyword_for) orelse return null;
-
-    _ = try expectToken(it, tree, .LParen);
-    const array_expr = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    _ = try expectToken(it, tree, .RParen);
-
-    const payload = try expectNode(arena, it, tree, parsePtrIndexPayload, .{
-        .ExpectedPayload = .{ .token = it.index },
-    });
-
-    const node = try arena.create(Node.For);
-    node.* = .{
-        .label = null,
-        .inline_token = null,
-        .for_token = for_token,
-        .array_expr = array_expr,
-        .payload = payload,
-        .body = undefined, // set by caller
-        .@"else" = null,
-    };
-    return &node.base;
-}
-
-/// Payload <- PIPE IDENTIFIER PIPE
-fn parsePayload(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const lpipe = eatToken(it, .Pipe) orelse return null;
-    const identifier = try expectNode(arena, it, tree, parseIdentifier, .{
-        .ExpectedIdentifier = .{ .token = it.index },
-    });
-    const rpipe = try expectToken(it, tree, .Pipe);
-
-    const node = try arena.create(Node.Payload);
-    node.* = .{
-        .lpipe = lpipe,
-        .error_symbol = identifier,
-        .rpipe = rpipe,
-    };
-    return &node.base;
-}
-
-/// PtrPayload <- PIPE ASTERISK? IDENTIFIER PIPE
-fn parsePtrPayload(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const lpipe = eatToken(it, .Pipe) orelse return null;
-    const asterisk = eatToken(it, .Asterisk);
-    const identifier = try expectNode(arena, it, tree, parseIdentifier, .{
-        .ExpectedIdentifier = .{ .token = it.index },
-    });
-    const rpipe = try expectToken(it, tree, .Pipe);
-
-    const node = try arena.create(Node.PointerPayload);
-    node.* = .{
-        .lpipe = lpipe,
-        .ptr_token = asterisk,
-        .value_symbol = identifier,
-        .rpipe = rpipe,
-    };
-    return &node.base;
-}
-
-/// PtrIndexPayload <- PIPE ASTERISK? IDENTIFIER (COMMA IDENTIFIER)? PIPE
-fn parsePtrIndexPayload(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const lpipe = eatToken(it, .Pipe) orelse return null;
-    const asterisk = eatToken(it, .Asterisk);
-    const identifier = try expectNode(arena, it, tree, parseIdentifier, .{
-        .ExpectedIdentifier = .{ .token = it.index },
-    });
-
-    const index = if (eatToken(it, .Comma) == null)
-        null
-    else
-        try expectNode(arena, it, tree, parseIdentifier, .{
-            .ExpectedIdentifier = .{ .token = it.index },
+        const type_expr = try p.expectNode(parseTypeExpr, .{
+            .ExpectedTypeExpr = .{ .token = p.tok_i },
         });
+        for_prefix.body = type_expr;
 
-    const rpipe = try expectToken(it, tree, .Pipe);
-
-    const node = try arena.create(Node.PointerIndexPayload);
-    node.* = .{
-        .lpipe = lpipe,
-        .ptr_token = asterisk,
-        .value_symbol = identifier,
-        .index_symbol = index,
-        .rpipe = rpipe,
-    };
-    return &node.base;
-}
-
-/// SwitchProng <- SwitchCase EQUALRARROW PtrPayload? AssignExpr
-fn parseSwitchProng(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const node = (try parseSwitchCase(arena, it, tree)) orelse return null;
-    const arrow = try expectToken(it, tree, .EqualAngleBracketRight);
-    const payload = try parsePtrPayload(arena, it, tree);
-    const expr = try expectNode(arena, it, tree, parseAssignExpr, .{
-        .ExpectedExprOrAssignment = .{ .token = it.index },
-    });
-
-    const switch_case = node.cast(Node.SwitchCase).?;
-    switch_case.arrow_token = arrow;
-    switch_case.payload = payload;
-    switch_case.expr = expr;
-
-    return node;
-}
-
-/// SwitchCase
-///     <- SwitchItem (COMMA SwitchItem)* COMMA?
-///      / KEYWORD_else
-fn parseSwitchCase(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    var list = Node.SwitchCase.ItemList.init(arena);
-
-    if (try parseSwitchItem(arena, it, tree)) |first_item| {
-        try list.push(first_item);
-        while (eatToken(it, .Comma) != null) {
-            const next_item = (try parseSwitchItem(arena, it, tree)) orelse break;
-            try list.push(next_item);
-        }
-    } else if (eatToken(it, .Keyword_else)) |else_token| {
-        const else_node = try arena.create(Node.SwitchElse);
-        else_node.* = .{
-            .token = else_token,
-        };
-        try list.push(&else_node.base);
-    } else return null;
-
-    const node = try arena.create(Node.SwitchCase);
-    node.* = .{
-        .items = list,
-        .arrow_token = undefined, // set by caller
-        .payload = null,
-        .expr = undefined, // set by caller
-    };
-    return &node.base;
-}
-
-/// SwitchItem <- Expr (DOT3 Expr)?
-fn parseSwitchItem(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const expr = (try parseExpr(arena, it, tree)) orelse return null;
-    if (eatToken(it, .Ellipsis3)) |token| {
-        const range_end = try expectNode(arena, it, tree, parseExpr, .{
-            .ExpectedExpr = .{ .token = it.index },
-        });
-
-        const node = try arena.create(Node.InfixOp);
-        node.* = .{
-            .op_token = token,
-            .lhs = expr,
-            .op = .Range,
-            .rhs = range_end,
-        };
-        return &node.base;
-    }
-    return expr;
-}
-
-/// AssignOp
-///     <- ASTERISKEQUAL
-///      / SLASHEQUAL
-///      / PERCENTEQUAL
-///      / PLUSEQUAL
-///      / MINUSEQUAL
-///      / LARROW2EQUAL
-///      / RARROW2EQUAL
-///      / AMPERSANDEQUAL
-///      / CARETEQUAL
-///      / PIPEEQUAL
-///      / ASTERISKPERCENTEQUAL
-///      / PLUSPERCENTEQUAL
-///      / MINUSPERCENTEQUAL
-///      / EQUAL
-fn parseAssignOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = nextToken(it);
-    const op: Node.InfixOp.Op = switch (token.ptr.id) {
-        .AsteriskEqual => .AssignMul,
-        .SlashEqual => .AssignDiv,
-        .PercentEqual => .AssignMod,
-        .PlusEqual => .AssignAdd,
-        .MinusEqual => .AssignSub,
-        .AngleBracketAngleBracketLeftEqual => .AssignBitShiftLeft,
-        .AngleBracketAngleBracketRightEqual => .AssignBitShiftRight,
-        .AmpersandEqual => .AssignBitAnd,
-        .CaretEqual => .AssignBitXor,
-        .PipeEqual => .AssignBitOr,
-        .AsteriskPercentEqual => .AssignMulWrap,
-        .PlusPercentEqual => .AssignAddWrap,
-        .MinusPercentEqual => .AssignSubWrap,
-        .Equal => .Assign,
-        else => {
-            putBackToken(it, token.index);
-            return null;
-        },
-    };
-
-    const node = try arena.create(Node.InfixOp);
-    node.* = .{
-        .op_token = token.index,
-        .lhs = undefined, // set by caller
-        .op = op,
-        .rhs = undefined, // set by caller
-    };
-    return &node.base;
-}
-
-/// CompareOp
-///     <- EQUALEQUAL
-///      / EXCLAMATIONMARKEQUAL
-///      / LARROW
-///      / RARROW
-///      / LARROWEQUAL
-///      / RARROWEQUAL
-fn parseCompareOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = nextToken(it);
-    const op: Node.InfixOp.Op = switch (token.ptr.id) {
-        .EqualEqual => .EqualEqual,
-        .BangEqual => .BangEqual,
-        .AngleBracketLeft => .LessThan,
-        .AngleBracketRight => .GreaterThan,
-        .AngleBracketLeftEqual => .LessOrEqual,
-        .AngleBracketRightEqual => .GreaterOrEqual,
-        else => {
-            putBackToken(it, token.index);
-            return null;
-        },
-    };
-
-    return try createInfixOp(arena, token.index, op);
-}
-
-/// BitwiseOp
-///     <- AMPERSAND
-///      / CARET
-///      / PIPE
-///      / KEYWORD_orelse
-///      / KEYWORD_catch Payload?
-fn parseBitwiseOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = nextToken(it);
-    const op: Node.InfixOp.Op = switch (token.ptr.id) {
-        .Ampersand => .BitAnd,
-        .Caret => .BitXor,
-        .Pipe => .BitOr,
-        .Keyword_orelse => .UnwrapOptional,
-        .Keyword_catch => .{ .Catch = try parsePayload(arena, it, tree) },
-        else => {
-            putBackToken(it, token.index);
-            return null;
-        },
-    };
-
-    return try createInfixOp(arena, token.index, op);
-}
-
-/// BitShiftOp
-///     <- LARROW2
-///      / RARROW2
-fn parseBitShiftOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = nextToken(it);
-    const op: Node.InfixOp.Op = switch (token.ptr.id) {
-        .AngleBracketAngleBracketLeft => .BitShiftLeft,
-        .AngleBracketAngleBracketRight => .BitShiftRight,
-        else => {
-            putBackToken(it, token.index);
-            return null;
-        },
-    };
-
-    return try createInfixOp(arena, token.index, op);
-}
-
-/// AdditionOp
-///     <- PLUS
-///      / MINUS
-///      / PLUS2
-///      / PLUSPERCENT
-///      / MINUSPERCENT
-fn parseAdditionOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = nextToken(it);
-    const op: Node.InfixOp.Op = switch (token.ptr.id) {
-        .Plus => .Add,
-        .Minus => .Sub,
-        .PlusPlus => .ArrayCat,
-        .PlusPercent => .AddWrap,
-        .MinusPercent => .SubWrap,
-        else => {
-            putBackToken(it, token.index);
-            return null;
-        },
-    };
-
-    return try createInfixOp(arena, token.index, op);
-}
-
-/// MultiplyOp
-///     <- PIPE2
-///      / ASTERISK
-///      / SLASH
-///      / PERCENT
-///      / ASTERISK2
-///      / ASTERISKPERCENT
-fn parseMultiplyOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = nextToken(it);
-    const op: Node.InfixOp.Op = switch (token.ptr.id) {
-        .PipePipe => .MergeErrorSets,
-        .Asterisk => .Mul,
-        .Slash => .Div,
-        .Percent => .Mod,
-        .AsteriskAsterisk => .ArrayMult,
-        .AsteriskPercent => .MulWrap,
-        else => {
-            putBackToken(it, token.index);
-            return null;
-        },
-    };
-
-    return try createInfixOp(arena, token.index, op);
-}
-
-/// PrefixOp
-///     <- EXCLAMATIONMARK
-///      / MINUS
-///      / TILDE
-///      / MINUSPERCENT
-///      / AMPERSAND
-///      / KEYWORD_try
-///      / KEYWORD_await
-fn parsePrefixOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = nextToken(it);
-    const op: Node.PrefixOp.Op = switch (token.ptr.id) {
-        .Bang => .BoolNot,
-        .Minus => .Negation,
-        .Tilde => .BitNot,
-        .MinusPercent => .NegationWrap,
-        .Ampersand => .AddressOf,
-        .Keyword_try => .Try,
-        .Keyword_await => .Await,
-        else => {
-            putBackToken(it, token.index);
-            return null;
-        },
-    };
-
-    const node = try arena.create(Node.PrefixOp);
-    node.* = .{
-        .op_token = token.index,
-        .op = op,
-        .rhs = undefined, // set by caller
-    };
-    return &node.base;
-}
-
-// TODO: ArrayTypeStart is either an array or a slice, but const/allowzero only work on
-//       pointers. Consider updating this rule:
-//       ...
-//       / ArrayTypeStart
-//       / SliceTypeStart (ByteAlign / KEYWORD_const / KEYWORD_volatile / KEYWORD_allowzero)*
-//       / PtrTypeStart ...
-
-/// PrefixTypeOp
-///     <- QUESTIONMARK
-///      / KEYWORD_anyframe MINUSRARROW
-///      / ArrayTypeStart (ByteAlign / KEYWORD_const / KEYWORD_volatile / KEYWORD_allowzero)*
-///      / PtrTypeStart (KEYWORD_align LPAREN Expr (COLON INTEGER COLON INTEGER)? RPAREN / KEYWORD_const / KEYWORD_volatile / KEYWORD_allowzero)*
-fn parsePrefixTypeOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    if (eatToken(it, .QuestionMark)) |token| {
-        const node = try arena.create(Node.PrefixOp);
-        node.* = .{
-            .op_token = token,
-            .op = .OptionalType,
-            .rhs = undefined, // set by caller
-        };
-        return &node.base;
-    }
-
-    // TODO: Returning a AnyFrameType instead of PrefixOp makes casting and setting .rhs or
-    //       .return_type more difficult for the caller (see parsePrefixOpExpr helper).
-    //       Consider making the AnyFrameType a member of PrefixOp and add a
-    //       PrefixOp.AnyFrameType variant?
-    if (eatToken(it, .Keyword_anyframe)) |token| {
-        const arrow = eatToken(it, .Arrow) orelse {
-            putBackToken(it, token);
-            return null;
-        };
-        const node = try arena.create(Node.AnyFrameType);
-        node.* = .{
-            .anyframe_token = token,
-            .result = .{
-                .arrow_token = arrow,
-                .return_type = undefined, // set by caller
-            },
-        };
-        return &node.base;
-    }
-
-    if (try parsePtrTypeStart(arena, it, tree)) |node| {
-        // If the token encountered was **, there will be two nodes instead of one.
-        // The attributes should be applied to the rightmost operator.
-        const prefix_op = node.cast(Node.PrefixOp).?;
-        var ptr_info = if (tree.tokens.at(prefix_op.op_token).id == .AsteriskAsterisk)
-            &prefix_op.rhs.cast(Node.PrefixOp).?.op.PtrType
-        else
-            &prefix_op.op.PtrType;
-
-        while (true) {
-            if (eatToken(it, .Keyword_align)) |align_token| {
-                const lparen = try expectToken(it, tree, .LParen);
-                const expr_node = try expectNode(arena, it, tree, parseExpr, .{
-                    .ExpectedExpr = .{ .token = it.index },
-                });
-
-                // Optional bit range
-                const bit_range = if (eatToken(it, .Colon)) |_| bit_range_value: {
-                    const range_start = try expectNode(arena, it, tree, parseIntegerLiteral, .{
-                        .ExpectedIntegerLiteral = .{ .token = it.index },
-                    });
-                    _ = try expectToken(it, tree, .Colon);
-                    const range_end = try expectNode(arena, it, tree, parseIntegerLiteral, .{
-                        .ExpectedIntegerLiteral = .{ .token = it.index },
-                    });
-
-                    break :bit_range_value Node.PrefixOp.PtrInfo.Align.BitRange{
-                        .start = range_start,
-                        .end = range_end,
-                    };
-                } else null;
-                _ = try expectToken(it, tree, .RParen);
-
-                if (ptr_info.align_info != null) {
-                    try tree.errors.push(.{
-                        .ExtraAlignQualifier = .{ .token = it.index - 1 },
-                    });
-                    continue;
-                }
-
-                ptr_info.align_info = Node.PrefixOp.PtrInfo.Align{
-                    .node = expr_node,
-                    .bit_range = bit_range,
-                };
-
-                continue;
-            }
-            if (eatToken(it, .Keyword_const)) |const_token| {
-                if (ptr_info.const_token != null) {
-                    try tree.errors.push(.{
-                        .ExtraConstQualifier = .{ .token = it.index - 1 },
-                    });
-                    continue;
-                }
-                ptr_info.const_token = const_token;
-                continue;
-            }
-            if (eatToken(it, .Keyword_volatile)) |volatile_token| {
-                if (ptr_info.volatile_token != null) {
-                    try tree.errors.push(.{
-                        .ExtraVolatileQualifier = .{ .token = it.index - 1 },
-                    });
-                    continue;
-                }
-                ptr_info.volatile_token = volatile_token;
-                continue;
-            }
-            if (eatToken(it, .Keyword_allowzero)) |allowzero_token| {
-                if (ptr_info.allowzero_token != null) {
-                    try tree.errors.push(.{
-                        .ExtraAllowZeroQualifier = .{ .token = it.index - 1 },
-                    });
-                    continue;
-                }
-                ptr_info.allowzero_token = allowzero_token;
-                continue;
-            }
-            break;
-        }
-
-        return node;
-    }
-
-    if (try parseArrayTypeStart(arena, it, tree)) |node| {
-        switch (node.cast(Node.PrefixOp).?.op) {
-            .ArrayType => {},
-            .SliceType => |*slice_type| {
-                // Collect pointer qualifiers in any order, but disallow duplicates
-                while (true) {
-                    if (try parseByteAlign(arena, it, tree)) |align_expr| {
-                        if (slice_type.align_info != null) {
-                            try tree.errors.push(.{
-                                .ExtraAlignQualifier = .{ .token = it.index - 1 },
-                            });
-                            continue;
-                        }
-                        slice_type.align_info = Node.PrefixOp.PtrInfo.Align{
-                            .node = align_expr,
-                            .bit_range = null,
-                        };
-                        continue;
-                    }
-                    if (eatToken(it, .Keyword_const)) |const_token| {
-                        if (slice_type.const_token != null) {
-                            try tree.errors.push(.{
-                                .ExtraConstQualifier = .{ .token = it.index - 1 },
-                            });
-                            continue;
-                        }
-                        slice_type.const_token = const_token;
-                        continue;
-                    }
-                    if (eatToken(it, .Keyword_volatile)) |volatile_token| {
-                        if (slice_type.volatile_token != null) {
-                            try tree.errors.push(.{
-                                .ExtraVolatileQualifier = .{ .token = it.index - 1 },
-                            });
-                            continue;
-                        }
-                        slice_type.volatile_token = volatile_token;
-                        continue;
-                    }
-                    if (eatToken(it, .Keyword_allowzero)) |allowzero_token| {
-                        if (slice_type.allowzero_token != null) {
-                            try tree.errors.push(.{
-                                .ExtraAllowZeroQualifier = .{ .token = it.index - 1 },
-                            });
-                            continue;
-                        }
-                        slice_type.allowzero_token = allowzero_token;
-                        continue;
-                    }
-                    break;
-                }
-            },
-            else => unreachable,
-        }
-        return node;
-    }
-
-    return null;
-}
-
-/// SuffixOp
-///     <- LBRACKET Expr (DOT2 (Expr (COLON Expr)?)?)? RBRACKET
-///      / DOT IDENTIFIER
-///      / DOTASTERISK
-///      / DOTQUESTIONMARK
-fn parseSuffixOp(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const OpAndToken = struct {
-        op: Node.SuffixOp.Op,
-        token: TokenIndex,
-    };
-    const op_and_token: OpAndToken = blk: {
-        if (eatToken(it, .LBracket)) |_| {
-            const index_expr = try expectNode(arena, it, tree, parseExpr, .{
-                .ExpectedExpr = .{ .token = it.index },
+        if (p.eatToken(.Keyword_else)) |else_token| {
+            const else_expr = try p.expectNode(parseTypeExpr, .{
+                .ExpectedTypeExpr = .{ .token = p.tok_i },
             });
 
-            if (eatToken(it, .Ellipsis2) != null) {
-                const end_expr = try parseExpr(arena, it, tree);
-                const sentinel: ?*ast.Node = if (eatToken(it, .Colon) != null)
-                    try parseExpr(arena, it, tree)
-                else
-                    null;
-                break :blk .{
-                    .op = .{
-                        .Slice = .{
-                            .start = index_expr,
-                            .end = end_expr,
-                            .sentinel = sentinel,
-                        },
-                    },
-                    .token = try expectToken(it, tree, .RBracket),
-                };
-            }
-
-            break :blk .{
-                .op = .{ .ArrayAccess = index_expr },
-                .token = try expectToken(it, tree, .RBracket),
+            const else_node = try p.arena.allocator.create(Node.Else);
+            else_node.* = .{
+                .else_token = else_token,
+                .payload = null,
+                .body = else_expr,
             };
+
+            for_prefix.@"else" = else_node;
         }
 
-        if (eatToken(it, .PeriodAsterisk)) |period_asterisk| {
-            break :blk .{ .op = .Deref, .token = period_asterisk };
-        }
+        return node;
+    }
 
-        if (eatToken(it, .Period)) |period| {
-            if (try parseIdentifier(arena, it, tree)) |identifier| {
-                // TODO: It's a bit weird to return an InfixOp from the SuffixOp parser.
-                // Should there be an ast.Node.SuffixOp.FieldAccess variant? Or should
-                // this grammar rule be altered?
-                const node = try arena.create(Node.InfixOp);
-                node.* = .{
-                    .op_token = period,
-                    .lhs = undefined, // set by caller
-                    .op = .Period,
-                    .rhs = identifier,
-                };
-                return &node.base;
-            }
-            if (eatToken(it, .QuestionMark)) |question_mark| {
-                break :blk .{ .op = .UnwrapOptional, .token = question_mark };
-            }
-            try tree.errors.push(.{
-                .ExpectedSuffixOp = .{ .token = it.index },
+    /// WhileTypeExpr <- WhilePrefix TypeExpr (KEYWORD_else Payload? TypeExpr)?
+    fn parseWhileTypeExpr(p: *Parser) !?*Node {
+        const node = (try p.parseWhilePrefix()) orelse return null;
+        const while_prefix = node.cast(Node.While).?;
+
+        const type_expr = try p.expectNode(parseTypeExpr, .{
+            .ExpectedTypeExpr = .{ .token = p.tok_i },
+        });
+        while_prefix.body = type_expr;
+
+        if (p.eatToken(.Keyword_else)) |else_token| {
+            const payload = try p.parsePayload();
+
+            const else_expr = try p.expectNode(parseTypeExpr, .{
+                .ExpectedTypeExpr = .{ .token = p.tok_i },
             });
-            return null;
+
+            const else_node = try p.arena.allocator.create(Node.Else);
+            else_node.* = .{
+                .else_token = else_token,
+                .payload = null,
+                .body = else_expr,
+            };
+
+            while_prefix.@"else" = else_node;
         }
 
-        return null;
-    };
+        return node;
+    }
 
-    const node = try arena.create(Node.SuffixOp);
-    node.* = .{
-        .lhs = undefined, // set by caller
-        .op = op_and_token.op,
-        .rtoken = op_and_token.token,
-    };
-    return &node.base;
-}
+    /// SwitchExpr <- KEYWORD_switch LPAREN Expr RPAREN LBRACE SwitchProngList RBRACE
+    fn parseSwitchExpr(p: *Parser) !?*Node {
+        const switch_token = p.eatToken(.Keyword_switch) orelse return null;
+        _ = try p.expectToken(.LParen);
+        const expr_node = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+        _ = try p.expectToken(.RParen);
+        _ = try p.expectToken(.LBrace);
+        const cases = try p.parseSwitchProngList();
+        const rbrace = try p.expectToken(.RBrace);
 
-/// FnCallArguments <- LPAREN ExprList RPAREN
-/// ExprList <- (Expr COMMA)* Expr?
-fn parseFnCallArguments(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?AnnotatedParamList {
-    if (eatToken(it, .LParen) == null) return null;
-    const list = try ListParseFn(Node.FnProto.ParamList, parseExpr)(arena, it, tree);
-    const rparen = try expectToken(it, tree, .RParen);
-    return AnnotatedParamList{ .list = list, .rparen = rparen };
-}
-
-const AnnotatedParamList = struct {
-    list: Node.FnProto.ParamList, // NOTE: may also be any other type SegmentedList(*Node, 2)
-    rparen: TokenIndex,
-};
-
-/// ArrayTypeStart <- LBRACKET Expr? RBRACKET
-fn parseArrayTypeStart(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const lbracket = eatToken(it, .LBracket) orelse return null;
-    const expr = try parseExpr(arena, it, tree);
-    const sentinel = if (eatToken(it, .Colon)) |_|
-        try expectNode(arena, it, tree, parseExpr, .{
-            .ExpectedExpr = .{ .token = it.index },
-        })
-    else
-        null;
-    const rbracket = try expectToken(it, tree, .RBracket);
-
-    const op: Node.PrefixOp.Op = if (expr) |len_expr|
-        .{
-            .ArrayType = .{
-                .len_expr = len_expr,
-                .sentinel = sentinel,
-            },
-        }
-    else
-        .{
-            .SliceType = Node.PrefixOp.PtrInfo{
-                .allowzero_token = null,
-                .align_info = null,
-                .const_token = null,
-                .volatile_token = null,
-                .sentinel = sentinel,
-            },
-        };
-
-    const node = try arena.create(Node.PrefixOp);
-    node.* = .{
-        .op_token = lbracket,
-        .op = op,
-        .rhs = undefined, // set by caller
-    };
-    return &node.base;
-}
-
-/// PtrTypeStart
-///     <- ASTERISK
-///      / ASTERISK2
-///      / PTRUNKNOWN
-///      / PTRC
-fn parsePtrTypeStart(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    if (eatToken(it, .Asterisk)) |asterisk| {
-        const sentinel = if (eatToken(it, .Colon)) |_|
-            try expectNode(arena, it, tree, parseExpr, .{
-                .ExpectedExpr = .{ .token = it.index },
-            })
-        else
-            null;
-        const node = try arena.create(Node.PrefixOp);
+        const node = try p.arena.allocator.create(Node.Switch);
         node.* = .{
-            .op_token = asterisk,
-            .op = .{ .PtrType = .{ .sentinel = sentinel } },
-            .rhs = undefined, // set by caller
+            .switch_token = switch_token,
+            .expr = expr_node,
+            .cases = cases,
+            .rbrace = rbrace,
         };
         return &node.base;
     }
 
-    if (eatToken(it, .AsteriskAsterisk)) |double_asterisk| {
-        const node = try arena.create(Node.PrefixOp);
+    /// AsmExpr <- KEYWORD_asm KEYWORD_volatile? LPAREN Expr AsmOutput? RPAREN
+    fn parseAsmExpr(p: *Parser) !?*Node {
+        const asm_token = p.eatToken(.Keyword_asm) orelse return null;
+        const volatile_token = p.eatToken(.Keyword_volatile);
+        _ = try p.expectToken(.LParen);
+        const template = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+
+        const node = try p.arena.allocator.create(Node.Asm);
         node.* = .{
-            .op_token = double_asterisk,
-            .op = .{ .PtrType = .{} },
-            .rhs = undefined, // set by caller
+            .asm_token = asm_token,
+            .volatile_token = volatile_token,
+            .template = template,
+            .outputs = Node.Asm.OutputList{},
+            .inputs = Node.Asm.InputList{},
+            .clobbers = Node.Asm.ClobberList{},
+            .rparen = undefined,
         };
 
-        // Special case for **, which is its own token
-        const child = try arena.create(Node.PrefixOp);
-        child.* = .{
-            .op_token = double_asterisk,
-            .op = .{ .PtrType = .{} },
-            .rhs = undefined, // set by caller
-        };
-        node.rhs = &child.base;
-
+        try p.parseAsmOutput(node);
+        node.rparen = try p.expectToken(.RParen);
         return &node.base;
     }
-    if (eatToken(it, .LBracket)) |lbracket| {
-        const asterisk = eatToken(it, .Asterisk) orelse {
-            putBackToken(it, lbracket);
-            return null;
-        };
-        if (eatToken(it, .Identifier)) |ident| {
-            if (!std.mem.eql(u8, tree.tokenSlice(ident), "c")) {
-                putBackToken(it, ident);
-            } else {
-                _ = try expectToken(it, tree, .RBracket);
-                const node = try arena.create(Node.PrefixOp);
-                node.* = .{
-                    .op_token = lbracket,
-                    .op = .{ .PtrType = .{} },
-                    .rhs = undefined, // set by caller
-                };
-                return &node.base;
-            }
-        }
-        const sentinel = if (eatToken(it, .Colon)) |_|
-            try expectNode(arena, it, tree, parseExpr, .{
-                .ExpectedExpr = .{ .token = it.index },
-            })
-        else
-            null;
-        _ = try expectToken(it, tree, .RBracket);
-        const node = try arena.create(Node.PrefixOp);
-        node.* = .{
-            .op_token = lbracket,
-            .op = .{ .PtrType = .{ .sentinel = sentinel } },
-            .rhs = undefined, // set by caller
-        };
-        return &node.base;
-    }
-    return null;
-}
 
-/// ContainerDeclAuto <- ContainerDeclType LBRACE ContainerMembers RBRACE
-fn parseContainerDeclAuto(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const node = (try parseContainerDeclType(arena, it, tree)) orelse return null;
-    const lbrace = try expectToken(it, tree, .LBrace);
-    const members = try parseContainerMembers(arena, it, tree, false);
-    const rbrace = try expectToken(it, tree, .RBrace);
+    /// DOT IDENTIFIER
+    fn parseAnonLiteral(p: *Parser) !?*Node {
+        const dot = p.eatToken(.Period) orelse return null;
 
-    const decl_type = node.cast(Node.ContainerDecl).?;
-    decl_type.fields_and_decls = members;
-    decl_type.lbrace_token = lbrace;
-    decl_type.rbrace_token = rbrace;
-
-    return node;
-}
-
-/// ContainerDeclType
-///     <- KEYWORD_struct
-///      / KEYWORD_enum (LPAREN Expr RPAREN)?
-///      / KEYWORD_union (LPAREN (KEYWORD_enum (LPAREN Expr RPAREN)? / Expr) RPAREN)?
-fn parseContainerDeclType(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const kind_token = nextToken(it);
-
-    const init_arg_expr = switch (kind_token.ptr.id) {
-        .Keyword_struct => Node.ContainerDecl.InitArg{ .None = {} },
-        .Keyword_enum => blk: {
-            if (eatToken(it, .LParen) != null) {
-                const expr = try expectNode(arena, it, tree, parseExpr, .{
-                    .ExpectedExpr = .{ .token = it.index },
-                });
-                _ = try expectToken(it, tree, .RParen);
-                break :blk Node.ContainerDecl.InitArg{ .Type = expr };
-            }
-            break :blk Node.ContainerDecl.InitArg{ .None = {} };
-        },
-        .Keyword_union => blk: {
-            if (eatToken(it, .LParen) != null) {
-                if (eatToken(it, .Keyword_enum) != null) {
-                    if (eatToken(it, .LParen) != null) {
-                        const expr = try expectNode(arena, it, tree, parseExpr, .{
-                            .ExpectedExpr = .{ .token = it.index },
-                        });
-                        _ = try expectToken(it, tree, .RParen);
-                        _ = try expectToken(it, tree, .RParen);
-                        break :blk Node.ContainerDecl.InitArg{ .Enum = expr };
-                    }
-                    _ = try expectToken(it, tree, .RParen);
-                    break :blk Node.ContainerDecl.InitArg{ .Enum = null };
-                }
-                const expr = try expectNode(arena, it, tree, parseExpr, .{
-                    .ExpectedExpr = .{ .token = it.index },
-                });
-                _ = try expectToken(it, tree, .RParen);
-                break :blk Node.ContainerDecl.InitArg{ .Type = expr };
-            }
-            break :blk Node.ContainerDecl.InitArg{ .None = {} };
-        },
-        else => {
-            putBackToken(it, kind_token.index);
-            return null;
-        },
-    };
-
-    const node = try arena.create(Node.ContainerDecl);
-    node.* = .{
-        .layout_token = null,
-        .kind_token = kind_token.index,
-        .init_arg_expr = init_arg_expr,
-        .fields_and_decls = undefined, // set by caller
-        .lbrace_token = undefined, // set by caller
-        .rbrace_token = undefined, // set by caller
-    };
-    return &node.base;
-}
-
-/// ByteAlign <- KEYWORD_align LPAREN Expr RPAREN
-fn parseByteAlign(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    _ = eatToken(it, .Keyword_align) orelse return null;
-    _ = try expectToken(it, tree, .LParen);
-    const expr = try expectNode(arena, it, tree, parseExpr, .{
-        .ExpectedExpr = .{ .token = it.index },
-    });
-    _ = try expectToken(it, tree, .RParen);
-    return expr;
-}
-
-/// IdentifierList <- (IDENTIFIER COMMA)* IDENTIFIER?
-/// Only ErrorSetDecl parses an IdentifierList
-fn parseErrorTagList(arena: *Allocator, it: *TokenIterator, tree: *Tree) !Node.ErrorSetDecl.DeclList {
-    return try ListParseFn(Node.ErrorSetDecl.DeclList, parseErrorTag)(arena, it, tree);
-}
-
-/// SwitchProngList <- (SwitchProng COMMA)* SwitchProng?
-fn parseSwitchProngList(arena: *Allocator, it: *TokenIterator, tree: *Tree) !Node.Switch.CaseList {
-    return try ListParseFn(Node.Switch.CaseList, parseSwitchProng)(arena, it, tree);
-}
-
-/// AsmOutputList <- (AsmOutputItem COMMA)* AsmOutputItem?
-fn parseAsmOutputList(arena: *Allocator, it: *TokenIterator, tree: *Tree) Error!Node.Asm.OutputList {
-    return try ListParseFn(Node.Asm.OutputList, parseAsmOutputItem)(arena, it, tree);
-}
-
-/// AsmInputList <- (AsmInputItem COMMA)* AsmInputItem?
-fn parseAsmInputList(arena: *Allocator, it: *TokenIterator, tree: *Tree) Error!Node.Asm.InputList {
-    return try ListParseFn(Node.Asm.InputList, parseAsmInputItem)(arena, it, tree);
-}
-
-/// ParamDeclList <- (ParamDecl COMMA)* ParamDecl?
-fn parseParamDeclList(arena: *Allocator, it: *TokenIterator, tree: *Tree) !Node.FnProto.ParamList {
-    return try ListParseFn(Node.FnProto.ParamList, parseParamDecl)(arena, it, tree);
-}
-
-fn ParseFn(comptime T: type) type {
-    return fn (*Allocator, *TokenIterator, *Tree) Error!T;
-}
-
-const NodeParseFn = fn (*Allocator, *TokenIterator, *Tree) Error!?*Node;
-
-fn ListParseFn(comptime L: type, comptime nodeParseFn: var) ParseFn(L) {
-    return struct {
-        pub fn parse(arena: *Allocator, it: *TokenIterator, tree: *Tree) !L {
-            var list = L.init(arena);
-            while (try nodeParseFn(arena, it, tree)) |node| {
-                try list.push(node);
-
-                switch (it.peek().?.id) {
-                    .Comma => _ = nextToken(it),
-                    // all possible delimiters
-                    .Colon, .RParen, .RBrace, .RBracket => break,
-                    else => {
-                        // this is likely just a missing comma,
-                        // continue parsing this list and give an error
-                        try tree.errors.push(.{
-                            .ExpectedToken = .{ .token = it.index, .expected_id = .Comma },
-                        });
-                    },
-                }
-            }
-            return list;
-        }
-    }.parse;
-}
-
-fn SimpleBinOpParseFn(comptime token: Token.Id, comptime op: Node.InfixOp.Op) NodeParseFn {
-    return struct {
-        pub fn parse(arena: *Allocator, it: *TokenIterator, tree: *Tree) Error!?*Node {
-            const op_token = if (token == .Keyword_and) switch (it.peek().?.id) {
-                .Keyword_and => nextToken(it).index,
-                .Invalid_ampersands => blk: {
-                    try tree.errors.push(.{
-                        .InvalidAnd = .{ .token = it.index },
-                    });
-                    break :blk nextToken(it).index;
-                },
-                else => return null,
-            } else eatToken(it, token) orelse return null;
-
-            const node = try arena.create(Node.InfixOp);
+        // anon enum literal
+        if (p.eatToken(.Identifier)) |name| {
+            const node = try p.arena.allocator.create(Node.EnumLiteral);
             node.* = .{
-                .op_token = op_token,
-                .lhs = undefined, // set by caller
-                .op = op,
+                .dot = dot,
+                .name = name,
+            };
+            return &node.base;
+        }
+
+        // anon container literal
+        if (try p.parseInitList()) |node| {
+            node.lhs = .{ .dot = dot };
+            return &node.base;
+        }
+
+        p.putBackToken(dot);
+        return null;
+    }
+
+    /// AsmOutput <- COLON AsmOutputList AsmInput?
+    fn parseAsmOutput(p: *Parser, asm_node: *Node.Asm) !void {
+        if (p.eatToken(.Colon) == null) return;
+        asm_node.outputs = try p.parseAsmOutputList();
+        try p.parseAsmInput(asm_node);
+    }
+
+    /// AsmOutputItem <- LBRACKET IDENTIFIER RBRACKET STRINGLITERAL LPAREN (MINUSRARROW TypeExpr / IDENTIFIER) RPAREN
+    fn parseAsmOutputItem(p: *Parser) !?*Node.AsmOutput {
+        const lbracket = p.eatToken(.LBracket) orelse return null;
+        const name = try p.expectNode(parseIdentifier, .{
+            .ExpectedIdentifier = .{ .token = p.tok_i },
+        });
+        _ = try p.expectToken(.RBracket);
+
+        const constraint = try p.expectNode(parseStringLiteral, .{
+            .ExpectedStringLiteral = .{ .token = p.tok_i },
+        });
+
+        _ = try p.expectToken(.LParen);
+        const kind: Node.AsmOutput.Kind = blk: {
+            if (p.eatToken(.Arrow) != null) {
+                const return_ident = try p.expectNode(parseTypeExpr, .{
+                    .ExpectedTypeExpr = .{ .token = p.tok_i },
+                });
+                break :blk .{ .Return = return_ident };
+            }
+            const variable = try p.expectNode(parseIdentifier, .{
+                .ExpectedIdentifier = .{ .token = p.tok_i },
+            });
+            break :blk .{ .Variable = variable.cast(Node.Identifier).? };
+        };
+        const rparen = try p.expectToken(.RParen);
+
+        const node = try p.arena.allocator.create(Node.AsmOutput);
+        node.* = .{
+            .lbracket = lbracket,
+            .symbolic_name = name,
+            .constraint = constraint,
+            .kind = kind,
+            .rparen = rparen,
+        };
+        return node;
+    }
+
+    /// AsmInput <- COLON AsmInputList AsmClobbers?
+    fn parseAsmInput(p: *Parser, asm_node: *Node.Asm) !void {
+        if (p.eatToken(.Colon) == null) return;
+        asm_node.inputs = try p.parseAsmInputList();
+        try p.parseAsmClobbers(asm_node);
+    }
+
+    /// AsmInputItem <- LBRACKET IDENTIFIER RBRACKET STRINGLITERAL LPAREN Expr RPAREN
+    fn parseAsmInputItem(p: *Parser) !?*Node.AsmInput {
+        const lbracket = p.eatToken(.LBracket) orelse return null;
+        const name = try p.expectNode(parseIdentifier, .{
+            .ExpectedIdentifier = .{ .token = p.tok_i },
+        });
+        _ = try p.expectToken(.RBracket);
+
+        const constraint = try p.expectNode(parseStringLiteral, .{
+            .ExpectedStringLiteral = .{ .token = p.tok_i },
+        });
+
+        _ = try p.expectToken(.LParen);
+        const expr = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+        const rparen = try p.expectToken(.RParen);
+
+        const node = try p.arena.allocator.create(Node.AsmInput);
+        node.* = .{
+            .lbracket = lbracket,
+            .symbolic_name = name,
+            .constraint = constraint,
+            .expr = expr,
+            .rparen = rparen,
+        };
+        return node;
+    }
+
+    /// AsmClobbers <- COLON StringList
+    /// StringList <- (STRINGLITERAL COMMA)* STRINGLITERAL?
+    fn parseAsmClobbers(p: *Parser, asm_node: *Node.Asm) !void {
+        if (p.eatToken(.Colon) == null) return;
+        asm_node.clobbers = try ListParseFn(
+            Node.Asm.ClobberList,
+            parseStringLiteral,
+        )(p);
+    }
+
+    /// BreakLabel <- COLON IDENTIFIER
+    fn parseBreakLabel(p: *Parser) !?*Node {
+        _ = p.eatToken(.Colon) orelse return null;
+        return p.expectNode(parseIdentifier, .{
+            .ExpectedIdentifier = .{ .token = p.tok_i },
+        });
+    }
+
+    /// BlockLabel <- IDENTIFIER COLON
+    fn parseBlockLabel(p: *Parser, colon_token: *TokenIndex) ?TokenIndex {
+        const identifier = p.eatToken(.Identifier) orelse return null;
+        if (p.eatToken(.Colon)) |colon| {
+            colon_token.* = colon;
+            return identifier;
+        }
+        p.putBackToken(identifier);
+        return null;
+    }
+
+    /// FieldInit <- DOT IDENTIFIER EQUAL Expr
+    fn parseFieldInit(p: *Parser) !?*Node {
+        const period_token = p.eatToken(.Period) orelse return null;
+        const name_token = p.eatToken(.Identifier) orelse {
+            // Because of anon literals `.{` is also valid.
+            p.putBackToken(period_token);
+            return null;
+        };
+        const eq_token = p.eatToken(.Equal) orelse {
+            // `.Name` may also be an enum literal, which is a later rule.
+            p.putBackToken(name_token);
+            p.putBackToken(period_token);
+            return null;
+        };
+        const expr_node = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+
+        const node = try p.arena.allocator.create(Node.FieldInitializer);
+        node.* = .{
+            .period_token = period_token,
+            .name_token = name_token,
+            .expr = expr_node,
+        };
+        return &node.base;
+    }
+
+    /// WhileContinueExpr <- COLON LPAREN AssignExpr RPAREN
+    fn parseWhileContinueExpr(p: *Parser) !?*Node {
+        _ = p.eatToken(.Colon) orelse return null;
+        _ = try p.expectToken(.LParen);
+        const node = try p.expectNode(parseAssignExpr, .{
+            .ExpectedExprOrAssignment = .{ .token = p.tok_i },
+        });
+        _ = try p.expectToken(.RParen);
+        return node;
+    }
+
+    /// LinkSection <- KEYWORD_linksection LPAREN Expr RPAREN
+    fn parseLinkSection(p: *Parser) !?*Node {
+        _ = p.eatToken(.Keyword_linksection) orelse return null;
+        _ = try p.expectToken(.LParen);
+        const expr_node = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+        _ = try p.expectToken(.RParen);
+        return expr_node;
+    }
+
+    /// CallConv <- KEYWORD_callconv LPAREN Expr RPAREN
+    fn parseCallconv(p: *Parser) !?*Node {
+        _ = p.eatToken(.Keyword_callconv) orelse return null;
+        _ = try p.expectToken(.LParen);
+        const expr_node = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+        _ = try p.expectToken(.RParen);
+        return expr_node;
+    }
+
+    /// ParamDecl <- (KEYWORD_noalias / KEYWORD_comptime)? (IDENTIFIER COLON)? ParamType
+    fn parseParamDecl(p: *Parser) !?*Node {
+        const doc_comments = try p.parseDocComment();
+        const noalias_token = p.eatToken(.Keyword_noalias);
+        const comptime_token = if (noalias_token == null) p.eatToken(.Keyword_comptime) else null;
+        const name_token = blk: {
+            const identifier = p.eatToken(.Identifier) orelse break :blk null;
+            if (p.eatToken(.Colon) != null) break :blk identifier;
+            p.putBackToken(identifier); // ParamType may also be an identifier
+            break :blk null;
+        };
+        const param_type = (try p.parseParamType()) orelse {
+            // Only return cleanly if no keyword, identifier, or doc comment was found
+            if (noalias_token == null and
+                comptime_token == null and
+                name_token == null and
+                doc_comments == null) return null;
+            try p.errors.append(p.gpa, .{
+                .ExpectedParamType = .{ .token = p.tok_i },
+            });
+            return error.ParseError;
+        };
+
+        const param_decl = try p.arena.allocator.create(Node.ParamDecl);
+        param_decl.* = .{
+            .doc_comments = doc_comments,
+            .comptime_token = comptime_token,
+            .noalias_token = noalias_token,
+            .name_token = name_token,
+            .param_type = param_type,
+        };
+        return &param_decl.base;
+    }
+
+    /// ParamType
+    ///     <- KEYWORD_var
+    ///      / DOT3
+    ///      / TypeExpr
+    fn parseParamType(p: *Parser) !?Node.ParamDecl.ParamType {
+        // TODO cast from tuple to error union is broken
+        const P = Node.ParamDecl.ParamType;
+        if (try p.parseVarType()) |node| return P{ .var_type = node };
+        if (p.eatToken(.Ellipsis3)) |token| return P{ .var_args = token };
+        if (try p.parseTypeExpr()) |node| return P{ .type_expr = node };
+        return null;
+    }
+
+    /// IfPrefix <- KEYWORD_if LPAREN Expr RPAREN PtrPayload?
+    fn parseIfPrefix(p: *Parser) !?*Node {
+        const if_token = p.eatToken(.Keyword_if) orelse return null;
+        _ = try p.expectToken(.LParen);
+        const condition = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+        _ = try p.expectToken(.RParen);
+        const payload = try p.parsePtrPayload();
+
+        const node = try p.arena.allocator.create(Node.If);
+        node.* = .{
+            .if_token = if_token,
+            .condition = condition,
+            .payload = payload,
+            .body = undefined, // set by caller
+            .@"else" = null,
+        };
+        return &node.base;
+    }
+
+    /// WhilePrefix <- KEYWORD_while LPAREN Expr RPAREN PtrPayload? WhileContinueExpr?
+    fn parseWhilePrefix(p: *Parser) !?*Node {
+        const while_token = p.eatToken(.Keyword_while) orelse return null;
+
+        _ = try p.expectToken(.LParen);
+        const condition = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+        _ = try p.expectToken(.RParen);
+
+        const payload = try p.parsePtrPayload();
+        const continue_expr = try p.parseWhileContinueExpr();
+
+        const node = try p.arena.allocator.create(Node.While);
+        node.* = .{
+            .label = null,
+            .inline_token = null,
+            .while_token = while_token,
+            .condition = condition,
+            .payload = payload,
+            .continue_expr = continue_expr,
+            .body = undefined, // set by caller
+            .@"else" = null,
+        };
+        return &node.base;
+    }
+
+    /// ForPrefix <- KEYWORD_for LPAREN Expr RPAREN PtrIndexPayload
+    fn parseForPrefix(p: *Parser) !?*Node {
+        const for_token = p.eatToken(.Keyword_for) orelse return null;
+
+        _ = try p.expectToken(.LParen);
+        const array_expr = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+        _ = try p.expectToken(.RParen);
+
+        const payload = try p.expectNode(parsePtrIndexPayload, .{
+            .ExpectedPayload = .{ .token = p.tok_i },
+        });
+
+        const node = try p.arena.allocator.create(Node.For);
+        node.* = .{
+            .label = null,
+            .inline_token = null,
+            .for_token = for_token,
+            .array_expr = array_expr,
+            .payload = payload,
+            .body = undefined, // set by caller
+            .@"else" = null,
+        };
+        return &node.base;
+    }
+
+    /// Payload <- PIPE IDENTIFIER PIPE
+    fn parsePayload(p: *Parser) !?*Node {
+        const lpipe = p.eatToken(.Pipe) orelse return null;
+        const identifier = try p.expectNode(parseIdentifier, .{
+            .ExpectedIdentifier = .{ .token = p.tok_i },
+        });
+        const rpipe = try p.expectToken(.Pipe);
+
+        const node = try p.arena.allocator.create(Node.Payload);
+        node.* = .{
+            .lpipe = lpipe,
+            .error_symbol = identifier,
+            .rpipe = rpipe,
+        };
+        return &node.base;
+    }
+
+    /// PtrPayload <- PIPE ASTERISK? IDENTIFIER PIPE
+    fn parsePtrPayload(p: *Parser) !?*Node {
+        const lpipe = p.eatToken(.Pipe) orelse return null;
+        const asterisk = p.eatToken(.Asterisk);
+        const identifier = try p.expectNode(parseIdentifier, .{
+            .ExpectedIdentifier = .{ .token = p.tok_i },
+        });
+        const rpipe = try p.expectToken(.Pipe);
+
+        const node = try p.arena.allocator.create(Node.PointerPayload);
+        node.* = .{
+            .lpipe = lpipe,
+            .ptr_token = asterisk,
+            .value_symbol = identifier,
+            .rpipe = rpipe,
+        };
+        return &node.base;
+    }
+
+    /// PtrIndexPayload <- PIPE ASTERISK? IDENTIFIER (COMMA IDENTIFIER)? PIPE
+    fn parsePtrIndexPayload(p: *Parser) !?*Node {
+        const lpipe = p.eatToken(.Pipe) orelse return null;
+        const asterisk = p.eatToken(.Asterisk);
+        const identifier = try p.expectNode(parseIdentifier, .{
+            .ExpectedIdentifier = .{ .token = p.tok_i },
+        });
+
+        const index = if (p.eatToken(.Comma) == null)
+            null
+        else
+            try p.expectNode(parseIdentifier, .{
+                .ExpectedIdentifier = .{ .token = p.tok_i },
+            });
+
+        const rpipe = try p.expectToken(.Pipe);
+
+        const node = try p.arena.allocator.create(Node.PointerIndexPayload);
+        node.* = .{
+            .lpipe = lpipe,
+            .ptr_token = asterisk,
+            .value_symbol = identifier,
+            .index_symbol = index,
+            .rpipe = rpipe,
+        };
+        return &node.base;
+    }
+
+    /// SwitchProng <- SwitchCase EQUALRARROW PtrPayload? AssignExpr
+    fn parseSwitchProng(p: *Parser) !?*Node {
+        const node = (try p.parseSwitchCase()) orelse return null;
+        const arrow = try p.expectToken(.EqualAngleBracketRight);
+        const payload = try p.parsePtrPayload();
+        const expr = try p.expectNode(parseAssignExpr, .{
+            .ExpectedExprOrAssignment = .{ .token = p.tok_i },
+        });
+
+        const switch_case = node.cast(Node.SwitchCase).?;
+        switch_case.arrow_token = arrow;
+        switch_case.payload = payload;
+        switch_case.expr = expr;
+
+        return node;
+    }
+
+    /// SwitchCase
+    ///     <- SwitchItem (COMMA SwitchItem)* COMMA?
+    ///      / KEYWORD_else
+    fn parseSwitchCase(p: *Parser) !?*Node {
+        var list = Node.SwitchCase.ItemList{};
+        var list_it = &list.first;
+
+        if (try p.parseSwitchItem()) |first_item| {
+            list_it = try p.llpush(*Node, list_it, first_item);
+            while (p.eatToken(.Comma) != null) {
+                const next_item = (try p.parseSwitchItem()) orelse break;
+                list_it = try p.llpush(*Node, list_it, next_item);
+            }
+        } else if (p.eatToken(.Keyword_else)) |else_token| {
+            const else_node = try p.arena.allocator.create(Node.SwitchElse);
+            else_node.* = .{
+                .token = else_token,
+            };
+            list_it = try p.llpush(*Node, list_it, &else_node.base);
+        } else return null;
+
+        const node = try p.arena.allocator.create(Node.SwitchCase);
+        node.* = .{
+            .items = list,
+            .arrow_token = undefined, // set by caller
+            .payload = null,
+            .expr = undefined, // set by caller
+        };
+        return &node.base;
+    }
+
+    /// SwitchItem <- Expr (DOT3 Expr)?
+    fn parseSwitchItem(p: *Parser) !?*Node {
+        const expr = (try p.parseExpr()) orelse return null;
+        if (p.eatToken(.Ellipsis3)) |token| {
+            const range_end = try p.expectNode(parseExpr, .{
+                .ExpectedExpr = .{ .token = p.tok_i },
+            });
+
+            const node = try p.arena.allocator.create(Node.InfixOp);
+            node.* = .{
+                .op_token = token,
+                .lhs = expr,
+                .op = .Range,
+                .rhs = range_end,
+            };
+            return &node.base;
+        }
+        return expr;
+    }
+
+    /// AssignOp
+    ///     <- ASTERISKEQUAL
+    ///      / SLASHEQUAL
+    ///      / PERCENTEQUAL
+    ///      / PLUSEQUAL
+    ///      / MINUSEQUAL
+    ///      / LARROW2EQUAL
+    ///      / RARROW2EQUAL
+    ///      / AMPERSANDEQUAL
+    ///      / CARETEQUAL
+    ///      / PIPEEQUAL
+    ///      / ASTERISKPERCENTEQUAL
+    ///      / PLUSPERCENTEQUAL
+    ///      / MINUSPERCENTEQUAL
+    ///      / EQUAL
+    fn parseAssignOp(p: *Parser) !?*Node {
+        const token = p.nextToken();
+        const op: Node.InfixOp.Op = switch (token.ptr.id) {
+            .AsteriskEqual => .AssignMul,
+            .SlashEqual => .AssignDiv,
+            .PercentEqual => .AssignMod,
+            .PlusEqual => .AssignAdd,
+            .MinusEqual => .AssignSub,
+            .AngleBracketAngleBracketLeftEqual => .AssignBitShiftLeft,
+            .AngleBracketAngleBracketRightEqual => .AssignBitShiftRight,
+            .AmpersandEqual => .AssignBitAnd,
+            .CaretEqual => .AssignBitXor,
+            .PipeEqual => .AssignBitOr,
+            .AsteriskPercentEqual => .AssignMulWrap,
+            .PlusPercentEqual => .AssignAddWrap,
+            .MinusPercentEqual => .AssignSubWrap,
+            .Equal => .Assign,
+            else => {
+                p.putBackToken(token.index);
+                return null;
+            },
+        };
+
+        const node = try p.arena.allocator.create(Node.InfixOp);
+        node.* = .{
+            .op_token = token.index,
+            .lhs = undefined, // set by caller
+            .op = op,
+            .rhs = undefined, // set by caller
+        };
+        return &node.base;
+    }
+
+    /// CompareOp
+    ///     <- EQUALEQUAL
+    ///      / EXCLAMATIONMARKEQUAL
+    ///      / LARROW
+    ///      / RARROW
+    ///      / LARROWEQUAL
+    ///      / RARROWEQUAL
+    fn parseCompareOp(p: *Parser) !?*Node {
+        const token = p.nextToken();
+        const op: Node.InfixOp.Op = switch (token.ptr.id) {
+            .EqualEqual => .EqualEqual,
+            .BangEqual => .BangEqual,
+            .AngleBracketLeft => .LessThan,
+            .AngleBracketRight => .GreaterThan,
+            .AngleBracketLeftEqual => .LessOrEqual,
+            .AngleBracketRightEqual => .GreaterOrEqual,
+            else => {
+                p.putBackToken(token.index);
+                return null;
+            },
+        };
+
+        return p.createInfixOp(token.index, op);
+    }
+
+    /// BitwiseOp
+    ///     <- AMPERSAND
+    ///      / CARET
+    ///      / PIPE
+    ///      / KEYWORD_orelse
+    ///      / KEYWORD_catch Payload?
+    fn parseBitwiseOp(p: *Parser) !?*Node {
+        const token = p.nextToken();
+        const op: Node.InfixOp.Op = switch (token.ptr.id) {
+            .Ampersand => .BitAnd,
+            .Caret => .BitXor,
+            .Pipe => .BitOr,
+            .Keyword_orelse => .UnwrapOptional,
+            .Keyword_catch => .{ .Catch = try p.parsePayload() },
+            else => {
+                p.putBackToken(token.index);
+                return null;
+            },
+        };
+
+        return p.createInfixOp(token.index, op);
+    }
+
+    /// BitShiftOp
+    ///     <- LARROW2
+    ///      / RARROW2
+    fn parseBitShiftOp(p: *Parser) !?*Node {
+        const token = p.nextToken();
+        const op: Node.InfixOp.Op = switch (token.ptr.id) {
+            .AngleBracketAngleBracketLeft => .BitShiftLeft,
+            .AngleBracketAngleBracketRight => .BitShiftRight,
+            else => {
+                p.putBackToken(token.index);
+                return null;
+            },
+        };
+
+        return p.createInfixOp(token.index, op);
+    }
+
+    /// AdditionOp
+    ///     <- PLUS
+    ///      / MINUS
+    ///      / PLUS2
+    ///      / PLUSPERCENT
+    ///      / MINUSPERCENT
+    fn parseAdditionOp(p: *Parser) !?*Node {
+        const token = p.nextToken();
+        const op: Node.InfixOp.Op = switch (token.ptr.id) {
+            .Plus => .Add,
+            .Minus => .Sub,
+            .PlusPlus => .ArrayCat,
+            .PlusPercent => .AddWrap,
+            .MinusPercent => .SubWrap,
+            else => {
+                p.putBackToken(token.index);
+                return null;
+            },
+        };
+
+        return p.createInfixOp(token.index, op);
+    }
+
+    /// MultiplyOp
+    ///     <- PIPE2
+    ///      / ASTERISK
+    ///      / SLASH
+    ///      / PERCENT
+    ///      / ASTERISK2
+    ///      / ASTERISKPERCENT
+    fn parseMultiplyOp(p: *Parser) !?*Node {
+        const token = p.nextToken();
+        const op: Node.InfixOp.Op = switch (token.ptr.id) {
+            .PipePipe => .MergeErrorSets,
+            .Asterisk => .Mul,
+            .Slash => .Div,
+            .Percent => .Mod,
+            .AsteriskAsterisk => .ArrayMult,
+            .AsteriskPercent => .MulWrap,
+            else => {
+                p.putBackToken(token.index);
+                return null;
+            },
+        };
+
+        return p.createInfixOp(token.index, op);
+    }
+
+    /// PrefixOp
+    ///     <- EXCLAMATIONMARK
+    ///      / MINUS
+    ///      / TILDE
+    ///      / MINUSPERCENT
+    ///      / AMPERSAND
+    ///      / KEYWORD_try
+    ///      / KEYWORD_await
+    fn parsePrefixOp(p: *Parser) !?*Node {
+        const token = p.nextToken();
+        const op: Node.PrefixOp.Op = switch (token.ptr.id) {
+            .Bang => .BoolNot,
+            .Minus => .Negation,
+            .Tilde => .BitNot,
+            .MinusPercent => .NegationWrap,
+            .Ampersand => .AddressOf,
+            .Keyword_try => .Try,
+            .Keyword_await => .Await,
+            else => {
+                p.putBackToken(token.index);
+                return null;
+            },
+        };
+
+        const node = try p.arena.allocator.create(Node.PrefixOp);
+        node.* = .{
+            .op_token = token.index,
+            .op = op,
+            .rhs = undefined, // set by caller
+        };
+        return &node.base;
+    }
+
+    // TODO: ArrayTypeStart is either an array or a slice, but const/allowzero only work on
+    //       pointers. Consider updating this rule:
+    //       ...
+    //       / ArrayTypeStart
+    //       / SliceTypeStart (ByteAlign / KEYWORD_const / KEYWORD_volatile / KEYWORD_allowzero)*
+    //       / PtrTypeStart ...
+
+    /// PrefixTypeOp
+    ///     <- QUESTIONMARK
+    ///      / KEYWORD_anyframe MINUSRARROW
+    ///      / ArrayTypeStart (ByteAlign / KEYWORD_const / KEYWORD_volatile / KEYWORD_allowzero)*
+    ///      / PtrTypeStart (KEYWORD_align LPAREN Expr (COLON INTEGER COLON INTEGER)? RPAREN / KEYWORD_const / KEYWORD_volatile / KEYWORD_allowzero)*
+    fn parsePrefixTypeOp(p: *Parser) !?*Node {
+        if (p.eatToken(.QuestionMark)) |token| {
+            const node = try p.arena.allocator.create(Node.PrefixOp);
+            node.* = .{
+                .op_token = token,
+                .op = .OptionalType,
                 .rhs = undefined, // set by caller
             };
             return &node.base;
         }
-    }.parse;
-}
 
-// Helper parsers not included in the grammar
-
-fn parseBuiltinCall(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = eatToken(it, .Builtin) orelse return null;
-    const params = (try parseFnCallArguments(arena, it, tree)) orelse {
-        try tree.errors.push(.{
-            .ExpectedParamList = .{ .token = it.index },
-        });
-
-        // lets pretend this was an identifier so we can continue parsing
-        const node = try arena.create(Node.Identifier);
-        node.* = .{
-            .token = token,
-        };
-        return &node.base;
-    };
-    const node = try arena.create(Node.BuiltinCall);
-    node.* = .{
-        .builtin_token = token,
-        .params = params.list,
-        .rparen_token = params.rparen,
-    };
-    return &node.base;
-}
-
-fn parseErrorTag(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const doc_comments = try parseDocComment(arena, it, tree); // no need to rewind on failure
-    const token = eatToken(it, .Identifier) orelse return null;
-
-    const node = try arena.create(Node.ErrorTag);
-    node.* = .{
-        .doc_comments = doc_comments,
-        .name_token = token,
-    };
-    return &node.base;
-}
-
-fn parseIdentifier(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = eatToken(it, .Identifier) orelse return null;
-    const node = try arena.create(Node.Identifier);
-    node.* = .{
-        .token = token,
-    };
-    return &node.base;
-}
-
-fn parseVarType(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = eatToken(it, .Keyword_var) orelse return null;
-    const node = try arena.create(Node.VarType);
-    node.* = .{
-        .token = token,
-    };
-    return &node.base;
-}
-
-fn createLiteral(arena: *Allocator, comptime T: type, token: TokenIndex) !*Node {
-    const result = try arena.create(T);
-    result.* = T{
-        .base = Node{ .id = Node.typeToId(T) },
-        .token = token,
-    };
-    return &result.base;
-}
-
-fn parseStringLiteralSingle(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    if (eatToken(it, .StringLiteral)) |token| {
-        const node = try arena.create(Node.StringLiteral);
-        node.* = .{
-            .token = token,
-        };
-        return &node.base;
-    }
-    return null;
-}
-
-// string literal or multiline string literal
-fn parseStringLiteral(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    if (try parseStringLiteralSingle(arena, it, tree)) |node| return node;
-
-    if (eatToken(it, .MultilineStringLiteralLine)) |first_line| {
-        const node = try arena.create(Node.MultilineStringLiteral);
-        node.* = .{
-            .lines = Node.MultilineStringLiteral.LineList.init(arena),
-        };
-        try node.lines.push(first_line);
-        while (eatToken(it, .MultilineStringLiteralLine)) |line|
-            try node.lines.push(line);
-
-        return &node.base;
-    }
-
-    return null;
-}
-
-fn parseIntegerLiteral(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = eatToken(it, .IntegerLiteral) orelse return null;
-    const node = try arena.create(Node.IntegerLiteral);
-    node.* = .{
-        .token = token,
-    };
-    return &node.base;
-}
-
-fn parseFloatLiteral(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = eatToken(it, .FloatLiteral) orelse return null;
-    const node = try arena.create(Node.FloatLiteral);
-    node.* = .{
-        .token = token,
-    };
-    return &node.base;
-}
-
-fn parseTry(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = eatToken(it, .Keyword_try) orelse return null;
-    const node = try arena.create(Node.PrefixOp);
-    node.* = .{
-        .op_token = token,
-        .op = .Try,
-        .rhs = undefined, // set by caller
-    };
-    return &node.base;
-}
-
-fn parseUse(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node {
-    const token = eatToken(it, .Keyword_usingnamespace) orelse return null;
-    const node = try arena.create(Node.Use);
-    node.* = .{
-        .doc_comments = null,
-        .visib_token = null,
-        .use_token = token,
-        .expr = try expectNode(arena, it, tree, parseExpr, .{
-            .ExpectedExpr = .{ .token = it.index },
-        }),
-        .semicolon_token = try expectToken(it, tree, .Semicolon),
-    };
-    return &node.base;
-}
-
-/// IfPrefix Body (KEYWORD_else Payload? Body)?
-fn parseIf(arena: *Allocator, it: *TokenIterator, tree: *Tree, bodyParseFn: NodeParseFn) !?*Node {
-    const node = (try parseIfPrefix(arena, it, tree)) orelse return null;
-    const if_prefix = node.cast(Node.If).?;
-
-    if_prefix.body = try expectNode(arena, it, tree, bodyParseFn, .{
-        .InvalidToken = .{ .token = it.index },
-    });
-
-    const else_token = eatToken(it, .Keyword_else) orelse return node;
-    const payload = try parsePayload(arena, it, tree);
-    const else_expr = try expectNode(arena, it, tree, bodyParseFn, .{
-        .InvalidToken = .{ .token = it.index },
-    });
-    const else_node = try arena.create(Node.Else);
-    else_node.* = .{
-        .else_token = else_token,
-        .payload = payload,
-        .body = else_expr,
-    };
-    if_prefix.@"else" = else_node;
-
-    return node;
-}
-
-/// Eat a multiline doc comment
-fn parseDocComment(arena: *Allocator, it: *TokenIterator, tree: *Tree) !?*Node.DocComment {
-    var lines = Node.DocComment.LineList.init(arena);
-    while (eatToken(it, .DocComment)) |line| {
-        try lines.push(line);
-    }
-
-    if (lines.len == 0) return null;
-
-    const node = try arena.create(Node.DocComment);
-    node.* = .{
-        .lines = lines,
-    };
-    return node;
-}
-
-/// Eat a single-line doc comment on the same line as another node
-fn parseAppendedDocComment(arena: *Allocator, it: *TokenIterator, tree: *Tree, after_token: TokenIndex) !?*Node.DocComment {
-    const comment_token = eatToken(it, .DocComment) orelse return null;
-    if (tree.tokensOnSameLine(after_token, comment_token)) {
-        const node = try arena.create(Node.DocComment);
-        node.* = .{
-            .lines = Node.DocComment.LineList.init(arena),
-        };
-        try node.lines.push(comment_token);
-        return node;
-    }
-    putBackToken(it, comment_token);
-    return null;
-}
-
-/// Op* Child
-fn parsePrefixOpExpr(
-    arena: *Allocator,
-    it: *TokenIterator,
-    tree: *Tree,
-    opParseFn: NodeParseFn,
-    childParseFn: NodeParseFn,
-) Error!?*Node {
-    if (try opParseFn(arena, it, tree)) |first_op| {
-        var rightmost_op = first_op;
-        while (true) {
-            switch (rightmost_op.id) {
-                .PrefixOp => {
-                    var prefix_op = rightmost_op.cast(Node.PrefixOp).?;
-                    // If the token encountered was **, there will be two nodes
-                    if (tree.tokens.at(prefix_op.op_token).id == .AsteriskAsterisk) {
-                        rightmost_op = prefix_op.rhs;
-                        prefix_op = rightmost_op.cast(Node.PrefixOp).?;
-                    }
-                    if (try opParseFn(arena, it, tree)) |rhs| {
-                        prefix_op.rhs = rhs;
-                        rightmost_op = rhs;
-                    } else break;
+        // TODO: Returning a AnyFrameType instead of PrefixOp makes casting and setting .rhs or
+        //       .return_type more difficult for the caller (see parsePrefixOpExpr helper).
+        //       Consider making the AnyFrameType a member of PrefixOp and add a
+        //       PrefixOp.AnyFrameType variant?
+        if (p.eatToken(.Keyword_anyframe)) |token| {
+            const arrow = p.eatToken(.Arrow) orelse {
+                p.putBackToken(token);
+                return null;
+            };
+            const node = try p.arena.allocator.create(Node.AnyFrameType);
+            node.* = .{
+                .anyframe_token = token,
+                .result = .{
+                    .arrow_token = arrow,
+                    .return_type = undefined, // set by caller
                 },
-                .AnyFrameType => {
-                    const prom = rightmost_op.cast(Node.AnyFrameType).?;
-                    if (try opParseFn(arena, it, tree)) |rhs| {
-                        prom.result.?.return_type = rhs;
-                        rightmost_op = rhs;
-                    } else break;
+            };
+            return &node.base;
+        }
+
+        if (try p.parsePtrTypeStart()) |node| {
+            // If the token encountered was **, there will be two nodes instead of one.
+            // The attributes should be applied to the rightmost operator.
+            const prefix_op = node.cast(Node.PrefixOp).?;
+            var ptr_info = if (p.tokens[prefix_op.op_token].id == .AsteriskAsterisk)
+                &prefix_op.rhs.cast(Node.PrefixOp).?.op.PtrType
+            else
+                &prefix_op.op.PtrType;
+
+            while (true) {
+                if (p.eatToken(.Keyword_align)) |align_token| {
+                    const lparen = try p.expectToken(.LParen);
+                    const expr_node = try p.expectNode(parseExpr, .{
+                        .ExpectedExpr = .{ .token = p.tok_i },
+                    });
+
+                    // Optional bit range
+                    const bit_range = if (p.eatToken(.Colon)) |_| bit_range_value: {
+                        const range_start = try p.expectNode(parseIntegerLiteral, .{
+                            .ExpectedIntegerLiteral = .{ .token = p.tok_i },
+                        });
+                        _ = try p.expectToken(.Colon);
+                        const range_end = try p.expectNode(parseIntegerLiteral, .{
+                            .ExpectedIntegerLiteral = .{ .token = p.tok_i },
+                        });
+
+                        break :bit_range_value Node.PrefixOp.PtrInfo.Align.BitRange{
+                            .start = range_start,
+                            .end = range_end,
+                        };
+                    } else null;
+                    _ = try p.expectToken(.RParen);
+
+                    if (ptr_info.align_info != null) {
+                        try p.errors.append(p.gpa, .{
+                            .ExtraAlignQualifier = .{ .token = p.tok_i - 1 },
+                        });
+                        continue;
+                    }
+
+                    ptr_info.align_info = Node.PrefixOp.PtrInfo.Align{
+                        .node = expr_node,
+                        .bit_range = bit_range,
+                    };
+
+                    continue;
+                }
+                if (p.eatToken(.Keyword_const)) |const_token| {
+                    if (ptr_info.const_token != null) {
+                        try p.errors.append(p.gpa, .{
+                            .ExtraConstQualifier = .{ .token = p.tok_i - 1 },
+                        });
+                        continue;
+                    }
+                    ptr_info.const_token = const_token;
+                    continue;
+                }
+                if (p.eatToken(.Keyword_volatile)) |volatile_token| {
+                    if (ptr_info.volatile_token != null) {
+                        try p.errors.append(p.gpa, .{
+                            .ExtraVolatileQualifier = .{ .token = p.tok_i - 1 },
+                        });
+                        continue;
+                    }
+                    ptr_info.volatile_token = volatile_token;
+                    continue;
+                }
+                if (p.eatToken(.Keyword_allowzero)) |allowzero_token| {
+                    if (ptr_info.allowzero_token != null) {
+                        try p.errors.append(p.gpa, .{
+                            .ExtraAllowZeroQualifier = .{ .token = p.tok_i - 1 },
+                        });
+                        continue;
+                    }
+                    ptr_info.allowzero_token = allowzero_token;
+                    continue;
+                }
+                break;
+            }
+
+            return node;
+        }
+
+        if (try p.parseArrayTypeStart()) |node| {
+            switch (node.cast(Node.PrefixOp).?.op) {
+                .ArrayType => {},
+                .SliceType => |*slice_type| {
+                    // Collect pointer qualifiers in any order, but disallow duplicates
+                    while (true) {
+                        if (try p.parseByteAlign()) |align_expr| {
+                            if (slice_type.align_info != null) {
+                                try p.errors.append(p.gpa, .{
+                                    .ExtraAlignQualifier = .{ .token = p.tok_i - 1 },
+                                });
+                                continue;
+                            }
+                            slice_type.align_info = Node.PrefixOp.PtrInfo.Align{
+                                .node = align_expr,
+                                .bit_range = null,
+                            };
+                            continue;
+                        }
+                        if (p.eatToken(.Keyword_const)) |const_token| {
+                            if (slice_type.const_token != null) {
+                                try p.errors.append(p.gpa, .{
+                                    .ExtraConstQualifier = .{ .token = p.tok_i - 1 },
+                                });
+                                continue;
+                            }
+                            slice_type.const_token = const_token;
+                            continue;
+                        }
+                        if (p.eatToken(.Keyword_volatile)) |volatile_token| {
+                            if (slice_type.volatile_token != null) {
+                                try p.errors.append(p.gpa, .{
+                                    .ExtraVolatileQualifier = .{ .token = p.tok_i - 1 },
+                                });
+                                continue;
+                            }
+                            slice_type.volatile_token = volatile_token;
+                            continue;
+                        }
+                        if (p.eatToken(.Keyword_allowzero)) |allowzero_token| {
+                            if (slice_type.allowzero_token != null) {
+                                try p.errors.append(p.gpa, .{
+                                    .ExtraAllowZeroQualifier = .{ .token = p.tok_i - 1 },
+                                });
+                                continue;
+                            }
+                            slice_type.allowzero_token = allowzero_token;
+                            continue;
+                        }
+                        break;
+                    }
                 },
                 else => unreachable,
             }
+            return node;
         }
 
-        // If any prefix op existed, a child node on the RHS is required
-        switch (rightmost_op.id) {
-            .PrefixOp => {
-                const prefix_op = rightmost_op.cast(Node.PrefixOp).?;
-                prefix_op.rhs = try expectNode(arena, it, tree, childParseFn, .{
-                    .InvalidToken = .{ .token = it.index },
-                });
-            },
-            .AnyFrameType => {
-                const prom = rightmost_op.cast(Node.AnyFrameType).?;
-                prom.result.?.return_type = try expectNode(arena, it, tree, childParseFn, .{
-                    .InvalidToken = .{ .token = it.index },
-                });
-            },
-            else => unreachable,
-        }
-
-        return first_op;
-    }
-
-    // Otherwise, the child node is optional
-    return try childParseFn(arena, it, tree);
-}
-
-/// Child (Op Child)*
-/// Child (Op Child)?
-fn parseBinOpExpr(
-    arena: *Allocator,
-    it: *TokenIterator,
-    tree: *Tree,
-    opParseFn: NodeParseFn,
-    childParseFn: NodeParseFn,
-    chain: enum {
-        Once,
-        Infinitely,
-    },
-) Error!?*Node {
-    var res = (try childParseFn(arena, it, tree)) orelse return null;
-
-    while (try opParseFn(arena, it, tree)) |node| {
-        const right = try expectNode(arena, it, tree, childParseFn, .{
-            .InvalidToken = .{ .token = it.index },
-        });
-        const left = res;
-        res = node;
-
-        const op = node.cast(Node.InfixOp).?;
-        op.*.lhs = left;
-        op.*.rhs = right;
-
-        switch (chain) {
-            .Once => break,
-            .Infinitely => continue,
-        }
-    }
-
-    return res;
-}
-
-fn createInfixOp(arena: *Allocator, index: TokenIndex, op: Node.InfixOp.Op) !*Node {
-    const node = try arena.create(Node.InfixOp);
-    node.* = .{
-        .op_token = index,
-        .lhs = undefined, // set by caller
-        .op = op,
-        .rhs = undefined, // set by caller
-    };
-    return &node.base;
-}
-
-fn eatToken(it: *TokenIterator, id: Token.Id) ?TokenIndex {
-    return if (eatAnnotatedToken(it, id)) |token| token.index else null;
-}
-
-fn eatAnnotatedToken(it: *TokenIterator, id: Token.Id) ?AnnotatedToken {
-    return if (it.peek().?.id == id) nextToken(it) else null;
-}
-
-fn expectToken(it: *TokenIterator, tree: *Tree, id: Token.Id) Error!TokenIndex {
-    return (try expectTokenRecoverable(it, tree, id)) orelse
-        error.ParseError;
-}
-
-fn expectTokenRecoverable(it: *TokenIterator, tree: *Tree, id: Token.Id) !?TokenIndex {
-    const token = nextToken(it);
-    if (token.ptr.id != id) {
-        try tree.errors.push(.{
-            .ExpectedToken = .{ .token = token.index, .expected_id = id },
-        });
-        // go back so that we can recover properly
-        putBackToken(it, token.index);
         return null;
     }
-    return token.index;
-}
 
-fn nextToken(it: *TokenIterator) AnnotatedToken {
-    const result = AnnotatedToken{
-        .index = it.index,
-        .ptr = it.next().?,
+    /// SuffixOp
+    ///     <- LBRACKET Expr (DOT2 (Expr (COLON Expr)?)?)? RBRACKET
+    ///      / DOT IDENTIFIER
+    ///      / DOTASTERISK
+    ///      / DOTQUESTIONMARK
+    fn parseSuffixOp(p: *Parser) !?*Node {
+        const OpAndToken = struct {
+            op: Node.SuffixOp.Op,
+            token: TokenIndex,
+        };
+        const op_and_token: OpAndToken = blk: {
+            if (p.eatToken(.LBracket)) |_| {
+                const index_expr = try p.expectNode(parseExpr, .{
+                    .ExpectedExpr = .{ .token = p.tok_i },
+                });
+
+                if (p.eatToken(.Ellipsis2) != null) {
+                    const end_expr = try p.parseExpr();
+                    const sentinel: ?*ast.Node = if (p.eatToken(.Colon) != null)
+                        try p.parseExpr()
+                    else
+                        null;
+                    break :blk .{
+                        .op = .{
+                            .Slice = .{
+                                .start = index_expr,
+                                .end = end_expr,
+                                .sentinel = sentinel,
+                            },
+                        },
+                        .token = try p.expectToken(.RBracket),
+                    };
+                }
+
+                break :blk .{
+                    .op = .{ .ArrayAccess = index_expr },
+                    .token = try p.expectToken(.RBracket),
+                };
+            }
+
+            if (p.eatToken(.PeriodAsterisk)) |period_asterisk| {
+                break :blk .{ .op = .Deref, .token = period_asterisk };
+            }
+
+            if (p.eatToken(.Period)) |period| {
+                if (try p.parseIdentifier()) |identifier| {
+                    // TODO: It's a bit weird to return an InfixOp from the SuffixOp parser.
+                    // Should there be an ast.Node.SuffixOp.FieldAccess variant? Or should
+                    // this grammar rule be altered?
+                    const node = try p.arena.allocator.create(Node.InfixOp);
+                    node.* = .{
+                        .op_token = period,
+                        .lhs = undefined, // set by caller
+                        .op = .Period,
+                        .rhs = identifier,
+                    };
+                    return &node.base;
+                }
+                if (p.eatToken(.QuestionMark)) |question_mark| {
+                    break :blk .{ .op = .UnwrapOptional, .token = question_mark };
+                }
+                try p.errors.append(p.gpa, .{
+                    .ExpectedSuffixOp = .{ .token = p.tok_i },
+                });
+                return null;
+            }
+
+            return null;
+        };
+
+        const node = try p.arena.allocator.create(Node.SuffixOp);
+        node.* = .{
+            .lhs = undefined, // set by caller
+            .op = op_and_token.op,
+            .rtoken = op_and_token.token,
+        };
+        return &node.base;
+    }
+
+    /// FnCallArguments <- LPAREN ExprList RPAREN
+    /// ExprList <- (Expr COMMA)* Expr?
+    fn parseFnCallArguments(p: *Parser) !?AnnotatedParamList {
+        if (p.eatToken(.LParen) == null) return null;
+        const list = try ListParseFn(Node.FnProto.ParamList, parseExpr)(p);
+        const rparen = try p.expectToken(.RParen);
+        return AnnotatedParamList{ .list = list, .rparen = rparen };
+    }
+
+    const AnnotatedParamList = struct {
+        list: Node.FnProto.ParamList, // NOTE: may also be any other type SegmentedList(*Node, 2)
+        rparen: TokenIndex,
     };
-    assert(result.ptr.id != .LineComment);
 
-    while (true) {
-        const next_tok = it.peek() orelse return result;
-        if (next_tok.id != .LineComment) return result;
-        _ = it.next();
+    /// ArrayTypeStart <- LBRACKET Expr? RBRACKET
+    fn parseArrayTypeStart(p: *Parser) !?*Node {
+        const lbracket = p.eatToken(.LBracket) orelse return null;
+        const expr = try p.parseExpr();
+        const sentinel = if (p.eatToken(.Colon)) |_|
+            try p.expectNode(parseExpr, .{
+                .ExpectedExpr = .{ .token = p.tok_i },
+            })
+        else
+            null;
+        const rbracket = try p.expectToken(.RBracket);
+
+        const op: Node.PrefixOp.Op = if (expr) |len_expr|
+            .{
+                .ArrayType = .{
+                    .len_expr = len_expr,
+                    .sentinel = sentinel,
+                },
+            }
+        else
+            .{
+                .SliceType = Node.PrefixOp.PtrInfo{
+                    .allowzero_token = null,
+                    .align_info = null,
+                    .const_token = null,
+                    .volatile_token = null,
+                    .sentinel = sentinel,
+                },
+            };
+
+        const node = try p.arena.allocator.create(Node.PrefixOp);
+        node.* = .{
+            .op_token = lbracket,
+            .op = op,
+            .rhs = undefined, // set by caller
+        };
+        return &node.base;
     }
-}
 
-fn putBackToken(it: *TokenIterator, putting_back: TokenIndex) void {
-    while (true) {
-        const prev_tok = it.prev() orelse return;
-        if (prev_tok.id == .LineComment) continue;
-        assert(it.list.at(putting_back) == prev_tok);
-        return;
+    /// PtrTypeStart
+    ///     <- ASTERISK
+    ///      / ASTERISK2
+    ///      / PTRUNKNOWN
+    ///      / PTRC
+    fn parsePtrTypeStart(p: *Parser) !?*Node {
+        if (p.eatToken(.Asterisk)) |asterisk| {
+            const sentinel = if (p.eatToken(.Colon)) |_|
+                try p.expectNode(parseExpr, .{
+                    .ExpectedExpr = .{ .token = p.tok_i },
+                })
+            else
+                null;
+            const node = try p.arena.allocator.create(Node.PrefixOp);
+            node.* = .{
+                .op_token = asterisk,
+                .op = .{ .PtrType = .{ .sentinel = sentinel } },
+                .rhs = undefined, // set by caller
+            };
+            return &node.base;
+        }
+
+        if (p.eatToken(.AsteriskAsterisk)) |double_asterisk| {
+            const node = try p.arena.allocator.create(Node.PrefixOp);
+            node.* = .{
+                .op_token = double_asterisk,
+                .op = .{ .PtrType = .{} },
+                .rhs = undefined, // set by caller
+            };
+
+            // Special case for **, which is its own token
+            const child = try p.arena.allocator.create(Node.PrefixOp);
+            child.* = .{
+                .op_token = double_asterisk,
+                .op = .{ .PtrType = .{} },
+                .rhs = undefined, // set by caller
+            };
+            node.rhs = &child.base;
+
+            return &node.base;
+        }
+        if (p.eatToken(.LBracket)) |lbracket| {
+            const asterisk = p.eatToken(.Asterisk) orelse {
+                p.putBackToken(lbracket);
+                return null;
+            };
+            if (p.eatToken(.Identifier)) |ident| {
+                const token_slice = p.source[p.tokens[ident].start..p.tokens[ident].end];
+                if (!std.mem.eql(u8, token_slice, "c")) {
+                    p.putBackToken(ident);
+                } else {
+                    _ = try p.expectToken(.RBracket);
+                    const node = try p.arena.allocator.create(Node.PrefixOp);
+                    node.* = .{
+                        .op_token = lbracket,
+                        .op = .{ .PtrType = .{} },
+                        .rhs = undefined, // set by caller
+                    };
+                    return &node.base;
+                }
+            }
+            const sentinel = if (p.eatToken(.Colon)) |_|
+                try p.expectNode(parseExpr, .{
+                    .ExpectedExpr = .{ .token = p.tok_i },
+                })
+            else
+                null;
+            _ = try p.expectToken(.RBracket);
+            const node = try p.arena.allocator.create(Node.PrefixOp);
+            node.* = .{
+                .op_token = lbracket,
+                .op = .{ .PtrType = .{ .sentinel = sentinel } },
+                .rhs = undefined, // set by caller
+            };
+            return &node.base;
+        }
+        return null;
     }
-}
 
-const AnnotatedToken = struct {
-    index: TokenIndex,
-    ptr: *Token,
+    /// ContainerDeclAuto <- ContainerDeclType LBRACE ContainerMembers RBRACE
+    fn parseContainerDeclAuto(p: *Parser) !?*Node {
+        const node = (try p.parseContainerDeclType()) orelse return null;
+        const lbrace = try p.expectToken(.LBrace);
+        const members = try p.parseContainerMembers(false);
+        const rbrace = try p.expectToken(.RBrace);
+
+        const decl_type = node.cast(Node.ContainerDecl).?;
+        decl_type.fields_and_decls = members;
+        decl_type.lbrace_token = lbrace;
+        decl_type.rbrace_token = rbrace;
+
+        return node;
+    }
+
+    /// ContainerDeclType
+    ///     <- KEYWORD_struct
+    ///      / KEYWORD_enum (LPAREN Expr RPAREN)?
+    ///      / KEYWORD_union (LPAREN (KEYWORD_enum (LPAREN Expr RPAREN)? / Expr) RPAREN)?
+    fn parseContainerDeclType(p: *Parser) !?*Node {
+        const kind_token = p.nextToken();
+
+        const init_arg_expr = switch (kind_token.ptr.id) {
+            .Keyword_struct => Node.ContainerDecl.InitArg{ .None = {} },
+            .Keyword_enum => blk: {
+                if (p.eatToken(.LParen) != null) {
+                    const expr = try p.expectNode(parseExpr, .{
+                        .ExpectedExpr = .{ .token = p.tok_i },
+                    });
+                    _ = try p.expectToken(.RParen);
+                    break :blk Node.ContainerDecl.InitArg{ .Type = expr };
+                }
+                break :blk Node.ContainerDecl.InitArg{ .None = {} };
+            },
+            .Keyword_union => blk: {
+                if (p.eatToken(.LParen) != null) {
+                    if (p.eatToken(.Keyword_enum) != null) {
+                        if (p.eatToken(.LParen) != null) {
+                            const expr = try p.expectNode(parseExpr, .{
+                                .ExpectedExpr = .{ .token = p.tok_i },
+                            });
+                            _ = try p.expectToken(.RParen);
+                            _ = try p.expectToken(.RParen);
+                            break :blk Node.ContainerDecl.InitArg{ .Enum = expr };
+                        }
+                        _ = try p.expectToken(.RParen);
+                        break :blk Node.ContainerDecl.InitArg{ .Enum = null };
+                    }
+                    const expr = try p.expectNode(parseExpr, .{
+                        .ExpectedExpr = .{ .token = p.tok_i },
+                    });
+                    _ = try p.expectToken(.RParen);
+                    break :blk Node.ContainerDecl.InitArg{ .Type = expr };
+                }
+                break :blk Node.ContainerDecl.InitArg{ .None = {} };
+            },
+            else => {
+                p.putBackToken(kind_token.index);
+                return null;
+            },
+        };
+
+        const node = try p.arena.allocator.create(Node.ContainerDecl);
+        node.* = .{
+            .layout_token = null,
+            .kind_token = kind_token.index,
+            .init_arg_expr = init_arg_expr,
+            .fields_and_decls = undefined, // set by caller
+            .lbrace_token = undefined, // set by caller
+            .rbrace_token = undefined, // set by caller
+        };
+        return &node.base;
+    }
+
+    /// ByteAlign <- KEYWORD_align LPAREN Expr RPAREN
+    fn parseByteAlign(p: *Parser) !?*Node {
+        _ = p.eatToken(.Keyword_align) orelse return null;
+        _ = try p.expectToken(.LParen);
+        const expr = try p.expectNode(parseExpr, .{
+            .ExpectedExpr = .{ .token = p.tok_i },
+        });
+        _ = try p.expectToken(.RParen);
+        return expr;
+    }
+
+    /// IdentifierList <- (IDENTIFIER COMMA)* IDENTIFIER?
+    /// Only ErrorSetDecl parses an IdentifierList
+    fn parseErrorTagList(p: *Parser) !Node.ErrorSetDecl.DeclList {
+        return ListParseFn(Node.ErrorSetDecl.DeclList, parseErrorTag)(p);
+    }
+
+    /// SwitchProngList <- (SwitchProng COMMA)* SwitchProng?
+    fn parseSwitchProngList(p: *Parser) !Node.Switch.CaseList {
+        return ListParseFn(Node.Switch.CaseList, parseSwitchProng)(p);
+    }
+
+    /// AsmOutputList <- (AsmOutputItem COMMA)* AsmOutputItem?
+    fn parseAsmOutputList(p: *Parser) Error!Node.Asm.OutputList {
+        return ListParseFn(Node.Asm.OutputList, parseAsmOutputItem)(p);
+    }
+
+    /// AsmInputList <- (AsmInputItem COMMA)* AsmInputItem?
+    fn parseAsmInputList(p: *Parser) Error!Node.Asm.InputList {
+        return ListParseFn(Node.Asm.InputList, parseAsmInputItem)(p);
+    }
+
+    /// ParamDeclList <- (ParamDecl COMMA)* ParamDecl?
+    fn parseParamDeclList(p: *Parser, var_args_token: *?TokenIndex) !Node.FnProto.ParamList {
+        var list = Node.FnProto.ParamList{};
+        var list_it = &list.first;
+        var last: ?*Node = null;
+        while (try p.parseParamDecl()) |node| {
+            last = node;
+            list_it = try p.llpush(*Node, list_it, node);
+
+            switch (p.tokens[p.tok_i].id) {
+                .Comma => _ = p.nextToken(),
+                // all possible delimiters
+                .Colon, .RParen, .RBrace, .RBracket => break,
+                else => {
+                    // this is likely just a missing comma,
+                    // continue parsing this list and give an error
+                    try p.errors.append(p.gpa, .{
+                        .ExpectedToken = .{ .token = p.tok_i, .expected_id = .Comma },
+                    });
+                },
+            }
+        }
+        if (last) |node| {
+            const param_type = node.cast(Node.ParamDecl).?.param_type;
+            if (param_type == .var_args) {
+                var_args_token.* = param_type.var_args;
+            }
+        }
+        return list;
+    }
+
+    const NodeParseFn = fn (p: *Parser) Error!?*Node;
+
+    fn ListParseFn(comptime L: type, comptime nodeParseFn: var) ParseFn(L) {
+        return struct {
+            pub fn parse(p: *Parser) !L {
+                var list = L{};
+                var list_it = &list.first;
+                while (try nodeParseFn(p)) |node| {
+                    list_it = try p.llpush(L.Node.Data, list_it, node);
+
+                    switch (p.tokens[p.tok_i].id) {
+                        .Comma => _ = p.nextToken(),
+                        // all possible delimiters
+                        .Colon, .RParen, .RBrace, .RBracket => break,
+                        else => {
+                            // this is likely just a missing comma,
+                            // continue parsing this list and give an error
+                            try p.errors.append(p.gpa, .{
+                                .ExpectedToken = .{ .token = p.tok_i, .expected_id = .Comma },
+                            });
+                        },
+                    }
+                }
+                return list;
+            }
+        }.parse;
+    }
+
+    fn SimpleBinOpParseFn(comptime token: Token.Id, comptime op: Node.InfixOp.Op) NodeParseFn {
+        return struct {
+            pub fn parse(p: *Parser) Error!?*Node {
+                const op_token = if (token == .Keyword_and) switch (p.tokens[p.tok_i].id) {
+                    .Keyword_and => p.nextToken().index,
+                    .Invalid_ampersands => blk: {
+                        try p.errors.append(p.gpa, .{
+                            .InvalidAnd = .{ .token = p.tok_i },
+                        });
+                        break :blk p.nextToken().index;
+                    },
+                    else => return null,
+                } else p.eatToken(token) orelse return null;
+
+                const node = try p.arena.allocator.create(Node.InfixOp);
+                node.* = .{
+                    .op_token = op_token,
+                    .lhs = undefined, // set by caller
+                    .op = op,
+                    .rhs = undefined, // set by caller
+                };
+                return &node.base;
+            }
+        }.parse;
+    }
+
+    // Helper parsers not included in the grammar
+
+    fn parseBuiltinCall(p: *Parser) !?*Node {
+        const token = p.eatToken(.Builtin) orelse return null;
+        const params = (try p.parseFnCallArguments()) orelse {
+            try p.errors.append(p.gpa, .{
+                .ExpectedParamList = .{ .token = p.tok_i },
+            });
+
+            // lets pretend this was an identifier so we can continue parsing
+            const node = try p.arena.allocator.create(Node.Identifier);
+            node.* = .{
+                .token = token,
+            };
+            return &node.base;
+        };
+        const node = try p.arena.allocator.create(Node.BuiltinCall);
+        node.* = .{
+            .builtin_token = token,
+            .params = params.list,
+            .rparen_token = params.rparen,
+        };
+        return &node.base;
+    }
+
+    fn parseErrorTag(p: *Parser) !?*Node {
+        const doc_comments = try p.parseDocComment(); // no need to rewind on failure
+        const token = p.eatToken(.Identifier) orelse return null;
+
+        const node = try p.arena.allocator.create(Node.ErrorTag);
+        node.* = .{
+            .doc_comments = doc_comments,
+            .name_token = token,
+        };
+        return &node.base;
+    }
+
+    fn parseIdentifier(p: *Parser) !?*Node {
+        const token = p.eatToken(.Identifier) orelse return null;
+        const node = try p.arena.allocator.create(Node.Identifier);
+        node.* = .{
+            .token = token,
+        };
+        return &node.base;
+    }
+
+    fn parseVarType(p: *Parser) !?*Node {
+        const token = p.eatToken(.Keyword_var) orelse return null;
+        const node = try p.arena.allocator.create(Node.VarType);
+        node.* = .{
+            .token = token,
+        };
+        return &node.base;
+    }
+
+    fn createLiteral(p: *Parser, comptime T: type, token: TokenIndex) !*Node {
+        const result = try p.arena.allocator.create(T);
+        result.* = T{
+            .base = Node{ .id = Node.typeToId(T) },
+            .token = token,
+        };
+        return &result.base;
+    }
+
+    fn parseStringLiteralSingle(p: *Parser) !?*Node {
+        if (p.eatToken(.StringLiteral)) |token| {
+            const node = try p.arena.allocator.create(Node.StringLiteral);
+            node.* = .{
+                .token = token,
+            };
+            return &node.base;
+        }
+        return null;
+    }
+
+    // string literal or multiline string literal
+    fn parseStringLiteral(p: *Parser) !?*Node {
+        if (try p.parseStringLiteralSingle()) |node| return node;
+
+        if (p.eatToken(.MultilineStringLiteralLine)) |first_line| {
+            const node = try p.arena.allocator.create(Node.MultilineStringLiteral);
+            node.* = .{
+                .lines = Node.MultilineStringLiteral.LineList{},
+            };
+            var lines_it = &node.lines.first;
+            lines_it = try p.llpush(TokenIndex, lines_it, first_line);
+            while (p.eatToken(.MultilineStringLiteralLine)) |line|
+                lines_it = try p.llpush(TokenIndex, lines_it, line);
+
+            return &node.base;
+        }
+
+        return null;
+    }
+
+    fn parseIntegerLiteral(p: *Parser) !?*Node {
+        const token = p.eatToken(.IntegerLiteral) orelse return null;
+        const node = try p.arena.allocator.create(Node.IntegerLiteral);
+        node.* = .{
+            .token = token,
+        };
+        return &node.base;
+    }
+
+    fn parseFloatLiteral(p: *Parser) !?*Node {
+        const token = p.eatToken(.FloatLiteral) orelse return null;
+        const node = try p.arena.allocator.create(Node.FloatLiteral);
+        node.* = .{
+            .token = token,
+        };
+        return &node.base;
+    }
+
+    fn parseTry(p: *Parser) !?*Node {
+        const token = p.eatToken(.Keyword_try) orelse return null;
+        const node = try p.arena.allocator.create(Node.PrefixOp);
+        node.* = .{
+            .op_token = token,
+            .op = .Try,
+            .rhs = undefined, // set by caller
+        };
+        return &node.base;
+    }
+
+    fn parseUse(p: *Parser) !?*Node {
+        const token = p.eatToken(.Keyword_usingnamespace) orelse return null;
+        const node = try p.arena.allocator.create(Node.Use);
+        node.* = .{
+            .doc_comments = null,
+            .visib_token = null,
+            .use_token = token,
+            .expr = try p.expectNode(parseExpr, .{
+                .ExpectedExpr = .{ .token = p.tok_i },
+            }),
+            .semicolon_token = try p.expectToken(.Semicolon),
+        };
+        return &node.base;
+    }
+
+    /// IfPrefix Body (KEYWORD_else Payload? Body)?
+    fn parseIf(p: *Parser, bodyParseFn: NodeParseFn) !?*Node {
+        const node = (try p.parseIfPrefix()) orelse return null;
+        const if_prefix = node.cast(Node.If).?;
+
+        if_prefix.body = try p.expectNode(bodyParseFn, .{
+            .InvalidToken = .{ .token = p.tok_i },
+        });
+
+        const else_token = p.eatToken(.Keyword_else) orelse return node;
+        const payload = try p.parsePayload();
+        const else_expr = try p.expectNode(bodyParseFn, .{
+            .InvalidToken = .{ .token = p.tok_i },
+        });
+        const else_node = try p.arena.allocator.create(Node.Else);
+        else_node.* = .{
+            .else_token = else_token,
+            .payload = payload,
+            .body = else_expr,
+        };
+        if_prefix.@"else" = else_node;
+
+        return node;
+    }
+
+    /// Eat a multiline doc comment
+    fn parseDocComment(p: *Parser) !?*Node.DocComment {
+        var lines = Node.DocComment.LineList{};
+        var lines_it = &lines.first;
+
+        while (p.eatToken(.DocComment)) |line| {
+            lines_it = try p.llpush(TokenIndex, lines_it, line);
+        }
+
+        if (lines.first == null) return null;
+
+        const node = try p.arena.allocator.create(Node.DocComment);
+        node.* = .{
+            .lines = lines,
+        };
+        return node;
+    }
+
+    fn tokensOnSameLine(p: *Parser, token1: TokenIndex, token2: TokenIndex) bool {
+        return std.mem.indexOfScalar(u8, p.source[p.tokens[token1].end..p.tokens[token2].start], '\n') == null;
+    }
+
+    /// Eat a single-line doc comment on the same line as another node
+    fn parseAppendedDocComment(p: *Parser, after_token: TokenIndex) !?*Node.DocComment {
+        const comment_token = p.eatToken(.DocComment) orelse return null;
+        if (p.tokensOnSameLine(after_token, comment_token)) {
+            var lines = Node.DocComment.LineList{};
+            _ = try p.llpush(TokenIndex, &lines.first, comment_token);
+
+            const node = try p.arena.allocator.create(Node.DocComment);
+            node.* = .{ .lines = lines };
+            return node;
+        }
+        p.putBackToken(comment_token);
+        return null;
+    }
+
+    /// Op* Child
+    fn parsePrefixOpExpr(p: *Parser, opParseFn: NodeParseFn, childParseFn: NodeParseFn) Error!?*Node {
+        if (try opParseFn(p)) |first_op| {
+            var rightmost_op = first_op;
+            while (true) {
+                switch (rightmost_op.id) {
+                    .PrefixOp => {
+                        var prefix_op = rightmost_op.cast(Node.PrefixOp).?;
+                        // If the token encountered was **, there will be two nodes
+                        if (p.tokens[prefix_op.op_token].id == .AsteriskAsterisk) {
+                            rightmost_op = prefix_op.rhs;
+                            prefix_op = rightmost_op.cast(Node.PrefixOp).?;
+                        }
+                        if (try opParseFn(p)) |rhs| {
+                            prefix_op.rhs = rhs;
+                            rightmost_op = rhs;
+                        } else break;
+                    },
+                    .AnyFrameType => {
+                        const prom = rightmost_op.cast(Node.AnyFrameType).?;
+                        if (try opParseFn(p)) |rhs| {
+                            prom.result.?.return_type = rhs;
+                            rightmost_op = rhs;
+                        } else break;
+                    },
+                    else => unreachable,
+                }
+            }
+
+            // If any prefix op existed, a child node on the RHS is required
+            switch (rightmost_op.id) {
+                .PrefixOp => {
+                    const prefix_op = rightmost_op.cast(Node.PrefixOp).?;
+                    prefix_op.rhs = try p.expectNode(childParseFn, .{
+                        .InvalidToken = .{ .token = p.tok_i },
+                    });
+                },
+                .AnyFrameType => {
+                    const prom = rightmost_op.cast(Node.AnyFrameType).?;
+                    prom.result.?.return_type = try p.expectNode(childParseFn, .{
+                        .InvalidToken = .{ .token = p.tok_i },
+                    });
+                },
+                else => unreachable,
+            }
+
+            return first_op;
+        }
+
+        // Otherwise, the child node is optional
+        return childParseFn(p);
+    }
+
+    /// Child (Op Child)*
+    /// Child (Op Child)?
+    fn parseBinOpExpr(
+        p: *Parser,
+        opParseFn: NodeParseFn,
+        childParseFn: NodeParseFn,
+        chain: enum {
+            Once,
+            Infinitely,
+        },
+    ) Error!?*Node {
+        var res = (try childParseFn(p)) orelse return null;
+
+        while (try opParseFn(p)) |node| {
+            const right = try p.expectNode(childParseFn, .{
+                .InvalidToken = .{ .token = p.tok_i },
+            });
+            const left = res;
+            res = node;
+
+            const op = node.cast(Node.InfixOp).?;
+            op.*.lhs = left;
+            op.*.rhs = right;
+
+            switch (chain) {
+                .Once => break,
+                .Infinitely => continue,
+            }
+        }
+
+        return res;
+    }
+
+    fn createInfixOp(p: *Parser, index: TokenIndex, op: Node.InfixOp.Op) !*Node {
+        const node = try p.arena.allocator.create(Node.InfixOp);
+        node.* = .{
+            .op_token = index,
+            .lhs = undefined, // set by caller
+            .op = op,
+            .rhs = undefined, // set by caller
+        };
+        return &node.base;
+    }
+
+    fn eatToken(p: *Parser, id: Token.Id) ?TokenIndex {
+        return if (p.eatAnnotatedToken(id)) |token| token.index else null;
+    }
+
+    fn eatAnnotatedToken(p: *Parser, id: Token.Id) ?AnnotatedToken {
+        return if (p.tokens[p.tok_i].id == id) p.nextToken() else null;
+    }
+
+    fn expectToken(p: *Parser, id: Token.Id) Error!TokenIndex {
+        return (try p.expectTokenRecoverable(id)) orelse
+            error.ParseError;
+    }
+
+    fn expectTokenRecoverable(p: *Parser, id: Token.Id) !?TokenIndex {
+        const token = p.nextToken();
+        if (token.ptr.id != id) {
+            try p.errors.append(p.gpa, .{
+                .ExpectedToken = .{ .token = token.index, .expected_id = id },
+            });
+            // go back so that we can recover properly
+            p.putBackToken(token.index);
+            return null;
+        }
+        return token.index;
+    }
+
+    fn nextToken(p: *Parser) AnnotatedToken {
+        const result = AnnotatedToken{
+            .index = p.tok_i,
+            .ptr = &p.tokens[p.tok_i],
+        };
+        if (p.tokens[p.tok_i].id == .Eof) {
+            return result;
+        }
+        p.tok_i += 1;
+        assert(result.ptr.id != .LineComment);
+
+        while (true) {
+            const next_tok = p.tokens[p.tok_i];
+            if (next_tok.id != .LineComment) return result;
+            p.tok_i += 1;
+        }
+    }
+
+    fn putBackToken(p: *Parser, putting_back: TokenIndex) void {
+        while (p.tok_i > 0) {
+            p.tok_i -= 1;
+            const prev_tok = p.tokens[p.tok_i];
+            if (prev_tok.id == .LineComment) continue;
+            assert(putting_back == p.tok_i);
+            return;
+        }
+    }
+
+    const AnnotatedToken = struct {
+        index: TokenIndex,
+        ptr: *const Token,
+    };
+
+    fn expectNode(
+        p: *Parser,
+        parseFn: NodeParseFn,
+        /// if parsing fails
+        err: AstError,
+    ) Error!*Node {
+        return (try p.expectNodeRecoverable(parseFn, err)) orelse return error.ParseError;
+    }
+
+    fn expectNodeRecoverable(
+        p: *Parser,
+        parseFn: NodeParseFn,
+        /// if parsing fails
+        err: AstError,
+    ) !?*Node {
+        return (try parseFn(p)) orelse {
+            try p.errors.append(p.gpa, err);
+            return null;
+        };
+    }
 };
 
-fn expectNode(
-    arena: *Allocator,
-    it: *TokenIterator,
-    tree: *Tree,
-    parseFn: NodeParseFn,
-    err: AstError, // if parsing fails
-) Error!*Node {
-    return (try expectNodeRecoverable(arena, it, tree, parseFn, err)) orelse
-        return error.ParseError;
+fn ParseFn(comptime T: type) type {
+    return fn (p: *Parser) Error!T;
 }
 
-fn expectNodeRecoverable(
-    arena: *Allocator,
-    it: *TokenIterator,
-    tree: *Tree,
-    parseFn: NodeParseFn,
-    err: AstError, // if parsing fails
-) !?*Node {
-    return (try parseFn(arena, it, tree)) orelse {
-        try tree.errors.push(err);
-        return null;
-    };
-}
 
 test "std.zig.parser" {
     _ = @import("parser_test.zig");

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -10,6 +10,13 @@ const Token = std.zig.Token;
 
 pub const Error = error{ParseError} || Allocator.Error;
 
+/// This is the maximum length of a list that will be copied into the ast.Tree
+/// arena when parsing. If the list is longer than this, the ast.Tree will have
+/// a reference to the memory allocated in the general purpose allocator, and
+/// will free it separately. Simply put, lists longer than this will elide the
+/// memcpy().
+const large_list_len = 512;
+
 /// Result should be freed with tree.deinit() when there are
 /// no more references to any of the tokens or nodes.
 pub fn parse(gpa: *Allocator, source: []const u8) Allocator.Error!*Tree {
@@ -32,6 +39,11 @@ pub fn parse(gpa: *Allocator, source: []const u8) Allocator.Error!*Tree {
         .tokens = tokens.items,
         .errors = .{},
         .tok_i = 0,
+        .owned_memory = .{},
+    };
+    defer parser.owned_memory.deinit(gpa);
+    errdefer for (parser.owned_memory.items) |list| {
+        gpa.free(list);
     };
     defer parser.errors.deinit(gpa);
     errdefer parser.arena.deinit();
@@ -46,6 +58,7 @@ pub fn parse(gpa: *Allocator, source: []const u8) Allocator.Error!*Tree {
         .source = source,
         .tokens = tokens.toOwnedSlice(),
         .errors = parser.errors.toOwnedSlice(gpa),
+        .owned_memory = parser.owned_memory.toOwnedSlice(gpa),
         .root_node = root_node,
         .arena = parser.arena.state,
     };
@@ -60,6 +73,7 @@ const Parser = struct {
     tokens: []const Token,
     tok_i: TokenIndex,
     errors: std.ArrayListUnmanaged(AstError),
+    owned_memory: std.ArrayListUnmanaged([]u8),
 
     /// Root <- skip ContainerMembers eof
     fn parseRoot(p: *Parser) Allocator.Error!*Node.Root {
@@ -1307,11 +1321,19 @@ const Parser = struct {
                 const next = (try p.parseFieldInit()) orelse break;
                 try init_list.append(next);
             }
+
+            const list = if (init_list.items.len > large_list_len) blk: {
+                try p.owned_memory.ensureCapacity(p.gpa, p.owned_memory.items.len + 1);
+                const list = init_list.toOwnedSlice();
+                p.owned_memory.appendAssumeCapacity(std.mem.sliceAsBytes(list));
+                break :blk list;
+            } else try p.arena.allocator.dupe(*Node, init_list.items);
+
             const node = try p.arena.allocator.create(Node.StructInitializer);
             node.* = .{
                 .lhs = lhs,
                 .rtoken = try p.expectToken(.RBrace),
-                .list = try p.arena.allocator.dupe(*Node, init_list.items),
+                .list = list,
             };
             return &node.base;
         }
@@ -1322,11 +1344,19 @@ const Parser = struct {
                 const next = (try p.parseExpr()) orelse break;
                 try init_list.append(next);
             }
+
+            const list = if (init_list.items.len > large_list_len) blk: {
+                try p.owned_memory.ensureCapacity(p.gpa, p.owned_memory.items.len + 1);
+                const list = init_list.toOwnedSlice();
+                p.owned_memory.appendAssumeCapacity(std.mem.sliceAsBytes(list));
+                break :blk list;
+            } else try p.arena.allocator.dupe(*Node, init_list.items);
+
             const node = try p.arena.allocator.create(Node.ArrayInitializer);
             node.* = .{
                 .lhs = lhs,
                 .rtoken = try p.expectToken(.RBrace),
-                .list = try p.arena.allocator.dupe(*Node, init_list.items),
+                .list = list,
             };
             return &node.base;
         }
@@ -1355,11 +1385,19 @@ const Parser = struct {
                 const next = (try p.parseFieldInit()) orelse break;
                 try init_list.append(next);
             }
+
+            const list = if (init_list.items.len > large_list_len) blk: {
+                try p.owned_memory.ensureCapacity(p.gpa, p.owned_memory.items.len + 1);
+                const list = init_list.toOwnedSlice();
+                p.owned_memory.appendAssumeCapacity(std.mem.sliceAsBytes(list));
+                break :blk list;
+            } else try p.arena.allocator.dupe(*Node, init_list.items);
+
             const node = try p.arena.allocator.create(Node.StructInitializerDot);
             node.* = .{
                 .dot = dot,
                 .rtoken = try p.expectToken(.RBrace),
-                .list = try p.arena.allocator.dupe(*Node, init_list.items),
+                .list = list,
             };
             return &node.base;
         }
@@ -1370,11 +1408,19 @@ const Parser = struct {
                 const next = (try p.parseExpr()) orelse break;
                 try init_list.append(next);
             }
+
+            const list = if (init_list.items.len > large_list_len) blk: {
+                try p.owned_memory.ensureCapacity(p.gpa, p.owned_memory.items.len + 1);
+                const list = init_list.toOwnedSlice();
+                p.owned_memory.appendAssumeCapacity(std.mem.sliceAsBytes(list));
+                break :blk list;
+            } else try p.arena.allocator.dupe(*Node, init_list.items);
+
             const node = try p.arena.allocator.create(Node.ArrayInitializerDot);
             node.* = .{
                 .dot = dot,
                 .rtoken = try p.expectToken(.RBrace),
-                .list = try p.arena.allocator.dupe(*Node, init_list.items),
+                .list = list,
             };
             return &node.base;
         }

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -3181,7 +3181,7 @@ fn testParse(source: []const u8, allocator: *mem.Allocator, anything_changed: *b
     defer tree.deinit();
 
     for (tree.errors) |*parse_error| {
-        const token = tree.tokens[parse_error.loc()];
+        const token = tree.token_locs[parse_error.loc()];
         const loc = tree.tokenLocation(0, parse_error.loc());
         try stderr.print("(memory buffer):{}:{}: error: ", .{ loc.line + 1, loc.column + 1 });
         try tree.renderError(parse_error, stderr);

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -3180,9 +3180,8 @@ fn testParse(source: []const u8, allocator: *mem.Allocator, anything_changed: *b
     const tree = try std.zig.parse(allocator, source);
     defer tree.deinit();
 
-    var error_it = tree.errors.iterator(0);
-    while (error_it.next()) |parse_error| {
-        const token = tree.tokens.at(parse_error.loc());
+    for (tree.errors) |*parse_error| {
+        const token = tree.tokens[parse_error.loc()];
         const loc = tree.tokenLocation(0, parse_error.loc());
         try stderr.print("(memory buffer):{}:{}: error: ", .{ loc.line + 1, loc.column + 1 });
         try tree.renderError(parse_error, stderr);
@@ -3271,8 +3270,6 @@ fn testError(source: []const u8, expected_errors: []const Error) !void {
 
     std.testing.expect(tree.errors.len == expected_errors.len);
     for (expected_errors) |expected, i| {
-        const err = tree.errors.at(i);
-
-        std.testing.expect(expected == err.*);
+        std.testing.expect(expected == tree.errors[i]);
     }
 }

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1376,9 +1376,7 @@ fn renderExpression(
                 skip_first_indent = false;
             }
 
-            var it = multiline_str_literal.lines.first;
-            while (it) |t_node| : (it = t_node.next) {
-                const t = t_node.data;
+            for (multiline_str_literal.lines()) |t| {
                 if (!skip_first_indent) {
                     try stream.writeByteNTimes(' ', indent + indent_delta);
                 }

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -358,21 +358,20 @@ fn renderExpression(
                 try renderToken(tree, stream, tree.nextToken(label), indent, start_col, Space.Space);
             }
 
-            if (block.statements.first == null) {
+            if (block.statements_len == 0) {
                 try renderToken(tree, stream, block.lbrace, indent + indent_delta, start_col, Space.None);
                 return renderToken(tree, stream, block.rbrace, indent, start_col, space);
             } else {
                 const block_indent = indent + indent_delta;
                 try renderToken(tree, stream, block.lbrace, block_indent, start_col, Space.Newline);
 
-                var it = block.statements.first;
-                while (it) |statement_node| : (it = statement_node.next) {
-                    const statement = statement_node.data;
+                const block_statements = block.statements();
+                for (block_statements) |statement, i| {
                     try stream.writeByteNTimes(' ', block_indent);
                     try renderStatement(allocator, stream, tree, block_indent, start_col, statement);
 
-                    if (statement_node.next) |next_statement| {
-                        try renderExtraNewline(tree, stream, start_col, next_statement.data);
+                    if (i + 1 < block_statements.len) {
+                        try renderExtraNewline(tree, stream, start_col, block_statements[i + 1]);
                     }
                 }
 

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -915,8 +915,7 @@ fn renderExpression(
 
                     if (maybe_row_size) |row_size| {
                         // A place to store the width of each expression and its column's maximum
-                        const exprs_len = countLen(exprs.first);
-                        var widths = try allocator.alloc(usize, exprs_len + row_size);
+                        var widths = try allocator.alloc(usize, exprs.len() + row_size);
                         defer allocator.free(widths);
                         mem.set(usize, widths, 0);
 
@@ -1391,7 +1390,7 @@ fn renderExpression(
                 {
                     break :blk false;
                 }
-                const last_node = findLast(builtin_call.params.first.?).data;
+                const last_node = builtin_call.params.first.?.findLast().data;
                 const maybe_comma = tree.nextToken(last_node.lastToken());
                 break :blk tree.tokens[maybe_comma].id == .Comma;
             };
@@ -1615,7 +1614,7 @@ fn renderExpression(
 
             assert(switch_case.items.first != null);
             const src_has_trailing_comma = blk: {
-                const last_node = findLast(switch_case.items.first.?).data;
+                const last_node = switch_case.items.first.?.findLast().data;
                 const maybe_comma = tree.nextToken(last_node.lastToken());
                 break :blk tree.tokens[maybe_comma].id == .Comma;
             };
@@ -2509,20 +2508,4 @@ fn copyFixingWhitespace(stream: var, slice: []const u8) @TypeOf(stream).Error!vo
         '\r' => {},
         else => try stream.writeByte(byte),
     };
-}
-
-fn countLen(node: ?*std.SinglyLinkedList(*ast.Node).Node) usize {
-    var count: usize = 0;
-    var it = node;
-    while (it) |n| : (it = n.next) {
-        count += 1;
-    }
-    return count;
-}
-
-fn findLast(node: *std.SinglyLinkedList(*ast.Node).Node) *std.SinglyLinkedList(*ast.Node).Node {
-    var it = node;
-    while (true) {
-        it = it.next orelse return it;
-    }
 }

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -620,13 +620,13 @@ fn renderExpression(
                 .ArrayInitializerDot => blk: {
                     const casted = @fieldParentPtr(ast.Node.ArrayInitializerDot, "base", base);
                     rtoken = casted.rtoken;
-                    exprs = casted.list;
+                    exprs = casted.list();
                     break :blk .{ .dot = casted.dot };
                 },
                 .ArrayInitializer => blk: {
                     const casted = @fieldParentPtr(ast.Node.ArrayInitializer, "base", base);
                     rtoken = casted.rtoken;
-                    exprs = casted.list;
+                    exprs = casted.list();
                     break :blk .{ .node = casted.lhs };
                 },
                 else => unreachable,
@@ -784,13 +784,13 @@ fn renderExpression(
                 .StructInitializerDot => blk: {
                     const casted = @fieldParentPtr(ast.Node.StructInitializerDot, "base", base);
                     rtoken = casted.rtoken;
-                    field_inits = casted.list;
+                    field_inits = casted.list();
                     break :blk .{ .dot = casted.dot };
                 },
                 .StructInitializer => blk: {
                     const casted = @fieldParentPtr(ast.Node.StructInitializer, "base", base);
                     rtoken = casted.rtoken;
-                    field_inits = casted.list;
+                    field_inits = casted.list();
                     break :blk .{ .node = casted.lhs };
                 },
                 else => unreachable,

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -3,8 +3,12 @@ const mem = std.mem;
 
 pub const Token = struct {
     id: Id,
-    start: usize,
-    end: usize,
+    loc: Loc,
+
+    pub const Loc = struct {
+        start: usize,
+        end: usize,
+    };
 
     pub const Keyword = struct {
         bytes: []const u8,
@@ -426,8 +430,10 @@ pub const Tokenizer = struct {
         var state: State = .start;
         var result = Token{
             .id = .Eof,
-            .start = self.index,
-            .end = undefined,
+            .loc = .{
+                .start = self.index,
+                .end = undefined,
+            },
         };
         var seen_escape_digits: usize = undefined;
         var remaining_code_units: usize = undefined;
@@ -436,7 +442,7 @@ pub const Tokenizer = struct {
             switch (state) {
                 .start => switch (c) {
                     ' ', '\n', '\t', '\r' => {
-                        result.start = self.index + 1;
+                        result.loc.start = self.index + 1;
                     },
                     '"' => {
                         state = .string_literal;
@@ -686,7 +692,7 @@ pub const Tokenizer = struct {
                 .identifier => switch (c) {
                     'a'...'z', 'A'...'Z', '_', '0'...'9' => {},
                     else => {
-                        if (Token.getKeyword(self.buffer[result.start..self.index])) |id| {
+                        if (Token.getKeyword(self.buffer[result.loc.start..self.index])) |id| {
                             result.id = id;
                         }
                         break;
@@ -1313,7 +1319,7 @@ pub const Tokenizer = struct {
                 => {},
 
                 .identifier => {
-                    if (Token.getKeyword(self.buffer[result.start..self.index])) |id| {
+                    if (Token.getKeyword(self.buffer[result.loc.start..self.index])) |id| {
                         result.id = id;
                     }
                 },
@@ -1420,7 +1426,7 @@ pub const Tokenizer = struct {
             }
         }
 
-        result.end = self.index;
+        result.loc.end = self.index;
         return result;
     }
 
@@ -1430,8 +1436,10 @@ pub const Tokenizer = struct {
         if (invalid_length == 0) return;
         self.pending_invalid_token = .{
             .id = .Invalid,
-            .start = self.index,
-            .end = self.index + invalid_length,
+            .loc = .{
+                .start = self.index,
+                .end = self.index + invalid_length,
+            },
         };
     }
 

--- a/src-self-hosted/clang.zig
+++ b/src-self-hosted/clang.zig
@@ -63,7 +63,7 @@ pub const struct_ZigClangReturnStmt = @Type(.Opaque);
 pub const struct_ZigClangSkipFunctionBodiesScope = @Type(.Opaque);
 pub const struct_ZigClangSourceManager = @Type(.Opaque);
 pub const struct_ZigClangSourceRange = @Type(.Opaque);
-pub const struct_ZigClangStmt = @Type(.Opaque);
+pub const ZigClangStmt = @Type(.Opaque);
 pub const struct_ZigClangStringLiteral = @Type(.Opaque);
 pub const struct_ZigClangStringRef = @Type(.Opaque);
 pub const struct_ZigClangSwitchStmt = @Type(.Opaque);
@@ -842,9 +842,9 @@ pub extern fn ZigClangType_getTypeClassName(self: *const struct_ZigClangType) [*
 pub extern fn ZigClangType_getAsArrayTypeUnsafe(self: *const ZigClangType) *const ZigClangArrayType;
 pub extern fn ZigClangType_getAsRecordType(self: *const ZigClangType) ?*const ZigClangRecordType;
 pub extern fn ZigClangType_getAsUnionType(self: *const ZigClangType) ?*const ZigClangRecordType;
-pub extern fn ZigClangStmt_getBeginLoc(self: *const struct_ZigClangStmt) struct_ZigClangSourceLocation;
-pub extern fn ZigClangStmt_getStmtClass(self: ?*const struct_ZigClangStmt) ZigClangStmtClass;
-pub extern fn ZigClangStmt_classof_Expr(self: ?*const struct_ZigClangStmt) bool;
+pub extern fn ZigClangStmt_getBeginLoc(self: *const ZigClangStmt) struct_ZigClangSourceLocation;
+pub extern fn ZigClangStmt_getStmtClass(self: ?*const ZigClangStmt) ZigClangStmtClass;
+pub extern fn ZigClangStmt_classof_Expr(self: ?*const ZigClangStmt) bool;
 pub extern fn ZigClangExpr_getStmtClass(self: *const struct_ZigClangExpr) ZigClangStmtClass;
 pub extern fn ZigClangExpr_getType(self: *const struct_ZigClangExpr) struct_ZigClangQualType;
 pub extern fn ZigClangExpr_getBeginLoc(self: *const struct_ZigClangExpr) struct_ZigClangSourceLocation;
@@ -873,7 +873,7 @@ pub extern fn ZigClangFunctionDecl_getLocation(self: *const ZigClangFunctionDecl
 pub extern fn ZigClangFunctionDecl_hasBody(self: *const ZigClangFunctionDecl) bool;
 pub extern fn ZigClangFunctionDecl_getStorageClass(self: *const ZigClangFunctionDecl) ZigClangStorageClass;
 pub extern fn ZigClangFunctionDecl_getParamDecl(self: *const ZigClangFunctionDecl, i: c_uint) *const struct_ZigClangParmVarDecl;
-pub extern fn ZigClangFunctionDecl_getBody(self: *const ZigClangFunctionDecl) *const struct_ZigClangStmt;
+pub extern fn ZigClangFunctionDecl_getBody(self: *const ZigClangFunctionDecl) *const ZigClangStmt;
 pub extern fn ZigClangFunctionDecl_doesDeclarationForceExternallyVisibleDefinition(self: *const ZigClangFunctionDecl) bool;
 pub extern fn ZigClangFunctionDecl_isThisDeclarationADefinition(self: *const ZigClangFunctionDecl) bool;
 pub extern fn ZigClangFunctionDecl_doesThisDeclarationHaveABody(self: *const ZigClangFunctionDecl) bool;
@@ -959,7 +959,6 @@ pub const ZigClangReturnStmt = struct_ZigClangReturnStmt;
 pub const ZigClangSkipFunctionBodiesScope = struct_ZigClangSkipFunctionBodiesScope;
 pub const ZigClangSourceManager = struct_ZigClangSourceManager;
 pub const ZigClangSourceRange = struct_ZigClangSourceRange;
-pub const ZigClangStmt = struct_ZigClangStmt;
 pub const ZigClangStringLiteral = struct_ZigClangStringLiteral;
 pub const ZigClangStringRef = struct_ZigClangStringRef;
 pub const ZigClangSwitchStmt = struct_ZigClangSwitchStmt;
@@ -1018,7 +1017,7 @@ pub extern fn ZigClangLoadFromCommandLine(
 pub extern fn ZigClangDecl_getKind(decl: *const ZigClangDecl) ZigClangDeclKind;
 pub extern fn ZigClangDecl_getDeclKindName(decl: *const struct_ZigClangDecl) [*:0]const u8;
 
-pub const ZigClangCompoundStmt_const_body_iterator = [*]const *struct_ZigClangStmt;
+pub const ZigClangCompoundStmt_const_body_iterator = [*]const *ZigClangStmt;
 
 pub extern fn ZigClangCompoundStmt_body_begin(self: *const ZigClangCompoundStmt) ZigClangCompoundStmt_const_body_iterator;
 pub extern fn ZigClangCompoundStmt_body_end(self: *const ZigClangCompoundStmt) ZigClangCompoundStmt_const_body_iterator;

--- a/src-self-hosted/clang.zig
+++ b/src-self-hosted/clang.zig
@@ -22,7 +22,7 @@ pub const struct_ZigClangCompoundStmt = @Type(.Opaque);
 pub const struct_ZigClangConstantArrayType = @Type(.Opaque);
 pub const struct_ZigClangContinueStmt = @Type(.Opaque);
 pub const struct_ZigClangDecayedType = @Type(.Opaque);
-pub const struct_ZigClangDecl = @Type(.Opaque);
+pub const ZigClangDecl = @Type(.Opaque);
 pub const struct_ZigClangDeclRefExpr = @Type(.Opaque);
 pub const struct_ZigClangDeclStmt = @Type(.Opaque);
 pub const struct_ZigClangDefaultStmt = @Type(.Opaque);
@@ -781,7 +781,7 @@ pub extern fn ZigClangSourceManager_getCharacterData(self: ?*const struct_ZigCla
 pub extern fn ZigClangASTContext_getPointerType(self: ?*const struct_ZigClangASTContext, T: struct_ZigClangQualType) struct_ZigClangQualType;
 pub extern fn ZigClangASTUnit_getASTContext(self: ?*struct_ZigClangASTUnit) ?*struct_ZigClangASTContext;
 pub extern fn ZigClangASTUnit_getSourceManager(self: *struct_ZigClangASTUnit) *struct_ZigClangSourceManager;
-pub extern fn ZigClangASTUnit_visitLocalTopLevelDecls(self: *struct_ZigClangASTUnit, context: ?*c_void, Fn: ?fn (?*c_void, *const struct_ZigClangDecl) callconv(.C) bool) bool;
+pub extern fn ZigClangASTUnit_visitLocalTopLevelDecls(self: *struct_ZigClangASTUnit, context: ?*c_void, Fn: ?fn (?*c_void, *const ZigClangDecl) callconv(.C) bool) bool;
 pub extern fn ZigClangRecordType_getDecl(record_ty: ?*const struct_ZigClangRecordType) *const struct_ZigClangRecordDecl;
 pub extern fn ZigClangTagDecl_isThisDeclarationADefinition(self: *const ZigClangTagDecl) bool;
 pub extern fn ZigClangEnumType_getDecl(record_ty: ?*const struct_ZigClangEnumType) *const struct_ZigClangEnumDecl;
@@ -817,7 +817,7 @@ pub extern fn ZigClangEnumDecl_enumerator_end(*const ZigClangEnumDecl) ZigClangE
 pub extern fn ZigClangEnumDecl_enumerator_iterator_next(ZigClangEnumDecl_enumerator_iterator) ZigClangEnumDecl_enumerator_iterator;
 pub extern fn ZigClangEnumDecl_enumerator_iterator_deref(ZigClangEnumDecl_enumerator_iterator) *const ZigClangEnumConstantDecl;
 pub extern fn ZigClangEnumDecl_enumerator_iterator_neq(ZigClangEnumDecl_enumerator_iterator, ZigClangEnumDecl_enumerator_iterator) bool;
-pub extern fn ZigClangDecl_castToNamedDecl(decl: *const struct_ZigClangDecl) ?*const ZigClangNamedDecl;
+pub extern fn ZigClangDecl_castToNamedDecl(decl: *const ZigClangDecl) ?*const ZigClangNamedDecl;
 pub extern fn ZigClangNamedDecl_getName_bytes_begin(decl: ?*const struct_ZigClangNamedDecl) [*:0]const u8;
 pub extern fn ZigClangSourceLocation_eq(a: struct_ZigClangSourceLocation, b: struct_ZigClangSourceLocation) bool;
 pub extern fn ZigClangTypedefType_getDecl(self: ?*const struct_ZigClangTypedefType) *const struct_ZigClangTypedefNameDecl;
@@ -918,7 +918,6 @@ pub const ZigClangCompoundStmt = struct_ZigClangCompoundStmt;
 pub const ZigClangConstantArrayType = struct_ZigClangConstantArrayType;
 pub const ZigClangContinueStmt = struct_ZigClangContinueStmt;
 pub const ZigClangDecayedType = struct_ZigClangDecayedType;
-pub const ZigClangDecl = struct_ZigClangDecl;
 pub const ZigClangDeclRefExpr = struct_ZigClangDeclRefExpr;
 pub const ZigClangDeclStmt = struct_ZigClangDeclStmt;
 pub const ZigClangDefaultStmt = struct_ZigClangDefaultStmt;
@@ -1015,14 +1014,14 @@ pub extern fn ZigClangLoadFromCommandLine(
 ) ?*ZigClangASTUnit;
 
 pub extern fn ZigClangDecl_getKind(decl: *const ZigClangDecl) ZigClangDeclKind;
-pub extern fn ZigClangDecl_getDeclKindName(decl: *const struct_ZigClangDecl) [*:0]const u8;
+pub extern fn ZigClangDecl_getDeclKindName(decl: *const ZigClangDecl) [*:0]const u8;
 
 pub const ZigClangCompoundStmt_const_body_iterator = [*]const *ZigClangStmt;
 
 pub extern fn ZigClangCompoundStmt_body_begin(self: *const ZigClangCompoundStmt) ZigClangCompoundStmt_const_body_iterator;
 pub extern fn ZigClangCompoundStmt_body_end(self: *const ZigClangCompoundStmt) ZigClangCompoundStmt_const_body_iterator;
 
-pub const ZigClangDeclStmt_const_decl_iterator = [*]const *struct_ZigClangDecl;
+pub const ZigClangDeclStmt_const_decl_iterator = [*]const *ZigClangDecl;
 
 pub extern fn ZigClangDeclStmt_decl_begin(self: *const ZigClangDeclStmt) ZigClangDeclStmt_const_decl_iterator;
 pub extern fn ZigClangDeclStmt_decl_end(self: *const ZigClangDeclStmt) ZigClangDeclStmt_const_decl_iterator;

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -600,8 +600,7 @@ pub fn cmdFmt(gpa: *Allocator, args: []const []const u8) !void {
         };
         defer tree.deinit();
 
-        var error_it = tree.errors.iterator(0);
-        while (error_it.next()) |parse_error| {
+        for (tree.errors) |parse_error| {
             try printErrMsgToFile(gpa, parse_error, tree, "<stdin>", stderr_file, color);
         }
         if (tree.errors.len != 0) {
@@ -701,8 +700,7 @@ fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {
     };
     defer tree.deinit();
 
-    var error_it = tree.errors.iterator(0);
-    while (error_it.next()) |parse_error| {
+    for (tree.errors) |parse_error| {
         try printErrMsgToFile(fmt.gpa, parse_error, tree, file_path, std.io.getStdErr(), fmt.color);
     }
     if (tree.errors.len != 0) {
@@ -730,7 +728,7 @@ fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {
 
 fn printErrMsgToFile(
     gpa: *mem.Allocator,
-    parse_error: *const ast.Error,
+    parse_error: ast.Error,
     tree: *ast.Tree,
     path: []const u8,
     file: fs.File,
@@ -745,15 +743,15 @@ fn printErrMsgToFile(
     const span_first = lok_token;
     const span_last = lok_token;
 
-    const first_token = tree.tokens.at(span_first);
-    const last_token = tree.tokens.at(span_last);
+    const first_token = tree.tokens[span_first];
+    const last_token = tree.tokens[span_last];
     const start_loc = tree.tokenLocationPtr(0, first_token);
     const end_loc = tree.tokenLocationPtr(first_token.end, last_token);
 
     var text_buf = std.ArrayList(u8).init(gpa);
     defer text_buf.deinit();
     const out_stream = text_buf.outStream();
-    try parse_error.render(&tree.tokens, out_stream);
+    try parse_error.render(tree.tokens, out_stream);
     const text = text_buf.span();
 
     const stream = file.outStream();

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -743,15 +743,15 @@ fn printErrMsgToFile(
     const span_first = lok_token;
     const span_last = lok_token;
 
-    const first_token = tree.tokens[span_first];
-    const last_token = tree.tokens[span_last];
-    const start_loc = tree.tokenLocationPtr(0, first_token);
-    const end_loc = tree.tokenLocationPtr(first_token.end, last_token);
+    const first_token = tree.token_locs[span_first];
+    const last_token = tree.token_locs[span_last];
+    const start_loc = tree.tokenLocationLoc(0, first_token);
+    const end_loc = tree.tokenLocationLoc(first_token.end, last_token);
 
     var text_buf = std.ArrayList(u8).init(gpa);
     defer text_buf.deinit();
     const out_stream = text_buf.outStream();
-    try parse_error.render(tree.tokens, out_stream);
+    try parse_error.render(tree.token_ids, out_stream);
     const text = text_buf.span();
 
     const stream = file.outStream();

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -2235,6 +2235,7 @@ fn transInitListExprArray(
     }
 
     const ty_node = try transCreateNodeArrayType(rp, loc, ZigClangQualType_getTypePtr(child_qt), 1);
+    _ = try appendToken(rp.c, .LBrace, "{");
     const filler_init_node = try ast.Node.ArrayInitializer.alloc(rp.c.arena, 1);
     filler_init_node.* = .{
         .lhs = ty_node,

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -135,12 +135,13 @@ const Scope = struct {
         /// Given the desired name, return a name that does not shadow anything from outer scopes.
         /// Inserts the returned name into the scope.
         fn makeMangledName(scope: *Block, c: *Context, name: []const u8) ![]const u8 {
-            var proposed_name = name;
+            const name_copy = try c.arena.dupe(u8, name);
+            var proposed_name = name_copy;
             while (scope.contains(proposed_name)) {
                 scope.mangle_count += 1;
                 proposed_name = try std.fmt.allocPrint(c.arena, "{}_{}", .{ name, scope.mangle_count });
             }
-            try scope.variables.append(.{ .name = name, .alias = proposed_name });
+            try scope.variables.append(.{ .name = name_copy, .alias = proposed_name });
             return proposed_name;
         }
 

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -1486,17 +1486,9 @@ fn transDeclStmtOne(rp: RestorePoint, scope: *Scope, decl: *const ZigClangDecl, 
             const underlying_type = ZigClangQualType_getTypePtr(underlying_qual);
 
             const mangled_name = try block_scope.makeMangledName(c, name);
-            if (checkForBuiltinTypedef(name)) |builtin| {
-                try block_scope.variables.append(.{
-                    .alias = builtin,
-                    .name = mangled_name,
-                });
-                @panic("what are we supposed to return here?");
-            } else {
-                const node = (try transCreateNodeTypedef(rp, typedef_decl, false, mangled_name)) orelse
-                    return error.UnsupportedTranslation;
-                return &node.base;
-            }
+            const node = (try transCreateNodeTypedef(rp, typedef_decl, false, mangled_name)) orelse
+                return error.UnsupportedTranslation;
+            return &node.base;
         },
         else => |kind| return revertAndWarn(
             rp,

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -247,27 +247,6 @@ pub const Context = struct {
         }
     };
 
-    /// Helper function to append items to a singly linked list.
-    fn llpusher(c: *Context, list: *std.SinglyLinkedList(*ast.Node)) LinkedListPusher {
-        assert(list.first == null);
-        return .{
-            .c = c,
-            .it = &list.first,
-        };
-    }
-
-    fn llpush(
-        c: *Context,
-        comptime T: type,
-        it: *?*std.SinglyLinkedList(T).Node,
-        data: T,
-    ) !*?*std.SinglyLinkedList(T).Node {
-        const llnode = try c.arena.create(std.SinglyLinkedList(T).Node);
-        llnode.* = .{ .data = data };
-        it.* = llnode;
-        return &llnode.next;
-    }
-
     fn getMangle(c: *Context) u32 {
         c.mangle_count += 1;
         return c.mangle_count;

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -2478,8 +2478,8 @@ fn transDoWhileLoop(
     };
 
     // In both cases above, we reserved 1 extra statement.
-    body_node.statements()[body_node.statements_len] = &if_node.base;
     body_node.statements_len += 1;
+    body_node.statements()[body_node.statements_len - 1] = &if_node.base;
     if (new)
         body_node.rbrace = try appendToken(rp.c, .RBrace, "}");
     while_node.body = &body_node.base;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -3612,6 +3612,12 @@ static void add_top_level_decl(CodeGen *g, ScopeDecls *decls_scope, Tld *tld) {
         auto entry = decls_scope->decl_table.put_unique(tld->name, tld);
         if (entry) {
             Tld *other_tld = entry->value;
+            if (other_tld->id == TldIdVar) {
+                ZigVar *var = reinterpret_cast<TldVar *>(other_tld)->var;
+                if (var->var_type != nullptr && type_is_invalid(var->var_type)) {
+                    return; // already reported compile error
+                }
+            }
             ErrorMsg *msg = add_node_error(g, tld->source_node, buf_sprintf("redefinition of '%s'", buf_ptr(tld->name)));
             add_error_note(g, msg, other_tld->source_node, buf_sprintf("previous definition is here"));
             return;
@@ -3887,9 +3893,18 @@ ZigVar *add_variable(CodeGen *g, AstNode *source_node, Scope *parent_scope, Buf 
                 if (search_scope != nullptr) {
                     Tld *tld = find_decl(g, search_scope, name);
                     if (tld != nullptr && tld != src_tld) {
-                        ErrorMsg *msg = add_node_error(g, source_node,
-                                buf_sprintf("redefinition of '%s'", buf_ptr(name)));
-                        add_error_note(g, msg, tld->source_node, buf_sprintf("previous definition is here"));
+                        bool want_err_msg = true;
+                        if (tld->id == TldIdVar) {
+                            ZigVar *var = reinterpret_cast<TldVar *>(tld)->var;
+                            if (var->var_type != nullptr && type_is_invalid(var->var_type)) {
+                                want_err_msg = false;
+                            }
+                        }
+                        if (want_err_msg) {
+                            ErrorMsg *msg = add_node_error(g, source_node,
+                                    buf_sprintf("redefinition of '%s'", buf_ptr(name)));
+                            add_error_note(g, msg, tld->source_node, buf_sprintf("previous definition is here"));
+                        }
                         variable_entry->var_type = g->builtin_types.entry_invalid;
                     }
                 }

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -3614,7 +3614,7 @@ static void add_top_level_decl(CodeGen *g, ScopeDecls *decls_scope, Tld *tld) {
             Tld *other_tld = entry->value;
             if (other_tld->id == TldIdVar) {
                 ZigVar *var = reinterpret_cast<TldVar *>(other_tld)->var;
-                if (var->var_type != nullptr && type_is_invalid(var->var_type)) {
+                if (var != nullptr && var->var_type != nullptr && type_is_invalid(var->var_type)) {
                     return; // already reported compile error
                 }
             }
@@ -3896,7 +3896,7 @@ ZigVar *add_variable(CodeGen *g, AstNode *source_node, Scope *parent_scope, Buf 
                         bool want_err_msg = true;
                         if (tld->id == TldIdVar) {
                             ZigVar *var = reinterpret_cast<TldVar *>(tld)->var;
-                            if (var->var_type != nullptr && type_is_invalid(var->var_type)) {
+                            if (var != nullptr && var->var_type != nullptr && type_is_invalid(var->var_type)) {
                                 want_err_msg = false;
                             }
                         }

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -5300,9 +5300,18 @@ static ZigVar *create_local_var(CodeGen *codegen, AstNode *node, Scope *parent_s
                 } else {
                     Tld *tld = find_decl(codegen, parent_scope, name);
                     if (tld != nullptr) {
-                        ErrorMsg *msg = add_node_error(codegen, node,
-                                buf_sprintf("redefinition of '%s'", buf_ptr(name)));
-                        add_error_note(codegen, msg, tld->source_node, buf_sprintf("previous definition is here"));
+                        bool want_err_msg = true;
+                        if (tld->id == TldIdVar) {
+                            ZigVar *var = reinterpret_cast<TldVar *>(tld)->var;
+                            if (var->var_type != nullptr && type_is_invalid(var->var_type)) {
+                                want_err_msg = false;
+                            }
+                        }
+                        if (want_err_msg) {
+                            ErrorMsg *msg = add_node_error(codegen, node,
+                                    buf_sprintf("redefinition of '%s'", buf_ptr(name)));
+                            add_error_note(codegen, msg, tld->source_node, buf_sprintf("previous definition is here"));
+                        }
                         variable_entry->var_type = codegen->builtin_types.entry_invalid;
                     }
                 }

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -5303,7 +5303,7 @@ static ZigVar *create_local_var(CodeGen *codegen, AstNode *node, Scope *parent_s
                         bool want_err_msg = true;
                         if (tld->id == TldIdVar) {
                             ZigVar *var = reinterpret_cast<TldVar *>(tld)->var;
-                            if (var->var_type != nullptr && type_is_invalid(var->var_type)) {
+                            if (var != nullptr && var->var_type != nullptr && type_is_invalid(var->var_type)) {
                                 want_err_msg = false;
                             }
                         }


### PR DESCRIPTION
std.ast uses a singly linked list for lists of things. This is a
breaking change to the self-hosted parser API.

std.ast.Tree has been separated into a private "Parser" type which
represents in-progress parsing, and std.ast.Tree which has only
"output" data. This means cleaner, but breaking, API for parse results.
Specifically, `tokens` and `errors` are no longer SegmentedList but a
slice.

The way to iterate over AST nodes has necessarily changed since lists of
nodes are now singly linked lists rather than SegmentedList.

From these changes, I observe the following on the
self-hosted-parser benchmark from ziglang/gotta-go-fast:

with std.heap.page_allocator as the general purpose allocator:
throughput: 45.6 MiB/s => 55.6 MiB/s
maxrss: 359 KB => 342 KB

with std.heap.c_allocator as the general purpose allocator:
throughput: 46.2 MiB/s => 76.4 MiB/s
maxrss: 355 KB => 392 KB

This commit breaks the build; more updates are necessary to fix API
usage of the self-hosted parser.