### PR TITLE
Add special consideration for Archlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ cmake ..
 make install
 ```
 
+Some special considerations for specific hosts:
+
+###### Archlinux
+
+  Currently, the Clang package distributed via official Pacman sources isn't built with shared libraries, therefore, it is not possible to link
+  against individual Clang libs. Instead, one should link against `libclang-cpp.so`. More on this [here](https://bugs.archlinux.org/task/66283).
+  Thus, when building on Archlinux, you need to pass `ZIG_PREFER_CLANG_CPP_DYLIB` flag set to true like so:
+  
+  ```
+  cmake .. -DZIG_PREFER_CLANG_CPP_DYLIB=true
+  ```
+
 ##### MacOS
 
 ```

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Some special considerations for specific hosts:
 ###### Archlinux
 
 The Clang package distributed via official Pacman sources isn't built with static libraries, therefore, it is not possible to statically link
-  against individual Clang libs. Instead, one should link against the shared lib `libclang-cpp.so`.
-  Thus, when building on Archlinux, you need to pass `ZIG_PREFER_CLANG_CPP_DYLIB` flag set to true like so:
+against individual Clang libs. Instead, one should link against the shared lib `libclang-cpp.so`.
+Thus, when building on Archlinux, you need to pass `ZIG_PREFER_CLANG_CPP_DYLIB` flag set to true like so:
   
-  ```
-  cmake .. -DZIG_PREFER_CLANG_CPP_DYLIB=true
-  ```
+```
+cmake .. -DZIG_PREFER_CLANG_CPP_DYLIB=true
+```
 
 ##### MacOS
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Some special considerations for specific hosts:
 
 ###### Archlinux
 
-  Currently, the Clang package distributed via official Pacman sources isn't built with shared libraries, therefore, it is not possible to link
+The Clang package distributed via official Pacman sources isn't built with static libraries, therefore, it is not possible to statically link
   against individual Clang libs. Instead, one should link against `libclang-cpp.so`. More on this [here](https://bugs.archlinux.org/task/66283).
   Thus, when building on Archlinux, you need to pass `ZIG_PREFER_CLANG_CPP_DYLIB` flag set to true like so:
   

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Some special considerations for specific hosts:
 ###### Archlinux
 
 The Clang package distributed via official Pacman sources isn't built with static libraries, therefore, it is not possible to statically link
-  against individual Clang libs. Instead, one should link against `libclang-cpp.so`. More on this [here](https://bugs.archlinux.org/task/66283).
+  against individual Clang libs. Instead, one should link against the shared lib `libclang-cpp.so`.
   Thus, when building on Archlinux, you need to pass `ZIG_PREFER_CLANG_CPP_DYLIB` flag set to true like so:
   
   ```


### PR DESCRIPTION
Turns out `clang-10` package doesn't ship with individually build clang libs on Archlinux. Instead, it is advised to link against `libclang-cpp.so`. This commit adds a special section to build instructions for Archlinux about circumventing this issue.