### PR TITLE
std: add c._exit() and use in ChildProcess

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -81,6 +81,7 @@ pub extern "c" fn fread(ptr: [*]u8, size_of_type: usize, item_count: usize, stre
 pub extern "c" fn printf(format: [*:0]const u8, ...) c_int;
 pub extern "c" fn abort() noreturn;
 pub extern "c" fn exit(code: c_int) noreturn;
+pub extern "c" fn _exit(code: c_int) noreturn;
 pub extern "c" fn isatty(fd: fd_t) c_int;
 pub extern "c" fn close(fd: fd_t) c_int;
 pub extern "c" fn lseek(fd: fd_t, offset: off_t, whence: c_int) off_t;

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -819,8 +819,9 @@ fn forkChildErrReport(fd: i32, err: ChildProcess.SpawnError) noreturn {
     // which we really do not want to run in the fork child. I caught LLVM doing this and
     // it caused a deadlock instead of doing an exit syscall. In the words of Avril Lavigne,
     // "Why'd you have to go and make things so complicated?"
-    if (std.Target.current.os.tag == .linux) {
-        std.os.linux.exit(1); // By-pass libc regardless of whether it is linked.
+    if (builtin.link_libc) {
+        // The _exit(2) function does nothing but make the exit syscall, unlike exit(3)
+        std.c._exit(1);
     }
     os.exit(1);
 }


### PR DESCRIPTION
This issue with atexit() functions after forking isn't isolated to linux I'm sure, the proper way to do this when linking libc is to use _exit(2)

