### PR TITLE
translate-c proposal: Add option to set runtime safety of generated code

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7193,7 +7193,32 @@ pub const CallOptions = struct {
           <li>To avoid a symbol collision, for example if foo.h and bar.h both <code>#define CONNECTION_COUNT</code></li>
         <li>To analyze the C code with different preprocessor defines</li>
       </ul>
-      {#see_also|Import from C Header File|@cInclude|@cDefine|@cUndef#}
+      <p>
+      {#syntax#}@cDefine{#endsyntax#} can be used to pass options to {#syntax#}@cImport{#endsyntax#}:
+      </p>
+      <pre>{#syntax#}@cDefine("__ZIG_TRANSLATE_C_RUNTIME_SAFETY_OFF", {}){#endsyntax#}</pre>
+      <p>If the preprocessor symbol {#syntax#}__ZIG_TRANSLATE_C_RUNTIME_SAFETY_OFF{#endsyntax#}
+      is defined, any function definitions in the current translation buffer will contain a call to
+      {#syntax#}@setRuntimeSafety(false){#endsyntax#} as the first statement. Note that
+      {#syntax#}__ZIG_TRANSLATE_C_RUNTIME_SAFETY_OFF{#endsyntax#} is a global option for the current
+      {#syntax#}@cImport{#endsyntax#} temporary buffer - if it is defined, it applies to the entire buffer
+      regardless of its textual position (i.e. it does not matter whether it is defined before or after
+      a particular {#syntax#}@cImport{#endsyntax#} call). It will not affect your {#link|Build Mode#}.
+      </p>
+      <p>By default, it is not defined and no calls to {#syntax#}@setRuntimeSafety{#endsyntax#}
+        will be inserted in translated functions.
+      </p>
+      <pre>{#syntax#}@cDefine("__ZIG_TRANSLATE_C_RUNTIME_SAFETY_ON", {}){#endsyntax#}</pre>
+      <p>
+      Like {#syntax#}__ZIG_TRANSLATE_C_RUNTIME_SAFETY_OFF{#endsyntax#}, except calls to
+      {#syntax#}@setRuntimeSafety(true){#endsyntax#} will be inserted. The same rules and caveats
+      as {#syntax#}__ZIG_TRANSLATE_C_RUNTIME_SAFETY_OFF{#endsyntax#} apply. If both
+      {#syntax#}__ZIG_TRANSLATE_C_RUNTIME_SAFETY_ON{#endsyntax#} and
+      {#syntax#}__ZIG_TRANSLATE_C_RUNTIME_SAFETY_OFF{#endsyntax#} are defined, whichever is defined
+      last will take effect.
+      </p>
+
+      {#see_also|Import from C Header File|@cInclude|@cDefine|@cUndef|@setRuntimeSafety|Build Mode#}
       {#header_close#}
       {#header_open|@cInclude#}
       <pre>{#syntax#}@cInclude(comptime path: []u8){#endsyntax#}</pre>

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -126,6 +126,8 @@ pub const Node = extern union {
         div_trunc,
         /// @boolToInt(operand)
         bool_to_int,
+        /// @setRuntimeSafety(operand)
+        set_runtime_safety,
         /// @as(lhs, rhs)
         as,
         /// @truncate(lhs, rhs)
@@ -252,6 +254,7 @@ pub const Node = extern union {
                 .block_single,
                 .std_meta_sizeof,
                 .bool_to_int,
+                .set_runtime_safety,
                 .sizeof,
                 .alignof,
                 .typeof,
@@ -1156,6 +1159,10 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
         .bool_to_int => {
             const payload = node.castTag(.bool_to_int).?.data;
             return renderBuiltinCall(c, "@boolToInt", &.{payload});
+        },
+        .set_runtime_safety => {
+            const payload = node.castTag(.set_runtime_safety).?.data;
+            return renderBuiltinCall(c, "@setRuntimeSafety", &.{payload});
         },
         .as => {
             const payload = node.castTag(.as).?.data;
@@ -2116,6 +2123,7 @@ fn renderNodeGrouped(c: *Context, node: Node) !NodeIndex {
         .array_type,
         .null_sentinel_array_type,
         .bool_to_int,
+        .set_runtime_safety,
         .div_exact,
         .byte_offset_of,
         => {

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -3450,4 +3450,52 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    '\u{1f4af}',
         \\};
     });
+
+    cases.add("Explicit runtime safety on, regular function",
+        \\#include <stdint.h>
+        \\#define __ZIG_TRANSLATE_C_RUNTIME_SAFETY_ON
+        \\uint32_t mymul(uint16_t x, uint16_t y) { return x * y; }
+    , &[_][]const u8{
+        \\pub export fn mymul(arg_x: u16, arg_y: u16) u32 {
+        \\    @setRuntimeSafety(true);
+        \\    var x = arg_x;
+        \\    var y = arg_y;
+        \\    return @bitCast(u32, @bitCast(c_int, @as(c_uint, x)) * @bitCast(c_int, @as(c_uint, y)));
+        \\}
+    });
+
+    cases.add("Explicit runtime safety on, macro function",
+        \\#include <stdint.h>
+        \\#define __ZIG_TRANSLATE_C_RUNTIME_SAFETY_ON
+        \\#define MYMUL(x, y) (x) * (y)
+    , &[_][]const u8{
+        \\pub fn MYMUL(x: anytype, y: anytype) callconv(.Inline) @TypeOf(x * y) {
+        \\    @setRuntimeSafety(true);
+        \\    return x * y;
+        \\}
+    });
+
+    cases.add("Explicit runtime safety off, regular function",
+        \\#include <stdint.h>
+        \\#define __ZIG_TRANSLATE_C_RUNTIME_SAFETY_OFF
+        \\uint32_t mymul(uint16_t x, uint16_t y) { return x * y; }
+    , &[_][]const u8{
+        \\pub export fn mymul(arg_x: u16, arg_y: u16) u32 {
+        \\    @setRuntimeSafety(false);
+        \\    var x = arg_x;
+        \\    var y = arg_y;
+        \\    return @bitCast(u32, @bitCast(c_int, @as(c_uint, x)) * @bitCast(c_int, @as(c_uint, y)));
+        \\}
+    });
+
+    cases.add("Explicit runtime safety off, macro function",
+        \\#include <stdint.h>
+        \\#define __ZIG_TRANSLATE_C_RUNTIME_SAFETY_OFF
+        \\#define MYMUL(x, y) (x) * (y)
+    , &[_][]const u8{
+        \\pub fn MYMUL(x: anytype, y: anytype) callconv(.Inline) @TypeOf(x * y) {
+        \\    @setRuntimeSafety(false);
+        \\    return x * y;
+        \\}
+    });
 }


### PR DESCRIPTION
Putting this up as a draft for feedback to see if people think it's a good idea

Currently the only way to control the runtime safety setting of translate-c generated
functions is globally via the build mode. This PR adds a way to explicitly set it for generated
functions, independently of the build mode.

I suspect the primary use case for this would be using C code with undefined behavior
from within a Safe build mode of Zig. For example consider the following C function:

```C
uint32_t mul(uint16_t x, uint16_t y) { return x * y; }
```
And then called with:
```C
uint32_t prod = mul(45000, 50000);
```
On a platform with 32-bit integers this contains undefined behavior due to signed integer
overflow, even though it may seem to "just work" for a given C compiler if wrapping
twos-complement arithmetic is used. Calling `mul` from Zig with those arguments will
correctly trigger an integer overflow, but the developer may still want to use the function
from within a Safe build mode. This PR enables that via defining the
`__ZIG_TRANSLATE_C_RUNTIME_SAFETY_OFF` preprocessor symbol, which will insert
a call to `@setRuntimeSafety(false)` at the beginning of the definition of `mul`.


