### PR TITLE
`try` allocation of pointer type when parsing

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1629,7 +1629,7 @@ pub fn parseFree(comptime T: type, value: T, options: ParseOptions) void {
             switch (ptrInfo.size) {
                 .One => {
                     parseFree(ptrInfo.child, value.*, options);
-                    allocator.destroy(v);
+                    allocator.destroy(value);
                 },
                 .Slice => {
                     for (value) |v| {

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1535,7 +1535,7 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
             const allocator = options.allocator orelse return error.AllocatorRequired;
             switch (ptrInfo.size) {
                 .One => {
-                    const r: T = allocator.create(ptrInfo.child);
+                    const r: T = try allocator.create(ptrInfo.child);
                     r.* = try parseInternal(ptrInfo.child, token, tokens, options);
                     return r;
                 },


### PR DESCRIPTION
Fixes a bug where parsing into `*T` would fail due to assignment of an error union. Also fixes the dealloc portion of the code.