### PR TITLE
stage2: Hello, Silicon!\n

### DIFF
--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -705,6 +705,23 @@ pub const relocation_info = packed struct {
     r_type: u4,
 };
 
+/// The version_min_command contains the min OS version on which this 
+/// binary was built to run.
+pub const version_min_command = extern struct {
+    /// LC_VERSION_MIN_MACOSX or LC_VERSION_MIN_IPHONEOS or LC_VERSION_MIN_WATCHOS
+    /// or LC_VERSION_MIN_TVOS
+    cmd: u32,
+
+    /// sizeof(struct min_version_command)
+    cmdsize: u32,
+
+    /// X.Y.Z is encoded in nibbles xxxx.yy.zz
+    version: u32,
+
+    /// X.Y.Z is encoded in nibbles xxxx.yy.zz
+    sdk: u32,
+};
+
 /// After MacOS X 10.1 when a new load command is added that is required to be
 /// understood by the dynamic linker for the image to execute properly the
 /// LC_REQ_DYLD bit will be or'ed into the load command constant.  If the dynamic

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -1384,10 +1384,10 @@ pub const CSTYPE_INDEX_REQUIREMENTS: u32 = 0x00000002;
 /// Compat with amfi
 pub const CSTYPE_INDEX_ENTITLEMENTS: u32 = 0x00000005;
 
