### PR TITLE
stage2: Remove special double ampersand parsing case

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -999,7 +999,7 @@ fn tokenizeAndPrintRaw(docgen_tokenizer: *Tokenizer, out: anytype, source_token:
             .tilde,
             => try writeEscaped(out, src[token.loc.start..token.loc.end]),
 
-            .invalid, .invalid_ampersands, .invalid_periodasterisks => return parseError(
+            .invalid, .invalid_periodasterisks => return parseError(
                 docgen_tokenizer,
                 source_token,
                 "syntax error",

--- a/lib/std/zig/ast.zig
+++ b/lib/std/zig/ast.zig
@@ -280,9 +280,6 @@ pub const Tree = struct {
                     token_tags[parse_error.token].symbol(),
                 });
             },
-            .invalid_and => {
-                return stream.writeAll("`&&` is invalid; note that `and` is boolean AND");
-            },
             .invalid_bit_range => {
                 return stream.writeAll("bit range not allowed on slices and arrays");
             },
@@ -2412,7 +2409,6 @@ pub const Error = struct {
         extra_const_qualifier,
         extra_volatile_qualifier,
         ptr_mod_on_array_child_type,
-        invalid_and,
         invalid_bit_range,
         invalid_token,
         same_line_doc_comment,

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -1333,7 +1333,6 @@ const Parser = struct {
         .keyword_or = .{ .prec = 10, .tag = .bool_or },
 
         .keyword_and = .{ .prec = 20, .tag = .bool_and },
-        .invalid_ampersands = .{ .prec = 20, .tag = .bool_and },
 
         .equal_equal = .{ .prec = 30, .tag = .equal_equal, .assoc = Assoc.none },
         .bang_equal = .{ .prec = 30, .tag = .bang_equal, .assoc = Assoc.none },
@@ -1384,9 +1383,6 @@ const Parser = struct {
             switch (tok_tag) {
                 .keyword_catch => {
                     _ = try p.parsePayload();
-                },
-                .invalid_ampersands => {
-                    try p.warn(.invalid_and);
                 },
                 else => {},
             }

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -4930,7 +4930,6 @@ test "recovery: missing comma" {
     , &[_]Error{
         .expected_token,
         .expected_token,
-        .invalid_and,
         .invalid_token,
     });
 }
@@ -4963,7 +4962,6 @@ test "recovery: missing return type" {
         \\test ""
     , &[_]Error{
         .expected_return_type,
-        .invalid_and,
         .expected_block,
     });
 }
@@ -4980,7 +4978,6 @@ test "recovery: continue after invalid decl" {
         .expected_token,
         .expected_pub_item,
         .expected_param_list,
-        .invalid_and,
     });
     try testError(
         \\threadlocal test "" {
@@ -4989,7 +4986,6 @@ test "recovery: continue after invalid decl" {
     , &[_]Error{
         .expected_var_decl,
         .expected_param_list,
-        .invalid_and,
     });
 }
 
@@ -4998,13 +4994,11 @@ test "recovery: invalid extern/inline" {
         \\inline test "" { a && b; }
     , &[_]Error{
         .expected_fn,
-        .invalid_and,
     });
     try testError(
         \\extern "" test "" { a && b; }
     , &[_]Error{
         .expected_var_decl_or_fn,
-        .invalid_and,
     });
 }
 
@@ -5016,9 +5010,7 @@ test "recovery: missing semicolon" {
         \\    @foo
         \\}
     , &[_]Error{
-        .invalid_and,
         .expected_token,
-        .invalid_and,
         .expected_token,
         .expected_param_list,
         .expected_token,
@@ -5038,7 +5030,6 @@ test "recovery: invalid container members" {
         .expected_expr,
         .expected_token,
         .expected_container_members,
-        .invalid_and,
         .expected_token,
     });
 }
@@ -5076,7 +5067,6 @@ test "recovery: invalid global error set access" {
     , &[_]Error{
         .expected_token,
         .expected_token,
-        .invalid_and,
     });
 }
 
@@ -5094,7 +5084,6 @@ test "recovery: invalid asterisk after pointer dereference" {
         \\}
     , &[_]Error{
         .asterisk_after_ptr_deref,
-        .invalid_and,
     });
 }
 
