### PR TITLE
Add std.os.getFdPath and std.fs.Dir.realpath

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -109,15 +109,55 @@ test "Dir.Iterator" {
     testing.expect(contains(&entries, Dir.Entry{ .name = "some_dir", .kind = Dir.Entry.Kind.Directory }));
 }
 
-fn entry_eql(lhs: Dir.Entry, rhs: Dir.Entry) bool {
+fn entryEql(lhs: Dir.Entry, rhs: Dir.Entry) bool {
     return mem.eql(u8, lhs.name, rhs.name) and lhs.kind == rhs.kind;
 }
 
 fn contains(entries: *const std.ArrayList(Dir.Entry), el: Dir.Entry) bool {
     for (entries.items) |entry| {
-        if (entry_eql(entry, el)) return true;
+        if (entryEql(entry, el)) return true;
     }
     return false;
+}
+
+test "Dir.realpath smoke test" {
+    switch (builtin.os.tag) {
+        .linux, .windows, .macosx, .ios, .watchos, .tvos => {},
+        else => return error.SkipZigTest,
+    }
+
+    var tmp_dir = tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var file = try tmp_dir.dir.createFile("test_file", .{ .lock = File.Lock.Shared });
+    // We need to close the file immediately as otherwise on Windows we'll end up
+    // with a sharing violation.
+    file.close();
+
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const base_path = blk: {
+        const relative_path = try fs.path.join(&arena.allocator, &[_][]const u8{ "zig-cache", "tmp", tmp_dir.sub_path[0..] });
+        break :blk try fs.realpathAlloc(&arena.allocator, relative_path);
+    };
+
+    // First, test non-alloc version
+    {
+        var buf1: [fs.MAX_PATH_BYTES]u8 = undefined;
+        const file_path = try tmp_dir.dir.realpath("test_file", buf1[0..]);
+        const expected_path = try fs.path.join(&arena.allocator, &[_][]const u8{ base_path, "test_file" });
+
+        testing.expect(mem.eql(u8, file_path, expected_path));
+    }
+
+    // Next, test alloc version
+    {
+        const file_path = try tmp_dir.dir.realpathAlloc(&arena.allocator, "test_file");
+        const expected_path = try fs.path.join(&arena.allocator, &[_][]const u8{ base_path, "test_file" });
+
+        testing.expect(mem.eql(u8, file_path, expected_path));
+    }
 }
 
 test "readAllAlloc" {
@@ -167,12 +207,7 @@ test "directory operations on files" {
     testing.expectError(error.NotDir, tmp_dir.dir.deleteDir(test_file_name));
 
     if (builtin.os.tag != .wasi) {
-        // TODO: use Dir's realpath function once that exists
-        const absolute_path = blk: {
-            const relative_path = try fs.path.join(testing.allocator, &[_][]const u8{ "zig-cache", "tmp", tmp_dir.sub_path[0..], test_file_name });
-            defer testing.allocator.free(relative_path);
-            break :blk try fs.realpathAlloc(testing.allocator, relative_path);
-        };
+        const absolute_path = try tmp_dir.dir.realpathAlloc(testing.allocator, test_file_name);
         defer testing.allocator.free(absolute_path);
 
         testing.expectError(error.PathAlreadyExists, fs.makeDirAbsolute(absolute_path));
@@ -206,12 +241,7 @@ test "file operations on directories" {
     testing.expectError(error.IsDir, tmp_dir.dir.openFile(test_dir_name, .{ .write = true }));
 
     if (builtin.os.tag != .wasi) {
-        // TODO: use Dir's realpath function once that exists
-        const absolute_path = blk: {
-            const relative_path = try fs.path.join(testing.allocator, &[_][]const u8{ "zig-cache", "tmp", tmp_dir.sub_path[0..], test_dir_name });
-            defer testing.allocator.free(relative_path);
-            break :blk try fs.realpathAlloc(testing.allocator, relative_path);
-        };
+        const absolute_path = try tmp_dir.dir.realpathAlloc(testing.allocator, test_dir_name);
         defer testing.allocator.free(absolute_path);
 
         testing.expectError(error.IsDir, fs.createFileAbsolute(absolute_path, .{}));


### PR DESCRIPTION
~~`std.os.realpathat` is similar to `std.os.realpath`, however, it accepts~~
~~a pair `fd_t, []const u8` of args and thus works out the realpath~~
~~of a relative path wrt to some opened file descriptor.~~

~~If the input pathname argument turns out to be an absolute path, this~~
~~function reverts to calling `realpath` on that pathname completely~~
~~ignoring the input file descriptor. This behaviour is standard in~~
~~POSIX and IMHO a good rule of thumb to follow.~~

~~If the input file descriptor was obtained using `std.fs.cwd()` call,~~
~~this function reverts to `std.os.getcwd()` to obtain the file~~
~~descriptor's path.~~

~~`std.fs.Dir.realpath` integrates `std.os.realpathat` with `std.fs.Dir`~~
~~but with dynamic memory allocator.~~

---

~~Part 1 of #5636.~~

---
EDIT:

See the comments for an update of the contents of this PR.