### PR TITLE
Pretty print Slices

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -456,6 +456,18 @@ pub fn formatType(
                 }
                 if (ptr_info.child == u8) {
                     return formatText(value, fmt, options, writer);
+                } else if (fmt.len > 0 and ((fmt[0] == 'v') or (fmt[0] == 'V'))) {
+                    try format(writer, "[", .{});
+                    var i: usize = 0;
+                    for (value) |one| {
+                        if (i == value.len - 1) {
+                            try format(writer, "{}", .{one});
+                        } else{ 
+                            try format(writer, "{}, ", .{one});
+                        }
+                        i += 1;
+                    }
+                    return format(writer, "]", .{});
                 }
                 return format(writer, "{}@{x}", .{ @typeName(ptr_info.child), @ptrToInt(value.ptr) });
             },

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -462,7 +462,7 @@ pub fn formatType(
                     for (value) |one| {
                         if (i == value.len - 1) {
                             try format(writer, "{}", .{one});
-                        } else{ 
+                        } else { 
                             try format(writer, "{}, ", .{one});
                         }
                         i += 1;


### PR DESCRIPTION
This code is adapted from @pixelherodev paste from IRC

I have added a new fmt option to handle printing slice values ``{v}`` or ``{V}``

While i think it can be made the default, i want your opinion about it

```zig
    var slicea = [0]u32{};
    var sliceb = [3]u32{ 1, 2, 3 };

    std.log.info("Content: {v}", .{slicea});
    std.log.info("Content: {v}", .{sliceb});
```

will print:

```
info: Content: []
info: Content: [1, 2, 3]
```

Question:

Should we drop ``{v}`` and make it the default behavior?