### PR TITLE
Fix 6692

### DIFF
--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -32,6 +32,37 @@ if(ZIG_PREFER_CLANG_CPP_DYLIB)
       /usr/local/llvm11/lib
       /usr/local/llvm110/lib
   )
+
+  find_program(LLVM_CONFIG_EXE
+      NAMES llvm-config-11 llvm-config-11.0 llvm-config110 llvm-config11 llvm-config
+      PATHS
+          "/mingw64/bin"
+          "/c/msys64/mingw64/bin"
+          "c:/msys64/mingw64/bin"
+          "C:/Libraries/llvm-11.0.0/bin")
+
+  if ("${LLVM_CONFIG_EXE}" STREQUAL "LLVM_CONFIG_EXE-NOTFOUND")
+    message(FATAL_ERROR "unable to find llvm-config")
+  endif()
+
+  if ("${LLVM_CONFIG_EXE}" STREQUAL "LLVM_CONFIG_EXE-NOTFOUND")
+    message(FATAL_ERROR "unable to find llvm-config")
+  endif()
+
+  execute_process(
+    COMMAND ${LLVM_CONFIG_EXE} --version
+    OUTPUT_VARIABLE LLVM_CONFIG_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if("${LLVM_CONFIG_VERSION}" VERSION_LESS 11)
+    message(FATAL_ERROR "expected LLVM 11.x but found ${LLVM_CONFIG_VERSION} using ${LLVM_CONFIG_EXE}")
+  endif()
+  if("${LLVM_CONFIG_VERSION}" VERSION_EQUAL 12)
+    message(FATAL_ERROR "expected LLVM 11.x but found ${LLVM_CONFIG_VERSION} using ${LLVM_CONFIG_EXE}")
+  endif()
+  if("${LLVM_CONFIG_VERSION}" VERSION_GREATER 11)
+    message(FATAL_ERROR "expected LLVM 11.x but found ${LLVM_CONFIG_VERSION} using ${LLVM_CONFIG_EXE}")
+  endif()
 elseif(("${ZIG_TARGET_TRIPLE}" STREQUAL "native") OR ZIG_PREFER_LLVM_CONFIG)
   find_program(LLVM_CONFIG_EXE
       NAMES llvm-config-11 llvm-config-11.0 llvm-config110 llvm-config11 llvm-config

--- a/src/main.zig
+++ b/src/main.zig
@@ -934,7 +934,7 @@ fn buildOutputType(
                         });
                     },
                     .shared_library => {
-                        fatal("linking against dynamic libraries not yet supported", .{});
+                        try link_objects.append(arg);
                     },
                     .zig, .zir => {
                         if (root_src_file) |other| {


### PR DESCRIPTION
Fixes #6692 

In addition to missing adding dynamic libraries in main CLI, we were also missing detecting `llvm-config` path in CMakeLists when linking with clang dynamically. This patch adds both, however, not sure if this should be refactored further in `Findllvm.cmake` or not.