### PR TITLE
linuxWaitFd: make NetworkSubsystemFailed error unreachable

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -466,8 +466,9 @@ pub const Loop = struct {
                         .revents = undefined,
                     }};
                     _ = os.poll(&pfd, -1) catch |poll_err| switch (poll_err) {
+                        error.NetworkSubsystemFailed => unreachable, // only possible on windows
+
                         error.SystemResources,
-                        error.NetworkSubsystemFailed,
                         error.Unexpected,
                         => {
                             // Even poll() didn't work. The best we can do now is sleep for a


### PR DESCRIPTION
This error from os.poll is Windows-specific, so unreachable on Linux.

Closes #6794 