### PR TITLE
std.json: Add support for recursive objects to std.json.parse

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1750,6 +1750,7 @@ test "parseUnsigned" {
 }
 
 pub const parseFloat = @import("fmt/parse_float.zig").parseFloat;
+pub const ParseFloatError = @import("fmt/parse_float.zig").ParseFloatError;
 pub const parseHexFloat = @import("fmt/parse_hex_float.zig").parseHexFloat;
 
 test {

--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -349,7 +349,9 @@ fn caseInEql(a: []const u8, b: []const u8) bool {
     return true;
 }
 
-pub fn parseFloat(comptime T: type, s: []const u8) !T {
+pub const ParseFloatError = error{InvalidCharacter};
+
+pub fn parseFloat(comptime T: type, s: []const u8) ParseFloatError!T {
     if (s.len == 0 or (s.len == 1 and (s[0] == '+' or s[0] == '-'))) {
         return error.InvalidCharacter;
     }

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -2582,11 +2582,11 @@ pub fn unescapeValidString(output: []u8, input: []const u8) UnescapeValidStringE
             } else |err| {
                 // it might be a surrogate pair
                 if (err != error.Utf8CannotEncodeSurrogateHalf) {
-                    return UnescapeValidStringError.InvalidUnicodeHexSymbol;
+                    return error.InvalidUnicodeHexSymbol;
                 }
                 // check if a second code unit is present
                 if (inIndex + 7 >= input.len or input[inIndex + 6] != '\\' or input[inIndex + 7] != 'u') {
-                    return UnescapeValidStringError.InvalidUnicodeHexSymbol;
+                    return error.InvalidUnicodeHexSymbol;
                 }
 
                 const secondCodeUnit = std.fmt.parseInt(u16, input[inIndex + 8 .. inIndex + 12], 16) catch unreachable;

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1874,7 +1874,11 @@ fn parseInternal(
     unreachable;
 }
 
-pub fn parse(comptime T: type, tokens: *TokenStream, options: ParseOptions) !T {
+pub fn ParseError(comptime T: type) type {
+    return ParseInternalError(T) || error{UnexpectedEndOfJson} || TokenStream.Error;
+}
+
+pub fn parse(comptime T: type, tokens: *TokenStream, options: ParseOptions) ParseError(T)!T {
     const token = (try tokens.next()) orelse return error.UnexpectedEndOfJson;
     const r = try parseInternal(T, token, tokens, options);
     errdefer parseFree(T, r, options);

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1532,7 +1532,7 @@ test "skipValue" {
     }
 }
 
-fn ParseInternalError(comptime T: type, inferred_types: []const type) type {
+fn ParseInternalError(comptime T: type, comptime inferred_types: []const type) type {
     for (inferred_types) |ty| {
         if (T == ty) return error{};
     }


### PR DESCRIPTION
Inferred errors don't work for recursive function calls, so we add an explicit error set.

`parseInternal` recurses in several places, current error catches this:
https://github.com/ziglang/zig/blob/b7da1b2d45bc42a56eea3a143e4237a0712c4769/lib/std/json.zig#L1768