### PR TITLE
langref: Add test case for "if error union with optional"

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3861,6 +3861,32 @@ test "if error union" {
         unreachable;
     }
 }
+
+test "if error union with optional" {
+    // If expressions test for errors before unwrapping optionals.
+    // The |optional_value| capture's type is ?u32.
+
+    const a: anyerror!?u32 = 0;
+    if (a) |optional_value| {
+        assert(optional_value.? == 0);
+    } else |err| {
+        unreachable;
+    }
+
+    const b: anyerror!?u32 = null;
+    if (b) |optional_value| {
+        assert(optional_value == null);
+    } else |err| {
+        unreachable;
+    }
+
+    const c: anyerror!?u32 = error.BadValue;
+    if (c) |optional_value| {
+        unreachable;
+    } else |err| {
+        assert(err == error.BadValue);
+    }
+}
       {#code_end#}
       {#see_also|Optionals|Errors#}
       {#header_close#}


### PR DESCRIPTION
This is an edge case that isn't too uncommon but is rather confusing to try to deduce without documentation, since it feels like `else` is being overloaded in this scenario and there's no obvious 'correct' behavior here. This just adds a test demonstrating how Zig currently behaves in this scenario.

See https://github.com/ziglang/zig/issues/5819 for why the `// Access the value by reference using a pointer capture` case that the other `if` tests have isn't included in this for now.