### PR TITLE
Add skeleton for MachO support in stage2

### DIFF
--- a/src-self-hosted/Module.zig
+++ b/src-self-hosted/Module.zig
@@ -1562,6 +1562,9 @@ fn analyzeRootSrcFile(self: *Module, root_scope: *Scope.File) !void {
                             // in `Decl` to notice that the line number did not change.
                             self.work_queue.writeItemAssumeCapacity(.{ .update_line_number = decl });
                         },
+                        .macho => {
+                            // TODO Implement for MachO
+                        },
                         .c => {},
                     }
                 }
@@ -1768,10 +1771,12 @@ fn allocateNewDecl(
         .contents_hash = contents_hash,
         .link = switch (self.bin_file.tag) {
             .elf => .{ .elf = link.File.Elf.TextBlock.empty },
+            .macho => .{ .macho = link.File.MachO.TextBlock.empty },
             .c => .{ .c = {} },
         },
         .fn_link = switch (self.bin_file.tag) {
             .elf => .{ .elf = link.File.Elf.SrcFn.empty },
+            .macho => .{ .macho = link.File.MachO.SrcFn.empty },
             .c => .{ .c = {} },
         },
         .generation = 0,

--- a/src-self-hosted/link.zig
+++ b/src-self-hosted/link.zig
@@ -155,6 +155,7 @@ pub const File = struct {
         }
     }
 
