### PR TITLE
add UTIME_NOW and UTIME_OMIT constants for use in utimensat/futimens

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -770,6 +770,9 @@ pub fn S_ISSOCK(m: u32) bool {
     return m & S_IFMT == S_IFSOCK;
 }
 
+pub const UTIME_NOW = 0x3fffffff;
+pub const UTIME_OMIT = 0x3ffffffe;
+
 pub const TFD_NONBLOCK = O_NONBLOCK;
 pub const TFD_CLOEXEC = O_CLOEXEC;
 


### PR DESCRIPTION
I saw that these were missing when looking into #6082.

copied from lib/libc/include/generic-musl/sys/stat.h