### PR TITLE
Working integer parameters for ZIR on x64 / SystemV

### DIFF
--- a/src-self-hosted/Module.zig
+++ b/src-self-hosted/Module.zig
@@ -902,6 +902,9 @@ pub fn update(self: *Module) !void {
             self.root_scope.unload(self.allocator);
         }
         try self.bin_file.flush();
+    } else {
+        // performAllTheWork failed.
+        return error.AnalysisFail;
     }
 }
 

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -202,68 +202,21 @@ const Function = struct {
     fn genArg(self: *Function, inst: *ir.Inst.Arg) !MCValue {
         const src = inst.base.src;
         switch (self.target.cpu.arch) {
-            .x86_64 => {
-                switch (self.target.os.tag) {
-                    .linux => {
-                        const ParameterClass = enum {
-                            INTEGER,
-                            SSE,
-                            SSEUP,
-                            X87,
-                            X87UP,
-                            COMPLEX_X87,
-                            NO_CLASS,
-                            MEMORY,
-                        };
-
-                        const IntegerRegs = [6]x86_64.Register{
-                            .rdi,
-                            .rsi,
-                            .rdx,
-                            .rcx,
-                            .r8,
-                            .r9,
-                        };
-                        const index = inst.args.index;
-                        const fn_type = self.mod_fn.owner_decl.typed_value.most_recent.typed_value.ty;
-                        const param_types = fn_type.cast(Type.Payload.Function).?.param_types;
-                        if (index >= param_types.len) {
-                            return self.fail(src, "attempt to access non-existent argument {}", .{index});
-                        }
-                        const T = param_types[index];
-                        var class: ParameterClass = .NO_CLASS;
-                        if (T.isInt() or T.tag() == .bool or T.isSinglePointer() or T.isCPtr()) {
-                            class = .INTEGER;
-                            var i: usize = 0;
-                            var ints: u3 = 1;
-                            while (i < index) : (i += 1) {
-                                const oT = param_types[i];
-                                if (oT.isInt() or oT.tag() == .bool or oT.isSinglePointer() or oT.isCPtr()) {
-                                    ints += 1;
-                                }
-                            }
-                            if (ints > 6) {
-                                class = .MEMORY;
-                            }
-                        }
-                        switch (class) {
-                            .NO_CLASS => return self.fail(src, "TODO implement classifying parameter type {}", .{T}),
-                            .INTEGER => {
-                                var i: usize = 0;
-                                var ints: u3 = 0;
-                                while (i < index) : (i += 1) {
-                                    const oT = param_types[i];
-                                    if (oT.isInt() or oT.tag() == .bool or oT.isSinglePointer() or oT.isCPtr()) {
-                                        ints += 1;
-                                    }
-                                }
-                                return MCValue{ .register = @enumToInt(IntegerRegs[ints]) };
-                            },
-                            else => return self.fail(src, "TODO implement receiving parameter type {}", .{T}),
-                        }
-                    },
-                    else => return self.fail(src, "TODO implement function parameters for {}", .{self.target.cpu.arch}),
-                }
+            .x86_64 => switch (self.target.os.tag) {
+                .linux => {
+                    const index = inst.args.index;
+                    const fn_type = self.mod_fn.owner_decl.typed_value.most_recent.typed_value.ty;
+                    const param_types = fn_type.cast(Type.Payload.Function).?.param_types;
+                    if (index >= param_types.len) {
+                        return self.fail(src, "attempt to access non-existent argument {}", .{index});
+                    }
+                    return switch (x86_64.SysV.ParameterClass.classify(param_types, index)) {
+                        .NO_CLASS => self.fail(src, "TODO implement classifying parameter type {}", .{param_types[index]}),
+                        .INTEGER => MCValue{ .register = @enumToInt(x86_64.SysV.integerParameter(param_types, index)) },
+                        else => |e| self.fail(src, "TODO implement receiving parameter class {}", .{e}),
+                    };
+                },
+                else => return self.fail(src, "TODO implement function parameters for {}", .{self.target.os.tag}),
             },
             else => return self.fail(src, "TODO implement function parameters for {}", .{self.target.cpu.arch}),
         }

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -459,10 +459,20 @@ const Function = struct {
                     if (!needed[@enumToInt(reg)]) {
                         const arg = try self.resolveInst(inst.args.args[index]);
                         try self.genSetReg(inst.base.src, arch, reg, arg);
-                        if (arg == .register) {
-                            needed[arg.register] = false;
-                        }
                         handled[index] = true;
+                        if (arg == .register) {
+                            var i: u5 = 0;
+                            while (i < inst.args.inputs.len) : (i += 1) {
+                                if (!handled[i]) {
+                                    const a = try self.resolveInst(inst.args.args[i]);
+                                    if (a == .register and a.register == arg.register) {
+                                        break;
+                                    }
+                                }
+                            } else {
+                                needed[arg.register] = false;
+                            }
+                        }
                         moved_any = true;
                     }
                 }

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -209,7 +209,7 @@ const Function = struct {
                     if (index >= param_types.len) {
                         return self.fail(src, "attempt to access non-existent argument {}", .{index});
                     }
-                    return switch (x86_64.SysV.ParameterClass.classify(param_types, index)) {
+                    return switch (x86_64.SysV.ParameterClass.classify(self.target, param_types, index)) {
                         .NO_CLASS => self.fail(src, "TODO implement classifying parameter type {}", .{param_types[index]}),
                         .INTEGER => MCValue{ .register = @enumToInt(x86_64.SysV.integerParameter(param_types, index)) },
                         else => |e| self.fail(src, "TODO implement receiving parameter class {}", .{e}),
@@ -250,7 +250,7 @@ const Function = struct {
                                         return self.fail(inst.base.src, "expected {}, found {}", .{ T, arg.ty });
                                     }
                                     const val = try self.resolveInst(inst.args.args[i]);
-                                    const class = x86_64.SysV.ParameterClass.classify(param_types, i);
+                                    const class = x86_64.SysV.ParameterClass.classify(self.target, param_types, i);
                                     switch (class) {
                                         .INTEGER => {
                                             const reg = x86_64.SysV.integerParameter(param_types, i);

--- a/src-self-hosted/type.zig
+++ b/src-self-hosted/type.zig
@@ -852,6 +852,64 @@ pub const Type = extern union {
         };
     }
 
+    pub fn isInt(self: Type) bool {
+        return self.isUnsignedInt() or self.isSignedInt() or self.tag() == .comptime_int;
+    }
+
+    /// Returns true if and only if the type is a fixed-width, unsigned integer.
+    pub fn isUnsignedInt(self: Type) bool {
+        return switch (self.tag()) {
+            .f16,
+            .f32,
+            .f64,
+            .f128,
+            .c_longdouble,
+            .c_void,
+            .bool,
+            .void,
+            .type,
+            .anyerror,
+            .comptime_int,
+            .comptime_float,
+            .noreturn,
+            .@"null",
+            .@"undefined",
+            .fn_noreturn_no_args,
+            .fn_void_no_args,
+            .fn_naked_noreturn_no_args,
+            .fn_ccc_void_no_args,
+            .function,
+            .array,
+            .single_const_pointer,
+            .single_const_pointer_to_comptime_int,
+            .array_u8_sentinel_0,
+            .const_slice_u8,
+            .i8,
+            .i16,
+            .i32,
+            .i64,
+            .isize,
+            .c_short,
+            .c_int,
+            .c_long,
+            .c_longlong,
+            .int_signed,
+            => false,
+
+            .u8,
+            .u16,
+            .u32,
+            .u64,
+            .usize,
+            .c_ushort,
+            .c_uint,
+            .c_ulong,
+            .c_ulonglong,
+            .int_unsigned,
+            => true,
+        };
+    }
+
     /// Returns true if and only if the type is a fixed-width, signed integer.
     pub fn isSignedInt(self: Type) bool {
         return switch (self.tag()) {

--- a/test/stage2/compare_output.zig
+++ b/test/stage2/compare_output.zig
@@ -118,72 +118,72 @@ pub fn addCases(ctx: *TestContext) !void {
             \\
         );
     }
-    //   ctx.compareOutputZIR("function call with args",
-    //       \\@noreturn = primitive(noreturn)
-    //       \\@void = primitive(void)
-    //       \\@usize = primitive(usize)
-    //       \\
-    //       \\@0 = int(0)
-    //       \\@1 = int(1)
-    //       \\@2 = int(2)
-    //       \\@3 = int(3)
-    //       \\
-    //       \\@rax = str("{rax}")
-    //       \\@rdi = str("{rdi}")
-    //       \\@rcx = str("rcx")
-    //       \\@rdx = str("{rdx}")
-    //       \\@rsi = str("{rsi}")
-    //       \\@r11 = str("r11")
-    //       \\@memory = str("memory")
-    //       \\
-    //       \\@sysoutreg = str("={rax}")
-    //       \\
-    //       \\@syscall = str("syscall")
-    //       \\
-    //       \\@write_fnty = fntype([@usize, @usize], @void, cc=C)
-    //       \\@write = fn(@write_fnty, {
-    //       \\  %0 = arg(0)
-    //       \\  %1 = arg(1)
-    //       \\
-    //       \\  %SYS_write = as(@usize, @1)
-    //       \\  %STDOUT_FILENO = as(@usize, @1)
-    //       \\
-    //       \\  %rc_write = asm(@syscall, @usize,
-    //       \\    volatile=1,
-    //       \\    output=@sysoutreg,
-    //       \\    inputs=[@rax, @rdi, @rsi, @rdx],
-    //       \\    clobbers=[@rcx, @r11, @memory],
-    //       \\    args=[%SYS_write, %STDOUT_FILENO, %0, %1])
-    //       \\  %2 = returnvoid()
-    //       \\})
-    //       \\
-    //       \\@start_fnty = fntype([], @noreturn, cc=Naked)
-    //       \\@start = fn(@start_fnty, {
-    //       \\  %SYS_exit_group = int(231)
-    //       \\  %exit_code = as(@usize, @0)
-    //       \\
-    //       \\  %msg = str("Hello, world!\n")
-    //       \\  %msg_addr = ptrtoint(%msg)
-    //       \\  %len_name = str("len")
-    //       \\  %msg_len_ptr = fieldptr(%msg, %len_name)
-    //       \\  %msg_len = deref(%msg_len_ptr)
-    //       \\
-    //       \\  %nothing = call(@write, [%msg_addr, %msg_len])
-    //       \\
-    //       \\  %rc_exit = asm(@syscall, @usize,
-    //       \\    volatile=1,
-    //       \\    output=@sysoutreg,
-    //       \\    inputs=[@rax, @rdi],
-    //       \\    clobbers=[@rcx, @r11, @memory],
-    //       \\    args=[%SYS_exit_group, %exit_code])
-    //       \\
-    //       \\  %99 = unreachable()
-    //       \\});
-    //       \\
-    //       \\@9 = str("_start")
-    //       \\@11 = export(@9, "start")
-    //   , "Hello, world!\n");
-    //   //    ctx.exe("function call with args", linux_x64).addCompareOutput(
+    ctx.compareOutputZIR("function call with args",
+        \\@noreturn = primitive(noreturn)
+        \\@void = primitive(void)
+        \\@usize = primitive(usize)
+        \\
+        \\@0 = int(0)
+        \\@1 = int(1)
+        \\@2 = int(2)
+        \\@3 = int(3)
+        \\
+        \\@rax = str("{rax}")
+        \\@rdi = str("{rdi}")
+        \\@rcx = str("rcx")
+        \\@rdx = str("{rdx}")
+        \\@rsi = str("{rsi}")
+        \\@r11 = str("r11")
+        \\@memory = str("memory")
+        \\
+        \\@sysoutreg = str("={rax}")
+        \\
+        \\@syscall = str("syscall")
+        \\
+        \\@write_fnty = fntype([@usize, @usize], @void, cc=C)
+        \\@write = fn(@write_fnty, {
+        \\  %0 = arg(0)
+        \\  %1 = arg(1)
+        \\
+        \\  %SYS_write = as(@usize, @1)
+        \\  %STDOUT_FILENO = as(@usize, @1)
+        \\
+        \\  %rc_write = asm(@syscall, @usize,
+        \\    volatile=1,
+        \\    output=@sysoutreg,
+        \\    inputs=[@rax, @rdi, @rsi, @rdx],
+        \\    clobbers=[@rcx, @r11, @memory],
+        \\    args=[%SYS_write, %STDOUT_FILENO, %0, %1])
+        \\  %2 = returnvoid()
+        \\})
+        \\
+        \\@start_fnty = fntype([], @noreturn, cc=Naked)
+        \\@start = fn(@start_fnty, {
+        \\  %SYS_exit_group = int(231)
+        \\  %exit_code = as(@usize, @0)
+        \\
+        \\  %msg = str("Hello, world!\n")
+        \\  %msg_addr = ptrtoint(%msg)
+        \\  %len_name = str("len")
+        \\  %msg_len_ptr = fieldptr(%msg, %len_name)
+        \\  %msg_len = deref(%msg_len_ptr)
+        \\
+        \\  %nothing = call(@write, [%msg_addr, %msg_len])
+        \\
+        \\  %rc_exit = asm(@syscall, @usize,
+        \\    volatile=1,
+        \\    output=@sysoutreg,
+        \\    inputs=[@rax, @rdi],
+        \\    clobbers=[@rcx, @r11, @memory],
+        \\    args=[%SYS_exit_group, %exit_code])
+        \\
+        \\  %99 = unreachable()
+        \\});
+        \\
+        \\@9 = str("_start")
+        \\@11 = export(@9, "start")
+    , "Hello, world!\n");
+    //    ctx.exe("function call with args", linux_x64).addCompareOutput(
     //        \\export fn _start() noreturn {
     //        \\    print(@ptrToInt("Hello, World!\n"), 14);
     //        \\

--- a/test/stage2/compare_output.zig
+++ b/test/stage2/compare_output.zig
@@ -118,4 +118,100 @@ pub fn addCases(ctx: *TestContext) !void {
             \\
         );
     }
+    //   ctx.compareOutputZIR("function call with args",
+    //       \\@noreturn = primitive(noreturn)
+    //       \\@void = primitive(void)
+    //       \\@usize = primitive(usize)
+    //       \\
+    //       \\@0 = int(0)
+    //       \\@1 = int(1)
+    //       \\@2 = int(2)
+    //       \\@3 = int(3)
+    //       \\
+    //       \\@rax = str("{rax}")
+    //       \\@rdi = str("{rdi}")
+    //       \\@rcx = str("rcx")
+    //       \\@rdx = str("{rdx}")
+    //       \\@rsi = str("{rsi}")
+    //       \\@r11 = str("r11")
+    //       \\@memory = str("memory")
+    //       \\
+    //       \\@sysoutreg = str("={rax}")
+    //       \\
+    //       \\@syscall = str("syscall")
+    //       \\
+    //       \\@write_fnty = fntype([@usize, @usize], @void, cc=C)
+    //       \\@write = fn(@write_fnty, {
+    //       \\  %0 = arg(0)
+    //       \\  %1 = arg(1)
+    //       \\
+    //       \\  %SYS_write = as(@usize, @1)
+    //       \\  %STDOUT_FILENO = as(@usize, @1)
+    //       \\
+    //       \\  %rc_write = asm(@syscall, @usize,
+    //       \\    volatile=1,
+    //       \\    output=@sysoutreg,
+    //       \\    inputs=[@rax, @rdi, @rsi, @rdx],
+    //       \\    clobbers=[@rcx, @r11, @memory],
+    //       \\    args=[%SYS_write, %STDOUT_FILENO, %0, %1])
+    //       \\  %2 = returnvoid()
+    //       \\})
+    //       \\
+    //       \\@start_fnty = fntype([], @noreturn, cc=Naked)
+    //       \\@start = fn(@start_fnty, {
+    //       \\  %SYS_exit_group = int(231)
+    //       \\  %exit_code = as(@usize, @0)
+    //       \\
+    //       \\  %msg = str("Hello, world!\n")
+    //       \\  %msg_addr = ptrtoint(%msg)
+    //       \\  %len_name = str("len")
+    //       \\  %msg_len_ptr = fieldptr(%msg, %len_name)
+    //       \\  %msg_len = deref(%msg_len_ptr)
+    //       \\
+    //       \\  %nothing = call(@write, [%msg_addr, %msg_len])
+    //       \\
+    //       \\  %rc_exit = asm(@syscall, @usize,
+    //       \\    volatile=1,
+    //       \\    output=@sysoutreg,
+    //       \\    inputs=[@rax, @rdi],
+    //       \\    clobbers=[@rcx, @r11, @memory],
+    //       \\    args=[%SYS_exit_group, %exit_code])
+    //       \\
+    //       \\  %99 = unreachable()
+    //       \\});
+    //       \\
+    //       \\@9 = str("_start")
+    //       \\@11 = export(@9, "start")
+    //   , "Hello, world!\n");
+    //   //    ctx.exe("function call with args", linux_x64).addCompareOutput(
+    //        \\export fn _start() noreturn {
+    //        \\    print(@ptrToInt("Hello, World!\n"), 14);
+    //        \\
+    //        \\    exit();
+    //        \\}
+    //        \\
+    //        \\fn print(arg: usize, len: usize) void {
+    //        \\    asm volatile ("syscall"
+    //        \\        :
+    //        \\        : [number] "{rax}" (1),
+    //        \\          [arg1] "{rdi}" (1),
+    //        \\          [arg2] "{rsi}" (arg),
+    //        \\          [arg3] "{rdx}" (len)
+    //        \\        : "rcx", "r11", "memory"
+    //        \\    );
+    //        \\    return;
+    //        \\}
+    //        \\
+    //        \\fn exit() noreturn {
+    //        \\    asm volatile ("syscall"
+    //        \\        :
+    //        \\        : [number] "{rax}" (231),
+    //        \\          [arg1] "{rdi}" (0)
+    //        \\        : "rcx", "r11", "memory"
+    //        \\    );
+    //        \\    unreachable;
+    //        \\}
+    //    ,
+    //        "Hello, World!\n",
+    //    );
 }

--- a/test/stage2/compare_output.zig
+++ b/test/stage2/compare_output.zig
@@ -184,35 +184,36 @@ pub fn addCases(ctx: *TestContext) !void {
         \\@11 = export(@9, "start")
     , "Hello, world!\n");
 
-    //    ctx.exe("function call with args", linux_x64).addCompareOutput(
-    //        \\export fn _start() noreturn {
-    //        \\    print(@ptrToInt("Hello, World!\n"), 14);
-    //        \\
-    //        \\    exit();
-    //        \\}
-    //        \\
-    //        \\fn print(arg: usize, len: usize) void {
-    //        \\    asm volatile ("syscall"
-    //        \\        :
-    //        \\        : [number] "{rax}" (1),
-    //        \\          [arg1] "{rdi}" (1),
-    //        \\          [arg2] "{rsi}" (arg),
-    //        \\          [arg3] "{rdx}" (len)
-    //        \\        : "rcx", "r11", "memory"
-    //        \\    );
-    //        \\    return;
-    //        \\}
-    //        \\
-    //        \\fn exit() noreturn {
-    //        \\    asm volatile ("syscall"
-    //        \\        :
-    //        \\        : [number] "{rax}" (231),
-    //        \\          [arg1] "{rdi}" (0)
-    //        \\        : "rcx", "r11", "memory"
-    //        \\    );
-    //        \\    unreachable;
-    //        \\}
-    //    ,
-    //        "Hello, World!\n",
-    //    );
+    //   ctx.compareOutput(
+    //       "function call with args",
+    //       \\export fn _start() noreturn {
+    //       \\    print(@ptrToInt("Hello, World!\n"), 14);
+    //       \\
+    //       \\    exit();
+    //       \\}
+    //       \\
+    //       \\fn print(arg: usize, len: usize) void {
+    //       \\    asm volatile ("syscall"
+    //       \\        :
+    //       \\        : [number] "{rax}" (1),
+    //       \\          [arg1] "{rdi}" (1),
+    //       \\          [arg2] "{rsi}" (arg),
+    //       \\          [arg3] "{rdx}" (len)
+    //       \\        : "rcx", "r11", "memory"
+    //       \\    );
+    //       \\    return;
+    //       \\}
+    //       \\
+    //       \\fn exit() noreturn {
+    //       \\    asm volatile ("syscall"
+    //       \\        :
+    //       \\        : [number] "{rax}" (231),
+    //       \\          [arg1] "{rdi}" (0)
+    //       \\        : "rcx", "r11", "memory"
+    //       \\    );
+    //       \\    unreachable;
+    //       \\}
+    //   ,
+    //       "Hello, World!\n",
+    // );
 }

--- a/test/stage2/compare_output.zig
+++ b/test/stage2/compare_output.zig
@@ -183,6 +183,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\@9 = str("_start")
         \\@11 = export(@9, "start")
     , "Hello, world!\n");
+
     //    ctx.exe("function call with args", linux_x64).addCompareOutput(
     //        \\export fn _start() noreturn {
     //        \\    print(@ptrToInt("Hello, World!\n"), 14);

--- a/test/stage2/compile_errors.zig
+++ b/test/stage2/compile_errors.zig
@@ -88,7 +88,7 @@ pub fn addCases(ctx: *TestContext) !void {
     //     \\fn a() void {}
     // );
 
-    ctx.compileErrorZIR("function call with args", linux_x64,
+    ctx.compileErrorZIR("wrong arg type", linux_x64,
         \\@noreturn = primitive(noreturn)
         \\@void = primitive(void)
         \\@usize = primitive(usize)

--- a/test/stage2/zir.zig
+++ b/test/stage2/zir.zig
@@ -304,4 +304,28 @@ pub fn addCases(ctx: *TestContext) !void {
         \\@9 = str("_start")
         \\@11 = export(@9, "start")
     , "");
+    //  ctx.compilesZIR("new", linux_x64,
+    //      \\@void = primitive(void)
+    //      \\@i32 = primitive(i32)
+    //      \\@fnty = fntype([@i32, @i32], @void)
+    //      \\
+    //      \\@0 = str("entry")
+    //      \\@1 = export(@0, "entry")
+    //      \\
+    //      \\@entry = fn(@fnty, {
+    //      \\  %0 = arg(0)
+    //      \\  %1 = arg(1)
+    //      \\  %2 = add(%0, %1)
+    //      \\  %3 = int(7)
+    //      \\  %4 = block("if", {
+    //      \\    %neq = cmp(%2, neq, %3)
+    //      \\    %5 = condbr(%neq, {
+    //      \\      %6 = unreachable()
+    //      \\    }, {
+    //      \\      %7 = breakvoid("if")
+    //      \\    })
+    //      \\  })
+    //      \\  %11 = returnvoid()
+    //      \\})
+    //  );
 }


### PR DESCRIPTION
~~This adds a special case for a function returning void and taking any number of parameters. This is primarily for me to learn more about ZIR and get a better understanding before implementing the general case.~~

- [x] Merge ~~#5704~~ #5708 
    - [x] Rebase
     -   CI won't work until this is done
- [x] Remove NotCoercable
- [x] Make any edge cases in the register shuffler into explicit TODOs, or solve them immediately
    - I might have missed some, but I think it's good now
- [ ] Support Zig source
- [ ] Tests, tests, tests

~~[ ] Implement more parameter classes~~
    ~~[ ] Hook up parameter classification to stage1?~~
Those two belong in a separate PR.

Integer parameters are now supported in ZIR. A little more work is needed for Zig source.

~~* Coerce can now return NotCoercable. This is temporary, and needs to be fixed before the PR is merged.~~

One other major changes worth noting:
* Asm inputs are now shuffled.
```
Not yet handled: Register.rax
Register.rax isn't needed, writing...
Not yet handled: Register.rdi
Not yet handled: Register.rsi
Not yet handled: Register.rdx
Register.rdx isn't needed, writing...
Register.rsi is no longer needed.
Not yet handled: Register.rdi
Not yet handled: Register.rsi
Register.rsi isn't needed, writing...
Register.rdi is no longer needed.
Not yet handled: Register.rdi
Register.rdi isn't needed, writing...
```

This is absolutely necessary to avoid clobbering inputs before they're needed, and is very simple: it marks down which registers are needed as inputs, then loops over all args, writing to registers whose contents do not matter, and marked values as no longer needed once they're stored. There are a few limitations to this: if one input is used for multiple registers, it will be marked as unneeded after the first write, for instance. This should also be fixed before the merge.