### PR TITLE
Add PackedIntArray .initAllTo function

### DIFF
--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -205,7 +205,8 @@ pub fn PackedIntArrayEndian(comptime Int: type, comptime endian: builtin.Endian,
 
         ///Initialize all entries of a packed array to the same value
         pub fn initAllTo(int: Int) Self {
-            var self = @as(Self, undefined);
+            // TODO: use `var self = @as(Self, undefined);` https://github.com/ziglang/zig/issues/7635
+            var self = Self{ .bytes = [_]u8{0} ** total_bytes };
             self.setAll(int);
             return self;
         }

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -203,6 +203,13 @@ pub fn PackedIntArrayEndian(comptime Int: type, comptime endian: builtin.Endian,
             return self;
         }
 
+        ///Initialize all entries of a packed array to the same value
+        pub fn initAllTo(int: Int) Self {
+            var self = @as(Self, undefined);
+            self.setAll(int);
+            return self;
+        }
+
         ///Return the Int stored at index
         pub fn get(self: Self, index: usize) Int {
             debug.assert(index < int_count);
@@ -213,6 +220,14 @@ pub fn PackedIntArrayEndian(comptime Int: type, comptime endian: builtin.Endian,
         pub fn set(self: *Self, index: usize, int: Int) void {
             debug.assert(index < int_count);
             return Io.set(&self.bytes, index, 0, int);
+        }
+
+        ///Set all entries of a packed array to the same value
+        pub fn setAll(self: *Self, int: Int) void {
+            var i: usize = 0;
+            while (i < int_count) : (i += 1) {
+                self.set(i, int);
+            }
         }
 
         ///Create a PackedIntSlice of the array from given start to given end
@@ -365,7 +380,15 @@ test "PackedIntArray init" {
     const PackedArray = PackedIntArray(u3, 8);
     var packed_array = PackedArray.init([_]u3{ 0, 1, 2, 3, 4, 5, 6, 7 });
     var i = @as(usize, 0);
-    while (i < packed_array.len()) : (i += 1) testing.expect(packed_array.get(i) == i);
+    while (i < packed_array.len()) : (i += 1) testing.expectEqual(@intCast(u3, i), packed_array.get(i));
+}
+
+test "PackedIntArray initAllTo" {
+    if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
+    const PackedArray = PackedIntArray(u3, 8);
+    var packed_array = PackedArray.initAllTo(5);
+    var i = @as(usize, 0);
+    while (i < packed_array.len()) : (i += 1) testing.expectEqual(@as(u3, 5), packed_array.get(i));
 }
 
 test "PackedIntSlice" {


### PR DESCRIPTION
Useful helper function.

Putting up this PR now as this gets close to tickling a stage1 bug:
Attempting `comptime PackedArray.initAllTo(5)` results in
```
Semantic Analysis [947/1269] Assertion failed at /home/daurnimator/src/zig/src/stage1/codegen.cpp:7611 in gen_const_val. This is a bug in the Zig compiler.
Unable to dump stack trace: debug info stripped
```