### PR TITLE
Update cmake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Use ccache if possible
 FIND_PROGRAM(CCACHE_PROGRAM ccache)


### PR DESCRIPTION
Recent versions of cmake complain about our minimum version:

    CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 2.8.12 will be removed from a future version of
    CMake.

We don't require anything from version 2.8.5, and version 2.8.12 was released in 2011, so it is very unlikely that anyone still uses 2.8.5.