### PR TITLE
test: re-enable dragonfly tests

### DIFF
--- a/test/behavior/byteswap.zig
+++ b/test/behavior/byteswap.zig
@@ -39,9 +39,6 @@ test "@byteSwap integers" {
 }
 
 test "@byteSwap vectors" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (std.Target.current.os.tag == .dragonfly) return error.SkipZigTest;
-
     // https://github.com/ziglang/zig/issues/3317
     if (std.Target.current.cpu.arch == .mipsel or std.Target.current.cpu.arch == .mips) return error.SkipZigTest;
 

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -116,9 +116,6 @@ test "array to vector" {
 }
 
 test "vector casts of sizes not divisable by 8" {
-    // https://github.com/ziglang/zig/issues/3563
-    if (std.Target.current.os.tag == .dragonfly) return error.SkipZigTest;
-
     const S = struct {
         fn doTheTest() !void {
             {


### PR DESCRIPTION
Tests with LLVM assertions enabled are no longer failing.

closes #3563