### PR TITLE
translate-c: Add support for vector expressions

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -300,6 +300,14 @@ pub const ConstantExpr = opaque {};
 
 pub const ContinueStmt = opaque {};
 
+pub const ConvertVectorExpr = opaque {
+    pub const getSrcExpr = ZigClangConvertVectorExpr_getSrcExpr;
+    extern fn ZigClangConvertVectorExpr_getSrcExpr(*const ConvertVectorExpr) *const Expr;
+
+    pub const getTypeSourceInfo_getType = ZigClangConvertVectorExpr_getTypeSourceInfo_getType;
+    extern fn ZigClangConvertVectorExpr_getTypeSourceInfo_getType(*const ConvertVectorExpr) QualType;
+};
+
 pub const DecayedType = opaque {
     pub const getDecayedType = ZigClangDecayedType_getDecayedType;
     extern fn ZigClangDecayedType_getDecayedType(*const DecayedType) QualType;
@@ -748,6 +756,14 @@ pub const ReturnStmt = opaque {
     extern fn ZigClangReturnStmt_getRetValue(*const ReturnStmt) ?*const Expr;
 };
 
+pub const ShuffleVectorExpr = opaque {
+    pub const getNumSubExprs = ZigClangShuffleVectorExpr_getNumSubExprs;
+    extern fn ZigClangShuffleVectorExpr_getNumSubExprs(*const ShuffleVectorExpr) c_uint;
+
+    pub const getExpr = ZigClangShuffleVectorExpr_getExpr;
+    extern fn ZigClangShuffleVectorExpr_getExpr(*const ShuffleVectorExpr, c_uint) *const Expr;
+};
+
 pub const SourceManager = opaque {
     pub const getSpellingLoc = ZigClangSourceManager_getSpellingLoc;
     extern fn ZigClangSourceManager_getSpellingLoc(*const SourceManager, Loc: SourceLocation) SourceLocation;
@@ -836,6 +852,9 @@ pub const Type = opaque {
 
     pub const isRecordType = ZigClangType_isRecordType;
     extern fn ZigClangType_isRecordType(*const Type) bool;
+
+    pub const isVectorType = ZigClangType_isVectorType;
+    extern fn ZigClangType_isVectorType(*const Type) bool;
 
     pub const isIncompleteOrZeroLengthArrayType = ZigClangType_isIncompleteOrZeroLengthArrayType;
     extern fn ZigClangType_isIncompleteOrZeroLengthArrayType(*const Type, *const ASTContext) bool;
@@ -935,6 +954,14 @@ pub const VarDecl = opaque {
 
     pub const getTypeSourceInfo_getType = ZigClangVarDecl_getTypeSourceInfo_getType;
     extern fn ZigClangVarDecl_getTypeSourceInfo_getType(*const VarDecl) QualType;
+};
+
+pub const VectorType = opaque {
+    pub const getElementType = ZigClangVectorType_getElementType;
+    extern fn ZigClangVectorType_getElementType(*const VectorType) QualType;
+
+    pub const getNumElements = ZigClangVectorType_getNumElements;
+    extern fn ZigClangVectorType_getNumElements(*const VectorType) c_uint;
 };
 
 pub const WhileStmt = opaque {

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2046,6 +2046,11 @@ bool ZigClangType_isRecordType(const ZigClangType *self) {
     return casted->isRecordType();
 }
 
+bool ZigClangType_isVectorType(const ZigClangType *self) {
+    auto casted = reinterpret_cast<const clang::Type *>(self);
+    return casted->isVectorType();
+}
+
 bool ZigClangType_isIncompleteOrZeroLengthArrayType(const ZigClangQualType *self,
         const struct ZigClangASTContext *ctx)
 {
@@ -2738,6 +2743,16 @@ struct ZigClangQualType ZigClangBinaryOperator_getType(const struct ZigClangBina
     return bitcast(casted->getType());
 }
 
+const struct ZigClangExpr *ZigClangConvertVectorExpr_getSrcExpr(const struct ZigClangConvertVectorExpr *self) {
+    auto casted = reinterpret_cast<const clang::ConvertVectorExpr *>(self);
+    return reinterpret_cast<const struct ZigClangExpr *>(casted->getSrcExpr());
+}
+
+struct ZigClangQualType ZigClangConvertVectorExpr_getTypeSourceInfo_getType(const struct ZigClangConvertVectorExpr *self) {
+    auto casted = reinterpret_cast<const clang::ConvertVectorExpr *>(self);
+    return bitcast(casted->getTypeSourceInfo()->getType());
+}
+
 struct ZigClangQualType ZigClangDecayedType_getDecayedType(const struct ZigClangDecayedType *self) {
     auto casted = reinterpret_cast<const clang::DecayedType *>(self);
     return bitcast(casted->getDecayedType());
@@ -2843,6 +2858,16 @@ struct ZigClangQualType ZigClangValueDecl_getType(const struct ZigClangValueDecl
     return bitcast(casted->getType());
 }
 
+struct ZigClangQualType ZigClangVectorType_getElementType(const struct ZigClangVectorType *self) {
+    auto casted = reinterpret_cast<const clang::VectorType *>(self);
+    return bitcast(casted->getElementType());
+}
+
+unsigned ZigClangVectorType_getNumElements(const struct ZigClangVectorType *self) {
+    auto casted = reinterpret_cast<const clang::VectorType *>(self);
+    return casted->getNumElements();
+}
+
 const struct ZigClangExpr *ZigClangWhileStmt_getCond(const struct ZigClangWhileStmt *self) {
     auto casted = reinterpret_cast<const clang::WhileStmt *>(self);
     return reinterpret_cast<const struct ZigClangExpr *>(casted->getCond());
@@ -2922,6 +2947,15 @@ struct ZigClangSourceLocation ZigClangUnaryExprOrTypeTraitExpr_getBeginLoc(
     return bitcast(casted->getBeginLoc());
 }
 
+unsigned ZigClangShuffleVectorExpr_getNumSubExprs(const ZigClangShuffleVectorExpr *self) {
+    auto casted = reinterpret_cast<const clang::ShuffleVectorExpr *>(self);
+    return casted->getNumSubExprs();
+}
+
+const struct ZigClangExpr *ZigClangShuffleVectorExpr_getExpr(const struct ZigClangShuffleVectorExpr *self, unsigned idx) {
+    auto casted = reinterpret_cast<const clang::ShuffleVectorExpr *>(self);
+    return reinterpret_cast<const struct ZigClangExpr *>(casted->getExpr(idx));
+}
 
 enum ZigClangUnaryExprOrTypeTrait_Kind ZigClangUnaryExprOrTypeTraitExpr_getKind(
     const struct ZigClangUnaryExprOrTypeTraitExpr *self)

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -1064,6 +1064,7 @@ ZIG_EXTERN_C bool ZigClangType_isBooleanType(const struct ZigClangType *self);
 ZIG_EXTERN_C bool ZigClangType_isVoidType(const struct ZigClangType *self);
 ZIG_EXTERN_C bool ZigClangType_isArrayType(const struct ZigClangType *self);
 ZIG_EXTERN_C bool ZigClangType_isRecordType(const struct ZigClangType *self);
+ZIG_EXTERN_C bool ZigClangType_isVectorType(const struct ZigClangType *self);
 ZIG_EXTERN_C bool ZigClangType_isIncompleteOrZeroLengthArrayType(const ZigClangQualType *self, const struct ZigClangASTContext *ctx);
 ZIG_EXTERN_C bool ZigClangType_isConstantArrayType(const ZigClangType *self);
 ZIG_EXTERN_C const char *ZigClangType_getTypeClassName(const struct ZigClangType *self);
@@ -1199,6 +1200,9 @@ ZIG_EXTERN_C const struct ZigClangExpr *ZigClangBinaryOperator_getLHS(const stru
 ZIG_EXTERN_C const struct ZigClangExpr *ZigClangBinaryOperator_getRHS(const struct ZigClangBinaryOperator *);
 ZIG_EXTERN_C struct ZigClangQualType ZigClangBinaryOperator_getType(const struct ZigClangBinaryOperator *);
 
+ZIG_EXTERN_C const struct ZigClangExpr *ZigClangConvertVectorExpr_getSrcExpr(const struct ZigClangConvertVectorExpr *);
+ZIG_EXTERN_C struct ZigClangQualType ZigClangConvertVectorExpr_getTypeSourceInfo_getType(const struct ZigClangConvertVectorExpr *);
+
 ZIG_EXTERN_C struct ZigClangQualType ZigClangDecayedType_getDecayedType(const struct ZigClangDecayedType *);
 
 ZIG_EXTERN_C const struct ZigClangCompoundStmt *ZigClangStmtExpr_getSubStmt(const struct ZigClangStmtExpr *);
@@ -1228,6 +1232,9 @@ ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangUnaryOperator_getBeginLoc(con
 
 ZIG_EXTERN_C struct ZigClangQualType ZigClangValueDecl_getType(const struct ZigClangValueDecl *);
 
+ZIG_EXTERN_C struct ZigClangQualType ZigClangVectorType_getElementType(const struct ZigClangVectorType *);
+ZIG_EXTERN_C unsigned ZigClangVectorType_getNumElements(const struct ZigClangVectorType *);
+
 ZIG_EXTERN_C const struct ZigClangExpr *ZigClangWhileStmt_getCond(const struct ZigClangWhileStmt *);
 ZIG_EXTERN_C const struct ZigClangStmt *ZigClangWhileStmt_getBody(const struct ZigClangWhileStmt *);
 
@@ -1251,6 +1258,9 @@ ZIG_EXTERN_C const struct ZigClangExpr *ZigClangArraySubscriptExpr_getIdx(const 
 ZIG_EXTERN_C struct ZigClangQualType ZigClangUnaryExprOrTypeTraitExpr_getTypeOfArgument(const struct ZigClangUnaryExprOrTypeTraitExpr *);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangUnaryExprOrTypeTraitExpr_getBeginLoc(const struct ZigClangUnaryExprOrTypeTraitExpr *);
 ZIG_EXTERN_C enum ZigClangUnaryExprOrTypeTrait_Kind ZigClangUnaryExprOrTypeTraitExpr_getKind(const struct ZigClangUnaryExprOrTypeTraitExpr *);
+
+ZIG_EXTERN_C unsigned ZigClangShuffleVectorExpr_getNumSubExprs(const struct ZigClangShuffleVectorExpr *);
+ZIG_EXTERN_C const struct ZigClangExpr *ZigClangShuffleVectorExpr_getExpr(const struct ZigClangShuffleVectorExpr *, unsigned);
 
 ZIG_EXTERN_C const struct ZigClangStmt *ZigClangDoStmt_getBody(const struct ZigClangDoStmt *);
 ZIG_EXTERN_C const struct ZigClangExpr *ZigClangDoStmt_getCond(const struct ZigClangDoStmt *);

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1308,4 +1308,106 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\   ufoo = (uval += 100000000);  // compile error if @truncate() not inserted
         \\}
     , "");
+
+    cases.add("basic vector expressions",
+        \\#include <stdlib.h>
+        \\#include <stdint.h>
+        \\typedef int16_t  __v8hi __attribute__((__vector_size__(16)));
+        \\int main(int argc, char**argv) {
+        \\    __v8hi uninitialized;
+        \\    __v8hi empty_init = {};
+        \\    __v8hi partial_init = {0, 1, 2, 3};
+        \\
+        \\    __v8hi a = {0, 1, 2, 3, 4, 5, 6, 7};
+        \\    __v8hi b = (__v8hi) {100, 200, 300, 400, 500, 600, 700, 800};
+        \\
+        \\    __v8hi sum = a + b;
+        \\    for (int i = 0; i < 8; i++) {
+        \\        if (sum[i] != a[i] + b[i]) abort();
+        \\    }
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("__builtin_shufflevector",
+        \\#include <stdlib.h>
+        \\#include <stdint.h>
+        \\typedef int16_t  __v4hi __attribute__((__vector_size__(8)));
+        \\typedef int16_t  __v8hi __attribute__((__vector_size__(16)));
+        \\int main(int argc, char**argv) {
+        \\    __v8hi v8_a = {0, 1, 2, 3, 4, 5, 6, 7};
+        \\    __v8hi v8_b = {100, 200, 300, 400, 500, 600, 700, 800};
+        \\    __v8hi shuffled = __builtin_shufflevector(v8_a, v8_b, 0, 1, 2, 3, 8, 9, 10, 11);
+        \\    for (int i = 0; i < 8; i++) {
+        \\        if (i < 4) {
+        \\            if (shuffled[i] != v8_a[i]) abort();
+        \\        } else {
+        \\            if (shuffled[i] != v8_b[i - 4]) abort();
+        \\        }
+        \\    }
+        \\    shuffled = __builtin_shufflevector(
+        \\        (__v8hi) {-1, -1, -1, -1, -1, -1, -1, -1},
+        \\        (__v8hi) {42, 42, 42, 42, 42, 42, 42, 42},
+        \\        0, 1, 2, 3, 8, 9, 10, 11
+        \\    );
+        \\    for (int i = 0; i < 8; i++) {
+        \\        if (i < 4) {
+        \\            if (shuffled[i] != -1) abort();
+        \\        } else {
+        \\            if (shuffled[i] != 42) abort();
+        \\        }
+        \\    }
+        \\    __v4hi shuffled_to_fewer_elements = __builtin_shufflevector(v8_a, v8_b, 0, 1, 8, 9);
+        \\    for (int i = 0; i < 4; i++) {
+        \\        if (i < 2) {
+        \\            if (shuffled_to_fewer_elements[i] != v8_a[i]) abort();
+        \\        } else {
+        \\            if (shuffled_to_fewer_elements[i] != v8_b[i - 2]) abort();
+        \\        }
+        \\    }
+        \\    __v4hi v4_a = {0, 1, 2, 3};
+        \\    __v4hi v4_b = {100, 200, 300, 400};
+        \\    __v8hi shuffled_to_more_elements = __builtin_shufflevector(v4_a, v4_b, 0, 1, 2, 3, 4, 5, 6, 7);
+        \\    for (int i = 0; i < 4; i++) {
+        \\        if (shuffled_to_more_elements[i] != v4_a[i]) abort();
+        \\        if (shuffled_to_more_elements[i + 4] != v4_b[i]) abort();
+        \\    }
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("__builtin_convertvector",
+        \\#include <stdlib.h>
+        \\#include <stdint.h>
+        \\typedef int16_t  __v8hi __attribute__((__vector_size__(16)));
+        \\typedef uint16_t __v8hu __attribute__((__vector_size__(16)));
+        \\int main(int argc, char**argv) {
+        \\    __v8hi signed_vector = { 1, 2, 3, 4, -1, -2, -3,-4};
+        \\    __v8hu unsigned_vector = __builtin_convertvector(signed_vector, __v8hu);
+        \\
+        \\    for (int i = 0; i < 8; i++) {
+        \\        if (unsigned_vector[i] != (uint16_t)signed_vector[i]) abort();
+        \\    }
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("vector casting",
+        \\#include <stdlib.h>
+        \\#include <stdint.h>
+        \\typedef int8_t __v8qi __attribute__((__vector_size__(8)));
+        \\typedef uint8_t __v8qu __attribute__((__vector_size__(8)));
+        \\int main(int argc, char**argv) {
+        \\    __v8qi signed_vector = { 1, 2, 3, 4, -1, -2, -3,-4};
+        \\
+        \\    uint64_t big_int = (uint64_t) signed_vector;
+        \\    if (big_int != 0x01020304FFFEFDFCULL && big_int != 0xFCFDFEFF04030201ULL) abort();
+        \\    __v8qu unsigned_vector = (__v8qu) big_int;
+        \\    for (int i = 0; i < 8; i++) {
+        \\        if (unsigned_vector[i] != (uint8_t)signed_vector[i] && unsigned_vector[i] != (uint8_t)signed_vector[7 - i]) abort();
+        \\    }
+        \\    return 0;
+        \\}
+    , "");
+
 }


### PR DESCRIPTION
Includes vector types, __builtin_shufflevector, and __builtin_convertvector

