### PR TITLE
cmake: add option to use llvm-config to find cross-target llvm deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ option(ZIG_FORCE_EXTERNAL_LLD "does nothing" OFF)
 set(ZIG_TARGET_TRIPLE "native" CACHE STRING "arch-os-abi to output binaries for")
 set(ZIG_TARGET_MCPU "baseline" CACHE STRING "-mcpu parameter to output binaries for")
 set(ZIG_EXECUTABLE "" CACHE STRING "(when cross compiling) path to already-built zig binary")
+set(ZIG_PREFER_LLVM_CONFIG off CACHE BOOL "(when cross compiling) use llvm-config to find target llvm dependencies if needed")
 
 find_package(llvm)
 find_package(clang)

--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -32,7 +32,7 @@ if(ZIG_PREFER_CLANG_CPP_DYLIB)
       /usr/local/llvm10/lib
       /usr/local/llvm100/lib
   )
-elseif("${ZIG_TARGET_TRIPLE}" STREQUAL "native")
+elseif(("${ZIG_TARGET_TRIPLE}" STREQUAL "native") OR ZIG_PREFER_LLVM_CONFIG)
   find_program(LLVM_CONFIG_EXE
       NAMES llvm-config-10 llvm-config-10.0 llvm-config100 llvm-config10 llvm-config
       PATHS


### PR DESCRIPTION
Closes #6386 