### PR TITLE
[incomplete] Remove Zero-Sized Pointers (now all pointers hold addresses)

### DIFF
--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -610,16 +610,9 @@ ZigType *get_pointer_to_type_extra2(CodeGen *g, ZigType *child_type, bool is_con
         entry->size_in_bits = SIZE_MAX;
         entry->abi_align = UINT32_MAX;
     } else if (type_is_resolved(child_type, ResolveStatusZeroBitsKnown)) {
-        if (type_has_bits(g, child_type)) {
-            entry->abi_size = g->builtin_types.entry_usize->abi_size;
-            entry->size_in_bits = g->builtin_types.entry_usize->size_in_bits;
-            entry->abi_align = g->builtin_types.entry_usize->abi_align;
-        } else {
-            assert(byte_alignment == 0);
-            entry->abi_size = 0;
-            entry->size_in_bits = 0;
-            entry->abi_align = 0;
-        }
+        entry->abi_size = g->builtin_types.entry_usize->abi_size;
+        entry->size_in_bits = g->builtin_types.entry_usize->size_in_bits;
+        entry->abi_align = g->builtin_types.entry_usize->abi_align;
     } else {
         entry->abi_size = SIZE_MAX;
         entry->size_in_bits = SIZE_MAX;
@@ -6932,7 +6925,6 @@ static Error resolve_pointer_zero_bits(CodeGen *g, ZigType *ty) {
     }
     ty->data.pointer.resolve_loop_flag_zero_bits = true;
 
-    ZigType *elem_type;
     InferredStructField *isf = ty->data.pointer.inferred_struct_field;
     if (isf != nullptr) {
         TypeStructField *field = find_struct_type_field(isf->inferred_struct_type, isf->field_name);
@@ -6946,26 +6938,14 @@ static Error resolve_pointer_zero_bits(CodeGen *g, ZigType *ty) {
 
             return ErrorNone;
         }
-        elem_type = field->type_entry;
-    } else {
-        elem_type = ty->data.pointer.child_type;
     }
-
-    bool has_bits;
-    if ((err = type_has_bits2(g, elem_type, &has_bits)))
-        return err;
 
     ty->data.pointer.resolve_loop_flag_zero_bits = false;
 
-    if (has_bits) {
-        ty->abi_size = g->builtin_types.entry_usize->abi_size;
-        ty->size_in_bits = g->builtin_types.entry_usize->size_in_bits;
-        ty->abi_align = g->builtin_types.entry_usize->abi_align;
-    } else {
-        ty->abi_size = 0;
-        ty->size_in_bits = 0;
-        ty->abi_align = 0;
-    }
+    ty->abi_size = g->builtin_types.entry_usize->abi_size;
+    ty->size_in_bits = g->builtin_types.entry_usize->size_in_bits;
+    ty->abi_align = g->builtin_types.entry_usize->abi_align;
+
     return ErrorNone;
 }
 

--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -8414,41 +8414,6 @@ static void resolve_llvm_types_slice(CodeGen *g, ZigType *type, ResolveStatus wa
         if (ResolveStatusLLVMFwdDecl >= wanted_resolve_status) return;
     }
 
