### PR TITLE
glibc: additionally provide -lcrypt

### DIFF
--- a/lib/libc/glibc/abi.txt
+++ b/lib/libc/glibc/abi.txt
@@ -1655,6 +1655,8 @@ aarch64-linux-gnu aarch64_be-linux-gnu
 29
 29
 29
+29
+29
 37
 37
 37
@@ -1729,6 +1731,8 @@ aarch64-linux-gnu aarch64_be-linux-gnu
 29
 29
 38
+29
+29
 29
 29
 29
@@ -1910,6 +1914,7 @@ aarch64-linux-gnu aarch64_be-linux-gnu
 29
 29
 38
+29
 29
 29
 29
@@ -3251,6 +3256,8 @@ aarch64-linux-gnu aarch64_be-linux-gnu
 29
 29
 40
+29
+29
 29
 29
 29
@@ -5614,6 +5621,8 @@ s390x-linux-gnu
 5
 5
 5
+5
+5
 37
 37
 37
@@ -5694,6 +5703,8 @@ s390x-linux-gnu
 12
 5
 16
+5
+5
 5
 5
 5
@@ -5869,6 +5880,7 @@ s390x-linux-gnu
 5
 5
 38
+5
 5
 5
 5
@@ -7250,6 +7262,8 @@ s390x-linux-gnu
 15
 5
 31 5
+5
+5
 5
 5
 5
@@ -9573,6 +9587,8 @@ arm-linux-gnueabi armeb-linux-gnueabi arm-linux-gnueabihf armeb-linux-gnueabihf
 16
 16
 16
+16
+16
 
 37
 37
@@ -9650,6 +9666,8 @@ arm-linux-gnueabi armeb-linux-gnueabi arm-linux-gnueabihf armeb-linux-gnueabihf
 16
 16
 21
+16
+16
 16
 16
 16
@@ -9828,6 +9846,7 @@ arm-linux-gnueabi armeb-linux-gnueabi arm-linux-gnueabihf armeb-linux-gnueabihf
 16
 38 16
 38
+16
 16
 16
 16
@@ -11187,6 +11206,8 @@ arm-linux-gnueabi armeb-linux-gnueabi arm-linux-gnueabihf armeb-linux-gnueabihf
 16
 16
 26
+16
+16
 16
 16
 16
@@ -13530,6 +13551,8 @@ sparc-linux-gnu sparcel-linux-gnu
 0
 1
 0
+0
+0
 1
 1
 37
@@ -13613,6 +13636,8 @@ sparc-linux-gnu sparcel-linux-gnu
 0
 16
 1
+0
+0
 0
 0
 0
@@ -13787,6 +13812,7 @@ sparc-linux-gnu sparcel-linux-gnu
 0
 0 38
 38
+0
 0
 0
 0
@@ -15166,6 +15192,8 @@ sparc-linux-gnu sparcel-linux-gnu
 0
 0
 15
+0
+0
 0
 0
 0
@@ -17489,6 +17517,8 @@ sparcv9-linux-gnu
 5
 5
 5
+0
+0
 5
 5
 37
@@ -17574,6 +17604,8 @@ sparcv9-linux-gnu
 5
 5
 5
+0
+0
 5
 5
 5
@@ -17746,6 +17778,7 @@ sparcv9-linux-gnu
 5
 5
 38
+0
 5
 5
 5
@@ -19127,6 +19160,8 @@ sparcv9-linux-gnu
 15
 5
 5
+0
+0
 5
 5
 5
@@ -21448,6 +21483,8 @@ mips64el-linux-gnuabi64 mips64-linux-gnuabi64
 0
 5
 0
+0
+0
 5
 5
 37
@@ -21531,6 +21568,8 @@ mips64el-linux-gnuabi64 mips64-linux-gnuabi64
 0
 16
 5
+0
+0
 0
 0
 0
@@ -21705,6 +21744,7 @@ mips64el-linux-gnuabi64 mips64-linux-gnuabi64
 0
 0
 38
+0
 0
 0
 0
@@ -23084,6 +23124,8 @@ mips64el-linux-gnuabi64 mips64-linux-gnuabi64
 0
 0
 15
