### PR TITLE
zir-memory-layout: llvm backend: use new LazySrcLoc

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2326,11 +2326,14 @@ fn astgenAndSemaVarDecl(
         };
         defer gen_scope.instructions.deinit(mod.gpa);
 
-        const init_result_loc: astgen.ResultLoc = if (var_decl.ast.type_node != 0) .{
-            .ty = try astgen.expr(mod, &gen_scope.base, .{
-                .ty = @enumToInt(zir.Const.type_type),
-            }, var_decl.ast.type_node),
-        } else .none;
+        const init_result_loc: astgen.ResultLoc = if (var_decl.ast.type_node != 0)
+            .{
+                .ty = try astgen.expr(mod, &gen_scope.base, .{
+                    .ty = @enumToInt(zir.Const.type_type),
+                }, var_decl.ast.type_node),
+            }
+        else
+            .none;
 
         const init_inst = try astgen.comptimeExpr(
             mod,


### PR DESCRIPTION
This allows to compile with ninja/make now.

Not sure if this is the right way, but I tried to follow how you did the other backends.
Like this https://github.com/ziglang/zig/blob/abdbc11c7efb2f83804af64ac2fec10b972cdf2a/src/codegen/wasm.zig#L74-L78