### PR TITLE
stage1: Implement `@intCast` between vectors

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -1251,7 +1251,7 @@ fn genHtml(allocator: *mem.Allocator, tokenizer: *Tokenizer, toc: *Toc, out: any
                             },
                         }
                         if (mem.indexOf(u8, result.stderr, error_match) == null) {
-                            print("{}\nExpected to find '{}' in stderr", .{ result.stderr, error_match });
+                            print("{}\nExpected to find '{}' in stderr\n", .{ result.stderr, error_match });
                             return parseError(tokenizer, code.source_token, "example did not have expected compile error", .{});
                         }
                         const escaped_stderr = try escapeHtml(allocator, result.stderr);
@@ -1306,7 +1306,7 @@ fn genHtml(allocator: *mem.Allocator, tokenizer: *Tokenizer, toc: *Toc, out: any
                             },
                         }
                         if (mem.indexOf(u8, result.stderr, error_match) == null) {
-                            print("{}\nExpected to find '{}' in stderr", .{ result.stderr, error_match });
+                            print("{}\nExpected to find '{}' in stderr\n", .{ result.stderr, error_match });
                             return parseError(tokenizer, code.source_token, "example did not have expected runtime safety error message", .{});
                         }
                         const escaped_stderr = try escapeHtml(allocator, result.stderr);
@@ -1385,7 +1385,7 @@ fn genHtml(allocator: *mem.Allocator, tokenizer: *Tokenizer, toc: *Toc, out: any
                                 },
                             }
                             if (mem.indexOf(u8, result.stderr, error_match) == null) {
-                                print("{}\nExpected to find '{}' in stderr", .{ result.stderr, error_match });
+                                print("{}\nExpected to find '{}' in stderr\n", .{ result.stderr, error_match });
                                 return parseError(tokenizer, code.source_token, "example did not have expected compile error message", .{});
                             }
                             const escaped_stderr = try escapeHtml(allocator, result.stderr);

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8713,7 +8713,7 @@ fn foo(x: []const u8) u8 {
       {#header_close#}
       {#header_open|Cast Negative Number to Unsigned Integer#}
       <p>At compile-time:</p>
-      {#code_begin|test_err|cannot cast negative value -1 to unsigned integer type 'u32'#}
+      {#code_begin|test_err|attempt to cast negative value to unsigned integer#}
 comptime {
     const value: i32 = -1;
     const unsigned = @intCast(u32, value);
@@ -8735,7 +8735,7 @@ pub fn main() void {
       {#header_close#}
       {#header_open|Cast Truncates Data#}
       <p>At compile-time:</p>
-      {#code_begin|test_err|integer value 300 cannot be coerced to type 'u8'#}
+      {#code_begin|test_err|cast from 'u16' to 'u8' truncates bits#}
 comptime {
     const spartan_count: u16 = 300;
     const byte = @intCast(u8, spartan_count);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2944,7 +2944,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:4:18: error: expected type 'fn(i32) void', found 'fn(bool) void",
         "tmp.zig:4:18: note: parameter 0: 'bool' cannot cast into 'i32'",
     });
-
     cases.add("cast negative value to unsigned integer",
         \\comptime {
         \\    const value: i32 = -1;
@@ -2955,7 +2954,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    const unsigned: u32 = value;
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:36: error: cannot cast negative value -1 to unsigned integer type 'u32'",
+        "tmp.zig:3:22: error: attempt to cast negative value to unsigned integer",
         "tmp.zig:7:27: error: cannot cast negative value -1 to unsigned integer type 'u32'",
     });
 
@@ -2977,7 +2976,7 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    var unsigned: u64 = signed;
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:31: error: integer value 300 cannot be coerced to type 'u8'",
+        "tmp.zig:3:18: error: cast from 'u16' to 'u8' truncates bits",
         "tmp.zig:7:22: error: integer value 300 cannot be coerced to type 'u8'",
         "tmp.zig:11:20: error: expected type 'u8', found 'u16'",
         "tmp.zig:11:20: note: unsigned 8-bit int cannot represent all possible unsigned 16-bit values",

--- a/test/runtime_safety.zig
+++ b/test/runtime_safety.zig
@@ -70,6 +70,36 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         );
     }
 
+    cases.addRuntimeSafety("truncating vector cast",
+        \\const std = @import("std");
+        \\const V = @import("std").meta.Vector;
+        \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
+        \\    if (std.mem.eql(u8, message, "integer cast truncated bits")) {
+        \\        std.process.exit(126); // good
+        \\    }
+        \\    std.process.exit(0); // test failed
+        \\}
+        \\pub fn main() void {
+        \\    var x = @splat(4, @as(u32, 0xdeadbeef));
+        \\    var y = @intCast(V(4, u16), x);
+        \\}
+    );
+
+    cases.addRuntimeSafety("unsigned-signed vector cast",
+        \\const std = @import("std");
+        \\const V = @import("std").meta.Vector;
+        \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
+        \\    if (std.mem.eql(u8, message, "attempt to cast negative value to unsigned integer")) {
+        \\        std.process.exit(126); // good
+        \\    }
+        \\    std.process.exit(0); // test failed
+        \\}
+        \\pub fn main() void {
+        \\    var x = @splat(4, @as(u32, 0x80000000));
+        \\    var y = @intCast(V(4, i32), x);
+        \\}
+    );
+
     cases.addRuntimeSafety("shift left by huge amount",
         \\const std = @import("std");
         \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {


### PR DESCRIPTION
Explicit and implicit integer casts on vector types are now supported
and follow the same rules as their scalar counterparts.

Implicit float casts are accidentally supported, `@floatCast` is still
not vector-aware.