### PR TITLE
[libstd]: Enable CacheHash in WASI

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3793,10 +3793,7 @@ pub fn realpathZ(pathname: [*:0]const u8, out_buffer: *[MAX_PATH_BYTES]u8) RealP
         };
         defer close(fd);
 
-        var procfs_buf: ["/proc/self/fd/-2147483648".len:0]u8 = undefined;
-        const proc_path = std.fmt.bufPrint(procfs_buf[0..], "/proc/self/fd/{}\x00", .{fd}) catch unreachable;
-
-        return readlinkZ(@ptrCast([*:0]const u8, proc_path.ptr), out_buffer);
+        return fdPath(fd, out_buffer);
     }
     const result_path = std.c.realpath(pathname, out_buffer) orelse switch (std.c._errno().*) {
         EINVAL => unreachable,
@@ -3828,17 +3825,93 @@ pub fn realpathW(pathname: [*:0]const u16, out_buffer: *[MAX_PATH_BYTES]u8) Real
     );
     defer windows.CloseHandle(h_file);
 
-    var wide_buf: [windows.PATH_MAX_WIDE]u16 = undefined;
-    const wide_slice = try windows.GetFinalPathNameByHandleW(h_file, &wide_buf, wide_buf.len, windows.VOLUME_NAME_DOS);
+    return fdPath(h_file, out_buffer);
+}
 
