### PR TITLE
std: Make file copy ops use zero-copy mechanisms

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -18,6 +18,16 @@ pub extern "c" fn _dyld_get_image_header(image_index: u32) ?*mach_header;
 pub extern "c" fn _dyld_get_image_vmaddr_slide(image_index: u32) usize;
 pub extern "c" fn _dyld_get_image_name(image_index: u32) [*:0]const u8;
 
+pub const COPYFILE_ACL = 1 << 0;
+pub const COPYFILE_STAT = 1 << 1;
+pub const COPYFILE_XATTR = 1 << 2;
+pub const COPYFILE_DATA = 1 << 3;
+
+pub const copyfile_state_t = *@Type(.Opaque);
+pub extern "c" fn copyfile_state_alloc() copyfile_state_t;
+pub extern "c" fn copyfile_state_free(state: copyfile_state_t) c_int;
+pub extern "c" fn fcopyfile(from: fd_t, to: fd_t, state: ?copyfile_state_t, flags: u32) c_int;
+
 pub extern "c" fn @"realpath$DARWIN_EXTSN"(noalias file_name: [*:0]const u8, noalias resolved_name: [*]u8) ?[*:0]u8;
 
 pub extern "c" fn __getdirentries64(fd: c_int, buf_ptr: [*]u8, buf_len: usize, basep: *i64) isize;

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -24,8 +24,6 @@ pub const COPYFILE_XATTR = 1 << 2;
 pub const COPYFILE_DATA = 1 << 3;
 
 pub const copyfile_state_t = *@Type(.Opaque);
-pub extern "c" fn copyfile_state_alloc() copyfile_state_t;
-pub extern "c" fn copyfile_state_free(state: copyfile_state_t) c_int;
 pub extern "c" fn fcopyfile(from: fd_t, to: fd_t, state: ?copyfile_state_t, flags: u32) c_int;
 
 pub extern "c" fn @"realpath$DARWIN_EXTSN"(noalias file_name: [*:0]const u8, noalias resolved_name: [*]u8) ?[*:0]u8;

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1823,7 +1823,7 @@ pub const Dir = struct {
         var atomic_file = try dest_dir.atomicFile(dest_path, .{ .mode = mode });
         defer atomic_file.deinit();
 
-        try os.copy_file(in_file.handle, atomic_file.file.handle, .{});
+        try copy_file(in_file.handle, atomic_file.file.handle);
         return atomic_file.finish();
     }
 
