### PR TITLE
zig build: use ZIG_GLOBAL_CACHE_DIR

### DIFF
--- a/src/introspect.zig
+++ b/src/introspect.zig
@@ -61,6 +61,14 @@ pub fn findZigLibDirFromSelfExe(
 
 /// Caller owns returned memory.
 pub fn resolveGlobalCacheDir(allocator: *mem.Allocator) ![]u8 {
+    if (std.process.getEnvVarOwned(allocator, "ZIG_GLOBAL_CACHE_DIR")) |value| {
+        if (value.len > 0) {
+            return value;
+        } else {
+            allocator.free(value);
+        }
+    } else |_| {}
+
     const appname = "zig";
 
     if (std.Target.current.os.tag != .windows) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -557,7 +557,7 @@ fn buildOutputType(
     var test_filter: ?[]const u8 = null;
     var test_name_prefix: ?[]const u8 = null;
     var override_local_cache_dir: ?[]const u8 = try optionalStringEnvVar(arena, "ZIG_LOCAL_CACHE_DIR");
-    var override_global_cache_dir: ?[]const u8 = try optionalStringEnvVar(arena, "ZIG_GLOBAL_CACHE_DIR");
+    var override_global_cache_dir: ?[]const u8 = null;
     var override_lib_dir: ?[]const u8 = try optionalStringEnvVar(arena, "ZIG_LIB_DIR");
     var main_pkg_path: ?[]const u8 = null;
     var clang_preprocessor_mode: Compilation.ClangPreprocessorMode = .no;

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -2139,10 +2139,6 @@ struct CodeGen {
     Buf llvm_ir_file_output_path;
     Buf analysis_json_output_path;
     Buf docs_output_path;
-    Buf *cache_dir;
-    Buf *c_artifact_dir;
-    const char **libc_include_dir_list;
-    size_t libc_include_dir_len;
 
     Buf *builtin_zig_path;
     Buf *zig_std_special_dir; // Cannot be overridden; derived from zig_lib_dir.


### PR DESCRIPTION
- move ZIG_GLOBAL_CACHE_DIR to `introspect`
- cleanup some dead fields from stage1 codegen

---
- prior to this PR, `ZIG_GLOBAL_CACHE_DIR` did not effect `zig build`
- we cannot do the same thing with `ZIG_LOCAL_CACHE_DIR` because idiomatic `zig build install` assumes a local cache is private; ie: standalone tests would try to install to the same `bin/` location and if we ever enable parallel tests pathnames would clash