### PR TITLE
std.elf: Fix read functions for 32-bit targets

### DIFF
--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -538,7 +538,7 @@ pub fn int32(need_bswap: bool, int_32: anytype, comptime Int64: anytype) Int64 {
 }
 
 fn preadNoEof(file: std.fs.File, buf: []u8, offset: u64) !void {
-    var i: u64 = 0;
+    var i: usize = 0;
     while (i < buf.len) {
         const len = file.pread(buf[i .. buf.len - i], offset + i) catch |err| switch (err) {
             error.SystemResources => return error.SystemResources,


### PR DESCRIPTION
The buffer index was declared as `u64`, which overflows `usize` on a 32-bit target.

The following example program failed to compile for 32-bit targets:

```zig
const std = @import("std");

pub fn main() !void {
    const alloc = std.testing.allocator;
    const file = std.io.getStdIn();
    _ = try std.elf.readAllHeaders(alloc, file);
}
```

```
lib/zig/std/elf.zig:543:36: error: expected type 'usize', found 'u64'
        const len = file.pread(buf[i .. buf.len - i], offset + i) catch |err| switch (err) {
                                   ^
lib/zig/std/elf.zig:543:36: note: unsigned 32-bit int cannot represent all possible unsigned 64-bit values
        const len = file.pread(buf[i .. buf.len - i], offset + i) catch |err| switch (err) {
                                   ^
lib/zig/std/elf.zig:543:35: note: referenced here
        const len = file.pread(buf[i .. buf.len - i], offset + i) catch |err| switch (err) {
                                  ^
lib/zig/std/elf.zig:348:5: note: referenced here
    try preadNoEof(file, &hdr_buf, 0);
    ^
lib/zig/std/elf.zig:392:19: note: referenced here
        .header = try readHeader(file),
```