### PR TITLE
Add the ability to disable dynamic image base (Windows)

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -497,6 +497,7 @@ pub const InitOptions = struct {
     test_filter: ?[]const u8 = null,
     test_name_prefix: ?[]const u8 = null,
     subsystem: ?std.Target.SubSystem = null,
+    dynamic_base: bool = true,
 };
 
 fn addPackageTableToCacheHash(
@@ -1038,6 +1039,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
             .disable_lld_caching = options.disable_lld_caching,
             .subsystem = options.subsystem,
             .is_test = options.is_test,
+            .dynamic_base = options.dynamic_base,
         });
         errdefer bin_file.destroy();
         comp.* = .{

--- a/src/link.zig
+++ b/src/link.zig
@@ -98,6 +98,8 @@ pub const Options = struct {
     extra_lld_args: []const []const u8,
     /// Darwin-only. Set the root path to the system libraries and frameworks.
     syslibroot: ?[]const u8,
+    /// Windows only. Enable image base randomization
+    dynamic_base: bool,
 
     objects: []const []const u8,
     framework_dirs: []const []const u8,

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -965,6 +965,10 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
             }
         }
 
+        if (!self.base.options.dynamic_base) {
+            try argv.append("-DYNAMICBASE:no");
+        }
+
         if (is_dyn_lib) {
             try argv.append("-DLL");
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -343,6 +343,7 @@ const usage_build_generic =
     \\  -static                        Force output to be statically linked
     \\  -Bsymbolic                     Bind global references locally
     \\  --subsystem [subsystem]        (Windows) /SUBSYSTEM:<subsystem> to the linker
+    \\  --no-dynamic-base              (Windows) /DYNAMICBASE:no to the linker
     \\  --stack [size]                 Override default stack size
     \\  --image-base [addr]            Set base address for executable image
     \\  -framework [name]              (Darwin) link against framework
@@ -546,6 +547,7 @@ fn buildOutputType(
     var main_pkg_path: ?[]const u8 = null;
     var clang_preprocessor_mode: Compilation.ClangPreprocessorMode = .no;
     var subsystem: ?std.Target.SubSystem = null;
+    var dynamic_base: bool = true;
 
     var system_libs = std.ArrayList([]const u8).init(gpa);
     defer system_libs.deinit();
@@ -700,6 +702,8 @@ fn buildOutputType(
                                 \\
                             });
                         }
+                    } else if (mem.eql(u8, arg, "--no-dynamic-base")) {
+                        dynamic_base = false;
                     } else if (mem.eql(u8, arg, "-O")) {
                         if (i + 1 >= args.len) fatal("expected parameter after {s}", .{arg});
                         i += 1;
@@ -1822,6 +1826,7 @@ fn buildOutputType(
         .test_name_prefix = test_name_prefix,
         .disable_lld_caching = !have_enable_cache,
         .subsystem = subsystem,
+        .dynamic_base = dynamic_base,
     }) catch |err| {
         fatal("unable to create compilation: {s}", .{@errorName(err)});
     };


### PR DESCRIPTION
Hi!
This is a simple addition to make linking process more configurable.

By default, PE executables are linked with dynamic base enabled,
however in some cases it may be useful to override this (eg. for easier
debugging).

Add `--no-dynamic-base` flag to change the default linker behavior.