### PR TITLE
self-hosted compiler local consts

### DIFF
--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -408,8 +408,54 @@ pub const Node = struct {
         VarDecl,
         Defer,
 
-        // Operators
-        InfixOp,
+        // Infix operators
+        Catch,
+
+        // SimpleInfixOp
+        Add,
+        AddWrap,
+        ArrayCat,
+        ArrayMult,
+        Assign,
+        AssignBitAnd,
+        AssignBitOr,
+        AssignBitShiftLeft,
+        AssignBitShiftRight,
+        AssignBitXor,
+        AssignDiv,
+        AssignSub,
+        AssignSubWrap,
+        AssignMod,
+        AssignAdd,
+        AssignAddWrap,
+        AssignMul,
+        AssignMulWrap,
+        BangEqual,
+        BitAnd,
+        BitOr,
+        BitShiftLeft,
+        BitShiftRight,
+        BitXor,
+        BoolAnd,
+        BoolOr,
+        Div,
+        EqualEqual,
+        ErrorUnion,
+        GreaterOrEqual,
+        GreaterThan,
+        LessOrEqual,
+        LessThan,
+        MergeErrorSets,
+        Mod,
+        Mul,
+        MulWrap,
+        Period,
+        Range,
+        Sub,
+        SubWrap,
+        UnwrapOptional,
+
+        // SimplePrefixOp
         AddressOf,
         Await,
         BitNot,
@@ -419,6 +465,7 @@ pub const Node = struct {
         NegationWrap,
         Resume,
         Try,
+
         ArrayType,
         /// ArrayType but has a sentinel node.
         ArrayTypeSentinel,
@@ -492,7 +539,51 @@ pub const Node = struct {
                 .TestDecl => TestDecl,
                 .VarDecl => VarDecl,
                 .Defer => Defer,
-                .InfixOp => InfixOp,
+                .Catch => Catch,
+
+                .Add,
+                .AddWrap,
+                .ArrayCat,
+                .ArrayMult,
+                .Assign,
+                .AssignBitAnd,
+                .AssignBitOr,
+                .AssignBitShiftLeft,
+                .AssignBitShiftRight,
+                .AssignBitXor,
+                .AssignDiv,
+                .AssignSub,
+                .AssignSubWrap,
+                .AssignMod,
+                .AssignAdd,
+                .AssignAddWrap,
+                .AssignMul,
+                .AssignMulWrap,
+                .BangEqual,
+                .BitAnd,
+                .BitOr,
+                .BitShiftLeft,
+                .BitShiftRight,
+                .BitXor,
+                .BoolAnd,
+                .BoolOr,
+                .Div,
+                .EqualEqual,
+                .ErrorUnion,
+                .GreaterOrEqual,
+                .GreaterThan,
+                .LessOrEqual,
+                .LessThan,
+                .MergeErrorSets,
+                .Mod,
+                .Mul,
+                .MulWrap,
+                .Period,
+                .Range,
+                .Sub,
+                .SubWrap,
+                .UnwrapOptional,
+                => SimpleInfixOp,
 
                 .AddressOf,
                 .Await,
@@ -507,13 +598,17 @@ pub const Node = struct {
 
                 .ArrayType => ArrayType,
                 .ArrayTypeSentinel => ArrayTypeSentinel,
+
                 .PtrType => PtrType,
                 .SliceType => SliceType,
                 .SuffixOp => SuffixOp,
+
                 .ArrayInitializer => ArrayInitializer,
                 .ArrayInitializerDot => ArrayInitializerDot,
+
                 .StructInitializer => StructInitializer,
                 .StructInitializerDot => StructInitializerDot,
+
                 .Call => Call,
                 .Switch => Switch,
                 .While => While,
@@ -1859,117 +1954,22 @@ pub const Node = struct {
         }
     };
 
-    /// TODO split up and make every op its own AST Node tag
-    pub const InfixOp = struct {
-        base: Node = Node{ .tag = .InfixOp },
+    pub const Catch = struct {
+        base: Node = Node{ .tag = .Catch },
         op_token: TokenIndex,
         lhs: *Node,
-        op: Op,
         rhs: *Node,
+        payload: ?*Node,
 
-        pub const Op = union(enum) {
-            Add,
-            AddWrap,
-            ArrayCat,
-            ArrayMult,
-            Assign,
-            AssignBitAnd,
-            AssignBitOr,
-            AssignBitShiftLeft,
-            AssignBitShiftRight,
-            AssignBitXor,
-            AssignDiv,
-            AssignSub,
-            AssignSubWrap,
-            AssignMod,
-            AssignAdd,
-            AssignAddWrap,
-            AssignMul,
-            AssignMulWrap,
-            BangEqual,
-            BitAnd,
-            BitOr,
-            BitShiftLeft,
-            BitShiftRight,
-            BitXor,
-            BoolAnd,
-            BoolOr,
-            Catch: ?*Node,
-            Div,
-            EqualEqual,
-            ErrorUnion,
-            GreaterOrEqual,
-            GreaterThan,
-            LessOrEqual,
-            LessThan,
-            MergeErrorSets,
-            Mod,
-            Mul,
-            MulWrap,
-            Period,
-            Range,
-            Sub,
-            SubWrap,
-            UnwrapOptional,
-        };
-
-        pub fn iterate(self: *const InfixOp, index: usize) ?*Node {
+        pub fn iterate(self: *const Catch, index: usize) ?*Node {
             var i = index;
 
             if (i < 1) return self.lhs;
             i -= 1;
 
-            switch (self.op) {
-                .Catch => |maybe_payload| {
-                    if (maybe_payload) |payload| {
-                        if (i < 1) return payload;
-                        i -= 1;
-                    }
-                },
-
-                .Add,
-                .AddWrap,
-                .ArrayCat,
-                .ArrayMult,
-                .Assign,
-                .AssignBitAnd,
-                .AssignBitOr,
-                .AssignBitShiftLeft,
-                .AssignBitShiftRight,
-                .AssignBitXor,
-                .AssignDiv,
-                .AssignSub,
-                .AssignSubWrap,
-                .AssignMod,
-                .AssignAdd,
-                .AssignAddWrap,
-                .AssignMul,
-                .AssignMulWrap,
-                .BangEqual,
-                .BitAnd,
-                .BitOr,
-                .BitShiftLeft,
-                .BitShiftRight,
-                .BitXor,
-                .BoolAnd,
-                .BoolOr,
-                .Div,
-                .EqualEqual,
-                .ErrorUnion,
-                .GreaterOrEqual,
-                .GreaterThan,
-                .LessOrEqual,
-                .LessThan,
-                .MergeErrorSets,
-                .Mod,
-                .Mul,
-                .MulWrap,
-                .Period,
-                .Range,
-                .Sub,
-                .SubWrap,
-                .UnwrapOptional,
-                => {},
+            if (self.payload) |payload| {
+                if (i < 1) return payload;
+                i -= 1;
             }
 
             if (i < 1) return self.rhs;
@@ -1978,11 +1978,38 @@ pub const Node = struct {
             return null;
         }
 
-        pub fn firstToken(self: *const InfixOp) TokenIndex {
+        pub fn firstToken(self: *const Catch) TokenIndex {
             return self.lhs.firstToken();
         }
 
-        pub fn lastToken(self: *const InfixOp) TokenIndex {
+        pub fn lastToken(self: *const Catch) TokenIndex {
+            return self.rhs.lastToken();
+        }
+    };
+
+    pub const SimpleInfixOp = struct {
+        base: Node,
+        op_token: TokenIndex,
+        lhs: *Node,
+        rhs: *Node,
+
+        pub fn iterate(self: *const SimpleInfixOp, index: usize) ?*Node {
+            var i = index;
+
+            if (i < 1) return self.lhs;
+            i -= 1;
+
+            if (i < 1) return self.rhs;
+            i -= 1;
+
+            return null;
+        }
+
+        pub fn firstToken(self: *const SimpleInfixOp) TokenIndex {
+            return self.lhs.firstToken();
+        }
+
+        pub fn lastToken(self: *const SimpleInfixOp) TokenIndex {
             return self.rhs.lastToken();
         }
     };

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -223,7 +223,7 @@ fn renderTopLevelDecl(allocator: *mem.Allocator, stream: anytype, tree: *ast.Tre
 }
 
 fn renderContainerDecl(allocator: *mem.Allocator, stream: anytype, tree: *ast.Tree, indent: usize, start_col: *usize, decl: *ast.Node, space: Space) (@TypeOf(stream).Error || Error)!void {
-    switch (decl.id) {
+    switch (decl.tag) {
         .FnProto => {
             const fn_proto = @fieldParentPtr(ast.Node.FnProto, "base", decl);
 
@@ -365,7 +365,7 @@ fn renderExpression(
     base: *ast.Node,
     space: Space,
 ) (@TypeOf(stream).Error || Error)!void {
-    switch (base.id) {
+    switch (base.tag) {
         .Identifier => {
             const identifier = @fieldParentPtr(ast.Node.Identifier, "base", base);
             return renderToken(tree, stream, identifier.token, indent, start_col, space);
@@ -468,50 +468,25 @@ fn renderExpression(
             return renderExpression(allocator, stream, tree, indent, start_col, infix_op_node.rhs, space);
         },
 
-        .BitNot => {
-            const bit_not = @fieldParentPtr(ast.Node.BitNot, "base", base);
-            try renderToken(tree, stream, bit_not.op_token, indent, start_col, Space.None);
-            return renderExpression(allocator, stream, tree, indent, start_col, bit_not.rhs, space);
+        .BitNot,
+        .BoolNot,
+        .Negation,
+        .NegationWrap,
+        .OptionalType,
+        .AddressOf,
+        => {
+            const casted_node = @fieldParentPtr(ast.Node.SimplePrefixOp, "base", base);
+            try renderToken(tree, stream, casted_node.op_token, indent, start_col, Space.None);
+            return renderExpression(allocator, stream, tree, indent, start_col, casted_node.rhs, space);
         },
-        .BoolNot => {
-            const bool_not = @fieldParentPtr(ast.Node.BoolNot, "base", base);
-            try renderToken(tree, stream, bool_not.op_token, indent, start_col, Space.None);
-            return renderExpression(allocator, stream, tree, indent, start_col, bool_not.rhs, space);
-        },
-        .Negation => {
-            const negation = @fieldParentPtr(ast.Node.Negation, "base", base);
-            try renderToken(tree, stream, negation.op_token, indent, start_col, Space.None);
-            return renderExpression(allocator, stream, tree, indent, start_col, negation.rhs, space);
-        },
-        .NegationWrap => {
-            const negation_wrap = @fieldParentPtr(ast.Node.NegationWrap, "base", base);
-            try renderToken(tree, stream, negation_wrap.op_token, indent, start_col, Space.None);
-            return renderExpression(allocator, stream, tree, indent, start_col, negation_wrap.rhs, space);
-        },
-        .OptionalType => {
-            const opt_type = @fieldParentPtr(ast.Node.OptionalType, "base", base);
-            try renderToken(tree, stream, opt_type.op_token, indent, start_col, Space.None);
-            return renderExpression(allocator, stream, tree, indent, start_col, opt_type.rhs, space);
-        },
-        .AddressOf => {
-            const addr_of = @fieldParentPtr(ast.Node.AddressOf, "base", base);
-            try renderToken(tree, stream, addr_of.op_token, indent, start_col, Space.None);
-            return renderExpression(allocator, stream, tree, indent, start_col, addr_of.rhs, space);
-        },
-        .Try => {
-            const try_node = @fieldParentPtr(ast.Node.Try, "base", base);
-            try renderToken(tree, stream, try_node.op_token, indent, start_col, Space.Space);
-            return renderExpression(allocator, stream, tree, indent, start_col, try_node.rhs, space);
-        },
-        .Resume => {
-            const resume_node = @fieldParentPtr(ast.Node.Resume, "base", base);
-            try renderToken(tree, stream, resume_node.op_token, indent, start_col, Space.Space);
-            return renderExpression(allocator, stream, tree, indent, start_col, resume_node.rhs, space);
-        },
-        .Await => {
-            const await_node = @fieldParentPtr(ast.Node.Await, "base", base);
-            try renderToken(tree, stream, await_node.op_token, indent, start_col, Space.Space);
-            return renderExpression(allocator, stream, tree, indent, start_col, await_node.rhs, space);
+
+        .Try,
+        .Resume,
+        .Await,
+        => {
+            const casted_node = @fieldParentPtr(ast.Node.SimplePrefixOp, "base", base);
+            try renderToken(tree, stream, casted_node.op_token, indent, start_col, Space.Space);
+            return renderExpression(allocator, stream, tree, indent, start_col, casted_node.rhs, space);
         },
 
         .ArrayType => {
@@ -659,7 +634,7 @@ fn renderExpression(
         .ArrayInitializer, .ArrayInitializerDot => {
             var rtoken: ast.TokenIndex = undefined;
             var exprs: []*ast.Node = undefined;
-            const lhs: union(enum) { dot: ast.TokenIndex, node: *ast.Node } = switch (base.id) {
+            const lhs: union(enum) { dot: ast.TokenIndex, node: *ast.Node } = switch (base.tag) {
                 .ArrayInitializerDot => blk: {
                     const casted = @fieldParentPtr(ast.Node.ArrayInitializerDot, "base", base);
                     rtoken = casted.rtoken;
@@ -793,14 +768,14 @@ fn renderExpression(
                         }
 
                         try renderExtraNewline(tree, stream, start_col, next_expr);
-                        if (next_expr.id != .MultilineStringLiteral) {
+                        if (next_expr.tag != .MultilineStringLiteral) {
                             try stream.writeByteNTimes(' ', new_indent);
                         }
                     } else {
                         try renderExpression(allocator, stream, tree, new_indent, start_col, expr, Space.Comma); // ,
                     }
                 }
-                if (exprs[exprs.len - 1].id != .MultilineStringLiteral) {
+                if (exprs[exprs.len - 1].tag != .MultilineStringLiteral) {
                     try stream.writeByteNTimes(' ', indent);
                 }
                 return renderToken(tree, stream, rtoken, indent, start_col, space);
@@ -823,7 +798,7 @@ fn renderExpression(
         .StructInitializer, .StructInitializerDot => {
             var rtoken: ast.TokenIndex = undefined;
             var field_inits: []*ast.Node = undefined;
-            const lhs: union(enum) { dot: ast.TokenIndex, node: *ast.Node } = switch (base.id) {
+            const lhs: union(enum) { dot: ast.TokenIndex, node: *ast.Node } = switch (base.tag) {
                 .StructInitializerDot => blk: {
                     const casted = @fieldParentPtr(ast.Node.StructInitializerDot, "base", base);
                     rtoken = casted.rtoken;
@@ -877,7 +852,7 @@ fn renderExpression(
             if (field_inits.len == 1) blk: {
                 const field_init = field_inits[0].cast(ast.Node.FieldInitializer).?;
 
-                switch (field_init.expr.id) {
+                switch (field_init.expr.tag) {
                     .StructInitializer,
                     .StructInitializerDot,
                     => break :blk,
@@ -974,7 +949,7 @@ fn renderExpression(
 
                 const params = call.params();
                 for (params) |param_node, i| {
-                    const param_node_new_indent = if (param_node.id == .MultilineStringLiteral) blk: {
+                    const param_node_new_indent = if (param_node.tag == .MultilineStringLiteral) blk: {
                         break :blk indent;
                     } else blk: {
                         try stream.writeByteNTimes(' ', new_indent);
@@ -1284,7 +1259,7 @@ fn renderExpression(
             // declarations inside are fields
             const src_has_only_fields = blk: {
                 for (fields_and_decls) |decl| {
-                    if (decl.id != .ContainerField) break :blk false;
+                    if (decl.tag != .ContainerField) break :blk false;
                 }
                 break :blk true;
             };
@@ -1831,7 +1806,7 @@ fn renderExpression(
 
             const rparen = tree.nextToken(for_node.array_expr.lastToken());
 
-            const body_is_block = for_node.body.id == .Block;
+            const body_is_block = for_node.body.tag == .Block;
             const src_one_line_to_body = !body_is_block and tree.tokensOnSameLine(rparen, for_node.body.firstToken());
             const body_on_same_line = body_is_block or src_one_line_to_body;
 
@@ -1874,7 +1849,7 @@ fn renderExpression(
 
             try renderExpression(allocator, stream, tree, indent, start_col, if_node.condition, Space.None); // condition
 
-            const body_is_if_block = if_node.body.id == .If;
+            const body_is_if_block = if_node.body.tag == .If;
             const body_is_block = nodeIsBlock(if_node.body);
 
             if (body_is_if_block) {
@@ -1978,7 +1953,7 @@ fn renderExpression(
 
             const indent_once = indent + indent_delta;
 
-            if (asm_node.template.id == .MultilineStringLiteral) {
+            if (asm_node.template.tag == .MultilineStringLiteral) {
                 // After rendering a multiline string literal the cursor is
                 // already offset by indent
                 try stream.writeByteNTimes(' ', indent_delta);
@@ -2245,7 +2220,7 @@ fn renderVarDecl(
     }
 
     if (var_decl.getTrailer("init_node")) |init_node| {
-        const s = if (init_node.id == .MultilineStringLiteral) Space.None else Space.Space;
+        const s = if (init_node.tag == .MultilineStringLiteral) Space.None else Space.Space;
         try renderToken(tree, stream, var_decl.getTrailer("eq_token").?, indent, start_col, s); // =
         try renderExpression(allocator, stream, tree, indent, start_col, init_node, Space.None);
     }
@@ -2287,7 +2262,7 @@ fn renderStatement(
     start_col: *usize,
     base: *ast.Node,
 ) (@TypeOf(stream).Error || Error)!void {
-    switch (base.id) {
+    switch (base.tag) {
         .VarDecl => {
             const var_decl = @fieldParentPtr(ast.Node.VarDecl, "base", base);
             try renderVarDecl(allocator, stream, tree, indent, start_col, var_decl);
@@ -2566,7 +2541,7 @@ fn renderDocCommentsToken(
 }
 
 fn nodeIsBlock(base: *const ast.Node) bool {
-    return switch (base.id) {
+    return switch (base.tag) {
         .Block,
         .If,
         .For,

--- a/src-self-hosted/Module.zig
+++ b/src-self-hosted/Module.zig
@@ -1954,7 +1954,7 @@ pub fn addZIRInstSpecial(
     positionals: std.meta.fieldInfo(T, "positionals").field_type,
     kw_args: std.meta.fieldInfo(T, "kw_args").field_type,
 ) !*T {
-    const gen_zir = scope.cast(Scope.GenZIR).?;
+    const gen_zir = scope.getGenZIR();
     try gen_zir.instructions.ensureCapacity(self.gpa, gen_zir.instructions.items.len + 1);
     const inst = try newZIRInst(gen_zir.arena, src, T, positionals, kw_args);
     gen_zir.instructions.appendAssumeCapacity(&inst.base);

--- a/src-self-hosted/astgen.zig
+++ b/src-self-hosted/astgen.zig
@@ -1,0 +1,476 @@
+const std = @import("std");
+const mem = std.mem;
+const Value = @import("value.zig").Value;
+const Type = @import("type.zig").Type;
+const TypedValue = @import("TypedValue.zig");
+const assert = std.debug.assert;
+const zir = @import("zir.zig");
+const Module = @import("Module.zig");
+const ast = std.zig.ast;
+const trace = @import("tracy.zig").trace;
+const Scope = Module.Scope;
+const InnerError = Module.InnerError;
+
+pub fn expr(mod: *Module, scope: *Scope, ast_node: *ast.Node) InnerError!*zir.Inst {
+    switch (ast_node.id) {
+        .Identifier => return identifier(mod, scope, @fieldParentPtr(ast.Node.Identifier, "base", ast_node)),
+        .Asm => return assembly(mod, scope, @fieldParentPtr(ast.Node.Asm, "base", ast_node)),
+        .StringLiteral => return stringLiteral(mod, scope, @fieldParentPtr(ast.Node.StringLiteral, "base", ast_node)),
+        .IntegerLiteral => return integerLiteral(mod, scope, @fieldParentPtr(ast.Node.IntegerLiteral, "base", ast_node)),
+        .BuiltinCall => return builtinCall(mod, scope, @fieldParentPtr(ast.Node.BuiltinCall, "base", ast_node)),
+        .Call => return callExpr(mod, scope, @fieldParentPtr(ast.Node.Call, "base", ast_node)),
+        .Unreachable => return unreach(mod, scope, @fieldParentPtr(ast.Node.Unreachable, "base", ast_node)),
+        .ControlFlowExpression => return controlFlowExpr(mod, scope, @fieldParentPtr(ast.Node.ControlFlowExpression, "base", ast_node)),
+        .If => return ifExpr(mod, scope, @fieldParentPtr(ast.Node.If, "base", ast_node)),
+        .InfixOp => return infixOp(mod, scope, @fieldParentPtr(ast.Node.InfixOp, "base", ast_node)),
+        .BoolNot => return boolNot(mod, scope, @fieldParentPtr(ast.Node.BoolNot, "base", ast_node)),
+        .VarDecl => return varDecl(mod, scope, @fieldParentPtr(ast.Node.VarDecl, "base", ast_node)),
+        else => return mod.failNode(scope, ast_node, "TODO implement astgen.Expr for {}", .{@tagName(ast_node.id)}),
+    }
+}
+
+pub fn blockExpr(mod: *Module, scope: *Scope, block_node: *ast.Node.Block) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
+    if (block_node.label) |label| {
+        return mod.failTok(scope, label, "TODO implement labeled blocks", .{});
+    }
+    for (block_node.statements()) |statement| {
+        _ = try expr(mod, scope, statement);
+    }
+}
+
+fn varDecl(mod: *Module, scope: *Scope, node: *ast.Node.VarDecl) InnerError!*zir.Inst {
+    return mod.failNode(scope, &node.base, "TODO implement var decls", .{});
+}
+
+fn boolNot(mod: *Module, scope: *Scope, node: *ast.Node.BoolNot) InnerError!*zir.Inst {
+    const operand = try expr(mod, scope, node.rhs);
+    const tree = scope.tree();
+    const src = tree.token_locs[node.op_token].start;
+    return mod.addZIRInst(scope, src, zir.Inst.BoolNot, .{ .operand = operand }, .{});
+}
+
+fn infixOp(mod: *Module, scope: *Scope, infix_node: *ast.Node.InfixOp) InnerError!*zir.Inst {
+    switch (infix_node.op) {
+        .Assign => {
+            if (infix_node.lhs.id == .Identifier) {
+                const ident = @fieldParentPtr(ast.Node.Identifier, "base", infix_node.lhs);
+                const tree = scope.tree();
+                const ident_name = tree.tokenSlice(ident.token);
+                if (std.mem.eql(u8, ident_name, "_")) {
+                    return expr(mod, scope, infix_node.rhs);
+                } else {
+                    return mod.failNode(scope, &infix_node.base, "TODO implement infix operator assign", .{});
+                }
+            } else {
+                return mod.failNode(scope, &infix_node.base, "TODO implement infix operator assign", .{});
+            }
+        },
+        .Add => {
+            const lhs = try expr(mod, scope, infix_node.lhs);
+            const rhs = try expr(mod, scope, infix_node.rhs);
+
+            const tree = scope.tree();
+            const src = tree.token_locs[infix_node.op_token].start;
+
+            return mod.addZIRInst(scope, src, zir.Inst.Add, .{ .lhs = lhs, .rhs = rhs }, .{});
+        },
+        .BangEqual,
+        .EqualEqual,
+        .GreaterThan,
+        .GreaterOrEqual,
+        .LessThan,
+        .LessOrEqual,
+        => {
+            const lhs = try expr(mod, scope, infix_node.lhs);
+            const rhs = try expr(mod, scope, infix_node.rhs);
+
+            const tree = scope.tree();
+            const src = tree.token_locs[infix_node.op_token].start;
+
+            const op: std.math.CompareOperator = switch (infix_node.op) {
+                .BangEqual => .neq,
+                .EqualEqual => .eq,
+                .GreaterThan => .gt,
+                .GreaterOrEqual => .gte,
+                .LessThan => .lt,
+                .LessOrEqual => .lte,
+                else => unreachable,
+            };
+
+            return mod.addZIRInst(scope, src, zir.Inst.Cmp, .{
+                .lhs = lhs,
+                .op = op,
+                .rhs = rhs,
+            }, .{});
+        },
+        else => |op| {
+            return mod.failNode(scope, &infix_node.base, "TODO implement infix operator {}", .{op});
+        },
+    }
+}
+
+fn ifExpr(mod: *Module, scope: *Scope, if_node: *ast.Node.If) InnerError!*zir.Inst {
+    if (if_node.payload) |payload| {
+        return mod.failNode(scope, payload, "TODO implement astgen.IfExpr for optionals", .{});
+    }
+    if (if_node.@"else") |else_node| {
+        if (else_node.payload) |payload| {
+            return mod.failNode(scope, payload, "TODO implement astgen.IfExpr for error unions", .{});
+        }
+    }
+    var block_scope: Scope.GenZIR = .{
+        .decl = scope.decl().?,
+        .arena = scope.arena(),
+        .instructions = .{},
+    };
+    defer block_scope.instructions.deinit(mod.gpa);
+
+    const cond = try expr(mod, &block_scope.base, if_node.condition);
+
+    const tree = scope.tree();
+    const if_src = tree.token_locs[if_node.if_token].start;
+    const condbr = try mod.addZIRInstSpecial(&block_scope.base, if_src, zir.Inst.CondBr, .{
+        .condition = cond,
+        .true_body = undefined, // populated below
+        .false_body = undefined, // populated below
+    }, .{});
+
+    const block = try mod.addZIRInstBlock(scope, if_src, .{
+        .instructions = try block_scope.arena.dupe(*zir.Inst, block_scope.instructions.items),
+    });
+    var then_scope: Scope.GenZIR = .{
+        .decl = block_scope.decl,
+        .arena = block_scope.arena,
+        .instructions = .{},
+    };
+    defer then_scope.instructions.deinit(mod.gpa);
+
+    const then_result = try expr(mod, &then_scope.base, if_node.body);
+    if (!then_result.tag.isNoReturn()) {
+        const then_src = tree.token_locs[if_node.body.lastToken()].start;
+        _ = try mod.addZIRInst(&then_scope.base, then_src, zir.Inst.Break, .{
+            .block = block,
+            .operand = then_result,
+        }, .{});
+    }
+    condbr.positionals.true_body = .{
+        .instructions = try then_scope.arena.dupe(*zir.Inst, then_scope.instructions.items),
+    };
+
+    var else_scope: Scope.GenZIR = .{
+        .decl = block_scope.decl,
+        .arena = block_scope.arena,
+        .instructions = .{},
+    };
+    defer else_scope.instructions.deinit(mod.gpa);
+
+    if (if_node.@"else") |else_node| {
+        const else_result = try expr(mod, &else_scope.base, else_node.body);
+        if (!else_result.tag.isNoReturn()) {
+            const else_src = tree.token_locs[else_node.body.lastToken()].start;
+            _ = try mod.addZIRInst(&else_scope.base, else_src, zir.Inst.Break, .{
+                .block = block,
+                .operand = else_result,
+            }, .{});
+        }
+    } else {
+        // TODO Optimization opportunity: we can avoid an allocation and a memcpy here
+        // by directly allocating the body for this one instruction.
+        const else_src = tree.token_locs[if_node.lastToken()].start;
+        _ = try mod.addZIRInst(&else_scope.base, else_src, zir.Inst.BreakVoid, .{
+            .block = block,
+        }, .{});
+    }
+    condbr.positionals.false_body = .{
+        .instructions = try else_scope.arena.dupe(*zir.Inst, else_scope.instructions.items),
+    };
+
+    return &block.base;
+}
+
+fn controlFlowExpr(
+    mod: *Module,
+    scope: *Scope,
+    cfe: *ast.Node.ControlFlowExpression,
+) InnerError!*zir.Inst {
+    switch (cfe.kind) {
+        .Break => return mod.failNode(scope, &cfe.base, "TODO implement astgen.Expr for Break", .{}),
+        .Continue => return mod.failNode(scope, &cfe.base, "TODO implement astgen.Expr for Continue", .{}),
+        .Return => {},
+    }
+    const tree = scope.tree();
+    const src = tree.token_locs[cfe.ltoken].start;
+    if (cfe.rhs) |rhs_node| {
+        const operand = try expr(mod, scope, rhs_node);
+        return mod.addZIRInst(scope, src, zir.Inst.Return, .{ .operand = operand }, .{});
+    } else {
+        return mod.addZIRInst(scope, src, zir.Inst.ReturnVoid, .{}, .{});
+    }
+}
+
+fn identifier(mod: *Module, scope: *Scope, ident: *ast.Node.Identifier) InnerError!*zir.Inst {
+    const tree = scope.tree();
+    const ident_name = tree.tokenSlice(ident.token);
+    const src = tree.token_locs[ident.token].start;
+    if (mem.eql(u8, ident_name, "_")) {
+        return mod.failNode(scope, &ident.base, "TODO implement '_' identifier", .{});
+    }
+
+    if (getSimplePrimitiveValue(ident_name)) |typed_value| {
+        return mod.addZIRInstConst(scope, src, typed_value);
+    }
+
+    if (ident_name.len >= 2) integer: {
+        const first_c = ident_name[0];
+        if (first_c == 'i' or first_c == 'u') {
+            const is_signed = first_c == 'i';
+            const bit_count = std.fmt.parseInt(u16, ident_name[1..], 10) catch |err| switch (err) {
+                error.Overflow => return mod.failNode(
+                    scope,
+                    &ident.base,
+                    "primitive integer type '{}' exceeds maximum bit width of 65535",
+                    .{ident_name},
+                ),
+                error.InvalidCharacter => break :integer,
+            };
+            const val = switch (bit_count) {
+                8 => if (is_signed) Value.initTag(.i8_type) else Value.initTag(.u8_type),
+                16 => if (is_signed) Value.initTag(.i16_type) else Value.initTag(.u16_type),
+                32 => if (is_signed) Value.initTag(.i32_type) else Value.initTag(.u32_type),
+                64 => if (is_signed) Value.initTag(.i64_type) else Value.initTag(.u64_type),
+                else => return mod.failNode(scope, &ident.base, "TODO implement arbitrary integer bitwidth types", .{}),
+            };
+            return mod.addZIRInstConst(scope, src, .{
+                .ty = Type.initTag(.type),
+                .val = val,
+            });
+        }
+    }
+
+    if (mod.lookupDeclName(scope, ident_name)) |decl| {
+        return try mod.addZIRInst(scope, src, zir.Inst.DeclValInModule, .{ .decl = decl }, .{});
+    }
+
+    // Function parameter
+    if (scope.decl()) |decl| {
+        if (tree.root_node.decls()[decl.src_index].cast(ast.Node.FnProto)) |fn_proto| {
+            for (fn_proto.params()) |param, i| {
+                const param_name = tree.tokenSlice(param.name_token.?);
+                if (mem.eql(u8, param_name, ident_name)) {
+                    return try mod.addZIRInst(scope, src, zir.Inst.Arg, .{ .index = i }, .{});
+                }
+            }
+        }
+    }
+
+    return mod.failNode(scope, &ident.base, "TODO implement local variable identifier lookup", .{});
+}
+
+fn stringLiteral(mod: *Module, scope: *Scope, str_lit: *ast.Node.StringLiteral) InnerError!*zir.Inst {
+    const tree = scope.tree();
+    const unparsed_bytes = tree.tokenSlice(str_lit.token);
+    const arena = scope.arena();
+
+    var bad_index: usize = undefined;
+    const bytes = std.zig.parseStringLiteral(arena, unparsed_bytes, &bad_index) catch |err| switch (err) {
+        error.InvalidCharacter => {
+            const bad_byte = unparsed_bytes[bad_index];
+            const src = tree.token_locs[str_lit.token].start;
+            return mod.fail(scope, src + bad_index, "invalid string literal character: '{c}'\n", .{bad_byte});
+        },
+        else => |e| return e,
+    };
+
+    const src = tree.token_locs[str_lit.token].start;
+    return mod.addZIRInst(scope, src, zir.Inst.Str, .{ .bytes = bytes }, .{});
+}
+
+fn integerLiteral(mod: *Module, scope: *Scope, int_lit: *ast.Node.IntegerLiteral) InnerError!*zir.Inst {
+    const arena = scope.arena();
+    const tree = scope.tree();
+    const prefixed_bytes = tree.tokenSlice(int_lit.token);
+    const base = if (mem.startsWith(u8, prefixed_bytes, "0x"))
+        16
+    else if (mem.startsWith(u8, prefixed_bytes, "0o"))
+        8
+    else if (mem.startsWith(u8, prefixed_bytes, "0b"))
+        2
+    else
+        @as(u8, 10);
+
+    const bytes = if (base == 10)
+        prefixed_bytes
+    else
+        prefixed_bytes[2..];
+
+    if (std.fmt.parseInt(u64, bytes, base)) |small_int| {
+        const int_payload = try arena.create(Value.Payload.Int_u64);
+        int_payload.* = .{ .int = small_int };
+        const src = tree.token_locs[int_lit.token].start;
+        return mod.addZIRInstConst(scope, src, .{
+            .ty = Type.initTag(.comptime_int),
+            .val = Value.initPayload(&int_payload.base),
+        });
+    } else |err| {
+        return mod.failTok(scope, int_lit.token, "TODO implement int literals that don't fit in a u64", .{});
+    }
+}
+
+fn assembly(mod: *Module, scope: *Scope, asm_node: *ast.Node.Asm) InnerError!*zir.Inst {
+    if (asm_node.outputs.len != 0) {
+        return mod.failNode(scope, &asm_node.base, "TODO implement asm with an output", .{});
+    }
+    const arena = scope.arena();
+    const tree = scope.tree();
+
+    const inputs = try arena.alloc(*zir.Inst, asm_node.inputs.len);
+    const args = try arena.alloc(*zir.Inst, asm_node.inputs.len);
+
+    for (asm_node.inputs) |input, i| {
+        // TODO semantically analyze constraints
+        inputs[i] = try expr(mod, scope, input.constraint);
+        args[i] = try expr(mod, scope, input.expr);
+    }
+
+    const src = tree.token_locs[asm_node.asm_token].start;
+    const return_type = try mod.addZIRInstConst(scope, src, .{
+        .ty = Type.initTag(.type),
+        .val = Value.initTag(.void_type),
+    });
+    const asm_inst = try mod.addZIRInst(scope, src, zir.Inst.Asm, .{
+        .asm_source = try expr(mod, scope, asm_node.template),
+        .return_type = return_type,
+    }, .{
+        .@"volatile" = asm_node.volatile_token != null,
+        //.clobbers =  TODO handle clobbers
+        .inputs = inputs,
+        .args = args,
+    });
+    return asm_inst;
+}
+
+fn builtinCall(mod: *Module, scope: *Scope, call: *ast.Node.BuiltinCall) InnerError!*zir.Inst {
+    const tree = scope.tree();
+    const builtin_name = tree.tokenSlice(call.builtin_token);
+    const src = tree.token_locs[call.builtin_token].start;
+
+    inline for (std.meta.declarations(zir.Inst)) |inst| {
+        if (inst.data != .Type) continue;
+        const T = inst.data.Type;
+        if (!@hasDecl(T, "builtin_name")) continue;
+        if (std.mem.eql(u8, builtin_name, T.builtin_name)) {
+            var value: T = undefined;
+            const positionals = @typeInfo(std.meta.fieldInfo(T, "positionals").field_type).Struct;
+            if (positionals.fields.len == 0) {
+                return mod.addZIRInst(scope, src, T, value.positionals, value.kw_args);
+            }
+            const arg_count: ?usize = if (positionals.fields[0].field_type == []*zir.Inst) null else positionals.fields.len;
+            if (arg_count) |some| {
+                if (call.params_len != some) {
+                    return mod.failTok(
+                        scope,
+                        call.builtin_token,
+                        "expected {} parameter{}, found {}",
+                        .{ some, if (some == 1) "" else "s", call.params_len },
+                    );
+                }
+                const params = call.params();
+                inline for (positionals.fields) |p, i| {
+                    @field(value.positionals, p.name) = try expr(mod, scope, params[i]);
+                }
+            } else {
+                return mod.failTok(scope, call.builtin_token, "TODO var args builtin '{}'", .{builtin_name});
+            }
+
+            return mod.addZIRInst(scope, src, T, value.positionals, .{});
+        }
+    }
+    return mod.failTok(scope, call.builtin_token, "TODO implement builtin call for '{}'", .{builtin_name});
+}
+
+fn callExpr(mod: *Module, scope: *Scope, node: *ast.Node.Call) InnerError!*zir.Inst {
+    const tree = scope.tree();
+    const lhs = try expr(mod, scope, node.lhs);
+
+    const param_nodes = node.params();
+    const args = try scope.cast(Scope.GenZIR).?.arena.alloc(*zir.Inst, param_nodes.len);
+    for (param_nodes) |param_node, i| {
+        args[i] = try expr(mod, scope, param_node);
+    }
+
+    const src = tree.token_locs[node.lhs.firstToken()].start;
+    return mod.addZIRInst(scope, src, zir.Inst.Call, .{
+        .func = lhs,
+        .args = args,
+    }, .{});
+}
+
+fn unreach(mod: *Module, scope: *Scope, unreach_node: *ast.Node.Unreachable) InnerError!*zir.Inst {
+    const tree = scope.tree();
+    const src = tree.token_locs[unreach_node.token].start;
+    return mod.addZIRInst(scope, src, zir.Inst.Unreachable, .{}, .{});
+}
+
+fn getSimplePrimitiveValue(name: []const u8) ?TypedValue {
+    const simple_types = std.ComptimeStringMap(Value.Tag, .{
+        .{ "u8", .u8_type },
+        .{ "i8", .i8_type },
+        .{ "isize", .isize_type },
+        .{ "usize", .usize_type },
+        .{ "c_short", .c_short_type },
+        .{ "c_ushort", .c_ushort_type },
+        .{ "c_int", .c_int_type },
+        .{ "c_uint", .c_uint_type },
+        .{ "c_long", .c_long_type },
+        .{ "c_ulong", .c_ulong_type },
+        .{ "c_longlong", .c_longlong_type },
+        .{ "c_ulonglong", .c_ulonglong_type },
+        .{ "c_longdouble", .c_longdouble_type },
+        .{ "f16", .f16_type },
+        .{ "f32", .f32_type },
+        .{ "f64", .f64_type },
+        .{ "f128", .f128_type },
+        .{ "c_void", .c_void_type },
+        .{ "bool", .bool_type },
+        .{ "void", .void_type },
+        .{ "type", .type_type },
+        .{ "anyerror", .anyerror_type },
+        .{ "comptime_int", .comptime_int_type },
+        .{ "comptime_float", .comptime_float_type },
+        .{ "noreturn", .noreturn_type },
+    });
+    if (simple_types.get(name)) |tag| {
+        return TypedValue{
+            .ty = Type.initTag(.type),
+            .val = Value.initTag(tag),
+        };
+    }
+    if (mem.eql(u8, name, "null")) {
+        return TypedValue{
+            .ty = Type.initTag(.@"null"),
+            .val = Value.initTag(.null_value),
+        };
+    }
+    if (mem.eql(u8, name, "undefined")) {
+        return TypedValue{
+            .ty = Type.initTag(.@"undefined"),
+            .val = Value.initTag(.undef),
+        };
+    }
+    if (mem.eql(u8, name, "true")) {
+        return TypedValue{
+            .ty = Type.initTag(.bool),
+            .val = Value.initTag(.bool_true),
+        };
+    }
+    if (mem.eql(u8, name, "false")) {
+        return TypedValue{
+            .ty = Type.initTag(.bool),
+            .val = Value.initTag(.bool_false),
+        };
+    }
+    return null;
+}

--- a/src-self-hosted/codegen.zig
+++ b/src-self-hosted/codegen.zig
@@ -73,6 +73,7 @@ pub fn generateSymbol(
                 .code = code,
                 .err_msg = null,
                 .args = mc_args,
+                .arg_index = 0,
                 .branch_stack = &branch_stack,
                 .src = src,
             };
@@ -255,6 +256,7 @@ const Function = struct {
     code: *std.ArrayList(u8),
     err_msg: ?*ErrorMsg,
     args: []MCValue,
+    arg_index: usize,
     src: usize,
 
     /// Whenever there is a runtime branch, we push a Branch onto this stack,
@@ -603,7 +605,9 @@ const Function = struct {
     }
 
     fn genArg(self: *Function, inst: *ir.Inst.Arg) !MCValue {
-        return self.args[inst.args.index];
+        const i = self.arg_index;
+        self.arg_index += 1;
+        return self.args[i];
     }
 
     fn genBreakpoint(self: *Function, src: usize, comptime arch: std.Target.Cpu.Arch) !MCValue {

--- a/src-self-hosted/ir.zig
+++ b/src-self-hosted/ir.zig
@@ -101,10 +101,7 @@ pub const Inst = struct {
     pub const Arg = struct {
         pub const base_tag = Tag.arg;
         base: Inst,
-
-        args: struct {
-            index: usize,
-        },
+        args: void,
     };
 
     pub const Assembly = struct {


### PR DESCRIPTION
These are now supported enough that this example code hits the
limitations of the register allocator:

```zig
fn add(a: u32, b: u32) void {
    const c = a + b; // 7
    const d = a + c; // 10
    const e = d + b; // 14
    assert(e == 14);
}
```

```
error: TODO implement copyToNewRegister
```

So now the next step is to implement register allocation as planned.

This branch also has more breaking AST memory layout modifications.

Some other tidbits:

I had a key realization about result locations. We can actually learn during AST generation, when doing a variable declaration or assignment, whether or not the result location for an expression needs to be writable memory, before descending into the sub-expressions. This removes one of the causes of duality that stage1 currently has to deal with, eliminating one source of bugs completely. This is a big deal for the robustness of the self-hosted compiler implementation, and it also means that `const` locals will be capable of being backed by registers *even in debug builds*, and *without any optimization passes*. This means that it is quite possible that zig's native-backend debug builds will actually have faster *runtime performance* than llvm's in addition to compilation speed. With a couple weeks of work, we should have an answer to this question, at least for the comparison of some simple test cases.