### PR TITLE
std: make the use of pthread_join POSIX-compliant

### DIFF
--- a/ci/azure/linux_script
+++ b/ci/azure/linux_script
@@ -8,11 +8,27 @@ BUILDDIR="$(pwd)"
 sudo sh -c 'echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main" >> /etc/apt/sources.list'
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-sudo apt-get update -q
 
 sudo apt-get remove -y llvm-*
 sudo rm -rf /usr/local/*
-sudo apt-get install -y libxml2-dev libclang-11-dev llvm-11 llvm-11-dev liblld-11-dev cmake s3cmd gcc-7 g++-7 ninja-build tidy
+
+# Some APT mirrors can be flaky, retry the download instead of failing right
+# away.
+APT_MAX_RETRY=3
+
+for i in $(seq 1 "$APT_MAX_RETRY"); do
+  sudo apt-get update -q
+  sudo apt-get install -y \
+    libxml2-dev libclang-11-dev llvm-11 llvm-11-dev liblld-11-dev cmake s3cmd \
+    gcc-7 g++-7 ninja-build tidy \
+    && break
+  if [ "$i" -eq "$APT_MAX_RETRY" ]; then
+    echo 'apt-get failed, giving up...'
+    exit 1
+  fi
+  echo 'apt-get failed, retrying...'
+  sleep 5s
+done
 
 QEMUBASE="qemu-linux-x86_64-5.1.0"
 wget https://ziglang.org/deps/$QEMUBASE.tar.xz

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -259,6 +259,7 @@ pub extern "c" fn futimens(fd: fd_t, times: *const [2]timespec) c_int;
 pub extern "c" fn pthread_create(noalias newthread: *pthread_t, noalias attr: ?*const pthread_attr_t, start_routine: fn (?*c_void) callconv(.C) ?*c_void, noalias arg: ?*c_void) c_int;
 pub extern "c" fn pthread_attr_init(attr: *pthread_attr_t) c_int;
 pub extern "c" fn pthread_attr_setstack(attr: *pthread_attr_t, stackaddr: *c_void, stacksize: usize) c_int;
+pub extern "c" fn pthread_attr_setstacksize(attr: *pthread_attr_t, stacksize: usize) c_int;
 pub extern "c" fn pthread_attr_setguardsize(attr: *pthread_attr_t, guardsize: usize) c_int;
 pub extern "c" fn pthread_attr_destroy(attr: *pthread_attr_t) c_int;
 pub extern "c" fn pthread_self() pthread_t;


### PR DESCRIPTION
Applications supplying their own custom stack to pthread_create are not
allowed to free the allocated memory after pthread_join returns as,
according to the specification, the thread is not guaranteed to be dead
after the join call returns.

Avoid this class of problems by avoiding the use of a custom stack
altogether, let pthread handle its own resources.

Allocations made on the child stack are now done on the C heap.

Thanks @semarie for noticing the problem on OpenBSD and suggesting a
fix.

Closes #7275