### PR TITLE
stage2: initial implementation of control flow in LLVM backend + TZIR printing

### DIFF
--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -24,6 +24,9 @@ pub const Context = opaque {
     pub const constString = LLVMConstStringInContext;
     extern fn LLVMConstStringInContext(C: *const Context, Str: [*]const u8, Length: c_uint, DontNullTerminate: LLVMBool) *const Value;
 
+    pub const createBasicBlock = LLVMCreateBasicBlockInContext;
+    extern fn LLVMCreateBasicBlockInContext(C: *const Context, Name: [*:0]const u8) *const BasicBlock;
+
     pub const appendBasicBlock = LLVMAppendBasicBlockInContext;
     extern fn LLVMAppendBasicBlockInContext(C: *const Context, Fn: *const Value, Name: [*:0]const u8) *const BasicBlock;
 
@@ -37,6 +40,12 @@ pub const Value = opaque {
 
     pub const getFirstBasicBlock = LLVMGetFirstBasicBlock;
     extern fn LLVMGetFirstBasicBlock(Fn: *const Value) ?*const BasicBlock;
+
+    pub const appendExistingBasicBlock = LLVMAppendExistingBasicBlock;
+    extern fn LLVMAppendExistingBasicBlock(Fn: *const Value, BB: *const BasicBlock) void;
+
+    pub const addIncoming = LLVMAddIncoming;
+    extern fn LLVMAddIncoming(PhiNode: *const Value, IncomingValues: [*]*const Value, IncomingBlocks: [*]*const BasicBlock, Count: c_uint) void;
 
     pub const getNextInstruction = LLVMGetNextInstruction;
     extern fn LLVMGetNextInstruction(Inst: *const Value) ?*const Value;
@@ -183,6 +192,31 @@ pub const Builder = opaque {
 
     pub const buildInBoundsGEP = LLVMBuildInBoundsGEP;
     extern fn LLVMBuildInBoundsGEP(B: *const Builder, Pointer: *const Value, Indices: [*]*const Value, NumIndices: c_uint, Name: [*:0]const u8) *const Value;
+
+    pub const buildICmp = LLVMBuildICmp;
+    extern fn LLVMBuildICmp(*const Builder, Op: IntPredicate, LHS: *const Value, RHS: *const Value, Name: [*:0]const u8) *const Value;
+
+    pub const buildBr = LLVMBuildBr;
+    extern fn LLVMBuildBr(*const Builder, Dest: *const BasicBlock) *const Value;
+
+    pub const buildCondBr = LLVMBuildCondBr;
+    extern fn LLVMBuildCondBr(*const Builder, If: *const Value, Then: *const BasicBlock, Else: *const BasicBlock) *const Value;
+
+    pub const buildPhi = LLVMBuildPhi;
+    extern fn LLVMBuildPhi(*const Builder, Ty: *const Type, Name: [*:0]const u8) *const Value;
+};
+
+pub const IntPredicate = extern enum {
+    EQ = 32,
+    NE = 33,
+    UGT = 34,
+    UGE = 35,
+    ULT = 36,
+    ULE = 37,
+    SGT = 38,
+    SGE = 39,
+    SLT = 40,
+    SLE = 41,
 };
 
 pub const BasicBlock = opaque {

--- a/src/test.zig
+++ b/src/test.zig
@@ -657,8 +657,10 @@ pub const TestContext = struct {
             .object_format = case.object_format,
             .is_native_os = case.target.isNativeOs(),
             .is_native_abi = case.target.isNativeAbi(),
+            .dynamic_linker = target_info.dynamic_linker.get(),
             .link_libc = case.llvm_backend,
             .use_llvm = case.llvm_backend,
+            .use_lld = case.llvm_backend,
             .self_exe_path = std.testing.zig_exe_path,
         });
         defer comp.destroy();

--- a/test/stage2/llvm.zig
+++ b/test/stage2/llvm.zig
@@ -40,4 +40,75 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , "hello world!" ++ std.cstr.line_sep);
     }
