### PR TITLE
Change --enable-valgrind flag to -fvalgrind in std/build.zig

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2286,9 +2286,9 @@ pub const LibExeObjStep = struct {
 
         if (self.valgrind_support) |valgrind_support| {
             if (valgrind_support) {
-                try zig_args.append("--enable-valgrind");
+                try zig_args.append("-fvalgrind");
             } else {
-                try zig_args.append("--disable-valgrind");
+                try zig_args.append("-fno-valgrind");
             }
         }
 


### PR DESCRIPTION
I'm not sure in what commit the `--enable-valgrind` flag was removed but it is now `-fvalgrind` as of (https://github.com/ziglang/zig/commit/03a23418ff13e6ff64cdeed3ef4b54f99c533d88)

Otherwise I get:

```bash
$ zig build
error: unrecognized parameter: '--enable-valgrind'
zhttpd...The following command exited with error code 1:
workspace/zig/build/bin/zig build-exe workspace/zig-zhp/src/main.zig --cache-dir workspace/zig-zhp/zig-cache --name zhttpd --pkg-begin zhp workspace/zig-zhp/lib/zhp/zhp.zig --pkg-end --enable-valgrind --enable-cache 
error: the following build command failed with exit code 1:
workspace/zig-zhp/zig-cache/o/ba3f7704f9d6f38e57085ca8fba85aa6/build workspace/zig/build/bin/zig workspace/zig-zhp workspace/zig-zhp/zig-cache
```