### PR TITLE
Code Coverage

### DIFF
--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -323,6 +323,33 @@ comptime {
     }
     @export(@import("compiler_rt/muloti4.zig").__muloti4, .{ .name = "__muloti4", .linkage = linkage });
     @export(@import("compiler_rt/mulodi4.zig").__mulodi4, .{ .name = "__mulodi4", .linkage = linkage });
+
+    // Typically provided by the runtime and not overriden by the user, but can be.
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_dump_coverage, .{ .name = "__sanitizer_dump_coverage", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_pc_guard, .{ .name = "__sanitizer_cov_trace_pc_guard", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_pc_guard_init, .{ .name = "__sanitizer_cov_trace_pc_guard_init", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_dump_trace_pc_guard_coverage, .{ .name = "__sanitizer_dump_trace_pc_guard_coverage", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_dump, .{ .name = "__sanitizer_cov_dump", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_reset, .{ .name = "__sanitizer_cov_reset", .linkage = builtin.GlobalLinkage.Weak });
+
+    // Are defined as empty, but can be overriden by the user.
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_cmp, .{ .name = "__sanitizer_cov_trace_cmp", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_cmp1, .{ .name = "__sanitizer_cov_trace_cmp1", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_cmp2, .{ .name = "__sanitizer_cov_trace_cmp2", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_cmp4, .{ .name = "__sanitizer_cov_trace_cmp4", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_cmp8, .{ .name = "__sanitizer_cov_trace_cmp8", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_const_cmp1, .{ .name = "__sanitizer_cov_trace_const_cmp1", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_const_cmp2, .{ .name = "__sanitizer_cov_trace_const_cmp2", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_const_cmp4, .{ .name = "__sanitizer_cov_trace_const_cmp4", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_const_cmp8, .{ .name = "__sanitizer_cov_trace_const_cmp8", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_switch, .{ .name = "__sanitizer_cov_trace_switch", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_div4, .{ .name = "__sanitizer_cov_trace_div4", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_div8, .{ .name = "__sanitizer_cov_trace_div8", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_gep, .{ .name = "__sanitizer_cov_trace_gep", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_trace_pc_indir, .{ .name = "__sanitizer_cov_trace_pc_indir", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_8bit_counters_init, .{ .name = "__sanitizer_cov_8bit_counters_init", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_bool_flag_init, .{ .name = "__sanitizer_cov_bool_flag_init", .linkage = builtin.GlobalLinkage.Weak });
+    @export(@import("compiler_rt/sancov.zig").__sanitizer_cov_pcs_init, .{ .name = "__sanitizer_cov_pcs_init", .linkage = builtin.GlobalLinkage.Weak });
 }
 
 pub usingnamespace @import("compiler_rt/atomics.zig");

--- a/lib/std/special/compiler_rt/sancov.zig
+++ b/lib/std/special/compiler_rt/sancov.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+
+pub fn __sanitizer_dump_coverage(pcs: *const usize, len: usize) callconv(.C) void {
+
+}
+
+pub fn __sanitizer_cov_trace_pc_guard(guard: *const u32) callconv(.C) void {
+
+}
+
+pub fn __sanitizer_cov_trace_pc_guard_init(start: *const u32, end: *const u32) callconv(.C) void {
+
+}
+
+pub fn __sanitizer_dump_trace_pc_guard_coverage() callconv(.C) void {
+
+}
+
+pub fn __sanitizer_cov_dump() callconv(.C) void {
+
+}
+
+pub fn __sanitizer_cov_reset() callconv(.C) void {
+
+}
+
+// Default empty implementations.
+pub fn __sanitizer_cov_trace_cmp() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_cmp1() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_cmp2() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_cmp4() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_cmp8() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_const_cmp1() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_const_cmp2() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_const_cmp4() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_const_cmp8() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_switch() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_div4() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_div8() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_gep() callconv(.C) void {}
+pub fn __sanitizer_cov_trace_pc_indir() callconv(.C) void {}
+pub fn __sanitizer_cov_8bit_counters_init() callconv(.C) void {}
+pub fn __sanitizer_cov_bool_flag_init() callconv(.C) void {}
+pub fn __sanitizer_cov_pcs_init() callconv(.C) void {}

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -2281,6 +2281,7 @@ struct CodeGen {
     OptionalBool linker_gc_sections;
     OptionalBool linker_allow_shlib_undefined;
     OptionalBool linker_bind_global_refs_locally;
+    bool want_coverage;
     bool strip_debug_symbols;
     bool is_test_build;
     bool is_single_threaded;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8334,7 +8334,7 @@ static void zig_llvm_emit_output(CodeGen *g) {
     // pipeline multiple times if this is requested.
     if (asm_filename != nullptr && bin_filename != nullptr) {
         if (ZigLLVMTargetMachineEmitToFile(g->target_machine, g->module, &err_msg, g->build_mode == BuildModeDebug,
-            is_small, g->enable_time_report, nullptr, bin_filename, llvm_ir_filename))
+            is_small, g->want_coverage, g->enable_time_report, nullptr, bin_filename, llvm_ir_filename))
         {
             fprintf(stderr, "LLVM failed to emit file: %s\n", err_msg);
             exit(1);
@@ -8344,7 +8344,7 @@ static void zig_llvm_emit_output(CodeGen *g) {
     }
 
     if (ZigLLVMTargetMachineEmitToFile(g->target_machine, g->module, &err_msg, g->build_mode == BuildModeDebug,
-        is_small, g->enable_time_report, asm_filename, bin_filename, llvm_ir_filename))
+        is_small, g->want_coverage, g->enable_time_report, asm_filename, bin_filename, llvm_ir_filename))
     {
         fprintf(stderr, "LLVM failed to emit file: %s\n", err_msg);
         exit(1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,6 +137,7 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  -Bsymbolic                   bind global references locally\n"
         "\n"
         "Test Options:\n"
+        "  --coverage                   output code coverage reports\n"
         "  --test-filter [text]         skip tests that do not match filter\n"
         "  --test-name-prefix [text]    add prefix to all tests\n"
         "  --test-cmd [arg]             specify test execution command one arg at a time\n"
@@ -436,6 +437,7 @@ static int main0(int argc, char **argv) {
     int runtime_args_start = -1;
     bool system_linker_hack = false;
     TargetSubsystem subsystem = TargetSubsystemAuto;
+    bool want_coverage = false;
     bool want_single_threaded = false;
     bool bundle_compiler_rt = false;
     Buf *override_lib_dir = nullptr;
@@ -1026,6 +1028,8 @@ static int main0(int argc, char **argv) {
                 bundle_compiler_rt = true;
             } else if (strcmp(arg, "-Bsymbolic") == 0) {
                 linker_bind_global_refs_locally = OptionalBoolTrue;
+            } else if (strcmp(arg, "--coverage") == 0) {
+                want_coverage = true;
             } else if (strcmp(arg, "--test-cmd-bin") == 0) {
                 test_exec_args.append(nullptr);
             } else if (arg[1] == 'D' && arg[2] != 0) {
@@ -1586,6 +1590,7 @@ static int main0(int argc, char **argv) {
             g->want_stack_check = want_stack_check;
             g->want_sanitize_c = want_sanitize_c;
             g->subsystem = subsystem;
+            g->want_coverage = want_coverage;
 
             g->enable_time_report = timing_info;
             g->enable_stack_report = stack_report;

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -48,7 +48,7 @@ ZIG_EXTERN_C char *ZigLLVMGetNativeFeatures(void);
 
 ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
         char **error_message, bool is_debug,
-        bool is_small, bool time_report,
+        bool is_small, bool want_coverage, bool time_report,
         const char *asm_filename, const char *bin_filename, const char *llvm_ir_filename);
 
 


### PR DESCRIPTION
Taking a run at https://github.com/ziglang/zig/issues/352.

There are a couple of outstanding questions here:
1) Do we want to invent our own coverage format and visualizer, or do we want to emit data that is compatible with pre-existing tools? If so, what tool(s) are we integrating with?
2) How can we dynamically allocate memory in compiler_rt? This is needed for storing encountered program counters while tracking code coverage.
3) How can we get a mapping from program counter to function names or line numbers? Can we guarantee that Zig tests will be compiled with symbols or DWARF symbols and parse our own binary at runtime during coverage output?

You can find an implementation of ASan's SanitizerCoverage runtime here: https://github.com/llvm/llvm-project/blob/master/compiler-rt/lib/sanitizer_common/sanitizer_coverage_libcdep_new.cpp. If Zig decides to act similarly to the SanitizerCoverage runtime here, we also need to support disk access in the compiler_rt.

---
Thoughts on 1)

The LLVM coverage report server (`tools/sancov/coverage-report-server.py`) generates highlighted HTML from SanitizerCoverage files, but I was imagining more what Go does, e.g.:

```
$ go test -cover fmt
ok  	fmt	0.060s	coverage: 91.4% of statements
```

Alternatively we could write out the coverage file:
```
$ go test . -coverprofile cover.out
ok      example        0.001s  coverage: 100.0% of statements
```

And then provide a tool for collecting more information:

```
$ go tool cover -func cover.out
example.go:4:              DoSomething     100.0%
total:                     (statements)    100.0%
```

The advantage of writing out a coverage file is other members of the Zig community could create external software that takes advantage of Zig coverage files and e.g. produce more graphical representations like stylized HTML output.