### PR TITLE
tcpConnectToHost try all addresses in AddressList

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -573,7 +573,15 @@ pub fn tcpConnectToHost(allocator: *mem.Allocator, name: []const u8, port: u16) 
 
     if (list.addrs.len == 0) return error.UnknownHostName;
 
-    return tcpConnectToAddress(list.addrs[0]);
+    for (list.addrs) |addr| {
+        return tcpConnectToAddress(addr) catch |err| switch (err) {
+            error.ConnectionRefused => {
+                continue;
+            },
+            else => return err,
+        };
+    }
+    return std.os.ConnectError.ConnectionRefused;
 }
 
 pub fn tcpConnectToAddress(address: Address) !fs.File {


### PR DESCRIPTION
The AddressList returned can contain more than one item e.g. the ipv4 and ipv6 addresses for a given hostname. Previously if a server had multiple addresses but was not listening on one of them Zig would give up immediately.

Now on std.os.ConnectError.ConnectionRefused Zig will try the next address in the list. Zig still gives up on all other errors as they are related to the system and system resources rather than whether the remote server is listening on a particular address.