### PR TITLE
Improve crypto benchmarks

### DIFF
--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -47,7 +47,7 @@ pub fn benchmarkHash(comptime Hash: anytype, comptime bytes: comptime_int) !u64 
     while (offset < bytes) : (offset += block.len) {
         h.update(block[0..]);
     }
-    mem.forceEval(&h);
+    mem.doNotOptimizeAway(&h);
     const end = timer.read();
 
     const elapsed_s = @intToFloat(f64, end - start) / time.ns_per_s;
@@ -82,7 +82,7 @@ pub fn benchmarkMac(comptime Mac: anytype, comptime bytes: comptime_int) !u64 {
     const start = timer.lap();
     while (offset < bytes) : (offset += in.len) {
         Mac.create(mac[0..], in[0..], key[0..]);
-        mem.forceEval(&mac);
+        mem.doNotOptimizeAway(&mac);
     }
     const end = timer.read();
 
@@ -109,7 +109,7 @@ pub fn benchmarkKeyExchange(comptime DhKeyExchange: anytype, comptime exchange_c
         var i: usize = 0;
         while (i < exchange_count) : (i += 1) {
             _ = DhKeyExchange.create(out[0..], out[0..], in[0..]);
-            mem.forceEval(&out);
+            mem.doNotOptimizeAway(&out);
         }
     }
     const end = timer.read();
@@ -134,7 +134,7 @@ pub fn benchmarkSignature(comptime Signature: anytype, comptime signatures_count
         var i: usize = 0;
         while (i < signatures_count) : (i += 1) {
             const s = try Signature.sign(&msg, key_pair, null);
-            mem.forceEval(&s);
+            mem.doNotOptimizeAway(&s);
         }
     }
     const end = timer.read();
@@ -170,7 +170,7 @@ pub fn benchmarkAead(comptime Aead: anytype, comptime bytes: comptime_int) !u64 
         Aead.encrypt(in[0..], tag[0..], in[0..], &[_]u8{}, nonce, key);
         Aead.decrypt(in[0..], in[0..], tag, &[_]u8{}, nonce, key) catch unreachable;
     }
-    mem.forceEval(&in);
+    mem.doNotOptimizeAway(&in);
     const end = timer.read();
 
     const elapsed_s = @intToFloat(f64, end - start) / time.ns_per_s;

