### PR TITLE
Use -isysroot on Catalina too, not just Big Sur

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1536,8 +1536,9 @@ fn buildOutputType(
         }
 
         const has_sysroot = if (comptime std.Target.current.isDarwin()) outer: {
-            const at_least_big_sur = target_info.target.os.getVersionRange().semver.min.major >= 11;
-            if (at_least_big_sur) {
+            const min = target_info.target.os.getVersionRange().semver.min;
+            const at_least_catalina = min.major >= 11 or (min.major >= 10 and min.minor >= 15);
+            if (at_least_catalina) {
                 const sdk_path = try std.zig.system.getSDKPath(arena);
                 try clang_argv.ensureCapacity(clang_argv.items.len + 2);
                 clang_argv.appendAssumeCapacity("-isysroot");


### PR DESCRIPTION
I am writing a Zig program on macOS Catalina 10.15.7 that uses system frameworks.

Under Zig 0.7.1, I had to use [this workaround](https://github.com/ziglang/zig/issues/2208#issuecomment-772309228) otherwise it wouldn't find framework headers such as `#include <Carbon/Carbon.h>`:

```zig
fn getMacFrameworksDir(b: *Builder) ![]u8 {
    const sdk = try b.exec(&[_][]const u8{ "xcrun", "--show-sdk-path" });
    const parts = &[_][]const u8{
        std.mem.trimRight(u8, sdk, "\n"),
        "/System/Library/Frameworks",
    };
    return std.mem.concat(b.allocator, u8, parts);
}

pub fn build(b: *Builder) !void {
    // ...
    exe.addFrameworkDir(try getMacFrameworksDir(b));
    // ...
}
```

I then switched to tip-of-tree Zig (8661a13b748d25d796c0246dad7ad2584d9b0824, `zig version` is `0.8.0-dev.1118+8661a13b7`) which I built from source using [Option A](https://github.com/ziglang/zig/wiki/Building-Zig-From-Source#option-a-use-your-system-installed-build-tools), and it stopped working — with or without my workaround. However, after applying this patch to make main.zig use `-isysroot` on Catalina or later, it worked, _and_ I don't need the workaround anymore.

This was already done in #7506, but only for Big Sur or later. This PR just expands the check to include Catalina.

(Or, maybe we should just always attempt getSDKPath on macOS? Threads complaining about these headers moving go back years, so I'm not sure if Catalina is the earliest where it can happen.)

Related issues: #7697, #2208