### PR TITLE
stage2: enable stage2 end-to-end tests on macOS run natively

### DIFF
--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -608,8 +608,13 @@ pub const CrossTarget = struct {
         // If the OS and CPU arch match, the binary can be considered native.
         if (os_match and cpu_arch == Target.current.cpu.arch) {
             // However, we also need to verify that the dynamic linker path is valid.
-            // TODO Until that is implemented, we prevent returning `.native` when the OS is non-native.
             if (self.os_tag == null) {
+                return .native;
+            }
+            if (self.dynamic_linker.max_byte) |len| blk: {
+                std.fs.cwd().access(self.dynamic_linker.buffer[0..len + 1], .{}) catch {
+                    break :blk;
+                };
                 return .native;
             }
         }

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -14,6 +14,7 @@ const linux_x64 = std.zig.CrossTarget{
 const macosx_x64 = std.zig.CrossTarget{
     .cpu_arch = .x86_64,
     .os_tag = .macos,
+    .dynamic_linker = std.zig.CrossTarget.DynamicLinker.init("/usr/lib/dyld"),
 };
 
 const linux_riscv64 = std.zig.CrossTarget{
@@ -145,7 +146,7 @@ pub fn addCases(ctx: *TestContext) !void {
     }
 
     {
-        var case = ctx.exe("hello world", macosx_x64);
+        var case = ctx.exe("hello world with updates", macosx_x64);
         case.addError("", &[_][]const u8{":1:1: error: no entry point found"});
 
         // Incorrect return type


### PR DESCRIPTION
~~**Builds upon #6650**~~

This commit ~~(927b24d)~~ enables stage2 end-to-end tests to run natively on macOS (where and when applicable). Since QEMU on macOS doesn't support the same type of architecture emulation as it does on linux (i.e., there is no `qemu-x86_64` for instance), this commit ensures that we specify a path to dynamic linker on macOS (`/usr/lib/dyld`) which is then checked for existence in `std.CrossTarget.getExternalExecutor()` function, and if exists, we can run the test natively.

@andrewrk I'm not sure whether this is the way we want to handle this in `CrossTarget`, however, I'm super eager to get it to work one way or another so that we can run stage2 tests on macOS (concerning MachO ofc). I do realise that there will be a point when this will not be needed since we'll have only one set of tests running on all supported arch-os tuples, however, until such time, I figure it'd be super useful to have the basic stage2 tests run by the CI.