### PR TITLE
macOS: depend on bundled headers even for native

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2147,9 +2147,7 @@ fn detectLibCIncludeDirs(
         return detectLibCFromLibCInstallation(arena, target, lci);
     }
 
-    if (target_util.canBuildLibC(target)) outer: {
-        if (is_native_os and target.isDarwin()) break :outer; // If we're on Darwin, we want to use native since we only have headers.
-
+    if (target_util.canBuildLibC(target)) {
         const generic_name = target_util.libCGenericName(target);
         // Some architectures are handled by the same set of headers.
         const arch_name = if (target.abi.isMusl()) target_util.archMuslName(target.cpu.arch) else @tagName(target.cpu.arch);

--- a/src/target.zig
+++ b/src/target.zig
@@ -58,8 +58,11 @@ pub const available_libcs = [_]ArchOsAbi{
 };
 
 pub fn libCGenericName(target: std.Target) [:0]const u8 {
-    if (target.os.tag == .windows)
-        return "mingw";
+    switch (target.os.tag) {
+        .windows => return "mingw",
+        .macos, .ios, .tvos, .watchos => return "darwin",
+        else => {},
+    }
     switch (target.abi) {
         .gnu,
         .gnuabin32,


### PR DESCRIPTION
This is an alternate fix for #6773. Reverts
872bc787b56f71e53c80f4681523bc8356915b71.

~cc @prime31 I'm interested in making sure this does not re-introduce the regression from #6773.~

This is going to depend on another PR to update the macos header files