### PR TITLE
openbsd: define sem_t as optional pointer on opaque {}

### DIFF
--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -28,9 +28,10 @@ pub const pthread_cond_t = extern struct {
 pub const pthread_spinlock_t = extern struct {
     inner: ?*c_void = null,
 };
-
 pub const pthread_attr_t = extern struct {
     inner: ?*c_void = null,
 };
+
+pub const sem_t = ?*opaque {};
 
 pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;


### PR DESCRIPTION
on OpenBSD, `sem_t` is defined as a [pointer on opaque struct](https://github.com/openbsd/src/blob/master/include/semaphore.h#L44): there is no definition of `struct __sem` in userland.

Additionnally, a possible value of `sem_t` is `SEM_FAILED`, which is `(sem_t *)0` (aka `NULL`), so I used an optional pointer on `opaque {}` to be able to represent it.

Alternatively, it could be defined as `pthread_attr_t` with a struct on optional pointer on `c_void`, but I think zig `opaque {}` should be fine.

It unbreaks build on OpenBSD after #7519 which use `sem_t` in ResetEvent.zig