+
+    {
+        var case = ctx.exeUsingLlvmBackend("simple if statement", linux_x64);
+
+        case.addCompareOutput(
+            \\fn add(a: i32, b: i32) i32 {
+            \\    return a + b;
+            \\}
+            \\
+            \\fn assert(ok: bool) void {
+            \\    if (!ok) unreachable;
+            \\}
+            \\
+            \\export fn main() c_int {
+            \\    assert(add(1,2) == 3);
+            \\    return 0;
+            \\}
+        , "");
+    }
+
+    {
+        var case = ctx.exeUsingLlvmBackend("blocks", linux_x64);
+
+        case.addCompareOutput(
+            \\fn assert(ok: bool) void {
+            \\    if (!ok) unreachable;
+            \\}
+            \\
+            \\fn foo(ok: bool) i32 {
+            \\    const val: i32 = blk: {
+            \\        var x: i32 = 1;
+            \\        if (!ok) break :blk x + 9;
+            \\        break :blk x + 19;
+            \\    };
+            \\    return val + 10;
+            \\}
+            \\
+            \\export fn main() c_int {
+            \\    assert(foo(false) == 20);
+            \\    assert(foo(true) == 30);
+            \\    return 0;
+            \\}
+        , "");
+    }
+
+    {
+        var case = ctx.exeUsingLlvmBackend("nested blocks", linux_x64);
+
+        case.addCompareOutput(
+            \\fn assert(ok: bool) void {
+            \\    if (!ok) unreachable;
+            \\}
+            \\
+            \\fn foo(ok: bool) i32 {
+            \\    var val: i32 = blk: {
+            \\        const val2: i32 = another: {
+            \\            if (!ok) break :blk 10;
+            \\            break :another 10;
+            \\        };
+            \\        break :blk val2 + 10;
+            \\    };
+            \\    return val;
+            \\}
+            \\
+            \\export fn main() c_int {
+            \\    assert(foo(false) == 10);
+            \\    assert(foo(true) == 20);
+            \\    return 0;
+            \\}
+        , "");
+    }
 }


### PR DESCRIPTION
TLDR: The following example now works:
```zig
fn assert(ok: bool) void {
    if (!ok) unreachable;
}

fn foo(ok: bool) i32 {
    const val: i32 = blk: {
        var x: i32 = 1;
        if (!ok) break :blk x + 9;
        break :blk x + 19;
    };
    return val + 10;
}

export fn main() c_int {
    assert(foo(false) == 20);
    assert(foo(true) == 30);
    return 0;
}
```

It generates the following LLVM IR:
```ir
; ModuleID = 'mainstage2'
source_filename = "mainstage2"

define i32 @main() {
Entry:
  %0 = call i32 @foo(i1 false)
  %1 = icmp eq i32 %0, 20
  call void @assert(i1 %1)
  %2 = call i32 @foo(i1 true)
  %3 = icmp eq i32 %2, 30
  call void @assert(i1 %3)
  ret i32 0
}

define i32 @foo(i1 %0) {
Entry:
  %1 = alloca i1, align 1
  %2 = alloca i32, align 4
  %3 = alloca i32, align 4
  store i1 %0, i1* %1, align 1
  %4 = load i1, i1* %1, align 1
  store i32 1, i32* %3, align 4
  %5 = xor i1 %4, true
  br i1 %5, label %Then, label %Else

Then:                                             ; preds = %Entry
  %6 = load i32, i32* %3, align 4
  %7 = add nsw i32 %6, 9
  store i32 %7, i32* %2, align 4
  br label %Block1

Else:                                             ; preds = %Entry
  br label %Block

Block:                                            ; preds = %Else
  %8 = load i32, i32* %3, align 4
  %9 = add nsw i32 %8, 19
  store i32 %9, i32* %2, align 4
  br label %Block1

Block1:                                           ; preds = %Block, %Then
  %10 = phi i32 [ %7, %Then ], [ %9, %Block ]
  %11 = add nsw i32 %10, 10
  ret i32 %11
}

define void @assert(i1 %0) {
Entry:
  %1 = alloca i1, align 1
  store i1 %0, i1* %1, align 1
  %2 = load i1, i1* %1, align 1
  %3 = xor i1 %2, true
  br i1 %3, label %Then, label %Else

Then:                                             ; preds = %Entry
  call void @llvm.debugtrap()
  unreachable

Else:                                             ; preds = %Entry
  br label %Block

Block:                                            ; preds = %Else
  ret void
}

; Function Attrs: nounwind
declare void @llvm.debugtrap() #0

attributes #0 = { nounwind }
```
See commits for more details.