### PR TITLE
C ABI: Add C support for passing structs of floats to an extern function

### DIFF
--- a/test/stage1/c_abi/cfuncs.c
+++ b/test/stage1/c_abi/cfuncs.c
@@ -63,6 +63,20 @@ void zig_split_struct_ints(struct SplitStructInts);
 
 struct BigStruct zig_big_struct_both(struct BigStruct);
 
+typedef struct Vector3 {
+    float x;
+    float y;
+    float z;
+} Vector3;
+
+typedef struct Vector5 {
+    float x;
+    float y;
+    float z;
+    float w;
+    float q;
+} Vector5;
+
 void run_c_tests(void) {
     zig_u8(0xff);
     zig_u16(0xfffe);
@@ -225,4 +239,18 @@ struct BigStruct c_big_struct_both(struct BigStruct x) {
     assert_or_panic(x.e == 5);
     struct BigStruct y = {10, 11, 12, 13, 14};
     return y;
+}
+
+void c_small_struct_floats(Vector3 vec) {
+    assert_or_panic(vec.x == 3.0);
+    assert_or_panic(vec.y == 6.0);
+    assert_or_panic(vec.z == 12.0);
+}
+
+void c_big_struct_floats(Vector5 vec) {
+    assert_or_panic(vec.x == 76.0);
+    assert_or_panic(vec.y == -1.0);
+    assert_or_panic(vec.z == -12.0);
+    assert_or_panic(vec.w == 69);
+    assert_or_panic(vec.q == 55);
 }

--- a/test/stage1/c_abi/main.zig
+++ b/test/stage1/c_abi/main.zig
@@ -261,3 +261,37 @@ export fn zig_big_struct_both(x: BigStruct) BigStruct {
     };
     return s;
 }
+
+const Vector3 = extern struct {
+    x: f32,
+    y: f32,
+    z: f32,
+};
+extern fn c_small_struct_floats(Vector3) void;
+
+const Vector5 = extern struct {
+    x: f32,
+    y: f32,
+    z: f32,
+    w: f32,
+    q: f32,
+};
+extern fn c_big_struct_floats(Vector5) void;
+
+test "C ABI structs of floats as parameter" {
+    var v3 = Vector3{
+        .x = 3.0,
+        .y = 6.0,
+        .z = 12.0,
+    };
+    c_small_struct_floats(v3);
+
+    var v5 = Vector5{
+        .x = 76.0,
+        .y = -1.0,
+        .z = -12.0,
+        .w = 69.0,
+        .q = 55,
+    };
+    c_big_struct_floats(v5);
+}


### PR DESCRIPTION
Currently this does not handle returning these structs yet, because I'm not sure where in the Zig codebase this is handled.

Also while working on this, I found out that the code that detects which C ABI Class should be used is quite outdated (from 2014). Version 1.0 can be found [here](https://github.com/hjl-tools/x86-psABI/wiki/X86-psABI) (Yes, official documents on a github wiki page lol).

Also, this looks like a bug. Its iterating but then only looking at the first field, same issue for the union case. Basically this code needs a refactor.
https://github.com/ziglang/zig/blob/2ae9e06363b294f60b62e765d31fce4417e14a9d/src/analyze.cpp#L7978-L7979 

Related: #1481