### PR TITLE
translate-c: handle nested statement expressions

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -922,4 +922,13 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Use correct break label for statement expression in nested scope",
+        \\#include <stdlib.h>
+        \\int main(void) {
+        \\    int x = ({1, ({2; 3;});});
+        \\    if (x != 3) abort();
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
When translating statement expressions, look up the block label
in the scope instead of hardcoding "blk", since they may be
nested.