### PR TITLE
stage2: remove value field from error

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4101,7 +4101,6 @@ pub fn namedFieldPtr(
                             scope.arena(),
                             try Value.Tag.@"error".create(scope.arena(), .{
                                 .name = entry.key,
-                                .value = entry.value,
                             }),
                         ),
                     });

--- a/src/value.zig
+++ b/src/value.zig
@@ -1561,7 +1561,6 @@ pub const Value = extern union {
             .@"error" => {
                 const payload = self.castTag(.@"error").?.data;
                 hasher.update(payload.name);
-                std.hash.autoHash(&hasher, payload.value);
             },
             .error_union => {
                 const payload = self.castTag(.error_union).?.data;
@@ -2157,7 +2156,6 @@ pub const Value = extern union {
                 /// duration of the compilation.
                 /// TODO revisit this when we have the concept of the error tag type
                 name: []const u8,
-                value: u16,
             },
         };
 

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -1178,7 +1178,6 @@ fn zirErrorValue(mod: *Module, scope: *Scope, inst: *zir.Inst.ErrorValue) InnerE
         .ty = result_type,
         .val = try Value.Tag.@"error".create(scope.arena(), .{
             .name = entry.key,
-            .value = entry.value,
         }),
     });
 }
@@ -2215,7 +2214,8 @@ fn zirCmp(
         }
         if (rhs.value()) |rval| {
             if (lhs.value()) |lval| {
-                return mod.constBool(scope, inst.base.src, (lval.castTag(.@"error").?.data.value == rval.castTag(.@"error").?.data.value) == (op == .eq));
+                // TODO optimisation oppurtunity: evaluate if std.mem.eql is faster with the names, or calling to Module.getErrorValue to get the values and then compare them is faster
+                return mod.constBool(scope, inst.base.src, std.mem.eql(u8, lval.castTag(.@"error").?.data.name, rval.castTag(.@"error").?.data.name) == (op == .eq));
             }
         }
         return mod.fail(scope, inst.base.src, "TODO implement equality comparison between runtime errors", .{});


### PR DESCRIPTION
This saves memory and from what I have heard allows threading
to be easier.

See https://freenode.irclog.whitequark.org/zig/2021-02-26#1614302124-1614302080;

This is part one of 3 optimizations.
The next one will be moving error_set to type.zig from value. The final will be making an error_set a hashset instead of a hashmap to save memory since all the values are stored in Module anyways. I will probably bundle the latter as 1 pr.