### PR TITLE
stage1 HashMap: store hash & do robin hood hashing

### DIFF
--- a/src/list.hpp
+++ b/src/list.hpp
@@ -19,6 +19,9 @@ struct ZigList {
         ensure_capacity(length + 1);
         items[length++] = item;
     }
+    void append_assuming_capacity(const T& item) {
+        items[length++] = item;
+    }
     // remember that the pointer to this item is invalid after you
     // modify the length of the list
     const T & at(size_t index) const {


### PR DESCRIPTION
This adds these two fields to a HashMap Entry:

uint32_t hash
uint32_t distance_from_start_index

Compared to master branch, standard library tests compiled 8.4% faster
and took negligible (0.001%) more memory to complete. The amount of
memory used is still down from before 8b82c4010480 which moved indexes
to be stored separately from entries.

So, it turns out, keeping robin hood hashing plus separating indexes
did result in a performance improvement. What happened previously is
that the gains from separating indexes balanced out the losses from
removing robin hood hashing, resulting in a wash.

This also serves as an inspiration for adding a benchmark to
std.AutoHashMap and improving the implementation.