### PR TITLE
std: Disable _only_ the flaky part of the ResetEvent test

### DIFF
--- a/lib/std/reset_event.zig
+++ b/lib/std/reset_event.zig
@@ -363,12 +363,6 @@ const AtomicEvent = struct {
 };
 
 test "ResetEvent" {
-    if (false) {
-        // I have now observed this fail on macOS, Windows, and Linux.
-        // https://github.com/ziglang/zig/issues/7009
-        return error.SkipZigTest;
-    }
-
     var event = ResetEvent.init();
     defer event.deinit();
 
@@ -462,9 +456,13 @@ test "ResetEvent" {
     defer receiver.wait();
     context.sender();
 
-    var timed = Context.init();
-    defer timed.deinit();
-    const sleeper = try std.Thread.spawn(&timed, Context.sleeper);
-    defer sleeper.wait();
-    try timed.timedWaiter();
+    if (false) {
+        // I have now observed this fail on macOS, Windows, and Linux.
+        // https://github.com/ziglang/zig/issues/7009
+        var timed = Context.init();
+        defer timed.deinit();
+        const sleeper = try std.Thread.spawn(&timed, Context.sleeper);
+        defer sleeper.wait();
+        try timed.timedWaiter();
+    }
 }


### PR DESCRIPTION
The remaining part is working just fine as it's not time-dependent.