### PR TITLE
Update event loop sendto error to SendToError

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -1262,7 +1262,7 @@ pub const Loop = struct {
         flags: u32,
         dest_addr: ?*const os.sockaddr,
         addrlen: os.socklen_t,
-    ) os.SendError!usize {
+    ) os.SendToError!usize {
         while (true) {
             return os.sendto(sockfd, buf, flags, dest_addr, addrlen) catch |err| switch (err) {
                 error.WouldBlock => {


### PR DESCRIPTION
Otherwise build fails with:

```zig
lib/zig/std/event/loop.zig:1272:32: error: expected type 'std.os.SendError', found 'std.os.SendToError'
                else => return err,
                               ^
```

See https://github.com/ziglang/zig/blob/master/lib/std/os.zig#L4758