### PR TITLE
std: Fix two bugs in bigint pow

### DIFF
--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -1486,6 +1486,13 @@ test "big.int pow" {
         var a = try Managed.initSet(testing.allocator, 10);
         defer a.deinit();
 
+        try a.pow(a, 8);
+        testing.expectEqual(@as(u32, 100000000), try a.to(u32));
+    }
+    {
+        var a = try Managed.initSet(testing.allocator, 10);
+        defer a.deinit();
+
         var y = try Managed.init(testing.allocator);
         defer y.deinit();
 


### PR DESCRIPTION
* Correctly scan all the exponent bits, this caused the incorrect result
  to be computed for exponents being powers of two.
* Allocate enough limbs to make llmulacc stop whining.