### PR TITLE
Shared Cache Locking

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10713,6 +10713,14 @@ fn readU32Be() u32 {}
       See the Zig Standard Library for more examples.
       </p>
       {#header_close#}
+      {#header_open|Doc Comment Guidance#}
+      <ul>
+        <li>Omit any information that is redundant based on the name of the thing being documented.</li>
+        <li>Duplicating information onto multiple similar functions is encouraged because it helps IDEs and other tools provide better help text.</li>
+        <li>Use the word <strong>assume</strong> to indicate invariants that cause {#link|Undefined Behavior#} when violated.</li>
+        <li>Use the word <strong>assert</strong> to indicate invariants that cause <em>safety-checked</em> {#link|Undefined Behavior#} when violated.</li>
+      </ul>
+      {#header_close#}
       {#header_close#}
       {#header_open|Source Encoding#}
       <p>Zig source code is encoded in UTF-8. An invalid UTF-8 byte sequence results in a compile error.</p>

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -74,17 +74,28 @@ pub const File = struct {
         read: bool = true,
         write: bool = false,
 
-        /// Open the file with a lock to prevent other processes from accessing it at the
-        /// same time. An exclusive lock will prevent other processes from acquiring a lock.
-        /// A shared lock will prevent other processes from acquiring a exclusive lock, but
-        /// doesn't prevent other process from getting their own shared locks.
+        /// Open the file with an advisory lock to coordinate with other processes
+        /// accessing it at the same time. An exclusive lock will prevent other
+        /// processes from acquiring a lock. A shared lock will prevent other
+        /// processes from acquiring a exclusive lock, but does not prevent
+        /// other process from getting their own shared locks.
         ///
-        /// Note that the lock is only advisory on Linux, except in very specific cirsumstances[1].
+        /// The lock is advisory, except on Linux in very specific cirsumstances[1].
         /// This means that a process that does not respect the locking API can still get access
         /// to the file, despite the lock.
         ///
-        /// Windows' file locks are mandatory, and any process attempting to access the file will
-        /// receive an error.
+        /// On these operating systems, the lock is acquired atomically with
+        /// opening the file:
+        /// * Darwin
+        /// * DragonFlyBSD
+        /// * FreeBSD
+        /// * Haiku
+        /// * NetBSD
+        /// * OpenBSD
+        /// On these operating systems, the lock is acquired via a separate syscall
+        /// after opening the file:
+        /// * Linux
+        /// * Windows
         ///
         /// [1]: https://www.kernel.org/doc/Documentation/filesystems/mandatory-locking.txt
         lock: Lock = .None,
@@ -120,17 +131,28 @@ pub const File = struct {
         /// `error.PathAlreadyExists` to be returned.
         exclusive: bool = false,
 
-        /// Open the file with a lock to prevent other processes from accessing it at the
-        /// same time. An exclusive lock will prevent other processes from acquiring a lock.
-        /// A shared lock will prevent other processes from acquiring a exclusive lock, but
-        /// doesn't prevent other process from getting their own shared locks.
+        /// Open the file with an advisory lock to coordinate with other processes
+        /// accessing it at the same time. An exclusive lock will prevent other
+        /// processes from acquiring a lock. A shared lock will prevent other
+        /// processes from acquiring a exclusive lock, but does not prevent
+        /// other process from getting their own shared locks.
         ///
-        /// Note that the lock is only advisory on Linux, except in very specific cirsumstances[1].
+        /// The lock is advisory, except on Linux in very specific cirsumstances[1].
         /// This means that a process that does not respect the locking API can still get access
         /// to the file, despite the lock.
         ///
-        /// Windows's file locks are mandatory, and any process attempting to access the file will
-        /// receive an error.
+        /// On these operating systems, the lock is acquired atomically with
+        /// opening the file:
+        /// * Darwin
+        /// * DragonFlyBSD
+        /// * FreeBSD
+        /// * Haiku
+        /// * NetBSD
+        /// * OpenBSD
+        /// On these operating systems, the lock is acquired via a separate syscall
+        /// after opening the file:
+        /// * Linux
+        /// * Windows
         ///
         /// [1]: https://www.kernel.org/doc/Documentation/filesystems/mandatory-locking.txt
         lock: Lock = .None,

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -145,7 +145,7 @@ pub extern "NtDll" fn NtLockFile(
     Event: ?HANDLE,
     ApcRoutine: ?*IO_APC_ROUTINE,
     ApcContext: ?*c_void,
-    IoStatusBlock: ?*IO_STATUS_BLOCK,
+    IoStatusBlock: *IO_STATUS_BLOCK,
     ByteOffset: *const LARGE_INTEGER,
     Length: *const LARGE_INTEGER,
     Key: ?*ULONG,
@@ -155,7 +155,7 @@ pub extern "NtDll" fn NtLockFile(
 
 pub extern "NtDll" fn NtUnlockFile(
     FileHandle: HANDLE,
-    IoStatusBlock: ?*IO_STATUS_BLOCK,
+    IoStatusBlock: *IO_STATUS_BLOCK,
     ByteOffset: *const LARGE_INTEGER,
     Length: *const LARGE_INTEGER,
     Key: ?*ULONG,

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -139,3 +139,24 @@ pub extern "NtDll" fn RtlWaitOnAddress(
     AddressSize: SIZE_T,
     Timeout: ?*const LARGE_INTEGER,
 ) callconv(WINAPI) NTSTATUS;
+
+pub extern "NtDll" fn NtLockFile(
+    FileHandle: HANDLE,
+    Event: ?HANDLE,
+    ApcRoutine: ?*IO_APC_ROUTINE,
+    ApcContext: ?*c_void,
+    IoStatusBlock: ?*IO_STATUS_BLOCK,
+    ByteOffset: *const LARGE_INTEGER,
+    Length: *const LARGE_INTEGER,
+    Key: ?*ULONG,
+    FailImmediately: BOOLEAN,
+    ExclusiveLock: BOOLEAN,
+) callconv(WINAPI) NTSTATUS;
+
+pub extern "NtDll" fn NtUnlockFile(
+    FileHandle: HANDLE,
+    IoStatusBlock: ?*IO_STATUS_BLOCK,
+    ByteOffset: *const LARGE_INTEGER,
+    Length: *const LARGE_INTEGER,
+    Key: ?*ULONG,
+) callconv(WINAPI) NTSTATUS;

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -181,6 +181,12 @@ pub const Manifest = struct {
     hash: HashHelper,
     manifest_file: ?fs.File,
     manifest_dirty: bool,
+    /// Set this flag to true before calling hit() in order to indicate that
+    /// upon a cache hit, the code using the cache will not modify the files
+    /// within the cache directory. This allows multiple processes to utilize
+    /// the same cache directory at the same time.
+    want_shared_lock: bool = true,
+    have_exclusive_lock: bool = false,
     files: std.ArrayListUnmanaged(File) = .{},
     hex_digest: [hex_digest_len]u8,
     /// Populated when hit() returns an error because of one
@@ -257,7 +263,9 @@ pub const Manifest = struct {
     ///
     /// This function will also acquire an exclusive lock to the manifest file. This means
     /// that a process holding a Manifest will block any other process attempting to
-    /// acquire the lock.
+    /// acquire the lock. If `want_shared_lock` is `true`, a cache hit guarantees the
+    /// manifest file to be locked in shared mode, and a cache miss guarantees the manifest
+    /// file to be locked in exclusive mode.
     ///
     /// The lock on the manifest file is released when `deinit` is called. As another
     /// option, one may call `toOwnedLock` to obtain a smaller object which can represent
@@ -285,31 +293,62 @@ pub const Manifest = struct {
         mem.copy(u8, &manifest_file_path, &self.hex_digest);
         manifest_file_path[self.hex_digest.len..][0..ext.len].* = ext.*;
 
-        if (self.files.items.len != 0) {
-            self.manifest_file = try self.cache.manifest_dir.createFile(&manifest_file_path, .{
+        if (self.files.items.len == 0) {
+            // If there are no file inputs, we check if the manifest file exists instead of
+            // comparing the hashes on the files used for the cached item
+            while (true) {
+                if (self.cache.manifest_dir.openFile(&manifest_file_path, .{
+                    .read = true,
+                    .write = true,
+                    .lock = .Exclusive,
+                    .lock_nonblocking = self.want_shared_lock,
+                })) |manifest_file| {
+                    self.manifest_file = manifest_file;
+                    self.have_exclusive_lock = true;
+                    break;
+                } else |open_err| switch (open_err) {
+                    error.WouldBlock => {
+                        self.manifest_file = try self.cache.manifest_dir.openFile(&manifest_file_path, .{
+                            .lock = .Shared,
+                        });
+                        break;
+                    },
+                    error.FileNotFound => {
+                        if (self.cache.manifest_dir.createFile(&manifest_file_path, .{
+                            .read = true,
+                            .truncate = false,
+                            .lock = .Exclusive,
+                            .lock_nonblocking = self.want_shared_lock,
+                        })) |manifest_file| {
+                            self.manifest_file = manifest_file;
+                            self.manifest_dirty = true;
+                            self.have_exclusive_lock = true;
+                            return false; // cache miss; exclusive lock already held
+                        } else |err| switch (err) {
+                            error.WouldBlock => continue,
+                            else => |e| return e,
+                        }
+                    },
+                    else => |e| return e,
+                }
+            }
+        } else {
+            if (self.cache.manifest_dir.createFile(&manifest_file_path, .{
                 .read = true,
                 .truncate = false,
                 .lock = .Exclusive,
-            });
-        } else {
-            // If there are no file inputs, we check if the manifest file exists instead of
-            // comparing the hashes on the files used for the cached item
-            self.manifest_file = self.cache.manifest_dir.openFile(&manifest_file_path, .{
-                .read = true,
-                .write = true,
-                .lock = .Exclusive,
-            }) catch |err| switch (err) {
-                error.FileNotFound => {
-                    self.manifest_dirty = true;
-                    self.manifest_file = try self.cache.manifest_dir.createFile(&manifest_file_path, .{
-                        .read = true,
-                        .truncate = false,
-                        .lock = .Exclusive,
+                .lock_nonblocking = self.want_shared_lock,
+            })) |manifest_file| {
+                self.manifest_file = manifest_file;
+                self.have_exclusive_lock = true;
+            } else |err| switch (err) {
+                error.WouldBlock => {
+                    self.manifest_file = try self.cache.manifest_dir.openFile(&manifest_file_path, .{
+                        .lock = .Shared,
                     });
-                    return false;
                 },
                 else => |e| return e,
-            };
+            }
         }
 
         const file_contents = try self.manifest_file.?.reader().readAllAlloc(self.cache.gpa, manifest_file_size_max);
@@ -360,7 +399,10 @@ pub const Manifest = struct {
             }
 
             const this_file = fs.cwd().openFile(cache_hash_file.path.?, .{ .read = true }) catch |err| switch (err) {
-                error.FileNotFound => return false,
+                error.FileNotFound => {
+                    try self.upgradeToExclusiveLock();
+                    return false;
+                },
                 else => return error.CacheUnavailable,
             };
             defer this_file.close();
@@ -405,6 +447,7 @@ pub const Manifest = struct {
             // cache miss
             // keep the manifest file open
             self.unhit(bin_digest, input_file_count);
+            try self.upgradeToExclusiveLock();
             return false;
         }
 
@@ -417,9 +460,11 @@ pub const Manifest = struct {
                     return err;
                 };
             }
+            try self.upgradeToExclusiveLock();
             return false;
         }
 
+        try self.downgradeToSharedLock();
         return true;
     }
 
@@ -585,34 +630,56 @@ pub const Manifest = struct {
         return out_digest;
     }
 
+    /// If `want_shared_lock` is true, this function automatically downgrades the
+    /// lock from exclusive to shared.
     pub fn writeManifest(self: *Manifest) !void {
         const manifest_file = self.manifest_file.?;
-        if (!self.manifest_dirty) return;
+        if (self.manifest_dirty) {
+            self.manifest_dirty = false;
 
-        var contents = std.ArrayList(u8).init(self.cache.gpa);
-        defer contents.deinit();
+            var contents = std.ArrayList(u8).init(self.cache.gpa);
+            defer contents.deinit();
 
-        const writer = contents.writer();
-        var encoded_digest: [hex_digest_len]u8 = undefined;
+            const writer = contents.writer();
+            var encoded_digest: [hex_digest_len]u8 = undefined;
 
-        for (self.files.items) |file| {
-            _ = std.fmt.bufPrint(
-                &encoded_digest,
-                "{s}",
-                .{std.fmt.fmtSliceHexLower(&file.bin_digest)},
-            ) catch unreachable;
-            try writer.print("{d} {d} {d} {s} {s}\n", .{
-                file.stat.size,
-                file.stat.inode,
-                file.stat.mtime,
-                &encoded_digest,
-                file.path,
-            });
+            for (self.files.items) |file| {
+                _ = std.fmt.bufPrint(
+                    &encoded_digest,
+                    "{s}",
+                    .{std.fmt.fmtSliceHexLower(&file.bin_digest)},
+                ) catch unreachable;
+                try writer.print("{d} {d} {d} {s} {s}\n", .{
+                    file.stat.size,
+                    file.stat.inode,
+                    file.stat.mtime,
+                    &encoded_digest,
+                    file.path,
+                });
+            }
+
+            try manifest_file.setEndPos(contents.items.len);
+            try manifest_file.pwriteAll(contents.items, 0);
         }
 
-        try manifest_file.setEndPos(contents.items.len);
-        try manifest_file.pwriteAll(contents.items, 0);
-        self.manifest_dirty = false;
+        if (self.want_shared_lock) {
+            try self.downgradeToSharedLock();
+        }
+    }
+
+    fn downgradeToSharedLock(self: *Manifest) !void {
+        if (!self.have_exclusive_lock) return;
+        const manifest_file = self.manifest_file.?;
+        try manifest_file.setLock(.Shared, false);
+        self.have_exclusive_lock = false;
+    }
+
+    fn upgradeToExclusiveLock(self: *Manifest) !void {
+        if (self.have_exclusive_lock) return;
+        const manifest_file = self.manifest_file.?;
+        try manifest_file.setLock(.None, false);
+        try manifest_file.setLock(.Exclusive, false);
+        self.have_exclusive_lock = true;
     }
 
     /// Obtain only the data needed to maintain a lock on the manifest file.
@@ -881,27 +948,27 @@ test "no file inputs" {
     defer cache.manifest_dir.close();
 
     {
-        var ch = cache.obtain();
-        defer ch.deinit();
+        var man = cache.obtain();
+        defer man.deinit();
 
-        ch.hash.addBytes("1234");
+        man.hash.addBytes("1234");
 
         // There should be nothing in the cache
-        try testing.expectEqual(false, try ch.hit());
+        try testing.expectEqual(false, try man.hit());
 
-        digest1 = ch.final();
+        digest1 = man.final();
 
-        try ch.writeManifest();
+        try man.writeManifest();
     }
     {
-        var ch = cache.obtain();
-        defer ch.deinit();
+        var man = cache.obtain();
+        defer man.deinit();
 
-        ch.hash.addBytes("1234");
+        man.hash.addBytes("1234");
 
-        try testing.expect(try ch.hit());
-        digest2 = ch.final();
-        try ch.writeManifest();
+        try testing.expect(try man.hit());
+        digest2 = man.final();
+        try man.writeManifest();
     }
 
     try testing.expectEqual(digest1, digest2);


### PR DESCRIPTION
The cache system now drops from exclusive locks to shared locks after the artifact is built. Additionally, when checking the cache, if an exclusive lock cannot be obtained, a shared lock will be obtained instead. Together, this solves a design flaw in the caching system that was causing deadlocks, and allows multiple processes to share the same read-only build artifacts, while still allowing a cache garbage collection utility to avoid deleting files which are being actively used.

This required new std lib functionality: `std.fs.File.setLock`. This PR cannot be merged until the Windows implementation is completed. This may require switching strategies to using `NtLockFile` and `NtUnlockFile` rather than relying on ShareAccess flags and manual polling.

I was able to reproduce the deadlock problems reported in #9139 and observed this change fixed the problem. It also allowed me to delete another workaround to a deadlock when supplying the same source file multiple times.

Closes #7596
Fixes #9139
Fixes #9187