### PR TITLE
build: allow specifying rpaths explicitly

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1341,6 +1341,7 @@ pub const LibExeObjStep = struct {
     name_only_filename: []const u8,
     strip: bool,
     lib_paths: ArrayList([]const u8),
+    rpaths: ArrayList([]const u8),
     framework_dirs: ArrayList([]const u8),
     frameworks: BufSet,
     verbose_link: bool,
@@ -1536,6 +1537,7 @@ pub const LibExeObjStep = struct {
             .link_objects = ArrayList(LinkObject).init(builder.allocator),
             .c_macros = ArrayList([]const u8).init(builder.allocator),
             .lib_paths = ArrayList([]const u8).init(builder.allocator),
+            .rpaths = ArrayList([]const u8).init(builder.allocator),
             .framework_dirs = ArrayList([]const u8).init(builder.allocator),
             .object_src = undefined,
             .build_options_contents = std.ArrayList(u8).init(builder.allocator),
@@ -2072,6 +2074,10 @@ pub const LibExeObjStep = struct {
         self.lib_paths.append(self.builder.dupe(path)) catch unreachable;
     }
 
+    pub fn addRPath(self: *LibExeObjStep, path: []const u8) void {
+        self.rpaths.append(self.builder.dupe(path)) catch unreachable;
+    }
+
     pub fn addFrameworkDir(self: *LibExeObjStep, dir_path: []const u8) void {
         self.framework_dirs.append(self.builder.dupe(dir_path)) catch unreachable;
     }
@@ -2574,6 +2580,11 @@ pub const LibExeObjStep = struct {
         }
 
         if (self.target.isDarwin()) {
+            for (self.rpaths.items) |rpath| {
+                try zig_args.append("-rpath");
+                try zig_args.append(rpath);
+            }
+
             for (self.framework_dirs.items) |dir| {
                 try zig_args.append("-F");
                 try zig_args.append(dir);

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2574,17 +2574,17 @@ pub const LibExeObjStep = struct {
             try zig_args.append(lib_path);
         }
 
+        for (self.rpaths.items) |rpath| {
+            try zig_args.append("-rpath");
+            try zig_args.append(rpath);
+        }
+
         for (self.c_macros.items) |c_macro| {
             try zig_args.append("-D");
             try zig_args.append(c_macro);
         }
 
         if (self.target.isDarwin()) {
-            for (self.rpaths.items) |rpath| {
-                try zig_args.append("-rpath");
-                try zig_args.append(rpath);
-            }
-
             for (self.framework_dirs.items) |dir| {
                 try zig_args.append("-F");
                 try zig_args.append(dir);


### PR DESCRIPTION
It currently looks like that if the user links in a dylib using
`lib_or_exe.linkSystemLibrary`, and the linked lib doesn't have
a hardcoded path in its description load command but rather it
allows for any runtime path via `@rpath`, then it is not possible
to specify the runtime path explicitly using the build system.