### PR TITLE
std: Add std.math.divCeil

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -646,31 +646,31 @@ test "math.divCeil" {
     comptime testDivCeil();
 }
 fn testDivCeil() void {
-    testing.expectEqual(divCeil(i32, 5, 3) catch unreachable, 2);
-    testing.expectEqual(divCeil(i32, -5, 3) catch unreachable, -1);
-    testing.expectEqual(divCeil(i32, 5, -3) catch unreachable, -1);
-    testing.expectEqual(divCeil(i32, -5, -3) catch unreachable, 2);
-    testing.expectEqual(divCeil(i32, 0, 5) catch unreachable, 0);
-    testing.expectEqual(divCeil(u32, 0, 5) catch unreachable, 0);
+    testing.expectEqual(@as(i32, 2), divCeil(i32, 5, 3) catch unreachable);
+    testing.expectEqual(@as(i32, -1), divCeil(i32, -5, 3) catch unreachable);
+    testing.expectEqual(@as(i32, -1), divCeil(i32, 5, -3) catch unreachable);
+    testing.expectEqual(@as(i32, 2), divCeil(i32, -5, -3) catch unreachable);
+    testing.expectEqual(@as(i32, 0), divCeil(i32, 0, 5) catch unreachable);
+    testing.expectEqual(@as(u32, 0), divCeil(u32, 0, 5) catch unreachable);
     testing.expectError(error.DivisionByZero, divCeil(i8, -5, 0));
     testing.expectError(error.Overflow, divCeil(i8, -128, -1));
 
-    testing.expectEqual(divCeil(f32, 0.0, 5.0) catch unreachable, 0.0);
-    testing.expectEqual(divCeil(f32, 5.0, 3.0) catch unreachable, 2.0);
-    testing.expectEqual(divCeil(f32, -5.0, 3.0) catch unreachable, -1.0);
-    testing.expectEqual(divCeil(f32, 5.0, -3.0) catch unreachable, -1.0);
-    testing.expectEqual(divCeil(f32, -5.0, -3.0) catch unreachable, 2.0);
+    testing.expectEqual(@as(f32, 0.0), divCeil(f32, 0.0, 5.0) catch unreachable);
+    testing.expectEqual(@as(f32, 2.0), divCeil(f32, 5.0, 3.0) catch unreachable);
+    testing.expectEqual(@as(f32, -1.0), divCeil(f32, -5.0, 3.0) catch unreachable);
+    testing.expectEqual(@as(f32, -1.0), divCeil(f32, 5.0, -3.0) catch unreachable);
+    testing.expectEqual(@as(f32, 2.0), divCeil(f32, -5.0, -3.0) catch unreachable);
 
-    testing.expectEqual(divCeil(comptime_int, 23, 4) catch unreachable, 6);
-    testing.expectEqual(divCeil(comptime_int, -23, 4) catch unreachable, -5);
-    testing.expectEqual(divCeil(comptime_int, 23, -4) catch unreachable, -5);
-    testing.expectEqual(divCeil(comptime_int, -23, -4) catch unreachable, 6);
+    testing.expectEqual(6, divCeil(comptime_int, 23, 4) catch unreachable);
+    testing.expectEqual(-5, divCeil(comptime_int, -23, 4) catch unreachable);
+    testing.expectEqual(-5, divCeil(comptime_int, 23, -4) catch unreachable);
+    testing.expectEqual(6, divCeil(comptime_int, -23, -4) catch unreachable);
     testing.expectError(error.DivisionByZero, divCeil(comptime_int, 23, 0));
 
-    testing.expectEqual(divCeil(comptime_float, 23.0, 4.0) catch unreachable, 6.0);
-    testing.expectEqual(divCeil(comptime_float, -23.0, 4.0) catch unreachable, -5.0);
-    testing.expectEqual(divCeil(comptime_float, 23.0, -4.0) catch unreachable, -5.0);
-    testing.expectEqual(divCeil(comptime_float, -23.0, -4.0) catch unreachable, 6.0);
+    testing.expectEqual(6.0, divCeil(comptime_float, 23.0, 4.0) catch unreachable);
+    testing.expectEqual(-5.0, divCeil(comptime_float, -23.0, 4.0) catch unreachable);
+    testing.expectEqual(-5.0, divCeil(comptime_float, 23.0, -4.0) catch unreachable);
+    testing.expectEqual(6.0, divCeil(comptime_float, -23.0, -4.0) catch unreachable);
     testing.expectError(error.DivisionByZero, divCeil(comptime_float, 23.0, 0.0));
 }
 

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -621,6 +621,26 @@ fn testDivFloor() void {
     testing.expect((divFloor(f32, -5.0, 3.0) catch unreachable) == -2.0);
 }
 
