### PR TITLE
stage2/link: clarify comments on calling order

### DIFF
--- a/src-self-hosted/link.zig
+++ b/src-self-hosted/link.zig
@@ -110,6 +110,8 @@ pub const File = struct {
         }
     }
 
+    /// May be called before or after updateDeclExports but must be called
+    /// after allocateDeclIndexes for any given Decl.
     pub fn updateDecl(base: *File, module: *Module, decl: *Module.Decl) !void {
         switch (base.tag) {
             .elf => return @fieldParentPtr(Elf, "base", base).updateDecl(module, decl),
@@ -127,6 +129,8 @@ pub const File = struct {
         }
     }
 
+    /// Must be called before any call to updateDecl or updateDeclExports for
+    /// any given Decl.
     pub fn allocateDeclIndexes(base: *File, decl: *Module.Decl) !void {
         switch (base.tag) {
             .elf => return @fieldParentPtr(Elf, "base", base).allocateDeclIndexes(decl),
@@ -200,7 +204,8 @@ pub const File = struct {
         };
     }
 
-    /// Must be called only after a successful call to `updateDecl`.
+    /// May be called before or after updateDecl, but must be called after
+    /// allocateDeclIndexes for any given Decl.
     pub fn updateDeclExports(
         base: *File,
         module: *Module,


### PR DESCRIPTION
See: https://github.com/ziglang/zig/pull/6056#discussion_r471015550

This assert suggest that `allocateDeclIndexes` is indeed required to be called first.
https://github.com/ziglang/zig/blob/c0517bf1f6f6f7de0279e3766f414c5c8380bed7/src-self-hosted/link.zig#L2028