### PR TITLE
fix LRESULT/LPARAM typedefs

### DIFF
--- a/lib/std/os/windows/bits.zig
+++ b/lib/std/os/windows/bits.zig
@@ -84,8 +84,8 @@ pub const HLOCAL = HANDLE;
 pub const LANGID = c_ushort;
 
 pub const WPARAM = usize;
-pub const LPARAM = ?*c_void;
-pub const LRESULT = ?*c_void;
+pub const LPARAM = LONG_PTR;
+pub const LRESULT = LONG_PTR;
 
 pub const va_list = *opaque {};
 


### PR DESCRIPTION
`LRESULT` and `LPARAM` are currently typedef'd as `?*c_void`, however, they are supposed to be typedef'd as `LONG_PTR` which is an integral type (not a pointer type as it appears to be).  `LONG_PTR` is a signed integer large enough to hold a pointer (i.e. `isize` in Zig).