### PR TITLE
openbsd: malloc_usable_size is unavailable on OpenBSD

### DIFF
--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -34,4 +34,4 @@ pub const pthread_attr_t = extern struct {
 };
 
 pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
-pub extern "c" fn malloc_usable_size(?*const c_void) usize;
+


### PR DESCRIPTION
unbreak OpenBSD after #6385
