### PR TITLE
fix event lock after change in atomic queue

### DIFF
--- a/lib/std/event/lock.zig
+++ b/lib/std/event/lock.zig
@@ -95,7 +95,7 @@ pub const Lock = struct {
     }
 
     pub fn acquire(self: *Lock) callconv(.Async) Held {
-        var my_tick_node = Loop.NextTickNode.init(@frame());
+        var my_tick_node = Loop.NextTickNode{ .data = @frame() };
 
         errdefer _ = self.queue.remove(&my_tick_node); // TODO test canceling an acquire
         suspend {

--- a/lib/std/event/lock.zig
+++ b/lib/std/event/lock.zig
@@ -128,13 +128,11 @@ test "std.event.Lock" {
     // TODO https://github.com/ziglang/zig/issues/3251
     if (builtin.os.tag == .freebsd) return error.SkipZigTest;
 
-    // TODO this file has bit-rotted. repair it
-    if (true) return error.SkipZigTest;
-
     var lock = Lock.init();
     defer lock.deinit();
 
-    _ = async testLock(&lock);
+    var frame = async testLock(&lock);
+    await frame;
 
     const expected_result = [1]i32{3 * @intCast(i32, shared_test_data.len)} ** shared_test_data.len;
     testing.expectEqualSlices(i32, &expected_result, &shared_test_data);


### PR DESCRIPTION
Noticed when updating zig-okredis to latest Zig, it caused my CI to fail: https://github.com/kristoff-it/zig-okredis/runs/1173136808

It wasn't caught because the corresponding test was disabled. I fixed and reenabled it, although it definitely has lost the original semantics.