### PR TITLE
std: expose all atomic operations from std.atomic.Int

### DIFF
--- a/lib/std/atomic/int.zig
+++ b/lib/std/atomic/int.zig
@@ -3,6 +3,9 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
+
+const builtin = @import("std").builtin;
+
 /// Thread-safe, lock-free integer
 pub fn Int(comptime T: type) type {
     return struct {
@@ -14,30 +17,43 @@ pub fn Int(comptime T: type) type {
             return Self{ .unprotected_value = init_val };
         }
 
+        /// Read, Modify, Write
+        pub fn rmw(self: *Self, comptime op: builtin.AtomicRmwOp, operand: T, comptime ordering: builtin.AtomicOrder) T {
+            return @atomicRmw(T, &self.unprotected_value, operand, ordering);
+        }
+
+        pub fn load(self: *Self, comptime ordering: builtin.AtomicOrder) T {
+            return @atomicLoad(T, &self.unprotected_value, ordering);
+        }
+
+        pub fn store(self: *Self, value: T, comptime ordering: builtin.AtomicOrder) void {
+            @atomicStore(T, &self.unprotected_value, value, ordering);
+        }
+
         /// Returns previous value
         pub fn incr(self: *Self) T {
-            return @atomicRmw(T, &self.unprotected_value, .Add, 1, .SeqCst);
+            return self.rmw(.Add, 1, .SeqCst);
         }
 
         /// Returns previous value
         pub fn decr(self: *Self) T {
-            return @atomicRmw(T, &self.unprotected_value, .Sub, 1, .SeqCst);
+            return self.rmw(.Sub, 1, .SeqCst);
         }
 
         pub fn get(self: *Self) T {
-            return @atomicLoad(T, &self.unprotected_value, .SeqCst);
+            return self.load(.SeqCst);
         }
 
         pub fn set(self: *Self, new_value: T) void {
-            _ = self.xchg(new_value);
+            self.store(new_value, .SeqCst);
         }
 
         pub fn xchg(self: *Self, new_value: T) T {
-            return @atomicRmw(T, &self.unprotected_value, .Xchg, new_value, .SeqCst);
+            return self.rmw(.Xchg, new_value, .SeqCst);
         }
 
         pub fn fetchAdd(self: *Self, op: T) T {
-            return @atomicRmw(T, &self.unprotected_value, .Add, op, .SeqCst);
+            return self.rmw(.Add, op, .SeqCst);
         }
     };
 }


### PR DESCRIPTION
I don't see a good reason that `std.atomic.Int` was limited to sequential consistency; nor why we didn't support all read-modify-write operations.
This PR adds the missing pieces.

Perhaps e.g. `.get` should be deprecated now that `.load` is added?

Alternatively, maybe we should remove `std.atomic.Int` all-together and point people to the builtins? Though I see it as a useful abstraction so that people don't accidentally use non-atomic operations.
