### PR TITLE
stage2: wasm backend - Enums

### DIFF
--- a/src/codegen/wasm.zig
+++ b/src/codegen/wasm.zig
@@ -758,6 +758,7 @@ pub const Context = struct {
         // TODO: Implement tail calls
         const operand = self.resolveInst(inst.operand);
         try self.emitWValue(operand);
+        try self.code.append(wasm.opcode(.@"return"));
         return .none;
     }
 
@@ -903,6 +904,9 @@ pub const Context = struct {
                             if (enum_full.values.count() != 0) {
                                 const tag_val = enum_full.values.entries.items[field_index.data].key;
                                 try self.emitConstant(src, tag_val, enum_full.tag_ty);
+                            } else {
+                                try writer.writeByte(wasm.opcode(.i32_const));
+                                try leb.writeULEB128(writer, field_index.data);
                             }
                         },
                         else => unreachable,

--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -391,10 +391,29 @@ pub fn addCases(ctx: *TestContext) !void {
         case.addCompareOutput(
             \\const Number = enum { One, Two, Three };
             \\
-            \\export fn _start() i32 {
+            \\pub export fn _start() i32 {
             \\    var number1 = Number.One;
             \\    var number2: Number = .Two;
             \\    const number3 = @intToEnum(Number, 2);
+            \\
+            \\    return @enumToInt(number3);
+            \\}
+        , "2\n");
+
+        case.addCompareOutput(
+            \\const Number = enum { One, Two, Three };
+            \\
+            \\pub export fn _start() i32 {
+            \\    var number1 = Number.One;
+            \\    var number2: Number = .Two;
+            \\    const number3 = @intToEnum(Number, 2);
+            \\    if (number1 == number2) return 1;
+            \\    if (number2 == number3) return 1;
+            \\    if (@enumToInt(number1) != 0) return 1;
+            \\    if (@enumToInt(number2) != 1) return 1;
+            \\    if (@enumToInt(number3) != 2) return 1;
+            \\    var x: Number = .Two;
+            \\    if (number2 != x) return 1;
             \\
             \\    return @enumToInt(number3);
             \\}

--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -384,4 +384,20 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , "5\n");
     }
+
+    {
+        var case = ctx.exe("wasm enum values", wasi);
+
+        case.addCompareOutput(
+            \\const Number = enum { One, Two, Three };
+            \\
+            \\export fn _start() i32 {
+            \\    var number1 = Number.One;
+            \\    var number2: Number = .Two;
+            \\    const number3 = @intToEnum(Number, 2);
+            \\
+            \\    return @enumToInt(number3);
+            \\}
+        , "2\n");
+    }
 }


### PR DESCRIPTION
This PR adds initial enum support for the wasm backend.

- Only enums based on tag indexes are currently tested as astgen doesn't allow for enums with explicit values yet. (tho, wasm codegen does implement it).
- Return statements now also add an explicit `return` opcode as those are required within blocks. Having them always be emitted
rather than relying on implicit returns makes the logic a lot easier for now.
- A basic form of bitcast was also implemented (it returns the `WValue` for its operand)
- `emitConstant()` signature was updated to allow for emitting constants by generating a type (i.e. using an enum's integer type rather than enum type).
