### PR TITLE
Express ArrayList in ArrayListUnmanaged operations

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -52,9 +52,8 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
 
         /// Release all allocated memory.
         pub fn deinit(self: *Self) void {
-            var unmanaged = self.toUnmanaged();
-            defer self.* = unmanaged.toManaged(self.allocator);
-            return unmanaged.deinit(self.allocator);
+            self.toUnmanaged().deinit(self.allocator);
+            self.* = undefined;
         }
 
         /// Deprecated: use `items` field directly.

--- a/lib/std/dwarf.zig
+++ b/lib/std/dwarf.zig
@@ -439,7 +439,7 @@ pub const DwarfInfo = struct {
             const next_unit_pos = this_unit_offset + next_offset;
 
             while ((try seekable.getPos()) < next_unit_pos) {
-                const die_obj = (try di.parseDie(in, abbrev_table, is_64)) orelse continue;
+                var die_obj = (try di.parseDie(in, abbrev_table, is_64)) orelse continue;
                 defer die_obj.attrs.deinit();
 
                 const after_die_offset = try seekable.getPos();

--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -86,7 +86,7 @@ pub const PreopenList = struct {
     }
 
     /// Release all allocated memory.
-    pub fn deinit(pm: Self) void {
+    pub fn deinit(pm: *Self) void {
         for (pm.buffer.items) |preopen| {
             switch (preopen.@"type") {
                 PreopenType.Dir => |path| pm.buffer.allocator.free(path),

--- a/src-self-hosted/test.zig
+++ b/src-self-hosted/test.zig
@@ -389,7 +389,7 @@ pub const TestContext = struct {
     }
 
     fn deinit(self: *TestContext) void {
-        for (self.cases.items) |case| {
+        for (self.cases.items) |*case| {
             for (case.updates.items) |u| {
                 if (u.case == .Error) {
                     case.updates.allocator.free(u.case.Error);


### PR DESCRIPTION
I came across several issues in ArrayListUnmanaged, namely:
- An error in initCapacity which was introduced in #6232 https://github.com/ziglang/zig/blob/7d487a41627658bfda37f1f06f8e453c2b576b9c/lib/std/array_list.zig#L374
- An error in replaceRange introduced in #5511 https://github.com/ziglang/zig/blob/7d487a41627658bfda37f1f06f8e453c2b576b9c/lib/std/array_list.zig#L422

This PR changes the implementation of ArrayList to use that of ArrayListUnmanaged wherever possible, which ensures that the implementation of ArrayListUnmanaged and ArrayList are the same. The original test cases now also test ArrayListUnmanaged. Furthermore, this reduces code duplication in the standard library.

Note that i've changed `ArrayList.deinit` to require `*Self` like other std containers. I've changed constness of ArrayList wherever required.

Currently, most calls to ArrayListUnmanaged are called like
```zig
var unmanaged = self.toUnmanaged();
defer self.* = unmanaged.toManaged(self.allocator);
return unmanaged.addOne(self.allocator);
```
I hope that this is optimization/result location friendly, i haven't done any benchmarking.