### PR TITLE
Draft: Fix bitwise op conflicting with optional payload

### DIFF
--- a/src/stage1/parser.cpp
+++ b/src/stage1/parser.cpp
@@ -2530,7 +2530,9 @@ static AstNode *ast_parse_bitwise_op(ParseContext *pc) {
 
     BinOpType op = table[peek_token(pc)->id];
     if (op != BinOpTypeInvalid) {
-        if (op != BinOpTypeUnwrapOptional && peek_token_i(pc, 1)->id == TokenIdLBrace) {
+        if (op != BinOpTypeUnwrapOptional
+                && peek_token_i(pc, 1)->id == TokenIdLBrace
+                && peek_token_i(pc, 2)->id != TokenIdRBrace) {
             return nullptr; // Bin op with block is invalid
         }
         Token *op_token = eat_token(pc);

--- a/src/stage1/parser.cpp
+++ b/src/stage1/parser.cpp
@@ -2530,6 +2530,9 @@ static AstNode *ast_parse_bitwise_op(ParseContext *pc) {
 
     BinOpType op = table[peek_token(pc)->id];
     if (op != BinOpTypeInvalid) {
+        if (op == BinOpTypeBinOr && peek_token_i(pc, 1)->id == TokenIdLBrace) {
+            return nullptr; // Cannot have | { in a Bitwise or
+        }
         Token *op_token = eat_token(pc);
         AstNode *res = ast_create_node(pc, NodeTypeBinOpExpr, op_token);
         res->data.bin_op_expr.bin_op = op;

--- a/src/stage1/parser.cpp
+++ b/src/stage1/parser.cpp
@@ -2530,8 +2530,8 @@ static AstNode *ast_parse_bitwise_op(ParseContext *pc) {
 
     BinOpType op = table[peek_token(pc)->id];
     if (op != BinOpTypeInvalid) {
-        if (op == BinOpTypeBinOr && peek_token_i(pc, 1)->id == TokenIdLBrace) {
-            return nullptr; // Cannot have | { in a Bitwise or
+        if (op != BinOpTypeUnwrapOptional && peek_token_i(pc, 1)->id == TokenIdLBrace) {
+            return nullptr; // Bin op with block is invalid
         }
         Token *op_token = eat_token(pc);
         AstNode *res = ast_create_node(pc, NodeTypeBinOpExpr, op_token);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -8354,4 +8354,44 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     , &[_][]const u8{
         "tmp.zig:2:30: error: `.*` can't be followed by `*`. Are you missing a space?",
     });
+
+    cases.add("Issue #7186: don't let bitwise or capture optional payload",
+        \\fn getOptional(name: []const u8) ?[]const u8 {
+        \\    return if (name.len == 0) null else name;
+        \\}
+        \\fn getResult() []const u8 {
+        \\  if (getOptional("value") |name| {
+        \\     return name;
+        \\  }
+        \\  return "";
+        \\}
+
+    , &[_][]const u8{
+        "tmp.zig:5:33: error: expected token ')', found '|'",
+    });
+
+    cases.add("Issue #7186: don't let bitwise or capture for payload",
+        \\fn getResult() void {
+        \\  for ("value" |c| {
+        \\     break;
+        \\  }
+        \\}
+
+    , &[_][]const u8{
+        "tmp.zig:2:18: error: expected token ')', found '|'",
+    });
+
+    cases.add("Issue #7186: don't let bitwise or capture while payload",
+        \\fn getResult() void {
+        \\  var it = std.mem.split("1,2,3", ",");
+        \\  while (it.next() |value| {
+        \\     break;
+        \\  }
+        \\}
+
+    , &[_][]const u8{
+        "tmp.zig:3:26: error: expected token ')', found '|'",
+    });
+
+
 }


### PR DESCRIPTION
Fix for #7186 The problem is the  bitwise or is catching the optional payload.

This seems like a hack to do it here so maybe someone can find a cleaner way to do it. 

Output after the change: 
```
Semantic Analysis... ./issue7186.zig:9:34: error: expected token ')', found '|'
    if (getOptional("foo") |value| {
                                 ^

```