### PR TITLE
Include package root dir in stage2 error messages

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -403,10 +403,10 @@ pub const AllErrors = struct {
             const source = try module_note.src_loc.file_scope.getSource(module.gpa);
             const byte_offset = try module_note.src_loc.byteOffset(module.gpa);
             const loc = std.zig.findLineColumn(source, byte_offset);
-            const sub_file_path = module_note.src_loc.file_scope.sub_file_path;
+            const file_path = try module_note.src_loc.file_scope.fullPath(&arena.allocator);
             note.* = .{
                 .src = .{
-                    .src_path = try arena.allocator.dupe(u8, sub_file_path),
+                    .src_path = file_path,
                     .msg = try arena.allocator.dupe(u8, module_note.msg),
                     .byte_offset = byte_offset,
                     .line = @intCast(u32, loc.line),
@@ -426,10 +426,10 @@ pub const AllErrors = struct {
         const source = try module_err_msg.src_loc.file_scope.getSource(module.gpa);
         const byte_offset = try module_err_msg.src_loc.byteOffset(module.gpa);
         const loc = std.zig.findLineColumn(source, byte_offset);
-        const sub_file_path = module_err_msg.src_loc.file_scope.sub_file_path;
+        const file_path = try module_err_msg.src_loc.file_scope.fullPath(&arena.allocator);
         try errors.append(.{
             .src = .{
-                .src_path = try arena.allocator.dupe(u8, sub_file_path),
+                .src_path = file_path,
                 .msg = try arena.allocator.dupe(u8, module_err_msg.msg),
                 .byte_offset = byte_offset,
                 .line = @intCast(u32, loc.line),
@@ -480,7 +480,7 @@ pub const AllErrors = struct {
 
                     note.* = .{
                         .src = .{
-                            .src_path = try arena.dupe(u8, file.sub_file_path),
+                            .src_path = try file.fullPath(arena),
                             .msg = try arena.dupe(u8, msg),
                             .byte_offset = byte_offset,
                             .line = @intCast(u32, loc.line),
@@ -506,7 +506,7 @@ pub const AllErrors = struct {
 
             try errors.append(.{
                 .src = .{
-                    .src_path = try arena.dupe(u8, file.sub_file_path),
+                    .src_path = try file.fullPath(arena),
                     .msg = try arena.dupe(u8, msg),
                     .byte_offset = byte_offset,
                     .line = @intCast(u32, loc.line),

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1111,6 +1111,10 @@ pub const Scope = struct {
             return buf.toOwnedSliceSentinel(0);
         }
 
+        pub fn fullPath(file: File, ally: *Allocator) ![]u8 {
+            return file.pkg.root_src_directory.join(ally, &[_][]const u8{file.sub_file_path});
+        }
+
         pub fn dumpSrc(file: *File, src: LazySrcLoc) void {
             const loc = std.zig.findLineColumn(file.source.bytes, src);
             std.debug.print("{s}:{d}:{d}\n", .{ file.sub_file_path, loc.line + 1, loc.column + 1 });


### PR DESCRIPTION
This addresses a problem where error messages emitted by stage2 have an ambiguous source filename, breaking go-to navigation in text editors. This behavior differs from stage1, whose error messages always have an unambiguous filename.

For example, in vscode you can normally alt+click "src\main.zig:300:1" in the integrated terminal and it will take you to that file, line 300. However, stage2 will omit the "src" directory in error messages and navigation will fail; vscode will ask which main.zig you meant.

Before:
```
> zig build
http\http_service.zig:75:17: error: unused function parameter
    pub fn hash(self: HeaderMapContext, k: []const u8) u64 {
                ^

> zig build-exe subdir\test.zig
test.zig:2:11: error: unused local constant
    const y = 123;
          ^
```

After:
```
> zig build
D:\...\src\http\http_service.zig:75:17: error: unused function parameter
    pub fn hash(self: HeaderMapContext, k: []const u8) u64 {
                ^

> zig build-exe subdir\test.zig
subdir\test.zig:2:11: error: unused local constant
    const y = 123;
          ^
```
