### PR TITLE
std.c add syslog

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -353,6 +353,11 @@ pub extern "c" fn setrlimit(resource: rlimit_resource, rlim: *const rlimit) c_in
 
 pub extern "c" fn fmemopen(noalias buf: ?*c_void, size: usize, noalias mode: [*:0]const u8) ?*FILE;
 
+pub extern "c" fn syslog(priority: c_int, message: [*:0]const u8, ...) void;
+pub extern "c" fn openlog(ident: [*:0]const u8, logopt: c_int, facility: c_int) void;
+pub extern "c" fn closelog() void;
+pub extern "c" fn setlogmask(maskpri: c_int) c_int;
+
 pub const max_align_t = if (std.Target.current.abi == .msvc)
     f64
 else if (std.Target.current.isDarwin())

--- a/lib/std/os/bits.zig
+++ b/lib/std/os/bits.zig
@@ -34,3 +34,22 @@ pub const iovec_const = extern struct {
     iov_base: [*]const u8,
     iov_len: usize,
 };
+
+// syslog
+
+/// system is unusable
+pub const LOG_EMERG = 0;
+/// action must be taken immediately
+pub const LOG_ALERT = 1;
+/// critical conditions
+pub const LOG_CRIT = 2;
+/// error conditions
+pub const LOG_ERR = 3;
+/// warning conditions
+pub const LOG_WARNING = 4;
+/// normal but significant condition
+pub const LOG_NOTICE = 5;
+/// informational
+pub const LOG_INFO = 6;
+/// debug-level messages
+pub const LOG_DEBUG = 7;


### PR DESCRIPTION
I guess in theory the priority constants could be different on some weird systems.
These are standardized in RFC 5424, but that's the network protocol.
Let me know what you think about placing them in `std/os/bits.zig`