### PR TITLE
stage2: detect redundant C/C++ source files

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -33,6 +33,7 @@ gpa: *Allocator,
 arena_state: std.heap.ArenaAllocator.State,
 bin_file: *link.File,
 c_object_table: std.AutoArrayHashMapUnmanaged(*CObject, void) = .{},
+c_object_cache_digest_set: std.AutoHashMapUnmanaged(Cache.BinDigest, void) = .{},
 stage1_lock: ?Cache.Lock = null,
 stage1_cache_manifest: *Cache.Manifest = undefined,
 
@@ -1152,6 +1153,7 @@ pub fn destroy(self: *Compilation) void {
         entry.key.destroy(gpa);
     }
     self.c_object_table.deinit(gpa);
+    self.c_object_cache_digest_set.deinit(gpa);
 
     for (self.failed_c_objects.items()) |entry| {
         entry.value.destroy(gpa);
@@ -1727,6 +1729,17 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_comp_progress_node: *
                     _ = try man.addFile(c_object.src.extra_flags[arg_i], null);
                 }
             }
+        }
+    }
+
+    {
+        const gop = try comp.c_object_cache_digest_set.getOrPut(comp.gpa, man.hash.peekBin());
+        if (gop.found_existing) {
+            return comp.failCObj(
+                c_object,
+                "the same source file was already added to the same compilation with the same flags",
+                .{},
+            );
         }
     }
 


### PR DESCRIPTION
Cache exposes BinDigest.

Compilation gains a set of a BinDigest for every C/C++ source file. We
detect when the same source/flags have already been added and emit a
compile error. This prevents a deadlock in the caching system.

Closes #7308

Example output:

```
[nix-shell:~/dev/zig/build]$ ./zig build-lib foo.c foo.c
foo.c:1:1: error: unable to build C object: the same source file was already added to the same compilation with the same flags
```

The `:1:1` thing is a separate issue, which can be addressed separately now that 2ed1ed9b32ae588f6a8997248d69817b5d89a133 introduced different kinds of error messages.