### PR TITLE
Fix a double free and leak in json.zig

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1571,6 +1571,7 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
                                         return error.DuplicateJSONField;
                                     } else if (options.duplicate_field_behavior == .UseLast) {
                                         parseFree(field.field_type, @field(r, field.name), options);
+                                        fields_seen[i] = false;
                                     }
                                 }
                                 if (field.is_comptime) {
@@ -1642,6 +1643,7 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
             switch (ptrInfo.size) {
                 .One => {
                     const r: T = try allocator.create(ptrInfo.child);
+                    errdefer allocator.destroy(r);
                     r.* = try parseInternal(ptrInfo.child, token, tokens, options);
                     return r;
                 },
@@ -1986,6 +1988,24 @@ test "parse into struct with misc fields" {
     testing.expectEqualSlices(u8, "zig", r.veryComplex[0].foo);
     testing.expectEqualSlices(u8, "rocks", r.veryComplex[1].foo);
     testing.expectEqual(T.Union{ .float = 100000 }, r.a_union);
+}
+
+test "parse into struct with duplicate field" {
+    // allow allocator to detect double frees by keeping bucket in use
+    const ballast = try testing.allocator.alloc(u64, 1);
+    defer testing.allocator.free(ballast);
+
+    const options = ParseOptions{ 
+        .allocator = testing.allocator,
+        .duplicate_field_behavior = .UseLast,
+    };
+    const str = "{ \"a\": 1, \"a\": 0.25 }";
+    
+    const T1 = struct { a: *u64 };
+    testing.expectError(error.UnexpectedToken, parse(T1, &TokenStream.init(str), options));
+
+    const T2 = struct { a: f64 };
+    testing.expectEqual(T2{ .a = 0.25 }, try parse(T2, &TokenStream.init(str), options));
 }
 
 /// A non-stream JSON parser which constructs a tree of Value's.


### PR DESCRIPTION
If  `parse()` is used with the option `duplicate_field_behavior` set to `UseLast`, a double free occurs when a field requires allocation and an error occurs when parsing a second or later occurrence. This is because any later occurrences of the field will free the old value before trying to parse a new value, but crucially will not reset `fields_seen[i]` back to `false`. So if there is an error when parsing the new value, the earlier `errdefer` block will try to free the old value again. This can be fixed by simply clearing `fields_seen[i]`.

For example, if trying to parse into a `struct` with a `*u64` field `a` and `UseLast` set, the following JSON will cause a double free currently because an error occurs when trying to parse `0.25` as a u64:

`{
    "a": 1,
    "a": 0.25
}`

There is also a memory leak in the `.Pointer` case of `parseInternal` when parsing to a pointer to a single item. An object of type `ptrInfo.child` is first allocated, then a recursive call to `parseInternal` is tried. If that returns an error, then the object is never freed. This can be fixed by adding an `errdefer` statement before the parsing. I included this change in this pull request because otherwise the test I wrote will leak memory.

I added a test for parsing into a struct with a duplicate field. Because the testing allocator (a `GeneralPurposeAllocator`) can only detect double frees if the bucket it's allocating from is kept alive, I had to add a slightly odd ballast allocation. 