### PR TITLE
Allow environment variables in crossbuild files

### DIFF
--- a/src-self-hosted/libc_installation.zig
+++ b/src-self-hosted/libc_installation.zig
@@ -38,7 +38,7 @@ pub const LibCInstallation = struct {
         ZigIsTheCCompiler,
     };
 
-    fn envSubstitution(allocator: *Allocator, input: [:0]const u8, stderr: anytype) ![:0]u8 {
+    fn envSubstitution(allocator: *Allocator, input: []const u8, stderr: anytype) ![:0]u8 {
         var result = try ArrayList(u8).initCapacity(allocator, input.len + 1);
         errdefer result.deinit();
 
@@ -66,6 +66,8 @@ pub const LibCInstallation = struct {
                             },
                             error.OutOfMemory => |e| return e,
                         };
+
+                        defer allocator.free(value);
 
                         try result.appendSlice(value);
                         i += needle.len;
@@ -120,9 +122,7 @@ pub const LibCInstallation = struct {
                     if (value.len == 0) {
                         @field(self, field.name) = null;
                     } else {
-                        const valuez = try std.mem.dupeZ(allocator, u8, value);
-                        found_keys[i].allocated = try envSubstitution(allocator, valuez, stderr);
-                        allocator.free(valuez);
+                        found_keys[i].allocated = try envSubstitution(allocator, value, stderr);
                         @field(self, field.name) = found_keys[i].allocated;
                     }
                     break;


### PR DESCRIPTION
This PR closes https://github.com/ziglang/zig/issues/3332, requesting environment variables in Zig crossbuild files.

Given `arm64-android.txt`:
```
include_dir=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include
sys_include_dir=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include
static_crt_dir=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/lib/gcc/aarch64-linux-android/4.9.x/
crt_dir=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/21

msvc_lib_dir=
kernel32_lib_dir=
```

If your environment is not set-up correctly and you attempt to build:
```
$ zig build-exe --library c -target aarch64-linux-android --libc arm64-android.txt sample.zig
environment variable $ANDROID_NDK specified but not found
Unable to parse --libc text file: semantic analyze failed
```

Once you set the correct environment variables:
```
$ export ANDROID_NDK=/opt/android-ndk/
$ zig build-exe --library c -target aarch64-linux-android --libc arm64-android.txt sample.zig
$ echo $?
0
```