### PR TITLE
fix segfault in std.fs.Walker

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2183,7 +2183,7 @@ pub const Walker = struct {
         while (true) {
             if (self.stack.items.len == 0) return null;
             // `top` becomes invalid after appending to `self.stack`.
-            const top = &self.stack.items[self.stack.items.len - 1];
+            var top = &self.stack.items[self.stack.items.len - 1];
             const dirname_len = top.dirname_len;
             if (try top.dir_it.next()) |base| {
                 self.name_buffer.shrink(dirname_len);
@@ -2200,6 +2200,7 @@ pub const Walker = struct {
                             .dir_it = new_dir.iterate(),
                             .dirname_len = self.name_buffer.items.len,
                         });
+                        top = &self.stack.items[self.stack.items.len - 1];
                     }
                 }
                 return Entry{


### PR DESCRIPTION
I'm not sure exactly what makes the test fail at 8 sub directories for me, it might not fail for other people.
The test also uses `testing.allocator` directly when calling `walkPath`, I wasn't able to reproduce it using `&arena.allocator`.

I've verified the fix on a couple of crashes using the code in #7560 