### PR TITLE
Implement fmtDuration using Formatter

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1256,7 +1256,7 @@ pub fn formatDuration(ns: u64, comptime fmt: []const u8, options: std.fmt.Format
         }
     }
 
-    try formatInt(ns, 10, false, .{}, writer);
+    try formatInt(ns_remaining, 10, false, .{}, writer);
     try writer.writeAll("ns");
     return;
 }
@@ -1292,6 +1292,7 @@ test "fmtDuration" {
         .{ .s = "1y1h999.999us", .d = 365 * std.time.ns_per_day + std.time.ns_per_hour + std.time.ns_per_ms - 1 },
         .{ .s = "1y1h1ms", .d = 365 * std.time.ns_per_day + std.time.ns_per_hour + std.time.ns_per_ms },
         .{ .s = "1y1h1ms", .d = 365 * std.time.ns_per_day + std.time.ns_per_hour + std.time.ns_per_ms + 1 },
+        .{ .s = "1y1m999ns", .d = 365 * std.time.ns_per_day + std.time.ns_per_min + 999 },
     }) |tc| {
         const slice = try bufPrint(&buf, "{}", .{fmtDuration(tc.d)});
         std.testing.expectEqualStrings(tc.s, slice);

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1210,11 +1210,7 @@ pub fn formatIntBuf(out_buf: []u8, value: anytype, base: u8, uppercase: bool, op
     return fbs.pos;
 }
 
-/// Formats a number of nanoseconds according to its magnitude:
-///
-/// - #ns
-/// - [#y][#w][#d][#h][#m]#[.###][u|m]s
-pub fn formatDuration(ns: u64, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
+fn formatDuration(ns: u64, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
     var ns_remaining = ns;
     inline for (.{
         .{ .ns = 365 * std.time.ns_per_day, .sep = 'y' },
@@ -1261,8 +1257,9 @@ pub fn formatDuration(ns: u64, comptime fmt: []const u8, options: std.fmt.Format
     return;
 }
 
-/// Return a Formatter for a number of nanoseconds using `formatDuration`.
-fn fmtDuration(ns: u64) Formatter(formatDuration) {
+/// Return a Formatter for number of nanoseconds according to its magnitude:
+/// [#y][#w][#d][#h][#m]#[.###][n|u|m]s
+pub fn fmtDuration(ns: u64) Formatter(formatDuration) {
     return .{ .data = ns };
 }
 
@@ -1298,9 +1295,6 @@ test "fmtDuration" {
         std.testing.expectEqualStrings(tc.s, slice);
     }
 }
-
-const Duration = @compileError("Duration has been deprecated; wrap your argument in std.fmt.fmtDuration instead");
-const duration = @compileError("duration has been deprecated; wrap your argument in std.fmt.fmtDuration instead");
 
 pub const ParseIntError = error{
     /// The result cannot fit in the type specified


### PR DESCRIPTION
Per #8007, this removes single-purpose `std.fmt.Duration` and `std.fmt.duration` and creates `std.fmt.fmtDuration` which uses the `std.fmt.Formatter` pattern.