### PR TITLE
zld: fix section mapping for Go specific sections

### DIFF
--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -94,7 +94,7 @@ pub const Section = struct {
 
     pub fn isCode(self: Section) bool {
         const attr = self.sectionAttrs();
-        return attr & macho.S_ATTR_PURE_INSTRUCTIONS != 0 and attr & macho.S_ATTR_SOME_INSTRUCTIONS != 0;
+        return attr & macho.S_ATTR_PURE_INSTRUCTIONS != 0 or attr & macho.S_ATTR_SOME_INSTRUCTIONS != 0;
     }
 
     pub fn isDebug(self: Section) bool {


### PR DESCRIPTION
which include:
* `__TEXT,__rodata` => `__DATA_CONST,__const`
* `__TEXT,__typelink` => `__DATA_CONST,__const`
* `__TEXT,__itablink` => `__DATA_CONST,__const`
* `__TEXT,__gosymtab` => `__DATA_CONST,__const`
* `__TEXT,__gopclntab` => `__DATA_CONST,__const`

Also, we treat section as containing machine code and mapping it to `__TEXT,__text` if it is `S_REGULAR` and contains either `S_ATTR_PURE_INSTRUCTIONS` or `S_ATTR_SOME_INSTRUCTIONS` or both.