### PR TITLE
std/crypto: implement the Hash-To-Curve standard for Edwards25519

### DIFF
--- a/lib/std/crypto/25519/field.zig
+++ b/lib/std/crypto/25519/field.zig
@@ -12,26 +12,46 @@ pub const Fe = struct {
 
     const MASK51: u64 = 0x7ffffffffffff;
 
+    /// 0
     pub const zero = Fe{ .limbs = .{ 0, 0, 0, 0, 0 } };
 
+    /// 1
     pub const one = Fe{ .limbs = .{ 1, 0, 0, 0, 0 } };
 
-    pub const sqrtm1 = Fe{ .limbs = .{ 1718705420411056, 234908883556509, 2233514472574048, 2117202627021982, 765476049583133 } }; // sqrt(-1)
+    /// sqrt(-1)
+    pub const sqrtm1 = Fe{ .limbs = .{ 1718705420411056, 234908883556509, 2233514472574048, 2117202627021982, 765476049583133 } };
 
+    /// The Curve25519 base point
     pub const curve25519BasePoint = Fe{ .limbs = .{ 9, 0, 0, 0, 0 } };
 
-    pub const edwards25519d = Fe{ .limbs = .{ 929955233495203, 466365720129213, 1662059464998953, 2033849074728123, 1442794654840575 } }; // 37095705934669439343138083508754565189542113879843219016388785533085940283555
+    /// Edwards25519 d = 37095705934669439343138083508754565189542113879843219016388785533085940283555
+    pub const edwards25519d = Fe{ .limbs = .{ 929955233495203, 466365720129213, 1662059464998953, 2033849074728123, 1442794654840575 } };
 
-    pub const edwards25519d2 = Fe{ .limbs = .{ 1859910466990425, 932731440258426, 1072319116312658, 1815898335770999, 633789495995903 } }; // 2d
+    /// Edwards25519 2d
+    pub const edwards25519d2 = Fe{ .limbs = .{ 1859910466990425, 932731440258426, 1072319116312658, 1815898335770999, 633789495995903 } };
 
-    pub const edwards25519sqrtamd = Fe{ .limbs = .{ 278908739862762, 821645201101625, 8113234426968, 1777959178193151, 2118520810568447 } }; // 1/sqrt(a-d)
+    /// Edwards25519 1/sqrt(a-d)
+    pub const edwards25519sqrtamd = Fe{ .limbs = .{ 278908739862762, 821645201101625, 8113234426968, 1777959178193151, 2118520810568447 } };
 
-    pub const edwards25519eonemsqd = Fe{ .limbs = .{ 1136626929484150, 1998550399581263, 496427632559748, 118527312129759, 45110755273534 } }; // 1-d^2
+    /// Edwards25519 1-d^2
+    pub const edwards25519eonemsqd = Fe{ .limbs = .{ 1136626929484150, 1998550399581263, 496427632559748, 118527312129759, 45110755273534 } };
 
-    pub const edwards25519sqdmone = Fe{ .limbs = .{ 1507062230895904, 1572317787530805, 683053064812840, 317374165784489, 1572899562415810 } }; // (d-1)^2
+    /// Edwards25519 (d-1)^2
+    pub const edwards25519sqdmone = Fe{ .limbs = .{ 1507062230895904, 1572317787530805, 683053064812840, 317374165784489, 1572899562415810 } };
 
+    /// Edwards25519 sqrt(ad-1) with a = -1 (mod p)
     pub const edwards25519sqrtadm1 = Fe{ .limbs = .{ 2241493124984347, 425987919032274, 2207028919301688, 1220490630685848, 974799131293748 } };
 
+    /// Edwards25519 A, as a single limb
+    pub const edwards25519a_32: u32 = 486662;
+
+    /// Edwards25519 A
+    pub const edwards25519a = Fe{ .limbs = .{ @as(u64, edwards25519a_32), 0, 0, 0, 0 } };
+
+    /// Edwards25519 sqrt(A-2)
+    pub const edwards25519sqrtam2 = Fe{ .limbs = .{ 1693982333959686, 608509411481997, 2235573344831311, 947681270984193, 266558006233600 } };
+
+    /// Return true if the field element is zero
     pub inline fn isZero(fe: Fe) bool {
         var reduced = fe;
         reduced.reduce();
@@ -39,10 +59,12 @@ pub const Fe = struct {
         return (limbs[0] | limbs[1] | limbs[2] | limbs[3] | limbs[4]) == 0;
     }
 
+    /// Return true if both field elements are equivalent
     pub inline fn equivalent(a: Fe, b: Fe) bool {
         return a.sub(b).isZero();
     }
 
+    /// Unpack a field element
     pub fn fromBytes(s: [32]u8) Fe {
         var fe: Fe = undefined;
         fe.limbs[0] = readIntLittle(u64, s[0..8]) & MASK51;
@@ -54,6 +76,7 @@ pub const Fe = struct {
         return fe;
     }
 
+    /// Pack a field element
     pub fn toBytes(fe: Fe) [32]u8 {
         var reduced = fe;
         reduced.reduce();
@@ -66,6 +89,29 @@ pub const Fe = struct {
         return s;
     }
 
+    /// Map a 64-bit big endian string into a field element
+    pub fn fromBytes64(s: [64]u8) Fe {
+        var fl: [32]u8 = undefined;
+        var gl: [32]u8 = undefined;
+        var i: usize = 0;
+        while (i < 32) : (i += 1) {
+            fl[i] = s[63 - i];
+            gl[i] = s[31 - i];
+        }
+        fl[31] &= 0x7f;
+        gl[31] &= 0x7f;
+        var fe_f = fromBytes(fl);
+        const fe_g = fromBytes(gl);
+        fe_f.limbs[0] += (s[32] >> 7) * 19;
+        i = 0;
+        while (i < 5) : (i += 1) {
+            fe_f.limbs[i] += 38 * fe_g.limbs[i];
+        }
+        fe_f.reduce();
+        return fe_f;
+    }
+
+    /// Reject non-canonical encodings of an element, possibly ignoring the top bit
     pub fn rejectNonCanonical(s: [32]u8, comptime ignore_extra_bit: bool) !void {
         var c: u16 = (s[31] & 0x7f) ^ 0x7f;
         comptime var i = 30;
@@ -80,6 +126,7 @@ pub const Fe = struct {
         }
     }
 
+    /// Reduce a field element mod 2^255-19
     fn reduce(fe: *Fe) void {
         comptime var i = 0;
         comptime var j = 0;
@@ -116,6 +163,7 @@ pub const Fe = struct {
         limbs[4] &= MASK51;
     }
 
+    /// Add a field element
     pub inline fn add(a: Fe, b: Fe) Fe {
         var fe: Fe = undefined;
         comptime var i = 0;
@@ -125,6 +173,7 @@ pub const Fe = struct {
         return fe;
     }
 
+    /// Substract a field elememnt
     pub inline fn sub(a: Fe, b: Fe) Fe {
         var fe = b;
         comptime var i = 0;
@@ -143,14 +192,17 @@ pub const Fe = struct {
         return fe;
     }
 
+    /// Negate a field element
     pub inline fn neg(a: Fe) Fe {
         return zero.sub(a);
     }
 
+    /// Return true if a field element is negative
     pub inline fn isNegative(a: Fe) bool {
         return (a.toBytes()[0] & 1) != 0;
     }
 
+    /// Conditonally replace a field element with `a` if `c` is positive
     pub inline fn cMov(fe: *Fe, a: Fe, c: u64) void {
         const mask: u64 = 0 -% c;
         var x = fe.*;
@@ -168,6 +220,7 @@ pub const Fe = struct {
         }
     }
 
+    /// Conditionally swap two pairs of field elements if `c` is positive
     pub fn cSwap2(a0: *Fe, b0: *Fe, a1: *Fe, b1: *Fe, c: u64) void {
         const mask: u64 = 0 -% c;
         var x0 = a0.*;
@@ -211,6 +264,7 @@ pub const Fe = struct {
         return .{ .limbs = rs };
     }
 
+    /// Multiply two field elements
     pub inline fn mul(a: Fe, b: Fe) Fe {
         var ax: [5]u128 = undefined;
         var bx: [5]u128 = undefined;
@@ -262,14 +316,17 @@ pub const Fe = struct {
         return _carry128(&r);
     }
 
+    /// Square a field element
     pub inline fn sq(a: Fe) Fe {
         return _sq(a, false);
     }
 
+    /// Square and double a field element
     pub inline fn sq2(a: Fe) Fe {
         return _sq(a, true);
     }
 
+    /// Multiply a field element with a small (32-bit) integer
     pub inline fn mul32(a: Fe, comptime n: u32) Fe {
         const sn = @intCast(u128, n);
         var fe: Fe = undefined;
@@ -284,6 +341,7 @@ pub const Fe = struct {
         return fe;
     }
 
+    /// Square a field element `n` times
     inline fn sqn(a: Fe, comptime n: comptime_int) Fe {
         var i: usize = 0;
         var fe = a;
@@ -293,6 +351,7 @@ pub const Fe = struct {
         return fe;
     }
 
+    /// Compute the inverse of a field element
     pub fn invert(a: Fe) Fe {
         var t0 = a.sq();
         var t1 = t0.sqn(2).mul(a);
@@ -306,6 +365,8 @@ pub const Fe = struct {
         return t1.mul(t2.mul(t2.sqn(100)).sqn(50)).sqn(5).mul(t0);
     }
 
+    /// Return a^((p-5)/8) = a^(2^252-3)
+    /// Used to compute square roots since we have p=5 (mod 8); see Cohen and Frey.
     pub fn pow2523(a: Fe) Fe {
         var t0 = a.mul(a.sq());
         var t1 = t0.mul(t0.sqn(2)).sq().mul(a);
@@ -317,9 +378,47 @@ pub const Fe = struct {
         return t1.sqn(120).mul(t1).sqn(10).mul(t0).sqn(2).mul(a);
     }
 
+    /// Return the absolute value of a field element
     pub fn abs(a: Fe) Fe {
         var r = a;
         r.cMov(a.neg(), @boolToInt(a.isNegative()));
         return r;
+    }
+
+    /// Return true if the field element is a square
+    pub fn isSquare(a: Fe) bool {
+        // Compute the Jacobi symbol x^((p-1)/2)
+        const _11 = a.mul(a.sq());
+        const _1111 = _11.mul(_11.sq().sq());
+        const _11111111 = _1111.mul(_1111.sq().sq().sq().sq());
+        var t = _11111111.sqn(2).mul(_11);
+        const u = t;
+        t = t.sqn(10).mul(u).sqn(10).mul(u);
+        t = t.sqn(30).mul(t);
+        t = t.sqn(60).mul(t);
+        t = t.sqn(120).mul(t).sqn(10).mul(u).sqn(3).mul(_11).sq();
+        return @bitCast(bool, @truncate(u1, ~(t.toBytes()[1] & 1)));
+    }
+
+    fn uncheckedSqrt(x2: Fe) Fe {
+        var e = x2.pow2523();
+        const p_root = e.mul(x2); // positive root
+        const m_root = p_root.mul(Fe.sqrtm1); // negative root
+        const m_root2 = m_root.sq();
+        e = x2.sub(m_root2);
+        var x = p_root;
+        x.cMov(m_root, @boolToInt(e.isZero()));
+        return x;
+    }
+
+    /// Compute the square root of `x2`, returning `error.NotSquare` if `x2` was not a square
+    pub fn sqrt(x2: Fe) !Fe {
+        var x2_copy = x2;
+        const x = x2.uncheckedSqrt();
+        const check = x.sq().sub(x2_copy);
+        if (check.isZero()) {
+            return x;
+        }
+        return error.NotSquare;
     }
 };


### PR DESCRIPTION
This will allow Zig to be added to the list of compliant implementations of the [Hashing to Elliptic Curves](https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve) standard.

This is quite an important feature to have since many other standards being worked on depend on it.

Brings a couple useful arithmetic operations on field elements by the way.

This PR also adds comments to the functions we expose in 25519/field so that they can appear in the generated documentation.

This is a lazy port of the code I originally wrote for libsodium, but it has the advantage of already being well tested and conform to the standard.