### PR TITLE
std: Apple Silicon: no fstat$INODE64 symbol found

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -124,14 +124,7 @@ pub extern "c" fn readlinkat(dirfd: fd_t, noalias path: [*:0]const u8, noalias b
 pub usingnamespace switch (builtin.os.tag) {
     .macos, .ios, .watchos, .tvos => struct {
         pub const realpath = @"realpath$DARWIN_EXTSN";
-        pub usingnamespace switch (builtin.arch) {
-            .aarch64 => struct {
-                pub extern "c" fn fstatat(dirfd: fd_t, path: [*:0]const u8, stat_buf: *Stat, flags: u32) c_int;
-            },
-            else => struct {
-                pub const fstatat = @"fstatat$INODE64";
-            },
-        };
+        pub const fstatat = _fstatat;
     },
     else => struct {
         pub extern "c" fn realpath(noalias file_name: [*:0]const u8, noalias resolved_name: [*]u8) ?[*:0]u8;
@@ -201,14 +194,7 @@ pub usingnamespace switch (builtin.os.tag) {
         // XXX: getdirentries -> _getdirentries64
         pub extern "c" fn clock_getres(clk_id: c_int, tp: *timespec) c_int;
         pub extern "c" fn clock_gettime(clk_id: c_int, tp: *timespec) c_int;
-        pub usingnamespace switch (builtin.arch) {
-            .aarch64 => struct {
-                pub extern "c" fn fstat(fd: fd_t, buf: *Stat) c_int;
-            },
-            else => struct {
-                pub const fstat = @"fstat$INODE64";
-            }
-        };
+        pub const fstat = _fstat;
         pub extern "c" fn getrusage(who: c_int, usage: *rusage) c_int;
         pub extern "c" fn gettimeofday(noalias tv: ?*timeval, noalias tz: ?*timezone) c_int;
         pub extern "c" fn nanosleep(rqtp: *const timespec, rmtp: ?*timespec) c_int;

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -124,7 +124,14 @@ pub extern "c" fn readlinkat(dirfd: fd_t, noalias path: [*:0]const u8, noalias b
 pub usingnamespace switch (builtin.os.tag) {
     .macos, .ios, .watchos, .tvos => struct {
         pub const realpath = @"realpath$DARWIN_EXTSN";
-        pub const fstatat = @"fstatat$INODE64";
+        pub usingnamespace switch (builtin.arch) {
+            .aarch64 => struct {
+                pub extern "c" fn fstatat(dirfd: fd_t, path: [*:0]const u8, stat_buf: *Stat, flags: u32) c_int;
+            },
+            else => struct {
+                pub const fstatat = @"fstatat$INODE64";
+            },
+        };
     },
     else => struct {
         pub extern "c" fn realpath(noalias file_name: [*:0]const u8, noalias resolved_name: [*]u8) ?[*:0]u8;
@@ -194,7 +201,14 @@ pub usingnamespace switch (builtin.os.tag) {
         // XXX: getdirentries -> _getdirentries64
         pub extern "c" fn clock_getres(clk_id: c_int, tp: *timespec) c_int;
         pub extern "c" fn clock_gettime(clk_id: c_int, tp: *timespec) c_int;
-        pub const fstat = @"fstat$INODE64";
+        pub usingnamespace switch (builtin.arch) {
+            .aarch64 => struct {
+                pub extern "c" fn fstat(fd: fd_t, buf: *Stat) c_int;
+            },
+            else => struct {
+                pub const fstat = @"fstat$INODE64";
+            }
+        };
         pub extern "c" fn getrusage(who: c_int, usage: *rusage) c_int;
         pub extern "c" fn gettimeofday(noalias tv: ?*timeval, noalias tz: ?*timezone) c_int;
         pub extern "c" fn nanosleep(rqtp: *const timespec, rmtp: ?*timespec) c_int;

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -29,8 +29,18 @@ pub extern "c" fn fcopyfile(from: fd_t, to: fd_t, state: ?copyfile_state_t, flag
 pub extern "c" fn @"realpath$DARWIN_EXTSN"(noalias file_name: [*:0]const u8, noalias resolved_name: [*]u8) ?[*:0]u8;
 
 pub extern "c" fn __getdirentries64(fd: c_int, buf_ptr: [*]u8, buf_len: usize, basep: *i64) isize;
-pub extern "c" fn @"fstat$INODE64"(fd: fd_t, buf: *Stat) c_int;
-pub extern "c" fn @"fstatat$INODE64"(dirfd: fd_t, path_name: [*:0]const u8, buf: *Stat, flags: u32) c_int;
+
+extern "c" fn fstat(fd: fd_t, buf: *Stat) c_int;
+/// On x86_64 Darwin, fstat has to be manully linked with $INODE64 suffix to force 64bit version.
+/// Note that this is fixed on aarch64 and no longer necessary.
+extern "c" fn @"fstat$INODE64"(fd: fd_t, buf: *Stat) c_int;
+pub const _fstat = if (builtin.arch == .aarch64) fstat else @"fstat$INODE64";
+
+extern "c" fn fstatat(dirfd: fd_t, path: [*:0]const u8, stat_buf: *Stat, flags: u32) c_int;
+/// On x86_64 Darwin, fstatat has to be manully linked with $INODE64 suffix to force 64bit version.
+/// Note that this is fixed on aarch64 and no longer necessary.
+extern "c" fn @"fstatat$INODE64"(dirfd: fd_t, path_name: [*:0]const u8, buf: *Stat, flags: u32) c_int;
+pub const _fstatat = if (builtin.arch == .aarch64) fstatat else @"fstatat$INODE64";
 
 pub extern "c" fn mach_absolute_time() u64;
 pub extern "c" fn mach_timebase_info(tinfo: ?*mach_timebase_info_data) void;


### PR DESCRIPTION
It seems that Apple has finally got rid of the 32bit versions of
`fstat` and `fstatat`, and instead, only 64bit versions are available
on BigSur and Apple Silicon.

The tweak in this commit is required to make Zig stage1 compile on
BigSur + aarch64.