### PR TITLE
WASI: include exec-model in cache state.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1123,6 +1123,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
         cache.hash.add(options.machine_code_model);
         cache.hash.addOptionalEmitLoc(options.emit_bin);
         cache.hash.addBytes(options.root_name);
+        if (options.target.os.tag == .wasi) cache.hash.add(wasi_exec_model);
         // TODO audit this and make sure everything is in it
 
         const module: ?*Module = if (options.root_pkg) |root_pkg| blk: {


### PR DESCRIPTION
previously recompilation does not happen even if we change the value of`-mexec-model` flag in wasi target, so this PR fixes this!