### PR TITLE
Set paragraph line-height of language reference

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10,6 +10,9 @@
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;
         margin: 0;
       }
+      p {
+        line-height: 1.7;
+      }
       a:not(:hover) {
         text-decoration: none;
       }


### PR DESCRIPTION
The line-height of paragraphs is set to 1.7. This value is chosen based on
recommendations from W3C [1] via MDN Web Docs [2] and the contents of the
language reference.

The MDN Web Docs offers two recommendations:
1. Use a unitless number for line-height.
2. Use a minimum value of 1.5 for main paragraph content.

The line-height of this commit uses 1.7 due to the mix of text and code font in
language reference's paragraphs.

[1] https://www.w3.org/TR/WCAG21/#visual-presentation
[2] https://developer.mozilla.org/en-US/docs/Web/CSS/line-height

Closes #6313