### PR TITLE
Re-enable building the self-hosted compiler for 32-bit targets

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1071,7 +1071,7 @@ pub const Scope = struct {
             if (stat.size > std.math.maxInt(u32))
                 return error.FileTooBig;
 
-            const source = try gpa.allocSentinel(u8, stat.size, 0);
+            const source = try gpa.allocSentinel(u8, @intCast(usize, stat.size), 0);
             defer if (!file.source_loaded) gpa.free(source);
             const amt = try f.readAll(source);
             if (amt != stat.size)
@@ -2441,7 +2441,7 @@ pub fn astGenFile(mod: *Module, file: *Scope.File, prog_node: *std.Progress.Node
     if (stat.size > std.math.maxInt(u32))
         return error.FileTooBig;
 
-    const source = try gpa.allocSentinel(u8, stat.size, 0);
+    const source = try gpa.allocSentinel(u8, @intCast(usize, stat.size), 0);
     defer if (!file.source_loaded) gpa.free(source);
     const amt = try source_file.readAll(source);
     if (amt != stat.size)

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2483,7 +2483,7 @@ fn zirIntToError(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) InnerEr
         const payload = try sema.arena.create(Value.Payload.Error);
         payload.* = .{
             .base = .{ .tag = .@"error" },
-            .data = .{ .name = sema.mod.error_name_list.items[int] },
+            .data = .{ .name = sema.mod.error_name_list.items[@intCast(usize, int)] },
         };
         return sema.mod.constInst(sema.arena, src, .{
             .ty = Type.initTag(.anyerror),

--- a/src/main.zig
+++ b/src/main.zig
@@ -3642,7 +3642,7 @@ pub fn cmdAstCheck(
         if (stat.size > max_src_size)
             return error.FileTooBig;
 
-        const source = try arena.allocSentinel(u8, stat.size, 0);
+        const source = try arena.allocSentinel(u8, @intCast(usize, stat.size), 0);
         const amt = try f.readAll(source);
         if (amt != stat.size)
             return error.UnexpectedEndOfFile;
@@ -3778,7 +3778,7 @@ pub fn cmdChangelist(
         .root_decl = null,
     };
 
-    const source = try arena.allocSentinel(u8, stat.size, 0);
+    const source = try arena.allocSentinel(u8, @intCast(usize, stat.size), 0);
     const amt = try f.readAll(source);
     if (amt != stat.size)
         return error.UnexpectedEndOfFile;
@@ -3818,7 +3818,7 @@ pub fn cmdChangelist(
     if (new_stat.size > max_src_size)
         return error.FileTooBig;
 
-    const new_source = try arena.allocSentinel(u8, new_stat.size, 0);
+    const new_source = try arena.allocSentinel(u8, @intCast(usize, new_stat.size), 0);
     const new_amt = try new_f.readAll(new_source);
     if (new_amt != new_stat.size)
         return error.UnexpectedEndOfFile;

--- a/src/type.zig
+++ b/src/type.zig
@@ -2641,7 +2641,7 @@ pub const Type = extern union {
                 };
                 const end_val = Value.initPayload(&end_payload.base);
                 if (int_val.compare(.gte, end_val)) return null;
-                return int_val.toUnsignedInt();
+                return @intCast(usize, int_val.toUnsignedInt());
             }
         };
         switch (ty.tag()) {


### PR DESCRIPTION
I think most (if not all) of these `@intCast`s should be safe as there are checks guarding them.