### PR TITLE
callconv: add SysV

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -165,6 +165,7 @@ pub const CallingConvention = enum {
     APCS,
     AAPCS,
     AAPCSVFP,
+    SysV
 };
 
 /// This data structure is used by the Zig language code generation and

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -84,6 +84,7 @@ enum CallingConvention {
     CallingConventionAPCS,
     CallingConventionAAPCS,
     CallingConventionAAPCSVFP,
+    CallingConventionSysV
 };
 
 // This one corresponds to the builtin.zig enum.

--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -1971,10 +1971,10 @@ Error emit_error_unless_callconv_allowed_for_target(CodeGen *g, AstNode *source_
         case CallingConventionAAPCSVFP:
             if (!target_is_arm(g->zig_target))
                 allowed_platforms = "ARM";
+            break;
         case CallingConventionSysV:
             if (g->zig_target->arch != ZigLLVM_x86_64)
                 allowed_platforms = "x86_64";
-            break;
     }
     if (allowed_platforms != nullptr) {
         add_node_error(g, source_node, buf_sprintf(

--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -974,6 +974,7 @@ const char *calling_convention_name(CallingConvention cc) {
         case CallingConventionAAPCS: return "AAPCS";
         case CallingConventionAAPCSVFP: return "AAPCSVFP";
         case CallingConventionInline: return "Inline";
+        case CallingConventionSysV: return "SysV";
     }
     zig_unreachable();
 }
@@ -995,6 +996,7 @@ bool calling_convention_allows_zig_types(CallingConvention cc) {
         case CallingConventionAPCS:
         case CallingConventionAAPCS:
         case CallingConventionAAPCSVFP:
+        case CallingConventionSysV:
             return false;
     }
     zig_unreachable();
@@ -1969,6 +1971,10 @@ Error emit_error_unless_callconv_allowed_for_target(CodeGen *g, AstNode *source_
         case CallingConventionAAPCSVFP:
             if (!target_is_arm(g->zig_target))
                 allowed_platforms = "ARM";
+        case CallingConventionSysV:
+            if (g->zig_target->arch != ZigLLVM_x86_64)
+                allowed_platforms = "x86_64";
+            break;
     }
     if (allowed_platforms != nullptr) {
         add_node_error(g, source_node, buf_sprintf(
@@ -3805,6 +3811,7 @@ static void resolve_decl_fn(CodeGen *g, TldFn *tld_fn) {
                 case CallingConventionAPCS:
                 case CallingConventionAAPCS:
                 case CallingConventionAAPCSVFP:
+                case CallingConventionSysV:
                     add_fn_export(g, fn_table_entry, buf_ptr(&fn_table_entry->symbol_name),
                                   GlobalLinkageIdStrong, fn_cc);
                     break;

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -204,6 +204,9 @@ static ZigLLVM_CallingConv get_llvm_cc(CodeGen *g, CallingConvention cc) {
         case CallingConventionSignal:
             assert(g->zig_target->arch == ZigLLVM_avr);
             return ZigLLVM_AVR_SIGNAL;
+        case CallingConventionSysV:
+            assert(g->zig_target->arch == ZigLLVM_x86_64);
+            return ZigLLVM_X86_64_SysV;
     }
     zig_unreachable();
 }
@@ -348,6 +351,7 @@ static bool cc_want_sret_attr(CallingConvention cc) {
         case CallingConventionAPCS:
         case CallingConventionAAPCS:
         case CallingConventionAAPCSVFP:
+        case CallingConventionSysV:
             return true;
         case CallingConventionAsync:
         case CallingConventionUnspecified:
@@ -9101,6 +9105,7 @@ Buf *codegen_generate_builtin_source(CodeGen *g) {
     static_assert(CallingConventionAPCS == 11, "");
     static_assert(CallingConventionAAPCS == 12, "");
     static_assert(CallingConventionAAPCSVFP == 13, "");
+    static_assert(CallingConventionSysV == 14, "");
 
     static_assert(BuiltinPtrSizeOne == 0, "");
     static_assert(BuiltinPtrSizeMany == 1, "");

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -19223,6 +19223,7 @@ static IrInstGen *ir_analyze_instruction_export(IrAnalyze *ira, IrInstSrcExport 
                 case CallingConventionAPCS:
                 case CallingConventionAAPCS:
                 case CallingConventionAAPCSVFP:
+                case CallingConventionSysV:
                     add_fn_export(ira->codegen, fn_entry, buf_ptr(symbol_name), global_linkage_id, cc);
                     fn_entry->section_name = section_name;
                     break;

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -4381,6 +4381,7 @@ fn transCC(
         .X86ThisCall => return CallingConvention.Thiscall,
         .AAPCS => return CallingConvention.AAPCS,
         .AAPCS_VFP => return CallingConvention.AAPCSVFP,
+        .X86_64SysV => return CallingConvention.SysV,
         else => return fail(
             c,
             error.UnsupportedType,


### PR DESCRIPTION
This is useful for calling a foreign function that uses the SysV ABI from a non SysV ABI. For example, it's necessary in my project where I try to call into an ELF file loaded to memory (SysV ABI) from a zig UEFI binary (MSVC ABI).