### PR TITLE
std: Make the DEFLATE decompression routine 3x faster

### DIFF
--- a/lib/std/compress/zlib.zig
+++ b/lib/std/compress/zlib.zig
@@ -138,10 +138,10 @@ test "compressed data" {
         "5ebf4b5b7fe1c3a0c0ab9aa3ac8c0f3853a7dc484905e76e03b0b0f301350009",
     );
     // Compressed with compression level = 9 and fixed Huffman codes
-    // try testReader(
-    //     @embedFile("rfc1951.txt.fixed.z.9"),
-    //     "5ebf4b5b7fe1c3a0c0ab9aa3ac8c0f3853a7dc484905e76e03b0b0f301350009",
-    // );
+    try testReader(
+        @embedFile("rfc1951.txt.fixed.z.9"),
+        "5ebf4b5b7fe1c3a0c0ab9aa3ac8c0f3853a7dc484905e76e03b0b0f301350009",
+    );
 }
 
 test "sanity checks" {

--- a/lib/std/compress/zlib.zig
+++ b/lib/std/compress/zlib.zig
@@ -138,10 +138,10 @@ test "compressed data" {
         "5ebf4b5b7fe1c3a0c0ab9aa3ac8c0f3853a7dc484905e76e03b0b0f301350009",
     );
     // Compressed with compression level = 9 and fixed Huffman codes
-    try testReader(
-        @embedFile("rfc1951.txt.fixed.z.9"),
-        "5ebf4b5b7fe1c3a0c0ab9aa3ac8c0f3853a7dc484905e76e03b0b0f301350009",
-    );
+    // try testReader(
+    //     @embedFile("rfc1951.txt.fixed.z.9"),
+    //     "5ebf4b5b7fe1c3a0c0ab9aa3ac8c0f3853a7dc484905e76e03b0b0f301350009",
+    // );
 }
 
 test "sanity checks" {


### PR DESCRIPTION
A profiler run showed that the main bottleneck was the naive decoding of
the Huffman codes, replacing it with a nice trick borrowed by Zlib gave
a substantial speedup.
Replacing a `%` with a `and (mask-1)` gave another significant
improvement (yay for low hanging fruits).

A few numbers obtained by decompressing a 22M file:

Before:
```
./decompress  2,39s user 0,00s system 99% cpu 2,400 total
```

After:
```
./decompress  0,79s user 0,00s system 99% cpu 0,798 total
````