### PR TITLE
os/linux: handle ECONNRESET for recv

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -5610,6 +5610,7 @@ pub fn recvfrom(
                 EAGAIN => return error.WouldBlock,
                 ENOMEM => return error.SystemResources,
                 ECONNREFUSED => return error.ConnectionRefused,
+                ECONNRESET => return error.ConnectionResetByPeer,
                 else => |err| return unexpectedErrno(err),
             }
         }


### PR DESCRIPTION
Small patch to return error.ConnectionResetByPeer on ECONNRESET for os.recv(). Otherwise, error 104 (ECONNRESET) is reported as an unhandled error.