### PR TITLE
Add rename to std.fs API

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1890,7 +1890,7 @@ pub fn unlinkatW(dirfd: fd_t, sub_path_w: []const u16, flags: u32) UnlinkatError
     return windows.DeleteFile(sub_path_w, .{ .dir = dirfd, .remove_dir = remove_dir });
 }
 
-const RenameError = error{
+pub const RenameError = error{
     /// In WASI, this error may occur when the file descriptor does
     /// not hold the required rights to rename a resource by path relative to it.
     AccessDenied,
@@ -2107,6 +2107,7 @@ pub fn renameatW(
         .ACCESS_DENIED => return error.AccessDenied,
         .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
         .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
+        .NOT_SAME_DEVICE => error.RenameAcrossMountPoints,
         else => return windows.unexpectedStatus(rc),
     }
 }

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -828,7 +828,7 @@ pub fn DeleteFile(sub_path_w: []const u16, options: DeleteFileOptions) DeleteFil
     }
 }
 
-pub const MoveFileError = error{Unexpected};
+pub const MoveFileError = error{ FileNotFound, Unexpected };
 
 pub fn MoveFileEx(old_path: []const u8, new_path: []const u8, flags: DWORD) MoveFileError!void {
     const old_path_w = try sliceToPrefixedFileW(old_path);
@@ -839,6 +839,7 @@ pub fn MoveFileEx(old_path: []const u8, new_path: []const u8, flags: DWORD) Move
 pub fn MoveFileExW(old_path: [*:0]const u16, new_path: [*:0]const u16, flags: DWORD) MoveFileError!void {
     if (kernel32.MoveFileExW(old_path, new_path, flags) == 0) {
         switch (kernel32.GetLastError()) {
+            .FILE_NOT_FOUND => return error.FileNotFound,
             else => |err| return unexpectedError(err),
         }
     }


### PR DESCRIPTION
Closes #6344 

- Moves fs.rename functions to fs.renameAbsolute to match other functions outside of fs.Dir
- Adds fs.Dir.rename that takes two paths relative to the given Dir
- Adds fs.rename that takes two separate Dir's that the given paths are relative to (for renaming across directories without having to make the second path relative to a single directory)
- Fixes FileNotFound error return in std.os.windows.MoveFileExW
- Returns error.RenameAcrossMountPoints from renameatW
  + Matches the RenameAcrossMountPoints error return in renameatWasi/renameatZ

---

Notes:

- ~~There is likely a better name or API for `Dir.renameAt`. I couldn't really come up with anything, though (`renameElsewhere`? `renameTransfer`? `renameTo`?).~~

---

~~The tests are currently failing on Windows.~~ EDIT: Split the Windows rename failure to its own issue: #6364

- On Windows, the implementation of both `renameAbsolute` and `Dir.rename` do not allow renaming directories.
  + `renameAbsolute` [uses `MOVEFILE_REPLACE_EXISTING`](https://github.com/ziglang/zig/blob/61e9e82bdc10110b74bdeb973cc542c7b73a4ae2/lib/std/os.zig#L1968) which ["cannot be used if lpNewFileName or lpExistingFileName names a directory."](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw)
  + `Dir.rename` [uses `OpenFile`](https://github.com/ziglang/zig/blob/61e9e82bdc10110b74bdeb973cc542c7b73a4ae2/lib/std/os.zig#L2066-L2074) which fails with `error.IsDir`