### PR TITLE
bigint add failures with aliasing

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -316,7 +316,9 @@ pub const Mutable = struct {
         }
 
         if (a.limbs.len == 1 and b.limbs.len == 1 and a.positive == b.positive) {
-            if (!@addWithOverflow(Limb, a.limbs[0], b.limbs[0], &r.limbs[0])) {
+            var o: Limb = undefined;
+            if (!@addWithOverflow(Limb, a.limbs[0], b.limbs[0], &o)) {
+                r.limbs[0] = o;
                 r.len = 1;
                 r.positive = a.positive;
                 return;

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -1562,3 +1562,29 @@ test "big.int pow" {
         try testing.expectEqual(@as(i32, 1), try a.to(i32));
     }
 }
+
+test "bigint regression test for 1 limb overflow with alias" {
+    // Note these happen to be two consecutive Fibonacci sequence numbers, the
+    // first two whose sum exceeds 2**64.
+    var a = try Managed.initSet(testing.allocator, 7540113804746346429);
+    defer a.deinit();
+    var b = try Managed.initSet(testing.allocator, 12200160415121876738);
+    defer b.deinit();
+
+    try a.add(a.toConst(), b.toConst());
+
+    try testing.expect(a.toConst().orderAgainstScalar(19740274219868223167) == .eq);
+}
+
+test "bigint regression test for something else with alias" {
+    // Note these happen to be two consecutive Fibonacci sequence numbers, the
+    // second of which is the first such number to exceed 2**192.
+    var a = try Managed.initSet(testing.allocator, 5611500259351924431073312796924978741056961814867751431689);
+    defer a.deinit();
+    var b = try Managed.initSet(testing.allocator, 9079598147510263717870894449029933369491131786514446266146);
+    defer b.deinit();
+
+    try a.add(a.toConst(), b.toConst());
+
+    try testing.expect(a.toConst().orderAgainstScalar(14691098406862188148944207245954912110548093601382197697835) == .eq);
+}

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -538,6 +538,17 @@ test "big.int add sign" {
     try testing.expect((try a.to(i32)) == -3);
 }
 
+test "big.int add scalar" {
+    var a = try Managed.initSet(testing.allocator, 50);
+    defer a.deinit();
+
+    var b = try Managed.init(testing.allocator);
+    defer b.deinit();
+    try b.addScalar(a.toConst(), 5);
+
+    try testing.expect((try b.to(u32)) == 55);
+}
+
 test "big.int sub single-single" {
     var a = try Managed.initSet(testing.allocator, 50);
     defer a.deinit();
@@ -1563,7 +1574,7 @@ test "big.int pow" {
     }
 }
 
-test "bigint regression test for 1 limb overflow with alias" {
+test "big.int regression test for 1 limb overflow with alias" {
     // Note these happen to be two consecutive Fibonacci sequence numbers, the
     // first two whose sum exceeds 2**64.
     var a = try Managed.initSet(testing.allocator, 7540113804746346429);
@@ -1571,12 +1582,13 @@ test "bigint regression test for 1 limb overflow with alias" {
     var b = try Managed.initSet(testing.allocator, 12200160415121876738);
     defer b.deinit();
 
+    try a.ensureAddCapacity(a.toConst(), b.toConst());
     try a.add(a.toConst(), b.toConst());
 
     try testing.expect(a.toConst().orderAgainstScalar(19740274219868223167) == .eq);
 }
 
-test "bigint regression test for something else with alias" {
+test "big.int regression test for realloc with alias" {
     // Note these happen to be two consecutive Fibonacci sequence numbers, the
     // second of which is the first such number to exceed 2**192.
     var a = try Managed.initSet(testing.allocator, 5611500259351924431073312796924978741056961814867751431689);
@@ -1584,6 +1596,7 @@ test "bigint regression test for something else with alias" {
     var b = try Managed.initSet(testing.allocator, 9079598147510263717870894449029933369491131786514446266146);
     defer b.deinit();
 
+    try a.ensureAddCapacity(a.toConst(), b.toConst());
     try a.add(a.toConst(), b.toConst());
 
     try testing.expect(a.toConst().orderAgainstScalar(14691098406862188148944207245954912110548093601382197697835) == .eq);


### PR DESCRIPTION
A Discord user came to us with a failing use of bigint which was just calculating the Fibonacci sequence.

It turns out it was miscalculating on the jump between one and two limbs. See attached a test that fails currently, but should succeed. It is not written very elegantly, but it's easy to verify that it should work.

It looks like the offending code is this optimisation in `Mutable.add`:

https://github.com/ziglang/zig/blob/dce612ac2be5aa8a1aa0ee8dd670d7e875624216/lib/std/math/big/int.zig#L318-L324

Note that, if `@addWithOverflow` does overflow, `add` continues on to perform Knuth's algorithm in `ldadd`, **but** it has also overwritten the contents of `r.limbs[0]` here.  If `r` is aliased with one of its inputs, this causes the subsequent non-optimised calculation to fail.

I've confirmed the test passes if this is removed. We may want to do an alias check and skip the optimisation if overwriting `r` with garbage here will be a problem.

edit: I've added a suggested fix in case it's the right one, which skips this `@addWithOverflow` attempt if `r.limbs.ptr` is equal to `a.limbs.ptr` or `b.limbs.ptr`.

/cc @alexnask fyi