### PR TITLE
stage2: add aarch64 load/store pair of registers instructions

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -2768,8 +2768,8 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                     .x0,
                                     .x28,
                                     Register.sp,
-                                    -2,
-                                    .SignedOffset,
+                                    -16,
+                                    .PreIndex,
                                 ).toU32());
                                 // adr x28, #8
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.adr(.x28, 8).toU32());
@@ -2795,8 +2795,8 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                     .x0,
                                     .x28,
                                     Register.sp,
-                                    2,
-                                    .SignedOffset,
+                                    16,
+                                    .PostIndex,
                                 ).toU32());
                             }
                         } else {

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -2730,13 +2730,10 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             // For MachO, the binary, with the exception of object files, has to be a PIE.
                             // Therefore we cannot load an absolute address.
                             // Instead, we need to make use of PC-relative addressing.
-                            // TODO This needs to be optimised in the stack usage (perhaps use a shadow stack
-                            // like described here:
-                            // https://community.arm.com/developer/ip-products/processors/b/processors-ip-blog/posts/using-the-stack-in-aarch64-implementing-push-and-pop)
-                            // TODO As far as branching is concerned, instead of saving the return address
-                            // in a register, I'm thinking here of immitating x86_64, and having the address
-                            // passed on the stack.
                             if (reg.id() == 0) { // x0 is special-cased
+                                // TODO This needs to be optimised in the stack usage (perhaps use a shadow stack
+                                // like described here:
+                                // https://community.arm.com/developer/ip-products/processors/b/processors-ip-blog/posts/using-the-stack-in-aarch64-implementing-push-and-pop)
                                 // str x28, [sp, #-16]
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.str(.x28, Register.sp, .{
                                     .offset = Instruction.Offset.imm_pre_index(-16),
@@ -2755,21 +2752,25 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 // b [label]
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.b(0).toU32());
                                 // mov r, x0
-                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.orr(reg, .x0, Instruction.RegisterShift.none()).toU32());
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.orr(
+                                    reg,
+                                    .x0,
+                                    Instruction.RegisterShift.none(),
+                                ).toU32());
                                 // ldr x28, [sp], #16
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.ldr(.x28, .{
                                     .rn = Register.sp,
                                     .offset = Instruction.Offset.imm_post_index(16),
                                 }).toU32());
                             } else {
-                                // str x28, [sp, #-16]
-                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.str(.x28, Register.sp, .{
-                                    .offset = Instruction.Offset.imm_pre_index(-16),
-                                }).toU32());
-                                // str x0, [sp, #-16]
-                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.str(.x0, Register.sp, .{
-                                    .offset = Instruction.Offset.imm_pre_index(-16),
-                                }).toU32());
+                                // stp x0, x28, [sp, #-16]
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.stp(
+                                    .x0,
+                                    .x28,
+                                    Register.sp,
+                                    -2,
+                                    .SignedOffset,
+                                ).toU32());
                                 // adr x28, #8
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.adr(.x28, 8).toU32());
                                 if (self.bin_file.cast(link.File.MachO)) |macho_file| {
@@ -2784,17 +2785,19 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 // b [label]
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.b(0).toU32());
                                 // mov r, x0
-                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.orr(reg, .x0, Instruction.RegisterShift.none()).toU32());
-                                // ldr x0, [sp], #16
-                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.ldr(.x0, .{
-                                    .rn = Register.sp,
-                                    .offset = Instruction.Offset.imm_post_index(16),
-                                }).toU32());
-                                // ldr x28, [sp], #16
-                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.ldr(.x28, .{
-                                    .rn = Register.sp,
-                                    .offset = Instruction.Offset.imm_post_index(16),
-                                }).toU32());
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.orr(
+                                    reg,
+                                    .x0,
+                                    Instruction.RegisterShift.none(),
+                                ).toU32());
+                                // ldp x0, x28, [sp, #16]
+                                mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.ldp(
+                                    .x0,
+                                    .x28,
+                                    Register.sp,
+                                    2,
+                                    .SignedOffset,
+                                ).toU32());
                             }
                         } else {
                             // The value is in memory at a hard-coded address.

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -2736,7 +2736,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 // https://community.arm.com/developer/ip-products/processors/b/processors-ip-blog/posts/using-the-stack-in-aarch64-implementing-push-and-pop)
                                 // str x28, [sp, #-16]
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.str(.x28, Register.sp, .{
-                                    .offset = Instruction.Offset.imm_pre_index(-16),
+                                    .offset = Instruction.LoadStoreOffset.imm_pre_index(-16),
                                 }).toU32());
                                 // adr x28, #8
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.adr(.x28, 8).toU32());
@@ -2760,7 +2760,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 // ldr x28, [sp], #16
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.ldr(.x28, .{
                                     .rn = Register.sp,
-                                    .offset = Instruction.Offset.imm_post_index(16),
+                                    .offset = Instruction.LoadStoreOffset.imm_post_index(16),
                                 }).toU32());
                             } else {
                                 // stp x0, x28, [sp, #-16]
@@ -2768,8 +2768,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                     .x0,
                                     .x28,
                                     Register.sp,
-                                    -16,
-                                    .PreIndex,
+                                    Instruction.LoadStorePairOffset.pre_index(-16),
                                 ).toU32());
                                 // adr x28, #8
                                 mem.writeIntLittle(u32, try self.code.addManyAsArray(4), Instruction.adr(.x28, 8).toU32());
@@ -2795,8 +2794,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                     .x0,
                                     .x28,
                                     Register.sp,
-                                    16,
-                                    .PostIndex,
+                                    Instruction.LoadStorePairOffset.post_index(16),
                                 ).toU32());
                             }
                         } else {


### PR DESCRIPTION
This PR adds `stp`,`stnp`, `ldp` and `ldnp` instruction wrappers for `aarch64`. As a result, we can clean up slightly the codegen for PIE jumps since with these instructions we can simultaneously store and load pairs of pointers. Namely, instead of doing:

```
str x0, [sp], #-16
str x28, [sp], #-16
...
ldr x28, [sp, #16]!
ldr x0, [sp, #16]!
```

we can simply do:

```
stp x0, x28, [sp], #-16
...
ldp x0, x28, [sp, #16]!
```

 I've also made naming for the `Instruction.Offset` more explicit (now renamed to `Instruction.LoadStoreOffset`) so that it is disambiguated from `Instruction.LoadStorePairOffset` which doesn't encode in the same way.