### PR TITLE
stage2 x86_64: encoding helpers, fix bugs

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3885,6 +3885,13 @@ fn analyzeArithmetic(
                         try Module.floatSub(sema.arena, scalar_type, src, lhs_val, rhs_val);
                     break :blk val;
                 },
+                .mul => blk: {
+                    const val = if (is_int)
+                        try Module.intMul(sema.arena, lhs_val, rhs_val)
+                    else
+                        try Module.floatMul(sema.arena, scalar_type, src, lhs_val, rhs_val);
+                    break :blk val;
+                },
                 else => return sema.mod.fail(&block.base, src, "TODO Implement arithmetic operand '{s}'", .{@tagName(zir_tag)}),
             };
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3864,10 +3864,15 @@ fn analyzeArithmetic(
             // incase rhs is 0, simply return lhs without doing any calculations
             // TODO Once division is implemented we should throw an error when dividing by 0.
             if (rhs_val.compareWithZero(.eq)) {
-                return sema.mod.constInst(sema.arena, src, .{
-                    .ty = scalar_type,
-                    .val = lhs_val,
-                });
+                switch (zir_tag) {
+                    .add, .addwrap, .sub, .subwrap => {
+                        return sema.mod.constInst(sema.arena, src, .{
+                            .ty = scalar_type,
+                            .val = lhs_val,
+                        });
+                    },
+                    else => {},
+                }
             }
 
             const value = switch (zir_tag) {

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1505,8 +1505,14 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
         /// ADD, SUB, XOR, OR, AND
         fn genX8664BinMath(self: *Self, inst: *ir.Inst, op_lhs: *ir.Inst, op_rhs: *ir.Inst) !MCValue {
             // We'll handle these ops in two steps.
-            // 1) Prepare an output register, and put one of the arguments in it
+            // 1) Prepare an output location (register or memory)
+            //    This location will be the location of the operand that dies (if one exists)
+            //    or just a temporary register (if one doesn't exist)
             // 2) Perform the op with the other argument
+            // 3) Sometimes, the output location is memory but the op doesn't support it.
+            //    In this case, copy that location to a register, then perform the op to that register instead.
+            //
+            // TODO: make this algorithm less bad
 
             try self.code.ensureCapacity(self.code.items.len + 8);
 

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1691,10 +1691,10 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                         .register => |src_reg| {
                             // for register, register use mr + 1
                             // addressing mode: *r/m16/32/64*, r16/32/64
-                            const operand_size = dst_ty.abiSize(self.target.*);
+                            const abi_size = dst_ty.abiSize(self.target.*);
                             const encoder = try X8664Encoder.init(self.code, 3);
                             encoder.rex(.{
-                                .w = operand_size == 64,
+                                .w = abi_size == 8,
                                 .r = src_reg.isExtended(),
                                 .b = dst_reg.isExtended(),
                             });
@@ -1710,10 +1710,10 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             // opx = 83: r/m16/32/64, imm8
                             const imm32 = @intCast(i32, imm); // This case must be handled before calling genX8664BinMathCode.
                             if (imm32 <= math.maxInt(i8)) {
-                                const operand_size = dst_ty.abiSize(self.target.*);
+                                const abi_size = dst_ty.abiSize(self.target.*);
                                 const encoder = try X8664Encoder.init(self.code, 4);
                                 encoder.rex(.{
-                                    .w = operand_size == 64,
+                                    .w = abi_size == 8,
                                     .b = dst_reg.isExtended(),
                                 });
                                 encoder.opcode_1byte(0x83);
@@ -1723,10 +1723,10 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 );
                                 encoder.imm8(@intCast(i8, imm32));
                             } else {
-                                const operand_size = dst_ty.abiSize(self.target.*);
+                                const abi_size = dst_ty.abiSize(self.target.*);
                                 const encoder = try X8664Encoder.init(self.code, 7);
                                 encoder.rex(.{
-                                    .w = operand_size == 64,
+                                    .w = abi_size == 8,
                                     .b = dst_reg.isExtended(),
                                 });
                                 encoder.opcode_1byte(0x81);
@@ -1750,7 +1750,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             }
                             const encoder = try X8664Encoder.init(self.code, 7);
                             encoder.rex(.{
-                                .w = abi_size == 64,
+                                .w = abi_size == 8,
                                 .r = dst_reg.isExtended(),
                             });
                             encoder.opcode_1byte(mr + 3);
@@ -1837,7 +1837,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             const abi_size = dst_ty.abiSize(self.target.*);
                             const encoder = try X8664Encoder.init(self.code, 4);
                             encoder.rex(.{
-                                .w = abi_size == 64,
+                                .w = abi_size == 8,
                                 .r = dst_reg.isExtended(),
                                 .b = src_reg.isExtended(),
                             });
@@ -1866,7 +1866,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 const abi_size = dst_ty.abiSize(self.target.*);
                                 const encoder = try X8664Encoder.init(self.code, 4);
                                 encoder.rex(.{
-                                    .w = abi_size == 64,
+                                    .w = abi_size == 8,
                                     .r = dst_reg.isExtended(),
                                     .b = dst_reg.isExtended(),
                                 });
@@ -1880,7 +1880,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 const abi_size = dst_ty.abiSize(self.target.*);
                                 const encoder = try X8664Encoder.init(self.code, 7);
                                 encoder.rex(.{
-                                    .w = abi_size == 64,
+                                    .w = abi_size == 8,
                                     .r = dst_reg.isExtended(),
                                     .b = dst_reg.isExtended(),
                                 });
@@ -1923,7 +1923,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             const abi_size = dst_ty.abiSize(self.target.*);
                             const encoder = try X8664Encoder.init(self.code, 4);
                             encoder.rex(.{
-                                .w = abi_size == 64,
+                                .w = abi_size == 8,
                                 .r = dst_reg.isExtended(),
                                 .b = src_reg.isExtended(),
                             });
@@ -1965,7 +1965,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
             const i_adj_off = -@intCast(i32, adj_off);
             const encoder = try X8664Encoder.init(self.code, 7);
             encoder.rex(.{
-                .w = abi_size == 64,
+                .w = abi_size == 8,
                 .r = reg.isExtended(),
             });
             encoder.opcode_1byte(opcode);
@@ -3850,7 +3850,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                         const abi_size = ty.abiSize(self.target.*);
                         const encoder = try X8664Encoder.init(self.code, 3);
                         encoder.rex(.{
-                            .w = abi_size == 64,
+                            .w = abi_size == 8,
                             .r = reg.isExtended(),
                             .b = src_reg.isExtended(),
                         });
@@ -3869,7 +3869,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             // After we encode the instruction, we will know that the displacement bytes
                             // for [<offset>] will be at self.code.items.len - 4.
                             encoder.rex(.{
-                                .w = abi_size == 64,
+                                .w = abi_size == 8,
                                 .r = reg.isExtended(),
                             });
                             encoder.opcode_1byte(0x8D);
@@ -3891,7 +3891,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
 
                             // MOV reg, [reg]
                             encoder.rex(.{
-                                .w = abi_size == 64,
+                                .w = abi_size == 8,
                                 .r = reg.isExtended(),
                                 .b = reg.isExtended(),
                             });
@@ -3908,7 +3908,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             const abi_size = ty.abiSize(self.target.*);
                             const encoder = try X8664Encoder.init(self.code, 8);
                             encoder.rex(.{
-                                .w = abi_size == 64,
+                                .w = abi_size == 8,
                                 .r = reg.isExtended(),
                             });
                             encoder.opcode_1byte(0x8B);
@@ -3952,7 +3952,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                                 const abi_size = ty.abiSize(self.target.*);
                                 const encoder = try X8664Encoder.init(self.code, 3);
                                 encoder.rex(.{
-                                    .w = abi_size == 64,
+                                    .w = abi_size == 8,
                                     .r = reg.isExtended(),
                                     .b = reg.isExtended(),
                                 });
@@ -3970,7 +3970,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                         const ioff = -@intCast(i32, off);
                         const encoder = try X8664Encoder.init(self.code, 3);
                         encoder.rex(.{
-                            .w = abi_size == 64,
+                            .w = abi_size == 8,
                             .r = reg.isExtended(),
                         });
                         encoder.opcode_1byte(0x8B);

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -2424,6 +2424,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             .x86_64 => {
                                 try self.genSetReg(inst.base.src, Type.initTag(.u32), .rax, .{ .memory = got_addr });
                                 // callq *%rax
+                                try self.code.ensureCapacity(self.code.items.len + 2);
                                 self.code.appendSliceAssumeCapacity(&[2]u8{ 0xff, 0xd0 });
                             },
                             .aarch64 => {

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -740,7 +740,7 @@ pub fn addCases(ctx: *TestContext) !void {
         // Spilling registers to the stack.
         case.addCompareOutput(
             \\export fn _start() noreturn {
-            \\    assert(add(3, 4) == 791);
+            \\    assert(add(3, 4) == 1221);
             \\
             \\    exit();
             \\}
@@ -756,19 +756,21 @@ pub fn addCases(ctx: *TestContext) !void {
             \\        const i = g + h; // 100
             \\        const j = i + d; // 110
             \\        const k = i + j; // 210
-            \\        const l = k + c; // 217
-            \\        const m = l + d; // 227
-            \\        const n = m + e; // 241
-            \\        const o = n + f; // 265
-            \\        const p = o + g; // 303
-            \\        const q = p + h; // 365
-            \\        const r = q + i; // 465
-            \\        const s = r + j; // 575
-            \\        const t = s + k; // 785
-            \\        break :blk t;
+            \\        const l = j + k; // 320
+            \\        const m = l + c; // 327
+            \\        const n = m + d; // 337
+            \\        const o = n + e; // 351
+            \\        const p = o + f; // 375
+            \\        const q = p + g; // 413
+            \\        const r = q + h; // 475
+            \\        const s = r + i; // 575
+            \\        const t = s + j; // 685
+            \\        const u = t + k; // 895
+            \\        const v = u + l; // 1215
+            \\        break :blk v;
             \\    };
-            \\    const y = x + a; // 788
-            \\    const z = y + a; // 791
+            \\    const y = x + a; // 1218
+            \\    const z = y + a; // 1221
             \\    return z;
             \\}
             \\

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -359,6 +359,81 @@ pub fn addCases(ctx: *TestContext) !void {
     }
 
     {
+        var case = ctx.exe("multiplying numbers at runtime and comptime", linux_x64);
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    mul(3, 4);
+            \\
+            \\    exit();
+            \\}
+            \\
+            \\fn mul(a: u32, b: u32) void {
+            \\    if (a * b != 12) unreachable;
+            \\}
+            \\
+            \\fn exit() noreturn {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (231),
+            \\          [arg1] "{rdi}" (0)
+            \\        : "rcx", "r11", "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "",
+        );
+        // comptime function call
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    exit();
+            \\}
+            \\
+            \\fn mul(a: u32, b: u32) u32 {
+            \\    return a * b;
+            \\}
+            \\
+            \\const x = mul(3, 4);
+            \\
+            \\fn exit() noreturn {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (231),
+            \\          [arg1] "{rdi}" (x - 12)
+            \\        : "rcx", "r11", "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "",
+        );
+        // Inline function call
+        case.addCompareOutput(
+            \\export fn _start() noreturn {
+            \\    var x: usize = 5;
+            \\    const y = mul(2, 3, x);
+            \\    exit(y - 30);
+            \\}
+            \\
+            \\fn mul(a: usize, b: usize, c: usize) callconv(.Inline) usize {
+            \\    return a * b * c;
+            \\}
+            \\
+            \\fn exit(code: usize) noreturn {
+            \\    asm volatile ("syscall"
+            \\        :
+            \\        : [number] "{rax}" (231),
+            \\          [arg1] "{rdi}" (code)
+            \\        : "rcx", "r11", "memory"
+            \\    );
+            \\    unreachable;
+            \\}
+        ,
+            "",
+        );
+    }
+
+    {
         var case = ctx.exe("assert function", linux_x64);
         case.addCompareOutput(
             \\export fn _start() noreturn {
@@ -741,6 +816,7 @@ pub fn addCases(ctx: *TestContext) !void {
         case.addCompareOutput(
             \\export fn _start() noreturn {
             \\    assert(add(3, 4) == 1221);
+            \\    assert(mul(3, 4) == 21609);
             \\
             \\    exit();
             \\}
@@ -771,6 +847,32 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    };
             \\    const y = x + a; // 1218
             \\    const z = y + a; // 1221
+            \\    return z;
+            \\}
+            \\
+            \\fn mul(a: u32, b: u32) u32 {
+            \\    const x: u32 = blk: {
+            \\        const c = a * a * a * a; // 81
+            \\        const d = a * a * a * b; // 108
+            \\        const e = a * a * b * a; // 108
+            \\        const f = a * a * b * b; // 144
+            \\        const g = a * b * a * a; // 108
+            \\        const h = a * b * a * b; // 144
+            \\        const i = a * b * b * a; // 144
+            \\        const j = a * b * b * b; // 192
+            \\        const k = b * a * a * a; // 108
+            \\        const l = b * a * a * b; // 144
+            \\        const m = b * a * b * a; // 144
+            \\        const n = b * a * b * b; // 192
+            \\        const o = b * b * a * a; // 144
+            \\        const p = b * b * a * b; // 192
+            \\        const q = b * b * b * a; // 192
+            \\        const r = b * b * b * b; // 256
+            \\        const s = c + d + e + f + g + h + i + j + k + l + m + n + o + p + q + r; // 2401
+            \\        break :blk s;
+            \\    };
+            \\    const y = x * a; // 7203
+            \\    const z = y * a; // 21609
             \\    return z;
             \\}
             \\


### PR DESCRIPTION
As stated in https://github.com/ziglang/zig/pull/8474#issuecomment-817270681, I've changed the design of this PR once. It is now just a set of helper functions for encoding, with the intention of making code more easily checkable by reading, and only _slightly_ more ergonomic to write (it helps you do bit fiddling), but otherwise doesn't try to be smart and e.g. automatically add prefixes for you.

List of bugs fixed:
1) Spilling registers to stack now correctly handles 32/64 bit. It doesn't yet handle 8 or 16 bit (#7187), which I intend to do in a separate PR making the change to the whole codegen at once, possibly at a much later date. 2ba51f87f8c8f3d0b0cc39215206bb059d898063 416b0d693340bf5d41207683c9494eebd4ce28bb
2) Typo d7158359c096fdbc1062cb5f1817a1a590340dd6
2) As a result of (1), many operations that were unnecessarily 64 bit before now correctly become 32 bit as specified, but this revealed that the specification was wrong for loading the offset to the GOT, which needed to be a 64 bit op but was specified as 32 bit. Similarly, reading function pointers from the GOT was incorrect because function pointers are 64 bit on x86_64 and aarch64, but were doing a 32 bit genSetReg instead. 91a8e8160b3580e9566870fea32af209bda13c9e