### PR TITLE
translate-c: handle negative array indices

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1709,4 +1709,44 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("signed array subscript. Issue #8556",
+        \\#include <stdint.h>
+        \\#include <stdlib.h>
+        \\#define TEST_NEGATIVE(type) { type x = -1; if (ptr[x] != 42) abort(); }
+        \\#define TEST_UNSIGNED(type) { type x = 2; if (arr[x] != 42) abort(); }
+        \\int main(void) {
+        \\    int arr[] = {40, 41, 42, 43};
+        \\    int *ptr = arr + 3;
+        \\    if (ptr[-1] != 42) abort();
+        \\    TEST_NEGATIVE(int);
+        \\    TEST_NEGATIVE(long);
+        \\    TEST_NEGATIVE(long long);
+        \\    TEST_NEGATIVE(int64_t);
+        \\    TEST_NEGATIVE(__int128);
+        \\    TEST_UNSIGNED(unsigned);
+        \\    TEST_UNSIGNED(unsigned long);
+        \\    TEST_UNSIGNED(unsigned long long);
+        \\    TEST_UNSIGNED(uint64_t);
+        \\    TEST_UNSIGNED(size_t);
+        \\    TEST_UNSIGNED(unsigned __int128);
+        \\    return 0;
+        \\}
+    , "");
+
+    cases.add("Ensure side-effects only evaluated once for signed array indices",
+        \\#include <stdlib.h>
+        \\int main(void) {
+        \\    int foo[] = {1, 2, 3, 4};
+        \\    int *p = foo;
+        \\    int idx = 1;
+        \\    if ((++p)[--idx] != 2) abort();
+        \\    if (p != foo + 1) abort();
+        \\    if (idx != 0) abort();
+        \\    if ((p++)[idx++] != 2) abort();
+        \\    if (p != foo + 2) abort();
+        \\    if (idx != 1) abort();
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
Take advantage of wrapping pointer arithmetic to enable negative array
subscripts.

Fixes #8556