### PR TITLE
stage2: only pass -lm -lc -ldl for android libc

### DIFF
--- a/src/target.zig
+++ b/src/target.zig
@@ -387,13 +387,20 @@ pub fn libcFullLinkFlags(target: std.Target) []const []const u8 {
             "-lc",
             "-lutil",
         },
-        else => &[_][]const u8{
-            "-lm",
-            "-lpthread",
-            "-lc",
-            "-ldl",
-            "-lrt",
-            "-lutil",
+        else => switch (target.abi) {
+            .android => &[_][]const u8{
+                "-lm",
+                "-lc",
+                "-ldl",
+            },
+            else => &[_][]const u8{
+                "-lm",
+                "-lpthread",
+                "-lc",
+                "-ldl",
+                "-lrt",
+                "-lutil",
+            },
         },
     };
 }


### PR DESCRIPTION
I don't have an android setup to test this, but @MasterQ32 has confirmed that this works and that android only has these libc components available.