### PR TITLE
stage1: Fix crash in *[N]T to []T conversion with zst

### DIFF
--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -3343,7 +3343,7 @@ static LLVMValueRef ir_render_ptr_of_array_to_slice(CodeGen *g, IrExecutableGen 
         LLVMValueRef expr_val = ir_llvm_value(g, instruction->operand);
         LLVMValueRef slice_start_ptr = LLVMBuildInBoundsGEP(g->builder, expr_val, indices, 2, "");
         gen_store_untyped(g, slice_start_ptr, ptr_field_ptr, 0, false);
-    } else if (ir_want_runtime_safety(g, &instruction->base)) {
+    } else if (ir_want_runtime_safety(g, &instruction->base) && ptr_index != SIZE_MAX) {
         LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, result_loc, ptr_index, "");
         gen_undef_init(g, slice_ptr_type, slice_ptr_type, ptr_field_ptr);
     }

--- a/test/stage1/behavior/cast.zig
+++ b/test/stage1/behavior/cast.zig
@@ -908,3 +908,9 @@ test "cast from ?[*]T to ??[*]T" {
     const a: ??[*]u8 = @as(?[*]u8, null);
     expect(a != null and a.? == null);
 }
+
+test "cast between *[N]void and []void" {
+    var a: [4]void = undefined;
+    var b: []void = &a;
+    expect(b.len == 4);
+}


### PR DESCRIPTION
Prevent the crash by not making the codegen try to access the
non-existing ptr field in the slice.

Closes #6951