### PR TITLE
translate-c: Add bitfield support

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -148,6 +148,9 @@ pub const APSInt = opaque {
 pub const ASTContext = opaque {
     pub const getPointerType = ZigClangASTContext_getPointerType;
     extern fn ZigClangASTContext_getPointerType(*const ASTContext, T: QualType) QualType;
+
+    pub const getTypeSize = ZigClangASTContext_getTypeSize;
+    extern fn ZigClangASTContext_getTypeSize(*const ASTContext, T: QualType) u64;
 };
 
 pub const ASTUnit = opaque {
@@ -181,6 +184,14 @@ pub const ArraySubscriptExpr = opaque {
 pub const ArrayType = opaque {
     pub const getElementType = ZigClangArrayType_getElementType;
     extern fn ZigClangArrayType_getElementType(*const ArrayType) QualType;
+};
+
+pub const ASTRecordLayout = opaque {
+    pub const getFieldOffset = ZigClangASTRecordLayout_getFieldOffset;
+    extern fn ZigClangASTRecordLayout_getFieldOffset(*const ASTRecordLayout, c_uint) u64;
+
+    pub const getAlignment = ZigClangASTRecordLayout_getAlignment;
+    extern fn ZigClangASTRecordLayout_getAlignment(*const ASTRecordLayout) i64;
 };
 
 pub const AttributedType = opaque {
@@ -438,6 +449,12 @@ pub const Expr = opaque {
 
     pub const evaluateAsConstantExpr = ZigClangExpr_EvaluateAsConstantExpr;
     extern fn ZigClangExpr_EvaluateAsConstantExpr(*const Expr, *ExprEvalResult, Expr_ConstantExprKind, *const ASTContext) bool;
+
+    pub const refersToBitField = ZigClangExpr_refersToBitField;
+    extern fn ZigClangExpr_refersToBitField(*const Expr) bool;
+
+    pub const getSourceBitField = ZigClangExpr_getSourceBitField;
+    extern fn ZigClangExpr_getSourceBitField(*const Expr) ?*const FieldDecl;
 };
 
 pub const FieldDecl = opaque {
@@ -453,6 +470,9 @@ pub const FieldDecl = opaque {
     pub const isBitField = ZigClangFieldDecl_isBitField;
     extern fn ZigClangFieldDecl_isBitField(*const FieldDecl) bool;
 
+    pub const isUnnamedBitfield = ZigClangFieldDecl_isUnnamedBitfield;
+    extern fn ZigClangFieldDecl_isUnnamedBitfield(*const FieldDecl) bool;
+
     pub const getType = ZigClangFieldDecl_getType;
     extern fn ZigClangFieldDecl_getType(*const FieldDecl) QualType;
 
@@ -461,6 +481,12 @@ pub const FieldDecl = opaque {
 
     pub const getParent = ZigClangFieldDecl_getParent;
     extern fn ZigClangFieldDecl_getParent(*const FieldDecl) ?*const RecordDecl;
+
+    pub const getFieldIndex = ZigClangFieldDecl_getFieldIndex;
+    extern fn ZigClangFieldDecl_getFieldIndex(*const FieldDecl) c_uint;
+
+    pub const getBitWidthValue = ZigClangFieldDecl_getBitWidthValue;
+    extern fn ZigClangFieldDecl_getBitWidthValue(*const FieldDecl, *const ASTContext) c_uint;
 };
 
 pub const FileID = opaque {};
@@ -744,6 +770,9 @@ pub const RecordDecl = opaque {
 
     pub const getLocation = ZigClangRecordDecl_getLocation;
     extern fn ZigClangRecordDecl_getLocation(*const RecordDecl) SourceLocation;
+
+    pub const getASTRecordLayout = ZigClangRecordDecl_getASTRecordLayout;
+    extern fn ZigClangRecordDecl_getASTRecordLayout(*const RecordDecl, *const ASTContext) *const ASTRecordLayout;
 
     pub const field_begin = ZigClangRecordDecl_field_begin;
     extern fn ZigClangRecordDecl_field_begin(*const RecordDecl) field_iterator;

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -24,6 +24,7 @@
 #include <clang/AST/APValue.h>
 #include <clang/AST/Attr.h>
 #include <clang/AST/Expr.h>
+#include <clang/AST/RecordLayout.h>
 
 #if __GNUC__ >= 8
 #pragma GCC diagnostic pop
@@ -1637,7 +1638,6 @@ static clang::EnumDecl::enumerator_iterator bitcast(ZigClangEnumDecl_enumerator_
     return dest;
 }
 
-
 ZigClangSourceLocation ZigClangSourceManager_getSpellingLoc(const ZigClangSourceManager *self,
         ZigClangSourceLocation Loc)
 {
@@ -1671,6 +1671,10 @@ const char* ZigClangSourceManager_getCharacterData(const ZigClangSourceManager *
 
 ZigClangQualType ZigClangASTContext_getPointerType(const ZigClangASTContext* self, ZigClangQualType T) {
     return bitcast(reinterpret_cast<const clang::ASTContext *>(self)->getPointerType(bitcast(T)));
+}
+
+uint64_t ZigClangASTContext_getTypeSize(const ZigClangASTContext* self, ZigClangQualType T) {
+    return reinterpret_cast<const clang::ASTContext *>(self)->getTypeSize(bitcast(T));
 }
 
 unsigned ZigClangASTContext_getTypeAlign(const ZigClangASTContext* self, ZigClangQualType T) {
@@ -2154,6 +2158,16 @@ ZigClangQualType ZigClangExpr_getType(const ZigClangExpr *self) {
 ZigClangSourceLocation ZigClangExpr_getBeginLoc(const ZigClangExpr *self) {
     auto casted = reinterpret_cast<const clang::Expr *>(self);
     return bitcast(casted->getBeginLoc());
+}
+
+bool ZigClangExpr_refersToBitField(const ZigClangExpr *self) {
+    auto casted = reinterpret_cast<const clang::Expr *>(self);
+    return casted->refersToBitField();
+}
+
+const struct ZigClangFieldDecl *ZigClangExpr_getSourceBitField(const ZigClangExpr *self) {
+    auto casted = reinterpret_cast<const clang::Expr *>(self);
+    return reinterpret_cast<const ZigClangFieldDecl *>(casted->getSourceBitField());
 }
 
 bool ZigClangExpr_EvaluateAsBooleanCondition(const ZigClangExpr *self, bool *result,
@@ -2716,6 +2730,22 @@ struct ZigClangQualType ZigClangCStyleCastExpr_getType(const struct ZigClangCSty
     return bitcast(casted->getType());
 }
 
+const struct ZigClangASTRecordLayout *ZigClangRecordDecl_getASTRecordLayout(const struct ZigClangRecordDecl *self, const struct ZigClangASTContext *ctx) {
+    auto casted_self = reinterpret_cast<const clang::RecordDecl *>(self);
+    auto casted_ctx = reinterpret_cast<const clang::ASTContext *>(ctx);
+    const clang::ASTRecordLayout &layout = casted_ctx->getASTRecordLayout(casted_self);
+    return reinterpret_cast<const struct ZigClangASTRecordLayout *>(&layout);
+}
+
+uint64_t ZigClangASTRecordLayout_getFieldOffset(const struct ZigClangASTRecordLayout *self, unsigned field_no) {
+    return reinterpret_cast<const clang::ASTRecordLayout *>(self)->getFieldOffset(field_no);
+}
+
+int64_t ZigClangASTRecordLayout_getAlignment(const struct ZigClangASTRecordLayout *self) {
+    auto casted_self = reinterpret_cast<const clang::ASTRecordLayout *>(self);
+    return casted_self->getAlignment().getQuantity();
+}
+
 bool ZigClangIntegerLiteral_EvaluateAsInt(const struct ZigClangIntegerLiteral *self, struct ZigClangExprEvalResult *result, const struct ZigClangASTContext *ctx) {
     auto casted_self = reinterpret_cast<const clang::IntegerLiteral *>(self);
     auto casted_ctx = reinterpret_cast<const clang::ASTContext *>(ctx);
@@ -3115,6 +3145,11 @@ bool ZigClangFieldDecl_isBitField(const struct ZigClangFieldDecl *self) {
     return casted->isBitField();
 }
 
+bool ZigClangFieldDecl_isUnnamedBitfield(const struct ZigClangFieldDecl *self) {
+    auto casted = reinterpret_cast<const clang::FieldDecl *>(self);
+    return casted->isUnnamedBitfield();
+}
+
 bool ZigClangFieldDecl_isAnonymousStructOrUnion(const ZigClangFieldDecl *field_decl) {
     return reinterpret_cast<const clang::FieldDecl*>(field_decl)->isAnonymousStructOrUnion();
 }
@@ -3127,6 +3162,17 @@ ZigClangSourceLocation ZigClangFieldDecl_getLocation(const struct ZigClangFieldD
 const struct ZigClangRecordDecl *ZigClangFieldDecl_getParent(const struct ZigClangFieldDecl *self) {
     auto casted = reinterpret_cast<const clang::FieldDecl *>(self);
     return reinterpret_cast<const ZigClangRecordDecl *>(casted->getParent());
+}
+
+unsigned ZigClangFieldDecl_getFieldIndex(const struct ZigClangFieldDecl *self) {
+    auto casted = reinterpret_cast<const clang::FieldDecl *>(self);
+    return casted->getFieldIndex();
+}
+
+unsigned ZigClangFieldDecl_getBitWidthValue(const struct ZigClangFieldDecl *self, const struct ZigClangASTContext *ctx) {
+    auto casted_self = reinterpret_cast<const clang::FieldDecl *>(self);
+    const clang::ASTContext *casted_ctx = reinterpret_cast<const clang::ASTContext *>(ctx);
+    return casted_self->getBitWidthValue(*casted_ctx);
 }
 
 ZigClangQualType ZigClangFieldDecl_getType(const struct ZigClangFieldDecl *self) {

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -91,6 +91,7 @@ struct ZigClangAPFloat;
 struct ZigClangAPInt;
 struct ZigClangAPSInt;
 struct ZigClangASTContext;
+struct ZigClangASTRecordLayout;
 struct ZigClangASTUnit;
 struct ZigClangArraySubscriptExpr;
 struct ZigClangArrayType;
@@ -965,6 +966,7 @@ ZIG_EXTERN_C const char* ZigClangSourceManager_getCharacterData(const struct Zig
         struct ZigClangSourceLocation SL);
 
 ZIG_EXTERN_C struct ZigClangQualType ZigClangASTContext_getPointerType(const struct ZigClangASTContext*, struct ZigClangQualType T);
+ZIG_EXTERN_C uint64_t ZigClangASTContext_getTypeSize(const struct ZigClangASTContext*, struct ZigClangQualType T);
 
 
 // Can return null.
@@ -1015,6 +1017,11 @@ ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangEnumDecl_getLocation(const st
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangTypedefNameDecl_getLocation(const struct ZigClangTypedefNameDecl *);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangDecl_getLocation(const struct ZigClangDecl *);
 
+ZIG_EXTERN_C const struct ZigClangASTRecordLayout *ZigClangRecordDecl_getASTRecordLayout(const struct ZigClangRecordDecl *, const struct ZigClangASTContext *);
+
+ZIG_EXTERN_C uint64_t ZigClangASTRecordLayout_getFieldOffset(const struct ZigClangASTRecordLayout *, unsigned);
+ZIG_EXTERN_C int64_t ZigClangASTRecordLayout_getAlignment(const struct ZigClangASTRecordLayout *);
+
 ZIG_EXTERN_C struct ZigClangQualType ZigClangFunctionDecl_getType(const struct ZigClangFunctionDecl *);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangFunctionDecl_getLocation(const struct ZigClangFunctionDecl *);
 ZIG_EXTERN_C bool ZigClangFunctionDecl_hasBody(const struct ZigClangFunctionDecl *);
@@ -1032,6 +1039,7 @@ ZIG_EXTERN_C const char* ZigClangFunctionDecl_getSectionAttribute(const struct Z
 ZIG_EXTERN_C bool ZigClangRecordDecl_isUnion(const struct ZigClangRecordDecl *record_decl);
 ZIG_EXTERN_C bool ZigClangRecordDecl_isStruct(const struct ZigClangRecordDecl *record_decl);
 ZIG_EXTERN_C bool ZigClangRecordDecl_isAnonymousStructOrUnion(const struct ZigClangRecordDecl *record_decl);
+
 ZIG_EXTERN_C ZigClangRecordDecl_field_iterator ZigClangRecordDecl_field_begin(const struct ZigClangRecordDecl *);
 ZIG_EXTERN_C ZigClangRecordDecl_field_iterator ZigClangRecordDecl_field_end(const struct ZigClangRecordDecl *);
 ZIG_EXTERN_C ZigClangRecordDecl_field_iterator ZigClangRecordDecl_field_iterator_next(struct ZigClangRecordDecl_field_iterator);
@@ -1100,6 +1108,8 @@ ZIG_EXTERN_C bool ZigClangStmt_classof_Expr(const struct ZigClangStmt *self);
 ZIG_EXTERN_C enum ZigClangStmtClass ZigClangExpr_getStmtClass(const struct ZigClangExpr *self);
 ZIG_EXTERN_C struct ZigClangQualType ZigClangExpr_getType(const struct ZigClangExpr *self);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangExpr_getBeginLoc(const struct ZigClangExpr *self);
+ZIG_EXTERN_C bool ZigClangExpr_refersToBitField(const struct ZigClangExpr *self);
+ZIG_EXTERN_C const struct ZigClangFieldDecl *ZigClangExpr_getSourceBitField(const struct ZigClangExpr *self);
 ZIG_EXTERN_C bool ZigClangExpr_EvaluateAsBooleanCondition(const struct ZigClangExpr *self,
         bool *result, const struct ZigClangASTContext *ctx, bool in_constant_context);
 ZIG_EXTERN_C bool ZigClangExpr_EvaluateAsFloat(const struct ZigClangExpr *self,
@@ -1311,10 +1321,13 @@ ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangMacroDefinitionRecord_getSour
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangMacroDefinitionRecord_getSourceRange_getEnd(const struct ZigClangMacroDefinitionRecord *);
 
 ZIG_EXTERN_C bool ZigClangFieldDecl_isBitField(const struct ZigClangFieldDecl *);
+ZIG_EXTERN_C bool ZigClangFieldDecl_isUnnamedBitfield(const struct ZigClangFieldDecl *);
 ZIG_EXTERN_C bool ZigClangFieldDecl_isAnonymousStructOrUnion(const ZigClangFieldDecl *);
 ZIG_EXTERN_C struct ZigClangQualType ZigClangFieldDecl_getType(const struct ZigClangFieldDecl *);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangFieldDecl_getLocation(const struct ZigClangFieldDecl *);
 ZIG_EXTERN_C const struct ZigClangRecordDecl *ZigClangFieldDecl_getParent(const struct ZigClangFieldDecl *);
+ZIG_EXTERN_C unsigned ZigClangFieldDecl_getFieldIndex(const struct ZigClangFieldDecl *);
+ZIG_EXTERN_C unsigned ZigClangFieldDecl_getBitWidthValue(const struct ZigClangFieldDecl *, const struct ZigClangASTContext *);
 
 ZIG_EXTERN_C const struct ZigClangExpr *ZigClangEnumConstantDecl_getInitExpr(const struct ZigClangEnumConstantDecl *);
 ZIG_EXTERN_C const struct ZigClangAPSInt *ZigClangEnumConstantDecl_getInitVal(const struct ZigClangEnumConstantDecl *);

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1508,4 +1508,24 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Basic bitfields",
+        \\#include <stdlib.h>
+        \\#include <stdalign.h>
+        \\struct foo {
+        \\    unsigned x : 2;
+        \\    unsigned z : 16;
+        \\    unsigned y: 2;
+        \\    int *p;
+        \\};
+        \\int main(void) {
+        \\    struct foo bar = {.x = 0xFFFF, .z = 0, .y = 0b11, .p = NULL};
+        \\    if (bar.x != 0b11) abort();
+        \\    bar.z = 0xFFFFFF;
+        \\    if (bar.z != 0xFFFF) abort();
+        \\    unsigned char c = bar.z;
+        \\    if (c != 0xFF) abort();
+        \\    if (alignof(struct foo) < alignof(int *)) abort();
+        \\}
+    , "");
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -888,21 +888,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\};
     });
 
-    cases.add("pointer to struct demoted to opaque due to bit fields",
-        \\struct Foo {
-        \\    unsigned int: 1;
-        \\};
-        \\struct Bar {
-        \\    struct Foo *foo;
-        \\};
-    , &[_][]const u8{
-        \\pub const struct_Foo = opaque {};
-        ,
-        \\pub const struct_Bar = extern struct {
-        \\    foo: ?*struct_Foo,
-        \\};
-    });
-
     cases.add("macro with left shift",
         \\#define REDISMODULE_READ (1<<0)
     , &[_][]const u8{
@@ -3514,7 +3499,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
        \\}
     });
 
-    cases.add("Demote function that initializes opaque struct",
+    cases.add("Unnamed bitfield",
         \\struct my_struct {
         \\    unsigned a: 15;
         \\    unsigned: 2;
@@ -3524,9 +3509,16 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    struct my_struct S = {.a = 1, .b = 2};
         \\}
     , &[_][]const u8{
-        \\warning: Cannot initialize opaque type
-        ,
-        \\warning: unable to translate function, demoted to extern
-        \\pub extern fn initialize() void;
+        \\pub const struct_my_struct = packed struct {
+        \\    a: u15 align(4),
+        \\    unnamed_0: u2 = undefined,
+        \\    b: u15,
+        \\};
+        \\pub export fn initialize() void {
+        \\    var S: struct_my_struct = struct_my_struct{
+        \\        .a = @import("std").meta.cast(u15, @bitCast(c_uint, @as(c_int, 1))),
+        \\        .b = @import("std").meta.cast(u15, @bitCast(c_uint, @as(c_int, 2))),
+        \\    };
+        \\}
     });
 }


### PR DESCRIPTION
Some notes:

Implements bitfields with `packed` structs. Structs that do not contain bitfields should not be affected.

Should this problem even be solved this way - is the proper approach instead for `extern` structs to understand the ABI struct packing rules?

Even given a perfect translation in terms of layout, this might actually cause more problems than it solves since the C ABI is currently not supported for some packed structs (https://github.com/ziglang/zig/issues/1481) - for things like `@sizeOf` the size could be inlined, but calling a function and passing a struct by value won't work and in fact will cause a compile issue.

I implemented casts with `std.meta.cast` just to get something working but those can be replaced with builtins; compound assignments would still need to be translated with proper casts.

The `-target` flag to `zig translate-c` is important since the target ABI affects the layout. For example given this C struct:
```c
struct foo {
   unsigned x : 2;
   unsigned z : 16;
   unsigned y: 2;
   int *p;
};
```
With a `-target` of `x86_64-macos-gnu` I get:
```zig
pub const struct_foo = packed struct {
    x: u2 align(8),
    z: u16,
    y: u2,
    @"anon.padding_3": u44 = undefined,
    p: [*c]c_int,
};
```

With a `-target` of `thumb-freestanding-gnueabihf` I get:
```zig
pub const struct_foo = packed struct {
    x: u2 align(4),
    z: u16,
    y: u2,
    @"anon.padding_3": u12 = undefined,
    p: [*c]c_int,
};
```