### PR TITLE
stage2: Warn when using --debug-log without logging enabled

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -841,7 +841,11 @@ fn buildOutputType(
                     } else if (mem.eql(u8, arg, "--debug-log")) {
                         if (i + 1 >= args.len) fatal("expected parameter after {s}", .{arg});
                         i += 1;
-                        try log_scopes.append(gpa, args[i]);
+                        if (!build_options.enable_logging) {
+                            std.log.warn("Zig was compiled without logging enabled (-Dlog). --debug-log has no effect.", .{});
+                        } else {
+                            try log_scopes.append(gpa, args[i]);
+                        }
                     } else if (mem.eql(u8, arg, "-fcompiler-rt")) {
                         want_compiler_rt = true;
                     } else if (mem.eql(u8, arg, "-fno-compiler-rt")) {


### PR DESCRIPTION
A warning is emitted when using the debug option --debug-log when the compiler
was not compiled using the build option -Dlog.

Additionally, the scopes are not added to log_scopes as they have no effect.

I added this warning because I was working on another issue and I could not find why there was no debug logging even though I used the option --debug-log. Maybe this should be included in the [Building Zig from source](https://github.com/ziglang/zig/wiki/Building-Zig-From-Source) page.