### PR TITLE
sparc64 has a 8Kb page size

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -20,6 +20,7 @@ pub const page_size = switch (builtin.arch) {
         .macos, .ios, .watchos, .tvos => 16 * 1024,
         else => 4 * 1024,
     },
+    .sparcv9 => 8 * 1024,
     else => 4 * 1024,
 };
 


### PR DESCRIPTION
Since support for sparc64 was recently added: use the correct page size for this architecture.