### PR TITLE
std: Add pow(a,b) for big ints

### DIFF
--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -1480,3 +1480,48 @@ test "big.int const to managed" {
 
     testing.expect(a.toConst().eq(b.toConst()));
 }
+
+test "big.int pow" {
+    {
+        var a = try Managed.initSet(testing.allocator, 10);
+        defer a.deinit();
+
+        var y = try Managed.init(testing.allocator);
+        defer y.deinit();
+
+        // y and a are not aliased
+        try y.pow(a, 123);
+        // y and a are aliased
+        try a.pow(a, 123);
+
+        testing.expect(a.eq(y));
+
+        const ys = try y.toString(testing.allocator, 16, false);
+        defer testing.allocator.free(ys);
+        testing.expectEqualSlices(
+            u8,
+            "183425a5f872f126e00a5ad62c839075cd6846c6fb0230887c7ad7a9dc530fcb" ++
+                "4933f60e8000000000000000000000000000000",
+            ys,
+        );
+    }
+    // Special cases
+    {
+        var a = try Managed.initSet(testing.allocator, 0);
+        defer a.deinit();
+
+        try a.pow(a, 100);
+        testing.expectEqual(@as(i32, 0), try a.to(i32));
+
+        try a.set(1);
+        try a.pow(a, 0);
+        testing.expectEqual(@as(i32, 1), try a.to(i32));
+        try a.pow(a, 100);
+        testing.expectEqual(@as(i32, 1), try a.to(i32));
+        try a.set(-1);
+        try a.pow(a, 15);
+        testing.expectEqual(@as(i32, -1), try a.to(i32));
+        try a.pow(a, 16);
+        testing.expectEqual(@as(i32, 1), try a.to(i32));
+    }
+}


### PR DESCRIPTION
Implemented following Knuth's "Evaluation of Powers" chapter in TAOCP,
some extra complexity is needed to make sure there's no aliasing and
avoid allocating too many limbs.

A brief example to illustrate why the last point is important:
consider 10^123, since 10 is well within the limits of a single limb we
can safely say that the result will surely fit in:

⌈log2(10)⌉ bit * 123 = 492 bits = 7 limbs

A naive calculation using only the number of limbs yields:

1 limb * 123 = 123 limbs

The space savings are noticeable.