### PR TITLE
std.windows: fix `OVERLAPPED`, add `OVERLAPPED_ENTRY`

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -54,8 +54,12 @@ pub const Loop = struct {
             .windows => windows.OVERLAPPED{
                 .Internal = 0,
                 .InternalHigh = 0,
-                .Offset = 0,
-                .OffsetHigh = 0,
+                .DUMMYUNIONNAME = .{
+                    .DUMMYSTRUCTNAME = .{
+                        .Offset = 0,
+                        .OffsetHigh = 0,
+                    },
+                },
                 .hEvent = null,
             },
             else => {},

--- a/lib/std/fs/watch.zig
+++ b/lib/std/fs/watch.zig
@@ -437,8 +437,12 @@ pub fn Watch(comptime V: type) type {
                     .overlapped = windows.OVERLAPPED{
                         .Internal = 0,
                         .InternalHigh = 0,
-                        .Offset = 0,
-                        .OffsetHigh = 0,
+                        .DUMMYUNIONNAME = .{
+                            .DUMMYSTRUCTNAME = .{
+                                .Offset = 0,
+                                .OffsetHigh = 0,
+                            },
+                        },
                         .hEvent = null,
                     },
                 },

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -455,8 +455,12 @@ pub fn ReadFile(in_hFile: HANDLE, buffer: []u8, offset: ?u64, io_mode: std.io.Mo
                 .overlapped = OVERLAPPED{
                     .Internal = 0,
                     .InternalHigh = 0,
-                    .Offset = @truncate(u32, off),
-                    .OffsetHigh = @truncate(u32, off >> 32),
+                    .DUMMYUNIONNAME = .{
+                        .DUMMYSTRUCTNAME = .{
+                            .Offset = @truncate(u32, off),
+                            .OffsetHigh = @truncate(u32, off >> 32),
+                        },
+                    },
                     .hEvent = null,
                 },
             },
@@ -491,8 +495,12 @@ pub fn ReadFile(in_hFile: HANDLE, buffer: []u8, offset: ?u64, io_mode: std.io.Mo
                 overlapped_data = .{
                     .Internal = 0,
                     .InternalHigh = 0,
-                    .Offset = @truncate(u32, off),
-                    .OffsetHigh = @truncate(u32, off >> 32),
+                    .DUMMYUNIONNAME = .{
+                        .DUMMYSTRUCTNAME = .{
+                            .Offset = @truncate(u32, off),
+                            .OffsetHigh = @truncate(u32, off >> 32),
+                        },
+                    },
                     .hEvent = null,
                 };
                 break :blk &overlapped_data;
@@ -535,8 +543,12 @@ pub fn WriteFile(
                 .overlapped = OVERLAPPED{
                     .Internal = 0,
                     .InternalHigh = 0,
-                    .Offset = @truncate(u32, off),
-                    .OffsetHigh = @truncate(u32, off >> 32),
+                    .DUMMYUNIONNAME = .{
+                        .DUMMYSTRUCTNAME = .{
+                            .Offset = @truncate(u32, off),
+                            .OffsetHigh = @truncate(u32, off >> 32),
+                        },
+                    },
                     .hEvent = null,
                 },
             },
@@ -571,8 +583,12 @@ pub fn WriteFile(
             overlapped_data = .{
                 .Internal = 0,
                 .InternalHigh = 0,
-                .Offset = @truncate(u32, off),
-                .OffsetHigh = @truncate(u32, off >> 32),
+                .DUMMYUNIONNAME = .{
+                    .DUMMYSTRUCTNAME = .{
+                        .Offset = @truncate(u32, off),
+                        .OffsetHigh = @truncate(u32, off >> 32),
+                    },
+                },
                 .hEvent = null,
             };
             break :blk &overlapped_data;

--- a/lib/std/os/windows/bits.zig
+++ b/lib/std/os/windows/bits.zig
@@ -359,11 +359,24 @@ pub const FILE_INFORMATION_CLASS = enum(c_int) {
 pub const OVERLAPPED = extern struct {
     Internal: ULONG_PTR,
     InternalHigh: ULONG_PTR,
-    Offset: DWORD,
-    OffsetHigh: DWORD,
+    DUMMYUNIONNAME: extern union {
+        DUMMYSTRUCTNAME: extern struct {
+            Offset: DWORD,
+            OffsetHigh: DWORD,
+        },
+        Pointer: ?PVOID,
+    },
     hEvent: ?HANDLE,
 };
 pub const LPOVERLAPPED = *OVERLAPPED;
+
+pub const OVERLAPPED_ENTRY = extern struct {
+    lpCompletionKey: ULONG_PTR,
+    lpOverlapped: LPOVERLAPPED,
+    Internal: ULONG_PTR,
+    dwNumberOfBytesTransferred: DWORD,
+};
+pub const LPOVERLAPPED_ENTRY = *OVERLAPPED_ENTRY;
 
 pub const MAX_PATH = 260;
 


### PR DESCRIPTION
closes #9079 

adds `OVERLAPPED_ENTRY` type for referenced issue and corrects `OVERLAPPED` type to have a union field
see: https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-overlapped