### PR TITLE
Use boyer-moore-horspool algorithm for indexOfPos and lastIndexOf unless the haystack or needle is very small

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -870,7 +870,7 @@ fn indexOfPosLinear(comptime T: type, haystack: []const T, start_index: usize, n
     return null;
 }
 
-fn boyerMooreHorspoolPreprocessReverse(pattern: []const u8, table: []usize) void {
+fn boyerMooreHorspoolPreprocessReverse(pattern: []const u8, table: *[256]usize) void {
     for (table) |*c| {
         c.* = pattern.len;
     }
@@ -881,7 +881,7 @@ fn boyerMooreHorspoolPreprocessReverse(pattern: []const u8, table: []usize) void
     }
 }
 
-fn boyerMooreHorspoolPreprocess(pattern: []const u8, table: []usize) void {
+fn boyerMooreHorspoolPreprocess(pattern: []const u8, table: *[256]usize) void {
     for (table) |*c| {
         c.* = pattern.len;
     }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -927,7 +927,7 @@ pub fn indexOfPos(comptime T: type, haystack: []const T, start_index: usize, nee
     if (needle.len > haystack.len) return null;
     if (needle.len == 0) return 0;
 
-    if (!meta.trait.hasUniqueRepresentation(T) or haystack.len < 32 or needle.len <= 2)
+    if (!meta.trait.hasUniqueRepresentation(T) or haystack.len < 52 or needle.len <= 4)
         return indexOfPosLinear(T, haystack, start_index, needle);
 
     const haystack_bytes = sliceAsBytes(haystack);

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -876,6 +876,8 @@ fn boyerMooreHorspoolPreprocessReverse(pattern: []const u8, table: *[256]usize) 
     }
 
     var i: usize = pattern.len - 1;
+    // The first item is intentionally ignored and the skip size will be pattern.len.
+    // This is the standard way boyer-moore-horspool is implemented.
     while (i > 0) : (i -= 1) {
         table[pattern[i]] = i;
     }
@@ -887,6 +889,8 @@ fn boyerMooreHorspoolPreprocess(pattern: []const u8, table: *[256]usize) void {
     }
 
     var i: usize = 0;
+    // The last item is intentionally ignored and the skip size will be pattern.len.
+    // This is the standard way boyer-moore-horspool is implemented.
     while (i < pattern.len - 1) : (i += 1) {
         table[pattern[i]] = pattern.len - 1 - i;
     }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -930,7 +930,7 @@ pub fn indexOfPos(comptime T: type, haystack: []const T, start_index: usize, nee
     var skip_table: [256]usize = undefined;
     boyerMooreHorspoolPreprocess(needle_bytes, skip_table[0..]);
 
-    var i: usize = start_index;
+    var i: usize = start_index * @sizeOf(T);
     while (i <= haystack_bytes.len - needle_bytes.len) {
         if (mem.eql(u8, haystack_bytes[i .. i + needle_bytes.len], needle_bytes)) return i;
         i += skip_table[haystack_bytes[i + needle_bytes.len - 1]];

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -895,7 +895,8 @@ fn boyerMooreHorspoolPreprocess(pattern: []const u8, table: *[256]usize) void {
 /// To start looking at a different index, slice the haystack first.
 // Reverse boyer-moore-horspool algorithm
 pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?usize {
-    if (needle.len > haystack.len or needle.len == 0) return null;
+    if (needle.len > haystack.len) return null;
+    if (needle.len == 0) return haystack.len;
 
     if (!meta.trait.hasUniqueRepresentation(T) or haystack.len < 32 or needle.len <= 2)
         return lastIndexOfLinear(T, haystack, needle);
@@ -919,7 +920,8 @@ pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?us
 
 // Boyer-moore-horspool algorithm
 pub fn indexOfPos(comptime T: type, haystack: []const T, start_index: usize, needle: []const T) ?usize {
-    if (needle.len > haystack.len or needle.len == 0) return null;
+    if (needle.len > haystack.len) return null;
+    if (needle.len == 0) return 0;
 
     if (!meta.trait.hasUniqueRepresentation(T) or haystack.len < 32 or needle.len <= 2)
         return indexOfPosLinear(T, haystack, start_index, needle);
@@ -944,6 +946,9 @@ test "mem.indexOf" {
     testing.expect(lastIndexOf(u8, "one two three four five six seven eight nine ten", "three four").? == 8);
     testing.expect(indexOf(u8, "one two three four five six seven eight nine ten", "two two") == null);
     testing.expect(lastIndexOf(u8, "one two three four five six seven eight nine ten", "two two") == null);
+
+    testing.expect(indexOf(u8, "one two three four five six seven eight nine ten", "").? == 0);
+    testing.expect(lastIndexOf(u8, "one two three four five six seven eight nine ten", "").? == 48);
 
     testing.expect(indexOf(u8, "one two three four", "four").? == 14);
     testing.expect(lastIndexOf(u8, "one two three two four", "two").? == 14);

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -888,13 +888,13 @@ fn boyerMooreHorspoolPreprocess(pattern: []const u8, table: []usize) void {
 /// To start looking at a different index, slice the haystack first.
 // Reverse boyer-moore-horspool algorithm
 pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?usize {
-    if (haystack.len < 32 or needle.len <= 2)
+    if (!isValidAlign(T.bit_count) or haystack.len < 32 or needle.len <= 2)
         return lastIndexOfNaive(T, haystack, needle);
 
     if (needle.len > haystack.len or needle.len == 0) return null;
 
-    const haystackU8 = @bitCast([]const u8, haystack);
-    const needleU8 = @bitCast([]const u8, needle);
+    const haystackU8 = sliceAsBytes(haystack);
+    const needleU8 = sliceAsBytes(needle);
 
     var table: [256]usize = undefined;
     boyerMooreHorspoolPreprocess(needleU8, table[0..]);
@@ -911,13 +911,13 @@ pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?us
 
 // Boyer-moore-horspool algorithm
 pub fn indexOfPos(comptime T: type, haystack: []const T, start_index: usize, needle: []const T) ?usize {
-    if (haystack.len < 32 or needle.len <= 2)
+    if (!isValidAlign(T.bit_count) or haystack.len < 32 or needle.len <= 2)
         return indexOfPosNaive(T, haystack, start_index, needle);
 
     if (needle.len > haystack.len or needle.len == 0) return null;
 
-    const haystackU8 = @bitCast([]const u8, haystack);
-    const needleU8 = @bitCast([]const u8, needle);
+    const haystackU8 = sliceAsBytes(haystack);
+    const needleU8 = sliceAsBytes(needle);
 
     var table: [256]usize = undefined;
     boyerMooreHorspoolPreprocess(needleU8, table[0..]);

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -897,9 +897,7 @@ fn boyerMooreHorspoolPreprocess(pattern: []const u8, table: *[256]usize) void {
 pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?usize {
     if (needle.len > haystack.len or needle.len == 0) return null;
 
-    // byte comparison with float doesn't work because +0.0 and -0.0 and considered
-    // equal but their byte representations are not equal.
-    if (@typeInfo(T) == .Float or haystack.len < 32 or needle.len <= 2)
+    if (!meta.trait.hasUniqueRepresentation(T) or haystack.len < 32 or needle.len <= 2)
         return lastIndexOfLinear(T, haystack, needle);
 
     const haystack_bytes = sliceAsBytes(haystack);
@@ -923,9 +921,7 @@ pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?us
 pub fn indexOfPos(comptime T: type, haystack: []const T, start_index: usize, needle: []const T) ?usize {
     if (needle.len > haystack.len or needle.len == 0) return null;
 
-    // byte comparison with float doesn't work because +0.0 and -0.0 and considered
-    // equal but their byte representations are not equal.
-    if (@typeInfo(T) == .Float or haystack.len < 32 or needle.len <= 2)
+    if (!meta.trait.hasUniqueRepresentation(T) or haystack.len < 32 or needle.len <= 2)
         return indexOfPosLinear(T, haystack, start_index, needle);
 
     const haystack_bytes = sliceAsBytes(haystack);

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -897,7 +897,9 @@ fn boyerMooreHorspoolPreprocess(pattern: []const u8, table: *[256]usize) void {
 pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?usize {
     if (needle.len > haystack.len or needle.len == 0) return null;
 
-    if (!isValidAlign(T.bit_count) or haystack.len < 32 or needle.len <= 2)
+    // byte comparison with float doesn't work because +0.0 and -0.0 and considered
+    // equal but their byte representations are not equal.
+    if (@typeInfo(T) == .Float or haystack.len < 32 or needle.len <= 2)
         return lastIndexOfLinear(T, haystack, needle);
 
     const haystack_bytes = sliceAsBytes(haystack);
@@ -921,7 +923,9 @@ pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?us
 pub fn indexOfPos(comptime T: type, haystack: []const T, start_index: usize, needle: []const T) ?usize {
     if (needle.len > haystack.len or needle.len == 0) return null;
 
-    if (!isValidAlign(T.bit_count) or haystack.len < 32 or needle.len <= 2)
+    // byte comparison with float doesn't work because +0.0 and -0.0 and considered
+    // equal but their byte representations are not equal.
+    if (@typeInfo(T) == .Float or haystack.len < 32 or needle.len <= 2)
         return indexOfPosLinear(T, haystack, start_index, needle);
 
     const haystack_bytes = sliceAsBytes(haystack);

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -888,18 +888,22 @@ fn boyerMooreHorspoolPreprocess(pattern: []const u8, table: []usize) void {
 /// To start looking at a different index, slice the haystack first.
 // Reverse boyer-moore-horspool algorithm
 pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?usize {
-    if (T != u8 or haystack.len < 32 or needle.len <= 2)
+    if (haystack.len < 32 or needle.len <= 2)
         return lastIndexOfNaive(T, haystack, needle);
 
     if (needle.len > haystack.len or needle.len == 0) return null;
+
+    const haystackU8 = @bitCast([]const u8, haystack);
+    const needleU8 = @bitCast([]const u8, needle);
+
     var table: [256]usize = undefined;
-    boyerMooreHorspoolPreprocess(needle, table[0..]);
+    boyerMooreHorspoolPreprocess(needleU8, table[0..]);
 
     var i: usize = 0;
-    while (i <= haystack.len - needle.len) {
-        const reverseIndex = haystack.len - i - needle.len - 1;
-        if (mem.eql(T, haystack[reverseIndex .. reverseIndex + needle.len], needle)) return i;
-        i += table[haystack[reverseIndex + needle.len - 1]];
+    while (i <= haystackU8.len - needleU8.len) {
+        const reverseIndex = haystackU8.len - i - needleU8.len - 1;
+        if (mem.eql(u8, haystackU8[reverseIndex .. reverseIndex + needleU8.len], needleU8)) return i;
+        i += table[haystackU8[reverseIndex + needleU8.len - 1]];
     }
 
     return null;
@@ -907,17 +911,21 @@ pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?us
 
 // Boyer-moore-horspool algorithm
 pub fn indexOfPos(comptime T: type, haystack: []const T, start_index: usize, needle: []const T) ?usize {
-    if (T != u8 or haystack.len < 32 or needle.len <= 2)
+    if (haystack.len < 32 or needle.len <= 2)
         return indexOfPosNaive(T, haystack, start_index, needle);
 
     if (needle.len > haystack.len or needle.len == 0) return null;
+
+    const haystackU8 = @bitCast([]const u8, haystack);
+    const needleU8 = @bitCast([]const u8, needle);
+
     var table: [256]usize = undefined;
-    boyerMooreHorspoolPreprocess(needle, table[0..]);
+    boyerMooreHorspoolPreprocess(needleU8, table[0..]);
 
     var i: usize = start_index;
-    while (i <= haystack.len - needle.len) {
-        if (mem.eql(T, haystack[i .. i + needle.len], needle)) return i;
-        i += table[haystack[i + needle.len - 1]];
+    while (i <= haystackU8.len - needleU8.len) {
+        if (mem.eql(u8, haystackU8[i .. i + needleU8.len], needleU8)) return i;
+        i += table[haystackU8[i + needleU8.len - 1]];
     }
 
     return null;


### PR DESCRIPTION
This fixes #1060

Tested with this benchmark code:
```zig
const std = @import("std");

pub fn main() anyerror!void {
    var allocator = std.heap.page_allocator;
    var words = try std.fs.cwd().openFile("5mil.txt", .{});
    var data = try words.readAllAlloc(allocator, try words.getEndPos(), std.math.maxInt(usize));

    var timer = try std.time.Timer.start();

    {
        const index = std.mem.indexOf(u8, data, "91302825905726705360757676831967057670066947053278330749316994861764283699420937264487445512636827327107520").?;
        const elapsed_time = timer.read();
        timer.reset();
        std.debug.print("index: {}, elapsed time: {} nanoseconds\n", .{index, elapsed_time});
    }

    {
        const index = std.mem.indexOf(u8, data, "5933535").?;
        const elapsed_time = timer.read();
        timer.reset();
        std.debug.print("index: {}, elapsed time: {} nanoseconds\n", .{index, elapsed_time});
    }
}
```
5mil.txt is a file with 5 million digits of pi. With the old version the average time for the long needle is 7.883ms and 7.568ms for the short needle. With the boyer-moore-horspool version the average time for the long needle is 2.027ms and 3.401ms for the short needle. And of course, the larger the needle the faster the boyer-moore-horspool version is than the old version.
There is a fallback to the naive version if the needle is <= 4 because at such a small size the naive version is around 2.2 times faster.

Here is new benchmark with for haystack of size 0-1000: https://imgur.com/a/EQJRaBk
and here is benchmark when haystack size is 5mil: https://i.imgur.com/hmd9rGt.png
