### PR TITLE
std: Replace testing fns for floating-point values

### DIFF
--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -1353,7 +1353,7 @@ test "timeout (after a relative time)" {
         .res = -linux.ETIME,
         .flags = 0,
     }, cqe);
-    testing.expectWithinMargin(@intToFloat(f64, ms), @intToFloat(f64, stopped - started), margin);
+    testing.expectApproxEqAbs(@intToFloat(f64, ms), @intToFloat(f64, stopped - started), margin);
 }
 
 test "timeout (after a number of completions)" {

--- a/test/stage1/behavior/vector.zig
+++ b/test/stage1/behavior/vector.zig
@@ -4,7 +4,7 @@ const mem = std.mem;
 const math = std.math;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
-const expectWithinEpsilon = std.testing.expectWithinEpsilon;
+const expectApproxEqRel = std.testing.expectApproxEqRel;
 const Vector = std.meta.Vector;
 
 test "implicit cast vector to array - bool" {
@@ -514,10 +514,14 @@ test "vector reduce operation" {
             switch (@typeInfo(TX)) {
                 .Int, .Bool => expectEqual(expected, r),
                 .Float => {
-                    if (math.isNan(expected) != math.isNan(r)) {
-                        std.debug.panic("unexpected NaN value!\n", .{});
+                    const expected_nan = math.isNan(expected);
+                    const got_nan = math.isNan(r);
+
+                    if (expected_nan and got_nan) {
+                        // Do this check explicitly as two NaN values are never
+                        // equal.
                     } else {
-                        expectWithinEpsilon(expected, r, 0.001);
+                        expectApproxEqRel(expected, r, math.sqrt(math.epsilon(TX)));
                     }
                 },
                 else => unreachable,


### PR DESCRIPTION
Beside handling NaNs and other non-numeric values better we finally
offer the same pair of testing predicates in math and testing.

Real world bug that the previous didn't catch:
```zig
std.testing.expectWithinEpsilon(@as(f32, 1.0), std.math.nan(f32), 0.1); // This check passes!
```