### PR TITLE
zig fmt: allow and trim whitespace around zig fmt: (off|on)

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -1108,6 +1108,25 @@ test "zig fmt: comment to disable/enable zig fmt first" {
     );
 }
 
+test "zig fmt: 'zig fmt: (off|on)' can be surrounded by arbitrary whitespace" {
+    try testTransform(
+        \\// Test trailing comma syntax
+        \\//     zig fmt: off
+        \\
+        \\const struct_trailing_comma = struct { x: i32, y: i32, };
+        \\
+        \\//   zig fmt: on
+    ,
+        \\// Test trailing comma syntax
+        \\// zig fmt: off
+        \\
+        \\const struct_trailing_comma = struct { x: i32, y: i32, };
+        \\
+        \\// zig fmt: on
+        \\
+    );
+}
+
 test "zig fmt: comment to disable/enable zig fmt" {
     try testTransform(
         \\const  a  =  b;


### PR DESCRIPTION
Currently `//  zig fmt: off` does not work as there are two spaces
after the `//` instead of one. This can cause confusion, so allow
arbitrary whitespace before the `zig fmt: (off|on)` in the comment but
trim this whitespace to the canonical single space in the output.

requested by @LemonBoy :)