### PR TITLE
Windows TLS startup symbols are already provided by libcrt when linking against libc

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -54,7 +54,7 @@ fn _DllMainCRTStartup(
     fdwReason: std.os.windows.DWORD,
     lpReserved: std.os.windows.LPVOID,
 ) callconv(.Stdcall) std.os.windows.BOOL {
-    if (!builtin.single_threaded) {
+    if (!builtin.single_threaded and !builtin.link_libc) {
         _ = @import("start_windows_tls.zig");
     }
 


### PR DESCRIPTION
Closes #5748