### PR TITLE
stage2 ARM: fix callee_preserved_regs

### DIFF
--- a/src/codegen/arm.zig
+++ b/src/codegen/arm.zig
@@ -186,7 +186,7 @@ pub const Psr = enum {
     spsr,
 };
 
-pub const callee_preserved_regs = [_]Register{ .r0, .r1, .r2, .r3, .r4, .r5, .r6, .r7, .r8, .r10 };
+pub const callee_preserved_regs = [_]Register{ .r4, .r5, .r6, .r7, .r8, .r10 };
 pub const c_abi_int_param_regs = [_]Register{ .r0, .r1, .r2, .r3 };
 pub const c_abi_int_return_regs = [_]Register{ .r0, .r1 };
 


### PR DESCRIPTION
Previously, the registers included `r0`, `r1`, `r2`, `r3` which are not included in the callee saved registers according to the Procedure Call Standard for the ARM Architecture.