### PR TITLE
stage2: variable shadowing detection

### DIFF
--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -506,14 +506,14 @@ fn varDecl(
             .local_val => {
                 const local_val = s.cast(Scope.LocalVal).?;
                 if (mem.eql(u8, local_val.name, ident_name)) {
-                    return mod.fail(scope, name_src, "redeclaration of variable '{}'", .{ident_name});
+                    return mod.fail(scope, name_src, "redefinition of '{}'", .{ident_name});
                 }
                 s = local_val.parent;
             },
             .local_ptr => {
                 const local_ptr = s.cast(Scope.LocalPtr).?;
                 if (mem.eql(u8, local_ptr.name, ident_name)) {
-                    return mod.fail(scope, name_src, "redeclaration of variable '{}'", .{ident_name});
+                    return mod.fail(scope, name_src, "redefinition of '{}'", .{ident_name});
                 }
                 s = local_ptr.parent;
             },
@@ -524,7 +524,7 @@ fn varDecl(
 
     // Namespace vars shadowing detection
     if (mod.lookupDeclName(scope, ident_name)) |_| {
-        return mod.fail(scope, name_src, "redeclaration of variable '{}'", .{ident_name});
+        return mod.fail(scope, name_src, "redefinition of '{}'", .{ident_name});
     }
     const init_node = node.getInitNode() orelse
         return mod.fail(scope, name_src, "variables must be initialized", .{});

--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -489,7 +489,6 @@ fn varDecl(
     node: *ast.Node.VarDecl,
     block_arena: *Allocator,
 ) InnerError!*Scope {
-    // TODO implement detection of shadowing
     if (node.getComptimeToken()) |comptime_token| {
         return mod.failTok(scope, comptime_token, "TODO implement comptime locals", .{});
     }
@@ -499,6 +498,34 @@ fn varDecl(
     const tree = scope.tree();
     const name_src = tree.token_locs[node.name_token].start;
     const ident_name = try identifierTokenString(mod, scope, node.name_token);
+
+    // Local variables shadowing detection, including function parameters.
+    {
+        var s = scope;
+        while (true) switch (s.tag) {
+            .local_val => {
+                const local_val = s.cast(Scope.LocalVal).?;
+                if (mem.eql(u8, local_val.name, ident_name)) {
+                    return mod.fail(scope, name_src, "redeclaration of variable '{}'", .{ident_name});
+                }
+                s = local_val.parent;
+            },
+            .local_ptr => {
+                const local_ptr = s.cast(Scope.LocalPtr).?;
+                if (mem.eql(u8, local_ptr.name, ident_name)) {
+                    return mod.fail(scope, name_src, "redeclaration of variable '{}'", .{ident_name});
+                }
+                s = local_ptr.parent;
+            },
+            .gen_zir => s = s.cast(Scope.GenZIR).?.parent,
+            else => break,
+        };
+    }
+
+    // Namespace vars shadowing detection
+    if (mod.lookupDeclName(scope, ident_name)) |_| {
+        return mod.fail(scope, name_src, "redeclaration of variable '{}'", .{ident_name});
+    }
     const init_node = node.getInitNode() orelse
         return mod.fail(scope, name_src, "variables must be initialized", .{});
 

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1113,6 +1113,14 @@ pub fn addCases(ctx: *TestContext) !void {
         \\fn entry() void {}
     , &[_][]const u8{":2:4: error: redefinition of 'entry'"});
 
+    ctx.compileError("local variable shadowing", linux_x64,
+        \\export fn _start() noreturn {
+        \\    var i: u32 = 10;
+        \\    var i: u32 = 10;
+        \\    unreachable;
+        \\}
+    , &[_][]const u8{":3:9: error: redeclaration of variable 'i'"});
+
     {
         var case = ctx.obj("variable shadowing", linux_x64);
         case.addError(

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1113,13 +1113,23 @@ pub fn addCases(ctx: *TestContext) !void {
         \\fn entry() void {}
     , &[_][]const u8{":2:4: error: redefinition of 'entry'"});
 
-    ctx.compileError("local variable shadowing", linux_x64,
-        \\export fn _start() noreturn {
-        \\    var i: u32 = 10;
-        \\    var i: u32 = 10;
-        \\    unreachable;
-        \\}
-    , &[_][]const u8{":3:9: error: redeclaration of variable 'i'"});
+    {
+        var case = ctx.obj("variable shadowing", linux_x64);
+        case.addError(
+            \\export fn _start() noreturn {
+            \\    var i: u32 = 10;
+            \\    var i: u32 = 10;
+            \\    unreachable;
+            \\}
+        , &[_][]const u8{":3:9: error: redeclaration of variable 'i'"});
+        case.addError(
+            \\var testing: i64 = 10;
+            \\export fn _start() noreturn {
+            \\    var testing: i64 = 20;
+            \\    unreachable;
+            \\}
+        , &[_][]const u8{":3:9: error: redeclaration of variable 'testing'"});
+    }
 
     {
         var case = ctx.obj("extern variable has no type", linux_x64);

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -830,7 +830,7 @@ pub fn addCases(ctx: *TestContext) !void {
         // Character literals and multiline strings.
         case.addCompareOutput(
             \\export fn _start() noreturn {
-            \\    const ignore = 
+            \\    const ignore =
             \\        \\ cool thx
             \\        \\
             \\    ;
@@ -1112,6 +1112,14 @@ pub fn addCases(ctx: *TestContext) !void {
         \\fn entry() void {}
         \\fn entry() void {}
     , &[_][]const u8{":2:4: error: redefinition of 'entry'"});
+
+    ctx.compileError("local variable shadowing", linux_x64,
+        \\export fn _start() noreturn {
+        \\    var i: u32 = 10;
+        \\    var i: u32 = 10;
+        \\    unreachable;
+        \\}
+    , &[_][]const u8{":3:9: error: redeclaration of variable 'i'"});
 
     {
         var case = ctx.obj("extern variable has no type", linux_x64);

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1113,14 +1113,6 @@ pub fn addCases(ctx: *TestContext) !void {
         \\fn entry() void {}
     , &[_][]const u8{":2:4: error: redefinition of 'entry'"});
 
-    ctx.compileError("local variable shadowing", linux_x64,
-        \\export fn _start() noreturn {
-        \\    var i: u32 = 10;
-        \\    var i: u32 = 10;
-        \\    unreachable;
-        \\}
-    , &[_][]const u8{":3:9: error: redeclaration of variable 'i'"});
-
     {
         var case = ctx.obj("variable shadowing", linux_x64);
         case.addError(

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1121,14 +1121,14 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    var i: u32 = 10;
             \\    unreachable;
             \\}
-        , &[_][]const u8{":3:9: error: redeclaration of variable 'i'"});
+        , &[_][]const u8{":3:9: error: redefinition of 'i'"});
         case.addError(
             \\var testing: i64 = 10;
             \\export fn _start() noreturn {
             \\    var testing: i64 = 20;
             \\    unreachable;
             \\}
-        , &[_][]const u8{":3:9: error: redeclaration of variable 'testing'"});
+        , &[_][]const u8{":3:9: error: redefinition of 'testing'"});
     }
 
     {


### PR DESCRIPTION
This allows detection of variable shadowing in stage2, fixing a TODO in `varDecl` function. I added a `compileError` test to test/stage2/test.zig, but it didn't seem to run.

Edit:
The test actually did run and pass, but it said that it ran the wrong number of tests?
```
[jacob@archlinux ~co/zig/zig]$ zig build test-stage2
Test [1/17] test "self-hosted"... tests [1/28] referencing decls which appear later in the file [1/1] updAll 17 tests passed.
[jacob@archlinux ~co/zig/zig]$
```
Why does it say 1/17 and 1/28? and then only 17 tests pass? I think this is a bug in the testing code.