### PR TITLE
Fix overflow in compress/deflate.zig

### DIFF
--- a/lib/std/compress/deflate.zig
+++ b/lib/std/compress/deflate.zig
@@ -384,6 +384,8 @@ pub fn InflateStream(comptime ReaderType: type) type {
                         const last_length = lengths[i - 1];
                         const repeat = 3 + (try self.readBits(2));
                         const last_index = i + repeat;
+                        if (last_index > lengths.len)
+                            return error.InvalidLength;
                         while (i < last_index) : (i += 1) {
                             lengths[i] = last_length;
                         }
@@ -654,4 +656,20 @@ pub fn InflateStream(comptime ReaderType: type) type {
 
 pub fn inflateStream(reader: anytype, window_slice: []u8) InflateStream(@TypeOf(reader)) {
     return InflateStream(@TypeOf(reader)).init(reader, window_slice);
+}
+
+test "lengths overflow" {
+    // malformed final dynamic block, tries to write 321 code lengths (MAXCODES is 316)
+    // f dy  hlit hdist hclen 16  17  18   0 (18)    x138 (18)    x138 (18)     x39 (16) x6
+    // 1 10 11101 11101 0000 010 010 010 010 (11) 1111111 (11) 1111111 (11) 0011100 (01) 11
+    const stream = [_]u8{
+        0b11101101, 0b00011101, 0b00100100, 0b11101001, 0b11111111, 0b11111111, 0b00111001, 0b00001110
+    };
+
+    const reader = std.io.fixedBufferStream(&stream).reader();
+    var window: [0x8000]u8 = undefined;
+    var inflate = inflateStream(reader, &window);
+
+    var buf: [1]u8 = undefined;
+    std.testing.expectError(error.InvalidLength, inflate.read(&buf));    
 }


### PR DESCRIPTION
When InflateStream reads code lengths for dynamic Huffman codes, a malformed block can cause writes past the end of the `lengths` array. To recap, code lengths are encoded in a 19 symbol alphabet: 0-15 are literal lengths, 16 repeats the last length 3-6 times, 17 repeats a 0 length 3-11 times, and 18 repeats a 0 length 11-138 times. With 17 and 18, the index `i` can be moved past the end of the `lengths` array, but this is fine as the `while` condition check immediately following this will be false and then an error is returned. However, with 16, the `lengths` array is written to without checking that `i` won't move past its end.

Here is a minimal example that causes a panic due to an index out of bounds:
```
// f dy  hlit hdist hclen 16  17  18   0 (18)    x138 (18)    x138 (18)     x39 (16) x6
// 1 10 11101 11101 0000 010 010 010 010 (11) 1111111 (11) 1111111 (11) 0011100 (01) 11

const stream = [_]u8 {
    0b11101101, 0b00011101, 0b00100100, 0b11101001, 0b11111111, 0b11111111, 0b00111001, 0b00001110
};

const reader = std.io.fixedBufferStream(&stream).reader();
var window: [0x8000]u8 = undefined;
var inflate = std.compress.deflate.inflateStream(reader, &window);

var buf: [16]u8 = undefined;
const cnt = try inflate.read(&buf);
```

A block with 316 lengths is specified, then 315 zeroes are given with three 18 symbols. Then a final 16 symbol is used to repeat the last length 6 times, thus overflowing the `lengths` array, which has length of MAXCODES = 316.

I don't think this is exploitable in ReleaseFast builds because we can only write 5 bytes past the end of `lengths`, there are plenty of other locals on the stack at this point, and `i` is checked and an error is returned immediately after the `while` loop. Nonetheless, I added a check that the number of repeats for a 16 symbol is valid, as well as a test to make sure such a malformed block is caught.