### PR TITLE
Add experimental Darling support for cross testing macOS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -218,6 +218,7 @@ pub fn build(b: *Builder) !void {
     const is_wine_enabled = b.option(bool, "enable-wine", "Use Wine to run cross compiled Windows tests") orelse false;
     const is_qemu_enabled = b.option(bool, "enable-qemu", "Use QEMU to run cross compiled foreign architecture tests") orelse false;
     const is_wasmtime_enabled = b.option(bool, "enable-wasmtime", "Use Wasmtime to enable and run WASI libstd tests") orelse false;
+    const is_darling_enabled = b.option(bool, "enable-darling", "[Experimental] Use Darling to run cross compiled macOS tests") orelse false;
     const glibc_multi_dir = b.option([]const u8, "enable-foreign-glibc", "Provide directory with glibc installations to run cross compiled tests that link glibc");
 
     test_stage2.addBuildOption(bool, "skip_non_native", skip_non_native);
@@ -227,6 +228,7 @@ pub fn build(b: *Builder) !void {
     test_stage2.addBuildOption(bool, "enable_qemu", is_qemu_enabled);
     test_stage2.addBuildOption(bool, "enable_wine", is_wine_enabled);
     test_stage2.addBuildOption(bool, "enable_wasmtime", is_wasmtime_enabled);
+    test_stage2.addBuildOption(bool, "enable_darling", is_darling_enabled);
     test_stage2.addBuildOption(?[]const u8, "glibc_multi_install_dir", glibc_multi_dir);
     test_stage2.addBuildOption([]const u8, "version", version);
 
@@ -261,11 +263,56 @@ pub fn build(b: *Builder) !void {
     const fmt_step = b.step("test-fmt", "Run zig fmt against build.zig to make sure it works");
     fmt_step.dependOn(&fmt_build_zig.step);
 
-    // TODO for the moment, skip wasm32-wasi until bugs are sorted out.
-    toolchain_step.dependOn(tests.addPkgTests(b, test_filter, "test/stage1/behavior.zig", "behavior", "Run the behavior tests", modes, false, skip_non_native, skip_libc, is_wine_enabled, is_qemu_enabled, is_wasmtime_enabled, glibc_multi_dir));
+    toolchain_step.dependOn(tests.addPkgTests(
+        b,
+        test_filter,
+        "test/stage1/behavior.zig",
+        "behavior",
+        "Run the behavior tests",
+        modes,
+        false,
+        skip_non_native,
+        skip_libc,
+        is_wine_enabled,
+        is_qemu_enabled,
+        is_wasmtime_enabled,
+        is_darling_enabled,
+        glibc_multi_dir,
+    ));
 
-    toolchain_step.dependOn(tests.addPkgTests(b, test_filter, "lib/std/special/compiler_rt.zig", "compiler-rt", "Run the compiler_rt tests", modes, true, skip_non_native, true, is_wine_enabled, is_qemu_enabled, is_wasmtime_enabled, glibc_multi_dir));
-    toolchain_step.dependOn(tests.addPkgTests(b, test_filter, "lib/std/special/c.zig", "minilibc", "Run the mini libc tests", modes, true, skip_non_native, true, is_wine_enabled, is_qemu_enabled, is_wasmtime_enabled, glibc_multi_dir));
+    toolchain_step.dependOn(tests.addPkgTests(
+        b,
+        test_filter,
+        "lib/std/special/compiler_rt.zig",
+        "compiler-rt",
+        "Run the compiler_rt tests",
+        modes,
+        true,
+        skip_non_native,
+        true,
+        is_wine_enabled,
+        is_qemu_enabled,
+        is_wasmtime_enabled,
+        is_darling_enabled,
+        glibc_multi_dir,
+    ));
+
+    toolchain_step.dependOn(tests.addPkgTests(
+        b,
+        test_filter,
+        "lib/std/special/c.zig",
+        "minilibc",
+        "Run the mini libc tests",
+        modes,
+        true,
+        skip_non_native,
+        true,
+        is_wine_enabled,
+        is_qemu_enabled,
+        is_wasmtime_enabled,
+        is_darling_enabled,
+        glibc_multi_dir,
+    ));
 
     toolchain_step.dependOn(tests.addCompareOutputTests(b, test_filter, modes));
     toolchain_step.dependOn(tests.addStandaloneTests(b, test_filter, modes));
@@ -283,7 +330,22 @@ pub fn build(b: *Builder) !void {
         toolchain_step.dependOn(tests.addCompileErrorTests(b, test_filter, modes));
     }
 
-    const std_step = tests.addPkgTests(b, test_filter, "lib/std/std.zig", "std", "Run the standard library tests", modes, false, skip_non_native, skip_libc, is_wine_enabled, is_qemu_enabled, is_wasmtime_enabled, glibc_multi_dir);
+    const std_step = tests.addPkgTests(
+        b,
+        test_filter,
+        "lib/std/std.zig",
+        "std",
+        "Run the standard library tests",
+        modes,
+        false,
+        skip_non_native,
+        skip_libc,
+        is_wine_enabled,
+        is_qemu_enabled,
+        is_wasmtime_enabled,
+        is_darling_enabled,
+        glibc_multi_dir,
+    );
 
     const test_step = b.step("test", "Run all the tests");
     test_step.dependOn(toolchain_step);

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1398,6 +1398,9 @@ pub const LibExeObjStep = struct {
     /// Uses system Wasmtime installation to run cross compiled wasm/wasi build artifacts.
     enable_wasmtime: bool = false,
 
+    /// Experimental. Uses system Darling installation to run cross compiled macOS build artifacts.
+    enable_darling: bool = false,
+
     /// After following the steps in https://github.com/ziglang/zig/wiki/Updating-libc#glibc,
     /// this will be the directory $glibc-build-dir/install/glibcs
     /// Given the example of the aarch64 target, this is the directory
@@ -2512,6 +2515,11 @@ pub const LibExeObjStep = struct {
                 try zig_args.append(bin_name);
                 try zig_args.append("--test-cmd");
                 try zig_args.append("--dir=.");
+                try zig_args.append("--test-cmd-bin");
+            },
+            .darling => |bin_name| if (self.enable_darling) {
+                try zig_args.append("--test-cmd");
+                try zig_args.append(bin_name);
                 try zig_args.append("--test-cmd-bin");
             },
         }

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -606,6 +606,7 @@ pub const CrossTarget = struct {
         qemu: []const u8,
         wine: []const u8,
         wasmtime: []const u8,
+        darling: []const u8,
         unavailable,
     };
 
@@ -666,6 +667,15 @@ pub const CrossTarget = struct {
             .wasi => switch (cpu_arch.ptrBitWidth()) {
                 32 => return Executor{ .wasmtime = "wasmtime" },
                 else => return .unavailable,
+            },
+            .macos => {
+                // TODO loosen this check once upstream adds QEMU-based emulation
+                // layer for non-host architectures:
+                // https://github.com/darlinghq/darling/issues/863
+                if (cpu_arch != Target.current.cpu.arch) {
+                    return .unavailable;
+                }
+                return Executor{ .darling = "darling" };
             },
             else => return .unavailable,
         }

--- a/src/test.zig
+++ b/src/test.zig
@@ -9,6 +9,7 @@ const build_options = @import("build_options");
 const enable_qemu: bool = build_options.enable_qemu;
 const enable_wine: bool = build_options.enable_wine;
 const enable_wasmtime: bool = build_options.enable_wasmtime;
+const enable_darling: bool = build_options.enable_darling;
 const glibc_multi_install_dir: ?[]const u8 = build_options.glibc_multi_install_dir;
 const ThreadPool = @import("ThreadPool.zig");
 const CrossTarget = std.zig.CrossTarget;
@@ -898,6 +899,16 @@ pub const TestContext = struct {
                                 try argv.append(exe_path);
                             } else {
                                 return; // wasmtime not available; pass test.
+                            },
+
+                            .darling => |darling_bin_name| if (enable_darling) {
+                                try argv.append(darling_bin_name);
+                                // Since we use relative to cwd here, we invoke darling with
+                                // "shell" subcommand.
+                                try argv.append("shell");
+                                try argv.append(exe_path);
+                            } else {
+                                return; // Darling not available; pass test.
                             },
                         }
 

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -503,6 +503,7 @@ pub fn addPkgTests(
     is_wine_enabled: bool,
     is_qemu_enabled: bool,
     is_wasmtime_enabled: bool,
+    is_darling_enabled: bool,
     glibc_dir: ?[]const u8,
 ) *build.Step {
     const step = b.step(b.fmt("test-{s}", .{name}), desc);
@@ -564,6 +565,7 @@ pub fn addPkgTests(
         these_tests.enable_wine = is_wine_enabled;
         these_tests.enable_qemu = is_qemu_enabled;
         these_tests.enable_wasmtime = is_wasmtime_enabled;
+        these_tests.enable_darling = is_darling_enabled;
         these_tests.glibc_multi_install_dir = glibc_dir;
         these_tests.addIncludeDir("test");
 


### PR DESCRIPTION
[Darling](https://www.darlinghq.org/) is a translation layer of macOS syscalls to Linux. This basically allows you to run native macOS binaries (MachO binaries) on your Linux box.

This commit introduces an experimental binding of Darling as means for cross testing MachO binaries and macOS specific tests on your Linux box without the need to grab an actual copy of macOS. Of course, since Darling itself is experimental, so is this binding, and currently its functionality is limited to executing binaries compiled to the same architecture as the host, and in particular, mainly `x86_64`.

In more detail, in terms of code additions:
* for cross testing stage2 tests, we use `darling shell` command since the path to the tested binary is relative to cwd
* for the `zig test` command, we simply use `darling` since the path to the binary is absolute

Testing works great except for `test-std` (yep, stage2 tests of `x86_64` macOS run and pass on my Linux box) which has several failures and hangups due to missing syscalls implementations, etc. in Darling.

Darling can be enabled just like QEMU or Wasmtime, e.g., for testing stage2:

```
zig build test-stage2 -Denable-darling
```