### PR TITLE
translate-c: ensure bools are cast to int when necessary

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -703,4 +703,20 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Cast boolean expression result to int",
+        \\#include <stdlib.h>
+        \\char foo(char c) { return c; }
+        \\int  bar(int i)  { return i; }
+        \\long baz(long l) { return l; }
+        \\int main() {
+        \\    if (foo(1 == 2)) abort();
+        \\    if (!foo(1 == 1)) abort();
+        \\    if (bar(1 == 2)) abort();
+        \\    if (!bar(1 == 1)) abort();
+        \\    if (baz(1 == 2)) abort();
+        \\    if (!baz(1 == 1)) abort();
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
Fixes two scenarios where @boolToInt() calls were missing:

1. Boolean expression cast to different-size int (char, long, etc)
2. Boolean expression used as parameter for function with int argument