### PR TITLE
Fix `std.os.windows.GetFinalPathNameByHandle` for os versions before `win10_rs4`

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2402,3 +2402,46 @@ test "freeing empty string with null-terminated sentinel" {
     const empty_string = try dupeZ(testing.allocator, u8, "");
     testing.allocator.free(empty_string);
 }
+
+/// Returns a slice with the given new alignment,
+/// all other pointer attributes copied from `AttributeSource`.
+fn AlignedSlice(comptime AttributeSource: type, comptime new_alignment: u29) type {
+    const info = @typeInfo(AttributeSource).Pointer;
+    return @Type(.{
+        .Pointer = .{
+            .size = .Slice,
+            .is_const = info.is_const,
+            .is_volatile = info.is_volatile,
+            .is_allowzero = info.is_allowzero,
+            .alignment = new_alignment,
+            .child = info.child,
+            .sentinel = null,
+        },
+    });
+}
+
+/// Returns the largest slice in the given bytes that conforms to the new alignment,
+/// or `null` if the given bytes contain no conforming address.
+pub fn alignInBytes(bytes: []u8, comptime new_alignment: usize) ?[]align(new_alignment) u8 {
+    const begin_address = @ptrToInt(bytes.ptr);
+    const end_address = begin_address + bytes.len;
+
+    const begin_address_aligned = mem.alignForward(begin_address, new_alignment);
+    const new_length = std.math.sub(usize, end_address, begin_address_aligned) catch |e| switch (e) {
+        error.Overflow => return null,
+    };
+    const alignment_offset = begin_address_aligned - begin_address;
+    return @alignCast(new_alignment, bytes[alignment_offset .. alignment_offset + new_length]);
+}
+
+/// Returns the largest sub-slice within the given slice that conforms to the new alignment,
+/// or `null` if the given slice contains no conforming address.
+pub fn alignInSlice(slice: anytype, comptime new_alignment: usize) ?AlignedSlice(@TypeOf(slice), new_alignment) {
+    const bytes = sliceAsBytes(slice);
+    const aligned_bytes = alignInBytes(bytes, new_alignment) orelse return null;
+
+    const Element = @TypeOf(slice[0]);
+    const slice_length_bytes = aligned_bytes.len - (aligned_bytes.len % @sizeOf(Element));
+    const aligned_slice = bytesAsSlice(Element, aligned_bytes[0..slice_length_bytes]);
+    return @alignCast(new_alignment, aligned_slice);
+}

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -28,10 +28,6 @@ pub const gdi32 = @import("windows/gdi32.zig");
 
 pub usingnamespace @import("windows/bits.zig");
 
