### PR TITLE
macos: add aarch64 (arm64) to downloads page

### DIFF
--- a/ci/azure/macos_arm64_script
+++ b/ci/azure/macos_arm64_script
@@ -114,13 +114,12 @@ if [ "${BUILD_REASON}" != "PullRequest" ]; then
   SHASUM=$(shasum -a 256 $TARBALL | cut '-d ' -f1)
   BYTESIZE=$(wc -c < $TARBALL)
 
-  JSONFILE="macos-$GITBRANCH.json"
-  touch $JSONFILE
-  echo "{\"tarball\": \"$TARBALL\"," >>$JSONFILE
+  JSONFILE="tarball.json"
+  echo "{" >$JSONFILE
+  echo "\"tarball\": \"$TARBALL\"," >>$JSONFILE
   echo "\"shasum\": \"$SHASUM\"," >>$JSONFILE
   echo "\"size\": \"$BYTESIZE\"}" >>$JSONFILE
 
-  s3cmd put -P --add-header="Cache-Control: max-age=0, must-revalidate" "$JSONFILE" "s3://ziglang.org/builds/$JSONFILE"
   s3cmd put -P "$JSONFILE" "s3://ziglang.org/builds/$ARCH-macos-$VERSION.json"
 
   # `set -x` causes these variables to be mangled.

--- a/ci/azure/pipelines.yml
+++ b/ci/azure/pipelines.yml
@@ -24,7 +24,7 @@ jobs:
       secureFile: s3cfg
   - script: ci/azure/macos_arm64_script
     name: main
-    displayName: 'Build and cross-compile'
+    displayName: 'Build'
 - job: BuildLinux
   pool:
     vmImage: 'ubuntu-18.04'

--- a/ci/srht/index.html
+++ b/ci/srht/index.html
@@ -200,6 +200,12 @@
             <td class="code">{{X86_64_MACOS_SHASUM}}</td>
           </tr>
           <tr>
+            <td><a href="https://ziglang.org/builds/{{AARCH64_MACOS_TARBALL}}">{{AARCH64_MACOS_TARBALL}}</a></td>
+            <td>Binary</td>
+            <td>{{AARCH64_MACOS_BYTESIZE}}</td>
+            <td class="code">{{AARCH64_MACOS_SHASUM}}</td>
+          </tr>
+          <tr>
             <td><a href="https://ziglang.org/builds/{{X86_64_FREEBSD_TARBALL}}">{{X86_64_FREEBSD_TARBALL}}</a></td>
             <td>Binary</td>
             <td>{{X86_64_FREEBSD_BYTESIZE}}</td>

--- a/ci/srht/index.json
+++ b/ci/srht/index.json
@@ -19,6 +19,11 @@
       "shasum": "{{X86_64_MACOS_SHASUM}}",
       "size": "{{X86_64_MACOS_BYTESIZE}}"
     },
+    "aarch64-macos": {
+      "tarball": "https://ziglang.org/builds/{{AARCH64_MACOS_TARBALL}}",
+      "shasum": "{{AARCH64_MACOS_SHASUM}}",
+      "size": "{{AARCH64_MACOS_BYTESIZE}}"
+    },
     "x86_64-windows": {
       "tarball": "https://ziglang.org/builds/{{X86_64_WINDOWS_TARBALL}}",
       "shasum": "{{X86_64_WINDOWS_SHASUM}}",

--- a/ci/srht/update_download_page
+++ b/ci/srht/update_download_page
@@ -12,6 +12,7 @@ NATIVE_TARBALL="zig-linux-$(uname -m)-$VERSION.tar.xz"
 AARCH64_LINUX_JSON_URL="https://ziglang.org/builds/aarch64-linux-$VERSION.json"
 X86_64_LINUX_JSON_URL="https://ziglang.org/builds/x86_64-linux-$VERSION.json"
 X86_64_WINDOWS_JSON_URL="https://ziglang.org/builds/x86_64-windows-$VERSION.json"
+AARCH64_MACOS_JSON_URL="https://ziglang.org/builds/aarch64-macos-$VERSION.json"
 X86_64_MACOS_JSON_URL="https://ziglang.org/builds/x86_64-macos-$VERSION.json"
 X86_64_FREEBSD_JSON_URL="https://ziglang.org/builds/x86_64-freebsd-$VERSION.json"
 
@@ -20,6 +21,7 @@ X86_64_FREEBSD_JSON_URL="https://ziglang.org/builds/x86_64-freebsd-$VERSION.json
 curl --fail -I "$AARCH64_LINUX_JSON_URL" >/dev/null || exit 0
 curl --fail -I "$X86_64_LINUX_JSON_URL" >/dev/null || exit 0
 curl --fail -I "$X86_64_WINDOWS_JSON_URL" >/dev/null || exit 0
+curl --fail -I "$AARCH64_MACOS_JSON_URL" >/dev/null || exit 0
 curl --fail -I "$X86_64_MACOS_JSON_URL" >/dev/null || exit 0
 curl --fail -I "$X86_64_FREEBSD_JSON_URL" >/dev/null || exit 0
 
@@ -56,6 +58,11 @@ X86_64_WINDOWS_JSON=$(curl --fail "$X86_64_WINDOWS_JSON_URL" || exit 1)
 export X86_64_WINDOWS_TARBALL="$(echo "$X86_64_WINDOWS_JSON" | jq .tarball -r)"
 export X86_64_WINDOWS_BYTESIZE="$(echo "$X86_64_WINDOWS_JSON" | jq .size -r)"
 export X86_64_WINDOWS_SHASUM="$(echo "$X86_64_WINDOWS_JSON" | jq .shasum -r)"
+
+AARCH64_MACOS_JSON=$(curl --fail "$AARCH64_MACOS_JSON_URL" || exit 1)
+export AARCH64_MACOS_TARBALL="$(echo "$AARCH64_MACOS_JSON" | jq .tarball -r)"
+export AARCH64_MACOS_BYTESIZE="$(echo "$AARCH64_MACOS_JSON" | jq .size -r)"
+export AARCH64_MACOS_SHASUM="$(echo "$AARCH64_MACOS_JSON" | jq .shasum -r)"
 
 X86_64_MACOS_JSON=$(curl --fail "$X86_64_MACOS_JSON_URL" || exit 1)
 export X86_64_MACOS_TARBALL="$(echo "$X86_64_MACOS_JSON" | jq .tarball -r)"


### PR DESCRIPTION
add `zig-macos-aarch64` tarballs that are produced by azure CI to the main download page