### PR TITLE
Re-enable zig parser tests disabled targeting Wasm

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -956,9 +956,6 @@ test "zig fmt: same-line doc comment on variable declaration" {
 }
 
 test "zig fmt: if-else with comment before else" {
-    // TODO investigate why this fails in wasm.
-    if (builtin.cpu.arch == .wasm32) return error.SkipZigTest;
-
     try testCanonical(
         \\comptime {
         \\    // cexp(finite|nan +- i inf|nan) = nan + i nan
@@ -1573,8 +1570,6 @@ test "zig fmt: comment after if before another if" {
 }
 
 test "zig fmt: line comment between if block and else keyword" {
-    // TODO investigate why this fails in wasm.
-    if (builtin.cpu.arch == .wasm32) return error.SkipZigTest;
     try testCanonical(
         \\test "aoeu" {
         \\    // cexp(finite|nan +- i inf|nan) = nan + i nan


### PR DESCRIPTION
I'm not sure why I disabled them when landing extended Wasm/WASI support, but they pass the parser tests just fine now, so I'm gonna go ahead and re-enable them. Perhaps I've had something misconfigured at the time, or had some change that was interfering with those. Anyway, they seem fine now (although will need to wait for the CI to confirm).