### PR TITLE
fstatat() test now also fails on FreeBSD in ReleaseSmall mode

### DIFF
--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -263,7 +263,7 @@ test "linkat with different directories" {
 test "fstatat" {
     // enable when `fstat` and `fstatat` are implemented on Windows
     if (builtin.os.tag == .windows) return error.SkipZigTest;
-    if (builtin.os.tag == .freebsd and builtin.mode == .ReleaseFast) {
+    if (builtin.os.tag == .freebsd) {
         // https://github.com/ziglang/zig/issues/8538
         return error.SkipZigTest;
     }


### PR DESCRIPTION
Disable that test for now, if only because we haven't been updating -master builds for a couple days due to this.