### PR TITLE
add standalone test for c compiler with build modes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -328,7 +328,7 @@ pub fn build(b: *Builder) !void {
     ));
 
     toolchain_step.dependOn(tests.addCompareOutputTests(b, test_filter, modes));
-    toolchain_step.dependOn(tests.addStandaloneTests(b, test_filter, modes));
+    toolchain_step.dependOn(tests.addStandaloneTests(b, test_filter, modes, skip_non_native, target));
     toolchain_step.dependOn(tests.addStackTraceTests(b, test_filter, modes));
     toolchain_step.dependOn(tests.addCliTests(b, test_filter, modes));
     toolchain_step.dependOn(tests.addAssembleAndLinkTests(b, test_filter, modes));

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -129,6 +129,7 @@ pub fn buildLibCXX(comp: *Compilation) !void {
         try cflags.append("-D_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS");
         try cflags.append("-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS");
         try cflags.append("-D_LIBCPP_HAS_NO_VENDOR_AVAILABILITY_ANNOTATIONS");
+        try cflags.append("-D_LIBCPP_DISABLE_NEW_DELETE_DEFINITIONS");
         try cflags.append("-fvisibility=hidden");
         try cflags.append("-fvisibility-inlines-hidden");
 

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -8,26 +8,26 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.add("test/standalone/guess_number/main.zig");
     cases.add("test/standalone/main_return_error/error_u8.zig");
     cases.add("test/standalone/main_return_error/error_u8_non_zero.zig");
-    cases.addBuildFile("test/standalone/main_pkg_path/build.zig");
-    cases.addBuildFile("test/standalone/shared_library/build.zig");
-    cases.addBuildFile("test/standalone/mix_o_files/build.zig");
-    cases.addBuildFile("test/standalone/global_linkage/build.zig");
-    cases.addBuildFile("test/standalone/static_c_lib/build.zig");
-    cases.addBuildFile("test/standalone/link_interdependent_static_c_libs/build.zig");
-    cases.addBuildFile("test/standalone/link_static_lib_as_system_lib/build.zig");
-    cases.addBuildFile("test/standalone/issue_339/build.zig");
-    cases.addBuildFile("test/standalone/issue_8550/build.zig");
-    cases.addBuildFile("test/standalone/issue_794/build.zig");
-    cases.addBuildFile("test/standalone/issue_5825/build.zig");
-    cases.addBuildFile("test/standalone/pkg_import/build.zig");
-    cases.addBuildFile("test/standalone/use_alias/build.zig");
-    cases.addBuildFile("test/standalone/brace_expansion/build.zig");
-    cases.addBuildFile("test/standalone/empty_env/build.zig");
-    cases.addBuildFile("test/standalone/issue_7030/build.zig");
+    cases.addBuildFile("test/standalone/main_pkg_path/build.zig", .{});
+    cases.addBuildFile("test/standalone/shared_library/build.zig", .{});
+    cases.addBuildFile("test/standalone/mix_o_files/build.zig", .{});
+    cases.addBuildFile("test/standalone/global_linkage/build.zig", .{});
+    cases.addBuildFile("test/standalone/static_c_lib/build.zig", .{});
+    cases.addBuildFile("test/standalone/link_interdependent_static_c_libs/build.zig", .{});
+    cases.addBuildFile("test/standalone/link_static_lib_as_system_lib/build.zig", .{});
+    cases.addBuildFile("test/standalone/issue_339/build.zig", .{});
+    cases.addBuildFile("test/standalone/issue_8550/build.zig", .{});
+    cases.addBuildFile("test/standalone/issue_794/build.zig", .{});
+    cases.addBuildFile("test/standalone/issue_5825/build.zig", .{});
+    cases.addBuildFile("test/standalone/pkg_import/build.zig", .{});
+    cases.addBuildFile("test/standalone/use_alias/build.zig", .{});
+    cases.addBuildFile("test/standalone/brace_expansion/build.zig", .{});
+    cases.addBuildFile("test/standalone/empty_env/build.zig", .{});
+    cases.addBuildFile("test/standalone/issue_7030/build.zig", .{});
     if (std.Target.current.os.tag != .wasi) {
-        cases.addBuildFile("test/standalone/load_dynamic_library/build.zig");
+        cases.addBuildFile("test/standalone/load_dynamic_library/build.zig", .{});
     }
     if (std.Target.current.cpu.arch == .x86_64) { // TODO add C ABI support for other architectures
-        cases.addBuildFile("test/stage1/c_abi/build.zig");
+        cases.addBuildFile("test/stage1/c_abi/build.zig", .{});
     }
 }

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -30,4 +30,5 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     if (std.Target.current.cpu.arch == .x86_64) { // TODO add C ABI support for other architectures
         cases.addBuildFile("test/stage1/c_abi/build.zig", .{});
     }
