### PR TITLE
zig fmt: Break container decls if comment/multiline string is found

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -4,6 +4,22 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 
+test "zig fmt: comment or multiline string in field decl w/ no trailing comma" {
+    try testCanonical(
+        \\const S = struct {
+        \\    a: void, // a
+        \\    b: void
+        \\};
+        \\const S = struct {
+        \\    a: []const u8 =
+        \\        \\ foo
+        \\    ,
+        \\    b: void
+        \\};
+        \\
+    );
+}
+
 test "zig fmt: preserves clobbers in inline asm with stray comma" {
     try testTransform(
         \\fn foo() void {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1850,8 +1850,11 @@ fn renderContainerDecl(
         return renderToken(ais, tree, rbrace, space); // rbrace
     }
 
-    const src_has_trailing_comma = token_tags[rbrace - 1] == .comma;
-    if (!src_has_trailing_comma) one_line: {
+    const trailing_comma = token_tags[rbrace - 1] == .comma;
+    const contains_comment = hasComment(tree, lbrace, rbrace);
+    const contains_multiline_string = hasMultilineString(tree, lbrace, rbrace);
+
+    if (!trailing_comma and !(contains_comment or contains_multiline_string)) one_line: {
         // We can only print all the members in-line if all the members are fields.
         for (container_decl.ast.members) |member| {
             if (!node_tags[member].isContainerField()) break :one_line;


### PR DESCRIPTION
Behave as if a trailing comma is present and put every declaration on
its own line.

Closes #8810