### PR TITLE
macho: space preallocation, and various cleanups and fixes

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2280,6 +2280,7 @@ fn updateLinkeditSegmentSizes(self: *MachO) !void {
     const filesize = final_offset - linkedit_segment.inner.fileoff;
     linkedit_segment.inner.filesize = filesize;
     linkedit_segment.inner.vmsize = mem.alignForwardGeneric(u64, filesize, self.page_size);
+    try self.base.file.?.pwriteAll(&[_]u8{ 0 }, final_offset);
     self.load_commands_dirty = true;
 }
 
@@ -2299,7 +2300,9 @@ fn writeLoadCommands(self: *MachO) !void {
         try lc.write(writer);
     }
 
-    try self.base.file.?.pwriteAll(buffer, @sizeOf(macho.mach_header_64));
+    const off = @sizeOf(macho.mach_header_64);
+    log.debug("writing {} load commands from 0x{x} to 0x{x}", .{self.load_commands.items.len, off, off + sizeofcmds});
+    try self.base.file.?.pwriteAll(buffer, off);
     self.load_commands_dirty = false;
 }
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1537,6 +1537,7 @@ pub fn populateMissingMetadata(self: *MachO) !void {
                 .sdk = version,
             },
         });
+        self.cmd_table_dirty = true;
     }
     if (self.source_version_cmd_index == null) {
         self.source_version_cmd_index = @intCast(u16, self.load_commands.items.len);
@@ -1547,6 +1548,7 @@ pub fn populateMissingMetadata(self: *MachO) !void {
                 .version = 0x0,
             },
         });
+        self.cmd_table_dirty = true;
     }
     if (self.code_signature_cmd_index == null) {
         self.code_signature_cmd_index = @intCast(u16, self.load_commands.items.len);
@@ -1558,6 +1560,7 @@ pub fn populateMissingMetadata(self: *MachO) !void {
                 .datasize = 0,
             },
         });
