### PR TITLE
Add missing build docs on Windows

### DIFF
--- a/ci/azure/windows_msvc_script.bat
+++ b/ci/azure/windows_msvc_script.bat
@@ -24,19 +24,20 @@ cd %ZIGBUILDDIR%
 cmake.exe .. -Thost=x64 -G"Visual Studio 16 2019" -A x64 "-DCMAKE_INSTALL_PREFIX=%ZIGINSTALLDIR%" "-DCMAKE_PREFIX_PATH=%ZIGPREFIXPATH%" -DCMAKE_BUILD_TYPE=Release || exit /b
 msbuild /maxcpucount /p:Configuration=Release INSTALL.vcxproj || exit /b
 
+"%ZIGINSTALLDIR%\bin\zig.exe" build test-fmt || exit /b
 "%ZIGINSTALLDIR%\bin\zig.exe" build test-behavior -Dskip-non-native || exit /b
 "%ZIGINSTALLDIR%\bin\zig.exe" build test-stage2 -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-fmt -Dskip-non-native || exit /b
 "%ZIGINSTALLDIR%\bin\zig.exe" build test-std -Dskip-non-native || exit /b
 "%ZIGINSTALLDIR%\bin\zig.exe" build test-compiler-rt -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-compare-output -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-standalone -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-stack-traces -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-cli -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-asm-link -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-runtime-safety -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-translate-c -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-run-translated-c -Dskip-non-native || exit /b
+"%ZIGINSTALLDIR%\bin\zig.exe" build test-compare-output || exit /b
+"%ZIGINSTALLDIR%\bin\zig.exe" build test-standalone || exit /b
+"%ZIGINSTALLDIR%\bin\zig.exe" build test-stack-traces || exit /b
+"%ZIGINSTALLDIR%\bin\zig.exe" build test-cli || exit /b
+"%ZIGINSTALLDIR%\bin\zig.exe" build test-asm-link || exit /b
+"%ZIGINSTALLDIR%\bin\zig.exe" build test-runtime-safety || exit /b
+"%ZIGINSTALLDIR%\bin\zig.exe" build test-translate-c || exit /b
+"%ZIGINSTALLDIR%\bin\zig.exe" build test-run-translated-c || exit /b
+"%ZIGINSTALLDIR%\bin\zig.exe" build docs || exit /b
 
 set "PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem"
 SET "MSYSTEM=MINGW64"


### PR DESCRIPTION
Also, remove obsolete `-Dskip-non-native` in tests which don't require it.