### PR TITLE
stage2: enable incremental MachO linking

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -367,8 +367,6 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
         .Lib => return error.TODOImplementWritingLibFiles,
     }
 
-    if (self.cmd_table_dirty) try self.writeCmdHeaders();
-
     {
         // Update symbol table.
         const nlocals = @intCast(u32, self.local_symbols.items.len);
@@ -377,6 +375,8 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
         const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
         symtab.nsyms = nlocals + nglobals + nundefs;
     }
+
+    if (self.cmd_table_dirty) try self.writeCmdHeaders();
 
     if (self.entry_addr == null and self.base.options.output_mode == .Exe) {
         log.debug("flushing. no_entry_point_found = true\n", .{});

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -186,6 +186,38 @@ pub fn addCases(ctx: *TestContext) !void {
             ,
             "Hello, World!\n",
         );
+        // Now change the message only
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    print();
+            \\
+            \\    exit();
+            \\}
+            \\
+            \\fn print() void {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (0x2000004),
+            \\          [arg1] "{rdi}" (1),
+            \\          [arg2] "{rsi}" (@ptrToInt("What is up? This is a longer message that will force the data to be relocated in virtual address space.\n")),
+            \\          [arg3] "{rdx}" (104)
+            \\        : "memory"
+            \\    );
+            \\    return;
+            \\}
+            \\
+            \\fn exit() noreturn {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (0x2000001),
+            \\          [arg1] "{rdi}" (0)
+            \\        : "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "What is up? This is a longer message that will force the data to be relocated in virtual address space.\n",
+        );
     }
 
     {

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -218,6 +218,41 @@ pub fn addCases(ctx: *TestContext) !void {
         ,
             "What is up? This is a longer message that will force the data to be relocated in virtual address space.\n",
         );
+        // Now we print it twice.
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    print();
+            \\    print();
+            \\
+            \\    exit();
+            \\}
+            \\
+            \\fn print() void {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (0x2000004),
+            \\          [arg1] "{rdi}" (1),
+            \\          [arg2] "{rsi}" (@ptrToInt("What is up? This is a longer message that will force the data to be relocated in virtual address space.\n")),
+            \\          [arg3] "{rdx}" (104)
+            \\        : "memory"
+            \\    );
+            \\    return;
+            \\}
+            \\
+            \\fn exit() noreturn {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (0x2000001),
+            \\          [arg1] "{rdi}" (0)
+            \\        : "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            \\What is up? This is a longer message that will force the data to be relocated in virtual address space.
+            \\What is up? This is a longer message that will force the data to be relocated in virtual address space.
+            \\
+        );
     }
 
     {


### PR DESCRIPTION
This PR enables basic incremental MachO linking. In other words, it is now possible to play with the biggest game changer of stage2 on a x86_64 mac like so:

```
../stage2/bin/zig build-exe test.zig --watch
```

Word of caution though that I haven't yet added handling of `__text` section growth meaning that if you apply too many growing changes, or add some rather beefy symbols, you will likely end up trapping at some point. I'm also not happy with handling of load command headers since we end up overwriting all at every change rather than only updating symbol and dynamic symbol tables for instance. This is to follow in a subsequent PR in the near future though ;-)