### PR TITLE
When checking a cache hit, make sure to handle a (re)moved source file

### DIFF
--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -315,8 +315,9 @@ pub const Manifest = struct {
                 cache_hash_file.path = try self.cache.gpa.dupe(u8, file_path);
             }
 
-            const this_file = fs.cwd().openFile(cache_hash_file.path.?, .{ .read = true }) catch {
-                return error.CacheUnavailable;
+            const this_file = fs.cwd().openFile(cache_hash_file.path.?, .{ .read = true }) catch |err| switch (err) {
+                error.FileNotFound => return false,
+                else => return error.CacheUnavailable,
             };
             defer this_file.close();
 


### PR DESCRIPTION
When a file cannot be found in the cache, it is not a hit.

Closes #6729