### PR TITLE
Add io_uring TIMEOUT and TIMEOUT_REMOVE operations:

### DIFF
--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -1379,6 +1379,9 @@ test "timeout_remove" {
     if (cqe_timeout.user_data == 0x99999999 and cqe_timeout.res == -linux.EINVAL) {
         return error.SkipZigTest;
     }
+    if (cqe_timeout.user_data == 0x99999999) {
+        std.debug.print("unexpected cqe={}\n", .{ cqe_timeout });
+    }
     testing.expectEqual(linux.io_uring_cqe{
         .user_data = 0x88888888,
         .res = -linux.ECANCELED,


### PR DESCRIPTION
ring.timeout() to queue a IORING_OP_TIMEOUT operation
ring.timeout_remove() to queue a IORING_OP_TIMEOUT_REMOVE operation

io_uring_prep_timeout() to prep a IORING_OP_TIMEOUT sqe
io_uring_prep_timeout_remove() to prep a IORING_OP_TIMEOUT_REMOVE sqe