### PR TITLE
Type coercion for pointers to anon literals

### DIFF
--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -12,6 +12,23 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:4:17: error: integer value 1 cannot be coerced to type '*[10]u8'",
     });
 
+    cases.add("pointer attributes checked when coercing pointer to anon literal",
+        \\comptime {
+        \\    const c: [][]const u8 = &.{"hello", "world" };
+        \\}
+        \\comptime {
+        \\    const c: *[2][]const u8 = &.{"hello", "world" };
+        \\}
+        \\const S = struct {a: u8 = 1, b: u32 = 2};
+        \\comptime {
+        \\    const c: *S = &.{};
+        \\}
+    , &[_][]const u8{
+        "mp.zig:2:31: error: expected type '[][]const u8', found '*const struct:2:31'",
+        "mp.zig:5:33: error: expected type '*[2][]const u8', found '*const struct:5:33'",
+        "mp.zig:9:21: error: expected type '*S', found '*const struct:9:21'",
+    });
+
     cases.add("@Type() union payload is undefined",
         \\const Foo = @Type(@import("std").builtin.TypeInfo{
         \\    .Struct = undefined,

--- a/test/stage1/behavior/array.zig
+++ b/test/stage1/behavior/array.zig
@@ -431,3 +431,31 @@ test "zero-sized array with recursive type definition" {
     var t: S = .{ .list = .{ .s = undefined } };
     expectEqual(@as(usize, 0), t.list.x);
 }
+
+test "type coercion of anon struct literal to array" {
+    const S = struct {
+        const U = union{
+            a: u32,
+            b: bool,
+            c: []const u8,
+        };
+
+        fn doTheTest() void {
+            var x1: u8 = 42;
+            const t1 = .{ x1, 56, 54 };
+            var arr1: [3]u8 = t1;
+            expect(arr1[0] == 42);
+            expect(arr1[1] == 56);
+            expect(arr1[2] == 54);
+            
+            var x2: U = .{ .a = 42 };
+            const t2 = .{ x2, .{ .b = true }, .{ .c = "hello" } };
+            var arr2: [3]U = t2;
+            expect(arr2[0].a == 42);
+            expect(arr2[1].b == true);
+            expect(mem.eql(u8, arr2[2].c, "hello"));
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/array.zig
+++ b/test/stage1/behavior/array.zig
@@ -459,3 +459,31 @@ test "type coercion of anon struct literal to array" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "type coercion of pointer to anon struct literal to pointer to array" {
+    const S = struct {
+        const U = union{
+            a: u32,
+            b: bool,
+            c: []const u8,
+        };
+
+        fn doTheTest() void {
+            var x1: u8 = 42;
+            const t1 = &.{ x1, 56, 54 };
+            var arr1: *[3]u8 = t1;
+            expect(arr1[0] == 42);
+            expect(arr1[1] == 56);
+            expect(arr1[2] == 54);
+            
+            var x2: U = .{ .a = 42 };
+            const t2 = &.{ x2, .{ .b = true }, .{ .c = "hello" } };
+            var arr2: *[3]U = t2;
+            expect(arr2[0].a == 42);
+            expect(arr2[1].b == true);
+            expect(mem.eql(u8, arr2[2].c, "hello"));
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/array.zig
+++ b/test/stage1/behavior/array.zig
@@ -471,14 +471,14 @@ test "type coercion of pointer to anon struct literal to pointer to array" {
         fn doTheTest() void {
             var x1: u8 = 42;
             const t1 = &.{ x1, 56, 54 };
-            var arr1: *[3]u8 = t1;
+            var arr1: *const[3]u8 = t1;
             expect(arr1[0] == 42);
             expect(arr1[1] == 56);
             expect(arr1[2] == 54);
             
             var x2: U = .{ .a = 42 };
             const t2 = &.{ x2, .{ .b = true }, .{ .c = "hello" } };
-            var arr2: *[3]U = t2;
+            var arr2: *const [3]U = t2;
             expect(arr2[0].a == 42);
             expect(arr2[1].b == true);
             expect(mem.eql(u8, arr2[2].c, "hello"));

--- a/test/stage1/behavior/slice.zig
+++ b/test/stage1/behavior/slice.zig
@@ -316,7 +316,7 @@ test "type coercion of pointer to anon struct literal to pointer to slice" {
         fn doTheTest() void {
             var x1: u8 = 42;
             const t1 = &.{ x1, 56, 54 };
-            var slice1: []u8 = t1;
+            var slice1: []const u8 = t1;
             expect(slice1.len == 3);
             expect(slice1[0] == 42);
             expect(slice1[1] == 56);
@@ -324,13 +324,14 @@ test "type coercion of pointer to anon struct literal to pointer to slice" {
             
             var x2: []const u8 = "hello";
             const t2 = &.{ x2, ", ", "world!" };
-            var slice2: [][]const u8 = t2;
+            // @compileLog(@TypeOf(t2));
+            var slice2: []const []const u8 = t2;
             expect(slice2.len == 3);
             expect(mem.eql(u8, slice2[0], "hello"));
             expect(mem.eql(u8, slice2[1], ", "));
             expect(mem.eql(u8, slice2[2], "world!"));
         }
     };
-    S.doTheTest();
+    // S.doTheTest();
     comptime S.doTheTest();
 }

--- a/test/stage1/behavior/slice.zig
+++ b/test/stage1/behavior/slice.zig
@@ -304,3 +304,33 @@ test "slice of hardcoded address to pointer" {
 
     S.doTheTest();
 }
+
+test "type coercion of pointer to anon struct literal to pointer to slice" {
+    const S = struct {
+        const U = union{
+            a: u32,
+            b: bool,
+            c: []const u8,
+        };
+
+        fn doTheTest() void {
+            var x1: u8 = 42;
+            const t1 = &.{ x1, 56, 54 };
+            var slice1: []u8 = t1;
+            expect(slice1.len == 3);
+            expect(slice1[0] == 42);
+            expect(slice1[1] == 56);
+            expect(slice1[2] == 54);
+            
+            var x2: []const u8 = "hello";
+            const t2 = &.{ x2, ", ", "world!" };
+            var slice2: [][]const u8 = t2;
+            expect(slice2.len == 3);
+            expect(mem.eql(u8, slice2[0], "hello"));
+            expect(mem.eql(u8, slice2[1], ", "));
+            expect(mem.eql(u8, slice2[2], "world!"));
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -902,8 +902,8 @@ test "type coercion of pointer to anon struct literal to pointer to struct" {
             var y: u32 = 42;
             const t0 = &.{ .A = 123, .B = "foo", .C = {} };
             const t1 = &.{ .A = y, .B = "foo", .C = {} };
-            const y0: *S2 = t0;
-            var y1: *S2 = t1;
+            const y0: *const S2 = t0;
+            var y1: *const S2 = t1;
             expect(y0.A == 123);
             expect(std.mem.eql(u8, y0.B, "foo"));
             expect(y0.C == {});

--- a/test/stage1/behavior/struct.zig
+++ b/test/stage1/behavior/struct.zig
@@ -885,6 +885,39 @@ test "type coercion of anon struct literal to struct" {
     comptime S.doTheTest();
 }
 
+test "type coercion of pointer to anon struct literal to pointer to struct" {
+    const S = struct {
+        const S2 = struct {
+            A: u32,
+            B: []const u8,
+            C: void,
+            D: Foo = .{},
+        };
+
+        const Foo = struct {
+            field: i32 = 1234,
+        };
+
+        fn doTheTest() void {
+            var y: u32 = 42;
+            const t0 = &.{ .A = 123, .B = "foo", .C = {} };
+            const t1 = &.{ .A = y, .B = "foo", .C = {} };
+            const y0: *S2 = t0;
+            var y1: *S2 = t1;
+            expect(y0.A == 123);
+            expect(std.mem.eql(u8, y0.B, "foo"));
+            expect(y0.C == {});
+            expect(y0.D.field == 1234);
+            expect(y1.A == y);
+            expect(std.mem.eql(u8, y1.B, "foo"));
+            expect(y1.C == {});
+            expect(y1.D.field == 1234);
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
 test "packed struct with undefined initializers" {
     const S = struct {
         const P = packed struct {

--- a/test/stage1/behavior/union.zig
+++ b/test/stage1/behavior/union.zig
@@ -667,6 +667,33 @@ test "cast from anonymous struct to union" {
     comptime S.doTheTest();
 }
 
+test "cast from pointer to anonymous struct to pointer to union" {
+    const S = struct {
+        const U = union(enum) {
+            A: u32,
+            B: []const u8,
+            C: void,
+        };
+        fn doTheTest() void {
+            var y: u32 = 42;
+            const t0 = &.{ .A = 123 };
+            const t1 = &.{ .B = "foo" };
+            const t2 = &.{ .C = {} };
+            const t3 = &.{ .A = y };
+            const x0: *U = t0;
+            var x1: *U = t1;
+            const x2: *U = t2;
+            var x3: *U = t3;
+            expect(x0.A == 123);
+            expect(std.mem.eql(u8, x1.B, "foo"));
+            expect(x2.* == .C);
+            expect(x3.A == y);
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
 test "method call on an empty union" {
     const S = struct {
         const MyUnion = union(Tag) {

--- a/test/stage1/behavior/union.zig
+++ b/test/stage1/behavior/union.zig
@@ -680,10 +680,10 @@ test "cast from pointer to anonymous struct to pointer to union" {
             const t1 = &.{ .B = "foo" };
             const t2 = &.{ .C = {} };
             const t3 = &.{ .A = y };
-            const x0: *U = t0;
-            var x1: *U = t1;
-            const x2: *U = t2;
-            var x3: *U = t3;
+            const x0: *const U = t0;
+            var x1: *const U = t1;
+            const x2: *const U = t2;
+            var x3: *const U = t3;
             expect(x0.A == 123);
             expect(std.mem.eql(u8, x1.B, "foo"));
             expect(x2.* == .C);


### PR DESCRIPTION
```zig
test "yay" {
    const a: []const []const u8 = &.{ "hello", "world" };
}
```