### PR TITLE
std: Adds support for json parsing of comptime struct fields

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1637,7 +1637,7 @@ pub fn parseFree(comptime T: type, value: T, options: ParseOptions) void {
         },
         .Struct => |structInfo| {
             inline for (structInfo.fields) |field| {
-                parseFree(field.field_type, @field(value, field.name), options);
+                if (!field.is_comptime) parseFree(field.field_type, @field(value, field.name), options);
             }
         },
         .Array => |arrayInfo| {

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1496,6 +1496,8 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
                                       else => {},
                                     }
                                   }
+                                  // As we never set the field to the parsed value, free it now.
+                                  parseFree(field.field_type, parsed_value, options);
                                 }
                                 fields_seen[i] = true;
                                 found = true;

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1483,7 +1483,7 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
                                         parseFree(field.field_type, @field(r, field.name), options);
                                     }
                                 }
-                                var parsed_value = try parse(field.field_type, tokens, options);
+                                const parsed_value = try parse(field.field_type, tokens, options);
                                 if (!field.is_comptime) {
                                   @field(r, field.name) = parsed_value;
                                 } else {

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1487,6 +1487,8 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
                                 if (!field.is_comptime) {
                                   @field(r, field.name) = parsed_value;
                                 } else {
+                                  // As we never set the field to the parsed value, make sure we free it.
+                                  defer parseFree(field.field_type, parsed_value, options);
                                   // We have a comptime field. We need to check the value supplied in the
                                   // json matches what the comptime value is.
                                   if (field.default_value) |default| {
@@ -1496,8 +1498,6 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
                                       else => {},
                                     }
                                   }
-                                  // As we never set the field to the parsed value, free it now.
-                                  parseFree(field.field_type, parsed_value, options);
                                 }
                                 fields_seen[i] = true;
                                 found = true;


### PR DESCRIPTION
Closes #6231. 

- Supports bool, float, int, string
- Fails to parse if default_value does not equal parsed value