### PR TITLE
nice error for unsupported async sockets on Windows

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -894,7 +894,7 @@ pub const Loop = struct {
         self: *Loop,
         /// This argument is a socket that has been created with `socket`, bound to a local address
         /// with `bind`, and is listening for connections after a `listen`.
-        sockfd: os.fd_t,
+        sockfd: os.socket_t,
         /// This argument is a pointer to a sockaddr structure.  This structure is filled in with  the
         /// address  of  the  peer  socket, as known to the communications layer.  The exact format of the
         /// address returned addr is determined by the socket's address  family  (see  `socket`  and  the
@@ -911,7 +911,7 @@ pub const Loop = struct {
         /// * `SOCK_CLOEXEC`  - Set the close-on-exec (`FD_CLOEXEC`) flag on the new file descriptor.   See  the
         ///   description  of the `O_CLOEXEC` flag in `open` for reasons why this may be useful.
         flags: u32,
-    ) os.AcceptError!os.fd_t {
+    ) os.AcceptError!os.socket_t {
         while (true) {
             return os.accept(sockfd, addr, addr_size, flags | os.SOCK_NONBLOCK) catch |err| switch (err) {
                 error.WouldBlock => {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -8439,4 +8439,18 @@ pub fn addCases(cases: *tests.CompileErrorContext) void {
     , &[_][]const u8{
         "tmp.zig:2:30: error: `.*` cannot be followed by `*`. Are you missing a space?",
     });
+
+    cases.add("Issue #9165: windows tcp server compilation error",
+        \\const std = @import("std");
+        \\pub const io_mode = .evented;
+        \\pub fn main() !void {
+        \\    if (std.builtin.os.tag == .windows) {
+        \\        _ = try (std.net.StreamServer.init(.{})).accept();
+        \\    } else {
+        \\        @compileError("Unsupported OS");
+        \\    }
+        \\}
+    , &[_][]const u8{
+        "error: Unsupported OS",
+    });
 }


### PR DESCRIPTION
Address issue https://github.com/ziglang/zig/issues/9165

Currently if you try to call accept on a socket on Windows with evented IO, then you'll get these type errors.

```
D:\develop\sdk\zig-windows-x86_64-0.8.0\lib\std\net.zig:1800:45: error: expected type '*std.os.windows.ws2_32.SOCKET', found '*c_void'
                .stream = Stream{ .handle = fd },
D:\develop\sdk\zig-windows-x86_64-0.8.0\lib\std\event\loop.zig:912:30: error: expected type '*std.os.windows.ws2_32.SOCKET', found '*c_void'
            return os.accept(sockfd, addr, addr_size, flags | os.SOCK_NONBLOCK) catch |err| switch (err) {

```

But the real error is that our current event loop code hasn't implemented support for Windows.  By fixing the type of `std.event.Loop.accept` to use `os.socket_t` instead of `os.fd_t`, the error now indicates the root cause, namely, "Unsupported OS".