### PR TITLE
Added std.io.counting_reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ set(ZIG_STAGE2_SOURCES
     "${CMAKE_SOURCE_DIR}/lib/std/io/buffered_writer.zig"
     "${CMAKE_SOURCE_DIR}/lib/std/io/change_detection_stream.zig"
     "${CMAKE_SOURCE_DIR}/lib/std/io/counting_writer.zig"
+    "${CMAKE_SOURCE_DIR}/lib/std/io/counting_reader.zig"
     "${CMAKE_SOURCE_DIR}/lib/std/io/find_byte_out_stream.zig"
     "${CMAKE_SOURCE_DIR}/lib/std/io/fixed_buffer_stream.zig"
     "${CMAKE_SOURCE_DIR}/lib/std/io/reader.zig"

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -143,6 +143,8 @@ pub const cOutStream = cWriter;
 
 pub const CountingWriter = @import("io/counting_writer.zig").CountingWriter;
 pub const countingWriter = @import("io/counting_writer.zig").countingWriter;
+pub const CountingReader = @import("io/counting_reader.zig").CountingReader;
+pub const countingReader = @import("io/counting_reader.zig").countingReader;
 /// Deprecated: use `CountingWriter`
 pub const CountingOutStream = CountingWriter;
 /// Deprecated: use `countingWriter`

--- a/lib/std/io/counting_reader.zig
+++ b/lib/std/io/counting_reader.zig
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2015-2020 Zig Contributors
+// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
+// The MIT license requires this copyright notice to be included in all copies
+// and substantial portions of the software.
+const std = @import("../std.zig");
+const io = std.io;
+const testing = std.testing;
+
+/// A Reader that counts how many bytes has been read from it.
+pub fn CountingReader(comptime ReaderType: anytype) type {
+    return struct {
+        child_reader: ReaderType,
+        bytes_read: u64 = 0,
+        
+        pub const Error = ReaderType.Error;
+        pub const Reader = io.Reader(*@This(), Error, read);
+        
+        pub fn read(self: *@This(), buf: []u8) Error!usize {
+            const amt = try self.child_reader.read(buf);
+            self.bytes_read += amt;
+            return amt;
+        }
+        
+        pub fn reader(self: *@This()) Reader {
+            return .{ .context = self };
+        }
+    };
+}
+
+pub fn countingReader(reader: anytype) CountingReader(@TypeOf(reader)) {
+    return .{ .child_reader = reader, };
+}
+
+test "io.CountingReader" {
+    const bytes = "yay" ** 100;
+    var fbs = io.fixedBufferStream(bytes);
+    
+    var counting_stream = countingReader(fbs.reader());
+    const stream = counting_stream.reader();
+    
+    //read and discard all bytes
+    while(stream.readByte()) |_| {} else |err| {
+        testing.expect(err == error.EndOfStream);
+    }
+    
+    testing.expect(counting_stream.bytes_read == bytes.len);
+}


### PR DESCRIPTION
Added because 1) it compliments io.counting_writer and 2) I had to implement it to avoid an extra allocation in a WASM module deserializer.