### PR TITLE
std.zig: handle -frandom-seed in NIX_CFLAGS_COMPILE

### DIFF
--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -46,6 +46,9 @@ pub const NativePaths = struct {
             var it = mem.tokenize(nix_cflags_compile, " ");
             while (true) {
                 const word = it.next() orelse break;
+                if (mem.startsWith(u8, word, "-frandom-seed=")) {
+                    continue;
+                }
                 if (mem.eql(u8, word, "-isystem")) {
                     const include_path = it.next() orelse {
                         try self.addWarning("Expected argument after -isystem in NIX_CFLAGS_COMPILE");

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -46,9 +46,6 @@ pub const NativePaths = struct {
             var it = mem.tokenize(nix_cflags_compile, " ");
             while (true) {
                 const word = it.next() orelse break;
-                if (mem.startsWith(u8, word, "-frandom-seed=")) {
-                    continue;
-                }
                 if (mem.eql(u8, word, "-isystem")) {
                     const include_path = it.next() orelse {
                         try self.addWarning("Expected argument after -isystem in NIX_CFLAGS_COMPILE");
@@ -56,8 +53,10 @@ pub const NativePaths = struct {
                     };
                     try self.addIncludeDir(include_path);
                 } else {
+                    if (mem.startsWith(u8, word, "-frandom-seed=")) {
+                        continue;
+                    }
                     try self.addWarningFmt("Unrecognized C flag from NIX_CFLAGS_COMPILE: {s}", .{word});
-                    break;
                 }
             }
         } else |err| switch (err) {


### PR DESCRIPTION
Closes #8269 by ignoring the value of the `-frandom-seed` flag.

It would be nice to have it addressed before the upcoming NixOS release (21.05).