### PR TITLE
zld: permit system static libs

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -698,8 +698,8 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
                 try positionals.append(comp.libcxx_static_lib.?.full_object_path);
             }
 
-            // Shared libraries.
-            var shared_libs = std.ArrayList([]const u8).init(arena);
+            // Shared and static libraries passed via `-l` flag.
+            var libs = std.ArrayList([]const u8).init(arena);
             var search_lib_names = std.ArrayList([]const u8).init(arena);
 
             const system_libs = self.base.options.system_libs.items();
@@ -708,9 +708,8 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
                 // By this time, we depend on these libs being dynamically linked libraries and not static libraries
                 // (the check for that needs to be earlier), but they could be full paths to .dylib files, in which
                 // case we want to avoid prepending "-l".
-                // TODO I think they should go as an input file instead of via shared_libs.
                 if (Compilation.classifyFileExt(link_lib) == .shared_library) {
-                    try shared_libs.append(link_lib);
+                    try positionals.append(link_lib);
                     continue;
                 }
 
@@ -760,24 +759,29 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
                 }
             }
 
+            // TODO text-based API, or .tbd files.
+            const exts = &[_][]const u8{ "dylib", "a" };
+
             for (search_lib_names.items) |l_name| {
-                // TODO text-based API, or .tbd files.
-                const l_name_ext = try std.fmt.allocPrint(arena, "lib{s}.dylib", .{l_name});
-
                 var found = false;
-                for (search_lib_dirs.items) |lib_dir| {
-                    const full_path = try fs.path.join(arena, &[_][]const u8{ lib_dir, l_name_ext });
 
-                    // Check if the dylib file exists.
-                    const tmp = fs.cwd().openFile(full_path, .{}) catch |err| switch (err) {
-                        error.FileNotFound => continue,
-                        else => |e| return e,
-                    };
-                    defer tmp.close();
+                for (exts) |ext| ext: {
+                    const l_name_ext = try std.fmt.allocPrint(arena, "lib{s}.{s}", .{ l_name, ext });
 
-                    try shared_libs.append(full_path);
-                    found = true;
-                    break;
+                    for (search_lib_dirs.items) |lib_dir| {
+                        const full_path = try fs.path.join(arena, &[_][]const u8{ lib_dir, l_name_ext });
+
+                        // Check if the dylib file exists.
+                        const tmp = fs.cwd().openFile(full_path, .{}) catch |err| switch (err) {
+                            error.FileNotFound => continue,
+                            else => |e| return e,
+                        };
+                        defer tmp.close();
+
+                        try libs.append(full_path);
+                        found = true;
+                        break :ext;
+                    }
                 }
 
                 if (!found) {
@@ -835,7 +839,7 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
             }
 
             try zld.link(positionals.items, full_out_path, .{
-                .shared_libs = shared_libs.items,
+                .libs = libs.items,
                 .rpaths = rpaths.items,
             });
 

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -183,3 +183,9 @@ pub fn parseSymbols(self: *Dylib) !void {
         try self.symbols.putNoClobber(self.allocator, name, &proxy.base);
     }
 }
+
+pub fn isDylib(file: fs.File) !bool {
+    const header = try file.reader().readStruct(macho.mach_header_64);
+    try file.seekTo(0);
+    return header.filetype == macho.MH_DYLIB;
+}

--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -485,3 +485,9 @@ pub fn parseDataInCode(self: *Object) !void {
         try self.data_in_code_entries.append(self.allocator, dice);
     }
 }
+
+pub fn isObject(file: fs.File) !bool {
+    const header = try file.reader().readStruct(macho.mach_header_64);
+    try file.seekTo(0);
+    return header.filetype == macho.MH_OBJECT;
+}

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -14,6 +14,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/global_linkage/build.zig");
     cases.addBuildFile("test/standalone/static_c_lib/build.zig");
     cases.addBuildFile("test/standalone/link_interdependent_static_c_libs/build.zig");
+    cases.addBuildFile("test/standalone/link_static_lib_as_system_lib/build.zig");
     cases.addBuildFile("test/standalone/issue_339/build.zig");
     cases.addBuildFile("test/standalone/issue_794/build.zig");
     cases.addBuildFile("test/standalone/issue_5825/build.zig");

--- a/test/standalone/link_static_lib_as_system_lib/a.c
+++ b/test/standalone/link_static_lib_as_system_lib/a.c
@@ -1,0 +1,4 @@
+#include "a.h"
+int32_t add(int32_t a, int32_t b) {
+    return a + b;
+}

--- a/test/standalone/link_static_lib_as_system_lib/a.h
+++ b/test/standalone/link_static_lib_as_system_lib/a.h
@@ -1,0 +1,2 @@
+#include <stdint.h>
+int32_t add(int32_t a, int32_t b);

--- a/test/standalone/link_static_lib_as_system_lib/build.zig
+++ b/test/standalone/link_static_lib_as_system_lib/build.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const lib_a = b.addStaticLibrary("a", null);
+    lib_a.addCSourceFile("a.c", &[_][]const u8{});
+    lib_a.setBuildMode(mode);
+    lib_a.addIncludeDir(".");
+    lib_a.install();
+
+    const test_exe = b.addTest("main.zig");
+    test_exe.setBuildMode(mode);
+    test_exe.linkSystemLibrary("a"); // force linking liba.a as -la
+    test_exe.addSystemIncludeDir(".");
+    const search_path = std.fs.path.join(b.allocator, &[_][]const u8{ b.install_path, "lib" }) catch unreachable;
+    test_exe.addLibPath(search_path);
+
+    const test_step = b.step("test", "Test it");
+    test_step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_exe.step);
+}

--- a/test/standalone/link_static_lib_as_system_lib/main.zig
+++ b/test/standalone/link_static_lib_as_system_lib/main.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const expect = std.testing.expect;
+const c = @cImport(@cInclude("a.h"));
+
+test "import C add" {
+    const result = c.add(2, 1);
+    try expect(result == 3);
+}


### PR DESCRIPTION
This commits permits passing in static archives using the system lib flag `-la`. With this commit, `zig ld` will now look firstly for a dynamic library (which always takes precedence), and will fall back on `liba.a` if the dylib is not found. The static archive is searched for in the system lib search dirs like the dylibs.

cc @jedisct1 @Jarred-Sumner hopefully, this addesses issue #8860, so I'd be indebted if you could try this commit out!