### PR TITLE
linux: fix IOSQE_BIT decl and io_uring_sqe flags

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1270,7 +1270,7 @@ pub const io_uring_sqe = extern struct {
     union3: union3,
 };
 
-pub const IOSQE_BIT = extern enum {
+pub const IOSQE_BIT = extern enum(u8) {
     FIXED_FILE,
     IO_DRAIN,
     IO_LINK,
@@ -1283,16 +1283,16 @@ pub const IOSQE_BIT = extern enum {
 // io_uring_sqe.flags
 
 /// use fixed fileset
-pub const IOSQE_FIXED_FILE = 1 << IOSQE_BIT.FIXED_FILE;
+pub const IOSQE_FIXED_FILE = 1 << @enumToInt(IOSQE_BIT.FIXED_FILE);
 
 /// issue after inflight IO
-pub const IOSQE_IO_DRAIN = 1 << IOSQE_BIT.IO_DRAIN;
+pub const IOSQE_IO_DRAIN = 1 << @enumToInt(IOSQE_BIT.IO_DRAIN);
 
 /// links next sqe
-pub const IOSQE_IO_LINK = 1 << IOSQE_BIT.IO_LINK;
+pub const IOSQE_IO_LINK = 1 << @enumToInt(IOSQE_BIT.IO_LINK);
 
 /// like LINK, but stronger
-pub const IOSQE_IO_HARDLINK = 1 << IOSQE_BIT.IO_HARDLINK;
+pub const IOSQE_IO_HARDLINK = 1 << @enumToInt(IOSQE_BIT.IO_HARDLINK);
 
 /// always go async
 pub const IOSQE_ASYNC = 1 << IOSQE_BIT.ASYNC;


### PR DESCRIPTION
Repro:

```
const std = @import("std");

pub fn main() anyerror!void {
    var sqe: std.os.linux.io_uring_sqe = undefined;
    sqe.flags |= std.os.linux.IOSQE_IO_LINK;
}
```

First compilation error (on [godbolt](https://gcc.godbolt.org/z/XemLwr)):
```
/home/vincent/dev/devtools/zig/lib/std/os/bits/linux.zig:1280:5: error: non-exhaustive enum must specify size
    _,
    ^
/home/vincent/dev/devtools/zig/lib/std/os/bits/linux.zig:1292:41: note: referenced here
pub const IOSQE_IO_LINK = 1 << IOSQE_BIT.IO_LINK;
                                        ^
./src/main.zig:5:30: note: referenced here
    sqe.flags |= std.os.linux.IOSQE_IO_LINK;
```

Once fixed the shift are wrong:
```
/home/vincent/dev/devtools/zig/lib/std/os/bits/linux.zig:1292:41: error: shift amount has to be an integer type, but found 'std.os.bits.linux.IOSQE_BIT'
pub const IOSQE_IO_LINK = 1 << IOSQE_BIT.IO_LINK;
                                        ^
/home/vincent/dev/devtools/zig/lib/std/os/bits/linux.zig:1292:29: note: referenced here
pub const IOSQE_IO_LINK = 1 << IOSQE_BIT.IO_LINK;
                            ^
./src/main.zig:5:30: note: referenced here
    sqe.flags |= std.os.linux.IOSQE_IO_LINK;
```