### PR TITLE
add error for slice.len increment beyond bounds

### DIFF
--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -22655,9 +22655,10 @@ static IrInstGen *ir_analyze_instruction_elem_ptr(IrAnalyze *ira, IrInstSrcElemP
                                 if (ptr_field->data.x_ptr.data.base_array.array_val->data.x_array.special !=
                                         ConstArraySpecialBuf)
                                 {
-                                    ir_assert(new_index <
-                                            ptr_field->data.x_ptr.data.base_array.array_val->type->data.array.len,
-                                        &elem_ptr_instruction->base.base);
+                                    if (new_index >= ptr_field->data.x_ptr.data.base_array.array_val->type->data.array.len) {
+                                        ir_add_error(ira, &elem_ptr_instruction->base.base, buf_sprintf("out of bounds slice"));
+                                        return ira->codegen->invalid_inst_gen;
+                                    }
                                 }
                                 out_val->data.x_ptr.special = ConstPtrSpecialBaseArray;
                                 out_val->data.x_ptr.data.base_array.array_val =

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -7981,6 +7981,20 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:7:37: note: referenced here",
     });
 
+    // issue #7810
+    cases.add("comptime slice-len increment beyond bounds",
+        \\export fn foo_slice_len_increment_beyond_bounds() void {
+        \\    comptime {
+        \\        var buf_storage: [8]u8 = undefined;
+        \\        var buf: []const u8 = buf_storage[0..];
+        \\        buf.len += 1;
+        \\        buf[8] = 42;
+        \\    }
+        \\}
+    , &[_][]const u8{
+        ":6:12: error: out of bounds slice",
+    });
+
     cases.add("comptime slice-sentinel is out of bounds (unterminated)",
         \\export fn foo_array() void {
         \\    comptime {


### PR DESCRIPTION
comptime direct slice.len increment dodges bounds checking but
we can emit an error for it, at least in the simple case.

- promote original assert to compile-error
- add test case

closes #7810