### PR TITLE
Allow implicit casting of single pointers to unknown length pointers

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -11763,8 +11763,14 @@ static ConstCastOnly types_match_const_cast_only(IrAnalyze *ira, ZigType *wanted
             result.data.bad_ptr_sentinel->actual_type = actual_ptr_type;
             return result;
         }
-        bool ptr_lens_equal = actual_ptr_type->data.pointer.ptr_len == wanted_ptr_type->data.pointer.ptr_len;
-        if (!(ptr_lens_equal || wanted_is_c_ptr || actual_is_c_ptr)) {
+        bool ok_ptr_lens =
+            actual_ptr_type->data.pointer.ptr_len == wanted_ptr_type->data.pointer.ptr_len ||
+            (actual_ptr_type->data.pointer.ptr_len == PtrLenSingle &&
+                wanted_ptr_type->data.pointer.ptr_len == PtrLenUnknown) ||
+            wanted_is_c_ptr ||
+            actual_is_c_ptr;
+
+        if (!ok_ptr_lens) {
             result.id = ConstCastResultIdPtrLens;
             return result;
         }

--- a/test/stage1/behavior/cast.zig
+++ b/test/stage1/behavior/cast.zig
@@ -849,3 +849,16 @@ test "comptime float casts" {
     expect(b == 2);
     expect(@TypeOf(b) == comptime_int);
 }
+
+test "implicitly cast single-item pointer to pointer of unknown length" {
+    testCastSinglePtrToManyPtr();
+    comptime testCastSinglePtrToManyPtr();
+}
+
+fn testCastSinglePtrToManyPtr() void {
+    var a: u64 = 123666946355054;
+    const b: [*]u64 = &a;
+    expect(b[0] == 123666946355054);
+    b[0] = 12345;
+    expect(a == 12345);
+}


### PR DESCRIPTION
This pull request adds implicit conversion of single item pointers `*T` to multi-item pointers `[*]T`. My main motivation for this is Vulkan, where often times a pointer to a single item is passed where multiple can also be accepted, see the many casts required in [this example](https://github.com/Snektron/vulkan-zig/blob/master/examples/triangle.zig).

This is loosely related to #5516 and #3156, however, those issues argue for implicit conversion of `*T` to `[]T`. This change feels a little more natural to me, though.