### PR TITLE
disallow specification of both -dynamic and -static simultaneously when calling zig build-exe

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -957,8 +957,14 @@ fn buildOutputType(
                     } else if (mem.eql(u8, arg, "-fno-emit-analysis")) {
                         emit_analysis = .no;
                     } else if (mem.eql(u8, arg, "-dynamic")) {
+                        if (link_mode != null and link_mode.? == .Static) {
+                            fatal("Cannot specify both -dynamic and -static", .{});
+                        }
                         link_mode = .Dynamic;
                     } else if (mem.eql(u8, arg, "-static")) {
+                        if (link_mode != null and link_mode.? == .Dynamic) {
+                            fatal("Cannot specify both -dynamic and -static", .{});
+                        }
                         link_mode = .Static;
                     } else if (mem.eql(u8, arg, "-fdll-export-fns")) {
                         dll_export_fns = true;


### PR DESCRIPTION
As it says on the tin. See discussion in https://github.com/ziglang/zig/pull/8248