### PR TITLE
Increase default Wasm stack to 1MB

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -2100,6 +2100,10 @@ static void construct_linker_job_wasm(LinkJob *lj) {
     CodeGen *g = lj->codegen;
 
     lj->args.append("-error-limit=0");
+    // Increase the default stack size to a more reasonable value of 1MB instead of
+    // the default of 1 Wasm page being 64KB.
+    lj->args.append("-z");
+    lj->args.append("stack-size=1048576");
 
     if (g->out_type != OutTypeExe) {
         lj->args.append("--no-entry"); // So lld doesn't look for _start.


### PR DESCRIPTION
This commit increases the default Wasm stack to 1MB from the default of 1 Wasm page which equal 64KB. This seems like a reasonable default size while at the same time not overly large. Also, Rust lang seems to be favouring this default as well: [rust-lang#50083].

[rust-lang#50083]: https://github.com/rust-lang/rust/pull/50083

For more discussion on this topic and arriving at this conclusion, see #3735.

cc @fengb @pixelherodev @andrewrk 