### PR TITLE
fix position of `orelse` and `catch` in precedence table documentation

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1758,9 +1758,9 @@ const B = error{Two};
       </div>
       {#header_close#}
       {#header_open|Precedence#}
-      <pre>{#syntax#}x() x[] x.y
+      <pre>{#syntax#}x() x[] x.y x.* x.?
 a!b
-x{} x.* x.?
+x{}
 !x -x -%x ~x &x ?x
 * / % ** *% ||
 + - ++ +% -%

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1762,14 +1762,13 @@ const B = error{Two};
 a!b
 x{} x.* x.?
 !x -x -%x ~x &x ?x
-! * / % ** *% ||
+* / % ** *% ||
 + - ++ +% -%
 << >>
-& ^ |
+& ^ | orelse catch
 == != < > <= >=
 and
 or
-orelse catch
 = *= /= %= += -= <<= >>= &= ^= |={#endsyntax#}</pre>
       {#header_close#}
       {#header_close#}


### PR DESCRIPTION
The documentation lists `orelse` and `catch` as having the second lowest precedence, above only assignment operators. However, in the grammar, they are grouped with `BitwiseOp`, and in parse.zig as well they have the same `.prec` of 40 that `&`, `^`, and `|` have. Further, there is a misplaced `!` included with the binary multiplication operators, which appears in neither the grammar nor parse.zig. I think this was once the error union type operator, but that has its own line below the suffix operators.