### PR TITLE
Temporarily disable the cache for zig cc in link mode

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1217,7 +1217,7 @@ fn buildOutputType(
                 .link => {
                     output_mode = if (is_shared_lib) .Lib else .Exe;
                     emit_bin = .{ .yes = out_path orelse "a.out" };
-                    enable_cache = true;
+                    enable_cache = false;
                 },
                 .object => {
                     output_mode = .Obj;


### PR DESCRIPTION
`zig cc` cannot be really used any more (see #6979) due to caching issues:

```sh
$ rm -fr zig-cache
$ zig cc -o test test.c
$ zig cc -o test2 test.c
attempt to unwrap error: FileNotFound
$ zig cc test.c
attempt to unwrap error: FileNotFound
```

This PR disables the cache for the link operation when using `zig cc`. It doesn't fix the root cause and it is a terrible, horrible, awful thing to do. But since we are getting so close to the 0.7.0 release, maybe that can be a last resort option in order to avoid shipping the release with that issue.