### PR TITLE
Stage2 sema: change implementation of @setCold to call sema.zirSetCold rather than sema.zirSetAlignStack

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -473,7 +473,7 @@ pub fn analyzeBody(
                 continue;
             },
             .set_cold => {
-                try sema.zirSetAlignStack(block, inst);
+                try sema.zirSetCold(block, inst);
                 i += 1;
                 continue;
             },


### PR DESCRIPTION
I assume this is just a typo due to copy-paste, since all the other branches call the corresponding `sema.zirFoo` function, and `sema.zirSetCold` is completely unused otherwise.