### PR TITLE
stage2 type.zig: implement eql of error unions

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -520,9 +520,13 @@ pub const Type = extern union {
                 }
                 return a.tag() == b.tag();
             },
+            .ErrorUnion => {
+                const a_data = a.castTag(.error_union).?.data;
+                const b_data = b.castTag(.error_union).?.data;
+                return a_data.error_set.eql(b_data.error_set) and a_data.payload.eql(b_data.payload);
+            },
             .Opaque,
             .Float,
-            .ErrorUnion,
             .ErrorSet,
             .BoundFn,
             .Frame,

--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -600,5 +600,16 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    return error.Bruh;
             \\}
         , "69\n");
+        case.addCompareOutput(
+            \\pub export fn _start() u32 {
+            \\    var e = foo();
+            \\    const i = e catch 42;
+            \\    return i;
+            \\}
+            \\
+            \\fn foo() anyerror!u32 {
+            \\    return error.Dab;
+            \\}
+        , "42\n");
     }
 }


### PR DESCRIPTION
#9329 got closed when the branch got deleted. Continuation of that with a test. Incremental updates with error unions need eql to compare the types, so this tests it.