### PR TITLE
Add the output basename to the lld.id symlink

### DIFF
--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -785,7 +785,9 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
     defer arena_allocator.deinit();
     const arena = &arena_allocator.allocator;
 
-    const directory = self.base.options.emit.?.directory; // Just an alias to make it shorter to type.
+    // Just aliases to make it shorter to type.
+    const directory = self.base.options.emit.?.directory;
+    const sub_path = self.base.options.emit.?.sub_path;
 
     // If there is no Zig code to compile, then we should skip flushing the output file because it
     // will not be part of the linker line anyway.
@@ -823,6 +825,11 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
     var digest: [Cache.hex_digest_len]u8 = undefined;
 
     if (!self.base.options.disable_lld_caching) {
+        // Make sure sure the sub_path fits in the symlink metadata
+        if (sub_path.len > 255 - digest.len) {
+            log.emerg("Linking output basename '{}' too long to fit in lld.id symlink", .{sub_path});
+            std.os.exit(1);
+        }
         man = comp.cache_parent.obtain();
         self.base.releaseLock();
 
@@ -853,17 +860,45 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
         // We don't actually care whether it's a cache hit or miss; we just need the digest and the lock.
         _ = try man.hit();
         digest = man.final();
-        var prev_digest_buf: [digest.len]u8 = undefined;
-        const prev_digest: []u8 = Cache.readSmallFile(
+
+        var prev_id_data_buf: [255]u8 = undefined;
+        const prev_id_data = Cache.readSmallFile(
             directory.handle,
             id_symlink_basename,
-            &prev_digest_buf,
+            &prev_id_data_buf,
         ) catch |err| blk: {
             log.debug("COFF LLD new_digest={} error: {}", .{ digest, @errorName(err) });
             // Handle this as a cache miss.
-            break :blk prev_digest_buf[0..0];
+            break :blk prev_id_data_buf[0..0];
         };
-        if (mem.eql(u8, prev_digest, &digest)) {
+        const prev_digest = if (prev_id_data.len == 0)
+            prev_id_data
+        else
+            prev_id_data[0..digest.len];
+
+        if (mem.eql(u8, prev_digest, &digest)) blk: {
+            if (!mem.eql(u8, prev_id_data[digest.len..], sub_path)) {
+                // Rename the output to the new basename
+                directory.handle.rename(prev_id_data[digest.len..], sub_path) catch |err| {
+                    // If the rename fails, handle this as a cache miss.
+                    log.debug("Error renaming COFF linking output: {}", .{@errorName(err)});
+                    break :blk;
+                };
+                // Update the id to include the new basename
+                directory.handle.deleteFile(id_symlink_basename) catch |err| switch (err) {
+                    error.FileNotFound => {},
+                    else => |e| return e,
+                };
+                mem.copy(u8, prev_id_data_buf[digest.len..], sub_path);
+                Cache.writeSmallFile(
+                    directory.handle,
+                    id_symlink_basename,
+                    prev_id_data_buf[0 .. digest.len + sub_path.len],
+                ) catch |err| switch (err) {
+                    error.PathAlreadyExists => {},
+                    else => std.log.warn("failed to save linking hash digest file: {}", .{@errorName(err)}),
+                };
+            }
             log.debug("COFF LLD digest={} match - skipping invocation", .{digest});
             // Hot diggity dog! The output binary is already there.
             self.base.lock = man.toOwnedLock();
@@ -878,7 +913,7 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
         };
     }
 
-    const full_out_path = try directory.join(arena, &[_][]const u8{self.base.options.emit.?.sub_path});
+    const full_out_path = try directory.join(arena, &[_][]const u8{sub_path});
 
     if (self.base.options.output_mode == .Obj) {
         // LLD's COFF driver does not support the equvialent of `-r` so we do a simple file copy
@@ -1189,9 +1224,16 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
     }
 
     if (!self.base.options.disable_lld_caching) {
-        // Update the file with the digest. If it fails we can continue; it only
+        // Update the file with the digest and output basename. If it fails we can continue; it only
         // means that the next invocation will have an unnecessary cache miss.
-        Cache.writeSmallFile(directory.handle, id_symlink_basename, &digest) catch |err| {
+        var id_data: [255]u8 = undefined;
+        mem.copy(u8, &id_data, &digest);
+        mem.copy(u8, id_data[digest.len..], sub_path);
+        Cache.writeSmallFile(
+            directory.handle,
+            id_symlink_basename,
+            id_data[0 .. digest.len + sub_path.len],
+        ) catch |err| {
             std.log.warn("failed to save linking hash digest file: {}", .{@errorName(err)});
         };
         // Again failure here only means an unnecessary cache miss.

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -785,7 +785,7 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
     defer arena_allocator.deinit();
     const arena = &arena_allocator.allocator;
 
-    // Just aliases to make it shorter to type.
+    // Just aliases to make them shorter to type.
     const directory = self.base.options.emit.?.directory;
     const sub_path = self.base.options.emit.?.sub_path;
 

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1226,7 +1226,9 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
     defer arena_allocator.deinit();
     const arena = &arena_allocator.allocator;
 
-    const directory = self.base.options.emit.?.directory; // Just an alias to make it shorter to type.
+    // Just aliases to make it shorter to type.
+    const directory = self.base.options.emit.?.directory;
+    const sub_path = self.base.options.emit.?.sub_path;
 
     // If there is no Zig code to compile, then we should skip flushing the output file because it
     // will not be part of the linker line anyway.
@@ -1266,9 +1268,10 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
     // linked are in the hash that namespaces the directory we are outputting to. Therefore,
     // we must hash those now, and the resulting digest will form the "id" of the linking
     // job we are about to perform.
-    // After a successful link, we store the id in the metadata of a symlink named "id.txt" in
-    // the artifact directory. So, now, we check if this symlink exists, and if it matches
-    // our digest. If so, we can skip linking. Otherwise, we proceed with invoking LLD.
+    // After a successful link, we store the id as well as the output's basename in the
+    // metadata of a symlink named "lld.id" in the artifact directory. So, now, we check if
+    // this symlink exists, and if it matches our digest. If so, we can skip linking.
+    // Otherwise, we proceed with invoking LLD.
     const id_symlink_basename = "lld.id";
 
     var man: Cache.Manifest = undefined;
@@ -1277,6 +1280,11 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
     var digest: [Cache.hex_digest_len]u8 = undefined;
 
     if (!self.base.options.disable_lld_caching) {
+        // Make sure sure the sub_path fits in the symlink metadata
+        if (sub_path.len > 255 - digest.len) {
+            log.emerg("Linking output basename '{}' too long to fit in lld.id symlink", .{sub_path});
+            std.os.exit(1);
+        }
         man = comp.cache_parent.obtain();
 
         // We are about to obtain this lock, so here we give other processes a chance first.
@@ -1325,17 +1333,44 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
         _ = try man.hit();
         digest = man.final();
 
-        var prev_digest_buf: [digest.len]u8 = undefined;
-        const prev_digest: []u8 = Cache.readSmallFile(
+        var prev_id_data_buf: [255]u8 = undefined;
+        const prev_id_data = Cache.readSmallFile(
             directory.handle,
             id_symlink_basename,
-            &prev_digest_buf,
+            &prev_id_data_buf,
         ) catch |err| blk: {
             log.debug("ELF LLD new_digest={} error: {}", .{ digest, @errorName(err) });
             // Handle this as a cache miss.
-            break :blk prev_digest_buf[0..0];
+            break :blk prev_id_data_buf[0..0];
         };
-        if (mem.eql(u8, prev_digest, &digest)) {
+
+        const prev_digest = if (prev_id_data.len == 0)
+            prev_id_data
+        else
+            prev_id_data[0..digest.len];
+        if (mem.eql(u8, prev_digest, &digest)) blk: {
+            if (!mem.eql(u8, prev_id_data[digest.len..], sub_path)) {
+                // Rename the output to the new basename
+                directory.handle.rename(prev_id_data[digest.len..], sub_path) catch |err| {
+                    // If the rename fails, handle this as a cache miss.
+                    log.debug("Error renaming ELF linking output: {}", .{@errorName(err)});
+                    break :blk;
+                };
+                // Update the id to include the new basename
+                directory.handle.deleteFile(id_symlink_basename) catch |err| switch (err) {
+                    error.FileNotFound => {},
+                    else => |e| return e,
+                };
+                mem.copy(u8, prev_id_data_buf[digest.len..], sub_path);
+                Cache.writeSmallFile(
+                    directory.handle,
+                    id_symlink_basename,
+                    prev_id_data_buf[0 .. digest.len + sub_path.len],
+                ) catch |err| switch (err) {
+                    error.PathAlreadyExists => {},
+                    else => std.log.warn("failed to save linking hash digest file: {}", .{@errorName(err)}),
+                };
+            }
             log.debug("ELF LLD digest={} match - skipping invocation", .{digest});
             // Hot diggity dog! The output binary is already there.
             self.base.lock = man.toOwnedLock();
@@ -1426,7 +1461,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
         try argv.append("-pie");
     }
 
-    const full_out_path = try directory.join(arena, &[_][]const u8{self.base.options.emit.?.sub_path});
+    const full_out_path = try directory.join(arena, &[_][]const u8{sub_path});
     try argv.append("-o");
     try argv.append(full_out_path);
 
@@ -1656,9 +1691,16 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
     }
 
     if (!self.base.options.disable_lld_caching) {
-        // Update the file with the digest. If it fails we can continue; it only
+        // Update the file with the digest and output basename. If it fails we can continue; it only
         // means that the next invocation will have an unnecessary cache miss.
-        Cache.writeSmallFile(directory.handle, id_symlink_basename, &digest) catch |err| {
+        var id_data: [255]u8 = undefined;
+        mem.copy(u8, &id_data, &digest);
+        mem.copy(u8, id_data[digest.len..], sub_path);
+        Cache.writeSmallFile(
+            directory.handle,
+            id_symlink_basename,
+            id_data[0 .. digest.len + sub_path.len],
+        ) catch |err| {
             std.log.warn("failed to save linking hash digest file: {}", .{@errorName(err)});
         };
         // Again failure here only means an unnecessary cache miss.

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1226,7 +1226,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
     defer arena_allocator.deinit();
     const arena = &arena_allocator.allocator;
 
-    // Just aliases to make it shorter to type.
+    // Just aliases to make them shorter to type.
     const directory = self.base.options.emit.?.directory;
     const sub_path = self.base.options.emit.?.sub_path;
 

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -259,7 +259,9 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
     defer arena_allocator.deinit();
     const arena = &arena_allocator.allocator;
 
-    const directory = self.base.options.emit.?.directory; // Just an alias to make it shorter to type.
+    // Just aliases to make it shorter to type.
+    const directory = self.base.options.emit.?.directory;
+    const sub_path = self.base.options.emit.?.sub_path;
 
     // If there is no Zig code to compile, then we should skip flushing the output file because it
     // will not be part of the linker line anyway.
@@ -292,6 +294,11 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
     var digest: [Cache.hex_digest_len]u8 = undefined;
 
     if (!self.base.options.disable_lld_caching) {
+        // Make sure sure the sub_path fits in the symlink metadata
+        if (sub_path.len > 255 - digest.len) {
+            log.emerg("Linking output basename '{}' too long to fit in lld.id symlink", .{sub_path});
+            std.os.exit(1);
+        }
         man = comp.cache_parent.obtain();
 
         // We are about to obtain this lock, so here we give other processes a chance first.
@@ -309,17 +316,44 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
         _ = try man.hit();
         digest = man.final();
 
-        var prev_digest_buf: [digest.len]u8 = undefined;
-        const prev_digest: []u8 = Cache.readSmallFile(
+        var prev_id_data_buf: [255]u8 = undefined;
+        const prev_id_data = Cache.readSmallFile(
             directory.handle,
             id_symlink_basename,
-            &prev_digest_buf,
+            &prev_id_data_buf,
         ) catch |err| blk: {
             log.debug("WASM LLD new_digest={} error: {}", .{ digest, @errorName(err) });
             // Handle this as a cache miss.
-            break :blk prev_digest_buf[0..0];
+            break :blk prev_id_data_buf[0..0];
         };
-        if (mem.eql(u8, prev_digest, &digest)) {
+        const prev_digest = if (prev_id_data.len == 0)
+            prev_id_data
+        else
+            prev_id_data[0..digest.len];
+
+        if (mem.eql(u8, prev_digest, &digest)) blk: {
+            if (!mem.eql(u8, prev_id_data[digest.len..], sub_path)) {
+                // Rename the output to the new basename
+                directory.handle.rename(prev_id_data[digest.len..], sub_path) catch |err| {
+                    // If the rename fails, handle this as a cache miss.
+                    log.debug("Error renaming MachO linking output: {}", .{@errorName(err)});
+                    break :blk;
+                };
+                // Update the id to include the new basename
+                directory.handle.deleteFile(id_symlink_basename) catch |err| switch (err) {
+                    error.FileNotFound => {},
+                    else => |e| return e,
+                };
+                mem.copy(u8, prev_id_data_buf[digest.len..], sub_path);
+                Cache.writeSmallFile(
+                    directory.handle,
+                    id_symlink_basename,
+                    prev_id_data_buf[0 .. digest.len + sub_path.len],
+                ) catch |err| switch (err) {
+                    error.PathAlreadyExists => {},
+                    else => std.log.warn("failed to save linking hash digest file: {}", .{@errorName(err)}),
+                };
+            }
             log.debug("WASM LLD digest={} match - skipping invocation", .{digest});
             // Hot diggity dog! The output binary is already there.
             self.base.lock = man.toOwnedLock();
@@ -365,7 +399,7 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
     try argv.appendSlice(&[_][]const u8{
         "--allow-undefined",
         "-o",
-        try directory.join(arena, &[_][]const u8{self.base.options.emit.?.sub_path}),
+        try directory.join(arena, &[_][]const u8{sub_path}),
     });
 
     // Positional arguments to the linker such as object files.
@@ -428,10 +462,17 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
     }
 
     if (!self.base.options.disable_lld_caching) {
-        // Update the file with the digest. If it fails we can continue; it only
+        // Update the file with the digest and output basename. If it fails we can continue; it only
         // means that the next invocation will have an unnecessary cache miss.
-        Cache.writeSmallFile(directory.handle, id_symlink_basename, &digest) catch |err| {
-            std.log.warn("failed to save linking hash digest symlink: {}", .{@errorName(err)});
+        var id_data: [255]u8 = undefined;
+        mem.copy(u8, &id_data, &digest);
+        mem.copy(u8, id_data[digest.len..], sub_path);
+        Cache.writeSmallFile(
+            directory.handle,
+            id_symlink_basename,
+            id_data[0 .. digest.len + sub_path.len],
+        ) catch |err| {
+            std.log.warn("failed to save linking hash digest file: {}", .{@errorName(err)});
         };
         // Again failure here only means an unnecessary cache miss.
         man.writeManifest() catch |err| {

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -259,7 +259,7 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
     defer arena_allocator.deinit();
     const arena = &arena_allocator.allocator;
 
-    // Just aliases to make it shorter to type.
+    // Just aliases to make them shorter to type.
     const directory = self.base.options.emit.?.directory;
     const sub_path = self.base.options.emit.?.sub_path;
 
@@ -336,7 +336,7 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
                 // Rename the output to the new basename
                 directory.handle.rename(prev_id_data[digest.len..], sub_path) catch |err| {
                     // If the rename fails, handle this as a cache miss.
-                    log.debug("Error renaming MachO linking output: {}", .{@errorName(err)});
+                    log.debug("Error renaming WASM linking output: {}", .{@errorName(err)});
                     break :blk;
                 };
                 // Update the id to include the new basename


### PR DESCRIPTION
linkWithLLD functions now use the symlink to also keep track of the current basename of the linking output and rename it as necessary.  

This closes #6979  
The way this is currently implemented, a maximum length of 223 bytes is imposed on the basename of the linking output when linking with LLD, in order to guarantee it will fit in the 255 bytes of symlink metadata.  

This limit can be removed by making lld.id a file instead of a symlink, however I believe it is reasonable.  
