### PR TITLE
cc,wasi: force isysroot to / when building WASI libc

### DIFF
--- a/src/wasi_libc.zig
+++ b/src/wasi_libc.zig
@@ -242,6 +242,9 @@ fn addCCArgs(
         "-mthread-model",
         "single",
 
+        "-isysroot",
+        "/",
+
         "-iwithsysroot",
         try comp.zig_lib_directory.join(arena, &[_][]const u8{ "libc", "include", triple }),
     });


### PR DESCRIPTION
Hopefully, this is correct and doesn't cause potential errors for people with custom sysroots since we append a fully qualified path to the WASI libc anyway:

```zig
        "-iwithsysroot",
        try comp.zig_lib_directory.join(arena, &[_][]const u8{ "libc", "include", triple }),
```