### PR TITLE
Fixes static library building after #6250

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -473,8 +473,12 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
             {
                 break :dl true;
             }
-            if (options.system_libs.len != 0)
-                break :dl true;
+            if (options.system_libs.len != 0) {
+                // when creating a executable that links to system libraries,
+                // we require dynamic linking, but we must not link static libraries
+                // or object files dynamically!
+                break :dl (options.output_mode == .Exe);
+            }
 
             break :dl false;
         };


### PR DESCRIPTION
Depending on system libs only enforces libraries to require dynamic linking, but neither static libs nor object files.