### PR TITLE
Idiomaticize test discovery

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2687,9 +2687,9 @@ pub const InstalledFile = struct {
     path: []const u8,
 };
 
-test "" {
+comptime {
     // The only purpose of this test is to get all these untested functions
     // to be referenced to avoid regression so it is okay to skip some targets.
-    if (comptime std.Target.current.cpu.arch.ptrBitWidth() == 64)
+    if (builtin.is_test and std.Target.current.cpu.arch.ptrBitWidth() == 64)
         std.meta.refAllDecls(@This());
 }

--- a/lib/std/build/emit_raw.zig
+++ b/lib/std/build/emit_raw.zig
@@ -223,6 +223,6 @@ pub const InstallRawStep = struct {
     }
 };
 
-test "" {
+comptime {
     std.meta.refAllDecls(InstallRawStep);
 }

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -13,8 +13,9 @@ pub const Tokenizer = tokenizer.Tokenizer;
 pub const parse = @import("c/parse.zig").parse;
 pub const ast = @import("c/ast.zig");
 
-test "" {
-    _ = tokenizer;
+comptime {
+    if (builtin.is_test)
+        _ = tokenizer;
 }
 
 pub usingnamespace @import("os/bits.zig");

--- a/lib/std/compress.zig
+++ b/lib/std/compress.zig
@@ -9,7 +9,9 @@ pub const deflate = @import("compress/deflate.zig");
 pub const gzip = @import("compress/gzip.zig");
 pub const zlib = @import("compress/zlib.zig");
 
-test "" {
-    _ = gzip;
-    _ = zlib;
+comptime {
+    if (std.builtin.is_test) {
+        _ = gzip;
+        _ = zlib;
+    }
 }

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1836,6 +1836,7 @@ pub fn dumpStackPointerAddr(prefix: []const u8) void {
 }
 
 // Reference everything so it gets tested.
-test "" {
-    _ = leb;
+comptime {
+    if (builtin.is_test)
+        _ = leb;
 }

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2263,17 +2263,19 @@ pub fn realpathAlloc(allocator: *Allocator, pathname: []const u8) ![]u8 {
     return allocator.dupe(u8, try os.realpath(pathname, &buf));
 }
 
-test "" {
-    if (builtin.os.tag != .wasi) {
-        _ = makeDirAbsolute;
-        _ = makeDirAbsoluteZ;
-        _ = copyFileAbsolute;
-        _ = updateFileAbsolute;
+comptime {
+    if (builtin.is_test) {
+        if (builtin.os.tag != .wasi) {
+            _ = makeDirAbsolute;
+            _ = makeDirAbsoluteZ;
+            _ = copyFileAbsolute;
+            _ = updateFileAbsolute;
+        }
+        _ = Dir.copyFile;
+        _ = @import("fs/test.zig");
+        _ = @import("fs/path.zig");
+        _ = @import("fs/file.zig");
+        _ = @import("fs/get_app_data_dir.zig");
+        _ = @import("fs/watch.zig");
     }
-    _ = Dir.copyFile;
-    _ = @import("fs/test.zig");
-    _ = @import("fs/path.zig");
-    _ = @import("fs/file.zig");
-    _ = @import("fs/get_app_data_dir.zig");
-    _ = @import("fs/watch.zig");
 }

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -207,22 +207,24 @@ test "null_writer" {
     null_writer.writeAll("yay" ** 10) catch |err| switch (err) {};
 }
 
-test "" {
-    _ = @import("io/bit_reader.zig");
-    _ = @import("io/bit_writer.zig");
-    _ = @import("io/buffered_atomic_file.zig");
-    _ = @import("io/buffered_reader.zig");
-    _ = @import("io/buffered_writer.zig");
-    _ = @import("io/c_writer.zig");
-    _ = @import("io/counting_writer.zig");
-    _ = @import("io/fixed_buffer_stream.zig");
-    _ = @import("io/reader.zig");
-    _ = @import("io/writer.zig");
-    _ = @import("io/peek_stream.zig");
-    _ = @import("io/seekable_stream.zig");
-    _ = @import("io/serialization.zig");
-    _ = @import("io/stream_source.zig");
-    _ = @import("io/test.zig");
+comptime {
+    if (builtin.is_test) {
+        _ = @import("io/bit_reader.zig");
+        _ = @import("io/bit_writer.zig");
+        _ = @import("io/buffered_atomic_file.zig");
+        _ = @import("io/buffered_reader.zig");
+        _ = @import("io/buffered_writer.zig");
+        _ = @import("io/c_writer.zig");
+        _ = @import("io/counting_writer.zig");
+        _ = @import("io/fixed_buffer_stream.zig");
+        _ = @import("io/reader.zig");
+        _ = @import("io/writer.zig");
+        _ = @import("io/peek_stream.zig");
+        _ = @import("io/seekable_stream.zig");
+        _ = @import("io/serialization.zig");
+        _ = @import("io/stream_source.zig");
+        _ = @import("io/test.zig");
+    }
 }
 
 pub const writeFile = @compileError("deprecated: use std.fs.Dir.writeFile with math.maxInt(usize)");

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -188,7 +188,7 @@ pub const Complex = complex.Complex;
 
 pub const big = @import("math/big.zig");
 
-test "" {
+comptime {
     std.meta.refAllDecls(@This());
 }
 

--- a/lib/std/math/big.zig
+++ b/lib/std/math/big.zig
@@ -18,13 +18,13 @@ comptime {
     assert(std.math.floorPowerOfTwo(usize, limb_info.bits) == limb_info.bits);
     assert(limb_info.bits <= 64); // u128 set is unsupported
     assert(limb_info.is_signed == false);
-}
 
-test "" {
-    _ = int;
-    _ = Rational;
-    _ = Limb;
-    _ = DoubleLimb;
-    _ = SignedDoubleLimb;
-    _ = Log2Limb;
+    if (std.builtin.is_test) {
+        _ = int;
+        _ = Rational;
+        _ = Limb;
+        _ = DoubleLimb;
+        _ = SignedDoubleLimb;
+        _ = Log2Limb;
+    }
 }

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -2144,6 +2144,7 @@ fn fixedIntFromSignedDoubleLimb(A: SignedDoubleLimb, storage: []Limb) Mutable {
     };
 }
 
-test "" {
-    _ = @import("int_test.zig");
+comptime {
+    if (std.builtin.is_test)
+        _ = @import("int_test.zig");
 }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -11,8 +11,9 @@ const mem = std.mem;
 const os = std.os;
 const fs = std.fs;
 
-test "" {
-    _ = @import("net/test.zig");
+comptime {
+    if (builtin.is_test)
+        _ = @import("net/test.zig");
 }
 
 const has_unix_sockets = @hasDecl(os, "sockaddr_un");

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -42,16 +42,18 @@ comptime {
     assert(@import("std") == std); // std lib tests require --override-lib-dir
 }
 
-test "" {
-    _ = darwin;
-    _ = freebsd;
-    _ = linux;
-    _ = netbsd;
-    _ = uefi;
-    _ = wasi;
-    _ = windows;
+comptime {
+    if (builtin.is_tag) {
+        _ = darwin;
+        _ = freebsd;
+        _ = linux;
+        _ = netbsd;
+        _ = uefi;
+        _ = wasi;
+        _ = windows;
 
-    _ = @import("os/test.zig");
+        _ = @import("os/test.zig");
+    }
 }
 
 /// Applications can override the `system` API layer in their root source file.

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -43,7 +43,7 @@ comptime {
 }
 
 comptime {
-    if (builtin.is_tag) {
+    if (builtin.is_test) {
         _ = darwin;
         _ = freebsd;
         _ = linux;

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1263,8 +1263,8 @@ pub fn prctl(option: i32, arg2: usize, arg3: usize, arg4: usize, arg5: usize) us
     return syscall5(.prctl, @bitCast(usize, @as(isize, option)), arg2, arg3, arg4, arg5);
 }
 
-test "" {
-    if (builtin.os.tag == .linux) {
+comptime {
+    if (builtin.is_test and builtin.os.tag == .linux) {
         _ = @import("linux/test.zig");
     }
 }

--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -1139,6 +1139,6 @@ fn testRangeBias(r: *Random, start: i8, end: i8, biased: bool) void {
     }
 }
 
-test "" {
+comptime {
     std.meta.refAllDecls(@This());
 }

--- a/lib/std/special/compiler_rt/shift.zig
+++ b/lib/std/special/compiler_rt/shift.zig
@@ -124,13 +124,15 @@ pub fn __aeabi_llsr(a: i64, b: i32) callconv(.AAPCS) i64 {
     return __lshrdi3(a, b);
 }
 
-test "" {
-    _ = @import("ashrdi3_test.zig");
-    _ = @import("ashrti3_test.zig");
+comptime {
+    if (builtin.is_test) {
+        _ = @import("ashrdi3_test.zig");
+        _ = @import("ashrti3_test.zig");
 
-    _ = @import("ashldi3_test.zig");
-    _ = @import("ashlti3_test.zig");
+        _ = @import("ashldi3_test.zig");
+        _ = @import("ashlti3_test.zig");
 
-    _ = @import("lshrdi3_test.zig");
-    _ = @import("lshrti3_test.zig");
+        _ = @import("lshrdi3_test.zig");
+        _ = @import("lshrti3_test.zig");
+    }
 }

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -88,12 +88,10 @@ pub const valgrind = @import("valgrind.zig");
 pub const zig = @import("zig.zig");
 pub const start = @import("start.zig");
 
-// This forces the start.zig file to be imported, and the comptime logic inside that
-// file decides whether to export any appropriate start symbols.
 comptime {
+    // This forces the start.zig file to be imported, and the comptime logic inside that
+    // file decides whether to export any appropriate start symbols.
     _ = start;
-}
 
-test "" {
     meta.refAllDecls(@This());
 }

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1459,6 +1459,6 @@ pub const Target = struct {
     }
 };
 
-test "" {
+comptime {
     std.meta.refAllDecls(Target.Cpu.Arch);
 }

--- a/lib/std/valgrind.zig
+++ b/lib/std/valgrind.zig
@@ -140,7 +140,7 @@ pub fn nonSIMDCall3(func: fn (usize, usize, usize, usize) usize, a1: usize, a2: 
 /// VG_(unique_error)() for them to be counted.
 pub fn countErrors() usize {
     return doClientRequestExpr(0, // default return
-        .CountErrors, 0, 0, 0, 0, 0);
+    .CountErrors, 0, 0, 0, 0, 0);
 }
 
 pub fn mallocLikeBlock(mem: []u8, rzB: usize, is_zeroed: bool) void {
@@ -262,7 +262,9 @@ pub fn monitorCommand(command: [*]u8) bool {
 pub const memcheck = @import("valgrind/memcheck.zig");
 pub const callgrind = @import("valgrind/callgrind.zig");
 
-test "" {
-    _ = @import("valgrind/memcheck.zig");
-    _ = @import("valgrind/callgrind.zig");
+comptime {
+    if (builtin.is_test) {
+        _ = @import("valgrind/memcheck.zig");
+        _ = @import("valgrind/callgrind.zig");
+    }
 }

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -194,6 +194,6 @@ test "parseCharLiteral" {
     std.testing.expectError(error.InvalidCharacter, parseCharLiteral("'\\u{FFFF}x'", &bad_index));
 }
 
-test "" {
-    @import("std").meta.refAllDecls(@This());
+comptime {
+    std.meta.refAllDecls(@This());
 }

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -262,7 +262,7 @@ test "zig fmt: empty file" {
     );
 }
 
-test "zig fmt: if statment" {
+test "zig fmt: if statement" {
     try testCanonical(
         \\test "" {
         \\    if (optional()) |some|

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -933,6 +933,7 @@ pub const NativeTargetInfo = struct {
     }
 };
 
-test "" {
-    _ = @import("system/macos.zig");
+comptime {
+    if (std.builtin.is_test)
+        _ = @import("system/macos.zig");
 }


### PR DESCRIPTION
### Goal
Replace `test ""` blocks with `comptime` while preserving current test discovery behaviour.
### Rationale
Zig standard library is included with every Zig compiler distribution, and is implicitly a prime example of idiomatic Zig code.

Unfortunately, it currently contains code related to this in ~20 instances:
```zig
test "" {
    std.meta.refAllDecls(@This());
}
```
This example should be considered an anti-pattern for several reasons:
* It creates empty tests to achieve what `comptime` can;
* `std.meta.refAllDecls` already only references everything when `std.builtin.is_test` is `true`; on unrelated note, this is mentioned in #6436 and can require changes to this PR.
* It potentially breaks `zig test --test-filter` (skips tests that do not match filter) - causes it to skip all tests that depend on functionality in given example, because its hard for anything to match on `""`;
### Potential Issues
For now, I haven't figured out what to do with `test ""` in these files:
* `std/testing.zig`;
* `std/io/c_writer.zig`;

It is very likely that they will eventually be made into proper tests that have their own names, they then fall out of scope of this PR.

---

# Addendum
One of intended effects of lazy analysis is ability to write cross-platform software by including only code that matters. `std` itself depends on it, and thus I decided to include several, already transformed, example patterns for a broader image of what idiomatic use of this feature is being proposed to be accepted into standard library of this programming language.
### Always including items that depend on comptime logic
```zig
comptime {
    _ = item;
}
```
### Referencing all items in this module for test discovery in submodules
```zig
comptime {
    std.meta.refAllDecls(@This());
}
```
### Only allowing certain submodules to be included during testing
```zig
comptime {
    if (std.builtin.is_test)
        _ = item;
}
```
### Target dependent module inclusion during testing
```zig
comptime {
    if (std.builtin.is_test) {
        if (std.builtin.os.tag == .linux)
            _ = linux_specific_item;

        _ = item;
    }
}
```