-pub const CS_HASHTYPE_SHA1: u32 = 1;
-pub const CS_HASHTYPE_SHA256: u32 = 2;
-pub const CS_HASHTYPE_SHA256_TRUNCATED: u32 = 3;
-pub const CS_HASHTYPE_SHA384: u32 = 4;
+pub const CS_HASHTYPE_SHA1: u8 = 1;
+pub const CS_HASHTYPE_SHA256: u8 = 2;
+pub const CS_HASHTYPE_SHA256_TRUNCATED: u8 = 3;
+pub const CS_HASHTYPE_SHA384: u8 = 4;
 
 pub const CS_SHA1_LEN: u32 = 20;
 pub const CS_SHA256_LEN: u32 = 32;

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -1446,6 +1446,18 @@ pub const CodeDirectory = extern struct {
     /// Unused (must be zero)
     spare2: u32,
 
+    ///
+    scatterOffset: u32,
+
+    ///
+    teamOffset: u32,
+
+    ///
+    spare3: u32,
+
+    ///
+    codeLimit64: u64,
+
     /// Offset of executable segment
     execSegBase: u64,
 
@@ -1453,9 +1465,7 @@ pub const CodeDirectory = extern struct {
     execSegLimit: u64,
 
     /// Executable segment flags
-    execSegFlags,
-
-    // end_withExecSeg: [*]u8,
+    execSegFlags: u64,
 };
 
 /// Structure of an embedded-signature SuperBlob

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -1402,6 +1402,10 @@ pub const CS_SIGNER_TYPE_UNKNOWN: u32 = 0;
 pub const CS_SIGNER_TYPE_LEGACYVPN: u32 = 5;
 pub const CS_SIGNER_TYPE_MAC_APP_STORE: u32 = 6;
 
+pub const CS_ADHOC: u32 = 0x2;
+
+pub const CS_EXECSEG_MAIN_BINARY: u32 = 0x1;
+
 /// This CodeDirectory is tailored specfically at version 0x20400.
 pub const CodeDirectory = extern struct {
     /// Magic number (CSMAGIC_CODEDIRECTORY)
@@ -1488,8 +1492,6 @@ pub const SuperBlob = extern struct {
 
     /// Number of index BlobIndex entries following this struct
     count: u32,
-
-    // index: []const BlobIndex,
 };
 
 pub const GenericBlob = extern struct {
@@ -1498,6 +1500,4 @@ pub const GenericBlob = extern struct {
 
     /// Total length of blob
     length: u32,
-
-    // data: []const u8,
 };

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -705,36 +705,6 @@ pub const relocation_info = packed struct {
     r_type: u4,
 };
 
-/// The version_min_command contains the min OS version on which this 
-/// binary was built to run.
-pub const version_min_command = extern struct {
-    /// LC_VERSION_MIN_MACOSX or LC_VERSION_MIN_IPHONEOS or LC_VERSION_MIN_WATCHOS
-    /// or LC_VERSION_MIN_TVOS
-    cmd: u32,
-
-    /// sizeof(struct min_version_command)
-    cmdsize: u32,
-
-    /// X.Y.Z is encoded in nibbles xxxx.yy.zz
-    version: u32,
-
-    /// X.Y.Z is encoded in nibbles xxxx.yy.zz
-    sdk: u32,
-};
-
-/// The source_version_command is an optional load command containing
-/// the version of the sources used to build the binary.
-pub const source_version_command = extern struct {
-    /// LC_SOURCE_VERSION
-    cmd: u32,
-
-    /// sizeof(source_version_command)
-    cmdsize: u32,
-
-    /// A.B.C.D.E packed as a24.b10.c10.d10.e10
-    version: u64,
-};
-
 /// After MacOS X 10.1 when a new load command is added that is required to be
 /// understood by the dynamic linker for the image to execute properly the
 /// LC_REQ_DYLD bit will be or'ed into the load command constant.  If the dynamic

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -722,6 +722,19 @@ pub const version_min_command = extern struct {
     sdk: u32,
 };
 
+/// The source_version_command is an optional load command containing
+/// the version of the sources used to build the binary.
+pub const source_version_command = extern struct {
+    /// LC_SOURCE_VERSION
+    cmd: u32,
+
+    /// sizeof(source_version_command)
+    cmdsize: u32,
+
+    /// A.B.C.D.E packed as a24.b10.c10.d10.e10
+    version: u64,
+};
+
 /// After MacOS X 10.1 when a new load command is added that is required to be
 /// understood by the dynamic linker for the image to execute properly the
 /// LC_REQ_DYLD bit will be or'ed into the load command constant.  If the dynamic

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -2601,7 +2601,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 }).toU32());
                                 // adr x28, #8
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.adr(.x28, 8).toU32());
-                                try self.mod_fn.owner_decl.link.macho.addPieFixup(self.bin_file.allocator, .{
+                                try macho_file.pie_fixups.append(self.bin_file.allocator, .{
                                     .address = addr,
                                     .start = self.code.items.len,
                                     .len = 4,
@@ -2626,7 +2626,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 }).toU32());
                                 // adr x28, #8
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.adr(.x28, 8).toU32());
-                                try self.mod_fn.owner_decl.link.macho.addPieFixup(self.bin_file.allocator, .{
+                                try macho_file.pie_fixups.append(self.bin_file.allocator, .{
                                     .address = addr,
                                     .start = self.code.items.len,
                                     .len = 4,
@@ -2838,7 +2838,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             // later in the linker.
                             if (reg.id() == 0) { // %rax is special-cased
                                 try self.code.ensureCapacity(self.code.items.len + 5);
-                                try self.mod_fn.owner_decl.link.macho.addPieFixup(self.bin_file.allocator, .{
+                                try macho_file.pie_fixups.append(self.bin_file.allocator, .{
                                     .address = x,
                                     .start = self.code.items.len,
                                     .len = 5,
@@ -2855,7 +2855,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 try self.code.ensureCapacity(self.code.items.len + 10);
                                 // push %rax
                                 self.code.appendSliceAssumeCapacity(&[_]u8{0x50});
-                                try self.mod_fn.owner_decl.link.macho.addPieFixup(self.bin_file.allocator, .{
+                                try macho_file.pie_fixups.append(self.bin_file.allocator, .{
                                     .address = x,
                                     .start = self.code.items.len,
                                     .len = 5,

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -2588,17 +2588,64 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             // For MachO, the binary, with the exception of object files, has to be a PIE.
                             // Therefore we cannot load an absolute address.
                             // Instead, we need to make use of PC-relative addressing.
-                            // if (reg.id() == 0) { // x0 is special-cased
+                            // TODO This needs to be optimised in the stack usage (perhaps use a shadow stack
+                            // like described here:
+                            // https://community.arm.com/developer/ip-products/processors/b/processors-ip-blog/posts/using-the-stack-in-aarch64-implementing-push-and-pop)
+                            // TODO As far as branching is concerned, instead of saving the return address
+                            // in a register, I'm thinking here of immitating x86_64, and having the address
+                            // passed on the stack.
+                            if (reg.id() == 0) { // x0 is special-cased
+                                // str x28, [sp, #-16]
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.str(.x28, Register.sp, .{
+                                    .offset = Instruction.Offset.imm_pre_index(-16),
+                                }).toU32());
+                                // adr x28, #8
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.adr(.x28, 8).toU32());
                                 try self.mod_fn.owner_decl.link.macho.addPieFixup(self.bin_file.allocator, .{
                                     .address = addr,
                                     .start = self.code.items.len,
                                     .len = 4,
                                 });
-                                // bl [label]
-                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.bl(0).toU32());
-                            // } else {
-                            //     unreachable; // TODO
-                            // }
+                                // b [label]
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.b(0).toU32());
+                                // mov r, x0
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.orr(reg, .x0, Instruction.RegisterShift.none()).toU32());
+                                // ldr x28, [sp], #16
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.ldr(.x28, .{
+                                    .rn = Register.sp,
+                                    .offset = Instruction.Offset.imm_post_index(16),
+                                }).toU32());
+                            } else {
+                                // str x28, [sp, #-16]
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.str(.x28, Register.sp, .{
+                                    .offset = Instruction.Offset.imm_pre_index(-16),
+                                }).toU32());
+                                // str x0, [sp, #-16]
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.str(.x0, Register.sp, .{
+                                    .offset = Instruction.Offset.imm_pre_index(-16),
+                                }).toU32());
+                                // adr x28, #8
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.adr(.x28, 8).toU32());
+                                try self.mod_fn.owner_decl.link.macho.addPieFixup(self.bin_file.allocator, .{
+                                    .address = addr,
+                                    .start = self.code.items.len,
+                                    .len = 4,
+                                });
+                                // b [label]
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.b(0).toU32());
+                                // mov r, x0
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.orr(reg, .x0, Instruction.RegisterShift.none()).toU32());
+                                // ldr x0, [sp], #16
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.ldr(.x0, .{
+                                    .rn = Register.sp,
+                                    .offset = Instruction.Offset.imm_post_index(16),
+                                }).toU32());
+                                // ldr x28, [sp], #16
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.ldr(.x28, .{
+                                    .rn = Register.sp,
+                                    .offset = Instruction.Offset.imm_post_index(16),
+                                }).toU32());
+                            }
                         } else {
                             // The value is in memory at a hard-coded address.
                             // If the type is a pointer, it means the pointer address is at this memory location.

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -2773,7 +2773,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             // later in the linker.
                             if (reg.id() == 0) { // %rax is special-cased
                                 try self.code.ensureCapacity(self.code.items.len + 5);
-                                try self.mod_fn.owner_decl.link.macho.addRipPosition(self.bin_file.allocator, .{
+                                try self.mod_fn.owner_decl.link.macho.addPieFixup(self.bin_file.allocator, .{
                                     .address = x,
                                     .start = self.code.items.len,
                                     .len = 5,
@@ -2790,7 +2790,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 try self.code.ensureCapacity(self.code.items.len + 10);
                                 // push %rax
                                 self.code.appendSliceAssumeCapacity(&[_]u8{0x50});
-                                try self.mod_fn.owner_decl.link.macho.addRipPosition(self.bin_file.allocator, .{
+                                try self.mod_fn.owner_decl.link.macho.addPieFixup(self.bin_file.allocator, .{
                                     .address = x,
                                     .start = self.code.items.len,
                                     .len = 5,

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -2584,7 +2584,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                     },
                     .register => return self.fail(src, "TODO implement genSetReg for aarch64 {}", .{mcv}),
                     .memory => |addr| {
-                        if (self.bin_file.cast(link.File.MachO)) |macho_file| {
+                        if (self.bin_file.options.pie) {
                             // For MachO, the binary, with the exception of object files, has to be a PIE.
                             // Therefore we cannot load an absolute address.
                             // Instead, we need to make use of PC-relative addressing.

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -2601,11 +2601,15 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 }).toU32());
                                 // adr x28, #8
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.adr(.x28, 8).toU32());
-                                try macho_file.pie_fixups.append(self.bin_file.allocator, .{
-                                    .address = addr,
-                                    .start = self.code.items.len,
-                                    .len = 4,
-                                });
+                                if (self.bin_file.cast(link.File.MachO)) |macho_file| {
+                                    try macho_file.pie_fixups.append(self.bin_file.allocator, .{
+                                        .address = addr,
+                                        .start = self.code.items.len,
+                                        .len = 4,
+                                    });
+                                } else {
+                                    return self.fail(src, "TODO implement genSetReg for PIE on this platform", .{});
+                                }
                                 // b [label]
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.b(0).toU32());
                                 // mov r, x0
@@ -2626,11 +2630,15 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 }).toU32());
                                 // adr x28, #8
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.adr(.x28, 8).toU32());
-                                try macho_file.pie_fixups.append(self.bin_file.allocator, .{
-                                    .address = addr,
-                                    .start = self.code.items.len,
-                                    .len = 4,
-                                });
+                                if (self.bin_file.cast(link.File.MachO)) |macho_file| {
+                                    try macho_file.pie_fixups.append(self.bin_file.allocator, .{
+                                        .address = addr,
+                                        .start = self.code.items.len,
+                                        .len = 4,
+                                    });
+                                } else {
+                                    return self.fail(src, "TODO implement genSetReg for PIE on this platform", .{});
+                                }
                                 // b [label]
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.b(0).toU32());
                                 // mov r, x0
@@ -2828,7 +2836,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                         self.code.appendSliceAssumeCapacity(&[_]u8{ 0x8B, R });
                     },
                     .memory => |x| {
-                        if (self.bin_file.cast(link.File.MachO)) |macho_file| {
+                        if (self.bin_file.options.pie) {
                             // For MachO, the binary, with the exception of object files, has to be a PIE.
                             // Therefore, we cannot load an absolute address.
                             assert(x > math.maxInt(u32)); // 32bit direct addressing is not supported by MachO.
@@ -2838,11 +2846,15 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             // later in the linker.
                             if (reg.id() == 0) { // %rax is special-cased
                                 try self.code.ensureCapacity(self.code.items.len + 5);
-                                try macho_file.pie_fixups.append(self.bin_file.allocator, .{
-                                    .address = x,
-                                    .start = self.code.items.len,
-                                    .len = 5,
-                                });
+                                if (self.bin_file.cast(link.File.MachO)) |macho_file| {
+                                    try macho_file.pie_fixups.append(self.bin_file.allocator, .{
+                                        .address = x,
+                                        .start = self.code.items.len,
+                                        .len = 5,
+                                    });
+                                } else {
+                                    return self.fail(src, "TODO implement genSetReg for PIE on this platform", .{});
+                                }
                                 // call [label]
                                 self.code.appendSliceAssumeCapacity(&[_]u8{
                                     0xE8,
@@ -2855,11 +2867,15 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 try self.code.ensureCapacity(self.code.items.len + 10);
                                 // push %rax
                                 self.code.appendSliceAssumeCapacity(&[_]u8{0x50});
-                                try macho_file.pie_fixups.append(self.bin_file.allocator, .{
-                                    .address = x,
-                                    .start = self.code.items.len,
-                                    .len = 5,
-                                });
+                                if (self.bin_file.cast(link.File.MachO)) |macho_file| {
+                                    try macho_file.pie_fixups.append(self.bin_file.allocator, .{
+                                        .address = x,
+                                        .start = self.code.items.len,
+                                        .len = 5,
+                                    });
+                                } else {
+                                    return self.fail(src, "TODO implement genSetReg for PIE on this platform", .{});
+                                }
                                 // call [label]
                                 self.code.appendSliceAssumeCapacity(&[_]u8{
                                     0xE8,

--- a/src/link.zig
+++ b/src/link.zig
@@ -263,10 +263,7 @@ pub const File = struct {
                     fs.base64_encoder.encode(&random_sub_path, &random_bytes);
                     const tmp_file_name = try mem.join(base.allocator, "_", &[_][]const u8{ emit.sub_path, random_sub_path[0..] });
                     defer base.allocator.free(tmp_file_name);
-                    var tmp_file = try emit.directory.handle.createFile(tmp_file_name, .{ .mode = determineMode(base.options) });
-                    defer tmp_file.close();
-                    const stat = try f.stat();
-                    _ = try f.copyRangeAll(0, tmp_file, 0, stat.size);
+                    try emit.directory.handle.copyFile(emit.sub_path, emit.directory.handle, tmp_file_name, .{});
                     try emit.directory.handle.rename(tmp_file_name, emit.sub_path);
                 }
                 f.close();

--- a/src/link.zig
+++ b/src/link.zig
@@ -254,17 +254,8 @@ pub const File = struct {
                     // into a new inode, remove the original file, and rename the copy to match
                     // the original file. This is super messy, but there doesn't seem any other
                     // way to please the XNU.
-                    const random_bytes_len = 12;
-                    comptime const random_sub_path_len = std.base64.Base64Encoder.calcSize(random_bytes_len);
                     const emit = base.options.emit orelse return;
-                    var random_bytes: [random_bytes_len]u8 = undefined;
-                    try std.crypto.randomBytes(&random_bytes);
-                    var random_sub_path: [random_sub_path_len]u8 = undefined;
-                    fs.base64_encoder.encode(&random_sub_path, &random_bytes);
-                    const tmp_file_name = try mem.join(base.allocator, "_", &[_][]const u8{ emit.sub_path, random_sub_path[0..] });
-                    defer base.allocator.free(tmp_file_name);
-                    try emit.directory.handle.copyFile(emit.sub_path, emit.directory.handle, tmp_file_name, .{});
-                    try emit.directory.handle.rename(tmp_file_name, emit.sub_path);
+                    try emit.directory.handle.copyFile(emit.sub_path, emit.directory.handle, emit.sub_path, .{});
                 }
                 f.close();
                 base.file = null;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1774,6 +1774,8 @@ fn writeCodeSignature(self: *MachO) !void {
 
     code_sig.write(buffer);
 
+    log.debug("writing code signature from 0x{x} to 0x{x}\n", .{ code_sig_cmd.dataoff, code_sig_cmd.dataoff + buffer.len });
+
     try self.base.file.?.pwriteAll(buffer, code_sig_cmd.dataoff);
 }
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1760,6 +1760,9 @@ fn writeAllUndefSymbols(self: *MachO) !void {
 
 fn writeCodeSignature(self: *MachO) !void {
     const code_sig_cmd = &self.load_commands.items[self.code_signature_cmd_index.?].LinkeditData;
+    // Pad out the space. We need to do this to calculate valid hashes for everything in the file
+    // except for code signature data.
+    try self.base.file.?.pwriteAll(&[_]u8{0}, code_sig_cmd.dataoff + code_sig_cmd.datasize - 1);
 
     var code_sig = CodeSignature.init(self.base.allocator);
     defer code_sig.deinit();
@@ -1772,7 +1775,6 @@ fn writeCodeSignature(self: *MachO) !void {
     code_sig.write(buffer);
 
     try self.base.file.?.pwriteAll(buffer, code_sig_cmd.dataoff);
-    try self.base.file.?.pwriteAll(&[_]u8{0}, code_sig_cmd.dataoff + code_sig_cmd.datasize - 1);
 }
 
 fn writeExportTrie(self: *MachO) !void {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1015,14 +1015,18 @@ pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {
     while (self.pie_fixups.popOrNull()) |fixup| {
         const target_addr = fixup.address;
         const this_addr = symbol.n_value + fixup.start;
-        if (self.base.options.target.cpu.arch == .x86_64) {
-            const displacement = @intCast(u32, target_addr - this_addr - fixup.len);
-            var placeholder = code_buffer.items[fixup.start + fixup.len - @sizeOf(u32) ..][0..@sizeOf(u32)];
-            mem.writeIntSliceLittle(u32, placeholder, displacement);
-        } else {
-            const displacement = @intCast(u27, target_addr - this_addr);
-            var placeholder = code_buffer.items[fixup.start..][0..fixup.len];
-            mem.writeIntSliceLittle(u32, placeholder, aarch64.Instruction.b(@intCast(i28, displacement)).toU32());
+        switch (self.base.options.target.cpu.arch) {
+            .x86_64 => {
+                const displacement = @intCast(u32, target_addr - this_addr - fixup.len);
+                var placeholder = code_buffer.items[fixup.start + fixup.len - @sizeOf(u32) ..][0..@sizeOf(u32)];
+                mem.writeIntSliceLittle(u32, placeholder, displacement);
+            },
+            .aarch64 => {
+                const displacement = @intCast(u27, target_addr - this_addr);
+                var placeholder = code_buffer.items[fixup.start..][0..fixup.len];
+                mem.writeIntSliceLittle(u32, placeholder, aarch64.Instruction.b(@intCast(i28, displacement)).toU32());
+            },
+            else => unreachable, // unsupported target architecture
         }
     }
 
@@ -1651,23 +1655,27 @@ fn writeOffsetTableEntry(self: *MachO, index: usize) !void {
     const vmaddr = sect.addr + @sizeOf(u64) * index;
 
     var code: [8]u8 = undefined;
-    if (self.base.options.target.cpu.arch == .x86_64) {
-        const pos_symbol_off = @intCast(u31, vmaddr - self.offset_table.items[index] + 7);
-        const symbol_off = @bitCast(u32, @intCast(i32, pos_symbol_off) * -1);
-        // lea %rax, [rip - disp]
-        code[0] = 0x48;
-        code[1] = 0x8D;
-        code[2] = 0x5;
-        mem.writeIntLittle(u32, code[3..7], symbol_off);
-        // ret
-        code[7] = 0xC3;
-    } else {
-        const pos_symbol_off = @intCast(u20, vmaddr - self.offset_table.items[index]);
-        const symbol_off = @intCast(i21, pos_symbol_off) * -1;
-        // adr x0, #-disp
-        mem.writeIntLittle(u32, code[0..4], aarch64.Instruction.adr(.x0, symbol_off).toU32());
-        // ret x28
-        mem.writeIntLittle(u32, code[4..8], aarch64.Instruction.ret(.x28).toU32());
+    switch (self.base.options.target.cpu.arch) {
+        .x86_64 => {
+            const pos_symbol_off = @intCast(u31, vmaddr - self.offset_table.items[index] + 7);
+            const symbol_off = @bitCast(u32, @intCast(i32, pos_symbol_off) * -1);
+            // lea %rax, [rip - disp]
+            code[0] = 0x48;
+            code[1] = 0x8D;
+            code[2] = 0x5;
+            mem.writeIntLittle(u32, code[3..7], symbol_off);
+            // ret
+            code[7] = 0xC3;
+        },
+        .aarch64 => {
+            const pos_symbol_off = @intCast(u20, vmaddr - self.offset_table.items[index]);
+            const symbol_off = @intCast(i21, pos_symbol_off) * -1;
+            // adr x0, #-disp
+            mem.writeIntLittle(u32, code[0..4], aarch64.Instruction.adr(.x0, symbol_off).toU32());
+            // ret x28
+            mem.writeIntLittle(u32, code[4..8], aarch64.Instruction.ret(.x28).toU32());
+        },
+        else => unreachable, // unsupported target architecture
     }
     log.debug("writing offset table entry 0x{x} at 0x{x}\n", .{ self.offset_table.items[index], off });
     try self.base.file.?.pwriteAll(&code, off);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1028,7 +1028,7 @@ pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {
         } else {
             const displacement = @intCast(u27, target_addr - this_addr);
             var placeholder = code_buffer.items[fixup.start..][0..fixup.len];
-            mem.writeIntSliceLittle(u32, placeholder, aarch64.Instruction.bl(@intCast(i28, displacement)).toU32());
+            mem.writeIntSliceLittle(u32, placeholder, aarch64.Instruction.b(@intCast(i28, displacement)).toU32());
         }
     }
 
@@ -1670,10 +1670,10 @@ fn writeOffsetTableEntry(self: *MachO, index: usize) !void {
     } else {
         const pos_symbol_off = @intCast(u20, vmaddr - self.offset_table.items[index]);
         const symbol_off = @intCast(i21, pos_symbol_off) * -1;
-        // adr .x0 [-disp]
-        mem.writeIntLittle(u32, code[0..4], aarch64.Instruction.adr(.x1, symbol_off).toU32());
-        // ret
-        mem.writeIntLittle(u32, code[4..8], aarch64.Instruction.ret(null).toU32());
+        // adr x0, #-disp
+        mem.writeIntLittle(u32, code[0..4], aarch64.Instruction.adr(.x0, symbol_off).toU32());
+        // ret x28
+        mem.writeIntLittle(u32, code[4..8], aarch64.Instruction.ret(.x28).toU32());
     }
     log.debug("writing offset table entry 0x{x} at 0x{x}\n", .{ self.offset_table.items[index], off });
     try self.base.file.?.pwriteAll(&code, off);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -73,6 +73,10 @@ const LoadCommand = union(enum) {
 
 base: File,
 
+/// Page size is dependent on the target cpu architecture.
+/// For x86_64 that's 4KB, whereas for aarch64, that's 16KB.
+page_size: u16,
+
 /// Table of all load commands
 load_commands: std.ArrayListUnmanaged(LoadCommand) = .{},
 /// __PAGEZERO segment
@@ -301,6 +305,7 @@ pub fn createEmpty(gpa: *Allocator, options: link.Options) !*MachO {
             .allocator = gpa,
             .file = null,
         },
+        .page_size = if (options.target.cpu.arch == .aarch64) 0x4000 else 0x1000,
     };
     return self;
 }
@@ -387,7 +392,7 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
         const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
         const file_size = symtab.stroff + symtab.strsize - linkedit.fileoff;
         linkedit.filesize = file_size;
-        linkedit.vmsize = mem.alignForwardGeneric(u64, file_size, 0x4000);
+        linkedit.vmsize = mem.alignForwardGeneric(u64, file_size, self.page_size);
     }
 
     if (self.cmd_table_dirty) {
@@ -1163,8 +1168,8 @@ pub fn populateMissingMetadata(self: *MachO) !void {
 
         // const program_code_size_hint = self.base.options.program_code_size_hint;
         const program_code_size_hint = 128;
-        const file_size = mem.alignForwardGeneric(u64, program_code_size_hint, 0x4000);
-        const off = @intCast(u32, self.findFreeSpace(file_size, 0x4000)); // TODO maybe findFreeSpace should return u32 directly?
+        const file_size = mem.alignForwardGeneric(u64, program_code_size_hint, self.page_size);
+        const off = @intCast(u32, self.findFreeSpace(file_size, self.page_size)); // TODO maybe findFreeSpace should return u32 directly?
         const flags = macho.S_REGULAR | macho.S_ATTR_PURE_INSTRUCTIONS | macho.S_ATTR_SOME_INSTRUCTIONS;
 
         log.debug("found __text section free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
@@ -1237,7 +1242,7 @@ pub fn populateMissingMetadata(self: *MachO) !void {
             .reserved3 = 0,
         });
 
-        const segment_size = mem.alignForwardGeneric(u64, file_size, 0x4000);
+        const segment_size = mem.alignForwardGeneric(u64, file_size, self.page_size);
         data_segment.vmsize = segment_size;
         data_segment.filesize = segment_size;
         data_segment.fileoff = off;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1758,7 +1758,7 @@ fn writecodeSignature(self: *MachO) !void {
     var code_sig = CodeSignature.init(self.base.allocator);
     defer code_sig.deinit();
 
-    try code_sig.calcAdhocSignature();
+    try code_sig.calcAdhocSignature(self);
 
     var buffer = try self.base.allocator.alloc(u8, code_sig.size());
     defer self.base.allocator.free(buffer);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -387,7 +387,7 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
         const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
         const file_size = symtab.stroff + symtab.strsize - linkedit.fileoff;
         linkedit.filesize = file_size;
-        linkedit.vmsize = mem.alignForwardGeneric(u64, file_size, 0x1000);
+        linkedit.vmsize = mem.alignForwardGeneric(u64, file_size, 0x4000);
     }
 
     if (self.cmd_table_dirty) {
@@ -1163,8 +1163,8 @@ pub fn populateMissingMetadata(self: *MachO) !void {
 
         // const program_code_size_hint = self.base.options.program_code_size_hint;
         const program_code_size_hint = 128;
-        const file_size = mem.alignForwardGeneric(u64, program_code_size_hint, 0x1000);
-        const off = @intCast(u32, self.findFreeSpace(file_size, 0x1000)); // TODO maybe findFreeSpace should return u32 directly?
+        const file_size = mem.alignForwardGeneric(u64, program_code_size_hint, 0x4000);
+        const off = @intCast(u32, self.findFreeSpace(file_size, 0x4000)); // TODO maybe findFreeSpace should return u32 directly?
         const flags = macho.S_REGULAR | macho.S_ATTR_PURE_INSTRUCTIONS | macho.S_ATTR_SOME_INSTRUCTIONS;
 
         log.debug("found __text section free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
@@ -1237,7 +1237,7 @@ pub fn populateMissingMetadata(self: *MachO) !void {
             .reserved3 = 0,
         });
 
-        const segment_size = mem.alignForwardGeneric(u64, file_size, 0x1000);
+        const segment_size = mem.alignForwardGeneric(u64, file_size, 0x4000);
         data_segment.vmsize = segment_size;
         data_segment.filesize = segment_size;
         data_segment.fileoff = off;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -956,8 +956,7 @@ pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {
         },
     };
 
-    // const required_alignment = typed_value.ty.abiAlignment(self.base.options.target);
-    const required_alignment = 4;
+    const required_alignment = typed_value.ty.abiAlignment(self.base.options.target);
     assert(decl.link.macho.local_sym_index != 0); // Caller forgot to call allocateDeclIndexes()
     const symbol = &self.local_symbols.items[decl.link.macho.local_sym_index];
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -322,32 +322,14 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
-    // Unfortunately these have to be buffered and done at the end because MachO does not allow
-    // mixing local, global and undefined symbols within a symbol table.
-    try self.writeAllGlobalSymbols();
-    try self.writeAllUndefSymbols();
 
     switch (self.base.options.output_mode) {
         .Exe => {
-            // Write export trie.
-            try self.writeExportTrie();
             if (self.entry_addr) |addr| {
                 // Update LC_MAIN with entry offset.
                 const text_segment = self.load_commands.items[self.text_segment_cmd_index.?].Segment;
                 const main_cmd = &self.load_commands.items[self.main_cmd_index.?].EntryPoint;
                 main_cmd.entryoff = addr - text_segment.vmaddr;
-            }
-            {
-                // Update dynamic symbol table.
-                const nlocals = @intCast(u32, self.local_symbols.items.len);
-                const nglobals = @intCast(u32, self.global_symbols.items.len);
-                const nundefs = @intCast(u32, self.undef_symbols.items.len);
-                const dysymtab = &self.load_commands.items[self.dysymtab_cmd_index.?].Dysymtab;
-                dysymtab.nlocalsym = nlocals;
-                dysymtab.iextdefsym = nlocals;
-                dysymtab.nextdefsym = nglobals;
-                dysymtab.iundefsym = nlocals + nglobals;
-                dysymtab.nundefsym = nundefs;
             }
             if (self.dylinker_cmd_dirty) {
                 // Write path to dyld loader.
@@ -375,26 +357,33 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
                 try self.base.file.?.pwriteAll(mem.spanZ(LIB_SYSTEM_PATH), off);
                 self.libsystem_cmd_dirty = false;
             }
+        
+            // Write export trie.
+            try self.writeExportTrie();
+            const linkedit = &self.load_commands.items[self.linkedit_segment_cmd_index.?].Segment;
+            const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
+            const dyld_info = &self.load_commands.items[self.dyld_info_cmd_index.?].DyldInfo;
+            linkedit.fileoff = dyld_info.export_off;
+            symtab.symoff = dyld_info.export_off + dyld_info.export_size;
         },
         .Obj => {},
         .Lib => return error.TODOImplementWritingLibFiles,
     }
 
-    {
-        // Update symbol table.
-        const nlocals = @intCast(u32, self.local_symbols.items.len);
-        const nglobals = @intCast(u32, self.global_symbols.items.len);
-        const nundefs = @intCast(u32, self.undef_symbols.items.len);
-        const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
-        symtab.nsyms = nlocals + nglobals + nundefs;
-        symtab.stroff = symtab.symoff + symtab.nsyms * @sizeOf(macho.nlist_64);
-
-        // Extend dynamic linker info until start of symbol table
-        const dyld_info = &self.load_commands.items[self.dyld_info_cmd_index.?].DyldInfo;
-        dyld_info.export_size = symtab.symoff - dyld_info.export_off;
-    }
-
+    // Unfortunately these have to be buffered and done at the end because MachO does not allow
+    // mixing local, global and undefined symbols within a symbol table.
+    try self.writeSymbolTable();
     try self.writeStringTable();
+
+    {
+        // TODO rework how we preallocate space for the entire __LINKEDIT segment instead of
+        // doing dynamic updates like this.
+        const linkedit = &self.load_commands.items[self.linkedit_segment_cmd_index.?].Segment;
+        const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
+        const file_size = symtab.stroff + symtab.strsize - linkedit.fileoff;
+        linkedit.filesize = file_size;
+        linkedit.vmsize = mem.alignForwardGeneric(u64, file_size, 0x1000);
+    }
 
     if (self.cmd_table_dirty) {
         try self.writeCmdHeaders();
@@ -984,7 +973,7 @@ pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {
         symbol.n_sect = @intCast(u8, self.text_section_index.?) + 1;
         symbol.n_desc = 0;
         // TODO this write could be avoided if no fields of the symbol were changed.
-        try self.writeSymbol(decl.link.macho.local_sym_index);
+        // try self.writeSymbol(decl.link.macho.local_sym_index);
     } else {
         const decl_name = mem.spanZ(decl.name);
         const name_str_index = try self.makeString(decl_name);
@@ -1001,7 +990,7 @@ pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {
         };
         self.offset_table.items[decl.link.macho.offset_table_index] = addr;
 
-        try self.writeSymbol(decl.link.macho.local_sym_index);
+        // try self.writeSymbol(decl.link.macho.local_sym_index);
         try self.writeOffsetTableEntry(decl.link.macho.offset_table_index);
     }
 
@@ -1399,48 +1388,6 @@ pub fn populateMissingMetadata(self: *MachO) !void {
             },
         });
     }
-    {
-        const linkedit = &self.load_commands.items[self.linkedit_segment_cmd_index.?].Segment;
-        const dyld_info = &self.load_commands.items[self.dyld_info_cmd_index.?].DyldInfo;
-        if (dyld_info.export_off == 0) {
-            const nsyms = self.base.options.symbol_count_hint;
-            const file_size = @sizeOf(u64) * nsyms;
-            const off = @intCast(u32, self.findFreeSpace(file_size, 0x1000));
-            log.debug("found export trie free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
-            dyld_info.export_off = off;
-            dyld_info.export_size = @intCast(u32, file_size);
-
-            const segment_size = mem.alignForwardGeneric(u64, file_size, 0x1000);
-            linkedit.vmsize += segment_size;
-            linkedit.fileoff = off;
-        }
-    }
-    {
-        const linkedit = &self.load_commands.items[self.linkedit_segment_cmd_index.?].Segment;
-        const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
-        if (symtab.symoff == 0) {
-            const nsyms = self.base.options.symbol_count_hint;
-            const file_size = @sizeOf(macho.nlist_64) * nsyms;
-            const off = @intCast(u32, self.findFreeSpace(file_size, 0x1000));
-            log.debug("found symbol table free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
-            symtab.symoff = off;
-            symtab.nsyms = @intCast(u32, nsyms);
-
-            const segment_size = mem.alignForwardGeneric(u64, file_size, 0x1000);
-            linkedit.vmsize += segment_size;
-        }
-        if (symtab.stroff == 0) {
-            try self.string_table.append(self.base.allocator, 0);
-            const file_size = @intCast(u32, self.string_table.items.len);
-            const off = @intCast(u32, self.findFreeSpace(file_size, 0x1000));
-            log.debug("found string table free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
-            symtab.stroff = off;
-            symtab.strsize = file_size;
-
-            const segment_size = mem.alignForwardGeneric(u64, file_size, 0x1000);
-            linkedit.vmsize += segment_size;
-        }
-    }
     if (self.dyld_stub_binder_index == null) {
         self.dyld_stub_binder_index = @intCast(u16, self.undef_symbols.items.len);
         const name = try self.makeString("dyld_stub_binder");
@@ -1687,6 +1634,53 @@ fn writeOffsetTableEntry(self: *MachO, index: usize) !void {
     try self.base.file.?.pwriteAll(&buf, off);
 }
 
+fn writeSymbolTable(self: *MachO) !void {
+    const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
+    const locals_off = symtab.symoff;
+    
+    var locals = try self.base.allocator.alloc(macho.nlist_64, self.local_symbols.items.len - 1);
+    defer self.base.allocator.free(locals);
+
+    for (locals) |*sym, i| {
+        sym.* = .{
+            .n_strx = self.local_symbols.items[i + 1].n_strx,
+            .n_type = self.local_symbols.items[i + 1].n_type,
+            .n_sect = self.local_symbols.items[i + 1].n_sect,
+            .n_desc = self.local_symbols.items[i + 1].n_desc,
+            .n_value = self.local_symbols.items[i + 1].n_value,
+        };
+    }
+
+    const locals_size = locals.len * @sizeOf(macho.nlist_64);
+    log.debug("writing local symbols from 0x{x} to 0x{x}\n", .{ locals_off, locals_size + locals_off });
+    try self.base.file.?.pwriteAll(mem.sliceAsBytes(locals), locals_off);
+
+    const globals_off = locals_off + locals_size;
+    const globals_size = self.global_symbols.items.len * @sizeOf(macho.nlist_64);
+    log.debug("writing global symbols from 0x{x} to 0x{x}\n", .{ globals_off, globals_size + globals_off });
+    try self.base.file.?.pwriteAll(mem.sliceAsBytes(self.global_symbols.items), globals_off);
+
+    const undefs_off = globals_off + globals_size;
+    const undefs_size = self.undef_symbols.items.len * @sizeOf(macho.nlist_64);
+    log.debug("writing undef symbols from 0x{x} to 0x{x}\n", .{ undefs_off, undefs_size + undefs_off });
+    try self.base.file.?.pwriteAll(mem.sliceAsBytes(self.undef_symbols.items), undefs_off);
+
+    // Update symbol table.
+    const nlocals = @intCast(u32, locals.len);
+    const nglobals = @intCast(u32, self.global_symbols.items.len);
+    const nundefs = @intCast(u32, self.undef_symbols.items.len);
+    symtab.nsyms = nlocals + nglobals + nundefs;
+    symtab.stroff = symtab.symoff + symtab.nsyms * @sizeOf(macho.nlist_64);
+
+    // Update dynamic symbol table.
+    const dysymtab = &self.load_commands.items[self.dysymtab_cmd_index.?].Dysymtab;
+    dysymtab.nlocalsym = nlocals;
+    dysymtab.iextdefsym = nlocals;
+    dysymtab.nextdefsym = nglobals;
+    dysymtab.iundefsym = nlocals + nglobals;
+    dysymtab.nundefsym = nundefs;
+}
+
 fn writeAllGlobalSymbols(self: *MachO) !void {
     const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
     const off = symtab.symoff + self.local_symbols.items.len * @sizeOf(macho.nlist_64);
@@ -1728,29 +1722,26 @@ fn writeExportTrie(self: *MachO) !void {
 
     try trie.writeULEB128Mem(self.base.allocator, &buffer);
 
+    const data = &self.load_commands.items[self.data_segment_cmd_index.?].Segment;
     const dyld_info = &self.load_commands.items[self.dyld_info_cmd_index.?].DyldInfo;
+    dyld_info.export_off = @intCast(u32, data.fileoff + data.filesize);
+    dyld_info.export_size = mem.alignForwardGeneric(u32, @intCast(u32, buffer.items.len), @sizeOf(u64));
     try self.base.file.?.pwriteAll(buffer.items, dyld_info.export_off);
 }
 
 fn writeStringTable(self: *MachO) !void {
     const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
-    const allocated_size = self.allocatedSize(symtab.stroff);
+    // const allocated_size = self.allocatedSize(symtab.stroff);
     const needed_size = self.string_table.items.len;
 
-    if (needed_size > allocated_size) {
-        symtab.strsize = 0;
-        symtab.stroff = @intCast(u32, self.findFreeSpace(needed_size, 1));
-    }
-    symtab.strsize = @intCast(u32, needed_size);
-
-    log.debug("writing string table from 0x{x} to 0x{x}\n", .{ symtab.stroff, symtab.stroff + symtab.strsize });
-
+    // if (needed_size > allocated_size) {
+    //     symtab.strsize = 0;
+    //     symtab.stroff = @intCast(u32, self.findFreeSpace(needed_size, 1));
+    // }
+    symtab.strsize = mem.alignForwardGeneric(u32, @intCast(u32, needed_size), @sizeOf(u64));
+    try self.base.file.?.pwriteAll(&[_]u8{ 0 }, symtab.stroff + symtab.strsize - 1);
+    log.debug("writing string table from 0x{x} to 0x{x}\n", .{ symtab.stroff, symtab.stroff + needed_size });
     try self.base.file.?.pwriteAll(self.string_table.items, symtab.stroff);
-
-    // TODO rework how we preallocate space for the entire __LINKEDIT segment instead of
-    // doing dynamic updates like this.
-    const linkedit = &self.load_commands.items[self.linkedit_segment_cmd_index.?].Segment;
-    linkedit.filesize = symtab.stroff + symtab.strsize - linkedit.fileoff;
 }
 
 fn writeCmdHeaders(self: *MachO) !void {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1142,7 +1142,8 @@ pub fn populateMissingMetadata(self: *MachO) !void {
     }
     if (self.text_segment_cmd_index == null) {
         self.text_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
-        const prot = macho.VM_PROT_READ | macho.VM_PROT_EXECUTE;
+        const maxprot = macho.VM_PROT_READ | macho.VM_PROT_WRITE | macho.VM_PROT_EXECUTE;
+        const initprot = macho.VM_PROT_READ | macho.VM_PROT_EXECUTE;
         try self.load_commands.append(self.base.allocator, .{
             .Segment = .{
                 .cmd = macho.LC_SEGMENT_64,
@@ -1152,8 +1153,8 @@ pub fn populateMissingMetadata(self: *MachO) !void {
                 .vmsize = 0,
                 .fileoff = 0,
                 .filesize = 0,
-                .maxprot = prot,
-                .initprot = prot,
+                .maxprot = maxprot,
+                .initprot = initprot,
                 .nsects = 0,
                 .flags = 0,
             },
@@ -1194,7 +1195,8 @@ pub fn populateMissingMetadata(self: *MachO) !void {
     if (self.data_segment_cmd_index == null) {
         self.data_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
         const text_segment = &self.load_commands.items[self.text_segment_cmd_index.?].Segment;
-        const prot = macho.VM_PROT_READ | macho.VM_PROT_WRITE;
+        const maxprot = macho.VM_PROT_READ | macho.VM_PROT_WRITE | macho.VM_PROT_EXECUTE;
+        const initprot = macho.VM_PROT_READ | macho.VM_PROT_WRITE;
         try self.load_commands.append(self.base.allocator, .{
             .Segment = .{
                 .cmd = macho.LC_SEGMENT_64,
@@ -1204,8 +1206,8 @@ pub fn populateMissingMetadata(self: *MachO) !void {
                 .vmsize = 0,
                 .fileoff = 0,
                 .filesize = 0,
-                .maxprot = prot,
-                .initprot = prot,
+                .maxprot = maxprot,
+                .initprot = initprot,
                 .nsects = 0,
                 .flags = 0,
             },

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -21,6 +21,7 @@ const Cache = @import("../Cache.zig");
 const target_util = @import("../target.zig");
 
 const Trie = @import("MachO/Trie.zig");
+const CodeSignature = @import("MachO/CodeSignature.zig");
 
 pub const base_tag: File.Tag = File.Tag.macho;
 
@@ -385,7 +386,7 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
                 self.libsystem_cmd_dirty = false;
             }
 
-            try self.codeSign();
+            try self.writecodeSignature();
         },
         .Obj => {},
         .Lib => return error.TODOImplementWritingLibFiles,
@@ -1751,60 +1752,20 @@ fn writeAllUndefSymbols(self: *MachO) !void {
     try self.base.file.?.pwriteAll(mem.sliceAsBytes(self.undef_symbols.items), off);
 }
 
-fn codeSign(self: *MachO) !void {
+fn writecodeSignature(self: *MachO) !void {
     const code_sig_cmd = &self.load_commands.items[self.code_signature_cmd_index.?].LinkeditData;
-    // TODO add actual code signing mechanism
-    var buffer: std.ArrayListUnmanaged(u8) = .{};
-    defer buffer.deinit(self.base.allocator);
-    // var super_blob = macho.SuperBlob{
-    //     .magic = macho.CSMAGIC_EMBEDDED_SIGNATURE,
-    //     .length = 0,
-    //     .count = 2,
-    // };
-    const length: u32 = @sizeOf(u32) * 12;
-    try buffer.ensureCapacity(self.base.allocator, length);
-    var buf: [@sizeOf(u32)]u8 = undefined;
-    mem.writeIntBig(u32, &buf, macho.CSMAGIC_EMBEDDED_SIGNATURE);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    mem.writeIntBig(u32, &buf, length);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    mem.writeIntBig(u32, &buf, 2);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    // macho.BlobIndex{
-    //     .type = macho.CSSLOT_REQUIREMENTS,
-    //     .offset = offset,
-    // };
-    mem.writeIntBig(u32, &buf, macho.CSSLOT_REQUIREMENTS);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    mem.writeIntBig(u32, &buf, 28);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    // macho.BlobIndex{
-    //     .type = macho.CSSLOT_SIGNATURESLOT,
-    //     .offset = offset,
-    // };
-    mem.writeIntBig(u32, &buf, macho.CSSLOT_SIGNATURESLOT);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    mem.writeIntBig(u32, &buf, 40);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    // const requirements_blob = macho.GenericBlob{
-    //     .magic = macho.CSMAGIC_REQUIREMENTS,
-    //     .length = 0,
-    // };
-    mem.writeIntBig(u32, &buf, macho.CSMAGIC_REQUIREMENTS);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    mem.writeIntBig(u32, &buf, @sizeOf(u32) * 3);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    mem.writeIntBig(u32, &buf, 0);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    // const signature_blob = macho.GenericBlob{
-    //     .magic = macho.CSSLOT_SIGNATURESLOT,
-    //     .length = 0,
-    // };
-    mem.writeIntBig(u32, &buf, macho.CSMAGIC_BLOBWRAPPER);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    mem.writeIntBig(u32, &buf, @sizeOf(u32) * 2);
-    buffer.appendSliceAssumeCapacity(buf[0..]);
-    try self.base.file.?.pwriteAll(buffer.items[0..], code_sig_cmd.dataoff);
+
+    var code_sig = CodeSignature.init(self.base.allocator);
+    defer code_sig.deinit();
+
+    try code_sig.calcAdhocSignature();
+
+    var buffer = try self.base.allocator.alloc(u8, code_sig.size());
+    defer self.base.allocator.free(buffer);
+
+    code_sig.write(buffer);
+
+    try self.base.file.?.pwriteAll(buffer, code_sig_cmd.dataoff);
     try self.base.file.?.pwriteAll(&[_]u8{ 0 }, code_sig_cmd.dataoff + code_sig_cmd.datasize - 1);
 }
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1161,7 +1161,9 @@ pub fn populateMissingMetadata(self: *MachO) !void {
         text_segment.cmdsize += @sizeOf(macho.section_64);
         text_segment.nsects += 1;
 
-        const file_size = mem.alignForwardGeneric(u64, self.base.options.program_code_size_hint, 0x1000);
+        // const program_code_size_hint = self.base.options.program_code_size_hint;
+        const program_code_size_hint = 128;
+        const file_size = mem.alignForwardGeneric(u64, program_code_size_hint, 0x1000);
         const off = @intCast(u32, self.findFreeSpace(file_size, 0x1000)); // TODO maybe findFreeSpace should return u32 directly?
         const flags = macho.S_REGULAR | macho.S_ATTR_PURE_INSTRUCTIONS | macho.S_ATTR_SOME_INSTRUCTIONS;
 

--- a/src/link/MachO/CodeSignature.zig
+++ b/src/link/MachO/CodeSignature.zig
@@ -1,0 +1,59 @@
+const CodeSignature = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const log = std.log.scoped(.link);
+const macho = std.macho;
+const mem = std.mem;
+const testing = std.testing;
+const Allocator = mem.Allocator;
+
+// pub const Blob = union(enum) {
+//     Signature: struct{
+//         inner:
+//     }
+// };
+
+alloc: *Allocator,
+inner: macho.SuperBlob = .{
+    .magic = macho.CSMAGIC_EMBEDDED_SIGNATURE,
+    .length = @sizeOf(macho.SuperBlob),
+    .count = 0,
+},
+// blobs: std.ArrayList(Blob),
+
+pub fn init(alloc: *Allocator) CodeSignature {
+    return .{
+        .alloc = alloc,
+        // .indices = std.ArrayList(Blob).init(alloc),
+    };
+}
+
+pub fn calcAdhocSignature(self: *CodeSignature) !void {}
+
+pub fn size(self: CodeSignature) u32 {
+    return self.inner.length;
+}
+
+pub fn write(self: CodeSignature, buffer: []u8) void {
+    assert(buffer.len >= self.inner.length);
+    self.writeHeader(buffer);
+}
+
+pub fn deinit(self: *CodeSignature) void {}
+
+fn writeHeader(self: CodeSignature, buffer: []u8) void {
+    assert(buffer.len >= @sizeOf(macho.SuperBlob));
+    mem.writeIntBig(u32, buffer[0..4], self.inner.magic);
+    mem.writeIntBig(u32, buffer[4..8], self.inner.length);
+    mem.writeIntBig(u32, buffer[8..12], self.inner.count);
+}
+
+test "CodeSignature header" {
+    var code_sig = CodeSignature.init(testing.allocator);
+    defer code_sig.deinit();
+    var buffer: [@sizeOf(macho.SuperBlob)]u8 = undefined;
+    code_sig.writeHeader(buffer[0..]);
+    const expected = &[_]u8{ 0xfa, 0xde, 0x0c, 0xc0, 0x0, 0x0, 0x0, 0xc, 0x0, 0x0, 0x0, 0x0 };
+    testing.expect(mem.eql(u8, expected[0..], buffer[0..]));
+}

--- a/src/link/MachO/CodeSignature.zig
+++ b/src/link/MachO/CodeSignature.zig
@@ -8,11 +8,39 @@ const mem = std.mem;
 const testing = std.testing;
 const Allocator = mem.Allocator;
 
-// pub const Blob = union(enum) {
-//     Signature: struct{
-//         inner:
-//     }
-// };
+const Blob = struct {
+    inner: macho.CodeDirectory,
+    data: std.ArrayListUnmanaged(u8) = .{},
+
+    fn size(self: Blob) u32 {
+        return self.inner.length;
+    }
+
+    fn write(self: Blob, buffer: []u8) void {
+        assert(buffer.len >= self.inner.length);
+        mem.writeIntBig(u32, buffer[0..4], self.inner.magic);
+        mem.writeIntBig(u32, buffer[4..8], self.inner.length);
+        mem.writeIntBig(u32, buffer[8..12], self.inner.version);
+        mem.writeIntBig(u32, buffer[12..16], self.inner.flags);
+        mem.writeIntBig(u32, buffer[16..20], self.inner.hashOffset);
+        mem.writeIntBig(u32, buffer[20..24], self.inner.identOffset);
+        mem.writeIntBig(u32, buffer[24..28], self.inner.nSpecialSlots);
+        mem.writeIntBig(u32, buffer[28..32], self.inner.nCodeSlots);
+        mem.writeIntBig(u32, buffer[32..36], self.inner.codeLimit);
+        mem.writeIntBig(u8, buffer[36..37], self.inner.hashSize);
+        mem.writeIntBig(u8, buffer[37..38], self.inner.hashType);
+        mem.writeIntBig(u8, buffer[38..39], self.inner.platform);
+        mem.writeIntBig(u8, buffer[39..40], self.inner.pageSize);
+        mem.writeIntBig(u32, buffer[40..44], self.inner.spare2);
+        mem.writeIntBig(u32, buffer[44..48], self.inner.scatterOffset);
+        mem.writeIntBig(u32, buffer[48..52], self.inner.teamOffset);
+        mem.writeIntBig(u32, buffer[52..56], self.inner.spare3);
+        mem.writeIntBig(u64, buffer[56..64], self.inner.codeLimit64);
+        mem.writeIntBig(u64, buffer[64..72], self.inner.execSegBase);
+        mem.writeIntBig(u64, buffer[72..80], self.inner.execSegLimit);
+        mem.writeIntBig(u64, buffer[80..88], self.inner.execSegFlags);
+    }
+};
 
 alloc: *Allocator,
 inner: macho.SuperBlob = .{
@@ -20,16 +48,44 @@ inner: macho.SuperBlob = .{
     .length = @sizeOf(macho.SuperBlob),
     .count = 0,
 },
-// blobs: std.ArrayList(Blob),
+blob: ?Blob = null,
 
 pub fn init(alloc: *Allocator) CodeSignature {
     return .{
         .alloc = alloc,
-        // .indices = std.ArrayList(Blob).init(alloc),
     };
 }
 
-pub fn calcAdhocSignature(self: *CodeSignature) !void {}
+pub fn calcAdhocSignature(self: *CodeSignature) !void {
+    var blob = Blob{
+        .inner = .{
+            .magic = macho.CSMAGIC_CODEDIRECTORY,
+            .length = @sizeOf(macho.CodeDirectory),
+            .version = 0x20400,
+            .flags = 0,
+            .hashOffset = 0,
+            .identOffset = 0,
+            .nSpecialSlots = 0,
+            .nCodeSlots = 0,
+            .codeLimit = 0,
+            .hashSize = 0,
+            .hashType = 0,
+            .platform = 0,
+            .pageSize = 0,
+            .spare2 = 0,
+            .scatterOffset = 0,
+            .teamOffset = 0,
+            .spare3 = 0,
+            .codeLimit64 = 0,
+            .execSegBase = 0,
+            .execSegLimit = 0,
+            .execSegFlags = 0,
+        },
+    };
+    self.inner.length += @sizeOf(macho.BlobIndex) + blob.size();
+    self.inner.count = 1;
+    self.blob = blob;
+}
 
 pub fn size(self: CodeSignature) u32 {
     return self.inner.length;
@@ -38,9 +94,16 @@ pub fn size(self: CodeSignature) u32 {
 pub fn write(self: CodeSignature, buffer: []u8) void {
     assert(buffer.len >= self.inner.length);
     self.writeHeader(buffer);
+    const offset: u32 = @sizeOf(macho.SuperBlob) + @sizeOf(macho.BlobIndex);
+    writeBlobIndex(macho.CSSLOT_CODEDIRECTORY, offset, buffer[@sizeOf(macho.SuperBlob)..]);
+    self.blob.?.write(buffer[offset..]);
 }
 
-pub fn deinit(self: *CodeSignature) void {}
+pub fn deinit(self: *CodeSignature) void {
+    if (self.blob) |*b| {
+        b.data.deinit(self.alloc);
+    }
+}
 
 fn writeHeader(self: CodeSignature, buffer: []u8) void {
     assert(buffer.len >= @sizeOf(macho.SuperBlob));
@@ -49,11 +112,19 @@ fn writeHeader(self: CodeSignature, buffer: []u8) void {
     mem.writeIntBig(u32, buffer[8..12], self.inner.count);
 }
 
+fn writeBlobIndex(tt: u32, offset: u32, buffer: []u8) void {
+    assert(buffer.len >= @sizeOf(macho.BlobIndex));
+    mem.writeIntBig(u32, buffer[0..4], tt);
+    mem.writeIntBig(u32, buffer[4..8], offset);
+}
+
 test "CodeSignature header" {
     var code_sig = CodeSignature.init(testing.allocator);
     defer code_sig.deinit();
+
     var buffer: [@sizeOf(macho.SuperBlob)]u8 = undefined;
     code_sig.writeHeader(buffer[0..]);
+
     const expected = &[_]u8{ 0xfa, 0xde, 0x0c, 0xc0, 0x0, 0x0, 0x0, 0xc, 0x0, 0x0, 0x0, 0x0 };
     testing.expect(mem.eql(u8, expected[0..], buffer[0..]));
 }

--- a/src/link/MachO/CodeSignature.zig
+++ b/src/link/MachO/CodeSignature.zig
@@ -67,8 +67,6 @@ pub fn init(alloc: *Allocator) CodeSignature {
 
 pub fn calcAdhocSignature(self: *CodeSignature, bin_file: *const MachO) !void {
     const text_segment = bin_file.load_commands.items[bin_file.text_segment_cmd_index.?].Segment;
-    const data_segment = bin_file.load_commands.items[bin_file.data_segment_cmd_index.?].Segment;
-    const linkedit_segment = bin_file.load_commands.items[bin_file.linkedit_segment_cmd_index.?].Segment;
     const code_sig_cmd = bin_file.load_commands.items[bin_file.code_signature_cmd_index.?].LinkeditData;
 
     const execSegBase: u64 = text_segment.fileoff;

--- a/src/link/MachO/CodeSignature.zig
+++ b/src/link/MachO/CodeSignature.zig
@@ -102,7 +102,6 @@ pub fn calcAdhocSignature(self: *CodeSignature, bin_file: *const MachO) !void {
     };
 
     const total_pages = mem.alignForward(file_size, page_size) / page_size;
-    log.debug("Total file size: {}; total number of pages: {}\n", .{ file_size, total_pages });
 
     var hash: [hash_size]u8 = undefined;
     var buffer = try bin_file.base.allocator.alloc(u8, page_size);
@@ -129,7 +128,6 @@ pub fn calcAdhocSignature(self: *CodeSignature, bin_file: *const MachO) !void {
         assert(fsize <= len);
 
         Sha256.hash(buffer[0..fsize], &hash, .{});
-        log.debug("Calculated hash for page 0x{x}-0x{x}: 0x{x}\n", .{ fstart, fstart + fsize, hash[0..] });
 
         cdir.data.appendSliceAssumeCapacity(hash[0..]);
         cdir.inner.nCodeSlots += 1;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1727,6 +1727,9 @@ fn buildOutputType(
         error.SemanticAnalyzeFail => process.exit(1),
         else => |e| return e,
     };
+    if (output_mode == .Exe) {
+        try comp.makeBinFileExecutable();
+    }
 
     if (build_options.is_stage1 and comp.stage1_lock != null and watch) {
         warn("--watch is not recommended with the stage1 backend; it leaks memory and is not capable of incremental compilation", .{});

--- a/test/stage2/aarch64.zig
+++ b/test/stage2/aarch64.zig
@@ -12,9 +12,7 @@ const linux_aarch64 = std.zig.CrossTarget{
 };
 
 pub fn addCases(ctx: *TestContext) !void {
-    // TODO enable when we add codesigning to the self-hosted linker
-    // related to #6971
-    if (false) {
+    {
         var case = ctx.exe("hello world with updates", macos_aarch64);
 
         // Regular old hello world


### PR DESCRIPTION
Closes #7103 

First of, apologies for the size of the PR, but this is the minimal set of changes to stage2 which ensure that we can generate a valid MachO binary on Apple Silicon. To summarise, here are the main changes this PR brings to the table:

* It adds adhoc code signing machinery which is now part of the self-hosted toolchain. The machinery resides in `std/link/MachO/CodeSignature.zig` as it seemed natural to make it part of the MachO linker only.
* It ditches the use of absolute addressing in favour of RIP-relative on `x86_64` and PC-relative on `aarch64`. This in turn made it possible to rework the global offset table so that it's PIE compatible. I should probably add here that now, the global offset table is now more like a jump table, than a table of addresses. It stores small snippets of code which make it possible to compute the relative address to the symbol we'd like to call/load into a register.
* When targeting `aarch64` *from* `aarch64` macOS, the toolchain now performs a full artefact copy into a temporary filename, and then a rename back into the emitted binary. This is required to make incremental linking work with the latest constraints of the XNU kernel on Apple Silicon. For those lacking context, the latest kernel is actively caching run binaries and any change to the binary/inode that was already cached by the kernel ends up in an immediate SIGKILL. So copy-rename dance is the way to circumvent this.
* Bonus: stage2 tests targeting `aarch64-macos-gnu` are now enabled and are passing!

Of course, this PR is just the first small step towards the self-hosted on Intel and Apple Silicon Macs, so naturally many bits in the linker and codegen are in dire need to be rewritten and cleaned up. For example, handling segments and their sizes in MachO. One thing I've made sure here was that the Macs native code signing tools can be used to sign the binaries generated by the self-hosted. For this reason, currently the `__LINKEDIT` segment has to be rewritten (and compressed) at every incremental linker run. I think this is a small price to pay that should repay us handsomely in the future for ensuring a full compatibility with `codesign` tool, etc. Another thing that needs some rethinking is the assembly generated to facilitate PIE relative jumps and fixups in the codegen. But as I said, one thing a time. For the moment, let us enjoy the fact that we can now play with stage2 to generate valid MachO binaries on Apple Silicon with full incremental linking support.