### PR TITLE
Translate-c don't crash on complex switches

### DIFF
--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -2625,6 +2625,9 @@ fn transSwitch(
         const else_prong = try transCreateNodeSwitchCase(rp.c, try transCreateNodeSwitchElse(rp.c));
         else_prong.expr = &(try transCreateNodeBreak(rp.c, "__switch")).base;
         _ = try appendToken(rp.c, .Comma, ",");
+
+        if (switch_scope.case_index >= switch_scope.cases.len)
+            return revertAndWarn(rp, error.UnsupportedTranslation, ZigClangStmt_getBeginLoc(@ptrCast(*const ZigClangStmt, stmt)), "TODO complex switch cases", .{});
         switch_scope.cases[switch_scope.case_index] = &else_prong.base;
         switch_scope.case_index += 1;
     }
@@ -2666,6 +2669,9 @@ fn transCase(
     const switch_prong = try transCreateNodeSwitchCase(rp.c, expr);
     switch_prong.expr = &(try transCreateNodeBreak(rp.c, label)).base;
     _ = try appendToken(rp.c, .Comma, ",");
+
+    if (switch_scope.case_index >= switch_scope.cases.len)
+        return revertAndWarn(rp, error.UnsupportedTranslation, ZigClangStmt_getBeginLoc(@ptrCast(*const ZigClangStmt, stmt)), "TODO complex switch cases", .{});
     switch_scope.cases[switch_scope.case_index] = &switch_prong.base;
     switch_scope.case_index += 1;
 
@@ -2699,6 +2705,9 @@ fn transDefault(
     const else_prong = try transCreateNodeSwitchCase(rp.c, try transCreateNodeSwitchElse(rp.c));
     else_prong.expr = &(try transCreateNodeBreak(rp.c, label)).base;
     _ = try appendToken(rp.c, .Comma, ",");
+
+    if (switch_scope.case_index >= switch_scope.cases.len)
+        return revertAndWarn(rp, error.UnsupportedTranslation, ZigClangStmt_getBeginLoc(@ptrCast(*const ZigClangStmt, stmt)), "TODO complex switch cases", .{});
     switch_scope.cases[switch_scope.case_index] = &else_prong.base;
     switch_scope.case_index += 1;
 

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -3,6 +3,21 @@ const std = @import("std");
 const CrossTarget = std.zig.CrossTarget;
 
 pub fn addCases(cases: *tests.TranslateCContext) void {
+    cases.add("complex switch",
+        \\int main() {
+        \\    int i = 2;
+        \\    switch (i) {
+        \\        case 0: {
+        \\            case 2:{
+        \\                i += 2;}
+        \\            i += 1;
+        \\        }
+        \\    }
+        \\}
+    , &[_][]const u8{ // TODO properly translate this
+        \\pub const main = @compileError("unable to translate function");
+    });
+
     cases.add("correct semicolon after infixop",
         \\#define __ferror_unlocked_body(_fp) (((_fp)->_flags & _IO_ERR_SEEN) != 0)
     , &[_][]const u8{


### PR DESCRIPTION
C allows switch case labels to exist anywhere inside the switch so `getSwitchCaseCount` will give an incorrect count.

I tried using an arraylist but it resulted in wildly incorrect translations so I opted for this simpler workaround.
```c
int main() {
    int i = 2;
    switch (i) {
        case 0: {
            case 2:{
                i += 2;}
            i += 1;
        }
    }
}
```

```zig
pub export fn main() c_int {
    var i: c_int = 2;
    __switch: {
        switch (i) {
            @as(c_int, 0) => break :__case_0,
            @as(c_int, 2) => break :__case_1,
            else => break :__switch,
        }
        __case_1: {
            __case_0: {}
        }
        {
            {
                i += @as(c_int, 2);
            }
            i += @as(c_int, 1);
        }
    }
}
```

Closes #5523