### PR TITLE
std: remove init functions from linked list nodes

### DIFF
--- a/lib/std/linked_list.zig
+++ b/lib/std/linked_list.zig
@@ -28,12 +28,6 @@ pub fn SinglyLinkedList(comptime T: type) type {
 
             pub const Data = T;
 
-            pub fn init(data: T) Node {
-                return Node{
-                    .data = data,
-                };
-            }
-
             /// Insert a new node after the current one.
             ///
             /// Arguments:
@@ -175,12 +169,6 @@ pub fn TailQueue(comptime T: type) type {
             prev: ?*Node = null,
             next: ?*Node = null,
             data: T,
-
-            pub fn init(data: T) Node {
-                return Node{
-                    .data = data,
-                };
-            }
         };
 
         first: ?*Node = null,


### PR DESCRIPTION
These functions are rather useless and redundant as initializing the
struct directly is just as easy:

var node = TailQueue(u32).Node{ .data = 42 };

See: https://github.com/ziglang/zig/pull/6118#issuecomment-678487063