### PR TITLE
Speed up stage 1 by improving hash functions

### DIFF
--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -1879,8 +1879,8 @@ struct TypeId {
     } data;
 };
 
-uint32_t type_id_hash(TypeId);
-bool type_id_eql(TypeId a, TypeId b);
+uint32_t type_id_hash(TypeId const *);
+bool type_id_eql(TypeId const *a, TypeId const *b);
 
 enum ZigLLVMFnId {
     ZigLLVMFnIdCtz,
@@ -1935,8 +1935,8 @@ struct ZigLLVMFnKey {
     } data;
 };
 
-uint32_t zig_llvm_fn_key_hash(ZigLLVMFnKey);
-bool zig_llvm_fn_key_eql(ZigLLVMFnKey a, ZigLLVMFnKey b);
+uint32_t zig_llvm_fn_key_hash(ZigLLVMFnKey const *);
+bool zig_llvm_fn_key_eql(ZigLLVMFnKey const *a, ZigLLVMFnKey const *b);
 
 struct TimeEvent {
     double time;

--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -5674,7 +5674,7 @@ static uint32_t hash_combine_const_val(uint32_t hash_val, ZigValue *const_val) {
     //     return hash_combine(hash_val, &const_val);
     // }
     if (const_val->special != ConstValSpecialStatic) {
-        printf("\nInvalid special: %d\n", const_val->special);
+        fprintf(stderr, "\nInvalid special: %d\n", const_val->special);
     }
     assert(const_val->special == ConstValSpecialStatic);
     hash_val = hash_combine(hash_val, &const_val->type->id);
@@ -5775,9 +5775,6 @@ static uint32_t hash_combine_const_val(uint32_t hash_val, ZigValue *const_val) {
             zig_unreachable();
     }
     zig_unreachable();
-}
-static uint32_t hash_const_val(ZigValue *const_val) {
-    return hash_combine_const_val(HASH_INIT, const_val);
 }
 
 uint32_t generic_fn_type_id_hash(GenericFnTypeId *id) {

--- a/src/stage1/bigint.cpp
+++ b/src/stage1/bigint.cpp
@@ -1730,16 +1730,16 @@ Cmp bigint_cmp_zero(const BigInt *op) {
     return op->is_negative ? CmpLT : CmpGT;
 }
 
-uint32_t bigint_hash(BigInt x) {
-    if (x.digit_count == 0) {
+uint32_t bigint_hash(BigInt const *x) {
+    if (x->digit_count == 0) {
         return 0;
     } else {
-        return bigint_ptr(&x)[0];
+        return bigint_ptr(x)[0];
     }
 }
 
-bool bigint_eql(BigInt a, BigInt b) {
-    return bigint_cmp(&a, &b) == CmpEQ;
+bool bigint_eql(BigInt const *a, BigInt const *b) {
+    return bigint_cmp(a, b) == CmpEQ;
 }
 
 void bigint_incr(BigInt *x) {

--- a/src/stage1/bigint.cpp
+++ b/src/stage1/bigint.cpp
@@ -1691,6 +1691,13 @@ uint32_t bigint_as_u32(const BigInt *bigint) {
     return value32;
 }
 
+uint8_t bigint_as_u8(const BigInt *bigint) {
+    uint64_t value64 = bigint_as_unsigned(bigint);
+    uint8_t value8 = (uint8_t)value64;
+    assert (value64 == value8);
+    return value8;
+}
+
 size_t bigint_as_usize(const BigInt *bigint) {
     uint64_t value64 = bigint_as_unsigned(bigint);
     size_t valueUsize = (size_t)value64;

--- a/src/stage1/bigint.hpp
+++ b/src/stage1/bigint.hpp
@@ -100,7 +100,7 @@ void bigint_decr(BigInt *value);
 
 bool mul_u64_overflow(uint64_t op1, uint64_t op2, uint64_t *result);
 
-uint32_t bigint_hash(BigInt x);
-bool bigint_eql(BigInt a, BigInt b);
+uint32_t bigint_hash(BigInt const *x);
+bool bigint_eql(BigInt const *a, BigInt const *b);
 
 #endif

--- a/src/stage1/bigint.hpp
+++ b/src/stage1/bigint.hpp
@@ -39,6 +39,7 @@ void bigint_deinit(BigInt *bi);
 // panics if number won't fit
 uint64_t bigint_as_u64(const BigInt *bigint);
 uint32_t bigint_as_u32(const BigInt *bigint);
+uint8_t bigint_as_u8(const BigInt *bigint);
 size_t bigint_as_usize(const BigInt *bigint);
 
 int64_t bigint_as_signed(const BigInt *bigint);

--- a/src/stage1/buffer.hpp
+++ b/src/stage1/buffer.hpp
@@ -26,7 +26,7 @@ Buf *buf_sprintf(const char *format, ...)
     ATTRIBUTE_PRINTF(1, 2);
 Buf *buf_vprintf(const char *format, va_list ap);
 
-static inline size_t buf_len(Buf *buf) {
+static inline size_t buf_len(const Buf *buf) {
     assert(buf);
     assert(buf->list.length);
     return buf->list.length - 1;

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -25620,6 +25620,11 @@ static Error ir_resolve_lazy_recurse(IrAnalyze *ira, AstNode *source_node, ZigVa
         case ZigTypeIdStruct:
             for (size_t i = 0; i < val->type->data.structure.src_field_count; i += 1) {
                 ZigValue *field = val->data.x_struct.fields[i];
+                if (val->type->data.structure.fields[i]->is_comptime) {
+                    // comptime struct fields do not need to be resolved because
+                    // they are not part of the value.
+                    continue;
+                }
                 if ((err = ir_resolve_lazy_recurse(ira, source_node, field)))
                     return err;
             }

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -272,8 +272,8 @@ static bool value_cmp_numeric_val_all(ZigValue *left, Cmp predicate, ZigValue *r
 static void memoize_field_init_val(CodeGen *codegen, ZigType *container_type, TypeStructField *field);
 static void value_to_bigfloat(BigFloat *out, ZigValue *val);
 
-static Error ir_resolve_lazy_recurse(AstNode *source_node, ZigValue *val);
-static Error ir_resolve_lazy_recurse_array(AstNode *source_node, ZigValue *val, size_t len);
+static Error ir_resolve_lazy_recurse(IrAnalyze *ira, AstNode *source_node, ZigValue *val);
+static Error ir_resolve_lazy_recurse_array(IrAnalyze *ira, AstNode *source_node, ZigValue *val, size_t len);
 
 
 static void ir_assert_impl(bool ok, IrInstGen *source_instruction, char const *file, unsigned int line) {
@@ -12945,7 +12945,7 @@ static IrInstGen *ir_analyze_fn_call(IrAnalyze *ira, Scope *scope, AstNode *sour
         for (size_t i = 0; i < generic_id->param_count; i += 1) {
             ZigValue *generic_param = &generic_id->params[i];
             if (generic_param->special != ConstValSpecialRuntime) {
-                if ((err = ir_resolve_lazy_recurse(source_node, generic_param))) {
+                if ((err = ir_resolve_lazy_recurse(ira, source_node, generic_param))) {
                     return ira->codegen->invalid_inst_gen;
                 }
             }
@@ -25531,7 +25531,7 @@ static Error ir_resolve_lazy_raw(AstNode *source_node, ZigValue *val) {
     zig_unreachable();
 }
 
-static Error ir_resolve_lazy_recurse_array(AstNode *source_node, ZigValue *val, size_t len) {
+static Error ir_resolve_lazy_recurse_array(IrAnalyze *ira, AstNode *source_node, ZigValue *val, size_t len) {
     Error err;
     switch (val->data.x_array.special) {
         case ConstArraySpecialUndef:
@@ -25543,17 +25543,24 @@ static Error ir_resolve_lazy_recurse_array(AstNode *source_node, ZigValue *val, 
     ZigValue *elems = val->data.x_array.data.s_none.elements;
 
     for (size_t i = 0; i < len; i += 1) {
-        if ((err = ir_resolve_lazy_recurse(source_node, &elems[i])))
+        if ((err = ir_resolve_lazy_recurse(ira, source_node, &elems[i])))
             return err;
     }
 
     return ErrorNone;
 }
 
-static Error ir_resolve_lazy_recurse(AstNode *source_node, ZigValue *val) {
+static Error ir_resolve_lazy_recurse(IrAnalyze *ira, AstNode *source_node, ZigValue *val) {
     Error err;
     if ((err = ir_resolve_lazy_raw(source_node, val))) 
         return err;
+    if (val->special == ConstValSpecialRuntime) {
+        // This shouldn't be possible, it indicates an ICE.
+        // NO_COMMIT
+        ir_add_error_node(ira, source_node,
+            buf_sprintf("This is a bug in the Zig compiler. Runtime value found in comptime known parameter."));
+        return ErrorSemanticAnalyzeFail;
+    }
     if (val->special != ConstValSpecialStatic)
         return ErrorNone;
     switch (val->type->id) {
@@ -25581,16 +25588,16 @@ static Error ir_resolve_lazy_recurse(AstNode *source_node, ZigValue *val) {
             zig_panic("TODO: ir_resolve_lazy_recurse ZigTypeIdFnFrame");
         case ZigTypeIdUnion: {
             ConstUnionValue *union_val = &val->data.x_union;
-            return ir_resolve_lazy_recurse(source_node, union_val->payload);
+            return ir_resolve_lazy_recurse(ira, source_node, union_val->payload);
         }
         case ZigTypeIdVector:
-            return ir_resolve_lazy_recurse_array(source_node, val, val->type->data.vector.len);
+            return ir_resolve_lazy_recurse_array(ira, source_node, val, val->type->data.vector.len);
         case ZigTypeIdArray:
-            return ir_resolve_lazy_recurse_array(source_node, val, val->type->data.array.len);
+            return ir_resolve_lazy_recurse_array(ira, source_node, val, val->type->data.array.len);
         case ZigTypeIdStruct:
             for (size_t i = 0; i < val->type->data.structure.src_field_count; i += 1) {
                 ZigValue *field = val->data.x_struct.fields[i];
-                if ((err = ir_resolve_lazy_recurse(source_node, field)))
+                if ((err = ir_resolve_lazy_recurse(ira, source_node, field)))
                     return err;
             }
             return ErrorNone;
@@ -25600,13 +25607,13 @@ static Error ir_resolve_lazy_recurse(AstNode *source_node, ZigValue *val) {
             if (val->data.x_optional == nullptr)
                 return ErrorNone;
 
-            return ir_resolve_lazy_recurse(source_node, val->data.x_optional);
+            return ir_resolve_lazy_recurse(ira, source_node, val->data.x_optional);
         case ZigTypeIdErrorUnion: {
             bool is_err = val->data.x_err_union.error_set->data.x_err_set != nullptr;
             if (is_err) {
-                return ir_resolve_lazy_recurse(source_node, val->data.x_err_union.error_set);
+                return ir_resolve_lazy_recurse(ira, source_node, val->data.x_err_union.error_set);
             } else {
-                return ir_resolve_lazy_recurse(source_node, val->data.x_err_union.payload);
+                return ir_resolve_lazy_recurse(ira, source_node, val->data.x_err_union.payload);
             }
         }
     }

--- a/src/stage1/util.cpp
+++ b/src/stage1/util.cpp
@@ -21,29 +21,6 @@ void zig_panic(const char *format, ...) {
     abort();
 }
 
-uint32_t int_hash(int i) {
-    return (uint32_t)(i % UINT32_MAX);
-}
-bool int_eq(int a, int b) {
-    return a == b;
-}
-
-uint32_t uint64_hash(uint64_t i) {
-    return (uint32_t)(i % UINT32_MAX);
-}
-
-bool uint64_eq(uint64_t a, uint64_t b) {
-    return a == b;
-}
-
-uint32_t ptr_hash(const void *ptr) {
-    return (uint32_t)(((uintptr_t)ptr) % UINT32_MAX);
-}
-
-bool ptr_eq(const void *a, const void *b) {
-    return a == b;
-}
-
 // Ported from std/mem.zig.
 bool SplitIterator_isSplitByte(SplitIterator *self, uint8_t byte) {
     for (size_t i = 0; i < self->split_bytes.len; i += 1) {

--- a/src/stage1/util.hpp
+++ b/src/stage1/util.hpp
@@ -129,13 +129,6 @@ static inline uint64_t round_to_next_power_of_2(uint64_t x) {
     return x + 1;
 }
 
-uint32_t int_hash(int i);
-bool int_eq(int a, int b);
-uint32_t uint64_hash(uint64_t i);
-bool uint64_eq(uint64_t a, uint64_t b);
-uint32_t ptr_hash(const void *ptr);
-bool ptr_eq(const void *a, const void *b);
-
 static inline uint8_t log2_u64(uint64_t x) {
     return (63 - clzll(x));
 }

--- a/src/stage1/zig0.cpp
+++ b/src/stage1/zig0.cpp
@@ -265,6 +265,7 @@ int main(int argc, char **argv) {
     const char *override_lib_dir = nullptr;
     const char *mcpu = nullptr;
     bool single_threaded = false;
+    bool is_test_build = false;
 
     for (int i = 1; i < argc; i += 1) {
         char *arg = argv[i];
@@ -272,6 +273,8 @@ int main(int argc, char **argv) {
         if (arg[0] == '-') {
             if (strcmp(arg, "--") == 0) {
                 fprintf(stderr, "Unexpected end-of-parameter mark: %s\n", arg);
+            } else if (strcmp(arg, "--test") == 0) {
+                is_test_build = true;
             } else if (strcmp(arg, "-ODebug") == 0) {
                 optimize_mode = BuildModeDebug;
             } else if (strcmp(arg, "-OReleaseFast") == 0) {
@@ -446,7 +449,7 @@ int main(int argc, char **argv) {
         nullptr, 0,
         in_file, strlen(in_file),
         override_lib_dir, strlen(override_lib_dir),
-        &target, false);
+        &target, is_test_build);
 
     stage1->main_progress_node = root_progress_node;
     stage1->root_name_ptr = out_name;


### PR DESCRIPTION
A significant portion of stage 1 compilation time was spent in const_values_equal, called as part of hash map lookups.  This was called much more often than it should have been because the hash functions used for const values were not very good hashes.  This PR improves those hash functions, reducing the time to create a debug build of stage 2 from 37 seconds to 30 seconds on my computer.

I also have audited struct field accesses throughout the codebase to ensure that comptime fields are handled correctly.