### PR TITLE
start.zig: call wWinMain with root's type

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -354,13 +354,14 @@ pub fn callMain() u8 {
 }
 
 pub fn call_wWinMain() std.os.windows.INT {
-    const hInstance = @ptrCast(std.os.windows.HINSTANCE, std.os.windows.kernel32.GetModuleHandleW(null).?);
-    const hPrevInstance: ?std.os.windows.HINSTANCE = null; // MSDN: "This parameter is always NULL"
+    const MAIN_HINSTANCE = @typeInfo(@TypeOf(root.wWinMain)).Fn.args[0].arg_type.?;
+    const hInstance = @ptrCast(MAIN_HINSTANCE, std.os.windows.kernel32.GetModuleHandleW(null).?);
     const lpCmdLine = std.os.windows.kernel32.GetCommandLineW();
 
     // There's no (documented) way to get the nCmdShow parameter, so we're
     // using this fairly standard default.
     const nCmdShow = std.os.windows.user32.SW_SHOW;
 
-    return root.wWinMain(hInstance, hPrevInstance, lpCmdLine, nCmdShow);
+    // second parameter hPrevInstance, MSDN: "This parameter is always NULL"
+    return root.wWinMain(hInstance, null, lpCmdLine, nCmdShow);
 }


### PR DESCRIPTION
I have an alternative set of windows bindings I'm working on: https://github.com/marler8997/zig-os-windows.

So I'm declaring my `wWinMain` function with my own `HINSTANCE` type rather than the one from std.os.windows (see https://github.com/marler8997/zig-os-windows/blob/master/examples/helloworld-window.zig).

This change modifies `start.zig` to use whatever pointer type is declared in `wWinMain`.