### PR TITLE
stage1: Work around a small problem in LLVM API

### DIFF
--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -153,6 +153,11 @@ LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Tri
     }
 
     TargetOptions opt;
+
+    // Work around the missing initialization of this field in the default
+    // constructor. Use -1 so that the default value is used.
+    opt.StackProtectorGuardOffset = (unsigned)-1;
+
     opt.FunctionSections = function_sections;
     switch (float_abi) {
         case ZigLLVMABITypeDefault:


### PR DESCRIPTION
The missing initializer for a single field in the TargetOptions class
was enough to turn the stack protectors into hot garbage.

Fixes #8408