### PR TITLE
Put constant data in .rodata section instead of .text

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -59,10 +59,8 @@ debug_strtab: std.ArrayListUnmanaged(u8) = std.ArrayListUnmanaged(u8){},
 shstrtab: std.ArrayListUnmanaged(u8) = std.ArrayListUnmanaged(u8){},
 shstrtab_index: ?u16 = null,
 
-text_section_index: ?u16 = null,
 symtab_section_index: ?u16 = null,
 got_section_index: ?u16 = null,
-rodata_section_index: ?u16 = null,
 debug_info_section_index: ?u16 = null,
 debug_abbrev_section_index: ?u16 = null,
 debug_str_section_index: ?u16 = null,
@@ -115,8 +113,8 @@ error_flags: File.ErrorFlags = File.ErrorFlags{},
 /// overcapacity can be negative. A simple way to have negative overcapacity is to
 /// allocate a fresh text block, which will have ideal capacity, and then grow it
 /// by 1 byte. It will then have -1 overcapacity.
-text_block_free_list: std.ArrayListUnmanaged(*TextBlock) = .{},
-last_text_block: ?*TextBlock = null,
+text_block_list: TextBlockList = .{},
+rodata_block_list: TextBlockList = .{},
 
 /// A list of `SrcFn` whose Line Number Programs have surplus capacity.
 /// This is the same concept as `text_block_free_list`; see those doc comments.
@@ -202,6 +200,14 @@ pub const TextBlock = struct {
         const surplus = cap - ideal_cap;
         return surplus >= min_text_capacity;
     }
