### PR TITLE
stage1: Use correct format specifier for size_t parameters

### DIFF
--- a/src/stage1/os.hpp
+++ b/src/stage1/os.hpp
@@ -46,7 +46,7 @@
 #endif
 
 #if defined(ZIG_OS_WINDOWS)
-#define ZIG_PRI_usize "I64u"
+#define ZIG_PRI_usize "Iu"
 #define ZIG_PRI_i64 "I64d"
 #define ZIG_PRI_u64 "I64u"
 #define ZIG_PRI_llu "I64u"


### PR DESCRIPTION
Use `Iu` on Windows, the integer width depends on the target being
a 32bit or a 64bit one.

This should fix the garbled error messages observed in #7614.