### PR TITLE
cache-hash: add test_filter and test_name_prefix

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2590,6 +2590,8 @@ fn updateStage1Module(comp: *Compilation, main_progress_node: *std.Progress.Node
     man.hash.add(comp.emit_llvm_ir != null);
     man.hash.add(comp.emit_analysis != null);
     man.hash.add(comp.emit_docs != null);
+    man.hash.add(comp.test_filter != null);
+    man.hash.add(comp.test_name_prefix != null);
 
     // Capture the state in case we come back from this branch where the hash doesn't match.
     const prev_hash_state = man.hash.peekBin();

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2590,8 +2590,8 @@ fn updateStage1Module(comp: *Compilation, main_progress_node: *std.Progress.Node
     man.hash.add(comp.emit_llvm_ir != null);
     man.hash.add(comp.emit_analysis != null);
     man.hash.add(comp.emit_docs != null);
-    man.hash.add(comp.test_filter != null);
-    man.hash.add(comp.test_name_prefix != null);
+    man.hash.addOptionalBytes(comp.test_filter);
+    man.hash.addOptionalBytes(comp.test_name_prefix);
 
     // Capture the state in case we come back from this branch where the hash doesn't match.
     const prev_hash_state = man.hash.peekBin();


### PR DESCRIPTION
Before this commit `zig test file.zig` followed by `zig test file.zig --test-filter foo` wasn't being respected and the tests weren't being rebuilt.

It looks like this isn't always working. Further testing seems like something is still missing.  I would expect the following to fail on `./zig test test.zig --test-filter fail`:

```zig
// test.zig
const std = @import("std");
test "pass" {
    std.testing.expect(true);
}
test "fail" {
    std.testing.expect(false);
}
```

```sh
$ ./zig test test.zig --test-filter pass
All 1 tests passed.
...
$ ./zig test test.zig --test-filter fail
All 1 tests passed.

$ rm -rf zig-cache

$ ./zig test test.zig --test-filter fail
Test [1/1] test "fail"... test failure
```