### PR TITLE
generated docs improvements: add vector, fntype, anytype type-printing; bool, function value-printing

### DIFF
--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -726,6 +726,13 @@
                     payloadHtml += token('var', tokenKinds.Keyword, wantHtml);
                 }
                 return payloadHtml;
+            case typeKinds.AnyFrame:
+                var name = token('anyframe', tokenKinds.Keyword, wantHtml);
+                if (typeObj.result) {
+                  name += "->";
+                  name += typeIndexName(typeObj.result, wantHtml, wantSubLink, null);
+                }
+                return name;
             default:
                 if (wantHtml) {
                     return escapeHtml(typeObj.name);

--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -564,6 +564,13 @@
                 name += "]";
                 name += typeIndexName(typeObj.elem, wantHtml, wantSubLink, null);
                 return name;
+            case typeKinds.Vector:
+                var name = "Vector(";
+                name += token(typeObj.len, tokenKinds.Number, wantHtml);
+                name += ", ";
+                name += typeIndexName(typeObj.elem, wantHtml, wantSubLink, null);
+                name += ")";
+                return name;
             case typeKinds.Optional:
                 return "?" + typeIndexName(typeObj.child, wantHtml, wantSubLink, fnDecl, linkFnNameDecl);
             case typeKinds.Pointer:

--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -726,6 +726,25 @@
                     payloadHtml += token('var', tokenKinds.Keyword, wantHtml);
                 }
                 return payloadHtml;
+            case typeKinds.Frame:
+                var name = '@Frame(';
+                var fnObj = zigAnalysis.fns[typeObj.fn];
+                var declPath = fnObj.decl && getCanonDeclPath(fnObj.decl);
+                var fnName = typeObj.fnName;
+                if (wantHtml) {
+                  name += '<span class="tok-fn">';
+                  if (declPath) {
+                    name += '<a href="' + navLink(declPath.pkgNames, declPath.declNames) + '">'
+                        + escapeHtml(fnName) + '</a>';
+                  } else {
+                    name += escapeHtml(fnName);
+                  }
+                  name += '</span>';
+                } else {
+                  name += fnName;
+                }
+                name += ')';
+                return name;
             case typeKinds.AnyFrame:
                 var name = token('anyframe', tokenKinds.Keyword, wantHtml);
                 if (typeObj.result) {

--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -540,7 +540,23 @@
                 return typeIndexName(value, wantHtml, wantLink);
             case typeKinds.Fn:
                 var fnObj = zigAnalysis.fns[value];
-                return typeIndexName(fnObj.type, wantHtml, wantLink);
+                var declPath = fnObj.decl && getCanonDeclPath(fnObj.decl);
+                var fnName = declPath ? declPath.declNames.join('.') : '(unknown)';
+
+                if (!wantHtml) {
+                    return fnName;
+                }
+
+                var str = '<span class="tok-fn">';
+                if (wantLink && declPath != null) {
+                  str += '<a href="' + navLink(declPath.pkgNames, declPath.declNames) + '">';
+                  str += escapeHtml(fnName);
+                  str += '</a>';
+                } else {
+                  str += escapeHtml(fnName);
+                }
+                str += '</span>';
+                return str;
             case typeKinds.Int:
                 return token(value, tokenKinds.Number, wantHtml);
             case typeKinds.Optional:
@@ -727,24 +743,8 @@
                 }
                 return payloadHtml;
             case typeKinds.Frame:
-                var name = '@Frame(';
                 var fnObj = zigAnalysis.fns[typeObj.fn];
