### PR TITLE
Export isValidId, remove pub on unexported functions

### DIFF
--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -5,11 +5,13 @@
 // and substantial portions of the software.
 const std = @import("std.zig");
 const tokenizer = @import("zig/tokenizer.zig");
+const fmt = @import("zig/fmt.zig");
 
 pub const Token = tokenizer.Token;
 pub const Tokenizer = tokenizer.Tokenizer;
-pub const fmtId = @import("zig/fmt.zig").fmtId;
-pub const fmtEscapes = @import("zig/fmt.zig").fmtEscapes;
+pub const fmtId = fmt.fmtId;
+pub const fmtEscapes = fmt.fmtEscapes;
+pub const isValidId = fmt.isValidId;
 pub const parse = @import("zig/parse.zig").parse;
 pub const string_literal = @import("zig/string_literal.zig");
 pub const ast = @import("zig/ast.zig");

--- a/lib/std/zig/fmt.zig
+++ b/lib/std/zig/fmt.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const mem = std.mem;
 
 /// Print the string as a Zig identifier escaping it with @"" syntax if needed.
-pub fn formatId(
+fn formatId(
     bytes: []const u8,
     comptime fmt: []const u8,
     options: std.fmt.FormatOptions,
@@ -36,7 +36,7 @@ pub fn isValidId(bytes: []const u8) bool {
 /// Print the string as escaped contents of a double quoted or single-quoted string.
 /// Format `{}` treats contents as a double-quoted string.
 /// Format `{'}` treats contents as a single-quoted string.
-pub fn formatEscapes(
+fn formatEscapes(
     bytes: []const u8,
     comptime fmt: []const u8,
     options: std.fmt.FormatOptions,


### PR DESCRIPTION
`isValidId` is a useful function in some contexts, but was previously not exported. I don't really see a reason to export formatEscapes and formatId though, so i removed the pub modifiers there.