### PR TITLE
specify the output lib directory with a flag

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -190,7 +190,7 @@ pub const Builder = struct {
     }
 
     /// This function is intended to be called by std/special/build_runner.zig, not a build.zig file.
-    pub fn resolveInstallPrefix(self: *Builder, install_prefix: ?[]const u8) void {
+    pub fn resolveInstallPrefix(self: *Builder, install_prefix: ?[]const u8, lib_dir: ?[]const u8) void {
         if (self.dest_dir) |dest_dir| {
             self.install_prefix = install_prefix orelse "/usr";
             self.install_path = fs.path.join(self.allocator, &[_][]const u8{ dest_dir, self.install_prefix }) catch unreachable;
@@ -199,7 +199,7 @@ pub const Builder = struct {
                 (fs.path.join(self.allocator, &[_][]const u8{ self.build_root, "zig-out" }) catch unreachable);
             self.install_path = self.install_prefix;
         }
-        self.lib_dir = fs.path.join(self.allocator, &[_][]const u8{ self.install_path, "lib" }) catch unreachable;
+        self.lib_dir = fs.path.join(self.allocator, &[_][]const u8{ self.install_path, lib_dir orelse "lib" }) catch unreachable;
         self.exe_dir = fs.path.join(self.allocator, &[_][]const u8{ self.install_path, "bin" }) catch unreachable;
         self.h_dir = fs.path.join(self.allocator, &[_][]const u8{ self.install_path, "include" }) catch unreachable;
     }

--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -61,6 +61,7 @@ pub fn main() !void {
     const stdout_stream = io.getStdOut().writer();
 
     var install_prefix: ?[]const u8 = null;
+    var lib_dir: ?[]const u8 = null;
     while (nextArg(args, &arg_idx)) |arg| {
         if (mem.startsWith(u8, arg, "-D")) {
             const option_contents = arg[2..];
@@ -84,6 +85,11 @@ pub fn main() !void {
                 return usage(builder, false, stdout_stream);
             } else if (mem.eql(u8, arg, "-p") or mem.eql(u8, arg, "--prefix")) {
                 install_prefix = nextArg(args, &arg_idx) orelse {
+                    warn("Expected argument after {s}\n\n", .{arg});
+                    return usageAndErr(builder, false, stderr_stream);
+                };
+            } else if (mem.eql(u8, arg, "--output-lib-dir")) {
+                lib_dir = nextArg(args, &arg_idx) orelse {
                     warn("Expected argument after {s}\n\n", .{arg});
                     return usageAndErr(builder, false, stderr_stream);
                 };
@@ -135,7 +141,7 @@ pub fn main() !void {
         }
     }
 
-    builder.resolveInstallPrefix(install_prefix);
+    builder.resolveInstallPrefix(install_prefix, lib_dir);
     try runBuild(builder);
 
     if (builder.validateUserInputDidItFail())
@@ -189,6 +195,7 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
         \\  -h, --help                  Print this help and exit
         \\  --verbose                   Print commands before executing them
         \\  -p, --prefix [path]         Override default install prefix
+        \\  --output-lib-dir [path]     Override default library directory name
         \\  --search-prefix [path]      Add a path to look for binaries, libraries, headers
         \\  --color [auto|off|on]       Enable or disable colored error messages
         \\


### PR DESCRIPTION
closes https://github.com/ziglang/zig/issues/9017

by default zig will output libraries into PREFIX/lib, which is a sane default because lib\<qual\> are optional, but this may create conflicts on system where PREFIX/lib is not for the native arch

the variable names, flag or help message might need changing to be more descriptive 