### PR TITLE
Add testcase for switch statement with multiline string

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -3038,6 +3038,23 @@ test "zig fmt: switch" {
         \\}
         \\
     );
+
+    try testTransform(
+        \\test {
+        \\    switch (x) {
+        \\        foo =>
+        \\            "bar",
+        \\    }
+        \\}
+        \\
+    ,
+        \\test {
+        \\    switch (x) {
+        \\        foo => "bar",
+        \\    }
+        \\}
+        \\
+    );
 }
 
 test "zig fmt: switch multiline string" {

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -3040,6 +3040,24 @@ test "zig fmt: switch" {
     );
 }
 
+test "zig fmt: switch multiline string" {
+    try testCanonical(
+        \\test "switch multiline string" {
+        \\    const x: u32 = 0;
+        \\    const str = switch (x) {
+        \\        1 => "one",
+        \\        2 => 
+        \\        \\ Comma after the multiline string
+        \\        \\ is needed
+        \\        ,
+        \\        3 => "three",
+        \\        else => "else",
+        \\    };
+        \\}
+        \\
+    );
+}
+
 test "zig fmt: while" {
     try testCanonical(
         \\test "while" {

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -3046,12 +3046,25 @@ test "zig fmt: switch multiline string" {
         \\    const x: u32 = 0;
         \\    const str = switch (x) {
         \\        1 => "one",
-        \\        2 => 
+        \\        2 =>
         \\        \\ Comma after the multiline string
         \\        \\ is needed
         \\        ,
         \\        3 => "three",
         \\        else => "else",
+        \\    };
+        \\
+        \\    const Union = union(enum) {
+        \\        Int: i64,
+        \\        Float: f64,
+        \\    };
+        \\
+        \\    const str = switch (u) {
+        \\        Union.Int => |int|
+        \\        \\ Comma after the multiline string
+        \\        \\ is needed
+        \\        ,
+        \\        Union.Float => |*float| unreachable,
         \\    };
         \\}
         \\

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1423,6 +1423,7 @@ fn renderSwitchCase(
     switch_case: ast.full.SwitchCase,
     space: Space,
 ) Error!void {
+    const node_tags = tree.nodes.items(.tag);
     const token_tags = tree.tokens.items(.tag);
     const trailing_comma = token_tags[switch_case.ast.arrow_token - 1] == .comma;
 
@@ -1445,12 +1446,11 @@ fn renderSwitchCase(
     }
 
     // Render the arrow and everything after it
-    const first_target_token = tree.firstToken(switch_case.ast.target_expr);
-    const pre_target_space = if (tree.tokensOnSameLine(first_target_token - 1, first_target_token))
-        Space.space
+    const pre_target_space = if (node_tags[switch_case.ast.target_expr] == .multiline_string_literal)
+        // Newline gets inserted when rendering the target expr.
+        Space.none
     else
-        // Newline gets inserted when rendering the target expr if needed.
-        Space.none;
+        Space.space;
     const after_arrow_space: Space = if (switch_case.payload_token == null) pre_target_space else .space;
     try renderToken(ais, tree, switch_case.ast.arrow_token, after_arrow_space);
 

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1445,17 +1445,24 @@ fn renderSwitchCase(
     }
 
     // Render the arrow and everything after it
-    try renderToken(ais, tree, switch_case.ast.arrow_token, .space);
+    const first_target_token = tree.firstToken(switch_case.ast.target_expr);
+    const pre_target_space = if (tree.tokensOnSameLine(first_target_token - 1, first_target_token))
+        Space.space
+    else
+        // Newline gets inserted when rendering the target expr if needed.
+        Space.none;
+    const after_arrow_space: Space = if (switch_case.payload_token == null) pre_target_space else .space;
+    try renderToken(ais, tree, switch_case.ast.arrow_token, after_arrow_space);
 
     if (switch_case.payload_token) |payload_token| {
         try renderToken(ais, tree, payload_token - 1, .none); // pipe
         if (token_tags[payload_token] == .asterisk) {
             try renderToken(ais, tree, payload_token, .none); // asterisk
             try renderToken(ais, tree, payload_token + 1, .none); // identifier
-            try renderToken(ais, tree, payload_token + 2, .space); // pipe
+            try renderToken(ais, tree, payload_token + 2, pre_target_space); // pipe
         } else {
             try renderToken(ais, tree, payload_token, .none); // identifier
-            try renderToken(ais, tree, payload_token + 1, .space); // pipe
+            try renderToken(ais, tree, payload_token + 1, pre_target_space); // pipe
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/7855

The linked issue seems to already be fixed, but this PR adds a testcase to prevent regression.

Also fixed zig fmt adding trailing space after before the target expression when it's rendered on a newline (e.g. in this testcase).