### PR TITLE
Make LinearFifo not crash when discarding from empty buffer

### DIFF
--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -186,7 +186,9 @@ pub fn LinearFifo(
             } else {
                 var head = self.head + count;
                 if (powers_of_two) {
-                    head &= self.buf.len - 1;
+                    // Note it is safe to do a wrapping subtract as
+                    // bitwise & with all 1s is a noop
+                    head &= self.buf.len -% 1;
                 } else {
                     head %= self.buf.len;
                 }
@@ -374,6 +376,14 @@ pub fn LinearFifo(
             return self.buf[index];
         }
     };
+}
+
+test "LinearFifo(u8, .Dynamic) discard(0) from empty buffer should not error on overflow" {
+    var fifo = LinearFifo(u8, .Dynamic).init(testing.allocator);
+    defer fifo.deinit();
+
+    // If overflow is not explicitly allowed this will crash in debug / safe mode
+    fifo.discard(0);
 }
 
 test "LinearFifo(u8, .Dynamic)" {


### PR DESCRIPTION
Previously if a LinearFifo was empty and discard was called
an unsigned overflow would occur. However it is safe to perform
this overflow as a bitwise & operation with 0xFFFFFFFFFFFFFF is a noop