### PR TITLE
std: Fix code model argument

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2131,7 +2131,7 @@ pub const LibExeObjStep = struct {
         }
 
         if (self.code_model != .default) {
-            try zig_args.append("-code-model");
+            try zig_args.append("-mcmodel");
             try zig_args.append(@tagName(self.code_model));
         }
 


### PR DESCRIPTION
After upgrading to 0.7.0 I've experienced a compile error:
```
error: unrecognized parameter: '-code-model'
kernel...The following command exited with error code 1:
```
Fix this issue by passing appropriate flag