### PR TITLE
Replace DeviceIoControl with FsControlFile

### DIFF
--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -54,6 +54,18 @@ pub extern "NtDll" fn NtDeviceIoControlFile(
     OutputBuffer: ?PVOID,
     OutputBufferLength: ULONG,
 ) callconv(.Stdcall) NTSTATUS;
+pub extern "NtDll" fn NtFsControlFile(
+    FileHandle: HANDLE,
+    Event: ?HANDLE,
+    ApcRoutine: ?IO_APC_ROUTINE,
+    ApcContext: ?*c_void,
+    IoStatusBlock: *IO_STATUS_BLOCK,
+    FsControlCode: ULONG,
+    InputBuffer: ?*const c_void,
+    InputBufferLength: ULONG,
+    OutputBuffer: ?PVOID,
+    OutputBufferLength: ULONG,
+) callconv(.Stdcall) NTSTATUS;
 pub extern "NtDll" fn NtClose(Handle: HANDLE) callconv(.Stdcall) NTSTATUS;
 pub extern "NtDll" fn RtlDosPathNameToNtPathName_U(
     DosPathName: [*:0]const u16,


### PR DESCRIPTION
This commit replaces `windows.DeviceIoControl` with `windows.FsControlFile` which is a wrapper around the NT-based syscall `ntdll.NtFsControlFile`.

Note I haven't exposed *all* arguments in the wrapper `windows.FsControlFile` as so far I cannot find a use for all of them such as `ApcRoutine` or `ApcContext`. However, this is not to say it might not be reasonable to do just that in the future though!

EDIT: I should also mention that thanks to `windows.FsControlFile` we no longer need to rely on `kernel32.DeviceIoControl` in `windows.ReadLink` and `windows.CreateSymolicLink`. In essence, this brings us closer to #1840.