### PR TITLE
os/posix: handle ECONNRESET for write/writev

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -675,6 +675,9 @@ pub const WriteError = error{
     /// This error occurs when no global event loop is configured,
     /// and reading from the file descriptor would block.
     WouldBlock,
+
+    /// Connection reset by peer.
+    ConnectionResetByPeer,
 } || UnexpectedError;
 
 /// Write to a file descriptor.
@@ -752,6 +755,7 @@ pub fn write(fd: fd_t, bytes: []const u8) WriteError!usize {
             ENOSPC => return error.NoSpaceLeft,
             EPERM => return error.AccessDenied,
             EPIPE => return error.BrokenPipe,
+            ECONNRESET => return error.ConnectionResetByPeer,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -820,6 +824,7 @@ pub fn writev(fd: fd_t, iov: []const iovec_const) WriteError!usize {
             ENOSPC => return error.NoSpaceLeft,
             EPERM => return error.AccessDenied,
             EPIPE => return error.BrokenPipe,
+            ECONNRESET => return error.ConnectionResetByPeer,
             else => |err| return unexpectedErrno(err),
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -2859,6 +2859,7 @@ const FmtError = error{
     Unseekable,
     NotOpenForWriting,
     UnsupportedEncoding,
+    ConnectionResetByPeer,
 } || fs.File.OpenError;
 
 fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool, dir: fs.Dir, sub_path: []const u8) FmtError!void {


### PR DESCRIPTION
Fixes #8426. This PR does not handle ECONNRESET for write/writev on the WASI target yet as I have no means to test it right now; does anyone have any manpages/documentation to reference to see if ECONNRESET is reported as well for WASI?