### PR TITLE
Stage2 improvements

### DIFF
--- a/src-self-hosted/Module.zig
+++ b/src-self-hosted/Module.zig
@@ -1308,8 +1308,16 @@ fn astGenExpr(self: *Module, scope: *Scope, ast_node: *ast.Node) InnerError!*zir
         .ControlFlowExpression => return self.astGenControlFlowExpression(scope, @fieldParentPtr(ast.Node.ControlFlowExpression, "base", ast_node)),
         .If => return self.astGenIf(scope, @fieldParentPtr(ast.Node.If, "base", ast_node)),
         .InfixOp => return self.astGenInfixOp(scope, @fieldParentPtr(ast.Node.InfixOp, "base", ast_node)),
+        .BoolNot => return self.astGenBoolNot(scope, @fieldParentPtr(ast.Node.BoolNot, "base", ast_node)),
         else => return self.failNode(scope, ast_node, "TODO implement astGenExpr for {}", .{@tagName(ast_node.id)}),
     }
+}
+
+fn astGenBoolNot(self: *Module, scope: *Scope, node: *ast.Node.BoolNot) InnerError!*zir.Inst {
+    const operand = try self.astGenExpr(scope, node.rhs);
+    const tree = scope.tree();
+    const src = tree.token_locs[node.op_token].start;
+    return self.addZIRInst(scope, src, zir.Inst.BoolNot, .{ .operand = operand }, .{});
 }
 
 fn astGenInfixOp(self: *Module, scope: *Scope, infix_node: *ast.Node.InfixOp) InnerError!*zir.Inst {

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -415,7 +415,46 @@ const Function = struct {
         // No side effects, so if it's unreferenced, do nothing.
         if (inst.base.isUnused())
             return MCValue.dead;
+        const operand = try self.resolveInst(inst.args.operand);
+        switch (operand) {
+            .dead => unreachable,
+            .unreach => unreachable,
+            .compare_flags_unsigned => |op| return MCValue{
+                .compare_flags_unsigned = switch (op) {
+                    .gte => .lt,
+                    .gt => .lte,
+                    .neq => .eq,
+                    .lt => .gte,
+                    .lte => .gt,
+                    .eq => .neq,
+                },
+            },
+            .compare_flags_signed => |op| return MCValue{
+                .compare_flags_signed = switch (op) {
+                    .gte => .lt,
+                    .gt => .lte,
+                    .neq => .eq,
+                    .lt => .gte,
+                    .lte => .gt,
+                    .eq => .neq,
+                },
+            },
+            else => {},
+        }
+
         switch (arch) {
+            .x86_64 => {
+                var imm = ir.Inst.Constant{
+                    .base = .{
+                        .tag = .constant,
+                        .deaths = 0,
+                        .ty = inst.args.operand.ty,
+                        .src = inst.args.operand.src,
+                    },
+                    .val = Value.initTag(.bool_true),
+                };
+                return try self.genX8664BinMath(&inst.base, inst.args.operand, &imm.base, 6, 0x30);
+            },
             else => return self.fail(inst.base.src, "TODO implement NOT for {}", .{self.target.cpu.arch}),
         }
     }
@@ -444,7 +483,7 @@ const Function = struct {
         }
     }
 
