### PR TITLE
Link issue to the failing test case: miscompiled Vector in wasm

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1708,14 +1708,15 @@ test "vector" {
         return error.SkipZigTest;
     }
     if (builtin.arch != .wasm32) {
-        // TODO investigate why this fails on wasm32
-        const vbool: std.meta.Vector(4, bool) = [_]bool{ true, false, true, false };
-        try testFmt("{ true, false, true, false }", "{}", .{vbool});
+        // https://github.com/ziglang/zig/issues/5339
+        return error.SkipZigTest;
     }
 
+    const vbool: std.meta.Vector(4, bool) = [_]bool{ true, false, true, false };
     const vi64: std.meta.Vector(4, i64) = [_]i64{ -2, -1, 0, 1 };
     const vu64: std.meta.Vector(4, u64) = [_]u64{ 1000, 2000, 3000, 4000 };
 
+    try testFmt("{ true, false, true, false }", "{}", .{vbool});
     try testFmt("{ -2, -1, 0, 1 }", "{}", .{vi64});
     try testFmt("{ -   2, -   1, +   0, +   1 }", "{d:5}", .{vi64});
     try testFmt("{ 1000, 2000, 3000, 4000 }", "{}", .{vu64});

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1707,7 +1707,7 @@ test "vector" {
         // https://github.com/ziglang/zig/issues/4486
         return error.SkipZigTest;
     }
-    if (builtin.arch != .wasm32) {
+    if (builtin.arch == .wasm32) {
         // https://github.com/ziglang/zig/issues/5339
         return error.SkipZigTest;
     }


### PR DESCRIPTION
This commit does some bookkeeping, and swaps the imprecise "TODO" comment about the failing of formatting of `std.meta.Vector` test case in wasm for a link to the actual issue describing the problem in detail.