### PR TITLE
compiler-rt: Fix __floatunsitf signature

### DIFF
--- a/lib/std/special/compiler_rt/floatunsitf.zig
+++ b/lib/std/special/compiler_rt/floatunsitf.zig
@@ -7,7 +7,7 @@ const builtin = @import("builtin");
 const is_test = builtin.is_test;
 const std = @import("std");
 
-pub fn __floatunsitf(a: u64) callconv(.C) f128 {
+pub fn __floatunsitf(a: u32) callconv(.C) f128 {
     @setRuntimeSafety(is_test);
 
     if (a == 0) {
@@ -19,7 +19,7 @@ pub fn __floatunsitf(a: u64) callconv(.C) f128 {
     const exponent_bias = (1 << (exponent_bits - 1)) - 1;
     const implicit_bit = 1 << mantissa_bits;
 
-    const exp = (64 - 1) - @clz(u64, a);
+    const exp = (32 - 1) - @clz(u32, a);
     const shift = mantissa_bits - @intCast(u7, exp);
 
     // TODO(#1148): @bitCast alignment error

--- a/lib/std/special/compiler_rt/floatunsitf_test.zig
+++ b/lib/std/special/compiler_rt/floatunsitf_test.zig
@@ -5,7 +5,7 @@
 // and substantial portions of the software.
 const __floatunsitf = @import("floatunsitf.zig").__floatunsitf;
 
-fn test__floatunsitf(a: u64, expected_hi: u64, expected_lo: u64) !void {
+fn test__floatunsitf(a: u32, expected_hi: u64, expected_lo: u64) !void {
     const x = __floatunsitf(a);
 
     const x_repr = @bitCast(u128, x);


### PR DESCRIPTION
The function transforms an unsigned integer into a f128.

Closes #8996