### PR TITLE
Makes std.io.StreamSource usable with freestanding

### DIFF
--- a/lib/std/io/stream_source.zig
+++ b/lib/std/io/stream_source.zig
@@ -11,14 +11,23 @@ const io = std.io;
 /// For memory sources, if the supplied byte buffer is const, then `io.Writer` is not available.
 /// The error set of the stream functions is the error set of the corresponding file functions.
 pub const StreamSource = union(enum) {
-    buffer: io.FixedBufferStream([]u8),
-    const_buffer: io.FixedBufferStream([]const u8),
-    file: std.fs.File,
+    const has_file = (std.builtin.os.tag != .freestanding);
 
-    pub const ReadError = std.fs.File.ReadError;
-    pub const WriteError = std.fs.File.WriteError;
-    pub const SeekError = std.fs.File.SeekError;
-    pub const GetSeekPosError = std.fs.File.GetSeekPosError;
+    /// The stream access is redirected to this buffer.
+    buffer: io.FixedBufferStream([]u8),
+
+    /// The stream access is redirected to this buffer.
+    /// Writing to the source will always yield `error.AccessDenied`.
+    const_buffer: io.FixedBufferStream([]const u8),
+
+    /// The stream access is redirected to this file.
+    /// On freestanding, this must never be initialized!
+    file: if (has_file) std.fs.File else void,
+
+    pub const ReadError = io.FixedBufferStream([]u8).ReadError || (if (has_file) std.fs.File.ReadError else error{});
+    pub const WriteError = error{AccessDenied} || io.FixedBufferStream([]u8).WriteError || (if (has_file) std.fs.File.WriteError else error{});
+    pub const SeekError = io.FixedBufferStream([]u8).SeekError || (if (has_file) std.fs.File.SeekError else error{});
+    pub const GetSeekPosError = io.FixedBufferStream([]u8).GetSeekPosError || (if (has_file) std.fs.File.GetSeekPosError else error{});
 
     pub const Reader = io.Reader(*StreamSource, ReadError, read);
     pub const Writer = io.Writer(*StreamSource, WriteError, write);
@@ -36,7 +45,7 @@ pub const StreamSource = union(enum) {
         switch (self.*) {
             .buffer => |*x| return x.read(dest),
             .const_buffer => |*x| return x.read(dest),
-            .file => |x| return x.read(dest),
+            .file => |x| if (!has_file) unreachable else return x.read(dest),
         }
     }
 
@@ -44,7 +53,7 @@ pub const StreamSource = union(enum) {
         switch (self.*) {
             .buffer => |*x| return x.write(bytes),
             .const_buffer => return error.AccessDenied,
-            .file => |x| return x.write(bytes),
+            .file => |x| if (!has_file) unreachable else return x.write(bytes),
         }
     }
 
@@ -52,7 +61,7 @@ pub const StreamSource = union(enum) {
         switch (self.*) {
             .buffer => |*x| return x.seekTo(pos),
             .const_buffer => |*x| return x.seekTo(pos),
-            .file => |x| return x.seekTo(pos),
+            .file => |x| if (!has_file) unreachable else return x.seekTo(pos),
         }
     }
 
@@ -60,7 +69,7 @@ pub const StreamSource = union(enum) {
         switch (self.*) {
             .buffer => |*x| return x.seekBy(amt),
             .const_buffer => |*x| return x.seekBy(amt),
-            .file => |x| return x.seekBy(amt),
+            .file => |x| if (!has_file) unreachable else return x.seekBy(amt),
         }
     }
 
@@ -68,7 +77,7 @@ pub const StreamSource = union(enum) {
         switch (self.*) {
             .buffer => |*x| return x.getEndPos(),
             .const_buffer => |*x| return x.getEndPos(),
-            .file => |x| return x.getEndPos(),
+            .file => |x| if (!has_file) unreachable else return x.getEndPos(),
         }
     }
 
@@ -76,7 +85,7 @@ pub const StreamSource = union(enum) {
         switch (self.*) {
             .buffer => |*x| return x.getPos(),
             .const_buffer => |*x| return x.getPos(),
-            .file => |x| return x.getPos(),
+            .file => |x| if (!has_file) unreachable else return x.getPos(),
         }
     }
 
@@ -92,3 +101,30 @@ pub const StreamSource = union(enum) {
         return .{ .context = self };
     }
 };
+
+test "StreamSource (refs)" {
+    std.testing.refAllDecls(StreamSource);
+}
+
+test "StreamSource (mutable buffer)" {
+    var buffer: [64]u8 = undefined;
+    var source = StreamSource{ .buffer = std.io.fixedBufferStream(&buffer) };
+
+    var writer = source.writer();
+
+    try writer.writeAll("Hello, World!");
+
+    try std.testing.expectEqualStrings("Hello, World!", source.buffer.getWritten());
+}
+
+test "StreamSource (const buffer)" {
+    const buffer: [64]u8 = "Hello, World!".* ++ ([1]u8{0xAA} ** 51);
+    var source = StreamSource{ .const_buffer = std.io.fixedBufferStream(&buffer) };
+
+    var reader = source.reader();
+
+    var dst_buffer: [13]u8 = undefined;
+    try reader.readNoEof(&dst_buffer);
+
+    try std.testing.expectEqualStrings("Hello, World!", &dst_buffer);
+}


### PR DESCRIPTION
This PR solves the problem that `std.io.StreamSource` is referencing `std.fs.File` which makes it unusable on freestanding environments. This PR `void`s the `.file` field on freestanding environments and makes the 