### PR TITLE
parse.zig: simplify parsing functions that build lists by always using scratch buffer

### DIFF
--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -2616,7 +2616,7 @@ const Parser = struct {
         const found_payload = try p.parsePtrIndexPayload();
         if (found_payload == 0) try p.warn(.expected_loop_payload);
 
-        const then_expr = try p.expectExpr();
+        const then_expr = try p.expectTypeExpr();
         const else_token = p.eatToken(.keyword_else) orelse {
             return p.addNode(.{
                 .tag = .for_simple,

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5154,7 +5154,7 @@ test "recovery: missing for payload" {
     try testError(
         \\comptime {
         \\    const a = for(a) {};
-        \\    const a: for(a) {};
+        \\    const a: for(a) blk: {};
         \\    for(a) {}
         \\}
     , &[_]Error{


### PR DESCRIPTION
These changes simplify parsing functions that duplicate parsing logic in order to special case building lists of one or two items. This worked to avoid unnecessary small allocations. However, since https://github.com/ziglang/zig/pull/8910 avoids all small allocations, these functions can be made simpler and more uniform by always using the scratch buffer. In particular, the duplication of parsing logic is removed, and returns are generally collected together in one place, separate from the parsing logic. This commit rewrites the parsing of statement lists in `parseBlock`, initializer lists in `parseCurlySuffixExpr`, lists of suffix ops and function call arguments in `parseSuffixExpr`, dotted initializer lists and error set declarations in `parsePrimaryTypeExpr`, and argument lists in `parseBuiltinCall`.

One exception is parsing a case list in `parseSwitchProng`. Always using the scratch buffer did not end up making this simpler or clearer. For the sake of completeness, I'll note that this is largely due to the perhaps odd behavior where a one item case produces a `.switch_case_one` node unless it has a trailing comma, in which case it produces a `.switch_case` node in the same way as cases with two or more items. If one item cases always produced `.switch_case_one` nodes, the logic would be more uniform and the function would simplify slightly. Unlike nodes that have explicit trailing-comma variants, like `.array_init_one` versus `.array_init_one_comma`, I don't think anything depends on this behavior. The `firstToken` and `lastToken` functions in `Tree` don't, nor do `switchCase` and `switchCaseOne`, and even `renderSwitchCase` checks for a trailing comma itself for both types of node. 

For testing, I again parsed all valid zig files in this repo with and without these changes and checked that the resulting trees were identical. I also checked for any effect on performance. When using the C allocator, most files (especially larger ones) have a smaller than 1% change in MiB/s of parsed source on my machine, though there are a few outliers as large as +/- 3%. Running the tests with only one version of `parse` checked against itself gave differences in performance as large as 2%, so these numbers are likely noise.