### PR TITLE
add compile error if root.log is not a function

### DIFF
--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -142,6 +142,8 @@ fn log(
 
     if (@enumToInt(message_level) <= @enumToInt(effective_log_level)) {
         if (@hasDecl(root, "log")) {
+            if (@typeInfo(@TypeOf(root.log)) != .Fn)
+                @compileError("Expected root.log to be a function");
             root.log(message_level, scope, format, args);
         } else if (std.Target.current.os.tag == .freestanding) {
             // On freestanding one must provide a log function; we do not have


### PR DESCRIPTION
While developing, I used a private `log` variable to type less letters in my code, as such:

```zig
const log = std.log.scoped(.myapp);
```

Some time later, I made the variable public, and got an avalanche of somewhat cryptic errors (my changes were on a separate piece of code and so I got confused on why logging had errors):

```
/usr/lib/zig/std/log.zig:145:21: error: expected function, found 'type'
            root.log(message_level, scope, format, args);
                    ^
/usr/lib/zig/std/log.zig:212:16: note: called from here
            log(.err, scope, format, args);
               ^
/usr/lib/zig/std/start.zig:472:28: note: called from here
                std.log.err("{s}", .{@errorName(err)});
                           ^
```

I decided to add a compile time check for `root.log` before calling it, so the error message better explains the issue.

```
/usr/lib/zig/std/log.zig:145:54: error: Expected root.log to be a function
            if (@typeInfo(@TypeOf(root.log)) != .Fn) @compileError("Expected root.log to be a function");
                                                     ^
/usr/lib/zig/std/log.zig:213:16: note: called from here
            log(.err, scope, format, args);
               ^
/usr/lib/zig/std/start.zig:459:28: note: called from here
                std.log.err("{s}", .{@errorName(err)});
                           ^
```