### PR TITLE
Implement @offsetOf

### DIFF
--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -3043,6 +3043,7 @@ fn nodeMayNeedMemoryLocation(start_node: *ast.Node, scope: *Scope) bool {
                     .{ "@wasmMemoryGrow", false },
                     .{ "@mod", false },
                     .{ "@mulWithOverflow", false },
+                    .{ "@offsetOf", false },
                     .{ "@panic", false },
                     .{ "@popCount", false },
                     .{ "@ptrCast", false },

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -1813,6 +1813,7 @@ enum BuiltinFnId {
     BuiltinFnIdTagName,
     BuiltinFnIdTagType,
     BuiltinFnIdFieldParentPtr,
+    BuiltinFnIdOffsetOf,
     BuiltinFnIdByteOffsetOf,
     BuiltinFnIdBitOffsetOf,
     BuiltinFnIdAsyncCall,
@@ -2625,6 +2626,7 @@ enum IrInstSrcId {
     IrInstSrcIdTagName,
     IrInstSrcIdTagType,
     IrInstSrcIdFieldParentPtr,
+    IrInstSrcIdOffsetOf,
     IrInstSrcIdByteOffsetOf,
     IrInstSrcIdBitOffsetOf,
     IrInstSrcIdTypeInfo,
@@ -4093,6 +4095,13 @@ struct IrInstGenFieldParentPtr {
 
     IrInstGen *field_ptr;
     TypeStructField *field;
+};
+
+struct IrInstSrcOffsetOf {
+    IrInstSrc base;
+
+    IrInstSrc *type_value;
+    IrInstSrc *field_name;
 };
 
 struct IrInstSrcByteOffsetOf {

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -8844,6 +8844,7 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdTagName, "tagName", 1);
     create_builtin_fn(g, BuiltinFnIdTagType, "TagType", 1);
     create_builtin_fn(g, BuiltinFnIdFieldParentPtr, "fieldParentPtr", 3);
+    create_builtin_fn(g, BuiltinFnIdOffsetOf, "offsetOf", 2);
     create_builtin_fn(g, BuiltinFnIdByteOffsetOf, "byteOffsetOf", 2);
     create_builtin_fn(g, BuiltinFnIdBitOffsetOf, "bitOffsetOf", 2);
     create_builtin_fn(g, BuiltinFnIdDivExact, "divExact", 2);

--- a/src/stage1/ir_print.cpp
+++ b/src/stage1/ir_print.cpp
@@ -286,6 +286,8 @@ const char* ir_inst_src_type_str(IrInstSrcId id) {
             return "SrcTagType";
         case IrInstSrcIdFieldParentPtr:
             return "SrcFieldParentPtr";
+        case IrInstSrcIdOffsetOf:
+            return "SrcOffsetOf";
         case IrInstSrcIdByteOffsetOf:
             return "SrcByteOffsetOf";
         case IrInstSrcIdBitOffsetOf:
@@ -2280,6 +2282,14 @@ static void ir_print_byte_offset_of(IrPrintSrc *irp, IrInstSrcByteOffsetOf *inst
     fprintf(irp->f, ")");
 }
 
+static void ir_print_offset_of(IrPrintSrc *irp, IrInstSrcBitOffsetOf *instruction) {
+    fprintf(irp->f, "@offset_of(");
+    ir_print_other_inst_src(irp, instruction->type_value);
+    fprintf(irp->f, ",");
+    ir_print_other_inst_src(irp, instruction->field_name);
+    fprintf(irp->f, ")");
+}
+
 static void ir_print_bit_offset_of(IrPrintSrc *irp, IrInstSrcBitOffsetOf *instruction) {
     fprintf(irp->f, "@bit_offset_of(");
     ir_print_other_inst_src(irp, instruction->type_value);
@@ -2916,6 +2926,9 @@ static void ir_print_inst_src(IrPrintSrc *irp, IrInstSrc *instruction, bool trai
             break;
         case IrInstSrcIdFieldParentPtr:
             ir_print_field_parent_ptr(irp, (IrInstSrcFieldParentPtr *)instruction);
+            break;
+        case IrInstSrcIdOffsetOf:
+            ir_print_offset_of(irp, (IrInstSrcBitOffsetOf *)instruction);
             break;
         case IrInstSrcIdByteOffsetOf:
             ir_print_byte_offset_of(irp, (IrInstSrcByteOffsetOf *)instruction);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -6656,6 +6656,22 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:8:29: error: field 'b' has index 1 but pointer value is index 0 of struct 'Foo'",
     });
 
+    cases.add("@offsetOf - non integer offset",
+        \\const Foo = packed struct {
+        \\    a: i32,
+        \\    b: i1,
+        \\    c: i1,
+        \\};
+        \\export fn foo() usize {
+        \\    const a = @offsetOf(Foo, "a",);
+        \\    const b = @offsetOf(Foo, "b",);
+        \\    const c = @offsetOf(Foo, "c",);
+        \\    return a + b + c;
+        \\}
+    , &[_][]const u8{
+        "tmp.zig:9:30: error: struct 'Foo' field 'c' not at a byte boundary",
+    });
+
     cases.add("@byteOffsetOf - non struct",
         \\const Foo = i32;
         \\export fn foo() usize {

--- a/test/stage1/behavior/sizeof_and_typeof.zig
+++ b/test/stage1/behavior/sizeof_and_typeof.zig
@@ -34,8 +34,31 @@ const P = packed struct {
     i: u7,
 };
 
+test "@offsetOf" {
+    // Packed structs have fixed memory layout
+    expect(@offsetOf(P, "a") == 0);
+    expect(@offsetOf(P, "a") == 0);
+    expect(@offsetOf(P, "b") == 1);
+    expect(@offsetOf(P, "c") == 5);
+    expect(@offsetOf(P, "d") == 6);
+    expect(@offsetOf(P, "f") == 7);
+    expect(@offsetOf(P, "g") == 9);
+    expect(@offsetOf(P, "h") == 11);
+
+    // Normal struct fields can be moved/padded
+    var a: A = undefined;
+    expect(@ptrToInt(&a.a) - @ptrToInt(&a) == @offsetOf(A, "a"));
+    expect(@ptrToInt(&a.b) - @ptrToInt(&a) == @offsetOf(A, "b"));
+    expect(@ptrToInt(&a.c) - @ptrToInt(&a) == @offsetOf(A, "c"));
+    expect(@ptrToInt(&a.d) - @ptrToInt(&a) == @offsetOf(A, "d"));
+    expect(@ptrToInt(&a.f) - @ptrToInt(&a) == @offsetOf(A, "f"));
+    expect(@ptrToInt(&a.g) - @ptrToInt(&a) == @offsetOf(A, "g"));
+    expect(@ptrToInt(&a.h) - @ptrToInt(&a) == @offsetOf(A, "h"));
+}
+
 test "@byteOffsetOf" {
     // Packed structs have fixed memory layout
+    expect(@byteOffsetOf(P, "a") == 0);
     expect(@byteOffsetOf(P, "a") == 0);
     expect(@byteOffsetOf(P, "b") == 1);
     expect(@byteOffsetOf(P, "c") == 5);


### PR DESCRIPTION
@offsetOf behaves like @byteOffsetOf, with the exception that it fails
if the field does not begin at a byte boundary, i.e. the bit offset is
a multiple of 8.