### PR TITLE
zig cc: Support reading input from stdin

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3043,7 +3043,7 @@ pub const ClangArgIterator = struct {
             arg = mem.span(self.argv[self.next_index]);
             self.incrementArgIndex();
         }
-        if (!mem.startsWith(u8, arg, "-")) {
+        if (mem.eql(u8, arg, "-") or !mem.startsWith(u8, arg, "-")) {
             self.zig_equivalent = .positional;
             self.only_arg = arg;
             return;


### PR DESCRIPTION
This fixes #6271, which allows using `zig cc` with meson.