### PR TITLE
translate-c: Ensure assignments are within a block when necessary

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1244,4 +1244,18 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("convert single-statement bodies into blocks for if/else/for/while. issue #8159",
+        \\#include <stdlib.h>
+        \\int foo() { return 1; }
+        \\int main(void) {
+        \\    int i = 0;
+        \\    if (i == 0) if (i == 0) if (i != 0) i = 1;
+        \\    if (i != 0) i = 1; else if (i == 0) if (i == 0) i += 1;
+        \\    for (; i < 10;) for (; i < 10;) i++;
+        \\    while (i == 100) while (i == 100) foo();
+        \\    if (0) do do "string"; while(1); while(1);
+        \\    return 0;
+        \\}
+    , "");
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1934,7 +1934,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     , &[_][]const u8{
         \\pub export fn foo() c_int {
         \\    var a: c_int = 5;
-        \\    while (true) a = 2;
+        \\    while (true) {
+        \\        a = 2;
+        \\    }
         \\    while (true) {
         \\        var a_1: c_int = 4;
         \\        a_1 = 9;
@@ -1947,7 +1949,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\        var a_1: c_int = 2;
         \\        a_1 = 12;
         \\    }
-        \\    while (true) a = 7;
+        \\    while (true) {
+        \\        a = 7;
+        \\    }
         \\    return 0;
         \\}
     });
@@ -2008,7 +2012,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     , &[_][]const u8{
         \\pub export fn bar() c_int {
-        \\    if ((if (true) @as(c_int, 5) else if (true) @as(c_int, 4) else @as(c_int, 6)) != 0) _ = @as(c_int, 2);
+        \\    if ((if (true) @as(c_int, 5) else if (true) @as(c_int, 4) else @as(c_int, 6)) != 0) {
+        \\        _ = @as(c_int, 2);
+        \\    }
         \\    return if (true) @as(c_int, 5) else if (true) @as(c_int, 4) else @as(c_int, 6);
         \\}
     });
@@ -2389,7 +2395,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const yes = [*c]u8;
         \\pub export fn foo() void {
         \\    var a: yes = undefined;
-        \\    if (a != null) _ = @as(c_int, 2);
+        \\    if (a != null) {
+        \\        _ = @as(c_int, 2);
+        \\    }
         \\}
     });
 


### PR DESCRIPTION
Ensures that if an assignment statement is the sole statement within a
C if statement, for loop, do loop, or do while loop, then when translated
it resides within a block, even though it does not in the original C.

Fixes the following invalid translation:

`if (1) if (1) 2;` -> `if (true) if (true) _ = @as(c_int, 2);`

To this:
```zig
    if (true) if (true) {
        _ = @as(c_int, 2);
    };
```

Fixes #8159