### PR TITLE
Support non-tuples by debug.print

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -64,7 +64,11 @@ pub fn print(comptime fmt: []const u8, args: anytype) void {
     const held = stderr_mutex.acquire();
     defer held.release();
     const stderr = io.getStdErr().writer();
-    nosuspend stderr.print(fmt, args) catch return;
+    if (comptime std.meta.trait.isTuple(@TypeOf(args))) {
+        nosuspend stderr.print(fmt, args) catch return;
+    } else {
+        nosuspend stderr.print(fmt, .{args}) catch return;
+    }
 }
 
 pub fn getStderrMutex() *std.Mutex {


### PR DESCRIPTION
Sorry, I'm tired of typing brackets for single value.

```zig
pub fn main() void {
	const a = 123;
	
	print("print comptime_int: {}\n", 1);
	print("print comptime_float: {}\n", 1.23);
	print("print str: {}\n", "abc");
	print("print const: {}\n", a);
	
	print("\n{}\n\n", "Let's repeat...");
	
	print("print comptime_int: {}\n", .{1});
	print("print comptime_float: {}\n", .{1.23});
	print("print str: {}\n", .{"abc"});
	print("print const: {}\n", .{a});
}
