### PR TITLE
Allow Zig to be built with clang 11 and -Werror

### DIFF
--- a/src/stage1/os.cpp
+++ b/src/stage1/os.cpp
@@ -682,19 +682,6 @@ static Error copy_open_files(FILE *src_f, FILE *dest_f) {
     }
 }
 
-#if defined(ZIG_OS_WINDOWS)
-static void windows_filetime_to_os_timestamp(FILETIME *ft, OsTimeStamp *mtime) {
-    mtime->sec = (((ULONGLONG) ft->dwHighDateTime) << 32) + ft->dwLowDateTime;
-    mtime->nsec = 0;
-}
-static FILETIME windows_os_timestamp_to_filetime(OsTimeStamp mtime) {
-    FILETIME result;
-    result.dwHighDateTime = mtime.sec >> 32;
-    result.dwLowDateTime = mtime.sec;
-    return result;
-}
-#endif
-
 Error os_copy_file(Buf *src_path, Buf *dest_path) {
 #if defined(ZIG_OS_WINDOWS)
     PathSpace src_path_space = slice_to_prefixed_file_w(buf_to_slice(src_path));

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -1061,6 +1061,7 @@ bool ZigLLDLink(ZigLLVM_ObjectFormatType oformat, const char **args, size_t arg_
         case ZigLLVM_UnknownObjectFormat:
         case ZigLLVM_XCOFF:
             assert(false); // unreachable
+            break;
 
         case ZigLLVM_COFF:
             return lld::coff::link(array_ref_args, false, diag_stdout, diag_stderr);
@@ -1073,6 +1074,9 @@ bool ZigLLDLink(ZigLLVM_ObjectFormatType oformat, const char **args, size_t arg_
 
         case ZigLLVM_Wasm:
             return lld::wasm::link(array_ref_args, false, diag_stdout, diag_stderr);
+
+        default:
+            break;
     }
     assert(false); // unreachable
     abort();


### PR DESCRIPTION
This was brought to the horizon when using zig-bootstrap to cross compile
Zig for windows-gnu.