### PR TITLE
zig cc / c++: add cache dir option

### DIFF
--- a/src/clang_options_data.zig
+++ b/src/clang_options_data.zig
@@ -2,6 +2,16 @@
 // zig fmt: off
 usingnamespace @import("clang_options.zig");
 pub const data = blk: { @setEvalBranchQuota(6000); break :blk &[_]CliArg{
+// Applicable zig options:
+.{
+    .name = "cache-dir",
+    .syntax = .separate,
+    .zig_equivalent = .cache_dir,
+    .pd1 = false,
+    .pd2 = true,
+    .psl = false,
+},
+// Clang options:
 flagpd1("C"),
 flagpd1("CC"),
 .{

--- a/tools/update_clang_options.zig
+++ b/tools/update_clang_options.zig
@@ -284,6 +284,10 @@ const known_options = [_]KnownOpt{
         .name = "framework",
         .ident = "framework",
     },
+    .{
+        .name = "cache-dir",
+        .ident = "cache_dir",
+    },
 };
 
 const blacklisted_options = [_][]const u8{};
@@ -383,6 +387,16 @@ pub fn main() anyerror!void {
         \\// zig fmt: off
         \\usingnamespace @import("clang_options.zig");
         \\pub const data = blk: { @setEvalBranchQuota(6000); break :blk &[_]CliArg{
+        \\// Applicable zig options:
+        \\.{
+        \\    .name = "cache-dir",
+        \\    .syntax = .separate,
+        \\    .zig_equivalent = .cache_dir,
+        \\    .pd1 = false,
+        \\    .pd2 = true,
+        \\    .psl = false,
+        \\},
+        \\// Clang options:
         \\
     );
 


### PR DESCRIPTION
When using `zig cc` and `zig c++` allow specifying the location for the local zig-cache directory.

@andrewrk, as per your [request](https://github.com/ziglang/zig/pull/4928#issuecomment-649189769) I split the prvious PR (#4928).
Incidentally, I had to port the code from C++ to Zig in the process! :smile:

> Thanks for the contribution! `zig cc` has no test harness yet, so for now we rely on careful code review.

_Originally posted by @andrewrk in https://github.com/ziglang/zig/pull/4893#issuecomment-607273910_

I'm assuming there is still no test harness.
I hope the quality is good enough. I await the feedback on my first time writing Zig code.
Sorry for the long delay.
Have a great day!
Thanks for Zig!

additional PRs: #6630 and #6631