### PR TITLE
Add test for multi-line while cont expr with same-line then expr

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -3068,6 +3068,11 @@ test "zig fmt: while" {
         \\    while (i < 10) : ({
         \\        i += 1;
         \\        j += 1;
+        \\    }) continue;
+        \\
+        \\    while (i < 10) : ({
+        \\        i += 1;
+        \\        j += 1;
         \\    }) {
         \\        continue;
         \\    }


### PR DESCRIPTION
As discussed with @ifreund in IRC - this was fixed in https://github.com/ziglang/zig/pull/8127 but is not covered by a testcase.