### PR TITLE
[libstd]: add Dir.Iterator tests

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -453,6 +453,8 @@ pub const Dir = struct {
 
             pub const Error = IteratorError;
 
+            /// Memory such as file names referenced in this returned entry becomes invalid
+            /// with subsequent calls to `next`, as well as when this `Dir` is deinitialized.
             pub fn next(self: *Self) Error!?Entry {
                 start_over: while (true) {
                     const w = os.windows;

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -30,7 +30,7 @@ test "Dir.Iterator" {
     while (try iter.next()) |entry| {
         // We cannot just store `entry` as on Windows, we're re-using the name buffer
         // which means we'll actually share the `name` pointer between entries!
-        const name = try mem.dupe(&arena.allocator, u8, entry.name);
+        const name = try arena.allocator.dupe(u8, entry.name);
         try entries.append(Dir.Entry{ .name = name, .kind = entry.kind });
     }
 


### PR DESCRIPTION
This commit adds some `std.fs.Dir.Iterator` tests.

Partially addresses #5653.