### PR TITLE
Build-runner: Fix the text alignment in the output of `zig build --help`

### DIFF
--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -161,7 +161,7 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
             try fmt.allocPrint(allocator, "{} (default)", .{top_level_step.step.name})
         else
             top_level_step.step.name;
-        try out_stream.print("  {s:22} {}\n", .{ name, top_level_step.description });
+        try out_stream.print("  {s:<22} {}\n", .{ name, top_level_step.description });
     }
 
     try out_stream.writeAll(
@@ -185,7 +185,7 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
                 Builder.typeIdName(option.type_id),
             });
             defer allocator.free(name);
-            try out_stream.print("{s:24} {}\n", .{ name, option.description });
+            try out_stream.print("{s:<24} {}\n", .{ name, option.description });
         }
     }
 


### PR DESCRIPTION
This regressed in 27adb82fda516e95c3c03df80a95b895969fdd56


Btw: is there a way to specify the width at runtime? Because currently this solution does not formats it properly if the width of the name is larger then 22. So we could check all the options and then pick the longest length and use that as the width for formatting.
https://github.com/ziglang/zig/blob/58ee5f4e61cd9b7a9ba65798e2214efa3753a733/lib/std/special/build_runner.zig#L164