### PR TITLE
zig c++: fix compilation that includes any c++ std library file

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2264,6 +2264,7 @@ pub fn addCCArgs(
         }
         try argv.append("-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS");
         try argv.append("-D_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS");
+        try argv.append("-D_LIBCPP_HAS_NO_VENDOR_AVAILABILITY_ANNOTATIONS");
     }
 
     const llvm_triple = try @import("codegen/llvm.zig").targetTriple(arena, target);

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -128,6 +128,7 @@ pub fn buildLibCXX(comp: *Compilation) !void {
         try cflags.append("-DLIBCXX_BUILDING_LIBCXXABI");
         try cflags.append("-D_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS");
         try cflags.append("-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS");
+        try cflags.append("-D_LIBCPP_HAS_NO_VENDOR_AVAILABILITY_ANNOTATIONS");
 
         if (target.abi.isMusl()) {
             try cflags.append("-D_LIBCPP_HAS_MUSL_LIBC");


### PR DESCRIPTION
LLVM 12 included a patch that changed the way availability annotations
are specified. We now have to define the _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS
flag to make sure that we tell the c++ headers that we don't use
visibility annotations.

Related LLVM patch: D90843