### PR TITLE
panic when empty string passed as dest_rel_path to addInstallFileWithDir

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -907,6 +907,9 @@ pub const Builder = struct {
         install_dir: InstallDir,
         dest_rel_path: []const u8,
     ) *InstallFileStep {
+        if (dest_rel_path.len == 0) {
+            panic("dest_rel_path must be non-empty", .{});
+        }
         const install_step = self.allocator.create(InstallFileStep) catch unreachable;
         install_step.* = InstallFileStep.init(self, src_path, install_dir, dest_rel_path);
         return install_step;


### PR DESCRIPTION
closes #6586 

Not sure if this is all this entails, but it seemed easy so thought I'd take a stab at it.