### PR TITLE
llvm12: std.Target.Abi: add gnuilp32

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -443,6 +443,7 @@ pub const Target = struct {
         gnueabi,
         gnueabihf,
         gnux32,
+        gnuilp32,
         code16,
         eabi,
         eabihf,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -127,6 +127,7 @@ pub fn targetTriple(allocator: *Allocator, target: std.Target) ![:0]u8 {
         .gnueabi => "gnueabi",
         .gnueabihf => "gnueabihf",
         .gnux32 => "gnux32",
+        .gnuilp32 => "gnuilp32",
         .code16 => "code16",
         .eabi => "eabi",
         .eabihf => "eabihf",

--- a/src/target.zig
+++ b/src/target.zig
@@ -71,6 +71,7 @@ pub fn libCGenericName(target: std.Target) [:0]const u8 {
         .gnueabi,
         .gnueabihf,
         .gnux32,
+        .gnuilp32,
         => return "glibc",
         .musl,
         .musleabi,

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2227,8 +2227,8 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    var h: u8 = '\t';
         \\    var i: u8 = '\x0b';
         \\    var j: u8 = '\x00';
-        \\    var k: u8 = '\"';
-        \\    return "\'\\\x07\x08\x0c\n\r\t\x0b\x00\"";
+        \\    var k: u8 = '"';
+        \\    return "'\\\x07\x08\x0c\n\r\t\x0b\x00\"";
         \\}
     });
 


### PR DESCRIPTION
- fixes segfault when `-target x86_64-windows-msvc`
- caused bad llvm-ir `target triple = "x86_64-unknown-windows-musleabihf"`
- fixes test impacted by std.zig.fmtEscapes changes