### PR TITLE
Stage2: Substraction support

### DIFF
--- a/test/stage2/compare_output.zig
+++ b/test/stage2/compare_output.zig
@@ -176,7 +176,7 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("substracting numbers at runtime", linux_x64);
         case.addCompareOutput(
             \\export fn _start() noreturn {
-            \\    sub(7, 8);
+            \\    sub(7, 4);
             \\
             \\    exit();
             \\}

--- a/test/stage2/compare_output.zig
+++ b/test/stage2/compare_output.zig
@@ -172,7 +172,6 @@ pub fn addCases(ctx: *TestContext) !void {
     }
 
     {
-        // TODO add a test case for comptime substraction of numbers
         var case = ctx.exe("substracting numbers at runtime", linux_x64);
         case.addCompareOutput(
             \\export fn _start() noreturn {

--- a/test/stage2/compare_output.zig
+++ b/test/stage2/compare_output.zig
@@ -169,8 +169,38 @@ pub fn addCases(ctx: *TestContext) !void {
         ,
             "",
         );
+    }
 
-        // Tests the assert() function.
+    {
+        // TODO add a test case for comptime substraction of numbers
+        var case = ctx.exe("substracting numbers at runtime", linux_x64);
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    sub(7, 8);
+            \\
+            \\    exit();
+            \\}
+            \\
+            \\fn sub(a: u32, b: u32) void {
+            \\    if (a - b != 3) unreachable;
+            \\}
+            \\
+            \\fn exit() noreturn {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (231),
+            \\          [arg1] "{rdi}" (0)
+            \\        : "rcx", "r11", "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "",
+        );
+    }
+
+    {
+        var case = ctx.exe("assert function", linux_x64);
         case.addCompareOutput(
             \\export fn _start() noreturn {
             \\    add(3, 4);


### PR DESCRIPTION
This PR adds substraction support to stage2. Please let me know if there's any improvements I could make.
This is the first step to also support other semantics such as -=, -%, etc, I'd also like to remove the TODO's from analyzeInstSub. In that case we *should* be able to do the same for analyzeInstAdd. Also the testcase will succeed if we substract i.e. 8 from 7. So by adding the substraction support, we can work on adding integer overflow in both directions (add/sub).