### PR TITLE
dragonfly: port libc++

### DIFF
--- a/lib/libcxx/include/__config
+++ b/lib/libcxx/include/__config
@@ -122,7 +122,7 @@
 #  endif
 // Feature macros for disabling pre ABI v1 features. All of these options
 // are deprecated.
-#  if defined(__FreeBSD__)
+#  if defined(__FreeBSD__) || defined(__DragonFly__)
 #    define _LIBCPP_DEPRECATED_ABI_DISABLE_PAIR_TRIVIAL_COPY_CTOR
 #  endif
 #endif
@@ -366,7 +366,7 @@
 #    if __ANDROID_API__ >= 29
 #      define _LIBCPP_HAS_TIMESPEC_GET
 #    endif
-#  elif defined(__Fuchsia__) || defined(__wasi__) || defined(__NetBSD__)
+#  elif defined(__Fuchsia__) || defined(__wasi__) || defined(__NetBSD__) || defined(__DragonFly__)
 #    define _LIBCPP_HAS_ALIGNED_ALLOC
 #    define _LIBCPP_HAS_QUICK_EXIT
 #    define _LIBCPP_HAS_TIMESPEC_GET
@@ -914,7 +914,7 @@ typedef unsigned int   char32_t;
 #endif
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(_LIBCPP_MSVCRT_LIKE) || \
-    defined(__sun__) || defined(__NetBSD__) || defined(__CloudABI__)
+    defined(__sun__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CloudABI__)
 #define _LIBCPP_LOCALE__L_EXTENSIONS 1
 #endif
 
@@ -925,7 +925,7 @@ typedef unsigned int   char32_t;
 #  endif
 #endif
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 #define _DECLARE_C99_LDBL_MATH 1
 #endif
 
@@ -954,11 +954,11 @@ typedef unsigned int   char32_t;
 #  define _LIBCPP_HAS_NO_ALIGNED_ALLOCATION
 #endif
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
 #define _LIBCPP_HAS_DEFAULTRUNELOCALE
 #endif
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__sun__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__sun__)
 #define _LIBCPP_WCTYPE_IS_MASK
 #endif
 
@@ -1125,6 +1125,7 @@ extern "C" _LIBCPP_FUNC_VIS void __sanitizer_annotate_contiguous_container(
       defined(__wasi__) || \
       defined(__NetBSD__) || \
       defined(__OpenBSD__) || \
+      defined(__DragonFly__) || \
       defined(__NuttX__) || \
       defined(__linux__) || \
       defined(__GNU__) || \

--- a/lib/libcxx/include/__locale
+++ b/lib/libcxx/include/__locale
@@ -35,7 +35,7 @@
 # include <__support/newlib/xlocale.h>
 #elif defined(__OpenBSD__)
 # include <__support/openbsd/xlocale.h>
-#elif (defined(__APPLE__)      || defined(__FreeBSD__) \
+#elif (defined(__APPLE__)      || defined(__FreeBSD__) || defined(__DragonFly__) \
     || defined(__EMSCRIPTEN__) || defined(__IBMCPP__))
 # include <xlocale.h>
 #elif defined(__Fuchsia__)
@@ -450,10 +450,10 @@ public:
     static const mask blank  = _BLANK;
     static const mask __regex_word = 0x80;
 # define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_PRINT
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__EMSCRIPTEN__) || defined(__NetBSD__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__EMSCRIPTEN__) || defined(__NetBSD__) || defined(__DragonFly__)
 # ifdef __APPLE__
     typedef __uint32_t mask;
-# elif defined(__FreeBSD__)
+# elif defined(__FreeBSD__) || defined(__DragonFly__)
     typedef unsigned long mask;
 # elif defined(__EMSCRIPTEN__) || defined(__NetBSD__)
     typedef unsigned short mask;

--- a/lib/libcxx/include/locale
+++ b/lib/libcxx/include/locale
@@ -223,7 +223,7 @@ _LIBCPP_PUSH_MACROS
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
 #  define _LIBCPP_GET_C_LOCALE 0
 #elif defined(__CloudABI__) || defined(__NetBSD__)
 #  define _LIBCPP_GET_C_LOCALE LC_C_LOCALE

--- a/lib/libcxx/src/locale.cpp
+++ b/lib/libcxx/src/locale.cpp
@@ -1133,7 +1133,7 @@ ctype<char>::classic_table()  _NOEXCEPT
 const ctype<char>::mask*
 ctype<char>::classic_table()  _NOEXCEPT
 {
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
     return _DefaultRuneLocale.__runetype;
 #elif defined(__NetBSD__)
     return _C_ctype_tab_ + 1;


### PR DESCRIPTION
Used https://github.com/DragonFlyBSD/DPorts/tree/master/devel/libc++/files
for hints as to which patches were needed.