### PR TITLE
macho: require _main as global export in self-hosted

### DIFF
--- a/test/stage2/darwin.zig
+++ b/test/stage2/darwin.zig
@@ -17,7 +17,7 @@ pub fn addCases(ctx: *TestContext) !void {
 
             // Incorrect return type
             case.addError(
-                \\export fn _start() noreturn {
+                \\export fn _main() noreturn {
                 \\}
             , &[_][]const u8{":2:1: error: expected noreturn, found void"});
 
@@ -26,7 +26,7 @@ pub fn addCases(ctx: *TestContext) !void {
                 \\extern "c" fn write(usize, usize, usize) usize;
                 \\extern "c" fn exit(usize) noreturn;
                 \\
-                \\export fn _start() noreturn {
+                \\export fn _main() noreturn {
                 \\    print();
                 \\
                 \\    exit(0);
@@ -46,7 +46,7 @@ pub fn addCases(ctx: *TestContext) !void {
                 \\extern "c" fn write(usize, usize, usize) usize;
                 \\extern "c" fn exit(usize) noreturn;
                 \\
-                \\export fn _start() noreturn {
+                \\export fn _main() noreturn {
                 \\    print();
                 \\    print();
                 \\    print();
@@ -73,7 +73,7 @@ pub fn addCases(ctx: *TestContext) !void {
                 \\extern "c" fn write(usize, usize, usize) usize;
                 \\extern "c" fn exit(usize) noreturn;
                 \\
-                \\export fn _start() noreturn {
+                \\export fn _main() noreturn {
                 \\    print();
                 \\
                 \\    exit(0);
@@ -93,7 +93,7 @@ pub fn addCases(ctx: *TestContext) !void {
                 \\extern "c" fn write(usize, usize, usize) usize;
                 \\extern "c" fn exit(usize) noreturn;
                 \\
-                \\export fn _start() noreturn {
+                \\export fn _main() noreturn {
                 \\    print();
                 \\    print();
                 \\
@@ -119,7 +119,7 @@ pub fn addCases(ctx: *TestContext) !void {
             case.addCompareOutput(
                 \\extern "c" fn exit(usize) noreturn;
                 \\
-                \\export fn _start() noreturn {
+                \\export fn _main() noreturn {
                 \\    exit(0);
                 \\}
             ,
@@ -130,7 +130,7 @@ pub fn addCases(ctx: *TestContext) !void {
                 \\extern "c" fn exit(usize) noreturn;
                 \\extern "c" fn write(usize, usize, usize) usize;
                 \\
-                \\export fn _start() noreturn {
+                \\export fn _main() noreturn {
                 \\    _ = write(1, @ptrToInt("Hey!\n"), 5);
                 \\    exit(0);
                 \\}


### PR DESCRIPTION
Clean up type and description flags generation for exports
in self-hosted MachO backend.