### PR TITLE
translate-c: Support compound assignment of pointer and signed int

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1154,6 +1154,16 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    y = x - idx;
         \\    if (y != x + 1 || y != &array[6]) abort();
         \\
+        \\    idx = 1;
+        \\    x += idx;
+        \\    if (x != &array[6]) abort();
+        \\    x -= idx;
+        \\    if (x != &array[5]) abort();
+        \\    y = (x += idx);
+        \\    if (y != x || y != &array[6]) abort();
+        \\    y = (x -= idx);
+        \\    if (y != x || y != &array[5]) abort();
+        \\
         \\    return 0;
         \\}
     , "");


### PR DESCRIPTION
This handles `ptr += idx` and `ptr -= idx` when `idx` is a
signed integer expression.