### PR TITLE
stage2: basic fn args for aarch64

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -298,7 +298,7 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
     self.base.file = file;
 
     // Create dSYM bundle.
-    const d_sym_path = try fmt.allocPrint(allocator, "{}.dSYM/Contents/Resources/DWARF/", .{sub_path});
+    const d_sym_path = try fmt.allocPrint(allocator, "{s}.dSYM/Contents/Resources/DWARF/", .{sub_path});
     defer allocator.free(d_sym_path);
     var d_sym_bundle = try options.emit.?.directory.handle.makeOpenPath(d_sym_path, .{});
     defer d_sym_bundle.close();

--- a/test/stage2/aarch64.zig
+++ b/test/stage2/aarch64.zig
@@ -155,4 +155,48 @@ pub fn addCases(ctx: *TestContext) !void {
             "Hello, World!\n",
         );
     }
+
+    {
+        var case = ctx.exe("exit fn taking argument", macos_aarch64);
+
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    exit(0);
+            \\}
+            \\
+            \\fn exit(ret: usize) noreturn {
+            \\    asm volatile ("svc #0x80"
+            \\        :
+            \\        : [number] "{x16}" (1),
+            \\          [arg1] "{x0}" (ret)
+            \\        : "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "",
+        );
+    }
+
+    {
+        var case = ctx.exe("exit fn taking argument", linux_aarch64);
+
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    exit(0);
+            \\}
+            \\
+            \\fn exit(ret: usize) noreturn {
+            \\    asm volatile ("svc #0"
+            \\        :
+            \\        : [number] "{x8}" (93),
+            \\          [arg1] "{x0}" (ret)
+            \\        : "memory", "cc"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "",
+        );
+    }
 }


### PR DESCRIPTION
This PR:
* implements basic function params for `aarch64` architecture
* implements missing `.register` prong in `genSetReg` on `aarch64`
* adds some stage2 tests to that effect
* fixes missing string format specifier in Mach-O linker used to generate output path of the debugging symbols bundle