### PR TITLE
stage2 ARM: implement basic integer multiplication

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -106,6 +106,7 @@ pub const Inst = struct {
         store,
         sub,
         unreach,
+        mul,
         not,
         floatcast,
         intcast,
@@ -165,6 +166,7 @@ pub const Inst = struct {
 
                 .add,
                 .sub,
+                .mul,
                 .cmp_lt,
                 .cmp_lte,
                 .cmp_eq,

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -1649,6 +1649,7 @@ const DumpTzir = struct {
 
                 .add,
                 .sub,
+                .mul,
                 .cmp_lt,
                 .cmp_lte,
                 .cmp_eq,
@@ -1771,6 +1772,7 @@ const DumpTzir = struct {
 
                 .add,
                 .sub,
+                .mul,
                 .cmp_lt,
                 .cmp_lte,
                 .cmp_eq,

--- a/src/zir_sema.zig
+++ b/src/zir_sema.zig
@@ -2075,6 +2075,7 @@ fn zirArithmetic(mod: *Module, scope: *Scope, inst: *zir.Inst.BinOp) InnerError!
     const ir_tag = switch (inst.base.tag) {
         .add => Inst.Tag.add,
         .sub => Inst.Tag.sub,
+        .mul => Inst.Tag.mul,
         else => return mod.fail(scope, inst.base.src, "TODO implement arithmetic for operand '{s}''", .{@tagName(inst.base.tag)}),
     };
 

--- a/test/stage2/arm.zig
+++ b/test/stage2/arm.zig
@@ -344,4 +344,38 @@ pub fn addCases(ctx: *TestContext) !void {
             "",
         );
     }
+
+    {
+        var case = ctx.exe("integer multiplication", linux_arm);
+        // Simple u32 integer multiplication
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    assert(mul(1, 1) == 1);
+            \\    assert(mul(42, 1) == 42);
+            \\    assert(mul(1, 42) == 42);
+            \\    assert(mul(123, 42) == 5166);
+            \\    exit();
+            \\}
+            \\
+            \\fn mul(x: u32, y: u32) u32 {
+            \\    return x * y;
+            \\}
+            \\
+            \\fn assert(ok: bool) void {
+            \\    if (!ok) unreachable;
+            \\}
+            \\
+            \\fn exit() noreturn {
+            \\    asm volatile ("svc #0"
+            \\        :
+            \\        : [number] "{r7}" (1),
+            \\          [arg1] "{r0}" (0)
+            \\        : "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "",
+        );
+    }
 }


### PR DESCRIPTION
This adds a new tag `mul` to `ir.Instruction`. Currently, this only works with unsigned 32-bit integers (`u32`).