### PR TITLE
stage1/2: don't show color in compiler when in a "dumb" terminal

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -184,11 +184,7 @@ pub const File = struct {
         }
         if (self.isTty()) {
             if (self.handle == os.STDOUT_FILENO or self.handle == os.STDERR_FILENO) {
-                // Use getenvC to workaround https://github.com/ziglang/zig/issues/3511
-                if (os.getenvZ("TERM")) |term| {
-                    if (std.mem.eql(u8, term, "dumb"))
-                        return false;
-                }
+                return !os.isDumbTerm();
             }
             return true;
         }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2501,6 +2501,13 @@ pub fn setregid(rgid: gid_t, egid: gid_t) SetIdError!void {
     }
 }
 
+/// Does the environment have TERM set to "dumb"
+pub fn isDumbTerm() bool {
+    if (getenv("TERM")) |term|
+        return std.mem.eql(u8, term, "dumb");
+    return false;
+}
+
 /// Test whether a file descriptor refers to a terminal.
 pub fn isatty(handle: fd_t) bool {
     if (builtin.os.tag == .windows) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2887,7 +2887,7 @@ fn printErrMsgToFile(
     color: Color,
 ) !void {
     const color_on = switch (color) {
-        .auto => file.isTty(),
+        .auto => file.isTty() and !(std.os.isDumbTerm()),
         .on => true,
         .off => false,
     };

--- a/src/stage1/errmsg.cpp
+++ b/src/stage1/errmsg.cpp
@@ -17,7 +17,8 @@ enum ErrType {
 
 static void print_err_msg_type(ErrorMsg *err, ErrColor color, ErrType err_type) {
     bool is_tty = os_stderr_tty();
-    bool use_colors = color == ErrColorOn || (color == ErrColorAuto && is_tty);
+    bool use_colors = color == ErrColorOn || 
+        (color == ErrColorAuto && is_tty && !os_is_dumb_term());
 
     // Show the error location, if available
     if (err->path != nullptr) {

--- a/src/stage1/os.cpp
+++ b/src/stage1/os.cpp
@@ -844,6 +844,12 @@ bool os_stderr_tty(void) {
 #endif
 }
 
+bool os_is_dumb_term(void) {
+    char* term = getenv("TERM");
+    if (term == nullptr) return false;
+    return strcmp(term, "dumb") == 0;
+}
+
 Error os_rename(Buf *src_path, Buf *dest_path) {
     if (buf_eql_buf(src_path, dest_path)) {
         return ErrorNone;

--- a/src/stage1/os.hpp
+++ b/src/stage1/os.hpp
@@ -98,6 +98,7 @@ Error ATTRIBUTE_MUST_USE os_fetch_file_path(Buf *full_path, Buf *out_contents);
 Error ATTRIBUTE_MUST_USE os_get_cwd(Buf *out_cwd);
 
 bool os_stderr_tty(void);
+bool os_is_dumb_term(void);
 void os_stderr_set_color(TermColor color);
 
 Error os_rename(Buf *src_path, Buf *dest_path);


### PR DESCRIPTION
Difference: 
![image](https://user-images.githubusercontent.com/58830309/106475316-ce4b7380-6473-11eb-8916-cbc776984b2c.png)
`zig` is from tarball, `zag` is one I built. A terminal is dumb when it has `env["TERM"] == "dumb"`. This includes acme and 9term.

Compliments #7931 
cc @pixelherodev 