### PR TITLE
Documentation TOC item color changed

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -133,7 +133,7 @@
             color: #bbb;
         }
         a {
-            color: #88f;
+            color: #f7a31d;
         }
         table, th, td {
             border-color: grey;


### PR DESCRIPTION
The motivation for this pull request is to set a less aggressive color for the items in the documentation's table of content (and other related anchors). After exploring the documentation for some time my eyes started hurting a bit with the current color.

The look I am proposing: 
![option_1](https://user-images.githubusercontent.com/457455/120031006-caf96c00-bfbd-11eb-8f55-31a3bc85bd3f.png)

It has a similar feel to that on the ziglearn page.

This is the current look for reference:
![original](https://user-images.githubusercontent.com/457455/120031115-f8deb080-bfbd-11eb-9475-92fbbcd67016.png)