+};
+
+/// A list of text blocks in a specific section
+const TextBlockList = struct {
+    free_list: std.ArrayListUnmanaged(*TextBlock) = .{},
+    last_block: ?*TextBlock = null,
+    phdr_index: ?u16 = null,
+    section_index: ?u16 = null,
 };
 
 pub const Export = struct {
@@ -314,7 +320,8 @@ pub fn deinit(self: *Elf) void {
     self.global_symbol_free_list.deinit(self.base.allocator);
     self.local_symbol_free_list.deinit(self.base.allocator);
     self.offset_table_free_list.deinit(self.base.allocator);
-    self.text_block_free_list.deinit(self.base.allocator);
+    self.text_block_list.free_list.deinit(self.base.allocator);
+    self.rodata_block_list.free_list.deinit(self.base.allocator);
     self.dbg_line_fn_free_list.deinit(self.base.allocator);
     self.dbg_info_decl_free_list.deinit(self.base.allocator);
     self.offset_table.deinit(self.base.allocator);
@@ -450,6 +457,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
     const ptr_size: u8 = self.ptrWidthBytes();
     if (self.phdr_load_re_index == null) {
         self.phdr_load_re_index = @intCast(u16, self.program_headers.items.len);
+        self.text_block_list.phdr_index = self.phdr_load_re_index;
         const file_size = self.base.options.program_code_size_hint;
         const p_align = 0x1000;
         const off = self.findFreeSpace(file_size, p_align);
@@ -494,6 +502,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
     }
     if (self.phdr_load_ro_index == null) {
         self.phdr_load_ro_index = @intCast(u16, self.program_headers.items.len);
+        self.rodata_block_list.phdr_index = self.phdr_load_ro_index;
         // TODO Find a hint about how much data need to be in rodata ?
         const file_size = 1024;
         // Same reason as for GOT
@@ -535,8 +544,8 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         self.shstrtab_dirty = true;
         self.shdr_table_dirty = true;
     }
-    if (self.text_section_index == null) {
-        self.text_section_index = @intCast(u16, self.sections.items.len);
+    if (self.text_block_list.section_index == null) {
+        self.text_block_list.section_index = @intCast(u16, self.sections.items.len);
         const phdr = &self.program_headers.items[self.phdr_load_re_index.?];
 
         try self.sections.append(self.base.allocator, .{
@@ -571,8 +580,8 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         });
         self.shdr_table_dirty = true;
     }
-    if (self.rodata_section_index == null) {
-        self.rodata_section_index = @intCast(u16, self.sections.items.len);
+    if (self.rodata_block_list.section_index == null) {
+        self.rodata_block_list.section_index = @intCast(u16, self.sections.items.len);
         const phdr = &self.program_headers.items[self.phdr_load_ro_index.?];
 
         try self.sections.append(self.base.allocator, .{
@@ -1954,17 +1963,17 @@ fn writeElfHeader(self: *Elf) !void {
     try self.base.file.?.pwriteAll(hdr_buf[0..index], 0);
 }
 
-fn freeTextBlock(self: *Elf, text_block: *TextBlock) void {
+fn freeTextBlock(self: *Elf, block_list: *TextBlockList, text_block: *TextBlock) void {
     var already_have_free_list_node = false;
     {
         var i: usize = 0;
         // TODO turn text_block_free_list into a hash map
-        while (i < self.text_block_free_list.items.len) {
-            if (self.text_block_free_list.items[i] == text_block) {
-                _ = self.text_block_free_list.swapRemove(i);
+        while (i < block_list.free_list.items.len) {
+            if (block_list.free_list.items[i] == text_block) {
+                _ = block_list.free_list.swapRemove(i);
                 continue;
             }
-            if (self.text_block_free_list.items[i] == text_block.prev) {
+            if (block_list.free_list.items[i] == text_block.prev) {
                 already_have_free_list_node = true;
             }
             i += 1;
@@ -1972,9 +1981,9 @@ fn freeTextBlock(self: *Elf, text_block: *TextBlock) void {
     }
     // TODO process free list for dbg info just like we do above for vaddrs
 
-    if (self.last_text_block == text_block) {
+    if (block_list.last_block == text_block) {
         // TODO shrink the .text section size here
-        self.last_text_block = text_block.prev;
+        block_list.last_block = text_block.prev;
     }
     if (self.dbg_info_decl_first == text_block) {
         self.dbg_info_decl_first = text_block.dbg_info_next;
@@ -1990,7 +1999,7 @@ fn freeTextBlock(self: *Elf, text_block: *TextBlock) void {
         if (!already_have_free_list_node and prev.freeListEligible(self.*)) {
             // The free list is heuristics, it doesn't have to be perfect, so we can
             // ignore the OOM here.
-            self.text_block_free_list.append(self.base.allocator, prev) catch {};
+            block_list.free_list.append(self.base.allocator, prev) catch {};
         }
     } else {
         text_block.prev = null;
@@ -2017,22 +2026,22 @@ fn freeTextBlock(self: *Elf, text_block: *TextBlock) void {
     }
 }
 
-fn shrinkTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64) void {
+fn shrinkTextBlock(self: *Elf, block_list: *TextBlockList, text_block: *TextBlock, new_block_size: u64) void {
     // TODO check the new capacity, and if it crosses the size threshold into a big enough
     // capacity, insert a free list node for it.
 }
 
-fn growTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, alignment: u64) !u64 {
+fn growTextBlock(self: *Elf, block_list: *TextBlockList, text_block: *TextBlock, new_block_size: u64, alignment: u64) !u64 {
     const sym = self.local_symbols.items[text_block.local_sym_index];
     const align_ok = mem.alignBackwardGeneric(u64, sym.st_value, alignment) == sym.st_value;
     const need_realloc = !align_ok or new_block_size > text_block.capacity(self.*);
     if (!need_realloc) return sym.st_value;
-    return self.allocateTextBlock(text_block, new_block_size, alignment);
+    return self.allocateTextBlock(block_list, text_block, new_block_size, alignment);
 }
 
-fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, alignment: u64) !u64 {
-    const phdr = &self.program_headers.items[self.phdr_load_re_index.?];
-    const shdr = &self.sections.items[self.text_section_index.?];
+fn allocateTextBlock(self: *Elf, block_list: *TextBlockList, text_block: *TextBlock, new_block_size: u64, alignment: u64) !u64 {
+    const phdr = &self.program_headers.items[block_list.phdr_index.?];
+    const shdr = &self.sections.items[block_list.section_index.?];
     const new_block_ideal_capacity = padToIdeal(new_block_size);
 
     // We use these to indicate our intention to update metadata, placing the new block,
@@ -2047,8 +2056,8 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
     // The list is unordered. We'll just take the first thing that works.
     const vaddr = blk: {
         var i: usize = 0;
-        while (i < self.text_block_free_list.items.len) {
-            const big_block = self.text_block_free_list.items[i];
+        while (i < block_list.free_list.items.len) {
+            const big_block = block_list.free_list.items[i];
             // We now have a pointer to a live text block that has too much capacity.
             // Is it enough that we could fit this new text block?
             const sym = self.local_symbols.items[big_block.local_sym_index];
@@ -2063,7 +2072,7 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
                 // should be deleted because the block that it points to has grown to take up
                 // more of the extra capacity.
                 if (!big_block.freeListEligible(self.*)) {
-                    _ = self.text_block_free_list.swapRemove(i);
+                    _ = block_list.free_list.swapRemove(i);
                 } else {
                     i += 1;
                 }
@@ -2081,7 +2090,7 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
                 free_list_removal = i;
             }
             break :blk new_start_vaddr;
-        } else if (self.last_text_block) |last| {
+        } else if (block_list.last_block) |last| {
             const sym = self.local_symbols.items[last.local_sym_index];
             const ideal_capacity = padToIdeal(sym.st_size);
             const ideal_capacity_end_vaddr = sym.st_value + ideal_capacity;
@@ -2101,7 +2110,7 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
         if (needed_size > text_capacity) {
             // Must move the entire text section.
             const new_offset = self.findFreeSpace(needed_size, 0x1000);
-            const text_size = if (self.last_text_block) |last| blk: {
+            const text_size = if (block_list.last_block) |last| blk: {
                 const sym = self.local_symbols.items[last.local_sym_index];
                 break :blk (sym.st_value + sym.st_size) - phdr.p_vaddr;
             } else 0;
@@ -2110,7 +2119,7 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
             shdr.sh_offset = new_offset;
             phdr.p_offset = new_offset;
         }
-        self.last_text_block = text_block;
+        block_list.last_block = text_block;
 
         shdr.sh_size = needed_size;
         phdr.p_memsz = needed_size;
@@ -2148,9 +2157,20 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
         text_block.next = null;
     }
     if (free_list_removal) |i| {
-        _ = self.text_block_free_list.swapRemove(i);
+        _ = block_list.free_list.swapRemove(i);
     }
     return vaddr;
+}
+
+/// Get the block list corresponding to a specific decl
+/// For example, if the decl is a function, it returns the list of the section .text
+fn getDeclBlockList(self: *Elf, decl: *const Module.Decl) *TextBlockList {
+    const typed_value = decl.typed_value.most_recent.typed_value;
+    const is_fn: bool = switch (typed_value.ty.zigTypeTag()) {
+        .Fn => true,
+        else => false,
+    };
+    return if (is_fn) &self.text_block_list else &self.rodata_block_list;
 }
 
 pub fn allocateDeclIndexes(self: *Elf, decl: *Module.Decl) !void {
@@ -2194,8 +2214,10 @@ pub fn allocateDeclIndexes(self: *Elf, decl: *Module.Decl) !void {
 pub fn freeDecl(self: *Elf, decl: *Module.Decl) void {
     if (self.llvm_ir_module) |_| return;
 
+    const block_list = self.getDeclBlockList(decl);
+
     // Appending to free lists is allowed to fail because the free lists are heuristics based anyway.
-    self.freeTextBlock(&decl.link.elf);
+    self.freeTextBlock(block_list, &decl.link.elf);
     if (decl.link.elf.local_sym_index != 0) {
         self.local_symbol_free_list.append(self.base.allocator, decl.link.elf.local_sym_index) catch {};
         self.offset_table_free_list.append(self.base.allocator, decl.link.elf.offset_table_index) catch {};
@@ -2261,6 +2283,9 @@ pub fn updateDecl(self: *Elf, module: *Module, decl: *Module.Decl) !void {
         .Fn => true,
         else => false,
     };
+
+    const block_list = self.getDeclBlockList(decl);
+
     if (is_fn) {
         // For functions we need to add a prologue to the debug line program.
         try dbg_line_buffer.ensureCapacity(26);
@@ -2371,7 +2396,7 @@ pub fn updateDecl(self: *Elf, module: *Module, decl: *Module.Decl) !void {
         const need_realloc = code.len > capacity or
             !mem.isAlignedGeneric(u64, local_sym.st_value, required_alignment);
         if (need_realloc) {
-            const vaddr = try self.growTextBlock(&decl.link.elf, code.len, required_alignment);
+            const vaddr = try self.growTextBlock(block_list, &decl.link.elf, code.len, required_alignment);
             log.debug("growing {s} from 0x{x} to 0x{x}\n", .{ decl.name, local_sym.st_value, vaddr });
             if (vaddr != local_sym.st_value) {
                 local_sym.st_value = vaddr;
@@ -2381,27 +2406,27 @@ pub fn updateDecl(self: *Elf, module: *Module, decl: *Module.Decl) !void {
                 try self.writeOffsetTableEntry(decl.link.elf.offset_table_index);
             }
         } else if (code.len < local_sym.st_size) {
-            self.shrinkTextBlock(&decl.link.elf, code.len);
+            self.shrinkTextBlock(block_list, &decl.link.elf, code.len);
         }
         local_sym.st_size = code.len;
         local_sym.st_name = try self.updateString(local_sym.st_name, mem.spanZ(decl.name));
         local_sym.st_info = (elf.STB_LOCAL << 4) | stt_bits;
         local_sym.st_other = 0;
-        local_sym.st_shndx = self.text_section_index.?;
+        local_sym.st_shndx = self.text_block_list.section_index.?;
         // TODO this write could be avoided if no fields of the symbol were changed.
         try self.writeSymbol(decl.link.elf.local_sym_index);
     } else {
         const decl_name = mem.spanZ(decl.name);
         const name_str_index = try self.makeString(decl_name);
-        const vaddr = try self.allocateTextBlock(&decl.link.elf, code.len, required_alignment);
+        const vaddr = try self.allocateTextBlock(block_list, &decl.link.elf, code.len, required_alignment);
         log.debug("allocated text block for {s} at 0x{x}\n", .{ decl_name, vaddr });
-        errdefer self.freeTextBlock(&decl.link.elf);
+        errdefer self.freeTextBlock(block_list, &decl.link.elf);
 
         local_sym.* = .{
             .st_name = name_str_index,
             .st_info = (elf.STB_LOCAL << 4) | stt_bits,
             .st_other = 0,
-            .st_shndx = self.text_section_index.?,
+            .st_shndx = self.text_block_list.section_index.?,
             .st_value = vaddr,
             .st_size = code.len,
         };
@@ -2411,8 +2436,8 @@ pub fn updateDecl(self: *Elf, module: *Module, decl: *Module.Decl) !void {
         try self.writeOffsetTableEntry(decl.link.elf.offset_table_index);
     }
 
-    const section_offset = local_sym.st_value - self.program_headers.items[self.phdr_load_re_index.?].p_vaddr;
-    const file_offset = self.sections.items[self.text_section_index.?].sh_offset + section_offset;
+    const section_offset = local_sym.st_value - self.program_headers.items[block_list.phdr_index.?].p_vaddr;
+    const file_offset = self.sections.items[block_list.section_index.?].sh_offset + section_offset;
     try self.base.file.?.pwriteAll(code, file_offset);
 
     const target_endian = self.base.options.target.cpu.arch.endian();
@@ -2762,7 +2787,7 @@ pub fn updateDeclExports(
                 .st_name = try self.updateString(sym.st_name, exp.options.name),
                 .st_info = (stb_bits << 4) | stt_bits,
                 .st_other = 0,
-                .st_shndx = self.text_section_index.?,
+                .st_shndx = self.text_block_list.section_index.?,
                 .st_value = decl_sym.st_value,
                 .st_size = decl_sym.st_size,
             };
@@ -2776,7 +2801,7 @@ pub fn updateDeclExports(
                 .st_name = name,
                 .st_info = (stb_bits << 4) | stt_bits,
                 .st_other = 0,
-                .st_shndx = self.text_section_index.?,
+                .st_shndx = self.text_block_list.section_index.?,
                 .st_value = decl_sym.st_value,
                 .st_size = decl_sym.st_size,
             };

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2419,7 +2419,7 @@ pub fn updateDecl(self: *Elf, module: *Module, decl: *Module.Decl) !void {
         local_sym.st_name = try self.updateString(local_sym.st_name, mem.spanZ(decl.name));
         local_sym.st_info = (elf.STB_LOCAL << 4) | stt_bits;
         local_sym.st_other = 0;
-        local_sym.st_shndx = self.text_block_list.section_index.?;
+        local_sym.st_shndx = block_list.section_index.?;
         // TODO this write could be avoided if no fields of the symbol were changed.
         try self.writeSymbol(decl.link.elf.local_sym_index);
     } else {
@@ -2433,7 +2433,7 @@ pub fn updateDecl(self: *Elf, module: *Module, decl: *Module.Decl) !void {
             .st_name = name_str_index,
             .st_info = (elf.STB_LOCAL << 4) | stt_bits,
             .st_other = 0,
-            .st_shndx = self.text_block_list.section_index.?,
+            .st_shndx = block_list.section_index.?,
             .st_value = vaddr,
             .st_size = code.len,
         };
@@ -2758,6 +2758,8 @@ pub fn updateDeclExports(
     if (decl.link.elf.local_sym_index == 0) return;
     const decl_sym = self.local_symbols.items[decl.link.elf.local_sym_index];
 
+    const block_list = self.getDeclBlockList(decl) orelse return;
+
     for (exports) |exp| {
         if (exp.options.section) |section_name| {
             if (!mem.eql(u8, section_name, ".text")) {
@@ -2794,7 +2796,7 @@ pub fn updateDeclExports(
                 .st_name = try self.updateString(sym.st_name, exp.options.name),
                 .st_info = (stb_bits << 4) | stt_bits,
                 .st_other = 0,
-                .st_shndx = self.text_block_list.section_index.?,
+                .st_shndx = block_list.section_index.?,
                 .st_value = decl_sym.st_value,
                 .st_size = decl_sym.st_size,
             };
@@ -2808,7 +2810,7 @@ pub fn updateDeclExports(
                 .st_name = name,
                 .st_info = (stb_bits << 4) | stt_bits,
                 .st_other = 0,
-                .st_shndx = self.text_block_list.section_index.?,
+                .st_shndx = block_list.section_index.?,
                 .st_value = decl_sym.st_value,
                 .st_size = decl_sym.st_size,
             };

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -461,7 +461,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         const file_size = self.base.options.program_code_size_hint;
         const p_align = 0x1000;
         const off = self.findFreeSpace(file_size, p_align);
-        log.debug("found PT_LOAD free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
+        log.debug("found PT_LOAD free space 0x{x} to 0x{x}", .{ off, off + file_size });
         const entry_addr: u64 = self.entry_addr orelse if (self.base.options.target.cpu.arch == .spu_2) @as(u64, 0) else default_entry_addr;
         try self.program_headers.append(self.base.allocator, .{
             .p_type = elf.PT_LOAD,
@@ -483,7 +483,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         // page align.
         const p_align = if (self.base.options.target.os.tag == .linux) 0x1000 else @as(u16, ptr_size);
         const off = self.findFreeSpace(file_size, p_align);
-        log.debug("found PT_LOAD free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
+        log.debug("found PT_LOAD free space 0x{x} to 0x{x}", .{ off, off + file_size });
         // TODO instead of hard coding the vaddr, make a function to find a vaddr to put things at.
         // we'll need to re-use that function anyway, in case the GOT grows and overlaps something
         // else in virtual memory.
@@ -508,7 +508,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         // Same reason as for GOT
         const p_align = if (self.base.options.target.os.tag == .linux) 0x1000 else @as(u16, ptr_size);
         const off = self.findFreeSpace(file_size, p_align);
-        log.debug("found PT_LOAD free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
+        log.debug("found PT_LOAD free space 0x{x} to 0x{x}", .{ off, off + file_size });
         // TODO Same as for GOT
         const rodata_addr: u32 = if (self.base.options.target.cpu.arch.ptrBitWidth() >= 32) 0x6000000 else 0xD000;
         try self.program_headers.append(self.base.allocator, .{
@@ -528,7 +528,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         assert(self.shstrtab.items.len == 0);
         try self.shstrtab.append(self.base.allocator, 0); // need a 0 at position 0
         const off = self.findFreeSpace(self.shstrtab.items.len, 1);
-        log.debug("found shstrtab free space 0x{x} to 0x{x}\n", .{ off, off + self.shstrtab.items.len });
+        log.debug("found shstrtab free space 0x{x} to 0x{x}", .{ off, off + self.shstrtab.items.len });
         try self.sections.append(self.base.allocator, .{
             .sh_name = try self.makeString(".shstrtab"),
             .sh_type = elf.SHT_STRTAB,
@@ -604,7 +604,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         const each_size: u64 = if (small_ptr) @sizeOf(elf.Elf32_Sym) else @sizeOf(elf.Elf64_Sym);
         const file_size = self.base.options.symbol_count_hint * each_size;
         const off = self.findFreeSpace(file_size, min_align);
-        log.debug("found symtab free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
+        log.debug("found symtab free space 0x{x} to 0x{x}", .{ off, off + file_size });
 
         try self.sections.append(self.base.allocator, .{
             .sh_name = try self.makeString(".symtab"),
@@ -646,7 +646,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         const file_size_hint = 200;
         const p_align = 1;
         const off = self.findFreeSpace(file_size_hint, p_align);
-        log.debug("found .debug_info free space 0x{x} to 0x{x}\n", .{
+        log.debug("found .debug_info free space 0x{x} to 0x{x}", .{
             off,
             off + file_size_hint,
         });
@@ -671,7 +671,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         const file_size_hint = 128;
         const p_align = 1;
         const off = self.findFreeSpace(file_size_hint, p_align);
-        log.debug("found .debug_abbrev free space 0x{x} to 0x{x}\n", .{
+        log.debug("found .debug_abbrev free space 0x{x} to 0x{x}", .{
             off,
             off + file_size_hint,
         });
@@ -696,7 +696,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         const file_size_hint = 160;
         const p_align = 16;
         const off = self.findFreeSpace(file_size_hint, p_align);
-        log.debug("found .debug_aranges free space 0x{x} to 0x{x}\n", .{
+        log.debug("found .debug_aranges free space 0x{x} to 0x{x}", .{
             off,
             off + file_size_hint,
         });
@@ -721,7 +721,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         const file_size_hint = 250;
         const p_align = 1;
         const off = self.findFreeSpace(file_size_hint, p_align);
-        log.debug("found .debug_line free space 0x{x} to 0x{x}\n", .{
+        log.debug("found .debug_line free space 0x{x} to 0x{x}", .{
             off,
             off + file_size_hint,
         });
@@ -877,7 +877,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
             debug_abbrev_sect.sh_offset = self.findFreeSpace(needed_size, 1);
         }
         debug_abbrev_sect.sh_size = needed_size;
-        log.debug(".debug_abbrev start=0x{x} end=0x{x}\n", .{
+        log.debug(".debug_abbrev start=0x{x} end=0x{x}", .{
             debug_abbrev_sect.sh_offset,
             debug_abbrev_sect.sh_offset + needed_size,
         });
@@ -1024,7 +1024,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
             debug_aranges_sect.sh_offset = self.findFreeSpace(needed_size, 16);
         }
         debug_aranges_sect.sh_size = needed_size;
-        log.debug(".debug_aranges start=0x{x} end=0x{x}\n", .{
+        log.debug(".debug_aranges start=0x{x} end=0x{x}", .{
             debug_aranges_sect.sh_offset,
             debug_aranges_sect.sh_offset + needed_size,
         });
@@ -1191,7 +1191,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
                 shstrtab_sect.sh_offset = self.findFreeSpace(needed_size, 1);
             }
             shstrtab_sect.sh_size = needed_size;
-            log.debug("writing shstrtab start=0x{x} end=0x{x}\n", .{ shstrtab_sect.sh_offset, shstrtab_sect.sh_offset + needed_size });
+            log.debug("writing shstrtab start=0x{x} end=0x{x}", .{ shstrtab_sect.sh_offset, shstrtab_sect.sh_offset + needed_size });
 
             try self.base.file.?.pwriteAll(self.shstrtab.items, shstrtab_sect.sh_offset);
             if (!self.shdr_table_dirty) {
@@ -1212,7 +1212,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
                 debug_strtab_sect.sh_offset = self.findFreeSpace(needed_size, 1);
             }
             debug_strtab_sect.sh_size = needed_size;
-            log.debug("debug_strtab start=0x{x} end=0x{x}\n", .{ debug_strtab_sect.sh_offset, debug_strtab_sect.sh_offset + needed_size });
+            log.debug("debug_strtab start=0x{x} end=0x{x}", .{ debug_strtab_sect.sh_offset, debug_strtab_sect.sh_offset + needed_size });
 
             try self.base.file.?.pwriteAll(self.debug_strtab.items, debug_strtab_sect.sh_offset);
             if (!self.shdr_table_dirty) {
@@ -1246,7 +1246,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
 
                 for (buf) |*shdr, i| {
                     shdr.* = sectHeaderTo32(self.sections.items[i]);
-                    log.debug("writing section {}\n", .{shdr.*});
+                    log.debug("writing section {}", .{shdr.*});
                     if (foreign_endian) {
                         std.elf.bswapAllFields(elf.Elf32_Shdr, shdr);
                     }
@@ -1259,7 +1259,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
 
                 for (buf) |*shdr, i| {
                     shdr.* = self.sections.items[i];
-                    log.debug("writing section {}\n", .{shdr.*});
+                    log.debug("writing section {}", .{shdr.*});
                     if (foreign_endian) {
                         std.elf.bswapAllFields(elf.Elf64_Shdr, shdr);
                     }
@@ -1270,10 +1270,10 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
         self.shdr_table_dirty = false;
     }
     if (self.entry_addr == null and self.base.options.effectiveOutputMode() == .Exe) {
-        log.debug("flushing. no_entry_point_found = true\n", .{});
+        log.debug("flushing. no_entry_point_found = true", .{});
         self.error_flags.no_entry_point_found = true;
     } else {
-        log.debug("flushing. no_entry_point_found = false\n", .{});
+        log.debug("flushing. no_entry_point_found = false", .{});
         self.error_flags.no_entry_point_found = false;
         try self.writeElfHeader();
     }
@@ -2182,10 +2182,10 @@ pub fn allocateDeclIndexes(self: *Elf, decl: *Module.Decl) !void {
     try self.offset_table.ensureCapacity(self.base.allocator, self.offset_table.items.len + 1);
 
     if (self.local_symbol_free_list.popOrNull()) |i| {
-        log.debug("reusing symbol index {d} for {s}\n", .{ i, decl.name });
+        log.debug("reusing symbol index {d} for {s}", .{ i, decl.name });
         decl.link.elf.local_sym_index = i;
     } else {
-        log.debug("allocating symbol index {d} for {s}\n", .{ self.local_symbols.items.len, decl.name });
+        log.debug("allocating symbol index {d} for {s}", .{ self.local_symbols.items.len, decl.name });
         decl.link.elf.local_sym_index = @intCast(u32, self.local_symbols.items.len);
         _ = self.local_symbols.addOneAssumeCapacity();
     }
@@ -2397,11 +2397,11 @@ pub fn updateDecl(self: *Elf, module: *Module, decl: *Module.Decl) !void {
             !mem.isAlignedGeneric(u64, local_sym.st_value, required_alignment);
         if (need_realloc) {
             const vaddr = try self.growTextBlock(block_list, &decl.link.elf, code.len, required_alignment);
-            log.debug("growing {s} from 0x{x} to 0x{x}\n", .{ decl.name, local_sym.st_value, vaddr });
+            log.debug("growing {s} from 0x{x} to 0x{x}", .{ decl.name, local_sym.st_value, vaddr });
             if (vaddr != local_sym.st_value) {
                 local_sym.st_value = vaddr;
 
-                log.debug("  (writing new offset table entry)\n", .{});
+                log.debug("  (writing new offset table entry)", .{});
                 self.offset_table.items[decl.link.elf.offset_table_index] = vaddr;
                 try self.writeOffsetTableEntry(decl.link.elf.offset_table_index);
             }
@@ -2419,7 +2419,7 @@ pub fn updateDecl(self: *Elf, module: *Module, decl: *Module.Decl) !void {
         const decl_name = mem.spanZ(decl.name);
         const name_str_index = try self.makeString(decl_name);
         const vaddr = try self.allocateTextBlock(block_list, &decl.link.elf, code.len, required_alignment);
-        log.debug("allocated text block for {s} at 0x{x}\n", .{ decl_name, vaddr });
+        log.debug("allocated text block for {s} at 0x{x}", .{ decl_name, vaddr });
         errdefer self.freeTextBlock(block_list, &decl.link.elf);
 
         local_sym.* = .{
@@ -2537,7 +2537,7 @@ pub fn updateDecl(self: *Elf, module: *Module, decl: *Module.Decl) !void {
             if (needed_size > self.allocatedSize(debug_line_sect.sh_offset)) {
                 const new_offset = self.findFreeSpace(needed_size, 1);
                 const existing_size = last_src_fn.off;
-                log.debug("moving .debug_line section: {d} bytes from 0x{x} to 0x{x}\n", .{
+                log.debug("moving .debug_line section: {d} bytes from 0x{x} to 0x{x}", .{
                     existing_size,
                     debug_line_sect.sh_offset,
                     new_offset,
@@ -2704,7 +2704,7 @@ fn writeDeclDebugInfo(self: *Elf, text_block: *TextBlock, dbg_info_buf: []const 
         if (needed_size > self.allocatedSize(debug_info_sect.sh_offset)) {
             const new_offset = self.findFreeSpace(needed_size, 1);
             const existing_size = last_decl.dbg_info_off;
-            log.debug("moving .debug_info section: {} bytes from 0x{x} to 0x{x}\n", .{
+            log.debug("moving .debug_info section: {} bytes from 0x{x} to 0x{x}", .{
                 existing_size,
                 debug_info_sect.sh_offset,
                 new_offset,


### PR DESCRIPTION
Closes #6029

This PR is still in progress. There are still no tests and a few unresolved issues.

## Unresolved issues

Is this a good design ?

Should we drop the `Text` part of `TextBlock` and `TextBlockList` as it isn't just about the `.text` section anymore ?

Should the program headers for GOT and `.rodata` be merged ? They have strictly the same configuration, but maybe it would hurt incremental compilation as we would need to move them around more often when they grow.