### PR TITLE
std/crypto: fix gimli-aead in-place decryption

### DIFF
--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -168,7 +168,7 @@ pub fn benchmarkAead(comptime Aead: anytype, comptime bytes: comptime_int) !u64 
     const start = timer.lap();
     while (offset < bytes) : (offset += in.len) {
         Aead.encrypt(in[0..], tag[0..], in[0..], &[_]u8{}, nonce, key);
-        Aead.decrypt(in[0..], in[0..], tag, &[_]u8{}, nonce, key) catch unreachable;
+        try Aead.decrypt(in[0..], in[0..], tag, &[_]u8{}, nonce, key);
     }
     mem.doNotOptimizeAway(&in);
     const end = timer.read();

--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -292,14 +292,16 @@ pub const Aead = struct {
             out = out[State.RATE..];
         }) {
             for (buf[0..State.RATE]) |*p, i| {
-                out[i] = p.* ^ in[i];
-                p.* = in[i];
+                const d = in[i];
+                out[i] = p.* ^ d;
+                p.* = d;
             }
             state.permute();
         }
         for (buf[0..in.len]) |*p, i| {
-            out[i] = p.* ^ in[i];
-            p.* = in[i];
+            const d = in[i];
+            out[i] = p.* ^ d;
+            p.* = d;
         }
 
         // XOR 1 into the next byte of the state


### PR DESCRIPTION
If the input & output buffers were the same, decryption used to fail.

Return on decryption error in the benchmark to detect similar issues in future AEADs even in non release-fast mode.