### PR TITLE
Fix std.event.Future

### DIFF
--- a/lib/std/event/future.zig
+++ b/lib/std/event/future.zig
@@ -95,7 +95,7 @@ test "std.event.Future" {
     // TODO provide a way to run tests in evented I/O mode
     if (!std.io.is_async) return error.SkipZigTest;
 
-    const handle = async testFuture();
+    testFuture();
 }
 
 fn testFuture() void {


### PR DESCRIPTION
As mentioned in #6441, the new implementation broke futures. This wasn't caught because the existing test was broken, I fixed it.

@kprotty please confirm what the new method I added works as intended. I opted for a new method, rather than just call acquire(), to avoid touching the mutex, since it shouldn't be necessary when initializing the struct.