### PR TITLE
wasi: always grant fd_readdir right

### DIFF
--- a/ci/azure/linux_script
+++ b/ci/azure/linux_script
@@ -25,10 +25,8 @@ wget -nv "https://ziglang.org/deps/$QEMUBASE.tar.xz"
 tar xf "$QEMUBASE.tar.xz"
 export PATH="$(pwd)/$QEMUBASE/bin:$PATH"
 
-# Bump to v0.23 once this issue is resolved:
-# https://github.com/ziglang/zig/issues/8742
-WASMTIME="wasmtime-v0.22.1-x86_64-linux"
-wget -nv "https://github.com/bytecodealliance/wasmtime/releases/download/v0.22.1/$WASMTIME.tar.xz"
+WASMTIME="wasmtime-v0.26.1-x86_64-linux"
+wget -nv "https://github.com/bytecodealliance/wasmtime/releases/download/v0.26.1/$WASMTIME.tar.xz"
 tar xf "$WASMTIME.tar.xz"
 export PATH="$(pwd)/$WASMTIME:$PATH"
 

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1264,11 +1264,9 @@ pub const Dir = struct {
     pub fn openDirWasi(self: Dir, sub_path: []const u8, args: OpenDirOptions) OpenError!Dir {
         const w = os.wasi;
         var base: w.rights_t = w.RIGHT_FD_FILESTAT_GET | w.RIGHT_FD_FDSTAT_SET_FLAGS | w.RIGHT_FD_FILESTAT_SET_TIMES;
-        if (args.iterate) {
-            base |= w.RIGHT_FD_READDIR;
-        }
         if (args.access_sub_paths) {
-            base |= w.RIGHT_PATH_CREATE_DIRECTORY |
+            base |= w.RIGHT_FD_READDIR |
+                w.RIGHT_PATH_CREATE_DIRECTORY |
                 w.RIGHT_PATH_CREATE_FILE |
                 w.RIGHT_PATH_LINK_SOURCE |
                 w.RIGHT_PATH_LINK_TARGET |

--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -56,13 +56,7 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
             \\fn bar() void {}
         ,
-        // This is what you get when you take the bits of the IEE-754
-        // representation of 42.0 and reinterpret them as an unsigned
-        // integer.
-        // Bug is fixed in wasmtime v0.26 but updating to v0.26 is blocked
-        // on this issue:
-        // https://github.com/ziglang/zig/issues/8742
-            "1109917696\n",
+            "42\n",
         );
 
         case.addCompareOutput(


### PR DESCRIPTION
Since v0.23 release of Wasmtime, if we want to iterate a directory Y then directory Y needed to have been granted `fd_readdir` right. However, it is now also required for directory X to carry `fd_readdir` right, and so on, up-chain all the way until we reach the preopen (which possesses all rights by default).

This caused problems for us since our libstd implementation is more fine-grained and allowed for parent dirs not to carry the right while allow for iterating on its children. My proposal here is to always grant `fd_readdir` right as part of `std.fs.Dir.OpenDirOptions.access_sub_paths`. This seems to be the approach taken by Rust also, plus we should be justified to take this approach since WASI is experimental and snapshot1 will be discontinued eventually and replaced with a new approach to access management that will require a complete rewrite of our libstd anyhow.

PRs for context:
- https://github.com/bytecodealliance/wasmtime/issues/2891
- https://github.com/WebAssembly/wasi-filesystem/issues/31

Closes #8742