### PR TITLE
Add option to hide build command on compilation error to build_runner

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -45,7 +45,8 @@ pub const Builder = struct {
     verbose_llvm_ir: bool,
     verbose_cimport: bool,
     verbose_llvm_cpu_features: bool,
-    hide_build_command_on_error: bool,
+    /// The purpose of executing the command is for a human to read compile errors from the terminal
+    prominent_compile_errors: bool,
     color: enum { auto, on, off } = .auto,
     invalid_user_input: bool,
     zig_exe: []const u8,
@@ -158,7 +159,7 @@ pub const Builder = struct {
             .verbose_llvm_ir = false,
             .verbose_cimport = false,
             .verbose_llvm_cpu_features = false,
-            .hide_build_command_on_error = false,
+            .prominent_compile_errors = false,
             .invalid_user_input = false,
             .allocator = allocator,
             .user_input_options = UserInputOptionsMap.init(allocator),
@@ -1164,7 +1165,7 @@ pub const Builder = struct {
             },
             error.ExitCodeFailure => {
                 if (src_step) |s| warn("{s}...", .{s.name});
-                if (self.hide_build_command_on_error) {
+                if (self.prominent_compile_errors) {
                     warn("The step exited with error code {d}\n", .{code});
                 } else {
                     warn("The following command exited with error code {d}:\n", .{code});

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -45,6 +45,7 @@ pub const Builder = struct {
     verbose_llvm_ir: bool,
     verbose_cimport: bool,
     verbose_llvm_cpu_features: bool,
+    hide_build_command_on_error: bool,
     color: enum { auto, on, off } = .auto,
     invalid_user_input: bool,
     zig_exe: []const u8,
@@ -157,6 +158,7 @@ pub const Builder = struct {
             .verbose_llvm_ir = false,
             .verbose_cimport = false,
             .verbose_llvm_cpu_features = false,
+            .hide_build_command_on_error = false,
             .invalid_user_input = false,
             .allocator = allocator,
             .user_input_options = UserInputOptionsMap.init(allocator),
@@ -1162,8 +1164,13 @@ pub const Builder = struct {
             },
             error.ExitCodeFailure => {
                 if (src_step) |s| warn("{s}...", .{s.name});
-                warn("The following command exited with error code {d}:\n", .{code});
-                printCmd(null, argv);
+                if (self.hide_build_command_on_error) {
+                    warn("The step exited with error code {d}\n", .{code});
+                } else {
+                    warn("The following command exited with error code {d}:\n", .{code});
+                    printCmd(null, argv);
+                }
+
                 std.os.exit(@truncate(u8, code));
             },
             error.ProcessTerminated => {

--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -221,11 +221,19 @@ fn make(step: *Step) !void {
     switch (term) {
         .Exited => |code| {
             if (code != self.expected_exit_code) {
-                warn("The following command exited with error code {} (expected {}):\n", .{
-                    code,
-                    self.expected_exit_code,
-                });
-                printCmd(cwd, argv);
+                if (self.builder.prominent_compile_errors) {
+                    warn("Run step exited with error code {} (expected {})\n", .{
+                        code,
+                        self.expected_exit_code,
+                    });
+                } else {
+                    warn("The following command exited with error code {} (expected {}):\n", .{
+                        code,
+                        self.expected_exit_code,
+                    });
+                    printCmd(cwd, argv);
+                }
+
                 return error.UncleanExit;
             }
         },

--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -216,15 +216,15 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
             try fmt.allocPrint(allocator, "{s} (default)", .{top_level_step.step.name})
         else
             top_level_step.step.name;
-        try out_stream.print("  {s:<27}   {s}\n", .{ name, top_level_step.description });
+        try out_stream.print("  {s:<29} {s}\n", .{ name, top_level_step.description });
     }
 
     try out_stream.writeAll(
         \\
         \\General Options:
-        \\  -p, --prefix         [path]   Override default install prefix
-        \\  --prefix-lib-dir     [path]   Override default library directory path
-        \\  --prefix-exe-dir     [path]   Override default executable directory path
+        \\  -p, --prefix [path]           Override default install prefix
+        \\  --prefix-lib-dir [path]       Override default library directory path
+        \\  --prefix-exe-dir [path]       Override default executable directory path
         \\  --prefix-include-dir [path]   Override default include directory path
         \\
         \\  --sysroot [path]              Set the system root directory (usually /)
@@ -248,7 +248,7 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
                 @tagName(option.type_id),
             });
             defer allocator.free(name);
-            try out_stream.print("{s:<29}   {s}\n", .{ name, option.description });
+            try out_stream.print("{s:<31} {s}\n", .{ name, option.description });
         }
     }
 

--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -157,6 +157,8 @@ pub fn main() !void {
                 builder.verbose_cc = true;
             } else if (mem.eql(u8, arg, "--verbose-llvm-cpu-features")) {
                 builder.verbose_llvm_cpu_features = true;
+            } else if (mem.eql(u8, arg, "--hide-build-command-on-error")) {
+                builder.hide_build_command_on_error = true;
             } else if (mem.eql(u8, arg, "--")) {
                 builder.args = argsRest(args, arg_idx);
                 break;
@@ -214,24 +216,24 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
             try fmt.allocPrint(allocator, "{s} (default)", .{top_level_step.step.name})
         else
             top_level_step.step.name;
-        try out_stream.print("  {s:<27} {s}\n", .{ name, top_level_step.description });
+        try out_stream.print("  {s:<27}   {s}\n", .{ name, top_level_step.description });
     }
 
     try out_stream.writeAll(
         \\
         \\General Options:
-        \\  -p, --prefix         [path] Override default install prefix
-        \\  --prefix-lib-dir     [path] Override default library directory path
-        \\  --prefix-exe-dir     [path] Override default executable directory path
-        \\  --prefix-include-dir [path] Override default include directory path
+        \\  -p, --prefix         [path]   Override default install prefix
+        \\  --prefix-lib-dir     [path]   Override default library directory path
+        \\  --prefix-exe-dir     [path]   Override default executable directory path
+        \\  --prefix-include-dir [path]   Override default include directory path
         \\
-        \\  --sysroot [path]            Set the system root directory (usually /)
-        \\  --search-prefix [path]      Add a path to look for binaries, libraries, headers
-        \\  --libc [file]               Provide a file which specifies libc paths
+        \\  --sysroot [path]              Set the system root directory (usually /)
+        \\  --search-prefix [path]        Add a path to look for binaries, libraries, headers
+        \\  --libc [file]                 Provide a file which specifies libc paths
         \\
-        \\  -h, --help                  Print this help and exit
-        \\  --verbose                   Print commands before executing them
-        \\  --color [auto|off|on]       Enable or disable colored error messages
+        \\  -h, --help                    Print this help and exit
+        \\  --verbose                     Print commands before executing them
+        \\  --color [auto|off|on]         Enable or disable colored error messages
         \\
         \\Project-Specific Options:
         \\
@@ -246,24 +248,25 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
                 @tagName(option.type_id),
             });
             defer allocator.free(name);
-            try out_stream.print("{s:<29} {s}\n", .{ name, option.description });
+            try out_stream.print("{s:<29}   {s}\n", .{ name, option.description });
         }
     }
 
     try out_stream.writeAll(
         \\
         \\Advanced Options:
-        \\  --build-file [file]         Override path to build.zig
-        \\  --cache-dir [path]          Override path to zig cache directory
-        \\  --zig-lib-dir [arg]         Override path to Zig lib directory
-        \\  --verbose-tokenize          Enable compiler debug output for tokenization
-        \\  --verbose-ast               Enable compiler debug output for parsing into an AST
-        \\  --verbose-link              Enable compiler debug output for linking
-        \\  --verbose-ir                Enable compiler debug output for Zig IR
-        \\  --verbose-llvm-ir           Enable compiler debug output for LLVM IR
-        \\  --verbose-cimport           Enable compiler debug output for C imports
-        \\  --verbose-cc                Enable compiler debug output for C compilation
-        \\  --verbose-llvm-cpu-features Enable compiler debug output for LLVM CPU features
+        \\  --build-file [file]           Override path to build.zig
+        \\  --cache-dir [path]            Override path to zig cache directory
+        \\  --zig-lib-dir [arg]           Override path to Zig lib directory
+        \\  --verbose-tokenize            Enable compiler debug output for tokenization
+        \\  --verbose-ast                 Enable compiler debug output for parsing into an AST
+        \\  --verbose-link                Enable compiler debug output for linking
+        \\  --verbose-ir                  Enable compiler debug output for Zig IR
+        \\  --verbose-llvm-ir             Enable compiler debug output for LLVM IR
+        \\  --verbose-cimport             Enable compiler debug output for C imports
+        \\  --verbose-cc                  Enable compiler debug output for C compilation
+        \\  --verbose-llvm-cpu-features   Enable compiler debug output for LLVM CPU features
+        \\  --hide-build-command-on-error Disable output of build command on failure
         \\
     );
 }

--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -157,8 +157,8 @@ pub fn main() !void {
                 builder.verbose_cc = true;
             } else if (mem.eql(u8, arg, "--verbose-llvm-cpu-features")) {
                 builder.verbose_llvm_cpu_features = true;
-            } else if (mem.eql(u8, arg, "--hide-build-command-on-error")) {
-                builder.hide_build_command_on_error = true;
+            } else if (mem.eql(u8, arg, "--prominent-compile-errors")) {
+                builder.prominent_compile_errors = true;
             } else if (mem.eql(u8, arg, "--")) {
                 builder.args = argsRest(args, arg_idx);
                 break;
@@ -216,24 +216,25 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
             try fmt.allocPrint(allocator, "{s} (default)", .{top_level_step.step.name})
         else
             top_level_step.step.name;
-        try out_stream.print("  {s:<29} {s}\n", .{ name, top_level_step.description });
+        try out_stream.print("  {s:<28} {s}\n", .{ name, top_level_step.description });
     }
 
     try out_stream.writeAll(
         \\
         \\General Options:
-        \\  -p, --prefix [path]           Override default install prefix
-        \\  --prefix-lib-dir [path]       Override default library directory path
-        \\  --prefix-exe-dir [path]       Override default executable directory path
-        \\  --prefix-include-dir [path]   Override default include directory path
+        \\  -p, --prefix [path]          Override default install prefix
+        \\  --prefix-lib-dir [path]      Override default library directory path
+        \\  --prefix-exe-dir [path]      Override default executable directory path
+        \\  --prefix-include-dir [path]  Override default include directory path
         \\
-        \\  --sysroot [path]              Set the system root directory (usually /)
-        \\  --search-prefix [path]        Add a path to look for binaries, libraries, headers
-        \\  --libc [file]                 Provide a file which specifies libc paths
+        \\  --sysroot [path]             Set the system root directory (usually /)
+        \\  --search-prefix [path]       Add a path to look for binaries, libraries, headers
+        \\  --libc [file]                Provide a file which specifies libc paths
         \\
-        \\  -h, --help                    Print this help and exit
-        \\  --verbose                     Print commands before executing them
-        \\  --color [auto|off|on]         Enable or disable colored error messages
+        \\  -h, --help                   Print this help and exit
+        \\  --verbose                    Print commands before executing them
+        \\  --color [auto|off|on]        Enable or disable colored error messages
+        \\  --prominent-compile-errors   Output compile errors formatted for a human to read
         \\
         \\Project-Specific Options:
         \\
@@ -248,25 +249,24 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
                 @tagName(option.type_id),
             });
             defer allocator.free(name);
-            try out_stream.print("{s:<31} {s}\n", .{ name, option.description });
+            try out_stream.print("{s:<30} {s}\n", .{ name, option.description });
         }
     }
 
     try out_stream.writeAll(
         \\
         \\Advanced Options:
-        \\  --build-file [file]           Override path to build.zig
-        \\  --cache-dir [path]            Override path to zig cache directory
-        \\  --zig-lib-dir [arg]           Override path to Zig lib directory
-        \\  --verbose-tokenize            Enable compiler debug output for tokenization
-        \\  --verbose-ast                 Enable compiler debug output for parsing into an AST
-        \\  --verbose-link                Enable compiler debug output for linking
-        \\  --verbose-ir                  Enable compiler debug output for Zig IR
-        \\  --verbose-llvm-ir             Enable compiler debug output for LLVM IR
-        \\  --verbose-cimport             Enable compiler debug output for C imports
-        \\  --verbose-cc                  Enable compiler debug output for C compilation
-        \\  --verbose-llvm-cpu-features   Enable compiler debug output for LLVM CPU features
-        \\  --hide-build-command-on-error Disable output of build command on failure
+        \\  --build-file [file]          Override path to build.zig
+        \\  --cache-dir [path]           Override path to zig cache directory
+        \\  --zig-lib-dir [arg]          Override path to Zig lib directory
+        \\  --verbose-tokenize           Enable compiler debug output for tokenization
+        \\  --verbose-ast                Enable compiler debug output for parsing into an AST
+        \\  --verbose-link               Enable compiler debug output for linking
+        \\  --verbose-ir                 Enable compiler debug output for Zig IR
+        \\  --verbose-llvm-ir            Enable compiler debug output for LLVM IR
+        \\  --verbose-cimport            Enable compiler debug output for C imports
+        \\  --verbose-cc                 Enable compiler debug output for C compilation
+        \\  --verbose-llvm-cpu-features  Enable compiler debug output for LLVM CPU features
         \\
     );
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -2722,6 +2722,8 @@ pub const usage_build =
 ;
 
 pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !void {
+    var prominent_compile_errors: bool = false;
+
     // We want to release all the locks before executing the child process, so we make a nice
     // big block here to ensure the cleanup gets run when we extract out our argv.
     const child_argv = argv: {
@@ -2773,6 +2775,8 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
                         i += 1;
                         override_global_cache_dir = args[i];
                         continue;
+                    } else if (mem.eql(u8, arg, "--prominent-compile-errors")) {
+                        prominent_compile_errors = true;
                     }
                 }
                 try child_argv.append(arg);
