### PR TITLE
std.os: add atexit() implementation

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -82,6 +82,7 @@ pub extern "c" fn printf(format: [*:0]const u8, ...) c_int;
 pub extern "c" fn abort() noreturn;
 pub extern "c" fn exit(code: c_int) noreturn;
 pub extern "c" fn _exit(code: c_int) noreturn;
+pub extern "c" fn atexit(function: ?fn () callconv(.C) void) c_int;
 pub extern "c" fn isatty(fd: fd_t) c_int;
 pub extern "c" fn close(fd: fd_t) c_int;
 pub extern "c" fn lseek(fd: fd_t, offset: off_t, whence: c_int) off_t;


### PR DESCRIPTION
This change adds a Zig wrapper for the C stdlib `atexit(3)` function, which registers a function to be called at program exit, either from normal termination or from main() returning.