### PR TITLE
Fix a typo (s/multple/multiple/)

### DIFF
--- a/lib/std/crypto/aes/aesni.zig
+++ b/lib/std/crypto/aes/aesni.zig
@@ -123,7 +123,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Encrypt multple blocks in parallel with the same round key.
+        /// Encrypt multiple blocks in parallel with the same round key.
         pub inline fn encryptWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             comptime var i = 0;
             var out: [count]Block = undefined;
@@ -133,7 +133,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Decrypt multple blocks in parallel with the same round key.
+        /// Decrypt multiple blocks in parallel with the same round key.
         pub inline fn decryptWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             comptime var i = 0;
             var out: [count]Block = undefined;
@@ -143,7 +143,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Encrypt multple blocks in parallel with the same last round key.
+        /// Encrypt multiple blocks in parallel with the same last round key.
         pub inline fn encryptLastWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             comptime var i = 0;
             var out: [count]Block = undefined;
@@ -153,7 +153,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Decrypt multple blocks in parallel with the same last round key.
+        /// Decrypt multiple blocks in parallel with the same last round key.
         pub inline fn decryptLastWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             comptime var i = 0;
             var out: [count]Block = undefined;

--- a/lib/std/crypto/aes/armcrypto.zig
+++ b/lib/std/crypto/aes/armcrypto.zig
@@ -139,7 +139,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Encrypt multple blocks in parallel with the same round key.
+        /// Encrypt multiple blocks in parallel with the same round key.
         pub inline fn encryptWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             comptime var i = 0;
             var out: [count]Block = undefined;
@@ -149,7 +149,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Decrypt multple blocks in parallel with the same round key.
+        /// Decrypt multiple blocks in parallel with the same round key.
         pub inline fn decryptWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             comptime var i = 0;
             var out: [count]Block = undefined;
@@ -159,7 +159,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Encrypt multple blocks in parallel with the same last round key.
+        /// Encrypt multiple blocks in parallel with the same last round key.
         pub inline fn encryptLastWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             comptime var i = 0;
             var out: [count]Block = undefined;
@@ -169,7 +169,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Decrypt multple blocks in parallel with the same last round key.
+        /// Decrypt multiple blocks in parallel with the same last round key.
         pub inline fn decryptLastWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             comptime var i = 0;
             var out: [count]Block = undefined;

--- a/lib/std/crypto/aes/soft.zig
+++ b/lib/std/crypto/aes/soft.zig
@@ -180,7 +180,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Encrypt multple blocks in parallel with the same round key.
+        /// Encrypt multiple blocks in parallel with the same round key.
         pub fn encryptWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             var i = 0;
             var out: [count]Block = undefined;
@@ -190,7 +190,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Decrypt multple blocks in parallel with the same round key.
+        /// Decrypt multiple blocks in parallel with the same round key.
         pub fn decryptWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             var i = 0;
             var out: [count]Block = undefined;
@@ -200,7 +200,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Encrypt multple blocks in parallel with the same last round key.
+        /// Encrypt multiple blocks in parallel with the same last round key.
         pub fn encryptLastWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             var i = 0;
             var out: [count]Block = undefined;
@@ -210,7 +210,7 @@ pub const Block = struct {
             return out;
         }
 
-        /// Decrypt multple blocks in parallel with the same last round key.
+        /// Decrypt multiple blocks in parallel with the same last round key.
         pub fn decryptLastWide(comptime count: usize, blocks: [count]Block, round_key: Block) [count]Block {
             var i = 0;
             var out: [count]Block = undefined;


### PR DESCRIPTION
Just fixes a typo, blindly copypasted a couple times.
