### PR TITLE
Wrapping add/sub for the C backend

### DIFF
--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -60,9 +60,161 @@
 #define zig_breakpoint() raise(SIGTRAP)
 #endif
 
+
+#define ZIG_UADDW(Type, lhs, rhs, max)                      \
+    Type thresh = max - rhs;                                \
+    if (lhs > thresh) {                                     \
+        return lhs - thresh - 1;                            \
+    } else {                                                \
+        return lhs + rhs;                                   \
+    }
+
+#define ZIG_SADDW(Type, lhs, rhs, min, max)                 \
+    if ((lhs > 0) && (rhs > 0)) {                           \
+        Type thresh = max - rhs;                            \
+        if (lhs > thresh) {                                 \
+            return min + lhs - thresh - 1;                  \
+        }                                                   \
+    } else if ((lhs < 0) && (rhs < 0)) {                    \
+        Type thresh = min - rhs;                            \
+        if (lhs < thresh) {                                 \
+            return max + lhs - thresh + 1;                  \
+        }                                                   \
+    }                                                       \
+                                                            \
+    return lhs + rhs;
+
+#define ZIG_USUBW(lhs, rhs, max)                            \
+    if (lhs < rhs) {                                        \
+        return max - rhs - lhs + 1;                         \
+    } else {                                                \
+        return lhs - rhs;                                   \
+    }
+
+#define ZIG_SSUBW(Type, lhs, rhs, min, max)                 \
+    if ((lhs > 0) && (rhs < 0)) {                           \
+        Type thresh = lhs - max;                            \
+        if (rhs < thresh) {                                 \
+            return min + (thresh - rhs - 1);                \
+        }                                                   \
+    } else if ((lhs < 0) && (rhs > 0)) {                    \
+        Type thresh = lhs - min;                            \
+        if (rhs > thresh) {                                 \
+            return max - (rhs - thresh - 1);                \
+        }                                                   \
+    }                                                       \
+    return lhs - rhs;
+
 #include <stdint.h>
 #include <stddef.h>
+#include <limits.h>
 #define int128_t __int128
 #define uint128_t unsigned __int128
 ZIG_EXTERN_C void *memcpy (void *ZIG_RESTRICT, const void *ZIG_RESTRICT, size_t);
