### PR TITLE
Fix Compiler Error When Using wWinMain Entry-Point

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -170,7 +170,8 @@ fn wWinMainCRTStartup() callconv(.Stdcall) noreturn {
 
     std.debug.maybeEnableSegfaultHandler();
 
-    std.os.windows.kernel32.ExitProcess(initEventLoopAndCallWinMain());
+    const result: std.os.windows.INT = initEventLoopAndCallWinMain();
+    std.os.windows.kernel32.ExitProcess(@bitCast(std.os.windows.UINT, result));
 }
 
 // TODO https://github.com/ziglang/zig/issues/265


### PR DESCRIPTION
The fix for #6715 introduced a new compiler error when attempting to use wWinMain as the application entry-point.

The Windows API often relies on implicit casts between signed and unsigned values. In this case, wWinMain returns an INT despite the fact this value is intended to feed into ExitProcess, which expects a UINT, so I've restored the bitcast from #5613.