### PR TITLE
std.meta.trait: Remove `isIntegerNumber` and `isFloatingNumber`

### DIFF
--- a/lib/std/meta/trait.zig
+++ b/lib/std/meta/trait.zig
@@ -298,20 +298,6 @@ pub fn isNumber(comptime T: type) bool {
     };
 }
 
-pub fn isIntegerNumber(comptime T: type) bool {
-    return switch (@typeInfo(T)) {
-        .Int, .ComptimeInt => true,
-        else => false,
-    };
-}
-
-pub fn isFloatingNumber(comptime T: type) bool {
-    return switch (@typeInfo(T)) {
-        .Float, .ComptimeFloat => true,
-        else => false,
-    };
-}
-
 test "std.meta.trait.isNumber" {
     const NotANumber = struct {
         number: u8,


### PR DESCRIPTION
Seem like in `std.meta.trait`, `isIntegerNumber` and `isFloatingNumber` are duplicate of `isIntegral` and `isFloat`.
Also, i don't see any use case outside of trait.zig.