### PR TITLE
remove licensing comments from init-exe/init-lib

### DIFF
--- a/lib/std/special/init-exe/build.zig
+++ b/lib/std/special/init-exe/build.zig
@@ -1,8 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright (c) 2015-2020 Zig Contributors
-// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
-// The MIT license requires this copyright notice to be included in all copies
-// and substantial portions of the software.
 const Builder = @import("std").build.Builder;
 
 pub fn build(b: *Builder) void {

--- a/lib/std/special/init-exe/src/main.zig
+++ b/lib/std/special/init-exe/src/main.zig
@@ -1,8 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright (c) 2015-2020 Zig Contributors
-// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
-// The MIT license requires this copyright notice to be included in all copies
-// and substantial portions of the software.
 const std = @import("std");
 
 pub fn main() anyerror!void {

--- a/lib/std/special/init-lib/build.zig
+++ b/lib/std/special/init-lib/build.zig
@@ -1,8 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright (c) 2015-2020 Zig Contributors
-// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
-// The MIT license requires this copyright notice to be included in all copies
-// and substantial portions of the software.
 const Builder = @import("std").build.Builder;
 
 pub fn build(b: *Builder) void {

--- a/lib/std/special/init-lib/src/main.zig
+++ b/lib/std/special/init-lib/src/main.zig
@@ -1,8 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright (c) 2015-2020 Zig Contributors
-// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
-// The MIT license requires this copyright notice to be included in all copies
-// and substantial portions of the software.
 const std = @import("std");
 const testing = std.testing;
 


### PR DESCRIPTION
I'm confused if those comments, which are specific to the copyright of the Zig project, should be embedded into new projects doing `init-lib` / `init-exe`.

Making this as a PR instead of an issue as it's a trivial change.