### PR TITLE
A couple std.log conveniences

### DIFF
--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -100,6 +100,23 @@ pub const Level = enum {
     info,
     /// Debug: messages only useful for debugging.
     debug,
+
+    /// Returns a string literal of the given level in full text form.
+    pub fn asText(comptime self: Level) switch (self) {
+        .emerg => @TypeOf("emergency"),
+        .crit => @TypeOf("critical"),
+        .err => @TypeOf("error"),
+        .warn => @TypeOf("warning"),
+        else => @TypeOf(@tagName(self)),
+    } {
+        return switch (self) {
+            .emerg => "emergency",
+            .crit => "critical",
+            .err => "error",
+            .warn => "warning",
+            else => @tagName(self),
+        };
+    }
 };
 
 /// The default log level is based on build mode.
@@ -165,16 +182,7 @@ pub fn defaultLog(
         return;
     }
 
-    const level_txt = switch (message_level) {
-        .emerg => "emergency",
-        .alert => "alert",
-        .crit => "critical",
-        .err => "error",
-        .warn => "warning",
-        .notice => "notice",
-        .info => "info",
-        .debug => "debug",
-    };
+    const level_txt = comptime message_level.asText();
     const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
     const stderr = std.io.getStdErr().writer();
     const held = std.debug.getStderrMutex().acquire();

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -585,16 +585,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    comptime format: []const u8,
         \\    args: anytype,
         \\) void {
-        \\    const level_txt = switch (level) {
-        \\        .emerg => "emergency",
-        \\        .alert => "alert",
-        \\        .crit => "critical",
-        \\        .err => "error",
-        \\        .warn => "warning",
-        \\        .notice => "notice",
-        \\        .info => "info",
-        \\        .debug => "debug",
-        \\    };
+        \\    const level_txt = comptime level.asText();
         \\    const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
         \\    const stdout = std.io.getStdOut().writer();
         \\    nosuspend stdout.print(level_txt ++ prefix2 ++ format ++ "\n", args) catch return;
@@ -638,16 +629,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    comptime format: []const u8,
         \\    args: anytype,
         \\) void {
-        \\    const level_txt = switch (level) {
-        \\        .emerg => "emergency",
-        \\        .alert => "alert",
-        \\        .crit => "critical",
-        \\        .err => "error",
-        \\        .warn => "warning",
-        \\        .notice => "notice",
-        \\        .info => "info",
-        \\        .debug => "debug",
-        \\    };
+        \\    const level_txt = comptime level.asText();
         \\    const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
         \\    const stdout = std.io.getStdOut().writer();
         \\    nosuspend stdout.print(level_txt ++ prefix2 ++ format ++ "\n", args) catch return;


### PR DESCRIPTION
1. Expose default `std.log` implementation

This allows root.log implementations to capture log messages, process them, and forward them to the default implementation if desired.

2. Expose mechanism to convert log levels to string literals

This makes it easier to reproduce and customize the default log message style with the level prefix.  This can be seen by the test cases in `compare_output.zig`.