### PR TITLE
stage2: delete allowing input (and output) zir from the pipeline

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -939,11 +939,6 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
             // However we currently do not have serialization of such metadata, so for now
             // we set up an empty Module that does the entire compilation fresh.
 
-            // TODO remove CLI support for .zir files and then we can remove this error
-            // handling and assertion.
-            if (mem.endsWith(u8, root_pkg.root_src_path, ".zir")) return error.ZirFilesUnsupported;
-            assert(mem.endsWith(u8, root_pkg.root_src_path, ".zig"));
-
             const root_scope = try gpa.create(Module.Scope.File);
             errdefer gpa.destroy(root_scope);
 
@@ -2487,7 +2482,7 @@ pub fn addCCArgs(
                 try argv.append("-fPIC");
             }
         },
-        .shared_library, .assembly, .ll, .bc, .unknown, .static_library, .object, .zig, .zir => {},
+        .shared_library, .assembly, .ll, .bc, .unknown, .static_library, .object, .zig => {},
     }
     if (out_dep_path) |p| {
         try argv.appendSlice(&[_][]const u8{ "-MD", "-MV", "-MF", p });
@@ -2561,7 +2556,6 @@ pub const FileExt = enum {
     object,
     static_library,
     zig,
-    zir,
     unknown,
 
     pub fn clangSupportsDepFile(ext: FileExt) bool {
@@ -2575,7 +2569,6 @@ pub const FileExt = enum {
             .object,
             .static_library,
             .zig,
-            .zir,
             .unknown,
             => false,
         };
@@ -2647,8 +2640,6 @@ pub fn classifyFileExt(filename: []const u8) FileExt {
         return .h;
     } else if (mem.endsWith(u8, filename, ".zig")) {
         return .zig;
-    } else if (mem.endsWith(u8, filename, ".zir")) {
-        return .zir;
     } else if (hasSharedLibraryExt(filename)) {
         return .shared_library;
     } else if (hasStaticLibraryExt(filename)) {
@@ -2669,7 +2660,6 @@ test "classifyFileExt" {
     std.testing.expectEqual(FileExt.shared_library, classifyFileExt("foo.so.1.2.3"));
     std.testing.expectEqual(FileExt.unknown, classifyFileExt("foo.so.1.2.3~"));
     std.testing.expectEqual(FileExt.zig, classifyFileExt("foo.zig"));
-    std.testing.expectEqual(FileExt.zir, classifyFileExt("foo.zir"));
 }
 
 fn haveFramePointer(comp: *const Compilation) bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -505,7 +505,6 @@ fn buildOutputType(
     var emit_bin: EmitBin = .yes_default_path;
     var emit_asm: Emit = .no;
     var emit_llvm_ir: Emit = .no;
-    var emit_zir: Emit = .no;
     var emit_docs: Emit = .no;
     var emit_analysis: Emit = .no;
     var target_arch_os_abi: []const u8 = "native";
@@ -923,12 +922,6 @@ fn buildOutputType(
                         emit_bin = .{ .yes = arg["-femit-bin=".len..] };
                     } else if (mem.eql(u8, arg, "-fno-emit-bin")) {
                         emit_bin = .no;
-                    } else if (mem.eql(u8, arg, "-femit-zir")) {
-                        emit_zir = .yes_default_path;
-                    } else if (mem.startsWith(u8, arg, "-femit-zir=")) {
-                        emit_zir = .{ .yes = arg["-femit-zir=".len..] };
-                    } else if (mem.eql(u8, arg, "-fno-emit-zir")) {
-                        emit_zir = .no;
                     } else if (mem.eql(u8, arg, "-femit-h")) {
                         emit_h = .yes_default_path;
                     } else if (mem.startsWith(u8, arg, "-femit-h=")) {
@@ -1723,13 +1716,6 @@ fn buildOutputType(
 
     var emit_docs_resolved = try emit_docs.resolve("docs");
     defer emit_docs_resolved.deinit();
-
-    switch (emit_zir) {
-        .no => {},
-        .yes_default_path, .yes => {
-            fatal("The -femit-zir implementation has been intentionally deleted so that it can be rewritten as a proper backend.", .{});
-        },
-    }
 
     const root_pkg: ?*Package = if (root_src_file) |src_path| blk: {
         if (main_pkg_path) |p| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1025,7 +1025,7 @@ fn buildOutputType(
                             .extra_flags = try arena.dupe([]const u8, extra_cflags.items),
                         });
                     },
-                    .zig, .zir => {
+                    .zig => {
                         if (root_src_file) |other| {
                             fatal("found another zig file '{s}' after root source file '{s}'", .{ arg, other });
                         } else {
@@ -1086,7 +1086,7 @@ fn buildOutputType(
                             .unknown, .shared_library, .object, .static_library => {
                                 try link_objects.append(it.only_arg);
                             },
-                            .zig, .zir => {
+                            .zig => {
                                 if (root_src_file) |other| {
                                     fatal("found another zig file '{s}' after root source file '{s}'", .{ it.only_arg, other });
                                 } else {

--- a/src/test.zig
+++ b/src/test.zig
@@ -122,11 +122,6 @@ pub const TestContext = struct {
         path: []const u8,
     };
 
-    pub const Extension = enum {
-        Zig,
-        ZIR,
-    };
-
     /// A `Case` consists of a list of `Update`. The same `Compilation` is used for each
     /// update, so each update's source is treated as a single file being
     /// updated by the test harness and incrementally compiled.
@@ -141,7 +136,6 @@ pub const TestContext = struct {
         /// to Executable.
         output_mode: std.builtin.OutputMode,
         updates: std.ArrayList(Update),
-        extension: Extension,
         object_format: ?std.builtin.ObjectFormat = null,
         emit_h: bool = false,
         llvm_backend: bool = false,
@@ -238,14 +232,12 @@ pub const TestContext = struct {
         ctx: *TestContext,
         name: []const u8,
         target: CrossTarget,
-        extension: Extension,
     ) *Case {
         ctx.cases.append(Case{
             .name = name,
             .target = target,
             .updates = std.ArrayList(Update).init(ctx.cases.allocator),
             .output_mode = .Exe,
-            .extension = extension,
             .files = std.ArrayList(File).init(ctx.cases.allocator),
         }) catch @panic("out of memory");
         return &ctx.cases.items[ctx.cases.items.len - 1];
@@ -253,7 +245,7 @@ pub const TestContext = struct {
 
     /// Adds a test case for Zig input, producing an executable
     pub fn exe(ctx: *TestContext, name: []const u8, target: CrossTarget) *Case {
-        return ctx.addExe(name, target, .Zig);
+        return ctx.addExe(name, target);
     }
 
     /// Adds a test case for ZIR input, producing an executable
@@ -269,7 +261,6 @@ pub const TestContext = struct {
             .target = target,
             .updates = std.ArrayList(Update).init(ctx.cases.allocator),
             .output_mode = .Exe,
-            .extension = .Zig,
             .object_format = .c,
             .files = std.ArrayList(File).init(ctx.cases.allocator),
         }) catch @panic("out of memory");
@@ -284,7 +275,6 @@ pub const TestContext = struct {
             .target = target,
             .updates = std.ArrayList(Update).init(ctx.cases.allocator),
             .output_mode = .Exe,
-            .extension = .Zig,
             .files = std.ArrayList(File).init(ctx.cases.allocator),
             .llvm_backend = true,
         }) catch @panic("out of memory");
@@ -295,14 +285,12 @@ pub const TestContext = struct {
         ctx: *TestContext,
         name: []const u8,
         target: CrossTarget,
-        extension: Extension,
     ) *Case {
         ctx.cases.append(Case{
             .name = name,
             .target = target,
             .updates = std.ArrayList(Update).init(ctx.cases.allocator),
             .output_mode = .Obj,
-            .extension = extension,
             .files = std.ArrayList(File).init(ctx.cases.allocator),
         }) catch @panic("out of memory");
         return &ctx.cases.items[ctx.cases.items.len - 1];
@@ -310,7 +298,7 @@ pub const TestContext = struct {
 
     /// Adds a test case for Zig input, producing an object file.
     pub fn obj(ctx: *TestContext, name: []const u8, target: CrossTarget) *Case {
-        return ctx.addObj(name, target, .Zig);
+        return ctx.addObj(name, target);
     }
 
     /// Adds a test case for ZIR input, producing an object file.
@@ -319,13 +307,12 @@ pub const TestContext = struct {
     }
 
     /// Adds a test case for Zig or ZIR input, producing C code.
-    pub fn addC(ctx: *TestContext, name: []const u8, target: CrossTarget, ext: Extension) *Case {
+    pub fn addC(ctx: *TestContext, name: []const u8, target: CrossTarget) *Case {
         ctx.cases.append(Case{
             .name = name,
             .target = target,
             .updates = std.ArrayList(Update).init(ctx.cases.allocator),
             .output_mode = .Obj,
-            .extension = ext,
             .object_format = .c,
             .files = std.ArrayList(File).init(ctx.cases.allocator),
         }) catch @panic("out of memory");
@@ -333,21 +320,20 @@ pub const TestContext = struct {
     }
 
     pub fn c(ctx: *TestContext, name: []const u8, target: CrossTarget, src: [:0]const u8, comptime out: [:0]const u8) void {
-        ctx.addC(name, target, .Zig).addCompareObjectFile(src, zig_h ++ out);
+        ctx.addC(name, target).addCompareObjectFile(src, zig_h ++ out);
     }
 
     pub fn h(ctx: *TestContext, name: []const u8, target: CrossTarget, src: [:0]const u8, comptime out: [:0]const u8) void {
-        ctx.addC(name, target, .Zig).addHeader(src, zig_h ++ out);
+        ctx.addC(name, target).addHeader(src, zig_h ++ out);
     }
 
     pub fn addCompareOutput(
         ctx: *TestContext,
         name: []const u8,
-        extension: Extension,
         src: [:0]const u8,
         expected_stdout: []const u8,
     ) void {
-        ctx.addExe(name, .{}, extension).addCompareOutput(src, expected_stdout);
+        ctx.addExe(name, .{}).addCompareOutput(src, expected_stdout);
     }
 
     /// Adds a test case that compiles the Zig source given in `src`, executes
@@ -358,7 +344,7 @@ pub const TestContext = struct {
         src: [:0]const u8,
         expected_stdout: []const u8,
     ) void {
-        return ctx.addCompareOutput(name, .Zig, src, expected_stdout);
+        return ctx.addCompareOutput(name, src, expected_stdout);
     }
 
     /// Adds a test case that compiles the ZIR source given in `src`, executes
@@ -376,11 +362,10 @@ pub const TestContext = struct {
         ctx: *TestContext,
         name: []const u8,
         target: CrossTarget,
-        extension: Extension,
         src: [:0]const u8,
         result: [:0]const u8,
     ) void {
-        ctx.addObj(name, target, extension).addTransform(src, result);
+        ctx.addObj(name, target).addTransform(src, result);
     }
 
     /// Adds a test case that compiles the Zig given in `src` to ZIR and tests
@@ -392,7 +377,7 @@ pub const TestContext = struct {
         src: [:0]const u8,
         result: [:0]const u8,
     ) void {
-        ctx.addTransform(name, target, .Zig, src, result);
+        ctx.addTransform(name, target, src, result);
     }
 
     /// Adds a test case that cleans up the ZIR source given in `src`, and
@@ -411,11 +396,10 @@ pub const TestContext = struct {
         ctx: *TestContext,
         name: []const u8,
         target: CrossTarget,
-        extension: Extension,
         src: [:0]const u8,
         expected_errors: []const []const u8,
     ) void {
-        ctx.addObj(name, target, extension).addError(src, expected_errors);
+        ctx.addObj(name, target).addError(src, expected_errors);
     }
 
     /// Adds a test case that ensures that the Zig given in `src` fails to
@@ -428,7 +412,7 @@ pub const TestContext = struct {
         src: [:0]const u8,
         expected_errors: []const []const u8,
     ) void {
-        ctx.addError(name, target, .Zig, src, expected_errors);
+        ctx.addError(name, target, src, expected_errors);
     }
 
     /// Adds a test case that ensures that the ZIR given in `src` fails to
@@ -448,10 +432,9 @@ pub const TestContext = struct {
         ctx: *TestContext,
         name: []const u8,
         target: CrossTarget,
-        extension: Extension,
         src: [:0]const u8,
     ) void {
-        ctx.addObj(name, target, extension).compiles(src);
+        ctx.addObj(name, target).compiles(src);
     }
 
     /// Adds a test case that asserts that the Zig given in `src` compiles
@@ -462,7 +445,7 @@ pub const TestContext = struct {
         target: CrossTarget,
         src: [:0]const u8,
     ) void {
-        ctx.addCompiles(name, target, .Zig, src);
+        ctx.addCompiles(name, target, src);
     }
 
     /// Adds a test case that asserts that the ZIR given in `src` compiles
@@ -489,7 +472,7 @@ pub const TestContext = struct {
         expected_errors: []const []const u8,
         fixed_src: [:0]const u8,
     ) void {
-        var case = ctx.addObj(name, target, .Zig);
+        var case = ctx.addObj(name, target);
         case.addError(src, expected_errors);
         case.compiles(fixed_src);
     }
@@ -614,10 +597,7 @@ pub const TestContext = struct {
             .path = try std.fs.path.join(arena, &[_][]const u8{ tmp_dir_path, "zig-cache" }),
         };
 
-        const tmp_src_path = switch (case.extension) {
-            .Zig => "test_case.zig",
-            .ZIR => "test_case.zir",
-        };
+        const tmp_src_path = "test_case.zig";
 
         var root_pkg: Package = .{
             .root_src_directory = .{ .path = tmp_dir_path, .handle = tmp.dir },


### PR DESCRIPTION
This removes a TODO that asserts the file is not zir.

~~Should I also remove -femit-zir, or is that left in intentionally as a TODO for a backend?~~ yagni!