### PR TITLE
macho: extern functions come to MachO!

### DIFF
--- a/src/link/MachO/imports.zig
+++ b/src/link/MachO/imports.zig
@@ -6,365 +6,177 @@ const mem = std.mem;
 const assert = std.debug.assert;
 const Allocator = mem.Allocator;
 
-pub const RebaseInfoTable = struct {
-    rebase_type: u8 = macho.REBASE_TYPE_POINTER,
-    symbols: std.ArrayListUnmanaged(Symbol) = .{},
+pub const ExternSymbol = struct {
+    /// Symbol name.
+    /// We own the memory, therefore we'll need to free it by calling `deinit`.
+    /// In self-hosted, we don't expect it to be null ever.
+    /// However, this is for backwards compatibility with LLD when
+    /// we'll be patching things up post mortem.
+    name: ?[]u8 = null,
 
-    pub const Symbol = struct {
-        segment: u8,
-        offset: i64,
-    };
+    /// Id of the dynamic library where the specified entries can be found.
+    /// Id of 0 means self.
+    /// TODO this should really be an id into the table of all defined
+    /// dylibs.
+    dylib_ordinal: i64 = 0,
 
-    pub fn deinit(self: *RebaseInfoTable, allocator: *Allocator) void {
-        self.symbols.deinit(allocator);
-    }
+    segment: u16 = 0,
+    offset: u32 = 0,
+    addend: ?i32 = null,
+    index: u32,
 
-    /// Write the rebase info table to byte stream.
-    pub fn write(self: RebaseInfoTable, writer: anytype) !void {
-        for (self.symbols.items) |symbol| {
-            try writer.writeByte(macho.REBASE_OPCODE_SET_TYPE_IMM | @truncate(u4, self.rebase_type));
-            try writer.writeByte(macho.REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | @truncate(u4, symbol.segment));
-            try leb.writeILEB128(writer, symbol.offset);
-            try writer.writeByte(macho.REBASE_OPCODE_DO_REBASE_IMM_TIMES | @truncate(u4, 1));
+    pub fn deinit(self: *ExternSymbol, allocator: *Allocator) void {
+        if (self.name) |*name| {
+            allocator.free(name);
         }
-
-        try writer.writeByte(macho.REBASE_OPCODE_DONE);
-    }
-
-    /// Calculate size in bytes of this rebase info table.
-    pub fn calcSize(self: *RebaseInfoTable) !u64 {
-        var stream = std.io.countingWriter(std.io.null_writer);
-        var writer = stream.writer();
-        var size: u64 = 0;
-
-        for (self.symbols.items) |symbol| {
-            size += 2;
-            try leb.writeILEB128(writer, symbol.offset);
-            size += 1;
-        }
-
-        size += 1 + stream.bytes_written;
-        return size;
     }
 };
 
-/// Table of binding info entries used to tell the dyld which
-/// symbols to bind at loading time.
-pub const BindingInfoTable = struct {
-    /// Id of the dynamic library where the specified entries can be found.
-    dylib_ordinal: i64 = 0,
+pub fn rebaseInfoSize(symbols: []*const ExternSymbol) !u64 {
+    var stream = std.io.countingWriter(std.io.null_writer);
+    var writer = stream.writer();
+    var size: u64 = 0;
 
-    /// Binding type; defaults to pointer type.
-    binding_type: u8 = macho.BIND_TYPE_POINTER,
-
-    symbols: std.ArrayListUnmanaged(Symbol) = .{},
-
-    pub const Symbol = struct {
-        /// Symbol name.
-        name: ?[]u8 = null,
-
-        /// Id of the segment where to bind this symbol to.
-        segment: u8,
-
-        /// Offset of this symbol wrt to the segment id encoded in `segment`.
-        offset: i64,
-
-        /// Addend value (if any).
-        addend: ?i64 = null,
-    };
-
-    pub fn deinit(self: *BindingInfoTable, allocator: *Allocator) void {
-        for (self.symbols.items) |*symbol| {
-            if (symbol.name) |name| {
-                allocator.free(name);
-            }
-        }
-        self.symbols.deinit(allocator);
+    for (symbols) |symbol| {
+        size += 2;
+        try leb.writeILEB128(writer, symbol.offset);
+        size += 1;
     }
 
-    /// Parse the binding info table from byte stream.
-    pub fn read(self: *BindingInfoTable, reader: anytype, allocator: *Allocator) !void {
-        var symbol: Symbol = .{
-            .segment = 0,
-            .offset = 0,
-        };
+    size += 1 + stream.bytes_written;
+    return size;
+}
 
-        var dylib_ordinal_set = false;
-        var done = false;
-        while (true) {
-            const inst = reader.readByte() catch |err| switch (err) {
-                error.EndOfStream => break,
-                else => return err,
-            };
-            const imm: u8 = inst & macho.BIND_IMMEDIATE_MASK;
-            const opcode: u8 = inst & macho.BIND_OPCODE_MASK;
-
-            switch (opcode) {
-                macho.BIND_OPCODE_DO_BIND => {
-                    try self.symbols.append(allocator, symbol);
-                    symbol = .{
-                        .segment = 0,
-                        .offset = 0,
-                    };
-                },
-                macho.BIND_OPCODE_DONE => {
-                    done = true;
-                    break;
-                },
-                macho.BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM => {
-                    var name = std.ArrayList(u8).init(allocator);
-                    var next = try reader.readByte();
-                    while (next != @as(u8, 0)) {
-                        try name.append(next);
-                        next = try reader.readByte();
-                    }
-                    symbol.name = name.toOwnedSlice();
-                },
-                macho.BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB => {
-                    symbol.segment = imm;
-                    symbol.offset = try leb.readILEB128(i64, reader);
-                },
-                macho.BIND_OPCODE_SET_DYLIB_SPECIAL_IMM, macho.BIND_OPCODE_SET_DYLIB_ORDINAL_IMM => {
-                    assert(!dylib_ordinal_set);
-                    self.dylib_ordinal = imm;
-                },
-                macho.BIND_OPCODE_SET_DYLIB_ORDINAL_ULEB => {
-                    assert(!dylib_ordinal_set);
-                    self.dylib_ordinal = try leb.readILEB128(i64, reader);
-                },
-                macho.BIND_OPCODE_SET_TYPE_IMM => {
-                    self.binding_type = imm;
-                },
-                macho.BIND_OPCODE_SET_ADDEND_SLEB => {
-                    symbol.addend = try leb.readILEB128(i64, reader);
-                },
-                else => {
-                    std.log.warn("unhandled BIND_OPCODE_: 0x{x}", .{opcode});
-                },
-            }
-        }
-        assert(done);
+pub fn writeRebaseInfo(symbols: []*const ExternSymbol, writer: anytype) !void {
+    for (symbols) |symbol| {
+        try writer.writeByte(macho.REBASE_OPCODE_SET_TYPE_IMM | @truncate(u4, macho.REBASE_TYPE_POINTER));
+        try writer.writeByte(macho.REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | @truncate(u4, symbol.segment));
+        try leb.writeILEB128(writer, symbol.offset);
+        try writer.writeByte(macho.REBASE_OPCODE_DO_REBASE_IMM_TIMES | @truncate(u4, 1));
     }
+    try writer.writeByte(macho.REBASE_OPCODE_DONE);
+}
 
-    /// Write the binding info table to byte stream.
-    pub fn write(self: BindingInfoTable, writer: anytype) !void {
-        if (self.dylib_ordinal > 15) {
-            try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_ORDINAL_ULEB);
-            try leb.writeULEB128(writer, @bitCast(u64, self.dylib_ordinal));
-        } else if (self.dylib_ordinal > 0) {
-            try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_ORDINAL_IMM | @truncate(u4, @bitCast(u64, self.dylib_ordinal)));
-        } else {
-            try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_SPECIAL_IMM | @truncate(u4, @bitCast(u64, self.dylib_ordinal)));
+pub fn bindInfoSize(symbols: []*const ExternSymbol) !u64 {
+    var stream = std.io.countingWriter(std.io.null_writer);
+    var writer = stream.writer();
+    var size: u64 = 0;
+
+    for (symbols) |symbol| {
+        size += 1;
+        if (symbol.dylib_ordinal > 15) {
+            try leb.writeULEB128(writer, @bitCast(u64, symbol.dylib_ordinal));
         }
-        try writer.writeByte(macho.BIND_OPCODE_SET_TYPE_IMM | @truncate(u4, self.binding_type));
+        size += 1;
 
-        for (self.symbols.items) |symbol| {
-            if (symbol.name) |name| {
-                try writer.writeByte(macho.BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM); // TODO Sometimes we might want to add flags.
-                try writer.writeAll(name);
-                try writer.writeByte(0);
-            }
-
-            try writer.writeByte(macho.BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | @truncate(u4, symbol.segment));
-            try leb.writeILEB128(writer, symbol.offset);
-
-            if (symbol.addend) |addend| {
-                try writer.writeByte(macho.BIND_OPCODE_SET_ADDEND_SLEB);
-                try leb.writeILEB128(writer, addend);
-            }
-
-            try writer.writeByte(macho.BIND_OPCODE_DO_BIND);
-        }
-
-        try writer.writeByte(macho.BIND_OPCODE_DONE);
-    }
-
-    /// Calculate size in bytes of this binding info table.
-    pub fn calcSize(self: *BindingInfoTable) !u64 {
-        var stream = std.io.countingWriter(std.io.null_writer);
-        var writer = stream.writer();
-        var size: u64 = 1;
-
-        if (self.dylib_ordinal > 15) {
-            try leb.writeULEB128(writer, @bitCast(u64, self.dylib_ordinal));
+        if (symbol.name) |name| {
+            size += 1;
+            size += name.len;
+            size += 1;
         }
 
         size += 1;
+        try leb.writeILEB128(writer, symbol.offset);
 
-        for (self.symbols.items) |symbol| {
-            if (symbol.name) |name| {
-                size += 1;
-                size += name.len;
-                size += 1;
-            }
-
+        if (symbol.addend) |addend| {
             size += 1;
-            try leb.writeILEB128(writer, symbol.offset);
+            try leb.writeILEB128(writer, addend);
+        }
 
-            if (symbol.addend) |addend| {
-                size += 1;
-                try leb.writeILEB128(writer, addend);
-            }
+        size += 2;
+    }
 
+    size += stream.bytes_written;
+    return size;
+}
+
+pub fn writeBindInfo(symbols: []*const ExternSymbol, writer: anytype) !void {
+    for (symbols) |symbol| {
+        if (symbol.dylib_ordinal > 15) {
+            try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_ORDINAL_ULEB);
+            try leb.writeULEB128(writer, @bitCast(u64, symbol.dylib_ordinal));
+        } else if (symbol.dylib_ordinal > 0) {
+            try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_ORDINAL_IMM | @truncate(u4, @bitCast(u64, symbol.dylib_ordinal)));
+        } else {
+            try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_SPECIAL_IMM | @truncate(u4, @bitCast(u64, symbol.dylib_ordinal)));
+        }
+        try writer.writeByte(macho.BIND_OPCODE_SET_TYPE_IMM | @truncate(u4, macho.BIND_TYPE_POINTER));
+
+        if (symbol.name) |name| {
+            try writer.writeByte(macho.BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM); // TODO Sometimes we might want to add flags.
+            try writer.writeAll(name);
+            try writer.writeByte(0);
+        }
+
+        try writer.writeByte(macho.BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | @truncate(u4, symbol.segment));
+        try leb.writeILEB128(writer, symbol.offset);
+
+        if (symbol.addend) |addend| {
+            try writer.writeByte(macho.BIND_OPCODE_SET_ADDEND_SLEB);
+            try leb.writeILEB128(writer, addend);
+        }
+
+        try writer.writeByte(macho.BIND_OPCODE_DO_BIND);
+        try writer.writeByte(macho.BIND_OPCODE_DONE);
+    }
+}
+
+pub fn lazyBindInfoSize(symbols: []*const ExternSymbol) !u64 {
+    var stream = std.io.countingWriter(std.io.null_writer);
+    var writer = stream.writer();
+    var size: u64 = 0;
+
+    for (symbols) |symbol| {
+        size += 1;
+        try leb.writeILEB128(writer, symbol.offset);
+
+        if (symbol.addend) |addend| {
+            size += 1;
+            try leb.writeILEB128(writer, addend);
+        }
+
+        size += 1;
+        if (symbol.dylib_ordinal > 15) {
+            try leb.writeULEB128(writer, @bitCast(u64, symbol.dylib_ordinal));
+        }
+        if (symbol.name) |name| {
+            size += 1;
+            size += name.len;
             size += 1;
         }
-
-        size += 1 + stream.bytes_written;
-        return size;
-    }
-};
-
-/// Table of lazy binding info entries used to tell the dyld which
-/// symbols to lazily bind at first load of a dylib.
-pub const LazyBindingInfoTable = struct {
-    symbols: std.ArrayListUnmanaged(Symbol) = .{},
-
-    pub const Symbol = struct {
-        /// Symbol name.
-        name: ?[]u8 = null,
-
-        /// Offset of this symbol wrt to the segment id encoded in `segment`.
-        offset: i64,
-
-        /// Id of the dylib where this symbol is expected to reside.
-        /// Positive ordinals point at dylibs imported with LC_LOAD_DYLIB,
-        /// 0 means this binary, -1 the main executable, and -2 flat lookup.
-        dylib_ordinal: i64,
-
-        /// Id of the segment where to bind this symbol to.
-        segment: u8,
-
-        /// Addend value (if any).
-        addend: ?i64 = null,
-    };
-
-    pub fn deinit(self: *LazyBindingInfoTable, allocator: *Allocator) void {
-        for (self.symbols.items) |*symbol| {
-            if (symbol.name) |name| {
-                allocator.free(name);
-            }
-        }
-        self.symbols.deinit(allocator);
+        size += 2;
     }
 
-    /// Parse the binding info table from byte stream.
-    pub fn read(self: *LazyBindingInfoTable, reader: anytype, allocator: *Allocator) !void {
-        var symbol: Symbol = .{
-            .offset = 0,
-            .segment = 0,
-            .dylib_ordinal = 0,
-        };
+    size += stream.bytes_written;
+    return size;
+}
 
-        var done = false;
-        while (true) {
-            const inst = reader.readByte() catch |err| switch (err) {
-                error.EndOfStream => break,
-                else => return err,
-            };
-            const imm: u8 = inst & macho.BIND_IMMEDIATE_MASK;
-            const opcode: u8 = inst & macho.BIND_OPCODE_MASK;
+pub fn writeLazyBindInfo(symbols: []*const ExternSymbol, writer: anytype) !void {
+    for (symbols) |symbol| {
+        try writer.writeByte(macho.BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | @truncate(u4, symbol.segment));
+        try leb.writeILEB128(writer, symbol.offset);
 
-            switch (opcode) {
-                macho.BIND_OPCODE_DO_BIND => {
-                    try self.symbols.append(allocator, symbol);
-                },
-                macho.BIND_OPCODE_DONE => {
-                    done = true;
-                    symbol = .{
-                        .offset = 0,
-                        .segment = 0,
-                        .dylib_ordinal = 0,
-                    };
-                },
-                macho.BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM => {
-                    var name = std.ArrayList(u8).init(allocator);
-                    var next = try reader.readByte();
-                    while (next != @as(u8, 0)) {
-                        try name.append(next);
-                        next = try reader.readByte();
-                    }
-                    symbol.name = name.toOwnedSlice();
-                },
-                macho.BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB => {
-                    symbol.segment = imm;
-                    symbol.offset = try leb.readILEB128(i64, reader);
-                },
-                macho.BIND_OPCODE_SET_DYLIB_SPECIAL_IMM, macho.BIND_OPCODE_SET_DYLIB_ORDINAL_IMM => {
-                    symbol.dylib_ordinal = imm;
-                },
-                macho.BIND_OPCODE_SET_DYLIB_ORDINAL_ULEB => {
-                    symbol.dylib_ordinal = try leb.readILEB128(i64, reader);
-                },
-                macho.BIND_OPCODE_SET_ADDEND_SLEB => {
-                    symbol.addend = try leb.readILEB128(i64, reader);
-                },
-                else => {
-                    std.log.warn("unhandled BIND_OPCODE_: 0x{x}", .{opcode});
-                },
-            }
-        }
-        assert(done);
-    }
-
-    /// Write the binding info table to byte stream.
-    pub fn write(self: LazyBindingInfoTable, writer: anytype) !void {
-        for (self.symbols.items) |symbol| {
-            try writer.writeByte(macho.BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | @truncate(u4, symbol.segment));
-            try leb.writeILEB128(writer, symbol.offset);
-
-            if (symbol.addend) |addend| {
-                try writer.writeByte(macho.BIND_OPCODE_SET_ADDEND_SLEB);
-                try leb.writeILEB128(writer, addend);
-            }
-
-            if (symbol.dylib_ordinal > 15) {
-                try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_ORDINAL_ULEB);
-                try leb.writeULEB128(writer, @bitCast(u64, symbol.dylib_ordinal));
-            } else if (symbol.dylib_ordinal > 0) {
-                try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_ORDINAL_IMM | @truncate(u4, @bitCast(u64, symbol.dylib_ordinal)));
-            } else {
-                try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_SPECIAL_IMM | @truncate(u4, @bitCast(u64, symbol.dylib_ordinal)));
-            }
-
-            if (symbol.name) |name| {
-                try writer.writeByte(macho.BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM); // TODO Sometimes we might want to add flags.
-                try writer.writeAll(name);
-                try writer.writeByte(0);
-            }
-
-            try writer.writeByte(macho.BIND_OPCODE_DO_BIND);
-            try writer.writeByte(macho.BIND_OPCODE_DONE);
-        }
-    }
-
-    /// Calculate size in bytes of this binding info table.
-    pub fn calcSize(self: *LazyBindingInfoTable) !u64 {
-        var stream = std.io.countingWriter(std.io.null_writer);
-        var writer = stream.writer();
-        var size: u64 = 0;
-
-        for (self.symbols.items) |symbol| {
-            size += 1;
-            try leb.writeILEB128(writer, symbol.offset);
-
-            if (symbol.addend) |addend| {
-                size += 1;
-                try leb.writeILEB128(writer, addend);
-            }
-
-            size += 1;
-            if (symbol.dylib_ordinal > 15) {
-                try leb.writeULEB128(writer, @bitCast(u64, symbol.dylib_ordinal));
-            }
-            if (symbol.name) |name| {
-                size += 1;
-                size += name.len;
-                size += 1;
-            }
-            size += 2;
+        if (symbol.addend) |addend| {
+            try writer.writeByte(macho.BIND_OPCODE_SET_ADDEND_SLEB);
+            try leb.writeILEB128(writer, addend);
         }
 
-        size += stream.bytes_written;
-        return size;
+        if (symbol.dylib_ordinal > 15) {
+            try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_ORDINAL_ULEB);
+            try leb.writeULEB128(writer, @bitCast(u64, symbol.dylib_ordinal));
+        } else if (symbol.dylib_ordinal > 0) {
+            try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_ORDINAL_IMM | @truncate(u4, @bitCast(u64, symbol.dylib_ordinal)));
+        } else {
+            try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_SPECIAL_IMM | @truncate(u4, @bitCast(u64, symbol.dylib_ordinal)));
+        }
+
+        if (symbol.name) |name| {
+            try writer.writeByte(macho.BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM); // TODO Sometimes we might want to add flags.
+            try writer.writeAll(name);
+            try writer.writeByte(0);
+        }
+
+        try writer.writeByte(macho.BIND_OPCODE_DO_BIND);
+        try writer.writeByte(macho.BIND_OPCODE_DONE);
     }
-};
+}

