### PR TITLE
zig fmt: Respect line breaks in struct default value decls

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -4,6 +4,24 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 
+test "zig fmt: respect line breaks in struct field value declaration" {
+    try testCanonical(
+        \\const Foo = struct {
+        \\    bar: u32 =
+        \\        42,
+        \\    bar: u32 =
+        \\        // a comment
+        \\        42,
+        \\    bar: []const u8 =
+        \\        \\ foo
+        \\        \\ bar
+        \\        \\ baz
+        \\    ,
+        \\};
+        \\
+    );
+}
+
 // TODO Remove this after zig 0.9.0 is released.
 test "zig fmt: rewrite inline functions as callconv(.Inline)" {
     try testTransform(

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -12,6 +12,9 @@ test "zig fmt: respect line breaks in struct field value declaration" {
         \\    bar: u32 =
         \\        // a comment
         \\        42,
+        \\    bar: u32 =
+        \\        42,
+        \\    // a comment
         \\    bar: []const u8 =
         \\        \\ foo
         \\        \\ bar

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -17,6 +17,10 @@ test "zig fmt: respect line breaks in struct field value declaration" {
         \\        \\ bar
         \\        \\ baz
         \\    ,
+        \\    bar: u32 =
+        \\        blk: {
+        \\            break :blk 42;
+        \\        },
         \\};
         \\
     );

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1165,8 +1165,23 @@ fn renderContainerField(
         try renderToken(ais, tree, eq_token, eq_space); // =
         ais.popIndent();
     }
-    ais.pushIndentOneShot();
-    return renderExpressionComma(gpa, ais, tree, field.ast.value_expr, space); // value
+
+    if (eq_space == .space)
+        return renderExpressionComma(gpa, ais, tree, field.ast.value_expr, space); // value
+
+    const token_tags = tree.tokens.items(.tag);
+    const maybe_comma = tree.lastToken(field.ast.value_expr) + 1;
+
+    if (token_tags[maybe_comma] == .comma) {
+        ais.pushIndent();
+        try renderExpression(gpa, ais, tree, field.ast.value_expr, .none); // value
+        ais.popIndent();
+        try renderToken(ais, tree, maybe_comma, space);
+    } else {
+        ais.pushIndent();
+        try renderExpression(gpa, ais, tree, field.ast.value_expr, space); // value
+        ais.popIndent();
+    }
 }
 
 fn renderBuiltinCall(

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1159,7 +1159,13 @@ fn renderContainerField(
         try renderToken(ais, tree, rparen_token, .space); // )
     }
     const eq_token = tree.firstToken(field.ast.value_expr) - 1;
-    try renderToken(ais, tree, eq_token, .space); // =
+    const eq_space: Space = if (tree.tokensOnSameLine(eq_token, eq_token + 1)) .space else .newline;
+    {
+        ais.pushIndent();
+        try renderToken(ais, tree, eq_token, eq_space); // =
+        ais.popIndent();
+    }
+    ais.pushIndentOneShot();
     return renderExpressionComma(gpa, ais, tree, field.ast.value_expr, space); // value
 }
 


### PR DESCRIPTION
Bring this in line with how variable declarations are handled.

Closes #7618

CC @ifreund 