### PR TITLE
macho: ensure that strtab always follows symtab

### DIFF
--- a/test/stage2/aarch64.zig
+++ b/test/stage2/aarch64.zig
@@ -217,4 +217,20 @@ pub fn addCases(ctx: *TestContext) !void {
             "Hello, World!\n",
         );
     }
+
+    {
+        var case = ctx.exe("only libc exit", macos_aarch64);
+
+        // This test case covers an infrequent scenarion where the string table *may* be relocated
+        // into the position preceeding the symbol table which results in a dyld error.
+        case.addCompareOutput(
+            \\extern "c" fn exit(usize) noreturn;
+            \\
+            \\export fn _start() noreturn {
+            \\    exit(0);
+            \\}
+        ,
+            "",
+        );
+    }
 }

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1513,4 +1513,20 @@ pub fn addCases(ctx: *TestContext) !void {
             "Hello, World!\n",
         );
     }
+
+    {
+        var case = ctx.exe("only libc exit", macosx_x64);
+
+        // This test case covers an infrequent scenarion where the string table *may* be relocated
+        // into the position preceeding the symbol table which results in a dyld error.
+        case.addCompareOutput(
+            \\extern "c" fn exit(usize) noreturn;
+            \\
+            \\export fn _start() noreturn {
+            \\    exit(0);
+            \\}
+        ,
+            "",
+        );
+    }
 }


### PR DESCRIPTION
In rare occassions, it may happen that string table is allocated free
space preceeding symbol table. This is an error in the eyes of the `dyld`
dynamic loader and thus has to forbidden by the linker.