### PR TITLE
Introduces a space after the ellipsis for test and progress.

### DIFF
--- a/lib/std/progress.zig
+++ b/lib/std/progress.zig
@@ -197,7 +197,7 @@ pub const Progress = struct {
             var maybe_node: ?*Node = &self.root;
             while (maybe_node) |node| {
                 if (need_ellipse) {
-                    self.bufWrite(&end, "...", .{});
+                    self.bufWrite(&end, "... ", .{});
                 }
                 need_ellipse = false;
                 if (node.name.len != 0 or node.estimated_total_items != null) {
@@ -218,7 +218,7 @@ pub const Progress = struct {
                 maybe_node = node.recently_updated_child;
             }
             if (need_ellipse) {
-                self.bufWrite(&end, "...", .{});
+                self.bufWrite(&end, "... ", .{});
             }
         }
 
@@ -253,7 +253,7 @@ pub const Progress = struct {
         const bytes_needed_for_esc_codes_at_end = if (std.builtin.os.tag == .windows) 0 else 11;
         const max_end = self.output_buffer.len - bytes_needed_for_esc_codes_at_end;
         if (end.* > max_end) {
-            const suffix = "...";
+            const suffix = "... ";
             self.columns_written = self.columns_written - (end.* - max_end) + suffix.len;
             std.mem.copy(u8, self.output_buffer[max_end..], suffix);
             end.* = max_end + suffix.len;

--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -40,7 +40,7 @@ pub fn main() anyerror!void {
         test_node.activate();
         progress.refresh();
         if (progress.terminal == null) {
-            std.debug.print("{}/{} {}...", .{ i + 1, test_fn_list.len, test_fn.name });
+            std.debug.print("{}/{} {}... ", .{ i + 1, test_fn_list.len, test_fn.name });
         }
         const result = if (test_fn.async_frame_size) |size| switch (io_mode) {
             .evented => blk: {


### PR DESCRIPTION
This is a pure convencience PR. It doesn't change any functionality but helps when tests output debug information or error traces:

Old behaviour:
```
Test [116/121] compiler.analysis.test "validate correct program"...reached unreachable code
```

New behaviour:
```
Test [116/121] compiler.analysis.test "validate correct program"... reached unreachable code
```

Why this change?
Editors like Visual Studio Code allow selecting and opening file paths from the terminal so when a stack trace is printed from within a test or compile error, it's not possible to click the first path as it is prepended by `...`. The introduced space allows visual and semantic separation between the test name and the message.