### PR TITLE
export winmain if linking libc and using windows subsystem

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -39,7 +39,18 @@ comptime {
             }
         } else if (builtin.output_mode == .Exe or @hasDecl(root, "main")) {
             if (builtin.link_libc and @hasDecl(root, "main")) {
-                if (@typeInfo(@TypeOf(root.main)).Fn.calling_convention != .C) {
+                if (builtin.os.tag == .windows and 
+                    builtin.subsystem == builtin.SubSystem.Windows and
+                    !@hasDecl(root, "wWinMain")) 
+                {
+                    if (@hasDecl(root, "WinMain")) {
+                        @compileError("WinMain not supported; declare wWinMain instead");
+                    }
+                    else {
+                        @export(WinStartup, .{ .name = "wWinMain" });
+                    }
+                }
+                else if (@typeInfo(@TypeOf(root.main)).Fn.calling_convention != .C) {
                     @export(main, .{ .name = "main", .linkage = .Weak });
                 }
             } else if (builtin.os.tag == .windows) {

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -39,18 +39,16 @@ comptime {
             }
         } else if (builtin.output_mode == .Exe or @hasDecl(root, "main")) {
             if (builtin.link_libc and @hasDecl(root, "main")) {
-                if (builtin.os.tag == .windows and 
+                if (builtin.os.tag == .windows and
                     builtin.subsystem == builtin.SubSystem.Windows and
-                    !@hasDecl(root, "wWinMain")) 
+                    !@hasDecl(root, "wWinMain"))
                 {
                     if (@hasDecl(root, "WinMain")) {
                         @compileError("WinMain not supported; declare wWinMain instead");
-                    }
-                    else {
+                    } else {
                         @export(WinStartup, .{ .name = "wWinMain" });
                     }
-                }
-                else if (@typeInfo(@TypeOf(root.main)).Fn.calling_convention != .C) {
+                } else if (@typeInfo(@TypeOf(root.main)).Fn.calling_convention != .C) {
                     @export(main, .{ .name = "main", .linkage = .Weak });
                 }
             } else if (builtin.os.tag == .windows) {


### PR DESCRIPTION
Hey there, this is my first PR to zig and I'm an open source newbie so let me know if I'm doing anything wrong.

Anyway, the issue at hand is this linker error: `undefined symbol: WinMain` when linking libc and using the windows subsystem. My OS is Windows x86_64. Here's an easy way to reproduce:
1. `mkdir test`
2. `cd test`
3. `zig init-exe`
4. `zig build-exe --subsystem windows -lc src/main.zig`

I get this error:
```
lld-link: error: undefined symbol: WinMain
>>> referenced by D:\agent\_work\9\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:102
>>>               libcmtd.lib(exe_winmain.obj):(int __cdecl invoke_main(void))
error: LLDReportedFailure`
```

I took a look in start.zig and it looks like there's a special path for exporting winmain symbols that isn't being reached when linking libc. I put in a change that fixed the issue for me. I'm not a Windows expert so please let me know if there's something I'm missing here or if you would like the change edited in any way.

Thank you!