### PR TITLE
Support CRLF line endings in multiline string literals in the stdlib tokenizer

### DIFF
--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2387,7 +2387,20 @@ fn renderTokenOffset(
     }
 
     var token_loc = tree.token_locs[token_index];
-    try ais.writer().writeAll(mem.trimRight(u8, tree.tokenSliceLoc(token_loc)[token_skip_bytes..], " "));
+    const token_id = tree.token_ids[token_index];
+
+    write_token: {
+        const slice = tree.tokenSliceLoc(token_loc)[token_skip_bytes..];
+        if (token_id == .MultilineStringLiteralLine) {
+            // Turn CRLF line endings to a single line feed in multi line string literal lines
+            if (slice[slice.len - 2] == '\r') {
+                try ais.writer().writeAll(mem.trimRight(u8, slice[0 .. slice.len - 2], " "));
+                try ais.writer().writeByte('\n');
+                break :write_token;
+            }
+        }
+        try ais.writer().writeAll(mem.trimRight(u8, slice, " "));
+    }
 
     if (space == Space.NoComment)
         return;

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -1710,6 +1710,14 @@ test "tokenizer - multiline string literal with literal tab" {
     });
 }
 
+test "tokenizer - multiline string literal with CRLF line ending" {
+    testTokenize(
+        "\\\\foo bar" ++ [1]u8 { 0x0D } ++ "\n"
+    , &[_]Token.Id{
+        .MultilineStringLiteralLine,
+    });
+}
+
 test "tokenizer - comments with literal tab" {
     testTokenize(
         \\//foo	bar

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -841,7 +841,7 @@ pub const Tokenizer = struct {
                         self.index += 1;
                         break;
                     },
-                    '\t' => {},
+                    '\t', '\r' => {},
                     else => self.checkLiteralCharacter(),
                 },
 

--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -1927,8 +1927,14 @@ fn multilineStrLiteral(mod: *Module, scope: *Scope, node: *ast.Node.MultilineStr
     // line lengths and new lines
     var len = lines.len - 1;
     for (lines) |line| {
-        // 2 for the '//' + 1 for '\n'
-        len += tree.tokenSlice(line).len - 3;
+        const slice = tree.tokenSlice(line);
+        // 2 for the '\\' + 1 for '\n'
+        len += slice.len - 3;
+        if (slice[slice.len - 2] == '\r') {
+            // If the line ending was '\r\n', we also
+            // remove the carriage return.
+            len -= 1;
+        }
     }
 
     const bytes = try scope.arena().alloc(u8, len);
@@ -1939,8 +1945,14 @@ fn multilineStrLiteral(mod: *Module, scope: *Scope, node: *ast.Node.MultilineStr
             i += 1;
         }
         const slice = tree.tokenSlice(line);
-        mem.copy(u8, bytes[i..], slice[2 .. slice.len - 1]);
-        i += slice.len - 3;
+        // Remove the whole line ending if it's '\r\n'
+        if (slice[slice.len - 2] == '\r') {
+            mem.copy(u8, bytes[i..], slice[2 .. slice.len - 2]);
+            i += slice.len - 4;
+        } else {
+            mem.copy(u8, bytes[i..], slice[2 .. slice.len - 1]);
+            i += slice.len - 3;
+        }
     }
 
     return addZIRInst(mod, scope, src, zir.Inst.Str, .{ .bytes = bytes }, .{});


### PR DESCRIPTION
Before tokenizer change
![](https://i.imgur.com/pOysMZF.png)