### PR TITLE
Add waitid syscall on linux

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -205,10 +205,13 @@ pub const WCONTINUED = 8;
 pub const WNOWAIT = 0x1000000;
 
 // waitid id types
-pub const P_ALL = 0;
-pub const P_PID = 1;
-pub const P_PGID = 2;
-pub const P_PIDFD = 3;
+pub const P = enum(c_uint) {
+    ALL = 0,
+    PID = 1,
+    PGID = 2,
+    PIDFD = 3,
+    _,
+};
 
 pub usingnamespace if (is_mips)
     struct {

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -204,6 +204,12 @@ pub const WEXITED = 4;
 pub const WCONTINUED = 8;
 pub const WNOWAIT = 0x1000000;
 
+// waitid id types
+pub const P_ALL = 0;
+pub const P_PID = 1;
+pub const P_PGID = 2;
+pub const P_PIDFD = 3;
+
 pub usingnamespace if (is_mips)
     struct {
         pub const SA_NOCLDSTOP = 1;

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -710,8 +710,8 @@ pub fn waitpid(pid: pid_t, status: *u32, flags: u32) usize {
     return syscall4(.wait4, @bitCast(usize, @as(isize, pid)), @ptrToInt(status), flags, 0);
 }
 
-pub fn waitid(id_type: i32, id: i32, infop: *siginfo_t, flags: u32) usize {
-    return syscall5(.waitid, @bitCast(usize, @as(isize, id_type)), @bitCast(usize, @as(isize, id)), @ptrToInt(infop), flags, 0);
+pub fn waitid(id_type: P, id: i32, infop: *siginfo_t, flags: u32) usize {
+    return syscall5(.waitid, @enumToInt(id_type), @bitCast(usize, @as(isize, id)), @ptrToInt(infop), flags, 0);
 }
 
 pub fn fcntl(fd: fd_t, cmd: i32, arg: usize) usize {

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -710,6 +710,10 @@ pub fn waitpid(pid: pid_t, status: *u32, flags: u32) usize {
     return syscall4(.wait4, @bitCast(usize, @as(isize, pid)), @ptrToInt(status), flags, 0);
 }
 
+pub fn waitid(id_type: i32, id: i32, infop: *siginfo_t, flags: u32) usize {
+    return syscall5(.waitid, @bitCast(usize, @as(isize, id_type)), @bitCast(usize, @as(isize, id)), @ptrToInt(infop), flags, 0);
+}
+
 pub fn fcntl(fd: fd_t, cmd: i32, arg: usize) usize {
     return syscall3(.fcntl, @bitCast(usize, @as(isize, fd)), @bitCast(usize, @as(isize, cmd)), arg);
 }


### PR DESCRIPTION
Adds `waitid` syscall on linux

- wraps `syscall5(.waitid...`
- provides values for `idtype` parameter

This syscall is particularly useful in conjunction with [`pidfd_open`](https://github.com/ziglang/zig/blob/master/lib/std/os/linux.zig#L1416) (and the `P_PIDFD` `id_type`)  as it allows waiting on a process via its `pidfd` rather than its `pid`.