### PR TITLE
Support casting enums to all int types in translate-c.

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -371,4 +371,117 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("assign enum to uint, no explicit cast",
+        \\#include <stdlib.h>
+        \\typedef enum {
+        \\    ENUM_0 = 0,
+        \\    ENUM_1 = 1,
+        \\} my_enum_t;
+        \\
+        \\int main() {
+        \\    my_enum_t val = ENUM_1;
+        \\    unsigned int x = val;
+        \\    if (x != 1) abort();
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("assign enum to int",
+        \\#include <stdlib.h>
+        \\typedef enum {
+        \\    ENUM_0 = 0,
+        \\    ENUM_1 = 1,
+        \\} my_enum_t;
+        \\
+        \\int main() {
+        \\    my_enum_t val = ENUM_1;
+        \\    int x = val;
+        \\    if (x != 1) abort();
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("cast enum to smaller uint",
+        \\#include <stdlib.h>
+        \\#include <stdint.h>
+        \\typedef enum {
+        \\    ENUM_0 = 0,
+        \\    ENUM_257 = 257,
+        \\} my_enum_t;
+        \\
+        \\int main() {
+        \\    my_enum_t val = ENUM_257;
+        \\    uint8_t x = (uint8_t)val;
+        \\    if (x != (uint8_t)257) abort();
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("cast enum to smaller signed int",
+        \\#include <stdlib.h>
+        \\#include <stdint.h>
+        \\typedef enum {
+        \\    ENUM_0 = 0,
+        \\    ENUM_384 = 384,
+        \\} my_enum_t;
+        \\
+        \\int main() {
+        \\    my_enum_t val = ENUM_384;
+        \\    int8_t x = (int8_t)val;
+        \\    if (x != (int8_t)384) abort();
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("cast negative enum to smaller signed int",
+        \\#include <stdlib.h>
+        \\#include <stdint.h>
+        \\typedef enum {
+        \\    ENUM_MINUS_1 = -1,
+        \\    ENUM_384 = 384,
+        \\} my_enum_t;
+        \\
+        \\int main() {
+        \\    my_enum_t val = ENUM_MINUS_1;
+        \\    int8_t x = (int8_t)val;
+        \\    if (x != -1) abort();
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("cast negative enum to smaller unsigned int",
+        \\#include <stdlib.h>
+        \\#include <stdint.h>
+        \\typedef enum {
+        \\    ENUM_MINUS_1 = -1,
+        \\    ENUM_384 = 384,
+        \\} my_enum_t;
+        \\
+        \\int main() {
+        \\    my_enum_t val = ENUM_MINUS_1;
+        \\    uint8_t x = (uint8_t)val;
+        \\    if (x != (uint8_t)-1) abort();
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("implicit enum cast in boolean expression",
+        \\#include <stdlib.h>
+        \\enum Foo {
+        \\    FooA,
+        \\    FooB,
+        \\    FooC,
+        \\};
+        \\int main() {
+        \\    int a = 0;
+        \\    float b = 0;
+        \\    void *c = 0;
+        \\    enum Foo d = FooA;
+        \\    if (a || d) abort();
+        \\    if (d && b) abort();
+        \\    if (c || d) abort();
+        \\    return 0;
+        \\}
+    , "");
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2000,9 +2000,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    int h = (a || b);
         \\    int i = (b || c);
         \\    int j = (a || c);
-        \\    int k = (a || d);
-        \\    int l = (d && b);
-        \\    int m = (c || d);
+        \\    int k = (a || (int)d);
+        \\    int l = ((int)d && b);
+        \\    int m = (c || (unsigned int)d);
         \\    SomeTypedef td = 44;
         \\    int o = (td || b);
         \\    int p = (c && td);
@@ -2027,9 +2027,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    var h: c_int = @boolToInt(((a != 0) or (b != 0)));
         \\    var i: c_int = @boolToInt(((b != 0) or (c != null)));
         \\    var j: c_int = @boolToInt(((a != 0) or (c != null)));
-        \\    var k: c_int = @boolToInt(((a != 0) or (@enumToInt(d) != 0)));
-        \\    var l: c_int = @boolToInt(((@enumToInt(d) != 0) and (b != 0)));
-        \\    var m: c_int = @boolToInt(((c != null) or (@enumToInt(d) != 0)));
+        \\    var k: c_int = @boolToInt(((a != 0) or (@bitCast(c_int, @enumToInt(d)) != 0)));
+        \\    var l: c_int = @boolToInt(((@bitCast(c_int, @enumToInt(d)) != 0) and (b != 0)));
+        \\    var m: c_int = @boolToInt(((c != null) or (@bitCast(c_uint, @enumToInt(d)) != 0)));
         \\    var td: SomeTypedef = 44;
         \\    var o: c_int = @boolToInt(((td != 0) or (b != 0)));
         \\    var p: c_int = @boolToInt(((c != null) and (td != 0)));


### PR DESCRIPTION
In C, enums are represented as signed integers, so casting from an enum to an integer
should use the "cast integer to integer" translation code path. Previously it used the
"cast enum to generic non-enum" code path, because enums were not being treated as integers.
Ultimately this can produce zig code that fails to compile if the destination type does not
support the full range of enum values (e.g. translated C code that casts an enum value to an
unsigned integer would fail to compile since enums are signed integers, and unsigned integers
cannot represent the full range of values that signed ones can).