### PR TITLE
stage2: make std.fmt.parseInt ignore `_`

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -5111,6 +5111,7 @@ fn integerLiteral(
         };
         return rvalue(gz, scope, rl, result, node);
     } else |err| {
+        assert(err != error.InvalidCharacter);
         return gz.astgen.failNode(node, "TODO implement int literals that don't fit in a u64", .{});
     }
 }

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -2721,7 +2721,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                 return MCValue.dead;
             switch (arch) {
                 .spu_2 => {
-                    if (inst.inputs.len > 0 or inst.output != null) {
+                    if (inst.inputs.len > 0 or inst.output_constraint != null) {
                         return self.fail(inst.base.src, "TODO implement inline asm inputs / outputs for SPU Mark II", .{});
                     }
                     if (mem.eql(u8, inst.asm_source, "undefined0")) {


### PR DESCRIPTION
This allows more astgen stuff. Also make it compile w/o skip-non-native.