### PR TITLE
ARM/AArch64 CPU host detection

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -75,7 +75,7 @@ pub fn spinLoopHint() callconv(.Inline) void {
         },
         .arm, .armeb, .thumb, .thumbeb => {
             // `yield` was introduced in v6k but are also available on v6m.
-            const can_yield = comptime std.Target.arm.featureSetHas(std.Target.current.cpu.features, .has_v6m);
+            const can_yield = comptime std.Target.arm.featureSetHasAny(std.Target.current.cpu.features, .{ .has_v6k, .has_v6m });
             if (can_yield) asm volatile ("yield" ::: "memory");
         },
         .aarch64, .aarch64_be, .aarch64_32 => {

--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -76,7 +76,9 @@ pub fn spinLoopHint() callconv(.Inline) void {
         .arm, .armeb, .thumb, .thumbeb => {
             // `yield` was introduced in v6k but are also available on v6m.
             const can_yield = comptime std.Target.arm.featureSetHasAny(std.Target.current.cpu.features, .{ .has_v6k, .has_v6m });
-            if (can_yield) asm volatile ("yield" ::: "memory");
+            if (can_yield) asm volatile ("yield" ::: "memory")
+            // Fallback.
+            else asm volatile ("" ::: "memory");
         },
         .aarch64, .aarch64_be, .aarch64_32 => {
             asm volatile ("isb" ::: "memory");

--- a/lib/std/target/aarch64.zig
+++ b/lib/std/target/aarch64.zig
@@ -1621,6 +1621,16 @@ pub const cpu = struct {
             .apple_a7,
         }),
     };
+    pub const emag = CpuModel{
+        .name = "emag",
+        .llvm_name = null,
+        .features = featureSet(&[_]Feature{
+            .crc,
+            .crypto,
+            .perfmon,
+            .v8a,
+        }),
+    };
     pub const exynos_m1 = CpuModel{
         .name = "exynos_m1",
         .llvm_name = null,
@@ -1865,6 +1875,14 @@ pub const cpu = struct {
             .spe,
             .use_postra_scheduler,
             .v8_2a,
+        }),
+    };
+    pub const xgene1 = CpuModel{
+        .name = "xgene1",
+        .llvm_name = null,
+        .features = featureSet(&[_]Feature{
+            .perfmon,
+            .v8a,
         }),
     };
 };

