### PR TITLE
stage1: Fix for atomicrmw xchg on fp types

### DIFF
--- a/test/behavior/atomics.zig
+++ b/test/behavior/atomics.zig
@@ -149,11 +149,6 @@ fn testAtomicStore() !void {
 }
 
 test "atomicrmw with floats" {
-    switch (builtin.target.cpu.arch) {
-        // https://github.com/ziglang/zig/issues/4457
-        .aarch64, .arm, .thumb, .riscv64 => return error.SkipZigTest,
-        else => {},
-    }
     try testAtomicRmwFloat();
     comptime try testAtomicRmwFloat();
 }


### PR DESCRIPTION
Bitcast the pointer and operands to integer types having the same size,
working around LLVM inability to lower a LL/SC operation when the
operands have floating-point types (and are reasonably sized).

Makes #8866 work without skipping many test cases. cc @kprotty
The corresponding LLVM patch is [here](https://reviews.llvm.org/D103232).

Closes #4457