### PR TITLE
Translate-c fix rhs not cast on array access

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -268,5 +268,77 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    if (count != 4) abort();
         \\    return 0;
         \\}
-    ,"");
+    , "");
+
+    cases.add("array value type casts properly",
+        \\#include <stdlib.h>
+        \\unsigned int choose[53][10];
+        \\static int hash_binary(int k)
+        \\{
+        \\    choose[0][k] = 3;
+        \\    int sum = 0;
+        \\    sum += choose[0][k];
+        \\    return sum;
+        \\}
+        \\
+        \\int main() {
+        \\    int s = hash_binary(4);
+        \\    if (s != 3) abort();
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("array value type casts properly use +=",
+        \\#include <stdlib.h>
+        \\static int hash_binary(int k)
+        \\{
+        \\    unsigned int choose[1][1] = {{3}};
+        \\    int sum = -1;
+        \\    int prev = 0;
+        \\    prev = sum += choose[0][0];
+        \\    if (sum != 2) abort();
+        \\    return sum + prev;
+        \\}
+        \\
+        \\int main() {
+        \\    int x = hash_binary(4);
+        \\    if (x != 4) abort();
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("ensure array casts outisde +=",
+        \\#include <stdlib.h>
+        \\static int hash_binary(int k)
+        \\{
+        \\    unsigned int choose[3] = {1, 2, 3};
+        \\    int sum = -2;
+        \\    int prev = sum + choose[k];
+        \\    if (prev != 0) abort();
+        \\    return sum + prev;
+        \\}
+        \\
+        \\int main() {
+        \\    int x = hash_binary(1);
+        \\    if (x != -2) abort();
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("array cast int to uint",
+        \\#include <stdlib.h>
+        \\static unsigned int hash_binary(int k)
+        \\{
+        \\    int choose[3] = {-1, -2, 3};
+        \\    unsigned int sum = 2;
+        \\    sum += choose[k];
+        \\    return sum;
+        \\}
+        \\
+        \\int main() {
+        \\    unsigned int x = hash_binary(1);
+        \\    if (x != 0) abort();
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
Closes #5671. Checks if the rhs is integral and of
differing or the same signedness. If they are different
does an @intCast to the lhs type

The tests added are slightly different than the example given as they don't use extern. That was causing zig to look for a symbol called `_choose` and I think that is a different issue (though I couldn't find it).