### PR TITLE
Bring back stack trace printing on ARM Darwin

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -250,6 +250,24 @@ pub fn panicExtra(trace: ?*const builtin.StackTrace, first_trace_addr: ?usize, c
         resetSegfaultHandler();
     }
 
+    if (comptime std.Target.current.isDarwin() and std.Target.current.cpu.arch == .aarch64)
+        nosuspend {
+            // As a workaround for not having threadlocal variable support in LLD for this target,
+            // we have a simpler panic implementation that does not use threadlocal variables.
+            // TODO https://github.com/ziglang/zig/issues/7527
+            const stderr = io.getStdErr().writer();
+            if (@atomicRmw(u8, &panicking, .Add, 1, .SeqCst) == 0) {
+                stderr.print("panic: " ++ format ++ "\n", args) catch os.abort();
+                if (trace) |t| {
+                    dumpStackTrace(t.*);
+                }
+                dumpCurrentStackTrace(first_trace_addr);
+            } else {
+                stderr.print("Panicked during a panic. Aborting.\n", .{}) catch os.abort();
+            }
+            os.abort();
+        };
+
     nosuspend switch (panic_stage) {
         0 => {
             panic_stage = 1;


### PR DESCRIPTION
~~This commit brings back stack trace printing on ARM Darwin OSes by
avoiding the use of `threadlocal` for keeping track of panic stages per
thread. Essentially, LLVM/LLD fails to properly emit thread-local variables
which causes a segfault on attempting access. Since the default panic
handler relies on a threadlocal to keep track of panic stages per
thread using a thread-local variable, we ensure at compilation time
that ARM Darwin platforms explicitly opt-out from this in favour of
storing the panic stages per thread in a hash-map behind a mutex.
This is a temporary solution until the underlying issue is fixed
but much welcome one since this brings back stack traces printouts
on ARM macOS without the necessity to resort to the system linker and
still get broken stack traces due to addressing differences between the
system linker and LLD. For a more complete overview of the problem with
`threadlocal` in LLVM, see ziglang/zig#7527.~~

---

EDIT:

This temporary patch fixes a segfault caused by miscompilation
by the LLD when generating stubs for initialization of thread local
storage. We effectively bypass TLS in the default panic handler
so that no segfault is generated and the stack trace is correctly
reported back to the user.

Note that, this is linked directly to a bigger issue with LLD
#7527 and when resolved, we only need to remove the
`comptime` code path introduced with this patch to use the default
panic handler that relies on TLS.