### PR TITLE
wasm: produce static lib by default and rename produced object files to simply .o from .o.wasm

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -284,6 +284,7 @@ const Code = struct {
     link_objects: []const []const u8,
     target_str: ?[]const u8,
     link_libc: bool,
+    link_mode: ?std.builtin.LinkMode,
     disable_cache: bool,
 
     const Id = union(enum) {
@@ -533,6 +534,7 @@ fn genToc(allocator: *mem.Allocator, tokenizer: *Tokenizer) !Toc {
                     defer link_objects.deinit();
                     var target_str: ?[]const u8 = null;
                     var link_libc = false;
+                    var link_mode: ?std.builtin.LinkMode = null;
                     var disable_cache = false;
 
                     const source_token = while (true) {
@@ -562,6 +564,8 @@ fn genToc(allocator: *mem.Allocator, tokenizer: *Tokenizer) !Toc {
                             target_str = "wasm32-wasi";
                         } else if (mem.eql(u8, end_tag_name, "link_libc")) {
                             link_libc = true;
+                        } else if (mem.eql(u8, end_tag_name, "link_mode_dynamic")) {
+                            link_mode = .Dynamic;
                         } else if (mem.eql(u8, end_tag_name, "code_end")) {
                             _ = try eatToken(tokenizer, Token.Id.BracketClose);
                             break content_tok;
@@ -585,6 +589,7 @@ fn genToc(allocator: *mem.Allocator, tokenizer: *Tokenizer) !Toc {
                             .link_objects = link_objects.toOwnedSlice(),
                             .target_str = target_str,
                             .link_libc = link_libc,
+                            .link_mode = link_mode,
                             .disable_cache = disable_cache,
                         },
                     });
@@ -1467,6 +1472,18 @@ fn genHtml(allocator: *mem.Allocator, tokenizer: *Tokenizer, toc: *Toc, out: any
                         if (code.target_str) |triple| {
                             try test_args.appendSlice(&[_][]const u8{ "-target", triple });
                             try out.print(" -target {s}", .{triple});
+                        }
+                        if (code.link_mode) |link_mode| {
+                            switch (link_mode) {
+                                .Static => {
+                                    try test_args.append("-static");
+                                    try out.print(" -static", .{});
+                                },
+                                .Dynamic => {
+                                    try test_args.append("-dynamic");
+                                    try out.print(" -dynamic", .{});
+                                },
+                            }
                         }
                         const result = exec(allocator, &env_map, test_args.items) catch return parseError(tokenizer, code.source_token, "test failed", .{});
                         const escaped_stderr = try escapeHtml(allocator, result.stderr);

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10036,10 +10036,11 @@ all your base are belong to us</code></pre>
       {#header_open|WebAssembly#}
       <p>Zig supports building for WebAssembly out of the box.</p>
       {#header_open|Freestanding#}
-      <p>For host environments like the web browser and nodejs, build as a library using the freestanding OS target.
-      Here's an example of running Zig code compiled to WebAssembly with nodejs.</p>
+      <p>For host environments like the web browser and nodejs, build as a dynamic library using the freestanding
+      OS target. Here's an example of running Zig code compiled to WebAssembly with nodejs.</p>
       {#code_begin|lib|math#}
       {#target_wasm#}
+      {#link_mode_dynamic#}
 extern fn print(i32) void;
 
 export fn add(a: i32, b: i32) void {

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1259,9 +1259,6 @@ pub const Target = struct {
     }
 
     pub fn oFileExt_cpu_arch_abi(cpu_arch: Cpu.Arch, abi: Abi) [:0]const u8 {
-        if (cpu_arch.isWasm()) {
-            return ".o.wasm";
-        }
         switch (abi) {
             .msvc => return ".obj",
             else => return ".o",
@@ -1289,9 +1286,6 @@ pub const Target = struct {
     }
 
     pub fn staticLibSuffix_cpu_arch_abi(cpu_arch: Cpu.Arch, abi: Abi) [:0]const u8 {
-        if (cpu_arch.isWasm()) {
-            return ".wasm";
-        }
         switch (abi) {
             .msvc => return ".lib",
             else => return ".a",

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -698,7 +698,7 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
 
         if (link_in_crt) {
             // TODO work out if we want standard crt, a reactor or a command
-            try argv.append(try comp.get_libc_crt_file(arena, "crt.o.wasm"));
+            try argv.append(try comp.get_libc_crt_file(arena, "crt.o"));
         }
 
         if (!is_obj and self.base.options.link_libc) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1548,12 +1548,6 @@ fn buildOutputType(
             link_libcpp = true;
     }
 
-    if (cross_target.getCpuArch().isWasm() and output_mode == .Lib and link_mode == null) {
-        // If link_mode is unspecified, always link as dynamic library when targeting Wasm,
-        // so that wasm-ld is invoked rather than standard archiver.
-        link_mode = .Dynamic;
-    }
-
     // Now that we have target info, we can find out if any of the system libraries
     // are part of libc or libc++. We remove them from the list and communicate their
     // existence via flags instead.


### PR DESCRIPTION
### Produce static lib by default

This matches the behaviour for other targets in that

```
> zig build-lib math.zig -target wasm32-freestanding
libmath.a
```

produces now `libmath.a` while

```
> zig build-lib math.zig -dynamic -target wasm32-freestanding
math.wasm
```

is required to create a loadable Wasm module.

### Rename produced object files to .o from .o.wasm

This should offer more compatibility with external tooling when cross-compiling to wasm with zig.

```
> zig build-obj hello.zig -target wasm32-freestanding
hello.o
```