### PR TITLE
Implement SymbolMap interface

### DIFF
--- a/lib/std/debug_info_utils.zig
+++ b/lib/std/debug_info_utils.zig
@@ -1,0 +1,83 @@
+//! Misc utility functions for creating a `SymbolMap` for `std.debug`
+//! TODO: better name for this file?
+
+const std = @import("std.zig");
+const SymbolMap = std.debug.SymbolMap;
+const SymbolInfo = SymbolMap.SymbolInfo;
+const mem = std.mem;
+const DW = std.dwarf;
+const os = std.os;
+const math = std.math;
+const File = std.fs.File;
+
+pub fn SymbolMapStateFromModuleInfo(comptime Module: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const AddressMap = std.AutoHashMap(usize, *Module);
+
+        allocator: *mem.Allocator,
+        address_map: AddressMap,
+        symbol_map: SymbolMap,
+
+        pub fn init(allocator: *mem.Allocator) !*SymbolMap {
+            const value = try allocator.create(Self);
+            value.* = Self{
+                .allocator = allocator,
+                .address_map = std.AutoHashMap(usize, *Module).init(allocator),
+                .symbol_map = .{
+                    .deinitFn = deinit,
+                    .addressToSymbolFn = addressToSymbol,
+                },
+            };
+
+            return &value.symbol_map;
+        }
+
+        fn deinit(symbol_map: *SymbolMap) void {
+            const self = @fieldParentPtr(Self, "symbol_map", symbol_map);
+            self.address_map.deinit();
+            self.allocator.destroy(self);
+        }
+
+        fn addressToSymbol(symbol_map: *SymbolMap, address: usize) !SymbolInfo {
+            const self = @fieldParentPtr(Self, "symbol_map", symbol_map);
+            const module = Module.lookup(self.allocator, &self.address_map, address) catch |err|
+                return if (std.meta.errorInSet(err, BaseError)) SymbolInfo{} else return err;
+            return module.addressToSymbol(address);
+        }
+    };
+}
+
+const BaseError = error{
+    MissingDebugInfo,
+    InvalidDebugInfo,
+};
+
+pub fn chopSlice(ptr: []const u8, offset: u64, size: u64) ![]const u8 {
+    const start = try math.cast(usize, offset);
+    const end = start + try math.cast(usize, size);
+    return ptr[start..end];
+}
+
+/// `file` is expected to have been opened with .intended_io_mode == .blocking.
+/// Takes ownership of file, even on error.
+/// TODO it's weird to take ownership even on error, rework this code.
+pub fn mapWholeFile(file: File) ![]align(mem.page_size) const u8 {
+    nosuspend {
+        defer file.close();
+
+        const file_len = try math.cast(usize, try file.getEndPos());
+        const mapped_mem = try os.mmap(
+            null,
+            file_len,
+            os.PROT_READ,
+            os.MAP_SHARED,
+            file.handle,
+            0,
+        );
+        errdefer os.munmap(mapped_mem);
+
+        return mapped_mem;
+    }
+}

--- a/lib/std/dwarf.zig
+++ b/lib/std/dwarf.zig
@@ -210,7 +210,7 @@ const LineNumberProgram = struct {
         };
     }
 
