### PR TITLE
remove "||=" from stage1

### DIFF
--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -818,7 +818,6 @@ enum BinOpType {
     BinOpTypeAssignBitAnd,
     BinOpTypeAssignBitXor,
     BinOpTypeAssignBitOr,
-    BinOpTypeAssignMergeErrorSets,
     BinOpTypeBoolOr,
     BinOpTypeBoolAnd,
     BinOpTypeCmpEq,

--- a/src/stage1/ast_render.cpp
+++ b/src/stage1/ast_render.cpp
@@ -49,7 +49,6 @@ static const char *bin_op_str(BinOpType bin_op) {
         case BinOpTypeAssignBitAnd:           return "&=";
         case BinOpTypeAssignBitXor:           return "^=";
         case BinOpTypeAssignBitOr:            return "|=";
-        case BinOpTypeAssignMergeErrorSets:   return "||=";
         case BinOpTypeUnwrapOptional:         return "orelse";
         case BinOpTypeArrayCat:               return "++";
         case BinOpTypeArrayMult:              return "**";

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -5748,19 +5748,6 @@ static IrInstSrc *ir_gen_assign(IrBuilderSrc *irb, Scope *scope, AstNode *node) 
     return ir_build_const_void(irb, scope, node);
 }
 
-static IrInstSrc *ir_gen_assign_merge_err_sets(IrBuilderSrc *irb, Scope *scope, AstNode *node) {
-    IrInstSrc *lvalue = ir_gen_node_extra(irb, node->data.bin_op_expr.op1, scope, LValAssign, nullptr);
-    if (lvalue == irb->codegen->invalid_inst_src)
-        return lvalue;
-    IrInstSrc *op1 = ir_build_load_ptr(irb, scope, node->data.bin_op_expr.op1, lvalue);
-    IrInstSrc *op2 = ir_gen_node(irb, node->data.bin_op_expr.op2, scope);
-    if (op2 == irb->codegen->invalid_inst_src)
-        return op2;
-    IrInstSrc *result = ir_build_merge_err_sets(irb, scope, node, op1, op2, nullptr);
-    ir_build_store_ptr(irb, scope, node, lvalue, result);
-    return ir_build_const_void(irb, scope, node);
-}
-
 static IrInstSrc *ir_gen_assign_op(IrBuilderSrc *irb, Scope *scope, AstNode *node, IrBinOp op_id) {
     IrInstSrc *lvalue = ir_gen_node_extra(irb, node->data.bin_op_expr.op1, scope, LValAssign, nullptr);
     if (lvalue == irb->codegen->invalid_inst_src)
@@ -6001,8 +5988,6 @@ static IrInstSrc *ir_gen_bin_op(IrBuilderSrc *irb, Scope *scope, AstNode *node, 
             return ir_lval_wrap(irb, scope, ir_gen_assign_op(irb, scope, node, IrBinOpBinXor), lval, result_loc);
         case BinOpTypeAssignBitOr:
             return ir_lval_wrap(irb, scope, ir_gen_assign_op(irb, scope, node, IrBinOpBinOr), lval, result_loc);
-        case BinOpTypeAssignMergeErrorSets:
-            return ir_lval_wrap(irb, scope, ir_gen_assign_merge_err_sets(irb, scope, node), lval, result_loc);
         case BinOpTypeBoolOr:
             return ir_lval_wrap(irb, scope, ir_gen_bool_or(irb, scope, node), lval, result_loc);
         case BinOpTypeBoolAnd:

--- a/src/stage1/parser.cpp
+++ b/src/stage1/parser.cpp
@@ -2460,7 +2460,6 @@ static AstNode *ast_parse_assign_op(ParseContext *pc) {
     // In C, we have `T arr[N] = {[i] = T{}};` but it doesn't
     // seem to work in C++...
     BinOpType table[TokenIdCount] = {};
-    table[TokenIdBarBarEq] = BinOpTypeAssignMergeErrorSets;
     table[TokenIdBitAndEq] = BinOpTypeAssignBitAnd;
     table[TokenIdBitOrEq] = BinOpTypeAssignBitOr;
     table[TokenIdBitShiftLeftEq] = BinOpTypeAssignBitShiftLeft;

--- a/src/stage1/tokenizer.cpp
+++ b/src/stage1/tokenizer.cpp
@@ -208,7 +208,6 @@ enum TokenizeState {
     TokenizeStateSawAmpersand,
     TokenizeStateSawCaret,
     TokenizeStateSawBar,
-    TokenizeStateSawBarBar,
     TokenizeStateDocComment,
     TokenizeStateContainerDocComment,
     TokenizeStateLineComment,
@@ -833,19 +832,6 @@ void tokenize(Buf *buf, Tokenization *out) {
                         break;
                     case '|':
                         set_token_id(&t, t.cur_tok, TokenIdBarBar);
-                        t.state = TokenizeStateSawBarBar;
-                        break;
-                    default:
-                        t.pos -= 1;
-                        end_token(&t);
-                        t.state = TokenizeStateStart;
-                        continue;
-                }
-                break;
-            case TokenizeStateSawBarBar:
-                switch (c) {
-                    case '=':
-                        set_token_id(&t, t.cur_tok, TokenIdBarBarEq);
                         end_token(&t);
                         t.state = TokenizeStateStart;
                         break;
@@ -1500,7 +1486,6 @@ void tokenize(Buf *buf, Tokenization *out) {
         case TokenizeStateSawMinusPercent:
         case TokenizeStateLineString:
         case TokenizeStateLineStringEnd:
-        case TokenizeStateSawBarBar:
         case TokenizeStateDocComment:
         case TokenizeStateContainerDocComment:
             end_token(&t);
@@ -1659,7 +1644,6 @@ const char * token_name(TokenId id) {
         case TokenIdTimesEq: return "*=";
         case TokenIdTimesPercent: return "*%";
         case TokenIdTimesPercentEq: return "*%=";
-        case TokenIdBarBarEq: return "||=";
         case TokenIdCount:
             zig_unreachable();
     }

--- a/src/stage1/tokenizer.hpp
+++ b/src/stage1/tokenizer.hpp
@@ -18,7 +18,6 @@ enum TokenId {
     TokenIdAtSign,
     TokenIdBang,
     TokenIdBarBar,
-    TokenIdBarBarEq,
     TokenIdBinOr,
     TokenIdBinXor,
     TokenIdBitAndEq,


### PR DESCRIPTION
Apparently it did assign merge error sets, but was not in the stage2 tokenizer/parser or the documentation, so I think it is depreciated.