### PR TITLE
std: don't reference non-existant ComptimeStringHashMap type

### DIFF
--- a/lib/std/comptime_string_map.zig
+++ b/lib/std/comptime_string_map.zig
@@ -6,7 +6,7 @@
 const std = @import("std.zig");
 const mem = std.mem;
 
-/// Like ComptimeStringHashMap but optimized for small sets of disparate string keys.
+/// Comptime string map optimized for small sets of disparate string keys.
 /// Works by separating the keys by length at comptime and only checking strings of
 /// equal length at runtime.
 ///


### PR DESCRIPTION
This doesn't exist in the repo as https://github.com/ziglang/zig/pull/5359 was never merged.