### PR TITLE
Use regular file for caching stage 1 hash digest instead of symlink, fix zig build caching on Windows

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1490,6 +1490,15 @@ pub const Dir = struct {
         return os.windows.ReadLink(self.fd, sub_path_w, buffer);
     }
 
+    /// Read all of file contents using a preallocated buffer
+    pub fn readFile(self: Dir, file_path: []const u8, buffer: []u8) ![]u8 {
+        var file = try self.openFile(file_path, .{});
+        defer file.close();
+
+        const end_index = try file.readAll(buffer);
+        return buffer[0..end_index];
+    }
+
     /// On success, caller owns returned buffer.
     /// If the file is larger than `max_bytes`, returns `error.FileTooBig`.
     pub fn readFileAlloc(self: Dir, allocator: *mem.Allocator, file_path: []const u8, max_bytes: usize) ![]u8 {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2605,8 +2605,8 @@ fn updateStage1Module(comp: *Compilation, main_progress_node: *std.Progress.Node
 
         // We use an extra hex-encoded byte here to store some flags.
         var prev_digest_buf: [digest.len + 2]u8 = undefined;
-        const prev_digest: []u8 = directory.handle.readLink(id_symlink_basename, &prev_digest_buf) catch |err| blk: {
-            log.debug("stage1 {} new_digest={} readlink error: {}", .{ mod.root_pkg.root_src_path, digest, @errorName(err) });
+        const prev_digest: []u8 = directory.handle.readFile(id_symlink_basename, &prev_digest_buf) catch |err| blk: {
+            log.debug("stage1 {} new_digest={} readFile error: {}", .{ mod.root_pkg.root_src_path, digest, @errorName(err) });
             // Handle this as a cache miss.
             break :blk prev_digest_buf[0..0];
         };
@@ -2792,8 +2792,8 @@ fn updateStage1Module(comp: *Compilation, main_progress_node: *std.Progress.Node
     log.debug("saved digest + flags: '{s}' (byte = {}) have_winmain_crt_startup={}", .{
         digest_plus_flags, stage1_flags_byte, mod.stage1_flags.have_winmain_crt_startup,
     });
-    directory.handle.symLink(&digest_plus_flags, id_symlink_basename, .{}) catch |err| {
-        log.warn("failed to save stage1 hash digest symlink: {}", .{@errorName(err)});
+    directory.handle.writeFile(id_symlink_basename, &digest_plus_flags) catch |err| {
+        log.warn("failed to save stage1 hash digest file: {}", .{@errorName(err)});
     };
     // Again failure here only means an unnecessary cache miss.
     man.writeManifest() catch |err| {

--- a/src/link.zig
+++ b/src/link.zig
@@ -466,8 +466,8 @@ pub const File = struct {
         const digest = ch.final();
 
         var prev_digest_buf: [digest.len]u8 = undefined;
-        const prev_digest: []u8 = directory.handle.readLink(id_symlink_basename, &prev_digest_buf) catch |err| b: {
-            log.debug("archive new_digest={} readlink error: {}", .{ digest, @errorName(err) });
+        const prev_digest: []u8 = directory.handle.readFile(id_symlink_basename, &prev_digest_buf) catch |err| b: {
+            log.debug("archive new_digest={} readFile error: {}", .{ digest, @errorName(err) });
             break :b prev_digest_buf[0..0];
         };
         if (mem.eql(u8, prev_digest, &digest)) {
@@ -512,8 +512,8 @@ pub const File = struct {
         const bad = llvm.WriteArchive(full_out_path_z, object_files.items.ptr, object_files.items.len, os_type);
         if (bad) return error.UnableToWriteArchive;
 
-        directory.handle.symLink(&digest, id_symlink_basename, .{}) catch |err| {
-            std.log.warn("failed to save archive hash digest symlink: {}", .{@errorName(err)});
+        directory.handle.writeFile(id_symlink_basename, &digest) catch |err| {
+            std.log.warn("failed to save archive hash digest file: {}", .{@errorName(err)});
         };
 
         ch.writeManifest() catch |err| {

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -854,8 +854,8 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
         _ = try man.hit();
         digest = man.final();
         var prev_digest_buf: [digest.len]u8 = undefined;
-        const prev_digest: []u8 = directory.handle.readLink(id_symlink_basename, &prev_digest_buf) catch |err| blk: {
-            log.debug("COFF LLD new_digest={} readlink error: {}", .{ digest, @errorName(err) });
+        const prev_digest: []u8 = directory.handle.readFile(id_symlink_basename, &prev_digest_buf) catch |err| blk: {
+            log.debug("COFF LLD new_digest={} readFile error: {}", .{ digest, @errorName(err) });
             // Handle this as a cache miss.
             break :blk prev_digest_buf[0..0];
         };
@@ -1180,10 +1180,10 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
     }
 
     if (!self.base.options.disable_lld_caching) {
-        // Update the dangling symlink with the digest. If it fails we can continue; it only
+        // Update the dangling file with the digest. If it fails we can continue; it only
         // means that the next invocation will have an unnecessary cache miss.
-        directory.handle.symLink(&digest, id_symlink_basename, .{}) catch |err| {
-            std.log.warn("failed to save linking hash digest symlink: {}", .{@errorName(err)});
+        directory.handle.writeFile(id_symlink_basename, &digest) catch |err| {
+            std.log.warn("failed to save linking hash digest file: {}", .{@errorName(err)});
         };
         // Again failure here only means an unnecessary cache miss.
         man.writeManifest() catch |err| {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1326,8 +1326,8 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
         digest = man.final();
 
         var prev_digest_buf: [digest.len]u8 = undefined;
-        const prev_digest: []u8 = directory.handle.readLink(id_symlink_basename, &prev_digest_buf) catch |err| blk: {
-            log.debug("ELF LLD new_digest={} readlink error: {}", .{ digest, @errorName(err) });
+        const prev_digest: []u8 = directory.handle.readFile(id_symlink_basename, &prev_digest_buf) catch |err| blk: {
+            log.debug("ELF LLD new_digest={} readFile error: {}", .{ digest, @errorName(err) });
             // Handle this as a cache miss.
             break :blk prev_digest_buf[0..0];
         };
@@ -1647,10 +1647,10 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
     }
 
     if (!self.base.options.disable_lld_caching) {
-        // Update the dangling symlink with the digest. If it fails we can continue; it only
+        // Update the dangling file with the digest. If it fails we can continue; it only
         // means that the next invocation will have an unnecessary cache miss.
-        directory.handle.symLink(&digest, id_symlink_basename, .{}) catch |err| {
-            std.log.warn("failed to save linking hash digest symlink: {}", .{@errorName(err)});
+        directory.handle.writeFile(id_symlink_basename, &digest) catch |err| {
+            std.log.warn("failed to save linking hash digest file: {}", .{@errorName(err)});
         };
         // Again failure here only means an unnecessary cache miss.
         man.writeManifest() catch |err| {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -419,8 +419,8 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
         digest = man.final();
 
         var prev_digest_buf: [digest.len]u8 = undefined;
-        const prev_digest: []u8 = directory.handle.readLink(id_symlink_basename, &prev_digest_buf) catch |err| blk: {
-            log.debug("MachO LLD new_digest={} readlink error: {}", .{ digest, @errorName(err) });
+        const prev_digest: []u8 = directory.handle.readFile(id_symlink_basename, &prev_digest_buf) catch |err| blk: {
+            log.debug("MachO LLD new_digest={} readFile error: {}", .{ digest, @errorName(err) });
             // Handle this as a cache miss.
             break :blk prev_digest_buf[0..0];
         };
@@ -674,10 +674,10 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
     }
 
     if (!self.base.options.disable_lld_caching) {
-        // Update the dangling symlink with the digest. If it fails we can continue; it only
+        // Update the dangling file with the digest. If it fails we can continue; it only
         // means that the next invocation will have an unnecessary cache miss.
-        directory.handle.symLink(&digest, id_symlink_basename, .{}) catch |err| {
-            std.log.warn("failed to save linking hash digest symlink: {}", .{@errorName(err)});
+        directory.handle.writeFile(id_symlink_basename, &digest) catch |err| {
+            std.log.warn("failed to save linking hash digest file: {}", .{@errorName(err)});
         };
         // Again failure here only means an unnecessary cache miss.
         man.writeManifest() catch |err| {

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -310,8 +310,8 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
         digest = man.final();
 
         var prev_digest_buf: [digest.len]u8 = undefined;
-        const prev_digest: []u8 = directory.handle.readLink(id_symlink_basename, &prev_digest_buf) catch |err| blk: {
-            log.debug("WASM LLD new_digest={} readlink error: {}", .{ digest, @errorName(err) });
+        const prev_digest: []u8 = directory.handle.readFile(id_symlink_basename, &prev_digest_buf) catch |err| blk: {
+            log.debug("WASM LLD new_digest={} readFile error: {}", .{ digest, @errorName(err) });
             // Handle this as a cache miss.
             break :blk prev_digest_buf[0..0];
         };
@@ -424,9 +424,9 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
     }
 
     if (!self.base.options.disable_lld_caching) {
-        // Update the dangling symlink with the digest. If it fails we can continue; it only
+        // Update the dangling file with the digest. If it fails we can continue; it only
         // means that the next invocation will have an unnecessary cache miss.
-        directory.handle.symLink(&digest, id_symlink_basename, .{}) catch |err| {
+        directory.handle.writeFile(id_symlink_basename, &digest) catch |err| {
             std.log.warn("failed to save linking hash digest symlink: {}", .{@errorName(err)});
         };
         // Again failure here only means an unnecessary cache miss.


### PR DESCRIPTION
Use regular file for caching stage 1 hash digest instead of symlink, fix zig build caching on Windows

Fix #6500