### PR TITLE
translate-c: add <assert.h> support

### DIFF
--- a/lib/std/c/builtins.zig
+++ b/lib/std/c/builtins.zig
@@ -182,3 +182,9 @@ pub fn __builtin_memcpy(
     @memcpy(dst_cast, src_cast, len);
     return dst;
 }
+
+/// The return value of __builtin_expect is `expr`. `c` is the expected value
+/// of `expr` and is used as a hint to the compiler in C. Here it is unused.
+pub fn __builtin_expect(expr: c_long, c: c_long) callconv(.Inline) c_long {
+    return expr;
+}

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1106,4 +1106,27 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("handle assert.h",
+        \\#include <assert.h>
+        \\int main() {
+        \\    int x = 1;
+        \\    int *xp = &x;
+        \\    assert(1);
+        \\    assert(x != 0);
+        \\    assert(xp);
+        \\    assert(*xp);
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("NDEBUG disables assert",
+        \\#define NDEBUG
+        \\#include <assert.h>
+        \\int main() {
+        \\    assert(0);
+        \\    assert(NULL);
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
Implement __builtin_expect so C code that uses assert() can be translated.