### PR TITLE
On darwin, only add the self exe to the cache hash for compiler id

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -38,11 +38,19 @@ Error get_compiler_id(Buf **result) {
     ZigList<Buf *> lib_paths = {};
     if ((err = os_self_exe_shared_libs(lib_paths)))
         return err;
+    #if defined(ZIG_OS_DARWIN)
+    // only add the self exe path on mac os
+    Buf *lib_path = lib_paths.at(0);
+    if ((err = cache_add_file(ch, lib_path)))
+        return err;
+    #else 
     for (size_t i = 0; i < lib_paths.length; i += 1) {
         Buf *lib_path = lib_paths.at(i);
         if ((err = cache_add_file(ch, lib_path)))
             return err;
     }
+    #endif
+
     if ((err = cache_final(ch, &saved_compiler_id)))
         return err;
 


### PR DESCRIPTION
Now that Big Sur does not have system libraries on the filesystem, `zig` can no longer read them and add them to the cache hash for the compiler id. 
This changes it so that only the first library path returned by `os_self_exe_shared_libs` is added to the cache hash under Darwin. I looked into methods on getting the system version to keep parity with older versions, but @fengb reported that this works on Catalina (a version behind Big Sur)