### PR TITLE
macho: allow overriding stack size in binary

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -442,6 +442,7 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
                 const text_segment = self.load_commands.items[self.text_segment_cmd_index.?].Segment;
                 const main_cmd = &self.load_commands.items[self.main_cmd_index.?].Main;
                 main_cmd.entryoff = addr - text_segment.inner.vmaddr;
+                main_cmd.stacksize = self.base.options.stack_size_override orelse 0;
                 self.load_commands_dirty = true;
             }
             try self.writeRebaseInfoTable();
@@ -695,7 +696,9 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
                 Compilation.dump_argv(argv.items);
             }
 
-            try zld.link(input_files.items, full_out_path);
+            try zld.link(input_files.items, full_out_path, .{
+                .stack_size = self.base.options.stack_size_override,
+            });
 
             break :outer;
         }

--- a/src/link/MachO/Zld.zig
+++ b/src/link/MachO/Zld.zig
@@ -29,6 +29,10 @@ page_size: ?u16 = null,
 file: ?fs.File = null,
 out_path: ?[]const u8 = null,
 
+// TODO these args will become obselete once Zld is coalesced with incremental
+// linker.
+stack_size: u64 = 0,
+
 objects: std.ArrayListUnmanaged(*Object) = .{},
 archives: std.ArrayListUnmanaged(*Archive) = .{},
 
@@ -172,7 +176,11 @@ pub fn closeFiles(self: Zld) void {
     if (self.file) |f| f.close();
 }
 
-pub fn link(self: *Zld, files: []const []const u8, out_path: []const u8) !void {
+const LinkArgs = struct {
+    stack_size: ?u64 = null,
+};
+
+pub fn link(self: *Zld, files: []const []const u8, out_path: []const u8, args: LinkArgs) !void {
     if (files.len == 0) return error.NoInputFiles;
     if (out_path.len == 0) return error.EmptyOutputPath;
 
@@ -206,6 +214,7 @@ pub fn link(self: *Zld, files: []const []const u8, out_path: []const u8) !void {
         .read = true,
         .mode = if (std.Target.current.os.tag == .windows) 0 else 0o777,
     });
+    self.stack_size = args.stack_size orelse 0;
 
     try self.populateMetadata();
     try self.parseInputFiles(files);
@@ -2204,6 +2213,7 @@ fn setEntryPoint(self: *Zld) !void {
     const entry_sym = sym.cast(Symbol.Regular) orelse unreachable;
     const ec = &self.load_commands.items[self.main_cmd_index.?].Main;
     ec.entryoff = @intCast(u32, entry_sym.address - seg.inner.vmaddr);
+    ec.stacksize = self.stack_size;
 }
 
 fn writeRebaseInfoTable(self: *Zld) !void {


### PR DESCRIPTION
cc @andrewrk 

I tried setting tiny stack size, and was greeted with a segfault so fingers crossed that macOS actually respects this value.