### PR TITLE
Version-gate appending -syslibroot flag to lld

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -534,7 +534,10 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
 
         const darwin_options: DarwinOptions = if (build_options.have_llvm and comptime std.Target.current.isDarwin()) outer: {
             const opts: DarwinOptions = if (use_lld and options.is_native_os and options.target.isDarwin()) inner: {
-                const syslibroot = try std.zig.system.getSDKPath(arena);
+                // TODO Revisit this targeting versions lower than macOS 11 when LLVM 12 is out.
+                // See https://github.com/ziglang/zig/issues/6996
+                const at_least_big_sur = options.target.os.getVersionRange().semver.min.major >= 11;
+                const syslibroot = if (at_least_big_sur) try std.zig.system.getSDKPath(arena) else null;
                 const system_linker_hack = std.os.getenv("ZIG_SYSTEM_LINKER_HACK") != null;
                 break :inner .{
                     .syslibroot = syslibroot,

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -421,6 +421,8 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
         man.hash.addStringSet(self.base.options.system_libs);
         man.hash.add(allow_shlib_undefined);
         man.hash.add(self.base.options.bind_global_refs_locally);
+        man.hash.add(self.base.options.system_linker_hack);
+        man.hash.addOptionalBytes(self.base.options.syslibroot);
 
         // We don't actually care whether it's a cache hit or miss; we just need the digest and the lock.
         _ = try man.hit();


### PR DESCRIPTION
This commit version-gates appending `-syslibroot` flag to lld. This
is predicated upon the fact that for versions of macOS lower than
11, lld would fail to find and link against frameworks with this
flag specified.

Closes #6996 

Co-authored-by: Andrew Kelley <andrew@ziglang.org>