-    /// ADD, SUB
+    /// ADD, SUB, XOR, OR, AND
     fn genX8664BinMath(self: *Function, inst: *ir.Inst, op_lhs: *ir.Inst, op_rhs: *ir.Inst, opx: u8, mr: u8) !MCValue {
         try self.code.ensureCapacity(self.code.items.len + 8);
 
@@ -705,7 +744,7 @@ const Function = struct {
 
     fn genCondBr(self: *Function, inst: *ir.Inst.CondBr, comptime arch: std.Target.Cpu.Arch) !MCValue {
         switch (arch) {
-            .i386, .x86_64 => {
+            .x86_64 => {
                 try self.code.ensureCapacity(self.code.items.len + 6);
 
                 const cond = try self.resolveInst(inst.args.condition);
@@ -734,7 +773,20 @@ const Function = struct {
                         };
                         return self.genX86CondBr(inst, opcode, arch);
                     },
-                    else => return self.fail(inst.base.src, "TODO implement condbr {} when condition not already in the compare flags", .{self.target.cpu.arch}),
+                    .register => |reg_usize| {
+                        const reg = @intToEnum(Reg(arch), @intCast(u8, reg_usize));
+                        // test reg, 1
+                        // TODO detect al, ax, eax
+                        try self.code.ensureCapacity(self.code.items.len + 4);
+                        self.rex(.{ .b = reg.isExtended(), .w = reg.size() == 64 });
+                        self.code.appendSliceAssumeCapacity(&[_]u8{
+                            0xf6,
+                            @as(u8, 0xC0) | (0 << 3) | @truncate(u3, reg.id()),
+                            0x01,
+                        });
+                        return self.genX86CondBr(inst, 0x84, arch);
+                    },
+                    else => return self.fail(inst.base.src, "TODO implement condbr {} when condition is {}", .{ self.target.cpu.arch, @tagName(cond) }),
                 }
             },
             else => return self.fail(inst.base.src, "TODO implement condbr for {}", .{self.target.cpu.arch}),
@@ -892,7 +944,18 @@ const Function = struct {
                 .none => unreachable,
                 .unreach => unreachable,
                 .compare_flags_unsigned => |op| {
-                    return self.fail(src, "TODO set register with compare flags value (unsigned)", .{});
+                    try self.code.ensureCapacity(self.code.items.len + 3);
+                    self.rex(.{ .b = reg.isExtended(), .w = reg.size() == 64 });
+                    const opcode: u8 = switch (op) {
+                        .gte => 0x93,
+                        .gt => 0x97,
+                        .neq => 0x95,
+                        .lt => 0x92,
+                        .lte => 0x96,
+                        .eq => 0x94,
+                    };
+                    const id = @as(u8, reg.id() & 0b111);
+                    self.code.appendSliceAssumeCapacity(&[_]u8{ 0x0f, opcode, 0xC0 | id });
                 },
                 .compare_flags_signed => |op| {
                     return self.fail(src, "TODO set register with compare flags value (signed)", .{});
@@ -1146,6 +1209,9 @@ const Function = struct {
                     return self.fail(src, "TODO const int bigger than ptr and signed int", .{});
                 }
                 return MCValue{ .immediate = typed_value.val.toUnsignedInt() };
+            },
+            .Bool => {
+                return MCValue{ .immediate = @boolToInt(typed_value.val.toBool()) };
             },
             .ComptimeInt => unreachable, // semantic analysis prevents this
             .ComptimeFloat => unreachable, // semantic analysis prevents this

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -412,6 +412,9 @@ const Function = struct {
     }
 
     fn genNot(self: *Function, inst: *ir.Inst.Not, comptime arch: std.Target.Cpu.Arch) !MCValue {
+        // No side effects, so if it's unreferenced, do nothing.
+        if (inst.base.isUnused())
+            return MCValue.dead;
         switch (arch) {
             else => return self.fail(inst.base.src, "TODO implement NOT for {}", .{self.target.cpu.arch}),
         }
@@ -819,6 +822,8 @@ const Function = struct {
     }
 
     fn genAsm(self: *Function, inst: *ir.Inst.Assembly, comptime arch: Target.Cpu.Arch) !MCValue {
+        if (!inst.args.is_volatile and inst.base.isUnused())
+            return MCValue.dead;
         if (arch != .x86_64 and arch != .i386) {
             return self.fail(inst.base.src, "TODO implement inline asm support for more architectures", .{});
         }

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -407,6 +407,13 @@ const Function = struct {
             .retvoid => return self.genRetVoid(inst.cast(ir.Inst.RetVoid).?, arch),
             .sub => return self.genSub(inst.cast(ir.Inst.Sub).?, arch),
             .unreach => return MCValue{ .unreach = {} },
+            .not => return self.genNot(inst.cast(ir.Inst.Not).?, arch),
+        }
+    }
+
+    fn genNot(self: *Function, inst: *ir.Inst.Not, comptime arch: std.Target.Cpu.Arch) !MCValue {
+        switch (arch) {
+            else => return self.fail(inst.base.src, "TODO implement NOT for {}", .{self.target.cpu.arch}),
         }
     }
 

--- a/src-self-hosted/ir.zig
+++ b/src-self-hosted/ir.zig
@@ -60,6 +60,7 @@ pub const Inst = struct {
         retvoid,
         sub,
         unreach,
+        not,
     };
 
     pub fn cast(base: *Inst, comptime T: type) ?*T {
@@ -192,6 +193,15 @@ pub const Inst = struct {
         deaths: [*]*Inst = undefined,
         true_death_count: u32 = 0,
         false_death_count: u32 = 0,
+    };
+
+    pub const Not = struct {
+        pub const base_tag = Tag.not;
+
+        base: Inst,
+        args: struct {
+            operand: *Inst,
+        },
     };
 
     pub const Constant = struct {

--- a/src-self-hosted/ir.zig
+++ b/src-self-hosted/ir.zig
@@ -14,30 +14,35 @@ pub const Inst = struct {
     tag: Tag,
     /// Each bit represents the index of an `Inst` parameter in the `args` field.
     /// If a bit is set, it marks the end of the lifetime of the corresponding
-    /// instruction parameter. For example, 0b000_00101 means that the first and
+    /// instruction parameter. For example, 0b101 means that the first and
     /// third `Inst` parameters' lifetimes end after this instruction, and will
     /// not have any more following references.
     /// The most significant bit being set means that the instruction itself is
     /// never referenced, in other words its lifetime ends as soon as it finishes.
-    /// If bit 7 (0b1xxx_xxxx) is set, it means this instruction itself is unreferenced.
-    /// If bit 6 (0bx1xx_xxxx) is set, it means this is a special case and the
+    /// If bit 15 (0b1xxx_xxxx_xxxx_xxxx) is set, it means this instruction itself is unreferenced.
+    /// If bit 14 (0bx1xx_xxxx_xxxx_xxxx) is set, it means this is a special case and the
     /// lifetimes of operands are encoded elsewhere.
-    deaths: u8 = undefined,
+    deaths: DeathsInt = undefined,
     ty: Type,
     /// Byte offset into the source.
     src: usize,
 
+    pub const DeathsInt = u16;
+    pub const DeathsBitIndex = std.math.Log2Int(DeathsInt);
+    pub const unreferenced_bit_index = @typeInfo(DeathsInt).Int.bits - 1;
+    pub const deaths_bits = unreferenced_bit_index - 1;
+
     pub fn isUnused(self: Inst) bool {
-        return (self.deaths & 0b1000_0000) != 0;
+        return (self.deaths & (1 << unreferenced_bit_index)) != 0;
     }
 
-    pub fn operandDies(self: Inst, index: u3) bool {
-        assert(index < 6);
+    pub fn operandDies(self: Inst, index: DeathsBitIndex) bool {
+        assert(index < deaths_bits);
         return @truncate(u1, self.deaths << index) != 0;
     }
 
     pub fn specialOperandDeaths(self: Inst) bool {
-        return (self.deaths & 0b1000_0000) != 0;
+        return (self.deaths & (1 << deaths_bits)) != 0;
     }
 
     pub const Tag = enum {

--- a/src-self-hosted/type.zig
+++ b/src-self-hosted/type.zig
@@ -163,6 +163,22 @@ pub const Type = extern union {
                     return sentinel_b == null;
                 }
             },
+            .Fn => {
+                if (!a.fnReturnType().eql(b.fnReturnType()))
+                    return false;
+                if (a.fnCallingConvention() != b.fnCallingConvention())
+                    return false;
+                const a_param_len = a.fnParamLen();
+                const b_param_len = b.fnParamLen();
+                if (a_param_len != b_param_len)
+                    return false;
+                var i: usize = 0;
+                while (i < a_param_len) : (i += 1) {
+                    if (!a.fnParamType(i).eql(b.fnParamType(i)))
+                        return false;
+                }
+                return true;
+            },
             .Float,
             .Struct,
             .Optional,
@@ -170,14 +186,13 @@ pub const Type = extern union {
             .ErrorSet,
             .Enum,
             .Union,
-            .Fn,
             .BoundFn,
             .Opaque,
             .Frame,
             .AnyFrame,
             .Vector,
             .EnumLiteral,
-            => @panic("TODO implement more Type equality comparison"),
+            => std.debug.panic("TODO implement Type equality comparison of {} and {}", .{ a, b }),
         }
     }
 

--- a/src-self-hosted/value.zig
+++ b/src-self-hosted/value.zig
@@ -427,8 +427,6 @@ pub const Value = extern union {
             .fn_ccc_void_no_args_type,
             .single_const_pointer_to_comptime_int_type,
             .const_slice_u8_type,
-            .bool_true,
-            .bool_false,
             .null_value,
             .function,
             .ref_val,
@@ -441,7 +439,10 @@ pub const Value = extern union {
 
             .the_one_possible_value, // An integer with one possible value is always zero.
             .zero,
+            .bool_false,
             => return BigIntMutable.init(&space.limbs, 0).toConst(),
+
+            .bool_true => return BigIntMutable.init(&space.limbs, 1).toConst(),
 
             .int_u64 => return BigIntMutable.init(&space.limbs, self.cast(Payload.Int_u64).?.int).toConst(),
             .int_i64 => return BigIntMutable.init(&space.limbs, self.cast(Payload.Int_i64).?.int).toConst(),
@@ -493,8 +494,6 @@ pub const Value = extern union {
             .fn_ccc_void_no_args_type,
             .single_const_pointer_to_comptime_int_type,
             .const_slice_u8_type,
-            .bool_true,
-            .bool_false,
             .null_value,
             .function,
             .ref_val,
@@ -507,7 +506,10 @@ pub const Value = extern union {
 
             .zero,
             .the_one_possible_value, // an integer with one possible value is always zero
+            .bool_false,
             => return 0,
+
+            .bool_true => return 1,
 
             .int_u64 => return self.cast(Payload.Int_u64).?.int,
             .int_i64 => return @intCast(u64, self.cast(Payload.Int_u64).?.int),
@@ -560,8 +562,6 @@ pub const Value = extern union {
             .fn_ccc_void_no_args_type,
             .single_const_pointer_to_comptime_int_type,
             .const_slice_u8_type,
-            .bool_true,
-            .bool_false,
             .null_value,
             .function,
             .ref_val,
@@ -574,7 +574,10 @@ pub const Value = extern union {
 
             .the_one_possible_value, // an integer with one possible value is always zero
             .zero,
+            .bool_false,
             => return 0,
+
+            .bool_true => return 1,
 
             .int_u64 => {
                 const x = self.cast(Payload.Int_u64).?.int;
@@ -632,8 +635,6 @@ pub const Value = extern union {
             .fn_ccc_void_no_args_type,
             .single_const_pointer_to_comptime_int_type,
             .const_slice_u8_type,
-            .bool_true,
-            .bool_false,
             .null_value,
             .function,
             .ref_val,
@@ -646,7 +647,17 @@ pub const Value = extern union {
             .zero,
             .undef,
             .the_one_possible_value, // an integer with one possible value is always zero
+            .bool_false,
             => return true,
+
+            .bool_true => {
+                const info = ty.intInfo(target);
+                if (info.signed) {
+                    return info.bits >= 2;
+                } else {
+                    return info.bits >= 1;
+                }
+            },
 
             .int_u64 => switch (ty.zigTypeTag()) {
                 .Int => {
@@ -796,8 +807,6 @@ pub const Value = extern union {
             .fn_ccc_void_no_args_type,
             .single_const_pointer_to_comptime_int_type,
             .const_slice_u8_type,
-            .bool_true,
-            .bool_false,
             .null_value,
             .function,
             .ref_val,
@@ -810,7 +819,10 @@ pub const Value = extern union {
 
             .zero,
             .the_one_possible_value, // an integer with one possible value is always zero
+            .bool_false,
             => return .eq,
+
+            .bool_true => return .gt,
 
             .int_u64 => return std.math.order(lhs.cast(Payload.Int_u64).?.int, 0),
             .int_i64 => return std.math.order(lhs.cast(Payload.Int_i64).?.int, 0),
@@ -855,7 +867,7 @@ pub const Value = extern union {
     pub fn toBool(self: Value) bool {
         return switch (self.tag()) {
             .bool_true => true,
-            .bool_false => false,
+            .bool_false, .zero => false,
             else => unreachable,
         };
     }

--- a/test/stage2/compare_output.zig
+++ b/test/stage2/compare_output.zig
@@ -170,4 +170,61 @@ pub fn addCases(ctx: *TestContext) !void {
             "",
         );
     }
+    {
+        var case = ctx.exe("assert function", linux_x64);
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    add(3, 4);
+            \\
+            \\    exit();
+            \\}
+            \\
+            \\fn add(a: u32, b: u32) void {
+            \\    assert(a + b == 7);
+            \\}
+            \\
+            \\pub fn assert(ok: bool) void {
+            \\    if (!ok) unreachable; // assertion failure
+            \\}
+            \\
+            \\fn exit() noreturn {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (231),
+            \\          [arg1] "{rdi}" (0)
+            \\        : "rcx", "r11", "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "",
+        );
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    add(100, 200);
+            \\
+            \\    exit();
+            \\}
+            \\
+            \\fn add(a: u32, b: u32) void {
+            \\    assert(a + b == 300);
+            \\}
+            \\
+            \\pub fn assert(ok: bool) void {
+            \\    if (!ok) unreachable; // assertion failure
+            \\}
+            \\
+            \\fn exit() noreturn {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (231),
+            \\          [arg1] "{rdi}" (0)
+            \\        : "rcx", "r11", "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "",
+        );
+    }
 }


### PR DESCRIPTION
The main reason to open this PR is:

#### stage2 parser: split out PrefixOp into separate AST Nodes

This is part of a larger effort to improve the memory layout of AST
nodes of the self-hosted parser to reduce wasted memory. Reduction of
wasted memory also translates to improved performance because of fewer
memory allocations, and fewer cache misses.

Compared to master, when running `zig fmt` on the std lib:

 * cache-misses: 801,829 => 768,624
 * instructions: 3,234,877,167 => 3,232,075,022
 * peak memory: 81480 KB => 75964 KB


Heads up @alexnask this probably has some changes needed for ZLS.