### PR TITLE
std: testing.expectEqual uses the `eql` method if available

### DIFF
--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -348,6 +348,8 @@ test "vector division operators" {
         }
 
         fn doTheTest() !void {
+            @setEvalBranchQuota(2000);
+
             // https://github.com/ziglang/zig/issues/4952
             if (builtin.target.os.tag != .windows) {
                 try doTheTestDiv(f16, [4]f16{ 4.0, -4.0, 4.0, -4.0 }, [4]f16{ 1.0, 2.0, -1.0, -2.0 });


### PR DESCRIPTION
Implements the proposal outlined in #8625