-//version detection
-const version = std.zig.system.windows;
-const WindowsVersion = version.WindowsVersion;
-
 pub const self_process_handle = @intToPtr(HANDLE, maxInt(usize));
 
 pub const OpenError = error{
@@ -1033,65 +1029,35 @@ pub fn GetFinalPathNameByHandle(
     out_buffer: []u16,
 ) GetFinalPathNameByHandleError![]u16 {
     var path_buffer: [math.max(@sizeOf(FILE_NAME_INFORMATION), @sizeOf(OBJECT_NAME_INFORMATION)) + PATH_MAX_WIDE * 2]u8 align(@alignOf(FILE_NAME_INFORMATION)) = undefined;
-    var volume_buffer: [@sizeOf(FILE_NAME_INFORMATION) + MAX_PATH]u8 align(@alignOf(FILE_NAME_INFORMATION)) = undefined; // MAX_PATH bytes should be enough since it's Windows-defined name
+    const final_path = QueryObjectName(hFile, mem.bytesAsSlice(u16, &path_buffer)) catch |err| switch (err) {
+        // we assume InvalidHandle is close enough to FileNotFound in semantics
+        // to not further complicate the error set
+        error.InvalidHandle => return error.FileNotFound,
+        else => |e| return e,
+    };
 
-    var file_name_u16: []const u16 = undefined;
-    var volume_name_u16: []const u16 = undefined;
-    if ((comptime (std.builtin.os.version_range.windows.isAtLeast(WindowsVersion.win10_rs4) != true)) and !version.detectRuntimeVersion().isAtLeast(WindowsVersion.win10_rs4)) {
-        const final_path = QueryObjectName(hFile, mem.bytesAsSlice(u16, &path_buffer)) catch |err| return switch (err) {
-            // we assume InvalidHandle is close enough to FileNotFound in semantics
-            // to not further complicate the error set
-            error.InvalidHandle => error.FileNotFound,
-            else => |e| e,
-        };
-
-        if (fmt.volume_name == .Nt) {
+    switch (fmt.volume_name) {
+        .Nt => {
+            // the returned path is already in .Nt format
             if (out_buffer.len < final_path.len) {
                 return error.NameTooLong;
             }
             mem.copy(u16, out_buffer, final_path);
             return out_buffer[0..final_path.len];
-        }
-
-        //otherwise we need to parse the string for volume path for the .Dos logic below to work
-        const expected_prefix = std.unicode.utf8ToUtf16LeStringLiteral("\\Device\\");
-
-        // TODO find out if a path can start with something besides `\Device\<volume name>`,
-        // and if we need to handle it differently
-        // (i.e. how to determine the start and end of the volume name in that case)
-        if (!mem.eql(u16, expected_prefix, final_path[0..expected_prefix.len])) return error.Unexpected;
-
-        const index = mem.indexOfPos(u16, final_path, expected_prefix.len, &[_]u16{'\\'}) orelse unreachable;
-        volume_name_u16 = final_path[0..index];
-        file_name_u16 = final_path[index..];
-
-        //fallthrough for fmt.volume_name != .Nt
-    } else {
-        // Get normalized path; doesn't include volume name though.
-        try QueryInformationFile(hFile, .FileNormalizedNameInformation, &path_buffer);
-        const file_name = @ptrCast(*const FILE_NAME_INFORMATION, &path_buffer);
-        file_name_u16 = @ptrCast([*]const u16, &file_name.FileName)[0..@divExact(file_name.FileNameLength, 2)];
-
-        // Get NT volume name.
-        try QueryInformationFile(hFile, .FileVolumeNameInformation, &volume_buffer);
-        const volume_name_info = @ptrCast(*const FILE_NAME_INFORMATION, &volume_buffer);
-        volume_name_u16 = @ptrCast([*]const u16, &volume_name_info.FileName)[0..@divExact(volume_name_info.FileNameLength, 2)];
-
-        if (fmt.volume_name == .Nt) {
-            // Nothing to do, we simply copy the bytes to the user-provided buffer.
-            if (out_buffer.len < volume_name_u16.len + file_name_u16.len) return error.NameTooLong;
-
-            mem.copy(u16, out_buffer, volume_name_u16);
-            mem.copy(u16, out_buffer[volume_name_u16.len..], file_name_u16);
-
-            return out_buffer[0 .. volume_name_u16.len + file_name_u16.len];
-        }
-        //fallthrough for fmt.volume_name != .Nt
-    }
-
-    switch (fmt.volume_name) {
-        .Nt => unreachable, //handled above
+        },
         .Dos => {
+            // parse the string to separate volume path from file path
+            const expected_prefix = std.unicode.utf8ToUtf16LeStringLiteral("\\Device\\");
+
+            // TODO find out if a path can start with something besides `\Device\<volume name>`,
+            // and if we need to handle it differently
+            // (i.e. how to determine the start and end of the volume name in that case)
+            if (!mem.eql(u16, expected_prefix, final_path[0..expected_prefix.len])) return error.Unexpected;
+
+            const file_path_begin_index = mem.indexOfPos(u16, final_path, expected_prefix.len, &[_]u16{'\\'}) orelse unreachable;
+            const volume_name_u16 = final_path[0..file_path_begin_index];
+            const file_name_u16 = final_path[file_path_begin_index..];
+
             // Get DOS volume name. DOS volume names are actually symbolic link objects to the
             // actual NT volume. For example:
             // (NT) \Device\HarddiskVolume4 => (DOS) \DosDevices\C: == (DOS) C:

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -956,29 +956,29 @@ pub fn QueryObjectName(
     handle: HANDLE,
     out_buffer: []u16,
 ) ![]u16 {
-    var full_buffer: [@sizeOf(OBJECT_NAME_INFORMATION) + PATH_MAX_WIDE * 2]u8 align(@alignOf(OBJECT_NAME_INFORMATION)) = undefined;
-    var info = @ptrCast(*OBJECT_NAME_INFORMATION, &full_buffer);
+    const out_buffer_aligned = mem.alignInSlice(out_buffer, @alignOf(OBJECT_NAME_INFORMATION)) orelse return error.NameTooLong;
+
+    const info = @ptrCast(*OBJECT_NAME_INFORMATION, out_buffer_aligned);
     //buffer size is specified in bytes
+    const out_buffer_len = std.math.cast(ULONG, out_buffer_aligned.len * 2) catch |e| switch (e) {
+        error.Overflow => std.math.maxInt(ULONG),
+    };
     //last argument would return the length required for full_buffer, not exposed here
-    const rc = ntdll.NtQueryObject(handle, .ObjectNameInformation, &full_buffer, full_buffer.len, null);
+    const rc = ntdll.NtQueryObject(handle, .ObjectNameInformation, info, out_buffer_len, null);
     switch (rc) {
         .SUCCESS => {
             // info.Name.Buffer from ObQueryNameString is documented to be null (and MaximumLength == 0)
             // if the object was "unnamed", not sure if this can happen for file handles
             if (info.Name.MaximumLength == 0) return error.Unexpected;
-            //resulting string length is specified in bytes
+            // resulting string length is specified in bytes
             const path_length_unterminated = @divExact(info.Name.Length, 2);
-            if (out_buffer.len < path_length_unterminated) {
-                return error.NameTooLong;
-            }
-            mem.copy(WCHAR, out_buffer[0..path_length_unterminated], info.Name.Buffer[0..path_length_unterminated]);
-            return out_buffer[0..path_length_unterminated];
+            return info.Name.Buffer[0..path_length_unterminated];
         },
         .ACCESS_DENIED => return error.AccessDenied,
         .INVALID_HANDLE => return error.InvalidHandle,
-        .BUFFER_OVERFLOW, .BUFFER_TOO_SMALL => return error.NameTooLong,
-        //name_buffer.len >= @sizeOf(OBJECT_NAME_INFORMATION) holds statically
-        .INFO_LENGTH_MISMATCH => unreachable,
+        // triggered when the buffer is too small for the OBJECT_NAME_INFORMATION object (.INFO_LENGTH_MISMATCH),
+        // or if the buffer is too small for the file path returned (.BUFFER_OVERFLOW, .BUFFER_TOO_SMALL)
+        .INFO_LENGTH_MISMATCH, .BUFFER_OVERFLOW, .BUFFER_TOO_SMALL => return error.NameTooLong,
         else => |e| return unexpectedStatus(e),
     }
 }
@@ -993,10 +993,11 @@ test "QueryObjectName" {
     var out_buffer: [PATH_MAX_WIDE]u16 = undefined;
 
     var result_path = try QueryObjectName(handle, &out_buffer);
+    const required_len_in_u16 = result_path.len + @divExact(@ptrToInt(result_path.ptr) - @ptrToInt(&out_buffer), 2) + 1;
     //insufficient size
-    std.testing.expectError(error.NameTooLong, QueryObjectName(handle, out_buffer[0 .. result_path.len - 1]));
+    std.testing.expectError(error.NameTooLong, QueryObjectName(handle, out_buffer[0 .. required_len_in_u16 - 1]));
     //exactly-sufficient size
-    _ = try QueryObjectName(handle, out_buffer[0..result_path.len]);
+    _ = try QueryObjectName(handle, out_buffer[0..required_len_in_u16]);
 }
 
 pub const GetFinalPathNameByHandleError = error{
@@ -1028,8 +1029,7 @@ pub fn GetFinalPathNameByHandle(
     fmt: GetFinalPathNameByHandleFormat,
     out_buffer: []u16,
 ) GetFinalPathNameByHandleError![]u16 {
-    var path_buffer: [math.max(@sizeOf(FILE_NAME_INFORMATION), @sizeOf(OBJECT_NAME_INFORMATION)) + PATH_MAX_WIDE * 2]u8 align(@alignOf(FILE_NAME_INFORMATION)) = undefined;
-    const final_path = QueryObjectName(hFile, mem.bytesAsSlice(u16, &path_buffer)) catch |err| switch (err) {
+    const final_path = QueryObjectName(hFile, out_buffer) catch |err| switch (err) {
         // we assume InvalidHandle is close enough to FileNotFound in semantics
         // to not further complicate the error set
         error.InvalidHandle => return error.FileNotFound,
@@ -1039,11 +1039,7 @@ pub fn GetFinalPathNameByHandle(
     switch (fmt.volume_name) {
         .Nt => {
             // the returned path is already in .Nt format
-            if (out_buffer.len < final_path.len) {
-                return error.NameTooLong;
-            }
-            mem.copy(u16, out_buffer, final_path);
-            return out_buffer[0..final_path.len];
+            return final_path;
         },
         .Dos => {
             // parse the string to separate volume path from file path
@@ -1152,16 +1148,17 @@ test "GetFinalPathNameByHandle" {
     var buffer: [PATH_MAX_WIDE]u16 = undefined;
 
     //check with sufficient size
-    const nt_length = (try GetFinalPathNameByHandle(handle, .{ .volume_name = .Nt }, &buffer)).len;
-    const dos_length = (try GetFinalPathNameByHandle(handle, .{ .volume_name = .Dos }, &buffer)).len;
+    const nt_path = try GetFinalPathNameByHandle(handle, .{ .volume_name = .Nt }, &buffer);
+    _ = try GetFinalPathNameByHandle(handle, .{ .volume_name = .Dos }, &buffer);
 
+    const required_len_in_u16 = nt_path.len + @divExact(@ptrToInt(nt_path.ptr) - @ptrToInt(&buffer), 2) + 1;
     //check with insufficient size
-    std.testing.expectError(error.NameTooLong, GetFinalPathNameByHandle(handle, .{ .volume_name = .Nt }, buffer[0 .. nt_length - 1]));
-    std.testing.expectError(error.NameTooLong, GetFinalPathNameByHandle(handle, .{ .volume_name = .Dos }, buffer[0 .. dos_length - 1]));
+    std.testing.expectError(error.NameTooLong, GetFinalPathNameByHandle(handle, .{ .volume_name = .Nt }, buffer[0 .. required_len_in_u16 - 1]));
+    std.testing.expectError(error.NameTooLong, GetFinalPathNameByHandle(handle, .{ .volume_name = .Dos }, buffer[0 .. required_len_in_u16 - 1]));
 
     //check with exactly-sufficient size
-    _ = try GetFinalPathNameByHandle(handle, .{ .volume_name = .Nt }, buffer[0..nt_length]);
-    _ = try GetFinalPathNameByHandle(handle, .{ .volume_name = .Dos }, buffer[0..dos_length]);
+    _ = try GetFinalPathNameByHandle(handle, .{ .volume_name = .Nt }, buffer[0..required_len_in_u16]);
+    _ = try GetFinalPathNameByHandle(handle, .{ .volume_name = .Dos }, buffer[0..required_len_in_u16]);
 }
 
 pub const QueryInformationFileError = error{Unexpected};

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1000,19 +1000,13 @@ test "QueryObjectName" {
     _ = try QueryObjectName(file.handle, out_buffer[0..result_path.len]);
 }
 
-pub const GetFinalPathNameByHandleError = error {
-        BadPathName,
-        FileNotFound,
-        NameTooLong,
-        Unexpected,
-    }
-    || if((comptime builtin.os.tag != .windows) or (targetVersionIsAtLeast(WindowsVersion.win10_rs4) == true))
-        error {}
-    else
-        error {
-            AccessDenied,
-            SystemResources,
-        };
+pub const GetFinalPathNameByHandleError = error{
+    AccessDenied,
+    BadPathName,
+    FileNotFound,
+    NameTooLong,
+    Unexpected,
+};
 
 /// Specifies how to format volume path in the result of `GetFinalPathNameByHandle`.
 /// Defaults to DOS volume names.
@@ -1035,75 +1029,64 @@ pub fn GetFinalPathNameByHandle(
     fmt: GetFinalPathNameByHandleFormat,
     out_buffer: []u16,
 ) GetFinalPathNameByHandleError![]u16 {
+    var path_buffer: [std.math.max(@sizeOf(FILE_NAME_INFORMATION), @sizeOf(OBJECT_NAME_INFORMATION)) + PATH_MAX_WIDE * 2]u8 align(@alignOf(FILE_NAME_INFORMATION)) = undefined;
+    var volume_buffer: [@sizeOf(FILE_NAME_INFORMATION) + MAX_PATH]u8 align(@alignOf(FILE_NAME_INFORMATION)) = undefined; // MAX_PATH bytes should be enough since it's Windows-defined name
 
-    var path_buffer: [@sizeOf(FILE_NAME_INFORMATION) + PATH_MAX_WIDE * 2]u8 align(@alignOf(FILE_NAME_INFORMATION)) = undefined;
-
+    var file_name_u16: []const u16 = undefined;
+    var volume_name_u16: []const u16 = undefined;
     if ((comptime (targetVersionIsAtLeast(WindowsVersion.win10_rs4) != true)) //need explicit comptime, because error returns affect return type
-       and !runtimeVersionIsAtLeast(WindowsVersion.win10_rs4)) {
-        // TODO: directly replace/emulate QueryInformationFile of .FileNormalizedNameInformation
-        // with ntdll instead of calling into kernel32
-        // (probably using some less-powerful query and looping over path segments)
-        const flags: DWORD = FILE_NAME_NORMALIZED | switch(fmt.volume_name) {
-            .Dos => @as(DWORD, VOLUME_NAME_DOS),
-            .Nt => @as(DWORD, VOLUME_NAME_NT),
+        and !runtimeVersionIsAtLeast(WindowsVersion.win10_rs4))
+    {
+        const final_path = QueryObjectName(hFile, std.mem.bytesAsSlice(u16, path_buffer[0..])) catch |err| return switch (err) {
+            error.InvalidHandle => error.FileNotFound, //close enough?
+            else => |e| e,
         };
-        const wide_path_buffer = std.mem.bytesAsSlice(u16, path_buffer[0..]);
-        const rc = kernel32.GetFinalPathNameByHandleW(hFile, wide_path_buffer.ptr, @intCast(u32, wide_path_buffer.len), flags);
-        if (rc == 0) {
-            switch (kernel32.GetLastError()) {
-                .FILE_NOT_FOUND => return error.FileNotFound,
-                .PATH_NOT_FOUND => return error.FileNotFound,
-                .NOT_ENOUGH_MEMORY => return error.SystemResources,
-                .FILENAME_EXCED_RANGE => return error.NameTooLong,
-                .ACCESS_DENIED => return error.AccessDenied, //can happen in SMB sub-queries for parent path segments
-                .INVALID_PARAMETER => unreachable,
-                else => |err| return unexpectedError(err),
+
+        if (fmt.volume_name == .Nt) {
+            if (out_buffer.len < final_path.len) {
+                return error.NameTooLong;
             }
+            std.mem.copy(u16, out_buffer[0..], final_path[0..]);
+            return final_path; //we can directly return the slice we received
         }
 
-        //in case of failure, rc == length of string INCLUDING null terminator,
-        if (rc > wide_path_buffer.len) return error.NameTooLong;
-        //in case of success, rc == length of string EXCLUDING null terminator
-        const result_slice = switch(fmt.volume_name) {
-            .Dos => blk: {
-                const expected_prefix = [_]u16{'\\', '\\', '?', '\\'};
-                if (!std.mem.eql(u16, expected_prefix[0..], wide_path_buffer[0..expected_prefix.len])) {
-                    return error.BadPathName;
-                }
-                break :blk wide_path_buffer[expected_prefix.len..rc:0];
-            },
-            //no prefix here
-            .Nt => wide_path_buffer[0..rc:0],
-        };
-        if(result_slice.len > out_buffer.len) return error.NameTooLong;
-        std.mem.copy(u16, out_buffer[0..], result_slice);
-        return out_buffer[0..result_slice.len];
-    }
+        //otherwise we need to parse the string for volume path for the .Dos logic below to work
+        const expected_prefix = std.unicode.utf8ToUtf16LeStringLiteral("\\Device\\");
+        if (!std.mem.eql(u16, expected_prefix, final_path[0..expected_prefix.len])) {
+            //TODO find out if this can occur, and if we need to handle it differently
+            //(i.e. how to determine the end of a volume name)
+            return error.BadPathName;
+        }
+        const index = std.mem.indexOfPos(u16, final_path, expected_prefix.len, &[_]u16{'\\'}) orelse unreachable;
+        volume_name_u16 = final_path[0..index];
+        file_name_u16 = final_path[index..];
 
-    // Get normalized path; doesn't include volume name though.
-    try QueryInformationFile(hFile, .FileNormalizedNameInformation, path_buffer[0..]);
+        //fallthrough for fmt.volume_name != .Nt
+    } else {
+        // Get normalized path; doesn't include volume name though.
+        try QueryInformationFile(hFile, .FileNormalizedNameInformation, path_buffer[0..]);
+        const file_name = @ptrCast(*const FILE_NAME_INFORMATION, &path_buffer[0]);
+        file_name_u16 = @ptrCast([*]const u16, &file_name.FileName[0])[0..@divExact(file_name.FileNameLength, 2)];
 
-    // Get NT volume name.
-    var volume_buffer: [@sizeOf(FILE_NAME_INFORMATION) + MAX_PATH]u8 align(@alignOf(FILE_NAME_INFORMATION)) = undefined; // MAX_PATH bytes should be enough since it's Windows-defined name
-    try QueryInformationFile(hFile, .FileVolumeNameInformation, volume_buffer[0..]);
+        // Get NT volume name.
+        try QueryInformationFile(hFile, .FileVolumeNameInformation, volume_buffer[0..]);
+        const volume_name_info = @ptrCast(*const FILE_NAME_INFORMATION, &volume_buffer[0]);
+        volume_name_u16 = @ptrCast([*]const u16, &volume_name_info.FileName[0])[0..@divExact(volume_name_info.FileNameLength, 2)];
 
-    const file_name = @ptrCast(*const FILE_NAME_INFORMATION, &path_buffer[0]);
-    const file_name_u16 = @ptrCast([*]const u16, &file_name.FileName[0])[0 .. file_name.FileNameLength / 2];
-
-    const volume_name = @ptrCast(*const FILE_NAME_INFORMATION, &volume_buffer[0]);
-
-    switch (fmt.volume_name) {
-        .Nt => {
+        if (fmt.volume_name == .Nt) {
             // Nothing to do, we simply copy the bytes to the user-provided buffer.
-            const volume_name_u16 = @ptrCast([*]const u16, &volume_name.FileName[0])[0 .. volume_name.FileNameLength / 2];
-
             if (out_buffer.len < volume_name_u16.len + file_name_u16.len) return error.NameTooLong;
 
             std.mem.copy(u16, out_buffer[0..], volume_name_u16);
             std.mem.copy(u16, out_buffer[volume_name_u16.len..], file_name_u16);
 
             return out_buffer[0 .. volume_name_u16.len + file_name_u16.len];
-        },
+        }
+        //fallthrough for fmt.volume_name != .Nt
+    }
+
+    switch (fmt.volume_name) {
+        .Nt => unreachable, //handled above
         .Dos => {
             // Get DOS volume name. DOS volume names are actually symbolic link objects to the
             // actual NT volume. For example:
@@ -1137,8 +1120,8 @@ pub fn GetFinalPathNameByHandle(
 
             var input_struct = @ptrCast(*MOUNTMGR_MOUNT_POINT, &input_buf[0]);
             input_struct.DeviceNameOffset = @sizeOf(MOUNTMGR_MOUNT_POINT);
-            input_struct.DeviceNameLength = @intCast(USHORT, volume_name.FileNameLength);
-            @memcpy(input_buf[@sizeOf(MOUNTMGR_MOUNT_POINT)..], @ptrCast([*]const u8, &volume_name.FileName[0]), volume_name.FileNameLength);
+            input_struct.DeviceNameLength = @intCast(USHORT, volume_name_u16.len * 2);
+            @memcpy(input_buf[@sizeOf(MOUNTMGR_MOUNT_POINT)..], @ptrCast([*]const u8, volume_name_u16.ptr), volume_name_u16.len * 2);
 
             DeviceIoControl(mgmt_handle, IOCTL_MOUNTMGR_QUERY_POINTS, input_buf[0..], output_buf[0..]) catch |err| switch (err) {
                 error.AccessDenied => unreachable,

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -28,6 +28,9 @@ pub const gdi32 = @import("windows/gdi32.zig");
 
 pub usingnamespace @import("windows/bits.zig");
 
+//version detection
+usingnamespace std.zig.system.windows;
+
 pub const self_process_handle = @intToPtr(HANDLE, maxInt(usize));
 
 pub const OpenError = error{
@@ -952,12 +955,19 @@ pub fn SetFilePointerEx_CURRENT_get(handle: HANDLE) SetFilePointerError!u64 {
     return @bitCast(u64, result);
 }
 
-pub const GetFinalPathNameByHandleError = error{
-    BadPathName,
-    FileNotFound,
-    NameTooLong,
-    Unexpected,
-};
+pub const GetFinalPathNameByHandleError = error {
+        BadPathName,
+        FileNotFound,
+        NameTooLong,
+        Unexpected,
+    }
+    || if((comptime builtin.os.tag != .windows) or (targetVersionIsAtLeast(WindowsVersion.win10_rs4) == true))
+        error {}
+    else
+        error {
+            AccessDenied,
+            SystemResources,
+        };
 
 /// Specifies how to format volume path in the result of `GetFinalPathNameByHandle`.
 /// Defaults to DOS volume names.
@@ -980,8 +990,52 @@ pub fn GetFinalPathNameByHandle(
     fmt: GetFinalPathNameByHandleFormat,
     out_buffer: []u16,
 ) GetFinalPathNameByHandleError![]u16 {
-    // Get normalized path; doesn't include volume name though.
+
     var path_buffer: [@sizeOf(FILE_NAME_INFORMATION) + PATH_MAX_WIDE * 2]u8 align(@alignOf(FILE_NAME_INFORMATION)) = undefined;
+
+    if ((comptime (targetVersionIsAtLeast(WindowsVersion.win10_rs4) != true)) //need explicit comptime, because error returns affect return type
+       and !runtimeVersionIsAtLeast(WindowsVersion.win10_rs4)) {
+        // TODO: directly replace/emulate QueryInformationFile of .FileNormalizedNameInformation
+        // with ntdll instead of calling into kernel32
+        // (probably using some less-powerful query and looping over path segments)
+        const flags: DWORD = FILE_NAME_NORMALIZED | switch(fmt.volume_name) {
+            .Dos => @as(DWORD, VOLUME_NAME_DOS),
+            .Nt => @as(DWORD, VOLUME_NAME_NT),
+        };
+        const wide_path_buffer = std.mem.bytesAsSlice(u16, path_buffer[0..]);
+        const rc = kernel32.GetFinalPathNameByHandleW(hFile, wide_path_buffer.ptr, @intCast(u32, wide_path_buffer.len), flags);
+        if (rc == 0) {
+            switch (kernel32.GetLastError()) {
+                .FILE_NOT_FOUND => return error.FileNotFound,
+                .PATH_NOT_FOUND => return error.FileNotFound,
+                .NOT_ENOUGH_MEMORY => return error.SystemResources,
+                .FILENAME_EXCED_RANGE => return error.NameTooLong,
+                .ACCESS_DENIED => return error.AccessDenied, //can happen in SMB sub-queries for parent path segments
+                .INVALID_PARAMETER => unreachable,
+                else => |err| return unexpectedError(err),
+            }
+        }
+
+        //in case of failure, rc == length of string INCLUDING null terminator,
+        if (rc > wide_path_buffer.len) return error.NameTooLong;
+        //in case of success, rc == length of string EXCLUDING null terminator
+        const result_slice = switch(fmt.volume_name) {
+            .Dos => blk: {
+                const expected_prefix = [_]u16{'\\', '\\', '?', '\\'};
+                if (!std.mem.eql(u16, expected_prefix[0..], wide_path_buffer[0..expected_prefix.len])) {
+                    return error.BadPathName;
+                }
+                break :blk wide_path_buffer[expected_prefix.len..rc:0];
+            },
+            //no prefix here
+            .Nt => wide_path_buffer[0..rc:0],
+        };
+        if(result_slice.len > out_buffer.len) return error.NameTooLong;
+        std.mem.copy(u16, out_buffer[0..], result_slice);
+        return out_buffer[0..result_slice.len];
+    }
+
+    // Get normalized path; doesn't include volume name though.
     try QueryInformationFile(hFile, .FileNormalizedNameInformation, path_buffer[0..]);
 
     // Get NT volume name.

--- a/lib/std/os/windows/bits.zig
+++ b/lib/std/os/windows/bits.zig
@@ -65,6 +65,7 @@ pub const SIZE_T = usize;
 pub const TCHAR = if (UNICODE) WCHAR else u8;
 pub const UINT = c_uint;
 pub const ULONG_PTR = usize;
+pub const PULONG = *ULONG;
 pub const LONG_PTR = isize;
 pub const DWORD_PTR = ULONG_PTR;
 pub const UNICODE = false;
@@ -1606,3 +1607,18 @@ pub const IOCTL_MOUNTMGR_QUERY_POINTS: ULONG = 0x6d0008;
 pub const SD_RECEIVE = 0;
 pub const SD_SEND = 1;
 pub const SD_BOTH = 2;
+
+pub const OBJECT_INFORMATION_CLASS = extern enum {
+    ObjectBasicInformation = 0,
+    ObjectNameInformation = 1,
+    ObjectTypeInformation = 2,
+    ObjectTypesInformation = 3,
+    ObjectHandleFlagInformation = 4,
+    ObjectSessionInformation = 5,
+    MaxObjectInfoClass,
+};
+
+pub const OBJECT_NAME_INFORMATION = extern struct {
+    Name: UNICODE_STRING,
+};
+pub const POBJECT_NAME_INFORMATION = *OBJECT_NAME_INFORMATION;

--- a/lib/std/os/windows/bits.zig
+++ b/lib/std/os/windows/bits.zig
@@ -65,7 +65,6 @@ pub const SIZE_T = usize;
 pub const TCHAR = if (UNICODE) WCHAR else u8;
 pub const UINT = c_uint;
 pub const ULONG_PTR = usize;
-pub const PULONG = *ULONG;
 pub const LONG_PTR = isize;
 pub const DWORD_PTR = ULONG_PTR;
 pub const UNICODE = false;

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -119,5 +119,5 @@ pub extern "NtDll" fn NtQueryObject(
     ObjectInformationClass: OBJECT_INFORMATION_CLASS,
     ObjectInformation: PVOID,
     ObjectInformationLength: ULONG,
-    ReturnLength: ?PULONG,
+    ReturnLength: ?*ULONG,
 ) callconv(WINAPI) NTSTATUS;

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -113,3 +113,11 @@ pub extern "NtDll" fn NtWaitForKeyedEvent(
 ) callconv(WINAPI) NTSTATUS;
 
 pub extern "NtDll" fn RtlSetCurrentDirectory_U(PathName: *UNICODE_STRING) callconv(WINAPI) NTSTATUS;
+
+pub extern "NtDll" fn NtQueryObject(
+    Handle: HANDLE,
+    ObjectInformationClass: OBJECT_INFORMATION_CLASS,
+    ObjectInformation: PVOID,
+    ObjectInformationLength: ULONG,
+    ReturnLength: ?PULONG,
+) callconv(WINAPI) NTSTATUS;

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -109,6 +109,20 @@ pub const Target = struct {
             /// Latest Windows version that the Zig Standard Library is aware of
             pub const latest = WindowsVersion.win10_20h1;
 
+            /// Compared against build numbers reported by the runtime to distinguish win10 versions,
+            /// where 0x0A000000 + index corresponds to the WindowsVersion u32 value.
+            pub const known_win10_build_numbers = [_]u32{
+                10240, //win10
+                10586, //win10_th2
+                14393, //win_rs1
+                15063, //win_rs2
+                16299, //win_rs3
+                17134, //win_rs4
+                17763, //win_rs5
+                18362, //win_19h1
+                19041, //win_20h1
+            };
+
             pub const Range = struct {
                 min: WindowsVersion,
                 max: WindowsVersion,

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -95,7 +95,7 @@ pub const Target = struct {
             win7 = 0x06010000,
             win8 = 0x06020000,
             win8_1 = 0x06030000,
-            win10 = 0x0A000000,
+            win10 = 0x0A000000, //aka win10_th1
             win10_th2 = 0x0A000001,
             win10_rs1 = 0x0A000002,
             win10_rs2 = 0x0A000003,
@@ -103,25 +103,34 @@ pub const Target = struct {
             win10_rs4 = 0x0A000005,
             win10_rs5 = 0x0A000006,
             win10_19h1 = 0x0A000007,
-            win10_20h1 = 0x0A000008,
+            win10_vb = 0x0A000008, //aka win10_19h2
+            win10_mn = 0x0A000009, //aka win10_20h1
+            win10_fe = 0x0A00000A, //aka win10_20h2
             _,
 
             /// Latest Windows version that the Zig Standard Library is aware of
-            pub const latest = WindowsVersion.win10_20h1;
+            pub const latest = WindowsVersion.win10_fe;
 
             /// Compared against build numbers reported by the runtime to distinguish win10 versions,
             /// where 0x0A000000 + index corresponds to the WindowsVersion u32 value.
             pub const known_win10_build_numbers = [_]u32{
-                10240, //win10
+                10240, //win10 aka win10_th1
                 10586, //win10_th2
-                14393, //win_rs1
-                15063, //win_rs2
-                16299, //win_rs3
-                17134, //win_rs4
-                17763, //win_rs5
-                18362, //win_19h1
-                19041, //win_20h1
+                14393, //win10_rs1
+                15063, //win10_rs2
+                16299, //win10_rs3
+                17134, //win10_rs4
+                17763, //win10_rs5
+                18362, //win10_19h1
+                18363, //win10_vb aka win10_19h2
+                19041, //win10_mn aka win10_20h1
+                19042, //win10_fe aka win10_20h2
             };
+
+            /// Returns whether the first version `self` is newer (greater) than or equal to the second version `ver`.
+            pub fn isAtLeast(self: WindowsVersion, ver: WindowsVersion) bool {
+                return @enumToInt(self) >= @enumToInt(ver);
+            }
 
             pub const Range = struct {
                 min: WindowsVersion,

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -14,6 +14,7 @@ const process = std.process;
 const Target = std.Target;
 const CrossTarget = std.zig.CrossTarget;
 const macos = @import("system/macos.zig");
+pub const windows = @import("system/windows.zig");
 
 const is_windows = Target.current.os.tag == .windows;
 
@@ -223,44 +224,9 @@ pub const NativeTargetInfo = struct {
                     }
                 },
                 .windows => {
-                    var version_info: std.os.windows.RTL_OSVERSIONINFOW = undefined;
-                    version_info.dwOSVersionInfoSize = @sizeOf(@TypeOf(version_info));
-
-                    switch (std.os.windows.ntdll.RtlGetVersion(&version_info)) {
-                        .SUCCESS => {},
-                        else => unreachable,
-                    }
-
-                    // Starting from the system infos build a NTDDI-like version
-                    // constant whose format is:
-                    //   B0 B1 B2 B3
-                    //   `---` `` ``--> Sub-version (Starting from Windows 10 onwards)
-                    //     \    `--> Service pack (Always zero in the constants defined)
-                    //      `--> OS version (Major & minor)
-                    const os_ver: u16 =
-                        @intCast(u16, version_info.dwMajorVersion & 0xff) << 8 |
-                        @intCast(u16, version_info.dwMinorVersion & 0xff);
-                    const sp_ver: u8 = 0;
-                    const sub_ver: u8 = if (os_ver >= 0x0A00) subver: {
-                        // There's no other way to obtain this info beside
-                        // checking the build number against a known set of
-                        // values
-                        const known_build_numbers = [_]u32{
-                            10240, 10586, 14393, 15063, 16299, 17134, 17763,
-                            18362, 19041,
-                        };
-                        var last_idx: usize = 0;
-                        for (known_build_numbers) |build, i| {
-                            if (version_info.dwBuildNumber >= build)
-                                last_idx = i;
-                        }
-                        break :subver @truncate(u8, last_idx);
-                    } else 0;
-
-                    const version: u32 = @as(u32, os_ver) << 16 | @as(u32, sp_ver) << 8 | sub_ver;
-
-                    os.version_range.windows.max = @intToEnum(Target.Os.WindowsVersion, version);
-                    os.version_range.windows.min = @intToEnum(Target.Os.WindowsVersion, version);
+                    const detected_version = windows.detectRuntimeVersion();
+                    os.version_range.windows.min = detected_version;
+                    os.version_range.windows.max = detected_version;
                 },
                 .macos => {
                     var scbuf: [32]u8 = undefined;

--- a/lib/std/zig/system/windows.zig
+++ b/lib/std/zig/system/windows.zig
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2015-2020 Zig Contributors
+// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
+// The MIT license requires this copyright notice to be included in all copies
+// and substantial portions of the software.
+const std = @import("std");
+
+pub const WindowsVersion = std.Target.Os.WindowsVersion;
+
+/// Returns the highest known WindowsVersion deduced from reported runtime information.
+/// Discards information about in-between versions we don't differentiate.
+pub fn detectRuntimeVersion() WindowsVersion {
+    var version_info: std.os.windows.RTL_OSVERSIONINFOW = undefined;
+    version_info.dwOSVersionInfoSize = @sizeOf(@TypeOf(version_info));
+
+    switch (std.os.windows.ntdll.RtlGetVersion(&version_info)) {
+        .SUCCESS => {},
+        else => unreachable,
+    }
+
+    // Starting from the system infos build a NTDDI-like version
+    // constant whose format is:
+    //   B0 B1 B2 B3
+    //   `---` `` ``--> Sub-version (Starting from Windows 10 onwards)
+    //     \    `--> Service pack (Always zero in the constants defined)
+    //      `--> OS version (Major & minor)
+    const os_ver: u16 = @intCast(u16, version_info.dwMajorVersion & 0xff) << 8 |
+        @intCast(u16, version_info.dwMinorVersion & 0xff);
+    const sp_ver: u8 = 0;
+    const sub_ver: u8 = if (os_ver >= 0x0A00) subver: {
+        // There's no other way to obtain this info beside
+        // checking the build number against a known set of
+        // values
+        var last_idx: usize = 0;
+        for (WindowsVersion.known_win10_build_numbers) |build, i| {
+            if (version_info.dwBuildNumber >= build)
+                last_idx = i;
+        }
+        break :subver @truncate(u8, last_idx);
+    } else 0;
+
+    const version: u32 = @as(u32, os_ver) << 16 | @as(u16, sp_ver) << 8 | sub_ver;
+
+    return @intToEnum(WindowsVersion, version);
+}

--- a/lib/std/zig/system/windows.zig
+++ b/lib/std/zig/system/windows.zig
@@ -43,3 +43,19 @@ pub fn detectRuntimeVersion() WindowsVersion {
 
     return @intToEnum(WindowsVersion, version);
 }
+
+/// Returns whether the target os versions are uniformly at least as new as the argument:
+/// true/false if this holds for the entire target range, null if it only holds for some.
+pub fn targetVersionIsAtLeast(requested_version: WindowsVersion) ?bool {
+    const requested = @enumToInt(requested_version);
+    const version_range = std.builtin.os.version_range.windows;
+    const target_min = @enumToInt(version_range.min);
+    const target_max = @enumToInt(version_range.max);
+    return if (target_max < requested) false else if (target_min >= requested) true else null;
+}
+
+/// Returns whether the runtime os version is at least as new as the argument.
+pub fn runtimeVersionIsAtLeast(requested_version: WindowsVersion) bool {
+    return targetVersionIsAtLeast(requested_version) orelse
+        (@enumToInt(detectRuntimeVersion()) >= @enumToInt(requested_version));
+}

--- a/lib/std/zig/system/windows.zig
+++ b/lib/std/zig/system/windows.zig
@@ -43,19 +43,3 @@ pub fn detectRuntimeVersion() WindowsVersion {
 
     return @intToEnum(WindowsVersion, version);
 }
-
-/// Returns whether the target os versions are uniformly at least as new as the argument:
-/// true/false if this holds for the entire target range, null if it only holds for some.
-pub fn targetVersionIsAtLeast(requested_version: WindowsVersion) ?bool {
-    const requested = @enumToInt(requested_version);
-    const version_range = std.builtin.os.version_range.windows;
-    const target_min = @enumToInt(version_range.min);
-    const target_max = @enumToInt(version_range.max);
-    return if (target_max < requested) false else if (target_min >= requested) true else null;
-}
-
-/// Returns whether the runtime os version is at least as new as the argument.
-pub fn runtimeVersionIsAtLeast(requested_version: WindowsVersion) bool {
-    return targetVersionIsAtLeast(requested_version) orelse
-        (@enumToInt(detectRuntimeVersion()) >= @enumToInt(requested_version));
-}


### PR DESCRIPTION
This PR fixes `std.os.windows.GetFinalPathNameByHandle` for older Windows versions, unblocking #7242 (although that might be an ongoing effort, so shouldn't be closed yet I think).

#5993 removed the codepath that called the `kernel32.dll` implementation. According to [some document I found](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/efbfe127-73ad-4140-9967-ec6500e66d5e), the new `.FileNormalizedNameInformation` query value was only added as recently as 2018 (not even 3 years ago), meaning we dropped support for more than just Windows 7.

Originally I just wanted to query the runtime OS version and reintroduce the old codepath, but then I tried the [prophesized `NtQueryObject` function](https://github.com/ziglang/zig/pull/5993#issuecomment-693209192), and that ended up working too. Note though that it's using an undocumented value (`ObjectNameInformation = 1` appears in `ntifs.h`, but not the documentation) and a `struct` that is named appropriately but also documented somewhere else. And yet, it still works.

_If_ we trust this new implementation, I would be inclined to maybe delete the other codepath (that needs two `ntdll` calls instead of just one) in favor of this one. (And maybe move the logic for finding DOS volume names into its own function.)
But now that I've worked on this for a day, I thought I would ask for some feedback, to make sure I'm not overlooking anything crucial.

Tested (see new tests in std/os/windows.zig) on my Windows 7 and an up-to-date Windows 10 machine. Things I tried with this implementation:
- NTFS junctions are resolved
- Symbolic links are resolved
- Hard links remain separate paths
- Returned paths > 500 characters work without issue

Also let me know if I should squish/reorganize commits in any way, I thought for documentation/discussion (and maybe unexpected troubleshooting) the commits with the kernel32 path were worth keeping for now.