### PR TITLE
stage2: Add "tilde pointing" to errors for multi-character offenses

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3292,6 +3292,7 @@ fn printErrMsgToStdErr(
     const lok_token = parse_error.token;
     const start_loc = tree.tokenLocation(0, lok_token);
     const source_line = tree.source[start_loc.line_start..start_loc.line_end];
+    const lexeme_length = @intCast(u32, tree.tokenSlice(lok_token).len);
 
     var text_buf = std.ArrayList(u8).init(gpa);
     defer text_buf.deinit();
@@ -3307,6 +3308,7 @@ fn printErrMsgToStdErr(
             .line = @intCast(u32, start_loc.line),
             .column = @intCast(u32, start_loc.column),
             .source_line = source_line,
+            .lexeme_length = lexeme_length,
         },
     };
 


### PR DESCRIPTION
Error refactoring in #9117 removed this style from main.zig file. This commit adds it back and in addition to all other possible compiler errors.

I added the `lexeme_length` to `Compilation.AllErrors.Message` in order to get more reliable data where it can be done. As an alternative we can use a similar approach as for `Compilation.AllErrors.add` for all errors since `Message` has both `source_line` and `column` present. But it doesn't look very good to me.

Sketchy implementation in `Compilation.AllErrors.add` is inspired by
https://github.com/ziglang/zig/blob/master/lib/std/zig/ast.zig#L97-L116

I tried to test all paths with the following snippets, `zig run`:

```zig
const std = @import("std");

pub fn main() void {
    hello();
}
```
```
Compilation_add.zig:4:5: error: use of undeclared identifier 'hello'
    hello();
    ~~~~~
```
***
```zig
const std = @import("std");

pub fn main() void {
    h();
}
```
```
single_caret.zig:4:5: error: use of undeclared identifier 'h'
    h();
    ^
```
***
```zig
const std = @import("std");

pub fn main() !void {
    const hello = true || false;
}
```
```
addZir_with_token_present.zig:4:11: error: unused local constant
    const hello = true || false;
          ~~~~~
```
***
```zig
const std = @import("std");

pub fn main() !void {
    suspend {
        suspend {}
    }
    // const hello = true || false;
}
```
```
addZir_with_node_present.zig:5:9: error: cannot suspend inside suspend block
        suspend {}
        ~~~~~~~
addZir_with_node_present.zig:4:5: note: other suspend block here
    suspend {
    ~~~~~~~
```
