### PR TITLE
macho: LC_RPATH: reserve byte for null-terminator

### DIFF
--- a/src/link/MachO/Zld.zig
+++ b/src/link/MachO/Zld.zig
@@ -2511,7 +2511,7 @@ fn addRpaths(self: *Zld, rpaths: []const []const u8) !void {
     for (rpaths) |rpath| {
         const cmdsize = @intCast(u32, mem.alignForwardGeneric(
             u64,
-            @sizeOf(macho.rpath_command) + rpath.len,
+            @sizeOf(macho.rpath_command) + rpath.len + 1,
             @sizeOf(u64),
         ));
         var rpath_cmd = emptyGenericCommandWithData(macho.rpath_command{


### PR DESCRIPTION
another ob1 bug :)

bug description fixed by this PR:
- aligned buffer size is zero'd
- if rpath string is exactly size of buffer, a macho exe is created with rpath load command missing null-terminator

---

- bad (output from `otool -l foo.exe`)
```
Load command 14
          cmd LC_RPATH
      cmdsize 120
         path /Users/mike/project/zig/work/oob/test/standalone/shared_library/zig-cache/o/ac090d8df97d307d47fb7e0d6a483d49
                                                                                                                           (offset 12)
```

- good (notice there is no more garbage linefeed dumped)
```
Load command 14
          cmd LC_RPATH
      cmdsize 128
         path /Users/mike/project/zig/work/oob/test/standalone/shared_library/zig-cache/o/ac090d8df97d307d47fb7e0d6a483d49 (offset 12)
```