### PR TITLE
stage1: improve error messages for missing `try` statements

### DIFF
--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -20102,7 +20102,7 @@ static IrInstGen *ir_analyze_store_ptr(IrAnalyze *ira, IrInst* source_instr,
         if (uncasted_value->value->type->id == ZigTypeIdErrorUnion ||
             uncasted_value->value->type->id == ZigTypeIdErrorSet)
         {
-            ir_add_error(ira, source_instr, buf_sprintf("error is discarded"));
+            ir_add_error(ira, source_instr, buf_sprintf("error is discarded. consider using `try`, `catch`, or `if`"));
             return ira->codegen->invalid_inst_gen;
         }
         return ir_const_void(ira, source_instr);
@@ -29492,7 +29492,11 @@ static IrInstGen *ir_analyze_instruction_check_statement_is_void(IrAnalyze *ira,
         return ira->codegen->invalid_inst_gen;
 
     if (statement_type->id != ZigTypeIdVoid && statement_type->id != ZigTypeIdUnreachable) {
-        ir_add_error(ira, &instruction->base.base, buf_sprintf("expression value is ignored"));
+        if(statement_type->id == ZigTypeIdErrorUnion || statement_type->id == ZigTypeIdErrorSet) {
+            ir_add_error(ira, &instruction->base.base, buf_sprintf("error is ignored. consider using `try`, `catch`, or `if`"));
+        }else{
+            ir_add_error(ira, &instruction->base.base, buf_sprintf("expression value is ignored"));
+        }
     }
 
     return ir_const_void(ira, &instruction->base.base);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2287,7 +2287,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return error.OutOfMemory;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:12: error: error is discarded",
+        "tmp.zig:2:12: error: error is discarded. consider using `try`, `catch`, or `if`",
     });
 
     cases.add("volatile on global assembly",
@@ -2338,9 +2338,9 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    return error.Bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:24: error: expression value is ignored",
-        "tmp.zig:6:25: error: expression value is ignored",
-        "tmp.zig:10:25: error: expression value is ignored",
+        "tmp.zig:2:24: error: error is ignored. consider using `try`, `catch`, or `if`",
+        "tmp.zig:6:25: error: error is ignored. consider using `try`, `catch`, or `if`",
+        "tmp.zig:10:25: error: error is ignored. consider using `try`, `catch`, or `if`",
     });
 
     cases.add("empty while loop body",
@@ -6236,7 +6236,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn bar() anyerror!i32 { return 0; }
     , &[_][]const u8{
-        "tmp.zig:2:14: error: expression value is ignored",
+        "tmp.zig:2:14: error: error is ignored. consider using `try`, `catch`, or `if`",
     });
 
     cases.add("dereference an array",


### PR DESCRIPTION
```zig
array_list.append({});
```
will now report `error: error is ignored. consider using catch or try` instead of just `expression value is ignored`

```
1;
```
will still report `expression value is ignored`

```zig
_ = array_list.append({});
```
will now report `error: error is discarded. consider using catch or try` instead of `error is discarded`

```zig
fn somefn() void {
    try array_list.append({});
}
```
it be nice if this had a better error message too, but that seems complicated. the current error message is basically unreadable, `error: expected type 'void', found '@typeInfo(@typeInfo(@TypeOf(std.array_list.ArrayListAligned([]const u8,null).append)).Fn.return_type.?).ErrorUnion.error_set'` while the actual error is really easy to fix. maybe "`try` was used, but this function is not allowed to return an error" and like an arrow to `) void {` and a message saying "consider using !void" or something.