### PR TITLE
Fix Sigaction struct on FreeBSD

### DIFF
--- a/lib/std/os/bits/freebsd.zig
+++ b/lib/std/os/bits/freebsd.zig
@@ -749,10 +749,47 @@ pub const Sigaction = extern struct {
     },
 
     /// see signal options
-    sa_flags: u32,
+    sa_flags: c_int,
 
     /// signal mask to apply
     sa_mask: sigset_t,
+};
+
+pub const __siginfo = extern struct {
+    si_signo: c_int,
+    si_errno: c_int,
+    si_code: c_int,
+    si_pid: pid_t,
+    si_uid: uid_t,
+    si_status: c_int,
+    si_addr: ?*c_void,
+    si_value: sigval,
+    _reason: extern union {
+        _fault: extern struct {
+            _trapno: c_int,
+        },
+        _timer: extern struct {
+            _timerid: c_int,
+            _overrun: c_int,
+        },
+        _mesgq: extern struct {
+            _mqd: c_int,
+        },
+        _poll: extern struct {
+            _band: c_long,
+        },
+        __spare__: extern struct {
+            __spare1__: c_long,
+            __spare2__: [7]c_int,
+        },
+    },
+};
+
+pub const sigval = extern union {
+    sival_int: c_int,
+    sival_ptr: ?*c_void,
+    sigval_int: c_int,
+    sigval_ptr: ?*c_void,
 };
 
 pub const _SIG_WORDS = 4;
@@ -774,6 +811,8 @@ pub inline fn _SIG_VALID(sig: usize) usize {
 pub const sigset_t = extern struct {
     __bits: [_SIG_WORDS]u32,
 };
+
+pub const empty_sigset = sigset_t{ .__bits = [_]u32{0} ** _SIG_WORDS };
 
 pub const EPERM = 1; // Operation not permitted
 pub const ENOENT = 2; // No such file or directory


### PR DESCRIPTION
Closes #5892.

I think the struct definitions should look like this. I've pasted the relevant structs from my `/usr/include` to aid reviewers:

## sigaction
```c
/*
 * Signal vector "template" used in sigaction call.
 */
struct sigaction {
        union {
                void    (*__sa_handler)(int);
                void    (*__sa_sigaction)(int, struct __siginfo *, void *);
        } __sigaction_u;                /* signal handler */
        int     sa_flags;               /* see signal options below */
        sigset_t sa_mask;               /* signal mask to apply */
};
```

## __siginfo
```c
typedef struct __siginfo {
        int     si_signo;               /* signal number */
        int     si_errno;               /* errno association */
        /*
         * Cause of signal, one of the SI_ macros or signal-specific
         * values, i.e. one of the FPE_... values for SIGFPE.  This
         * value is equivalent to the second argument to an old-style
         * FreeBSD signal handler.
         */
        int     si_code;                /* signal code */
        __pid_t si_pid;                 /* sending process */
        __uid_t si_uid;                 /* sender's ruid */
        int     si_status;              /* exit value */
        void    *si_addr;               /* faulting instruction */
        union sigval si_value;          /* signal value */
        union   {
                struct {
                        int     _trapno;/* machine specific trap code */
                } _fault;
                struct {
                        int     _timerid;
                        int     _overrun;
                } _timer;
                struct {
                        int     _mqd;
                } _mesgq;
                struct {
                        long    _band;          /* band event for SIGPOLL */
                } _poll;                        /* was this ever used ? */
                struct {
                        long    __spare1__;
                        int     __spare2__[7];
                } __spare__;
        } _reason;
} siginfo_t;
```

## sigval
```c
union sigval {
        /* Members as suggested by Annex C of POSIX 1003.1b. */
        int     sival_int;
        void    *sival_ptr;
        /* 6.0 compatibility */
        int     sigval_int;
        void    *sigval_ptr;
};
```

With this patch, I'm able to compile a program similar to the one in the linked issue.

```zig
const std = @import("std");

pub fn main() anyerror!void {
    var foo = std.os.Sigaction{
        .__sigaction_u = undefined,
        .sa_mask = std.os.empty_sigset,
        .sa_flags = 0,
    };
}
```