### PR TITLE
translate-c: call @boolToInt on return value when necessary

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -874,4 +874,39 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Return boolean expression as int; issue #6215",
+        \\#include <stdlib.h>
+        \\#include <stdbool.h>
+        \\bool  actual_bool(void)    { return 4 - 1 < 4;}
+        \\char  char_bool_ret(void)  { return 0 || 1; }
+        \\short short_bool_ret(void) { return 0 < 1; }
+        \\int   int_bool_ret(void)   { return 1 && 1; }
+        \\long  long_bool_ret(void)  { return !(0 > 1); }
+        \\static int GLOBAL = 1;
+        \\int nested_scopes(int a, int b) {
+        \\    if (a == 1) {
+        \\        int target = 1;
+        \\        return b == target;
+        \\    } else {
+        \\        int target = 2;
+        \\        if (b == target) {
+        \\            return GLOBAL == 1;
+        \\        }
+        \\        return target == 2;
+        \\    }
+        \\}
+        \\int main(void) {
+        \\    if (!actual_bool()) abort();
+        \\    if (!char_bool_ret()) abort();
+        \\    if (!short_bool_ret()) abort();
+        \\    if (!int_bool_ret()) abort();
+        \\    if (!long_bool_ret()) abort();
+        \\    if (!nested_scopes(1, 1)) abort();
+        \\    if (nested_scopes(1, 2)) abort();
+        \\    if (!nested_scopes(0, 2)) abort();
+        \\    if (!nested_scopes(0, 3)) abort();
+        \\    return 1 != 1;
+        \\}
+    , "");
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1305,10 +1305,10 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    var a: c_int = undefined;
         \\    var b: f32 = undefined;
         \\    var c: ?*c_void = undefined;
-        \\    return !(a == @as(c_int, 0));
-        \\    return !(a != 0);
-        \\    return !(b != 0);
-        \\    return !(c != null);
+        \\    return @boolToInt(!(a == @as(c_int, 0)));
+        \\    return @boolToInt(!(a != 0));
+        \\    return @boolToInt(!(b != 0));
+        \\    return @boolToInt(!(c != null));
         \\}
     });
 


### PR DESCRIPTION
In C, if a function has return type `int` and the return expression
is a boolean expression, there is no implicit cast. Therefore the
translated Zig code needs to call @boolToInt() on the result.

Additionally, treat a Zig if/else with a boolean result in both bodies
as a boolean result. This allows translated C ternary expressions to be
recognized as boolean results if both arms are boolean expressions.

Fixes #6215