### PR TITLE
stage1: allow async and resume inside nosuspend blocks

### DIFF
--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -10095,10 +10095,6 @@ static IrInstSrc *ir_gen_fn_proto(IrBuilderSrc *irb, Scope *parent_scope, AstNod
 
 static IrInstSrc *ir_gen_resume(IrBuilderSrc *irb, Scope *scope, AstNode *node) {
     assert(node->type == NodeTypeResume);
-    if (get_scope_nosuspend(scope) != nullptr) {
-        add_node_error(irb->codegen, node, buf_sprintf("resume in nosuspend scope"));
-        return irb->codegen->invalid_inst_src;
-    }
 
     IrInstSrc *target_inst = ir_gen_node_extra(irb, node->data.resume_expr.expr, scope, LValPtr, nullptr);
     if (target_inst == irb->codegen->invalid_inst_src)

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -7607,12 +7607,7 @@ static IrInstSrc *ir_gen_fn_call(IrBuilderSrc *irb, Scope *scope, AstNode *node,
 
     bool is_nosuspend = get_scope_nosuspend(scope) != nullptr;
     CallModifier modifier = node->data.fn_call_expr.modifier;
-    if (is_nosuspend) {
-        if (modifier == CallModifierAsync) {
-            add_node_error(irb->codegen, node,
-                    buf_sprintf("async call in nosuspend scope"));
-            return irb->codegen->invalid_inst_src;
-        }
+    if (is_nosuspend && modifier != CallModifierAsync) {
         modifier = CallModifierNoSuspend;
     }
 

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1029,7 +1029,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     , &[_][]const u8{
         "tmp.zig:3:21: error: async call in nosuspend scope",
         "tmp.zig:4:9: error: suspend in nosuspend scope",
-        "tmp.zig:5:9: error: resume in nosuspend scope",
     });
 
     cases.add("atomicrmw with bool op not .Xchg",

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1027,7 +1027,6 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\}
         \\fn foo() void {}
     , &[_][]const u8{
-        "tmp.zig:3:21: error: async call in nosuspend scope",
         "tmp.zig:4:9: error: suspend in nosuspend scope",
     });
 


### PR DESCRIPTION
This is to address issue #8000.

My biggest worry is that this could invalidate some assumptions I don't know about. In particular, I may be missing something fundamental because I don't understand why the `CallModifier` enum is an enum rather than a collection of flags; are the different modifiers really mutually exclusive?

Based on looking at just `stage1/ir.cpp` and `stage1/codegen.cpp`, it looks like `CallModifierAsync` should take priority over `CallModifierNoSuspend`.

When modifying the test case, I only removed the error messages, but left the `async` call and `resume` in the code fragment being compiled, to serve as a test that errors are **not** generated anymore. I don't know if that part of the test should be moved somewhere other than `test/compile_errors.zig`.