--- a/src/link/MachO/imports.zig
+++ b/src/link/MachO/imports.zig
@@ -21,9 +21,8 @@ pub const RebaseInfoTable = struct {
 
     /// Write the rebase info table to byte stream.
     pub fn write(self: RebaseInfoTable, writer: anytype) !void {
-        try writer.writeByte(macho.REBASE_OPCODE_SET_TYPE_IMM | @truncate(u4, self.rebase_type));
-
         for (self.symbols.items) |symbol| {
+            try writer.writeByte(macho.REBASE_OPCODE_SET_TYPE_IMM | @truncate(u4, self.rebase_type));
             try writer.writeByte(macho.REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | @truncate(u4, symbol.segment));
             try leb.writeILEB128(writer, symbol.offset);
             try writer.writeByte(macho.REBASE_OPCODE_DO_REBASE_IMM_TIMES | @truncate(u4, 1));
@@ -36,10 +35,10 @@ pub const RebaseInfoTable = struct {
     pub fn calcSize(self: *RebaseInfoTable) !u64 {
         var stream = std.io.countingWriter(std.io.null_writer);
         var writer = stream.writer();
-        var size: u64 = 1;
+        var size: u64 = 0;
 
         for (self.symbols.items) |symbol| {
-            size += 1;
+            size += 2;
             try leb.writeILEB128(writer, symbol.offset);
             size += 1;
         }

--- a/test/stage2/aarch64.zig
+++ b/test/stage2/aarch64.zig
@@ -209,7 +209,8 @@ pub fn addCases(ctx: *TestContext) !void {
             \\extern "c" fn exit(usize) noreturn;
             \\
             \\export fn _start() noreturn {
-            \\    write(1, @ptrToInt("Hello, World!\n"), 14);
+            \\    write(1, @ptrToInt("Hello,"), 6);
+            \\    write(1, @ptrToInt(" World!\n,"), 8);
             \\    exit(0);
             \\}
         ,

--- a/test/stage2/aarch64.zig
+++ b/test/stage2/aarch64.zig
@@ -199,4 +199,21 @@ pub fn addCases(ctx: *TestContext) !void {
             "",
         );
     }
+
+    {
+        var case = ctx.exe("hello world linked to libc", macos_aarch64);
+
+        // TODO rewrite this test once we handle more int conversions and return args.
+        case.addCompareOutput(
+            \\extern "c" fn write(usize, usize, usize) void;
+            \\extern "c" fn exit(usize) noreturn;
+            \\
+            \\export fn _start() noreturn {
+            \\    write(1, @ptrToInt("Hello, World!\n"), 14);
+            \\    exit(0);
+            \\}
+        ,
+            "Hello, World!\n",
+        );
+    }
 }

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1495,4 +1495,22 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , &[_][]const u8{":8:10: error: evaluation exceeded 1000 backwards branches"});
     }
+
+    {
+        var case = ctx.exe("hello world linked to libc", macosx_x64);
+
+        // TODO rewrite this test once we handle more int conversions and return args.
+        case.addCompareOutput(
+            \\extern "c" fn write(usize, usize, usize) void;
+            \\extern "c" fn exit(usize) noreturn;
+            \\
+            \\export fn _start() noreturn {
+            \\    write(1, @ptrToInt("Hello,"), 6);
+            \\    write(1, @ptrToInt(" World!\n,"), 8);
+            \\    exit(0);
+            \\}
+        ,
+            "Hello, World!\n",
+        );
+    }
 }


### PR DESCRIPTION
~~**Do not merge until #7731 lands.**~~

This PR adds and wires up the necessary parts within the MachO linker to allow for use of `extern fn`s targeting Apple's platforms in stage2. The new additions include:
* Added new segment `__DATA_CONST` which includes section `__got`. This section contains a placeholder for the address of the `dyld_stub_binder` required to resolve the addresses of `extern fn`s from linked dylibs.
* Added new `__TEXT` sections `__stubs` and `__stub_helper` which contain the necessary boilerplate trampoline code to properly wire up the `extern fn`s in MachO.
* Added new `__DATA` sections `__la_symbol_ptr` and `__data`. The former comprises of placeholders where actual addresses to the resolved `extern fn`s will be saved and fed to the stub trampolines defined in `__stubs` and `__stub_helper` sections.
* Updated the `DebugSymbols` to include a mapping to the new segments/sections.
* Streamlined writing rebase and binding tables; simplified handling of cross-compilation hotfix when linking with LLD.
* Added basic test cases for "Hello, World!" using libc `write` and `exit` on both `aarch64` and `x86_64` architectures:

```zig
extern "c" fn write(usize, usize, usize) void;
extern "c" fn exit(usize) noreturn;

export fn _start() noreturn {
    write(1, @ptrToInt("Hello,"), 6);
    write(1, @ptrToInt(" World!\n", 8);
    exit(0);
}
```