### PR TITLE
target: Implement running OS version detection for FreeBSD

### DIFF
--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -292,8 +292,21 @@ pub const NativeTargetInfo = struct {
                     }
                 },
                 .freebsd => {
-                    // Unimplemented, fall back to default.
-                    // https://github.com/ziglang/zig/issues/4582
+                    var osreldate: u32 = undefined;
+                    var len: usize = undefined;
+
+                    std.os.sysctlbynameZ("kern.osreldate", &osreldate, &len, null, 0) catch unreachable;
+
+                    // https://www.freebsd.org/doc/en_US.ISO8859-1/books/porters-handbook/versions.html
+                    // Major * 100,000 has been convention since FreeBSD 2.2 (1997)
+                    // Minor * 1(0),000 summed has been convention since FreeBSD 2.2 (1997)
+                    // e.g. 492101 = 4.11-STABLE = 4.(9+2)
+                    const major = osreldate / 100_000;
+                    const minor1 = osreldate % 100_000 / 10_000; // usually 0 since 5.1
+                    const minor2 = osreldate % 10_000 / 1_000; // 0 before 5.1, minor version since
+                    const patch = osreldate % 1_000;
+                    os.version_range.semver.min = .{ .major = major, .minor = minor1 + minor2, .patch = patch };
+                    os.version_range.semver.max = .{ .major = major, .minor = minor1 + minor2, .patch = patch };
                 },
                 else => {
                     // Unimplemented, fall back to default version range.


### PR DESCRIPTION
Fixes #4582

Produces `zig target` output like:
`    "triple": "x86_64-freebsd.13.0.95...13.0.95-gnu",`

Catch unreachable because:
`error.PermissionDenied`: Only happens when setting values
`error.SystemResources`: Memory is already allocated on the stack
`error.NameTooLong`: Known good value
`error.UnknownName`: Known good value
`error.Unexpected`: The pointers are to stack values (EFAULT), and the sysctl name is known good (ENOTDIR, EISDIR)