### PR TITLE
std/crypto - edwards25519 precomp: prefer doublings over adds

### DIFF
--- a/lib/std/crypto/25519/edwards25519.zig
+++ b/lib/std/crypto/25519/edwards25519.zig
@@ -221,7 +221,7 @@ pub const Edwards25519 = struct {
         pc[1] = p;
         var i: usize = 2;
         while (i <= count) : (i += 1) {
-            pc[i] = pc[i - 1].add(p);
+            pc[i] = if (i % 2 == 0) pc[i / 2].dbl() else pc[i - 1].add(p);
         }
         return pc;
     }


### PR DESCRIPTION
Doublings are a little bit faster than additions, so use them half the time during precomputations.