### PR TITLE
stage2: add support for optionals in the LLVM backend

### DIFF
--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -21,8 +21,14 @@ pub const Context = opaque {
     pub const voidType = LLVMVoidTypeInContext;
     extern fn LLVMVoidTypeInContext(C: *const Context) *const Type;
 
+    pub const structType = LLVMStructTypeInContext;
+    extern fn LLVMStructTypeInContext(C: *const Context, ElementTypes: [*]*const Type, ElementCount: c_uint, Packed: LLVMBool) *const Type;
+
     pub const constString = LLVMConstStringInContext;
     extern fn LLVMConstStringInContext(C: *const Context, Str: [*]const u8, Length: c_uint, DontNullTerminate: LLVMBool) *const Value;
+
+    pub const constStruct = LLVMConstStructInContext;
+    extern fn LLVMConstStructInContext(C: *const Context, ConstantVals: [*]*const Value, Count: c_uint, Packed: LLVMBool) *const Value;
 
     pub const createBasicBlock = LLVMCreateBasicBlockInContext;
     extern fn LLVMCreateBasicBlockInContext(C: *const Context, Name: [*:0]const u8) *const BasicBlock;
@@ -204,6 +210,9 @@ pub const Builder = opaque {
 
     pub const buildPhi = LLVMBuildPhi;
     extern fn LLVMBuildPhi(*const Builder, Ty: *const Type, Name: [*:0]const u8) *const Value;
+
+    pub const buildExtractValue = LLVMBuildExtractValue;
+    extern fn LLVMBuildExtractValue(*const Builder, AggVal: *const Value, Index: c_uint, Name: [*:0]const u8) *const Value;
 };
 
 pub const IntPredicate = extern enum {

--- a/src/link.zig
+++ b/src/link.zig
@@ -550,11 +550,11 @@ pub const File = struct {
                 id_symlink_basename,
                 &prev_digest_buf,
             ) catch |err| b: {
-                log.debug("archive new_digest={x} readFile error: {s}", .{ digest, @errorName(err) });
+                log.debug("archive new_digest={s} readFile error: {s}", .{ std.fmt.fmtSliceHexLower(&digest), @errorName(err) });
                 break :b prev_digest_buf[0..0];
             };
             if (mem.eql(u8, prev_digest, &digest)) {
-                log.debug("archive digest={x} match - skipping invocation", .{digest});
+                log.debug("archive digest={s} match - skipping invocation", .{std.fmt.fmtSliceHexLower(&digest)});
                 base.lock = man.toOwnedLock();
                 return;
             }

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -892,17 +892,17 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
             id_symlink_basename,
             &prev_digest_buf,
         ) catch |err| blk: {
-            log.debug("COFF LLD new_digest={x} error: {s}", .{ digest, @errorName(err) });
+            log.debug("COFF LLD new_digest={s} error: {s}", .{ std.fmt.fmtSliceHexLower(&digest), @errorName(err) });
             // Handle this as a cache miss.
             break :blk prev_digest_buf[0..0];
         };
         if (mem.eql(u8, prev_digest, &digest)) {
-            log.debug("COFF LLD digest={x} match - skipping invocation", .{digest});
+            log.debug("COFF LLD digest={s} match - skipping invocation", .{std.fmt.fmtSliceHexLower(&digest)});
             // Hot diggity dog! The output binary is already there.
             self.base.lock = man.toOwnedLock();
             return;
         }
-        log.debug("COFF LLD prev_digest={x} new_digest={x}", .{ prev_digest, digest });
+        log.debug("COFF LLD prev_digest={s} new_digest={s}", .{ std.fmt.fmtSliceHexLower(prev_digest), std.fmt.fmtSliceHexLower(&digest) });
 
         // We are about to change the output file to be different, so we invalidate the build hash now.
         directory.handle.deleteFile(id_symlink_basename) catch |err| switch (err) {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1365,17 +1365,17 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
             id_symlink_basename,
             &prev_digest_buf,
         ) catch |err| blk: {
-            log.debug("ELF LLD new_digest={x} error: {s}", .{ digest, @errorName(err) });
+            log.debug("ELF LLD new_digest={s} error: {s}", .{ std.fmt.fmtSliceHexLower(&digest), @errorName(err) });
             // Handle this as a cache miss.
             break :blk prev_digest_buf[0..0];
         };
         if (mem.eql(u8, prev_digest, &digest)) {
-            log.debug("ELF LLD digest={x} match - skipping invocation", .{digest});
+            log.debug("ELF LLD digest={s} match - skipping invocation", .{std.fmt.fmtSliceHexLower(&digest)});
             // Hot diggity dog! The output binary is already there.
             self.base.lock = man.toOwnedLock();
             return;
         }
-        log.debug("ELF LLD prev_digest={x} new_digest={x}", .{ prev_digest, digest });
+        log.debug("ELF LLD prev_digest={s} new_digest={s}", .{ std.fmt.fmtSliceHexLower(prev_digest), std.fmt.fmtSliceHexLower(&digest) });
 
         // We are about to change the output file to be different, so we invalidate the build hash now.
         directory.handle.deleteFile(id_symlink_basename) catch |err| switch (err) {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -556,17 +556,17 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
             id_symlink_basename,
             &prev_digest_buf,
         ) catch |err| blk: {
-            log.debug("MachO LLD new_digest={x} error: {s}", .{ digest, @errorName(err) });
+            log.debug("MachO LLD new_digest={s} error: {s}", .{ std.fmt.fmtSliceHexLower(&digest), @errorName(err) });
             // Handle this as a cache miss.
             break :blk prev_digest_buf[0..0];
         };
         if (mem.eql(u8, prev_digest, &digest)) {
-            log.debug("MachO LLD digest={x} match - skipping invocation", .{digest});
+            log.debug("MachO LLD digest={s} match - skipping invocation", .{std.fmt.fmtSliceHexLower(&digest)});
             // Hot diggity dog! The output binary is already there.
             self.base.lock = man.toOwnedLock();
             return;
         }
-        log.debug("MachO LLD prev_digest={x} new_digest={x}", .{ prev_digest, digest });
+        log.debug("MachO LLD prev_digest={s} new_digest={s}", .{ std.fmt.fmtSliceHexLower(prev_digest), std.fmt.fmtSliceHexLower(&digest) });
 
         // We are about to change the output file to be different, so we invalidate the build hash now.
         directory.handle.deleteFile(id_symlink_basename) catch |err| switch (err) {

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -391,17 +391,17 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
             id_symlink_basename,
             &prev_digest_buf,
         ) catch |err| blk: {
-            log.debug("WASM LLD new_digest={x} error: {s}", .{ digest, @errorName(err) });
+            log.debug("WASM LLD new_digest={s} error: {s}", .{ std.fmt.fmtSliceHexLower(&digest), @errorName(err) });
             // Handle this as a cache miss.
             break :blk prev_digest_buf[0..0];
         };
         if (mem.eql(u8, prev_digest, &digest)) {
-            log.debug("WASM LLD digest={x} match - skipping invocation", .{digest});
+            log.debug("WASM LLD digest={s} match - skipping invocation", .{std.fmt.fmtSliceHexLower(&digest)});
             // Hot diggity dog! The output binary is already there.
             self.base.lock = man.toOwnedLock();
             return;
         }
-        log.debug("WASM LLD prev_digest={x} new_digest={x}", .{ prev_digest, digest });
+        log.debug("WASM LLD prev_digest={s} new_digest={s}", .{ std.fmt.fmtSliceHexLower(prev_digest), std.fmt.fmtSliceHexLower(&digest) });
 
         // We are about to change the output file to be different, so we invalidate the build hash now.
         directory.handle.deleteFile(id_symlink_basename) catch |err| switch (err) {

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -299,6 +299,9 @@ pub const Inst = struct {
         xor,
         /// Create an optional type '?T'
         optional_type,
+        /// Create an optional type '?T'. The operand is a pointer value. The optional type will
+        /// be the type of the pointer element, wrapped in an optional.
+        optional_type_from_ptr_elem,
         /// Create a union type.
         union_type,
         /// ?T => T with safety.
@@ -397,6 +400,7 @@ pub const Inst = struct {
                 .mut_slice_type,
                 .const_slice_type,
                 .optional_type,
+                .optional_type_from_ptr_elem,
                 .optional_payload_safe,
                 .optional_payload_unsafe,
                 .optional_payload_safe_ptr,
@@ -597,6 +601,7 @@ pub const Inst = struct {
                 .typeof,
                 .xor,
                 .optional_type,
+                .optional_type_from_ptr_elem,
                 .optional_payload_safe,
                 .optional_payload_unsafe,
                 .optional_payload_safe_ptr,

--- a/test/stage2/llvm.zig
+++ b/test/stage2/llvm.zig
@@ -132,4 +132,44 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , "");
     }
+
+    {
+        var case = ctx.exeUsingLlvmBackend("optionals", linux_x64);
+
+        case.addCompareOutput(
+            \\fn assert(ok: bool) void {
+            \\    if (!ok) unreachable;
+            \\}
+            \\
+            \\export fn main() c_int {
+            \\    var opt_val: ?i32 = 10;
+            \\    var null_val: ?i32 = null;
+            \\
+            \\    var val1: i32 = opt_val.?;
+            \\    const val1_1: i32 = opt_val.?;
+            \\    var ptr_val1 = &(opt_val.?);
+            \\    const ptr_val1_1 = &(opt_val.?);
+            \\
+            \\    var val2: i32 = null_val orelse 20;
+            \\    const val2_2: i32 = null_val orelse 20;
+            \\
+            \\    var value: i32 = 20;
+            \\    var ptr_val2 = &(null_val orelse value);
+            \\
+            \\    const val3 = opt_val orelse 30;
+            \\
+            \\    assert(val1 == 10);
+            \\    assert(val1_1 == 10);
+            \\    assert(ptr_val1.* == 10);
+            \\    assert(ptr_val1_1.* == 10);
+            \\
+            \\    assert(val2 == 20);
+            \\    assert(val2_2 == 20);
+            \\    assert(ptr_val2.* == 20);
+            \\
+            \\    assert(val3 == 10);
+            \\    return 0;
+            \\}
+        , "");
+    }
 }

--- a/test/stage2/llvm.zig
+++ b/test/stage2/llvm.zig
@@ -172,4 +172,23 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , "");
     }
