### PR TITLE
fix parsing of assignment with 'inline for' and 'inline while'

### DIFF
--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -1981,7 +1981,7 @@ const Parser = struct {
                 }
             },
             .keyword_inline => {
-                p.tok_i += 2;
+                p.tok_i += 1;
                 switch (p.token_tags[p.tok_i]) {
                     .keyword_for => return p.parseForExpr(),
                     .keyword_while => return p.parseWhileExpr(),

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -4297,6 +4297,18 @@ test "zig fmt: respect extra newline between switch items" {
     );
 }
 
+test "zig fmt: assignment with inline for and inline while" {
+    try testCanonical(
+        \\const tmp = inline for (items) |item| {};
+        \\
+    );
+
+    try testCanonical(
+        \\const tmp2 = inline while (true) {};
+        \\
+    );
+}
+
 test "zig fmt: insert trailing comma if there are comments between switch values" {
     try testTransform(
         \\const a = switch (b) {


### PR DESCRIPTION
I found this because with Zig `0.8.0-dev.1417+9f722f43a` `zig fmt` is broken with the following code:
```
const std = @import("std");

pub fn main() anyerror!void {
    const data = &[_][]const u8{
        "foo", "bar",
    };

    const foo = inline while (true) {
        break data[0];
    };

    const foo2 = inline for (data) |element| {
        break element;
    };
}
```
I get this error:
```
$ zig fmt src/main.zig
src/main.zig:8:30: error: expected 'while' or 'for', found '('
    const foo = inline while (true) {
                             ~
src/main.zig:12:29: error: expected 'while' or 'for', found '('
    const foo2 = inline for (data) |element| {
```

I've also added two tests for both `inline for` and `inline while`