### PR TITLE
stage2: add initial support for start.zig

### DIFF
--- a/lib/std/start2.zig
+++ b/lib/std/start2.zig
@@ -1,0 +1,58 @@
+const root = @import("root");
+const builtin = @import("builtin");
+
+comptime {
+    if (builtin.output_mode == 0) { // OutputMode.Exe
+        if (builtin.link_libc or builtin.object_format == 5) { // ObjectFormat.c
+            if (!@hasDecl(root, "main")) {
+                @export(otherMain, "main");
+            }
+        } else {
+            if (!@hasDecl(root, "_start")) {
+                @export(otherStart, "_start");
+            }
+        }
+    }
+}
+
+// FIXME: Cannot call this function `main`, because `fully qualified names`
+//        have not been implemented yet.
+fn otherMain() callconv(.C) c_int {
+    root.zigMain();
+    return 0;
+}
+
+// FIXME: Cannot call this function `_start`, because `fully qualified names`
+//        have not been implemented yet.
+fn otherStart() callconv(.Naked) noreturn {
+    root.zigMain();
+    otherExit();
+}
+
+// FIXME: Cannot call this function `exit`, because `fully qualified names`
+//        have not been implemented yet.
+fn otherExit() noreturn {
+    if (builtin.arch == 31) { // x86_64
+        asm volatile ("syscall"
+            :
+            : [number] "{rax}" (231),
+              [arg1] "{rdi}" (0)
+            : "rcx", "r11", "memory"
+        );
+    } else if (builtin.arch == 0) { // arm
+        asm volatile ("svc #0"
+            :
+            : [number] "{r7}" (1),
+              [arg1] "{r0}" (0)
+            : "memory"
+        );
+    } else if (builtin.arch == 2) { // aarch64
+        asm volatile ("svc #0"
+            :
+            : [number] "{x8}" (93),
+              [arg1] "{x0}" (0)
+            : "memory", "cc"
+        );
+    } else @compileError("not yet supported!");
+    unreachable;
+}

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -1245,6 +1245,7 @@ fn blockExprStmts(
                         .fn_type_var_args,
                         .fn_type_cc,
                         .fn_type_cc_var_args,
+                        .has_decl,
                         .int,
                         .float,
                         .float128,
@@ -4159,6 +4160,16 @@ fn builtinCall(
             return rvalue(gz, scope, rl, .void_value, node);
         },
 
+        .has_decl => {
+            const container_type = try typeExpr(gz, scope, params[0]);
+            const name = try comptimeExpr(gz, scope, .{ .ty = .const_slice_u8_type }, params[1]);
+            const result = try gz.addPlNode(.has_decl, node, zir.Inst.Bin{
+                .lhs = container_type,
+                .rhs = name,
+            });
+            return rvalue(gz, scope, rl, result, node);
+        },
+
         .add_with_overflow,
         .align_cast,
         .align_of,
@@ -4191,7 +4202,6 @@ fn builtinCall(
         .fence,
         .field_parent_ptr,
         .float_to_int,
-        .has_decl,
         .has_field,
         .int_to_float,
         .int_to_ptr,

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -1336,6 +1336,7 @@ fn blockExprStmts(
                         .dbg_stmt_node,
                         .ensure_result_used,
                         .ensure_result_non_error,
+                        .@"export",
                         .set_eval_branch_quota,
                         .compile_log,
                         .ensure_err_payload_void,
@@ -4146,6 +4147,18 @@ fn builtinCall(
             return rvalue(gz, scope, rl, result, node);
         },
 
+        .@"export" => {
+            const target_fn = try expr(gz, scope, .none, params[0]);
+            // FIXME: When structs work in stage2, actually implement this correctly!
+            //        Currently the name is always signifies Strong linkage.
+            const export_name = try comptimeExpr(gz, scope, .{ .ty = .const_slice_u8_type }, params[1]);
+            _ = try gz.addPlNode(.@"export", node, zir.Inst.Bin{
+                .lhs = target_fn,
+                .rhs = export_name,
+            });
+            return rvalue(gz, scope, rl, .void_value, node);
+        },
+
         .add_with_overflow,
         .align_cast,
         .align_of,
@@ -4175,7 +4188,6 @@ fn builtinCall(
         .error_name,
         .error_return_trace,
         .err_set_cast,
-        .@"export",
         .fence,
         .field_parent_ptr,
         .float_to_int,

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -35,8 +35,11 @@ comp: *Compilation,
 zig_cache_artifact_directory: Compilation.Directory,
 /// Pointer to externally managed resource. `null` if there is no zig file being compiled.
 root_pkg: *Package,
+/// This is populated when `@import("root")` is analysed.
+root_scope: ?*Scope.File,
+start_pkg: *Package,
 /// Module owns this resource.
-root_scope: *Scope.File,
+start_scope: *Scope.File,
 /// It's rare for a decl to be exported, so we save memory by having a sparse map of
 /// Decl pointers to details about them being exported.
 /// The Export memory is owned by the `export_owners` table; the slice itself is owned by this table.
@@ -2341,7 +2344,9 @@ pub fn deinit(mod: *Module) void {
     mod.export_owners.deinit(gpa);
 
     mod.symbol_exports.deinit(gpa);
-    mod.root_scope.destroy(gpa);
+
+    mod.start_scope.destroy(gpa);
+    mod.start_pkg.destroy(gpa);
 
     var it = mod.global_error_set.iterator();
     while (it.next()) |entry| {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2863,8 +2863,9 @@ fn astgenAndSemaFn(
 
         _ = try AstGen.expr(&gen_scope, params_scope, .none, body_node);
 
-        if (gen_scope.instructions.items.len == 0 or
-            !astgen.instructions.items(.tag)[gen_scope.instructions.items.len - 1]
+        const inst_tags = astgen.instructions.items(.tag);
+        if (inst_tags.len == 0 or
+            !inst_tags[inst_tags.len - 1]
             .isNoReturn())
         {
             // astgen uses result location semantics to coerce return operands.

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2513,6 +2513,7 @@ fn astgenAndSemaDecl(mod: *Module, decl: *Decl) !bool {
 
                 const block_expr = node_datas[decl_node].lhs;
                 _ = try AstGen.comptimeExpr(&gen_scope, &gen_scope.base, .none, block_expr);
+                _ = try gen_scope.addBreak(.break_inline, gen_scope.break_block, .void_value);
 
                 const code = try gen_scope.finish();
                 if (std.builtin.mode == .Debug and mod.comp.verbose_ir) {

--- a/src/Package.zig
+++ b/src/Package.zig
@@ -58,7 +58,9 @@ pub fn destroy(pkg: *Package, gpa: *Allocator) void {
     {
         var it = pkg.table.iterator();
         while (it.next()) |kv| {
-            kv.value.destroy(gpa);
+            if (pkg != kv.value) {
+                kv.value.destroy(gpa);
+            }
             gpa.free(kv.key);
         }
     }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4699,7 +4699,7 @@ fn namedFieldPtr(
                         }
 
                         // TODO this will give false positives for structs inside the root file
-                        if (container_scope.file_scope == mod.root_scope) {
+                        if (container_scope.file_scope == mod.root_scope.?) {
                             return mod.fail(
                                 &block.base,
                                 src,
@@ -5338,6 +5338,9 @@ fn analyzeImport(sema: *Sema, block: *Scope.Block, src: LazySrcLoc, target_strin
             .ty = struct_ty,
         },
     };
+    if (mem.eql(u8, target_string, "root")) {
+        sema.mod.root_scope = file_scope;
+    }
     sema.mod.analyzeContainer(&file_scope.root_container) catch |err| switch (err) {
         error.AnalysisFail => {
             assert(sema.mod.comp.totalErrorCount() != 0);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1732,6 +1732,8 @@ fn buildOutputType(
         },
     }
 
+    // This gets cleaned up, because root_pkg becomes part of the
+    // package table of the start_pkg.
     const root_pkg: ?*Package = if (root_src_file) |src_path| blk: {
         if (main_pkg_path) |p| {
             const rel_src_path = try fs.path.relative(gpa, p, src_path);
@@ -1741,7 +1743,6 @@ fn buildOutputType(
             break :blk try Package.create(gpa, fs.path.dirname(src_path), fs.path.basename(src_path));
         }
     } else null;
-    defer if (root_pkg) |p| p.destroy(gpa);
 
     // Transfer packages added with --pkg-begin/--pkg-end to the root package
     if (root_pkg) |pkg| {

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -364,6 +364,9 @@ pub const Inst = struct {
         fn_type_cc,
         /// Same as `fn_type_cc` but the function is variadic.
         fn_type_cc_var_args,
+        /// Determines whether a container has a declaration matching name.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
+        has_decl,
         /// `@import(operand)`.
         /// Uses the `un_node` field.
         import,
@@ -751,6 +754,7 @@ pub const Inst = struct {
                 .fn_type_var_args,
                 .fn_type_cc,
                 .fn_type_cc_var_args,
+                .has_decl,
                 .int,
                 .float,
                 .float128,
@@ -1681,6 +1685,7 @@ const Writer = struct {
             .cmp_gt,
             .cmp_neq,
             .div,
+            .has_decl,
             .mod_rem,
             .shl,
             .shr,

--- a/src/zir.zig
+++ b/src/zir.zig
@@ -328,6 +328,10 @@ pub const Inst = struct {
         error_union_type,
         /// `error.Foo` syntax. Uses the `str_tok` field of the Data union.
         error_value,
+        /// Exports a function with a specified name. This can be used at comptime
+        /// to export a function conditionally.
+        /// Uses the `pl_node` union field. Payload is `Bin`.
+        @"export",
         /// Given a pointer to a struct or object that contains virtual fields, returns a pointer
         /// to the named field. The field name is stored in string_bytes. Used by a.b syntax.
         /// Uses `pl_node` field. The AST node is the a.b syntax. Payload is Field.
@@ -737,6 +741,7 @@ pub const Inst = struct {
                 .elem_val_node,
                 .ensure_result_used,
                 .ensure_result_non_error,
+                .@"export",
                 .floatcast,
                 .field_ptr,
                 .field_val,
@@ -1682,6 +1687,7 @@ const Writer = struct {
             .xor,
             .store_node,
             .error_union_type,
+            .@"export",
             .merge_error_sets,
             .bit_and,
             .bit_or,


### PR DESCRIPTION
This is a draft, because i would like to get some feedback on the current structure of the code.

For example, the current code does not work correctly in the CBE, because `main` is now static and the c compiler does not like this (Probably the CBE does not take into account the exported name). `Container.fullyQualifiedNameHash` has to be implemented (I think), however I'm unsure how to do that.

Positive news:
`zig build-exe main.zig` works!
```zig
pub fn main() void {}
```

After the feedback I can fixup all the testcases :)