### PR TITLE
Add c_longdouble mapping for bpf

### DIFF
--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -8660,6 +8660,10 @@ static void define_builtin_types(CodeGen *g) {
         case ZigLLVM_msp430:
             add_fp_entry(g, "c_longdouble", 64, LLVMDoubleType(), &g->builtin_types.entry_c_longdouble);
             break;
+        case ZigLLVM_bpfel:
+        case ZigLLVM_bpfeb:
+            // eBPF does not have floating point numbers
+            break;
         default:
             zig_panic("TODO implement mapping for c_longdouble");
     }

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -8662,7 +8662,7 @@ static void define_builtin_types(CodeGen *g) {
             break;
         case ZigLLVM_bpfel:
         case ZigLLVM_bpfeb:
-            // eBPF does not have floating point numbers
+            add_fp_entry(g, "c_longdouble", 64, LLVMDoubleType(), &g->builtin_types.entry_c_longdouble);
             break;
         default:
             zig_panic("TODO implement mapping for c_longdouble");


### PR DESCRIPTION
I've been getting a c_longdouble mapping todo error in my CI and decided to do some digging since BPF does not have any floating point numbers.