### PR TITLE
build: Test the c.zig file too

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -259,6 +259,7 @@ pub fn build(b: *Builder) !void {
     test_step.dependOn(tests.addPkgTests(b, test_filter, "lib/std/std.zig", "std", "Run the standard library tests", modes, false, skip_non_native, skip_libc, is_wine_enabled, is_qemu_enabled, is_wasmtime_enabled, glibc_multi_dir));
 
     test_step.dependOn(tests.addPkgTests(b, test_filter, "lib/std/special/compiler_rt.zig", "compiler-rt", "Run the compiler_rt tests", modes, true, skip_non_native, true, is_wine_enabled, is_qemu_enabled, is_wasmtime_enabled, glibc_multi_dir));
+    test_step.dependOn(tests.addPkgTests(b, test_filter, "lib/std/special/c.zig", "minilibc", "Run the mini libc tests", modes, true, skip_non_native, true, is_wine_enabled, is_qemu_enabled, is_wasmtime_enabled, glibc_multi_dir));
 
     test_step.dependOn(tests.addCompareOutputTests(b, test_filter, modes));
     test_step.dependOn(tests.addStandaloneTests(b, test_filter, modes));

--- a/lib/std/math/sqrt.zig
+++ b/lib/std/math/sqrt.zig
@@ -39,7 +39,13 @@ pub fn sqrt(x: anytype) Sqrt(@TypeOf(x)) {
     }
 }
 
-fn sqrt_int(comptime T: type, value: T) std.meta.Int(.unsigned, @typeInfo(T).Int.bits / 2) {
+fn sqrt_int(comptime T: type, value: T) Sqrt(T) {
+    switch (T) {
+        u0 => return 0,
+        u1 => return value,
+        else => {},
+    }
+
     var op = value;
     var res: T = 0;
     var one: T = 1 << (@typeInfo(T).Int.bits - 2);
@@ -58,11 +64,13 @@ fn sqrt_int(comptime T: type, value: T) std.meta.Int(.unsigned, @typeInfo(T).Int
         one >>= 2;
     }
 
-    const ResultType = std.meta.Int(.unsigned, @typeInfo(T).Int.bits / 2);
+    const ResultType = Sqrt(T);
     return @intCast(ResultType, res);
 }
 
 test "math.sqrt_int" {
+    expect(sqrt_int(u0, 0) == 0);
+    expect(sqrt_int(u1, 1) == 1);
     expect(sqrt_int(u32, 3) == 1);
     expect(sqrt_int(u32, 4) == 2);
     expect(sqrt_int(u32, 5) == 2);
@@ -74,7 +82,13 @@ test "math.sqrt_int" {
 /// Returns the return type `sqrt` will return given an operand of type `T`.
 pub fn Sqrt(comptime T: type) type {
     return switch (@typeInfo(T)) {
-        .Int => |int| std.meta.Int(.unsigned, int.bits / 2),
+        .Int => |int| {
+            return switch (int.bits) {
+                0 => u0,
+                1 => u1,
+                else => std.meta.Int(.unsigned, int.bits / 2),
+            };
+        },
         else => T,
     };
 }

--- a/lib/std/special/c.zig
+++ b/lib/std/special/c.zig
@@ -85,7 +85,7 @@ test "strncpy" {
     var s1: [9:0]u8 = undefined;
 
     s1[0] = 0;
-    _ = strncpy(&s1, "foobarbaz", 9);
+    _ = strncpy(&s1, "foobarbaz", @sizeOf(@TypeOf(s1)));
     std.testing.expectEqualSlices(u8, "foobarbaz", std.mem.spanZ(&s1));
 }
 
@@ -993,17 +993,24 @@ export fn sqrt(x: f64) f64 {
 }
 
 test "sqrt" {
-    const epsilon = 0.000001;
+    const V = [_]f64{
+        0.0,
+        4.089288054930154,
+        7.538757127071935,
+        8.97780793672623,
+        5.304443821913729,
+        5.682408965311888,
+        0.5846878579110049,
+        3.650338664297043,
+        0.3178091951800732,
+        7.1505232436382835,
+        3.6589165881946464,
+    };
 
-    std.testing.expect(sqrt(0.0) == 0.0);
-    std.testing.expect(std.math.approxEqAbs(f64, sqrt(2.0), 1.414214, epsilon));
-    std.testing.expect(std.math.approxEqAbs(f64, sqrt(3.6), 1.897367, epsilon));
-    std.testing.expect(sqrt(4.0) == 2.0);
-    std.testing.expect(std.math.approxEqAbs(f64, sqrt(7.539840), 2.745877, epsilon));
-    std.testing.expect(std.math.approxEqAbs(f64, sqrt(19.230934), 4.385309, epsilon));
-    std.testing.expect(sqrt(64.0) == 8.0);
-    std.testing.expect(std.math.approxEqAbs(f64, sqrt(64.1), 8.006248, epsilon));
-    std.testing.expect(std.math.approxEqAbs(f64, sqrt(8942.230469), 94.563367, epsilon));
+    // Note that @sqrt will either generate the sqrt opcode (if supported by the
+    // target ISA) or a call to `sqrtf` otherwise.
+    for (V) |val|
+        std.testing.expectEqual(@sqrt(val), sqrt(val));
 }
 
 test "sqrt special" {
@@ -1091,17 +1098,24 @@ export fn sqrtf(x: f32) f32 {
 }
 
 test "sqrtf" {
-    const epsilon = 0.000001;
+    const V = [_]f32{
+        0.0,
+        4.089288054930154,
+        7.538757127071935,
+        8.97780793672623,
+        5.304443821913729,
+        5.682408965311888,
+        0.5846878579110049,
+        3.650338664297043,
+        0.3178091951800732,
+        7.1505232436382835,
+        3.6589165881946464,
+    };
 
-    std.testing.expect(sqrtf(0.0) == 0.0);
-    std.testing.expect(std.math.approxEqAbs(f32, sqrtf(2.0), 1.414214, epsilon));
-    std.testing.expect(std.math.approxEqAbs(f32, sqrtf(3.6), 1.897367, epsilon));
-    std.testing.expect(sqrtf(4.0) == 2.0);
-    std.testing.expect(std.math.approxEqAbs(f32, sqrtf(7.539840), 2.745877, epsilon));
-    std.testing.expect(std.math.approxEqAbs(f32, sqrtf(19.230934), 4.385309, epsilon));
-    std.testing.expect(sqrtf(64.0) == 8.0);
-    std.testing.expect(std.math.approxEqAbs(f32, sqrtf(64.1), 8.006248, epsilon));
-    std.testing.expect(std.math.approxEqAbs(f32, sqrtf(8942.230469), 94.563370, epsilon));
+    // Note that @sqrt will either generate the sqrt opcode (if supported by the
+    // target ISA) or a call to `sqrtf` otherwise.
+    for (V) |val|
+        std.testing.expectEqual(@sqrt(val), sqrtf(val));
 }
 
 test "sqrtf special" {


### PR DESCRIPTION
* Add some more tests for the sqrt/sqrtf implementations.
  The idea is to cross-check the software impl with the HW one whenever
  possible.
* Fix a broken test, oops.

I'll eventually move the sqrt/modf implementations out of there but this is a good starting point to detect accidental breakage.