### PR TITLE
Changed "macosx" to "macos" in support os to better relfect the output of…

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10170,7 +10170,7 @@ Operating Systems:
   kfreebsd
   linux (native)
   lv2
-  macosx
+  macos
   netbsd
   openbsd
   solaris


### PR DESCRIPTION
… zig targets in the documentation. Tried cross compiling while reading the docs and entered the wrong target in for the argument. Zig targets output was accurate and I wanted to reflect that output in the documentation. 