### PR TITLE
Add zig_llvm-ar.cpp in build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -769,6 +769,7 @@ const zig_cpp_sources = [_][]const u8{
     // These are planned to stay even when we are self-hosted.
     "src/zig_llvm.cpp",
     "src/zig_clang.cpp",
+    "src/zig_llvm-ar.cpp",
     "src/zig_clang_driver.cpp",
     "src/zig_clang_cc1_main.cpp",
     "src/zig_clang_cc1as_main.cpp",


### PR DESCRIPTION
zig_llvm-ar.cpp was added to the cmake file in 0afb5b2ec6de494efe0605b2270f6a01b95237af 8 days ago, but it seems it was not added in build.zig

I got this error when following [the Building Zig on Windows instructions](https://github.com/ziglang/zig/wiki/Building-Zig-on-Windows#option-1-use-the-windows-zig-compiler-dev-kit):

```
lld-link: error: undefined symbol: ZigLlvmAr_main
```

This patch fixes it