### PR TITLE
SPIR-V: Codegen basis

### DIFF
--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -57,6 +57,7 @@ pub const DeclGen = struct {
     module: *Module,
     spv: *SPIRVModule,
 
+    args: std.ArrayList(u32),
     types: TypeMap,
 
     decl: *Decl,
@@ -213,7 +214,17 @@ pub const DeclGen = struct {
                 prototype_id,
             });
 
-            // TODO: Parameters
+            const params = tv.ty.fnParamLen();
+            var i: usize = 0;
+
+            try self.args.ensureCapacity(params);
+            while (i < params) : (i += 1) {
+                const param_type_id = self.types.get(tv.ty.fnParamType(i)).?;
+                const arg_result_id = self.spv.allocResultId();
+                try writeInstruction(&self.spv.fn_decls, .OpFunctionParameter, &[_]u32{ param_type_id, arg_result_id });
+                self.args.appendAssumeCapacity(arg_result_id);
+            }
+
             // TODO: Body
 
             try writeInstruction(&self.spv.fn_decls, .OpFunctionEnd, &[_]u32{});

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -6,6 +6,7 @@ const spec = @import("spirv/spec.zig");
 const Module = @import("../Module.zig");
 const Decl = Module.Decl;
 const Type = @import("../type.zig").Type;
+const LazySrcLoc = Module.LazySrcLoc;
 
 pub const TypeMap = std.HashMap(Type, u32, Type.hash, Type.eql, std.hash_map.default_max_load_percentage);
 
@@ -15,30 +16,24 @@ pub fn writeInstruction(code: *std.ArrayList(u32), instr: spec.Opcode, args: []c
     try code.appendSlice(args);
 }
 
