### PR TITLE
stage1: Fix ICE when generating struct fields with padding

### DIFF
--- a/test/stage1/behavior.zig
+++ b/test/stage1/behavior.zig
@@ -50,6 +50,7 @@ comptime {
     _ = @import("behavior/bugs/4769_b.zig");
     _ = @import("behavior/bugs/4769_c.zig");
     _ = @import("behavior/bugs/4954.zig");
+    _ = @import("behavior/bugs/5398.zig");
     _ = @import("behavior/bugs/5413.zig");
     _ = @import("behavior/bugs/5474.zig");
     _ = @import("behavior/bugs/5487.zig");

--- a/test/stage1/behavior/bugs/5398.zig
+++ b/test/stage1/behavior/bugs/5398.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+const testing = std.testing;
+
+pub const Mesh = struct {
+    id: u32,
+};
+pub const Material = struct {
+    transparent: bool = true,
+    emits_shadows: bool = true,
+    render_color: bool = true,
+};
+pub const Renderable = struct {
+    material: Material,
+    // The compiler inserts some padding here to ensure Mesh is correctly aligned.
+    mesh: Mesh,
+};
+
+var renderable: Renderable = undefined;
+
+test "assignment of field with padding" {
+    renderable = Renderable{
+        .mesh = Mesh{ .id = 0 },
+        .material = Material{
+            .transparent = false,
+            .emits_shadows = false,
+        },
+    };
+    testing.expectEqual(false, renderable.material.transparent);
+    testing.expectEqual(false, renderable.material.emits_shadows);
+    testing.expectEqual(true, renderable.material.render_color);
+}


### PR DESCRIPTION
Make gen_const_ptr_struct_recursive aware of the possible presence of
some trailing padding by always bitcasting the pointer to its expected
type.

Not an elegant solution but makes LLVM happy and is consistent with how
the other callsites are handling this case.

Fixes #5398