### PR TITLE
openbsd: add commonly used libc wrappers for pledge(2) and unveil(2)

### DIFF
--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -35,3 +35,6 @@ pub const pthread_attr_t = extern struct {
 pub const sem_t = ?*opaque {};
 
 pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
+
+pub extern "c" fn pledge(promises: ?[*:0]const u8, execpromises: ?[*:0]const u8) c_int;
+pub extern "c" fn unveil(path: ?[*:0]const u8, permissions: ?[*:0]const u8) c_int;


### PR DESCRIPTION
the following commit adds [pledge(2)](https://man.openbsd.org/pledge.2) and [unveil(2)](https://man.openbsd.org/unveil.2) syscalls definition in `std.c` for OpenBSD.
