### PR TITLE
std/special: init-exe,lib make import(std) its own decl

### DIFF
--- a/lib/std/special/init-exe/build.zig
+++ b/lib/std/special/init-exe/build.zig
@@ -1,4 +1,5 @@
-const Builder = @import("std").build.Builder;
+const std = @import("std");
+const Builder = std.build.Builder;
 
 pub fn build(b: *Builder) void {
     // Standard target options allows the person running `zig build` to choose

--- a/lib/std/special/init-exe/build.zig
+++ b/lib/std/special/init-exe/build.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
+pub fn build(b: *std.build.Builder) void {
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
     // means any target is allowed, and the default is native. Other options

--- a/lib/std/special/init-lib/build.zig
+++ b/lib/std/special/init-lib/build.zig
@@ -1,4 +1,5 @@
-const Builder = @import("std").build.Builder;
+const std = @import("std");
+const Builder = std.build.Builder;
 
 pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();

--- a/lib/std/special/init-lib/build.zig
+++ b/lib/std/special/init-lib/build.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
 
 pub fn build(b: *std.build.Builder) void {
+    // Standard release options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const mode = b.standardReleaseOptions();
+
     const lib = b.addStaticLibrary("$", "src/main.zig");
     lib.setBuildMode(mode);
     lib.install();

--- a/lib/std/special/init-lib/build.zig
+++ b/lib/std/special/init-lib/build.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
+pub fn build(b: *std.build.Builder) void {
     const mode = b.standardReleaseOptions();
     const lib = b.addStaticLibrary("$", "src/main.zig");
     lib.setBuildMode(mode);


### PR DESCRIPTION
developers will often have to make this change when adding complexity to their `build.zig`. this change makes the default to put `std` available at the top level.