### PR TITLE
stage1: Allow array-like initialization for tuple types

### DIFF
--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -16694,7 +16694,7 @@ static IrInstGen *ir_analyze_instruction_container_init_list(IrAnalyze *ira,
     {
         // We're now done inferring the type.
         container_type->data.structure.resolve_status = ResolveStatusUnstarted;
-    } else if (container_type->id == ZigTypeIdVector) {
+    } else if (container_type->id == ZigTypeIdVector || is_tuple(container_type)) {
         // OK
     } else {
         ir_add_error(ira, &instruction->base.base,

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -111,3 +111,39 @@ test "tuple initializer for var" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "array-like initializer for tuple types" {
+    const T = @Type(std.builtin.TypeInfo{
+        .Struct = std.builtin.TypeInfo.Struct{
+            .is_tuple = true,
+            .layout = .Auto,
+            .decls = &[_]std.builtin.TypeInfo.Declaration{},
+            .fields = &[_]std.builtin.TypeInfo.StructField{
+                .{
+                    .name = "0",
+                    .field_type = i32,
+                    .default_value = @as(?i32, null),
+                    .is_comptime = false,
+                    .alignment = @alignOf(i32),
+                },
+                .{
+                    .name = "1",
+                    .field_type = u8,
+                    .default_value = @as(?i32, null),
+                    .is_comptime = false,
+                    .alignment = @alignOf(i32),
+                },
+            },
+        },
+    });
+    const S = struct {
+        fn doTheTest() !void {
+            var obj: T = .{ -1234, 128 };
+            try testing.expectEqual(@as(i32, -1234), obj[0]);
+            try testing.expectEqual(@as(u8, 128), obj[1]);
+        }
+    };
+
+    try S.doTheTest();
+    comptime try S.doTheTest();
+}


### PR DESCRIPTION
This small change makes working with tuple types much easier, allowing
the use of anonymous (eg. obtained with meta.ArgsTuple) tuples in more
places without the need for specifying each (quoted!) field name in the
initializer.