### PR TITLE
Macho more cleanup

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1617,8 +1617,10 @@ pub fn analyzeContainer(self: *Module, container_scope: *Scope.Container) !void 
                             // in `Decl` to notice that the line number did not change.
                             self.comp.work_queue.writeItemAssumeCapacity(.{ .update_line_number = decl });
                         },
-                        .macho => {
-                            // TODO Implement for MachO
+                        .macho => if (decl.fn_link.macho.len != 0) {
+                            // TODO Look into detecting when this would be unnecessary by storing enough state
+                            // in `Decl` to notice that the line number did not change.
+                            self.comp.work_queue.writeItemAssumeCapacity(.{ .update_line_number = decl });
                         },
                         .c, .wasm => {},
                     }

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -1079,7 +1079,8 @@ pub fn commitDeclDebugInfo(
             const debug_line_sect = &dwarf_segment.sections.items[self.debug_line_section_index.?];
             const src_fn = &decl.fn_link.macho;
             src_fn.len = @intCast(u32, dbg_line_buffer.items.len);
-            if (self.dbg_line_fn_last) |last| {
+            if (self.dbg_line_fn_last) |last| blk: {
+                if (src_fn == last) break :blk;
                 if (src_fn.next) |next| {
                     // Update existing function - non-last item.
                     if (src_fn.off + src_fn.len + min_nop_size > next.off) {
@@ -1238,7 +1239,8 @@ fn updateDeclDebugInfoAllocation(
     const dwarf_segment = &self.load_commands.items[self.dwarf_segment_cmd_index.?].Segment;
     const debug_info_sect = &dwarf_segment.sections.items[self.debug_info_section_index.?];
     text_block.dbg_info_len = len;
-    if (self.dbg_info_decl_last) |last| {
+    if (self.dbg_info_decl_last) |last| blk: {
+        if (text_block == last) break :blk;
         if (text_block.dbg_info_next) |next| {
             // Update existing Decl - non-last item.
             if (text_block.dbg_info_off + text_block.dbg_info_len + min_nop_size > next.dbg_info_off) {


### PR DESCRIPTION
This PR cleans up how we write indirect symbol table into the final artifact. It also forces rewriting of code signature padding at every update so that we take into account possible section relocations and expansion of the last preceding section, e.g., the string table.

This PR also tweaks the logic responsible for managing debug lines in `DebugSymbols`. In particular, in case we update the same function, we'd previously incorrectly create a cycle adding pointer to the same `SrcFn` to itself.  This would manifest itself when running self-hosted compiler in `watch` mode with a segfault in this line: [src/link/MachO/DebugSymbols.zig#L1142](https://github.com/ziglang/zig/blob/c3dadfa95b01d140460eb3d3d47d13859302f298/src/link/MachO/DebugSymbols.zig#L1142). Since we've just created a cycle pointing `SrcFn` inside `Decl` to itself, the offsets will cancel out, leaving out us trying to save negative length into a `u32` value. A repro on macOS would be the following:

* First incremental linking update

```zig
extern "c" exit(usize) noreturn;

export fn _start() noreturn {
    exit(0);
}
```

* Second incremental linking update

```zig
extern "c" fn exit(usize) noreturn;
extern "c" fn write(usize, usize, usize) usize;

export fn _start() noreturn {
    print();
    exit(0);
}

fn print() void {
    _ = write(1, @ptrToInt("Hey\n"), 4);
}
```

On the second incremental update, we'd get the segfault. Since I'm not sure whether my fix is correct, I'm pinging you @andrewrk to have a look and lemme know if this makes sense. If so, I guess I should also update the matching lines in the `Elf` linker.