### PR TITLE
std.fmt.comptimePrint: Return null terminated string

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1181,8 +1181,8 @@ fn bufPrintIntToSlice(buf: []u8, value: anytype, base: u8, uppercase: bool, opti
     return buf[0..formatIntBuf(buf, value, base, uppercase, options)];
 }
 
-pub fn comptimePrint(comptime fmt: []const u8, args: anytype) *const [count(fmt, args)]u8 {
-    comptime var buf: [count(fmt, args)]u8 = undefined;
+pub fn comptimePrint(comptime fmt: []const u8, args: anytype) *const [count(fmt, args):0]u8 {
+    comptime var buf: [count(fmt, args):0]u8 = undefined;
     _ = bufPrint(&buf, fmt, args) catch unreachable;
     return &buf;
 }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1184,10 +1184,13 @@ fn bufPrintIntToSlice(buf: []u8, value: anytype, base: u8, uppercase: bool, opti
 pub fn comptimePrint(comptime fmt: []const u8, args: anytype) *const [count(fmt, args):0]u8 {
     comptime var buf: [count(fmt, args):0]u8 = undefined;
     _ = bufPrint(&buf, fmt, args) catch unreachable;
+    buf[buf.len] = 0;
     return &buf;
 }
 
 test "comptimePrint" {
+    @setEvalBranchQuota(2000);
+    std.testing.expectEqual(*const [3:0]u8, @TypeOf(comptime comptimePrint("{}", .{100})));
     std.testing.expectEqualSlices(u8, "100", comptime comptimePrint("{}", .{100}));
 }
 


### PR DESCRIPTION
Same reason as string literals are null terminated.
I don't need to explicitly set the 0 even if the array is undefined, right?