### PR TITLE
housekeeping: builtin.arch → builtin.cpu.arch

### DIFF
--- a/lib/std/c/minix.zig
+++ b/lib/std/c/minix.zig
@@ -13,7 +13,7 @@ pub const pthread_cond_t = extern struct {
 const __SIZEOF_PTHREAD_COND_T = 48;
 const __SIZEOF_PTHREAD_MUTEX_T = switch (builtin.abi) {
     .musl, .musleabi, .musleabihf => if (@sizeOf(usize) == 8) 40 else 24,
-    .gnu, .gnuabin32, .gnuabi64, .gnueabi, .gnueabihf, .gnux32 => switch (builtin.arch) {
+    .gnu, .gnuabin32, .gnuabi64, .gnueabi, .gnueabihf, .gnux32 => switch (builtin.cpu.arch) {
         .aarch64 => 48,
         .x86_64 => if (builtin.abi == .gnux32) 40 else 32,
         .mips64, .powerpc64, .powerpc64le, .sparcv9 => 40,

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -56,7 +56,7 @@ pub const pthread_cond_t = extern struct {
 
 pub const pthread_rwlock_t = extern struct {
     ptr_magic: c_uint = 0x99990009,
-    ptr_interlock: switch (std.builtin.arch) {
+    ptr_interlock: switch (std.builtin.cpu.arch) {
         .aarch64, .sparc, .x86_64, .i386 => u8,
         .arm, .powerpc => c_int,
         else => unreachable,
@@ -70,7 +70,7 @@ pub const pthread_rwlock_t = extern struct {
     ptr_private: ?*c_void = null,
 };
 
-const pthread_spin_t = switch (builtin.arch) {
+const pthread_spin_t = switch (builtin.cpu.arch) {
     .aarch64, .aarch64_be, .aarch64_32 => u8,
     .mips, .mipsel, .mips64, .mips64el => u32,
     .powerpc, .powerpc64, .powerpc64le => i32,
@@ -81,7 +81,7 @@ const pthread_spin_t = switch (builtin.arch) {
     else => @compileError("undefined pthread_spin_t for this arch"),
 };
 
-const padded_pthread_spin_t = switch (builtin.arch) {
+const padded_pthread_spin_t = switch (builtin.cpu.arch) {
     .i386, .x86_64 => u32,
     .sparc, .sparcel, .sparcv9 => u32,
     else => pthread_spin_t,

--- a/lib/std/os/bits/haiku.zig
+++ b/lib/std/os/bits/haiku.zig
@@ -858,7 +858,7 @@ pub const EOWNERDEAD = 96; // Previous owner died
 
 pub const ELAST = 96; // Must be equal largest errno
 
-pub const MINSIGSTKSZ = switch (builtin.arch) {
+pub const MINSIGSTKSZ = switch (builtin.cpu.arch) {
     .i386, .x86_64 => 2048,
     .arm, .aarch64 => 4096,
     else => @compileError("MINSIGSTKSZ not defined for this architecture"),

--- a/lib/std/os/bits/netbsd.zig
+++ b/lib/std/os/bits/netbsd.zig
@@ -841,7 +841,7 @@ pub const ucontext_t = extern struct {
     stack: stack_t,
     mcontext: mcontext_t,
     __pad: [
-        switch (builtin.arch) {
+        switch (builtin.cpu.arch) {
             .i386 => 4,
             .mips, .mipsel, .mips64, .mips64el => 14,
             .arm, .armeb, .thumb, .thumbeb => 1,

--- a/lib/std/os/linux/bpf/kern.zig
+++ b/lib/std/os/linux/bpf/kern.zig
@@ -5,7 +5,7 @@
 // and substantial portions of the software.
 const std = @import("../../../std.zig");
 
-const in_bpf_program = switch (std.builtin.arch) {
+const in_bpf_program = switch (std.builtin.cpu.arch) {
     .bpfel, .bpfeb => true,
     else => false,
 };

--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -9,7 +9,7 @@ const R_ARM_RELATIVE = 23;
 const R_AARCH64_RELATIVE = 1027;
 const R_RISCV_RELATIVE = 3;
 
-const ARCH_RELATIVE_RELOC = switch (builtin.arch) {
+const ARCH_RELATIVE_RELOC = switch (builtin.cpu.arch) {
     .i386 => R_386_RELATIVE,
     .x86_64 => R_AMD64_RELATIVE,
     .arm => R_ARM_RELATIVE,
@@ -21,7 +21,7 @@ const ARCH_RELATIVE_RELOC = switch (builtin.arch) {
 // Just a convoluted (but necessary) way to obtain the address of the _DYNAMIC[]
 // vector as PC-relative so that we can use it before any relocation is applied
 fn getDynamicSymbol() [*]elf.Dyn {
-    const addr = switch (builtin.arch) {
+    const addr = switch (builtin.cpu.arch) {
         .i386 => asm volatile (
             \\ .weak _DYNAMIC
             \\ .hidden _DYNAMIC


### PR DESCRIPTION
update sources to use `builtin.cpu.arch` because `builtin.arch` has been deprecated/removed