### PR TITLE
Fixes floating point alignment in std.fmt.format

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -560,13 +560,19 @@ fn formatFloatValue(
     options: FormatOptions,
     writer: anytype,
 ) !void {
+    // this buffer should be enough to display all decimal places of a decimal f64 number.
+    var buf: [512]u8 = undefined;
+    var buf_stream = std.io.fixedBufferStream(&buf);
+
     if (fmt.len == 0 or comptime std.mem.eql(u8, fmt, "e")) {
-        return formatFloatScientific(value, options, writer);
+        try formatFloatScientific(value, options, buf_stream.writer());
     } else if (comptime std.mem.eql(u8, fmt, "d")) {
-        return formatFloatDecimal(value, options, writer);
+        try formatFloatDecimal(value, options, buf_stream.writer());
     } else {
         @compileError("Unknown format string: '" ++ fmt ++ "'");
     }
+
+    return formatBuf(buf[0..buf_stream.pos], options, writer);
 }
 
 pub fn formatText(
@@ -1790,4 +1796,18 @@ test "padding" {
     try testFmt("Minimum            width", "{:18} width", .{"Minimum"});
     try testFmt("==================Filled", "{:=>24}", .{"Filled"});
     try testFmt("        Centered        ", "{:^24}", .{"Centered"});
+}
+
+test "decimal float padding" {
+    var number: f32 = 3.1415;
+    try testFmt("left-pad:   **3.141\n", "left-pad:   {d:*>7.3}\n", .{number});
+    try testFmt("center-pad: *3.141*\n", "center-pad: {d:*^7.3}\n", .{number});
+    try testFmt("right-pad:  3.141**\n", "right-pad:  {d:*<7.3}\n", .{number});
+}
+
+test "sci float padding" {
+    var number: f32 = 3.1415;
+    try testFmt("left-pad:   **3.141e+00\n", "left-pad:   {e:*>11.3}\n", .{number});
+    try testFmt("center-pad: *3.141e+00*\n", "center-pad: {e:*^11.3}\n", .{number});
+    try testFmt("right-pad:  3.141e+00**\n", "right-pad:  {e:*<11.3}\n", .{number});
 }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -565,9 +565,15 @@ fn formatFloatValue(
     var buf_stream = std.io.fixedBufferStream(&buf);
 
     if (fmt.len == 0 or comptime std.mem.eql(u8, fmt, "e")) {
-        try formatFloatScientific(value, options, buf_stream.writer());
+        formatFloatScientific(value, options, buf_stream.writer()) catch |err| switch (err) {
+            error.NoSpaceLeft => unreachable,
+            else => |e| return e,
+        };
     } else if (comptime std.mem.eql(u8, fmt, "d")) {
-        try formatFloatDecimal(value, options, buf_stream.writer());
+        formatFloatDecimal(value, options, buf_stream.writer()) catch |err| switch (err) {
+            error.NoSpaceLeft => unreachable,
+            else => |e| return e,
+        };
     } else {
         @compileError("Unknown format string: '" ++ fmt ++ "'");
     }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -578,7 +578,7 @@ fn formatFloatValue(
         @compileError("Unknown format string: '" ++ fmt ++ "'");
     }
 
-    return formatBuf(buf[0..buf_stream.pos], options, writer);
+    return formatBuf(buf_stream.getWritten(), options, writer);
 }
 
 pub fn formatText(


### PR DESCRIPTION
Fixes `std.fmt.formatFloatValue` to adhere to the alignment and filling rules. I'm not sure about the buffer printing workaround, but i think it should be safe (assuming f64 with 10^308 digits + 15 significant decimal places)