@@ -5110,7 +5099,6 @@ test "recovery: missing semicolon after if, for, while stmt" {
         .expected_semi_or_else,
         .expected_semi_or_else,
         .expected_semi_or_else,
-        .invalid_and,
     });
 }
 

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -76,7 +76,6 @@ pub const Token = struct {
 
     pub const Tag = enum {
         invalid,
-        invalid_ampersands,
         invalid_periodasterisks,
         identifier,
         string_literal,
@@ -210,7 +209,6 @@ pub const Token = struct {
                 .container_doc_comment,
                 => null,
 
-                .invalid_ampersands => "&&",
                 .invalid_periodasterisks => ".**",
                 .bang => "!",
                 .pipe => "|",
@@ -579,11 +577,6 @@ pub const Tokenizer = struct {
                 },
 
                 .ampersand => switch (c) {
-                    '&' => {
-                        result.tag = .invalid_ampersands;
-                        self.index += 1;
-                        break;
-                    },
                     '=' => {
                         result.tag = .ampersand_equal;
                         self.index += 1;

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -554,14 +554,19 @@ fn expr(gz: *GenZir, scope: *Scope, rl: ResultLoc, node: ast.Node.Index) InnerEr
         .bit_and  => {
             const current_ampersand_token = main_tokens[node];
             if (token_tags[current_ampersand_token + 1] == .ampersand) {
-                return astgen.failTok(
-                    current_ampersand_token,
-                    "`&&` is invalid; note that `and` is boolean AND",
-                    .{},
-                );
-            } else {
-                return simpleBinOp(gz, scope, rl, node, .bit_and);
+                const token_starts = tree.tokens.items(.start);
+                const current_token_offset = token_starts[current_ampersand_token];
+                const next_token_offset = token_starts[current_ampersand_token + 1];
+                if (current_token_offset + 1 == next_token_offset) {
+                    return astgen.failTok(
+                        current_ampersand_token,
+                        "`&&` is invalid; note that `and` is boolean AND",
+                        .{},
+                    );
+                }
             }
+
+            return simpleBinOp(gz, scope, rl, node, .bit_and);
         },
         .bit_or   => return simpleBinOp(gz, scope, rl, node, .bit_or),
         .bit_xor  => return simpleBinOp(gz, scope, rl, node, .xor),

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -551,7 +551,18 @@ fn expr(gz: *GenZir, scope: *Scope, rl: ResultLoc, node: ast.Node.Index) InnerEr
         .mul_wrap => return simpleBinOp(gz, scope, rl, node, .mulwrap),
         .div      => return simpleBinOp(gz, scope, rl, node, .div),
         .mod      => return simpleBinOp(gz, scope, rl, node, .mod_rem),
-        .bit_and  => return simpleBinOp(gz, scope, rl, node, .bit_and),
+        .bit_and  => {
+            const current_ampersand_token = main_tokens[node];
+            if (token_tags[current_ampersand_token + 1] == .ampersand) {
+                return astgen.failTok(
+                    current_ampersand_token,
+                    "`&&` is invalid; note that `and` is boolean AND",
+                    .{},
+                );
+            } else {
+                return simpleBinOp(gz, scope, rl, node, .bit_and);
+            }
+        },
         .bit_or   => return simpleBinOp(gz, scope, rl, node, .bit_or),
         .bit_xor  => return simpleBinOp(gz, scope, rl, node, .xor),
 

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1000,10 +1000,6 @@ pub fn addCases(ctx: *TestContext) !void {
         \\}
     , &[_][]const u8{":2:3: error: this is an error"});
 
-    ctx.compileError("double ampersand as boolean and", linux_x64,
-        \\const a = if (true && false) 1 else 2;
-    , &[_][]const u8{":1:20: error: `&&` is invalid; note that `and` is boolean AND"});
-
     {
         var case = ctx.obj("variable shadowing", linux_x64);
         case.addError(
@@ -1568,5 +1564,28 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    return;
             \\}
         , "HeHelHellHello");
+    }
+
+    {
+        var case = ctx.exe("double ampersand", linux_x64);
+
+        case.addError(
+            \\const a = if (true && false) 1 else 2;
+        , &[_][]const u8{":1:20: error: `&&` is invalid; note that `and` is boolean AND"});
+
+        case.addError(
+            \\pub fn main() void {
+            \\    const a = true;
+            \\    const b = false;
+            \\    const c = a & &b;
+            \\}
+        , &[_][]const u8{":4:17: error: incompatible types: 'bool' and '*const bool'"});
+
+        case.addCompareOutput(
+            \\pub fn main() void {
+            \\    const b: u8 = 1;
+            \\    const c = &&b;
+            \\}
+        , "");
     }
 }

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1000,6 +1000,10 @@ pub fn addCases(ctx: *TestContext) !void {
         \\}
     , &[_][]const u8{":2:3: error: this is an error"});
 
+    ctx.compileError("double ampersand as boolean and", linux_x64,
+        \\const a = if (true && false) 1 else 2;
+    , &[_][]const u8{":1:20: error: `&&` is invalid; note that `and` is boolean AND"});
+
     {
         var case = ctx.obj("variable shadowing", linux_x64);
         case.addError(

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -1570,21 +1570,21 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("double ampersand", linux_x64);
 
         case.addError(
-            \\const a = if (true && false) 1 else 2;
-        , &[_][]const u8{":1:20: error: `&&` is invalid; note that `and` is boolean AND"});
+            \\pub const a = if (true && false) 1 else 2;
+        , &[_][]const u8{":1:24: error: `&&` is invalid; note that `and` is boolean AND"});
 
         case.addError(
             \\pub fn main() void {
             \\    const a = true;
             \\    const b = false;
-            \\    const c = a & &b;
+            \\    _ = a & &b;
             \\}
-        , &[_][]const u8{":4:17: error: incompatible types: 'bool' and '*const bool'"});
+        , &[_][]const u8{":4:11: error: incompatible types: 'bool' and '*const bool'"});
 
         case.addCompareOutput(
             \\pub fn main() void {
             \\    const b: u8 = 1;
-            \\    const c = &&b;
+            \\    _ = &&b;
             \\}
         , "");
     }


### PR DESCRIPTION
Fixes #8046

I'm stuck with finding how to generate an error on AstGen level. My assumption is that I should insert `astgen.failTok` somewhere [here](https://github.com/ziglang/zig/blob/master/src/AstGen.zig#L686-L689). Or in a better place where the tree is analyzed and not constructed. For that I'd want to understand how zig parses the now incorrect structure into AST, I tried to get a flattened AST with the following snippet and so far failed:
```zig
const std = @import("std");

pub fn main() !void {
    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
    defer arena.deinit();
    const ally = &arena.allocator;

    const src =
        \\const a = (true && false);
    ;
    const tree = try std.zig.parse(ally, src);
    const rendered_tree = try tree.render(ally);
    std.debug.print("{s}\n", .{rendered_tree});
}
```

I'm new here, let me know if I'm doing something wrong.