### PR TITLE
stage1: coerce single-item ptr to slice

### DIFF
--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -64,6 +64,7 @@ comptime {
     _ = @import("behavior/bugs/726.zig");
     _ = @import("behavior/bugs/828.zig");
     _ = @import("behavior/bugs/920.zig");
+    _ = @import("behavior/bugs/5516.zig");
     _ = @import("behavior/byteswap.zig");
     _ = @import("behavior/byval_arg_var.zig");
     _ = @import("behavior/call.zig");

--- a/test/stage1/behavior/bugs/5516.zig
+++ b/test/stage1/behavior/bugs/5516.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+const mem = std.mem;
+const expect = std.testing.expect;
+
+test "single-item ptr to slice" {
+    var x: u32 = 1;
+    const single_item_array: *[1]u32 = &x;
+    const slice1: []u32 = single_item_array;
+    const slice2: []u32 = @as(*[1]u32, &x);
+    expect(mem.eql(u32, slice1, slice2));
+    const slice3 = @as([]u32, &x);
+    expect(mem.eql(u32, slice2, slice3));
+}


### PR DESCRIPTION
Technically, this PR fixes #5516. However, I'm wondering if there's a better approach to this?

In summary, this PR adds a new coercion rule representing coercion chain: `*T -> *[1]T -> []T`. This then fixes #5516 but also allows for a direct cast from `*T` to `[]T`. Internally, the new rule makes two recursive calls to `ir_analyze_cast` such that firstly `*T -> *[1]T`, followed by `*[1]T -> []T`. I was wondering if there exists a better way of doing this. @andrewrk @Vexu @daurnimator could you have a look and lemme know what you reckon? In particular, could you let me know if in your mind this is the way to go, and if so, double check is the predicates are valid? If you reckon it's not the way to go, I'd welcome any pointers as to how to tackle this issue.