### PR TITLE
Added support for passing write file args as build options

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2016,8 +2016,11 @@ pub const LibExeObjStep = struct {
     ) void {
         // Note that pathFromRoot uses resolve path, so this will have
         // correct behavior even if getOutputPath is already absolute.
-        const abs_path = std.zig.fmtEscapes(self.builder.pathFromRoot(path));
-        self.addBuildOption([]const u8, name, abs_path);
+        const escaped_abs_path = self.builder.fmt(
+            "{s}",
+            std.zig.fmtEscapes(self.builder.pathFromRoot(path)),
+        );
+        self.addBuildOption([]const u8, name, escaped_abs_path);
     }
 
     pub fn addSystemIncludeDir(self: *LibExeObjStep, path: []const u8) void {

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2006,23 +2006,6 @@ pub const LibExeObjStep = struct {
         self.step.dependOn(&write_file.step);
     }
 
-    /// Adds build option corresponding to the absolute (resolved) path.
-    /// Path is either an absolute path or a path relative to the build
-    /// working directory.
-    pub fn addPathBuildOption(
-        self: *LibExeObjStep,
-        name: []const u8,
-        path: []const u8,
-    ) void {
-        // Note that pathFromRoot uses resolve path, so this will have
-        // correct behavior even if getOutputPath is already absolute.
-        const escaped_abs_path = self.builder.fmt(
-            "{s}",
-            std.zig.fmtEscapes(self.builder.pathFromRoot(path)),
-        );
-        self.addBuildOption([]const u8, name, escaped_abs_path);
-    }
-
     pub fn addSystemIncludeDir(self: *LibExeObjStep, path: []const u8) void {
         self.include_dirs.append(IncludeDir{ .RawPathSystem = self.builder.dupe(path) }) catch unreachable;
     }
@@ -2244,16 +2227,21 @@ pub const LibExeObjStep = struct {
             self.build_options_write_file_args.items.len > 0)
         {
             // Render build artifact and write file options at the last minute, now that the path is known.
+            //
+            // Note that pathFromRoot uses resolve path, so this will have
+            // correct behavior even if getOutputPath is already absolute.
             for (self.build_options_artifact_args.items) |item| {
-                self.addPathBuildOption(
+                self.addBuildOption(
+                    []const u8,
                     item.name,
-                    item.artifact.getOutputPath(),
+                    self.builder.pathFromRoot(item.artifact.getOutputPath()),
                 );
             }
             for (self.build_options_write_file_args.items) |item| {
-                self.addPathBuildOption(
+                self.addBuildOption(
+                    []const u8,
                     item.name,
-                    item.write_file.getOutputPath(item.basename),
+                    self.builder.pathFromRoot(item.write_file.getOutputPath(item.basename)),
                 );
             }
 

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2016,7 +2016,7 @@ pub const LibExeObjStep = struct {
     ) void {
         // Note that pathFromRoot uses resolve path, so this will have
         // correct behavior even if getOutputPath is already absolute.
-        const abs_path = self.builder.pathFromRoot(path);
+        const abs_path = std.zig.fmtEscapes(self.builder.pathFromRoot(path));
         self.addBuildOption([]const u8, name, abs_path);
     }
 
@@ -2240,7 +2240,6 @@ pub const LibExeObjStep = struct {
             self.build_options_artifact_args.items.len > 0 or
             self.build_options_write_file_args.items.len > 0)
         {
-            const path_option_fmt = "pub const {s}: []const u8 = \"{}\";\n";
             // Render build artifact and write file options at the last minute, now that the path is known.
             for (self.build_options_artifact_args.items) |item| {
                 self.addPathBuildOption(


### PR DESCRIPTION
Works the same way as addBuildOptionArtifact. This PR also adds "addPathBuildOption" for abstraction - I think this should be public, but I'm not certain. 

Note that this PR changes the behavior of addBuildOptionArtifact in the edge case where setOutputPath was called and a relative path was used. I think this behavior change is basically a bug fix because the path in build_options should really always be absolute.

I've tested this locally and everything I tried worked. I would add tests, but I don't think there are any integration tests set up for Builder.