### PR TITLE
Add handler for INVALID_HANDLE to prevent infinite loop

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -644,6 +644,7 @@ pub const WriteError = error{
     BrokenPipe,
     SystemResources,
     OperationAborted,
+    InvalidFd,
 
     /// This error occurs when no global event loop is configured,
     /// and reading from the file descriptor would block.

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -491,6 +491,7 @@ pub const WriteFileError = error{
     SystemResources,
     OperationAborted,
     BrokenPipe,
+    InvalidFd,
     Unexpected,
 };
 
@@ -567,11 +568,7 @@ pub fn WriteFile(
                 // https://github.com/ziglang/zig/issues/4196
                 // Prevents infinite loop when stderr/stdout is not available.
                 // TODO Should implement a NoOpOutStream but this is not possible for now because we cannot coerce or cast to File.OutStream
-                .INVALID_HANDLE => {
-                    if (std.io.getStdOut().handle == handle) return error.BrokenPipe;
-                    if (std.io.getStdErr().handle == handle) return error.BrokenPipe;
-                    unreachable;
-                },
+                .INVALID_HANDLE => return error.InvalidFd,
                 else => |err| return unexpectedError(err),
             }
         }

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -566,7 +566,7 @@ pub fn WriteFile(
                 .BROKEN_PIPE => return error.BrokenPipe,
                 // https://github.com/ziglang/zig/issues/4196
                 // Prevents infinite loop when stderr/stdout is not available.
-                // Implementing a NoOpOutStream is not possible for now because we cannot coerce that to File.OutStream.
+                // TODO Should implement a NoOpOutStream but this is not possible for now because we cannot coerce or cast to File.OutStream
                 .INVALID_HANDLE => return error.Unexpected,
                 else => |err| return unexpectedError(err),
             }

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -567,7 +567,11 @@ pub fn WriteFile(
                 // https://github.com/ziglang/zig/issues/4196
                 // Prevents infinite loop when stderr/stdout is not available.
                 // TODO Should implement a NoOpOutStream but this is not possible for now because we cannot coerce or cast to File.OutStream
-                .INVALID_HANDLE => return error.Unexpected,
+                .INVALID_HANDLE => {
+                    if (std.io.getStdOut().handle == handle) return error.BrokenPipe;
+                    if (std.io.getStdErr().handle == handle) return error.BrokenPipe;
+                    unreachable;
+                },
                 else => |err| return unexpectedError(err),
             }
         }

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -564,6 +564,10 @@ pub fn WriteFile(
                 .NOT_ENOUGH_QUOTA => return error.SystemResources,
                 .IO_PENDING => unreachable,
                 .BROKEN_PIPE => return error.BrokenPipe,
+                // https://github.com/ziglang/zig/issues/4196
+                // Prevents infinite loop when stderr/stdout is not available.
+                // Implementing a NoOpOutStream is not possible for now because we cannot coerce that to File.OutStream.
+                .INVALID_HANDLE => return error.Unexpected,
                 else => |err| return unexpectedError(err),
             }
         }

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -478,7 +478,7 @@ const Function = struct {
                         return self.fail(src, "TODO decide whether to implement non-64-bit loads", .{});
                     }
                     const src_reg = @intToEnum(Reg(arch), @intCast(u8, r));
-                    // This is a varient of 8B /r. Since we're using 64-bit moves, we require a REX.
+                    // This is a variant of 8B /r. Since we're using 64-bit moves, we require a REX.
                     // This is thus three bytes: REX 0x8B R/M.
                     // If the destination is extended, the R field must be 1.
                     // If the *source* is extended, the B field must be 1.

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -657,6 +657,7 @@ const FmtError = error{
     ReadOnlyFileSystem,
     LinkQuotaExceeded,
     FileBusy,
+    InvalidFd,
 } || fs.File.OpenError;
 
 fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool) FmtError!void {

--- a/src-self-hosted/stage2.zig
+++ b/src-self-hosted/stage2.zig
@@ -163,6 +163,7 @@ export fn stage2_render_ast(tree: *ast.Tree, output_file: *FILE) Error {
         error.OutOfMemory => return .OutOfMemory,
         error.Unexpected => return .Unexpected,
         error.InputOutput => return .FileSystem,
+        error.InvalidFd => return .FileSystem,
     };
     return .None;
 }
@@ -606,6 +607,7 @@ export fn stage2_libc_parse(stage1_libc: *Stage2LibCInstallation, libc_file_z: [
         error.NotDir => return .NotDir,
         error.DeviceBusy => return .DeviceBusy,
         error.FileLocksNotSupported => unreachable,
+        error.InvalidFd => return .FileSystem,
     };
     stage1_libc.initFromStage2(libc);
     return .None;
@@ -649,6 +651,7 @@ export fn stage2_libc_render(stage1_libc: *Stage2LibCInstallation, output_file: 
         error.AccessDenied => return .AccessDenied,
         error.Unexpected => return .Unexpected,
         error.InputOutput => return .FileSystem,
+        error.InvalidFd => return .FileSystem,
     };
     return .None;
 }


### PR DESCRIPTION
As explained on #4196, the application will freeze on using `std.db.warn`, `stdout` ou `stderr` if we are using the windows subsystem. This workaround simply adds a dedicated case to the existing switch.

A better solution would be to implement a NoOpOutStream but it is not possible to coerce/assign this type to   `std.fs.File.OutStream` (see [details](https://github.com/ziglang/zig/issues/4196#issuecomment-632835195)).