### PR TITLE
openbsd: crt0.o file is different when build static or dynamic mode

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1441,8 +1441,14 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
 
     if (link_in_crt) {
         const crt1o: []const u8 = o: {
-            if (target.os.tag == .netbsd or target.os.tag == .openbsd) {
+            if (target.os.tag == .netbsd) {
                 break :o "crt0.o";
+            } else if (target.os.tag == .openbsd) {
+                if (self.base.options.link_mode == .Static) {
+                    break :o "rcrt0.o";
+                } else {
+                    break :o "crt0.o";
+                }
             } else if (target.isAndroid()) {
                 if (self.base.options.link_mode == .Dynamic) {
                     break :o "crtbegin_dynamic.o";


### PR DESCRIPTION
it is a first step for support static *and* dynamic mode for openbsd