### PR TITLE
Use Writer for Language Reference Hello World Example

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -231,7 +231,7 @@
 const std = @import("std");
 
 pub fn main() !void {
-    const stdout = std.io.getStdOut().outStream();
+    const stdout = std.io.getStdOut().writer();
     try stdout.print("Hello, {}!\n", .{"world"});
 }
       {#code_end#}


### PR DESCRIPTION
`OutStream` has been deprecated, so the "Hello, World!" example has been
updated to use `Writer`.