@@ -2261,6 +2261,52 @@ pub fn realpathAlloc(allocator: *Allocator, pathname: []const u8) ![]u8 {
     // anyway.
     var buf: [MAX_PATH_BYTES]u8 = undefined;
     return allocator.dupe(u8, try os.realpath(pathname, &buf));
+}
+
+const CopyFileError = error{SystemResources} || os.CopyFileRangeError || os.SendFileError;
+
+/// Transfer all the data between two file descriptors in the most efficient way.
+/// No metadata is transferred over.
+fn copy_file(fd_in: os.fd_t, fd_out: os.fd_t) CopyFileError!void {
+    if (comptime std.Target.current.isDarwin()) {
+        const rc = os.system.fcopyfile(fd_in, fd_out, null, os.system.COPYFILE_DATA);
+        switch (errno(rc)) {
+            0 => return,
+            EINVAL => unreachable,
+            ENOMEM => return error.SystemResources,
+            // The source file was not a directory, symbolic link, or regular file.
+            // Try with the fallback path before giving up.
+            ENOTSUP => {},
+            else => |err| return unexpectedErrno(err),
+        }
+    }
+
+    if (std.Target.current.os.tag == .linux) {
+        // Try copy_file_range first as that works at the FS level and is the
+        // most efficient method (if available).
+        var offset: u64 = 0;
+        cfr_loop: while (true) {
+            // The kernel checks `offset+count` for overflow, use a 32 bit
+            // value so that the syscall won't return EINVAL except for
+            // impossibly large files.
+            const amt = try os.copy_file_range(fd_in, offset, fd_out, offset, math.maxInt(u32), 0);
+            // Terminate when no data was copied
+            if (amt == 0) break :cfr_loop;
+            offset += amt;
+        }
+        return;
+    }
+
+    // Sendfile is a zero-copy mechanism iff the OS supports it, otherwise the
+    // fallback code will copy the contents chunk by chunk.
+    const empty_iovec = [0]os.iovec_const{};
+    var offset: u64 = 0;
+    sendfile_loop: while (true) {
+        const amt = try os.sendfile(fd_out, fd_in, offset, 0, &empty_iovec, &empty_iovec, 0);
+        // Terminate when no data was copied
+        if (amt == 0) break :sendfile_loop;
+        offset += amt;
+    }
 }
 
 test "" {

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2265,8 +2265,9 @@ pub fn realpathAlloc(allocator: *Allocator, pathname: []const u8) ![]u8 {
 
 const CopyFileError = error{SystemResources} || os.CopyFileRangeError || os.SendFileError;
 
-/// Transfer all the data between two file descriptors in the most efficient way.
-/// No metadata is transferred over.
+// Transfer all the data between two file descriptors in the most efficient way.
+// The copy starts at offset 0, the initial offsets are preserved.
+// No metadata is transferred over.
 fn copy_file(fd_in: os.fd_t, fd_out: os.fd_t) CopyFileError!void {
     if (comptime std.Target.current.isDarwin()) {
         const rc = os.system.fcopyfile(fd_in, fd_out, null, os.system.COPYFILE_DATA);

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2270,14 +2270,14 @@ const CopyFileError = error{SystemResources} || os.CopyFileRangeError || os.Send
 fn copy_file(fd_in: os.fd_t, fd_out: os.fd_t) CopyFileError!void {
     if (comptime std.Target.current.isDarwin()) {
         const rc = os.system.fcopyfile(fd_in, fd_out, null, os.system.COPYFILE_DATA);
-        switch (errno(rc)) {
+        switch (os.errno(rc)) {
             0 => return,
-            EINVAL => unreachable,
-            ENOMEM => return error.SystemResources,
-            // The source file was not a directory, symbolic link, or regular file.
+            os.EINVAL => unreachable,
+            os.ENOMEM => return error.SystemResources,
+            // The source file is not a directory, symbolic link, or regular file.
             // Try with the fallback path before giving up.
-            ENOTSUP => {},
-            else => |err| return unexpectedErrno(err),
+            os.ENOTSUP => {},
+            else => |err| return os.unexpectedErrno(err),
         }
     }
 
@@ -2286,9 +2286,9 @@ fn copy_file(fd_in: os.fd_t, fd_out: os.fd_t) CopyFileError!void {
         // most efficient method (if available).
         var offset: u64 = 0;
         cfr_loop: while (true) {
-            // The kernel checks `offset+count` for overflow, use a 32 bit
-            // value so that the syscall won't return EINVAL except for
-            // impossibly large files.
+            // The kernel checks the u64 value `offset+count` for overflow, use
+            // a 32 bit value so that the syscall won't return EINVAL except for
+            // impossibly large files (> 2^64-1 - 2^32-1).
             const amt = try os.copy_file_range(fd_in, offset, fd_out, offset, math.maxInt(u32), 0);
             // Terminate when no data was copied
             if (amt == 0) break :cfr_loop;

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1823,7 +1823,7 @@ pub const Dir = struct {
         var atomic_file = try dest_dir.atomicFile(dest_path, .{ .mode = mode });
         defer atomic_file.deinit();
 
-        try os.copy_file(in_file.handle, atomic_file.file.handle, .{ .file_size = size });
+        try os.copy_file(in_file.handle, atomic_file.file.handle, .{});
         return atomic_file.finish();
     }
 

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1823,7 +1823,7 @@ pub const Dir = struct {
         var atomic_file = try dest_dir.atomicFile(dest_path, .{ .mode = mode });
         defer atomic_file.deinit();
 
-        try atomic_file.file.writeFileAll(in_file, .{ .in_len = size });
+        try os.copy_file(in_file.handle, atomic_file.file.handle, .{ .file_size = size });
         return atomic_file.finish();
     }
 


### PR DESCRIPTION
Use copy_file_range on Linux (if available), fcopyfile on Darwin,
sendfile on *BSDs (and on Linux kernels without copy_file_range).