### PR TITLE
stage2: inferred local variables

### DIFF
--- a/BRANCH_TODO
+++ b/BRANCH_TODO
@@ -1,2 +1,2 @@
- * no need for payload on inferred_alloc for the type
  * compile error for "variable of type '{}' must be const or comptime" after resolving types
+ * test with branches

--- a/BRANCH_TODO
+++ b/BRANCH_TODO
@@ -1,2 +1,0 @@
- * compile error for "variable of type '{}' must be const or comptime" after resolving types
- * test with branches

--- a/BRANCH_TODO
+++ b/BRANCH_TODO
@@ -1,0 +1,2 @@
+ * no need for payload on inferred_alloc for the type
+ * compile error for "variable of type '{}' must be const or comptime" after resolving types

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3421,3 +3421,9 @@ pub fn getTarget(self: Module) Target {
 pub fn optimizeMode(self: Module) std.builtin.Mode {
     return self.comp.bin_file.options.optimize_mode;
 }
+
+pub fn validateVarType(mod: *Module, scope: *Scope, src: usize, ty: Type) !void {
+    if (!ty.isValidVarType(false)) {
+        return mod.fail(scope, src, "variable of type '{}' must be const or comptime", .{ty});
+    }
+}

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3189,7 +3189,14 @@ pub fn floatSub(
     }
 }
 
