### PR TITLE
std.os.uefi.tables.boot_services: implement locateDevicePath

### DIFF
--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -78,7 +78,8 @@ pub const BootServices = extern struct {
     /// Returns an array of handles that support a specified protocol.
     locateHandle: fn (LocateSearchType, ?*align(8) const Guid, ?*const c_void, *usize, [*]Handle) callconv(.C) Status,
 
-    locateDevicePath: Status, // TODO
+    /// Locates the handle to a device on the device path that supports the specified protocol
+    locateDevicePath: fn (*align(8) const Guid, **const DevicePathProtocol, *?Handle) callconv(.C) Status,
     installConfigurationTable: Status, // TODO
 
     /// Loads an EFI image into memory.


### PR DESCRIPTION
This is necessary to open the root volume as described [here](https://github.com/rust-osdev/uefi-rs/issues/175#issuecomment-787421884), since the default SimpleFileSystem volume is often not the boot volume. This is my first pull request and I'm still a bit of a beginner to Zig so let me know if there's any changes I need to make (optionals, etc.)