### PR TITLE
std/zig: handle underscore in kernel version

### DIFF
--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -213,6 +213,8 @@ pub const NativeTargetInfo = struct {
                     // kernel version
                     const kernel_version = if (mem.indexOfScalar(u8, release, '-')) |pos|
                         release[0..pos]
+                    else if (mem.indexOfScalar(u8, release, '_')) |pos|
+                        release[0..pos]
                     else
                         release;
 


### PR DESCRIPTION
On some distros (e.g. Void Linux) the release field of the tsname
struct may contain an underscore followed by a revision number at the
end. (e.g. 5.8.12_2).

See: https://github.com/ziglang/zig/issues/6469#issuecomment-703209367