-pub fn simplePtrType(self: *Module, scope: *Scope, src: usize, elem_ty: Type, mutable: bool, size: std.builtin.TypeInfo.Pointer.Size) Allocator.Error!Type {
+pub fn simplePtrType(
+    self: *Module,
+    scope: *Scope,
+    src: usize,
+    elem_ty: Type,
+    mutable: bool,
+    size: std.builtin.TypeInfo.Pointer.Size,
+) Allocator.Error!Type {
     if (!mutable and size == .Slice and elem_ty.eql(Type.initTag(.u8))) {
         return Type.initTag(.const_slice_u8);
     }

--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -625,9 +625,9 @@ fn varDecl(
                 const alloc = try addZIRUnOp(mod, scope, name_src, .alloc_mut, type_inst);
                 break :a .{ .alloc = alloc, .result_loc = .{ .ptr = alloc } };
             } else a: {
-                const alloc = try addZIRNoOp(mod, scope, name_src, .alloc_inferred_mut);
-                resolve_inferred_alloc = alloc;
-                break :a .{ .alloc = alloc, .result_loc = .{ .inferred_ptr = alloc.castTag(.alloc_inferred_mut).? } };
+                const alloc = try addZIRNoOpT(mod, scope, name_src, .alloc_inferred);
+                resolve_inferred_alloc = &alloc.base;
+                break :a .{ .alloc = &alloc.base, .result_loc = .{ .inferred_ptr = alloc } };
             };
             const init_inst = try expr(mod, scope, var_data.result_loc, init_node);
             if (resolve_inferred_alloc) |inst| {

--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -625,7 +625,7 @@ fn varDecl(
                 const alloc = try addZIRUnOp(mod, scope, name_src, .alloc_mut, type_inst);
                 break :a .{ .alloc = alloc, .result_loc = .{ .ptr = alloc } };
             } else a: {
-                const alloc = try addZIRNoOpT(mod, scope, name_src, .alloc_inferred);
+                const alloc = try addZIRNoOpT(mod, scope, name_src, .alloc_inferred_mut);
                 resolve_inferred_alloc = &alloc.base;
                 break :a .{ .alloc = &alloc.base, .result_loc = .{ .inferred_ptr = alloc } };
             };

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -196,7 +196,7 @@ pub const Inst = struct {
     pub fn value(base: *Inst) ?Value {
         if (base.ty.onePossibleValue()) |opv| return opv;
 
-        const inst = base.cast(Constant) orelse return null;
+        const inst = base.castTag(.constant) orelse return null;
         return inst.val;
     }
 

--- a/src/link/cbe.h
+++ b/src/link/cbe.h
@@ -41,4 +41,4 @@
 #include <stdint.h>
 #define int128_t __int128
 #define uint128_t unsigned __int128
-
+#include <string.h>

--- a/src/test.zig
+++ b/src/test.zig
@@ -782,6 +782,7 @@ pub const TestContext = struct {
                                 "-std=c89",
                                 "-pedantic",
                                 "-Werror",
+                                "-Wno-declaration-after-statement",
                                 "--",
                                 "-lc",
                                 exe_path,

--- a/src/type.zig
+++ b/src/type.zig
@@ -78,7 +78,8 @@ pub const Type = extern union {
             .const_slice,
             .mut_slice,
             .pointer,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => return .Pointer,
 
             .optional,
@@ -159,7 +160,8 @@ pub const Type = extern union {
             .optional_single_mut_pointer,
             => self.cast(Payload.ElemType),
 
-            .inferred_alloc => unreachable,
+            .inferred_alloc_const => unreachable,
+            .inferred_alloc_mut => unreachable,
 
             else => null,
         };
@@ -387,7 +389,8 @@ pub const Type = extern union {
             .enum_literal,
             .anyerror_void_error_union,
             .@"anyframe",
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
 
             .array_u8,
@@ -690,7 +693,8 @@ pub const Type = extern union {
                     const name = ty.castTag(.error_set_single).?.data;
                     return out_stream.print("error{{{s}}}", .{name});
                 },
-                .inferred_alloc => return out_stream.writeAll("(inferred allocation type)"),
+                .inferred_alloc_const => return out_stream.writeAll("(inferred_alloc_const)"),
+                .inferred_alloc_mut => return out_stream.writeAll("(inferred_alloc_mut)"),
             }
             unreachable;
         }
@@ -738,7 +742,8 @@ pub const Type = extern union {
             .single_const_pointer_to_comptime_int => return Value.initTag(.single_const_pointer_to_comptime_int_type),
             .const_slice_u8 => return Value.initTag(.const_slice_u8_type),
             .enum_literal => return Value.initTag(.enum_literal_type),
-            .inferred_alloc => unreachable,
+            .inferred_alloc_const => unreachable,
+            .inferred_alloc_mut => unreachable,
             else => return Value.Tag.ty.create(allocator, self),
         }
     }
@@ -810,7 +815,8 @@ pub const Type = extern union {
             .empty_struct,
             => false,
 
-            .inferred_alloc => unreachable,
+            .inferred_alloc_const => unreachable,
+            .inferred_alloc_mut => unreachable,
         };
     }
 
@@ -928,7 +934,8 @@ pub const Type = extern union {
             .@"undefined",
             .enum_literal,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
         };
     }
@@ -952,7 +959,8 @@ pub const Type = extern union {
             .enum_literal => unreachable,
             .single_const_pointer_to_comptime_int => unreachable,
             .empty_struct => unreachable,
-            .inferred_alloc => unreachable,
+            .inferred_alloc_const => unreachable,
+            .inferred_alloc_mut => unreachable,
 
             .u8,
             .i8,
@@ -1131,7 +1139,8 @@ pub const Type = extern union {
             .single_const_pointer,
             .single_mut_pointer,
             .single_const_pointer_to_comptime_int,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => true,
 
             .pointer => self.castTag(.pointer).?.data.size == .One,
@@ -1214,7 +1223,8 @@ pub const Type = extern union {
             .single_const_pointer,
             .single_mut_pointer,
             .single_const_pointer_to_comptime_int,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => .One,
 
             .pointer => self.castTag(.pointer).?.data.size,
@@ -1285,7 +1295,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => false,
 
             .const_slice,
@@ -1358,7 +1369,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => false,
 
             .single_const_pointer,
@@ -1440,7 +1452,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => false,
 
             .pointer => {
@@ -1517,7 +1530,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => false,
 
             .pointer => {
@@ -1636,7 +1650,8 @@ pub const Type = extern union {
             .error_set => unreachable,
             .error_set_single => unreachable,
             .empty_struct => unreachable,
-            .inferred_alloc => unreachable,
+            .inferred_alloc_const => unreachable,
+            .inferred_alloc_mut => unreachable,
 
             .array => self.castTag(.array).?.data.elem_type,
             .array_sentinel => self.castTag(.array_sentinel).?.data.elem_type,
@@ -1758,7 +1773,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
 
             .array => self.castTag(.array).?.data.len,
@@ -1825,7 +1841,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
 
             .single_const_pointer,
@@ -1909,7 +1926,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => false,
 
             .int_signed,
@@ -1985,7 +2003,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => false,
 
             .int_unsigned,
@@ -2051,7 +2070,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
 
             .int_unsigned => .{
@@ -2141,7 +2161,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => false,
 
             .usize,
@@ -2254,7 +2275,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
         };
     }
@@ -2333,7 +2355,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
         }
     }
@@ -2411,7 +2434,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
         }
     }
@@ -2489,7 +2513,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
         };
     }
@@ -2564,7 +2589,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
         };
     }
@@ -2639,7 +2665,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
         };
     }
@@ -2714,7 +2741,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => false,
         };
     }
@@ -2807,7 +2835,8 @@ pub const Type = extern union {
                 ty = ty.castTag(.pointer).?.data.pointee_type;
                 continue;
             },
-            .inferred_alloc => unreachable,
+            .inferred_alloc_const => unreachable,
+            .inferred_alloc_mut => unreachable,
         };
     }
 
@@ -2876,7 +2905,8 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => return false,
 
             .c_const_pointer,
