### PR TITLE
Add support for WASI reactor in pure Zig-exe.

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -457,6 +457,13 @@ pub const LinkMode = enum {
 
 /// This data structure is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
+pub const WasiExecModel = enum {
+    command,
+    reactor,
+};
+
+/// This data structure is used by the Zig language code generation and
+/// therefore must be kept in sync with the compiler implementation.
 pub const Version = struct {
     major: u32,
     minor: u32,

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -16,7 +16,7 @@ const native_os = builtin.os.tag;
 
 var argc_argv_ptr: [*]usize = undefined;
 
-const start_sym_name = if (native_arch.isMIPS()) "__start" else if (builtin.wasi_exec_model == .reactor) "_initialize" else "_start";
+const start_sym_name = if (native_arch.isMIPS()) "__start" else "_start";
 
 comptime {
     // No matter what, we import the root file, so that any export, test, comptime
@@ -65,7 +65,8 @@ comptime {
             } else if (native_os == .uefi) {
                 if (!@hasDecl(root, "EfiMain")) @export(EfiMain, .{ .name = "EfiMain" });
             } else if (native_arch.isWasm()) {
-                if (!@hasDecl(root, start_sym_name)) @export(wasm_start, .{ .name = start_sym_name });
+                const wasm_start_sym = if (builtin.wasi_exec_model == .reactor) "_initialize" else "_start";
+                if (!@hasDecl(root, start_sym_name)) @export(wasm_start, .{ .name = wasm_start_sym });
             } else if (native_os != .other and native_os != .freestanding) {
                 if (!@hasDecl(root, start_sym_name)) @export(_start, .{ .name = start_sym_name });
             }

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -66,7 +66,7 @@ comptime {
                 if (!@hasDecl(root, "EfiMain")) @export(EfiMain, .{ .name = "EfiMain" });
             } else if (native_arch.isWasm()) {
                 const wasm_start_sym = if (builtin.wasi_exec_model == .reactor) "_initialize" else "_start";
-                if (!@hasDecl(root, start_sym_name)) @export(wasm_start, .{ .name = wasm_start_sym });
+                if (!@hasDecl(root, wasm_start_sym)) @export(wasm_start, .{ .name = wasm_start_sym });
             } else if (native_os != .other and native_os != .freestanding) {
                 if (!@hasDecl(root, start_sym_name)) @export(_start, .{ .name = start_sym_name });
             }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -724,7 +724,7 @@ pub const InitOptions = struct {
     test_name_prefix: ?[]const u8 = null,
     subsystem: ?std.Target.SubSystem = null,
     /// WASI-only. Type of WASI execution model ("command" or "reactor").
-    wasi_exec_model: ?[]const u8 = null,
+    wasi_exec_model: ?std.builtin.WasiExecModel = null,
 };
 
 fn addPackageTableToCacheHash(
@@ -3638,10 +3638,14 @@ pub fn generateBuiltinZigSource(comp: *Compilation, allocator: *Allocator) Alloc
         std.zig.fmtId(@tagName(comp.bin_file.options.machine_code_model)),
     });
 
+    const wasi_exec_model_fmt = if (comp.bin_file.options.wasi_exec_model) |model|
+        std.zig.fmtId(@tagName(model))
+    else
+        std.zig.fmtId(@tagName(std.builtin.WasiExecModel.command));
     try buffer.writer().print(
-        \\pub const is_wasi_reactor_exec_model = {};
+        \\pub const wasi_exec_model = std.builtin.WasiExecModel.{};
         \\
-    , .{if (comp.bin_file.options.wasi_exec_model) |model| std.mem.eql(u8, model, "reactor") else false});
+    , .{wasi_exec_model_fmt});
 
     if (comp.bin_file.options.is_test) {
         try buffer.appendSlice(

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1449,7 +1449,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
                 });
             }
             comp.work_queue.writeAssumeCapacity(&[_]Job{
-                .{ .wasi_libc_crt_file = wasi_libc.getExecModelCrtFIle(wasi_exec_model) },
+                .{ .wasi_libc_crt_file = wasi_libc.execModelCrtFile(wasi_exec_model) },
                 .{ .wasi_libc_crt_file = .libc_a },
             });
         }
@@ -3641,7 +3641,7 @@ pub fn generateBuiltinZigSource(comp: *Compilation, allocator: *Allocator) Alloc
         std.zig.fmtId(@tagName(comp.bin_file.options.machine_code_model)),
     });
 