+/// This structure represents a SPIR-V binary module being compiled, and keeps track of relevant information
+/// such as code for the different logical sections, and the next result-id.
 pub const SPIRVModule = struct {
-    next_result_id: u32 = 0,
-
-    target: std.Target,
-
-    types: TypeMap,
-
+    next_result_id: u32,
     types_and_globals: std.ArrayList(u32),
     fn_decls: std.ArrayList(u32),
 
-    pub fn init(target: std.Target, allocator: *Allocator) SPIRVModule {
+    pub fn init(allocator: *Allocator) SPIRVModule {
         return .{
-            .target = target,
-            .types = TypeMap.init(allocator),
+            .next_result_id = 0,
             .types_and_globals = std.ArrayList(u32).init(allocator),
             .fn_decls = std.ArrayList(u32).init(allocator),
         };
     }
 
     pub fn deinit(self: *SPIRVModule) void {
-        self.fn_decls.deinit();
         self.types_and_globals.deinit();
-        self.types.deinit();
-        self.* = undefined;
+        self.fn_decls.deinit();
     }
 
     pub fn allocResultId(self: *SPIRVModule) u32 {
@@ -49,21 +44,40 @@ pub const SPIRVModule = struct {
     pub fn resultIdBound(self: *SPIRVModule) u32 {
         return self.next_result_id;
     }
+};
 
-    pub fn getOrGenType(self: *SPIRVModule, t: Type) !u32 {
+/// This structure is used to compile a declaration, and contains all relevant meta-information to deal with that.
+pub const DeclGen = struct {
+    module: *Module,
+    spv: *SPIRVModule,
+
+    types: TypeMap,
+
+    decl: *Decl,
+    error_msg: ?*Module.ErrorMsg,
+
+    fn fail(self: *DeclGen, src: LazySrcLoc, comptime format: []const u8, args: anytype) error{ AnalysisFail, OutOfMemory } {
+        @setCold(true);
+        const src_loc = src.toSrcLocWithDecl(self.decl);
+        self.error_msg = try Module.ErrorMsg.create(self.module.gpa, src_loc, format, args);
+        return error.AnalysisFail;
+    }
+
+    pub fn getOrGenType(self: *DeclGen, t: Type) !u32 {
         // We can't use getOrPut here so we can recursively generate types.
         if (self.types.get(t)) |already_generated| {
             return already_generated;
         }
 
-        const result = self.allocResultId();
+        const result = self.spv.allocResultId();
 
         switch (t.zigTypeTag()) {
-            .Void => try writeInstruction(&self.types_and_globals, .OpTypeVoid, &[_]u32{ result }),
-            .Bool => try writeInstruction(&self.types_and_globals, .OpTypeBool, &[_]u32{ result }),
+            .Void => try writeInstruction(&self.spv.types_and_globals, .OpTypeVoid, &[_]u32{ result }),
+            .Bool => try writeInstruction(&self.spv.types_and_globals, .OpTypeBool, &[_]u32{ result }),
             .Int => {
-                const int_info = t.intInfo(self.target);
-                try writeInstruction(&self.types_and_globals, .OpTypeInt, &[_]u32{
+                const int_info = t.intInfo(self.module.getTarget());
+                // TODO: Capabilities.
+                try writeInstruction(&self.spv.types_and_globals, .OpTypeInt, &[_]u32{
                     result,
                     int_info.bits,
                     switch (int_info.signedness) {
@@ -72,8 +86,8 @@ pub const SPIRVModule = struct {
                     },
                 });
             },
-            // TODO: Verify that floatBits() will be correct.
-            .Float => try writeInstruction(&self.types_and_globals, .OpTypeFloat, &[_]u32{ result, t.floatBits(self.target) }),
+            // TODO: Capabilities.
+            .Float => try writeInstruction(&self.spv.types_and_globals, .OpTypeFloat, &[_]u32{ result, t.floatBits(self.module.getTarget()) }),
             .Null,
             .Undefined,
             .EnumLiteral,
@@ -84,23 +98,23 @@ pub const SPIRVModule = struct {
 
             .BoundFn => unreachable, // this type will be deleted from the language.
 
-            else => return error.TODO,
+            else => |tag| return self.fail(.{ .node_offset = 0 }, "TODO: SPIR-V backend: implement type with tag {}", .{ tag }),
         }
 
         try self.types.put(t, result);
         return result;
     }
 
-    pub fn gen(self: *SPIRVModule, decl: *Decl) !void {
-        const typed_value = decl.typed_value.most_recent.typed_value;
+    pub fn gen(self: *DeclGen) !void {
+        const typed_value = self.decl.typed_value.most_recent.typed_value;
 
         switch (typed_value.ty.zigTypeTag()) {
             .Fn => {
-                log.debug("Generating code for function '{s}'", .{ std.mem.spanZ(decl.name) });
+                log.debug("Generating code for function '{s}'", .{ std.mem.spanZ(self.decl.name) });
 
                 _ = try self.getOrGenType(typed_value.ty.fnReturnType());
             },
-            else => return error.TODO,
+            else => |tag| return self.fail(.{ .node_offset = 0 }, "TODO: SPIR-V backend: generate decl with tag {}", .{ tag }),
         }
     }
 };

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const log = std.log.scoped(.codegen);
 
+const Target = std.Target;
+
 const spec = @import("spirv/spec.zig");
 const Module = @import("../Module.zig");
 const Decl = Module.Decl;
@@ -63,6 +65,43 @@ pub const DeclGen = struct {
         return error.AnalysisFail;
     }
 
+    /// SPIR-V requires enabling specific integer sizes through capabilities, and so if they are not enabled, we need
+    /// to emulate them in other instructions/types. This function returns, given an integer bit width (signed or unsigned, sign
+    /// included), the width of the underlying type which represents it, given the enabled features for the current target.
+    /// If the result is `null`, the largest type the target platform supports natively is not able to perform computations using
+    /// that size. In this case, multiple elements of the largest type should be used.
+    /// The backing type will be chosen as the smallest supported integer larger or equal to it in number of bits.
+    /// The result is valid to be used with OpTypeInt.
+    /// TODO: The extension SPV_INTEL_arbitrary_precision_integers allows any integer size (at least up to 32 bits).
+    /// TODO: This probably needs an ABI-version as well (especially in combination with SPV_INTEL_arbitrary_precision_integers).
+    fn backingIntBits(self: *DeclGen, bits: u32) ?u32 {
+        // TODO: Figure out what to do with u0/i0.
+        std.debug.assert(bits != 0);
+
+        const target = self.module.getTarget();
+
+        // 8, 16 and 64-bit integers require the Int8, Int16 and Inr64 capabilities respectively.
+        const ints = [_]struct{ bits: u32, feature: ?Target.spirv.Feature } {
+            .{ .bits = 8, .feature = .Int8 },
+            .{ .bits = 16, .feature = .Int16 },
+            .{ .bits = 32, .feature = null },
+            .{ .bits = 64, .feature = .Int64 },
+        };
+
+        for (ints) |int| {
+            const has_feature = if (int.feature) |feature|
+                Target.spirv.featureSetHas(target.cpu.features, feature)
+            else
+                true;
+
+            if (bits <= int.bits and has_feature) {
+                return int.bits;
+            }
+        }
+
+        return null;
+    }
+
     pub fn getOrGenType(self: *DeclGen, t: Type) !u32 {
         // We can't use getOrPut here so we can recursively generate types.
         if (self.types.get(t)) |already_generated| {
@@ -76,10 +115,12 @@ pub const DeclGen = struct {
             .Bool => try writeInstruction(&self.spv.types_and_globals, .OpTypeBool, &[_]u32{ result }),
             .Int => {
                 const int_info = t.intInfo(self.module.getTarget());
-                // TODO: Capabilities.
+                const backing_bits = self.backingIntBits(int_info.bits) orelse
+                    return self.fail(.{.node_offset = 0}, "TODO: SPIR-V backend: implement fallback for integer of {} bits", .{ int_info.bits });
+
                 try writeInstruction(&self.spv.types_and_globals, .OpTypeInt, &[_]u32{
                     result,
-                    int_info.bits,
+                    backing_bits,
                     switch (int_info.signedness) {
                         .unsigned => 0,
                         .signed => 1,

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -140,23 +140,26 @@ pub fn flushModule(self: *SpirV, comp: *Compilation) !void {
     // Now, actually generate the code for all declarations.
     {
         // We are just going to re-use this same DeclGen for every Decl, and we are just going to
-        // change the decl. Otherwise, we would have to keep a separate `types`, and re-construct this
+        // change the decl. Otherwise, we would have to keep a separate `args` and `types`, and re-construct this
         // structure every time.
         var decl_gen = codegen.DeclGen{
             .module = module,
             .spv = &spv,
+            .args = std.ArrayList(u32).init(self.base.allocator),
             .types = codegen.TypeMap.init(self.base.allocator),
             .decl = undefined,
             .error_msg = undefined,
         };
 
         defer decl_gen.types.deinit();
+        defer decl_gen.args.deinit();
 
         for (module.decl_table.items()) |entry| {
             const decl = entry.value;
             if (decl.typed_value != .most_recent)
                 continue;
 
+            decl_gen.args.items.len = 0;
             decl_gen.decl = decl;
             decl_gen.error_msg = null;
 

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -146,11 +146,14 @@ pub fn flushModule(self: *SpirV, comp: *Compilation) !void {
             .module = module,
             .spv = &spv,
             .args = std.ArrayList(u32).init(self.base.allocator),
+            .next_arg_index = undefined,
             .types = codegen.TypeMap.init(self.base.allocator),
+            .values = codegen.ValueMap.init(self.base.allocator),
             .decl = undefined,
             .error_msg = undefined,
         };
 
+        defer decl_gen.values.deinit();
         defer decl_gen.types.deinit();
         defer decl_gen.args.deinit();
 
@@ -160,6 +163,7 @@ pub fn flushModule(self: *SpirV, comp: *Compilation) !void {
                 continue;
 
             decl_gen.args.items.len = 0;
+            decl_gen.next_arg_index = 0;
             decl_gen.decl = decl;
             decl_gen.error_msg = null;
 
@@ -191,7 +195,7 @@ pub fn flushModule(self: *SpirV, comp: *Compilation) !void {
     // follows the SPIR-V logical module format!
     var all_buffers = [_]std.os.iovec_const{
         wordsToIovConst(binary.items),
-        wordsToIovConst(spv.types_and_globals.items),
+        wordsToIovConst(spv.types_globals_constants.items),
         wordsToIovConst(spv.fn_decls.items),
     };
 


### PR DESCRIPTION
This PR adds a bunch of basic SPIR-V code- and constant generation. I figured to make this PR before it gets too large, and now seems like a decent size. List of additions:
- Codegen was restructured a bit in general from last time. There is now a DeclGen struct, which (similar to the other backends) is used to generate declarations for a struct. It contains a bunch of types which must be persistent over different decls, and to save some extra constructing of that struct i just reset the appropriate fields every time a new decl must be generated. 
- Basic generation was implemented for:
  * Types: Void, bool, int (only non composite ones), float, and function prototypes.
  * Function setup/teardown.
  * Binary operations
  * Unary operations
  * ret/retvoid
  * Unreachable
  * arg
 
 I left a few comments in the code for guarantees i wasn't sure about, it would be beneficial if someone reviewed those. In particular, what the expected types are for arguments of binary instructions (are they always equal?) and whether unreachable/return instructions always terminate a block.