### PR TITLE
housekeeping: remove `pub` from ccPrintFileName()

### DIFF
--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -523,7 +523,7 @@ pub const CCPrintFileNameOptions = struct {
 };
 
 /// caller owns returned memory
-pub fn ccPrintFileName(args: CCPrintFileNameOptions) ![:0]u8 {
+fn ccPrintFileName(args: CCPrintFileNameOptions) ![:0]u8 {
     const allocator = args.allocator;
 
     const cc_exe = std.os.getenvZ("CC") orelse default_cc_exe;


### PR DESCRIPTION
- this was inadvertently made public while iterating on #8730