@@ -2942,8 +2946,13 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
     switch (term) {
         .Exited => |code| {
             if (code == 0) return cleanExit();
-            const cmd = try argvCmd(arena, child_argv);
-            fatal("the following build command failed with exit code {d}:\n{s}", .{ code, cmd });
+
+            if (prominent_compile_errors) {
+                fatal("the build command failed with exit code {d}", .{code});
+            } else {
+                const cmd = try argvCmd(arena, child_argv);
+                fatal("the following build command failed with exit code {d}:\n{s}", .{ code, cmd });
+            }
         },
         else => {
             const cmd = try argvCmd(arena, child_argv);


### PR DESCRIPTION
I know https://github.com/ziglang/zig/issues/6673 is still open with no consensus for the long term improvement of cli errors, but with a project with a large number of C files added you get errors like [this](https://pastebin.com/NuJ11rMn) (~36,000 characters of build command) which is just actively hostile to a nice debugging experience.

This PR is a stopgap that is not intended to be permanent which adds `hide_build_command_on_error: bool` on builder and `--hide-build-command-on-error` command line argument when using `zig build`

The scope of this change is kept small with the flag only taken into account in `execFromStep` when encountering a `ExitCodeFailure` as this is the path that a normal failed compilation will execute, rather than checking this flag everytime a failed command is to be printed e.g. on file not found.  