### PR TITLE
Fix bigint_shl

### DIFF
--- a/src/stage1/bigint.cpp
+++ b/src/stage1/bigint.cpp
@@ -1349,7 +1349,7 @@ void bigint_shl(BigInt *dest, const BigInt *op1, const BigInt *op2) {
 
     if (op1->digit_count == 1 && shift_amt < 64) {
         dest->data.digit = op1_digits[0] << shift_amt;
-        if (dest->data.digit > op1_digits[0]) {
+        if (dest->data.digit >> shift_amt == op1_digits[0]) {
             dest->digit_count = 1;
             dest->is_negative = op1->is_negative;
             return;

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -573,6 +573,13 @@ test "comptime shlWithOverflow" {
     try expect(ct_shifted == rt_shifted);
 }
 
+test "comptime shl" {
+    var a: u128 = 3;
+    var b: u7 = 63;
+    var c: u128 = 3 << 63;
+    try expectEqual(a << b, c);
+}
+
 test "runtime 128 bit integer division" {
     var a: u128 = 152313999999999991610955792383;
     var b: u128 = 10000000000000000000;


### PR DESCRIPTION
This PR fixes `bigint_shl` behavior reaching unreachable in [the following code](https://godbolt.org/z/3hbhbxTeG). To check whether the `bigint_shl` result has only one digit, we should check whether shr gives the original operand.
```Zig
comptime {
    if (3<<63 == 1<<63) 
        unreachable; // reaches unrechable
}
```
