### PR TITLE
stage2: fix bug in genArg

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1480,6 +1480,9 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
         }
 
         fn genArg(self: *Self, inst: *ir.Inst.Arg) !MCValue {
+            const arg_index = self.arg_index;
+            self.arg_index += 1;
+
             if (FreeRegInt == u0) {
                 return self.fail(inst.base.src, "TODO implement Register enum for {}", .{self.target.cpu.arch});
             }
@@ -1488,8 +1491,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
 
             try self.registers.ensureCapacity(self.gpa, self.registers.count() + 1);
 
-            const result = self.args[self.arg_index];
-            self.arg_index += 1;
+            const result = self.args[arg_index];
 
             const name_with_null = inst.name[0 .. mem.lenZ(inst.name) + 1];
             switch (result) {


### PR DESCRIPTION
When an argument is unused in the function body, still increment `arg_index` so we still select the correct arguments in the `args` slice.

This example now works. Previously, the assert failed.

```zig
export fn _start() noreturn {
    assert(select4th(1, 2, 3, 4) == 4);
    exit(0);
}

fn select4th(a: u32, b: u32, c: u32, d: u32) u32 {
    return d;
}

fn assert(ok: bool) void {
    if (!ok) unreachable; // assertion failure
}

fn exit(code: usize) noreturn {
    asm volatile ("svc #0"
        :
        : [number] "{r7}" (1),
          [arg1] "{r0}" (code)
        : "memory"
    );
    unreachable;
}
```