### PR TITLE
Write out Mach-O header

### DIFF
--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -703,3 +703,15 @@ pub const cpu_type_t = integer_t;
 pub const cpu_subtype_t = integer_t;
 pub const integer_t = c_int;
 pub const vm_prot_t = c_int;
+
+/// CPU type targeting 64-bit Intel-based Macs
+pub const CPU_TYPE_X86_64: cpu_type_t = 0x01000007;
+
+/// CPU type targeting 64-bit ARM-based Macs
+pub const CPU_TYPE_ARM64: cpu_type_t = 0x0100000C;
+
+/// All Intel-based Macs
+pub const CPU_SUBTYPE_X86_64_ALL: cpu_subtype_t = 0x3;
+
+/// All ARM-based Macs
+pub const CPU_SUBTYPE_ARM_ALL: cpu_subtype_t = 0x0;

--- a/src-self-hosted/link.zig
+++ b/src-self-hosted/link.zig
@@ -40,7 +40,6 @@ pub const Options = struct {
     program_code_size_hint: u64 = 256 * 1024,
 };
 
-
 pub const File = struct {
     pub const LinkBlock = union {
         elf: Elf.TextBlock,

--- a/src-self-hosted/link/MachO.zig
+++ b/src-self-hosted/link/MachO.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const fs = std.fs;
-const log = std.log;
+const log = std.log.scoped(.link);
 const macho = std.macho;
 
 const Module = @import("../Module.zig");

--- a/src-self-hosted/link/MachO.zig
+++ b/src-self-hosted/link/MachO.zig
@@ -134,10 +134,10 @@ fn writeMachOHeader(self: *MachO) !void {
 pub fn flush(self: *MachO, module: *Module) !void {
     // TODO implement flush
     if (self.entry_addr == null and self.base.options.output_mode == .Exe) {
-        log.debug(.link, "flushing. no_entry_point_found = true\n", .{});
+        log.debug("flushing. no_entry_point_found = true\n", .{});
         self.error_flags.no_entry_point_found = true;
     } else {
-        log.debug(.link, "flushing. no_entry_point_found = false\n", .{});
+        log.debug("flushing. no_entry_point_found = false\n", .{});
         self.error_flags.no_entry_point_found = false;
         try self.writeMachOHeader();
     }


### PR DESCRIPTION
This commit write out Mach-O header in the linker's `flush`
method. The header currently only populates the magic number,
filetype, and cpu info.

Signed-off-by: Jakub Konka <kubkon@jakubkonka.com>