### PR TITLE
Fix CoInitializeEx so it can take a null pointer

### DIFF
--- a/lib/std/os/windows/bits.zig
+++ b/lib/std/os/windows/bits.zig
@@ -60,6 +60,7 @@ pub const SIZE_T = usize;
 pub const TCHAR = if (UNICODE) WCHAR else u8;
 pub const UINT = c_uint;
 pub const ULONG_PTR = usize;
+pub const LONG_PTR = isize;
 pub const DWORD_PTR = ULONG_PTR;
 pub const UNICODE = false;
 pub const WCHAR = u16;

--- a/lib/std/os/windows/ole32.zig
+++ b/lib/std/os/windows/ole32.zig
@@ -8,4 +8,4 @@ usingnamespace @import("bits.zig");
 pub extern "ole32" fn CoTaskMemFree(pv: LPVOID) callconv(.Stdcall) void;
 pub extern "ole32" fn CoUninitialize() callconv(.Stdcall) void;
 pub extern "ole32" fn CoGetCurrentProcess() callconv(.Stdcall) DWORD;
-pub extern "ole32" fn CoInitializeEx(pvReserved: LPVOID, dwCoInit: DWORD) callconv(.Stdcall) HRESULT;
+pub extern "ole32" fn CoInitializeEx(pvReserved: ?LPVOID, dwCoInit: DWORD) callconv(.Stdcall) HRESULT;


### PR DESCRIPTION
So CoInitializeEx is specified so you have to pass in a null pointer in the first argument. Unfortunately in our declaration we said we can't take a null pointer. This fixes that issue.