### PR TITLE
translate-c: group array subscript LHS if necessary

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -1353,10 +1353,14 @@ fn transCreatePointerArithmeticSignedOp(
 
     const bitcast_node = try usizeCastForWrappingPtrArithmetic(c.arena, rhs_node);
 
-    const arith_args = .{ .lhs = lhs_node, .rhs = bitcast_node };
-    const arith_node = try if (is_add) Tag.add.create(c.arena, arith_args) else Tag.sub.create(c.arena, arith_args);
-
-    return maybeSuppressResult(c, scope, result_used, arith_node);
+    return transCreateNodeInfixOp(
+        c,
+        scope,
+        if (is_add) .add else .sub,
+        lhs_node,
+        bitcast_node,
+        result_used,
+    );
 }
 
 fn transBinaryOperator(

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -1665,7 +1665,7 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
         },
         .array_access => {
             const payload = node.castTag(.array_access).?.data;
-            const lhs = try renderNode(c, payload.lhs);
+            const lhs = try renderNodeGrouped(c, payload.lhs);
             const l_bracket = try c.addToken(.l_bracket, "[");
             const index_expr = try renderNode(c, payload.rhs);
             _ = try c.addToken(.r_bracket, "]");

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1467,4 +1467,13 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Render array LHS as grouped node if necessary",
+        \\#include <stdlib.h>
+        \\int main(void) {
+        \\    int arr[] = {40, 41, 42, 43};
+        \\    if ((arr + 1)[1] != 42) abort();
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
Two small translate-c improvements:

1) Code cleanup: in `transCreatePointerArithmeticSignedOp` use the existing `transCreateNodeInfixOp` helper instead of reimplementing the logic

2) Render array subscript LHS as a grouped (parenthesized) node if necessary.