### PR TITLE
change `_m_prefetchw` type to match Windows headers

### DIFF
--- a/lib/include/prfchwintrin.h
+++ b/lib/include/prfchwintrin.h
@@ -47,7 +47,7 @@ _m_prefetch(void *__P)
 /// \param __P
 ///    A pointer specifying the memory address to be prefetched.
 static __inline__ void __attribute__((__always_inline__, __nodebug__))
-_m_prefetchw(void *__P)
+_m_prefetchw(volatile const void *__P)
 {
   __builtin_prefetch (__P, 1, 3 /* _MM_HINT_T0 */);
 }


### PR DESCRIPTION
When compiling `sqlite3.c` I got a type error indicating that the type in the shipped Windows intrinsics differ from the ones in the Windows headers. This fixes that and sqlite3 compiles and can be used statically without issue.

Granted, I don't know how much these things move between UCRT releases but changing it seems unlikely to be an issue(?).

Kit 10.0.18362.0 UCRT:

```
VOID
_m_prefetchw (
    _In_ volatile CONST VOID *Source
    );
```