### PR TITLE
[libstd]: reworked CacheHash means its WASI compatible now

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1003,7 +1003,7 @@ pub const Dir = struct {
         // paths. musl supports passing NULL but restricts the output to PATH_MAX
         // anyway.
         var buf: [MAX_PATH_BYTES]u8 = undefined;
-        return mem.dupe(allocator, u8, try os.realpathat(self.fd, pathname, &buf));
+        return allocator.dupe(u8, try os.realpathat(self.fd, pathname, &buf));
     }
 
     /// Changes the current working directory to the open directory handle.

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -119,12 +119,7 @@ test "directory operations on files" {
     testing.expectError(error.NotDir, tmp_dir.dir.deleteDir(test_file_name));
 
     if (builtin.os.tag != .wasi) {
-        // TODO: use Dir's realpath function once that exists
-        const absolute_path = blk: {
-            const relative_path = try fs.path.join(testing.allocator, &[_][]const u8{ "zig-cache", "tmp", tmp_dir.sub_path[0..], test_file_name });
-            defer testing.allocator.free(relative_path);
-            break :blk try fs.realpathAlloc(testing.allocator, relative_path);
-        };
+        const absolute_path = try tmp_dir.dir.realpath(testing.allocator, test_file_name);
         defer testing.allocator.free(absolute_path);
 
         testing.expectError(error.PathAlreadyExists, fs.makeDirAbsolute(absolute_path));

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -50,6 +50,26 @@ fn contains(entries: *const std.ArrayList(Dir.Entry), el: Dir.Entry) bool {
     return false;
 }
 
+test "Dir.realpath" {
+    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+
+    var tmp_dir = tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var file = try tmp_dir.dir.createFile("test_file", .{});
+    defer file.close();
+
+    const abs_file_path = try tmp_dir.dir.realpath(testing.allocator, "test_file");
+    defer testing.allocator.free(abs_file_path);
+
+    const dir_path = try tmp_dir.dir.realpath(testing.allocator, "");
+    defer testing.allocator.free(dir_path);
+    const expected_path = try fs.path.join(testing.allocator, &[_][]const u8{ dir_path, "test_file" });
+    defer testing.allocator.free(expected_path);
+
+    testing.expect(mem.eql(u8, abs_file_path, expected_path));
+}
+
 test "readAllAlloc" {
     var tmp_dir = tmpDir(.{});
     defer tmp_dir.cleanup();

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -56,11 +56,10 @@ test "Dir.realpath" {
     var tmp_dir = tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    // We need to open with File.Lock.Shared as otherwise `std.os.realpath` will
-    // error out with sharing violation on Windows.
-    // TODO is this a bug on Windows?
     var file = try tmp_dir.dir.createFile("test_file", .{ .lock = File.Lock.Shared });
-    defer file.close();
+    // We need to close the file immediately as otherwise on Windows we'll end up
+    // with a sharing violation.
+    file.close();
 
     const abs_file_path = try tmp_dir.dir.realpath(testing.allocator, "test_file");
     defer testing.allocator.free(abs_file_path);

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -56,7 +56,10 @@ test "Dir.realpath" {
     var tmp_dir = tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    var file = try tmp_dir.dir.createFile("test_file", .{});
+    // We need to open with File.Lock.Shared as otherwise `std.os.realpath` will
+    // error out with sharing violation on Windows.
+    // TODO is this a bug on Windows?
+    var file = try tmp_dir.dir.createFile("test_file", .{ .lock = File.Lock.Shared });
     defer file.close();
 
     const abs_file_path = try tmp_dir.dir.realpath(testing.allocator, "test_file");

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4193,6 +4193,7 @@ pub fn realpathatWasi(fd: fd_t, pathname: []const u8, out_buffer: *[MAX_PATH_BYT
                     break;
             }
         } else {
+            if (result_index >= MAX_PATH_BYTES) return error.NameTooLong;
             if (result_index > 0) {
                 out_buffer[result_index] = '/';
                 result_index += 1;

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4141,7 +4141,7 @@ pub fn realpathatW(fd: fd_t, pathname: [*:0]const u16, out_buffer: *[MAX_PATH_BY
 
     // Convert UTF16LE to UTF8
     var pathname_u8: [MAX_PATH_BYTES]u8 = undefined;
-    const end_index = std.unicode.utf16leToUtf8(pathname_u8[0..], wide_slice[start_index..]) catch unreachable;
+    const end_index = std.unicode.utf16leToUtf8(pathname_u8[0..], mem.spanZ(pathname)) catch unreachable;
     const total_len = fd_path.len + end_index + 1; // +1 to account for path separator
     if (total_len >= MAX_PATH_BYTES) {
         return error.NameTooLong;

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -71,20 +71,22 @@ test "realpathatWasi" {
     defer tmp.cleanup();
 
     // create some dirs
-    try tmp.dir.makeDir("a");
-    try tmp.dir.makeDir("b");
+    try tmp.dir.makePath("a/b");
 
-    // create file in "a/"
-    try tmp.dir.writeFile("a/file.txt", "nonsense");
+    // create file in "a/b"
+    try tmp.dir.writeFile("a/b/file.txt", "nonsense");
 
-    // create a symlink "b/c" -> "a"
-    try os.symlinkat("a", tmp.dir.fd, "b/c");
+    // create a symlink "a/c" -> "a/b"
+    var subdir = try tmp.dir.openDir("a", .{});
+    defer subdir.close();
 
-    // get realpath of "b/c/file.txt"
+    try os.symlinkat("b", subdir.fd, "c");
+
+    // get realpath of "a/c/file.txt"
     var buf: [fs.MAX_PATH_BYTES]u8 = undefined;
-    const realpath = try os.realpathatWasi(tmp.dir.fd, "b/c/file.txt", &buf);
+    const realpath = try os.realpathatWasi(tmp.dir.fd, "a/c/file.txt", &buf);
 
-    testing.expect(mem.eql(u8, "a/file.txt", realpath));
+    testing.expect(mem.eql(u8, "a/b/file.txt", realpath));
 }
 
 test "readlinkat" {


### PR DESCRIPTION
**This PR builds upon #5701.**

This PR reworks `CacheHash` to make it WASI compatible. The summary of changes:

* On non-capability-oriented hosts (i.e., excluding WASI), use `Dir.realpathAlloc` to resolve cached path. Previously, we relied on `std.fs.path.resolve` to do the path resolution which could yield erroneous results since `std.fs.path.resolve` would not actually issue any syscalls, and hence, would not correctly resolve any symlinks. Using `Dir.realpathAlloc` which now supports WASI (more on this below), means `CacheHash` now supports WASI.

* Add `Dir.realpathWasi`, and `os.realpathatWasi`. The latter resolves the path however upto only the `Dir` it is relative
to ensuring the sandboxing rules are observed. In fact, it proceeds in two steps:
  1. Try opening the path as-is, and check if that works OK. Then, this will imply the path was valid under WASI's capability-oriented security model, and no path traversal attack was attempted.
  2. Since we've verified we're OK wrt sandboxing rules, we can analyze the path component-by-component working out the canonicalized path in the process.

This PR closes #5437.

EDIT: This PR also fixes `os.realpathatW` to correctly handle relative `pathname` with relative components such as `.` or `..`.