### PR TITLE
Added edge case test to mem.count

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -920,6 +920,7 @@ test "mem.count" {
     testing.expect(count(u8, "foo bar", "o bar") == 1);
     testing.expect(count(u8, "foofoofoo", "foo") == 3);
     testing.expect(count(u8, "fffffff", "ff") == 3);
+    testing.expect(count(u8, "owowowu", "owowu") == 1);
 }
 
 /// Reads an integer from memory with size equal to bytes.len.


### PR DESCRIPTION
Some implementations break on this edge case. Thought relevant to add it.