### PR TITLE
Make clearer inline code blocks in language reference paragraphs

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -47,7 +47,7 @@
         border: 1px dotted silver;
         line-height: normal;
       }
-      p code, ul code, ol code, table code {
+      code {
         background-color: #f8f8f8;
         border: 1px dotted silver;
         padding-left: 0.3em;
@@ -161,7 +161,7 @@
             background: #222;
             border-color: #444;
         }
-        p code, ul code, ol code, table code {
+        code {
           background-color: #222;
           border-color: #444;
         }

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10,9 +10,6 @@
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;
         margin: 0;
       }
-      p, ul, ol, :not(#toc) {
-        line-height: 1.5;
-      }
       a:not(:hover) {
         text-decoration: none;
       }
@@ -48,6 +45,7 @@
         color: #333;
         background: #f8f8f8;
         border: 1px dotted silver;
+        line-height: normal;
       }
       p code, ul code, ol code, table code {
         background-color: #f8f8f8;
@@ -102,6 +100,7 @@
       #contents {
         max-width: 60em;
         margin: auto;
+        line-height: 1.5;
       }
 
       #toc {
@@ -160,6 +159,7 @@
         pre > code {
             color: #ccc;
             background: #222;
+            border-color: #444;
         }
         p code, ul code, ol code, table code {
           background-color: #222;

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10,14 +10,8 @@
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;
         margin: 0;
       }
-      p {
-        line-height: 1.7;
-      }
-      p code {
-        background-color: lightgray;
-        border: darkblue dotted 1px;
-        padding-left: 0.3em;
-        padding-right: 0.3em;
+      p, ul, ol, :not(#toc) {
+        line-height: 1.5;
       }
       a:not(:hover) {
         text-decoration: none;
@@ -48,14 +42,18 @@
         text-decoration: underline;
       }
       pre > code {
-        font-size: 12pt;
-      }
-      pre > code {
         display: block;
         overflow: auto;
         padding: 0.5em;
         color: #333;
         background: #f8f8f8;
+        border: 1px dotted silver;
+      }
+      p code, ul code, ol code, table code {
+        background-color: #f8f8f8;
+        border: 1px dotted silver;
+        padding-left: 0.3em;
+        padding-right: 0.3em;
       }
       .table-wrapper {
         width: 100%;
@@ -141,10 +139,6 @@
             background-color:#111;
             color: #bbb;
         }
-        p code {
-          background-color: #333;
-          border-color: darkgray;
-        }
         a {
             color: #f7a31d;
         }
@@ -166,6 +160,10 @@
         pre > code {
             color: #ccc;
             background: #222;
+        }
+        p code, ul code, ol code, table code {
+          background-color: #222;
+          border-color: #444;
         }
         .tok-kw {
             color: #eee;

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10,6 +10,15 @@
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;
         margin: 0;
       }
+      p {
+        line-height: 1.7;
+      }
+      p code {
+        background-color: lightgray;
+        border: darkblue dotted 1px;
+        padding-left: 0.3em;
+        padding-right: 0.3em;
+      }
       a:not(:hover) {
         text-decoration: none;
       }
@@ -38,7 +47,7 @@
       .file {
         text-decoration: underline;
       }
-      pre,code {
+      pre > code {
         font-size: 12pt;
       }
       pre > code {
@@ -131,6 +140,10 @@
         body{
             background-color:#111;
             color: #bbb;
+        }
+        p code {
+          background-color: #333;
+          border-color: darkgray;
         }
         a {
             color: #f7a31d;


### PR DESCRIPTION
_**Please read later comments. There have been updates since this comment was made. This message is left to preserve the differences made during code review.**_

This commit makes the inline code blocks within paragraphs standout against the
descriptive text. The code blocks within tables are left un-styled.

The line-height of the paragraphs has been set to 1.7 based on recommendations
from MDN Web Docs and W3C. The value is unitless based on the recommendation.

The changes apply both normal and dark modes.

### Screenshots

![pic-selected-210706-1629-09](https://user-images.githubusercontent.com/4141567/124580095-fb181280-de79-11eb-9884-a1e88ab59f62.png)
![pic-selected-210706-1629-40](https://user-images.githubusercontent.com/4141567/124580099-fce1d600-de79-11eb-8669-e341956a2041.png)
![pic-selected-210706-1630-08](https://user-images.githubusercontent.com/4141567/124580102-fe130300-de79-11eb-904e-b1b03d968687.png)
![pic-selected-210706-1630-22](https://user-images.githubusercontent.com/4141567/124580104-feab9980-de79-11eb-9565-bb1af2d19ff8.png)


Closes #9316, #6313