### PR TITLE
Fix operator precedence documentation

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1743,8 +1743,8 @@ const B = error{Two};
       {#header_open|Precedence#}
       <pre>{#syntax#}x() x[] x.y
 a!b
-!x -x -%x ~x &x ?x
 x{} x.* x.?
+!x -x -%x ~x &x ?x
 ! * / % ** *% ||
 + - ++ +% -%
 << >>


### PR DESCRIPTION
Thanks to @EleanorNB for pointing this out.

The docs had operator precedence backwards between prefix unary operators and postfix unary operators.
Things like `&x.?`, `-x.*`, `&T{}` all compile, but the previous order in the documentation would say that these require parentheses.