### PR TITLE
translate-c: add wide string literal support

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -794,4 +794,28 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Wide, UTF-16, and UTF-32 string literals",
+        \\#include <stdlib.h>
+        \\#include <stdint.h>
+        \\#include <wchar.h>
+        \\int main(void) {
+        \\    const wchar_t *wide_str = L"wide";
+        \\    const wchar_t wide_hello[] = L"hello";
+        \\    if (wcslen(wide_str) != 4) abort();
+        \\    if (wcslen(L"literal") != 7) abort();
+        \\    if (wcscmp(wide_hello, L"hello") != 0) abort();
+        \\
+        \\    const uint16_t *u16_str = u"wide";
+        \\    const uint16_t u16_hello[] = u"hello";
+        \\    if (u16_str[3] != u'e' || u16_str[4] != 0) abort();
+        \\    if (u16_hello[4] != u'o' || u16_hello[5] != 0) abort();
+        \\
+        \\    const uint32_t *u32_str = U"wide";
+        \\    const uint32_t u32_hello[] = U"hello";
+        \\    if (u32_str[3] != U'e' || u32_str[4] != 0) abort();
+        \\    if (u32_hello[4] != U'o' || u32_hello[5] != 0) abort();
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
Adds support for wide, UTF-16, and UTF-32 string literals. If used to initialize
an incomplete array, the same logic as narrow strings is used. Otherwise they
are translated as global "anonymous" arrays of the relevant underlying char type.
A dot is used in the name to ensure the generated names do not conflict with any
other names in the translated program.

For example:

```c
void my_fn() {
    const uint32_t *foo = U"foo";
}
```

becomes:
```zig
const @"zig.UTF32_string_2" = [4]c_uint{
    '\u{66}',
    '\u{6f}',
    '\u{6f}',
    0,
};
pub export fn my_fn() void {
    var foo: [*c]const u32 = &@"zig.UTF32_string_2";
}
```