### PR TITLE
Changed return values of SectionHeaderIterator().next() to bswapAllFields()

### DIFF
--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -459,6 +459,8 @@ pub fn ProgramHeaderIterator(ParseSource: anytype) type {
     };
 }
 
+
+
 pub fn SectionHeaderIterator(ParseSource: anytype) type {
     return struct {
         elf_header: Header,
@@ -479,18 +481,8 @@ pub fn SectionHeaderIterator(ParseSource: anytype) type {
                 if (self.elf_header.endian == native_endian) return shdr;
 
                 // Convert fields to native endianness.
-                return Elf64_Shdr{
-                    .sh_name = @byteSwap(@TypeOf(shdr.sh_name), shdr.sh_name),
-                    .sh_type = @byteSwap(@TypeOf(shdr.sh_type), shdr.sh_type),
-                    .sh_flags = @byteSwap(@TypeOf(shdr.sh_flags), shdr.sh_flags),
-                    .sh_addr = @byteSwap(@TypeOf(shdr.sh_addr), shdr.sh_addr),
-                    .sh_offset = @byteSwap(@TypeOf(shdr.sh_offset), shdr.sh_offset),
-                    .sh_size = @byteSwap(@TypeOf(shdr.sh_size), shdr.sh_size),
-                    .sh_link = @byteSwap(@TypeOf(shdr.sh_link), shdr.sh_link),
-                    .sh_info = @byteSwap(@TypeOf(shdr.sh_info), shdr.sh_info),
-                    .sh_addralign = @byteSwap(@TypeOf(shdr.sh_addralign), shdr.sh_addralign),
-                    .sh_entsize = @byteSwap(@TypeOf(shdr.sh_entsize), shdr.sh_entsize),
-                };
+                bswapAllFields(Elf64_Shdr, &shdr);
+
             }
 
             var shdr: Elf32_Shdr = undefined;
@@ -501,18 +493,7 @@ pub fn SectionHeaderIterator(ParseSource: anytype) type {
             // ELF endianness does NOT match native endianness.
             if (self.elf_header.endian != native_endian) {
                 // Convert fields to native endianness.
-                shdr = .{
-                    .sh_name = @byteSwap(@TypeOf(shdr.sh_name), shdr.sh_name),
-                    .sh_type = @byteSwap(@TypeOf(shdr.sh_type), shdr.sh_type),
-                    .sh_flags = @byteSwap(@TypeOf(shdr.sh_flags), shdr.sh_flags),
-                    .sh_addr = @byteSwap(@TypeOf(shdr.sh_addr), shdr.sh_addr),
-                    .sh_offset = @byteSwap(@TypeOf(shdr.sh_offset), shdr.sh_offset),
-                    .sh_size = @byteSwap(@TypeOf(shdr.sh_size), shdr.sh_size),
-                    .sh_link = @byteSwap(@TypeOf(shdr.sh_link), shdr.sh_link),
-                    .sh_info = @byteSwap(@TypeOf(shdr.sh_info), shdr.sh_info),
-                    .sh_addralign = @byteSwap(@TypeOf(shdr.sh_addralign), shdr.sh_addralign),
-                    .sh_entsize = @byteSwap(@TypeOf(shdr.sh_entsize), shdr.sh_entsize),
-                };
+                bswapAllFields(Elf32_Shdr, &shdr);
             }
 
             // Convert 32-bit header to 64-bit.
@@ -531,6 +512,7 @@ pub fn SectionHeaderIterator(ParseSource: anytype) type {
         }
     };
 }
+
 
 pub fn int(is_64: bool, need_bswap: bool, int_32: anytype, int_64: anytype) @TypeOf(int_64) {
     if (is_64) {

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -459,8 +459,6 @@ pub fn ProgramHeaderIterator(ParseSource: anytype) type {
     };
 }
 
-
-
 pub fn SectionHeaderIterator(ParseSource: anytype) type {
     return struct {
         elf_header: Header,
@@ -482,7 +480,6 @@ pub fn SectionHeaderIterator(ParseSource: anytype) type {
 
                 // Convert fields to native endianness.
                 bswapAllFields(Elf64_Shdr, &shdr);
-
             }
 
             var shdr: Elf32_Shdr = undefined;
@@ -512,7 +509,6 @@ pub fn SectionHeaderIterator(ParseSource: anytype) type {
         }
     };
 }
-
 
 pub fn int(is_64: bool, need_bswap: bool, int_32: anytype, int_64: anytype) @TypeOf(int_64) {
     if (is_64) {

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -479,7 +479,7 @@ pub fn SectionHeaderIterator(ParseSource: anytype) type {
                 if (self.elf_header.endian == native_endian) return shdr;
 
                 // Convert fields to native endianness.
-                bswapAllFields(Elf64_Shdr, &shdr);
+                return bswapAllFields(Elf64_Shdr, &shdr);
             }
 
             var shdr: Elf32_Shdr = undefined;

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -479,7 +479,8 @@ pub fn SectionHeaderIterator(ParseSource: anytype) type {
                 if (self.elf_header.endian == native_endian) return shdr;
 
                 // Convert fields to native endianness.
-                return bswapAllFields(Elf64_Shdr, &shdr);
+                bswapAllFields(Elf64_Shdr, &shdr);
+                return shdr;
             }
 
             var shdr: Elf32_Shdr = undefined;


### PR DESCRIPTION
SectionHeaderIterator().next() now uses bswapAllFields()