### PR TITLE
Fix the damn deadlock

### DIFF
--- a/ci/drone/linux_script
+++ b/ci/drone/linux_script
@@ -17,8 +17,8 @@ git config core.abbrev 9
 
 mkdir build
 cd build
-# TODO figure out why Drone CI is deadlocking and stop passing -DZIG_SINGLE_THREADED=ON
-cmake .. -DCMAKE_BUILD_TYPE=Release "-DCMAKE_INSTALL_PREFIX=$DISTDIR" -DZIG_STATIC=ON -DCMAKE_PREFIX_PATH=/deps/local -GNinja -DZIG_SINGLE_THREADED=ON
+# TODO put this back on Release
+cmake .. -DCMAKE_BUILD_TYPE=Debug "-DCMAKE_INSTALL_PREFIX=$DISTDIR" -DZIG_STATIC=ON -DCMAKE_PREFIX_PATH=/deps/local -GNinja
 
 samu install
 ./zig build test -Dskip-release -Dskip-non-native

--- a/ci/drone/linux_script
+++ b/ci/drone/linux_script
@@ -17,8 +17,7 @@ git config core.abbrev 9
 
 mkdir build
 cd build
-# TODO put this back on Release
-cmake .. -DCMAKE_BUILD_TYPE=Debug "-DCMAKE_INSTALL_PREFIX=$DISTDIR" -DZIG_STATIC=ON -DCMAKE_PREFIX_PATH=/deps/local -GNinja
+cmake .. -DCMAKE_BUILD_TYPE=Release "-DCMAKE_INSTALL_PREFIX=$DISTDIR" -DZIG_STATIC=ON -DCMAKE_PREFIX_PATH=/deps/local -GNinja
 
 samu install
 ./zig build test -Dskip-release -Dskip-non-native

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -13,11 +13,10 @@ const fmt = std.fmt;
 const Allocator = std.mem.Allocator;
 
 /// Process-scoped map keeping track of all locked Cache hashes, to detect deadlocks.
-/// The plan is to enable this for debug builds only, but for now we enable
-/// it always to catch a deadlock.
+/// This protection is conditionally compiled depending on `want_debug_deadlock`.
 var all_cache_digest_set: std.AutoHashMapUnmanaged(BinDigest, void) = .{};
 var all_cache_digest_lock: std.Mutex = .{};
-const want_debug_deadlock = true; // TODO change this for release builds
+const want_debug_deadlock = std.debug.runtime_safety;
 const DebugBinDigest = if (want_debug_deadlock) BinDigest else void;
 const null_debug_bin_digest = if (want_debug_deadlock) ([1]u8{0} ** bin_digest_len) else {};
 


### PR DESCRIPTION
This branch adds debug code for detecting any deadlock in the Cache system. The fix is not in this branch yet but hopefully this new debug code will lead us to it.

I confirmed that when removing the code protecting detection of the same C source files:

```diff
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1865,25 +1865,6 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_comp_progress_node: *
         }
     }
 
-    {
-        const is_collision = blk: {
-            const bin_digest = man.hash.peekBin();
-
-            const lock = comp.mutex.acquire();
-            defer lock.release();
-
-            const gop = try comp.c_object_cache_digest_set.getOrPut(comp.gpa, bin_digest);
-            break :blk gop.found_existing;
-        };
-        if (is_collision) {
-            return comp.failCObj(
-                c_object,
-                "the same source file was already added to the same compilation with the same flags",
-                .{},
-            );
-        }
-    }
-
     var arena_allocator = std.heap.ArenaAllocator.init(comp.gpa);
     defer arena_allocator.deinit();
     const arena = &arena_allocator.allocator;

```

The detection code is indeed triggered:

```
[nix-shell:~/Downloads/zig/build]$ ./zig cc simple_race.c simple_race.c 
Cache deadlock detected in Cache.hit. Manifest has 1 files:
  file: /home/andy/Downloads/zig/build/simple_race.c
Cache deadlock detected
/home/andy/Downloads/zig/src/Cache.zig:277:17: 0xb54a1a in Cache.Manifest.hit (zig1)
                @panic("Cache deadlock detected");
                ^
/home/andy/Downloads/zig/src/Compilation.zig:1890:63: 0xd95574 in Compilation.updateCObject (zig1)
    const digest = if (!comp.disable_c_depfile and try man.hit()) man.final() else blk: {
                                                              ^
/home/andy/Downloads/zig/src/Compilation.zig:1805:23: 0xd94c48 in Compilation.workerUpdateCObject (zig1)
    comp.updateCObject(c_object, progress_node) catch |err| switch (err) {
                      ^
/home/andy/Downloads/zig/src/ThreadPool.zig:117:28: 0xd97cc8 in ThreadPool.Closure.runFn (zig1)
            const result = @call(.{}, func, closure.arguments);
                           ^
/home/andy/Downloads/zig/src/ThreadPool.zig:35:38: 0xbd2452 in ThreadPool.Worker.run (zig1)
                (run_node.data.runFn)(&run_node.data);
                                     ^
/home/andy/Downloads/zig/lib/std/thread.zig:268:32: 0xbd2847 in std.thread.MainFuncs.posixThreadMain (zig1)
                        startFn(arg);
                               ^
???:?:?: 0x7f66c692deac in ??? (???)
Aborted (core dumped)
```