### PR TITLE
openbsd: fix siginfo_t struct definition

### DIFF
--- a/lib/std/os/bits/openbsd.zig
+++ b/lib/std/os/bits/openbsd.zig
@@ -781,11 +781,17 @@ pub const siginfo_t = extern struct {
     data: extern union {
         proc: extern struct {
             pid: pid_t,
-            uid: uid_t,
-            value: sigval,
-            utime: clock_t,
-            stime: clock_t,
-            status: c_int,
+            pdata: extern union {
+                kill: extern struct {
+                    uid: uid_t,
+                    value: sigval,
+                },
+                cld: extern struct {
+                    utime: clock_t,
+                    stime: clock_t,
+                    status: c_int,
+                },
+            },
         },
         fault: extern struct {
             addr: ?*c_void,


### PR DESCRIPTION
`_proc` struct part contains an union for kill/cld parts.

see [siginfo_t](https://github.com/openbsd/src/blob/77c6c13150aaa9f0a29fe29b233c4436d1da01c0/sys/sys/siginfo.h#L132)