### PR TITLE
don't allow a token starting with an asterisk directly following .*

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -972,7 +972,7 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: anytype, source_token:
             .Tilde,
             => try writeEscaped(out, src[token.loc.start..token.loc.end]),
 
-            .Invalid, .Invalid_ampersands => return parseError(
+            .Invalid, .Invalid_ampersands, .Invalid_periodasterisks => return parseError(
                 docgen_tokenizer,
                 source_token,
                 "syntax error",

--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -171,6 +171,7 @@ pub const Error = union(enum) {
     ExpectedBlockOrField: ExpectedBlockOrField,
     DeclBetweenFields: DeclBetweenFields,
     InvalidAnd: InvalidAnd,
+    AsteriskAfterPointerDereference: AsteriskAfterPointerDereference,
 
     pub fn render(self: *const Error, tokens: []const Token.Id, stream: anytype) !void {
         switch (self.*) {
@@ -222,6 +223,7 @@ pub const Error = union(enum) {
             .ExpectedBlockOrField => |*x| return x.render(tokens, stream),
             .DeclBetweenFields => |*x| return x.render(tokens, stream),
             .InvalidAnd => |*x| return x.render(tokens, stream),
+            .AsteriskAfterPointerDereference => |*x| return x.render(tokens, stream),
         }
     }
 
@@ -275,6 +277,7 @@ pub const Error = union(enum) {
             .ExpectedBlockOrField => |x| return x.token,
             .DeclBetweenFields => |x| return x.token,
             .InvalidAnd => |x| return x.token,
+            .AsteriskAfterPointerDereference => |x| return x.token,
         }
     }
 
@@ -323,6 +326,7 @@ pub const Error = union(enum) {
     pub const ExtraAllowZeroQualifier = SimpleError("Extra allowzero qualifier");
     pub const DeclBetweenFields = SimpleError("Declarations are not allowed between container fields");
     pub const InvalidAnd = SimpleError("`&&` is invalid. Note that `and` is boolean AND.");
+    pub const AsteriskAfterPointerDereference = SimpleError("`.*` can't be followed by `*`.  Are you missing a space?");
 
     pub const ExpectedCall = struct {
         node: *Node,

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -2701,6 +2701,13 @@ const Parser = struct {
             return &node.base;
         }
 
+        if (p.token_ids[p.tok_i] == .Invalid_periodasterisks) {
+            try p.errors.append(p.gpa, .{
+                .AsteriskAfterPointerDereference = .{ .token = p.tok_i },
+            });
+            return null;
+        }
+
         if (p.eatToken(.Period)) |period| {
             if (try p.parseIdentifier()) |identifier| {
                 const node = try p.arena.allocator.create(Node.SimpleInfixOp);

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -2701,11 +2701,17 @@ const Parser = struct {
             return &node.base;
         }
 
-        if (p.token_ids[p.tok_i] == .Invalid_periodasterisks) {
+        if (p.eatToken(.Invalid_periodasterisks)) |period_asterisk| {
             try p.errors.append(p.gpa, .{
-                .AsteriskAfterPointerDereference = .{ .token = p.tok_i },
+                .AsteriskAfterPointerDereference = .{ .token = period_asterisk },
             });
-            return null;
+            const node = try p.arena.allocator.create(Node.SimpleSuffixOp);
+            node.* = .{
+                .base = .{ .tag = .Deref },
+                .lhs = lhs,
+                .rtoken = period_asterisk,
+            };
+            return &node.base;
         }
 
         if (p.eatToken(.Period)) |period| {

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -219,6 +219,17 @@ test "recovery: invalid global error set access" {
     });
 }
 
+test "recovery: invalid asterisk after pointer dereference" {
+    try testError(
+        \\test "" {
+        \\    var sequence = "repeat".*** 10;
+        \\}
+    , &[_]Error{
+        .AsteriskAfterPointerDereference,
+        .ExpectedToken,
+    });
+}
+
 test "recovery: missing semicolon after if, for, while stmt" {
     try testError(
         \\test "" {

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -226,7 +226,14 @@ test "recovery: invalid asterisk after pointer dereference" {
         \\}
     , &[_]Error{
         .AsteriskAfterPointerDereference,
-        .ExpectedToken,
+    });
+    try testError(
+        \\test "" {
+        \\    var sequence = "repeat".** 10&&a;
+        \\}
+    , &[_]Error{
+        .AsteriskAfterPointerDereference,
+        .InvalidAnd,
     });
 }
 

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -78,6 +78,7 @@ pub const Token = struct {
     pub const Id = enum {
         Invalid,
         Invalid_ampersands,
+        Invalid_periodasterisks,
         Identifier,
         StringLiteral,
         MultilineStringLiteralLine,
@@ -201,6 +202,7 @@ pub const Token = struct {
             return switch (id) {
                 .Invalid => "Invalid",
                 .Invalid_ampersands => "&&",
+                .Invalid_periodasterisks => ".**",
                 .Identifier => "Identifier",
                 .StringLiteral => "StringLiteral",
                 .MultilineStringLiteralLine => "MultilineStringLiteralLine",
@@ -1002,13 +1004,13 @@ pub const Tokenizer = struct {
 
                 .period_asterisk => switch (c) {
                     '*' => {
-                        result.id = .Invalid;
+                        result.id = .Invalid_periodasterisks;
                         break;
                     },
                     else => {
                         result.id = .PeriodAsterisk;
                         break;
-                    }
+                    },
                 },
 
                 .slash => switch (c) {
@@ -1794,7 +1796,7 @@ test "correctly parse pointer dereference followed by asterisk" {
 
     testTokenize("\"b\".*** 10", &[_]Token.Id{
         .StringLiteral,
-        .Invalid,
+        .Invalid_periodasterisks,
         .AsteriskAsterisk,
         .IntegerLiteral,
     });

--- a/src/stage1/tokenizer.cpp
+++ b/src/stage1/tokenizer.cpp
@@ -223,6 +223,7 @@ enum TokenizeState {
     TokenizeStateSawGreaterThanGreaterThan,
     TokenizeStateSawDot,
     TokenizeStateSawDotDot,
+    TokenizeStateSawDotStar,
     TokenizeStateSawAtSign,
     TokenizeStateCharCode,
     TokenizeStateError,
@@ -566,9 +567,8 @@ void tokenize(Buf *buf, Tokenization *out) {
                         set_token_id(&t, t.cur_tok, TokenIdEllipsis2);
                         break;
                     case '*':
-                        t.state = TokenizeStateStart;
+                        t.state = TokenizeStateSawDotStar;
                         set_token_id(&t, t.cur_tok, TokenIdDotStar);
-                        end_token(&t);
                         break;
                     default:
                         t.pos -= 1;
@@ -583,6 +583,18 @@ void tokenize(Buf *buf, Tokenization *out) {
                         t.state = TokenizeStateStart;
                         set_token_id(&t, t.cur_tok, TokenIdEllipsis3);
                         end_token(&t);
+                        break;
+                    default:
+                        t.pos -= 1;
+                        end_token(&t);
+                        t.state = TokenizeStateStart;
+                        continue;
+                }
+                break;
+            case TokenizeStateSawDotStar:
+                switch (c) {
+                    case '*':
+                        tokenize_error(&t, "`.*` can't be followed by `*`.  Are you missing a space?");
                         break;
                     default:
                         t.pos -= 1;

--- a/src/stage1/tokenizer.cpp
+++ b/src/stage1/tokenizer.cpp
@@ -1493,6 +1493,7 @@ void tokenize(Buf *buf, Tokenization *out) {
         case TokenizeStateSawGreaterThan:
         case TokenizeStateSawGreaterThanGreaterThan:
         case TokenizeStateSawDot:
+        case TokenizeStateSawDotStar:
         case TokenizeStateSawAtSign:
         case TokenizeStateSawStarPercent:
         case TokenizeStateSawPlusPercent:

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -8195,4 +8195,12 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     , &[_][]const u8{
         "tmp.zig:4:9: error: expected type '*c_void', found '?*c_void'",
     });
+
+    cases.add("Issue #6823: don't allow .* to be followed by **",
+        \\fn foo() void {
+        \\    var sequence = "repeat".*** 10;
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:2:30: error: `.*` can't be followed by `*`.  Are you missing a space?",
+    });
 }


### PR DESCRIPTION
closes #6823 

I couldn't find where the tests are for the tokenizing so if one needs added if you could point me in the right direction that'd be great