### PR TITLE
Build.zig: Skip copying files that are used internally by the compiler

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2339,6 +2339,14 @@ pub const LibExeObjStep = struct {
 
                 var it = src_dir.iterate();
                 while (try it.next()) |entry| {
+                    // The compiler can put these files into the same directory, but we don't
+                    // want to copy them over.
+                    if (mem.eql(u8, entry.name, "stage1.id") or
+                        mem.eql(u8, entry.name, "llvm-ar.id") or
+                        mem.eql(u8, entry.name, "libs.txt") or
+                        mem.eql(u8, entry.name, "builtin.zig") or
+                        mem.eql(u8, entry.name, "lld.id")) continue;
+
                     _ = try src_dir.updateFile(entry.name, dest_dir, entry.name, .{});
                 }
             } else {


### PR DESCRIPTION
This might not be the best solution and would require some rework in the compiler to make sure that it uses a different cache directory for the internal files. But it does fix the issue

Closes #6493