### PR TITLE
std.ChildProcess: close & delete NUL file properly on Windows

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -489,10 +489,11 @@ pub const ChildProcess = struct {
         const nul_handle = if (any_ignore)
             windows.OpenFile(&[_]u16{ 'N', 'U', 'L' }, .{
                 .dir = std.fs.cwd().fd,
-                .access_mask = windows.GENERIC_READ | windows.SYNCHRONIZE,
+                .access_mask = windows.GENERIC_READ | windows.SYNCHRONIZE | windows.DELETE,
                 .share_access = windows.FILE_SHARE_READ,
                 .creation = windows.OPEN_EXISTING,
                 .io_mode = .blocking,
+                .delete_on_close = true,
             }) catch |err| switch (err) {
                 error.PathAlreadyExists => unreachable, // not possible for "NUL"
                 error.PipeBusy => unreachable, // not possible for "NUL"
@@ -505,7 +506,7 @@ pub const ChildProcess = struct {
         else
             undefined;
         defer {
-            if (any_ignore) os.close(nul_handle);
+            if (any_ignore) windows.CloseHandle(nul_handle);
         }
         if (any_ignore) {
             try windows.SetHandleInformation(nul_handle, windows.HANDLE_FLAG_INHERIT, 0);

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -57,6 +57,9 @@ pub const OpenFileOptions = struct {
     /// If false, tries to open path as a reparse point without dereferencing it.
     /// Defaults to true.
     follow_symlinks: bool = true,
+    /// If true, file is also deleted when closed.
+    /// Defaults to false.
+    delete_on_close: bool = false,
 };
 
 /// TODO when share_access_nonblocking is false, this implementation uses
@@ -90,8 +93,9 @@ pub fn OpenFile(sub_path_w: []const u16, options: OpenFileOptions) OpenError!HAN
     var io: IO_STATUS_BLOCK = undefined;
     const blocking_flag: ULONG = if (options.io_mode == .blocking) FILE_SYNCHRONOUS_IO_NONALERT else 0;
     const file_or_dir_flag: ULONG = if (options.open_dir) FILE_DIRECTORY_FILE else FILE_NON_DIRECTORY_FILE;
+    const delete_on_close_flag: ULONG = if (options.delete_on_close) FILE_DELETE_ON_CLOSE else 0;
     // If we're not following symlinks, we need to ensure we don't pass in any synchronization flags such as FILE_SYNCHRONOUS_IO_NONALERT.
-    const flags: ULONG = if (options.follow_symlinks) file_or_dir_flag | blocking_flag else file_or_dir_flag | FILE_OPEN_REPARSE_POINT;
+    const flags: ULONG = if (options.follow_symlinks) file_or_dir_flag | delete_on_close_flag | blocking_flag else file_or_dir_flag | delete_on_close_flag | FILE_OPEN_REPARSE_POINT;
 
     var delay: usize = 1;
     while (true) {


### PR DESCRIPTION
This is supposed to fix #5989.

- In `std.ChildProcess.spawnWindows()`, a `NUL` file is created, but isn't closed properly, leaving it locked by the Windows file system.
- I added a flag to `windows.OpenFileOptions` which passes `FILE_DELETE_ON_CLOSE` to `NtCreateFile`. Assuming that cleaning up this file afterwards is the intended behavior.