### PR TITLE
c.zig: add sigfillset, alarm, sigwait

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -207,6 +207,9 @@ pub usingnamespace switch (builtin.os.tag) {
         pub extern "c" fn sigprocmask(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
         pub extern "c" fn socket(domain: c_uint, sock_type: c_uint, protocol: c_uint) c_int;
         pub extern "c" fn stat(noalias path: [*:0]const u8, noalias buf: *libc_stat) c_int;
+        pub extern "c" fn sigfillset(set: [*c]lc.sigset_t) void;
+        pub extern "c" fn alarm(seconds: c_uint) c_uint;
+        pub extern "c" fn sigwait(set: [*c]lc.sigset_t, sig: [*c]c_int) c_int;
     },
     .windows => struct {
         // TODO: copied the else case and removed the socket function (because its in ws2_32)
@@ -221,6 +224,9 @@ pub usingnamespace switch (builtin.os.tag) {
         pub extern "c" fn sigaction(sig: c_int, noalias act: ?*const Sigaction, noalias oact: ?*Sigaction) c_int;
         pub extern "c" fn sigprocmask(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
         pub extern "c" fn stat(noalias path: [*:0]const u8, noalias buf: *libc_stat) c_int;
+        pub extern "c" fn sigfillset(set: [*c]lc.sigset_t) void;
+        pub extern "c" fn alarm(seconds: c_uint) c_uint;
+        pub extern "c" fn sigwait(set: [*c]lc.sigset_t, sig: [*c]c_int) c_int;
     },
     else => struct {
         pub extern "c" fn clock_getres(clk_id: c_int, tp: *timespec) c_int;
@@ -234,6 +240,9 @@ pub usingnamespace switch (builtin.os.tag) {
         pub extern "c" fn sigprocmask(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
         pub extern "c" fn socket(domain: c_uint, sock_type: c_uint, protocol: c_uint) c_int;
         pub extern "c" fn stat(noalias path: [*:0]const u8, noalias buf: *libc_stat) c_int;
+        pub extern "c" fn sigfillset(set: [*c]lc.sigset_t) void;
+        pub extern "c" fn alarm(seconds: c_uint) c_uint;
+        pub extern "c" fn sigwait(set: [*c]lc.sigset_t, sig: [*c]c_int) c_int;
     },
 };
 

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -207,9 +207,9 @@ pub usingnamespace switch (builtin.os.tag) {
         pub extern "c" fn sigprocmask(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
         pub extern "c" fn socket(domain: c_uint, sock_type: c_uint, protocol: c_uint) c_int;
         pub extern "c" fn stat(noalias path: [*:0]const u8, noalias buf: *libc_stat) c_int;
-        pub extern "c" fn sigfillset(set: [*c]lc.sigset_t) void;
+        pub extern "c" fn sigfillset(set: ?*sigset_t) void;
         pub extern "c" fn alarm(seconds: c_uint) c_uint;
-        pub extern "c" fn sigwait(set: [*c]lc.sigset_t, sig: [*c]c_int) c_int;
+        pub extern "c" fn sigwait(set: ?*sigset_t, sig: ?*c_int) c_int;
     },
     .windows => struct {
         // TODO: copied the else case and removed the socket function (because its in ws2_32)
@@ -224,9 +224,9 @@ pub usingnamespace switch (builtin.os.tag) {
         pub extern "c" fn sigaction(sig: c_int, noalias act: ?*const Sigaction, noalias oact: ?*Sigaction) c_int;
         pub extern "c" fn sigprocmask(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
         pub extern "c" fn stat(noalias path: [*:0]const u8, noalias buf: *libc_stat) c_int;
-        pub extern "c" fn sigfillset(set: [*c]lc.sigset_t) void;
+        pub extern "c" fn sigfillset(set: ?*sigset_t) void;
         pub extern "c" fn alarm(seconds: c_uint) c_uint;
-        pub extern "c" fn sigwait(set: [*c]lc.sigset_t, sig: [*c]c_int) c_int;
+        pub extern "c" fn sigwait(set: ?*sigset_t, sig: ?*c_int) c_int;
     },
     else => struct {
         pub extern "c" fn clock_getres(clk_id: c_int, tp: *timespec) c_int;
@@ -240,9 +240,9 @@ pub usingnamespace switch (builtin.os.tag) {
         pub extern "c" fn sigprocmask(how: c_int, noalias set: ?*const sigset_t, noalias oset: ?*sigset_t) c_int;
         pub extern "c" fn socket(domain: c_uint, sock_type: c_uint, protocol: c_uint) c_int;
         pub extern "c" fn stat(noalias path: [*:0]const u8, noalias buf: *libc_stat) c_int;
-        pub extern "c" fn sigfillset(set: [*c]lc.sigset_t) void;
+        pub extern "c" fn sigfillset(set: ?*sigset_t) void;
         pub extern "c" fn alarm(seconds: c_uint) c_uint;
-        pub extern "c" fn sigwait(set: [*c]lc.sigset_t, sig: [*c]c_int) c_int;
+        pub extern "c" fn sigwait(set: ?*sigset_t, sig: ?*c_int) c_int;
     },
 };
 


### PR DESCRIPTION
I've added these three functions to all switches except NetBSD, because I don't know what the function is named there. I've even added it on the .windows switch since all the posix functions seem to be there anyways. That probably needs some testing and cleaning up.