### PR TITLE
os/linux: fix IO_Uring.timeout

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -2244,3 +2244,8 @@ pub const MADV_COLD = 20;
 pub const MADV_PAGEOUT = 21;
 pub const MADV_HWPOISON = 100;
 pub const MADV_SOFT_OFFLINE = 101;
+
+pub const __kernel_timespec = extern struct {
+    tv_sec: i64,
+    tv_nsec: i64,
+};

--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -526,7 +526,7 @@ pub const IO_Uring = struct {
     pub fn timeout(
         self: *IO_Uring,
         user_data: u64,
-        ts: *const os.timespec,
+        ts: *const os.__kernel_timespec,
         count: u32,
         flags: u32,
     ) !*io_uring_sqe {
@@ -884,7 +884,7 @@ pub fn io_uring_prep_close(sqe: *io_uring_sqe, fd: os.fd_t) void {
 
 pub fn io_uring_prep_timeout(
     sqe: *io_uring_sqe,
-    ts: *const os.timespec,
+    ts: *const os.__kernel_timespec,
     count: u32,
     flags: u32,
 ) void {
@@ -1339,7 +1339,7 @@ test "timeout (after a relative time)" {
 
     const ms = 10;
     const margin = 5;
-    const ts = os.timespec{ .tv_sec = 0, .tv_nsec = ms * 1000000 };
+    const ts = os.__kernel_timespec{ .tv_sec = 0, .tv_nsec = ms * 1000000 };
 
     const started = std.time.milliTimestamp();
     const sqe = try ring.timeout(0x55555555, &ts, 0, 0);
@@ -1366,7 +1366,7 @@ test "timeout (after a number of completions)" {
     };
     defer ring.deinit();
 
-    const ts = os.timespec{ .tv_sec = 3, .tv_nsec = 0 };
+    const ts = os.__kernel_timespec{ .tv_sec = 3, .tv_nsec = 0 };
     const count_completions: u64 = 1;
     const sqe_timeout = try ring.timeout(0x66666666, &ts, count_completions, 0);
     testing.expectEqual(linux.IORING_OP.TIMEOUT, sqe_timeout.opcode);
@@ -1399,7 +1399,7 @@ test "timeout_remove" {
     };
     defer ring.deinit();
 
-    const ts = os.timespec{ .tv_sec = 3, .tv_nsec = 0 };
+    const ts = os.__kernel_timespec{ .tv_sec = 3, .tv_nsec = 0 };
     const sqe_timeout = try ring.timeout(0x88888888, &ts, 0, 0);
     testing.expectEqual(linux.IORING_OP.TIMEOUT, sqe_timeout.opcode);
     testing.expectEqual(@as(u64, 0x88888888), sqe_timeout.user_data);


### PR DESCRIPTION
This PR fixes IO_Uring.timeout on i386

According to the [io_uring PDF](https://kernel.dk/io_uring.pdf) the timeout struct must be 64 bits on both 32 and 64 bit architectures:

> To retain compatibility between 32 vs 64-bit applications and kernel space, the type used must be of the following format
```
struct __kernel_timespec {
  int64_t tv_sec;
  long long tv_nsec;
};
```

I only found this issue because when running `zig build test-std -Dskip-release` on my desktop, [this test](https://github.com/ziglang/zig/blob/master/lib/std/os/linux/io_uring.zig#L1330-L1357) hangs. It can be triggered easily with `zig test -target i386-linux-musl lib/std/os/linux/io_uring.zig` while in the root of the repository.

I found it weird that the CI builds are not affected but grepping through the logs (for example [this one](https://dev.azure.com/ziglang/0184afc2-b8d3-409b-8e4f-4032aaca4c96/_apis/build/builds/12625/logs/27)) all the io_uring tests seem to be skipped for some reason.