### PR TITLE
Fix alignment parsing in stage1.

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2679,7 +2679,7 @@ static AstNode *ast_parse_prefix_type_op(ParseContext *pc) {
 
             if (eat_token_if(pc, TokenIdKeywordAlign) != nullptr) {
                 expect_token(pc, TokenIdLParen);
-                AstNode *align_expr = ast_parse_expr(pc);
+                AstNode *align_expr = ast_expect(pc, ast_parse_expr);
                 child->data.pointer_type.align_expr = align_expr;
                 if (eat_token_if(pc, TokenIdColon) != nullptr) {
                     Token *bit_offset_start = expect_token(pc, TokenIdIntLiteral);

--- a/test/stage1/behavior/eval.zig
+++ b/test/stage1/behavior/eval.zig
@@ -758,7 +758,7 @@ test "comptime bitwise operators" {
 test "*align(1) u16 is the same as *align(1:0:2) u16" {
     comptime {
         expect(*align(1:0:2) u16 == *align(1) u16);
-        expect(*align(:0:2) u16 == *u16);
+        expect(*align(2:0:2) u16 == *u16);
     }
 }
 


### PR DESCRIPTION
According to the grammar the byte alignment should not have been optional and omitting it was already an error in the self hosted parser.

Alternatively the grammar could be changed to allow omitting byte alignment when bit alignment is specified.