### PR TITLE
stage1: implement --omit-lib-prefix

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2303,6 +2303,7 @@ struct CodeGen {
     bool test_is_evented;
     bool linker_z_nodelete;
     bool linker_z_defs;
+    bool omit_lib_prefix;
 
     Buf *root_out_name;
     Buf *test_filter;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -112,8 +112,9 @@ void codegen_set_strip(CodeGen *g, bool strip) {
     }
 }
 
-void codegen_set_out_name(CodeGen *g, Buf *out_name) {
+void codegen_set_out_name(CodeGen *g, Buf *out_name, bool omit_lib_prefix) {
     g->root_out_name = out_name;
+    g->omit_lib_prefix = omit_lib_prefix;
 }
 
 void codegen_add_lib_dir(CodeGen *g, const char *dir) {
@@ -10773,6 +10774,7 @@ static Error check_cache(CodeGen *g, Buf *manifest_dir, Buf *digest) {
     }
     cache_buf(ch, compiler_id);
     cache_buf(ch, g->root_out_name);
+    cache_bool(ch, g->omit_lib_prefix);
     cache_buf(ch, g->zig_lib_dir);
     cache_buf(ch, g->zig_std_dir);
     cache_list_of_link_lib(ch, g->link_libs_list.items, g->link_libs_list.length);
@@ -10893,7 +10895,9 @@ static void resolve_out_paths(CodeGen *g) {
             case OutTypeLib:
                 buf_append_str(o_basename, target_o_file_ext(g->zig_target));
                 buf_resize(out_basename, 0);
-                buf_append_str(out_basename, target_lib_file_prefix(g->zig_target));
+                if (!g->omit_lib_prefix) {
+                    buf_append_str(out_basename, target_lib_file_prefix(g->zig_target));
+                }
                 buf_append_buf(out_basename, g->root_out_name);
                 buf_append_str(out_basename, target_lib_file_ext(g->zig_target, !g->is_dynamic, g->is_versioned,
                             g->version_major, g->version_minor, g->version_patch));

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -28,7 +28,7 @@ void codegen_set_each_lib_rpath(CodeGen *codegen, bool each_lib_rpath);
 
 void codegen_set_strip(CodeGen *codegen, bool strip);
 void codegen_set_errmsg_color(CodeGen *codegen, ErrColor err_color);
-void codegen_set_out_name(CodeGen *codegen, Buf *out_name);
+void codegen_set_out_name(CodeGen *codegen, Buf *out_name, bool omit_lib_prefix);
 void codegen_add_lib_dir(CodeGen *codegen, const char *dir);
 void codegen_add_forbidden_lib(CodeGen *codegen, Buf *lib);
 LinkLib *codegen_add_link_lib(CodeGen *codegen, Buf *lib);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,7 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  -fno-emit-h                  (default) do not generate a C header file (.h)\n"
         "  --libc [file]                Provide a file which specifies libc paths\n"
         "  --name [name]                override output name\n"
+        "  --omit-lib-prefix            never prefix the name of generated libraries with \"lib\"\n"
         "  --output-dir [dir]           override output directory (defaults to cwd)\n"
         "  --pkg-begin [name] [path]    make pkg available to import and push current pkg\n"
         "  --pkg-end                    pop current pkg\n"
@@ -384,6 +385,7 @@ static int main0(int argc, char **argv) {
     bool is_dynamic = false;
     OutType out_type = OutTypeUnknown;
     const char *out_name = nullptr;
+    bool omit_lib_prefix = false;
     bool verbose_tokenize = false;
     bool verbose_ast = false;
     bool verbose_link = false;
@@ -554,7 +556,7 @@ static int main0(int argc, char **argv) {
                 BuildModeDebug, override_lib_dir, nullptr, &full_cache_dir, false, root_progress_node);
         g->valgrind_support = valgrind_support;
         g->enable_time_report = timing_info;
-        codegen_set_out_name(g, buf_create_from_str("build"));
+        codegen_set_out_name(g, buf_create_from_str("build"), false);
 
         args.items[2] = buf_ptr(&build_file_dirname);
         args.items[3] = buf_ptr(&full_cache_dir);
@@ -1028,6 +1030,8 @@ static int main0(int argc, char **argv) {
                 linker_bind_global_refs_locally = OptionalBoolTrue;
             } else if (strcmp(arg, "--test-cmd-bin") == 0) {
                 test_exec_args.append(nullptr);
+            } else if (strcmp(arg, "--omit-lib-prefix") == 0) {
+                omit_lib_prefix = true;
             } else if (arg[1] == 'D' && arg[2] != 0) {
                 clang_argv.append("-D");
                 clang_argv.append(&arg[2]);
@@ -1595,7 +1599,7 @@ static int main0(int argc, char **argv) {
             g->emit_asm = emit_asm;
             g->emit_llvm_ir = emit_llvm_ir;
 
-            codegen_set_out_name(g, buf_out_name);
+            codegen_set_out_name(g, buf_out_name, omit_lib_prefix);
             codegen_set_lib_version(g, is_versioned, ver_major, ver_minor, ver_patch);
             g->want_single_threaded = want_single_threaded;
             codegen_set_linker_script(g, linker_script);


### PR DESCRIPTION
When building shared libraries for use as plugins, it is often necessary to follow different naming conventions. Passing the new --omit-lib-prefix flag prevents zig from prefixing the name of generated libraries with "lib" and makes following such conventions possible.

~Consider this an alternative to #6317~
Closes #2231
