### PR TITLE
Fix premature closing brace being considered valid JSON in json.zig

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -623,7 +623,7 @@ pub const StreamingParser = struct {
 
             .ObjectSeparator => switch (c) {
                 ':' => {
-                    p.state = .ValueBegin;
+                    p.state = .ValueBeginNoClosing;
                     p.after_string_state = .ValueEnd;
                 },
                 0x09, 0x0A, 0x0D, 0x20 => {
@@ -1203,6 +1203,13 @@ test "json.token mismatched close" {
     try checkNext(&p, .Number);
     try checkNext(&p, .Number);
     try testing.expectError(error.UnexpectedClosingBrace, p.next());
+}
+
+test "json.token premature object close" {
+    var p = TokenStream.init("{ \"key\": }");
+    checkNext(&p, .ObjectBegin);
+    checkNext(&p, .String);
+    testing.expectError(error.InvalidValueBegin, p.next());
 }
 
 /// Validate a JSON string. This does not limit number precision so a decoder may not necessarily

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1207,9 +1207,9 @@ test "json.token mismatched close" {
 
 test "json.token premature object close" {
     var p = TokenStream.init("{ \"key\": }");
-    checkNext(&p, .ObjectBegin);
-    checkNext(&p, .String);
-    testing.expectError(error.InvalidValueBegin, p.next());
+    try checkNext(&p, .ObjectBegin);
+    try checkNext(&p, .String);
+    try testing.expectError(error.InvalidValueBegin, p.next());
 }
 
 /// Validate a JSON string. This does not limit number precision so a decoder may not necessarily

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -77,7 +77,7 @@ test "y_trailing_comma_after_empty" {
 }
 
 test "n_object_closed_missing_value" {
-    err(
+    try err(
         \\{"a":}
     );
 }

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -76,6 +76,12 @@ test "y_trailing_comma_after_empty" {
     );
 }
 
+test "n_object_closed_missing_value" {
+    err(
+        \\{"a":}
+    );
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 test "y_array_arraysWithSpaces" {


### PR DESCRIPTION
The state machine of `Parser`'s `transition` function considers some tokens `unreachable` from certain states. I believe this is currently correct for reading an `.ArrayEnd` in the `.ObjectValue` state and for reading an `.ObjectEnd` in the `.ArrayValue` state because the bit-stack mechanism in `StreamParser` will catch these as mismatched braces and brackets. Further, reading either `.ObjectEnd` or `.ArrayEnd` in the `.Simple` state will be caught by the bit-stack being empty. However, `.ObjectEnd` can be read in the `.ObjectValue` state because `StreamingParser` considers some malformed JSON to be valid. For example,

`std.json.validate("{ \"key\": }")`

returns `true` currently. This is because when the `.ObjectSeparator` state of `StreamingParser` reads a colon, it sets the new state to `.ValueBegin` rather than `.ValueBeginNoClosing`, which allows a premature closing brace to read without error. (If instead a closing array bracket is read in `.ValueBegin`, then the bit-stack again catches the mismatch.)

The result is that trying to parse such malformed JSON results in panic in safe builds and a silent crash in a ReleaseFast build. For example, the following program will panic currently:

```
pub fn main() !void {
    var heap = std.heap.HeapAllocator.init();
    defer heap.deinit();
    var parser = std.json.Parser.init(&heap.allocator, false);
    defer parser.deinit();
    var tree = try parser.parse("{ \"key\": }");
    defer tree.deinit();
}
```

I've changed the `.ObjectSeparator` state to set the new state to `.ValueBeginNoClosing` after reading a colon, and I added a test case for `TokenStream`. I also added a test for `Parser` to json/test.zig under the "Additional tests not part of JSONTestSuite" section. There was already a very similar test for `{"a":` in the suite, but that does not catch this bug.