### PR TITLE
Add tests for using directory operations on files

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1099,6 +1099,7 @@ pub const Dir = struct {
             .OBJECT_NAME_INVALID => unreachable,
             .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
             .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
+            .NOT_A_DIRECTORY => return error.NotDir,
             .INVALID_PARAMETER => unreachable,
             else => return w.unexpectedStatus(rc),
         }


### PR DESCRIPTION
Also fixes `fs.Dir.openDir` on Windows when called with a path to a file. Contributes towards #5653

cc @kubkon to make sure this would work for WASI (I'm unsure of how to test WASI).