-                var declPath = fnObj.decl && getCanonDeclPath(fnObj.decl);
-                var fnName = typeObj.fnName;
-                if (wantHtml) {
-                  name += '<span class="tok-fn">';
-                  if (declPath) {
-                    name += '<a href="' + navLink(declPath.pkgNames, declPath.declNames) + '">'
-                        + escapeHtml(fnName) + '</a>';
-                  } else {
-                    name += escapeHtml(fnName);
-                  }
-                  name += '</span>';
-                } else {
-                  name += fnName;
-                }
-                name += ')';
-                return name;
+                return '@Frame(' + getValueText(fnObj.type, typeObj.fn, wantHtml, wantSubLink) + ')';
             case typeKinds.AnyFrame:
                 var name = token('anyframe', tokenKinds.Keyword, wantHtml);
                 if (typeObj.result) {

--- a/src/stage1/dump_analysis.cpp
+++ b/src/stage1/dump_analysis.cpp
@@ -1046,6 +1046,16 @@ static void anal_dump_type(AnalDumpCtx *ctx, ZigType *ty) {
             anal_dump_type_ref(ctx, ty->data.array.child_type);
             break;
         }
+        case ZigTypeIdVector: {
+            jw_object_field(jw, "len");
+            jw_int(jw, ty->data.vector.len);
+
+            jw_object_field(jw, "elem");
+            anal_dump_type_ref(ctx, ty->data.vector.elem_type);
+            break;
+        }
+        case ZigTypeIdInvalid:
+            zig_unreachable();
         default:
             jw_object_field(jw, "name");
             jw_string(jw, buf_ptr(&ty->name));

--- a/src/stage1/dump_analysis.cpp
+++ b/src/stage1/dump_analysis.cpp
@@ -1054,6 +1054,13 @@ static void anal_dump_type(AnalDumpCtx *ctx, ZigType *ty) {
             anal_dump_type_ref(ctx, ty->data.vector.elem_type);
             break;
         }
+        case ZigTypeIdAnyFrame: {
+            if (ty->data.any_frame.result_type != nullptr) {
+                jw_object_field(jw, "result");
+                anal_dump_type_ref(ctx, ty->data.any_frame.result_type);
+            }
+            break;
+        }
         case ZigTypeIdInvalid:
             zig_unreachable();
         default:

--- a/src/stage1/dump_analysis.cpp
+++ b/src/stage1/dump_analysis.cpp
@@ -352,6 +352,7 @@ struct AnalDumpCtx {
 
     ZigList<ZigFn *> fn_list;
     HashMap<const ZigFn *, uint32_t, fn_ptr_hash, fn_ptr_eql> fn_map;
+    HashMap<const ZigFn *, uint32_t, fn_ptr_hash, fn_ptr_eql> fn_decl_map;
 
     ZigList<AstNode *> node_list;
     HashMap<const AstNode *, uint32_t, node_ptr_hash, node_ptr_eql> node_map;
@@ -491,6 +492,7 @@ static uint32_t anal_dump_get_decl_id(AnalDumpCtx *ctx, Tld *tld) {
 
                 if (fn != nullptr) {
                     (void)anal_dump_get_type_id(ctx, fn->type_entry);
+                    ctx->fn_decl_map.put_unique(fn, decl_id);
                 }
                 break;
             }
@@ -1061,6 +1063,14 @@ static void anal_dump_type(AnalDumpCtx *ctx, ZigType *ty) {
             }
             break;
         }
+        case ZigTypeIdFnFrame: {
+            jw_object_field(jw, "fnName");
+            jw_string(jw, buf_ptr(&ty->data.frame.fn->symbol_name));
+
+            jw_object_field(jw, "fn");
+            anal_dump_fn_ref(ctx, ty->data.frame.fn);
+            break;
+        }
         case ZigTypeIdInvalid:
             zig_unreachable();
         default:
@@ -1186,6 +1196,12 @@ static void anal_dump_fn(AnalDumpCtx *ctx, ZigFn *fn) {
     jw_object_field(jw, "type");
     anal_dump_type_ref(ctx, fn->type_entry);
 
+    auto entry = ctx->fn_decl_map.maybe_get(fn);
+    if (entry != nullptr) {
+      jw_object_field(jw, "decl");
+      jw_int(jw, entry->value);
+    }
+
     jw_end_object(jw);
 }
 
@@ -1200,6 +1216,7 @@ void zig_print_analysis_dump(CodeGen *g, FILE *f, const char *one_indent, const 
     ctx.decl_map.init(16);
     ctx.node_map.init(16);
     ctx.fn_map.init(16);
+    ctx.fn_decl_map.init(16);
     ctx.err_map.init(16);
 
     jw_begin_object(jw);


### PR DESCRIPTION
See  #3404.

I think that some of these aren't currently used in (tested parts of) the stdlib, so this patch can be used to see them in action:

```diff
diff --git a/lib/std/meta.zig b/lib/std/meta.zig
index 79b0424e9..719fe1f65 100644
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -702,6 +702,41 @@ pub fn Vector(comptime len: u32, comptime child: type) type {
     });
 }

+pub fn dummy_vec() Vector(3, f32) {
+    var asd : Vector(3, f32) = undefined;
+    return asd;
+}
+
+const OpaqueType = opaque {};
+pub fn dummy_opaque() *OpaqueType {
+    return @intToPtr(*OpaqueType, 1234);
+}
+
+pub fn dummy_fnframe() @Frame(dummy_vec) {
+    return undefined;
+}
+
+pub fn dummy_anyframe() anyframe {
+    return @frame();
+}
+
+pub fn dummy_anyframe_ret() anyframe->f32 {
+    return undefined;
+}
+
+pub fn DummyTypeFnArg(arg: @TypeOf(dummy_opaque)) type {
+    return i8;
+}
+
+test "test vector" {
+    _ = dummy_vec();
+    _ = dummy_opaque();
+    _ = dummy_fnframe();
+    _ = dummy_anyframe();
+    _ = dummy_anyframe_ret();
+    _ = DummyTypeFnArg(dummy_opaque);
+}
+
 /// Given a type and value, cast the value to the type as c would.
 /// This is for translate-c and is not intended for general use.
 pub fn cast(comptime DestType: type, target: anytype) DestType {
```