-    if (comp.getTarget().os.tag == .wasi) {
+    if (target.os.tag == .wasi) {
         const wasi_exec_model_fmt = std.zig.fmtId(@tagName(comp.bin_file.options.wasi_exec_model));
         try buffer.writer().print(
             \\pub const wasi_exec_model = std.builtin.WasiExecModel.{};

--- a/src/link.zig
+++ b/src/link.zig
@@ -119,7 +119,7 @@ pub const Options = struct {
     libc_installation: ?*const LibCInstallation,
 
     /// WASI-only. Type of WASI execution model ("command" or "reactor").
-    wasi_exec_model: ?std.builtin.WasiExecModel,
+    wasi_exec_model: std.builtin.WasiExecModel = undefined,
 
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;

--- a/src/link.zig
+++ b/src/link.zig
@@ -119,7 +119,7 @@ pub const Options = struct {
     libc_installation: ?*const LibCInstallation,
 
     /// WASI-only. Type of WASI execution model ("command" or "reactor").
-    wasi_exec_model: ?wasi_libc.CRTFile = null,
+    wasi_exec_model: ?[]const u8,
 
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;

--- a/src/link.zig
+++ b/src/link.zig
@@ -119,7 +119,7 @@ pub const Options = struct {
     libc_installation: ?*const LibCInstallation,
 
     /// WASI-only. Type of WASI execution model ("command" or "reactor").
-    wasi_exec_model: ?[]const u8,
+    wasi_exec_model: ?std.builtin.WasiExecModel,
 
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -682,9 +682,9 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
             // before corrupting globals. See https://github.com/ziglang/zig/issues/4496
             try argv.append("--stack-first");
 
-            // Reactor execution model does not have _start so lld doesn't look for it.
             if (self.base.options.wasi_exec_model) |model| {
                 if (std.mem.eql(u8, model, "reactor")) {
+                    // Reactor execution model does not have _start so lld doesn't look for it.
                     try argv.append("--no-entry");
                     // Make sure "_initialize" is exported even if this is pure Zig WASI reactor
                     // where WASM_SYMBOL_EXPORTED flag in LLVM is not set on _initialize.

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -682,8 +682,7 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
             // before corrupting globals. See https://github.com/ziglang/zig/issues/4496
             try argv.append("--stack-first");
 
-            if (self.base.options.wasi_exec_model) |exec_model| blk: {
-                if (exec_model != .reactor) break :blk;
+            if (self.base.options.wasi_exec_model == .reactor) {
                 // Reactor execution model does not have _start so lld doesn't look for it.
                 try argv.append("--no-entry");
                 // Make sure "_initialize" is exported even if this is pure Zig WASI reactor
@@ -718,7 +717,7 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
                 if (self.base.options.link_libc) {
                     try argv.append(try comp.get_libc_crt_file(
                         arena,
-                        wasi_libc.execModelCRTFileFullName(self.base.options.wasi_exec_model),
+                        wasi_libc.execModelCrtFileFullName(self.base.options.wasi_exec_model),
                     ));
                     try argv.append(try comp.get_libc_crt_file(arena, "libc.a"));
                 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -321,6 +321,7 @@ const usage_build_generic =
     \\            medium|large]
     \\  -mred-zone                Force-enable the "red-zone"
     \\  -mno-red-zone             Force-disable the "red-zone"
+    \\  -mexec-model=[value]      Execution model (WASI only)
     \\  --name [name]             Override root name (not a file path)
     \\  -O [mode]                 Choose what to optimize for
     \\    Debug                   (default) Optimizations off, safety on

--- a/src/main.zig
+++ b/src/main.zig
@@ -1067,12 +1067,9 @@ fn buildOutputType(
                     {
                         try clang_argv.append(arg);
                     } else if (mem.startsWith(u8, arg, "-mexec-model=")) {
-                        const value = arg["-mexec-model=".len..];
-                        if (std.mem.eql(u8, value, "reactor")) {
-                            wasi_exec_model = .reactor;
-                        } else if (std.mem.eql(u8, value, "command")) {
-                            wasi_exec_model = .command;
-                        }
+                        wasi_exec_model = std.meta.stringToEnum(std.builtin.WasiExecModel, arg["-mexec-model=".len..]) orelse {
+                            fatal("expected [command|reactor] for -mexec-mode=[value], found '{s}'", .{arg["-mexec-model=".len..]});
+                        };
                     } else {
                         fatal("unrecognized parameter: '{s}'", .{arg});
                     }
@@ -1279,11 +1276,9 @@ fn buildOutputType(
                     .nostdlibinc => want_native_include_dirs = false,
                     .strip => strip = true,
                     .exec_model => {
-                        if (std.mem.eql(u8, it.only_arg, "reactor")) {
-                            wasi_exec_model = .reactor;
-                        } else if (std.mem.eql(u8, it.only_arg, "command")) {
-                            wasi_exec_model = .command;
-                        }
+                        wasi_exec_model = std.meta.stringToEnum(std.builtin.WasiExecModel, it.only_arg) orelse {
+                            fatal("expected [command|reactor] for -mexec-mode=[value], found '{s}'", .{it.only_arg});
+                        };
                     },
                 }
             }

--- a/src/wasi_libc.zig
+++ b/src/wasi_libc.zig
@@ -45,7 +45,7 @@ pub fn emulatedLibCRFileLibName(crt_file: CRTFile) []const u8 {
     };
 }
 
-pub fn getExecModelCrtFIle(wasi_exec_model: std.builtin.WasiExecModel) CRTFile {
+pub fn execModelCrtFile(wasi_exec_model: std.builtin.WasiExecModel) CRTFile {
     return switch (wasi_exec_model) {
         .reactor => CRTFile.crt1_reactor_o,
         .command => CRTFile.crt1_command_o,
@@ -53,7 +53,7 @@ pub fn getExecModelCrtFIle(wasi_exec_model: std.builtin.WasiExecModel) CRTFile {
 }
 
 pub fn execModelCrtFileFullName(wasi_exec_model: std.builtin.WasiExecModel) []const u8 {
-    return switch (getExecModelCrtFIle(wasi_exec_model)) {
+    return switch (execModelCrtFile(wasi_exec_model)) {
         .crt1_reactor_o => "crt1-reactor.o",
         .crt1_command_o => "crt1-command.o",
         else => unreachable,

--- a/src/wasi_libc.zig
+++ b/src/wasi_libc.zig
@@ -45,19 +45,15 @@ pub fn emulatedLibCRFileLibName(crt_file: CRTFile) []const u8 {
     };
 }
 
-pub fn getExecModelCRTFIle(wasi_exec_model: ?std.builtin.WasiExecModel) CRTFile {
-    return if (wasi_exec_model) |model|
-        switch (model) {
-            .reactor => CRTFile.crt1_reactor_o,
-            .command => CRTFile.crt1_command_o,
-        }
-    else
-        CRTFile.crt1_o;
+pub fn getExecModelCrtFIle(wasi_exec_model: std.builtin.WasiExecModel) CRTFile {
+    return switch (wasi_exec_model) {
+        .reactor => CRTFile.crt1_reactor_o,
+        .command => CRTFile.crt1_command_o,
+    };
 }
 
-pub fn execModelCRTFileFullName(wasi_exec_model: ?std.builtin.WasiExecModel) []const u8 {
-    return switch (getExecModelCRTFIle(wasi_exec_model)) {
-        .crt1_o => "crt1.o",
+pub fn execModelCrtFileFullName(wasi_exec_model: std.builtin.WasiExecModel) []const u8 {
+    return switch (getExecModelCrtFIle(wasi_exec_model)) {
         .crt1_reactor_o => "crt1-reactor.o",
         .crt1_command_o => "crt1-command.o",
         else => unreachable,

--- a/src/wasi_libc.zig
+++ b/src/wasi_libc.zig
@@ -45,19 +45,17 @@ pub fn emulatedLibCRFileLibName(crt_file: CRTFile) []const u8 {
     };
 }
 
-pub fn getExecModelCRTFIle(wasi_exec_model: ?[]const u8) CRTFile {
+pub fn getExecModelCRTFIle(wasi_exec_model: ?std.builtin.WasiExecModel) CRTFile {
     return if (wasi_exec_model) |model|
-        if (std.mem.eql(u8, model, "reactor"))
-            CRTFile.crt1_reactor_o
-        else if (std.mem.eql(u8, model, "command"))
-            CRTFile.crt1_command_o
-        else
-            unreachable
+        switch (model) {
+            .reactor => CRTFile.crt1_reactor_o,
+            .command => CRTFile.crt1_command_o,
+        }
     else
         CRTFile.crt1_o;
 }
 
-pub fn execModelCRTFileFullName(wasi_exec_model: ?[]const u8) []const u8 {
+pub fn execModelCRTFileFullName(wasi_exec_model: ?std.builtin.WasiExecModel) []const u8 {
     return switch (getExecModelCRTFIle(wasi_exec_model)) {
         .crt1_o => "crt1.o",
         .crt1_reactor_o => "crt1-reactor.o",

--- a/src/wasi_libc.zig
+++ b/src/wasi_libc.zig
@@ -45,8 +45,20 @@ pub fn emulatedLibCRFileLibName(crt_file: CRTFile) []const u8 {
     };
 }
 
-pub fn crtFileFullName(crt_file: CRTFile) []const u8 {
-    return switch (crt_file) {
+pub fn getExecModelCRTFIle(wasi_exec_model: ?[]const u8) CRTFile {
+    return if (wasi_exec_model) |model|
+        if (std.mem.eql(u8, model, "reactor"))
+            CRTFile.crt1_reactor_o
+        else if (std.mem.eql(u8, model, "command"))
+            CRTFile.crt1_command_o
+        else
+            unreachable
+    else
+        CRTFile.crt1_o;
+}
+
+pub fn execModelCRTFileFullName(wasi_exec_model: ?[]const u8) []const u8 {
+    return switch (getExecModelCRTFIle(wasi_exec_model)) {
         .crt1_o => "crt1.o",
         .crt1_reactor_o => "crt1-reactor.o",
         .crt1_command_o => "crt1-command.o",


### PR DESCRIPTION
This PR adds support for WASI reactor in pure Zig WASI targets. Notably this enables users to produce WASI reactor binary with `build-exe` command with `-mexec-model=reactor` just like `zig cc`, `zig c++`, and clang.

With `-mexec-model=reactor` flag, Zig 1) exports `_initialize` symbol which calls the user defined `pub fn main`, 2) does not define `_start`, and 3) does not execute `proc_exit` after `main`.

Please refer to https://github.com/WebAssembly/WASI/blob/main/design/application-abi.md for the ABI in detail.

Finally resolves #6757 together with #9052.

cc @kubkon 
