### PR TITLE
stage1: add cmake flag for enabling logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(ZIG_TARGET_MCPU "baseline" CACHE STRING "-mcpu parameter to output binaries 
 set(ZIG_EXECUTABLE "" CACHE STRING "(when cross compiling) path to already-built zig binary")
 set(ZIG_SINGLE_THREADED off CACHE BOOL "limit the zig compiler to use only 1 thread")
 set(ZIG_OMIT_STAGE2 off CACHE BOOL "omit the stage2 backend from stage1")
+set(ZIG_ENABLE_LOGGING off CACHE BOOL "enable logging")
 
 if("${ZIG_TARGET_TRIPLE}" STREQUAL "native")
     set(ZIG_USE_LLVM_CONFIG ON CACHE BOOL "use llvm-config to find LLVM libraries")
@@ -605,6 +606,12 @@ if(ZIG_OMIT_STAGE2)
   set(ZIG_OMIT_STAGE2_BOOL "true")
 else()
   set(ZIG_OMIT_STAGE2_BOOL "false")
+endif()
+
+if(ZIG_ENABLE_LOGGING)
+  set(ZIG_ENABLE_LOGGING_BOOL "true")
+else()
+  set(ZIG_ENABLE_LOGGING_BOOL "false")
 endif()
 
 configure_file (

--- a/src/config.zig.in
+++ b/src/config.zig.in
@@ -1,7 +1,7 @@
 pub const have_llvm = true;
 pub const version: [:0]const u8 = "@ZIG_VERSION@";
 pub const semver = try @import("std").SemanticVersion.parse(version);
-pub const enable_logging: bool = false;
+pub const enable_logging: bool = @ZIG_ENABLE_LOGGING_BOOL@;
 pub const enable_tracy = false;
 pub const is_stage1 = true;
 pub const skip_non_native = false;


### PR DESCRIPTION
Now that we ship our own linker for MachO by default in both stage1
and stage2, we need a way to enable logs for verbose debugging.
This commit adds `ZIG_ENABLE_LOGGING` cmake option which is equivalent
to stage2's `-Dlog` flag.

To enable it when building stage1 with cmake, add:

```
cmake .. -DZIG_ENABLE_LOGGING=on
```