### PR TITLE
Fix .gitattributes rules that should be recursive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,9 +3,9 @@
 langref.html.in text eol=lf
 deps/SoftFloat-3e/*.txt text eol=crlf
 
-deps/* linguist-vendored
-lib/include/* linguist-vendored
-lib/libc/* linguist-vendored
-lib/libcxx/* linguist-vendored
-lib/libcxxabi/* linguist-vendored
-lib/libunwind/* linguist-vendored
+deps/** linguist-vendored
+lib/include/** linguist-vendored
+lib/libc/** linguist-vendored
+lib/libcxx/** linguist-vendored
+lib/libcxxabi/** linguist-vendored
+lib/libunwind/** linguist-vendored


### PR DESCRIPTION
These are currently incorrect according to the gitattributes(5) and
gitignore(5) man pages. However, it seems github ended up treating them
as we intended due to a bug until recently when that bug was fixed.