--- a/lib/std/crypto/chacha20.zig
+++ b/lib/std/crypto/chacha20.zig
@@ -744,26 +744,26 @@ pub const Chacha20Poly1305 = struct {
     pub const key_length = 32;
 
     /// c: ciphertext: output buffer should be of size m.len
-    /// at: authentication tag: output MAC
+    /// tag: authentication tag: output MAC
     /// m: message
     /// ad: Associated Data
     /// npub: public nonce
     /// k: private key
-    pub fn encrypt(c: []u8, at: *[tag_length]u8, m: []const u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) void {
+    pub fn encrypt(c: []u8, tag: *[tag_length]u8, m: []const u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) void {
         assert(c.len == m.len);
-        return chacha20poly1305SealDetached(c, at, m, ad, k, npub);
+        return chacha20poly1305SealDetached(c, tag, m, ad, k, npub);
     }
 
     /// m: message: output buffer should be of size c.len
     /// c: ciphertext
-    /// at: authentication tag
+    /// tag: authentication tag
     /// ad: Associated Data
     /// npub: public nonce
     /// k: private key
     /// NOTE: the check of the authentication tag is currently not done in constant time
-    pub fn decrypt(m: []u8, c: []const u8, at: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) !void {
+    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) !void {
         assert(c.len == m.len);
-        return try chacha20poly1305OpenDetached(m, c, at[0..], ad, k, npub);
+        return try chacha20poly1305OpenDetached(m, c, tag[0..], ad, k, npub);
     }
 };
 
@@ -773,26 +773,26 @@ pub const XChacha20Poly1305 = struct {
     pub const key_length = 32;
 
     /// c: ciphertext: output buffer should be of size m.len
-    /// at: authentication tag: output MAC
+    /// tag: authentication tag: output MAC
     /// m: message
     /// ad: Associated Data
     /// npub: public nonce
     /// k: private key
-    pub fn encrypt(c: []u8, at: *[tag_length]u8, m: []const u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) void {
+    pub fn encrypt(c: []u8, tag: *[tag_length]u8, m: []const u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) void {
         assert(c.len == m.len);
-        return xchacha20poly1305SealDetached(c, at, m, ad, k, npub);
+        return xchacha20poly1305SealDetached(c, tag, m, ad, k, npub);
     }
 
     /// m: message: output buffer should be of size c.len
     /// c: ciphertext
-    /// at: authentication tag
+    /// tag: authentication tag
     /// ad: Associated Data
     /// npub: public nonce
     /// k: private key
     /// NOTE: the check of the authentication tag is currently not done in constant time
-    pub fn decrypt(m: []u8, c: []const u8, at: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) !void {
+    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) !void {
         assert(c.len == m.len);
-        return try xchacha20poly1305OpenDetached(m, c, at[0..], ad, k, npub);
+        return try xchacha20poly1305OpenDetached(m, c, tag[0..], ad, k, npub);
     }
 };
 

--- a/lib/std/crypto/chacha20.zig
+++ b/lib/std/crypto/chacha20.zig
@@ -47,7 +47,7 @@ fn initContext(key: [8]u32, d: [4]u32) [16]u32 {
 }
 
 // The chacha family of ciphers are based on the salsa family.
-fn chacha20Core(x: []u32, input: [16]u32) void {
+inline fn chacha20Core(x: []u32, input: [16]u32) void {
     for (x) |_, i|
         x[i] = input[i];
 

--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -180,10 +180,14 @@ test "hash" {
 }
 
 pub const Aead = struct {
+    pub const tag_length = State.RATE;
+    pub const nonce_length = 16;
+    pub const key_length = 32;
+
     /// ad: Associated Data
     /// npub: public nonce
     /// k: private key
-    fn init(ad: []const u8, npub: [16]u8, k: [32]u8) State {
+    fn init(ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) State {
         var state = State{
             .data = undefined,
         };
@@ -229,7 +233,7 @@ pub const Aead = struct {
     /// ad: Associated Data
     /// npub: public nonce
     /// k: private key
-    pub fn encrypt(c: []u8, at: *[State.RATE]u8, m: []const u8, ad: []const u8, npub: [16]u8, k: [32]u8) void {
+    pub fn encrypt(c: []u8, at: *[tag_length]u8, m: []const u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) void {
         assert(c.len == m.len);
 
         var state = Aead.init(ad, npub, k);
@@ -275,7 +279,7 @@ pub const Aead = struct {
     /// npub: public nonce
     /// k: private key
     /// NOTE: the check of the authentication tag is currently not done in constant time
-    pub fn decrypt(m: []u8, c: []const u8, at: [State.RATE]u8, ad: []const u8, npub: [16]u8, k: [32]u8) !void {
+    pub fn decrypt(m: []u8, c: []const u8, at: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) !void {
         assert(c.len == m.len);
 
         var state = Aead.init(ad, npub, k);

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -5,6 +5,7 @@
 // and substantial portions of the software.
 const std = @import("std.zig");
 const assert = std.debug.assert;
+const mem = std.mem;
 const testing = std.testing;
 
 /// Euler's number (e)
@@ -108,34 +109,8 @@ pub fn approxEq(comptime T: type, x: T, y: T, epsilon: T) bool {
     return fabs(x - y) < epsilon;
 }
 
-// TODO: Hide the following in an internal module.
 pub fn forceEval(value: anytype) void {
-    const T = @TypeOf(value);
-    switch (T) {
-        f16 => {
-            var x: f16 = undefined;
-            const p = @ptrCast(*volatile f16, &x);
-            p.* = x;
-        },
-        f32 => {
-            var x: f32 = undefined;
-            const p = @ptrCast(*volatile f32, &x);
-            p.* = x;
-        },
-        f64 => {
-            var x: f64 = undefined;
-            const p = @ptrCast(*volatile f64, &x);
-            p.* = x;
-        },
-        f128 => {
-            var x: f128 = undefined;
-            const p = @ptrCast(*volatile f128, &x);
-            p.* = x;
-        },
-        else => {
-            @compileError("forceEval not implemented for " ++ @typeName(T));
-        },
-    }
+    mem.forceEval(value);
 }
 
 pub fn raiseInvalid() void {

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -109,8 +109,8 @@ pub fn approxEq(comptime T: type, x: T, y: T, epsilon: T) bool {
     return fabs(x - y) < epsilon;
 }
 
-pub fn forceEval(value: anytype) void {
-    mem.forceEval(value);
+pub fn doNotOptimizeAway(value: anytype) void {
+    mem.doNotOptimizeAway(value);
 }
 
 pub fn raiseInvalid() void {

--- a/lib/std/math/asinh.zig
+++ b/lib/std/math/asinh.zig
@@ -56,7 +56,7 @@ fn asinh32(x: f32) f32 {
     }
     // |x| < 0x1p-12, inexact if x != 0
     else {
-        math.forceEval(x + 0x1.0p120);
+        math.doNotOptimizeAway(x + 0x1.0p120);
     }
 
     return if (s != 0) -rx else rx;
@@ -87,7 +87,7 @@ fn asinh64(x: f64) f64 {
     }
     // |x| < 0x1p-12, inexact if x != 0
     else {
-        math.forceEval(x + 0x1.0p120);
+        math.doNotOptimizeAway(x + 0x1.0p120);
     }
 
     return if (s != 0) -rx else rx;

--- a/lib/std/math/atan.zig
+++ b/lib/std/math/atan.zig
@@ -72,7 +72,7 @@ fn atan32(x_: f32) f32 {
         // |x| < 2^(-12)
         if (ix < 0x39800000) {
             if (ix < 0x00800000) {
-                math.forceEval(x * x);
+                math.doNotOptimizeAway(x * x);
             }
             return x;
         }
@@ -170,7 +170,7 @@ fn atan64(x_: f64) f64 {
         // |x| < 2^(-27)
         if (ix < 0x3E400000) {
             if (ix < 0x00100000) {
-                math.forceEval(@floatCast(f32, x));
+                math.doNotOptimizeAway(@floatCast(f32, x));
             }
             return x;
         }

--- a/lib/std/math/atanh.zig
+++ b/lib/std/math/atanh.zig
@@ -45,7 +45,7 @@ fn atanh_32(x: f32) f32 {
         if (u < 0x3F800000 - (32 << 23)) {
             // underflow
             if (u < (1 << 23)) {
-                math.forceEval(y * y);
+                math.doNotOptimizeAway(y * y);
             }
         }
         // |x| < 0.5
@@ -74,7 +74,7 @@ fn atanh_64(x: f64) f64 {
         if (e < 0x3FF - 32) {
             // underflow
             if (e == 0) {
-                math.forceEval(@floatCast(f32, y));
+                math.doNotOptimizeAway(@floatCast(f32, y));
             }
         }
         // |x| < 0.5

--- a/lib/std/math/ceil.zig
+++ b/lib/std/math/ceil.zig
@@ -47,14 +47,14 @@ fn ceil32(x: f32) f32 {
         if (u & m == 0) {
             return x;
         }
-        math.forceEval(x + 0x1.0p120);
+        math.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 == 0) {
             u += m;
         }
         u &= ~m;
         return @bitCast(f32, u);
     } else {
-        math.forceEval(x + 0x1.0p120);
+        math.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 != 0) {
             return -0.0;
         } else {
@@ -79,7 +79,7 @@ fn ceil64(x: f64) f64 {
     }
 
     if (e <= 0x3FF - 1) {
-        math.forceEval(y);
+        math.doNotOptimizeAway(y);
         if (u >> 63 != 0) {
             return -0.0;
         } else {
@@ -106,7 +106,7 @@ fn ceil128(x: f128) f128 {
     }
 
     if (e <= 0x3FFF - 1) {
-        math.forceEval(y);
+        math.doNotOptimizeAway(y);
         if (u >> 127 != 0) {
             return -0.0;
         } else {

--- a/lib/std/math/exp.zig
+++ b/lib/std/math/exp.zig
@@ -56,7 +56,7 @@ fn exp32(x_: f32) f32 {
             return x * 0x1.0p127;
         }
         if (sign != 0) {
-            math.forceEval(-0x1.0p-149 / x); // overflow
+            math.doNotOptimizeAway(-0x1.0p-149 / x); // overflow
             // x <= -103.972084
             if (hx >= 0x42CFF1B5) {
                 return 0;
@@ -88,7 +88,7 @@ fn exp32(x_: f32) f32 {
         hi = x;
         lo = 0;
     } else {
-        math.forceEval(0x1.0p127 + x); // inexact
+        math.doNotOptimizeAway(0x1.0p127 + x); // inexact
         return 1 + x;
     }
 
@@ -139,7 +139,7 @@ fn exp64(x_: f64) f64 {
         }
         if (x < -708.39641853226410622) {
             // underflow if x != -inf
-            // math.forceEval(@as(f32, -0x1.0p-149 / x));
+            // math.doNotOptimizeAway(@as(f32, -0x1.0p-149 / x));
             if (x < -745.13321910194110842) {
                 return 0;
             }
@@ -172,7 +172,7 @@ fn exp64(x_: f64) f64 {
         lo = 0;
     } else {
         // inexact if x != 0
-        // math.forceEval(0x1.0p1023 + x);
+        // math.doNotOptimizeAway(0x1.0p1023 + x);
         return 1 + x;
     }
 

--- a/lib/std/math/exp2.zig
+++ b/lib/std/math/exp2.zig
@@ -70,7 +70,7 @@ fn exp2_32(x: f32) f32 {
         // x < -126
         if (u >= 0x80000000) {
             if (u >= 0xC3160000 or u & 0x000FFFF != 0) {
-                math.forceEval(-0x1.0p-149 / x);
+                math.doNotOptimizeAway(-0x1.0p-149 / x);
             }
             // x <= -150
             if (u >= 0x3160000) {
@@ -393,7 +393,7 @@ fn exp2_64(x: f64) f64 {
         if (ux >> 63 != 0) {
             // underflow
             if (x <= -1075 or x - 0x1.0p52 + 0x1.0p52 != x) {
-                math.forceEval(@floatCast(f32, -0x1.0p-149 / x));
+                math.doNotOptimizeAway(@floatCast(f32, -0x1.0p-149 / x));
             }
             if (x <= -1075) {
                 return 0;

--- a/lib/std/math/expm1.zig
+++ b/lib/std/math/expm1.zig
@@ -106,7 +106,7 @@ fn expm1_32(x_: f32) f32 {
     // |x| < 2^(-25)
     else if (hx < 0x33000000) {
         if (hx < 0x00800000) {
-            math.forceEval(x * x);
+            math.doNotOptimizeAway(x * x);
         }
         return x;
     } else {
@@ -237,7 +237,7 @@ fn expm1_64(x_: f64) f64 {
     // |x| < 2^(-54)
     else if (hx < 0x3C900000) {
         if (hx < 0x00100000) {
-            math.forceEval(@floatCast(f32, x));
+            math.doNotOptimizeAway(@floatCast(f32, x));
         }
         return x;
     } else {

--- a/lib/std/math/floor.zig
+++ b/lib/std/math/floor.zig
@@ -50,13 +50,13 @@ fn floor16(x: f16) f16 {
         if (u & m == 0) {
             return x;
         }
-        math.forceEval(x + 0x1.0p120);
+        math.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 15 != 0) {
             u += m;
         }
         return @bitCast(f16, u & ~m);
     } else {
-        math.forceEval(x + 0x1.0p120);
+        math.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 15 == 0) {
             return 0.0;
         } else {
@@ -84,13 +84,13 @@ fn floor32(x: f32) f32 {
         if (u & m == 0) {
             return x;
         }
-        math.forceEval(x + 0x1.0p120);
+        math.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 != 0) {
             u += m;
         }
         return @bitCast(f32, u & ~m);
     } else {
-        math.forceEval(x + 0x1.0p120);
+        math.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 == 0) {
             return 0.0;
         } else {
@@ -115,7 +115,7 @@ fn floor64(x: f64) f64 {
     }
 
     if (e <= 0x3FF - 1) {
-        math.forceEval(y);
+        math.doNotOptimizeAway(y);
         if (u >> 63 != 0) {
             return -1.0;
         } else {
@@ -142,7 +142,7 @@ fn floor128(x: f128) f128 {
     }
 
     if (e <= 0x3FFF - 1) {
-        math.forceEval(y);
+        math.doNotOptimizeAway(y);
         if (u >> 127 != 0) {
             return -1.0;
         } else {

--- a/lib/std/math/log1p.zig
+++ b/lib/std/math/log1p.zig
@@ -62,7 +62,7 @@ fn log1p_32(x: f32) f32 {
         if ((ix << 1) < (0x33800000 << 1)) {
             // underflow if subnormal
             if (ix & 0x7F800000 == 0) {
-                math.forceEval(x * x);
+                math.doNotOptimizeAway(x * x);
             }
             return x;
         }

--- a/lib/std/math/round.zig
+++ b/lib/std/math/round.zig
@@ -43,7 +43,7 @@ fn round32(x_: f32) f32 {
         x = -x;
     }
     if (e < 0x7F - 1) {
-        math.forceEval(x + math.f32_toint);
+        math.doNotOptimizeAway(x + math.f32_toint);
         return 0 * @bitCast(f32, u);
     }
 
@@ -76,7 +76,7 @@ fn round64(x_: f64) f64 {
         x = -x;
     }
     if (e < 0x3ff - 1) {
-        math.forceEval(x + math.f64_toint);
+        math.doNotOptimizeAway(x + math.f64_toint);
         return 0 * @bitCast(f64, u);
     }
 
@@ -109,7 +109,7 @@ fn round128(x_: f128) f128 {
         x = -x;
     }
     if (e < 0x3FFF - 1) {
-        math.forceEval(x + math.f64_toint);
+        math.doNotOptimizeAway(x + math.f64_toint);
         return 0 * @bitCast(f128, u);
     }
 

--- a/lib/std/math/tanh.zig
+++ b/lib/std/math/tanh.zig
@@ -67,7 +67,7 @@ fn tanh32(x: f32) f32 {
     }
     // |x| is subnormal
     else {
-        math.forceEval(x * x);
+        math.doNotOptimizeAway(x * x);
         t = x;
     }
 
@@ -112,7 +112,7 @@ fn tanh64(x: f64) f64 {
     }
     // |x| is subnormal
     else {
-        math.forceEval(@floatCast(f32, x));
+        math.doNotOptimizeAway(@floatCast(f32, x));
         t = x;
     }
 

--- a/lib/std/math/trunc.zig
+++ b/lib/std/math/trunc.zig
@@ -46,7 +46,7 @@ fn trunc32(x: f32) f32 {
     if (u & m == 0) {
         return x;
     } else {
-        math.forceEval(x + 0x1p120);
+        math.doNotOptimizeAway(x + 0x1p120);
         return @bitCast(f32, u & ~m);
     }
 }
@@ -67,7 +67,7 @@ fn trunc64(x: f64) f64 {
     if (u & m == 0) {
         return x;
     } else {
-        math.forceEval(x + 0x1p120);
+        math.doNotOptimizeAway(x + 0x1p120);
         return @bitCast(f64, u & ~m);
     }
 }
@@ -88,7 +88,7 @@ fn trunc128(x: f128) f128 {
     if (u & m == 0) {
         return x;
     } else {
-        math.forceEval(x + 0x1p120);
+        math.doNotOptimizeAway(x + 0x1p120);
         return @bitCast(f128, u & ~m);
     }
 }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2161,7 +2161,7 @@ pub fn alignForwardGeneric(comptime T: type, addr: T, alignment: T) T {
 /// Force an evaluation of the expression; this tries to prevent
 /// the compiler from optimizing the computation away even if the
 /// result eventually gets discarded.
-pub fn forceEval(val: anytype) void {
+pub fn doNotOptimizeAway(val: anytype) void {
     asm volatile (""
         :
         : [val] "rm" (val)

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2158,6 +2158,17 @@ pub fn alignForwardGeneric(comptime T: type, addr: T, alignment: T) T {
     return alignBackwardGeneric(T, addr + (alignment - 1), alignment);
 }
 
+/// Force an evaluation of the expression; this tries to prevent
+/// the compiler from optimizing the computation away even if the
+/// result eventually gets discarded.
+pub fn forceEval(val: anytype) void {
+    asm volatile (""
+        :
+        : [val] "rm" (val)
+        : "memory"
+    );
+}
+
 test "alignForward" {
     testing.expect(alignForward(1, 1) == 1);
     testing.expect(alignForward(2, 1) == 2);


### PR DESCRIPTION
- 1MiB objects on the stack doesn't play well with wasmtime. Reduce these to 512KiB so that the webassembly benchmarks can run.
- Pass expected results to a `blackBox()` function. Without this, in `release-fast` mode, the compiler could detected unused return values, and would produce results that didn't make sense for `siphash`.
- Add AEAD constructions to the benchmarks.
- Inline `chacha20Core()` makes it 4 times faster.
- `benchmarkSignatures()` -> `benchmarkSignature()` for consistency.