### PR TITLE
translate-c: add limited OffsetOfExpr support

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -432,6 +432,9 @@ pub const FieldDecl = opaque {
 
     pub const getLocation = ZigClangFieldDecl_getLocation;
     extern fn ZigClangFieldDecl_getLocation(*const FieldDecl) SourceLocation;
+
+    pub const getParent = ZigClangFieldDecl_getParent;
+    extern fn ZigClangFieldDecl_getParent(*const FieldDecl) ?*const RecordDecl;
 };
 
 pub const FileID = opaque {};
@@ -591,6 +594,34 @@ pub const TypeOfType = opaque {
 pub const TypeOfExprType = opaque {
     pub const getUnderlyingExpr = ZigClangTypeOfExprType_getUnderlyingExpr;
     extern fn ZigClangTypeOfExprType_getUnderlyingExpr(*const TypeOfExprType) *const Expr;
+};
+
+pub const OffsetOfNode = opaque {
+    pub const getKind = ZigClangOffsetOfNode_getKind;
+    extern fn ZigClangOffsetOfNode_getKind(*const OffsetOfNode) OffsetOfNode_Kind;
+
+    pub const getArrayExprIndex = ZigClangOffsetOfNode_getArrayExprIndex;
+    extern fn ZigClangOffsetOfNode_getArrayExprIndex(*const OffsetOfNode) c_uint;
+
+    pub const getField = ZigClangOffsetOfNode_getField;
+    extern fn ZigClangOffsetOfNode_getField(*const OffsetOfNode) *FieldDecl;
+};
+
+pub const OffsetOfExpr = opaque {
+    pub const getNumComponents = ZigClangOffsetOfExpr_getNumComponents;
+    extern fn ZigClangOffsetOfExpr_getNumComponents(*const OffsetOfExpr) c_uint;
+
+    pub const getNumExpressions = ZigClangOffsetOfExpr_getNumExpressions;
+    extern fn ZigClangOffsetOfExpr_getNumExpressions(*const OffsetOfExpr) c_uint;
+
+    pub const getIndexExpr = ZigClangOffsetOfExpr_getIndexExpr;
+    extern fn ZigClangOffsetOfExpr_getIndexExpr(*const OffsetOfExpr, idx: c_uint) *const Expr;
+
+    pub const getComponent = ZigClangOffsetOfExpr_getComponent;
+    extern fn ZigClangOffsetOfExpr_getComponent(*const OffsetOfExpr, idx: c_uint) *const OffsetOfNode;
+
+    pub const getBeginLoc = ZigClangOffsetOfExpr_getBeginLoc;
+    extern fn ZigClangOffsetOfExpr_getBeginLoc(*const OffsetOfExpr) SourceLocation;
 };
 
 pub const MemberExpr = opaque {
@@ -1653,6 +1684,13 @@ pub const UnaryExprOrTypeTrait_Kind = extern enum {
     VecStep,
     OpenMPRequiredSimdAlign,
     PreferredAlignOf,
+};
+
+pub const OffsetOfNode_Kind = extern enum {
+    Array,
+    Field,
+    Identifier,
+    Base,
 };
 
 pub const Stage2ErrorMsg = extern struct {

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -148,6 +148,8 @@ pub const Node = extern union {
         ptr_cast,
         /// @divExact(lhs, rhs)
         div_exact,
+        /// @byteOffsetOf(lhs, rhs)
+        byte_offset_of,
 
         negate,
         negate_wrap,
@@ -303,6 +305,7 @@ pub const Node = extern union {
                 .std_mem_zeroinit,
                 .ptr_cast,
                 .div_exact,
+                .byte_offset_of,
                 => Payload.BinOp,
 
                 .integer_literal,
@@ -1134,6 +1137,10 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
         .div_exact => {
             const payload = node.castTag(.div_exact).?.data;
             return renderBuiltinCall(c, "@divExact", &.{ payload.lhs, payload.rhs });
+        },
+        .byte_offset_of => {
+            const payload = node.castTag(.byte_offset_of).?.data;
+            return renderBuiltinCall(c, "@byteOffsetOf", &.{ payload.lhs, payload.rhs });
         },
         .sizeof => {
             const payload = node.castTag(.sizeof).?.data;
@@ -2001,6 +2008,7 @@ fn renderNodeGrouped(c: *Context, node: Node) !NodeIndex {
         .array_type,
         .bool_to_int,
         .div_exact,
+        .byte_offset_of,
         => {
             // no grouping needed
             return renderNode(c, node);

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2609,6 +2609,46 @@ const struct ZigClangExpr *ZigClangTypeOfExprType_getUnderlyingExpr(const struct
     return reinterpret_cast<const struct ZigClangExpr *>(casted->getUnderlyingExpr());
 }
 
+enum ZigClangOffsetOfNode_Kind ZigClangOffsetOfNode_getKind(const struct ZigClangOffsetOfNode *self) {
+    auto casted = reinterpret_cast<const clang::OffsetOfNode *>(self);
+    return (ZigClangOffsetOfNode_Kind)casted->getKind();
+}
+
+unsigned ZigClangOffsetOfNode_getArrayExprIndex(const struct ZigClangOffsetOfNode *self) {
+    auto casted = reinterpret_cast<const clang::OffsetOfNode *>(self);
+    return casted->getArrayExprIndex();
+}
+
+struct ZigClangFieldDecl *ZigClangOffsetOfNode_getField(const struct ZigClangOffsetOfNode *self) {
+    auto casted = reinterpret_cast<const clang::OffsetOfNode *>(self);
+    return reinterpret_cast<ZigClangFieldDecl *>(casted->getField());
+}
+
+unsigned ZigClangOffsetOfExpr_getNumComponents(const struct ZigClangOffsetOfExpr *self) {
+    auto casted = reinterpret_cast<const clang::OffsetOfExpr *>(self);
+    return casted->getNumComponents();
+}
+
+unsigned ZigClangOffsetOfExpr_getNumExpressions(const struct ZigClangOffsetOfExpr *self) {
+    auto casted = reinterpret_cast<const clang::OffsetOfExpr *>(self);
+    return casted->getNumExpressions();
+}
+
+const struct ZigClangExpr *ZigClangOffsetOfExpr_getIndexExpr(const struct ZigClangOffsetOfExpr *self, unsigned idx) {
+    auto casted = reinterpret_cast<const clang::OffsetOfExpr *>(self);
+    return reinterpret_cast<const struct ZigClangExpr *>(casted->getIndexExpr(idx));
+}
+
+const struct ZigClangOffsetOfNode *ZigClangOffsetOfExpr_getComponent(const struct ZigClangOffsetOfExpr *self, unsigned idx) {
+    auto casted = reinterpret_cast<const clang::OffsetOfExpr *>(self);
+    return reinterpret_cast<const struct ZigClangOffsetOfNode *>(&casted->getComponent(idx));
+}
+
+ZigClangSourceLocation ZigClangOffsetOfExpr_getBeginLoc(const ZigClangOffsetOfExpr *self) {
+    auto casted = reinterpret_cast<const clang::OffsetOfExpr *>(self);
+    return bitcast(casted->getBeginLoc());
+}
+
 struct ZigClangQualType ZigClangElaboratedType_getNamedType(const struct ZigClangElaboratedType *self) {
     auto casted = reinterpret_cast<const clang::ElaboratedType *>(self);
     return bitcast(casted->getNamedType());
@@ -3006,6 +3046,11 @@ bool ZigClangFieldDecl_isAnonymousStructOrUnion(const ZigClangFieldDecl *field_d
 ZigClangSourceLocation ZigClangFieldDecl_getLocation(const struct ZigClangFieldDecl *self) {
     auto casted = reinterpret_cast<const clang::FieldDecl *>(self);
     return bitcast(casted->getLocation());
+}
+
+const struct ZigClangRecordDecl *ZigClangFieldDecl_getParent(const struct ZigClangFieldDecl *self) {
+    auto casted = reinterpret_cast<const clang::FieldDecl *>(self);
+    return reinterpret_cast<const ZigClangRecordDecl *>(casted->getParent());
 }
 
 ZigClangQualType ZigClangFieldDecl_getType(const struct ZigClangFieldDecl *self) {

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -928,6 +928,13 @@ enum ZigClangUnaryExprOrTypeTrait_Kind {
     ZigClangUnaryExprOrTypeTrait_KindPreferredAlignOf,
 };
 
+enum ZigClangOffsetOfNode_Kind {
+    ZigClangOffsetOfNode_KindArray,
+    ZigClangOffsetOfNode_KindField,
+    ZigClangOffsetOfNode_KindIdentifier,
+    ZigClangOffsetOfNode_KindBase,
+};
+
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangSourceManager_getSpellingLoc(const struct ZigClangSourceManager *,
         struct ZigClangSourceLocation Loc);
 ZIG_EXTERN_C const char *ZigClangSourceManager_getFilename(const struct ZigClangSourceManager *,
@@ -1161,6 +1168,16 @@ ZIG_EXTERN_C struct ZigClangQualType ZigClangTypeOfType_getUnderlyingType(const 
 
 ZIG_EXTERN_C const struct ZigClangExpr *ZigClangTypeOfExprType_getUnderlyingExpr(const struct ZigClangTypeOfExprType *);
 
+ZIG_EXTERN_C enum ZigClangOffsetOfNode_Kind ZigClangOffsetOfNode_getKind(const struct ZigClangOffsetOfNode *);
+ZIG_EXTERN_C unsigned ZigClangOffsetOfNode_getArrayExprIndex(const struct ZigClangOffsetOfNode *);
+ZIG_EXTERN_C struct ZigClangFieldDecl * ZigClangOffsetOfNode_getField(const struct ZigClangOffsetOfNode *);
+
+ZIG_EXTERN_C unsigned ZigClangOffsetOfExpr_getNumComponents(const struct ZigClangOffsetOfExpr *);
+ZIG_EXTERN_C unsigned ZigClangOffsetOfExpr_getNumExpressions(const struct ZigClangOffsetOfExpr *);
+ZIG_EXTERN_C const struct ZigClangExpr *ZigClangOffsetOfExpr_getIndexExpr(const struct ZigClangOffsetOfExpr *, unsigned idx);
+ZIG_EXTERN_C const struct ZigClangOffsetOfNode *ZigClangOffsetOfExpr_getComponent(const struct ZigClangOffsetOfExpr *, unsigned idx);
+ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangOffsetOfExpr_getBeginLoc(const struct ZigClangOffsetOfExpr *);
+
 ZIG_EXTERN_C struct ZigClangQualType ZigClangElaboratedType_getNamedType(const struct ZigClangElaboratedType *);
 ZIG_EXTERN_C enum ZigClangElaboratedTypeKeyword ZigClangElaboratedType_getKeyword(const struct ZigClangElaboratedType *);
 
@@ -1261,6 +1278,7 @@ ZIG_EXTERN_C bool ZigClangFieldDecl_isBitField(const struct ZigClangFieldDecl *)
 ZIG_EXTERN_C bool ZigClangFieldDecl_isAnonymousStructOrUnion(const ZigClangFieldDecl *);
 ZIG_EXTERN_C struct ZigClangQualType ZigClangFieldDecl_getType(const struct ZigClangFieldDecl *);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangFieldDecl_getLocation(const struct ZigClangFieldDecl *);
+ZIG_EXTERN_C const struct ZigClangRecordDecl *ZigClangFieldDecl_getParent(const struct ZigClangFieldDecl *);
 
 ZIG_EXTERN_C const struct ZigClangExpr *ZigClangEnumConstantDecl_getInitExpr(const struct ZigClangEnumConstantDecl *);
 ZIG_EXTERN_C const struct ZigClangAPSInt *ZigClangEnumConstantDecl_getInitVal(const struct ZigClangEnumConstantDecl *);

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1073,4 +1073,37 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("offsetof",
+        \\#include <stddef.h>
+        \\#include <stdlib.h>
+        \\#define container_of(ptr, type, member) ({                      \
+        \\        const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
+        \\        (type *)( (char *)__mptr - offsetof(type,member) );})
+        \\typedef struct {
+        \\    int i;
+        \\    struct { int x; char y; int z; } s;
+        \\    float f;
+        \\} container;
+        \\int main(void) {
+        \\    if (offsetof(container, i) != 0) abort();
+        \\    if (offsetof(container, s) <= offsetof(container, i)) abort();
+        \\    if (offsetof(container, f) <= offsetof(container, s)) abort();
+        \\
+        \\    container my_container;
+        \\    typeof(my_container.s) *inner_member_pointer = &my_container.s;
+        \\    float *float_member_pointer = &my_container.f;
+        \\    int *anon_member_pointer = &my_container.s.z;
+        \\    container *my_container_p;
+        \\
+        \\    my_container_p = container_of(inner_member_pointer, container, s);
+        \\    if (my_container_p != &my_container) abort();
+        \\
+        \\    my_container_p = container_of(float_member_pointer, container, f);
+        \\    if (my_container_p != &my_container) abort();
+        \\
+        \\    if (container_of(anon_member_pointer, typeof(my_container.s), z) != inner_member_pointer) abort();
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
Add support for OffsetOfExpr that contain exactly 1 component, when that component
is a field.

For example, given:

```c
struct S {
  float f;
  double d;
};
struct T {
  long l;
  int i;
  struct S s[10];
};
```

Then:
```c
offsetof(struct T, i)       // supported
offsetof(struct T, s[2].d)  // not supported currently
```