### PR TITLE
Build verbosity

### DIFF
--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -103,6 +103,8 @@ pub fn main() !void {
                 builder.verbose_cc = true;
             } else if (mem.eql(u8, arg, "--verbose-llvm-cpu-features")) {
                 builder.verbose_llvm_cpu_features = true;
+            } else if (mem.eql(u8, arg, "--verbose-build")) {
+                builder.verbose_build = true;
             } else if (mem.eql(u8, arg, "--")) {
                 builder.args = argsRest(args, arg_idx);
                 break;


### PR DESCRIPTION
Added a new switch to make build command less verbose

```
--verbose-build

b.verbose_build = true;
```

Before:

![Code_sbs0a5Amkt](https://user-images.githubusercontent.com/44361234/95904449-d5048c80-0d97-11eb-9828-f2e626a2c3f3.png)

After:

![Code_mOmb3KZffu](https://user-images.githubusercontent.com/44361234/95904463-d8981380-0d97-11eb-817c-c6adec8c8044.png)


Error message is now more visible

The verbosity was unnecessary, and counter productive