### PR TITLE
zig ld: act as linker for golang

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -807,6 +807,11 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
                 rpaths.appendAssumeCapacity(key.*);
             }
 
+            // frameworks
+            for (self.base.options.frameworks) |framework| {
+                log.warn("frameworks not yet supported for '-framework {s}'", .{framework});
+            }
+
             if (self.base.options.verbose_link) {
                 var argv = std.ArrayList([]const u8).init(arena);
 

--- a/src/link/MachO/Zld.zig
+++ b/src/link/MachO/Zld.zig
@@ -442,6 +442,25 @@ fn updateMetadata(self: *Zld) !void {
             const flags = source_sect.flags;
 
             switch (flags) {
+                macho.S_REGULAR | macho.S_ATTR_PURE_INSTRUCTIONS | macho.S_ATTR_SOME_INSTRUCTIONS => {
+                    if (self.text_section_index != null) continue;
+
+                    self.text_section_index = @intCast(u16, text_seg.sections.items.len);
+                    try text_seg.addSection(self.allocator, .{
+                        .sectname = makeStaticString("__text"),
+                        .segname = makeStaticString("__TEXT"),
+                        .addr = 0,
+                        .size = 0,
+                        .offset = 0,
+                        .@"align" = 0,
+                        .reloff = 0,
+                        .nreloc = 0,
+                        .flags = macho.S_REGULAR | macho.S_ATTR_PURE_INSTRUCTIONS | macho.S_ATTR_SOME_INSTRUCTIONS,
+                        .reserved1 = 0,
+                        .reserved2 = 0,
+                        .reserved3 = 0,
+                    });
+                },
                 macho.S_REGULAR, macho.S_4BYTE_LITERALS, macho.S_8BYTE_LITERALS, macho.S_16BYTE_LITERALS => {
                     if (mem.eql(u8, segname, "__TEXT")) {
                         if (mem.eql(u8, sectname, "__ustring")) {
@@ -654,8 +673,32 @@ fn updateMetadata(self: *Zld) !void {
                         .reserved3 = 0,
                     });
                 },
+                macho.S_COALESCED |
+                    macho.S_ATTR_NO_TOC |
+                    macho.S_ATTR_STRIP_STATIC_SYMS |
+                    macho.S_ATTR_LIVE_SUPPORT => {
+                    log.debug("TODO __eh_frame section: type 0x{x}, name '{s},{s}'", .{
+                        flags, segname, sectname,
+                    });
+                    continue;
+                },
+                macho.S_REGULAR | macho.S_ATTR_DEBUG => {
+                    if (mem.eql(u8, "__LD", segname) and mem.eql(u8, "__compact_unwind", sectname)) {
+                        log.debug("TODO compact unwind section: type 0x{x}, name '{s},{s}'", .{
+                            flags, segname, sectname,
+                        });
+                    }
+                    continue;
+                },
                 else => {
-                    log.debug("unhandled section type 0x{x} for '{s}/{s}'", .{ flags, segname, sectname });
+                    if (mem.eql(u8, "__LLVM", segname) and mem.eql(u8, "__asm", sectname)) {
+                        log.debug("TODO LLVM bitcode section: type 0x{x}, name '{s},{s}'", .{
+                            flags, segname, sectname,
+                        });
+                        continue;
+                    }
+                    log.err("unhandled section type 0x{x} for '{s},{s}'", .{ flags, segname, sectname });
+                    return error.UnhandledSection;
                 },
             }
         }

--- a/src/link/MachO/Zld.zig
+++ b/src/link/MachO/Zld.zig
@@ -857,24 +857,23 @@ fn getMatchingSection(self: *Zld, section: macho.section_64) ?MatchingSection {
                             .seg = self.text_segment_cmd_index.?,
                             .sect = self.ustring_section_index.?,
                         };
-                    } else {
-                        break :blk .{
-                            .seg = self.text_segment_cmd_index.?,
-                            .sect = self.text_const_section_index.?,
-                        };
                     }
-                } else if (mem.eql(u8, segname, "__DATA")) {
-                    if (mem.eql(u8, sectname, "__data")) {
-                        break :blk .{
-                            .seg = self.data_segment_cmd_index.?,
-                            .sect = self.data_section_index.?,
-                        };
-                    } else if (mem.eql(u8, sectname, "__const")) {
+                    break :blk .{
+                        .seg = self.text_segment_cmd_index.?,
+                        .sect = self.text_const_section_index.?,
+                    };
+                }
+                if (mem.eql(u8, segname, "__DATA")) {
+                    if (mem.eql(u8, sectname, "__const")) {
                         break :blk .{
                             .seg = self.data_const_segment_cmd_index.?,
                             .sect = self.data_const_section_index.?,
                         };
                     }
+                    break :blk .{
+                        .seg = self.data_segment_cmd_index.?,
+                        .sect = self.data_section_index.?,
+                    };
                 }
                 break :blk null;
             },


### PR DESCRIPTION
Fixes #9050

Changes:
* match all `__DATA` sections as `__data` except `__const` --- in golang, you will get `__DATA,__noptrdata` or `__DATA,__go_buildinfo` which should be mapped to `__DATA,__data`
* allow for existence of `__DATA_CONST` sections in objects --- up until now, we only expected old-fashioned objects which carried two basic segments by name: `__TEXT` and `__DATA`. Since macOS 11.1, there is a new segment `__DATA_CONST`, and we should expect and correctly parse sections designated to that segment explicitly as is the case in golang
* throw an error if found unknown section in object --- we will silently ignore expected section that are either won't take part in linking such as any `__DWARF` section, or are known but are not yet implemented such as `__TEXT,__eh_frame`. For any other we will throw an error and exit
* inform the caller that we currently are unable to handle frameworks