### PR TITLE
stage1: Ask LLVM to produce compact code in ReleaseSize mode

### DIFF
--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -484,6 +484,12 @@ static LLVMValueRef make_fn_llvm_value(CodeGen *g, ZigFn *fn) {
         addLLVMFnAttrInt(llvm_fn, "alignstack", fn->alignstack_value);
     }
 
+    if (g->build_mode == BuildModeSmallRelease) {
+        // Optimize for small code size.
+        addLLVMFnAttr(llvm_fn, "minsize");
+        addLLVMFnAttr(llvm_fn, "optsize");
+    }
+
     addLLVMFnAttr(llvm_fn, "nounwind");
     add_uwtable_attr(g, llvm_fn);
     addLLVMFnAttr(llvm_fn, "nobuiltin");


### PR DESCRIPTION
Let's follow what Clang does for -Oz and apply the `minsize` and `optsize` attributes by default.

Your detective chops are weak, nobody took a look at the generated IR :(
Check out Clang's `CodeGenModule::ConstructDefaultFnAttrList` for more info.

Closes #7048
Supersedes #7077