### PR TITLE
std: remove stray allocator parameter from HashMap function

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -96,7 +96,7 @@ pub fn HashMap(
             return self.unmanaged.clearRetainingCapacity();
         }
 
-        pub fn clearAndFree(self: *Self, allocator: *Allocator) void {
+        pub fn clearAndFree(self: *Self) void {
             return self.unmanaged.clearAndFree(self.allocator);
         }
 


### PR DESCRIPTION
Looks like a copypaste error from HashMapUnmanaged.