### PR TITLE
Print } as format argument in enum build option

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1710,7 +1710,7 @@ pub const LibExeObjStep = struct {
                 inline for (enum_info.fields) |field| {
                     out.print("    {},\n", .{field.name}) catch unreachable;
                 }
-                out.print("}};\n", .{}) catch unreachable;
+                out.print("{};\n", .{"}"}) catch unreachable;
             },
             else => {},
         }

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1710,7 +1710,7 @@ pub const LibExeObjStep = struct {
                 inline for (enum_info.fields) |field| {
                     out.print("    {},\n", .{field.name}) catch unreachable;
                 }
-                out.print("{};\n", .{"}"}) catch unreachable;
+                out.writeAll("};\n") catch unreachable;
             },
             else => {},
         }


### PR DESCRIPTION
Since 11d38a7e5 an escaped '}' isn't printed properly because the codepath is fast tracked to `writeAll` if there are no format arguments. This patch fixes generating an escaped '}' for enum build options.