### PR TITLE
Provide method to set logging level per scope

### DIFF
--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -525,35 +525,45 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\
         \\pub const scope_levels = [_]std.log.ScopeLevel{
         \\    .{ .scope = .a, .level = .alert },
+        \\    .{ .scope = .c, .level = .emerg },
         \\};
         \\
         \\const loga = std.log.scoped(.a);
         \\const logb = std.log.scoped(.b);
+        \\const logc = std.log.scoped(.c);
         \\
         \\pub fn main() !void {
         \\    loga.debug("", .{});
         \\    logb.debug("", .{});
+        \\    logc.debug("", .{});
         \\
         \\    loga.info("", .{});
         \\    logb.info("", .{});
+        \\    logc.info("", .{});
         \\
         \\    loga.notice("", .{});
         \\    logb.notice("", .{});
+        \\    logc.notice("", .{});
         \\
         \\    loga.warn("", .{});
         \\    logb.warn("", .{});
+        \\    logc.warn("", .{});
         \\
         \\    loga.err("", .{});
         \\    logb.err("", .{});
+        \\    logc.err("", .{});
         \\
         \\    loga.crit("", .{});
         \\    logb.crit("", .{});
+        \\    logc.crit("", .{});
         \\
         \\    loga.alert("", .{});
         \\    logb.alert("", .{});
+        \\    logc.alert("", .{});
         \\
         \\    loga.emerg("", .{});
         \\    logb.emerg("", .{});
+        \\    logc.emerg("", .{});
         \\}
         \\pub fn log(
         \\    comptime level: std.log.Level,
@@ -586,6 +596,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\alert(b): 
         \\emergency(a): 
         \\emergency(b): 
+        \\emergency(c): 
         \\
     );
 }

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -516,4 +516,76 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
 
         break :x tc;
     });
+
+    // It is required to override the log function in order to print to stdout instead of stderr
+    cases.add("std.log per scope log level override",
+        \\const std = @import("std");
+        \\
+        \\pub const log_level: std.log.Level = .debug;
+        \\
+        \\pub const scope_levels = [_]std.log.ScopeLevel{
+        \\    .{ .scope = .a, .level = .alert },
+        \\};
+        \\
+        \\const loga = std.log.scoped(.a);
+        \\const logb = std.log.scoped(.b);
+        \\
+        \\pub fn main() !void {
+        \\    loga.debug("", .{});
+        \\    logb.debug("", .{});
+        \\
+        \\    loga.info("", .{});
+        \\    logb.info("", .{});
+        \\
+        \\    loga.notice("", .{});
+        \\    logb.notice("", .{});
+        \\
+        \\    loga.warn("", .{});
+        \\    logb.warn("", .{});
+        \\
+        \\    loga.err("", .{});
+        \\    logb.err("", .{});
+        \\
+        \\    loga.crit("", .{});
+        \\    logb.crit("", .{});
+        \\
+        \\    loga.alert("", .{});
+        \\    logb.alert("", .{});
+        \\
+        \\    loga.emerg("", .{});
+        \\    logb.emerg("", .{});
+        \\}
+        \\pub fn log(
+        \\    comptime level: std.log.Level,
+        \\    comptime scope: @TypeOf(.EnumLiteral),
+        \\    comptime format: []const u8,
+        \\    args: anytype,
+        \\) void {
+        \\    const level_txt = switch (level) {
+        \\        .emerg => "emergency",
+        \\        .alert => "alert",
+        \\        .crit => "critical",
+        \\        .err => "error",
+        \\        .warn => "warning",
+        \\        .notice => "notice",
+        \\        .info => "info",
+        \\        .debug => "debug",
+        \\    };
+        \\    const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
+        \\    const stdout = std.io.getStdOut().writer();
+        \\    nosuspend stdout.print(level_txt ++ prefix2 ++ format ++ "\n", args) catch return;
+        \\}
+    ,
+        \\debug(b): 
+        \\info(b): 
+        \\notice(b): 
+        \\warning(b): 
+        \\error(b): 
+        \\critical(b): 
+        \\alert(a): 
+        \\alert(b): 
+        \\emergency(a): 
+        \\emergency(b): 
+        \\
+    );
 }


### PR DESCRIPTION
This PR adds a way to override the logging level used by `std.log` on a scope by scope basis.

In order to do so the user defines a public `scope_levels` in the root file as per below:
```zig
pub const scope_levels = [_]std.log.ScopeLevel{
    .{ .scope = .liba, .level = .crit },
    .{ .scope = .memory, .level = .info },
    .{ .scope = .libds .level = .warn },
};
```

If a scope level is provided by the user for the scope in question then the provided level is used to determine if the message is logged and the global log level is ignored. If the scope is not within `scope_levels` then the global log level is used.