### PR TITLE
Std: Expose reader and writer types of std.fifo.LinearFifo

### DIFF
--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -44,6 +44,8 @@ pub fn LinearFifo(
         count: usize,
 
         const Self = @This();
+        pub const Reader = std.io.Reader(*Self, error{}, readFn);
+        pub const Writer = std.io.Writer(*Self, error{OutOfMemory}, appendWrite);
 
         // Type of Self argument for slice operations.
         // If buffer is inline (Static) then we need to ensure we haven't
@@ -228,7 +230,7 @@ pub fn LinearFifo(
             return self.read(dest);
         }
 
-        pub fn reader(self: *Self) std.io.Reader(*Self, error{}, readFn) {
+        pub fn reader(self: *Self) Reader {
             return .{ .context = self };
         }
 
@@ -318,7 +320,7 @@ pub fn LinearFifo(
             return bytes.len;
         }
 
-        pub fn writer(self: *Self) std.io.Writer(*Self, error{OutOfMemory}, appendWrite) {
+        pub fn writer(self: *Self) Writer {
             return .{ .context = self };
         }
 


### PR DESCRIPTION
Good morning,

Some structures of the standard library already expose their Reader/Writer type, like [ArrayList.Writer](https://github.com/ziglang/zig/blob/36178caf3e34859fc715bb281f2692135a337154/lib/std/array_list.zig#L238), [PeekStream.Reader](https://github.com/ziglang/zig/blob/36178caf3e34859fc715bb281f2692135a337154/lib/std/io/peek_stream.zig#L23), etc... but `std.fifo.LinearFifo` does not.

I have a use-case in my codebase where I miss this feature:
```zig
const LinearFifo =@import("std").fifo.LinearFifo;
 
pub const MyType = struct {
    buffer: DynamicLinearFifo,

    const DynamicLinearFifo= LinearFifo([]u8, .Dynamic);

    pub fn reader(self: MyType) ??? { // <--------- Currently unable to declare the return type here.
        return self.buffer.reader();
    }
};
```

I hope this PR make sens :)

Have a nice day !