@@ -2962,7 +2992,8 @@ pub const Type = extern union {
             .c_const_pointer,
             .c_mut_pointer,
             .pointer,
-            .inferred_alloc,
+            .inferred_alloc_const,
+            .inferred_alloc_mut,
             => unreachable,
 
             .empty_struct => self.castTag(.empty_struct).?.data,
@@ -3077,7 +3108,9 @@ pub const Type = extern union {
         /// This is a special value that tracks a set of types that have been stored
         /// to an inferred allocation. It does not support most of the normal type queries.
         /// However it does respond to `isConstPtr`, `ptrSize`, `zigTypeTag`, etc.
-        inferred_alloc, // See last_no_payload_tag below.
+        inferred_alloc_mut,
+        /// Same as `inferred_alloc_mut` but the local is `var` not `const`.
+        inferred_alloc_const, // See last_no_payload_tag below.
         // After this, the tag requires a payload.
 
         array_u8,
@@ -3105,7 +3138,7 @@ pub const Type = extern union {
         error_set_single,
         empty_struct,
 
-        pub const last_no_payload_tag = Tag.inferred_alloc;
+        pub const last_no_payload_tag = Tag.inferred_alloc_const;
         pub const no_payload_count = @enumToInt(last_no_payload_tag) + 1;
 
         pub fn Type(comptime t: Tag) type {
@@ -3152,7 +3185,8 @@ pub const Type = extern union {
                 .anyerror_void_error_union,
                 .@"anyframe",
                 .const_slice_u8,
-                .inferred_alloc,
+                .inferred_alloc_const,
+                .inferred_alloc_mut,
                 => @compileError("Type Tag " ++ @tagName(t) ++ " has no payload"),
 
                 .array_u8,

--- a/src/type.zig
+++ b/src/type.zig
@@ -78,6 +78,7 @@ pub const Type = extern union {
             .const_slice,
             .mut_slice,
             .pointer,
+            .inferred_alloc,
             => return .Pointer,
 
             .optional,
@@ -157,6 +158,8 @@ pub const Type = extern union {
             .optional_single_const_pointer,
             .optional_single_mut_pointer,
             => self.cast(Payload.ElemType),
+
+            .inferred_alloc => unreachable,
 
             else => null,
         };
@@ -384,6 +387,7 @@ pub const Type = extern union {
             .enum_literal,
             .anyerror_void_error_union,
             .@"anyframe",
+            .inferred_alloc,
             => unreachable,
 
             .array_u8,
@@ -686,6 +690,7 @@ pub const Type = extern union {
                     const name = ty.castTag(.error_set_single).?.data;
                     return out_stream.print("error{{{s}}}", .{name});
                 },
+                .inferred_alloc => return out_stream.writeAll("(inferred allocation type)"),
             }
             unreachable;
         }
@@ -733,6 +738,7 @@ pub const Type = extern union {
             .single_const_pointer_to_comptime_int => return Value.initTag(.single_const_pointer_to_comptime_int_type),
             .const_slice_u8 => return Value.initTag(.const_slice_u8_type),
             .enum_literal => return Value.initTag(.enum_literal_type),
+            .inferred_alloc => unreachable,
             else => return Value.Tag.ty.create(allocator, self),
         }
     }
@@ -803,6 +809,8 @@ pub const Type = extern union {
             .enum_literal,
             .empty_struct,
             => false,
+
+            .inferred_alloc => unreachable,
         };
     }
 
@@ -920,6 +928,7 @@ pub const Type = extern union {
             .@"undefined",
             .enum_literal,
             .empty_struct,
+            .inferred_alloc,
             => unreachable,
         };
     }
@@ -943,6 +952,7 @@ pub const Type = extern union {
             .enum_literal => unreachable,
             .single_const_pointer_to_comptime_int => unreachable,
             .empty_struct => unreachable,
+            .inferred_alloc => unreachable,
 
             .u8,
             .i8,
@@ -1121,6 +1131,7 @@ pub const Type = extern union {
             .single_const_pointer,
             .single_mut_pointer,
             .single_const_pointer_to_comptime_int,
+            .inferred_alloc,
             => true,
 
             .pointer => self.castTag(.pointer).?.data.size == .One,
@@ -1203,6 +1214,7 @@ pub const Type = extern union {
             .single_const_pointer,
             .single_mut_pointer,
             .single_const_pointer_to_comptime_int,
+            .inferred_alloc,
             => .One,
 
             .pointer => self.castTag(.pointer).?.data.size,
@@ -1273,6 +1285,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => false,
 
             .const_slice,
@@ -1345,6 +1358,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => false,
 
             .single_const_pointer,
@@ -1426,6 +1440,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => false,
 
             .pointer => {
@@ -1502,6 +1517,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => false,
 
             .pointer => {
@@ -1569,58 +1585,58 @@ pub const Type = extern union {
     /// Asserts the type is a pointer or array type.
     pub fn elemType(self: Type) Type {
         return switch (self.tag()) {
-            .u8,
-            .i8,
-            .u16,
-            .i16,
-            .u32,
-            .i32,
-            .u64,
-            .i64,
-            .usize,
-            .isize,
-            .c_short,
-            .c_ushort,
-            .c_int,
-            .c_uint,
-            .c_long,
-            .c_ulong,
-            .c_longlong,
-            .c_ulonglong,
-            .c_longdouble,
-            .f16,
-            .f32,
-            .f64,
-            .f128,
-            .c_void,
-            .bool,
-            .void,
-            .type,
-            .anyerror,
-            .comptime_int,
-            .comptime_float,
-            .noreturn,
-            .@"null",
-            .@"undefined",
-            .fn_noreturn_no_args,
-            .fn_void_no_args,
-            .fn_naked_noreturn_no_args,
-            .fn_ccc_void_no_args,
-            .function,
-            .int_unsigned,
-            .int_signed,
-            .optional,
-            .optional_single_const_pointer,
-            .optional_single_mut_pointer,
-            .enum_literal,
-            .error_union,
-            .@"anyframe",
-            .anyframe_T,
-            .anyerror_void_error_union,
-            .error_set,
-            .error_set_single,
-            .empty_struct,
-            => unreachable,
+            .u8 => unreachable,
+            .i8 => unreachable,
+            .u16 => unreachable,
+            .i16 => unreachable,
+            .u32 => unreachable,
+            .i32 => unreachable,
+            .u64 => unreachable,
+            .i64 => unreachable,
+            .usize => unreachable,
+            .isize => unreachable,
+            .c_short => unreachable,
+            .c_ushort => unreachable,
+            .c_int => unreachable,
+            .c_uint => unreachable,
+            .c_long => unreachable,
+            .c_ulong => unreachable,
+            .c_longlong => unreachable,
+            .c_ulonglong => unreachable,
+            .c_longdouble => unreachable,
+            .f16 => unreachable,
+            .f32 => unreachable,
+            .f64 => unreachable,
+            .f128 => unreachable,
+            .c_void => unreachable,
+            .bool => unreachable,
+            .void => unreachable,
+            .type => unreachable,
+            .anyerror => unreachable,
+            .comptime_int => unreachable,
+            .comptime_float => unreachable,
+            .noreturn => unreachable,
+            .@"null" => unreachable,
+            .@"undefined" => unreachable,
+            .fn_noreturn_no_args => unreachable,
+            .fn_void_no_args => unreachable,
+            .fn_naked_noreturn_no_args => unreachable,
+            .fn_ccc_void_no_args => unreachable,
+            .function => unreachable,
+            .int_unsigned => unreachable,
+            .int_signed => unreachable,
+            .optional => unreachable,
+            .optional_single_const_pointer => unreachable,
+            .optional_single_mut_pointer => unreachable,
+            .enum_literal => unreachable,
+            .error_union => unreachable,
+            .@"anyframe" => unreachable,
+            .anyframe_T => unreachable,
+            .anyerror_void_error_union => unreachable,
+            .error_set => unreachable,
+            .error_set_single => unreachable,
+            .empty_struct => unreachable,
+            .inferred_alloc => unreachable,
 
             .array => self.castTag(.array).?.data.elem_type,
             .array_sentinel => self.castTag(.array_sentinel).?.data.elem_type,
@@ -1742,6 +1758,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => unreachable,
 
             .array => self.castTag(.array).?.data.len,
@@ -1808,6 +1825,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => unreachable,
 
             .single_const_pointer,
@@ -1891,6 +1909,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => false,
 
             .int_signed,
@@ -1966,6 +1985,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => false,
 
             .int_unsigned,
@@ -2031,6 +2051,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => unreachable,
 
             .int_unsigned => .{
@@ -2120,6 +2141,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => false,
 
             .usize,
@@ -2232,6 +2254,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => unreachable,
         };
     }
@@ -2310,6 +2333,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => unreachable,
         }
     }
@@ -2387,6 +2411,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => unreachable,
         }
     }
@@ -2464,6 +2489,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => unreachable,
         };
     }
@@ -2538,6 +2564,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => unreachable,
         };
     }
@@ -2612,6 +2639,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => unreachable,
         };
     }
