### PR TITLE
self-hosted compiler browser-based wasm playground

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -225,6 +225,11 @@ pub fn assert(ok: bool) void {
 
 pub fn panic(comptime format: []const u8, args: anytype) noreturn {
     @setCold(true);
+    if (comptime std.Target.current.isWasm() and std.Target.current.os.tag == .freestanding) {
+        // TODO unify this code path for all operating systems
+        std.log.emerg(format, args);
+        std.os.abort();
+    }
     // TODO: remove conditional once wasi / LLVM defines __builtin_return_address
     const first_trace_addr = if (builtin.os.tag == .wasi) null else @returnAddress();
     panicExtra(null, first_trace_addr, format, args);

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -224,6 +224,13 @@ pub fn abort() noreturn {
         @breakpoint();
         exit(1);
     }
+    if (builtin.os.tag == .freestanding and std.Target.current.isWasm()) {
+        // TODO wasm has a trap instruction but we do not have an intrinsic
+        // to activate it.
+        while (true) {
+            @breakpoint();
+        }
+    }
 
     system.abort();
 }

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -1,8 +1,7 @@
 gpa: *Allocator,
-manifest_dir: fs.Dir,
+manifest_dir: if (browser.active) void else fs.Dir,
 hash: HashHelper = .{},
 
-const Cache = @This();
 const std = @import("std");
 const crypto = std.crypto;
 const fs = std.fs;
@@ -11,6 +10,9 @@ const testing = std.testing;
 const mem = std.mem;
 const fmt = std.fmt;
 const Allocator = std.mem.Allocator;
+
+const Cache = @This();
+const browser = @import("playground/browser.zig");
 
 /// Be sure to call `Manifest.deinit` after successful initialization.
 pub fn obtain(cache: *const Cache) Manifest {
@@ -158,7 +160,9 @@ pub const HashHelper = struct {
     }
 };
 
-pub const Lock = struct {
+pub const Lock = if (browser.active) browser.Cache.Lock else RealLock;
+
+const RealLock = struct {
     manifest_file: fs.File,
 
     pub fn release(lock: *Lock) void {
@@ -170,7 +174,7 @@ pub const Lock = struct {
 /// Manifest manages project-local `zig-cache` directories.
 /// This is not a general-purpose cache.
 /// It is designed to be fast and simple, not to withstand attacks using specially-crafted input.
-pub const Manifest = struct {
+pub const Manifest = if (browser.active) browser.Cache.Manifest else struct {
     cache: *const Cache,
     /// Current state for incremental hashing.
     hash: HashHelper,

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -32,6 +32,8 @@ const WaitGroup = @import("WaitGroup.zig");
 const libtsan = @import("libtsan.zig");
 const browser = @import("playground/browser.zig");
 
+const dump_zir = std.builtin.mode == .Debug and !browser.active;
+
 /// This is state that does not apply to WebAssembly browser builds of the compiler.
 const NonBrowser = if (browser.active) void else struct {
     /// Arena-allocated memory used during initialization. Should be untouched until deinit.
@@ -1511,7 +1513,7 @@ pub fn performAllTheWork(self: *Compilation) error{ TimerUnsupported, OutOfMemor
                     log.debug("analyze liveness of {s}\n", .{decl.name});
                     try liveness.analyze(module.gpa, &decl_arena.allocator, func.body);
 
-                    if (std.builtin.mode == .Debug and self.verbose_ir) {
+                    if (dump_zir and self.verbose_ir) {
                         func.dump(module.*);
                     }
                 }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -264,9 +264,13 @@ pub const AllErrors = struct {
         },
 
         pub fn renderToStdErr(self: Message) void {
+            self.renderToWriter(std.io.getStdErr().writer()) catch {};
+        }
+
+        pub fn renderToWriter(self: Message, writer: anytype) !void {
             switch (self) {
                 .src => |src| {
-                    std.debug.print("{s}:{d}:{d}: error: {s}\n", .{
+                    try writer.print("{s}:{d}:{d}: error: {s}\n", .{
                         src.src_path,
                         src.line + 1,
                         src.column + 1,
@@ -274,7 +278,7 @@ pub const AllErrors = struct {
                     });
                 },
                 .plain => |plain| {
-                    std.debug.print("error: {s}\n", .{plain.msg});
+                    try writer.print("error: {s}\n", .{plain.msg});
                 },
             }
         }

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -25,6 +25,7 @@ const zir_sema = @import("zir_sema.zig");
 const browser = @import("playground/browser.zig");
 
 const default_eval_branch_quota = 1000;
+const dump_zir = std.builtin.mode == .Debug and !browser.active;
 
 /// General-purpose allocator. Used for both temporary and long-term storage.
 gpa: *Allocator,
@@ -1139,7 +1140,7 @@ fn astGenAndAnalyzeDecl(self: *Module, decl: *Decl) !bool {
                 .param_types = param_types,
             }, .{});
 
-            if (std.builtin.mode == .Debug and self.comp.verbose_ir) {
+            if (dump_zir and self.comp.verbose_ir) {
                 zir.dumpZir(self.gpa, "fn_type", decl.name, fn_type_scope.instructions.items) catch {};
             }
 
@@ -1251,7 +1252,7 @@ fn astGenAndAnalyzeDecl(self: *Module, decl: *Decl) !bool {
                     _ = try astgen.addZIRNoOp(self, &gen_scope.base, src, .returnvoid);
                 }
 
-                if (std.builtin.mode == .Debug and self.comp.verbose_ir) {
+                if (dump_zir and self.comp.verbose_ir) {
                     zir.dumpZir(self.gpa, "fn_body", decl.name, gen_scope.instructions.items) catch {};
                 }
 
@@ -1420,7 +1421,7 @@ fn astGenAndAnalyzeDecl(self: *Module, decl: *Decl) !bool {
 
                 const src = tree.token_locs[init_node.firstToken()].start;
                 const init_inst = try astgen.expr(self, &gen_scope.base, init_result_loc, init_node);
-                if (std.builtin.mode == .Debug and self.comp.verbose_ir) {
+                if (dump_zir and self.comp.verbose_ir) {
                     zir.dumpZir(self.gpa, "var_init", decl.name, gen_scope.instructions.items) catch {};
                 }
 
@@ -1473,7 +1474,7 @@ fn astGenAndAnalyzeDecl(self: *Module, decl: *Decl) !bool {
                     .val = Value.initTag(.type_type),
                 });
                 const var_type = try astgen.expr(self, &type_scope.base, .{ .ty = type_type }, type_node);
-                if (std.builtin.mode == .Debug and self.comp.verbose_ir) {
+                if (dump_zir and self.comp.verbose_ir) {
                     zir.dumpZir(self.gpa, "var_type", decl.name, type_scope.instructions.items) catch {};
                 }
 
@@ -1549,7 +1550,7 @@ fn astGenAndAnalyzeDecl(self: *Module, decl: *Decl) !bool {
             defer gen_scope.instructions.deinit(self.gpa);
 
             _ = try astgen.comptimeExpr(self, &gen_scope.base, .none, comptime_decl.expr);
-            if (std.builtin.mode == .Debug and self.comp.verbose_ir) {
+            if (dump_zir and self.comp.verbose_ir) {
                 zir.dumpZir(self.gpa, "comptime_block", decl.name, gen_scope.instructions.items) catch {};
             }
 

--- a/src/WaitGroup.zig
+++ b/src/WaitGroup.zig
@@ -57,5 +57,6 @@ pub fn wait(self: *WaitGroup) void {
 }
 
 pub fn reset(self: *WaitGroup) void {
+    self.counter = 0;
     self.event.reset();
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -20,6 +20,7 @@ const translate_c = @import("translate_c.zig");
 const Cache = @import("Cache.zig");
 const target_util = @import("target.zig");
 const ThreadPool = @import("ThreadPool.zig");
+const browser = @import("playground/browser.zig");
 
 pub fn fatal(comptime format: []const u8, args: anytype) noreturn {
     std.log.emerg(format, args);

--- a/src/playground.zig
+++ b/src/playground.zig
@@ -1,0 +1,3 @@
+export fn eval(code_ptr: [*]const u8, code_len: usize) f64 {
+    return 12.34;
+}

--- a/src/playground.zig
+++ b/src/playground.zig
@@ -1,3 +1,208 @@
-export fn eval(code_ptr: [*]const u8, code_len: usize) f64 {
-    return 12.34;
+const std = @import("std");
+
+const Compilation = @import("Compilation.zig");
+const Module = @import("Module.zig");
+const Package = @import("Package.zig");
+const Type = @import("type.zig").Type;
+const ThreadPool = @import("ThreadPool.zig");
+const link = @import("link.zig");
+
+extern fn wasmEval(code_ptr: [*]const u8, code_len: usize) f64;
+
+export fn zigEval(code_ptr: [*]const u8, code_len: usize) f64 {
+    if (eval(code_ptr[0..code_len])) |result| {
+        return result;
+    } else |err| {
+        // TODO figure out how to handle errors
+        return 99.99;
+    }
+}
+
+pub const os = struct {
+    pub const system = struct {
+        pub fn exit(status: u8) noreturn {
+            std.os.abort();
+        }
+
+        pub fn abort() noreturn {
+            // TODO trap instruction
+            while (true) {
+                @breakpoint();
+            }
+        }
+    };
+};
+
+pub fn log(
+    comptime level: std.log.Level,
+    comptime scope: @TypeOf(.EnumLiteral),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    // TODO capture these messages
+}
+
+pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace) noreturn {
+    // TODO capture this message
+    std.os.abort();
+}
+
+fn eval(code: []const u8) !f64 {
+    var arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_allocator.deinit();
+    const arena = &arena_allocator.allocator;
+    const gpa = arena;
+
+    const comp = try arena.create(Compilation);
+
+    const root_pkg = try Package.create(arena, null, "main.zig");
+    const root_scope = try arena.create(Module.Scope.File);
+    const struct_ty = try Type.Tag.empty_struct.create(arena, &root_scope.root_container);
+    root_scope.* = .{
+        .sub_file_path = root_pkg.root_src_path,
+        .source = .{ .unloaded = {} },
+        .contents = .{ .not_available = {} },
+        .status = .never_loaded,
+        .pkg = root_pkg,
+        .root_container = .{
+            .file_scope = root_scope,
+            .decls = .{},
+            .ty = struct_ty,
+        },
+    };
+
+    const module = try arena.create(Module);
+    module.* = .{
+        .gpa = gpa,
+        .comp = comp,
+        .root_pkg = root_pkg,
+        .root_scope = &root_scope.base,
+        .zig_cache_artifact_directory = .{
+            .path = null,
+            .handle = .{},
+        },
+        .emit_h = null,
+    };
+
+    const emit_directory: Compilation.Directory = .{
+        .path = null,
+        .handle = .{},
+    };
+
+    const emit_bin: link.Emit = .{
+        .directory = emit_directory,
+        .sub_path = "main.wasm",
+    };
+
+    const bin_file = try link.File.openPath(arena, .{
+        .emit = emit_bin,
+        .root_name = "main",
+        .module = module,
+        .target = std.Target.current,
+        .dynamic_linker = null,
+        .output_mode = .Lib,
+        .link_mode = .Static,
+        .object_format = .wasm,
+        .optimize_mode = .Debug,
+        .use_lld = false,
+        .use_llvm = false,
+        .system_linker_hack = false,
+        .link_libc = false,
+        .link_libcpp = false,
+        .objects = &[0][]const u8{},
+        .frameworks = &[0][]const u8{},
+        .framework_dirs = &[0][]const u8{},
+        .system_libs = std.StringArrayHashMapUnmanaged(void){},
+        .syslibroot = null,
+        .lib_dirs = &[0][]const u8{},
+        .rpath_list = &[0][]const u8{},
+        .strip = false,
+        .is_native_os = false,
+        .is_native_abi = false,
+        .function_sections = false,
+        .allow_shlib_undefined = false,
+        .bind_global_refs_locally = false,
+        .z_nodelete = false,
+        .z_defs = false,
+        .stack_size_override = null,
+        .image_base_override = null,
+        .include_compiler_rt = false,
+        .linker_script = null,
+        .version_script = null,
+        .gc_sections = false,
+        .eh_frame_hdr = false,
+        .emit_relocs = false,
+        .rdynamic = false,
+        .extra_lld_args = &[0][]const u8{},
+        .soname = null,
+        .version = null,
+        .libc_installation = null,
+        .pic = false,
+        .pie = false,
+        .valgrind = false,
+        .tsan = false,
+        .stack_check = false,
+        .single_threaded = true,
+        .verbose_link = false,
+        .machine_code_model = .default,
+        .dll_export_fns = false,
+        .error_return_tracing = false,
+        .llvm_cpu_features = null,
+        .skip_linker_dependencies = false,
+        .parent_compilation_link_libc = false,
+        .each_lib_rpath = false,
+        .disable_lld_caching = true,
+        .subsystem = null,
+        .is_test = false,
+    });
+
+    var thread_pool: ThreadPool = undefined;
+    try thread_pool.init(gpa);
+    defer thread_pool.deinit();
+
+    comp.* = .{
+        .gpa = gpa,
+        .bin_file = bin_file,
+        .work_queue = std.fifo.LinearFifo(Compilation.Job, .Dynamic).init(gpa),
+        .keep_source_files_loaded = true,
+        .use_clang = false,
+        .sanitize_c = false,
+        .c_source_files = &[0]Compilation.CSourceFile{},
+        .thread_pool = &thread_pool,
+        .verbose_cc = false,
+        .verbose_tokenize = false,
+        .verbose_ast = false,
+        .verbose_ir = false,
+        .verbose_llvm_ir = false,
+        .verbose_cimport = false,
+        .verbose_llvm_cpu_features = false,
+        .disable_c_depfile = true,
+        .time_report = false,
+        .stack_report = false,
+        .test_evented_io = false,
+        .work_queue_wait_group = undefined,
+        .color = .off,
+    };
+
+    try comp.update();
+
+    var errors = try comp.getAllErrorsAlloc();
+    if (errors.list.len != 0) {
+        // TODO report compile errors
+        //for (errors.list) |full_err_msg| {
+        //    full_err_msg.renderToStdErr();
+        //}
+        return error.SemanticAnalyzeFail;
+    }
+
+    const wasm_binary = try emit_directory.handle.readFileAllocOptions(
+        arena,
+        emit_bin.sub_path,
+        std.math.maxInt(u32),
+        null,
+        1,
+        0,
+    );
+
+    return wasmEval(wasm_binary.ptr, wasm_binary.len);
 }

--- a/src/playground.zig
+++ b/src/playground.zig
@@ -46,14 +46,11 @@ pub fn log(
 
 // TODO recover from panic by having the js re-instantiate the wasm
 pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace) noreturn {
-    const arena = &arena_allocator.allocator;
-    const full_msg = std.fmt.allocPrint(arena, "panic: {s}", .{msg}) catch
-        "panic: out of memory";
-    stderr(full_msg.ptr, full_msg.len);
+    stderr(msg.ptr, msg.len);
     std.os.abort();
 }
 
-var arena_allocator: std.heap.ArenaAllocator = undefined;
+pub var arena_allocator: std.heap.ArenaAllocator = undefined;
 
 export fn zigEval(code_ptr: [*]const u8, code_len: usize) f64 {
     arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);

--- a/src/playground/browser.zig
+++ b/src/playground/browser.zig
@@ -117,11 +117,7 @@ pub const Dir = struct {
         comptime optional_sentinel: ?u8,
     ) !(if (optional_sentinel) |s| [:s]align(alignment) u8 else []align(alignment) u8) {
         if (std.mem.eql(u8, file_path, "main.zig")) {
-            return allocator.dupeZ(u8,
-                \\export fn _start() f64 {
-                \\    return 42.0;
-                \\}
-            );
+            return playground.getMainFile();
         } else if (std.mem.eql(u8, file_path, "main.wasm")) {
             const af = &actual_files[main_wasm_index];
             if (optional_sentinel) |s| {

--- a/src/playground/browser.zig
+++ b/src/playground/browser.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const Compilation = @import("../Compilation.zig");
+
+pub const active = std.Target.current.isWasm() and
+    std.Target.current.os.tag == .freestanding;
+
+pub const Directory = struct {
+    path: ?[]const u8,
+    handle: Dir,
+
+    pub fn join(self: Directory, allocator: *Allocator, paths: []const []const u8) ![]u8 {
+        return Compilation.joinPaths(self.path, allocator, paths);
+    }
+};
+
+pub const Cache = struct {
+    pub const Lock = struct {
+        pub fn release(lock: *Lock) void {}
+    };
+    pub const Manifest = struct {};
+};
+
+pub const File = struct {
+    pos: u64 = 0,
+
+    pub const OpenError = error{};
+
+    pub const CreateFlags = struct {
+        read: bool = false,
+        truncate: bool = true,
+    };
+
+    pub const WriteError = error{};
+
+    pub fn write(self: File, bytes: []const u8) WriteError!usize {
+        return bytes.len;
+    }
+
+    pub fn writeAll(self: File, bytes: []const u8) WriteError!void {}
+
+    pub const PWriteError = error{};
+
+    pub fn pwriteAll(self: File, bytes: []const u8, offset: u64) PWriteError!void {}
+
+    pub const SetEndPosError = error{};
+
+    pub fn setEndPos(self: File, length: u64) SetEndPosError!void {}
+
+    pub const SeekError = error{};
+
+    pub fn seekTo(self: File, offset: u64) SeekError!void {}
+
+    pub fn seekBy(self: File, offset: i64) SeekError!void {}
+
+    pub const GetPosError = error{};
+
+    pub fn getPos(self: File) GetPosError!u64 {
+        return self.pos;
+    }
+
+    pub fn close(self: File) void {}
+
+    pub const Writer = std.io.Writer(File, WriteError, write);
+
+    pub fn writer(file: File) Writer {
+        return .{ .context = file };
+    }
+};
+
+pub const Dir = struct {
+    pub fn createFile(dir: Dir, sub_path: []const u8, flags: File.CreateFlags) File.OpenError!File {
+        return File{};
+    }
+
+    pub fn readFileAllocOptions(
+        self: Dir,
+        allocator: *std.mem.Allocator,
+        file_path: []const u8,
+        max_bytes: usize,
+        size_hint: ?usize,
+        comptime alignment: u29,
+        comptime optional_sentinel: ?u8,
+    ) !(if (optional_sentinel) |s| [:s]align(alignment) u8 else []align(alignment) u8) {
+        if (std.mem.eql(u8, file_path, "main.zig")) {
+            return allocator.dupeZ(u8,
+                \\export fn _start() f64 {
+                \\    return 42.0;
+                \\}
+            );
+        } else {
+            return error.FileNotFound;
+        }
+    }
+
+    pub fn writeFile(self: Dir, sub_path: []const u8, data: []const u8) !void {}
+
+    pub fn close(dir: *Dir) void {}
+};

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Zig Playground (experimental)</title>
+</head>
+<body>
+  <script src="playground.js"></script>
+</body>
+</html>

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -5,7 +5,14 @@
   <title>Zig Playground (experimental)</title>
 </head>
 <body>
-  <div id="status"></div>
+  <div id="status">Loading...</div>
+  <textarea id="src">
+export fn _start() f64 {
+    return 42.0;
+}
+  </textarea>
+  <input type="button" id="run" value="Run">
+  <div id="output"></div>
   <script src="playground.js"></script>
 </body>
 </html>

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -5,6 +5,7 @@
   <title>Zig Playground (experimental)</title>
 </head>
 <body>
+  <div id="status"></div>
   <script src="playground.js"></script>
 </body>
 </html>

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -1,20 +1,24 @@
 (function() {
-    var env = {
-        imports: { }
+    var options = {
+        env: {
+            wasmEval: function(code_ptr, code_len) {
+                console.log("code_ptr", code_ptr, "code_len", code_len);
+            },
+        },
     };
 
-    WebAssembly.instantiateStreaming(fetch("playground.wasm"), {env}).then(function(result) {
+    WebAssembly.instantiateStreaming(fetch("playground.wasm"), options).then(function(result) {
         callback(null, result);
     }, function(err) {
         callback(err, null);
     });
     function callback(err, result) {
         if (err) {
-            document.getElementById('status').innerText = "error: " + err;
+            document.getElementById('status').textContent = "error: " + err;
             return;
         }
         // for debugging
         window._wasm = result.instance;
-        console.log(result.instance.exports.eval());
+        console.log(result.instance.exports.zigEval());
     }
 })();

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -4,6 +4,9 @@
             wasmEval: function(code_ptr, code_len) {
                 console.log("code_ptr", code_ptr, "code_len", code_len);
             },
+            stderr: function(msg_ptr, msg_len) {
+                console.log(makeString(msg_ptr, msg_len));
+            },
         },
     };
 
@@ -20,5 +23,10 @@
         // for debugging
         window._wasm = result.instance;
         console.log(result.instance.exports.zigEval());
+    }
+
+    function makeString(ptr, len) {
+        var bytes = new Uint8Array(window._wasm.exports.memory.buffer, ptr, len);
+        return new TextDecoder().decode(bytes);
     }
 })();

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -1,0 +1,20 @@
+(function() {
+    var env = {
+        imports: { }
+    };
+
+    WebAssembly.instantiateStreaming(fetch("playground.wasm"), {env}).then(function(result) {
+        callback(null, result);
+    }, function(err) {
+        callback(err, null);
+    });
+    function callback(err, result) {
+        if (err) {
+            document.getElementById('status').innerText = "error: " + err;
+            return;
+        }
+        // for debugging
+        window._wasm = result.instance;
+        console.log(result.instance.exports.eval());
+    }
+})();

--- a/src/test.zig
+++ b/src/test.zig
@@ -952,10 +952,10 @@ pub const TestContext = struct {
         const spu = @import("codegen/spu-mk2.zig");
         if (case.target.os_tag) |os| {
             if (os != .freestanding) {
-                std.debug.panic("Only freestanding makes sense for SPU-II tests!", .{});
+                std.builtin.panic("Only freestanding makes sense for SPU-II tests!", .{});
             }
         } else {
-            std.debug.panic("SPU_2 has no native OS, check the test!", .{});
+            std.builtin.panic("SPU_2 has no native OS, check the test!", .{});
         }
 
         var interpreter = spu.Interpreter(struct {

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -25,6 +25,7 @@ const trace = @import("tracy.zig").trace;
 const Scope = Module.Scope;
 const InnerError = Module.InnerError;
 const Decl = Module.Decl;
+const browser = @import("playground/browser.zig");
 
 pub fn analyzeInst(mod: *Module, scope: *Scope, old_inst: *zir.Inst) InnerError!*Inst {
     switch (old_inst.tag) {
@@ -632,6 +633,9 @@ fn analyzeInstCompileError(mod: *Module, scope: *Scope, inst: *zir.Inst.UnOp) In
 }
 
 fn analyzeInstCompileLog(mod: *Module, scope: *Scope, inst: *zir.Inst.CompileLog) InnerError!*Inst {
+    if (browser.active) {
+        return mod.fail(scope, inst.base.src, "TODO: implement @compileLog for browser builds", .{});
+    }
     std.debug.print("| ", .{});
     for (inst.positionals.to_log) |item, i| {
         const to_log = try resolveInst(mod, scope, item);


### PR DESCRIPTION
This is a proof-of-concept for several reasons, the most significant one being that it breaks the main compiler because I didn't finish reworking the fields that got moved around.

But in general, the concept works, and with some adjustments I think the maintenance burden on the codebase wouldn't be too severe.

There's a new root source file, `src/playground.zig` which defines a function `zigEval` for js code to call into.

Some problems to solve before this would be reasonable to merge:

 * [ ] cleanup, reduce maintenance burden on the main compiler use case
 * [x] expose errors to the web page
 * [x] implement the file system shim functions
 * [ ] implement more of the actual webassembly backend, at least to the point where we can do hello, world
 * [ ] create a start file that calls into pub fn main
 * [ ] provide the std lib