### PR TITLE
stage1: Unbreak build on FreeBSD

### DIFF
--- a/src/stage1/softfloat_ext.cpp
+++ b/src/stage1/softfloat_ext.cpp
@@ -1,19 +1,21 @@
 #include "softfloat_ext.hpp"
+#include "zigendian.h"
 
 extern "C" {
-    #include "platform.h"
-    #include "internals.h"
     #include "softfloat.h"
 }
 
 void f128M_abs(const float128_t *aPtr, float128_t *zPtr) {
-    float128_t zero_float;
-    ui32_to_f128M(0, &zero_float);
-    if (f128M_lt(aPtr, &zero_float)) {
-        f128M_sub(&zero_float, aPtr, zPtr);
-    } else {
-        *zPtr = *aPtr;
-    } 
+    // Clear the sign bit.
+#if ZIG_BYTE_ORDER == ZIG_LITTLE_ENDIAN
+    zPtr->v[1] = aPtr->v[1] & ~(UINT64_C(1) << 63);
+    zPtr->v[0] = aPtr->v[0];
+#elif ZIG_BYTE_ORDER == ZIG_BIG_ENDIAN
+    zPtr->v[0] = aPtr->v[0] & ~(UINT64_C(1) << 63);
+    zPtr->v[1] = aPtr->v[1];
+#else
+#error Unsupported endian
+#endif
 }
 
 void f128M_trunc(const float128_t *aPtr, float128_t *zPtr) {
@@ -27,12 +29,21 @@ void f128M_trunc(const float128_t *aPtr, float128_t *zPtr) {
 }
 
 float16_t f16_neg(const float16_t a) {
-    union ui16_f16 uZ;
-    uZ.ui = a.v ^ (UINT16_C(1) << 15);
-    return uZ.f;
+    union { uint16_t ui; float16_t f; } uA;
+    // Toggle the sign bit.
+    uA.ui = a.v ^ (UINT16_C(1) << 15);
+    return uA.f;
 }
 
 void f128M_neg(const float128_t *aPtr, float128_t *zPtr) {
-    zPtr->v[indexWord(2,1)] = aPtr->v[indexWord(2,1)] ^ (UINT64_C(1) << 63);
-    zPtr->v[indexWord(2,0)] = aPtr->v[indexWord(2,0)];
+    // Toggle the sign bit.
+#if ZIG_BYTE_ORDER == ZIG_LITTLE_ENDIAN
+    zPtr->v[1] = aPtr->v[1] ^ (UINT64_C(1) << 63);
+    zPtr->v[0] = aPtr->v[0];
+#elif ZIG_BYTE_ORDER == ZIG_BIG_ENDIAN
+    zPtr->v[0] = aPtr->v[0] ^ (UINT64_C(1) << 63);
+    zPtr->v[1] = aPtr->v[1];
+#else
+#error Unsupported endian
+#endif
 }


### PR DESCRIPTION
It turns out that the endianness-detection header delivered with the
softfloat library is extremely brittle and gives wrong results when
targeting FreeBSD (long story short, _BIG_ENDIAN is always defined there
and that breaks the #if defined() chain).

Use our own endianness detection header to work around any potential
problem.