### PR TITLE
Add builtins for LLVM Wasm intrinsics

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7643,6 +7643,46 @@ mem.copy(u8, dest[0..byte_count], source[0..byte_count]);{#endsyntax#}</pre>
 mem.set(u8, dest, c);{#endsyntax#}</pre>
       {#header_close#}
 
+      {#header_open|@wasmMemorySize#}
+      <pre>{#syntax#}@wasmMemorySize(index: u32) u32{#endsyntax#}</pre>
+      <p>
+      This function returns the size of the Wasm memory identified by {#syntax#}index{#endsyntax#} as
+      an unsigned value in units of Wasm pages. Note that each Wasm page is 64KB in size.
+      </p>
+      <p>
+      This function is a low level intrinsic with no safety mechanisms usually useful for allocator
+      designers targeting Wasm. So unless you are writing a new allocator from scratch, you should use
+      something like {#syntax#}@import("std").heap.WasmAllocator{#endsyntax#}.
+      </p>
+      {#see_also|@wasmMemoryGrow#}
+      {#header_close#}
+
+      {#header_open|@wasmMemoryGrow#}
+      <pre>{#syntax#}@wasmMemoryGrow(index: u32, delta: u32) i32{#endsyntax#}</pre>
+      <p>
+      This function increases the size of the Wasm memory identified by {#syntax#}index{#endsyntax#} by
+      {#syntax#}delta{#endsyntax#} in units of unsigned number of Wasm pages. Note that each Wasm page
+      is 64KB in size. On success, returns previous memory size; on failure, if the allocation fails,
+      returns -1.
+      </p>
+      <p>
+      This function is a low level intrinsic with no safety mechanisms usually useful for allocator
+      designers targeting Wasm. So unless you are writing a new allocator from scratch, you should use
+      something like {#syntax#}@import("std").heap.WasmAllocator{#endsyntax#}.
+      </p>
+      {#code_begin|test#}
+const std = @import("std");
+const assert = std.debug.assert;
+
+test "@wasmMemoryGrow" {
+    var prev = @wasmMemorySize(0);
+    assert(prev == @wasmMemoryGrow(0, 1));
+    assert(prev + 1 == @wasmMemorySize(0));
+}
+      {#code_end#}
+      {#see_also|@wasmMemorySize#}
+      {#header_close#}
+
       {#header_open|@mod#}
       <pre>{#syntax#}@mod(numerator: T, denominator: T) T{#endsyntax#}</pre>
       <p>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7652,7 +7652,7 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       <p>
       This function is a low level intrinsic with no safety mechanisms usually useful for allocator
       designers targeting Wasm. So unless you are writing a new allocator from scratch, you should use
-      something like {#syntax#}@import("std").heap.WasmAllocator{#endsyntax#}.
+      something like {#syntax#}@import("std").heap.WasmPageAllocator{#endsyntax#}.
       </p>
       {#see_also|@wasmMemoryGrow#}
       {#header_close#}
@@ -7668,13 +7668,16 @@ mem.set(u8, dest, c);{#endsyntax#}</pre>
       <p>
       This function is a low level intrinsic with no safety mechanisms usually useful for allocator
       designers targeting Wasm. So unless you are writing a new allocator from scratch, you should use
-      something like {#syntax#}@import("std").heap.WasmAllocator{#endsyntax#}.
+      something like {#syntax#}@import("std").heap.WasmPageAllocator{#endsyntax#}.
       </p>
       {#code_begin|test#}
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 
 test "@wasmMemoryGrow" {
+    if (builtin.arch != .wasm32) return error.SkipZigTest;
+
     var prev = @wasmMemorySize(0);
     assert(prev == @wasmMemoryGrow(0, 1));
     assert(prev + 1 == @wasmMemorySize(0));

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -250,11 +250,6 @@ const PageAllocator = struct {
     }
 };
 
-// TODO Exposed LLVM intrinsics is a bug
-// See: https://github.com/ziglang/zig/issues/2291
-extern fn @"llvm.wasm.memory.size.i32"(u32) u32;
-extern fn @"llvm.wasm.memory.grow.i32"(u32, u32) i32;
-
 const WasmPageAllocator = struct {
     comptime {
         if (!std.Target.current.isWasm()) {
@@ -357,7 +352,7 @@ const WasmPageAllocator = struct {
             return idx + extendedOffset();
         }
 
-        const prev_page_count = @"llvm.wasm.memory.grow.i32"(0, @intCast(u32, page_count));
+        const prev_page_count = @wasmMemoryGrow(@intCast(u32, page_count));
         if (prev_page_count <= 0) {
             return error.OutOfMemory;
         }

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -352,7 +352,7 @@ const WasmPageAllocator = struct {
             return idx + extendedOffset();
         }
 
-        const prev_page_count = @wasmMemoryGrow(@intCast(u32, page_count));
+        const prev_page_count = @wasmMemoryGrow(0, @intCast(u32, page_count));
         if (prev_page_count <= 0) {
             return error.OutOfMemory;
         }

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1825,6 +1825,7 @@ enum BuiltinFnId {
     BuiltinFnIdAs,
     BuiltinFnIdCall,
     BuiltinFnIdBitSizeof,
+    BuiltinFnIdWasmMemorySize,
 };
 
 struct BuiltinFnEntry {
@@ -2075,6 +2076,7 @@ struct CodeGen {
     LLVMValueRef err_name_table;
     LLVMValueRef safety_crash_err_fn;
     LLVMValueRef return_err_fn;
+    LLVMValueRef wasm_memory_size;
     LLVMTypeRef anyframe_fn_type;
 
     // reminder: hash tables must be initialized before use
@@ -2748,6 +2750,7 @@ enum IrInstSrcId {
     IrInstSrcIdResume,
     IrInstSrcIdSpillBegin,
     IrInstSrcIdSpillEnd,
+    IrInstSrcIdWasmMemorySize,
 };
 
 // ir_render_* functions in codegen.cpp consume Gen instructions and produce LLVM IR.
@@ -2840,6 +2843,7 @@ enum IrInstGenId {
     IrInstGenIdVectorExtractElem,
     IrInstGenIdAlloca,
     IrInstGenIdConst,
+    IrInstGenIdWasmMemorySize,
 };
 
 // Common fields between IrInstSrc and IrInstGen. This allows future passes
@@ -3725,6 +3729,14 @@ struct IrInstGenMemcpy {
     IrInstGen *dest_ptr;
     IrInstGen *src_ptr;
     IrInstGen *count;
+};
+
+struct IrInstSrcWasmMemorySize {
+  IrInstSrc base;
+};
+
+struct IrInstGenWasmMemorySize {
+  IrInstGen base;
 };
 
 struct IrInstSrcSlice {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1826,6 +1826,7 @@ enum BuiltinFnId {
     BuiltinFnIdCall,
     BuiltinFnIdBitSizeof,
     BuiltinFnIdWasmMemorySize,
+    BuiltinFnIdWasmMemoryGrow,
 };
 
 struct BuiltinFnEntry {
@@ -2077,6 +2078,7 @@ struct CodeGen {
     LLVMValueRef safety_crash_err_fn;
     LLVMValueRef return_err_fn;
     LLVMValueRef wasm_memory_size;
+    LLVMValueRef wasm_memory_grow;
     LLVMTypeRef anyframe_fn_type;
 
     // reminder: hash tables must be initialized before use
@@ -2751,6 +2753,7 @@ enum IrInstSrcId {
     IrInstSrcIdSpillBegin,
     IrInstSrcIdSpillEnd,
     IrInstSrcIdWasmMemorySize,
+    IrInstSrcIdWasmMemoryGrow,
 };
 
 // ir_render_* functions in codegen.cpp consume Gen instructions and produce LLVM IR.
@@ -2844,6 +2847,7 @@ enum IrInstGenId {
     IrInstGenIdAlloca,
     IrInstGenIdConst,
     IrInstGenIdWasmMemorySize,
+    IrInstGenIdWasmMemoryGrow,
 };
 
 // Common fields between IrInstSrc and IrInstGen. This allows future passes
@@ -3732,11 +3736,23 @@ struct IrInstGenMemcpy {
 };
 
 struct IrInstSrcWasmMemorySize {
-  IrInstSrc base;
+    IrInstSrc base;
 };
 
 struct IrInstGenWasmMemorySize {
-  IrInstGen base;
+    IrInstGen base;
+};
+
+struct IrInstSrcWasmMemoryGrow {
+    IrInstSrc base;
+
+    IrInstSrc *delta;
+};
+
+struct IrInstGenWasmMemoryGrow {
+    IrInstGen base;
+
+    IrInstGen *delta;
 };
 
 struct IrInstSrcSlice {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -3737,21 +3737,27 @@ struct IrInstGenMemcpy {
 
 struct IrInstSrcWasmMemorySize {
     IrInstSrc base;
+
+    IrInstSrc *index;
 };
 
 struct IrInstGenWasmMemorySize {
     IrInstGen base;
+
+    IrInstGen *index;
 };
 
 struct IrInstSrcWasmMemoryGrow {
     IrInstSrc base;
 
+    IrInstSrc *index;
     IrInstSrc *delta;
 };
 
 struct IrInstGenWasmMemoryGrow {
     IrInstGen base;
 
+    IrInstGen *index;
     IrInstGen *delta;
 };
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5620,26 +5620,16 @@ static LLVMValueRef ir_render_memcpy(CodeGen *g, IrExecutableGen *executable, Ir
 }
 
 static LLVMValueRef ir_render_wasm_memory_size(CodeGen *g, IrExecutableGen *executable, IrInstGenWasmMemorySize *instruction) {
-    // When Wasm lands multi-memory support, we can relax this to permit the user specify
-    // memory index to inquire about. For now, we pass in the recommended default of index 0.
-    //
-    // More info:
-    // https://github.com/sunfishcode/wasm-reference-manual/blob/master/WebAssembly.md#current-linear-memory-size
     // TODO adjust for wasm64
-    LLVMValueRef zero = LLVMConstNull(g->builtin_types.entry_i32->llvm_type);
-    LLVMValueRef val = LLVMBuildCall(g->builder, gen_wasm_memory_size(g), &zero, 1, "");
+    LLVMValueRef param = ir_llvm_value(g, instruction->index);
+    LLVMValueRef val = LLVMBuildCall(g->builder, gen_wasm_memory_size(g), &param, 1, "");
     return val;
 }
 
 static LLVMValueRef ir_render_wasm_memory_grow(CodeGen *g, IrExecutableGen *executable, IrInstGenWasmMemoryGrow *instruction) {
-    // When Wasm lands multi-memory support, we can relax this to permit the user specify
-    // memory index to inquire about. For now, we pass in the recommended default of index 0.
-    //
-    // More info:
-    // https://github.com/sunfishcode/wasm-reference-manual/blob/master/WebAssembly.md#grow-linear-memory-size
     // TODO adjust for wasm64
     LLVMValueRef params[] = {
-        LLVMConstNull(g->builtin_types.entry_i32->llvm_type),
+        ir_llvm_value(g, instruction->index),
         ir_llvm_value(g, instruction->delta),
     };
     LLVMValueRef val = LLVMBuildCall(g->builder, gen_wasm_memory_grow(g), params, 2, "");
@@ -8722,8 +8712,8 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdAs, "as", 2);
     create_builtin_fn(g, BuiltinFnIdCall, "call", 3);
     create_builtin_fn(g, BuiltinFnIdBitSizeof, "bitSizeOf", 1);
-    create_builtin_fn(g, BuiltinFnIdWasmMemorySize, "wasmMemorySize", 0);
-    create_builtin_fn(g, BuiltinFnIdWasmMemoryGrow, "wasmMemoryGrow", 1);
+    create_builtin_fn(g, BuiltinFnIdWasmMemorySize, "wasmMemorySize", 1);
+    create_builtin_fn(g, BuiltinFnIdWasmMemoryGrow, "wasmMemoryGrow", 2);
 }
 
 static const char *bool_to_str(bool b) {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -4997,7 +4997,7 @@ static IrInstSrc *ir_build_wasm_memory_size_src(IrBuilderSrc *irb, Scope *scope,
 static IrInstGen *ir_build_wasm_memory_size_gen(IrAnalyze *ira, IrInst *source_instr, IrInstGen *index) {
     IrInstGenWasmMemorySize *instruction = ir_build_inst_gen<IrInstGenWasmMemorySize>(&ira->new_irb,
             source_instr->scope, source_instr->source_node);
-    instruction->base.value->type = ira->codegen->builtin_types.entry_i32;
+    instruction->base.value->type = ira->codegen->builtin_types.entry_u32;
     instruction->index = index;
 
     ir_ref_inst_gen(index);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -558,6 +558,8 @@ static void destroy_instruction_src(IrInstSrc *inst) {
             return heap::c_allocator.destroy(reinterpret_cast<IrInstSrcCallArgs *>(inst));
         case IrInstSrcIdWasmMemorySize:
             return heap::c_allocator.destroy(reinterpret_cast<IrInstSrcWasmMemorySize *>(inst));
+        case IrInstSrcIdWasmMemoryGrow:
+            return heap::c_allocator.destroy(reinterpret_cast<IrInstSrcWasmMemoryGrow *>(inst));
     }
     zig_unreachable();
 }
@@ -740,6 +742,8 @@ void destroy_instruction_gen(IrInstGen *inst) {
             return heap::c_allocator.destroy(reinterpret_cast<IrInstGenNegationWrapping *>(inst));
         case IrInstGenIdWasmMemorySize:
             return heap::c_allocator.destroy(reinterpret_cast<IrInstGenWasmMemorySize *>(inst));
+        case IrInstGenIdWasmMemoryGrow:
+            return heap::c_allocator.destroy(reinterpret_cast<IrInstGenWasmMemoryGrow *>(inst));
     }
     zig_unreachable();
 }
@@ -1338,10 +1342,6 @@ static constexpr IrInstSrcId ir_inst_id(IrInstSrcBoolNot *) {
     return IrInstSrcIdBoolNot;
 }
 
-static constexpr IrInstSrcId ir_inst_id(IrInstSrcWasmMemorySize *) {
-    return IrInstSrcIdWasmMemorySize;
-}
-
 static constexpr IrInstSrcId ir_inst_id(IrInstSrcMemset *) {
     return IrInstSrcIdMemset;
 }
@@ -1616,6 +1616,14 @@ static constexpr IrInstSrcId ir_inst_id(IrInstSrcSpillBegin *) {
 
 static constexpr IrInstSrcId ir_inst_id(IrInstSrcSpillEnd *) {
     return IrInstSrcIdSpillEnd;
+}
+
+static constexpr IrInstSrcId ir_inst_id(IrInstSrcWasmMemorySize *) {
+    return IrInstSrcIdWasmMemorySize;
+}
+
+static constexpr IrInstSrcId ir_inst_id(IrInstSrcWasmMemoryGrow *) {
+    return IrInstSrcIdWasmMemoryGrow;
 }
 
 
@@ -1965,6 +1973,10 @@ static constexpr IrInstGenId ir_inst_id(IrInstGenConst *) {
 
 static constexpr IrInstGenId ir_inst_id(IrInstGenWasmMemorySize *) {
   return IrInstGenIdWasmMemorySize;
+}
+
+static constexpr IrInstGenId ir_inst_id(IrInstGenWasmMemoryGrow *) {
+  return IrInstGenIdWasmMemoryGrow;
 }
 
 template<typename T>
@@ -3654,20 +3666,6 @@ static IrInstGen *ir_build_bool_not_gen(IrAnalyze *ira, IrInst *source_instr, Ir
     return &instruction->base;
 }
 
-static IrInstSrc *ir_build_wasm_memory_size_src(IrBuilderSrc *irb, Scope *scope, AstNode *source_node) {
-    IrInstSrcWasmMemorySize *instruction = ir_build_instruction<IrInstSrcWasmMemorySize>(irb, scope, source_node);
-
-    return &instruction->base;
-}
-
-static IrInstGen *ir_build_wasm_memory_size_gen(IrAnalyze *ira, IrInst *source_instr) {
-    IrInstGenWasmMemorySize *instruction = ir_build_inst_gen<IrInstGenWasmMemorySize>(&ira->new_irb,
-            source_instr->scope, source_instr->source_node);
-    instruction->base.value->type = ira->codegen->builtin_types.entry_i32;
-
-    return &instruction->base;
-}
-
 static IrInstSrc *ir_build_memset_src(IrBuilderSrc *irb, Scope *scope, AstNode *source_node,
     IrInstSrc *dest_ptr, IrInstSrc *byte, IrInstSrc *count)
 {
@@ -4986,6 +4984,41 @@ static IrInstGen *ir_build_vector_extract_elem(IrAnalyze *ira, IrInst *source_in
 
     return &instruction->base;
 }
+
+static IrInstSrc *ir_build_wasm_memory_size_src(IrBuilderSrc *irb, Scope *scope, AstNode *source_node) {
+    IrInstSrcWasmMemorySize *instruction = ir_build_instruction<IrInstSrcWasmMemorySize>(irb, scope, source_node);
+
+    return &instruction->base;
+}
+
+static IrInstGen *ir_build_wasm_memory_size_gen(IrAnalyze *ira, IrInst *source_instr) {
+    IrInstGenWasmMemorySize *instruction = ir_build_inst_gen<IrInstGenWasmMemorySize>(&ira->new_irb,
+            source_instr->scope, source_instr->source_node);
+    instruction->base.value->type = ira->codegen->builtin_types.entry_i32;
+
+    return &instruction->base;
+}
+
+static IrInstSrc *ir_build_wasm_memory_grow_src(IrBuilderSrc *irb, Scope *scope, AstNode *source_node, IrInstSrc *delta) {
+    IrInstSrcWasmMemoryGrow *instruction = ir_build_instruction<IrInstSrcWasmMemoryGrow>(irb, scope, source_node);
+    instruction->delta = delta;
+
+    ir_ref_instruction(delta, irb->current_basic_block);
+
+    return &instruction->base;
+}
+
+static IrInstGen *ir_build_wasm_memory_grow_gen(IrAnalyze *ira, IrInst *source_instr, IrInstGen *delta) {
+    IrInstGenWasmMemoryGrow *instruction = ir_build_inst_gen<IrInstGenWasmMemoryGrow>(&ira->new_irb,
+            source_instr->scope, source_instr->source_node);
+    instruction->base.value->type = ira->codegen->builtin_types.entry_i32;
+    instruction->delta = delta;
+
+    ir_ref_inst_gen(delta);
+
+    return &instruction->base;
+}
+
 
 static void ir_count_defers(IrBuilderSrc *irb, Scope *inner_scope, Scope *outer_scope, size_t *results) {
     results[ReturnKindUnconditional] = 0;
@@ -6784,6 +6817,16 @@ static IrInstSrc *ir_gen_builtin_fn_call(IrBuilderSrc *irb, Scope *scope, AstNod
             {
                 IrInstSrc *ir_wasm_memory_size = ir_build_wasm_memory_size_src(irb, scope, node);
                 return ir_lval_wrap(irb, scope, ir_wasm_memory_size, lval, result_loc);
+            }
+        case BuiltinFnIdWasmMemoryGrow:
+            {
+                AstNode *arg0_node = node->data.fn_call_expr.params.at(0);
+                IrInstSrc *arg0_value = ir_gen_node(irb, arg0_node, scope);
+                if (arg0_value == irb->codegen->invalid_inst_src)
+                    return arg0_value;
+
+                IrInstSrc *ir_wasm_memory_grow = ir_build_wasm_memory_grow_src(irb, scope, node, arg0_value);
+                return ir_lval_wrap(irb, scope, ir_wasm_memory_grow, lval, result_loc);
             }
         case BuiltinFnIdField:
             {
@@ -27683,13 +27726,35 @@ static IrInstGen *ir_analyze_instruction_has_field(IrAnalyze *ira, IrInstSrcHasF
 }
 
 static IrInstGen *ir_analyze_instruction_wasm_memory_size(IrAnalyze *ira, IrInstSrcWasmMemorySize *instruction) {
+    // TODO generate compile error for target_arch different than 32bit
     if (!target_is_wasm(ira->codegen->zig_target)) {
         ir_add_error_node(ira, instruction->base.base.source_node,
-            buf_sprintf("@wasmMemorySize is a wasm feature only"));
+            buf_sprintf("@wasmMemorySize is a wasm32 feature only"));
         return ira->codegen->invalid_inst_gen;
     }
 
     return ir_build_wasm_memory_size_gen(ira, &instruction->base.base);
+}
+
+static IrInstGen *ir_analyze_instruction_wasm_memory_grow(IrAnalyze *ira, IrInstSrcWasmMemoryGrow *instruction) {
+    // TODO generate compile error for target_arch different than 32bit
+    if (!target_is_wasm(ira->codegen->zig_target)) {
+        ir_add_error_node(ira, instruction->base.base.source_node,
+            buf_sprintf("@wasmMemoryGrow is a wasm32 feature only"));
+        return ira->codegen->invalid_inst_gen;
+    }
+
+    IrInstGen *delta = instruction->delta->child;
+    if (type_is_invalid(delta->value->type))
+        return ira->codegen->invalid_inst_gen;
+
+    ZigType *i32_type = ira->codegen->builtin_types.entry_i32;
+
+    IrInstGen *casted_delta = ir_implicit_cast(ira, delta, i32_type);
+    if (type_is_invalid(casted_delta->value->type))
+        return ira->codegen->invalid_inst_gen;
+
+    return ir_build_wasm_memory_grow_gen(ira, &instruction->base.base, casted_delta);
 }
 
 static IrInstGen *ir_analyze_instruction_breakpoint(IrAnalyze *ira, IrInstSrcBreakpoint *instruction) {
@@ -30922,6 +30987,8 @@ static IrInstGen *ir_analyze_instruction_base(IrAnalyze *ira, IrInstSrc *instruc
             return ir_analyze_instruction_spill_end(ira, (IrInstSrcSpillEnd *)instruction);
         case IrInstSrcIdWasmMemorySize:
             return ir_analyze_instruction_wasm_memory_size(ira, (IrInstSrcWasmMemorySize *)instruction);
+        case IrInstSrcIdWasmMemoryGrow:
+            return ir_analyze_instruction_wasm_memory_grow(ira, (IrInstSrcWasmMemoryGrow *)instruction);
     }
     zig_unreachable();
 }
@@ -31098,6 +31165,7 @@ bool ir_inst_gen_has_side_effects(IrInstGen *instruction) {
         case IrInstGenIdResume:
         case IrInstGenIdAwait:
         case IrInstGenIdSpillBegin:
+        case IrInstGenIdWasmMemoryGrow:
             return true;
 
         case IrInstGenIdPhi:
@@ -31230,6 +31298,7 @@ bool ir_inst_src_has_side_effects(IrInstSrc *instruction) {
         case IrInstSrcIdResume:
         case IrInstSrcIdAwait:
         case IrInstSrcIdSpillBegin:
+        case IrInstSrcIdWasmMemoryGrow:
             return true;
 
         case IrInstSrcIdPhi:

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -4997,7 +4997,7 @@ static IrInstSrc *ir_build_wasm_memory_size_src(IrBuilderSrc *irb, Scope *scope,
 static IrInstGen *ir_build_wasm_memory_size_gen(IrAnalyze *ira, IrInst *source_instr, IrInstGen *index) {
     IrInstGenWasmMemorySize *instruction = ir_build_inst_gen<IrInstGenWasmMemorySize>(&ira->new_irb,
             source_instr->scope, source_instr->source_node);
-    instruction->base.value->type = ira->codegen->builtin_types.entry_i32;
+    instruction->base.value->type = ira->codegen->builtin_types.entry_u32;
     instruction->index = index;
 
     ir_ref_inst_gen(index);
@@ -5019,7 +5019,7 @@ static IrInstSrc *ir_build_wasm_memory_grow_src(IrBuilderSrc *irb, Scope *scope,
 static IrInstGen *ir_build_wasm_memory_grow_gen(IrAnalyze *ira, IrInst *source_instr, IrInstGen *index, IrInstGen *delta) {
     IrInstGenWasmMemoryGrow *instruction = ir_build_inst_gen<IrInstGenWasmMemoryGrow>(&ira->new_irb,
             source_instr->scope, source_instr->source_node);
-    instruction->base.value->type = ira->codegen->builtin_types.entry_i32;
+    instruction->base.value->type = ira->codegen->builtin_types.entry_u32;
     instruction->index = index;
     instruction->delta = delta;
 
@@ -27757,9 +27757,9 @@ static IrInstGen *ir_analyze_instruction_wasm_memory_size(IrAnalyze *ira, IrInst
     if (type_is_invalid(index->value->type))
         return ira->codegen->invalid_inst_gen;
 
-    ZigType *i32_type = ira->codegen->builtin_types.entry_i32;
+    ZigType *u32 = ira->codegen->builtin_types.entry_u32;
 
-    IrInstGen *casted_index = ir_implicit_cast(ira, index, i32_type);
+    IrInstGen *casted_index = ir_implicit_cast(ira, index, u32);
     if (type_is_invalid(casted_index->value->type))
         return ira->codegen->invalid_inst_gen;
 
@@ -27778,9 +27778,9 @@ static IrInstGen *ir_analyze_instruction_wasm_memory_grow(IrAnalyze *ira, IrInst
     if (type_is_invalid(index->value->type))
         return ira->codegen->invalid_inst_gen;
 
-    ZigType *i32_type = ira->codegen->builtin_types.entry_i32;
+    ZigType *u32 = ira->codegen->builtin_types.entry_u32;
 
-    IrInstGen *casted_index = ir_implicit_cast(ira, index, i32_type);
+    IrInstGen *casted_index = ir_implicit_cast(ira, index, u32);
     if (type_is_invalid(casted_index->value->type))
         return ira->codegen->invalid_inst_gen;
 
@@ -27788,7 +27788,7 @@ static IrInstGen *ir_analyze_instruction_wasm_memory_grow(IrAnalyze *ira, IrInst
     if (type_is_invalid(delta->value->type))
         return ira->codegen->invalid_inst_gen;
 
-    IrInstGen *casted_delta = ir_implicit_cast(ira, delta, i32_type);
+    IrInstGen *casted_delta = ir_implicit_cast(ira, delta, u32);
     if (type_is_invalid(casted_delta->value->type))
         return ira->codegen->invalid_inst_gen;
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -4997,7 +4997,7 @@ static IrInstSrc *ir_build_wasm_memory_size_src(IrBuilderSrc *irb, Scope *scope,
 static IrInstGen *ir_build_wasm_memory_size_gen(IrAnalyze *ira, IrInst *source_instr, IrInstGen *index) {
     IrInstGenWasmMemorySize *instruction = ir_build_inst_gen<IrInstGenWasmMemorySize>(&ira->new_irb,
             source_instr->scope, source_instr->source_node);
-    instruction->base.value->type = ira->codegen->builtin_types.entry_u32;
+    instruction->base.value->type = ira->codegen->builtin_types.entry_i32;
     instruction->index = index;
 
     ir_ref_inst_gen(index);
@@ -5019,7 +5019,7 @@ static IrInstSrc *ir_build_wasm_memory_grow_src(IrBuilderSrc *irb, Scope *scope,
 static IrInstGen *ir_build_wasm_memory_grow_gen(IrAnalyze *ira, IrInst *source_instr, IrInstGen *index, IrInstGen *delta) {
     IrInstGenWasmMemoryGrow *instruction = ir_build_inst_gen<IrInstGenWasmMemoryGrow>(&ira->new_irb,
             source_instr->scope, source_instr->source_node);
-    instruction->base.value->type = ira->codegen->builtin_types.entry_u32;
+    instruction->base.value->type = ira->codegen->builtin_types.entry_i32;
     instruction->index = index;
     instruction->delta = delta;
 

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -323,6 +323,8 @@ const char* ir_inst_src_type_str(IrInstSrcId id) {
             return "SrcSpillEnd";
         case IrInstSrcIdWasmMemorySize:
             return "SrcWasmMemorySize";
+        case IrInstSrcIdWasmMemoryGrow:
+            return "SrcWasmMemoryGrow";
     }
     zig_unreachable();
 }
@@ -505,6 +507,8 @@ const char* ir_inst_gen_type_str(IrInstGenId id) {
             return "GenNegationWrapping";
         case IrInstGenIdWasmMemorySize:
             return "GenWasmMemorySize";
+        case IrInstGenIdWasmMemoryGrow:
+            return "GenWasmMemoryGrow";
     }
     zig_unreachable();
 }
@@ -1718,6 +1722,18 @@ static void ir_print_wasm_memory_size(IrPrintSrc *irp, IrInstSrcWasmMemorySize *
 
 static void ir_print_wasm_memory_size(IrPrintGen *irp, IrInstGenWasmMemorySize *instruction) {
     fprintf(irp->f, "@wasmMemorySize()");
+}
+
+static void ir_print_wasm_memory_grow(IrPrintSrc *irp, IrInstSrcWasmMemoryGrow *instruction) {
+    fprintf(irp->f, "@wasmMemoryGrow(");
+    ir_print_other_inst_src(irp, instruction->delta);
+    fprintf(irp->f, ")");
+}
+
+static void ir_print_wasm_memory_grow(IrPrintGen *irp, IrInstGenWasmMemoryGrow *instruction) {
+    fprintf(irp->f, "@wasmMemoryGrow(");
+    ir_print_other_inst_gen(irp, instruction->delta);
+    fprintf(irp->f, ")");
 }
 
 static void ir_print_memset(IrPrintSrc *irp, IrInstSrcMemset *instruction) {
@@ -2967,6 +2983,9 @@ static void ir_print_inst_src(IrPrintSrc *irp, IrInstSrc *instruction, bool trai
         case IrInstSrcIdWasmMemorySize:
             ir_print_wasm_memory_size(irp, (IrInstSrcWasmMemorySize *)instruction);
             break;
+        case IrInstSrcIdWasmMemoryGrow:
+            ir_print_wasm_memory_grow(irp, (IrInstSrcWasmMemoryGrow *)instruction);
+            break;
     }
     fprintf(irp->f, "\n");
 }
@@ -3236,6 +3255,9 @@ static void ir_print_inst_gen(IrPrintGen *irp, IrInstGen *instruction, bool trai
             break;
         case IrInstGenIdWasmMemorySize:
             ir_print_wasm_memory_size(irp, (IrInstGenWasmMemorySize *)instruction);
+            break;
+        case IrInstGenIdWasmMemoryGrow:
+            ir_print_wasm_memory_grow(irp, (IrInstGenWasmMemoryGrow *)instruction);
             break;
     }
     fprintf(irp->f, "\n");

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1717,21 +1717,29 @@ static void ir_print_bool_not(IrPrintGen *irp, IrInstGenBoolNot *instruction) {
 }
 
 static void ir_print_wasm_memory_size(IrPrintSrc *irp, IrInstSrcWasmMemorySize *instruction) {
-    fprintf(irp->f, "@wasmMemorySize()");
+    fprintf(irp->f, "@wasmMemorySize(");
+    ir_print_other_inst_src(irp, instruction->index);
+    fprintf(irp->f, ")");
 }
 
 static void ir_print_wasm_memory_size(IrPrintGen *irp, IrInstGenWasmMemorySize *instruction) {
-    fprintf(irp->f, "@wasmMemorySize()");
+    fprintf(irp->f, "@wasmMemorySize(");
+    ir_print_other_inst_gen(irp, instruction->index);
+    fprintf(irp->f, ")");
 }
 
 static void ir_print_wasm_memory_grow(IrPrintSrc *irp, IrInstSrcWasmMemoryGrow *instruction) {
     fprintf(irp->f, "@wasmMemoryGrow(");
+    ir_print_other_inst_src(irp, instruction->index);
+    fprintf(irp->f, ", ");
     ir_print_other_inst_src(irp, instruction->delta);
     fprintf(irp->f, ")");
 }
 
 static void ir_print_wasm_memory_grow(IrPrintGen *irp, IrInstGenWasmMemoryGrow *instruction) {
     fprintf(irp->f, "@wasmMemoryGrow(");
+    ir_print_other_inst_gen(irp, instruction->index);
+    fprintf(irp->f, ", ");
     ir_print_other_inst_gen(irp, instruction->delta);
     fprintf(irp->f, ")");
 }

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -321,6 +321,8 @@ const char* ir_inst_src_type_str(IrInstSrcId id) {
             return "SrcSpillBegin";
         case IrInstSrcIdSpillEnd:
             return "SrcSpillEnd";
+        case IrInstSrcIdWasmMemorySize:
+            return "SrcWasmMemorySize";
     }
     zig_unreachable();
 }
@@ -501,6 +503,8 @@ const char* ir_inst_gen_type_str(IrInstGenId id) {
             return "GenNegation";
         case IrInstGenIdNegationWrapping:
             return "GenNegationWrapping";
+        case IrInstGenIdWasmMemorySize:
+            return "GenWasmMemorySize";
     }
     zig_unreachable();
 }
@@ -1706,6 +1710,14 @@ static void ir_print_bool_not(IrPrintSrc *irp, IrInstSrcBoolNot *instruction) {
 static void ir_print_bool_not(IrPrintGen *irp, IrInstGenBoolNot *instruction) {
     fprintf(irp->f, "! ");
     ir_print_other_inst_gen(irp, instruction->value);
+}
+
+static void ir_print_wasm_memory_size(IrPrintSrc *irp, IrInstSrcWasmMemorySize *instruction) {
+    fprintf(irp->f, "@wasmMemorySize()");
+}
+
+static void ir_print_wasm_memory_size(IrPrintGen *irp, IrInstGenWasmMemorySize *instruction) {
+    fprintf(irp->f, "@wasmMemorySize()");
 }
 
 static void ir_print_memset(IrPrintSrc *irp, IrInstSrcMemset *instruction) {
@@ -2952,6 +2964,9 @@ static void ir_print_inst_src(IrPrintSrc *irp, IrInstSrc *instruction, bool trai
         case IrInstSrcIdClz:
             ir_print_clz(irp, (IrInstSrcClz *)instruction);
             break;
+        case IrInstSrcIdWasmMemorySize:
+            ir_print_wasm_memory_size(irp, (IrInstSrcWasmMemorySize *)instruction);
+            break;
     }
     fprintf(irp->f, "\n");
 }
@@ -3218,6 +3233,9 @@ static void ir_print_inst_gen(IrPrintGen *irp, IrInstGen *instruction, bool trai
             break;
         case IrInstGenIdNegationWrapping:
             ir_print_negation_wrapping(irp, (IrInstGenNegationWrapping *)instruction);
+            break;
+        case IrInstGenIdWasmMemorySize:
+            ir_print_wasm_memory_size(irp, (IrInstGenWasmMemorySize *)instruction);
             break;
     }
     fprintf(irp->f, "\n");

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -7498,7 +7498,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
 
     cases.add("wasmMemorySize is a compile error in non-Wasm targets",
         \\export fn foo() void {
-        \\    _ = @wasmMemorySize();
+        \\    _ = @wasmMemorySize(0);
         \\    return;
         \\}
     , &[_][]const u8{
@@ -7507,7 +7507,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
 
     cases.add("wasmMemoryGrow is a compile error in non-Wasm targets",
         \\export fn foo() void {
-        \\    _ = @wasmMemoryGrow(1);
+        \\    _ = @wasmMemoryGrow(0, 1);
         \\    return;
         \\}
     , &[_][]const u8{

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -7495,4 +7495,22 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         ":22:12: error: cannot compare types '?[3]i32' and '[3]i32'",
         ":22:12: note: operator not supported for type '[3]i32'",
     });
+
+    cases.add("wasmMemorySize is a compile error in non-Wasm targets",
+        \\export fn foo() void {
+        \\    _ = @wasmMemorySize();
+        \\    return;
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:2:9: error: @wasmMemorySize is a wasm32 feature only",
+    });
+
+    cases.add("wasmMemoryGrow is a compile error in non-Wasm targets",
+        \\export fn foo() void {
+        \\    _ = @wasmMemoryGrow(1);
+        \\    return;
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:2:9: error: @wasmMemoryGrow is a wasm32 feature only",
+    });
 }

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -125,6 +125,9 @@ comptime {
     _ = @import("behavior/var_args.zig");
     _ = @import("behavior/vector.zig");
     _ = @import("behavior/void.zig");
+    if (builtin.arch == .wasm32) {
+        _ = @import("behavior/wasm.zig");
+    }
     _ = @import("behavior/while.zig");
     _ = @import("behavior/widening.zig");
 }

--- a/test/stage1/behavior/wasm.zig
+++ b/test/stage1/behavior/wasm.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const expect = std.testing.expect;
 
 test "memory size and grow" {
-    var prev = @wasmMemorySize();
-    expect(prev == @wasmMemoryGrow(1));
-    expect(prev + 1 == @wasmMemorySize());
+    var prev = @wasmMemorySize(0);
+    expect(prev == @wasmMemoryGrow(0, 1));
+    expect(prev + 1 == @wasmMemorySize(0));
 }

--- a/test/stage1/behavior/wasm.zig
+++ b/test/stage1/behavior/wasm.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const expect = std.testing.expect;
+
+test "memory size and grow" {
+    var prev = @wasmMemorySize();
+    expect(prev == @wasmMemoryGrow(1));
+    expect(prev + 1 == @wasmMemorySize());
+}


### PR DESCRIPTION
This PR proposes adding builtins for LLVM’s Wasm intrinsics `llvm.wasm.memory.size` and `llvm.wasm.memory.grow` called `@wasmMemorySize` and `@wasmMemoryGrow` respectively. Typical example usage:

```zig
var prev = @wasmMemorySize(0);
assert(prev == @wasmMemoryGrow(0, 1);
assert(prev + 1 == @wasmMemorySize(0));
```

This PR essentially closes #2291, however, it favors the simpler approach of adding target-specific builtins rather than adjusting `asm` for Wasm. I reckon this is a good enough initial solution until we figure out the design for supporting Wasm in `asm`. Oh and FWIW, LLVM doesn’t expose any set of instructions for inlining Wasm.

cc @andrewrk what do you think about this approach?