### PR TITLE
spinlock: Default SpinLock.state to .Unlocked to allow default struct initialization

### DIFF
--- a/lib/std/spinlock.zig
+++ b/lib/std/spinlock.zig
@@ -7,7 +7,7 @@ const std = @import("std.zig");
 const builtin = @import("builtin");
 
 pub const SpinLock = struct {
-    state: State,
+    state: State = .Unlocked,
 
     const State = enum(u8) {
         Unlocked,


### PR DESCRIPTION
`std.Mutex`, which is default struct initialized in some places (e.g. `GeneralPurposeAllocator`), is possibly defined to be `std.SpinLock` as a default (e.g. on the freestanding target), which would then raise a compile error when trying to use `std.Mutex` or one of its users (e.g. `GeneralPurposeAllocator`).

This is consistent with the other types of mutexes.