### PR TITLE
Add support for `zig build run -- arg1 arg2` in build.zig created by init-exe

### DIFF
--- a/lib/std/special/init-exe/build.zig
+++ b/lib/std/special/init-exe/build.zig
@@ -18,6 +18,9 @@ pub fn build(b: *Builder) void {
 
     const run_cmd = exe.run();
     run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
 
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);


### PR DESCRIPTION
Change build.zig file created by `zig init-exe` so that you can pass parameters to `zig build run -- arg1 arg2`.

With `zig run` you already can pass arguments in similar fashion e.g. `zig run -- arg1 arg2`.