### PR TITLE
debug: don't fail printLineInfo if the source file is not readable

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -639,6 +639,7 @@ fn printLineInfo(
             } else |err| switch (err) {
                 error.EndOfFile, error.FileNotFound => {},
                 error.BadPathName => {},
+                error.AccessDenied => {},
                 else => return err,
             }
         }


### PR DESCRIPTION
Without this if [this call](https://github.com/ziglang/zig/blob/master/lib/std/debug.zig#L1024) to `openFile` fails with a `AccessDenied` the whole stacktrace dump fails with this error:
```
error: Nope
/home/vincent/tmp/zig-dump-stacktrace/src/main.zig:5:5: 0x2366c2 in lol3 (main)
Unable to dump stack trace: AccessDenied
```

In my case I'm running a binary with systemd with the [ProtectHome](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Sandboxing) property set to `true` which makes `/home` inaccessible, with `openat` calls returning `EACCES`:
```
openat(AT_FDCWD, "/home/vincent/tmp/zig-dump-stacktrace/src/main.zig", O_RDONLY|O_NOCTTY|O_CLOEXEC) = -1 EACCES (Permission non accordée)
```

With this patch the dump works fine:
```
error: Nope
/home/vincent/tmp/zig-dump-stacktrace/src/main.zig:5:5: 0x2366d2 in lol3 (main)
/home/vincent/tmp/zig-dump-stacktrace/src/main.zig:9:5: 0x2366a3 in lol2 (main)
/home/vincent/tmp/zig-dump-stacktrace/src/main.zig:13:5: 0x2348b3 in lol (main)
/home/vincent/tmp/zig-dump-stacktrace/src/main.zig:18:5: 0x22d5b5 in main (main)
```