### PR TITLE
stage2: Fix UAF in ErrorMsg destructor

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -232,7 +232,6 @@ pub const CObject = struct {
         pub fn destroy(em: *ErrorMsg, gpa: *Allocator) void {
             gpa.free(em.msg);
             gpa.destroy(em);
-            em.* = undefined;
         }
     };
 


### PR DESCRIPTION
After calling gpa.destroy the object is gone for good, setting the
contents to undefined is a bug and may crash the compiler.