### PR TITLE
std: add range(usize)

### DIFF
--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -92,6 +92,18 @@ pub const x = @import("x.zig");
 pub const zig = @import("zig.zig");
 pub const start = @import("start.zig");
 
+/// Use this as a way to increment an index using a for loop. Works with both
+/// runtime and comptime integers.
+///
+/// ```zig
+/// for (range(10)) |_, i| {
+///   // 'i' will increment from 0 -> 9
+/// }
+/// ```
+pub fn range(len: usize) []const u0 {
+    return @as([*]u0, undefined)[0..len];
+}
+
 // This forces the start.zig file to be imported, and the comptime logic inside that
 // file decides whether to export any appropriate start symbols, and call main.
 comptime {


### PR DESCRIPTION
Many have requested an easier way to make an incrementing loop. In a way that doesn't dirty the namespace currently being worked in with an `i` variable with use of a while loop. Or suggesting a syntax change to the for loop or a new loop entirely. However, this is possible in userspace by taking advantage of the semantics of zero sized types.

As written in the doc comment it is used like so:
```zig
for (std.range(10)) |_, i| {
    // 'i' will increment from 0 -> 9
}
```

Justification: #358, #8292, and more