### PR TITLE
Json Stringify option to not write out null optional fields

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -2998,3 +2998,11 @@ test "stringify struct with custom stringifier" {
 test "stringify vector" {
     try teststringify("[1,1]", @splat(2, @as(u32, 1)), StringifyOptions{});
 }
+
+test "stringify null optional fields" {
+    const MyStruct = struct {
+        optional: ?[]const u8 = null,
+    };
+    try teststringify("{\"optional\":null}", MyStruct{}, StringifyOptions{});
+    try teststringify("{}", MyStruct{}, StringifyOptions{ .string = .{ .String = .{ .write_null_optional_fields = false } } });
+}


### PR DESCRIPTION
Example usage:
```
const std = @import("std");

const Foo = struct {
    not_optional: []const u8 = "required",

    bar: struct {
        optional: ?[]const u8 = null,
    } = .{},
};

const writer = std.io.getStdOut().writer();

test "#1 stringify default (existing) behaviour" {
    try std.json.stringify(Foo{}, .{}, writer);
    try writer.writeAll("\n");
}

test "#2 stringify ignore nulls" {
    const options: std.json.StringifyOptions = .{ .string = .{ .String = .{ .write_null_optional_fields = false } } };
    try std.json.stringify(Foo{}, options, writer);
    try writer.writeAll("\n");
}

```

test 1 output: `{"not_optional":"required","bar":{"optional":null}}`

test 2 output: `{"not_optional":"required","bar":{}}`