### PR TITLE
fix accidental quadratic dependence on haystack length in replace and replacementSize

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2074,7 +2074,7 @@ pub fn replace(comptime T: type, input: []const T, needle: []const T, replacemen
     var slide: usize = 0;
     var replacements: usize = 0;
     while (slide < input.len) {
-        if (mem.indexOf(T, input[slide..], needle) == @as(usize, 0)) {
+        if (mem.startsWith(T, input[slide..], needle)) {
             mem.copy(T, output[i .. i + replacement.len], replacement);
             i += replacement.len;
             slide += needle.len;
@@ -2129,7 +2129,7 @@ pub fn replacementSize(comptime T: type, input: []const T, needle: []const T, re
     var i: usize = 0;
     var size: usize = input.len;
     while (i < input.len) {
-        if (mem.indexOf(T, input[i..], needle) == @as(usize, 0)) {
+        if (mem.startsWith(T, input[i..], needle)) {
             size = size - needle.len + replacement.len;
             i += needle.len;
         } else {


### PR DESCRIPTION
In `std.mem`, the functions `replace` and `replacementSize` both do a simple linear search for `needle` in `haystack`. However, when checking for a match at a particular location they call `mem.indexOf` on the remaining input, which will search up to the whole of the remainder for a match. This leads to a worst-case quadratic dependence on the length of `haystack`, and should be replaced by a simple call to `mem.startsWith`. For example:

```
var text = try std.testing.allocator.alloc(u8, 200_000);
var output = try std.testing.allocator.alloc(u8, 200_000);
const pat1 = "baaaa";
const pat2 = "xxxxx";
std.mem.set(u8, text, 'a');
std.mem.copy(u8, text[text.len - pat1.len ..], pat1);
const reps = std.mem.replace(u8, text, pat1, pat2, output);
```

This replaces the single instance of a short pattern at the end of a 200k character string. In ReleaseFast, during one run on my machine, the `replace` call took 1m1.767s. With this patch, the `replace` call took only 144.4us.