### PR TITLE
Fix building the zig compiler for 32-bit targets

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2757,7 +2757,7 @@ fn writeSymbol(self: *Elf, index: usize) !void {
         if (needed_size > self.allocatedSize(syms_sect.sh_offset)) {
             // Move all the symbols to a new file location.
             const new_offset = self.findFreeSpace(needed_size, sym_align);
-            const existing_size = @as(u64, syms_sect.sh_info) * sym_size;
+            const existing_size = syms_sect.sh_info * sym_size;
             const amt = try self.base.file.?.copyRangeAll(syms_sect.sh_offset, self.base.file.?, new_offset, existing_size);
             if (amt != existing_size) return error.InputOutput;
             syms_sect.sh_offset = new_offset;
@@ -2911,7 +2911,7 @@ fn pwriteDbgLineNops(
     prev_padding_size: usize,
     buf: []const u8,
     next_padding_size: usize,
-    offset: usize,
+    offset: u64,
 ) !void {
     const tracy = trace(@src());
     defer tracy.end();

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1267,7 +1267,7 @@ fn updateString(self: *MachO, old_str_off: u32, new_name: []const u8) !u32 {
 fn addPadding(self: *MachO, size: u64, file_offset: u64) !void {
     if (size == 0) return;
 
-    const buf = try self.base.allocator.alloc(u8, size);
+    const buf = try self.base.allocator.alloc(u8, @intCast(usize, size));
     defer self.base.allocator.free(buf);
 
     mem.set(u8, buf[0..], 0);

--- a/src/main.zig
+++ b/src/main.zig
@@ -2538,7 +2538,7 @@ fn fmtPathFile(
     check_mode: bool,
     dir: fs.Dir,
     sub_path: []const u8,
-) FmtError!void {
+) (FmtError || error{Overflow})!void {
     const source_file = try dir.openFile(sub_path, .{});
     var file_closed = false;
     errdefer if (!file_closed) source_file.close();
@@ -2551,7 +2551,7 @@ fn fmtPathFile(
     const source_code = source_file.readToEndAllocOptions(
         fmt.gpa,
         max_src_size,
-        stat.size,
+        try std.math.cast(usize, stat.size),
         @alignOf(u8),
         null,
     ) catch |err| switch (err) {

--- a/src/value.zig
+++ b/src/value.zig
@@ -842,7 +842,7 @@ pub const Value = extern union {
             .int_u64 => {
                 const x = self.cast(Payload.Int_u64).?.int;
                 if (x == 0) return 0;
-                return std.math.log2(x) + 1;
+                return @intCast(usize, std.math.log2(x) + 1);
             },
             .int_i64 => {
                 @panic("TODO implement i64 intBitCountTwosComp");


### PR DESCRIPTION
Suggestions are welcome if all these intCasts are actually correct. It does make sure that we can build the zig compiler for a 32 bit target.