### PR TITLE
Fix call to selectSymbol in std.os.windows.user32.messageBoxW

### DIFF
--- a/lib/std/os/windows/user32.zig
+++ b/lib/std/os/windows/user32.zig
@@ -663,7 +663,7 @@ pub fn messageBoxA(hWnd: ?HWND, lpText: [*:0]const u8, lpCaption: [*:0]const u8,
 pub extern "user32" fn MessageBoxW(hWnd: ?HWND, lpText: [*:0]const u16, lpCaption: ?[*:0]const u16, uType: UINT) callconv(WINAPI) i32;
 pub var pfnMessageBoxW: @TypeOf(MessageBoxW) = undefined;
 pub fn messageBoxW(hWnd: ?HWND, lpText: [*:0]const u16, lpCaption: [*:0]const u16, uType: u32) !i32 {
-    const function = selectSymbol(pfnMessageBoxW, MessageBoxW, .win2k);
+    const function = selectSymbol(MessageBoxW, pfnMessageBoxW, .win2k);
     const value = function(hWnd, lpText, lpCaption, uType);
     if (value != 0) return value;
     switch (GetLastError()) {


### PR DESCRIPTION
Arguments to `selectSymbol` were passed in the wrong order. It expects the static function pointer as first argument.

https://github.com/ziglang/zig/blob/a38042e3ac446194ae1496513d9b4634b1dd94b8/lib/std/os/windows/user32.zig#L15-L22