### PR TITLE
Use @bitCast instead of @ptrCast for HINSTANCE.

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -366,7 +366,7 @@ pub fn callMain() u8 {
 
 pub fn call_wWinMain() std.os.windows.INT {
     const MAIN_HINSTANCE = @typeInfo(@TypeOf(root.wWinMain)).Fn.args[0].arg_type.?;
-    const hInstance = @ptrCast(MAIN_HINSTANCE, std.os.windows.kernel32.GetModuleHandleW(null).?);
+    const hInstance = @bitCast(MAIN_HINSTANCE, std.os.windows.kernel32.GetModuleHandleW(null).?);
     const lpCmdLine = std.os.windows.kernel32.GetCommandLineW();
 
     // There's no (documented) way to get the nCmdShow parameter, so we're


### PR DESCRIPTION
Currently win32metadata is defining all handle types as integral types rather than pointer types.   Maintainer @scotteson1 pointed out here (https://github.com/microsoft/win32metadata/issues/392#issuecomment-810414111) that handles are "opaque types that need to be as big as a pointer", implying that whether or not a handle is an integral or a pointer is inconsequential.  I haven't found a case that disproves this so in this change I've modified the cast to HINSTANCE to be a `@bitCast` which should handle the cases where the handle HINSTANCE is either an integral or pointer type.  I'll be updating zigwin32 to define handles as integral types like the win32metadata defines them, so this will be required to make start.zig compatible with zigwin32.  Also note that start.zig should remain compatible with the standard library's current definition of HINSTANCE as well.