### PR TITLE
fix windows bug in Progress.zig (deadlocked compiler on windows)

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -103,7 +103,11 @@ pub const Node = struct {
             }
             parent.completeOne();
         } else {
-            self.context.done = true;
+            {
+                const held = self.context.update_lock.acquire();
+                defer held.release();
+                self.context.done = true;
+            }
             self.context.refresh();
         }
     }

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -299,6 +299,6 @@ pub extern "kernel32" fn SleepConditionVariableSRW(
     f: ULONG,
 ) callconv(WINAPI) BOOL;
 
-pub extern "kernel32" fn TryAcquireSRWLockExclusive(s: *SRWLOCK) callconv(WINAPI) BOOL;
+pub extern "kernel32" fn TryAcquireSRWLockExclusive(s: *SRWLOCK) callconv(WINAPI) BOOLEAN;
 pub extern "kernel32" fn AcquireSRWLockExclusive(s: *SRWLOCK) callconv(WINAPI) void;
 pub extern "kernel32" fn ReleaseSRWLockExclusive(s: *SRWLOCK) callconv(WINAPI) void;


### PR DESCRIPTION
This bug caused the compiler to deadlock when multiple c objects were build in parallel.

Thanks @kprotty for finding this bug!

Now we can use the `win-dev-kit` again to build the compiler :)

It is probably a good idea to check all the functions in `kernel32.zig`, because this is a really annoying bug to find and fix.