### PR TITLE
openbsd: adjust dynamic linker path

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1487,7 +1487,7 @@ pub const Target = struct {
         switch (self.os.tag) {
             .freebsd => return copy(&result, "/libexec/ld-elf.so.1"),
             .netbsd => return copy(&result, "/libexec/ld.elf_so"),
-            .openbsd => return copy(&result, "/libexec/ld.so"),
+            .openbsd => return copy(&result, "/usr/libexec/ld.so"),
             .dragonfly => return copy(&result, "/libexec/ld-elf.so.2"),
             .linux => switch (self.cpu.arch) {
                 .i386,


### PR DESCRIPTION
the dynamic linker on OpenBSD is at `/usr/libexec/ld.so` (and not `/libexec/ld.so`)

with this patch, I am able to crosscompile from x86_64-openbsd to i386-openbsd (using a libc file)