### PR TITLE
Fix an error when running `zig run` without any args.

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1238,6 +1238,10 @@ fn buildOutputType(
         fatal("one zig source file is required to run `zig test`", .{});
     }
 
+    if (root_src_file == null and arg_mode == .run) {
+        fatal("one zig source file is required to run `zig run`", .{});
+    }
+
     const root_name = if (provided_name) |n| n else blk: {
         if (arg_mode == .zig_test) {
             break :blk "test";

--- a/src/main.zig
+++ b/src/main.zig
@@ -1238,8 +1238,8 @@ fn buildOutputType(
         fatal("one zig source file is required to run `zig test`", .{});
     }
 
-    if (root_src_file == null and arg_mode == .run) {
-        fatal("one zig source file is required to run `zig run`", .{});
+    if (link_objects.items.len == 0 and root_src_file == null and c_source_files.items.len == 0 and arg_mode == .run) {
+        fatal("one source file is required to run `zig run`", .{});
     }
 
     const root_name = if (provided_name) |n| n else blk: {


### PR DESCRIPTION
Before it had an `Out of Memory` error, but now it doesn't because it checks how many args `zig run` is called with. 