### PR TITLE
Sanitizers

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1695,7 +1695,7 @@ else
     runtime_safety and have_segfault_handling_support;
 
 pub fn maybeEnableSegfaultHandler() void {
-    if (enable_segfault_handler) {
+    if (enable_segfault_handler and !builtin.sanitized) {
         std.debug.attachSegfaultHandler();
     }
 }

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2023,6 +2023,11 @@ enum WantCSanitize {
     WantCSanitizeEnabled,
 };
 
+enum WantSanitize {
+    WantSanitizeDisabled,
+    WantSanitizeEnabled,
+};
+
 enum OptionalBool {
     OptionalBoolNull,
     OptionalBoolFalse,
@@ -2209,6 +2214,7 @@ struct CodeGen {
     WantPIC want_pic;
     WantStackCheck want_stack_check;
     WantCSanitize want_sanitize_c;
+    WantSanitize want_sanitize;
     CacheHash cache_hash;
     ErrColor err_color;
     uint32_t next_unresolved_index;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5,6 +5,7 @@
  * See http://opensource.org/licenses/MIT
  */
 
+#include "all_types.hpp"
 #include "analyze.hpp"
 #include "ast_render.hpp"
 #include "codegen.hpp"
@@ -8337,7 +8338,7 @@ static void zig_llvm_emit_output(CodeGen *g) {
     // pipeline multiple times if this is requested.
     if (asm_filename != nullptr && bin_filename != nullptr) {
         if (ZigLLVMTargetMachineEmitToFile(g->target_machine, g->module, &err_msg, g->build_mode == BuildModeDebug,
-            is_small, g->enable_time_report, nullptr, bin_filename, llvm_ir_filename))
+            is_small, g->want_sanitize == WantSanitizeEnabled, g->enable_time_report, nullptr, bin_filename, llvm_ir_filename))
         {
             fprintf(stderr, "LLVM failed to emit file: %s\n", err_msg);
             exit(1);
@@ -8347,7 +8348,7 @@ static void zig_llvm_emit_output(CodeGen *g) {
     }
 
     if (ZigLLVMTargetMachineEmitToFile(g->target_machine, g->module, &err_msg, g->build_mode == BuildModeDebug,
-        is_small, g->enable_time_report, asm_filename, bin_filename, llvm_ir_filename))
+        is_small, g->want_sanitize == WantSanitizeEnabled, g->enable_time_report, asm_filename, bin_filename, llvm_ir_filename))
     {
         fprintf(stderr, "LLVM failed to emit file: %s\n", err_msg);
         exit(1);
@@ -9024,6 +9025,7 @@ Buf *codegen_generate_builtin_source(CodeGen *g) {
     }
     buf_appendf(contents, "pub const object_format = ObjectFormat.%s;\n", cur_obj_fmt);
     buf_appendf(contents, "pub const mode = %s;\n", build_mode_to_str(g->build_mode));
+    buf_appendf(contents, "pub const sanitized = %s;\n", bool_to_str(g->want_sanitize == WantSanitizeEnabled));
     buf_appendf(contents, "pub const link_libc = %s;\n", bool_to_str(g->libc_link_lib != nullptr));
     buf_appendf(contents, "pub const link_libcpp = %s;\n", bool_to_str(g->libcpp_link_lib != nullptr));
     buf_appendf(contents, "pub const have_error_return_tracing = %s;\n", bool_to_str(g->have_err_ret_tracing));

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -2066,6 +2066,10 @@ static void construct_linker_job_elf(LinkJob *lj) {
         }
     }
 
+    if (g->want_sanitize) {
+        lj->args.append("/usr/lib/clang/10.0.0/lib/linux/libclang_rt.asan-x86_64.a");
+    }
+
     // crt end
     if (lj->link_in_crt) {
         if (target_is_android(g->zig_target)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,7 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  -fno-stack-check             disable stack probing in safe builds\n"
         "  -fsanitize-c                 enable C undefined behavior detection in unsafe builds\n"
         "  -fno-sanitize-c              disable C undefined behavior detection in safe builds\n"
+        "  --sanitize                   enable ASan\n"
         "  --emit [asm|bin|llvm-ir]     (deprecated) emit a specific file format as compilation output\n"
         "  -fPIC                        enable Position Independent Code\n"
         "  -fno-PIC                     disable Position Independent Code\n"
@@ -442,6 +443,7 @@ static int main0(int argc, char **argv) {
     WantPIC want_pic = WantPICAuto;
     WantStackCheck want_stack_check = WantStackCheckAuto;
     WantCSanitize want_sanitize_c = WantCSanitizeAuto;
+    WantSanitize want_sanitize = WantSanitizeDisabled;
     bool function_sections = false;
     const char *mcpu = nullptr;
     CodeModel code_model = CodeModelDefault;
@@ -1012,6 +1014,8 @@ static int main0(int argc, char **argv) {
                 want_sanitize_c = WantCSanitizeEnabled;
             } else if (strcmp(arg, "-fno-sanitize-c") == 0) {
                 want_sanitize_c = WantCSanitizeDisabled;
+            } else if (strcmp(arg, "--sanitize") == 0) {
+                want_sanitize = WantSanitizeEnabled;
             } else if (strcmp(arg, "--system-linker-hack") == 0) {
                 system_linker_hack = true;
             } else if (strcmp(arg, "--single-threaded") == 0) {
@@ -1576,6 +1580,7 @@ static int main0(int argc, char **argv) {
             g->want_pic = want_pic;
             g->want_stack_check = want_stack_check;
             g->want_sanitize_c = want_sanitize_c;
+            g->want_sanitize = want_sanitize;
             g->subsystem = subsystem;
 
             g->enable_time_report = timing_info;

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -48,7 +48,7 @@ ZIG_EXTERN_C char *ZigLLVMGetNativeFeatures(void);
 
 ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
         char **error_message, bool is_debug,
-        bool is_small, bool time_report,
+        bool is_small, bool sanitize, bool time_report,
         const char *asm_filename, const char *bin_filename, const char *llvm_ir_filename);
 
 


### PR DESCRIPTION
This PR is a draft. Looking to add first-class support for sanitizers in Zig.

- [x] ASan
- [ ] MSan
- [ ] LSan
- [ ] TSan
- [ ] Platform detection for Zig sanitizers
	- Automatically detect the ASan `compiler_rt`
- [ ] Allow multiple sanitizers to be selected and ensure there are no conflicts
- [ ] Error if not linking against `libc`

The game plan is to have end-users build their software with, e.g.: `--sanitizers=address`, etc. and get all the features that ASan and friends provide.

After this PR, I'd like to add libFuzzer as a first-class citizen in Zig, allowing users to easily write fuzz-tests for their programs, as well as fuzz-test the Zig `std`.

---

Here's the current progress:

```zig
const std = @import("std");
const c = @cImport({
    @cInclude("stdlib.h");
});

pub fn main() !void {
    const allocator = std.heap.c_allocator;
    var data = c.malloc(100);
    _ = try allocator.dupeZ(u8, "Hello, world");
}
```

This is a leaky program. It uses `malloc` both directly and indirectly, and does not free the result. This is compiled with `zig build-exe --library c --sanitize sample.zig`, and the program output is as follows:

```
$ ./sample

=================================================================
==385335==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 100 byte(s) in 1 object(s) allocated from:
    #0 0x30cf19 in malloc (/sample+0x30cf19)
    #1 0x23a8c5 in main.0 /sample.zig:8:24
    #2 0x23ada1 in std.start.callMain /zig/lib/std/start.zig:252:37
    #3 0x23ada1 in std.start.initEventLoopAndCallMain /zig/lib/std/start.zig:225:12
    #4 0x23ada1 in std.start.callMainWithArgs /zig/lib/std/start.zig:188:36
    #5 0x23ada1 in main /zig/lib/std/start.zig:195:12
    #6 0x7fe0a029f001 in __libc_start_main (/usr/lib/libc.so.6+0x27001)

Direct leak of 13 byte(s) in 1 object(s) allocated from:
    #0 0x30cf19 in malloc (/sample+0x30cf19)
    #1 0x239bac in std.heap.cAlloc /zig/lib/std/heap.zig:41:41
    #2 0x250b28 in std.mem.Allocator.callAllocFn /zig/lib/std/mem.zig:45:28
    #3 0x23d4ed in std.mem.Allocator.allocAdvanced /zig/lib/std/mem.zig:252:48
    #4 0x23bdf2 in std.mem.Allocator.alignedAlloc /zig/lib/std/mem.zig:226:34
    #5 0x23bcff in std.mem.Allocator.alloc /zig/lib/std/mem.zig:176:33
    #6 0x23aa91 in std.mem.Allocator.dupeZ /zig/lib/std/mem.zig:390:44
    #7 0x23a8e4 in main.0 /sample.zig:9:28
    #8 0x23ada1 in std.start.callMain /zig/lib/std/start.zig:252:37
    #9 0x23ada1 in std.start.initEventLoopAndCallMain /zig/lib/std/start.zig:225:12
    #10 0x23ada1 in std.start.callMainWithArgs /zig/lib/std/start.zig:188:36
    #11 0x23ada1 in main /zig/lib/std/start.zig:195:12
    #12 0x7fe0a029f001 in __libc_start_main (/usr/lib/libc.so.6+0x27001)

SUMMARY: AddressSanitizer: 113 byte(s) leaked in 2 allocation(s).
```