### PR TITLE
Truncate user and group ids for 64 bit Linux systems

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -745,33 +745,33 @@ pub fn setregid(rgid: gid_t, egid: gid_t) usize {
 
 pub fn getuid() uid_t {
     if (@hasField(SYS, "getuid32")) {
-        return @truncate(uid_t, syscall0(.getuid32));
+        return @intCast(uid_t, syscall0(.getuid32));
     } else {
-        return @truncate(uid_t, syscall0(.getuid));
+        return @intCast(uid_t, syscall0(.getuid));
     }
 }
 
 pub fn getgid() gid_t {
     if (@hasField(SYS, "getgid32")) {
-        return @truncate(gid_t, syscall0(.getgid32));
+        return @intCast(gid_t, syscall0(.getgid32));
     } else {
-        return @truncate(gid_t, syscall0(.getgid));
+        return @intCast(gid_t, syscall0(.getgid));
     }
 }
 
 pub fn geteuid() uid_t {
     if (@hasField(SYS, "geteuid32")) {
-        return @truncate(uid_t, syscall0(.geteuid32));
+        return @intCast(uid_t, syscall0(.geteuid32));
     } else {
-        return @truncate(uid_t, syscall0(.geteuid));
+        return @intCast(uid_t, syscall0(.geteuid));
     }
 }
 
 pub fn getegid() gid_t {
     if (@hasField(SYS, "getegid32")) {
-        return @truncate(gid_t, syscall0(.getegid32));
+        return @intCast(gid_t, syscall0(.getegid32));
     } else {
-        return @truncate(gid_t, syscall0(.getegid));
+        return @intCast(gid_t, syscall0(.getegid));
     }
 }
 

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -745,33 +745,33 @@ pub fn setregid(rgid: gid_t, egid: gid_t) usize {
 
 pub fn getuid() uid_t {
     if (@hasField(SYS, "getuid32")) {
-        return @as(uid_t, syscall0(.getuid32));
+        return @truncate(uid_t, syscall0(.getuid32));
     } else {
-        return @as(uid_t, syscall0(.getuid));
+        return @truncate(uid_t, syscall0(.getuid));
     }
 }
 
 pub fn getgid() gid_t {
     if (@hasField(SYS, "getgid32")) {
-        return @as(gid_t, syscall0(.getgid32));
+        return @truncate(gid_t, syscall0(.getgid32));
     } else {
-        return @as(gid_t, syscall0(.getgid));
+        return @truncate(gid_t, syscall0(.getgid));
     }
 }
 
 pub fn geteuid() uid_t {
     if (@hasField(SYS, "geteuid32")) {
-        return @as(uid_t, syscall0(.geteuid32));
+        return @truncate(uid_t, syscall0(.geteuid32));
     } else {
-        return @as(uid_t, syscall0(.geteuid));
+        return @truncate(uid_t, syscall0(.geteuid));
     }
 }
 
 pub fn getegid() gid_t {
     if (@hasField(SYS, "getegid32")) {
-        return @as(gid_t, syscall0(.getegid32));
+        return @truncate(gid_t, syscall0(.getegid32));
     } else {
-        return @as(gid_t, syscall0(.getegid));
+        return @truncate(gid_t, syscall0(.getegid));
     }
 }
 

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -10,6 +10,7 @@ const mem = std.mem;
 const elf = std.elf;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
+const getauxval = linux.getauxval;
 const fs = std.fs;
 
 test "fallocate" {

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -10,7 +10,6 @@ const mem = std.mem;
 const elf = std.elf;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
-const getauxval = linux.getauxval;
 const fs = std.fs;
 
 test "fallocate" {

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -9,6 +9,7 @@ const linux = std.os.linux;
 const mem = std.mem;
 const elf = std.elf;
 const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
 const fs = std.fs;
 
 test "fallocate" {
@@ -98,4 +99,11 @@ test "statx" {
     expect(@bitCast(u64, @as(i64, stat_buf.size)) == statx_buf.size);
     expect(@bitCast(u64, @as(i64, stat_buf.blksize)) == statx_buf.blksize);
     expect(@bitCast(u64, @as(i64, stat_buf.blocks)) == statx_buf.blocks);
+}
+
+test "user and group ids" {
+    expectEqual(getauxval(AT_UID), getuid());
+    expectEqual(getauxval(AT_GID), getgid());
+    expectEqual(getauxval(AT_EUID), geteuid());
+    expectEqual(getauxval(AT_EGID), getegid());
 }

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -102,6 +102,7 @@ test "statx" {
 }
 
 test "user and group ids" {
+    if (builtin.link_libc) return error.SkipZigTest;
     expectEqual(linux.getauxval(elf.AT_UID), linux.getuid());
     expectEqual(linux.getauxval(elf.AT_GID), linux.getgid());
     expectEqual(linux.getauxval(elf.AT_EUID), linux.geteuid());

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -103,8 +103,8 @@ test "statx" {
 }
 
 test "user and group ids" {
-    expectEqual(getauxval(AT_UID), getuid());
-    expectEqual(getauxval(AT_GID), getgid());
-    expectEqual(getauxval(AT_EUID), geteuid());
-    expectEqual(getauxval(AT_EGID), getegid());
+    expectEqual(linux.getauxval(elf.AT_UID), linux.getuid());
+    expectEqual(linux.getauxval(elf.AT_GID), linux.getgid());
+    expectEqual(linux.getauxval(elf.AT_EUID), linux.geteuid());
+    expectEqual(linux.getauxval(elf.AT_EGID), linux.getegid());
 }


### PR DESCRIPTION
Calls to `getuid`, `getgid` and their `eid` variants fail to compile on
64bit Linux systems because the return value of the syscall is of
`usize` and needs to be truncated to fit the size of `uid_t` that is 32
bit.

Thanks to @FireFox317 for figuring this out in Zig's Discord channel!

**TODO**

- [ ] squash commits
- [x] fix CI test
- [x] run regression test