### PR TITLE
test: re-enable "float widening f16 to f128"

### DIFF
--- a/test/behavior/widening.zig
+++ b/test/behavior/widening.zig
@@ -29,10 +29,6 @@ test "float widening" {
 }
 
 test "float widening f16 to f128" {
-    // TODO https://github.com/ziglang/zig/issues/3282
-    if (@import("builtin").target.cpu.arch == .aarch64) return error.SkipZigTest;
-    if (@import("builtin").target.cpu.arch == .powerpc64le) return error.SkipZigTest;
-
     var x: f16 = 12.34;
     var y: f128 = x;
     try expect(x == y);


### PR DESCRIPTION
- test no longer trips llvm assert for aarch64 and powerpc64le
- unclear which version of llvm fixed issue but 12.0.0 works

closes #3282