### PR TITLE
stage2 codegen: Fix silent bug in reuseOperand

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1247,7 +1247,6 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                 },
                 .stack_offset => |off| {
                     log.debug("reusing stack offset {} => {*}", .{ off, inst });
-                    return true;
                 },
                 else => return false,
             }


### PR DESCRIPTION
The premature `return true;` prevents the book-keeping code from running which is necessary for marking the operand in question as not dead anymore.