### PR TITLE
zig fmt: deref, unwrap optional

### DIFF
--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -462,6 +462,7 @@ pub const Tree = struct {
             .UndefinedLiteral,
             .UnreachableLiteral,
             .Identifier,
+            .Deref,
             => return main_tokens[n] + end_offset,
 
             .Call,
@@ -515,7 +516,6 @@ pub const Tree = struct {
             .Asm => unreachable, // TODO
             .SliceOpen => unreachable, // TODO
             .Slice => unreachable, // TODO
-            .Deref => unreachable, // TODO
             .ArrayInitOne => unreachable, // TODO
             .ArrayInit => unreachable, // TODO
             .StructInitOne => unreachable, // TODO

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -1503,15 +1503,15 @@ test "zig fmt: top-level fields" {
 //        \\
 //    );
 //}
-//
-//test "zig fmt: ptr deref operator and unwrap optional operator" {
-//    try testCanonical(
-//        \\const a = b.*;
-//        \\const a = b.?;
-//        \\
-//    );
-//}
-//
+
+test "zig fmt: ptr deref operator and unwrap optional operator" {
+   try testCanonical(
+       \\const a = b.*;
+       \\const a = b.?;
+       \\
+   );
+}
+
 //test "zig fmt: comment after if before another if" {
 //    try testCanonical(
 //        \\test "aoeu" {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -991,21 +991,16 @@ fn renderExpression(ais: *Ais, tree: ast.Tree, node: ast.Node.Index, space: Spac
         //    return renderToken(ais, tree, suffix_op.rtoken, space); // ]
         //},
 
-        .Deref => unreachable, // TODO
-        //.Deref => {
-        //    const suffix_op = base.castTag(.Deref).?;
+        .Deref => {
+            try renderExpression(ais, tree, datas[node].lhs, .None);
+            return renderToken(ais, tree, main_tokens[node], space);
+        },
 
-        //    try renderExpression(ais, tree, suffix_op.lhs, Space.None);
-        //    return renderToken(ais, tree, suffix_op.rtoken, space); // .*
-        //},
-        .UnwrapOptional => unreachable, // TODO
-        //.UnwrapOptional => {
-        //    const suffix_op = base.castTag(.UnwrapOptional).?;
-
-        //    try renderExpression(ais, tree, suffix_op.lhs, Space.None);
-        //    try renderToken(ais, tree, tree.prevToken(suffix_op.rtoken), Space.None); // .
-        //    return renderToken(ais, tree, suffix_op.rtoken, space); // ?
-        //},
+        .UnwrapOptional => {
+            try renderExpression(ais, tree, datas[node].lhs, .None);
+            try renderToken(ais, tree, main_tokens[node], .None);
+            return renderToken(ais, tree, datas[node].rhs, space);
+        },
 
         .Break => unreachable, // TODO
         //.Break => {


### PR DESCRIPTION
Dipping my toe in. I'm not 100% confident about where I've placed Deref's `lastToken`. It _works_, in this test case and in slightly more elaborate ones, but I'm a bit unclear on `end_offset`'s role. It appears to be 1 here, which correctly advances it in this case.