### PR TITLE
std/os/linux: Fix compilation of getuid/getgid/geteuid/getegid on x86_64

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -747,7 +747,7 @@ pub fn getuid() uid_t {
     if (@hasField(SYS, "getuid32")) {
         return @as(uid_t, syscall0(.getuid32));
     } else {
-        return @as(uid_t, syscall0(.getuid));
+        return @truncate(uid_t, syscall0(.getuid));
     }
 }
 
@@ -755,7 +755,7 @@ pub fn getgid() gid_t {
     if (@hasField(SYS, "getgid32")) {
         return @as(gid_t, syscall0(.getgid32));
     } else {
-        return @as(gid_t, syscall0(.getgid));
+        return @truncate(gid_t, syscall0(.getgid));
     }
 }
 
@@ -763,7 +763,7 @@ pub fn geteuid() uid_t {
     if (@hasField(SYS, "geteuid32")) {
         return @as(uid_t, syscall0(.geteuid32));
     } else {
-        return @as(uid_t, syscall0(.geteuid));
+        return @truncate(uid_t, syscall0(.geteuid));
     }
 }
 
@@ -771,7 +771,7 @@ pub fn getegid() gid_t {
     if (@hasField(SYS, "getegid32")) {
         return @as(gid_t, syscall0(.getegid32));
     } else {
-        return @as(gid_t, syscall0(.getegid));
+        return @truncate(gid_t, syscall0(.getegid));
     }
 }
 

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -34,6 +34,22 @@ test "getpid" {
     expect(linux.getpid() != 0);
 }
 
+test "getuid" {
+    _ = linux.getuid();
+}
+
+test "getgid" {
+    _ = linux.getgid();
+}
+
+test "geteuid" {
+    _ = linux.geteuid();
+}
+
+test "getegid" {
+    _ = linux.getegid();
+}
+
 test "timer" {
     const epoll_fd = linux.epoll_create();
     var err: usize = linux.getErrno(epoll_fd);


### PR DESCRIPTION
Both uid_t and gid_t are 32 bits wide, so the syscall result needs to be truncated.

