### PR TITLE
Windows: Handle ACCESS_DENIED in DeviceIoControl

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -217,6 +217,7 @@ pub fn DeviceIoControl(
     switch (rc) {
         .SUCCESS => {},
         .PRIVILEGE_NOT_HELD => return error.AccessDenied,
+        .ACCESS_DENIED => return error.AccessDenied,
         .INVALID_PARAMETER => unreachable,
         else => return unexpectedStatus(rc),
     }


### PR DESCRIPTION
This was causing the Dir.readLink test to fail for me locally with error.Unexpected NTSTATUS=0xc0000022. Not sure if PRIVILEGE_NOT_HELD is actually possible or not.

[Relevant code in ReactOS showing that STATUS_ACCESS_DENIED being returned from IopDeviceFsIoControl](https://github.com/reactos/reactos/blob/e1a01de7f7cbd6529b70bfc00c61b4df1fab82a8/ntoskrnl/io/iomgr/iofunc.c#L296-L310)