### PR TITLE
stage2: remove error number from error set map

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4083,15 +4083,15 @@ pub fn namedFieldPtr(
             const child_type = try val.toType(scope.arena());
             switch (child_type.zigTypeTag()) {
                 .ErrorSet => {
+                    var name: []const u8 = undefined;
                     // TODO resolve inferred error sets
-                    const entry = if (val.castTag(.error_set)) |payload|
-                        (payload.data.fields.getEntry(field_name) orelse
-                            return mod.fail(scope, src, "no error named '{s}' in '{}'", .{ field_name, child_type })).*
+                    if (val.castTag(.error_set)) |payload|
+                        name = (payload.data.fields.getEntry(field_name) orelse return mod.fail(scope, src, "no error named '{s}' in '{}'", .{ field_name, child_type })).key
                     else
-                        try mod.getErrorValue(field_name);
+                        name = (try mod.getErrorValue(field_name)).key;
 
                     const result_type = if (child_type.tag() == .anyerror)
-                        try Type.Tag.error_set_single.create(scope.arena(), entry.key)
+                        try Type.Tag.error_set_single.create(scope.arena(), name)
                     else
                         child_type;
 
@@ -4100,7 +4100,7 @@ pub fn namedFieldPtr(
                         .val = try Value.Tag.ref_val.create(
                             scope.arena(),
                             try Value.Tag.@"error".create(scope.arena(), .{
-                                .name = entry.key,
+                                .name = name,
                             }),
                         ),
                     });

--- a/src/value.zig
+++ b/src/value.zig
@@ -2144,7 +2144,7 @@ pub const Value = extern union {
             base: Payload = .{ .tag = base_tag },
             data: struct {
                 /// TODO revisit this when we have the concept of the error tag type
-                fields: std.StringHashMapUnmanaged(u16),
+                fields: std.StringHashMapUnmanaged(void),
                 decl: *Module.Decl,
             },
         };

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -1154,7 +1154,7 @@ fn zirErrorSet(mod: *Module, scope: *Scope, inst: *zir.Inst.ErrorSet) InnerError
 
     for (inst.positionals.fields) |field_name| {
         const entry = try mod.getErrorValue(field_name);
-        if (payload.data.fields.fetchPutAssumeCapacity(entry.key, entry.value)) |prev| {
+        if (payload.data.fields.fetchPutAssumeCapacity(entry.key, {})) |_| {
             return mod.fail(scope, inst.base.src, "duplicate error: '{s}'", .{field_name});
         }
     }


### PR DESCRIPTION
This saves memory since it is already stored in module as well as allowing for better threading.
Probably conflicts a little with #7778.
Part 3 of what is outlined in #8079.