### PR TITLE
Correctly cast bool to signed int in translate-c

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -644,4 +644,17 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("assign bool result to int or char",
+        \\#include <stdlib.h>
+        \\#include <stdbool.h>
+        \\bool foo() { return true; }
+        \\int main() {
+        \\    int x = foo();
+        \\    if (x != 1) abort();
+        \\    signed char c = foo();
+        \\    if (c != 1) abort();
+        \\    return 0;
+        \\}
+    , "");
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2964,10 +2964,10 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     , &[_][]const u8{
         \\pub export fn foo(arg_x: bool) bool {
         \\    var x = arg_x;
-        \\    var a: bool = (@intCast(c_int, @bitCast(i1, @intCast(u1, @boolToInt(x)))) != @as(c_int, 1));
-        \\    var b: bool = (@intCast(c_int, @bitCast(i1, @intCast(u1, @boolToInt(a)))) != @as(c_int, 0));
+        \\    var a: bool = (@as(c_int, @boolToInt(x)) != @as(c_int, 1));
+        \\    var b: bool = (@as(c_int, @boolToInt(a)) != @as(c_int, 0));
         \\    var c: bool = @ptrToInt(foo) != 0;
-        \\    return foo((@intCast(c_int, @bitCast(i1, @intCast(u1, @boolToInt(c)))) != @intCast(c_int, @bitCast(i1, @intCast(u1, @boolToInt(b))))));
+        \\    return foo((@as(c_int, @boolToInt(c)) != @as(c_int, @boolToInt(b))));
         \\}
     });
 


### PR DESCRIPTION
Previously casting a bool to an int would result in the following Zig code:

    @intCast(c_int, @bitCast(i1, @intCast(u1, @boolToInt(b))));

This is incorrect if `b` is true, since bitcasting a `u1` with the value 1
to an `i1` will result in the value -1. Instead, generate the following code:

    @as(c_int, @boolToInt(b));

Since @boolToInt returns a `u1`, this is only disallowed if the destination
type is one-bit and signed, which can only happen if it's a bitfield
(currently not supported by translate-c)