### PR TITLE
Stage2 inferred error sets and `@panic`

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -677,6 +677,13 @@ pub const panic: PanicFn = if (@hasDecl(root, "panic")) root.panic else default_
 /// therefore must be kept in sync with the compiler implementation.
 pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace) noreturn {
     @setCold(true);
+    // Until self-hosted catches up with stage1 language features, we have a simpler
+    // default panic function:
+    if (builtin.zig_is_stage2) {
+        while (true) {
+            @breakpoint();
+        }
+    }
     if (@hasDecl(root, "os") and @hasDecl(root.os, "panic")) {
         root.os.panic(msg, error_return_trace);
         unreachable;

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -483,10 +483,20 @@ pub fn HashMap(
             return self.unmanaged.getOrPutValueContext(self.allocator, key, value, self.ctx);
         }
 
+        /// Deprecated: call `ensureUnusedCapacity` or `ensureTotalCapacity`.
+        pub const ensureCapacity = ensureTotalCapacity;
+
         /// Increases capacity, guaranteeing that insertions up until the
         /// `expected_count` will not cause an allocation, and therefore cannot fail.
-        pub fn ensureCapacity(self: *Self, expected_count: Size) !void {
-            return self.unmanaged.ensureCapacityContext(self.allocator, expected_count, self.ctx);
+        pub fn ensureTotalCapacity(self: *Self, expected_count: Size) !void {
+            return self.unmanaged.ensureTotalCapacityContext(self.allocator, expected_count, self.ctx);
+        }
+
+        /// Increases capacity, guaranteeing that insertions up until
+        /// `additional_count` **more** items will not cause an allocation, and
+        /// therefore cannot fail.
+        pub fn ensureUnusedCapacity(self: *Self, additional_count: Size) !void {
+            return self.unmanaged.ensureUnusedCapacityContext(self.allocator, additional_count, self.ctx);
         }
 
         /// Returns the number of total elements which may be present before it is
@@ -821,14 +831,24 @@ pub fn HashMapUnmanaged(
             return new_cap;
         }
 
-        pub fn ensureCapacity(self: *Self, allocator: *Allocator, new_size: Size) !void {
+        /// Deprecated: call `ensureUnusedCapacity` or `ensureTotalCapacity`.
+        pub const ensureCapacity = ensureTotalCapacity;
+
+        pub fn ensureTotalCapacity(self: *Self, allocator: *Allocator, new_size: Size) !void {
             if (@sizeOf(Context) != 0)
-                @compileError("Cannot infer context " ++ @typeName(Context) ++ ", call ensureCapacityContext instead.");
-            return ensureCapacityContext(self, allocator, new_size, undefined);
+                @compileError("Cannot infer context " ++ @typeName(Context) ++ ", call ensureTotalCapacityContext instead.");
+            return ensureTotalCapacityContext(self, allocator, new_size, undefined);
         }
-        pub fn ensureCapacityContext(self: *Self, allocator: *Allocator, new_size: Size, ctx: Context) !void {
+        pub fn ensureTotalCapacityContext(self: *Self, allocator: *Allocator, new_size: Size, ctx: Context) !void {
             if (new_size > self.size)
                 try self.growIfNeeded(allocator, new_size - self.size, ctx);
+        }
+
+        pub fn ensureUnusedCapacity(self: *Self, allocator: *Allocator, additional_size: Size) !void {
+            return ensureUnusedCapacityContext(self, allocator, additional_size, undefined);
+        }
+        pub fn ensureUnusedCapacityContext(self: *Self, allocator: *Allocator, additional_size: Size, ctx: Context) !void {
+            return ensureTotalCapacityContext(self, allocator, self.capacity() + additional_size, ctx);
         }
 
         pub fn clearRetainingCapacity(self: *Self) void {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -777,8 +777,19 @@ pub const Fn = struct {
     }
 
     pub fn deinit(func: *Fn, gpa: *Allocator) void {
-        _ = func;
-        _ = gpa;
+        if (func.getInferredErrorSet()) |map| {
+            map.deinit(gpa);
+        }
+    }
+
+    pub fn getInferredErrorSet(func: *Fn) ?*std.StringHashMapUnmanaged(void) {
+        const ret_ty = func.owner_decl.ty.fnReturnType();
+        if (ret_ty.zigTypeTag() == .ErrorUnion) {
+            if (ret_ty.errorUnionSet().castTag(.error_set_inferred)) |payload| {
+                return &payload.data.map;
+            }
+        }
+        return null;
     }
 };
 

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -755,6 +755,7 @@ pub const Fn = struct {
     rbrace_column: u16,
 
     state: Analysis,
+    is_cold: bool = false,
 
     pub const Analysis = enum {
         queued,
@@ -3453,6 +3454,9 @@ pub fn clearDecl(
     for (decl.dependencies.keys()) |dep| {
         dep.removeDependant(decl);
         if (dep.dependants.count() == 0 and !dep.deletion_flag) {
+            log.debug("insert {*} ({s}) dependant {*} ({s}) into deletion set", .{
+                decl, decl.name, dep, dep.name,
+            });
             // We don't recursively perform a deletion here, because during the update,
             // another reference to it may turn up.
             dep.deletion_flag = true;

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -1,7 +1,7 @@
 //! Zig Intermediate Representation. Astgen.zig converts AST nodes to these
-//! untyped IR instructions. Next, Sema.zig processes these into TZIR.
+//! untyped IR instructions. Next, Sema.zig processes these into AIR.
 //! The minimum amount of information needed to represent a list of ZIR instructions.
-//! Once this structure is completed, it can be used to generate TZIR, followed by
+//! Once this structure is completed, it can be used to generate AIR, followed by
 //! machine code, without any memory access into the AST tree token list, node list,
 //! or source bytes. Exceptions include:
 //!  * Compile errors, which may need to reach into these data structures to
@@ -416,8 +416,8 @@ pub const Inst = struct {
         /// A labeled block of code that loops forever. At the end of the body will have either
         /// a `repeat` instruction or a `repeat_inline` instruction.
         /// Uses the `pl_node` field. The AST node is either a for loop or while loop.
-        /// This ZIR instruction is needed because TZIR does not (yet?) match ZIR, and Sema
-        /// needs to emit more than 1 TZIR block for this instruction.
+        /// This ZIR instruction is needed because AIR does not (yet?) match ZIR, and Sema
+        /// needs to emit more than 1 AIR block for this instruction.
         /// The payload is `Block`.
         loop,
         /// Sends runtime control flow back to the beginning of the current block.
@@ -466,6 +466,19 @@ pub const Inst = struct {
         /// Uses the `un_tok` union field.
         /// The operand needs to get coerced to the function's return type.
         ret_coerce,
+        /// Sends control flow back to the function's callee.
+        /// The return operand is `error.foo` where `foo` is given by the string.
+        /// If the current function has an inferred error set, the error given by the
+        /// name is added to it.
+        /// Uses the `str_tok` union field.
+        ret_err_value,
+        /// A string name is provided which is an anonymous error set value.
+        /// If the current function has an inferred error set, the error given by the
+        /// name is added to it.
+        /// Results in the error code. Note that control flow is not diverted with
+        /// this instruction; a following 'ret' instruction will do the diversion.
+        /// Uses the `str_tok` union field.
+        ret_err_value_code,
         /// Create a pointer type that does not have a sentinel, alignment, or bit range specified.
         /// Uses the `ptr_type_simple` union field.
         ptr_type_simple,
@@ -1193,6 +1206,7 @@ pub const Inst = struct {
                 .@"resume",
                 .@"await",
                 .await_nosuspend,
+                .ret_err_value_code,
                 .extended,
                 => false,
 
@@ -1203,6 +1217,7 @@ pub const Inst = struct {
                 .compile_error,
                 .ret_node,
                 .ret_coerce,
+                .ret_err_value,
                 .@"unreachable",
                 .repeat,
                 .repeat_inline,
@@ -1307,6 +1322,8 @@ pub const Inst = struct {
                 .ref = .un_tok,
                 .ret_node = .un_node,
                 .ret_coerce = .un_tok,
+                .ret_err_value = .str_tok,
+                .ret_err_value_code = .str_tok,
                 .ptr_type_simple = .ptr_type_simple,
                 .ptr_type = .ptr_type,
                 .slice_start = .pl_node,
@@ -3077,6 +3094,8 @@ const Writer = struct {
             .decl_val,
             .import,
             .arg,
+            .ret_err_value,
+            .ret_err_value_code,
             => try self.writeStrTok(stream, inst),
 
             .func => try self.writeFunc(stream, inst, false),

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -398,21 +398,15 @@ pub const Inst = struct {
         /// Return a boolean false if an optional is null. `x != null`
         /// Uses the `un_node` field.
         is_non_null,
-        /// Return a boolean true if an optional is null. `x == null`
-        /// Uses the `un_node` field.
-        is_null,
         /// Return a boolean false if an optional is null. `x.* != null`
         /// Uses the `un_node` field.
         is_non_null_ptr,
-        /// Return a boolean true if an optional is null. `x.* == null`
+        /// Return a boolean false if value is an error
         /// Uses the `un_node` field.
-        is_null_ptr,
-        /// Return a boolean true if value is an error
+        is_non_err,
+        /// Return a boolean false if dereferenced pointer is an error
         /// Uses the `un_node` field.
-        is_err,
-        /// Return a boolean true if dereferenced pointer is an error
-        /// Uses the `un_node` field.
-        is_err_ptr,
+        is_non_err_ptr,
         /// A labeled block of code that loops forever. At the end of the body will have either
         /// a `repeat` instruction or a `repeat_inline` instruction.
         /// Uses the `pl_node` field. The AST node is either a for loop or while loop.
@@ -1046,11 +1040,9 @@ pub const Inst = struct {
                 .float128,
                 .int_type,
                 .is_non_null,
-                .is_null,
                 .is_non_null_ptr,
-                .is_null_ptr,
-                .is_err,
-                .is_err_ptr,
+                .is_non_err,
+                .is_non_err_ptr,
                 .mod_rem,
                 .mul,
                 .mulwrap,
@@ -1306,11 +1298,9 @@ pub const Inst = struct {
                 .float128 = .pl_node,
                 .int_type = .int_type,
                 .is_non_null = .un_node,
-                .is_null = .un_node,
                 .is_non_null_ptr = .un_node,
-                .is_null_ptr = .un_node,
-                .is_err = .un_node,
-                .is_err_ptr = .un_node,
+                .is_non_err = .un_node,
+                .is_non_err_ptr = .un_node,
                 .loop = .pl_node,
                 .repeat = .node,
                 .repeat_inline = .node,
@@ -2857,11 +2847,9 @@ const Writer = struct {
             .err_union_code,
             .err_union_code_ptr,
             .is_non_null,
-            .is_null,
             .is_non_null_ptr,
-            .is_null_ptr,
-            .is_err,
-            .is_err_ptr,
+            .is_non_err,
+            .is_non_err_ptr,
             .typeof,
             .typeof_elem,
             .struct_init_empty,

--- a/src/air.zig
+++ b/src/air.zig
@@ -90,8 +90,12 @@ pub const Inst = struct {
         is_non_null_ptr,
         /// E!T => bool
         is_err,
+        /// E!T => bool (inverted logic)
+        is_non_err,
         /// *E!T => bool
         is_err_ptr,
+        /// *E!T => bool (inverted logic)
+        is_non_err_ptr,
         bool_and,
         bool_or,
         /// Read a value from a pointer.
@@ -154,7 +158,9 @@ pub const Inst = struct {
                 .is_null,
                 .is_null_ptr,
                 .is_err,
+                .is_non_err,
                 .is_err_ptr,
+                .is_non_err_ptr,
                 .ptrtoint,
                 .floatcast,
                 .intcast,
@@ -759,7 +765,9 @@ const DumpAir = struct {
                 .is_null,
                 .is_null_ptr,
                 .is_err,
+                .is_non_err,
                 .is_err_ptr,
+                .is_non_err_ptr,
                 .ptrtoint,
                 .floatcast,
                 .intcast,
@@ -888,11 +896,13 @@ const DumpAir = struct {
                 .bitcast,
                 .not,
                 .is_non_null,
-                .is_null,
                 .is_non_null_ptr,
+                .is_null,
                 .is_null_ptr,
                 .is_err,
                 .is_err_ptr,
+                .is_non_err,
+                .is_non_err_ptr,
                 .ptrtoint,
                 .floatcast,
                 .intcast,

--- a/src/air.zig
+++ b/src/air.zig
@@ -672,15 +672,15 @@ pub const Body = struct {
 /// For debugging purposes, prints a function representation to stderr.
 pub fn dumpFn(old_module: Module, module_fn: *Module.Fn) void {
     const allocator = old_module.gpa;
-    var ctx: DumpTzir = .{
+    var ctx: DumpAir = .{
         .allocator = allocator,
         .arena = std.heap.ArenaAllocator.init(allocator),
         .old_module = &old_module,
         .module_fn = module_fn,
         .indent = 2,
-        .inst_table = DumpTzir.InstTable.init(allocator),
-        .partial_inst_table = DumpTzir.InstTable.init(allocator),
-        .const_table = DumpTzir.InstTable.init(allocator),
+        .inst_table = DumpAir.InstTable.init(allocator),
+        .partial_inst_table = DumpAir.InstTable.init(allocator),
+        .const_table = DumpAir.InstTable.init(allocator),
     };
     defer ctx.inst_table.deinit();
     defer ctx.partial_inst_table.deinit();
@@ -695,12 +695,12 @@ pub fn dumpFn(old_module: Module, module_fn: *Module.Fn) void {
         .dependency_failure => std.debug.print("(dependency_failure)", .{}),
         .success => {
             const writer = std.io.getStdErr().writer();
-            ctx.dump(module_fn.body, writer) catch @panic("failed to dump TZIR");
+            ctx.dump(module_fn.body, writer) catch @panic("failed to dump AIR");
         },
     }
 }
 
-const DumpTzir = struct {
+const DumpAir = struct {
     allocator: *std.mem.Allocator,
     arena: std.heap.ArenaAllocator,
     old_module: *const Module,
@@ -718,7 +718,7 @@ const DumpTzir = struct {
     /// TODO: Improve this code to include a stack of Body and store the instructions
     /// in there. Now we are putting all the instructions in a function local table,
     /// however instructions that are in a Body can be thown away when the Body ends.
-    fn dump(dtz: *DumpTzir, body: Body, writer: std.fs.File.Writer) !void {
+    fn dump(dtz: *DumpAir, body: Body, writer: std.fs.File.Writer) !void {
         // First pass to pre-populate the table so that we can show even invalid references.
         // Must iterate the same order we iterate the second time.
         // We also look for constants and put them in the const_table.
@@ -737,7 +737,7 @@ const DumpTzir = struct {
         return dtz.dumpBody(body, writer);
     }
 
-    fn fetchInstsAndResolveConsts(dtz: *DumpTzir, body: Body) error{OutOfMemory}!void {
+    fn fetchInstsAndResolveConsts(dtz: *DumpAir, body: Body) error{OutOfMemory}!void {
         for (body.instructions) |inst| {
             try dtz.inst_table.put(inst, dtz.next_index);
             dtz.next_index += 1;
@@ -865,7 +865,7 @@ const DumpTzir = struct {
         }
     }
 
-    fn dumpBody(dtz: *DumpTzir, body: Body, writer: std.fs.File.Writer) (std.fs.File.WriteError || error{OutOfMemory})!void {
+    fn dumpBody(dtz: *DumpAir, body: Body, writer: std.fs.File.Writer) (std.fs.File.WriteError || error{OutOfMemory})!void {
         for (body.instructions) |inst| {
             const my_index = dtz.next_partial_index;
             try dtz.partial_inst_table.put(inst, my_index);
@@ -1150,7 +1150,7 @@ const DumpTzir = struct {
         }
     }
 
-    fn writeInst(dtz: *DumpTzir, writer: std.fs.File.Writer, inst: *Inst) !?usize {
+    fn writeInst(dtz: *DumpAir, writer: std.fs.File.Writer, inst: *Inst) !?usize {
         if (dtz.partial_inst_table.get(inst)) |operand_index| {
             try writer.print("%{d}", .{operand_index});
             return null;
@@ -1166,7 +1166,7 @@ const DumpTzir = struct {
         }
     }
 
-    fn findConst(dtz: *DumpTzir, operand: *Inst) !void {
+    fn findConst(dtz: *DumpAir, operand: *Inst) !void {
         if (operand.tag == .constant) {
             try dtz.const_table.put(operand, dtz.next_const_index);
             dtz.next_const_index += 1;

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -859,6 +859,8 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                 .is_non_null_ptr => return self.genIsNonNullPtr(inst.castTag(.is_non_null_ptr).?),
                 .is_null => return self.genIsNull(inst.castTag(.is_null).?),
                 .is_null_ptr => return self.genIsNullPtr(inst.castTag(.is_null_ptr).?),
+                .is_non_err => return self.genIsNonErr(inst.castTag(.is_non_err).?),
+                .is_non_err_ptr => return self.genIsNonErrPtr(inst.castTag(.is_non_err_ptr).?),
                 .is_err => return self.genIsErr(inst.castTag(.is_err).?),
                 .is_err_ptr => return self.genIsErrPtr(inst.castTag(.is_err_ptr).?),
                 .load => return self.genLoad(inst.castTag(.load).?),
@@ -2970,6 +2972,16 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
 
         fn genIsErrPtr(self: *Self, inst: *ir.Inst.UnOp) !MCValue {
             return self.fail(inst.base.src, "TODO load the operand and call genIsErr", .{});
+        }
+
+        fn genIsNonErr(self: *Self, inst: *ir.Inst.UnOp) !MCValue {
+            switch (arch) {
+                else => return self.fail(inst.base.src, "TODO implement is_non_err for {}", .{self.target.cpu.arch}),
+            }
+        }
+
+        fn genIsNonErrPtr(self: *Self, inst: *ir.Inst.UnOp) !MCValue {
+            return self.fail(inst.base.src, "TODO load the operand and call genIsNonErr", .{});
         }
 
         fn genLoop(self: *Self, inst: *ir.Inst.Loop) !MCValue {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -39,7 +39,12 @@ const BlockData = struct {
 };
 
 pub const CValueMap = std.AutoHashMap(*Inst, CValue);
-pub const TypedefMap = std.HashMap(Type, struct { name: []const u8, rendered: []u8 }, Type.HashContext, std.hash_map.default_max_load_percentage);
+pub const TypedefMap = std.HashMap(
+    Type,
+    struct { name: []const u8, rendered: []u8 },
+    Type.HashContext,
+    std.hash_map.default_max_load_percentage,
+);
 
 fn formatTypeAsCIdentifier(
     data: Type,
@@ -151,14 +156,49 @@ pub const Object = struct {
             render_ty = render_ty.elemType();
         }
 
-        try o.dg.renderType(w, render_ty);
+        if (render_ty.zigTypeTag() == .Fn) {
+            const ret_ty = render_ty.fnReturnType();
+            if (ret_ty.zigTypeTag() == .NoReturn) {
+                // noreturn attribute is not allowed here.
+                try w.writeAll("void");
+            } else {
+                try o.dg.renderType(w, ret_ty);
+            }
+            try w.writeAll(" (*");
+            switch (mutability) {
+                .Const => try w.writeAll("const "),
+                .Mut => {},
+            }
+            try o.writeCValue(w, name);
+            try w.writeAll(")(");
+            const param_len = render_ty.fnParamLen();
+            const is_var_args = render_ty.fnIsVarArgs();
+            if (param_len == 0 and !is_var_args)
+                try w.writeAll("void")
+            else {
+                var index: usize = 0;
+                while (index < param_len) : (index += 1) {
+                    if (index > 0) {
+                        try w.writeAll(", ");
+                    }
+                    try o.dg.renderType(w, render_ty.fnParamType(index));
+                }
+            }
+            if (is_var_args) {
+                if (param_len != 0) try w.writeAll(", ");
+                try w.writeAll("...");
+            }
+            try w.writeByte(')');
+        } else {
+            try o.dg.renderType(w, render_ty);
 
-        const const_prefix = switch (mutability) {
-            .Const => "const ",
-            .Mut => "",
-        };
-        try w.print(" {s}", .{const_prefix});
-        try o.writeCValue(w, name);
+            const const_prefix = switch (mutability) {
+                .Const => "const ",
+                .Mut => "",
+            };
+            try w.print(" {s}", .{const_prefix});
+            try o.writeCValue(w, name);
+        }
         try w.writeAll(suffix.items);
     }
 };
@@ -196,35 +236,72 @@ pub const DeclGen = struct {
                     return writer.print("{d}", .{val.toSignedInt()});
                 return writer.print("{d}", .{val.toUnsignedInt()});
             },
-            .Pointer => switch (val.tag()) {
-                .null_value, .zero => try writer.writeAll("NULL"),
-                .one => try writer.writeAll("1"),
-                .decl_ref => {
-                    const decl = val.castTag(.decl_ref).?.data;
+            .Pointer => switch (t.ptrSize()) {
+                .Slice => {
+                    try writer.writeByte('(');
+                    try dg.renderType(writer, t);
+                    try writer.writeAll("){");
+                    var buf: Type.Payload.ElemType = undefined;
+                    try dg.renderValue(writer, t.slicePtrFieldType(&buf), val);
+                    try writer.writeAll(", ");
+                    try writer.print("{d}", .{val.sliceLen()});
+                    try writer.writeAll("}");
+                },
+                else => switch (val.tag()) {
+                    .null_value, .zero => try writer.writeAll("NULL"),
+                    .one => try writer.writeAll("1"),
+                    .decl_ref => {
+                        const decl = val.castTag(.decl_ref).?.data;
 
-                    // Determine if we must pointer cast.
-                    assert(decl.has_tv);
-                    if (t.eql(decl.ty)) {
-                        try writer.print("&{s}", .{decl.name});
-                    } else {
-                        try writer.writeAll("(");
-                        try dg.renderType(writer, t);
-                        try writer.print(")&{s}", .{decl.name});
-                    }
+                        // Determine if we must pointer cast.
+                        assert(decl.has_tv);
+                        if (t.eql(decl.ty)) {
+                            try writer.print("&{s}", .{decl.name});
+                        } else {
+                            try writer.writeAll("(");
+                            try dg.renderType(writer, t);
+                            try writer.print(")&{s}", .{decl.name});
+                        }
+                    },
+                    .function => {
+                        const func = val.castTag(.function).?.data;
+                        try writer.print("{s}", .{func.owner_decl.name});
+                    },
+                    .extern_fn => {
+                        const decl = val.castTag(.extern_fn).?.data;
+                        try writer.print("{s}", .{decl.name});
+                    },
+                    else => switch (t.ptrSize()) {
+                        .Slice => unreachable,
+                        .Many => {
+                            if (val.castTag(.ref_val)) |ref_val_payload| {
+                                const sub_val = ref_val_payload.data;
+                                if (sub_val.castTag(.bytes)) |bytes_payload| {
+                                    const bytes = bytes_payload.data;
+                                    try writer.writeByte('(');
+                                    try dg.renderType(writer, t);
+                                    // TODO: make our own C string escape instead of using std.zig.fmtEscapes
+                                    try writer.print(")\"{}\"", .{std.zig.fmtEscapes(bytes)});
+                                } else {
+                                    unreachable;
+                                }
+                            } else {
+                                unreachable;
+                            }
+                        },
+                        .One => {
+                            var arena = std.heap.ArenaAllocator.init(dg.module.gpa);
+                            defer arena.deinit();
+
+                            const elem_ty = t.elemType();
+                            const elem_val = try val.pointerDeref(&arena.allocator);
+
+                            try writer.writeAll("&");
+                            try dg.renderValue(writer, elem_ty, elem_val);
+                        },
+                        .C => unreachable,
+                    },
                 },
-                .function => {
-                    const func = val.castTag(.function).?.data;
-                    try writer.print("{s}", .{func.owner_decl.name});
-                },
-                .extern_fn => {
-                    const decl = val.castTag(.extern_fn).?.data;
-                    try writer.print("{s}", .{decl.name});
-                },
-                else => |e| return dg.fail(
-                    .{ .node_offset = 0 },
-                    "TODO: C backend: implement Pointer value {s}",
-                    .{@tagName(e)},
-                ),
             },
             .Array => {
                 // First try specific tag representations for more efficiency.
@@ -329,6 +406,32 @@ pub const DeclGen = struct {
                     },
                 }
             },
+            .Fn => switch (val.tag()) {
+                .null_value, .zero => try writer.writeAll("NULL"),
+                .one => try writer.writeAll("1"),
+                .decl_ref => {
+                    const decl = val.castTag(.decl_ref).?.data;
+
+                    // Determine if we must pointer cast.
+                    assert(decl.has_tv);
+                    if (t.eql(decl.ty)) {
+                        try writer.print("&{s}", .{decl.name});
+                    } else {
+                        try writer.writeAll("(");
+                        try dg.renderType(writer, t);
+                        try writer.print(")&{s}", .{decl.name});
+                    }
+                },
+                .function => {
+                    const func = val.castTag(.function).?.data;
+                    try writer.print("{s}", .{func.owner_decl.name});
+                },
+                .extern_fn => {
+                    const decl = val.castTag(.extern_fn).?.data;
+                    try writer.print("{s}", .{decl.name});
+                },
+                else => unreachable,
+            },
             else => |e| return dg.fail(.{ .node_offset = 0 }, "TODO: C backend: implement value {s}", .{
                 @tagName(e),
             }),
@@ -338,6 +441,12 @@ pub const DeclGen = struct {
     fn renderFunctionSignature(dg: *DeclGen, w: anytype, is_global: bool) !void {
         if (!is_global) {
             try w.writeAll("static ");
+        }
+        if (dg.decl.val.castTag(.function)) |func_payload| {
+            const func: *Module.Fn = func_payload.data;
+            if (func.is_cold) {
+                try w.writeAll("ZIG_COLD ");
+            }
         }
         try dg.renderType(w, dg.decl.ty.fnReturnType());
         const decl_name = mem.span(dg.decl.name);
@@ -413,7 +522,35 @@ pub const DeclGen = struct {
 
             .Pointer => {
                 if (t.isSlice()) {
-                    return dg.fail(.{ .node_offset = 0 }, "TODO: C backend: implement slices", .{});
+                    if (dg.typedefs.get(t)) |some| {
+                        return w.writeAll(some.name);
+                    }
+
+                    var buffer = std.ArrayList(u8).init(dg.typedefs.allocator);
+                    defer buffer.deinit();
+                    const bw = buffer.writer();
+
+                    try bw.writeAll("typedef struct { ");
+                    const elem_type = t.elemType();
+                    try dg.renderType(bw, elem_type);
+                    try bw.writeAll(" *");
+                    if (t.isConstPtr()) {
+                        try bw.writeAll("const ");
+                    }
+                    if (t.isVolatilePtr()) {
+                        try bw.writeAll("volatile ");
+                    }
+                    try bw.writeAll("ptr; size_t len; } ");
+                    const name_index = buffer.items.len;
+                    try bw.print("zig_L_{s};\n", .{typeToCIdentifier(elem_type)});
+
+                    const rendered = buffer.toOwnedSlice();
+                    errdefer dg.typedefs.allocator.free(rendered);
+                    const name = rendered[name_index .. rendered.len - 2];
+
+                    try dg.typedefs.ensureUnusedCapacity(1);
+                    try w.writeAll(name);
+                    dg.typedefs.putAssumeCapacityNoClobber(t, .{ .name = name, .rendered = rendered });
                 } else {
                     try dg.renderType(w, t.elemType());
                     try w.writeAll(" *");
@@ -446,13 +583,13 @@ pub const DeclGen = struct {
                 try dg.renderType(bw, child_type);
                 try bw.writeAll(" payload; bool is_null; } ");
                 const name_index = buffer.items.len;
-                try bw.print("zig_opt_{s}_t;\n", .{typeToCIdentifier(child_type)});
+                try bw.print("zig_Q_{s};\n", .{typeToCIdentifier(child_type)});
 
                 const rendered = buffer.toOwnedSlice();
                 errdefer dg.typedefs.allocator.free(rendered);
                 const name = rendered[name_index .. rendered.len - 2];
 
-                try dg.typedefs.ensureCapacity(dg.typedefs.capacity() + 1);
+                try dg.typedefs.ensureUnusedCapacity(1);
                 try w.writeAll(name);
                 dg.typedefs.putAssumeCapacityNoClobber(t, .{ .name = name, .rendered = rendered });
             },
@@ -465,7 +602,7 @@ pub const DeclGen = struct {
                     return w.writeAll(some.name);
                 }
                 const child_type = t.errorUnionChild();
-                const set_type = t.errorUnionSet();
+                const err_set_type = t.errorUnionSet();
 
                 var buffer = std.ArrayList(u8).init(dg.typedefs.allocator);
                 defer buffer.deinit();
@@ -475,13 +612,20 @@ pub const DeclGen = struct {
                 try dg.renderType(bw, child_type);
                 try bw.writeAll(" payload; uint16_t error; } ");
                 const name_index = buffer.items.len;
-                try bw.print("zig_err_union_{s}_{s}_t;\n", .{ typeToCIdentifier(set_type), typeToCIdentifier(child_type) });
+                if (err_set_type.castTag(.error_set_inferred)) |inf_err_set_payload| {
+                    const func = inf_err_set_payload.data;
+                    try bw.print("zig_E_{s};\n", .{func.owner_decl.name});
+                } else {
+                    try bw.print("zig_E_{s}_{s};\n", .{
+                        typeToCIdentifier(err_set_type), typeToCIdentifier(child_type),
+                    });
+                }
 
                 const rendered = buffer.toOwnedSlice();
                 errdefer dg.typedefs.allocator.free(rendered);
                 const name = rendered[name_index .. rendered.len - 2];
 
-                try dg.typedefs.ensureCapacity(dg.typedefs.capacity() + 1);
+                try dg.typedefs.ensureUnusedCapacity(1);
                 try w.writeAll(name);
                 dg.typedefs.putAssumeCapacityNoClobber(t, .{ .name = name, .rendered = rendered });
             },
@@ -514,7 +658,7 @@ pub const DeclGen = struct {
                 errdefer dg.typedefs.allocator.free(rendered);
                 const name = rendered[name_start .. rendered.len - 2];
 
-                try dg.typedefs.ensureCapacity(dg.typedefs.capacity() + 1);
+                try dg.typedefs.ensureUnusedCapacity(1);
                 try w.writeAll(name);
                 dg.typedefs.putAssumeCapacityNoClobber(t, .{ .name = name, .rendered = rendered });
             },
@@ -526,7 +670,28 @@ pub const DeclGen = struct {
                 try dg.renderType(w, int_tag_ty);
             },
             .Union => return dg.fail(.{ .node_offset = 0 }, "TODO: C backend: implement type Union", .{}),
-            .Fn => return dg.fail(.{ .node_offset = 0 }, "TODO: C backend: implement type Fn", .{}),
+            .Fn => {
+                try dg.renderType(w, t.fnReturnType());
+                try w.writeAll(" (*)(");
+                const param_len = t.fnParamLen();
+                const is_var_args = t.fnIsVarArgs();
+                if (param_len == 0 and !is_var_args)
+                    try w.writeAll("void")
+                else {
+                    var index: usize = 0;
+                    while (index < param_len) : (index += 1) {
+                        if (index > 0) {
+                            try w.writeAll(", ");
+                        }
+                        try dg.renderType(w, t.fnParamType(index));
+                    }
+                }
+                if (is_var_args) {
+                    if (param_len != 0) try w.writeAll(", ");
+                    try w.writeAll("...");
+                }
+                try w.writeByte(')');
+            },
             .Opaque => return dg.fail(.{ .node_offset = 0 }, "TODO: C backend: implement type Opaque", .{}),
             .Frame => return dg.fail(.{ .node_offset = 0 }, "TODO: C backend: implement type Frame", .{}),
             .AnyFrame => return dg.fail(.{ .node_offset = 0 }, "TODO: C backend: implement type AnyFrame", .{}),
@@ -569,23 +734,27 @@ pub fn genDecl(o: *Object) !void {
         .val = o.dg.decl.val,
     };
     if (tv.val.castTag(.function)) |func_payload| {
-        const is_global = o.dg.declIsGlobal(tv);
-        const fwd_decl_writer = o.dg.fwd_decl.writer();
-        if (is_global) {
-            try fwd_decl_writer.writeAll("ZIG_EXTERN_C ");
-        }
-        try o.dg.renderFunctionSignature(fwd_decl_writer, is_global);
-        try fwd_decl_writer.writeAll(";\n");
-
         const func: *Module.Fn = func_payload.data;
-        try o.indent_writer.insertNewline();
-        try o.dg.renderFunctionSignature(o.writer(), is_global);
+        if (func.owner_decl == o.dg.decl) {
+            const is_global = o.dg.declIsGlobal(tv);
+            const fwd_decl_writer = o.dg.fwd_decl.writer();
+            if (is_global) {
+                try fwd_decl_writer.writeAll("ZIG_EXTERN_C ");
+            }
+            try o.dg.renderFunctionSignature(fwd_decl_writer, is_global);
+            try fwd_decl_writer.writeAll(";\n");
 
-        try o.writer().writeByte(' ');
-        try genBody(o, func.body);
+            try o.indent_writer.insertNewline();
+            try o.dg.renderFunctionSignature(o.writer(), is_global);
 
-        try o.indent_writer.insertNewline();
-    } else if (tv.val.tag() == .extern_fn) {
+            try o.writer().writeByte(' ');
+            try genBody(o, func.body);
+
+            try o.indent_writer.insertNewline();
+            return;
+        }
+    }
+    if (tv.val.tag() == .extern_fn) {
         const writer = o.writer();
         try writer.writeAll("ZIG_EXTERN_C ");
         try o.dg.renderFunctionSignature(writer, true);
@@ -644,9 +813,9 @@ pub fn genHeader(dg: *DeclGen) error{ AnalysisFail, OutOfMemory }!void {
             const is_global = dg.declIsGlobal(tv);
             if (is_global) {
                 try writer.writeAll("ZIG_EXTERN_C ");
+                try dg.renderFunctionSignature(writer, is_global);
+                try dg.fwd_decl.appendSlice(";\n");
             }
-            try dg.renderFunctionSignature(writer, is_global);
-            try dg.fwd_decl.appendSlice(";\n");
         },
         else => {},
     }

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -12,6 +12,12 @@
 #define zig_threadlocal zig_threadlocal_unavailable
 #endif
 
+#if __GNUC__
+#define ZIG_COLD __attribute__ ((cold))
+#else
+#define ZIG_COLD
+#endif
+
 #if __STDC_VERSION__ >= 199901L
 #define ZIG_RESTRICT restrict
 #elif defined(__GNUC__)

--- a/src/type.zig
+++ b/src/type.zig
@@ -1041,7 +1041,7 @@ pub const Type = extern union {
                     return writer.writeAll(std.mem.spanZ(error_set.owner_decl.name));
                 },
                 .error_set_inferred => {
-                    const func = ty.castTag(.error_set_inferred).?.data;
+                    const func = ty.castTag(.error_set_inferred).?.data.func;
                     return writer.print("(inferred error set of {s})", .{func.owner_decl.name});
                 },
                 .error_set_single => {
@@ -3154,7 +3154,10 @@ pub const Type = extern union {
             pub const base_tag = Tag.error_set_inferred;
 
             base: Payload = Payload{ .tag = base_tag },
-            data: *Module.Fn,
+            data: struct {
+                func: *Module.Fn,
+                map: std.StringHashMapUnmanaged(void),
+            },
         };
 
         pub const Pointer = struct {

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -804,6 +804,26 @@ pub fn addCases(ctx: *TestContext) !void {
         });
     }
 
+    {
+        var case = ctx.exeFromCompiledC("inferred error sets", .{});
+
+        case.addCompareOutput(
+            \\pub export fn main() c_int {
+            \\    if (foo()) |_| {
+            \\        @panic("test fail");
+            \\    } else |err| {
+            \\        if (err != error.ItBroke) {
+            \\            @panic("test fail");
+            \\        }
+            \\    }
+            \\    return 0;
+            \\}
+            \\fn foo() !void {
+            \\    return error.ItBroke;
+            \\}
+        , "");
+    }
+
     ctx.h("simple header", linux_x64,
         \\export fn start() void{}
     ,

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -804,19 +804,6 @@ pub fn addCases(ctx: *TestContext) !void {
         });
     }
 
-    ctx.c("empty start function", linux_x64,
-        \\export fn _start() noreturn {
-        \\    unreachable;
-        \\}
-    ,
-        \\ZIG_EXTERN_C zig_noreturn void _start(void);
-        \\
-        \\zig_noreturn void _start(void) {
-        \\ zig_breakpoint();
-        \\ zig_unreachable();
-        \\}
-        \\
-    );
     ctx.h("simple header", linux_x64,
         \\export fn start() void{}
     ,

--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -587,8 +587,6 @@ pub fn addCases(ctx: *TestContext) !void {
     }
 
     {
-        // TODO implement Type equality comparison of error unions in SEMA
-        // before we can incrementally compile functions with an error union as return type
         var case = ctx.exe("wasm error union part 2", wasi);
 
         case.addCompareOutput(


### PR DESCRIPTION
The main motivating test case is:

```zig
pub fn main() void {
    if (foo()) |_| {
        @panic("test fail");
    } else |err| {
        if (err != error.ItBroke) {
            @panic("test fail");
        }
    }
}
fn foo() !void {
    return error.ItBroke;
}
```

However a prerequisite test case that I am working on first is:

```zig
pub fn main() void {
    @panic("foobar");
}
```

I got it generally working but it's causing some test failures since it increases the requirements on the backend, because we need to emit and call the panic function:

```
[nix-shell:~/dev/zig/build-release]$ ./zig build test-stage2 -Denable-qemu -Denable-llvm  -Dskip-compile-errors
[compiler] (err): TODO implement .debug_info for type '[]const u8'
[compiler] (err): TODO implement .debug_info for type '?*builtin.StackTrace'
[compiler] (err): TODO implement .debug_info for type '[]const u8'
[compiler] (err): TODO implement .debug_info for type '?*builtin.StackTrace'
tests [36/105] linux_arm hello world [1/1] update [3/3] 
Case 'linux_arm hello world': unexpected errors at update_index=0:
================================================================================
./zig-cache/tmp/qjoTvCOvZRHGZFJ5/tmp.zig:25:5: error: TODO codegen more kinds of const pointers
================================================================================
test 'linux_arm hello world' failed: UnexpectedCompileErrors

[compiler] (err): TODO implement .debug_info for type '[]const u8'
[compiler] (err): TODO implement .debug_info for type '?*builtin.StackTrace'
[compiler] (err): TODO implement .debug_info for type '[]const u8'
[compiler] (err): TODO implement .debug_info for type '?*builtin.StackTrace'
tests [37/105] parameters and return values [1/1] update [3/3] 
Case 'parameters and return values': unexpected errors at update_index=0:
================================================================================
/home/andy/dev/zig/lib/std/start.zig:125:5: error: TODO codegen more kinds of const pointers
================================================================================
test 'parameters and return values' failed: UnexpectedCompileErrors

[compiler] (err): TODO implement .debug_info for type '[]const u8'
[compiler] (err): TODO implement .debug_info for type '?*builtin.StackTrace'
[compiler] (err): TODO implement .debug_info for type '[]const u8'
[compiler] (err): TODO implement .debug_info for type '?*builtin.StackTrace'
tests [38/105] non-leaf functions [1/1] update [3/3] 
Case 'non-leaf functions': unexpected errors at update_index=0:
================================================================================
/home/andy/dev/zig/lib/std/start.zig:125:5: error: TODO codegen more kinds of const pointers
================================================================================
test 'non-leaf functions' failed: UnexpectedCompileErrors

[compiler] (err): TODO implement .debug_info for type '[]const u8'
[compiler] (err): TODO implement .debug_info for type '?*builtin.StackTrace'
[compiler] (err): TODO implement .debug_info for type '[]const u8'
[compiler] (err): TODO implement .debug_info for type '?*builtin.StackTrace'
tests [39/105] arithmetic operations [1/5] update [3/3] 
Case 'arithmetic operations': unexpected errors at update_index=0:
================================================================================
/home/andy/dev/zig/lib/std/start.zig:125:5: error: TODO codegen more kinds of const pointers
================================================================================
test 'arithmetic operations' failed: UnexpectedCompileErrors

thread 13111 panic: reached unreachable code/3] 
/home/andy/dev/zig/lib/std/debug.zig:231:14: 0x2553ba8 in std.debug.assert (test)
    if (!ok) unreachable; // assertion failure
             ^
/home/andy/dev/zig/src/codegen.zig:429:23: 0x27d745f in codegen.Function(std.target.Arch.arm).generateSymbol (test)
                assert(branch_stack.items.len == 1);
                      ^
/home/andy/dev/zig/src/codegen.zig:63:61: 0x27ba01a in codegen.generateSymbol (test)
                .arm => return Function(.arm).generateSymbol(bin_file, src_loc, typed_value, code, debug_output),
                                                            ^
```

Once working, this will require adding support for safety panic tests to the stage2 test harness.

See individual commit messages for more info.