### PR TITLE
Fixed crash when resolving peer types of *[N:s]const T and [*:s]const T

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -12603,6 +12603,7 @@ static ZigType *ir_resolve_peer_types(IrAnalyze *ira, AstNode *source_node, ZigT
             prev_type->data.pointer.child_type->id == ZigTypeIdArray &&
             ((cur_type->id == ZigTypeIdPointer && cur_type->data.pointer.ptr_len == PtrLenUnknown)))
         {
+            convert_to_const_slice = false;
             prev_inst = cur_inst;
 
             if (prev_type->data.pointer.is_const && !cur_type->data.pointer.is_const) {

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -50,6 +50,7 @@ comptime {
     _ = @import("behavior/bugs/4769_b.zig");
     _ = @import("behavior/bugs/4769_c.zig");
     _ = @import("behavior/bugs/4954.zig");
+    _ = @import("behavior/bugs/5413.zig");
     _ = @import("behavior/bugs/5474.zig");
     _ = @import("behavior/bugs/5487.zig");
     _ = @import("behavior/bugs/394.zig");

--- a/test/stage1/behavior/bugs/5413.zig
+++ b/test/stage1/behavior/bugs/5413.zig
@@ -1,0 +1,6 @@
+const expect = @import("std").testing.expect;
+
+test "Peer type resolution with string literals and unknown length u8 pointers" {
+    expect(@TypeOf("", "a", @as([*:0]const u8, "")) == [*:0]const u8);
+    expect(@TypeOf(@as([*:0]const u8, "baz"), "foo", "bar") == [*:0]const u8);
+}


### PR DESCRIPTION
Closes #5413