### PR TITLE
BYOS support for system.isatty(fd: fd_t);

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2553,6 +2553,9 @@ pub fn isatty(handle: fd_t) bool {
         var out: windows.DWORD = undefined;
         return windows.kernel32.GetConsoleMode(handle, &out) != 0;
     }
+    if (builtin.link_libc) {
+        return system.isatty(handle) != 0;
+    }
     if (builtin.os.tag == .wasi) {
         var statbuf: fdstat_t = undefined;
         const err = system.fd_fdstat_get(handle, &statbuf);

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2553,9 +2553,6 @@ pub fn isatty(handle: fd_t) bool {
         var out: windows.DWORD = undefined;
         return windows.kernel32.GetConsoleMode(handle, &out) != 0;
     }
-    if (builtin.link_libc) {
-        return system.isatty(handle) != 0;
-    }
     if (builtin.os.tag == .wasi) {
         var statbuf: fdstat_t = undefined;
         const err = system.fd_fdstat_get(handle, &statbuf);
@@ -2585,7 +2582,7 @@ pub fn isatty(handle: fd_t) bool {
             }
         }
     }
-    unreachable;
+    return system.isatty(handle) != 0;
 }
 
 pub fn isCygwinPty(handle: fd_t) bool {


### PR DESCRIPTION
This patch removes an `unreachable;` statement in case of a custom OS and replaces it with the `system.isatty(fd);` call. It also eliminates the C-library condition, since it would be redundant code.