### PR TITLE
stage1: Implement @reduce builtin for vector types

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -100,6 +100,16 @@ pub const AtomicOrder = enum {
 
 /// This data structure is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
+pub const ReduceOp = enum {
+    And,
+    Or,
+    Xor,
+    Min,
+    Max,
+};
+
+/// This data structure is used by the Zig language code generation and
+/// therefore must be kept in sync with the compiler implementation.
 pub const AtomicRmwOp = enum {
     Xchg,
     Add,

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -1826,6 +1826,7 @@ enum BuiltinFnId {
     BuiltinFnIdWasmMemorySize,
     BuiltinFnIdWasmMemoryGrow,
     BuiltinFnIdSrc,
+    BuiltinFnIdReduce,
 };
 
 struct BuiltinFnEntry {
@@ -2441,6 +2442,15 @@ enum AtomicOrder {
     AtomicOrderSeqCst,
 };
 
+// synchronized with code in define_builtin_compile_vars
+enum ReduceOp {
+    ReduceOp_and,
+    ReduceOp_or,
+    ReduceOp_xor,
+    ReduceOp_min,
+    ReduceOp_max,
+};
+
 // synchronized with the code in define_builtin_compile_vars
 enum AtomicRmwOp {
     AtomicRmwOp_xchg,
@@ -2550,6 +2560,7 @@ enum IrInstSrcId {
     IrInstSrcIdEmbedFile,
     IrInstSrcIdCmpxchg,
     IrInstSrcIdFence,
+    IrInstSrcIdReduce,
     IrInstSrcIdTruncate,
     IrInstSrcIdIntCast,
     IrInstSrcIdFloatCast,
@@ -2672,6 +2683,7 @@ enum IrInstGenId {
     IrInstGenIdErrName,
     IrInstGenIdCmpxchg,
     IrInstGenIdFence,
+    IrInstGenIdReduce,
     IrInstGenIdTruncate,
     IrInstGenIdShuffleVector,
     IrInstGenIdSplat,
@@ -3519,6 +3531,20 @@ struct IrInstGenFence {
     IrInstGen base;
 
     AtomicOrder order;
+};
+
+struct IrInstSrcReduce {
+    IrInstSrc base;
+
+    IrInstSrc *op;
+    IrInstSrc *value;
+};
+
+struct IrInstGenReduce {
+    IrInstGen base;
+
+    ReduceOp op;
+    IrInstGen *value;
 };
 
 struct IrInstSrcTruncate {

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -1123,6 +1123,34 @@ LLVMValueRef ZigLLVMBuildAtomicRMW(LLVMBuilderRef B, enum ZigLLVM_AtomicRMWBinOp
         singleThread ? SyncScope::SingleThread : SyncScope::System));
 }
 
+LLVMValueRef ZigLLVMBuildAndReduce(LLVMBuilderRef B, LLVMValueRef Val) {
+    return wrap(unwrap(B)->CreateAndReduce(unwrap(Val)));
+}
+
+LLVMValueRef ZigLLVMBuildOrReduce(LLVMBuilderRef B, LLVMValueRef Val) {
+    return wrap(unwrap(B)->CreateOrReduce(unwrap(Val)));
+}
+
+LLVMValueRef ZigLLVMBuildXorReduce(LLVMBuilderRef B, LLVMValueRef Val) {
+    return wrap(unwrap(B)->CreateXorReduce(unwrap(Val)));
+}
+
+LLVMValueRef ZigLLVMBuildIntMaxReduce(LLVMBuilderRef B, LLVMValueRef Val, bool is_signed) {
+    return wrap(unwrap(B)->CreateIntMaxReduce(unwrap(Val), is_signed));
+}
+
+LLVMValueRef ZigLLVMBuildIntMinReduce(LLVMBuilderRef B, LLVMValueRef Val, bool is_signed) {
+    return wrap(unwrap(B)->CreateIntMinReduce(unwrap(Val), is_signed));
+}
+
+LLVMValueRef ZigLLVMBuildFPMaxReduce(LLVMBuilderRef B, LLVMValueRef Val) {
+    return wrap(unwrap(B)->CreateFPMaxReduce(unwrap(Val)));
+}
+
+LLVMValueRef ZigLLVMBuildFPMinReduce(LLVMBuilderRef B, LLVMValueRef Val) {
+    return wrap(unwrap(B)->CreateFPMinReduce(unwrap(Val)));
+}
+
 static_assert((Triple::ArchType)ZigLLVM_UnknownArch == Triple::UnknownArch, "");
 static_assert((Triple::ArchType)ZigLLVM_arm == Triple::arm, "");
 static_assert((Triple::ArchType)ZigLLVM_armeb == Triple::armeb, "");

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -455,6 +455,14 @@ LLVMValueRef ZigLLVMBuildAtomicRMW(LLVMBuilderRef B, enum ZigLLVM_AtomicRMWBinOp
     LLVMValueRef PTR, LLVMValueRef Val,
     LLVMAtomicOrdering ordering, LLVMBool singleThread);
 
+LLVMValueRef ZigLLVMBuildAndReduce(LLVMBuilderRef B, LLVMValueRef Val);
+LLVMValueRef ZigLLVMBuildOrReduce(LLVMBuilderRef B, LLVMValueRef Val);
+LLVMValueRef ZigLLVMBuildXorReduce(LLVMBuilderRef B, LLVMValueRef Val);
+LLVMValueRef ZigLLVMBuildIntMaxReduce(LLVMBuilderRef B, LLVMValueRef Val, bool is_signed);
+LLVMValueRef ZigLLVMBuildIntMinReduce(LLVMBuilderRef B, LLVMValueRef Val, bool is_signed);
+LLVMValueRef ZigLLVMBuildFPMaxReduce(LLVMBuilderRef B, LLVMValueRef Val);
+LLVMValueRef ZigLLVMBuildFPMinReduce(LLVMBuilderRef B, LLVMValueRef Val);
+
 #define ZigLLVM_DIFlags_Zero 0U
 #define ZigLLVM_DIFlags_Private 1U
 #define ZigLLVM_DIFlags_Protected 2U

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -484,3 +484,43 @@ test "vector shift operators" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "vector reduce operation" {
+    const S = struct {
+        fn doTheTestReduce(comptime op: builtin.ReduceOp, x: anytype, expected: anytype) void {
+            const N = @typeInfo(@TypeOf(x)).Array.len;
+            const TX = @typeInfo(@TypeOf(x)).Array.child;
+
+            var r = @reduce(op, @as(Vector(N, TX), x));
+            expectEqual(expected, r);
+        }
+        fn doTheTest() void {
+            doTheTestReduce(.And, [4]bool{ true, false, true, true }, @as(bool, false));
+            doTheTestReduce(.Or, [4]bool{ false, true, false, false }, @as(bool, true));
+            doTheTestReduce(.Xor, [4]bool{ true, true, true, false }, @as(bool, true));
+
+            doTheTestReduce(.And, [4]u1{ 1, 0, 1, 1 }, @as(u1, 0));
+            doTheTestReduce(.Or, [4]u1{ 0, 1, 0, 0 }, @as(u1, 1));
+            doTheTestReduce(.Xor, [4]u1{ 1, 1, 1, 0 }, @as(u1, 1));
+
+            doTheTestReduce(.And, [4]u32{ 0xffffffff, 0xffff5555, 0xaaaaffff, 0x10101010 }, @as(u32, 0x1010));
+            doTheTestReduce(.Or, [4]u32{ 0xffff0000, 0xff00, 0xf0, 0xf }, ~@as(u32, 0));
+            doTheTestReduce(.Xor, [4]u32{ 0x00000000, 0x33333333, 0x88888888, 0x44444444 }, ~@as(u32, 0));
+
+            doTheTestReduce(.Min, [4]i32{ 1234567, -386, 0, 3 }, @as(i32, -386));
+            doTheTestReduce(.Max, [4]i32{ 1234567, -386, 0, 3 }, @as(i32, 1234567));
+
+            doTheTestReduce(.Min, [4]u32{ 99, 9999, 9, 99999 }, @as(u32, 9));
+            doTheTestReduce(.Max, [4]u32{ 99, 9999, 9, 99999 }, @as(u32, 99999));
+
+            doTheTestReduce(.Min, [4]f32{ -10.3, 10.0e9, 13.0, -100.0 }, @as(f32, -100.0));
+            doTheTestReduce(.Max, [4]f32{ -10.3, 10.0e9, 13.0, -100.0 }, @as(f32, 10.0e9));
+
+            doTheTestReduce(.Min, [4]f64{ -10.3, 10.0e9, 13.0, -100.0 }, @as(f64, -100.0));
+            doTheTestReduce(.Max, [4]f64{ -10.3, 10.0e9, 13.0, -100.0 }, @as(f64, 10.0e9));
+        }
+    };
+
+    S.doTheTest();
+    comptime S.doTheTest();
+}


### PR DESCRIPTION
The builtin folds a Vector(N,T) into a scalar T using a specified operator.

Closes #2698