### PR TITLE
stage2: rework Type Payload layout

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -825,9 +825,11 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
 
             const root_scope = rs: {
                 if (mem.endsWith(u8, root_pkg.root_src_path, ".zig")) {
-                    const struct_payload = try gpa.create(Type.Payload.EmptyStruct);
                     const root_scope = try gpa.create(Module.Scope.File);
-                    struct_payload.* = .{ .scope = &root_scope.root_container };
+                    const struct_ty = try Type.Tag.empty_struct.create(
+                        gpa,
+                        &root_scope.root_container,
+                    );
                     root_scope.* = .{
                         // TODO this is duped so it can be freed in Container.deinit
                         .sub_file_path = try gpa.dupe(u8, root_pkg.root_src_path),
@@ -838,7 +840,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
                         .root_container = .{
                             .file_scope = root_scope,
                             .decls = .{},
-                            .ty = Type.initPayload(&struct_payload.base),
+                            .ty = struct_ty,
                         },
                     };
                     break :rs &root_scope.base;

--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -1956,13 +1956,13 @@ fn identifier(mod: *Module, scope: *Scope, rl: ResultLoc, ident: *ast.Node.OneTo
                 32 => if (is_signed) Value.initTag(.i32_type) else Value.initTag(.u32_type),
                 64 => if (is_signed) Value.initTag(.i64_type) else Value.initTag(.u64_type),
                 else => {
-                    const int_type_payload = try scope.arena().create(Value.Payload.IntType);
-                    int_type_payload.* = .{ .signed = is_signed, .bits = bit_count };
-                    const result = try addZIRInstConst(mod, scope, src, .{
+                    return rlWrap(mod, scope, rl, try addZIRInstConst(mod, scope, src, .{
                         .ty = Type.initTag(.type),
-                        .val = Value.initPayload(&int_type_payload.base),
-                    });
-                    return rlWrap(mod, scope, rl, result);
+                        .val = try Value.Tag.int_type.create(scope.arena(), .{
+                            .signed = is_signed,
+                            .bits = bit_count,
+                        }),
+                    }));
                 },
             };
             const result = try addZIRInstConst(mod, scope, src, .{
@@ -2062,11 +2062,9 @@ fn charLiteral(mod: *Module, scope: *Scope, node: *ast.Node.OneToken) !*zir.Inst
         },
     };
 
-    const int_payload = try scope.arena().create(Value.Payload.Int_u64);
-    int_payload.* = .{ .int = value };
     return addZIRInstConst(mod, scope, src, .{
         .ty = Type.initTag(.comptime_int),
-        .val = Value.initPayload(&int_payload.base),
+        .val = try Value.Tag.int_u64.create(scope.arena(), value),
     });
 }
 
@@ -2089,12 +2087,10 @@ fn integerLiteral(mod: *Module, scope: *Scope, int_lit: *ast.Node.OneToken) Inne
         prefixed_bytes[2..];
 
     if (std.fmt.parseInt(u64, bytes, base)) |small_int| {
-        const int_payload = try arena.create(Value.Payload.Int_u64);
-        int_payload.* = .{ .int = small_int };
         const src = tree.token_locs[int_lit.token].start;
         return addZIRInstConst(mod, scope, src, .{
             .ty = Type.initTag(.comptime_int),
-            .val = Value.initPayload(&int_payload.base),
+            .val = try Value.Tag.int_u64.create(arena, small_int),
         });
     } else |err| {
         return mod.failTok(scope, int_lit.token, "TODO implement int literals that don't fit in a u64", .{});
@@ -2109,15 +2105,13 @@ fn floatLiteral(mod: *Module, scope: *Scope, float_lit: *ast.Node.OneToken) Inne
         return mod.failTok(scope, float_lit.token, "TODO hex floats", .{});
     }
 
-    const val = std.fmt.parseFloat(f128, bytes) catch |e| switch (e) {
+    const float_number = std.fmt.parseFloat(f128, bytes) catch |e| switch (e) {
         error.InvalidCharacter => unreachable, // validated by tokenizer
     };
-    const float_payload = try arena.create(Value.Payload.Float_128);
-    float_payload.* = .{ .val = val };
     const src = tree.token_locs[float_lit.token].start;
     return addZIRInstConst(mod, scope, src, .{
         .ty = Type.initTag(.comptime_float),
-        .val = Value.initPayload(&float_payload.base),
+        .val = try Value.Tag.float_128.create(arena, float_number),
     });
 }
 

--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -2723,7 +2723,7 @@ fn rlWrap(mod: *Module, scope: *Scope, rl: ResultLoc, result: *zir.Inst) InnerEr
             return mod.fail(scope, result.src, "TODO implement rlWrap .bitcasted_ptr", .{});
         },
         .inferred_ptr => |alloc| {
-            return mod.fail(scope, result.src, "TODO implement rlWrap .inferred_ptr", .{});
+            return addZIRBinOp(mod, scope, result.src, .store, &alloc.base, result);
         },
         .block_ptr => |block_ptr| {
             return mod.fail(scope, result.src, "TODO implement rlWrap .block_ptr", .{});

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -3262,7 +3262,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                         if (typed_value.val.isNull())
                             return MCValue{ .immediate = 0 };
 
-                        var buf: Type.Payload.PointerSimple = undefined;
+                        var buf: Type.Payload.ElemType = undefined;
                         return self.genTypedValue(src, .{
                             .ty = typed_value.ty.optionalChild(&buf),
                             .val = typed_value.val,

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -137,7 +137,7 @@ pub fn generateSymbol(
         },
         .Array => {
             // TODO populate .debug_info for the array
-            if (typed_value.val.cast(Value.Payload.Bytes)) |payload| {
+            if (typed_value.val.castTag(.bytes)) |payload| {
                 if (typed_value.ty.sentinel()) |sentinel| {
                     try code.ensureCapacity(code.items.len + payload.data.len + 1);
                     code.appendSliceAssumeCapacity(payload.data);
@@ -168,8 +168,8 @@ pub fn generateSymbol(
         },
         .Pointer => {
             // TODO populate .debug_info for the pointer
-            if (typed_value.val.cast(Value.Payload.DeclRef)) |payload| {
-                const decl = payload.decl;
+            if (typed_value.val.castTag(.decl_ref)) |payload| {
+                const decl = payload.data;
                 if (decl.analysis != .complete) return error.AnalysisFail;
                 // TODO handle the dependency of this symbol on the decl's vaddr.
                 // If the decl changes vaddr, then this symbol needs to get regenerated.
@@ -432,7 +432,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                 @panic("Attempted to compile for architecture that was disabled by build configuration");
             }
 
-            const module_fn = typed_value.val.cast(Value.Payload.Function).?.func;
+            const module_fn = typed_value.val.castTag(.function).?.data;
 
             const fn_type = module_fn.owner_decl.typed_value.most_recent.typed_value.ty;
 
@@ -1579,9 +1579,9 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             }
                         }
 
-                        if (inst.func.cast(ir.Inst.Constant)) |func_inst| {
-                            if (func_inst.val.cast(Value.Payload.Function)) |func_val| {
-                                const func = func_val.func;
+                        if (inst.func.value()) |func_value| {
+                            if (func_value.castTag(.function)) |func_payload| {
+                                const func = func_payload.data;
 
                                 const ptr_bits = self.target.cpu.arch.ptrBitWidth();
                                 const ptr_bytes: u64 = @divExact(ptr_bits, 8);
@@ -1607,9 +1607,9 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                     .riscv64 => {
                         if (info.args.len > 0) return self.fail(inst.base.src, "TODO implement fn args for {}", .{self.target.cpu.arch});
 
-                        if (inst.func.cast(ir.Inst.Constant)) |func_inst| {
-                            if (func_inst.val.cast(Value.Payload.Function)) |func_val| {
-                                const func = func_val.func;
+                        if (inst.func.value()) |func_value| {
+                            if (func_value.castTag(.function)) |func_payload| {
+                                const func = func_payload.data;
 
                                 const ptr_bits = self.target.cpu.arch.ptrBitWidth();
                                 const ptr_bytes: u64 = @divExact(ptr_bits, 8);
@@ -1631,12 +1631,12 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                         }
                     },
                     .spu_2 => {
-                        if (inst.func.cast(ir.Inst.Constant)) |func_inst| {
+                        if (inst.func.value()) |func_value| {
                             if (info.args.len != 0) {
                                 return self.fail(inst.base.src, "TODO implement call with more than 0 parameters", .{});
                             }
-                            if (func_inst.val.cast(Value.Payload.Function)) |func_val| {
-                                const func = func_val.func;
+                            if (func_value.castTag(.function)) |func_payload| {
+                                const func = func_payload.data;
                                 const got_addr = if (self.bin_file.cast(link.File.Elf)) |elf_file| blk: {
                                     const got = &elf_file.program_headers.items[elf_file.phdr_got_index.?];
                                     break :blk @intCast(u16, got.p_vaddr + func.owner_decl.link.elf.offset_table_index * 2);
@@ -1705,9 +1705,9 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             }
                         }
 
-                        if (inst.func.cast(ir.Inst.Constant)) |func_inst| {
-                            if (func_inst.val.cast(Value.Payload.Function)) |func_val| {
-                                const func = func_val.func;
+                        if (inst.func.value()) |func_value| {
+                            if (func_value.castTag(.function)) |func_payload| {
+                                const func = func_payload.data;
                                 const ptr_bits = self.target.cpu.arch.ptrBitWidth();
                                 const ptr_bytes: u64 = @divExact(ptr_bits, 8);
                                 const got_addr = if (self.bin_file.cast(link.File.Elf)) |elf_file| blk: {
@@ -1766,9 +1766,9 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             }
                         }
 
-                        if (inst.func.cast(ir.Inst.Constant)) |func_inst| {
-                            if (func_inst.val.cast(Value.Payload.Function)) |func_val| {
-                                const func = func_val.func;
+                        if (inst.func.value()) |func_value| {
+                            if (func_value.castTag(.function)) |func_payload| {
+                                const func = func_payload.data;
                                 const ptr_bits = self.target.cpu.arch.ptrBitWidth();
                                 const ptr_bytes: u64 = @divExact(ptr_bits, 8);
                                 const got_addr = if (self.bin_file.cast(link.File.Elf)) |elf_file| blk: {
@@ -1825,9 +1825,9 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                     }
                 }
 
-                if (inst.func.cast(ir.Inst.Constant)) |func_inst| {
-                    if (func_inst.val.cast(Value.Payload.Function)) |func_val| {
-                        const func = func_val.func;
+                if (inst.func.value()) |func_value| {
+                    if (func_value.castTag(.function)) |func_payload| {
+                        const func = func_payload.data;
                         const text_segment = &macho_file.load_commands.items[macho_file.text_segment_cmd_index.?].Segment;
                         const got = &text_segment.sections.items[macho_file.got_section_index.?];
                         const got_addr = got.addr + func.owner_decl.link.macho.offset_table_index * @sizeOf(u64);
@@ -3223,20 +3223,20 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
             const ptr_bytes: u64 = @divExact(ptr_bits, 8);
             switch (typed_value.ty.zigTypeTag()) {
                 .Pointer => {
-                    if (typed_value.val.cast(Value.Payload.DeclRef)) |payload| {
+                    if (typed_value.val.castTag(.decl_ref)) |payload| {
                         if (self.bin_file.cast(link.File.Elf)) |elf_file| {
-                            const decl = payload.decl;
+                            const decl = payload.data;
                             const got = &elf_file.program_headers.items[elf_file.phdr_got_index.?];
                             const got_addr = got.p_vaddr + decl.link.elf.offset_table_index * ptr_bytes;
                             return MCValue{ .memory = got_addr };
                         } else if (self.bin_file.cast(link.File.MachO)) |macho_file| {
-                            const decl = payload.decl;
+                            const decl = payload.data;
                             const text_segment = &macho_file.load_commands.items[macho_file.text_segment_cmd_index.?].Segment;
                             const got = &text_segment.sections.items[macho_file.got_section_index.?];
                             const got_addr = got.addr + decl.link.macho.offset_table_index * ptr_bytes;
                             return MCValue{ .memory = got_addr };
                         } else if (self.bin_file.cast(link.File.Coff)) |coff_file| {
-                            const decl = payload.decl;
+                            const decl = payload.data;
                             const got_addr = coff_file.offset_table_virtual_address + decl.link.coff.offset_table_index * ptr_bytes;
                             return MCValue{ .memory = got_addr };
                         } else {

--- a/src/codegen/wasm.zig
+++ b/src/codegen/wasm.zig
@@ -62,7 +62,7 @@ pub fn genCode(buf: *ArrayList(u8), decl: *Decl) !void {
     // Write instructions
     // TODO: check for and handle death of instructions
     const tv = decl.typed_value.most_recent.typed_value;
-    const mod_fn = tv.val.cast(Value.Payload.Function).?.func;
+    const mod_fn = tv.val.castTag(.function).?.data;
     for (mod_fn.analysis.success.instructions) |inst| try genInst(buf, decl, inst);
 
     // Write 'end' opcode
@@ -125,8 +125,8 @@ fn genRet(buf: *ArrayList(u8), decl: *Decl, inst: *Inst.UnOp) !void {
 
 fn genCall(buf: *ArrayList(u8), decl: *Decl, inst: *Inst.Call) !void {
     const func_inst = inst.func.castTag(.constant).?;
-    const func_val = func_inst.val.cast(Value.Payload.Function).?;
-    const target = func_val.func.owner_decl;
+    const func = func_inst.val.castTag(.function).?.data;
+    const target = func.owner_decl;
     const target_ty = target.typed_value.most_recent.typed_value.ty;
 
     if (inst.args.len != 0) return error.TODOImplementMoreWasmCodegen;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2183,7 +2183,7 @@ pub fn updateDecl(self: *Elf, module: *Module, decl: *Module.Decl) !void {
             for (zir_dumps) |fn_name| {
                 if (mem.eql(u8, mem.spanZ(decl.name), fn_name)) {
                     std.debug.print("\n{}\n", .{decl.name});
-                    typed_value.val.cast(Value.Payload.Function).?.func.dump(module.*);
+                    typed_value.val.castTag(.function).?.data.dump(module.*);
                 }
             }
         }

--- a/src/llvm_backend.zig
+++ b/src/llvm_backend.zig
@@ -280,7 +280,7 @@ pub const LLVMIRModule = struct {
     fn gen(self: *LLVMIRModule, module: *Module, typed_value: TypedValue, src: usize) !void {
         switch (typed_value.ty.zigTypeTag()) {
             .Fn => {
-                const func = typed_value.val.cast(Value.Payload.Function).?.func;
+                const func = typed_value.val.castTag(.function).?.data;
 
                 const llvm_func = try self.resolveLLVMFunction(func);
 
@@ -314,9 +314,9 @@ pub const LLVMIRModule = struct {
     }
 
     fn genCall(self: *LLVMIRModule, inst: *Inst.Call) !void {
-        if (inst.func.cast(Inst.Constant)) |func_inst| {
-            if (func_inst.val.cast(Value.Payload.Function)) |func_val| {
-                const func = func_val.func;
+        if (inst.func.value()) |func_value| {
+            if (func_value.castTag(.function)) |func_payload| {
+                const func = func_payload.data;
                 const zig_fn_type = func.owner_decl.typed_value.most_recent.typed_value.ty;
                 const llvm_fn = try self.resolveLLVMFunction(func);
 

--- a/src/type.zig
+++ b/src/type.zig
@@ -112,18 +112,39 @@ pub const Type = extern union {
         }
     }
 
+    /// Prefer `castTag` to this.
     pub fn cast(self: Type, comptime T: type) ?*T {
+        if (@hasField(T, "base_tag")) {
+            return base.castTag(T.base_tag);
+        }
+        if (self.tag_if_small_enough < Tag.no_payload_count) {
+            return null;
+        }
+        inline for (@typeInfo(Tag).Enum.fields) |field| {
+            if (field.value < Tag.no_payload_count)
+                continue;
+            const t = @intToEnum(Tag, field.value);
+            if (self.ptr_otherwise.tag == t) {
+                if (T == t.Type()) {
+                    return @fieldParentPtr(T, "base", self.ptr_otherwise);
+                }
+                return null;
+            }
+        }
+        unreachable;
+    }
+
+    pub fn castTag(self: Type, comptime t: Tag) ?*t.Type() {
         if (self.tag_if_small_enough < Tag.no_payload_count)
             return null;
 
-        const expected_tag = std.meta.fieldInfo(T, "base").default_value.?.tag;
-        if (self.ptr_otherwise.tag != expected_tag)
-            return null;
+        if (self.ptr_otherwise.tag == t)
+            return @fieldParentPtr(t.Type(), "base", self.ptr_otherwise);
 
-        return @fieldParentPtr(T, "base", self.ptr_otherwise);
+        return null;
     }
 
-    pub fn castPointer(self: Type) ?*Payload.PointerSimple {
+    pub fn castPointer(self: Type) ?*Payload.ElemType {
         return switch (self.tag()) {
             .single_const_pointer,
             .single_mut_pointer,
@@ -135,7 +156,8 @@ pub const Type = extern union {
             .mut_slice,
             .optional_single_const_pointer,
             .optional_single_mut_pointer,
-            => @fieldParentPtr(Payload.PointerSimple, "base", self.ptr_otherwise),
+            => self.cast(Payload.ElemType),
+
             else => null,
         };
     }
@@ -165,7 +187,7 @@ pub const Type = extern union {
                 // Hot path for common case:
                 if (a.castPointer()) |a_payload| {
                     if (b.castPointer()) |b_payload| {
-                        return a.tag() == b.tag() and eql(a_payload.pointee_type, b_payload.pointee_type);
+                        return a.tag() == b.tag() and eql(a_payload.data, b_payload.data);
                     }
                 }
                 const is_slice_a = isSlice(a);
@@ -230,8 +252,8 @@ pub const Type = extern union {
                 return true;
             },
             .Optional => {
-                var buf_a: Payload.PointerSimple = undefined;
-                var buf_b: Payload.PointerSimple = undefined;
+                var buf_a: Payload.ElemType = undefined;
+                var buf_b: Payload.ElemType = undefined;
                 return a.optionalChild(&buf_a).eql(b.optionalChild(&buf_b));
             },
             .Float,
@@ -294,7 +316,7 @@ pub const Type = extern union {
                 }
             },
             .Optional => {
-                var buf: Payload.PointerSimple = undefined;
+                var buf: Payload.ElemType = undefined;
                 std.hash.autoHash(&hasher, self.optionalChild(&buf).hash());
             },
             .Float,
@@ -364,47 +386,10 @@ pub const Type = extern union {
             .@"anyframe",
             => unreachable,
 
-            .array_u8_sentinel_0 => return self.copyPayloadShallow(allocator, Payload.Array_u8_Sentinel0),
-            .array_u8 => return self.copyPayloadShallow(allocator, Payload.Array_u8),
-            .array => {
-                const payload = @fieldParentPtr(Payload.Array, "base", self.ptr_otherwise);
-                const new_payload = try allocator.create(Payload.Array);
-                new_payload.* = .{
-                    .base = payload.base,
-                    .len = payload.len,
-                    .elem_type = try payload.elem_type.copy(allocator),
-                };
-                return Type{ .ptr_otherwise = &new_payload.base };
-            },
-            .array_sentinel => {
-                const payload = @fieldParentPtr(Payload.ArraySentinel, "base", self.ptr_otherwise);
-                const new_payload = try allocator.create(Payload.ArraySentinel);
-                new_payload.* = .{
-                    .base = payload.base,
-                    .len = payload.len,
-                    .sentinel = try payload.sentinel.copy(allocator),
-                    .elem_type = try payload.elem_type.copy(allocator),
-                };
-                return Type{ .ptr_otherwise = &new_payload.base };
-            },
-            .int_signed => return self.copyPayloadShallow(allocator, Payload.IntSigned),
-            .int_unsigned => return self.copyPayloadShallow(allocator, Payload.IntUnsigned),
-            .function => {
-                const payload = @fieldParentPtr(Payload.Function, "base", self.ptr_otherwise);
-                const new_payload = try allocator.create(Payload.Function);
-                const param_types = try allocator.alloc(Type, payload.param_types.len);
-                for (payload.param_types) |param_type, i| {
-                    param_types[i] = try param_type.copy(allocator);
-                }
-                new_payload.* = .{
-                    .base = payload.base,
-                    .return_type = try payload.return_type.copy(allocator),
-                    .param_types = param_types,
-                    .cc = payload.cc,
-                };
-                return Type{ .ptr_otherwise = &new_payload.base };
-            },
-            .optional => return self.copyPayloadSingleField(allocator, Payload.Optional, "child_type"),
+            .array_u8,
+            .array_u8_sentinel_0,
+            => return self.copyPayloadShallow(allocator, Payload.Len),
+
             .single_const_pointer,
             .single_mut_pointer,
             .many_const_pointer,
@@ -413,19 +398,52 @@ pub const Type = extern union {
             .c_mut_pointer,
             .const_slice,
             .mut_slice,
+            .optional,
             .optional_single_mut_pointer,
             .optional_single_const_pointer,
-            => return self.copyPayloadSingleField(allocator, Payload.PointerSimple, "pointee_type"),
-            .anyframe_T => return self.copyPayloadSingleField(allocator, Payload.AnyFrame, "return_type"),
+            .anyframe_T,
+            => return self.copyPayloadShallow(allocator, Payload.ElemType),
 
+            .int_signed,
+            .int_unsigned,
+            => return self.copyPayloadShallow(allocator, Payload.Bits),
+
+            .array => {
+                const payload = self.castTag(.array).?.data;
+                return Tag.array.create(allocator, .{
+                    .len = payload.len,
+                    .elem_type = try payload.elem_type.copy(allocator),
+                });
+            },
+            .array_sentinel => {
+                const payload = self.castTag(.array_sentinel).?.data;
+                return Tag.array_sentinel.create(allocator, .{
+                    .len = payload.len,
+                    .sentinel = try payload.sentinel.copy(allocator),
+                    .elem_type = try payload.elem_type.copy(allocator),
+                });
+            },
+            .function => {
+                const payload = self.castTag(.function).?.data;
+                const param_types = try allocator.alloc(Type, payload.param_types.len);
+                for (payload.param_types) |param_type, i| {
+                    param_types[i] = try param_type.copy(allocator);
+                }
+                return Tag.function.create(allocator, .{
+                    .return_type = try payload.return_type.copy(allocator),
+                    .param_types = param_types,
+                    .cc = payload.cc,
+                });
+            },
             .pointer => {
-                const payload = @fieldParentPtr(Payload.Pointer, "base", self.ptr_otherwise);
-                const new_payload = try allocator.create(Payload.Pointer);
-                new_payload.* = .{
-                    .base = payload.base,
-
+                const payload = self.castTag(.pointer).?.data;
+                const sent: ?Value = if (payload.sentinel) |some|
+                    try some.copy(allocator)
+                else
+                    null;
+                return Tag.pointer.create(allocator, .{
                     .pointee_type = try payload.pointee_type.copy(allocator),
-                    .sentinel = if (payload.sentinel) |some| try some.copy(allocator) else null,
+                    .sentinel = sent,
                     .@"align" = payload.@"align",
                     .bit_offset = payload.bit_offset,
                     .host_size = payload.host_size,
@@ -433,38 +451,25 @@ pub const Type = extern union {
                     .mutable = payload.mutable,
                     .@"volatile" = payload.@"volatile",
                     .size = payload.size,
-                };
-                return Type{ .ptr_otherwise = &new_payload.base };
+                });
             },
             .error_union => {
-                const payload = @fieldParentPtr(Payload.ErrorUnion, "base", self.ptr_otherwise);
-                const new_payload = try allocator.create(Payload.ErrorUnion);
-                new_payload.* = .{
-                    .base = payload.base,
-
+                const payload = self.castTag(.error_union).?.data;
+                return Tag.error_union.create(allocator, .{
                     .error_set = try payload.error_set.copy(allocator),
                     .payload = try payload.payload.copy(allocator),
-                };
-                return Type{ .ptr_otherwise = &new_payload.base };
+                });
             },
-            .error_set => return self.copyPayloadShallow(allocator, Payload.ErrorSet),
-            .error_set_single => return self.copyPayloadShallow(allocator, Payload.ErrorSetSingle),
-            .empty_struct => return self.copyPayloadShallow(allocator, Payload.EmptyStruct),
+            .error_set => return self.copyPayloadShallow(allocator, Payload.Decl),
+            .error_set_single => return self.copyPayloadShallow(allocator, Payload.Name),
+            .empty_struct => return self.copyPayloadShallow(allocator, Payload.ContainerScope),
         }
     }
 
     fn copyPayloadShallow(self: Type, allocator: *Allocator, comptime T: type) error{OutOfMemory}!Type {
-        const payload = @fieldParentPtr(T, "base", self.ptr_otherwise);
+        const payload = self.cast(T).?;
         const new_payload = try allocator.create(T);
         new_payload.* = payload.*;
-        return Type{ .ptr_otherwise = &new_payload.base };
-    }
-
-    fn copyPayloadSingleField(self: Type, allocator: *Allocator, comptime T: type, comptime field_name: []const u8) error{OutOfMemory}!Type {
-        const payload = @fieldParentPtr(T, "base", self.ptr_otherwise);
-        const new_payload = try allocator.create(T);
-        new_payload.base = payload.base;
-        @field(new_payload, field_name) = try @field(payload, field_name).copy(allocator);
         return Type{ .ptr_otherwise = &new_payload.base };
     }
 
@@ -527,7 +532,7 @@ pub const Type = extern union {
                 .fn_ccc_void_no_args => return out_stream.writeAll("fn() callconv(.C) void"),
                 .single_const_pointer_to_comptime_int => return out_stream.writeAll("*const comptime_int"),
                 .function => {
-                    const payload = @fieldParentPtr(Payload.Function, "base", ty.ptr_otherwise);
+                    const payload = ty.castTag(.function).?.data;
                     try out_stream.writeAll("fn(");
                     for (payload.param_types) |param_type, i| {
                         if (i != 0) try out_stream.writeAll(", ");
@@ -539,108 +544,108 @@ pub const Type = extern union {
                 },
 
                 .anyframe_T => {
-                    const payload = @fieldParentPtr(Payload.AnyFrame, "base", ty.ptr_otherwise);
+                    const return_type = ty.castTag(.anyframe_T).?.data;
                     try out_stream.print("anyframe->", .{});
-                    ty = payload.return_type;
+                    ty = return_type;
                     continue;
                 },
                 .array_u8 => {
-                    const payload = @fieldParentPtr(Payload.Array_u8, "base", ty.ptr_otherwise);
-                    return out_stream.print("[{}]u8", .{payload.len});
+                    const len = ty.castTag(.array_u8).?.data;
+                    return out_stream.print("[{}]u8", .{len});
                 },
                 .array_u8_sentinel_0 => {
-                    const payload = @fieldParentPtr(Payload.Array_u8_Sentinel0, "base", ty.ptr_otherwise);
-                    return out_stream.print("[{}:0]u8", .{payload.len});
+                    const len = ty.castTag(.array_u8_sentinel_0).?.data;
+                    return out_stream.print("[{}:0]u8", .{len});
                 },
                 .array => {
-                    const payload = @fieldParentPtr(Payload.Array, "base", ty.ptr_otherwise);
+                    const payload = ty.castTag(.array).?.data;
                     try out_stream.print("[{}]", .{payload.len});
                     ty = payload.elem_type;
                     continue;
                 },
                 .array_sentinel => {
-                    const payload = @fieldParentPtr(Payload.ArraySentinel, "base", ty.ptr_otherwise);
+                    const payload = ty.castTag(.array_sentinel).?.data;
                     try out_stream.print("[{}:{}]", .{ payload.len, payload.sentinel });
                     ty = payload.elem_type;
                     continue;
                 },
                 .single_const_pointer => {
-                    const payload = @fieldParentPtr(Payload.PointerSimple, "base", ty.ptr_otherwise);
+                    const pointee_type = ty.castTag(.single_const_pointer).?.data;
                     try out_stream.writeAll("*const ");
-                    ty = payload.pointee_type;
+                    ty = pointee_type;
                     continue;
                 },
                 .single_mut_pointer => {
-                    const payload = @fieldParentPtr(Payload.PointerSimple, "base", ty.ptr_otherwise);
+                    const pointee_type = ty.castTag(.single_mut_pointer).?.data;
                     try out_stream.writeAll("*");
-                    ty = payload.pointee_type;
+                    ty = pointee_type;
                     continue;
                 },
                 .many_const_pointer => {
-                    const payload = @fieldParentPtr(Payload.PointerSimple, "base", ty.ptr_otherwise);
+                    const pointee_type = ty.castTag(.many_const_pointer).?.data;
                     try out_stream.writeAll("[*]const ");
-                    ty = payload.pointee_type;
+                    ty = pointee_type;
                     continue;
                 },
                 .many_mut_pointer => {
-                    const payload = @fieldParentPtr(Payload.PointerSimple, "base", ty.ptr_otherwise);
+                    const pointee_type = ty.castTag(.many_mut_pointer).?.data;
                     try out_stream.writeAll("[*]");
-                    ty = payload.pointee_type;
+                    ty = pointee_type;
                     continue;
                 },
                 .c_const_pointer => {
-                    const payload = @fieldParentPtr(Payload.PointerSimple, "base", ty.ptr_otherwise);
+                    const pointee_type = ty.castTag(.c_const_pointer).?.data;
                     try out_stream.writeAll("[*c]const ");
-                    ty = payload.pointee_type;
+                    ty = pointee_type;
                     continue;
                 },
                 .c_mut_pointer => {
-                    const payload = @fieldParentPtr(Payload.PointerSimple, "base", ty.ptr_otherwise);
+                    const pointee_type = ty.castTag(.c_mut_pointer).?.data;
                     try out_stream.writeAll("[*c]");
-                    ty = payload.pointee_type;
+                    ty = pointee_type;
                     continue;
                 },
                 .const_slice => {
-                    const payload = @fieldParentPtr(Payload.PointerSimple, "base", ty.ptr_otherwise);
+                    const pointee_type = ty.castTag(.const_slice).?.data;
                     try out_stream.writeAll("[]const ");
-                    ty = payload.pointee_type;
+                    ty = pointee_type;
                     continue;
                 },
                 .mut_slice => {
-                    const payload = @fieldParentPtr(Payload.PointerSimple, "base", ty.ptr_otherwise);
+                    const pointee_type = ty.castTag(.mut_slice).?.data;
                     try out_stream.writeAll("[]");
-                    ty = payload.pointee_type;
+                    ty = pointee_type;
                     continue;
                 },
                 .int_signed => {
-                    const payload = @fieldParentPtr(Payload.IntSigned, "base", ty.ptr_otherwise);
-                    return out_stream.print("i{}", .{payload.bits});
+                    const bits = ty.castTag(.int_signed).?.data;
+                    return out_stream.print("i{d}", .{bits});
                 },
                 .int_unsigned => {
-                    const payload = @fieldParentPtr(Payload.IntUnsigned, "base", ty.ptr_otherwise);
-                    return out_stream.print("u{}", .{payload.bits});
+                    const bits = ty.castTag(.int_unsigned).?.data;
+                    return out_stream.print("u{d}", .{bits});
                 },
                 .optional => {
-                    const payload = @fieldParentPtr(Payload.Optional, "base", ty.ptr_otherwise);
+                    const child_type = ty.castTag(.optional).?.data;
                     try out_stream.writeByte('?');
-                    ty = payload.child_type;
+                    ty = child_type;
                     continue;
                 },
                 .optional_single_const_pointer => {
-                    const payload = @fieldParentPtr(Payload.PointerSimple, "base", ty.ptr_otherwise);
+                    const pointee_type = ty.castTag(.optional_single_const_pointer).?.data;
                     try out_stream.writeAll("?*const ");
-                    ty = payload.pointee_type;
+                    ty = pointee_type;
                     continue;
                 },
                 .optional_single_mut_pointer => {
-                    const payload = @fieldParentPtr(Payload.PointerSimple, "base", ty.ptr_otherwise);
+                    const pointee_type = ty.castTag(.optional_single_mut_pointer).?.data;
                     try out_stream.writeAll("?*");
-                    ty = payload.pointee_type;
+                    ty = pointee_type;
                     continue;
                 },
 
                 .pointer => {
-                    const payload = @fieldParentPtr(Payload.Pointer, "base", ty.ptr_otherwise);
+                    const payload = ty.castTag(.pointer).?.data;
                     if (payload.sentinel) |some| switch (payload.size) {
                         .One, .C => unreachable,
                         .Many => try out_stream.print("[*:{}]", .{some}),
@@ -652,10 +657,10 @@ pub const Type = extern union {
                         .Slice => try out_stream.writeAll("[]"),
                     }
                     if (payload.@"align" != 0) {
-                        try out_stream.print("align({}", .{payload.@"align"});
+                        try out_stream.print("align({d}", .{payload.@"align"});
 
                         if (payload.bit_offset != 0) {
-                            try out_stream.print(":{}:{}", .{ payload.bit_offset, payload.host_size });
+                            try out_stream.print(":{d}:{d}", .{ payload.bit_offset, payload.host_size });
                         }
                         try out_stream.writeAll(") ");
                     }
@@ -667,19 +672,19 @@ pub const Type = extern union {
                     continue;
                 },
                 .error_union => {
-                    const payload = @fieldParentPtr(Payload.ErrorUnion, "base", ty.ptr_otherwise);
+                    const payload = ty.castTag(.error_union).?.data;
                     try payload.error_set.format("", .{}, out_stream);
                     try out_stream.writeAll("!");
                     ty = payload.payload;
                     continue;
                 },
                 .error_set => {
-                    const payload = @fieldParentPtr(Payload.ErrorSet, "base", ty.ptr_otherwise);
-                    return out_stream.writeAll(std.mem.spanZ(payload.decl.name));
+                    const decl = ty.castTag(.error_set).?.data;
+                    return out_stream.writeAll(std.mem.spanZ(decl.name));
                 },
                 .error_set_single => {
-                    const payload = @fieldParentPtr(Payload.ErrorSetSingle, "base", ty.ptr_otherwise);
-                    return out_stream.print("error{{{}}}", .{payload.name});
+                    const name = ty.castTag(.error_set_single).?.data;
+                    return out_stream.print("error{{{s}}}", .{name});
                 },
             }
             unreachable;
@@ -784,11 +789,10 @@ pub const Type = extern union {
             .array => self.elemType().hasCodeGenBits() and self.arrayLen() != 0,
             .array_u8 => self.arrayLen() != 0,
             .array_sentinel, .single_const_pointer, .single_mut_pointer, .many_const_pointer, .many_mut_pointer, .c_const_pointer, .c_mut_pointer, .const_slice, .mut_slice, .pointer => self.elemType().hasCodeGenBits(),
-            .int_signed => self.cast(Payload.IntSigned).?.bits != 0,
-            .int_unsigned => self.cast(Payload.IntUnsigned).?.bits != 0,
+            .int_signed, .int_unsigned => self.cast(Payload.Bits).?.data != 0,
 
             .error_union => {
-                const payload = self.cast(Payload.ErrorUnion).?;
+                const payload = self.castTag(.error_union).?.data;
                 return payload.error_set.hasCodeGenBits() or payload.payload.hasCodeGenBits();
             },
 
@@ -855,7 +859,7 @@ pub const Type = extern union {
             => return @divExact(target.cpu.arch.ptrBitWidth(), 8),
 
             .pointer => {
-                const payload = @fieldParentPtr(Payload.Pointer, "base", self.ptr_otherwise);
+                const payload = self.castTag(.pointer).?.data;
 
                 if (payload.@"align" != 0) return payload.@"align";
                 return @divExact(target.cpu.arch.ptrBitWidth(), 8);
@@ -885,18 +889,12 @@ pub const Type = extern union {
             .array, .array_sentinel => return self.elemType().abiAlignment(target),
 
             .int_signed, .int_unsigned => {
-                const bits: u16 = if (self.cast(Payload.IntSigned)) |pl|
-                    pl.bits
-                else if (self.cast(Payload.IntUnsigned)) |pl|
-                    pl.bits
-                else
-                    unreachable;
-
+                const bits: u16 = self.cast(Payload.Bits).?.data;
                 return std.math.ceilPowerOfTwoPromote(u16, (bits + 7) / 8);
             },
 
             .optional => {
-                var buf: Payload.PointerSimple = undefined;
+                var buf: Payload.ElemType = undefined;
                 const child_type = self.optionalChild(&buf);
                 if (!child_type.hasCodeGenBits()) return 1;
 
@@ -907,7 +905,7 @@ pub const Type = extern union {
             },
 
             .error_union => {
-                const payload = self.cast(Payload.ErrorUnion).?;
+                const payload = self.castTag(.error_union).?.data;
                 if (!payload.error_set.hasCodeGenBits()) {
                     return payload.payload.abiAlignment(target);
                 } else if (!payload.payload.hasCodeGenBits()) {
@@ -955,16 +953,19 @@ pub const Type = extern union {
             .bool,
             => return 1,
 
-            .array_u8 => @fieldParentPtr(Payload.Array_u8_Sentinel0, "base", self.ptr_otherwise).len,
-            .array_u8_sentinel_0 => @fieldParentPtr(Payload.Array_u8_Sentinel0, "base", self.ptr_otherwise).len + 1,
+            .array_u8 => self.castTag(.array_u8).?.data,
+            .array_u8_sentinel_0 => self.castTag(.array_u8_sentinel_0).?.data + 1,
             .array => {
-                const payload = @fieldParentPtr(Payload.Array, "base", self.ptr_otherwise);
+                const payload = self.castTag(.array).?.data;
                 const elem_size = std.math.max(payload.elem_type.abiAlignment(target), payload.elem_type.abiSize(target));
                 return payload.len * elem_size;
             },
             .array_sentinel => {
-                const payload = @fieldParentPtr(Payload.ArraySentinel, "base", self.ptr_otherwise);
-                const elem_size = std.math.max(payload.elem_type.abiAlignment(target), payload.elem_type.abiSize(target));
+                const payload = self.castTag(.array_sentinel).?.data;
+                const elem_size = std.math.max(
+                    payload.elem_type.abiAlignment(target),
+                    payload.elem_type.abiSize(target),
+                );
                 return (payload.len + 1) * elem_size;
             },
             .i16, .u16 => return 2,
@@ -1022,18 +1023,12 @@ pub const Type = extern union {
             => return 2, // TODO revisit this when we have the concept of the error tag type
 
             .int_signed, .int_unsigned => {
-                const bits: u16 = if (self.cast(Payload.IntSigned)) |pl|
-                    pl.bits
-                else if (self.cast(Payload.IntUnsigned)) |pl|
-                    pl.bits
-                else
-                    unreachable;
-
+                const bits: u16 = self.cast(Payload.Bits).?.data;
                 return std.math.ceilPowerOfTwoPromote(u16, (bits + 7) / 8);
             },
 
             .optional => {
-                var buf: Payload.PointerSimple = undefined;
+                var buf: Payload.ElemType = undefined;
                 const child_type = self.optionalChild(&buf);
                 if (!child_type.hasCodeGenBits()) return 1;
 
@@ -1048,7 +1043,7 @@ pub const Type = extern union {
             },
 
             .error_union => {
-                const payload = self.cast(Payload.ErrorUnion).?;
+                const payload = self.castTag(.error_union).?.data;
                 if (!payload.error_set.hasCodeGenBits() and !payload.payload.hasCodeGenBits()) {
                     return 0;
                 } else if (!payload.error_set.hasCodeGenBits()) {
@@ -1132,7 +1127,7 @@ pub const Type = extern union {
             .single_const_pointer_to_comptime_int,
             => true,
 
-            .pointer => self.cast(Payload.Pointer).?.size == .One,
+            .pointer => self.castTag(.pointer).?.data.size == .One,
         };
     }
 
@@ -1214,7 +1209,7 @@ pub const Type = extern union {
             .single_const_pointer_to_comptime_int,
             => .One,
 
-            .pointer => self.cast(Payload.Pointer).?.size,
+            .pointer => self.castTag(.pointer).?.data.size,
         };
     }
 
@@ -1289,7 +1284,7 @@ pub const Type = extern union {
             .const_slice_u8,
             => true,
 
-            .pointer => self.cast(Payload.Pointer).?.size == .Slice,
+            .pointer => self.castTag(.pointer).?.data.size == .Slice,
         };
     }
 
@@ -1364,7 +1359,7 @@ pub const Type = extern union {
             .const_slice,
             => true,
 
-            .pointer => !self.cast(Payload.Pointer).?.mutable,
+            .pointer => !self.castTag(.pointer).?.data.mutable,
         };
     }
 
@@ -1438,7 +1433,7 @@ pub const Type = extern union {
             => false,
 
             .pointer => {
-                const payload = @fieldParentPtr(Payload.Pointer, "base", self.ptr_otherwise);
+                const payload = self.castTag(.pointer).?.data;
                 return payload.@"volatile";
             },
         };
@@ -1514,7 +1509,7 @@ pub const Type = extern union {
             => false,
 
             .pointer => {
-                const payload = @fieldParentPtr(Payload.Pointer, "base", self.ptr_otherwise);
+                const payload = self.castTag(.pointer).?.data;
                 return payload.@"allowzero";
             },
         };
@@ -1525,7 +1520,7 @@ pub const Type = extern union {
         switch (self.tag()) {
             .optional_single_const_pointer, .optional_single_mut_pointer => return true,
             .optional => {
-                var buf: Payload.PointerSimple = undefined;
+                var buf: Payload.ElemType = undefined;
                 const child_type = self.optionalChild(&buf);
                 // optionals of zero sized pointers behave like bools
                 if (!child_type.hasCodeGenBits()) return false;
@@ -1563,7 +1558,7 @@ pub const Type = extern union {
             => return false,
 
             .Optional => {
-                var buf: Payload.PointerSimple = undefined;
+                var buf: Payload.ElemType = undefined;
                 return ty.optionalChild(&buf).isValidVarType(is_extern);
             },
             .Pointer, .Array => ty = ty.elemType(),
@@ -1631,8 +1626,8 @@ pub const Type = extern union {
             .empty_struct,
             => unreachable,
 
-            .array => self.cast(Payload.Array).?.elem_type,
-            .array_sentinel => self.cast(Payload.ArraySentinel).?.elem_type,
+            .array => self.castTag(.array).?.data.elem_type,
+            .array_sentinel => self.castTag(.array_sentinel).?.data.elem_type,
             .single_const_pointer,
             .single_mut_pointer,
             .many_const_pointer,
@@ -1641,28 +1636,29 @@ pub const Type = extern union {
             .c_mut_pointer,
             .const_slice,
             .mut_slice,
-            => self.castPointer().?.pointee_type,
+            => self.castPointer().?.data,
             .array_u8, .array_u8_sentinel_0, .const_slice_u8 => Type.initTag(.u8),
             .single_const_pointer_to_comptime_int => Type.initTag(.comptime_int),
-            .pointer => self.cast(Payload.Pointer).?.pointee_type,
+            .pointer => self.castTag(.pointer).?.data.pointee_type,
         };
     }
 
     /// Asserts that the type is an optional.
-    pub fn optionalChild(self: Type, buf: *Payload.PointerSimple) Type {
+    /// Resulting `Type` will have inner memory referencing `buf`.
+    pub fn optionalChild(self: Type, buf: *Payload.ElemType) Type {
         return switch (self.tag()) {
-            .optional => self.cast(Payload.Optional).?.child_type,
+            .optional => self.castTag(.optional).?.data,
             .optional_single_mut_pointer => {
                 buf.* = .{
                     .base = .{ .tag = .single_mut_pointer },
-                    .pointee_type = self.castPointer().?.pointee_type,
+                    .data = self.castPointer().?.data,
                 };
                 return Type.initPayload(&buf.base);
             },
             .optional_single_const_pointer => {
                 buf.* = .{
                     .base = .{ .tag = .single_const_pointer },
-                    .pointee_type = self.castPointer().?.pointee_type,
+                    .data = self.castPointer().?.data,
                 };
                 return Type.initPayload(&buf.base);
             },
@@ -1673,23 +1669,16 @@ pub const Type = extern union {
     /// Asserts that the type is an optional.
     /// Same as `optionalChild` but allocates the buffer if needed.
     pub fn optionalChildAlloc(self: Type, allocator: *Allocator) !Type {
-        return switch (self.tag()) {
-            .optional => self.cast(Payload.Optional).?.child_type,
-            .optional_single_mut_pointer, .optional_single_const_pointer => {
-                const payload = try allocator.create(Payload.PointerSimple);
-                payload.* = .{
-                    .base = .{
-                        .tag = if (self.tag() == .optional_single_const_pointer)
-                            .single_const_pointer
-                        else
-                            .single_mut_pointer,
-                    },
-                    .pointee_type = self.castPointer().?.pointee_type,
-                };
-                return Type.initPayload(&payload.base);
+        switch (self.tag()) {
+            .optional => return self.castTag(.optional).?.data,
+            .optional_single_mut_pointer => {
+                return Tag.single_mut_pointer.create(allocator, self.castPointer().?.data);
+            },
+            .optional_single_const_pointer => {
+                return Tag.single_const_pointer.create(allocator, self.castPointer().?.data);
             },
             else => unreachable,
-        };
+        }
     }
 
     /// Asserts the type is an array or vector.
@@ -1759,10 +1748,10 @@ pub const Type = extern union {
             .empty_struct,
             => unreachable,
 
-            .array => self.cast(Payload.Array).?.len,
-            .array_sentinel => self.cast(Payload.ArraySentinel).?.len,
-            .array_u8 => self.cast(Payload.Array_u8).?.len,
-            .array_u8_sentinel_0 => self.cast(Payload.Array_u8_Sentinel0).?.len,
+            .array => self.castTag(.array).?.data.len,
+            .array_sentinel => self.castTag(.array_sentinel).?.data.len,
+            .array_u8 => self.castTag(.array_u8).?.data,
+            .array_u8_sentinel_0 => self.castTag(.array_u8_sentinel_0).?.data,
         };
     }
 
@@ -1836,8 +1825,8 @@ pub const Type = extern union {
             .array_u8,
             => return null,
 
-            .pointer => return self.cast(Payload.Pointer).?.sentinel,
-            .array_sentinel => return self.cast(Payload.ArraySentinel).?.sentinel,
+            .pointer => return self.castTag(.pointer).?.data.sentinel,
+            .array_sentinel => return self.castTag(.array_sentinel).?.data.sentinel,
             .array_u8_sentinel_0 => return Value.initTag(.zero),
         };
     }
@@ -2048,8 +2037,14 @@ pub const Type = extern union {
             .empty_struct,
             => unreachable,
 
-            .int_unsigned => .{ .signedness = .unsigned, .bits = self.cast(Payload.IntUnsigned).?.bits },
-            .int_signed => .{ .signedness = .signed, .bits = self.cast(Payload.IntSigned).?.bits },
+            .int_unsigned => .{
+                .signedness = .unsigned,
+                .bits = self.castTag(.int_unsigned).?.data,
+            },
+            .int_signed => .{
+                .signedness = .signed,
+                .bits = self.castTag(.int_signed).?.data,
+            },
             .u8 => .{ .signedness = .unsigned, .bits = 8 },
             .i8 => .{ .signedness = .signed, .bits = 8 },
             .u16 => .{ .signedness = .unsigned, .bits = 16 },
@@ -2178,7 +2173,7 @@ pub const Type = extern union {
             .fn_void_no_args => 0,
             .fn_naked_noreturn_no_args => 0,
             .fn_ccc_void_no_args => 0,
-            .function => @fieldParentPtr(Payload.Function, "base", self.ptr_otherwise).param_types.len,
+            .function => self.castTag(.function).?.data.param_types.len,
 
             .f16,
             .f32,
@@ -2254,7 +2249,7 @@ pub const Type = extern union {
             .fn_naked_noreturn_no_args => return,
             .fn_ccc_void_no_args => return,
             .function => {
-                const payload = @fieldParentPtr(Payload.Function, "base", self.ptr_otherwise);
+                const payload = self.castTag(.function).?.data;
                 std.mem.copy(Type, types, payload.param_types);
             },
 
@@ -2327,7 +2322,7 @@ pub const Type = extern union {
     pub fn fnParamType(self: Type, index: usize) Type {
         switch (self.tag()) {
             .function => {
-                const payload = @fieldParentPtr(Payload.Function, "base", self.ptr_otherwise);
+                const payload = self.castTag(.function).?.data;
                 return payload.param_types[index];
             },
 
@@ -2410,7 +2405,7 @@ pub const Type = extern union {
             .fn_ccc_void_no_args,
             => Type.initTag(.void),
 
-            .function => @fieldParentPtr(Payload.Function, "base", self.ptr_otherwise).return_type,
+            .function => self.castTag(.function).?.data.return_type,
 
             .f16,
             .f32,
@@ -2484,7 +2479,7 @@ pub const Type = extern union {
             .fn_void_no_args => .Unspecified,
             .fn_naked_noreturn_no_args => .Naked,
             .fn_ccc_void_no_args => .C,
-            .function => @fieldParentPtr(Payload.Function, "base", self.ptr_otherwise).cc,
+            .function => self.castTag(.function).?.data.cc,
 
             .f16,
             .f32,
@@ -2760,15 +2755,8 @@ pub const Type = extern union {
             .@"null" => return Value.initTag(.null_value),
             .@"undefined" => return Value.initTag(.undef),
 
-            .int_unsigned => {
-                if (ty.cast(Payload.IntUnsigned).?.bits == 0) {
-                    return Value.initTag(.zero);
-                } else {
-                    return null;
-                }
-            },
-            .int_signed => {
-                if (ty.cast(Payload.IntSigned).?.bits == 0) {
+            .int_unsigned, .int_signed => {
+                if (ty.cast(Payload.Bits).?.data == 0) {
                     return Value.initTag(.zero);
                 } else {
                     return null;
@@ -2787,12 +2775,11 @@ pub const Type = extern union {
             .single_const_pointer,
             .single_mut_pointer,
             => {
-                const ptr = ty.castPointer().?;
-                ty = ptr.pointee_type;
+                ty = ty.castPointer().?.data;
                 continue;
             },
             .pointer => {
-                ty = ty.cast(Payload.Pointer).?.pointee_type;
+                ty = ty.castTag(.pointer).?.data.pointee_type;
                 continue;
             },
         };
@@ -2869,7 +2856,7 @@ pub const Type = extern union {
             .c_mut_pointer,
             => return true,
 
-            .pointer => self.cast(Payload.Pointer).?.size == .C,
+            .pointer => self.castTag(.pointer).?.data.size == .C,
         };
     }
 
@@ -2950,7 +2937,7 @@ pub const Type = extern union {
             .pointer,
             => unreachable,
 
-            .empty_struct => self.cast(Type.Payload.EmptyStruct).?.scope,
+            .empty_struct => self.castTag(.empty_struct).?.data,
         };
     }
 
@@ -3105,117 +3092,195 @@ pub const Type = extern union {
 
         pub const last_no_payload_tag = Tag.const_slice_u8;
         pub const no_payload_count = @enumToInt(last_no_payload_tag) + 1;
+
+        pub fn Type(comptime t: Tag) type {
+            return switch (t) {
+                .u8,
+                .i8,
+                .u16,
+                .i16,
+                .u32,
+                .i32,
+                .u64,
+                .i64,
+                .usize,
+                .isize,
+                .c_short,
+                .c_ushort,
+                .c_int,
+                .c_uint,
+                .c_long,
+                .c_ulong,
+                .c_longlong,
+                .c_ulonglong,
+                .c_longdouble,
+                .f16,
+                .f32,
+                .f64,
+                .f128,
+                .c_void,
+                .bool,
+                .void,
+                .type,
+                .anyerror,
+                .comptime_int,
+                .comptime_float,
+                .noreturn,
+                .enum_literal,
+                .@"null",
+                .@"undefined",
+                .fn_noreturn_no_args,
+                .fn_void_no_args,
+                .fn_naked_noreturn_no_args,
+                .fn_ccc_void_no_args,
+                .single_const_pointer_to_comptime_int,
+                .anyerror_void_error_union,
+                .@"anyframe",
+                .const_slice_u8,
+                => @compileError("Type Tag " ++ @tagName(t) ++ " has no payload"),
+
+                .array_u8,
+                .array_u8_sentinel_0,
+                => Payload.Len,
+
+                .single_const_pointer,
+                .single_mut_pointer,
+                .many_const_pointer,
+                .many_mut_pointer,
+                .c_const_pointer,
+                .c_mut_pointer,
+                .const_slice,
+                .mut_slice,
+                .optional,
+                .optional_single_mut_pointer,
+                .optional_single_const_pointer,
+                .anyframe_T,
+                => Payload.ElemType,
+
+                .int_signed,
+                .int_unsigned,
+                => Payload.Bits,
+
+                .array => Payload.Array,
+                .array_sentinel => Payload.ArraySentinel,
+                .pointer => Payload.Pointer,
+                .function => Payload.Function,
+                .error_union => Payload.ErrorUnion,
+                .error_set => Payload.Decl,
+                .error_set_single => Payload.Name,
+                .empty_struct => Payload.ContainerScope,
+            };
+        }
+
+        pub fn create(comptime t: Tag, ally: *Allocator, data: Data(t)) error{OutOfMemory}!Type {
+            const ptr = try ally.create(t.Type());
+            ptr.* = .{
+                .base = .{ .tag = t },
+                .data = data,
+            };
+            return Type{ .ptr_otherwise = &ptr.base };
+        }
+
+        pub fn Data(comptime t: Tag) type {
+            return std.meta.fieldInfo(t.Type(), "data").field_type;
+        }
     };
 
+    /// The sub-types are named after what fields they contain.
     pub const Payload = struct {
         tag: Tag,
 
-        pub const Array_u8_Sentinel0 = struct {
-            base: Payload = Payload{ .tag = .array_u8_sentinel_0 },
-
-            len: u64,
-        };
-
-        pub const Array_u8 = struct {
-            base: Payload = Payload{ .tag = .array_u8 },
-
-            len: u64,
+        pub const Len = struct {
+            base: Payload,
+            data: u64,
         };
 
         pub const Array = struct {
-            base: Payload = Payload{ .tag = .array },
+            pub const base_tag = Tag.array;
 
-            len: u64,
-            elem_type: Type,
+            base: Payload = Payload{ .tag = base_tag },
+            data: struct {
+                len: u64,
+                elem_type: Type,
+            },
         };
 
         pub const ArraySentinel = struct {
-            base: Payload = Payload{ .tag = .array_sentinel },
+            pub const base_tag = Tag.array_sentinel;
 
-            len: u64,
-            sentinel: Value,
-            elem_type: Type,
+            base: Payload = Payload{ .tag = base_tag },
+            data: struct {
+                len: u64,
+                sentinel: Value,
+                elem_type: Type,
+            },
         };
 
-        pub const PointerSimple = struct {
+        pub const ElemType = struct {
             base: Payload,
-
-            pointee_type: Type,
+            data: Type,
         };
 
-        pub const IntSigned = struct {
-            base: Payload = Payload{ .tag = .int_signed },
-
-            bits: u16,
-        };
-
-        pub const IntUnsigned = struct {
-            base: Payload = Payload{ .tag = .int_unsigned },
-
-            bits: u16,
+        pub const Bits = struct {
+            base: Payload,
+            data: u16,
         };
 
         pub const Function = struct {
-            base: Payload = Payload{ .tag = .function },
+            pub const base_tag = Tag.function;
 
-            param_types: []Type,
-            return_type: Type,
-            cc: std.builtin.CallingConvention,
-        };
-
-        pub const Optional = struct {
-            base: Payload = Payload{ .tag = .optional },
-
-            child_type: Type,
+            base: Payload = Payload{ .tag = base_tag },
+            data: struct {
+                param_types: []Type,
+                return_type: Type,
+                cc: std.builtin.CallingConvention,
+            },
         };
 
         pub const Pointer = struct {
-            base: Payload = .{ .tag = .pointer },
+            pub const base_tag = Tag.pointer;
 
-            pointee_type: Type,
-            sentinel: ?Value,
-            /// If zero use pointee_type.AbiAlign()
-            @"align": u32,
-            bit_offset: u16,
-            host_size: u16,
-            @"allowzero": bool,
-            mutable: bool,
-            @"volatile": bool,
-            size: std.builtin.TypeInfo.Pointer.Size,
+            base: Payload = Payload{ .tag = base_tag },
+            data: struct {
+                pointee_type: Type,
+                sentinel: ?Value,
+                /// If zero use pointee_type.AbiAlign()
+                @"align": u32,
+                bit_offset: u16,
+                host_size: u16,
+                @"allowzero": bool,
+                mutable: bool,
+                @"volatile": bool,
+                size: std.builtin.TypeInfo.Pointer.Size,
+            },
         };
 
         pub const ErrorUnion = struct {
-            base: Payload = .{ .tag = .error_union },
+            pub const base_tag = Tag.error_union;
 
-            error_set: Type,
-            payload: Type,
+            base: Payload = Payload{ .tag = base_tag },
+            data: struct {
+                error_set: Type,
+                payload: Type,
+            },
         };
 
-        pub const AnyFrame = struct {
-            base: Payload = .{ .tag = .anyframe_T },
-
-            return_type: Type,
+        pub const Decl = struct {
+            base: Payload,
+            data: *Module.Decl,
         };
 
-        pub const ErrorSet = struct {
-            base: Payload = .{ .tag = .error_set },
-
-            decl: *Module.Decl,
-        };
-
-        pub const ErrorSetSingle = struct {
-            base: Payload = .{ .tag = .error_set_single },
-
+        pub const Name = struct {
+            base: Payload,
             /// memory is owned by `Module`
-            name: []const u8,
+            data: []const u8,
         };
 
         /// Mostly used for namespace like structs with zero fields.
         /// Most commonly used for files.
-        pub const EmptyStruct = struct {
-            base: Payload = .{ .tag = .empty_struct },
-
-            scope: *Module.Scope.Container,
+        pub const ContainerScope = struct {
+            base: Payload,
+            data: *Module.Scope.Container,
         };
     };
 };

--- a/src/value.zig
+++ b/src/value.zig
@@ -84,11 +84,16 @@ pub const Value = extern union {
         function,
         extern_fn,
         variable,
+        /// Represents a pointer to another immutable value.
         ref_val,
+        /// Represents a pointer to a decl, not the value of the decl.
         decl_ref,
         elem_ptr,
+        /// A slice of u8 whose memory is managed externally.
         bytes,
-        repeated, // the value is a value repeated some number of times
+        /// This value is repeated some number of times. The amount of times to repeat
+        /// is stored externally.
+        repeated,
         float_16,
         float_32,
         float_64,
@@ -99,6 +104,106 @@ pub const Value = extern union {
 
         pub const last_no_payload_tag = Tag.bool_false;
         pub const no_payload_count = @enumToInt(last_no_payload_tag) + 1;
+
+        pub fn Type(comptime t: Tag) type {
+            return switch (t) {
+                .u8_type,
+                .i8_type,
+                .u16_type,
+                .i16_type,
+                .u32_type,
+                .i32_type,
+                .u64_type,
+                .i64_type,
+                .usize_type,
+                .isize_type,
+                .c_short_type,
+                .c_ushort_type,
+                .c_int_type,
+                .c_uint_type,
+                .c_long_type,
+                .c_ulong_type,
+                .c_longlong_type,
+                .c_ulonglong_type,
+                .c_longdouble_type,
+                .f16_type,
+                .f32_type,
+                .f64_type,
+                .f128_type,
+                .c_void_type,
+                .bool_type,
+                .void_type,
+                .type_type,
+                .anyerror_type,
+                .comptime_int_type,
+                .comptime_float_type,
+                .noreturn_type,
+                .null_type,
+                .undefined_type,
+                .fn_noreturn_no_args_type,
+                .fn_void_no_args_type,
+                .fn_naked_noreturn_no_args_type,
+                .fn_ccc_void_no_args_type,
+                .single_const_pointer_to_comptime_int_type,
+                .const_slice_u8_type,
+                .enum_literal_type,
+                .anyframe_type,
+                .undef,
+                .zero,
+                .one,
+                .void_value,
+                .unreachable_value,
+                .empty_struct_value,
+                .empty_array,
+                .null_value,
+                .bool_true,
+                .bool_false,
+                => @compileError("Value Tag " ++ @tagName(t) ++ " has no payload"),
+
+                .int_big_positive,
+                .int_big_negative,
+                => Payload.BigInt,
+
+                .extern_fn,
+                .decl_ref,
+                => Payload.Decl,
+
+                .ref_val,
+                .repeated,
+                => Payload.SubValue,
+
+                .bytes,
+                .enum_literal,
+                => Payload.Bytes,
+
+                .ty => Payload.Ty,
+                .int_type => Payload.IntType,
+                .int_u64 => Payload.U64,
+                .int_i64 => Payload.I64,
+                .function => Payload.Function,
+                .variable => Payload.Variable,
+                .elem_ptr => Payload.ElemPtr,
+                .float_16 => Payload.Float_16,
+                .float_32 => Payload.Float_32,
+                .float_64 => Payload.Float_64,
+                .float_128 => Payload.Float_128,
+                .error_set => Payload.ErrorSet,
+                .@"error" => Payload.Error,
+            };
+        }
+
+        pub fn create(comptime t: Tag, ally: *Allocator, data: Data(t)) error{OutOfMemory}!Value {
+            const ptr = try ally.create(t.Type());
+            ptr.* = .{
+                .base = .{ .tag = t },
+                .data = data,
+            };
+            return Value{ .ptr_otherwise = &ptr.base };
+        }
+
+        pub fn Data(comptime t: Tag) type {
+            return std.meta.fieldInfo(t.Type(), "data").field_type;
+        }
     };
 
     pub fn initTag(small_tag: Tag) Value {
@@ -119,15 +224,36 @@ pub const Value = extern union {
         }
     }
 
+    /// Prefer `castTag` to this.
     pub fn cast(self: Value, comptime T: type) ?*T {
+        if (@hasField(T, "base_tag")) {
+            return base.castTag(T.base_tag);
+        }
+        if (self.tag_if_small_enough < Tag.no_payload_count) {
+            return null;
+        }
+        inline for (@typeInfo(Tag).Enum.fields) |field| {
+            if (field.value < Tag.no_payload_count)
+                continue;
+            const t = @intToEnum(Tag, field.value);
+            if (self.ptr_otherwise.tag == t) {
+                if (T == t.Type()) {
+                    return @fieldParentPtr(T, "base", self.ptr_otherwise);
+                }
+                return null;
+            }
+        }
+        unreachable;
+    }
+
+    pub fn castTag(self: Value, comptime t: Tag) ?*t.Type() {
         if (self.tag_if_small_enough < Tag.no_payload_count)
             return null;
 
-        const expected_tag = std.meta.fieldInfo(T, "base").default_value.?.tag;
-        if (self.ptr_otherwise.tag != expected_tag)
-            return null;
+        if (self.ptr_otherwise.tag == t)
+            return @fieldParentPtr(t.Type(), "base", self.ptr_otherwise);
 
-        return @fieldParentPtr(T, "base", self.ptr_otherwise);
+        return null;
     }
 
     pub fn copy(self: Value, allocator: *Allocator) error{OutOfMemory}!Value {
@@ -188,17 +314,17 @@ pub const Value = extern union {
             => unreachable,
 
             .ty => {
-                const payload = @fieldParentPtr(Payload.Ty, "base", self.ptr_otherwise);
+                const payload = self.castTag(.ty).?;
                 const new_payload = try allocator.create(Payload.Ty);
                 new_payload.* = .{
                     .base = payload.base,
-                    .ty = try payload.ty.copy(allocator),
+                    .data = try payload.data.copy(allocator),
                 };
                 return Value{ .ptr_otherwise = &new_payload.base };
             },
             .int_type => return self.copyPayloadShallow(allocator, Payload.IntType),
-            .int_u64 => return self.copyPayloadShallow(allocator, Payload.Int_u64),
-            .int_i64 => return self.copyPayloadShallow(allocator, Payload.Int_i64),
+            .int_u64 => return self.copyPayloadShallow(allocator, Payload.U64),
+            .int_i64 => return self.copyPayloadShallow(allocator, Payload.I64),
             .int_big_positive => {
                 @panic("TODO implement copying of big ints");
             },
@@ -206,35 +332,37 @@ pub const Value = extern union {
                 @panic("TODO implement copying of big ints");
             },
             .function => return self.copyPayloadShallow(allocator, Payload.Function),
-            .extern_fn => return self.copyPayloadShallow(allocator, Payload.ExternFn),
+            .extern_fn => return self.copyPayloadShallow(allocator, Payload.Decl),
             .variable => return self.copyPayloadShallow(allocator, Payload.Variable),
             .ref_val => {
-                const payload = @fieldParentPtr(Payload.RefVal, "base", self.ptr_otherwise);
-                const new_payload = try allocator.create(Payload.RefVal);
+                const payload = self.castTag(.ref_val).?;
+                const new_payload = try allocator.create(Payload.SubValue);
                 new_payload.* = .{
                     .base = payload.base,
-                    .val = try payload.val.copy(allocator),
+                    .data = try payload.data.copy(allocator),
                 };
                 return Value{ .ptr_otherwise = &new_payload.base };
             },
-            .decl_ref => return self.copyPayloadShallow(allocator, Payload.DeclRef),
+            .decl_ref => return self.copyPayloadShallow(allocator, Payload.Decl),
             .elem_ptr => {
-                const payload = @fieldParentPtr(Payload.ElemPtr, "base", self.ptr_otherwise);
+                const payload = self.castTag(.elem_ptr).?;
                 const new_payload = try allocator.create(Payload.ElemPtr);
                 new_payload.* = .{
                     .base = payload.base,
-                    .array_ptr = try payload.array_ptr.copy(allocator),
-                    .index = payload.index,
+                    .data = .{
+                        .array_ptr = try payload.data.array_ptr.copy(allocator),
+                        .index = payload.data.index,
+                    },
                 };
                 return Value{ .ptr_otherwise = &new_payload.base };
             },
             .bytes => return self.copyPayloadShallow(allocator, Payload.Bytes),
             .repeated => {
-                const payload = @fieldParentPtr(Payload.Repeated, "base", self.ptr_otherwise);
-                const new_payload = try allocator.create(Payload.Repeated);
+                const payload = self.castTag(.repeated).?;
+                const new_payload = try allocator.create(Payload.SubValue);
                 new_payload.* = .{
                     .base = payload.base,
-                    .val = try payload.val.copy(allocator),
+                    .data = try payload.data.copy(allocator),
                 };
                 return Value{ .ptr_otherwise = &new_payload.base };
             },
@@ -243,7 +371,7 @@ pub const Value = extern union {
             .float_64 => return self.copyPayloadShallow(allocator, Payload.Float_64),
             .float_128 => return self.copyPayloadShallow(allocator, Payload.Float_128),
             .enum_literal => {
-                const payload = @fieldParentPtr(Payload.Bytes, "base", self.ptr_otherwise);
+                const payload = self.castTag(.enum_literal).?;
                 const new_payload = try allocator.create(Payload.Bytes);
                 new_payload.* = .{
                     .base = payload.base,
@@ -259,7 +387,7 @@ pub const Value = extern union {
     }
 
     fn copyPayloadShallow(self: Value, allocator: *Allocator, comptime T: type) error{OutOfMemory}!Value {
-        const payload = @fieldParentPtr(T, "base", self.ptr_otherwise);
+        const payload = self.cast(T).?;
         const new_payload = try allocator.create(T);
         new_payload.* = payload.*;
         return Value{ .ptr_otherwise = &new_payload.base };
@@ -326,45 +454,45 @@ pub const Value = extern union {
             .unreachable_value => return out_stream.writeAll("unreachable"),
             .bool_true => return out_stream.writeAll("true"),
             .bool_false => return out_stream.writeAll("false"),
-            .ty => return val.cast(Payload.Ty).?.ty.format("", options, out_stream),
+            .ty => return val.castTag(.ty).?.data.format("", options, out_stream),
             .int_type => {
-                const int_type = val.cast(Payload.IntType).?;
+                const int_type = val.castTag(.int_type).?.data;
                 return out_stream.print("{}{}", .{
                     if (int_type.signed) "s" else "u",
                     int_type.bits,
                 });
             },
-            .int_u64 => return std.fmt.formatIntValue(val.cast(Payload.Int_u64).?.int, "", options, out_stream),
-            .int_i64 => return std.fmt.formatIntValue(val.cast(Payload.Int_i64).?.int, "", options, out_stream),
-            .int_big_positive => return out_stream.print("{}", .{val.cast(Payload.IntBigPositive).?.asBigInt()}),
-            .int_big_negative => return out_stream.print("{}", .{val.cast(Payload.IntBigNegative).?.asBigInt()}),
+            .int_u64 => return std.fmt.formatIntValue(val.castTag(.int_u64).?.data, "", options, out_stream),
+            .int_i64 => return std.fmt.formatIntValue(val.castTag(.int_i64).?.data, "", options, out_stream),
+            .int_big_positive => return out_stream.print("{}", .{val.castTag(.int_big_positive).?.asBigInt()}),
+            .int_big_negative => return out_stream.print("{}", .{val.castTag(.int_big_negative).?.asBigInt()}),
             .function => return out_stream.writeAll("(function)"),
             .extern_fn => return out_stream.writeAll("(extern function)"),
             .variable => return out_stream.writeAll("(variable)"),
             .ref_val => {
-                const ref_val = val.cast(Payload.RefVal).?;
+                const ref_val = val.castTag(.ref_val).?.data;
                 try out_stream.writeAll("&const ");
-                val = ref_val.val;
+                val = ref_val;
             },
             .decl_ref => return out_stream.writeAll("(decl ref)"),
             .elem_ptr => {
-                const elem_ptr = val.cast(Payload.ElemPtr).?;
+                const elem_ptr = val.castTag(.elem_ptr).?.data;
                 try out_stream.print("&[{}] ", .{elem_ptr.index});
                 val = elem_ptr.array_ptr;
             },
             .empty_array => return out_stream.writeAll(".{}"),
-            .enum_literal => return out_stream.print(".{z}", .{self.cast(Payload.Bytes).?.data}),
-            .bytes => return out_stream.print("\"{Z}\"", .{self.cast(Payload.Bytes).?.data}),
+            .enum_literal => return out_stream.print(".{z}", .{self.castTag(.enum_literal).?.data}),
+            .bytes => return out_stream.print("\"{Z}\"", .{self.castTag(.bytes).?.data}),
             .repeated => {
                 try out_stream.writeAll("(repeated) ");
-                val = val.cast(Payload.Repeated).?.val;
+                val = val.castTag(.repeated).?.data;
             },
-            .float_16 => return out_stream.print("{}", .{val.cast(Payload.Float_16).?.val}),
-            .float_32 => return out_stream.print("{}", .{val.cast(Payload.Float_32).?.val}),
-            .float_64 => return out_stream.print("{}", .{val.cast(Payload.Float_64).?.val}),
-            .float_128 => return out_stream.print("{}", .{val.cast(Payload.Float_128).?.val}),
+            .float_16 => return out_stream.print("{}", .{val.castTag(.float_16).?.data}),
+            .float_32 => return out_stream.print("{}", .{val.castTag(.float_32).?.data}),
+            .float_64 => return out_stream.print("{}", .{val.castTag(.float_64).?.data}),
+            .float_128 => return out_stream.print("{}", .{val.castTag(.float_128).?.data}),
             .error_set => {
-                const error_set = val.cast(Payload.ErrorSet).?;
+                const error_set = val.castTag(.error_set).?.data;
                 try out_stream.writeAll("error{");
                 var it = error_set.fields.iterator();
                 while (it.next()) |entry| {
@@ -372,21 +500,24 @@ pub const Value = extern union {
                 }
                 return out_stream.writeAll("}");
             },
-            .@"error" => return out_stream.print("error.{}", .{val.cast(Payload.Error).?.name}),
+            .@"error" => return out_stream.print("error.{}", .{val.castTag(.@"error").?.data.name}),
         };
     }
 
     /// Asserts that the value is representable as an array of bytes.
     /// Copies the value into a freshly allocated slice of memory, which is owned by the caller.
     pub fn toAllocatedBytes(self: Value, allocator: *Allocator) ![]u8 {
-        if (self.cast(Payload.Bytes)) |bytes| {
-            return std.mem.dupe(allocator, u8, bytes.data);
+        if (self.castTag(.bytes)) |payload| {
+            return std.mem.dupe(allocator, u8, payload.data);
         }
-        if (self.cast(Payload.Repeated)) |repeated| {
+        if (self.castTag(.enum_literal)) |payload| {
+            return std.mem.dupe(allocator, u8, payload.data);
+        }
+        if (self.castTag(.repeated)) |payload| {
             @panic("TODO implement toAllocatedBytes for this Value tag");
         }
-        if (self.cast(Payload.DeclRef)) |declref| {
-            const val = try declref.decl.value();
+        if (self.castTag(.decl_ref)) |payload| {
+            const val = try payload.data.value();
             return val.toAllocatedBytes(allocator);
         }
         unreachable;
@@ -395,7 +526,7 @@ pub const Value = extern union {
     /// Asserts that the value is representable as a type.
     pub fn toType(self: Value, allocator: *Allocator) !Type {
         return switch (self.tag()) {
-            .ty => self.cast(Payload.Ty).?.ty,
+            .ty => self.castTag(.ty).?.data,
             .u8_type => Type.initTag(.u8),
             .i8_type => Type.initTag(.i8),
             .u16_type => Type.initTag(.u16),
@@ -439,7 +570,7 @@ pub const Value = extern union {
             .anyframe_type => Type.initTag(.@"anyframe"),
 
             .int_type => {
-                const payload = self.cast(Payload.IntType).?;
+                const payload = self.castTag(.int_type).?.data;
                 const new = try allocator.create(Type.Payload.Bits);
                 new.* = .{
                     .base = .{
@@ -450,7 +581,7 @@ pub const Value = extern union {
                 return Type.initPayload(&new.base);
             },
             .error_set => {
-                const payload = self.cast(Payload.ErrorSet).?;
+                const payload = self.castTag(.error_set).?.data;
                 return Type.Tag.error_set.create(allocator, payload.decl);
             },
 
@@ -564,10 +695,10 @@ pub const Value = extern union {
             .bool_true,
             => return BigIntMutable.init(&space.limbs, 1).toConst(),
 
-            .int_u64 => return BigIntMutable.init(&space.limbs, self.cast(Payload.Int_u64).?.int).toConst(),
-            .int_i64 => return BigIntMutable.init(&space.limbs, self.cast(Payload.Int_i64).?.int).toConst(),
-            .int_big_positive => return self.cast(Payload.IntBigPositive).?.asBigInt(),
-            .int_big_negative => return self.cast(Payload.IntBigNegative).?.asBigInt(),
+            .int_u64 => return BigIntMutable.init(&space.limbs, self.castTag(.int_u64).?.data).toConst(),
+            .int_i64 => return BigIntMutable.init(&space.limbs, self.castTag(.int_i64).?.data).toConst(),
+            .int_big_positive => return self.castTag(.int_big_positive).?.asBigInt(),
+            .int_big_negative => return self.castTag(.int_big_negative).?.asBigInt(),
         }
     }
 
@@ -649,10 +780,10 @@ pub const Value = extern union {
             .bool_true,
             => return 1,
 
-            .int_u64 => return self.cast(Payload.Int_u64).?.int,
-            .int_i64 => return @intCast(u64, self.cast(Payload.Int_i64).?.int),
-            .int_big_positive => return self.cast(Payload.IntBigPositive).?.asBigInt().to(u64) catch unreachable,
-            .int_big_negative => return self.cast(Payload.IntBigNegative).?.asBigInt().to(u64) catch unreachable,
+            .int_u64 => return self.castTag(.int_u64).?.data,
+            .int_i64 => return @intCast(u64, self.castTag(.int_i64).?.data),
+            .int_big_positive => return self.castTag(.int_big_positive).?.asBigInt().to(u64) catch unreachable,
+            .int_big_negative => return self.castTag(.int_big_negative).?.asBigInt().to(u64) catch unreachable,
         }
     }
 
@@ -734,10 +865,10 @@ pub const Value = extern union {
             .bool_true,
             => return 1,
 
-            .int_u64 => return @intCast(i64, self.cast(Payload.Int_u64).?.int),
-            .int_i64 => return self.cast(Payload.Int_i64).?.int,
-            .int_big_positive => return self.cast(Payload.IntBigPositive).?.asBigInt().to(i64) catch unreachable,
-            .int_big_negative => return self.cast(Payload.IntBigNegative).?.asBigInt().to(i64) catch unreachable,
+            .int_u64 => return @intCast(i64, self.castTag(.int_u64).?.data),
+            .int_i64 => return self.castTag(.int_i64).?.data,
+            .int_big_positive => return self.castTag(.int_big_positive).?.asBigInt().to(i64) catch unreachable,
+            .int_big_negative => return self.castTag(.int_big_negative).?.asBigInt().to(i64) catch unreachable,
         }
     }
 
@@ -753,14 +884,14 @@ pub const Value = extern union {
     pub fn toFloat(self: Value, comptime T: type) T {
         return switch (self.tag()) {
             .float_16 => @panic("TODO soft float"),
-            .float_32 => @floatCast(T, self.cast(Payload.Float_32).?.val),
-            .float_64 => @floatCast(T, self.cast(Payload.Float_64).?.val),
-            .float_128 => @floatCast(T, self.cast(Payload.Float_128).?.val),
+            .float_32 => @floatCast(T, self.castTag(.float_32).?.data),
+            .float_64 => @floatCast(T, self.castTag(.float_64).?.data),
+            .float_128 => @floatCast(T, self.castTag(.float_128).?.data),
 
             .zero => 0,
             .one => 1,
-            .int_u64 => @intToFloat(T, self.cast(Payload.Int_u64).?.int),
-            .int_i64 => @intToFloat(T, self.cast(Payload.Int_i64).?.int),
+            .int_u64 => @intToFloat(T, self.castTag(.int_u64).?.data),
+            .int_i64 => @intToFloat(T, self.castTag(.int_i64).?.data),
 
             .int_big_positive, .int_big_negative => @panic("big int to f128"),
             else => unreachable,
@@ -846,15 +977,15 @@ pub const Value = extern union {
             => return 1,
 
             .int_u64 => {
-                const x = self.cast(Payload.Int_u64).?.int;
+                const x = self.castTag(.int_u64).?.data;
                 if (x == 0) return 0;
                 return @intCast(usize, std.math.log2(x) + 1);
             },
             .int_i64 => {
                 @panic("TODO implement i64 intBitCountTwosComp");
             },
-            .int_big_positive => return self.cast(Payload.IntBigPositive).?.asBigInt().bitCountTwosComp(),
-            .int_big_negative => return self.cast(Payload.IntBigNegative).?.asBigInt().bitCountTwosComp(),
+            .int_big_positive => return self.castTag(.int_big_positive).?.asBigInt().bitCountTwosComp(),
+            .int_big_negative => return self.castTag(.int_big_negative).?.asBigInt().bitCountTwosComp(),
         }
     }
 
@@ -943,7 +1074,7 @@ pub const Value = extern union {
 
             .int_u64 => switch (ty.zigTypeTag()) {
                 .Int => {
-                    const x = self.cast(Payload.Int_u64).?.int;
+                    const x = self.castTag(.int_u64).?.data;
                     if (x == 0) return true;
                     const info = ty.intInfo(target);
                     const needed_bits = std.math.log2(x) + 1 + @boolToInt(info.signedness == .signed);
@@ -954,7 +1085,7 @@ pub const Value = extern union {
             },
             .int_i64 => switch (ty.zigTypeTag()) {
                 .Int => {
-                    const x = self.cast(Payload.Int_i64).?.int;
+                    const x = self.castTag(.int_i64).?.data;
                     if (x == 0) return true;
                     const info = ty.intInfo(target);
                     if (info.signedness == .unsigned and x < 0)
@@ -967,7 +1098,7 @@ pub const Value = extern union {
             .int_big_positive => switch (ty.zigTypeTag()) {
                 .Int => {
                     const info = ty.intInfo(target);
-                    return self.cast(Payload.IntBigPositive).?.asBigInt().fitsInTwosComp(info.signedness, info.bits);
+                    return self.castTag(.int_big_positive).?.asBigInt().fitsInTwosComp(info.signedness, info.bits);
                 },
                 .ComptimeInt => return true,
                 else => unreachable,
@@ -975,7 +1106,7 @@ pub const Value = extern union {
             .int_big_negative => switch (ty.zigTypeTag()) {
                 .Int => {
                     const info = ty.intInfo(target);
-                    return self.cast(Payload.IntBigNegative).?.asBigInt().fitsInTwosComp(info.signedness, info.bits);
+                    return self.castTag(.int_big_negative).?.asBigInt().fitsInTwosComp(info.signedness, info.bits);
                 },
                 .ComptimeInt => return true,
                 else => unreachable,
@@ -986,42 +1117,28 @@ pub const Value = extern union {
     /// Converts an integer or a float to a float.
     /// Returns `error.Overflow` if the value does not fit in the new type.
     pub fn floatCast(self: Value, allocator: *Allocator, ty: Type, target: Target) !Value {
-        const dest_bit_count = switch (ty.tag()) {
-            .comptime_float => 128,
-            else => ty.floatBits(target),
-        };
-        switch (dest_bit_count) {
-            16, 32, 64, 128 => {},
-            else => std.debug.panic("TODO float cast bit count {}\n", .{dest_bit_count}),
-        }
-        if (ty.isInt()) {
-            @panic("TODO int to float");
-        }
-
-        switch (dest_bit_count) {
-            16 => {
-                @panic("TODO soft float");
-                // var res_payload = Value.Payload.Float_16{.val = self.toFloat(f16)};
-                // if (!self.eql(Value.initPayload(&res_payload.base)))
-                //     return error.Overflow;
-                // return Value.initPayload(&res_payload.base).copy(allocator);
+        switch (ty.tag()) {
+            .f16 => {
+                @panic("TODO add __trunctfhf2 to compiler-rt");
+                //const res = try Value.Tag.float_16.create(allocator, self.toFloat(f16));
+                //if (!self.eql(res))
+                //    return error.Overflow;
+                //return res;
             },
-            32 => {
-                var res_payload = Value.Payload.Float_32{ .val = self.toFloat(f32) };
-                if (!self.eql(Value.initPayload(&res_payload.base)))
+            .f32 => {
+                const res = try Value.Tag.float_32.create(allocator, self.toFloat(f32));
+                if (!self.eql(res))
                     return error.Overflow;
-                return Value.initPayload(&res_payload.base).copy(allocator);
+                return res;
             },
-            64 => {
-                var res_payload = Value.Payload.Float_64{ .val = self.toFloat(f64) };
-                if (!self.eql(Value.initPayload(&res_payload.base)))
+            .f64 => {
+                const res = try Value.Tag.float_64.create(allocator, self.toFloat(f64));
+                if (!self.eql(res))
                     return error.Overflow;
-                return Value.initPayload(&res_payload.base).copy(allocator);
+                return res;
             },
-            128 => {
-                const float_payload = try allocator.create(Value.Payload.Float_128);
-                float_payload.* = .{ .val = self.toFloat(f128) };
-                return Value.initPayload(&float_payload.base);
+            .f128, .comptime_float, .c_longdouble => {
+                return Value.Tag.float_128.create(allocator, self.toFloat(f128));
             },
             else => unreachable,
         }
@@ -1102,10 +1219,10 @@ pub const Value = extern union {
             .one,
             => false,
 
-            .float_16 => @rem(self.cast(Payload.Float_16).?.val, 1) != 0,
-            .float_32 => @rem(self.cast(Payload.Float_32).?.val, 1) != 0,
-            .float_64 => @rem(self.cast(Payload.Float_64).?.val, 1) != 0,
-            // .float_128 => @rem(self.cast(Payload.Float_128).?.val, 1) != 0,
+            .float_16 => @rem(self.castTag(.float_16).?.data, 1) != 0,
+            .float_32 => @rem(self.castTag(.float_32).?.data, 1) != 0,
+            .float_64 => @rem(self.castTag(.float_64).?.data, 1) != 0,
+            // .float_128 => @rem(self.castTag(.float_128).?.data, 1) != 0,
             .float_128 => @panic("TODO lld: error: undefined symbol: fmodl"),
         };
     }
@@ -1182,15 +1299,15 @@ pub const Value = extern union {
             .bool_true,
             => .gt,
 
-            .int_u64 => std.math.order(lhs.cast(Payload.Int_u64).?.int, 0),
-            .int_i64 => std.math.order(lhs.cast(Payload.Int_i64).?.int, 0),
-            .int_big_positive => lhs.cast(Payload.IntBigPositive).?.asBigInt().orderAgainstScalar(0),
-            .int_big_negative => lhs.cast(Payload.IntBigNegative).?.asBigInt().orderAgainstScalar(0),
+            .int_u64 => std.math.order(lhs.castTag(.int_u64).?.data, 0),
+            .int_i64 => std.math.order(lhs.castTag(.int_i64).?.data, 0),
+            .int_big_positive => lhs.castTag(.int_big_positive).?.asBigInt().orderAgainstScalar(0),
+            .int_big_negative => lhs.castTag(.int_big_negative).?.asBigInt().orderAgainstScalar(0),
 
-            .float_16 => std.math.order(lhs.cast(Payload.Float_16).?.val, 0),
-            .float_32 => std.math.order(lhs.cast(Payload.Float_32).?.val, 0),
-            .float_64 => std.math.order(lhs.cast(Payload.Float_64).?.val, 0),
-            .float_128 => std.math.order(lhs.cast(Payload.Float_128).?.val, 0),
+            .float_16 => std.math.order(lhs.castTag(.float_16).?.data, 0),
+            .float_32 => std.math.order(lhs.castTag(.float_32).?.data, 0),
+            .float_64 => std.math.order(lhs.castTag(.float_64).?.data, 0),
+            .float_128 => std.math.order(lhs.castTag(.float_128).?.data, 0),
         };
     }
 
@@ -1208,10 +1325,10 @@ pub const Value = extern union {
         if (lhs_float and rhs_float) {
             if (lhs_tag == rhs_tag) {
                 return switch (lhs.tag()) {
-                    .float_16 => return std.math.order(lhs.cast(Payload.Float_16).?.val, rhs.cast(Payload.Float_16).?.val),
-                    .float_32 => return std.math.order(lhs.cast(Payload.Float_32).?.val, rhs.cast(Payload.Float_32).?.val),
-                    .float_64 => return std.math.order(lhs.cast(Payload.Float_64).?.val, rhs.cast(Payload.Float_64).?.val),
-                    .float_128 => return std.math.order(lhs.cast(Payload.Float_128).?.val, rhs.cast(Payload.Float_128).?.val),
+                    .float_16 => return std.math.order(lhs.castTag(.float_16).?.data, rhs.castTag(.float_16).?.data),
+                    .float_32 => return std.math.order(lhs.castTag(.float_32).?.data, rhs.castTag(.float_32).?.data),
+                    .float_64 => return std.math.order(lhs.castTag(.float_64).?.data, rhs.castTag(.float_64).?.data),
+                    .float_128 => return std.math.order(lhs.castTag(.float_128).?.data, rhs.castTag(.float_128).?.data),
                     else => unreachable,
                 };
             }
@@ -1244,8 +1361,8 @@ pub const Value = extern union {
             if (a.tag() == .void_value or a.tag() == .null_value) {
                 return true;
             } else if (a.tag() == .enum_literal) {
-                const a_name = @fieldParentPtr(Payload.Bytes, "base", a.ptr_otherwise).data;
-                const b_name = @fieldParentPtr(Payload.Bytes, "base", b.ptr_otherwise).data;
+                const a_name = a.castTag(.enum_literal).?.data;
+                const b_name = b.castTag(.enum_literal).?.data;
                 return std.mem.eql(u8, a_name, b_name);
             }
         }
@@ -1313,11 +1430,11 @@ pub const Value = extern union {
             },
             .error_set => {
                 // Payload.decl should be same for all instances of the type.
-                const payload = @fieldParentPtr(Payload.ErrorSet, "base", self.ptr_otherwise);
+                const payload = self.castTag(.error_set).?.data;
                 std.hash.autoHash(&hasher, payload.decl);
             },
             .int_type => {
-                const payload = self.cast(Payload.IntType).?;
+                const payload = self.castTag(.int_type).?.data;
                 var int_payload = Type.Payload.Bits{
                     .base = .{
                         .tag = if (payload.signed) .int_signed else .int_unsigned,
@@ -1341,25 +1458,29 @@ pub const Value = extern union {
             .one, .bool_true => std.hash.autoHash(&hasher, @as(u64, 1)),
 
             .float_16, .float_32, .float_64, .float_128 => {},
-            .enum_literal, .bytes => {
-                const payload = @fieldParentPtr(Payload.Bytes, "base", self.ptr_otherwise);
+            .enum_literal => {
+                const payload = self.castTag(.enum_literal).?;
+                hasher.update(payload.data);
+            },
+            .bytes => {
+                const payload = self.castTag(.bytes).?;
                 hasher.update(payload.data);
             },
             .int_u64 => {
-                const payload = @fieldParentPtr(Payload.Int_u64, "base", self.ptr_otherwise);
-                std.hash.autoHash(&hasher, payload.int);
+                const payload = self.castTag(.int_u64).?;
+                std.hash.autoHash(&hasher, payload.data);
             },
             .int_i64 => {
-                const payload = @fieldParentPtr(Payload.Int_i64, "base", self.ptr_otherwise);
-                std.hash.autoHash(&hasher, payload.int);
+                const payload = self.castTag(.int_i64).?;
+                std.hash.autoHash(&hasher, payload.data);
             },
             .repeated => {
-                const payload = @fieldParentPtr(Payload.Repeated, "base", self.ptr_otherwise);
-                std.hash.autoHash(&hasher, payload.val.hash());
+                const payload = self.castTag(.repeated).?;
+                std.hash.autoHash(&hasher, payload.data.hash());
             },
             .ref_val => {
-                const payload = @fieldParentPtr(Payload.RefVal, "base", self.ptr_otherwise);
-                std.hash.autoHash(&hasher, payload.val.hash());
+                const payload = self.castTag(.ref_val).?;
+                std.hash.autoHash(&hasher, payload.data.hash());
             },
             .int_big_positive, .int_big_negative => {
                 var space: BigIntSpace = undefined;
@@ -1379,28 +1500,28 @@ pub const Value = extern union {
                 }
             },
             .elem_ptr => {
-                const payload = @fieldParentPtr(Payload.ElemPtr, "base", self.ptr_otherwise);
+                const payload = self.castTag(.elem_ptr).?.data;
                 std.hash.autoHash(&hasher, payload.array_ptr.hash());
                 std.hash.autoHash(&hasher, payload.index);
             },
             .decl_ref => {
-                const payload = @fieldParentPtr(Payload.DeclRef, "base", self.ptr_otherwise);
-                std.hash.autoHash(&hasher, payload.decl);
+                const decl = self.castTag(.decl_ref).?.data;
+                std.hash.autoHash(&hasher, decl);
             },
             .function => {
-                const payload = @fieldParentPtr(Payload.Function, "base", self.ptr_otherwise);
-                std.hash.autoHash(&hasher, payload.func);
+                const func = self.castTag(.function).?.data;
+                std.hash.autoHash(&hasher, func);
             },
             .extern_fn => {
-                const payload = @fieldParentPtr(Payload.ExternFn, "base", self.ptr_otherwise);
-                std.hash.autoHash(&hasher, payload.decl);
+                const decl = self.castTag(.extern_fn).?.data;
+                std.hash.autoHash(&hasher, decl);
             },
             .variable => {
-                const payload = @fieldParentPtr(Payload.Variable, "base", self.ptr_otherwise);
-                std.hash.autoHash(&hasher, payload.variable);
+                const variable = self.castTag(.variable).?.data;
+                std.hash.autoHash(&hasher, variable);
             },
             .@"error" => {
-                const payload = @fieldParentPtr(Payload.Error, "base", self.ptr_otherwise);
+                const payload = self.castTag(.@"error").?.data;
                 hasher.update(payload.name);
                 std.hash.autoHash(&hasher, payload.value);
             },
@@ -1483,10 +1604,10 @@ pub const Value = extern union {
             .empty_struct_value,
             => unreachable,
 
-            .ref_val => self.cast(Payload.RefVal).?.val,
-            .decl_ref => self.cast(Payload.DeclRef).?.decl.value(),
+            .ref_val => self.castTag(.ref_val).?.data,
+            .decl_ref => self.castTag(.decl_ref).?.data.value(),
             .elem_ptr => {
-                const elem_ptr = self.cast(Payload.ElemPtr).?;
+                const elem_ptr = self.castTag(.elem_ptr).?.data;
                 const array_val = try elem_ptr.array_ptr.pointerDeref(allocator);
                 return array_val.elemValue(allocator, elem_ptr.index);
             },
@@ -1570,26 +1691,26 @@ pub const Value = extern union {
 
             .empty_array => unreachable, // out of bounds array index
 
-            .bytes => {
-                const int_payload = try allocator.create(Payload.Int_u64);
-                int_payload.* = .{ .int = self.cast(Payload.Bytes).?.data[index] };
-                return Value.initPayload(&int_payload.base);
-            },
+            .bytes => return Tag.int_u64.create(allocator, self.castTag(.bytes).?.data[index]),
 
             // No matter the index; all the elements are the same!
-            .repeated => return self.cast(Payload.Repeated).?.val,
+            .repeated => return self.castTag(.repeated).?.data,
         }
     }
 
     /// Returns a pointer to the element value at the index.
     pub fn elemPtr(self: Value, allocator: *Allocator, index: usize) !Value {
-        const payload = try allocator.create(Payload.ElemPtr);
-        if (self.cast(Payload.ElemPtr)) |elem_ptr| {
-            payload.* = .{ .array_ptr = elem_ptr.array_ptr, .index = elem_ptr.index + index };
-        } else {
-            payload.* = .{ .array_ptr = self, .index = index };
+        if (self.castTag(.elem_ptr)) |elem_ptr| {
+            return Tag.elem_ptr.create(allocator, .{
+                .array_ptr = elem_ptr.data.array_ptr,
+                .index = elem_ptr.data.index + index,
+            });
         }
-        return Value.initPayload(&payload.base);
+
+        return Tag.elem_ptr.create(allocator, .{
+            .array_ptr = self,
+            .index = index,
+        });
     }
 
     pub fn isUndef(self: Value) bool {
@@ -1776,131 +1897,128 @@ pub const Value = extern union {
     pub const Payload = struct {
         tag: Tag,
 
-        pub const Int_u64 = struct {
-            base: Payload = Payload{ .tag = .int_u64 },
-            int: u64,
+        pub const U64 = struct {
+            base: Payload,
+            data: u64,
         };
 
-        pub const Int_i64 = struct {
-            base: Payload = Payload{ .tag = .int_i64 },
-            int: i64,
+        pub const I64 = struct {
+            base: Payload,
+            data: i64,
         };
 
-        pub const IntBigPositive = struct {
-            base: Payload = Payload{ .tag = .int_big_positive },
-            limbs: []const std.math.big.Limb,
+        pub const BigInt = struct {
+            base: Payload,
+            data: []const std.math.big.Limb,
 
-            pub fn asBigInt(self: IntBigPositive) BigIntConst {
-                return BigIntConst{ .limbs = self.limbs, .positive = true };
-            }
-        };
-
-        pub const IntBigNegative = struct {
-            base: Payload = Payload{ .tag = .int_big_negative },
-            limbs: []const std.math.big.Limb,
-
-            pub fn asBigInt(self: IntBigNegative) BigIntConst {
-                return BigIntConst{ .limbs = self.limbs, .positive = false };
+            pub fn asBigInt(self: BigInt) BigIntConst {
+                const positive = switch (self.base.tag) {
+                    .int_big_positive => true,
+                    .int_big_negative => false,
+                    else => unreachable,
+                };
+                return BigIntConst{ .limbs = self.data, .positive = positive };
             }
         };
 
         pub const Function = struct {
-            base: Payload = Payload{ .tag = .function },
-            func: *Module.Fn,
+            base: Payload,
+            data: *Module.Fn,
         };
 
-        pub const ExternFn = struct {
-            base: Payload = Payload{ .tag = .extern_fn },
-            decl: *Module.Decl,
+        pub const Decl = struct {
+            base: Payload,
+            data: *Module.Decl,
         };
 
         pub const Variable = struct {
-            base: Payload = Payload{ .tag = .variable },
-            variable: *Module.Var,
+            base: Payload,
+            data: *Module.Var,
         };
 
-        pub const ArraySentinel0_u8_Type = struct {
-            base: Payload = Payload{ .tag = .array_sentinel_0_u8_type },
-            len: u64,
-        };
-
-        /// Represents a pointer to another immutable value.
-        pub const RefVal = struct {
-            base: Payload = Payload{ .tag = .ref_val },
-            val: Value,
-        };
-
-        /// Represents a pointer to a decl, not the value of the decl.
-        pub const DeclRef = struct {
-            base: Payload = Payload{ .tag = .decl_ref },
-            decl: *Module.Decl,
+        pub const SubValue = struct {
+            base: Payload,
+            data: Value,
         };
 
         pub const ElemPtr = struct {
-            base: Payload = Payload{ .tag = .elem_ptr },
-            array_ptr: Value,
-            index: usize,
+            pub const base_tag = Tag.elem_ptr;
+
+            base: Payload = Payload{ .tag = base_tag },
+            data: struct {
+                array_ptr: Value,
+                index: usize,
+            },
         };
 
         pub const Bytes = struct {
-            base: Payload = Payload{ .tag = .bytes },
+            base: Payload,
             data: []const u8,
         };
 
         pub const Ty = struct {
-            base: Payload = Payload{ .tag = .ty },
-            ty: Type,
+            base: Payload,
+            data: Type,
         };
 
         pub const IntType = struct {
-            base: Payload = Payload{ .tag = .int_type },
-            bits: u16,
-            signed: bool,
-        };
+            pub const base_tag = Tag.int_type;
 
-        pub const Repeated = struct {
-            base: Payload = Payload{ .tag = .ty },
-            /// This value is repeated some number of times. The amount of times to repeat
-            /// is stored externally.
-            val: Value,
+            base: Payload = Payload{ .tag = base_tag },
+            data: struct {
+                bits: u16,
+                signed: bool,
+            },
         };
 
         pub const Float_16 = struct {
-            base: Payload = .{ .tag = .float_16 },
-            val: f16,
+            pub const base_tag = Tag.float_16;
+
+            base: Payload = .{ .tag = base_tag },
+            data: f16,
         };
 
         pub const Float_32 = struct {
-            base: Payload = .{ .tag = .float_32 },
-            val: f32,
+            pub const base_tag = Tag.float_32;
+
+            base: Payload = .{ .tag = base_tag },
+            data: f32,
         };
 
         pub const Float_64 = struct {
-            base: Payload = .{ .tag = .float_64 },
-            val: f64,
+            pub const base_tag = Tag.float_64;
+
+            base: Payload = .{ .tag = base_tag },
+            data: f64,
         };
 
         pub const Float_128 = struct {
-            base: Payload = .{ .tag = .float_128 },
-            val: f128,
+            pub const base_tag = Tag.float_128;
+
+            base: Payload = .{ .tag = base_tag },
+            data: f128,
         };
 
         pub const ErrorSet = struct {
-            base: Payload = .{ .tag = .error_set },
+            pub const base_tag = Tag.error_set;
 
-            // TODO revisit this when we have the concept of the error tag type
-            fields: std.StringHashMapUnmanaged(u16),
-            decl: *Module.Decl,
+            base: Payload = .{ .tag = base_tag },
+            data: struct {
+                // TODO revisit this when we have the concept of the error tag type
+                fields: std.StringHashMapUnmanaged(u16),
+                decl: *Module.Decl,
+            },
         };
 
         pub const Error = struct {
             base: Payload = .{ .tag = .@"error" },
-
-            // TODO revisit this when we have the concept of the error tag type
-            /// `name` is owned by `Module` and will be valid for the entire
-            /// duration of the compilation.
-            name: []const u8,
-            value: u16,
+            data: struct {
+                // TODO revisit this when we have the concept of the error tag type
+                /// `name` is owned by `Module` and will be valid for the entire
+                /// duration of the compilation.
+                name: []const u8,
+                value: u16,
+            },
         };
     };
 
@@ -1914,15 +2032,24 @@ pub const Value = extern union {
 
 test "hash same value different representation" {
     const zero_1 = Value.initTag(.zero);
-    var payload_1 = Value.Payload.Int_u64{ .int = 0 };
+    var payload_1 = Value.Payload.U64{
+        .base = .{ .tag = .int_u64 },
+        .data = 0,
+    };
     const zero_2 = Value.initPayload(&payload_1.base);
     std.testing.expectEqual(zero_1.hash(), zero_2.hash());
 
-    var payload_2 = Value.Payload.Int_i64{ .int = 0 };
+    var payload_2 = Value.Payload.I64{
+        .base = .{ .tag = .int_i64 },
+        .data = 0,
+    };
     const zero_3 = Value.initPayload(&payload_2.base);
     std.testing.expectEqual(zero_2.hash(), zero_3.hash());
 
-    var payload_3 = Value.Payload.IntBigNegative{ .limbs = &[_]std.math.big.Limb{0} };
+    var payload_3 = Value.Payload.BigInt{
+        .base = .{ .tag = .int_big_negative },
+        .data = &[_]std.math.big.Limb{0},
+    };
     const zero_4 = Value.initPayload(&payload_3.base);
     std.testing.expectEqual(zero_3.hash(), zero_4.hash());
 }

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -1990,15 +1990,15 @@ const EmitZIR = struct {
 
     fn resolveInst(self: *EmitZIR, new_body: ZirBody, inst: *ir.Inst) !*Inst {
         if (inst.cast(ir.Inst.Constant)) |const_inst| {
-            const new_inst = if (const_inst.val.cast(Value.Payload.Function)) |func_pl| blk: {
-                const owner_decl = func_pl.func.owner_decl;
+            const new_inst = if (const_inst.val.castTag(.function)) |func_pl| blk: {
+                const owner_decl = func_pl.data.owner_decl;
                 break :blk try self.emitDeclVal(inst.src, mem.spanZ(owner_decl.name));
-            } else if (const_inst.val.cast(Value.Payload.DeclRef)) |declref| blk: {
-                const decl_ref = try self.emitDeclRef(inst.src, declref.decl);
+            } else if (const_inst.val.castTag(.decl_ref)) |declref| blk: {
+                const decl_ref = try self.emitDeclRef(inst.src, declref.data);
                 try new_body.instructions.append(decl_ref);
                 break :blk decl_ref;
-            } else if (const_inst.val.cast(Value.Payload.Variable)) |var_pl| blk: {
-                const owner_decl = var_pl.variable.owner_decl;
+            } else if (const_inst.val.castTag(.variable)) |var_pl| blk: {
+                const owner_decl = var_pl.data.owner_decl;
                 break :blk try self.emitDeclVal(inst.src, mem.spanZ(owner_decl.name));
             } else blk: {
                 break :blk (try self.emitTypedValue(inst.src, .{ .ty = inst.ty, .val = const_inst.val })).inst;
@@ -2150,13 +2150,13 @@ const EmitZIR = struct {
 
     fn emitTypedValue(self: *EmitZIR, src: usize, typed_value: TypedValue) Allocator.Error!*Decl {
         const allocator = &self.arena.allocator;
-        if (typed_value.val.cast(Value.Payload.DeclRef)) |decl_ref| {
-            const decl = decl_ref.decl;
+        if (typed_value.val.castTag(.decl_ref)) |decl_ref| {
+            const decl = decl_ref.data;
             return try self.emitUnnamedDecl(try self.emitDeclRef(src, decl));
-        } else if (typed_value.val.cast(Value.Payload.Variable)) |variable| {
+        } else if (typed_value.val.castTag(.variable)) |variable| {
             return self.emitTypedValue(src, .{
                 .ty = typed_value.ty,
-                .val = variable.variable.init,
+                .val = variable.data.init,
             });
         }
         if (typed_value.val.isUndef()) {
@@ -2215,7 +2215,7 @@ const EmitZIR = struct {
                 return self.emitType(src, ty);
             },
             .Fn => {
-                const module_fn = typed_value.val.cast(Value.Payload.Function).?.func;
+                const module_fn = typed_value.val.castTag(.function).?.data;
                 return self.emitFn(module_fn, src, typed_value.ty);
             },
             .Array => {
@@ -2248,7 +2248,7 @@ const EmitZIR = struct {
             else
                 return self.emitPrimitive(src, .@"false"),
             .EnumLiteral => {
-                const enum_literal = @fieldParentPtr(Value.Payload.Bytes, "base", typed_value.val.ptr_otherwise);
+                const enum_literal = typed_value.val.castTag(.enum_literal).?;
                 const inst = try self.arena.allocator.create(Inst.Str);
                 inst.* = .{
                     .base = .{
@@ -2748,9 +2748,8 @@ const EmitZIR = struct {
                         .signed => .@"true",
                         .unsigned => .@"false",
                     });
-                    const bits_payload = try self.arena.allocator.create(Value.Payload.Int_u64);
-                    bits_payload.* = .{ .int = info.bits };
-                    const bits = try self.emitComptimeIntVal(src, Value.initPayload(&bits_payload.base));
+                    const bits_val = try Value.Tag.int_u64.create(&self.arena.allocator, info.bits);
+                    const bits = try self.emitComptimeIntVal(src, bits_val);
                     const inttype_inst = try self.arena.allocator.create(Inst.IntType);
                     inttype_inst.* = .{
                         .base = .{
@@ -2800,7 +2799,10 @@ const EmitZIR = struct {
                     return self.emitUnnamedDecl(&inst.base);
                 },
                 .Array => {
-                    var len_pl = Value.Payload.Int_u64{ .int = ty.arrayLen() };
+                    var len_pl = Value.Payload.U64{
+                        .base = .{ .tag = .int_u64 },
+                        .data = ty.arrayLen(),
+                    };
                     const len = Value.initPayload(&len_pl.base);
 
                     const inst = if (ty.sentinel()) |sentinel| blk: {

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -2785,7 +2785,7 @@ const EmitZIR = struct {
                     }
                 },
                 .Optional => {
-                    var buf: Type.Payload.PointerSimple = undefined;
+                    var buf: Type.Payload.ElemType = undefined;
                     const inst = try self.arena.allocator.create(Inst.UnOp);
                     inst.* = .{
                         .base = .{


### PR DESCRIPTION
Add `Type.castTag` and note that it is preferable to call than
`Type.cast`. This matches other abstractions in the codebase.

Added a convenience function `Type.Tag.create` which really cleans up
the callsites of creating `Type` objects.

`Type` payloads can now share types. This is in preparation for another
improvement that I want to do.