### PR TITLE
stage2: make repl ui better

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -96,6 +96,10 @@ generation: u32 = 0,
 /// When populated it means there was an error opening/reading the root source file.
 failed_root_src_file: ?anyerror = null,
 
+/// Used for getting stats about the Compilation that happened
+num_decls_removed: usize = 0,
+num_decls_added: usize = 0,
+
 stage1_flags: packed struct {
     have_winmain: bool = false,
     have_wwinmain: bool = false,
@@ -3614,6 +3618,7 @@ pub fn deleteDecl(
     defer tracy.end();
 
     log.debug("deleting decl '{s}'", .{decl.name});
+    mod.num_decls_removed += 1;
 
     if (outdated_decls) |map| {
         _ = map.swapRemove(decl);
@@ -3843,6 +3848,7 @@ fn createNewDecl(
     errdefer mod.gpa.destroy(new_decl);
     new_decl.name = try mem.dupeZ(mod.gpa, u8, decl_name);
     mod.decl_table.putAssumeCapacityNoClobber(name_hash, new_decl);
+    mod.num_decls_added += 1;
     return new_decl;
 }
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -670,7 +670,7 @@ pub const TestContext = struct {
             var module_node = update_node.start("parse/analysis/codegen", 0);
             module_node.activate();
             try comp.makeBinFileWritable();
-            try comp.update();
+            try comp.update(false);
             module_node.end();
 
             if (update.case != .Error) {


### PR DESCRIPTION
As stage2 is improving, I found myself using this repl more and more and it was annoying to type out `update` every time, so I updated the ui.
`""` runs the previous command
Any first letter for a command also works for the command itself. As we add more commands, this could be fleshed out more to avoid collisions.
I made it print `updating...` every time so that if you did `""` and it took a short time :partying_face: you would know it was actually updating and not just skipping. Should a different message print here?