### PR TITLE
Add the "sync" family of functions

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -330,3 +330,8 @@ pub const FILE = @Type(.Opaque);
 pub extern "c" fn dlopen(path: [*:0]const u8, mode: c_int) ?*c_void;
 pub extern "c" fn dlclose(handle: *c_void) c_int;
 pub extern "c" fn dlsym(handle: ?*c_void, symbol: [*:0]const u8) ?*c_void;
+
+pub extern "c" fn sync() void;
+pub extern "c" fn syncfs(fd: c_int) c_int;
+pub extern "c" fn fsync(fd: c_int) c_int;
+pub extern "c" fn fdatasync(fd: c_int) c_int;

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1226,6 +1226,22 @@ pub fn bpf(cmd: BPF.Cmd, attr: *BPF.Attr, size: u32) usize {
     return syscall3(.bpf, @enumToInt(cmd), @ptrToInt(attr), size);
 }
 
+pub fn sync() void {
+    _ = syscall0(.sync);
+}
+
+pub fn syncfs(fd: fd_t) usize {
+    return syscall1(.syncfs, @bitCast(usize, @as(isize, fd)));
+}
+
+pub fn fsync(fd: fd_t) usize {
+    return syscall1(.fsync, @bitCast(usize, @as(isize, fd)));
+}
+
+pub fn fdatasync(fd: fd_t) usize {
+    return syscall1(.fdatasync, @bitCast(usize, @as(isize, fd)));
+}
+
 test "" {
     if (builtin.os.tag == .linux) {
         _ = @import("linux/test.zig");

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -557,6 +557,24 @@ test "signalfd" {
 }
 
 test "sync" {
+    if (builtin.os.tag != .linux)
+        return error.SkipZigTest;
+
+    var tmp = tmpDir(.{});
+    defer tmp.cleanup();
+
+    const test_out_file = "os_tmp_test";
+    const file = try tmp.dir.createFile(test_out_file, .{});
+    defer {
+        file.close();
+        tmp.dir.deleteFile(test_out_file) catch {};
+    }
+
+    os.sync();
+    try os.syncfs(file.handle);
+}
+
+test "fsync" {
     if (builtin.os.tag != .linux and builtin.os.tag != .windows)
         return error.SkipZigTest;
 
@@ -570,8 +588,6 @@ test "sync" {
         tmp.dir.deleteFile(test_out_file) catch {};
     }
 
-    try os.syncfs(file.handle);
     try os.fsync(file.handle);
     try os.fdatasync(file.handle);
-    os.sync();
 }

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -555,3 +555,23 @@ test "signalfd" {
         return error.SkipZigTest;
     _ = std.os.signalfd;
 }
+
+test "sync" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .windows)
+        return error.SkipZigTest;
+
+    var tmp = tmpDir(.{});
+    defer tmp.cleanup();
+
+    const test_out_file = "os_tmp_test";
+    const file = try tmp.dir.createFile(test_out_file, .{});
+    defer {
+        file.close();
+        tmp.dir.deleteFile(test_out_file) catch {};
+    }
+
+    try os.syncfs(file.handle);
+    try os.fsync(file.handle);
+    try os.fdatasync(file.handle);
+    os.sync();
+}

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -287,3 +287,5 @@ pub extern "kernel32" fn K32GetWsChangesEx(hProcess: HANDLE, lpWatchInfoEx: PPSA
 pub extern "kernel32" fn K32InitializeProcessForWsWatch(hProcess: HANDLE) callconv(.Stdcall) BOOL;
 pub extern "kernel32" fn K32QueryWorkingSet(hProcess: HANDLE, pv: PVOID, cb: DWORD) callconv(.Stdcall) BOOL;
 pub extern "kernel32" fn K32QueryWorkingSetEx(hProcess: HANDLE, pv: PVOID, cb: DWORD) callconv(.Stdcall) BOOL;
+
+pub extern "kernel32" fn FlushFileBuffers(hFile: HANDLE) callconv(.Stdcall) BOOL;


### PR DESCRIPTION
An improvement which I considered writing would be a Windows implementation of `syncfs`, but Wine doesn't implement the `NtQueryVolumeInformationFile` function for `FILE_FS_VOLUME_INFORMATION` so I had no way of testing it.

For the Windows version of `fsync`, returning `error.InputOutput` as a catchall is following the example of [gnulib](https://github.com/digitalocean/gnulib/blob/28098428d3d371a238837f338739283cf19dc650/lib/fsync.c#L74-L75).