+    cases.addBuildFile("test/standalone/c_compiler/build.zig", .{ .build_modes = true, .cross_targets = true });
 }

--- a/test/standalone/c_compiler/build.zig
+++ b/test/standalone/c_compiler/build.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+const CrossTarget = std.zig.CrossTarget;
+
+fn isRunnableTarget(t: CrossTarget) bool {
+    if (t.isNative()) return true;
+
+    return (t.getOsTag() == std.Target.current.os.tag and
+        t.getCpuArch() == std.Target.current.cpu.arch);
+}
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const target = b.standardTargetOptions(.{});
+
+    const test_step = b.step("test", "Test the program");
+
+    const exe_c = b.addExecutable("test_c", null);
+    b.default_step.dependOn(&exe_c.step);
+    exe_c.addCSourceFile("test.c", &[0][]const u8{});
+    exe_c.setBuildMode(mode);
+    exe_c.setTarget(target);
+    exe_c.linkLibC();
+
+    const exe_cpp = b.addExecutable("test_cpp", null);
+    b.default_step.dependOn(&exe_cpp.step);
+    exe_cpp.addCSourceFile("test.cpp", &[0][]const u8{});
+    exe_cpp.setBuildMode(mode);
+    exe_cpp.setTarget(target);
+    exe_cpp.linkSystemLibrary("c++");
+
+    // disable broken LTO links:
+    switch(target.getOsTag()) {
+        .windows => {
+            exe_cpp.want_lto = false;
+        },
+        .macos => {
+            exe_cpp.want_lto = false;
+            exe_c.want_lto = false;
+        },
+        else => {},
+    }
+
+    if (isRunnableTarget(target)) {
+        const run_c_cmd = exe_c.run();
+        test_step.dependOn(&run_c_cmd.step);
+        const run_cpp_cmd = exe_cpp.run();
+        test_step.dependOn(&run_cpp_cmd.step);
+    } else {
+        test_step.dependOn(&exe_c.step);
+        test_step.dependOn(&exe_cpp.step);
+    }
+}

--- a/test/standalone/c_compiler/test.c
+++ b/test/standalone/c_compiler/test.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <stdio.h>
+
+typedef struct  {
+    int val;
+} STest;
+
+int getVal(STest* data) { return data->val; }
+
+int main (int argc, char *argv[])
+{
+	STest* data = (STest*)malloc(sizeof(STest));
+    data->val = 123;
+
+    assert(getVal(data) != 456);
+    int ok = (getVal(data) == 123);
+
+    if (argc>1) fprintf(stdout, "val=%d\n", data->val);
+
+    free(data);
+
+    if (!ok) abort();
+
+	return 0;
+}

--- a/test/standalone/c_compiler/test.cpp
+++ b/test/standalone/c_compiler/test.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <cassert>
+
+class CTest {
+public:
+	CTest(int val) : m_val(val) {};
+	virtual ~CTest() {}
+
+	virtual int getVal() const { return m_val; }
+	virtual void printVal() { std::cout << "val=" << m_val << std::endl; }
+private:
+	int m_val;
+};
+
+int main (int argc, char *argv[])
+{
+	auto* t = new CTest(123);
+	assert(t->getVal()!=456);
+    if (argc>1) t->printVal();
+	bool ok = t->getVal() == 123;
+	delete t;
+
+    if (!ok) abort();
+
+	return 0;
+}

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -399,7 +399,7 @@ pub fn addCompileErrorTests(b: *build.Builder, test_filter: ?[]const u8, modes: 
     return cases.step;
 }
 
