### PR TITLE
Add Linux XDP bits

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -30,6 +30,7 @@ pub usingnamespace switch (arch) {
 pub usingnamespace @import("linux/netlink.zig");
 pub usingnamespace @import("linux/prctl.zig");
 pub usingnamespace @import("linux/securebits.zig");
+pub usingnamespace @import("linux/xdp.zig");
 
 const is_mips = arch.isMIPS();
 const is_ppc = arch.isPPC();

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -408,7 +408,8 @@ pub const PF_VSOCK = 40;
 pub const PF_KCM = 41;
 pub const PF_QIPCRTR = 42;
 pub const PF_SMC = 43;
-pub const PF_MAX = 44;
+pub const PF_XDP = 44;
+pub const PF_MAX = 45;
 
 pub const AF_UNSPEC = PF_UNSPEC;
 pub const AF_LOCAL = PF_LOCAL;
@@ -457,6 +458,7 @@ pub const AF_VSOCK = PF_VSOCK;
 pub const AF_KCM = PF_KCM;
 pub const AF_QIPCRTR = PF_QIPCRTR;
 pub const AF_SMC = PF_SMC;
+pub const AF_XDP = PF_XDP;
 pub const AF_MAX = PF_MAX;
 
 pub usingnamespace if (is_mips)
@@ -601,6 +603,7 @@ pub const SOL_ALG = 279;
 pub const SOL_NFC = 280;
 pub const SOL_KCM = 281;
 pub const SOL_TLS = 282;
+pub const SOL_XDP = 283;
 
 pub const SOMAXCONN = 128;
 

--- a/lib/std/os/bits/linux/xdp.zig
+++ b/lib/std/os/bits/linux/xdp.zig
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2015-2021 Zig Contributors
+// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
+// The MIT license requires this copyright notice to be included in all copies
+// and substantial portions of the software.
+usingnamespace @import("../linux.zig");
+
+pub const XDP_SHARED_UMEM = (1 << 0);
+pub const XDP_COPY = (1 << 1);
+pub const XDP_ZEROCOPY = (1 << 2);
+
+pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG = (1 << 0);
+
+pub const sockaddr_xdp = extern struct {
+    family: u16 = AF_XDP,
+    flags: u16,
+    ifindex: u32,
+    queue_id: u32,
+    shared_umem_fd: u32,
+};
+
+pub const XDP_USE_NEED_WAKEUP = (1 << 3);
+
+pub const xdp_ring_offset = extern struct {
+    producer: u64,
+    consumer: u64,
+    desc: u64,
+    flags: u64,
+};
+
+pub const xdp_mmap_offsets = extern struct {
+    rx: xdp_ring_offset,
+    tx: xdp_ring_offset,
+    fr: xdp_ring_offset,
+    cr: xdp_ring_offset,
+};
+
+pub const XDP_MMAP_OFFSETS = 1;
+pub const XDP_RX_RING = 2;
+pub const XDP_TX_RING = 3;
+pub const XDP_UMEM_REG = 4;
+pub const XDP_UMEM_FILL_RING = 5;
+pub const XDP_UMEM_COMPLETION_RING = 6;
+pub const XDP_STATISTICS = 7;
+pub const XDP_OPTIONS = 8;
+
+pub const xdp_umem_reg = extern struct {
+    addr: u64,
+    len: u64,
+    chunk_size: u32,
+    headroom: u32,
+    flags: u32,
+};
+
+pub const xdp_statistics = extern struct {
+    rx_dropped: u64,
+    rx_invalid_descs: u64,
+    tx_invalid_descs: u64,
+    rx_ring_full: u64,
+    rx_fill_ring_empty_descs: u64,
+    tx_ring_empty_descs: u64,
+};
+
+pub const xdp_options = extern struct {
+    flags: u32,
+};
+
+pub const XDP_OPTIONS_ZEROCOPY = (1 << 0);
+
+pub const XDP_PGOFF_RX_RING = 0;
+pub const XDP_PGOFF_TX_RING = 0x80000000;
+pub const XDP_UMEM_PGOFF_FILL_RING = 0x100000000;
+pub const XDP_UMEM_PGOFF_COMPLETION_RING = 0x180000000;
+
+pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT = 48;
+pub const XSK_UNALIGNED_BUF_ADDR_MASK = (1 << XSK_UNALIGNED_BUF_OFFSET_SHIFT) - 1;
+
+pub const xdp_desc = extern struct {
+    addr: u64,
+    len: u32,
+    options: u32,
+};


### PR DESCRIPTION
Add the XDP bits necessary for extreme sanic speed packet processing on Linux.

CI testing it would be iffy as it requires a whole lot of code to make even a "hello word" program (including building a separate eBPF XDP program etc), and a available network interface on the server which is liable to be left in an unclean state.