+0
+0
 0
 0
 0
@@ -25407,6 +25449,8 @@ mips64el-linux-gnuabin32 mips64-linux-gnuabin32
 0
 5
 0
+0
+0
 5
 5
 37
@@ -25490,6 +25534,8 @@ mips64el-linux-gnuabin32 mips64-linux-gnuabin32
 0
 16
 5
+0
+0
 0
 0
 0
@@ -25664,6 +25710,7 @@ mips64el-linux-gnuabin32 mips64-linux-gnuabin32
 0
 0 38
 38
+0
 0
 0
 0
@@ -27043,6 +27090,8 @@ mips64el-linux-gnuabin32 mips64-linux-gnuabin32
 0
 0
 15
+0
+0
 0
 0
 0
@@ -29366,6 +29415,8 @@ mipsel-linux-gnueabihf mips-linux-gnueabihf
 0
 5
 0
+0
+0
 5
 5
 
@@ -29449,6 +29500,8 @@ mipsel-linux-gnueabihf mips-linux-gnueabihf
 0
 16
 5
+0
+0
 0
 0
 0
@@ -29623,6 +29676,7 @@ mipsel-linux-gnueabihf mips-linux-gnueabihf
 0
 0 38
 38
+0
 0
 0
 0
@@ -31002,6 +31056,8 @@ mipsel-linux-gnueabihf mips-linux-gnueabihf
 0
 0
 15
+0
+0
 0
 0
 0
@@ -33325,6 +33381,8 @@ mipsel-linux-gnueabi mips-linux-gnueabi
 0
 5
 0
+0
+0
 5
 5
 
@@ -33408,6 +33466,8 @@ mipsel-linux-gnueabi mips-linux-gnueabi
 0
 16
 5
+0
+0
 0
 0
 0
@@ -33582,6 +33642,7 @@ mipsel-linux-gnueabi mips-linux-gnueabi
 0
 0 38
 38
+0
 0
 0
 0
@@ -34961,6 +35022,8 @@ mipsel-linux-gnueabi mips-linux-gnueabi
 0
 0
 15
+0
+0
 0
 0
 0
@@ -37286,6 +37349,8 @@ x86_64-linux-gnu
 10
 10
 10
+10
+10
 36
 37
 37
@@ -37366,6 +37431,8 @@ x86_64-linux-gnu
 12
 10
 16
+10
+10
 10
 10
 10
@@ -37541,6 +37608,7 @@ x86_64-linux-gnu
 10
 10
 38
+10
 10
 10
 10
@@ -38920,6 +38988,8 @@ x86_64-linux-gnu
 10
 10
 15
+10
+10
 10
 10
 10
@@ -41245,6 +41315,8 @@ x86_64-linux-gnux32
 28
 28
 28
+28
+28
 36
 37
 37
@@ -41319,6 +41391,8 @@ x86_64-linux-gnux32
 28
 28
 38
+28
+28
 28
 28
 28
@@ -41500,6 +41574,7 @@ x86_64-linux-gnux32
 28
 28
 38
+28
 28
 28
 28
@@ -42841,6 +42916,8 @@ x86_64-linux-gnux32
 28
 28
 40
+28
+28
 28
 28
 28
@@ -45202,6 +45279,8 @@ i386-linux-gnu
 0
 1
 0
+0
+0
 1
 1
 36
@@ -45285,6 +45364,8 @@ i386-linux-gnu
 0
 16
 1
+0
+0
 0
 0
 0
@@ -45459,6 +45540,7 @@ i386-linux-gnu
 0
 0 38
 38
+0
 0
 0
 0
@@ -46838,6 +46920,8 @@ i386-linux-gnu
 0
 0
 15
+0
+0
 0
 0
 0
@@ -49163,6 +49247,8 @@ powerpc64le-linux-gnu
 29
 29
 29
+29
+29
 36
 37
 37
@@ -49237,6 +49323,8 @@ powerpc64le-linux-gnu
 29
 29
 38
+29
+29
 29
 29
 29
