### PR TITLE
translate-c: Explicitly cast decayed array to pointer with @ptrCast

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1164,6 +1164,10 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    y = (x -= idx);
         \\    if (y != x || y != &array[5]) abort();
         \\
+        \\    if (array + idx != &array[1] || array + 1 != &array[1]) abort();
+        \\    idx = -1;
+        \\    if (array - idx != &array[1]) abort();
+        \\
         \\    return 0;
         \\}
     , "");


### PR DESCRIPTION
This enables translation of code that uses pointer arithmetic with arrays