### PR TITLE
boot_services: allow custom MemoryTypes

### DIFF
--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -179,6 +179,7 @@ pub const MemoryType = enum(u32) {
     PalCode,
     PersistentMemory,
     MaxMemoryType,
+    _,
 };
 
 pub const MemoryDescriptor = extern struct {


### PR DESCRIPTION
The UEFI spec actually allows specifying custom MemoryTypes in a certain range for calling AllocatePages and AllocatePool, and the current exhaustive enum does not allow for that. The flip side is that custom memory used by your program or the firmware or chainloaders can appear when you get a memory map from UEFI, and the current exhaustive enum doesn't accommodate that either. Making the enum non exhaustive solves the issue. I've attached relevant screenshots from the oldest UEFI 2.0 spec from 2006 and the latest UEFI 2.9 spec from 2021. In particular, the Parameters -> MemoryType section is important here.
![2 0](https://user-images.githubusercontent.com/23709124/123880133-e4604180-d8f6-11eb-94ca-30014fd3feb5.png)
![2 9](https://user-images.githubusercontent.com/23709124/123880149-ede9a980-d8f6-11eb-955a-3f854c4c29c1.png)