+
+    {
+        var case = ctx.exeUsingLlvmBackend("for loop", linux_x64);
+
+        case.addCompareOutput(
+            \\fn assert(ok: bool) void {
+            \\    if (!ok) unreachable;
+            \\}
+            \\
+            \\export fn main() c_int {
+            \\    var x: u32 = 0;
+            \\    for ("hello") |_| {
+            \\        x += 1;
+            \\    }
+            \\    assert("hello".len == x);
+            \\    return 0;
+            \\}
+        , "");
+    }
 }

--- a/test/stage2/llvm.zig
+++ b/test/stage2/llvm.zig
@@ -157,6 +157,7 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    var ptr_val2 = &(null_val orelse value);
             \\
             \\    const val3 = opt_val orelse 30;
+            \\    var val3_var = opt_val orelse 30;
             \\
             \\    assert(val1 == 10);
             \\    assert(val1_1 == 10);
@@ -168,6 +169,14 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    assert(ptr_val2.* == 20);
             \\
             \\    assert(val3 == 10);
+            \\    assert(val3_var == 10);
+            \\
+            \\    (null_val orelse val2) = 1234;
+            \\    assert(val2 == 1234);
+            \\
+            \\    (opt_val orelse val2) = 5678;
+            \\    assert(opt_val.? == 5678);
+            \\
             \\    return 0;
             \\}
         , "");


### PR DESCRIPTION
We can now codegen optionals! This includes the following instructions:
- isnull
- isnonnull
- unwrap_optional
- brvoid

Also includes a test.

The test currently does not pass because of #7730.

EDIT: Also sneak in an extra test for loops.