### PR TITLE
Add 'which' function to standard library

### DIFF
--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -1201,13 +1201,13 @@ pub fn which(allocator: *mem.Allocator, command: []const u8) !?[]const u8 {
 test "which" {
     if (builtin.os.tag == .windows) {
         const ping = try which(std.testing.allocator, "ping");
-        defer std.testing.allocator.free(ping);
+        defer std.testing.allocator.free(ping.?);
 
         std.testing.expect(ping != null);
         std.testing.expectEqualStrings("C:\\Windows\\System32\\PING.EXE", ping.?);
     } else {
         const ls = try which(std.testing.allocator, "ls");
-        defer std.testing.allocator.free(ls);
+        defer std.testing.allocator.free(ls.?);
 
         std.testing.expect(ls != null);
         std.testing.expectEqualStrings("/bin/ls", ls.?);


### PR DESCRIPTION
Add a `which` function to the standard library that returns the full path to a given command if it exists. This is useful for e.g. checking if a certain command exists before trying to run it with `std.ChildProcess.exec` and cleanly handling the case if it doesn't.

This is similar to the POSIX shell command `command -v` or Python's [`shutil.which`](https://docs.python.org/3/library/shutil.html#shutil.which).

Some thoughts/notes:

1. It would be nice to have both `whichAlloc` and `whichBuf` variants similar to other functions in the standard library, the latter of which would not require an allocator. However, this function depends on the `std.fs.path.join` function which currently only supports using an allocator, so this function must also depend on an allocator.

2. I have not tested this on Windows but AFAIK Windows also uses `PATH` as its environment variable, and this implementation uses the OS-specific path delimiters and separators (`:` and `/` for POSIX, `;` and `\` for Windows), so it might already work?

3.  Is the `std.fs.path` the right place for this? Would `std.process` be better?

4. I am not sure how to write a good test case for this since it depends on the OS and file system it's being run on. I've included a simple test for now but I expect this will need to be flushed out.