### PR TITLE
get_codegen_ptr_type no longer results in nullptr when called on optional zero-sized ptr

### DIFF
--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -4592,20 +4592,20 @@ ZigType *get_src_ptr_type(ZigType *type) {
 Error get_codegen_ptr_type(CodeGen *g, ZigType *type, ZigType **result) {
     Error err;
 
-    ZigType *ty = get_src_ptr_type(type);
-    if (ty == nullptr) {
+    ZigType *ptr_type = get_src_ptr_type(type);
+    if (ptr_type == nullptr) {
         *result = nullptr;
         return ErrorNone;
     }
 
     bool has_bits;
-    if ((err = type_has_bits2(g, ty, &has_bits))) return err;
+    if ((err = type_has_bits2(g, type, &has_bits))) return err;
     if (!has_bits) {
         *result = nullptr;
         return ErrorNone;
     }
 
-    *result = ty;
+    *result = ptr_type;
     return ErrorNone;
 }
 

--- a/test/stage1/behavior/misc.zig
+++ b/test/stage1/behavior/misc.zig
@@ -537,6 +537,19 @@ test "equality compare fn ptrs" {
     expect(a == a);
 }
 
+test "equality compare optional zero-sized pointers" {
+    var x: u0 = 0;
+    var y: u0 = 0;
+
+    var x_opt_ptr: ?*u0 = &x;
+    var y_ptr: *u0 = &y;
+    var null_u0_ptr: ?*u0 = null;
+
+    expect(x_opt_ptr == y_ptr);
+    expect(!(x_opt_ptr != y_ptr));
+    expect(x_opt_ptr != null_u0_ptr and y_ptr != null_u0_ptr);
+}
+
 test "self reference through fn ptr field" {
     const S = struct {
         const A = struct {


### PR DESCRIPTION
This is intended to close #6983, by having `get_codegen_ptr_type()` no longer result in `nullptr` when called on an optional zero-sized pointer type. Before, it would return `nullptr` if `get_src_ptr_type(type)` was zero-sized. This change makes it so that the function will return nullptr when `type` is zero-sized instead. 

However, the one concern I have here is that this function can now result in a zero-sized type being returned (since it returns `get_src_ptr_type(type)` if it succeeds). It used to return null if the src_ptr_type was zero-sized, meaning that the return value would never be a zero-sized type. But now, it is possible if the parameter is a `ZigType` representing `?*u0`, for example. 

I scrolled through all the uses of `get_codegen_ptr_type` as well as `get_codegen_ptr_type_bail`, and this change seems to be OK in all of those cases. The uses I am slightly concerned about are:

*  `type_c_abi_x86_64_class` (which I am pretty sure is ok) 
* `iter_function_params_c_abi` 
* `ir_render_atomic_rmw`

There may be other cases where the possibility of this function returning a zero-sized pointer is invalid, but these looked the most suspect. 