### PR TITLE
implement fadvise for linux

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -2244,3 +2244,24 @@ pub const MADV_COLD = 20;
 pub const MADV_PAGEOUT = 21;
 pub const MADV_HWPOISON = 100;
 pub const MADV_SOFT_OFFLINE = 101;
+
+pub const POSIX_FADV_NORMAL = 0;
+pub const POSIX_FADV_RANDOM = 1;
+pub const POSIX_FADV_SEQUENTIAL = 2;
+pub const POSIX_FADV_WILLNEED = 3;
+pub usingnamespace switch (builtin.arch) {
+    .s390x => if (@typeInfo(usize).Int.bits == 64)
+        struct {
+            pub const POSIX_FADV_DONTNEED = 6;
+            pub const POSIX_FADV_NOREUSE = 7;
+        }
+    else
+        struct {
+            pub const POSIX_FADV_DONTNEED = 4;
+            pub const POSIX_FADV_NOREUSE = 5;
+        },
+    else => struct {
+        pub const POSIX_FADV_DONTNEED = 4;
+        pub const POSIX_FADV_NOREUSE = 5;
+    },
+};

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -108,3 +108,22 @@ test "user and group ids" {
     expectEqual(linux.getauxval(elf.AT_EUID), linux.geteuid());
     expectEqual(linux.getauxval(elf.AT_EGID), linux.getegid());
 }
+
+test "posix_fadvise" {
+    const tmp_file_name = "temp_posix_fadvise.txt";
+    var file = try fs.cwd().createFile(tmp_file_name, .{});
+    defer {
+        file.close();
+        fs.cwd().deleteFile(tmp_file_name) catch {};
+    }
+
+    const stat = try file.stat();
+
+    const ret = linux.posix_fadvise(
+        file.handle,
+        0,
+        @bitCast(i64, stat.size),
+        linux.POSIX_FADV_SEQUENTIAL,
+    );
+    expectEqual(@as(usize, 0), ret);
+}


### PR DESCRIPTION
This adds `posix_fadvise` for linux and the `POSIX_FADV_*` constants from fcntl.h