### PR TITLE
parser: fix parsing/rendering of a[b.. :c] slicing

### DIFF
--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -525,7 +525,9 @@ pub const Tree = struct {
             => {
                 // Look for a label.
                 const lbrace = main_tokens[n];
-                if (token_tags[lbrace - 1] == .colon) {
+                if (token_tags[lbrace - 1] == .colon and
+                    token_tags[lbrace - 2] == .identifier)
+                {
                     end_offset += 2;
                 }
                 return lbrace - end_offset;
@@ -989,13 +991,13 @@ pub const Tree = struct {
             },
             .slice => {
                 const extra = tree.extraData(datas[n].rhs, Node.Slice);
-                assert(extra.end != 0); // should have used SliceOpen
+                assert(extra.end != 0); // should have used slice_open
                 end_offset += 1; // rbracket
                 n = extra.end;
             },
             .slice_sentinel => {
                 const extra = tree.extraData(datas[n].rhs, Node.SliceSentinel);
-                assert(extra.sentinel != 0); // should have used Slice
+                assert(extra.sentinel != 0); // should have used slice
                 end_offset += 1; // rbracket
                 n = extra.sentinel;
             },
@@ -2925,6 +2927,7 @@ pub const Node = struct {
 
     pub const SliceSentinel = struct {
         start: Index,
+        /// May be 0 if the slice is "open"
         end: Index,
         sentinel: Index,
     };

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -852,6 +852,7 @@ test "zig fmt: slices" {
     try testCanonical(
         \\const a = b[0..];
         \\const c = d[0..1];
+        \\const d = f[0.. :0];
         \\const e = f[0..1 :0];
         \\
     );
@@ -861,6 +862,7 @@ test "zig fmt: slices with spaces in bounds" {
     try testCanonical(
         \\const a = b[0 + 0 ..];
         \\const c = d[0 + 0 .. 1];
+        \\const c = d[0 + 0 .. :0];
         \\const e = f[0 .. 1 + 1 :0];
         \\
     );

--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -848,7 +848,9 @@ pub fn blockExpr(
     const token_tags = tree.tokens.items(.tag);
 
     const lbrace = main_tokens[block_node];
-    if (token_tags[lbrace - 1] == .colon) {
+    if (token_tags[lbrace - 1] == .colon and
+        token_tags[lbrace - 2] == .identifier)
+    {
         return labeledBlockExpr(mod, scope, rl, block_node, statements, .block);
     }
 


### PR DESCRIPTION
Note: checking if the previous token is a colon is insufficent to tell
if a block has a label, the identifier must be checked for as well. This
can be seen in sentinel terminated slicing: `foo[0..1:{}]`