### PR TITLE
stage2: implement @errorToInt and @intToError

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -1237,6 +1237,8 @@ fn blockExprStmts(
                         .bit_not,
                         .error_set,
                         .error_value,
+                        .error_to_int,
+                        .int_to_error,
                         .slice_start,
                         .slice_end,
                         .slice_sentinel,
@@ -3370,6 +3372,16 @@ fn builtinCall(
             const result = try gz.addUnNode(.import, target, node);
             return rvalue(gz, scope, rl, result, node);
         },
+        .error_to_int => {
+            const target = try expr(gz, scope, .none, params[0]);
+            const result = try gz.addUnNode(.error_to_int, target, node);
+            return rvalue(gz, scope, rl, result, node);
+        },
+        .int_to_error => {
+            const target = try expr(gz, scope, .{ .ty = .u16_type }, params[0]);
+            const result = try gz.addUnNode(.int_to_error, target, node);
+            return rvalue(gz, scope, rl, result, node);
+        },
         .compile_error => {
             const target = try expr(gz, scope, .none, params[0]);
             const result = try gz.addUnNode(.compile_error, target, node);
@@ -3439,7 +3451,6 @@ fn builtinCall(
         .enum_to_int,
         .error_name,
         .error_return_trace,
-        .error_to_int,
         .err_set_cast,
         .@"export",
         .fence,
@@ -3448,7 +3459,6 @@ fn builtinCall(
         .has_decl,
         .has_field,
         .int_to_enum,
-        .int_to_error,
         .int_to_float,
         .int_to_ptr,
         .memcpy,

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -941,6 +941,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
             };
 
             const module = try arena.create(Module);
+            errdefer module.deinit();
             module.* = .{
                 .gpa = gpa,
                 .comp = comp,
@@ -948,7 +949,9 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
                 .root_scope = root_scope,
                 .zig_cache_artifact_directory = zig_cache_artifact_directory,
                 .emit_h = options.emit_h,
+                .error_name_list = try std.ArrayListUnmanaged([]const u8).initCapacity(gpa, 1),
             };
+            module.error_name_list.appendAssumeCapacity("(no error)");
             break :blk module;
         } else blk: {
             if (options.emit_h != null) return error.NoZigModuleForCHeader;

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -898,6 +898,8 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                 .is_null_ptr => return self.genIsNullPtr(inst.castTag(.is_null_ptr).?),
                 .is_err => return self.genIsErr(inst.castTag(.is_err).?),
                 .is_err_ptr => return self.genIsErrPtr(inst.castTag(.is_err_ptr).?),
+                .error_to_int => return self.genErrorToInt(inst.castTag(.error_to_int).?),
+                .int_to_error => return self.genIntToError(inst.castTag(.int_to_error).?),
                 .load => return self.genLoad(inst.castTag(.load).?),
                 .loop => return self.genLoop(inst.castTag(.loop).?),
                 .not => return self.genNot(inst.castTag(.not).?),
@@ -2555,6 +2557,14 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
 
         fn genIsErrPtr(self: *Self, inst: *ir.Inst.UnOp) !MCValue {
             return self.fail(inst.base.src, "TODO load the operand and call genIsErr", .{});
+        }
+
+        fn genErrorToInt(self: *Self, inst: *ir.Inst.UnOp) !MCValue {
+            return self.resolveInst(inst.operand);
+        }
+
+        fn genIntToError(self: *Self, inst: *ir.Inst.UnOp) !MCValue {
+            return self.resolveInst(inst.operand);
         }
 
         fn genLoop(self: *Self, inst: *ir.Inst.Loop) !MCValue {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -569,6 +569,8 @@ pub fn genBody(o: *Object, body: ir.Body) error{ AnalysisFail, OutOfMemory }!voi
             .optional_payload_ptr => try genOptionalPayload(o, inst.castTag(.optional_payload_ptr).?),
             .is_err => try genIsErr(o, inst.castTag(.is_err).?),
             .is_err_ptr => try genIsErr(o, inst.castTag(.is_err_ptr).?),
+            .error_to_int => try genErrorToInt(o, inst.castTag(.error_to_int).?),
+            .int_to_error => try genIntToError(o, inst.castTag(.int_to_error).?),
             .unwrap_errunion_payload => try genUnwrapErrUnionPay(o, inst.castTag(.unwrap_errunion_payload).?),
             .unwrap_errunion_err => try genUnwrapErrUnionErr(o, inst.castTag(.unwrap_errunion_err).?),
             .unwrap_errunion_payload_ptr => try genUnwrapErrUnionPay(o, inst.castTag(.unwrap_errunion_payload_ptr).?),
@@ -1070,6 +1072,14 @@ fn genIsErr(o: *Object, inst: *Inst.UnOp) !CValue {
     try o.writeCValue(writer, operand);
     try writer.print("){s}.error != 0;\n", .{maybe_deref});
     return local;
+}
+
+fn genIntToError(o: *Object, inst: *Inst.UnOp) !CValue {
+    return o.resolveInst(inst.operand);
+}
+
+fn genErrorToInt(o: *Object, inst: *Inst.UnOp) !CValue {
+    return o.resolveInst(inst.operand);
 }
 
 fn IndentWriter(comptime UnderlyingWriter: type) type {

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -92,6 +92,10 @@ pub const Inst = struct {
         is_err,
         /// *E!T => bool
         is_err_ptr,
+        /// E => u16
+        error_to_int,
+        /// u16 => E
+        int_to_error,
         bool_and,
         bool_or,
         /// Read a value from a pointer.
@@ -152,6 +156,8 @@ pub const Inst = struct {
                 .is_null_ptr,
                 .is_err,
                 .is_err_ptr,
+                .int_to_error,
+                .error_to_int,
                 .ptrtoint,
                 .floatcast,
                 .intcast,
@@ -696,6 +702,8 @@ const DumpTzir = struct {
                 .is_null_ptr,
                 .is_err,
                 .is_err_ptr,
+                .error_to_int,
+                .int_to_error,
                 .ptrtoint,
                 .floatcast,
                 .intcast,
@@ -817,6 +825,8 @@ const DumpTzir = struct {
                 .is_null_ptr,
                 .is_err,
                 .is_err_ptr,
+                .error_to_int,
+                .int_to_error,
                 .ptrtoint,
                 .floatcast,
                 .intcast,

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -185,8 +185,7 @@ pub fn flushModule(self: *C, comp: *Compilation) !void {
         if (module.global_error_set.size == 0) break :render_errors;
         var it = module.global_error_set.iterator();
         while (it.next()) |entry| {
-            // + 1 because 0 represents no error
-            try err_typedef_writer.print("#define zig_error_{s} {d}\n", .{ entry.key, entry.value + 1 });
+            try err_typedef_writer.print("#define zig_error_{s} {d}\n", .{ entry.key, entry.value });
         }
         try err_typedef_writer.writeByte('\n');
     }

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -365,6 +365,10 @@ pub const Inst = struct {
         /// Make an integer type out of signedness and bit count.
         /// Payload is `int_type`
         int_type,
+        /// Convert an error type to `u16`
+        error_to_int,
+        /// Convert a `u16` to `anyerror`
+        int_to_error,
         /// Return a boolean false if an optional is null. `x != null`
         /// Uses the `un_node` field.
         is_non_null,
@@ -728,6 +732,8 @@ pub const Inst = struct {
                 .err_union_payload_unsafe_ptr,
                 .err_union_code,
                 .err_union_code_ptr,
+                .error_to_int,
+                .int_to_error,
                 .ptr_type,
                 .ptr_type_simple,
                 .ensure_err_payload_void,
@@ -1414,6 +1420,8 @@ const Writer = struct {
             .err_union_payload_unsafe_ptr,
             .err_union_code,
             .err_union_code_ptr,
+            .int_to_error,
+            .error_to_int,
             .is_non_null,
             .is_null,
             .is_non_null_ptr,

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -55,6 +55,42 @@ pub fn addCases(ctx: *TestContext) !void {
     }
 
     {
+        var case = ctx.exeFromCompiledC("@intToError", .{});
+
+        case.addCompareOutput(
+            \\pub export fn main() c_int {
+            \\    // comptime checks
+            \\    const a = error.A;
+            \\    const b = error.B;
+            \\    const c = @intToError(2);
+            \\    const d = @intToError(1);
+            \\    if (!(c == b)) unreachable;
+            \\    if (!(a == d)) unreachable;
+            \\    // runtime checks
+            \\    var x = error.A;
+            \\    var y = error.B;
+            \\    var z = @intToError(2);
+            \\    var f = @intToError(1);
+            \\    if (!(y == z)) unreachable;
+            \\    if (!(x == f)) unreachable;
+            \\    return 0;
+            \\}
+        , "");
+        case.addError(
+            \\pub export fn main() c_int {
+            \\    const c = @intToError(0);
+            \\    return 0;
+            \\}
+        , &.{":2:27: error: integer value 0 represents no error"});
+        case.addError(
+            \\pub export fn main() c_int {
+            \\    const c = @intToError(3);
+            \\    return 0;
+            \\}
+        , &.{":2:27: error: integer value 3 represents no error"});
+    }
+
+    {
         var case = ctx.exeFromCompiledC("x86_64-linux inline assembly", linux_x64);
 
         // Exit with 0


### PR DESCRIPTION
I could not test @errorToInt because we do not have error set equality yet (I realized this out after I implemented it :().

There is another big problem:
`error`s do *not* get removed from `Module` when they are removed from source code in an incremental update. This means that this test case fails: 
```zig
    {
        var case = ctx.exeFromCompiledC("@intToError", .{});

        case.addCompareOutput(
            \\pub export fn main() c_int {
            \\    // comptime checks
            \\    const a = error.A;
            \\    const b = error.B;
            \\    const c = @intToError(2);
            \\    const d = @intToError(1);
            \\    if (!(c == b)) unreachable;
            \\    if (!(a == d)) unreachable;
            \\    // runtime checks
            \\    var x = error.A;
            \\    var y = error.B;
            \\    var z = @intToError(2);
            \\    var f = @intToError(1);
            \\    if (!(y == z)) unreachable;
            \\    if (!(x == f)) unreachable;
            \\    return 0;
            \\}
        , "");
        case.addError(
            \\pub export fn main() c_int {
            \\    const c = @intToError(0);
            \\    return 0;
            \\}
        , &.{":2:26: error: integer value 0 represents no error"});
        case.addError(
            \\pub export fn main() c_int {
            \\    const c = @intToError(2);
            \\    return 0;
            \\}
        , &.{":2:26: error: integer value 2 represents no error"});
    }
```
Because integer value 2 does represent an error, just in a past update. Not sure what we should do about this yet ...
Also not sure if there is a better way to represent no-ops in the cbe than just making a local and returning it?