### PR TITLE
c.zig: fix waitpid() definition

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -103,7 +103,7 @@ pub extern "c" fn linkat(oldfd: fd_t, oldpath: [*:0]const u8, newfd: fd_t, newpa
 pub extern "c" fn unlink(path: [*:0]const u8) c_int;
 pub extern "c" fn unlinkat(dirfd: fd_t, path: [*:0]const u8, flags: c_uint) c_int;
 pub extern "c" fn getcwd(buf: [*]u8, size: usize) ?[*]u8;
-pub extern "c" fn waitpid(pid: c_int, stat_loc: *c_uint, options: c_uint) c_int;
+pub extern "c" fn waitpid(pid: pid_t, stat_loc: ?*c_int, options: c_int) pid_t;
 pub extern "c" fn fork() c_int;
 pub extern "c" fn access(path: [*:0]const u8, mode: c_uint) c_int;
 pub extern "c" fn faccessat(dirfd: fd_t, path: [*:0]const u8, mode: c_uint, flags: c_uint) c_int;

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3435,10 +3435,10 @@ pub const WaitPidResult = struct {
 };
 
 pub fn waitpid(pid: pid_t, flags: u32) WaitPidResult {
-    const Status = if (builtin.link_libc) c_uint else u32;
+    const Status = if (builtin.link_libc) c_int else u32;
     var status: Status = undefined;
     while (true) {
-        const rc = system.waitpid(pid, &status, flags);
+        const rc = system.waitpid(pid, &status, if (builtin.link_libc) @intCast(c_int, flags) else flags);
         switch (errno(rc)) {
             0 => return .{
                 .pid = @intCast(pid_t, rc),


### PR DESCRIPTION
The definition for std.c.waitpid currently looks like this:
`pub extern "c" fn waitpid(pid: c_int, stat_loc: *c_uint, options: c_uint) c_int;`
However, this is inconsistent with the proper definition in libc, which is:
`pid_t waitpid(pid_t pid, int *stat_loc, int options);`

Notice that the proper function signature returns pid_t and takes pid_t as it's first parameter. The second parameter should also be a C pointer. While it isn't standardized as far as I can tell, both glibc and the musl bundled with Zig use `int` instead of `unsigned int`, so I've also changed it to c_int. 