### PR TITLE
libstd: store bytes written as usize in counting writer

### DIFF
--- a/lib/std/io/counting_writer.zig
+++ b/lib/std/io/counting_writer.zig
@@ -10,7 +10,7 @@ const testing = std.testing;
 /// A Writer that counts how many bytes has been written to it.
 pub fn CountingWriter(comptime WriterType: type) type {
     return struct {
-        bytes_written: u64,
+        bytes_written: usize,
         child_stream: WriterType,
 
         pub const Error = WriterType.Error;


### PR DESCRIPTION
`std.io.counting_writer` currently stores bytes written as `u64` while
`std.io.counting_writer.write` returns bytes written as `usize`. This
commit suggests unifying both to always use `usize`. I think this makes
sense since on 32bit platforms will seldom (if ever) write more than
32bit worth of payload.

This fixes `MachO.zig` struct compilation errors on 32bit platforms,
and addresses partially issue #7630.

cc @LemonBoy 