### PR TITLE
stage1: Fix crash in comptime struct value copy

### DIFF
--- a/test/stage1/behavior/tuple.zig
+++ b/test/stage1/behavior/tuple.zig
@@ -93,3 +93,21 @@ test "pass tuple to comptime var parameter" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "tuple initializer for var" {
+    const S = struct {
+        fn doTheTest() void {
+            const Bytes = struct {
+                id: usize,
+            };
+
+            var tmp = .{
+                .id = @as(usize, 2),
+                .name = Bytes{ .id = 20 },
+            };
+        }
+    };
+
+    S.doTheTest();
+    comptime S.doTheTest();
+}


### PR DESCRIPTION
Comptime fields are never materialized in the ZigValue so pay attention
when iterating over the fields array.

Fixes #6800

I expect other bugs like this in several other parts of the compiler that are oblivious to the `is_comptime` fields.