### PR TITLE
Add doc comment for std.meta.refAllDecls

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -845,6 +845,7 @@ pub fn fieldIndex(comptime T: type, comptime name: []const u8) ?comptime_int {
     return null;
 }
 
+/// Do not use. This has been moved to std.testing.
 pub const refAllDecls = @compileError("refAllDecls has been moved from std.meta to std.testing");
 
 /// Returns a slice of pointers to public declarations of a namespace.


### PR DESCRIPTION
This is so that it shows up in the generated documentation, as it came
up in #8234.