### PR TITLE
Improve support for f128 and comptime_float operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ set(ZIG_SOURCES
     "${CMAKE_SOURCE_DIR}/src/target.cpp"
     "${CMAKE_SOURCE_DIR}/src/tokenizer.cpp"
     "${CMAKE_SOURCE_DIR}/src/util.cpp"
+    "${CMAKE_SOURCE_DIR}/src/softfloat_ext.cpp"
     "${ZIG_SOURCES_MEM_PROFILE}"
 )
 set(OPTIMIZED_C_SOURCES

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -122,6 +122,11 @@ pub fn forceEval(value: var) void {
             const p = @ptrCast(*volatile f64, &x);
             p.* = x;
         },
+        f128 => {
+            var x: f128 = undefined;
+            const p = @ptrCast(*volatile f128, &x);
+            p.* = x;
+        },
         else => {
             @compileError("forceEval not implemented for " ++ @typeName(T));
         },

--- a/lib/std/math/trunc.zig
+++ b/lib/std/math/trunc.zig
@@ -20,6 +20,7 @@ pub fn trunc(x: var) @TypeOf(x) {
     return switch (T) {
         f32 => trunc32(x),
         f64 => trunc64(x),
+        f128 => trunc128(x),
         else => @compileError("trunc not implemented for " ++ @typeName(T)),
     };
 }
@@ -66,9 +67,31 @@ fn trunc64(x: f64) f64 {
     }
 }
 
