### PR TITLE
Fix & update windows version stuff

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -77,8 +77,6 @@ pub const Target = struct {
             }
         };
 
-        // TODO do we really need these constants? Versions 19h1 and 19h2 share
-        // the same NTDDI version, we cannot encode them both in this format
         /// Based on NTDDI version constants from
         /// https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt
         pub const WindowsVersion = enum(u32) {

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -101,6 +101,7 @@ pub const Target = struct {
             win10_20h1 = 0x0A000008,
             _,
 
+            /// Latest Windows version that the Zig Standard Library is aware of
             pub const latest = WindowsVersion.win10_20h1;
             
             pub const Range = struct {

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -131,9 +131,9 @@ pub const Target = struct {
             ) !void {
                 if (fmt.len > 0 and fmt[0] == 's') {
                     if (@enumToInt(self) >= @enumToInt(WindowsVersion.nt4) and @enumToInt(self) <= @enumToInt(WindowsVersion.latest)) {
-                        try std.fmt.format(out_stream, "{}", .{@tagName(self)});
+                        try std.fmt.format(out_stream, ".{}", .{@tagName(self)});
                     } else {
-                        // TODO this breaks CrossTarget.parse
+                        // TODO this code path breaks zig triples, but it is used in `builtin`
                         try std.fmt.format(out_stream, "@intToEnum(Target.Os.WindowsVersion, 0x{X:0>8})", .{@enumToInt(self)});
                     }
                 } else {

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -77,6 +77,8 @@ pub const Target = struct {
             }
         };
 
+        // TODO do we really need these constants? Versions 19h1 and 19h2 share
+        // the same NTDDI version, we cannot encode them both in this format
         /// Based on NTDDI version constants from
         /// https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt
         pub const WindowsVersion = enum(u32) {
@@ -96,8 +98,11 @@ pub const Target = struct {
             win10_rs4 = 0x0A000005,
             win10_rs5 = 0x0A000006,
             win10_19h1 = 0x0A000007,
+            win10_20h1 = 0x0A000008,
             _,
 
+            pub const latest = WindowsVersion.win10_20h1;
+            
             pub const Range = struct {
                 min: WindowsVersion,
                 max: WindowsVersion,
@@ -124,16 +129,17 @@ pub const Target = struct {
                 out_stream: anytype,
             ) !void {
                 if (fmt.len > 0 and fmt[0] == 's') {
-                    if (@enumToInt(self) >= @enumToInt(WindowsVersion.nt4) and @enumToInt(self) <= @enumToInt(WindowsVersion.win10_19h1)) {
-                        try std.fmt.format(out_stream, ".{}", .{@tagName(self)});
+                    if (@enumToInt(self) >= @enumToInt(WindowsVersion.nt4) and @enumToInt(self) <= @enumToInt(WindowsVersion.latest)) {
+                        try std.fmt.format(out_stream, "{}", .{@tagName(self)});
                     } else {
-                        try std.fmt.format(out_stream, "@intToEnum(Target.Os.WindowsVersion, {})", .{@enumToInt(self)});
+                        // TODO this breaks CrossTarget.parse
+                        try std.fmt.format(out_stream, "@intToEnum(Target.Os.WindowsVersion, 0x{X:0>8})", .{@enumToInt(self)});
                     }
                 } else {
-                    if (@enumToInt(self) >= @enumToInt(WindowsVersion.nt4) and @enumToInt(self) <= @enumToInt(WindowsVersion.win10_19h1)) {
+                    if (@enumToInt(self) >= @enumToInt(WindowsVersion.nt4) and @enumToInt(self) <= @enumToInt(WindowsVersion.latest)) {
                         try std.fmt.format(out_stream, "WindowsVersion.{}", .{@tagName(self)});
                     } else {
-                        try std.fmt.format(out_stream, "WindowsVersion({})", .{@enumToInt(self)});
+                        try std.fmt.format(out_stream, "WindowsVersion(0x{X:0>8})", .{@enumToInt(self)});
                     }
                 }
             }
@@ -278,7 +284,7 @@ pub const Target = struct {
                     .windows => return .{
                         .windows = .{
                             .min = .win8_1,
-                            .max = .win10_19h1,
+                            .max = WindowsVersion.latest,
                         },
                     },
                 }

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -519,14 +519,14 @@ pub const CrossTarget = struct {
             switch (self.getOsVersionMin()) {
                 .none => {},
                 .semver => |v| try result.outStream().print(".{}", .{v}),
-                .windows => |v| try result.outStream().print(".{s}", .{v}),
+                .windows => |v| try result.outStream().print("{s}", .{v}),
             }
         }
         if (self.os_version_max) |max| {
             switch (max) {
                 .none => {},
                 .semver => |v| try result.outStream().print("...{}", .{v}),
-                .windows => |v| try result.outStream().print("...{s}", .{v}),
+                .windows => |v| try result.outStream().print("..{s}", .{v}),
             }
         }
 

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -519,14 +519,14 @@ pub const CrossTarget = struct {
             switch (self.getOsVersionMin()) {
                 .none => {},
                 .semver => |v| try result.outStream().print(".{}", .{v}),
-                .windows => |v| try result.outStream().print("{s}", .{v}),
+                .windows => |v| try result.outStream().print(".{s}", .{v}),
             }
         }
         if (self.os_version_max) |max| {
             switch (max) {
                 .none => {},
                 .semver => |v| try result.outStream().print("...{}", .{v}),
-                .windows => |v| try result.outStream().print("..{s}", .{v}),
+                .windows => |v| try result.outStream().print("...{s}", .{v}),
             }
         }
 

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -249,7 +249,7 @@ pub const NativeTargetInfo = struct {
                         // values
                         const known_build_numbers = [_]u32{
                             10240, 10586, 14393, 15063, 16299, 17134, 17763,
-                            18362, 18363,
+                            18362, 19041,
                         };
                         var last_idx: usize = 0;
                         for (known_build_numbers) |build, i| {


### PR DESCRIPTION
Removed build 18363 from known_build_numbers since that build does not have a dedicated NTDDI version
Moved hardcoded latest windows version to a centralised location  