### PR TITLE
HashMap.getOrPutAssumeCapacityAdapted should set key to undefined

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1884,6 +1884,52 @@ test "std.hash_map clone" {
     }
 }
 
+test "std.hash_map getOrPutAdapted" {
+    const AdaptedContext = struct {
+        fn eql(self: @This(), adapted_key: []const u8, test_key: u64) bool {
+            return std.fmt.parseInt(u64, adapted_key, 10) catch unreachable == test_key;
+        }
+        fn hash(self: @This(), adapted_key: []const u8) u64 {
+            const key = std.fmt.parseInt(u64, adapted_key, 10) catch unreachable;
+            return (AutoContext(u64){}).hash(key);
+        }
+    };
+    var map = AutoHashMap(u64, u64).init(testing.allocator);
+    defer map.deinit();
+
+    const keys = [_][]const u8{
+        "1231",
+        "4564",
+        "7894",
+        "1132",
+        "65235",
+        "95462",
+        "0112305",
+        "00658",
+        "0",
+        "2",
+    };
+
+    var real_keys: [keys.len]u64 = undefined;
+
+    inline for (keys) |key_str, i| {
+        const result = try map.getOrPutAdapted(key_str, AdaptedContext{});
+        try testing.expect(!result.found_existing);
+        real_keys[i] = std.fmt.parseInt(u64, key_str, 10) catch unreachable;
+        result.key_ptr.* = real_keys[i];
+        result.value_ptr.* = i * 2;
+    }
+
+    try testing.expectEqual(map.count(), keys.len);
+
+    inline for (keys) |key_str, i| {
+        const result = try map.getOrPutAdapted(key_str, AdaptedContext{});
+        try testing.expect(result.found_existing);
+        try testing.expectEqual(real_keys[i], result.key_ptr.*);
+        try testing.expectEqual(@as(u64, i) * 2, result.value_ptr.*);
+    }
+}
+
 test "compile everything" {
     std.testing.refAllDecls(AutoHashMap(i32, i32));
     std.testing.refAllDecls(StringHashMap([]const u8));

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1236,7 +1236,7 @@ pub fn HashMapUnmanaged(
             metadata[0].fill(fingerprint);
             const new_key = &self.keys()[idx];
             const new_value = &self.values()[idx];
-            new_key.* = key;
+            new_key.* = undefined;
             new_value.* = undefined;
             self.size += 1;
 


### PR DESCRIPTION
As the doc comment states, this method sets the key and value to undefined if no existing entry was found and the caller should then initialize the key and value. But it looks like the new key was mistakenly set to the adapted key passed into this method, which will cause a compile error if its type is different from the real key.