### PR TITLE
std/lib/system: Implement native CPU feature detection for ARM

### DIFF
--- a/lib/std/os/bits/linux/arm-eabi.zig
+++ b/lib/std/os/bits/linux/arm-eabi.zig
@@ -518,6 +518,12 @@ pub const HWCAP_IDIV = HWCAP_IDIVA | HWCAP_IDIVT;
 pub const HWCAP_LPAE = 1 << 20;
 pub const HWCAP_EVTSTRM = 1 << 21;
 
+pub const HWCAP2_AES = 1 << 0;
+pub const HWCAP2_PMULL = 1 << 1;
+pub const HWCAP2_SHA1 = 1 << 2;
+pub const HWCAP2_SHA2 = 1 << 3;
+pub const HWCAP2_CRC32 = 1 << 4;
+
 pub const Flock = extern struct {
     l_type: i16,
     l_whence: i16,

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -889,6 +889,9 @@ pub const NativeTargetInfo = struct {
             .x86_64, .i386 => {
                 return @import("system/x86.zig").detectNativeCpuAndFeatures(cpu_arch, os, cross_target);
             },
+            .arm, .armeb => {
+                return @import("system/arm.zig").detectNativeCpuAndFeatures(cpu_arch, os, cross_target);
+            },
             else => {
                 // This architecture does not have CPU model & feature detection yet.
                 // See https://github.com/ziglang/zig/issues/4591

--- a/lib/std/zig/system/arm.zig
+++ b/lib/std/zig/system/arm.zig
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2015-2021 Zig Contributors
+// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
+// The MIT license requires this copyright notice to be included in all copies
+// and substantial portions of the software.
+const std = @import("std");
+const Target = std.Target;
+const CrossTarget = std.zig.CrossTarget;
+
+const FeatureMapEntry = struct {
+    mask: usize,
+    feature: Target.arm.Feature,
+};
+
+const hwcap_feature_map = [_]FeatureMapEntry{
+    .{ .mask = std.os.HWCAP_HALF, .feature = .fp16 },
+    .{ .mask = std.os.HWCAP_NEON, .feature = .neon },
+    .{ .mask = std.os.HWCAP_VFPv3, .feature = .vfp3 },
+    .{ .mask = std.os.HWCAP_VFPv3D16, .feature = .vfp3d16 },
+    .{ .mask = std.os.HWCAP_VFPv4, .feature = .vfp4 },
+    .{ .mask = std.os.HWCAP_IDIVA, .feature = .hwdiv_arm },
+    .{ .mask = std.os.HWCAP_IDIVT, .feature = .hwdiv },
+};
+
+fn detectNativeCpuAndFeaturesLinux(arch: Target.Cpu.Arch, cross_target: CrossTarget) ?Target.Cpu {
+    // TODO detect CPU model and use that as a starting point
+    const baseline = Target.Cpu.Model.baseline(arch);
+
+    var cpu = Target.Cpu{
+        .arch = arch,
+        .model = baseline,
+        .features = baseline.features,
+    };
+
+    const hwcap = std.os.linux.getauxval(std.elf.AT_HWCAP);
+
+    for (hwcap_feature_map) |entry| {
+        if (hwcap & entry.mask != 0) {
+            const idx = @as(Target.Cpu.Feature.Set.Index, @enumToInt(entry.feature));
+            cpu.features.addFeature(idx);
+        }
+    }
+
+    cpu.features.populateDependencies(cpu.arch.allFeaturesList());
+
+    return cpu;
+}
+
+pub fn detectNativeCpuAndFeatures(arch: Target.Cpu.Arch, os: Target.Os, cross_target: CrossTarget) ?Target.Cpu {
+    return switch (os.tag) {
+        .linux => return detectNativeCpuAndFeaturesLinux(arch, cross_target),
+        else => return null,
+    };
+}


### PR DESCRIPTION
Currently, this mirrors LLVM's implementation of CPU feature detection:

https://github.com/llvm/llvm-project/blob/2aef202981211a6744273e4bd56a18e309dd2d79/llvm/lib/Support/Host.cpp#L1591

In future, more information (e.g. from `HWCAP2`) can be extracted and evaluated.