### PR TITLE
replaced inStream() with reader() in std.ChildProcess

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -210,8 +210,8 @@ pub const ChildProcess = struct {
 
         try child.spawn();
 
-        const stdout_in = child.stdout.?.inStream();
-        const stderr_in = child.stderr.?.inStream();
+        const stdout_in = child.stdout.?.reader();
+        const stderr_in = child.stderr.?.reader();
 
         // TODO https://github.com/ziglang/zig/issues/6343
         const stdout = try stdout_in.readAllAlloc(args.allocator, args.max_output_bytes);
@@ -843,7 +843,7 @@ fn readIntFd(fd: i32) !ErrInt {
         .capable_io_mode = .blocking,
         .intended_io_mode = .blocking,
     };
-    return @intCast(ErrInt, file.inStream().readIntNative(u64) catch return error.SystemResources);
+    return @intCast(ErrInt, file.reader().readIntNative(u64) catch return error.SystemResources);
 }
 
 /// Caller must free result.


### PR DESCRIPTION
Nothing special. Just `inStream()` is now deprecated and deserves replacing. If I recall, this is a transparent change and should no longer conflict.