### PR TITLE
require nameless tuples for std.fmt

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -93,6 +93,9 @@ pub fn format(
         @compileError("32 arguments max are supported per format call");
     }
 
+    if (comptime fields_info.len > 0 and !std.mem.eql(u8, fields_info[0].name, "0"))
+        @compileError("Expected tuple, found " ++ @typeName(ArgsType));
+
     comptime var arg_state: struct {
         next_arg: usize = 0,
         used_args: usize = 0,

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -8793,4 +8793,14 @@ pub fn addCases(ctx: *TestContext) !void {
     , &[_][]const u8{
         "error: Unsupported OS",
     });
+
+    ctx.objErrStage1("Require tuples for fmt args",
+        \\const std = @import("std");
+        \\pub const io_mode = .evented;
+        \\pub fn main() !void {
+        \\    std.debug.print("{s}\n", .{.foo="bar"});
+        \\}
+    , &[_][]const u8{
+        "error: Expected tuple, found struct",
+    });
 }


### PR DESCRIPTION
A user on discord showed this curious example that unexpectedly compiled but produced unexpected output:
```zig
const std = @import("std");

pub fn main() !void {
    std.debug.print("{s}\n", std.fmt.fmtSliceHexLower("foo"));
}
```

This example prints the string "foo" but it's supposed to print it in hex.  The problem is that it's missing the braces around the args.  It should have been this:

```zig
const std = @import("std");

pub fn main() !void {
    std.debug.print("{s}\n", .{std.fmt.fmtSliceHexLower("foo")});
}
```

This PR makes the first example a compile error.  It modifies `std.fmt` to only work with nameless tuples, i.e. `.{ x, y, z}`.  I do this by checking if the first field is named `0`.  This isn't perfect but it should catch 99% of cases for a relatively small cost to checking all fields.