### PR TITLE
--bundle-compiler-rt flag was removed

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1216,7 +1216,6 @@ pub const LibExeObjStep = struct {
     emit_bin: bool = true,
     emit_docs: bool = false,
     emit_h: bool = false,
-    bundle_compiler_rt: bool,
     disable_stack_probing: bool,
     disable_sanitize_c: bool,
     rdynamic: bool,
@@ -1392,7 +1391,6 @@ pub const LibExeObjStep = struct {
             .exec_cmd_args = null,
             .name_prefix = "",
             .filter = null,
-            .bundle_compiler_rt = false,
             .disable_stack_probing = false,
             .disable_sanitize_c = false,
             .rdynamic = false,
@@ -2116,9 +2114,6 @@ pub const LibExeObjStep = struct {
         }
         if (self.is_dynamic) {
             try zig_args.append("-dynamic");
-        }
-        if (self.bundle_compiler_rt) {
-            try zig_args.append("--bundle-compiler-rt");
         }
         if (self.disable_stack_probing) {
             try zig_args.append("-fno-stack-check");


### PR DESCRIPTION
I went looking for the `--bundle-compiler-rt` flag but it seems it has been removed. Finish the job by removing it from the zig build system.