### PR TITLE
GeneralPurposeAllocator: use std.log instead of std.debug.print

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -52,6 +52,25 @@ pub const subsystem: ?SubSystem = blk: {
 pub const StackTrace = struct {
     index: usize,
     instruction_addresses: []usize,
+
+    pub fn format(
+        self: StackTrace,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+        const debug_info = std.debug.getSelfDebugInfo() catch |err| {
+            return writer.print("\nUnable to print stack trace: Unable to open debug info: {}\n", .{@errorName(err)});
+        };
+        const tty_config = std.debug.detectTTYConfig();
+        try writer.writeAll("\n");
+        std.debug.writeStackTrace(self, writer, &arena.allocator, debug_info, tty_config) catch |err| {
+            try writer.print("Unable to print stack trace: {}\n", .{@errorName(err)});
+        };
+        try writer.writeAll("\n");
+    }
 };
 
 /// This data structure is used by the Zig language code generation and

--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -4,6 +4,8 @@ const builtin = @import("builtin");
 
 pub const io_mode: io.Mode = builtin.test_io_mode;
 
+var log_err_count: usize = 0;
+
 pub fn main() anyerror!void {
     const test_fn_list = builtin.test_functions;
     var ok_count: usize = 0;
@@ -75,8 +77,13 @@ pub fn main() anyerror!void {
     } else {
         std.debug.print("{} passed; {} skipped.\n", .{ ok_count, skip_count });
     }
+    if (log_err_count != 0) {
+        std.debug.print("{} errors were logged.\n", .{log_err_count});
+    }
     if (leaks != 0) {
-        std.debug.print("{} tests leaked memory\n", .{ok_count});
+        std.debug.print("{} tests leaked memory.\n", .{ok_count});
+    }
+    if (leaks != 0 or log_err_count != 0) {
         std.process.exit(1);
     }
 }
@@ -87,6 +94,9 @@ pub fn log(
     comptime format: []const u8,
     args: anytype,
 ) void {
+    if (@enumToInt(message_level) <= @enumToInt(std.log.Level.err)) {
+        log_err_count += 1;
+    }
     if (@enumToInt(message_level) <= @enumToInt(std.testing.log_level)) {
         std.debug.print("[{}] ({}): " ++ format, .{ @tagName(scope), @tagName(message_level) } ++ args);
     }

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -42,17 +42,19 @@ pub fn log(
     comptime format: []const u8,
     args: anytype,
 ) void {
-    if (@enumToInt(level) > @enumToInt(std.log.level))
-        return;
+    // Hide anything more verbose than warn unless it was added with `-Dlog=foo`.
+    if (@enumToInt(level) > @enumToInt(std.log.level) or
+        @enumToInt(level) > @enumToInt(std.log.Level.warn))
+    {
+        const scope_name = @tagName(scope);
+        const ok = comptime for (build_options.log_scopes) |log_scope| {
+            if (mem.eql(u8, log_scope, scope_name))
+                break true;
+        } else false;
 
-    const scope_name = @tagName(scope);
-    const ok = comptime for (build_options.log_scopes) |log_scope| {
-        if (mem.eql(u8, log_scope, scope_name))
-            break true;
-    } else false;
-
-    if (!ok)
-        return;
+        if (!ok)
+            return;
+    }
 
     const prefix = "[" ++ @tagName(level) ++ "] " ++ "(" ++ @tagName(scope) ++ "): ";
 


### PR DESCRIPTION
`std.builtin.StackTrace` gains a `format` function.

GeneralPurposeAllocator uses `std.log.err` instead of directly printing
to stderr. Some errors are recoverable.

The test runner is modified to fail the test run if any log messages of
"err" or worse severity are encountered.

self-hosted is modified to always print log messages of "err" severity
or worse even if they have not been explicitly enabled.

**This makes GeneralPurposeAllocator available on the freestanding target.**