### PR TITLE
Ensure start_windows_tls.zig is imported for non-single-threaded Windows builds

### DIFF
--- a/test/stack_traces.zig
+++ b/test/stack_traces.zig
@@ -282,10 +282,10 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\source.zig:10:8: [address] in main (test)
                     \\    foo();
                     \\       ^
-                    \\start.zig:249:29: [address] in std.start.posixCallMainAndExit (test)
+                    \\start.zig:251:29: [address] in std.start.posixCallMainAndExit (test)
                     \\            return root.main();
                     \\                            ^
-                    \\start.zig:123:5: [address] in std.start._start (test)
+                    \\start.zig:129:5: [address] in std.start._start (test)
                     \\    @call(.{ .modifier = .never_inline }, posixCallMainAndExit, .{});
                     \\    ^
                     \\


### PR DESCRIPTION
Addresses issue #5002 

Basically, Windows TLS stuff wasn't getting imported unless the build system decided to export its own entry-point. If the user defines their own, such as `WinMain`, then the default entry-point wouldn't be exported and so `start_windows_tls.zig` would never be imported. It looked like the same issue would affect dynamic libs, so I applied the same change there too.

Please review carefully, as I have only really looked at the code that I've changed, and any additional ramifications of this change are entirely unknown to me 👍 