### PR TITLE
macho: put dSYM bundle in zig-cache

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -363,8 +363,8 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
     self.base.file = file;
 
     // Create dSYM bundle.
-    if (options.module) |mod| {
-        const dir = mod.zig_cache_artifact_directory;
+    if (!options.strip and options.module != null) {
+        const dir = options.module.?.zig_cache_artifact_directory;
         log.debug("creating {s}.dSYM bundle in {s}", .{ sub_path, dir.path });
 
         const d_sym_path = try fmt.allocPrint(
@@ -399,7 +399,7 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
 
     switch (options.output_mode) {
         .Exe => {},
-        .Obj => return error.TODOImplementWritingObjFiles,
+        .Obj => {},
         .Lib => return error.TODOImplementWritingLibFiles,
     }
 


### PR DESCRIPTION
Originally, I thought that the dSYM bundle has to reside side-by-side
with the binary it carries the debugging information for. However, it
turns out macOS is clever enough that it auto-searches for matching
dSYM bundle based on the embedded UUID of the binary.

To verify this, run this on your macOS:

```
mdfind "com_apple_xcode_dsym_uuids == <UUID from LC_UUID>"
```

See [here] for more info.

[here]: https://developer.apple.com/documentation/xcode/adding-identifiable-symbol-names-to-a-crash-report