### PR TITLE
Reorganize AES implementation internals

### DIFF
--- a/lib/std/crypto/aes.zig
+++ b/lib/std/crypto/aes.zig
@@ -26,8 +26,8 @@ fn AESImpl(comptime keysize: usize) type {
         // Number of rounds is set by length of expanded key; - 2: one above, one more below
         const numRounds = expKeyIntsLen / 4 - 2; // NR
 
-        const Key = [keyBytesLen]u8;
-        const ExpKey = [expKeyIntsLen]u32;
+        pub const Key = [keyBytesLen]u8;
+        const ExpKey = [expKeyIntsLen]u32; // for internal use
 
         enc: Encrypt,
         dec: Decrypt,

--- a/lib/std/crypto/aes.zig
+++ b/lib/std/crypto/aes.zig
@@ -230,13 +230,12 @@ fn EncryptCtx(comptime AES: type) type {
             var ctrbuf = iv;
             var n: usize = 0;
 
-            const len16 = src.len - (src.len & 15);
-            while (n < len16) {
+            // iterate block by block
+            while (n < src.len) : (n += 16) {
                 ctx.encrypt(keystream[0..], ctrbuf[0..]);
                 var ctr_i = std.mem.readIntBig(u128, ctrbuf[0..]);
                 std.mem.writeIntBig(u128, ctrbuf[0..], ctr_i +% 1);
                 xorBytes(src[n..][0..16], &keystream, dst[n..][0..16]);
-                n += 16;
             }
         }
     };

--- a/lib/std/crypto/aes.zig
+++ b/lib/std/crypto/aes.zig
@@ -235,7 +235,7 @@ fn EncryptCtx(comptime AES: type) type {
                 ctx.encrypt(keystream[0..], ctrbuf[0..]);
                 var ctr_i = std.mem.readIntBig(u128, ctrbuf[0..]);
                 std.mem.writeIntBig(u128, ctrbuf[0..], ctr_i +% 1);
-                xorBytes(src[n..][0..16], &keystream, dst[n..][0..16]);
+                xorBytes(&keystream, src[n..][0..16], dst[n..][0..16]);
             }
         }
     };

--- a/lib/std/crypto/aes.zig
+++ b/lib/std/crypto/aes.zig
@@ -386,9 +386,6 @@ test "expand key" {
 }
 
 // constants
-
-const poly = 1 << 8 | 1 << 4 | 1 << 3 | 1 << 1 | 1 << 0;
-
 const powx = [16]u8{
     0x01,
     0x02,


### PR DESCRIPTION
- group functions logically
- move constants to one place, name them descriptively 
- more type safe code
- more generic code

I would like to change AES public api a bit so there might be a part2.