### PR TITLE
link: Recognize -Wl,-implib,foo.lib and pass it to LLD as /implib:foo.lib.

### DIFF
--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -996,6 +996,9 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
         if (self.base.options.dynamicbase) {
             try argv.append("-dynamicbase");
         }
+
+        try argv.appendSlice(self.base.options.extra_lld_args);
+
         const subsystem_suffix = ss: {
             if (self.base.options.major_subsystem_version) |major| {
                 if (self.base.options.minor_subsystem_version) |minor| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1341,6 +1341,12 @@ fn buildOutputType(
                         fatal("expected linker arg after '{s}'", .{arg});
                     }
                     version_script = linker_args.items[i];
+                } else if (mem.eql(u8, arg, "-implib")) {
+                    i += 1;
+                    if (i >= linker_args.items.len) {
+                        fatal("expected linker arg after '{s}'", .{arg});
+                    }
+                    try lld_argv.append(try std.fmt.allocPrint(arena, "/implib:{s}", .{linker_args.items[i]}));
                 } else if (mem.startsWith(u8, arg, "-O")) {
                     try lld_argv.append(arg);
                 } else if (mem.eql(u8, arg, "--gc-sections")) {


### PR DESCRIPTION
Fixes #9210.

Note that this is just intended as a stopgap. The syntax isn't exactly the same as if you're working with `lld-link` directly, and we should probably think about doing this by default for DLLs.