### PR TITLE
std: add option to use single-threaded event loop

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -112,7 +112,8 @@ pub const Loop = struct {
     /// have the correct pointer value.
     /// https://github.com/ziglang/zig/issues/2761 and https://github.com/ziglang/zig/issues/2765
     pub fn init(self: *Loop) !void {
-        if (builtin.single_threaded) {
+        if (builtin.single_threaded
+            or (@hasDecl(root, "event_loop_mode") and root.event_loop_mode == .single_threaded)) {
             return self.initSingleThreaded();
         } else {
             return self.initMultiThreaded();


### PR DESCRIPTION
std.event.Loop does not yet work in single threaded builds. However,
using evented io on a single thread can be very convenient. This commit
allows settind @import("root").event_loop_mode to .single_threaded
in order to allow this without reimplementing the startup code in
start.zig