### PR TITLE
Fix typo in Pcg.zig's fill function

### DIFF
--- a/lib/std/rand/Isaac64.zig
+++ b/lib/std/rand/Isaac64.zig
@@ -208,3 +208,35 @@ test "isaac64 sequence" {
         std.testing.expect(s == r.next());
     }
 }
+
+test "isaac64 fill" {
+    var r = Isaac64.init(0);
+
+    // from reference implementation
+    const seq = [_]u64{
+        0xf67dfba498e4937c,
+        0x84a5066a9204f380,
+        0xfee34bd5f5514dbb,
+        0x4d1664739b8f80d6,
+        0x8607459ab52a14aa,
+        0x0e78bc5a98529e49,
+        0xfe5332822ad13777,
+        0x556c27525e33d01a,
+        0x08643ca615f3149f,
+        0xd0771faf3cb04714,
+        0x30e86f68a37b008d,
+        0x3074ebc0488a3adf,
+        0x270645ea7a2790bc,
+        0x5601a0a8d3763c6a,
+        0x2f83071f53f325dd,
+        0xb9090f3d42d2d2ea,
+    };
+
+    for (seq) |s| {
+        var buf0: [8]u8 = undefined;
+        var buf1: [7]u8 = undefined;
+        std.mem.writeIntLittle(u64, &buf0, s);
+        Isaac64.fill(&r.random, &buf1);
+        std.testing.expect(std.mem.eql(u8, buf0[0..7], buf1[0..]));
+    }
+}

--- a/lib/std/rand/Pcg.zig
+++ b/lib/std/rand/Pcg.zig
@@ -99,3 +99,27 @@ test "pcg sequence" {
         std.testing.expect(s == r.next());
     }
 }
+
+test "pcg fill" {
+    var r = Pcg.init(0);
+    const s0: u64 = 0x9394bf54ce5d79de;
+    const s1: u64 = 0x84e9c579ef59bbf7;
+    r.seedTwo(s0, s1);
+
+    const seq = [_]u32{
+        2881561918,
+        3063928540,
+        1199791034,
+        2487695858,
+        1479648952,
+        3247963454,
+    };
+
+    for (seq) |s| {
+        var buf0: [4]u8 = undefined;
+        var buf1: [3]u8 = undefined;
+        std.mem.writeIntLittle(u32, &buf0, s);
+        Pcg.fill(&r.random, &buf1);
+        std.testing.expect(std.mem.eql(u8, buf0[0..3], buf1[0..]));
+    }
+}

--- a/lib/std/rand/Pcg.zig
+++ b/lib/std/rand/Pcg.zig
@@ -75,7 +75,7 @@ fn fill(r: *Random, buf: []u8) void {
         var n = self.next();
         while (i < buf.len) : (i += 1) {
             buf[i] = @truncate(u8, n);
-            n >>= 4;
+            n >>= 8;
         }
     }
 }

--- a/lib/std/rand/Sfc64.zig
+++ b/lib/std/rand/Sfc64.zig
@@ -106,3 +106,35 @@ test "Sfc64 sequence" {
         std.testing.expectEqual(s, r.next());
     }
 }
+
+test "Sfc64 fill" {
+    // Unfortunately there does not seem to be an official test sequence.
+    var r = Sfc64.init(0);
+
+    const seq = [_]u64{
+        0x3acfa029e3cc6041,
+        0xf5b6515bf2ee419c,
+        0x1259635894a29b61,
+        0xb6ae75395f8ebd6,
+        0x225622285ce302e2,
+        0x520d28611395cb21,
+        0xdb909c818901599d,
+        0x8ffd195365216f57,
+        0xe8c4ad5e258ac04a,
+        0x8f8ef2c89fdb63ca,
+        0xf9865b01d98d8e2f,
+        0x46555871a65d08ba,
+        0x66868677c6298fcd,
+        0x2ce15a7e6329f57d,
+        0xb2f1833ca91ca79,
+        0x4b0890ac9bf453ca,
+    };
+
+    for (seq) |s| {
+        var buf0: [8]u8 = undefined;
+        var buf1: [7]u8 = undefined;
+        std.mem.writeIntLittle(u64, &buf0, s);
+        Sfc64.fill(&r.random, &buf1);
+        std.testing.expect(std.mem.eql(u8, buf0[0..7], buf1[0..]));
+    }
+}

--- a/lib/std/rand/Xoroshiro128.zig
+++ b/lib/std/rand/Xoroshiro128.zig
@@ -131,3 +131,26 @@ test "xoroshiro sequence" {
         std.testing.expect(s == r.next());
     }
 }
+
+test "xoroshiro fill" {
+    var r = Xoroshiro128.init(0);
+    r.s[0] = 0xaeecf86f7878dd75;
+    r.s[1] = 0x01cd153642e72622;
+
+    const seq = [_]u64{
+        0xb0ba0da5bb600397,
+        0x18a08afde614dccc,
+        0xa2635b956a31b929,
+        0xabe633c971efa045,
+        0x9ac19f9706ca3cac,
+        0xf62b426578c1e3fb,
+    };
+
+    for (seq) |s| {
+        var buf0: [8]u8 = undefined;
+        var buf1: [7]u8 = undefined;
+        std.mem.writeIntLittle(u64, &buf0, s);
+        Xoroshiro128.fill(&r.random, &buf1);
+        std.testing.expect(std.mem.eql(u8, buf0[0..7], buf1[0..]));
+    }
+}


### PR DESCRIPTION
When filling the last (len % 4) bytes of a buffer, the random number n was only being shifted right by 4 bits for each byte instead of 8. A random u16, for example, would always have its middle two nybbles be equal when generated this way. For comparison, Isaac64.zig, Sfc64.zig, and Xoroshiro128.zig all correctly shift right by 8 bits for each of the last bytes in their nearly identical fill functions.