### PR TITLE
Catch sigpipe on linux

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1749,6 +1749,7 @@ fn resetSegfaultHandler() void {
     os.sigaction(os.SIGSEGV, &act, null);
     os.sigaction(os.SIGILL, &act, null);
     os.sigaction(os.SIGBUS, &act, null);
+    os.sigaction(os.SIGPIPE, &act, null);
 }
 
 fn handleSegfaultLinux(sig: i32, info: *const os.siginfo_t, ctx_ptr: ?*const c_void) callconv(.C) noreturn {
@@ -1766,6 +1767,7 @@ fn handleSegfaultLinux(sig: i32, info: *const os.siginfo_t, ctx_ptr: ?*const c_v
         os.SIGSEGV => std.debug.warn("Segmentation fault at address 0x{x}\n", .{addr}),
         os.SIGILL => std.debug.warn("Illegal instruction at address 0x{x}\n", .{addr}),
         os.SIGBUS => std.debug.warn("Bus error at address 0x{x}\n", .{addr}),
+        os.SIGPIPE => std.debug.warn("Pipe error at address 0x{x}\n", .{addr}),
         else => unreachable,
     }
     switch (builtin.arch) {


### PR DESCRIPTION
Doesn't fix https://github.com/ziglang/zig/issues/5614 but this will at least will let you know what is happening without having to use a debugger.  Otherwise it just exit's without any error.  The user can override this so I don't see any downsides.

Before: 
```
$ zig run http.zig           
Listening at 127.0.0.1:9000
Connection{ .file = File{ .handle = 14, .capable_io_mode = Mode.evented, .intended_io_mode = Mode.evented }, .address = 127.0.0.1:52114 }
```
Wtf???

After:

```
$ zig run http.zig           
Listening at 127.0.0.1:9000
Connection{ .file = File{ .handle = 14, .capable_io_mode = Mode.evented, .intended_io_mode = Mode.evented }, .address = 127.0.0.1:60956 }
Pipe error at address 0x3e8000dafce
/home/user/Workspace/zig/build/lib/zig/std/os/linux/x86_64.zig:36:12: 0x2373ba in std.os.linux.x86_64.syscall3 (http)
    return asm volatile ("syscall"
           ^
/home/user/Workspace/zig/build/lib/zig/std/os/linux.zig:398:20: 0x212a1a in std.os.linux.write (http)
    return syscall3(.write, @bitCast(usize, @as(isize, fd)), @ptrToInt(buf), count);
                   ^
/home/user/Workspace/zig/build/lib/zig/std/os.zig:721:32: 0x20d536 in std.os.write (http)
        const rc = system.write(fd, bytes.ptr, adjusted_len);
                               ^
/home/user/Workspace/zig/build/lib/zig/std/event/loop.zig:1142:32: 0x20dad1 in std.event.loop.Loop.write (http)
                return os.write(fd, bytes) catch |err| switch (err) {
                               ^
/home/user/Workspace/zig-examples/src/http.zig:25:21: 0x24e205 in main (http)
        var frame = async handleConn(conn);
                    ^
/home/user/Workspace/zig/build/lib/zig/std/event/loop.zig:1350:25: 0x25e2cb in std.event.loop.Loop.workerRun (http)
                        resume handle;
                        ^
/home/user/Workspace/zig/build/lib/zig/std/event/loop.zig:639:23: 0x2370dd in std.event.loop.Loop.run (http)
        self.workerRun();
                      ^
/home/user/Workspace/zig/build/lib/zig/std/start.zig:261:21: 0x20b327 in std.start.posixCallMainAndExit (http)
            loop.run();
                    ^
/home/user/Workspace/zig/build/lib/zig/std/start.zig:154:5: 0x20aea2 in std.start._start (http)
    @call(.{ .modifier = .never_inline }, posixCallMainAndExit, .{});
    ^
Aborted

```


To test run this:

```zig
const std = @import("std");
const net = std.net;
const fs = std.fs;
const os = std.os;

pub const io_mode = .evented;

var gpa = std.heap.GeneralPurposeAllocator(.{}){};
const allocator = &gpa.allocator;

pub fn main() anyerror!void {
    const req_listen_addr = try net.Address.parseIp4("127.0.0.1", 9000);
    defer std.debug.assert(!gpa.deinit());

    // Ignore sigpipe
//     var act = os.Sigaction{
//         .sigaction = os.SIG_IGN,
//         .mask = os.empty_sigset,
//         .flags = 0,
//     };
//     os.sigaction(os.SIGPIPE, &act, null);

    var server = net.StreamServer.init(.{});
    defer server.deinit();

    try server.listen(req_listen_addr);

    std.debug.warn("Listening at {}\n", .{server.listen_address});

    while (true) {
        const conn = try server.accept();
        std.debug.warn("{}\n", .{conn});
        var frame = async handleConn(conn);
        await frame catch |err| {
            std.debug.warn("Disconnected {}: {}\n", .{conn, err});
        };
    }
}

pub fn handleConn(conn: net.StreamServer.Connection) !void {
    var reader = conn.file.reader();
    var writer = conn.file.writer();
    var buf: [4096]u8 = undefined;
    while (true) {
        const n = try reader.read(&buf);
        try writer.writeAll(
            "HTTP/1.1 200 OK\r\n" ++
            "Content-Length: 15\r\n" ++
            "Connection: keep-alive\r\n" ++
            "Content-Type: text/plain; charset=UTF-8\r\n" ++
            "Server: Example\r\n" ++
            "Date: Wed, 17 Apr 2013 12:00:00 GMT\r\n" ++
            "\r\n" ++
            "Hello, World!\r\n" ++
            "\r\n"
        );
    }
}
```

Then use https://github.com/wg/wrk and run `wrk -t1 -c1 -d10s --latency http://127.0.0.1:9000/`

Also if the signal is ignored then you hit https://github.com/ziglang/zig/issues/6590 (which is what I'm trying to solve...)