### PR TITLE
stage1: Create a new declaration scope for union enum types

### DIFF
--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -3281,7 +3281,8 @@ static Error resolve_union_zero_bits(CodeGen *g, ZigType *union_type) {
         tag_type->data.enumeration.src_field_count = field_count;
         tag_type->data.enumeration.fields = heap::c_allocator.allocate<TypeEnumField>(field_count);
         tag_type->data.enumeration.fields_by_name.init(field_count);
-        tag_type->data.enumeration.decls_scope = union_type->data.unionation.decls_scope;
+        tag_type->data.enumeration.decls_scope = create_decls_scope(
+                g, nullptr, nullptr, tag_type, get_scope_import(scope), &tag_type->name);
     } else if (enum_type_node != nullptr) {
         tag_type = analyze_type_expr(g, scope, enum_type_node);
     } else {

--- a/test/stage1/behavior/union.zig
+++ b/test/stage1/behavior/union.zig
@@ -761,3 +761,18 @@ test "@unionInit on union w/ tag but no fields" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "union enum type gets a separate scope" {
+    const S = struct {
+        const U = union(enum) {
+            a: u8,
+            const foo = 1;
+        };
+
+        fn doTheTest() void {
+            expect(!@hasDecl(@TagType(U), "foo"));
+        }
+    };
+
+    S.doTheTest();
+}


### PR DESCRIPTION
Making the enum type share the scope with the parent union means every
declaration "bleeds" into the enum scope.
Let's mint a fresh empty scope for the enum type.

Thanks to @Vexu for the test case.

Closes #7532