### PR TITLE
Stage2: Change tag returned by zigTagType for c_longdouble to Float.

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -38,7 +38,6 @@ pub const Type = extern union {
             .c_ulong,
             .c_longlong,
             .c_ulonglong,
-            .c_longdouble,
             .int_signed,
             .int_unsigned,
             => return .Int,
@@ -47,6 +46,7 @@ pub const Type = extern union {
             .f32,
             .f64,
             .f128,
+            .c_longdouble,
             => return .Float,
 
             .c_void => return .Opaque,


### PR DESCRIPTION
The function is currently returning Int.