### PR TITLE
openbsd: getdents could return invalid entry with d_fileno==0

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -352,7 +352,7 @@ pub const Dir = struct {
 
                     const name = @ptrCast([*]u8, &darwin_entry.d_name)[0..darwin_entry.d_namlen];
 
-                    if (mem.eql(u8, name, ".") or mem.eql(u8, name, "..")) {
+                    if (mem.eql(u8, name, ".") or mem.eql(u8, name, "..") or (darwin_entry.d_ino == 0)) {
                         continue :start_over;
                     }
 

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -393,17 +393,17 @@ pub const Dir = struct {
                         self.index = 0;
                         self.end_index = @intCast(usize, rc);
                     }
-                    const freebsd_entry = @ptrCast(*align(1) os.dirent, &self.buf[self.index]);
-                    const next_index = self.index + freebsd_entry.reclen();
+                    const bsd_entry = @ptrCast(*align(1) os.dirent, &self.buf[self.index]);
+                    const next_index = self.index + bsd_entry.reclen();
                     self.index = next_index;
 
-                    const name = @ptrCast([*]u8, &freebsd_entry.d_name)[0..freebsd_entry.d_namlen];
+                    const name = @ptrCast([*]u8, &bsd_entry.d_name)[0..bsd_entry.d_namlen];
 
                     if (mem.eql(u8, name, ".") or mem.eql(u8, name, "..")) {
                         continue :start_over;
                     }
 
-                    const entry_kind = switch (freebsd_entry.d_type) {
+                    const entry_kind = switch (bsd_entry.d_type) {
                         os.DT_BLK => Entry.Kind.BlockDevice,
                         os.DT_CHR => Entry.Kind.CharacterDevice,
                         os.DT_DIR => Entry.Kind.Directory,


### PR DESCRIPTION
According to [getdents(2)](http://man.openbsd.org/getdents.2) man page, OpenBSD could return some invalid entries with `d_fileno` set to 0 may be returned among regular entries.

The diff makes iterates to ignore such entries on OpenBSD.

I checked the `getdents(2)` man-pages from [FreeBSD 12.2](https://www.freebsd.org/cgi/man.cgi?query=getdents&apropos=0&sektion=0&manpath=FreeBSD+12.2-RELEASE+and+Ports&arch=default&format=html) and [NetBSD](http://man.netbsd.org/getdents.2) and no such invalid entries should be returned.