### PR TITLE
std.mem: make sliceAsBytes, etc. respect volatile

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1937,7 +1937,7 @@ pub fn nativeToBig(comptime T: type, x: T) T {
     };
 }
 
-fn CopyPtrAttrs(comptime source: type, size: builtin.TypeInfo.Pointer.Size, child: type) type {
+fn CopyPtrAttrs(comptime source: type, comptime size: builtin.TypeInfo.Pointer.Size, comptime child: type) type {
     const info = @typeInfo(source).Pointer;
     return @Type(.{
         .Pointer = .{
@@ -2001,7 +2001,7 @@ test "asBytes" {
     testing.expect(eql(u8, asBytes(&zero), ""));
 }
 
-test "asBytes preserves qualifiers" {
+test "asBytes preserves pointer attributes" {
     const inArr: u32 align(16) = 0xDEADBEEF;
     const inPtr = @ptrCast(*align(16) const volatile u32, &inArr);
     const outSlice = asBytes(inPtr);
@@ -2090,7 +2090,7 @@ test "bytesAsValue" {
     testing.expect(meta.eql(inst, inst2.*));
 }
 
-test "bytesAsValue preserves qualifiers" {
+test "bytesAsValue preserves pointer attributes" {
     const inArr align(16) = [4]u8{ 0xDE, 0xAD, 0xBE, 0xEF };
     const inSlice = @ptrCast(*align(16) const volatile [4]u8, &inArr)[0..];
     const outPtr = bytesAsValue(u32, inSlice);
@@ -2198,7 +2198,7 @@ test "bytesAsSlice with specified alignment" {
     testing.expect(slice[0] == 0x33333333);
 }
 
-test "bytesAsSlice preserves qualifiers" {
+test "bytesAsSlice preserves pointer attributes" {
     const inArr align(16) = [4]u8{ 0xDE, 0xAD, 0xBE, 0xEF };
     const inSlice = @ptrCast(*align(16) const volatile [4]u8, &inArr)[0..];
     const outSlice = bytesAsSlice(u16, inSlice);
@@ -2302,7 +2302,7 @@ test "sliceAsBytes and bytesAsSlice back" {
     testing.expect(bytes[11] == math.maxInt(u8));
 }
 
-test "sliceAsBytes preserves qualifiers" {
+test "sliceAsBytes preserves pointer attributes" {
     const inArr align(16) = [2]u16{ 0xDEAD, 0xBEEF };
     const inSlice = @ptrCast(*align(16) const volatile [2]u16, &inArr)[0..];
     const outSlice = sliceAsBytes(inSlice);

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -13,7 +13,8 @@ const meta = std.meta;
 const trait = meta.trait;
 const testing = std.testing;
 
-/// https://github.com/ziglang/zig/issues/2564
+/// Compile time known minimum page size.
+/// https://github.com/ziglang/zig/issues/4082
 pub const page_size = switch (builtin.arch) {
     .wasm32, .wasm64 => 64 * 1024,
     .aarch64 => switch (builtin.os.tag) {
@@ -139,7 +140,7 @@ test "mem.Allocator basics" {
 
 /// Copy all of source into dest at position 0.
 /// dest.len must be >= source.len.
-/// dest.ptr must be <= src.ptr.
+/// If the slices overlap, dest.ptr must be <= src.ptr.
 pub fn copy(comptime T: type, dest: []T, source: []const T) void {
     // TODO instead of manually doing this check for the whole array
     // and turning off runtime safety, the compiler should detect loops like
@@ -152,7 +153,7 @@ pub fn copy(comptime T: type, dest: []T, source: []const T) void {
 
 /// Copy all of source into dest at position 0.
 /// dest.len must be >= source.len.
-/// dest.ptr must be >= src.ptr.
+/// If the slices overlap, dest.ptr must be >= src.ptr.
 pub fn copyBackwards(comptime T: type, dest: []T, source: []const T) void {
     // TODO instead of manually doing this check for the whole array
     // and turning off runtime safety, the compiler should detect loops like


### PR DESCRIPTION
Looks like the bug preventing `@Type` from working correctly in this case has been fixed.