### PR TITLE
translate-c: allow casting signed integer -> pointer

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -1887,7 +1887,12 @@ fn transCCast(
     }
     if (cIsInteger(src_type) and qualTypeIsPtr(dst_type)) {
         // @intToPtr(dest_type, val)
-        return Tag.int_to_ptr.create(c.arena, .{ .lhs = dst_node, .rhs = expr });
+        var rhs = expr;
+        if (cIsSignedInteger(src_type)) {
+            // @intToPtr(dest_type, @bitCast(usize, @intCast(isize, val)));
+            rhs = try usizeCastForWrappingPtrArithmetic(c.arena, expr);
+        }
+        return Tag.int_to_ptr.create(c.arena, .{ .lhs = dst_node, .rhs = rhs });
     }
     if (cIsFloating(src_type) and cIsFloating(dst_type)) {
         // @floatCast(dest_type, val)

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1187,4 +1187,15 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Cast signed integer to pointer. Issue #8201",
+        \\#include <stdlib.h>
+        \\#define MAP_FAILED  ((void *) -1)
+        \\int main(void) {
+        \\    void *ptr = MAP_FAILED;
+        \\    if ((size_t)ptr != (size_t)-1) abort();
+        \\    if ((int)ptr != -1) abort();
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
This is a specific fix for the cast in the linked issue but there is
still room to improve integer casting between ints and pointers (e.g
performing proper truncation if casting to a smaller-size int)

Fixes #8201