### PR TITLE
Pdb.openFile use `[]const u8` instead of `[]u8`

### DIFF
--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -469,7 +469,7 @@ pub const Pdb = struct {
 
     msf: Msf,
 
-    pub fn openFile(self: *Pdb, coff_ptr: *coff.Coff, file_name: []u8) !void {
+    pub fn openFile(self: *Pdb, coff_ptr: *coff.Coff, file_name: []const u8) !void {
         self.in_file = try fs.cwd().openFile(file_name, .{ .intended_io_mode = .blocking });
         self.allocator = coff_ptr.allocator;
         self.coff = coff_ptr;


### PR DESCRIPTION
I didn't see any reason to use []u8...