### PR TITLE
Reject bare +/- input when parsing floats

### DIFF
--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -339,7 +339,7 @@ fn caseInEql(a: []const u8, b: []const u8) bool {
 }
 
 pub fn parseFloat(comptime T: type, s: []const u8) !T {
-    if (s.len == 0) {
+    if (s.len == 0 or (s.len == 1 and (s[0] == '+' or s[0] == '-'))) {
         return error.InvalidCharacter;
     }
 
@@ -379,6 +379,8 @@ test "fmt.parseFloat" {
         testing.expectError(error.InvalidCharacter, parseFloat(T, ""));
         testing.expectError(error.InvalidCharacter, parseFloat(T, "   1"));
         testing.expectError(error.InvalidCharacter, parseFloat(T, "1abc"));
+        testing.expectError(error.InvalidCharacter, parseFloat(T, "+"));
+        testing.expectError(error.InvalidCharacter, parseFloat(T, "-"));
 
         expectEqual(try parseFloat(T, "0"), 0.0);
         expectEqual(try parseFloat(T, "0"), 0.0);


### PR DESCRIPTION
This PR proposes that `parseFloat` should fail when inputs are bare sign characters, the same way `parseInt` does. Currently `parseFloat(f64, "+") == 0.0` Note that leading spaces are handled elsewhere in the parser, so I think the s[0] based conditionals are fine (parseInt does the same)