### PR TITLE
Improve documentation for ArrayList, ArrayListUnmanaged, etc.

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -142,6 +142,7 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
         /// Replace range of elements `list[start..start+len]` with `new_items`.
         /// Grows list if `len < new_items.len`.
         /// Shrinks list if `len > new_items.len`.
+        /// Invalidates pointers if this ArrayList is resized.
         pub fn replaceRange(self: *Self, start: usize, len: usize, new_items: SliceConst) !void {
             const after_range = start + len;
             const range = self.items[start..after_range];
@@ -486,6 +487,7 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
         /// Replace range of elements `list[start..start+len]` with `new_items`
         /// Grows list if `len < new_items.len`.
         /// Shrinks list if `len > new_items.len`
+        /// Invalidates pointers if this ArrayList is resized.
         pub fn replaceRange(self: *Self, allocator: *Allocator, start: usize, len: usize, new_items: SliceConst) !void {
             var managed = self.toManaged(allocator);
             try managed.replaceRange(start, len, new_items);

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -167,7 +167,7 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
             }
         }
 
-        /// Extend the list by 1 element.
+        /// Extend the list by 1 element. Allocates more memory as necessary.
         pub fn append(self: *Self, item: T) !void {
             const new_item_ptr = try self.addOne();
             new_item_ptr.* = item;


### PR DESCRIPTION
I made some improvements to `ArrayList` and related structs' documentation. My goal here is to help users avoid footguns from referencing invalid pointers after an ArrayList's size changes. Here's [an example](https://github.com/ziglang/zig/issues/7560) of that in `std`.

If the changes I made don't fit the spirit of the documentation (I couldn't find any existing guidelines) then please let me know and I will happily make changes to fit these rules.

I could not make stronger statements on pointer safety since `resizeFn` varies between allocators (e.g. PageAllocator, FixedBufferAllocator). I also avoided being more explicit in changes to `ArrayListUnmanaged` since users of that struct will generally have a better idea of their use case.

Feedback, criticism, comments, etc. are appreciated.