### PR TITLE
std.rand: set DefaultCsprng to Gimli, and require a larger seed

### DIFF
--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -28,6 +28,15 @@ pub const State = struct {
 
     const Self = @This();
 
+    pub fn init(initial_state: [State.BLOCKBYTES]u8) Self {
+        var data: [BLOCKBYTES / 4]u32 = undefined;
+        var i: usize = 0;
+        while (i < State.BLOCKBYTES) : (i += 4) {
+            data[i / 4] = mem.readIntLittle(u32, initial_state[i..][0..4]);
+        }
+        return Self{ .data = data };
+    }
+
     /// TODO follow the span() convention instead of having this and `toSliceConst`
     pub fn toSlice(self: *Self) []u8 {
         return mem.sliceAsBytes(self.data[0..]);


### PR DESCRIPTION
`DefaultCsprng` is documented as a cryptographically secure RNG.

While `ISAAC` is a CSPRNG, the variant we have, `ISAAC64` is not. A 64 bit seed is a bit small to satisfy that claim.

We also saw it being used with the current date as a seed, that also defeats the point of a CSPRNG.

Set `DefaultCsprng` to `Gimli` instead of `ISAAC64`, rename the parameter from `init_s` to `secret_seed` + add a comment to clarify what kind of seed is expected here.

Instead of directly touching the internals of the Gimli implementation (which can change/be architecture-specific), add an `init()` function to the state.

Our Gimli-based CSPRNG was also not backtracking resistant. Gimli is a permutation; it can be reversed. If the state was ever leaked, future secrets, but also all the previously generated ones could be recovered. Clear the rate after a squeeze in order to prevent this.

Finally, a dumb test was added just to exercise `DefaultCsprng` since we don't use it anywhere.