### PR TITLE
stage1: Fix crash in can_mutate_comptime_var_state

### DIFF
--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -5749,6 +5749,28 @@ static bool can_mutate_comptime_var_state(ZigValue *value) {
     assert(value != nullptr);
     if (value->special == ConstValSpecialUndef)
         return false;
+
+    if (value->special == ConstValSpecialLazy) {
+        // No lazy value has side effects.
+        // Use a switch here to get a compile error whenever a new kind of lazy
+        // value is added.
+        switch (value->data.x_lazy->id) {
+            case LazyValueIdInvalid:
+                zig_unreachable();
+
+            case LazyValueIdAlignOf:
+            case LazyValueIdSizeOf:
+            case LazyValueIdPtrType:
+            case LazyValueIdOptType:
+            case LazyValueIdSliceType:
+            case LazyValueIdFnType:
+            case LazyValueIdErrUnionType:
+            case LazyValueIdArrayType:
+            case LazyValueIdTypeInfoDecls:
+                return false;
+        }
+    }
+
     switch (value->type->id) {
         case ZigTypeIdInvalid:
             zig_unreachable();

--- a/test/stage1/behavior/misc.zig
+++ b/test/stage1/behavior/misc.zig
@@ -752,3 +752,10 @@ test "extern variable with non-pointer opaque type" {
     @export(var_to_export, .{ .name = "opaque_extern_var" });
     expect(@ptrCast(*align(1) u32, &opaque_extern_var).* == 42);
 }
+
+test "lazy typeInfo value as generic parameter" {
+    const S = struct {
+        fn foo(args: anytype) void {}
+    };
+    S.foo(@typeInfo(@TypeOf(.{})));
+}


### PR DESCRIPTION
No lazy value can mutate global state, no need to resolve them.

If you're reading this then please provide a minimized test case.

Closes #7426