### PR TITLE
parser: disallow ptr modifiers on array types

### DIFF
--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -275,8 +275,10 @@ pub const Tree = struct {
             .extra_volatile_qualifier => {
                 return stream.writeAll("extra volatile qualifier");
             },
-            .invalid_align => {
-                return stream.writeAll("alignment not allowed on arrays");
+            .ptr_mod_on_array_child_type => {
+                return stream.print("pointer modifier '{s}' not allowed on array child type", .{
+                    token_tags[parse_error.token].symbol(),
+                });
             },
             .invalid_and => {
                 return stream.writeAll("`&&` is invalid; note that `and` is boolean AND");
@@ -2388,7 +2390,7 @@ pub const Error = struct {
         extra_allowzero_qualifier,
         extra_const_qualifier,
         extra_volatile_qualifier,
-        invalid_align,
+        ptr_mod_on_array_child_type,
         invalid_and,
         invalid_bit_range,
         invalid_token,

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -4350,11 +4350,17 @@ test "zig fmt: error for invalid bit range" {
     });
 }
 
-test "zig fmt: error for invalid align" {
+test "zig fmt: error for ptr mod on array child type" {
     try testError(
-        \\var x: [10]align(10)u8 = bar;
+        \\var a: [10]align(10) u8 = e;
+        \\var b: [10]const u8 = f;
+        \\var c: [10]volatile u8 = g;
+        \\var d: [10]allowzero u8 = h;
     , &[_]Error{
-        .invalid_align,
+        .ptr_mod_on_array_child_type,
+        .ptr_mod_on_array_child_type,
+        .ptr_mod_on_array_child_type,
+        .ptr_mod_on_array_child_type,
     });
 }
 


### PR DESCRIPTION
closes  #8161

see also: https://github.com/ziglang/zig-spec/pull/28