### PR TITLE
stage2: @compileLog

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1353,8 +1353,7 @@ pub fn totalErrorCount(self: *Compilation) usize {
         total += module.failed_decls.items().len +
             module.failed_exports.items().len +
             module.failed_files.items().len +
-            @boolToInt(module.failed_root_src_file != null) +
-            module.failed_files.items().len;
+            @boolToInt(module.failed_root_src_file != null);
         for (module.compile_log_decls.items()) |entry| {
             total += entry.value.items.len;
         }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1353,7 +1353,11 @@ pub fn totalErrorCount(self: *Compilation) usize {
         total += module.failed_decls.items().len +
             module.failed_exports.items().len +
             module.failed_files.items().len +
-            @boolToInt(module.failed_root_src_file != null);
+            @boolToInt(module.failed_root_src_file != null) +
+            module.failed_files.items().len;
+        for (module.compile_log_decls.items()) |entry| {
+            total += entry.value.items.len;
+        }
     }
 
     // The "no entry point found" error only counts if there are no other errors.
@@ -1403,6 +1407,15 @@ pub fn getAllErrorsAlloc(self: *Compilation) !AllErrors {
                 file_path, @errorName(err),
             });
             try AllErrors.addPlain(&arena, &errors, msg);
+        }
+        for (module.compile_log_decls.items()) |entry| {
+            const decl = entry.key;
+            const path = decl.scope.subFilePath();
+            const source = try decl.scope.getSource(module);
+            for (entry.value.items) |src_loc| {
+                const err_msg = ErrorMsg{ .byte_offset = src_loc, .msg = "found compile log statement" };
+                try AllErrors.add(&arena, &errors, path, source, err_msg);
+            }
         }
     }
 

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -54,6 +54,8 @@ decl_table: std.ArrayHashMapUnmanaged(Scope.NameHash, *Decl, Scope.name_hash_has
 /// Note that a Decl can succeed but the Fn it represents can fail. In this case,
 /// a Decl can have a failed_decls entry but have analysis status of success.
 failed_decls: std.AutoArrayHashMapUnmanaged(*Decl, *Compilation.ErrorMsg) = .{},
+/// A Decl can have multiple compileLogs, but only one error, so we map a Decl to a the src locs of all the compileLogs
+compile_log_decls: std.AutoArrayHashMapUnmanaged(*Decl, *ArrayListUnmanaged(usize)) = .{},
 /// Using a map here for consistency with the other fields here.
 /// The ErrorMsg memory is owned by the `Scope`, using Module's general purpose allocator.
 failed_files: std.AutoArrayHashMapUnmanaged(*Scope, *Compilation.ErrorMsg) = .{},
@@ -863,6 +865,12 @@ pub fn deinit(self: *Module) void {
         entry.value.destroy(gpa);
     }
     self.failed_exports.deinit(gpa);
+
+    for (self.compile_log_decls.items()) |entry| {
+        entry.value.deinit(gpa);
+        gpa.destroy(entry.value);
+    }
+    self.compile_log_decls.deinit(gpa);
 
     for (self.decl_exports.items()) |entry| {
         const export_list = entry.value;
@@ -2948,6 +2956,56 @@ pub fn failNode(
     return self.fail(scope, src, format, args);
 }
 
+fn addCompileLog(self: *Module, decl: *Decl, src: usize) error{OutOfMemory}!void {
+    var res = self.compile_log_decls.get(decl);
+    if (res) |value| {
+        try value.append(self.gpa, src);
+    } else {
+        // TODO does it have to be this complicated. why doesn't ArrayListUnmanaged have initCapacityAlloc that returns a heap allocated ArrayList?
+        var new_list = try self.gpa.create(ArrayListUnmanaged(usize));
+        const new_memory = try self.gpa.alloc(usize, 1);
+        new_list.items.ptr = new_memory.ptr;
+        new_list.items.len = 0;
+        new_list.capacity = new_memory.len;
+        new_list.appendAssumeCapacity(src);
+        try self.compile_log_decls.put(self.gpa, decl, new_list);
+    }
+}
+pub fn failCompileLog(
+    self: *Module,
+    scope: *Scope,
+    src: usize,
+) InnerError!void { // we do void because we dont actually want to fail because analysis should continue
+    switch (scope.tag) {
+        .decl => {
+            const decl = scope.cast(Scope.DeclAnalysis).?.decl;
+            try self.addCompileLog(decl, src);
+        },
+        .block => {
+            const block = scope.cast(Scope.Block).?;
+            try self.addCompileLog(block.decl, src);
+        },
+        .gen_zir => {
+            const gen_zir = scope.cast(Scope.GenZIR).?;
+            try self.addCompileLog(gen_zir.decl, src);
+        },
+        .local_val => {
+            const gen_zir = scope.cast(Scope.LocalVal).?.gen_zir;
+            try self.addCompileLog(gen_zir.decl, src);
+        },
+        .local_ptr => {
+            const gen_zir = scope.cast(Scope.LocalPtr).?.gen_zir;
+            try self.addCompileLog(gen_zir.decl, src);
+        },
+        .zir_module => {
+            // TODO is this actually unreachable?
+            unreachable;
+            // const zir_module = scope.cast(Scope.ZIRModule).?;
+        },
+        .file => unreachable,
+        .container => unreachable,
+    }
+}
 fn failWithOwnedErrorMsg(self: *Module, scope: *Scope, src: usize, err_msg: *Compilation.ErrorMsg) InnerError {
     {
         errdefer err_msg.destroy(self.gpa);

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2964,7 +2964,7 @@ pub fn failCompileLog(
     self: *Module,
     scope: *Scope,
     src: usize,
-) InnerError!void { 
+) InnerError!void {
     switch (scope.tag) {
         .decl => {
             const decl = scope.cast(Scope.DeclAnalysis).?.decl;
@@ -2988,7 +2988,8 @@ pub fn failCompileLog(
         },
         .zir_module,
         .file,
-        .container, => unreachable,
+        .container,
+        => unreachable,
     }
 }
 

--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -2349,6 +2349,16 @@ fn typeOf(mod: *Module, scope: *Scope, rl: ResultLoc, call: *ast.Node.BuiltinCal
         items[param_i] = try expr(mod, scope, .none, param);
     return rlWrap(mod, scope, rl, try addZIRInst(mod, scope, src, zir.Inst.TypeOfPeer, .{ .items = items }, .{}));
 }
+fn compileLog(mod: *Module, scope: *Scope, call: *ast.Node.BuiltinCall) InnerError!*zir.Inst {
+    const tree = scope.tree();
+    const arena = scope.arena();
+    const src = tree.token_locs[call.builtin_token].start;
+    const params = call.params();
+    var targets = try arena.alloc(*zir.Inst, params.len);
+    for (params) |param, param_i|
+        targets[param_i] = try expr(mod, scope, .none, param);
+    return addZIRInst(mod, scope, src, zir.Inst.CompileLog, .{ .to_log = targets }, .{});
+}
 
 fn builtinCall(mod: *Module, scope: *Scope, rl: ResultLoc, call: *ast.Node.BuiltinCall) InnerError!*zir.Inst {
     const tree = scope.tree();
@@ -2378,6 +2388,8 @@ fn builtinCall(mod: *Module, scope: *Scope, rl: ResultLoc, call: *ast.Node.Built
         return rlWrap(mod, scope, rl, try import(mod, scope, call));
     } else if (mem.eql(u8, builtin_name, "@compileError")) {
         return compileError(mod, scope, call);
+    } else if (mem.eql(u8, builtin_name, "@compileLog")) {
+        return compileLog(mod, scope, call);
     } else {
         return mod.failTok(scope, call.builtin_token, "invalid builtin function: '{}'", .{builtin_name});
     }

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -126,6 +126,8 @@ pub const Inst = struct {
         coerce_to_ptr_elem,
         /// Emit an error message and fail compilation.
         compileerror,
+        /// Log compile time variables and emit an error message.
+        compilelog,
         /// Conditional branch. Splits control flow based on a boolean condition value.
         condbr,
         /// Special case, has no textual representation.
@@ -392,6 +394,8 @@ pub const Inst = struct {
                 .declval => DeclVal,
                 .declval_in_module => DeclValInModule,
                 .coerce_result_block_ptr => CoerceResultBlockPtr,
+                .compileerror => CompileError,
+                .compilelog => CompileLog,
                 .loop => Loop,
                 .@"const" => Const,
                 .str => Str,
@@ -528,6 +532,7 @@ pub const Inst = struct {
                 .breakvoid,
                 .condbr,
                 .compileerror,
+                .compilelog,
                 .@"return",
                 .returnvoid,
                 .unreach_nocheck,
@@ -701,6 +706,26 @@ pub const Inst = struct {
         positionals: struct {
             dest_type: *Inst,
             block: *Block,
+        },
+        kw_args: struct {},
+    };
+
+    pub const CompileError = struct {
+        pub const base_tag = Tag.compileerror;
+        base: Inst,
+
+        positionals: struct {
+            msg: []const u8,
+        },
+        kw_args: struct {},
+    };
+
+    pub const CompileLog = struct {
+        pub const base_tag = Tag.compilelog;
+        base: Inst,
+
+        positionals: struct {
+            to_log: []*Inst,
         },
         kw_args: struct {},
     };

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -394,7 +394,6 @@ pub const Inst = struct {
                 .declval => DeclVal,
                 .declval_in_module => DeclValInModule,
                 .coerce_result_block_ptr => CoerceResultBlockPtr,
-                .compileerror => CompileError,
                 .compilelog => CompileLog,
                 .loop => Loop,
                 .@"const" => Const,
@@ -706,16 +705,6 @@ pub const Inst = struct {
         positionals: struct {
             dest_type: *Inst,
             block: *Block,
-        },
-        kw_args: struct {},
-    };
-
-    pub const CompileError = struct {
-        pub const base_tag = Tag.compileerror;
-        base: Inst,
-
-        positionals: struct {
-            msg: []const u8,
         },
         kw_args: struct {},
     };

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -526,13 +526,13 @@ pub const Inst = struct {
                 .import,
                 .switch_range,
                 .typeof_peer,
+                .compilelog,
                 => false,
 
                 .@"break",
                 .breakvoid,
                 .condbr,
                 .compileerror,
-                .compilelog,
                 .@"return",
                 .returnvoid,
                 .unreach_nocheck,
@@ -727,7 +727,10 @@ pub const Inst = struct {
         positionals: struct {
             to_log: []*Inst,
         },
-        kw_args: struct {},
+        kw_args: struct {
+            /// If we have seen it already so don't make another error
+            seen: bool = false,
+        },
     };
 
     pub const Const = struct {

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -516,7 +516,9 @@ fn analyzeInstCompileLog(mod: *Module, scope: *Scope, inst: *zir.Inst.CompileLog
     }
     std.debug.print("\n", .{});
     if (!inst.kw_args.seen) {
-        inst.kw_args.seen = true; // so that we do not give multiple compile errors if it gets evaled twice
+
+        // so that we do not give multiple compile errors if it gets evaled twice
+        inst.kw_args.seen = true;
         try mod.failCompileLog(scope, inst.base.src);
     }
     return mod.constVoid(scope, inst.base.src);

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -45,6 +45,7 @@ pub fn analyzeInst(mod: *Module, scope: *Scope, old_inst: *zir.Inst) InnerError!
         .coerce_result_ptr => return analyzeInstCoerceResultPtr(mod, scope, old_inst.castTag(.coerce_result_ptr).?),
         .coerce_to_ptr_elem => return analyzeInstCoerceToPtrElem(mod, scope, old_inst.castTag(.coerce_to_ptr_elem).?),
         .compileerror => return analyzeInstCompileError(mod, scope, old_inst.castTag(.compileerror).?),
+        .compilelog => return analyzeInstCompileLog(mod, scope, old_inst.castTag(.compilelog).?),
         .@"const" => return analyzeInstConst(mod, scope, old_inst.castTag(.@"const").?),
         .dbg_stmt => return analyzeInstDbgStmt(mod, scope, old_inst.castTag(.dbg_stmt).?),
         .declref => return analyzeInstDeclRef(mod, scope, old_inst.castTag(.declref).?),
@@ -500,6 +501,21 @@ fn analyzeInstExport(mod: *Module, scope: *Scope, export_inst: *zir.Inst.Export)
 fn analyzeInstCompileError(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp) InnerError!*Inst {
     const msg = try resolveConstString(mod, scope, inst.positionals.operand);
     return mod.fail(scope, inst.base.src, "{}", .{msg});
+}
+
+fn analyzeInstCompileLog(mod: *Module, scope: *Scope, inst: *zir.Inst.CompileLog) InnerError!*Inst {
+    std.debug.print("| ", .{});
+    for (inst.positionals.to_log) |item, i| {
+        const to_log = try resolveInst(mod, scope, item);
+        if (to_log.value()) |val| {
+            std.debug.print("{}", .{val});
+        } else {
+            std.debug.print("(runtime value)", .{});
+        }
+        if (i != inst.positionals.to_log.len - 1) std.debug.print(", ", .{});
+    }
+    std.debug.print("\n", .{});
+    return mod.fail(scope, inst.base.src, "found compile log statement", .{});
 }
 
 fn analyzeInstArg(mod: *Module, scope: *Scope, inst: *zir.Inst.Arg) InnerError!*Inst {

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -515,9 +515,9 @@ fn analyzeInstCompileLog(mod: *Module, scope: *Scope, inst: *zir.Inst.CompileLog
         if (i != inst.positionals.to_log.len - 1) std.debug.print(", ", .{});
     }
     std.debug.print("\n", .{});
-    switch (mod.fail(scope, inst.base.src, "found compile log statement", .{})) {
-        error.AnalysisFail => {},
-        else => |e| return e,
+    if (!inst.kw_args.seen) {
+        inst.kw_args.seen = true; // so that we do not give multiple compile errors if it gets evaled twice
+        try mod.failCompileLog(scope, inst.base.src);
     }
     return mod.constVoid(scope, inst.base.src);
 }

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -515,7 +515,11 @@ fn analyzeInstCompileLog(mod: *Module, scope: *Scope, inst: *zir.Inst.CompileLog
         if (i != inst.positionals.to_log.len - 1) std.debug.print(", ", .{});
     }
     std.debug.print("\n", .{});
-    return mod.fail(scope, inst.base.src, "found compile log statement", .{});
+    switch (mod.fail(scope, inst.base.src, "found compile log statement", .{})) {
+        error.AnalysisFail => {},
+        else => |e| return e,
+    }
+    return mod.constVoid(scope, inst.base.src);
 }
 
 fn analyzeInstArg(mod: *Module, scope: *Scope, inst: *zir.Inst.Arg) InnerError!*Inst {

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1195,6 +1195,16 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , &[_][]const u8{":3:9: error: redefinition of 'testing'"});
     }
+    ctx.compileError("compileLog", linux_x64,
+        \\export fn _start() noreturn {
+        \\  const b = true;
+        \\  var f: u32 = 1;
+        \\  @compileLog(b, 20, f, x);
+        \\  unreachable;
+        \\}
+        \\fn x() void {}
+    , &[_][]const u8{":4:3: error: found compile log statement"});
+    // "| true, 20, (runtime value), (function)" // TODO if this is here it invalidates the compile error checker. Need a way to check though.
 
     {
         var case = ctx.obj("extern variable has no type", linux_x64);

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1200,11 +1200,19 @@ pub fn addCases(ctx: *TestContext) !void {
         \\  const b = true;
         \\  var f: u32 = 1;
         \\  @compileLog(b, 20, f, x);
+        \\  @compileLog(1000);
+        \\  var bruh: usize = true;
         \\  unreachable;
         \\}
         \\fn x() void {}
-    , &[_][]const u8{":4:3: error: found compile log statement"});
-    // "| true, 20, (runtime value), (function)" // TODO if this is here it invalidates the compile error checker. Need a way to check though.
+    , &[_][]const u8{
+        ":4:3: error: found compile log statement",
+        ":5:3: error: found compile log statement",
+        ":6:21: error: expected usize, found bool",
+    });
+    // TODO if this is here it invalidates the compile error checker:
+    // "| true, 20, (runtime value), (function)"
+    // "| 1000"
 
     {
         var case = ctx.obj("extern variable has no type", linux_x64);


### PR DESCRIPTION
This is an improvement from the previous pr because it gives Module a `compile_log_decls` field that stores a map from a Decl -> ArrayList(usize) for the locations of the compileLog in the Decl. This allows multiple `@compileLogs` to coexist with regular compile errors.

See #7218
