### PR TITLE
Fix a performance hazard in std.HashMap

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -472,9 +472,7 @@ pub fn HashMapUnmanaged(
 
         /// Insert an entry in the map. Assumes it is not already present.
         pub fn putNoClobber(self: *Self, allocator: *Allocator, key: K, value: V) !void {
-            assert(!self.contains(key));
             try self.growIfNeeded(allocator, 1);
-
             self.putAssumeCapacityNoClobber(key, value);
         }
 
@@ -489,7 +487,12 @@ pub fn HashMapUnmanaged(
         /// Insert an entry in the map. Assumes it is not already present,
         /// and that no allocation is needed.
         pub fn putAssumeCapacityNoClobber(self: *Self, key: K, value: V) void {
-            assert(!self.contains(key));
+            if (std.debug.runtime_safety) {
+                // Note: The compiler can't optimize this away in release-fast
+                // for some reason.  If anyone wants to dig into llvm and find
+                // out why, that would be a useful piece of information.
+                assert(!self.contains(key));
+            }
 
             const hash = hashFn(key);
             const mask = self.capacity() - 1;
@@ -681,7 +684,12 @@ pub fn HashMapUnmanaged(
         /// Asserts there is an `Entry` with matching key, deletes it from the hash map,
         /// and discards it.
         pub fn removeAssertDiscard(self: *Self, key: K) void {
-            assert(self.contains(key));
+            if (std.debug.runtime_safety) {
+                // Note: The compiler can't optimize this away in release-fast
+                // for some reason.  If anyone wants to dig into llvm and find
+                // out why, that would be a useful piece of information.
+                assert(self.contains(key));
+            }
 
             const hash = hashFn(key);
             const mask = self.capacity() - 1;


### PR DESCRIPTION
I was doing some microbenchmarks of std.HashMap and noticed something odd:
![image](https://user-images.githubusercontent.com/2281818/115784540-de446680-a383-11eb-9b44-726613d77486.png)

Despite making more assumptions, `putAssumeCapacityNoClobber` was by far the slowest `put` variant.  It turns out the reason for this is the `assert(!self.contains(key))` at the beginning of the function, which apparently cannot be optimized away.

This patch adds guards to prevent the assert code from running in release-fast builds.  With these guards, `putAssumeCapacityNoClobber` becomes the fastest `put` in these tests.

It would be nice to dig into the IR and figure out why this can't be optimized and what piece of it is left over, but I don't really want to do that right now.  If this can be fixed on the zig side or in LLVM though, we should do that instead.