### PR TITLE
stage2 type.zig: implement eql of error unions

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -520,9 +520,13 @@ pub const Type = extern union {
                 }
                 return a.tag() == b.tag();
             },
+            .ErrorUnion => {
+                const a_data = a.castTag(.error_union).?.data;
+                const b_data = b.castTag(.error_union).?.data;
+                return a_data.error_set.eql(b_data.error_set) and a_data.payload.eql(b_data.payload);
+            },
             .Opaque,
             .Float,
-            .ErrorUnion,
             .ErrorSet,
             .BoundFn,
             .Frame,


### PR DESCRIPTION
Salvaged from https://github.com/ziglang/zig/pull/7092 , reminded of because https://github.com/ziglang/zig/pull/9325 removed 
![image](https://user-images.githubusercontent.com/58830309/124835961-23724080-df50-11eb-922d-719837cd42f4.png) comment.