### PR TITLE
std: clean up debug stderr variables

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1288,7 +1288,7 @@ pub const Value = union(enum) {
         var held = std.debug.getStderrMutex().acquire();
         defer held.release();
 
-        const stderr = std.debug.getStderrStream();
+        const stderr = io.getStdErr().writer();
         std.json.stringify(self, std.json.StringifyOptions{ .whitespace = null }, stderr) catch return;
     }
 };


### PR DESCRIPTION
  - `stderr_file_writer` was unused
  - `stderr_stream` was a pointer to a stream, rather than a stream
  - other functions assumed that `getStderrStream` has already been called

---

Fixes `std.json.Value.dump` which would fail to compile with:

```
./lib/std/json.zig:2408:22: error: type '*std.io.writer.Writer(std.fs.file.File,std.os.WriteError,std.fs.file.File.write)' has no member called 'Error'
) @TypeOf(out_stream).Error!void {
                     ^
./lib/std/json.zig:2408:28: note: called from here
) @TypeOf(out_stream).Error!void {
                           ^
./lib/std/json.zig:1287:35: note: called from here
    pub fn dump(self: Value) void {
                                  ^
./lib/std/json.zig:1292:27: note: referenced here
        std.json.stringify(self, std.json.StringifyOptions{ .whitespace = null }, stderr) catch return;
                          ^
```