+fn trunc128(x: f128) f128 {
+    const u = @bitCast(u128, x);
+    var e = @intCast(i32, ((u >> 112) & 0x7FFF)) - 0x3FFF + 16;
+    var m: u128 = undefined;
+
+    if (e >= 112 + 16) {
+        return x;
+    }
+    if (e < 16) {
+        e = 1;
+    }
+
+    m = @as(u128, maxInt(u128)) >> @intCast(u7, e);
+    if (u & m == 0) {
+        return x;
+    } else {
+        math.forceEval(x + 0x1p120);
+        return @bitCast(f128, u & ~m);
+    }
+}
+
 test "math.trunc" {
     expect(trunc(@as(f32, 1.3)) == trunc32(1.3));
     expect(trunc(@as(f64, 1.3)) == trunc64(1.3));
+    expect(trunc(@as(f128, 1.3)) == trunc128(1.3));
 }
 
 test "math.trunc32" {
@@ -81,6 +104,12 @@ test "math.trunc64" {
     expect(trunc64(1.3) == 1.0);
     expect(trunc64(-1.3) == -1.0);
     expect(trunc64(0.2) == 0.0);
+}
+
+test "math.trunc128" {
+    expect(trunc128(1.3) == 1.0);
+    expect(trunc128(-1.3) == -1.0);
+    expect(trunc128(0.2) == 0.0);
 }
 
 test "math.trunc32.special" {
@@ -97,4 +126,12 @@ test "math.trunc64.special" {
     expect(math.isPositiveInf(trunc64(math.inf(f64))));
     expect(math.isNegativeInf(trunc64(-math.inf(f64))));
     expect(math.isNan(trunc64(math.nan(f64))));
+}
+
+test "math.trunc128.special" {
+    expect(trunc128(0.0) == 0.0);
+    expect(trunc128(-0.0) == -0.0);
+    expect(math.isPositiveInf(trunc128(math.inf(f128))));
+    expect(math.isNegativeInf(trunc128(-math.inf(f128))));
+    expect(math.isNan(trunc128(math.nan(f128))));
 }

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -13,6 +13,7 @@
 #include "os.hpp"
 #include "range_set.hpp"
 #include "softfloat.hpp"
+#include "softfloat_ext.hpp"
 #include "util.hpp"
 #include "mem_list.hpp"
 #include "all_types.hpp"
@@ -30303,6 +30304,21 @@ static ErrorMsg *ir_eval_float_op(IrAnalyze *ira, IrInst* source_instr, BuiltinF
         case BuiltinFnIdSqrt:
             f128M_sqrt(in, out);
             break;
+        case BuiltinFnIdFabs:
+            f128M_abs(in, out);
+            break;
+        case BuiltinFnIdFloor:
+            f128M_roundToInt(in, softfloat_round_min, false, out);
+            break;
+        case BuiltinFnIdCeil:
+            f128M_roundToInt(in, softfloat_round_max, false, out);
+        break;
+        case BuiltinFnIdTrunc:
+            f128M_trunc(in, out);
+            break;
+        case BuiltinFnIdRound: 
+            f128M_roundToInt(in, softfloat_round_near_maxMag, false, out);
+            break;
         case BuiltinFnIdNearbyInt:
         case BuiltinFnIdSin:
         case BuiltinFnIdCos:
@@ -30311,11 +30327,6 @@ static ErrorMsg *ir_eval_float_op(IrAnalyze *ira, IrInst* source_instr, BuiltinF
         case BuiltinFnIdLog:
         case BuiltinFnIdLog10:
         case BuiltinFnIdLog2:
-        case BuiltinFnIdFabs:
-        case BuiltinFnIdFloor:
-        case BuiltinFnIdCeil:
-        case BuiltinFnIdTrunc:
-        case BuiltinFnIdRound:
             return ir_add_error(ira, source_instr,
                 buf_sprintf("compiler bug: TODO: implement '%s' for type '%s'. See https://github.com/ziglang/zig/issues/4026",
                     float_op_to_name(fop), buf_ptr(&float_type->name)));

--- a/src/softfloat_ext.cpp
+++ b/src/softfloat_ext.cpp
@@ -1,0 +1,25 @@
+#include "softfloat_ext.hpp"
+
+extern "C" {
+    #include "softfloat.h"
+}
+
+void f128M_abs(const float128_t *aPtr, float128_t *zPtr) {
+    float128_t zero_float;
+    ui32_to_f128M(0, &zero_float);
+    if (f128M_lt(aPtr, &zero_float)) {
+        f128M_sub(&zero_float, aPtr, zPtr);
+    } else {
+        *zPtr = *aPtr;
+    } 
+}
+
+void f128M_trunc(const float128_t *aPtr, float128_t *zPtr) {
+    float128_t zero_float;
+    ui32_to_f128M(0, &zero_float);
+    if (f128M_lt(aPtr, &zero_float)) {
+        f128M_roundToInt(aPtr, softfloat_round_max, false, zPtr);
+    } else {
+        f128M_roundToInt(aPtr, softfloat_round_min, false, zPtr);
+    } 
+}

--- a/src/softfloat_ext.hpp
+++ b/src/softfloat_ext.hpp
@@ -1,0 +1,9 @@
+#ifndef ZIG_SOFTFLOAT_EXT_HPP
+#define ZIG_SOFTFLOAT_EXT_HPP
+
+#include "softfloat_types.h"
+
+void f128M_abs(const float128_t *aPtr, float128_t *zPtr);
+void f128M_trunc(const float128_t *aPtr, float128_t *zPtr);
+
+#endif

--- a/test/stage1/behavior/math.zig
+++ b/test/stage1/behavior/math.zig
@@ -634,6 +634,128 @@ fn testSqrt(comptime T: type, x: T) void {
     expect(@sqrt(x * x) == x);
 }
 
+test "@fabs" {
+    testFabs(f128, 12.0);
+    comptime testFabs(f128, 12.0);
+    testFabs(f64, 12.0);
+    comptime testFabs(f64, 12.0);
+    testFabs(f32, 12.0);
+    comptime testFabs(f32, 12.0);
+    testFabs(f16, 12.0);
+    comptime testFabs(f16, 12.0);
+
+    const x = 14.0;
+    const y = -x;
+    const z = @fabs(y);
+    comptime expectEqual(x, z);
+}
+
+fn testFabs(comptime T: type, x: T) void {
+    const y = -x;
+    const z = @fabs(y);
+    expectEqual(x, z);
+}
+
+test "@floor" {
+    // FIXME: Generates a floorl function call
+    // testFloor(f128, 12.0);
+    comptime testFloor(f128, 12.0);
+    testFloor(f64, 12.0);
+    comptime testFloor(f64, 12.0);
+    testFloor(f32, 12.0);
+    comptime testFloor(f32, 12.0);
+    testFloor(f16, 12.0);
+    comptime testFloor(f16, 12.0);
+
+    const x = 14.0;
+    const y = x + 0.7;
+    const z = @floor(y);
+    comptime expectEqual(x, z);
+}
+
+fn testFloor(comptime T: type, x: T) void {
+    const y = x + 0.6;
+    const z = @floor(y);
+    expectEqual(x, z);
+}
+
+test "@ceil" {
+    // FIXME: Generates a ceill function call
+    //testCeil(f128, 12.0);
+    comptime testCeil(f128, 12.0);
+    testCeil(f64, 12.0);
+    comptime testCeil(f64, 12.0);
+    testCeil(f32, 12.0);
+    comptime testCeil(f32, 12.0);
+    testCeil(f16, 12.0);
+    comptime testCeil(f16, 12.0);
+
+    const x = 14.0;
+    const y = x - 0.7;
+    const z = @ceil(y);
+    comptime expectEqual(x, z);
+}
+
+fn testCeil(comptime T: type, x: T) void {
+    const y = x - 0.8;
+    const z = @ceil(y);
+    expectEqual(x, z);
+}
+
+test "@trunc" {
+    // FIXME: Generates a truncl function call
+    //testTrunc(f128, 12.0);
+    comptime testTrunc(f128, 12.0);
+    testTrunc(f64, 12.0);
+    comptime testTrunc(f64, 12.0);
+    testTrunc(f32, 12.0);
+    comptime testTrunc(f32, 12.0);
+    testTrunc(f16, 12.0);
+    comptime testTrunc(f16, 12.0);
+
+    const x = 14.0;
+    const y = x + 0.7;
+    const z = @trunc(y);
+    comptime expectEqual(x, z);
+}
+
+fn testTrunc(comptime T: type, x: T) void {
+    {
+        const y = x + 0.8;
+        const z = @trunc(y);
+        expectEqual(x, z);
+    }
+
+    {
+        const y = -x - 0.8;
+        const z = @trunc(y);
+        expectEqual(-x, z);
+    }
+}
+
+test "@round" {
+    // FIXME: Generates a roundl function call
+    //testRound(f128, 12.0);
+    comptime testRound(f128, 12.0);
+    testRound(f64, 12.0);
+    comptime testRound(f64, 12.0);
+    testRound(f32, 12.0);
+    comptime testRound(f32, 12.0);
+    testRound(f16, 12.0);
+    comptime testRound(f16, 12.0);
+
+    const x = 14.0;
+    const y = x + 0.4;
+    const z = @round(y);
+    comptime expectEqual(x, z);
+}
+
+fn testRound(comptime T: type, x: T) void {
+    const y = x - 0.5;
+    const z = @round(y);
+    expectEqual(x, z);
+}
+
 test "comptime_int param and return" {
     const a = comptimeAdd(35361831660712422535336160538497375248, 101752735581729509668353361206450473702);
     expect(a == 137114567242441932203689521744947848950);


### PR DESCRIPTION
- Adds builtin support for fabs, floor, ceil, trunc and round to f128 and comptime_float. 
- Adds standard library support for same operations for f128.

The behavior tests are not fully complete because the compiler seems to generate calls to floorl, ceill, truncl and roundl which results in a linking error. But this only happens when these builtins are called from within another function. Adding exports in special/c.zig solves the issue for the bare target but tests fail when linking against libc, these functions seem to just return the input. This might be because the libc floorl, ceill, truncl and roundl usually supports 80-bit floats?