### PR TITLE
translate-c: Add `@truncate` where needed

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 pub const builtin = @import("builtin");
 
 pub const SourceLocation = extern struct {
@@ -115,7 +116,9 @@ pub const APFloatBaseSemantics = extern enum {
 };
 
 pub const APInt = opaque {
-    pub const getLimitedValue = ZigClangAPInt_getLimitedValue;
+    pub fn getLimitedValue(self: *const APInt, comptime T: type) T {
+        return @truncate(T, ZigClangAPInt_getLimitedValue(self, std.math.maxInt(T)));
+    }
     extern fn ZigClangAPInt_getLimitedValue(*const APInt, limit: u64) u64;
 };
 

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -2341,7 +2341,7 @@ fn transInitListExprArray(
     assert(@ptrCast(*const clang.Type, arr_type).isConstantArrayType());
     const const_arr_ty = @ptrCast(*const clang.ConstantArrayType, arr_type);
     const size_ap_int = const_arr_ty.getSize();
-    const all_count = size_ap_int.getLimitedValue(math.maxInt(usize));
+    const all_count = size_ap_int.getLimitedValue(usize);
     const leftover_count = all_count - init_count;
 
     if (all_count == 0) {
@@ -4266,7 +4266,7 @@ fn transType(c: *Context, scope: *Scope, ty: *const clang.Type, source_loc: clan
             const const_arr_ty = @ptrCast(*const clang.ConstantArrayType, ty);
 
             const size_ap_int = const_arr_ty.getSize();
-            const size = size_ap_int.getLimitedValue(math.maxInt(usize));
+            const size = size_ap_int.getLimitedValue(usize);
             const elem_type = try transType(c, scope, const_arr_ty.getElementType().getTypePtr(), source_loc);
 
             return Tag.array_type.create(c.arena, .{ .len = size, .elem_type = elem_type });


### PR DESCRIPTION
Make getLimitedValue API much easier to use with zig.
Fixes the compilation on 32bit hosts.

Fixes part of #8805