### PR TITLE
std.mem.dupe is deprecated, move all references in std

### DIFF
--- a/lib/std/buf_map.zig
+++ b/lib/std/buf_map.zig
@@ -79,7 +79,7 @@ pub const BufMap = struct {
     }
 
     fn copy(self: BufMap, value: []const u8) ![]u8 {
-        return mem.dupe(self.hash_map.allocator, u8, value);
+        return self.hash_map.allocator.dupe(u8, value);
     }
 };
 

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -286,7 +286,7 @@ pub const Builder = struct {
     }
 
     pub fn dupe(self: *Builder, bytes: []const u8) []u8 {
-        return mem.dupe(self.allocator, u8, bytes) catch unreachable;
+        return self.allocator.dupe(u8, bytes) catch unreachable;
     }
 
     pub fn dupePath(self: *Builder, bytes: []const u8) []u8 {

--- a/lib/std/cache_hash.zig
+++ b/lib/std/cache_hash.zig
@@ -207,7 +207,7 @@ pub const CacheHash = struct {
             }
 
             if (cache_hash_file.path == null) {
-                cache_hash_file.path = try mem.dupe(self.allocator, u8, file_path);
+                cache_hash_file.path = try self.allocator.dupe(u8, file_path);
             }
 
             const this_file = fs.cwd().openFile(cache_hash_file.path.?, .{ .read = true }) catch {

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1825,7 +1825,7 @@ pub fn selfExePathAlloc(allocator: *Allocator) ![]u8 {
     // TODO(#4812): Investigate other systems and whether it is possible to get
     // this path by trying larger and larger buffers until one succeeds.
     var buf: [MAX_PATH_BYTES]u8 = undefined;
-    return mem.dupe(allocator, u8, try selfExePath(&buf));
+    return allocator.dupe(u8, try selfExePath(&buf));
 }
 
 /// Get the path to the current executable.
@@ -1888,7 +1888,7 @@ pub fn selfExeDirPathAlloc(allocator: *Allocator) ![]u8 {
     // TODO(#4812): Investigate other systems and whether it is possible to get
     // this path by trying larger and larger buffers until one succeeds.
     var buf: [MAX_PATH_BYTES]u8 = undefined;
-    return mem.dupe(allocator, u8, try selfExeDirPath(&buf));
+    return allocator.dupe(u8, try selfExeDirPath(&buf));
 }
 
 /// Get the directory path that contains the current executable.
@@ -1910,7 +1910,7 @@ pub fn realpathAlloc(allocator: *Allocator, pathname: []const u8) ![]u8 {
     // paths. musl supports passing NULL but restricts the output to PATH_MAX
     // anyway.
     var buf: [MAX_PATH_BYTES]u8 = undefined;
-    return mem.dupe(allocator, u8, try os.realpath(pathname, &buf));
+    return allocator.dupe(u8, try os.realpath(pathname, &buf));
 }
 
 test "" {

--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -1034,7 +1034,7 @@ pub fn relativeWindows(allocator: *Allocator, from: []const u8, to: []const u8) 
     var from_it = mem.tokenize(resolved_from, "/\\");
     var to_it = mem.tokenize(resolved_to, "/\\");
     while (true) {
-        const from_component = from_it.next() orelse return mem.dupe(allocator, u8, to_it.rest());
+        const from_component = from_it.next() orelse return allocator.dupe(u8, to_it.rest());
         const to_rest = to_it.rest();
         if (to_it.next()) |to_component| {
             // TODO ASCII is wrong, we actually need full unicode support to compare paths.
@@ -1085,7 +1085,7 @@ pub fn relativePosix(allocator: *Allocator, from: []const u8, to: []const u8) ![
     var from_it = mem.tokenize(resolved_from, "/");
     var to_it = mem.tokenize(resolved_to, "/");
     while (true) {
-        const from_component = from_it.next() orelse return mem.dupe(allocator, u8, to_it.rest());
+        const from_component = from_it.next() orelse return allocator.dupe(u8, to_it.rest());
         const to_rest = to_it.rest();
         if (to_it.next()) |to_component| {
             if (mem.eql(u8, from_component, to_component))

--- a/lib/std/fs/watch.zig
+++ b/lib/std/fs/watch.zig
@@ -360,7 +360,7 @@ pub fn Watch(comptime V: type) type {
 
         fn addFileWindows(self: *Self, file_path: []const u8, value: V) !?V {
             // TODO we might need to convert dirname and basename to canonical file paths ("short"?)
-            const dirname = try std.mem.dupe(self.allocator, u8, std.fs.path.dirname(file_path) orelse ".");
+            const dirname = try self.allocator.dupe(u8, std.fs.path.dirname(file_path) orelse ".");
             var dirname_consumed = false;
             defer if (!dirname_consumed) self.allocator.free(dirname);
 

--- a/lib/std/http/headers.zig
+++ b/lib/std/http/headers.zig
@@ -38,7 +38,7 @@ const HeaderEntry = struct {
         return Self{
             .allocator = allocator,
             .name = name, // takes reference
-            .value = try mem.dupe(allocator, u8, value),
+            .value = try allocator.dupe(u8, value),
             .never_index = never_index orelse never_index_default(name),
         };
     }
@@ -161,7 +161,7 @@ pub const Headers = struct {
             var dex = &kv.value;
             try dex.append(n - 1);
         } else {
-            const name_dup = try mem.dupe(self.allocator, u8, name);
+            const name_dup = try self.allocator.dupe(u8, name);
             errdefer self.allocator.free(name_dup);
             entry = try HeaderEntry.init(self.allocator, name_dup, value, never_index);
             errdefer entry.deinit();

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1567,7 +1567,7 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
                             if (ptrInfo.child != u8) return error.UnexpectedToken;
                             const source_slice = stringToken.slice(tokens.slice, tokens.i - 1);
                             switch (stringToken.escapes) {
-                                .None => return mem.dupe(allocator, u8, source_slice),
+                                .None => return allocator.dupe(u8, source_slice),
                                 .Some => |some_escapes| {
                                     const output = try allocator.alloc(u8, stringToken.decodedLength());
                                     errdefer allocator.free(output);
@@ -2043,7 +2043,7 @@ pub const Parser = struct {
     fn parseString(p: *Parser, allocator: *Allocator, s: std.meta.TagPayloadType(Token, Token.String), input: []const u8, i: usize) !Value {
         const slice = s.slice(input, i);
         switch (s.escapes) {
-            .None => return Value{ .String = if (p.copy_strings) try mem.dupe(allocator, u8, slice) else slice },
+            .None => return Value{ .String = if (p.copy_strings) try allocator.dupe(u8, slice) else slice },
             .Some => |some_escapes| {
                 const output = try allocator.alloc(u8, s.decodedLength());
                 errdefer allocator.free(output);

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -1105,7 +1105,7 @@ pub const Const = struct {
         assert(base <= 16);
 
         if (self.eqZero()) {
-            return mem.dupe(allocator, u8, "0");
+            return allocator.dupe(u8, "0");
         }
         const string = try allocator.alloc(u8, self.sizeInBaseUpperBound(base));
         errdefer allocator.free(string);

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -682,7 +682,7 @@ pub fn getAddressList(allocator: *mem.Allocator, name: []const u8, port: u16) !*
 
             if (info.canonname) |n| {
                 if (result.canon_name == null) {
-                    result.canon_name = try mem.dupe(arena, u8, mem.spanZ(n));
+                    result.canon_name = try arena.dupe(u8, mem.spanZ(n));
                 }
             }
             i += 1;

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -333,7 +333,7 @@ test "std.PriorityQueue: addSlice" {
 
 test "std.PriorityQueue: fromOwnedSlice" {
     const items = [_]u32{ 15, 7, 21, 14, 13, 22, 12, 6, 7, 25, 5, 24, 11, 16, 15, 24, 2, 1 };
-    const heap_items = try std.mem.dupe(testing.allocator, u32, items[0..]);
+    const heap_items = try testing.allocator.dupe(u32, items[0..]);
     var queue = PQ.fromOwnedSlice(testing.allocator, lessThan, heap_items[0..]);
     defer queue.deinit();
 

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -30,7 +30,7 @@ pub fn getCwdAlloc(allocator: *Allocator) ![]u8 {
     var current_buf: []u8 = &stack_buf;
     while (true) {
         if (os.getcwd(current_buf)) |slice| {
-            return mem.dupe(allocator, u8, slice);
+            return allocator.dupe(u8, slice);
         } else |err| switch (err) {
             error.NameTooLong => {
                 // The path is too long to fit in stack_buf. Allocate geometrically
@@ -169,7 +169,7 @@ pub fn getEnvVarOwned(allocator: *mem.Allocator, key: []const u8) GetEnvVarOwned
         };
     } else {
         const result = os.getenv(key) orelse return error.EnvironmentVariableNotFound;
-        return mem.dupe(allocator, u8, result);
+        return allocator.dupe(u8, result);
     }
 }
 
@@ -436,7 +436,7 @@ pub const ArgIterator = struct {
         if (builtin.os.tag == .windows) {
             return self.inner.next(allocator);
         } else {
-            return mem.dupe(allocator, u8, self.inner.next() orelse return null);
+            return allocator.dupe(u8, self.inner.next() orelse return null);
         }
     }
 
@@ -718,7 +718,7 @@ pub fn getSelfExeSharedLibPaths(allocator: *Allocator) error{OutOfMemory}![][:0]
                 fn callback(info: *os.dl_phdr_info, size: usize, list: *List) !void {
                     const name = info.dlpi_name orelse return;
                     if (name[0] == '/') {
-                        const item = try mem.dupeZ(list.allocator, u8, mem.spanZ(name));
+                        const item = try list.allocator.dupeZ(u8, mem.spanZ(name));
                         errdefer list.allocator.free(item);
                         try list.append(item);
                     }
@@ -739,7 +739,7 @@ pub fn getSelfExeSharedLibPaths(allocator: *Allocator) error{OutOfMemory}![][:0]
             var i: u32 = 0;
             while (i < img_count) : (i += 1) {
                 const name = std.c._dyld_get_image_name(i);
-                const item = try mem.dupeZ(allocator, u8, mem.spanZ(name));
+                const item = try allocator.dupeZ(u8, mem.spanZ(name));
                 errdefer allocator.free(item);
                 try paths.append(item);
             }

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -497,7 +497,7 @@ pub const CrossTarget = struct {
 
     pub fn zigTriple(self: CrossTarget, allocator: *mem.Allocator) error{OutOfMemory}![]u8 {
         if (self.isNative()) {
-            return mem.dupe(allocator, u8, "native");
+            return allocator.dupe(u8, "native");
         }
 
         const arch_name = if (self.cpu_arch) |arch| @tagName(arch) else "native";

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -161,7 +161,7 @@ pub const NativePaths = struct {
     }
 
     fn appendArray(self: *NativePaths, array: *ArrayList([:0]u8), s: []const u8) !void {
-        const item = try std.mem.dupeZ(array.allocator, u8, s);
+        const item = try array.allocator.dupeZ(u8, s);
         errdefer array.allocator.free(item);
         try array.append(item);
     }


### PR DESCRIPTION
Replaced all occurences of `std.mem.dupe` in stdlib with `Allocator.dupe` or `std.mem.dupeZ` with `Allocator.dupeZ`