### PR TITLE
Add CPU feature check to standardTargetOptions

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -668,11 +668,11 @@ pub const Target = struct {
                     return mem.eql(usize, &set.ints, &other_set.ints);
                 }
 
-                /// Is the other set a sub set of this set
-                pub fn subSet(set: Set, other_set: Set) bool {
-                    return std.meta.eql((@as(std.meta.Vector(usize_count, usize), set.ints) &
-                        @as(std.meta.Vector(usize_count, usize), other_set.ints)),
-                        @as(std.meta.Vector(usize_count, usize), other_set.ints));
+                pub fn isSuperSetOf(set: Set, other_set: Set) bool {
+                    const V = std.meta.Vector(usize_count, usize);
+                    const set_v: V = set.ints;
+                    const other_v: V = other_set.ints;
+                    return @reduce(.And, (set_v & other_v) == other_v);
                 }
             };
 

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -664,8 +664,15 @@ pub const Target = struct {
                     return @ptrCast(*const [byte_count]u8, &set.ints);
                 }
 
-                pub fn eql(set: Set, other: Set) bool {
-                    return mem.eql(usize, &set.ints, &other.ints);
+                pub fn eql(set: Set, other_set: Set) bool {
+                    return mem.eql(usize, &set.ints, &other_set.ints);
+                }
+
+                /// Is the other set a sub set of this set
+                pub fn subSet(set: Set, other_set: Set) bool {
+                    return std.meta.eql((@as(std.meta.Vector(usize_count, usize), set.ints) &
+                        @as(std.meta.Vector(usize_count, usize), other_set.ints)),
+                        @as(std.meta.Vector(usize_count, usize), other_set.ints));
                 }
             };
 


### PR DESCRIPTION
If there is a mismatch of CPU features provided
compared to the whitelist, then will fail the build and
print what the expected CPU model is and the feature
set for the model. Also prints what features need to be
removed.