### PR TITLE
std, stage1: make shared library versioning optional

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2265,6 +2265,7 @@ struct CodeGen {
 
     Stage2LibCInstallation *libc;
 
+    bool is_versioned;
     size_t version_major;
     size_t version_minor;
     size_t version_patch;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -90,7 +90,8 @@ void codegen_set_test_name_prefix(CodeGen *g, Buf *prefix) {
     g->test_name_prefix = prefix;
 }
 
-void codegen_set_lib_version(CodeGen *g, size_t major, size_t minor, size_t patch) {
+void codegen_set_lib_version(CodeGen *g, bool is_versioned, size_t major, size_t minor, size_t patch) {
+    g->is_versioned = is_versioned;
     g->version_major = major;
     g->version_minor = minor;
     g->version_patch = patch;
@@ -10823,6 +10824,7 @@ static Error check_cache(CodeGen *g, Buf *manifest_dir, Buf *digest) {
     cache_bool(ch, g->emit_bin);
     cache_bool(ch, g->emit_llvm_ir);
     cache_bool(ch, g->emit_asm);
+    cache_bool(ch, g->is_versioned);
     cache_usize(ch, g->version_major);
     cache_usize(ch, g->version_minor);
     cache_usize(ch, g->version_patch);
@@ -10893,7 +10895,7 @@ static void resolve_out_paths(CodeGen *g) {
                 buf_resize(out_basename, 0);
                 buf_append_str(out_basename, target_lib_file_prefix(g->zig_target));
                 buf_append_buf(out_basename, g->root_out_name);
-                buf_append_str(out_basename, target_lib_file_ext(g->zig_target, !g->is_dynamic,
+                buf_append_str(out_basename, target_lib_file_ext(g->zig_target, !g->is_dynamic, g->is_versioned,
                             g->version_major, g->version_minor, g->version_patch));
                 break;
         }

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -38,7 +38,7 @@ void codegen_set_rdynamic(CodeGen *g, bool rdynamic);
 void codegen_set_linker_script(CodeGen *g, const char *linker_script);
 void codegen_set_test_filter(CodeGen *g, Buf *filter);
 void codegen_set_test_name_prefix(CodeGen *g, Buf *prefix);
-void codegen_set_lib_version(CodeGen *g, size_t major, size_t minor, size_t patch);
+void codegen_set_lib_version(CodeGen *g, bool is_versioned, size_t major, size_t minor, size_t patch);
 void codegen_add_time_event(CodeGen *g, const char *name);
 void codegen_print_timing_report(CodeGen *g, FILE *f);
 void codegen_link(CodeGen *g);

--- a/src/glibc.cpp
+++ b/src/glibc.cpp
@@ -335,7 +335,7 @@ Error glibc_build_dummies_and_maps(CodeGen *g, const ZigGLibCAbi *glibc_abi, con
         bool is_ld = (strcmp(lib->name, "ld") == 0);
 
         CodeGen *child_gen = create_child_codegen(g, zig_file_path, OutTypeLib, nullptr, lib->name, progress_node);
-        codegen_set_lib_version(child_gen, lib->sover, 0, 0);
+        codegen_set_lib_version(child_gen, true, lib->sover, 0, 0);
         child_gen->is_dynamic = true;
         child_gen->is_dummy_so = true;
         child_gen->version_script_path = map_file_path;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -416,6 +416,7 @@ static int main0(int argc, char **argv) {
     const char *test_filter = nullptr;
     const char *test_name_prefix = nullptr;
     bool test_evented_io = false;
+    bool is_versioned = false;
     size_t ver_major = 0;
     size_t ver_minor = 0;
     size_t ver_patch = 0;
@@ -870,6 +871,7 @@ static int main0(int argc, char **argv) {
                     fprintf(stderr, "expected linker arg after '%s'\n", buf_ptr(arg));
                     return EXIT_FAILURE;
                 }
+                is_versioned = true;
                 ver_major = atoi(buf_ptr(linker_args.at(i)));
             } else if (buf_eql_str(arg, "--minor-image-version")) {
                 i += 1;
@@ -877,6 +879,7 @@ static int main0(int argc, char **argv) {
                     fprintf(stderr, "expected linker arg after '%s'\n", buf_ptr(arg));
                     return EXIT_FAILURE;
                 }
+                is_versioned = true;
                 ver_minor = atoi(buf_ptr(linker_args.at(i)));
             } else if (buf_eql_str(arg, "--stack")) {
                 i += 1;
@@ -1228,10 +1231,13 @@ static int main0(int argc, char **argv) {
                 } else if (strcmp(arg, "--test-name-prefix") == 0) {
                     test_name_prefix = argv[i];
                 } else if (strcmp(arg, "--ver-major") == 0) {
+                    is_versioned = true;
                     ver_major = atoi(argv[i]);
                 } else if (strcmp(arg, "--ver-minor") == 0) {
+                    is_versioned = true;
                     ver_minor = atoi(argv[i]);
                 } else if (strcmp(arg, "--ver-patch") == 0) {
+                    is_versioned = true;
                     ver_patch = atoi(argv[i]);
                 } else if (strcmp(arg, "--test-cmd") == 0) {
                     test_exec_args.append(argv[i]);
@@ -1590,7 +1596,7 @@ static int main0(int argc, char **argv) {
             g->emit_llvm_ir = emit_llvm_ir;
 
             codegen_set_out_name(g, buf_out_name);
-            codegen_set_lib_version(g, ver_major, ver_minor, ver_patch);
+            codegen_set_lib_version(g, is_versioned, ver_major, ver_minor, ver_patch);
             g->want_single_threaded = want_single_threaded;
             codegen_set_linker_script(g, linker_script);
             g->version_script_path = version_script; 

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -779,7 +779,7 @@ const char *target_lib_file_prefix(const ZigTarget *target) {
     }
 }
 
-const char *target_lib_file_ext(const ZigTarget *target, bool is_static,
+const char *target_lib_file_ext(const ZigTarget *target, bool is_static, bool is_versioned,
         size_t version_major, size_t version_minor, size_t version_patch)
 {
     if (target_is_wasm(target)) {
@@ -799,11 +799,19 @@ const char *target_lib_file_ext(const ZigTarget *target, bool is_static,
         if (is_static) {
             return ".a";
         } else if (target_os_is_darwin(target->os)) {
-            return buf_ptr(buf_sprintf(".%" ZIG_PRI_usize ".%" ZIG_PRI_usize ".%" ZIG_PRI_usize ".dylib",
-                        version_major, version_minor, version_patch));
+            if (is_versioned) {
+                return buf_ptr(buf_sprintf(".%" ZIG_PRI_usize ".%" ZIG_PRI_usize ".%" ZIG_PRI_usize ".dylib",
+                            version_major, version_minor, version_patch));
+            } else {
+                return ".dylib";
+            }
         } else {
-            return buf_ptr(buf_sprintf(".so.%" ZIG_PRI_usize ".%" ZIG_PRI_usize ".%" ZIG_PRI_usize,
-                        version_major, version_minor, version_patch));
+            if (is_versioned) {
+                return buf_ptr(buf_sprintf(".so.%" ZIG_PRI_usize ".%" ZIG_PRI_usize ".%" ZIG_PRI_usize,
+                            version_major, version_minor, version_patch));
+            } else {
+                return ".so";
+            }
         }
     }
 }

--- a/src/target.hpp
+++ b/src/target.hpp
@@ -87,7 +87,7 @@ const char *target_asm_file_ext(const ZigTarget *target);
 const char *target_llvm_ir_file_ext(const ZigTarget *target);
 const char *target_exe_file_ext(const ZigTarget *target);
 const char *target_lib_file_prefix(const ZigTarget *target);
-const char *target_lib_file_ext(const ZigTarget *target, bool is_static,
+const char *target_lib_file_ext(const ZigTarget *target, bool is_static, bool is_versioned,
         size_t version_major, size_t version_minor, size_t version_patch);
 
 bool target_can_exec(const ZigTarget *host_target, const ZigTarget *guest_target);


### PR DESCRIPTION
This commit changes the behavior of stage1 to emit libfoo.so instead
of libfoo.so.0.0.0 when none of the --ver-major, --ver-minor, or
--ver-patch flags are set.

It also makes it possible to create unversioned shared libraries
using the zig build system, changing the version parameter of
addSharedLibrary() to a tagged union.

Closes #2230