### PR TITLE
std.elf: expose parsing decoupled from std.fs.File

### DIFF
--- a/lib/std/build/emit_raw.zig
+++ b/lib/std/build/emit_raw.zig
@@ -51,9 +51,10 @@ const BinaryElfOutput = struct {
             .segments = ArrayList(*BinaryElfSegment).init(allocator),
             .sections = ArrayList(*BinaryElfSection).init(allocator),
         };
-        const elf_hdr = try std.elf.readHeader(elf_file);
+        const elf_source = std.elf.FileParseSource{ .file = elf_file };
+        const elf_hdr = try std.elf.Header.read(elf_source);
 
-        var section_headers = elf_hdr.section_header_iterator(elf_file);
+        var section_headers = elf_hdr.section_header_iterator(elf_source);
         while (try section_headers.next()) |section| {
             if (sectionValidForOutput(section)) {
                 const newSection = try allocator.create(BinaryElfSection);
@@ -67,7 +68,7 @@ const BinaryElfOutput = struct {
             }
         }
 
-        var program_headers = elf_hdr.program_header_iterator(elf_file);
+        var program_headers = elf_hdr.program_header_iterator(elf_source);
         while (try program_headers.next()) |phdr| {
             if (phdr.p_type == elf.PT_LOAD) {
                 const newSegment = try allocator.create(BinaryElfSegment);

--- a/lib/std/build/emit_raw.zig
+++ b/lib/std/build/emit_raw.zig
@@ -51,10 +51,9 @@ const BinaryElfOutput = struct {
             .segments = ArrayList(*BinaryElfSegment).init(allocator),
             .sections = ArrayList(*BinaryElfSection).init(allocator),
         };
-        const elf_source = std.elf.FileParseSource{ .file = elf_file };
-        const elf_hdr = try std.elf.Header.read(elf_source);
+        const elf_hdr = try std.elf.Header.read(&elf_file);
 
-        var section_headers = elf_hdr.section_header_iterator(elf_source);
+        var section_headers = elf_hdr.section_header_iterator(&elf_file);
         while (try section_headers.next()) |section| {
             if (sectionValidForOutput(section)) {
                 const newSection = try allocator.create(BinaryElfSection);
@@ -68,7 +67,7 @@ const BinaryElfOutput = struct {
             }
         }
 
-        var program_headers = elf_hdr.program_header_iterator(elf_source);
+        var program_headers = elf_hdr.program_header_iterator(&elf_file);
         while (try program_headers.next()) |phdr| {
             if (phdr.p_type == elf.PT_LOAD) {
                 const newSegment = try allocator.create(BinaryElfSegment);

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -365,8 +365,12 @@ const Header = struct {
 pub fn readHeader(file: File) !Header {
     var hdr_buf: [@sizeOf(Elf64_Ehdr)]u8 align(@alignOf(Elf64_Ehdr)) = undefined;
     try preadNoEof(file, &hdr_buf, 0);
-    const hdr32 = @ptrCast(*Elf32_Ehdr, &hdr_buf);
-    const hdr64 = @ptrCast(*Elf64_Ehdr, &hdr_buf);
+    return parseHeader(hdr_buf);
+}
+
+pub fn parseHeader(hdr_buf: *align(@alignOf(Elf64_Ehdr)) const [@sizeOf(Elf64_Ehdr)]u8) !Header {
+    const hdr32 = @ptrCast(*const Elf32_Ehdr, hdr_buf);
+    const hdr64 = @ptrCast(*const Elf64_Ehdr, hdr_buf);
     if (!mem.eql(u8, hdr32.e_ident[0..4], "\x7fELF")) return error.InvalidElfMagic;
     if (hdr32.e_ident[EI_VERSION] != 1) return error.InvalidElfVersion;
 

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -335,7 +335,7 @@ pub const ET = extern enum(u16) {
 };
 
 /// All integers are native endian.
-const Header = struct {
+pub const Header = struct {
     endian: builtin.Endian,
     is_64: bool,
     entry: u64,

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -398,7 +398,7 @@ pub const Header = struct {
 pub fn readHeader(file: File) !Header {
     var hdr_buf: [@sizeOf(Elf64_Ehdr)]u8 align(@alignOf(Elf64_Ehdr)) = undefined;
     try preadNoEof(file, &hdr_buf, 0);
-    return Header.parse(hdr_buf);
+    return Header.parse(&hdr_buf);
 }
 
 pub const ProgramHeaderIterator = struct {

--- a/src/test.zig
+++ b/src/test.zig
@@ -989,9 +989,8 @@ pub const TestContext = struct {
             var file = try tmp_dir.openFile(bin_name, .{ .read = true });
             defer file.close();
 
-            const elf_source = std.elf.FileParseSource{ .file = file };
-            const header = try std.elf.Header.read(elf_source);
-            var iterator = header.program_header_iterator(elf_source);
+            const header = try std.elf.Header.read(&file);
+            var iterator = header.program_header_iterator(&file);
 
             var none_loaded = true;
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -989,8 +989,9 @@ pub const TestContext = struct {
             var file = try tmp_dir.openFile(bin_name, .{ .read = true });
             defer file.close();
 
-            const header = try std.elf.readHeader(file);
-            var iterator = header.program_header_iterator(file);
+            const elf_source = std.elf.FileParseSource{ .file = file };
+            const header = try std.elf.Header.read(elf_source);
+            var iterator = header.program_header_iterator(elf_source);
 
             var none_loaded = true;
 


### PR DESCRIPTION
I don't know what the maintenance status of `std.elf` is, or how much we want to expose. This PR separates the parsing in `std.elf.readHeader` into `std.elf.parseHeader` for non-`File`-based use.