### PR TITLE
std/crypto/x25519: return encoded points directly + ed->mont map

### DIFF
--- a/lib/std/crypto/25519/curve25519.zig
+++ b/lib/std/crypto/25519/curve25519.zig
@@ -100,6 +100,14 @@ pub const Curve25519 = struct {
         _ = ladder(p, cofactor, 4) catch |_| return error.WeakPublicKey;
         return try ladder(p, s, 256);
     }
+
+    /// Compute the Curve25519 equivalent to an Edwards25519 point.
+    pub fn fromEdwards25519(p: std.crypto.ecc.Edwards25519) !Curve25519 {
+        try p.clearCofactor().rejectIdentity();
+        const one = std.crypto.ecc.Edwards25519.Fe.one;
+        const x = one.add(p.y).mul(one.sub(p.y).invert()); // xMont=(1+yEd)/(1-yEd)
+        return Curve25519{ .x = x };
+    }
 };
 
 test "curve25519" {

--- a/lib/std/crypto/25519/edwards25519.zig
+++ b/lib/std/crypto/25519/edwards25519.zig
@@ -12,6 +12,8 @@ pub const Edwards25519 = struct {
     pub const Fe = @import("field.zig").Fe;
     /// Field arithmetic mod the order of the main subgroup.
     pub const scalar = @import("scalar.zig");
+    /// Length in bytes of a compressed representation of a point.
+    pub const encoded_length: usize = 32;
 
     x: Fe,
     y: Fe,
@@ -21,7 +23,7 @@ pub const Edwards25519 = struct {
     is_base: bool = false,
 
     /// Decode an Edwards25519 point from its compressed (Y+sign) coordinates.
-    pub fn fromBytes(s: [32]u8) !Edwards25519 {
+    pub fn fromBytes(s: [encoded_length]u8) !Edwards25519 {
         const z = Fe.one;
         const y = Fe.fromBytes(s);
         var u = y.sq();
@@ -43,7 +45,7 @@ pub const Edwards25519 = struct {
     }
 
     /// Encode an Edwards25519 point.
-    pub fn toBytes(p: Edwards25519) [32]u8 {
+    pub fn toBytes(p: Edwards25519) [encoded_length]u8 {
         const zi = p.z.invert();
         var s = p.y.mul(zi).toBytes();
         s[31] ^= @as(u8, @boolToInt(p.x.mul(zi).isNegative())) << 7;

--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -98,18 +98,20 @@ const exchanges = [_]Crypto{Crypto{ .ty = crypto.dh.X25519, .name = "x25519" }};
 pub fn benchmarkKeyExchange(comptime DhKeyExchange: anytype, comptime exchange_count: comptime_int) !u64 {
     std.debug.assert(DhKeyExchange.shared_length >= DhKeyExchange.secret_length);
 
-    var in: [DhKeyExchange.shared_length]u8 = undefined;
-    prng.random.bytes(in[0..]);
+    var secret: [DhKeyExchange.shared_length]u8 = undefined;
+    prng.random.bytes(secret[0..]);
 
-    var out: [DhKeyExchange.shared_length]u8 = undefined;
-    prng.random.bytes(out[0..]);
+    var public: [DhKeyExchange.shared_length]u8 = undefined;
+    prng.random.bytes(public[0..]);
 
     var timer = try Timer.start();
     const start = timer.lap();
     {
         var i: usize = 0;
         while (i < exchange_count) : (i += 1) {
-            try DhKeyExchange.scalarmult(&out, out, in);
+            const out = try DhKeyExchange.scalarmult(secret, public);
+            mem.copy(u8, secret[0..16], out[0..16]);
+            mem.copy(u8, public[0..16], out[16..32]);
             mem.doNotOptimizeAway(&out);
         }
     }

--- a/lib/std/crypto/salsa20.zig
+++ b/lib/std/crypto/salsa20.zig
@@ -314,8 +314,7 @@ pub const Box = struct {
 
     /// Compute a secret suitable for `secretbox` given a recipent's public key and a sender's secret key.
     pub fn createSharedSecret(public_key: [public_length]u8, secret_key: [secret_length]u8) ![shared_length]u8 {
-        var p: [32]u8 = undefined;
-        try X25519.scalarmult(&p, secret_key, public_key);
+        const p = try X25519.scalarmult(secret_key, public_key);
         const zero = [_]u8{0} ** 16;
         return Salsa20Impl.hsalsa20(zero, p);
     }


### PR DESCRIPTION
Leverage result location semantics for X25519 like we do everywhere else in `25519/*`

Also add the edwards25519->curve25519 map by the way since many applications seem to use this to share the same key pair for encryption and signature.