### PR TITLE
Add zig astgen --errors-only --stdin flags

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3717,7 +3717,7 @@ pub fn cmdAstgen(
     } else if (errors_only_flag) {
         const elapsed = std.time.nanoTimestamp() - start;
 
-        if (elapsed < 1000) {
+        if (elapsed < std.time.ns_per_ms) {
             try io.getStdOut().writer().print("No errors found in {s}!\nCompleted in {d}μ", .{ zig_source_file, @divFloor(elapsed, std.time.ns_per_us) });
         } else {
             try io.getStdOut().writer().print("No errors found in {s}!\nCompleted in {d}ms", .{ zig_source_file, @divFloor(elapsed, std.time.ns_per_ms) });


### PR DESCRIPTION
This:
- Always includes `zig astgen` in builds instead of debug-only
- Adds an `--errors-only` flag and a `--stdin` flag to `zig astgen`. 

`--stdin` is like `zig fmt --stdin` 

`--errors-only` causes it to skip printing the ast and instead either:
- if there are errors, print those errors
- else, brag about how fast `zig astgen` runs

This is used by https://github.com/ziglang/vscode-zig/pull/50


Example output:
```bash
❯ zig astgen src/exact_size_matcher.zig --errors-only
No errors found in src/exact_size_matcher.zig!
Completed in 480μ⏎  
```
