### PR TITLE
Use a unified error set for std/crypto/*

### DIFF
--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -144,6 +144,8 @@ pub const random = &@import("crypto/tlcsprng.zig").interface;
 
 const std = @import("std.zig");
 
+pub const Error = @import("crypto/error.zig").Error;
+
 test "crypto" {
     const please_windows_dont_oom = std.Target.current.os.tag == .windows;
     if (please_windows_dont_oom) return error.SkipZigTest;
@@ -151,7 +153,9 @@ test "crypto" {
     inline for (std.meta.declarations(@This())) |decl| {
         switch (decl.data) {
             .Type => |t| {
-                std.testing.refAllDecls(t);
+                if (@typeInfo(t) != .ErrorSet) {
+                    std.testing.refAllDecls(t);
+                }
             },
             .Var => |v| {
                 _ = v;

--- a/lib/std/crypto/25519/curve25519.zig
+++ b/lib/std/crypto/25519/curve25519.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
+const Error = std.crypto.Error;
 
 /// Group operations over Curve25519.
 pub const Curve25519 = struct {
@@ -28,12 +29,12 @@ pub const Curve25519 = struct {
     pub const basePoint = Curve25519{ .x = Fe.curve25519BasePoint };
 
     /// Check that the encoding of a Curve25519 point is canonical.
-    pub fn rejectNonCanonical(s: [32]u8) !void {
+    pub fn rejectNonCanonical(s: [32]u8) Error!void {
         return Fe.rejectNonCanonical(s, false);
     }
 
     /// Reject the neutral element.
-    pub fn rejectIdentity(p: Curve25519) !void {
+    pub fn rejectIdentity(p: Curve25519) Error!void {
         if (p.x.isZero()) {
             return error.IdentityElement;
         }
@@ -44,7 +45,7 @@ pub const Curve25519 = struct {
         return p.dbl().dbl().dbl();
     }
 
-    fn ladder(p: Curve25519, s: [32]u8, comptime bits: usize) !Curve25519 {
+    fn ladder(p: Curve25519, s: [32]u8, comptime bits: usize) Error!Curve25519 {
         var x1 = p.x;
         var x2 = Fe.one;
         var z2 = Fe.zero;
@@ -85,7 +86,7 @@ pub const Curve25519 = struct {
     /// way to use Curve25519 for a DH operation.
     /// Return error.IdentityElement if the resulting point is
     /// the identity element.
-    pub fn clampedMul(p: Curve25519, s: [32]u8) !Curve25519 {
+    pub fn clampedMul(p: Curve25519, s: [32]u8) Error!Curve25519 {
         var t: [32]u8 = s;
         scalar.clamp(&t);
         return try ladder(p, t, 255);
@@ -95,14 +96,14 @@ pub const Curve25519 = struct {
     /// Return error.IdentityElement if the resulting point is
     /// the identity element or error.WeakPublicKey if the public
     /// key is a low-order point.
-    pub fn mul(p: Curve25519, s: [32]u8) !Curve25519 {
+    pub fn mul(p: Curve25519, s: [32]u8) Error!Curve25519 {
         const cofactor = [_]u8{8} ++ [_]u8{0} ** 31;
         _ = ladder(p, cofactor, 4) catch |_| return error.WeakPublicKey;
         return try ladder(p, s, 256);
     }
 
     /// Compute the Curve25519 equivalent to an Edwards25519 point.
-    pub fn fromEdwards25519(p: std.crypto.ecc.Edwards25519) !Curve25519 {
+    pub fn fromEdwards25519(p: std.crypto.ecc.Edwards25519) Error!Curve25519 {
         try p.clearCofactor().rejectIdentity();
         const one = std.crypto.ecc.Edwards25519.Fe.one;
         const x = one.add(p.y).mul(one.sub(p.y).invert()); // xMont=(1+yEd)/(1-yEd)

--- a/lib/std/crypto/25519/ed25519.zig
+++ b/lib/std/crypto/25519/ed25519.zig
@@ -8,7 +8,8 @@ const crypto = std.crypto;
 const debug = std.debug;
 const fmt = std.fmt;
 const mem = std.mem;
-const Sha512 = std.crypto.hash.sha2.Sha512;
+const Sha512 = crypto.hash.sha2.Sha512;
+const Error = crypto.Error;
 
 /// Ed25519 (EdDSA) signatures.
 pub const Ed25519 = struct {
@@ -40,7 +41,7 @@ pub const Ed25519 = struct {
         ///
         /// For this reason, an EdDSA secret key is commonly called a seed,
         /// from which the actual secret is derived.
-        pub fn create(seed: ?[seed_length]u8) !KeyPair {
+        pub fn create(seed: ?[seed_length]u8) Error!KeyPair {
             const ss = seed orelse ss: {
                 var random_seed: [seed_length]u8 = undefined;
                 crypto.random.bytes(&random_seed);
@@ -71,7 +72,7 @@ pub const Ed25519 = struct {
     /// Sign a message using a key pair, and optional random noise.
     /// Having noise creates non-standard, non-deterministic signatures,
     /// but has been proven to increase resilience against fault attacks.
-    pub fn sign(msg: []const u8, key_pair: KeyPair, noise: ?[noise_length]u8) ![signature_length]u8 {
+    pub fn sign(msg: []const u8, key_pair: KeyPair, noise: ?[noise_length]u8) Error![signature_length]u8 {
         const seed = key_pair.secret_key[0..seed_length];
         const public_key = key_pair.secret_key[seed_length..];
         if (!mem.eql(u8, public_key, &key_pair.public_key)) {
@@ -111,8 +112,8 @@ pub const Ed25519 = struct {
     }
 
     /// Verify an Ed25519 signature given a message and a public key.
-    /// Returns error.InvalidSignature is the signature verification failed.
-    pub fn verify(sig: [signature_length]u8, msg: []const u8, public_key: [public_length]u8) !void {
+    /// Returns error.SignatureVerificationFailed is the signature verification failed.
+    pub fn verify(sig: [signature_length]u8, msg: []const u8, public_key: [public_length]u8) Error!void {
         const r = sig[0..32];
         const s = sig[32..64];
         try Curve.scalar.rejectNonCanonical(s.*);
@@ -133,7 +134,7 @@ pub const Ed25519 = struct {
         const ah = try a.neg().mulPublic(hram);
         const sb_ah = (try Curve.basePoint.mulPublic(s.*)).add(ah);
         if (expected_r.sub(sb_ah).clearCofactor().rejectIdentity()) |_| {
-            return error.InvalidSignature;
+            return error.SignatureVerificationFailed;
         } else |_| {}
     }
 
@@ -145,7 +146,7 @@ pub const Ed25519 = struct {
     };
 
     /// Verify several signatures in a single operation, much faster than verifying signatures one-by-one
-    pub fn verifyBatch(comptime count: usize, signature_batch: [count]BatchElement) !void {
+    pub fn verifyBatch(comptime count: usize, signature_batch: [count]BatchElement) Error!void {
         var r_batch: [count][32]u8 = undefined;
         var s_batch: [count][32]u8 = undefined;
         var a_batch: [count]Curve = undefined;
@@ -200,7 +201,7 @@ pub const Ed25519 = struct {
 
         const zsb = try Curve.basePoint.mulPublic(zs_sum);
         if (zr.add(zah).sub(zsb).rejectIdentity()) |_| {
-            return error.InvalidSignature;
+            return error.SignatureVerificationFailed;
         } else |_| {}
     }
 };
@@ -223,7 +224,7 @@ test "ed25519 signature" {
     var buf: [128]u8 = undefined;
     std.testing.expectEqualStrings(try std.fmt.bufPrint(&buf, "{s}", .{std.fmt.fmtSliceHexUpper(&sig)}), "10A442B4A80CC4225B154F43BEF28D2472CA80221951262EB8E0DF9091575E2687CC486E77263C3418C757522D54F84B0359236ABBBD4ACD20DC297FDCA66808");
     try Ed25519.verify(sig, "test", key_pair.public_key);
-    std.testing.expectError(error.InvalidSignature, Ed25519.verify(sig, "TEST", key_pair.public_key));
+    std.testing.expectError(error.SignatureVerificationFailed, Ed25519.verify(sig, "TEST", key_pair.public_key));
 }
 
 test "ed25519 batch verification" {
@@ -251,7 +252,7 @@ test "ed25519 batch verification" {
         try Ed25519.verifyBatch(2, signature_batch);
 
         signature_batch[1].sig = sig1;
-        std.testing.expectError(error.InvalidSignature, Ed25519.verifyBatch(signature_batch.len, signature_batch));
+        std.testing.expectError(error.SignatureVerificationFailed, Ed25519.verifyBatch(signature_batch.len, signature_batch));
     }
 }
 
@@ -316,7 +317,7 @@ test "ed25519 test vectors" {
             .msg_hex = "9bedc267423725d473888631ebf45988bad3db83851ee85c85e241a07d148b41",
             .public_key_hex = "f7badec5b8abeaf699583992219b7b223f1df3fbbea919844e3f7c554a43dd43",
             .sig_hex = "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff03be9678ac102edcd92b0210bb34d7428d12ffc5df5f37e359941266a4e35f0f",
-            .expected = error.InvalidSignature, // 8 - non-canonical R
+            .expected = error.SignatureVerificationFailed, // 8 - non-canonical R
         },
         Vec{
             .msg_hex = "9bedc267423725d473888631ebf45988bad3db83851ee85c85e241a07d148b41",

--- a/lib/std/crypto/25519/field.zig
+++ b/lib/std/crypto/25519/field.zig
@@ -6,6 +6,7 @@
 const std = @import("std");
 const readIntLittle = std.mem.readIntLittle;
 const writeIntLittle = std.mem.writeIntLittle;
+const Error = std.crypto.Error;
 
 pub const Fe = struct {
     limbs: [5]u64,
@@ -112,7 +113,7 @@ pub const Fe = struct {
     }
 
     /// Reject non-canonical encodings of an element, possibly ignoring the top bit
-    pub fn rejectNonCanonical(s: [32]u8, comptime ignore_extra_bit: bool) !void {
+    pub fn rejectNonCanonical(s: [32]u8, comptime ignore_extra_bit: bool) Error!void {
         var c: u16 = (s[31] & 0x7f) ^ 0x7f;
         comptime var i = 30;
         inline while (i > 0) : (i -= 1) {
@@ -412,7 +413,7 @@ pub const Fe = struct {
     }
 
     /// Compute the square root of `x2`, returning `error.NotSquare` if `x2` was not a square
-    pub fn sqrt(x2: Fe) !Fe {
+    pub fn sqrt(x2: Fe) Error!Fe {
         var x2_copy = x2;
         const x = x2.uncheckedSqrt();
         const check = x.sq().sub(x2_copy);

--- a/lib/std/crypto/25519/ristretto255.zig
+++ b/lib/std/crypto/25519/ristretto255.zig
@@ -5,6 +5,7 @@
 // and substantial portions of the software.
 const std = @import("std");
 const fmt = std.fmt;
+const Error = std.crypto.Error;
 
 /// Group operations over Edwards25519.
 pub const Ristretto255 = struct {
@@ -34,7 +35,7 @@ pub const Ristretto255 = struct {
         return .{ .ratio_is_square = @boolToInt(has_m_root) | @boolToInt(has_p_root), .root = x.abs() };
     }
 
-    fn rejectNonCanonical(s: [encoded_length]u8) !void {
+    fn rejectNonCanonical(s: [encoded_length]u8) Error!void {
         if ((s[0] & 1) != 0) {
             return error.NonCanonical;
         }
@@ -42,7 +43,7 @@ pub const Ristretto255 = struct {
     }
 
     /// Reject the neutral element.
-    pub fn rejectIdentity(p: Ristretto255) callconv(.Inline) !void {
+    pub fn rejectIdentity(p: Ristretto255) callconv(.Inline) Error!void {
         return p.p.rejectIdentity();
     }
 
@@ -50,7 +51,7 @@ pub const Ristretto255 = struct {
     pub const basePoint = Ristretto255{ .p = Curve.basePoint };
 
     /// Decode a Ristretto255 representative.
-    pub fn fromBytes(s: [encoded_length]u8) !Ristretto255 {
+    pub fn fromBytes(s: [encoded_length]u8) Error!Ristretto255 {
         try rejectNonCanonical(s);
         const s_ = Fe.fromBytes(s);
         const ss = s_.sq(); // s^2
@@ -153,7 +154,7 @@ pub const Ristretto255 = struct {
     /// Multiply a Ristretto255 element with a scalar.
     /// Return error.WeakPublicKey if the resulting element is
     /// the identity element.
-    pub fn mul(p: Ristretto255, s: [encoded_length]u8) callconv(.Inline) !Ristretto255 {
+    pub fn mul(p: Ristretto255, s: [encoded_length]u8) callconv(.Inline) Error!Ristretto255 {
         return Ristretto255{ .p = try p.p.mul(s) };
     }
 

--- a/lib/std/crypto/25519/scalar.zig
+++ b/lib/std/crypto/25519/scalar.zig
@@ -5,6 +5,7 @@
 // and substantial portions of the software.
 const std = @import("std");
 const mem = std.mem;
+const Error = std.crypto.Error;
 
 /// 2^252 + 27742317777372353535851937790883648493
 pub const field_size = [32]u8{
@@ -18,7 +19,7 @@ pub const CompressedScalar = [32]u8;
 pub const zero = [_]u8{0} ** 32;
 
 /// Reject a scalar whose encoding is not canonical.
-pub fn rejectNonCanonical(s: [32]u8) !void {
+pub fn rejectNonCanonical(s: [32]u8) Error!void {
     var c: u8 = 0;
     var n: u8 = 1;
     var i: usize = 31;

--- a/lib/std/crypto/25519/x25519.zig
+++ b/lib/std/crypto/25519/x25519.zig
@@ -9,6 +9,7 @@ const mem = std.mem;
 const fmt = std.fmt;
 
 const Sha512 = crypto.hash.sha2.Sha512;
+const Error = crypto.Error;
 
 /// X25519 DH function.
 pub const X25519 = struct {
@@ -31,7 +32,7 @@ pub const X25519 = struct {
         secret_key: [secret_length]u8,
 
         /// Create a new key pair using an optional seed.
-        pub fn create(seed: ?[seed_length]u8) !KeyPair {
+        pub fn create(seed: ?[seed_length]u8) Error!KeyPair {
             const sk = seed orelse sk: {
                 var random_seed: [seed_length]u8 = undefined;
                 crypto.random.bytes(&random_seed);
@@ -44,7 +45,7 @@ pub const X25519 = struct {
         }
 
         /// Create a key pair from an Ed25519 key pair
-        pub fn fromEd25519(ed25519_key_pair: crypto.sign.Ed25519.KeyPair) !KeyPair {
+        pub fn fromEd25519(ed25519_key_pair: crypto.sign.Ed25519.KeyPair) Error!KeyPair {
             const seed = ed25519_key_pair.secret_key[0..32];
             var az: [Sha512.digest_length]u8 = undefined;
             Sha512.hash(seed, &az, .{});
@@ -59,13 +60,13 @@ pub const X25519 = struct {
     };
 
     /// Compute the public key for a given private key.
-    pub fn recoverPublicKey(secret_key: [secret_length]u8) ![public_length]u8 {
+    pub fn recoverPublicKey(secret_key: [secret_length]u8) Error![public_length]u8 {
         const q = try Curve.basePoint.clampedMul(secret_key);
         return q.toBytes();
     }
 
     /// Compute the X25519 equivalent to an Ed25519 public eky.
-    pub fn publicKeyFromEd25519(ed25519_public_key: [crypto.sign.Ed25519.public_length]u8) ![public_length]u8 {
+    pub fn publicKeyFromEd25519(ed25519_public_key: [crypto.sign.Ed25519.public_length]u8) Error![public_length]u8 {
         const pk_ed = try crypto.ecc.Edwards25519.fromBytes(ed25519_public_key);
         const pk = try Curve.fromEdwards25519(pk_ed);
         return pk.toBytes();
@@ -74,7 +75,7 @@ pub const X25519 = struct {
     /// Compute the scalar product of a public key and a secret scalar.
     /// Note that the output should not be used as a shared secret without
     /// hashing it first.
-    pub fn scalarmult(secret_key: [secret_length]u8, public_key: [public_length]u8) ![shared_length]u8 {
+    pub fn scalarmult(secret_key: [secret_length]u8, public_key: [public_length]u8) Error![shared_length]u8 {
         const q = try Curve.fromBytes(public_key).clampedMul(secret_key);
         return q.toBytes();
     }

--- a/lib/std/crypto/aegis.zig
+++ b/lib/std/crypto/aegis.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const mem = std.mem;
 const assert = std.debug.assert;
 const AesBlock = std.crypto.core.aes.Block;
+const Error = std.crypto.Error;
 
 const State128L = struct {
     blocks: [8]AesBlock,
@@ -136,7 +137,7 @@ pub const Aegis128L = struct {
     /// ad: Associated Data
     /// npub: public nonce
     /// k: private key
-    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, key: [key_length]u8) !void {
+    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, key: [key_length]u8) Error!void {
         assert(c.len == m.len);
         var state = State128L.init(key, npub);
         var src: [32]u8 align(16) = undefined;
@@ -298,7 +299,7 @@ pub const Aegis256 = struct {
     /// ad: Associated Data
     /// npub: public nonce
     /// k: private key
-    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, key: [key_length]u8) !void {
+    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, key: [key_length]u8) Error!void {
         assert(c.len == m.len);
         var state = State256.init(key, npub);
         var src: [16]u8 align(16) = undefined;

--- a/lib/std/crypto/aes_gcm.zig
+++ b/lib/std/crypto/aes_gcm.zig
@@ -12,6 +12,7 @@ const debug = std.debug;
 const Ghash = std.crypto.onetimeauth.Ghash;
 const mem = std.mem;
 const modes = crypto.core.modes;
+const Error = crypto.Error;
 
 pub const Aes128Gcm = AesGcm(crypto.core.aes.Aes128);
 pub const Aes256Gcm = AesGcm(crypto.core.aes.Aes256);
@@ -59,7 +60,7 @@ fn AesGcm(comptime Aes: anytype) type {
             }
         }
 
-        pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, key: [key_length]u8) !void {
+        pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, key: [key_length]u8) Error!void {
             assert(c.len == m.len);
 
             const aes = Aes.initEnc(key);

--- a/lib/std/crypto/aes_ocb.zig
+++ b/lib/std/crypto/aes_ocb.zig
@@ -10,6 +10,7 @@ const aes = crypto.core.aes;
 const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
+const Error = crypto.Error;
 
 pub const Aes128Ocb = AesOcb(aes.Aes128);
 pub const Aes256Ocb = AesOcb(aes.Aes256);
@@ -178,7 +179,7 @@ fn AesOcb(comptime Aes: anytype) type {
         /// ad: Associated Data
         /// npub: public nonce
         /// k: secret key
-        pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, key: [key_length]u8) !void {
+        pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, key: [key_length]u8) Error!void {
             assert(c.len == m.len);
 
             const aes_enc_ctx = Aes.initEnc(key);

--- a/lib/std/crypto/error.zig
+++ b/lib/std/crypto/error.zig
@@ -1,0 +1,34 @@
+pub const Error = error{
+    /// MAC verification failed - The tag doesn't verify for the given ciphertext and secret key
+    AuthenticationFailed,
+
+    /// The requested output length is too long for the chosen algorithm
+    OutputTooLong,
+
+    /// Finite field operation returned the identity element
+    IdentityElement,
+
+    /// Encoded input cannot be decoded
+    InvalidEncoding,
+
+    /// The signature does't verify for the given message and public key
+    SignatureVerificationFailed,
+
+    /// Both a public and secret key have been provided, but they are incompatible
+    KeyMismatch,
+
+    /// Encoded input is not in canonical form
+    NonCanonical,
+
+    /// Square root has no solutions
+    NotSquare,
+
+    /// Verification string doesn't match the provided password and parameters
+    PasswordVerificationFailed,
+
+    /// Parameters would be insecure to use
+    WeakParameters,
+
+    /// Public key would be insecure to use
+    WeakPublicKey,
+};

--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -20,6 +20,7 @@ const assert = std.debug.assert;
 const testing = std.testing;
 const htest = @import("test.zig");
 const Vector = std.meta.Vector;
+const Error = std.crypto.Error;
 
 pub const State = struct {
     pub const BLOCKBYTES = 48;
@@ -392,7 +393,7 @@ pub const Aead = struct {
     /// npub: public nonce
     /// k: private key
     /// NOTE: the check of the authentication tag is currently not done in constant time
-    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) !void {
+    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) Error!void {
         assert(c.len == m.len);
 
         var state = Aead.init(ad, npub, k);
@@ -429,7 +430,7 @@ pub const Aead = struct {
         // TODO: use a constant-time equality check here, see https://github.com/ziglang/zig/issues/1776
         if (!mem.eql(u8, buf[0..State.RATE], &tag)) {
             @memset(m.ptr, undefined, m.len);
-            return error.InvalidMessage;
+            return error.AuthenticationFailed;
         }
     }
 };

--- a/lib/std/crypto/isap.zig
+++ b/lib/std/crypto/isap.zig
@@ -3,6 +3,7 @@ const debug = std.debug;
 const mem = std.mem;
 const math = std.math;
 const testing = std.testing;
+const Error = std.crypto.Error;
 
 /// ISAPv2 is an authenticated encryption system hardened against side channels and fault attacks.
 /// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/round-2/spec-doc-rnd2/isap-spec-round2.pdf
@@ -217,7 +218,7 @@ pub const IsapA128A = struct {
         tag.* = mac(c, ad, npub, key);
     }
 
-    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, key: [key_length]u8) !void {
+    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, key: [key_length]u8) Error!void {
         var computed_tag = mac(c, ad, npub, key);
         var acc: u8 = 0;
         for (computed_tag) |_, j| {

--- a/lib/std/crypto/salsa20.zig
+++ b/lib/std/crypto/salsa20.zig
@@ -15,6 +15,7 @@ const Vector = std.meta.Vector;
 const Poly1305 = crypto.onetimeauth.Poly1305;
 const Blake2b = crypto.hash.blake2.Blake2b;
 const X25519 = crypto.dh.X25519;
+const Error = crypto.Error;
 
 const Salsa20VecImpl = struct {
     const Lane = Vector(4, u32);
@@ -398,7 +399,7 @@ pub const XSalsa20Poly1305 = struct {
     /// ad: Associated Data
     /// npub: public nonce
     /// k: private key
-    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) !void {
+    pub fn decrypt(m: []u8, c: []const u8, tag: [tag_length]u8, ad: []const u8, npub: [nonce_length]u8, k: [key_length]u8) Error!void {
         debug.assert(c.len == m.len);
         const extended = extend(k, npub);
         var block0 = [_]u8{0} ** 64;
@@ -446,7 +447,7 @@ pub const SecretBox = struct {
 
     /// Verify and decrypt `c` using a nonce `npub` and a key `k`.
     /// `m` must be exactly `tag_length` smaller than `c`, as `c` includes an authentication tag in addition to the encrypted message.
-    pub fn open(m: []u8, c: []const u8, npub: [nonce_length]u8, k: [key_length]u8) !void {
+    pub fn open(m: []u8, c: []const u8, npub: [nonce_length]u8, k: [key_length]u8) Error!void {
         if (c.len < tag_length) {
             return error.AuthenticationFailed;
         }
@@ -481,20 +482,20 @@ pub const Box = struct {
     pub const KeyPair = X25519.KeyPair;
 
     /// Compute a secret suitable for `secretbox` given a recipent's public key and a sender's secret key.
-    pub fn createSharedSecret(public_key: [public_length]u8, secret_key: [secret_length]u8) ![shared_length]u8 {
+    pub fn createSharedSecret(public_key: [public_length]u8, secret_key: [secret_length]u8) Error![shared_length]u8 {
         const p = try X25519.scalarmult(secret_key, public_key);
         const zero = [_]u8{0} ** 16;
         return Salsa20Impl.hsalsa20(zero, p);
     }
 
     /// Encrypt and authenticate a message using a recipient's public key `public_key` and a sender's `secret_key`.
-    pub fn seal(c: []u8, m: []const u8, npub: [nonce_length]u8, public_key: [public_length]u8, secret_key: [secret_length]u8) !void {
+    pub fn seal(c: []u8, m: []const u8, npub: [nonce_length]u8, public_key: [public_length]u8, secret_key: [secret_length]u8) Error!void {
         const shared_key = try createSharedSecret(public_key, secret_key);
         return SecretBox.seal(c, m, npub, shared_key);
     }
 
     /// Verify and decrypt a message using a recipient's secret key `public_key` and a sender's `public_key`.
-    pub fn open(m: []u8, c: []const u8, npub: [nonce_length]u8, public_key: [public_length]u8, secret_key: [secret_length]u8) !void {
+    pub fn open(m: []u8, c: []const u8, npub: [nonce_length]u8, public_key: [public_length]u8, secret_key: [secret_length]u8) Error!void {
         const shared_key = try createSharedSecret(public_key, secret_key);
         return SecretBox.open(m, c, npub, shared_key);
     }
@@ -527,7 +528,7 @@ pub const SealedBox = struct {
 
     /// Encrypt a message `m` for a recipient whose public key is `public_key`.
     /// `c` must be `seal_length` bytes larger than `m`, so that the required metadata can be added.
-    pub fn seal(c: []u8, m: []const u8, public_key: [public_length]u8) !void {
+    pub fn seal(c: []u8, m: []const u8, public_key: [public_length]u8) Error!void {
         debug.assert(c.len == m.len + seal_length);
         var ekp = try KeyPair.create(null);
         const nonce = createNonce(ekp.public_key, public_key);
@@ -538,7 +539,7 @@ pub const SealedBox = struct {
 
     /// Decrypt a message using a key pair.
     /// `m` must be exactly `seal_length` bytes smaller than `c`, as `c` also includes metadata.
-    pub fn open(m: []u8, c: []const u8, keypair: KeyPair) !void {
+    pub fn open(m: []u8, c: []const u8, keypair: KeyPair) Error!void {
         if (c.len < seal_length) {
             return error.AuthenticationFailed;
         }


### PR DESCRIPTION
This ensures that errors are used consistently across all operations.