### PR TITLE
clang driver: fix lost argv[0]

### DIFF
--- a/src/zig_clang_driver.cpp
+++ b/src/zig_clang_driver.cpp
@@ -448,7 +448,9 @@ int ZigClang_main(int argc_, const char **argv_) {
     ApplyQAOverride(argv, OverrideStr, SavedStrings);
   }
 
-  std::string Path = GetExecutablePath(argv[0], CanonicalPrefixes);
+  // Pass local param `argv_[0]` as fallback.
+  // See https://github.com/ziglang/zig/pull/3292 .
+  std::string Path = GetExecutablePath(argv_[0], CanonicalPrefixes);
 
   // Whether the cc1 tool should be called inside the current process, or if we
   // should spawn a new clang subprocess (old behavior).


### PR DESCRIPTION
- #3292 was unintentionally reverted by 56f433b3d9fb18a634c51366d0b18b5025e19260
- issue manifests on openbsd
- issue does NOT manifest on freebsd because llvm 10 has added freebsd-specific code for `getMainExecutable`
- most other bsd will manifest if `/proc` is not mounted
- see llvm [source](https://github.com/llvm/llvm-project/blob/d28af7c654d8db0b68c175db5ce212d74fb5e9bc/llvm/lib/Support/Unix/Path.inc#L192)

---

reduction: look for the 2 command lines using `/usr/bin/clang`
```sh
$ zig clang -### -c foo.S
clang version 12.0.0 (https://github.com/llvm/llvm-project.git fa0971b87fb2c9d14d1bba2551e61f02f18f329b)
Target: amd64-unknown-openbsd6.9
Thread model: posix
InstalledDir: /usr/bin
 "/usr/bin/clang" "-cc1" "-triple" "amd64-unknown-openbsd6.9" "-E" "-disable-free" "-disable-llvm-verifier" "-discard-value-names" "-main-file-name" "foo.S" "-mrelocation-model" "pic" "-pic-level" "1" "-pic-is-pie" "-mframe-pointer=all" "-fno-rounding-math" "-mconstructor-aliases" "-munwind-tables" "-target-cpu" "x86-64" "-tune-cpu" "generic" "-fno-split-dwarf-inlining" "-debugger-tuning=gdb" "-resource-dir" "/usr/lib/clang/12.0.0" "-internal-isystem" "/usr/lib/clang/12.0.0/include" "-internal-externc-isystem" "/usr/include" "-fdebug-compilation-dir" "/home/mike/project/zig/work/main" "-ferror-limit" "19" "-stack-protector" "2" "-fgnuc-version=4.2.1" "-fcolor-diagnostics" "-faddrsig" "-o" "/tmp/foo-57b2a5.s" "-x" "assembler-with-cpp" "foo.S"
 "/usr/bin/clang" "-cc1as" "-triple" "amd64-unknown-openbsd6.9" "-filetype" "obj" "-main-file-name" "foo.S" "-target-cpu" "x86-64" "-fdebug-compilation-dir" "/home/mike/project/zig/work/main" "-dwarf-debug-producer" "clang version 12.0.0 (https://github.com/llvm/llvm-project.git fa0971b87fb2c9d14d1bba2551e61f02f18f329b)" "-dwarf-version=2" "-mrelocation-model" "pic" "--mrelax-relocations" "-o" "foo.o" "/tmp/foo-57b2a5.s"
```

1. a new `argv` is created from `argv_` using a beginning offset is 1
2. later the fallback path is INCORRECTLY set to `argv[0]` which happens to be `clang` or `cc` depending on the driver command; fallback should be `argv_[0]`
3. llvm then searches path for those commands and execs the incorrect compiler