### PR TITLE
stop tokenizer from recognizing lone `@` or `@` followed by a digit as a builtin

### DIFF
--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -568,11 +568,13 @@ pub const Tokenizer = struct {
                         result.tag = .identifier;
                         state = .string_literal;
                     },
-                    else => {
-                        // reinterpret as a builtin
-                        self.index -= 1;
+                    'a'...'z', 'A'...'Z', '_' => {
                         state = .builtin;
                         result.tag = .builtin;
+                    },
+                    else => {
+                        result.tag = .invalid;
+                        break;
                     },
                 },
 
@@ -2051,6 +2053,11 @@ test "tokenizer - number literals hexadecimal" {
 
 test "tokenizer - multi line string literal with only 1 backslash" {
     try testTokenize("x \\\n;", &.{ .identifier, .invalid, .semicolon });
+}
+
+test "tokenizer - invalid builtin identifiers" {
+    try testTokenize("@()", &.{ .invalid, .l_paren, .r_paren });
+    try testTokenize("@0()", &.{ .invalid, .integer_literal, .l_paren, .r_paren });
 }
 
 fn testTokenize(source: []const u8, expected_tokens: []const Token.Tag) !void {


### PR DESCRIPTION
When `Tokenizer.next()` is in the `.saw_at_sign` state, any character other than `"` will set `result.tag` to `.builtin` and then move to the `.builtin` state, which will always produce a valid token when a non-indentifier character is seen. Thus a lone `@` is recognized as a `.builtin` token, as are builtins that would start with a number, like `@0`. This is contrary to the formal grammar (which says `BUILTINIDENTIFIER <- "@"[A-Za-z_][A-Za-z0-9_]* skip`) and I believe to how the stage1 tokenizer works (which sees a builtin as a `TokenIdAtSign` followed by a `TokenIdSymbol`).
