### PR TITLE
zig build: add --libc general option

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -58,6 +58,7 @@ pub const Builder = struct {
     h_dir: []const u8,
     install_path: []const u8,
     search_prefixes: ArrayList([]const u8),
+    libc_file: ?[]const u8 = null,
     installed_files: ArrayList(InstalledFile),
     build_root: []const u8,
     cache_root: []const u8,
@@ -2474,6 +2475,9 @@ pub const LibExeObjStep = struct {
         if (self.libc_file) |libc_file| {
             try zig_args.append("--libc");
             try zig_args.append(libc_file.getPath(self.builder));
+        } else if (builder.libc_file) |libc_file| {
+            try zig_args.append("--libc");
+            try zig_args.append(libc_file);
         }
 
         switch (self.build_mode) {

--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -110,6 +110,12 @@ pub fn main() !void {
                     return usageAndErr(builder, false, stderr_stream);
                 };
                 builder.addSearchPrefix(search_prefix);
+            } else if (mem.eql(u8, arg, "--libc")) {
+                const libc_file = nextArg(args, &arg_idx) orelse {
+                    warn("Expected argument after --libc\n\n", .{});
+                    return usageAndErr(builder, false, stderr_stream);
+                };
+                builder.libc_file = libc_file;
             } else if (mem.eql(u8, arg, "--color")) {
                 const next_arg = nextArg(args, &arg_idx) orelse {
                     warn("expected [auto|on|off] after --color", .{});
@@ -209,6 +215,7 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
         \\  --prefix-include-dir [path] Override default include directory path
         \\
         \\  --search-prefix [path]      Add a path to look for binaries, libraries, headers
+        \\  --libc [file]               Provide a file which specifies libc paths
         \\
         \\  -h, --help                  Print this help and exit
         \\  --verbose                   Print commands before executing them


### PR DESCRIPTION
This new option sets a default libc paths file to be used for all
LibExeObjSteps. Setting LibExeObjStep.libc_file overrides this default.

This is required to allow users to cross compile projects linking system
libraries without needing to patch the build.zig.