### PR TITLE
zld: clean up stubs resolution, error messages and use ld64 defaults for system libs resolution

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -758,10 +758,11 @@ fn linkWithLLD(self: *MachO, comp: *Compilation) !void {
                 }
             }
 
-            // Search for static libraries first, then dynamic libraries.
-            // TODO Respect flags such as -search_paths_first to the linker.
+            // Assume ld64 default: -search_paths_first
+            // Look in each directory for a dylib (tbd), and then for archive
+            // TODO implement alternative: -search_dylibs_first
             // TODO text-based API, or .tbd files.
-            const exts = &[_][]const u8{ "a", "dylib" };
+            const exts = &[_][]const u8{ "dylib", "a" };
 
             for (search_lib_names.items) |l_name| {
                 var found = false;


### PR DESCRIPTION
* stubs can also be resolved by scanning `.unsigned` reloc type (e.g., as part of `__data` section)
* clean up error messages for failed relocation target resolution - now, this is an internal linker error
* assume Apple's `ld64` default for system libs resolution - `-search_paths_first` which looks up a dylib first in a search path, and if that fails, tries to fallback on a static archive before moving on

---

cc @MasterQ32 @moosichu this change allowed to successfully link against `libSDL2.dylib` and create a working executable on my M1:

```zig
const c = @cImport({
    @cInclude("SDL2/SDL.h");
});

pub fn main() !void {
    if (c.SDL_Init(c.SDL_INIT_VIDEO) != 0) return error.SdlInitFailed;
    defer c.SDL_Quit();

    const screen = c.SDL_CreateWindow("Hello SDL", c.SDL_WINDOWPOS_UNDEFINED, c.SDL_WINDOWPOS_UNDEFINED, 800, 600, c.SDL_WINDOW_OPENGL) orelse return error.SdlCreateWindowFailed;
    defer c.SDL_DestroyWindow(screen);

    main_loop: while (true) {
        var event: c.SDL_Event = undefined;
        while (c.SDL_PollEvent(&event) != 0) switch (event.@"type") {
            c.SDL_QUIT => break :main_loop,
            else => {},
        };
        c.SDL_Delay(17);
    }
}
```

```
zig build-exe img.zig -target aarch64-macos -I$(brew --prefix sdl2)/include -L$(brew --prefix sdl2)/lib -lsdl2
```