### PR TITLE
translate-c: Add support for pointer subtraction

### DIFF
--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -146,6 +146,8 @@ pub const Node = extern union {
         align_cast,
         /// @ptrCast(lhs, rhs)
         ptr_cast,
+        /// @divExact(lhs, rhs)
+        div_exact,
 
         negate,
         negate_wrap,
@@ -300,6 +302,7 @@ pub const Node = extern union {
                 .array_access,
                 .std_mem_zeroinit,
                 .ptr_cast,
+                .div_exact,
                 => Payload.BinOp,
 
                 .integer_literal,
@@ -1127,6 +1130,10 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
         .ptr_cast => {
             const payload = node.castTag(.ptr_cast).?.data;
             return renderBuiltinCall(c, "@ptrCast", &.{ payload.lhs, payload.rhs });
+        },
+        .div_exact => {
+            const payload = node.castTag(.div_exact).?.data;
+            return renderBuiltinCall(c, "@divExact", &.{ payload.lhs, payload.rhs });
         },
         .sizeof => {
             const payload = node.castTag(.sizeof).?.data;
@@ -1993,6 +2000,7 @@ fn renderNodeGrouped(c: *Context, node: Node) !NodeIndex {
         .call,
         .array_type,
         .bool_to_int,
+        .div_exact,
         => {
             // no grouping needed
             return renderNode(c, node);


### PR DESCRIPTION
When two pointers are subtracted, both shall point to elements of the
same array object, or one past the last element of the array object;
the result is the difference of the subscripts of the two array elements.

The size of the result is implementation-defined, and its type
(a signed integer type) is ptrdiff_t defined in the <stddef.h> header.
If the result is not representable in an object of that type,
the behavior is undefined.

See C Standard, §6.5.6 [ISO/IEC 9899:2011]

Fixes #7216