-    pub fn checkLineMatch(self: *LineNumberProgram) !?debug.LineInfo {
+    pub fn checkLineMatch(self: *LineNumberProgram) !?debug.SymbolMap.LineInfo {
         if (self.prev_valid and self.target_address >= self.prev_address and self.target_address < self.address) {
             const file_entry = if (self.prev_file == 0) {
                 return error.MissingDebugInfo;
@@ -223,7 +223,7 @@ const LineNumberProgram = struct {
             } else self.include_dirs[file_entry.dir_index];
             const file_name = try fs.path.join(self.file_entries.allocator, &[_][]const u8{ dir_name, file_entry.file_name });
             errdefer self.file_entries.allocator.free(file_name);
-            return debug.LineInfo{
+            return debug.SymbolMap.LineInfo{
                 .line = if (self.prev_line >= 0) @intCast(u64, self.prev_line) else 0,
                 .column = self.prev_column,
                 .file_name = file_name,
@@ -693,7 +693,7 @@ pub const DwarfInfo = struct {
         return result;
     }
 
-    pub fn getLineNumberInfo(di: *DwarfInfo, compile_unit: CompileUnit, target_address: u64) !debug.LineInfo {
+    pub fn getLineNumberInfo(di: *DwarfInfo, compile_unit: CompileUnit, target_address: u64) !debug.SymbolMap.LineInfo {
         var stream = io.fixedBufferStream(di.debug_line);
         const in = &stream.reader();
         const seekable = &stream.seekableStream();

--- a/lib/std/symbol_map_darwin.zig
+++ b/lib/std/symbol_map_darwin.zig
@@ -1,0 +1,353 @@
+const std = @import("std.zig");
+const SymbolInfo = std.debug.SymbolMap.SymbolInfo;
+const assert = std.debug.assert;
+const debug_info_utils = @import("debug_info_utils.zig");
+const chopSlice = debug_info_utils;
+const mem = std.mem;
+const macho = std.macho;
+const fs = std.fs;
+const File = std.fs.File;
+const DW = std.dwarf;
+
+const SymbolMapState = debug_info_utils.SymbolMapStateFromModuleInfo(Module);
+pub const init = SymbolMapState.init;
+
+const Module = struct {
+    const Self = @This();
+
+    base_address: usize,
+    mapped_memory: []const u8,
+    symbols: []const MachoSymbol,
+    strings: [:0]const u8,
+    ofiles: OFileTable,
+
+    const MachoSymbol = struct {
+        nlist: *const macho.nlist_64,
+        ofile: ?*const macho.nlist_64,
+        reloc: u64,
+
+        /// Returns the address from the macho file
+        fn address(self: MachoSymbol) u64 {
+            return self.nlist.n_value;
+        }
+
+        fn addressLessThan(context: void, lhs: MachoSymbol, rhs: MachoSymbol) bool {
+            _ = context;
+            return lhs.address() < rhs.address();
+        }
+    };
+
+    const OFileTable = std.StringHashMap(DW.DwarfInfo);
+
+    pub fn lookup(allocator: *mem.Allocator, address_map: *SymbolMapState.AddressMap, address: usize) !*Self {
+        const image_count = std.c._dyld_image_count();
+
+        var i: u32 = 0;
+        while (i < image_count) : (i += 1) {
+            const base_address = std.c._dyld_get_image_vmaddr_slide(i);
+
+            if (address < base_address) continue;
+
+            const header = std.c._dyld_get_image_header(i) orelse continue;
+            // The array of load commands is right after the header
+            var cmd_ptr = @intToPtr([*]u8, @ptrToInt(header) + @sizeOf(macho.mach_header_64));
+
+            var cmds = header.ncmds;
+            while (cmds != 0) : (cmds -= 1) {
+                const lc = @ptrCast(
+                    *macho.load_command,
+                    @alignCast(@alignOf(macho.load_command), cmd_ptr),
+                );
+                cmd_ptr += lc.cmdsize;
+                if (lc.cmd != macho.LC_SEGMENT_64) continue;
+
+                const segment_cmd = @ptrCast(
+                    *const std.macho.segment_command_64,
+                    @alignCast(@alignOf(std.macho.segment_command_64), lc),
+                );
+
+                const rebased_address = address - base_address;
+                const seg_start = segment_cmd.vmaddr;
+                const seg_end = seg_start + segment_cmd.vmsize;
+
+                if (rebased_address >= seg_start and rebased_address < seg_end) {
+                    if (address_map.get(base_address)) |obj_di| {
+                        return obj_di;
+                    }
+
+                    const obj_di = try allocator.create(Self);
+                    errdefer allocator.destroy(obj_di);
+
+                    const macho_path = mem.spanZ(std.c._dyld_get_image_name(i));
+                    const macho_file = fs.cwd().openFile(macho_path, .{ .intended_io_mode = .blocking }) catch |err| switch (err) {
+                        error.FileNotFound => return error.MissingDebugInfo,
+                        else => return err,
+                    };
+                    obj_di.* = try readMachODebugInfo(allocator, macho_file);
+                    obj_di.base_address = base_address;
+
+                    try address_map.putNoClobber(base_address, obj_di);
+
+                    return obj_di;
+                }
+            }
+        }
+
+        return error.MissingDebugInfo;
+    }
+
+    /// TODO resources https://github.com/ziglang/zig/issues/4353
+    /// This takes ownership of macho_file: users of this function should not close
+    /// it themselves, even on error.
+    /// TODO it's weird to take ownership even on error, rework this code.
+    fn readMachODebugInfo(allocator: *mem.Allocator, macho_file: File) !Self {
+        const mapped_mem = try debug_line.mapWholeFile(macho_file);
+
+        const hdr = @ptrCast(
+            *const macho.mach_header_64,
+            @alignCast(@alignOf(macho.mach_header_64), mapped_mem.ptr),
+        );
+        if (hdr.magic != macho.MH_MAGIC_64)
+            return error.InvalidDebugInfo;
+
+        const hdr_base = @ptrCast([*]const u8, hdr);
+        var ptr = hdr_base + @sizeOf(macho.mach_header_64);
+        var ncmd: u32 = hdr.ncmds;
+        const symtab = while (ncmd != 0) : (ncmd -= 1) {
+            const lc = @ptrCast(*const std.macho.load_command, ptr);
+            switch (lc.cmd) {
+                std.macho.LC_SYMTAB => break @ptrCast(*const std.macho.symtab_command, ptr),
+                else => {},
+            }
+            ptr = @alignCast(@alignOf(std.macho.load_command), ptr + lc.cmdsize);
+        } else {
+            return error.MissingDebugInfo;
+        };
+        const syms = @ptrCast([*]const macho.nlist_64, @alignCast(@alignOf(macho.nlist_64), hdr_base + symtab.symoff))[0..symtab.nsyms];
+        const strings = @ptrCast([*]const u8, hdr_base + symtab.stroff)[0 .. symtab.strsize - 1 :0];
+
+        const symbols_buf = try allocator.alloc(MachoSymbol, syms.len);
+
+        var ofile: ?*const macho.nlist_64 = null;
+        var reloc: u64 = 0;
+        var symbol_index: usize = 0;
+        var last_len: u64 = 0;
+        for (syms) |*sym| {
+            if (sym.n_type & std.macho.N_STAB != 0) {
+                switch (sym.n_type) {
+                    std.macho.N_OSO => {
+                        ofile = sym;
+                        reloc = 0;
+                    },
+                    std.macho.N_FUN => {
+                        if (sym.n_sect == 0) {
+                            last_len = sym.n_value;
+                        } else {
+                            symbols_buf[symbol_index] = MachoSymbol{
+                                .nlist = sym,
+                                .ofile = ofile,
+                                .reloc = reloc,
+                            };
+                            symbol_index += 1;
+                        }
+                    },
+                    std.macho.N_BNSYM => {
+                        if (reloc == 0) {
+                            reloc = sym.n_value;
+                        }
+                    },
+                    else => continue,
+                }
+            }
+        }
+        const sentinel = try allocator.create(macho.nlist_64);
+        sentinel.* = macho.nlist_64{
+            .n_strx = 0,
+            .n_type = 36,
+            .n_sect = 0,
+            .n_desc = 0,
+            .n_value = symbols_buf[symbol_index - 1].nlist.n_value + last_len,
+        };
+
+        const symbols = allocator.shrink(symbols_buf, symbol_index);
+
+        // Even though lld emits symbols in ascending order, this debug code
+        // should work for programs linked in any valid way.
+        // This sort is so that we can binary search later.
+        std.sort.sort(MachoSymbol, symbols, {}, MachoSymbol.addressLessThan);
+
+        return Self{
+            .base_address = undefined,
+            .mapped_memory = mapped_mem,
+            .ofiles = Self.OFileTable.init(allocator),
+            .symbols = symbols,
+            .strings = strings,
+        };
+    }
+
+    pub fn addressToSymbol(self: *Self, address: usize) !SymbolInfo {
+        nosuspend {
+            // Translate the VA into an address into this object
+            const relocated_address = address - self.base_address;
+            assert(relocated_address >= 0x100000000);
+
+            // Find the .o file where this symbol is defined
+            const symbol = machoSearchSymbols(self.symbols, relocated_address) orelse
+                return SymbolInfo{};
+
+            // Take the symbol name from the N_FUN STAB entry, we're going to
+            // use it if we fail to find the DWARF infos
+            const stab_symbol = mem.spanZ(self.strings[symbol.nlist.n_strx..]);
+
+            if (symbol.ofile == null)
+                return SymbolInfo{ .symbol_name = stab_symbol };
+
+            const o_file_path = mem.spanZ(self.strings[symbol.ofile.?.n_strx..]);
+
+            // Check if its debug infos are already in the cache
+            var o_file_di = self.ofiles.get(o_file_path) orelse
+                (self.loadOFile(o_file_path) catch |err| switch (err) {
+                error.FileNotFound,
+                error.MissingDebugInfo,
+                error.InvalidDebugInfo,
+                => {
+                    return SymbolInfo{ .symbol_name = stab_symbol };
+                },
+                else => return err,
+            });
+
+            // Translate again the address, this time into an address inside the
+            // .o file
+            const relocated_address_o = relocated_address - symbol.reloc;
+
+            if (o_file_di.findCompileUnit(relocated_address_o)) |compile_unit| {
+                return SymbolInfo{
+                    .symbol_name = o_file_di.getSymbolName(relocated_address_o) orelse "???",
+                    .compile_unit_name = compile_unit.die.getAttrString(&o_file_di, DW.AT_name) catch |err| switch (err) {
+                        error.MissingDebugInfo, error.InvalidDebugInfo => "???",
+                        else => return err,
+                    },
+                    .line_info = o_file_di.getLineNumberInfo(compile_unit.*, relocated_address_o) catch |err| switch (err) {
+                        error.MissingDebugInfo, error.InvalidDebugInfo => null,
+                        else => return err,
+                    },
+                };
+            } else |err| switch (err) {
+                error.MissingDebugInfo, error.InvalidDebugInfo => {
+                    return SymbolInfo{ .symbol_name = stab_symbol };
+                },
+                else => return err,
+            }
+
+            unreachable;
+        }
+    }
+
+    fn machoSearchSymbols(symbols: []const MachoSymbol, address: usize) ?*const MachoSymbol {
+        var min: usize = 0;
+        var max: usize = symbols.len - 1; // Exclude sentinel.
+        while (min < max) {
+            const mid = min + (max - min) / 2;
+            const curr = &symbols[mid];
+            const next = &symbols[mid + 1];
+            if (address >= next.address()) {
+                min = mid + 1;
+            } else if (address < curr.address()) {
+                max = mid;
+            } else {
+                return curr;
+            }
+        }
+        return null;
+    }
+
+    fn loadOFile(self: *Self, o_file_path: []const u8) !DW.DwarfInfo {
+        const o_file = try fs.cwd().openFile(o_file_path, .{ .intended_io_mode = .blocking });
+        const mapped_mem = try debug_line.mapWholeFile(o_file);
+
+        const hdr = @ptrCast(
+            *const macho.mach_header_64,
+            @alignCast(@alignOf(macho.mach_header_64), mapped_mem.ptr),
+        );
+        if (hdr.magic != std.macho.MH_MAGIC_64)
+            return error.InvalidDebugInfo;
+
+        const hdr_base = @ptrCast([*]const u8, hdr);
+        var ptr = hdr_base + @sizeOf(macho.mach_header_64);
+        var ncmd: u32 = hdr.ncmds;
+        const segcmd = while (ncmd != 0) : (ncmd -= 1) {
+            const lc = @ptrCast(*const std.macho.load_command, ptr);
+            switch (lc.cmd) {
+                std.macho.LC_SEGMENT_64 => {
+                    break @ptrCast(
+                        *const std.macho.segment_command_64,
+                        @alignCast(@alignOf(std.macho.segment_command_64), ptr),
+                    );
+                },
+                else => {},
+            }
+            ptr = @alignCast(@alignOf(std.macho.load_command), ptr + lc.cmdsize);
+        } else {
+            return error.MissingDebugInfo;
+        };
+
+        var opt_debug_line: ?*const macho.section_64 = null;
+        var opt_debug_info: ?*const macho.section_64 = null;
+        var opt_debug_abbrev: ?*const macho.section_64 = null;
+        var opt_debug_str: ?*const macho.section_64 = null;
+        var opt_debug_ranges: ?*const macho.section_64 = null;
+
+        const sections = @ptrCast(
+            [*]const macho.section_64,
+            @alignCast(@alignOf(macho.section_64), ptr + @sizeOf(std.macho.segment_command_64)),
+        )[0..segcmd.nsects];
+        for (sections) |*sect| {
+            // The section name may not exceed 16 chars and a trailing null may
+            // not be present
+            const name = if (mem.indexOfScalar(u8, sect.sectname[0..], 0)) |last|
+                sect.sectname[0..last]
+            else
+                sect.sectname[0..];
+
+            if (mem.eql(u8, name, "__debug_line")) {
+                opt_debug_line = sect;
+            } else if (mem.eql(u8, name, "__debug_info")) {
+                opt_debug_info = sect;
+            } else if (mem.eql(u8, name, "__debug_abbrev")) {
+                opt_debug_abbrev = sect;
+            } else if (mem.eql(u8, name, "__debug_str")) {
+                opt_debug_str = sect;
+            } else if (mem.eql(u8, name, "__debug_ranges")) {
+                opt_debug_ranges = sect;
+            }
+        }
+
+        const debug_line = opt_debug_line orelse
+            return error.MissingDebugInfo;
+        const debug_info = opt_debug_info orelse
+            return error.MissingDebugInfo;
+        const debug_str = opt_debug_str orelse
+            return error.MissingDebugInfo;
+        const debug_abbrev = opt_debug_abbrev orelse
+            return error.MissingDebugInfo;
+
+        var di = DW.DwarfInfo{
+            .endian = .Little,
+            .debug_info = try chopSlice(mapped_mem, debug_info.offset, debug_info.size),
+            .debug_abbrev = try chopSlice(mapped_mem, debug_abbrev.offset, debug_abbrev.size),
+            .debug_str = try chopSlice(mapped_mem, debug_str.offset, debug_str.size),
+            .debug_line = try chopSlice(mapped_mem, debug_line.offset, debug_line.size),
+            .debug_ranges = if (opt_debug_ranges) |debug_ranges|
+                try chopSlice(mapped_mem, debug_ranges.offset, debug_ranges.size)
+            else
+                null,
+        };
+
+        try DW.openDwarfDebugInfo(&di, self.allocator());
+
+        // Add the debug info to the cache
+        try self.ofiles.putNoClobber(o_file_path, di);
+
+        return di;
+    }
+};

--- a/lib/std/symbol_map_unix.zig
+++ b/lib/std/symbol_map_unix.zig
@@ -1,0 +1,194 @@
+//! TODO: the name for this file is a bit misleading, this is actually for
+//! *nix - darwin, but unix_other_than_darwin is too long.
+
+const std = @import("std.zig");
+const builtin = std.builtin;
+const assert = std.debug.assert;
+const SymbolInfo = std.debug.SymbolMap.SymbolInfo;
+const debug_info_utils = @import("debug_info_utils.zig");
+const chopSlice = debug_info_utils.chopSlice;
+const mem = std.mem;
+const DW = std.dwarf;
+const elf = std.elf;
+const os = std.os;
+const math = std.math;
+const fs = std.fs;
+const File = fs.File;
+const native_endian = std.Target.current.cpu.arch.endian();
+
+const SymbolMapState = debug_info_utils.SymbolMapStateFromModuleInfo(Module);
+pub const init = SymbolMapState.init;
+
+const Module = struct {
+    const Self = @This();
+
+    base_address: usize,
+    dwarf: DW.DwarfInfo,
+    mapped_memory: []const u8,
+
+    pub fn lookup(allocator: *mem.Allocator, address_map: *SymbolMapState.AddressMap, address: usize) !*Self {
+        var ctx: struct {
+            // Input
+            address: usize,
+            // Output
+            base_address: usize = undefined,
+            name: []const u8 = undefined,
+        } = .{ .address = address };
+        const CtxTy = @TypeOf(ctx);
+
+        if (os.dl_iterate_phdr(&ctx, anyerror, struct {
+            fn callback(info: *os.dl_phdr_info, size: usize, context: *CtxTy) !void {
+                _ = size;
+                // The base address is too high
+                if (context.address < info.dlpi_addr)
+                    return;
+
+                const phdrs = info.dlpi_phdr[0..info.dlpi_phnum];
+                for (phdrs) |*phdr| {
+                    if (phdr.p_type != elf.PT_LOAD) continue;
+
+                    const seg_start = info.dlpi_addr + phdr.p_vaddr;
+                    const seg_end = seg_start + phdr.p_memsz;
+
+                    if (context.address >= seg_start and context.address < seg_end) {
+                        // Android libc uses NULL instead of an empty string to mark the
+                        // main program
+                        context.name = mem.spanZ(info.dlpi_name) orelse "";
+                        context.base_address = info.dlpi_addr;
+                        // Stop the iteration
+                        return error.Found;
+                    }
+                }
+            }
+        }.callback)) {
+            return error.MissingDebugInfo;
+        } else |err| switch (err) {
+            error.Found => {},
+            else => return error.MissingDebugInfo,
+        }
+
+        if (address_map.get(ctx.base_address)) |obj_di| {
+            return obj_di;
+        }
+
+        const obj_di = try allocator.create(Self);
+        errdefer allocator.destroy(obj_di);
+
+        // TODO https://github.com/ziglang/zig/issues/5525
+        const copy = if (ctx.name.len > 0)
+            fs.cwd().openFile(ctx.name, .{ .intended_io_mode = .blocking })
+        else
+            fs.openSelfExe(.{ .intended_io_mode = .blocking });
+
+        const elf_file = copy catch |err| switch (err) {
+            error.FileNotFound => return error.MissingDebugInfo,
+            else => return err,
+        };
+
+        obj_di.* = try readElfDebugInfo(allocator, elf_file);
+        obj_di.base_address = ctx.base_address;
+
+        try address_map.putNoClobber(ctx.base_address, obj_di);
+
+        return obj_di;
+    }
+
+    /// This takes ownership of elf_file: users of this function should not close
+    /// it themselves, even on error.
+    /// TODO resources https://github.com/ziglang/zig/issues/4353
+    /// TODO it's weird to take ownership even on error, rework this code.
+    pub fn readElfDebugInfo(allocator: *mem.Allocator, elf_file: File) !Self {
+        nosuspend {
+            const mapped_mem = try debug_info_utils.mapWholeFile(elf_file);
+            const hdr = @ptrCast(*const elf.Ehdr, &mapped_mem[0]);
+            if (!mem.eql(u8, hdr.e_ident[0..4], "\x7fELF")) return error.InvalidElfMagic;
+            if (hdr.e_ident[elf.EI_VERSION] != 1) return error.InvalidElfVersion;
+
+            const endian: builtin.Endian = switch (hdr.e_ident[elf.EI_DATA]) {
+                elf.ELFDATA2LSB => .Little,
+                elf.ELFDATA2MSB => .Big,
+                else => return error.InvalidElfEndian,
+            };
+            assert(endian == native_endian); // this is our own debug info
+
+            const shoff = hdr.e_shoff;
+            const str_section_off = shoff + @as(u64, hdr.e_shentsize) * @as(u64, hdr.e_shstrndx);
+            const str_shdr = @ptrCast(
+                *const elf.Shdr,
+                @alignCast(@alignOf(elf.Shdr), &mapped_mem[try math.cast(usize, str_section_off)]),
+            );
+            const header_strings = mapped_mem[str_shdr.sh_offset .. str_shdr.sh_offset + str_shdr.sh_size];
+            const shdrs = @ptrCast(
+                [*]const elf.Shdr,
+                @alignCast(@alignOf(elf.Shdr), &mapped_mem[shoff]),
+            )[0..hdr.e_shnum];
+
+            var opt_debug_info: ?[]const u8 = null;
+            var opt_debug_abbrev: ?[]const u8 = null;
+            var opt_debug_str: ?[]const u8 = null;
+            var opt_debug_line: ?[]const u8 = null;
+            var opt_debug_ranges: ?[]const u8 = null;
+
+            for (shdrs) |*shdr| {
+                if (shdr.sh_type == elf.SHT_NULL) continue;
+
+                const name = std.mem.span(std.meta.assumeSentinel(header_strings[shdr.sh_name..].ptr, 0));
+                if (mem.eql(u8, name, ".debug_info")) {
+                    opt_debug_info = try chopSlice(mapped_mem, shdr.sh_offset, shdr.sh_size);
+                } else if (mem.eql(u8, name, ".debug_abbrev")) {
+                    opt_debug_abbrev = try chopSlice(mapped_mem, shdr.sh_offset, shdr.sh_size);
+                } else if (mem.eql(u8, name, ".debug_str")) {
+                    opt_debug_str = try chopSlice(mapped_mem, shdr.sh_offset, shdr.sh_size);
+                } else if (mem.eql(u8, name, ".debug_line")) {
+                    opt_debug_line = try chopSlice(mapped_mem, shdr.sh_offset, shdr.sh_size);
+                } else if (mem.eql(u8, name, ".debug_ranges")) {
+                    opt_debug_ranges = try chopSlice(mapped_mem, shdr.sh_offset, shdr.sh_size);
+                }
+            }
+
+            var di = DW.DwarfInfo{
+                .endian = endian,
+                .debug_info = opt_debug_info orelse return error.MissingDebugInfo,
+                .debug_abbrev = opt_debug_abbrev orelse return error.MissingDebugInfo,
+                .debug_str = opt_debug_str orelse return error.MissingDebugInfo,
+                .debug_line = opt_debug_line orelse return error.MissingDebugInfo,
+                .debug_ranges = opt_debug_ranges,
+            };
+
+            try DW.openDwarfDebugInfo(&di, allocator);
+
+            return Self{
+                .base_address = undefined,
+                .dwarf = di,
+                .mapped_memory = mapped_mem,
+            };
+        }
+    }
+
+    fn dwarfAddressToSymbol(address: u64, di: *DW.DwarfInfo) !SymbolInfo {
+        if (nosuspend di.findCompileUnit(address)) |compile_unit| {
+            return SymbolInfo{
+                .symbol_name = nosuspend di.getSymbolName(address) orelse "???",
+                .compile_unit_name = compile_unit.die.getAttrString(di, DW.AT_name) catch |err| switch (err) {
+                    error.MissingDebugInfo, error.InvalidDebugInfo => "???",
+                    else => return err,
+                },
+                .line_info = nosuspend di.getLineNumberInfo(compile_unit.*, address) catch |err| switch (err) {
+                    error.MissingDebugInfo, error.InvalidDebugInfo => null,
+                    else => return err,
+                },
+            };
+        } else |err| switch (err) {
+            error.MissingDebugInfo, error.InvalidDebugInfo => {
+                return SymbolInfo{};
+            },
+            else => return err,
+        }
+    }
+
+    pub fn addressToSymbol(self: *Self, address: usize) !SymbolInfo {
+        // Translate the VA into an address into this object
+        const relocated_address = address - self.base_address;
+        return dwarfAddressToSymbol(relocated_address, &self.dwarf);
+    }
+};

--- a/lib/std/symbol_map_unsupported.zig
+++ b/lib/std/symbol_map_unsupported.zig
@@ -1,0 +1,39 @@
+//! This is so printing a stack trace on an unsupported platform just prints
+//! with empty symbols instead of failing to build. This is important for
+//! GeneralPurposeAllocator and similar.
+//!
+//! To implement actual debug symbols, use `root.debug_config.initSymbolMap`
+//! or `root.os.debug.initSymbolMap`.
+
+const std = @import("std.zig");
+const SymbolMap = std.debug.SymbolMap;
+const SymbolInfo = SymbolMap.SymbolInfo;
+const mem = std.mem;
+
+const Self = @This();
+
+allocator: *mem.Allocator,
+symbol_map: SymbolMap,
+
+pub fn init(allocator: *mem.Allocator) !*SymbolMap {
+    const value = try allocator.create(Self);
+    value.* = Self{
+        .allocator = allocator,
+        .symbol_map = .{
+            .deinitFn = deinit,
+            .addressToSymbolFn = addressToSymbol,
+        },
+    };
+
+    return &value.symbol_map;
+}
+
+fn deinit(_: *SymbolMap) void {}
+
+fn addressToSymbol(_: *SymbolMap, _: usize) !SymbolInfo {
+    return SymbolInfo{};
+}
+
+test {
+    std.testing.refAllDecls(Self);
+}

--- a/lib/std/symbol_map_windows.zig
+++ b/lib/std/symbol_map_windows.zig
@@ -1,0 +1,219 @@
+const std = @import("std.zig");
+const assert = std.debug.assert;
+const SymbolInfo = std.debug.SymbolMap.SymbolInfo;
+const debug_info_utils = @import("debug_info_utils.zig");
+const mem = std.mem;
+const math = std.math;
+const fs = std.fs;
+const File = fs.File;
+const coff = std.coff;
+const pdb = std.pdb;
+const windows = std.os.windows;
+
+const SymbolMapState = debug_info_utils.SymbolMapStateFromModuleInfo(Module);
+pub const init = SymbolMapState.init;
+
+const Module = struct {
+    const Self = @This();
+
+    base_address: usize,
+    debug_data: PdbOrDwarf,
+    coff: *coff.Coff,
+
+    const PdbOrDwarf = union(enum) {
+        pdb: pdb.Pdb,
+        dwarf: DW.DwarfInfo,
+    };
+
+    pub fn lookup(allocator: *mem.Allocator, address_map: *SymbolMapState.AddressMap, address: usize) !*Self {
+        const process_handle = windows.kernel32.GetCurrentProcess();
+
+        // Find how many modules are actually loaded
+        var dummy: windows.HMODULE = undefined;
+        var bytes_needed: windows.DWORD = undefined;
+        if (windows.kernel32.K32EnumProcessModules(
+            process_handle,
+            @ptrCast([*]windows.HMODULE, &dummy),
+            0,
+            &bytes_needed,
+        ) == 0)
+            return error.MissingDebugInfo;
+
+        const needed_modules = bytes_needed / @sizeOf(windows.HMODULE);
+
+        // Fetch the complete module list
+        var modules = try allocator.alloc(windows.HMODULE, needed_modules);
+        defer allocator.free(modules);
+        if (windows.kernel32.K32EnumProcessModules(
+            process_handle,
+            modules.ptr,
+            try math.cast(windows.DWORD, modules.len * @sizeOf(windows.HMODULE)),
+            &bytes_needed,
+        ) == 0)
+            return error.MissingDebugInfo;
+
+        // There's an unavoidable TOCTOU problem here, the module list may have
+        // changed between the two EnumProcessModules call.
+        // Pick the smallest amount of elements to avoid processing garbage.
+        const needed_modules_after = bytes_needed / @sizeOf(windows.HMODULE);
+        const loaded_modules = math.min(needed_modules, needed_modules_after);
+
+        for (modules[0..loaded_modules]) |module| {
+            var info: windows.MODULEINFO = undefined;
+            if (windows.kernel32.K32GetModuleInformation(
+                process_handle,
+                module,
+                &info,
+                @sizeOf(@TypeOf(info)),
+            ) == 0)
+                return error.MissingDebugInfo;
+
+            const seg_start = @ptrToInt(info.lpBaseOfDll);
+            const seg_end = seg_start + info.SizeOfImage;
+
+            if (address >= seg_start and address < seg_end) {
+                if (address_map.get(seg_start)) |obj_di| {
+                    return obj_di;
+                }
+
+                var name_buffer: [windows.PATH_MAX_WIDE + 4:0]u16 = undefined;
+                // openFileAbsoluteW requires the prefix to be present
+                mem.copy(u16, name_buffer[0..4], &[_]u16{ '\\', '?', '?', '\\' });
+                const len = windows.kernel32.K32GetModuleFileNameExW(
+                    process_handle,
+                    module,
+                    @ptrCast(windows.LPWSTR, &name_buffer[4]),
+                    windows.PATH_MAX_WIDE,
+                );
+                assert(len > 0);
+
+                const obj_di = try allocator.create(Self);
+                errdefer allocator.destroy(obj_di);
+
+                const coff_file = fs.openFileAbsoluteW(name_buffer[0 .. len + 4 :0], .{}) catch |err| switch (err) {
+                    error.FileNotFound => return error.MissingDebugInfo,
+                    else => return err,
+                };
+                obj_di.* = try readCoffDebugInfo(allocator, coff_file);
+                obj_di.base_address = seg_start;
+
+                try address_map.putNoClobber(seg_start, obj_di);
+
+                return obj_di;
+            }
+        }
+
+        return error.MissingDebugInfo;
+    }
+
+    /// This takes ownership of coff_file: users of this function should not close
+    /// it themselves, even on error.
+    /// TODO resources https://github.com/ziglang/zig/issues/4353
+    /// TODO it's weird to take ownership even on error, rework this code.
+    fn readCoffDebugInfo(allocator: *mem.Allocator, coff_file: File) !Self {
+        nosuspend {
+            errdefer coff_file.close();
+
+            const coff_obj = try allocator.create(coff.Coff);
+            coff_obj.* = coff.Coff.init(allocator, coff_file);
+
+            var di = Self{
+                .base_address = undefined,
+                .coff = coff_obj,
+                .debug_data = undefined,
+            };
+
+            try di.coff.loadHeader();
+            try di.coff.loadSections();
+            if (di.coff.getSection(".debug_info")) |sec| {
+                // This coff file has embedded DWARF debug info
+                _ = sec;
+                // TODO: free the section data slices
+                const debug_info_data = di.coff.getSectionData(".debug_info", allocator) catch null;
+                const debug_abbrev_data = di.coff.getSectionData(".debug_abbrev", allocator) catch null;
+                const debug_str_data = di.coff.getSectionData(".debug_str", allocator) catch null;
+                const debug_line_data = di.coff.getSectionData(".debug_line", allocator) catch null;
+                const debug_ranges_data = di.coff.getSectionData(".debug_ranges", allocator) catch null;
+
+                var dwarf = DW.DwarfInfo{
+                    .endian = native_endian,
+                    .debug_info = debug_info_data orelse return error.MissingDebugInfo,
+                    .debug_abbrev = debug_abbrev_data orelse return error.MissingDebugInfo,
+                    .debug_str = debug_str_data orelse return error.MissingDebugInfo,
+                    .debug_line = debug_line_data orelse return error.MissingDebugInfo,
+                    .debug_ranges = debug_ranges_data,
+                };
+                try DW.openDwarfDebugInfo(&dwarf, allocator);
+                di.debug_data = PdbOrDwarf{ .dwarf = dwarf };
+                return di;
+            }
+
+            var path_buf: [windows.MAX_PATH]u8 = undefined;
+            const len = try di.coff.getPdbPath(path_buf[0..]);
+            const raw_path = path_buf[0..len];
+
+            const path = try fs.path.resolve(allocator, &[_][]const u8{raw_path});
+            defer allocator.free(path);
+
+            di.debug_data = PdbOrDwarf{ .pdb = undefined };
+            di.debug_data.pdb = try pdb.Pdb.init(allocator, path);
+            try di.debug_data.pdb.parseInfoStream();
+            try di.debug_data.pdb.parseDbiStream();
+
+            if (!mem.eql(u8, &di.coff.guid, &di.debug_data.pdb.guid) or di.coff.age != di.debug_data.pdb.age)
+                return error.InvalidDebugInfo;
+
+            return di;
+        }
+    }
+
+    pub fn addressToSymbol(self: *Self, address: usize) !SymbolInfo {
+        // Translate the VA into an address into this object
+        const relocated_address = address - self.base_address;
+
+        switch (self.debug_data) {
+            .dwarf => |*dwarf| {
+                const dwarf_address = relocated_address + self.coff.pe_header.image_base;
+                return getSymbolFromDwarf(dwarf_address, dwarf);
+            },
+            .pdb => {
+                // fallthrough to pdb handling
+            },
+        }
+
+        var coff_section: *coff.Section = undefined;
+        const mod_index = for (self.debug_data.pdb.sect_contribs) |sect_contrib| {
+            if (sect_contrib.Section > self.coff.sections.items.len) continue;
+            // Remember that SectionContribEntry.Section is 1-based.
+            coff_section = &self.coff.sections.items[sect_contrib.Section - 1];
+
+            const vaddr_start = coff_section.header.virtual_address + sect_contrib.Offset;
+            const vaddr_end = vaddr_start + sect_contrib.Size;
+            if (relocated_address >= vaddr_start and relocated_address < vaddr_end) {
+                break sect_contrib.ModuleIndex;
+            }
+        } else {
+            // we have no information to add to the address
+            return SymbolInfo{};
+        };
+
+        const module = (try self.debug_data.pdb.getModule(mod_index)) orelse
+            return error.InvalidDebugInfo;
+        const obj_basename = fs.path.basename(module.obj_file_name);
+
+        const symbol_name = self.debug_data.pdb.getSymbolName(
+            module,
+            relocated_address - coff_section.header.virtual_address,
+        ) orelse "???";
+        const opt_line_info = try self.debug_data.pdb.getLineNumberInfo(
+            module,
+            relocated_address - coff_section.header.virtual_address,
+        );
+
+        return SymbolInfo{
+            .symbol_name = symbol_name,
+            .compile_unit_name = obj_basename,
+            .line_info = opt_line_info,
+        };
+    }
+};


### PR DESCRIPTION
It's desirable to allow users to override how addresses are mapped to symbols (`SymbolInfo`) in debug.zig. To accomplish this, a new interface is introduced: `SymbolMap`. This function used to get a new object of this interface can overriden by `root.debug_config.initSymbolMap` or by `root.os.debug.initSymbolMap`.

This is the design that was eventually decided upon in https://github.com/ziglang/zig/pull/8228. This pr is a subset of https://github.com/ziglang/zig/pull/8228.

Symbol map loading is moved from `debug.zig` to `symbol_map_unix.zig`, `symbol_map_darwin.zig`, and `symbol_map_windows.zig`. All of the functions for loading debug symbols should be exactly the same: the functions were just copy pasted with a few input and import renames. Unfortunately git isn't clever enough to recognize this in the diff (because the functions were moved). I'm not sure if there is an easy way to view the (minimal) diff of these function.

Note that the override is obtained from a config struct despite there only being a single override (the `initSymbolMap` function).  This is done because more overrides will (probably) be intruduced in a future PR (another chunk of https://github.com/ziglang/zig/pull/8228). I will wait to make this next pr until the design for this is settled.

Outstanding issues:
- [ ] The interface currently allows `anyerror`. This should maybe be narrowed down to a specific error set.
- [ ] For whatever reason, this change makes the compiler crash when building for windows :/
```
Assertion failed at /home/ryan/.cache/yay/zig-git/src/zig/src/stage1/ir.cpp:14937 in ir_analyze_container_field_ptr. This is a bug in the Zig compiler.thread 1016325 panic:
```
- [ ] Maybe `symbol_map_darwin.zig` should have a different name? (see top of file for comment)