-pub fn addStandaloneTests(b: *build.Builder, test_filter: ?[]const u8, modes: []const Mode) *build.Step {
+pub fn addStandaloneTests(b: *build.Builder, test_filter: ?[]const u8, modes: []const Mode, skip_non_native: bool, target: std.zig.CrossTarget) *build.Step {
     const cases = b.allocator.create(StandaloneContext) catch unreachable;
     cases.* = StandaloneContext{
         .b = b,
@@ -407,6 +407,8 @@ pub fn addStandaloneTests(b: *build.Builder, test_filter: ?[]const u8, modes: []
         .test_index = 0,
         .test_filter = test_filter,
         .modes = modes,
+        .skip_non_native = skip_non_native,
+        .target = target,
     };
 
     standalone.addCases(cases);
@@ -1136,6 +1138,8 @@ pub const StandaloneContext = struct {
     test_index: usize,
     test_filter: ?[]const u8,
     modes: []const Mode,
+    skip_non_native: bool,
+    target: std.zig.CrossTarget,
 
     pub fn addC(self: *StandaloneContext, root_src: []const u8) void {
         self.addAllArgs(root_src, true);
@@ -1145,10 +1149,10 @@ pub const StandaloneContext = struct {
         self.addAllArgs(root_src, false);
     }
 
-    pub fn addBuildFile(self: *StandaloneContext, build_file: []const u8) void {
+    pub fn addBuildFile(self: *StandaloneContext, build_file: []const u8, features: struct { build_modes: bool = false, cross_targets: bool = false }) void {
         const b = self.b;
 
-        const annotated_case_name = b.fmt("build {s} (Debug)", .{build_file});
+        const annotated_case_name = b.fmt("build {s}", .{build_file});
         if (self.test_filter) |filter| {
             if (mem.indexOf(u8, annotated_case_name, filter) == null) return;
         }
@@ -1167,12 +1171,30 @@ pub const StandaloneContext = struct {
             zig_args.append("--verbose") catch unreachable;
         }
 
-        const run_cmd = b.addSystemCommand(zig_args.items);
+        if (features.cross_targets and !self.target.isNative()) {
+            const target_arg = fmt.allocPrint(b.allocator, "-Dtarget={s}", .{self.target.zigTriple(b.allocator) catch unreachable}) catch unreachable;
+            zig_args.append(target_arg) catch unreachable;
+        }
 
-        const log_step = b.addLog("PASS {s}\n", .{annotated_case_name});
-        log_step.step.dependOn(&run_cmd.step);
+        const modes = if (features.build_modes) self.modes else &[1]Mode{.Debug};
+        for (modes) |mode| {
+            const arg = switch (mode) {
+                .Debug => "",
+                .ReleaseFast => "-Drelease-fast",
+                .ReleaseSafe => "-Drelease-safe",
+                .ReleaseSmall => "-Drelease-small",
+            };
+            const zig_args_base_len = zig_args.items.len;
+            if (arg.len > 0)
+                zig_args.append(arg) catch unreachable;
+            defer zig_args.resize(zig_args_base_len) catch unreachable;
 
-        self.step.dependOn(&log_step.step);
+            const run_cmd = b.addSystemCommand(zig_args.items);
+            const log_step = b.addLog("PASS {s} ({s})\n", .{ annotated_case_name, @tagName(mode) });
+            log_step.step.dependOn(&run_cmd.step);
+
+            self.step.dependOn(&log_step.step);
+        }
     }
 
     pub fn addAllArgs(self: *StandaloneContext, root_src: []const u8, link_libc: bool) void {


### PR DESCRIPTION
* Add the possibility for standalone tests to test all build modes / targets. 

* And a test for compiling c and c++ code, in debug and release mode.
(with LTO disabled on windows and macos because they fail)


maybe Release Modes should only enable LTO by default for lld+elf ?