### PR TITLE
Remove .Cold calling convention.

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -151,7 +151,6 @@ pub const Mode = enum {
 pub const CallingConvention = enum {
     Unspecified,
     C,
-    Cold,
     Naked,
     Async,
     Interrupt,

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -72,7 +72,6 @@ enum PtrLen {
 enum CallingConvention {
     CallingConventionUnspecified,
     CallingConventionC,
-    CallingConventionCold,
     CallingConventionNaked,
     CallingConventionAsync,
     CallingConventionInterrupt,

--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -949,7 +949,6 @@ const char *calling_convention_name(CallingConvention cc) {
     switch (cc) {
         case CallingConventionUnspecified: return "Unspecified";
         case CallingConventionC: return "C";
-        case CallingConventionCold: return "Cold";
         case CallingConventionNaked: return "Naked";
         case CallingConventionAsync: return "Async";
         case CallingConventionInterrupt: return "Interrupt";
@@ -971,7 +970,6 @@ bool calling_convention_allows_zig_types(CallingConvention cc) {
         case CallingConventionAsync:
             return true;
         case CallingConventionC:
-        case CallingConventionCold:
         case CallingConventionNaked:
         case CallingConventionInterrupt:
         case CallingConventionSignal:
@@ -3603,7 +3601,6 @@ static void resolve_decl_fn(CodeGen *g, TldFn *tld_fn) {
                     tld_fn->base.resolution = TldResolutionInvalid;
                     return;
                 case CallingConventionC:
-                case CallingConventionCold:
                 case CallingConventionNaked:
                 case CallingConventionInterrupt:
                 case CallingConventionSignal:

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -160,12 +160,6 @@ static ZigLLVM_CallingConv get_llvm_cc(CodeGen *g, CallingConvention cc) {
             return ZigLLVM_Fast;
         case CallingConventionC:
             return ZigLLVM_C;
-        case CallingConventionCold:
-            if ((g->zig_target->arch == ZigLLVM_x86 ||
-                 g->zig_target->arch == ZigLLVM_x86_64) &&
-                g->zig_target->os != OsWindows)
-                return ZigLLVM_Cold;
-            return ZigLLVM_C;
         case CallingConventionNaked:
             zig_unreachable();
         case CallingConventionStdcall:
@@ -339,7 +333,6 @@ static bool cc_want_sret_attr(CallingConvention cc) {
         case CallingConventionNaked:
             zig_unreachable();
         case CallingConventionC:
-        case CallingConventionCold:
         case CallingConventionInterrupt:
         case CallingConventionSignal:
         case CallingConventionStdcall:
@@ -448,7 +441,7 @@ static LLVMValueRef make_fn_llvm_value(CodeGen *g, ZigFn *fn) {
         ZigLLVMFunctionSetCallingConv(llvm_fn, get_llvm_cc(g, cc));
     }
 
-    bool want_cold = fn->is_cold || cc == CallingConventionCold;
+    bool want_cold = fn->is_cold;
     if (want_cold) {
         ZigLLVMAddFunctionAttrCold(llvm_fn);
     }
@@ -8818,18 +8811,17 @@ Buf *codegen_generate_builtin_source(CodeGen *g) {
 
     static_assert(CallingConventionUnspecified == 0, "");
     static_assert(CallingConventionC == 1, "");
-    static_assert(CallingConventionCold == 2, "");
-    static_assert(CallingConventionNaked == 3, "");
-    static_assert(CallingConventionAsync == 4, "");
-    static_assert(CallingConventionInterrupt == 5, "");
-    static_assert(CallingConventionSignal == 6, "");
-    static_assert(CallingConventionStdcall == 7, "");
-    static_assert(CallingConventionFastcall == 8, "");
-    static_assert(CallingConventionVectorcall == 9, "");
-    static_assert(CallingConventionThiscall == 10, "");
-    static_assert(CallingConventionAPCS == 11, "");
-    static_assert(CallingConventionAAPCS == 12, "");
-    static_assert(CallingConventionAAPCSVFP == 13, "");
+    static_assert(CallingConventionNaked == 2, "");
+    static_assert(CallingConventionAsync == 3, "");
+    static_assert(CallingConventionInterrupt == 4, "");
+    static_assert(CallingConventionSignal == 5, "");
+    static_assert(CallingConventionStdcall == 6, "");
+    static_assert(CallingConventionFastcall == 7, "");
+    static_assert(CallingConventionVectorcall == 8, "");
+    static_assert(CallingConventionThiscall == 9, "");
+    static_assert(CallingConventionAPCS == 10, "");
+    static_assert(CallingConventionAAPCS == 11, "");
+    static_assert(CallingConventionAAPCSVFP == 12, "");
 
     static_assert(FnInlineAuto == 0, "");
     static_assert(FnInlineAlways == 1, "");

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -18916,7 +18916,6 @@ static IrInstGen *ir_analyze_instruction_export(IrAnalyze *ira, IrInstSrcExport 
                     add_error_note(ira->codegen, msg, fn_entry->proto_node, buf_sprintf("declared here"));
                 } break;
                 case CallingConventionC:
-                case CallingConventionCold:
                 case CallingConventionNaked:
                 case CallingConventionInterrupt:
                 case CallingConventionSignal:


### PR DESCRIPTION
This isn't a stable, defined calling convention, so it shouldn't be
grouped in with the others.

Closes https://github.com/ziglang/zig/issues/6556

---

I said "keep it as an implementation detail" in the original issue, but it seems like ZigLLVMAddFunctionAttrCold doesn't change the calling convention.
I think using the cold calling convention for .Unspecified calling convention functions which are `@setCold(true)` can be a different PR.
