### PR TITLE
Implemented lossyCast -> int #5080

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -941,14 +941,42 @@ test "std.math.log2_int_ceil" {
     testing.expect(log2_int_ceil(u32, 10) == 4);
 }
 
+///Cast a value to a different type. If the value doesn't fit in, or can't be perfectly represented by,
+///the new type, it will be converted to the closest possible representation.
 pub fn lossyCast(comptime T: type, value: anytype) T {
-    switch (@typeInfo(@TypeOf(value))) {
-        .Int => return @intToFloat(T, value),
-        .Float => return @floatCast(T, value),
-        .ComptimeInt => return @as(T, value),
-        .ComptimeFloat => return @as(T, value),
-        else => @compileError("bad type"),
+    switch(@typeInfo(T)) {
+        .Float => {
+            switch (@typeInfo(@TypeOf(value))) {
+                .Int => return @intToFloat(T, value),
+                .Float => return @floatCast(T, value),
+                .ComptimeInt => return @as(T, value),
+                .ComptimeFloat => return @as(T, value),
+                else => @compileError("bad type"),
+            }
+        },
+        .Int => {
+            switch(@typeInfo(@TypeOf(value))) {
+                .Int, .ComptimeInt => {
+                    if (value > maxInt(T)) { return @as(T, maxInt(T)); }
+                    else if (value < minInt(T)) { return @as(T, minInt(T)); }
+                    else { return @intCast(T, value); }
+                },
+                .Float, .ComptimeFloat => {
+                    if (value > maxInt(T)) { return @as(T, maxInt(T)); }
+                    else if (value < minInt(T)) { return @as(T, minInt(T)); }
+                    else { return @floatToInt(T, value); }
+                },
+                else => @compileError("bad type"),
+            }
+        },
+        else => @compileError("bad result type"),
     }
+}
+
+test "math.lossyCast" {
+    testing.expect(lossyCast(i16, 70000.0) == @as(i16, 32767));
+    testing.expect(lossyCast(u32, @as(i16, -255)) == @as(u32, 0));
+    testing.expect(lossyCast(i9, @as(u32, 200)) == @as(i9, 200));
 }
 
 test "math.f64_min" {


### PR DESCRIPTION
Allows lossyCast to convert from float -> int and int -> int. This is currently a proposal, (#5080), but you can look at this to see if you want to include it in std.

I also added a brief doc comment for the function, and tests for the int conversions. I didn't write any tests for the floating point case because... floating point math is hard.