### PR TITLE
stage1: improve message for missing fn return type

### DIFF
--- a/src/stage1/parser.cpp
+++ b/src/stage1/parser.cpp
@@ -825,7 +825,16 @@ static AstNode *ast_parse_fn_proto(ParseContext *pc) {
     AstNode *return_type = nullptr;
     if (anytype == nullptr) {
         exmark = eat_token_if(pc, TokenIdBang);
-        return_type = ast_expect(pc, ast_parse_type_expr);
+        return_type = ast_parse_type_expr(pc);
+        if (return_type == nullptr) {
+            Token *next = peek_token(pc);
+            ast_error(
+                pc,
+                next,
+                "expected return type (use 'void' to return nothing), found: '%s'",
+                token_name(next->id)
+            );
+        }
     }
 
     AstNode *res = ast_create_node(pc, NodeTypeFnProto, first);


### PR DESCRIPTION
Coming from other languages it might be tempting for programmers to
accidentally leave out the return type instead of returning 'void'.

The error for this used to be

    error: invalid token: '{'
    pub fn main() {
                  ^

which is misleading. The '{' is expected but only after a return type.

The new message is

    error: expected return type (use 'void' to return nothing), found: '{'
    pub fn main() {
                  ^

which not only points out the real error but also hints at a (probably)
very common case where someone coming from e.g. Go is used to not
specifying a return type if a function returns nothing and thus forgets
to put 'void' there.

It might seem overkill to hint at the 'void' option but then the
compiler error messages are our user interface to the programmer. We
can be better than other languages in our error messages and leaving
out the return type seems to be a rather clear indication of the above
mentioned issue. Adding this will help more than distract.