-    if (!type_has_bits(g, child_type)) {
-        LLVMTypeRef element_types[] = {
-            usize_llvm_type,
-        };
-        LLVMStructSetBody(type->llvm_type, element_types, 1, false);
-
-        uint64_t len_debug_size_in_bits = usize_type->size_in_bits;
-        uint64_t len_debug_align_in_bits = 8*usize_type->abi_align;
-        uint64_t len_offset_in_bits = 8*LLVMOffsetOfElement(g->target_data_ref, type->llvm_type, 0);
-
-        uint64_t debug_size_in_bits = type->size_in_bits;
-        uint64_t debug_align_in_bits = 8*type->abi_align;
-
-        ZigLLVMDIType *di_element_types[] = {
-            ZigLLVMCreateDebugMemberType(g->dbuilder, ZigLLVMTypeToScope(type->llvm_di_type),
-                    "len", di_file, line,
-                    len_debug_size_in_bits,
-                    len_debug_align_in_bits,
-                    len_offset_in_bits,
-                    ZigLLVM_DIFlags_Zero,
-                    usize_llvm_di_type),
-        };
-        ZigLLVMDIType *replacement_di_type = ZigLLVMCreateDebugStructType(g->dbuilder,
-                compile_unit_scope,
-                buf_ptr(&type->name),
-                di_file, line, debug_size_in_bits, debug_align_in_bits,
-                ZigLLVM_DIFlags_Zero,
-                nullptr, di_element_types, 1, 0, nullptr, "");
-
-        ZigLLVMReplaceTemporary(g->dbuilder, type->llvm_di_type, replacement_di_type);
-        type->llvm_di_type = replacement_di_type;
-        type->data.structure.resolve_status = ResolveStatusLLVMFull;
-        return;
-    }
-
     LLVMTypeRef element_types[2];
     element_types[slice_ptr_index] = get_llvm_type(g, ptr_type);
     element_types[slice_len_index] = get_llvm_type(g, g->builtin_types.entry_usize);

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -3337,19 +3337,10 @@ static LLVMValueRef ir_render_ptr_of_array_to_slice(CodeGen *g, IrExecutableGen 
     ZigType *array_type = actual_type->data.pointer.child_type;
     assert(array_type->id == ZigTypeIdArray);
 
-    if (type_has_bits(g, array_type)) {
-        LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, result_loc, ptr_index, "");
-        LLVMValueRef indices[] = {
-            LLVMConstNull(g->builtin_types.entry_usize->llvm_type),
-            LLVMConstInt(g->builtin_types.entry_usize->llvm_type, 0, false),
-        };
-        LLVMValueRef expr_val = ir_llvm_value(g, instruction->operand);
-        LLVMValueRef slice_start_ptr = LLVMBuildInBoundsGEP(g->builder, expr_val, indices, 2, "");
-        gen_store_untyped(g, slice_start_ptr, ptr_field_ptr, 0, false);
-    } else if (ir_want_runtime_safety(g, &instruction->base) && ptr_index != SIZE_MAX) {
-        LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, result_loc, ptr_index, "");
-        gen_undef_init(g, slice_ptr_type, slice_ptr_type, ptr_field_ptr);
-    }
+    LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, result_loc, ptr_index, "");
+    LLVMValueRef expr_val = ir_llvm_value(g, instruction->operand);
+    LLVMValueRef slice_start_ptr = LLVMBuildBitCast(g->builder, expr_val, get_llvm_type(g, slice_ptr_type), "");
+    gen_store_untyped(g, slice_start_ptr, ptr_field_ptr, 0, false);
 
     LLVMValueRef len_field_ptr = LLVMBuildStructGEP(g->builder, result_loc, len_index, "");
     LLVMValueRef len_value = LLVMConstInt(g->builtin_types.entry_usize->llvm_type,

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -3337,7 +3337,7 @@ static LLVMValueRef ir_render_ptr_of_array_to_slice(CodeGen *g, IrExecutableGen 
     ZigType *array_type = actual_type->data.pointer.child_type;
     assert(array_type->id == ZigTypeIdArray);
 
-    if (type_has_bits(g, actual_type)) {
+    if (type_has_bits(g, array_type)) {
         LLVMValueRef ptr_field_ptr = LLVMBuildStructGEP(g->builder, result_loc, ptr_index, "");
         LLVMValueRef indices[] = {
             LLVMConstNull(g->builtin_types.entry_usize->llvm_type),


### PR DESCRIPTION
# Remove Zero-Size Pointers
The purpose of this PR is to close #6706. The tests currently cause ICEs, since this is a work in progress.
Completed Changes:
-
- `get_pointer_to_type_extra2` and `resolve_pointer_zero_bits` no longer make pointer size/alignment 0 if the referent type is zero-sized
- Compiler is now able to build fully
- Removed unnecessary internal special-cases that check if a pointer is zero-sized (possibly incomplete, but done as far as I am aware)
- Zero-size, runtime-compatible types are given `LLVMGetUndef` values instead of nullptr llvm values when computing a function's allocas.

What needs to be done:
- replace LLVMGetUndef call to use `gen_undef_init` if possible
- Make all compiler tests pass (fix expectations as well as ICEs)
- Ensure that pointers to zero-sized types have properly aligned, non-zero addresses
  - also make sure that pointers to zero-sized struct members exist with the range of the struct's allocation
  - test that `@fieldParentPtr` works with pointers to zero-sized fields