### PR TITLE
Fix AutoArrayHashMap's store_hash logic

### DIFF
--- a/lib/std/array_hash_map.zig
+++ b/lib/std/array_hash_map.zig
@@ -18,11 +18,11 @@ const builtin = @import("builtin");
 const hash_map = @This();
 
 pub fn AutoArrayHashMap(comptime K: type, comptime V: type) type {
-    return ArrayHashMap(K, V, getAutoHashFn(K), getAutoEqlFn(K), autoEqlIsCheap(K));
+    return ArrayHashMap(K, V, getAutoHashFn(K), getAutoEqlFn(K), !autoEqlIsCheap(K));
 }
 
 pub fn AutoArrayHashMapUnmanaged(comptime K: type, comptime V: type) type {
-    return ArrayHashMapUnmanaged(K, V, getAutoHashFn(K), getAutoEqlFn(K), autoEqlIsCheap(K));
+    return ArrayHashMapUnmanaged(K, V, getAutoHashFn(K), getAutoEqlFn(K), !autoEqlIsCheap(K));
 }
 
 /// Builtin hashmap for strings as keys.
@@ -1294,7 +1294,7 @@ test "reIndex" {
         try al.append(std.testing.allocator, .{
             .key = i,
             .value = i * 10,
-            .hash = hash(i),
+            .hash = {},
         });
     }
 
@@ -1321,7 +1321,7 @@ test "fromOwnedArrayList" {
         try al.append(std.testing.allocator, .{
             .key = i,
             .value = i * 10,
-            .hash = hash(i),
+            .hash = {},
         });
     }
 
@@ -1336,6 +1336,18 @@ test "fromOwnedArrayList" {
         try testing.expect(gop.entry.value == i * 10);
         try testing.expect(gop.index == i);
     }
+}
+
+test "auto store_hash" {
+    const HasCheapEql = AutoArrayHashMap(i32, i32);
+    const HasExpensiveEql = AutoArrayHashMap([32]i32, i32);
+    try testing.expect(meta.fieldInfo(HasCheapEql.Entry, .hash).field_type == void);
+    try testing.expect(meta.fieldInfo(HasExpensiveEql.Entry, .hash).field_type != void);
+
+    const HasCheapEqlUn = AutoArrayHashMapUnmanaged(i32, i32);
+    const HasExpensiveEqlUn = AutoArrayHashMapUnmanaged([32]i32, i32);
+    try testing.expect(meta.fieldInfo(HasCheapEqlUn.Entry, .hash).field_type == void);
+    try testing.expect(meta.fieldInfo(HasExpensiveEqlUn.Entry, .hash).field_type != void);
 }
 
 pub fn getHashPtrAddrFn(comptime K: type) (fn (K) u32) {


### PR DESCRIPTION
`ArrayHashMap` and `ArrayHashMapUnmanaged` take a comptime bool `store_hash` that is meant to be false when the `eql` function for keys is cheap and true when it isn't. The helper `autoEqlIsCheap` returns true for primitives and a few other types, and its return value is passed directly for `store_hash` by `AutoArrayHashMap` and `AutoArrayHashMapUnmanaged`. This means `store_hash` is true when the key has a cheap `eql` function, which wastes space, and `store_hash` is false when the key has an expensive `eql` function, which wastes time. In other words, this is exactly backwards to what was intended, and `store_hash` should instead be `!autoEqlIsCheap(K)`.

Two tests that directly handled `Entry` structs had to be changed because they were storing hashes for a key type of `i32` (which has a cheap `eql`), and this change may break user code doing anything similar. I also added a test to check that an `AutoArrayHashMap`'s `Entry` type does in fact have a void or non-void `hash` field as expected.