### PR TITLE
zig c++: fix libcxx build and add support for wasm32-wasi target.

### DIFF
--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -141,6 +141,7 @@ pub fn buildLibCXX(comp: *Compilation) !void {
         if (target.os.tag == .wasi) {
             // WASI doesn't support thread yet.
             try cflags.append("-D_LIBCPP_HAS_NO_THREADS");
+            // Also, exception is not supported yet.
             try cflags.append("-fno-exceptions");
         }
 

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -139,9 +139,8 @@ pub fn buildLibCXX(comp: *Compilation) !void {
         }
 
         if (target.os.tag == .wasi) {
-            // WASI doesn't support thread yet.
+            // WASI doesn't support thread and exception yet.
             try cflags.append("-D_LIBCPP_HAS_NO_THREADS");
-            // Also, exception is not supported yet.
             try cflags.append("-fno-exceptions");
         }
 
@@ -253,13 +252,12 @@ pub fn buildLibCXXABI(comp: *Compilation) !void {
         var cflags = std.ArrayList([]const u8).init(arena);
 
         if (target.os.tag == .wasi) {
-            // WASI doesn't support thread yet.
+            // WASI doesn't support thread and exception yet.
             if (std.mem.startsWith(u8, cxxabi_src, "src/cxa_thread_atexit.cpp") or
                 std.mem.startsWith(u8, cxxabi_src, "src/cxa_exception.cpp") or
                 std.mem.startsWith(u8, cxxabi_src, "src/cxa_personality.cpp"))
                 continue;
             try cflags.append("-D_LIBCXXABI_HAS_NO_THREADS");
-            // Also, exception is not supported yet.
             try cflags.append("-fno-exceptions");
         } else {
             try cflags.append("-DHAVE___CXA_THREAD_ATEXIT_IMPL");

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -113,11 +113,13 @@ pub fn buildLibCXX(comp: *Compilation) !void {
     for (libcxx_files) |cxx_src| {
         var cflags = std.ArrayList([]const u8).init(arena);
 
-        if (target.os.tag == .windows) {
-            // Filesystem stuff isn't supported on Windows.
+        if (target.os.tag == .windows or target.os.tag == .wasi) {
+            // Filesystem stuff isn't supported on Windows and WASI.
             if (std.mem.startsWith(u8, cxx_src, "src/filesystem/"))
                 continue;
-        } else {
+        }
+
+        if (target.os.tag != .windows) {
             if (std.mem.startsWith(u8, cxx_src, "src/support/win32/"))
                 continue;
         }
@@ -133,7 +135,7 @@ pub fn buildLibCXX(comp: *Compilation) !void {
         try cflags.append("-fvisibility=hidden");
         try cflags.append("-fvisibility-inlines-hidden");
 
-        if (target.abi.isMusl()) {
+        if (target.abi.isMusl() or target.os.tag == .wasi) {
             try cflags.append("-D_LIBCPP_HAS_MUSL_LIBC");
         }
 
@@ -252,7 +254,7 @@ pub fn buildLibCXXABI(comp: *Compilation) !void {
         try cflags.append("-fvisibility=hidden");
         try cflags.append("-fvisibility-inlines-hidden");
 
-        if (target.abi.isMusl()) {
+        if (target.abi.isMusl() or target.os.tag == .wasi) {
             try cflags.append("-D_LIBCPP_HAS_MUSL_LIBC");
         }
 

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -716,6 +716,10 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
                     ));
                     try argv.append(try comp.get_libc_crt_file(arena, "libc.a"));
                 }
+
+                if (self.base.options.link_libcpp) {
+                    try argv.append(comp.libcxx_static_lib.?.full_object_path);
+                }
             }
         }
 

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -719,6 +719,7 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
 
                 if (self.base.options.link_libcpp) {
                     try argv.append(comp.libcxx_static_lib.?.full_object_path);
+                    try argv.append(comp.libcxxabi_static_lib.?.full_object_path);
                 }
             }
         }


### PR DESCRIPTION
This is basically following wasi-sdk's [Makefile](https://github.com/WebAssembly/wasi-sdk/blob/main/Makefile#L127-L164), and notably I emulated the behavior of [`LIBCXX_ENABLE_FILESYSTEM:BOOL`](https://github.com/llvm/llvm-project/blob/ceccfaae140d2a067d9023a9a3ca71efc86f9e2d/llvm/utils/gn/secondary/libcxx/src/BUILD.gn#L184-L194) CMake flag, and completely disabled the threading APIs. This resolves https://github.com/ziglang/zig/issues/9044 without modifying libcxx. Ref: https://github.com/WebAssembly/wasi-sdk/issues/125
