### PR TITLE
Switch rand.DefaultPrng to Xoshiro256++

### DIFF
--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -23,7 +23,7 @@ const ziggurat = @import("rand/ziggurat.zig");
 const maxInt = std.math.maxInt;
 
 /// Fast unbiased random numbers.
-pub const DefaultPrng = Xoroshiro128;
+pub const DefaultPrng = Xoshiro256;
 
 /// Cryptographically secure random numbers.
 pub const DefaultCsprng = Gimli;


### PR DESCRIPTION
Xoroshiro128+ is the current default non-cryptographic random number generator.

This algorithm was designed to generate floating-point numbers, by only using the top 53 bits. Lower bits have a significant bias, that contradicts the documented properties for `rand.DefaultPrng`. This also has implications on everything using `Random.fill()`, including the way we generate random floating-point numbers.

In addition, Xoroshiro128+ has known issues. See for example:
- https://lemire.me/blog/2017/08/22/cracking-random-number-generators-xoroshiro128/
- https://www.pcg-random.org/posts/xoroshiro-fails-truncated.html

Xoshiro256++ addresses these issues, while remaining very fast.

Fixes #9292 