### PR TITLE
Do not keep the build.zig cache manifest file locked.

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2228,7 +2228,7 @@ pub const usage_build =
 pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !void {
     // We want to release all the locks before executing the child process, so we make a nice
     // big block here to ensure the cleanup gets run when we extract out our argv.
-    const lock_and_argv = lock_and_argv: {
+    const child_argv = argv: {
         const self_exe_path = try fs.selfExePathAlloc(arena);
 
         var build_file: ?[]const u8 = null;
@@ -2424,15 +2424,8 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
             &[_][]const u8{exe_basename},
         );
 
-        break :lock_and_argv .{
-            .child_argv = child_argv.items,
-            .lock = comp.bin_file.toOwnedLock(),
-        };
+        break :argv child_argv.items;
     };
-    const child_argv = lock_and_argv.child_argv;
-    var lock = lock_and_argv.lock;
-    defer lock.release();
-
     const child = try std.ChildProcess.init(child_argv, gpa);
     defer child.deinit();
 


### PR DESCRIPTION
This allows to have multiple instances of `zig build` at the same
time. For example when you have a long running `zig build run` and
then want to run `zig build somethingelse`.

I tried to implement this on windows, however when having a long running command (`zig build run`) and then running the next command (`zig build another`) immediately exits with code 1 without printing anything. This also happens before I applied this patch, so it is a different issue. However I don't have a debug build of zig on windows to debug this issue.

Note on Windows we need some other solution, because we can't change a running executable (build runner):
```
18:36 <andrewrk> hmm I think there is a new consideration though - with the updated caching behavior, this might actually cause a problem on windows where the exe can't be touched because it is being executed. previously we did not have this situation because hashing the input files was part of the cache namespace
18:37 <andrewrk> just brainstorming here, but one possibility would be to copy the `build` executable (which is likely to be small) to a unique file name before executing it, and then release the lock
18:38 <andrewrk> this would essentially match the semantics of the old cache behavior but with the performance benefits of the new one
18:38 <andrewrk> (in this proposal the unique file name would be based on the hashes of the input files)
```

Related: #7042
