### PR TITLE
Add error message for unreachable else prong in switch

### DIFF
--- a/lib/std/zig/string_literal.zig
+++ b/lib/std/zig/string_literal.zig
@@ -104,7 +104,6 @@ pub fn parse(
                     return error.InvalidCharacter;
                 },
             },
-            else => unreachable,
         }
     }
     unreachable;

--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -2791,7 +2791,6 @@ fn transCharLiteral(
             "TODO: support character literal kind {}",
             .{kind},
         ),
-        else => unreachable,
     };
     if (suppress_as == .no_as) {
         return maybeSuppressResult(rp, scope, result_used, int_lit_node);

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -4095,7 +4095,7 @@ struct IrInstSrcCheckSwitchProngs {
     IrInstSrc *target_value;
     IrInstSrcCheckSwitchProngsRange *ranges;
     size_t range_count;
-    bool have_else_prong;
+    AstNode* else_prong;
     bool have_underscore_prong;
 };
 

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2177,7 +2177,7 @@ static void ir_print_check_switch_prongs(IrPrintSrc *irp, IrInstSrcCheckSwitchPr
         fprintf(irp->f, "...");
         ir_print_other_inst_src(irp, instruction->ranges[i].end);
     }
-    const char *have_else_str = instruction->have_else_prong ? "yes" : "no";
+    const char *have_else_str = instruction->else_prong != nullptr ? "yes" : "no";
     fprintf(irp->f, ")else:%s", have_else_str);
 }
 

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -468,6 +468,102 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:12:5: error: switch on non-exhaustive enum must include `else` or `_` prong",
     });
 
+    cases.add("switch expression - unreachable else prong (bool)",
+        \\fn foo(x: bool) void {
+        \\    switch (x) {
+        \\        true => {},
+        \\        false => {},
+        \\        else => {},
+        \\    }
+        \\}
+        \\export fn entry() usize { return @sizeOf(@TypeOf(foo)); }
+    , &[_][]const u8{
+        "tmp.zig:5:9: error: unreachable else prong, all cases already handled",
+    });
+
+    cases.add("switch expression - unreachable else prong (u1)",
+        \\fn foo(x: u1) void {
+        \\    switch (x) {
+        \\        0 => {},
+        \\        1 => {},
+        \\        else => {},
+        \\    }
+        \\}
+        \\export fn entry() usize { return @sizeOf(@TypeOf(foo)); }
+    , &[_][]const u8{
+        "tmp.zig:5:9: error: unreachable else prong, all cases already handled",
+    });
+
+    cases.add("switch expression - unreachable else prong (u2)",
+        \\fn foo(x: u2) void {
+        \\    switch (x) {
+        \\        0 => {},
+        \\        1 => {},
+        \\        2 => {},
+        \\        3 => {},
+        \\        else => {},
+        \\    }
+        \\}
+        \\export fn entry() usize { return @sizeOf(@TypeOf(foo)); }
+    , &[_][]const u8{
+        "tmp.zig:7:9: error: unreachable else prong, all cases already handled",
+    });
+
+    cases.add("switch expression - unreachable else prong (range u8)",
+        \\fn foo(x: u8) void {
+        \\    switch (x) {
+        \\        0 => {},
+        \\        1 => {},
+        \\        2 => {},
+        \\        3 => {},
+        \\        4...255 => {},
+        \\        else => {},
+        \\    }
+        \\}
+        \\export fn entry() usize { return @sizeOf(@TypeOf(foo)); }
+    , &[_][]const u8{
+        "tmp.zig:8:9: error: unreachable else prong, all cases already handled",
+    });
+
+    cases.add("switch expression - unreachable else prong (range i8)",
+        \\fn foo(x: i8) void {
+        \\    switch (x) {
+        \\        -128...0 => {},
+        \\        1 => {},
+        \\        2 => {},
+        \\        3 => {},
+        \\        4...127 => {},
+        \\        else => {},
+        \\    }
+        \\}
+        \\export fn entry() usize { return @sizeOf(@TypeOf(foo)); }
+    , &[_][]const u8{
+        "tmp.zig:8:9: error: unreachable else prong, all cases already handled",
+    });
+
+    cases.add("switch expression - unreachable else prong (enum)",
+        \\const TestEnum = enum{ T1, T2 };
+        \\
+        \\fn err(x: u8) TestEnum {
+        \\    switch (x) {
+        \\        0 => return TestEnum.T1,
+        \\        else => return TestEnum.T2,
+        \\    }
+        \\}
+        \\
+        \\fn foo(x: u8) void {
+        \\    switch (err(x)) {
+        \\        TestEnum.T1 => {},
+        \\        TestEnum.T2 => {},
+        \\        else => {},
+        \\    }
+        \\}
+        \\
+        \\export fn entry() usize { return @sizeOf(@TypeOf(foo)); }
+    , &[_][]const u8{
+        "tmp.zig:14:9: error: unreachable else prong, all cases already handled",
+    });
+
     cases.addTest("@export with empty name string",
         \\pub export fn entry() void { }
         \\comptime {

--- a/test/stage1/behavior/bugs/1111.zig
+++ b/test/stage1/behavior/bugs/1111.zig
@@ -7,6 +7,5 @@ test "issue 1111 fixed" {
 
     switch (v) {
         Foo.Bar => return,
-        else => return,
     }
 }


### PR DESCRIPTION
Closes #5623.

All the compile error tests are passing, ~~but the check for error set unreachable else prongs are causing some problems.~~
_PR no longer contains checks for error sets_ 

The else prong might be required in one context and not in another. This is probably most apparent in generics where the error set could depend on some argument. 

Example in std/io/reader.zig:
```zig
pub fn Reader(
    comptime Context: type,
    comptime ReadError: type,
    /// Returns the number of bytes read. It may be less than buffer.len.
    /// If the number of bytes read is 0, it means end of stream.
    /// End of stream is not an error condition.
    comptime readFn: fn (context: Context, buffer: []u8) ReadError!usize,
) type {
    return struct {
        pub const Error = ReadError;

        context: Context,

        const Self = @This();

        /// Returns the number of bytes read. It may be less than buffer.len.
        /// If the number of bytes read is 0, it means end of stream.
        /// End of stream is not an error condition.
        pub fn read(self: Self, buffer: []u8) Error!usize {
            return readFn(self.context, buffer);
        }
        ...

        pub fn readUntilDelimiterOrEof(self: Self, buf: []u8, delimiter: u8) !?[]u8 {
            var index: usize = 0;
            while (true) {
                const byte = self.readByte() catch |err| switch (err) {
                    error.EndOfStream => {
                        if (index == 0) {
                            return null;
                        } else {
                            return buf[0..index];
                        }
                    },
                    else => |e| return e, // This is sometimes an error depending on if ReadError contains any more errors
                };

                if (byte == delimiter) return buf[0..index];
                if (index >= buf.len) return error.StreamTooLong;

                buf[index] = byte;
                index += 1;
            }
        }
        ...

        pub fn readByte(self: Self) !u8 {
            var result: [1]u8 = undefined;
            const amt_read = try self.read(result[0..]); // an error could be returned from here but not always
            if (amt_read < 1) return error.EndOfStream; // this error can always be returned
            return result[0];
        }
        ...
```
This might example might generate error: unreachable else prong depending on if ReadError contains any more errors.

We could maybe get a similar effect from compile time constants such as target?

This PR could be merged if we remove the error message for error sets.