### PR TITLE
ensure main return type is not i8

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -248,7 +248,7 @@ pub fn callMain() u8 {
             return 0;
         },
         .Int => |info| {
-            if (info.bits != 8) {
+            if (info.bits != 8 or info.is_signed) {
                 @compileError(bad_main_ret);
             }
             return root.main();
@@ -264,7 +264,7 @@ pub fn callMain() u8 {
             switch (@typeInfo(@TypeOf(result))) {
                 .Void => return 0,
                 .Int => |info| {
-                    if (info.bits != 8) {
+                    if (info.bits != 8 or info.is_signed) {
                         @compileError(bad_main_ret);
                     }
                     return result;


### PR DESCRIPTION
Avoids a compile error from start.zig:

```
/home/kivikakk/zig/build/lib/zig/std/start.zig:265:28: error: expected type 'u8', found 'i8'
		    return result;
				   ^
/home/kivikakk/zig/build/lib/zig/std/start.zig:265:28: note: unsigned 8-bit int cannot represent all possible signed 8-bit values
		    return result;
```

We could add a test case in `compile_errors.zig`, but it doesn't seem worth it?