### PR TITLE
Fix paths on Windows

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1168,7 +1168,7 @@ pub const Dir = struct {
     /// Asserts that the path parameter has no null bytes.
     pub fn openDir(self: Dir, sub_path: []const u8, args: OpenDirOptions) OpenError!Dir {
         if (builtin.os.tag == .windows) {
-            const nt_path = try os.windows.NtPath.initA(sub_path);
+            const nt_path = try os.windows.NtPath.init((try os.windows.utf8ToWPathSpace(sub_path)).span());
             defer nt_path.deinit();
             return self.openDirWindows(std.fs.path.isAbsoluteWindows(sub_path), nt_path.str, args);
         } else if (builtin.os.tag == .wasi) {

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -79,8 +79,17 @@ test "openDirAbsolute" {
         break :blk try fs.realpathAlloc(&arena.allocator, relative_path);
     };
 
-    var dir = try fs.openDirAbsolute(base_path, .{});
-    defer dir.close();
+    {
+        var dir = try fs.openDirAbsolute(base_path, .{});
+        defer dir.close();
+    }
+
+    for ([_][]const u8 { ".", ".." }) |sub_path| {
+        const dir_path = try fs.path.join(&arena.allocator, &[_][]const u8 { base_path, sub_path });
+        defer arena.allocator.free(dir_path);
+        var dir = try fs.openDirAbsolute(dir_path, .{});
+        defer dir.close();
+    }
 }
 
 test "readLinkAbsolute" {

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -113,3 +113,10 @@ pub extern "NtDll" fn NtWaitForKeyedEvent(
 ) callconv(WINAPI) NTSTATUS;
 
 pub extern "NtDll" fn RtlSetCurrentDirectory_U(PathName: *UNICODE_STRING) callconv(WINAPI) NTSTATUS;
+
+pub extern "NtDll" fn RtlDosPathNameToNtPathName_U_WithStatus(
+  DosFileName: [*:0]const WCHAR,
+  NtFileName: *UNICODE_STRING,
+  FilePath: ?*[*:0]WCHAR,
+  cd: ?*CURDIR,
+) callconv(WINAPI) NTSTATUS;

--- a/lib/std/os/windows/test.zig
+++ b/lib/std/os/windows/test.zig
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2015-2020 Zig Contributors
+// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
+// The MIT license requires this copyright notice to be included in all copies
+// and substantial portions of the software.
+const std = @import("../../std.zig");
+const builtin = @import("builtin");
+const windows = std.os.windows;
+const mem = std.mem;
+const testing = std.testing;
+const expect = testing.expect;
+
+fn testNtPath(input: []const u8, expected: []const u8) !void {
+    const input_w = try std.unicode.utf8ToUtf16LeWithNull(testing.allocator, input);
+    defer testing.allocator.free(input_w);
+    const expected_w = try std.unicode.utf8ToUtf16LeWithNull(testing.allocator, expected);
+    defer testing.allocator.free(expected_w);
+
+    const nt_path = try windows.NtPath.init(input_w);
+    defer nt_path.deinit();
+    const relative_path = try windows.toRelativeNtPath(nt_path.str);
+    expect(mem.eql(u16, windows.unicodeSpan(relative_path), expected_w));
+}
+
+test "NtPath" {
+    try testNtPath("a", "a");
+    try testNtPath("a\\b", "a\\b");
+    try testNtPath("a\\.\\b", "a\\b");
+    try testNtPath("a\\..\\b", "b");
+}


### PR DESCRIPTION
fixes: https://github.com/ziglang/zig/issues/6044

This PR replaces the custom logic Zig has implemented to convert legacy DOS paths to NT paths with calls into `ntdll` to do the conversion for us.  These should be the same conversion functions that Win32 functions like `CreateFile` use to convert DOS paths to NT paths.

Now that `ntdll` is handling this conversion, missing features like support for `"."` and `".."` should be resolved.

### Follow Up: look for more NT calls

This PR has only replaced the implementation for the `openDir*` calls because those functions boil down to `NtCreateFile` which requires an NT formatted path.  We should see if there are any other filesystem functions that end up calling NT-specific functions and fix those as well (if there are any).  Look for places where `sliceToPrefixedFileW` is called and where those paths are passed to `NT` functions such as `NtCreateFile`.

### Follow Up: consider RtlDosPathNameToRelativeNtPathName_U_WithStatus

Another thing to follow up on is using `RtlDosPathNameToRelativeNtPathName_U_WithStatus` for relative paths.  The current mechanism uses `RtlDosPathNameToNtPathName_U_WithStatus` for the path and then removes the CWD prefix.  I don't know whether one implementation has benefits over the other.  There's also diverging implementations to consider, I noticed that Wine and ReactOS seemed to have differences in opinion on these functions, so we may want to keep our usage of them to a minimal subset.
