### PR TITLE
std: new simpler linked-list std.ListHead

### DIFF
--- a/lib/std/linked_list.zig
+++ b/lib/std/linked_list.zig
@@ -205,8 +205,7 @@ pub const ListHead = struct {
     }
 
     pub fn isEmpty(list: *ListHead) bool {
-        if (list.next == null) return true;
-        return false;
+        return list.next == list;
     }
 };
 
@@ -235,6 +234,9 @@ test "ListHead" {
     expect(listHeadTest(a.list.last()).value == 3);
     expect(listHeadTest(a.list.pop()).value == 3);
     expect(listHeadTest(a.list.last()).value == 2);
+    expect(listHeadTest(a.list.pop()).value == 2);
+    expect(listHeadTest(a.list.pop()).value == 1);
+    expect(a.list.isEmpty());
 }
 
 /// A tail queue is headed by a pair of pointers, one to the head of the

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -21,6 +21,7 @@ pub const Progress = @import("progress.zig").Progress;
 pub const ResetEvent = @import("reset_event.zig").ResetEvent;
 pub const SegmentedList = @import("segmented_list.zig").SegmentedList;
 pub const SinglyLinkedList = @import("linked_list.zig").SinglyLinkedList;
+pub const ListHead = @import("linked_list.zig").ListHead;
 pub const SpinLock = @import("spinlock.zig").SpinLock;
 pub const StringHashMap = @import("hash_map.zig").StringHashMap;
 pub const TailQueue = @import("linked_list.zig").TailQueue;


### PR DESCRIPTION
The existing SinglyLinkedList is not flexible enough for my needs.
This is very similar to what is used in the Linux kernel,
and because it does not use null it is even simpler.