### PR TITLE
stage2: Add support for extern functions for the wasm backend

### DIFF
--- a/lib/std/wasm.zig
+++ b/lib/std/wasm.zig
@@ -253,6 +253,20 @@ pub fn section(val: Section) u8 {
     return @enumToInt(val);
 }
 
+/// The kind of the type when importing or exporting to/from the host environment
+/// https://webassembly.github.io/spec/core/syntax/modules.html
+pub const ExternalKind = enum(u8) {
+    function,
+    table,
+    memory,
+    global,
+};
+
+/// Returns the integer value of a given `ExternalKind`
+pub fn kind(val: ExternalKind) u8 {
+    return @enumToInt(val);
+}
+
 // types
 pub const element_type: u8 = 0x70;
 pub const function_type: u8 = 0x60;

--- a/lib/std/wasm.zig
+++ b/lib/std/wasm.zig
@@ -263,7 +263,7 @@ pub const ExternalKind = enum(u8) {
 };
 
 /// Returns the integer value of a given `ExternalKind`
-pub fn kind(val: ExternalKind) u8 {
+pub fn externalKind(val: ExternalKind) u8 {
     return @enumToInt(val);
 }
 

--- a/src/codegen/wasm.zig
+++ b/src/codegen/wasm.zig
@@ -161,7 +161,6 @@ pub const Context = struct {
     pub fn gen(self: *Context) InnerError!void {
         assert(self.code.items.len == 0);
         try self.genFunctype();
-        const writer = self.code.writer();
 
         // Write instructions
         // TODO: check for and handle death of instructions
@@ -194,6 +193,7 @@ pub const Context = struct {
             }
         }
 
+        const writer = self.code.writer();
         try writer.writeByte(wasm.opcode(.end));
 
         // Fill in the size of the generated code to the reserved space at the

--- a/src/codegen/wasm.zig
+++ b/src/codegen/wasm.zig
@@ -163,13 +163,18 @@ pub const Context = struct {
         try self.genFunctype();
         const writer = self.code.writer();
 
-        // Reserve space to write the size after generating the code as well as space for locals count
-        try self.code.resize(10);
-
         // Write instructions
         // TODO: check for and handle death of instructions
         const tv = self.decl.typed_value.most_recent.typed_value;
-        const mod_fn = tv.val.castTag(.function).?.data;
+        const mod_fn = blk: {
+            if (tv.val.castTag(.function)) |func| break :blk func.data;
+            if (tv.val.castTag(.extern_fn)) |ext_fn| return; // don't need codegen for extern functions
+            return self.fail(self.decl.src(), "TODO: Wasm codegen for decl type '{s}'", .{tv.ty.tag()});
+        };
+
+        // Reserve space to write the size after generating the code as well as space for locals count
+        try self.code.resize(10);
+
         try self.genBody(mod_fn.body);
 
         // finally, write our local types at the 'offset' position
@@ -239,9 +244,16 @@ pub const Context = struct {
 
     fn genCall(self: *Context, inst: *Inst.Call) InnerError!WValue {
         const func_inst = inst.func.castTag(.constant).?;
-        const func = func_inst.val.castTag(.function).?.data;
-        const target = func.owner_decl;
-        const target_ty = target.typed_value.most_recent.typed_value.ty;
+        const func_val = inst.func.value().?;
+
+        const target = blk: {
+            if (func_val.castTag(.function)) |func| {
+                break :blk func.data.owner_decl;
+            } else if (func_val.castTag(.extern_fn)) |ext_fn| {
+                break :blk ext_fn.data;
+            }
+            return self.fail(inst.base.src, "Expected a function, but instead found type '{s}'", .{func_val.tag()});
+        };
 
         for (inst.args) |arg| {
             const arg_val = self.resolveInst(arg);
@@ -495,7 +507,7 @@ pub const Context = struct {
     }
 
     fn genBr(self: *Context, br: *Inst.Br) InnerError!WValue {
-        // of operand has codegen bits we should break with a value
+        // if operand has codegen bits we should break with a value
         if (br.operand.ty.hasCodeGenBits()) {
             const operand = self.resolveInst(br.operand);
             try self.emitWValue(operand);


### PR DESCRIPTION
This PR implements extern functions and allows importing functions from the host environment i.e. Javascript.
This however does not yet support other 'import' types such as globals.

The example from the docs now works in stage2:
```zig
extern fn print(i32) void;

export fn add(a: i32, b: i32) void {
    print(a + b);
}
```

```js
const fs = require('fs');
const source = fs.readFileSync("./math.wasm");
const typedArray = new Uint8Array(source);

WebAssembly.instantiate(typedArray, {
  env: {
    print: (result) => { console.log(`The result is ${result}`); }
  }}).then(result => {
  const add = result.instance.exports.add;
  add(1, 2);
});
```

```shell
$ node test.js
The result is 3
```

Currently, we do not yet have a strategy to test this within our testing strategy. We discussed the idea of embedding Wasmtime for the wasm tests to not only support this use case but also allow for more complex tests than simple stdout checking. As that is quite the project on its own, I'll (or someone else will) do that in a separate PR instead.

Lastly, similar to the 'valtype' enum and 'section' enum I added a new `ExternalKind` enum in `std.wasm` that is used for both import and export types.