### PR TITLE
A few more PPC32 touch-ups

### DIFF
--- a/lib/std/os/bits/linux/powerpc.zig
+++ b/lib/std/os/bits/linux/powerpc.zig
@@ -557,18 +557,10 @@ pub const kernel_stat = extern struct {
     size: off_t,
     blksize: blksize_t,
     blocks: blkcnt_t,
-    __atim32: timespec32,
-    __mtim32: timespec32,
-    __ctim32: timespec32,
-    __unused: [2]u32,
     atim: timespec,
     mtim: timespec,
     ctim: timespec,
-
-    const timespec32 = extern struct {
-        tv_sec: i32,
-        tv_nsec: i32,
-    };
+    __unused: [2]u32,
 
     pub fn atime(self: @This()) timespec {
         return self.atim;

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -52,6 +52,7 @@ pub fn getauxval(index: usize) usize {
 // Some architectures (and some syscalls) require 64bit parameters to be passed
 // in a even-aligned register pair.
 const require_aligned_register_pair =
+    std.Target.current.cpu.arch.isPPC() or
     std.Target.current.cpu.arch.isMIPS() or
     std.Target.current.cpu.arch.isARM() or
     std.Target.current.cpu.arch.isThumb();

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -113,9 +113,11 @@ comptime {
     @export(@import("compiler_rt/extendXfYf2.zig").__extenddftf2, .{ .name = "__extenddftf2", .linkage = linkage });
     @export(@import("compiler_rt/extendXfYf2.zig").__extendsftf2, .{ .name = "__extendsftf2", .linkage = linkage });
     @export(@import("compiler_rt/extendXfYf2.zig").__extendhfsf2, .{ .name = "__extendhfsf2", .linkage = linkage });
+    @export(@import("compiler_rt/extendXfYf2.zig").__extendhftf2, .{ .name = "__extendhftf2", .linkage = linkage });
 
     @export(@import("compiler_rt/truncXfYf2.zig").__truncsfhf2, .{ .name = "__truncsfhf2", .linkage = linkage });
     @export(@import("compiler_rt/truncXfYf2.zig").__truncdfhf2, .{ .name = "__truncdfhf2", .linkage = linkage });
+    @export(@import("compiler_rt/truncXfYf2.zig").__trunctfhf2, .{ .name = "__trunctfhf2", .linkage = linkage });
     @export(@import("compiler_rt/truncXfYf2.zig").__trunctfdf2, .{ .name = "__trunctfdf2", .linkage = linkage });
     @export(@import("compiler_rt/truncXfYf2.zig").__trunctfsf2, .{ .name = "__trunctfsf2", .linkage = linkage });
 

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -296,7 +296,7 @@ comptime {
         @export(@import("compiler_rt/sparc.zig")._Qp_qtod, .{ .name = "_Qp_qtod", .linkage = linkage });
     }
 
-    if (builtin.arch == .powerpc or builtin.arch.isPPC64()) {
+    if ((builtin.arch == .powerpc or builtin.arch.isPPC64()) and !is_test) {
         @export(@import("compiler_rt/addXf3.zig").__addtf3, .{ .name = "__addkf3", .linkage = linkage });
         @export(@import("compiler_rt/addXf3.zig").__subtf3, .{ .name = "__subkf3", .linkage = linkage });
         @export(@import("compiler_rt/mulXf3.zig").__multf3, .{ .name = "__mulkf3", .linkage = linkage });

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -800,6 +800,13 @@ pub const Target = struct {
                 };
             }
 
+            pub fn isPPC(arch: Arch) bool {
+                return switch (arch) {
+                    .powerpc, .powerpcle => true,
+                    else => false,
+                };
+            }
+
             pub fn isPPC64(arch: Arch) bool {
                 return switch (arch) {
                     .powerpc64, .powerpc64le => true,

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -214,6 +214,22 @@ const test_targets = blk: {
 
         TestTarget{
             .target = .{
+                .cpu_arch = .powerpc,
+                .os_tag = .linux,
+                .abi = .none,
+            },
+        },
+        TestTarget{
+            .target = .{
+                .cpu_arch = .powerpc,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .link_libc = true,
+        },
+
+        TestTarget{
+            .target = .{
                 .cpu_arch = .riscv64,
                 .os_tag = .linux,
                 .abi = .none,


### PR DESCRIPTION
Let's add it to the testing plan! (and bump its tier?)

**Bikeshedding moment**

At the moment we have a few `isXXX` functions defined for the `Arch` enum, some of them refer to the whole "family" (eg. `isMIPS` is true for both 32 and 64 bit targets) while other are split (`isPPC` and `isPPC64`).
If we were to harmonize this API what's your favourite pick between:
* Separate `isARCH` and `isARCH64` methods
* A single `isARCH(enum{ 32, 64, both})` method
* A single `isARCH` method that returns true for both 32 and 64 bit variants, leaving the user to discriminate on `ptrBitWidth`
* A single `isOneOf([]Arch)` and `isAnyOf([]Arch)` methods, generalizing the problem
* Something else?