### PR TITLE
Tidy-up in json test module

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1234,7 +1234,7 @@ test "json.validate" {
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const ArrayList = std.ArrayList;
-const StringHashMap = std.StringHashMap;
+const StringArrayHashMap = std.StringArrayHashMap;
 
 pub const ValueTree = struct {
     arena: ArenaAllocator,
@@ -1245,7 +1245,7 @@ pub const ValueTree = struct {
     }
 };
 
-pub const ObjectMap = StringHashMap(Value);
+pub const ObjectMap = StringArrayHashMap(Value);
 pub const Array = ArrayList(Value);
 
 /// Represents a JSON value

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -81,7 +81,7 @@ test "y_trailing_comma_after_empty" {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 test "y_array_arraysWithSpaces" {
-    ok(
+    try ok(
         \\[[]   ]
     );
 }
@@ -111,7 +111,7 @@ test "y_array_false" {
 }
 
 test "y_array_heterogeneous" {
-    ok(
+    try ok(
         \\[null, 1, "1", {}]
     );
 }
@@ -123,14 +123,14 @@ test "y_array_null" {
 }
 
 test "y_array_with_1_and_newline" {
-    ok(
+    try ok(
         \\[1
         \\]
     );
 }
 
 test "y_array_with_leading_space" {
-    ok(
+    try ok(
         \\ [1]
     );
 }
@@ -142,47 +142,47 @@ test "y_array_with_several_null" {
 }
 
 test "y_array_with_trailing_space" {
-    ok("[2] ");
+    try ok("[2] ");
 }
 
 test "y_number_0e+1" {
-    ok(
+    try ok(
         \\[0e+1]
     );
 }
 
 test "y_number_0e1" {
-    ok(
+    try ok(
         \\[0e1]
     );
 }
 
 test "y_number_after_space" {
-    ok(
+    try ok(
         \\[ 4]
     );
 }
 
 test "y_number_double_close_to_zero" {
-    ok(
+    try ok(
         \\[-0.000000000000000000000000000000000000000000000000000000000000000000000000000001]
     );
 }
 
 test "y_number_int_with_exp" {
-    ok(
+    try ok(
         \\[20e1]
     );
 }
 
 test "y_number" {
-    ok(
+    try ok(
         \\[123e65]
     );
 }
 
 test "y_number_minus_zero" {
-    ok(
+    try ok(
         \\[-0]
     );
 }
@@ -200,49 +200,49 @@ test "y_number_negative_one" {
 }
 
 test "y_number_negative_zero" {
-    ok(
+    try ok(
         \\[-0]
     );
 }
 
 test "y_number_real_capital_e" {
-    ok(
+    try ok(
         \\[1E22]
     );
 }
 
 test "y_number_real_capital_e_neg_exp" {
-    ok(
+    try ok(
         \\[1E-2]
     );
 }
 
 test "y_number_real_capital_e_pos_exp" {
-    ok(
+    try ok(
         \\[1E+2]
     );
 }
 
 test "y_number_real_exponent" {
-    ok(
+    try ok(
         \\[123e45]
     );
 }
 
 test "y_number_real_fraction_exponent" {
-    ok(
+    try ok(
         \\[123.456e78]
     );
 }
 
 test "y_number_real_neg_exp" {
-    ok(
+    try ok(
         \\[1e-2]
     );
 }
 
 test "y_number_real_pos_exponent" {
-    ok(
+    try ok(
         \\[1e+2]
     );
 }
@@ -254,7 +254,7 @@ test "y_number_simple_int" {
 }
 
 test "y_number_simple_real" {
-    ok(
+    try ok(
         \\[123.456789]
     );
 }
@@ -266,13 +266,13 @@ test "y_object_basic" {
 }
 
 test "y_object_duplicated_key_and_value" {
-    ok(
+    try ok(
         \\{"a":"b","a":"b"}
     );
 }
 
 test "y_object_duplicated_key" {
-    ok(
+    try ok(
         \\{"a":"b","a":"c"}
     );
 }
@@ -290,25 +290,25 @@ test "y_object_empty_key" {
 }
 
 test "y_object_escaped_null_in_key" {
-    ok(
+    try ok(
         \\{"foo\u0000bar": 42}
     );
 }
 
 test "y_object_extreme_numbers" {
-    ok(
+    try ok(
         \\{ "min": -1.0e+28, "max": 1.0e+28 }
     );
 }
 
 test "y_object" {
-    ok(
+    try ok(
         \\{"asd":"sdf", "dfg":"fgh"}
     );
 }
 
 test "y_object_long_strings" {
-    ok(
+    try ok(
         \\{"x":[{"id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}], "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
     );
 }
@@ -320,13 +320,13 @@ test "y_object_simple" {
 }
 
 test "y_object_string_unicode" {
-    ok(
+    try ok(
         \\{"title":"\u041f\u043e\u043b\u0442\u043e\u0440\u0430 \u0417\u0435\u043c\u043b\u0435\u043a\u043e\u043f\u0430" }
     );
 }
 
 test "y_object_with_newlines" {
-    ok(
+    try ok(
         \\{
         \\"a": "b"
         \\}
@@ -334,31 +334,31 @@ test "y_object_with_newlines" {
 }
 
 test "y_string_1_2_3_bytes_UTF-8_sequences" {
-    ok(
+    try ok(
         \\["\u0060\u012a\u12AB"]
     );
 }
 
 test "y_string_accepted_surrogate_pair" {
-    ok(
+    try ok(
         \\["\uD801\udc37"]
     );
 }
 
 test "y_string_accepted_surrogate_pairs" {
-    ok(
+    try ok(
         \\["\ud83d\ude39\ud83d\udc8d"]
     );
 }
 
 test "y_string_allowed_escapes" {
-    ok(
+    try ok(
         \\["\"\\\/\b\f\n\r\t"]
     );
 }
 
 test "y_string_backslash_and_u_escaped_zero" {
-    ok(
+    try ok(
         \\["\\u0000"]
     );
 }
@@ -370,13 +370,13 @@ test "y_string_backslash_doublequotes" {
 }
 
 test "y_string_comments" {
-    ok(
+    try ok(
         \\["a/*b*/c/*d//e"]
     );
 }
 
 test "y_string_double_escape_a" {
-    ok(
+    try ok(
         \\["\\a"]
     );
 }
@@ -388,79 +388,79 @@ test "y_string_double_escape_n" {
 }
 
 test "y_string_escaped_control_character" {
-    ok(
+    try ok(
         \\["\u0012"]
     );
 }
 
 test "y_string_escaped_noncharacter" {
-    ok(
+    try ok(
         \\["\uFFFF"]
     );
 }
 
 test "y_string_in_array" {
-    ok(
+    try ok(
         \\["asd"]
     );
 }
 
 test "y_string_in_array_with_leading_space" {
-    ok(
+    try ok(
         \\[ "asd"]
     );
 }
 
 test "y_string_last_surrogates_1_and_2" {
-    ok(
+    try ok(
         \\["\uDBFF\uDFFF"]
     );
 }
 
 test "y_string_nbsp_uescaped" {
-    ok(
+    try ok(
         \\["new\u00A0line"]
     );
 }
 
 test "y_string_nonCharacterInUTF-8_U+10FFFF" {
-    ok(
+    try ok(
         \\["􏿿"]
     );
 }
 
 test "y_string_nonCharacterInUTF-8_U+FFFF" {
-    ok(
+    try ok(
         \\["￿"]
     );
 }
 
 test "y_string_null_escape" {
-    ok(
+    try ok(
         \\["\u0000"]
     );
 }
 
 test "y_string_one-byte-utf-8" {
-    ok(
+    try ok(
         \\["\u002c"]
     );
 }
 
 test "y_string_pi" {
-    ok(
+    try ok(
         \\["π"]
     );
 }
 
 test "y_string_reservedCharacterInUTF-8_U+1BFFF" {
-    ok(
+    try ok(
         \\["𛿿"]
     );
 }
 
 test "y_string_simple_ascii" {
-    ok(
+    try ok(
         \\["asd "]
     );
 }
@@ -472,115 +472,115 @@ test "y_string_space" {
 }
 
 test "y_string_surrogates_U+1D11E_MUSICAL_SYMBOL_G_CLEF" {
-    ok(
+    try ok(
         \\["\uD834\uDd1e"]
     );
 }
 
 test "y_string_three-byte-utf-8" {
-    ok(
+    try ok(
         \\["\u0821"]
     );
 }
 
 test "y_string_two-byte-utf-8" {
-    ok(
+    try ok(
         \\["\u0123"]
     );
 }
 
 test "y_string_u+2028_line_sep" {
-    ok("[\"\xe2\x80\xa8\"]");
+    try ok("[\"\xe2\x80\xa8\"]");
 }
 
 test "y_string_u+2029_par_sep" {
-    ok("[\"\xe2\x80\xa9\"]");
+    try ok("[\"\xe2\x80\xa9\"]");
 }
 
 test "y_string_uescaped_newline" {
-    ok(
+    try ok(
         \\["new\u000Aline"]
     );
 }
 
 test "y_string_uEscape" {
-    ok(
+    try ok(
         \\["\u0061\u30af\u30EA\u30b9"]
     );
 }
 
 test "y_string_unescaped_char_delete" {
-    ok("[\"\x7f\"]");
+    try ok("[\"\x7f\"]");
 }
 
 test "y_string_unicode_2" {
-    ok(
+    try ok(
         \\["⍂㈴⍂"]
     );
 }
 
 test "y_string_unicodeEscapedBackslash" {
-    ok(
+    try ok(
         \\["\u005C"]
     );
 }
 
 test "y_string_unicode_escaped_double_quote" {
-    ok(
+    try ok(
         \\["\u0022"]
     );
 }
 
 test "y_string_unicode" {
-    ok(
+    try ok(
         \\["\uA66D"]
     );
 }
 
 test "y_string_unicode_U+10FFFE_nonchar" {
-    ok(
+    try ok(
         \\["\uDBFF\uDFFE"]
     );
 }
 
 test "y_string_unicode_U+1FFFE_nonchar" {
-    ok(
+    try ok(
         \\["\uD83F\uDFFE"]
     );
 }
 
 test "y_string_unicode_U+200B_ZERO_WIDTH_SPACE" {
-    ok(
+    try ok(
         \\["\u200B"]
     );
 }
 
 test "y_string_unicode_U+2064_invisible_plus" {
-    ok(
+    try ok(
         \\["\u2064"]
     );
 }
 
 test "y_string_unicode_U+FDD0_nonchar" {
-    ok(
+    try ok(
         \\["\uFDD0"]
     );
 }
 
 test "y_string_unicode_U+FFFE_nonchar" {
-    ok(
+    try ok(
         \\["\uFFFE"]
     );
 }
 
 test "y_string_utf8" {
-    ok(
+    try ok(
         \\["€𝄞"]
     );
 }
 
 test "y_string_with_del_character" {
-    ok("[\"a\x7fa\"]");
+    try ok("[\"a\x7fa\"]");
 }
 
 test "y_structure_lonely_false" {
@@ -596,7 +596,7 @@ test "y_structure_lonely_int" {
 }
 
 test "y_structure_lonely_negative_real" {
-    ok(
+    try ok(
         \\-0.1
     );
 }
@@ -638,7 +638,7 @@ test "y_structure_true_in_array" {
 }
 
 test "y_structure_whitespace_array" {
-    ok(" [] ");
+    try ok(" [] ");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -12,7 +12,7 @@ const std = @import("../std.zig");
 const json = std.json;
 const testing = std.testing;
 
-fn testNonStreaming(comptime s: []const u8) !void {
+fn testNonStreaming(s: []const u8) !void {
     var p = json.Parser.init(testing.allocator, false);
     defer p.deinit();
 
@@ -20,32 +20,32 @@ fn testNonStreaming(comptime s: []const u8) !void {
     defer tree.deinit();
 }
 
-fn ok(comptime s: []const u8) void {
+fn ok(s: []const u8) !void {
     testing.expect(json.validate(s));
 
-    testNonStreaming(s) catch testing.expect(false);
+    try testNonStreaming(s);
 }
 
-fn err(comptime s: []const u8) void {
+fn err(s: []const u8) void {
     testing.expect(!json.validate(s));
 
     testNonStreaming(s) catch return;
     testing.expect(false);
 }
 
-fn utf8Error(comptime s: []const u8) void {
+fn utf8Error(s: []const u8) void {
     testing.expect(!json.validate(s));
 
     testing.expectError(error.InvalidUtf8Byte, testNonStreaming(s));
 }
 
-fn any(comptime s: []const u8) void {
+fn any(s: []const u8) void {
     _ = json.validate(s);
 
     testNonStreaming(s) catch {};
 }
 
-fn anyStreamingErrNonStreaming(comptime s: []const u8) void {
+fn anyStreamingErrNonStreaming(s: []const u8) void {
     _ = json.validate(s);
 
     testNonStreaming(s) catch return;

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -52,12 +52,29 @@ fn anyStreamingErrNonStreaming(comptime s: []const u8) void {
     testing.expect(false);
 }
 
+fn roundTrip(comptime s: []const u8) void {
+    testing.expect(json.validate(s));
+
+    var p = json.Parser.init(testing.allocator, false);
+    defer p.deinit();
+
+    var tree = p.parse(s) catch return testing.expect(false);
+    defer tree.deinit();
+
+    var buf: [256]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buf);
+    var str_array = std.ArrayList(u8).init(&fba.allocator);
+    tree.root.jsonStringify(.{}, str_array.writer()) catch testing.expect(false);
+
+    testing.expectEqualStrings(s, str_array.items);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // Additional tests not part of test JSONTestSuite.
 
 test "y_trailing_comma_after_empty" {
-    ok(
+    roundTrip(
         \\{"1":[],"2":{},"3":"4"}
     );
 }
@@ -71,25 +88,25 @@ test "y_array_arraysWithSpaces" {
 }
 
 test "y_array_empty" {
-    ok(
+    roundTrip(
         \\[]
     );
 }
 
 test "y_array_empty-string" {
-    ok(
+    roundTrip(
         \\[""]
     );
 }
 
 test "y_array_ending_with_newline" {
-    ok(
+    roundTrip(
         \\["a"]
     );
 }
 
 test "y_array_false" {
-    ok(
+    roundTrip(
         \\[false]
     );
 }
@@ -101,7 +118,7 @@ test "y_array_heterogeneous" {
 }
 
 test "y_array_null" {
-    ok(
+    roundTrip(
         \\[null]
     );
 }
@@ -120,7 +137,7 @@ test "y_array_with_leading_space" {
 }
 
 test "y_array_with_several_null" {
-    ok(
+    roundTrip(
         \\[1,null,null,null,2]
     );
 }
@@ -172,13 +189,13 @@ test "y_number_minus_zero" {
 }
 
 test "y_number_negative_int" {
-    ok(
+    roundTrip(
         \\[-123]
     );
 }
 
 test "y_number_negative_one" {
-    ok(
+    roundTrip(
         \\[-1]
     );
 }
@@ -232,7 +249,7 @@ test "y_number_real_pos_exponent" {
 }
 
 test "y_number_simple_int" {
-    ok(
+    roundTrip(
         \\[123]
     );
 }
@@ -244,7 +261,7 @@ test "y_number_simple_real" {
 }
 
 test "y_object_basic" {
-    ok(
+    roundTrip(
         \\{"asd":"sdf"}
     );
 }
@@ -262,13 +279,13 @@ test "y_object_duplicated_key" {
 }
 
 test "y_object_empty" {
-    ok(
+    roundTrip(
         \\{}
     );
 }
 
 test "y_object_empty_key" {
-    ok(
+    roundTrip(
         \\{"":0}
     );
 }
@@ -298,7 +315,7 @@ test "y_object_long_strings" {
 }
 
 test "y_object_simple" {
-    ok(
+    roundTrip(
         \\{"a":[]}
     );
 }
@@ -348,7 +365,7 @@ test "y_string_backslash_and_u_escaped_zero" {
 }
 
 test "y_string_backslash_doublequotes" {
-    ok(
+    roundTrip(
         \\["\""]
     );
 }
@@ -366,7 +383,7 @@ test "y_string_double_escape_a" {
 }
 
 test "y_string_double_escape_n" {
-    ok(
+    roundTrip(
         \\["\\n"]
     );
 }
@@ -450,7 +467,7 @@ test "y_string_simple_ascii" {
 }
 
 test "y_string_space" {
-    ok(
+    roundTrip(
         \\" "
     );
 }
@@ -568,13 +585,13 @@ test "y_string_with_del_character" {
 }
 
 test "y_structure_lonely_false" {
-    ok(
+    roundTrip(
         \\false
     );
 }
 
 test "y_structure_lonely_int" {
-    ok(
+    roundTrip(
         \\42
     );
 }
@@ -586,37 +603,37 @@ test "y_structure_lonely_negative_real" {
 }
 
 test "y_structure_lonely_null" {
-    ok(
+    roundTrip(
         \\null
     );
 }
 
 test "y_structure_lonely_string" {
-    ok(
+    roundTrip(
         \\"asd"
     );
 }
 
 test "y_structure_lonely_true" {
-    ok(
+    roundTrip(
         \\true
     );
 }
 
 test "y_structure_string_empty" {
-    ok(
+    roundTrip(
         \\""
     );
 }
 
 test "y_structure_trailing_newline" {
-    ok(
+    roundTrip(
         \\["a"]
     );
 }
 
 test "y_structure_true_in_array" {
-    ok(
+    roundTrip(
         \\[true]
     );
 }

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -73,7 +73,7 @@ fn roundTrip(s: []const u8) !void {
 // Additional tests not part of test JSONTestSuite.
 
 test "y_trailing_comma_after_empty" {
-    roundTrip(
+    try roundTrip(
         \\{"1":[],"2":{},"3":"4"}
     );
 }
@@ -87,25 +87,25 @@ test "y_array_arraysWithSpaces" {
 }
 
 test "y_array_empty" {
-    roundTrip(
+    try roundTrip(
         \\[]
     );
 }
 
 test "y_array_empty-string" {
-    roundTrip(
+    try roundTrip(
         \\[""]
     );
 }
 
 test "y_array_ending_with_newline" {
-    roundTrip(
+    try roundTrip(
         \\["a"]
     );
 }
 
 test "y_array_false" {
-    roundTrip(
+    try roundTrip(
         \\[false]
     );
 }
@@ -117,7 +117,7 @@ test "y_array_heterogeneous" {
 }
 
 test "y_array_null" {
-    roundTrip(
+    try roundTrip(
         \\[null]
     );
 }
@@ -136,7 +136,7 @@ test "y_array_with_leading_space" {
 }
 
 test "y_array_with_several_null" {
-    roundTrip(
+    try roundTrip(
         \\[1,null,null,null,2]
     );
 }
@@ -188,13 +188,13 @@ test "y_number_minus_zero" {
 }
 
 test "y_number_negative_int" {
-    roundTrip(
+    try roundTrip(
         \\[-123]
     );
 }
 
 test "y_number_negative_one" {
-    roundTrip(
+    try roundTrip(
         \\[-1]
     );
 }
@@ -248,7 +248,7 @@ test "y_number_real_pos_exponent" {
 }
 
 test "y_number_simple_int" {
-    roundTrip(
+    try roundTrip(
         \\[123]
     );
 }
@@ -260,7 +260,7 @@ test "y_number_simple_real" {
 }
 
 test "y_object_basic" {
-    roundTrip(
+    try roundTrip(
         \\{"asd":"sdf"}
     );
 }
@@ -278,13 +278,13 @@ test "y_object_duplicated_key" {
 }
 
 test "y_object_empty" {
-    roundTrip(
+    try roundTrip(
         \\{}
     );
 }
 
 test "y_object_empty_key" {
-    roundTrip(
+    try roundTrip(
         \\{"":0}
     );
 }
@@ -314,7 +314,7 @@ test "y_object_long_strings" {
 }
 
 test "y_object_simple" {
-    roundTrip(
+    try roundTrip(
         \\{"a":[]}
     );
 }
@@ -364,7 +364,7 @@ test "y_string_backslash_and_u_escaped_zero" {
 }
 
 test "y_string_backslash_doublequotes" {
-    roundTrip(
+    try roundTrip(
         \\["\""]
     );
 }
@@ -382,7 +382,7 @@ test "y_string_double_escape_a" {
 }
 
 test "y_string_double_escape_n" {
-    roundTrip(
+    try roundTrip(
         \\["\\n"]
     );
 }
@@ -466,7 +466,7 @@ test "y_string_simple_ascii" {
 }
 
 test "y_string_space" {
-    roundTrip(
+    try roundTrip(
         \\" "
     );
 }
@@ -584,13 +584,13 @@ test "y_string_with_del_character" {
 }
 
 test "y_structure_lonely_false" {
-    roundTrip(
+    try roundTrip(
         \\false
     );
 }
 
 test "y_structure_lonely_int" {
-    roundTrip(
+    try roundTrip(
         \\42
     );
 }
@@ -602,37 +602,37 @@ test "y_structure_lonely_negative_real" {
 }
 
 test "y_structure_lonely_null" {
-    roundTrip(
+    try roundTrip(
         \\null
     );
 }
 
 test "y_structure_lonely_string" {
-    roundTrip(
+    try roundTrip(
         \\"asd"
     );
 }
 
 test "y_structure_lonely_true" {
-    roundTrip(
+    try roundTrip(
         \\true
     );
 }
 
 test "y_structure_string_empty" {
-    roundTrip(
+    try roundTrip(
         \\""
     );
 }
 
 test "y_structure_trailing_newline" {
-    roundTrip(
+    try roundTrip(
         \\["a"]
     );
 }
 
 test "y_structure_true_in_array" {
-    roundTrip(
+    try roundTrip(
         \\[true]
     );
 }


### PR DESCRIPTION
Remove unnecessary comptime from params, replace `testing.expect(false)` with letting the error propagate for better reporting.

As requested by @ifreund in #8422.