### PR TITLE
SPIR-V: More codegen

### DIFF
--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -157,20 +157,19 @@ pub fn flushModule(self: *SpirV, comp: *Compilation) !void {
             .spv = &spv,
             .args = std.ArrayList(u32).init(self.base.allocator),
             .next_arg_index = undefined,
-            .types = codegen.TypeMap.init(self.base.allocator),
-            .values = codegen.ValueMap.init(self.base.allocator),
+            .inst_results = codegen.InstMap.init(self.base.allocator),
             .decl = undefined,
             .error_msg = undefined,
         };
 
-        defer decl_gen.values.deinit();
-        defer decl_gen.types.deinit();
+        defer decl_gen.inst_results.deinit();
         defer decl_gen.args.deinit();
 
         for (self.decl_table.items()) |entry| {
             const decl = entry.key;
             if (!decl.has_tv) continue;
 
+            // Reset the decl_gen, but retain allocated resources.
             decl_gen.args.items.len = 0;
             decl_gen.next_arg_index = 0;
             decl_gen.decl = decl;
@@ -204,8 +203,8 @@ pub fn flushModule(self: *SpirV, comp: *Compilation) !void {
     // follows the SPIR-V logical module format!
     var all_buffers = [_]std.os.iovec_const{
         wordsToIovConst(binary.items),
-        wordsToIovConst(spv.types_globals_constants.items),
-        wordsToIovConst(spv.fn_decls.items),
+        wordsToIovConst(spv.binary.types_globals_constants.items),
+        wordsToIovConst(spv.binary.fn_decls.items),
     };
 
     const file = self.base.file.?;

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -161,12 +161,15 @@ pub fn flushModule(self: *SpirV, comp: *Compilation) !void {
             .args = std.ArrayList(codegen.Word).init(self.base.allocator),
             .next_arg_index = undefined,
             .inst_results = codegen.InstMap.init(self.base.allocator),
+            .blocks = codegen.BlockMap.init(self.base.allocator),
+            .current_block_label_id = undefined,
             .decl = undefined,
             .error_msg = undefined,
         };
 
         defer decl_gen.inst_results.deinit();
         defer decl_gen.args.deinit();
+        defer decl_gen.blocks.deinit();
 
         for (self.decl_table.items()) |entry| {
             const decl = entry.key;
@@ -175,6 +178,9 @@ pub fn flushModule(self: *SpirV, comp: *Compilation) !void {
             // Reset the decl_gen, but retain allocated resources.
             decl_gen.args.items.len = 0;
             decl_gen.next_arg_index = 0;
+            decl_gen.inst_results.clearRetainingCapacity();
+            decl_gen.blocks.clearRetainingCapacity();
+            decl_gen.current_block_label_id = undefined;
             decl_gen.decl = decl;
             decl_gen.error_msg = null;
 

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -41,7 +41,7 @@ const spec = @import("../codegen/spirv/spec.zig");
 pub const FnData = struct {
     // We're going to fill these in flushModule, and we're going to fill them unconditionally,
     // so just set it to undefined.
-    id: ResultId = undefined
+    id: ResultId = undefined,
 };
 
 base: link.File,

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -152,7 +152,7 @@ pub fn flushModule(self: *SpirV, comp: *Compilation) !void {
 
     // Now, actually generate the code for all declarations.
     {
-        var decl_gen = codegen.DeclGen.init(self.base.allocator, &spv);
+        var decl_gen = codegen.DeclGen.init(&spv);
         defer decl_gen.deinit();
 
         for (self.decl_table.items()) |entry| {

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -146,7 +146,6 @@ pub fn flushModule(self: *SpirV, comp: *Compilation) !void {
             if (!decl.has_tv) continue;
 
             decl.fn_link.spirv.id = spv.allocResultId();
-            log.debug("Allocating id {} to '{s}'", .{ decl.fn_link.spirv.id, std.mem.spanZ(decl.name) });
         }
     }
 


### PR DESCRIPTION
This PR adds again some more SPIR-V codegen stuff:
- Reworked generation of float constants a bit, now uses Value.toFloat instead of the raw tag type.
- Some general restructuring.
- Integer encoding: This turned out to be harder than i anticipated, mostly because there is no decent way yet to obtain a 2s complement value for an int. For now, i handled it through toUnsignedInt and toSignedInt and then did some bit operations on that. I'm not yet sure how to encode "strange" integer types, so for now they're just inserted as an equivalent constant of the backing type.
- Split out genCmp and genBinOp as Andrew suggested, though i have not yet removed the extra switch in genCmp, genBinOp and genUnOp.
- A preliminary version of generating alloc, store and load.
  * They only work for local variables (with storage class `Function`) as of now. As these operations require pointers, and so more advanced stuff depends on #653. This is next on the agenda.
  * Local variables need to be declared in the first SPIR-V block, and so i made an additional arraylist in DeclGen to temporarily hold code generated by the current function, which OpVariable bypasses as it is inserted directly into spv.binary.fn_decls.  
- In order to get more useful error messages during developing i pass the instruction's source location to genType and genConstant, though i'm not actually sure whether this is the right source location (it points to the instruction instead of the type). Furthermore, how do i pass the proper source of stuff like types of function parameters? 
- With #8554 merged, dbg_stmt now contains the actual source offset and so we can nicely generate that in SPIR-V debug info. Both OpLine and OpSource are emitted now.