### PR TITLE
std/os: define and use dev_t for linux x86_64

### DIFF
--- a/lib/std/os/bits/linux/x86_64.zig
+++ b/lib/std/os/bits/linux/x86_64.zig
@@ -511,10 +511,11 @@ pub const msghdr_const = extern struct {
 
 pub const off_t = i64;
 pub const ino_t = u64;
+pub const dev_t = u64;
 
 // The `stat` definition used by the Linux kernel.
 pub const kernel_stat = extern struct {
-    dev: u64,
+    dev: dev_t,
     ino: ino_t,
     nlink: usize,
 
@@ -522,7 +523,7 @@ pub const kernel_stat = extern struct {
     uid: uid_t,
     gid: gid_t,
     __pad0: u32,
-    rdev: u64,
+    rdev: dev_t,
     size: off_t,
     blksize: isize,
     blocks: i64,


### PR DESCRIPTION
I wanted to use this but found that the definition was missing for linux x86_64 for some reason. It is present for many other arches already. Not sure what the policy is with regards to what gets included in 0.7.1 or not, but this would be convenient to have..