### PR TITLE
Switch std.json to use an ordered hashmap

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1234,7 +1234,7 @@ test "json.validate" {
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const ArrayList = std.ArrayList;
-const StringHashMap = std.StringHashMap;
+const StringArrayHashMap = std.StringArrayHashMap;
 
 pub const ValueTree = struct {
     arena: ArenaAllocator,
@@ -1245,7 +1245,7 @@ pub const ValueTree = struct {
     }
 };
 
-pub const ObjectMap = StringHashMap(Value);
+pub const ObjectMap = StringArrayHashMap(Value);
 pub const Array = ArrayList(Value);
 
 /// Represents a JSON value

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -52,12 +52,29 @@ fn anyStreamingErrNonStreaming(comptime s: []const u8) void {
     testing.expect(false);
 }
 
+fn roundTrip(comptime s: []const u8) void {
+    testing.expect(json.validate(s));
+
+    var p = json.Parser.init(testing.allocator, false);
+    defer p.deinit();
+
+    var tree = p.parse(s) catch return testing.expect(false);
+    defer tree.deinit();
+
+    var buf: [256]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buf);
+    var str_array = std.ArrayList(u8).init(&fba.allocator);
+    tree.root.jsonStringify(.{}, str_array.writer()) catch testing.expect(false);
+
+    testing.expectEqualStrings(s, str_array.items);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // Additional tests not part of test JSONTestSuite.
 
 test "y_trailing_comma_after_empty" {
-    ok(
+    roundTrip(
         \\{"1":[],"2":{},"3":"4"}
     );
 }
@@ -71,25 +88,25 @@ test "y_array_arraysWithSpaces" {
 }
 
 test "y_array_empty" {
-    ok(
+    roundTrip(
         \\[]
     );
 }
 
 test "y_array_empty-string" {
-    ok(
+    roundTrip(
         \\[""]
     );
 }
 
 test "y_array_ending_with_newline" {
-    ok(
+    roundTrip(
         \\["a"]
     );
 }
 
 test "y_array_false" {
-    ok(
+    roundTrip(
         \\[false]
     );
 }
@@ -101,7 +118,7 @@ test "y_array_heterogeneous" {
 }
 
 test "y_array_null" {
-    ok(
+    roundTrip(
         \\[null]
     );
 }
@@ -120,7 +137,7 @@ test "y_array_with_leading_space" {
 }
 
 test "y_array_with_several_null" {
-    ok(
+    roundTrip(
         \\[1,null,null,null,2]
     );
 }
@@ -172,13 +189,13 @@ test "y_number_minus_zero" {
 }
 
 test "y_number_negative_int" {
-    ok(
+    roundTrip(
         \\[-123]
     );
 }
 
 test "y_number_negative_one" {
-    ok(
+    roundTrip(
         \\[-1]
     );
 }
@@ -232,7 +249,7 @@ test "y_number_real_pos_exponent" {
 }
 
 test "y_number_simple_int" {
-    ok(
+    roundTrip(
         \\[123]
     );
 }
@@ -244,7 +261,7 @@ test "y_number_simple_real" {
 }
 
 test "y_object_basic" {
-    ok(
+    roundTrip(
         \\{"asd":"sdf"}
     );
 }
@@ -262,13 +279,13 @@ test "y_object_duplicated_key" {
 }
 
 test "y_object_empty" {
-    ok(
+    roundTrip(
         \\{}
     );
 }
 
 test "y_object_empty_key" {
-    ok(
+    roundTrip(
         \\{"":0}
     );
 }
@@ -298,7 +315,7 @@ test "y_object_long_strings" {
 }
 
 test "y_object_simple" {
-    ok(
+    roundTrip(
         \\{"a":[]}
     );
 }
@@ -348,7 +365,7 @@ test "y_string_backslash_and_u_escaped_zero" {
 }
 
 test "y_string_backslash_doublequotes" {
-    ok(
+    roundTrip(
         \\["\""]
     );
 }
@@ -366,7 +383,7 @@ test "y_string_double_escape_a" {
 }
 
 test "y_string_double_escape_n" {
-    ok(
+    roundTrip(
         \\["\\n"]
     );
 }
@@ -450,7 +467,7 @@ test "y_string_simple_ascii" {
 }
 
 test "y_string_space" {
-    ok(
+    roundTrip(
         \\" "
     );
 }
@@ -568,13 +585,13 @@ test "y_string_with_del_character" {
 }
 
 test "y_structure_lonely_false" {
-    ok(
+    roundTrip(
         \\false
     );
 }
 
 test "y_structure_lonely_int" {
-    ok(
+    roundTrip(
         \\42
     );
 }
@@ -586,37 +603,37 @@ test "y_structure_lonely_negative_real" {
 }
 
 test "y_structure_lonely_null" {
-    ok(
+    roundTrip(
         \\null
     );
 }
 
 test "y_structure_lonely_string" {
-    ok(
+    roundTrip(
         \\"asd"
     );
 }
 
 test "y_structure_lonely_true" {
-    ok(
+    roundTrip(
         \\true
     );
 }
 
 test "y_structure_string_empty" {
-    ok(
+    roundTrip(
         \\""
     );
 }
 
 test "y_structure_trailing_newline" {
-    ok(
+    roundTrip(
         \\["a"]
     );
 }
 
 test "y_structure_true_in_array" {
-    ok(
+    roundTrip(
         \\[true]
     );
 }

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -73,7 +73,7 @@ fn roundTrip(s: []const u8) !void {
 // Additional tests not part of test JSONTestSuite.
 
 test "y_trailing_comma_after_empty" {
-    roundTrip(
+    try roundTrip(
         \\{"1":[],"2":{},"3":"4"}
     );
 }
@@ -87,25 +87,25 @@ test "y_array_arraysWithSpaces" {
 }
 
 test "y_array_empty" {
-    roundTrip(
+    try roundTrip(
         \\[]
     );
 }
 
 test "y_array_empty-string" {
-    roundTrip(
+    try roundTrip(
         \\[""]
     );
 }
 
 test "y_array_ending_with_newline" {
-    roundTrip(
+    try roundTrip(
         \\["a"]
     );
 }
 
 test "y_array_false" {
-    roundTrip(
+    try roundTrip(
         \\[false]
     );
 }
@@ -117,7 +117,7 @@ test "y_array_heterogeneous" {
 }
 
 test "y_array_null" {
-    roundTrip(
+    try roundTrip(
         \\[null]
     );
 }
@@ -136,7 +136,7 @@ test "y_array_with_leading_space" {
 }
 
 test "y_array_with_several_null" {
-    roundTrip(
+    try roundTrip(
         \\[1,null,null,null,2]
     );
 }
@@ -188,13 +188,13 @@ test "y_number_minus_zero" {
 }
 
 test "y_number_negative_int" {
-    roundTrip(
+    try roundTrip(
         \\[-123]
     );
 }
 
 test "y_number_negative_one" {
-    roundTrip(
+    try roundTrip(
         \\[-1]
     );
 }
@@ -248,7 +248,7 @@ test "y_number_real_pos_exponent" {
 }
 
 test "y_number_simple_int" {
-    roundTrip(
+    try roundTrip(
         \\[123]
     );
 }
@@ -260,7 +260,7 @@ test "y_number_simple_real" {
 }
 
 test "y_object_basic" {
-    roundTrip(
+    try roundTrip(
         \\{"asd":"sdf"}
     );
 }
@@ -278,13 +278,13 @@ test "y_object_duplicated_key" {
 }
 
 test "y_object_empty" {
-    roundTrip(
+    try roundTrip(
         \\{}
     );
 }
 
 test "y_object_empty_key" {
-    roundTrip(
+    try roundTrip(
         \\{"":0}
     );
 }
@@ -314,7 +314,7 @@ test "y_object_long_strings" {
 }
 
 test "y_object_simple" {
-    roundTrip(
+    try roundTrip(
         \\{"a":[]}
     );
 }
@@ -364,7 +364,7 @@ test "y_string_backslash_and_u_escaped_zero" {
 }
 
 test "y_string_backslash_doublequotes" {
-    roundTrip(
+    try roundTrip(
         \\["\""]
     );
 }
@@ -382,7 +382,7 @@ test "y_string_double_escape_a" {
 }
 
 test "y_string_double_escape_n" {
-    roundTrip(
+    try roundTrip(
         \\["\\n"]
     );
 }
@@ -466,7 +466,7 @@ test "y_string_simple_ascii" {
 }
 
 test "y_string_space" {
-    roundTrip(
+    try roundTrip(
         \\" "
     );
 }
@@ -584,13 +584,13 @@ test "y_string_with_del_character" {
 }
 
 test "y_structure_lonely_false" {
-    roundTrip(
+    try roundTrip(
         \\false
     );
 }
 
 test "y_structure_lonely_int" {
-    roundTrip(
+    try roundTrip(
         \\42
     );
 }
@@ -602,37 +602,37 @@ test "y_structure_lonely_negative_real" {
 }
 
 test "y_structure_lonely_null" {
-    roundTrip(
+    try roundTrip(
         \\null
     );
 }
 
 test "y_structure_lonely_string" {
-    roundTrip(
+    try roundTrip(
         \\"asd"
     );
 }
 
 test "y_structure_lonely_true" {
-    roundTrip(
+    try roundTrip(
         \\true
     );
 }
 
 test "y_structure_string_empty" {
-    roundTrip(
+    try roundTrip(
         \\""
     );
 }
 
 test "y_structure_trailing_newline" {
-    roundTrip(
+    try roundTrip(
         \\["a"]
     );
 }
 
 test "y_structure_true_in_array" {
-    roundTrip(
+    try roundTrip(
         \\[true]
     );
 }


### PR DESCRIPTION
Use `StringArrayHashMap` as an ordered alternative to `StringHashMap` in `std.json`, which allows for round-tripping input.

I'm open to any objections - just opening the PR to get people's thoughts!

Note that `{"1":[],"2":{},"3":"4"}` is a fairly canonical example of JSON that previous didn't round-trip.