### PR TITLE
Make sure to include the root_name in the cache.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -665,6 +665,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
         cache.hash.add(options.output_mode);
         cache.hash.add(options.machine_code_model);
         cache.hash.add(options.emit_bin != null);
+        cache.hash.addBytes(options.root_name);
         // TODO audit this and make sure everything is in it
 
         const module: ?*Module = if (options.root_pkg) |root_pkg| blk: {


### PR DESCRIPTION
This fixes a bug where the caching system did not notice when the
--name flag changed.

@andrewrk There is still a TODO in the code regarding checking if we cache everything correctly:
https://github.com/ziglang/zig/blob/02e12ede46502e7c0f04ae94292e005a113a84c9/src/Compilation.zig#L645-L668

Fixes #7266