### PR TITLE
fs.Path: add a parent function that returns null when the root is reached

### DIFF
--- a/src/introspect.zig
+++ b/src/introspect.zig
@@ -46,7 +46,7 @@ pub fn findZigLibDirFromSelfExe(
 ) error{ OutOfMemory, FileNotFound }!Compilation.Directory {
     const cwd = fs.cwd();
     var cur_path: []const u8 = self_exe_path;
-    while (fs.path.dirname(cur_path)) |dirname| : (cur_path = dirname) {
+    while (fs.path.parent(cur_path)) |dirname| : (cur_path = dirname) {
         var base_dir = cwd.openDir(dirname, .{}) catch continue;
         defer base_dir.close();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -2253,7 +2253,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
                     break :blk .{ .path = dirname, .handle = dir };
                 } else |err| switch (err) {
                     error.FileNotFound => {
-                        dirname = fs.path.dirname(dirname) orelse {
+                        dirname = fs.path.parent(dirname) orelse {
                             std.log.info("{}", .{
                                 \\Initialize a 'build.zig' template file with `zig init-lib` or `zig init-exe`,
                                 \\or see `zig --help` for more options.


### PR DESCRIPTION
When calling dirname in a loop, it's pretty easy to forget that you have
to check for a root directory. So this adds an API that forces the check.

Closes #6727, #6584, #6592, #6602.