### PR TITLE
translate-c: Improve function pointer handling

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -848,7 +848,10 @@ pub const UnaryOperator = opaque {
     extern fn ZigClangUnaryOperator_getBeginLoc(*const UnaryOperator) SourceLocation;
 };
 
-pub const ValueDecl = opaque {};
+pub const ValueDecl = opaque {
+    pub const getType = ZigClangValueDecl_getType;
+    extern fn ZigClangValueDecl_getType(*const ValueDecl) QualType;
+};
 
 pub const VarDecl = opaque {
     pub const getLocation = ZigClangVarDecl_getLocation;

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2773,6 +2773,11 @@ struct ZigClangSourceLocation ZigClangUnaryOperator_getBeginLoc(const struct Zig
     return bitcast(casted->getBeginLoc());
 }
 
+struct ZigClangQualType ZigClangValueDecl_getType(const struct ZigClangValueDecl *self) {
+    auto casted = reinterpret_cast<const clang::ValueDecl *>(self);
+    return bitcast(casted->getType());
+}
+
 const struct ZigClangExpr *ZigClangWhileStmt_getCond(const struct ZigClangWhileStmt *self) {
     auto casted = reinterpret_cast<const clang::WhileStmt *>(self);
     return reinterpret_cast<const struct ZigClangExpr *>(casted->getCond());

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -1200,6 +1200,8 @@ ZIG_EXTERN_C struct ZigClangQualType ZigClangUnaryOperator_getType(const struct 
 ZIG_EXTERN_C const struct ZigClangExpr *ZigClangUnaryOperator_getSubExpr(const struct ZigClangUnaryOperator *);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangUnaryOperator_getBeginLoc(const struct ZigClangUnaryOperator *);
 
+ZIG_EXTERN_C struct ZigClangQualType ZigClangValueDecl_getType(const struct ZigClangValueDecl *);
+
 ZIG_EXTERN_C const struct ZigClangExpr *ZigClangWhileStmt_getCond(const struct ZigClangWhileStmt *);
 ZIG_EXTERN_C const struct ZigClangStmt *ZigClangWhileStmt_getBody(const struct ZigClangWhileStmt *);
 

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -818,4 +818,60 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Address of function is no-op",
+        \\#include <stdlib.h>
+        \\#include <stdbool.h>
+        \\typedef int (*myfunc)(int);
+        \\int a(int arg) { return arg + 1;}
+        \\int b(int arg) { return arg + 2;}
+        \\int caller(myfunc fn, int arg) {
+        \\    return fn(arg);
+        \\}
+        \\int main() {
+        \\    myfunc arr[3] = {&a, &b, a};
+        \\    myfunc foo = a;
+        \\    myfunc bar = &(a);
+        \\    if (foo != bar) abort();
+        \\    if (arr[0] == arr[1]) abort();
+        \\    if (arr[0] != arr[2]) abort();
+        \\    if (caller(b, 40) != 42) abort();
+        \\    if (caller(&b, 40) != 42) abort();
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("Obscure ways of calling functions; issue #4124",
+        \\#include <stdlib.h>
+        \\static int add(int a, int b) {
+        \\    return a + b;
+        \\}
+        \\typedef int (*adder)(int, int);
+        \\typedef void (*funcptr)(void);
+        \\int main() {
+        \\    if ((add)(1, 2) != 3) abort();
+        \\    if ((&add)(1, 2) != 3) abort();
+        \\    if (add(3, 1) != 4) abort();
+        \\    if ((*add)(2, 3) != 5) abort();
+        \\    if ((**add)(7, -1) != 6) abort();
+        \\    if ((***add)(-2, 9) != 7) abort();
+        \\
+        \\    int (*ptr)(int a, int b);
+        \\    ptr = add;
+        \\
+        \\    if (ptr(1, 2) != 3) abort();
+        \\    if ((*ptr)(3, 1) != 4) abort();
+        \\    if ((**ptr)(2, 3) != 5) abort();
+        \\    if ((***ptr)(7, -1) != 6) abort();
+        \\    if ((****ptr)(-2, 9) != 7) abort();
+        \\
+        \\    funcptr addr1 = (funcptr)(add);
+        \\    funcptr addr2 = (funcptr)(&add);
+        \\
+        \\    if (addr1 != addr2) abort();
+        \\    if (((int(*)(int, int))addr1)(1, 2) != 3) abort();
+        \\    if (((adder)addr2)(1, 2) != 3) abort();
+        \\    return 0;
+        \\}
+    , "");
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2802,8 +2802,8 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    fn_f64(3);
         \\    fn_bool(@as(c_int, 123) != 0);
         \\    fn_bool(@as(c_int, 0) != 0);
-        \\    fn_bool(@ptrToInt(&fn_int) != 0);
-        \\    fn_int(@intCast(c_int, @ptrToInt(&fn_int)));
+        \\    fn_bool(@ptrToInt(fn_int) != 0);
+        \\    fn_int(@intCast(c_int, @ptrToInt(fn_int)));
         \\    fn_ptr(@intToPtr(?*c_void, @as(c_int, 42)));
         \\}
     });


### PR DESCRIPTION
Omit address-of operator if operand is a function.

Improve handling of function-call translation when using function pointers

Fixes #4124