### PR TITLE
std.json: support field aliases

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1727,6 +1727,12 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
             if (options.field_aliases.len > field_names.len) return error.TooManyFieldAliases;
             var field_alias_map = buildFieldAliasMap(field_names, options, &list_data);
 
+            // re-index the alias map.  this is a no-op unless there are more than
+            // ArrayHashMap.linear_scan_max (8) entries.
+            var buf: [if (field_names.len > 8) field_names.len * 9 else 0]u8 = undefined;
+            var fba = std.heap.FixedBufferAllocator.init(&buf);
+            try field_alias_map.reIndex(&fba.allocator);
+
             while (true) {
                 switch ((try tokens.next()) orelse return error.UnexpectedEndOfJson) {
                     .ObjectEnd => break,

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1466,6 +1466,7 @@ pub const ParseOptions = struct {
     ignore_unknown_fields: bool = false,
 
     allow_trailing_data: bool = false,
+    field_aliases: ?[]const [2][]const u8 = null,
 };
 
 fn skipValue(tokens: *TokenStream) !void {
@@ -1530,71 +1531,40 @@ test "skipValue" {
     }
 }
 
-// build a list of aliases.  entries are [2][]const u8{alias_name, target_field_name}
-fn buildFieldAliases(comptime T: type) []const [2][]const u8 {
-    const tags_decl_name = "__tags";
-    const alias_field_name = "alias";
-    // look for `pub const __tags` decl in T
-    comptime {
-        const ti = @typeInfo(T);
-        const tags = if ((ti == .Struct or ti == .Union or ti == .Enum) and
-            @hasDecl(T, tags_decl_name) and
-            std.meta.declarationInfo(T, tags_decl_name).is_pub)
-            @field(T, tags_decl_name)
-        else
-            return &.{};
-
-        var result: []const [2][]const u8 = &.{};
-        const field_names = std.meta.fieldNames(T);
-        for (std.meta.fieldNames(@TypeOf(tags))) |tags_field_name| {
-            // check if tag field name matches a field name from T
-            // have to use a function rather than for loop to work around a compiler bug
-            const found = std.mem.indexOfSliceScalar([]const u8, field_names, tags_field_name) != null;
-            if (found) {
-                const tag_member = @field(tags, tags_field_name);
-                // if the tag_member has an alias field, append this alias, target pair to result
-                if (@hasField(@TypeOf(tag_member), alias_field_name)) {
-                    result = result ++ [1][2][]const u8{.{ @field(tag_member, alias_field_name), tags_field_name }};
-                }
+// build a map of aliases from alias_name => target_field_name
+fn buildFieldAliases(comptime T: type, options: ParseOptions) !std.StringHashMapUnmanaged([]const u8) {
+    const field_aliases = options.field_aliases;
+    var result = std.StringHashMapUnmanaged([]const u8){};
+    const alias_entries = field_aliases orelse return result;
+    inline for (comptime std.meta.fieldNames(T)) |field_name| {
+        for (alias_entries) |entry| {
+            if (std.mem.eql(u8, field_name, entry[0])) {
+                const allocator = options.allocator orelse return error.AllocatorRequired;
+                try result.put(allocator, entry[1], entry[0]);
             }
         }
-        return result;
     }
+    return result;
 }
 
-fn findFieldAlias(field_aliases: []const [2][]const u8, field_name: []const u8) []const u8 {
-    for (field_aliases) |alias_pair| {
-        if (std.mem.eql(u8, alias_pair[0], field_name)) return alias_pair[1];
-    }
-    return field_name;
-}
-
-test "fieldAliases" {
+test "field aliases" {
     const S = struct {
         value: u8,
-        pub const __tags = .{
-            .value = .{ .alias = "__value" },
-        };
     };
     const text =
         \\{"__value": 42}
     ;
-    const s = try parse(S, &TokenStream.init(text), .{});
+
+    try testing.expectError(
+        error.AllocatorRequired,
+        parse(S, &TokenStream.init(text), .{ .field_aliases = &.{.{ "value", "__value" }} }),
+    );
+
+    const s = try parse(S, &TokenStream.init(text), .{
+        .field_aliases = &.{.{ "value", "__value" }},
+        .allocator = std.testing.allocator,
+    });
     try testing.expectEqual(@as(u8, 42), s.value);
-}
-
-test "fieldAliases __tags missing pub" {
-    const S = struct {
-        value: u8,
-        // missing pub
-        const __tags = .{
-            .value = .{ .alias = "__value" },
-        };
-    };
-    const text =
-        \\{"__value": 42}
-    ;
-    try std.testing.expectError(error.UnknownField, parse(S, &TokenStream.init(text), .{}));
 }
 
 fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: ParseOptions) !T {
@@ -1691,16 +1661,15 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
                 }
             }
 
-            comptime const field_aliases = buildFieldAliases(T);
+            var field_alias_map = try buildFieldAliases(T, options);
+            defer if (options.allocator) |allocator| field_alias_map.deinit(allocator);
 
             while (true) {
                 switch ((try tokens.next()) orelse return error.UnexpectedEndOfJson) {
                     .ObjectEnd => break,
                     .String => |stringToken| {
-                        const key_source_slice = findFieldAlias(
-                            field_aliases,
-                            stringToken.slice(tokens.slice, tokens.i - 1),
-                        );
+                        const key_source_slice_orig = stringToken.slice(tokens.slice, tokens.i - 1);
+                        const key_source_slice = field_alias_map.get(key_source_slice_orig) orelse key_source_slice_orig;
                         var child_options = options;
                         child_options.allow_trailing_data = true;
                         var found = false;

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1567,6 +1567,18 @@ test "field aliases" {
     try testing.expectEqual(@as(u8, 42), s.value);
 }
 
+test "field alias escapes" {
+    const S = struct { foo: u8 };
+    const text =
+        "{\"__f\x6fo\": 42}";
+
+    const s = try parse(S, &TokenStream.init(text), .{
+        .field_aliases = &.{.{ "foo", "__foo" }},
+        .allocator = std.testing.allocator,
+    });
+    try testing.expectEqual(@as(u8, 42), s.foo);
+}
+
 fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: ParseOptions) !T {
     switch (@typeInfo(T)) {
         .Bool => {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1063,6 +1063,20 @@ pub fn indexOfPosLinear(comptime T: type, haystack: []const T, start_index: usiz
     return null;
 }
 
+/// Linear search for the index of a scalar slice value inside a slice of slices.
+pub fn indexOfSliceScalar(comptime Slice: type, haystack: []const Slice, needle: Slice) ?usize {
+    return indexOfSliceScalarPos(Slice, haystack, 0, needle);
+}
+/// Linear search for the index of a scalar slice value inside a slice of slices starting from start_index.
+/// Uses std.mem.eql to check for equality.
+pub fn indexOfSliceScalarPos(comptime Slice: type, haystack: []const Slice, start_index: usize, needle: Slice) ?usize {
+    var i: usize = start_index;
+    while (i < haystack.len) : (i += 1) {
+        if (std.mem.eql(std.meta.Child(Slice), haystack[i], needle)) return i;
+    }
+    return null;
+}
+
 fn boyerMooreHorspoolPreprocessReverse(pattern: []const u8, table: *[256]usize) void {
     for (table) |*c| {
         c.* = pattern.len;

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1063,20 +1063,6 @@ pub fn indexOfPosLinear(comptime T: type, haystack: []const T, start_index: usiz
     return null;
 }
 
-/// Linear search for the index of a scalar slice value inside a slice of slices.
-pub fn indexOfSliceScalar(comptime Slice: type, haystack: []const Slice, needle: Slice) ?usize {
-    return indexOfSliceScalarPos(Slice, haystack, 0, needle);
-}
-/// Linear search for the index of a scalar slice value inside a slice of slices starting from start_index.
-/// Uses std.mem.eql to check for equality.
-pub fn indexOfSliceScalarPos(comptime Slice: type, haystack: []const Slice, start_index: usize, needle: Slice) ?usize {
-    var i: usize = start_index;
-    while (i < haystack.len) : (i += 1) {
-        if (std.mem.eql(std.meta.Child(Slice), haystack[i], needle)) return i;
-    }
-    return null;
-}
-
 fn boyerMooreHorspoolPreprocessReverse(pattern: []const u8, table: *[256]usize) void {
     for (table) |*c| {
         c.* = pattern.len;


### PR DESCRIPTION
- if a struct T passed to `parse(T, ...)` contains a `pub const __tags` of the form
  shown below, these aliases will be used as the json keys instead of the
  field name.
- adds `std.mem.{indexOfSliceScalar, indexOfSliceScalarPos}` which support
  finding aliases. adding these was my workaround to a compiler bug
  encountered when using a for loop for the same purpose.

```zig
    const S = struct {
        value: u8,
        pub const __tags = .{
            .value = .{ .alias = "__value" },
        };
    };
```

The names `__tags` and `alias` were chosen by me ad-hoc and may be easily
changed.
Inspired by #1099 https://github.com/ziglang/zig/issues/1099#issuecomment-846404132