### PR TITLE
document how to escape curly braces in fmt.format

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -83,7 +83,7 @@ fn peekIsAlign(comptime fmt: []const u8) bool {
 ///
 /// A user type may be a `struct`, `vector`, `union` or `enum` type.
 ///
-/// To print literal curly braces, escape them by writing them twice, eg `{{` or `}}`.
+/// To print literal curly braces, escape them by writing them twice, e.g. `{{` or `}}`.
 pub fn format(
     writer: anytype,
     comptime fmt: []const u8,

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -82,6 +82,8 @@ fn peekIsAlign(comptime fmt: []const u8) bool {
 /// This allows user types to be formatted in a logical manner instead of dumping all fields of the type.
 ///
 /// A user type may be a `struct`, `vector`, `union` or `enum` type.
+///
+/// To print literal curly braces, escape them by writing them twice, eg `{{` or `}}`.
 pub fn format(
     writer: anytype,
     comptime fmt: []const u8,


### PR DESCRIPTION
Very small addition, had to look this up in the code so I figured I would document for others.