### PR TITLE
stage2: wasm control flow

### DIFF
--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -77,6 +77,7 @@ pub const testing = @import("testing.zig");
 pub const time = @import("time.zig");
 pub const unicode = @import("unicode.zig");
 pub const valgrind = @import("valgrind.zig");
+pub const wasm = @import("wasm.zig");
 pub const zig = @import("zig.zig");
 pub const start = @import("start.zig");
 

--- a/lib/std/wasm.zig
+++ b/lib/std/wasm.zig
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2015-2021 Zig Contributors
+// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
+// The MIT license requires this copyright notice to be included in all copies
+// and substantial portions of the software.
+const testing = @import("std.zig").testing;
+
+/// Wasm instruction opcodes
+///
+/// All instructions are defined as per spec:
+/// https://webassembly.github.io/spec/core/appendix/index-instructions.html
+pub const Opcode = enum(u8) {
+    @"unreachable" = 0x00,
+    nop = 0x01,
+    block = 0x02,
+    loop = 0x03,
+    @"if" = 0x04,
+    @"else" = 0x05,
+    end = 0x0B,
+    br = 0x0C,
+    br_if = 0x0D,
+    br_table = 0x0E,
+    @"return" = 0x0F,
+    call = 0x10,
+    call_indirect = 0x11,
+    drop = 0x1A,
+    select = 0x1B,
+    local_get = 0x20,
+    local_set = 0x21,
+    local_tee = 0x22,
+    global_get = 0x23,
+    global_set = 0x24,
+    i32_load = 0x28,
+    i64_load = 0x29,
+    f32_load = 0x2A,
+    f64_load = 0x2B,
+    i32_load8_s = 0x2C,
+    i32_load8_u = 0x2D,
+    i32_load16_s = 0x2E,
+    i32_load16_u = 0x2F,
+    i64_load8_s = 0x30,
+    i64_load8_u = 0x31,
+    i64_load16_s = 0x32,
+    i64_load16_u = 0x33,
+    i64_load32_s = 0x34,
+    i64_load32_u = 0x35,
+    i32_store = 0x36,
+    i64_store = 0x37,
+    f32_store = 0x38,
+    f64_store = 0x39,
+    i32_store8 = 0x3A,
+    i32_store16 = 0x3B,
+    i64_store8 = 0x3C,
+    i64_store16 = 0x3D,
+    i64_store32 = 0x3E,
+    memory_size = 0x3F,
+    memory_grow = 0x40,
+    i32_const = 0x41,
+    i64_const = 0x42,
+    f32_const = 0x43,
+    f64_const = 0x44,
+    i32_eqz = 0x45,
+    i32_eq = 0x46,
+    i32_ne = 0x47,
+    i32_lt_s = 0x48,
+    i32_lt_u = 0x49,
+    i32_gt_s = 0x4A,
+    i32_gt_u = 0x4B,
+    i32_le_s = 0x4C,
+    i32_le_u = 0x4D,
+    i32_ge_s = 0x4E,
+    i32_ge_u = 0x4F,
+    i64_eqz = 0x50,
+    i64_eq = 0x51,
+    i64_ne = 0x52,
+    i64_lt_s = 0x53,
+    i64_lt_u = 0x54,
+    i64_gt_s = 0x55,
+    i64_gt_u = 0x56,
+    i64_le_s = 0x57,
+    i64_le_u = 0x58,
+    i64_ge_s = 0x59,
+    i64_ge_u = 0x5A,
+    f32_eq = 0x5B,
+    f32_ne = 0x5C,
+    f32_lt = 0x5D,
+    f32_gt = 0x5E,
+    f32_le = 0x5F,
+    f32_ge = 0x60,
+    f64_eq = 0x61,
+    f64_ne = 0x62,
+    f64_lt = 0x63,
+    f64_gt = 0x64,
+    f64_le = 0x65,
+    f64_ge = 0x66,
+    i32_clz = 0x67,
+    i32_ctz = 0x68,
+    i32_popcnt = 0x69,
+    i32_add = 0x6A,
+    i32_sub = 0x6B,
+    i32_mul = 0x6C,
+    i32_div_s = 0x6D,
+    i32_div_u = 0x6E,
+    i32_rem_s = 0x6F,
+    i32_rem_u = 0x70,
+    i32_and = 0x71,
+    i32_or = 0x72,
+    i32_xor = 0x73,
+    i32_shl = 0x74,
+    i32_shr_s = 0x75,
+    i32_shr_u = 0x76,
+    i32_rotl = 0x77,
+    i32_rotr = 0x78,
+    i64_clz = 0x79,
+    i64_ctz = 0x7A,
+    i64_popcnt = 0x7B,
+    i64_add = 0x7C,
+    i64_sub = 0x7D,
+    i64_mul = 0x7E,
+    i64_div_s = 0x7F,
+    i64_div_u = 0x80,
+    i64_rem_s = 0x81,
+    i64_rem_u = 0x82,
+    i64_and = 0x83,
+    i64_or = 0x84,
+    i64_xor = 0x85,
+    i64_shl = 0x86,
+    i64_shr_s = 0x87,
+    i64_shr_u = 0x88,
+    i64_rotl = 0x89,
+    i64_rotr = 0x8A,
+    f32_abs = 0x8B,
+    f32_neg = 0x8C,
+    f32_ceil = 0x8D,
+    f32_floor = 0x8E,
+    f32_trunc = 0x8F,
+    f32_nearest = 0x90,
+    f32_sqrt = 0x91,
+    f32_add = 0x92,
+    f32_sub = 0x93,
+    f32_mul = 0x94,
+    f32_div = 0x95,
+    f32_min = 0x96,
+    f32_max = 0x97,
+    f32_copysign = 0x98,
+    f64_abs = 0x99,
+    f64_neg = 0x9A,
+    f64_ceil = 0x9B,
+    f64_floor = 0x9C,
+    f64_trunc = 0x9D,
+    f64_nearest = 0x9E,
+    f64_sqrt = 0x9F,
+    f64_add = 0xA0,
+    f64_sub = 0xA1,
+    f64_mul = 0xA2,
+    f64_div = 0xA3,
+    f64_min = 0xA4,
+    f64_max = 0xA5,
+    f64_copysign = 0xA6,
+    i32_wrap_i64 = 0xA7,
+    i32_trunc_f32_s = 0xA8,
+    i32_trunc_f32_u = 0xA9,
+    i32_trunc_f64_s = 0xB0,
+    i32_trunc_f64_u = 0xB1,
+    f32_convert_i32_s = 0xB2,
+    f32_convert_i32_u = 0xB3,
+    f32_convert_i64_s = 0xB4,
+    f32_convert_i64_u = 0xB5,
+    f32_demote_f64 = 0xB6,
+    f64_convert_i32_s = 0xB7,
+    f64_convert_i32_u = 0xB8,
+    f64_convert_i64_s = 0xB9,
+    f64_convert_i64_u = 0xBA,
+    f64_promote_f32 = 0xBB,
+    i32_reinterpret_f32 = 0xBC,
+    i64_reinterpret_f64 = 0xBD,
+    f32_reinterpret_i32 = 0xBE,
+    i64_reinterpret_i64 = 0xBF,
+    i32_extend8_s = 0xC0,
+    i32_extend16_s = 0xC1,
+    i64_extend8_s = 0xC2,
+    i64_extend16_s = 0xC3,
+    i64_extend32_s = 0xC4,
+    _,
+};
+
+/// Returns the integer value of an `Opcode`. Used by the Zig compiler
+/// to write instructions to the wasm binary file
+pub fn opcode(op: Opcode) u8 {
+    return @enumToInt(op);
+}
+
+test "Wasm - opcodes" {
+    // Ensure our opcodes values remain intact as certain values are skipped due to them being reserved
+    const i32_const = opcode(.i32_const);
+    const end = opcode(.end);
+    const drop = opcode(.drop);
+    const local_get = opcode(.local_get);
+    const i64_extend32_s = opcode(.i64_extend32_s);
+
+    testing.expectEqual(@as(u16, 0x41), i32_const);
+    testing.expectEqual(@as(u16, 0x0B), end);
+    testing.expectEqual(@as(u16, 0x1A), drop);
+    testing.expectEqual(@as(u16, 0x20), local_get);
+    testing.expectEqual(@as(u16, 0xC4), i64_extend32_s);
+}
+
+/// Enum representing all Wasm value types as per spec:
+/// https://webassembly.github.io/spec/core/binary/types.html
+pub const Valtype = enum(u8) {
+    i32 = 0x7F,
+    i64 = 0x7E,
+    f32 = 0x7D,
+    f64 = 0x7C,
+};
+
+/// Returns the integer value of a `Valtype`
+pub fn valtype(value: Valtype) u8 {
+    return @enumToInt(value);
+}
+
+test "Wasm - valtypes" {
+    const _i32 = valtype(.i32);
+    const _i64 = valtype(.i64);
+    const _f32 = valtype(.f32);
+    const _f64 = valtype(.f64);
+
+    testing.expectEqual(@as(u8, 0x7F), _i32);
+    testing.expectEqual(@as(u8, 0x7E), _i64);
+    testing.expectEqual(@as(u8, 0x7D), _f32);
+    testing.expectEqual(@as(u8, 0x7C), _f64);
+}
+
+/// Wasm module sections as per spec:
+/// https://webassembly.github.io/spec/core/binary/modules.html
+pub const Section = enum(u8) {
+    custom,
+    type,
+    import,
+    function,
+    table,
+    memory,
+    global,
+    @"export",
+    start,
+    element,
+    code,
+    data,
+};
+
+/// Returns the integer value of a given `Section`
+pub fn section(val: Section) u8 {
+    return @enumToInt(val);
+}
+
+// types
+pub const element_type: u8 = 0x70;
+pub const function_type: u8 = 0x60;
+pub const result_type: u8 = 0x40;
+
+/// Represents a block which will not return a value
+pub const block_empty: u8 = 0x40;
+
+// binary constants
+pub const magic = [_]u8{ 0x00, 0x61, 0x73, 0x6D }; // \0asm
+pub const version = [_]u8{ 0x01, 0x00, 0x00, 0x00 }; // version 1

