### PR TITLE
Fix UEFI packed struct bitfields

### DIFF
--- a/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
+++ b/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
@@ -45,7 +45,9 @@ pub const AbsolutePointerMode = extern struct {
     attributes: packed struct {
         supports_alt_active: bool,
         supports_pressure_as_z: bool,
-        _pad1: u30,
+        _pad1: u6,
+        _pad2: u8,
+        _pad3: u16,
     },
 };
 
@@ -56,6 +58,8 @@ pub const AbsolutePointerState = extern struct {
     active_buttons: packed struct {
         touch_active: bool,
         alt_active: bool,
-        _pad1: u30,
+        _pad1: u6,
+        _pad2: u8,
+        _pad3: u16,
     },
 };

--- a/lib/std/os/uefi/protocols/edid_override_protocol.zig
+++ b/lib/std/os/uefi/protocols/edid_override_protocol.zig
@@ -31,5 +31,7 @@ pub const EdidOverrideProtocol = extern struct {
 pub const EdidOverrideProtocolAttributes = packed struct {
     dont_override: bool,
     enable_hot_plug: bool,
-    _pad1: u30,
+    _pad1: u6,
+    _pad2: u8,
+    _pad3: u16,
 };

--- a/lib/std/os/uefi/protocols/simple_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_network_protocol.zig
@@ -131,7 +131,9 @@ pub const SimpleNetworkReceiveFilter = packed struct {
     receive_broadcast: bool,
     receive_promiscuous: bool,
     receive_promiscuous_multicast: bool,
-    _pad: u27 = undefined,
+    _pad1: u3 = undefined,
+    _pad2: u8 = undefined,
+    _pad3: u16 = undefined,
 };
 
 pub const SimpleNetworkState = enum(u32) {
@@ -174,5 +176,7 @@ pub const SimpleNetworkInterruptStatus = packed struct {
     transmit_interrupt: bool,
     command_interrupt: bool,
     software_interrupt: bool,
-    _pad: u28,
+    _pad1: u4,
+    _pad2: u8,
+    _pad3: u16,
 };

--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -192,7 +192,8 @@ pub const MemoryDescriptor = extern struct {
         wt: bool,
         wb: bool,
         uce: bool,
-        _pad1: u7,
+        _pad1: u3,
+        _pad2: u4,
         wp: bool,
         rp: bool,
         xp: bool,
@@ -201,7 +202,9 @@ pub const MemoryDescriptor = extern struct {
         ro: bool,
         sp: bool,
         cpu_crypto: bool,
-        _pad2: u43,
+        _pad3: u4,
+        _pad4: u32,
+        _pad5: u7,
         memory_runtime: bool,
     },
 };
@@ -219,7 +222,9 @@ pub const OpenProtocolAttributes = packed struct {
     by_child_controller: bool = false,
     by_driver: bool = false,
     exclusive: bool = false,
-    _pad: u26 = undefined,
+    _pad1: u2 = undefined,
+    _pad2: u8 = undefined,
+    _pad3: u16 = undefined,
 };
 
 pub const ProtocolInformationEntry = extern struct {


### PR DESCRIPTION
Some of the packed structs in `std.os.uefi` have padding that spans byte boundaries, which confuses the stage1 compiler into create padding. This fixes that by splitting the padding into multiple parts that abide by the current implementation of packed structs.