### PR TITLE
Allow SegmentedList to be used in recursive structs and unions when prealloc_item_count is 0

### DIFF
--- a/lib/std/segmented_list.zig
+++ b/lib/std/segmented_list.zig
@@ -96,7 +96,7 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
             }
         };
 
-        prealloc_segment: [prealloc_item_count]T,
+        prealloc_segment: if (prealloc_item_count == 0) void else [prealloc_item_count]T,
         dynamic_segments: [][*]T,
         allocator: *Allocator,
         len: usize,
@@ -223,12 +223,14 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
             assert(end <= self.len);
 
             var i = start;
-            if (end <= prealloc_item_count) {
-                std.mem.copy(T, dest[i - start ..], self.prealloc_segment[i..end]);
-                return;
-            } else if (i < prealloc_item_count) {
-                std.mem.copy(T, dest[i - start ..], self.prealloc_segment[i..]);
-                i = prealloc_item_count;
+            if (prealloc_item_count != 0) {
+                if (end <= prealloc_item_count) {
+                    std.mem.copy(T, dest[i - start ..], self.prealloc_segment[i..end]);
+                    return;
+                } else if (i < prealloc_item_count) {
+                    std.mem.copy(T, dest[i - start ..], self.prealloc_segment[i..]);
+                    i = prealloc_item_count;
+                }
             }
 
             while (i < end) {


### PR DESCRIPTION
When using `SegmentedList` with a `prealloc_item_count` equal to 0 inside of recursive structs or unions you get the error: 
`struct 'TYPE NAME' depends on itself`. This pull request fixes this issue by replacing the `prealloc_segments` array type with void when `prealloc_item_count` is equal to 0. 

This is probably something to fix in the compiler itself though, maybe zero size arrays shouldn't produce the error? I'm opening an issue for this.