### PR TITLE
stage2: print valid filename in error messages

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -402,10 +402,10 @@ pub const AllErrors = struct {
             const source = try module_note.src_loc.file_scope.getSource(module.gpa);
             const byte_offset = try module_note.src_loc.byteOffset(module.gpa);
             const loc = std.zig.findLineColumn(source, byte_offset);
-            const sub_file_path = module_note.src_loc.file_scope.sub_file_path;
+            const file_path = try module_note.src_loc.file_scope.fullPath(&arena.allocator);
             note.* = .{
                 .src = .{
-                    .src_path = try arena.allocator.dupe(u8, sub_file_path),
+                    .src_path = file_path,
                     .msg = try arena.allocator.dupe(u8, module_note.msg),
                     .byte_offset = byte_offset,
                     .line = @intCast(u32, loc.line),
@@ -425,10 +425,10 @@ pub const AllErrors = struct {
         const source = try module_err_msg.src_loc.file_scope.getSource(module.gpa);
         const byte_offset = try module_err_msg.src_loc.byteOffset(module.gpa);
         const loc = std.zig.findLineColumn(source, byte_offset);
-        const sub_file_path = module_err_msg.src_loc.file_scope.sub_file_path;
+        const file_path = try module_err_msg.src_loc.file_scope.fullPath(&arena.allocator);
         try errors.append(.{
             .src = .{
-                .src_path = try arena.allocator.dupe(u8, sub_file_path),
+                .src_path = file_path,
                 .msg = try arena.allocator.dupe(u8, module_err_msg.msg),
                 .byte_offset = byte_offset,
                 .line = @intCast(u32, loc.line),
@@ -479,7 +479,7 @@ pub const AllErrors = struct {
 
                     note.* = .{
                         .src = .{
-                            .src_path = try arena.dupe(u8, file.sub_file_path),
+                            .src_path = try file.fullPath(arena),
                             .msg = try arena.dupe(u8, msg),
                             .byte_offset = byte_offset,
                             .line = @intCast(u32, loc.line),
@@ -505,7 +505,7 @@ pub const AllErrors = struct {
 
             try errors.append(.{
                 .src = .{
-                    .src_path = try arena.dupe(u8, file.sub_file_path),
+                    .src_path = try file.fullPath(arena),
                     .msg = try arena.dupe(u8, msg),
                     .byte_offset = byte_offset,
                     .line = @intCast(u32, loc.line),

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1111,6 +1111,11 @@ pub const Scope = struct {
             return buf.toOwnedSliceSentinel(0);
         }
 
+        /// Returns the full path to this file relative to its package.
+        pub fn fullPath(file: File, ally: *Allocator) ![]u8 {
+            return file.pkg.root_src_directory.join(ally, &[_][]const u8{file.sub_file_path});
+        }
+
         pub fn dumpSrc(file: *File, src: LazySrcLoc) void {
             const loc = std.zig.findLineColumn(file.source.bytes, src);
             std.debug.print("{s}:{d}:{d}\n", .{ file.sub_file_path, loc.line + 1, loc.column + 1 });

--- a/src/main.zig
+++ b/src/main.zig
@@ -3117,6 +3117,9 @@ pub fn cmdFmt(gpa: *Allocator, args: []const []const u8) !void {
                 .root_decl = null,
             };
 
+            file.pkg = try Package.create(gpa, null, file.sub_file_path);
+            defer file.pkg.destroy(gpa);
+
             file.zir = try AstGen.generate(gpa, file.tree);
             file.zir_loaded = true;
             defer file.zir.deinit(gpa);
@@ -3308,6 +3311,9 @@ fn fmtPathFile(
             .pkg = undefined,
             .root_decl = null,
         };
+
+        file.pkg = try Package.create(fmt.gpa, null, file.sub_file_path);
+        defer file.pkg.destroy(fmt.gpa);
 
         if (stat.size > max_src_size)
             return error.FileTooBig;
@@ -3901,6 +3907,9 @@ pub fn cmdAstCheck(
         file.stat_size = source.len;
     }
 
+    file.pkg = try Package.create(gpa, null, file.sub_file_path);
+    defer file.pkg.destroy(gpa);
+
     file.tree = try std.zig.parse(gpa, file.source);
     file.tree_loaded = true;
     defer file.tree.deinit(gpa);
@@ -4016,6 +4025,9 @@ pub fn cmdChangelist(
         .pkg = undefined,
         .root_decl = null,
     };
+
+    file.pkg = try Package.create(gpa, null, file.sub_file_path);
+    defer file.pkg.destroy(gpa);
 
     const source = try arena.allocSentinel(u8, @intCast(usize, stat.size), 0);
     const amt = try f.readAll(source);


### PR DESCRIPTION
Take two. Apologies for the bad PR (#9221, which was reverted in 6d47b4f39e8cdd95ead71b1efdbf67a737174e97). I should have tested it a bit more outside of typical build contexts. This PR addresses the same issue as the previous one, but includes a couple more changes to make sure it works properly in every context.

- `Module.Scope.File.pkg` is now `null` instead of `undefined` when the file being processed is not part of any package, such as when using `zig fmt` or `zig ast-check`. `pkg` being `undefined` was the source of crashes. Since this is a case that needs to be handled differently, it makes sense to be able to tell if we can safely access `pkg` or not.
- There are a couple places that assume the `pkg` pointer is valid when called. Assertions were added in these locations, but their assumptions are left unchanged.

Fixes #9249.