### PR TITLE
Zig docs look tiny on mobile screens

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Documentation - The Zig Programming Language</title>
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAgklEQVR4AWMYWuD7EllJIM4G4g4g5oIJ/odhOJ8wToOxSTXgNxDHoeiBMfA4+wGShjyYOCkG/IGqWQziEzYAoUAeiF9D5U+DxEg14DRU7jWIT5IBIOdCxf+A+CQZAAoopEB7QJwBCBwHiip8UYmRdrAlDpIMgApwQZNnNii5Dq0MBgCxxycBnwEd+wAAAABJRU5ErkJggg=="/>
     <style>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7474,7 +7474,7 @@ export fn @"A function name that is a complete sentence."() void {}
       <p>
       When looking at the resulting object, you can see the symbol is used verbatim:
       </p>
-      <pre>00000000000001f0 T A function name that is a complete sentence.</pre>
+      <pre><code>00000000000001f0 T A function name that is a complete sentence.</code></pre>
       {#see_also|Exporting a C Library#}
       {#header_close#}
 


### PR DESCRIPTION
Currently, zig docs look like this on my mobile devices (Oneplus 8, Samsung S9)
<img src="https://user-images.githubusercontent.com/85740/88456716-a0222100-ce9d-11ea-80cf-dfe82083ebd8.png" alt="current" width="400"/>


Adding a simple viewport tag fixes these and makes them readable on my devices.
<img src="https://user-images.githubusercontent.com/85740/88456711-91d40500-ce9d-11ea-9274-3f21b12b30cc.png" alt="current" width="400"/>