+        self.cmd_table_dirty = true;
     }
     if (self.dyld_stub_binder_index == null) {
         self.dyld_stub_binder_index = @intCast(u16, self.undef_symbols.items.len);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1739,7 +1739,10 @@ fn detectAllocCollision(self: *MachO, segment: *const SegmentCommand, start: u64
 }
 
 fn findFreeSpace(self: *MachO, segment: *const SegmentCommand, object_size: u64, min_alignment: u16) u64 {
-    var start: u64 = if (parseAndCmpName(&segment.inner.segname, "__TEXT")) self.header_pad else 0;
+    var start: u64 = if (parseAndCmpName(&segment.inner.segname, "__TEXT"))
+        self.header_pad
+    else
+        segment.inner.fileoff;
     while (self.detectAllocCollision(segment, start, object_size)) |item_end| {
         start = mem.alignForwardGeneric(u64, item_end, min_alignment);
     }

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1674,7 +1674,7 @@ fn allocateTextBlock(self: *MachO, text_block: *TextBlock, new_block_size: u64, 
 pub fn makeStaticString(comptime bytes: []const u8) [16]u8 {
     var buf = [_]u8{0} ** 16;
     if (bytes.len > buf.len) @compileError("string too long; max 16 bytes");
-    mem.copy(u8, buf[0..], bytes);
+    mem.copy(u8, &buf, bytes);
     return buf;
 }
 
@@ -2048,18 +2048,18 @@ fn parseFromFile(self: *MachO, file: fs.File) !void {
         switch (cmd.cmd()) {
             macho.LC_SEGMENT_64 => {
                 const x = cmd.Segment;
-                if (parseAndCmpName(x.inner.segname[0..], "__PAGEZERO")) {
+                if (parseAndCmpName(&x.inner.segname, "__PAGEZERO")) {
                     self.pagezero_segment_cmd_index = i;
-                } else if (parseAndCmpName(x.inner.segname[0..], "__LINKEDIT")) {
+                } else if (parseAndCmpName(&x.inner.segname, "__LINKEDIT")) {
                     self.linkedit_segment_cmd_index = i;
-                } else if (parseAndCmpName(x.inner.segname[0..], "__TEXT")) {
+                } else if (parseAndCmpName(&x.inner.segname, "__TEXT")) {
                     self.text_segment_cmd_index = i;
                     for (x.sections.items) |sect, j| {
-                        if (parseAndCmpName(sect.sectname[0..], "__text")) {
+                        if (parseAndCmpName(&sect.sectname, "__text")) {
                             self.text_section_index = @intCast(u16, j);
                         }
                     }
-                } else if (parseAndCmpName(x.inner.segname[0..], "__DATA")) {
+                } else if (parseAndCmpName(&x.inner.segname, "__DATA")) {
                     self.data_segment_cmd_index = i;
                 }
             },
@@ -2109,7 +2109,7 @@ fn parseFromFile(self: *MachO, file: fs.File) !void {
 }
 
 fn parseAndCmpName(name: []const u8, needle: []const u8) bool {
-    const len = mem.indexOfScalar(u8, name[0..], @as(u8, 0)) orelse name.len;
+    const len = mem.indexOfScalar(u8, name, @as(u8, 0)) orelse name.len;
     return mem.eql(u8, name[0..len], needle);
 }
 

--- a/src/link/MachO/CodeSignature.zig
+++ b/src/link/MachO/CodeSignature.zig
@@ -126,7 +126,7 @@ pub fn calcAdhocSignature(
 
         Sha256.hash(buffer[0..fsize], &hash, .{});
 
-        cdir.data.appendSliceAssumeCapacity(hash[0..]);
+        cdir.data.appendSliceAssumeCapacity(&hash);
         cdir.inner.nCodeSlots += 1;
     }
 
@@ -174,10 +174,10 @@ test "CodeSignature header" {
     defer code_sig.deinit();
 
     var buffer: [@sizeOf(macho.SuperBlob)]u8 = undefined;
-    code_sig.writeHeader(buffer[0..]);
+    code_sig.writeHeader(&buffer);
 
     const expected = &[_]u8{ 0xfa, 0xde, 0x0c, 0xc0, 0x0, 0x0, 0x0, 0xc, 0x0, 0x0, 0x0, 0x0 };
-    testing.expect(mem.eql(u8, expected[0..], buffer[0..]));
+    testing.expect(mem.eql(u8, expected, &buffer));
 }
 
 pub fn calcCodeSignaturePadding(id: []const u8, file_size: u64) u32 {

--- a/src/link/MachO/Trie.zig
+++ b/src/link/MachO/Trie.zig
@@ -531,14 +531,14 @@ test "write Trie to a byte stream" {
     {
         const nwritten = try trie.write(stream.writer());
         testing.expect(nwritten == trie.size);
-        testing.expect(mem.eql(u8, buffer, exp_buffer[0..]));
+        testing.expect(mem.eql(u8, buffer, &exp_buffer));
     }
     {
         // Writing finalized trie again should yield the same result.
         try stream.seekTo(0);
         const nwritten = try trie.write(stream.writer());
         testing.expect(nwritten == trie.size);
-        testing.expect(mem.eql(u8, buffer, exp_buffer[0..]));
+        testing.expect(mem.eql(u8, buffer, &exp_buffer));
     }
 }
 
@@ -556,7 +556,7 @@ test "parse Trie from byte stream" {
         0x3, 0x0, 0x80, 0x20, 0x0, // terminal node
     };
 
-    var in_stream = std.io.fixedBufferStream(in_buffer[0..]);
+    var in_stream = std.io.fixedBufferStream(&in_buffer);
     var trie = Trie.init(gpa);
     defer trie.deinit();
     const nread = try trie.read(in_stream.reader());
@@ -571,5 +571,5 @@ test "parse Trie from byte stream" {
     const nwritten = try trie.write(out_stream.writer());
 
     testing.expect(nwritten == trie.size);
-    testing.expect(mem.eql(u8, in_buffer[0..], out_buffer));
+    testing.expect(mem.eql(u8, &in_buffer, out_buffer));
 }

--- a/src/link/MachO/commands.zig
+++ b/src/link/MachO/commands.zig
@@ -7,11 +7,7 @@ const macho = std.macho;
 const testing = std.testing;
 
 const Allocator = std.mem.Allocator;
-const MachO = @import("../MachO.zig");
-const makeName = MachO.makeStaticString;
-const alloc_num = MachO.alloc_num;
-const alloc_den = MachO.alloc_den;
-const satMul = MachO.satMul;
+const makeStaticString = @import("../MachO.zig").makeStaticString;
 
 pub const LoadCommand = union(enum) {
     Segment: SegmentCommand,
@@ -153,7 +149,6 @@ pub const LoadCommand = union(enum) {
 
 pub const SegmentCommand = struct {
     inner: macho.segment_command_64,
-    header_pad: ?u64 = null,
     sections: std.ArrayListUnmanaged(macho.section_64) = .{},
 
     pub fn empty(inner: macho.segment_command_64) SegmentCommand {
@@ -164,26 +159,6 @@ pub const SegmentCommand = struct {
         try self.sections.append(alloc, section);
         self.inner.cmdsize += @sizeOf(macho.section_64);
         self.inner.nsects += 1;
-    }
-
-    fn detectAllocCollision(self: SegmentCommand, start: u64, size: u64) ?u64 {
-        const end = start + satMul(size, alloc_num) / alloc_den;
-        for (self.sections.items) |section| {
-            const increased_size = satMul(section.size, alloc_num) / alloc_den;
-            const test_end = section.offset + increased_size;
-            if (end > section.offset and start < test_end) {
-                return test_end;
-            }
-        }
-        return null;
-    }
-
-    pub fn findFreeSpace(self: SegmentCommand, object_size: u64, min_alignment: u16) u32 {
-        var start: u64 = if (self.header_pad) |pad| pad else 0;
-        while (self.detectAllocCollision(start, object_size)) |item_end| {
-            start = mem.alignForwardGeneric(u64, item_end, min_alignment);
-        }
-        return @intCast(u32, start);
     }
 
     pub fn read(alloc: *Allocator, reader: anytype) !SegmentCommand {
@@ -308,7 +283,7 @@ test "read-write segment command" {
         .inner = .{
             .cmd = macho.LC_SEGMENT_64,
             .cmdsize = 152,
-            .segname = makeName("__TEXT"),
+            .segname = makeStaticString("__TEXT"),
             .vmaddr = 4294967296,
             .vmsize = 294912,
             .fileoff = 0,
@@ -320,8 +295,8 @@ test "read-write segment command" {
         },
     };
     try cmd.sections.append(gpa, .{
-        .sectname = makeName("__text"),
-        .segname = makeName("__TEXT"),
+        .sectname = makeStaticString("__text"),
+        .segname = makeStaticString("__TEXT"),
         .addr = 4294983680,
         .size = 448,
         .offset = 16384,


### PR DESCRIPTION
In the order of importance, this PR:
* brings back space preallocation for segments/sections and `__LINKEDIT` hidden sections -- this means, we now write local symbols incrementally as needed, and update other `__LINKEDIT` sections such as export info or the string table only if changed. There is one catch to this solution though in that the Mach-O generated by our self-hosted toolchain will not follow the convention set up by Apple's `ld` or LLVM's `ld64`; that is, to make linking faster, we do not enforce sorting of the `__LINKEDIT` sections (e.g., rebase -> bind -> lazy bind -> export -> indirect symbols -> symbol table -> string table -> codesign). Instead, we do allow for the sections to be moved freely within the `__LINKEDIT` segment. This effectively means we don't have to rewrite the entire segment as we add a new local symbol, etc. This might mean that the binary won't be 100% compatible with Apple's native code signing tools such as `codesign`, but this doesn't really matter since we codesign ourselves anyhow, and it definitely doesn't have any impact on the performance of `dyld` loader.
* refactors use of `log` module so that we don't unnecessarily double the newline characters in each log message.
* makes the code more idiomatic, e.g., encourages the use of `&arr` to coerce to slice rather than via the slicing operator `arr[0..]`.