--- a/src/codegen/wasm.zig
+++ b/src/codegen/wasm.zig
@@ -4,6 +4,7 @@ const ArrayList = std.ArrayList;
 const assert = std.debug.assert;
 const leb = std.leb;
 const mem = std.mem;
+const wasm = std.wasm;
 
 const Module = @import("../Module.zig");
 const Decl = Module.Decl;
@@ -12,6 +13,7 @@ const Inst = ir.Inst;
 const Type = @import("../type.zig").Type;
 const Value = @import("../value.zig").Value;
 const Compilation = @import("../Compilation.zig");
+const AnyMCValue = @import("../codegen.zig").AnyMCValue;
 
 /// Wasm Value, created when generating an instruction
 const WValue = union(enum) {
@@ -20,23 +22,14 @@ const WValue = union(enum) {
     local: u32,
     /// Instruction holding a constant `Value`
     constant: *Inst,
-    /// Block label
+    /// Offset position in the list of bytecode instructions
+    code_offset: usize,
+    /// The label of the block, used by breaks to find its relative distance
     block_idx: u32,
 };
 
 /// Hashmap to store generated `WValue` for each `Inst`
-pub const ValueTable = std.AutoHashMap(*Inst, WValue);
-
-/// Using a given `Type`, returns the corresponding wasm value type
-fn genValtype(ty: Type) ?u8 {
-    return switch (ty.tag()) {
-        .f32 => 0x7D,
-        .f64 => 0x7C,
-        .u32, .i32 => 0x7F,
-        .u64, .i64 => 0x7E,
-        else => null,
-    };
-}
+pub const ValueTable = std.AutoHashMapUnmanaged(*Inst, WValue);
 
 /// Code represents the `Code` section of wasm that
 /// belongs to a function
@@ -58,13 +51,25 @@ pub const Context = struct {
     local_index: u32 = 0,
     /// If codegen fails, an error messages will be allocated and saved in `err_msg`
     err_msg: *Module.ErrorMsg,
+    /// Current block depth. Used to calculate the relative difference between a break
+    /// and block
+    block_depth: u32 = 0,
+    /// List of all locals' types generated throughout this declaration
+    /// used to emit locals count at start of 'code' section.
+    locals: std.ArrayListUnmanaged(u8),
 
     const InnerError = error{
         OutOfMemory,
         CodegenFail,
     };
 
-    /// Sets `err_msg` on `Context` and returns `error.CodegenFail` which is caught in link/Wasm.zig
+    pub fn deinit(self: *Context) void {
+        self.values.deinit(self.gpa);
+        self.locals.deinit(self.gpa);
+        self.* = undefined;
+    }
+
+    /// Sets `err_msg` on `Context` and returns `error.CodegemFail` which is caught in link/Wasm.zig
     fn fail(self: *Context, src: usize, comptime fmt: []const u8, args: anytype) InnerError {
         self.err_msg = try Module.ErrorMsg.create(self.gpa, .{
             .file_scope = self.decl.getFileScope(),
@@ -85,13 +90,35 @@ pub const Context = struct {
         return self.values.get(inst).?; // Instruction does not dominate all uses!
     }
 
+    /// Using a given `Type`, returns the corresponding wasm value type
+    fn genValtype(self: *Context, src: usize, ty: Type) InnerError!u8 {
+        return switch (ty.tag()) {
+            .f32 => wasm.valtype(.f32),
+            .f64 => wasm.valtype(.f64),
+            .u32, .i32 => wasm.valtype(.i32),
+            .u64, .i64 => wasm.valtype(.i64),
+            else => self.fail(src, "TODO - Wasm genValtype for type '{s}'", .{ty.tag()}),
+        };
+    }
+
+    /// Using a given `Type`, returns the corresponding wasm value type
+    /// Differently from `genValtype` this also allows `void` to create a block
+    /// with no return type
+    fn genBlockType(self: *Context, src: usize, ty: Type) InnerError!u8 {
+        return switch (ty.tag()) {
+            .void, .noreturn => wasm.block_empty,
+            else => self.genValtype(src, ty),
+        };
+    }
+
     /// Writes the bytecode depending on the given `WValue` in `val`
     fn emitWValue(self: *Context, val: WValue) InnerError!void {
         const writer = self.code.writer();
         switch (val) {
-            .none, .block_idx => {},
+            .block_idx => unreachable,
+            .none, .code_offset => {},
             .local => |idx| {
-                try writer.writeByte(0x20); // local.get
+                try writer.writeByte(wasm.opcode(.local_get));
                 try leb.writeULEB128(writer, idx);
             },
             .constant => |inst| try self.emitConstant(inst.castTag(.constant).?), // creates a new constant onto the stack
@@ -102,8 +129,7 @@ pub const Context = struct {
         const ty = self.decl.typed_value.most_recent.typed_value.ty;
         const writer = self.func_type_data.writer();
 
-        // functype magic
-        try writer.writeByte(0x60);
+        try writer.writeByte(wasm.function_type);
 
         // param types
         try leb.writeULEB128(writer, @intCast(u32, ty.fnParamLen()));
@@ -112,8 +138,8 @@ pub const Context = struct {
             defer self.gpa.free(params);
             ty.fnParamTypes(params);
             for (params) |param_type| {
-                const val_type = genValtype(param_type) orelse
-                    return self.fail(self.decl.src(), "TODO: Wasm codegen - arg type value for type '{s}'", .{param_type.tag()});
+                // Can we maybe get the source index of each param?
+                const val_type = try self.genValtype(self.decl.src(), param_type);
                 try writer.writeByte(val_type);
             }
         }
@@ -124,8 +150,8 @@ pub const Context = struct {
             .void, .noreturn => try leb.writeULEB128(writer, @as(u32, 0)),
             else => |ret_type| {
                 try leb.writeULEB128(writer, @as(u32, 1));
-                const val_type = genValtype(return_type) orelse
-                    return self.fail(self.decl.src(), "TODO: Wasm codegen - return type value for type '{s}'", .{ret_type});
+                // Can we maybe get the source index of the return type?
+                const val_type = try self.genValtype(self.decl.src(), return_type);
                 try writer.writeByte(val_type);
             },
         }
@@ -140,37 +166,33 @@ pub const Context = struct {
         // Reserve space to write the size after generating the code
         try self.code.resize(5);
 
+        // offset into 'code' section where we will put our locals count
+        var local_offset = self.code.items.len;
+
         // Write instructions
         // TODO: check for and handle death of instructions
         const tv = self.decl.typed_value.most_recent.typed_value;
         const mod_fn = tv.val.castTag(.function).?.data;
-
-        var locals = std.ArrayList(u8).init(self.gpa);
-        defer locals.deinit();
-
-        for (mod_fn.body.instructions) |inst| {
-            if (inst.tag != .alloc) continue;
-
-            const alloc: *Inst.NoOp = inst.castTag(.alloc).?;
-            const elem_type = alloc.base.ty.elemType();
-
-            const wasm_type = genValtype(elem_type) orelse
-                return self.fail(inst.src, "TODO: Wasm codegen - valtype for type '{s}'", .{elem_type.tag()});
-
-            try locals.append(wasm_type);
-        }
-
-        try leb.writeULEB128(writer, @intCast(u32, locals.items.len));
-
-        // emit the actual locals amount
-        for (locals.items) |local| {
-            try leb.writeULEB128(writer, @as(u32, 1));
-            try leb.writeULEB128(writer, local); // valtype
-        }
-
         try self.genBody(mod_fn.body);
 
-        try writer.writeByte(0x0B); // end
+        // finally, write our local types at the 'offset' position
+        {
+            var totals_buffer: [5]u8 = undefined;
+            leb.writeUnsignedFixed(5, totals_buffer[0..5], @intCast(u32, self.locals.items.len));
+            try self.code.insertSlice(local_offset, &totals_buffer);
+            local_offset += 5;
+
+            // emit the actual locals amount
+            for (self.locals.items) |local| {
+                var buf: [6]u8 = undefined;
+                leb.writeUnsignedFixed(5, buf[0..5], @as(u32, 1));
+                buf[5] = local;
+                try self.code.insertSlice(local_offset, &buf);
+                local_offset += 6;
+            }
+        }
+
+        try writer.writeByte(wasm.opcode(.end));
 
         // Fill in the size of the generated code to the reserved space at the
         // beginning of the buffer.
@@ -183,10 +205,20 @@ pub const Context = struct {
             .add => self.genAdd(inst.castTag(.add).?),
             .alloc => self.genAlloc(inst.castTag(.alloc).?),
             .arg => self.genArg(inst.castTag(.arg).?),
+            .block => self.genBlock(inst.castTag(.block).?),
+            .br => self.genBr(inst.castTag(.br).?),
             .call => self.genCall(inst.castTag(.call).?),
+            .cmp_eq => self.genCmp(inst.castTag(.cmp_eq).?, .eq),
+            .cmp_gte => self.genCmp(inst.castTag(.cmp_gte).?, .gte),
+            .cmp_gt => self.genCmp(inst.castTag(.cmp_gt).?, .gt),
+            .cmp_lte => self.genCmp(inst.castTag(.cmp_lte).?, .lte),
+            .cmp_lt => self.genCmp(inst.castTag(.cmp_lt).?, .lt),
+            .cmp_neq => self.genCmp(inst.castTag(.cmp_neq).?, .neq),
+            .condbr => self.genCondBr(inst.castTag(.condbr).?),
             .constant => unreachable,
             .dbg_stmt => WValue.none,
             .load => self.genLoad(inst.castTag(.load).?),
+            .loop => self.genLoop(inst.castTag(.loop).?),
             .ret => self.genRet(inst.castTag(.ret).?),
             .retvoid => WValue.none,
             .store => self.genStore(inst.castTag(.store).?),
@@ -197,7 +229,7 @@ pub const Context = struct {
     fn genBody(self: *Context, body: ir.Body) InnerError!void {
         for (body.instructions) |inst| {
             const result = try self.genInst(inst);
-            try self.values.putNoClobber(inst, result);
+            try self.values.putNoClobber(self.gpa, inst, result);
         }
     }
 
@@ -205,7 +237,7 @@ pub const Context = struct {
         // TODO: Implement tail calls
         const operand = self.resolveInst(inst.operand);
         try self.emitWValue(operand);
-        return WValue.none;
+        return .none;
     }
 
     fn genCall(self: *Context, inst: *Inst.Call) InnerError!WValue {
@@ -219,7 +251,7 @@ pub const Context = struct {
             try self.emitWValue(arg_val);
         }
 
-        try self.code.append(0x10); // call
+        try self.code.append(wasm.opcode(.call));
 
         // The function index immediate argument will be filled in using this data
         // in link.Wasm.flush().
@@ -228,10 +260,14 @@ pub const Context = struct {
             .decl = target,
         });
 
-        return WValue.none;
+        return .none;
     }
 
     fn genAlloc(self: *Context, inst: *Inst.NoOp) InnerError!WValue {
+        const elem_type = inst.base.ty.elemType();
+        const valtype = try self.genValtype(inst.base.src, elem_type);
+        try self.locals.append(self.gpa, valtype);
+
         defer self.local_index += 1;
         return WValue{ .local = self.local_index };
     }
@@ -243,15 +279,14 @@ pub const Context = struct {
         const rhs = self.resolveInst(inst.rhs);
         try self.emitWValue(rhs);
 
-        try writer.writeByte(0x21); // local.set
+        try writer.writeByte(wasm.opcode(.local_set));
         try leb.writeULEB128(writer, lhs.local);
-        return WValue.none;
+        return .none;
     }
 
     fn genLoad(self: *Context, inst: *Inst.UnOp) InnerError!WValue {
         const operand = self.resolveInst(inst.operand);
-        try self.emitWValue(operand);
-        return WValue.none;
+        return operand;
     }
 
     fn genArg(self: *Context, inst: *Inst.Arg) InnerError!WValue {
@@ -267,49 +302,207 @@ pub const Context = struct {
         try self.emitWValue(lhs);
         try self.emitWValue(rhs);
 
-        const opcode: u8 = switch (inst.base.ty.tag()) {
-            .u32, .i32 => 0x6A, //i32.add
-            .u64, .i64 => 0x7C, //i64.add
-            .f32 => 0x92, //f32.add
-            .f64 => 0xA0, //f64.add
+        const opcode: wasm.Opcode = switch (inst.base.ty.tag()) {
+            .u32, .i32 => .i32_add,
+            .u64, .i64 => .i64_add,
+            .f32 => .f32_add,
+            .f64 => .f64_add,
             else => return self.fail(inst.base.src, "TODO - Implement wasm genAdd for type '{s}'", .{inst.base.ty.tag()}),
         };
 
-        try self.code.append(opcode);
-        return WValue.none;
+        try self.code.append(wasm.opcode(opcode));
+        return .none;
     }
 
     fn emitConstant(self: *Context, inst: *Inst.Constant) InnerError!void {
         const writer = self.code.writer();
         switch (inst.base.ty.tag()) {
             .u32 => {
-                try writer.writeByte(0x41); // i32.const
+                try writer.writeByte(wasm.opcode(.i32_const));
                 try leb.writeILEB128(writer, inst.val.toUnsignedInt());
             },
             .i32 => {
-                try writer.writeByte(0x41); // i32.const
+                try writer.writeByte(wasm.opcode(.i32_const));
                 try leb.writeILEB128(writer, inst.val.toSignedInt());
             },
             .u64 => {
-                try writer.writeByte(0x42); // i64.const
+                try writer.writeByte(wasm.opcode(.i64_const));
                 try leb.writeILEB128(writer, inst.val.toUnsignedInt());
             },
             .i64 => {
-                try writer.writeByte(0x42); // i64.const
+                try writer.writeByte(wasm.opcode(.i64_const));
                 try leb.writeILEB128(writer, inst.val.toSignedInt());
             },
             .f32 => {
-                try writer.writeByte(0x43); // f32.const
+                try writer.writeByte(wasm.opcode(.f32_const));
                 // TODO: enforce LE byte order
                 try writer.writeAll(mem.asBytes(&inst.val.toFloat(f32)));
             },
             .f64 => {
-                try writer.writeByte(0x44); // f64.const
+                try writer.writeByte(wasm.opcode(.f64_const));
                 // TODO: enforce LE byte order
                 try writer.writeAll(mem.asBytes(&inst.val.toFloat(f64)));
             },
             .void => {},
             else => |ty| return self.fail(inst.base.src, "Wasm TODO: emitConstant for type {s}", .{ty}),
         }
+    }
+
+    fn genBlock(self: *Context, block: *Inst.Block) InnerError!WValue {
+        const block_ty = try self.genBlockType(block.base.src, block.base.ty);
+
+        block.codegen = .{
+            // we don't use relocs, so using `relocs` is illegal behaviour.
+            .relocs = undefined,
+            // Here we set the current block idx, so conditions know the depth to jump
+            // to when breaking out. This will be set to .none when it is found again within
+            // the same block
+            .mcv = @bitCast(AnyMCValue, WValue{ .block_idx = self.block_depth }),
+        };
+        self.block_depth += 1;
+
+        try self.code.append(wasm.opcode(.block));
+        try self.code.append(block_ty);
+        try self.genBody(block.body);
+        try self.code.append(wasm.opcode(.end));
+
+        self.block_depth -= 1;
+        return .none;
+    }
+
+    fn genLoop(self: *Context, loop: *Inst.Loop) InnerError!WValue {
+        const loop_ty = try self.genBlockType(loop.base.src, loop.base.ty);
+
+        try self.code.append(wasm.opcode(.loop));
+        try self.code.append(loop_ty);
+        self.block_depth += 1;
+        try self.genBody(loop.body);
+        self.block_depth -= 1;
+
+        try self.code.append(wasm.opcode(.end));
+
+        return .none;
+    }
+
+    fn genCondBr(self: *Context, condbr: *Inst.CondBr) InnerError!WValue {
+        const condition = self.resolveInst(condbr.condition);
+        const writer = self.code.writer();
+
+        // insert blocks at the position of `offset` so
+        // the condition can jump to it
+        const offset = condition.code_offset;
+        try self.code.insert(offset, wasm.opcode(.block));
+        try self.code.insert(offset, try self.genBlockType(condbr.base.src, condbr.base.ty));
+
+        // we inserted the block in front of the condition
+        // so now check if condition matches. If not, break outside this block
+        // and continue with the regular codepath
+        try writer.writeByte(wasm.opcode(.br_if));
+        try leb.writeULEB128(writer, @as(u32, 0));
+
+        // else body in case condition does not match
+        try self.genBody(condbr.else_body);
+
+        // finally, tell wasm we have reached the end of the block we inserted above
+        try writer.writeByte(wasm.opcode(.end));
+
+        // Outer block that matches the condition
+        try self.genBody(condbr.then_body);
+
+        return .none;
+    }
+
+    fn genCmp(self: *Context, inst: *Inst.BinOp, op: std.math.CompareOperator) InnerError!WValue {
+        const ty = inst.lhs.ty.tag();
+
+        // save offset, so potential conditions can insert blocks in front of
+        // the comparison that we can later jump back to
+        const offset = self.code.items.len - 1;
+
+        const lhs = self.resolveInst(inst.lhs);
+        const rhs = self.resolveInst(inst.rhs);
+
+        try self.emitWValue(lhs);
+        try self.emitWValue(rhs);
+
+        const opcode_maybe: ?wasm.Opcode = switch (op) {
+            .lt => @as(?wasm.Opcode, switch (ty) {
+                .i32 => .i32_lt_s,
+                .u32 => .i32_lt_u,
+                .i64 => .i64_lt_s,
+                .u64 => .i64_lt_u,
+                .f32 => .f32_lt,
+                .f64 => .f64_lt,
+                else => null,
+            }),
+            .lte => @as(?wasm.Opcode, switch (ty) {
+                .i32 => .i32_le_s,
+                .u32 => .i32_le_u,
+                .i64 => .i64_le_s,
+                .u64 => .i64_le_u,
+                .f32 => .f32_le,
+                .f64 => .f64_le,
+                else => null,
+            }),
+            .eq => @as(?wasm.Opcode, switch (ty) {
+                .i32, .u32 => .i32_eq,
+                .i64, .u64 => .i64_eq,
+                .f32 => .f32_eq,
+                .f64 => .f64_eq,
+                else => null,
+            }),
+            .gte => @as(?wasm.Opcode, switch (ty) {
+                .i32 => .i32_ge_s,
+                .u32 => .i32_ge_u,
+                .i64 => .i64_ge_s,
+                .u64 => .i64_ge_u,
+                .f32 => .f32_ge,
+                .f64 => .f64_ge,
+                else => null,
+            }),
+            .gt => @as(?wasm.Opcode, switch (ty) {
+                .i32 => .i32_gt_s,
+                .u32 => .i32_gt_u,
+                .i64 => .i64_gt_s,
+                .u64 => .i64_gt_u,
+                .f32 => .f32_gt,
+                .f64 => .f64_gt,
+                else => null,
+            }),
+            .neq => @as(?wasm.Opcode, switch (ty) {
+                .i32, .u32 => .i32_ne,
+                .i64, .u64 => .i64_ne,
+                .f32 => .f32_ne,
+                .f64 => .f64_ne,
+                else => null,
+            }),
+        };
+
+        const opcode = opcode_maybe orelse
+            return self.fail(inst.base.src, "TODO - Wasm genCmp for type '{s}' and operator '{s}'", .{ ty, @tagName(op) });
+
+        try self.code.append(wasm.opcode(opcode));
+        return WValue{ .code_offset = offset };
+    }
+
+    fn genBr(self: *Context, br: *Inst.Br) InnerError!WValue {
+        // of operand has codegen bits we should break with a value
+        if (br.operand.ty.hasCodeGenBits()) {
+            const operand = self.resolveInst(br.operand);
+            try self.emitWValue(operand);
+        }
+
+        // if the block contains a block_idx, do a relative jump to it
+        // if `wvalue` was already 'consumed', simply break out of current block
+        const wvalue = @bitCast(WValue, br.block.codegen.mcv);
+        const idx: u32 = if (wvalue == .block_idx) blk: {
+            br.block.codegen.mcv = @bitCast(AnyMCValue, WValue{ .none = {} });
+            break :blk self.block_depth - wvalue.block_idx;
+        } else 0;
+
+        const writer = self.code.writer();
+        try writer.writeByte(wasm.opcode(.br));
+        try leb.writeULEB128(writer, idx);
+        return WValue.none;
     }
 };

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -103,13 +103,14 @@ pub fn updateDecl(self: *Wasm, module: *Module, decl: *Module.Decl) !void {
 
     var context = codegen.Context{
         .gpa = self.base.allocator,
-        .values = codegen.ValueTable.init(self.base.allocator),
+        .values = .{},
         .code = managed_code,
         .func_type_data = managed_functype,
         .decl = decl,
         .err_msg = undefined,
+        .locals = .{},
     };
-    defer context.values.deinit();
+    defer context.deinit();
 
     // generate the 'code' section for the function declaration
     context.gen() catch |err| switch (err) {

--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -122,4 +122,96 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , "35\n");
     }
+
+    {
+        var case = ctx.exe("wasm conditions", wasi);
+
+        case.addCompareOutput(
+            \\export fn _start() u32 {
+            \\    var i: u32 = 5;
+            \\    if (i > @as(u32, 4)) {
+            \\        i += 10;
+            \\    }
+            \\    return i;
+            \\}
+        , "15\n");
+
+        case.addCompareOutput(
+            \\export fn _start() u32 {
+            \\    var i: u32 = 5;
+            \\    if (i < @as(u32, 4)) {
+            \\        i += 10;
+            \\    } else {
+            \\        i = 2;
+            \\    }
+            \\    return i;
+            \\}
+        , "2\n");
+
+        case.addCompareOutput(
+            \\export fn _start() u32 {
+            \\    var i: u32 = 5;
+            \\    if (i < @as(u32, 4)) {
+            \\        i += 10;
+            \\    } else if(i == @as(u32, 5)) {
+            \\        i = 20;
+            \\    }
+            \\    return i;
+            \\}
+        , "20\n");
+
+        case.addCompareOutput(
+            \\export fn _start() u32 {
+            \\    var i: u32 = 11;
+            \\    if (i < @as(u32, 4)) {
+            \\        i += 10;
+            \\    } else {
+            \\        if (i > @as(u32, 10)) {
+            \\            i += 20;
+            \\        } else {
+            \\            i = 20;
+            \\        }
+            \\    }
+            \\    return i;
+            \\}
+        , "31\n");
+    }
+
+    {
+        var case = ctx.exe("wasm while loops", wasi);
+
+        case.addCompareOutput(
+            \\export fn _start() u32 {
+            \\    var i: u32 = 0;
+            \\    while(i < @as(u32, 5)){
+            \\        i += 1;
+            \\    }
+            \\
+            \\    return i;
+            \\}
+        , "5\n");
+
+        case.addCompareOutput(
+            \\export fn _start() u32 {
+            \\    var i: u32 = 0;
+            \\    while(i < @as(u32, 10)){
+            \\        var x: u32 = 1;
+            \\        i += x;
+            \\    }
+            \\    return i;
+            \\}
+        , "10\n");
+
+        case.addCompareOutput(
+            \\export fn _start() u32 {
+            \\    var i: u32 = 0;
+            \\    while(i < @as(u32, 10)){
+            \\        var x: u32 = 1;
+            \\        i += x;
+            \\        if (i == @as(u32, 5)) break;
+            \\    }
+            \\    return i;
+            \\}
+        , "5\n");
+    }
 }


### PR DESCRIPTION
Note: This depends on #7864 

This PR implements control flow for the wasm backend and makes the following work:

```zig
export fn _start() u32 {
    var i: u32 = 0;
    while (i < @as(u32, 5)) {
        i += 1;
        if (i == @as(u32, 3)) break;
    }
    
    return i; // returns 3
}
```

This however does not handle dead instructions yet.

Previously, locals were only 'calculated' that were declared inside the direct function scope. Those that were declared in an inner scope (such as an if statement or a while loop) were not counted. To fix this, we now hold a list of all local types and patch the bytecode at the end of the codegen for that particular function. Afterwards we also patch the offset of all function calls to correct them as we may have inserted bytecode after the bytecode for the call was inserted.