### PR TITLE
stage2 Sema: add type resolving from comptime_float to float

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7365,6 +7365,15 @@ fn resolvePeerTypes(sema: *Sema, block: *Scope.Block, src: LazySrcLoc, instructi
             continue;
         }
 
+        if (chosen.ty.zigTypeTag() == .ComptimeFloat and candidate.ty.isFloat()) {
+            chosen = candidate;
+            continue;
+        }
+
+        if (chosen.ty.isFloat() and candidate.ty.zigTypeTag() == .ComptimeFloat) {
+            continue;
+        }
+
         if (chosen.ty.zigTypeTag() == .Enum and candidate.ty.zigTypeTag() == .EnumLiteral) {
             continue;
         }


### PR DESCRIPTION
Now, this code passes semantic analysis:

```zig
pub fn main() !void {
    var x: f32 = 1.0;
    var y = x * 2.0;
}
```