### PR TITLE
stage1: Print correct error message for vector @intCast

### DIFF
--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -1487,7 +1487,7 @@ static LLVMValueRef gen_widen_or_shorten(CodeGen *g, bool want_runtime_safety, Z
         LLVMBuildCondBr(g->builder, ok_bit, ok_block, fail_block);
 
         LLVMPositionBuilderAtEnd(g->builder, fail_block);
-        gen_safety_crash(g, actual_type->data.integral.is_signed ? PanicMsgIdCastNegativeToUnsigned : PanicMsgIdCastTruncatedData);
+        gen_safety_crash(g, scalar_actual_type->data.integral.is_signed ? PanicMsgIdCastNegativeToUnsigned : PanicMsgIdCastTruncatedData);
 
         LLVMPositionBuilderAtEnd(g->builder, ok_block);
     }

--- a/test/runtime_safety.zig
+++ b/test/runtime_safety.zig
@@ -89,7 +89,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\const std = @import("std");
         \\const V = @import("std").meta.Vector;
         \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
-        \\    if (std.mem.eql(u8, message, "attempt to cast negative value to unsigned integer")) {
+        \\    if (std.mem.eql(u8, message, "integer cast truncated bits")) {
         \\        std.process.exit(126); // good
         \\    }
         \\    std.process.exit(0); // test failed
@@ -97,6 +97,21 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\pub fn main() void {
         \\    var x = @splat(4, @as(u32, 0x80000000));
         \\    var y = @intCast(V(4, i32), x);
+        \\}
+    );
+
+    cases.addRuntimeSafety("signed-unsigned vector cast",
+        \\const std = @import("std");
+        \\const V = @import("std").meta.Vector;
+        \\pub fn panic(message: []const u8, stack_trace: ?*@import("builtin").StackTrace) noreturn {
+        \\    if (std.mem.eql(u8, message, "attempt to cast negative value to unsigned integer")) {
+        \\        std.process.exit(126); // good
+        \\    }
+        \\    std.process.exit(0); // test failed
+        \\}
+        \\pub fn main() void {
+        \\    var x = @splat(4, @as(i32, -2147483647));
+        \\    var y = @intCast(V(4, u32), x);
         \\}
     );
 


### PR DESCRIPTION
> I suspect it could be based on what vector CPU features are available.

It's much sillier than that, nobody noticed a typo :)