### PR TITLE
Add the reboot and sync Linux syscalls

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1770,3 +1770,21 @@ pub const ifreq = extern struct {
         data: ?[*]u8,
     },
 };
+
+pub const LINUX_REBOOT_MAGIC2 = enum(u32) {
+    MAGIC2 = 0x28121969,
+    MAGIC2A = 0x05121996,
+    MAGIC2B = 0x16041998,
+    MAGIC2C = 0x20112000,
+};
+
+pub const LINUX_REBOOT_CMD = enum(u32) {
+    CAD_OFF = 0,
+    CAD_ON = 0x89abcdef,
+    HALT = 0xcdef0123,
+    KEXEC = 0x45584543,
+    POWER_OFF = 0x4321fedc,
+    RESTART = 0x1234567,
+    RESTART2 = 0xa1b2c3d4,
+    SW_SUSPEND = 0xd000fce1,
+};

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1226,6 +1226,27 @@ pub fn bpf(cmd: BPF.Cmd, attr: *BPF.Attr, size: u32) usize {
     return syscall3(.bpf, @enumToInt(cmd), @ptrToInt(attr), size);
 }
 
+pub fn sync() void {
+    _ = syscall0(.sync);
+    return;
+}
+
+pub fn syncfs(fd: fd_t) usize {
+    return syscall1(.syncfs, @bitCast(usize, @as(isize, fd)));
+}
+
+pub fn fsync(fd: fd_t) usize {
+    return syscall1(.fsync, @bitCast(usize, @as(isize, fd)));
+}
+
+pub fn fdatasync(fd: fd_t) usize {
+    return syscall1(.fdatasync, @bitCast(usize, @as(isize, fd)));
+}
+
+pub fn reboot(magic2: LINUX_REBOOT_MAGIC2, cmd: LINUX_REBOOT_CMD, arg: ?[*:0]const u8) usize {
+    return syscall4(.reboot, 0xfee1dead, @enumToInt(magic2), @enumToInt(cmd), @ptrToInt(arg));
+}
+
 test "" {
     if (builtin.os.tag == .linux) {
         _ = @import("linux/test.zig");


### PR DESCRIPTION
The first argument to *reboot* must always be 0xfee1dead, so I hardcoded that. The second argument has four alternative easter-egg values (the birthday of Linus Torvalds and his children, respectively) that all do the same thing and could also potentially be hardcoded to just the first value, like glibc and [musl does](http://git.musl-libc.org/cgit/musl/tree/src/linux/reboot.c).