### PR TITLE
Fixes for std.Thread.Condition

### DIFF
--- a/lib/std/Thread/Condition.zig
+++ b/lib/std/Thread/Condition.zig
@@ -17,6 +17,18 @@ const linux = std.os.linux;
 const Mutex = std.Thread.Mutex;
 const assert = std.debug.assert;
 
+pub fn wait(cond: *Condition, mutex: *Mutex) void {
+    cond.impl.wait(mutex);
+}
+
+pub fn signal(cond: *Condition) void {
+    cond.impl.signal();
+}
+
+pub fn broadcast(cond: *Condition) void {
+    cond.impl.broadcast();
+}
+
 const Impl = if (std.builtin.single_threaded)
     SingleThreadedCondition
 else if (std.Target.current.os.tag == .windows)

--- a/lib/std/Thread/Condition.zig
+++ b/lib/std/Thread/Condition.zig
@@ -8,7 +8,7 @@
 //! to wake up. Spurious wakeups are possible.
 //! This API supports static initialization and does not require deinitialization.
 
-impl: Impl,
+impl: Impl = .{},
 
 const std = @import("../std.zig");
 const Condition = @This();

--- a/lib/std/Thread/Condition.zig
+++ b/lib/std/Thread/Condition.zig
@@ -62,7 +62,7 @@ pub const PthreadCondition = struct {
     cond: std.c.pthread_cond_t = .{},
 
     pub fn wait(cond: *PthreadCondition, mutex: *Mutex) void {
-        const rc = std.c.pthread_cond_wait(&cond.cond, &mutex.mutex);
+        const rc = std.c.pthread_cond_wait(&cond.cond, &mutex.impl.pthread_mutex);
         assert(rc == 0);
     }
 


### PR DESCRIPTION
A fix to `PThreadCondition` to make it compile.

Initialize `impl` so we can just do `var condition = std.Thread.Condition{}`.

Added forwarding calls `wait`, `signal` and `broadcast` so we don't need to do `cond.impl.signal()`.