### PR TITLE
make writeIntSlice functions work for signed integers

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1412,7 +1412,7 @@ pub fn writeIntSliceLittle(comptime T: type, buffer: []u8, value: T) void {
 
     // TODO I want to call writeIntLittle here but comptime eval facilities aren't good enough
     const uint = std.meta.Int(.unsigned, @typeInfo(T).Int.bits);
-    var bits = @truncate(uint, value);
+    var bits = @bitCast(uint, value);
     for (buffer) |*b| {
         b.* = @truncate(u8, bits);
         bits >>= 8;
@@ -1432,7 +1432,7 @@ pub fn writeIntSliceBig(comptime T: type, buffer: []u8, value: T) void {
 
     // TODO I want to call writeIntBig here but comptime eval facilities aren't good enough
     const uint = std.meta.Int(.unsigned, @typeInfo(T).Int.bits);
-    var bits = @truncate(uint, value);
+    var bits = @bitCast(uint, value);
     var index: usize = buffer.len;
     while (index != 0) {
         index -= 1;
@@ -1995,6 +1995,30 @@ fn testWriteIntImpl() !void {
         0x00,
         0x00,
         0x00,
+    }));
+
+    writeIntSlice(i16, bytes[0..], @as(i16, -21555), Endian.Little);
+    try testing.expect(eql(u8, &bytes, &[_]u8{
+        0xCD,
+        0xAB,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+    }));
+
+    writeIntSlice(i16, bytes[0..], @as(i16, -21555), Endian.Big);
+    try testing.expect(eql(u8, &bytes, &[_]u8{
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0xAB,
+        0xCD,
     }));
 }
 


### PR DESCRIPTION
The `writeInt` functions accept signed integers, and the comments for the `writeIntSlice` functions say they write two's complement integers, implying the same. However, to get the bits of the value passed in, the `writeIntSlice` functions try to `@truncate` to an unsigned type with the same number of bits. This causes a compile error because `@truncate` expects an unsigned value. For example,

```
var buf: [2]u8 = undefined;
std.mem.writeIntLittle(i16, &buf, -21555); // ok
std.debug.assert(mem.eql(u8, &buf, &[2]u8 { 0xcd, 0xab }));
std.mem.writeIntSliceLittle(i16, &buf, -21555); // compile error
std.debug.assert(mem.eql(u8, &buf, &[2]u8 { 0xcd, 0xab }));
```

The obvious fix is just to use `@bitCast` instead of `@truncate` here. I've made this change and expanded the test for the `writeIntSlice` functions to cover signed integers too.

Curiously, I noticed that trying to `@truncate` a signed integer to an unsigned integer actually works at comptime. So,

```
var x: i16 = -21555;
std.debug.assert(@truncate(u16, x) == @as(u16, 0xabcd)); // compile error
```

but,

```
comptime var x: i16 = -21555;
std.debug.assert(@truncate(u16, x) == @as(u16, 0xabcd)); // ok
```

I don't know if this is intended or if I should make a separate issue for this behavior.