### PR TITLE
std.log: (breaking) remove scope parameter from logging functions

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -325,7 +325,7 @@ pub fn main() !void {
         represents writing data to a file. When the disk is full, a write to the file will fail.
         However, we typically do not expect writing text to the standard output to fail. To avoid having
         to handle the failure case of printing to standard output, you can use alternate functions: the
-        <code>std.log</code> function for proper logging or the <code>std.debug.print</code> function.
+        functions in <code>std.log</code> for proper logging or the <code>std.debug.print</code> function.
         This documentation will use the latter option to print to standard error (stderr) and silently return
         on failure. The next code sample, <code>hello_again.zig</code> demonstrates the use of
         <code>std.debug.print</code>.

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -93,6 +93,7 @@
 //! in a `std.HashMap` using the backing allocator.
 
 const std = @import("std");
+const log = std.log.scoped(.std);
 const math = std.math;
 const assert = std.debug.assert;
 const mem = std.mem;
@@ -288,7 +289,7 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
                         if (is_used) {
                             const slot_index = @intCast(SlotIndex, used_bits_byte * 8 + bit_index);
                             const stack_trace = bucketStackTrace(bucket, size_class, slot_index, .alloc);
-                            std.log.err(.std, "Memory leak detected: {}", .{stack_trace});
+                            log.err("Memory leak detected: {}", .{stack_trace});
                             leaks = true;
                         }
                         if (bit_index == math.maxInt(u3))
@@ -315,7 +316,7 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
                 }
             }
             for (self.large_allocations.items()) |*large_alloc| {
-                std.log.err(.std, "Memory leak detected: {}", .{large_alloc.value.getStackTrace()});
+                log.err("Memory leak detected: {}", .{large_alloc.value.getStackTrace()});
                 leaks = true;
             }
             return leaks;
@@ -450,7 +451,7 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
                     .index = 0,
                 };
                 std.debug.captureStackTrace(ret_addr, &free_stack_trace);
