### PR TITLE
Eventloop: Fix deadlock in linux event loop implementation

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -1257,11 +1257,6 @@ test "std.event.Loop - basic" {
     // https://github.com/ziglang/zig/issues/1908
     if (builtin.single_threaded) return error.SkipZigTest;
 
-    if (true) {
-        // https://github.com/ziglang/zig/issues/4922
-        return error.SkipZigTest;
-    }
-
     var loop: Loop = undefined;
     try loop.initMultiThreaded();
     defer loop.deinit();


### PR DESCRIPTION
This fixes an issue on linux with the event loop. Basically this simple program was not exiting:
```zig
pub const io_mode = .evented;

pub fn main() void {}
```
The problem was that multiple threads were still sleeping and were not woken up by the write to the eventfd. The write would only wake up one thread and thus the program would deadlock. This is mentioned in the [epoll man page](https://man7.org/linux/man-pages/man7/epoll.7.html): 

_If multiple threads (or processes, if child processes have inherited
       the epoll file descriptor across fork(2)) are blocked in
       epoll_wait(2) waiting on the same epoll file descriptor and a file
       descriptor in the interest list that is marked for edge-triggered
       (EPOLLET) notification becomes ready, just one of the threads (or
       processes) is awoken from epoll_wait(2).  This provides a useful
       optimization for avoiding "thundering herd" wake-ups in some
       scenarios._

Doing the write syscall multiple times assures that all the threads are woken up. This is similar to how it is done on Windows.