### PR TITLE
Change defineCMacro to take separate name and value arugments

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -101,7 +101,7 @@ pub fn build(b: *Builder) !void {
             // of being built by cmake. But when built by zig it's gonna get a compiler_rt so that
             // is pointless.
             exe.addPackagePath("compiler_rt", "src/empty.zig");
-            exe.defineCMacro("ZIG_LINK_MODE=Static");
+            exe.defineCMacro("ZIG_LINK_MODE", "Static");
 
             const softfloat = b.addStaticLibrary("softfloat", null);
             softfloat.setBuildMode(.ReleaseFast);

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1674,8 +1674,23 @@ pub const LibExeObjStep = struct {
         }
     }
 
+    /// If the value is omitted, it is set to 1.
+    /// `name` and `value` need not live longer than the function call.
+    pub fn defineCMacro(self: *LibExeObjStep, name: []const u8, value: ?[]const u8) void {
+        var macro = self.builder.allocator.alloc(
+            u8,
+            name.len + if (value) |value_slice| value_slice.len + 1 else 0,
+        ) catch |err| if (err == error.OutOfMemory) @panic("Out of memory") else unreachable;
+        mem.copy(u8, macro, name);
+        if (value) |value_slice| {
+            macro[name.len] = '=';
+            mem.copy(u8, macro[name.len + 1 ..], value_slice);
+        }
+        self.c_macros.append(macro) catch unreachable;
+    }
+
     /// name_and_value looks like [name]=[value]. If the value is omitted, it is set to 1.
-    pub fn defineCMacro(self: *LibExeObjStep, name_and_value: []const u8) void {
+    pub fn defineCMacroRaw(self: *LibExeObjStep, name_and_value: []const u8) void {
         self.c_macros.append(self.builder.dupe(name_and_value)) catch unreachable;
     }
 
@@ -1764,9 +1779,9 @@ pub const LibExeObjStep = struct {
                 self.linkSystemLibraryName(tok["-l".len..]);
             } else if (mem.eql(u8, tok, "-D")) {
                 const macro = it.next() orelse return error.PkgConfigInvalidOutput;
-                self.defineCMacro(macro);
+                self.defineCMacroRaw(macro);
             } else if (mem.startsWith(u8, tok, "-D")) {
-                self.defineCMacro(tok["-D".len..]);
+                self.defineCMacroRaw(tok["-D".len..]);
             } else if (mem.eql(u8, tok, "-pthread")) {
                 self.linkLibC();
             } else if (self.builder.verbose) {


### PR DESCRIPTION
Before this change, when one or more of name or value are not known at
comptime, build.zig files must allocate and do the concatenation, which can be
cumbersome, and also adds a redundant allocation when name and value are
slices. The new version only does a single allocation directly in the builder's
allocator to concatenate name and value

Additional options considered: 
 - not do it at all 
 - do it in a new function (`defineCMacroKeyValue`?)
 - do it, but also keep the old behavior in a different function (`defineCMacroFlag`?)