### PR TITLE
std.os: (p)writev should perform partial writes if iov.len > IOV_MAX

### DIFF
--- a/lib/std/os/bits/darwin.zig
+++ b/lib/std/os/bits/darwin.zig
@@ -235,6 +235,7 @@ pub const host_t = mach_port_t;
 pub const CALENDAR_CLOCK = 1;
 
 pub const PATH_MAX = 1024;
+pub const IOV_MAX = 16;
 
 pub const STDIN_FILENO = 0;
 pub const STDOUT_FILENO = 1;

--- a/lib/std/os/bits/dragonfly.zig
+++ b/lib/std/os/bits/dragonfly.zig
@@ -168,6 +168,7 @@ pub const SA_NOCLDWAIT = 0x0020;
 pub const SA_SIGINFO = 0x0040;
 
 pub const PATH_MAX = 1024;
+pub const IOV_MAX = KERN_IOV_MAX;
 
 pub const ino_t = c_ulong;
 

--- a/lib/std/os/bits/freebsd.zig
+++ b/lib/std/os/bits/freebsd.zig
@@ -238,8 +238,10 @@ pub const CTL_DEBUG = 5;
 
 pub const KERN_PROC = 14; // struct: process entries
 pub const KERN_PROC_PATHNAME = 12; // path to executable
+pub const KERN_IOV_MAX = 35;
 
 pub const PATH_MAX = 1024;
+pub const IOV_MAX = KERN_IOV_MAX;
 
 pub const STDIN_FILENO = 0;
 pub const STDOUT_FILENO = 1;

--- a/lib/std/os/bits/netbsd.zig
+++ b/lib/std/os/bits/netbsd.zig
@@ -405,8 +405,10 @@ pub const CTL_DEBUG = 5;
 
 pub const KERN_PROC_ARGS = 48; // struct: process argv/env
 pub const KERN_PROC_PATHNAME = 5; // path to executable
+pub const KERN_IOV_MAX = 38;
 
 pub const PATH_MAX = 1024;
+pub const IOV_MAX = KERN_IOV_MAX;
 
 pub const STDIN_FILENO = 0;
 pub const STDOUT_FILENO = 1;

--- a/lib/std/os/bits/wasi.zig
+++ b/lib/std/os/bits/wasi.zig
@@ -76,6 +76,8 @@ pub const kernel_stat = struct {
     }
 };
 
+pub const IOV_MAX = 1024;
+
 pub const AT_REMOVEDIR: u32 = 0x4;
 pub const AT_FDCWD: fd_t = -2;
 


### PR DESCRIPTION
@g-w1 ran into an issue where `pwritevAll` failed with EINVAL when passed more iovecs than `IOV_MAX`.

We may need to track down `IOV_MAX` values for more OS-es before this is mergable