@@ -49418,6 +49506,7 @@ powerpc64le-linux-gnu
 29
 29
 38
+29
 29
 29
 29
@@ -50759,6 +50848,8 @@ powerpc64le-linux-gnu
 29
 29
 40
+29
+29
 29
 29
 29
@@ -53122,6 +53213,8 @@ powerpc64-linux-gnu
 12
 12
 12
+12
+12
 
 37
 37
@@ -53202,6 +53295,8 @@ powerpc64-linux-gnu
 12
 12
 16
+12
+12
 12
 12
 12
@@ -53377,6 +53472,7 @@ powerpc64-linux-gnu
 12
 12
 38
+12
 12
 12
 12
@@ -54758,6 +54854,8 @@ powerpc64-linux-gnu
 15
 12
 12 15
+12
+12
 12
 12
 12
@@ -57079,6 +57177,8 @@ powerpc-linux-gnueabi powerpc-linux-gnueabihf
 0
 1
 0
+0
+0
 1
 1
 
@@ -57162,6 +57262,8 @@ powerpc-linux-gnueabi powerpc-linux-gnueabihf
 0
 16
 1
+0
+0
 0
 0
 0
@@ -57336,6 +57438,7 @@ powerpc-linux-gnueabi powerpc-linux-gnueabihf
 0
 0 38
 38
+0
 0
 0
 0
@@ -58717,6 +58820,8 @@ powerpc-linux-gnueabi powerpc-linux-gnueabihf
 15
 0
 0 15
+0
+0
 0
 0
 0

--- a/lib/libc/glibc/fns.txt
+++ b/lib/libc/glibc/fns.txt
@@ -1652,6 +1652,8 @@ creall m
 creat c
 creat64 c
 create_module c
+crypt crypt
+crypt_r crypt
 csin m
 csinf m
 csinf128 m
@@ -1737,6 +1739,8 @@ eaccess c
 ecb_crypt c
 ecvt c
 ecvt_r c
+encrypt crypt
+encrypt_r crypt
 endaliasent c
 endfsent c
 endgrent c
@@ -1909,6 +1913,7 @@ fclose c
 fcloseall c
 fcntl c
 fcntl64 c
+fcrypt crypt
 fcvt c
 fcvt_r c
 fdatasync c
@@ -3290,6 +3295,8 @@ sethostname c
 setipv4sourcefilter c
 setitimer c
 setjmp c
+setkey crypt
+setkey_r crypt
 setlinebuf c
 setlocale c
 setlogin c

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -48,6 +48,7 @@ pub const libs = [_]Lib{
     .{ .name = "rt", .sover = 1 },
     .{ .name = "ld", .sover = 2 },
     .{ .name = "util", .sover = 1 },
+    .{ .name = "crypt", .sover = 1 },
 };
 
 pub const LoadMetaDataError = error{

--- a/src/stage1/target.cpp
+++ b/src/stage1/target.cpp
@@ -1146,8 +1146,6 @@ bool target_is_libc_lib_name(const ZigTarget *target, const char *name) {
             return true;
         if (equal(name, "dl"))
             return true;
-        if (equal(name, "util"))
-            return true;
     }
 
     if (target_os_is_darwin(target->os) && equal(name, "System"))

--- a/src/target.zig
+++ b/src/target.zig
@@ -324,8 +324,6 @@ pub fn is_libc_lib_name(target: std.Target, name: []const u8) bool {
             return true;
         if (eqlIgnoreCase(ignore_case, name, "dl"))
             return true;
-        if (eqlIgnoreCase(ignore_case, name, "util"))
-            return true;
     }
 
     if (target.os.tag.isDarwin() and eqlIgnoreCase(ignore_case, name, "System"))

--- a/tools/update_glibc.zig
+++ b/tools/update_glibc.zig
@@ -22,6 +22,7 @@ const lib_names = [_][]const u8{
     "rt",
     "ld",
     "util",
+    "crypt",
 };
 
 // fpu/nofpu are hardcoded elsewhere, based on .gnueabi/.gnueabihf with an exception for .arm


### PR DESCRIPTION
Looks like we were missing support for this other library that glibc provides.