### PR TITLE
@intCast takes two args

### DIFF
--- a/src/BuiltinFn.zig
+++ b/src/BuiltinFn.zig
@@ -477,7 +477,7 @@ pub const list = list: {
             "@intCast",
             .{
                 .tag = .int_cast,
-                .param_count = 1,
+                .param_count = 2,
             },
         },
         .{


### PR DESCRIPTION
Extremely minor fix. '@intCast' takes two args instead of one.