### PR TITLE
translate-c: Improve array support

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -735,6 +735,15 @@ pub const StringLiteral = opaque {
     pub const getKind = ZigClangStringLiteral_getKind;
     extern fn ZigClangStringLiteral_getKind(*const StringLiteral) StringLiteral_StringKind;
 
+    pub const getCodeUnit = ZigClangStringLiteral_getCodeUnit;
+    extern fn ZigClangStringLiteral_getCodeUnit(*const StringLiteral, usize) u32;
+
+    pub const getLength = ZigClangStringLiteral_getLength;
+    extern fn ZigClangStringLiteral_getLength(*const StringLiteral) c_uint;
+
+    pub const getCharByteWidth = ZigClangStringLiteral_getCharByteWidth;
+    extern fn ZigClangStringLiteral_getCharByteWidth(*const StringLiteral) c_uint;
+
     pub const getString_bytes_begin_size = ZigClangStringLiteral_getString_bytes_begin_size;
     extern fn ZigClangStringLiteral_getString_bytes_begin_size(*const StringLiteral, *usize) [*]const u8;
 };

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2504,6 +2504,21 @@ enum ZigClangStringLiteral_StringKind ZigClangStringLiteral_getKind(const struct
     return (ZigClangStringLiteral_StringKind)casted->getKind();
 }
 
+uint32_t ZigClangStringLiteral_getCodeUnit(const struct ZigClangStringLiteral *self, size_t i) {
+    auto casted = reinterpret_cast<const clang::StringLiteral *>(self);
+    return casted->getCodeUnit(i);
+}
+
+unsigned ZigClangStringLiteral_getLength(const struct ZigClangStringLiteral *self) {
+    auto casted = reinterpret_cast<const clang::StringLiteral *>(self);
+    return casted->getLength();
+}
+
+unsigned ZigClangStringLiteral_getCharByteWidth(const struct ZigClangStringLiteral *self) {
+    auto casted = reinterpret_cast<const clang::StringLiteral *>(self);
+    return casted->getCharByteWidth();
+}
+
 const char *ZigClangStringLiteral_getString_bytes_begin_size(const struct ZigClangStringLiteral *self, size_t *len) {
     auto casted = reinterpret_cast<const clang::StringLiteral *>(self);
     llvm::StringRef str_ref = casted->getString();

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -1126,6 +1126,10 @@ ZIG_EXTERN_C unsigned ZigClangAPFloat_convertToHexString(const struct ZigClangAP
 ZIG_EXTERN_C double ZigClangFloatingLiteral_getValueAsApproximateDouble(const ZigClangFloatingLiteral *self);
 
 ZIG_EXTERN_C enum ZigClangStringLiteral_StringKind ZigClangStringLiteral_getKind(const struct ZigClangStringLiteral *self);
+ZIG_EXTERN_C uint32_t ZigClangStringLiteral_getCodeUnit(const struct ZigClangStringLiteral *self, size_t i);
+ZIG_EXTERN_C unsigned ZigClangStringLiteral_getLength(const struct ZigClangStringLiteral *self);
+ZIG_EXTERN_C unsigned ZigClangStringLiteral_getCharByteWidth(const struct ZigClangStringLiteral *self);
+
 ZIG_EXTERN_C const char *ZigClangStringLiteral_getString_bytes_begin_size(const struct ZigClangStringLiteral *self,
         size_t *len);
 

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -746,4 +746,52 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "1 2" ++ nl);
+
+    cases.add("multi-character character constant",
+        \\#include <stdlib.h>
+        \\int main(void) {
+        \\    int foo = 'abcd';
+        \\    switch (foo) {
+        \\        case 'abcd': break;
+        \\        default: abort();
+        \\    }
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("Array initializers (string literals, incomplete arrays)",
+        \\#include <stdlib.h>
+        \\#include <string.h>
+        \\extern int foo[];
+        \\int global_arr[] = {1, 2, 3};
+        \\char global_string[] = "hello";
+        \\int main(int argc, char *argv[]) {
+        \\    if (global_arr[2] != 3) abort();
+        \\    if (strlen(global_string) != 5) abort();
+        \\    const char *const_str = "hello";
+        \\    if (strcmp(const_str, "hello") != 0) abort();
+        \\    char empty_str[] = "";
+        \\    if (strlen(empty_str) != 0) abort();
+        \\    char hello[] = "hello";
+        \\    if (strlen(hello) != 5 || sizeof(hello) != 6) abort();
+        \\    int empty[] = {};
+        \\    if (sizeof(empty) != 0) abort();
+        \\    int bar[] = {42};
+        \\    if (bar[0] != 42) abort();
+        \\    bar[0] = 43;
+        \\    if (bar[0] != 43) abort();
+        \\    int baz[] = {1, [42] = 123, 456};
+        \\    if (baz[42] != 123 || baz[43] != 456) abort();
+        \\    if (sizeof(baz) != sizeof(int) * 44) abort();
+        \\    const char *const names[] = {"first", "second", "third"};
+        \\    if (strcmp(names[2], "third") != 0) abort();
+        \\    char catted_str[] = "abc" "def";
+        \\    if (strlen(catted_str) != 6 || sizeof(catted_str) != 7) abort();
+        \\    char catted_trunc_str[2] = "abc" "def";
+        \\    if (sizeof(catted_trunc_str) != 2 || catted_trunc_str[0] != 'a' || catted_trunc_str[1] != 'b') abort();
+        \\    char big_array_utf8lit[10] = "💯";
+        \\    if (strcmp(big_array_utf8lit, "💯") != 0 || big_array_utf8lit[9] != 0) abort();
+        \\    return 0;
+        \\}
+    , "");
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -539,7 +539,14 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    static const char v2[] = "2.2.2";
         \\}
     , &[_][]const u8{
-        \\const v2: [*c]const u8 = "2.2.2";
+        \\const v2: [6]u8 = [6]u8{
+        \\    '2',
+        \\    '.',
+        \\    '2',
+        \\    '.',
+        \\    '2',
+        \\    0,
+        \\};
         \\pub export fn foo() void {
         \\    _ = v2;
         \\}
@@ -1395,9 +1402,30 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\static char arr1[] = "hello";
         \\char arr2[] = "hello";
     , &[_][]const u8{
-        \\pub export var arr0: [*c]u8 = "hello";
-        \\pub var arr1: [*c]u8 = "hello";
-        \\pub export var arr2: [*c]u8 = "hello";
+        \\pub export var arr0: [6]u8 = [6]u8{
+        \\    'h',
+        \\    'e',
+        \\    'l',
+        \\    'l',
+        \\    'o',
+        \\    0,
+        \\};
+        \\pub var arr1: [6]u8 = [6]u8{
+        \\    'h',
+        \\    'e',
+        \\    'l',
+        \\    'l',
+        \\    'o',
+        \\    0,
+        \\};
+        \\pub export var arr2: [6]u8 = [6]u8{
+        \\    'h',
+        \\    'e',
+        \\    'l',
+        \\    'l',
+        \\    'o',
+        \\    0,
+        \\};
     });
 
     cases.add("array initializer expr",


### PR DESCRIPTION
1. For incomplete arrays with initializer list (`int x[] = {1};`) use the
initializer size as the array size.

2. For arrays initialized with a string literal translate it as an array
of character literals instead of `[*c]const u8`

3. Don't crash if an empty initializer is used for an incomplete array.

4. Add a test for multi-character character constants

Additionally lay some groundwork for supporting wide string literals.

fixes #4831 #7832 #7842