### PR TITLE
zig fmt: Fix alignment of initializer elements

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -286,7 +286,7 @@ test "zig fmt: respect line breaks after var declarations" {
         \\    lookup_tables[6][@truncate(u8, self.crc >> 8)] ^
         \\    lookup_tables[7][@truncate(u8, self.crc >> 0)];
         \\
-    );    
+    );
 }
 
 test "zig fmt: multiline string mixed with comments" {
@@ -558,6 +558,24 @@ test "zig fmt: anon literal in array" {
         \\var arr: [2]Foo = .{
         \\    .{ .a = 2 },
         \\    .{ .b = 3 },
+        \\};
+        \\
+    );
+}
+
+test "zig fmt: alignment in anonymous literal" {
+    try testTransform(
+        \\const a = .{
+        \\    "U",     "L",     "F",
+        \\    "U'",
+        \\    "L'",
+        \\    "F'",
+        \\};
+        \\
+    ,
+        \\const a = .{
+        \\    "U",  "L",  "F",
+        \\    "U'", "L'", "F'",
         \\};
         \\
     );

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -813,12 +813,10 @@ fn renderExpression(
                                     const expr_last_token = expr.*.lastToken() + 1;
                                     const next_expr = section_exprs[i + 1];
                                     const loc = tree.tokenLocation(tree.token_locs[expr_last_token].start, next_expr.*.firstToken());
-                                    if (loc.line == 0) {
-                                        column_counter += 1;
-                                    } else {
-                                        single_line = false;
-                                        column_counter = 0;
-                                    }
+
+                                    column_counter += 1;
+
+                                    if (loc.line != 0) single_line = false;
                                 } else {
                                     single_line = false;
                                     column_counter = 0;
@@ -2655,6 +2653,8 @@ fn copyFixingWhitespace(ais: anytype, slice: []const u8) @TypeOf(ais.*).Error!vo
     };
 }
 
+// Returns the number of nodes in `expr` that are on the same line as `rtoken`,
+// or null if they all are on the same line.
 fn rowSize(tree: *ast.Tree, exprs: []*ast.Node, rtoken: ast.TokenIndex) ?usize {
     const first_token = exprs[0].firstToken();
     const first_loc = tree.tokenLocation(tree.token_locs[first_token].start, rtoken);


### PR DESCRIPTION
Resetting `column_counter` is not needed as the effective column number
is calculated by taking that value modulo `row_size`.

Closes #7289

cc @LakeByTheWoods 