### PR TITLE
zir: add negate/negate_wrap, implement astgen

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1462,6 +1462,8 @@ pub const WipZirCode = struct {
                 .str,
                 .sub,
                 .subwrap,
+                .negate,
+                .negate_wrap,
                 .typeof,
                 .xor,
                 .optional_type,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -156,6 +156,8 @@ pub fn analyzeBody(sema: *Sema, block: *Scope.Block, body: []const zir.Inst.Inde
             .addwrap => try sema.zirArithmetic(block, zir_inst),
             .sub => try sema.zirArithmetic(block, zir_inst),
             .subwrap => try sema.zirArithmetic(block, zir_inst),
+            .negate => @panic("TODO"),
+            .negate_wrap => @panic("TODO"),
             .mul => try sema.zirArithmetic(block, zir_inst),
             .mulwrap => try sema.zirArithmetic(block, zir_inst),
             .div => try sema.zirArithmetic(block, zir_inst),

--- a/src/astgen.zig
+++ b/src/astgen.zig
@@ -1789,15 +1789,15 @@ fn simpleBinOp(
     infix_node: ast.Node.Index,
     op_inst_tag: zir.Inst.Tag,
 ) InnerError!zir.Inst.Ref {
-    if (true) @panic("TODO update for zir-memory-layout");
     const tree = scope.tree();
     const node_datas = tree.nodes.items(.data);
-    const main_tokens = tree.nodes.items(.main_token);
 
-    const lhs = try expr(mod, scope, .none, node_datas[infix_node].lhs);
-    const rhs = try expr(mod, scope, .none, node_datas[infix_node].rhs);
-    const result = try addZIRBinOp(mod, scope, src, op_inst_tag, lhs, rhs);
-    return rvalue(mod, scope, rl, result);
+    const gz = scope.getGenZir();
+    const result = try gz.addPlNode(op_inst_tag, infix_node, zir.Inst.Bin{
+        .lhs = try expr(mod, scope, .none, node_datas[infix_node].lhs),
+        .rhs = try expr(mod, scope, .none, node_datas[infix_node].rhs),
+    });
+    return rvalue(mod, scope, rl, result, infix_node);
 }
 
 fn boolBinOp(

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -737,6 +737,14 @@ pub const Inst = struct {
         sub,
         /// Twos complement wrapping integer subtraction.
         subwrap,
+        /// Arithmetic negation. Asserts no integer overflow.
+        /// Same as sub with a lhs of 0, split into a separate instruction to save memory.
+        /// Uses `un_node`.
+        negate,
+        /// Twos complement wrapping integer negation.
+        /// Same as subwrap with a lhs of 0, split into a separate instruction to save memory.
+        /// Uses `un_node`.
+        negate_wrap,
         /// Returns the type of a value.
         /// Uses the `un_tok` field.
         typeof,
@@ -944,6 +952,8 @@ pub const Inst = struct {
                 .str,
                 .sub,
                 .subwrap,
+                .negate,
+                .negate_wrap,
                 .typeof,
                 .xor,
                 .optional_type,
@@ -1341,6 +1351,8 @@ const Writer = struct {
             .@"await",
             .bit_not,
             .bool_not,
+            .negate,
+            .negate_wrap,
             .call_none,
             .compile_error,
             .deref_node,

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -392,8 +392,10 @@ pub const Inst = struct {
     /// These names are used directly as the instruction names in the text format.
     pub const Tag = enum {
         /// Arithmetic addition, asserts no integer overflow.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         add,
         /// Twos complement wrapping integer addition.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         addwrap,
         /// Allocates stack local memory.
         /// Uses the `un_node` union field. The operand is the type of the allocated object.
@@ -411,8 +413,10 @@ pub const Inst = struct {
         /// Uses the `un_node` field. AST node is the `anyframe->T` syntax. Operand is the type.
         anyframe_type,
         /// Array concatenation. `a ++ b`
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         array_cat,
         /// Array multiplication `a ** b`
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         array_mul,
         /// `[N]T` syntax. No source location provided.
         /// Uses the `bin` union field. lhs is length, rhs is element type.
@@ -468,13 +472,13 @@ pub const Inst = struct {
         /// Same as `block_flat` but additionally makes the inner instructions execute at comptime.
         block_comptime_flat,
         /// Boolean AND. See also `bit_and`.
-        /// Uses the `bin` field.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         bool_and,
         /// Boolean NOT. See also `bit_not`.
         /// Uses the `un_node` field.
         bool_not,
         /// Boolean OR. See also `bit_or`.
-        /// Uses the `bin` field.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         bool_or,
         /// Return a value from a block.
         /// Uses the `bin` union field: `lhs` is `Index` to the block (*not* `Ref`!),
@@ -501,16 +505,22 @@ pub const Inst = struct {
         /// Uses the `un_node` field. Operand is callee. AST node is the function call.
         call_none,
         /// `<`
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         cmp_lt,
         /// `<=`
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         cmp_lte,
         /// `==`
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         cmp_eq,
         /// `>=`
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         cmp_gte,
         /// `>`
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         cmp_gt,
         /// `!=`
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         cmp_neq,
         /// Coerces a result location pointer to a new element type. It is evaluated "backwards"-
         /// as type coercion from the new element type to the old element type.
@@ -543,6 +553,7 @@ pub const Inst = struct {
         /// Uses `un_node` field. AST node is the `x.*` syntax.
         deref_node,
         /// Arithmetic division. Asserts no integer overflow.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         div,
         /// Given a pointer to an array, slice, or pointer, returns a pointer to the element at
         /// the provided index. Uses the `bin` union field. Source location is implied
@@ -646,10 +657,13 @@ pub const Inst = struct {
         /// Ambiguously remainder division or modulus. If the computation would possibly have
         /// a different value depending on whether the operation is remainder division or modulus,
         /// a compile error is emitted. Otherwise the computation is performed.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         mod_rem,
         /// Arithmetic multiplication. Asserts no integer overflow.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         mul,
         /// Twos complement wrapping integer multiplication.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         mulwrap,
         /// An await inside a nosuspend scope.
         nosuspend_await,
@@ -697,8 +711,10 @@ pub const Inst = struct {
         /// Uses the `un_node` union field.
         set_eval_branch_quota,
         /// Integer shift-left. Zeroes are shifted in from the right hand side.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         shl,
         /// Integer shift-right. Arithmetic or logical depending on the signedness of the integer type.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         shr,
         /// Create a pointer type that does not have a sentinel, alignment, or bit range specified.
         /// Uses the `ptr_type_simple` union field.
@@ -734,8 +750,10 @@ pub const Inst = struct {
         /// Uses the `str` union field.
         str,
         /// Arithmetic subtraction. Asserts no integer overflow.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         sub,
         /// Twos complement wrapping integer subtraction.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         subwrap,
         /// Arithmetic negation. Asserts no integer overflow.
         /// Same as sub with a lhs of 0, split into a separate instruction to save memory.
@@ -756,6 +774,7 @@ pub const Inst = struct {
         /// Uses the `unreachable` union field.
         @"unreachable",
         /// Bitwise XOR. `^`
+        /// Uses the `pl_node` union field. Payload is `Bin`.
         xor,
         /// Create an optional type '?T'
         /// Uses the `un_node` field.


### PR DESCRIPTION
These were previously implemented as a sub/sub_wrap instruction with a
lhs of 0. Making this separate instructions however allows us to save
some memory as there is no need to store a lhs.

This commit was written under the assumption that every zir instruction requires source information, which will not fit in the 8 byte `Data` union alongside 2 32 bit indexes to lhs and rhs nodes.