### PR TITLE
further haiku support    initial compile and link

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1686,7 +1686,7 @@ pub const ModuleDebugInfo = switch (native_os) {
             };
         }
     },
-    .linux, .netbsd, .freebsd, .dragonfly, .openbsd => struct {
+    .linux, .netbsd, .freebsd, .dragonfly, .openbsd, .haiku => struct {
         base_address: usize,
         dwarf: DW.DwarfInfo,
         mapped_memory: []const u8,

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -800,7 +800,10 @@ pub fn getSelfExeSharedLibPaths(allocator: *Allocator) error{OutOfMemory}![][:0]
 }
 
 /// Tells whether calling the `execv` or `execve` functions will be a compile error.
-pub const can_execv = std.builtin.os.tag != .windows;
+pub const can_execv = switch (builtin.os.tag) {
+    .windows, .haiku => false,
+    else => true,
+};
 
 pub const ExecvError = std.os.ExecveError || error{OutOfMemory};
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3286,6 +3286,13 @@ pub fn get_libc_crt_file(comp: *Compilation, arena: *Allocator, basename: []cons
     return full_path;
 }
 
+pub fn get_libc_crtbegin_file(comp: *Compilation, arena: *Allocator, basename: []const u8) ![]const u8 {
+    const lci = comp.bin_file.options.libc_installation orelse return error.LibCInstallationNotAvailable;
+    const crtbegin_dir_path = lci.crtbegin_dir orelse return error.LibCInstallationMissingCRTDir;
+    const full_path = try std.fs.path.join(arena, &[_][]const u8{ crtbegin_dir_path, basename });
+    return full_path;
+}
+
 fn addBuildingGLibCJobs(comp: *Compilation) !void {
     try comp.work_queue.write(&[_]Job{
         .{ .glibc_crt_file = .crti_o },

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3286,13 +3286,6 @@ pub fn get_libc_crt_file(comp: *Compilation, arena: *Allocator, basename: []cons
     return full_path;
 }
 
-pub fn get_libc_crtbegin_file(comp: *Compilation, arena: *Allocator, basename: []const u8) ![]const u8 {
-    const lci = comp.bin_file.options.libc_installation orelse return error.LibCInstallationNotAvailable;
-    const crtbegin_dir_path = lci.crtbegin_dir orelse return error.LibCInstallationMissingCRTDir;
-    const full_path = try std.fs.path.join(arena, &[_][]const u8{ crtbegin_dir_path, basename });
-    return full_path;
-}
-
 fn addBuildingGLibCJobs(comp: *Compilation) !void {
     try comp.work_queue.write(&[_]Job{
         .{ .glibc_crt_file = .crti_o },

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -21,7 +21,7 @@ pub const LibCInstallation = struct {
     crt_dir: ?[]const u8 = null,
     msvc_lib_dir: ?[]const u8 = null,
     kernel32_lib_dir: ?[]const u8 = null,
-    crtbegin_dir: ?[]const u8 = null,
+    gcc_dir: ?[]const u8 = null,
 
     pub const FindError = error{
         OutOfMemory,
@@ -114,8 +114,8 @@ pub const LibCInstallation = struct {
             });
             return error.ParseError;
         }
-        if (self.crtbegin_dir == null and is_haiku) {
-            log.err("crtbegin_dir may not be empty for {s}\n", .{@tagName(Target.current.os.tag)});
+        if (self.gcc_dir == null and is_haiku) {
+            log.err("gcc_dir may not be empty for {s}\n", .{@tagName(Target.current.os.tag)});
             return error.ParseError;
         }
 
@@ -129,7 +129,7 @@ pub const LibCInstallation = struct {
         const crt_dir = self.crt_dir orelse "";
         const msvc_lib_dir = self.msvc_lib_dir orelse "";
         const kernel32_lib_dir = self.kernel32_lib_dir orelse "";
-        const crtbegin_dir = self.crtbegin_dir orelse "";
+        const gcc_dir = self.gcc_dir orelse "";
 
         try out.print(
             \\# The directory that contains `stdlib.h`.
@@ -156,7 +156,7 @@ pub const LibCInstallation = struct {
             \\
             \\# The directory that contains `crtbeginS.o` and `crtendS.o`
             \\# Only needed when targeting Haiku.
-            \\crtbegin_dir={s}
+            \\gcc_dir={s}
             \\
         , .{
             include_dir,
@@ -164,7 +164,7 @@ pub const LibCInstallation = struct {
             crt_dir,
             msvc_lib_dir,
             kernel32_lib_dir,
-            crtbegin_dir,
+            gcc_dir,
         });
     }
 
@@ -442,7 +442,7 @@ pub const LibCInstallation = struct {
     }
 
     fn findNativeCrtBeginDirHaiku(self: *LibCInstallation, args: FindNativeOptions) FindError!void {
-        self.crtbegin_dir = try ccPrintFileName(.{
+        self.gcc_dir = try ccPrintFileName(.{
             .allocator = args.allocator,
             .search_basename = "crtbeginS.o",
             .want_dirname = .only_dir,

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -3310,7 +3310,7 @@ const CsuObjects = struct {
                     .static_pie  => result.set( "crt0.o", "crti.o", "crtbeginT.o", "crtendS.o", "crtn.o" ),
                     // zig fmt: on
                 },
-                .openbsd => switch(mode) {
+                .openbsd => switch (mode) {
                     // zig fmt: off
                     .dynamic_lib => result.set( null,      null, "crtbeginS.o", "crtendS.o", null ),
                     .dynamic_exe,
@@ -3352,24 +3352,24 @@ const CsuObjects = struct {
                     if (result.crtend) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crt_dir_path, gccv, obj.* });
                 },
                 .haiku => {
-                    const crtbegin_dir_path = lci.crtbegin_dir orelse return error.LibCInstallationMissingCRTDir;
+                    const gcc_dir_path = lci.gcc_dir orelse return error.LibCInstallationMissingCRTDir;
                     if (result.crt0) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crt_dir_path, obj.* });
                     if (result.crti) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crt_dir_path, obj.* });
                     if (result.crtn) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crt_dir_path, obj.* });
 
-                    if (result.crtbegin) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crtbegin_dir_path, obj.* });
-                    if (result.crtend) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crtbegin_dir_path, obj.* });
+                    if (result.crtbegin) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ gcc_dir_path, obj.* });
+                    if (result.crtend) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ gcc_dir_path, obj.* });
                 },
                 else => {
-                    inline for (std.meta.fields(@TypeOf(result))) |f,i| {
+                    inline for (std.meta.fields(@TypeOf(result))) |f, i| {
                         if (@field(result, f.name)) |*obj| {
                             obj.* = try fs.path.join(arena, &[_][]const u8{ crt_dir_path, obj.* });
                         }
                     }
-                }
+                },
             }
         } else {
-            inline for (std.meta.fields(@TypeOf(result))) |f,i| {
+            inline for (std.meta.fields(@TypeOf(result))) |f, i| {
                 if (@field(result, f.name)) |*obj| {
                     if (comp.crt_files.get(obj.*)) |crtf| {
                         obj.* = crtf.full_object_path;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -3319,6 +3319,15 @@ const CsuObjects = struct {
                     .static_pie  => result.set( "rcrt0.o", null, "crtbegin.o",  "crtend.o",  null ),
                     // zig fmt: on
                 },
+                .haiku => switch (mode) {
+                    // zig fmt: off
+                    .dynamic_lib => result.set( null,          "crti.o", "crtbeginS.o", "crtendS.o", "crtn.o" ),
+                    .dynamic_exe => result.set( "start_dyn.o", "crti.o", "crtbegin.o",  "crtend.o",  "crtn.o" ),
+                    .dynamic_pie => result.set( "start_dyn.o", "crti.o", "crtbeginS.o", "crtendS.o", "crtn.o" ),
+                    .static_exe  => result.set( "start_dyn.o", "crti.o", "crtbegin.o",  "crtend.o",  "crtn.o" ),
+                    .static_pie  => result.set( "start_dyn.o", "crti.o", "crtbeginS.o", "crtendS.o", "crtn.o" ),
+                    // zig fmt: on
+                },
                 else => {},
             }
         }
@@ -3341,6 +3350,15 @@ const CsuObjects = struct {
 
                     if (result.crtbegin) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crt_dir_path, gccv, obj.* });
                     if (result.crtend) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crt_dir_path, gccv, obj.* });
