### PR TITLE
Support allocating 0 bit types

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -915,6 +915,10 @@ pub fn testAllocator(base_allocator: *mem.Allocator) !void {
     testing.expect(slice.len == 10);
 
     allocator.free(slice);
+
+    const zero_bit_ptr = try allocator.create(u0);
+    zero_bit_ptr.* = 0;
+    allocator.destroy(zero_bit_ptr);
 }
 
 pub fn testAllocatorAligned(base_allocator: *mem.Allocator, comptime alignment: u29) !void {

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -159,7 +159,7 @@ fn moveBytes(
 /// Returns a pointer to undefined memory.
 /// Call `destroy` with the result to free the memory.
 pub fn create(self: *Allocator, comptime T: type) Error!*T {
-    if (@sizeOf(T) == 0) return &(T{});
+    if (@sizeOf(T) == 0) return @as(*T, undefined);
     const slice = try self.allocAdvancedWithRetAddr(T, null, 1, .exact, @returnAddress());
     return &slice[0];
 }


### PR DESCRIPTION
This is useful for generic functions so 0 bit types don't have to be special cased every time. The current code errors because `*const T` cannot be assigned to `*T`.