### PR TITLE
stage1: SPARCv9 f128 enablement

### DIFF
--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -277,6 +277,25 @@ comptime {
         @export(@import("compiler_rt/aullrem.zig")._aullrem, .{ .name = "\x01__aullrem", .linkage = strong_linkage });
     }
 
+    if (builtin.arch.isSPARC()) {
+        // SPARC systems use a different naming scheme
+        @export(@import("compiler_rt/sparc.zig")._Qp_add, .{ .name = "_Qp_add", .linkage = linkage });
+        @export(@import("compiler_rt/sparc.zig")._Qp_div, .{ .name = "_Qp_div", .linkage = linkage });
+        @export(@import("compiler_rt/sparc.zig")._Qp_mul, .{ .name = "_Qp_mul", .linkage = linkage });
+        @export(@import("compiler_rt/sparc.zig")._Qp_sub, .{ .name = "_Qp_sub", .linkage = linkage });
+
+        @export(@import("compiler_rt/sparc.zig")._Qp_cmp, .{ .name = "_Qp_cmp", .linkage = linkage });
+        @export(@import("compiler_rt/sparc.zig")._Qp_feq, .{ .name = "_Qp_feq", .linkage = linkage });
+        @export(@import("compiler_rt/sparc.zig")._Qp_fne, .{ .name = "_Qp_fne", .linkage = linkage });
+        @export(@import("compiler_rt/sparc.zig")._Qp_flt, .{ .name = "_Qp_flt", .linkage = linkage });
+        @export(@import("compiler_rt/sparc.zig")._Qp_fle, .{ .name = "_Qp_fle", .linkage = linkage });
+        @export(@import("compiler_rt/sparc.zig")._Qp_fgt, .{ .name = "_Qp_fgt", .linkage = linkage });
+        @export(@import("compiler_rt/sparc.zig")._Qp_fge, .{ .name = "_Qp_fge", .linkage = linkage });
+
+        @export(@import("compiler_rt/sparc.zig")._Qp_dtoq, .{ .name = "_Qp_dtoq", .linkage = linkage });
+        @export(@import("compiler_rt/sparc.zig")._Qp_qtod, .{ .name = "_Qp_qtod", .linkage = linkage });
+    }
+
     if (builtin.os.tag == .windows) {
         // Default stack-probe functions emitted by LLVM
         if (is_mingw) {

--- a/lib/std/special/compiler_rt/sparc.zig
+++ b/lib/std/special/compiler_rt/sparc.zig
@@ -38,33 +38,33 @@ pub fn _Qp_sub(c: *f128, a: *f128, b: *f128) callconv(.C) void {
 
 // Comparison
 
-pub fn _Qp_cmp(a: f128, b: f128) callconv(.C) i32 {
-    return @enumToInt(@import("compareXf2.zig").cmp(f128, FCMP, a, b));
+pub fn _Qp_cmp(a: *f128, b: *f128) callconv(.C) i32 {
+    return @enumToInt(@import("compareXf2.zig").cmp(f128, FCMP, a.*, b.*));
 }
 
 pub fn _Qp_feq(a: *f128, b: *f128) callconv(.C) bool {
-    return _Qp_cmp(a.*, b.*) == @enumToInt(FCMP.Equal);
+    return _Qp_cmp(a, b) == @enumToInt(FCMP.Equal);
 }
 
 pub fn _Qp_fne(a: *f128, b: *f128) callconv(.C) bool {
-    return _Qp_cmp(a.*, b.*) != @enumToInt(FCMP.Equal);
+    return _Qp_cmp(a, b) != @enumToInt(FCMP.Equal);
 }
 
 pub fn _Qp_flt(a: *f128, b: *f128) callconv(.C) bool {
-    return _Qp_cmp(a.*, b.*) == @enumToInt(FCMP.Less);
+    return _Qp_cmp(a, b) == @enumToInt(FCMP.Less);
 }
 
 pub fn _Qp_fle(a: *f128, b: *f128) callconv(.C) bool {
-    const cmp = _Qp_cmp(a.*, b.*);
+    const cmp = _Qp_cmp(a, b);
     return cmp == @enumToInt(FCMP.Less) or cmp == @enumToInt(FCMP.Equal);
 }
 
 pub fn _Qp_fgt(a: *f128, b: *f128) callconv(.C) bool {
-    return _Qp_cmp(a.*, b.*) == @enumToInt(FCMP.Greater);
+    return _Qp_cmp(a, b) == @enumToInt(FCMP.Greater);
 }
 
 pub fn _Qp_fge(a: *f128, b: *f128) callconv(.C) bool {
-    const cmp = _Qp_cmp(a.*, b.*);
+    const cmp = _Qp_cmp(a, b);
     return cmp == @enumToInt(FCMP.Greater) or cmp == @enumToInt(FCMP.Equal);
 }
 

--- a/lib/std/special/compiler_rt/sparc.zig
+++ b/lib/std/special/compiler_rt/sparc.zig
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2015-2020 Zig Contributors
+// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
+// The MIT license requires this copyright notice to be included in all copies
+// and substantial portions of the software.
+//
+// SPARC uses a different naming scheme for its support routines so we map it here to the x86 name.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+// The SPARC Architecture Manual, Version 9:
+// A.13 Floating-Point Compare
+const FCMP = extern enum(i32) {
+    Equal = 0,
+    Less = 1,
+    Greater = 2,
+    Unordered = 3,
+};
+
+// Basic arithmetic
+
+pub fn _Qp_add(c: *f128, a: *f128, b: *f128) callconv(.C) void {
+    c.* = @import("addXf3.zig").__addtf3(a.*, b.*);
+}
+
+pub fn _Qp_div(c: *f128, a: *f128, b: *f128) callconv(.C) void {
+    c.* = @import("divtf3.zig").__divtf3(a.*, b.*);
+}
+
+pub fn _Qp_mul(c: *f128, a: *f128, b: *f128) callconv(.C) void {
+    c.* = @import("mulXf3.zig").__multf3(a.*, b.*);
+}
+
+pub fn _Qp_sub(c: *f128, a: *f128, b: *f128) callconv(.C) void {
+    c.* = @import("addXf3.zig").__subtf3(a.*, b.*);
+}
+
+// Comparison
+
+pub fn _Qp_cmp(a: f128, b: f128) callconv(.C) i32 {
+    return @enumToInt(@import("compareXf2.zig").cmp(f128, FCMP, a, b));
+}
+
+pub fn _Qp_feq(a: *f128, b: *f128) callconv(.C) bool {
+    return _Qp_cmp(a.*, b.*) == @enumToInt(FCMP.Equal);
+}
+
+pub fn _Qp_fne(a: *f128, b: *f128) callconv(.C) bool {
+    return _Qp_cmp(a.*, b.*) != @enumToInt(FCMP.Equal);
+}
+
+pub fn _Qp_flt(a: *f128, b: *f128) callconv(.C) bool {
+    return _Qp_cmp(a.*, b.*) == @enumToInt(FCMP.Less);
+}
+
+pub fn _Qp_fle(a: *f128, b: *f128) callconv(.C) bool {
+    const cmp = _Qp_cmp(a.*, b.*);
+    return cmp == @enumToInt(FCMP.Less) or cmp == @enumToInt(FCMP.Equal);
+}
+
+pub fn _Qp_fgt(a: *f128, b: *f128) callconv(.C) bool {
+    return _Qp_cmp(a.*, b.*) == @enumToInt(FCMP.Greater);
+}
+
+pub fn _Qp_fge(a: *f128, b: *f128) callconv(.C) bool {
+    const cmp = _Qp_cmp(a.*, b.*);
+    return cmp == @enumToInt(FCMP.Greater) or cmp == @enumToInt(FCMP.Equal);
+}
+
+
+// Casting
+
+pub fn _Qp_dtoq(c: *f128, a: f64) callconv(.C) void {
+    c.* = @import("extendXfYf2.zig").__extenddftf2(a);
+}
+
+pub fn _Qp_qtod(a: *f128) callconv(.C) f64 {
+    return @import("truncXfYf2.zig").__trunctfdf2(a.*);
+}

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -19,6 +19,7 @@
 #include "stage2.h"
 #include "dump_analysis.hpp"
 #include "softfloat.hpp"
+#include "zigendian.h"
 
 #include <stdio.h>
 #include <errno.h>
@@ -7421,11 +7422,20 @@ static LLVMValueRef gen_const_val(CodeGen *g, ZigValue *const_val, const char *n
                     return LLVMConstReal(get_llvm_type(g, type_entry), const_val->data.x_f64);
                 case 128:
                     {
-                        // TODO make sure this is correct on big endian targets too
-                        uint8_t buf[16];
-                        memcpy(buf, &const_val->data.x_f128, 16);
-                        LLVMValueRef as_int = LLVMConstIntOfArbitraryPrecision(LLVMInt128Type(), 2,
-                                (uint64_t*)buf);
+                        uint64_t buf[2];
+
+                        // LLVM seems to require that the lower half of the f128 be placed first in the buffer.
+                        #if defined(ZIG_BYTE_ORDER) && ZIG_BYTE_ORDER == ZIG_LITTLE_ENDIAN
+                            buf[0] = const_val->data.x_f128.v[0];
+                            buf[1] = const_val->data.x_f128.v[1];
+                        #elif defined(ZIG_BYTE_ORDER) && ZIG_BYTE_ORDER == ZIG_BIG_ENDIAN
+                            buf[0] = const_val->data.x_f128.v[1];
+                            buf[1] = const_val->data.x_f128.v[0];
+                        #else
+                            #error Unsupported endian
+                        #endif
+
+                        LLVMValueRef as_int = LLVMConstIntOfArbitraryPrecision(LLVMInt128Type(), 2, buf);
                         return LLVMConstBitCast(as_int, get_llvm_type(g, type_entry));
                     }
                 default:


### PR DESCRIPTION
This is to track the progress of making f128 work on SPARCv9 (sparc64) targets.

At the moment, this still suffers from issue #7706, so some f128 values get miscomputed, but otherwise I believe that this is complete enough for a review.