### PR TITLE
Fix evented-io compile error about NetworkSubsystemFailed

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -466,6 +466,7 @@ pub const Loop = struct {
                         .revents = undefined,
                     }};
                     _ = os.poll(&pfd, -1) catch |poll_err| switch (poll_err) {
+                        error.NetworkSubsystemFailed,
                         error.SystemResources,
                         error.Unexpected,
                         => {


### PR DESCRIPTION
This was triggered by 127fa80 in #6237.

Closes #6794.