### PR TITLE
stage2: rename fail to todo in LLVM backend

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -727,6 +727,11 @@ pub const FuncGen = struct {
     }
 
     fn genRet(self: *FuncGen, inst: *Inst.UnOp) !?*const llvm.Value {
+        if (!inst.operand.ty.hasCodeGenBits()) {
+            // TODO: in astgen these instructions should turn into `retvoid` instructions.
+            _ = self.builder.buildRetVoid();
+            return null;
+        }
         _ = self.builder.buildRet(try self.resolveInst(inst.operand));
         return null;
     }


### PR DESCRIPTION
This way we don't have to pass src to every function and we can simply
use the first node as the lazy source location for all the todo
errors.

Also handle void in genRet in the LLVM backend