### PR TITLE
Fix issue where root.os.panic could return

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -671,7 +671,12 @@ pub const PanicFn = fn ([]const u8, ?*StackTrace) noreturn;
 
 /// This function is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
-pub const panic: PanicFn = if (@hasDecl(root, "panic")) root.panic else default_panic;
+pub const panic: PanicFn = if (@hasDecl(root, "panic"))
+    root.panic
+else if (@hasDecl(root, "os") and @hasDecl(root.os, "panic"))
+    root.os.panic
+else
+    default_panic;
 
 /// This function is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
@@ -683,10 +688,6 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace) noreturn
         while (true) {
             @breakpoint();
         }
-    }
-    if (@hasDecl(root, "os") and @hasDecl(root.os, "panic")) {
-        root.os.panic(msg, error_return_trace);
-        unreachable;
     }
     switch (os.tag) {
         .freestanding => {


### PR DESCRIPTION
This change forces root.os.panic to have the `PanicFn` type. I think this also simplifies the code somewhat.

This could break existing code somewhere.

Edit with more detail on the issue this PR solves:
The issue is that `root.os.panic` was used without checking the type of the function (specifically, without checking the type is `PanicFn`). `PanicFn` has return type `noreturn`, but because `root.os.panic` isn't checked, the function could have return type `void`. For this reason, there was `unreachable` after `root.os.panic`. So if you accidently wrote a panic handler which returned, then you would get issues at runtime (hitting the unreachable and causing another panic or undefined behavior) instead of a compiler error. 

Additionally, the code for using the override `root.os.panic` was different than the code for using the override `root.panic` for no good reason.