### PR TITLE
fix os.waitpid returning also pid of child #6581

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -269,9 +269,9 @@ pub const ChildProcess = struct {
     }
 
     fn waitUnwrapped(self: *ChildProcess) void {
-        const status = os.waitpid(self.pid, 0);
+        const ret = os.waitpid(self.pid, 0);
         self.cleanupStreams();
-        self.handleWaitResult(status.status);
+        self.handleWaitResult(ret.status);
     }
 
     fn handleWaitResult(self: *ChildProcess, status: u32) void {

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -271,7 +271,7 @@ pub const ChildProcess = struct {
     fn waitUnwrapped(self: *ChildProcess) void {
         const status = os.waitpid(self.pid, 0);
         self.cleanupStreams();
-        self.handleWaitResult(status);
+        self.handleWaitResult(status.status);
     }
 
     fn handleWaitResult(self: *ChildProcess, status: u32) void {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3121,18 +3121,23 @@ pub fn getsockoptError(sockfd: fd_t) ConnectError!void {
     }
 }
 
-pub fn waitpid(pid: i32, flags: u32) u32 {
+
+pub const waitpid_ret = struct {
+   pid: i32,
+   status: u32
+};
+
+pub fn waitpid(pid: i32, flags: u32) waitpid_ret {
     // TODO allow implicit pointer cast from *u32 to *c_uint ?
     const Status = if (builtin.link_libc) c_uint else u32;
     var status: Status = undefined;
     while (true) {
-        switch (errno(system.waitpid(pid, &status, flags))) {
-            0 => return @bitCast(u32, status),
-            EINTR => continue,
-            ECHILD => unreachable, // The process specified does not exist. It would be a race condition to handle this error.
-            EINVAL => unreachable, // The options argument was invalid
-            else => unreachable,
+        var ret: usize = system.waitpid(pid, &status, flags);
+        if (ret == -1) {
+            if (std.os.errno(ret) == 4) continue; //EINTR
+            unreachable;
         }
+        return waitpid_ret{ .pid =  @intCast(i32, @truncate(u32, ret)), .status = @bitCast(u32, status) };
     }
 }
 

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3121,10 +3121,8 @@ pub fn getsockoptError(sockfd: fd_t) ConnectError!void {
     }
 }
 
-
 pub const WaitpidRet = struct {
-   pid: pid_t,
-   status: u32
+    pid: pid_t, status: u32
 };
 
 pub fn waitpid(pid: pid_t, flags: u32) WaitpidRet {
@@ -3134,7 +3132,7 @@ pub fn waitpid(pid: pid_t, flags: u32) WaitpidRet {
     while (true) {
         const rc = system.waitpid(pid, &status, flags);
         switch (errno(rc)) {
-            0 => return WaitpidRet{ .pid =  @intCast(pid_t,rc), .status = @bitCast(u32, status) },
+            0 => return WaitpidRet{ .pid = @intCast(pid_t, rc), .status = @bitCast(u32, status) },
             EINTR => continue,
             ECHILD => unreachable, // The process specified does not exist. It would be a race condition to handle this error.
             EINVAL => unreachable, // The options argument was invalid


### PR DESCRIPTION
this is an attempt at fixing #6581 - only `builtin.link_libc == true` has been tested though, would be interesting to test if this works also on other arches/setups.