### PR TITLE
zld: fix symbol resolution from interdependent static archives

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -16,6 +16,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/mix_o_files/build.zig");
     cases.addBuildFile("test/standalone/global_linkage/build.zig");
     cases.addBuildFile("test/standalone/static_c_lib/build.zig");
+    cases.addBuildFile("test/standalone/link_interdependent_static_c_libs/build.zig");
     cases.addBuildFile("test/standalone/issue_339/build.zig");
     cases.addBuildFile("test/standalone/issue_794/build.zig");
     cases.addBuildFile("test/standalone/issue_5825/build.zig");

--- a/test/standalone/link_interdependent_static_c_libs/a.c
+++ b/test/standalone/link_interdependent_static_c_libs/a.c
@@ -1,0 +1,4 @@
+#include "a.h"
+int32_t add(int32_t a, int32_t b) {
+    return a + b;
+}

--- a/test/standalone/link_interdependent_static_c_libs/a.h
+++ b/test/standalone/link_interdependent_static_c_libs/a.h
@@ -1,0 +1,2 @@
+#include <stdint.h>
+int32_t add(int32_t a, int32_t b);

--- a/test/standalone/link_interdependent_static_c_libs/b.c
+++ b/test/standalone/link_interdependent_static_c_libs/b.c
@@ -1,0 +1,6 @@
+#include "a.h"
+#include "b.h"
+
+int32_t sub(int32_t a, int32_t b) {
+  return add(a, -1 * b);
+}

--- a/test/standalone/link_interdependent_static_c_libs/b.h
+++ b/test/standalone/link_interdependent_static_c_libs/b.h
@@ -1,0 +1,2 @@
+#include <stdint.h>
+int32_t sub(int32_t a, int32_t b);

--- a/test/standalone/link_interdependent_static_c_libs/build.zig
+++ b/test/standalone/link_interdependent_static_c_libs/build.zig
@@ -1,0 +1,24 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const lib_a = b.addStaticLibrary("a", null);
+    lib_a.addCSourceFile("a.c", &[_][]const u8{});
+    lib_a.setBuildMode(mode);
+    lib_a.addIncludeDir(".");
+
+    const lib_b = b.addStaticLibrary("b", null);
+    lib_b.addCSourceFile("b.c", &[_][]const u8{});
+    lib_b.setBuildMode(mode);
+    lib_b.addIncludeDir(".");
+
+    const test_exe = b.addTest("main.zig");
+    test_exe.setBuildMode(mode);
+    test_exe.linkLibrary(lib_a);
+    test_exe.linkLibrary(lib_b);
+    test_exe.addIncludeDir(".");
+
+    const test_step = b.step("test", "Test it");
+    test_step.dependOn(&test_exe.step);
+}

--- a/test/standalone/link_interdependent_static_c_libs/main.zig
+++ b/test/standalone/link_interdependent_static_c_libs/main.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const expect = std.testing.expect;
+const c = @cImport(@cInclude("b.h"));
+
+test "import C sub" {
+    const result = c.sub(2, 1);
+    expect(result == 1);
+}


### PR DESCRIPTION
Fixes symbol resolution if an archive occurring later in the linker line depends on a object embedded within the archive that occurred before. For example, if the linker line has the following:

```
main.o libA.a libB.a
```

where `main.o` pulls a symbol `_sub` from `libB.a`, which in turn is dependent on a symbol `_add` from `libA.a`, this fix correctly resolves `_sub` and `_add`. Prior to this fix, `_add` would be unresolved and expected within `libSystem.B.dylib`.

This commit also adds a standalone test case to that effect to shield ourselves from possible regressions in the future.