### PR TITLE
stage1: Fix small bug in pointer type analysis

### DIFF
--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -6821,9 +6821,12 @@ static Error resolve_pointer_zero_bits(CodeGen *g, ZigType *ty) {
         TypeStructField *field = find_struct_type_field(isf->inferred_struct_type, isf->field_name);
         assert(field != nullptr);
         if (field->is_comptime) {
+            ty->data.pointer.resolve_loop_flag_zero_bits = false;
+
             ty->abi_size = 0;
             ty->size_in_bits = 0;
             ty->abi_align = 0;
+
             return ErrorNone;
         }
         elem_type = field->type_entry;
@@ -6834,6 +6837,8 @@ static Error resolve_pointer_zero_bits(CodeGen *g, ZigType *ty) {
     bool has_bits;
     if ((err = type_has_bits2(g, elem_type, &has_bits)))
         return err;
+
+    ty->data.pointer.resolve_loop_flag_zero_bits = false;
 
     if (has_bits) {
         ty->abi_size = g->builtin_types.entry_usize->abi_size;

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -54,6 +54,7 @@ comptime {
     _ = @import("behavior/bugs/5474.zig");
     _ = @import("behavior/bugs/5487.zig");
     _ = @import("behavior/bugs/6781.zig");
+    _ = @import("behavior/bugs/6850.zig");
     _ = @import("behavior/bugs/394.zig");
     _ = @import("behavior/bugs/421.zig");
     _ = @import("behavior/bugs/529.zig");

--- a/test/stage1/behavior/bugs/6850.zig
+++ b/test/stage1/behavior/bugs/6850.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+
+test "lazy sizeof comparison with zero" {
+    const Empty = struct {};
+    const T = *Empty;
+
+    std.testing.expect(hasNoBits(T));
+}
+
+fn hasNoBits(comptime T: type) bool {
+    return @sizeOf(T) == 0;
+}


### PR DESCRIPTION
A flag meant to catch recursively-defined types was never reset, leading
the compiler to generate wrong answers when asked for its
type/alignment.

Closes #6850