### PR TITLE
os/linux: return error on EALREADY for connect() and getsockoptError()

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3254,6 +3254,9 @@ pub const ConnectError = error{
 
     /// Connection was reset by peer before connect could complete.
     ConnectionResetByPeer,
+
+    /// Socket is non-blocking and already has a pending connection in progress.
+    ConnectionPending,
 } || UnexpectedError;
 
 /// Initiate a connection on a socket.
@@ -3294,7 +3297,7 @@ pub fn connect(sock: socket_t, sock_addr: *const sockaddr, len: socklen_t) Conne
             EADDRNOTAVAIL => return error.AddressNotAvailable,
             EAFNOSUPPORT => return error.AddressFamilyNotSupported,
             EAGAIN, EINPROGRESS => return error.WouldBlock,
-            EALREADY => unreachable, // The socket is nonblocking and a previous connection attempt has not yet been completed.
+            EALREADY => return error.ConnectionPending,
             EBADF => unreachable, // sockfd is not a valid open file descriptor.
             ECONNREFUSED => return error.ConnectionRefused,
             ECONNRESET => return error.ConnectionResetByPeer,
@@ -3325,7 +3328,7 @@ pub fn getsockoptError(sockfd: fd_t) ConnectError!void {
             EADDRNOTAVAIL => return error.AddressNotAvailable,
             EAFNOSUPPORT => return error.AddressFamilyNotSupported,
             EAGAIN => return error.SystemResources,
-            EALREADY => unreachable, // The socket is nonblocking and a previous connection attempt has not yet been completed.
+            EALREADY => return error.ConnectionPending,
             EBADF => unreachable, // sockfd is not a valid open file descriptor.
             ECONNREFUSED => return error.ConnectionRefused,
             EFAULT => unreachable, // The socket structure address is outside the user's address space.


### PR DESCRIPTION
This one's rather interesting as I could not find any reports of similar encounters with EALREADY on connect() for Linux.

I'm writing a fuzz test for an async TCP client that holds a bounded pool of connections that auto-reconnect to their destination address when they lose connection. The fuzz test repeatedly starts up the TCP client, then shuts it down in an infinite loop to check for any potential data races or memory leaks.

On Linux, socket file descriptors (well, file descriptors in general) to put it short are recycled as soon as they are closed. The race I encountered on Linux was that if a connected socket file descriptor is closed via the close() syscall, then immediately returned by a subsequent socket() syscall, it is possible for a connect() syscall to the returned file descriptor to report EALREADY.

As there is no perfect workaround for this race condition on socket file descriptors, when EALREADY is encountered, this PR will have EALREADY from connect() return error.ConnectionPending rather than cause a panic.

It is then up to the user to figure out how to handle the error. In the case of my async TCP client, the workaround I use is to reattempt the connect() syscall in an infinite loop when error.ConnectionPending is returned.

Here are debug logs straight from my fuzz test. When a connection is 'released', the underlying socket file descriptor of the connection is closed. When a connection is 'established', a call to socket() is made.

```
info(gossip): connection Connection@1c27180 was established
info(gossip): Connection@1c27180 calling connect with fd 9
info(gossip): Connection@1c27180 reported to be connected (status: ClientStatus.open)
info(gossip): connection Connection@7fe02c000d00 was established
info(gossip): Connection@7fe02c000d00 calling connect with fd 10
info(gossip): Connection@7fe02c000d00 reported to be connected (status: ClientStatus.open)
info(gossip): Connection@1c27180 is done
info(gossip): Connection@1c27180 reported to be disconnected (status: ClientStatus.errored)
info(gossip): connection Connection@1c27180 was released
info(gossip): Connection@7fe02c000d00 is done
info(gossip): Connection@7fe02c000d00 reported to be disconnected (status: ClientStatus.errored)
info(gossip): attempt 0 by Connection@7fe02c000d00: reconnecting to 0.0.0.0:9001...
info(gossip): Connection@7fe02c000d00 calling connect with fd 9
thread 20290 panic: reached unreachable code // EALREADY
```

EDIT: Some other things to mention, the socket() syscall is performed with flags SOCK_CLOEXEC | SOCK_NONBLOCK.