### PR TITLE
Prevent double file close in MachO linking

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -256,7 +256,10 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
     errdefer file.close();
 
     const self = try createEmpty(allocator, options);
-    errdefer self.base.destroy();
+    errdefer {
+        self.base.file = null;
+        self.base.destroy();
+    }
 
     self.base.file = file;
 


### PR DESCRIPTION
If any of the subsequent function calls return an error, we'll call `close` on the file twice. To avoid this, I'm just unsetting one of them in the `errdefer` block.