### PR TITLE
Initialize the Stat structure

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3408,7 +3408,7 @@ pub fn fstat(fd: fd_t) FStatError!Stat {
         @compileError("fstat is not yet implemented on Windows");
     }
 
-    var stat: Stat = undefined;
+    var stat: Stat = mem.zeroes(Stat);
     switch (errno(system.fstat(fd, &stat))) {
         0 => return stat,
         EINVAL => unreachable,
@@ -3459,7 +3459,7 @@ pub fn fstatatWasi(dirfd: fd_t, pathname: []const u8, flags: u32) FStatAtError!S
 /// Same as `fstatat` but `pathname` is null-terminated.
 /// See also `fstatat`.
 pub fn fstatatZ(dirfd: fd_t, pathname: [*:0]const u8, flags: u32) FStatAtError!Stat {
-    var stat: Stat = undefined;
+    var stat: Stat = mem.zeroes(Stat);
     switch (errno(system.fstatat(dirfd, pathname, &stat, flags))) {
         0 => return stat,
         EINVAL => unreachable,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3408,7 +3408,7 @@ pub fn fstat(fd: fd_t) FStatError!Stat {
         @compileError("fstat is not yet implemented on Windows");
     }
 
-    var stat: Stat = mem.zeroes(Stat);
+    var stat = mem.zeroes(Stat);
     switch (errno(system.fstat(fd, &stat))) {
         0 => return stat,
         EINVAL => unreachable,
@@ -3459,7 +3459,7 @@ pub fn fstatatWasi(dirfd: fd_t, pathname: []const u8, flags: u32) FStatAtError!S
 /// Same as `fstatat` but `pathname` is null-terminated.
 /// See also `fstatat`.
 pub fn fstatatZ(dirfd: fd_t, pathname: [*:0]const u8, flags: u32) FStatAtError!Stat {
-    var stat: Stat = mem.zeroes(Stat);
+    var stat = mem.zeroes(Stat);
     switch (errno(system.fstatat(dirfd, pathname, &stat, flags))) {
         0 => return stat,
         EINVAL => unreachable,

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -263,10 +263,6 @@ test "linkat with different directories" {
 test "fstatat" {
     // enable when `fstat` and `fstatat` are implemented on Windows
     if (builtin.os.tag == .windows) return error.SkipZigTest;
-    if (builtin.os.tag == .freebsd and builtin.mode == .ReleaseFast) {
-        // https://github.com/ziglang/zig/issues/8538
-        return error.SkipZigTest;
-    }
 
     var tmp = tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
The system `stat` structure includes padding, and, on some operating systems such as all BSDs, "spare" bytes at the end.

We can't reliably compare two `Stat` values if these are uninitialized, while being later compared.

This is what was causing the `fstatat` test to fail on FreeBSD since the update to LLVM 12. It was previously only passing by accident.

Fixes #8538