### PR TITLE
update depreciated code

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -42,7 +42,7 @@ pub fn main() !void {
 
     const input_file_bytes = try in_file.inStream().readAllAlloc(allocator, max_doc_file_size);
 
-    var buffered_out_stream = io.bufferedOutStream(out_file.outStream());
+    var buffered_out_stream = io.bufferedOutStream(out_file.writer());
 
     var tokenizer = Tokenizer.init(in_file_name, input_file_bytes);
     var toc = try genToc(allocator, &tokenizer);
@@ -50,7 +50,7 @@ pub fn main() !void {
     try fs.cwd().makePath(tmp_dir_name);
     defer fs.cwd().deleteTree(tmp_dir_name) catch {};
 
-    try genHtml(allocator, &tokenizer, &toc, buffered_out_stream.outStream(), zig_exe);
+    try genHtml(allocator, &tokenizer, &toc, buffered_out_stream.writer(), zig_exe);
     try buffered_out_stream.flush();
 }
 
@@ -325,7 +325,7 @@ fn genToc(allocator: *mem.Allocator, tokenizer: *Tokenizer) !Toc {
     var toc_buf = std.ArrayList(u8).init(allocator);
     defer toc_buf.deinit();
 
-    var toc = toc_buf.outStream();
+    var toc = toc_buf.writer();
 
     var nodes = std.ArrayList(Node).init(allocator);
     defer nodes.deinit();
@@ -615,7 +615,7 @@ fn urlize(allocator: *mem.Allocator, input: []const u8) ![]u8 {
     var buf = std.ArrayList(u8).init(allocator);
     defer buf.deinit();
 
-    const out = buf.outStream();
+    const out = buf.writer();
     for (input) |c| {
         switch (c) {
             'a'...'z', 'A'...'Z', '_', '-', '0'...'9' => {
@@ -634,7 +634,7 @@ fn escapeHtml(allocator: *mem.Allocator, input: []const u8) ![]u8 {
     var buf = std.ArrayList(u8).init(allocator);
     defer buf.deinit();
 
-    const out = buf.outStream();
+    const out = buf.writer();
     try writeEscaped(out, input);
     return buf.toOwnedSlice();
 }
@@ -680,7 +680,7 @@ fn termColor(allocator: *mem.Allocator, input: []const u8) ![]u8 {
     var buf = std.ArrayList(u8).init(allocator);
     defer buf.deinit();
 
-    var out = buf.outStream();
+    var out = buf.writer();
     var number_start_index: usize = undefined;
     var first_number: usize = undefined;
     var second_number: usize = undefined;

--- a/src/main.zig
+++ b/src/main.zig
@@ -199,7 +199,7 @@ pub fn mainArgs(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
     } else if (mem.eql(u8, cmd, "version")) {
         try std.io.getStdOut().writeAll(build_options.version ++ "\n");
     } else if (mem.eql(u8, cmd, "env")) {
-        try @import("print_env.zig").cmdEnv(arena, cmd_args, io.getStdOut().outStream());
+        try @import("print_env.zig").cmdEnv(arena, cmd_args, io.getStdOut().writer());
     } else if (mem.eql(u8, cmd, "zen")) {
         try io.getStdOut().writeAll(info_zen);
     } else if (mem.eql(u8, cmd, "help") or mem.eql(u8, cmd, "-h") or mem.eql(u8, cmd, "--help")) {

--- a/src/print_env.zig
+++ b/src/print_env.zig
@@ -4,7 +4,7 @@ const introspect = @import("introspect.zig");
 const Allocator = std.mem.Allocator;
 const fatal = @import("main.zig").fatal;
 
-pub fn cmdEnv(gpa: *Allocator, args: []const []const u8, stdout: anytype) !void {
+pub fn cmdEnv(gpa: *Allocator, args: []const []const u8, stdout: std.fs.File.Writer) !void {
     const self_exe_path = try std.fs.selfExePathAlloc(gpa);
     defer gpa.free(self_exe_path);
 

--- a/tools/update_glibc.zig
+++ b/tools/update_glibc.zig
@@ -239,8 +239,8 @@ pub fn main() !void {
         const vers_txt_path = try fs.path.join(allocator, &[_][]const u8{ glibc_out_dir, "vers.txt" });
         const vers_txt_file = try fs.cwd().createFile(vers_txt_path, .{});
         defer vers_txt_file.close();
-        var buffered = std.io.bufferedOutStream(vers_txt_file.outStream());
-        const vers_txt = buffered.outStream();
+        var buffered = std.io.bufferedOutStream(vers_txt_file.writer());
+        const vers_txt = buffered.writer();
         for (global_ver_list) |name, i| {
             _ = global_ver_set.put(name, i) catch unreachable;
             try vers_txt.print("{}\n", .{name});
@@ -251,8 +251,8 @@ pub fn main() !void {
         const fns_txt_path = try fs.path.join(allocator, &[_][]const u8{ glibc_out_dir, "fns.txt" });
         const fns_txt_file = try fs.cwd().createFile(fns_txt_path, .{});
         defer fns_txt_file.close();
-        var buffered = std.io.bufferedOutStream(fns_txt_file.outStream());
-        const fns_txt = buffered.outStream();
+        var buffered = std.io.bufferedOutStream(fns_txt_file.writer());
+        const fns_txt = buffered.writer();
         for (global_fn_list) |name, i| {
             const entry = global_fn_set.getEntry(name).?;
             entry.value.index = i;
@@ -282,8 +282,8 @@ pub fn main() !void {
         const abilist_txt_path = try fs.path.join(allocator, &[_][]const u8{ glibc_out_dir, "abi.txt" });
         const abilist_txt_file = try fs.cwd().createFile(abilist_txt_path, .{});
         defer abilist_txt_file.close();
-        var buffered = std.io.bufferedOutStream(abilist_txt_file.outStream());
-        const abilist_txt = buffered.outStream();
+        var buffered = std.io.bufferedOutStream(abilist_txt_file.writer());
+        const abilist_txt = buffered.writer();
 
         // first iterate over the abi lists
         for (abi_lists) |*abi_list, abi_index| {


### PR DESCRIPTION
* fix depreciated interface, update `outStream` -> `writer`
* make code more readable by updating `anytype` -> `std.fs.File.Writer`

Was there a reason for anytype? A compiler bug?