### PR TITLE
stage2: make `zig --help` not error

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -195,7 +195,7 @@ pub fn mainArgs(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
         try @import("print_env.zig").cmdEnv(arena, cmd_args, io.getStdOut().outStream());
     } else if (mem.eql(u8, cmd, "zen")) {
         try io.getStdOut().writeAll(info_zen);
-    } else if (mem.eql(u8, cmd, "help")) {
+    } else if (mem.eql(u8, cmd, "--help")) {
         try io.getStdOut().writeAll(usage);
     } else {
         std.log.info("{}", .{usage});


### PR DESCRIPTION
Fixes #7083. Currently, `zig --help` exits with a nonzero status code and prints `error: unknown command: --help`, this fixes that
