### PR TITLE
stage1: Reject undefined values when taking union ptr

### DIFF
--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -11,6 +11,21 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:1:50: error: use of undefined value here causes undefined behavior",
     });
 
+    cases.add("wrong initializer for union payload of type 'type'",
+        \\const U = union(enum) {
+        \\    A: type,
+        \\};
+        \\const S = struct {
+        \\    u: U,
+        \\};
+        \\export fn entry() void {
+        \\    comptime var v: S = undefined;
+        \\    v.u.A = U{ .A = i32 };
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:9:8: error: use of undefined value here causes undefined behavior",
+    });
+
     cases.add("union with too small explicit signed tag type",
         \\const U = union(enum(i2)) {
         \\    A: u8,


### PR DESCRIPTION
The code rightfully assumes the union_val object to be fully initialized.

Closes #7019

How do we add a regression test for this? It's not something that deserves its own place in `compile_errors` as it's only a stage1 quirk but I have no idea where to add a test.

Here's a minimal reproducer:

```zig
const U = union(enum) {
    A: u32,
};

const S = struct {
    u: U,

    fn foo() void {
        comptime var v: S = undefined;
        v.u.A = U{ .A = 10 };
    }
};

test "" {
    comptime S.foo();
}
```