### PR TITLE
integrate CBE with Compilation.update pipeline (closes #7589)

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -291,7 +291,7 @@ pub const File = struct {
             .coff => return @fieldParentPtr(Coff, "base", base).updateDecl(module, decl),
             .elf => return @fieldParentPtr(Elf, "base", base).updateDecl(module, decl),
             .macho => return @fieldParentPtr(MachO, "base", base).updateDecl(module, decl),
-            .c => return @fieldParentPtr(C, "base", base).updateDecl(module, decl),
+            .c => {},
             .wasm => return @fieldParentPtr(Wasm, "base", base).updateDecl(module, decl),
         }
     }
@@ -412,7 +412,7 @@ pub const File = struct {
             .coff => @fieldParentPtr(Coff, "base", base).freeDecl(decl),
             .elf => @fieldParentPtr(Elf, "base", base).freeDecl(decl),
             .macho => @fieldParentPtr(MachO, "base", base).freeDecl(decl),
-            .c => unreachable,
+            .c => {},
             .wasm => @fieldParentPtr(Wasm, "base", base).freeDecl(decl),
         }
     }

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -24,13 +24,13 @@ pub fn addCases(ctx: *TestContext) !void {
         // Now change the message only
         // TODO fix C backend not supporting updates
         // https://github.com/ziglang/zig/issues/7589
-        //case.addCompareOutput(
-        //    \\extern fn puts(s: [*:0]const u8) c_int;
-        //    \\export fn main() c_int {
-        //    \\    _ = puts("yo");
-        //    \\    return 0;
-        //    \\}
-        //, "yo" ++ std.cstr.line_sep);
+        case.addCompareOutput(
+            \\extern fn puts(s: [*:0]const u8) c_int;
+            \\export fn main() c_int {
+            \\    _ = puts("yo");
+            \\    return 0;
+            \\}
+        , "yo" ++ std.cstr.line_sep);
     }
 
     {
@@ -79,13 +79,13 @@ pub fn addCases(ctx: *TestContext) !void {
     ,
         \\static zig_noreturn void main(void);
         \\
-        \\zig_noreturn void _start(void) {
-        \\    main();
-        \\}
-        \\
         \\static zig_noreturn void main(void) {
         \\    zig_breakpoint();
         \\    zig_unreachable();
+        \\}
+        \\
+        \\zig_noreturn void _start(void) {
+        \\    main();
         \\}
         \\
     );
@@ -111,16 +111,16 @@ pub fn addCases(ctx: *TestContext) !void {
         \\static uint8_t exitGood__anon_1[6] = "{rdi}";
         \\static uint8_t exitGood__anon_2[8] = "syscall";
         \\
-        \\zig_noreturn void _start(void) {
-        \\    exitGood();
-        \\}
-        \\
         \\static zig_noreturn void exitGood(void) {
         \\    register uintptr_t rax_constant __asm__("rax") = 231;
         \\    register uintptr_t rdi_constant __asm__("rdi") = 0;
         \\    __asm volatile ("syscall" :: ""(rax_constant), ""(rdi_constant));
         \\    zig_breakpoint();
         \\    zig_unreachable();
+        \\}
+        \\
+        \\zig_noreturn void _start(void) {
+        \\    exitGood();
         \\}
         \\
     );


### PR DESCRIPTION
* CBE buffers are only valid during a flush()
* the file is reopened and truncated during each flush()
* CBE now explicitly ignores updateDecl and deleteDecl
* CBE updateDecl is gone
* test case is enabled