### PR TITLE
openbsd: skip tests using Dir.realpath

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -227,7 +227,7 @@ test "directory operations on files" {
     testing.expectError(error.NotDir, tmp_dir.dir.openDir(test_file_name, .{}));
     testing.expectError(error.NotDir, tmp_dir.dir.deleteDir(test_file_name));
 
-    if (builtin.os.tag != .wasi and builtin.os.tag != .freebsd) {
+    if (builtin.os.tag != .wasi and builtin.os.tag != .freebsd and builtin.os.tag != .openbsd) {
         const absolute_path = try tmp_dir.dir.realpathAlloc(testing.allocator, test_file_name);
         defer testing.allocator.free(absolute_path);
 
@@ -264,7 +264,7 @@ test "file operations on directories" {
     // TODO: Add a read-only test as well, see https://github.com/ziglang/zig/issues/5732
     testing.expectError(error.IsDir, tmp_dir.dir.openFile(test_dir_name, .{ .write = true }));
 
-    if (builtin.os.tag != .wasi and builtin.os.tag != .freebsd) {
+    if (builtin.os.tag != .wasi and builtin.os.tag != .freebsd and builtin.os.tag != .openbsd) {
         const absolute_path = try tmp_dir.dir.realpathAlloc(testing.allocator, test_dir_name);
         defer testing.allocator.free(absolute_path);
 


### PR DESCRIPTION
The `Dir.realpath()` implementation is based on `getFdPath()`, which doesn't exist on OpenBSD (or some others OS like FreeBSD). Disable the tests using it for now.

I am thinking about some ways to provide alternative implementation, for example:
- add the know pathname used to open the descriptor in zig structure and resolv it on demand with `realpath()`; but not all descriptors are opened with a name: on exec you could have an already open descriptor, or you could receive descriptor from UNIX socket
- iterate on descriptor to retreive the name from filesystem (with `openat(fd, "..")` and searching for the right inode with `fstat()`) ; but it could be permission issue to read directory content
- call `chdir()` on the descriptor and read the path with `getcwd()` ; but it is bad when threads are involved (it changes a global parameter)

I will see that later.