### PR TITLE
Add Reader.readAllArrayListAligned for ArrayLists of arbitrary alignment

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -394,7 +394,7 @@ pub const File = struct {
         var array_list = try std.ArrayListAligned(u8, alignment).initCapacity(allocator, initial_cap);
         defer array_list.deinit();
 
-        self.reader().readAllArrayList(&array_list, max_bytes) catch |err| switch (err) {
+        self.reader().readAllArrayListAligned(alignment, &array_list, max_bytes) catch |err| switch (err) {
             error.StreamTooLong => return error.FileTooBig,
             else => |e| return e,
         };

--- a/lib/std/io/reader.zig
+++ b/lib/std/io/reader.zig
@@ -57,6 +57,15 @@ pub fn Reader(
         /// If the number of bytes appended would exceed `max_append_size`, `error.StreamTooLong` is returned
         /// and the `std.ArrayList` has exactly `max_append_size` bytes appended.
         pub fn readAllArrayList(self: Self, array_list: *std.ArrayList(u8), max_append_size: usize) !void {
+            return self.readAllArrayListAligned(null, array_list, max_append_size);
+        }
+
+        pub fn readAllArrayListAligned(
+            self: Self,
+            comptime alignment: ?u29,
+            array_list: *std.ArrayListAligned(u8, alignment),
+            max_append_size: usize
+        ) !void {
             try array_list.ensureCapacity(math.min(max_append_size, 4096));
             const original_len = array_list.items.len;
             var start_index: usize = original_len;


### PR DESCRIPTION
I fixed #6426 by adding a `readAllArrayListAligned` function to Reader that accepts an ArrayListAligned of arbitrary alignment, which `File.readFileAllocOptions` now uses.