### PR TITLE
std: Implement featureSetHasAny/featureSetHasAll

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -637,8 +637,27 @@ pub const Target = struct {
                         return x;
                     }
 
+                    /// Returns true if the specified feature is enabled.
                     pub fn featureSetHas(set: Set, feature: F) bool {
                         return set.isEnabled(@enumToInt(feature));
+                    }
+
+                    /// Returns true if any specified feature is enabled.
+                    pub fn featureSetHasAny(set: Set, features: anytype) bool {
+                        comptime std.debug.assert(std.meta.trait.isIndexable(@TypeOf(features)));
+                        inline for (features) |feature| {
+                            if (set.isEnabled(@enumToInt(@as(F, feature)))) return true;
+                        }
+                        return false;
+                    }
+
+                    /// Returns true if every specified feature is enabled.
+                    pub fn featureSetHasAll(set: Set, features: anytype) bool {
+                        comptime std.debug.assert(std.meta.trait.isIndexable(@TypeOf(features)));
+                        inline for (features) |feature| {
+                            if (!set.isEnabled(@enumToInt(@as(F, feature)))) return false;
+                        }
+                        return true;
                     }
                 };
             }

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -823,6 +823,11 @@ test "CrossTarget.parse" {
         std.testing.expect(Target.x86.featureSetHas(target.cpu.features, .cmov));
         std.testing.expect(Target.x86.featureSetHas(target.cpu.features, .fxsr));
 
+        std.testing.expect(Target.x86.featureSetHasAny(target.cpu.features, .{ .sse, .avx, .cmov }));
+        std.testing.expect(!Target.x86.featureSetHasAny(target.cpu.features, .{ .sse, .avx }));
+        std.testing.expect(Target.x86.featureSetHasAll(target.cpu.features, .{ .mmx, .x87 }));
+        std.testing.expect(!Target.x86.featureSetHasAll(target.cpu.features, .{ .mmx, .x87, .sse }));
+
         const text = try cross_target.zigTriple(std.testing.allocator);
         defer std.testing.allocator.free(text);
         std.testing.expectEqualSlices(u8, "x86_64-linux-gnu", text);


### PR DESCRIPTION
Introduce two helper functions to avoid writing short novels only to check for more
than a single feature.