### PR TITLE
ptrCast between pointer types of different sizes no longer allowed

### DIFF
--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -231,7 +231,12 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
                 const start_ptr = @ptrCast([*]u8, bucket) + bucketStackFramesStart(size_class);
                 const addr = start_ptr + one_trace_size * traces_per_slot * slot_index +
                     @enumToInt(trace_kind) * @as(usize, one_trace_size);
-                return @ptrCast(*[stack_n]usize, @alignCast(@alignOf(usize), addr));
+                if (stack_n > 0) {
+                    return @ptrCast(*[stack_n]usize, @alignCast(@alignOf(usize), addr));
+                } else {
+                    comptime var ret = [0]usize {};
+                    return &ret;
+                }
             }
 
             fn captureStackTrace(

--- a/test/stage1/behavior/cast.zig
+++ b/test/stage1/behavior/cast.zig
@@ -513,12 +513,6 @@ fn incrementVoidPtrArray(array: ?*c_void, len: usize) void {
     }
 }
 
-test "*usize to *void" {
-    var i = @as(usize, 0);
-    var v = @ptrCast(*void, &i);
-    v.* = {};
-}
-
 test "compile time int to ptr of function" {
     foobar(FUNCTION_CONSTANT);
 }


### PR DESCRIPTION
This should close #1469 and close #6861. This change prevents doing a @ptrCast() between any two pointer types with different memory layouts. 

While not explicitly stated it should be disallowed in #1469, this change also prevents a cast from a normal-sized pointer to a 1-bit pointer (optional zero-sized pointer, e.g., `?*void`)