### PR TITLE
std: set page size to 16KB for aarch64 macos

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -16,6 +16,10 @@ const testing = std.testing;
 /// https://github.com/ziglang/zig/issues/2564
 pub const page_size = switch (builtin.arch) {
     .wasm32, .wasm64 => 64 * 1024,
+    .aarch64 => switch (builtin.os.tag) {
+        .macos, .ios, .watchos, .tvos => 16 * 1024,
+        else => 4 * 1024,
+    },
     else => 4 * 1024,
 };
 


### PR DESCRIPTION
With this tweak, `test-std` pass on Apple Silicon + BigSur.

My guess here is (thanks @LemonBoy for pointing this out BTW!) that this will be a temp fix until https://github.com/ziglang/zig/issues/2564 is resolved/decided upon.