### PR TITLE
zig ld: add preliminary mechanism for linking dylibs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,6 +568,7 @@ set(ZIG_STAGE2_SOURCES
     "${CMAKE_SOURCE_DIR}/src/link/MachO/Archive.zig"
     "${CMAKE_SOURCE_DIR}/src/link/MachO/CodeSignature.zig"
     "${CMAKE_SOURCE_DIR}/src/link/MachO/DebugSymbols.zig"
+    "${CMAKE_SOURCE_DIR}/src/link/MachO/Dylib.zig"
     "${CMAKE_SOURCE_DIR}/src/link/MachO/Object.zig"
     "${CMAKE_SOURCE_DIR}/src/link/MachO/Symbol.zig"
     "${CMAKE_SOURCE_DIR}/src/link/MachO/Trie.zig"

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -71,6 +71,38 @@ pub const source_version_command = extern struct {
     version: u64,
 };
 
+/// The build_version_command contains the min OS version on which this
+/// binary was built to run for its platform. The list of known platforms and
+/// tool values following it.
+pub const build_version_command = extern struct {
+    /// LC_BUILD_VERSION
+    cmd: u32,
+
+    /// sizeof(struct build_version_command) plus
+    /// ntools * sizeof(struct build_version_command)
+    cmdsize: u32,
+
+    /// platform
+    platform: u32,
+
+    /// X.Y.Z is encoded in nibbles xxxx.yy.zz
+    minos: u32,
+
+    /// X.Y.Z is encoded in nibbles xxxx.yy.zz
+    sdk: u32,
+
+    /// number of tool entries following this
+    ntools: u32,
+};
+
+pub const build_tool_version = extern struct {
+    /// enum for the tool
+    tool: u32,
+
+    /// version number of the tool
+    version: u32,
+};
+
 /// The entry_point_command is a replacement for thread_command.
 /// It is used for main executables to specify the location (file offset)
 /// of main(). If -stack_size was used at link time, the stacksize

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -516,6 +516,19 @@ pub const dylib = extern struct {
     compatibility_version: u32,
 };
 
+/// The rpath_command contains a path which at runtime should be added to the current
+/// run path used to find @rpath prefixed dylibs.
+pub const rpath_command = extern struct {
+    /// LC_RPATH
+    cmd: u32,
+
+    /// includes string
+    cmdsize: u32,
+
+    /// path to add to run path
+    path: u32,
+};
+
 /// The segment load command indicates that a part of this file is to be
 /// mapped into the task's address space.  The size of this segment in memory,
 /// vmsize, maybe equal to or larger than the amount to map from this file,

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -1,0 +1,137 @@
+const Dylib = @This();
+
+const std = @import("std");
+const fs = std.fs;
+const log = std.log.scoped(.dylib);
+const macho = std.macho;
+const mem = std.mem;
+
+const Allocator = mem.Allocator;
+const Symbol = @import("Symbol.zig");
+
+usingnamespace @import("commands.zig");
+
+allocator: *Allocator,
+arch: ?std.Target.Cpu.Arch = null,
+header: ?macho.mach_header_64 = null,
+file: ?fs.File = null,
+name: ?[]const u8 = null,
+
+ordinal: ?u16 = null,
+
+load_commands: std.ArrayListUnmanaged(LoadCommand) = .{},
+
+symtab_cmd_index: ?u16 = null,
+dysymtab_cmd_index: ?u16 = null,
+
+symbols: std.StringArrayHashMapUnmanaged(*Symbol) = .{},
+
+pub fn init(allocator: *Allocator) Dylib {
+    return .{ .allocator = allocator };
+}
+
+pub fn deinit(self: *Dylib) void {
+    for (self.load_commands.items) |*lc| {
+        lc.deinit(self.allocator);
+    }
+    self.load_commands.deinit(self.allocator);
+
+    for (self.symbols.items()) |entry| {
+        entry.value.deinit(self.allocator);
+        self.allocator.destroy(entry.value);
+    }
+    self.symbols.deinit(self.allocator);
+
+    if (self.name) |name| {
+        self.allocator.free(name);
+    }
+}
+
+pub fn closeFile(self: Dylib) void {
+    if (self.file) |file| {
+        file.close();
+    }
+}
+
+pub fn parse(self: *Dylib) !void {
+    log.warn("parsing shared library '{s}'", .{self.name.?});
+
+    var reader = self.file.?.reader();
+    self.header = try reader.readStruct(macho.mach_header_64);
+
+    if (self.header.?.filetype != macho.MH_DYLIB) {
+        log.err("invalid filetype: expected 0x{x}, found 0x{x}", .{ macho.MH_DYLIB, self.header.?.filetype });
+        return error.MalformedDylib;
+    }
+
+    const this_arch: std.Target.Cpu.Arch = switch (self.header.?.cputype) {
+        macho.CPU_TYPE_ARM64 => .aarch64,
+        macho.CPU_TYPE_X86_64 => .x86_64,
+        else => |value| {
+            log.err("unsupported cpu architecture 0x{x}", .{value});
+            return error.UnsupportedCpuArchitecture;
+        },
+    };
+    if (this_arch != self.arch.?) {
+        log.err("mismatched cpu architecture: expected {s}, found {s}", .{ self.arch.?, this_arch });
+        return error.MismatchedCpuArchitecture;
+    }
+
+    try self.readLoadCommands(reader);
+    try self.parseSymbols();
+}
+
+pub fn readLoadCommands(self: *Dylib, reader: anytype) !void {
+    try self.load_commands.ensureCapacity(self.allocator, self.header.?.ncmds);
+
+    var i: u16 = 0;
+    while (i < self.header.?.ncmds) : (i += 1) {
+        var cmd = try LoadCommand.read(self.allocator, reader);
+        switch (cmd.cmd()) {
+            macho.LC_SYMTAB => {
+                self.symtab_cmd_index = i;
+            },
+            macho.LC_DYSYMTAB => {
+                self.dysymtab_cmd_index = i;
+            },
+            else => {
+                log.debug("Unknown load command detected: 0x{x}.", .{cmd.cmd()});
+            },
+        }
+        self.load_commands.appendAssumeCapacity(cmd);
+    }
+}
+
+pub fn parseSymbols(self: *Dylib) !void {
+    const index = self.symtab_cmd_index orelse return;
+    const symtab_cmd = self.load_commands.items[index].Symtab;
+
+    var symtab = try self.allocator.alloc(u8, @sizeOf(macho.nlist_64) * symtab_cmd.nsyms);
+    defer self.allocator.free(symtab);
+    _ = try self.file.?.preadAll(symtab, symtab_cmd.symoff);
+    const slice = @alignCast(@alignOf(macho.nlist_64), mem.bytesAsSlice(macho.nlist_64, symtab));
+
+    var strtab = try self.allocator.alloc(u8, symtab_cmd.strsize);
+    defer self.allocator.free(strtab);
+    _ = try self.file.?.preadAll(strtab, symtab_cmd.stroff);
+
+    for (slice) |sym| {
+        const sym_name = mem.spanZ(@ptrCast([*:0]const u8, strtab.ptr + sym.n_strx));
+
+        if (!(Symbol.isSect(sym) and Symbol.isExt(sym))) continue;
+
+        const name = try self.allocator.dupe(u8, sym_name);
+        const proxy = try self.allocator.create(Symbol.Proxy);
+        errdefer self.allocator.destroy(proxy);
+
+        proxy.* = .{
+            .base = .{
+                .@"type" = .proxy,
+                .name = name,
+            },
+            .dylib = self,
+        };
+
+        try self.symbols.putNoClobber(self.allocator, name, &proxy.base);
+    }
+}

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -72,7 +72,7 @@ pub fn closeFile(self: Dylib) void {
 }
 
 pub fn parse(self: *Dylib) !void {
-    log.warn("parsing shared library '{s}'", .{self.name.?});
+    log.debug("parsing shared library '{s}'", .{self.name.?});
 
     var reader = self.file.?.reader();
     self.header = try reader.readStruct(macho.mach_header_64);

--- a/src/link/MachO/Symbol.zig
+++ b/src/link/MachO/Symbol.zig
@@ -5,6 +5,7 @@ const macho = std.macho;
 const mem = std.mem;
 
 const Allocator = mem.Allocator;
+const Dylib = @import("Dylib.zig");
 const Object = @import("Object.zig");
 
 pub const Type = enum {
@@ -43,7 +44,7 @@ pub const Regular = struct {
     /// Whether the symbol is a weak ref.
     weak_ref: bool,
 
-    /// File where to locate this symbol.
+    /// Object file where to locate this symbol.
     file: *Object,
 
     /// Debug stab if defined.
@@ -78,8 +79,8 @@ pub const Regular = struct {
 pub const Proxy = struct {
     base: Symbol,
 
-    /// Dylib ordinal.
-    dylib: u16,
+    /// Dylib where to locate this symbol.
+    dylib: ?*Dylib = null,
 
     pub const base_type: Symbol.Type = .proxy;
 };

--- a/src/link/MachO/Zld.zig
+++ b/src/link/MachO/Zld.zig
@@ -339,8 +339,14 @@ fn parseDylibs(self: *Zld, shared_libs: []const []const u8) !void {
         try self.dylibs.append(self.allocator, dylib);
 
         // Add LC_LOAD_DYLIB command
-        // TODO Read the timestamp and versions from the dylib itself.
-        var dylib_cmd = try createLoadDylibCommand(self.allocator, dylib.name.?, 2, 0, 0);
+        const dylib_id = dylib.id orelse unreachable;
+        var dylib_cmd = try createLoadDylibCommand(
+            self.allocator,
+            dylib_id.name,
+            dylib_id.timestamp,
+            dylib_id.current_version,
+            dylib_id.compatibility_version,
+        );
         errdefer dylib_cmd.deinit(self.allocator);
 
         try self.load_commands.append(self.allocator, .{ .Dylib = dylib_cmd });

--- a/src/link/MachO/commands.zig
+++ b/src/link/MachO/commands.zig
@@ -38,7 +38,9 @@ pub const LoadCommand = union(enum) {
             macho.LC_SEGMENT_64 => LoadCommand{
                 .Segment = try SegmentCommand.read(allocator, stream.reader()),
             },
-            macho.LC_DYLD_INFO, macho.LC_DYLD_INFO_ONLY => LoadCommand{
+            macho.LC_DYLD_INFO,
+            macho.LC_DYLD_INFO_ONLY,
+            => LoadCommand{
                 .DyldInfoOnly = try stream.reader().readStruct(macho.dyld_info_command),
             },
             macho.LC_SYMTAB => LoadCommand{
@@ -47,16 +49,27 @@ pub const LoadCommand = union(enum) {
             macho.LC_DYSYMTAB => LoadCommand{
                 .Dysymtab = try stream.reader().readStruct(macho.dysymtab_command),
             },
-            macho.LC_ID_DYLINKER, macho.LC_LOAD_DYLINKER, macho.LC_DYLD_ENVIRONMENT => LoadCommand{
+            macho.LC_ID_DYLINKER,
+            macho.LC_LOAD_DYLINKER,
+            macho.LC_DYLD_ENVIRONMENT,
+            => LoadCommand{
                 .Dylinker = try GenericCommandWithData(macho.dylinker_command).read(allocator, stream.reader()),
             },
-            macho.LC_ID_DYLIB, macho.LC_LOAD_WEAK_DYLIB, macho.LC_LOAD_DYLIB, macho.LC_REEXPORT_DYLIB => LoadCommand{
+            macho.LC_ID_DYLIB,
+            macho.LC_LOAD_WEAK_DYLIB,
+            macho.LC_LOAD_DYLIB,
+            macho.LC_REEXPORT_DYLIB,
+            => LoadCommand{
                 .Dylib = try GenericCommandWithData(macho.dylib_command).read(allocator, stream.reader()),
             },
             macho.LC_MAIN => LoadCommand{
                 .Main = try stream.reader().readStruct(macho.entry_point_command),
             },
-            macho.LC_VERSION_MIN_MACOSX, macho.LC_VERSION_MIN_IPHONEOS, macho.LC_VERSION_MIN_WATCHOS, macho.LC_VERSION_MIN_TVOS => LoadCommand{
+            macho.LC_VERSION_MIN_MACOSX,
+            macho.LC_VERSION_MIN_IPHONEOS,
+            macho.LC_VERSION_MIN_WATCHOS,
+            macho.LC_VERSION_MIN_TVOS,
+            => LoadCommand{
                 .VersionMin = try stream.reader().readStruct(macho.version_min_command),
             },
             macho.LC_SOURCE_VERSION => LoadCommand{
@@ -65,7 +78,10 @@ pub const LoadCommand = union(enum) {
             macho.LC_UUID => LoadCommand{
                 .Uuid = try stream.reader().readStruct(macho.uuid_command),
             },
-            macho.LC_FUNCTION_STARTS, macho.LC_DATA_IN_CODE, macho.LC_CODE_SIGNATURE => LoadCommand{
+            macho.LC_FUNCTION_STARTS,
+            macho.LC_DATA_IN_CODE,
+            macho.LC_CODE_SIGNATURE,
+            => LoadCommand{
                 .LinkeditData = try stream.reader().readStruct(macho.linkedit_data_command),
             },
             else => LoadCommand{

--- a/src/link/MachO/commands.zig
+++ b/src/link/MachO/commands.zig
@@ -24,6 +24,7 @@ pub const LoadCommand = union(enum) {
     SourceVersion: macho.source_version_command,
     Uuid: macho.uuid_command,
     LinkeditData: macho.linkedit_data_command,
+    Rpath: GenericCommandWithData(macho.rpath_command),
     Unknown: GenericCommandWithData(macho.load_command),
 
     pub fn read(allocator: *Allocator, reader: anytype) !LoadCommand {
@@ -84,6 +85,9 @@ pub const LoadCommand = union(enum) {
             => LoadCommand{
                 .LinkeditData = try stream.reader().readStruct(macho.linkedit_data_command),
             },
+            macho.LC_RPATH => LoadCommand{
+                .Rpath = try GenericCommandWithData(macho.rpath_command).read(allocator, stream.reader()),
+            },
             else => LoadCommand{
                 .Unknown = try GenericCommandWithData(macho.load_command).read(allocator, stream.reader()),
             },
@@ -103,6 +107,7 @@ pub const LoadCommand = union(enum) {
             .Segment => |x| x.write(writer),
             .Dylinker => |x| x.write(writer),
             .Dylib => |x| x.write(writer),
+            .Rpath => |x| x.write(writer),
             .Unknown => |x| x.write(writer),
         };
     }
@@ -120,6 +125,7 @@ pub const LoadCommand = union(enum) {
             .Segment => |x| x.inner.cmd,
             .Dylinker => |x| x.inner.cmd,
             .Dylib => |x| x.inner.cmd,
+            .Rpath => |x| x.inner.cmd,
             .Unknown => |x| x.inner.cmd,
         };
     }
@@ -137,6 +143,7 @@ pub const LoadCommand = union(enum) {
             .Segment => |x| x.inner.cmdsize,
             .Dylinker => |x| x.inner.cmdsize,
             .Dylib => |x| x.inner.cmdsize,
+            .Rpath => |x| x.inner.cmdsize,
             .Unknown => |x| x.inner.cmdsize,
         };
     }
@@ -146,6 +153,7 @@ pub const LoadCommand = union(enum) {
             .Segment => |*x| x.deinit(allocator),
             .Dylinker => |*x| x.deinit(allocator),
             .Dylib => |*x| x.deinit(allocator),
+            .Rpath => |*x| x.deinit(allocator),
             .Unknown => |*x| x.deinit(allocator),
             else => {},
         };
@@ -169,6 +177,7 @@ pub const LoadCommand = union(enum) {
             .Segment => |x| x.eql(other.Segment),
             .Dylinker => |x| x.eql(other.Dylinker),
             .Dylib => |x| x.eql(other.Dylib),
+            .Rpath => |x| x.eql(other.Rpath),
             .Unknown => |x| x.eql(other.Unknown),
         };
     }

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -9,10 +9,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.add("test/standalone/main_return_error/error_u8.zig");
     cases.add("test/standalone/main_return_error/error_u8_non_zero.zig");
     cases.addBuildFile("test/standalone/main_pkg_path/build.zig");
-    if (std.Target.current.os.tag != .macos) {
-        // TODO zld cannot link shared libraries yet.
-        cases.addBuildFile("test/standalone/shared_library/build.zig");
-    }
+    cases.addBuildFile("test/standalone/shared_library/build.zig");
     cases.addBuildFile("test/standalone/mix_o_files/build.zig");
     cases.addBuildFile("test/standalone/global_linkage/build.zig");
     cases.addBuildFile("test/standalone/static_c_lib/build.zig");


### PR DESCRIPTION
This PR adds preliminary way of linking dylibs with `zig ld`. The support is minimalistic in the sense that we currently only support parsing actual dylib files and not stubs/tbds just yet, and we also don't support re-exports just yet (all to come shortly though!).

An example invocation would look like:

```
> ls
hello.zig libhello.dylib

> cat hello.zig
const std = @import("std");

extern "c" fn say_hello() void;

pub fn main() anyerror!void {
    std.log.info("Initializing...", .{});
    say_hello();
    std.log.info("Terminating...", .{});
}

> zig build-exe hello.zig -lhello -L. --verbose-link
zig ld -syslibroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk zig-cache/o/2d54abe7b83122b488c223a79a925d91/hello.o /Users/me/.cache/zig/o/9544dd0a44b53b5da4521d7b92c2f110/libcompiler_rt.a -o hello -lhello -L. -L/usr/lib -L/usr/local/lib
```

When it comes to searching for the dylibs, the current assumed order is matching that of ld64 (well, mostly; thanks @mikdusan for pointers!):
* if exists `syslibroot/DIR` then use it
* else if exists `/DIR` then use it
* else do not add to path and emit warning

In case a library cannot be found, we flag up a warning immediately like so:

```
> zig build-exe hello.zig -lsomething
warning(link): library '-lsomething' not found
warning(link): Library search paths:
warning(link):   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib
```

Finally, `zig ld` supports `-rpath` flag too, and hence, I've enabled the last missing standalone test on `x86_64` macOS which involves linking dylib via an rpath. Mind though that the same test will fail on `arm64` since we are still missing functionality to actually create a dylib with `zig ld`.