### PR TITLE
Make Cache WASI-compatible

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -580,6 +580,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
         const cache = try arena.create(Cache);
         cache.* = .{
             .gpa = gpa,
+            .work_dir = std.fs.cwd(),
             .manifest_dir = try options.local_cache_directory.handle.makeOpenPath("h", .{}),
         };
         errdefer cache.manifest_dir.close();

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -707,6 +707,7 @@ pub fn buildSharedObjects(comp: *Compilation) !void {
     // Use the global cache directory.
     var cache_parent: Cache = .{
         .gpa = comp.gpa,
+        .work_dir = std.fs.cwd(),
         .manifest_dir = try comp.global_cache_directory.handle.makeOpenPath("h", .{}),
     };
     defer cache_parent.manifest_dir.close();

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -306,6 +306,7 @@ pub fn buildImportLib(comp: *Compilation, lib_name: []const u8) !void {
 
     var cache: Cache = .{
         .gpa = comp.gpa,
+        .work_dir = std.fs.cwd(),
         .manifest_dir = comp.cache_parent.manifest_dir,
     };
     cache.hash.addBytes(build_options.version);


### PR DESCRIPTION
This commit makes `Cache` struct (and related) WASI-compatible by removing all references to `std.fs.cwd` and instead taking a working directory as an argument.

I've purposely set `work_dir` to `std.fs.cwd()` in callsites (`Compilation`, `glibc` and `mingw`) as I don't have a very good understanding of what would be required to at least make `Compilation` WASI-compatible yet. If anyone has any suggestions though, I'd love to hear them!

Closes #5437

cc @alexnask 