### PR TITLE
os.getrandom(): don't use libc on linux

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -140,11 +140,9 @@ pub fn getrandom(buffer: []u8) GetRandomError!void {
     }
     if (builtin.os.tag == .linux or builtin.os.tag == .freebsd) {
         var buf = buffer;
-        const use_c = builtin.os.tag != .linux or
-            std.c.versionCheck(builtin.Version{ .major = 2, .minor = 25, .patch = 0 }).ok;
 
         while (buf.len != 0) {
-            const res = if (use_c) blk: {
+            const res = if (builtin.os.tag != .linux) blk: {
                 const rc = std.c.getrandom(buf.ptr, buf.len, 0);
                 break :blk .{
                     .num_read = @bitCast(usize, rc),


### PR DESCRIPTION
The function is missing from some C libraries, yet it does nothing but call the system call directly.

Fixes #9146