### PR TITLE
stage2: wasm - Structs and switch support

### DIFF
--- a/src/codegen/wasm.zig
+++ b/src/codegen/wasm.zig
@@ -795,11 +795,7 @@ pub const Context = struct {
 
     fn genAlloc(self: *Context, inst: *Inst.NoOp) InnerError!WValue {
         const elem_type = inst.base.ty.elemType();
-        const valtype = try self.genValtype(inst.base.src, elem_type);
-        try self.locals.append(self.gpa, valtype);
-
         const local_value = WValue{ .local = self.local_index };
-        self.local_index += 1;
 
         switch (elem_type.zigTypeTag()) {
             .Struct => {
@@ -816,7 +812,11 @@ pub const Context = struct {
                 }
             },
             // TODO: Add more types that require extra locals such as optionals
-            else => {},
+            else => {
+                const valtype = try self.genValtype(inst.base.src, elem_type);
+                try self.locals.append(self.gpa, valtype);
+                self.local_index += 1;
+            },
         }
 
         return local_value;
@@ -1115,6 +1115,6 @@ pub const Context = struct {
     fn genStructFieldPtr(self: *Context, inst: *Inst.StructFieldPtr) InnerError!WValue {
         const struct_ptr = self.resolveInst(inst.struct_ptr);
 
-        return WValue{ .local = struct_ptr.local + @intCast(u32, inst.field_index) + 1 };
+        return WValue{ .local = struct_ptr.local + @intCast(u32, inst.field_index) };
     }
 };

--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -474,4 +474,65 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , "30\n");
     }
+
+    {
+        var case = ctx.exe("wasm switch", wasi);
+
+        case.addCompareOutput(
+            \\pub export fn _start() u32 {
+            \\    var val: u32 = 1;
+            \\    var a: u32 = switch (val) {
+            \\        0, 1 => 2,
+            \\        2 => 3,
+            \\        3 => 4,
+            \\        else => 5,
+            \\    };
+            \\
+            \\    return a;
+            \\}
+        , "2\n");
+
+        case.addCompareOutput(
+            \\pub export fn _start() u32 {
+            \\    var val: u32 = 2;
+            \\    var a: u32 = switch (val) {
+            \\        0, 1 => 2,
+            \\        2 => 3,
+            \\        3 => 4,
+            \\        else => 5,
+            \\    };
+            \\
+            \\    return a;
+            \\}
+        , "3\n");
+
+        case.addCompareOutput(
+            \\pub export fn _start() u32 {
+            \\    var val: u32 = 10;
+            \\    var a: u32 = switch (val) {
+            \\        0, 1 => 2,
+            \\        2 => 3,
+            \\        3 => 4,
+            \\        else => 5,
+            \\    };
+            \\
+            \\    return a;
+            \\}
+        , "5\n");
+
+        case.addCompareOutput(
+            \\const MyEnum = enum { One, Two, Three };
+            \\
+            \\pub export fn _start() u32 {
+            \\    var val: MyEnum = .Two;
+            \\    var a: u32 = switch (val) {
+            \\        .One => 1,
+            \\        .Two => 2,
+            \\        .Three => 3,
+            \\    };
+            \\
+            \\    return a;
+            \\}
+        , "2\n");
+    }
 }

--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -419,4 +419,26 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , "2\n");
     }
+
+    {
+        var case = ctx.exe("wasm structs", wasi);
+
+        case.addCompareOutput(
+            \\const Example = struct { x: u32 };
+            \\
+            \\export fn _start() u32 {
+            \\    var example: Example = .{ .x = 5 };
+            \\    return example.x;
+            \\}
+        , "5\n");
+
+        case.addCompareOutput(
+            \\const Example = struct { x: u32, y: u32 };
+            \\
+            \\export fn _start() u32 {
+            \\    var example: Example = .{ .x = 5, .y = 10 };
+            \\    return example.y + example.x;
+            \\}
+        , "15\n");
+    }
 }

--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -426,19 +426,52 @@ pub fn addCases(ctx: *TestContext) !void {
         case.addCompareOutput(
             \\const Example = struct { x: u32 };
             \\
-            \\export fn _start() u32 {
+            \\pub export fn _start() u32 {
             \\    var example: Example = .{ .x = 5 };
             \\    return example.x;
             \\}
         , "5\n");
 
         case.addCompareOutput(
+            \\const Example = struct { x: u32 };
+            \\
+            \\pub export fn _start() u32 {
+            \\    var example: Example = .{ .x = 5 };
+            \\    example.x = 10;
+            \\    return example.x;
+            \\}
+        , "10\n");
+
+        case.addCompareOutput(
             \\const Example = struct { x: u32, y: u32 };
             \\
-            \\export fn _start() u32 {
+            \\pub export fn _start() u32 {
             \\    var example: Example = .{ .x = 5, .y = 10 };
             \\    return example.y + example.x;
             \\}
         , "15\n");
+
+        case.addCompareOutput(
+            \\const Example = struct { x: u32, y: u32 };
+            \\
+            \\pub export fn _start() u32 {
+            \\    var example: Example = .{ .x = 5, .y = 10 };
+            \\    var example2: Example = .{ .x = 10, .y = 20 };
+            \\
+            \\    example = example2;
+            \\    return example.y + example.x;
+            \\}
+        , "30\n");
+
+        case.addCompareOutput(
+            \\const Example = struct { x: u32, y: u32 };
+            \\
+            \\pub export fn _start() u32 {
+            \\    var example: Example = .{ .x = 5, .y = 10 };
+            \\
+            \\    example = .{ .x = 10, .y = 20 };
+            \\    return example.y + example.x;
+            \\}
+        , "30\n");
     }
 }


### PR DESCRIPTION
This PR adds support for structs and switches.

One thing I haven't been able to test yet is how this behaves for fields with default values as sema will generate a 
compile error if you do not supply all fields when initializing a struct.

The way structs are implemented is by creating a `local` for each field.
Structs will return a `Wvalue.multi_value` rather than `Wvalue.local` which means we can create a generic way
of handling structures that require multiple locals (such as optionals as well). This multi_value is lowered to a `Wvalue.local`
by the instruction `struct_field_ptr`. This is done by calculating the index by getting the 'offset' from the mutli_value and adding the field index. (can struct fields be re-ordered at some point later down the line?)
When assigning a new struct value to an existing struct variable `genStore` will simply overwrite the `Wvalue` of the old struct with the new one to update the offset index.

Switches are implemented by creating a block in wasm for each single-prong. When it does not match the condition, it will jump out of this block and continue
to the next prong. When it does match, it will run the branch's body and break out of the outer block (the switch itself) and the end of the body.
multi-prong live in the outer block as sema will generate regular `condbr` instructions with `a or b`.
Else branch lives in the outer block as well and is treated as regular code. At the end of the body it will simply exist the block.

Afaict, multi-prong enums are not supported yet as it wasn't generating any instructions for me. So a test case for this is missing.