+
+/* Wrapping addition operators */
+static inline uint8_t zig_addw_u8(uint8_t lhs, uint8_t rhs, uint8_t max) {
+    ZIG_UADDW(uint8_t, lhs, rhs, max);
+}
+
+static inline int8_t zig_addw_i8(int8_t lhs, int8_t rhs, int8_t min, int8_t max) {
+    ZIG_SADDW(int8_t, lhs, rhs, min, max);
+}
+
+static inline uint16_t zig_addw_u16(uint16_t lhs, uint16_t rhs, uint16_t max) {
+    ZIG_UADDW(uint16_t, lhs, rhs, max);
+}
+
+static inline int16_t zig_addw_i16(int16_t lhs, int16_t rhs, int16_t min, int16_t max) {
+    ZIG_SADDW(int16_t, lhs, rhs, min, max);
+}
+
+static inline uint32_t zig_addw_u32(uint32_t lhs, uint32_t rhs, uint32_t max) {
+    ZIG_UADDW(uint32_t, lhs, rhs, max);
+}
+
+static inline int32_t zig_addw_i32(int32_t lhs, int32_t rhs, int32_t min, int32_t max) {
+    ZIG_SADDW(int32_t, lhs, rhs, min, max);
+}
+
+static inline uint64_t zig_addw_u64(uint64_t lhs, uint64_t rhs, uint64_t max) {
+    ZIG_UADDW(uint64_t, lhs, rhs, max);
+}
+
+static inline int64_t zig_addw_i64(int64_t lhs, int64_t rhs, int64_t min, int64_t max) {
+    ZIG_SADDW(int64_t, lhs, rhs, min, max);
+}
+
+static inline intptr_t zig_addw_isize(intptr_t lhs, intptr_t rhs, intptr_t min, intptr_t max) {
+    return (intptr_t)(((uintptr_t)lhs) + ((uintptr_t)rhs));
+}
+
+static inline short zig_addw_short(short lhs, short rhs, short min, short max) {
+    return (short)(((unsigned short)lhs) + ((unsigned short)rhs));
+}
+
+static inline int zig_addw_int(int lhs, int rhs, int min, int max) {
+    return (int)(((unsigned)lhs) + ((unsigned)rhs));
+}
+
+static inline long zig_addw_long(long lhs, long rhs, long min, long max) {
+    return (long)(((unsigned long)lhs) + ((unsigned long)rhs));
+}
+
+static inline long long zig_addw_longlong(long long lhs, long long rhs, long long min, long long max) {
+    return (long long)(((unsigned long long)lhs) + ((unsigned long long)rhs));
+}
+
+/* Wrapping subtraction operators */
+static inline uint8_t zig_subw_u8(uint8_t lhs, uint8_t rhs, uint8_t max) {
+    ZIG_USUBW(lhs, rhs, max);
+}
+
+static inline int8_t zig_subw_i8(int8_t lhs, int8_t rhs, int8_t min, int8_t max) {
+    ZIG_SSUBW(int8_t, lhs, rhs, min, max);
+}
+
+static inline uint16_t zig_subw_u16(uint16_t lhs, uint16_t rhs, uint16_t max) {
+    ZIG_USUBW(lhs, rhs, max);
+}
+
+static inline int16_t zig_subw_i16(int16_t lhs, int16_t rhs, int16_t min, int16_t max) {
+    ZIG_SSUBW(int16_t, lhs, rhs, min, max);
+}
+
+static inline uint32_t zig_subw_u32(uint32_t lhs, uint32_t rhs, uint32_t max) {
+    ZIG_USUBW(lhs, rhs, max);
+}
+
+static inline int32_t zig_subw_i32(int32_t lhs, int32_t rhs, int32_t min, int32_t max) {
+    ZIG_SSUBW(int32_t, lhs, rhs, min, max);
+}
+
+static inline uint64_t zig_subw_u64(uint64_t lhs, uint64_t rhs, uint64_t max) {
+    ZIG_USUBW(lhs, rhs, max);
+}
+
+static inline int64_t zig_subw_i64(int64_t lhs, int64_t rhs, int64_t min, int64_t max) {
+    ZIG_SSUBW(int64_t, lhs, rhs, min, max);
+}
+
+static inline intptr_t zig_subw_isize(intptr_t lhs, intptr_t rhs, intptr_t min, intptr_t max) {
+    return (intptr_t)(((uintptr_t)lhs) - ((uintptr_t)rhs));
+}
+
+static inline short zig_subw_short(short lhs, short rhs, short min, short max) {
+    return (short)(((unsigned short)lhs) - ((unsigned short)rhs));
+}
+
+static inline int zig_subw_int(int lhs, int rhs, int min, int max) {
+    return (int)(((unsigned)lhs) - ((unsigned)rhs));
+}
+
+static inline long zig_subw_long(long lhs, long rhs, long min, long max) {
+    return (long)(((unsigned long)lhs) - ((unsigned long)rhs));
+}
+
+static inline long long zig_subw_longlong(long long lhs, long long rhs, long long min, long long max) {
+    return (long long)(((unsigned long long)lhs) - ((unsigned long long)rhs));
+}
 

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -60,51 +60,6 @@
 #define zig_breakpoint() raise(SIGTRAP)
 #endif
 
