### PR TITLE
macho: specify -install_name as full dylib's name

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -534,11 +534,9 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
                 try argv.append(cur_vers);
             }
 
-            // TODO getting an error when running an executable when doing this rpath thing
-            //Buf *dylib_install_name = buf_sprintf("@rpath/lib%s.%" ZIG_PRI_usize ".dylib",
-            //    buf_ptr(g->root_out_name), g->version_major);
-            //try argv.append("-install_name");
-            //try argv.append(buf_ptr(dylib_install_name));
+            const dylib_install_name = try std.fmt.allocPrint(arena, "@rpath/{}", .{self.base.options.emit.?.sub_path});
+            try argv.append("-install_name");
+            try argv.append(dylib_install_name);
         }
 
         try argv.append("-arch");


### PR DESCRIPTION
This then allows for proper resolution of names via runpath search
path list, i.e., `-rpath @loader_path` will correctly resolve
to `@rpath/libxxx.dylib (...)` in the linked binary.

Closes #7046 