### PR TITLE
std: Make C allocator respect the required alignment

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -246,20 +246,8 @@ pub extern "c" fn setresuid(ruid: uid_t, euid: uid_t, suid: uid_t) c_int;
 pub extern "c" fn setresgid(rgid: gid_t, egid: gid_t, sgid: gid_t) c_int;
 
 pub extern "c" fn malloc(usize) ?*c_void;
-
-pub usingnamespace switch (builtin.os.tag) {
-    .linux, .freebsd, .kfreebsd, .netbsd => struct {
-        pub extern "c" fn malloc_usable_size(?*const c_void) usize;
-    },
-    .macos, .ios, .watchos, .tvos => struct {
-        pub extern "c" fn malloc_size(?*const c_void) usize;
-    },
-    else => struct {},
-};
-
 pub extern "c" fn realloc(?*c_void, usize) ?*c_void;
 pub extern "c" fn free(*c_void) void;
-pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
 
 pub extern "c" fn futimes(fd: fd_t, times: *[2]timeval) c_int;
 pub extern "c" fn utimes(path: [*:0]const u8, times: *[2]timeval) c_int;

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -245,7 +245,6 @@ pub extern "c" fn setregid(rgid: gid_t, egid: gid_t) c_int;
 pub extern "c" fn setresuid(ruid: uid_t, euid: uid_t, suid: uid_t) c_int;
 pub extern "c" fn setresgid(rgid: gid_t, egid: gid_t, sgid: gid_t) c_int;
 
