### PR TITLE
Dwarf on windows

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -22,6 +22,10 @@ const Progress = @This();
 /// not print on update()
 terminal: ?std.fs.File = undefined,
 
+/// Is this a windows API terminal (note: this is not the same as being run on windows
+/// because other terminals exist like MSYS/git-bash)
+is_windows_terminal: bool = false,
+
 /// Whether the terminal supports ANSI escape codes.
 supports_ansi_escape_codes: bool = false,
 
@@ -143,6 +147,7 @@ pub fn start(self: *Progress, name: []const u8, estimated_total_items: usize) !*
         self.terminal = stderr;
         self.supports_ansi_escape_codes = true;
     } else if (std.builtin.os.tag == .windows and stderr.isTty()) {
+        self.is_windows_terminal = true;
         self.terminal = stderr;
     } else if (std.builtin.os.tag != .windows) {
         // we are in a "dumb" terminal like in acme or writing to a file
@@ -192,8 +197,9 @@ const DECRC = "\x1b8";
 // supported by some terminals (eg. Terminal.app).
 
 fn refreshWithHeldLock(self: *Progress) void {
-    const is_dumb = !self.supports_ansi_escape_codes and !(std.builtin.os.tag == .windows);
+    const is_dumb = !self.supports_ansi_escape_codes and !self.is_windows_terminal;
     if (is_dumb and self.dont_print_on_dumb) return;
+
     const file = self.terminal orelse return;
 
     var end: usize = 0;
@@ -206,6 +212,8 @@ fn refreshWithHeldLock(self: *Progress) void {
         std.mem.copy(u8, self.output_buffer[end..], seq_before);
         end += seq_before.len;
     } else if (std.builtin.os.tag == .windows) winapi: {
+        std.debug.assert(self.is_windows_terminal);
+
         var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
         if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) != windows.TRUE)
             unreachable;
@@ -282,7 +290,7 @@ fn refreshWithHeldLock(self: *Progress) void {
         const seq_after = DECRC;
         std.mem.copy(u8, self.output_buffer[end..], seq_after);
         end += seq_after.len;
-    } else if (std.builtin.os.tag != .windows) {
+    } else if (!self.is_windows_terminal) {
         self.output_buffer[end] = '\n';
         end += 1;
     }
@@ -293,8 +301,10 @@ fn refreshWithHeldLock(self: *Progress) void {
     };
 
     if (std.builtin.os.tag == .windows) {
-        if (windows.kernel32.SetConsoleCursorPosition(file.handle, saved_cursor_pos) != windows.TRUE)
-            unreachable;
+        if (self.is_windows_terminal) {
+            const res = windows.kernel32.SetConsoleCursorPosition(file.handle, saved_cursor_pos);
+            std.debug.assert(res == windows.TRUE);
+        }
     }
 
     self.prev_refresh_timestamp = self.timer.read();
@@ -318,7 +328,7 @@ fn bufWrite(self: *Progress, end: *usize, comptime format: []const u8, args: any
             end.* = self.output_buffer.len;
         },
     }
-    const bytes_needed_for_esc_codes_at_end = if (std.builtin.os.tag == .windows) 0 else 11;
+    const bytes_needed_for_esc_codes_at_end: u8 = if (self.is_windows_terminal) 0 else 11;
     const max_end = self.output_buffer.len - bytes_needed_for_esc_codes_at_end;
     if (end.* > max_end) {
         const suffix = "... ";

--- a/lib/std/dwarf.zig
+++ b/lib/std/dwarf.zig
@@ -144,7 +144,7 @@ const FileEntry = struct {
 };
 
 const LineNumberProgram = struct {
-    address: usize,
+    address: u64,
     file: usize,
     line: i64,
     column: u64,
@@ -153,12 +153,12 @@ const LineNumberProgram = struct {
     end_sequence: bool,
 
     default_is_stmt: bool,
-    target_address: usize,
+    target_address: u64,
     include_dirs: []const []const u8,
     file_entries: *ArrayList(FileEntry),
 
     prev_valid: bool,
-    prev_address: usize,
+    prev_address: u64,
     prev_file: usize,
     prev_line: i64,
     prev_column: u64,
@@ -186,7 +186,7 @@ const LineNumberProgram = struct {
         self.prev_end_sequence = undefined;
     }
 
-    pub fn init(is_stmt: bool, include_dirs: []const []const u8, file_entries: *ArrayList(FileEntry), target_address: usize) LineNumberProgram {
+    pub fn init(is_stmt: bool, include_dirs: []const []const u8, file_entries: *ArrayList(FileEntry), target_address: u64) LineNumberProgram {
         return LineNumberProgram{
             .address = 0,
             .file = 1,
@@ -691,7 +691,7 @@ pub const DwarfInfo = struct {
         return result;
     }
 
-    pub fn getLineNumberInfo(di: *DwarfInfo, compile_unit: CompileUnit, target_address: usize) !debug.LineInfo {
+    pub fn getLineNumberInfo(di: *DwarfInfo, compile_unit: CompileUnit, target_address: u64) !debug.LineInfo {
         var stream = io.fixedBufferStream(di.debug_line);
         const in = &stream.reader();
         const seekable = &stream.seekableStream();


### PR DESCRIPTION
This PR does 3 things but can be split up if needed.

- Fix a compile time crash/unreachable-code when using bash based terminals on windows
- Emit Dwarf debug info if targetting gnu abi on windows (maybe this should be a flag instead)
- Add support for reading Dwarf info from COFF executables for stack and error tracing
