### PR TITLE
Fixes missing error prong in std.os.send

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4853,6 +4853,7 @@ pub fn send(
         error.NotDir => unreachable,
         error.NetworkUnreachable => unreachable,
         error.AddressNotAvailable => unreachable,
+        error.SocketNotConnected => unreachable,
         else => |e| return e,
     };
 }


### PR DESCRIPTION
In #7481, the function was rendered unusable due to a missing switch prong