### PR TITLE
Want native headers when linking with frameworks

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1432,6 +1432,12 @@ fn buildOutputType(
         }
     }
 
+    if (comptime std.Target.current.isDarwin()) {
+        // If we want to link against frameworks, we need system headers.
+        if (framework_dirs.items.len > 0 or frameworks.items.len > 0)
+            want_native_include_dirs = true;
+    }
+
     if (cross_target.isNativeOs() and (system_libs.items.len != 0 or want_native_include_dirs)) {
         const paths = std.zig.system.NativePaths.detect(arena) catch |err| {
             fatal("unable to detect native system paths: {s}", .{@errorName(err)});


### PR DESCRIPTION
This PR ensures we use system libc headers and system search paths for
framework headers when linking against frameworks and compiling natively
on macOS.

Fixes #7697 