### PR TITLE
Comply with semantic versioning pre-release format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ project(zig C CXX)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 set(ZIG_VERSION_MAJOR 0)
-set(ZIG_VERSION_MINOR 7)
-set(ZIG_VERSION_PATCH 1)
+set(ZIG_VERSION_MINOR 8)
+set(ZIG_VERSION_PATCH 0)
 set(ZIG_VERSION "" CACHE STRING "Override Zig version string. Default is to find out with git.")
 
 if("${ZIG_VERSION}" STREQUAL "")
@@ -34,18 +34,31 @@ if("${ZIG_VERSION}" STREQUAL "")
     find_program(GIT_EXE NAMES git)
     if(GIT_EXE)
         execute_process(
-            COMMAND ${GIT_EXE} -C ${CMAKE_SOURCE_DIR} name-rev HEAD --tags --name-only --no-undefined --always
+            COMMAND ${GIT_EXE} -C ${CMAKE_SOURCE_DIR} describe --match *.*.* --tags
             RESULT_VARIABLE EXIT_STATUS
-            OUTPUT_VARIABLE ZIG_GIT_REV
+            OUTPUT_VARIABLE GIT_DESCRIBE
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET)
         if(EXIT_STATUS EQUAL "0")
-            if(ZIG_GIT_REV MATCHES "\\^0$")
-                if(NOT("${ZIG_GIT_REV}" STREQUAL "${ZIG_VERSION}^0"))
-                    message("WARNING: Tag does not match configured Zig version")
+            if(GIT_DESCRIBE MATCHES "^v?([0-9]+\\.[0-9]+\\.[0-9]+)$")
+                # Tagged release version.
+                set(GIT_TAG ${CMAKE_MATCH_1})
+                if(NOT GIT_TAG VERSION_EQUAL ZIG_VERSION)
+                    message(SEND_ERROR "Configured Zig version (${ZIG_VERSION}) does not match Git tag (${GIT_TAG}).")
                 endif()
+            elseif(GIT_DESCRIBE MATCHES "^v?([0-9]+\\.[0-9]+\\.[0-9]+)-([0-9]+)-(.+)$")
+                # Untagged pre-release. The Zig version is updated to include the number of commits
+                # since the last tagged version and the commit hash. The version is formatted in
+                # accordance with the https://semver.org specification.
+                set(GIT_TAG ${CMAKE_MATCH_1})
+                set(GIT_COMMITS_AFTER_TAG ${CMAKE_MATCH_2})
+                set(GIT_COMMIT ${CMAKE_MATCH_3})
+                if(NOT ZIG_VERSION VERSION_GREATER GIT_TAG)
+                    message(SEND_ERROR "Configured Zig version (${ZIG_VERSION}) must be greater than tagged ancestor (${GIT_TAG}).")
+                endif()
+                set(ZIG_VERSION "${ZIG_VERSION}-dev.${GIT_COMMITS_AFTER_TAG}+${GIT_COMMIT}")
             else()
-                set(ZIG_VERSION "${ZIG_VERSION}+${ZIG_GIT_REV}")
+                message(WARNING "Failed to parse version from output of `git describe`.")
             endif()
         endif()
     endif()


### PR DESCRIPTION
Example version: 0.8.0-dev.460+g81b343a16

From a semantic versioning perspective, development builds will now be
considered distinct from a tagged release. The number of commits added
since the last tag is included in the pre-release component.

Updates #6466