### PR TITLE
stage1 and stage2: closes #7120

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1663,7 +1663,6 @@ pub const ModuleDebugInfo = switch (builtin.os.tag) {
                     .symbol_name = nosuspend self.dwarf.getSymbolName(relocated_address) orelse "???",
                     .compile_unit_name = compile_unit.die.getAttrString(&self.dwarf, DW.AT_name) catch |err| switch (err) {
                         error.MissingDebugInfo, error.InvalidDebugInfo => "???",
-                        else => return err,
                     },
                     .line_info = nosuspend self.dwarf.getLineNumberInfo(compile_unit.*, relocated_address) catch |err| switch (err) {
                         error.MissingDebugInfo, error.InvalidDebugInfo => null,

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -587,12 +587,10 @@ fn formatFloatValue(
     if (fmt.len == 0 or comptime std.mem.eql(u8, fmt, "e")) {
         formatFloatScientific(value, options, buf_stream.writer()) catch |err| switch (err) {
             error.NoSpaceLeft => unreachable,
-            else => |e| return e,
         };
     } else if (comptime std.mem.eql(u8, fmt, "d")) {
         formatFloatDecimal(value, options, buf_stream.writer()) catch |err| switch (err) {
             error.NoSpaceLeft => unreachable,
-            else => |e| return e,
         };
     } else {
         @compileError("Unknown format string: '" ++ fmt ++ "'");

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1960,16 +1960,6 @@ pub fn analyzeExport(self: *Module, scope: *Scope, src: usize, borrowed_symbol_n
     try self.symbol_exports.putNoClobber(self.gpa, symbol_name, new_export);
     self.comp.bin_file.updateDeclExports(self, exported_decl, de_gop.entry.value) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
-        else => {
-            try self.failed_exports.ensureCapacity(self.gpa, self.failed_exports.items().len + 1);
-            self.failed_exports.putAssumeCapacityNoClobber(new_export, try Compilation.ErrorMsg.create(
-                self.gpa,
-                src,
-                "unable to export: {}",
-                .{@errorName(err)},
-            ));
-            new_export.status = .failed_retryable;
-        },
     };
 }
 

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -6362,7 +6362,7 @@ static IrInstSrc *ir_gen_builtin_fn_call(IrBuilderSrc *irb, Scope *scope, AstNod
     BuiltinFnEntry *builtin_fn = entry->value;
     size_t actual_param_count = node->data.fn_call_expr.params.length;
 
-    if (builtin_fn->param_count != SIZE_MAX && builtin_fn->param_count != actual_param_count) { 
+    if (builtin_fn->param_count != SIZE_MAX && builtin_fn->param_count != actual_param_count) {
         add_node_error(irb->codegen, node,
                 buf_sprintf("expected %" ZIG_PRI_usize " argument(s), found %" ZIG_PRI_usize,
                     builtin_fn->param_count, actual_param_count));
@@ -8576,7 +8576,7 @@ static IrInstSrc *ir_gen_for_expr(IrBuilderSrc *irb, Scope *parent_scope, AstNod
 
     if (is_duplicate_label(irb->codegen, child_scope, node, node->data.for_expr.name))
         return irb->codegen->invalid_inst_src;
-    
+
     ZigList<IrInstSrc *> incoming_values = {0};
     ZigList<IrBasicBlockSrc *> incoming_blocks = {0};
     ScopeLoop *loop_scope = create_loop_scope(irb->codegen, node, child_scope);
@@ -20854,7 +20854,7 @@ static IrInstGen *ir_analyze_fn_call(IrAnalyze *ira, IrInst* source_instr,
                     expected_return_type->id != ZigTypeIdErrorUnion && expected_return_type->id != ZigTypeIdErrorSet)
                 {
                     if (call_result_loc->id == ResultLocIdReturn) {
-                        add_error_note(ira->codegen, ira->new_irb.exec->first_err_trace_msg, 
+                        add_error_note(ira->codegen, ira->new_irb.exec->first_err_trace_msg,
                             ira->explicit_return_type_source_node, buf_sprintf("function cannot return an error"));
                     } else {
                         add_error_note(ira->codegen, ira->new_irb.exec->first_err_trace_msg, result_loc->base.source_node,
@@ -29479,7 +29479,7 @@ static IrInstGen *ir_analyze_instruction_check_switch_prongs(IrAnalyze *ira,
                 }
             }
         } else if(!switch_type->data.enumeration.non_exhaustive && switch_type->data.enumeration.src_field_count == instruction->range_count) {
-            ir_add_error_node(ira, instruction->else_prong, 
+            ir_add_error_node(ira, instruction->else_prong,
                 buf_sprintf("unreachable else prong, all cases already handled"));
             return ira->codegen->invalid_inst_gen;
         }
@@ -29617,7 +29617,7 @@ static IrInstGen *ir_analyze_instruction_check_switch_prongs(IrAnalyze *ira,
                 ir_add_error(ira, &instruction->base.base, buf_sprintf("switch must handle all possibilities"));
                 return ira->codegen->invalid_inst_gen;
         } else if(handles_all_cases && instruction->else_prong != nullptr) {
-            ir_add_error_node(ira, instruction->else_prong, 
+            ir_add_error_node(ira, instruction->else_prong,
                 buf_sprintf("unreachable else prong, all cases already handled"));
             return ira->codegen->invalid_inst_gen;
             }
@@ -29656,7 +29656,7 @@ static IrInstGen *ir_analyze_instruction_check_switch_prongs(IrAnalyze *ira,
         }
 
         if(seenTrue == 1 && seenFalse == 1 && instruction->else_prong != nullptr) {
-            ir_add_error_node(ira, instruction->else_prong, 
+            ir_add_error_node(ira, instruction->else_prong,
                 buf_sprintf("unreachable else prong, all cases already handled"));
             return ira->codegen->invalid_inst_gen;
         }
@@ -29694,7 +29694,7 @@ static IrInstGen *ir_analyze_instruction_check_switch_prongs(IrAnalyze *ira,
             }
         }
         prevs.deinit();
-    } 
+    }
     return ir_const_void(ira, &instruction->base.base);
 }
 

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -29544,6 +29544,23 @@ static IrInstGen *ir_analyze_instruction_check_switch_prongs(IrAnalyze *ira,
                     }
                 }
             }
+        } else {
+            if (!type_is_global_error_set(switch_type)) {
+                bool needs_else = false;
+                for (uint32_t i = 0; i < switch_type->data.error_set.err_count; i += 1) {
+                    ErrorTableEntry *err_entry = switch_type->data.error_set.errors[i];
+
+                    AstNode *prev_node = field_prev_uses[err_entry->value];
+                    if (prev_node == nullptr) {
+                      needs_else = true;
+                    }
+                }
+                if (!needs_else) {
+                    ir_add_error_node(ira, instruction->else_prong,
+                        buf_sprintf("unreachable else prong, all cases already handled"));
+                    return ira->codegen->invalid_inst_gen;
+                }
+            }
         }
 
         heap::c_allocator.deallocate(field_prev_uses, field_prev_uses_count);


### PR DESCRIPTION
This fixes a case where 
```zig
pub fn main() {
  const x = error.T;
  switch (x) {
    error.T => {},
    else => {},
  }
}
```
was allowed. Funnily, the stdlib and some parts of stage2 included this pattern, so I fixed it there too.
My editor does weird stuff with whitespace, so feel free to ignore that.
See [here](https://freenode.irclog.whitequark.org/zig/2020-11-16#28381521;) for conversation on irc.