### PR TITLE
PowerPC: Fix build error when targeting CPUs with numeric model name

### DIFF
--- a/lib/std/target/powerpc.zig
+++ b/lib/std/target/powerpc.zig
@@ -384,8 +384,8 @@ pub const all_features = blk: {
 };
 
 pub const cpu = struct {
-    pub const @"440" = CpuModel{
-        .name = "440",
+    pub const @"ppc440" = CpuModel{
+        .name = "ppc440",
         .llvm_name = "440",
         .features = featureSet(&[_]Feature{
             .booke,
@@ -396,8 +396,8 @@ pub const cpu = struct {
             .msync,
         }),
     };
-    pub const @"450" = CpuModel{
-        .name = "450",
+    pub const @"ppc450" = CpuModel{
+        .name = "ppc450",
         .llvm_name = "450",
         .features = featureSet(&[_]Feature{
             .booke,
@@ -408,70 +408,70 @@ pub const cpu = struct {
             .msync,
         }),
     };
-    pub const @"601" = CpuModel{
-        .name = "601",
+    pub const @"ppc601" = CpuModel{
+        .name = "ppc601",
         .llvm_name = "601",
         .features = featureSet(&[_]Feature{
             .fpu,
         }),
     };
-    pub const @"602" = CpuModel{
-        .name = "602",
+    pub const @"ppc602" = CpuModel{
+        .name = "ppc602",
         .llvm_name = "602",
         .features = featureSet(&[_]Feature{
             .fpu,
         }),
     };
-    pub const @"603" = CpuModel{
-        .name = "603",
+    pub const @"ppc603" = CpuModel{
+        .name = "ppc603",
         .llvm_name = "603",
         .features = featureSet(&[_]Feature{
             .fres,
             .frsqrte,
         }),
     };
-    pub const @"603e" = CpuModel{
-        .name = "603e",
+    pub const @"ppc603e" = CpuModel{
+        .name = "ppc603e",
         .llvm_name = "603e",
         .features = featureSet(&[_]Feature{
             .fres,
             .frsqrte,
         }),
     };
-    pub const @"603ev" = CpuModel{
-        .name = "603ev",
+    pub const @"ppc603ev" = CpuModel{
+        .name = "ppc603ev",
         .llvm_name = "603ev",
         .features = featureSet(&[_]Feature{
             .fres,
             .frsqrte,
         }),
     };
-    pub const @"604" = CpuModel{
-        .name = "604",
+    pub const @"ppc604" = CpuModel{
+        .name = "ppc604",
         .llvm_name = "604",
         .features = featureSet(&[_]Feature{
             .fres,
             .frsqrte,
         }),
     };
-    pub const @"604e" = CpuModel{
-        .name = "604e",
+    pub const @"ppc604e" = CpuModel{
+        .name = "ppc604e",
         .llvm_name = "604e",
         .features = featureSet(&[_]Feature{
             .fres,
             .frsqrte,
         }),
     };
-    pub const @"620" = CpuModel{
-        .name = "620",
+    pub const @"ppc620" = CpuModel{
+        .name = "ppc620",
         .llvm_name = "620",
         .features = featureSet(&[_]Feature{
             .fres,
             .frsqrte,
         }),
     };
-    pub const @"7400" = CpuModel{
-        .name = "7400",
+    pub const @"ppc7400" = CpuModel{
+        .name = "ppc7400",
         .llvm_name = "7400",
         .features = featureSet(&[_]Feature{
             .altivec,
@@ -479,8 +479,8 @@ pub const cpu = struct {
             .frsqrte,
         }),
     };
-    pub const @"7450" = CpuModel{
-        .name = "7450",
+    pub const @"ppc7450" = CpuModel{
+        .name = "ppc7450",
         .llvm_name = "7450",
         .features = featureSet(&[_]Feature{
             .altivec,
@@ -488,16 +488,16 @@ pub const cpu = struct {
             .frsqrte,
         }),
     };
-    pub const @"750" = CpuModel{
-        .name = "750",
+    pub const @"ppc750" = CpuModel{
+        .name = "ppc750",
         .llvm_name = "750",
         .features = featureSet(&[_]Feature{
             .fres,
             .frsqrte,
         }),
     };
-    pub const @"970" = CpuModel{
-        .name = "970",
+    pub const @"ppc970" = CpuModel{
+        .name = "ppc970",
         .llvm_name = "970",
         .features = featureSet(&[_]Feature{
             .@"64bit",


### PR DESCRIPTION
From the discussion at #5527:

When compiling for a machine with a numeric model name (e.g. "970"), I got errors like this:
```
/home/koakuma/.cache/zig/stage1/builtin/TeeptOn_BLLib3RXLkznJp-Y5ppVHA9yYU9XXbckXlDyt0XFOyOJLtsXGiE-3UKp/builtin.zig:13:34: error: expected token 'Symbol', found 'IntLiteral'
    .model = &Target.powerpc.cpu.970,
                                 ^
```
I've added "ppc" prefix to all of the numeric CPU names as a workaround, but I'm not sure if this is the right way to fix it.
Any comments?