### PR TITLE
Add . and .. tests for std.fs functions

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -954,6 +954,10 @@ test ". and .. in fs.Dir functions" {
     renamed_file.close();
     try tmp.dir.deleteFile("./subdir/../rename");
 
+    try tmp.dir.writeFile("./subdir/../update", "something");
+    const prev_status = try tmp.dir.updateFile("./subdir/../file", tmp.dir, "./subdir/../update", .{});
+    try testing.expectEqual(fs.PrevStatus.stale, prev_status);
+
     try tmp.dir.deleteDir("./subdir");
 }
 
@@ -990,6 +994,13 @@ test ". and .. in absolute functions" {
     const renamed_file = try fs.openFileAbsolute(renamed_file_path, .{});
     renamed_file.close();
     try fs.deleteFileAbsolute(renamed_file_path);
+
+    const update_file_path = try fs.path.join(allocator, &[_][]const u8{ subdir_path, "../update" });
+    const update_file = try fs.createFileAbsolute(update_file_path, .{});
+    try update_file.writeAll("something");
+    update_file.close();
+    const prev_status = try fs.updateFileAbsolute(created_file_path, update_file_path, .{});
+    try testing.expectEqual(fs.PrevStatus.stale, prev_status);
 
     try fs.deleteDirAbsolute(subdir_path);
 }


### PR DESCRIPTION
These tests check that . and .. are able to be handled by the std.fs functions. Before #7664, these tests would have failed on Windows.

Closes #4659

EDIT: Note that this doesn't test the full `fs.Dir` API, but it does test all functions that have a `fooAbsolute` counterpart (except `updateFile` which I will file an issue about shortly).
EDIT#2: The updateFile thing was my mistake actually, will add it into this PR.