### PR TITLE
std.zig.ast: extract out Node.LabeledBlock from Node.Block

### DIFF
--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -530,15 +530,15 @@ pub const Node = struct {
 
         // Misc
         DocComment,
-        SwitchCase,
-        SwitchElse,
-        Else,
-        Payload,
-        PointerPayload,
-        PointerIndexPayload,
+        SwitchCase, // TODO make this not a child of AST Node
+        SwitchElse, // TODO make this not a child of AST Node
+        Else, // TODO make this not a child of AST Node
+        Payload, // TODO make this not a child of AST Node
+        PointerPayload, // TODO make this not a child of AST Node
+        PointerIndexPayload, // TODO make this not a child of AST Node
         ContainerField,
-        ErrorTag,
-        FieldInitializer,
+        ErrorTag, // TODO make this not a child of AST Node
+        FieldInitializer, // TODO make this not a child of AST Node
 
         pub fn Type(tag: Tag) type {
             return switch (tag) {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -392,28 +392,50 @@ fn renderExpression(
             return renderToken(tree, stream, any_type.token, indent, start_col, space);
         },
 
-        .Block => {
-            const block = @fieldParentPtr(ast.Node.Block, "base", base);
+        .Block, .LabeledBlock => {
+            const block: struct {
+                label: ?ast.TokenIndex,
+                statements: []*ast.Node,
+                lbrace: ast.TokenIndex,
+                rbrace: ast.TokenIndex,
+            } = b: {
+                if (base.castTag(.Block)) |block| {
+                    break :b .{
+                        .label = null,
+                        .statements = block.statements(),
+                        .lbrace = block.lbrace,
+                        .rbrace = block.rbrace,
+                    };
+                } else if (base.castTag(.LabeledBlock)) |block| {
+                    break :b .{
+                        .label = block.label,
+                        .statements = block.statements(),
+                        .lbrace = block.lbrace,
+                        .rbrace = block.rbrace,
+                    };
+                } else {
+                    unreachable;
+                }
+            };
 
             if (block.label) |label| {
                 try renderToken(tree, stream, label, indent, start_col, Space.None);
                 try renderToken(tree, stream, tree.nextToken(label), indent, start_col, Space.Space);
             }
 
-            if (block.statements_len == 0) {
+            if (block.statements.len == 0) {
                 try renderToken(tree, stream, block.lbrace, indent + indent_delta, start_col, Space.None);
                 return renderToken(tree, stream, block.rbrace, indent, start_col, space);
             } else {
                 const block_indent = indent + indent_delta;
                 try renderToken(tree, stream, block.lbrace, block_indent, start_col, Space.Newline);
 
-                const block_statements = block.statements();
-                for (block_statements) |statement, i| {
+                for (block.statements) |statement, i| {
                     try stream.writeByteNTimes(' ', block_indent);
                     try renderStatement(allocator, stream, tree, block_indent, start_col, statement);
 
-                    if (i + 1 < block_statements.len) {
-                        try renderExtraNewline(tree, stream, start_col, block_statements[i + 1]);
+                    if (i + 1 < block.statements.len) {
+                        try renderExtraNewline(tree, stream, start_col, block.statements[i + 1]);
                     }
                 }
 
@@ -1841,7 +1863,7 @@ fn renderExpression(
 
             const rparen = tree.nextToken(for_node.array_expr.lastToken());
 
-            const body_is_block = for_node.body.tag == .Block;
+            const body_is_block = for_node.body.tag.isBlock();
             const src_one_line_to_body = !body_is_block and tree.tokensOnSameLine(rparen, for_node.body.firstToken());
             const body_on_same_line = body_is_block or src_one_line_to_body;
 
@@ -2578,6 +2600,7 @@ fn renderDocCommentsToken(
 fn nodeIsBlock(base: *const ast.Node) bool {
     return switch (base.tag) {
         .Block,
+        .LabeledBlock,
         .If,
         .For,
         .While,

--- a/src-self-hosted/Module.zig
+++ b/src-self-hosted/Module.zig
@@ -737,6 +737,7 @@ pub const Scope = struct {
         arena: *Allocator,
         /// The first N instructions in a function body ZIR are arg instructions.
         instructions: std.ArrayListUnmanaged(*zir.Inst) = .{},
+        label: ?ast.TokenIndex = null,
     };
 
     /// This is always a `const` local and importantly the `inst` is a value type, not a pointer.

--- a/src-self-hosted/Module.zig
+++ b/src-self-hosted/Module.zig
@@ -1343,7 +1343,7 @@ fn astGenAndAnalyzeDecl(self: *Module, decl: *Decl) !bool {
 
                 const body_block = body_node.cast(ast.Node.Block).?;
 
-                _ = try astgen.blockExpr(self, params_scope, .none, body_block);
+                try astgen.blockExpr(self, params_scope, body_block);
 
                 if (gen_scope.instructions.items.len == 0 or
                     !gen_scope.instructions.items[gen_scope.instructions.items.len - 1].tag.isNoReturn())

--- a/src-self-hosted/astgen.zig
+++ b/src-self-hosted/astgen.zig
@@ -47,7 +47,19 @@ pub fn typeExpr(mod: *Module, scope: *Scope, type_node: *ast.Node) InnerError!*z
 /// Turn Zig AST into untyped ZIR istructions.
 pub fn expr(mod: *Module, scope: *Scope, rl: ResultLoc, node: *ast.Node) InnerError!*zir.Inst {
     switch (node.tag) {
+        .Root => unreachable, // Top-level declaration.
+        .Use => unreachable, // Top-level declaration.
+        .TestDecl => unreachable, // Top-level declaration.
+        .DocComment => unreachable, // Top-level declaration.
         .VarDecl => unreachable, // Handled in `blockExpr`.
+        .SwitchCase => unreachable, // Handled in `switchExpr`.
+        .SwitchElse => unreachable, // Handled in `switchExpr`.
+        .Else => unreachable, // Handled explicitly the control flow expression functions.
+        .Payload => unreachable, // Handled explicitly.
+        .PointerPayload => unreachable, // Handled explicitly.
+        .PointerIndexPayload => unreachable, // Handled explicitly.
+        .ErrorTag => unreachable, // Handled explicitly.
+        .FieldInitializer => unreachable, // Handled explicitly.
 
         .Assign => return rlWrapVoid(mod, scope, rl, node, try assign(mod, scope, node.castTag(.Assign).?)),
         .AssignBitAnd => return rlWrapVoid(mod, scope, rl, node, try assignOp(mod, scope, node.castTag(.AssignBitAnd).?, .bitand)),
@@ -109,7 +121,49 @@ pub fn expr(mod: *Module, scope: *Scope, rl: ResultLoc, node: *ast.Node) InnerEr
         .UnwrapOptional => return unwrapOptional(mod, scope, rl, node.castTag(.UnwrapOptional).?),
         .Block => return rlWrapVoid(mod, scope, rl, node, try blockExpr(mod, scope, node.castTag(.Block).?)),
         .LabeledBlock => return labeledBlockExpr(mod, scope, rl, node.castTag(.LabeledBlock).?),
-        else => return mod.failNode(scope, node, "TODO implement astgen.Expr for {}", .{@tagName(node.tag)}),
+        .Defer => return mod.failNode(scope, node, "TODO implement astgen.expr for .Defer", .{}),
+        .Catch => return mod.failNode(scope, node, "TODO implement astgen.expr for .Catch", .{}),
+        .BoolAnd => return mod.failNode(scope, node, "TODO implement astgen.expr for .BoolAnd", .{}),
+        .BoolOr => return mod.failNode(scope, node, "TODO implement astgen.expr for .BoolOr", .{}),
+        .ErrorUnion => return mod.failNode(scope, node, "TODO implement astgen.expr for .ErrorUnion", .{}),
+        .MergeErrorSets => return mod.failNode(scope, node, "TODO implement astgen.expr for .MergeErrorSets", .{}),
+        .Range => return mod.failNode(scope, node, "TODO implement astgen.expr for .Range", .{}),
+        .OrElse => return mod.failNode(scope, node, "TODO implement astgen.expr for .OrElse", .{}),
+        .AddressOf => return mod.failNode(scope, node, "TODO implement astgen.expr for .AddressOf", .{}),
+        .Await => return mod.failNode(scope, node, "TODO implement astgen.expr for .Await", .{}),
+        .BitNot => return mod.failNode(scope, node, "TODO implement astgen.expr for .BitNot", .{}),
+        .Negation => return mod.failNode(scope, node, "TODO implement astgen.expr for .Negation", .{}),
+        .NegationWrap => return mod.failNode(scope, node, "TODO implement astgen.expr for .NegationWrap", .{}),
+        .Resume => return mod.failNode(scope, node, "TODO implement astgen.expr for .Resume", .{}),
+        .Try => return mod.failNode(scope, node, "TODO implement astgen.expr for .Try", .{}),
+        .ArrayType => return mod.failNode(scope, node, "TODO implement astgen.expr for .ArrayType", .{}),
+        .ArrayTypeSentinel => return mod.failNode(scope, node, "TODO implement astgen.expr for .ArrayTypeSentinel", .{}),
+        .PtrType => return mod.failNode(scope, node, "TODO implement astgen.expr for .PtrType", .{}),
+        .SliceType => return mod.failNode(scope, node, "TODO implement astgen.expr for .SliceType", .{}),
+        .Slice => return mod.failNode(scope, node, "TODO implement astgen.expr for .Slice", .{}),
+        .ArrayAccess => return mod.failNode(scope, node, "TODO implement astgen.expr for .ArrayAccess", .{}),
+        .ArrayInitializer => return mod.failNode(scope, node, "TODO implement astgen.expr for .ArrayInitializer", .{}),
+        .ArrayInitializerDot => return mod.failNode(scope, node, "TODO implement astgen.expr for .ArrayInitializerDot", .{}),
+        .StructInitializer => return mod.failNode(scope, node, "TODO implement astgen.expr for .StructInitializer", .{}),
+        .StructInitializerDot => return mod.failNode(scope, node, "TODO implement astgen.expr for .StructInitializerDot", .{}),
+        .Switch => return mod.failNode(scope, node, "TODO implement astgen.expr for .Switch", .{}),
+        .For => return mod.failNode(scope, node, "TODO implement astgen.expr for .For", .{}),
+        .Suspend => return mod.failNode(scope, node, "TODO implement astgen.expr for .Suspend", .{}),
+        .Continue => return mod.failNode(scope, node, "TODO implement astgen.expr for .Continue", .{}),
+        .Break => return mod.failNode(scope, node, "TODO implement astgen.expr for .Break", .{}),
+        .AnyType => return mod.failNode(scope, node, "TODO implement astgen.expr for .AnyType", .{}),
+        .ErrorType => return mod.failNode(scope, node, "TODO implement astgen.expr for .ErrorType", .{}),
+        .FnProto => return mod.failNode(scope, node, "TODO implement astgen.expr for .FnProto", .{}),
+        .AnyFrameType => return mod.failNode(scope, node, "TODO implement astgen.expr for .AnyFrameType", .{}),
+        .EnumLiteral => return mod.failNode(scope, node, "TODO implement astgen.expr for .EnumLiteral", .{}),
+        .MultilineStringLiteral => return mod.failNode(scope, node, "TODO implement astgen.expr for .MultilineStringLiteral", .{}),
+        .CharLiteral => return mod.failNode(scope, node, "TODO implement astgen.expr for .CharLiteral", .{}),
+        .GroupedExpression => return mod.failNode(scope, node, "TODO implement astgen.expr for .GroupedExpression", .{}),
+        .ErrorSetDecl => return mod.failNode(scope, node, "TODO implement astgen.expr for .ErrorSetDecl", .{}),
+        .ContainerDecl => return mod.failNode(scope, node, "TODO implement astgen.expr for .ContainerDecl", .{}),
+        .Comptime => return mod.failNode(scope, node, "TODO implement astgen.expr for .Comptime", .{}),
+        .Nosuspend => return mod.failNode(scope, node, "TODO implement astgen.expr for .Nosuspend", .{}),
+        .ContainerField => return mod.failNode(scope, node, "TODO implement astgen.expr for .ContainerField", .{}),
     }
 }
 


### PR DESCRIPTION
This is part of an ongoing effort to reduce size of in-memory AST. This
enum flattening pattern is widespread throughout the self-hosted
compiler.

This is a API breaking change for consumers of the self-hosted parser.