### PR TITLE
x/net: fix tcp tests for openbsd and add missing `fmt` import

### DIFF
--- a/lib/std/x/net/ip.zig
+++ b/lib/std/x/net/ip.zig
@@ -6,6 +6,8 @@
 
 const std = @import("../../std.zig");
 
+const fmt = std.fmt;
+
 const IPv4 = std.x.os.IPv4;
 const IPv6 = std.x.os.IPv6;
 const Socket = std.x.os.Socket;

--- a/lib/std/x/net/tcp.zig
+++ b/lib/std/x/net/tcp.zig
@@ -282,7 +282,11 @@ test "tcp: create client/listener pair" {
     try listener.bind(ip.Address.initIPv4(IPv4.unspecified, 0));
     try listener.listen(128);
 
-    const binded_address = try listener.getLocalAddress();
+    var binded_address = try listener.getLocalAddress();
+    switch (binded_address) {
+        .ipv4 => |*ipv4| ipv4.host = IPv4.localhost,
+        .ipv6 => |*ipv6| ipv6.host = IPv6.localhost,
+    }
 
     const client = try tcp.Client.init(.ip, os.SOCK_CLOEXEC);
     defer client.deinit();
@@ -302,7 +306,11 @@ test "tcp/client: set read timeout of 1 millisecond on blocking client" {
     try listener.bind(ip.Address.initIPv4(IPv4.unspecified, 0));
     try listener.listen(128);
 
-    const binded_address = try listener.getLocalAddress();
+    var binded_address = try listener.getLocalAddress();
+    switch (binded_address) {
+        .ipv4 => |*ipv4| ipv4.host = IPv4.localhost,
+        .ipv6 => |*ipv6| ipv6.host = IPv6.localhost,
+    }
 
     const client = try tcp.Client.init(.ip, os.SOCK_CLOEXEC);
     defer client.deinit();

--- a/lib/std/x/os/Socket.zig
+++ b/lib/std/x/os/Socket.zig
@@ -8,6 +8,7 @@ const std = @import("../../std.zig");
 const net = @import("net.zig");
 
 const os = std.os;
+const fmt = std.fmt;
 const mem = std.mem;
 const time = std.time;
 


### PR DESCRIPTION
On OpenBSD, connecting to a newly-allocated port on an unspecified IPv4 host address causes EINVAL. This was found by @mikdusan when running TCP tests on OpenBSD.

This commit fixes TCP tests on OpenBSD by having all tests that allocate a new host-port pair to have the host IPv4/IPv6 address point to the host's loopback adapter (on localhost).