### PR TITLE
alternative idea to solve #7948

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -388,19 +388,16 @@ pub fn formatAddress(value: anytype, options: FormatOptions, writer: anytype) @T
     @compileError("Cannot format non-pointer type " ++ @typeName(T) ++ " with * specifier");
 }
 
-// This ANY const is a workaround for: https://github.com/ziglang/zig/issues/7948
-const ANY = "any";
-
 fn defaultSpec(comptime T: type) [:0]const u8 {
     switch (@typeInfo(T)) {
-        .Array => |_| return ANY,
+        .Array => |_| return "any",
         .Pointer => |ptr_info| switch (ptr_info.size) {
             .One => switch (@typeInfo(ptr_info.child)) {
                 .Array => |_| return "*",
                 else => {},
             },
             .Many, .C => return "*",
-            .Slice => return ANY,
+            .Slice => return "any",
         },
         .Optional => |info| return defaultSpec(info.child),
         else => {},
@@ -410,12 +407,16 @@ fn defaultSpec(comptime T: type) [:0]const u8 {
 
 pub fn formatType(
     value: anytype,
-    comptime fmt: []const u8,
+    comptime fmt: anytype,
     options: FormatOptions,
     writer: anytype,
     max_depth: usize,
 ) @TypeOf(writer).Error!void {
-    const actual_fmt = comptime if (std.mem.eql(u8, fmt, ANY)) defaultSpec(@TypeOf(value)) else fmt;
+    if (comptime !std.meta.isArray(@TypeOf(fmt))) {
+        const fmt_array = comptime std.meta.asArray(u8, fmt);
+        return formatType(value, fmt_array, options, writer, max_depth);
+    }
+    const actual_fmt: []const u8 = comptime if (std.mem.eql(u8, &fmt, "any")) defaultSpec(@TypeOf(value)) else &fmt;
     if (comptime std.mem.eql(u8, actual_fmt, "*")) {
         return formatAddress(value, options, writer);
     }
@@ -486,7 +487,7 @@ pub fn formatType(
                 try writer.writeAll(" = ");
                 inline for (info.fields) |u_field| {
                     if (value == @field(UnionTagType, u_field.name)) {
-                        try formatType(@field(value, u_field.name), ANY, options, writer, max_depth - 1);
+                        try formatType(@field(value, u_field.name), "any", options, writer, max_depth - 1);
                     }
                 }
                 try writer.writeAll(" }");
@@ -508,7 +509,7 @@ pub fn formatType(
                 }
                 try writer.writeAll(f.name);
                 try writer.writeAll(" = ");
-                try formatType(@field(value, f.name), ANY, options, writer, max_depth - 1);
+                try formatType(@field(value, f.name), "any", options, writer, max_depth - 1);
             }
             try writer.writeAll(" }");
         },

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2748,3 +2748,11 @@ pub fn alignInSlice(slice: anytype, comptime new_alignment: usize) ?AlignedSlice
     const aligned_slice = bytesAsSlice(Element, aligned_bytes[0..slice_length_bytes]);
     return @alignCast(new_alignment, aligned_slice);
 }
+
+pub fn sliceToArray(comptime T: type, comptime s: []const T) [s.len]T {
+    var result: [s.len]T = undefined;
+    inline for (s) |e, i| {
+        result[i] = e;
+    }
+    return result;
+}


### PR DESCRIPTION
This is a variation on https://github.com/ziglang/zig/pull/8839

Instead of creating a wrapper function that takes a comptime slice and converts it to an array, this mechanism sets the array to `anytype` and then recursively calls itself if it needs to be converted to an array.