### PR TITLE
stage2: Force Clang to use LLVM's assembler for SPARC targets

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2695,6 +2695,12 @@ pub fn addCCArgs(
         try argv.appendSlice(&[_][]const u8{ "-MD", "-MV", "-MF", p });
     }
 
+    if (target.cpu.arch.isSPARC()) {
+        // Clang defaults to using the system assembler over the internal one
+        // when targeting a non-BSD OS.
+        try argv.append("-integrated-as");
+    }
+
     if (target.os.tag == .freestanding) {
         try argv.append("-ffreestanding");
     }


### PR DESCRIPTION
This change allows cross-compiling C code for SPARC, if you hit any
error with the internal assembler please open a ticket.

cc @koachan 