### PR TITLE
add Thread.setName and Thread.getName

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -193,6 +193,8 @@ pub const pthread_attr_t = extern struct {
 
 const pthread_t = std.c.pthread_t;
 pub extern "c" fn pthread_threadid_np(thread: ?pthread_t, thread_id: *u64) c_int;
+pub extern "c" fn pthread_setname_np(name: [*:0]const u8) c_int;
+pub extern "c" fn pthread_getname_np(thread: std.c.pthread_t, name: [*:0]u8, len: usize) c_int;
 
 pub extern "c" fn arc4random_buf(buf: [*]u8, len: usize) void;
 

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -14,6 +14,8 @@ pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;
 
 pub extern "c" fn pthread_getthreadid_np() c_int;
+pub extern "c" fn pthread_set_name_np(thread: std.c.pthread_t, name: [*:0]const u8) void;
+pub extern "c" fn pthread_get_name_np(thread: std.c.pthread_t, name: [*:0]u8, len: usize) void;
 pub extern "c" fn pipe2(fds: *[2]fd_t, flags: u32) c_int;
 
 pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -186,6 +186,9 @@ const __SIZEOF_PTHREAD_MUTEX_T = if (os_tag == .fuchsia) 40 else switch (abi) {
 };
 const __SIZEOF_SEM_T = 4 * @sizeOf(usize);
 
+pub extern "c" fn pthread_setname_np(thread: std.c.pthread_t, name: [*:0]const u8) c_int;
+pub extern "c" fn pthread_getname_np(thread: std.c.pthread_t, name: [*:0]u8, len: usize) c_int;
+
 pub const RTLD_LAZY = 1;
 pub const RTLD_NOW = 2;
 pub const RTLD_NOLOAD = 4;

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -94,3 +94,6 @@ pub const pthread_attr_t = extern struct {
 };
 
 pub const sem_t = ?*opaque {};
+
+pub extern "c" fn pthread_setname_np(thread: std.c.pthread_t, name: [*:0]const u8, arg: ?*c_void) c_int;
+pub extern "c" fn pthread_getname_np(thread: std.c.pthread_t, name: [*:0]u8, len: usize) c_int;

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -45,3 +45,6 @@ pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usiz
 
 pub extern "c" fn pledge(promises: ?[*:0]const u8, execpromises: ?[*:0]const u8) c_int;
 pub extern "c" fn unveil(path: ?[*:0]const u8, permissions: ?[*:0]const u8) c_int;
+
+pub extern "c" fn pthread_set_name_np(thread: std.c.pthread_t, name: [*:0]const u8) void;
+pub extern "c" fn pthread_get_name_np(thread: std.c.pthread_t, name: [*:0]u8, len: usize) void;

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1631,6 +1631,10 @@ pub fn HeapDestroy(hHeap: HANDLE) void {
     assert(kernel32.HeapDestroy(hHeap) != 0);
 }
 
+pub fn LocalFree(hMem: HLOCAL) void {
+    assert(kernel32.LocalFree(hMem) == null);
+}
+
 pub const GetFileInformationByHandleError = error{Unexpected};
 
 pub fn GetFileInformationByHandle(
@@ -2009,6 +2013,21 @@ pub fn unexpectedStatus(status: NTSTATUS) std.os.UnexpectedError {
         std.debug.dumpCurrentStackTrace(null);
     }
     return error.Unexpected;
+}
+
+pub fn SetThreadDescription(hThread: HANDLE, lpThreadDescription: LPCWSTR) !void {
+    if (kernel32.SetThreadDescription(hThread, lpThreadDescription) == 0) {
+        switch (kernel32.GetLastError()) {
+            else => |err| return unexpectedError(err),
+        }
+    }
+}
+pub fn GetThreadDescription(hThread: HANDLE, ppszThreadDescription: *LPWSTR) !void {
+    if (kernel32.GetThreadDescription(hThread, ppszThreadDescription) == 0) {
+        switch (kernel32.GetLastError()) {
+            else => |err| return unexpectedError(err),
+        }
+    }
 }
 
 test "" {

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -192,6 +192,8 @@ pub extern "kernel32" fn HeapValidate(hHeap: HANDLE, dwFlags: DWORD, lpMem: ?*co
 pub extern "kernel32" fn VirtualAlloc(lpAddress: ?LPVOID, dwSize: SIZE_T, flAllocationType: DWORD, flProtect: DWORD) callconv(WINAPI) ?LPVOID;
 pub extern "kernel32" fn VirtualFree(lpAddress: ?LPVOID, dwSize: SIZE_T, dwFreeType: DWORD) callconv(WINAPI) BOOL;
 
+pub extern "kernel32" fn LocalFree(hMem: HLOCAL) callconv(WINAPI) ?HLOCAL;
+
 pub extern "kernel32" fn MoveFileExW(
     lpExistingFileName: [*:0]const u16,
     lpNewFileName: [*:0]const u16,
@@ -342,3 +344,6 @@ pub extern "kernel32" fn SleepConditionVariableSRW(
 pub extern "kernel32" fn TryAcquireSRWLockExclusive(s: *SRWLOCK) callconv(WINAPI) BOOLEAN;
 pub extern "kernel32" fn AcquireSRWLockExclusive(s: *SRWLOCK) callconv(WINAPI) void;
 pub extern "kernel32" fn ReleaseSRWLockExclusive(s: *SRWLOCK) callconv(WINAPI) void;
+
+pub extern "kernel32" fn SetThreadDescription(hThread: HANDLE, lpThreadDescription: LPCWSTR) callconv(WINAPI) HRESULT;
+pub extern "kernel32" fn GetThreadDescription(hThread: HANDLE, ppszThreadDescription: *LPWSTR) callconv(WINAPI) HRESULT;


### PR DESCRIPTION
This PR adds `Thread.setName` and `Thread.getName`.

It's not complete, I only tested this on linux. I spent a bit of time researching what other platforms do and from what I can tell setting/getting a thread's name is supported on linux, windows (since [Windows 10](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreaddescription)), [macos](https://opensource.apple.com/source/libpthread/libpthread-454.80.2/include/pthread/pthread.h.auto.html), [openbsd](https://man.openbsd.org/pthread_get_name_np.3), [freebsd](https://www.freebsd.org/cgi/man.cgi?query=pthread_getname_np&apropos=0&sektion=3&manpath=FreeBSD+12.2-RELEASE+and+Ports&arch=default&format=html), [netbsd](https://man.netbsd.org/pthread_getname_np.3).
Annoyingly since it's non standard there are some slight differences between implementations of `pthread_setname_np`.

Before implementing everything I'd like to get some early feedback on the API.