### PR TITLE
Improve error message when `std.fmt.format` is missing arguments

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6262,7 +6262,7 @@ pub fn printValue(self: *Writer, value: anytype) !void {
       <p>
       And now, what happens if we give too many arguments to {#syntax#}printf{#endsyntax#}?
       </p>
-      {#code_begin|test_err|Unused arguments#}
+      {#code_begin|test_err|Unused argument in "here is a string: '{s}' here is a number: {}#}
 const print = @import("std").debug.print;
 
 const a_number: i32 = 1234;

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -359,7 +359,12 @@ pub fn format(
     }
 
     if (comptime arg_state.hasUnusedArgs()) {
-        @compileError("Unused arguments");
+        const missing_count = arg_state.args_len - @popCount(ArgSetType, arg_state.used_args);
+        switch (missing_count) {
+            0 => unreachable,
+            1 => @compileError("Unused argument in \"" ++ fmt ++ "\""),
+            else => @compileError((comptime comptimePrint("{d}", .{missing_count})) ++ " unused arguments in \"" ++ fmt ++ "\""),
+        }
     }
 }
 

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2,6 +2,14 @@ const tests = @import("tests.zig");
 const std = @import("std");
 
 pub fn addCases(cases: *tests.CompileErrorContext) void {
+    cases.add("std.fmt error for unused arguments",
+        \\pub fn main() !void {
+        \\    @import("std").debug.print("{d} {d} {d} {d} {d}", .{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15});
+        \\}
+    , &.{
+        \\error: 10 unused arguments in "{d} {d} {d} {d} {d}"
+    });
+
     cases.add("lazy pointer with undefined element type",
         \\export fn foo() void {
         \\    comptime var T: type = undefined;


### PR DESCRIPTION
**Before** | **After**
-----------|--------
<img src="https://user-images.githubusercontent.com/709451/121289873-8a8dce00-c89a-11eb-8a7f-8a304b7c6457.png" /> | ![image](https://user-images.githubusercontent.com/709451/121290035-ccb70f80-c89a-11eb-93f6-9137a2f9a827.png)