### PR TITLE
stage2: make sure to emit the ZIR instructions of exported functions

### DIFF
--- a/src/zir.zig
+++ b/src/zir.zig
@@ -1952,10 +1952,9 @@ const EmitZIR = struct {
                     };
                     _ = try self.emitUnnamedDecl(&export_inst.base);
                 }
-            } else {
-                const new_decl = try self.emitTypedValue(ir_decl.src(), ir_decl.typed_value.most_recent.typed_value);
-                new_decl.name = try self.arena.allocator.dupe(u8, mem.spanZ(ir_decl.name));
             }
+            const new_decl = try self.emitTypedValue(ir_decl.src(), ir_decl.typed_value.most_recent.typed_value);
+            new_decl.name = try self.arena.allocator.dupe(u8, mem.spanZ(ir_decl.name));
         }
     }
 

--- a/test/stage2/zir.zig
+++ b/test/stage2/zir.zig
@@ -26,8 +26,9 @@ pub fn addCases(ctx: *TestContext) !void {
         \\@9__anon_0 = str("entry")
         \\@unnamed$4 = str("entry")
         \\@unnamed$5 = export(@unnamed$4, "entry")
-        \\@unnamed$6 = fntype([], @void, cc=C)
-        \\@entry = fn(@unnamed$6, {
+        \\@11 = primitive(void_value)
+        \\@unnamed$7 = fntype([], @void, cc=C)
+        \\@entry = fn(@unnamed$7, {
         \\  %0 = returnvoid() ; deaths=0b1000000000000000
         \\})
         \\
@@ -83,6 +84,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\@9__anon_0 = str("entry")
         \\@unnamed$11 = str("entry")
         \\@unnamed$12 = export(@unnamed$11, "entry")
+        \\@11 = primitive(void_value)
         \\
     );
 
@@ -116,18 +118,19 @@ pub fn addCases(ctx: *TestContext) !void {
             \\@9__anon_0 = str("entry")
             \\@unnamed$4 = str("entry")
             \\@unnamed$5 = export(@unnamed$4, "entry")
-            \\@unnamed$6 = fntype([], @void, cc=C)
-            \\@entry = fn(@unnamed$6, {
+            \\@11 = primitive(void_value)
+            \\@unnamed$7 = fntype([], @void, cc=C)
+            \\@entry = fn(@unnamed$7, {
             \\  %0 = call(@a, [], modifier=auto) ; deaths=0b1000000000000001
             \\  %1 = returnvoid() ; deaths=0b1000000000000000
             \\})
-            \\@unnamed$8 = fntype([], @void, cc=C)
-            \\@a = fn(@unnamed$8, {
+            \\@unnamed$9 = fntype([], @void, cc=C)
+            \\@a = fn(@unnamed$9, {
             \\  %0 = call(@b, [], modifier=auto) ; deaths=0b1000000000000001
             \\  %1 = returnvoid() ; deaths=0b1000000000000000
             \\})
-            \\@unnamed$10 = fntype([], @void, cc=C)
-            \\@b = fn(@unnamed$10, {
+            \\@unnamed$11 = fntype([], @void, cc=C)
+            \\@b = fn(@unnamed$11, {
             \\  %0 = call(@a, [], modifier=auto) ; deaths=0b1000000000000001
             \\  %1 = returnvoid() ; deaths=0b1000000000000000
             \\})
@@ -192,8 +195,9 @@ pub fn addCases(ctx: *TestContext) !void {
             \\@9__anon_2 = str("entry")
             \\@unnamed$4 = str("entry")
             \\@unnamed$5 = export(@unnamed$4, "entry")
-            \\@unnamed$6 = fntype([], @void, cc=C)
-            \\@entry = fn(@unnamed$6, {
+            \\@11 = primitive(void_value)
+            \\@unnamed$7 = fntype([], @void, cc=C)
+            \\@entry = fn(@unnamed$7, {
             \\  %0 = returnvoid() ; deaths=0b1000000000000000
             \\})
             \\


### PR DESCRIPTION
Previously the emitted ZIR code would not have the ZIR instructions
of the exported functions.

Before:
```
@unnamed$0 = str("_start")
@unnamed$1 = export(@unnamed$0, "_start")
@unnamed$2 = str("{rax}")
@unnamed$3 = str("{rdi}")
@unnamed$4 = str("{rsi}")
@unnamed$5 = str("{rdx}")
@unnamed$6 = primitive(usize)
....
```
After:
```
@unnamed$0 = str("_start")
@unnamed$1 = export(@unnamed$0, "_start")
@unnamed$2 = primitive(noreturn)
@unnamed$3 = fntype([], @unnamed$2, cc=Unspecified)
@_start = fn(@unnamed$3, {
  %0 = dbg_stmt() ; deaths=0b1000000000000000 0x7f9b4b34c868
  %1 = call(@print, [], modifier=auto) ; deaths=0b1000000000000001 0x7f9b4b37ec18
  %2 = dbg_stmt() ; deaths=0b1000000000000000 0x7f9b4b37ec68
  %3 = call(@exit, [], modifier=auto) ; deaths=0b1000000000000001 0x7f9b4b37ece0
})
@unnamed$5 = str("{rax}")
@unnamed$6 = str("{rdi}")
@unnamed$7 = str("{rsi}")
@unnamed$8 = str("{rdx}")
@unnamed$9 = primitive(usize)
....
```