### PR TITLE
copy_file_range linux syscall

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -428,6 +428,12 @@ pub const Version = struct {
             if (self.max.order(ver) == .lt) return false;
             return true;
         }
+
+        pub fn isAtLeast(self: Range, ver: Version) std.math.Ternary {
+            if (self.min.order(ver) != .lt) return .yes;
+            if (self.max.order(ver) == .lt) return .no;
+            return .maybe;
+        }
     };
 
     pub fn order(lhs: Version, rhs: Version) std.math.Order {

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -429,10 +429,12 @@ pub const Version = struct {
             return true;
         }
 
-        pub fn isAtLeast(self: Range, ver: Version) std.math.Ternary {
-            if (self.min.order(ver) != .lt) return .yes;
-            if (self.max.order(ver) == .lt) return .no;
-            return .maybe;
+        /// Checks if system is guaranteed to be at least `version` or older than `version`.
+        /// Returns `null` if a runtime check is required.
+        pub fn isAtLeast(self: Range, ver: Version) ?bool {
+            if (self.min.order(ver) != .lt) return true;
+            if (self.max.order(ver) == .lt) return false;
+            return null;
         }
     };
 

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -91,6 +91,8 @@ pub extern "c" fn sendfile(
     count: usize,
 ) isize;
 
+pub extern "c" fn copy_file_range(fd_in: fd_t, off_in: ?*i64, fd_out: fd_t, off_out: ?*i64, len: usize, flags: c_uint) isize;
+
 pub const pthread_attr_t = extern struct {
     __size: [56]u8,
     __align: c_long,

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -607,15 +607,10 @@ pub const File = struct {
         }
     }
 
-    pub const CopyRangeError = PWriteError || PReadError;
+    pub const CopyRangeError = os.CopyFileRangeError;
 
     pub fn copyRange(in: File, in_offset: u64, out: File, out_offset: u64, len: usize) CopyRangeError!usize {
-        // TODO take advantage of copy_file_range OS APIs
-        var buf: [8 * 4096]u8 = undefined;
-        const adjusted_count = math.min(buf.len, len);
-        const amt_read = try in.pread(buf[0..adjusted_count], in_offset);
-        if (amt_read == 0) return @as(usize, 0);
-        return out.pwrite(buf[0..amt_read], out_offset);
+        return os.copy_file_range(in.handle, in_offset, out.handle, out_offset, len, 0);
     }
 
     /// Returns the number of bytes copied. If the number read is smaller than `buffer.len`, it

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -1096,3 +1096,9 @@ test "compare between signed and unsigned" {
     testing.expect(!compare(@as(u8, 255), .eq, @as(i8, -1)));
     testing.expect(compare(@as(u8, 1), .eq, @as(u8, 1)));
 }
+
+pub const Ternary = enum {
+    yes,
+    no,
+    maybe,
+};

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -1096,9 +1096,3 @@ test "compare between signed and unsigned" {
     testing.expect(!compare(@as(u8, 255), .eq, @as(i8, -1)));
     testing.expect(compare(@as(u8, 1), .eq, @as(u8, 1)));
 }
-
-pub const Ternary = enum {
-    yes,
-    no,
-    maybe,
-};

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1210,6 +1210,18 @@ pub fn signalfd4(fd: fd_t, mask: *const sigset_t, flags: i32) usize {
     );
 }
 
+pub fn copy_file_range(fd_in: fd_t, off_in: ?*i64, fd_out: fd_t, off_out: ?*i64, len: usize, flags: u32) usize {
+    return syscall6(
+        .copy_file_range,
+        @bitCast(usize, @as(isize, fd_in)),
+        @ptrToInt(off_in),
+        @bitCast(usize, @as(isize, fd_out)),
+        @ptrToInt(off_out),
+        len,
+        flags,
+    );
+}
+
 test "" {
     if (builtin.os.tag == .linux) {
         _ = @import("linux/test.zig");

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -100,6 +100,12 @@ pub const Target = struct {
                 pub fn includesVersion(self: Range, ver: WindowsVersion) bool {
                     return @enumToInt(ver) >= @enumToInt(self.min) and @enumToInt(ver) <= @enumToInt(self.max);
                 }
+
+                pub fn isAtLeast(self: Range, ver: Version) std.math.Ternary {
+                    if (@enumToInt(self.min) >= @enumToInt(ver)) return .yes;
+                    if (@enumToInt(self.max) < @enumToInt(ver)) return .no;
+                    return .maybe;
+                }
             };
 
             /// This function is defined to serialize a Zig source code representation of this
@@ -134,6 +140,10 @@ pub const Target = struct {
 
             pub fn includesVersion(self: LinuxVersionRange, ver: Version) bool {
                 return self.range.includesVersion(ver);
+            }
+
+            pub fn isAtLeast(self: LinuxVersionRange, ver: Version) std.math.Ternary {
+                return self.range.isAtLeast(ver);
             }
         };
 


### PR DESCRIPTION
Take advantage of `copy_file_range` syscall in `File.copyRange`.