### PR TITLE
remove z/Z format specifiers

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1851,25 +1851,25 @@ pub const LibExeObjStep = struct {
         const out = self.build_options_contents.outStream();
         switch (T) {
             []const []const u8 => {
-                out.print("pub const {z}: []const []const u8 = &[_][]const u8{{\n", .{name}) catch unreachable;
+                out.print("pub const {}: []const []const u8 = &[_][]const u8{{\n", .{std.zig.fmtId(name)}) catch unreachable;
                 for (value) |slice| {
-                    out.print("    \"{Z}\",\n", .{slice}) catch unreachable;
+                    out.print("    \"{}\",\n", .{std.zig.fmtEscapes(slice)}) catch unreachable;
                 }
                 out.writeAll("};\n") catch unreachable;
                 return;
             },
             [:0]const u8 => {
-                out.print("pub const {z}: [:0]const u8 = \"{Z}\";\n", .{ name, value }) catch unreachable;
+                out.print("pub const {}: [:0]const u8 = \"{}\";\n", .{ std.zig.fmtId(name), std.zig.fmtEscapes(value) }) catch unreachable;
                 return;
             },
             []const u8 => {
-                out.print("pub const {z}: []const u8 = \"{Z}\";\n", .{ name, value }) catch unreachable;
+                out.print("pub const {}: []const u8 = \"{}\";\n", .{ std.zig.fmtId(name), std.zig.fmtEscapes(value) }) catch unreachable;
                 return;
             },
             ?[]const u8 => {
-                out.print("pub const {z}: ?[]const u8 = ", .{name}) catch unreachable;
+                out.print("pub const {}: ?[]const u8 = ", .{std.zig.fmtId(name)}) catch unreachable;
                 if (value) |payload| {
-                    out.print("\"{Z}\";\n", .{payload}) catch unreachable;
+                    out.print("\"{}\";\n", .{std.zig.fmtEscapes(payload)}) catch unreachable;
                 } else {
                     out.writeAll("null;\n") catch unreachable;
                 }
@@ -1877,14 +1877,14 @@ pub const LibExeObjStep = struct {
             },
             std.builtin.Version => {
                 out.print(
-                    \\pub const {z}: @import("builtin").Version = .{{
+                    \\pub const {}: @import("builtin").Version = .{{
                     \\    .major = {d},
                     \\    .minor = {d},
                     \\    .patch = {d},
                     \\}};
                     \\
                 , .{
-                    name,
+                    std.zig.fmtId(name),
 
                     value.major,
                     value.minor,
@@ -1893,23 +1893,23 @@ pub const LibExeObjStep = struct {
             },
             std.SemanticVersion => {
                 out.print(
-                    \\pub const {z}: @import("std").SemanticVersion = .{{
+                    \\pub const {}: @import("std").SemanticVersion = .{{
                     \\    .major = {d},
                     \\    .minor = {d},
                     \\    .patch = {d},
                     \\
                 , .{
-                    name,
+                    std.zig.fmtId(name),
 
                     value.major,
                     value.minor,
                     value.patch,
                 }) catch unreachable;
                 if (value.pre) |some| {
-                    out.print("    .pre = \"{Z}\",\n", .{some}) catch unreachable;
+                    out.print("    .pre = \"{}\",\n", .{std.zig.fmtEscapes(some)}) catch unreachable;
                 }
                 if (value.build) |some| {
-                    out.print("    .build = \"{Z}\",\n", .{some}) catch unreachable;
+                    out.print("    .build = \"{}\",\n", .{std.zig.fmtEscapes(some)}) catch unreachable;
                 }
                 out.writeAll("};\n") catch unreachable;
                 return;
@@ -1918,15 +1918,15 @@ pub const LibExeObjStep = struct {
         }
         switch (@typeInfo(T)) {
             .Enum => |enum_info| {
-                out.print("pub const {z} = enum {{\n", .{@typeName(T)}) catch unreachable;
+                out.print("pub const {} = enum {{\n", .{std.zig.fmtId(@typeName(T))}) catch unreachable;
                 inline for (enum_info.fields) |field| {
-                    out.print("    {z},\n", .{field.name}) catch unreachable;
+                    out.print("    {},\n", .{std.zig.fmtId(field.name)}) catch unreachable;
                 }
                 out.writeAll("};\n") catch unreachable;
             },
             else => {},
         }
-        out.print("pub const {z}: {s} = {};\n", .{ name, @typeName(T), value }) catch unreachable;
+        out.print("pub const {}: {s} = {};\n", .{ std.zig.fmtId(name), @typeName(T), value }) catch unreachable;
     }
 
     /// The value is the path in the cache dir.
@@ -2156,7 +2156,7 @@ pub const LibExeObjStep = struct {
             // Render build artifact options at the last minute, now that the path is known.
             for (self.build_options_artifact_args.items) |item| {
                 const out = self.build_options_contents.writer();
-                out.print("pub const {s}: []const u8 = \"{Z}\";\n", .{ item.name, item.artifact.getOutputPath() }) catch unreachable;
+                out.print("pub const {s}: []const u8 = \"{}\";\n", .{ item.name, std.zig.fmtEscapes(item.artifact.getOutputPath()) }) catch unreachable;
             }
 
             const build_options_file = try fs.path.join(

--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -38,7 +38,7 @@ pub const PreopenType = union(PreopenTypeTag) {
     pub fn format(self: Self, comptime fmt: []const u8, options: std.fmt.FormatOptions, out_stream: anytype) !void {
         try out_stream.print("PreopenType{{ ", .{});
         switch (self) {
-            PreopenType.Dir => |path| try out_stream.print(".Dir = '{z}'", .{path}),
+            PreopenType.Dir => |path| try out_stream.print(".Dir = '{}'", .{std.zig.fmtId(path)}),
         }
         return out_stream.print(" }}", .{});
     }

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -8,6 +8,8 @@ const tokenizer = @import("zig/tokenizer.zig");
 
 pub const Token = tokenizer.Token;
 pub const Tokenizer = tokenizer.Tokenizer;
+pub const fmtId = @import("zig/fmt.zig").fmtId;
+pub const fmtEscapes = @import("zig/fmt.zig").fmtEscapes;
 pub const parse = @import("zig/parse.zig").parse;
 pub const parseStringLiteral = @import("zig/string_literal.zig").parse;
 pub const render = @import("zig/render.zig").render;

--- a/lib/std/zig/fmt.zig
+++ b/lib/std/zig/fmt.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const mem = std.mem;
+
+/// Print the string as a Zig identifier escaping it with @"" syntax if needed.
+pub fn formatId(
+    bytes: []const u8,
+    comptime fmt: []const u8,
+    options: std.fmt.FormatOptions,
+    writer: anytype,
+) !void {
+    if (isValidId(bytes)) {
+        return writer.writeAll(bytes);
+    }
+    try writer.writeAll("@\"");
+    try formatEscapes(bytes, fmt, options, writer);
+    try writer.writeByte('"');
+}
+
+/// Return a Formatter for a Zig identifier
+pub fn fmtId(bytes: []const u8) std.fmt.Formatter(formatId) {
+    return .{ .data = bytes };
+}
+
+pub fn isValidId(bytes: []const u8) bool {
+    for (bytes) |c, i| {
+        switch (c) {
+            '_', 'a'...'z', 'A'...'Z' => {},
+            '0'...'9' => if (i == 0) return false,
+            else => return false,
+        }
+    }
+    return std.zig.Token.getKeyword(bytes) == null;
+}
+
+pub fn formatEscapes(
+    bytes: []const u8,
+    comptime fmt: []const u8,
+    options: std.fmt.FormatOptions,
+    writer: anytype,
+) !void {
+    for (bytes) |byte| switch (byte) {
+        '\n' => try writer.writeAll("\\n"),
+        '\r' => try writer.writeAll("\\r"),
+        '\t' => try writer.writeAll("\\t"),
+        '\\' => try writer.writeAll("\\\\"),
+        '"' => try writer.writeAll("\\\""),
+        '\'' => try writer.writeAll("\\'"),
+        ' ', '!', '#'...'&', '('...'[', ']'...'~' => try writer.writeByte(byte),
+        // Use hex escapes for rest any unprintable characters.
+        else => {
+            try writer.writeAll("\\x");
+            try std.fmt.formatInt(byte, 16, false, .{ .width = 2, .fill = '0' }, writer);
+        },
+    };
+}
+
+/// Return a Formatter for Zig Escapes
+pub fn fmtEscapes(bytes: []const u8) std.fmt.Formatter(formatEscapes) {
+    return .{ .data = bytes };
+}
+
+test "escape invalid identifiers" {
+    try std.fmt.testFmt("@\"while\"", "{}", .{fmtId("while")});
+    try std.fmt.testFmt("hello", "{}", .{fmtId("hello")});
+    try std.fmt.testFmt("@\"11\\\"23\"", "{}", .{fmtId("11\"23")});
+    try std.fmt.testFmt("@\"11\\x0f23\"", "{}", .{fmtId("11\x0F23")});
+    try std.fmt.testFmt("\\x0f", "{}", .{fmtEscapes("\x0f")});
+    try std.fmt.testFmt(
+        \\" \\ hi \x07 \x11 \" derp \'"
+    , "\"{}\"", .{fmtEscapes(" \\ hi \x07 \x11 \" derp '")});
+}

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2703,27 +2703,27 @@ pub fn generateBuiltinZigSource(comp: *Compilation, allocator: *Allocator) ![]u8
         \\pub const arch = Target.current.cpu.arch;
         \\/// Deprecated
         \\pub const endian = Target.current.cpu.arch.endian();
-        \\pub const output_mode = OutputMode.{z};
-        \\pub const link_mode = LinkMode.{z};
+        \\pub const output_mode = OutputMode.{};
+        \\pub const link_mode = LinkMode.{};
         \\pub const is_test = {};
         \\pub const single_threaded = {};
-        \\pub const abi = Abi.{z};
+        \\pub const abi = Abi.{};
         \\pub const cpu: Cpu = Cpu{{
-        \\    .arch = .{z},
-        \\    .model = &Target.{z}.cpu.{z},
-        \\    .features = Target.{z}.featureSet(&[_]Target.{z}.Feature{{
+        \\    .arch = .{},
+        \\    .model = &Target.{}.cpu.{},
+        \\    .features = Target.{}.featureSet(&[_]Target.{}.Feature{{
         \\
     , .{
-        @tagName(comp.bin_file.options.output_mode),
-        @tagName(comp.bin_file.options.link_mode),
+        std.zig.fmtId(@tagName(comp.bin_file.options.output_mode)),
+        std.zig.fmtId(@tagName(comp.bin_file.options.link_mode)),
         comp.bin_file.options.is_test,
         comp.bin_file.options.single_threaded,
-        @tagName(target.abi),
-        @tagName(target.cpu.arch),
-        generic_arch_name,
-        target.cpu.model.name,
-        generic_arch_name,
-        generic_arch_name,
+        std.zig.fmtId(@tagName(target.abi)),
+        std.zig.fmtId(@tagName(target.cpu.arch)),
+        std.zig.fmtId(generic_arch_name),
+        std.zig.fmtId(target.cpu.model.name),
+        std.zig.fmtId(generic_arch_name),
+        std.zig.fmtId(generic_arch_name),
     });
 
     for (target.cpu.arch.allFeaturesList()) |feature, index_usize| {
@@ -2742,10 +2742,10 @@ pub fn generateBuiltinZigSource(comp: *Compilation, allocator: *Allocator) ![]u8
         \\    }}),
         \\}};
         \\pub const os = Os{{
-        \\    .tag = .{z},
+        \\    .tag = .{},
         \\    .version_range = .{{
     ,
-        .{@tagName(target.os.tag)},
+        .{std.zig.fmtId(@tagName(target.os.tag))},
     );
 
     switch (target.os.getVersionRange()) {
@@ -2828,8 +2828,8 @@ pub fn generateBuiltinZigSource(comp: *Compilation, allocator: *Allocator) ![]u8
         (comp.bin_file.options.skip_linker_dependencies and comp.bin_file.options.parent_compilation_link_libc);
 
     try buffer.writer().print(
-        \\pub const object_format = ObjectFormat.{z};
-        \\pub const mode = Mode.{z};
+        \\pub const object_format = ObjectFormat.{};
+        \\pub const mode = Mode.{};
         \\pub const link_libc = {};
         \\pub const link_libcpp = {};
         \\pub const have_error_return_tracing = {};
@@ -2837,11 +2837,11 @@ pub fn generateBuiltinZigSource(comp: *Compilation, allocator: *Allocator) ![]u8
         \\pub const position_independent_code = {};
         \\pub const position_independent_executable = {};
         \\pub const strip_debug_info = {};
-        \\pub const code_model = CodeModel.{z};
+        \\pub const code_model = CodeModel.{};
         \\
     , .{
-        @tagName(comp.bin_file.options.object_format),
-        @tagName(comp.bin_file.options.optimize_mode),
+        std.zig.fmtId(@tagName(comp.bin_file.options.object_format)),
+        std.zig.fmtId(@tagName(comp.bin_file.options.optimize_mode)),
         link_libc,
         comp.bin_file.options.link_libcpp,
         comp.bin_file.options.error_return_tracing,
@@ -2849,7 +2849,7 @@ pub fn generateBuiltinZigSource(comp: *Compilation, allocator: *Allocator) ![]u8
         comp.bin_file.options.pic,
         comp.bin_file.options.pie,
         comp.bin_file.options.strip,
-        @tagName(comp.bin_file.options.machine_code_model),
+        std.zig.fmtId(@tagName(comp.bin_file.options.machine_code_model)),
     });
 
     if (comp.bin_file.options.is_test) {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -169,8 +169,8 @@ pub const DeclGen = struct {
                     .undef, .empty_struct_value, .empty_array => try writer.writeAll("{}"),
                     .bytes => {
                         const bytes = val.castTag(.bytes).?.data;
-                        // TODO: make our own C string escape instead of using {Z}
-                        try writer.print("\"{Z}\"", .{bytes});
+                        // TODO: make our own C string escape instead of using std.zig.fmtEscapes
+                        try writer.print("\"{}\"", .{std.zig.fmtEscapes(bytes)});
                     },
                     else => {
                         // Fall back to generic implementation.

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -2031,7 +2031,7 @@ fn transStringLiteral(
             const bytes_ptr = stmt.getString_bytes_begin_size(&len);
             const str = bytes_ptr[0..len];
 
-            const token = try appendTokenFmt(rp.c, .StringLiteral, "\"{Z}\"", .{str});
+            const token = try appendTokenFmt(rp.c, .StringLiteral, "\"{}\"", .{std.zig.fmtEscapes(str)});
             const node = try rp.c.arena.create(ast.Node.OneToken);
             node.* = .{
                 .base = .{ .tag = .StringLiteral },
@@ -2944,7 +2944,8 @@ fn transCharLiteral(
                 if (val > 255)
                     break :blk try transCreateNodeInt(rp.c, val);
             }
-            const token = try appendTokenFmt(rp.c, .CharLiteral, "'{Z}'", .{@intCast(u8, val)});
+            const val_array = [_]u8 { @intCast(u8, val) };
+            const token = try appendTokenFmt(rp.c, .CharLiteral, "'{}'", .{std.zig.fmtEscapes(&val_array)});
             const node = try rp.c.arena.create(ast.Node.OneToken);
             node.* = .{
                 .base = .{ .tag = .CharLiteral },
@@ -5315,7 +5316,7 @@ fn isZigPrimitiveType(name: []const u8) bool {
 }
 
 fn appendIdentifier(c: *Context, name: []const u8) !ast.TokenIndex {
-    return appendTokenFmt(c, .Identifier, "{z}", .{name});
+    return appendTokenFmt(c, .Identifier, "{}", .{std.zig.fmtId(name)});
 }
 
 fn transCreateNodeIdentifier(c: *Context, name: []const u8) !*ast.Node {

--- a/src/value.zig
+++ b/src/value.zig
@@ -491,8 +491,8 @@ pub const Value = extern union {
                 val = elem_ptr.array_ptr;
             },
             .empty_array => return out_stream.writeAll(".{}"),
-            .enum_literal => return out_stream.print(".{z}", .{self.castTag(.enum_literal).?.data}),
-            .bytes => return out_stream.print("\"{Z}\"", .{self.castTag(.bytes).?.data}),
+            .enum_literal => return out_stream.print(".{}", .{std.zig.fmtId(self.castTag(.enum_literal).?.data)}),
+            .bytes => return out_stream.print("\"{}\"", .{std.zig.fmtEscapes(self.castTag(.bytes).?.data)}),
             .repeated => {
                 try out_stream.writeAll("(repeated) ");
                 val = val.castTag(.repeated).?.data;

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -1308,17 +1308,17 @@ const Writer = struct {
                 try stream.writeByte('}');
             },
             bool => return stream.writeByte("01"[@boolToInt(param)]),
-            []u8, []const u8 => return stream.print("\"{Z}\"", .{param}),
+            []u8, []const u8 => return stream.print("\"{}\"", .{std.zig.fmtEscapes(param)}),
             BigIntConst, usize => return stream.print("{}", .{param}),
             TypedValue => return stream.print("TypedValue{{ .ty = {}, .val = {}}}", .{ param.ty, param.val }),
             *IrModule.Decl => return stream.print("Decl({s})", .{param.name}),
             *Inst.Block => {
                 const name = self.block_table.get(param).?;
-                return stream.print("\"{Z}\"", .{name});
+                return stream.print("\"{}\"", .{std.zig.fmtEscapes(name)});
             },
             *Inst.Loop => {
                 const name = self.loop_table.get(param).?;
-                return stream.print("\"{Z}\"", .{name});
+                return stream.print("\"{}\"", .{std.zig.fmtEscapes(name)});
             },
             [][]const u8 => {
                 try stream.writeByte('[');
@@ -1326,7 +1326,7 @@ const Writer = struct {
                     if (i != 0) {
                         try stream.writeAll(", ");
                     }
-                    try stream.print("\"{Z}\"", .{str});
+                    try stream.print("\"{}\"", .{std.zig.fmtEscapes(str)});
                 }
                 try stream.writeByte(']');
             },


### PR DESCRIPTION
Zig's format system is flexible enough to add custom formatters.  This PR removes the new z/Z format specifiers that were added for printing Zig identifiers and replaces them with custom formatters.