### PR TITLE
std/crypto/hmac: remove HmacBlake2s256 definition

### DIFF
--- a/lib/std/crypto/hmac.zig
+++ b/lib/std/crypto/hmac.zig
@@ -18,10 +18,6 @@ pub const sha2 = struct {
     pub const HmacSha512 = Hmac(crypto.hash.sha2.Sha512);
 };
 
-pub const blake2 = struct {
-    pub const HmacBlake2s256 = Hmac(crypto.hash.blake2.Blake2s256);
-};
-
 pub fn Hmac(comptime Hash: type) type {
     return struct {
         const Self = @This();


### PR DESCRIPTION
HMAC is a generic construction, so we allow it to be instantiated with any hash function.

In practice, HMAC is almost exclusively used with MD5, SHA1 and SHA2, so it makes sense to define some shortcuts for them.

However, defining `HmacBlake2s256` is a bit weird (and why specifically that one, and not other hash functions we also support?).
There would be nothing wrong with that construction, but it's not used in any standard protocol and would be a curious choice. We don't even use it in tests or benchmarks.

BLAKE2 being a keyed hash function, it doesn't need HMAC to be used as a MAC, so that also doesn't make it a good example of a possible hash function for HMAC.

This commit doesn't remove the ability to use a `Hmac(Blake2s256)` type if, for some reason, applications really need this, but it removes `HmacBlake2s256` as a constant.