### PR TITLE
macho: add preliminary support for DWARF debugging symbols

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -355,7 +355,7 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
 
             if (self.d_sym) |*ds| {
                 // Flush debug symbols bundle.
-                try ds.flush();
+                try ds.flush(self.base.allocator);
             }
 
             if (target.cpu.arch == .aarch64) {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1199,7 +1199,7 @@ pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {
 
         // .debug_info subprogram
         const decl_name_with_null = decl.name[0 .. mem.lenZ(decl.name) + 1];
-        try dbg_info_buffer.ensureCapacity(dbg_info_buffer.items.len + 25 + decl_name_with_null.len);
+        try dbg_info_buffer.ensureCapacity(dbg_info_buffer.items.len + 27 + decl_name_with_null.len);
 
         const fn_ret_type = typed_value.ty.fnReturnType();
         const fn_ret_has_bits = fn_ret_type.hasCodeGenBits();
@@ -1227,6 +1227,8 @@ pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {
             dbg_info_buffer.items.len += 4; // DW.AT_type,  DW.FORM_ref4
         }
         dbg_info_buffer.appendSliceAssumeCapacity(decl_name_with_null); // DW.AT_name, DW.FORM_string
+        mem.writeIntLittle(u32, dbg_info_buffer.addManyAsArrayAssumeCapacity(4), line_off + 1); // DW.AT_decl_line, DW.FORM_data4
+        dbg_info_buffer.appendAssumeCapacity(file_index); // DW.AT_decl_file, DW.FORM_data1
     } else {
         // TODO implement .debug_info for global variables
     }

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -11,9 +11,10 @@ const codegen = @import("../codegen.zig");
 const aarch64 = @import("../codegen/aarch64.zig");
 const math = std.math;
 const mem = std.mem;
+const DW = std.dwarf;
+const leb = std.leb;
 
 const trace = @import("../tracy.zig").trace;
-const Type = @import("../type.zig").Type;
 const build_options = @import("build_options");
 const Module = @import("../Module.zig");
 const Compilation = @import("../Compilation.zig");
@@ -107,9 +108,6 @@ dyld_stub_binder_index: ?u16 = null,
 
 /// Table of symbol names aka the string table.
 string_table: std.ArrayListUnmanaged(u8) = .{},
-
-/// Table of debug symbol names aka the debug string table.
-debug_string_table: std.ArrayListUnmanaged(u8) = .{},
 
 /// Table of trampolines to the actual symbols in __text section.
 offset_table: std.ArrayListUnmanaged(u64) = .{},
@@ -207,12 +205,25 @@ pub const TextBlock = struct {
     prev: ?*TextBlock,
     next: ?*TextBlock,
 
+    /// Previous/next linked list pointers. This value is `next ^ prev`.
+    /// This is the linked list node for this Decl's corresponding .debug_info tag.
+    dbg_info_prev: ?*TextBlock,
+    dbg_info_next: ?*TextBlock,
+    /// Offset into .debug_info pointing to the tag for this Decl.
+    dbg_info_off: u32,
+    /// Size of the .debug_info tag for this Decl, not including padding.
+    dbg_info_len: u32,
+
     pub const empty = TextBlock{
         .local_sym_index = 0,
         .offset_table_index = undefined,
         .size = 0,
         .prev = null,
         .next = null,
+        .dbg_info_prev = null,
+        .dbg_info_next = null,
+        .dbg_info_off = undefined,
+        .dbg_info_len = undefined,
     };
 
     /// Returns how much room there is to grow in virtual address space.
@@ -248,7 +259,23 @@ pub const Export = struct {
 };
 
 pub const SrcFn = struct {
-    pub const empty = SrcFn{};
+    /// Offset from the beginning of the Debug Line Program header that contains this function.
+    off: u32,
+    /// Size of the line number program component belonging to this function, not
+    /// including padding.
+    len: u32,
+
+    /// Points to the previous and next neighbors, based on the offset from .debug_line.
+    /// This can be used to find, for example, the capacity of this `SrcFn`.
+    prev: ?*SrcFn,
+    next: ?*SrcFn,
+
+    pub const empty: SrcFn = .{
+        .off = 0,
+        .len = 0,
+        .prev = null,
+        .next = null,
+    };
 };
 
 pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Options) !*MachO {
@@ -361,7 +388,7 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
 
             if (self.d_sym) |*ds| {
                 // Flush debug symbols bundle.
-                try ds.flush(self.base.allocator);
+                try ds.flushModule(self.base.allocator, self.base.options);
             }
 
             if (target.cpu.arch == .aarch64) {
@@ -983,7 +1010,6 @@ pub fn deinit(self: *MachO) void {
     self.text_block_free_list.deinit(self.base.allocator);
     self.offset_table.deinit(self.base.allocator);
     self.offset_table_free_list.deinit(self.base.allocator);
-    self.debug_string_table.deinit(self.base.allocator);
     self.string_table.deinit(self.base.allocator);
     self.undef_symbols.deinit(self.base.allocator);
     self.global_symbols.deinit(self.base.allocator);
@@ -1091,8 +1117,126 @@ pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {
     var code_buffer = std.ArrayList(u8).init(self.base.allocator);
     defer code_buffer.deinit();
 
+    var dbg_line_buffer = std.ArrayList(u8).init(self.base.allocator);
+    defer dbg_line_buffer.deinit();
+
+    var dbg_info_buffer = std.ArrayList(u8).init(self.base.allocator);
+    defer dbg_info_buffer.deinit();
+
+    var dbg_info_type_relocs: File.DbgInfoTypeRelocsTable = .{};
+    defer {
+        var it = dbg_info_type_relocs.iterator();
+        while (it.next()) |entry| {
+            entry.value.relocs.deinit(self.base.allocator);
+        }
+        dbg_info_type_relocs.deinit(self.base.allocator);
+    }
+
     const typed_value = decl.typed_value.most_recent.typed_value;
-    const res = try codegen.generateSymbol(&self.base, decl.src(), typed_value, &code_buffer, .none);
+    const is_fn: bool = switch (typed_value.ty.zigTypeTag()) {
+        .Fn => true,
+        else => false,
+    };
+    if (is_fn) {
+        const zir_dumps = if (std.builtin.is_test) &[0][]const u8{} else build_options.zir_dumps;
+        if (zir_dumps.len != 0) {
+            for (zir_dumps) |fn_name| {
+                if (mem.eql(u8, mem.spanZ(decl.name), fn_name)) {
+                    std.debug.print("\n{}\n", .{decl.name});
+                    typed_value.val.cast(Value.Payload.Function).?.func.dump(module.*);
+                }
+            }
+        }
+
+        // For functions we need to add a prologue to the debug line program.
+        try dbg_line_buffer.ensureCapacity(26);
+
+        const line_off: u28 = blk: {
+            if (decl.scope.cast(Module.Scope.Container)) |container_scope| {
+                const tree = container_scope.file_scope.contents.tree;
+                const file_ast_decls = tree.root_node.decls();
+                // TODO Look into improving the performance here by adding a token-index-to-line
+                // lookup table. Currently this involves scanning over the source code for newlines.
+                const fn_proto = file_ast_decls[decl.src_index].castTag(.FnProto).?;
+                const block = fn_proto.getBodyNode().?.castTag(.Block).?;
+                const line_delta = std.zig.lineDelta(tree.source, 0, tree.token_locs[block.lbrace].start);
+                break :blk @intCast(u28, line_delta);
+            } else if (decl.scope.cast(Module.Scope.ZIRModule)) |zir_module| {
+                const byte_off = zir_module.contents.module.decls[decl.src_index].inst.src;
+                const line_delta = std.zig.lineDelta(zir_module.source.bytes, 0, byte_off);
+                break :blk @intCast(u28, line_delta);
+            } else {
+                unreachable;
+            }
+        };
+
+        dbg_line_buffer.appendSliceAssumeCapacity(&[_]u8{
+            DW.LNS_extended_op,
+            @sizeOf(u64) + 1,
+            DW.LNE_set_address,
+        });
+        // This is the "relocatable" vaddr, corresponding to `code_buffer` index `0`.
+        assert(DebugSymbols.dbg_line_vaddr_reloc_index == dbg_line_buffer.items.len);
+        dbg_line_buffer.items.len += @sizeOf(u64);
+
+        dbg_line_buffer.appendAssumeCapacity(DW.LNS_advance_line);
+        // This is the "relocatable" relative line offset from the previous function's end curly
+        // to this function's begin curly.
+        assert(DebugSymbols.getRelocDbgLineOff() == dbg_line_buffer.items.len);
+        // Here we use a ULEB128-fixed-4 to make sure this field can be overwritten later.
+        leb.writeUnsignedFixed(4, dbg_line_buffer.addManyAsArrayAssumeCapacity(4), line_off);
+
+        dbg_line_buffer.appendAssumeCapacity(DW.LNS_set_file);
+        assert(DebugSymbols.getRelocDbgFileIndex() == dbg_line_buffer.items.len);
+        // Once we support more than one source file, this will have the ability to be more
+        // than one possible value.
+        const file_index = 1;
+        leb.writeUnsignedFixed(4, dbg_line_buffer.addManyAsArrayAssumeCapacity(4), file_index);
+
+        // Emit a line for the begin curly with prologue_end=false. The codegen will
+        // do the work of setting prologue_end=true and epilogue_begin=true.
+        dbg_line_buffer.appendAssumeCapacity(DW.LNS_copy);
+
+        // .debug_info subprogram
+        const decl_name_with_null = decl.name[0 .. mem.lenZ(decl.name) + 1];
+        try dbg_info_buffer.ensureCapacity(dbg_info_buffer.items.len + 25 + decl_name_with_null.len);
+
+        const fn_ret_type = typed_value.ty.fnReturnType();
+        const fn_ret_has_bits = fn_ret_type.hasCodeGenBits();
+        if (fn_ret_has_bits) {
+            dbg_info_buffer.appendAssumeCapacity(DebugSymbols.abbrev_subprogram);
+        } else {
+            dbg_info_buffer.appendAssumeCapacity(DebugSymbols.abbrev_subprogram_retvoid);
+        }
+        // These get overwritten after generating the machine code. These values are
+        // "relocations" and have to be in this fixed place so that functions can be
+        // moved in virtual address space.
+        assert(DebugSymbols.dbg_info_low_pc_reloc_index == dbg_info_buffer.items.len);
+        dbg_info_buffer.items.len += @sizeOf(u64); // DW.AT_low_pc,  DW.FORM_addr
+        assert(DebugSymbols.getRelocDbgInfoSubprogramHighPC() == dbg_info_buffer.items.len);
+        dbg_info_buffer.items.len += 4; // DW.AT_high_pc,  DW.FORM_data4
+        if (fn_ret_has_bits) {
+            const gop = try dbg_info_type_relocs.getOrPut(self.base.allocator, fn_ret_type);
+            if (!gop.found_existing) {
+                gop.entry.value = .{
+                    .off = undefined,
+                    .relocs = .{},
+                };
+            }
+            try gop.entry.value.relocs.append(self.base.allocator, @intCast(u32, dbg_info_buffer.items.len));
+            dbg_info_buffer.items.len += 4; // DW.AT_type,  DW.FORM_ref4
+        }
+        dbg_info_buffer.appendSliceAssumeCapacity(decl_name_with_null); // DW.AT_name, DW.FORM_string
+    } else {
+        // TODO implement .debug_info for global variables
+    }
+    const res = try codegen.generateSymbol(&self.base, decl.src(), typed_value, &code_buffer, .{
+        .dwarf = .{
+            .dbg_line = &dbg_line_buffer,
+            .dbg_info = &dbg_info_buffer,
+            .dbg_info_type_relocs = &dbg_info_type_relocs,
+        },
+    });
 
     const code = switch (res) {
         .externally_managed => |x| x,
@@ -1178,12 +1322,160 @@ pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {
     const file_offset = text_section.offset + section_offset;
     try self.base.file.?.pwriteAll(code, file_offset);
 
+    const text_block = &decl.link.macho;
+    // If the Decl is a function, we need to update the __debug_line program.
+    if (is_fn) {
+        // Perform the relocations based on vaddr.
+        {
+            const ptr = dbg_line_buffer.items[DebugSymbols.dbg_line_vaddr_reloc_index..][0..8];
+            mem.writeIntLittle(u64, ptr, symbol.n_value);
+        }
+        {
+            const ptr = dbg_info_buffer.items[DebugSymbols.dbg_info_low_pc_reloc_index..][0..8];
+            mem.writeIntLittle(u64, ptr, symbol.n_value);
+        }
+        {
+            const ptr = dbg_info_buffer.items[DebugSymbols.getRelocDbgInfoSubprogramHighPC()..][0..4];
+            mem.writeIntLittle(u32, ptr, @intCast(u32, text_block.size));
+        }
+
+        try dbg_line_buffer.appendSlice(&[_]u8{ DW.LNS_extended_op, 1, DW.LNE_end_sequence });
+
+        // Now we have the full contents and may allocate a region to store it.
+
+        // This logic is nearly identical to the logic below in `updateDeclDebugInfo` for
+        // `TextBlock` and the .debug_info. If you are editing this logic, you
+        // probably need to edit that logic too.
+
+        const dwarf_segment = &self.d_sym.?.load_commands.items[self.d_sym.?.dwarf_segment_cmd_index.?].Segment;
+        const debug_line_sect = &dwarf_segment.sections.items[self.d_sym.?.debug_line_section_index.?];
+        const src_fn = &decl.fn_link.macho;
+        src_fn.len = @intCast(u32, dbg_line_buffer.items.len);
+        if (self.d_sym.?.dbg_line_fn_last) |last| {
+            if (src_fn.next) |next| {
+                // Update existing function - non-last item.
+                if (src_fn.off + src_fn.len + DebugSymbols.min_nop_size > next.off) {
+                    // It grew too big, so we move it to a new location.
+                    if (src_fn.prev) |prev| {
+                        _ = self.d_sym.?.dbg_line_fn_free_list.put(self.base.allocator, prev, {}) catch {};
+                        prev.next = src_fn.next;
+                    }
+                    next.prev = src_fn.prev;
+                    src_fn.next = null;
+                    // Populate where it used to be with NOPs.
+                    const file_pos = debug_line_sect.offset + src_fn.off;
+                    try self.d_sym.?.pwriteDbgLineNops(0, &[0]u8{}, src_fn.len, file_pos);
+                    // TODO Look at the free list before appending at the end.
+                    src_fn.prev = last;
+                    last.next = src_fn;
+                    self.d_sym.?.dbg_line_fn_last = src_fn;
+
+                    src_fn.off = last.off + (last.len * alloc_num / alloc_den);
+                }
+            } else if (src_fn.prev == null) {
+                // Append new function.
+                // TODO Look at the free list before appending at the end.
+                src_fn.prev = last;
+                last.next = src_fn;
+                self.d_sym.?.dbg_line_fn_last = src_fn;
+
+                src_fn.off = last.off + (last.len * alloc_num / alloc_den);
+            }
+        } else {
+            // This is the first function of the Line Number Program.
+            self.d_sym.?.dbg_line_fn_first = src_fn;
+            self.d_sym.?.dbg_line_fn_last = src_fn;
+
+            src_fn.off = self.d_sym.?.dbgLineNeededHeaderBytes(module) * alloc_num / alloc_den;
+        }
+
+        const last_src_fn = self.d_sym.?.dbg_line_fn_last.?;
+        const needed_size = last_src_fn.off + last_src_fn.len;
+        if (needed_size != debug_line_sect.size) {
+            if (needed_size > dwarf_segment.allocatedSize(debug_line_sect.offset)) {
+                const new_offset = dwarf_segment.findFreeSpace(needed_size, 1, null);
+                const existing_size = last_src_fn.off;
+
+                assert(dwarf_segment.inner.fileoff + dwarf_segment.inner.filesize >= new_offset + needed_size);
+
+                log.debug("moving __zdebug_line section: {} bytes from 0x{x} to 0x{x}", .{
+                    existing_size,
+                    debug_line_sect.offset,
+                    new_offset,
+                });
+
+                const amt = try self.d_sym.?.file.copyRangeAll(debug_line_sect.offset, self.d_sym.?.file, new_offset, existing_size);
+                if (amt != existing_size) return error.InputOutput;
+                debug_line_sect.offset = @intCast(u32, new_offset);
+                debug_line_sect.addr = dwarf_segment.inner.vmaddr + new_offset - dwarf_segment.inner.fileoff;
+            }
+            debug_line_sect.size = needed_size;
+            self.d_sym.?.load_commands_dirty = true; // TODO look into making only the one section dirty
+            self.d_sym.?.debug_line_header_dirty = true;
+        }
+        const prev_padding_size: u32 = if (src_fn.prev) |prev| src_fn.off - (prev.off + prev.len) else 0;
+        const next_padding_size: u32 = if (src_fn.next) |next| next.off - (src_fn.off + src_fn.len) else 0;
+
+        // We only have support for one compilation unit so far, so the offsets are directly
+        // from the .debug_line section.
+        const file_pos = debug_line_sect.offset + src_fn.off;
+        try self.d_sym.?.pwriteDbgLineNops(prev_padding_size, dbg_line_buffer.items, next_padding_size, file_pos);
+
+        // .debug_info - End the TAG_subprogram children.
+        try dbg_info_buffer.append(0);
+    }
+
+    // Now we emit the .debug_info types of the Decl. These will count towards the size of
+    // the buffer, so we have to do it before computing the offset, and we can't perform the actual
+    // relocations yet.
+    var it = dbg_info_type_relocs.iterator();
+    while (it.next()) |entry| {
+        entry.value.off = @intCast(u32, dbg_info_buffer.items.len);
+        try self.d_sym.?.addDbgInfoType(entry.key, &dbg_info_buffer, self.base.options.target);
+    }
+
+    try self.d_sym.?.updateDeclDebugInfoAllocation(self.base.allocator, text_block, @intCast(u32, dbg_info_buffer.items.len));
+
+    // Now that we have the offset assigned we can finally perform type relocations.
+    it = dbg_info_type_relocs.iterator();
+    while (it.next()) |entry| {
+        for (entry.value.relocs.items) |off| {
+            mem.writeIntLittle(
+                u32,
+                dbg_info_buffer.items[off..][0..4],
+                text_block.dbg_info_off + entry.value.off,
+            );
+        }
+    }
+
+    try self.d_sym.?.writeDeclDebugInfo(text_block, dbg_info_buffer.items);
+
     // Since we updated the vaddr and the size, each corresponding export symbol also needs to be updated.
     const decl_exports = module.decl_exports.get(decl) orelse &[0]*Module.Export{};
     try self.updateDeclExports(module, decl, decl_exports);
 }
 
-pub fn updateDeclLineNumber(self: *MachO, module: *Module, decl: *const Module.Decl) !void {}
+pub fn updateDeclLineNumber(self: *MachO, module: *Module, decl: *const Module.Decl) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
+    const container_scope = decl.scope.cast(Module.Scope.Container).?;
+    const tree = container_scope.file_scope.contents.tree;
+    const file_ast_decls = tree.root_node.decls();
+    // TODO Look into improving the performance here by adding a token-index-to-line
+    // lookup table. Currently this involves scanning over the source code for newlines.
+    const fn_proto = file_ast_decls[decl.src_index].castTag(.FnProto).?;
+    const block = fn_proto.getBodyNode().?.castTag(.Block).?;
+    const line_delta = std.zig.lineDelta(tree.source, 0, tree.token_locs[block.lbrace].start);
+    const casted_line_off = @intCast(u28, line_delta);
+
+    const dwarf_segment = &self.d_sym.?.load_commands.items[self.d_sym.?.dwarf_segment_cmd_index.?].Segment;
+    const shdr = &dwarf_segment.sections.items[self.d_sym.?.debug_line_section_index.?];
+    const file_pos = shdr.offset + decl.fn_link.macho.off + DebugSymbols.getRelocDbgLineOff();
+    var data: [4]u8 = undefined;
+    leb.writeUnsignedFixed(4, &data, casted_line_off);
+    try self.d_sym.?.file.pwriteAll(&data, file_pos);
+}
 
 pub fn updateDeclExports(
     self: *MachO,

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -299,6 +299,7 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
     }
 
     try self.populateMissingMetadata();
+    try self.d_sym.?.populateMissingMetadata(allocator);
 
     return self;
 }
@@ -351,6 +352,11 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
             try self.writeAllGlobalAndUndefSymbols();
             try self.writeStringTable();
             try self.updateLinkeditSegmentSizes();
+
+            if (self.d_sym) |*ds| {
+                // Flush debug symbols bundle.
+                try ds.flush();
+            }
 
             if (target.cpu.arch == .aarch64) {
                 // Preallocate space for the code signature.

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -108,6 +108,9 @@ dyld_stub_binder_index: ?u16 = null,
 /// Table of symbol names aka the string table.
 string_table: std.ArrayListUnmanaged(u8) = .{},
 
+/// Table of debug symbol names aka the debug string table.
+debug_string_table: std.ArrayListUnmanaged(u8) = .{},
+
 /// Table of trampolines to the actual symbols in __text section.
 offset_table: std.ArrayListUnmanaged(u64) = .{},
 
@@ -980,6 +983,7 @@ pub fn deinit(self: *MachO) void {
     self.text_block_free_list.deinit(self.base.allocator);
     self.offset_table.deinit(self.base.allocator);
     self.offset_table_free_list.deinit(self.base.allocator);
+    self.debug_string_table.deinit(self.base.allocator);
     self.string_table.deinit(self.base.allocator);
     self.undef_symbols.deinit(self.base.allocator);
     self.global_symbols.deinit(self.base.allocator);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1460,25 +1460,9 @@ pub fn updateDecl(self: *MachO, module: *Module, decl: *Module.Decl) !void {
 }
 
 pub fn updateDeclLineNumber(self: *MachO, module: *Module, decl: *const Module.Decl) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
-
-    const container_scope = decl.scope.cast(Module.Scope.Container).?;
-    const tree = container_scope.file_scope.contents.tree;
-    const file_ast_decls = tree.root_node.decls();
-    // TODO Look into improving the performance here by adding a token-index-to-line
-    // lookup table. Currently this involves scanning over the source code for newlines.
-    const fn_proto = file_ast_decls[decl.src_index].castTag(.FnProto).?;
-    const block = fn_proto.getBodyNode().?.castTag(.Block).?;
-    const line_delta = std.zig.lineDelta(tree.source, 0, tree.token_locs[block.lbrace].start);
-    const casted_line_off = @intCast(u28, line_delta);
-
-    const dwarf_segment = &self.d_sym.?.load_commands.items[self.d_sym.?.dwarf_segment_cmd_index.?].Segment;
-    const shdr = &dwarf_segment.sections.items[self.d_sym.?.debug_line_section_index.?];
-    const file_pos = shdr.offset + decl.fn_link.macho.off + DebugSymbols.getRelocDbgLineOff();
-    var data: [4]u8 = undefined;
-    leb.writeUnsignedFixed(4, &data, casted_line_off);
-    try self.d_sym.?.file.pwriteAll(&data, file_pos);
+    if (self.d_sym) |*ds| {
+        try ds.updateDeclLineNumber(module, decl);
+    }
 }
 
 pub fn updateDeclExports(

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -299,8 +299,8 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
 
     self.base.file = file;
 
-    // Create dSym bundle.
-    const d_sym_path = try fmt.allocPrint(allocator, "{}.dSym/Contents/Resources/DWARF/", .{sub_path});
+    // Create dSYM bundle.
+    const d_sym_path = try fmt.allocPrint(allocator, "{}.dSYM/Contents/Resources/DWARF/", .{sub_path});
     defer allocator.free(d_sym_path);
     var d_sym_bundle = try options.emit.?.directory.handle.makeOpenPath(d_sym_path, .{});
     defer d_sym_bundle.close();

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -525,8 +525,8 @@ pub fn flushModule(self: *DebugSymbols, allocator: *Allocator, options: link.Opt
         mem.writeIntLittle(u64, di_buf.addManyAsArrayAssumeCapacity(8), text_section.size);
 
         // Sentinel.
-        mem.writeIntLittle(u64, di_buf.addManyAsArrayAssumeCapacity(8), 0);
-        mem.writeIntLittle(u64, di_buf.addManyAsArrayAssumeCapacity(8), 0);
+        mem.writeIntLittle(u32, di_buf.addManyAsArrayAssumeCapacity(4), 0);
+        mem.writeIntLittle(u32, di_buf.addManyAsArrayAssumeCapacity(4), 0);
 
         // Go back and populate the initial length.
         const init_len = di_buf.items.len - after_init_len;

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -412,7 +412,9 @@ pub fn flushModule(self: *DebugSymbols, allocator: *Allocator, options: link.Opt
         const allocated_size = dwarf_segment.allocatedSize(debug_abbrev_sect.offset);
         if (needed_size > allocated_size) {
             debug_abbrev_sect.size = 0; // free the space
-            debug_abbrev_sect.offset = @intCast(u32, dwarf_segment.findFreeSpace(needed_size, 1, null));
+            const offset = dwarf_segment.findFreeSpace(needed_size, 1, null);
+            debug_abbrev_sect.offset = @intCast(u32, offset);
+            debug_abbrev_sect.addr = dwarf_segment.inner.vmaddr + offset - dwarf_segment.inner.fileoff;
         }
         debug_abbrev_sect.size = needed_size;
         log.debug("__debug_abbrev start=0x{x} end=0x{x}", .{
@@ -536,9 +538,9 @@ pub fn flushModule(self: *DebugSymbols, allocator: *Allocator, options: link.Opt
         const allocated_size = dwarf_segment.allocatedSize(debug_aranges_sect.offset);
         if (needed_size > allocated_size) {
             debug_aranges_sect.size = 0; // free the space
-            const offset = dwarf_segment.findFreeSpace(needed_size, 16, null);
-            debug_aranges_sect.offset = @intCast(u32, offset);
-            debug_aranges_sect.addr = dwarf_segment.inner.vmaddr + offset - dwarf_segment.inner.fileoff;
+            const new_offset = dwarf_segment.findFreeSpace(needed_size, 16, null);
+            debug_aranges_sect.addr = dwarf_segment.inner.vmaddr + new_offset - dwarf_segment.inner.fileoff;
+            debug_aranges_sect.offset = @intCast(u32, new_offset);
         }
         debug_aranges_sect.size = needed_size;
         log.debug("__debug_aranges start=0x{x} end=0x{x}", .{

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -10,6 +10,7 @@ const DW = std.dwarf;
 const leb = std.leb;
 const Allocator = mem.Allocator;
 
+const build_options = @import("build_options");
 const trace = @import("../../tracy.zig").trace;
 const Module = @import("../../Module.zig");
 const Type = @import("../../type.zig").Type;
@@ -87,21 +88,21 @@ debug_aranges_section_dirty: bool = false,
 debug_info_header_dirty: bool = false,
 debug_line_header_dirty: bool = false,
 
-pub const abbrev_compile_unit = 1;
-pub const abbrev_subprogram = 2;
-pub const abbrev_subprogram_retvoid = 3;
-pub const abbrev_base_type = 4;
-pub const abbrev_pad1 = 5;
-pub const abbrev_parameter = 6;
+const abbrev_compile_unit = 1;
+const abbrev_subprogram = 2;
+const abbrev_subprogram_retvoid = 3;
+const abbrev_base_type = 4;
+const abbrev_pad1 = 5;
+const abbrev_parameter = 6;
 
 /// The reloc offset for the virtual address of a function in its Line Number Program.
 /// Size is a virtual address integer.
-pub const dbg_line_vaddr_reloc_index = 3;
+const dbg_line_vaddr_reloc_index = 3;
 /// The reloc offset for the virtual address of a function in its .debug_info TAG_subprogram.
 /// Size is a virtual address integer.
-pub const dbg_info_low_pc_reloc_index = 1;
+const dbg_info_low_pc_reloc_index = 1;
 
-pub const min_nop_size = 2;
+const min_nop_size = 2;
 
 /// You must call this function *after* `MachO.populateMissingMetadata()`
 /// has been called to get a viable debug symbols output.
@@ -888,8 +889,304 @@ fn writeStringTable(self: *DebugSymbols) !void {
     self.string_table_dirty = false;
 }
 
+pub fn updateDeclLineNumber(self: *DebugSymbols, module: *Module, decl: *const Module.Decl) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
+    const container_scope = decl.scope.cast(Module.Scope.Container).?;
+    const tree = container_scope.file_scope.contents.tree;
+    const file_ast_decls = tree.root_node.decls();
+    // TODO Look into improving the performance here by adding a token-index-to-line
+    // lookup table. Currently this involves scanning over the source code for newlines.
+    const fn_proto = file_ast_decls[decl.src_index].castTag(.FnProto).?;
+    const block = fn_proto.getBodyNode().?.castTag(.Block).?;
+    const line_delta = std.zig.lineDelta(tree.source, 0, tree.token_locs[block.lbrace].start);
+    const casted_line_off = @intCast(u28, line_delta);
+
+    const dwarf_segment = &self.load_commands.items[self.dwarf_segment_cmd_index.?].Segment;
+    const shdr = &dwarf_segment.sections.items[self.debug_line_section_index.?];
+    const file_pos = shdr.offset + decl.fn_link.macho.off + getRelocDbgLineOff();
+    var data: [4]u8 = undefined;
+    leb.writeUnsignedFixed(4, &data, casted_line_off);
+    try self.file.pwriteAll(&data, file_pos);
+}
+
+pub const DeclDebugBuffers = struct {
+    dbg_line_buffer: std.ArrayList(u8),
+    dbg_info_buffer: std.ArrayList(u8),
+    dbg_info_type_relocs: link.File.DbgInfoTypeRelocsTable,
+};
+
+/// Caller owns the returned memory.
+pub fn initDeclDebugBuffers(
+    self: *DebugSymbols,
+    allocator: *Allocator,
+    module: *Module,
+    decl: *Module.Decl,
+) !DeclDebugBuffers {
+    const tracy = trace(@src());
+    defer tracy.end();
+
+    var dbg_line_buffer = std.ArrayList(u8).init(allocator);
+    var dbg_info_buffer = std.ArrayList(u8).init(allocator);
+    var dbg_info_type_relocs: link.File.DbgInfoTypeRelocsTable = .{};
+
+    const typed_value = decl.typed_value.most_recent.typed_value;
+    switch (typed_value.ty.zigTypeTag()) {
+        .Fn => {
+            const zir_dumps = if (std.builtin.is_test) &[0][]const u8{} else build_options.zir_dumps;
+            if (zir_dumps.len != 0) {
+                for (zir_dumps) |fn_name| {
+                    if (mem.eql(u8, mem.spanZ(decl.name), fn_name)) {
+                        std.debug.print("\n{}\n", .{decl.name});
+                        typed_value.val.cast(Value.Payload.Function).?.func.dump(module.*);
+                    }
+                }
+            }
+
+            // For functions we need to add a prologue to the debug line program.
+            try dbg_line_buffer.ensureCapacity(26);
+
+            const line_off: u28 = blk: {
+                if (decl.scope.cast(Module.Scope.Container)) |container_scope| {
+                    const tree = container_scope.file_scope.contents.tree;
+                    const file_ast_decls = tree.root_node.decls();
+                    // TODO Look into improving the performance here by adding a token-index-to-line
+                    // lookup table. Currently this involves scanning over the source code for newlines.
+                    const fn_proto = file_ast_decls[decl.src_index].castTag(.FnProto).?;
+                    const block = fn_proto.getBodyNode().?.castTag(.Block).?;
+                    const line_delta = std.zig.lineDelta(tree.source, 0, tree.token_locs[block.lbrace].start);
+                    break :blk @intCast(u28, line_delta);
+                } else if (decl.scope.cast(Module.Scope.ZIRModule)) |zir_module| {
+                    const byte_off = zir_module.contents.module.decls[decl.src_index].inst.src;
+                    const line_delta = std.zig.lineDelta(zir_module.source.bytes, 0, byte_off);
+                    break :blk @intCast(u28, line_delta);
+                } else {
+                    unreachable;
+                }
+            };
+
+            dbg_line_buffer.appendSliceAssumeCapacity(&[_]u8{
+                DW.LNS_extended_op,
+                @sizeOf(u64) + 1,
+                DW.LNE_set_address,
+            });
+            // This is the "relocatable" vaddr, corresponding to `code_buffer` index `0`.
+            assert(dbg_line_vaddr_reloc_index == dbg_line_buffer.items.len);
+            dbg_line_buffer.items.len += @sizeOf(u64);
+
+            dbg_line_buffer.appendAssumeCapacity(DW.LNS_advance_line);
+            // This is the "relocatable" relative line offset from the previous function's end curly
+            // to this function's begin curly.
+            assert(getRelocDbgLineOff() == dbg_line_buffer.items.len);
+            // Here we use a ULEB128-fixed-4 to make sure this field can be overwritten later.
+            leb.writeUnsignedFixed(4, dbg_line_buffer.addManyAsArrayAssumeCapacity(4), line_off);
+
+            dbg_line_buffer.appendAssumeCapacity(DW.LNS_set_file);
+            assert(getRelocDbgFileIndex() == dbg_line_buffer.items.len);
+            // Once we support more than one source file, this will have the ability to be more
+            // than one possible value.
+            const file_index = 1;
+            leb.writeUnsignedFixed(4, dbg_line_buffer.addManyAsArrayAssumeCapacity(4), file_index);
+
+            // Emit a line for the begin curly with prologue_end=false. The codegen will
+            // do the work of setting prologue_end=true and epilogue_begin=true.
+            dbg_line_buffer.appendAssumeCapacity(DW.LNS_copy);
+
+            // .debug_info subprogram
+            const decl_name_with_null = decl.name[0 .. mem.lenZ(decl.name) + 1];
+            try dbg_info_buffer.ensureCapacity(dbg_info_buffer.items.len + 27 + decl_name_with_null.len);
+
+            const fn_ret_type = typed_value.ty.fnReturnType();
+            const fn_ret_has_bits = fn_ret_type.hasCodeGenBits();
+            if (fn_ret_has_bits) {
+                dbg_info_buffer.appendAssumeCapacity(abbrev_subprogram);
+            } else {
+                dbg_info_buffer.appendAssumeCapacity(abbrev_subprogram_retvoid);
+            }
+            // These get overwritten after generating the machine code. These values are
+            // "relocations" and have to be in this fixed place so that functions can be
+            // moved in virtual address space.
+            assert(dbg_info_low_pc_reloc_index == dbg_info_buffer.items.len);
+            dbg_info_buffer.items.len += @sizeOf(u64); // DW.AT_low_pc,  DW.FORM_addr
+            assert(getRelocDbgInfoSubprogramHighPC() == dbg_info_buffer.items.len);
+            dbg_info_buffer.items.len += 4; // DW.AT_high_pc,  DW.FORM_data4
+            if (fn_ret_has_bits) {
+                const gop = try dbg_info_type_relocs.getOrPut(allocator, fn_ret_type);
+                if (!gop.found_existing) {
+                    gop.entry.value = .{
+                        .off = undefined,
+                        .relocs = .{},
+                    };
+                }
+                try gop.entry.value.relocs.append(allocator, @intCast(u32, dbg_info_buffer.items.len));
+                dbg_info_buffer.items.len += 4; // DW.AT_type,  DW.FORM_ref4
+            }
+            dbg_info_buffer.appendSliceAssumeCapacity(decl_name_with_null); // DW.AT_name, DW.FORM_string
+            mem.writeIntLittle(u32, dbg_info_buffer.addManyAsArrayAssumeCapacity(4), line_off + 1); // DW.AT_decl_line, DW.FORM_data4
+            dbg_info_buffer.appendAssumeCapacity(file_index); // DW.AT_decl_file, DW.FORM_data1
+        },
+        else => {
+            // TODO implement .debug_info for global variables
+        },
+    }
+
+    return DeclDebugBuffers{
+        .dbg_info_buffer = dbg_info_buffer,
+        .dbg_line_buffer = dbg_line_buffer,
+        .dbg_info_type_relocs = dbg_info_type_relocs,
+    };
+}
+
+pub fn commitDeclDebugInfo(
+    self: *DebugSymbols,
+    allocator: *Allocator,
+    module: *Module,
+    decl: *Module.Decl,
+    debug_buffers: *DeclDebugBuffers,
+    target: std.Target,
+) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
+    var dbg_line_buffer = &debug_buffers.dbg_line_buffer;
+    var dbg_info_buffer = &debug_buffers.dbg_info_buffer;
+    var dbg_info_type_relocs = &debug_buffers.dbg_info_type_relocs;
+
+    const symbol = self.base.local_symbols.items[decl.link.macho.local_sym_index];
+    const text_block = &decl.link.macho;
+    // If the Decl is a function, we need to update the __debug_line program.
+    const typed_value = decl.typed_value.most_recent.typed_value;
+    switch (typed_value.ty.zigTypeTag()) {
+        .Fn => {
+            // Perform the relocations based on vaddr.
+            {
+                const ptr = dbg_line_buffer.items[dbg_line_vaddr_reloc_index..][0..8];
+                mem.writeIntLittle(u64, ptr, symbol.n_value);
+            }
+            {
+                const ptr = dbg_info_buffer.items[dbg_info_low_pc_reloc_index..][0..8];
+                mem.writeIntLittle(u64, ptr, symbol.n_value);
+            }
+            {
+                const ptr = dbg_info_buffer.items[getRelocDbgInfoSubprogramHighPC()..][0..4];
+                mem.writeIntLittle(u32, ptr, @intCast(u32, text_block.size));
+            }
+
+            try dbg_line_buffer.appendSlice(&[_]u8{ DW.LNS_extended_op, 1, DW.LNE_end_sequence });
+
+            // Now we have the full contents and may allocate a region to store it.
+
+            // This logic is nearly identical to the logic below in `updateDeclDebugInfo` for
+            // `TextBlock` and the .debug_info. If you are editing this logic, you
+            // probably need to edit that logic too.
+
+            const dwarf_segment = &self.load_commands.items[self.dwarf_segment_cmd_index.?].Segment;
+            const debug_line_sect = &dwarf_segment.sections.items[self.debug_line_section_index.?];
+            const src_fn = &decl.fn_link.macho;
+            src_fn.len = @intCast(u32, dbg_line_buffer.items.len);
+            if (self.dbg_line_fn_last) |last| {
+                if (src_fn.next) |next| {
+                    // Update existing function - non-last item.
+                    if (src_fn.off + src_fn.len + min_nop_size > next.off) {
+                        // It grew too big, so we move it to a new location.
+                        if (src_fn.prev) |prev| {
+                            _ = self.dbg_line_fn_free_list.put(allocator, prev, {}) catch {};
+                            prev.next = src_fn.next;
+                        }
+                        next.prev = src_fn.prev;
+                        src_fn.next = null;
+                        // Populate where it used to be with NOPs.
+                        const file_pos = debug_line_sect.offset + src_fn.off;
+                        try self.pwriteDbgLineNops(0, &[0]u8{}, src_fn.len, file_pos);
+                        // TODO Look at the free list before appending at the end.
+                        src_fn.prev = last;
+                        last.next = src_fn;
+                        self.dbg_line_fn_last = src_fn;
+
+                        src_fn.off = last.off + (last.len * alloc_num / alloc_den);
+                    }
+                } else if (src_fn.prev == null) {
+                    // Append new function.
+                    // TODO Look at the free list before appending at the end.
+                    src_fn.prev = last;
+                    last.next = src_fn;
+                    self.dbg_line_fn_last = src_fn;
+
+                    src_fn.off = last.off + (last.len * alloc_num / alloc_den);
+                }
+            } else {
+                // This is the first function of the Line Number Program.
+                self.dbg_line_fn_first = src_fn;
+                self.dbg_line_fn_last = src_fn;
+
+                src_fn.off = self.dbgLineNeededHeaderBytes(module) * alloc_num / alloc_den;
+            }
+
+            const last_src_fn = self.dbg_line_fn_last.?;
+            const needed_size = last_src_fn.off + last_src_fn.len;
+            if (needed_size != debug_line_sect.size) {
+                if (needed_size > dwarf_segment.allocatedSize(debug_line_sect.offset)) {
+                    const new_offset = dwarf_segment.findFreeSpace(needed_size, 1, null);
+                    const existing_size = last_src_fn.off;
+
+                    log.debug("moving __debug_line section: {} bytes from 0x{x} to 0x{x}", .{
+                        existing_size,
+                        debug_line_sect.offset,
+                        new_offset,
+                    });
+
+                    const amt = try self.file.copyRangeAll(debug_line_sect.offset, self.file, new_offset, existing_size);
+                    if (amt != existing_size) return error.InputOutput;
+                    debug_line_sect.offset = @intCast(u32, new_offset);
+                    debug_line_sect.addr = dwarf_segment.inner.vmaddr + new_offset - dwarf_segment.inner.fileoff;
+                }
+                debug_line_sect.size = needed_size;
+                self.load_commands_dirty = true; // TODO look into making only the one section dirty
+                self.debug_line_header_dirty = true;
+            }
+            const prev_padding_size: u32 = if (src_fn.prev) |prev| src_fn.off - (prev.off + prev.len) else 0;
+            const next_padding_size: u32 = if (src_fn.next) |next| next.off - (src_fn.off + src_fn.len) else 0;
+
+            // We only have support for one compilation unit so far, so the offsets are directly
+            // from the .debug_line section.
+            const file_pos = debug_line_sect.offset + src_fn.off;
+            try self.pwriteDbgLineNops(prev_padding_size, dbg_line_buffer.items, next_padding_size, file_pos);
+
+            // .debug_info - End the TAG_subprogram children.
+            try dbg_info_buffer.append(0);
+        },
+        else => {},
+    }
+
+    // Now we emit the .debug_info types of the Decl. These will count towards the size of
+    // the buffer, so we have to do it before computing the offset, and we can't perform the actual
+    // relocations yet.
+    var it = dbg_info_type_relocs.iterator();
+    while (it.next()) |entry| {
+        entry.value.off = @intCast(u32, dbg_info_buffer.items.len);
+        try self.addDbgInfoType(entry.key, dbg_info_buffer, target);
+    }
+
+    try self.updateDeclDebugInfoAllocation(allocator, text_block, @intCast(u32, dbg_info_buffer.items.len));
+
+    // Now that we have the offset assigned we can finally perform type relocations.
+    it = dbg_info_type_relocs.iterator();
+    while (it.next()) |entry| {
+        for (entry.value.relocs.items) |off| {
+            mem.writeIntLittle(
+                u32,
+                dbg_info_buffer.items[off..][0..4],
+                text_block.dbg_info_off + entry.value.off,
+            );
+        }
+    }
+
+    try self.writeDeclDebugInfo(text_block, dbg_info_buffer.items);
+}
+
 /// Asserts the type has codegen bits.
-pub fn addDbgInfoType(
+fn addDbgInfoType(
     self: *DebugSymbols,
     ty: Type,
     dbg_info_buffer: *std.ArrayList(u8),
@@ -931,7 +1228,7 @@ pub fn addDbgInfoType(
     }
 }
 
-pub fn updateDeclDebugInfoAllocation(
+fn updateDeclDebugInfoAllocation(
     self: *DebugSymbols,
     allocator: *Allocator,
     text_block: *TextBlock,
@@ -986,7 +1283,7 @@ pub fn updateDeclDebugInfoAllocation(
     }
 }
 
-pub fn writeDeclDebugInfo(self: *DebugSymbols, text_block: *TextBlock, dbg_info_buf: []const u8) !void {
+fn writeDeclDebugInfo(self: *DebugSymbols, text_block: *TextBlock, dbg_info_buf: []const u8) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -1057,19 +1354,19 @@ fn makeDebugString(self: *DebugSymbols, allocator: *Allocator, bytes: []const u8
 
 /// The reloc offset for the line offset of a function from the previous function's line.
 /// It's a fixed-size 4-byte ULEB128.
-pub fn getRelocDbgLineOff() usize {
+fn getRelocDbgLineOff() usize {
     return dbg_line_vaddr_reloc_index + @sizeOf(u64) + 1;
 }
 
-pub fn getRelocDbgFileIndex() usize {
+fn getRelocDbgFileIndex() usize {
     return getRelocDbgLineOff() + 5;
 }
 
-pub fn getRelocDbgInfoSubprogramHighPC() u32 {
+fn getRelocDbgInfoSubprogramHighPC() u32 {
     return dbg_info_low_pc_reloc_index + @sizeOf(u64);
 }
 
-pub fn dbgLineNeededHeaderBytes(self: DebugSymbols, module: *Module) u32 {
+fn dbgLineNeededHeaderBytes(self: DebugSymbols, module: *Module) u32 {
     const directory_entry_format_count = 1;
     const file_name_entry_format_count = 1;
     const directory_count = 1;
@@ -1092,7 +1389,7 @@ fn dbgInfoNeededHeaderBytes(self: DebugSymbols) u32 {
 /// are less than 126,976 bytes (if this limit is ever reached, this function can be
 /// improved to make more than one pwritev call, or the limit can be raised by a fixed
 /// amount by increasing the length of `vecs`).
-pub fn pwriteDbgLineNops(
+fn pwriteDbgLineNops(
     self: *DebugSymbols,
     prev_padding_size: usize,
     buf: []const u8,
@@ -1170,7 +1467,7 @@ pub fn pwriteDbgLineNops(
 
 /// Writes to the file a buffer, prefixed and suffixed by the specified number of
 /// bytes of padding.
-pub fn pwriteDbgInfoNops(
+fn pwriteDbgInfoNops(
     self: *DebugSymbols,
     prev_padding_size: usize,
     buf: []const u8,
@@ -1238,26 +1535,4 @@ pub fn pwriteDbgInfoNops(
     }
 
     try self.file.pwritevAll(vecs[0..vec_index], offset - prev_padding_size);
-}
-
-pub fn updateDeclLineNumber(self: *DebugSymbols, module: *Module, decl: *const Module.Decl) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
-
-    const container_scope = decl.scope.cast(Module.Scope.Container).?;
-    const tree = container_scope.file_scope.contents.tree;
-    const file_ast_decls = tree.root_node.decls();
-    // TODO Look into improving the performance here by adding a token-index-to-line
-    // lookup table. Currently this involves scanning over the source code for newlines.
-    const fn_proto = file_ast_decls[decl.src_index].castTag(.FnProto).?;
-    const block = fn_proto.getBodyNode().?.castTag(.Block).?;
-    const line_delta = std.zig.lineDelta(tree.source, 0, tree.token_locs[block.lbrace].start);
-    const casted_line_off = @intCast(u28, line_delta);
-
-    const dwarf_segment = &self.load_commands.items[self.dwarf_segment_cmd_index.?].Segment;
-    const shdr = &dwarf_segment.sections.items[self.debug_line_section_index.?];
-    const file_pos = shdr.offset + decl.fn_link.macho.off + getRelocDbgLineOff();
-    var data: [4]u8 = undefined;
-    leb.writeUnsignedFixed(4, &data, casted_line_off);
-    try self.file.pwriteAll(&data, file_pos);
 }

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -10,7 +10,11 @@ const DW = std.dwarf;
 const leb = std.leb;
 const Allocator = mem.Allocator;
 
+const trace = @import("../../tracy.zig").trace;
 const MachO = @import("../MachO.zig");
+const satMul = MachO.satMul;
+const alloc_num = MachO.alloc_num;
+const alloc_den = MachO.alloc_den;
 
 usingnamespace @import("commands.zig");
 
@@ -40,8 +44,12 @@ uuid_cmd_index: ?u16 = null,
 /// Index into __TEXT,__text section.
 text_section_index: ?u16 = null,
 
+linkedit_off: u16 = 0x1000,
+linkedit_size: u16 = 0x1000,
+
 header_dirty: bool = false,
 load_commands_dirty: bool = false,
+string_table_dirty: bool = false,
 
 /// You must call this function *after* `MachO.populateMissingMetadata()`
 /// has been called to get a viable debug symbols output.
@@ -61,22 +69,6 @@ pub fn populateMissingMetadata(self: *DebugSymbols, allocator: *Allocator) !void
         self.header = header;
         self.header_dirty = true;
     }
-    if (self.pagezero_segment_cmd_index == null) {
-        self.pagezero_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
-        const base_cmd = self.base.load_commands.items[self.base.pagezero_segment_cmd_index.?].Segment;
-        try self.copySegmentCommand(allocator, base_cmd);
-    }
-    if (self.text_segment_cmd_index == null) {
-        self.text_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
-        const base_cmd = self.base.load_commands.items[self.base.text_segment_cmd_index.?].Segment;
-        try self.copySegmentCommand(allocator, base_cmd);
-    }
-    if (self.data_segment_cmd_index == null) outer: {
-        if (self.base.data_segment_cmd_index == null) break :outer; // __DATA is optional
-        self.data_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
-        const base_cmd = self.base.load_commands.items[self.base.data_segment_cmd_index.?].Segment;
-        try self.copySegmentCommand(allocator, base_cmd);
-    }
     if (self.uuid_cmd_index == null) {
         const base_cmd = self.base.load_commands.items[self.base.uuid_cmd_index.?];
         self.uuid_cmd_index = @intCast(u16, self.load_commands.items.len);
@@ -84,13 +76,79 @@ pub fn populateMissingMetadata(self: *DebugSymbols, allocator: *Allocator) !void
         self.header_dirty = true;
         self.load_commands_dirty = true;
     }
+    if (self.symtab_cmd_index == null) {
+        self.symtab_cmd_index = @intCast(u16, self.load_commands.items.len);
+        const base_cmd = self.base.load_commands.items[self.base.symtab_cmd_index.?].Symtab;
+        const symtab_size = base_cmd.nsyms * @sizeOf(macho.nlist_64);
+        const symtab_off = self.findFreeSpaceLinkedit(symtab_size, @sizeOf(macho.nlist_64));
+
+        log.debug("found dSym symbol table free space 0x{x} to 0x{x}", .{ symtab_off, symtab_off + symtab_size });
+
+        const strtab_off = self.findFreeSpaceLinkedit(base_cmd.strsize, 1);
+
+        log.debug("found dSym string table free space 0x{x} to 0x{x}", .{ strtab_off, strtab_off + base_cmd.strsize });
+
+        try self.load_commands.append(allocator, .{
+            .Symtab = .{
+                .cmd = macho.LC_SYMTAB,
+                .cmdsize = @sizeOf(macho.symtab_command),
+                .symoff = @intCast(u32, symtab_off),
+                .nsyms = base_cmd.nsyms,
+                .stroff = @intCast(u32, strtab_off),
+                .strsize = base_cmd.strsize,
+            },
+        });
+        try self.writeLocalSymbol(0);
+        self.header_dirty = true;
+        self.load_commands_dirty = true;
+        self.string_table_dirty = true;
+    }
+    if (self.pagezero_segment_cmd_index == null) {
+        self.pagezero_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
+        const base_cmd = self.base.load_commands.items[self.base.pagezero_segment_cmd_index.?].Segment;
+        const cmd = try self.copySegmentCommand(allocator, base_cmd);
+        try self.load_commands.append(allocator, .{ .Segment = cmd });
+        self.header_dirty = true;
+        self.load_commands_dirty = true;
+    }
+    if (self.text_segment_cmd_index == null) {
+        self.text_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
+        const base_cmd = self.base.load_commands.items[self.base.text_segment_cmd_index.?].Segment;
+        const cmd = try self.copySegmentCommand(allocator, base_cmd);
+        try self.load_commands.append(allocator, .{ .Segment = cmd });
+        self.header_dirty = true;
+        self.load_commands_dirty = true;
+    }
+    if (self.data_segment_cmd_index == null) outer: {
+        if (self.base.data_segment_cmd_index == null) break :outer; // __DATA is optional
+        self.data_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
+        const base_cmd = self.base.load_commands.items[self.base.data_segment_cmd_index.?].Segment;
+        const cmd = try self.copySegmentCommand(allocator, base_cmd);
+        try self.load_commands.append(allocator, .{ .Segment = cmd });
+        self.header_dirty = true;
+        self.load_commands_dirty = true;
+    }
+    if (self.linkedit_segment_cmd_index == null) {
+        self.linkedit_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
+        const base_cmd = self.base.load_commands.items[self.base.linkedit_segment_cmd_index.?].Segment;
+        var cmd = try self.copySegmentCommand(allocator, base_cmd);
+        cmd.inner.vmsize = self.linkedit_size;
+        cmd.inner.fileoff = self.linkedit_off;
+        cmd.inner.filesize = self.linkedit_size;
+        try self.load_commands.append(allocator, .{ .Segment = cmd });
+        self.header_dirty = true;
+        self.load_commands_dirty = true;
+    }
 }
 
 pub fn flush(self: *DebugSymbols, allocator: *Allocator) !void {
+    try self.writeStringTable();
     try self.writeLoadCommands(allocator);
     try self.writeHeader();
+
     assert(!self.header_dirty);
     assert(!self.load_commands_dirty);
+    assert(!self.string_table_dirty);
 }
 
 pub fn deinit(self: *DebugSymbols, allocator: *Allocator) void {
@@ -100,7 +158,7 @@ pub fn deinit(self: *DebugSymbols, allocator: *Allocator) void {
     self.file.close();
 }
 
-fn copySegmentCommand(self: *DebugSymbols, allocator: *Allocator, base_cmd: SegmentCommand) !void {
+fn copySegmentCommand(self: *DebugSymbols, allocator: *Allocator, base_cmd: SegmentCommand) !SegmentCommand {
     var cmd = SegmentCommand.empty(.{
         .cmd = macho.LC_SEGMENT_64,
         .cmdsize = base_cmd.inner.cmdsize,
@@ -142,9 +200,7 @@ fn copySegmentCommand(self: *DebugSymbols, allocator: *Allocator, base_cmd: Segm
         cmd.sections.appendAssumeCapacity(sect);
     }
 
-    try self.load_commands.append(allocator, .{ .Segment = cmd });
-    self.header_dirty = true;
-    self.load_commands_dirty = true;
+    return cmd;
 }
 
 /// Writes all load commands and section headers.
@@ -181,4 +237,116 @@ fn writeHeader(self: *DebugSymbols) !void {
     log.debug("writing Mach-O dSym header {}", .{self.header.?});
     try self.file.pwriteAll(mem.asBytes(&self.header.?), 0);
     self.header_dirty = false;
+}
+
+fn allocatedSizeLinkedit(self: *DebugSymbols, start: u64) u64 {
+    assert(start > 0);
+    var min_pos: u64 = std.math.maxInt(u64);
+
+    if (self.symtab_cmd_index) |idx| {
+        const symtab = self.load_commands.items[idx].Symtab;
+        if (symtab.symoff >= start and symtab.symoff < min_pos) min_pos = symtab.symoff;
+        if (symtab.stroff >= start and symtab.stroff < min_pos) min_pos = symtab.stroff;
+    }
+
+    return min_pos - start;
+}
+
+fn detectAllocCollisionLinkedit(self: *DebugSymbols, start: u64, size: u64) ?u64 {
+    const end = start + satMul(size, alloc_num) / alloc_den;
+
+    if (self.symtab_cmd_index) |idx| outer: {
+        if (self.load_commands.items.len == idx) break :outer;
+        const symtab = self.load_commands.items[idx].Symtab;
+        {
+            // Symbol table
+            const symsize = symtab.nsyms * @sizeOf(macho.nlist_64);
+            const increased_size = satMul(symsize, alloc_num) / alloc_den;
+            const test_end = symtab.symoff + increased_size;
+            if (end > symtab.symoff and start < test_end) {
+                return test_end;
+            }
+        }
+        {
+            // String table
+            const increased_size = satMul(symtab.strsize, alloc_num) / alloc_den;
+            const test_end = symtab.stroff + increased_size;
+            if (end > symtab.stroff and start < test_end) {
+                return test_end;
+            }
+        }
+    }
+
+    return null;
+}
+
+fn findFreeSpaceLinkedit(self: *DebugSymbols, object_size: u64, min_alignment: u16) u64 {
+    var start: u64 = self.linkedit_off;
+    while (self.detectAllocCollisionLinkedit(start, object_size)) |item_end| {
+        start = mem.alignForwardGeneric(u64, item_end, min_alignment);
+    }
+    return start;
+}
+
+fn relocateSymbolTable(self: *DebugSymbols) !void {
+    const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
+    const nlocals = self.base.local_symbols.items.len;
+    const nglobals = self.base.global_symbols.items.len;
+    const nsyms = nlocals + nglobals;
+
+    if (symtab.nsyms < nsyms) {
+        const linkedit_segment = self.load_commands.items[self.linkedit_segment_cmd_index.?].Segment;
+        const needed_size = nsyms * @sizeOf(macho.nlist_64);
+        if (needed_size > self.allocatedSizeLinkedit(symtab.symoff)) {
+            // Move the entire symbol table to a new location
+            const new_symoff = self.findFreeSpaceLinkedit(needed_size, @alignOf(macho.nlist_64));
+            const existing_size = symtab.nsyms * @sizeOf(macho.nlist_64);
+
+            assert(new_symoff + existing_size <= self.linkedit_off + self.linkedit_size);
+            log.debug("relocating dSym symbol table from 0x{x}-0x{x} to 0x{x}-0x{x}", .{
+                symtab.symoff,
+                symtab.symoff + existing_size,
+                new_symoff,
+                new_symoff + existing_size,
+            });
+
+            const amt = try self.file.copyRangeAll(symtab.symoff, self.file, new_symoff, existing_size);
+            if (amt != existing_size) return error.InputOutput;
+            symtab.symoff = @intCast(u32, new_symoff);
+        }
+        symtab.nsyms = @intCast(u32, nsyms);
+        self.load_commands_dirty = true;
+    }
+}
+
+pub fn writeLocalSymbol(self: *DebugSymbols, index: usize) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+    try self.relocateSymbolTable();
+    const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
+    const off = symtab.symoff + @sizeOf(macho.nlist_64) * index;
+    log.debug("writing dSym local symbol {} at 0x{x}", .{ index, off });
+    try self.file.pwriteAll(mem.asBytes(&self.base.local_symbols.items[index]), off);
+}
+
+pub fn writeStringTable(self: *DebugSymbols) !void {
+    if (!self.string_table_dirty) return;
+
+    const tracy = trace(@src());
+    defer tracy.end();
+
+    const symtab = &self.load_commands.items[self.symtab_cmd_index.?].Symtab;
+    const allocated_size = self.allocatedSizeLinkedit(symtab.stroff);
+    const needed_size = mem.alignForwardGeneric(u64, self.base.string_table.items.len, @alignOf(u64));
+
+    if (needed_size > allocated_size) {
+        symtab.strsize = 0;
+        symtab.stroff = @intCast(u32, self.findFreeSpaceLinkedit(needed_size, 1));
+    }
+    symtab.strsize = @intCast(u32, needed_size);
+    log.debug("writing dSym string table from 0x{x} to 0x{x}", .{ symtab.stroff, symtab.stroff + symtab.strsize });
+
+    try self.file.pwriteAll(self.base.string_table.items, symtab.stroff);
+    self.load_commands_dirty = true;
+    self.string_table_dirty = false;
 }

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -1,0 +1,40 @@
+const DebugSymbols = @This();
+
+const std = @import("std");
+const fs = std.fs;
+const macho = std.macho;
+const mem = std.mem;
+const DW = std.dwarf;
+const leb = std.leb;
+const Allocator = mem.Allocator;
+
+const MachO = @import("../MachO.zig");
+
+usingnamespace @import("commands.zig");
+
+base: *MachO,
+file: fs.File,
+
+/// Mach header
+header: ?macho.mach_header_64 = null,
+
+/// Table of all load commands
+load_commands: std.ArrayListUnmanaged(LoadCommand) = .{},
+/// __PAGEZERO segment
+pagezero_segment_cmd_index: ?u16 = null,
+/// __TEXT segment
+text_segment_cmd_index: ?u16 = null,
+/// __DWARF segment
+dwarf_segment_cmd_index: ?u16 = null,
+/// __DATA segment
+data_segment_cmd_index: ?u16 = null,
+/// __LINKEDIT segment
+linkedit_segment_cmd_index: ?u16 = null,
+/// Symbol table
+symtab_cmd_index: ?u16 = null,
+/// UUID load command
+uuid_cmd_index: ?u16 = null,
+
+pub fn deinit(self: *DebugSymbols, allocator: *Allocator) void {
+    self.file.close();
+}

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -361,52 +361,41 @@ pub fn flushModule(self: *DebugSymbols, allocator: *Allocator, options: link.Opt
         // we can simply append these bytes.
         const abbrev_buf = [_]u8{
             abbrev_compile_unit, DW.TAG_compile_unit, DW.CHILDREN_yes, // header
-            DW.AT_stmt_list,     DW.FORM_sec_offset,  DW.AT_low_pc,
-            DW.FORM_addr,        DW.AT_high_pc,       DW.FORM_addr,
-            DW.AT_name,          DW.FORM_strp,        DW.AT_comp_dir,
-            DW.FORM_strp,        DW.AT_producer,      DW.FORM_strp,
-            DW.AT_language,      DW.FORM_data2,       0,
-            0, // table sentinel
-            abbrev_subprogram,
-            DW.TAG_subprogram,
-            DW.CHILDREN_yes, // header
-            DW.AT_low_pc,
-            DW.FORM_addr,
-            DW.AT_high_pc,
-            DW.FORM_data4,
-            DW.AT_type,
-            DW.FORM_ref4,
-            DW.AT_name,
-            DW.FORM_string,
+            DW.AT_stmt_list, DW.FORM_sec_offset, // offset
+            DW.AT_low_pc,    DW.FORM_addr,
+            DW.AT_high_pc,   DW.FORM_addr,
+            DW.AT_name,      DW.FORM_strp,
+            DW.AT_comp_dir,  DW.FORM_strp,
+            DW.AT_producer,  DW.FORM_strp,
+            DW.AT_language,  DW.FORM_data2,
+            0, 0, // table sentinel
+            abbrev_subprogram, DW.TAG_subprogram, DW.CHILDREN_yes, // header
+            DW.AT_low_pc,    DW.FORM_addr, // start VM address
+            DW.AT_high_pc,   DW.FORM_data4,
+            DW.AT_type,      DW.FORM_ref4,
+            DW.AT_name,      DW.FORM_string,
+            DW.AT_decl_line, DW.FORM_data4,
+            DW.AT_decl_file, DW.FORM_data1,
             0,                         0, // table sentinel
             abbrev_subprogram_retvoid,
             DW.TAG_subprogram, DW.CHILDREN_yes, // header
             DW.AT_low_pc,      DW.FORM_addr,
             DW.AT_high_pc,     DW.FORM_data4,
             DW.AT_name,        DW.FORM_string,
-            0,
-            0, // table sentinel
-            abbrev_base_type,
-            DW.TAG_base_type,
-            DW.CHILDREN_no, // header
-            DW.AT_encoding,
-            DW.FORM_data1,
-            DW.AT_byte_size,
-            DW.FORM_data1,
-            DW.AT_name,
-            DW.FORM_string, 0, 0, // table sentinel
+            DW.AT_decl_line,   DW.FORM_data4,
+            DW.AT_decl_file,   DW.FORM_data1,
+            0, 0, // table sentinel
+            abbrev_base_type, DW.TAG_base_type, DW.CHILDREN_no, // header
+            DW.AT_encoding,   DW.FORM_data1,    DW.AT_byte_size,
+            DW.FORM_data1,    DW.AT_name,       DW.FORM_string,
+            0, 0, // table sentinel
             abbrev_pad1, DW.TAG_unspecified_type, DW.CHILDREN_no, // header
-            0,                0, // table sentinel
-            abbrev_parameter,
-            DW.TAG_formal_parameter, DW.CHILDREN_no, // header
-            DW.AT_location,          DW.FORM_exprloc,
-            DW.AT_type,              DW.FORM_ref4,
-            DW.AT_name,              DW.FORM_string,
-            0,
-            0, // table sentinel
-            0,
-            0,
-            0, // section sentinel
+            0, 0, // table sentinel
+            abbrev_parameter, DW.TAG_formal_parameter, DW.CHILDREN_no, // header
+            DW.AT_location,   DW.FORM_exprloc,         DW.AT_type,
+            DW.FORM_ref4,     DW.AT_name,              DW.FORM_string,
+            0, 0, // table sentinel
+            0, 0, 0, // section sentinel
         };
 
         const needed_size = abbrev_buf.len;

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -1,7 +1,9 @@
 const DebugSymbols = @This();
 
 const std = @import("std");
+const assert = std.debug.assert;
 const fs = std.fs;
+const log = std.log.scoped(.link);
 const macho = std.macho;
 const mem = std.mem;
 const DW = std.dwarf;
@@ -35,6 +37,49 @@ symtab_cmd_index: ?u16 = null,
 /// UUID load command
 uuid_cmd_index: ?u16 = null,
 
+header_dirty: bool = false,
+load_commands_dirty: bool = false,
+
+/// You must call this function *after* `MachO.populateMissingMetadata()`
+/// has been called to get a viable debug symbols output.
+pub fn populateMissingMetadata(self: *DebugSymbols, allocator: *Allocator) !void {
+    if (self.header == null) {
+        const base_header = self.base.header.?;
+        var header: macho.mach_header_64 = undefined;
+        header.magic = macho.MH_MAGIC_64;
+        header.cputype = base_header.cputype;
+        header.cpusubtype = base_header.cpusubtype;
+        header.filetype = macho.MH_DSYM;
+        // These will get populated at the end of flushing the results to file.
+        header.ncmds = 0;
+        header.sizeofcmds = 0;
+        header.flags = 0;
+        header.reserved = 0;
+        self.header = header;
+        self.header_dirty = true;
+    }
+}
+
+pub fn flush(self: *DebugSymbols) !void {
+    try self.writeHeader();
+    assert(!self.header_dirty);
+    assert(!self.load_commands_dirty);
+}
+
 pub fn deinit(self: *DebugSymbols, allocator: *Allocator) void {
     self.file.close();
+}
+
+fn writeHeader(self: *DebugSymbols) !void {
+    if (!self.header_dirty) return;
+
+    self.header.?.ncmds = @intCast(u32, self.load_commands.items.len);
+    var sizeofcmds: u32 = 0;
+    for (self.load_commands.items) |cmd| {
+        sizeofcmds += cmd.cmdsize();
+    }
+    self.header.?.sizeofcmds = sizeofcmds;
+    log.debug("writing Mach-O dSym header {}", .{self.header.?});
+    try self.file.pwriteAll(mem.asBytes(&self.header.?), 0);
+    self.header_dirty = false;
 }

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -26,16 +26,19 @@ load_commands: std.ArrayListUnmanaged(LoadCommand) = .{},
 pagezero_segment_cmd_index: ?u16 = null,
 /// __TEXT segment
 text_segment_cmd_index: ?u16 = null,
-/// __DWARF segment
-dwarf_segment_cmd_index: ?u16 = null,
 /// __DATA segment
 data_segment_cmd_index: ?u16 = null,
 /// __LINKEDIT segment
 linkedit_segment_cmd_index: ?u16 = null,
+/// __DWARF segment
+dwarf_segment_cmd_index: ?u16 = null,
 /// Symbol table
 symtab_cmd_index: ?u16 = null,
 /// UUID load command
 uuid_cmd_index: ?u16 = null,
+
+/// Index into __TEXT,__text section.
+text_section_index: ?u16 = null,
 
 header_dirty: bool = false,
 load_commands_dirty: bool = false,
@@ -58,6 +61,22 @@ pub fn populateMissingMetadata(self: *DebugSymbols, allocator: *Allocator) !void
         self.header = header;
         self.header_dirty = true;
     }
+    if (self.pagezero_segment_cmd_index == null) {
+        self.pagezero_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
+        const base_cmd = self.base.load_commands.items[self.base.pagezero_segment_cmd_index.?].Segment;
+        try self.copySegmentCommand(allocator, base_cmd);
+    }
+    if (self.text_segment_cmd_index == null) {
+        self.text_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
+        const base_cmd = self.base.load_commands.items[self.base.text_segment_cmd_index.?].Segment;
+        try self.copySegmentCommand(allocator, base_cmd);
+    }
+    if (self.data_segment_cmd_index == null) outer: {
+        if (self.base.data_segment_cmd_index == null) break :outer; // __DATA is optional
+        self.data_segment_cmd_index = @intCast(u16, self.load_commands.items.len);
+        const base_cmd = self.base.load_commands.items[self.base.data_segment_cmd_index.?].Segment;
+        try self.copySegmentCommand(allocator, base_cmd);
+    }
     if (self.uuid_cmd_index == null) {
         const base_cmd = self.base.load_commands.items[self.base.uuid_cmd_index.?];
         self.uuid_cmd_index = @intCast(u16, self.load_commands.items.len);
@@ -79,6 +98,53 @@ pub fn deinit(self: *DebugSymbols, allocator: *Allocator) void {
         lc.deinit(allocator);
     }
     self.file.close();
+}
+
+fn copySegmentCommand(self: *DebugSymbols, allocator: *Allocator, base_cmd: SegmentCommand) !void {
+    var cmd = SegmentCommand.empty(.{
+        .cmd = macho.LC_SEGMENT_64,
+        .cmdsize = base_cmd.inner.cmdsize,
+        .segname = undefined,
+        .vmaddr = base_cmd.inner.vmaddr,
+        .vmsize = base_cmd.inner.vmsize,
+        .fileoff = 0,
+        .filesize = 0,
+        .maxprot = base_cmd.inner.maxprot,
+        .initprot = base_cmd.inner.initprot,
+        .nsects = base_cmd.inner.nsects,
+        .flags = base_cmd.inner.flags,
+    });
+    mem.copy(u8, &cmd.inner.segname, &base_cmd.inner.segname);
+
+    try cmd.sections.ensureCapacity(allocator, cmd.inner.nsects);
+    for (base_cmd.sections.items) |base_sect, i| {
+        var sect = macho.section_64{
+            .sectname = undefined,
+            .segname = undefined,
+            .addr = base_sect.addr,
+            .size = base_sect.size,
+            .offset = 0,
+            .@"align" = base_sect.@"align",
+            .reloff = 0,
+            .nreloc = 0,
+            .flags = base_sect.flags,
+            .reserved1 = base_sect.reserved1,
+            .reserved2 = base_sect.reserved2,
+            .reserved3 = base_sect.reserved3,
+        };
+        mem.copy(u8, &sect.sectname, &base_sect.sectname);
+        mem.copy(u8, &sect.segname, &base_sect.segname);
+
+        if (self.base.text_section_index.? == i) {
+            self.text_section_index = @intCast(u16, i);
+        }
+
+        cmd.sections.appendAssumeCapacity(sect);
+    }
+
+    try self.load_commands.append(allocator, .{ .Segment = cmd });
+    self.header_dirty = true;
+    self.load_commands_dirty = true;
 }
 
 /// Writes all load commands and section headers.

--- a/src/link/MachO/commands.zig
+++ b/src/link/MachO/commands.zig
@@ -23,6 +23,7 @@ pub const LoadCommand = union(enum) {
     Main: macho.entry_point_command,
     VersionMin: macho.version_min_command,
     SourceVersion: macho.source_version_command,
+    Uuid: macho.uuid_command,
     LinkeditData: macho.linkedit_data_command,
     Unknown: GenericCommandWithData(macho.load_command),
 
@@ -62,6 +63,9 @@ pub const LoadCommand = union(enum) {
             macho.LC_SOURCE_VERSION => LoadCommand{
                 .SourceVersion = try stream.reader().readStruct(macho.source_version_command),
             },
+            macho.LC_UUID => LoadCommand{
+                .Uuid = try stream.reader().readStruct(macho.uuid_command),
+            },
             macho.LC_FUNCTION_STARTS, macho.LC_DATA_IN_CODE, macho.LC_CODE_SIGNATURE => LoadCommand{
                 .LinkeditData = try stream.reader().readStruct(macho.linkedit_data_command),
             },
@@ -79,6 +83,7 @@ pub const LoadCommand = union(enum) {
             .Main => |x| writeStruct(x, writer),
             .VersionMin => |x| writeStruct(x, writer),
             .SourceVersion => |x| writeStruct(x, writer),
+            .Uuid => |x| writeStruct(x, writer),
             .LinkeditData => |x| writeStruct(x, writer),
             .Segment => |x| x.write(writer),
             .Dylinker => |x| x.write(writer),
@@ -95,6 +100,7 @@ pub const LoadCommand = union(enum) {
             .Main => |x| x.cmd,
             .VersionMin => |x| x.cmd,
             .SourceVersion => |x| x.cmd,
+            .Uuid => |x| x.cmd,
             .LinkeditData => |x| x.cmd,
             .Segment => |x| x.inner.cmd,
             .Dylinker => |x| x.inner.cmd,
@@ -112,6 +118,7 @@ pub const LoadCommand = union(enum) {
             .VersionMin => |x| x.cmdsize,
             .SourceVersion => |x| x.cmdsize,
             .LinkeditData => |x| x.cmdsize,
+            .Uuid => |x| x.cmdsize,
             .Segment => |x| x.inner.cmdsize,
             .Dylinker => |x| x.inner.cmdsize,
             .Dylib => |x| x.inner.cmdsize,
@@ -142,6 +149,7 @@ pub const LoadCommand = union(enum) {
             .Main => |x| meta.eql(x, other.Main),
             .VersionMin => |x| meta.eql(x, other.VersionMin),
             .SourceVersion => |x| meta.eql(x, other.SourceVersion),
+            .Uuid => |x| meta.eql(x, other.Uuid),
             .LinkeditData => |x| meta.eql(x, other.LinkeditData),
             .Segment => |x| x.eql(other.Segment),
             .Dylinker => |x| x.eql(other.Dylinker),

--- a/src/link/MachO/commands.zig
+++ b/src/link/MachO/commands.zig
@@ -5,6 +5,7 @@ const mem = std.mem;
 const meta = std.meta;
 const macho = std.macho;
 const testing = std.testing;
+const assert = std.debug.assert;
 
 const Allocator = std.mem.Allocator;
 const MachO = @import("../MachO.zig");
@@ -202,9 +203,12 @@ pub const SegmentCommand = struct {
 
     pub fn allocatedSize(self: SegmentCommand, start: u64) u64 {
         assert(start > 0);
+        if (start == self.inner.fileoff)
+            return 0;
         var min_pos: u64 = std.math.maxInt(u64);
         for (self.sections.items) |section| {
-            if (section.offset > start and section.offset < min_pos) min_pos = section.offset;
+            if (section.offset <= start) continue;
+            if (section.offset < min_pos) min_pos = section.offset;
         }
         return min_pos - start;
     }


### PR DESCRIPTION
This PR adds preliminary support for DWARF debugging symbols info on macOS. My research revealed there are two ways of providing the debuggers on macOS with DWARF: 1) embedding incomplete (prior to final relocations) DWARF segment/sections within an intermediate object file `.o`, or 2) creating a supplementary companion Mach-O file as part of a `dSYM` bundle. The former is closer to what we currently have on Elf targets, however, it implies we'd need to always create an intermediate object file before performing the final linking into an executable (this is how the old-school toolchains do it AFAICT). The latter seems more suited towards our goal of incremental linking in the sense that it is not that difficult to create a mirror image of the base Mach-O executable, keep it in-sync, and append the DWARF segment/sections. In essence, we now create and incrementally update two Mach-O files: the executable, and its mirror image that carries the debugging symbols. I should point here that the mirror image Mach-O, in addition to the DWARF segment, carries only the VM addresses of relevant executable and writable segments, and the symbol and string tables. To the best of my knowledge, this is exactly how it's done in Xcode for "Debug with dSYM" and "Release with dSYM" builds.

Now as far as the actual debugging info goes, I've basically included the same info we already produce in Elf linker, however, I'll be updating/tweaking it as I learn more on DWARF. So while it currently doesn't provide much in terms of debugging on macOS using the `lldb`, you can at least preview some info using `dwarfdump` as follows:

```
> dwarfdump --all hello.dSYM
hello.dSYM/Contents/Resources/DWARF/hello:	file format Mach-O 64-bit x86-64
UUID: 85DD25A2-3580-41A0-3494-210683B5B0C9 (x86_64) hello.dSYM/Contents/Resources/DWARF/hello

.debug_abbrev contents:
Abbrev table for offset: 0x00000000
[1] DW_TAG_compile_unit	DW_CHILDREN_yes
	DW_AT_stmt_list	DW_FORM_sec_offset
	DW_AT_low_pc	DW_FORM_addr
	DW_AT_high_pc	DW_FORM_addr
...
```