-    // Windows returns \\?\ prepended to the path.
-    // We strip it to make this function consistent across platforms.
-    const prefix = [_]u16{ '\\', '\\', '?', '\\' };
-    const start_index = if (mem.startsWith(u16, wide_slice, &prefix)) prefix.len else 0;
+fn fdPath(fd: fd_t, out_buffer: *[MAX_PATH_BYTES]u8) RealPathError![]u8 {
+    switch (builtin.os.tag) {
+        .wasi => @compileError("fdPath is unsupported in WASI"),
+        .windows => {
+            var wide_buf: [windows.PATH_MAX_WIDE]u16 = undefined;
+            const wide_slice = try windows.GetFinalPathNameByHandleW(fd, &wide_buf, wide_buf.len, windows.VOLUME_NAME_DOS);
 
-    // Trust that Windows gives us valid UTF-16LE.
-    const end_index = std.unicode.utf16leToUtf8(out_buffer, wide_slice[start_index..]) catch unreachable;
-    return out_buffer[0..end_index];
+            // Windows returns \\?\ prepended to the path.
+            // We strip it to make this function consistent across platforms.
+            const prefix = [_]u16{ '\\', '\\', '?', '\\' };
+            const start_index = if (mem.startsWith(u16, wide_slice, &prefix)) prefix.len else 0;
+
+            // Trust that Windows gives us valid UTF-16LE.
+            const end_index = std.unicode.utf16leToUtf8(out_buffer, wide_slice[start_index..]) catch unreachable;
+            return out_buffer[0..end_index];
+        },
+        .macosx, .ios, .watchos, .tvos => {
+            // On macOS, we can use F_GETPATH fcntl command to query the OS for
+            // the path to the file descriptor.
+            @memset(out_buffer, 0, MAX_PATH_BYTES);
+            switch (errno(system.fcntl(fd, F_GETPATH, out_buffer))) {
+                0 => {},
+                EBADF => return error.FileNotFound,
+                // TODO man pages for fcntl on macOS don't really tell you what
+                // errno values to expect when command is F_GETPATH...
+                else => |err| return unexpectedErrno(err),
+            }
+            const len = mem.indexOfScalar(u8, out_buffer[0..], @as(u8, 0)) orelse MAX_PATH_BYTES;
+            return out_buffer[0..len];
+        },
+        else => {
+            var procfs_buf: ["/proc/self/fd/-2147483648".len:0]u8 = undefined;
+            const proc_path = std.fmt.bufPrint(procfs_buf[0..], "/proc/self/fd/{}\x00", .{fd}) catch unreachable;
+
+            return readlinkZ(@ptrCast([*:0]const u8, proc_path.ptr), out_buffer);
+        },
+    }
+}
+
+/// Similar to `realpath`, however, returns the canonicalized absolute pathname of
+/// a `pathname` relative to a file descriptor `fd`.
+/// If `pathname` is an absolute path, ignores `fd` and reverts to calling
+/// `realpath` on the `pathname` argument.
+/// In Unix, if `fd` was obtained using `std.fs.cwd()` call, reverts to calling
+/// `std.os.getcwd()` to obtain file descriptor's path.
+pub fn realpathat(fd: fd_t, pathname: []const u8, out_buffer: *[MAX_PATH_BYTES]u8) RealPathError![]u8 {
+    if (builtin.os.tag == .wasi) {
+        @compileError("realpathat is unsupported in WASI");
+    }
+    if (std.fs.path.isAbsolute(pathname)) {
+        return realpath(pathname, out_buffer);
+    }
+
+    var buffer: [MAX_PATH_BYTES]u8 = undefined;
+    var fd_path: []const u8 = undefined;
+    if (@hasDecl(@This(), "AT_FDCWD")) {
+        if (fd == @field(@This(), "AT_FDCWD")) {
+            fd_path = getcwd(buffer[0..]) catch |err| {
+                return switch (err) {
+                    GetCwdError.NameTooLong => error.NameTooLong,
+                    GetCwdError.CurrentWorkingDirectoryUnlinked => error.FileNotFound,
+                    else => |e| e,
+                };
+            };
+        } else {
+            fd_path = try fdPath(fd, &buffer);
+        }
+    } else {
+        fd_path = try fdPath(fd, &buffer);
+    }
+
+    const total_len = fd_path.len + pathname.len + 1; // +1 to account for path separator
+    if (total_len >= MAX_PATH_BYTES) {
+        return error.NameTooLong;
+    }
+
+    const sep = if (builtin.os.tag == .windows) '\\' else '/';
+
+    var unnormalized: [MAX_PATH_BYTES]u8 = undefined;
+    mem.copy(u8, unnormalized[0..], fd_path);
+    unnormalized[fd_path.len] = sep;
+    mem.copy(u8, unnormalized[fd_path.len + 1 ..], pathname);
+
+    return realpath(unnormalized[0..total_len], out_buffer);
 }
 
 /// Spurious wakeups are possible and no precision of timing is guaranteed.

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -276,16 +276,17 @@ test "realpathat" {
     var buf2: [fs.MAX_PATH_BYTES]u8 = undefined;
     const cwd_realpathat = try os.realpathat(cwd.fd, "", &buf2);
     testing.expect(mem.eql(u8, cwd_path, cwd_realpathat));
-    const cwd_realpathat2 = try os.realpathat(cwd.fd, ".", &buf2); // shouldn't change a thing
-    testing.expect(mem.eql(u8, cwd_path, cwd_realpathat2));
 
     // Now, open an actual Dir{"."} since on Unix `realpathat` behaves
     // in a special way when `fd` equals `cwd.fd`
-    const dir = try cwd.openDir(".", .{});
-    const cwd_realpathat3 = try os.realpathat(dir.fd, "", &buf2);
-    testing.expect(mem.eql(u8, cwd_path, cwd_realpathat3));
-    const cwd_realpathat4 = try os.realpathat(dir.fd, ".", &buf2); // shouldn't change a thing
-    testing.expect(mem.eql(u8, cwd_path, cwd_realpathat4));
+    var dir = try cwd.openDir(".", .{});
+    defer dir.close();
+
+    const cwd_realpathat2 = try os.realpathat(dir.fd, "", &buf2);
+    testing.expect(mem.eql(u8, cwd_path, cwd_realpathat2));
+
+    // Finally, try getting a path for something that doesn't exist
+    testing.expectError(error.FileNotFound, os.realpathat(dir.fd, "definitely_bogus_does_not_exist1234", &buf2));
 }
 
 test "sigaltstack" {


### PR DESCRIPTION
This PR fixes #5437.

Summary of changes to achieve this:
* adds `std.os.realpathat` which is similar to `std.os.realpath`, however, it accepts a tuple `(fd_t, []const u8)` of args and thus works out the realpath of a relative path wrt to some opened file descriptor.

  If the input pathname argument turns out to be an absolute path, this function reverts to calling `realpath` on that pathname completely ignoring the input file descriptor. This behaviour is standard in POSIX and IMHO a good rule of thumb to follow.

  If the input file descriptor was obtained using `std.fs.cwd()` call, this function reverts to `std.os.getcwd()` to obtain the file descriptor's path.

* adds `std.fs.path.resolveat` functions which is similar to `std.fs.path.resolve`, however, differs in the sense that, in addition to a slice of paths, it also accepts a `Dir` handle with respect to which the paths should be resolved. It also issues one syscall in order to workout the path to the `Dir` handle.

  With `std.fs.path.resolveat`, it is now possible to store `work_dir` handle directly in `CacheHash` struct and workout paths to cached files wrt to it rather than wrt `cwd`.

* adds `std.fs.path.resolveRelative` function which is like `std.fs.path.resolve` however it resolves relative paths **only**, and they are always resolved to wrt ".". If the final path is resolved to "." or beyond, `null` is returned instead to signify this. Also, if an absolute path is passed as an argument, `ResolveRelativeError.AbsolutePath` is thrown. This function is particularly useful for Capsicum-like targets such as WASI.

  This commit also tweaks `std.cache_hash.CacheHash` to use either `std.fs.path.resolveat` or `std.fs.path.resolveRelative` (the latter used when targeting WASI). This way, we essentially got rid of any mention of CWD, and hence, it is now possible to use `CacheHash` struct in WASI. As a result, all tests in the said module have been enabled for WASI.

cc @andrewrk, as per usual, looking forward to your thoughts on this!