@@ -2686,6 +2714,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => false,
         };
     }
@@ -2778,6 +2807,7 @@ pub const Type = extern union {
                 ty = ty.castTag(.pointer).?.data.pointee_type;
                 continue;
             },
+            .inferred_alloc => unreachable,
         };
     }
 
@@ -2846,6 +2876,7 @@ pub const Type = extern union {
             .error_set,
             .error_set_single,
             .empty_struct,
+            .inferred_alloc,
             => return false,
 
             .c_const_pointer,
@@ -2931,6 +2962,7 @@ pub const Type = extern union {
             .c_const_pointer,
             .c_mut_pointer,
             .pointer,
+            .inferred_alloc,
             => unreachable,
 
             .empty_struct => self.castTag(.empty_struct).?.data,
@@ -3068,6 +3100,10 @@ pub const Type = extern union {
         error_set,
         error_set_single,
         empty_struct,
+        /// This is a special value that tracks a set of types that have been stored
+        /// to an inferred allocation. It does not support most of the normal type queries.
+        /// However it does respond to `isConstPtr`, `ptrSize`, `zigTypeTag`, etc.
+        inferred_alloc,
 
         pub const last_no_payload_tag = Tag.const_slice_u8;
         pub const no_payload_count = @enumToInt(last_no_payload_tag) + 1;
@@ -3148,6 +3184,7 @@ pub const Type = extern union {
                 .error_set => Payload.Decl,
                 .error_set_single => Payload.Name,
                 .empty_struct => Payload.ContainerScope,
+                .inferred_alloc => Payload.InferredAlloc,
             };
         }
 
@@ -3260,6 +3297,13 @@ pub const Type = extern union {
         pub const ContainerScope = struct {
             base: Payload,
             data: *Module.Scope.Container,
+        };
+
+        pub const InferredAlloc = struct {
+            pub const base_tag = Tag.inferred_alloc;
+
+            base: Payload = .{ .tag = base_tag },
+            data: *Value.Payload.InferredAlloc,
         };
     };
 };

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -241,12 +241,20 @@ pub const Inst = struct {
         const_slice_type,
         /// Create a pointer type with attributes
         ptr_type,
+        /// Each `store_to_inferred_ptr` puts the type of the stored value into a set,
+        /// and then `resolve_inferred_alloc` triggers peer type resolution on the set.
+        /// The operand is a `alloc_inferred` or `alloc_inferred_mut` instruction, which
+        /// is the allocation that needs to have its type inferred.
+        resolve_inferred_alloc,
         /// Slice operation `array_ptr[start..end:sentinel]`
         slice,
         /// Slice operation with just start `lhs[rhs..]`
         slice_start,
         /// Write a value to a pointer. For loading, see `deref`.
         store,
+        /// Same as `store` but the type of the value being stored will be used to infer
+        /// the pointer type.
+        store_to_inferred_ptr,
         /// String Literal. Makes an anonymous Decl and then takes a pointer to it.
         str,
         /// Arithmetic subtraction. Asserts no integer overflow.
@@ -319,6 +327,7 @@ pub const Inst = struct {
                 .ref,
                 .bitcast_ref,
                 .typeof,
+                .resolve_inferred_alloc,
                 .single_const_ptr_type,
                 .single_mut_ptr_type,
                 .many_const_ptr_type,
@@ -355,6 +364,7 @@ pub const Inst = struct {
                 .shl,
                 .shr,
                 .store,
+                .store_to_inferred_ptr,
                 .sub,
                 .subwrap,
                 .cmp_lt,
@@ -498,6 +508,7 @@ pub const Inst = struct {
                 .mut_slice_type,
                 .const_slice_type,
                 .store,
+                .store_to_inferred_ptr,
                 .str,
                 .sub,
                 .subwrap,
@@ -522,6 +533,7 @@ pub const Inst = struct {
                 .import,
                 .switch_range,
                 .typeof_peer,
+                .resolve_inferred_alloc,
                 => false,
 
                 .@"break",

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -10,10 +10,12 @@
 const std = @import("std");
 const mem = std.mem;
 const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
+const log = std.log.scoped(.sema);
+
 const Value = @import("value.zig").Value;
 const Type = @import("type.zig").Type;
 const TypedValue = @import("TypedValue.zig");
-const assert = std.debug.assert;
 const ir = @import("ir.zig");
 const zir = @import("zir.zig");
 const Module = @import("Module.zig");
@@ -55,8 +57,10 @@ pub fn analyzeInst(mod: *Module, scope: *Scope, old_inst: *zir.Inst) InnerError!
         .ensure_result_non_error => return analyzeInstEnsureResultNonError(mod, scope, old_inst.castTag(.ensure_result_non_error).?),
         .ensure_indexable => return analyzeInstEnsureIndexable(mod, scope, old_inst.castTag(.ensure_indexable).?),
         .ref => return analyzeInstRef(mod, scope, old_inst.castTag(.ref).?),
+        .resolve_inferred_alloc => return analyzeInstResolveInferredAlloc(mod, scope, old_inst.castTag(.resolve_inferred_alloc).?),
         .ret_ptr => return analyzeInstRetPtr(mod, scope, old_inst.castTag(.ret_ptr).?),
         .ret_type => return analyzeInstRetType(mod, scope, old_inst.castTag(.ret_type).?),
+        .store_to_inferred_ptr => return analyzeInstStoreToInferredPtr(mod, scope, old_inst.castTag(.store_to_inferred_ptr).?),
         .single_const_ptr_type => return analyzeInstSimplePtrType(mod, scope, old_inst.castTag(.single_const_ptr_type).?, false, .One),
         .single_mut_ptr_type => return analyzeInstSimplePtrType(mod, scope, old_inst.castTag(.single_mut_ptr_type).?, true, .One),
         .many_const_ptr_type => return analyzeInstSimplePtrType(mod, scope, old_inst.castTag(.many_const_ptr_type).?, false, .Many),
@@ -428,11 +432,64 @@ fn analyzeInstAllocMut(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp) InnerE
 }
 
 fn analyzeInstAllocInferred(mod: *Module, scope: *Scope, inst: *zir.Inst.NoOp) InnerError!*Inst {
-    return mod.fail(scope, inst.base.src, "TODO implement analyzeInstAllocInferred", .{});
+    const val_payload = try scope.arena().create(Value.Payload.InferredAlloc);
+    val_payload.* = .{
+        .data = .{},
+    };
+    // `Module.constInst` does not add the instruction to the block because it is
+    // not needed in the case of constant values. However here, we plan to "downgrade"
+    // to a normal instruction when we hit `resolve_inferred_alloc`. So we append
+    // to the block even though it is currently a `.constant`.
+    const result = try mod.constInst(scope, inst.base.src, .{
+        .ty = try Type.Tag.inferred_alloc.create(scope.arena(), val_payload),
+        .val = Value.initPayload(&val_payload.base),
+    });
+    const block = try mod.requireFunctionBlock(scope, inst.base.src);
+    try block.instructions.append(mod.gpa, result);
+    return result;
 }
 
 fn analyzeInstAllocInferredMut(mod: *Module, scope: *Scope, inst: *zir.Inst.NoOp) InnerError!*Inst {
     return mod.fail(scope, inst.base.src, "TODO implement analyzeInstAllocInferredMut", .{});
+}
+
+fn analyzeInstResolveInferredAlloc(
+    mod: *Module,
+    scope: *Scope,
+    inst: *zir.Inst.UnOp,
+) InnerError!*Inst {
+    const ptr = try resolveInst(mod, scope, inst.positionals.operand);
+    const ptr_val = ptr.castTag(.constant).?.val;
+    const inferred_alloc = ptr_val.castTag(.inferred_alloc).?;
+    const peer_inst_list = inferred_alloc.data.stored_inst_list.items;
+    const final_elem_ty = try mod.resolvePeerTypes(scope, peer_inst_list);
+    const is_mut = true;
+    const final_ptr_ty = try mod.simplePtrType(scope, inst.base.src, final_elem_ty, is_mut, .One);
+
+    // Change it to a normal alloc.
+    ptr.ty = final_ptr_ty;
+    ptr.tag = .alloc;
+
+    return mod.constVoid(scope, inst.base.src);
+}
+
+fn analyzeInstStoreToInferredPtr(
+    mod: *Module,
+    scope: *Scope,
+    inst: *zir.Inst.BinOp,
+) InnerError!*Inst {
+    const ptr = try resolveInst(mod, scope, inst.positionals.lhs);
+    const value = try resolveInst(mod, scope, inst.positionals.rhs);
+    const inferred_alloc = ptr.castTag(.constant).?.val.castTag(.inferred_alloc).?;
+    // Add the stored instruction to the set we will use to resolve peer types
+    // for the inferred allocation.
+    try inferred_alloc.data.stored_inst_list.append(scope.arena(), value);
+    // Create a new alloc with exactly the type the pointer wants.
+    // Later it gets cleaned up by aliasing the alloc we are supposed to be storing to.
+    const ptr_ty = try mod.simplePtrType(scope, inst.base.src, value.ty, true, .One);
+    const b = try mod.requireRuntimeBlock(scope, inst.base.src);
+    const bitcasted_ptr = try mod.addUnOp(b, inst.base.src, ptr_ty, .bitcast, ptr);
+    return mod.storePtr(scope, inst.base.src, bitcasted_ptr, value);
 }
 
 fn analyzeInstStore(mod: *Module, scope: *Scope, inst: *zir.Inst.BinOp) InnerError!*Inst {

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -30,8 +30,18 @@ pub fn analyzeInst(mod: *Module, scope: *Scope, old_inst: *zir.Inst) InnerError!
     switch (old_inst.tag) {
         .alloc => return analyzeInstAlloc(mod, scope, old_inst.castTag(.alloc).?),
         .alloc_mut => return analyzeInstAllocMut(mod, scope, old_inst.castTag(.alloc_mut).?),
-        .alloc_inferred => return analyzeInstAllocInferred(mod, scope, old_inst.castTag(.alloc_inferred).?),
-        .alloc_inferred_mut => return analyzeInstAllocInferredMut(mod, scope, old_inst.castTag(.alloc_inferred_mut).?),
+        .alloc_inferred => return analyzeInstAllocInferred(
+            mod,
+            scope,
+            old_inst.castTag(.alloc_inferred).?,
+            .inferred_alloc_const,
+        ),
+        .alloc_inferred_mut => return analyzeInstAllocInferred(
+            mod,
+            scope,
+            old_inst.castTag(.alloc_inferred_mut).?,
+            .inferred_alloc_mut,
+        ),
         .arg => return analyzeInstArg(mod, scope, old_inst.castTag(.arg).?),
         .bitcast_ref => return analyzeInstBitCastRef(mod, scope, old_inst.castTag(.bitcast_ref).?),
         .bitcast_result_ptr => return analyzeInstBitCastResultPtr(mod, scope, old_inst.castTag(.bitcast_result_ptr).?),
@@ -423,15 +433,18 @@ fn analyzeInstAlloc(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp) InnerErro
 
 fn analyzeInstAllocMut(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp) InnerError!*Inst {
     const var_type = try resolveType(mod, scope, inst.positionals.operand);
-    if (!var_type.isValidVarType(false)) {
-        return mod.fail(scope, inst.base.src, "variable of type '{}' must be const or comptime", .{var_type});
-    }
+    try mod.validateVarType(scope, inst.base.src, var_type);
     const ptr_type = try mod.simplePtrType(scope, inst.base.src, var_type, true, .One);
     const b = try mod.requireRuntimeBlock(scope, inst.base.src);
     return mod.addNoOp(b, inst.base.src, ptr_type, .alloc);
 }
 
-fn analyzeInstAllocInferred(mod: *Module, scope: *Scope, inst: *zir.Inst.NoOp) InnerError!*Inst {
+fn analyzeInstAllocInferred(
+    mod: *Module,
+    scope: *Scope,
+    inst: *zir.Inst.NoOp,
+    mut_tag: Type.Tag,
+) InnerError!*Inst {
     const val_payload = try scope.arena().create(Value.Payload.InferredAlloc);
     val_payload.* = .{
         .data = .{},
@@ -441,16 +454,16 @@ fn analyzeInstAllocInferred(mod: *Module, scope: *Scope, inst: *zir.Inst.NoOp) I
     // to a normal instruction when we hit `resolve_inferred_alloc`. So we append
     // to the block even though it is currently a `.constant`.
     const result = try mod.constInst(scope, inst.base.src, .{
-        .ty = Type.initTag(.inferred_alloc),
+        .ty = switch (mut_tag) {
+            .inferred_alloc_const => Type.initTag(.inferred_alloc_const),
+            .inferred_alloc_mut => Type.initTag(.inferred_alloc_mut),
+            else => unreachable,
+        },
         .val = Value.initPayload(&val_payload.base),
     });
     const block = try mod.requireFunctionBlock(scope, inst.base.src);
     try block.instructions.append(mod.gpa, result);
     return result;
-}
-
-fn analyzeInstAllocInferredMut(mod: *Module, scope: *Scope, inst: *zir.Inst.NoOp) InnerError!*Inst {
-    return mod.fail(scope, inst.base.src, "TODO implement analyzeInstAllocInferredMut", .{});
 }
 
 fn analyzeInstResolveInferredAlloc(
@@ -463,8 +476,15 @@ fn analyzeInstResolveInferredAlloc(
     const inferred_alloc = ptr_val.castTag(.inferred_alloc).?;
     const peer_inst_list = inferred_alloc.data.stored_inst_list.items;
     const final_elem_ty = try mod.resolvePeerTypes(scope, peer_inst_list);
-    const is_mut = true;
-    const final_ptr_ty = try mod.simplePtrType(scope, inst.base.src, final_elem_ty, is_mut, .One);
+    const var_is_mut = switch (ptr.ty.tag()) {
+        .inferred_alloc_const => false,
+        .inferred_alloc_mut => true,
+        else => unreachable,
+    };
+    if (var_is_mut) {
+        try mod.validateVarType(scope, inst.base.src, final_elem_ty);
+    }
+    const final_ptr_ty = try mod.simplePtrType(scope, inst.base.src, final_elem_ty, true, .One);
 
     // Change it to a normal alloc.
     ptr.ty = final_ptr_ty;

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -441,7 +441,7 @@ fn analyzeInstAllocInferred(mod: *Module, scope: *Scope, inst: *zir.Inst.NoOp) I
     // to a normal instruction when we hit `resolve_inferred_alloc`. So we append
     // to the block even though it is currently a `.constant`.
     const result = try mod.constInst(scope, inst.base.src, .{
-        .ty = try Type.Tag.inferred_alloc.create(scope.arena(), val_payload),
+        .ty = Type.initTag(.inferred_alloc),
         .val = Value.initPayload(&val_payload.base),
     });
     const block = try mod.requireFunctionBlock(scope, inst.base.src);

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -51,6 +51,21 @@ pub fn addCases(ctx: *TestContext) !void {
         , "");
     }
 
+    {
+        var case = ctx.exeFromCompiledC("inferred local const", .{});
+
+        case.addCompareOutput(
+            \\fn add(a: i32, b: i32) i32 {
+            \\    return a + b;
+            \\}
+            \\
+            \\export fn main() c_int {
+            \\    const x = add(1, 2);
+            \\    return x - 3;
+            \\}
+        , "");
+    }
+
     ctx.c("empty start function", linux_x64,
         \\export fn _start() noreturn {
         \\    unreachable;

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -52,7 +52,7 @@ pub fn addCases(ctx: *TestContext) !void {
     }
 
     {
-        var case = ctx.exeFromCompiledC("inferred local const", .{});
+        var case = ctx.exeFromCompiledC("inferred local const and var", .{});
 
         case.addCompareOutput(
             \\fn add(a: i32, b: i32) i32 {
@@ -61,7 +61,9 @@ pub fn addCases(ctx: *TestContext) !void {
             \\
             \\export fn main() c_int {
             \\    const x = add(1, 2);
-            \\    return x - 3;
+            \\    var y = add(3, 0);
+            \\    y -= x;
+            \\    return y;
             \\}
         , "");
     }

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1322,4 +1322,13 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , &[_][]const u8{":2:5: error: unused for label"});
     }
+
+    {
+        var case = ctx.exe("bad inferred variable type", linux_x64);
+        case.addError(
+            \\export fn foo() void {
+            \\    var x = null;
+            \\}
+        , &[_][]const u8{":2:9: error: variable of type '@Type(.Null)' must be const or comptime"});
+    }
 }


### PR DESCRIPTION
This patch introduces the following new things:

Types:
 - inferred_alloc
   - This is a special value that tracks a set of types that have been stored
     to an inferred allocation. It does not support most of the normal type queries.
     However it does respond to `isConstPtr`, `ptrSize`, `zigTypeTag`, etc.
   - The payload for this type simply points to the corresponding Value
     payload.

Values:
 - inferred_alloc
   - This is a special value that tracks a set of types that have been stored
     to an inferred allocation. It does not support any of the normal value queries.

ZIR instructions:
 - store_to_inferred_ptr,
   - Same as `store` but the type of the value being stored will be used to infer
     the pointer type.
 - resolve_inferred_alloc
   - Each `store_to_inferred_ptr` puts the type of the stored value into a set,
     and then `resolve_inferred_alloc` triggers peer type resolution on the set.
     The operand is a `alloc_inferred` or `alloc_inferred_mut` instruction, which
     is the allocation that needs to have its type inferred.

Changes to the C backend:
 * Implements the bitcast instruction. If the source and dest types
   are both pointers, uses a cast, otherwise uses memcpy.
 * Tests are run with -Wno-declaration-after-statement. Someday we can
   conform to this but not today.

Here is an example case:

```zig
fn add(a: i32, b: i32) i32 {
    return a + b;
}

export fn main() c_int {
    const x = add(1, 2);
    return x - 3;
}
```

In ZIR form it looks like this:

```zir
fn_body main { // unanalyzed
  %0 = dbg_stmt()
=>%1 = alloc_inferred()
  %2 = declval_in_module(Decl(add))
  %3 = deref(%2)
  %4 = param_type(%3, 0)
  %5 = const(TypedValue{ .ty = comptime_int, .val = 1})
  %6 = as(%4, %5)
  %7 = param_type(%3, 1)
  %8 = const(TypedValue{ .ty = comptime_int, .val = 2})
  %9 = as(%7, %8)
  %10 = call(%3, [%6, %9], modifier=auto)
=>%11 = store_to_inferred_ptr(%1, %10)
=>%12 = resolve_inferred_alloc(%1)
  %13 = dbg_stmt()
  %14 = ret_type()
  %15 = const(TypedValue{ .ty = comptime_int, .val = 3})
  %16 = sub(%10, %15)
  %17 = as(%14, %16)
  %18 = return(%17)
} // fn_body main
```

After analysis:

```zir
@unnamed$0 = primitive(i32)
@unnamed$1 = fntype([@unnamed$0, @unnamed$0], @unnamed$0, cc=Unspecified)
@add = fn(@unnamed$1, {
  %0 = arg("a") ; deaths=0b0 0x7f9e951b8818
  %1 = arg("b") ; deaths=0b0 0x7f9e951b8840
  %2 = dbg_stmt() ; deaths=0b1000000000000000 0x7f9e951b8860
  %3 = add(%0, %1) ; deaths=0b11 0x7f9e951b8898
  %4 = return(%3) ; deaths=0b1000000000000001 0x7f9e951b88c0
})
@unnamed$3 = str("main")
@unnamed$4 = export(@unnamed$3, "main")
@unnamed$5 = single_mut_ptr_type(@unnamed$0)
@unnamed$6 = int(1)
@unnamed$7 = as(@unnamed$0, @unnamed$6)
@unnamed$8 = int(2)
@unnamed$9 = as(@unnamed$0, @unnamed$8)
@unnamed$10 = single_mut_ptr_type(@unnamed$0)
@unnamed$11 = int(3)
@unnamed$12 = as(@unnamed$0, @unnamed$11)
@unnamed$13 = primitive(c_int)
@unnamed$14 = fntype([], @unnamed$13, cc=Unspecified)
@main = fn(@unnamed$14, {
  %0 = dbg_stmt() ; deaths=0b1000000000000000 0x7f9e951757a0
  %1 = alloc(@unnamed$5) ; deaths=0b0 0x7f9e95183e18
  %2 = call(@add, [@unnamed$7, @unnamed$9], modifier=auto) ; deaths=0b111 0x7f9e95183f88
  %3 = bitcast(@unnamed$10, %1) ; deaths=0b1 0x7f9e951bc028
  %4 = store(%3, %2) ; deaths=0b1000000000000001 0x7f9e951bc048
  %5 = dbg_stmt() ; deaths=0b1000000000000000 0x7f9e951bc0a0
  %6 = sub(%2, @unnamed$12) ; deaths=0b11 0x7f9e951bc128
  %7 = intcast(@unnamed$13, %6) ; deaths=0b1 0x7f9e951bc150
  %8 = return(%7) ; deaths=0b1000000000000001 0x7f9e951bc170
})
```

You can see there is some dead code that might be nice to eliminate in a follow-up pass.

I have not played around with very many test cases yet. Some interesting
ones that I want to look at before merging:

```zig
var x = blk: {
  var y = foo();
  y.a = 1;
  break :blk y;
};
```

In the above test case, x and y are supposed to alias.

```zig
var x = if (bar()) blk: {
  var y = foo();
  y.a = 1;
  break :blk y;
} else blk: {
  var z = baz();
  z.b = 1;
  break :blk z;
};
```

In the above test case, x, y, and z are supposed to alias.

I also haven't tested with `var` instead of `const` yet.