### PR TITLE
Fix std.mem.Allocator.resize for non-u8 types

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -434,12 +434,14 @@ pub fn formatType(
                     if (info.child == u8) {
                         return formatText(value, fmt, options, writer);
                     }
-                    return format(writer, "{}@{x}", .{ @typeName(@typeInfo(T).Pointer.child), @ptrToInt(value) });
+                    return if (@sizeOf(T) == 0) format(writer, "{}@void", .{ @typeName(@typeInfo(T).Pointer.child) })
+                        else format(writer, "{}@{x}", .{ @typeName(@typeInfo(T).Pointer.child), @ptrToInt(value) });
                 },
                 .Enum, .Union, .Struct => {
                     return formatType(value.*, fmt, options, writer, max_depth);
                 },
-                else => return format(writer, "{}@{x}", .{ @typeName(@typeInfo(T).Pointer.child), @ptrToInt(value) }),
+                else => return if (@sizeOf(T) == 0) format(writer, "{}@void", .{ @typeName(@typeInfo(T).Pointer.child) })
+                    else format(writer, "{}@{x}", .{ @typeName(@typeInfo(T).Pointer.child), @ptrToInt(value) }),
             },
             .Many, .C => {
                 if (ptr_info.sentinel) |sentinel| {
@@ -450,7 +452,8 @@ pub fn formatType(
                         return formatText(mem.span(value), fmt, options, writer);
                     }
                 }
-                return format(writer, "{}@{x}", .{ @typeName(@typeInfo(T).Pointer.child), @ptrToInt(value) });
+                return if (@sizeOf(T) == 0) format(writer, "{}@void", .{ @typeName(@typeInfo(T).Pointer.child) })
+                    else format(writer, "{}@{x}", .{ @typeName(@typeInfo(T).Pointer.child), @ptrToInt(value) });
             },
             .Slice => {
                 if (fmt.len > 0 and ((fmt[0] == 'x') or (fmt[0] == 'X'))) {
@@ -459,7 +462,8 @@ pub fn formatType(
                 if (ptr_info.child == u8) {
                     return formatText(value, fmt, options, writer);
                 }
-                return format(writer, "{}@{x}", .{ @typeName(ptr_info.child), @ptrToInt(value.ptr) });
+                return if (@sizeOf(ptr_info.child) == 0) format(writer, "[{}]{}@void", .{ value.len, @typeName(ptr_info.child) })
+                    else format(writer, "[{}]{}@{x}", .{ value.len, @typeName(ptr_info.child), @ptrToInt(value.ptr) });
             },
         },
         .Array => |info| {
@@ -1381,7 +1385,7 @@ test "slice" {
     {
         var runtime_zero: usize = 0;
         const value = @intToPtr([*]align(1) const []const u8, 0xdeadbeef)[runtime_zero..runtime_zero];
-        try testFmt("slice: []const u8@deadbeef\n", "slice: {}\n", .{value});
+        try testFmt("slice: [0][]const u8@deadbeef\n", "slice: {}\n", .{value});
     }
 
     try testFmt("buf:  Test\n", "buf: {s:5}\n", .{"Test"});

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -217,9 +217,10 @@ pub fn allocWithOptionsRetAddr(
 
 fn AllocWithOptionsPayload(comptime Elem: type, comptime alignment: ?u29, comptime sentinel: ?Elem) type {
     if (sentinel) |s| {
+        // Assume that sentinels imply the type is not zero-sized
         return [:s]align(alignment orelse @alignOf(Elem)) Elem;
     } else {
-        return []align(alignment orelse @alignOf(Elem)) Elem;
+        return SafeSlice(Elem, alignment);
     }
 }
 
@@ -247,7 +248,7 @@ pub fn alignedAlloc(
     /// null means naturally aligned
     comptime alignment: ?u29,
     n: usize,
-) Error![]align(alignment orelse @alignOf(T)) T {
+) Error!SafeSlice(T, alignment) {
     return self.allocAdvancedWithRetAddr(T, alignment, n, .exact, @returnAddress());
 }
 
@@ -258,7 +259,7 @@ pub fn allocAdvanced(
     comptime alignment: ?u29,
     n: usize,
     exact: Exact,
-) Error![]align(alignment orelse @alignOf(T)) T {
+) Error!SafeSlice(T, alignment) {
     return self.allocAdvancedWithRetAddr(T, alignment, n, exact, @returnAddress());
 }
 
@@ -272,7 +273,11 @@ pub fn allocAdvancedWithRetAddr(
     n: usize,
     exact: Exact,
     return_address: usize,
-) Error![]align(alignment orelse @alignOf(T)) T {
+) Error!SafeSlice(T, alignment) {
+    if (@sizeOf(T) == 0) {
+        return @as([*]T, undefined)[0..n];
+    }
+
     const a = if (alignment) |a| blk: {
         if (a == @alignOf(T)) return allocAdvancedWithRetAddr(self, T, null, n, exact, return_address);
         break :blk a;
@@ -310,15 +315,18 @@ pub fn allocAdvancedWithRetAddr(
 pub fn resize(self: *Allocator, old_mem: anytype, new_n: usize) Error!@TypeOf(old_mem) {
     const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
     const T = Slice.child;
+    if (@sizeOf([*]T) == 0) {
+        return @as([*]T, undefined)[0..new_n];
+    }
     if (new_n == 0) {
         self.free(old_mem);
-        return &[0]T{};
+        return @as([]T, @as(*[0]T, undefined));
     }
     const old_byte_slice = mem.sliceAsBytes(old_mem);
     const new_byte_count = math.mul(usize, @sizeOf(T), new_n) catch return Error.OutOfMemory;
     const rc = try self.resizeFn(self, old_byte_slice, Slice.alignment, new_byte_count, 0, @returnAddress());
     assert(rc == new_byte_count);
-    const new_byte_slice = old_mem.ptr[0..new_byte_count];
+    const new_byte_slice = old_byte_slice.ptr[0..new_byte_count];
     return mem.bytesAsSlice(T, new_byte_slice);
 }
 
@@ -332,19 +340,13 @@ pub fn resize(self: *Allocator, old_mem: anytype, new_n: usize) Error!@TypeOf(ol
 /// in `std.ArrayList.shrink`.
 /// If you need guaranteed success, call `shrink`.
 /// If `new_n` is 0, this is the same as `free` and it always succeeds.
-pub fn realloc(self: *Allocator, old_mem: anytype, new_n: usize) t: {
-    const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
-    break :t Error![]align(Slice.alignment) Slice.child;
-} {
-    const old_alignment = @typeInfo(@TypeOf(old_mem)).Pointer.alignment;
+pub fn realloc(self: *Allocator, old_mem: anytype, new_n: usize) Error!DerivedSlice(@TypeOf(old_mem), safeAlignment(@TypeOf(old_mem))) {
+    const old_alignment = comptime safeAlignment(@TypeOf(old_mem));
     return self.reallocAdvancedWithRetAddr(old_mem, old_alignment, new_n, .exact, @returnAddress());
 }
 
-pub fn reallocAtLeast(self: *Allocator, old_mem: anytype, new_n: usize) t: {
-    const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
-    break :t Error![]align(Slice.alignment) Slice.child;
-} {
-    const old_alignment = @typeInfo(@TypeOf(old_mem)).Pointer.alignment;
+pub fn reallocAtLeast(self: *Allocator, old_mem: anytype, new_n: usize) Error!DerivedSlice(@TypeOf(old_mem), safeAlignment(@TypeOf(old_mem))) {
+    const old_alignment = comptime safeAlignment(@TypeOf(old_mem));
     return self.reallocAdvancedWithRetAddr(old_mem, old_alignment, new_n, .at_least, @returnAddress());
 }
 
@@ -354,23 +356,30 @@ pub fn reallocAtLeast(self: *Allocator, old_mem: anytype, new_n: usize) t: {
 pub fn reallocAdvanced(
     self: *Allocator,
     old_mem: anytype,
-    comptime new_alignment: u29,
+    comptime new_alignment: ?u29,
     new_n: usize,
     exact: Exact,
-) Error![]align(new_alignment) @typeInfo(@TypeOf(old_mem)).Pointer.child {
+) Error!DerivedSlice(@TypeOf(old_mem), new_alignment) {
     return self.reallocAdvancedWithRetAddr(old_mem, new_alignment, new_n, exact, @returnAddress());
 }
 
 pub fn reallocAdvancedWithRetAddr(
     self: *Allocator,
     old_mem: anytype,
-    comptime new_alignment: u29,
+    comptime new_alignment_safe: ?u29,
     new_n: usize,
     exact: Exact,
     return_address: usize,
-) Error![]align(new_alignment) @typeInfo(@TypeOf(old_mem)).Pointer.child {
+) Error!DerivedSlice(@TypeOf(old_mem), new_alignment_safe) {
     const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
     const T = Slice.child;
+    if (@sizeOf(T) == 0) {
+        return @as([*]T, undefined)[0..new_n];
+    }
+
+    // can't do this until after check for zero-sized child
+    const new_alignment = new_alignment_safe orelse Slice.alignment;
+
     if (old_mem.len == 0) {
         return self.allocAdvancedWithRetAddr(T, new_alignment, new_n, exact, return_address);
     }
@@ -395,23 +404,20 @@ pub fn reallocAdvancedWithRetAddr(
 /// Shrink always succeeds, and `new_n` must be <= `old_mem.len`.
 /// Returned slice has same alignment as old_mem.
 /// Shrinking to 0 is the same as calling `free`.
-pub fn shrink(self: *Allocator, old_mem: anytype, new_n: usize) t: {
-    const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
-    break :t []align(Slice.alignment) Slice.child;
-} {
-    const old_alignment = @typeInfo(@TypeOf(old_mem)).Pointer.alignment;
+pub fn shrink(self: *Allocator, old_mem: anytype, new_n: usize) DerivedSlice(@TypeOf(old_mem), safeAlignment(@TypeOf(old_mem))) {
+    const old_alignment = comptime safeAlignment(@TypeOf(old_mem));
     return self.alignedShrinkWithRetAddr(old_mem, old_alignment, new_n, @returnAddress());
 }
 
 /// This is the same as `shrink`, except caller may additionally request
 /// a new alignment, which must be smaller or the same as the old
-/// allocation.
+/// allocation.  This function does not support zero-sized types.
 pub fn alignedShrink(
     self: *Allocator,
     old_mem: anytype,
     comptime new_alignment: u29,
     new_n: usize,
-) []align(new_alignment) @typeInfo(@TypeOf(old_mem)).Pointer.child {
+) DerivedSlice(@TypeOf(old_mem), new_alignment) {
     return self.alignedShrinkWithRetAddr(old_mem, new_alignment, new_n, @returnAddress());
 }
 
@@ -421,17 +427,24 @@ pub fn alignedShrink(
 pub fn alignedShrinkWithRetAddr(
     self: *Allocator,
     old_mem: anytype,
-    comptime new_alignment: u29,
+    comptime new_alignment_safe: ?u29,
     new_n: usize,
     return_address: usize,
-) []align(new_alignment) @typeInfo(@TypeOf(old_mem)).Pointer.child {
+) DerivedSlice(@TypeOf(old_mem), new_alignment_safe)  {
     const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
     const T = Slice.child;
 
     if (new_n == old_mem.len)
         return old_mem;
     assert(new_n < old_mem.len);
-    assert(new_alignment <= Slice.alignment);
+
+    if (@sizeOf(T) == 0) {
+        return old_mem[0..new_n];
+    }
+
+    // can't do this until after the check for zero-size
+    const new_alignment = new_alignment_safe orelse Slice.alignment;
+    if (new_alignment > Slice.alignment) @compileError("alignedShrink* cannot increase alignment.");
 
     // Here we skip the overflow checking on the multiplication because
     // new_n <= old_mem.len and the multiplication didn't overflow for that operation.
@@ -448,6 +461,8 @@ pub fn alignedShrinkWithRetAddr(
 /// see `destroy`.
 pub fn free(self: *Allocator, memory: anytype) void {
     const Slice = @typeInfo(@TypeOf(memory)).Pointer;
+    if (@sizeOf(Slice.child) == 0) return;
+
     const bytes = mem.sliceAsBytes(memory);
     const bytes_len = bytes.len + if (Slice.sentinel != null) @sizeOf(Slice.child) else 0;
     if (bytes_len == 0) return;
@@ -487,3 +502,40 @@ pub fn shrinkBytes(
     assert(new_len <= buf.len);
     return self.resizeFn(self, buf, buf_align, new_len, len_align, return_address) catch unreachable;
 }
+
+/// This function is meant to be called at comptime.
+/// It returns the alignment of a pointer or slice type,
+/// or null if the child is a zero-sized type.
+/// Use SafeSlice to construct a slice type.
+fn safeAlignment(comptime PtrOrSliceT: type) ?u29 {
+    if (@sizeOf(@typeInfo(PtrOrSliceT).Pointer.child) == 0) {
+        return null;
+    } else {
+        // Workaround for #6942
+        return if (false) void else @as(?u29, @typeInfo(PtrOrSliceT).Pointer.alignment);
+    }
+}
+
+/// Constructs a slice type with given alignment and child type.
+/// Provides a helpful compile error if a zero-sized type is aligned.
+fn SafeSlice(comptime ChildT: type, comptime alignment: ?u29) type {
+    if (@sizeOf(ChildT) == 0) {
+        if (alignment != null) @compileError(std.fmt.comptimePrint(
+            "Cannot align zero-sized type {}. (requested alignment: {})",
+            .{ @typeName(T), alignment.? },
+        ));
+        return []ChildT;
+    } else {
+        if (alignment) |a| {
+            return []align(a) ChildT;
+        } else {
+            return []ChildT;
+        }
+    }
+}
+
+/// Constructs an aligned slice from a slice type and a desired alignment.
+fn DerivedSlice(comptime PtrOrSliceT: type, comptime alignment: ?u29) type {
+    return SafeSlice(@typeInfo(PtrOrSliceT).Pointer.child, alignment);
+}
+


### PR DESCRIPTION
Three fixes: a typo, a const problem, and a failure to handle empty types.