### PR TITLE
stage2: remove operand from return instruction

### DIFF
--- a/src-self-hosted/Module.zig
+++ b/src-self-hosted/Module.zig
@@ -1240,7 +1240,7 @@ fn astGenAndAnalyzeDecl(self: *Module, decl: *Decl) !bool {
                 .return_type = return_type_inst,
                 .param_types = param_types,
             }, .{});
-            _ = try astgen.addZIRUnOp(self, &fn_type_scope.base, fn_src, .@"return", fn_type_inst);
+            _ = try astgen.addZIRUnOp(self, &fn_type_scope.base, fn_src, .ret_value, fn_type_inst);
 
             // We need the memory for the Type to go into the arena for the Decl
             var decl_arena = std.heap.ArenaAllocator.init(self.gpa);
@@ -1309,7 +1309,7 @@ fn astGenAndAnalyzeDecl(self: *Module, decl: *Decl) !bool {
                     !gen_scope.instructions.items[gen_scope.instructions.items.len - 1].tag.isNoReturn()))
                 {
                     const src = tree.token_locs[body_block.rbrace].start;
-                    _ = try astgen.addZIRNoOp(self, &gen_scope.base, src, .returnvoid);
+                    _ = try astgen.addZIRNoOp(self, &gen_scope.base, src, .@"return");
                 }
 
                 const fn_zir = try gen_scope_arena.allocator.create(Fn.ZIR);

--- a/src-self-hosted/astgen.zig
+++ b/src-self-hosted/astgen.zig
@@ -457,18 +457,10 @@ fn ret(mod: *Module, scope: *Scope, cfe: *ast.Node.ControlFlowExpression) InnerE
     const tree = scope.tree();
     const src = tree.token_locs[cfe.ltoken].start;
     if (cfe.getRHS()) |rhs_node| {
-        if (nodeMayNeedMemoryLocation(rhs_node)) {
-            const ret_ptr = try addZIRNoOp(mod, scope, src, .ret_ptr);
-            const operand = try expr(mod, scope, .{ .ptr = ret_ptr }, rhs_node);
-            return addZIRUnOp(mod, scope, src, .@"return", operand);
-        } else {
-            const fn_ret_ty = try addZIRNoOp(mod, scope, src, .ret_type);
-            const operand = try expr(mod, scope, .{ .ty = fn_ret_ty }, rhs_node);
-            return addZIRUnOp(mod, scope, src, .@"return", operand);
-        }
-    } else {
-        return addZIRNoOp(mod, scope, src, .returnvoid);
+        const result = try expr(mod, scope, .none, rhs_node);
+        _ = try addZIRUnOp(mod, scope, src, .ret_value, result);
     }
