### PR TITLE
stage1: fix render_const_value for printing const optional pointers

### DIFF
--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -7588,8 +7588,16 @@ void render_const_value(CodeGen *g, Buf *buf, ZigValue *const_val) {
             }
         case ZigTypeIdOptional:
             {
-                if (get_src_ptr_type(const_val->type) != nullptr)
+                ZigType *src_ptr_type = get_src_ptr_type(const_val->type);
+                if (src_ptr_type != nullptr) {
+                    if (src_ptr_type->id == ZigTypeIdPointer && !optional_value_is_null(const_val)) {
+                        ZigValue tmp = {};
+                        copy_const_val(g, &tmp, const_val);
+                        tmp.type = type_entry->data.maybe.child_type;
+                        return render_const_val_ptr(g, buf, &tmp, tmp.type);
+                    }
                     return render_const_val_ptr(g, buf, const_val, type_entry->data.maybe.child_type);
+                }
                 if (type_entry->data.maybe.child_type->id == ZigTypeIdErrorSet)
                     return render_const_val_err_set(g, buf, const_val, type_entry->data.maybe.child_type);
                 if (const_val->data.x_optional) {


### PR DESCRIPTION
Currently, using `--verbose-ir` with the stage1 compiler is likely to fail (if not building freestanding) with an "Assertion failed at E:\ZZZ\zig\src\stage1\ir.cpp:2587 in const_ptr_pointee. This is a bug in the Zig compiler." This happens when printing the generated ir for this line in debug.zig:

```
debug_info_allocator = &debug_info_arena_allocator.allocator;
```

`debug_info_allocator` is an `?*std.mem.Allocator` and `debug_info_arena_allocator` is a top-level variable, so the value of this assignment is a comptime known optional pointer. When printing the GenConst instruction for `--verbose-ir`, eventually `render_const_value` is called on this value. Because comptime known optional pointers have the same data layout as comptime pointers, the value is passed to `render_const_value_ptr`. For some types of pointers, like `ConstPtrSpecialRef` or `ConstPtrSpecialBaseStruct`, a recursive call is made with the result of `const_ptr_pointee`. However, `const_ptr_pointee` asserts that the type id of the const value it accepts is exactly `ZigTypeIdPointer`, hence the message that an assertion failed.

There are at least two ways to fix this. First, because the intent seems to be that `const_ptr_pointee` and the variants it calls should also accept const optional pointers, these functions could be modified. `const_ptr_pointee_unchecked`, for example, already doesn't directly assert the type id is `ZigTypeIdPointer` but instead asserts that `get_src_ptr_type` doesn't return nullptr. That return type could be saved and used in place of almost all other references to `const_val->type` (the exception would be the call to `type_has_one_possible_value`, which should not be done for optional pointers or it would erroneously recognize types like `?*u0` as having only one possible value). However, these are widely used functions. I checked all call sites and found that they either first explicitly tested that the const value used as an argument to `const_ptr_pointee` was a pointer, or else had cast or constructed the const value directly as a pointer. Nonetheless, there may be unintended consequences. I didn't find any building stage1 from stage0 or running test-std or test-behavior, but I'm not familiar enough with stage1 to be sure.

The other fix and what this commit does is somewhat of a hack. When `render_const_value` wants to use to `render_const_value_ptr` on a non-null optional pointer, it makes a temporary copy with `copy_const_val` and simply changes its type to the optional's child type. Then `render_const_value_ptr` and all the `const_ptr_pointee` functions can be used unchanged. 

While this is meant to fix the `--verbose-ir` flag, it is possible to trigger the same bug without it. For example, using compile time logging like

```
const thing: u32 = 10;
const arrow: ?*const u32 = &thing;
@compileLog(arrow);
```

will hit the same code path outlined above, as will any very weird and unlikely code that tries to use a non-null optional pointer as a sentinel, like

```
comptime var a: u32 = 10;
const x: ?*u32 = &a;
var z: [*:x]?*u32 = undefined;
```

The compiler panics here while trying to print the sentinel when constructing a name for the type of `z`.
