### PR TITLE
Add error.ArgumentsInvalid to os.openatZ()

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -660,6 +660,7 @@ pub const Dir = struct {
         InvalidUtf8,
         BadPathName,
         DeviceBusy,
+        ArgumentsInvalid,
     } || os.UnexpectedError;
 
     pub fn close(self: *Dir) void {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1020,6 +1020,12 @@ pub const OpenError = error{
 
     BadPathName,
     InvalidUtf8,
+
+    // The final component ("basename") of the path is invalid, or
+    // the underlying filesystem does not support the O_DIRECT flag, or
+    // O_TMPFILE was specified without O_WRONLY or O_RDWR, or
+    // there is an invalid value in flags:
+    ArgumentsInvalid,
 } || UnexpectedError;
 
 /// Open and possibly create a file. Keeps trying if it gets interrupted.

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1183,7 +1183,7 @@ pub fn openatZ(dir_fd: fd_t, file_path: [*:0]const u8, flags: u32, mode: mode_t)
             EINTR => continue,
 
             EFAULT => unreachable,
-            EINVAL => unreachable,
+            EINVAL => return error.ArgumentsInvalid,
             EACCES => return error.AccessDenied,
             EFBIG => return error.FileTooBig,
             EOVERFLOW => return error.FileTooBig,


### PR DESCRIPTION
This is necessary to handle file systems that do not support O_DIRECT,
and other common file system features.

Fixes: https://github.com/ziglang/zig/issues/6925