### PR TITLE
link: don't link system libs by the wasm linker

### DIFF
--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -701,17 +701,6 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
             const is_exe_or_dyn_lib = self.base.options.output_mode == .Exe or
                 (self.base.options.output_mode == .Lib and self.base.options.link_mode == .Dynamic);
             if (is_exe_or_dyn_lib) {
-                const system_libs = self.base.options.system_libs.keys();
-
-                for (system_libs) |link_lib| {
-                    if (mem.eql(u8, "wasi_snapshot_preview1", link_lib)) {
-                        // Any referenced symbol from this lib, will be undefined until
-                        // runtime as this lib is provided directly by the runtime.
-                        continue;
-                    }
-                    try argv.append(try std.fmt.allocPrint(arena, "-l{s}", .{link_lib}));
-                }
-
                 const wasi_emulated_libs = self.base.options.wasi_emulated_libs;
                 for (wasi_emulated_libs) |crt_file| {
                     try argv.append(try comp.get_libc_crt_file(


### PR DESCRIPTION
The only allowed system libraries that we can link are libraries that are part of the sysroot such as libc or WASI emulated subcomponents. This is required as Wasm allows to defer symbol resolution until load time.

For example, the following import in Zig

```zig
extern "wasi_snapshot_preview1" fn proc_exit() void;
```

would normally result in appending `-lwasi_snapshot_preview1` flag to the linker line. However, for Wasm/WASI, the symbol is provided at load rather than link time, therefore, the linker should not be concerned with resolving the symbol. As a result, we should not consider system libs by the Wasm linker.

cc @jedisct1 hopefully this should fix the regression with zigly you were experiencing!