### PR TITLE
replace ArrayList.shrinkAndFree by ArrayList.shrinkRetainingCapacity

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2186,7 +2186,7 @@ pub const Walker = struct {
             var top = &self.stack.items[self.stack.items.len - 1];
             const dirname_len = top.dirname_len;
             if (try top.dir_it.next()) |base| {
-                self.name_buffer.shrinkAndFree(dirname_len);
+                self.name_buffer.shrinkRetainingCapacity(dirname_len);
                 try self.name_buffer.append(path.sep);
                 try self.name_buffer.appendSlice(base.name);
                 if (base.kind == .Directory) {

--- a/lib/std/io/reader.zig
+++ b/lib/std/io/reader.zig
@@ -111,7 +111,7 @@ pub fn Reader(
             delimiter: u8,
             max_size: usize,
         ) !void {
-            array_list.shrinkAndFree(0);
+            array_list.shrinkRetainingCapacity(0);
             while (true) {
                 var byte: u8 = try self.readByte();
 

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -2018,7 +2018,7 @@ pub const Parser = struct {
 
     pub fn reset(p: *Parser) void {
         p.state = .Simple;
-        p.stack.shrinkAndFree(0);
+        p.stack.shrinkRetainingCapacity(0);
     }
 
     pub fn parse(p: *Parser, input: []const u8) !ValueTree {

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -607,7 +607,7 @@ pub const Mutable = struct {
     /// it will have the same length as it had when the function was called.
     pub fn gcd(rma: *Mutable, x: Const, y: Const, limbs_buffer: *std.ArrayList(Limb)) !void {
         const prev_len = limbs_buffer.items.len;
-        defer limbs_buffer.shrinkAndFree(prev_len);
+        defer limbs_buffer.shrinkRetainingCapacity(prev_len);
         const x_copy = if (rma.limbs.ptr == x.limbs.ptr) blk: {
             const start = limbs_buffer.items.len;
             try limbs_buffer.appendSlice(x.limbs);

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1205,13 +1205,13 @@ fn linuxLookupNameFromDnsSearch(
 
     var tok_it = mem.tokenize(search, " \t");
     while (tok_it.next()) |tok| {
-        canon.shrinkAndFree(canon_name.len + 1);
+        canon.shrinkRetainingCapacity(canon_name.len + 1);
         try canon.appendSlice(tok);
         try linuxLookupNameFromDns(addrs, canon, canon.items, family, rc, port);
         if (addrs.items.len != 0) return;
     }
 
-    canon.shrinkAndFree(canon_name.len);
+    canon.shrinkRetainingCapacity(canon_name.len);
     return linuxLookupNameFromDns(addrs, canon, name, family, rc, port);
 }
 


### PR DESCRIPTION
At some point `ArrayList.shrink` got renamed to `ArrayList.shrinkAndFree` and another option `ArrayList.shrinkRetainingCapacity` was introduced. A lot of standard library code used `shrink`, then `shrinkAndFree` while it should be discussed whether `shrinkRetainingCapacity` would be more appropriate.

* In `fs.zig`: no need to waste buffer space if the buffer is appended again anyway.
* In `json.zig`. Calling `reset()` on the `Parser` currently deallocates the stack completely. While this may be intended behavior it could be implemented by just initializing a new `Parser` alltogether. As such, `reset()` just resetting the state in terms of its behavior while retaining already owned buffer space seems reasonable.
* In `reader.zig`. Here it seems obvious to keep the buffer alive especially on use-cases like reading a stream line-by-line.
* In the latter two cases `int.zig` and `net.zig` it's not that obvious, but I think the changes are appropriate.