### PR TITLE
stage2 x86_64: fix bug in Function.gen

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -543,13 +543,10 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                         if (self.code.items.len >= math.maxInt(i32)) {
                             return self.fail(self.src, "unable to perform relocation: jump too far", .{});
                         }
-                        for (self.exitlude_jump_relocs.items) |jmp_reloc| {
+                        if (self.exitlude_jump_relocs.items.len == 1) {
+                            self.code.items.len -= 5;
+                        } else for (self.exitlude_jump_relocs.items) |jmp_reloc| {
                             const amt = self.code.items.len - (jmp_reloc + 4);
-                            // If it wouldn't jump at all, elide it.
-                            if (amt == 0) {
-                                self.code.items.len -= 5;
-                                continue;
-                            }
                             const s32_amt = @intCast(i32, amt);
                             mem.writeIntLittle(i32, self.code.items[jmp_reloc..][0..4], s32_amt);
                         }


### PR DESCRIPTION
Previously, the x86_64 backend would remove code for exitlude relocs if the jump amount was 0. This causes issues as earlier jumps rely on the jump being present at the same address.

This comment in the same section for the ARM backend also explains this behavior.

https://github.com/ziglang/zig/blob/a9c75a2b48f202d5c55097877499942ed07cc2e8/src/codegen.zig#L611-L625

Example code which doesn't segfault anymore with the change:

```zig
export fn _start() noreturn {
    assert(answer(42) == 123);
    exit();
}

fn answer(n: u32) u32 {
    if (n == 42) {
        return 123;
    } else {
        return 69;
    }
}

fn assert(ok: bool) void {
    if (!ok) unreachable; // assertion failure
}

fn exit() noreturn {
    asm volatile ("syscall"
        :
        : [number] "{rax}" (231),
          [arg1] "{rdi}" (0)
        : "rcx", "r11", "memory"
    );
    unreachable;
}
```