### PR TITLE
Azure CI: Test std.* and the rest separately

### DIFF
--- a/ci/azure/linux_script
+++ b/ci/azure/linux_script
@@ -65,17 +65,9 @@ make $JOBS install
 cmake .. -DZIG_EXECUTABLE="$(pwd)/release/bin/zig"
 make $JOBS install
 
-set +x
-LOG=$(mktemp)
 for step in test-toolchain test-std docs; do
-  echo "* Running step: [$step]"
-  if ! release/bin/zig build $step -Denable-qemu -Denable-wasmtime 2>"$LOG" >&2; then
-    cat "$LOG" >&2
-    exit 1
-  fi
-  echo "  Done."
+  release/bin/zig build $step -Denable-qemu -Denable-wasmtime
 done
-set -x
 
 # Look for HTML errors.
 tidy -qe ../zig-cache/langref.html

--- a/ci/azure/linux_script
+++ b/ci/azure/linux_script
@@ -65,7 +65,17 @@ make $JOBS install
 cmake .. -DZIG_EXECUTABLE="$(pwd)/release/bin/zig"
 make $JOBS install
 
-release/bin/zig build test -Denable-qemu -Denable-wasmtime
+set +x
+LOG=$(mktemp)
+for step in test-toolchain test-std docs; do
+  echo "* Running step: [$step]"
+  if ! release/bin/zig build $step -Denable-qemu -Denable-wasmtime 2>"$LOG" >&2; then
+    cat "$LOG" >&2
+    exit 1
+  fi
+  echo "  Done."
+done
+set -x
 
 # Look for HTML errors.
 tidy -qe ../zig-cache/langref.html

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -18,7 +18,7 @@ tar xf "$CACHE_BASENAME.tar.xz"
 
 ZIG="$PREFIX/bin/zig"
 NATIVE_LIBC_TXT="$HOME/native_libc.txt"
-$ZIG libc > "$NATIVE_LIBC_TXT"
+$ZIG libc >"$NATIVE_LIBC_TXT"
 export ZIG_LIBC="$NATIVE_LIBC_TXT"
 export CC="$ZIG cc"
 export CXX="$ZIG c++"
@@ -55,7 +55,17 @@ make $JOBS install
 cmake .. -DZIG_EXECUTABLE="$(pwd)/release/bin/zig" -DZIG_TARGET_MCPU="x86_64_v2"
 make $JOBS install
 
-release/bin/zig build test
+set +x
+LOG=$(mktemp)
+for step in test-toolchain test-std docs; do
+  echo "* Running step: [$step]"
+  if ! release/bin/zig build $step -Denable-qemu -Denable-wasmtime 2>"$LOG" >&2; then
+    cat "$LOG" >&2
+    exit 1
+  fi
+  echo "  Done."
+done
+set -x
 
 if [ "${BUILD_REASON}" != "PullRequest" ]; then
   mv ../LICENSE release/

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -55,17 +55,9 @@ make $JOBS install
 cmake .. -DZIG_EXECUTABLE="$(pwd)/release/bin/zig" -DZIG_TARGET_MCPU="x86_64_v2"
 make $JOBS install
 
-set +x
-LOG=$(mktemp)
 for step in test-toolchain test-std docs; do
-  echo "* Running step: [$step]"
-  if ! release/bin/zig build $step 2>"$LOG" >&2; then
-    cat "$LOG" >&2
-    exit 1
-  fi
-  echo "  Done."
+  release/bin/zig build $step
 done
-set -x
 
 if [ "${BUILD_REASON}" != "PullRequest" ]; then
   mv ../LICENSE release/

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -59,7 +59,7 @@ set +x
 LOG=$(mktemp)
 for step in test-toolchain test-std docs; do
   echo "* Running step: [$step]"
-  if ! release/bin/zig build $step -Denable-qemu -Denable-wasmtime 2>"$LOG" >&2; then
+  if ! release/bin/zig build $step 2>"$LOG" >&2; then
     cat "$LOG" >&2
     exit 1
   fi

--- a/ci/azure/windows_msvc_script.bat
+++ b/ci/azure/windows_msvc_script.bat
@@ -26,20 +26,8 @@ cd %ZIGBUILDDIR%
 cmake.exe .. -Thost=x64 -G"Visual Studio 16 2019" -A x64 "-DCMAKE_INSTALL_PREFIX=%ZIGINSTALLDIR%" "-DCMAKE_PREFIX_PATH=%ZIGPREFIXPATH%" -DCMAKE_BUILD_TYPE=Release -DZIG_OMIT_STAGE2=ON || exit /b
 msbuild /maxcpucount /p:Configuration=Release INSTALL.vcxproj || exit /b
 
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-behavior -Dskip-non-native || exit /b
-REM Disabled to prevent OOM
-REM "%ZIGINSTALLDIR%\bin\zig.exe" build test-stage2 -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-fmt -Dskip-non-native || exit /b
+"%ZIGINSTALLDIR%\bin\zig.exe" build test-toolchain -Dskip-non-native -Dskip-stage2-tests || exit /b
 "%ZIGINSTALLDIR%\bin\zig.exe" build test-std -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-compiler-rt -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-compare-output -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-standalone -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-stack-traces -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-cli -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-asm-link -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-runtime-safety -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-translate-c -Dskip-non-native || exit /b
-"%ZIGINSTALLDIR%\bin\zig.exe" build test-run-translated-c -Dskip-non-native || exit /b
 "%ZIGINSTALLDIR%\bin\zig.exe" build docs || exit /b
 
 set "PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem"


### PR DESCRIPTION
On CI, we have been running into OOM issues when running the test suite on Windows for quite some time.

Unfortunately, we are very close to having the same issues on Linux as well. Some additional comptime work immediately makes these builds fail as well.

Add a new `test-toolchain` step, that tests everything except `std.*` and documentation.

On CI, call `test-toolchain`, `test-std` and `docs` separately instead of the `test` big hammer that emcompasses all of them. The original `test` step remains available.

Change the special case we made for Windows to the same code as other platforms.

This is a stopgap measure that stage2 will eventually make useless.

Until then, it gives us some headroom.