### PR TITLE
Emit reloc patch

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2076,8 +2076,8 @@ pub const LibExeObjStep = struct {
         if (self.link_eh_frame_hdr) {
             try zig_args.append("--eh-frame-hdr");
         }
-        if(self.link_emit_relocs){
-            try zig_args.append("-emit-relocs");
+        if(self.link_emit_relocs) {
+            try zig_args.append("--emit-relocs");
         }
         if (self.link_function_sections) {
             try zig_args.append("-ffunction-sections");

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1239,6 +1239,7 @@ pub const LibExeObjStep = struct {
     /// Create a .eh_frame_hdr section and a PT_GNU_EH_FRAME segment in the ELF
     /// file.
     link_eh_frame_hdr: bool = false,
+    link_emit_relocs: bool = false,
 
     /// Place every function in its own section so that unused ones may be
     /// safely garbage-collected during the linking phase.
@@ -2074,6 +2075,9 @@ pub const LibExeObjStep = struct {
         }
         if (self.link_eh_frame_hdr) {
             try zig_args.append("--eh-frame-hdr");
+        }
+        if(self.link_emit_relocs){
+            try zig_args.append("-emit-relocs");
         }
         if (self.link_function_sections) {
             try zig_args.append("-ffunction-sections");

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2076,7 +2076,7 @@ pub const LibExeObjStep = struct {
         if (self.link_eh_frame_hdr) {
             try zig_args.append("--eh-frame-hdr");
         }
-        if(self.link_emit_relocs) {
+        if (self.link_emit_relocs) {
             try zig_args.append("--emit-relocs");
         }
         if (self.link_function_sections) {

--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -649,7 +649,7 @@ pub const Loop = struct {
 
     /// Runs the provided function asynchonously, similarly to Go's "go" operator.
     /// `func` must return void and it can be an async function.
-    fn runDetached(self: *Loop, alloc: *mem.Allocator, comptime func: anytype, args: anytype) error{OutOfMemory}!void {
+    pub fn runDetached(self: *Loop, alloc: *mem.Allocator, comptime func: anytype, args: anytype) error{OutOfMemory}!void {
         if (!std.io.is_async) @compileError("Can't use runDetached in non-async mode!");
         if (@TypeOf(@call(.{}, func, args)) != void) {
             @compileError("`func` must not have a return value");

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -352,6 +352,7 @@ pub const InitOptions = struct {
     time_report: bool = false,
     stack_report: bool = false,
     link_eh_frame_hdr: bool = false,
+    link_emit_relocs: bool = false,
     linker_script: ?[]const u8 = null,
     version_script: ?[]const u8 = null,
     override_soname: ?[]const u8 = null,
@@ -447,6 +448,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
                 options.system_libs.len != 0 or
                 options.link_libc or options.link_libcpp or
                 options.link_eh_frame_hdr or
+                options.link_emit_relocs or
                 options.output_mode == .Lib or
                 options.lld_argv.len != 0 or
                 options.linker_script != null or options.version_script != null)
@@ -769,6 +771,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
             .version_script = options.version_script,
             .gc_sections = options.linker_gc_sections,
             .eh_frame_hdr = options.link_eh_frame_hdr,
+            .emit_relocs = options.link_emit_relocs,
             .rdynamic = options.rdynamic,
             .extra_lld_args = options.lld_argv,
             .override_soname = options.override_soname,

--- a/src/link.zig
+++ b/src/link.zig
@@ -60,6 +60,7 @@ pub const Options = struct {
     link_libcpp: bool,
     function_sections: bool,
     eh_frame_hdr: bool,
+    emit_relocs: bool,
     rdynamic: bool,
     z_nodelete: bool,
     z_defs: bool,

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1367,7 +1367,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
     }
     
     if (self.base.options.emit_relocs) {
-        try argv.append("-emit-relocs");
+        try argv.append("--emit-relocs");
     }
 
     if (self.base.options.rdynamic) {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1286,6 +1286,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
         man.hash.add(stack_size);
         man.hash.add(gc_sections);
         man.hash.add(self.base.options.eh_frame_hdr);
+        man.hash.add(self.base.options.emit_relocs);
         man.hash.add(self.base.options.rdynamic);
         man.hash.addListOfBytes(self.base.options.extra_lld_args);
         man.hash.addListOfBytes(self.base.options.lib_dirs);
@@ -1363,6 +1364,10 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
 
     if (self.base.options.eh_frame_hdr) {
         try argv.append("--eh-frame-hdr");
+    }
+    
+    if (self.base.options.emit_relocs) {
+        try argv.append("-emit-relocs");
     }
 
     if (self.base.options.rdynamic) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -840,7 +840,7 @@ fn buildOutputType(
                         function_sections = true;
                     } else if (mem.eql(u8, arg, "--eh-frame-hdr")) {
                         link_eh_frame_hdr = true;
-                    } else if (mem.eql(u8, arg, "-emit-relocs")) {
+                    } else if (mem.eql(u8, arg, "--emit-relocs")) {
                         link_emit_relocs = true;
                     } else if (mem.eql(u8, arg, "-Bsymbolic")) {
                         linker_bind_global_refs_locally = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -273,7 +273,7 @@ const usage_build_generic =
     \\  -rdynamic                      Add all symbols to the dynamic symbol table
     \\  -rpath [path]                  Add directory to the runtime library search path
     \\  --eh-frame-hdr                 Enable C++ exception handling by passing --eh-frame-hdr to linker
-    \\  -emit-relocs                   Enable output of relocation sections for post build tools
+    \\  --emit-relocs                   Enable output of relocation sections for post build tools
     \\  -dynamic                       Force output to be dynamically linked
     \\  -static                        Force output to be statically linked
     \\  -Bsymbolic                     Bind global references locally

--- a/src/main.zig
+++ b/src/main.zig
@@ -273,6 +273,7 @@ const usage_build_generic =
     \\  -rdynamic                      Add all symbols to the dynamic symbol table
     \\  -rpath [path]                  Add directory to the runtime library search path
     \\  --eh-frame-hdr                 Enable C++ exception handling by passing --eh-frame-hdr to linker
+    \\  -emit-relocs                   Enable output of relocation sections for post build tools
     \\  -dynamic                       Force output to be dynamically linked
     \\  -static                        Force output to be statically linked
     \\  -Bsymbolic                     Bind global references locally
@@ -438,6 +439,7 @@ fn buildOutputType(
     var use_lld: ?bool = null;
     var use_clang: ?bool = null;
     var link_eh_frame_hdr = false;
+    var link_emit_relocs = false;
     var each_lib_rpath = false;
     var libc_paths_file: ?[]const u8 = null;
     var machine_code_model: std.builtin.CodeModel = .default;
@@ -838,6 +840,8 @@ fn buildOutputType(
                         function_sections = true;
                     } else if (mem.eql(u8, arg, "--eh-frame-hdr")) {
                         link_eh_frame_hdr = true;
+                    } else if (mem.eql(u8, arg, "-emit-relocs")) {
+                        link_emit_relocs = true;
                     } else if (mem.eql(u8, arg, "-Bsymbolic")) {
                         linker_bind_global_refs_locally = true;
                     } else if (mem.eql(u8, arg, "--verbose-link")) {
@@ -1580,6 +1584,7 @@ fn buildOutputType(
         .linker_z_nodelete = linker_z_nodelete,
         .linker_z_defs = linker_z_defs,
         .link_eh_frame_hdr = link_eh_frame_hdr,
+        .link_emit_relocs = link_emit_relocs,
         .stack_size_override = stack_size_override,
         .strip = strip,
         .single_threaded = single_threaded,


### PR DESCRIPTION
This small patch adds relocation support behind a flag (-emit-relocs) and resolves #5986. This is a valuable addition for those using post-build tools.