### PR TITLE
os: return error.SocketNotListening for EINVAL on accept

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1641,6 +1641,8 @@ pub const StreamServer = struct {
         /// by the socket buffer limits, not by the system memory.
         SystemResources,
 
+        Invalid,
+
         ProtocolFailure,
 
         /// Firewall rules forbid connection.

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1641,7 +1641,8 @@ pub const StreamServer = struct {
         /// by the socket buffer limits, not by the system memory.
         SystemResources,
 
-        Invalid,
+        /// Socket is not listening for new connections.
+        SocketNotListening,
 
         ProtocolFailure,
 

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2802,7 +2802,8 @@ pub const AcceptError = error{
     /// by the socket buffer limits, not by the system memory.
     SystemResources,
 
-    Invalid,
+    /// Socket is not listening for new connections.
+    SocketNotListening,
 
     ProtocolFailure,
 
@@ -2872,7 +2873,7 @@ pub fn accept(
             EBADF => unreachable, // always a race condition
             ECONNABORTED => return error.ConnectionAborted,
             EFAULT => unreachable,
-            EINVAL => return error.Invalid,
+            EINVAL => return error.SocketNotListening,
             ENOTSOCK => unreachable,
             EMFILE => return error.ProcessFdQuotaExceeded,
             ENFILE => return error.SystemFdQuotaExceeded,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2802,6 +2802,8 @@ pub const AcceptError = error{
     /// by the socket buffer limits, not by the system memory.
     SystemResources,
 
+    Invalid,
+
     ProtocolFailure,
 
     /// Firewall rules forbid connection.
@@ -2870,7 +2872,7 @@ pub fn accept(
             EBADF => unreachable, // always a race condition
             ECONNABORTED => return error.ConnectionAborted,
             EFAULT => unreachable,
-            EINVAL => unreachable,
+            EINVAL => return error.Invalid,
             ENOTSOCK => unreachable,
             EMFILE => return error.ProcessFdQuotaExceeded,
             ENFILE => return error.SystemFdQuotaExceeded,


### PR DESCRIPTION
Should a socket (std.net.StreamServer) listening for connections be shutdown via [shutdown(2)](https://man7.org/linux/man-pages/man2/shutdown.2.html) on Linux, [accept(2)](https://man7.org/linux/man-pages/man2/accept.2.html) will return EINVAL. I made std.os.accept() directly return error.Invalid in this case.

Returning error.Invalid allows for users to gracefully shutdown a listening socket stuck on `accept()`. Example workflow code in Python can be found here: https://stackoverflow.com/a/19239058/4589486

Here's another example graceful shutdown workflow from a networking framework I'm building in Zig:

```zig
const std = @import("std");
const testing = std.testing;

const Allocator = std.mem.Allocator;

const StreamServer = std.net.StreamServer;
const Connection = std.net.StreamServer.Connection;
const Address = std.net.Address;

const info = std.log.info;

pub const Peer = struct {
    const Self = @This();
};

pub const Listener = struct {
    const Self = @This();

    allocator: *Allocator,
    handle: StreamServer,
    frame: *@Frame(start),

    fn start(self: *Self) !void {
        while (true) {
            const conn = try self.handle.accept();

            const buffered_reader = std.io.bufferedReader(conn);
            const buffered_writer = std.io.bufferedWriter(conn);
        }
    }

    pub fn deinit(self: *Self) void {
        const fd = self.handle.sockfd orelse unreachable;

        const rc = std.os.system.shutdown(fd, std.os.SHUT_RD);
        switch (std.os.errno(rc)) {
            0 => {},
            else => unreachable,
        }

        await self.frame catch |err| switch (err) {
            error.Invalid => {},
            else => unreachable,
        };

        self.allocator.destroy(self.frame);

        self.handle.close();
    }
};

pub const Node = struct {
    const Self = @This();

    pub const ListenOptions = struct {
        allocator: *Allocator = std.heap.page_allocator,
        bind_address: Address = std.net.Address.parseIp("0.0.0.0", 0) catch unreachable,
        reuse_address: bool = true,
    };

    pub fn listen(self: *Self, opts: ListenOptions) !Listener {
        var listener: Listener = .{
            .allocator = opts.allocator,
            .handle = StreamServer.init(.{ .reuse_address = opts.reuse_address }),
            .frame = undefined,
        };

        try listener.handle.listen(opts.bind_address);
        errdefer listener.handle.close();

        listener.frame = try opts.allocator.create(@Frame(Listener.start));
        errdefer opts.allocator.destroy(listener.frame);

        listener.frame.* = async listener.start();

        return listener;
    }
};

pub const io_mode = .evented;

pub fn main() !void {
    var node: Node = .{};

    var listener = try node.listen(
        .{
            .allocator = std.heap.page_allocator,
            .bind_address = try Address.parseIp("::", 9000),
            .reuse_address = true,
        },
    );
    defer listener.deinit();
}
```