### PR TITLE
Two small patches

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -336,6 +336,13 @@ pub const StackIterator = struct {
     fp: usize,
 
     pub fn init(first_address: ?usize, fp: ?usize) StackIterator {
+        if (builtin.arch == .sparcv9) {
+            // Flush all the register windows on stack.
+            asm volatile (
+                \\ flushw
+                ::: "memory");
+        }
+
         return StackIterator{
             .first_address = first_address,
             .fp = fp orelse @frameAddress(),
@@ -343,18 +350,18 @@ pub const StackIterator = struct {
     }
 
     // Offset of the saved BP wrt the frame pointer.
-    const fp_offset = if (builtin.arch.isRISCV())
+    const fp_offset = if (comptime builtin.arch.isRISCV())
         // On RISC-V the frame pointer points to the top of the saved register
         // area, on pretty much every other architecture it points to the stack
         // slot where the previous frame pointer is saved.
         2 * @sizeOf(usize)
-    else if (builtin.arch.isSPARC())
+    else if (comptime builtin.arch.isSPARC())
         // On SPARC the previous frame pointer is stored at 14 slots past %fp+BIAS.
         14 * @sizeOf(usize)
     else
         0;
 
-    const fp_bias = if (builtin.arch.isSPARC())
+    const fp_bias = if (comptime builtin.arch.isSPARC())
         // On SPARC frame pointers are biased by a constant.
         2047
     else
@@ -380,7 +387,7 @@ pub const StackIterator = struct {
     }
 
     fn next_internal(self: *StackIterator) ?usize {
-        const fp = if (builtin.arch.isSPARC())
+        const fp = if (comptime builtin.arch.isSPARC())
             // On SPARC the offset is positive. (!)
             math.add(usize, self.fp, fp_offset) catch return null
         else

--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -248,7 +248,7 @@ fn initTLS() void {
         tls_data = @intToPtr([*]u8, img_base + phdr.p_vaddr)[0..phdr.p_filesz];
         tls_data_alloc_size = phdr.p_memsz;
     } else {
-        tls_align_factor = @alignOf(*usize);
+        tls_align_factor = @alignOf(usize);
         tls_data = &[_]u8{};
         tls_data_alloc_size = 0;
     }
@@ -308,7 +308,7 @@ fn initTLS() void {
 }
 
 fn alignPtrCast(comptime T: type, ptr: [*]u8) callconv(.Inline) *T {
-    return @ptrCast(*T, @alignCast(@alignOf(*T), ptr));
+    return @ptrCast(*T, @alignCast(@alignOf(T), ptr));
 }
 
 /// Initializes all the fields of the static TLS area and returns the computed


### PR DESCRIPTION
cc @koachan 

Without the `flushw` I was getting spurious segfaults here and there when running the test suite, even a simple example like this would segfault:
```zig
const std = @import("std");

pub fn main() !void {
    @panic("foo");
}
```

Can you confirm this is fine on your machine?