### PR TITLE
stage2: make Alloc(Inferred) have mutabality info

### DIFF
--- a/src/zir.zig
+++ b/src/zir.zig
@@ -292,7 +292,6 @@ pub const Inst = struct {
                 .breakpoint,
                 .dbg_stmt,
                 .returnvoid,
-                .alloc_inferred,
                 .ret_ptr,
                 .ret_type,
                 .unreach_nocheck,
@@ -306,7 +305,6 @@ pub const Inst = struct {
                 .isnonnull,
                 .iserr,
                 .ptrtoint,
-                .alloc,
                 .ensure_result_used,
                 .ensure_result_non_error,
                 .ensure_indexable,
@@ -376,6 +374,8 @@ pub const Inst = struct {
                 .block_comptime_flat,
                 => Block,
 
+                .alloc => Alloc,
+                .alloc_inferred => AllocInferred,
                 .arg => Arg,
                 .array_type_sentinel => ArrayTypeSentinel,
                 .@"break" => Break,
@@ -581,6 +581,25 @@ pub const Inst = struct {
         positionals: struct {
             lhs: *Inst,
             rhs: *Inst,
+        },
+        kw_args: struct {},
+    };
+
+    pub const Alloc = struct {
+        pub const base_tag = Tag.alloc;
+        base: Inst,
+        positionals: struct {
+            operand: *Inst,
+            mutable: bool,
+        },
+        kw_args: struct {},
+    };
+
+    pub const AllocInferred = struct {
+        pub const base_tag = Tag.alloc;
+        base: Inst,
+        positionals: struct {
+            mutable: bool,
         },
         kw_args: struct {},
     };

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -41,8 +41,12 @@ pub const Inst = struct {
         /// Allocates stack local memory. Its lifetime ends when the block ends that contains
         /// this instruction. The operand is the type of the allocated object.
         alloc,
+        /// Same as `alloc` except mutable.
+        alloc_mut,
         /// Same as `alloc` except the type is inferred.
         alloc_inferred,
+        /// Same as `alloc_inferred` except mutable.
+        alloc_inferred_mut,
         /// Create an `anyframe->T`.
         anyframe_type,
         /// Array concatenation. `a ++ b`
@@ -289,6 +293,8 @@ pub const Inst = struct {
 
         pub fn Type(tag: Tag) type {
             return switch (tag) {
+                .alloc_inferred,
+                .alloc_inferred_mut,
                 .breakpoint,
                 .dbg_stmt,
                 .returnvoid,
@@ -298,6 +304,8 @@ pub const Inst = struct {
                 .@"unreachable",
                 => NoOp,
 
+                .alloc,
+                .alloc_mut,
                 .boolnot,
                 .deref,
                 .@"return",
@@ -374,8 +382,6 @@ pub const Inst = struct {
                 .block_comptime_flat,
                 => Block,
 
-                .alloc => Alloc,
-                .alloc_inferred => AllocInferred,
                 .arg => Arg,
                 .array_type_sentinel => ArrayTypeSentinel,
                 .@"break" => Break,
@@ -419,7 +425,9 @@ pub const Inst = struct {
                 .add,
                 .addwrap,
                 .alloc,
+                .alloc_mut,
                 .alloc_inferred,
+                .alloc_inferred_mut,
                 .array_cat,
                 .array_mul,
                 .array_type,
@@ -581,25 +589,6 @@ pub const Inst = struct {
         positionals: struct {
             lhs: *Inst,
             rhs: *Inst,
-        },
-        kw_args: struct {},
-    };
-
-    pub const Alloc = struct {
-        pub const base_tag = Tag.alloc;
-        base: Inst,
-        positionals: struct {
-            operand: *Inst,
-            mutable: bool,
-        },
-        kw_args: struct {},
-    };
-
-    pub const AllocInferred = struct {
-        pub const base_tag = Tag.alloc;
-        base: Inst,
-        positionals: struct {
-            mutable: bool,
         },
         kw_args: struct {},
     };

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -408,10 +408,9 @@ fn analyzeInstEnsureIndexable(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp)
     }
 }
 
-fn analyzeInstAlloc(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp) InnerError!*Inst {
+fn analyzeInstAlloc(mod: *Module, scope: *Scope, inst: *zir.Inst.Alloc) InnerError!*Inst {
     const var_type = try resolveType(mod, scope, inst.positionals.operand);
-    // TODO this should happen only for var allocs
-    if (!var_type.isValidVarType(false)) {
+    if (inst.positionals.mutable and !var_type.isValidVarType(false)) {
         return mod.fail(scope, inst.base.src, "variable of type '{}' must be const or comptime", .{var_type});
     }
     const ptr_type = try mod.simplePtrType(scope, inst.base.src, var_type, true, .One);
@@ -419,7 +418,7 @@ fn analyzeInstAlloc(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp) InnerErro
     return mod.addNoOp(b, inst.base.src, ptr_type, .alloc);
 }
 
-fn analyzeInstAllocInferred(mod: *Module, scope: *Scope, inst: *zir.Inst.NoOp) InnerError!*Inst {
+fn analyzeInstAllocInferred(mod: *Module, scope: *Scope, inst: *zir.Inst.AllocInferred) InnerError!*Inst {
     return mod.fail(scope, inst.base.src, "TODO implement analyzeInstAllocInferred", .{});
 }
 

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -27,7 +27,9 @@ const Decl = Module.Decl;
 pub fn analyzeInst(mod: *Module, scope: *Scope, old_inst: *zir.Inst) InnerError!*Inst {
     switch (old_inst.tag) {
         .alloc => return analyzeInstAlloc(mod, scope, old_inst.castTag(.alloc).?),
+        .alloc_mut => return analyzeInstAllocMut(mod, scope, old_inst.castTag(.alloc_mut).?),
         .alloc_inferred => return analyzeInstAllocInferred(mod, scope, old_inst.castTag(.alloc_inferred).?),
+        .alloc_inferred_mut => return analyzeInstAllocInferredMut(mod, scope, old_inst.castTag(.alloc_inferred_mut).?),
         .arg => return analyzeInstArg(mod, scope, old_inst.castTag(.arg).?),
         .bitcast_ref => return analyzeInstBitCastRef(mod, scope, old_inst.castTag(.bitcast_ref).?),
         .bitcast_result_ptr => return analyzeInstBitCastResultPtr(mod, scope, old_inst.castTag(.bitcast_result_ptr).?),
@@ -408,9 +410,16 @@ fn analyzeInstEnsureIndexable(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp)
     }
 }
 
-fn analyzeInstAlloc(mod: *Module, scope: *Scope, inst: *zir.Inst.Alloc) InnerError!*Inst {
+fn analyzeInstAlloc(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp) InnerError!*Inst {
     const var_type = try resolveType(mod, scope, inst.positionals.operand);
-    if (inst.positionals.mutable and !var_type.isValidVarType(false)) {
+    const ptr_type = try mod.simplePtrType(scope, inst.base.src, var_type, true, .One);
+    const b = try mod.requireRuntimeBlock(scope, inst.base.src);
+    return mod.addNoOp(b, inst.base.src, ptr_type, .alloc);
+}
+
+fn analyzeInstAllocMut(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp) InnerError!*Inst {
+    const var_type = try resolveType(mod, scope, inst.positionals.operand);
+    if (!var_type.isValidVarType(false)) {
         return mod.fail(scope, inst.base.src, "variable of type '{}' must be const or comptime", .{var_type});
     }
     const ptr_type = try mod.simplePtrType(scope, inst.base.src, var_type, true, .One);
@@ -418,8 +427,12 @@ fn analyzeInstAlloc(mod: *Module, scope: *Scope, inst: *zir.Inst.Alloc) InnerErr
     return mod.addNoOp(b, inst.base.src, ptr_type, .alloc);
 }
 
-fn analyzeInstAllocInferred(mod: *Module, scope: *Scope, inst: *zir.Inst.AllocInferred) InnerError!*Inst {
+fn analyzeInstAllocInferred(mod: *Module, scope: *Scope, inst: *zir.Inst.NoOp) InnerError!*Inst {
     return mod.fail(scope, inst.base.src, "TODO implement analyzeInstAllocInferred", .{});
+}
+
+fn analyzeInstAllocInferredMut(mod: *Module, scope: *Scope, inst: *zir.Inst.NoOp) InnerError!*Inst {
+    return mod.fail(scope, inst.base.src, "TODO implement analyzeInstAllocInferredMut", .{});
 }
 
 fn analyzeInstStore(mod: *Module, scope: *Scope, inst: *zir.Inst.BinOp) InnerError!*Inst {


### PR DESCRIPTION
This makes `Alloc` and `AllocInferred` their own ir instructions with a `bool` for mutable. This allows `analyzeInstAlloc` to check for mutability, fixing a TODO and paving the way for comptime constants that cannot be codegened.