### PR TITLE
stage1: Fix crash in comptime struct generation

### DIFF
--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -6878,9 +6878,12 @@ static LLVMValueRef gen_parent_ptr(CodeGen *g, ZigValue *val, ConstParent *paren
             render_const_val(g, val, "");
             render_const_val_global(g, val, "");
             return val->llvm_global;
-        case ConstParentIdStruct:
-            return gen_const_ptr_struct_recursive(g, parent->data.p_struct.struct_val,
-                    parent->data.p_struct.field_index);
+        case ConstParentIdStruct: {
+            ZigValue *struct_val = parent->data.p_struct.struct_val;
+            size_t src_field_index = parent->data.p_struct.field_index;
+            size_t gen_field_index = struct_val->type->data.structure.fields[src_field_index]->gen_index;
+            return gen_const_ptr_struct_recursive(g, struct_val, gen_field_index);
+        }
         case ConstParentIdErrUnionCode:
             return gen_const_ptr_err_union_code_recursive(g, parent->data.p_err_union_code.err_union_val);
         case ConstParentIdErrUnionPayload:

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -56,6 +56,7 @@ comptime {
     _ = @import("behavior/bugs/6456.zig");
     _ = @import("behavior/bugs/6781.zig");
     _ = @import("behavior/bugs/6850.zig");
+    _ = @import("behavior/bugs/7027.zig");
     _ = @import("behavior/bugs/7047.zig");
     _ = @import("behavior/bugs/394.zig");
     _ = @import("behavior/bugs/421.zig");

--- a/test/stage1/behavior/bugs/7027.zig
+++ b/test/stage1/behavior/bugs/7027.zig
@@ -1,0 +1,17 @@
+const Foobar = struct {
+    myTypes: [128]type,
+    str: [1024]u8,
+
+    fn foo() @This() {
+        comptime var foobar: Foobar = undefined;
+        foobar.str = [_]u8{'a'} ** 1024;
+        return foobar;
+    }
+};
+
+fn foo(arg: anytype) void {}
+
+test "" {
+    comptime var foobar = Foobar.foo();
+    foo(foobar.str[0..10]);
+}


### PR DESCRIPTION
Using the gen_index rather than the src_index is needed to handle
structures containing zero-sized or comptime only types.

Closes #7027