### PR TITLE
zld: dylib paths need nul terminator included

### DIFF
--- a/src/link/MachO/commands.zig
+++ b/src/link/MachO/commands.zig
@@ -316,7 +316,7 @@ pub fn createLoadDylibCommand(
 ) !GenericCommandWithData(macho.dylib_command) {
     const cmdsize = @intCast(u32, mem.alignForwardGeneric(
         u64,
-        @sizeOf(macho.dylib_command) + name.len,
+        @sizeOf(macho.dylib_command) + name.len + 1, // +1 for nul
         @sizeOf(u64),
     ));
 


### PR DESCRIPTION
Otherwise, we'd sporadically hit a runtime error of `dyld: malformed mach-o image: dylib load command #14 string extends beyond end of load command`.