### PR TITLE
Add context to fatal OpenErrors

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1778,7 +1778,7 @@ fn buildOutputType(
                 const handle = fs.cwd().openDir(dirname, .{}) catch |err| {
                     switch (err) {
                         error.FileNotFound => {
-                            fatal("unable to open directory: '{s}': {s}", .{ dirname, @errorName(err) });
+                            fatal("unable to open output directory '{s}': {s}", .{ dirname, @errorName(err) });
                         },
                         else => return err,
                     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -2496,7 +2496,9 @@ fn cmdTranslateC(comp: *Compilation, arena: *Allocator, enable_cache: bool) !voi
         return cleanExit();
     } else {
         const out_zig_path = try fs.path.join(arena, &[_][]const u8{ "o", &digest, translated_zig_basename });
-        const zig_file = try comp.local_cache_directory.handle.openFile(out_zig_path, .{});
+        const zig_file = comp.local_cache_directory.handle.openFile(out_zig_path, .{}) catch |err| {
+            fatal("unable to open file '{s}': {s}\n", .{ out_zig_path, @errorName(err) });
+        };
         defer zig_file.close();
         try io.getStdOut().writeFileAll(zig_file, .{});
         return cleanExit();
@@ -3818,7 +3820,9 @@ pub fn cmdAstCheck(
         .root_decl = null,
     };
     if (zig_source_file) |file_name| {
-        var f = try fs.cwd().openFile(file_name, .{});
+        var f = fs.cwd().openFile(file_name, .{}) catch |err| {
+            fatal("unable to open file '{s}': {s}\n", .{ file_name, @errorName(err) });
+        };
         defer f.close();
 
         const stat = try f.stat();
@@ -3938,7 +3942,9 @@ pub fn cmdChangelist(
     const old_source_file = args[0];
     const new_source_file = args[1];
 
-    var f = try fs.cwd().openFile(old_source_file, .{});
+    var f = fs.cwd().openFile(old_source_file, .{}) catch |err| {
+        fatal("unable to open file '{s}': {s}\n", .{ old_source_file, @errorName(err) });
+    };
     defer f.close();
 
     const stat = try f.stat();
@@ -3994,7 +4000,9 @@ pub fn cmdChangelist(
         process.exit(1);
     }
 
-    var new_f = try fs.cwd().openFile(new_source_file, .{});
+    var new_f = fs.cwd().openFile(new_source_file, .{}) catch |err| {
+        fatal("unable to open file '{s}': {s}\n", .{ new_source_file, @errorName(err) });
+    };
     defer new_f.close();
 
     const new_stat = try new_f.stat();

--- a/src/main.zig
+++ b/src/main.zig
@@ -1776,12 +1776,7 @@ fn buildOutputType(
             }
             if (fs.path.dirname(full_path)) |dirname| {
                 const handle = fs.cwd().openDir(dirname, .{}) catch |err| {
-                    switch (err) {
-                        error.FileNotFound => {
-                            fatal("unable to open output directory '{s}': {s}", .{ dirname, @errorName(err) });
-                        },
-                        else => return err,
-                    }
+                    fatal("unable to open output directory '{s}': {s}", .{ dirname, @errorName(err) });
                 };
                 cleanup_emit_bin_dir = handle;
                 break :b Compilation.EmitLoc{
@@ -1806,55 +1801,30 @@ fn buildOutputType(
 
     const default_h_basename = try std.fmt.allocPrint(arena, "{s}.h", .{root_name});
     var emit_h_resolved = emit_h.resolve(default_h_basename) catch |err| {
-        switch (err) {
-            error.FileNotFound => {
-                fatal("unable to open: '{s}': {s}", .{ default_h_basename, @errorName(err) });
-            },
-            else => return err,
-        }
+        fatal("unable to open: '{s}': {s}", .{ default_h_basename, @errorName(err) });
     };
     defer emit_h_resolved.deinit();
 
     const default_asm_basename = try std.fmt.allocPrint(arena, "{s}.s", .{root_name});
     var emit_asm_resolved = emit_asm.resolve(default_asm_basename) catch |err| {
-        switch (err) {
-            error.FileNotFound => {
-                fatal("unable to open: '{s}': {s}", .{ default_asm_basename, @errorName(err) });
-            },
-            else => return err,
-        }
+        fatal("unable to open: '{s}': {s}", .{ default_asm_basename, @errorName(err) });
     };
     defer emit_asm_resolved.deinit();
 
     const default_llvm_ir_basename = try std.fmt.allocPrint(arena, "{s}.ll", .{root_name});
     var emit_llvm_ir_resolved = emit_llvm_ir.resolve(default_llvm_ir_basename) catch |err| {
-        switch (err) {
-            error.FileNotFound => {
-                fatal("unable to open: '{s}': {s}", .{ default_llvm_ir_basename, @errorName(err) });
-            },
-            else => return err,
-        }
+        fatal("unable to open: '{s}': {s}", .{ default_llvm_ir_basename, @errorName(err) });
     };
     defer emit_llvm_ir_resolved.deinit();
 
     const default_analysis_basename = try std.fmt.allocPrint(arena, "{s}-analysis.json", .{root_name});
     var emit_analysis_resolved = emit_analysis.resolve(default_analysis_basename) catch |err| {
-        switch (err) {
-            error.FileNotFound => {
-                fatal("unable to open: '{s}': {s}", .{ default_analysis_basename, @errorName(err) });
-            },
-            else => return err,
-        }
+        fatal("unable to open: '{s}': {s}", .{ default_analysis_basename, @errorName(err) });
     };
     defer emit_analysis_resolved.deinit();
 
     var emit_docs_resolved = emit_docs.resolve("docs") catch |err| {
-        switch (err) {
-            error.FileNotFound => {
-                fatal("unable to open: '{s}': {s}", .{ default_analysis_basename, @errorName(err) });
-            },
-            else => return err,
-        }
+        fatal("unable to open: '{s}': {s}", .{ default_analysis_basename, @errorName(err) });
     };
     defer emit_docs_resolved.deinit();
 
@@ -1879,12 +1849,7 @@ fn buildOutputType(
     var zig_lib_directory: Compilation.Directory = if (override_lib_dir) |lib_dir| .{
         .path = lib_dir,
         .handle = fs.cwd().openDir(lib_dir, .{}) catch |err| {
-            switch (err) {
-                error.FileNotFound => {
-                    fatal("unable to open directory: '{s}': {s}", .{ lib_dir, @errorName(err) });
-                },
-                else => return err,
-            }
+            fatal("unable to open directory: '{s}': {s}", .{ lib_dir, @errorName(err) });
         },
     } else introspect.findZigLibDirFromSelfExe(arena, self_exe_path) catch |err| {
         fatal("unable to find zig installation directory: {s}", .{@errorName(err)});
@@ -2641,12 +2606,7 @@ pub fn cmdInit(
         .Exe => "std" ++ s ++ "special" ++ s ++ "init-exe",
     };
     var template_dir = zig_lib_directory.handle.openDir(template_sub_path, .{}) catch |err| {
-        switch (err) {
-            error.FileNotFound => {
-                fatal("unable to open directory: '{s}': {s}", .{ template_sub_path, @errorName(err) });
-            },
-            else => return err,
-        }
+        fatal("unable to open directory: '{s}': {s}", .{ template_sub_path, @errorName(err) });
     };
     defer template_dir.close();
 
@@ -2763,15 +2723,10 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
         var zig_lib_directory: Compilation.Directory = if (override_lib_dir) |lib_dir| .{
             .path = lib_dir,
             .handle = fs.cwd().openDir(lib_dir, .{}) catch |err| {
-                switch (err) {
-                    error.FileNotFound => {
-                        fatal("unable to open directory: '{s}': {s}", .{ lib_dir, @errorName(err) });
-                    },
-                    else => return err,
-                }
+                fatal("unable to open directory: '{s}': {s}", .{ lib_dir, @errorName(err) });
             },
         } else introspect.findZigLibDirFromSelfExe(arena, self_exe_path) catch |err| {
-            fatal("unable to find zig installation directory: {s}", .{@errorName(err)});
+            fatal("unable to find zig installation directory '{s}': {s}", .{ self_exe_path, @errorName(err) });
         };
         defer zig_lib_directory.handle.close();
 
@@ -2782,12 +2737,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
             .root_src_directory = .{
                 .path = special_dir_path,
                 .handle = zig_lib_directory.handle.openDir(std_special, .{}) catch |err| {
-                    switch (err) {
-                        error.FileNotFound => {
-                            fatal("unable to open directory: '{s}{s}{s}': {s}", .{ override_lib_dir, fs.path.sep_str, std_special, @errorName(err) });
-                        },
-                        else => return err,
-                    }
+                    fatal("unable to open directory: '{s}{s}{s}': {s}", .{ override_lib_dir, fs.path.sep_str, std_special, @errorName(err) });
                 },
             },
             .root_src_path = "build_runner.zig",
@@ -2803,12 +2753,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
             if (build_file) |bf| {
                 if (fs.path.dirname(bf)) |dirname| {
                     const dir = fs.cwd().openDir(dirname, .{}) catch |err| {
-                        switch (err) {
-                            error.FileNotFound => {
-                                fatal("unable to open directory: '{s}': {s}", .{ dirname, @errorName(err) });
-                            },
-                            else => return err,
-                        }
+                        fatal("unable to open directory: '{s}': {s}", .{ dirname, @errorName(err) });
                     };
                     cleanup_build_dir = dir;
                     break :blk .{ .path = dirname, .handle = dir };
@@ -2822,12 +2767,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
                 const joined_path = try fs.path.join(arena, &[_][]const u8{ dirname, build_zig_basename });
                 if (fs.cwd().access(joined_path, .{})) |_| {
                     const dir = fs.cwd().openDir(dirname, .{}) catch |err| {
-                        switch (err) {
-                            error.FileNotFound => {
-                                fatal("unable to open directory: '{s}': {s}", .{ dirname, @errorName(err) });
-                            },
-                            else => return err,
-                        }
+                        fatal("unable to open directory: '{s}': {s}", .{ dirname, @errorName(err) });
                     };
                     break :blk .{ .path = dirname, .handle = dir };
                 } else |err| switch (err) {
@@ -3174,14 +3114,7 @@ pub fn cmdFmt(gpa: *Allocator, args: []const []const u8) !void {
     defer fmt.out_buffer.deinit();
 
     for (input_files.items) |file_path| {
-        fmtPath(&fmt, file_path, check_flag, fs.cwd(), file_path) catch |err| {
-            switch (err) {
-                error.FileNotFound => {
-                    fatal("unable to open: '{s}': {s}", .{ file_path, @errorName(err) });
-                },
-                else => return err,
-            }
-        };
+        try fmtPath(&fmt, file_path, check_flag, fs.cwd(), file_path);
     }
     if (fmt.any_error) {
         process.exit(1);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1776,7 +1776,7 @@ fn buildOutputType(
             }
             if (fs.path.dirname(full_path)) |dirname| {
                 const handle = fs.cwd().openDir(dirname, .{}) catch |err| {
-                    fatal("Unable to open output directory '{s}': {s}", .{ dirname, @errorName(err) });
+                    fatal("unable to open output directory '{s}': {s}", .{ dirname, @errorName(err) });
                 };
                 cleanup_emit_bin_dir = handle;
                 break :b Compilation.EmitLoc{
@@ -1803,10 +1803,10 @@ fn buildOutputType(
     var emit_h_resolved = emit_h.resolve(default_h_basename) catch |err| {
         switch (emit_h) {
             .yes => {
-                fatal("Unable to open directory from argument 'femit-h', '{s}': {s}", .{ emit_h.yes, @errorName(err) });
+                fatal("unable to open directory from argument 'femit-h', '{s}': {s}", .{ emit_h.yes, @errorName(err) });
             },
             .yes_default_path => {
-                fatal("Unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_h_basename, @errorName(err) });
+                fatal("unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_h_basename, @errorName(err) });
             },
             .no => unreachable,
         }
@@ -1817,10 +1817,10 @@ fn buildOutputType(
     var emit_asm_resolved = emit_asm.resolve(default_asm_basename) catch |err| {
         switch (emit_asm) {
             .yes => {
-                fatal("Unable to open directory from argument 'femit-asm', '{s}': {s}", .{ emit_asm.yes, @errorName(err) });
+                fatal("unable to open directory from argument 'femit-asm', '{s}': {s}", .{ emit_asm.yes, @errorName(err) });
             },
             .yes_default_path => {
-                fatal("Unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_asm_basename, @errorName(err) });
+                fatal("unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_asm_basename, @errorName(err) });
             },
             .no => unreachable,
         }
@@ -1831,10 +1831,10 @@ fn buildOutputType(
     var emit_llvm_ir_resolved = emit_llvm_ir.resolve(default_llvm_ir_basename) catch |err| {
         switch (emit_llvm_ir) {
             .yes => {
-                fatal("Unable to open directory from argument 'femit-llvm-ir', '{s}': {s}", .{ emit_llvm_ir.yes, @errorName(err) });
+                fatal("unable to open directory from argument 'femit-llvm-ir', '{s}': {s}", .{ emit_llvm_ir.yes, @errorName(err) });
             },
             .yes_default_path => {
-                fatal("Unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_llvm_ir_basename, @errorName(err) });
+                fatal("unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_llvm_ir_basename, @errorName(err) });
             },
             .no => unreachable,
         }
@@ -1845,10 +1845,10 @@ fn buildOutputType(
     var emit_analysis_resolved = emit_analysis.resolve(default_analysis_basename) catch |err| {
         switch (emit_analysis) {
             .yes => {
-                fatal("Unable to open directory from argument 'femit-analysis',  '{s}': {s}", .{ emit_analysis.yes, @errorName(err) });
+                fatal("unable to open directory from argument 'femit-analysis',  '{s}': {s}", .{ emit_analysis.yes, @errorName(err) });
             },
             .yes_default_path => {
-                fatal("Unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_analysis_basename, @errorName(err) });
+                fatal("unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_analysis_basename, @errorName(err) });
             },
             .no => unreachable,
         }
@@ -1858,10 +1858,10 @@ fn buildOutputType(
     var emit_docs_resolved = emit_docs.resolve("docs") catch |err| {
         switch (emit_docs) {
             .yes => {
-                fatal("Unable to open directory from argument 'femit-docs', '{s}': {s}", .{ emit_h.yes, @errorName(err) });
+                fatal("unable to open directory from argument 'femit-docs', '{s}': {s}", .{ emit_h.yes, @errorName(err) });
             },
             .yes_default_path => {
-                fatal("Unable to open directory 'docs': {s}", .{@errorName(err)});
+                fatal("unable to open directory 'docs': {s}", .{@errorName(err)});
             },
             .no => unreachable,
         }
@@ -1889,10 +1889,10 @@ fn buildOutputType(
     var zig_lib_directory: Compilation.Directory = if (override_lib_dir) |lib_dir| .{
         .path = lib_dir,
         .handle = fs.cwd().openDir(lib_dir, .{}) catch |err| {
-            fatal("Unable to open zig lib directory from 'zig-lib-dir' argument or env, '{s}': {s}", .{ lib_dir, @errorName(err) });
+            fatal("unable to open zig lib directory from 'zig-lib-dir' argument or env, '{s}': {s}", .{ lib_dir, @errorName(err) });
         },
     } else introspect.findZigLibDirFromSelfExe(arena, self_exe_path) catch |err| {
-        fatal("Unable to find zig installation directory: {s}\n", .{@errorName(err)});
+        fatal("unable to find zig installation directory: {s}\n", .{@errorName(err)});
     };
     defer zig_lib_directory.handle.close();
 
@@ -2537,7 +2537,7 @@ fn cmdTranslateC(comp: *Compilation, arena: *Allocator, enable_cache: bool) !voi
     } else {
         const out_zig_path = try fs.path.join(arena, &[_][]const u8{ "o", &digest, translated_zig_basename });
         const zig_file = comp.local_cache_directory.handle.openFile(out_zig_path, .{}) catch |err| {
-            fatal("Unable to open cached translated zig file '{s}{s}{s}': {s}", .{ comp.local_cache_directory.path, fs.path.sep_str, out_zig_path, @errorName(err) });
+            fatal("unable to open cached translated zig file '{s}{s}{s}': {s}", .{ comp.local_cache_directory.path, fs.path.sep_str, out_zig_path, @errorName(err) });
         };
         defer zig_file.close();
         try io.getStdOut().writeFileAll(zig_file, .{});
@@ -2648,7 +2648,7 @@ pub fn cmdInit(
         .Exe => "std" ++ s ++ "special" ++ s ++ "init-exe",
     };
     var template_dir = zig_lib_directory.handle.openDir(template_sub_path, .{}) catch |err| {
-        fatal("Unable to open zig project template directory '{s}{s}{s}': {s}", .{ zig_lib_directory.path, s, template_sub_path, @errorName(err) });
+        fatal("unable to open zig project template directory '{s}{s}{s}': {s}", .{ zig_lib_directory.path, s, template_sub_path, @errorName(err) });
     };
     defer template_dir.close();
 
@@ -2765,7 +2765,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
         var zig_lib_directory: Compilation.Directory = if (override_lib_dir) |lib_dir| .{
             .path = lib_dir,
             .handle = fs.cwd().openDir(lib_dir, .{}) catch |err| {
-                fatal("Unable to open zig lib directory from 'zig-lib-dir' argument: '{s}': {s}", .{ lib_dir, @errorName(err) });
+                fatal("unable to open zig lib directory from 'zig-lib-dir' argument: '{s}': {s}", .{ lib_dir, @errorName(err) });
             },
         } else introspect.findZigLibDirFromSelfExe(arena, self_exe_path) catch |err| {
             fatal("unable to find zig installation directory '{s}': {s}", .{ self_exe_path, @errorName(err) });
@@ -2779,7 +2779,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
             .root_src_directory = .{
                 .path = special_dir_path,
                 .handle = zig_lib_directory.handle.openDir(std_special, .{}) catch |err| {
-                    fatal("Unable to open directory '{s}{s}{s}': {s}", .{ override_lib_dir, fs.path.sep_str, std_special, @errorName(err) });
+                    fatal("unable to open directory '{s}{s}{s}': {s}", .{ override_lib_dir, fs.path.sep_str, std_special, @errorName(err) });
                 },
             },
             .root_src_path = "build_runner.zig",
@@ -2795,7 +2795,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
             if (build_file) |bf| {
                 if (fs.path.dirname(bf)) |dirname| {
                     const dir = fs.cwd().openDir(dirname, .{}) catch |err| {
-                        fatal("Unable to open directory to build file from argument 'build-file', '{s}': {s}", .{ dirname, @errorName(err) });
+                        fatal("unable to open directory to build file from argument 'build-file', '{s}': {s}", .{ dirname, @errorName(err) });
                     };
                     cleanup_build_dir = dir;
                     break :blk .{ .path = dirname, .handle = dir };
@@ -2809,7 +2809,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
                 const joined_path = try fs.path.join(arena, &[_][]const u8{ dirname, build_zig_basename });
                 if (fs.cwd().access(joined_path, .{})) |_| {
                     const dir = fs.cwd().openDir(dirname, .{}) catch |err| {
-                        fatal("Unable to open directory while searching for build.zig file, '{s}': {s}", .{ dirname, @errorName(err) });
+                        fatal("unable to open directory while searching for build.zig file, '{s}': {s}", .{ dirname, @errorName(err) });
                     };
                     break :blk .{ .path = dirname, .handle = dir };
                 } else |err| switch (err) {
@@ -3861,7 +3861,7 @@ pub fn cmdAstCheck(
     };
     if (zig_source_file) |file_name| {
         var f = fs.cwd().openFile(file_name, .{}) catch |err| {
-            fatal("Unable to open file for ast-check '{s}': {s}", .{ file_name, @errorName(err) });
+            fatal("unable to open file for ast-check '{s}': {s}", .{ file_name, @errorName(err) });
         };
         defer f.close();
 
@@ -3983,7 +3983,7 @@ pub fn cmdChangelist(
     const new_source_file = args[1];
 
     var f = fs.cwd().openFile(old_source_file, .{}) catch |err| {
-        fatal("Unable to open old source file for comparison '{s}': {s}", .{ old_source_file, @errorName(err) });
+        fatal("unable to open old source file for comparison '{s}': {s}", .{ old_source_file, @errorName(err) });
     };
     defer f.close();
 
@@ -4041,7 +4041,7 @@ pub fn cmdChangelist(
     }
 
     var new_f = fs.cwd().openFile(new_source_file, .{}) catch |err| {
-        fatal("Unable to open new source file for comparison '{s}': {s}", .{ new_source_file, @errorName(err) });
+        fatal("unable to open new source file for comparison '{s}': {s}", .{ new_source_file, @errorName(err) });
     };
     defer new_f.close();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1776,7 +1776,7 @@ fn buildOutputType(
             }
             if (fs.path.dirname(full_path)) |dirname| {
                 const handle = fs.cwd().openDir(dirname, .{}) catch |err| {
-                    fatal("unable to open output directory '{s}': {s}", .{ dirname, @errorName(err) });
+                    fatal("Unable to open output directory '{s}': {s}", .{ dirname, @errorName(err) });
                 };
                 cleanup_emit_bin_dir = handle;
                 break :b Compilation.EmitLoc{
@@ -1801,30 +1801,70 @@ fn buildOutputType(
 
     const default_h_basename = try std.fmt.allocPrint(arena, "{s}.h", .{root_name});
     var emit_h_resolved = emit_h.resolve(default_h_basename) catch |err| {
-        fatal("unable to open: '{s}': {s}", .{ default_h_basename, @errorName(err) });
+        switch (emit_h) {
+            .yes => {
+                fatal("Unable to open directory from argument 'femit-h', '{s}': {s}", .{ emit_h.yes, @errorName(err) });
+            },
+            .yes_default_path => {
+                fatal("Unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_h_basename, @errorName(err) });
+            },
+            .no => unreachable,
+        }
     };
     defer emit_h_resolved.deinit();
 
     const default_asm_basename = try std.fmt.allocPrint(arena, "{s}.s", .{root_name});
     var emit_asm_resolved = emit_asm.resolve(default_asm_basename) catch |err| {
-        fatal("unable to open: '{s}': {s}", .{ default_asm_basename, @errorName(err) });
+        switch (emit_asm) {
+            .yes => {
+                fatal("Unable to open directory from argument 'femit-asm', '{s}': {s}", .{ emit_asm.yes, @errorName(err) });
+            },
+            .yes_default_path => {
+                fatal("Unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_asm_basename, @errorName(err) });
+            },
+            .no => unreachable,
+        }
     };
     defer emit_asm_resolved.deinit();
 
     const default_llvm_ir_basename = try std.fmt.allocPrint(arena, "{s}.ll", .{root_name});
     var emit_llvm_ir_resolved = emit_llvm_ir.resolve(default_llvm_ir_basename) catch |err| {
-        fatal("unable to open: '{s}': {s}", .{ default_llvm_ir_basename, @errorName(err) });
+        switch (emit_llvm_ir) {
+            .yes => {
+                fatal("Unable to open directory from argument 'femit-llvm-ir', '{s}': {s}", .{ emit_llvm_ir.yes, @errorName(err) });
+            },
+            .yes_default_path => {
+                fatal("Unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_llvm_ir_basename, @errorName(err) });
+            },
+            .no => unreachable,
+        }
     };
     defer emit_llvm_ir_resolved.deinit();
 
     const default_analysis_basename = try std.fmt.allocPrint(arena, "{s}-analysis.json", .{root_name});
     var emit_analysis_resolved = emit_analysis.resolve(default_analysis_basename) catch |err| {
-        fatal("unable to open: '{s}': {s}", .{ default_analysis_basename, @errorName(err) });
+        switch (emit_analysis) {
+            .yes => {
+                fatal("Unable to open directory from argument 'femit-analysis',  '{s}': {s}", .{ emit_analysis.yes, @errorName(err) });
+            },
+            .yes_default_path => {
+                fatal("Unable to open directory from arguments 'name' or 'soname', '{s}': {s}", .{ default_analysis_basename, @errorName(err) });
+            },
+            .no => unreachable,
+        }
     };
     defer emit_analysis_resolved.deinit();
 
     var emit_docs_resolved = emit_docs.resolve("docs") catch |err| {
-        fatal("unable to open: '{s}': {s}", .{ default_analysis_basename, @errorName(err) });
+        switch (emit_docs) {
+            .yes => {
+                fatal("Unable to open directory from argument 'femit-docs', '{s}': {s}", .{ emit_h.yes, @errorName(err) });
+            },
+            .yes_default_path => {
+                fatal("Unable to open directory 'docs': {s}", .{@errorName(err)});
+            },
+            .no => unreachable,
+        }
     };
     defer emit_docs_resolved.deinit();
 
@@ -1849,10 +1889,10 @@ fn buildOutputType(
     var zig_lib_directory: Compilation.Directory = if (override_lib_dir) |lib_dir| .{
         .path = lib_dir,
         .handle = fs.cwd().openDir(lib_dir, .{}) catch |err| {
-            fatal("unable to open directory: '{s}': {s}", .{ lib_dir, @errorName(err) });
+            fatal("Unable to open zig lib directory from 'zig-lib-dir' argument or env, '{s}': {s}", .{ lib_dir, @errorName(err) });
         },
     } else introspect.findZigLibDirFromSelfExe(arena, self_exe_path) catch |err| {
-        fatal("unable to find zig installation directory: {s}", .{@errorName(err)});
+        fatal("Unable to find zig installation directory: {s}\n", .{@errorName(err)});
     };
     defer zig_lib_directory.handle.close();
 
@@ -2497,7 +2537,7 @@ fn cmdTranslateC(comp: *Compilation, arena: *Allocator, enable_cache: bool) !voi
     } else {
         const out_zig_path = try fs.path.join(arena, &[_][]const u8{ "o", &digest, translated_zig_basename });
         const zig_file = comp.local_cache_directory.handle.openFile(out_zig_path, .{}) catch |err| {
-            fatal("unable to open file '{s}': {s}\n", .{ out_zig_path, @errorName(err) });
+            fatal("Unable to open cached translated zig file '{s}{s}{s}': {s}", .{ comp.local_cache_directory.path, fs.path.sep_str, out_zig_path, @errorName(err) });
         };
         defer zig_file.close();
         try io.getStdOut().writeFileAll(zig_file, .{});
@@ -2608,7 +2648,7 @@ pub fn cmdInit(
         .Exe => "std" ++ s ++ "special" ++ s ++ "init-exe",
     };
     var template_dir = zig_lib_directory.handle.openDir(template_sub_path, .{}) catch |err| {
-        fatal("unable to open directory: '{s}': {s}", .{ template_sub_path, @errorName(err) });
+        fatal("Unable to open zig project template directory '{s}{s}{s}': {s}", .{ zig_lib_directory.path, s, template_sub_path, @errorName(err) });
     };
     defer template_dir.close();
 
@@ -2725,7 +2765,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
         var zig_lib_directory: Compilation.Directory = if (override_lib_dir) |lib_dir| .{
             .path = lib_dir,
             .handle = fs.cwd().openDir(lib_dir, .{}) catch |err| {
-                fatal("unable to open directory: '{s}': {s}", .{ lib_dir, @errorName(err) });
+                fatal("Unable to open zig lib directory from 'zig-lib-dir' argument: '{s}': {s}", .{ lib_dir, @errorName(err) });
             },
         } else introspect.findZigLibDirFromSelfExe(arena, self_exe_path) catch |err| {
             fatal("unable to find zig installation directory '{s}': {s}", .{ self_exe_path, @errorName(err) });
@@ -2739,7 +2779,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
             .root_src_directory = .{
                 .path = special_dir_path,
                 .handle = zig_lib_directory.handle.openDir(std_special, .{}) catch |err| {
-                    fatal("unable to open directory: '{s}{s}{s}': {s}", .{ override_lib_dir, fs.path.sep_str, std_special, @errorName(err) });
+                    fatal("Unable to open directory '{s}{s}{s}': {s}", .{ override_lib_dir, fs.path.sep_str, std_special, @errorName(err) });
                 },
             },
             .root_src_path = "build_runner.zig",
@@ -2755,7 +2795,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
             if (build_file) |bf| {
                 if (fs.path.dirname(bf)) |dirname| {
                     const dir = fs.cwd().openDir(dirname, .{}) catch |err| {
-                        fatal("unable to open directory: '{s}': {s}", .{ dirname, @errorName(err) });
+                        fatal("Unable to open directory to build file from argument 'build-file', '{s}': {s}", .{ dirname, @errorName(err) });
                     };
                     cleanup_build_dir = dir;
                     break :blk .{ .path = dirname, .handle = dir };
@@ -2769,7 +2809,7 @@ pub fn cmdBuild(gpa: *Allocator, arena: *Allocator, args: []const []const u8) !v
                 const joined_path = try fs.path.join(arena, &[_][]const u8{ dirname, build_zig_basename });
                 if (fs.cwd().access(joined_path, .{})) |_| {
                     const dir = fs.cwd().openDir(dirname, .{}) catch |err| {
-                        fatal("unable to open directory: '{s}': {s}", .{ dirname, @errorName(err) });
+                        fatal("Unable to open directory while searching for build.zig file, '{s}': {s}", .{ dirname, @errorName(err) });
                     };
                     break :blk .{ .path = dirname, .handle = dir };
                 } else |err| switch (err) {
@@ -3821,7 +3861,7 @@ pub fn cmdAstCheck(
     };
     if (zig_source_file) |file_name| {
         var f = fs.cwd().openFile(file_name, .{}) catch |err| {
-            fatal("unable to open file '{s}': {s}\n", .{ file_name, @errorName(err) });
+            fatal("Unable to open file for ast-check '{s}': {s}", .{ file_name, @errorName(err) });
         };
         defer f.close();
 
@@ -3943,7 +3983,7 @@ pub fn cmdChangelist(
     const new_source_file = args[1];
 
     var f = fs.cwd().openFile(old_source_file, .{}) catch |err| {
-        fatal("unable to open file '{s}': {s}\n", .{ old_source_file, @errorName(err) });
+        fatal("Unable to open old source file for comparison '{s}': {s}", .{ old_source_file, @errorName(err) });
     };
     defer f.close();
 
@@ -4001,7 +4041,7 @@ pub fn cmdChangelist(
     }
 
     var new_f = fs.cwd().openFile(new_source_file, .{}) catch |err| {
-        fatal("unable to open file '{s}': {s}\n", .{ new_source_file, @errorName(err) });
+        fatal("Unable to open new source file for comparison '{s}': {s}", .{ new_source_file, @errorName(err) });
     };
     defer new_f.close();
 

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -148,7 +148,7 @@ fn testMissingOutputPath(zig_exe: []const u8, dir_path: []const u8) !void {
     const source_path = try fs.path.join(a, &[_][]const u8{ "src", "main.zig" });
     const result = try exec(dir_path, false, &[_][]const u8{ zig_exe, "build-exe", source_path, output_arg });
     const s = std.fs.path.sep_str;
-    const expected: []const u8 = "error: unable to open output directory 'does" ++ s ++ "not" ++ s ++ "exist': FileNotFound\n";
+    const expected: []const u8 = "error: Unable to open output directory 'does" ++ s ++ "not" ++ s ++ "exist': FileNotFound\n";
     try testing.expectEqualStrings(expected, result.stderr);
 }
 

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -148,7 +148,7 @@ fn testMissingOutputPath(zig_exe: []const u8, dir_path: []const u8) !void {
     const source_path = try fs.path.join(a, &[_][]const u8{ "src", "main.zig" });
     const result = try exec(dir_path, false, &[_][]const u8{ zig_exe, "build-exe", source_path, output_arg });
     const s = std.fs.path.sep_str;
-    const expected: []const u8 = "error: Unable to open output directory 'does" ++ s ++ "not" ++ s ++ "exist': FileNotFound\n";
+    const expected: []const u8 = "error: unable to open output directory 'does" ++ s ++ "not" ++ s ++ "exist': FileNotFound\n";
     try testing.expectEqualStrings(expected, result.stderr);
 }
 


### PR DESCRIPTION
Hello, I'm new to Zig and had some frustrations earlier today building Zig and passing `--zig-lib-dir` then having "FileNotFound" error returned, but not being sure what file (or directory it seems) wasn't being found. This pull replaces the `try` on `openDir()` methods with a `catch` that if `FileNotFound`, will call `fatal()` with the directory that was supposed to be found formatted in.

I checked the call hierarchy and all of these errors should have lead to an exit of the compiler regardless, except without `fatal()` they would've just bubbled up to `main()` without any context. One thing I am unsure of is whether the paths formatted in should be absolute or relative. I did absolute when convenient, but otherwise just formatted in what was attempted to be opened.

One thing not done is add any testing of these exits. Based upon the [testMissingOutputPath()](https://github.com/ziglang/zig/blob/86ebd4b975d2f1e01f468e06daab6e28c06f9719/test/cli.zig#L144) test it seems that is desired. Also these catches should be done for `openFile()` methods as well to provide more context.

Thanks for your work, and any help/critique you can provide.