### PR TITLE
Adds error return trace printing to stage1

### DIFF
--- a/src/stage1.zig
+++ b/src/stage1.zig
@@ -39,7 +39,12 @@ pub export fn main(argc: c_int, argv: [*]const [*:0]const u8) c_int {
     for (args) |*arg, i| {
         arg.* = mem.spanZ(argv[i]);
     }
-    stage2.mainArgs(gpa, arena, args) catch |err| fatal("{}", .{@errorName(err)});
+    stage2.mainArgs(gpa, arena, args) catch |err| {
+        if (@errorReturnTrace()) |trace| {
+            std.debug.dumpStackTrace(trace.*);
+        }
+        fatal("unhandled internal error: {}", .{@errorName(err)});
+    };
     return 0;
 }
 


### PR DESCRIPTION
Right now, when stage1 fails with an error, only the error name itself is printed which isn't helpful at all. This adds printing the return trace to stage1 when it fails with an internal error