### PR TITLE
netbsd: add args to limit number of PT_LOAD segs

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -191,6 +191,7 @@ pub usingnamespace switch (builtin.os.tag) {
         pub const sigaction = __sigaction14;
         pub const sigaltstack = __sigaltstack14;
         pub const sigprocmask = __sigprocmask14;
+        pub const socket = __socket30;
         pub const stat = __stat50;
     },
     .macos, .ios, .watchos, .tvos => struct {

--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -19,7 +19,7 @@ const max = std.math.max;
 pub const DynLib = switch (builtin.os.tag) {
     .linux => if (builtin.link_libc) DlDynlib else ElfDynLib,
     .windows => WindowsDynLib,
-    .macos, .tvos, .watchos, .ios, .freebsd, .openbsd, .dragonfly => DlDynlib,
+    .macos, .tvos, .watchos, .ios, .freebsd, .netbsd, .openbsd, .dragonfly => DlDynlib,
     else => void,
 };
 

--- a/lib/std/os/bits/netbsd.zig
+++ b/lib/std/os/bits/netbsd.zig
@@ -34,6 +34,17 @@ pub const Kevent = extern struct {
     udata: usize,
 };
 
+pub const RTLD_LAZY = 1;
+pub const RTLD_NOW = 2;
+pub const RTLD_GLOBAL = 0x100;
+pub const RTLD_LOCAL = 0x200;
+pub const RTLD_NODELETE = 0x01000;
+pub const RTLD_NOLOAD = 0x02000;
+
+pub const RTLD_NEXT = @intToPtr(*c_void, @bitCast(usize, @as(isize, -1)));
+pub const RTLD_DEFAULT = @intToPtr(*c_void, @bitCast(usize, @as(isize, -2)));
+pub const RTLD_SELF = @intToPtr(*c_void, @bitCast(usize, @as(isize, -3)));
+
 pub const dl_phdr_info = extern struct {
     dlpi_addr: usize,
     dlpi_name: ?[*:0]const u8,
@@ -211,6 +222,121 @@ pub const dirent = extern struct {
         return self.d_reclen;
     }
 };
+
+pub const SOCK_STREAM = 1;
+pub const SOCK_DGRAM = 2;
+pub const SOCK_RAW = 3;
+pub const SOCK_RDM = 4;
+pub const SOCK_SEQPACKET = 5;
+pub const SOCK_CONN_DGRAM = 6;
+pub const SOCK_DCCP = SOCK_CONN_DGRAM;
+
+pub const SOCK_CLOEXEC = 0x10000000;
+pub const SOCK_NONBLOCK = 0x20000000;
+pub const SOCK_NOSIGPIPE = 0x40000000;
+pub const SOCK_FLAGS_MASK = 0xf0000000;
+
+pub const SO_DEBUG = 0x0001;
+pub const SO_ACCEPTCONN = 0x0002;
+pub const SO_REUSEADDR = 0x0004;
+pub const SO_KEEPALIVE = 0x0008;
+pub const SO_DONTROUTE = 0x0010;
+pub const SO_BROADCAST = 0x0020;
+pub const SO_USELOOPBACK = 0x0040;
+pub const SO_LINGER = 0x0080;
+pub const SO_OOBINLINE = 0x0100;
+pub const SO_REUSEPORT = 0x0200;
+pub const SO_NOSIGPIPE = 0x0800;
+pub const SO_ACCEPTFILTER = 0x1000;
+pub const SO_TIMESTAMP = 0x2000;
+pub const SO_RERROR = 0x4000;
+
+pub const SO_SNDBUF = 0x1001;
+pub const SO_RCVBUF = 0x1002;
+pub const SO_SNDLOWAT = 0x1003;
+pub const SO_RCVLOWAT = 0x1004;
+pub const SO_ERROR = 0x1007;
+pub const SO_TYPE = 0x1008;
+pub const SO_OVERFLOWED = 0x1009;
+
+pub const SO_NOHEADER = 0x100a;
+pub const SO_SNDTIMEO = 0x100b;
+pub const SO_RCVTIMEO = 0x100c;
+
+pub const SOL_SOCKET = 0xffff;
+
+pub const PF_UNSPEC = AF_UNSPEC;
+pub const PF_LOCAL = AF_LOCAL;
+pub const PF_UNIX = PF_LOCAL;
+pub const PF_INET = AF_INET;
+pub const PF_IMPLINK = AF_IMPLINK;
+pub const PF_PUP = AF_PUP;
+pub const PF_CHAOS = AF_CHAOS;
+pub const PF_NS = AF_NS;
+pub const PF_ISO = AF_ISO;
+pub const PF_OSI = AF_ISO;
+pub const PF_ECMA = AF_ECMA;
+pub const PF_DATAKIT = AF_DATAKIT;
+pub const PF_CCITT = AF_CCITT;
+pub const PF_SNA = AF_SNA;
+pub const PF_DECnet = AF_DECnet;
+pub const PF_DLI = AF_DLI;
+pub const PF_LAT = AF_LAT;
+pub const PF_HYLINK = AF_HYLINK;
+pub const PF_APPLETALK = AF_APPLETALK;
+pub const PF_OROUTE = AF_OROUTE;
+pub const PF_LINK = AF_LINK;
+pub const PF_COIP = AF_COIP;
+pub const PF_CNT = AF_CNT;
+pub const PF_INET6 = AF_INET6;
+pub const PF_IPX = AF_IPX;
+pub const PF_ISDN = AF_ISDN;
+pub const PF_E164 = AF_E164;
+pub const PF_NATM = AF_NATM;
+pub const PF_ARP = AF_ARP;
+pub const PF_BLUETOOTH = AF_BLUETOOTH;
+pub const PF_MPLS = AF_MPLS;
+pub const PF_ROUTE = AF_ROUTE;
+pub const PF_CAN = AF_CAN;
+pub const PF_ETHER = AF_ETHER;
+pub const PF_MAX = AF_MAX;
+
+pub const AF_UNSPEC = 0;
+pub const AF_LOCAL = 1;
+pub const AF_UNIX = AF_LOCAL;
+pub const AF_INET = 2;
+pub const AF_IMPLINK = 3;
+pub const AF_PUP = 4;
+pub const AF_CHAOS = 5;
+pub const AF_NS = 6;
+pub const AF_ISO = 7;
+pub const AF_OSI = AF_ISO;
+pub const AF_ECMA = 8;
+pub const AF_DATAKIT = 9;
+pub const AF_CCITT = 10;
+pub const AF_SNA = 11;
+pub const AF_DECnet = 12;
+pub const AF_DLI = 13;
+pub const AF_LAT = 14;
+pub const AF_HYLINK = 15;
+pub const AF_APPLETALK = 16;
+pub const AF_OROUTE = 17;
+pub const AF_LINK = 18;
+pub const AF_COIP = 20;
+pub const AF_CNT = 21;
+pub const AF_IPX = 23;
+pub const AF_INET6 = 24;
+pub const AF_ISDN = 26;
+pub const AF_E164 = AF_ISDN;
+pub const AF_NATM = 27;
+pub const AF_ARP = 28;
+pub const AF_BLUETOOTH = 31;
+pub const AF_IEEE80211 = 32;
+pub const AF_MPLS = 33;
+pub const AF_ROUTE = 34;
+pub const AF_CAN = 35;
+pub const AF_ETHER = 36;
+pub const AF_MAX = 37;
 
 pub const in_port_t = u16;
 pub const sa_family_t = u8;
@@ -470,48 +596,6 @@ pub const SEEK_END = 2;
 pub const SIG_BLOCK = 1;
 pub const SIG_UNBLOCK = 2;
 pub const SIG_SETMASK = 3;
-
-pub const SOCK_STREAM = 1;
-pub const SOCK_DGRAM = 2;
-pub const SOCK_RAW = 3;
-pub const SOCK_RDM = 4;
-pub const SOCK_SEQPACKET = 5;
-
-pub const SOCK_CLOEXEC = 0x10000000;
-pub const SOCK_NONBLOCK = 0x20000000;
-
-pub const PF_UNSPEC = 0;
-pub const PF_LOCAL = 1;
-pub const PF_UNIX = PF_LOCAL;
-pub const PF_FILE = PF_LOCAL;
-pub const PF_INET = 2;
-pub const PF_APPLETALK = 16;
-pub const PF_INET6 = 24;
-pub const PF_DECnet = 12;
-pub const PF_KEY = 29;
-pub const PF_ROUTE = 34;
-pub const PF_SNA = 11;
-pub const PF_MPLS = 33;
-pub const PF_CAN = 35;
-pub const PF_BLUETOOTH = 31;
-pub const PF_ISDN = 26;
-pub const PF_MAX = 37;
-
-pub const AF_UNSPEC = PF_UNSPEC;
-pub const AF_LOCAL = PF_LOCAL;
-pub const AF_UNIX = AF_LOCAL;
-pub const AF_FILE = AF_LOCAL;
-pub const AF_INET = PF_INET;
-pub const AF_APPLETALK = PF_APPLETALK;
-pub const AF_INET6 = PF_INET6;
-pub const AF_KEY = PF_KEY;
-pub const AF_ROUTE = PF_ROUTE;
-pub const AF_SNA = PF_SNA;
-pub const AF_MPLS = PF_MPLS;
-pub const AF_CAN = PF_CAN;
-pub const AF_BLUETOOTH = PF_BLUETOOTH;
-pub const AF_ISDN = PF_ISDN;
-pub const AF_MAX = PF_MAX;
 
 pub const DT_UNKNOWN = 0;
 pub const DT_FIFO = 1;

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -732,8 +732,16 @@ test "sigaction" {
     const S = struct {
         fn handler(sig: i32, info: *const os.siginfo_t, ctx_ptr: ?*const c_void) callconv(.C) void {
             // Check that we received the correct signal.
-            if (sig == os.SIGUSR1 and sig == info.signo)
-                signal_test_failed = false;
+            switch (native_os) {
+                .netbsd => {
+                    if (sig == os.SIGUSR1 and sig == info.info.signo)
+                        signal_test_failed = false;
+                },
+                else => {
+                    if (sig == os.SIGUSR1 and sig == info.signo)
+                        signal_test_failed = false;
+                },
+            }
         }
     };
 

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1496,6 +1496,15 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
             try argv.append("-pie");
         }
 
+        if (self.base.options.link_mode == .Dynamic and target.os.tag == .netbsd) {
+            // Add options to produce shared objects with only 2 PT_LOAD segments.
+            // NetBSD expects 2 PT_LOAD segments in a shared object, otherwise
+            // ld.elf_so fails to load, emitting a general "not found" error.
+            // See https://github.com/ziglang/zig/issues/9109 .
+            try argv.append("--no-rosegment");
+            try argv.append("-znorelro");
+        }
+
         try argv.append("-o");
         try argv.append(full_out_path);
 


### PR DESCRIPTION
netbsd: add args to limit number of PT_LOAD segs

NetBSD expects 2 PT_LOAD segments in a shared object, otherwise
ld.elf_so fails to load, emitting a general "not found" error.

Workaround issue by adding args `--no-rosegment` and `-znorelro`.

see #9109