### PR TITLE
Darwin rusage

### DIFF
--- a/lib/std/os/bits/darwin.zig
+++ b/lib/std/os/bits/darwin.zig
@@ -1474,3 +1474,25 @@ pub const CLOCK_UPTIME_RAW = 8;
 pub const CLOCK_UPTIME_RAW_APPROX = 9;
 pub const CLOCK_PROCESS_CPUTIME_ID = 12;
 pub const CLOCK_THREAD_CPUTIME_ID = 16;
+
+pub const RUSAGE_SELF = 0;
+pub const RUSAGE_CHILDREN = -1;
+
+pub const rusage = extern struct {
+    utime: timeval,
+    stime: timeval,
+    maxrss: isize,
+    ixrss: isize,
+    idrss: isize,
+    isrss: isize,
+    minflt: isize,
+    majflt: isize,
+    nswap: isize,
+    inblock: isize,
+    oublock: isize,
+    msgsnd: isize,
+    msgrcv: isize,
+    nsignals: isize,
+    nvcsw: isize,
+    nivcsw: isize,
+};

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1769,7 +1769,7 @@ pub const rusage = extern struct {
     utime: timeval,
     stime: timeval,
     maxrss: isize,
-    ix_rss: isize,
+    ixrss: isize,
     idrss: isize,
     isrss: isize,
     minflt: isize,


### PR DESCRIPTION
Tests against `time -l` results:

```
$ /usr/bin/time -l ./rusage
rusage{ .utime = timeval{ .tv_sec = 0, .tv_usec = 398281 },.stime = timeval{ .tv_sec = 0, .tv_usec = 270910 },
.maxrss = 843776, .ixrss = 0, .idrss = 0, .isrss = 0,.minflt = 226, .majflt = 0, .nswap = 0, .inblock = 0,
.oublock = 0, .msgsnd = 0, .msgrcv = 0,.nsignals = 0, .nvcsw = 1, .nivcsw = 100161 }

        5.22 real         0.39 user         0.27 sys
    860160  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
       230  page reclaims
         0  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         1  voluntary context switches
    100161  involuntary context switches
```