### PR TITLE
Classify .tbd files as shared libraries

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2012,7 +2012,8 @@ pub fn hasAsmExt(filename: []const u8) bool {
 pub fn hasSharedLibraryExt(filename: []const u8) bool {
     if (mem.endsWith(u8, filename, ".so") or
         mem.endsWith(u8, filename, ".dll") or
-        mem.endsWith(u8, filename, ".dylib"))
+        mem.endsWith(u8, filename, ".dylib") or
+        mem.endsWith(u8, filename, ".tbd"))
     {
         return true;
     }


### PR DESCRIPTION
On macOS, a `.tbd` (_"text-based dylib definition"_) file is a shared library stub, allowing symbols to be defined only once for all the architectures the library was compiled for.

`.tbd` files can be linked like `.dylib` files.