### PR TITLE
std: Fix PIE startup sequence

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -34,6 +34,7 @@ pub usingnamespace switch (native_arch) {
 };
 pub usingnamespace @import("bits.zig");
 pub const tls = @import("linux/tls.zig");
+pub const pie = @import("linux/start_pie.zig");
 pub const BPF = @import("linux/bpf.zig");
 pub usingnamespace @import("linux/io_uring.zig");
 

--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -190,50 +190,15 @@ pub fn setThreadPointer(addr: usize) void {
     }
 }
 
-fn initTLS() void {
+fn initTLS(phdrs: []elf.Phdr) void {
     var tls_phdr: ?*elf.Phdr = null;
     var img_base: usize = 0;
 
-    const auxv = std.os.linux.elf_aux_maybe.?;
-    var at_phent: usize = undefined;
-    var at_phnum: usize = undefined;
-    var at_phdr: usize = undefined;
-    var at_hwcap: usize = undefined;
-
-    var i: usize = 0;
-    while (auxv[i].a_type != std.elf.AT_NULL) : (i += 1) {
-        switch (auxv[i].a_type) {
-            elf.AT_PHENT => at_phent = auxv[i].a_un.a_val,
-            elf.AT_PHNUM => at_phnum = auxv[i].a_un.a_val,
-            elf.AT_PHDR => at_phdr = auxv[i].a_un.a_val,
-            elf.AT_HWCAP => at_hwcap = auxv[i].a_un.a_val,
-            else => continue,
-        }
-    }
-
-    // Sanity check
-    assert(at_phent == @sizeOf(elf.Phdr));
-
-    // Find the TLS section
-    const phdrs = (@intToPtr([*]elf.Phdr, at_phdr))[0..at_phnum];
-
     for (phdrs) |*phdr| {
         switch (phdr.p_type) {
-            elf.PT_PHDR => img_base = at_phdr - phdr.p_vaddr,
+            elf.PT_PHDR => img_base = @ptrToInt(phdrs.ptr) - phdr.p_vaddr,
             elf.PT_TLS => tls_phdr = phdr,
             else => {},
-        }
-    }
-
-    // ARMv6 targets (and earlier) have no support for TLS in hardware
-    // FIXME: Elide the check for targets >= ARMv7 when the target feature API
-    // becomes less verbose (and more usable).
-    if (comptime native_arch.isARM()) {
-        if (at_hwcap & std.os.linux.HWCAP_TLS == 0) {
-            // FIXME: Make __aeabi_read_tp call the kernel helper kuser_get_tls
-            // For the time being use a simple abort instead of a @panic call to
-            // keep the binary bloat under control.
-            std.os.abort();
         }
     }
 
@@ -344,8 +309,8 @@ pub fn prepareTLS(area: []u8) usize {
 // overhead.
 var main_thread_tls_buffer: [0x2100]u8 align(mem.page_size) = undefined;
 
-pub fn initStaticTLS() void {
-    initTLS();
+pub fn initStaticTLS(phdrs: []elf.Phdr) void {
+    initTLS(phdrs);
 
     const tls_area = blk: {
         // Fast path for the common case where the TLS data is really small,

--- a/test/stage2/darwin.zig
+++ b/test/stage2/darwin.zig
@@ -14,7 +14,7 @@ pub fn addCases(ctx: *TestContext) !void {
         {
             var case = ctx.exe("hello world with updates", target);
             case.addError("", &[_][]const u8{
-                ":84:9: error: struct 'test_case.test_case' has no member named 'main'",
+                ":85:9: error: struct 'test_case.test_case' has no member named 'main'",
             });
 
             // Incorrect return type

--- a/test/stage2/test.zig
+++ b/test/stage2/test.zig
@@ -24,7 +24,7 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("hello world with updates", linux_x64);
 
         case.addError("", &[_][]const u8{
-            ":84:9: error: struct 'test_case.test_case' has no member named 'main'",
+            ":85:9: error: struct 'test_case.test_case' has no member named 'main'",
         });
 
         // Incorrect return type

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -33,6 +33,11 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     }
     cases.addBuildFile("test/standalone/c_compiler/build.zig", .{ .build_modes = true, .cross_targets = true });
 
+    // Try to build and run a PIE executable.
+    if (std.Target.current.os.tag == .linux) {
+        cases.addBuildFile("test/standalone/pie/build.zig", .{});
+    }
+
     // Ensure the development tools are buildable.
     cases.add("tools/gen_spirv_spec.zig");
     cases.add("tools/gen_stubs.zig");

--- a/test/standalone/pie/build.zig
+++ b/test/standalone/pie/build.zig
@@ -1,0 +1,12 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const main = b.addTest("main.zig");
+    main.setBuildMode(b.standardReleaseOptions());
+    main.pie = true;
+
+    const test_step = b.step("test", "Test the program");
+    test_step.dependOn(&main.step);
+
+    b.default_step.dependOn(test_step);
+}

--- a/test/standalone/pie/main.zig
+++ b/test/standalone/pie/main.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const elf = std.elf;
+
+threadlocal var foo: u8 = 42;
+
+test "Check ELF header" {
+    // PIE executables are marked as ET_DYN, regular exes as ET_EXEC.
+    const header = @intToPtr(*elf.Ehdr, std.process.getBaseAddress());
+    try std.testing.expectEqual(elf.ET.DYN, header.e_type);
+}
+
+test "TLS is initialized" {
+    // Ensure the TLS is initialized by the startup code.
+    try std.testing.expectEqual(@as(u8, 42), foo);
+}


### PR DESCRIPTION
* Don't skip the TLS initialization (Fixes #9083)
* Add a test case where a PIE program is built and run
* Refactor the common initialization code in the Linux startup
  sequence.