### PR TITLE
Fix floating point parsing on BE systems

### DIFF
--- a/src/stage1/parse_f128.c
+++ b/src/stage1/parse_f128.c
@@ -5,11 +5,19 @@
 #include "softfloat.h"
 #include <stddef.h>
 #include <sys/types.h>
-#include <endian.h>
 #include <errno.h>
 #include <limits.h>
 #include <string.h>
 #include <math.h>
+
+// Every OSes seem to define endianness macros in different files.
+#if defined(__APPLE__)
+  #include <machine/endian.h>
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+  #include <sys/endian.h>
+#else
+  #include <endian.h>
+#endif
 
 #define shcnt(f) ((f)->shcnt + ((f)->rpos - (f)->buf))
 #define shlim(f, lim) __shlim((f), (lim))

--- a/src/stage1/parse_f128.c
+++ b/src/stage1/parse_f128.c
@@ -15,6 +15,10 @@
   #include <machine/endian.h>
 #elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
   #include <sys/endian.h>
+#elif defined(_WIN32) || defined(_WIN64)
+  // Assume that Windows installations are always little endian.
+  #define __LITTLE_ENDIAN 1
+  #define __BYTE_ORDER __LITTLE_ENDIAN
 #else
   #include <endian.h>
 #endif
@@ -56,7 +60,7 @@
 
 #define DECIMAL_DIG 36
 
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
 union ldshape {
     float128_t f;
     struct {
@@ -70,7 +74,7 @@ union ldshape {
         uint64_t hi;
     } i2;
 };
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
 union ldshape {
     float128_t f;
     struct {

--- a/src/stage1/parse_f128.c
+++ b/src/stage1/parse_f128.c
@@ -5,6 +5,7 @@
 #include "softfloat.h"
 #include <stddef.h>
 #include <sys/types.h>
+#include <endian.h>
 #include <errno.h>
 #include <limits.h>
 #include <string.h>
@@ -47,7 +48,6 @@
 
 #define DECIMAL_DIG 36
 
-
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 union ldshape {
     float128_t f;
@@ -76,6 +76,7 @@ union ldshape {
         uint64_t lo;
     } i2;
 };
+#else
 #error Unsupported endian
 #endif
 

--- a/src/stage1/parse_f128.c
+++ b/src/stage1/parse_f128.c
@@ -13,6 +13,9 @@
 // Every OSes seem to define endianness macros in different files.
 #if defined(__APPLE__)
   #include <machine/endian.h>
+  #define __BIG_ENDIAN BIG_ENDIAN
+  #define __LITTLE_ENDIAN LITTLE_ENDIAN
+  #define __BYTE_ORDER BYTE_ORDER
 #elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
   #include <sys/endian.h>
 #elif defined(_WIN32) || defined(_WIN64)

--- a/src/stage1/parse_f128.c
+++ b/src/stage1/parse_f128.c
@@ -13,17 +13,23 @@
 // Every OSes seem to define endianness macros in different files.
 #if defined(__APPLE__)
   #include <machine/endian.h>
-  #define __BIG_ENDIAN BIG_ENDIAN
-  #define __LITTLE_ENDIAN LITTLE_ENDIAN
-  #define __BYTE_ORDER BYTE_ORDER
+  #define ZIG_BIG_ENDIAN    BIG_ENDIAN
+  #define ZIG_LITTLE_ENDIAN LITTLE_ENDIAN
+  #define ZIG_BYTE_ORDER    BYTE_ORDER
 #elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
   #include <sys/endian.h>
+  #define ZIG_BIG_ENDIAN    _BIG_ENDIAN
+  #define ZIG_LITTLE_ENDIAN _LITTLE_ENDIAN
+  #define ZIG_BYTE_ORDER    _BYTE_ORDER
 #elif defined(_WIN32) || defined(_WIN64)
   // Assume that Windows installations are always little endian.
-  #define __LITTLE_ENDIAN 1
-  #define __BYTE_ORDER __LITTLE_ENDIAN
-#else
+  #define ZIG_LITTLE_ENDIAN 1
+  #define ZIG_BYTE_ORDER    ZIG_LITTLE_ENDIAN
+#else // Linux
   #include <endian.h>
+  #define ZIG_BIG_ENDIAN    __BIG_ENDIAN
+  #define ZIG_LITTLE_ENDIAN __LITTLE_ENDIAN
+  #define ZIG_BYTE_ORDER    __BYTE_ORDER
 #endif
 
 #define shcnt(f) ((f)->shcnt + ((f)->rpos - (f)->buf))
@@ -63,7 +69,7 @@
 
 #define DECIMAL_DIG 36
 
-#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
+#if defined(ZIG_BYTE_ORDER) && ZIG_BYTE_ORDER == ZIG_LITTLE_ENDIAN
 union ldshape {
     float128_t f;
     struct {
@@ -77,7 +83,7 @@ union ldshape {
         uint64_t hi;
     } i2;
 };
-#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
+#elif defined(ZIG_BYTE_ORDER) && ZIG_BYTE_ORDER == ZIG_BIG_ENDIAN
 union ldshape {
     float128_t f;
     struct {


### PR DESCRIPTION
From the IRC:
```
13:02 <koakuma> Zig uses strict -std=c99 to compile files, and it, for some reason, makes sys/types.h not include endian.h
13:02 <koakuma> So we don't get the endianness macros
13:04 <koakuma> It just probably happen to work on LE machines because, for reasons that I don't know why, the lack of macros results in the #if in parse_f128.c to take the LE branch
13:19 <TheLemonMan> does it pick the correct macros if you explicitly include it?
13:37 <koakuma> If I explicitly include endian.h, then yes, the macros seem to be picked correctly
```
So, yeah, this should fix the missing endianness macros.