### PR TITLE
openbsd: make dl_phdr_info cross arches

### DIFF
--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -937,6 +937,16 @@ pub const Verdaux = switch (@sizeOf(usize)) {
     8 => Elf64_Verdaux,
     else => @compileError("expected pointer size of 32 or 64"),
 };
+pub const Addr = switch (@sizeOf(usize)) {
+    4 => Elf32_Addr,
+    8 => Elf64_Addr,
+    else => @compileError("expected pointer size of 32 or 64"),
+};
+pub const Half = switch (@sizeOf(usize)) {
+    4 => Elf32_Half,
+    8 => Elf64_Half,
+    else => @compileError("expected pointer size of 32 or 64"),
+};
 
 /// Machine architectures
 /// See current registered ELF machine architectures at:

--- a/lib/std/os/bits/openbsd.zig
+++ b/lib/std/os/bits/openbsd.zig
@@ -33,10 +33,10 @@ pub const Kevent = extern struct {
 };
 
 pub const dl_phdr_info = extern struct {
-    dlpi_addr: usize,
+    dlpi_addr: std.elf.Addr,
     dlpi_name: ?[*:0]const u8,
     dlpi_phdr: [*]std.elf.Phdr,
-    dlpi_phnum: u16,
+    dlpi_phnum: std.elf.Half,
 };
 
 pub const Flock = extern struct {


### PR DESCRIPTION
it should make `dl_phdr_info` on OpenBSD to be correctly defined on all arches (64 or 32 bits).