### PR TITLE
Adding a function to update the priority of an element

### DIFF
--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -196,7 +196,6 @@ pub fn PriorityQueue(comptime T: type) type {
 
         pub fn update(self: *Self, elem: T, new_elem: T) !void {
             var update_index: usize = std.mem.indexOfScalar(T, self.items, elem) orelse return error.ElementNotFound;
-            assert (update_index >= 0 and update_index < self.items.len);
             const old_elem: T = self.items[update_index];
             self.items[update_index] = new_elem;
             if (self.compareFn(new_elem, old_elem)) {

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -190,26 +190,12 @@ pub fn PriorityQueue(comptime T: type) type {
             self.len = new_len;
         }
 
-        fn binarySearch(items: []const T, target: T) usize {
-            var left: usize = 0;
-            var right: usize = items.len-1;
-
-            while(left <= right) {
-                const mid = left + (right - left) / 2;
-                if (items[mid] == target) {
-                    return mid;
-                } else if (items[mid] < target) {
-                    left= mid+1;
-                } else { 
-                    right= mid-1;
-                }
-            }
-
-            return 0;
+        fn orderFn(lhs: T, rhs: T) std.math.Order {
+            return std.math.order(lhs, rhs);
         }
 
         pub fn update(self: *Self, elem: T, new_elem: T) !void {
-            var update_index: usize = binarySearch(self.items, elem);
+            var update_index: usize = std.sort.binarySearch(T, elem, self.items, orderFn) orelse 0;
             assert (update_index >= 0 and update_index < self.items.len);
             _ = self.removeIndex(update_index);
             try self.add(new_elem);

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -195,7 +195,7 @@ pub fn PriorityQueue(comptime T: type) type {
         }
 
         pub fn update(self: *Self, elem: T, new_elem: T) !void {
-            var update_index: usize = std.sort.binarySearch(T, elem, self.items, orderFn) orelse 0;
+            var update_index: usize = std.sort.binarySearch(T, elem, self.items, {}, orderFn) orelse 0;
             assert (update_index >= 0 and update_index < self.items.len);
             _ = self.removeIndex(update_index);
             try self.add(new_elem);

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -195,7 +195,7 @@ pub fn PriorityQueue(comptime T: type) type {
         }
 
         pub fn update(self: *Self, elem: T, new_elem: T) !void {
-            var update_index: usize = std.mem.indexOfScalar(T, self.items, elem) catch |error| return error.ElementNotFound;
+            var update_index: usize = std.mem.indexOfScalar(T, self.items, elem) orelse return error.ElementNotFound;
             assert (update_index >= 0 and update_index < self.items.len);
             const old_elem: T = self.items[update_index];
             self.items[update_index] = new_elem;

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -204,8 +204,13 @@ pub fn PriorityQueue(comptime T: type) type {
         pub fn update(self: *Self, elem: T, new_elem: T) !void {
             var update_index: usize = linearSearch(elem, self.items);
             assert (update_index >= 0 and update_index < self.items.len);
-            _ = self.removeIndex(update_index);
-            try self.add(new_elem);
+            // Heapreplace:
+            // replace the item: self.items[update_index]= new_elem; 
+            // swap the new item to the top of the heap: std.mem.swap(heap[0], heap[update_index]);
+            // sift up or down: which has been generically implemented as sift down: siftDown(self, 0)
+            self.items[update_index] = new_elem;
+            std.mem.swap(T, &self.items[0], &self.items[update_index]);
+            siftDown(self, 0);
         }
 
         pub const Iterator = struct {

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -190,6 +190,31 @@ pub fn PriorityQueue(comptime T: type) type {
             self.len = new_len;
         }
 
+        fn binarySearch(items: []const T, target: T) usize {
+            var left: usize = 0;
+            var right: usize = items.len-1;
+
+            while(left <= right) {
+                const mid = left + (right - left) / 2;
+                if (items[mid] == target) {
+                    return mid;
+                } else if (items[mid] < target) {
+                    left= mid+1;
+                } else { 
+                    right= mid-1;
+                }
+            }
+
+            return 0;
+        }
+
+        pub fn update(self: *Self, elem: T, new_elem: T) !void {
+            var update_index: usize = binarySearch(self.items, elem);
+            assert (update_index >= 0 and update_index < self.items.len);
+            _ = self.removeIndex(update_index);
+            try self.add(new_elem);
+        }
+
         pub const Iterator = struct {
             queue: *PriorityQueue(T),
             count: usize,
@@ -436,4 +461,67 @@ test "std.PriorityQueue: iterator while empty" {
     var it = queue.iterator();
 
     expectEqual(it.next(), null);
+}
+
+test "std.PriorityQueue: update min heap" {
+    var queue = PQ.init(testing.allocator, lessThan);
+    defer queue.deinit();
+
+    try queue.add(55);
+    try queue.add(44);
+    try queue.add(11);
+    try queue.update(55, 5);
+    try queue.update(44, 4);
+    try queue.update(11, 1);
+    expectEqual(@as(u32, 1), queue.remove());
+    expectEqual(@as(u32, 4), queue.remove());
+    expectEqual(@as(u32, 5), queue.remove());
+}
+
+
+test "std.PriorityQueue: update same min heap" {
+    var queue = PQ.init(testing.allocator, lessThan);
+    defer queue.deinit();
+
+    try queue.add(1);
+    try queue.add(1);
+    try queue.add(2);
+    try queue.add(2);
+    try queue.update(1, 5);
+    try queue.update(2, 4);
+    expectEqual(@as(u32, 1), queue.remove());
+    expectEqual(@as(u32, 2), queue.remove());
+    expectEqual(@as(u32, 4), queue.remove());
+    expectEqual(@as(u32, 5), queue.remove());
+}
+
+test "std.PriorityQueue: update max heap" {
+    var queue = PQ.init(testing.allocator, greaterThan);
+    defer queue.deinit();
+
+    try queue.add(55);
+    try queue.add(44);
+    try queue.add(11);
+    try queue.update(55, 5);
+    try queue.update(44, 1);
+    try queue.update(11, 4);
+    expectEqual(@as(u32, 5), queue.remove());
+    expectEqual(@as(u32, 4), queue.remove());
+    expectEqual(@as(u32, 1), queue.remove());
+}
+
+test "std.PriorityQueue: update same max heap" {
+    var queue = PQ.init(testing.allocator, greaterThan);
+    defer queue.deinit();
+
+    try queue.add(1);
+    try queue.add(1);
+    try queue.add(2);
+    try queue.add(2);
+    try queue.update(1, 5);
+    try queue.update(2, 4);
+    expectEqual(@as(u32, 5), queue.remove());
+    expectEqual(@as(u32, 4), queue.remove());
+    expectEqual(@as(u32, 2), queue.remove());
+    expectEqual(@as(u32, 1), queue.remove());
 }

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -190,12 +190,19 @@ pub fn PriorityQueue(comptime T: type) type {
             self.len = new_len;
         }
 
-        fn orderFn(lhs: T, rhs: T) std.math.Order {
-            return std.math.order(lhs, rhs);
+        fn linearSearch(elem: T, items: []const T) usize {
+            var found: usize = 0;
+            for (items) |item, i| {
+                if (item == elem) {
+                    found = i;
+                    break;
+                }
+            }
+            return found;
         }
 
         pub fn update(self: *Self, elem: T, new_elem: T) !void {
-            var update_index: usize = std.sort.binarySearch(T, elem, self.items, {}, orderFn) orelse 0;
+            var update_index: usize = linearSearch(elem, self.items);
             assert (update_index >= 0 and update_index < self.items.len);
             _ = self.removeIndex(update_index);
             try self.add(new_elem);


### PR DESCRIPTION
This is a small convenience function that has been added update an existing element in the priority queue. It searches for the element to be replaced in the queue, and updates the element and maintains the heap invariant. I wrote this because I had to re-implement this function myself a lot while working on algorithms that require you to update the priority of an existing element in the queue.