### PR TITLE
std.Progress: improve support for "dumb" terminals

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1538,7 +1538,9 @@ pub fn getCompileLogOutput(self: *Compilation) []const u8 {
 }
 
 pub fn performAllTheWork(self: *Compilation) error{ TimerUnsupported, OutOfMemory }!void {
-    var progress: std.Progress = .{};
+    // If the terminal is dumb, we dont want to show the user all the
+    // output.
+    var progress: std.Progress = .{ .dont_print_on_dumb = true };
     var main_progress_node = try progress.start("", 0);
     defer main_progress_node.end();
     if (self.color == .off) progress.terminal = null;

--- a/src/stage1.zig
+++ b/src/stage1.zig
@@ -278,7 +278,9 @@ export fn stage2_attach_segfault_handler() void {
 // ABI warning
 export fn stage2_progress_create() *std.Progress {
     const ptr = std.heap.c_allocator.create(std.Progress) catch @panic("out of memory");
-    ptr.* = std.Progress{};
+    // If the terminal is dumb, we dont want to show the user all the
+    // output.
+    ptr.* = std.Progress{ .dont_print_on_dumb = true };
     return ptr;
 }
 


### PR DESCRIPTION
This improves support for terminals that don't support ansi escape codes, either regular files, or unix like terminals where $TERM=="dumb" like in [9term](https://9fans.github.io/plan9port/man/man1/9term.html) and [acme](http://acme.cat-v.org/).

It makes it that progress for compilation **does not** show, but progress for anything else (tests, user defined stuff) **does** show if `dont_print_on_dumb` is false which is the default. IMO this improves the UX when developing in acme or other terminals that do not support escape codes. It allows the user to see which tests are run, while also not cluttering the output with compilation progress.
Screenshot:
![image](https://user-images.githubusercontent.com/58830309/106471422-9b06e580-646f-11eb-9c8c-0844a9aff17e.png)



cc @pixelherodev 