### PR TITLE
re-enable behavior/vector test for aarch64

### DIFF
--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -510,18 +510,9 @@ test "vector reduce operation" {
             const N = @typeInfo(@TypeOf(x)).Array.len;
             const TX = @typeInfo(@TypeOf(x)).Array.child;
 
-            // LLVM ERROR: Cannot select: intrinsic %llvm.aarch64.neon.fminnmv
-            // https://github.com/ziglang/zig/issues/8130
             // wasmtime: unknown import: `env::fminf` has not been defined
             // https://github.com/ziglang/zig/issues/8131
             switch (std.builtin.arch) {
-                .aarch64 => switch (TX) {
-                    f16 => switch (op) {
-                        .Min, .Max, => return,
-                        else => {},
-                    },
-                    else => {},
-                },
                 .wasm32 => switch (@typeInfo(TX)) {
                     .Float => switch (op) {
                         .Min, .Max, => return,


### PR DESCRIPTION
- issue fixed in llvmorg-12.0.0-rc3

closes #8130

- 12.0.0-rc2 vs rc3, respectively:
```sh
$ _build/zig test test/stage1/behavior.zig -target aarch64-linux-none -I test
LLVM Emit Object... LLVM ERROR: Cannot select: intrinsic %llvm.aarch64.neon.fminnmv
zsh: abort      _build/zig test test/stage1/behavior.zig -target aarch64-linux-none -I test

$ _build.rc3/zig test test/stage1/behavior.zig -target aarch64-linux-none -I test
warning: created /Users/mike/project/zig/work/llvm12/zig-cache/o/958cb366d6cca35c4c1a2eb76369e8a8/test but skipping execution because it is non-native
```