### PR TITLE
stage1: Fix edge case in casting between optional types

### DIFF
--- a/test/stage1/behavior/cast.zig
+++ b/test/stage1/behavior/cast.zig
@@ -849,3 +849,8 @@ test "comptime float casts" {
     expect(b == 2);
     expect(@TypeOf(b) == comptime_int);
 }
+
+test "cast from ?[*]T to ??[*]T" {
+    const a: ??[*]u8 = @as(?[*]u8, null);
+    expect(a != null and a.? == null);
+}


### PR DESCRIPTION
A nasty edge case, check the diff for more info.
I've re-used `type_mismatch` as I'm too lazy to come up with a new struct and stage1 deserves no love.
Please fix the error message before/after merging, I have no idea on how to explain the problem to the end user (and I wonder if this error will ever surface to the user-level)

Closes #6370