### PR TITLE
Windows: Handle ERROR_DIRECTORY in std.fs.deleteDirAbsolute when called on a file path

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -745,6 +745,7 @@ pub const RemoveDirectoryError = error{
     FileNotFound,
     DirNotEmpty,
     Unexpected,
+    NotDir,
 };
 
 pub fn RemoveDirectory(dir_path: []const u8) RemoveDirectoryError!void {
@@ -757,6 +758,7 @@ pub fn RemoveDirectoryW(dir_path_w: [*:0]const u16) RemoveDirectoryError!void {
         switch (kernel32.GetLastError()) {
             .PATH_NOT_FOUND => return error.FileNotFound,
             .DIR_NOT_EMPTY => return error.DirNotEmpty,
+            .DIRECTORY => return error.NotDir,
             else => |err| return unexpectedError(err),
         }
     }


### PR DESCRIPTION
`ERROR_DIRECTORY` (267) is returned from `kernel32.RemoveDirectoryW` if the path is not a directory. Note also that `os.DeleteDirError` already includes `NotDir`, so this doesn't change `std.os.rmdir`'s error set.

Test code:
```zig
const std = @import("std");

pub fn main() !void {
    try std.fs.deleteDirAbsolute("C:\\Users\\Ryan\\Programming\\Zig\\zig\\tmp\\file.txt");
}
```

Before:

```
C:\Users\Ryan\Programming\Zig\zig\tmp>zig run test.zig
error.Unexpected: GetLastError(267): The directory name is invalid.

C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\debug.zig:419:53: 0x13f6b8ca0 in std.debug.writeCurrentStackTraceWindows (run.obj)
    const n = windows.ntdll.RtlCaptureStackBackTrace(0, addr_buf.len, @ptrCast(**c_void, &addr_buf), null);
                                                    ^
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\debug.zig:404:45: 0x13f6a32da in std.debug.writeCurrentStackTrace (run.obj)
        return writeCurrentStackTraceWindows(out_stream, debug_info, tty_config, start_addr);
                                            ^
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\debug.zig:125:31: 0x13f6a20fd in std.debug.dumpCurrentStackTrace (run.obj)
        writeCurrentStackTrace(stderr, debug_info, detectTTYConfig(), start_addr) catch |err| {
                              ^
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\os\windows.zig:1309:40: 0x13f6a3b99 in std.os.windows.unexpectedError (run.obj)
        std.debug.dumpCurrentStackTrace(null);
                                       ^
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\os\windows.zig:760:49: 0x13f6b9554 in std.os.windows.RemoveDirectoryW (run.obj)
            else => |err| return unexpectedError(err),
                                                ^
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\os.zig:2148:40: 0x13f6b94b6 in std.os.rmdir (run.obj)
        return windows.RemoveDirectoryW(dir_path_w.span().ptr);
                                       ^
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\fs.zig:242:20: 0x13f6b92ed in std.fs.deleteDirAbsolute (run.obj)
    return os.rmdir(dir_path);
                   ^
C:\Users\Ryan\Programming\Zig\zig\tmp\test.zig:4:33: 0x13f6a37a9 in main (run.obj)
    try std.fs.deleteDirAbsolute("C:\\Users\\Ryan\\Programming\\Zig\\zig\\tmp\\file.txt");
                                ^
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\start.zig:134:65: 0x13f6a1b7e in std.start.WinMainCRTStartup (run.obj)
    std.os.windows.kernel32.ExitProcess(initEventLoopAndCallMain());
                                                                ^
integer overflow

...

C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\fs.zig:242:20: 0x13f6b92ed in std.fs.deleteDirAbsolute (run.obj)
    return os.rmdir(dir_path);
                   ^
C:\Users\Ryan\Programming\Zig\zig\tmp\test.zig:4:33: 0x13f6a37a9 in main (run.obj)
    try std.fs.deleteDirAbsolute("C:\\Users\\Ryan\\Programming\\Zig\\zig\\tmp\\file.txt");
                                ^
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\start.zig:134:65: 0x13f6a1b7e in std.start.WinMainCRTStartup (run.obj)
    std.os.windows.kernel32.ExitProcess(initEventLoopAndCallMain());
                                                                ^
Panicked during a panic. Aborting.
```

After:

```
error: NotDir
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\os\windows.zig:762:27: 0x13ffd94ad in std.os.windows.RemoveDirectoryW (run.obj)
            .DIRECTORY => return error.NotDir,
                          ^
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\os.zig:2149:9: 0x13ffd93bc in std.os.rmdir (run.obj)
        return windows.RemoveDirectoryW(dir_path_w.span().ptr);
        ^
C:\Users\Ryan\Programming\Zig\zig\build-release\lib\zig\std\fs.zig:242:5: 0x13ffd92d0 in std.fs.deleteDirAbsolute (run.obj)
    return os.rmdir(dir_path);
    ^
C:\Users\Ryan\Programming\Zig\zig\tmp\test.zig:4:5: 0x13ffc37c8 in main (run.obj)
    try std.fs.deleteDirAbsolute("C:\\Users\\Ryan\\Programming\\Zig\\zig\\tmp\\file.txt");
    ^
```