### PR TITLE
stage2: store Cache files in a map data structure

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1584,7 +1584,7 @@ pub fn cImport(comp: *Compilation, c_src: []const u8) !CImportResult {
     const prev_hash_state = man.hash.peekBin();
     const actual_hit = hit: {
         const is_hit = try man.hit();
-        if (man.files.items.len == 0) {
+        if (man.files.count() == 0) {
             man.unhit(prev_hash_state, 0);
             break :hit false;
         }
@@ -2842,7 +2842,7 @@ fn updateStage1Module(comp: *Compilation, main_progress_node: *std.Progress.Node
 
     // Capture the state in case we come back from this branch where the hash doesn't match.
     const prev_hash_state = man.hash.peekBin();
-    const input_file_count = man.files.items.len;
+    const input_file_count = man.files.count();
 
     if (try man.hit()) {
         const digest = man.final();


### PR DESCRIPTION
Cache now stores files as an StringArrayListHashMap instead of an
ArrayList. The key is the resolved file path, to avoid adding the same
file multiple times into the cache system when it is depended on
multiple times. This avoids re-hashing file contents that have already
been inserted into the cache.

This was an attempt to fix #7308, but it is solving a different problem.
I do think it is worth considering this improvement regardless. On the
other hand, it might be wasted CPU cycles / code bloat since the layer of code above
this one probably wants to do its own de-duplication as well.

This implementation would be much nicer with #7391.