### PR TITLE
Add alignment field to TypeInfo.UnionField and TypeInfo.StructField 

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -214,7 +214,7 @@ pub const TypeInfo = union(enum) {
         size: Size,
         is_const: bool,
         is_volatile: bool,
-        alignment: u29,
+        alignment: comptime_int,
         child: type,
         is_allowzero: bool,
 
@@ -262,7 +262,7 @@ pub const TypeInfo = union(enum) {
         field_type: type,
         default_value: anytype,
         is_comptime: bool,
-        alignment: u29,
+        alignment: comptime_int,
     };
 
     /// This data structure is used by the Zig language code generation and
@@ -319,7 +319,7 @@ pub const TypeInfo = union(enum) {
     pub const UnionField = struct {
         name: []const u8,
         field_type: type,
-        alignment: u29,
+        alignment: comptime_int,
     };
 
     /// This data structure is used by the Zig language code generation and

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -262,6 +262,7 @@ pub const TypeInfo = union(enum) {
         field_type: type,
         default_value: anytype,
         is_comptime: bool,
+        alignment: u29,
     };
 
     /// This data structure is used by the Zig language code generation and
@@ -318,6 +319,7 @@ pub const TypeInfo = union(enum) {
     pub const UnionField = struct {
         name: []const u8,
         field_type: type,
+        alignment: u29,
     };
 
     /// This data structure is used by the Zig language code generation and

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -214,7 +214,7 @@ pub const TypeInfo = union(enum) {
         size: Size,
         is_const: bool,
         is_volatile: bool,
-        alignment: comptime_int,
+        alignment: u29,
         child: type,
         is_allowzero: bool,
 

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -854,6 +854,7 @@ pub fn ArgsTuple(comptime Function: type) type {
             .field_type = arg.arg_type.?,
             .default_value = @as(?(arg.arg_type.?), null),
             .is_comptime = false,
+            .alignment = @alignOf(arg.arg_type.?),
         };
     }
 

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -884,6 +884,7 @@ pub fn Tuple(comptime types: []const type) type {
             .field_type = T,
             .default_value = @as(?T, null),
             .is_comptime = false,
+            .alignment = @alignOf(T),
         };
     }
 

--- a/lib/std/meta/trailer_flags.zig
+++ b/lib/std/meta/trailer_flags.zig
@@ -47,6 +47,7 @@ pub fn TrailerFlags(comptime Fields: type) type {
                         @as(?struct_field.field_type, null),
                     ),
                     .is_comptime = false,
+                    .alignment = @alignOf(?struct_field.field_type),
                 };
             }
             break :blk @Type(.{

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -25431,10 +25431,14 @@ static Error ir_make_type_info_value(IrAnalyze *ira, IrInst* source_instr, ZigTy
                     union_field_val->special = ConstValSpecialStatic;
                     union_field_val->type = type_info_union_field_type;
 
-                    ZigValue **inner_fields = alloc_const_vals_ptrs(ira->codegen, 2);
+                    ZigValue **inner_fields = alloc_const_vals_ptrs(ira->codegen, 3);
                     inner_fields[1]->special = ConstValSpecialStatic;
                     inner_fields[1]->type = ira->codegen->builtin_types.entry_type;
                     inner_fields[1]->data.x_type = union_field->type_entry;
+
+                    inner_fields[2]->special = ConstValSpecialStatic;
+                    inner_fields[2]->type = ira->codegen->builtin_types.entry_u29;
+                    bigint_init_unsigned(&inner_fields[2]->data.x_bigint, union_field->align);
 
                     ZigValue *name = create_const_str_lit(ira->codegen, union_field->name)->data.x_ptr.data.ref.pointee;
                     init_const_slice(ira->codegen, inner_fields[0], name, 0, buf_len(union_field->name), true);
@@ -25502,7 +25506,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, IrInst* source_instr, ZigTy
                     struct_field_val->special = ConstValSpecialStatic;
                     struct_field_val->type = type_info_struct_field_type;
 
-                    ZigValue **inner_fields = alloc_const_vals_ptrs(ira->codegen, 4);
+                    ZigValue **inner_fields = alloc_const_vals_ptrs(ira->codegen, 5);
 
                     inner_fields[1]->special = ConstValSpecialStatic;
                     inner_fields[1]->type = ira->codegen->builtin_types.entry_type;
@@ -25521,6 +25525,10 @@ static Error ir_make_type_info_value(IrAnalyze *ira, IrInst* source_instr, ZigTy
                     inner_fields[3]->special = ConstValSpecialStatic;
                     inner_fields[3]->type = ira->codegen->builtin_types.entry_bool;
                     inner_fields[3]->data.x_bool = struct_field->is_comptime;
+
+                    inner_fields[4]->special = ConstValSpecialStatic;
+                    inner_fields[4]->type = ira->codegen->builtin_types.entry_u29;
+                    bigint_init_unsigned(&inner_fields[4]->data.x_bigint, struct_field->align);
 
                     ZigValue *name = create_const_str_lit(ira->codegen, struct_field->name)->data.x_ptr.data.ref.pointee;
                     init_const_slice(ira->codegen, inner_fields[0], name, 0, buf_len(struct_field->name), true);
@@ -26145,6 +26153,8 @@ static ZigType *type_info_to_type(IrAnalyze *ira, IrInst *source_instr, ZigTypeI
                 }
                 if ((err = get_const_field_bool(ira, source_instr->source_node, field_value, "is_comptime", 3, &field->is_comptime)))
                     return ira->codegen->invalid_inst_gen->value->type;
+                if ((err = get_const_field_u29(ira, source_instr->source_node, field_value, "alignment", 4, &field->align)))
+                    return ira->codegen->invalid_inst_gen->value->type;
             }
 
             return entry;
@@ -26314,6 +26324,8 @@ static ZigType *type_info_to_type(IrAnalyze *ira, IrInst *source_instr, ZigTypeI
                     return ira->codegen->invalid_inst_gen->value->type;
                 field->type_val = type_value;
                 field->type_entry = type_value->data.x_type;
+                if ((err = get_const_field_u29(ira, source_instr->source_node, field_value, "alignment", 2, &field->align)))
+                    return ira->codegen->invalid_inst_gen->value->type;
             }
             return entry;
         }

--- a/test/stage1/behavior/type.zig
+++ b/test/stage1/behavior/type.zig
@@ -320,8 +320,8 @@ test "Type.Union" {
             .layout = .Auto,
             .tag_type = null,
             .fields = &[_]TypeInfo.UnionField{
-                .{ .name = "int", .field_type = i32 },
-                .{ .name = "float", .field_type = f32 },
+                .{ .name = "int", .field_type = i32, .alignment = @alignOf(f32) },
+                .{ .name = "float", .field_type = f32, .alignment = @alignOf(f32) },
             },
             .decls = &[_]TypeInfo.Declaration{},
         },
@@ -336,8 +336,8 @@ test "Type.Union" {
             .layout = .Packed,
             .tag_type = null,
             .fields = &[_]TypeInfo.UnionField{
-                .{ .name = "signed", .field_type = i32 },
-                .{ .name = "unsigned", .field_type = u32 },
+                .{ .name = "signed", .field_type = i32, .alignment = @alignOf(i32) },
+                .{ .name = "unsigned", .field_type = u32, .alignment = @alignOf(u32) },
             },
             .decls = &[_]TypeInfo.Declaration{},
         },
@@ -363,8 +363,8 @@ test "Type.Union" {
             .layout = .Auto,
             .tag_type = Tag,
             .fields = &[_]TypeInfo.UnionField{
-                .{ .name = "signed", .field_type = i32 },
-                .{ .name = "unsigned", .field_type = u32 },
+                .{ .name = "signed", .field_type = i32, .alignment = @alignOf(i32) },
+                .{ .name = "unsigned", .field_type = u32, .alignment = @alignOf(u32) },
             },
             .decls = &[_]TypeInfo.Declaration{},
         },
@@ -392,7 +392,7 @@ test "Type.Union from Type.Enum" {
             .layout = .Auto,
             .tag_type = Tag,
             .fields = &[_]TypeInfo.UnionField{
-                .{ .name = "working_as_expected", .field_type = u32 },
+                .{ .name = "working_as_expected", .field_type = u32, .alignment = @alignOf(u32) },
             },
             .decls = &[_]TypeInfo.Declaration{},
         },
@@ -408,7 +408,7 @@ test "Type.Union from regular enum" {
             .layout = .Auto,
             .tag_type = E,
             .fields = &[_]TypeInfo.UnionField{
-                .{ .name = "working_as_expected", .field_type = u32 },
+                .{ .name = "working_as_expected", .field_type = u32, .alignment = @alignOf(u32) },
             },
             .decls = &[_]TypeInfo.Declaration{},
         },

--- a/test/stage1/behavior/type_info.zig
+++ b/test/stage1/behavior/type_info.zig
@@ -211,7 +211,9 @@ fn testUnion() void {
     expect(notag_union_info.Union.tag_type == null);
     expect(notag_union_info.Union.layout == .Auto);
     expect(notag_union_info.Union.fields.len == 2);
+    expect(notag_union_info.Union.fields[0].alignment == @alignOf(void));
     expect(notag_union_info.Union.fields[1].field_type == u32);
+    expect(notag_union_info.Union.fields[1].alignment == @alignOf(u32));
 
     const TestExternUnion = extern union {
         foo: *c_void,
@@ -229,13 +231,18 @@ test "type info: struct info" {
 }
 
 fn testStruct() void {
+    const unpacked_struct_info = @typeInfo(TestUnpackedStruct);
+    expect(unpacked_struct_info.Struct.fields[0].alignment == @alignOf(u32));
+
     const struct_info = @typeInfo(TestStruct);
     expect(struct_info == .Struct);
     expect(struct_info.Struct.layout == .Packed);
     expect(struct_info.Struct.fields.len == 4);
+    expect(struct_info.Struct.fields[0].alignment == 2 * @alignOf(usize));
     expect(struct_info.Struct.fields[2].field_type == *TestStruct);
     expect(struct_info.Struct.fields[2].default_value == null);
     expect(struct_info.Struct.fields[3].default_value.? == 4);
+    expect(struct_info.Struct.fields[3].alignment == 1);
     expect(struct_info.Struct.decls.len == 2);
     expect(struct_info.Struct.decls[0].is_pub);
     expect(!struct_info.Struct.decls[0].data.Fn.is_extern);
@@ -244,8 +251,12 @@ fn testStruct() void {
     expect(struct_info.Struct.decls[0].data.Fn.fn_type == fn (*const TestStruct) void);
 }
 
+const TestUnpackedStruct = struct {
+    fieldA: u32 = 4,
+};
+
 const TestStruct = packed struct {
-    fieldA: usize,
+    fieldA: usize align(2 * @alignOf(usize)),
     fieldB: void,
     fieldC: *Self,
     fieldD: u32 = 4,


### PR DESCRIPTION
Also makes TypeInfo.Pointer.alignment u29 instead of comptime_int.

Closes #6122