### PR TITLE
fix to compile against 12.0.0-rc2

### DIFF
--- a/src/stage1/target.cpp
+++ b/src/stage1/target.cpp
@@ -31,6 +31,7 @@ static const ZigLLVM_ArchType arch_list[] = {
     ZigLLVM_mips64el,       // MIPS64EL: mips64el, mips64r6el, mipsn32el, mipsn32r6el
     ZigLLVM_msp430,         // MSP430: msp430
     ZigLLVM_ppc,            // PPC: powerpc
+    ZigLLVM_ppcle,          // PPCLE: powerpc (little endian)
     ZigLLVM_ppc64,          // PPC64: powerpc64, ppu
     ZigLLVM_ppc64le,        // PPC64LE: powerpc64le
     ZigLLVM_r600,           // R600: AMD GPUs HD2XXX - HD6XXX
@@ -134,6 +135,7 @@ static const ZigLLVM_EnvironmentType abi_list[] = {
     ZigLLVM_GNUEABI,
     ZigLLVM_GNUEABIHF,
     ZigLLVM_GNUX32,
+    ZigLLVM_GNUILP32,
     ZigLLVM_CODE16,
     ZigLLVM_EABI,
     ZigLLVM_EABIHF,
@@ -484,6 +486,7 @@ uint32_t target_arch_pointer_bit_width(ZigLLVM_ArchType arch) {
         case ZigLLVM_mipsel:
         case ZigLLVM_nvptx:
         case ZigLLVM_ppc:
+        case ZigLLVM_ppcle:
         case ZigLLVM_r600:
         case ZigLLVM_riscv32:
         case ZigLLVM_sparc:
@@ -550,6 +553,7 @@ uint32_t target_arch_largest_atomic_bits(ZigLLVM_ArchType arch) {
         case ZigLLVM_mipsel:
         case ZigLLVM_nvptx:
         case ZigLLVM_ppc:
+        case ZigLLVM_ppcle:
         case ZigLLVM_r600:
         case ZigLLVM_riscv32:
         case ZigLLVM_sparc:
@@ -800,6 +804,7 @@ const char *arch_stack_pointer_register_name(ZigLLVM_ArchType arch) {
         case ZigLLVM_riscv64:
         case ZigLLVM_mipsel:
         case ZigLLVM_ppc:
+        case ZigLLVM_ppcle:
         case ZigLLVM_ppc64:
         case ZigLLVM_ppc64le:
             return "sp";
@@ -904,6 +909,7 @@ bool target_is_arm(const ZigTarget *target) {
         case ZigLLVM_wasm64:
         case ZigLLVM_xcore:
         case ZigLLVM_ppc:
+        case ZigLLVM_ppcle:
         case ZigLLVM_ppc64:
         case ZigLLVM_ve:
             return false;
@@ -1097,6 +1103,7 @@ const char *target_libc_generic_name(const ZigTarget *target) {
         case ZigLLVM_GNUEABI:
         case ZigLLVM_GNUEABIHF:
         case ZigLLVM_GNUX32:
+        case ZigLLVM_GNUILP32:
             return "glibc";
         case ZigLLVM_Musl:
         case ZigLLVM_MuslEABI:

--- a/src/zig_clang_cc1_main.cpp
+++ b/src/zig_clang_cc1_main.cpp
@@ -251,8 +251,7 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
     if (auto profilerOutput =
             Clang->createOutputFile(Path.str(),
                                     /*Binary=*/false,
-                                    /*RemoveFileOnSignal=*/false, "",
-                                    /*Extension=*/"json",
+                                    /*RemoveFileOnSignal=*/false,
                                     /*useTemporary=*/false)) {
 
       llvm::timeTraceProfilerWrite(*profilerOutput);

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -1190,6 +1190,7 @@ static_assert((Triple::ArchType)ZigLLVM_mips64 == Triple::mips64, "");
 static_assert((Triple::ArchType)ZigLLVM_mips64el == Triple::mips64el, "");
 static_assert((Triple::ArchType)ZigLLVM_msp430 == Triple::msp430, "");
 static_assert((Triple::ArchType)ZigLLVM_ppc == Triple::ppc, "");
+static_assert((Triple::ArchType)ZigLLVM_ppcle == Triple::ppcle, "");
 static_assert((Triple::ArchType)ZigLLVM_ppc64 == Triple::ppc64, "");
 static_assert((Triple::ArchType)ZigLLVM_ppc64le == Triple::ppc64le, "");
 static_assert((Triple::ArchType)ZigLLVM_r600 == Triple::r600, "");
@@ -1291,6 +1292,7 @@ static_assert((Triple::EnvironmentType)ZigLLVM_GNUABI64 == Triple::GNUABI64, "")
 static_assert((Triple::EnvironmentType)ZigLLVM_GNUEABI == Triple::GNUEABI, "");
 static_assert((Triple::EnvironmentType)ZigLLVM_GNUEABIHF == Triple::GNUEABIHF, "");
 static_assert((Triple::EnvironmentType)ZigLLVM_GNUX32 == Triple::GNUX32, "");
+static_assert((Triple::EnvironmentType)ZigLLVM_GNUILP32 == Triple::GNUILP32, "");
 static_assert((Triple::EnvironmentType)ZigLLVM_CODE16 == Triple::CODE16, "");
 static_assert((Triple::EnvironmentType)ZigLLVM_EABI == Triple::EABI, "");
 static_assert((Triple::EnvironmentType)ZigLLVM_EABIHF == Triple::EABIHF, "");

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -296,6 +296,7 @@ enum ZigLLVM_ArchType {
     ZigLLVM_mips64el,       // MIPS64EL: mips64el, mips64r6el, mipsn32el, mipsn32r6el
     ZigLLVM_msp430,         // MSP430: msp430
     ZigLLVM_ppc,            // PPC: powerpc
+    ZigLLVM_ppcle,          // PPCLE: powerpc (little endian)
     ZigLLVM_ppc64,          // PPC64: powerpc64, ppu
     ZigLLVM_ppc64le,        // PPC64LE: powerpc64le
     ZigLLVM_r600,           // R600: AMD GPUs HD2XXX - HD6XXX
@@ -408,6 +409,7 @@ enum ZigLLVM_EnvironmentType {
     ZigLLVM_GNUEABI,
     ZigLLVM_GNUEABIHF,
     ZigLLVM_GNUX32,
+    ZigLLVM_GNUILP32,
     ZigLLVM_CODE16,
     ZigLLVM_EABI,
     ZigLLVM_EABIHF,


### PR DESCRIPTION
might save you a few minutes of tedium

note: `zig0` segfaults building zig1.o

<details>
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/48141240/109248443-d2895900-77b3-11eb-8a78-33e8afe04572.png">
</details>