### PR TITLE
std/crypto: don't constrain Gimli hash output to a fixed length

### DIFF
--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -254,7 +254,7 @@ pub const Hash = struct {
     /// By default, Gimli-Hash provides a fixed-length output of 32 bytes
     /// (the concatenation of two 16-byte blocks).  However, Gimli-Hash can
     /// be used as an “extendable one-way function” (XOF).
-    pub fn final(self: *Self, out: *[digest_length]u8) void {
+    pub fn final(self: *Self, out: []u8) void {
         const buf = self.state.toSlice();
 
         // XOR 1 into the next byte of the state
@@ -266,7 +266,7 @@ pub const Hash = struct {
     }
 };
 
-pub fn hash(out: *[Hash.digest_length]u8, in: []const u8, options: Hash.Options) void {
+pub fn hash(out: []u8, in: []const u8, options: Hash.Options) void {
     var st = Hash.init(options);
     st.update(in);
     st.final(out);


### PR DESCRIPTION
As documented in the comment right above the finalization function, Gimli can be used as a XOF, i.e. the output doesn't have a fixed length.

So, allow it to be used that way, just like BLAKE3.