+    /// Commit pending changes and write headers.
     pub fn flush(base: *File) !void {
         const tracy = trace(@src());
         defer tracy.end();
@@ -1019,7 +1020,6 @@ pub const File = struct {
         pub const abbrev_pad1 = 5;
         pub const abbrev_parameter = 6;
 
-        /// Commit pending changes and write headers.
         pub fn flush(self: *Elf) !void {
             const target_endian = self.base.options.target.cpu.arch.endian();
             const foreign_endian = target_endian != std.Target.current.cpu.arch.endian();
@@ -2327,7 +2327,6 @@ pub const File = struct {
             try self.pwriteDbgInfoNops(prev_padding_size, dbg_info_buf, next_padding_size, trailing_zero, file_pos);
         }
 
-        /// Must be called only after a successful call to `updateDecl`.
         pub fn updateDeclExports(
             self: *Elf,
             module: *Module,
@@ -2829,99 +2828,7 @@ pub const File = struct {
 
     };
 
-    pub const MachO = struct {
-        pub const base_tag: Tag = .macho;
-
-        base: File,
-
-        ptr_width: enum { p32, p64 },
-
-        error_flags: ErrorFlags = ErrorFlags{},
-
-        pub const TextBlock = struct {
-            pub const empty = TextBlock{};
-        };
-
-        pub const SrcFn = struct {
-            pub const empty = SrcFn{};
-        };
-
-        pub fn openPath(allocator: *Allocator, dir: fs.Dir, sub_path: []const u8, options: Options) !*File {
-            assert(options.object_format == .macho);
-
-            const file = try dir.createFile(sub_path, .{ .truncate = false, .read = true, .mode = determineMode(options) });
-            errdefer file.close();
-
-            var macho_file = try allocator.create(MachO);
-            errdefer allocator.destroy(macho_file);
-
-            macho_file.* = openFile(allocator, file, options) catch |err| switch (err) {
-                error.IncrFailed => try createFile(allocator, file, options),
-                else => |e| return e,
-            };
-
-            return &macho_file.base;
-        }
-
-        /// Returns error.IncrFailed if incremental update could not be performed.
-        fn openFile(allocator: *Allocator, file: fs.File, options: Options) !MachO {
-            switch (options.output_mode) {
-                .Exe => {},
-                .Obj => {},
-                .Lib => return error.IncrFailed,
-            }
-            var self: MachO = .{
-                .base = .{
-                    .file = file,
-                    .tag = .macho,
-                    .options = options,
-                    .allocator = allocator,
-                },
-                .ptr_width = switch (options.target.cpu.arch.ptrBitWidth()) {
-                    32 => .p32,
-                    64 => .p64,
-                    else => return error.UnsupportedELFArchitecture,
-                },
-            };
-            errdefer self.deinit();
-
-            // TODO implement reading the macho file
-            return error.IncrFailed;
-            //try self.populateMissingMetadata();
-            //return self;
-        }
-
-        /// Truncates the existing file contents and overwrites the contents.
-        /// Returns an error if `file` is not already open with +read +write +seek abilities.
-        fn createFile(allocator: *Allocator, file: fs.File, options: Options) !MachO {
-            switch (options.output_mode) {
-                .Exe => return error.TODOImplementWritingMachOExeFiles,
-                .Obj => return error.TODOImplementWritingMachOObjFiles,
-                .Lib => return error.TODOImplementWritingLibFiles,
-            }
-        }
-
-        /// Commit pending changes and write headers.
-        pub fn flush(self: *MachO) !void {}
-
-        pub fn deinit(self: *MachO) void {}
-
-        pub fn allocateDeclIndexes(self: *MachO, decl: *Module.Decl) !void {}
-
-        pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {}
-
-        pub fn updateDeclLineNumber(self: *MachO, module: *Module, decl: *const Module.Decl) !void {}
-
-        /// Must be called only after a successful call to `updateDecl`.
-        pub fn updateDeclExports(
-            self: *MachO,
-            module: *Module,
-            decl: *const Module.Decl,
-            exports: []const *Module.Export,
-        ) !void {}
-
-        pub fn freeDecl(self: *MachO, decl: *Module.Decl) void {}
-    };
+    pub const MachO = @import("link/MachO.zig");
 };
 
 /// Saturating multiplication
@@ -2962,7 +2869,7 @@ fn sectHeaderTo32(shdr: elf.Elf64_Shdr) elf.Elf32_Shdr {
     };
 }
 
-fn determineMode(options: Options) fs.File.Mode {
+pub fn determineMode(options: Options) fs.File.Mode {
     // On common systems with a 0o022 umask, 0o777 will still result in a file created
     // with 0o755 permissions, but it works appropriately if the system is configured
     // more leniently. As another data point, C's fopen seems to open files with the

--- a/src-self-hosted/link/MachO.zig
+++ b/src-self-hosted/link/MachO.zig
@@ -1,0 +1,93 @@
+const MachO = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
+const fs = std.fs;
+
+const Module = @import("../Module.zig");
+const link = @import("../link.zig");
+const File = link.File;
+
+pub const base_tag: Tag = File.Tag.macho;
+
+base: File,
+
+error_flags: File.ErrorFlags = File.ErrorFlags{},
+
+pub const TextBlock = struct {
+    pub const empty = TextBlock{};
+};
+
+pub const SrcFn = struct {
+    pub const empty = SrcFn{};
+};
+
+pub fn openPath(allocator: *Allocator, dir: fs.Dir, sub_path: []const u8, options: link.Options) !*File {
+    assert(options.object_format == .macho);
+
+    const file = try dir.createFile(sub_path, .{ .truncate = false, .read = true, .mode = link.determineMode(options) });
+    errdefer file.close();
+
+    var macho_file = try allocator.create(MachO);
+    errdefer allocator.destroy(macho_file);
+
+    macho_file.* = openFile(allocator, file, options) catch |err| switch (err) {
+        error.IncrFailed => try createFile(allocator, file, options),
+        else => |e| return e,
+    };
+
+    return &macho_file.base;
+}
+
+/// Returns error.IncrFailed if incremental update could not be performed.
+fn openFile(allocator: *Allocator, file: fs.File, options: link.Options) !MachO {
+    switch (options.output_mode) {
+        .Exe => {},
+        .Obj => {},
+        .Lib => return error.IncrFailed,
+    }
+    var self: MachO = .{
+        .base = .{
+            .file = file,
+            .tag = .macho,
+            .options = options,
+            .allocator = allocator,
+        },
+    };
+    errdefer self.deinit();
+
+    // TODO implement reading the macho file
+    return error.IncrFailed;
+    //try self.populateMissingMetadata();
+    //return self;
+}
+
+/// Truncates the existing file contents and overwrites the contents.
+/// Returns an error if `file` is not already open with +read +write +seek abilities.
+fn createFile(allocator: *Allocator, file: fs.File, options: link.Options) !MachO {
+    switch (options.output_mode) {
+        .Exe => return error.TODOImplementWritingMachOExeFiles,
+        .Obj => return error.TODOImplementWritingMachOObjFiles,
+        .Lib => return error.TODOImplementWritingLibFiles,
+    }
+}
+
+pub fn flush(self: *MachO) !void {}
+
+pub fn deinit(self: *MachO) void {}
+
+pub fn allocateDeclIndexes(self: *MachO, decl: *Module.Decl) !void {}
+
+pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {}
+
+pub fn updateDeclLineNumber(self: *MachO, module: *Module, decl: *const Module.Decl) !void {}
+
+pub fn updateDeclExports(
+    self: *MachO,
+    module: *Module,
+    decl: *const Module.Decl,
+    exports: []const *Module.Export,
+) !void {}
+
+pub fn freeDecl(self: *MachO, decl: *Module.Decl) void {}


### PR DESCRIPTION
This commit adds an empty skeleton for MachO format support in stage2.

@andrewrk so this is my first commit to stage2, and since I never wrote a linker before, I thought that I'll keep the PRs relatively small so that you can (and anyone else interested ofc!) guide me in the right direction. Lemme know what you think!