### PR TITLE
stage1: make `@truncate` to an integer type of different sign an error at comptime too

### DIFF
--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -27603,6 +27603,18 @@ static IrInstGen *ir_analyze_instruction_truncate(IrAnalyze *ira, IrInstSrcTrunc
         return ir_implicit_cast2(ira, &instruction->target->base, target, dest_type);
     }
 
+    if (src_type->id != ZigTypeIdComptimeInt) {
+        if (src_type->data.integral.is_signed != dest_type->data.integral.is_signed) {
+            const char *sign_str = dest_type->data.integral.is_signed ? "signed" : "unsigned";
+            ir_add_error(ira, &target->base, buf_sprintf("expected %s integer type, found '%s'", sign_str, buf_ptr(&src_type->name)));
+            return ira->codegen->invalid_inst_gen;
+        } else if (src_type->data.integral.bit_count > 0 && src_type->data.integral.bit_count < dest_type->data.integral.bit_count) {
+            ir_add_error(ira, &target->base, buf_sprintf("type '%s' has fewer bits than destination type '%s'",
+                        buf_ptr(&src_type->name), buf_ptr(&dest_type->name)));
+            return ira->codegen->invalid_inst_gen;
+        }
+    }
+
     if (instr_is_comptime(target)) {
         ZigValue *val = ir_resolve_const(ira, target, UndefBad);
         if (val == nullptr)
@@ -27618,16 +27630,6 @@ static IrInstGen *ir_analyze_instruction_truncate(IrAnalyze *ira, IrInstSrcTrunc
         IrInstGen *result = ir_const(ira, &instruction->base.base, dest_type);
         bigint_init_unsigned(&result->value->data.x_bigint, 0);
         return result;
-    }
-
-    if (src_type->data.integral.is_signed != dest_type->data.integral.is_signed) {
-        const char *sign_str = dest_type->data.integral.is_signed ? "signed" : "unsigned";
-        ir_add_error(ira, &target->base, buf_sprintf("expected %s integer type, found '%s'", sign_str, buf_ptr(&src_type->name)));
-        return ira->codegen->invalid_inst_gen;
-    } else if (src_type->data.integral.bit_count < dest_type->data.integral.bit_count) {
-        ir_add_error(ira, &target->base, buf_sprintf("type '%s' has fewer bits than destination type '%s'",
-                    buf_ptr(&src_type->name), buf_ptr(&dest_type->name)));
-        return ira->codegen->invalid_inst_gen;
     }
 
     return ir_build_truncate_gen(ira, &instruction->base.base, dest_type, target);

--- a/test/behavior/truncate.zig
+++ b/test/behavior/truncate.zig
@@ -24,13 +24,34 @@ test "truncate.u0.var" {
     try expect(z == 0);
 }
 
-test "truncate sign mismatch but comptime known so it works anyway" {
-    const x: u32 = 10;
-    var result = @truncate(i8, x);
-    try expect(result == 10);
+test "truncate i0 to larger integer allowed and has comptime known result" {
+    var x: i0 = 0;
+    const y = @truncate(i8, x);
+    comptime try expect(y == 0);
+}
+
+test "truncate.i0.literal" {
+    var z = @truncate(i0, 0);
+    try expect(z == 0);
+}
+
+test "truncate.i0.const" {
+    const c0: isize = 0;
+    var z = @truncate(i0, c0);
+    try expect(z == 0);
+}
+
+test "truncate.i0.var" {
+    var d: i8 = 2;
+    var z = @truncate(i0, d);
+    try expect(z == 0);
 }
 
 test "truncate on comptime integer" {
     var x = @truncate(u16, 9999);
     try expect(x == 9999);
+    var y = @truncate(u16, -21555);
+    try expect(y == 0xabcd);
+    var z = @truncate(i16, -65537);
+    try expect(z == -1);
 }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -6031,14 +6031,27 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     });
 
     cases.add("truncate sign mismatch",
-        \\fn f() i8 {
+        \\export fn entry1() i8 {
         \\    var x: u32 = 10;
         \\    return @truncate(i8, x);
         \\}
-        \\
-        \\export fn entry() usize { return @sizeOf(@TypeOf(f)); }
+        \\export fn entry2() u8 {
+        \\    var x: i32 = -10;
+        \\    return @truncate(u8, x);
+        \\}
+        \\export fn entry3() i8 {
+        \\    comptime var x: u32 = 10;
+        \\    return @truncate(i8, x);
+        \\}
+        \\export fn entry4() u8 {
+        \\    comptime var x: i32 = -10;
+        \\    return @truncate(u8, x);
+        \\}
     , &[_][]const u8{
         "tmp.zig:3:26: error: expected signed integer type, found 'u32'",
+        "tmp.zig:7:26: error: expected unsigned integer type, found 'i32'",
+        "tmp.zig:11:26: error: expected signed integer type, found 'u32'",
+        "tmp.zig:15:26: error: expected unsigned integer type, found 'i32'",
     });
 
     cases.add("try in function with non error return type",


### PR DESCRIPTION
This fixes https://github.com/ziglang/zig/issues/8931 by moving the checks for matching signedness and for having at least as many bits as the destination type in `ir_analyze_instruction_truncate` to above the early exit for comptime known values. This preserves two other behaviors that however may not be desired:

- Though `@truncate` from a smaller to a larger type is usually an error, an exception is made for 0-bit integers. This was explicitly tested for `u0` in test/behavior/truncate.zig. I added tests for `i0` as well.

- Because a `comptime_int` has no bit-size or innate signedness, truncations are always allowed, to all integer types. This means `@truncate(u8, -257) == 255`, for example. To make this error, a sign check could be added to the special case for comptime known values.

I also removed a test that expected sign mismatch to work at comptime and added new cases to tests/compile_errors.zig for sign mismatch.