### PR TITLE
stage2: introduce the concept of "trailer flags" to the AST

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -6,6 +6,7 @@ const math = std.math;
 const testing = std.testing;
 
 pub const trait = @import("meta/trait.zig");
+pub const TrailerFlags = @import("meta/trailer_flags.zig").TrailerFlags;
 
 const TypeInfo = builtin.TypeInfo;
 

--- a/lib/std/meta/trailer_flags.zig
+++ b/lib/std/meta/trailer_flags.zig
@@ -1,0 +1,118 @@
+const std = @import("../std.zig");
+const meta = std.meta;
+const testing = std.testing;
+const mem = std.mem;
+const assert = std.debug.assert;
+
+/// This is useful for saving memory when allocating an object that has many
+/// optional components. The optional objects are allocated sequentially in
+/// memory, and a single integer is used to represent each optional object
+/// and whether it is present based on each corresponding bit.
+pub fn TrailerFlags(comptime Fields: type) type {
+    return struct {
+        bits: Int,
+
+        pub const Int = @Type(.{ .Int = .{ .bits = bit_count, .is_signed = false } });
+        pub const bit_count = @typeInfo(Fields).Struct.fields.len;
+
+        pub const Self = @This();
+
+        pub fn has(self: Self, comptime name: []const u8) bool {
+            const field_index = meta.fieldIndex(Fields, name).?;
+            return (self.bits & (1 << field_index)) != 0;
+        }
+
+        pub fn get(self: Self, p: [*]align(@alignOf(Fields)) const u8, comptime name: []const u8) ?Field(name) {
+            if (!self.has(name))
+                return null;
+            return self.ptrConst(p, name).*;
+        }
+
+        pub fn setFlag(self: *Self, comptime name: []const u8) void {
+            const field_index = meta.fieldIndex(Fields, name).?;
+            self.bits |= 1 << field_index;
+        }
+
+        pub fn init(comptime names: anytype) Self {
+            var self: Self = .{ .bits = 0 };
+            inline for (@typeInfo(@TypeOf(names)).Struct.fields) |field| {
+                if (@field(names, field.name)) {
+                    const field_index = meta.fieldIndex(Fields, field.name).?;
+                    self.bits |= 1 << field_index;
+                }
+            }
+            return self;
+        }
+
+        pub fn set(
+            self: Self,
+            p: [*]align(@alignOf(Fields)) u8,
+            comptime name: []const u8,
+            value: Field(name),
+        ) void {
+            self.ptr(p, name).* = value;
+        }
+
+        pub fn ptr(self: Self, p: [*]align(@alignOf(Fields)) u8, comptime name: []const u8) *Field(name) {
+            const off = self.offset(p, name);
+            return @ptrCast(*Field(name), @alignCast(@alignOf(Field(name)), p + off));
+        }
+
+        pub fn ptrConst(self: Self, p: [*]align(@alignOf(Fields)) const u8, comptime name: []const u8) *const Field(name) {
+            const off = self.offset(p, name);
+            return @ptrCast(*const Field(name), @alignCast(@alignOf(Field(name)), p + off));
+        }
+
+        pub fn offset(self: Self, p: [*]align(@alignOf(Fields)) const u8, comptime name: []const u8) usize {
+            var off: usize = 0;
+            inline for (@typeInfo(Fields).Struct.fields) |field, i| {
+                const active = (self.bits & (1 << i)) != 0;
+                if (comptime mem.eql(u8, field.name, name)) {
+                    assert(active);
+                    return mem.alignForwardGeneric(usize, off, @alignOf(field.field_type));
+                } else if (active) {
+                    off = mem.alignForwardGeneric(usize, off, @alignOf(field.field_type));
+                    off += @sizeOf(field.field_type);
+                }
+            }
+            @compileError("no field named " ++ name ++ " in type " ++ @typeName(Fields));
+        }
+
+        pub fn Field(comptime name: []const u8) type {
+            return meta.fieldInfo(Fields, name).field_type;
+        }
+
+        pub fn sizeInBytes(self: Self) usize {
+            var off: usize = 0;
+            inline for (@typeInfo(Fields).Struct.fields) |field, i| {
+                if ((self.bits & (1 << i)) != 0) {
+                    off = mem.alignForwardGeneric(usize, off, @alignOf(field.field_type));
+                    off += @sizeOf(field.field_type);
+                }
+            }
+            return off;
+        }
+    };
+}
+
+test "TrailerFlags" {
+    const Flags = TrailerFlags(struct {
+        a: i32,
+        b: bool,
+        c: u64,
+    });
+    var flags = Flags.init(.{
+        .b = true,
+        .c = true,
+    });
+    testing.expect(flags.sizeInBytes() == 16);
+    const slice = try testing.allocator.allocAdvanced(u8, 8, flags.sizeInBytes(), .exact);
+    defer testing.allocator.free(slice);
+
+    flags.set(slice.ptr, "b", false);
+    flags.set(slice.ptr, "c", 12345678);
+
+    testing.expect(flags.get(slice.ptr, "a") == null);
+    testing.expect(!flags.get(slice.ptr, "b").?);
+    testing.expect(flags.get(slice.ptr, "c").? == 12345678);
+}

