### PR TITLE
docs: Clarify that @field can work on declarations

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7533,25 +7533,36 @@ export fn @"A function name that is a complete sentence."() void {}
 
       {#header_open|@field#}
       <pre>{#syntax#}@field(lhs: anytype, comptime field_name: []const u8) (field){#endsyntax#}</pre>
-      <p>Performs field access by a compile-time string.
+      <p>Performs field access by a compile-time string. Works on both fields and declarations.
       </p>
        {#code_begin|test#}
 const std = @import("std");
 
 const Point = struct {
     x: u32,
-    y: u32
+    y: u32,
+
+    pub var z: u32 = 1;
 };
 
 test "field access by string" {
     const expect = std.testing.expect;
-    var p = Point {.x = 0, .y = 0};
+    var p = Point{ .x = 0, .y = 0 };
 
     @field(p, "x") = 4;
     @field(p, "y") = @field(p, "x") + 1;
 
     expect(@field(p, "x") == 4);
     expect(@field(p, "y") == 5);
+}
+
+test "decl access by string" {
+    const expect = std.testing.expect;
+
+    expect(@field(Point, "z") == 1);
+
+    @field(Point, "z") = 2;
+    expect(@field(Point, "z") == 2);
 }
       {#code_end#}
 


### PR DESCRIPTION
This was very non-obvious to me, so I figured it'd be worth including in the docs.