### PR TITLE
Fix calculation of max_io_bits in PackedIntIo

### DIFF
--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -28,13 +28,13 @@ pub fn PackedIntIo(comptime Int: type, comptime endian: builtin.Endian) type {
     const min_io_bits = ((int_bits + 7) / 8) * 8;
 
     //in the worst case, this is the number of bytes we need to touch
-    // to read or write a value, as bits
+    // to read or write a value, as bits. To calculate for int_bits > 1,
+    // set aside 2 bits to touch the first and last bytes, then divide
+    // by 8 to see how many bytes can be filled up inbetween.
     const max_io_bits = switch (int_bits) {
         0 => 0,
         1 => 8,
-        2...9 => 16,
-        10...65535 => ((int_bits / 8) + 2) * 8,
-        else => unreachable,
+        else => ((int_bits - 2) / 8 + 2) * 8,
     };
 
     //we bitcast the desired Int type to an unsigned version of itself
@@ -376,12 +376,20 @@ test "PackedIntArray" {
     }
 }
 
+test "PackedIntIo" {
+    const bytes = [_]u8 { 0b01101_000, 0b01011_110, 0b00011_101 };
+    try testing.expectEqual(@as(u15,  0x2bcd), PackedIntIo(u15, .Little).get(&bytes, 0, 3));
+    try testing.expectEqual(@as(u16,  0xabcd), PackedIntIo(u16, .Little).get(&bytes, 0, 3));
+    try testing.expectEqual(@as(u17, 0x1abcd), PackedIntIo(u17, .Little).get(&bytes, 0, 3));
+    try testing.expectEqual(@as(u18, 0x3abcd), PackedIntIo(u18, .Little).get(&bytes, 0, 3));
+}
+
 test "PackedIntArray init" {
     if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
     const PackedArray = PackedIntArray(u3, 8);
     var packed_array = PackedArray.init([_]u3{ 0, 1, 2, 3, 4, 5, 6, 7 });
     var i = @as(usize, 0);
-    while (i < packed_array.len()) : (i += 1) testing.expectEqual(@intCast(u3, i), packed_array.get(i));
+    while (i < packed_array.len()) : (i += 1) try testing.expectEqual(@intCast(u3, i), packed_array.get(i));
 }
 
 test "PackedIntArray initAllTo" {
@@ -389,7 +397,7 @@ test "PackedIntArray initAllTo" {
     const PackedArray = PackedIntArray(u3, 8);
     var packed_array = PackedArray.initAllTo(5);
     var i = @as(usize, 0);
-    while (i < packed_array.len()) : (i += 1) testing.expectEqual(@as(u3, 5), packed_array.get(i));
+    while (i < packed_array.len()) : (i += 1) try testing.expectEqual(@as(u3, 5), packed_array.get(i));
 }
 
 test "PackedIntSlice" {


### PR DESCRIPTION
The way `max_io_bits` is calculated in `PackedIntIo` is slightly off. `PackedIntIo` uses `max_io_bits` to determine the largest number of bytes that can be touched by `int_bits` many contiguous, unaligned bits. However, when `int_bits` is a multiple of 8 or one more than a multiple of 8, `max_io_bits` is one byte too large. For example, a u16 can touch at worst 3 bytes and thus 24 bits and the same is true for a u17, but the current formula `((int_bits / 8) + 2) * 8` yields 32 bits for both. 

As an example, if `PackedIntIo` is used with u16 and a non-zero `bit_offset`, then a call to `get` or `set` that needs to read or write to the last 3 bytes of an array will think a `MaxIo` integer is too large and fall back to a `MinIo` integer. But a `MinIo` is only 2 bytes and too small in this case, and the calculation of `tail_keep_bits` will overflow. So while the following code should set `x` to 0xABCD, it will panic because of integer overflow:

```
const bytes = [_]u8 { 0b01101_000, 0b01011_110, 0b00000_101 };
const x = std.packed_int_array.PackedIntIo(u16, .Little).get(&bytes, 0, 3); // panic
```

Reading a u17 here will work because, while `max_io_bits` is still too large, its proper value is the same as `min_io_bits`, so falling back to `MinIo` doesn't cause problems. Further, while `PackedIntArray` and `PackIntSlice` are built on `PackedIntIo`, neither hit this problem because when they are reading integers like u16 that have a multiple of 8 bits, the `bit_offset` they pass in will always be 0. But since `PackedIntIo` is a public function and nothing in the comments says it can't be used generally, with any `bit_offset`, I think it is worth fixing.

For an integer to cover k bytes, for k > 1, it needs at least 1 bit each for the first and last bytes and then (k - 2) * 8 bits for all the inbetween bytes. Thus at least (k - 2) * 8 + 2 bits are needed. The number of bytes covered then doesn't increase until there are enough bits to cover k + 1 bytes, that is, ((k + 1) - 2) * 8 + 2 = (k - 2) * 8 + 10 bits. So `max_io_bits` should map the closed interval [(k - 2) * 8 + 2, (k - 2) * 8 + 9] to k * 8 bits. For x in this interval, (x - 2) is then in [(k - 2) * 8, (k - 2) * 8 + 7], and so k = floor((x - 2) / 8) + 2. Thus `max_io_bits` can be expressed as

```
const max_io_bits = switch (int_bits) {
    0 => 0,
    1 => 8,
    else => ((int_bits - 2) / 8 + 2) * 8,
};
```

I've made this change, added a test, and fixed two other tests that were missing a `try` before `testing.expect` for the new testing change.