--- a/lib/std/meta/trailer_flags.zig
+++ b/lib/std/meta/trailer_flags.zig
@@ -124,7 +124,6 @@ test "TrailerFlags" {
         .b = true,
         .c = 1234,
     });
-    testing.expect(flags.sizeInBytes() == 16);
     const slice = try testing.allocator.allocAdvanced(u8, 8, flags.sizeInBytes(), .exact);
     defer testing.allocator.free(slice);
 

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -1,4 +1,32 @@
-const builtin = @import("builtin");
+test "zig fmt: convert var to anytype" {
+    // TODO remove in next release cycle
+    try testTransform(
+        \\pub fn main(
+        \\    a: var,
+        \\    bar: var,
+        \\) void {}
+    ,
+        \\pub fn main(
+        \\    a: anytype,
+        \\    bar: anytype,
+        \\) void {}
+        \\
+    );
+}
+
+test "zig fmt: noasync to nosuspend" {
+    // TODO: remove this
+    try testTransform(
+        \\pub fn main() void {
+        \\    noasync call();
+        \\}
+    ,
+        \\pub fn main() void {
+        \\    nosuspend call();
+        \\}
+        \\
+    );
+}
 
 test "recovery: top level" {
     try testError(
@@ -3146,20 +3174,6 @@ test "zig fmt: hexadeciaml float literals with underscore separators" {
     );
 }
 
-test "zig fmt: noasync to nosuspend" {
-    // TODO: remove this
-    try testTransform(
-        \\pub fn main() void {
-        \\    noasync call();
-        \\}
-    ,
-        \\pub fn main() void {
-        \\    nosuspend call();
-        \\}
-        \\
-    );
-}
-
 test "zig fmt: convert async fn into callconv(.Async)" {
     try testTransform(
         \\async fn foo() void {}
@@ -3180,18 +3194,9 @@ test "zig fmt: convert extern fn proto into callconv(.C)" {
     );
 }
 
-test "zig fmt: convert var to anytype" {
-    // TODO remove in next release cycle
-    try testTransform(
-        \\pub fn main(
-        \\    a: var,
-        \\    bar: var,
-        \\) void {}
-    ,
-        \\pub fn main(
-        \\    a: anytype,
-        \\    bar: anytype,
-        \\) void {}
+test "zig fmt: C var args" {
+    try testCanonical(
+        \\pub extern "c" fn printf(format: [*:0]const u8, ...) c_int;
         \\
     );
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2797,7 +2797,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub fn a() callconv(.C) void {}
         \\pub fn b() callconv(.C) void {}
         \\pub export fn c() void {}
-        \\pub fn foo() callconv(.C) void {}
+        \\pub fn foo(...) callconv(.C) void {}
     });
 
     cases.add("casting away const and volatile",


### PR DESCRIPTION
This is useful for saving memory when allocating an object that has many
optional components. The optional objects are allocated sequentially in
memory, and a single integer is used to represent each optional object
and whether it is present based on each corresponding bit.

stage2: VarDecl and FnProto take advantage of TrailerFlags API

These AST nodes now have a flags field and then a bunch of optional
trailing objects. The end result is lower memory usage and consequently
better performance. This is part of an ongoing effort to reduce the
amount of memory parsed ASTs take up.

Running `zig fmt` on the std lib:
 * cache-misses: 2,554,321 => 2,534,745
 * instructions: 3,293,220,119 => 3,302,479,874
 * peak memory: 74.0 MiB => 73.0 MiB

Holding the entire std lib AST in memory at the same time:

  93.9 MiB => 88.5 MiB

This is a nice proof of concept that has applications in other areas, for example codegen instructions.

There are many more improvements to be made to the AST memory layout. I'll be moving on to other backend stuff of self-hosted, but contributors are welcome in this area!