### PR TITLE
Add option to override default stack size in build system.

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1291,6 +1291,9 @@ pub const LibExeObjStep = struct {
 
     subsystem: ?builtin.SubSystem = null,
 
+    /// Overrides the default stack size
+    stack_size: ?u64 = null,
+
     const LinkObject = union(enum) {
         StaticPath: []const u8,
         OtherStep: *LibExeObjStep,
@@ -1985,6 +1988,11 @@ pub const LibExeObjStep = struct {
         if (builder.color != .auto) {
             try zig_args.append("--color");
             try zig_args.append(@tagName(builder.color));
+        }
+
+        if (self.stack_size) |stack_size| {
+            try zig_args.append("--stack");
+            try zig_args.append(try std.fmt.allocPrint(builder.allocator, "{}", .{stack_size}));
         }
 
         if (self.root_src) |root_src| try zig_args.append(root_src.getPath(builder));


### PR DESCRIPTION
Implements #7253.

This PR also adds the option --stack to the build system itself to override all stack sizes set by setStackSize. But maybe this isn't that useful and should be removed? 