### PR TITLE
Fix general purpose allocator incorrectly modifying total_requested_bytes in some cases.

### DIFF
--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -528,7 +528,11 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
                         second_free_stack_trace,
                     });
                     if (new_size == 0) {
-                        // Recoverable.
+                        // Recoverable. Restore self.total_requested_bytes if needed, as we
+                        // don't return an error value so the errdefer above does not run.
+                        if (config.enable_memory_limit) {
+                            self.total_requested_bytes = prev_req_bytes;
+                        }
                         return @as(usize, 0);
                     }
                     @panic("Unrecoverable double free");


### PR DESCRIPTION
When recovering from a double free, the general purpose allocator will not run its `errdefer` and thus incorrectly modify `self.total_requested_bytes`.