### PR TITLE
elf: Iterate over headers w/o need for allocator

### DIFF
--- a/lib/std/build/emit_raw.zig
+++ b/lib/std/build/emit_raw.zig
@@ -46,9 +46,10 @@ const BinaryElfOutput = struct {
             .segments = ArrayList(*BinaryElfSegment).init(allocator),
             .sections = ArrayList(*BinaryElfSection).init(allocator),
         };
-        const elf_hdrs = try std.elf.readAllHeaders(allocator, elf_file);
+        const elf_hdr = try std.elf.readHeader(elf_file);
 
-        for (elf_hdrs.section_headers) |section, i| {
+        var section_headers = elf_hdr.section_header_iterator(elf_file);
+        while (try section_headers.next()) |section| {
             if (sectionValidForOutput(section)) {
                 const newSection = try allocator.create(BinaryElfSection);
 
@@ -61,7 +62,8 @@ const BinaryElfOutput = struct {
             }
         }
 
-        for (elf_hdrs.program_headers) |phdr, i| {
+        var program_headers = elf_hdr.program_header_iterator(elf_file);
+        while (try program_headers.next()) |phdr| {
             if (phdr.p_type == elf.PT_LOAD) {
                 const newSegment = try allocator.create(BinaryElfSegment);
 


### PR DESCRIPTION
I am writing an ELF loader for DOS, and this change helps me for two reasons:

1. It conserves precious conventional memory.
2. It reduces my executable file size from ~12K to ~6K!

Sidenote: This code could benefit from a generic comptime function that byte swaps all integer fields in a struct. That seemed out of scope for this PR though.