### PR TITLE
std/crypto/25519: do cofactored ed25519 verification

### DIFF
--- a/lib/std/crypto/25519/curve25519.zig
+++ b/lib/std/crypto/25519/curve25519.zig
@@ -39,6 +39,11 @@ pub const Curve25519 = struct {
         }
     }
 
+    /// Multiply a point by the cofactor
+    pub fn clearCofactor(p: Edwards25519) Edwards25519 {
+        return p.dbl().dbl().dbl();
+    }
+
     fn ladder(p: Curve25519, s: [32]u8, comptime bits: usize) !Curve25519 {
         var x1 = p.x;
         var x2 = Fe.one;


### PR DESCRIPTION
This is slightly slower but makes our verification function compatible with batch signatures. Which, in turn, makes blockchain people happy.

And we want to make our users happy.

Add convenience functions to substract edwards25519 points and to clear the cofactor.