### PR TITLE
Fixes std.meta.Tuple and std.meta.ArgsTuple for zero-sized types 

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -847,14 +847,15 @@ pub fn ArgsTuple(comptime Function: type) type {
 
     var argument_field_list: [function_info.args.len]std.builtin.TypeInfo.StructField = undefined;
     inline for (function_info.args) |arg, i| {
+        const T = arg.arg_type.?;
         @setEvalBranchQuota(10_000);
         var num_buf: [128]u8 = undefined;
         argument_field_list[i] = std.builtin.TypeInfo.StructField{
             .name = std.fmt.bufPrint(&num_buf, "{d}", .{i}) catch unreachable,
-            .field_type = arg.arg_type.?,
-            .default_value = @as(?(arg.arg_type.?), null),
+            .field_type = T,
+            .default_value = @as(?T, null),
             .is_comptime = false,
-            .alignment = @alignOf(arg.arg_type.?),
+            .alignment = if (@sizeOf(T) > 0) @alignOf(T) else 0,
         };
     }
 
@@ -885,7 +886,7 @@ pub fn Tuple(comptime types: []const type) type {
             .field_type = T,
             .default_value = @as(?T, null),
             .is_comptime = false,
-            .alignment = @alignOf(T),
+            .alignment = if (@sizeOf(T) > 0) @alignOf(T) else 0,
         };
     }
 
@@ -928,12 +929,12 @@ test "ArgsTuple" {
     TupleTester.assertTuple(.{}, ArgsTuple(fn () void));
     TupleTester.assertTuple(.{u32}, ArgsTuple(fn (a: u32) []const u8));
     TupleTester.assertTuple(.{ u32, f16 }, ArgsTuple(fn (a: u32, b: f16) noreturn));
-    TupleTester.assertTuple(.{ u32, f16, []const u8 }, ArgsTuple(fn (a: u32, b: f16, c: []const u8) noreturn));
+    TupleTester.assertTuple(.{ u32, f16, []const u8, void }, ArgsTuple(fn (a: u32, b: f16, c: []const u8, void) noreturn));
 }
 
 test "Tuple" {
     TupleTester.assertTuple(.{}, Tuple(&[_]type{}));
     TupleTester.assertTuple(.{u32}, Tuple(&[_]type{u32}));
     TupleTester.assertTuple(.{ u32, f16 }, Tuple(&[_]type{ u32, f16 }));
-    TupleTester.assertTuple(.{ u32, f16, []const u8 }, Tuple(&[_]type{ u32, f16, []const u8 }));
+    TupleTester.assertTuple(.{ u32, f16, []const u8, void }, Tuple(&[_]type{ u32, f16, []const u8, void }));
 }


### PR DESCRIPTION
Using `std.meta.Tuple(&[_]type { void })` failed, as `void` has no alignment. This sets the correct 0 alignment of 0-sized types