### PR TITLE
Add a comment about ints

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -2786,6 +2786,7 @@ pub const Type = extern union {
     pub fn isIndexable(self: Type) bool {
         const zig_tag = self.zigTypeTag();
         // TODO tuples are indexable
+        // TODO ints are indexable (from 0..N)
         return zig_tag == .Array or zig_tag == .Vector or self.isSlice() or
             (self.isSinglePointer() and self.elemType().zigTypeTag() == .Array);
     }


### PR DESCRIPTION
Iterating over ints (0 and up) also makes sense:

```zig
for (10) |x| {
     println!("{}", x);
}
```

This pull request just adds a comment.