### PR TITLE
translate-c: Add Wide, UTF-16, and UTF-32 character literals

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -719,4 +719,22 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Wide, UTF-16, and UTF-32 character literals",
+        \\#include <wchar.h>
+        \\#include <stdlib.h>
+        \\int main() {
+        \\    wchar_t wc = L'™';
+        \\    int utf16_char = u'™';
+        \\    int utf32_char = U'💯';
+        \\    if (wc != 8482) abort();
+        \\    if (utf16_char != 8482) abort();
+        \\    if (utf32_char != 128175) abort();
+        \\    unsigned char c = wc;
+        \\    if (c != 0x22) abort();
+        \\    c = utf32_char;
+        \\    if (c != 0xaf) abort();
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
Add support for L'<wchar_t>', u'<char16_t>', and U'<char32_t>'. Currently
this just translates wide char literals to \u{NNNNNN} escape codes
(e.g. U'💯' -> '\u{1f4af}')

Another approach would be to emit UTF-8 encoded character literals
directly, but in my opinion this approaches Unicode-complete because it
would require knowledge of which Unicode codepoints have graphical
representations for the emitted source to be readable.

We could also just emit integer literals, but the current method makes
it clear that we have translated a wide character literal and not just
an integer constant.