### PR TITLE
Implement chdir and chdirZ for Windows

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2309,13 +2309,8 @@ pub fn chdir(dir_path: []const u8) ChangeCurDirError!void {
         @compileError("chdir is not supported in WASI");
     } else if (builtin.os.tag == .windows) {
         windows.SetCurrentDirectory(dir_path) catch |err| switch (err) {
-            error.InvalidUtf8 => return error.InvalidUtf8,
-            error.NameTooLong => return error.NameTooLong,
-            error.FileNotFound => return error.FileNotFound,
-            error.NotDir => return error.NotDir,
             error.NoDevice => return error.FileSystem,
-            error.AccessDenied => return error.AccessDenied,
-            error.Unexpected => return error.Unexpected,
+            else => |e| return e,
         };
     } else {
         const dir_path_c = try toPosixPath(dir_path);

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -565,28 +565,25 @@ pub const SetCurrentDirectoryError = error{
     NotDir,
     AccessDenied,
     NoDevice,
+    BadPathName,
     Unexpected,
 };
 
-pub fn SetCurrentDirectory(path_name: []const u8) SetCurrentDirectoryError!void {
-    var path_space: PathSpace = undefined;
-    path_space.len = try std.unicode.utf8ToUtf16Le(path_space.data[0..], path_name);
-    if (path_space.len > path_space.data.len) return error.NameTooLong;
-    
-    const path_len_bytes = math.cast(u16, path_space.len * 2) catch |err| switch (err) {
+pub fn SetCurrentDirectory(path_name: []const u16) SetCurrentDirectoryError!void {
+    const path_len_bytes = math.cast(u16, path_name.len * 2) catch |err| switch (err) {
         error.Overflow => return error.NameTooLong,
     };
     
     var nt_name = UNICODE_STRING{
         .Length = path_len_bytes,
         .MaximumLength = path_len_bytes,
-        .Buffer = @intToPtr([*]u16, @ptrToInt(&path_space.data)),
+        .Buffer = @intToPtr([*]u16, @ptrToInt(path_name.ptr)),
     };
     
     const rc = ntdll.RtlSetCurrentDirectory_U(&nt_name);
     switch (rc) {
         .SUCCESS => {},
-        .OBJECT_NAME_INVALID => unreachable,
+        .OBJECT_NAME_INVALID => return error.BadPathName,
         .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
         .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
         .NO_MEDIA_IN_DEVICE => return error.NoDevice,

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -559,29 +559,42 @@ pub fn WriteFile(
 }
 
 pub const SetCurrentDirectoryError = error{
-    PathNotFound,
-    InvalidName,
-    InvalidUtf8,
     NameTooLong,
+    InvalidUtf8,
+    FileNotFound,
     NotDir,
+    AccessDenied,
+    NoDevice,
     Unexpected,
 };
 
 pub fn SetCurrentDirectory(path_name: []const u8) SetCurrentDirectoryError!void {
-    // PATH_MAX_WIDE - 1 as we need to ensure there is space for the null terminator
-    if (path_name.len >= PATH_MAX_WIDE - 1) return error.NameTooLong;
+    var path_space: PathSpace = undefined;
+    path_space.len = try std.unicode.utf8ToUtf16Le(path_space.data[0..], path_name);
+    if (path_space.len > path_space.data.len) return error.NameTooLong;
     
-    var utf16le_buf: [PATH_MAX_WIDE]u16 = undefined;
-    const end = try std.unicode.utf8ToUtf16Le(utf16le_buf[0..], path_name);
-    utf16le_buf[end] = 0;
+    const path_len_bytes = math.cast(u16, path_space.len * 2) catch |err| switch (err) {
+        error.Overflow => return error.NameTooLong,
+    };
     
-    if (kernel32.SetCurrentDirectoryW(@ptrCast([*:0]const u16, &utf16le_buf)) == 0) {
-        switch (kernel32.GetLastError()) {
-            .PATH_NOT_FOUND, .FILE_NOT_FOUND => return error.PathNotFound,
-            .DIRECTORY => return error.NotDir,
-            .INVALID_NAME => return error.InvalidName,
-            else => |err| return unexpectedError(err),
-        }
+    var nt_name = UNICODE_STRING{
+        .Length = path_len_bytes,
+        .MaximumLength = path_len_bytes,
+        .Buffer = @intToPtr([*]u16, @ptrToInt(&path_space.data)),
+    };
+    
+    const rc = ntdll.RtlSetCurrentDirectory_U(&nt_name);
+    switch (rc) {
+        .SUCCESS => {},
+        .OBJECT_NAME_INVALID => unreachable,
+        .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
+        .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
+        .NO_MEDIA_IN_DEVICE => return error.NoDevice,
+        .INVALID_PARAMETER => unreachable,
+        .ACCESS_DENIED => return error.AccessDenied,
+        .OBJECT_PATH_SYNTAX_BAD => unreachable,
+        .NOT_A_DIRECTORY => return error.NotDir,
+        else => return unexpectedStatus(rc),
     }
 }
 

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -558,6 +558,33 @@ pub fn WriteFile(
     }
 }
 
+pub const SetCurrentDirectoryError = error{
+    PathNotFound,
+    InvalidName,
+    InvalidUtf8,
+    NameTooLong,
+    NotDir,
+    Unexpected,
+};
+
+pub fn SetCurrentDirectory(path_name: []const u8) SetCurrentDirectoryError!void {
+    // PATH_MAX_WIDE - 1 as we need to ensure there is space for the null terminator
+    if (path_name.len >= PATH_MAX_WIDE - 1) return error.NameTooLong;
+    
+    var utf16le_buf: [PATH_MAX_WIDE]u16 = undefined;
+    const end = try std.unicode.utf8ToUtf16Le(utf16le_buf[0..], path_name);
+    utf16le_buf[end] = 0;
+    
+    if (kernel32.SetCurrentDirectoryW(@ptrCast([*:0]const u16, &utf16le_buf)) == 0) {
+        switch (kernel32.GetLastError()) {
+            .PATH_NOT_FOUND, .FILE_NOT_FOUND => return error.PathNotFound,
+            .DIRECTORY => return error.NotDir,
+            .INVALID_NAME => return error.InvalidName,
+            else => |err| return unexpectedError(err),
+        }
+    }
+}
+
 pub const GetCurrentDirectoryError = error{
     NameTooLong,
     Unexpected,

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -93,7 +93,6 @@ pub extern "kernel32" fn FillConsoleOutputCharacterA(hConsoleOutput: HANDLE, cCh
 pub extern "kernel32" fn FillConsoleOutputAttribute(hConsoleOutput: HANDLE, wAttribute: WORD, nLength: DWORD, dwWriteCoord: COORD, lpNumberOfAttrsWritten: LPDWORD) callconv(.Stdcall) BOOL;
 pub extern "kernel32" fn SetConsoleCursorPosition(hConsoleOutput: HANDLE, dwCursorPosition: COORD) callconv(.Stdcall) BOOL;
 
-pub extern "kernel32" fn SetCurrentDirectoryW(lpPathName: [*:0]const u16) callconv(.Stdcall) BOOL;
 pub extern "kernel32" fn GetCurrentDirectoryW(nBufferLength: DWORD, lpBuffer: ?[*]WCHAR) callconv(.Stdcall) DWORD;
 
 pub extern "kernel32" fn GetCurrentThread() callconv(.Stdcall) HANDLE;

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -93,6 +93,7 @@ pub extern "kernel32" fn FillConsoleOutputCharacterA(hConsoleOutput: HANDLE, cCh
 pub extern "kernel32" fn FillConsoleOutputAttribute(hConsoleOutput: HANDLE, wAttribute: WORD, nLength: DWORD, dwWriteCoord: COORD, lpNumberOfAttrsWritten: LPDWORD) callconv(.Stdcall) BOOL;
 pub extern "kernel32" fn SetConsoleCursorPosition(hConsoleOutput: HANDLE, dwCursorPosition: COORD) callconv(.Stdcall) BOOL;
 
+pub extern "kernel32" fn SetCurrentDirectoryW(lpPathName: [*:0]const u16) callconv(.Stdcall) BOOL;
 pub extern "kernel32" fn GetCurrentDirectoryW(nBufferLength: DWORD, lpBuffer: ?[*]WCHAR) callconv(.Stdcall) DWORD;
 
 pub extern "kernel32" fn GetCurrentThread() callconv(.Stdcall) HANDLE;

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -111,3 +111,7 @@ pub extern "NtDll" fn NtWaitForKeyedEvent(
     Alertable: BOOLEAN,
     Timeout: ?*LARGE_INTEGER,
 ) callconv(.Stdcall) NTSTATUS;
+
+pub extern "NtDll" fn RtlSetCurrentDirectory_U(
+    PathName: *UNICODE_STRING
+) callconv(.Stdcall) NTSTATUS;


### PR DESCRIPTION
Replaced the `@compileError`'s for Windows in `chdir` and `chdirZ` with an implementation calling into kernel32 `SetCurrentDirectoryW`