### PR TITLE
std/ascii: add spaces array 

### DIFF
--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -230,6 +230,20 @@ pub fn isSpace(c: u8) bool {
     return inTable(c, tIndex.Space);
 }
 
+/// All the values for which isSpace() returns true. This may be used with
+/// e.g. std.mem.trim() to trim whiteSpace.
+pub const spaces = [_]u8{ ' ', '\t', '\n', '\r', control_code.VT, control_code.FF };
+
+test "spaces" {
+    const testing = std.testing;
+    for (spaces) |space| testing.expect(isSpace(space));
+
+    var i: u8 = 0;
+    while (isASCII(i)) : (i += 1) {
+        if (isSpace(i)) testing.expect(std.mem.indexOfScalar(u8, &spaces, i) != null);
+    }
+}
+
 pub fn isUpper(c: u8) bool {
     return inTable(c, tIndex.Upper);
 }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1703,8 +1703,8 @@ fn testFmt(expected: []const u8, comptime template: []const u8, args: anytype) !
     return error.TestFailed;
 }
 
-pub const trim = @compileError("deprecated; use std.mem.trim instead");
-pub const isWhiteSpace = @compileError("deprecated; use std.mem.isWhiteSpace instead");
+pub const trim = @compileError("deprecated; use std.mem.trim with std.ascii.spaces instead");
+pub const isWhiteSpace = @compileError("deprecated; use std.ascii.isSpace instead");
 
 pub fn hexToBytes(out: []u8, input: []const u8) !void {
     if (out.len * 2 < input.len)
@@ -1890,4 +1890,3 @@ test "null" {
     const inst = null;
     try testFmt("null", "{}", .{inst});
 }
-


### PR DESCRIPTION
This may be combined with std.mem.trim to form a proper replacement for
the now deprecated std.fmt.trimWhitespace().

See discussion in #6904