### PR TITLE
std: malloc alignment

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -242,6 +242,7 @@ pub const malloc_min_align = @alignOf(extern union {
 });
 
 pub extern "c" fn aligned_alloc(alignment: usize, size: usize) ?*c_void;
+pub extern "c" fn calloc(usize, usize) ?*align(malloc_min_align) c_void;
 pub extern "c" fn malloc(usize) ?*align(malloc_min_align) c_void;
 pub extern "c" fn realloc(?*align(malloc_min_align) c_void, usize) ?*align(malloc_min_align) c_void;
 pub extern "c" fn free(*c_void) void;

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -229,9 +229,21 @@ pub extern "c" fn getdirentries(fd: fd_t, buf_ptr: [*]u8, nbytes: usize, basep: 
 pub extern "c" fn setgid(ruid: c_uint, euid: c_uint) c_int;
 pub extern "c" fn setuid(uid: c_uint) c_int;
 
+/// The order and contiguity of storage allocated by successive calls
+/// to the calloc , malloc , and realloc functions is unspecified.  The
+/// pointer returned if the allocation succeeds is suitably aligned so
+/// that it may be assigned to a pointer to any type of object and then
+/// used to access such an object in the space allocated (until the space
+/// is explicitly freed or reallocated).
+pub const malloc_min_align = @alignOf(extern union {
+    a: *c_void,
+    b: c_long,
+    c: c_longdouble,
+});
+
 pub extern "c" fn aligned_alloc(alignment: usize, size: usize) ?*c_void;
-pub extern "c" fn malloc(usize) ?*c_void;
-pub extern "c" fn realloc(?*c_void, usize) ?*c_void;
+pub extern "c" fn malloc(usize) ?*align(malloc_min_align) c_void;
+pub extern "c" fn realloc(?*align(malloc_min_align) c_void, usize) ?*align(malloc_min_align) c_void;
 pub extern "c" fn free(*c_void) void;
 pub extern "c" fn posix_memalign(memptr: **c_void, alignment: usize, size: usize) c_int;
 

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -22,14 +22,14 @@ var c_allocator_state = Allocator{
 };
 
 fn cRealloc(self: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) ![]u8 {
-    assert(new_align <= @alignOf(c_longdouble));
-    const old_ptr = if (old_mem.len == 0) null else @ptrCast(*c_void, old_mem.ptr);
+    assert(new_align <= c.malloc_min_align); // TODO: use posix_memalign / aligned_alloc
+    const old_ptr = if (old_mem.len == 0) null else @alignCast(c.malloc_min_align, @ptrCast(*c_void, old_mem.ptr));
     const buf = c.realloc(old_ptr, new_size) orelse return error.OutOfMemory;
     return @ptrCast([*]u8, buf)[0..new_size];
 }
 
 fn cShrink(self: *Allocator, old_mem: []u8, old_align: u29, new_size: usize, new_align: u29) []u8 {
-    const old_ptr = @ptrCast(*c_void, old_mem.ptr);
+    const old_ptr = @alignCast(c.malloc_min_align, @ptrCast(*c_void, old_mem.ptr));
     const buf = c.realloc(old_ptr, new_size) orelse return old_mem[0..new_size];
     return @ptrCast([*]u8, buf)[0..new_size];
 }


### PR DESCRIPTION
I noticed a new user needing to `@alignCast` the result of `malloc`.