### PR TITLE
start.zig: export main with strong linkage

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -40,7 +40,7 @@ comptime {
         } else if (builtin.output_mode == .Exe or @hasDecl(root, "main")) {
             if (builtin.link_libc and @hasDecl(root, "main")) {
                 if (@typeInfo(@TypeOf(root.main)).Fn.calling_convention != .C) {
-                    @export(main, .{ .name = "main", .linkage = .Weak });
+                    @export(main, .{ .name = "main" });
                 }
             } else if (builtin.os.tag == .windows) {
                 if (!@hasDecl(root, "WinMain") and !@hasDecl(root, "WinMainCRTStartup") and


### PR DESCRIPTION
Unmarks `_main` as weak symbol making it global (the entire linked
program) in scope.