### PR TITLE
Fix evented builds on windows with runtime safety on

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -391,6 +391,7 @@ pub fn GetQueuedCompletionStatus(
             .HANDLE_EOF => return GetQueuedCompletionStatusResult.EOF,
             else => |err| {
                 if (std.debug.runtime_safety) {
+                    @setEvalBranchQuota(2500);
                     std.debug.panic("unexpected error: {}\n", .{err});
                 }
             },


### PR DESCRIPTION
Steps to reproduce the issue:  

```sh
mkdir test_proj
cd test_proj
zig init-exe
# Use your favorite text editor, add "pub const io_mode = .evented;"
zig build # assuming windows default target
``` 

Error message
```
C:\dev\zig\build-release\lib\zig\std\fmt.zig:369:20: error: evaluation exceeded 1000 backwards branches
            inline for (enumInfo.fields) |enumField| {
                   ^
C:\dev\zig\build-release\lib\zig\std\fmt.zig:182:35: note: called from here
                    try formatType(
                                  ^
C:\dev\zig\build-release\lib\zig\std\io\out_stream.zig:28:34: note: called from here
            return std.fmt.format(self, format, args);
                                 ^
C:\dev\zig\build-release\lib\zig\std\debug.zig:276:29: note: called from here
                stderr.print(format ++ "\n", args) catch os.abort();
                            ^
C:\dev\zig\build-release\lib\zig\std\debug.zig:241:15: note: called from here
    panicExtra(null, first_trace_addr, format, args);
              ^
C:\dev\zig\build-release\lib\zig\std\os\windows.zig:394:36: note: called from here
                    std.debug.panic("unexpected error: {}\n", .{err});
                                   ^
C:\dev\zig\build-release\lib\zig\std\os\windows.zig:380:35: note: called from here
) GetQueuedCompletionStatusResult {
                                  ^
C:\dev\zig\build-release\lib\zig\std\fmt.zig:182:35: note: referenced here
                    try formatType(
                                  ^
```

I'm pretty sure this is a recent regression.