### PR TITLE
ci: enable LLVM when testing stage2 on Linux and macOS

### DIFF
--- a/ci/azure/linux_script
+++ b/ci/azure/linux_script
@@ -65,9 +65,9 @@ make $JOBS install
 cmake .. -DZIG_EXECUTABLE="$(pwd)/release/bin/zig"
 make $JOBS install
 
-for step in test-toolchain test-std docs; do
-  release/bin/zig build $step -Denable-qemu -Denable-wasmtime
-done
+release/bin/zig build test-toolchain -Denable-qemu -Denable-wasmtime -Denable-llvm
+release/bin/zig build test-std -Denable-qemu -Denable-wasmtime
+release/bin/zig build docs
 
 # Look for HTML errors.
 tidy -qe ../zig-cache/langref.html

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -54,9 +54,9 @@ make $JOBS install
 cmake .. -DZIG_EXECUTABLE="$(pwd)/release/bin/zig"
 make $JOBS install
 
-for step in test-toolchain test-std docs; do
-  release/bin/zig build $step
-done
+release/bin/zig build test-toolchain -Denable-llvm
+release/bin/zig build test-std
+release/bin/zig build docs
 
 if [ "${BUILD_REASON}" != "PullRequest" ]; then
   mv ../LICENSE release/


### PR DESCRIPTION
Enabling LLVM as part of stage2 tests, will exercise not only stage2 itself but also any drop-in linker replacement, e.g., `zig ld`, with respect to linking C++. I realise this inevitably will add a little overhead to the entire build process, but hopefully it is not anything outrageous.