### PR TITLE
stage1: Prevent crash with some lazy pointer types

### DIFF
--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -13778,7 +13778,7 @@ static ZigValue *ir_resolve_type_lazy(IrAnalyze *ira, IrInstGen *type_value) {
 
     Error err;
     if ((err = ir_resolve_const_val(ira->codegen, ira->new_irb.exec, type_value->base.source_node,
-                    type_value->value, LazyOk)))
+                    type_value->value, LazyOkNoUndef)))
     {
         return nullptr;
     }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,6 +2,16 @@ const tests = @import("tests.zig");
 const std = @import("std");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
+    cases.add("lazy pointer with undefined element type",
+        \\export fn foo() void {
+        \\    comptime var T: type = undefined;
+        \\    const S = struct { x: *T };
+        \\    const I = @typeInfo(S);
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:3:28: error: use of undefined value here causes undefined behavior",
+    });
+
     cases.add("pointer arithmetic on pointer-to-array",
         \\export fn foo() void {
         \\    var x: [10]u8 = undefined;


### PR DESCRIPTION
Make sure the child element is not undefined, let's catch this problem
early on.

Closes #7568