### PR TITLE
Implement refAllDeclsInTree, fix some docs

### DIFF
--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -14,9 +14,9 @@
 
 const std = @import("std");
 
-/// Contains constants for the C0 control codes of the ASCII encoding.
-/// https://en.wikipedia.org/wiki/C0_and_C1_control_codes
 pub const control_code = struct {
+    //! Contains constants for the C0 control codes of the ASCII encoding.
+    //! https://en.wikipedia.org/wiki/C0_and_C1_control_codes
     pub const NUL = 0x00;
     pub const SOH = 0x01;
     pub const STX = 0x02;
@@ -378,4 +378,8 @@ test "indexOfIgnoreCase" {
     std.testing.expect(indexOfIgnoreCase("foo", "fool") == null);
 
     std.testing.expect(indexOfIgnoreCase("FOO foo", "fOo").? == 0);
+}
+
+test "" {
+    std.testing.refAllDeclsInTree(@This(), 2);
 }

--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -4,8 +4,9 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 
-/// Authenticated Encryption with Associated Data
 pub const aead = struct {
+    //! Authenticated Encryption with Associated Data
+
     pub const aegis = struct {
         pub const Aegis128L = @import("crypto/aegis.zig").Aegis128L;
         pub const Aegis256 = @import("crypto/aegis.zig").Aegis256;
@@ -30,14 +31,15 @@ pub const aead = struct {
     };
 };
 
-/// Authentication (MAC) functions.
 pub const auth = struct {
+    //! Authentication (MAC) functions.
     pub const hmac = @import("crypto/hmac.zig");
     pub const siphash = @import("crypto/siphash.zig");
 };
 
-/// Core functions, that should rarely be used directly by applications.
 pub const core = struct {
+    //! Core functions, that should rarely be used directly by applications.
+
     pub const aes = @import("crypto/aes.zig");
     pub const Gimli = @import("crypto/gimli.zig").State;
 
@@ -49,20 +51,20 @@ pub const core = struct {
     pub const modes = @import("crypto/modes.zig");
 };
 
-/// Diffie-Hellman key exchange functions.
 pub const dh = struct {
+    //! Diffie-Hellman key exchange functions.
     pub const X25519 = @import("crypto/25519/x25519.zig").X25519;
 };
 
-/// Elliptic-curve arithmetic.
 pub const ecc = struct {
+    //! Elliptic-curve arithmetic.
     pub const Curve25519 = @import("crypto/25519/curve25519.zig").Curve25519;
     pub const Edwards25519 = @import("crypto/25519/edwards25519.zig").Edwards25519;
     pub const Ristretto255 = @import("crypto/25519/ristretto255.zig").Ristretto255;
 };
 
-/// Hash functions.
 pub const hash = struct {
+    //! Hash functions.
     pub const blake2 = @import("crypto/blake2.zig");
     pub const Blake3 = @import("crypto/blake3.zig").Blake3;
     pub const Gimli = @import("crypto/gimli.zig").Hash;
@@ -72,46 +74,48 @@ pub const hash = struct {
     pub const sha3 = @import("crypto/sha3.zig");
 };
 
-/// Key derivation functions.
 pub const kdf = struct {
+    //! Key derivation functions.
     pub const hkdf = @import("crypto/hkdf.zig");
 };
 
-/// MAC functions requiring single-use secret keys.
 pub const onetimeauth = struct {
+    //! MAC functions requiring single-use secret keys.
     pub const Ghash = @import("crypto/ghash.zig").Ghash;
     pub const Poly1305 = @import("crypto/poly1305.zig").Poly1305;
 };
 
-/// A password hashing function derives a uniform key from low-entropy input material such as passwords.
-/// It is intentionally slow or expensive.
-///
-/// With the standard definition of a key derivation function, if a key space is small, an exhaustive search may be practical.
-/// Password hashing functions make exhaustive searches way slower or way more expensive, even when implemented on GPUs and ASICs, by using different, optionally combined strategies:
-///
-/// - Requiring a lot of computation cycles to complete
-/// - Requiring a lot of memory to complete
-/// - Requiring multiple CPU cores to complete
-/// - Requiring cache-local data to complete in reasonable time
-/// - Requiring large static tables
-/// - Avoiding precomputations and time/memory tradeoffs
-/// - Requiring multi-party computations
-/// - Combining the input material with random per-entry data (salts), application-specific contexts and keys
-///
-/// Password hashing functions must be used whenever sensitive data has to be directly derived from a password.
 pub const pwhash = struct {
+    //! A password hashing function derives a uniform key from low-entropy input material such as passwords.
+    //! It is intentionally slow or expensive.
+    //!
+    //! With the standard definition of a key derivation function, if a key space is small, an exhaustive search may be practical.
+    //! Password hashing functions make exhaustive searches way slower or way more expensive, even when implemented on GPUs and ASICs,
+    //! by using different, optionally combined strategies:
+    //!
+    //! - Requiring a lot of computation cycles to complete
+    //! - Requiring a lot of memory to complete
+    //! - Requiring multiple CPU cores to complete
+    //! - Requiring cache-local data to complete in reasonable time
+    //! - Requiring large static tables
+    //! - Avoiding precomputations and time/memory tradeoffs
+    //! - Requiring multi-party computations
+    //! - Combining the input material with random per-entry data (salts), application-specific contexts and keys
+    //!
+    //! Password hashing functions must be used whenever sensitive data has to be directly derived from a password.
     pub const bcrypt = @import("crypto/bcrypt.zig");
     pub const pbkdf2 = @import("crypto/pbkdf2.zig").pbkdf2;
 };
 
-/// Digital signature functions.
 pub const sign = struct {
+    //! Digital signature functions.
     pub const Ed25519 = @import("crypto/25519/ed25519.zig").Ed25519;
 };
 
-/// Stream ciphers. These do not provide any kind of authentication.
-/// Most applications should be using AEAD constructions instead of stream ciphers directly.
 pub const stream = struct {
+    //! Stream ciphers. These do not provide any kind of authentication.
+    //! Most applications should be using AEAD constructions instead of stream ciphers directly.
+
     pub const chacha = struct {
         pub const ChaCha20IETF = @import("crypto/chacha20.zig").ChaCha20IETF;
         pub const ChaCha20With64BitNonce = @import("crypto/chacha20.zig").ChaCha20With64BitNonce;
@@ -138,19 +142,7 @@ const std = @import("std.zig");
 pub const randomBytes = std.os.getrandom;
 
 test "crypto" {
-    inline for (std.meta.declarations(@This())) |decl| {
-        switch (decl.data) {
-            .Type => |t| {
-                std.testing.refAllDecls(t);
-            },
-            .Var => |v| {
-                _ = v;
-            },
-            .Fn => |f| {
-                _ = f;
-            },
-        }
-    }
+    std.testing.refAllDeclsInTree(@This(), 2);
 
     _ = @import("crypto/aes.zig");
     _ = @import("crypto/bcrypt.zig");

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -435,3 +435,23 @@ pub fn refAllDecls(comptime T: type) void {
         _ = decl;
     }
 }
+
+/// Given a type, recursively reference all the declarations inside,
+/// so that the semantic analyzer sees them. Up to `levels` deep. 
+pub fn refAllDeclsInTree(comptime T: type, comptime levels: u8) void {
+    if (!@import("builtin").is_test) return;
+    if (levels < 1) return;
+    inline for (std.meta.declarations(T)) |decl| {
+        switch (decl.data) {
+            .Type => |S| {
+                refAllDeclsInTree(S, levels - 1);
+            },
+            .Var => |v| {
+                _ = v;
+            },
+            .Fn => |f| {
+                _ = f;
+            },
+        }
+    }
+}


### PR DESCRIPTION
Convert doc comments on nested namespaces to top-level doc comments so they get display in generated docs. Add a function to recursive reference such namespaces. 

Closes #7400