### PR TITLE
fix bug in `zig build`

### DIFF
--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -748,6 +748,44 @@ fn testResolvePosix(paths: []const []const u8, expected: []const u8) !void {
     defer testing.allocator.free(actual);
     return testing.expect(mem.eql(u8, actual, expected));
 }
+/// If the path is at the root of the filesystem ex: "/" returns true else returns false
+pub fn isRoot(path: []const u8) bool {
+    if (builtin.os.tag == .windows) {
+        return isRootWindows(path);
+    } else {
+        return isRootPosix(path);
+    }
+}
+
+pub fn isRootWindows(path: []const u8) bool {
+    return mem.eql(u8, dirnameWindows(path) orelse return false, path);
+}
+pub fn isRootPosix(path: []const u8) bool {
+    return mem.eql(u8, dirnamePosix(path) orelse return false, path);
+}
+
+fn testIsRootWindows(input: []const u8, expected_output: bool) void {
+    testing.expect(isRootWindows(input) == expected_output);
+}
+fn testIsRootPosix(input: []const u8, expected_output: bool) void {
+    testing.expect(isRootPosix(input) == expected_output);
+}
+
+test "isRootWindows" {
+    testIsRootWindows("", false);
+    testIsRootWindows("c:\\", true);
+    testIsRootWindows("c:\\foo", false);
+    testIsRootWindows("\\", true);
+    testIsRootWindows("\\Users\\foo\\bar\\baz\\quux\\", false);
+    testIsRootWindows("/", true);
+}
+test "isRootPosix" {
+    testIsRootPosix("/", true);
+    testIsRootPosix("/a", false);
+    testIsRootPosix("", false);
+    testIsRootPosix("foo", false);
+    testIsRootPosix("/a/b", false);
+}
 
 /// If the path is a file in the current directory (no directory component)
 /// then returns null

--- a/src/main.zig
+++ b/src/main.zig
@@ -2210,16 +2210,15 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
                     break :blk .{ .path = dirname, .handle = dir };
                 } else |err| switch (err) {
                     error.FileNotFound => {
-                        dirname = fs.path.dirname(dirname) orelse {
+                        if (fs.path.isRoot(dirname)) {
                             std.log.info("{}", .{
                                 \\Initialize a 'build.zig' template file with `zig init-lib` or `zig init-exe`,
                                 \\or see `zig --help` for more options.
                             });
                             fatal("No 'build.zig' file found, in the current directory or any parent directories.", .{});
-                        };
-                        if (std.fs.path.isRoot(dirname)) {
-                            dirname = "";
                         }
+
+                        dirname = fs.path.dirname(dirname).?; // this is not null because it is null on not a real path but all our paths are real because it comes from cwd
                         continue;
                     },
                     else => |e| return e,

--- a/src/main.zig
+++ b/src/main.zig
@@ -2217,6 +2217,9 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
                             });
                             fatal("No 'build.zig' file found, in the current directory or any parent directories.", .{});
                         };
+                        if (std.fs.path.isRoot(dirname)) {
+                            dirname = "";
+                        }
                         continue;
                     },
                     else => |e| return e,


### PR DESCRIPTION
std.fs.path.dirname(path) when passed "/" just returns "/" so infinite
loop. It adds 
- std.fs.path.isRoot(path) which returns true if the path is a root path.
- If a `build.zig` was not in any higher directories, it would just loop forever because dirname("/") is just "/". Now it checks if it is root and stops it.
