### PR TITLE
stage1: Store the specified code model in the LLVM module

### DIFF
--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -9289,6 +9289,10 @@ static void init(CodeGen *g) {
         ZigLLVMSetModulePIELevel(g->module);
     }
 
+    if (g->code_model != CodeModelDefault) {
+        ZigLLVMSetModuleCodeModel(g->module, to_llvm_code_model(g));
+    }
+
     const char *target_specific_cpu_args = "";
     const char *target_specific_features = "";
 

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -969,6 +969,12 @@ void ZigLLVMSetModulePIELevel(LLVMModuleRef module) {
     unwrap(module)->setPIELevel(PIELevel::Level::Large);
 }
 
+void ZigLLVMSetModuleCodeModel(LLVMModuleRef module, LLVMCodeModel code_model) {
+    bool JIT;
+    unwrap(module)->setCodeModel(*unwrap(code_model, JIT));
+    assert(!JIT);
+}
+
 static AtomicOrdering mapFromLLVMOrdering(LLVMAtomicOrdering Ordering) {
     switch (Ordering) {
         case LLVMAtomicOrderingNotAtomic: return AtomicOrdering::NotAtomic;

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -208,6 +208,7 @@ ZIG_EXTERN_C void ZigLLVMAddModuleDebugInfoFlag(LLVMModuleRef module);
 ZIG_EXTERN_C void ZigLLVMAddModuleCodeViewFlag(LLVMModuleRef module);
 ZIG_EXTERN_C void ZigLLVMSetModulePICLevel(LLVMModuleRef module);
 ZIG_EXTERN_C void ZigLLVMSetModulePIELevel(LLVMModuleRef module);
+ZIG_EXTERN_C void ZigLLVMSetModuleCodeModel(LLVMModuleRef module, LLVMCodeModel code_model);
 
 ZIG_EXTERN_C void ZigLLVMSetCurrentDebugLocation(LLVMBuilderRef builder, int line, int column,
         struct ZigLLVMDIScope *scope);


### PR DESCRIPTION
This is needed for LTO builds to pick up the correct module.

Closes #9132

@leecannon please confirm this works for you.