### PR TITLE
docs: document the nosuspend keyword

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6581,13 +6581,11 @@ const std = @import("std");
 const expect = std.testing.expect;
 
 test "async and await" {
-    // Here we have an exception where we do not match an async
-    // with an await. The test block is not async and so cannot
-    // have a suspend point in it.
-    // This is well-defined behavior, and everything is OK here.
-    // Note however that there would be no way to collect the
-    // return value of amain, if it were something other than void.
-    _ = async amain();
+    // The test block is not async and so cannot have a suspend
+    // point in it. By using the nosuspend keyword, we promise that
+    // the code in amain will finish executing without suspending
+    // back to the test block.
+    nosuspend amain();
 }
 
 fn amain() void {

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10760,10 +10760,14 @@ fn readU32Be() u32 {}
           </td>
           <td>
             The {#syntax#}nosuspend{#endsyntax#} keyword can be used in front of a block, statement or expression.
-            It marks a scope where async functions are not allowed to actually suspend execution.
-            Attempting to suspend execution inside a {#syntax#}nosuspend{#endsyntax#} scope results in safety-checked {#link|Undefined Behavior#}.
-            Code inside a {#syntax#}nosuspend{#endsyntax#} scope does not cause the enclosing function to become an {#link|async function|Async Functions#}.
+            It marks a scope where async functions are not allowed to suspend execution.
             <ul>
+              <li>Attempting to suspend execution inside a {#syntax#}nosuspend{#endsyntax#} scope results in safety-checked {#link|Undefined Behavior#}.
+                <ul>
+                  <li>An async function which {#link|resumes itself from a suspend block|Resuming from Suspend Blocks#} is not considered suspended, so this construct is allowed inside {#syntax#}nosuspend{#endsyntax#}.</li>
+                </ul>
+              </li>
+              <li>Code inside a {#syntax#}nosuspend{#endsyntax#} scope does not cause the enclosing function to become an {#link|async function|Async Functions#}.</li>
               <li>See also {#link|Async Functions#}</li>
             </ul>
           </td>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10759,9 +10759,12 @@ fn readU32Be() u32 {}
             <pre>{#syntax#}nosuspend{#endsyntax#}</pre>
           </td>
           <td>
-            The {#syntax#}nosuspend{#endsyntax#} keyword.
+            The {#syntax#}nosuspend{#endsyntax#} keyword can be used in front of a block, statement or expression.
+            It marks a scope where async functions are not allowed to actually suspend execution.
+            Attempting to suspend execution inside a {#syntax#}nosuspend{#endsyntax#} scope results in safety-checked {#link|Undefined Behavior#}.
+            Code inside a {#syntax#}nosuspend{#endsyntax#} scope does not cause the enclosing function to become an {#link|async function|Async Functions#}.
             <ul>
-              <li>TODO add documentation for nosuspend</li>
+              <li>See also {#link|Async Functions#}</li>
             </ul>
           </td>
         </tr>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10759,15 +10759,15 @@ fn readU32Be() u32 {}
             <pre>{#syntax#}nosuspend{#endsyntax#}</pre>
           </td>
           <td>
-            The {#syntax#}nosuspend{#endsyntax#} keyword can be used in front of a block, statement or expression.
-            It marks a scope where async functions are not allowed to suspend execution.
+            The {#syntax#}nosuspend{#endsyntax#} keyword can be used in front of a block, statement or expression, to mark a scope where no suspension points are reached.
+            In particular, inside a {#syntax#}nosuspend{#endsyntax#} scope:
             <ul>
-              <li>Attempting to suspend execution inside a {#syntax#}nosuspend{#endsyntax#} scope results in safety-checked {#link|Undefined Behavior#}.
-                <ul>
-                  <li>An async function which {#link|resumes itself from a suspend block|Resuming from Suspend Blocks#} is not considered suspended, so this construct is allowed inside {#syntax#}nosuspend{#endsyntax#}.</li>
-                </ul>
-              </li>
-              <li>Code inside a {#syntax#}nosuspend{#endsyntax#} scope does not cause the enclosing function to become an {#link|async function|Async Functions#}.</li>
+              <li>Using the {#syntax#}suspend{#endsyntax#} keyword results in a compile error.</li>
+              <li>Using {#syntax#}await{#endsyntax#} on a function frame which hasn't completed yet results in safety-checked {#link|Undefined Behavior#}.</li>
+              <li>Calling an async function may result in safety-checked {#link|Undefined Behavior#}, because it's equivalent to <code>await async some_async_fn()</code>, which contains an {#syntax#}await{#endsyntax#}.</li>
+            </ul>
+            Code inside a {#syntax#}nosuspend{#endsyntax#} scope does not cause the enclosing function to become an {#link|async function|Async Functions#}.
+            <ul>
               <li>See also {#link|Async Functions#}</li>
             </ul>
           </td>


### PR DESCRIPTION
Here's a basic description, based on the examples I gathered from the standard library.

One detail I tested and wasn't sure whether to include: a `suspend` block can still be reached inside a `nosuspend` scope, as long as it resumes itself, and this is fine, as illustrated in the following program:

```zig
pub fn main() void {
    nosuspend bla();
}

fn bla() void {
    suspend {
        resume @frame();
    }
}
```