### PR TITLE
Enable loop interleaving when unrolling is enabled

### DIFF
--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -221,6 +221,7 @@ bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMM
     PMBuilder->DisableUnrollLoops = is_debug;
     PMBuilder->SLPVectorize = !is_debug;
     PMBuilder->LoopVectorize = !is_debug;
+    PMBuilder->LoopsInterleaved = !PMBuilder->DisableUnrollLoops;
     PMBuilder->RerollLoops = !is_debug;
     // Leaving NewGVN as default (off) because when on it caused issue #673
     //PMBuilder->NewGVN = !is_debug;


### PR DESCRIPTION
This mimics [clang's default behavior](https://github.com/llvm/llvm-project/blob/c1e3d38301c305357debcedbda4999335fd727cc/clang/lib/CodeGen/BackendUtil.cpp#L662-L664).