### PR TITLE
Add "long double" mapping and implement fork() on Linux/sparc64

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -112,7 +112,9 @@ pub fn execve(path: [*:0]const u8, argv: [*:null]const ?[*:0]const u8, envp: [*:
 }
 
 pub fn fork() usize {
-    if (@hasField(SYS, "fork")) {
+    if (comptime builtin.arch.isSPARC()) {
+        return syscall_fork();
+    } else if (@hasField(SYS, "fork")) {
         return syscall0(.fork);
     } else {
         return syscall2(.clone, SIGCHLD, 0);

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -22,6 +22,11 @@ pub fn syscall_pipe(fd: *[2]i32) usize {
 }
 
 pub fn syscall_fork() usize {
+    // Linux/sparc64 fork() returns two values in %o0 and %o1:
+    // - On the parent's side, %o0 is the child's PID and %o1 is 0.
+    // - On the child's side, %o0 is the parent's PID and %o1 is 1.
+    // We need to clear the child's %o0 so that the return values
+    // conform to the libc convention.
     return asm volatile (
         \\ t 0x6d
         \\ bcc,pt %%xcc, 1f
@@ -29,6 +34,7 @@ pub fn syscall_fork() usize {
         \\ ba 2f
         \\ neg %%o0
         \\ 1:
+        \\ # Clear the child's %%o0
         \\ dec %%o1
         \\ and %%o1, %%o0, %%o0
         \\ 2:

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -21,6 +21,23 @@ pub fn syscall_pipe(fd: *[2]i32) usize {
     );
 }
 
+pub fn syscall_fork() usize {
+    return asm volatile (
+        \\ t 0x6d
+        \\ bcc,pt %%xcc, 1f
+        \\ nop
+        \\ ba 2f
+        \\ neg %%o0
+        \\ 1:
+        \\ dec %%o1
+        \\ and %%o1, %%o0, %%o0
+        \\ 2:
+        : [ret] "={o0}" (-> usize)
+        : [number] "{g1}" (@enumToInt(SYS.fork))
+        : "memory", "xcc", "o1", "o2", "o3", "o4", "o5", "o7"
+    );
+}
+
 pub fn syscall0(number: SYS) usize {
     return asm volatile (
         \\ t 0x6d

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -8640,6 +8640,9 @@ static void define_builtin_types(CodeGen *g) {
         case ZigLLVM_ppc64le:
             add_fp_entry(g, "c_longdouble", 128, LLVMFP128Type(), &g->builtin_types.entry_c_longdouble);
             break;
+        case ZigLLVM_sparcv9:
+            add_fp_entry(g, "c_longdouble", 128, LLVMFP128Type(), &g->builtin_types.entry_c_longdouble);
+            break;
         case ZigLLVM_avr:
             // It's either a float or a double, depending on a toolchain switch
             add_fp_entry(g, "c_longdouble", 64, LLVMDoubleType(), &g->builtin_types.entry_c_longdouble);


### PR DESCRIPTION
Add long double mapping and implement fork() for Linux/sparc64.
With this, now the test suite manages to build and run (though there's still a lot of failing tests).