### PR TITLE
Fix #9299

### DIFF
--- a/src/stage1/bigint.cpp
+++ b/src/stage1/bigint.cpp
@@ -88,8 +88,13 @@ static void to_twos_complement(BigInt *dest, const BigInt *op, size_t bit_count)
     size_t digits_to_copy = bit_count / 64;
     size_t leftover_bits = bit_count % 64;
     dest->digit_count = digits_to_copy + ((leftover_bits == 0) ? 0 : 1);
-    if (dest->digit_count == 1 && leftover_bits == 0) {
-        dest->data.digit = op_digits[0];
+    if (dest->digit_count == 1) {
+        if (leftover_bits == 0) {
+            dest->data.digit = op_digits[0];
+        } else {
+            dest->data.digit = op_digits[0] & ((1ULL << leftover_bits) - 1);
+        }
+        dest->data.digit = op_digits[0] & ((1ULL << leftover_bits) - 1);
         if (dest->data.digit == 0) dest->digit_count = 0;
         return;
     }

--- a/src/stage1/bigint.cpp
+++ b/src/stage1/bigint.cpp
@@ -89,10 +89,9 @@ static void to_twos_complement(BigInt *dest, const BigInt *op, size_t bit_count)
     size_t leftover_bits = bit_count % 64;
     dest->digit_count = digits_to_copy + ((leftover_bits == 0) ? 0 : 1);
     if (dest->digit_count == 1) {
-        if (leftover_bits == 0) {
-            dest->data.digit = op_digits[0];
-        } else {
-            dest->data.digit = op_digits[0] & ((1ULL << leftover_bits) - 1);
+        dest->data.digit = op_digits[0];
+        if (leftover_bits != 0) {
+            dest->data.digit &= (1ULL << leftover_bits) - 1;
         }
         dest->data.digit = op_digits[0] & ((1ULL << leftover_bits) - 1);
         if (dest->data.digit == 0) dest->digit_count = 0;

--- a/test/behavior/truncate.zig
+++ b/test/behavior/truncate.zig
@@ -54,4 +54,6 @@ test "truncate on comptime integer" {
     try expect(y == 0xabcd);
     var z = @truncate(i16, -65537);
     try expect(z == -1);
+    var w = @truncate(u1, 1 << 100);
+    try expect(w == 0);
 }


### PR DESCRIPTION
This PR fixes bigint truncation. When `dest->digit_count == 1`, the union `{digit; digits;}` represents `digit`, so it should simply copy value regardless of `leftover_bits`, instead of cloning `digits` vector.