### PR TITLE
Don't prevent compilation on platforms where debug info is unsupported

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -666,7 +666,7 @@ pub fn openSelfDebugInfo(allocator: *mem.Allocator) anyerror!DebugInfo {
             .macos,
             .windows,
             => return DebugInfo.init(allocator),
-            else => @compileError("openSelfDebugInfo unsupported for this platform"),
+            else => return error.UnsupportedDebugInfo,
         }
     }
 }


### PR DESCRIPTION
We don't support debug information on platforms that are not tier-1, but it shouldn't be a hard error that completely prevents compilation.