### PR TITLE
Fix @import of empty file

### DIFF
--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -1988,7 +1988,7 @@ static ZigType *analyze_fn_type(CodeGen *g, AstNode *proto_node, Scope *child_sc
             // behaviour when checking expected alignment with `@ptrToInt(fn_ptr)`
             // or similar. This commit proposes to make `align` expressions a
             // compile error when compiled to Wasm architecture.
-            // 
+            //
             // Some references:
             // [1] [Mozilla: WebAssembly Tables](https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format#WebAssembly_tables)
             // [2] [Sunfishcode's Wasm Ref Manual](https://github.com/sunfishcode/wasm-reference-manual/blob/master/WebAssembly.md#indirect-call)
@@ -8052,10 +8052,13 @@ not_integer:
 }
 
 Error file_fetch(CodeGen *g, Buf *resolved_path, Buf *contents_buf) {
-    size_t len;
+    size_t len = 0xAA;
     const char *contents = stage2_fetch_file(&g->stage1, buf_ptr(resolved_path), buf_len(resolved_path), &len);
-    if (contents == nullptr)
+    if (len == 0) {
+        // File exists but is empty (otherwise it would be 0xAA)
+    } else if (contents == nullptr) {
         return ErrorFileNotFound;
+    }
     buf_init_from_mem(contents_buf, contents, len);
     return ErrorNone;
 }
@@ -9044,7 +9047,7 @@ static void resolve_llvm_types_optional(CodeGen *g, ZigType *type, ResolveStatus
                 8 * child_type->abi_align,
                 val_offset_in_bits,
                 ZigLLVM_DIFlags_Zero, child_llvm_di_type);
-    di_element_types[maybe_null_index] = 
+    di_element_types[maybe_null_index] =
         ZigLLVMCreateDebugMemberType(g->dbuilder, ZigLLVMTypeToScope(type->llvm_di_type),
                 "maybe", di_file, line,
                 8*g->builtin_types.entry_bool->abi_size,

--- a/test/stage1/behavior/import.zig
+++ b/test/stage1/behavior/import.zig
@@ -16,3 +16,7 @@ test "import in non-toplevel scope" {
     };
     expectEqual(@as(i32, 1234), S.foo());
 }
+
+test "import empty file" {
+    const empty = @import("import/empty.zig");
+}


### PR DESCRIPTION
For #6790

Uses a bit of a hack... 

If the file does not exist it returns nullptr before updating the length so by setting the initial len to an arbitrary value of 0xAA then checking if it is changed to 0 then the file exists but is empty.  