### PR TITLE
std.fmt meets UTF-8

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -561,7 +561,7 @@ pub fn formatIntValue(
         if (@typeInfo(@TypeOf(int_value)).Int.bits <= 21) {
             return formatUnicodeCodepoint(@as(u21, int_value), options, writer);
         } else {
-            @compileError("Cannot print integer that is larger than 32 bits as an UTF-8 sequence");
+            @compileError("Cannot print integer that is larger than 21 bits as an UTF-8 sequence");
         }
     } else if (comptime std.mem.eql(u8, fmt, "b")) {
         radix = 2;
@@ -657,7 +657,7 @@ pub fn formatUnicodeCodepoint(
     if (unicode.utf8ValidCodepoint(c)) {
         var buf: [4]u8 = undefined;
         // The codepoint is surely valid, hence the use of unreachable
-        const len = std.unicode.utf8Encode(@truncate(u21, c), &buf) catch |err| switch (err) {
+        const len = std.unicode.utf8Encode(c, &buf) catch |err| switch (err) {
             error.Utf8CannotEncodeSurrogateHalf, error.CodepointTooLarge => unreachable,
         };
         return formatBuf(buf[0..len], options, writer);

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -77,7 +77,7 @@ fn peekIsAlign(comptime fmt: []const u8) bool {
 /// - `b`: output integer value in binary notation
 /// - `o`: output integer value in octal notation
 /// - `c`: output integer as an ASCII character. Integer type must have 8 bits at max.
-/// - `u`: output integer as an UTF-8 sequence. Integer type must have 32 bits at max.
+/// - `u`: output integer as an UTF-8 sequence. Integer type must have 21 bits at max.
 /// - `*`: output the address of the value instead of the value itself.
 ///
 /// If a formatted user type contains a function of the type

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -654,17 +654,14 @@ pub fn formatUnicodeCodepoint(
     options: FormatOptions,
     writer: anytype,
 ) !void {
-    if (unicode.utf8ValidCodepoint(c)) {
-        var buf: [4]u8 = undefined;
-        // The codepoint is surely valid, hence the use of unreachable
-        const len = std.unicode.utf8Encode(c, &buf) catch |err| switch (err) {
-            error.Utf8CannotEncodeSurrogateHalf, error.CodepointTooLarge => unreachable,
-        };
-        return formatBuf(buf[0..len], options, writer);
-    }
-
-    // In case of error output the replacement char U+FFFD
-    return formatBuf(&[_]u8{ 0xef, 0xbf, 0xbd }, options, writer);
+    var buf: [4]u8 = undefined;
+    const len = std.unicode.utf8Encode(c, &buf) catch |err| switch (err) {
+        error.Utf8CannotEncodeSurrogateHalf, error.CodepointTooLarge => {
+            // In case of error output the replacement char U+FFFD
+            return formatBuf(&[_]u8{ 0xef, 0xbf, 0xbd }, options, writer);
+        },
+    };
+    return formatBuf(buf[0..len], options, writer);
 }
 
 pub fn formatBuf(

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -153,6 +153,15 @@ pub fn utf8Decode4(bytes: []const u8) Utf8Decode4Error!u21 {
     return value;
 }
 
+/// Returns true if the given unicode codepoint can be encoded in UTF-8.
+pub fn utf8ValidCodepoint(value: u21) bool {
+    return switch (value) {
+        0xD800...0xDFFF => false, // Surrogates range
+        0x110000...0x1FFFFF => false, // Above the maximum codepoint value
+        else => true,
+    };
+}
+
 /// Returns the length of a supplied UTF-8 string literal in terms of unicode
 /// codepoints.
 /// Asserts that the data is valid UTF-8.
@@ -784,4 +793,20 @@ fn testUtf8CountCodepoints() !void {
 test "utf8 count codepoints" {
     try testUtf8CountCodepoints();
     comptime testUtf8CountCodepoints() catch unreachable;
+}
+
+fn testUtf8ValidCodepoint() !void {
+    testing.expect(utf8ValidCodepoint('e'));
+    testing.expect(utf8ValidCodepoint('ë'));
+    testing.expect(utf8ValidCodepoint('は'));
+    testing.expect(utf8ValidCodepoint(0xe000));
+    testing.expect(utf8ValidCodepoint(0x10ffff));
+    testing.expect(!utf8ValidCodepoint(0xd800));
+    testing.expect(!utf8ValidCodepoint(0xdfff));
+    testing.expect(!utf8ValidCodepoint(0x110000));
+}
+
+test "utf8 valid codepoint" {
+    try testUtf8ValidCodepoint();
+    comptime testUtf8ValidCodepoint() catch unreachable;
 }

--- a/lib/std/unicode/throughput_test.zig
+++ b/lib/std/unicode/throughput_test.zig
@@ -3,47 +3,79 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-const builtin = @import("builtin");
 const std = @import("std");
+const builtin = std.builtin;
+const time = std.time;
+const unicode = std.unicode;
+
+const Timer = time.Timer;
+
+const N = 1_000_000;
+
+const KiB = 1024;
+const MiB = 1024 * KiB;
+const GiB = 1024 * MiB;
+
+const ResultCount = struct {
+    count: usize,
+    throughput: u64,
+};
+
+fn benchmarkCodepointCount(buf: []const u8) !ResultCount {
+    var timer = try Timer.start();
+
+    const bytes = N * buf.len;
+
+    const start = timer.lap();
+    var i: usize = 0;
+    var r: usize = undefined;
+    while (i < N) : (i += 1) {
+        r = try @call(
+            .{ .modifier = .never_inline },
+            std.unicode.utf8CountCodepoints,
+            .{buf},
+        );
+    }
+    const end = timer.read();
+
+    const elapsed_s = @intToFloat(f64, end - start) / time.ns_per_s;
+    const throughput = @floatToInt(u64, @intToFloat(f64, bytes) / elapsed_s);
+
+    return ResultCount{ .count = r, .throughput = throughput };
+}
 
 pub fn main() !void {
     const stdout = std.io.getStdOut().outStream();
 
     const args = try std.process.argsAlloc(std.heap.page_allocator);
 
-    // Warm up runs
-    var buffer0: [32767]u16 align(4096) = undefined;
-    _ = try std.unicode.utf8ToUtf16Le(&buffer0, args[1]);
-    _ = try std.unicode.utf8ToUtf16Le_better(&buffer0, args[1]);
+    try stdout.print("short ASCII strings\n", .{});
+    {
+        const result = try benchmarkCodepointCount("abc");
+        try stdout.print("  count: {:5} MiB/s [{d}]\n", .{ result.throughput / (1 * MiB), result.count });
+    }
 
-    @fence(.SeqCst);
-    var timer = try std.time.Timer.start();
-    @fence(.SeqCst);
+    try stdout.print("short Unicode strings\n", .{});
+    {
+        const result = try benchmarkCodepointCount("ŌŌŌ");
+        try stdout.print("  count: {:5} MiB/s [{d}]\n", .{ result.throughput / (1 * MiB), result.count });
+    }
 
-    var buffer1: [32767]u16 align(4096) = undefined;
-    _ = try std.unicode.utf8ToUtf16Le(&buffer1, args[1]);
+    try stdout.print("pure ASCII strings\n", .{});
+    {
+        const result = try benchmarkCodepointCount("hello" ** 16);
+        try stdout.print("  count: {:5} MiB/s [{d}]\n", .{ result.throughput / (1 * MiB), result.count });
+    }
 
-    @fence(.SeqCst);
-    const elapsed_ns_orig = timer.lap();
-    @fence(.SeqCst);
+    try stdout.print("pure Unicode strings\n", .{});
+    {
+        const result = try benchmarkCodepointCount("こんにちは" ** 16);
+        try stdout.print("  count: {:5} MiB/s [{d}]\n", .{ result.throughput / (1 * MiB), result.count });
+    }
 
-    var buffer2: [32767]u16 align(4096) = undefined;
-    _ = try std.unicode.utf8ToUtf16Le_better(&buffer2, args[1]);
-
-    @fence(.SeqCst);
-    const elapsed_ns_better = timer.lap();
-    @fence(.SeqCst);
-
-    std.debug.warn("original utf8ToUtf16Le: elapsed: {} ns ({} ms)\n", .{
-        elapsed_ns_orig, elapsed_ns_orig / 1000000,
-    });
-    std.debug.warn("new utf8ToUtf16Le: elapsed: {} ns ({} ms)\n", .{
-        elapsed_ns_better, elapsed_ns_better / 1000000,
-    });
-    asm volatile ("nop"
-        :
-        : [a] "r" (&buffer1),
-          [b] "r" (&buffer2)
-        : "memory"
-    );
+    try stdout.print("mixed ASCII/Unicode strings\n", .{});
+    {
+        const result = try benchmarkCodepointCount("Hyvää huomenta" ** 16);
+        try stdout.print("  count: {:5} MiB/s [{d}]\n", .{ result.throughput / (1 * MiB), result.count });
+    }
 }


### PR DESCRIPTION
This is a reboot of #5569 and #3970 with more polish on top of it.
You can still print ASCII chars (a-la `printf` `c` specifier) with `c`, use `u` for printing unicode codepoints.
You can now print UTF-8 encoded strings with the specified width/alignment.