### PR TITLE
stage1: Fix other OS target

### DIFF
--- a/src/stage1/stage1.h
+++ b/src/stage1/stage1.h
@@ -56,7 +56,7 @@ enum TargetSubsystem {
 
 
 // ABI warning
-// Synchronize with target.cpp::os_list
+// Synchronize with std.Target.Os.Tag and target.cpp::os_list
 enum Os {
     OsFreestanding,
     OsAnanas,
@@ -94,6 +94,9 @@ enum Os {
     OsWASI,
     OsEmscripten,
     OsUefi,
+    OsOpenCL,
+    OsGLSL450,
+    OsVulkan,
     OsOther,
 };
 

--- a/src/stage1/target.cpp
+++ b/src/stage1/target.cpp
@@ -122,6 +122,9 @@ static const Os os_list[] = {
     OsWASI,
     OsEmscripten,
     OsUefi,
+    OsOpenCL,
+    OsGLSL450,
+    OsVulkan,
     OsOther,
 };
 
@@ -213,6 +216,9 @@ Os target_os_enum(size_t index) {
 ZigLLVM_OSType get_llvm_os_type(Os os_type) {
     switch (os_type) {
         case OsFreestanding:
+        case OsOpenCL:
+        case OsGLSL450:
+        case OsVulkan:
         case OsOther:
             return ZigLLVM_UnknownOS;
         case OsAnanas:
@@ -330,6 +336,9 @@ const char *target_os_name(Os os_type) {
         case OsHurd:
         case OsWASI:
         case OsEmscripten:
+        case OsOpenCL:
+        case OsGLSL450:
+        case OsVulkan:
             return ZigLLVMGetOSTypeName(get_llvm_os_type(os_type));
     }
     zig_unreachable();
@@ -733,6 +742,9 @@ uint32_t target_c_type_size_in_bits(const ZigTarget *target, CIntType id) {
         case OsAMDPAL:
         case OsHermitCore:
         case OsHurd:
+        case OsOpenCL:
+        case OsGLSL450:
+        case OsVulkan:
             zig_panic("TODO c type size in bits for this target");
     }
     zig_unreachable();
@@ -999,6 +1011,10 @@ ZigLLVM_EnvironmentType target_default_abi(ZigLLVM_ArchType arch, Os os) {
         case OsWASI:
         case OsEmscripten:
             return ZigLLVM_Musl;
+        case OsOpenCL:
+        case OsGLSL450:
+        case OsVulkan:
+            return ZigLLVM_UnknownEnvironment;
     }
     zig_unreachable();
 }


### PR DESCRIPTION
PR #7827 added some new `std.Target.Os.Tag` before `other`.
The corresponding enum in stage1.h was not updated, which caused a
mismatch in the underlying integer values. While attempting to target
`other`, I encountered crashes.

This PR updates the stage1.h enum to include the added OS tags.
The new tags also had to be added to various switch cases to fix
compiler warnings, but have not been tested in any way.