### PR TITLE
std: add sendmsg

### DIFF
--- a/lib/std/os/bits/linux/arm64.zig
+++ b/lib/std/os/bits/linux/arm64.zig
@@ -400,10 +400,10 @@ pub const msghdr = extern struct {
     msg_namelen: socklen_t,
     msg_iov: [*]iovec,
     msg_iovlen: i32,
-    __pad1: i32,
+    __pad1: i32 = 0,
     msg_control: ?*c_void,
     msg_controllen: socklen_t,
-    __pad2: socklen_t,
+    __pad2: socklen_t = 0,
     msg_flags: i32,
 };
 
@@ -412,10 +412,10 @@ pub const msghdr_const = extern struct {
     msg_namelen: socklen_t,
     msg_iov: [*]iovec_const,
     msg_iovlen: i32,
-    __pad1: i32,
+    __pad1: i32 = 0,
     msg_control: ?*c_void,
     msg_controllen: socklen_t,
-    __pad2: socklen_t,
+    __pad2: socklen_t = 0,
     msg_flags: i32,
 };
 

--- a/lib/std/os/bits/linux/x86_64.zig
+++ b/lib/std/os/bits/linux/x86_64.zig
@@ -495,10 +495,10 @@ pub const msghdr = extern struct {
     msg_namelen: socklen_t,
     msg_iov: [*]iovec,
     msg_iovlen: i32,
-    __pad1: i32,
+    __pad1: i32 = 0,
     msg_control: ?*c_void,
     msg_controllen: socklen_t,
-    __pad2: socklen_t,
+    __pad2: socklen_t = 0,
     msg_flags: i32,
 };
 
@@ -507,10 +507,10 @@ pub const msghdr_const = extern struct {
     msg_namelen: socklen_t,
     msg_iov: [*]iovec_const,
     msg_iovlen: i32,
-    __pad1: i32,
+    __pad1: i32 = 0,
     msg_control: ?*c_void,
     msg_controllen: socklen_t,
-    __pad2: socklen_t,
+    __pad2: socklen_t = 0,
     msg_flags: i32,
 };
 

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -977,7 +977,7 @@ pub fn getsockopt(fd: i32, level: u32, optname: u32, noalias optval: [*]u8, noal
     return syscall5(.getsockopt, @bitCast(usize, @as(isize, fd)), level, optname, @ptrToInt(optval), @ptrToInt(optlen));
 }
 
-pub fn sendmsg(fd: i32, msg: *msghdr_const, flags: u32) usize {
+pub fn sendmsg(fd: i32, msg: *const msghdr_const, flags: u32) usize {
     if (builtin.arch == .i386) {
         return socketcall(SC_sendmsg, &[3]usize{ @bitCast(usize, @as(isize, fd)), @ptrToInt(msg), flags });
     }

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1291,6 +1291,19 @@ pub fn getsockname(s: ws2_32.SOCKET, name: *ws2_32.sockaddr, namelen: *ws2_32.so
     return ws2_32.getsockname(s, name, @ptrCast(*i32, namelen));
 }
 
+pub fn sendmsg(
+    s: ws2_32.SOCKET,
+    msg: *const ws2_32.WSAMSG,
+    flags: u32,
+) i32 {
+    var bytes_send: DWORD = undefined;
+    if (ws2_32.WSASendMsg(s, msg, flags, &bytes_send, null, null) == ws2_32.SOCKET_ERROR) {
+        return ws2_32.SOCKET_ERROR;
+    } else {
+        return @as(i32, @intCast(u31, bytes_send));
+    }
+}
+
 pub fn sendto(s: ws2_32.SOCKET, buf: [*]const u8, len: usize, flags: u32, to: ?*const ws2_32.sockaddr, to_len: ws2_32.socklen_t) i32 {
     var buffer = ws2_32.WSABUF{ .len = @truncate(u31, len), .buf = @intToPtr([*]u8, @ptrToInt(buf)) };
     var bytes_send: DWORD = undefined;


### PR DESCRIPTION
  - Error sets copied from `sendto`, they might be different in practice
  - Untested on windows
  - Padding initialised to 0 on 64bit linux (the padding fields don't exist in 32bit, so without a default its quite painful to use)