### PR TITLE
stage1: implement --full-name

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2302,6 +2302,7 @@ struct CodeGen {
     bool test_is_evented;
     bool linker_z_nodelete;
     bool linker_z_defs;
+    bool is_full_out_name; // if full a prefix/extension should not be added
 
     Buf *root_out_name;
     Buf *test_filter;

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -28,7 +28,7 @@ void codegen_set_each_lib_rpath(CodeGen *codegen, bool each_lib_rpath);
 
 void codegen_set_strip(CodeGen *codegen, bool strip);
 void codegen_set_errmsg_color(CodeGen *codegen, ErrColor err_color);
-void codegen_set_out_name(CodeGen *codegen, Buf *out_name);
+void codegen_set_out_name(CodeGen *codegen, Buf *out_name, bool full);
 void codegen_add_lib_dir(CodeGen *codegen, const char *dir);
 void codegen_add_forbidden_lib(CodeGen *codegen, Buf *lib);
 LinkLib *codegen_add_link_lib(CodeGen *codegen, Buf *lib);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,7 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  -fno-emit-h                  (default) do not generate a C header file (.h)\n"
         "  --libc [file]                Provide a file which specifies libc paths\n"
         "  --name [name]                override output name\n"
+        "  --full-name [name]           override full output name and extension\n"
         "  --output-dir [dir]           override output directory (defaults to cwd)\n"
         "  --pkg-begin [name] [path]    make pkg available to import and push current pkg\n"
         "  --pkg-end                    pop current pkg\n"
@@ -384,6 +385,7 @@ static int main0(int argc, char **argv) {
     bool is_dynamic = false;
     OutType out_type = OutTypeUnknown;
     const char *out_name = nullptr;
+    bool is_full_out_name = false;
     bool verbose_tokenize = false;
     bool verbose_ast = false;
     bool verbose_link = false;
@@ -553,7 +555,7 @@ static int main0(int argc, char **argv) {
                 BuildModeDebug, override_lib_dir, nullptr, &full_cache_dir, false, root_progress_node);
         g->valgrind_support = valgrind_support;
         g->enable_time_report = timing_info;
-        codegen_set_out_name(g, buf_create_from_str("build"));
+        codegen_set_out_name(g, buf_create_from_str("build"), false);
 
         args.items[2] = buf_ptr(&build_file_dirname);
         args.items[3] = buf_ptr(&full_cache_dir);
@@ -1134,6 +1136,9 @@ static int main0(int argc, char **argv) {
                     }
                 } else if (strcmp(arg, "--name") == 0) {
                     out_name = argv[i];
+                } else if (strcmp(arg, "--full-name") == 0) {
+                    is_full_out_name = true;
+                    out_name = argv[i];
                 } else if (strcmp(arg, "--dynamic-linker") == 0) {
                     dynamic_linker = argv[i];
                 } else if (strcmp(arg, "--libc") == 0) {
@@ -1589,7 +1594,7 @@ static int main0(int argc, char **argv) {
             g->emit_asm = emit_asm;
             g->emit_llvm_ir = emit_llvm_ir;
 
-            codegen_set_out_name(g, buf_out_name);
+            codegen_set_out_name(g, buf_out_name, is_full_out_name);
             codegen_set_lib_version(g, ver_major, ver_minor, ver_patch);
             g->want_single_threaded = want_single_threaded;
             codegen_set_linker_script(g, linker_script);


### PR DESCRIPTION
This allows overriding the output name of the resulting binary, including the lib prefix for libraries and the extension.

This is necessary, for example, when creating a shared library for use as a plugin, in which case specific naming conventions must be followed.

Closes  #2231
This does not yet expose this feature in the zig build system, that will be implemented in a follow up PR if this one is accepted