### PR TITLE
parse.zig: make `parseParamDeclList` check for nonfinal varargs

### DIFF
--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -297,6 +297,9 @@ pub const Tree = struct {
             .unattached_doc_comment => {
                 return stream.writeAll("unattached documentation comment");
             },
+            .varargs_nonfinal => {
+                return stream.writeAll("function prototype has parameter after varargs");
+            },
 
             .expected_token => {
                 const found_tag = token_tags[parse_error.token];
@@ -2414,6 +2417,7 @@ pub const Error = struct {
         invalid_token,
         same_line_doc_comment,
         unattached_doc_comment,
+        varargs_nonfinal,
 
         /// `expected_tag` is populated.
         expected_token,

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5164,6 +5164,18 @@ test "recovery: missing while rbrace" {
     });
 }
 
+test "recovery: nonfinal varargs" {
+    try testError(
+        \\extern fn f(a: u32, ..., b: u32) void;
+        \\extern fn g(a: u32, ..., b: anytype) void;
+        \\extern fn h(a: u32, ..., ...) void;
+    , &[_]Error{
+        .varargs_nonfinal,
+        .varargs_nonfinal,
+        .varargs_nonfinal,
+    });
+}
+
 const std = @import("std");
 const mem = std.mem;
 const print = std.debug.print;


### PR DESCRIPTION
The stage1 parser, in `ast_parse_fn_proto`, checks a fully parsed function prototype for arguments following the variadic ellipsis and reports an error if any are found. The zig parser currently does not. For example, the following all parse without error:

```
var tree = try std.zig.parse(std.testing.allocator, 
    \\extern fn f(a: u32, ..., b: u32) void;
    \\extern fn g(a: u32, ..., b: anytype) void;
    \\extern fn h(a: u32, ..., ...) void;
);
std.debug.assert(tree.errors.len == 0);
```

No check can be easily added to `parseFnProto` because `...` and `anytype` parameters are not explicitly represented in the AST. The test must be added to `parseParamDeclList` instead, but this is complicated somewhat by its current implementation. Essentially the same parsing logic is repeated three times, for the first, second, and then remaining parameters. This would avoid temporary allocations for small parameter lists, but with https://github.com/ziglang/zig/pull/8910, I think this is now an unnecessary optimization. Hence, I've split this PR into two commits. 

The first commit simplifies `parseParamDeclList`: by always using the scratch buffer, there is a single loop where the parsing and collection of parameters is done, and all returns are gathered in one place at the end of the function. Like with the scratch buffer changes, I tested this by parsing all valid zig files in this repo, with and without this change, and checked that the resulting trees were identical. With this, the second commit to add a test for nonfinal varargs is much simpler. It also adds a new value to `ast.Error.Tag` and a test to check that nonfinal varargs are reported.

Additionally, nonfinal varargs could be disallowed in the formal grammar by moving `DOT3` out of `ParamDecl` and to the end of `ParamDeclList` as an optional suffix.

I've also noticed other parsing functions that have duplicated logic to handle small parameter lists and which could be simplified the same way as `parseParamDeclList`. Would this be something worth doing for its own sake?


