### PR TITLE
Stage2: Wasm codegen - Implement storing and loading of locals

### DIFF
--- a/src/codegen/wasm.zig
+++ b/src/codegen/wasm.zig
@@ -94,7 +94,12 @@ pub fn genCode(buf: *ArrayList(u8), decl: *Decl) !void {
 
     // Write instructions
     // TODO: check for and handle death of instructions
-    for (mod_fn.body.instructions) |inst| try genInst(buf, decl, inst);
+    for (mod_fn.body.instructions) |inst| {
+        // skip load as they should be triggered by other instructions
+        if (inst.tag != .load) {
+            try genInst(buf, decl, inst);
+        }
+    }
 
     // Write 'end' opcode
     try writer.writeByte(0x0B);
@@ -155,7 +160,6 @@ fn genConstant(buf: *ArrayList(u8), decl: *Decl, inst: *Inst.Constant) !void {
 
 fn genRet(buf: *ArrayList(u8), decl: *Decl, inst: *Inst.UnOp) !void {
     try genInst(buf, decl, inst.operand);
-    try buf.append(0x0F);
 }
 
 fn genCall(buf: *ArrayList(u8), decl: *Decl, inst: *Inst.Call) !void {

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -50,6 +50,8 @@ pub const FnData = struct {
     locals: std.ArrayListUnmanaged(*Inst) = .{},
 
     /// Returns the index of a local given a pointer to an `Inst`
+    /// TODO: Function arguments share the local index with local variables
+    /// meaning this will be out of sync once arguments are implemented.
     pub fn getLocalidx(self: *FnData, inst: *Inst) ?u32 {
         return for (self.locals.items) |local, idx| {
             if (local == inst) break @intCast(u32, idx);

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1229,7 +1229,9 @@ pub fn addCases(ctx: *TestContext) !void {
         case.addCompareOutput(
             \\export fn _start() u32 {
             \\    var y: u32 = 5;
-            \\	  var x: u32 = 20;
+            \\    var z: f32 = 42.0;
+            \\    var x: u32 = 20;
+            \\	
             \\    y = x;
             \\
             \\    return y;

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1214,6 +1214,31 @@ pub fn addCases(ctx: *TestContext) !void {
         );
     }
 
+    {
+        var case = ctx.exe("wasm locals", wasi);
+
+        case.addCompareOutput(
+            \\export fn _start() u32 {
+            \\    var y: u32 = 5;
+            \\    return y;
+            \\}
+        ,
+            "5\n",
+        );
+
+        case.addCompareOutput(
+            \\export fn _start() u32 {
+            \\    var y: u32 = 5;
+            \\	  var x: u32 = 20;
+            \\    y = x;
+            \\
+            \\    return y;
+            \\}
+        ,
+            "20\n",
+        );
+    }
+
     ctx.compileError("function redefinition", linux_x64,
         \\fn entry() void {}
         \\fn entry() void {}


### PR DESCRIPTION
This PR implements the loading and storing of function locals. It does this by first calculating the number of locals found inside a function body and emitting this as part of the 'code' section. 
This also adds the load and store instructions to retrieve and store those values.

For example, the following now works:
```zig
export fn _start() u32 {
    var y: u32 = 5;
    var x: u32 = 20;
    
    y = x;
    return y;
}
```
Which returns the value `20`.

This generates the following pseudo code using wasm-decompile:
```
export function start():int {
  var a:int = 5;
  var b:int = 20;
  a = b;
  return a;
}

