### PR TITLE
build: rename ast_render in build.zig.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -741,7 +741,7 @@ const softfloat_sources = [_][]const u8{
 
 const stage1_sources = [_][]const u8{
     "src/stage1/analyze.cpp",
-    "src/stage1/ast_render.cpp",
+    "src/stage1/astgen.cpp",
     "src/stage1/bigfloat.cpp",
     "src/stage1/bigint.cpp",
     "src/stage1/buffer.cpp",


### PR DESCRIPTION
https://github.com/ziglang/zig/commit/2a990d69669c2a2cd16134e8ebbd2750060f8071#diff-987559377503ef031326fafa907b2d2dc36145acb4e2d95f3e8a70df88ba51e5 removed `ast_render.cpp` but build.zig still refers to this file, so it results in FileNotFound in the stage1 build with a prebuilt binary build. 

```
zig build -Dstage1 --search-prefix ....
/home/mathetake/zig/src/stage1/ast_render.cpp:1:1: error: unable to build C object: unable to build C object: FileNotFound
```