### PR TITLE
std.Thread.Semaphore: Fix wrong variable name

### DIFF
--- a/lib/std/Thread/Semaphore.zig
+++ b/lib/std/Thread/Semaphore.zig
@@ -13,7 +13,7 @@ cond: Condition = .{},
 //! It is OK to initialize this field to any value.
 permits: usize = 0,
 
-const RwLock = @This();
+const Semaphore = @This();
 const std = @import("../std.zig");
 const Mutex = std.Thread.Mutex;
 const Condition = std.Thread.Condition;


### PR DESCRIPTION
Fixes ziglang#8052