+pub fn divCeil(comptime T: type, numerator: T, denominator: T) !T {
+    @setRuntimeSafety(false);
+    if (numerator <= 0) return divTrunc(T, numerator, denominator);
+    return (try divFloor(T, numerator - 1, denominator)) + 1;
+}
+
+test "math.divCeil" {
+    testDivCeil();
+    comptime testDivCeil();
+}
+fn testDivCeil() void {
+    testing.expect((divCeil(i32, 5, 3) catch unreachable) == 2);
+    testing.expect((divCeil(i32, -5, 3) catch unreachable) == -1);
+    testing.expectError(error.DivisionByZero, divCeil(i8, -5, 0));
+    testing.expectError(error.Overflow, divCeil(i8, -128, -1));
+
+    testing.expect((divCeil(f32, 5.0, 3.0) catch unreachable) == 2.0);
+    testing.expect((divCeil(f32, -5.0, 3.0) catch unreachable) == -1.0);
+}
+
 pub fn divExact(comptime T: type, numerator: T, denominator: T) !T {
     @setRuntimeSafety(false);
     if (denominator == 0) return error.DivisionByZero;

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -624,6 +624,7 @@ fn testDivFloor() void {
 pub fn divCeil(comptime T: type, numerator: T, denominator: T) !T {
     @setRuntimeSafety(false);
     if (numerator <= 0) return divTrunc(T, numerator, denominator);
+    if (@typeInfo(T) == .Float) return @ceil(numerator / denominator);
     return (try divFloor(T, numerator - 1, denominator)) + 1;
 }
 

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -623,7 +623,10 @@ fn testDivFloor() void {
 
 pub fn divCeil(comptime T: type, numerator: T, denominator: T) !T {
     @setRuntimeSafety(false);
-    if (denominator == 0) return error.DivisionByZero;
+    if (!(comptime std.meta.trait.isNumber(T)))
+        @compileError("divCeil unsupported on " ++ @typeName(T));
+    if (denominator == 0)
+        return error.DivisionByZero;
     const info = @typeInfo(T);
     switch (info) {
         .ComptimeFloat, .Float => return @ceil(numerator / denominator),
@@ -637,7 +640,7 @@ pub fn divCeil(comptime T: type, numerator: T, denominator: T) !T {
                 return @divFloor(numerator - 1, denominator) + 1;
             return @divTrunc(numerator, denominator);
         },
-        else => @compileError("divCeil unsupported on " ++ @typeName(T)),
+        else => unreachable,
     }
 }
 

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -623,10 +623,7 @@ fn testDivFloor() void {
 
 pub fn divCeil(comptime T: type, numerator: T, denominator: T) !T {
     @setRuntimeSafety(false);
-    if (!(comptime std.meta.trait.isNumber(T)))
-        @compileError("divCeil unsupported on " ++ @typeName(T));
-    if (denominator == 0)
-        return error.DivisionByZero;
+    if (comptime std.meta.trait.isNumber(T) and denominator == 0) return error.DivisionByZero;
     const info = @typeInfo(T);
     switch (info) {
         .ComptimeFloat, .Float => return @ceil(numerator / denominator),
@@ -640,7 +637,7 @@ pub fn divCeil(comptime T: type, numerator: T, denominator: T) !T {
                 return @divFloor(numerator - 1, denominator) + 1;
             return @divTrunc(numerator, denominator);
         },
-        else => unreachable,
+        else => @compileError("divCeil unsupported on " ++ @typeName(T)),
     }
 }
 

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -646,31 +646,31 @@ test "math.divCeil" {
     comptime testDivCeil();
 }
 fn testDivCeil() void {
-    testing.expect((divCeil(i32, 5, 3) catch unreachable) == 2);
-    testing.expect((divCeil(i32, -5, 3) catch unreachable) == -1);
-    testing.expect((divCeil(i32, 5, -3) catch unreachable) == -1);
-    testing.expect((divCeil(i32, -5, -3) catch unreachable) == 2);
-    testing.expect((divCeil(i32, 0, 5) catch unreachable) == 0);
-    testing.expect((divCeil(u32, 0, 5) catch unreachable) == 0);
+    testing.expectEqual(divCeil(i32, 5, 3) catch unreachable, 2);
+    testing.expectEqual(divCeil(i32, -5, 3) catch unreachable, -1);
+    testing.expectEqual(divCeil(i32, 5, -3) catch unreachable, -1);
+    testing.expectEqual(divCeil(i32, -5, -3) catch unreachable, 2);
+    testing.expectEqual(divCeil(i32, 0, 5) catch unreachable, 0);
+    testing.expectEqual(divCeil(u32, 0, 5) catch unreachable, 0);
     testing.expectError(error.DivisionByZero, divCeil(i8, -5, 0));
     testing.expectError(error.Overflow, divCeil(i8, -128, -1));
 
-    testing.expect((divCeil(f32, 0.0, 5.0) catch unreachable) == 0.0);
-    testing.expect((divCeil(f32, 5.0, 3.0) catch unreachable) == 2.0);
-    testing.expect((divCeil(f32, -5.0, 3.0) catch unreachable) == -1.0);
-    testing.expect((divCeil(f32, 5.0, -3.0) catch unreachable) == -1.0);
-    testing.expect((divCeil(f32, -5.0, -3.0) catch unreachable) == 2.0);
+    testing.expectEqual(divCeil(f32, 0.0, 5.0) catch unreachable, 0.0);
+    testing.expectEqual(divCeil(f32, 5.0, 3.0) catch unreachable, 2.0);
+    testing.expectEqual(divCeil(f32, -5.0, 3.0) catch unreachable, -1.0);
+    testing.expectEqual(divCeil(f32, 5.0, -3.0) catch unreachable, -1.0);
+    testing.expectEqual(divCeil(f32, -5.0, -3.0) catch unreachable, 2.0);
 
-    testing.expect((divCeil(comptime_int, 23, 4) catch unreachable) == 6);
-    testing.expect((divCeil(comptime_int, -23, 4) catch unreachable) == -5);
-    testing.expect((divCeil(comptime_int, 23, -4) catch unreachable) == -5);
-    testing.expect((divCeil(comptime_int, -23, -4) catch unreachable) == 6);
+    testing.expectEqual(divCeil(comptime_int, 23, 4) catch unreachable, 6);
+    testing.expectEqual(divCeil(comptime_int, -23, 4) catch unreachable, -5);
+    testing.expectEqual(divCeil(comptime_int, 23, -4) catch unreachable, -5);
+    testing.expectEqual(divCeil(comptime_int, -23, -4) catch unreachable, 6);
     testing.expectError(error.DivisionByZero, divCeil(comptime_int, 23, 0));
 
-    testing.expect((divCeil(comptime_float, 23.0, 4.0) catch unreachable) == 6.0);
-    testing.expect((divCeil(comptime_float, -23.0, 4.0) catch unreachable) == -5.0);
-    testing.expect((divCeil(comptime_float, 23.0, -4.0) catch unreachable) == -5.0);
-    testing.expect((divCeil(comptime_float, -23.0, -4.0) catch unreachable) == 6.0);
+    testing.expectEqual(divCeil(comptime_float, 23.0, 4.0) catch unreachable, 6.0);
+    testing.expectEqual(divCeil(comptime_float, -23.0, 4.0) catch unreachable, -5.0);
+    testing.expectEqual(divCeil(comptime_float, 23.0, -4.0) catch unreachable, -5.0);
+    testing.expectEqual(divCeil(comptime_float, -23.0, -4.0) catch unreachable, 6.0);
     testing.expectError(error.DivisionByZero, divCeil(comptime_float, 23.0, 0.0));
 }
 

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -624,7 +624,10 @@ fn testDivFloor() void {
 pub fn divCeil(comptime T: type, numerator: T, denominator: T) !T {
     @setRuntimeSafety(false);
     if (numerator <= 0) return divTrunc(T, numerator, denominator);
-    if (@typeInfo(T) == .Float) return @ceil(numerator / denominator);
+    if (@typeInfo(T) == .Float) {
+        if (denominator == 0) return error.DivisionByZero;
+        return @ceil(numerator / denominator);
+    }
     return (try divFloor(T, numerator - 1, denominator)) + 1;
 }
 


### PR DESCRIPTION
This pull request adds an implementation of `divCeil` to the standard library.

Ceiled division is a useful operation that is easy to implement in a naive manner, but history has shown that not having it in a language's standard library leads to subpar attempts to implement the primitive. For example, both implementations [here](https://stackoverflow.com/a/2745086) not only ignore the existence of negative numbers, but also have overflow bugs. The first implementation addresses the overflow by referring to the second, which suggests checking for equality with 0 to avoid overflowing the numerator. But that approach *still* completely ignores negative numbers, and a naive implementation might incorrectly return `0` for `0/0` rather than `error.DivisionByZero`!

This standard implementation gives one obvious way for users in need of ceiled division to perform the required operation without the undesired behavior that could occur in a homemade implementation.