### PR TITLE
translate-c: wrap switch statements in a while (true) loop

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1410,4 +1410,47 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\}
     , "");
 
+    cases.add("break from switch statement. Issue #8387",
+        \\#include <stdlib.h>
+        \\int switcher(int x) {
+        \\    switch (x) {
+        \\        case 0:      // no braces
+        \\            x += 1;
+        \\            break;
+        \\        case 1:      // conditional break
+        \\            if (x == 1) {
+        \\                x += 1;
+        \\                break;
+        \\            }
+        \\            x += 100;
+        \\        case 2: {    // braces with fallthrough
+        \\            x += 1;
+        \\        }
+        \\        case 3:      // fallthrough to return statement
+        \\            x += 1;
+        \\        case 42: {   // random out of order case
+        \\            x += 1;
+        \\            return x;
+        \\        }
+        \\        case 4: {    // break within braces
+        \\            x += 1;
+        \\            break;
+        \\        }
+        \\        case 5:
+        \\            x += 1;  // fallthrough to default
+        \\        default:
+        \\            x += 1;
+        \\    }
+        \\    return x;
+        \\}
+        \\int main(void) {
+        \\    int expected[] = {1, 2, 5, 5, 5, 7, 7};
+        \\    for (int i = 0; i < sizeof(expected) / sizeof(int); i++) {
+        \\        int res = switcher(i);
+        \\        if (res != expected[i]) abort();
+        \\    }
+        \\    if (switcher(42) != 43) abort();
+        \\    return 0;
+        \\}
+    , "");
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2072,40 +2072,49 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn switch_fn(arg_i: c_int) void {
         \\    var i = arg_i;
         \\    var res: c_int = 0;
-        \\    switch (i) {
-        \\        @as(c_int, 0) => {
-        \\            res = 1;
-        \\            res = 2;
-        \\            res = @as(c_int, 3) * i;
-        \\        },
-        \\        @as(c_int, 1)...@as(c_int, 3) => {
-        \\            res = 2;
-        \\            res = @as(c_int, 3) * i;
-        \\        },
-        \\        else => {
-        \\            res = @as(c_int, 3) * i;
-        \\        },
-        \\        @as(c_int, 7) => {
-        \\            {
-        \\                res = 7;
+        \\    while (true) {
+        \\        switch (i) {
+        \\            @as(c_int, 0) => {
+        \\                res = 1;
+        \\                res = 2;
+        \\                res = @as(c_int, 3) * i;
         \\                break;
-        \\            }
-        \\        },
-        \\        @as(c_int, 4), @as(c_int, 5) => {
-        \\            res = 69;
-        \\            {
-        \\                res = 5;
+        \\            },
+        \\            @as(c_int, 1)...@as(c_int, 3) => {
+        \\                res = 2;
+        \\                res = @as(c_int, 3) * i;
+        \\                break;
+        \\            },
+        \\            else => {
+        \\                res = @as(c_int, 3) * i;
+        \\                break;
+        \\            },
+        \\            @as(c_int, 7) => {
+        \\                {
+        \\                    res = 7;
+        \\                    break;
+        \\                }
+        \\            },
+        \\            @as(c_int, 4), @as(c_int, 5) => {
+        \\                res = 69;
+        \\                {
+        \\                    res = 5;
+        \\                    return;
+        \\                }
+        \\            },
+        \\            @as(c_int, 6) => {
+        \\                while (true) {
+        \\                    switch (res) {
+        \\                        @as(c_int, 9) => break,
+        \\                        else => {},
+        \\                    }
+        \\                    break;
+        \\                }
+        \\                res = 1;
         \\                return;
-        \\            }
-        \\        },
-        \\        @as(c_int, 6) => {
-        \\            switch (res) {
-        \\                @as(c_int, 9) => {},
-        \\                else => {},
-        \\            }
-        \\            res = 1;
-        \\            return;
-        \\        },
+        \\            },
+        \\        }
+        \\        break;
         \\    }
         \\}
     });


### PR DESCRIPTION
This allows `break` statements to be directly translated from the original C.
Add a break statement as the last statement of the while loop to ensure we
don't have an infinite loop if no breaks / returns are hit in the switch.

Fixes #8387