### PR TITLE
Add option for overriding the stack size

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -2100,6 +2100,10 @@ static void construct_linker_job_wasm(LinkJob *lj) {
     CodeGen *g = lj->codegen;
 
     lj->args.append("-error-limit=0");
+    // Increase the default stack size to a more reasonable value of 1MB instead of
+    // the default of 1 Wasm page being 64KB.
+    lj->args.append("-z");
+    lj->args.append("stack-size=1048576");
 
     if (g->out_type != OutTypeExe) {
         lj->args.append("--no-entry"); // So lld doesn't look for _start.

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -2101,9 +2101,10 @@ static void construct_linker_job_wasm(LinkJob *lj) {
 
     lj->args.append("-error-limit=0");
     // Increase the default stack size to a more reasonable value of 1MB instead of
-    // the default of 1 Wasm page being 64KB.
+    // the default of 1 Wasm page being 64KB, unless overriden by the user.
+    size_t stack_size = (g->stack_size_override == 0) ? 1048576 : g->stack_size_override;
     lj->args.append("-z");
-    lj->args.append("stack-size=1048576");
+    lj->args.append(buf_ptr(buf_sprintf("stack-size=%" ZIG_PRI_usize, stack_size)));
 
     if (g->out_type != OutTypeExe) {
         lj->args.append("--no-entry"); // So lld doesn't look for _start.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,7 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  -l[lib]                      alias for --library\n"
         "  -rdynamic                    add all symbols to the dynamic symbol table\n"
         "  -rpath [path]                add directory to the runtime library search path\n"
+        "  --stack [size]               (linux, windows, Wasm) override default stack size\n"
         "  --subsystem [subsystem]      (windows) /SUBSYSTEM:<subsystem> to the linker\n"
         "  -F[dir]                      (darwin) add search path for frameworks\n"
         "  -framework [name]            (darwin) link against framework\n"
@@ -1231,6 +1232,8 @@ static int main0(int argc, char **argv) {
                     ver_patch = atoi(argv[i]);
                 } else if (strcmp(arg, "--test-cmd") == 0) {
                     test_exec_args.append(argv[i]);
+                } else if (strcmp(arg, "--stack") == 0) {
+                    stack_size_override = atoi(argv[i]);
                 } else if (strcmp(arg, "--subsystem") == 0) {
                     if (strcmp(argv[i], "console") == 0) {
                         subsystem = TargetSubsystemConsole;


### PR DESCRIPTION
**Depends on #5529 so don't merge until that one lands.**

This commit adds a `--stack [size]` link-time option to zig compiler allowing the user to override the default stack size set for the specified executable/library format. This is currently limited to ELF, COFF and Wasm however (i.e., Mach-O is excluded).

As far as Mach-O is concerned, I couldn't find any info on tweaking the stack size in `ld64.lld`'s manual. If anyone's got any ideas, please do shout out!

Constitutes a temporary fix of #3735 until `@stackSize()` (or similar) lands. See #1639 for more info.

cc @pixelherodev @fengb @andrewrk