### PR TITLE
fixes #6531

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1714,8 +1714,8 @@ fn buildOutputType(
             }
             if (std.builtin.os.tag != .windows and arg_mode == .run and !watch) {
                 var env_vars = try process.getEnvMap(gpa);
-                defer env_vars.deinit();
                 const err = os.execvpe(gpa, argv.items, &env_vars);
+                env_vars.deinit(); // it would cause a memory leak because a defer would be unreachable
                 fatal("There was an error with `zig run`: {}", .{@errorName(err)});
             } else {
                 const child = try std.ChildProcess.init(argv.items, gpa);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1712,7 +1712,7 @@ fn buildOutputType(
             if (runtime_args_start) |i| {
                 try argv.appendSlice(all_args[i..]);
             }
-            if (std.builtin.os.tag == .linux and (arg_mode == .run or arg_mode == .zig_test) and watch == false) { // TODO does other posix os support execve in zig stdlib?
+            if (std.builtin.os.tag == .linux and arg_mode == .run and watch == false) { // TODO does other posix os support execve in zig stdlib?
                 var env_vars = try process.getEnvMap(gpa);
                 defer env_vars.deinit();
                 const term = os.execvpe(gpa, argv.items, &env_vars);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1715,7 +1715,8 @@ fn buildOutputType(
             if (std.builtin.os.tag != .windows and arg_mode == .run and !watch) {
                 var env_vars = try process.getEnvMap(gpa);
                 defer env_vars.deinit();
-                return os.execvpe(gpa, argv.items, &env_vars);
+                const err = os.execvpe(gpa, argv.items, &env_vars);
+                fatal("There was an error with `zig run`: {}", .{@errorName(err)});
             } else {
                 const child = try std.ChildProcess.init(argv.items, gpa);
                 defer child.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -1712,14 +1712,10 @@ fn buildOutputType(
             if (runtime_args_start) |i| {
                 try argv.appendSlice(all_args[i..]);
             }
-            if (std.builtin.os.tag == .linux and arg_mode == .run and watch == false) { // TODO does other posix os support execve in zig stdlib?
+            if (std.builtin.os.tag != .windows and arg_mode == .run and !watch) {
                 var env_vars = try process.getEnvMap(gpa);
                 defer env_vars.deinit();
-                const term = os.execvpe(gpa, argv.items, &env_vars);
-                switch (arg_mode) {
-                    .run => process.exit(1),
-                    else => unreachable,
-                }
+                return os.execvpe(gpa, argv.items, &env_vars);
             } else {
                 const child = try std.ChildProcess.init(argv.items, gpa);
                 defer child.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -1718,10 +1718,6 @@ fn buildOutputType(
                 const term = os.execvpe(gpa, argv.items, &env_vars);
                 switch (arg_mode) {
                     .run => process.exit(1),
-                    .zig_test => {
-                        const cmd = try argvCmd(arena, argv.items);
-                        fatal("the following test command failed with exit status {}:\n{}", .{ term, cmd });
-                    },
                     else => unreachable,
                 }
             } else {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1715,7 +1715,7 @@ fn buildOutputType(
             if (std.builtin.os.tag != .windows and arg_mode == .run and !watch) {
                 var env_vars = try process.getEnvMap(gpa);
                 const err = os.execvpe(gpa, argv.items, &env_vars);
-                env_vars.deinit(); // it would cause a memory leak because a defer would be unreachable
+                env_vars.deinit(); // it would cause a memory leak because a defer would be unreachable because of fatal
                 fatal("There was an error with `zig run`: {}", .{@errorName(err)});
             } else {
                 const child = try std.ChildProcess.init(argv.items, gpa);


### PR DESCRIPTION
I used execvpe because std.os had a wrapper for it. The only downside is that it needs memory allocation because getEnvMap needs an allocator.

Is execvpe supported on any other os besides linux in zig?