### PR TITLE
stage1: Fix symbol lookup logic

### DIFF
--- a/src/stage1/analyze.hpp
+++ b/src/stage1/analyze.hpp
@@ -75,6 +75,7 @@ enum SourceKind {
 ZigType *add_source_file(CodeGen *g, ZigPackage *package, Buf *abs_full_path, Buf *source_code,
         SourceKind source_kind);
 
+bool find_decl_or_variable(CodeGen *g, Scope *scope, Buf *name, ScopeFnDef **crossed_fndef_scope, ZigVar **var_out, Tld **tld_out);
 ZigVar *find_variable(CodeGen *g, Scope *orig_context, Buf *name, ScopeFnDef **crossed_fndef_scope);
 Tld *find_decl(CodeGen *g, Scope *scope, Buf *name);
 Tld *find_container_decl(CodeGen *g, ScopeDecls *decls_scope, Buf *name);

--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -59,6 +59,7 @@ comptime {
     _ = @import("behavior/bugs/7027.zig");
     _ = @import("behavior/bugs/7047.zig");
     _ = @import("behavior/bugs/7003.zig");
+    _ = @import("behavior/bugs/7140.zig");
     _ = @import("behavior/bugs/394.zig");
     _ = @import("behavior/bugs/421.zig");
     _ = @import("behavior/bugs/529.zig");

--- a/test/stage1/behavior/bugs/7140.zig
+++ b/test/stage1/behavior/bugs/7140.zig
@@ -1,0 +1,20 @@
+const P = struct {
+    fn print() void {}
+};
+
+const print = P.print;
+
+const S = struct {
+    fn print(self: @This(), n: usize) void {
+        // The first `print` definition in the scope hierarchy is this one, make
+        // sure the compiler doesn't pick the toplevel variable `print`.
+        if (n == 0) print(self, 1);
+    }
+};
+
+test "bug 7140" {
+    // The variable `print` is now bound.
+    print();
+    var s: S = undefined;
+    s.print(0);
+}


### PR DESCRIPTION
The compiler performed a weird two-pass lookup over the scope hierarchy
when it tried to find a given symbol. Beside being quite inefficient,
doing so is also wrong as it doesn't respect the scope nesting and
introduce lookup rules that defy any sort of common sense.

The newly introduced function performs a single scan over the scope
hierarchy and considers both declarations and variables at the same
time.

The fix is sloppy and inelegant, but that's par for the course as stage1
must die.

Please review with care.

Fixes #7140