### PR TITLE
Restructured integer parsing to allow for most negative integer

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1035,7 +1035,7 @@ pub fn parseWithSign(comptime T: type, buf: []const u8, radix: u8, negative: boo
 
         if (x != 0) x = try math.mul(T, x, try math.cast(T, radix));
         if (negative) {
-            x = try math.add(T, x, math.negate(try math.cast(T, digit)));
+            x = try math.add(T, x, try math.negate(try math.cast(T, digit)));
         } else {
             x = try math.add(T, x, try math.cast(T, digit));
         }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1038,6 +1038,7 @@ pub fn parseWithSign(comptime T: type, buf: []const u8, radix: u8, negative: boo
             x = try math.add(T, x, math.negate(try math.cast(T, digit)));
         } else {
             x = try math.add(T, x, try math.cast(T, digit));
+        }
     }
 
     return x;


### PR DESCRIPTION
Previously we simply negated the result of parsing the absolute value, which would overflow for the most negative integer. This version negates every digit individually, which fixes that issue at the cost of some performance. Perhaps there's a more efficient implementation, I'll be happy to implement it if anyone knows. Public interface is preserved, although `parseUnsignedError` has been renamed to `parseIntError`.