### PR TITLE
stage1: don't filter test blocks with empty label

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -553,7 +553,7 @@ pub fn getCurrentThreadId() u64 {
     }
 }
 
-test "" {
+test {
     if (!builtin.single_threaded) {
         std.testing.refAllDecls(@This());
     }

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2985,7 +2985,7 @@ test "LibExeObjStep.addPackage" {
     std.testing.expectEqualStrings(pkg_top.name, dupe.name);
 }
 
-test "" {
+test {
     // The only purpose of this test is to get all these untested functions
     // to be referenced to avoid regression so it is okay to skip some targets.
     if (comptime std.Target.current.cpu.arch.ptrBitWidth() == 64) {

--- a/lib/std/build/emit_raw.zig
+++ b/lib/std/build/emit_raw.zig
@@ -223,6 +223,6 @@ pub const InstallRawStep = struct {
     }
 };
 
-test "" {
+test {
     std.testing.refAllDecls(InstallRawStep);
 }

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -14,7 +14,7 @@ pub const parse = @import("c/parse.zig").parse;
 pub const ast = @import("c/ast.zig");
 pub const builtins = @import("c/builtins.zig");
 
-test "" {
+test {
     _ = tokenizer;
 }
 

--- a/lib/std/compress.zig
+++ b/lib/std/compress.zig
@@ -9,7 +9,7 @@ pub const deflate = @import("compress/deflate.zig");
 pub const gzip = @import("compress/gzip.zig");
 pub const zlib = @import("compress/zlib.zig");
 
-test "" {
+test {
     _ = gzip;
     _ = zlib;
 }

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2475,7 +2475,7 @@ fn copy_file(fd_in: os.fd_t, fd_out: os.fd_t) CopyFileError!void {
     }
 }
 
-test "" {
+test {
     if (builtin.os.tag != .wasi) {
         _ = makeDirAbsolute;
         _ = makeDirAbsoluteZ;

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -171,7 +171,7 @@ test "null_writer" {
     null_writer.writeAll("yay" ** 10) catch |err| switch (err) {};
 }
 
-test "" {
+test {
     _ = @import("io/bit_reader.zig");
     _ = @import("io/bit_writer.zig");
     _ = @import("io/buffered_atomic_file.zig");

--- a/lib/std/io/c_writer.zig
+++ b/lib/std/io/c_writer.zig
@@ -34,7 +34,7 @@ fn cWriterWrite(c_file: *std.c.FILE, bytes: []const u8) std.fs.File.WriteError!u
     }
 }
 
-test "" {
+test {
     if (!builtin.link_libc) return error.SkipZigTest;
 
     const filename = "tmp_io_test_file.txt";

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -278,7 +278,7 @@ pub const Complex = complex.Complex;
 
 pub const big = @import("math/big.zig");
 
-test "" {
+test {
     std.testing.refAllDecls(@This());
 }
 

--- a/lib/std/math/big.zig
+++ b/lib/std/math/big.zig
@@ -20,7 +20,7 @@ comptime {
     assert(limb_info.signedness == .unsigned);
 }
 
-test "" {
+test {
     _ = int;
     _ = Rational;
     _ = Limb;

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -2344,6 +2344,6 @@ fn fixedIntFromSignedDoubleLimb(A: SignedDoubleLimb, storage: []Limb) Mutable {
     };
 }
 
-test "" {
+test {
     _ = @import("int_test.zig");
 }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1769,6 +1769,6 @@ pub const StreamServer = struct {
     }
 };
 
-test "" {
+test {
     _ = @import("net/test.zig");
 }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -43,7 +43,7 @@ comptime {
     assert(@import("std") == std); // std lib tests require --override-lib-dir
 }
 
-test "" {
+test {
     _ = darwin;
     _ = freebsd;
     _ = linux;

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1355,7 +1355,7 @@ pub fn madvise(address: [*]u8, len: usize, advice: u32) usize {
     return syscall3(.madvise, @ptrToInt(address), len, advice);
 }
 
-test "" {
+test {
     if (builtin.os.tag == .linux) {
         _ = @import("linux/test.zig");
     }

--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -602,6 +602,6 @@ test "CSPRNG" {
     expect(a ^ b ^ c != 0);
 }
 
-test "" {
+test {
     std.testing.refAllDecls(@This());
 }

--- a/lib/std/special/compiler_rt/shift.zig
+++ b/lib/std/special/compiler_rt/shift.zig
@@ -124,7 +124,7 @@ pub fn __aeabi_llsr(a: i64, b: i32) callconv(.AAPCS) i64 {
     return __lshrdi3(a, b);
 }
 
-test "" {
+test {
     _ = @import("ashrdi3_test.zig");
     _ = @import("ashrti3_test.zig");
 

--- a/lib/std/special/compiler_rt/sparc.zig
+++ b/lib/std/special/compiler_rt/sparc.zig
@@ -68,7 +68,6 @@ pub fn _Qp_fge(a: *f128, b: *f128) callconv(.C) bool {
     return cmp == @enumToInt(FCMP.Greater) or cmp == @enumToInt(FCMP.Equal);
 }
 
-
 // Casting
 
 pub fn _Qp_dtoq(c: *f128, a: f64) callconv(.C) void {

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -86,7 +86,7 @@ comptime {
     _ = start;
 }
 
-test "" {
+test {
     if (builtin.os.tag == .windows) {
         // We only test the Windows-relevant stuff to save memory because the CI
         // server is hitting OOM. TODO revert this after stage2 arrives.

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1577,6 +1577,6 @@ pub const Target = struct {
     }
 };
 
-test "" {
+test {
     std.testing.refAllDecls(Target.Cpu.Arch);
 }

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -443,7 +443,7 @@ fn printLine(line: []const u8) void {
     print("{s}\n", .{line});
 }
 
-test "" {
+test {
     expectEqualStrings("foo", "foo");
 }
 

--- a/lib/std/valgrind.zig
+++ b/lib/std/valgrind.zig
@@ -262,7 +262,7 @@ pub fn monitorCommand(command: [*]u8) bool {
 pub const memcheck = @import("valgrind/memcheck.zig");
 pub const callgrind = @import("valgrind/callgrind.zig");
 
-test "" {
+test {
     _ = @import("valgrind/memcheck.zig");
     _ = @import("valgrind/callgrind.zig");
 }

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -255,6 +255,6 @@ test "parseCharLiteral" {
     std.testing.expectError(error.InvalidCharacter, parseCharLiteral("'\\u{FFFF}x'", &bad_index));
 }
 
-test "" {
+test {
     @import("std").testing.refAllDecls(@This());
 }

--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -3231,7 +3231,7 @@ pub const Node = struct {
         base: Node = Node{ .tag = .TestDecl },
         doc_comments: ?*DocComment,
         test_token: TokenIndex,
-        name: *Node,
+        name: ?*Node,
         body_node: *Node,
 
         pub fn iterate(self: *const TestDecl, index: usize) ?*Node {

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -366,9 +366,7 @@ const Parser = struct {
     /// TestDecl <- KEYWORD_test STRINGLITERALSINGLE Block
     fn parseTestDecl(p: *Parser) !?*Node {
         const test_token = p.eatToken(.Keyword_test) orelse return null;
-        const name_node = try p.expectNode(parseStringLiteralSingle, .{
-            .ExpectedStringLiteral = .{ .token = p.tok_i },
-        });
+        const name_node = try p.parseStringLiteralSingle();
         const block_node = (try p.parseBlock(null)) orelse {
             try p.errors.append(p.gpa, .{ .ExpectedLBrace = .{ .token = p.tok_i } });
             return error.ParseError;

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -228,7 +228,8 @@ fn renderContainerDecl(allocator: *mem.Allocator, ais: anytype, tree: *ast.Tree,
 
             try renderDocComments(tree, ais, test_decl, test_decl.doc_comments);
             try renderToken(tree, ais, test_decl.test_token, .Space);
-            try renderExpression(allocator, ais, tree, test_decl.name, .Space);
+            if (test_decl.name) |name|
+                try renderExpression(allocator, ais, tree, name, .Space);
             try renderExpression(allocator, ais, tree, test_decl.body_node, space);
         },
 

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -898,6 +898,6 @@ pub const NativeTargetInfo = struct {
     }
 };
 
-test "" {
+test {
     _ = @import("system/macos.zig");
 }

--- a/src/codegen/aarch64.zig
+++ b/src/codegen/aarch64.zig
@@ -906,7 +906,7 @@ pub const Instruction = union(enum) {
     }
 };
 
-test "" {
+test {
     testing.refAllDecls(@This());
 }
 

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -797,6 +797,7 @@ struct AstNodeVariableDeclaration {
 };
 
 struct AstNodeTestDecl {
+    // nullptr if the test declaration has no name
     Buf *name;
 
     AstNode *body;

--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -3875,7 +3875,8 @@ static void preview_test_decl(CodeGen *g, AstNode *node, ScopeDecls *decls_scope
     Buf *test_name = g->test_name_prefix ?
         buf_sprintf("%s%s", buf_ptr(g->test_name_prefix), buf_ptr(decl_name_buf)) : decl_name_buf;
 
-    if (g->test_filter != nullptr && strstr(buf_ptr(test_name), buf_ptr(g->test_filter)) == nullptr) {
+    if (g->test_filter != nullptr && buf_len(test_name) > 0 &&
+            strstr(buf_ptr(test_name), buf_ptr(g->test_filter)) == nullptr) {
         return;
     }
 

--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -3871,13 +3871,18 @@ static void preview_test_decl(CodeGen *g, AstNode *node, ScopeDecls *decls_scope
         return;
 
     Buf *decl_name_buf = node->data.test_decl.name;
+    Buf *test_name;
 
-    Buf *test_name = g->test_name_prefix ?
-        buf_sprintf("%s%s", buf_ptr(g->test_name_prefix), buf_ptr(decl_name_buf)) : decl_name_buf;
+    if (decl_name_buf != nullptr) {
+        test_name = g->test_name_prefix ?
+                buf_sprintf("%s%s", buf_ptr(g->test_name_prefix), buf_ptr(decl_name_buf)) : decl_name_buf;
 
-    if (g->test_filter != nullptr && buf_len(test_name) > 0 &&
-            strstr(buf_ptr(test_name), buf_ptr(g->test_filter)) == nullptr) {
-        return;
+        if (g->test_filter != nullptr && strstr(buf_ptr(test_name), buf_ptr(g->test_filter)) == nullptr) {
+            return;
+        }
+    } else {
+        // Unnamed test blocks are always executed.
+        test_name = buf_sprintf("%s", g->test_name_prefix ? buf_ptr(g->test_name_prefix) : "");
     }
 
     TldFn *tld_fn = heap::c_allocator.create<TldFn>();

--- a/src/stage1/parser.cpp
+++ b/src/stage1/parser.cpp
@@ -658,10 +658,10 @@ static AstNode *ast_parse_test_decl(ParseContext *pc) {
     if (test == nullptr)
         return nullptr;
 
-    Token *name = expect_token(pc, TokenIdStringLiteral);
+    Token *name = eat_token_if(pc, TokenIdStringLiteral);
     AstNode *block = ast_expect(pc, ast_parse_block);
     AstNode *res = ast_create_node(pc, NodeTypeTestDecl, test);
-    res->data.test_decl.name = token_buf(name);
+    res->data.test_decl.name = name ? token_buf(name) : nullptr;
     res->data.test_decl.body = block;
     return res;
 }


### PR DESCRIPTION
The common pattern of including a file containing all the tests in a
empty-label test block breaks down when using --test-filter.