### PR TITLE
netlink ifi_change no longer reserved

### DIFF
--- a/lib/std/os/bits/linux/netlink.zig
+++ b/lib/std/os/bits/linux/netlink.zig
@@ -273,8 +273,7 @@ pub const ifinfomsg = extern struct {
     flags: c_uint,
 
     /// IFF_* change mask
-    /// is reserved for future use and should be always set to 0xFFFFFFFF.
-    change: c_uint = 0xFFFFFFFF,
+    change: c_uint,
 };
 
 pub const rtattr = extern struct {


### PR DESCRIPTION
The documentation (e.g. `man 7 rtnetlink`) states that `ifi_change` in `ifinfomsg` "is reserved for future use and should be always set to 0xFFFFFFFF". This is no longer true, even though the text hasn't been updated.

Now, if you send a netlink message with 0xFFFFFFFF in `ifi_change` it'll be interpreted as you explicitly wanting to overwrite all flags. This includes the flag IFF_UP, so it'll likely unexpectedly bring the interface down.

To verify this, try `strace ip link set dev lo up 2>&1 | grep ifi_change` (which should be a no-op on your host). The last row will include `ifi_flags=IFF_UP, ifi_change=0x1`, where you can plainly see that iproute2 is actively setting the mask of the change you requested.