### PR TITLE
Stage 2: Fix c_longdouble abi.

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -1005,7 +1005,7 @@ pub const Type = extern union {
             .f32 => return 4,
             .f64 => return 8,
             .f128 => return 16,
-            .c_longdouble => return 16,
+            .c_longdouble => return @divExact(CType.longdouble.sizeInBits(target), 8),
 
             .error_set,
             .error_set_single,

--- a/src/type.zig
+++ b/src/type.zig
@@ -866,7 +866,7 @@ pub const Type = extern union {
             .f32 => return 4,
             .f64 => return 8,
             .f128 => return 16,
-            .c_longdouble => return 16,
+            .c_longdouble => @panic("TODO figure out what alignment `long double` should have on this target"),
 
             .error_set,
             .error_set_single,


### PR DESCRIPTION
The alignment of ```long double``` is not always 16 bytes, this PR doesn't fix the alignment but replaces it with a panic to prevent future bugs. Same for the size but the panic comes from within ```CType.longdouble.sizeInBits```.

I'm not sure what alignment long double should have even on x86 because it is highly dependent on the compiler.