### PR TITLE
Fix std.ResetEvent.timedWait on darwin/macOS.

### DIFF
--- a/lib/std/reset_event.zig
+++ b/lib/std/reset_event.zig
@@ -442,7 +442,7 @@ test "std.ResetEvent" {
         fn timedWaiter(self: *Self) !void {
             self.in.wait();
             testing.expectError(error.TimedOut, self.out.timedWait(time.ns_per_us));
-            try self.out.timedWait(time.ns_per_ms * 5);
+            try self.out.timedWait(time.ns_per_ms * 10);
             testing.expect(self.value == 5);
         }
     };

--- a/lib/std/reset_event.zig
+++ b/lib/std/reset_event.zig
@@ -434,7 +434,7 @@ test "std.ResetEvent" {
 
         fn sleeper(self: *Self) void {
             self.in.set();
-            time.sleep(time.ns_per_ms);
+            time.sleep(time.ns_per_ms * 2);
             self.value = 5;
             self.out.set();
         }
@@ -442,7 +442,7 @@ test "std.ResetEvent" {
         fn timedWaiter(self: *Self) !void {
             self.in.wait();
             testing.expectError(error.TimedOut, self.out.timedWait(time.ns_per_us));
-            try self.out.timedWait(time.ns_per_ms * 2);
+            try self.out.timedWait(time.ns_per_ms * 5);
             testing.expect(self.value == 5);
         }
     };
@@ -453,11 +453,9 @@ test "std.ResetEvent" {
     defer receiver.wait();
     context.sender();
 
-    if (builtin.link_libc) {
-        var timed = Context.init();
-        defer timed.deinit();
-        const sleeper = try std.Thread.spawn(&timed, Context.sleeper);
-        defer sleeper.wait();
-        try timed.timedWaiter();
-    }
+    var timed = Context.init();
+    defer timed.deinit();
+    const sleeper = try std.Thread.spawn(&timed, Context.sleeper);
+    defer sleeper.wait();
+    try timed.timedWaiter();
 }


### PR DESCRIPTION
The wrong conversion constant was being used in the darwin branch of `timedWait`, and so timeouts would never happen for me on macOS. I fixed this and also added a test that ensures the timeout actually happens.