### PR TITLE
stage1: fix case close to 8520

### DIFF
--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -18896,6 +18896,14 @@ static IrInstGen *ir_analyze_instruction_merge_err_sets(IrAnalyze *ira,
 
 static IrInstGen *ir_analyze_instruction_bin_op(IrAnalyze *ira, IrInstSrcBinOp *bin_op_instruction) {
     IrBinOp op_id = bin_op_instruction->op_id;
+    if (bin_op_instruction->op1->child->value->special == ConstValSpecialUndef) {
+        ir_add_error_node(ira, bin_op_instruction->op1->base.source_node, buf_sprintf("use of undefined value here causes undefined behavior"));
+        return ira->codegen->invalid_inst_gen;
+    }
+    if (bin_op_instruction->op2->child->value->special == ConstValSpecialUndef) {
+        ir_add_error_node(ira, bin_op_instruction->op2->base.source_node, buf_sprintf("use of undefined value here causes undefined behavior"));
+        return ira->codegen->invalid_inst_gen;
+    }
     switch (op_id) {
         case IrBinOpInvalid:
             zig_unreachable();


### PR DESCRIPTION
Fix a case close to #8520.
```zig
const expect = @import("std").testing.expect;
const Empty = struct {
    pub const PI = 3.14;
    pub const PI2: u32 = undefined;
};
test "struct namespaced variable" {
    expect(Empty.PI == 3.14);
    expect(Empty.PI2 == 3.14); // fails to fail
    expect(@sizeOf(Empty) == 0);

    // you can still instantiate an empty struct
    const does_nothing = Empty{};
}
```
![image](https://user-images.githubusercontent.com/58830309/114649569-c0557280-9cae-11eb-8650-560976f8c08f.png)
Note: without the u32 type annotation here, it does not work.