### PR TITLE
azure: produce macos arm64 binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,12 +728,14 @@ if(MSVC OR MINGW)
     target_link_libraries(zigstage1 LINK_PUBLIC version)
 endif()
 
-add_executable(zig0 ${ZIG0_SOURCES})
-set_target_properties(zig0 PROPERTIES
-    COMPILE_FLAGS ${EXE_CFLAGS}
-    LINK_FLAGS ${EXE_LDFLAGS}
-)
-target_link_libraries(zig0 zigstage1)
+if("${ZIG_EXECUTABLE}" STREQUAL "")
+  add_executable(zig0 ${ZIG0_SOURCES})
+  set_target_properties(zig0 PROPERTIES
+      COMPILE_FLAGS ${EXE_CFLAGS}
+      LINK_FLAGS ${EXE_LDFLAGS}
+  )
+  target_link_libraries(zig0 zigstage1)
+endif()
 
 if(MSVC)
     set(ZIG1_OBJECT "${CMAKE_BINARY_DIR}/zig1.obj")
@@ -782,7 +784,6 @@ if("${ZIG_EXECUTABLE}" STREQUAL "")
 else()
   add_custom_command(
       OUTPUT "${ZIG1_OBJECT}"
-      BYPRODUCTS "${ZIG1_OBJECT}"
       COMMAND "${ZIG_EXECUTABLE}" "build-obj" ${BUILD_ZIG1_ARGS}
       DEPENDS ${ZIG_STAGE2_SOURCES}
       COMMENT STATUS "Building self-hosted component ${ZIG1_OBJECT}"

--- a/ci/azure/macos_arm64_script
+++ b/ci/azure/macos_arm64_script
@@ -1,0 +1,132 @@
+#!/bin/sh
+
+set -x
+set -e
+
+brew install s3cmd ninja gnu-tar
+
+ZIGDIR="$(pwd)"
+ARCH="aarch64"
+# {product}-{os}{sdk_version}-{arch}-{llvm_version}-{cmake_build_type}
+CACHE_HOST_BASENAME="llvm-macos10.15-x86_64-11.0.1-release"
+CACHE_ARM64_BASENAME="llvm-macos11.0-arm64-11.0.1-release"
+PREFIX_HOST="$HOME/$CACHE_HOST_BASENAME"
+PREFIX_ARM64="$HOME/$CACHE_ARM64_BASENAME"
+JOBS="-j2"
+
+rm -rf $PREFIX
+cd $HOME
+wget -nv "https://ziglang.org/deps/$CACHE_HOST_BASENAME.tar.xz"
+wget -nv "https://ziglang.org/deps/$CACHE_ARM64_BASENAME.tar.xz"
+
+gtar xf "$CACHE_HOST_BASENAME.tar.xz"
+gtar xf "$CACHE_ARM64_BASENAME.tar.xz"
+
+cd $ZIGDIR
+
+# Make the `zig version` number consistent.
+# This will affect the cmake command below.
+git config core.abbrev 9
+git fetch --unshallow || true
+git fetch --tags
+
+# Select xcode: latest version found on vmImage macOS-10.15 .
+DEVELOPER_DIR=/Applications/Xcode_12.4.app
+
+export ZIG_LOCAL_CACHE_DIR="$ZIGDIR/zig-cache"
+export ZIG_GLOBAL_CACHE_DIR="$ZIGDIR/zig-cache"
+
+# Build zig for host and use `Debug` type to make builds a little faster.
+
+cd $ZIGDIR
+mkdir build.host
+cd build.host
+cmake -G "Ninja" .. \
+  -DCMAKE_INSTALL_PREFIX="$(pwd)/release" \
+  -DCMAKE_PREFIX_PATH="$PREFIX_HOST" \
+  -DCMAKE_BUILD_TYPE="Debug" \
+  -DZIG_STATIC="OFF"
+
+# Build but do not install.
+ninja $JOBS
+
+ZIG_EXE="$ZIGDIR/build.host/zig"
+
+# Build zig for arm64 target.
+# - use `Release` type for published tarballs
+# - ad-hoc codesign with linker
+# - note: apple quarantine of downloads (eg. via safari) still apply
+
+cd $ZIGDIR
+mkdir build.arm64
+cd build.arm64
+cmake -G "Ninja" .. \
+  -DCMAKE_INSTALL_PREFIX="$(pwd)/release" \
+  -DCMAKE_PREFIX_PATH="$PREFIX_ARM64" \
+  -DCMAKE_BUILD_TYPE="Release" \
+  -DCMAKE_CROSSCOMPILING="True" \
+  -DCMAKE_SYSTEM_NAME="Darwin" \
+  -DCMAKE_C_FLAGS="-arch arm64" \
+  -DCMAKE_CXX_FLAGS="-arch arm64" \
+  -DCMAKE_EXE_LINKER_FLAGS="-lz -Xlinker -adhoc_codesign" \
+  -DZIG_USE_LLVM_CONFIG="OFF" \
+  -DZIG_EXECUTABLE="$ZIG_EXE" \
+  -DZIG_TARGET_TRIPLE="${ARCH}-macos" \
+  -DZIG_STATIC="OFF"
+
+ninja $JOBS install
+
+# Disable test because binary is foreign arch.
+#release/bin/zig build test
+
+if [ "${BUILD_REASON}" != "PullRequest" ]; then
+  mv ../LICENSE release/
+
+  # We do not run test suite but still need langref.
+  mkdir -p release/docs
+  $ZIG_EXE run ../doc/docgen.zig -- $ZIG_EXE ../doc/langref.html.in release/docs/langref.html
+
+  # Produce the experimental std lib documentation.
+  mkdir -p release/docs/std
+  $ZIG_EXE test ../lib/std/std.zig \
+    --override-lib-dir ../lib \
+    -femit-docs=release/docs/std \
+    -fno-emit-bin
+
+  # Remove the unnecessary bin dir in $prefix/bin/zig
+  mv release/bin/zig release/
+  rmdir release/bin
+
+  # Remove the unnecessary zig dir in $prefix/lib/zig/std/std.zig
+  mv release/lib/zig release/lib2
+  rmdir release/lib
+  mv release/lib2 release/lib
+
+  VERSION=$($ZIG_EXE version)
+  DIRNAME="zig-macos-$ARCH-$VERSION"
+  TARBALL="$DIRNAME.tar.xz"
+  gtar cJf "$TARBALL" release/ --owner=root --sort=name --transform="s,^release,${DIRNAME},"
+  ln "$TARBALL" "$BUILD_ARTIFACTSTAGINGDIRECTORY/."
+
+  mv "$DOWNLOADSECUREFILE_SECUREFILEPATH" "$HOME/.s3cfg"
+  s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" "$TARBALL" s3://ziglang.org/builds/
+
+  SHASUM=$(shasum -a 256 $TARBALL | cut '-d ' -f1)
+  BYTESIZE=$(wc -c < $TARBALL)
+
+  JSONFILE="macos-$GITBRANCH.json"
+  touch $JSONFILE
+  echo "{\"tarball\": \"$TARBALL\"," >>$JSONFILE
+  echo "\"shasum\": \"$SHASUM\"," >>$JSONFILE
+  echo "\"size\": \"$BYTESIZE\"}" >>$JSONFILE
+
+  s3cmd put -P --add-header="Cache-Control: max-age=0, must-revalidate" "$JSONFILE" "s3://ziglang.org/builds/$JSONFILE"
+  s3cmd put -P "$JSONFILE" "s3://ziglang.org/builds/$ARCH-macos-$VERSION.json"
+
+  # `set -x` causes these variables to be mangled.
+  # See https://developercommunity.visualstudio.com/content/problem/375679/pipeline-variable-incorrectly-inserts-single-quote.html
+  set +x
+  echo "##vso[task.setvariable variable=tarball;isOutput=true]$TARBALL"
+  echo "##vso[task.setvariable variable=shasum;isOutput=true]$SHASUM"
+  echo "##vso[task.setvariable variable=bytesize;isOutput=true]$BYTESIZE"
+fi

--- a/ci/azure/pipelines.yml
+++ b/ci/azure/pipelines.yml
@@ -12,6 +12,19 @@ jobs:
   - script: ci/azure/macos_script
     name: main
     displayName: 'Build and test'
+- job: BuildMacOS_arm64
+  pool:
+    vmImage: 'macOS-10.15'
+
+  timeoutInMinutes: 60
+
+  steps:
+  - task: DownloadSecureFile@1
+    inputs:
+      secureFile: s3cfg
+  - script: ci/azure/macos_arm64_script
+    name: main
+    displayName: 'Build and cross-compile'
 - job: BuildLinux
   pool:
     vmImage: 'ubuntu-18.04'


### PR DESCRIPTION
new pipeline `BuildMacOS_arm64`
  - `vmImage: 'macOS-10.15' `

new `macos_arm64_script`
  - switch from using `make` to `ninja`
  - select xcode 12.4
  - set zig-cache env variables
  - build host-zig binary with xcode,  link against llvm for x86_64 (target macos 10.15)
  - build arm64-zig binary with xcode and host-zig, link against llvm for arm64 (target macos 11.0)
  - use host-zig for docgen
  - use host-zig for experimental std lib docs
  - sync final `release/` hierarchy with `linux_script`
  - use gnu-tar for good-practices (set owner, set sort)

enhance `CMakeLists.txt`
  - do not build `zig0` when cross-compiling
  - disable `BYPRODUCTS` directive `zig1.o` to avoid `ninja` error

see also #8149