### PR TITLE
stage2 register manager: Use an array instead of a hashmap for tracking allocated registers

### DIFF
--- a/src/register_manager.zig
+++ b/src/register_manager.zig
@@ -16,7 +16,7 @@ pub fn RegisterManager(
 ) type {
     return struct {
         /// The key must be canonical register.
-        registers: std.AutoHashMapUnmanaged(Register, *ir.Inst) = .{},
+        registers: [callee_preserved_regs.len]?*ir.Inst = [_]?*ir.Inst{null} ** callee_preserved_regs.len,
         free_registers: FreeRegInt = math.maxInt(FreeRegInt),
         /// Tracks all registers allocated in the course of this function
         allocated_registers: FreeRegInt = 0,
@@ -29,14 +29,6 @@ pub fn RegisterManager(
 
         fn getFunction(self: *Self) *Function {
             return @fieldParentPtr(Function, "register_manager", self);
-        }
-
-        pub fn deinit(self: *Self, allocator: *Allocator) void {
-            self.registers.deinit(allocator);
-        }
-
-        fn isTracked(reg: Register) bool {
-            return reg.allocIndex() != null;
         }
 
         fn markRegUsed(self: *Self, reg: Register) void {
@@ -73,13 +65,13 @@ pub fn RegisterManager(
             return self.allocated_registers & @as(FreeRegInt, 1) << shift != 0;
         }
 
-        /// Before calling, must ensureCapacity + count on self.registers.
         /// Returns `null` if all registers are allocated.
         pub fn tryAllocRegs(self: *Self, comptime count: comptime_int, insts: [count]*ir.Inst) ?[count]Register {
             if (self.tryAllocRegsWithoutTracking(count)) |regs| {
                 for (regs) |reg, i| {
+                    const index = reg.allocIndex().?; // allocIndex() on a callee-preserved reg should never return null
+                    self.registers[index] = insts[i];
                     self.markRegUsed(reg);
-                    self.registers.putAssumeCapacityNoClobber(reg, insts[i]);
                 }
 
                 return regs;
@@ -88,13 +80,11 @@ pub fn RegisterManager(
             }
         }
 
-        /// Before calling, must ensureCapacity + 1 on self.registers.
         /// Returns `null` if all registers are allocated.
         pub fn tryAllocReg(self: *Self, inst: *ir.Inst) ?Register {
             return if (tryAllocRegs(self, 1, .{inst})) |regs| regs[0] else null;
         }
 
-        /// Before calling, must ensureCapacity + count on self.registers.
         pub fn allocRegs(self: *Self, comptime count: comptime_int, insts: [count]*ir.Inst) ![count]Register {
             comptime assert(count > 0 and count <= callee_preserved_regs.len);
 
@@ -106,24 +96,22 @@ pub fn RegisterManager(
                 std.mem.copy(Register, &regs, callee_preserved_regs[0..count]);
 
                 for (regs) |reg, i| {
+                    const index = reg.allocIndex().?; // allocIndex() on a callee-preserved reg should never return null
                     if (self.isRegFree(reg)) {
                         self.markRegUsed(reg);
-                        self.registers.putAssumeCapacityNoClobber(reg, insts[i]);
                     } else {
-                        const regs_entry = self.registers.getEntry(reg).?;
-                        const spilled_inst = regs_entry.value;
-                        regs_entry.value = insts[i];
+                        const spilled_inst = self.registers[index].?;
                         try self.getFunction().spillInstruction(spilled_inst.src, reg, spilled_inst);
                     }
+                    self.registers[index] = insts[i];
                 }
 
                 break :blk regs;
             };
         }
 
-        /// Before calling, must ensureCapacity + 1 on self.registers.
         pub fn allocReg(self: *Self, inst: *ir.Inst) !Register {
-            return (try allocRegs(self, 1, .{inst}))[0];
+            return (try self.allocRegs(1, .{inst}))[0];
         }
 
         /// Does not track the registers.
@@ -150,37 +138,48 @@ pub fn RegisterManager(
         /// Does not track the register.
         /// Returns `null` if all registers are allocated.
         pub fn tryAllocRegWithoutTracking(self: *Self) ?Register {
-            return if (tryAllocRegsWithoutTracking(self, 1)) |regs| regs[0] else null;
+            return if (self.tryAllocRegsWithoutTracking(1)) |regs| regs[0] else null;
+        }
+
+        /// Does not track the registers
+        pub fn allocRegsWithoutTracking(self: *Self, comptime count: comptime_int) ![count]Register {
+            return self.tryAllocRegsWithoutTracking(count) orelse blk: {
+                // We'll take over the first count registers. Spill
+                // the instructions that were previously there to a
+                // stack allocations.
+                var regs: [count]Register = undefined;
+                std.mem.copy(Register, &regs, callee_preserved_regs[0..count]);
+
+                for (regs) |reg, i| {
+                    const index = reg.allocIndex().?; // allocIndex() on a callee-preserved reg should never return null
+                    if (!self.isRegFree(reg)) {
+                        const spilled_inst = self.registers[index].?;
+                        try self.getFunction().spillInstruction(spilled_inst.src, reg, spilled_inst);
+                        self.registers[index] = null;
+                        self.markRegFree(reg);
+                    }
+                }
+
+                break :blk regs;
+            };
         }
 
         /// Does not track the register.
         pub fn allocRegWithoutTracking(self: *Self) !Register {
-            return self.tryAllocRegWithoutTracking() orelse b: {
-                // We'll take over the first register. Move the instruction that was previously
-                // there to a stack allocation.
-                const reg = callee_preserved_regs[0];
-                const regs_entry = self.registers.remove(reg).?;
-                const spilled_inst = regs_entry.value;
-                try self.getFunction().spillInstruction(spilled_inst.src, reg, spilled_inst);
-                self.markRegFree(reg);
-
-                break :b reg;
-            };
+            return (try self.allocRegsWithoutTracking(1))[0];
         }
 
         /// Allocates the specified register with the specified
         /// instruction. Spills the register if it is currently
         /// allocated.
-        /// Before calling, must ensureCapacity + 1 on self.registers.
         pub fn getReg(self: *Self, reg: Register, inst: *ir.Inst) !void {
-            if (!isTracked(reg)) return;
+            const index = reg.allocIndex() orelse return;
 
             if (!self.isRegFree(reg)) {
                 // Move the instruction that was previously there to a
                 // stack allocation.
-                const regs_entry = self.registers.getEntry(reg).?;
-                const spilled_inst = regs_entry.value;
-                regs_entry.value = inst;
+                const spilled_inst = self.registers[index].?;
+                self.registers[index] = inst;
                 try self.getFunction().spillInstruction(spilled_inst.src, reg, spilled_inst);
             } else {
                 self.getRegAssumeFree(reg, inst);
@@ -190,34 +189,33 @@ pub fn RegisterManager(
         /// Spills the register if it is currently allocated.
         /// Does not track the register.
         pub fn getRegWithoutTracking(self: *Self, reg: Register) !void {
-            if (!isTracked(reg)) return;
+            const index = reg.allocIndex() orelse return;
 
             if (!self.isRegFree(reg)) {
                 // Move the instruction that was previously there to a
                 // stack allocation.
-                const regs_entry = self.registers.remove(reg).?;
-                const spilled_inst = regs_entry.value;
+                const spilled_inst = self.registers[index].?;
                 try self.getFunction().spillInstruction(spilled_inst.src, reg, spilled_inst);
                 self.markRegFree(reg);
             }
         }
 
         /// Allocates the specified register with the specified
-        /// instruction. Assumes that the register is free and no
+        /// instruction. Asserts that the register is free and no
         /// spilling is necessary.
-        /// Before calling, must ensureCapacity + 1 on self.registers.
         pub fn getRegAssumeFree(self: *Self, reg: Register, inst: *ir.Inst) void {
-            if (!isTracked(reg)) return;
+            const index = reg.allocIndex() orelse return;
 
-            self.registers.putAssumeCapacityNoClobber(reg, inst);
+            assert(self.registers[index] == null);
+            self.registers[index] = inst;
             self.markRegUsed(reg);
         }
 
         /// Marks the specified register as free
         pub fn freeReg(self: *Self, reg: Register) void {
-            if (!isTracked(reg)) return;
+            const index = reg.allocIndex() orelse return;
 
-            _ = self.registers.remove(reg);
+            self.registers[index] = null;
             self.markRegFree(reg);
         }
     };
@@ -247,7 +245,6 @@ const MockFunction = struct {
     const Self = @This();
 
     pub fn deinit(self: *Self) void {
-        self.register_manager.deinit(self.allocator);
         self.spilled.deinit(self.allocator);
     }
 
@@ -273,7 +270,6 @@ test "tryAllocReg: no spilling" {
     std.testing.expect(!function.register_manager.isRegAllocated(.r2));
     std.testing.expect(!function.register_manager.isRegAllocated(.r3));
 
-    try function.register_manager.registers.ensureCapacity(allocator, function.register_manager.registers.count() + 2);
     std.testing.expectEqual(@as(?MockRegister, .r2), function.register_manager.tryAllocReg(&mock_instruction));
     std.testing.expectEqual(@as(?MockRegister, .r3), function.register_manager.tryAllocReg(&mock_instruction));
     std.testing.expectEqual(@as(?MockRegister, null), function.register_manager.tryAllocReg(&mock_instruction));
@@ -305,7 +301,6 @@ test "allocReg: spilling" {
     std.testing.expect(!function.register_manager.isRegAllocated(.r2));
     std.testing.expect(!function.register_manager.isRegAllocated(.r3));
 
-    try function.register_manager.registers.ensureCapacity(allocator, function.register_manager.registers.count() + 2);
     std.testing.expectEqual(@as(?MockRegister, .r2), try function.register_manager.allocReg(&mock_instruction));
     std.testing.expectEqual(@as(?MockRegister, .r3), try function.register_manager.allocReg(&mock_instruction));
 
@@ -336,14 +331,12 @@ test "getReg" {
     std.testing.expect(!function.register_manager.isRegAllocated(.r2));
     std.testing.expect(!function.register_manager.isRegAllocated(.r3));
 
-    try function.register_manager.registers.ensureCapacity(allocator, function.register_manager.registers.count() + 2);
     try function.register_manager.getReg(.r3, &mock_instruction);
 
     std.testing.expect(!function.register_manager.isRegAllocated(.r2));
     std.testing.expect(function.register_manager.isRegAllocated(.r3));
 
     // Spill r3
-    try function.register_manager.registers.ensureCapacity(allocator, function.register_manager.registers.count() + 2);
     try function.register_manager.getReg(.r3, &mock_instruction);
 
     std.testing.expect(!function.register_manager.isRegAllocated(.r2));


### PR DESCRIPTION
Not only does this eliminate all allocations in the register manager, this also potentially uses a little less memory. The common case we would want to optimize towards is using all registers in a function. In that case, a hash map uses at least as much memory as an array.