### PR TITLE
ci linux: bump qemu-6.0.0

### DIFF
--- a/ci/azure/linux_script
+++ b/ci/azure/linux_script
@@ -20,7 +20,7 @@ cd $HOME
 wget -nv "https://ziglang.org/deps/$CACHE_BASENAME.tar.xz"
 tar xf "$CACHE_BASENAME.tar.xz"
 
-QEMUBASE="qemu-linux-x86_64-5.2.0"
+QEMUBASE="qemu-linux-x86_64-6.0.0"
 wget -nv "https://ziglang.org/deps/$QEMUBASE.tar.xz"
 tar xf "$QEMUBASE.tar.xz"
 export PATH="$(pwd)/$QEMUBASE/bin:$PATH"


### PR DESCRIPTION
uploaded tarball to `http://ziglang.org/deps/qemu-linux-x86_64-6.0.0.tar.xz`
```bash
$ md5 qemu-linux-x86_64-6.0.0.tar.xz
MD5 (qemu-linux-x86_64-6.0.0.tar.xz) = cf159b965dd21be6e09b816b8d934bb9
```