-                std.log.err(.std, "Allocation size {} bytes does not match free size {}. Allocation: {} Free: {}", .{
+                log.err("Allocation size {} bytes does not match free size {}. Allocation: {} Free: {}", .{
                     entry.value.bytes.len,
                     old_mem.len,
                     entry.value.getStackTrace(),
@@ -533,7 +534,7 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
                         .index = 0,
                     };
                     std.debug.captureStackTrace(ret_addr, &second_free_stack_trace);
-                    std.log.err(.std, "Double free detected. Allocation: {} First free: {} Second free: {}", .{
+                    log.err("Double free detected. Allocation: {} First free: {} Second free: {}", .{
                         alloc_stack_trace,
                         free_stack_trace,
                         second_free_stack_trace,

--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -129,92 +129,6 @@ fn log(
     }
 }
 
-/// Log an emergency message. This log level is intended to be used
-/// for conditions that cannot be handled and is usually followed by a panic.
-pub fn emerg(
-    comptime scope: @Type(.EnumLiteral),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    @setCold(true);
-    log(.emerg, scope, format, args);
-}
-
-/// Log an alert message. This log level is intended to be used for
-/// conditions that should be corrected immediately (e.g. database corruption).
-pub fn alert(
-    comptime scope: @Type(.EnumLiteral),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    @setCold(true);
-    log(.alert, scope, format, args);
-}
-
-/// Log a critical message. This log level is intended to be used
-/// when a bug has been detected or something has gone wrong and it will have
-/// an effect on the operation of the program.
-pub fn crit(
-    comptime scope: @Type(.EnumLiteral),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    @setCold(true);
-    log(.crit, scope, format, args);
-}
-
-/// Log an error message. This log level is intended to be used when
-/// a bug has been detected or something has gone wrong but it is recoverable.
-pub fn err(
-    comptime scope: @Type(.EnumLiteral),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    @setCold(true);
-    log(.err, scope, format, args);
-}
-
-/// Log a warning message. This log level is intended to be used if
-/// it is uncertain whether something has gone wrong or not, but the
-/// circumstances would be worth investigating.
-pub fn warn(
-    comptime scope: @Type(.EnumLiteral),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    log(.warn, scope, format, args);
-}
-
-/// Log a notice message. This log level is intended to be used for
-/// non-error but significant conditions.
-pub fn notice(
-    comptime scope: @Type(.EnumLiteral),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    log(.notice, scope, format, args);
-}
-
-/// Log an info message. This log level is intended to be used for
-/// general messages about the state of the program.
-pub fn info(
-    comptime scope: @Type(.EnumLiteral),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    log(.info, scope, format, args);
-}
-
-/// Log a debug message. This log level is intended to be used for
-/// messages which are only useful for debugging.
-pub fn debug(
-    comptime scope: @Type(.EnumLiteral),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    log(.debug, scope, format, args);
-}
-
 /// Returns a scoped logging namespace that logs all messages using the scope
 /// provided here.
 pub fn scoped(comptime scope: @Type(.EnumLiteral)) type {
@@ -301,3 +215,40 @@ pub fn scoped(comptime scope: @Type(.EnumLiteral)) type {
 
 /// The default scoped logging namespace.
 pub const default = scoped(.default);
+
+/// Log an emergency message using the default scope. This log level is
+/// intended to be used for conditions that cannot be handled and is usually
+/// followed by a panic.
+pub const emerg = default.emerg;
+
+/// Log an alert message using the default scope. This log level is intended to
+/// be used for conditions that should be corrected immediately (e.g. database
+/// corruption).
+pub const alert = default.alert;
+
+/// Log a critical message using the default scope. This log level is intended
+/// to be used when a bug has been detected or something has gone wrong and it
+/// will have an effect on the operation of the program.
+pub const crit = default.crit;
+
+/// Log an error message using the default scope. This log level is intended to
+/// be used when a bug has been detected or something has gone wrong but it is
+/// recoverable.
+pub const err = default.err;
+
+/// Log a warning message using the default scope. This log level is intended
+/// to be used if it is uncertain whether something has gone wrong or not, but
+/// the circumstances would be worth investigating.
+pub const warn = default.warn;
+
+/// Log a notice message using the default scope. This log level is intended to
+/// be used for non-error but significant conditions.
+pub const notice = default.notice;
+
+/// Log an info message using the default scope. This log level is intended to
+/// be used for general messages about the state of the program.
+pub const info = default.info;
+
+/// Log a debug message using the default scope. This log level is intended to
+/// be used for messages which are only useful for debugging.
+pub const debug = default.debug;

--- a/src-self-hosted/link.zig
+++ b/src-self-hosted/link.zig
@@ -8,7 +8,7 @@ const fs = std.fs;
 const elf = std.elf;
 const codegen = @import("codegen.zig");
 const c_codegen = @import("codegen/c.zig");
-const log = std.log;
+const log = std.log.scoped(.link);
 const DW = std.dwarf;
 const trace = @import("tracy.zig").trace;
 const leb128 = std.debug.leb;
@@ -726,7 +726,7 @@ pub const File = struct {
                 const file_size = self.base.options.program_code_size_hint;
                 const p_align = 0x1000;
                 const off = self.findFreeSpace(file_size, p_align);
-                log.debug(.link, "found PT_LOAD free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
+                log.debug("found PT_LOAD free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
                 try self.program_headers.append(self.base.allocator, .{
                     .p_type = elf.PT_LOAD,
                     .p_offset = off,
@@ -747,7 +747,7 @@ pub const File = struct {
                 // page align.
                 const p_align = if (self.base.options.target.os.tag == .linux) 0x1000 else @as(u16, ptr_size);
                 const off = self.findFreeSpace(file_size, p_align);
-                log.debug(.link, "found PT_LOAD free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
+                log.debug("found PT_LOAD free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
                 // TODO instead of hard coding the vaddr, make a function to find a vaddr to put things at.
                 // we'll need to re-use that function anyway, in case the GOT grows and overlaps something
                 // else in virtual memory.
@@ -769,7 +769,7 @@ pub const File = struct {
                 assert(self.shstrtab.items.len == 0);
                 try self.shstrtab.append(self.base.allocator, 0); // need a 0 at position 0
                 const off = self.findFreeSpace(self.shstrtab.items.len, 1);
-                log.debug(.link, "found shstrtab free space 0x{x} to 0x{x}\n", .{ off, off + self.shstrtab.items.len });
+                log.debug("found shstrtab free space 0x{x} to 0x{x}\n", .{ off, off + self.shstrtab.items.len });
                 try self.sections.append(self.base.allocator, .{
                     .sh_name = try self.makeString(".shstrtab"),
                     .sh_type = elf.SHT_STRTAB,
@@ -827,7 +827,7 @@ pub const File = struct {
                 const each_size: u64 = if (small_ptr) @sizeOf(elf.Elf32_Sym) else @sizeOf(elf.Elf64_Sym);
                 const file_size = self.base.options.symbol_count_hint * each_size;
                 const off = self.findFreeSpace(file_size, min_align);
-                log.debug(.link, "found symtab free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
+                log.debug("found symtab free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
 
                 try self.sections.append(self.base.allocator, .{
                     .sh_name = try self.makeString(".symtab"),
@@ -869,7 +869,7 @@ pub const File = struct {
                 const file_size_hint = 200;
                 const p_align = 1;
                 const off = self.findFreeSpace(file_size_hint, p_align);
-                log.debug(.link, "found .debug_info free space 0x{x} to 0x{x}\n", .{
+                log.debug("found .debug_info free space 0x{x} to 0x{x}\n", .{
                     off,
                     off + file_size_hint,
                 });
@@ -894,7 +894,7 @@ pub const File = struct {
                 const file_size_hint = 128;
                 const p_align = 1;
                 const off = self.findFreeSpace(file_size_hint, p_align);
-                log.debug(.link, "found .debug_abbrev free space 0x{x} to 0x{x}\n", .{
+                log.debug("found .debug_abbrev free space 0x{x} to 0x{x}\n", .{
                     off,
                     off + file_size_hint,
                 });
@@ -919,7 +919,7 @@ pub const File = struct {
                 const file_size_hint = 160;
                 const p_align = 16;
                 const off = self.findFreeSpace(file_size_hint, p_align);
-                log.debug(.link, "found .debug_aranges free space 0x{x} to 0x{x}\n", .{
+                log.debug("found .debug_aranges free space 0x{x} to 0x{x}\n", .{
                     off,
                     off + file_size_hint,
                 });
@@ -944,7 +944,7 @@ pub const File = struct {
                 const file_size_hint = 250;
                 const p_align = 1;
                 const off = self.findFreeSpace(file_size_hint, p_align);
-                log.debug(.link, "found .debug_line free space 0x{x} to 0x{x}\n", .{
+                log.debug("found .debug_line free space 0x{x} to 0x{x}\n", .{
                     off,
                     off + file_size_hint,
                 });
@@ -1071,7 +1071,7 @@ pub const File = struct {
                     debug_abbrev_sect.sh_offset = self.findFreeSpace(needed_size, 1);
                 }
                 debug_abbrev_sect.sh_size = needed_size;
-                log.debug(.link, ".debug_abbrev start=0x{x} end=0x{x}\n", .{
+                log.debug(".debug_abbrev start=0x{x} end=0x{x}\n", .{
                     debug_abbrev_sect.sh_offset,
                     debug_abbrev_sect.sh_offset + needed_size,
                 });
@@ -1218,7 +1218,7 @@ pub const File = struct {
                     debug_aranges_sect.sh_offset = self.findFreeSpace(needed_size, 16);
                 }
                 debug_aranges_sect.sh_size = needed_size;
-                log.debug(.link, ".debug_aranges start=0x{x} end=0x{x}\n", .{
+                log.debug(".debug_aranges start=0x{x} end=0x{x}\n", .{
                     debug_aranges_sect.sh_offset,
                     debug_aranges_sect.sh_offset + needed_size,
                 });
@@ -1386,7 +1386,7 @@ pub const File = struct {
                         shstrtab_sect.sh_offset = self.findFreeSpace(needed_size, 1);
                     }
                     shstrtab_sect.sh_size = needed_size;
-                    log.debug(.link, "writing shstrtab start=0x{x} end=0x{x}\n", .{ shstrtab_sect.sh_offset, shstrtab_sect.sh_offset + needed_size });
+                    log.debug("writing shstrtab start=0x{x} end=0x{x}\n", .{ shstrtab_sect.sh_offset, shstrtab_sect.sh_offset + needed_size });
 
                     try self.base.file.?.pwriteAll(self.shstrtab.items, shstrtab_sect.sh_offset);
                     if (!self.shdr_table_dirty) {
@@ -1407,7 +1407,7 @@ pub const File = struct {
                         debug_strtab_sect.sh_offset = self.findFreeSpace(needed_size, 1);
                     }
                     debug_strtab_sect.sh_size = needed_size;
-                    log.debug(.link, "debug_strtab start=0x{x} end=0x{x}\n", .{ debug_strtab_sect.sh_offset, debug_strtab_sect.sh_offset + needed_size });
+                    log.debug("debug_strtab start=0x{x} end=0x{x}\n", .{ debug_strtab_sect.sh_offset, debug_strtab_sect.sh_offset + needed_size });
 
                     try self.base.file.?.pwriteAll(self.debug_strtab.items, debug_strtab_sect.sh_offset);
                     if (!self.shdr_table_dirty) {
@@ -1441,7 +1441,7 @@ pub const File = struct {
 
                         for (buf) |*shdr, i| {
                             shdr.* = sectHeaderTo32(self.sections.items[i]);
-                            std.log.debug(.link, "writing section {}\n", .{shdr.*});
+                            log.debug("writing section {}\n", .{shdr.*});
                             if (foreign_endian) {
                                 bswapAllFields(elf.Elf32_Shdr, shdr);
                             }
@@ -1454,7 +1454,7 @@ pub const File = struct {
 
                         for (buf) |*shdr, i| {
                             shdr.* = self.sections.items[i];
-                            log.debug(.link, "writing section {}\n", .{shdr.*});
+                            log.debug("writing section {}\n", .{shdr.*});
                             if (foreign_endian) {
                                 bswapAllFields(elf.Elf64_Shdr, shdr);
                             }
@@ -1465,10 +1465,10 @@ pub const File = struct {
                 self.shdr_table_dirty = false;
             }
             if (self.entry_addr == null and self.base.options.output_mode == .Exe) {
-                log.debug(.link, "flushing. no_entry_point_found = true\n", .{});
+                log.debug("flushing. no_entry_point_found = true\n", .{});
                 self.error_flags.no_entry_point_found = true;
             } else {
-                log.debug(.link, "flushing. no_entry_point_found = false\n", .{});
+                log.debug("flushing. no_entry_point_found = false\n", .{});
                 self.error_flags.no_entry_point_found = false;
                 try self.writeElfHeader();
             }
@@ -1797,10 +1797,10 @@ pub const File = struct {
             try self.offset_table.ensureCapacity(self.base.allocator, self.offset_table.items.len + 1);
 
             if (self.local_symbol_free_list.popOrNull()) |i| {
-                log.debug(.link, "reusing symbol index {} for {}\n", .{ i, decl.name });
+                log.debug("reusing symbol index {} for {}\n", .{ i, decl.name });
                 decl.link.elf.local_sym_index = i;
             } else {
-                log.debug(.link, "allocating symbol index {} for {}\n", .{ self.local_symbols.items.len, decl.name });
+                log.debug("allocating symbol index {} for {}\n", .{ self.local_symbols.items.len, decl.name });
                 decl.link.elf.local_sym_index = @intCast(u32, self.local_symbols.items.len);
                 _ = self.local_symbols.addOneAssumeCapacity();
             }
@@ -1993,11 +1993,11 @@ pub const File = struct {
                     !mem.isAlignedGeneric(u64, local_sym.st_value, required_alignment);
                 if (need_realloc) {
                     const vaddr = try self.growTextBlock(&decl.link.elf, code.len, required_alignment);
-                    log.debug(.link, "growing {} from 0x{x} to 0x{x}\n", .{ decl.name, local_sym.st_value, vaddr });
+                    log.debug("growing {} from 0x{x} to 0x{x}\n", .{ decl.name, local_sym.st_value, vaddr });
                     if (vaddr != local_sym.st_value) {
                         local_sym.st_value = vaddr;
 
-                        log.debug(.link, "  (writing new offset table entry)\n", .{});
+                        log.debug("  (writing new offset table entry)\n", .{});
                         self.offset_table.items[decl.link.elf.offset_table_index] = vaddr;
                         try self.writeOffsetTableEntry(decl.link.elf.offset_table_index);
                     }
@@ -2015,7 +2015,7 @@ pub const File = struct {
                 const decl_name = mem.spanZ(decl.name);
                 const name_str_index = try self.makeString(decl_name);
                 const vaddr = try self.allocateTextBlock(&decl.link.elf, code.len, required_alignment);
-                log.debug(.link, "allocated text block for {} at 0x{x}\n", .{ decl_name, vaddr });
+                log.debug("allocated text block for {} at 0x{x}\n", .{ decl_name, vaddr });
                 errdefer self.freeTextBlock(&decl.link.elf);
 
                 local_sym.* = .{
@@ -2125,7 +2125,7 @@ pub const File = struct {
                     if (needed_size > self.allocatedSize(debug_line_sect.sh_offset)) {
                         const new_offset = self.findFreeSpace(needed_size, 1);
                         const existing_size = last_src_fn.off;
-                        log.debug(.link, "moving .debug_line section: {} bytes from 0x{x} to 0x{x}\n", .{
+                        log.debug("moving .debug_line section: {} bytes from 0x{x} to 0x{x}\n", .{
                             existing_size,
                             debug_line_sect.sh_offset,
                             new_offset,
@@ -2204,7 +2204,7 @@ pub const File = struct {
                     try dbg_info_buffer.writer().print("{}\x00", .{ty});
                 },
                 else => {
-                    log.err(.compiler, "TODO implement .debug_info for type '{}'", .{ty});
+                    std.log.scoped(.compiler).err("TODO implement .debug_info for type '{}'", .{ty});
                     try dbg_info_buffer.append(abbrev_pad1);
                 },
             }
@@ -2276,7 +2276,7 @@ pub const File = struct {
                 if (needed_size > self.allocatedSize(debug_info_sect.sh_offset)) {
                     const new_offset = self.findFreeSpace(needed_size, 1);
                     const existing_size = last_decl.dbg_info_off;
-                    log.debug(.link, "moving .debug_info section: {} bytes from 0x{x} to 0x{x}\n", .{
+                    log.debug("moving .debug_info section: {} bytes from 0x{x} to 0x{x}\n", .{
                         existing_size,
                         debug_info_sect.sh_offset,
                         new_offset,

--- a/src-self-hosted/liveness.zig
+++ b/src-self-hosted/liveness.zig
@@ -114,5 +114,5 @@ fn analyzeInst(arena: *std.mem.Allocator, table: *std.AutoHashMap(*ir.Inst, void
         @panic("Handle liveness analysis for instructions with many parameters");
     }
 
-    std.log.debug(.liveness, "analyze {}: 0b{b}\n", .{ base.tag, base.deaths });
+    std.log.scoped(.liveness).debug("analyze {}: 0b{b}\n", .{ base.tag, base.deaths });
 }

--- a/src-self-hosted/main.zig
+++ b/src-self-hosted/main.zig
@@ -560,7 +560,7 @@ fn updateModule(gpa: *Allocator, module: *Module, zir_out_path: ?[]const u8) !vo
             });
         }
     } else {
-        std.log.info(.compiler, "Update completed in {} ms\n", .{update_nanos / std.time.ns_per_ms});
+        std.log.scoped(.compiler).info("Update completed in {} ms\n", .{update_nanos / std.time.ns_per_ms});
     }
 
     if (zir_out_path) |zop| {


### PR DESCRIPTION
The logging functions in std.log don't take a scope parameter anymore, but use the .default scope. This is a follow-up to PR #6039 and a further implementation of #5943.

I also updated the standard library (currently only the general purpose allocator uses logging) as well as stage2 to use scoped logging. I tried to run test-std and test-stage2 tests but my old laptop hung during semantic analysis while doing so, so I'm relying on CI here.

Implemented as per @nmichaels' suggestion: https://github.com/ziglang/zig/pull/6039#issuecomment-673148971