-
-#define ZIG_UADDW(Type, lhs, rhs, max)                      \
-    Type thresh = max - rhs;                                \
-    if (lhs > thresh) {                                     \
-        return lhs - thresh - 1;                            \
-    } else {                                                \
-        return lhs + rhs;                                   \
-    }
-
-#define ZIG_SADDW(Type, lhs, rhs, min, max)                 \
-    if ((lhs > 0) && (rhs > 0)) {                           \
-        Type thresh = max - rhs;                            \
-        if (lhs > thresh) {                                 \
-            return min + lhs - thresh - 1;                  \
-        }                                                   \
-    } else if ((lhs < 0) && (rhs < 0)) {                    \
-        Type thresh = min - rhs;                            \
-        if (lhs < thresh) {                                 \
-            return max + lhs - thresh + 1;                  \
-        }                                                   \
-    }                                                       \
-                                                            \
-    return lhs + rhs;
-
-#define ZIG_USUBW(lhs, rhs, max)                            \
-    if (lhs < rhs) {                                        \
-        return max - rhs - lhs + 1;                         \
-    } else {                                                \
-        return lhs - rhs;                                   \
-    }
-
-#define ZIG_SSUBW(Type, lhs, rhs, min, max)                 \
-    if ((lhs > 0) && (rhs < 0)) {                           \
-        Type thresh = lhs - max;                            \
-        if (rhs < thresh) {                                 \
-            return min + (thresh - rhs - 1);                \
-        }                                                   \
-    } else if ((lhs < 0) && (rhs > 0)) {                    \
-        Type thresh = lhs - min;                            \
-        if (rhs > thresh) {                                 \
-            return max - (rhs - thresh - 1);                \
-        }                                                   \
-    }                                                       \
-    return lhs - rhs;
-
 #include <stdint.h>
 #include <stddef.h>
 #include <limits.h>
@@ -112,37 +67,100 @@
 #define uint128_t unsigned __int128
 ZIG_EXTERN_C void *memcpy (void *ZIG_RESTRICT, const void *ZIG_RESTRICT, size_t);
 
