### PR TITLE
target: map zig ppc32 → llvm ppc

### DIFF
--- a/lib/std/target/powerpc.zig
+++ b/lib/std/target/powerpc.zig
@@ -760,7 +760,7 @@ pub const cpu = struct {
     };
     pub const ppc32 = CpuModel{
         .name = "ppc32",
-        .llvm_name = "ppc32",
+        .llvm_name = "ppc",
         .features = featureSet(&[_]Feature{
             .hard_float,
         }),


### PR DESCRIPTION
- llvm does not accept `ppc32` as a CPU type

closes #7947