### PR TITLE
Fixes wrong error set in std.net

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4922,7 +4922,7 @@ pub fn send(
     sockfd: socket_t,
     buf: []const u8,
     flags: u32,
-) SendError!usize {
+) SendToError!usize {
     return sendto(sockfd, buf, flags, null, 0);
 }
 


### PR DESCRIPTION
Changes `std.os.send` error set to std.os.SendToError, as it uses `sendto` internally.