### PR TITLE
Add strict_align to pre-v6 ARM targets

### DIFF
--- a/lib/std/target/arm.zig
+++ b/lib/std/target/arm.zig
@@ -804,32 +804,43 @@ pub const all_features = blk: {
     result[@enumToInt(Feature.v2)] = .{
         .llvm_name = "armv2",
         .description = "ARMv2 architecture",
-        .dependencies = featureSet(&[_]Feature{}),
+        .dependencies = featureSet(&[_]Feature{
+            .strict_align,
+        }),
     };
     result[@enumToInt(Feature.v2a)] = .{
         .llvm_name = "armv2a",
         .description = "ARMv2a architecture",
-        .dependencies = featureSet(&[_]Feature{}),
+        .dependencies = featureSet(&[_]Feature{
+            .strict_align,
+        }),
     };
     result[@enumToInt(Feature.v3)] = .{
         .llvm_name = "armv3",
         .description = "ARMv3 architecture",
-        .dependencies = featureSet(&[_]Feature{}),
+        .dependencies = featureSet(&[_]Feature{
+            .strict_align,
+        }),
     };
     result[@enumToInt(Feature.v3m)] = .{
         .llvm_name = "armv3m",
         .description = "ARMv3m architecture",
-        .dependencies = featureSet(&[_]Feature{}),
+        .dependencies = featureSet(&[_]Feature{
+            .strict_align,
+        }),
     };
     result[@enumToInt(Feature.v4)] = .{
         .llvm_name = "armv4",
         .description = "ARMv4 architecture",
-        .dependencies = featureSet(&[_]Feature{}),
+        .dependencies = featureSet(&[_]Feature{
+            .strict_align,
+        }),
     };
     result[@enumToInt(Feature.v4t)] = .{
         .llvm_name = "armv4t",
         .description = "ARMv4t architecture",
         .dependencies = featureSet(&[_]Feature{
+            .strict_align,
             .has_v4t,
         }),
     };
@@ -837,6 +848,7 @@ pub const all_features = blk: {
         .llvm_name = "armv5t",
         .description = "ARMv5t architecture",
         .dependencies = featureSet(&[_]Feature{
+            .strict_align,
             .has_v5t,
         }),
     };
@@ -844,6 +856,7 @@ pub const all_features = blk: {
         .llvm_name = "armv5te",
         .description = "ARMv5te architecture",
         .dependencies = featureSet(&[_]Feature{
+            .strict_align,
             .has_v5te,
         }),
     };
@@ -851,6 +864,7 @@ pub const all_features = blk: {
         .llvm_name = "armv5tej",
         .description = "ARMv5tej architecture",
         .dependencies = featureSet(&[_]Feature{
+            .strict_align,
             .has_v5te,
         }),
     };


### PR DESCRIPTION
This PR fixes #2767 by adding the `strict_align` feature as a dependency to all ARM subarchitectures prior to ARMv6.

The `strict_align` feature causes certain memory reads to be compiled as multiple `LDRB` instructions, instead of a single `LDR` or `LDRH` instruction, when the compiler isn't sure the pointer is correctly aligned. Enabling this for ARMv4/ARMv5 matches the default behavior in Rust (which [includes `+strict-align` in `librustc_target`'s spec files](https://github.com/rust-lang/rust/blob/fd4b177aabb9749dfb562c48e47379cea81dc277/src/librustc_target/spec/armv4t_unknown_linux_gnueabi.rs#L18)) and Clang (which [passes `+strict-align` to LLVM unless the user supplies a `-munaligned-access` argument](https://github.com/llvm/llvm-project/blob/5fda192fed14d2024dd774e24a50d8208a654359/clang/lib/Driver/ToolChains/Arch/ARM.cpp#L572-L594)).