### PR TITLE
Fix shrinkAndFree and remove shrinkRetainingCapacity in PriorityQueue and PriorityDequeue

### DIFF
--- a/lib/std/priority_dequeue.zig
+++ b/lib/std/priority_dequeue.zig
@@ -387,17 +387,6 @@ pub fn PriorityDequeue(comptime T: type) type {
                     return;
                 },
             };
-            self.len = new_len;
-        }
-
-        /// Reduce length to `new_len`.
-        pub fn shrinkRetainingCapacity(self: *Self, new_len: usize) void {
-            assert(new_len <= self.items.len);
-
-            // Cannot shrink to smaller than the current queue size without invalidating the heap property
-            assert(new_len >= self.len);
-
-            self.len = new_len;
         }
 
         pub fn update(self: *Self, elem: T, new_elem: T) !void {
@@ -836,7 +825,7 @@ test "std.PriorityDequeue: iterator while empty" {
     try expectEqual(it.next(), null);
 }
 
-test "std.PriorityDequeue: shrinkRetainingCapacity and shrinkAndFree" {
+test "std.PriorityDequeue: shrinkAndFree" {
     var queue = PDQ.init(testing.allocator, lessThanComparison);
     defer queue.deinit();
 
@@ -846,10 +835,6 @@ test "std.PriorityDequeue: shrinkRetainingCapacity and shrinkAndFree" {
     try queue.add(1);
     try queue.add(2);
     try queue.add(3);
-    try expect(queue.capacity() >= 4);
-    try expectEqual(@as(usize, 3), queue.len);
-
-    queue.shrinkRetainingCapacity(3);
     try expect(queue.capacity() >= 4);
     try expectEqual(@as(usize, 3), queue.len);
 

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -203,17 +203,6 @@ pub fn PriorityQueue(comptime T: type) type {
                     return;
                 },
             };
-            self.len = new_len;
-        }
-
-        /// Reduce length to `new_len`.
-        pub fn shrinkRetainingCapacity(self: *Self, new_len: usize) void {
-            assert(new_len <= self.items.len);
-
-            // Cannot shrink to smaller than the current queue size without invalidating the heap property
-            assert(new_len >= self.len);
-
-            self.len = new_len;
         }
 
         pub fn update(self: *Self, elem: T, new_elem: T) !void {
@@ -495,7 +484,7 @@ test "std.PriorityQueue: iterator while empty" {
     try expectEqual(it.next(), null);
 }
 
-test "std.PriorityQueue: shrinkRetainingCapacity and shrinkAndFree" {
+test "std.PriorityQueue: shrinkAndFree" {
     var queue = PQ.init(testing.allocator, lessThan);
     defer queue.deinit();
 
@@ -505,10 +494,6 @@ test "std.PriorityQueue: shrinkRetainingCapacity and shrinkAndFree" {
     try queue.add(1);
     try queue.add(2);
     try queue.add(3);
-    try expect(queue.capacity() >= 4);
-    try expectEqual(@as(usize, 3), queue.len);
-
-    queue.shrinkRetainingCapacity(3);
     try expect(queue.capacity() >= 4);
     try expectEqual(@as(usize, 3), queue.len);
 


### PR DESCRIPTION
The `shrinkAndFree` and `shrinkRetainingCapacity` functions for both `PriorityQueue` and `PriorityDequeue` will increase the size of the heap itself if called with any value of `new_len > self.len` because they all end with `self.len = new_len`. This will add garbage items to the heap and most likely violate the heap property. For example,

```
var queue = std.PriorityQueue(i8).init(&heap.allocator, lessThan);
defer queue.deinit();

try queue.addSlice(&[_]i8{ 1, 2, 3, 4, 5 });
std.debug.print("{any}\n", .{ queue.items[0..queue.len] });
queue.shrinkAndFree(queue.capacity());
std.debug.print("{any}\n", .{ queue.items[0..queue.len] });
```

printed

```
{ 1, 2, 3, 4, 5 }
{ 1, 2, 3, 4, 5, -86, -86, -86 }
```

on one run on my machine.

Removing the assignment to `self.len` means `shrinkAndFree` will simply call `realloc` on  `self.items`, which is all it should do. However, without the assignment, `shrinkRetainingCapacity` will do nothing at all. I believe this is fundamentally because `shrinkRetainingCapacity` actually does not make sense for a heap. Arguably, a `shrinkRetainingCapacity` for `PriorityQueue` that accepted `new_len < self.len` could be written to repeatedly remove the minimum element from the queue. But I think this conflates two separate operations and is confusing, which is also supported by the `assert(new_len >= self.len)` currently found in all shrink functions. Furthermore, there would be no natural equivalent for `PriorityDequeue` because either minimum or maximum elements (or some mix of them) could be removed when shrinking. Therefore, `shrinkRetainingCapacity` can do nothing and should be removed from both queue types.