### PR TITLE
Implements std.meta.ArgsTuple.

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -807,7 +807,7 @@ pub fn sizeof(target: anytype) usize {
             // TODO to get the correct result we have to translate
             // `1073741824 * 4` as `int(1073741824) *% int(4)` since
             // sizeof(1073741824 * 4) != sizeof(4294967296).
-            
+
             // TODO test if target fits in int, long or long long
             return @sizeOf(c_int);
         },
@@ -825,4 +825,76 @@ test "sizeof" {
     testing.expect(sizeof(E) == @sizeOf(c_int));
     testing.expect(sizeof(E.One) == @sizeOf(c_int));
     testing.expect(sizeof(S) == 4);
+}
+
+/// For a given function type, returns a tuple type which fields will
+/// correspond to the argument types.
+///
+/// Examples:
+/// - `ArgsTuple(fn() void)` ⇒ `tuple { }`
+/// - `ArgsTuple(fn(a: u32) u32)` ⇒ `tuple { u32 }`
+/// - `ArgsTuple(fn(a: u32, b: f16) noreturn)` ⇒ `tuple { u32, f16 }`
+pub fn ArgsTuple(comptime Function: type) type {
+    const info = @typeInfo(Function);
+    if (info != .Fn)
+        @compileError("ArgsTuple expects a function type");
+
+    const function_info = info.Fn;
+    if (function_info.is_generic)
+        @compileError("Cannot create ArgsTuple for generic function");
+    if (function_info.is_var_args)
+        @compileError("Cannot create ArgsTuple for variadic function");
+
+    var argument_field_list: [function_info.args.len]std.builtin.TypeInfo.StructField = undefined;
+    inline for (function_info.args) |arg, i| {
+        @setEvalBranchQuota(10_000);
+        var num_buf: [128]u8 = undefined;
+        argument_field_list[i] = std.builtin.TypeInfo.StructField{
+            .name = std.fmt.bufPrint(&num_buf, "{d}", .{i}) catch unreachable,
+            .field_type = arg.arg_type.?,
+            .default_value = @as(?(arg.arg_type.?), null),
+            .is_comptime = false,
+        };
+    }
+
+    return @Type(std.builtin.TypeInfo{
+        .Struct = std.builtin.TypeInfo.Struct{
+            .is_tuple = true,
+            .layout = .Auto,
+            .decls = &[_]std.builtin.TypeInfo.Declaration{},
+            .fields = &argument_field_list,
+        },
+    });
+}
+
+comptime {
+    const T = struct {
+        fn assertTypeEqual(comptime Expected: type, comptime Actual: type) void {
+            if (Expected != Actual)
+                @compileError("Expected type " ++ @typeName(Expected) ++ ", but got type " ++ @typeName(Actual));
+        }
+
+        fn assertTuple(comptime expected: anytype, comptime Actual: type) void {
+            const info = @typeInfo(Actual);
+            if (info != .Struct)
+                @compileError("Expected struct type");
+            if (!info.Struct.is_tuple)
+                @compileError("Struct type must be a tuple type");
+
+            const fields_list = std.meta.fields(Actual);
+            if (expected.len != fields_list.len)
+                @compileError("Argument count mismatch");
+
+            inline for (fields_list) |fld, i| {
+                if (expected[i] != fld.field_type) {
+                    @compileError("Field " ++ fld.name ++ " expected to be type " ++ @typeName(expected[i]) ++ ", but was type " ++ @typeName(fld.field_type));
+                }
+            }
+        }
+    };
+
+    T.assertTuple(.{}, ArgsTuple(fn () void));
+    T.assertTuple(.{u32}, ArgsTuple(fn (a: u32) []const u8));
+    T.assertTuple(.{ u32, f16 }, ArgsTuple(fn (a: u32, b: f16) noreturn));
+    T.assertTuple(.{ u32, f16, []const u8 }, ArgsTuple(fn (a: u32, b: f16, c: []const u8) noreturn));
 }

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -867,7 +867,7 @@ pub fn ArgsTuple(comptime Function: type) type {
     });
 }
 
-comptime {
+test "ArgsTuple" {
     const T = struct {
         fn assertTypeEqual(comptime Expected: type, comptime Actual: type) void {
             if (Expected != Actual)


### PR DESCRIPTION
Implements a helper function that is useful for creating generic function calls: `std.meta.ArgsTuple` calculates a tuple type for any given non-generic, non-variadic function type that can be passed into `@call()` to invoke the function.