+                },
+                .haiku => {
+                    const crtbegin_dir_path = lci.crtbegin_dir orelse return error.LibCInstallationMissingCRTDir;
+                    if (result.crt0) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crt_dir_path, obj.* });
+                    if (result.crti) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crt_dir_path, obj.* });
+                    if (result.crtn) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crt_dir_path, obj.* });
+
+                    if (result.crtbegin) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crtbegin_dir_path, obj.* });
+                    if (result.crtend) |*obj| obj.* = try fs.path.join(arena, &[_][]const u8{ crtbegin_dir_path, obj.* });
                 },
                 else => {
                     inline for (std.meta.fields(@TypeOf(result))) |f,i| {

--- a/src/target.zig
+++ b/src/target.zig
@@ -366,6 +366,12 @@ pub fn libcFullLinkFlags(target: std.Target) []const []const u8 {
             "-lc",
             "-lutil",
         },
+        .haiku => &[_][]const u8{
+            "-lm",
+            "-lroot",
+            "-lpthread",
+            "-lc",
+        },
         else => switch (target.abi) {
             .android => &[_][]const u8{
                 "-lm",


### PR DESCRIPTION
Hello again,

I have made some more progress in getting Zig to work under Haiku. The following changes should get Zig to compile and build a (simple) Zig program that runs under Haiku. This is compiled with a llvm12 installation (can use pkgman under Haiku for this. relevant packages are llvm12, llvm12_clang, llvm12_libs, llvm12_lld).  This was tested on nightly build hrev55081.

Things I have been able to confirm now functional that wasn't previously (previous commands that were working under Haiku should still be):

* zig cc of a barebones c program appears to compile
* zig build-exe can generate an executable binary
* zig run on a zig file works

When running zig build on a sample project I am seeing an error returned along the lines of  _Unable to dump stack trace: Unable to open debug info: UnsupportedDebugInfo_ which is to be expected at this time. This most likely also affects _make install_ target as well.
 
This update also adds an extra returned parameter when running zig libc (crtbegin_dir) to note the extra directory that needs to be returned for what appears to be other bits of the c runtime for Haiku. I am not sure about this change but verified that it is functional at the moment. I would be open to suggestions to better approaches for handling this.


```
~/src/git/zig/build> uname -a
Haiku shredder 1 hrev55081 May 10 2021 07:04:00 x86_64 x86_64 Haiku

~/src/git/zig/build> ./zig version
0.8.0-dev.2591+4b69bd61e

~/src/git/zig/build> ./zig libc
# The directory that contains `stdlib.h`.
# On POSIX-like systems, include directories be found with: `cc -E -Wp,-v -xc /dev/null`
include_dir=/boot/system/develop/headers

# The system-specific include directory. May be the same as `include_dir`.
# On Windows it's the directory that includes `vcruntime.h`.
# On POSIX it's the directory that includes `sys/errno.h`.
sys_include_dir=/boot/system/develop/headers

# The directory that contains `crt1.o` or `crt2.o`.
# On POSIX, can be found with `cc -print-file-name=crt1.o`.
# Not needed when targeting MacOS.
crt_dir=/system/develop/lib

# The directory that contains `vcruntime.lib`.
# Only needed when targeting MSVC on Windows.
msvc_lib_dir=

# The directory that contains `kernel32.lib`.
# Only needed when targeting MSVC on Windows.
kernel32_lib_dir=

# The directory that contains `crtbeginS.o` and `crtendS.o`
# Only needed when targeting Haiku.
crtbegin_dir=/boot/system/develop/tools/bin/../lib/gcc/x86_64-unknown-haiku/8.3.0
~/src/git/zig/build> mkdir hellohaiku
~/src/git/zig/build> cd hellohaiku/
~/src/git/zig/build/hellohaiku> ../zig init-exe
info: Created build.zig
info: Created src/main.zig
info: Next, try `zig build --help` or `zig build run`
~/src/git/zig/build/hellohaiku> ../zig run src/main.zig 
info: All your codebase are belong to us.

```