### PR TITLE
compiler-rt: Add missing floatdisf routine

### DIFF
--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -100,7 +100,8 @@ comptime {
     @export(@import("compiler_rt/floatditf.zig").__floatditf, .{ .name = "__floatditf", .linkage = linkage });
     @export(@import("compiler_rt/floattitf.zig").__floattitf, .{ .name = "__floattitf", .linkage = linkage });
     @export(@import("compiler_rt/floattidf.zig").__floattidf, .{ .name = "__floattidf", .linkage = linkage });
-    @export(@import("compiler_rt/floattisf.zig").__floattisf, .{ .name = "__floattisf", .linkage = linkage });
+    @export(@import("compiler_rt/floatXisf.zig").__floattisf, .{ .name = "__floattisf", .linkage = linkage });
+    @export(@import("compiler_rt/floatXisf.zig").__floatdisf, .{ .name = "__floatdisf", .linkage = linkage });
 
     @export(@import("compiler_rt/floatunditf.zig").__floatunditf, .{ .name = "__floatunditf", .linkage = linkage });
     @export(@import("compiler_rt/floatunsitf.zig").__floatunsitf, .{ .name = "__floatunsitf", .linkage = linkage });
@@ -204,6 +205,7 @@ comptime {
         @export(@import("compiler_rt/extendXfYf2.zig").__aeabi_f2d, .{ .name = "__aeabi_f2d", .linkage = linkage });
         @export(@import("compiler_rt/floatsiXf.zig").__aeabi_i2d, .{ .name = "__aeabi_i2d", .linkage = linkage });
         @export(@import("compiler_rt/floatdidf.zig").__aeabi_l2d, .{ .name = "__aeabi_l2d", .linkage = linkage });
+        @export(@import("compiler_rt/floatXisf.zig").__aeabi_l2f, .{ .name = "__aeabi_l2f", .linkage = linkage });
         @export(@import("compiler_rt/floatunsidf.zig").__aeabi_ui2d, .{ .name = "__aeabi_ui2d", .linkage = linkage });
         @export(@import("compiler_rt/floatundidf.zig").__aeabi_ul2d, .{ .name = "__aeabi_ul2d", .linkage = linkage });
         @export(@import("compiler_rt/floatunsisf.zig").__aeabi_ui2f, .{ .name = "__aeabi_ui2f", .linkage = linkage });

--- a/lib/std/special/compiler_rt/floatdisf_test.zig
+++ b/lib/std/special/compiler_rt/floatdisf_test.zig
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2015-2020 Zig Contributors
+// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
+// The MIT license requires this copyright notice to be included in all copies
+// and substantial portions of the software.
+const __floatdisf = @import("floatXisf.zig").__floatdisf;
+const testing = @import("std").testing;
+
+fn test__floatdisf(a: i64, expected: f32) void {
+    const x = __floatdisf(a);
+    testing.expect(x == expected);
+}
+
+test "floatdisf" {
+    test__floatdisf(0, 0.0);
+    test__floatdisf(1, 1.0);
+    test__floatdisf(2, 2.0);
+    test__floatdisf(-1, -1.0);
+    test__floatdisf(-2, -2.0);
+    test__floatdisf(0x7FFFFF8000000000, 0x1.FFFFFEp+62);
+    test__floatdisf(0x7FFFFF0000000000, 0x1.FFFFFCp+62);
+    test__floatdisf(0x8000008000000000, -0x1.FFFFFEp+62);
+    test__floatdisf(0x8000010000000000, -0x1.FFFFFCp+62);
+    test__floatdisf(0x8000000000000000, -0x1.000000p+63);
+    test__floatdisf(0x8000000000000001, -0x1.000000p+63);
+    test__floatdisf(0x0007FB72E8000000, 0x1.FEDCBAp+50);
+    test__floatdisf(0x0007FB72EA000000, 0x1.FEDCBAp+50);
+    test__floatdisf(0x0007FB72EB000000, 0x1.FEDCBAp+50);
+    test__floatdisf(0x0007FB72EBFFFFFF, 0x1.FEDCBAp+50);
+    test__floatdisf(0x0007FB72EC000000, 0x1.FEDCBCp+50);
+    test__floatdisf(0x0007FB72E8000001, 0x1.FEDCBAp+50);
+    test__floatdisf(0x0007FB72E6000000, 0x1.FEDCBAp+50);
+    test__floatdisf(0x0007FB72E7000000, 0x1.FEDCBAp+50);
+    test__floatdisf(0x0007FB72E7FFFFFF, 0x1.FEDCBAp+50);
+    test__floatdisf(0x0007FB72E4000001, 0x1.FEDCBAp+50);
+    test__floatdisf(0x0007FB72E4000000, 0x1.FEDCB8p+50);
+}

--- a/lib/std/special/compiler_rt/floattisf_test.zig
+++ b/lib/std/special/compiler_rt/floattisf_test.zig
@@ -3,7 +3,7 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-const __floattisf = @import("floattisf.zig").__floattisf;
+const __floattisf = @import("floatXisf.zig").__floattisf;
 const testing = @import("std").testing;
 
 fn test__floattisf(a: i128, expected: f32) void {


### PR DESCRIPTION
Add __floatdisf and __aeabi_l2f

Closes #6188

I'm new to Zig, be kind :wink: 