### PR TITLE
src: return a null-terminated slice

### DIFF
--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -24128,12 +24128,6 @@ static IrInstGen *ir_analyze_instruction_src(IrAnalyze *ira, IrInstSrcSrc *instr
         return ira->codegen->invalid_inst_gen;
     }
 
-    ZigType *u8_ptr = get_pointer_to_type_extra2(
-        ira->codegen, ira->codegen->builtin_types.entry_u8,
-        true, false, PtrLenUnknown,
-        0, 0, 0, false, VECTOR_INDEX_NONE, nullptr, ira->codegen->intern.for_zero_byte());
-    ZigType *u8_slice = get_slice_type(ira->codegen, u8_ptr);
-
     ZigType *source_location_type = get_builtin_type(ira->codegen, "SourceLocation");
     if (type_resolve(ira->codegen, source_location_type, ResolveStatusSizeKnown)) {
         zig_unreachable();
@@ -24153,18 +24147,16 @@ static IrInstGen *ir_analyze_instruction_src(IrAnalyze *ira, IrInstSrcSrc *instr
     ZigType *import = instruction->base.base.source_node->owner;
     RootStruct *root_struct = import->data.structure.root_struct;
     Buf *path = root_struct->path;
-    ZigValue *file_name = create_const_str_lit(ira->codegen, path)->data.x_ptr.data.ref.pointee;
-    init_const_slice(ira->codegen, fields[0], file_name, 0, buf_len(path), true, nullptr);
-    fields[0]->type = u8_slice;
+    fields[0] = create_sentineled_str_lit(
+        ira->codegen, path,
+        ira->codegen->intern.for_zero_byte());
 
     // fn_name: [:0]const u8
     ensure_field_index(source_location_type, "fn_name", 1);
     fields[1]->special = ConstValSpecialStatic;
-
-    ZigValue *fn_name = create_const_str_lit(ira->codegen, &fn_entry->symbol_name)->data.x_ptr.data.ref.pointee;
-    init_const_slice(ira->codegen, fields[1], fn_name, 0, buf_len(&fn_entry->symbol_name), true, nullptr);
-    fields[1]->type = u8_slice;
-
+    fields[1] = create_sentineled_str_lit(
+        ira->codegen, &fn_entry->symbol_name,
+        ira->codegen->intern.for_zero_byte());
 
     TokenLoc tok_loc = root_struct->token_locs[instruction->base.base.source_node->main_token];
 

--- a/test/behavior/bugs/3779.zig
+++ b/test/behavior/bugs/3779.zig
@@ -40,3 +40,18 @@ test "@embedFile() returns a string literal" {
     try std.testing.expectEqualStrings(expected_contents, actual_contents);
     try std.testing.expectEqualStrings(expected_contents, ptr_actual_contents[0..actual_contents.len]);
 }
+
+fn testFnForSrc() std.builtin.SourceLocation {
+    return @src();
+}
+
+test "@src() returns a struct containing 0-terminated string slices" {
+    const src = testFnForSrc();
+    try std.testing.expectEqual([:0]const u8, @TypeOf(src.file));
+    try std.testing.expect(std.mem.endsWith(u8, src.file, "3779.zig"));
+    try std.testing.expectEqual([:0]const u8, @TypeOf(src.fn_name));
+    try std.testing.expect(std.mem.endsWith(u8, src.fn_name, "testFnForSrc"));
+
+    const ptr_src_file: [*:0]const u8 = src.file;
+    const ptr_src_fn_name: [*:0]const u8 = src.fn_name;
+}


### PR DESCRIPTION
As noted by @Vexu in https://github.com/ziglang/zig/pull/8636#pullrequestreview-687047598. This amends the previous pull request so to also align `@src()` to the other builtins in returning a sentinel-terminated value, and is part of https://github.com/ziglang/zig/issues/3779.

This does not address `@typeInfo()` which is a trickier case and was forked off to https://github.com/ziglang/zig/issues/9182.