### PR TITLE
Link C runtime when compiling Windows DLL which uses libC

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -2503,6 +2503,11 @@ static void construct_linker_job_coff(LinkJob *lj) {
     bool is_library = g->out_type == OutTypeLib;
     if (is_library && g->is_dynamic) {
         lj->args.append("-DLL");
+
+        if (lj->codegen->libc_link_lib != nullptr) {
+            // Windows DLLs need to link the C runtime
+            lj->link_in_crt = true;
+        }
     }
 
     lj->args.append(buf_ptr(buf_sprintf("-OUT:%s", buf_ptr(&g->bin_file_output_path))));

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -2505,7 +2505,7 @@ static void construct_linker_job_coff(LinkJob *lj) {
         lj->args.append("-DLL");
 
         if (lj->codegen->libc_link_lib != nullptr) {
-            // Windows DLLs need to link the C runtime
+            // Using libC in a Windows DLL requires linking the C runtime
             lj->link_in_crt = true;
         }
     }
@@ -2958,4 +2958,3 @@ void codegen_link(CodeGen *g) {
         exit(1);
     }
 }
-


### PR DESCRIPTION
For Windows DLLs that want to call C standard library functions, the C runtime library must be linked.

This change makes sure libC is linked only when generating a COFF file and the library is dynamic (ie. a DLL).

Fixes #5842