### PR TITLE
Fix for Windows: std.os.windows.DeleteFile()

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -813,3 +813,26 @@ fn run_lock_file_test(contexts: []FileLockTestContext) !void {
         try threads.append(try std.Thread.spawn(ctx, FileLockTestContext.run));
     }
 }
+
+test "deleteDir" {
+    var tmp_dir = tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    // deleting a non-existent directory
+    testing.expectError(error.FileNotFound, tmp_dir.dir.deleteDir("test_dir"));
+
+    var dir = try tmp_dir.dir.makeOpenPath("test_dir", .{});
+    var file = try dir.createFile("test_file", .{});
+    file.close();
+    dir.close();
+
+    // deleting a non-empty directory
+    testing.expectError(error.DirNotEmpty, tmp_dir.dir.deleteDir("test_dir"));
+
+    dir = try tmp_dir.dir.openDir("test_dir", .{});
+    try dir.deleteFile("test_file");
+    dir.close();
+
+    // deleting an empty directory
+    try tmp_dir.dir.deleteDir("test_dir");
+}

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -828,7 +828,9 @@ pub fn DeleteFile(sub_path_w: []const u16, options: DeleteFileOptions) DeleteFil
         else => return unexpectedStatus(rc),
     }
 
-    if (options.remove_dir){
+    // If a directory fails to be deleted, CloseHandle will still report success
+    // Check if the directory still exists and return error.DirNotEmpty if true
+    if (options.remove_dir) {
         var basic_info: FILE_BASIC_INFORMATION = undefined;
         switch (ntdll.NtQueryAttributesFile(&attr, &basic_info)) {
             .SUCCESS => return error.DirNotEmpty,


### PR DESCRIPTION
This commit addresses #5537 using the following test:

```zig
const builtin = @import("builtin");
const std = @import("std");
const fs = std.fs;
const assert = std.debug.assert;
const print = std.debug.print;
const testing = std.testing;

test "#5537" {
    if (builtin.os.tag != .windows) return;
    const cwd = fs.cwd();

    cwd.makeDir("tmp") catch |e| {
        switch (e) {
            error.PathAlreadyExists => {},
            else => return e,
        }
    };
    defer cwd.deleteDir("tmp") catch unreachable;

    var file = try cwd.createFile("tmp/tmpfile", .{ .read = true });
    defer {
        file.close();
        cwd.deleteFile("tmp/tmpfile") catch unreachable;
    }

   // Actual test for proper behavior
    testing.expectError(error.DirNotEmpty, cwd.deleteDir("tmp"));
}
```

I considered adding this test to the std to catch regressions but I wasn't sure if it was wanted to be added and I also wasn't sure exactly where in the repo to add it. 