### PR TITLE
stage1: Don't skip steps when analyzing union types

### DIFF
--- a/test/stage1/behavior/union.zig
+++ b/test/stage1/behavior/union.zig
@@ -734,3 +734,30 @@ test "containers with single-field enums" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "@unionInit on union w/ tag but no fields" {
+    const S = struct {
+        const Type = enum(u8) { no_op = 105 };
+
+        const Data = union(Type) {
+            no_op: void,
+
+            pub fn decode(buf: []const u8) !Data {
+                return @unionInit(Data, "no_op", {});
+            }
+        };
+
+        comptime {
+            expect(@sizeOf(Data) != 0);
+        }
+
+        fn doTheTest() void {
+            var data: Data = .{ .no_op = .{} };
+            var o = try Data.decode(&[_]u8{});
+            expectEqual(Type.no_op, o);
+        }
+    };
+
+    S.doTheTest();
+    comptime S.doTheTest();
+}


### PR DESCRIPTION
Don't cut any corner and properly run the type trough every single step
even though it has no fields (or, better, the sum of the size of all its
fields is zero).

Fix the logic to consider an explicit non-zero-sized tag enough to treat
the type as sized.

Closes #7451

@ifreund please try rebuilding river with this patch as it replaces #7222 