### PR TITLE
idea to solve #7948

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2915,3 +2915,7 @@ pub fn alignInSlice(slice: anytype, comptime new_alignment: usize) ?AlignedSlice
     const aligned_slice = bytesAsSlice(Element, aligned_bytes[0..slice_length_bytes]);
     return @alignCast(new_alignment, aligned_slice);
 }
+
+pub fn sliceToArray(comptime T: type, comptime s: []const T) [s.len]T {
+    return s[0..s.len].*;
+}


### PR DESCRIPTION
NOTE: there is a variation on this idea here https://github.com/ziglang/zig/pull/8846

This addresses the comptime memoization issue #7948 in `std.fmt` by converting the `comptime []const u8` fmt argument into a `[T]u8`.  This addresses the infinite loop of instantiating `formatType` an infinite number of times, and at the same time, also fixes `formatType` to correctly memoize instantiations based on the format string contents, rather than for each instance of a format string.  This means it will work correctly even if it is called directly by the user.

For example,  the following calls will now all forward to the same instantiation of `formatTypeImpl`:

```zig
formatType(0, "x"        , opt, w, 1);
formatType(0, "x" ++ ""  , opt, w, 1);
formatType(0, &[_]{'x'}  , opt, w, 1);
formatType(0, "{x}"[1..2], opt, w, 1);
```

I've submitted this PR as a proof-of-concept.  This pattern might be considered a bit "over the top" to address this issue, in which case we could consider other options or language improvements to make this pattern easier to adhere to.  Note that there are a few dozen other locations in `std` that have the same issue, so whatever solution we go with will establish a pattern for many other locations in `std` and I'm sure user's code also.

> NOTE: you should be able to find the other case with the following grep command:

```sh
$ grep -r "comptime [a-zA-Z_]*: \[\]const u8" lib/std
```