### PR TITLE
Add log testing

### DIFF
--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -256,7 +256,7 @@ pub fn scoped(comptime scope: @Type(.EnumLiteral)) type {
 /// The default scoped logging namespace.
 pub const default = scoped(.default);
 
-/// This scope is ignored by `std.testing`'s log testing features.
+/// This scope is ignored by `std.testing`'s log testing features. If used inside of a test, it is always printed.
 pub const testing = scoped(.testing);
 
 /// Log an emergency message using the default scope. This log level is

--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -256,6 +256,9 @@ pub fn scoped(comptime scope: @Type(.EnumLiteral)) type {
 /// The default scoped logging namespace.
 pub const default = scoped(.default);
 
+/// This scope is ignored by `std.testing`'s log testing features.
+pub const testing = scoped(.testing);
+
 /// Log an emergency message using the default scope. This log level is
 /// intended to be used for conditions that cannot be handled and is usually
 /// followed by a panic.

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -21,6 +21,65 @@ pub var base_allocator_instance = std.heap.FixedBufferAllocator.init("");
 /// TODO https://github.com/ziglang/zig/issues/5738
 pub var log_level = std.log.Level.warn;
 
+const LogTestSettings = struct {
+    pub const LogCounts = struct {
+        // Add a field here if another settings field is added
+        scope: usize = 0,
+        text: usize = 0,
+        prefix: usize = 0,
+        exact_level: usize = 0,
+        min_level: usize = 0
+    };
+
+    scope: ?[]const u8 = null,
+    text: ?[]const u8 = null,
+    prefix: ?[]const u8 = null,
+    exact_level: ?std.log.Level = null,
+    min_level: ?std.log.Level = null,
+
+    seen: LogCounts = .{},
+
+    /// Given the log message, increment the `seen` counters for each rule the log matches.
+    pub fn countMatches(self: *LogTestSettings, comptime message_level: std.log.Level, comptime scope: @Type(.EnumLiteral), comptime format: []const u8, args: anytype) void {
+        if (self.scope) |test_scope| {
+            if (std.mem.eql(u8, test_scope, @tagName(scope))) {
+                self.seen.scope += 1;
+            }
+        }
+
+        if (self.text) |test_text| {
+            var buf: [format.len * 2]u8 = undefined;
+            const base_output: []const u8 = std.fmt.bufPrint(buf[0..], format, args) catch "";
+            if (std.mem.eql(u8, test_text, base_output)) {
+                self.seen.text += 1;
+            }
+        }
+
+        if (self.prefix) |test_prefix| {
+            var buf: [format.len * 2]u8 = undefined;
+            const base_output: []const u8 = std.fmt.bufPrint(buf[0..], format, args) catch "";
+            if (std.mem.startsWith(u8, base_output, test_prefix)) {
+                self.seen.prefix += 1;
+            }
+        }
+
+        if (self.exact_level) |test_exact_level| {            // break :blk @enumToInt(message_level) == @enumToInt(test_exact_level);
+            if (@enumToInt(message_level) == @enumToInt(test_exact_level)) {
+                self.seen.exact_level += 1;
+            }
+        }
+
+        if (self.min_level) |test_min_level| {
+            if (@enumToInt(message_level) >= @enumToInt(test_min_level)) {
+                self.seen.min_level += 1;
+            }
+        }
+    }
+};
+
+/// This can be set by a user inside a test by calling `std.testing.setupLogTests()`.
+pub var log_test_settings = LogTestSettings{};
+
 /// This is available to any test that wants to execute Zig in a child process.
 /// It will be the same executable that is running `zig test`.
 pub var zig_exe_path: []const u8 = undefined;
@@ -425,6 +484,125 @@ pub fn expectStringEndsWith(actual: []const u8, expected_ends_with: []const u8) 
     print("\n======================================\n", .{});
 
     return error.TestExpectedEndsWith;
+}
+
+/// Define rules for log statements that should be tracked by the test runner.
+/// Each time a log is written during a test, the test runner will check if it should be
+/// counted. At the end of the test, `std.testing.expectLogCounts()` can be used to test
+/// if the expected number of logs were recorded.
+///
+/// The available rules are:
+/// * .scope - Match all logs with the given scope (must set this using `@tagName(.scope)`)
+/// * .exact_level - Match all logs with the given level
+/// * .min_level - Match all logs at *at least* the given level
+/// * .text - Match all logs which print this exact message
+/// * .prefix - Match all logs which print a message that starts with this prefix
+pub fn setupLogTests(log_settings: LogTestSettings) void {
+    log_test_settings = log_settings;
+}
+
+/// Pass the expected number of logs for each rule that was set with `std.testing.setupLogTests()`. 
+pub fn expectLogCounts(counts: LogTestSettings.LogCounts) !void {
+    const count_fields = std.meta.fields(LogTestSettings.LogCounts);
+    inline for (count_fields) |field| {
+        const expected = @field(counts, field.name);
+        const actual = @field(log_test_settings.seen, field.name);
+
+        if (actual != expected) {
+            print("[Log Test] For rule {s}: Expected: {}, Actual: {}\n", .{ field.name, expected, actual });
+            return error.TestExpectedLogs;
+        }
+    }
+}
+
+test "watch logs by scope" {
+    std.testing.setupLogTests(.{ 
+        .scope = @tagName(.a), 
+        .exact_level = .debug, 
+    });
+    
+    const scope_a = std.log.scoped(.a);
+    const scope_b = std.log.scoped(.b);
+
+    scope_a.debug("Count me!", .{});
+    scope_b.debug("Don't count me!", .{});
+    scope_a.debug("Count me!", .{});
+    scope_a.warn("Don't count me!", .{});
+
+
+    try std.testing.expectLogCounts(.{
+        .scope = 3,
+        .exact_level = 3,
+    });
+}
+
+test "watch logs for text" {
+    std.testing.setupLogTests(.{ .text = "Looking for this text\n" });
+
+    const scope_a = std.log.scoped(.a);
+
+    scope_a.debug("Looking for this text\n", .{});
+    scope_a.warn("Looking for {s} text\n", .{"this"});
+    scope_a.debug("Not looking for this text\n", .{});
+
+    try std.testing.expectLogCounts(.{
+        .text = 2
+    });
+}
+
+test "ignore logs scoped by 'testing'" {
+    std.testing.setupLogTests(.{ .exact_level = .debug });
+
+    const scope_a = std.log.scoped(.a);
+
+    scope_a.debug("Should match this\n", .{});
+    std.log.testing.debug("Should not match this\n", .{});
+
+    try std.testing.expectLogCounts(.{
+        .exact_level = 1
+    });
+}
+
+test "0 logs recorded by default" {
+    const scope_a = std.log.scoped(.a);
+    const scope_b = std.log.scoped(.b);
+
+    scope_a.debug("Count me!", .{});
+    scope_b.debug("Don't count me!", .{});
+    scope_a.debug("Count me!", .{});
+    scope_a.warn("Don't count me!", .{});
+
+    scope_a.debug("Looking for this text\n", .{});
+    scope_a.warn("Looking for {s} text\n", .{"this"});
+    scope_a.debug("Not looking for this text\n", .{});
+
+    scope_a.debug("Should match this\n", .{});
+    std.log.testing.debug("Should not match this\n", .{});
+
+    try std.testing.expectLogCounts(.{});
+}
+
+test "multiple checks within one test" {
+    std.testing.setupLogTests(.{ .exact_level = .debug });
+
+    const scope_a = std.log.scoped(.a);
+
+    scope_a.debug("Should match this\n", .{});
+    std.log.testing.debug("Should not match this\n", .{});
+
+    try std.testing.expectLogCounts(.{
+        .exact_level = 1
+    });
+
+    std.testing.setupLogTests(.{ .text = "Looking for this text\n" });
+
+    scope_a.debug("Looking for this text\n", .{});
+    scope_a.warn("Looking for {s} text\n", .{"this"});
+    scope_a.debug("Not looking for this text\n", .{});
+
+    try std.testing.expectLogCounts(.{
+        .text = 2
+    });
 }
 
 fn printIndicatorLine(source: []const u8, indicator_index: usize) void {

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -469,11 +469,10 @@ test "watch logs by scope" {
     const scope_a = std.log.scoped(.a);
     const scope_b = std.log.scoped(.b);
 
-    scope_a.debug("Count me!", .{});
-    scope_b.debug("Don't count me!", .{});
-    scope_a.debug("Count me!", .{});
-    scope_a.warn("Don't count me!", .{});
-
+    scope_a.debug("Count scope and level", .{});
+    scope_b.debug("Count level", .{});
+    scope_a.debug("Count scope and level", .{});
+    scope_a.warn("Count scope", .{});
 
     try std.testing.expectLogCounts(.{
         .scope = 3,
@@ -512,10 +511,10 @@ test "0 logs recorded by default" {
     const scope_a = std.log.scoped(.a);
     const scope_b = std.log.scoped(.b);
 
-    scope_a.debug("Count me!", .{});
-    scope_b.debug("Don't count me!", .{});
-    scope_a.debug("Count me!", .{});
-    scope_a.warn("Don't count me!", .{});
+    scope_a.debug("Count scope and level", .{});
+    scope_b.debug("Count level", .{});
+    scope_a.debug("Count scope and level", .{});
+    scope_a.warn("Count scope", .{});
 
     scope_a.debug("Looking for this text\n", .{});
     scope_a.warn("Looking for {s} text\n", .{"this"});

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -18,66 +18,11 @@ pub var failing_allocator_instance = FailingAllocator.init(&base_allocator_insta
 
 pub var base_allocator_instance = std.heap.FixedBufferAllocator.init("");
 
-/// TODO https://github.com/ziglang/zig/issues/5738
 pub var log_level = std.log.Level.warn;
 
-const LogTestSettings = struct {
-    pub const LogCounts = struct {
-        // Add a field here if another settings field is added
-        scope: usize = 0,
-        text: usize = 0,
-        prefix: usize = 0,
-        exact_level: usize = 0,
-        min_level: usize = 0
-    };
-
-    scope: ?[]const u8 = null,
-    text: ?[]const u8 = null,
-    prefix: ?[]const u8 = null,
-    exact_level: ?std.log.Level = null,
-    min_level: ?std.log.Level = null,
-
-    seen: LogCounts = .{},
-
-    /// Given the log message, increment the `seen` counters for each rule the log matches.
-    pub fn countMatches(self: *LogTestSettings, comptime message_level: std.log.Level, comptime scope: @Type(.EnumLiteral), comptime format: []const u8, args: anytype) void {
-        if (self.scope) |test_scope| {
-            if (std.mem.eql(u8, test_scope, @tagName(scope))) {
-                self.seen.scope += 1;
-            }
-        }
-
-        if (self.text) |test_text| {
-            var buf: [format.len * 2]u8 = undefined;
-            const base_output: []const u8 = std.fmt.bufPrint(buf[0..], format, args) catch "";
-            if (std.mem.eql(u8, test_text, base_output)) {
-                self.seen.text += 1;
-            }
-        }
-
-        if (self.prefix) |test_prefix| {
-            var buf: [format.len * 2]u8 = undefined;
-            const base_output: []const u8 = std.fmt.bufPrint(buf[0..], format, args) catch "";
-            if (std.mem.startsWith(u8, base_output, test_prefix)) {
-                self.seen.prefix += 1;
-            }
-        }
-
-        if (self.exact_level) |test_exact_level| {            // break :blk @enumToInt(message_level) == @enumToInt(test_exact_level);
-            if (@enumToInt(message_level) == @enumToInt(test_exact_level)) {
-                self.seen.exact_level += 1;
-            }
-        }
-
-        if (self.min_level) |test_min_level| {
-            if (@enumToInt(message_level) >= @enumToInt(test_min_level)) {
-                self.seen.min_level += 1;
-            }
-        }
-    }
-};
-
 /// This can be set by a user inside a test by calling `std.testing.setupLogTests()`.
+/// This will be used in `test_runner.zig` to test logs & track how many matching logs have been seen
+/// during a test.
 pub var log_test_settings = LogTestSettings{};
 
 /// This is available to any test that wants to execute Zig in a child process.
@@ -651,3 +596,63 @@ pub fn refAllDecls(comptime T: type) void {
         _ = decl;
     }
 }
+
+const LogTestSettings = struct {
+    pub const LogCounts = struct {
+        // Add a field here if another settings field is added
+        scope: usize = 0,
+        text: usize = 0,
+        prefix: usize = 0,
+        exact_level: usize = 0,
+        min_level: usize = 0
+    };
+
+    scope: ?[]const u8 = null,
+    text: ?[]const u8 = null,
+    prefix: ?[]const u8 = null,
+    exact_level: ?std.log.Level = null,
+    min_level: ?std.log.Level = null,
+
+    seen: LogCounts = .{},
+
+    /// Given the log message, increment the `seen` counters for each rule the log matches.
+    pub fn countMatches(self: *LogTestSettings, comptime message_level: std.log.Level, comptime scope: @Type(.EnumLiteral), comptime format: []const u8, args: anytype) void {
+        if (self.scope) |test_scope| {
+            if (std.mem.eql(u8, test_scope, @tagName(scope))) {
+                self.seen.scope += 1;
+            }
+        }
+
+        if (self.text) |test_text| {
+            var buf: [format.len * 2]u8 = undefined;
+            // If there's an error formatting the message, skip checking it
+            if (std.fmt.bufPrint(buf[0..], format, args)) |base_output| {
+                if (std.mem.eql(u8, test_text, base_output)) {
+                    self.seen.text += 1;
+                }
+            } else |_| {}
+        }
+
+        if (self.prefix) |test_prefix| {
+            var buf: [format.len * 2]u8 = undefined;
+            // If there's an error formatting the message, skip checking it
+            if (std.fmt.bufPrint(buf[0..], format, args)) |base_output| {
+                if (std.mem.startsWith(u8, base_output, test_prefix)) {
+                    self.seen.prefix += 1;
+                }
+            } else |_| {}
+        }
+
+        if (self.exact_level) |test_exact_level| {            // break :blk @enumToInt(message_level) == @enumToInt(test_exact_level);
+            if (@enumToInt(message_level) == @enumToInt(test_exact_level)) {
+                self.seen.exact_level += 1;
+            }
+        }
+
+        if (self.min_level) |test_min_level| {
+            if (@enumToInt(message_level) >= @enumToInt(test_min_level)) {
+                self.seen.min_level += 1;
+            }
+        }
+    }
+};


### PR DESCRIPTION
This is intended to close #5738

This PR introduces a way to test what kinds of logs are printed during the execution of some code. Specifically, it adds the following features:

1. `std.testing.LogTestSettings` - A struct that defines some optional rules for what logs are counted. It also holds the counts themselves.
2. `std.testing.setupLogTests` and `std.testing.expectLogCounts` - The two functions required for doing log tests. `setupLogTests` should be called at the beginning of a test to define the rules that are going to be used to count logs as they happen. `expectLogCounts` should be called at the end with the number of logs that were expected to be seen per rule set.
3. `std.log.testing` - A preset logging scope to use inside tests. Logs with the `.testing` scope:
    a. Don't count towards any log tests
    b. Are always printed if triggered during a test, regardless of the log level

The reason why I structured the log tests this way is to make it easier to test large numbers of logs. By defining the rules at the beginning we can just count each log (or not) as it happens. The other solution would be to allow the test writer to put arbitrary expects at the end of the test, but that would require storing all the logs in a list and then searching them for each expectation. While this method is a bit more limiting and requires more structure, I think it's a better way to measure large number of logs.

Here's an example of this being used in a test:

```zig
test "watch logs by scope" {
    std.testing.setupLogTests(.{ 
        .scope = @tagName(.a), // count logs with the scope name '.a'
        .exact_level = .debug, // count logs with log_level '.debug'
    });

    const scope_a = std.log.scoped(.a);
    const scope_b = std.log.scoped(.b);

    scope_a.debug("Count scope and level", .{});
    scope_b.debug("Count level", .{});
    scope_a.debug("Count scope and level", .{});
    scope_a.warn("Count scope", .{});

    try std.testing.expectLogCounts(.{
        .scope = 3,
        .exact_level = 3,
    });
}

```