### PR TITLE
Fix logic for detecting _DYNAMIC symbol

### DIFF
--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -56,12 +56,13 @@ fn getDynamicSymbol() [*]elf.Dyn {
             : [ret] "=r" (-> usize)
         ),
         .riscv64 => asm volatile (
+            \\ .weak _DYNAMIC
+            \\ .hidden _DYNAMIC
             \\ lla %[ret], _DYNAMIC
             : [ret] "=r" (-> usize)
         ),
         else => @compileError("???"),
     };
-    if (addr == 0) unreachable;
     return @intToPtr([*]elf.Dyn, addr);
 }
 

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -386,8 +386,6 @@ fn iter_fn(info: *dl_phdr_info, size: usize, counter: *usize) IterFnError!void {
 test "dl_iterate_phdr" {
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi or builtin.os.tag == .macos)
         return error.SkipZigTest;
-    if (builtin.position_independent_executable)
-        return error.SkipZigTest;
 
     var counter: usize = 0;
     try os.dl_iterate_phdr(&counter, IterFnError, iter_fn);

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -686,8 +686,6 @@ pub fn getBaseAddress() usize {
             if (base != 0) {
                 return base;
             }
-            // XXX: Wrong for PIE executables, it should look at the difference
-            // between _DYNAMIC and the PT_DYNAMIC phdr instead.
             const phdr = os.system.getauxval(std.elf.AT_PHDR);
             return phdr - @sizeOf(std.elf.Ehdr);
         },

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -686,6 +686,8 @@ pub fn getBaseAddress() usize {
             if (base != 0) {
                 return base;
             }
+            // XXX: Wrong for PIE executables, it should look at the difference
+            // between _DYNAMIC and the PT_DYNAMIC phdr instead.
             const phdr = os.system.getauxval(std.elf.AT_PHDR);
             return phdr - @sizeOf(std.elf.Ehdr);
         },

--- a/test/stack_traces.zig
+++ b/test/stack_traces.zig
@@ -282,7 +282,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                     \\source.zig:10:8: [address] in main (test)
                     \\    foo();
                     \\       ^
-                    \\start.zig:331:29: [address] in std.start.posixCallMainAndExit (test)
+                    \\start.zig:337:29: [address] in std.start.posixCallMainAndExit (test)
                     \\            return root.main();
                     \\                            ^
                     \\start.zig:162:5: [address] in std.start._start (test)


### PR DESCRIPTION
Prevent spurious crashes for non-PIE executables.

This should make the CI green again, ~`dl_iterate_phdr` is still broken for PIE executables as the compiler rightfully rejects a double declaration of `_DYNAMIC`.~ fixed!