### PR TITLE
std: Open the eventfd fd with CLOEXEC flag

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -396,7 +396,7 @@ pub const ChildProcess = struct {
         // and execve from the child process to the parent process.
         const err_pipe = blk: {
             if (builtin.os.tag == .linux) {
-                const fd = try os.eventfd(0, 0);
+                const fd = try os.eventfd(0, os.EFD_CLOEXEC);
                 // There's no distinction between the readable and the writeable
                 // end with eventfd
                 break :blk [2]os.fd_t{ fd, fd };


### PR DESCRIPTION
Make sure the fd we use to communicate with the parent process is not
leaked to the child process.

Closes #5966