### PR TITLE
stage1: Resolve ErrorUnion children types

### DIFF
--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -745,8 +745,14 @@ ZigType *get_error_union_type(CodeGen *g, ZigType *err_set_type, ZigType *payloa
         return existing_entry->value;
     }
 
+    Error err;
+    if ((err = type_resolve(g, err_set_type, ResolveStatusSizeKnown)))
+        return g->builtin_types.entry_invalid;
+
+    if ((err = type_resolve(g, payload_type, ResolveStatusSizeKnown)))
+        return g->builtin_types.entry_invalid;
+
     ZigType *entry = new_type_table_entry(ZigTypeIdErrorUnion);
-    assert(type_is_resolved(payload_type, ResolveStatusSizeKnown));
 
     buf_resize(&entry->name, 0);
     buf_appendf(&entry->name, "%s!%s", buf_ptr(&err_set_type->name), buf_ptr(&payload_type->name));

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -56,6 +56,7 @@ comptime {
     _ = @import("behavior/bugs/6456.zig");
     _ = @import("behavior/bugs/6781.zig");
     _ = @import("behavior/bugs/6850.zig");
+    _ = @import("behavior/bugs/7003.zig");
     _ = @import("behavior/bugs/394.zig");
     _ = @import("behavior/bugs/421.zig");
     _ = @import("behavior/bugs/529.zig");

--- a/test/stage1/behavior/bugs/7003.zig
+++ b/test/stage1/behavior/bugs/7003.zig
@@ -1,0 +1,8 @@
+test "@Type should resolve its children types" {
+    const sparse = enum(u2) { a, b, c };
+    const dense = enum(u2) { a, b, c, d };
+
+    comptime var sparse_info = @typeInfo(anyerror!sparse);
+    sparse_info.ErrorUnion.payload = dense;
+    const B = @Type(sparse_info);
+}


### PR DESCRIPTION
Since the code is accessing the abi_size field compute the full type
size for both err_set_type and payload_type, not only for the latter.

Closes #7003 