### PR TITLE
std: Remove duplicated code

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -337,6 +337,9 @@ pub const Target = struct {
             };
         }
 
+        /// On Darwin, we always link libSystem which contains libc.
+        /// Similarly on FreeBSD and NetBSD we always link system libc
+        /// since this is the stable syscall interface.
         pub fn requiresLibC(os: Os) bool {
             return switch (os.tag) {
                 .freebsd,

--- a/src/target.zig
+++ b/src/target.zig
@@ -128,10 +128,7 @@ pub fn cannotDynamicLink(target: std.Target) bool {
 /// Similarly on FreeBSD and NetBSD we always link system libc
 /// since this is the stable syscall interface.
 pub fn osRequiresLibC(target: std.Target) bool {
-    return switch (target.os.tag) {
-        .freebsd, .netbsd, .dragonfly, .openbsd, .macos, .ios, .watchos, .tvos => true,
-        else => false,
-    };
+    return target.os.requiresLibC();
 }
 
 pub fn libcNeedsLibUnwind(target: std.Target) bool {


### PR DESCRIPTION
Make osRequiresLibC call Os.requiresLibC, let's keep a single list of OS
that require the libc to be linked in.