### PR TITLE
Add EPERM as a possible return error from sendto

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4256,6 +4256,7 @@ pub fn sendto(
             ENOTCONN => unreachable, // The socket is not connected, and no target has been given.
             ENOTSOCK => unreachable, // The file descriptor sockfd does not refer to a socket.
             EOPNOTSUPP => unreachable, // Some bit in the flags argument is inappropriate for the socket type.
+            EPERM => return error.PermissionDenied,
             EPIPE => return error.BrokenPipe,
             else => |err| return unexpectedErrno(err),
         }


### PR DESCRIPTION
EPERM is returned by sendto on Linux when a program sends a Unix datagram to a socket that has already been connect()-ed to another socket.