### PR TITLE
stage1: allow idx 0 err to be put into error_name_table

### DIFF
--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -5178,11 +5178,7 @@ static LLVMValueRef ir_render_ref(CodeGen *g, IrExecutableGen *executable, IrIns
 
 static LLVMValueRef ir_render_err_name(CodeGen *g, IrExecutableGen *executable, IrInstGenErrName *instruction) {
     assert(g->generate_error_name_table);
-
-    if (g->errors_by_index.length == 1) {
-        LLVMBuildUnreachable(g->builder);
-        return nullptr;
-    }
+    assert(g->errors_by_index.length > 0);
 
     LLVMValueRef err_val = ir_llvm_value(g, instruction->value);
     if (ir_want_runtime_safety(g, &instruction->base)) {
@@ -7890,7 +7886,7 @@ static void render_const_val_global(CodeGen *g, ZigValue *const_val, const char 
 }
 
 static void generate_error_name_table(CodeGen *g) {
-    if (g->err_name_table != nullptr || !g->generate_error_name_table || g->errors_by_index.length == 1) {
+    if (g->err_name_table != nullptr || !g->generate_error_name_table) {
         return;
     }
 

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -19,6 +19,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/use_alias/build.zig");
     cases.addBuildFile("test/standalone/brace_expansion/build.zig");
     cases.addBuildFile("test/standalone/empty_env/build.zig");
+    cases.addBuildFile("test/standalone/issue_7030/build.zig");
     if (std.Target.current.os.tag != .wasi) {
         cases.addBuildFile("test/standalone/load_dynamic_library/build.zig");
     }

--- a/test/standalone/issue_7030/build.zig
+++ b/test/standalone/issue_7030/build.zig
@@ -1,0 +1,14 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const exe = b.addExecutable("issue_7030", "main.zig");
+    exe.setTarget(.{
+        .cpu_arch = .wasm32,
+        .os_tag = .freestanding,
+    });
+    exe.install();
+    b.default_step.dependOn(&exe.step);
+
+    const test_step = b.step("test", "Test the program");
+    test_step.dependOn(&exe.step);
+}

--- a/test/standalone/issue_7030/main.zig
+++ b/test/standalone/issue_7030/main.zig
@@ -1,0 +1,5 @@
+const std = @import("std");
+
+pub fn main() anyerror!void {
+    std.log.info("All your codebase are belong to us.", .{});
+}


### PR DESCRIPTION
This way, in the very situation where a function has a return type an error union such as `anyerror!void` but doesn't have any erroneous paths, calling `@errorName` on the unpacked error (which will never be triggered) will not trip up the static analyzer.

Closes #7030

@andrewrk lemme know if this is acceptable. I'm more than to work on this more if this is not the way we'd like to handle this one!