### PR TITLE
Fix parsing of `unsigned` in translate-c.

### DIFF
--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -4514,7 +4514,7 @@ const CtrlFlow = struct {
         const ltoken = try appendToken(c, kw, kw_text);
         const label_token = if (label) |l| blk: {
             _ = try appendToken(c, .Colon, ":");
-            break :blk try appendToken(c, .Identifier, l);
+            break :blk try appendIdentifier(c, l);
         } else null;
         return CtrlFlow{
             .c = c,

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2715,6 +2715,16 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const BAR = (@import("std").meta.cast(?*c_void, a));
     });
 
+    cases.add("macro with cast to unsigned short, long, and long long",
+        \\#define CURLAUTH_BASIC_BUT_USHORT ((unsigned short) 1)
+        \\#define CURLAUTH_BASIC ((unsigned long) 1)
+        \\#define CURLAUTH_BASIC_BUT_ULONGLONG ((unsigned long long) 1)
+    , &[_][]const u8{
+        \\pub const CURLAUTH_BASIC_BUT_USHORT = (@import("std").meta.cast(c_ushort, 1));
+        \\pub const CURLAUTH_BASIC = (@import("std").meta.cast(c_ulong, 1));
+        \\pub const CURLAUTH_BASIC_BUT_ULONGLONG = (@import("std").meta.cast(c_ulonglong, 1));
+    });
+
     cases.add("macro conditional operator",
         \\#define FOO a ? b : c
     , &[_][]const u8{


### PR DESCRIPTION
Previously, `unsigned` was parsed as the shorthand for `unsigned int`.
This commit introduces code to parse `unsigned short`, `unsigned int`,
`unsigned long`, and `unsigned long long`.

There is a comment in the code about std.c.parse` - I'm not
familiar with zig internals, but it seems like this is a separate
C parsing implementation. In the long run, it probably makes
sense to merge both implementations, so this commit should be
regarded as a quick fix that doesn't address an apparently
underlying issue.

Closes #5928.