-/* Wrapping addition operators */
 static inline uint8_t zig_addw_u8(uint8_t lhs, uint8_t rhs, uint8_t max) {
-    ZIG_UADDW(uint8_t, lhs, rhs, max);
+    uint8_t thresh = max - rhs;
+    if (lhs > thresh) {
+        return lhs - thresh - 1;
+    } else {
+        return lhs + rhs;
+    }
 }
 
 static inline int8_t zig_addw_i8(int8_t lhs, int8_t rhs, int8_t min, int8_t max) {
-    ZIG_SADDW(int8_t, lhs, rhs, min, max);
+    if ((lhs > 0) && (rhs > 0)) {
+        int8_t thresh = max - rhs;
+        if (lhs > thresh) {
+            return min + lhs - thresh - 1;
+        }
+    } else if ((lhs < 0) && (rhs < 0)) {
+        int8_t thresh = min - rhs;
+        if (lhs < thresh) {
+            return max + lhs - thresh + 1;
+        }
+    }
+    return lhs + rhs;
 }
 
 static inline uint16_t zig_addw_u16(uint16_t lhs, uint16_t rhs, uint16_t max) {
-    ZIG_UADDW(uint16_t, lhs, rhs, max);
+    uint16_t thresh = max - rhs;
+    if (lhs > thresh) {
+        return lhs - thresh - 1;
+    } else {
+        return lhs + rhs;
+    }
 }
 
 static inline int16_t zig_addw_i16(int16_t lhs, int16_t rhs, int16_t min, int16_t max) {
-    ZIG_SADDW(int16_t, lhs, rhs, min, max);
+    if ((lhs > 0) && (rhs > 0)) {
+        int16_t thresh = max - rhs;
+        if (lhs > thresh) {
+            return min + lhs - thresh - 1;
+        }
+    } else if ((lhs < 0) && (rhs < 0)) {
+        int16_t thresh = min - rhs;
+        if (lhs < thresh) {
+            return max + lhs - thresh + 1;
+        }
+    }
+    return lhs + rhs;
 }
 
 static inline uint32_t zig_addw_u32(uint32_t lhs, uint32_t rhs, uint32_t max) {
-    ZIG_UADDW(uint32_t, lhs, rhs, max);
+    uint32_t thresh = max - rhs;
+    if (lhs > thresh) {
+        return lhs - thresh - 1;
+    } else {
+        return lhs + rhs;
+    }
 }
 
 static inline int32_t zig_addw_i32(int32_t lhs, int32_t rhs, int32_t min, int32_t max) {
-    ZIG_SADDW(int32_t, lhs, rhs, min, max);
+    if ((lhs > 0) && (rhs > 0)) {
+        int32_t thresh = max - rhs;
+        if (lhs > thresh) {
+            return min + lhs - thresh - 1;
+        }
+    } else if ((lhs < 0) && (rhs < 0)) {
+        int32_t thresh = min - rhs;
+        if (lhs < thresh) {
+            return max + lhs - thresh + 1;
+        }
+    }
+    return lhs + rhs;
 }
 
 static inline uint64_t zig_addw_u64(uint64_t lhs, uint64_t rhs, uint64_t max) {
-    ZIG_UADDW(uint64_t, lhs, rhs, max);
+    uint64_t thresh = max - rhs;
+    if (lhs > thresh) {
+        return lhs - thresh - 1;
+    } else {
+        return lhs + rhs;
+    }
 }
 
 static inline int64_t zig_addw_i64(int64_t lhs, int64_t rhs, int64_t min, int64_t max) {
-    ZIG_SADDW(int64_t, lhs, rhs, min, max);
+    if ((lhs > 0) && (rhs > 0)) {
+        int64_t thresh = max - rhs;
+        if (lhs > thresh) {
+            return min + lhs - thresh - 1;
+        }
+    } else if ((lhs < 0) && (rhs < 0)) {
+        int64_t thresh = min - rhs;
+        if (lhs < thresh) {
+            return max + lhs - thresh + 1;
+        }
+    }
+    return lhs + rhs;
 }
 
 static inline intptr_t zig_addw_isize(intptr_t lhs, intptr_t rhs, intptr_t min, intptr_t max) {
@@ -165,37 +183,96 @@ static inline long long zig_addw_longlong(long long lhs, long long rhs, long lon
     return (long long)(((unsigned long long)lhs) + ((unsigned long long)rhs));
 }
 
-/* Wrapping subtraction operators */
 static inline uint8_t zig_subw_u8(uint8_t lhs, uint8_t rhs, uint8_t max) {
-    ZIG_USUBW(lhs, rhs, max);
+    if (lhs < rhs) {
+        return max - rhs - lhs + 1;
+    } else {
+        return lhs - rhs;
+    }
 }
 
 static inline int8_t zig_subw_i8(int8_t lhs, int8_t rhs, int8_t min, int8_t max) {
-    ZIG_SSUBW(int8_t, lhs, rhs, min, max);
+    if ((lhs > 0) && (rhs < 0)) {
+        int8_t thresh = lhs - max;
+        if (rhs < thresh) {
+            return min + (thresh - rhs - 1);
+        }
+    } else if ((lhs < 0) && (rhs > 0)) {
+        int8_t thresh = lhs - min;
+        if (rhs > thresh) {
+            return max - (rhs - thresh - 1);
+        }
+    }
+    return lhs - rhs;
 }
 
 static inline uint16_t zig_subw_u16(uint16_t lhs, uint16_t rhs, uint16_t max) {
-    ZIG_USUBW(lhs, rhs, max);
+    if (lhs < rhs) {
+        return max - rhs - lhs + 1;
+    } else {
+        return lhs - rhs;
+    }
 }
 
 static inline int16_t zig_subw_i16(int16_t lhs, int16_t rhs, int16_t min, int16_t max) {
-    ZIG_SSUBW(int16_t, lhs, rhs, min, max);
+    if ((lhs > 0) && (rhs < 0)) {
+        int16_t thresh = lhs - max;
+        if (rhs < thresh) {
+            return min + (thresh - rhs - 1);
+        }
+    } else if ((lhs < 0) && (rhs > 0)) {
+        int16_t thresh = lhs - min;
+        if (rhs > thresh) {
+            return max - (rhs - thresh - 1);
+        }
+    }
+    return lhs - rhs;
 }
 
 static inline uint32_t zig_subw_u32(uint32_t lhs, uint32_t rhs, uint32_t max) {
-    ZIG_USUBW(lhs, rhs, max);
+    if (lhs < rhs) {
+        return max - rhs - lhs + 1;
+    } else {
+        return lhs - rhs;
+    }
 }
 
 static inline int32_t zig_subw_i32(int32_t lhs, int32_t rhs, int32_t min, int32_t max) {
-    ZIG_SSUBW(int32_t, lhs, rhs, min, max);
+    if ((lhs > 0) && (rhs < 0)) {
+        int32_t thresh = lhs - max;
+        if (rhs < thresh) {
+            return min + (thresh - rhs - 1);
+        }
+    } else if ((lhs < 0) && (rhs > 0)) {
+        int32_t thresh = lhs - min;
+        if (rhs > thresh) {
+            return max - (rhs - thresh - 1);
+        }
+    }
+    return lhs - rhs;
 }
 
 static inline uint64_t zig_subw_u64(uint64_t lhs, uint64_t rhs, uint64_t max) {
-    ZIG_USUBW(lhs, rhs, max);
+    if (lhs < rhs) {
+        return max - rhs - lhs + 1;
+    } else {
+        return lhs - rhs;
+    }
 }
 
 static inline int64_t zig_subw_i64(int64_t lhs, int64_t rhs, int64_t min, int64_t max) {
-    ZIG_SSUBW(int64_t, lhs, rhs, min, max);
+    if ((lhs > 0) && (rhs < 0)) {
+        int64_t thresh = lhs - max;
+        if (rhs < thresh) {
+            return min + (thresh - rhs - 1);
+        }
+    } else if ((lhs < 0) && (rhs > 0)) {
+        int64_t thresh = lhs - min;
+        if (rhs > thresh) {
+            return max - (rhs - thresh - 1);
+        }
+    }
+    return lhs - rhs;
 }
 
 static inline intptr_t zig_subw_isize(intptr_t lhs, intptr_t rhs, intptr_t min, intptr_t max) {

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -825,52 +825,53 @@ pub fn addCases(ctx: *TestContext) !void {
     }
 
     {
-        // TODO: move these cases into the programs themselves once stage 2 has array literals
         // TODO: add u64 tests, ran into issues with the literal generated for std.math.maxInt(u64)
-        var case = ctx.exeFromCompiledC("Wrapping operations", .{});
-        const programs = comptime blk: {
-            const cases = .{
-                // Addition
-                .{ u3, "+%", 1, 1, 2 },
-                .{ u3, "+%", 7, 1, 0 },
-                .{ i3, "+%", 1, 1, 2 },
-                .{ i3, "+%", 3, 2, -3 },
-                .{ i3, "+%", -3, -2, 3 },
-                .{ c_int, "+%", 1, 1, 2 },
-                .{ c_int, "+%", std.math.maxInt(c_int), 2, std.math.minInt(c_int) + 1 },
-                .{ c_int, "+%", std.math.minInt(c_int) + 1, -2, std.math.maxInt(c_int) },
-
-                // Subtraction
-                .{ u3, "-%", 2, 1, 1 },
-                .{ u3, "-%", 0, 1, 7 },
-                .{ i3, "-%", 2, 1, 1 },
-                .{ i3, "-%", 3, -2, -3 },
-                .{ i3, "-%", -3, 2, 3 },
-                .{ c_int, "-%", 2, 1, 1 },
-                .{ c_int, "-%", std.math.maxInt(c_int), -2, std.math.minInt(c_int) + 1 },
-                .{ c_int, "-%", std.math.minInt(c_int) + 1, 2, std.math.maxInt(c_int) },
-            };
-
-            var ret: [cases.len][:0]const u8 = undefined;
-            for (cases) |c, i| ret[i] = std.fmt.comptimePrint(
-                \\export fn main() i32 {{
-                \\    var lhs: {0} = {2};
-                \\    var rhs: {0} = {3};
-                \\    var expected: {0} = {4};
-                \\
-                \\    if (expected != lhs {1s} rhs) {{
-                \\        return 1;
-                \\    }} else {{
-                \\        return 0;
-                \\    }}
-                \\}}
-                \\
-            , c);
-
-            break :blk ret;
-        };
-
-        inline for (programs) |prog| case.addCompareOutput(prog, "");
+        var case = ctx.exeFromCompiledC("add/sub wrapping operations", .{});
+        case.addCompareOutput(
+            \\pub export fn main() c_int {
+            \\    // Addition
+            \\    if (!add_u3(1, 1, 2)) return 1;
+            \\    if (!add_u3(7, 1, 0)) return 1;
+            \\    if (!add_i3(1, 1, 2)) return 1;
+            \\    if (!add_i3(3, 2, -3)) return 1;
+            \\    if (!add_i3(-3, -2, 3)) return 1;
+            \\    if (!add_c_int(1, 1, 2)) return 1;
+            \\    // TODO enable these when stage2 supports std.math.maxInt
+            \\    //if (!add_c_int(maxInt(c_int), 2, minInt(c_int) + 1)) return 1;
+            \\    //if (!add_c_int(maxInt(c_int) + 1, -2, maxInt(c_int))) return 1;
+            \\
+            \\    // Subtraction
+            \\    if (!sub_u3(2, 1, 1)) return 1;
+            \\    if (!sub_u3(0, 1, 7)) return 1;
+            \\    if (!sub_i3(2, 1, 1)) return 1;
+            \\    if (!sub_i3(3, -2, -3)) return 1;
+            \\    if (!sub_i3(-3, 2, 3)) return 1;
+            \\    if (!sub_c_int(2, 1, 1)) return 1;
+            \\    // TODO enable these when stage2 supports std.math.maxInt
+            \\    //if (!sub_c_int(maxInt(c_int), -2, minInt(c_int) + 1)) return 1;
+            \\    //if (!sub_c_int(minInt(c_int) + 1, 2, maxInt(c_int))) return 1;
+            \\
+            \\    return 0;
+            \\}
+            \\fn add_u3(lhs: u3, rhs: u3, expected: u3) bool {
+            \\    return expected == lhs +% rhs;
+            \\}
+            \\fn add_i3(lhs: i3, rhs: i3, expected: i3) bool {
+            \\    return expected == lhs +% rhs;
+            \\}
+            \\fn add_c_int(lhs: c_int, rhs: c_int, expected: c_int) bool {
+            \\    return expected == lhs +% rhs;
+            \\}
+            \\fn sub_u3(lhs: u3, rhs: u3, expected: u3) bool {
+            \\    return expected == lhs -% rhs;
+            \\}
+            \\fn sub_i3(lhs: i3, rhs: i3, expected: i3) bool {
+            \\    return expected == lhs -% rhs;
+            \\}
+            \\fn sub_c_int(lhs: c_int, rhs: c_int, expected: c_int) bool {
+            \\    return expected == lhs -% rhs;
+            \\}
+        , "");
     }
 
     ctx.h("simple header", linux_x64,


### PR DESCRIPTION
This function is significantly longer than other codegen functions in this file, I'm not sure if that's the nature of this operation, or some abstractions are needed in order to make it readable, probably the latter. I'm also curious how we want to implement safety checks, it became obvious to me that we're going to need to add some of these overflow checks to the regular addition operator.

My approach for the problem has been portability first, then in the future we can add compiler specific optimizations. The general algorithm is: "check if it's going to wrap, if it will, then calculate the wrapped result, else add normally". There is an optimization that can be done for arbitrary width unsigned integers but I've left that as a TODO for now. Since it's fairly difficult to determine what the generated code looks like here are some examples that cover the different cases, the corresponding zig code is just `return lhs +% rhs`.

C integer type.
```c
int overflow_add_c_int(int a0, int a1) {
 int t0;
 if ((a0 > 0) && (a1 > 0)) {
  int const t1 = a0 < a1 ? a0 : a1;
  int const t2 = INT_MAX - ((a0 > a1) ? a0 : a1);
  if (t1 > t2) {
   t0 = INT_MIN + t1 - t2 - 1;
   goto zig_wrap_t0_ret;
  }
 } else if ((a0 < 0) && (a1 < 0)) {
  int const t3 = a0 > a1 ? a0 : a1;
  int const t4 = INT_MIN - ((a0 < a1) ? a0 : a1);
  if (t3 < t4) {
   t0 = INT_MAX + t3 - t4 + 1;
   goto zig_wrap_t0_ret;
  }
 }
 t0 = a0 + a1;
zig_wrap_t0_ret:
 return t0;
}
```
Zig integer type whose size depends on target:
```c
intptr_t overflow_add_isize(intptr_t a0, intptr_t a1) {
 intptr_t t0;
 if ((a0 > 0) && (a1 > 0)) {
  intptr_t const t1 = a0 < a1 ? a0 : a1;
  intptr_t const t2 = INTPTR_MAX - ((a0 > a1) ? a0 : a1);
  if (t1 > t2) {
   t0 = INTPTR_MIN + t1 - t2 - 1;
   goto zig_wrap_t0_ret;
  }
 } else if ((a0 < 0) && (a1 < 0)) {
  intptr_t const t3 = a0 > a1 ? a0 : a1;
  intptr_t const t4 = INTPTR_MIN - ((a0 < a1) ? a0 : a1);
  if (t3 < t4) {
   t0 = INTPTR_MAX + t3 - t4 + 1;
   goto zig_wrap_t0_ret;
  }
 }
 t0 = a0 + a1;
zig_wrap_t0_ret:
 return t0;
}
```
Zig unsigned integer type which doesn't have an arbitrary bit size, it will defer to C's unsigned wrapping to reduce size of generated code:
```c
uintptr_t overflow_add_usize(uintptr_t a0, uintptr_t a1) {
 uintptr_t const t0 = a0 + a1;
 return t0;
}
```

Zig arbitrary width unsigned integer:
```c
uint8_t overflow_add_u3(uint8_t a0, uint8_t a1) {
 uint8_t t0;
 if ((a0 > 0) && (a1 > 0)) {
  uint8_t const t1 = a0 < a1 ? a0 : a1;
  uint8_t const t2 = 7 - ((a0 > a1) ? a0 : a1);
  if (t1 > t2) {
   t0 = 0 + t1 - t2 - 1;
   goto zig_wrap_t0_ret;
  }
 }
 t0 = a0 + a1;
zig_wrap_t0_ret:
 return t0;
}
```

Zig arbitrary width signed integer:
```c
int8_t overflow_add_i3(int8_t a0, int8_t a1) {
 int8_t t0;
 if ((a0 > 0) && (a1 > 0)) {
  int8_t const t1 = a0 < a1 ? a0 : a1;
  int8_t const t2 = 3 - ((a0 > a1) ? a0 : a1);
  if (t1 > t2) {
   t0 = -4 + t1 - t2 - 1;
   goto zig_wrap_t0_ret;
  }
 } else if ((a0 < 0) && (a1 < 0)) {
  int8_t const t3 = a0 > a1 ? a0 : a1;
  int8_t const t4 = -4 - ((a0 < a1) ? a0 : a1);
  if (t3 < t4) {
   t0 = 3 + t3 - t4 + 1;
   goto zig_wrap_t0_ret;
  }
 }
 t0 = a0 + a1;
zig_wrap_t0_ret:
 return t0;
}
```