### PR TITLE
Disallow absolute paths passed as system libraries

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3734,7 +3734,7 @@ pub fn faccessatW(dirfd: fd_t, sub_path_w: [*:0]const u16, mode: u32, flags: u32
         .SUCCESS => return,
         .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
         .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
-        .OBJECT_NAME_INVALID => return error.BadPathName,
+        .OBJECT_NAME_INVALID => unreachable,
         .INVALID_PARAMETER => unreachable,
         .ACCESS_DENIED => return error.PermissionDenied,
         .OBJECT_PATH_SYNTAX_BAD => unreachable,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3734,6 +3734,7 @@ pub fn faccessatW(dirfd: fd_t, sub_path_w: [*:0]const u16, mode: u32, flags: u32
         .SUCCESS => return,
         .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
         .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
+        .OBJECT_NAME_INVALID => return error.BadPathName,
         .INVALID_PARAMETER => unreachable,
         .ACCESS_DENIED => return error.PermissionDenied,
         .OBJECT_PATH_SYNTAX_BAD => unreachable,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1353,6 +1353,9 @@ fn buildOutputType(
                 _ = system_libs.orderedRemove(i);
                 continue;
             }
+            if (std.fs.path.isAbsolute(lib_name)) {
+                fatal("cannot use absolute path as a system library: {}", .{lib_name});
+            }
             i += 1;
         }
     }


### PR DESCRIPTION
Closes #6868  

Also added OBJECT_NAME_INVALID handling in faccessatW, which was causing the Unexpected error in that issue.  
