### PR TITLE
builder: propagate env_map for child processes

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1038,6 +1038,7 @@ pub const Builder = struct {
         child.stdin_behavior = .Ignore;
         child.stdout_behavior = .Pipe;
         child.stderr_behavior = stderr_behavior;
+        child.env_map = self.env_map;
 
         try child.spawn();
 


### PR DESCRIPTION
two `spawn.child*()` call-sites in `lib/std/build.zig` and one of them did not propagate env_map; this patch makes them both propagate env_map which then makes things like this effective:

```
b.env_map.set("FOO", "1") catch unreachable;
b.env_map.set("ZIG_SYSTEM_LINKER_HACK", "1") catch unreachable;
```