### PR TITLE
os/bits: add the termios_c_cc bits

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1870,6 +1870,87 @@ pub const B3000000 = 0o0010015;
 pub const B3500000 = 0o0010016;
 pub const B4000000 = 0o0010017;
 
+pub usingnamespace switch (builtin.arch) {
+    .powerpc, .powerpc64, .powerpc64le => struct {
+        pub const VINTR = 0;
+        pub const VQUIT = 1;
+        pub const VERASE = 2;
+        pub const VKILL = 3;
+        pub const VEOF = 4;
+        pub const VMIN = 5;
+        pub const VEOL = 6;
+        pub const VTIME = 7;
+        pub const VEOL2 = 8;
+        pub const VSWTC = 9;
+        pub const VWERASE = 10;
+        pub const VREPRINT = 11;
+        pub const VSUSP = 12;
+        pub const VSTART = 13;
+        pub const VSTOP = 14;
+        pub const VLNEXT = 15;
+        pub const VDISCARD = 16;
+    },
+    .sparc, .sparcv9 => struct {
+        pub const VINTR = 0;
+        pub const VQUIT = 1;
+        pub const VERASE = 2;
+        pub const VKILL = 3;
+        pub const VEOF = 4;
+        pub const VEOL = 5;
+        pub const VEOL2 = 6;
+        pub const VSWTC = 7;
+        pub const VSTART = 8;
+        pub const VSTOP = 9;
+        pub const VSUSP = 10;
+        pub const VDSUSP = 11;
+        pub const VREPRINT = 12;
+        pub const VDISCARD = 13;
+        pub const VWERASE = 14;
+        pub const VLNEXT = 15;
+        pub const VMIN = VEOF;
+        pub const VTIME = VEOL;
+    },
+    .mips, .mipsel, .mips64, .mips64el => struct {
+        pub const VINTR = 0;
+        pub const VQUIT = 1;
+        pub const VERASE = 2;
+        pub const VKILL = 3;
+        pub const VMIN = 4;
+        pub const VTIME = 5;
+        pub const VEOL2 = 6;
+        pub const VSWTC = 7;
+        pub const VSWTCH = 7;
+        pub const VSTART = 8;
+        pub const VSTOP = 9;
+        pub const VSUSP = 10;
+        pub const VREPRINT = 12;
+        pub const VDISCARD = 13;
+        pub const VWERASE = 14;
+        pub const VLNEXT = 15;
+        pub const VEOF = 16;
+        pub const VEOL = 17;
+    },
+    else => struct {
+        pub const VINTR = 0;
+        pub const VQUIT = 1;
+        pub const VERASE = 2;
+        pub const VKILL = 3;
+        pub const VEOF = 4;
+        pub const VTIME = 5;
+        pub const VMIN = 6;
+        pub const VSWTC = 7;
+        pub const VSTART = 8;
+        pub const VSTOP = 9;
+        pub const VSUSP = 10;
+        pub const VEOL = 11;
+        pub const VREPRINT = 12;
+        pub const VDISCARD = 13;
+        pub const VWERASE = 14;
+        pub const VLNEXT = 15;
+        pub const VEOL2 = 16;
+    },
+};
+
 pub const IGNBRK = 1;
 pub const BRKINT = 2;
 pub const IGNPAR = 4;


### PR DESCRIPTION
I've been working on [this article](https://viewsourcecode.org/snaptoken/kilo/02.enteringRawMode.html#a-timeout-for-read) (but using Zig) and realized there's some termios constants missing in `bits/linux.zig`, mainly I needed `VMIN` and `VTIME`.

I've taken the constants from [musl](https://git.musl-libc.org/cgit/musl/tree/arch/generic/bits/termios.h)

However there are a bunch of different `termios-c_cc.h` files in zig itself (like [this one](https://github.com/ziglang/zig/blob/master/lib/libc/include/sparc-linux-gnu/bits/termios-c_cc.h) or [this one](https://github.com/ziglang/zig/blob/master/lib/libc/include/mips-linux-gnu/bits/termios-c_cc.h)) which don't have the same constants so I'm a little confused if the values I pulled from musl are actually generic.