### PR TITLE
Fixed error types for GetSeekPosError

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -223,15 +223,15 @@ pub const File = struct {
         return os.lseek_SET(self.handle, offset);
     }
 
-    pub const GetPosError = os.SeekError || os.FStatError;
+    pub const GetSeekPosError = os.SeekError || os.FStatError;
 
     /// TODO: integrate with async I/O
-    pub fn getPos(self: File) GetPosError!u64 {
+    pub fn getPos(self: File) GetSeekPosError!u64 {
         return os.lseek_CUR_get(self.handle);
     }
 
     /// TODO: integrate with async I/O
-    pub fn getEndPos(self: File) GetPosError!u64 {
+    pub fn getEndPos(self: File) GetSeekPosError!u64 {
         if (builtin.os.tag == .windows) {
             return windows.GetFileSizeEx(self.handle);
         }
@@ -819,7 +819,7 @@ pub const File = struct {
     pub const SeekableStream = io.SeekableStream(
         File,
         SeekError,
-        GetPosError,
+        GetSeekPosError,
         seekTo,
         seekBy,
         getPos,

--- a/lib/std/io/stream_source.zig
+++ b/lib/std/io/stream_source.zig
@@ -5,7 +5,6 @@
 // and substantial portions of the software.
 const std = @import("../std.zig");
 const io = std.io;
-const testing = std.testing;
 
 /// Provides `io.Reader`, `io.Writer`, and `io.SeekableStream` for in-memory buffers as
 /// well as files.
@@ -19,7 +18,7 @@ pub const StreamSource = union(enum) {
     pub const ReadError = std.fs.File.ReadError;
     pub const WriteError = std.fs.File.WriteError;
     pub const SeekError = std.fs.File.SeekError;
-    pub const GetSeekPosError = std.fs.File.GetPosError;
+    pub const GetSeekPosError = std.fs.File.GetSeekPosError;
 
     pub const Reader = io.Reader(*StreamSource, ReadError, read);
     pub const Writer = io.Writer(*StreamSource, WriteError, write);


### PR DESCRIPTION
File used `GetPosError` instead of `GetSeekPosError` making getting error sets for streams dependent on the underlying type.
So this fixes this so the get stream position all use `GetSeekPosError` like for fixed buffer stream.