### PR TITLE
ci: fix `git describe`

### DIFF
--- a/ci/azure/linux_script
+++ b/ci/azure/linux_script
@@ -49,6 +49,8 @@ PATH=$PWD/$WASMTIME:$PATH
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
 git config core.abbrev 9
+git fetch --unshallow || true
+git fetch --tags
 
 export CC=gcc-7
 export CXX=g++-7

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -28,6 +28,8 @@ cd $ZIGDIR
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
 git config core.abbrev 9
+git fetch --unshallow || true
+git fetch --tags
 
 mkdir build
 cd build

--- a/ci/azure/windows_msvc_script.bat
+++ b/ci/azure/windows_msvc_script.bat
@@ -18,6 +18,8 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliar
 REM Make the `zig version` number consistent.
 REM This will affect the cmake command below.
 git.exe config core.abbrev 9
+git.exe fetch --unshallow
+git.exe fetch --tags
 
 mkdir %ZIGBUILDDIR%
 cd %ZIGBUILDDIR%

--- a/ci/drone/linux_script
+++ b/ci/drone/linux_script
@@ -14,6 +14,8 @@ pip3 install s3cmd
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
 git config core.abbrev 9
+git fetch --unshallow || true
+git fetch --tags
 
 mkdir build
 cd build

--- a/ci/srht/freebsd_script
+++ b/ci/srht/freebsd_script
@@ -20,6 +20,8 @@ cd $ZIGDIR
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
 git config core.abbrev 9
+git fetch --unshallow || true
+git fetch --tags
 
 # SourceHut reports that it is a terminal that supports escape codes, but it
 # is a filthy liar. Here we tell Zig to not try to send any terminal escape


### PR DESCRIPTION
git describe is used for version string creation, but it had to be
reverted in commit 69da6ba because it was broken in CI builds.
Azure Pipelines and Drone perform shallow clones by default.
This change reconfigures them to fetch history and tags. It adds tens of
seconds, which is negligible compared to overall build and test time.

Related: #6466, #6509, #7601