### PR TITLE
stdlib: add std.os.argc

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -92,6 +92,10 @@ pub var environ: [][*:0]u8 = undefined;
 /// for obtaining the process arguments.
 pub var argv: [][*:0]u8 = undefined;
 
+/// Populated by startup code before main().
+/// for obtaining the process argument count.
+pub var argc: usize = undefined;
+
 /// To obtain errno, call this function with the return value of the
 /// system function call. For some systems this will obtain the value directly
 /// from the return code; for others it will use a thread-local errno variable.

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -362,6 +362,7 @@ fn expandStackSize(phdrs: []elf.Phdr) void {
 fn callMainWithArgs(argc: usize, argv: [*][*:0]u8, envp: [][*:0]u8) u8 {
     std.os.argv = argv[0..argc];
     std.os.environ = envp;
+    std.os.argc = argc;
 
     std.debug.maybeEnableSegfaultHandler();
 


### PR DESCRIPTION
Populated by startup code before main().
for obtaining the process argument count.