### PR TITLE
stage1: Fix type-checking of unary neg for vector types

### DIFF
--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -2653,7 +2653,6 @@ enum IrInstGenId {
     IrInstGenIdPhi,
     IrInstGenIdBinaryNot,
     IrInstGenIdNegation,
-    IrInstGenIdNegationWrapping,
     IrInstGenIdBinOp,
     IrInstGenIdLoadPtr,
     IrInstGenIdStorePtr,
@@ -2932,11 +2931,7 @@ struct IrInstGenBinaryNot {
 struct IrInstGenNegation {
     IrInstGen base;
     IrInstGen *operand;
-};
-
-struct IrInstGenNegationWrapping {
-    IrInstGen base;
-    IrInstGen *operand;
+    bool wrapping;
 };
 
 enum IrBinOp {

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -3564,13 +3564,7 @@ static LLVMValueRef ir_gen_negation(CodeGen *g, IrInstGen *inst, IrInstGen *oper
 static LLVMValueRef ir_render_negation(CodeGen *g, IrExecutableGen *executable,
         IrInstGenNegation *inst)
 {
-    return ir_gen_negation(g, &inst->base, inst->operand, false);
-}
-
-static LLVMValueRef ir_render_negation_wrapping(CodeGen *g, IrExecutableGen *executable,
-        IrInstGenNegationWrapping *inst)
-{
-    return ir_gen_negation(g, &inst->base, inst->operand, true);
+    return ir_gen_negation(g, &inst->base, inst->operand, inst->wrapping);
 }
 
 static LLVMValueRef ir_render_bool_not(CodeGen *g, IrExecutableGen *executable, IrInstGenBoolNot *instruction) {
@@ -6645,8 +6639,6 @@ static LLVMValueRef ir_render_instruction(CodeGen *g, IrExecutableGen *executabl
             return ir_render_binary_not(g, executable, (IrInstGenBinaryNot *)instruction);
         case IrInstGenIdNegation:
             return ir_render_negation(g, executable, (IrInstGenNegation *)instruction);
-        case IrInstGenIdNegationWrapping:
-            return ir_render_negation_wrapping(g, executable, (IrInstGenNegationWrapping *)instruction);
         case IrInstGenIdLoadPtr:
             return ir_render_load_ptr(g, executable, (IrInstGenLoadPtr *)instruction);
         case IrInstGenIdStorePtr:

--- a/src/stage1/ir_print.cpp
+++ b/src/stage1/ir_print.cpp
@@ -540,8 +540,6 @@ const char* ir_inst_gen_type_str(IrInstGenId id) {
             return "GenBinaryNot";
         case IrInstGenIdNegation:
             return "GenNegation";
-        case IrInstGenIdNegationWrapping:
-            return "GenNegationWrapping";
         case IrInstGenIdWasmMemorySize:
             return "GenWasmMemorySize";
         case IrInstGenIdWasmMemoryGrow:
@@ -1144,15 +1142,9 @@ static void ir_print_binary_not(IrPrintGen *irp, IrInstGenBinaryNot *instruction
 }
 
 static void ir_print_negation(IrPrintGen *irp, IrInstGenNegation *instruction) {
-    fprintf(irp->f, "-");
+    fprintf(irp->f, instruction->wrapping ? "-%%" : "-");
     ir_print_other_inst_gen(irp, instruction->operand);
 }
-
-static void ir_print_negation_wrapping(IrPrintGen *irp, IrInstGenNegationWrapping *instruction) {
-    fprintf(irp->f, "-%%");
-    ir_print_other_inst_gen(irp, instruction->operand);
-}
-
 
 static void ir_print_field_ptr(IrPrintSrc *irp, IrInstSrcFieldPtr *instruction) {
     if (instruction->field_name_buffer) {
@@ -3293,9 +3285,6 @@ static void ir_print_inst_gen(IrPrintGen *irp, IrInstGen *instruction, bool trai
             break;
         case IrInstGenIdNegation:
             ir_print_negation(irp, (IrInstGenNegation *)instruction);
-            break;
-        case IrInstGenIdNegationWrapping:
-            ir_print_negation_wrapping(irp, (IrInstGenNegationWrapping *)instruction);
             break;
         case IrInstGenIdWasmMemorySize:
             ir_print_wasm_memory_size(irp, (IrInstGenWasmMemorySize *)instruction);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -8172,14 +8172,19 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     , &[_][]const u8{
         "tmp.zig:2:9: error: @wasmMemoryGrow is a wasm32 feature only",
     });
-
     cases.add("Issue #5586: Make unary minus for unsigned types a compile error",
-        \\export fn f(x: u32) u32 {
+        \\export fn f1(x: u32) u32 {
+        \\    const y = -%x;
+        \\    return -y;
+        \\}
+        \\const V = @import("std").meta.Vector;
+        \\export fn f2(x: V(4, u32)) V(4, u32) {
         \\    const y = -%x;
         \\    return -y;
         \\}
     , &[_][]const u8{
         "tmp.zig:3:12: error: negation of type 'u32'",
+        "tmp.zig:8:12: error: negation of type 'u32'",
     });
 
     cases.add("Issue #5618: coercion of ?*c_void to *c_void must fail.",


### PR DESCRIPTION
Validate the vector element type as done for the scalar case.

Fixes #6708