### PR TITLE
fix for GCC 9.2: -Wno-maybe-uninitialized

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,6 +603,10 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
         if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.0)
             set(EXE_CFLAGS "${EXE_CFLAGS} -Werror=implicit-fallthrough")
         endif()
+        # GCC 9.2 and older are unable to detect valid variable initialization in some cases
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 9.2)
+            set(EXE_CFLAGS "${EXE_CFLAGS} -Wno-maybe-uninitialized")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
Compiling with GCC 9.2 yields dozens of "maybe uninitialized" errors.  This PR tells GCC compilers at 9.2 or older to ignore those errors.  Note that newer compilers that are able to properly check these cases still have the errors enabled.