### PR TITLE
stage2: simplify codegen for errorToInt and intToError

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2506,7 +2506,7 @@ fn zirErrorToInt(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) InnerEr
     }
 
     try sema.requireRuntimeBlock(block, src);
-    return block.addUnOp(src, result_ty, .error_to_int, op_coerced);
+    return block.addUnOp(src, result_ty, .bitcast, op_coerced);
 }
 
 fn zirIntToError(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) InnerError!*Inst {
@@ -2539,7 +2539,7 @@ fn zirIntToError(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) InnerEr
         // const is_gt_max = @panic("TODO get max errors in compilation");
         // try sema.addSafetyCheck(block, is_gt_max, .invalid_error_code);
     }
-    return block.addUnOp(src, Type.initTag(.anyerror), .int_to_error, op);
+    return block.addUnOp(src, Type.initTag(.anyerror), .bitcast, op);
 }
 
 fn zirMergeErrorSets(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) InnerError!*Inst {

--- a/src/air.zig
+++ b/src/air.zig
@@ -92,10 +92,6 @@ pub const Inst = struct {
         is_err,
         /// *E!T => bool
         is_err_ptr,
-        /// E => u16
-        error_to_int,
-        /// u16 => E
-        int_to_error,
         bool_and,
         bool_or,
         /// Read a value from a pointer.
@@ -159,8 +155,6 @@ pub const Inst = struct {
                 .is_null_ptr,
                 .is_err,
                 .is_err_ptr,
-                .int_to_error,
-                .error_to_int,
                 .ptrtoint,
                 .floatcast,
                 .intcast,
@@ -730,8 +724,6 @@ const DumpTzir = struct {
                 .is_null_ptr,
                 .is_err,
                 .is_err_ptr,
-                .error_to_int,
-                .int_to_error,
                 .ptrtoint,
                 .floatcast,
                 .intcast,
@@ -865,8 +857,6 @@ const DumpTzir = struct {
                 .is_null_ptr,
                 .is_err,
                 .is_err_ptr,
-                .error_to_int,
-                .int_to_error,
                 .ptrtoint,
                 .floatcast,
                 .intcast,

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -850,8 +850,6 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                 .is_null_ptr => return self.genIsNullPtr(inst.castTag(.is_null_ptr).?),
                 .is_err => return self.genIsErr(inst.castTag(.is_err).?),
                 .is_err_ptr => return self.genIsErrPtr(inst.castTag(.is_err_ptr).?),
-                .error_to_int => return self.genErrorToInt(inst.castTag(.error_to_int).?),
-                .int_to_error => return self.genIntToError(inst.castTag(.int_to_error).?),
                 .load => return self.genLoad(inst.castTag(.load).?),
                 .loop => return self.genLoop(inst.castTag(.loop).?),
                 .not => return self.genNot(inst.castTag(.not).?),
@@ -2958,14 +2956,6 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
 
         fn genIsErrPtr(self: *Self, inst: *ir.Inst.UnOp) !MCValue {
             return self.fail(inst.base.src, "TODO load the operand and call genIsErr", .{});
-        }
-
-        fn genErrorToInt(self: *Self, inst: *ir.Inst.UnOp) !MCValue {
-            return self.resolveInst(inst.operand);
-        }
-
-        fn genIntToError(self: *Self, inst: *ir.Inst.UnOp) !MCValue {
-            return self.resolveInst(inst.operand);
         }
 
         fn genLoop(self: *Self, inst: *ir.Inst.Loop) !MCValue {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -724,8 +724,6 @@ pub fn genBody(o: *Object, body: ir.Body) error{ AnalysisFail, OutOfMemory }!voi
 
             .is_err => try genIsErr(o, inst.castTag(.is_err).?),
             .is_err_ptr => try genIsErr(o, inst.castTag(.is_err_ptr).?),
-            .error_to_int => try genErrorToInt(o, inst.castTag(.error_to_int).?),
-            .int_to_error => try genIntToError(o, inst.castTag(.int_to_error).?),
 
             .unwrap_errunion_payload => try genUnwrapErrUnionPay(o, inst.castTag(.unwrap_errunion_payload).?),
             .unwrap_errunion_err => try genUnwrapErrUnionErr(o, inst.castTag(.unwrap_errunion_err).?),
@@ -1281,14 +1279,6 @@ fn genIsErr(o: *Object, inst: *Inst.UnOp) !CValue {
     try o.writeCValue(writer, operand);
     try writer.print("){s}.error != 0;\n", .{maybe_deref});
     return local;
-}
-
-fn genIntToError(o: *Object, inst: *Inst.UnOp) !CValue {
-    return o.resolveInst(inst.operand);
-}
-
-fn genErrorToInt(o: *Object, inst: *Inst.UnOp) !CValue {
-    return o.resolveInst(inst.operand);
 }
 
 fn IndentWriter(comptime UnderlyingWriter: type) type {


### PR DESCRIPTION
We can just use bitcast instead of error_to_int, int_to_error since
errorToInt and intToError do not actually do anything, just change types.
This allows us to remove 2 air ops that were the exact same as bitcast