### PR TITLE
mark TypeInfo strings as null-terminated

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -269,7 +269,7 @@ pub const TypeInfo = union(enum) {
     /// This data structure is used by the Zig language code generation and
     /// therefore must be kept in sync with the compiler implementation.
     pub const StructField = struct {
-        name: []const u8,
+        name: [:0]const u8,
         field_type: type,
         default_value: anytype,
         is_comptime: bool,
@@ -301,7 +301,7 @@ pub const TypeInfo = union(enum) {
     /// This data structure is used by the Zig language code generation and
     /// therefore must be kept in sync with the compiler implementation.
     pub const Error = struct {
-        name: []const u8,
+        name: [:0]const u8,
     };
 
     /// This data structure is used by the Zig language code generation and
@@ -311,7 +311,7 @@ pub const TypeInfo = union(enum) {
     /// This data structure is used by the Zig language code generation and
     /// therefore must be kept in sync with the compiler implementation.
     pub const EnumField = struct {
-        name: []const u8,
+        name: [:0]const u8,
         value: comptime_int,
     };
 
@@ -328,7 +328,7 @@ pub const TypeInfo = union(enum) {
     /// This data structure is used by the Zig language code generation and
     /// therefore must be kept in sync with the compiler implementation.
     pub const UnionField = struct {
-        name: []const u8,
+        name: [:0]const u8,
         field_type: type,
         alignment: comptime_int,
     };
@@ -389,7 +389,7 @@ pub const TypeInfo = union(enum) {
     /// This data structure is used by the Zig language code generation and
     /// therefore must be kept in sync with the compiler implementation.
     pub const Declaration = struct {
-        name: []const u8,
+        name: [:0]const u8,
         is_pub: bool,
         data: Data,
 
@@ -408,9 +408,9 @@ pub const TypeInfo = union(enum) {
                 is_var_args: bool,
                 is_extern: bool,
                 is_export: bool,
-                lib_name: ?[]const u8,
+                lib_name: ?[:0]const u8,
                 return_type: type,
-                arg_names: []const []const u8,
+                arg_names: []const [:0]const u8,
 
                 /// This data structure is used by the Zig language code generation and
                 /// therefore must be kept in sync with the compiler implementation.


### PR DESCRIPTION
Related Issue: https://github.com/ziglang/zig/pull/7644

I have some code that uses reflection to iterate over a set of function declarations.  It then passes these function names to a function that loads them (like `dlsym` https://linux.die.net/man/3/dlsym).  However, the loader function requires the name string be null-terminated, but it looks like the strings within TypeInfo aren't declared as being null-terminated.

Since string literals are guaranteed to be null-terminated, it is my guess that these strings within `TypeInfo` are also.  I've updated the `TypeInfo` definition to indicate they are, however, I haven't checked yet that the implementation guarantees this.