### PR TITLE
enables user-custom code to work with LI and SI

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -36,7 +36,7 @@ pub const LineInfo = struct {
     file_name: []const u8,
     allocator: ?*mem.Allocator,
 
-    fn deinit(self: LineInfo) void {
+    pub fn deinit(self: LineInfo) void {
         const allocator = self.allocator orelse return;
         allocator.free(self.file_name);
     }
@@ -47,7 +47,7 @@ pub const SymbolInfo = struct {
     compile_unit_name: []const u8 = "???",
     line_info: ?LineInfo = null,
 
-    fn deinit(self: @This()) void {
+    pub fn deinit(self: @This()) void {
         if (self.line_info) |li| {
             li.deinit();
         }


### PR DESCRIPTION
if user code wants to play around stacktraces, making these functions public lets that code be a good citizen and clean up the resources which get created (usually by other pub functions).