### PR TITLE
std/crypto: make Gimli 60% faster

### DIFF
--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -168,7 +168,7 @@ pub fn benchmarkAead(comptime Aead: anytype, comptime bytes: comptime_int) !u64 
     const start = timer.lap();
     while (offset < bytes) : (offset += in.len) {
         Aead.encrypt(in[0..], tag[0..], in[0..], &[_]u8{}, nonce, key);
-        Aead.decrypt(in[0..], in[0..], tag, &[_]u8{}, nonce, key) catch unreachable;
+        try Aead.decrypt(in[0..], in[0..], tag, &[_]u8{}, nonce, key);
     }
     mem.doNotOptimizeAway(&in);
     const end = timer.read();

--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -249,17 +249,13 @@ pub const Aead = struct {
             in = in[State.RATE..];
             out = out[State.RATE..];
         }) {
-            const d = in[0..State.RATE];
-            for (d) |v, i| {
+            for (in[0..State.RATE]) |v, i| {
                 buf[i] ^= v;
             }
-            for (d) |_, i| {
-                out[i] = buf[i];
-            }
+            mem.copy(u8, out[0..State.RATE], buf[0..State.RATE]);
             state.permute();
         }
-        const d = in[0..];
-        for (d) |v, i| {
+        for (in[0..]) |v, i| {
             buf[i] ^= v;
             out[i] = buf[i];
         }
@@ -299,9 +295,7 @@ pub const Aead = struct {
             for (d) |v, i| {
                 out[i] = buf[i] ^ v;
             }
-            for (d) |v, i| {
-                buf[i] = v;
-            }
+            mem.copy(u8, buf[0..State.RATE], d[0..State.RATE]);
             state.permute();
         }
         for (buf[0..in.len]) |*p, i| {

--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -38,7 +38,7 @@ pub const State = struct {
         return mem.sliceAsBytes(self.data[0..]);
     }
 
-    fn _permute_unrolled(self: *Self) void {
+    fn permute_unrolled(self: *Self) void {
         const state = &self.data;
         comptime var round = @as(u32, 24);
         inline while (round > 0) : (round -= 1) {
@@ -66,7 +66,7 @@ pub const State = struct {
         }
     }
 
-    fn _permute_small(self: *Self) void {
+    fn permute_small(self: *Self) void {
         const state = &self.data;
         var round = @as(u32, 24);
         while (round > 0) : (round -= 1) {
@@ -94,13 +94,7 @@ pub const State = struct {
         }
     }
 
-    pub fn permute(self: *Self) void {
-        if (std.builtin.mode == .ReleaseSmall) {
-            self._permute_small();
-        } else {
-            self._permute_unrolled();
-        }
-    }
+    pub const permute = if (std.builtin.mode == .ReleaseSmall) permute_small else permute_unrolled;
 
     pub fn squeeze(self: *Self, out: []u8) void {
         var i = @as(usize, 0);


### PR DESCRIPTION
Before:

           gimli-hash:        120 MiB/s
           gimli-aead:        130 MiB/s

After:

           gimli-hash:        195 MiB/s
           gimli-aead:        208 MiB/s


 Also fixes in-place decryption by the way, so this supersedes #6449 