### PR TITLE
stage2: More improvements to self-hosted LLVM backend

### DIFF
--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -16,7 +16,8 @@ const Allocator = std.mem.Allocator;
 /// This protection is conditionally compiled depending on `want_debug_deadlock`.
 var all_cache_digest_set: std.AutoHashMapUnmanaged(BinDigest, void) = .{};
 var all_cache_digest_lock: std.Mutex = .{};
-const want_debug_deadlock = std.debug.runtime_safety;
+// TODO: Figure out how to make sure that `all_cache_digest_set` does not leak memory!
+pub const want_debug_deadlock = false;
 const DebugBinDigest = if (want_debug_deadlock) BinDigest else void;
 const null_debug_bin_digest = if (want_debug_deadlock) ([1]u8{0} ** bin_digest_len) else {};
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1173,6 +1173,7 @@ pub fn destroy(self: *Compilation) void {
 
     const gpa = self.gpa;
     self.work_queue.deinit();
+    self.c_object_work_queue.deinit();
 
     {
         var it = self.crt_files.iterator();
@@ -1200,6 +1201,10 @@ pub fn destroy(self: *Compilation) void {
     }
     if (self.libc_static_lib) |*crt_file| {
         crt_file.deinit(gpa);
+    }
+
+    if (self.glibc_so_files) |*glibc_file| {
+        glibc_file.deinit(gpa);
     }
 
     for (self.c_object_table.items()) |entry| {

--- a/src/DepTokenizer.zig
+++ b/src/DepTokenizer.zig
@@ -927,7 +927,7 @@ fn depTokenizer(input: []const u8, expect: []const u8) !void {
     try out.writeAll("\n");
     try printSection(out, "<<<< input", input);
     try printSection(out, "==== expect", expect);
-    try printSection(out, ">>>> got", got);
+    try printSection(out, ">>>> got", buffer.items);
     try printRuler(out);
 
     testing.expect(false);

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -811,8 +811,11 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
     // If there is no Zig code to compile, then we should skip flushing the output file because it
     // will not be part of the linker line anyway.
     const module_obj_path: ?[]const u8 = if (self.base.options.module) |module| blk: {
-        const use_stage1 = build_options.is_stage1 and self.base.options.use_llvm;
-        if (use_stage1) {
+        // Both stage1 and stage2 LLVM backend put the object file in the cache directory.
+        if (self.base.options.use_llvm) {
+            // Stage2 has to call flushModule since that outputs the LLVM object file.
+            if (!build_options.is_stage1) try self.flushModule(comp);
+
             const obj_basename = try std.zig.binNameAlloc(arena, .{
                 .root_name = self.base.options.root_name,
                 .target = self.base.options.target,

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1251,8 +1251,11 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
     // If there is no Zig code to compile, then we should skip flushing the output file because it
     // will not be part of the linker line anyway.
     const module_obj_path: ?[]const u8 = if (self.base.options.module) |module| blk: {
-        const use_stage1 = build_options.is_stage1 and self.base.options.use_llvm;
-        if (use_stage1) {
+        // Both stage1 and stage2 LLVM backend put the object file in the cache directory.
+        if (self.base.options.use_llvm) {
+            // Stage2 has to call flushModule since that outputs the LLVM object file.
+            if (!build_options.is_stage1) try self.flushModule(comp);
+
             const obj_basename = try std.zig.binNameAlloc(arena, .{
                 .root_name = self.base.options.root_name,
                 .target = self.base.options.target,

--- a/src/llvm_backend.zig
+++ b/src/llvm_backend.zig
@@ -312,6 +312,7 @@ pub const LLVMIRModule = struct {
                         .arg => try self.genArg(inst.castTag(.arg).?),
                         .alloc => try self.genAlloc(inst.castTag(.alloc).?),
                         .store => try self.genStore(inst.castTag(.store).?),
+                        .load => try self.genLoad(inst.castTag(.load).?),
                         .dbg_stmt => blk: {
                             // TODO: implement debug info
                             break :blk null;
@@ -394,6 +395,11 @@ pub const LLVMIRModule = struct {
         const ptr = try self.resolveInst(inst.lhs);
         _ = self.builder.buildStore(val, ptr);
         return null;
+    }
+
+    fn genLoad(self: *LLVMIRModule, inst: *Inst.UnOp) !?*const llvm.ValueRef {
+        const ptr_val = try self.resolveInst(inst.operand);
+        return self.builder.buildLoad(ptr_val, "");
     }
 
     fn genBreakpoint(self: *LLVMIRModule, inst: *Inst.NoOp) !?*const llvm.ValueRef {

--- a/src/llvm_backend.zig
+++ b/src/llvm_backend.zig
@@ -271,6 +271,7 @@ pub const LLVMIRModule = struct {
             error.CodegenFail => {
                 decl.analysis = .codegen_failure;
                 try module.failed_decls.put(module.gpa, decl, self.err_msg.?);
+                self.err_msg = null;
                 return;
             },
             else => |e| return e,

--- a/src/llvm_bindings.zig
+++ b/src/llvm_bindings.zig
@@ -122,6 +122,9 @@ pub const BuilderRef = opaque {
 
     pub const buildAlloca = LLVMBuildAlloca;
     extern fn LLVMBuildAlloca(*const BuilderRef, Ty: *const TypeRef, Name: [*:0]const u8) *const ValueRef;
+
+    pub const buildStore = LLVMBuildStore;
+    extern fn LLVMBuildStore(*const BuilderRef, Val: *const ValueRef, Ptr: *const ValueRef) *const ValueRef;
 };
 
 pub const BasicBlockRef = opaque {

--- a/src/llvm_bindings.zig
+++ b/src/llvm_bindings.zig
@@ -125,6 +125,9 @@ pub const BuilderRef = opaque {
 
     pub const buildStore = LLVMBuildStore;
     extern fn LLVMBuildStore(*const BuilderRef, Val: *const ValueRef, Ptr: *const ValueRef) *const ValueRef;
+
+    pub const buildLoad = LLVMBuildLoad;
+    extern fn LLVMBuildLoad(*const BuilderRef, PointerVal: *const ValueRef, Name: [*:0]const u8) *const ValueRef;
 };
 
 pub const BasicBlockRef = opaque {

--- a/src/llvm_bindings.zig
+++ b/src/llvm_bindings.zig
@@ -63,9 +63,15 @@ pub const ModuleRef = opaque {
     pub const getNamedFunction = LLVMGetNamedFunction;
     extern fn LLVMGetNamedFunction(*const ModuleRef, Name: [*:0]const u8) ?*const ValueRef;
 
+    pub const getIntrinsicDeclaration = LLVMGetIntrinsicDeclaration;
+    extern fn LLVMGetIntrinsicDeclaration(Mod: *const ModuleRef, ID: c_uint, ParamTypes: ?[*]*const TypeRef, ParamCount: usize) *const ValueRef;
+
     pub const printToString = LLVMPrintModuleToString;
     extern fn LLVMPrintModuleToString(*const ModuleRef) [*:0]const u8;
 };
+
+pub const lookupIntrinsicID = LLVMLookupIntrinsicID;
+extern fn LLVMLookupIntrinsicID(Name: [*]const u8, NameLen: usize) c_uint;
 
 pub const disposeMessage = LLVMDisposeMessage;
 extern fn LLVMDisposeMessage(Message: [*:0]const u8) void;

--- a/src/llvm_bindings.zig
+++ b/src/llvm_bindings.zig
@@ -43,8 +43,14 @@ pub const TypeRef = opaque {
     pub const constAllOnes = LLVMConstAllOnes;
     extern fn LLVMConstAllOnes(Ty: *const TypeRef) *const ValueRef;
 
+    pub const constInt = LLVMConstInt;
+    extern fn LLVMConstInt(IntTy: *const TypeRef, N: c_ulonglong, SignExtend: LLVMBool) *const ValueRef;
+
     pub const getUndef = LLVMGetUndef;
     extern fn LLVMGetUndef(Ty: *const TypeRef) *const ValueRef;
+
+    pub const pointerType = LLVMPointerType;
+    extern fn LLVMPointerType(ElementType: *const TypeRef, AddressSpace: c_uint) *const TypeRef;
 };
 
 pub const ModuleRef = opaque {
@@ -81,6 +87,9 @@ pub const VerifierFailureAction = extern enum {
     PrintMessage,
     ReturnStatus,
 };
+
+pub const constNeg = LLVMConstNeg;
+extern fn LLVMConstNeg(ConstantVal: *const ValueRef) *const ValueRef;
 
 pub const voidType = LLVMVoidType;
 extern fn LLVMVoidType() *const TypeRef;
@@ -143,6 +152,24 @@ pub const BuilderRef = opaque {
 
     pub const buildNot = LLVMBuildNot;
     extern fn LLVMBuildNot(*const BuilderRef, V: *const ValueRef, Name: [*:0]const u8) *const ValueRef;
+
+    pub const buildNSWAdd = LLVMBuildNSWAdd;
+    extern fn LLVMBuildNSWAdd(*const BuilderRef, LHS: *const ValueRef, RHS: *const ValueRef, Name: [*:0]const u8) *const ValueRef;
+
+    pub const buildNUWAdd = LLVMBuildNUWAdd;
+    extern fn LLVMBuildNUWAdd(*const BuilderRef, LHS: *const ValueRef, RHS: *const ValueRef, Name: [*:0]const u8) *const ValueRef;
+
+    pub const buildNSWSub = LLVMBuildNSWSub;
+    extern fn LLVMBuildNSWSub(*const BuilderRef, LHS: *const ValueRef, RHS: *const ValueRef, Name: [*:0]const u8) *const ValueRef;
+
+    pub const buildNUWSub = LLVMBuildNUWSub;
+    extern fn LLVMBuildNUWSub(*const BuilderRef, LHS: *const ValueRef, RHS: *const ValueRef, Name: [*:0]const u8) *const ValueRef;
+
+    pub const buildIntCast2 = LLVMBuildIntCast2;
+    extern fn LLVMBuildIntCast2(*const BuilderRef, Val: *const ValueRef, DestTy: *const TypeRef, IsSigned: LLVMBool, Name: [*:0]const u8) *const ValueRef;
+
+    pub const buildBitCast = LLVMBuildBitCast;
+    extern fn LLVMBuildBitCast(*const BuilderRef, Val: *const ValueRef, DestTy: *const TypeRef, Name: [*:0]const u8) *const ValueRef;
 };
 
 pub const BasicBlockRef = opaque {

--- a/src/llvm_bindings.zig
+++ b/src/llvm_bindings.zig
@@ -79,6 +79,9 @@ pub const VerifierFailureAction = extern enum {
 pub const voidType = LLVMVoidType;
 extern fn LLVMVoidType() *const TypeRef;
 
+pub const getParam = LLVMGetParam;
+extern fn LLVMGetParam(Fn: *const ValueRef, Index: c_uint) *const ValueRef;
+
 pub const getEnumAttributeKindForName = LLVMGetEnumAttributeKindForName;
 extern fn LLVMGetEnumAttributeKindForName(Name: [*]const u8, SLen: usize) c_uint;
 
@@ -117,6 +120,9 @@ pub const BuilderRef = opaque {
     pub const buildRetVoid = LLVMBuildRetVoid;
     extern fn LLVMBuildRetVoid(*const BuilderRef) *const ValueRef;
 
+    pub const buildRet = LLVMBuildRet;
+    extern fn LLVMBuildRet(*const BuilderRef, V: *const ValueRef) *const ValueRef;
+
     pub const buildUnreachable = LLVMBuildUnreachable;
     extern fn LLVMBuildUnreachable(*const BuilderRef) *const ValueRef;
 
@@ -128,6 +134,9 @@ pub const BuilderRef = opaque {
 
     pub const buildLoad = LLVMBuildLoad;
     extern fn LLVMBuildLoad(*const BuilderRef, PointerVal: *const ValueRef, Name: [*:0]const u8) *const ValueRef;
+
+    pub const buildNot = LLVMBuildNot;
+    extern fn LLVMBuildNot(*const BuilderRef, V: *const ValueRef, Name: [*:0]const u8) *const ValueRef;
 };
 
 pub const BasicBlockRef = opaque {

--- a/src/test.zig
+++ b/src/test.zig
@@ -135,6 +135,7 @@ pub const TestContext = struct {
         extension: Extension,
         object_format: ?std.builtin.ObjectFormat = null,
         emit_h: bool = false,
+        llvm_backend: bool = false,
 
         files: std.ArrayList(File),
 
@@ -262,6 +263,21 @@ pub const TestContext = struct {
             .extension = .Zig,
             .object_format = .c,
             .files = std.ArrayList(File).init(ctx.cases.allocator),
+        }) catch unreachable;
+        return &ctx.cases.items[ctx.cases.items.len - 1];
+    }
+
+    /// Adds a test case that uses the LLVM backend to emit an executable.
+    /// Currently this implies linking libc, because only then we can generate a testable executable.
+    pub fn exeUsingLlvmBackend(ctx: *TestContext, name: []const u8, target: CrossTarget) *Case {
+        ctx.cases.append(Case{
+            .name = name,
+            .target = target,
+            .updates = std.ArrayList(Update).init(ctx.cases.allocator),
+            .output_mode = .Exe,
+            .extension = .Zig,
+            .files = std.ArrayList(File).init(ctx.cases.allocator),
+            .llvm_backend = true,
         }) catch unreachable;
         return &ctx.cases.items[ctx.cases.items.len - 1];
     }
@@ -518,8 +534,28 @@ pub const TestContext = struct {
         try thread_pool.init(std.testing.allocator);
         defer thread_pool.deinit();
 
+        // Use the same global cache dir for all the tests, such that we for example don't have to
+        // rebuild musl libc for every case (when LLVM backend is enabled).
+        var global_tmp = std.testing.tmpDir(.{});
+        defer global_tmp.cleanup();
+
+        var cache_dir = try global_tmp.dir.makeOpenPath("zig-cache", .{});
+        defer cache_dir.close();
+        const tmp_dir_path = try std.fs.path.join(std.testing.allocator, &[_][]const u8{ ".", "zig-cache", "tmp", &global_tmp.sub_path });
+        defer std.testing.allocator.free(tmp_dir_path);
+
+        const global_cache_directory: Compilation.Directory = .{
+            .handle = cache_dir,
+            .path = try std.fs.path.join(std.testing.allocator, &[_][]const u8{ tmp_dir_path, "zig-cache" }),
+        };
+        defer std.testing.allocator.free(global_cache_directory.path.?);
+
         for (self.cases.items) |case| {
             if (build_options.skip_non_native and case.target.getCpuArch() != std.Target.current.cpu.arch)
+                continue;
+
+            // Skip tests that require LLVM backend when it is not available
+            if (!build_options.have_llvm and case.llvm_backend)
                 continue;
 
             var prg_node = root_node.start(case.name, case.updates.items.len);
@@ -537,6 +573,7 @@ pub const TestContext = struct {
                 case,
                 zig_lib_directory,
                 &thread_pool,
+                global_cache_directory,
             );
         }
     }
@@ -548,6 +585,7 @@ pub const TestContext = struct {
         case: Case,
         zig_lib_directory: Compilation.Directory,
         thread_pool: *ThreadPool,
+        global_cache_directory: Compilation.Directory,
     ) !void {
         const target_info = try std.zig.system.NativeTargetInfo.detect(allocator, case.target);
         const target = target_info.target;
@@ -601,7 +639,7 @@ pub const TestContext = struct {
             null;
         const comp = try Compilation.create(allocator, .{
             .local_cache_directory = zig_cache_directory,
-            .global_cache_directory = zig_cache_directory,
+            .global_cache_directory = global_cache_directory,
             .zig_lib_directory = zig_lib_directory,
             .thread_pool = thread_pool,
             .root_name = "test_case",
@@ -619,6 +657,9 @@ pub const TestContext = struct {
             .object_format = case.object_format,
             .is_native_os = case.target.isNativeOs(),
             .is_native_abi = case.target.isNativeAbi(),
+            .link_libc = case.llvm_backend,
+            .use_llvm = case.llvm_backend,
+            .self_exe_path = std.testing.zig_exe_path,
         });
         defer comp.destroy();
 

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -8,13 +8,31 @@
 #ifndef ZIG_ZIG_CLANG_H
 #define ZIG_ZIG_CLANG_H
 
-#include "stage1/stage2.h"
 #include <inttypes.h>
 #include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+#define ZIG_EXTERN_C extern "C"
+#else
+#define ZIG_EXTERN_C
+#endif
 
 // ATTENTION: If you modify this file, be sure to update the corresponding
 // extern function declarations in the self-hosted compiler file
 // src/clang.zig.
+
+// ABI warning
+struct Stage2ErrorMsg {
+    const char *filename_ptr; // can be null
+    size_t filename_len;
+    const char *msg_ptr;
+    size_t msg_len;
+    const char *source; // valid until the ASTUnit is freed. can be null
+    unsigned line; // 0 based
+    unsigned column; // 0 based
+    unsigned offset; // byte offset into source
+};
 
 struct ZigClangSourceLocation {
     unsigned ID;

--- a/test/stage2/llvm_backend.zig
+++ b/test/stage2/llvm_backend.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const TestContext = @import("../../src/test.zig").TestContext;
+const build_options = @import("build_options");
+
+// These tests should work with all platforms, but we're using linux_x64 for
+// now for consistency. Will be expanded eventually.
+const linux_x64 = std.zig.CrossTarget{
+    .cpu_arch = .x86_64,
+    .os_tag = .linux,
+};
+
+pub fn addCases(ctx: *TestContext) !void {
+    {
+        var case = ctx.exeUsingLlvmBackend("simple addition and subtraction", linux_x64);
+
+        case.addCompareOutput(
+            \\fn add(a: i32, b: i32) i32 {
+            \\    return a + b;
+            \\}
+            \\
+            \\export fn main() c_int {
+            \\    var a: i32 = -5;
+            \\    const x = add(a, 7);
+            \\    var y = add(2, 0);
+            \\    y -= x;
+            \\    return y;
+            \\}
+        , "");
+    }
+}

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -31,6 +31,7 @@ pub fn addCases(ctx: *TestContext) !void {
     try @import("spu-ii.zig").addCases(ctx);
     try @import("arm.zig").addCases(ctx);
     try @import("aarch64.zig").addCases(ctx);
+    try @import("llvm_backend.zig").addCases(ctx);
 
     {
         var case = ctx.exe("hello world with updates", linux_x64);


### PR DESCRIPTION
Basically we can now compile this program:
```zig
export fn _start() noreturn {
    var x: bool = true;
    var other: bool = foo(x);
    exit();
}

fn foo(cond: bool) bool {
    return !cond;
}

fn exit() noreturn {
    unreachable;
}
```
See commit messages for more explanation.

Edit: Now also includes the ability to test the LLVM backend!