### PR TITLE
std: Show the panicking thread ID

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -186,6 +186,9 @@ pub const pthread_attr_t = extern struct {
     __opaque: [56]u8,
 };
 
+const pthread_t = std.c.pthread_t;
+pub extern "c" fn pthread_threadid_np(thread: ?pthread_t, thread_id: *u64) c_int;
+
 pub extern "c" fn arc4random_buf(buf: [*]u8, len: usize) void;
 
 // Grand Central Dispatch is exposed by libSystem.

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -13,6 +13,8 @@ pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) usize;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;
 
+pub extern "pthread" fn pthread_getthreadid_np() c_int;
+
 pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
 pub extern "c" fn malloc_usable_size(?*const c_void) usize;
 

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -14,6 +14,8 @@ pub const _errno = __errno;
 pub const dl_iterate_phdr_callback = fn (info: *dl_phdr_info, size: usize, data: ?*c_void) callconv(.C) c_int;
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*c_void) c_int;
 
+pub extern "c" fn _lwp_self() lwpid_t;
+
 pub extern "c" fn arc4random_buf(buf: [*]u8, len: usize) void;
 pub extern "c" fn __fstat50(fd: fd_t, buf: *Stat) c_int;
 pub extern "c" fn __stat50(path: [*:0]const u8, buf: *Stat) c_int;

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -16,6 +16,8 @@ pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*c_
 
 pub extern "c" fn arc4random_buf(buf: [*]u8, len: usize) void;
 
+pub extern "c" fn getthrid() pid_t;
+
 pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) usize;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -262,6 +262,12 @@ pub fn panicExtra(trace: ?*const builtin.StackTrace, first_trace_addr: ?usize, c
                 defer held.release();
 
                 const stderr = io.getStdErr().writer();
+                if (builtin.single_threaded) {
+                    stderr.print("main thread panicked: ", .{}) catch os.abort();
+                } else {
+                    const current_thread_id = std.Thread.getCurrentThreadId();
+                    stderr.print("thread {d} panicked: ", .{current_thread_id}) catch os.abort();
+                }
                 stderr.print(format ++ "\n", args) catch os.abort();
                 if (trace) |t| {
                     dumpStackTrace(t.*);


### PR DESCRIPTION
Annotate the panic message with the thread ID to know who's the culprit.

Thread names are not as portable as thread IDs.