### PR TITLE
std.crypto: namespace constructions a bit more

### DIFF
--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -6,18 +6,26 @@
 
 /// Authenticated Encryption with Associated Data
 pub const aead = struct {
-    pub const Aegis128L = @import("crypto/aegis.zig").Aegis128L;
-    pub const Aegis256 = @import("crypto/aegis.zig").Aegis256;
+    pub const aegis = struct {
+        pub const Aegis128L = @import("crypto/aegis.zig").Aegis128L;
+        pub const Aegis256 = @import("crypto/aegis.zig").Aegis256;
+    };
 
-    pub const Aes128Gcm = @import("crypto/aes_gcm.zig").Aes128Gcm;
-    pub const Aes256Gcm = @import("crypto/aes_gcm.zig").Aes256Gcm;
+    pub const aes_gcm = struct {
+        pub const Aes128Gcm = @import("crypto/aes_gcm.zig").Aes128Gcm;
+        pub const Aes256Gcm = @import("crypto/aes_gcm.zig").Aes256Gcm;
+    };
 
     pub const Gimli = @import("crypto/gimli.zig").Aead;
 
-    pub const ChaCha20Poly1305 = @import("crypto/chacha20.zig").Chacha20Poly1305;
-    pub const XChaCha20Poly1305 = @import("crypto/chacha20.zig").XChacha20Poly1305;
+    pub const chacha_poly = struct {
+        pub const ChaCha20Poly1305 = @import("crypto/chacha20.zig").Chacha20Poly1305;
+        pub const XChaCha20Poly1305 = @import("crypto/chacha20.zig").XChacha20Poly1305;
+    };
 
-    pub const XSalsa20Poly1305 = @import("crypto/salsa20.zig").XSalsa20Poly1305;
+    pub const salsa_poly = struct {
+        pub const XSalsa20Poly1305 = @import("crypto/salsa20.zig").XSalsa20Poly1305;
+    };
 };
 
 /// Authentication (MAC) functions.
@@ -102,12 +110,16 @@ pub const sign = struct {
 /// Stream ciphers. These do not provide any kind of authentication.
 /// Most applications should be using AEAD constructions instead of stream ciphers directly.
 pub const stream = struct {
-    pub const ChaCha20IETF = @import("crypto/chacha20.zig").ChaCha20IETF;
-    pub const ChaCha20With64BitNonce = @import("crypto/chacha20.zig").ChaCha20With64BitNonce;
-    pub const XChaCha20IETF = @import("crypto/chacha20.zig").XChaCha20IETF;
+    pub const chacha = struct {
+        pub const ChaCha20IETF = @import("crypto/chacha20.zig").ChaCha20IETF;
+        pub const ChaCha20With64BitNonce = @import("crypto/chacha20.zig").ChaCha20With64BitNonce;
+        pub const XChaCha20IETF = @import("crypto/chacha20.zig").XChaCha20IETF;
+    };
 
-    pub const Salsa20 = @import("crypto/salsa20.zig").Salsa20;
-    pub const XSalsa20 = @import("crypto/salsa20.zig").XSalsa20;
+    pub const salsa = struct {
+        pub const Salsa20 = @import("crypto/salsa20.zig").Salsa20;
+        pub const XSalsa20 = @import("crypto/salsa20.zig").XSalsa20;
+    };
 };
 
 pub const nacl = struct {

--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -200,14 +200,14 @@ pub fn benchmarkBatchSignatureVerification(comptime Signature: anytype, comptime
 }
 
 const aeads = [_]Crypto{
-    Crypto{ .ty = crypto.aead.ChaCha20Poly1305, .name = "chacha20Poly1305" },
-    Crypto{ .ty = crypto.aead.XChaCha20Poly1305, .name = "xchacha20Poly1305" },
-    Crypto{ .ty = crypto.aead.XSalsa20Poly1305, .name = "xsalsa20Poly1305" },
+    Crypto{ .ty = crypto.aead.chacha_poly.ChaCha20Poly1305, .name = "chacha20Poly1305" },
+    Crypto{ .ty = crypto.aead.chacha_poly.XChaCha20Poly1305, .name = "xchacha20Poly1305" },
+    Crypto{ .ty = crypto.aead.salsa_poly.XSalsa20Poly1305, .name = "xsalsa20Poly1305" },
     Crypto{ .ty = crypto.aead.Gimli, .name = "gimli-aead" },
-    Crypto{ .ty = crypto.aead.Aegis128L, .name = "aegis-128l" },
-    Crypto{ .ty = crypto.aead.Aegis256, .name = "aegis-256" },
-    Crypto{ .ty = crypto.aead.Aes128Gcm, .name = "aes128-gcm" },
-    Crypto{ .ty = crypto.aead.Aes256Gcm, .name = "aes256-gcm" },
+    Crypto{ .ty = crypto.aead.aegis.Aegis128L, .name = "aegis-128l" },
+    Crypto{ .ty = crypto.aead.aegis.Aegis256, .name = "aegis-256" },
+    Crypto{ .ty = crypto.aead.aes_gcm.Aes128Gcm, .name = "aes128-gcm" },
+    Crypto{ .ty = crypto.aead.aes_gcm.Aes256Gcm, .name = "aes256-gcm" },
 };
 
 pub fn benchmarkAead(comptime Aead: anytype, comptime bytes: comptime_int) !u64 {


### PR DESCRIPTION
With the simple rule that whenever we have or will have 2 similar functions, they should be in their own namespace.

Some of these new namespaces currently contain a single function.

This is to prepare for reduced-round versions that are likely to be added later (see the excellent [too much crypto](https://eprint.iacr.org/2019/1492.pdf) paper for justification).