### PR TITLE
stage2: Default AVR generic cpu to avr2

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1170,7 +1170,7 @@ pub const Target = struct {
                 return switch (arch) {
                     .arm, .armeb, .thumb, .thumbeb => &arm.cpu.generic,
                     .aarch64, .aarch64_be, .aarch64_32 => &aarch64.cpu.generic,
-                    .avr => &avr.cpu.avr1,
+                    .avr => &avr.cpu.avr2,
                     .bpfel, .bpfeb => &bpf.cpu.generic,
                     .hexagon => &hexagon.cpu.generic,
                     .mips, .mipsel => &mips.cpu.mips32,


### PR DESCRIPTION
The avr1 target is a very minimal subset of the AVR ISA, quoting the GCC
manual:

> This ISA is implemented by the minimal AVR core and supported for
> assembler only.

Default to avr2 as GCC and Clang do.