### PR TITLE
Make sqrt and log functions undefined for signed integer types

### DIFF
--- a/lib/std/math/ln.zig
+++ b/lib/std/math/ln.zig
@@ -36,8 +36,9 @@ pub fn ln(x: anytype) @TypeOf(x) {
         .ComptimeInt => {
             return @as(comptime_int, math.floor(ln_64(@as(f64, x))));
         },
-        .Int => {
-            return @as(T, math.floor(ln_64(@as(f64, x))));
+        .Int => |IntType| switch (IntType.signedness) {
+            .signed => return @compileError("ln not implemented for signed integers"),
+            .unsigned => return @as(T, math.floor(ln_64(@as(f64, x)))),
         },
         else => @compileError("ln not implemented for " ++ @typeName(T)),
     }

--- a/lib/std/math/log.zig
+++ b/lib/std/math/log.zig
@@ -31,9 +31,11 @@ pub fn log(comptime T: type, base: T, x: T) T {
         .ComptimeInt => {
             return @as(comptime_int, math.floor(math.ln(@as(f64, x)) / math.ln(float_base)));
         },
-        .Int => {
-            // TODO implement integer log without using float math
-            return @floatToInt(T, math.floor(math.ln(@intToFloat(f64, x)) / math.ln(float_base)));
+
+        // TODO implement integer log without using float math
+        .Int => |IntType| switch (IntType.signedness) {
+            .signed => return @compileError("log not implemented for signed integers"),
+            .unsigned => return @floatToInt(T, math.floor(math.ln(@intToFloat(f64, x)) / math.ln(float_base))),
         },
 
         .Float => {
@@ -53,7 +55,7 @@ pub fn log(comptime T: type, base: T, x: T) T {
 test "math.log integer" {
     expect(log(u8, 2, 0x1) == 0);
     expect(log(u8, 2, 0x2) == 1);
-    expect(log(i16, 2, 0x72) == 6);
+    expect(log(u16, 2, 0x72) == 6);
     expect(log(u32, 2, 0xFFFFFF) == 23);
     expect(log(u64, 2, 0x7FF0123456789ABC) == 62);
 }

--- a/lib/std/math/log10.zig
+++ b/lib/std/math/log10.zig
@@ -37,8 +37,9 @@ pub fn log10(x: anytype) @TypeOf(x) {
         .ComptimeInt => {
             return @as(comptime_int, math.floor(log10_64(@as(f64, x))));
         },
-        .Int => {
-            return @floatToInt(T, math.floor(log10_64(@intToFloat(f64, x))));
+        .Int => |IntType| switch (IntType.signedness) {
+            .signed => return @compileError("log10 not implemented for signed integers"),
+            .unsigned => return @floatToInt(T, math.floor(log10_64(@intToFloat(f64, x)))),
         },
         else => @compileError("log10 not implemented for " ++ @typeName(T)),
     }

--- a/lib/std/math/log2.zig
+++ b/lib/std/math/log2.zig
@@ -43,8 +43,9 @@ pub fn log2(x: anytype) @TypeOf(x) {
             }) : (result += 1) {}
             return result;
         },
-        .Int => {
-            return math.log2_int(T, x);
+        .Int => |IntType| switch (IntType.signedness) {
+            .signed => return @compileError("log2 not implemented for signed integers"),
+            .unsigned => return math.log2_int(T, x),
         },
         else => @compileError("log2 not implemented for " ++ @typeName(T)),
     }

--- a/lib/std/math/sqrt.zig
+++ b/lib/std/math/sqrt.zig
@@ -31,7 +31,10 @@ pub fn sqrt(x: anytype) Sqrt(@TypeOf(x)) {
             }
             return @as(T, sqrt_int(u128, x));
         },
-        .Int => return sqrt_int(T, x),
+        .Int => |IntType| switch (IntType.signedness) {
+            .signed => return @compileError("sqrt not implemented for signed integers"),
+            .unsigned => return sqrt_int(T, x),
+        },
         else => @compileError("sqrt not implemented for " ++ @typeName(T)),
     }
 }


### PR DESCRIPTION
Closes #8359

The functions sqrt, log, log2, log10 and ln which are undefined for negative integers now output compile errors when signed integers are used.

A test which used a signed integer was also changed to use an unsigned integer instead.