### PR TITLE
cbe tests: fix test on windows

### DIFF
--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -51,7 +51,7 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    _ = printf("Hello, %s!\n", "world");
             \\    return 0;
             \\}
-        , "Hello, world!\n");
+        , "Hello, world!" ++ std.cstr.line_sep);
     }
 
     {


### PR DESCRIPTION
"\n" -> std.cstr.line_sep
Fixes #8285.