### PR TITLE
Rename @byteOffsetOf to @offsetOf

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2715,7 +2715,7 @@ test "pointer to non-bit-aligned field" {
 }
       {#code_end#}
       <p>
-      This can be observed with {#link|@bitOffsetOf#} and {#link|byteOffsetOf#}:
+      This can be observed with {#link|@bitOffsetOf#} and {#link|offsetOf#}:
       </p>
       {#code_begin|test#}
 const std = @import("std");
@@ -2733,9 +2733,9 @@ test "pointer to non-bit-aligned field" {
         try expect(@bitOffsetOf(BitField, "b") == 3);
         try expect(@bitOffsetOf(BitField, "c") == 6);
 
-        try expect(@byteOffsetOf(BitField, "a") == 0);
-        try expect(@byteOffsetOf(BitField, "b") == 0);
-        try expect(@byteOffsetOf(BitField, "c") == 0);
+        try expect(@offsetOf(BitField, "a") == 0);
+        try expect(@offsetOf(BitField, "b") == 0);
+        try expect(@offsetOf(BitField, "c") == 0);
     }
 }
       {#code_end#}
@@ -7026,7 +7026,7 @@ fn func(y: *i32) void {
       For packed structs, non-byte-aligned fields will share a byte offset, but they will have different
       bit offsets.
       </p>
-      {#see_also|@byteOffsetOf#}
+      {#see_also|@offsetOf#}
       {#header_close#}
 
       {#header_open|@boolToInt#}
@@ -7106,8 +7106,8 @@ fn func(y: *i32) void {
       </p>
       {#header_close#}
 
-      {#header_open|@byteOffsetOf#}
-      <pre>{#syntax#}@byteOffsetOf(comptime T: type, comptime field_name: []const u8) comptime_int{#endsyntax#}</pre>
+      {#header_open|@offsetOf#}
+      <pre>{#syntax#}@offsetOf(comptime T: type, comptime field_name: []const u8) comptime_int{#endsyntax#}</pre>
       <p>
       Returns the byte offset of a field relative to its containing struct.
       </p>

--- a/lib/std/os/bits/darwin.zig
+++ b/lib/std/os/bits/darwin.zig
@@ -188,12 +188,12 @@ pub const Kevent = extern struct {
 // to make sure the struct is laid out the same. These values were
 // produced from C code using the offsetof macro.
 comptime {
-    assert(@byteOffsetOf(Kevent, "ident") == 0);
-    assert(@byteOffsetOf(Kevent, "filter") == 8);
-    assert(@byteOffsetOf(Kevent, "flags") == 10);
-    assert(@byteOffsetOf(Kevent, "fflags") == 12);
-    assert(@byteOffsetOf(Kevent, "data") == 16);
-    assert(@byteOffsetOf(Kevent, "udata") == 24);
+    assert(@offsetOf(Kevent, "ident") == 0);
+    assert(@offsetOf(Kevent, "filter") == 8);
+    assert(@offsetOf(Kevent, "flags") == 10);
+    assert(@offsetOf(Kevent, "fflags") == 12);
+    assert(@offsetOf(Kevent, "data") == 16);
+    assert(@offsetOf(Kevent, "udata") == 24);
 }
 
 pub const kevent64_s = extern struct {
@@ -210,13 +210,13 @@ pub const kevent64_s = extern struct {
 // to make sure the struct is laid out the same. These values were
 // produced from C code using the offsetof macro.
 comptime {
-    assert(@byteOffsetOf(kevent64_s, "ident") == 0);
-    assert(@byteOffsetOf(kevent64_s, "filter") == 8);
-    assert(@byteOffsetOf(kevent64_s, "flags") == 10);
-    assert(@byteOffsetOf(kevent64_s, "fflags") == 12);
-    assert(@byteOffsetOf(kevent64_s, "data") == 16);
-    assert(@byteOffsetOf(kevent64_s, "udata") == 24);
-    assert(@byteOffsetOf(kevent64_s, "ext") == 32);
+    assert(@offsetOf(kevent64_s, "ident") == 0);
+    assert(@offsetOf(kevent64_s, "filter") == 8);
+    assert(@offsetOf(kevent64_s, "flags") == 10);
+    assert(@offsetOf(kevent64_s, "fflags") == 12);
+    assert(@offsetOf(kevent64_s, "data") == 16);
+    assert(@offsetOf(kevent64_s, "udata") == 24);
+    assert(@offsetOf(kevent64_s, "ext") == 32);
 }
 
 pub const mach_port_t = c_uint;

--- a/lib/std/os/bits/dragonfly.zig
+++ b/lib/std/os/bits/dragonfly.zig
@@ -360,7 +360,7 @@ pub const dirent = extern struct {
     d_name: [256]u8,
 
     pub fn reclen(self: dirent) u16 {
-        return (@byteOffsetOf(dirent, "d_name") + self.d_namlen + 1 + 7) & ~@as(u16, 7);
+        return (@offsetOf(dirent, "d_name") + self.d_namlen + 1 + 7) & ~@as(u16, 7);
     }
 };
 

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -107,6 +107,21 @@ test "zig fmt: rewrite suspend without block expression" {
     );
 }
 
+// TODO Remove this after zig 0.9.0 is released.
+test "zig fmt: rewrite @byteOffsetOf to @offsetOf" {
+    try testTransform(
+        \\fn foo() void {
+        \\    @byteOffsetOf(Foo, "bar");
+        \\}
+        \\
+    ,
+        \\fn foo() void {
+        \\    @offsetOf(Foo, "bar");
+        \\}
+        \\
+    );
+}
+
 test "zig fmt: simple top level comptime block" {
     try testCanonical(
         \\// line comment

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1211,7 +1211,12 @@ fn renderBuiltinCall(
 ) Error!void {
     const token_tags = tree.tokens.items(.tag);
 
-    try renderToken(ais, tree, builtin_token, .none); // @name
+    const builtin_name = tokenSliceForRender(tree, builtin_token);
+    if (mem.eql(u8, builtin_name, "@byteOffsetOf")) {
+        try ais.writer().writeAll("@offsetOf");
+    } else {
+        try renderToken(ais, tree, builtin_token, .none); // @name
+    }
 
     if (params.len == 0) {
         try renderToken(ais, tree, builtin_token + 1, .none); // (

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -2027,7 +2027,7 @@ fn unusedResultExpr(gz: *GenZir, scope: *Scope, statement: ast.Node.Index) Inner
             .shl_exact,
             .shr_exact,
             .bit_offset_of,
-            .byte_offset_of,
+            .offset_of,
             .cmpxchg_strong,
             .cmpxchg_weak,
             .splat,
@@ -6816,7 +6816,7 @@ fn builtinCall(
         .shr_exact => return shiftOp(gz, scope, rl, node, params[0], params[1], .shr_exact),
 
         .bit_offset_of  => return offsetOf(gz, scope, rl, node, params[0], params[1], .bit_offset_of),
-        .byte_offset_of => return offsetOf(gz, scope, rl, node, params[0], params[1], .byte_offset_of),
+        .offset_of => return offsetOf(gz, scope, rl, node, params[0], params[1], .offset_of),
 
         .c_undef   => return simpleCBuiltin(gz, scope, rl, node, params[0], .c_undef),
         .c_include => return simpleCBuiltin(gz, scope, rl, node, params[0], .c_include),

--- a/src/BuiltinFn.zig
+++ b/src/BuiltinFn.zig
@@ -17,7 +17,7 @@ pub const Tag = enum {
     mul_add,
     byte_swap,
     bit_reverse,
-    byte_offset_of,
+    offset_of,
     call,
     c_define,
     c_import,
@@ -235,9 +235,9 @@ pub const list = list: {
             },
         },
         .{
-            "@byteOffsetOf",
+            "@offsetOf",
             .{
-                .tag = .byte_offset_of,
+                .tag = .offset_of,
                 .param_count = 2,
             },
         },

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -322,7 +322,7 @@ pub fn analyzeBody(
             .shl_exact                    => try sema.zirShlExact(block, inst),
             .shr_exact                    => try sema.zirShrExact(block, inst),
             .bit_offset_of                => try sema.zirBitOffsetOf(block, inst),
-            .byte_offset_of               => try sema.zirByteOffsetOf(block, inst),
+            .offset_of                    => try sema.zirOffsetOf(block, inst),
             .cmpxchg_strong               => try sema.zirCmpxchg(block, inst),
             .cmpxchg_weak                 => try sema.zirCmpxchg(block, inst),
             .splat                        => try sema.zirSplat(block, inst),
@@ -5860,10 +5860,10 @@ fn zirBitOffsetOf(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) InnerE
     return sema.mod.fail(&block.base, src, "TODO: Sema.zirBitOffsetOf", .{});
 }
 
-fn zirByteOffsetOf(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) InnerError!*Inst {
+fn zirOffsetOf(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) InnerError!*Inst {
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src = inst_data.src();
-    return sema.mod.fail(&block.base, src, "TODO: Sema.zirByteOffsetOf", .{});
+    return sema.mod.fail(&block.base, src, "TODO: Sema.zirOffsetOf", .{});
 }
 
 fn zirCmpxchg(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) InnerError!*Inst {

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -859,9 +859,9 @@ pub const Inst = struct {
         /// Implements the `@bitOffsetOf` builtin.
         /// Uses the `pl_node` union field with payload `Bin`.
         bit_offset_of,
-        /// Implements the `@byteOffsetOf` builtin.
+        /// Implements the `@offsetOf` builtin.
         /// Uses the `pl_node` union field with payload `Bin`.
-        byte_offset_of,
+        offset_of,
         /// Implements the `@cmpxchgStrong` builtin.
         /// Uses the `pl_node` union field with payload `Cmpxchg`.
         cmpxchg_strong,
@@ -1166,7 +1166,7 @@ pub const Inst = struct {
                 .shl_exact,
                 .shr_exact,
                 .bit_offset_of,
-                .byte_offset_of,
+                .offset_of,
                 .cmpxchg_strong,
                 .cmpxchg_weak,
                 .splat,
@@ -1436,7 +1436,7 @@ pub const Inst = struct {
                 .shr_exact = .pl_node,
 
                 .bit_offset_of = .pl_node,
-                .byte_offset_of = .pl_node,
+                .offset_of = .pl_node,
                 .cmpxchg_strong = .pl_node,
                 .cmpxchg_weak = .pl_node,
                 .splat = .pl_node,
@@ -2992,7 +2992,7 @@ const Writer = struct {
             .mod,
             .rem,
             .bit_offset_of,
-            .byte_offset_of,
+            .offset_of,
             .splat,
             .reduce,
             .atomic_load,

--- a/src/air.zig
+++ b/src/air.zig
@@ -407,7 +407,7 @@ pub const Inst = struct {
     pub const convertable_br_size = std.math.max(@sizeOf(BrBlockFlat), @sizeOf(Br));
     pub const convertable_br_align = std.math.max(@alignOf(BrBlockFlat), @alignOf(Br));
     comptime {
-        assert(@byteOffsetOf(BrBlockFlat, "base") == @byteOffsetOf(Br, "base"));
+        assert(@offsetOf(BrBlockFlat, "base") == @offsetOf(Br, "base"));
     }
 
     pub const BrBlockFlat = struct {

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -1768,7 +1768,7 @@ enum BuiltinFnId {
     BuiltinFnIdPtrToInt,
     BuiltinFnIdTagName,
     BuiltinFnIdFieldParentPtr,
-    BuiltinFnIdByteOffsetOf,
+    BuiltinFnIdOffsetOf,
     BuiltinFnIdBitOffsetOf,
     BuiltinFnIdAsyncCall,
     BuiltinFnIdShlExact,
@@ -2576,7 +2576,7 @@ enum IrInstSrcId {
     IrInstSrcIdPanic,
     IrInstSrcIdTagName,
     IrInstSrcIdFieldParentPtr,
-    IrInstSrcIdByteOffsetOf,
+    IrInstSrcIdOffsetOf,
     IrInstSrcIdBitOffsetOf,
     IrInstSrcIdTypeInfo,
     IrInstSrcIdType,
@@ -4047,7 +4047,7 @@ struct IrInstGenFieldParentPtr {
     TypeStructField *field;
 };
 
-struct IrInstSrcByteOffsetOf {
+struct IrInstSrcOffsetOf {
     IrInstSrc base;
 
     IrInstSrc *type_value;

--- a/src/stage1/astgen.cpp
+++ b/src/stage1/astgen.cpp
@@ -256,8 +256,8 @@ void destroy_instruction_src(IrInstSrc *inst) {
             return heap::c_allocator.destroy(reinterpret_cast<IrInstSrcPanic *>(inst));
         case IrInstSrcIdFieldParentPtr:
             return heap::c_allocator.destroy(reinterpret_cast<IrInstSrcFieldParentPtr *>(inst));
-        case IrInstSrcIdByteOffsetOf:
-            return heap::c_allocator.destroy(reinterpret_cast<IrInstSrcByteOffsetOf *>(inst));
+        case IrInstSrcIdOffsetOf:
+            return heap::c_allocator.destroy(reinterpret_cast<IrInstSrcOffsetOf *>(inst));
         case IrInstSrcIdBitOffsetOf:
             return heap::c_allocator.destroy(reinterpret_cast<IrInstSrcBitOffsetOf *>(inst));
         case IrInstSrcIdTypeInfo:
@@ -777,8 +777,8 @@ static constexpr IrInstSrcId ir_inst_id(IrInstSrcFieldParentPtr *) {
     return IrInstSrcIdFieldParentPtr;
 }
 
-static constexpr IrInstSrcId ir_inst_id(IrInstSrcByteOffsetOf *) {
-    return IrInstSrcIdByteOffsetOf;
+static constexpr IrInstSrcId ir_inst_id(IrInstSrcOffsetOf *) {
+    return IrInstSrcIdOffsetOf;
 }
 
 static constexpr IrInstSrcId ir_inst_id(IrInstSrcBitOffsetOf *) {
@@ -2472,10 +2472,10 @@ static IrInstSrc *ir_build_field_parent_ptr_src(Stage1AstGen *ag, Scope *scope, 
     return &inst->base;
 }
 
-static IrInstSrc *ir_build_byte_offset_of(Stage1AstGen *ag, Scope *scope, AstNode *source_node,
+static IrInstSrc *ir_build_offset_of(Stage1AstGen *ag, Scope *scope, AstNode *source_node,
         IrInstSrc *type_value, IrInstSrc *field_name)
 {
-    IrInstSrcByteOffsetOf *instruction = ir_build_instruction<IrInstSrcByteOffsetOf>(ag, scope, source_node);
+    IrInstSrcOffsetOf *instruction = ir_build_instruction<IrInstSrcOffsetOf>(ag, scope, source_node);
     instruction->type_value = type_value;
     instruction->field_name = field_name;
 
@@ -4945,7 +4945,7 @@ static IrInstSrc *astgen_builtin_fn_call(Stage1AstGen *ag, Scope *scope, AstNode
                         arg0_value, arg1_value, arg2_value);
                 return ir_lval_wrap(ag, scope, field_parent_ptr, lval, result_loc);
             }
-        case BuiltinFnIdByteOffsetOf:
+        case BuiltinFnIdOffsetOf:
             {
                 AstNode *arg0_node = node->data.fn_call_expr.params.at(0);
                 IrInstSrc *arg0_value = astgen_node(ag, arg0_node, scope);
@@ -4957,7 +4957,7 @@ static IrInstSrc *astgen_builtin_fn_call(Stage1AstGen *ag, Scope *scope, AstNode
                 if (arg1_value == ag->codegen->invalid_inst_src)
                     return arg1_value;
 
-                IrInstSrc *offset_of = ir_build_byte_offset_of(ag, scope, node, arg0_value, arg1_value);
+                IrInstSrc *offset_of = ir_build_offset_of(ag, scope, node, arg0_value, arg1_value);
                 return ir_lval_wrap(ag, scope, offset_of, lval, result_loc);
             }
         case BuiltinFnIdBitOffsetOf:

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -8902,7 +8902,7 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdPtrToInt, "ptrToInt", 1);
     create_builtin_fn(g, BuiltinFnIdTagName, "tagName", 1);
     create_builtin_fn(g, BuiltinFnIdFieldParentPtr, "fieldParentPtr", 3);
-    create_builtin_fn(g, BuiltinFnIdByteOffsetOf, "byteOffsetOf", 2);
+    create_builtin_fn(g, BuiltinFnIdOffsetOf, "offsetOf", 2);
     create_builtin_fn(g, BuiltinFnIdBitOffsetOf, "bitOffsetOf", 2);
     create_builtin_fn(g, BuiltinFnIdDivExact, "divExact", 2);
     create_builtin_fn(g, BuiltinFnIdDivTrunc, "divTrunc", 2);

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -17082,7 +17082,7 @@ static TypeStructField *validate_host_int_byte_offset(IrAnalyze *ira,
     return field;
 }
 
-static IrInstGen *ir_analyze_instruction_byte_offset_of(IrAnalyze *ira, IrInstSrcByteOffsetOf *instruction) {
+static IrInstGen *ir_analyze_instruction_offset_of(IrAnalyze *ira, IrInstSrcOffsetOf *instruction) {
     IrInstGen *type_value = instruction->type_value->child;
     if (type_is_invalid(type_value->value->type))
         return ira->codegen->invalid_inst_gen;
@@ -24368,8 +24368,8 @@ static IrInstGen *ir_analyze_instruction_base(IrAnalyze *ira, IrInstSrc *instruc
             return ir_analyze_instruction_enum_tag_name(ira, (IrInstSrcTagName *)instruction);
         case IrInstSrcIdFieldParentPtr:
             return ir_analyze_instruction_field_parent_ptr(ira, (IrInstSrcFieldParentPtr *)instruction);
-        case IrInstSrcIdByteOffsetOf:
-            return ir_analyze_instruction_byte_offset_of(ira, (IrInstSrcByteOffsetOf *)instruction);
+        case IrInstSrcIdOffsetOf:
+            return ir_analyze_instruction_offset_of(ira, (IrInstSrcOffsetOf *)instruction);
         case IrInstSrcIdBitOffsetOf:
             return ir_analyze_instruction_bit_offset_of(ira, (IrInstSrcBitOffsetOf *)instruction);
         case IrInstSrcIdTypeInfo:
@@ -24824,7 +24824,7 @@ bool ir_inst_src_has_side_effects(IrInstSrc *instruction) {
         case IrInstSrcIdTypeName:
         case IrInstSrcIdTagName:
         case IrInstSrcIdFieldParentPtr:
-        case IrInstSrcIdByteOffsetOf:
+        case IrInstSrcIdOffsetOf:
         case IrInstSrcIdBitOffsetOf:
         case IrInstSrcIdTypeInfo:
         case IrInstSrcIdType:

--- a/src/stage1/ir_print.cpp
+++ b/src/stage1/ir_print.cpp
@@ -287,8 +287,8 @@ const char* ir_inst_src_type_str(IrInstSrcId id) {
             return "SrcTagName";
         case IrInstSrcIdFieldParentPtr:
             return "SrcFieldParentPtr";
-        case IrInstSrcIdByteOffsetOf:
-            return "SrcByteOffsetOf";
+        case IrInstSrcIdOffsetOf:
+            return "SrcOffsetOf";
         case IrInstSrcIdBitOffsetOf:
             return "SrcBitOffsetOf";
         case IrInstSrcIdTypeInfo:
@@ -2292,8 +2292,8 @@ static void ir_print_field_parent_ptr(IrPrintGen *irp, IrInstGenFieldParentPtr *
     fprintf(irp->f, ")");
 }
 
-static void ir_print_byte_offset_of(IrPrintSrc *irp, IrInstSrcByteOffsetOf *instruction) {
-    fprintf(irp->f, "@byte_offset_of(");
+static void ir_print_offset_of(IrPrintSrc *irp, IrInstSrcOffsetOf *instruction) {
+    fprintf(irp->f, "@offset_of(");
     ir_print_other_inst_src(irp, instruction->type_value);
     fprintf(irp->f, ",");
     ir_print_other_inst_src(irp, instruction->field_name);
@@ -2946,8 +2946,8 @@ static void ir_print_inst_src(IrPrintSrc *irp, IrInstSrc *instruction, bool trai
         case IrInstSrcIdFieldParentPtr:
             ir_print_field_parent_ptr(irp, (IrInstSrcFieldParentPtr *)instruction);
             break;
-        case IrInstSrcIdByteOffsetOf:
-            ir_print_byte_offset_of(irp, (IrInstSrcByteOffsetOf *)instruction);
+        case IrInstSrcIdOffsetOf:
+            ir_print_offset_of(irp, (IrInstSrcOffsetOf *)instruction);
             break;
         case IrInstSrcIdBitOffsetOf:
             ir_print_bit_offset_of(irp, (IrInstSrcBitOffsetOf *)instruction);

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -1426,7 +1426,7 @@ fn transSimpleOffsetOfExpr(
                 const quoted_field_name = try std.fmt.allocPrint(c.arena, "\"{s}\"", .{raw_field_name});
                 const field_name_node = try Tag.string_literal.create(c.arena, quoted_field_name);
 
-                return Tag.byte_offset_of.create(c.arena, .{
+                return Tag.offset_of.create(c.arena, .{
                     .lhs = type_node,
                     .rhs = field_name_node,
                 });

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -158,8 +158,8 @@ pub const Node = extern union {
         ptr_cast,
         /// @divExact(lhs, rhs)
         div_exact,
-        /// @byteOffsetOf(lhs, rhs)
-        byte_offset_of,
+        /// @offsetOf(lhs, rhs)
+        offset_of,
         /// @shuffle(type, a, b, mask)
         shuffle,
 
@@ -335,7 +335,7 @@ pub const Node = extern union {
                 .std_meta_vector,
                 .ptr_cast,
                 .div_exact,
-                .byte_offset_of,
+                .offset_of,
                 .std_meta_cast,
                 => Payload.BinOp,
 
@@ -1304,9 +1304,9 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
             const payload = node.castTag(.div_exact).?.data;
             return renderBuiltinCall(c, "@divExact", &.{ payload.lhs, payload.rhs });
         },
-        .byte_offset_of => {
-            const payload = node.castTag(.byte_offset_of).?.data;
-            return renderBuiltinCall(c, "@byteOffsetOf", &.{ payload.lhs, payload.rhs });
+        .offset_of => {
+            const payload = node.castTag(.offset_of).?.data;
+            return renderBuiltinCall(c, "@offsetOf", &.{ payload.lhs, payload.rhs });
         },
         .sizeof => {
             const payload = node.castTag(.sizeof).?.data;
@@ -2274,7 +2274,7 @@ fn renderNodeGrouped(c: *Context, node: Node) !NodeIndex {
         .null_sentinel_array_type,
         .bool_to_int,
         .div_exact,
-        .byte_offset_of,
+        .offset_of,
         .shuffle,
         => {
             // no grouping needed

--- a/test/behavior/bugs/6781.zig
+++ b/test/behavior/bugs/6781.zig
@@ -15,7 +15,7 @@ pub const JournalHeader = packed struct {
         assert(entry.len >= @sizeOf(JournalHeader));
         assert(entry.len == self.size);
 
-        const checksum_offset = @byteOffsetOf(JournalHeader, "checksum");
+        const checksum_offset = @offsetOf(JournalHeader, "checksum");
         const checksum_size = @sizeOf(@TypeOf(self.checksum));
         assert(checksum_offset == 0 + 16 + 16);
         assert(checksum_size == 16);
@@ -29,12 +29,12 @@ pub const JournalHeader = packed struct {
         const hash_chain_root_size = @sizeOf(@TypeOf(self.hash_chain_root));
         assert(hash_chain_root_size == 16);
 
-        const prev_hash_chain_root_offset = @byteOffsetOf(JournalHeader, "prev_hash_chain_root");
+        const prev_hash_chain_root_offset = @offsetOf(JournalHeader, "prev_hash_chain_root");
         const prev_hash_chain_root_size = @sizeOf(@TypeOf(self.prev_hash_chain_root));
         assert(prev_hash_chain_root_offset == 0 + 16);
         assert(prev_hash_chain_root_size == 16);
 
-        const checksum_offset = @byteOffsetOf(JournalHeader, "checksum");
+        const checksum_offset = @offsetOf(JournalHeader, "checksum");
         const checksum_size = @sizeOf(@TypeOf(self.checksum));
         assert(checksum_offset == 0 + 16 + 16);
         assert(checksum_size == 16);

--- a/test/behavior/sizeof_and_typeof.zig
+++ b/test/behavior/sizeof_and_typeof.zig
@@ -34,71 +34,71 @@ const P = packed struct {
     i: u7,
 };
 
-test "@byteOffsetOf" {
+test "@offsetOf" {
     // Packed structs have fixed memory layout
-    try expect(@byteOffsetOf(P, "a") == 0);
-    try expect(@byteOffsetOf(P, "b") == 1);
-    try expect(@byteOffsetOf(P, "c") == 5);
-    try expect(@byteOffsetOf(P, "d") == 6);
-    try expect(@byteOffsetOf(P, "e") == 6);
-    try expect(@byteOffsetOf(P, "f") == 7);
-    try expect(@byteOffsetOf(P, "g") == 9);
-    try expect(@byteOffsetOf(P, "h") == 11);
-    try expect(@byteOffsetOf(P, "i") == 12);
+    try expect(@offsetOf(P, "a") == 0);
+    try expect(@offsetOf(P, "b") == 1);
+    try expect(@offsetOf(P, "c") == 5);
+    try expect(@offsetOf(P, "d") == 6);
+    try expect(@offsetOf(P, "e") == 6);
+    try expect(@offsetOf(P, "f") == 7);
+    try expect(@offsetOf(P, "g") == 9);
+    try expect(@offsetOf(P, "h") == 11);
+    try expect(@offsetOf(P, "i") == 12);
 
     // Normal struct fields can be moved/padded
     var a: A = undefined;
-    try expect(@ptrToInt(&a.a) - @ptrToInt(&a) == @byteOffsetOf(A, "a"));
-    try expect(@ptrToInt(&a.b) - @ptrToInt(&a) == @byteOffsetOf(A, "b"));
-    try expect(@ptrToInt(&a.c) - @ptrToInt(&a) == @byteOffsetOf(A, "c"));
-    try expect(@ptrToInt(&a.d) - @ptrToInt(&a) == @byteOffsetOf(A, "d"));
-    try expect(@ptrToInt(&a.e) - @ptrToInt(&a) == @byteOffsetOf(A, "e"));
-    try expect(@ptrToInt(&a.f) - @ptrToInt(&a) == @byteOffsetOf(A, "f"));
-    try expect(@ptrToInt(&a.g) - @ptrToInt(&a) == @byteOffsetOf(A, "g"));
-    try expect(@ptrToInt(&a.h) - @ptrToInt(&a) == @byteOffsetOf(A, "h"));
-    try expect(@ptrToInt(&a.i) - @ptrToInt(&a) == @byteOffsetOf(A, "i"));
+    try expect(@ptrToInt(&a.a) - @ptrToInt(&a) == @offsetOf(A, "a"));
+    try expect(@ptrToInt(&a.b) - @ptrToInt(&a) == @offsetOf(A, "b"));
+    try expect(@ptrToInt(&a.c) - @ptrToInt(&a) == @offsetOf(A, "c"));
+    try expect(@ptrToInt(&a.d) - @ptrToInt(&a) == @offsetOf(A, "d"));
+    try expect(@ptrToInt(&a.e) - @ptrToInt(&a) == @offsetOf(A, "e"));
+    try expect(@ptrToInt(&a.f) - @ptrToInt(&a) == @offsetOf(A, "f"));
+    try expect(@ptrToInt(&a.g) - @ptrToInt(&a) == @offsetOf(A, "g"));
+    try expect(@ptrToInt(&a.h) - @ptrToInt(&a) == @offsetOf(A, "h"));
+    try expect(@ptrToInt(&a.i) - @ptrToInt(&a) == @offsetOf(A, "i"));
 }
 
-test "@byteOffsetOf packed struct, array length not power of 2 or multiple of native pointer width in bytes" {
+test "@offsetOf packed struct, array length not power of 2 or multiple of native pointer width in bytes" {
     const p3a_len = 3;
     const P3 = packed struct {
         a: [p3a_len]u8,
         b: usize,
     };
-    try std.testing.expectEqual(0, @byteOffsetOf(P3, "a"));
-    try std.testing.expectEqual(p3a_len, @byteOffsetOf(P3, "b"));
+    try std.testing.expectEqual(0, @offsetOf(P3, "a"));
+    try std.testing.expectEqual(p3a_len, @offsetOf(P3, "b"));
 
     const p5a_len = 5;
     const P5 = packed struct {
         a: [p5a_len]u8,
         b: usize,
     };
-    try std.testing.expectEqual(0, @byteOffsetOf(P5, "a"));
-    try std.testing.expectEqual(p5a_len, @byteOffsetOf(P5, "b"));
+    try std.testing.expectEqual(0, @offsetOf(P5, "a"));
+    try std.testing.expectEqual(p5a_len, @offsetOf(P5, "b"));
 
     const p6a_len = 6;
     const P6 = packed struct {
         a: [p6a_len]u8,
         b: usize,
     };
-    try std.testing.expectEqual(0, @byteOffsetOf(P6, "a"));
-    try std.testing.expectEqual(p6a_len, @byteOffsetOf(P6, "b"));
+    try std.testing.expectEqual(0, @offsetOf(P6, "a"));
+    try std.testing.expectEqual(p6a_len, @offsetOf(P6, "b"));
 
     const p7a_len = 7;
     const P7 = packed struct {
         a: [p7a_len]u8,
         b: usize,
     };
-    try std.testing.expectEqual(0, @byteOffsetOf(P7, "a"));
-    try std.testing.expectEqual(p7a_len, @byteOffsetOf(P7, "b"));
+    try std.testing.expectEqual(0, @offsetOf(P7, "a"));
+    try std.testing.expectEqual(p7a_len, @offsetOf(P7, "b"));
 
     const p9a_len = 9;
     const P9 = packed struct {
         a: [p9a_len]u8,
         b: usize,
     };
-    try std.testing.expectEqual(0, @byteOffsetOf(P9, "a"));
-    try std.testing.expectEqual(p9a_len, @byteOffsetOf(P9, "b"));
+    try std.testing.expectEqual(0, @offsetOf(P9, "a"));
+    try std.testing.expectEqual(p9a_len, @offsetOf(P9, "b"));
 
     // 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22, 23, 25 etc. are further cases
 }
@@ -113,13 +113,13 @@ test "@bitOffsetOf" {
     try expect(@bitOffsetOf(P, "f") == 56);
     try expect(@bitOffsetOf(P, "g") == 72);
 
-    try expect(@byteOffsetOf(A, "a") * 8 == @bitOffsetOf(A, "a"));
-    try expect(@byteOffsetOf(A, "b") * 8 == @bitOffsetOf(A, "b"));
-    try expect(@byteOffsetOf(A, "c") * 8 == @bitOffsetOf(A, "c"));
-    try expect(@byteOffsetOf(A, "d") * 8 == @bitOffsetOf(A, "d"));
-    try expect(@byteOffsetOf(A, "e") * 8 == @bitOffsetOf(A, "e"));
-    try expect(@byteOffsetOf(A, "f") * 8 == @bitOffsetOf(A, "f"));
-    try expect(@byteOffsetOf(A, "g") * 8 == @bitOffsetOf(A, "g"));
+    try expect(@offsetOf(A, "a") * 8 == @bitOffsetOf(A, "a"));
+    try expect(@offsetOf(A, "b") * 8 == @bitOffsetOf(A, "b"));
+    try expect(@offsetOf(A, "c") * 8 == @bitOffsetOf(A, "c"));
+    try expect(@offsetOf(A, "d") * 8 == @bitOffsetOf(A, "d"));
+    try expect(@offsetOf(A, "e") * 8 == @bitOffsetOf(A, "e"));
+    try expect(@offsetOf(A, "f") * 8 == @bitOffsetOf(A, "f"));
+    try expect(@offsetOf(A, "g") * 8 == @bitOffsetOf(A, "g"));
 }
 
 test "@sizeOf on compile-time types" {

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -699,7 +699,7 @@ test "non-packed struct with u128 entry in union" {
 
     var sx: S = undefined;
     var s = &sx;
-    try std.testing.expect(@ptrToInt(&s.f2) - @ptrToInt(&s.f1) == @byteOffsetOf(S, "f2"));
+    try std.testing.expect(@ptrToInt(&s.f2) - @ptrToInt(&s.f1) == @offsetOf(S, "f2"));
     var v2 = U{ .Num = 123 };
     s.f2 = v2;
     try std.testing.expect(s.f2.Num == 123);

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -6669,24 +6669,24 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         "tmp.zig:8:29: error: field 'b' has index 1 but pointer value is index 0 of struct 'Foo'",
     });
 
-    cases.add("@byteOffsetOf - non struct",
+    cases.add("@offsetOf - non struct",
         \\const Foo = i32;
         \\export fn foo() usize {
-        \\    return @byteOffsetOf(Foo, "a",);
+        \\    return @offsetOf(Foo, "a",);
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:26: error: expected struct type, found 'i32'",
+        "tmp.zig:3:22: error: expected struct type, found 'i32'",
     });
 
-    cases.add("@byteOffsetOf - bad field name",
+    cases.add("@offsetOf - bad field name",
         \\const Foo = struct {
         \\    derp: i32,
         \\};
         \\export fn foo() usize {
-        \\    return @byteOffsetOf(Foo, "a",);
+        \\    return @offsetOf(Foo, "a",);
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:31: error: struct 'Foo' has no field 'a'",
+        "tmp.zig:5:27: error: struct 'Foo' has no field 'a'",
     });
 
     cases.addExe("missing main fn in executable",
@@ -7693,10 +7693,10 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
         \\    val: void,
         \\};
         \\export fn foo() void {
-        \\    const fieldOffset = @byteOffsetOf(Empty, "val",);
+        \\    const fieldOffset = @offsetOf(Empty, "val",);
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:46: error: zero-bit field 'val' in struct 'Empty' has no offset",
+        "tmp.zig:5:42: error: zero-bit field 'val' in struct 'Empty' has no offset",
     });
 
     cases.add("taking bit offset of void field in struct",


### PR DESCRIPTION
This pull request renames the @byteOffsetOf built-in function in order to be more consistent with the other built-in functions, resolving issue #7794.