### PR TITLE
Implement #7296

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 # -andrewrk
 
 zig-cache/
+/release/
+/debug/
 /build/
 /build-*/
 /docgen_tmp/

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -200,12 +200,16 @@ pub const Builder = struct {
             const install_prefix = self.install_prefix orelse "/usr";
             self.install_path = fs.path.join(self.allocator, &[_][]const u8{ dest_dir, install_prefix }) catch unreachable;
         } else {
-            const install_prefix = self.install_prefix orelse blk: {
-                const p = self.cache_root;
+            self.install_path = self.install_prefix orelse blk: {
+                const p = if (self.release_mode) |mode| switch (mode) {
+                    .Debug => "debug",
+                    .ReleaseSafe => "release",
+                    .ReleaseFast => "release",
+                    .ReleaseSmall => "release",
+                } else "debug";
                 self.install_prefix = p;
-                break :blk p;
+                break :blk self.pathFromRoot(p);
             };
-            self.install_path = install_prefix;
         }
         self.lib_dir = fs.path.join(self.allocator, &[_][]const u8{ self.install_path, "lib" }) catch unreachable;
         self.exe_dir = fs.path.join(self.allocator, &[_][]const u8{ self.install_path, "bin" }) catch unreachable;

--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -134,8 +134,8 @@ pub fn main() !void {
         }
     }
 
-    builder.resolveInstallPrefix();
     try runBuild(builder);
+    builder.resolveInstallPrefix();
 
     if (builder.validateUserInputDidItFail())
         return usageAndErr(builder, true, stderr_stream);


### PR DESCRIPTION
Closes #7296.
~~I also added a commit to change the default template from init-exe to use `std.debug.print` instead of `std.log.info`. This is so that it will  work in release modes other than `debug`. Found this when testing this. See https://freenode.irclog.whitequark.org/zig/2020-12-31#28714698; I noticed in 0.6.0 it used `std.debug.warn`, why did it change?~~