### PR TITLE
Pass full test suite on Apple Silicon

### DIFF
--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -298,6 +298,8 @@ test "cpu count" {
 
 test "thread local storage" {
     if (builtin.single_threaded) return error.SkipZigTest;
+    // TODO https://github.com/ziglang/zig/issues/7527
+    if (std.Target.current.isDarwin() and builtin.arch == .aarch64) return error.SkipZigTest;
     const thread1 = try Thread.spawn({}, testTls);
     const thread2 = try Thread.spawn({}, testTls);
     testTls({});

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -299,7 +299,8 @@ test "cpu count" {
 test "thread local storage" {
     if (builtin.single_threaded) return error.SkipZigTest;
     // TODO https://github.com/ziglang/zig/issues/7527
-    if (std.Target.current.isDarwin() and builtin.arch == .aarch64) return error.SkipZigTest;
+    if (comptime std.Target.current.isDarwin() and builtin.arch == .aarch64) return error.SkipZigTest;
+
     const thread1 = try Thread.spawn({}, testTls);
     const thread2 = try Thread.spawn({}, testTls);
     testTls({});

--- a/test/stage1/behavior/bugs/7250.zig
+++ b/test/stage1/behavior/bugs/7250.zig
@@ -1,3 +1,6 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
 const nrfx_uart_t = extern struct {
     p_reg: [*c]u32,
     drv_inst_idx: u8,
@@ -11,5 +14,8 @@ threadlocal var g_uart0 = nrfx_uart_t{
 };
 
 test "reference a global threadlocal variable" {
+    // TODO https://github.com/ziglang/zig/issues/7527
+    if (comptime std.Target.current.isDarwin() and builtin.arch == .aarch64) return error.SkipZigTest;
+
     _ = nrfx_uart_rx(&g_uart0);
 }

--- a/test/stage1/behavior/misc.zig
+++ b/test/stage1/behavior/misc.zig
@@ -168,7 +168,7 @@ test "multiline string" {
 
 test "multiline string comments at start" {
     const s1 =
-        //\\one
+    //\\one
         \\two)
         \\three
     ;
@@ -180,7 +180,7 @@ test "multiline string comments at end" {
     const s1 =
         \\one
         \\two)
-        //\\three
+         //\\three
     ;
     const s2 = "one\ntwo)";
     expect(mem.eql(u8, s1, s2));
@@ -189,7 +189,7 @@ test "multiline string comments at end" {
 test "multiline string comments in middle" {
     const s1 =
         \\one
-        //\\two)
+         //\\two)
         \\three
     ;
     const s2 = "one\nthree";
@@ -199,9 +199,9 @@ test "multiline string comments in middle" {
 test "multiline string comments at multiple places" {
     const s1 =
         \\one
-        //\\two
+         //\\two
         \\three
-        //\\four
+         //\\four
         \\five
     ;
     const s2 = "one\nthree\nfive";
@@ -641,6 +641,9 @@ fn getNull() ?*i32 {
 }
 
 test "thread local variable" {
+    // TODO https://github.com/ziglang/zig/issues/7527
+    if (comptime std.Target.current.isDarwin() and builtin.arch == .aarch64) return error.SkipZigTest;
+
     const S = struct {
         threadlocal var t: i32 = 1234;
     };
@@ -728,6 +731,9 @@ test "result location is optional inside error union" {
 threadlocal var buffer: [11]u8 = undefined;
 
 test "pointer to thread local array" {
+    // TODO https://github.com/ziglang/zig/issues/7527
+    if (comptime std.Target.current.isDarwin() and builtin.arch == .aarch64) return error.SkipZigTest;
+
     const s = "Hello world";
     std.mem.copy(u8, buffer[0..], s);
     std.testing.expectEqualSlices(u8, buffer[0..], s);


### PR DESCRIPTION
In order to pass the test suite on Apple Silicon, I've had to disable any test that makes use of `threadlocal` variables due to problems with LLD. See issue ziglang/zig#7527 for more details.

With this PR landing, it is now possible to successfully execute `zig build test` on Apple Silicon. One word of caution though. I've noticed that cross-compiling behavior tests to 64-bit RISC architectures sporadically fails with integer overflow runtime trap. If that happens, re-running the test suite generally fixes the problem for some mysterious reason. I haven't investigated it yet, but leaving it here for posterity.

The next thing would be to get our hands on some Apple Silicon-based CI to have the tests triggered on every push and pull request.