### PR TITLE
std meta: fix use of alignOf in meta.cast

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -705,34 +705,34 @@ pub fn Vector(comptime len: u32, comptime child: type) type {
 pub fn cast(comptime DestType: type, target: anytype) DestType {
     const TargetType = @TypeOf(target);
     switch (@typeInfo(DestType)) {
-        .Pointer => {
+        .Pointer => |dest_ptr| {
             switch (@typeInfo(TargetType)) {
                 .Int, .ComptimeInt => {
                     return @intToPtr(DestType, target);
                 },
                 .Pointer => |ptr| {
-                    return @ptrCast(DestType, @alignCast(ptr.alignment, target));
+                    return @ptrCast(DestType, @alignCast(dest_ptr.alignment, target));
                 },
                 .Optional => |opt| {
                     if (@typeInfo(opt.child) == .Pointer) {
-                        return @ptrCast(DestType, @alignCast(@alignOf(opt.child.Child), target));
+                        return @ptrCast(DestType, @alignCast(dest_ptr, target));
                     }
                 },
                 else => {},
             }
         },
-        .Optional => |opt| {
-            if (@typeInfo(opt.child) == .Pointer) {
+        .Optional => |dest_opt| {
+            if (@typeInfo(dest_opt.child) == .Pointer) {
                 switch (@typeInfo(TargetType)) {
                     .Int, .ComptimeInt => {
                         return @intToPtr(DestType, target);
                     },
-                    .Pointer => |ptr| {
-                        return @ptrCast(DestType, @alignCast(ptr.alignment, target));
+                    .Pointer => {
+                        return @ptrCast(DestType, @alignCast(@alignOf(dest_opt.child.Child), target));
                     },
                     .Optional => |target_opt| {
                         if (@typeInfo(target_opt.child) == .Pointer) {
-                            return @ptrCast(DestType, @alignCast(@alignOf(target_opt.child.Child), target));
+                            return @ptrCast(DestType, @alignCast(@alignOf(dest_opt.child.Child), target));
                         }
                     },
                     else => {},


### PR DESCRIPTION
Should alignCast to the destination type, previous version was redundantly casting pointer to its own size. Tried adding a test to test-run-translated-c but I'm not sure how to get it to generate meta.cast.

Ran into this trying to compile:
```
    var default_screen = (@import("std").meta.cast(_XPrivDisplay, display)).*.default_screen;
```