### PR TITLE
stage2: implement intCast for x86_64

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1016,6 +1016,23 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                 return operand;
 
             switch (arch) {
+                .x86_64 => switch (operand) {
+                    .unreach,
+                    .dead,
+                    .compare_flags_unsigned,
+                    .compare_flags_signed,
+                    => unreachable,
+                    .none,
+                    .undef,
+                    .immediate,
+                    .embedded_in_code,
+                    .ptr_embedded_in_code,
+                    .register,
+                    .memory,
+                    .stack_offset,
+                    .ptr_stack_offset,
+                    => return operand,
+                },
                 else => return self.fail(inst.base.src, "TODO implement intCast for {}", .{self.target.cpu.arch}),
             }
         }

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1393,4 +1393,33 @@ pub fn addCases(ctx: *TestContext) !void {
             "",
         );
     }
+
+    {
+        var case = ctx.exe("passing a differently-sized integer to a function parameter", linux_x64);
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    assertEquals5(5);
+            \\    var x: u31 = 5;
+            \\    assertEquals5(x);
+            \\    exit();
+            \\}
+            \\fn assertEquals5(i: u32) void {
+            \\    assert(i == 5);
+            \\}
+            \\fn assert(b: bool) void {
+            \\    if (!b) unreachable;
+            \\}
+            \\fn exit() noreturn {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (231),
+            \\          [arg1] "{rdi}" (0)
+            \\        : "rcx", "r11", "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "",
+        );
+    }
 }


### PR DESCRIPTION
This seems too simple, but I think it should work, since neither pointers nor registers need to be adjusted for this operation.