### PR TITLE
Fix langref.html anchor navigation

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -85,7 +85,6 @@
       #main-wrapper {
         display: flex;
         flex-direction: column;
-        height: 100vh;
       }
 
       #contents-wrapper {
@@ -105,6 +104,11 @@
       @media screen and (min-width: 1025px) {
         #main-wrapper {
             flex-direction: row;
+        }
+        #toc {
+            height: 100vh;
+            position: sticky;
+            top: 0;
         }
         #contents-wrapper, #toc {
             overflow: auto;


### PR DESCRIPTION
This is a simple css fix to allow using the back and forward browser buttons to navigate anchors. Right now when you click back or forward you can see the anchor change in the url but the page doesn't scroll.