### PR TITLE
std/build: fix ?[:0]const u8 build options

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1939,6 +1939,15 @@ pub const LibExeObjStep = struct {
                 out.print("pub const {}: []const u8 = \"{}\";\n", .{ std.zig.fmtId(name), std.zig.fmtEscapes(value) }) catch unreachable;
                 return;
             },
+            ?[:0]const u8 => {
+                out.print("pub const {}: ?[:0]const u8 = ", .{std.zig.fmtId(name)}) catch unreachable;
+                if (value) |payload| {
+                    out.print("\"{}\";\n", .{std.zig.fmtEscapes(payload)}) catch unreachable;
+                } else {
+                    out.writeAll("null;\n") catch unreachable;
+                }
+                return;
+            },
             ?[]const u8 => {
                 out.print("pub const {}: ?[]const u8 = ", .{std.zig.fmtId(name)}) catch unreachable;
                 if (value) |payload| {


### PR DESCRIPTION
As per the other string types, `?[:0]const u8` needs its own case as otherwise it will raise an error about using `{}` with slices.

There's no reasonable workaround for this, as you would have to either discount the use of the empty string value or manually rework the string to be sentinel-terminated at runtime. It's useful for passing build options to code making use of C libraries that make strong use of sentinel-terminated arrays for strings.