### PR TITLE
new trait `hasUniqueRepresentation` and hashmap speedup

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -5,6 +5,7 @@ const testing = std.testing;
 const math = std.math;
 const mem = std.mem;
 const meta = std.meta;
+const trait = meta.trait;
 const autoHash = std.hash.autoHash;
 const Wyhash = std.hash.Wyhash;
 const Allocator = mem.Allocator;
@@ -1023,9 +1024,13 @@ pub fn getTrivialEqlFn(comptime K: type) (fn (K, K) bool) {
 pub fn getAutoHashFn(comptime K: type) (fn (K) u32) {
     return struct {
         fn hash(key: K) u32 {
-            var hasher = Wyhash.init(0);
-            autoHash(&hasher, key);
-            return @truncate(u32, hasher.final());
+            if (comptime trait.hasUniqueRepresentation(K)) {
+                return @truncate(u32, Wyhash.hash(0, std.mem.asBytes(&key)));
+            } else {
+                var hasher = Wyhash.init(0);
+                autoHash(&hasher, key);
+                return @truncate(u32, hasher.final());
+            }
         }
     }.hash;
 }

--- a/lib/std/meta/trait.zig
+++ b/lib/std/meta/trait.zig
@@ -416,3 +416,71 @@ test "std.meta.trait.hasFunctions" {
     testing.expect(!hasFunctions(TestStruct2, .{ "a", "b", "c" }));
     testing.expect(!hasFunctions(TestStruct2, tuple));
 }
+
+/// True if every value of the type `T` has a unique bit pattern representing it.
+/// In other words, `T` has no unused bits and no padding.
+pub fn hasUniqueRepresentation(comptime T: type) bool {
+    switch (@typeInfo(T)) {
+        else => return false, // TODO can we know if it's true for some of these types ?
+
+        .AnyFrame,
+        .Bool,
+        .BoundFn,
+        .Enum,
+        .ErrorSet,
+        .Fn,
+        .Int, // TODO check that it is still true
+        .Pointer,
+        => return true,
+
+        .Array => |info| return comptime hasUniqueRepresentation(info.child),
+
+        .Struct => |info| {
+            var sum_size = @as(usize, 0);
+
+            inline for (info.fields) |field| {
+                const FieldType = field.field_type;
+                if (comptime !hasUniqueRepresentation(FieldType)) return false;
+                sum_size += @sizeOf(FieldType);
+            }
+
+            return @sizeOf(T) == sum_size;
+        },
+
+        .Vector => |info| return comptime hasUniqueRepresentation(info.child),
+    }
+}
+
+test "std.meta.trait.hasUniqueRepresentation" {
+    const TestStruct1 = struct {
+        a: u32,
+        b: u32,
+    };
+
+    testing.expect(hasUniqueRepresentation(TestStruct1));
+
+    const TestStruct2 = struct {
+        a: u32,
+        b: u16,
+    };
+
+    testing.expect(!hasUniqueRepresentation(TestStruct2));
+
+    const TestStruct3 = struct {
+        a: u32,
+        b: u32,
+    };
+
+    testing.expect(hasUniqueRepresentation(TestStruct3));
+
+    testing.expect(hasUniqueRepresentation(i1));
+    testing.expect(hasUniqueRepresentation(u2));
+    testing.expect(hasUniqueRepresentation(i3));
+    testing.expect(hasUniqueRepresentation(u4));
+    testing.expect(hasUniqueRepresentation(i5));
+    testing.expect(hasUniqueRepresentation(u6));
+    testing.expect(hasUniqueRepresentation(i7));
+    testing.expect(hasUniqueRepresentation(u8));
+    testing.expect(hasUniqueRepresentation(i9));
+    testing.expect(hasUniqueRepresentation(u10));
+}


### PR DESCRIPTION
The streaming hash implementation is generic, but hostile to the optimizer. This PR adds a trait to know when types can be directly hashed bitwise. We can make use of it to call into the stateless hash API that will be more likely to get inlined.

Tested on gotta-go-fast hashmap benchmark

#### Before
`{"samples_taken":39,"wall_time":{"median":259705600,"mean":259773118,"min":258346000,"max":262405900}}`

#### After
`{"samples_taken":46,"wall_time":{"median":220910400,"mean":221236613,"min":219978800,"max":224671900}}`

So we get a ~1.18x speedup on my machine just by inlining the hash function.