### PR TITLE
std/crypto: vectorize Gimli

### DIFF
--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -19,12 +19,13 @@ const debug = std.debug;
 const assert = std.debug.assert;
 const testing = std.testing;
 const htest = @import("test.zig");
+const Vector = std.meta.Vector;
 
 pub const State = struct {
     pub const BLOCKBYTES = 48;
     pub const RATE = 16;
 
-    data: [BLOCKBYTES / 4]u32,
+    data: [BLOCKBYTES / 4]u32 align(16),
 
     const Self = @This();
 
@@ -103,7 +104,57 @@ pub const State = struct {
         }
     }
 
-    pub const permute = if (std.builtin.mode == .ReleaseSmall) permute_small else permute_unrolled;
+    const Lane = Vector(4, u32);
+
+    inline fn shift(x: Lane, comptime n: comptime_int) Lane {
+        return x << @splat(4, @as(u5, n));
+    }
+
+    inline fn rot(x: Lane, comptime n: comptime_int) Lane {
+        return (x << @splat(4, @as(u5, n))) | (x >> @splat(4, @as(u5, 32 - n)));
+    }
+
+    fn permute_vectorized(self: *Self) void {
+        const state = &self.data;
+        var x = Lane{ state[0], state[1], state[2], state[3] };
+        var y = Lane{ state[4], state[5], state[6], state[7] };
+        var z = Lane{ state[8], state[9], state[10], state[11] };
+        var round = @as(u32, 24);
+        while (round > 0) : (round -= 1) {
+            x = rot(x, 24);
+            y = rot(y, 9);
+            const newz = x ^ shift(z, 1) ^ shift(y & z, 2);
+            const newy = y ^ x ^ shift(x | z, 1);
+            const newx = z ^ y ^ shift(x & y, 3);
+            x = newx;
+            y = newy;
+            z = newz;
+            switch (round & 3) {
+                0 => {
+                    x = @shuffle(u32, x, undefined, [_]i32{ 1, 0, 3, 2 });
+                    x[0] ^= round | 0x9e377900;
+                },
+                2 => {
+                    x = @shuffle(u32, x, undefined, [_]i32{ 2, 3, 0, 1 });
+                },
+                else => {},
+            }
+        }
+        comptime var i: usize = 0;
+        inline while (i < 4) : (i += 1) {
+            state[0 + i] = x[i];
+            state[4 + i] = y[i];
+            state[8 + i] = z[i];
+        }
+    }
+
+    pub const permute = if (std.Target.current.cpu.arch == .x86_64) impl: {
+        break :impl permute_vectorized;
+    } else if (std.builtin.mode == .ReleaseSmall) impl: {
+        break :impl permute_small;
+    } else impl: {
+        break :impl permute_unrolled;
+    };
 
     pub fn squeeze(self: *Self, out: []u8) void {
         var i = @as(usize, 0);

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -1645,11 +1645,13 @@ static void gen_assign_raw(CodeGen *g, LLVMValueRef ptr, ZigType *ptr_type,
 
         ZigType *usize = g->builtin_types.entry_usize;
         uint64_t size_bytes = LLVMStoreSizeOfType(g->target_data_ref, get_llvm_type(g, child_type));
-        uint64_t align_bytes = get_ptr_align(g, ptr_type);
+        uint64_t src_align_bytes = get_abi_alignment(g, child_type);
+        uint64_t dest_align_bytes = get_ptr_align(g, ptr_type);
         assert(size_bytes > 0);
-        assert(align_bytes > 0);
+        assert(src_align_bytes > 0);
+        assert(dest_align_bytes > 0);
 
-        ZigLLVMBuildMemCpy(g->builder, dest_ptr, align_bytes, src_ptr, align_bytes,
+        ZigLLVMBuildMemCpy(g->builder, dest_ptr, dest_align_bytes, src_ptr, src_align_bytes,
                 LLVMConstInt(usize->llvm_type, size_bytes, false),
                 ptr_type->data.pointer.is_volatile);
         return;


### PR DESCRIPTION
40% performance increase on x86_64.

But like ChaCha, this is slower on aarch64. So, only enable on x86_64 for now.
