### PR TITLE
Refactor out file and dir creation routines in Windows

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -480,25 +480,20 @@ pub const ChildProcess = struct {
 
         const any_ignore = (self.stdin_behavior == StdIo.Ignore or self.stdout_behavior == StdIo.Ignore or self.stderr_behavior == StdIo.Ignore);
 
-        // TODO use CreateFileW here since we are using a string literal for the path
         const nul_handle = if (any_ignore)
-            windows.CreateFile(
-                "NUL",
-                windows.GENERIC_READ,
-                windows.FILE_SHARE_READ,
-                null,
-                windows.OPEN_EXISTING,
-                windows.FILE_ATTRIBUTE_NORMAL,
-                null,
-            ) catch |err| switch (err) {
-                error.SharingViolation => unreachable, // not possible for "NUL"
+            windows.OpenFile(&[_]u16{ 'N', 'U', 'L' }, .{
+                .dir = std.fs.cwd().fd,
+                .access_mask = windows.GENERIC_READ,
+                .share_access = windows.FILE_SHARE_READ,
+                .creation = windows.OPEN_EXISTING,
+                .io_mode = .blocking,
+            }) catch |err| switch (err) {
                 error.PathAlreadyExists => unreachable, // not possible for "NUL"
                 error.PipeBusy => unreachable, // not possible for "NUL"
-                error.InvalidUtf8 => unreachable, // not possible for "NUL"
-                error.BadPathName => unreachable, // not possible for "NUL"
                 error.FileNotFound => unreachable, // not possible for "NUL"
                 error.AccessDenied => unreachable, // not possible for "NUL"
                 error.NameTooLong => unreachable, // not possible for "NUL"
+                error.WouldBlock => unreachable, // not possible for "NUL"
                 else => |e| return e,
             }
         else

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -484,7 +484,7 @@ pub const ChildProcess = struct {
         const nul_handle = if (any_ignore)
             windows.OpenFile(&[_]u16{ 'N', 'U', 'L' }, .{
                 .dir = std.fs.cwd().fd,
-                .access_mask = windows.GENERIC_READ,
+                .access_mask = windows.GENERIC_READ | windows.SYNCHRONIZE,
                 .share_access = windows.FILE_SHARE_READ,
                 .creation = windows.OPEN_EXISTING,
                 .io_mode = .blocking,

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -364,6 +364,7 @@ pub const ChildProcess = struct {
                 error.FileTooBig => unreachable,
                 error.DeviceBusy => unreachable,
                 error.FileLocksNotSupported => unreachable,
+                error.BadPathName => unreachable, // Windows-only
                 else => |e| return e,
             }
         else

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -225,8 +225,7 @@ pub fn makeDirAbsoluteZ(absolute_path_z: [*:0]const u8) !void {
 /// Same as `makeDirAbsolute` except the parameter is a null-terminated WTF-16 encoded string.
 pub fn makeDirAbsoluteW(absolute_path_w: [*:0]const u16) !void {
     assert(path.isAbsoluteWindowsW(absolute_path_w));
-    const handle = try os.windows.CreateDirectoryW(null, absolute_path_w, null);
-    os.windows.CloseHandle(handle);
+    return os.mkdirW(absolute_path_w, default_new_dir_mode);
 }
 
 pub const deleteDir = @compileError("deprecated; use dir.deleteDir or deleteDirAbsolute");
@@ -881,8 +880,7 @@ pub const Dir = struct {
     }
 
     pub fn makeDirW(self: Dir, sub_path: [*:0]const u16) !void {
-        const handle = try os.windows.CreateDirectoryW(self.fd, sub_path, null);
-        os.windows.CloseHandle(handle);
+        try os.mkdiratW(self.fd, sub_path, default_new_dir_mode);
     }
 
     /// Calls makeDir recursively to make an entire path. Returns success if the path

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -47,7 +47,20 @@ pub const File = struct {
         else => 0o666,
     };
 
-    pub const OpenError = windows.CreateFileError || os.OpenError || os.FlockError;
+    pub const OpenError = error{
+        SharingViolation,
+        PathAlreadyExists,
+        FileNotFound,
+        AccessDenied,
+        PipeBusy,
+        NameTooLong,
+        /// On Windows, file paths must be valid Unicode.
+        InvalidUtf8,
+        /// On Windows, file paths cannot contain these characters:
+        /// '/', '*', '?', '"', '<', '>', '|'
+        BadPathName,
+        Unexpected,
+    } || os.OpenError || os.FlockError;
 
     pub const Lock = enum { None, Shared, Exclusive };
 

--- a/lib/std/fs/watch.zig
+++ b/lib/std/fs/watch.zig
@@ -379,7 +379,7 @@ pub fn Watch(comptime V: type) type {
                 .access_mask = windows.FILE_LIST_DIRECTORY,
                 .creation = windows.FILE_OPEN,
                 .io_mode = .blocking,
-                .expect_dir = true,
+                .open_dir = true,
             });
             var dir_handle_consumed = false;
             defer if (!dir_handle_consumed) windows.CloseHandle(dir_handle);

--- a/lib/std/fs/watch.zig
+++ b/lib/std/fs/watch.zig
@@ -374,15 +374,13 @@ pub fn Watch(comptime V: type) type {
             defer if (!basename_utf16le_null_consumed) self.allocator.free(basename_utf16le_null);
             const basename_utf16le_no_null = basename_utf16le_null[0 .. basename_utf16le_null.len - 1];
 
-            const dir_handle = try windows.CreateFileW(
-                dirname_utf16le.ptr,
-                windows.FILE_LIST_DIRECTORY,
-                windows.FILE_SHARE_READ | windows.FILE_SHARE_DELETE | windows.FILE_SHARE_WRITE,
-                null,
-                windows.OPEN_EXISTING,
-                windows.FILE_FLAG_BACKUP_SEMANTICS | windows.FILE_FLAG_OVERLAPPED,
-                null,
-            );
+            const dir_handle = try windows.OpenFile(dirname_utf16le, .{
+                .dir = std.fs.cwd().fd,
+                .access_mask = windows.FILE_LIST_DIRECTORY,
+                .creation = windows.FILE_OPEN,
+                .io_mode = .blocking,
+                .expect_dir = true,
+            });
             var dir_handle_consumed = false;
             defer if (!dir_handle_consumed) windows.CloseHandle(dir_handle);
 

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2233,7 +2233,7 @@ pub fn mkdirZ(dir_path: [*:0]const u8, mode: u32) MakeDirError!void {
     }
 }
 
-/// Windows-only. Same as `mkdir` but the parameters is null-terminated, WTF16 encoded.
+/// Windows-only. Same as `mkdir` but the parameters is  WTF16 encoded.
 pub fn mkdirW(dir_path_w: []const u16, mode: u32) MakeDirError!void {
     const sub_dir_handle = windows.OpenFile(dir_path_w, .{
         .dir = std.fs.cwd().fd,
@@ -2304,7 +2304,7 @@ pub fn rmdirZ(dir_path: [*:0]const u8) DeleteDirError!void {
     }
 }
 
-/// Windows-only. Same as `rmdir` except the parameter is null-terminated, WTF16 encoded.
+/// Windows-only. Same as `rmdir` except the parameter is WTF16 encoded.
 pub fn rmdirW(dir_path_w: []const u16) DeleteDirError!void {
     return windows.DeleteFile(dir_path_w, .{ .dir = std.fs.cwd().fd, .remove_dir = true }) catch |err| switch (err) {
         error.IsDir => unreachable,
@@ -2411,7 +2411,7 @@ pub fn readlink(file_path: []const u8, out_buffer: []u8) ReadLinkError![]u8 {
 
 pub const readlinkC = @compileError("deprecated: renamed to readlinkZ");
 
-/// Windows-only. Same as `readlink` except `file_path` is null-terminated, WTF16 encoded.
+/// Windows-only. Same as `readlink` except `file_path` is WTF16 encoded.
 /// See also `readlinkZ`.
 pub fn readlinkW(file_path: []const u16, out_buffer: []u8) ReadLinkError![]u8 {
     return windows.ReadLink(std.fs.cwd().fd, file_path, out_buffer);
@@ -4059,8 +4059,8 @@ pub fn realpathZ(pathname: [*:0]const u8, out_buffer: *[MAX_PATH_BYTES]u8) RealP
     return mem.spanZ(result_path);
 }
 
-/// Same as `realpath` except `pathname` is null-terminated and UTF16LE-encoded.
-/// TODO use ntdll for better semantics
+/// Same as `realpath` except `pathname` is UTF16LE-encoded.
+/// TODO use ntdll to emulate `GetFinalPathNameByHandleW` routine
 pub fn realpathW(pathname: []const u16, out_buffer: *[MAX_PATH_BYTES]u8) RealPathError![]u8 {
     const w = windows;
 

--- a/lib/std/os/bits/windows.zig
+++ b/lib/std/os/bits/windows.zig
@@ -237,3 +237,28 @@ pub const IPPROTO_TCP = ws2_32.IPPROTO_TCP;
 pub const IPPROTO_UDP = ws2_32.IPPROTO_UDP;
 pub const IPPROTO_ICMPV6 = ws2_32.IPPROTO_ICMPV6;
 pub const IPPROTO_RM = ws2_32.IPPROTO_RM;
+
+pub const O_RDONLY = 0o0;
+pub const O_WRONLY = 0o1;
+pub const O_RDWR = 0o2;
+
+pub const O_CREAT = 0o100;
+pub const O_EXCL = 0o200;
+pub const O_NOCTTY = 0o400;
+pub const O_TRUNC = 0o1000;
+pub const O_APPEND = 0o2000;
+pub const O_NONBLOCK = 0o4000;
+pub const O_DSYNC = 0o10000;
+pub const O_SYNC = 0o4010000;
+pub const O_RSYNC = 0o4010000;
+pub const O_DIRECTORY = 0o200000;
+pub const O_NOFOLLOW = 0o400000;
+pub const O_CLOEXEC = 0o2000000;
+
+pub const O_ASYNC = 0o20000;
+pub const O_DIRECT = 0o40000;
+pub const O_LARGEFILE = 0;
+pub const O_NOATIME = 0o1000000;
+pub const O_PATH = 0o10000000;
+pub const O_TMPFILE = 0o20200000;
+pub const O_NDELAY = O_NONBLOCK;

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -27,7 +27,7 @@ test "symlink with relative paths" {
     try cwd.writeFile("file.txt", "nonsense");
 
     if (builtin.os.tag == .windows) {
-        try os.windows.CreateSymbolicLink(cwd.fd, "symlinked", "file.txt", false);
+        try os.windows.CreateSymbolicLink(cwd.fd, &[_]u16{ 's', 'y', 'm', 'l', 'i', 'n', 'k', 'e', 'd' }, &[_]u16{ 'f', 'i', 'l', 'e', '.', 't', 'x', 't' }, false);
     } else {
         try os.symlink("file.txt", "symlinked");
     }
@@ -85,7 +85,7 @@ test "readlinkat" {
 
     // create a symbolic link
     if (builtin.os.tag == .windows) {
-        try os.windows.CreateSymbolicLink(tmp.dir.fd, "link", "file.txt", false);
+        try os.windows.CreateSymbolicLink(tmp.dir.fd, &[_]u16{ 'l', 'i', 'n', 'k' }, &[_]u16{ 'f', 'i', 'l', 'e', '.', 't', 'x', 't' }, false);
     } else {
         try os.symlinkat("file.txt", tmp.dir.fd, "link");
     }

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -27,6 +27,7 @@ pub const self_process_handle = @intToPtr(HANDLE, maxInt(usize));
 
 pub const OpenError = error{
     IsDir,
+    NotDir,
     FileNotFound,
     NoDevice,
     AccessDenied,
@@ -125,7 +126,8 @@ pub fn OpenFile(sub_path_w: []const u16, options: OpenFileOptions) OpenError!HAN
             .PIPE_BUSY => return error.PipeBusy,
             .OBJECT_PATH_SYNTAX_BAD => unreachable,
             .OBJECT_NAME_COLLISION => return error.PathAlreadyExists,
-            .FILE_IS_A_DIRECTORY => if (options.open_dir) unreachable else return error.IsDir,
+            .FILE_IS_A_DIRECTORY => return error.IsDir,
+            .NOT_A_DIRECTORY => return error.NotDir,
             else => return unexpectedStatus(rc),
         }
     }
@@ -609,6 +611,7 @@ pub fn CreateSymbolicLink(
         .open_dir = is_directory,
     }) catch |err| switch (err) {
         error.IsDir => return error.PathAlreadyExists,
+        error.NotDir => unreachable,
         error.WouldBlock => unreachable,
         error.PipeBusy => unreachable,
         else => |e| return e,


### PR DESCRIPTION
This PR is yet another refactoring effort towards #1840. Here's the summary of changes:
* replace any use of kernel32 syscalls: `CreateDirectoryW`, `CreateFileW`, `DeleteFileW`, `RemoveDirectoryW`, with NT `NtCreateFile`
* extend `std.os.windows.OpenFile` to opening and creating directories *and* reparse points - behaves closer to POSIX's `openat` syscall this way, although I'm unsure whether I've not pushed its genericness a little too far so will welcome any and all feedback here
* add `std.os.windows.DeleteFile` based around the NT's `NtCreateFile` for deleting files, directories, and reparse points - this moves the implementation from `std.os.unlinkat` into `std.os.windows.DeleteFile` which can then be reused in multiple other settings
* unify signatures of `std.os.windows.OpenFile`, `std.os.windows.CreateSymbolicLink`, `std.os.windows.ReadLink`, and `std.os.windows.DeleteFile` into accepting `[]const u16` rather than `[*:0]const u16` - this was already the case for `OpenFile` so it made sense to unify the interface for the remaining functions
* implement preliminary (very much incomplete in their functionality) versions of `std.os.openW` and `std.os.openatW`
* add smoke tests for `std.os.open` and `std.os.openat`