### PR TITLE
fix race condition when starting (the event loop's) time wheel

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -796,10 +796,13 @@ pub const Loop = struct {
                 .waiters = DelayQueue.Waiters{
                     .entries = std.atomic.Queue(anyframe).init(),
                 },
-                .thread = try std.Thread.spawn(self, DelayQueue.run),
+                .thread = undefined,
                 .event = std.AutoResetEvent{},
-                .is_running = true,
+                .is_running = undefined,
             };
+
+            @atomicStore(bool, &self.is_running, true, .SeqCst);
+            self.thread = try std.Thread.spawn(self, DelayQueue.run);
         }
 
         /// Entry point for the timer thread


### PR DESCRIPTION
This condition was correctly reported by TSAN.

See how `run()` checks the `is_running` flag right away.