### PR TITLE
stage2: wasm - "Hello world"

### DIFF
--- a/lib/std/wasm.zig
+++ b/lib/std/wasm.zig
@@ -280,3 +280,6 @@ pub const block_empty: u8 = 0x40;
 // binary constants
 pub const magic = [_]u8{ 0x00, 0x61, 0x73, 0x6D }; // \0asm
 pub const version = [_]u8{ 0x01, 0x00, 0x00, 0x00 }; // version 1
+
+// Each wasm page size is 64kB
+pub const page_size = 64 * 1024;

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3842,7 +3842,7 @@ fn allocateNewDecl(
             .elf => .{ .elf = link.File.Elf.SrcFn.empty },
             .macho => .{ .macho = link.File.MachO.SrcFn.empty },
             .c => .{ .c = link.File.C.FnBlock.empty },
-            .wasm => .{ .wasm = null },
+            .wasm => .{ .wasm = .{} },
             .spirv => .{ .spirv = .{} },
         },
         .generation = 0,

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3029,9 +3029,12 @@ fn astgenAndSemaVarDecl(
         };
         defer gen_scope.instructions.deinit(mod.gpa);
 
-        const init_result_loc: AstGen.ResultLoc = if (var_decl.ast.type_node != 0) .{
-            .ty = try AstGen.expr(&gen_scope, &gen_scope.base, .{ .ty = .type_type }, var_decl.ast.type_node),
-        } else .none;
+        const init_result_loc: AstGen.ResultLoc = if (var_decl.ast.type_node != 0)
+            .{
+                .ty = try AstGen.expr(&gen_scope, &gen_scope.base, .{ .ty = .type_type }, var_decl.ast.type_node),
+            }
+        else
+            .none;
 
         const init_inst = try AstGen.comptimeExpr(
             &gen_scope,
@@ -3834,7 +3837,7 @@ fn allocateNewDecl(
             .elf => .{ .elf = link.File.Elf.TextBlock.empty },
             .macho => .{ .macho = link.File.MachO.TextBlock.empty },
             .c => .{ .c = link.File.C.DeclBlock.empty },
-            .wasm => .{ .wasm = {} },
+            .wasm => .{ .wasm = link.File.Wasm.DeclBlock.empty },
             .spirv => .{ .spirv = {} },
         },
         .fn_link = switch (mod.comp.bin_file.tag) {
@@ -3842,7 +3845,7 @@ fn allocateNewDecl(
             .elf => .{ .elf = link.File.Elf.SrcFn.empty },
             .macho => .{ .macho = link.File.MachO.SrcFn.empty },
             .c => .{ .c = link.File.C.FnBlock.empty },
-            .wasm => .{ .wasm = .{} },
+            .wasm => .{ .wasm = link.File.Wasm.FnData.empty },
             .spirv => .{ .spirv = .{} },
         },
         .generation = 0,

--- a/src/codegen/wasm.zig
+++ b/src/codegen/wasm.zig
@@ -622,9 +622,9 @@ pub const Context = struct {
                 // Write instructions
                 // TODO: check for and handle death of instructions
                 const mod_fn = blk: {
-                    if (tv.val.castTag(.function)) |func| break :blk func.data;
-                    if (tv.val.castTag(.extern_fn)) |ext_fn| return Result.appended; // don't need code body for extern functions
-                    return self.fail(.{ .node_offset = 0 }, "TODO: Wasm codegen for decl type '{s}'", .{tv.ty.tag()});
+                    if (typed_value.val.castTag(.function)) |func| break :blk func.data;
+                    if (typed_value.val.castTag(.extern_fn)) |ext_fn| return Result.appended; // don't need code body for extern functions
+                    return self.fail(.{ .node_offset = 0 }, "TODO: Wasm codegen for decl type '{s}'", .{typed_value.ty.tag()});
                 };
 
                 // Reserve space to write the size after generating the code as well as space for locals count
@@ -686,9 +686,9 @@ pub const Context = struct {
                     try self.code.append(@intCast(u8, int_byte));
                     return Result.appended;
                 }
-                return self.fail(self.decl.src(), "TODO: Implement codegen for int type: '{}'", .{typed_value.ty});
+                return self.fail(.{ .node_offset = 0 }, "TODO: Implement codegen for int type: '{}'", .{typed_value.ty});
             },
-            else => |tag| return self.fail(self.decl.src(), "TODO: Implement zig type codegen for type: '{s}'", .{tag}),
+            else => |tag| return self.fail(.{ .node_offset = 0 }, "TODO: Implement zig type codegen for type: '{s}'", .{tag}),
         }
     }
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -138,7 +138,7 @@ pub const File = struct {
         coff: Coff.TextBlock,
         macho: MachO.TextBlock,
         c: C.DeclBlock,
-        wasm: void,
+        wasm: Wasm.DeclBlock,
         spirv: void,
     };
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -147,7 +147,7 @@ pub const File = struct {
         coff: Coff.SrcFn,
         macho: MachO.SrcFn,
         c: C.FnBlock,
-        wasm: ?Wasm.FnData,
+        wasm: Wasm.FnData,
         spirv: SpirV.FnData,
     };
 
@@ -328,7 +328,8 @@ pub const File = struct {
             .elf => return @fieldParentPtr(Elf, "base", base).allocateDeclIndexes(decl),
             .macho => return @fieldParentPtr(MachO, "base", base).allocateDeclIndexes(decl),
             .c => return @fieldParentPtr(C, "base", base).allocateDeclIndexes(decl),
-            .wasm, .spirv => {},
+            .wasm => return @fieldParentPtr(Wasm, "base", base).allocateDeclIndexes(decl),
+            .spirv => {},
         }
     }
 


### PR DESCRIPTION
~~Note: conflicts with https://github.com/ziglang/zig/pull/8416. Will rebase after merge.~~

This PR implements arrays and the 'data' and 'mem' sections of wasm, allowing
for the following to work (including incremental compilation):
```zig
extern fn print(s: [*:0]const u8, len: i32) void;

pub export fn helloWorld() void {
    print("Hello, world!", 13);
}
```
Using the following JS:
```js
const fs = require('fs');
const source = fs.readFileSync("./test.wasm");
const typedArray = new Uint8Array(source);
var buffer = null;

WebAssembly.instantiate(typedArray, {
  env: {
    print: (offset, len) => {
        
        let s = "";
        for (let i = offset; i < offset + len; i++)
        	s += String.fromCharCode(buffer[i]);
        console.log(`The result is ${s}`); }

  }}).then(result => {
  	buffer = new Uint8Array(result.instance.exports.memory.buffer);
  	const helloWorld = result.instance.exports.helloWorld;
  	helloWorld();
});
```
Results in the following:
```sh
> node test test.js
> The result is Hello, world!
```