-pub extern "c" fn aligned_alloc(alignment: usize, size: usize) ?*c_void;
 pub extern "c" fn malloc(usize) ?*c_void;
 
 pub usingnamespace switch (builtin.os.tag) {
@@ -260,7 +259,7 @@ pub usingnamespace switch (builtin.os.tag) {
 
 pub extern "c" fn realloc(?*c_void, usize) ?*c_void;
 pub extern "c" fn free(*c_void) void;
-pub extern "c" fn posix_memalign(memptr: **c_void, alignment: usize, size: usize) c_int;
+pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
 
 pub extern "c" fn futimes(fd: fd_t, times: *[2]timeval) c_int;
 pub extern "c" fn utimes(path: [*:0]const u8, times: *[2]timeval) c_int;

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -45,6 +45,9 @@ pub const _fstatat = if (builtin.arch == .aarch64) fstatat else @"fstatat$INODE6
 pub extern "c" fn mach_absolute_time() u64;
 pub extern "c" fn mach_timebase_info(tinfo: ?*mach_timebase_info_data) void;
 
+pub extern "c" fn malloc_size(?*const c_void) usize;
+pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
+
 pub extern "c" fn kevent64(
     kq: c_int,
     changelist: [*]const kevent64_s,

--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -17,6 +17,8 @@ pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize
 pub const dl_iterate_phdr_callback = fn (info: *dl_phdr_info, size: usize, data: ?*c_void) callconv(.C) c_int;
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*c_void) c_int;
 
+pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
+
 pub const pthread_mutex_t = extern struct {
     inner: ?*c_void = null,
 };

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -13,6 +13,9 @@ pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) usize;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;
 
+pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
+pub extern "c" fn malloc_usable_size(?*const c_void) usize;
+
 pub const sf_hdtr = extern struct {
     headers: [*]const iovec_const,
     hdr_cnt: c_int,

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -101,6 +101,8 @@ pub extern "c" fn copy_file_range(fd_in: fd_t, off_in: ?*i64, fd_out: fd_t, off_
 pub extern "c" fn signalfd(fd: fd_t, mask: *const sigset_t, flags: c_uint) c_int;
 
 pub extern "c" fn prlimit(pid: pid_t, resource: rlimit_resource, new_limit: *const rlimit, old_limit: *rlimit) c_int;
+pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
+pub extern "c" fn malloc_usable_size(?*const c_void) usize;
 
 pub const pthread_attr_t = extern struct {
     __size: [56]u8,

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -30,6 +30,9 @@ pub extern "c" fn __getrusage50(who: c_int, usage: *rusage) c_int;
 // libc aliases this as sched_yield
 pub extern "c" fn __libc_thr_yield() c_int;
 
+pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
+pub extern "c" fn malloc_usable_size(?*const c_void) usize;
+
 pub const pthread_mutex_t = extern struct {
     ptm_magic: u32 = 0x33330003,
     ptm_errorcheck: padded_pthread_spin_t = 0,

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -32,3 +32,6 @@ pub const pthread_spinlock_t = extern struct {
 pub const pthread_attr_t = extern struct {
     inner: ?*c_void = null,
 };
+
+pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
+pub extern "c" fn malloc_usable_size(?*const c_void) usize;

--- a/lib/std/c/windows.zig
+++ b/lib/std/c/windows.zig
@@ -4,3 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 pub extern "c" fn _errno() *c_int;
+
+pub extern "c" fn _aligned_free(memblock: ?*c_void) void;
+pub extern "c" fn _aligned_malloc(size: usize, alignment: usize) ?*c_void;
+pub extern "c" fn _aligned_realloc(memblock: ?*c_void, size: usize, alignment: usize) ?*c_void;

--- a/lib/std/c/windows.zig
+++ b/lib/std/c/windows.zig
@@ -5,6 +5,4 @@
 // and substantial portions of the software.
 pub extern "c" fn _errno() *c_int;
 
-pub extern "c" fn _aligned_free(memblock: ?*c_void) void;
-pub extern "c" fn _aligned_malloc(size: usize, alignment: usize) ?*c_void;
-pub extern "c" fn _aligned_realloc(memblock: ?*c_void, size: usize, alignment: usize) ?*c_void;
+pub extern "c" fn _msize(memblock: ?*c_void) usize;

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -48,15 +48,16 @@ const CAllocator = struct {
             pub const supports_malloc_size = false;
         };
 
-    pub const supports_posix_memalign = false and @hasDecl(c, "posix_memalign");
+    pub const supports_posix_memalign = @hasDecl(c, "posix_memalign");
 
-    fn get_header(ptr: [*]u8) *[*]u8 {
+    fn getHeader(ptr: [*]u8) *[*]u8 {
         return @intToPtr(*[*]u8, @ptrToInt(ptr) - @sizeOf(usize));
     }
 
-    fn aligned_alloc(len: usize, alignment: usize) ?[*]u8 {
+    fn alignedAlloc(len: usize, alignment: usize) ?[*]u8 {
         if (supports_posix_memalign) {
-            // The minimum alignment supported posix_memalign is the pointer size
+            // The posix_memalign only accepts alignment values that are a
+            // multiple of the pointer size
             const eff_alignment = std.math.max(alignment, @sizeOf(usize));
 
             var aligned_ptr: ?*c_void = undefined;
@@ -73,26 +74,26 @@ const CAllocator = struct {
         const unaligned_addr = @ptrToInt(unaligned_ptr);
         const aligned_addr = mem.alignForward(unaligned_addr + @sizeOf(usize), alignment);
         var aligned_ptr = unaligned_ptr + (aligned_addr - unaligned_addr);
-        get_header(aligned_ptr).* = unaligned_ptr;
+        getHeader(aligned_ptr).* = unaligned_ptr;
 
         return aligned_ptr;
     }
 
-    fn aligned_free(ptr: [*]u8) void {
+    fn alignedFree(ptr: [*]u8) void {
         if (supports_posix_memalign) {
             return c.free(ptr);
         }
 
-        const unaligned_ptr = get_header(ptr).*;
+        const unaligned_ptr = getHeader(ptr).*;
         c.free(unaligned_ptr);
     }
 
-    fn aligned_alloc_size(ptr: [*]u8) usize {
+    fn alignedAllocSize(ptr: [*]u8) usize {
         if (supports_posix_memalign) {
             return malloc_size(ptr);
         }
 
-        const unaligned_ptr = get_header(ptr).*;
+        const unaligned_ptr = getHeader(ptr).*;
         const delta = @ptrToInt(ptr) - @ptrToInt(unaligned_ptr);
         return malloc_size(unaligned_ptr) - delta;
     }
@@ -107,13 +108,13 @@ const CAllocator = struct {
         assert(len > 0);
         assert(std.math.isPowerOfTwo(alignment));
 
-        var ptr = aligned_alloc(len, alignment) orelse return error.OutOfMemory;
+        var ptr = alignedAlloc(len, alignment) orelse return error.OutOfMemory;
         if (len_align == 0) {
             return ptr[0..len];
         }
         const full_len = init: {
             if (supports_malloc_size) {
-                const s = aligned_alloc_size(ptr);
+                const s = alignedAllocSize(ptr);
                 assert(s >= len);
                 break :init s;
             }
@@ -131,14 +132,14 @@ const CAllocator = struct {
         return_address: usize,
     ) Allocator.Error!usize {
         if (new_len == 0) {
-            aligned_free(buf.ptr);
+            alignedFree(buf.ptr);
             return 0;
         }
         if (new_len <= buf.len) {
             return mem.alignAllocLen(buf.len, new_len, len_align);
         }
         if (supports_malloc_size) {
-            const full_len = aligned_alloc_size(buf.ptr);
+            const full_len = alignedAllocSize(buf.ptr);
             if (new_len <= full_len) {
                 return mem.alignAllocLen(full_len, new_len, len_align);
             }


### PR DESCRIPTION
Use posix_memalign where available and the _aligned_{malloc,free} API on
Windows.

Closes #3783