--- a/lib/std/zig/system/linux.zig
+++ b/lib/std/zig/system/linux.zig
@@ -163,61 +163,113 @@ const ArmCpuinfoImpl = struct {
         const A32 = Target.arm.cpu;
         const A64 = Target.aarch64.cpu;
 
-        // implementer = 0x41
-        const ARM = .{
-            .{ 0x926, &A32.arm926ej_s, null },
-            .{ 0xb02, &A32.mpcore, null },
-            .{ 0xb36, &A32.arm1136j_s, null },
-            .{ 0xb56, &A32.arm1156t2_s, null },
-            .{ 0xb76, &A32.arm1176jz_s, null },
-            .{ 0xc05, &A32.cortex_a5, null },
-            .{ 0xc07, &A32.cortex_a7, null },
-            .{ 0xc08, &A32.cortex_a8, null },
-            .{ 0xc09, &A32.cortex_a9, null },
-            .{ 0xc0d, &A32.cortex_a17, null },
-            .{ 0xc0f, &A32.cortex_a15, null },
-            .{ 0xc0e, &A32.cortex_a17, null },
-            .{ 0xc14, &A32.cortex_r4, null },
-            .{ 0xc15, &A32.cortex_r5, null },
-            .{ 0xc17, &A32.cortex_r7, null },
-            .{ 0xc18, &A32.cortex_r8, null },
-            .{ 0xc20, &A32.cortex_m0, null },
-            .{ 0xc21, &A32.cortex_m1, null },
-            .{ 0xc23, &A32.cortex_m3, null },
-            .{ 0xc24, &A32.cortex_m4, null },
-            .{ 0xc27, &A32.cortex_m7, null },
-            .{ 0xc60, &A32.cortex_m0plus, null },
-            .{ 0xd01, &A32.cortex_a32, null },
-            .{ 0xd03, &A32.cortex_a53, &A64.cortex_a53 },
-            .{ 0xd04, &A32.cortex_a35, &A64.cortex_a35 },
-            .{ 0xd05, &A32.cortex_a55, &A64.cortex_a55 },
-            .{ 0xd07, &A32.cortex_a57, &A64.cortex_a57 },
-            .{ 0xd08, &A32.cortex_a72, &A64.cortex_a72 },
-            .{ 0xd09, &A32.cortex_a73, &A64.cortex_a73 },
-            .{ 0xd0a, &A32.cortex_a75, &A64.cortex_a75 },
-            .{ 0xd0b, &A32.cortex_a76, &A64.cortex_a76 },
-            .{ 0xd0c, &A32.neoverse_n1, null },
-            .{ 0xd0d, &A32.cortex_a77, &A64.cortex_a77 },
-            .{ 0xd13, &A32.cortex_r52, null },
-            .{ 0xd20, &A32.cortex_m23, null },
-            .{ 0xd21, &A32.cortex_m33, null },
-            .{ 0xd41, &A32.cortex_a78, &A64.cortex_a78 },
-            .{ 0xd4b, &A32.cortex_a78c, &A64.cortex_a78c },
-            .{ 0xd44, &A32.cortex_x1, &A64.cortex_x1 },
-            .{ 0xd02, null, &A64.cortex_a34 },
-            .{ 0xd06, null, &A64.cortex_a65 },
-            .{ 0xd43, null, &A64.cortex_a65ae },
+        const E = struct {
+            part: u16,
+            variant: ?u8 = null, // null if matches any variant
+            m32: ?*const Target.Cpu.Model = null,
+            m64: ?*const Target.Cpu.Model = null,
         };
 
-        fn isKnown(implementer: u8, part: u16, is_64bit: bool) ?*const Target.Cpu.Model {
-            const models = switch (implementer) {
-                0x41 => ARM,
+        // implementer = 0x41
+        const ARM = [_]E{
+            E{ .part = 0x926, .m32 = &A32.arm926ej_s, .m64 = null },
+            E{ .part = 0xb02, .m32 = &A32.mpcore, .m64 = null },
+            E{ .part = 0xb36, .m32 = &A32.arm1136j_s, .m64 = null },
+            E{ .part = 0xb56, .m32 = &A32.arm1156t2_s, .m64 = null },
+            E{ .part = 0xb76, .m32 = &A32.arm1176jz_s, .m64 = null },
+            E{ .part = 0xc05, .m32 = &A32.cortex_a5, .m64 = null },
+            E{ .part = 0xc07, .m32 = &A32.cortex_a7, .m64 = null },
+            E{ .part = 0xc08, .m32 = &A32.cortex_a8, .m64 = null },
+            E{ .part = 0xc09, .m32 = &A32.cortex_a9, .m64 = null },
+            E{ .part = 0xc0d, .m32 = &A32.cortex_a17, .m64 = null },
+            E{ .part = 0xc0f, .m32 = &A32.cortex_a15, .m64 = null },
+            E{ .part = 0xc0e, .m32 = &A32.cortex_a17, .m64 = null },
+            E{ .part = 0xc14, .m32 = &A32.cortex_r4, .m64 = null },
+            E{ .part = 0xc15, .m32 = &A32.cortex_r5, .m64 = null },
+            E{ .part = 0xc17, .m32 = &A32.cortex_r7, .m64 = null },
+            E{ .part = 0xc18, .m32 = &A32.cortex_r8, .m64 = null },
+            E{ .part = 0xc20, .m32 = &A32.cortex_m0, .m64 = null },
+            E{ .part = 0xc21, .m32 = &A32.cortex_m1, .m64 = null },
+            E{ .part = 0xc23, .m32 = &A32.cortex_m3, .m64 = null },
+            E{ .part = 0xc24, .m32 = &A32.cortex_m4, .m64 = null },
+            E{ .part = 0xc27, .m32 = &A32.cortex_m7, .m64 = null },
+            E{ .part = 0xc60, .m32 = &A32.cortex_m0plus, .m64 = null },
+            E{ .part = 0xd01, .m32 = &A32.cortex_a32, .m64 = null },
+            E{ .part = 0xd03, .m32 = &A32.cortex_a53, .m64 = &A64.cortex_a53 },
+            E{ .part = 0xd04, .m32 = &A32.cortex_a35, .m64 = &A64.cortex_a35 },
+            E{ .part = 0xd05, .m32 = &A32.cortex_a55, .m64 = &A64.cortex_a55 },
+            E{ .part = 0xd07, .m32 = &A32.cortex_a57, .m64 = &A64.cortex_a57 },
+            E{ .part = 0xd08, .m32 = &A32.cortex_a72, .m64 = &A64.cortex_a72 },
+            E{ .part = 0xd09, .m32 = &A32.cortex_a73, .m64 = &A64.cortex_a73 },
+            E{ .part = 0xd0a, .m32 = &A32.cortex_a75, .m64 = &A64.cortex_a75 },
+            E{ .part = 0xd0b, .m32 = &A32.cortex_a76, .m64 = &A64.cortex_a76 },
+            E{ .part = 0xd0c, .m32 = &A32.neoverse_n1, .m64 = null },
+            E{ .part = 0xd0d, .m32 = &A32.cortex_a77, .m64 = &A64.cortex_a77 },
+            E{ .part = 0xd13, .m32 = &A32.cortex_r52, .m64 = null },
+            E{ .part = 0xd20, .m32 = &A32.cortex_m23, .m64 = null },
+            E{ .part = 0xd21, .m32 = &A32.cortex_m33, .m64 = null },
+            E{ .part = 0xd41, .m32 = &A32.cortex_a78, .m64 = &A64.cortex_a78 },
+            E{ .part = 0xd4b, .m32 = &A32.cortex_a78c, .m64 = &A64.cortex_a78c },
+            E{ .part = 0xd44, .m32 = &A32.cortex_x1, .m64 = &A64.cortex_x1 },
+            E{ .part = 0xd02, .m64 = &A64.cortex_a34 },
+            E{ .part = 0xd06, .m64 = &A64.cortex_a65 },
+            E{ .part = 0xd43, .m64 = &A64.cortex_a65ae },
+        };
+        // implementer = 0x42
+        const Broadcom = [_]E{
+            E{ .part = 0x516, .m64 = &A64.thunderx2t99 },
+        };
+        // implementer = 0x43
+        const Cavium = [_]E{
+            E{ .part = 0x0a0, .m64 = &A64.thunderx },
+            E{ .part = 0x0a2, .m64 = &A64.thunderxt81 },
+            E{ .part = 0x0a3, .m64 = &A64.thunderxt83 },
+            E{ .part = 0x0a1, .m64 = &A64.thunderxt88 },
+            E{ .part = 0x0af, .m64 = &A64.thunderx2t99 },
+        };
+        // implementer = 0x46
+        const Fujitsu = [_]E{
+            E{ .part = 0x001, .m64 = &A64.a64fx },
+        };
+        // implementer = 0x48
+        const HiSilicon = [_]E{
+            E{ .part = 0xd01, .m64 = &A64.tsv110 },
+        };
+        // implementer = 0x4e
+        const Nvidia = [_]E{
+            E{ .part = 0x004, .m64 = &A64.carmel },
+        };
+        // implementer = 0x51
+        const Qualcomm = [_]E{
+            E{ .part = 0x06f, .m32 = &A32.krait },
+            E{ .part = 0x201, .m64 = &A64.kryo, .m32 = &A64.kryo },
+            E{ .part = 0x205, .m64 = &A64.kryo, .m32 = &A64.kryo },
+            E{ .part = 0x211, .m64 = &A64.kryo, .m32 = &A64.kryo },
+            E{ .part = 0x800, .m64 = &A64.cortex_a73, .m32 = &A64.cortex_a73 },
+            E{ .part = 0x801, .m64 = &A64.cortex_a73, .m32 = &A64.cortex_a73 },
+            E{ .part = 0x802, .m64 = &A64.cortex_a75, .m32 = &A64.cortex_a75 },
+            E{ .part = 0x803, .m64 = &A64.cortex_a75, .m32 = &A64.cortex_a75 },
+            E{ .part = 0x804, .m64 = &A64.cortex_a76, .m32 = &A64.cortex_a76 },
+            E{ .part = 0x805, .m64 = &A64.cortex_a76, .m32 = &A64.cortex_a76 },
+            E{ .part = 0xc00, .m64 = &A64.falkor },
+            E{ .part = 0xc01, .m64 = &A64.saphira },
+        };
+
+        fn isKnown(core: CoreInfo, is_64bit: bool) ?*const Target.Cpu.Model {
+            const models = switch (core.implementer) {
+                0x41 => &ARM,
+                0x42 => &Broadcom,
+                0x43 => &Cavium,
+                0x46 => &Fujitsu,
+                0x48 => &HiSilicon,
+                0x51 => &Qualcomm,
                 else => return null,
             };
 
-            inline for (models) |model| {
-                if (model[0] == part)
-                    return if (is_64bit) model[2] else model[1];
+            for (models) |model| {
+                if (model.part == core.part and
+                    (model.variant == null or model.variant.? == core.variant))
+                    return if (is_64bit) model.m64 else model.m32;
             }
 
             return null;
@@ -287,8 +339,7 @@ const ArmCpuinfoImpl = struct {
 
         var known_models: [self.cores.len]?*const Target.Cpu.Model = undefined;
         for (self.cores[0..self.core_no]) |core, i| {
-            known_models[i] =
-                cpu_models.isKnown(core.implementer, core.part, is_64bit);
+            known_models[i] = cpu_models.isKnown(core, is_64bit);
         }
 
         // XXX We pick the first core on big.LITTLE systems, hopefully the

--- a/lib/std/zig/system/linux.zig
+++ b/lib/std/zig/system/linux.zig
@@ -239,6 +239,11 @@ const ArmCpuinfoImpl = struct {
         const Nvidia = [_]E{
             E{ .part = 0x004, .m64 = &A64.carmel },
         };
+        // implementer = 0x50
+        const Ampere = [_]E{
+            E{ .part = 0x000, .variant = 3, .m64 = &A64.emag },
+            E{ .part = 0x000, .m64 = &A64.xgene1 },
+        };
         // implementer = 0x51
         const Qualcomm = [_]E{
             E{ .part = 0x06f, .m32 = &A32.krait },
@@ -262,6 +267,7 @@ const ArmCpuinfoImpl = struct {
                 0x43 => &Cavium,
                 0x46 => &Fujitsu,
                 0x48 => &HiSilicon,
+                0x50 => &Ampere,
                 0x51 => &Qualcomm,
                 else => return null,
             };

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -239,6 +239,28 @@ const llvm_targets = [_]LlvmTarget{
                     "zcz_fp",
                 },
             },
+            .{
+                .llvm_name = null,
+                .zig_name = "xgene1",
+                .features = &.{
+                    "fp_armv8",
+                    "neon",
+                    "perfmon",
+                    "v8a",
+                },
+            },
+            .{
+                .llvm_name = null,
+                .zig_name = "emag",
+                .features = &.{
+                    "crc",
+                    "crypto",
+                    "fp_armv8",
+                    "neon",
+                    "perfmon",
+                    "v8a",
+                },
+            },
         },
     },
     .{


### PR DESCRIPTION
Please give this a spin on your Linux ARM boxes and post the output of `zig build-obj --show-builtin` (together with your `/proc/cpuinfo` if the detection fails)

cc @joachimschmidt557 
cc @mikdusan I think we're missing some entries for some of the CI boxes, do you still have their cpuinfo ?