### PR TITLE
prctl improvements

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -5636,7 +5636,7 @@ pub const PrctlError = error{
     PermissionDenied,
 } || UnexpectedError;
 
-pub fn prctl(option: i32, args: anytype) PrctlError!u31 {
+pub fn prctl(option: PR, args: anytype) PrctlError!u31 {
     if (@typeInfo(@TypeOf(args)) != .Struct)
         @compileError("Expected tuple or struct argument, found " ++ @typeName(@TypeOf(args)));
     if (args.len > 4)
@@ -5648,7 +5648,7 @@ pub fn prctl(option: i32, args: anytype) PrctlError!u31 {
         inline while (i < args.len) : (i += 1) buf[i] = args[i];
     }
 
-    const rc = system.prctl(option, buf[0], buf[1], buf[2], buf[3]);
+    const rc = system.prctl(@enumToInt(option), buf[0], buf[1], buf[2], buf[3]);
     switch (errno(rc)) {
         0 => return @intCast(u31, rc),
         EACCES => return error.AccessDenied,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -5643,7 +5643,10 @@ pub fn prctl(option: i32, args: anytype) PrctlError!u31 {
         @compileError("prctl takes a maximum of 4 optional arguments");
 
     var buf: [4]usize = undefined;
-    inline for (args) |arg, i| buf[i] = arg;
+    {
+        comptime var i = 0;
+        inline while (i < args.len) : (i += 1) buf[i] = args[i];
+    }
 
     const rc = system.prctl(option, buf[0], buf[1], buf[2], buf[3]);
     switch (errno(rc)) {

--- a/lib/std/os/bits/linux/prctl.zig
+++ b/lib/std/os/bits/linux/prctl.zig
@@ -4,6 +4,88 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 
+pub const PR = extern enum(i32) {
+    SET_PDEATHSIG = 1,
+    GET_PDEATHSIG = 2,
+
+    GET_DUMPABLE = 3,
+    SET_DUMPABLE = 4,
+
+    GET_UNALIGN = 5,
+    SET_UNALIGN = 6,
+
+    GET_KEEPCAPS = 7,
+    SET_KEEPCAPS = 8,
+
+    GET_FPEMU = 9,
+    SET_FPEMU = 10,
+
+    GET_FPEXC = 11,
+    SET_FPEXC = 12,
+
+    GET_TIMING = 13,
+    SET_TIMING = 14,
+
+    SET_NAME = 15,
+    GET_NAME = 16,
+
+    GET_ENDIAN = 19,
+    SET_ENDIAN = 20,
+
+    GET_SECCOMP = 21,
+    SET_SECCOMP = 22,
+
+    CAPBSET_READ = 23,
+    CAPBSET_DROP = 24,
+
+    GET_TSC = 25,
+    SET_TSC = 26,
+
+    GET_SECUREBITS = 27,
+    SET_SECUREBITS = 28,
+
+    SET_TIMERSLACK = 29,
+    GET_TIMERSLACK = 30,
+
+    TASK_PERF_EVENTS_DISABLE = 31,
+    TASK_PERF_EVENTS_ENABLE = 32,
+
+    MCE_KILL = 33,
+
+    MCE_KILL_GET = 34,
+
+    SET_MM = 35,
+
+    SET_PTRACER = 0x59616d61,
+
+    SET_CHILD_SUBREAPER = 36,
+    GET_CHILD_SUBREAPER = 37,
+
+    SET_NO_NEW_PRIVS = 38,
+    GET_NO_NEW_PRIVS = 39,
+
+    GET_TID_ADDRESS = 40,
+
+    SET_THP_DISABLE = 41,
+    GET_THP_DISABLE = 42,
+
+    MPX_ENABLE_MANAGEMENT = 43,
+    MPX_DISABLE_MANAGEMENT = 44,
+
+    SET_FP_MODE = 45,
+    GET_FP_MODE = 46,
+
+    CAP_AMBIENT = 47,
+
+    SVE_SET_VL = 50,
+    SVE_GET_VL = 51,
+
+    GET_SPECULATION_CTRL = 52,
+    SET_SPECULATION_CTRL = 53,
+
+    _,
+};
+
 pub const PR_SET_PDEATHSIG = 1;
 pub const PR_GET_PDEATHSIG = 2;
 

--- a/lib/std/os/bits/linux/prctl.zig
+++ b/lib/std/os/bits/linux/prctl.zig
@@ -86,27 +86,27 @@ pub const PR = extern enum(i32) {
     _,
 };
 
-pub const PR_SET_PDEATHSIG = 1;
-pub const PR_GET_PDEATHSIG = 2;
+pub const PR_SET_PDEATHSIG = @enumToInt(PR.PR_SET_PDEATHSIG);
+pub const PR_GET_PDEATHSIG = @enumToInt(PR.PR_GET_PDEATHSIG);
 
-pub const PR_GET_DUMPABLE = 3;
-pub const PR_SET_DUMPABLE = 4;
+pub const PR_GET_DUMPABLE = @enumToInt(PR.PR_GET_DUMPABLE);
+pub const PR_SET_DUMPABLE = @enumToInt(PR.PR_SET_DUMPABLE);
 
-pub const PR_GET_UNALIGN = 5;
-pub const PR_SET_UNALIGN = 6;
+pub const PR_GET_UNALIGN = @enumToInt(PR.PR_GET_UNALIGN);
+pub const PR_SET_UNALIGN = @enumToInt(PR.PR_SET_UNALIGN);
 pub const PR_UNALIGN_NOPRINT = 1;
 pub const PR_UNALIGN_SIGBUS = 2;
 
-pub const PR_GET_KEEPCAPS = 7;
-pub const PR_SET_KEEPCAPS = 8;
+pub const PR_GET_KEEPCAPS = @enumToInt(PR.PR_GET_KEEPCAPS);
+pub const PR_SET_KEEPCAPS = @enumToInt(PR.PR_SET_KEEPCAPS);
 
-pub const PR_GET_FPEMU = 9;
-pub const PR_SET_FPEMU = 10;
+pub const PR_GET_FPEMU = @enumToInt(PR.PR_GET_FPEMU);
+pub const PR_SET_FPEMU = @enumToInt(PR.PR_SET_FPEMU);
 pub const PR_FPEMU_NOPRINT = 1;
 pub const PR_FPEMU_SIGFPE = 2;
 
-pub const PR_GET_FPEXC = 11;
-pub const PR_SET_FPEXC = 12;
+pub const PR_GET_FPEXC = @enumToInt(PR.PR_GET_FPEXC);
+pub const PR_SET_FPEXC = @enumToInt(PR.PR_SET_FPEXC);
 pub const PR_FP_EXC_SW_ENABLE = 0x80;
 pub const PR_FP_EXC_DIV = 0x010000;
 pub const PR_FP_EXC_OVF = 0x020000;
@@ -118,41 +118,41 @@ pub const PR_FP_EXC_NONRECOV = 1;
 pub const PR_FP_EXC_ASYNC = 2;
 pub const PR_FP_EXC_PRECISE = 3;
 
-pub const PR_GET_TIMING = 13;
-pub const PR_SET_TIMING = 14;
+pub const PR_GET_TIMING = @enumToInt(PR.PR_GET_TIMING);
+pub const PR_SET_TIMING = @enumToInt(PR.PR_SET_TIMING);
 pub const PR_TIMING_STATISTICAL = 0;
 pub const PR_TIMING_TIMESTAMP = 1;
 
-pub const PR_SET_NAME = 15;
-pub const PR_GET_NAME = 16;
+pub const PR_SET_NAME = @enumToInt(PR.PR_SET_NAME);
+pub const PR_GET_NAME = @enumToInt(PR.PR_GET_NAME);
 
-pub const PR_GET_ENDIAN = 19;
-pub const PR_SET_ENDIAN = 20;
+pub const PR_GET_ENDIAN = @enumToInt(PR.PR_GET_ENDIAN);
+pub const PR_SET_ENDIAN = @enumToInt(PR.PR_SET_ENDIAN);
 pub const PR_ENDIAN_BIG = 0;
 pub const PR_ENDIAN_LITTLE = 1;
 pub const PR_ENDIAN_PPC_LITTLE = 2;
 
-pub const PR_GET_SECCOMP = 21;
-pub const PR_SET_SECCOMP = 22;
+pub const PR_GET_SECCOMP = @enumToInt(PR.PR_GET_SECCOMP);
+pub const PR_SET_SECCOMP = @enumToInt(PR.PR_SET_SECCOMP);
 
-pub const PR_CAPBSET_READ = 23;
-pub const PR_CAPBSET_DROP = 24;
+pub const PR_CAPBSET_READ = @enumToInt(PR.PR_CAPBSET_READ);
+pub const PR_CAPBSET_DROP = @enumToInt(PR.PR_CAPBSET_DROP);
 
-pub const PR_GET_TSC = 25;
-pub const PR_SET_TSC = 26;
+pub const PR_GET_TSC = @enumToInt(PR.PR_GET_TSC);
+pub const PR_SET_TSC = @enumToInt(PR.PR_SET_TSC);
 pub const PR_TSC_ENABLE = 1;
 pub const PR_TSC_SIGSEGV = 2;
 
-pub const PR_GET_SECUREBITS = 27;
-pub const PR_SET_SECUREBITS = 28;
+pub const PR_GET_SECUREBITS = @enumToInt(PR.PR_GET_SECUREBITS);
+pub const PR_SET_SECUREBITS = @enumToInt(PR.PR_SET_SECUREBITS);
 
-pub const PR_SET_TIMERSLACK = 29;
-pub const PR_GET_TIMERSLACK = 30;
+pub const PR_SET_TIMERSLACK = @enumToInt(PR.PR_SET_TIMERSLACK);
+pub const PR_GET_TIMERSLACK = @enumToInt(PR.PR_GET_TIMERSLACK);
 
-pub const PR_TASK_PERF_EVENTS_DISABLE = 31;
-pub const PR_TASK_PERF_EVENTS_ENABLE = 32;
+pub const PR_TASK_PERF_EVENTS_DISABLE = @enumToInt(PR.PR_TASK_PERF_EVENTS_DISABLE);
+pub const PR_TASK_PERF_EVENTS_ENABLE = @enumToInt(PR.PR_TASK_PERF_EVENTS_ENABLE);
 
-pub const PR_MCE_KILL = 33;
+pub const PR_MCE_KILL = @enumToInt(PR.PR_MCE_KILL);
 pub const PR_MCE_KILL_CLEAR = 0;
 pub const PR_MCE_KILL_SET = 1;
 
@@ -160,9 +160,9 @@ pub const PR_MCE_KILL_LATE = 0;
 pub const PR_MCE_KILL_EARLY = 1;
 pub const PR_MCE_KILL_DEFAULT = 2;
 
-pub const PR_MCE_KILL_GET = 34;
+pub const PR_MCE_KILL_GET = @enumToInt(PR.PR_MCE_KILL_GET);
 
-pub const PR_SET_MM = 35;
+pub const PR_SET_MM = @enumToInt(PR.PR_SET_MM);
 pub const PR_SET_MM_START_CODE = 1;
 pub const PR_SET_MM_END_CODE = 2;
 pub const PR_SET_MM_START_DATA = 3;
@@ -196,42 +196,42 @@ pub const prctl_mm_map = extern struct {
     exe_fd: u32,
 };
 
-pub const PR_SET_PTRACER = 0x59616d61;
+pub const PR_SET_PTRACER = @enumToInt(PR.PR_SET_PTRACER);
 pub const PR_SET_PTRACER_ANY = std.math.maxInt(c_ulong);
 
-pub const PR_SET_CHILD_SUBREAPER = 36;
-pub const PR_GET_CHILD_SUBREAPER = 37;
+pub const PR_SET_CHILD_SUBREAPER = @enumToInt(PR.PR_SET_CHILD_SUBREAPER);
+pub const PR_GET_CHILD_SUBREAPER = @enumToInt(PR.PR_GET_CHILD_SUBREAPER);
 
-pub const PR_SET_NO_NEW_PRIVS = 38;
-pub const PR_GET_NO_NEW_PRIVS = 39;
+pub const PR_SET_NO_NEW_PRIVS = @enumToInt(PR.PR_SET_NO_NEW_PRIVS);
+pub const PR_GET_NO_NEW_PRIVS = @enumToInt(PR.PR_GET_NO_NEW_PRIVS);
 
-pub const PR_GET_TID_ADDRESS = 40;
+pub const PR_GET_TID_ADDRESS = @enumToInt(PR.PR_GET_TID_ADDRESS);
 
-pub const PR_SET_THP_DISABLE = 41;
-pub const PR_GET_THP_DISABLE = 42;
+pub const PR_SET_THP_DISABLE = @enumToInt(PR.PR_SET_THP_DISABLE);
+pub const PR_GET_THP_DISABLE = @enumToInt(PR.PR_GET_THP_DISABLE);
 
-pub const PR_MPX_ENABLE_MANAGEMENT = 43;
-pub const PR_MPX_DISABLE_MANAGEMENT = 44;
+pub const PR_MPX_ENABLE_MANAGEMENT = @enumToInt(PR.PR_MPX_ENABLE_MANAGEMENT);
+pub const PR_MPX_DISABLE_MANAGEMENT = @enumToInt(PR.PR_MPX_DISABLE_MANAGEMENT);
 
-pub const PR_SET_FP_MODE = 45;
-pub const PR_GET_FP_MODE = 46;
+pub const PR_SET_FP_MODE = @enumToInt(PR.PR_SET_FP_MODE);
+pub const PR_GET_FP_MODE = @enumToInt(PR.PR_GET_FP_MODE);
 pub const PR_FP_MODE_FR = 1 << 0;
 pub const PR_FP_MODE_FRE = 1 << 1;
 
-pub const PR_CAP_AMBIENT = 47;
+pub const PR_CAP_AMBIENT = @enumToInt(PR.PR_CAP_AMBIENT);
 pub const PR_CAP_AMBIENT_IS_SET = 1;
 pub const PR_CAP_AMBIENT_RAISE = 2;
 pub const PR_CAP_AMBIENT_LOWER = 3;
 pub const PR_CAP_AMBIENT_CLEAR_ALL = 4;
 
-pub const PR_SVE_SET_VL = 50;
+pub const PR_SVE_SET_VL = @enumToInt(PR.PR_SVE_SET_VL);
 pub const PR_SVE_SET_VL_ONEXEC = 1 << 18;
-pub const PR_SVE_GET_VL = 51;
+pub const PR_SVE_GET_VL = @enumToInt(PR.PR_SVE_GET_VL);
 pub const PR_SVE_VL_LEN_MASK = 0xffff;
 pub const PR_SVE_VL_INHERIT = 1 << 17;
 
-pub const PR_GET_SPECULATION_CTRL = 52;
-pub const PR_SET_SPECULATION_CTRL = 53;
+pub const PR_GET_SPECULATION_CTRL = @enumToInt(PR.PR_GET_SPECULATION_CTRL);
+pub const PR_SET_SPECULATION_CTRL = @enumToInt(PR.PR_SET_SPECULATION_CTRL);
 pub const PR_SPEC_STORE_BYPASS = 0;
 pub const PR_SPEC_NOT_AFFECTED = 0;
 pub const PR_SPEC_PRCTL = 1 << 0;


### PR DESCRIPTION
Includes:
  - workaround for #280
  - use a non-exhaustive enum for opcodes