### PR TITLE
translate_c: fix shadowing on nested blocks

### DIFF
--- a/src-self-hosted/translate_c.zig
+++ b/src-self-hosted/translate_c.zig
@@ -168,7 +168,7 @@ const Scope = struct {
 
         fn localContains(scope: *Block, name: []const u8) bool {
             for (scope.variables.items) |p| {
-                if (mem.eql(u8, p.name, name))
+                if (mem.eql(u8, p.alias, name))
                     return true;
             }
             return false;

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -3,6 +3,23 @@ const tests = @import("tests.zig");
 const nl = std.cstr.line_sep;
 
 pub fn addCases(cases: *tests.RunTranslatedCContext) void {
+    cases.add("variable shadowing type type",
+        \\#include <stdlib.h>
+        \\int main() {
+        \\    int type = 1;
+        \\    if (type != 1) abort();
+        \\}
+    , "");
+
+    cases.add("assignment as expression",
+        \\#include <stdlib.h>
+        \\int main() {
+        \\    int a, b, c, d = 5;
+        \\    int e = a = b = c = d;
+        \\    if (e != 5) abort();
+        \\}
+    , "");
+
     cases.add("static variable in block scope",
         \\#include <stdlib.h>
         \\int foo() {


### PR DESCRIPTION
```c
int a, b, c, d = 5;
int e = a = b = c = d;
```
Before:
```zig
var a: c_int = undefined;
var b: c_int = undefined;
var c: c_int = undefined;
var d: c_int = 5;
var e: c_int = blk: {
    const tmp = blk_1: {
        const tmp_2 = blk_1: {
            const tmp_2 = d;
            c = tmp_2;
            break :blk_1 tmp_2;
        };
        b = tmp_2;
        break :blk_1 tmp_2;
    };
    a = tmp;
    break :blk tmp;
};
```
After:
```zig
var a: c_int = undefined;
var b: c_int = undefined;
var c: c_int = undefined;
var d: c_int = 5;
var e: c_int = blk: {
    const tmp = blk_1: {
        const tmp_2 = blk_2: {
            const tmp_3 = d;
            c = tmp_3;
            break :blk_2 tmp_3;
        };
        b = tmp_2;
        break :blk_1 tmp_2;
    };
    a = tmp;
    break :blk tmp;
};
```
~~Also frees the name in the loop. I saw other calls to free on the arena, but let me know if I should remove this.~~