### PR TITLE
fix memory leak in BufMap

### DIFF
--- a/lib/std/buf_map.zig
+++ b/lib/std/buf_map.zig
@@ -39,6 +39,7 @@ pub const BufMap = struct {
         const get_or_put = try self.hash_map.getOrPut(key);
         if (get_or_put.found_existing) {
             self.free(get_or_put.entry.key);
+            self.free(get_or_put.entry.value);
             get_or_put.entry.key = key;
         }
         get_or_put.entry.value = value;
@@ -88,7 +89,8 @@ pub const BufMap = struct {
 };
 
 test "BufMap" {
-    var bufmap = BufMap.init(std.testing.allocator);
+    const allocator = std.testing.allocator;
+    var bufmap = BufMap.init(allocator);
     defer bufmap.deinit();
 
     try bufmap.set("x", "1");
@@ -105,4 +107,7 @@ test "BufMap" {
 
     bufmap.delete("x");
     testing.expect(0 == bufmap.count());
+
+    try bufmap.setMove(try allocator.dupe(u8, "k"), try allocator.dupe(u8, "v1"));
+    try bufmap.setMove(try allocator.dupe(u8, "k"), try allocator.dupe(u8, "v2"));
 }


### PR DESCRIPTION
Fix a leak in `BufMap`.  The issue is caused when `setMove` is called on a `BufMap` where the key already exists.  The problem is that the old value is overwritten with the new value, and the old value never gets freed.  I've appended the `BufMap` test to reproduce this use case, and added the fix to free the value when it is overwritten.
