### PR TITLE
Link basic MachO executables with stage2

### DIFF
--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -1295,3 +1295,9 @@ pub const N_WEAK_REF: u16 = 0x40;
 /// another (non-weak) definition for this symbol, the weak definition is ignored. Only symbols in a
 /// coalesced section (page 23) can be marked as a weak definition.
 pub const N_WEAK_DEF: u16 = 0x80;
+
+/// The N_SYMBOL_RESOLVER bit of the n_desc field indicates that the
+/// that the function is actually a resolver function and should
+/// be called to get the address of the real function to use.
+/// This bit is only available in .o files (MH_OBJECT filetype)
+pub const N_SYMBOL_RESOLVER: u16 = 0x100;

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -1257,3 +1257,41 @@ pub const reloc_type_x86_64 = packed enum(u4) {
     /// for thread local variables
     X86_64_RELOC_TLV,
 };
+
+/// This symbol is a reference to an external non-lazy (data) symbol.
+pub const REFERENCE_FLAG_UNDEFINED_NON_LAZY: u16 = 0x0;
+
+/// This symbol is a reference to an external lazy symbol—that is, to a function call.
+pub const REFERENCE_FLAG_UNDEFINED_LAZY: u16 = 0x1;
+
+/// This symbol is defined in this module.
+pub const REFERENCE_FLAG_DEFINED: u16 = 0x2;
+
+/// This symbol is defined in this module and is visible only to modules within this shared library.
+pub const REFERENCE_FLAG_PRIVATE_DEFINED: u16 = 3;
+
+/// This symbol is defined in another module in this file, is a non-lazy (data) symbol, and is visible
+/// only to modules within this shared library.
+pub const REFERENCE_FLAG_PRIVATE_UNDEFINED_NON_LAZY: u16 = 4;
+
+/// This symbol is defined in another module in this file, is a lazy (function) symbol, and is visible
+/// only to modules within this shared library.
+pub const REFERENCE_FLAG_PRIVATE_UNDEFINED_LAZY: u16 = 5;
+
+/// Must be set for any defined symbol that is referenced by dynamic-loader APIs (such as dlsym and
+/// NSLookupSymbolInImage) and not ordinary undefined symbol references. The strip tool uses this bit
+/// to avoid removing symbols that must exist: If the symbol has this bit set, strip does not strip it.
+pub const REFERENCED_DYNAMICALLY: u16 = 0x10;
+
+/// Used by the dynamic linker at runtime. Do not set this bit.
+pub const N_DESC_DISCARDED: u16 = 0x20;
+
+/// Indicates that this symbol is a weak reference. If the dynamic linker cannot find a definition
+/// for this symbol, it sets the address of this symbol to 0. The static linker sets this symbol given
+/// the appropriate weak-linking flags.
+pub const N_WEAK_REF: u16 = 0x40;
+
+/// Indicates that this symbol is a weak definition. If the static linker or the dynamic linker finds
+/// another (non-weak) definition for this symbol, the weak definition is ignored. Only symbols in a
+/// coalesced section (page 23) can be marked as a weak definition.
+pub const N_WEAK_DEF: u16 = 0x80;

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1537,6 +1537,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 // movabsq [addr], %rax
                                 try self.genSetReg(inst.base.src, .rax, .{ .memory = got_addr });
                                 // callq *%rax
+                                try self.code.ensureCapacity(self.code.items.len + 2);
                                 self.code.appendSliceAssumeCapacity(&[2]u8{ 0xff, 0xd0 });
                             } else {
                                 return self.fail(inst.base.src, "TODO implement calling bitcasted functions", .{});

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1532,7 +1532,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             if (func_inst.val.cast(Value.Payload.Function)) |func_val| {
                                 const func = func_val.func;
                                 const got = &macho_file.sections.items[macho_file.got_section_index.?];
-                                const got_addr = got.addr + func.owner_decl.link.macho.offset_table_index.? * @sizeOf(u64);
+                                const got_addr = got.addr + func.owner_decl.link.macho.offset_table_index * @sizeOf(u64);
                                 // Here, we store the got address in %rax, and then call %rax
                                 // movabsq [addr], %rax
                                 try self.genSetReg(inst.base.src, .rax, .{ .memory = got_addr });
@@ -2591,7 +2591,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                         } else if (self.bin_file.cast(link.File.MachO)) |macho_file| {
                             const decl = payload.decl;
                             const got = &macho_file.sections.items[macho_file.got_section_index.?];
-                            const got_addr = got.addr + decl.link.macho.offset_table_index.? * ptr_bytes;
+                            const got_addr = got.addr + decl.link.macho.offset_table_index * ptr_bytes;
                             return MCValue{ .memory = got_addr };
                         } else if (self.bin_file.cast(link.File.Coff)) |coff_file| {
                             const decl = payload.decl;


### PR DESCRIPTION
This PR adds enough of MachO linker implementation to pass basic stage2 "Hello, world!" test.

A couple of things left before I'll feel happy about merging this in:

- [x] refactor free space analysis - currently, it's a little bit hack-ish due to the weird structure of MachO meta info
~~- [ ] add basic export trie generation algorithm - currently, this bit is 100% hard-coded~~
- [x] move exe-only bits behind a switch/if statement in linker

EDIT: I really want this merged and working out a good algorithm for export trie will take some time (and potentially changes to the current codebase anyhow), so I'm inclined to leave it as is, i.e., it currently assumes that `_start` symbol is there and is the only exported symbol. In terms of free space analysis, I'm still not 100% happy with how things are done, but after more refactoring, it's definitely better than it was, and in subsequent PRs I'll revisit this bit and see if I can come up with a better alternative to how it's done now. Oh, and this mainly applies to Exes since Objs are a lot simpler in MachO wrt segment/section(s) organisation.