### PR TITLE
further haiku support build.zig

### DIFF
--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -20,8 +20,12 @@ pub extern "c" fn find_thread(thread_name: ?*c_void) i32;
 
 pub extern "c" fn get_system_info(system_info: *system_info) usize;
 
+pub extern "c" fn _get_team_info(team: c_int, team_info: *team_info, size: usize) i32;
+
+pub extern "c" fn _get_next_area_info(team: c_int, cookie: *i64, area_info: *area_info, size: usize) i32;
+
 // TODO revisit if abi changes or better option becomes apparent
-pub extern "c" fn _get_next_image_info(team: c_int, cookie: *i32, image_info: *image_info) usize;
+pub extern "c" fn _get_next_image_info(team: c_int, cookie: *i32, image_info: *image_info, size: usize) i32;
 
 pub extern "c" fn _kern_read_dir(fd: c_int, buf_ptr: [*]u8, nbytes: usize, maxcount: u32) usize;
 

--- a/lib/std/crypto/tlcsprng.zig
+++ b/lib/std/crypto/tlcsprng.zig
@@ -72,6 +72,11 @@ fn tlsCsprngFill(_: *const std.rand.Random, buffer: []u8) void {
         return fillWithOsEntropy(buffer);
     }
 
+    // Use OS syscall for haiku
+    if (std.Target.current.os.tag == .haiku) {
+        return fillWithOsEntropy(buffer);
+    }
+
     if (wipe_mem.len == 0) {
         // Not initialized yet.
         if (want_fork_safety and maybe_have_wipe_on_fork) {

--- a/lib/std/os/bits/haiku.zig
+++ b/lib/std/os/bits/haiku.zig
@@ -179,15 +179,29 @@ pub const dirent = extern struct {
     }
 };
 
+pub const area_info = extern struct {
+    area: u32,
+    name: [32]u8,
+    size: usize,
+    lock: u32,
+    protection: u32,
+    team_id: i32,
+    ram_size: u32,
+    copy_count: u32,
+    in_count: u32,
+    out_count: u32,
+    address: *c_void,
+};
+
 pub const image_info = extern struct {
     id: u32,
-    type: u32,
+    image_type: u32,
     sequence: i32,
     init_order: i32,
     init_routine: *c_void,
     term_routine: *c_void,
     device: i32,
-    node: i32,
+    node: i64,
     name: [1024]u8,
     text: *c_void,
     data: *c_void,
@@ -223,6 +237,19 @@ pub const system_info = extern struct {
     kernel_build_time: [32]u8,
     kernel_version: i64,
     abi: u32,
+};
+
+pub const team_info = extern struct {
+    team_id: i32,
+    thread_count: i32,
+    image_count: i32,
+    area_count: i32,
+    debugger_nub_thread: i32,
+    debugger_nub_port: i32,
+    argc: i32,
+    args: [64]u8,
+    uid: uid_t,
+    gid: gid_t,
 };
 
 pub const in_port_t = u16;
@@ -289,10 +316,10 @@ pub const CLOCK_THREAD_CPUTIME_ID = -3;
 pub const MAP_FAILED = @intToPtr(*c_void, maxInt(usize));
 pub const MAP_SHARED = 0x0001;
 pub const MAP_PRIVATE = 0x0002;
-pub const MAP_FIXED = 0x0010;
+pub const MAP_FIXED = 0x0004;
 pub const MAP_STACK = 0x0400;
 pub const MAP_NOSYNC = 0x0800;
-pub const MAP_ANON = 0x1000;
+pub const MAP_ANON = 0x0008;
 pub const MAP_ANONYMOUS = MAP_ANON;
 pub const MAP_FILE = 0;
 
@@ -369,9 +396,6 @@ pub const O_WRONLY = 0x0001;
 pub const O_RDWR = 0x0002;
 pub const O_ACCMODE = 0x0003;
 
-pub const O_SHLOCK = 0x0010;
-pub const O_EXLOCK = 0x0020;
-
 pub const O_CREAT = 0x0200;
 pub const O_EXCL = 0x0800;
 pub const O_NOCTTY = 0x8000;
@@ -383,7 +407,7 @@ pub const O_SYNC = 0x0080;
 pub const O_RSYNC = 0o4010000;
 pub const O_DIRECTORY = 0x20000;
 pub const O_NOFOLLOW = 0x0100;
-pub const O_CLOEXEC = 0x00100000;
+pub const O_CLOEXEC = 0x00000040;
 
 pub const O_ASYNC = 0x0040;
 pub const O_DIRECT = 0x00010000;


### PR DESCRIPTION
Hello again,

Congratulations Zig team on the release! Sorry I was not available then but I have been making some more progress for Haiku support on Zig. The following changes should get Zig  to use the Zig build system to compile programs under Haiku. This was tested on nightly build hrev55136.

Things I have been able to confirm now functional that wasn't previously (previous commands that were working under Haiku should still be):

    zig build in a (simple) zig project works (yay)

When running make install to attempt to install Zig after compiling, there is still an error being generated, unfortunately. This is on my future todo to try to address (along with debug info).

```
~/src/git/zig/build> mkdir hellohaiku

~/src/git/zig/build> cd hellohaiku

~/src/git/zig/build/hellohaiku> uname -a
Haiku shredder 1 hrev55136 Jun  6 2021 06:26:21 x86_64 x86_64 Haiku

~/src/git/zig/build/hellohaiku> ../zig init-exe
info: Created build.zig
info: Created src/main.zig
info: Next, try `zig build --help` or `zig build run`

~/src/git/zig/build/hellohaiku> ../zig build --verbose run
/boot/home/src/git/zig/build/zig build-exe /boot/home/src/git/zig/build/hellohaiku/src/main.zig --cache-dir /boot/home/src/git/zig/build/hellohaiku/zig-cache --global-cache-dir /boot/home/config/cache/zig --name hellohaiku --enable-cache 
cp /boot/home/src/git/zig/build/hellohaiku/zig-cache/o/e4fd5d75a03c2a1c959b8e3ce75b06b8/hellohaiku /boot/home/src/git/zig/build/hellohaiku/zig-out/bin/hellohaiku # installed
/boot/home/src/git/zig/build/hellohaiku/zig-out/bin/hellohaiku 
info: All your codebase are belong to us.

~/src/git/zig/build/hellohaiku> ../zig version
0.9.0-dev.1+b755c46d7


### try using zig build on some other zig codebase 
~/src/git/zig/build/ziglings> ../zig build 08
Compiling 08_quiz.zig...
Checking 08_quiz.zig...
PASSED: Program in Zig!
```