### PR TITLE
explicit parentheses to resolve issue #8159

### DIFF
--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -1366,7 +1366,10 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
                 _ = try c.addToken(.r_paren, ")");
                 break :blk res;
             } else 0;
+            
+            _ = try c.addToken(.l_paren, "(");
             const body = try renderNode(c, payload.body);
+            _ = try c.addToken(.r_paren, ")");
 
             if (cont_expr == 0) {
                 return c.addNode(.{


### PR DESCRIPTION
When an if statement in a while loop with no parentheses is parsed it gives: 
./forifassign.zig:1036:46: error: invalid left-hand side to assignment
        while (i < @as(c_int, 5)) : (i += 1) if (i == @as(c_int, 0)) i = 10;

With the explicit parentheses it should give:
        while (i < @as(c_int, 5)) : (i += 1) (if (i == @as(c_int, 0)) i = 10;)

So the ir can be read correctly.