+    return addZIRNoOp(mod, scope, src, .@"return");
 }
 
 fn identifier(mod: *Module, scope: *Scope, rl: ResultLoc, ident: *ast.Node.OneToken) InnerError!*zir.Inst {

--- a/src-self-hosted/codegen/c.zig
+++ b/src-self-hosted/codegen/c.zig
@@ -94,8 +94,7 @@ fn genFn(file: *C, decl: *Decl) !void {
             switch (inst.tag) {
                 .assembly => try genAsm(file, inst.castTag(.assembly).?, decl),
                 .call => try genCall(file, inst.castTag(.call).?, decl),
-                .ret => try genRet(file, inst.castTag(.ret).?, decl, tv.ty.fnReturnType()),
-                .retvoid => try file.main.writer().print("return;", .{}),
+                .ret => try file.main.writer().print("return;", .{}),
                 else => |e| return file.fail(decl.src(), "TODO implement C codegen for {}", .{e}),
             }
         }
@@ -103,10 +102,6 @@ fn genFn(file: *C, decl: *Decl) !void {
     }
 
     try writer.writeAll("}\n\n");
-}
-
-fn genRet(file: *C, inst: *Inst.UnOp, decl: *Decl, expected_return_type: Type) !void {
-    return file.fail(decl.src(), "TODO return {}", .{expected_return_type});
 }
 
 fn genCall(file: *C, inst: *Inst.Call, decl: *Decl) !void {

--- a/src-self-hosted/ir.zig
+++ b/src-self-hosted/ir.zig
@@ -72,7 +72,7 @@ pub const Inst = struct {
         ptrtoint,
         ref,
         ret,
-        retvoid,
+        ret_value,
         /// Write a value to a pointer. LHS is pointer, RHS is value.
         store,
         sub,
@@ -84,14 +84,13 @@ pub const Inst = struct {
         pub fn Type(tag: Tag) type {
             return switch (tag) {
                 .alloc,
-                .retvoid,
                 .unreach,
                 .arg,
                 .breakpoint,
+                .ret,
                 => NoOp,
 
                 .ref,
-                .ret,
                 .bitcast,
                 .not,
                 .isnonnull,
@@ -100,6 +99,7 @@ pub const Inst = struct {
                 .floatcast,
                 .intcast,
                 .load,
+                .ret_value,
                 => UnOp,
 
                 .add,

--- a/test/stage2/zir.zig
+++ b/test/stage2/zir.zig
@@ -17,7 +17,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\@11 = export(@9, "entry")
         \\
         \\@entry = fn(@fnty, {
-        \\  %11 = returnvoid()
+        \\  %11 = return()
         \\})
     ,
         \\@void = primitive(void)
@@ -28,7 +28,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\@unnamed$5 = export(@unnamed$4, "entry")
         \\@unnamed$6 = fntype([], @void, cc=C)
         \\@entry = fn(@unnamed$6, {
-        \\  %0 = returnvoid()
+        \\  %0 = return()
         \\})
         \\
     );
@@ -58,7 +58,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\  %expected = int(69)
         \\  %ok = cmp_eq(%result, %expected)
         \\  %10 = condbr(%ok, {
-        \\    %11 = returnvoid()
+        \\    %11 = return()
         \\  }, {
         \\    %12 = breakpoint()
         \\  })
@@ -75,7 +75,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\@3 = int(3)
         \\@unnamed$6 = fntype([], @void, cc=C)
         \\@entry = fn(@unnamed$6, {
-        \\  %0 = returnvoid()
+        \\  %0 = return()
         \\})
         \\@entry__anon_1 = str("2\x08\x01\n")
         \\@9 = declref("9__anon_0")
@@ -96,17 +96,17 @@ pub fn addCases(ctx: *TestContext) !void {
             \\
             \\@entry = fn(@fnty, {
             \\  %0 = call(@a, [])
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
             \\
             \\@a = fn(@fnty, {
             \\  %0 = call(@b, [])
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
             \\
             \\@b = fn(@fnty, {
             \\  %0 = call(@a, [])
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
         ,
             \\@void = primitive(void)
@@ -118,17 +118,17 @@ pub fn addCases(ctx: *TestContext) !void {
             \\@unnamed$6 = fntype([], @void, cc=C)
             \\@entry = fn(@unnamed$6, {
             \\  %0 = call(@a, [], modifier=auto)
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
             \\@unnamed$8 = fntype([], @void, cc=C)
             \\@a = fn(@unnamed$8, {
             \\  %0 = call(@b, [], modifier=auto)
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
             \\@unnamed$10 = fntype([], @void, cc=C)
             \\@b = fn(@unnamed$10, {
             \\  %0 = call(@a, [], modifier=auto)
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
             \\
         );
@@ -142,18 +142,18 @@ pub fn addCases(ctx: *TestContext) !void {
             \\
             \\@entry = fn(@fnty, {
             \\  %0 = call(@a, [])
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
             \\
             \\@a = fn(@fnty, {
             \\  %0 = call(@b, [])
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
             \\
             \\@b = fn(@fnty, {
             \\  %9 = compileerror("message")
             \\  %0 = call(@a, [])
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
         ,
             &[_][]const u8{
@@ -171,18 +171,18 @@ pub fn addCases(ctx: *TestContext) !void {
             \\@11 = export(@9, "entry")
             \\
             \\@entry = fn(@fnty, {
-            \\  %0 = returnvoid()
+            \\  %0 = return()
             \\})
             \\
             \\@a = fn(@fnty, {
             \\  %0 = call(@b, [])
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
             \\
             \\@b = fn(@fnty, {
             \\  %9 = compileerror("message")
             \\  %0 = call(@a, [])
-            \\  %1 = returnvoid()
+            \\  %1 = return()
             \\})
         ,
             \\@void = primitive(void)
@@ -193,7 +193,7 @@ pub fn addCases(ctx: *TestContext) !void {
             \\@unnamed$5 = export(@unnamed$4, "entry")
             \\@unnamed$6 = fntype([], @void, cc=C)
             \\@entry = fn(@unnamed$6, {
-            \\  %0 = returnvoid()
+            \\  %0 = return()
             \\})
             \\
         );


### PR DESCRIPTION
Removing the operand from the return instruction has multiple benefits:
* more accurately models machine code
* removes separate handling of less than pointer sized values
* makes it easier to generate defers without code duplication (#283)