### PR TITLE
Rename IrInstSrc to Stage1ZirInst and IrInstGen to Stage1AirInst

### DIFF
--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -31,14 +31,14 @@ struct BuiltinFnEntry;
 struct TypeStructField;
 struct CodeGen;
 struct ZigValue;
-struct IrInstSrc;
-struct IrInstGen;
-struct IrInstGenCast;
-struct IrInstGenAlloca;
-struct IrInstGenCall;
-struct IrInstGenAwait;
+struct Stage1ZirInst;
+struct Stage1AirInst;
+struct Stage1AirInstCast;
+struct Stage1AirInstAlloca;
+struct Stage1AirInstCall;
+struct Stage1AirInstAwait;
 struct Stage1ZirBasicBlock;
-struct IrBasicBlockGen;
+struct Stage1AirBasicBlock;
 struct ScopeDecls;
 struct ZigWindowsSDK;
 struct Tld;
@@ -122,7 +122,7 @@ struct Stage1Zir {
 };
 
 struct Stage1Air {
-    ZigList<IrBasicBlockGen *> basic_block_list;
+    ZigList<Stage1AirBasicBlock *> basic_block_list;
     Buf *name;
     ZigFn *name_fn;
     size_t mem_slot_count;
@@ -311,7 +311,7 @@ struct ConstErrValue {
 
 struct ConstBoundFnValue {
     ZigFn *fn;
-    IrInstGen *first_arg;
+    Stage1AirInst *first_arg;
     AstNode *first_arg_src;
 };
 
@@ -400,14 +400,14 @@ struct LazyValueAlignOf {
     LazyValue base;
 
     IrAnalyze *ira;
-    IrInstGen *target_type;
+    Stage1AirInst *target_type;
 };
 
 struct LazyValueSizeOf {
     LazyValue base;
 
     IrAnalyze *ira;
-    IrInstGen *target_type;
+    Stage1AirInst *target_type;
 
     bool bit_size;
 };
@@ -416,9 +416,9 @@ struct LazyValueSliceType {
     LazyValue base;
 
     IrAnalyze *ira;
-    IrInstGen *sentinel; // can be null
-    IrInstGen *elem_type;
-    IrInstGen *align_inst; // can be null
+    Stage1AirInst *sentinel; // can be null
+    Stage1AirInst *elem_type;
+    Stage1AirInst *align_inst; // can be null
 
     bool is_const;
     bool is_volatile;
@@ -429,8 +429,8 @@ struct LazyValueArrayType {
     LazyValue base;
 
     IrAnalyze *ira;
-    IrInstGen *sentinel; // can be null
-    IrInstGen *elem_type;
+    Stage1AirInst *sentinel; // can be null
+    Stage1AirInst *elem_type;
     uint64_t length;
 };
 
@@ -438,9 +438,9 @@ struct LazyValuePtrType {
     LazyValue base;
 
     IrAnalyze *ira;
-    IrInstGen *sentinel; // can be null
-    IrInstGen *elem_type;
-    IrInstGen *align_inst; // can be null
+    Stage1AirInst *sentinel; // can be null
+    Stage1AirInst *elem_type;
+    Stage1AirInst *align_inst; // can be null
 
     PtrLen ptr_len;
     uint32_t bit_offset_in_host;
@@ -455,14 +455,14 @@ struct LazyValuePtrTypeSimple {
     LazyValue base;
 
     IrAnalyze *ira;
-    IrInstGen *elem_type;
+    Stage1AirInst *elem_type;
 };
 
 struct LazyValueOptType {
     LazyValue base;
 
     IrAnalyze *ira;
-    IrInstGen *payload_type;
+    Stage1AirInst *payload_type;
 };
 
 struct LazyValueFnType {
@@ -470,9 +470,9 @@ struct LazyValueFnType {
 
     IrAnalyze *ira;
     AstNode *proto_node;
-    IrInstGen **param_types;
-    IrInstGen *align_inst; // can be null
-    IrInstGen *return_type;
+    Stage1AirInst **param_types;
+    Stage1AirInst *align_inst; // can be null
+    Stage1AirInst *return_type;
 
     CallingConvention cc;
     bool is_generic;
@@ -482,8 +482,8 @@ struct LazyValueErrUnionType {
     LazyValue base;
 
     IrAnalyze *ira;
-    IrInstGen *err_set_type;
-    IrInstGen *payload_type;
+    Stage1AirInst *err_set_type;
+    Stage1AirInst *payload_type;
     Buf *type_name;
 };
 
@@ -1651,13 +1651,13 @@ struct ZigFn {
     size_t branch_quota;
     AstNode **param_source_nodes;
     Buf **param_names;
-    IrInstGen *err_code_spill;
+    Stage1AirInst *err_code_spill;
     AstNode *assumed_non_async;
 
     AstNode *fn_no_inline_set_node;
     AstNode *fn_static_eval_set_node;
 
-    ZigList<IrInstGenAlloca *> alloca_gen_list;
+    ZigList<Stage1AirInstAlloca *> alloca_gen_list;
     ZigList<ZigVar *> variable_list;
 
     Buf *section_name;
@@ -1669,8 +1669,8 @@ struct ZigFn {
     AstNode *non_async_node;
 
     ZigList<GlobalExport> export_list;
-    ZigList<IrInstGenCall *> call_list;
-    ZigList<IrInstGenAwait *> await_list;
+    ZigList<Stage1AirInstCall *> call_list;
+    ZigList<Stage1AirInstAwait *> await_list;
 
     LLVMValueRef valgrind_client_request_array;
 
@@ -2096,9 +2096,9 @@ struct CodeGen {
     Buf *builtin_zig_path;
     Buf *zig_std_special_dir; // Cannot be overridden; derived from zig_lib_dir.
 
-    IrInstSrc *invalid_inst_src;
-    IrInstGen *invalid_inst_gen;
-    IrInstGen *unreach_instruction;
+    Stage1ZirInst *invalid_inst_src;
+    Stage1AirInst *invalid_inst_gen;
+    Stage1AirInst *unreach_instruction;
 
     ZigValue panic_msg_vals[PanicMsgIdCount];
 
@@ -2165,8 +2165,8 @@ struct ZigVar {
     ZigValue *const_value;
     ZigType *var_type;
     LLVMValueRef value_ref;
-    IrInstSrc *is_comptime;
-    IrInstGen *ptr_instruction;
+    Stage1ZirInst *is_comptime;
+    Stage1AirInst *ptr_instruction;
     // which node is the declaration of the variable
     AstNode *decl_node;
     ZigLLVMDILocalVariable *di_loc_var;
@@ -2268,9 +2268,9 @@ struct ScopeBlock {
 
     Buf *name;
     Stage1ZirBasicBlock *end_block;
-    IrInstSrc *is_comptime;
+    Stage1ZirInst *is_comptime;
     ResultLocPeerParent *peer_parent;
-    ZigList<IrInstSrc *> *incoming_values;
+    ZigList<Stage1ZirInst *> *incoming_values;
     ZigList<Stage1ZirBasicBlock *> *incoming_blocks;
 
     AstNode *safety_set_node;
@@ -2325,8 +2325,8 @@ struct ScopeLoop {
     Buf *name;
     Stage1ZirBasicBlock *break_block;
     Stage1ZirBasicBlock *continue_block;
-    IrInstSrc *is_comptime;
-    ZigList<IrInstSrc *> *incoming_values;
+    Stage1ZirInst *is_comptime;
+    ZigList<Stage1ZirInst *> *incoming_values;
     ZigList<Stage1ZirBasicBlock *> *incoming_blocks;
     ResultLocPeerParent *peer_parent;
     ScopeExpr *spill_scope;
@@ -2340,7 +2340,7 @@ struct ScopeLoop {
 struct ScopeRuntime {
     Scope base;
 
-    IrInstSrc *is_comptime;
+    Stage1ZirInst *is_comptime;
 };
 
 // This scope is created for a suspend block in order to have labeled
@@ -2439,11 +2439,11 @@ enum AtomicRmwOp {
 // Phi instructions must be first in a basic block.
 // The last instruction in a basic block must be of type unreachable.
 struct Stage1ZirBasicBlock {
-    ZigList<IrInstSrc *> instruction_list;
-    IrBasicBlockGen *child;
+    ZigList<Stage1ZirInst *> instruction_list;
+    Stage1AirBasicBlock *child;
     Scope *scope;
     const char *name_hint;
-    IrInstSrc *suspend_instruction_ref;
+    Stage1ZirInst *suspend_instruction_ref;
 
     uint32_t ref_count;
     uint32_t index; // index into the basic block list
@@ -2453,8 +2453,8 @@ struct Stage1ZirBasicBlock {
     bool in_resume_stack;
 };
 
-struct IrBasicBlockGen {
-    ZigList<IrInstGen *> instruction_list;
+struct Stage1AirBasicBlock {
+    ZigList<Stage1AirInst *> instruction_list;
     Scope *scope;
     const char *name_hint;
     LLVMBasicBlockRef llvm_block;
@@ -2462,7 +2462,7 @@ struct IrBasicBlockGen {
     // The instruction that referenced this basic block and caused us to
     // analyze the basic block. If the same instruction wants us to emit
     // the same basic block, then we re-generate it instead of saving it.
-    IrInstSrc *ref_instruction;
+    Stage1ZirInst *ref_instruction;
     // When this is non-null, a branch to this basic block is only allowed
     // if the branch is comptime. The instruction points to the reason
     // the basic block must be comptime.
@@ -2475,246 +2475,246 @@ struct IrBasicBlockGen {
 // Src instructions are generated by ir_gen_* functions in ir.cpp from AST.
 // ir_analyze_* functions consume Src instructions and produce Gen instructions.
 // Src instructions do not have type information; Gen instructions do.
-enum IrInstSrcId : uint8_t {
-    IrInstSrcIdInvalid,
-    IrInstSrcIdDeclVar,
-    IrInstSrcIdBr,
-    IrInstSrcIdCondBr,
-    IrInstSrcIdSwitchBr,
-    IrInstSrcIdSwitchVar,
-    IrInstSrcIdSwitchElseVar,
-    IrInstSrcIdSwitchTarget,
-    IrInstSrcIdPhi,
-    IrInstSrcIdUnOp,
-    IrInstSrcIdBinOp,
-    IrInstSrcIdMergeErrSets,
-    IrInstSrcIdLoadPtr,
-    IrInstSrcIdStorePtr,
-    IrInstSrcIdFieldPtr,
-    IrInstSrcIdElemPtr,
-    IrInstSrcIdVarPtr,
-    IrInstSrcIdCall,
-    IrInstSrcIdCallArgs,
-    IrInstSrcIdCallExtra,
-    IrInstSrcIdAsyncCallExtra,
-    IrInstSrcIdConst,
-    IrInstSrcIdReturn,
-    IrInstSrcIdContainerInitList,
-    IrInstSrcIdContainerInitFields,
-    IrInstSrcIdUnreachable,
-    IrInstSrcIdTypeOf,
-    IrInstSrcIdSetCold,
-    IrInstSrcIdSetRuntimeSafety,
-    IrInstSrcIdSetFloatMode,
-    IrInstSrcIdArrayType,
-    IrInstSrcIdAnyFrameType,
-    IrInstSrcIdSliceType,
-    IrInstSrcIdAsm,
-    IrInstSrcIdSizeOf,
-    IrInstSrcIdTestNonNull,
-    IrInstSrcIdOptionalUnwrapPtr,
-    IrInstSrcIdClz,
-    IrInstSrcIdCtz,
-    IrInstSrcIdPopCount,
-    IrInstSrcIdBswap,
-    IrInstSrcIdBitReverse,
-    IrInstSrcIdImport,
-    IrInstSrcIdCImport,
-    IrInstSrcIdCInclude,
-    IrInstSrcIdCDefine,
-    IrInstSrcIdCUndef,
-    IrInstSrcIdRef,
-    IrInstSrcIdCompileErr,
-    IrInstSrcIdCompileLog,
-    IrInstSrcIdErrName,
-    IrInstSrcIdEmbedFile,
-    IrInstSrcIdCmpxchg,
-    IrInstSrcIdFence,
-    IrInstSrcIdReduce,
-    IrInstSrcIdTruncate,
-    IrInstSrcIdIntCast,
-    IrInstSrcIdFloatCast,
-    IrInstSrcIdIntToFloat,
-    IrInstSrcIdFloatToInt,
-    IrInstSrcIdBoolToInt,
-    IrInstSrcIdVectorType,
-    IrInstSrcIdShuffleVector,
-    IrInstSrcIdSplat,
-    IrInstSrcIdBoolNot,
-    IrInstSrcIdMemset,
-    IrInstSrcIdMemcpy,
-    IrInstSrcIdSlice,
-    IrInstSrcIdBreakpoint,
-    IrInstSrcIdReturnAddress,
-    IrInstSrcIdFrameAddress,
-    IrInstSrcIdFrameHandle,
-    IrInstSrcIdFrameType,
-    IrInstSrcIdFrameSize,
-    IrInstSrcIdAlignOf,
-    IrInstSrcIdOverflowOp,
-    IrInstSrcIdTestErr,
-    IrInstSrcIdMulAdd,
-    IrInstSrcIdFloatOp,
-    IrInstSrcIdUnwrapErrCode,
-    IrInstSrcIdUnwrapErrPayload,
-    IrInstSrcIdFnProto,
-    IrInstSrcIdTestComptime,
-    IrInstSrcIdPtrCast,
-    IrInstSrcIdBitCast,
-    IrInstSrcIdIntToPtr,
-    IrInstSrcIdPtrToInt,
-    IrInstSrcIdIntToEnum,
-    IrInstSrcIdEnumToInt,
-    IrInstSrcIdIntToErr,
-    IrInstSrcIdErrToInt,
-    IrInstSrcIdCheckSwitchProngsUnderYes,
-    IrInstSrcIdCheckSwitchProngsUnderNo,
-    IrInstSrcIdCheckStatementIsVoid,
-    IrInstSrcIdTypeName,
-    IrInstSrcIdDeclRef,
-    IrInstSrcIdPanic,
-    IrInstSrcIdTagName,
-    IrInstSrcIdFieldParentPtr,
-    IrInstSrcIdOffsetOf,
-    IrInstSrcIdBitOffsetOf,
-    IrInstSrcIdTypeInfo,
-    IrInstSrcIdType,
-    IrInstSrcIdHasField,
-    IrInstSrcIdSetEvalBranchQuota,
-    IrInstSrcIdPtrType,
-    IrInstSrcIdPtrTypeSimple,
-    IrInstSrcIdPtrTypeSimpleConst,
-    IrInstSrcIdAlignCast,
-    IrInstSrcIdImplicitCast,
-    IrInstSrcIdResolveResult,
-    IrInstSrcIdResetResult,
-    IrInstSrcIdSetAlignStack,
-    IrInstSrcIdArgTypeAllowVarFalse,
-    IrInstSrcIdArgTypeAllowVarTrue,
-    IrInstSrcIdExport,
-    IrInstSrcIdExtern,
-    IrInstSrcIdErrorReturnTrace,
-    IrInstSrcIdErrorUnion,
-    IrInstSrcIdAtomicRmw,
-    IrInstSrcIdAtomicLoad,
-    IrInstSrcIdAtomicStore,
-    IrInstSrcIdSaveErrRetAddr,
-    IrInstSrcIdAddImplicitReturnType,
-    IrInstSrcIdErrSetCast,
-    IrInstSrcIdCheckRuntimeScope,
-    IrInstSrcIdHasDecl,
-    IrInstSrcIdUndeclaredIdent,
-    IrInstSrcIdAlloca,
-    IrInstSrcIdEndExpr,
-    IrInstSrcIdUnionInitNamedField,
-    IrInstSrcIdSuspendBegin,
-    IrInstSrcIdSuspendFinish,
-    IrInstSrcIdAwait,
-    IrInstSrcIdResume,
-    IrInstSrcIdSpillBegin,
-    IrInstSrcIdSpillEnd,
-    IrInstSrcIdWasmMemorySize,
-    IrInstSrcIdWasmMemoryGrow,
-    IrInstSrcIdSrc,
+enum Stage1ZirInstId : uint8_t {
+    Stage1ZirInstIdInvalid,
+    Stage1ZirInstIdDeclVar,
+    Stage1ZirInstIdBr,
+    Stage1ZirInstIdCondBr,
+    Stage1ZirInstIdSwitchBr,
+    Stage1ZirInstIdSwitchVar,
+    Stage1ZirInstIdSwitchElseVar,
+    Stage1ZirInstIdSwitchTarget,
+    Stage1ZirInstIdPhi,
+    Stage1ZirInstIdUnOp,
+    Stage1ZirInstIdBinOp,
+    Stage1ZirInstIdMergeErrSets,
+    Stage1ZirInstIdLoadPtr,
+    Stage1ZirInstIdStorePtr,
+    Stage1ZirInstIdFieldPtr,
+    Stage1ZirInstIdElemPtr,
+    Stage1ZirInstIdVarPtr,
+    Stage1ZirInstIdCall,
+    Stage1ZirInstIdCallArgs,
+    Stage1ZirInstIdCallExtra,
+    Stage1ZirInstIdAsyncCallExtra,
+    Stage1ZirInstIdConst,
+    Stage1ZirInstIdReturn,
+    Stage1ZirInstIdContainerInitList,
+    Stage1ZirInstIdContainerInitFields,
+    Stage1ZirInstIdUnreachable,
+    Stage1ZirInstIdTypeOf,
+    Stage1ZirInstIdSetCold,
+    Stage1ZirInstIdSetRuntimeSafety,
+    Stage1ZirInstIdSetFloatMode,
+    Stage1ZirInstIdArrayType,
+    Stage1ZirInstIdAnyFrameType,
+    Stage1ZirInstIdSliceType,
+    Stage1ZirInstIdAsm,
+    Stage1ZirInstIdSizeOf,
+    Stage1ZirInstIdTestNonNull,
+    Stage1ZirInstIdOptionalUnwrapPtr,
+    Stage1ZirInstIdClz,
+    Stage1ZirInstIdCtz,
+    Stage1ZirInstIdPopCount,
+    Stage1ZirInstIdBswap,
+    Stage1ZirInstIdBitReverse,
+    Stage1ZirInstIdImport,
+    Stage1ZirInstIdCImport,
+    Stage1ZirInstIdCInclude,
+    Stage1ZirInstIdCDefine,
+    Stage1ZirInstIdCUndef,
+    Stage1ZirInstIdRef,
+    Stage1ZirInstIdCompileErr,
+    Stage1ZirInstIdCompileLog,
+    Stage1ZirInstIdErrName,
+    Stage1ZirInstIdEmbedFile,
+    Stage1ZirInstIdCmpxchg,
+    Stage1ZirInstIdFence,
+    Stage1ZirInstIdReduce,
+    Stage1ZirInstIdTruncate,
+    Stage1ZirInstIdIntCast,
+    Stage1ZirInstIdFloatCast,
+    Stage1ZirInstIdIntToFloat,
+    Stage1ZirInstIdFloatToInt,
+    Stage1ZirInstIdBoolToInt,
+    Stage1ZirInstIdVectorType,
+    Stage1ZirInstIdShuffleVector,
+    Stage1ZirInstIdSplat,
+    Stage1ZirInstIdBoolNot,
+    Stage1ZirInstIdMemset,
+    Stage1ZirInstIdMemcpy,
+    Stage1ZirInstIdSlice,
+    Stage1ZirInstIdBreakpoint,
+    Stage1ZirInstIdReturnAddress,
+    Stage1ZirInstIdFrameAddress,
+    Stage1ZirInstIdFrameHandle,
+    Stage1ZirInstIdFrameType,
+    Stage1ZirInstIdFrameSize,
+    Stage1ZirInstIdAlignOf,
+    Stage1ZirInstIdOverflowOp,
+    Stage1ZirInstIdTestErr,
+    Stage1ZirInstIdMulAdd,
+    Stage1ZirInstIdFloatOp,
+    Stage1ZirInstIdUnwrapErrCode,
+    Stage1ZirInstIdUnwrapErrPayload,
+    Stage1ZirInstIdFnProto,
+    Stage1ZirInstIdTestComptime,
+    Stage1ZirInstIdPtrCast,
+    Stage1ZirInstIdBitCast,
+    Stage1ZirInstIdIntToPtr,
+    Stage1ZirInstIdPtrToInt,
+    Stage1ZirInstIdIntToEnum,
+    Stage1ZirInstIdEnumToInt,
+    Stage1ZirInstIdIntToErr,
+    Stage1ZirInstIdErrToInt,
+    Stage1ZirInstIdCheckSwitchProngsUnderYes,
+    Stage1ZirInstIdCheckSwitchProngsUnderNo,
+    Stage1ZirInstIdCheckStatementIsVoid,
+    Stage1ZirInstIdTypeName,
+    Stage1ZirInstIdDeclRef,
+    Stage1ZirInstIdPanic,
+    Stage1ZirInstIdTagName,
+    Stage1ZirInstIdFieldParentPtr,
+    Stage1ZirInstIdOffsetOf,
+    Stage1ZirInstIdBitOffsetOf,
+    Stage1ZirInstIdTypeInfo,
+    Stage1ZirInstIdType,
+    Stage1ZirInstIdHasField,
+    Stage1ZirInstIdSetEvalBranchQuota,
+    Stage1ZirInstIdPtrType,
+    Stage1ZirInstIdPtrTypeSimple,
+    Stage1ZirInstIdPtrTypeSimpleConst,
+    Stage1ZirInstIdAlignCast,
+    Stage1ZirInstIdImplicitCast,
+    Stage1ZirInstIdResolveResult,
+    Stage1ZirInstIdResetResult,
+    Stage1ZirInstIdSetAlignStack,
+    Stage1ZirInstIdArgTypeAllowVarFalse,
+    Stage1ZirInstIdArgTypeAllowVarTrue,
+    Stage1ZirInstIdExport,
+    Stage1ZirInstIdExtern,
+    Stage1ZirInstIdErrorReturnTrace,
+    Stage1ZirInstIdErrorUnion,
+    Stage1ZirInstIdAtomicRmw,
+    Stage1ZirInstIdAtomicLoad,
+    Stage1ZirInstIdAtomicStore,
+    Stage1ZirInstIdSaveErrRetAddr,
+    Stage1ZirInstIdAddImplicitReturnType,
+    Stage1ZirInstIdErrSetCast,
+    Stage1ZirInstIdCheckRuntimeScope,
+    Stage1ZirInstIdHasDecl,
+    Stage1ZirInstIdUndeclaredIdent,
+    Stage1ZirInstIdAlloca,
+    Stage1ZirInstIdEndExpr,
+    Stage1ZirInstIdUnionInitNamedField,
+    Stage1ZirInstIdSuspendBegin,
+    Stage1ZirInstIdSuspendFinish,
+    Stage1ZirInstIdAwait,
+    Stage1ZirInstIdResume,
+    Stage1ZirInstIdSpillBegin,
+    Stage1ZirInstIdSpillEnd,
+    Stage1ZirInstIdWasmMemorySize,
+    Stage1ZirInstIdWasmMemoryGrow,
+    Stage1ZirInstIdSrc,
 };
 
 // ir_render_* functions in codegen.cpp consume Gen instructions and produce LLVM IR.
 // Src instructions do not have type information; Gen instructions do.
-enum IrInstGenId : uint8_t {
-    IrInstGenIdInvalid,
-    IrInstGenIdDeclVar,
-    IrInstGenIdBr,
-    IrInstGenIdCondBr,
-    IrInstGenIdSwitchBr,
-    IrInstGenIdPhi,
-    IrInstGenIdBinaryNot,
-    IrInstGenIdNegation,
-    IrInstGenIdBinOp,
-    IrInstGenIdLoadPtr,
-    IrInstGenIdStorePtr,
-    IrInstGenIdVectorStoreElem,
-    IrInstGenIdStructFieldPtr,
-    IrInstGenIdUnionFieldPtr,
-    IrInstGenIdElemPtr,
-    IrInstGenIdVarPtr,
-    IrInstGenIdReturnPtr,
-    IrInstGenIdCall,
-    IrInstGenIdReturn,
-    IrInstGenIdCast,
-    IrInstGenIdUnreachable,
-    IrInstGenIdAsm,
-    IrInstGenIdTestNonNull,
-    IrInstGenIdOptionalUnwrapPtr,
-    IrInstGenIdOptionalWrap,
-    IrInstGenIdUnionTag,
-    IrInstGenIdClz,
-    IrInstGenIdCtz,
-    IrInstGenIdPopCount,
-    IrInstGenIdBswap,
-    IrInstGenIdBitReverse,
-    IrInstGenIdRef,
-    IrInstGenIdErrName,
-    IrInstGenIdCmpxchg,
-    IrInstGenIdFence,
-    IrInstGenIdReduce,
-    IrInstGenIdTruncate,
-    IrInstGenIdShuffleVector,
-    IrInstGenIdSplat,
-    IrInstGenIdBoolNot,
-    IrInstGenIdMemset,
-    IrInstGenIdMemcpy,
-    IrInstGenIdSlice,
-    IrInstGenIdBreakpoint,
-    IrInstGenIdReturnAddress,
-    IrInstGenIdFrameAddress,
-    IrInstGenIdFrameHandle,
-    IrInstGenIdFrameSize,
-    IrInstGenIdOverflowOp,
-    IrInstGenIdTestErr,
-    IrInstGenIdMulAdd,
-    IrInstGenIdFloatOp,
-    IrInstGenIdUnwrapErrCode,
-    IrInstGenIdUnwrapErrPayload,
-    IrInstGenIdErrWrapCode,
-    IrInstGenIdErrWrapPayload,
-    IrInstGenIdPtrCast,
-    IrInstGenIdBitCast,
-    IrInstGenIdWidenOrShorten,
-    IrInstGenIdIntToPtr,
-    IrInstGenIdPtrToInt,
-    IrInstGenIdIntToEnum,
-    IrInstGenIdIntToErr,
-    IrInstGenIdErrToInt,
-    IrInstGenIdPanic,
-    IrInstGenIdTagName,
-    IrInstGenIdFieldParentPtr,
-    IrInstGenIdAlignCast,
-    IrInstGenIdErrorReturnTrace,
-    IrInstGenIdAtomicRmw,
-    IrInstGenIdAtomicLoad,
-    IrInstGenIdAtomicStore,
-    IrInstGenIdSaveErrRetAddr,
-    IrInstGenIdVectorToArray,
-    IrInstGenIdArrayToVector,
-    IrInstGenIdAssertZero,
-    IrInstGenIdAssertNonNull,
-    IrInstGenIdPtrOfArrayToSlice,
-    IrInstGenIdSuspendBegin,
-    IrInstGenIdSuspendFinish,
-    IrInstGenIdAwait,
-    IrInstGenIdResume,
-    IrInstGenIdSpillBegin,
-    IrInstGenIdSpillEnd,
-    IrInstGenIdVectorExtractElem,
-    IrInstGenIdAlloca,
-    IrInstGenIdConst,
-    IrInstGenIdWasmMemorySize,
-    IrInstGenIdWasmMemoryGrow,
-    IrInstGenIdExtern,
+enum Stage1AirInstId : uint8_t {
+    Stage1AirInstIdInvalid,
+    Stage1AirInstIdDeclVar,
+    Stage1AirInstIdBr,
+    Stage1AirInstIdCondBr,
+    Stage1AirInstIdSwitchBr,
+    Stage1AirInstIdPhi,
+    Stage1AirInstIdBinaryNot,
+    Stage1AirInstIdNegation,
+    Stage1AirInstIdBinOp,
+    Stage1AirInstIdLoadPtr,
+    Stage1AirInstIdStorePtr,
+    Stage1AirInstIdVectorStoreElem,
+    Stage1AirInstIdStructFieldPtr,
+    Stage1AirInstIdUnionFieldPtr,
+    Stage1AirInstIdElemPtr,
+    Stage1AirInstIdVarPtr,
+    Stage1AirInstIdReturnPtr,
+    Stage1AirInstIdCall,
+    Stage1AirInstIdReturn,
+    Stage1AirInstIdCast,
+    Stage1AirInstIdUnreachable,
+    Stage1AirInstIdAsm,
+    Stage1AirInstIdTestNonNull,
+    Stage1AirInstIdOptionalUnwrapPtr,
+    Stage1AirInstIdOptionalWrap,
+    Stage1AirInstIdUnionTag,
+    Stage1AirInstIdClz,
+    Stage1AirInstIdCtz,
+    Stage1AirInstIdPopCount,
+    Stage1AirInstIdBswap,
+    Stage1AirInstIdBitReverse,
+    Stage1AirInstIdRef,
+    Stage1AirInstIdErrName,
+    Stage1AirInstIdCmpxchg,
+    Stage1AirInstIdFence,
+    Stage1AirInstIdReduce,
+    Stage1AirInstIdTruncate,
+    Stage1AirInstIdShuffleVector,
+    Stage1AirInstIdSplat,
+    Stage1AirInstIdBoolNot,
+    Stage1AirInstIdMemset,
+    Stage1AirInstIdMemcpy,
+    Stage1AirInstIdSlice,
+    Stage1AirInstIdBreakpoint,
+    Stage1AirInstIdReturnAddress,
+    Stage1AirInstIdFrameAddress,
+    Stage1AirInstIdFrameHandle,
+    Stage1AirInstIdFrameSize,
+    Stage1AirInstIdOverflowOp,
+    Stage1AirInstIdTestErr,
+    Stage1AirInstIdMulAdd,
+    Stage1AirInstIdFloatOp,
+    Stage1AirInstIdUnwrapErrCode,
+    Stage1AirInstIdUnwrapErrPayload,
+    Stage1AirInstIdErrWrapCode,
+    Stage1AirInstIdErrWrapPayload,
+    Stage1AirInstIdPtrCast,
+    Stage1AirInstIdBitCast,
+    Stage1AirInstIdWidenOrShorten,
+    Stage1AirInstIdIntToPtr,
+    Stage1AirInstIdPtrToInt,
+    Stage1AirInstIdIntToEnum,
+    Stage1AirInstIdIntToErr,
+    Stage1AirInstIdErrToInt,
+    Stage1AirInstIdPanic,
+    Stage1AirInstIdTagName,
+    Stage1AirInstIdFieldParentPtr,
+    Stage1AirInstIdAlignCast,
+    Stage1AirInstIdErrorReturnTrace,
+    Stage1AirInstIdAtomicRmw,
+    Stage1AirInstIdAtomicLoad,
+    Stage1AirInstIdAtomicStore,
+    Stage1AirInstIdSaveErrRetAddr,
+    Stage1AirInstIdVectorToArray,
+    Stage1AirInstIdArrayToVector,
+    Stage1AirInstIdAssertZero,
+    Stage1AirInstIdAssertNonNull,
+    Stage1AirInstIdPtrOfArrayToSlice,
+    Stage1AirInstIdSuspendBegin,
+    Stage1AirInstIdSuspendFinish,
+    Stage1AirInstIdAwait,
+    Stage1AirInstIdResume,
+    Stage1AirInstIdSpillBegin,
+    Stage1AirInstIdSpillEnd,
+    Stage1AirInstIdVectorExtractElem,
+    Stage1AirInstIdAlloca,
+    Stage1AirInstIdConst,
+    Stage1AirInstIdWasmMemorySize,
+    Stage1AirInstIdWasmMemoryGrow,
+    Stage1AirInstIdExtern,
 };
 
-struct IrInstSrc {
-    IrInstSrcId id;
+struct Stage1ZirInst {
+    Stage1ZirInstId id;
     uint16_t ref_count;
     uint32_t debug_id;
 
@@ -2724,7 +2724,7 @@ struct IrInstSrc {
     // When analyzing IR, instructions that point to this instruction in the "old ir"
     // can find the instruction that corresponds to this value in the "new ir"
     // with this child field.
-    IrInstGen *child;
+    Stage1AirInst *child;
     Stage1ZirBasicBlock *owner_bb;
 
     // for debugging purposes, these are useful to call to inspect the instruction
@@ -2732,8 +2732,8 @@ struct IrInstSrc {
     void src();
 };
 
-struct IrInstGen {
-    IrInstGenId id;
+struct Stage1AirInst {
+    Stage1AirInstId id;
     // if ref_count is zero and the instruction has no side effects,
     // the instruction can be omitted in codegen
     uint16_t ref_count;
@@ -2744,130 +2744,130 @@ struct IrInstGen {
 
     LLVMValueRef llvm_value;
     ZigValue *value;
-    IrBasicBlockGen *owner_bb;
+    Stage1AirBasicBlock *owner_bb;
     // Nearly any instruction can have to be stored as a local variable before suspending
     // and then loaded after resuming, in case there is an expression with a suspend point
     // in it, such as: x + await y
-    IrInstGen *spill;
+    Stage1AirInst *spill;
 
     // for debugging purposes, these are useful to call to inspect the instruction
     void dump();
     void src();
 };
 
-struct IrInstSrcDeclVar {
-    IrInstSrc base;
+struct Stage1ZirInstDeclVar {
+    Stage1ZirInst base;
 
     ZigVar *var;
-    IrInstSrc *var_type;
-    IrInstSrc *align_value;
-    IrInstSrc *ptr;
+    Stage1ZirInst *var_type;
+    Stage1ZirInst *align_value;
+    Stage1ZirInst *ptr;
 };
 
-struct IrInstGenDeclVar {
-    IrInstGen base;
+struct Stage1AirInstDeclVar {
+    Stage1AirInst base;
 
     ZigVar *var;
-    IrInstGen *var_ptr;
+    Stage1AirInst *var_ptr;
 };
 
-struct IrInstSrcCondBr {
-    IrInstSrc base;
+struct Stage1ZirInstCondBr {
+    Stage1ZirInst base;
 
-    IrInstSrc *condition;
+    Stage1ZirInst *condition;
     Stage1ZirBasicBlock *then_block;
     Stage1ZirBasicBlock *else_block;
-    IrInstSrc *is_comptime;
+    Stage1ZirInst *is_comptime;
     ResultLoc *result_loc;
 };
 
-struct IrInstGenCondBr {
-    IrInstGen base;
+struct Stage1AirInstCondBr {
+    Stage1AirInst base;
 
-    IrInstGen *condition;
-    IrBasicBlockGen *then_block;
-    IrBasicBlockGen *else_block;
+    Stage1AirInst *condition;
+    Stage1AirBasicBlock *then_block;
+    Stage1AirBasicBlock *else_block;
 };
 
-struct IrInstSrcBr {
-    IrInstSrc base;
+struct Stage1ZirInstBr {
+    Stage1ZirInst base;
 
     Stage1ZirBasicBlock *dest_block;
-    IrInstSrc *is_comptime;
+    Stage1ZirInst *is_comptime;
 };
 
-struct IrInstGenBr {
-    IrInstGen base;
+struct Stage1AirInstBr {
+    Stage1AirInst base;
 
-    IrBasicBlockGen *dest_block;
+    Stage1AirBasicBlock *dest_block;
 };
 
-struct IrInstSrcSwitchBrCase {
-    IrInstSrc *value;
+struct Stage1ZirInstSwitchBrCase {
+    Stage1ZirInst *value;
     Stage1ZirBasicBlock *block;
 };
 
-struct IrInstSrcSwitchBr {
-    IrInstSrc base;
+struct Stage1ZirInstSwitchBr {
+    Stage1ZirInst base;
 
-    IrInstSrc *target_value;
+    Stage1ZirInst *target_value;
     Stage1ZirBasicBlock *else_block;
     size_t case_count;
-    IrInstSrcSwitchBrCase *cases;
-    IrInstSrc *is_comptime;
-    IrInstSrc *switch_prongs_void;
+    Stage1ZirInstSwitchBrCase *cases;
+    Stage1ZirInst *is_comptime;
+    Stage1ZirInst *switch_prongs_void;
 };
 
-struct IrInstGenSwitchBrCase {
-    IrInstGen *value;
-    IrBasicBlockGen *block;
+struct Stage1AirInstSwitchBrCase {
+    Stage1AirInst *value;
+    Stage1AirBasicBlock *block;
 };
 
-struct IrInstGenSwitchBr {
-    IrInstGen base;
+struct Stage1AirInstSwitchBr {
+    Stage1AirInst base;
 
-    IrInstGen *target_value;
-    IrBasicBlockGen *else_block;
+    Stage1AirInst *target_value;
+    Stage1AirBasicBlock *else_block;
     size_t case_count;
-    IrInstGenSwitchBrCase *cases;
+    Stage1AirInstSwitchBrCase *cases;
 };
 
-struct IrInstSrcSwitchVar {
-    IrInstSrc base;
+struct Stage1ZirInstSwitchVar {
+    Stage1ZirInst base;
 
-    IrInstSrc *target_value_ptr;
-    IrInstSrc **prongs_ptr;
+    Stage1ZirInst *target_value_ptr;
+    Stage1ZirInst **prongs_ptr;
     size_t prongs_len;
 };
 
-struct IrInstSrcSwitchElseVar {
-    IrInstSrc base;
+struct Stage1ZirInstSwitchElseVar {
+    Stage1ZirInst base;
 
-    IrInstSrc *target_value_ptr;
-    IrInstSrcSwitchBr *switch_br;
+    Stage1ZirInst *target_value_ptr;
+    Stage1ZirInstSwitchBr *switch_br;
 };
 
-struct IrInstSrcSwitchTarget {
-    IrInstSrc base;
+struct Stage1ZirInstSwitchTarget {
+    Stage1ZirInst base;
 
-    IrInstSrc *target_value_ptr;
+    Stage1ZirInst *target_value_ptr;
 };
 
-struct IrInstSrcPhi {
-    IrInstSrc base;
+struct Stage1ZirInstPhi {
+    Stage1ZirInst base;
 
     size_t incoming_count;
     Stage1ZirBasicBlock **incoming_blocks;
-    IrInstSrc **incoming_values;
+    Stage1ZirInst **incoming_values;
     ResultLocPeerParent *peer_parent;
 };
 
-struct IrInstGenPhi {
-    IrInstGen base;
+struct Stage1AirInstPhi {
+    Stage1AirInst base;
 
     size_t incoming_count;
-    IrBasicBlockGen **incoming_blocks;
-    IrInstGen **incoming_values;
+    Stage1AirBasicBlock **incoming_blocks;
+    Stage1AirInst **incoming_values;
 };
 
 enum IrUnOp {
@@ -2879,23 +2879,23 @@ enum IrUnOp {
     IrUnOpOptional,
 };
 
-struct IrInstSrcUnOp {
-    IrInstSrc base;
+struct Stage1ZirInstUnOp {
+    Stage1ZirInst base;
 
     IrUnOp op_id;
     LVal lval;
-    IrInstSrc *value;
+    Stage1ZirInst *value;
     ResultLoc *result_loc;
 };
 
-struct IrInstGenBinaryNot {
-    IrInstGen base;
-    IrInstGen *operand;
+struct Stage1AirInstBinaryNot {
+    Stage1AirInst base;
+    Stage1AirInst *operand;
 };
 
-struct IrInstGenNegation {
-    IrInstGen base;
-    IrInstGen *operand;
+struct Stage1AirInstNegation {
+    Stage1AirInst base;
+    Stage1AirInst *operand;
     bool wrapping;
 };
 
@@ -2933,122 +2933,122 @@ enum IrBinOp {
     IrBinOpArrayMult,
 };
 
-struct IrInstSrcBinOp {
-    IrInstSrc base;
+struct Stage1ZirInstBinOp {
+    Stage1ZirInst base;
 
-    IrInstSrc *op1;
-    IrInstSrc *op2;
+    Stage1ZirInst *op1;
+    Stage1ZirInst *op2;
     IrBinOp op_id;
     bool safety_check_on;
 };
 
-struct IrInstGenBinOp {
-    IrInstGen base;
+struct Stage1AirInstBinOp {
+    Stage1AirInst base;
 
-    IrInstGen *op1;
-    IrInstGen *op2;
+    Stage1AirInst *op1;
+    Stage1AirInst *op2;
     IrBinOp op_id;
     bool safety_check_on;
 };
 
-struct IrInstSrcMergeErrSets {
-    IrInstSrc base;
+struct Stage1ZirInstMergeErrSets {
+    Stage1ZirInst base;
 
-    IrInstSrc *op1;
-    IrInstSrc *op2;
+    Stage1ZirInst *op1;
+    Stage1ZirInst *op2;
     Buf *type_name;
 };
 
-struct IrInstSrcLoadPtr {
-    IrInstSrc base;
+struct Stage1ZirInstLoadPtr {
+    Stage1ZirInst base;
 
-    IrInstSrc *ptr;
+    Stage1ZirInst *ptr;
 };
 
-struct IrInstGenLoadPtr {
-    IrInstGen base;
+struct Stage1AirInstLoadPtr {
+    Stage1AirInst base;
 
-    IrInstGen *ptr;
-    IrInstGen *result_loc;
+    Stage1AirInst *ptr;
+    Stage1AirInst *result_loc;
 };
 
-struct IrInstSrcStorePtr {
-    IrInstSrc base;
+struct Stage1ZirInstStorePtr {
+    Stage1ZirInst base;
 
-    IrInstSrc *ptr;
-    IrInstSrc *value;
+    Stage1ZirInst *ptr;
+    Stage1ZirInst *value;
 
     bool allow_write_through_const;
 };
 
-struct IrInstGenStorePtr {
-    IrInstGen base;
+struct Stage1AirInstStorePtr {
+    Stage1AirInst base;
 
-    IrInstGen *ptr;
-    IrInstGen *value;
+    Stage1AirInst *ptr;
+    Stage1AirInst *value;
 };
 
-struct IrInstGenVectorStoreElem {
-    IrInstGen base;
+struct Stage1AirInstVectorStoreElem {
+    Stage1AirInst base;
 
-    IrInstGen *vector_ptr;
-    IrInstGen *index;
-    IrInstGen *value;
+    Stage1AirInst *vector_ptr;
+    Stage1AirInst *index;
+    Stage1AirInst *value;
 };
 
-struct IrInstSrcFieldPtr {
-    IrInstSrc base;
+struct Stage1ZirInstFieldPtr {
+    Stage1ZirInst base;
 
-    IrInstSrc *container_ptr;
+    Stage1ZirInst *container_ptr;
     Buf *field_name_buffer;
-    IrInstSrc *field_name_expr;
+    Stage1ZirInst *field_name_expr;
     bool initializing;
 };
 
-struct IrInstGenStructFieldPtr {
-    IrInstGen base;
+struct Stage1AirInstStructFieldPtr {
+    Stage1AirInst base;
 
-    IrInstGen *struct_ptr;
+    Stage1AirInst *struct_ptr;
     TypeStructField *field;
     bool is_const;
 };
 
-struct IrInstGenUnionFieldPtr {
-    IrInstGen base;
+struct Stage1AirInstUnionFieldPtr {
+    Stage1AirInst base;
 
-    IrInstGen *union_ptr;
+    Stage1AirInst *union_ptr;
     TypeUnionField *field;
     bool safety_check_on;
     bool initializing;
 };
 
-struct IrInstSrcElemPtr {
-    IrInstSrc base;
+struct Stage1ZirInstElemPtr {
+    Stage1ZirInst base;
 
-    IrInstSrc *array_ptr;
-    IrInstSrc *elem_index;
+    Stage1ZirInst *array_ptr;
+    Stage1ZirInst *elem_index;
     AstNode *init_array_type_source_node;
     PtrLen ptr_len;
     bool safety_check_on;
 };
 
-struct IrInstGenElemPtr {
-    IrInstGen base;
+struct Stage1AirInstElemPtr {
+    Stage1AirInst base;
 
-    IrInstGen *array_ptr;
-    IrInstGen *elem_index;
+    Stage1AirInst *array_ptr;
+    Stage1AirInst *elem_index;
     bool safety_check_on;
 };
 
-struct IrInstSrcVarPtr {
-    IrInstSrc base;
+struct Stage1ZirInstVarPtr {
+    Stage1ZirInst base;
 
     ZigVar *var;
     ScopeFnDef *crossed_fndef_scope;
 };
 
-struct IrInstGenVarPtr {
-    IrInstGen base;
+struct Stage1AirInstVarPtr {
+    Stage1AirInst base;
 
     ZigVar *var;
 };
@@ -3056,21 +3056,21 @@ struct IrInstGenVarPtr {
 // For functions that have a return type for which handle_is_ptr is true, a
 // result location pointer is the secret first parameter ("sret"). This
 // instruction returns that pointer.
-struct IrInstGenReturnPtr {
-    IrInstGen base;
+struct Stage1AirInstReturnPtr {
+    Stage1AirInst base;
 };
 
-struct IrInstSrcCall {
-    IrInstSrc base;
+struct Stage1ZirInstCall {
+    Stage1ZirInst base;
 
-    IrInstSrc *fn_ref;
+    Stage1ZirInst *fn_ref;
     ZigFn *fn_entry;
     size_t arg_count;
-    IrInstSrc **args;
-    IrInstSrc *ret_ptr;
+    Stage1ZirInst **args;
+    Stage1ZirInst *ret_ptr;
     ResultLoc *result_loc;
 
-    IrInstSrc *new_stack;
+    Stage1ZirInst *new_stack;
 
     CallModifier modifier;
     bool is_async_call_builtin;
@@ -3078,12 +3078,12 @@ struct IrInstSrcCall {
 
 // This is a pass1 instruction, used by @call when the args node is
 // a tuple or struct literal.
-struct IrInstSrcCallArgs {
-    IrInstSrc base;
+struct Stage1ZirInstCallArgs {
+    Stage1ZirInst base;
 
-    IrInstSrc *options;
-    IrInstSrc *fn_ref;
-    IrInstSrc **args_ptr;
+    Stage1ZirInst *options;
+    Stage1ZirInst *fn_ref;
+    Stage1ZirInst **args_ptr;
     size_t args_len;
     ResultLoc *result_loc;
 };
@@ -3091,68 +3091,68 @@ struct IrInstSrcCallArgs {
 // This is a pass1 instruction, used by @call, when the args node
 // is not a literal.
 // `args` is expected to be either a struct or a tuple.
-struct IrInstSrcCallExtra {
-    IrInstSrc base;
+struct Stage1ZirInstCallExtra {
+    Stage1ZirInst base;
 
-    IrInstSrc *options;
-    IrInstSrc *fn_ref;
-    IrInstSrc *args;
+    Stage1ZirInst *options;
+    Stage1ZirInst *fn_ref;
+    Stage1ZirInst *args;
     ResultLoc *result_loc;
 };
 
 // This is a pass1 instruction, used by @asyncCall, when the args node
 // is not a literal.
 // `args` is expected to be either a struct or a tuple.
-struct IrInstSrcAsyncCallExtra {
-    IrInstSrc base;
+struct Stage1ZirInstAsyncCallExtra {
+    Stage1ZirInst base;
 
     CallModifier modifier;
-    IrInstSrc *fn_ref;
-    IrInstSrc *ret_ptr;
-    IrInstSrc *new_stack;
-    IrInstSrc *args;
+    Stage1ZirInst *fn_ref;
+    Stage1ZirInst *ret_ptr;
+    Stage1ZirInst *new_stack;
+    Stage1ZirInst *args;
     ResultLoc *result_loc;
 };
 
-struct IrInstGenCall {
-    IrInstGen base;
+struct Stage1AirInstCall {
+    Stage1AirInst base;
 
-    IrInstGen *fn_ref;
+    Stage1AirInst *fn_ref;
     ZigFn *fn_entry;
     size_t arg_count;
-    IrInstGen **args;
-    IrInstGen *result_loc;
-    IrInstGen *frame_result_loc;
-    IrInstGen *new_stack;
+    Stage1AirInst **args;
+    Stage1AirInst *result_loc;
+    Stage1AirInst *frame_result_loc;
+    Stage1AirInst *new_stack;
 
     CallModifier modifier;
 
     bool is_async_call_builtin;
 };
 
-struct IrInstSrcConst {
-    IrInstSrc base;
+struct Stage1ZirInstConst {
+    Stage1ZirInst base;
 
     ZigValue *value;
 };
 
-struct IrInstGenConst {
-    IrInstGen base;
+struct Stage1AirInstConst {
+    Stage1AirInst base;
 };
 
-struct IrInstSrcReturn {
-    IrInstSrc base;
+struct Stage1ZirInstReturn {
+    Stage1ZirInst base;
 
-    IrInstSrc *operand;
+    Stage1ZirInst *operand;
 };
 
 // When an IrExecutable is not in a function, a return instruction means that
 // the expression returns with that value, even though a return statement from
 // an AST perspective is invalid.
-struct IrInstGenReturn {
-    IrInstGen base;
+struct Stage1AirInstReturn {
+    Stage1AirInst base;
 
-    IrInstGen *operand;
+    Stage1AirInst *operand;
 };
 
 enum CastOp {
@@ -3167,94 +3167,94 @@ enum CastOp {
 };
 
 // TODO get rid of this instruction, replace with instructions for each op code
-struct IrInstGenCast {
-    IrInstGen base;
+struct Stage1AirInstCast {
+    Stage1AirInst base;
 
-    IrInstGen *value;
+    Stage1AirInst *value;
     CastOp cast_op;
 };
 
-struct IrInstSrcContainerInitList {
-    IrInstSrc base;
+struct Stage1ZirInstContainerInitList {
+    Stage1ZirInst base;
 
-    IrInstSrc *elem_type;
+    Stage1ZirInst *elem_type;
     size_t item_count;
-    IrInstSrc **elem_result_loc_list;
-    IrInstSrc *result_loc;
+    Stage1ZirInst **elem_result_loc_list;
+    Stage1ZirInst *result_loc;
     AstNode *init_array_type_source_node;
 };
 
-struct IrInstSrcContainerInitFieldsField {
+struct Stage1ZirInstContainerInitFieldsField {
     Buf *name;
     AstNode *source_node;
-    IrInstSrc *result_loc;
+    Stage1ZirInst *result_loc;
 };
 
-struct IrInstSrcContainerInitFields {
-    IrInstSrc base;
+struct Stage1ZirInstContainerInitFields {
+    Stage1ZirInst base;
 
     size_t field_count;
-    IrInstSrcContainerInitFieldsField *fields;
-    IrInstSrc *result_loc;
+    Stage1ZirInstContainerInitFieldsField *fields;
+    Stage1ZirInst *result_loc;
 };
 
-struct IrInstSrcUnreachable {
-    IrInstSrc base;
+struct Stage1ZirInstUnreachable {
+    Stage1ZirInst base;
 };
 
-struct IrInstGenUnreachable {
-    IrInstGen base;
+struct Stage1AirInstUnreachable {
+    Stage1AirInst base;
 };
 
-struct IrInstSrcTypeOf {
-    IrInstSrc base;
+struct Stage1ZirInstTypeOf {
+    Stage1ZirInst base;
 
     union {
-        IrInstSrc *scalar; // value_count == 1
-        IrInstSrc **list; // value_count > 1
+        Stage1ZirInst *scalar; // value_count == 1
+        Stage1ZirInst **list; // value_count > 1
     } value;
     size_t value_count;
 };
 
-struct IrInstSrcSetCold {
-    IrInstSrc base;
+struct Stage1ZirInstSetCold {
+    Stage1ZirInst base;
 
-    IrInstSrc *is_cold;
+    Stage1ZirInst *is_cold;
 };
 
-struct IrInstSrcSetRuntimeSafety {
-    IrInstSrc base;
+struct Stage1ZirInstSetRuntimeSafety {
+    Stage1ZirInst base;
 
-    IrInstSrc *safety_on;
+    Stage1ZirInst *safety_on;
 };
 
-struct IrInstSrcSetFloatMode {
-    IrInstSrc base;
+struct Stage1ZirInstSetFloatMode {
+    Stage1ZirInst base;
 
-    IrInstSrc *scope_value;
-    IrInstSrc *mode_value;
+    Stage1ZirInst *scope_value;
+    Stage1ZirInst *mode_value;
 };
 
-struct IrInstSrcArrayType {
-    IrInstSrc base;
+struct Stage1ZirInstArrayType {
+    Stage1ZirInst base;
 
-    IrInstSrc *size;
-    IrInstSrc *sentinel;
-    IrInstSrc *child_type;
+    Stage1ZirInst *size;
+    Stage1ZirInst *sentinel;
+    Stage1ZirInst *child_type;
 };
 
-struct IrInstSrcPtrTypeSimple {
-    IrInstSrc base;
+struct Stage1ZirInstPtrTypeSimple {
+    Stage1ZirInst base;
 
-    IrInstSrc *child_type;
+    Stage1ZirInst *child_type;
 };
 
-struct IrInstSrcPtrType {
-    IrInstSrc base;
+struct Stage1ZirInstPtrType {
+    Stage1ZirInst base;
 
-    IrInstSrc *sentinel;
-    IrInstSrc *align_value;
-    IrInstSrc *child_type;
+    Stage1ZirInst *sentinel;
+    Stage1ZirInst *align_value;
+    Stage1ZirInst *child_type;
     uint32_t bit_offset_start;
     uint32_t host_int_bytes;
     PtrLen ptr_len;
@@ -3263,459 +3263,459 @@ struct IrInstSrcPtrType {
     bool is_allow_zero;
 };
 
-struct IrInstSrcAnyFrameType {
-    IrInstSrc base;
+struct Stage1ZirInstAnyFrameType {
+    Stage1ZirInst base;
 
-    IrInstSrc *payload_type;
+    Stage1ZirInst *payload_type;
 };
 
-struct IrInstSrcSliceType {
-    IrInstSrc base;
+struct Stage1ZirInstSliceType {
+    Stage1ZirInst base;
 
-    IrInstSrc *sentinel;
-    IrInstSrc *align_value;
-    IrInstSrc *child_type;
+    Stage1ZirInst *sentinel;
+    Stage1ZirInst *align_value;
+    Stage1ZirInst *child_type;
     bool is_const;
     bool is_volatile;
     bool is_allow_zero;
 };
 
-struct IrInstSrcAsm {
-    IrInstSrc base;
+struct Stage1ZirInstAsm {
+    Stage1ZirInst base;
 
-    IrInstSrc *asm_template;
-    IrInstSrc **input_list;
-    IrInstSrc **output_types;
+    Stage1ZirInst *asm_template;
+    Stage1ZirInst **input_list;
+    Stage1ZirInst **output_types;
     ZigVar **output_vars;
     size_t return_count;
     bool has_side_effects;
     bool is_global;
 };
 
-struct IrInstGenAsm {
-    IrInstGen base;
+struct Stage1AirInstAsm {
+    Stage1AirInst base;
 
     Buf *asm_template;
     AsmToken *token_list;
     size_t token_list_len;
-    IrInstGen **input_list;
-    IrInstGen **output_types;
+    Stage1AirInst **input_list;
+    Stage1AirInst **output_types;
     ZigVar **output_vars;
     size_t return_count;
     bool has_side_effects;
 };
 
-struct IrInstSrcSizeOf {
-    IrInstSrc base;
+struct Stage1ZirInstSizeOf {
+    Stage1ZirInst base;
 
-    IrInstSrc *type_value;
+    Stage1ZirInst *type_value;
     bool bit_size;
 };
 
 // returns true if nonnull, returns false if null
-struct IrInstSrcTestNonNull {
-    IrInstSrc base;
+struct Stage1ZirInstTestNonNull {
+    Stage1ZirInst base;
 
-    IrInstSrc *value;
+    Stage1ZirInst *value;
 };
 
-struct IrInstGenTestNonNull {
-    IrInstGen base;
+struct Stage1AirInstTestNonNull {
+    Stage1AirInst base;
 
-    IrInstGen *value;
+    Stage1AirInst *value;
 };
 
 // Takes a pointer to an optional value, returns a pointer
 // to the payload.
-struct IrInstSrcOptionalUnwrapPtr {
-    IrInstSrc base;
+struct Stage1ZirInstOptionalUnwrapPtr {
+    Stage1ZirInst base;
 
-    IrInstSrc *base_ptr;
+    Stage1ZirInst *base_ptr;
     bool safety_check_on;
 };
 
-struct IrInstGenOptionalUnwrapPtr {
-    IrInstGen base;
+struct Stage1AirInstOptionalUnwrapPtr {
+    Stage1AirInst base;
 
-    IrInstGen *base_ptr;
+    Stage1AirInst *base_ptr;
     bool safety_check_on;
     bool initializing;
 };
 
-struct IrInstSrcCtz {
-    IrInstSrc base;
+struct Stage1ZirInstCtz {
+    Stage1ZirInst base;
 
-    IrInstSrc *type;
-    IrInstSrc *op;
+    Stage1ZirInst *type;
+    Stage1ZirInst *op;
 };
 
-struct IrInstGenCtz {
-    IrInstGen base;
+struct Stage1AirInstCtz {
+    Stage1AirInst base;
 
-    IrInstGen *op;
+    Stage1AirInst *op;
 };
 
-struct IrInstSrcClz {
-    IrInstSrc base;
+struct Stage1ZirInstClz {
+    Stage1ZirInst base;
 
-    IrInstSrc *type;
-    IrInstSrc *op;
+    Stage1ZirInst *type;
+    Stage1ZirInst *op;
 };
 
-struct IrInstGenClz {
-    IrInstGen base;
+struct Stage1AirInstClz {
+    Stage1AirInst base;
 
-    IrInstGen *op;
+    Stage1AirInst *op;
 };
 
-struct IrInstSrcPopCount {
-    IrInstSrc base;
+struct Stage1ZirInstPopCount {
+    Stage1ZirInst base;
 
-    IrInstSrc *type;
-    IrInstSrc *op;
+    Stage1ZirInst *type;
+    Stage1ZirInst *op;
 };
 
-struct IrInstGenPopCount {
-    IrInstGen base;
+struct Stage1AirInstPopCount {
+    Stage1AirInst base;
 
-    IrInstGen *op;
+    Stage1AirInst *op;
 };
 
-struct IrInstGenUnionTag {
-    IrInstGen base;
+struct Stage1AirInstUnionTag {
+    Stage1AirInst base;
 
-    IrInstGen *value;
+    Stage1AirInst *value;
 };
 
-struct IrInstSrcImport {
-    IrInstSrc base;
+struct Stage1ZirInstImport {
+    Stage1ZirInst base;
 
-    IrInstSrc *name;
+    Stage1ZirInst *name;
 };
 
-struct IrInstSrcRef {
-    IrInstSrc base;
+struct Stage1ZirInstRef {
+    Stage1ZirInst base;
 
-    IrInstSrc *value;
+    Stage1ZirInst *value;
 };
 
-struct IrInstGenRef {
-    IrInstGen base;
+struct Stage1AirInstRef {
+    Stage1AirInst base;
 
-    IrInstGen *operand;
-    IrInstGen *result_loc;
+    Stage1AirInst *operand;
+    Stage1AirInst *result_loc;
 };
 
-struct IrInstSrcCompileErr {
-    IrInstSrc base;
+struct Stage1ZirInstCompileErr {
+    Stage1ZirInst base;
 
-    IrInstSrc *msg;
+    Stage1ZirInst *msg;
 };
 
-struct IrInstSrcCompileLog {
-    IrInstSrc base;
+struct Stage1ZirInstCompileLog {
+    Stage1ZirInst base;
 
     size_t msg_count;
-    IrInstSrc **msg_list;
+    Stage1ZirInst **msg_list;
 };
 
-struct IrInstSrcErrName {
-    IrInstSrc base;
+struct Stage1ZirInstErrName {
+    Stage1ZirInst base;
 
-    IrInstSrc *value;
+    Stage1ZirInst *value;
 };
 
-struct IrInstGenErrName {
-    IrInstGen base;
+struct Stage1AirInstErrName {
+    Stage1AirInst base;
 
-    IrInstGen *value;
+    Stage1AirInst *value;
 };
 
-struct IrInstSrcCImport {
-    IrInstSrc base;
+struct Stage1ZirInstCImport {
+    Stage1ZirInst base;
 };
 
-struct IrInstSrcCInclude {
-    IrInstSrc base;
+struct Stage1ZirInstCInclude {
+    Stage1ZirInst base;
 
-    IrInstSrc *name;
+    Stage1ZirInst *name;
 };
 
-struct IrInstSrcCDefine {
-    IrInstSrc base;
+struct Stage1ZirInstCDefine {
+    Stage1ZirInst base;
 
-    IrInstSrc *name;
-    IrInstSrc *value;
+    Stage1ZirInst *name;
+    Stage1ZirInst *value;
 };
 
-struct IrInstSrcCUndef {
-    IrInstSrc base;
+struct Stage1ZirInstCUndef {
+    Stage1ZirInst base;
 
-    IrInstSrc *name;
+    Stage1ZirInst *name;
 };
 
-struct IrInstSrcEmbedFile {
-    IrInstSrc base;
+struct Stage1ZirInstEmbedFile {
+    Stage1ZirInst base;
 
-    IrInstSrc *name;
+    Stage1ZirInst *name;
 };
 
-struct IrInstSrcCmpxchg {
-    IrInstSrc base;
+struct Stage1ZirInstCmpxchg {
+    Stage1ZirInst base;
 
     bool is_weak;
-    IrInstSrc *type_value;
-    IrInstSrc *ptr;
-    IrInstSrc *cmp_value;
-    IrInstSrc *new_value;
-    IrInstSrc *success_order_value;
-    IrInstSrc *failure_order_value;
+    Stage1ZirInst *type_value;
+    Stage1ZirInst *ptr;
+    Stage1ZirInst *cmp_value;
+    Stage1ZirInst *new_value;
+    Stage1ZirInst *success_order_value;
+    Stage1ZirInst *failure_order_value;
     ResultLoc *result_loc;
 };
 
-struct IrInstGenCmpxchg {
-    IrInstGen base;
+struct Stage1AirInstCmpxchg {
+    Stage1AirInst base;
 
     AtomicOrder success_order;
     AtomicOrder failure_order;
-    IrInstGen *ptr;
-    IrInstGen *cmp_value;
-    IrInstGen *new_value;
-    IrInstGen *result_loc;
+    Stage1AirInst *ptr;
+    Stage1AirInst *cmp_value;
+    Stage1AirInst *new_value;
+    Stage1AirInst *result_loc;
     bool is_weak;
 };
 
-struct IrInstSrcFence {
-    IrInstSrc base;
+struct Stage1ZirInstFence {
+    Stage1ZirInst base;
 
-    IrInstSrc *order;
+    Stage1ZirInst *order;
 };
 
-struct IrInstGenFence {
-    IrInstGen base;
+struct Stage1AirInstFence {
+    Stage1AirInst base;
 
     AtomicOrder order;
 };
 
-struct IrInstSrcReduce {
-    IrInstSrc base;
+struct Stage1ZirInstReduce {
+    Stage1ZirInst base;
 
-    IrInstSrc *op;
-    IrInstSrc *value;
+    Stage1ZirInst *op;
+    Stage1ZirInst *value;
 };
 
-struct IrInstGenReduce {
-    IrInstGen base;
+struct Stage1AirInstReduce {
+    Stage1AirInst base;
 
     ReduceOp op;
-    IrInstGen *value;
+    Stage1AirInst *value;
 };
 
-struct IrInstSrcTruncate {
-    IrInstSrc base;
+struct Stage1ZirInstTruncate {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_type;
-    IrInstSrc *target;
+    Stage1ZirInst *dest_type;
+    Stage1ZirInst *target;
 };
 
-struct IrInstGenTruncate {
-    IrInstGen base;
+struct Stage1AirInstTruncate {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstSrcIntCast {
-    IrInstSrc base;
+struct Stage1ZirInstIntCast {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_type;
-    IrInstSrc *target;
+    Stage1ZirInst *dest_type;
+    Stage1ZirInst *target;
 };
 
-struct IrInstSrcFloatCast {
-    IrInstSrc base;
+struct Stage1ZirInstFloatCast {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_type;
-    IrInstSrc *target;
+    Stage1ZirInst *dest_type;
+    Stage1ZirInst *target;
 };
 
-struct IrInstSrcErrSetCast {
-    IrInstSrc base;
+struct Stage1ZirInstErrSetCast {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_type;
-    IrInstSrc *target;
+    Stage1ZirInst *dest_type;
+    Stage1ZirInst *target;
 };
 
-struct IrInstSrcIntToFloat {
-    IrInstSrc base;
+struct Stage1ZirInstIntToFloat {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_type;
-    IrInstSrc *target;
+    Stage1ZirInst *dest_type;
+    Stage1ZirInst *target;
 };
 
-struct IrInstSrcFloatToInt {
-    IrInstSrc base;
+struct Stage1ZirInstFloatToInt {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_type;
-    IrInstSrc *target;
+    Stage1ZirInst *dest_type;
+    Stage1ZirInst *target;
 };
 
-struct IrInstSrcBoolToInt {
-    IrInstSrc base;
+struct Stage1ZirInstBoolToInt {
+    Stage1ZirInst base;
 
-    IrInstSrc *target;
+    Stage1ZirInst *target;
 };
 
-struct IrInstSrcVectorType {
-    IrInstSrc base;
+struct Stage1ZirInstVectorType {
+    Stage1ZirInst base;
 
-    IrInstSrc *len;
-    IrInstSrc *elem_type;
+    Stage1ZirInst *len;
+    Stage1ZirInst *elem_type;
 };
 
-struct IrInstSrcBoolNot {
-    IrInstSrc base;
+struct Stage1ZirInstBoolNot {
+    Stage1ZirInst base;
 
-    IrInstSrc *value;
+    Stage1ZirInst *value;
 };
 
-struct IrInstGenBoolNot {
-    IrInstGen base;
+struct Stage1AirInstBoolNot {
+    Stage1AirInst base;
 
-    IrInstGen *value;
+    Stage1AirInst *value;
 };
 
-struct IrInstSrcMemset {
-    IrInstSrc base;
+struct Stage1ZirInstMemset {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_ptr;
-    IrInstSrc *byte;
-    IrInstSrc *count;
+    Stage1ZirInst *dest_ptr;
+    Stage1ZirInst *byte;
+    Stage1ZirInst *count;
 };
 
-struct IrInstGenMemset {
-    IrInstGen base;
+struct Stage1AirInstMemset {
+    Stage1AirInst base;
 
-    IrInstGen *dest_ptr;
-    IrInstGen *byte;
-    IrInstGen *count;
+    Stage1AirInst *dest_ptr;
+    Stage1AirInst *byte;
+    Stage1AirInst *count;
 };
 
-struct IrInstSrcMemcpy {
-    IrInstSrc base;
+struct Stage1ZirInstMemcpy {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_ptr;
-    IrInstSrc *src_ptr;
-    IrInstSrc *count;
+    Stage1ZirInst *dest_ptr;
+    Stage1ZirInst *src_ptr;
+    Stage1ZirInst *count;
 };
 
-struct IrInstGenMemcpy {
-    IrInstGen base;
+struct Stage1AirInstMemcpy {
+    Stage1AirInst base;
 
-    IrInstGen *dest_ptr;
-    IrInstGen *src_ptr;
-    IrInstGen *count;
+    Stage1AirInst *dest_ptr;
+    Stage1AirInst *src_ptr;
+    Stage1AirInst *count;
 };
 
-struct IrInstSrcWasmMemorySize {
-    IrInstSrc base;
+struct Stage1ZirInstWasmMemorySize {
+    Stage1ZirInst base;
 
-    IrInstSrc *index;
+    Stage1ZirInst *index;
 };
 
-struct IrInstGenWasmMemorySize {
-    IrInstGen base;
+struct Stage1AirInstWasmMemorySize {
+    Stage1AirInst base;
 
-    IrInstGen *index;
+    Stage1AirInst *index;
 };
 
-struct IrInstSrcWasmMemoryGrow {
-    IrInstSrc base;
+struct Stage1ZirInstWasmMemoryGrow {
+    Stage1ZirInst base;
 
-    IrInstSrc *index;
-    IrInstSrc *delta;
+    Stage1ZirInst *index;
+    Stage1ZirInst *delta;
 };
 
-struct IrInstGenWasmMemoryGrow {
-    IrInstGen base;
+struct Stage1AirInstWasmMemoryGrow {
+    Stage1AirInst base;
 
-    IrInstGen *index;
-    IrInstGen *delta;
+    Stage1AirInst *index;
+    Stage1AirInst *delta;
 };
 
-struct IrInstSrcSrc {
-    IrInstSrc base;
+struct Stage1ZirInstSrc {
+    Stage1ZirInst base;
 };
 
-struct IrInstSrcSlice {
-    IrInstSrc base;
+struct Stage1ZirInstSlice {
+    Stage1ZirInst base;
 
-    IrInstSrc *ptr;
-    IrInstSrc *start;
-    IrInstSrc *end;
-    IrInstSrc *sentinel;
+    Stage1ZirInst *ptr;
+    Stage1ZirInst *start;
+    Stage1ZirInst *end;
+    Stage1ZirInst *sentinel;
     ResultLoc *result_loc;
     bool safety_check_on;
 };
 
-struct IrInstGenSlice {
-    IrInstGen base;
+struct Stage1AirInstSlice {
+    Stage1AirInst base;
 
-    IrInstGen *ptr;
-    IrInstGen *start;
-    IrInstGen *end;
-    IrInstGen *result_loc;
+    Stage1AirInst *ptr;
+    Stage1AirInst *start;
+    Stage1AirInst *end;
+    Stage1AirInst *result_loc;
     ZigValue *sentinel;
     bool safety_check_on;
 };
 
-struct IrInstSrcBreakpoint {
-    IrInstSrc base;
+struct Stage1ZirInstBreakpoint {
+    Stage1ZirInst base;
 };
 
-struct IrInstGenBreakpoint {
-    IrInstGen base;
+struct Stage1AirInstBreakpoint {
+    Stage1AirInst base;
 };
 
-struct IrInstSrcReturnAddress {
-    IrInstSrc base;
+struct Stage1ZirInstReturnAddress {
+    Stage1ZirInst base;
 };
 
-struct IrInstGenReturnAddress {
-    IrInstGen base;
+struct Stage1AirInstReturnAddress {
+    Stage1AirInst base;
 };
 
-struct IrInstSrcFrameAddress {
-    IrInstSrc base;
+struct Stage1ZirInstFrameAddress {
+    Stage1ZirInst base;
 };
 
-struct IrInstGenFrameAddress {
-    IrInstGen base;
+struct Stage1AirInstFrameAddress {
+    Stage1AirInst base;
 };
 
-struct IrInstSrcFrameHandle {
-    IrInstSrc base;
+struct Stage1ZirInstFrameHandle {
+    Stage1ZirInst base;
 };
 
-struct IrInstGenFrameHandle {
-    IrInstGen base;
+struct Stage1AirInstFrameHandle {
+    Stage1AirInst base;
 };
 
-struct IrInstSrcFrameType {
-    IrInstSrc base;
+struct Stage1ZirInstFrameType {
+    Stage1ZirInst base;
 
-    IrInstSrc *fn;
+    Stage1ZirInst *fn;
 };
 
-struct IrInstSrcFrameSize {
-    IrInstSrc base;
+struct Stage1ZirInstFrameSize {
+    Stage1ZirInst base;
 
-    IrInstSrc *fn;
+    Stage1ZirInst *fn;
 };
 
-struct IrInstGenFrameSize {
-    IrInstGen base;
+struct Stage1AirInstFrameSize {
+    Stage1AirInst base;
 
-    IrInstGen *fn;
+    Stage1AirInst *fn;
 };
 
 enum IrOverflowOp {
@@ -3725,397 +3725,397 @@ enum IrOverflowOp {
     IrOverflowOpShl,
 };
 
-struct IrInstSrcOverflowOp {
-    IrInstSrc base;
+struct Stage1ZirInstOverflowOp {
+    Stage1ZirInst base;
 
     IrOverflowOp op;
-    IrInstSrc *type_value;
-    IrInstSrc *op1;
-    IrInstSrc *op2;
-    IrInstSrc *result_ptr;
+    Stage1ZirInst *type_value;
+    Stage1ZirInst *op1;
+    Stage1ZirInst *op2;
+    Stage1ZirInst *result_ptr;
 };
 
-struct IrInstGenOverflowOp {
-    IrInstGen base;
+struct Stage1AirInstOverflowOp {
+    Stage1AirInst base;
 
     IrOverflowOp op;
-    IrInstGen *op1;
-    IrInstGen *op2;
-    IrInstGen *result_ptr;
+    Stage1AirInst *op1;
+    Stage1AirInst *op2;
+    Stage1AirInst *result_ptr;
 
     // TODO can this field be removed?
     ZigType *result_ptr_type;
 };
 
-struct IrInstSrcMulAdd {
-    IrInstSrc base;
+struct Stage1ZirInstMulAdd {
+    Stage1ZirInst base;
 
-    IrInstSrc *type_value;
-    IrInstSrc *op1;
-    IrInstSrc *op2;
-    IrInstSrc *op3;
+    Stage1ZirInst *type_value;
+    Stage1ZirInst *op1;
+    Stage1ZirInst *op2;
+    Stage1ZirInst *op3;
 };
 
-struct IrInstGenMulAdd {
-    IrInstGen base;
+struct Stage1AirInstMulAdd {
+    Stage1AirInst base;
 
-    IrInstGen *op1;
-    IrInstGen *op2;
-    IrInstGen *op3;
+    Stage1AirInst *op1;
+    Stage1AirInst *op2;
+    Stage1AirInst *op3;
 };
 
-struct IrInstSrcAlignOf {
-    IrInstSrc base;
+struct Stage1ZirInstAlignOf {
+    Stage1ZirInst base;
 
-    IrInstSrc *type_value;
+    Stage1ZirInst *type_value;
 };
 
 // returns true if error, returns false if not error
-struct IrInstSrcTestErr {
-    IrInstSrc base;
+struct Stage1ZirInstTestErr {
+    Stage1ZirInst base;
 
-    IrInstSrc *base_ptr;
+    Stage1ZirInst *base_ptr;
     bool resolve_err_set;
     bool base_ptr_is_payload;
 };
 
-struct IrInstGenTestErr {
-    IrInstGen base;
+struct Stage1AirInstTestErr {
+    Stage1AirInst base;
 
-    IrInstGen *err_union;
+    Stage1AirInst *err_union;
 };
 
 // Takes an error union pointer, returns a pointer to the error code.
-struct IrInstSrcUnwrapErrCode {
-    IrInstSrc base;
+struct Stage1ZirInstUnwrapErrCode {
+    Stage1ZirInst base;
 
-    IrInstSrc *err_union_ptr;
+    Stage1ZirInst *err_union_ptr;
     bool initializing;
 };
 
-struct IrInstGenUnwrapErrCode {
-    IrInstGen base;
+struct Stage1AirInstUnwrapErrCode {
+    Stage1AirInst base;
 
-    IrInstGen *err_union_ptr;
+    Stage1AirInst *err_union_ptr;
     bool initializing;
 };
 
-struct IrInstSrcUnwrapErrPayload {
-    IrInstSrc base;
+struct Stage1ZirInstUnwrapErrPayload {
+    Stage1ZirInst base;
 
-    IrInstSrc *value;
+    Stage1ZirInst *value;
     bool safety_check_on;
     bool initializing;
 };
 
-struct IrInstGenUnwrapErrPayload {
-    IrInstGen base;
+struct Stage1AirInstUnwrapErrPayload {
+    Stage1AirInst base;
 
-    IrInstGen *value;
+    Stage1AirInst *value;
     bool safety_check_on;
     bool initializing;
 };
 
-struct IrInstGenOptionalWrap {
-    IrInstGen base;
+struct Stage1AirInstOptionalWrap {
+    Stage1AirInst base;
 
-    IrInstGen *operand;
-    IrInstGen *result_loc;
+    Stage1AirInst *operand;
+    Stage1AirInst *result_loc;
 };
 
-struct IrInstGenErrWrapPayload {
-    IrInstGen base;
+struct Stage1AirInstErrWrapPayload {
+    Stage1AirInst base;
 
-    IrInstGen *operand;
-    IrInstGen *result_loc;
+    Stage1AirInst *operand;
+    Stage1AirInst *result_loc;
 };
 
-struct IrInstGenErrWrapCode {
-    IrInstGen base;
+struct Stage1AirInstErrWrapCode {
+    Stage1AirInst base;
 
-    IrInstGen *operand;
-    IrInstGen *result_loc;
+    Stage1AirInst *operand;
+    Stage1AirInst *result_loc;
 };
 
-struct IrInstSrcFnProto {
-    IrInstSrc base;
+struct Stage1ZirInstFnProto {
+    Stage1ZirInst base;
 
-    IrInstSrc **param_types;
-    IrInstSrc *align_value;
-    IrInstSrc *callconv_value;
-    IrInstSrc *return_type;
+    Stage1ZirInst **param_types;
+    Stage1ZirInst *align_value;
+    Stage1ZirInst *callconv_value;
+    Stage1ZirInst *return_type;
     bool is_var_args;
 };
 
 // true if the target value is compile time known, false otherwise
-struct IrInstSrcTestComptime {
-    IrInstSrc base;
+struct Stage1ZirInstTestComptime {
+    Stage1ZirInst base;
 
-    IrInstSrc *value;
+    Stage1ZirInst *value;
 };
 
-struct IrInstSrcPtrCast {
-    IrInstSrc base;
+struct Stage1ZirInstPtrCast {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_type;
-    IrInstSrc *ptr;
+    Stage1ZirInst *dest_type;
+    Stage1ZirInst *ptr;
     bool safety_check_on;
 };
 
-struct IrInstGenPtrCast {
-    IrInstGen base;
+struct Stage1AirInstPtrCast {
+    Stage1AirInst base;
 
-    IrInstGen *ptr;
+    Stage1AirInst *ptr;
     bool safety_check_on;
 };
 
-struct IrInstSrcImplicitCast {
-    IrInstSrc base;
+struct Stage1ZirInstImplicitCast {
+    Stage1ZirInst base;
 
-    IrInstSrc *operand;
+    Stage1ZirInst *operand;
     ResultLocCast *result_loc_cast;
 };
 
-struct IrInstSrcBitCast {
-    IrInstSrc base;
+struct Stage1ZirInstBitCast {
+    Stage1ZirInst base;
 
-    IrInstSrc *operand;
+    Stage1ZirInst *operand;
     ResultLocBitCast *result_loc_bit_cast;
 };
 
-struct IrInstGenBitCast {
-    IrInstGen base;
+struct Stage1AirInstBitCast {
+    Stage1AirInst base;
 
-    IrInstGen *operand;
+    Stage1AirInst *operand;
 };
 
-struct IrInstGenWidenOrShorten {
-    IrInstGen base;
+struct Stage1AirInstWidenOrShorten {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstSrcPtrToInt {
-    IrInstSrc base;
+struct Stage1ZirInstPtrToInt {
+    Stage1ZirInst base;
 
-    IrInstSrc *target;
+    Stage1ZirInst *target;
 };
 
-struct IrInstGenPtrToInt {
-    IrInstGen base;
+struct Stage1AirInstPtrToInt {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstSrcIntToPtr {
-    IrInstSrc base;
+struct Stage1ZirInstIntToPtr {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_type;
-    IrInstSrc *target;
+    Stage1ZirInst *dest_type;
+    Stage1ZirInst *target;
 };
 
-struct IrInstGenIntToPtr {
-    IrInstGen base;
+struct Stage1AirInstIntToPtr {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstSrcIntToEnum {
-    IrInstSrc base;
+struct Stage1ZirInstIntToEnum {
+    Stage1ZirInst base;
 
-    IrInstSrc *dest_type;
-    IrInstSrc *target;
+    Stage1ZirInst *dest_type;
+    Stage1ZirInst *target;
 };
 
-struct IrInstGenIntToEnum {
-    IrInstGen base;
+struct Stage1AirInstIntToEnum {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstSrcEnumToInt {
-    IrInstSrc base;
+struct Stage1ZirInstEnumToInt {
+    Stage1ZirInst base;
 
-    IrInstSrc *target;
+    Stage1ZirInst *target;
 };
 
-struct IrInstSrcIntToErr {
-    IrInstSrc base;
+struct Stage1ZirInstIntToErr {
+    Stage1ZirInst base;
 
-    IrInstSrc *target;
+    Stage1ZirInst *target;
 };
 
-struct IrInstGenIntToErr {
-    IrInstGen base;
+struct Stage1AirInstIntToErr {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstSrcErrToInt {
-    IrInstSrc base;
+struct Stage1ZirInstErrToInt {
+    Stage1ZirInst base;
 
-    IrInstSrc *target;
+    Stage1ZirInst *target;
 };
 
-struct IrInstGenErrToInt {
-    IrInstGen base;
+struct Stage1AirInstErrToInt {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstSrcCheckSwitchProngsRange {
-    IrInstSrc *start;
-    IrInstSrc *end;
+struct Stage1ZirInstCheckSwitchProngsRange {
+    Stage1ZirInst *start;
+    Stage1ZirInst *end;
 };
 
-struct IrInstSrcCheckSwitchProngs {
-    IrInstSrc base;
+struct Stage1ZirInstCheckSwitchProngs {
+    Stage1ZirInst base;
 
-    IrInstSrc *target_value;
-    IrInstSrcCheckSwitchProngsRange *ranges;
+    Stage1ZirInst *target_value;
+    Stage1ZirInstCheckSwitchProngsRange *ranges;
     size_t range_count;
     AstNode* else_prong;
 };
 
-struct IrInstSrcCheckStatementIsVoid {
-    IrInstSrc base;
+struct Stage1ZirInstCheckStatementIsVoid {
+    Stage1ZirInst base;
 
-    IrInstSrc *statement_value;
+    Stage1ZirInst *statement_value;
 };
 
-struct IrInstSrcTypeName {
-    IrInstSrc base;
+struct Stage1ZirInstTypeName {
+    Stage1ZirInst base;
 
-    IrInstSrc *type_value;
+    Stage1ZirInst *type_value;
 };
 
-struct IrInstSrcDeclRef {
-    IrInstSrc base;
+struct Stage1ZirInstDeclRef {
+    Stage1ZirInst base;
 
     LVal lval;
     Tld *tld;
 };
 
-struct IrInstSrcPanic {
-    IrInstSrc base;
+struct Stage1ZirInstPanic {
+    Stage1ZirInst base;
 
-    IrInstSrc *msg;
+    Stage1ZirInst *msg;
 };
 
-struct IrInstGenPanic {
-    IrInstGen base;
+struct Stage1AirInstPanic {
+    Stage1AirInst base;
 
-    IrInstGen *msg;
+    Stage1AirInst *msg;
 };
 
-struct IrInstSrcTagName {
-    IrInstSrc base;
+struct Stage1ZirInstTagName {
+    Stage1ZirInst base;
 
-    IrInstSrc *target;
+    Stage1ZirInst *target;
 };
 
-struct IrInstGenTagName {
-    IrInstGen base;
+struct Stage1AirInstTagName {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstSrcFieldParentPtr {
-    IrInstSrc base;
+struct Stage1ZirInstFieldParentPtr {
+    Stage1ZirInst base;
 
-    IrInstSrc *type_value;
-    IrInstSrc *field_name;
-    IrInstSrc *field_ptr;
+    Stage1ZirInst *type_value;
+    Stage1ZirInst *field_name;
+    Stage1ZirInst *field_ptr;
 };
 
-struct IrInstGenFieldParentPtr {
-    IrInstGen base;
+struct Stage1AirInstFieldParentPtr {
+    Stage1AirInst base;
 
-    IrInstGen *field_ptr;
+    Stage1AirInst *field_ptr;
     TypeStructField *field;
 };
 
-struct IrInstSrcOffsetOf {
-    IrInstSrc base;
+struct Stage1ZirInstOffsetOf {
+    Stage1ZirInst base;
 
-    IrInstSrc *type_value;
-    IrInstSrc *field_name;
+    Stage1ZirInst *type_value;
+    Stage1ZirInst *field_name;
 };
 
-struct IrInstSrcBitOffsetOf {
-    IrInstSrc base;
+struct Stage1ZirInstBitOffsetOf {
+    Stage1ZirInst base;
 
-    IrInstSrc *type_value;
-    IrInstSrc *field_name;
+    Stage1ZirInst *type_value;
+    Stage1ZirInst *field_name;
 };
 
-struct IrInstSrcTypeInfo {
-    IrInstSrc base;
+struct Stage1ZirInstTypeInfo {
+    Stage1ZirInst base;
 
-    IrInstSrc *type_value;
+    Stage1ZirInst *type_value;
 };
 
-struct IrInstSrcType {
-    IrInstSrc base;
+struct Stage1ZirInstType {
+    Stage1ZirInst base;
 
-    IrInstSrc *type_info;
+    Stage1ZirInst *type_info;
 };
 
-struct IrInstSrcHasField {
-    IrInstSrc base;
+struct Stage1ZirInstHasField {
+    Stage1ZirInst base;
 
-    IrInstSrc *container_type;
-    IrInstSrc *field_name;
+    Stage1ZirInst *container_type;
+    Stage1ZirInst *field_name;
 };
 
-struct IrInstSrcSetEvalBranchQuota {
-    IrInstSrc base;
+struct Stage1ZirInstSetEvalBranchQuota {
+    Stage1ZirInst base;
 
-    IrInstSrc *new_quota;
+    Stage1ZirInst *new_quota;
 };
 
-struct IrInstSrcAlignCast {
-    IrInstSrc base;
+struct Stage1ZirInstAlignCast {
+    Stage1ZirInst base;
 
-    IrInstSrc *align_bytes;
-    IrInstSrc *target;
+    Stage1ZirInst *align_bytes;
+    Stage1ZirInst *target;
 };
 
-struct IrInstGenAlignCast {
-    IrInstGen base;
+struct Stage1AirInstAlignCast {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstSrcSetAlignStack {
-    IrInstSrc base;
+struct Stage1ZirInstSetAlignStack {
+    Stage1ZirInst base;
 
-    IrInstSrc *align_bytes;
+    Stage1ZirInst *align_bytes;
 };
 
-struct IrInstSrcArgType {
-    IrInstSrc base;
+struct Stage1ZirInstArgType {
+    Stage1ZirInst base;
 
-    IrInstSrc *fn_type;
-    IrInstSrc *arg_index;
+    Stage1ZirInst *fn_type;
+    Stage1ZirInst *arg_index;
 };
 
-struct IrInstSrcExport {
-    IrInstSrc base;
+struct Stage1ZirInstExport {
+    Stage1ZirInst base;
 
-    IrInstSrc *target;
-    IrInstSrc *options;
+    Stage1ZirInst *target;
+    Stage1ZirInst *options;
 };
 
-struct IrInstSrcExtern {
-    IrInstSrc base;
+struct Stage1ZirInstExtern {
+    Stage1ZirInst base;
 
-    IrInstSrc *type;
-    IrInstSrc *options;
+    Stage1ZirInst *type;
+    Stage1ZirInst *options;
 };
 
-struct IrInstGenExtern {
-    IrInstGen base;
+struct Stage1AirInstExtern {
+    Stage1AirInst base;
 
     Buf *name;
     GlobalLinkageId linkage;
@@ -4127,310 +4127,310 @@ enum IrInstErrorReturnTraceOptional {
     IrInstErrorReturnTraceNonNull,
 };
 
-struct IrInstSrcErrorReturnTrace {
-    IrInstSrc base;
+struct Stage1ZirInstErrorReturnTrace {
+    Stage1ZirInst base;
 
     IrInstErrorReturnTraceOptional optional;
 };
 
-struct IrInstGenErrorReturnTrace {
-    IrInstGen base;
+struct Stage1AirInstErrorReturnTrace {
+    Stage1AirInst base;
 
     IrInstErrorReturnTraceOptional optional;
 };
 
-struct IrInstSrcErrorUnion {
-    IrInstSrc base;
+struct Stage1ZirInstErrorUnion {
+    Stage1ZirInst base;
 
-    IrInstSrc *err_set;
-    IrInstSrc *payload;
+    Stage1ZirInst *err_set;
+    Stage1ZirInst *payload;
     Buf *type_name;
 };
 
-struct IrInstSrcAtomicRmw {
-    IrInstSrc base;
+struct Stage1ZirInstAtomicRmw {
+    Stage1ZirInst base;
 
-    IrInstSrc *operand_type;
-    IrInstSrc *ptr;
-    IrInstSrc *op;
-    IrInstSrc *operand;
-    IrInstSrc *ordering;
+    Stage1ZirInst *operand_type;
+    Stage1ZirInst *ptr;
+    Stage1ZirInst *op;
+    Stage1ZirInst *operand;
+    Stage1ZirInst *ordering;
 };
 
-struct IrInstGenAtomicRmw {
-    IrInstGen base;
+struct Stage1AirInstAtomicRmw {
+    Stage1AirInst base;
 
-    IrInstGen *ptr;
-    IrInstGen *operand;
+    Stage1AirInst *ptr;
+    Stage1AirInst *operand;
     AtomicRmwOp op;
     AtomicOrder ordering;
 };
 
-struct IrInstSrcAtomicLoad {
-    IrInstSrc base;
+struct Stage1ZirInstAtomicLoad {
+    Stage1ZirInst base;
 
-    IrInstSrc *operand_type;
-    IrInstSrc *ptr;
-    IrInstSrc *ordering;
+    Stage1ZirInst *operand_type;
+    Stage1ZirInst *ptr;
+    Stage1ZirInst *ordering;
 };
 
-struct IrInstGenAtomicLoad {
-    IrInstGen base;
+struct Stage1AirInstAtomicLoad {
+    Stage1AirInst base;
 
-    IrInstGen *ptr;
+    Stage1AirInst *ptr;
     AtomicOrder ordering;
 };
 
-struct IrInstSrcAtomicStore {
-    IrInstSrc base;
+struct Stage1ZirInstAtomicStore {
+    Stage1ZirInst base;
 
-    IrInstSrc *operand_type;
-    IrInstSrc *ptr;
-    IrInstSrc *value;
-    IrInstSrc *ordering;
+    Stage1ZirInst *operand_type;
+    Stage1ZirInst *ptr;
+    Stage1ZirInst *value;
+    Stage1ZirInst *ordering;
 };
 
-struct IrInstGenAtomicStore {
-    IrInstGen base;
+struct Stage1AirInstAtomicStore {
+    Stage1AirInst base;
 
-    IrInstGen *ptr;
-    IrInstGen *value;
+    Stage1AirInst *ptr;
+    Stage1AirInst *value;
     AtomicOrder ordering;
 };
 
-struct IrInstSrcSaveErrRetAddr {
-    IrInstSrc base;
+struct Stage1ZirInstSaveErrRetAddr {
+    Stage1ZirInst base;
 };
 
-struct IrInstGenSaveErrRetAddr {
-    IrInstGen base;
+struct Stage1AirInstSaveErrRetAddr {
+    Stage1AirInst base;
 };
 
-struct IrInstSrcAddImplicitReturnType {
-    IrInstSrc base;
+struct Stage1ZirInstAddImplicitReturnType {
+    Stage1ZirInst base;
 
-    IrInstSrc *value;
+    Stage1ZirInst *value;
     ResultLocReturn *result_loc_ret;
 };
 
 // For float ops that take a single argument
-struct IrInstSrcFloatOp {
-    IrInstSrc base;
+struct Stage1ZirInstFloatOp {
+    Stage1ZirInst base;
 
-    IrInstSrc *operand;
+    Stage1ZirInst *operand;
     BuiltinFnId fn_id;
 };
 
-struct IrInstGenFloatOp {
-    IrInstGen base;
+struct Stage1AirInstFloatOp {
+    Stage1AirInst base;
 
-    IrInstGen *operand;
+    Stage1AirInst *operand;
     BuiltinFnId fn_id;
 };
 
-struct IrInstSrcCheckRuntimeScope {
-    IrInstSrc base;
+struct Stage1ZirInstCheckRuntimeScope {
+    Stage1ZirInst base;
 
-    IrInstSrc *scope_is_comptime;
-    IrInstSrc *is_comptime;
+    Stage1ZirInst *scope_is_comptime;
+    Stage1ZirInst *is_comptime;
 };
 
-struct IrInstSrcBswap {
-    IrInstSrc base;
+struct Stage1ZirInstBswap {
+    Stage1ZirInst base;
 
-    IrInstSrc *type;
-    IrInstSrc *op;
+    Stage1ZirInst *type;
+    Stage1ZirInst *op;
 };
 
-struct IrInstGenBswap {
-    IrInstGen base;
+struct Stage1AirInstBswap {
+    Stage1AirInst base;
 
-    IrInstGen *op;
+    Stage1AirInst *op;
 };
 
-struct IrInstSrcBitReverse {
-    IrInstSrc base;
+struct Stage1ZirInstBitReverse {
+    Stage1ZirInst base;
 
-    IrInstSrc *type;
-    IrInstSrc *op;
+    Stage1ZirInst *type;
+    Stage1ZirInst *op;
 };
 
-struct IrInstGenBitReverse {
-    IrInstGen base;
+struct Stage1AirInstBitReverse {
+    Stage1AirInst base;
 
-    IrInstGen *op;
+    Stage1AirInst *op;
 };
 
-struct IrInstGenArrayToVector {
-    IrInstGen base;
+struct Stage1AirInstArrayToVector {
+    Stage1AirInst base;
 
-    IrInstGen *array;
+    Stage1AirInst *array;
 };
 
-struct IrInstGenVectorToArray {
-    IrInstGen base;
+struct Stage1AirInstVectorToArray {
+    Stage1AirInst base;
 
-    IrInstGen *vector;
-    IrInstGen *result_loc;
+    Stage1AirInst *vector;
+    Stage1AirInst *result_loc;
 };
 
-struct IrInstSrcShuffleVector {
-    IrInstSrc base;
+struct Stage1ZirInstShuffleVector {
+    Stage1ZirInst base;
 
-    IrInstSrc *scalar_type;
-    IrInstSrc *a;
-    IrInstSrc *b;
-    IrInstSrc *mask; // This is in zig-format, not llvm format
+    Stage1ZirInst *scalar_type;
+    Stage1ZirInst *a;
+    Stage1ZirInst *b;
+    Stage1ZirInst *mask; // This is in zig-format, not llvm format
 };
 
-struct IrInstGenShuffleVector {
-    IrInstGen base;
+struct Stage1AirInstShuffleVector {
+    Stage1AirInst base;
 
-    IrInstGen *a;
-    IrInstGen *b;
-    IrInstGen *mask; // This is in zig-format, not llvm format
+    Stage1AirInst *a;
+    Stage1AirInst *b;
+    Stage1AirInst *mask; // This is in zig-format, not llvm format
 };
 
-struct IrInstSrcSplat {
-    IrInstSrc base;
+struct Stage1ZirInstSplat {
+    Stage1ZirInst base;
 
-    IrInstSrc *len;
-    IrInstSrc *scalar;
+    Stage1ZirInst *len;
+    Stage1ZirInst *scalar;
 };
 
-struct IrInstGenSplat {
-    IrInstGen base;
+struct Stage1AirInstSplat {
+    Stage1AirInst base;
 
-    IrInstGen *scalar;
+    Stage1AirInst *scalar;
 };
 
-struct IrInstGenAssertZero {
-    IrInstGen base;
+struct Stage1AirInstAssertZero {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstGenAssertNonNull {
-    IrInstGen base;
+struct Stage1AirInstAssertNonNull {
+    Stage1AirInst base;
 
-    IrInstGen *target;
+    Stage1AirInst *target;
 };
 
-struct IrInstSrcUnionInitNamedField {
-    IrInstSrc base;
+struct Stage1ZirInstUnionInitNamedField {
+    Stage1ZirInst base;
 
-    IrInstSrc *union_type;
-    IrInstSrc *field_name;
-    IrInstSrc *field_result_loc;
-    IrInstSrc *result_loc;
+    Stage1ZirInst *union_type;
+    Stage1ZirInst *field_name;
+    Stage1ZirInst *field_result_loc;
+    Stage1ZirInst *result_loc;
 };
 
-struct IrInstSrcHasDecl {
-    IrInstSrc base;
+struct Stage1ZirInstHasDecl {
+    Stage1ZirInst base;
 
-    IrInstSrc *container;
-    IrInstSrc *name;
+    Stage1ZirInst *container;
+    Stage1ZirInst *name;
 };
 
-struct IrInstSrcUndeclaredIdent {
-    IrInstSrc base;
+struct Stage1ZirInstUndeclaredIdent {
+    Stage1ZirInst base;
 
     Buf *name;
 };
 
-struct IrInstSrcAlloca {
-    IrInstSrc base;
+struct Stage1ZirInstAlloca {
+    Stage1ZirInst base;
 
-    IrInstSrc *align;
-    IrInstSrc *is_comptime;
+    Stage1ZirInst *align;
+    Stage1ZirInst *is_comptime;
     const char *name_hint;
 };
 
-struct IrInstGenAlloca {
-    IrInstGen base;
+struct Stage1AirInstAlloca {
+    Stage1AirInst base;
 
     uint32_t align;
     const char *name_hint;
     size_t field_index;
 };
 
-struct IrInstSrcEndExpr {
-    IrInstSrc base;
+struct Stage1ZirInstEndExpr {
+    Stage1ZirInst base;
 
-    IrInstSrc *value;
+    Stage1ZirInst *value;
     ResultLoc *result_loc;
 };
 
 // This one is for writing through the result pointer.
-struct IrInstSrcResolveResult {
-    IrInstSrc base;
+struct Stage1ZirInstResolveResult {
+    Stage1ZirInst base;
 
     ResultLoc *result_loc;
-    IrInstSrc *ty;
+    Stage1ZirInst *ty;
 };
 
-struct IrInstSrcResetResult {
-    IrInstSrc base;
+struct Stage1ZirInstResetResult {
+    Stage1ZirInst base;
 
     ResultLoc *result_loc;
 };
 
-struct IrInstGenPtrOfArrayToSlice {
-    IrInstGen base;
+struct Stage1AirInstPtrOfArrayToSlice {
+    Stage1AirInst base;
 
-    IrInstGen *operand;
-    IrInstGen *result_loc;
+    Stage1AirInst *operand;
+    Stage1AirInst *result_loc;
 };
 
-struct IrInstSrcSuspendBegin {
-    IrInstSrc base;
+struct Stage1ZirInstSuspendBegin {
+    Stage1ZirInst base;
 };
 
-struct IrInstGenSuspendBegin {
-    IrInstGen base;
+struct Stage1AirInstSuspendBegin {
+    Stage1AirInst base;
 
     LLVMBasicBlockRef resume_bb;
 };
 
-struct IrInstSrcSuspendFinish {
-    IrInstSrc base;
+struct Stage1ZirInstSuspendFinish {
+    Stage1ZirInst base;
 
-    IrInstSrcSuspendBegin *begin;
+    Stage1ZirInstSuspendBegin *begin;
 };
 
-struct IrInstGenSuspendFinish {
-    IrInstGen base;
+struct Stage1AirInstSuspendFinish {
+    Stage1AirInst base;
 
-    IrInstGenSuspendBegin *begin;
+    Stage1AirInstSuspendBegin *begin;
 };
 
-struct IrInstSrcAwait {
-    IrInstSrc base;
+struct Stage1ZirInstAwait {
+    Stage1ZirInst base;
 
-    IrInstSrc *frame;
+    Stage1ZirInst *frame;
     ResultLoc *result_loc;
     bool is_nosuspend;
 };
 
-struct IrInstGenAwait {
-    IrInstGen base;
+struct Stage1AirInstAwait {
+    Stage1AirInst base;
 
-    IrInstGen *frame;
-    IrInstGen *result_loc;
+    Stage1AirInst *frame;
+    Stage1AirInst *result_loc;
     ZigFn *target_fn;
     bool is_nosuspend;
 };
 
-struct IrInstSrcResume {
-    IrInstSrc base;
+struct Stage1ZirInstResume {
+    Stage1ZirInst base;
 
-    IrInstSrc *frame;
+    Stage1ZirInst *frame;
 };
 
-struct IrInstGenResume {
-    IrInstGen base;
+struct Stage1AirInstResume {
+    Stage1AirInst base;
 
-    IrInstGen *frame;
+    Stage1AirInst *frame;
 };
 
 enum SpillId {
@@ -4438,37 +4438,37 @@ enum SpillId {
     SpillIdRetErrCode,
 };
 
-struct IrInstSrcSpillBegin {
-    IrInstSrc base;
+struct Stage1ZirInstSpillBegin {
+    Stage1ZirInst base;
 
-    IrInstSrc *operand;
+    Stage1ZirInst *operand;
     SpillId spill_id;
 };
 
-struct IrInstGenSpillBegin {
-    IrInstGen base;
+struct Stage1AirInstSpillBegin {
+    Stage1AirInst base;
 
     SpillId spill_id;
-    IrInstGen *operand;
+    Stage1AirInst *operand;
 };
 
-struct IrInstSrcSpillEnd {
-    IrInstSrc base;
+struct Stage1ZirInstSpillEnd {
+    Stage1ZirInst base;
 
-    IrInstSrcSpillBegin *begin;
+    Stage1ZirInstSpillBegin *begin;
 };
 
-struct IrInstGenSpillEnd {
-    IrInstGen base;
+struct Stage1AirInstSpillEnd {
+    Stage1AirInst base;
 
-    IrInstGenSpillBegin *begin;
+    Stage1AirInstSpillBegin *begin;
 };
 
-struct IrInstGenVectorExtractElem {
-    IrInstGen base;
+struct Stage1AirInstVectorExtractElem {
+    Stage1AirInst base;
 
-    IrInstGen *vector;
-    IrInstGen *index;
+    Stage1AirInst *vector;
+    Stage1AirInst *index;
 };
 
 enum ResultLocId {
@@ -4489,9 +4489,9 @@ struct ResultLoc {
     ResultLocId id;
     bool written;
     bool allow_write_through_const;
-    IrInstGen *resolved_loc; // result ptr
-    IrInstSrc *source_instruction;
-    IrInstGen *gen_instruction; // value to store to the result loc
+    Stage1AirInst *resolved_loc; // result ptr
+    Stage1ZirInst *source_instruction;
+    Stage1AirInst *gen_instruction; // value to store to the result loc
     ZigType *implicit_elem_type;
 };
 
@@ -4525,7 +4525,7 @@ struct ResultLocPeerParent {
     ResultLoc *parent;
     ZigList<ResultLocPeer *> peers;
     ZigType *resolved_type;
-    IrInstSrc *is_comptime;
+    Stage1ZirInst *is_comptime;
 };
 
 struct ResultLocPeer {
@@ -4603,7 +4603,7 @@ struct FnWalkAttrs {
 struct FnWalkCall {
     ZigList<LLVMValueRef> *gen_param_values;
     ZigList<ZigType *> *gen_param_types;
-    IrInstGenCall *inst;
+    Stage1AirInstCall *inst;
     bool is_var_args;
 };
 

--- a/src/stage1/analyze.hpp
+++ b/src/stage1/analyze.hpp
@@ -138,7 +138,7 @@ ScopeSuspend *create_suspend_scope(CodeGen *g, AstNode *node, Scope *parent);
 ScopeFnDef *create_fndef_scope(CodeGen *g, AstNode *node, Scope *parent, ZigFn *fn_entry);
 Scope *create_comptime_scope(CodeGen *g, AstNode *node, Scope *parent);
 Scope *create_nosuspend_scope(CodeGen *g, AstNode *node, Scope *parent);
-Scope *create_runtime_scope(CodeGen *g, AstNode *node, Scope *parent, IrInstSrc *is_comptime);
+Scope *create_runtime_scope(CodeGen *g, AstNode *node, Scope *parent, Stage1ZirInst *is_comptime);
 Scope *create_typeof_scope(CodeGen *g, AstNode *node, Scope *parent);
 ScopeExpr *create_expr_scope(CodeGen *g, AstNode *node, Scope *parent);
 

--- a/src/stage1/astgen.hpp
+++ b/src/stage1/astgen.hpp
@@ -14,10 +14,10 @@ bool stage1_astgen(CodeGen *g, AstNode *node, Scope *scope, Stage1Zir *stage1_zi
         ZigFn *fn, bool in_c_import_scope);
 bool stage1_astgen_fn(CodeGen *g, ZigFn *fn_entry);
 
-bool ir_inst_src_has_side_effects(IrInstSrc *inst);
+bool ir_inst_src_has_side_effects(Stage1ZirInst *inst);
 
 ZigVar *create_local_var(CodeGen *codegen, AstNode *node, Scope *parent_scope,
-        Buf *name, bool src_is_const, bool gen_is_const, bool is_shadowable, IrInstSrc *is_comptime,
+        Buf *name, bool src_is_const, bool gen_is_const, bool is_shadowable, Stage1ZirInst *is_comptime,
         bool skip_name_check);
 
 ResultLoc *no_result_loc(void);
@@ -28,7 +28,7 @@ AstNode *ast_field_to_symbol_node(AstNode *err_set_field_node);
 void ir_add_call_stack_errors_gen(CodeGen *codegen, Stage1Air *exec, ErrorMsg *err_msg,
         int limit);
 
-void destroy_instruction_src(IrInstSrc *inst);
+void destroy_instruction_src(Stage1ZirInst *inst);
 
 bool ir_should_inline(Stage1Zir *exec, Scope *scope);
 Buf *get_anon_type_name(CodeGen *codegen, Stage1Zir *exec, const char *kind_name,

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -84,7 +84,7 @@ static void generate_error_name_table(CodeGen *g);
 static bool value_is_all_undef(CodeGen *g, ZigValue *const_val);
 static void gen_undef_init(CodeGen *g, ZigType *ptr_type, ZigType *value_type, LLVMValueRef ptr);
 static LLVMValueRef build_alloca(CodeGen *g, ZigType *type_entry, const char *name, uint32_t alignment);
-static LLVMValueRef gen_await_early_return(CodeGen *g, IrInstGen *source_instr,
+static LLVMValueRef gen_await_early_return(CodeGen *g, Stage1AirInst *source_instr,
         LLVMValueRef target_frame_ptr, ZigType *result_type, ZigType *ptr_result_type,
         LLVMValueRef result_loc, bool non_async);
 
@@ -906,14 +906,14 @@ static LLVMValueRef get_handle_value(CodeGen *g, LLVMValueRef ptr, ZigType *type
     }
 }
 
-static void ir_assert_impl(bool ok, IrInstGen *source_instruction, const char *file, unsigned int line) {
+static void ir_assert_impl(bool ok, Stage1AirInst *source_instruction, const char *file, unsigned int line) {
     if (ok) return;
     src_assert_impl(ok, source_instruction->source_node, file, line);
 }
 
 #define ir_assert(OK, SOURCE_INSTRUCTION) ir_assert_impl((OK), (SOURCE_INSTRUCTION), __FILE__, __LINE__)
 
-static bool ir_want_fast_math(CodeGen *g, IrInstGen *instruction) {
+static bool ir_want_fast_math(CodeGen *g, Stage1AirInst *instruction) {
     // TODO memoize
     Scope *scope = instruction->scope;
     while (scope) {
@@ -950,7 +950,7 @@ static bool ir_want_runtime_safety_scope(CodeGen *g, Scope *scope) {
             g->build_mode != BuildModeSmallRelease);
 }
 
-static bool ir_want_runtime_safety(CodeGen *g, IrInstGen *instruction) {
+static bool ir_want_runtime_safety(CodeGen *g, Stage1AirInst *instruction) {
     return ir_want_runtime_safety_scope(g, instruction->scope);
 }
 
@@ -1077,7 +1077,7 @@ static void gen_assertion_scope(CodeGen *g, PanicMsgId msg_id, Scope *source_sco
     }
 }
 
-static void gen_assertion(CodeGen *g, PanicMsgId msg_id, IrInstGen *source_instruction) {
+static void gen_assertion(CodeGen *g, PanicMsgId msg_id, Stage1AirInst *source_instruction) {
     return gen_assertion_scope(g, msg_id, source_instruction->scope);
 }
 
@@ -1816,7 +1816,7 @@ static void gen_var_debug_decl(CodeGen *g, ZigVar *var) {
             LLVMGetInsertBlock(g->builder));
 }
 
-static LLVMValueRef ir_llvm_value(CodeGen *g, IrInstGen *instruction) {
+static LLVMValueRef ir_llvm_value(CodeGen *g, Stage1AirInst *instruction) {
     Error err;
 
     bool value_has_bits;
@@ -1827,8 +1827,8 @@ static LLVMValueRef ir_llvm_value(CodeGen *g, IrInstGen *instruction) {
         return nullptr;
 
     if (!instruction->llvm_value) {
-        if (instruction->id == IrInstGenIdAwait) {
-            IrInstGenAwait *await = reinterpret_cast<IrInstGenAwait*>(instruction);
+        if (instruction->id == Stage1AirInstIdAwait) {
+            Stage1AirInstAwait *await = reinterpret_cast<Stage1AirInstAwait*>(instruction);
             if (await->result_loc != nullptr) {
                 return get_handle_value(g, ir_llvm_value(g, await->result_loc),
                     await->result_loc->value->type->data.pointer.child_type, await->result_loc->value->type);
@@ -1921,7 +1921,7 @@ static bool iter_function_params_c_abi(CodeGen *g, ZigType *fn_type, FnWalk *fn_
         case FnWalkIdCall: {
             if (src_i >= fn_walk->data.call.inst->arg_count)
                 return false;
-            IrInstGen *arg = fn_walk->data.call.inst->args[src_i];
+            Stage1AirInst *arg = fn_walk->data.call.inst->args[src_i];
             ty = arg->value->type;
             source_node = arg->source_node;
             val = ir_llvm_value(g, arg);
@@ -2228,10 +2228,10 @@ void walk_function_params(CodeGen *g, ZigType *fn_type, FnWalk *fn_walk) {
         return;
     }
     if (fn_walk->id == FnWalkIdCall) {
-        IrInstGenCall *instruction = fn_walk->data.call.inst;
+        Stage1AirInstCall *instruction = fn_walk->data.call.inst;
         bool is_var_args = fn_walk->data.call.is_var_args;
         for (size_t call_i = 0; call_i < instruction->arg_count; call_i += 1) {
-            IrInstGen *param_instruction = instruction->args[call_i];
+            Stage1AirInst *param_instruction = instruction->args[call_i];
             ZigType *param_type = param_instruction->value->type;
             if (is_var_args || type_has_bits(g, param_type)) {
                 LLVMValueRef param_value = ir_llvm_value(g, param_instruction);
@@ -2445,7 +2445,7 @@ static LLVMValueRef get_merge_err_ret_traces_fn_val(CodeGen *g) {
 
 }
 static LLVMValueRef ir_render_save_err_ret_addr(CodeGen *g, Stage1Air *executable,
-        IrInstGenSaveErrRetAddr *save_err_ret_addr_instruction)
+        Stage1AirInstSaveErrRetAddr *save_err_ret_addr_instruction)
 {
     assert(g->have_err_ret_tracing);
 
@@ -2466,7 +2466,7 @@ static LLVMValueRef ir_render_save_err_ret_addr(CodeGen *g, Stage1Air *executabl
     return nullptr;
 }
 
-static void gen_assert_resume_id(CodeGen *g, IrInstGen *source_instr, ResumeId resume_id, PanicMsgId msg_id,
+static void gen_assert_resume_id(CodeGen *g, Stage1AirInst *source_instr, ResumeId resume_id, PanicMsgId msg_id,
         LLVMBasicBlockRef end_bb)
 {
     LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->llvm_type;
@@ -2543,7 +2543,7 @@ static LLVMValueRef gen_maybe_atomic_op(CodeGen *g, LLVMAtomicRMWBinOp op, LLVMV
     }
 }
 
-static void gen_async_return(CodeGen *g, IrInstGenReturn *instruction) {
+static void gen_async_return(CodeGen *g, Stage1AirInstReturn *instruction) {
     LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->llvm_type;
 
     ZigType *operand_type = (instruction->operand != nullptr) ? instruction->operand->value->type : nullptr;
@@ -2637,7 +2637,7 @@ static void gen_async_return(CodeGen *g, IrInstGenReturn *instruction) {
     LLVMBuildRetVoid(g->builder);
 }
 
-static LLVMValueRef ir_render_return(CodeGen *g, Stage1Air *executable, IrInstGenReturn *instruction) {
+static LLVMValueRef ir_render_return(CodeGen *g, Stage1Air *executable, Stage1AirInstReturn *instruction) {
     if (fn_is_async(g->cur_fn)) {
         gen_async_return(g, instruction);
         return nullptr;
@@ -3063,11 +3063,11 @@ static void gen_shift_rhs_check(CodeGen *g, ZigType *lhs_type, ZigType *rhs_type
 }
 
 static LLVMValueRef ir_render_bin_op(CodeGen *g, Stage1Air *executable,
-        IrInstGenBinOp *bin_op_instruction)
+        Stage1AirInstBinOp *bin_op_instruction)
 {
     IrBinOp op_id = bin_op_instruction->op_id;
-    IrInstGen *op1 = bin_op_instruction->op1;
-    IrInstGen *op2 = bin_op_instruction->op2;
+    Stage1AirInst *op1 = bin_op_instruction->op1;
+    Stage1AirInst *op2 = bin_op_instruction->op2;
 
     ZigType *operand_type = op1->value->type;
     ZigType *scalar_type = (operand_type->id == ZigTypeIdVector) ? operand_type->data.vector.elem_type : operand_type;
@@ -3285,7 +3285,7 @@ static void add_error_range_check(CodeGen *g, ZigType *err_set_type, ZigType *in
 }
 
 static LLVMValueRef ir_render_cast(CodeGen *g, Stage1Air *executable,
-        IrInstGenCast *cast_instruction)
+        Stage1AirInstCast *cast_instruction)
 {
     Error err;
     ZigType *actual_type = cast_instruction->value->value->type;
@@ -3369,7 +3369,7 @@ static LLVMValueRef ir_render_cast(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_ptr_of_array_to_slice(CodeGen *g, Stage1Air *executable,
-        IrInstGenPtrOfArrayToSlice *instruction)
+        Stage1AirInstPtrOfArrayToSlice *instruction)
 {
     ZigType *actual_type = instruction->operand->value->type;
     ZigType *slice_type = instruction->base.value->type;
@@ -3406,7 +3406,7 @@ static LLVMValueRef ir_render_ptr_of_array_to_slice(CodeGen *g, Stage1Air *execu
 }
 
 static LLVMValueRef ir_render_ptr_cast(CodeGen *g, Stage1Air *executable,
-        IrInstGenPtrCast *instruction)
+        Stage1AirInstPtrCast *instruction)
 {
     ZigType *wanted_type = instruction->base.value->type;
     if (!type_has_bits(g, wanted_type)) {
@@ -3432,7 +3432,7 @@ static LLVMValueRef ir_render_ptr_cast(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_bit_cast(CodeGen *g, Stage1Air *executable,
-        IrInstGenBitCast *instruction)
+        Stage1AirInstBitCast *instruction)
 {
     ZigType *wanted_type = instruction->base.value->type;
     ZigType *actual_type = instruction->operand->value->type;
@@ -3460,7 +3460,7 @@ static LLVMValueRef ir_render_bit_cast(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_widen_or_shorten(CodeGen *g, Stage1Air *executable,
-        IrInstGenWidenOrShorten *instruction)
+        Stage1AirInstWidenOrShorten *instruction)
 {
     ZigType *actual_type = instruction->target->value->type;
     // TODO instead of this logic, use the Noop instruction to change the type from
@@ -3476,7 +3476,7 @@ static LLVMValueRef ir_render_widen_or_shorten(CodeGen *g, Stage1Air *executable
             instruction->base.value->type, target_val);
 }
 
-static LLVMValueRef ir_render_int_to_ptr(CodeGen *g, Stage1Air *executable, IrInstGenIntToPtr *instruction) {
+static LLVMValueRef ir_render_int_to_ptr(CodeGen *g, Stage1Air *executable, Stage1AirInstIntToPtr *instruction) {
     ZigType *wanted_type = instruction->base.value->type;
     LLVMValueRef target_val = ir_llvm_value(g, instruction->target);
     const uint32_t align_bytes = get_ptr_align(g, wanted_type);
@@ -3514,13 +3514,13 @@ static LLVMValueRef ir_render_int_to_ptr(CodeGen *g, Stage1Air *executable, IrIn
     return LLVMBuildIntToPtr(g->builder, target_val, get_llvm_type(g, wanted_type), "");
 }
 
-static LLVMValueRef ir_render_ptr_to_int(CodeGen *g, Stage1Air *executable, IrInstGenPtrToInt *instruction) {
+static LLVMValueRef ir_render_ptr_to_int(CodeGen *g, Stage1Air *executable, Stage1AirInstPtrToInt *instruction) {
     ZigType *wanted_type = instruction->base.value->type;
     LLVMValueRef target_val = ir_llvm_value(g, instruction->target);
     return LLVMBuildPtrToInt(g->builder, target_val, get_llvm_type(g, wanted_type), "");
 }
 
-static LLVMValueRef ir_render_int_to_enum(CodeGen *g, Stage1Air *executable, IrInstGenIntToEnum *instruction) {
+static LLVMValueRef ir_render_int_to_enum(CodeGen *g, Stage1Air *executable, Stage1AirInstIntToEnum *instruction) {
     ZigType *wanted_type = instruction->base.value->type;
     assert(wanted_type->id == ZigTypeIdEnum);
     ZigType *tag_int_type = wanted_type->data.enumeration.tag_int_type;
@@ -3560,7 +3560,7 @@ static LLVMValueRef ir_render_int_to_enum(CodeGen *g, Stage1Air *executable, IrI
     return tag_int_value;
 }
 
-static LLVMValueRef ir_render_int_to_err(CodeGen *g, Stage1Air *executable, IrInstGenIntToErr *instruction) {
+static LLVMValueRef ir_render_int_to_err(CodeGen *g, Stage1Air *executable, Stage1AirInstIntToErr *instruction) {
     ZigType *wanted_type = instruction->base.value->type;
     assert(wanted_type->id == ZigTypeIdErrorSet);
 
@@ -3577,7 +3577,7 @@ static LLVMValueRef ir_render_int_to_err(CodeGen *g, Stage1Air *executable, IrIn
     return gen_widen_or_shorten(g, false, actual_type, g->err_tag_type, target_val);
 }
 
-static LLVMValueRef ir_render_err_to_int(CodeGen *g, Stage1Air *executable, IrInstGenErrToInt *instruction) {
+static LLVMValueRef ir_render_err_to_int(CodeGen *g, Stage1Air *executable, Stage1AirInstErrToInt *instruction) {
     ZigType *wanted_type = instruction->base.value->type;
     assert(wanted_type->id == ZigTypeIdInt);
     assert(!wanted_type->data.integral.is_signed);
@@ -3604,7 +3604,7 @@ static LLVMValueRef ir_render_err_to_int(CodeGen *g, Stage1Air *executable, IrIn
 }
 
 static LLVMValueRef ir_render_unreachable(CodeGen *g, Stage1Air *executable,
-        IrInstGenUnreachable *unreachable_instruction)
+        Stage1AirInstUnreachable *unreachable_instruction)
 {
     if (ir_want_runtime_safety(g, &unreachable_instruction->base)) {
         gen_safety_crash(g, PanicMsgIdUnreachable);
@@ -3615,7 +3615,7 @@ static LLVMValueRef ir_render_unreachable(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_cond_br(CodeGen *g, Stage1Air *executable,
-        IrInstGenCondBr *cond_br_instruction)
+        Stage1AirInstCondBr *cond_br_instruction)
 {
     LLVMBuildCondBr(g->builder,
             ir_llvm_value(g, cond_br_instruction->condition),
@@ -3624,19 +3624,19 @@ static LLVMValueRef ir_render_cond_br(CodeGen *g, Stage1Air *executable,
     return nullptr;
 }
 
-static LLVMValueRef ir_render_br(CodeGen *g, Stage1Air *executable, IrInstGenBr *br_instruction) {
+static LLVMValueRef ir_render_br(CodeGen *g, Stage1Air *executable, Stage1AirInstBr *br_instruction) {
     LLVMBuildBr(g->builder, br_instruction->dest_block->llvm_block);
     return nullptr;
 }
 
 static LLVMValueRef ir_render_binary_not(CodeGen *g, Stage1Air *executable,
-        IrInstGenBinaryNot *inst)
+        Stage1AirInstBinaryNot *inst)
 {
     LLVMValueRef operand = ir_llvm_value(g, inst->operand);
     return LLVMBuildNot(g->builder, operand, "");
 }
 
-static LLVMValueRef ir_gen_negation(CodeGen *g, IrInstGen *inst, IrInstGen *operand, bool wrapping) {
+static LLVMValueRef ir_gen_negation(CodeGen *g, Stage1AirInst *inst, Stage1AirInst *operand, bool wrapping) {
     LLVMValueRef llvm_operand = ir_llvm_value(g, operand);
     ZigType *operand_type = operand->value->type;
     ZigType *scalar_type = (operand_type->id == ZigTypeIdVector) ?
@@ -3662,12 +3662,12 @@ static LLVMValueRef ir_gen_negation(CodeGen *g, IrInstGen *inst, IrInstGen *oper
 }
 
 static LLVMValueRef ir_render_negation(CodeGen *g, Stage1Air *executable,
-        IrInstGenNegation *inst)
+        Stage1AirInstNegation *inst)
 {
     return ir_gen_negation(g, &inst->base, inst->operand, inst->wrapping);
 }
 
-static LLVMValueRef ir_render_bool_not(CodeGen *g, Stage1Air *executable, IrInstGenBoolNot *instruction) {
+static LLVMValueRef ir_render_bool_not(CodeGen *g, Stage1Air *executable, Stage1AirInstBoolNot *instruction) {
     LLVMValueRef value = ir_llvm_value(g, instruction->value);
     LLVMValueRef zero = LLVMConstNull(LLVMTypeOf(value));
     return LLVMBuildICmp(g->builder, LLVMIntEQ, value, zero, "");
@@ -3681,7 +3681,7 @@ static void render_decl_var(CodeGen *g, ZigVar *var) {
     gen_var_debug_decl(g, var);
 }
 
-static LLVMValueRef ir_render_decl_var(CodeGen *g, Stage1Air *executable, IrInstGenDeclVar *instruction) {
+static LLVMValueRef ir_render_decl_var(CodeGen *g, Stage1Air *executable, Stage1AirInstDeclVar *instruction) {
     instruction->var->ptr_instruction = instruction->var_ptr;
     instruction->var->did_the_decl_codegen = true;
     render_decl_var(g, instruction->var);
@@ -3689,7 +3689,7 @@ static LLVMValueRef ir_render_decl_var(CodeGen *g, Stage1Air *executable, IrInst
 }
 
 static LLVMValueRef ir_render_load_ptr(CodeGen *g, Stage1Air *executable,
-        IrInstGenLoadPtr *instruction)
+        Stage1AirInstLoadPtr *instruction)
 {
     ZigType *child_type = instruction->base.value->type;
     if (!type_has_bits(g, child_type))
@@ -3896,7 +3896,7 @@ static void gen_undef_init(CodeGen *g, ZigType *ptr_type, ZigType *value_type, L
     gen_assign_raw(g, ptr, ptr_type, zero);
 }
 
-static LLVMValueRef ir_render_store_ptr(CodeGen *g, Stage1Air *executable, IrInstGenStorePtr *instruction) {
+static LLVMValueRef ir_render_store_ptr(CodeGen *g, Stage1Air *executable, Stage1AirInstStorePtr *instruction) {
     Error err;
 
     ZigType *ptr_type = instruction->ptr->value->type;
@@ -3929,7 +3929,7 @@ static LLVMValueRef ir_render_store_ptr(CodeGen *g, Stage1Air *executable, IrIns
 }
 
 static LLVMValueRef ir_render_vector_store_elem(CodeGen *g, Stage1Air *executable,
-        IrInstGenVectorStoreElem *instruction)
+        Stage1AirInstVectorStoreElem *instruction)
 {
     LLVMValueRef vector_ptr = ir_llvm_value(g, instruction->vector_ptr);
     LLVMValueRef index = ir_llvm_value(g, instruction->index);
@@ -3941,7 +3941,7 @@ static LLVMValueRef ir_render_vector_store_elem(CodeGen *g, Stage1Air *executabl
     return nullptr;
 }
 
-static LLVMValueRef ir_render_var_ptr(CodeGen *g, Stage1Air *executable, IrInstGenVarPtr *instruction) {
+static LLVMValueRef ir_render_var_ptr(CodeGen *g, Stage1Air *executable, Stage1AirInstVarPtr *instruction) {
     Error err;
 
     ZigType *ptr_type = instruction->base.value->type;
@@ -3969,7 +3969,7 @@ static LLVMValueRef ir_render_var_ptr(CodeGen *g, Stage1Air *executable, IrInstG
 }
 
 static LLVMValueRef ir_render_return_ptr(CodeGen *g, Stage1Air *executable,
-        IrInstGenReturnPtr *instruction)
+        Stage1AirInstReturnPtr *instruction)
 {
     if (!type_has_bits(g, instruction->base.value->type))
         return nullptr;
@@ -3977,7 +3977,7 @@ static LLVMValueRef ir_render_return_ptr(CodeGen *g, Stage1Air *executable,
     return g->cur_ret_ptr;
 }
 
-static LLVMValueRef ir_render_elem_ptr(CodeGen *g, Stage1Air *executable, IrInstGenElemPtr *instruction) {
+static LLVMValueRef ir_render_elem_ptr(CodeGen *g, Stage1Air *executable, Stage1AirInstElemPtr *instruction) {
     LLVMValueRef array_ptr_ptr = ir_llvm_value(g, instruction->array_ptr);
     ZigType *array_ptr_type = instruction->array_ptr->value->type;
     assert(array_ptr_type->id == ZigTypeIdPointer);
@@ -4152,7 +4152,7 @@ static void render_async_spills(CodeGen *g) {
     ZigType *frame_type = g->cur_fn->frame_type->data.frame.locals_struct;
 
     for (size_t alloca_i = 0; alloca_i < g->cur_fn->alloca_gen_list.length; alloca_i += 1) {
-        IrInstGenAlloca *instruction = g->cur_fn->alloca_gen_list.at(alloca_i);
+        Stage1AirInstAlloca *instruction = g->cur_fn->alloca_gen_list.at(alloca_i);
         if (instruction->field_index == SIZE_MAX)
             continue;
 
@@ -4229,7 +4229,7 @@ static void gen_init_stack_trace(CodeGen *g, LLVMValueRef trace_field_ptr, LLVMV
     LLVMBuildStore(g->builder, LLVMConstInt(usize_type_ref, stack_trace_ptr_count, false), addrs_len_ptr);
 }
 
-static LLVMValueRef ir_render_call(CodeGen *g, Stage1Air *executable, IrInstGenCall *instruction) {
+static LLVMValueRef ir_render_call(CodeGen *g, Stage1Air *executable, Stage1AirInstCall *instruction) {
     Error err;
 
     LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->llvm_type;
@@ -4579,7 +4579,7 @@ static LLVMValueRef ir_render_call(CodeGen *g, Stage1Air *executable, IrInstGenC
                 return nullptr;
 
             if (result_loc != nullptr) {
-                if (instruction->result_loc->id == IrInstGenIdReturnPtr) {
+                if (instruction->result_loc->id == Stage1AirInstIdReturnPtr) {
                     instruction->base.spill = nullptr;
                     return g->cur_ret_ptr;
                 } else {
@@ -4650,7 +4650,7 @@ static LLVMValueRef ir_render_call(CodeGen *g, Stage1Air *executable, IrInstGenC
 }
 
 static LLVMValueRef ir_render_struct_field_ptr(CodeGen *g, Stage1Air *executable,
-    IrInstGenStructFieldPtr *instruction)
+    Stage1AirInstStructFieldPtr *instruction)
 {
     Error err;
 
@@ -4701,7 +4701,7 @@ static LLVMValueRef ir_render_struct_field_ptr(CodeGen *g, Stage1Air *executable
 }
 
 static LLVMValueRef ir_render_union_field_ptr(CodeGen *g, Stage1Air *executable,
-    IrInstGenUnionFieldPtr *instruction)
+    Stage1AirInstUnionFieldPtr *instruction)
 {
     if (instruction->base.value->special != ConstValSpecialRuntime)
         return nullptr;
@@ -4800,7 +4800,7 @@ static size_t find_asm_index(CodeGen *g, AstNode *node, AsmToken *tok, Buf *src_
     return SIZE_MAX;
 }
 
-static LLVMValueRef ir_render_asm_gen(CodeGen *g, Stage1Air *executable, IrInstGenAsm *instruction) {
+static LLVMValueRef ir_render_asm_gen(CodeGen *g, Stage1Air *executable, Stage1AirInstAsm *instruction) {
     AstNode *asm_node = instruction->base.source_node;
     assert(asm_node->type == NodeTypeAsmExpr);
     AstNodeAsmExpr *asm_expr = &asm_node->data.asm_expr;
@@ -4885,7 +4885,7 @@ static LLVMValueRef ir_render_asm_gen(CodeGen *g, Stage1Air *executable, IrInstG
     for (size_t i = 0; i < asm_expr->input_list.length; i += 1, total_index += 1, param_index += 1) {
         AsmInput *asm_input = asm_expr->input_list.at(i);
         buf_replace(asm_input->constraint, ',', '|');
-        IrInstGen *ir_input = instruction->input_list[i];
+        Stage1AirInst *ir_input = instruction->input_list[i];
         buf_append_buf(&constraint_buf, asm_input->constraint);
         if (total_index + 1 < total_constraint_count) {
             buf_append_char(&constraint_buf, ',');
@@ -4978,13 +4978,13 @@ static LLVMValueRef gen_non_null_bit(CodeGen *g, ZigType *maybe_type, LLVMValueR
 }
 
 static LLVMValueRef ir_render_test_non_null(CodeGen *g, Stage1Air *executable,
-    IrInstGenTestNonNull *instruction)
+    Stage1AirInstTestNonNull *instruction)
 {
     return gen_non_null_bit(g, instruction->value->value->type, ir_llvm_value(g, instruction->value));
 }
 
 static LLVMValueRef ir_render_optional_unwrap_ptr(CodeGen *g, Stage1Air *executable,
-        IrInstGenOptionalUnwrapPtr *instruction)
+        Stage1AirInstOptionalUnwrapPtr *instruction)
 {
     if (instruction->base.value->special != ConstValSpecialRuntime)
         return nullptr;
@@ -5090,7 +5090,7 @@ static LLVMValueRef get_int_builtin_fn(CodeGen *g, ZigType *expr_type, BuiltinFn
     return fn_val;
 }
 
-static LLVMValueRef ir_render_clz(CodeGen *g, Stage1Air *executable, IrInstGenClz *instruction) {
+static LLVMValueRef ir_render_clz(CodeGen *g, Stage1Air *executable, Stage1AirInstClz *instruction) {
     ZigType *int_type = instruction->op->value->type;
     LLVMValueRef fn_val = get_int_builtin_fn(g, int_type, BuiltinFnIdClz);
     LLVMValueRef operand = ir_llvm_value(g, instruction->op);
@@ -5102,7 +5102,7 @@ static LLVMValueRef ir_render_clz(CodeGen *g, Stage1Air *executable, IrInstGenCl
     return gen_widen_or_shorten(g, false, int_type, instruction->base.value->type, wrong_size_int);
 }
 
-static LLVMValueRef ir_render_ctz(CodeGen *g, Stage1Air *executable, IrInstGenCtz *instruction) {
+static LLVMValueRef ir_render_ctz(CodeGen *g, Stage1Air *executable, Stage1AirInstCtz *instruction) {
     ZigType *int_type = instruction->op->value->type;
     LLVMValueRef fn_val = get_int_builtin_fn(g, int_type, BuiltinFnIdCtz);
     LLVMValueRef operand = ir_llvm_value(g, instruction->op);
@@ -5114,7 +5114,7 @@ static LLVMValueRef ir_render_ctz(CodeGen *g, Stage1Air *executable, IrInstGenCt
     return gen_widen_or_shorten(g, false, int_type, instruction->base.value->type, wrong_size_int);
 }
 
-static LLVMValueRef ir_render_shuffle_vector(CodeGen *g, Stage1Air *executable, IrInstGenShuffleVector *instruction) {
+static LLVMValueRef ir_render_shuffle_vector(CodeGen *g, Stage1Air *executable, Stage1AirInstShuffleVector *instruction) {
     uint64_t len_a = instruction->a->value->type->data.vector.len;
     uint64_t len_mask = instruction->mask->value->type->data.vector.len;
 
@@ -5123,7 +5123,7 @@ static LLVMValueRef ir_render_shuffle_vector(CodeGen *g, Stage1Air *executable, 
     // when changing code, so Zig uses negative numbers to index the
     // second vector. These start at -1 and go down, and are easiest to use
     // with the ~ operator. Here we convert between the two formats.
-    IrInstGen *mask = instruction->mask;
+    Stage1AirInst *mask = instruction->mask;
     LLVMValueRef *values = heap::c_allocator.allocate<LLVMValueRef>(len_mask);
     for (uint64_t i = 0; i < len_mask; i++) {
         if (mask->value->data.x_array.data.s_none.elements[i].special == ConstValSpecialUndef) {
@@ -5144,7 +5144,7 @@ static LLVMValueRef ir_render_shuffle_vector(CodeGen *g, Stage1Air *executable, 
         llvm_mask_value, "");
 }
 
-static LLVMValueRef ir_render_splat(CodeGen *g, Stage1Air *executable, IrInstGenSplat *instruction) {
+static LLVMValueRef ir_render_splat(CodeGen *g, Stage1Air *executable, Stage1AirInstSplat *instruction) {
     ZigType *result_type = instruction->base.value->type;
     ir_assert(result_type->id == ZigTypeIdVector, &instruction->base);
     uint32_t len = result_type->data.vector.len;
@@ -5156,7 +5156,7 @@ static LLVMValueRef ir_render_splat(CodeGen *g, Stage1Air *executable, IrInstGen
     return LLVMBuildShuffleVector(g->builder, op_vector, undef_vector, LLVMConstNull(mask_llvm_type), "");
 }
 
-static LLVMValueRef ir_render_pop_count(CodeGen *g, Stage1Air *executable, IrInstGenPopCount *instruction) {
+static LLVMValueRef ir_render_pop_count(CodeGen *g, Stage1Air *executable, Stage1AirInstPopCount *instruction) {
     ZigType *int_type = instruction->op->value->type;
     LLVMValueRef fn_val = get_int_builtin_fn(g, int_type, BuiltinFnIdPopCount);
     LLVMValueRef operand = ir_llvm_value(g, instruction->op);
@@ -5164,7 +5164,7 @@ static LLVMValueRef ir_render_pop_count(CodeGen *g, Stage1Air *executable, IrIns
     return gen_widen_or_shorten(g, false, int_type, instruction->base.value->type, wrong_size_int);
 }
 
-static LLVMValueRef ir_render_switch_br(CodeGen *g, Stage1Air *executable, IrInstGenSwitchBr *instruction) {
+static LLVMValueRef ir_render_switch_br(CodeGen *g, Stage1Air *executable, Stage1AirInstSwitchBr *instruction) {
     ZigType *target_type = instruction->target_value->value->type;
     LLVMBasicBlockRef else_block = instruction->else_block->llvm_block;
 
@@ -5178,7 +5178,7 @@ static LLVMValueRef ir_render_switch_br(CodeGen *g, Stage1Air *executable, IrIns
                                                 (unsigned)instruction->case_count);
 
     for (size_t i = 0; i < instruction->case_count; i += 1) {
-        IrInstGenSwitchBrCase *this_case = &instruction->cases[i];
+        Stage1AirInstSwitchBrCase *this_case = &instruction->cases[i];
 
         LLVMValueRef case_value = ir_llvm_value(g, this_case->value);
         if (target_type->id == ZigTypeIdPointer) {
@@ -5192,7 +5192,7 @@ static LLVMValueRef ir_render_switch_br(CodeGen *g, Stage1Air *executable, IrIns
     return nullptr;
 }
 
-static LLVMValueRef ir_render_phi(CodeGen *g, Stage1Air *executable, IrInstGenPhi *instruction) {
+static LLVMValueRef ir_render_phi(CodeGen *g, Stage1Air *executable, Stage1AirInstPhi *instruction) {
     if (!type_has_bits(g, instruction->base.value->type))
         return nullptr;
 
@@ -5216,12 +5216,12 @@ static LLVMValueRef ir_render_phi(CodeGen *g, Stage1Air *executable, IrInstGenPh
     return phi;
 }
 
-static LLVMValueRef ir_render_ref(CodeGen *g, Stage1Air *executable, IrInstGenRef *instruction) {
+static LLVMValueRef ir_render_ref(CodeGen *g, Stage1Air *executable, Stage1AirInstRef *instruction) {
     if (!type_has_bits(g, instruction->base.value->type)) {
         return nullptr;
     }
-    if (instruction->operand->id == IrInstGenIdCall) {
-        IrInstGenCall *call = reinterpret_cast<IrInstGenCall *>(instruction->operand);
+    if (instruction->operand->id == Stage1AirInstIdCall) {
+        Stage1AirInstCall *call = reinterpret_cast<Stage1AirInstCall *>(instruction->operand);
         if (call->result_loc != nullptr) {
             return ir_llvm_value(g, call->result_loc);
         }
@@ -5236,7 +5236,7 @@ static LLVMValueRef ir_render_ref(CodeGen *g, Stage1Air *executable, IrInstGenRe
     }
 }
 
-static LLVMValueRef ir_render_err_name(CodeGen *g, Stage1Air *executable, IrInstGenErrName *instruction) {
+static LLVMValueRef ir_render_err_name(CodeGen *g, Stage1Air *executable, Stage1AirInstErrName *instruction) {
     assert(g->generate_error_name_table);
     assert(g->errors_by_index.length > 0);
 
@@ -5363,7 +5363,7 @@ static LLVMValueRef get_enum_tag_name_function(CodeGen *g, ZigType *enum_type) {
 }
 
 static LLVMValueRef ir_render_enum_tag_name(CodeGen *g, Stage1Air *executable,
-        IrInstGenTagName *instruction)
+        Stage1AirInstTagName *instruction)
 {
     ZigType *enum_type = instruction->target->value->type;
     assert(enum_type->id == ZigTypeIdEnum);
@@ -5376,7 +5376,7 @@ static LLVMValueRef ir_render_enum_tag_name(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_field_parent_ptr(CodeGen *g, Stage1Air *executable,
-        IrInstGenFieldParentPtr *instruction)
+        Stage1AirInstFieldParentPtr *instruction)
 {
     ZigType *container_ptr_type = instruction->base.value->type;
     assert(container_ptr_type->id == ZigTypeIdPointer);
@@ -5402,7 +5402,7 @@ static LLVMValueRef ir_render_field_parent_ptr(CodeGen *g, Stage1Air *executable
     }
 }
 
-static LLVMValueRef ir_render_align_cast(CodeGen *g, Stage1Air *executable, IrInstGenAlignCast *instruction) {
+static LLVMValueRef ir_render_align_cast(CodeGen *g, Stage1Air *executable, Stage1AirInstAlignCast *instruction) {
     LLVMValueRef target_val = ir_llvm_value(g, instruction->target);
     assert(target_val);
 
@@ -5466,7 +5466,7 @@ static LLVMValueRef ir_render_align_cast(CodeGen *g, Stage1Air *executable, IrIn
 }
 
 static LLVMValueRef ir_render_error_return_trace(CodeGen *g, Stage1Air *executable,
-        IrInstGenErrorReturnTrace *instruction)
+        Stage1AirInstErrorReturnTrace *instruction)
 {
     bool is_llvm_alloca;
     LLVMValueRef cur_err_ret_trace_val = get_cur_err_ret_trace_val(g, instruction->base.scope, &is_llvm_alloca);
@@ -5507,7 +5507,7 @@ static enum ZigLLVM_AtomicRMWBinOp to_ZigLLVMAtomicRMWBinOp(AtomicRmwOp op, bool
     zig_unreachable();
 }
 
-static LLVMTypeRef get_atomic_abi_type(CodeGen *g, IrInstGen *instruction, bool RMWXchg) {
+static LLVMTypeRef get_atomic_abi_type(CodeGen *g, Stage1AirInst *instruction, bool RMWXchg) {
     // If the operand type of an atomic operation is not byte sized we need to
     // widen it before using it and then truncate the result.
     // RMW exchange of floating-point values is bitcasted to same-sized integer
@@ -5538,7 +5538,7 @@ static LLVMTypeRef get_atomic_abi_type(CodeGen *g, IrInstGen *instruction, bool 
     }
 }
 
-static LLVMValueRef ir_render_cmpxchg(CodeGen *g, Stage1Air *executable, IrInstGenCmpxchg *instruction) {
+static LLVMValueRef ir_render_cmpxchg(CodeGen *g, Stage1Air *executable, Stage1AirInstCmpxchg *instruction) {
     LLVMValueRef ptr_val = ir_llvm_value(g, instruction->ptr);
     LLVMValueRef cmp_val = ir_llvm_value(g, instruction->cmp_value);
     LLVMValueRef new_val = ir_llvm_value(g, instruction->new_value);
@@ -5600,7 +5600,7 @@ static LLVMValueRef ir_render_cmpxchg(CodeGen *g, Stage1Air *executable, IrInstG
     return result_loc;
 }
 
-static LLVMValueRef ir_render_reduce(CodeGen *g, Stage1Air *executable, IrInstGenReduce *instruction) {
+static LLVMValueRef ir_render_reduce(CodeGen *g, Stage1Air *executable, Stage1AirInstReduce *instruction) {
     LLVMValueRef value = ir_llvm_value(g, instruction->value);
 
     ZigType *value_type = instruction->value->value->type;
@@ -5664,13 +5664,13 @@ static LLVMValueRef ir_render_reduce(CodeGen *g, Stage1Air *executable, IrInstGe
     return result_val;
 }
 
-static LLVMValueRef ir_render_fence(CodeGen *g, Stage1Air *executable, IrInstGenFence *instruction) {
+static LLVMValueRef ir_render_fence(CodeGen *g, Stage1Air *executable, Stage1AirInstFence *instruction) {
     LLVMAtomicOrdering atomic_order = to_LLVMAtomicOrdering(instruction->order);
     LLVMBuildFence(g->builder, atomic_order, false, "");
     return nullptr;
 }
 
-static LLVMValueRef ir_render_truncate(CodeGen *g, Stage1Air *executable, IrInstGenTruncate *instruction) {
+static LLVMValueRef ir_render_truncate(CodeGen *g, Stage1Air *executable, Stage1AirInstTruncate *instruction) {
     LLVMValueRef target_val = ir_llvm_value(g, instruction->target);
     ZigType *dest_type = instruction->base.value->type;
     ZigType *src_type = instruction->target->value->type;
@@ -5685,7 +5685,7 @@ static LLVMValueRef ir_render_truncate(CodeGen *g, Stage1Air *executable, IrInst
     }
 }
 
-static LLVMValueRef ir_render_memset(CodeGen *g, Stage1Air *executable, IrInstGenMemset *instruction) {
+static LLVMValueRef ir_render_memset(CodeGen *g, Stage1Air *executable, Stage1AirInstMemset *instruction) {
     LLVMValueRef dest_ptr = ir_llvm_value(g, instruction->dest_ptr);
     LLVMValueRef len_val = ir_llvm_value(g, instruction->count);
 
@@ -5715,7 +5715,7 @@ static LLVMValueRef ir_render_memset(CodeGen *g, Stage1Air *executable, IrInstGe
     return nullptr;
 }
 
-static LLVMValueRef ir_render_memcpy(CodeGen *g, Stage1Air *executable, IrInstGenMemcpy *instruction) {
+static LLVMValueRef ir_render_memcpy(CodeGen *g, Stage1Air *executable, Stage1AirInstMemcpy *instruction) {
     LLVMValueRef dest_ptr = ir_llvm_value(g, instruction->dest_ptr);
     LLVMValueRef src_ptr = ir_llvm_value(g, instruction->src_ptr);
     LLVMValueRef len_val = ir_llvm_value(g, instruction->count);
@@ -5737,14 +5737,14 @@ static LLVMValueRef ir_render_memcpy(CodeGen *g, Stage1Air *executable, IrInstGe
     return nullptr;
 }
 
-static LLVMValueRef ir_render_wasm_memory_size(CodeGen *g, Stage1Air *executable, IrInstGenWasmMemorySize *instruction) {
+static LLVMValueRef ir_render_wasm_memory_size(CodeGen *g, Stage1Air *executable, Stage1AirInstWasmMemorySize *instruction) {
     // TODO adjust for wasm64
     LLVMValueRef param = ir_llvm_value(g, instruction->index);
     LLVMValueRef val = LLVMBuildCall(g->builder, gen_wasm_memory_size(g), &param, 1, "");
     return val;
 }
 
-static LLVMValueRef ir_render_wasm_memory_grow(CodeGen *g, Stage1Air *executable, IrInstGenWasmMemoryGrow *instruction) {
+static LLVMValueRef ir_render_wasm_memory_grow(CodeGen *g, Stage1Air *executable, Stage1AirInstWasmMemoryGrow *instruction) {
     // TODO adjust for wasm64
     LLVMValueRef params[] = {
         ir_llvm_value(g, instruction->index),
@@ -5754,7 +5754,7 @@ static LLVMValueRef ir_render_wasm_memory_grow(CodeGen *g, Stage1Air *executable
     return val;
 }
 
-static LLVMValueRef ir_render_slice(CodeGen *g, Stage1Air *executable, IrInstGenSlice *instruction) {
+static LLVMValueRef ir_render_slice(CodeGen *g, Stage1Air *executable, Stage1AirInstSlice *instruction) {
     Error err;
 
     LLVMValueRef array_ptr_ptr = ir_llvm_value(g, instruction->ptr);
@@ -5991,13 +5991,13 @@ static LLVMValueRef get_trap_fn_val(CodeGen *g) {
 }
 
 
-static LLVMValueRef ir_render_breakpoint(CodeGen *g, Stage1Air *executable, IrInstGenBreakpoint *instruction) {
+static LLVMValueRef ir_render_breakpoint(CodeGen *g, Stage1Air *executable, Stage1AirInstBreakpoint *instruction) {
     LLVMBuildCall(g->builder, get_trap_fn_val(g), nullptr, 0, "");
     return nullptr;
 }
 
 static LLVMValueRef ir_render_return_address(CodeGen *g, Stage1Air *executable,
-        IrInstGenReturnAddress *instruction)
+        Stage1AirInstReturnAddress *instruction)
 {
     if (target_is_wasm(g->zig_target) && g->zig_target->os != OsEmscripten) {
         // I got this error from LLVM 10:
@@ -6025,18 +6025,18 @@ static LLVMValueRef get_frame_address_fn_val(CodeGen *g) {
 }
 
 static LLVMValueRef ir_render_frame_address(CodeGen *g, Stage1Air *executable,
-        IrInstGenFrameAddress *instruction)
+        Stage1AirInstFrameAddress *instruction)
 {
     LLVMValueRef zero = LLVMConstNull(g->builtin_types.entry_i32->llvm_type);
     LLVMValueRef ptr_val = LLVMBuildCall(g->builder, get_frame_address_fn_val(g), &zero, 1, "");
     return LLVMBuildPtrToInt(g->builder, ptr_val, g->builtin_types.entry_usize->llvm_type, "");
 }
 
-static LLVMValueRef ir_render_handle(CodeGen *g, Stage1Air *executable, IrInstGenFrameHandle *instruction) {
+static LLVMValueRef ir_render_handle(CodeGen *g, Stage1Air *executable, Stage1AirInstFrameHandle *instruction) {
     return g->cur_frame_ptr;
 }
 
-static LLVMValueRef render_shl_with_overflow(CodeGen *g, IrInstGenOverflowOp *instruction) {
+static LLVMValueRef render_shl_with_overflow(CodeGen *g, Stage1AirInstOverflowOp *instruction) {
     ZigType *int_type = instruction->result_ptr_type;
     assert(int_type->id == ZigTypeIdInt);
 
@@ -6061,7 +6061,7 @@ static LLVMValueRef render_shl_with_overflow(CodeGen *g, IrInstGenOverflowOp *in
     return overflow_bit;
 }
 
-static LLVMValueRef ir_render_overflow_op(CodeGen *g, Stage1Air *executable, IrInstGenOverflowOp *instruction) {
+static LLVMValueRef ir_render_overflow_op(CodeGen *g, Stage1Air *executable, Stage1AirInstOverflowOp *instruction) {
     AddSubMul add_sub_mul;
     switch (instruction->op) {
         case IrOverflowOpAdd:
@@ -6099,7 +6099,7 @@ static LLVMValueRef ir_render_overflow_op(CodeGen *g, Stage1Air *executable, IrI
     return overflow_bit;
 }
 
-static LLVMValueRef ir_render_test_err(CodeGen *g, Stage1Air *executable, IrInstGenTestErr *instruction) {
+static LLVMValueRef ir_render_test_err(CodeGen *g, Stage1Air *executable, Stage1AirInstTestErr *instruction) {
     ZigType *err_union_type = instruction->err_union->value->type;
     ZigType *payload_type = err_union_type->data.error_union.payload_type;
     LLVMValueRef err_union_handle = ir_llvm_value(g, instruction->err_union);
@@ -6117,7 +6117,7 @@ static LLVMValueRef ir_render_test_err(CodeGen *g, Stage1Air *executable, IrInst
 }
 
 static LLVMValueRef ir_render_unwrap_err_code(CodeGen *g, Stage1Air *executable,
-        IrInstGenUnwrapErrCode *instruction)
+        Stage1AirInstUnwrapErrCode *instruction)
 {
     if (instruction->base.value->special != ConstValSpecialRuntime)
         return nullptr;
@@ -6137,7 +6137,7 @@ static LLVMValueRef ir_render_unwrap_err_code(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_unwrap_err_payload(CodeGen *g, Stage1Air *executable,
-        IrInstGenUnwrapErrPayload *instruction)
+        Stage1AirInstUnwrapErrPayload *instruction)
 {
     Error err;
 
@@ -6205,7 +6205,7 @@ static LLVMValueRef ir_render_unwrap_err_payload(CodeGen *g, Stage1Air *executab
     }
 }
 
-static LLVMValueRef ir_render_optional_wrap(CodeGen *g, Stage1Air *executable, IrInstGenOptionalWrap *instruction) {
+static LLVMValueRef ir_render_optional_wrap(CodeGen *g, Stage1Air *executable, Stage1AirInstOptionalWrap *instruction) {
     ZigType *wanted_type = instruction->base.value->type;
 
     assert(wanted_type->id == ZigTypeIdOptional);
@@ -6241,7 +6241,7 @@ static LLVMValueRef ir_render_optional_wrap(CodeGen *g, Stage1Air *executable, I
     return result_loc;
 }
 
-static LLVMValueRef ir_render_err_wrap_code(CodeGen *g, Stage1Air *executable, IrInstGenErrWrapCode *instruction) {
+static LLVMValueRef ir_render_err_wrap_code(CodeGen *g, Stage1Air *executable, Stage1AirInstErrWrapCode *instruction) {
     ZigType *wanted_type = instruction->base.value->type;
 
     assert(wanted_type->id == ZigTypeIdErrorUnion);
@@ -6261,7 +6261,7 @@ static LLVMValueRef ir_render_err_wrap_code(CodeGen *g, Stage1Air *executable, I
     return result_loc;
 }
 
-static LLVMValueRef ir_render_err_wrap_payload(CodeGen *g, Stage1Air *executable, IrInstGenErrWrapPayload *instruction) {
+static LLVMValueRef ir_render_err_wrap_payload(CodeGen *g, Stage1Air *executable, Stage1AirInstErrWrapPayload *instruction) {
     ZigType *wanted_type = instruction->base.value->type;
 
     assert(wanted_type->id == ZigTypeIdErrorUnion);
@@ -6292,7 +6292,7 @@ static LLVMValueRef ir_render_err_wrap_payload(CodeGen *g, Stage1Air *executable
     return result_loc;
 }
 
-static LLVMValueRef ir_render_union_tag(CodeGen *g, Stage1Air *executable, IrInstGenUnionTag *instruction) {
+static LLVMValueRef ir_render_union_tag(CodeGen *g, Stage1Air *executable, Stage1AirInstUnionTag *instruction) {
     ZigType *union_type = instruction->value->value->type;
 
     ZigType *tag_type = union_type->data.unionation.tag_type;
@@ -6310,7 +6310,7 @@ static LLVMValueRef ir_render_union_tag(CodeGen *g, Stage1Air *executable, IrIns
     return get_handle_value(g, tag_field_ptr, tag_type, ptr_type);
 }
 
-static LLVMValueRef ir_render_panic(CodeGen *g, Stage1Air *executable, IrInstGenPanic *instruction) {
+static LLVMValueRef ir_render_panic(CodeGen *g, Stage1Air *executable, Stage1AirInstPanic *instruction) {
     bool is_llvm_alloca;
     LLVMValueRef err_ret_trace_val = get_cur_err_ret_trace_val(g, instruction->base.scope, &is_llvm_alloca);
     gen_panic(g, ir_llvm_value(g, instruction->msg), err_ret_trace_val, is_llvm_alloca);
@@ -6318,7 +6318,7 @@ static LLVMValueRef ir_render_panic(CodeGen *g, Stage1Air *executable, IrInstGen
 }
 
 static LLVMValueRef ir_render_atomic_rmw(CodeGen *g, Stage1Air *executable,
-        IrInstGenAtomicRmw *instruction)
+        Stage1AirInstAtomicRmw *instruction)
 {
     bool is_signed;
     ZigType *operand_type = instruction->operand->value->type;
@@ -6370,7 +6370,7 @@ static LLVMValueRef ir_render_atomic_rmw(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_atomic_load(CodeGen *g, Stage1Air *executable,
-        IrInstGenAtomicLoad *instruction)
+        Stage1AirInstAtomicLoad *instruction)
 {
     LLVMAtomicOrdering ordering = to_LLVMAtomicOrdering(instruction->ordering);
     LLVMValueRef ptr = ir_llvm_value(g, instruction->ptr);
@@ -6391,7 +6391,7 @@ static LLVMValueRef ir_render_atomic_load(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_atomic_store(CodeGen *g, Stage1Air *executable,
-        IrInstGenAtomicStore *instruction)
+        Stage1AirInstAtomicStore *instruction)
 {
     LLVMAtomicOrdering ordering = to_LLVMAtomicOrdering(instruction->ordering);
     LLVMValueRef ptr = ir_llvm_value(g, instruction->ptr);
@@ -6413,13 +6413,13 @@ static LLVMValueRef ir_render_atomic_store(CodeGen *g, Stage1Air *executable,
     return nullptr;
 }
 
-static LLVMValueRef ir_render_float_op(CodeGen *g, Stage1Air *executable, IrInstGenFloatOp *instruction) {
+static LLVMValueRef ir_render_float_op(CodeGen *g, Stage1Air *executable, Stage1AirInstFloatOp *instruction) {
     LLVMValueRef operand = ir_llvm_value(g, instruction->operand);
     LLVMValueRef fn_val = get_float_fn(g, instruction->base.value->type, ZigLLVMFnIdFloatOp, instruction->fn_id);
     return LLVMBuildCall(g->builder, fn_val, &operand, 1, "");
 }
 
-static LLVMValueRef ir_render_mul_add(CodeGen *g, Stage1Air *executable, IrInstGenMulAdd *instruction) {
+static LLVMValueRef ir_render_mul_add(CodeGen *g, Stage1Air *executable, Stage1AirInstMulAdd *instruction) {
     LLVMValueRef op1 = ir_llvm_value(g, instruction->op1);
     LLVMValueRef op2 = ir_llvm_value(g, instruction->op2);
     LLVMValueRef op3 = ir_llvm_value(g, instruction->op3);
@@ -6434,7 +6434,7 @@ static LLVMValueRef ir_render_mul_add(CodeGen *g, Stage1Air *executable, IrInstG
     return LLVMBuildCall(g->builder, fn_val, args, 3, "");
 }
 
-static LLVMValueRef ir_render_bswap(CodeGen *g, Stage1Air *executable, IrInstGenBswap *instruction) {
+static LLVMValueRef ir_render_bswap(CodeGen *g, Stage1Air *executable, Stage1AirInstBswap *instruction) {
     LLVMValueRef op = ir_llvm_value(g, instruction->op);
     ZigType *expr_type = instruction->base.value->type;
     bool is_vector = expr_type->id == ZigTypeIdVector;
@@ -6469,7 +6469,7 @@ static LLVMValueRef ir_render_bswap(CodeGen *g, Stage1Air *executable, IrInstGen
 }
 
 static LLVMValueRef ir_render_extern(CodeGen *g, Stage1Air *executable,
-        IrInstGenExtern *instruction)
+        Stage1AirInstExtern *instruction)
 {
     ZigType *expr_type = instruction->base.value->type;
     assert(get_src_ptr_type(expr_type));
@@ -6492,7 +6492,7 @@ static LLVMValueRef ir_render_extern(CodeGen *g, Stage1Air *executable,
     return LLVMBuildBitCast(g->builder, global_value, get_llvm_type(g, expr_type), "");
 }
 
-static LLVMValueRef ir_render_bit_reverse(CodeGen *g, Stage1Air *executable, IrInstGenBitReverse *instruction) {
+static LLVMValueRef ir_render_bit_reverse(CodeGen *g, Stage1Air *executable, Stage1AirInstBitReverse *instruction) {
     LLVMValueRef op = ir_llvm_value(g, instruction->op);
     ZigType *int_type = instruction->base.value->type;
     assert(int_type->id == ZigTypeIdInt);
@@ -6501,7 +6501,7 @@ static LLVMValueRef ir_render_bit_reverse(CodeGen *g, Stage1Air *executable, IrI
 }
 
 static LLVMValueRef ir_render_vector_to_array(CodeGen *g, Stage1Air *executable,
-        IrInstGenVectorToArray *instruction)
+        Stage1AirInstVectorToArray *instruction)
 {
     ZigType *array_type = instruction->base.value->type;
     assert(array_type->id == ZigTypeIdArray);
@@ -6535,7 +6535,7 @@ static LLVMValueRef ir_render_vector_to_array(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_array_to_vector(CodeGen *g, Stage1Air *executable,
-        IrInstGenArrayToVector *instruction)
+        Stage1AirInstArrayToVector *instruction)
 {
     ZigType *vector_type = instruction->base.value->type;
     assert(vector_type->id == ZigTypeIdVector);
@@ -6572,7 +6572,7 @@ static LLVMValueRef ir_render_array_to_vector(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_assert_zero(CodeGen *g, Stage1Air *executable,
-        IrInstGenAssertZero *instruction)
+        Stage1AirInstAssertZero *instruction)
 {
     LLVMValueRef target = ir_llvm_value(g, instruction->target);
     ZigType *int_type = instruction->target->value->type;
@@ -6583,7 +6583,7 @@ static LLVMValueRef ir_render_assert_zero(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_assert_non_null(CodeGen *g, Stage1Air *executable,
-        IrInstGenAssertNonNull *instruction)
+        Stage1AirInstAssertNonNull *instruction)
 {
     LLVMValueRef target = ir_llvm_value(g, instruction->target);
     ZigType *target_type = instruction->target->value->type;
@@ -6608,7 +6608,7 @@ static LLVMValueRef ir_render_assert_non_null(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_suspend_begin(CodeGen *g, Stage1Air *executable,
-        IrInstGenSuspendBegin *instruction)
+        Stage1AirInstSuspendBegin *instruction)
 {
     if (fn_is_async(g->cur_fn)) {
         instruction->resume_bb = gen_suspend_begin(g, "SuspendResume");
@@ -6617,7 +6617,7 @@ static LLVMValueRef ir_render_suspend_begin(CodeGen *g, Stage1Air *executable,
 }
 
 static LLVMValueRef ir_render_suspend_finish(CodeGen *g, Stage1Air *executable,
-        IrInstGenSuspendFinish *instruction)
+        Stage1AirInstSuspendFinish *instruction)
 {
     LLVMBuildRetVoid(g->builder);
 
@@ -6629,7 +6629,7 @@ static LLVMValueRef ir_render_suspend_finish(CodeGen *g, Stage1Air *executable,
     return nullptr;
 }
 
-static LLVMValueRef gen_await_early_return(CodeGen *g, IrInstGen *source_instr,
+static LLVMValueRef gen_await_early_return(CodeGen *g, Stage1AirInst *source_instr,
         LLVMValueRef target_frame_ptr, ZigType *result_type, ZigType *ptr_result_type,
         LLVMValueRef result_loc, bool non_async)
 {
@@ -6668,7 +6668,7 @@ static LLVMValueRef gen_await_early_return(CodeGen *g, IrInstGen *source_instr,
     }
 }
 
-static LLVMValueRef ir_render_await(CodeGen *g, Stage1Air *executable, IrInstGenAwait *instruction) {
+static LLVMValueRef ir_render_await(CodeGen *g, Stage1Air *executable, Stage1AirInstAwait *instruction) {
     LLVMTypeRef usize_type_ref = g->builtin_types.entry_usize->llvm_type;
     LLVMValueRef zero = LLVMConstNull(usize_type_ref);
     LLVMValueRef target_frame_ptr = ir_llvm_value(g, instruction->frame);
@@ -6755,7 +6755,7 @@ static LLVMValueRef ir_render_await(CodeGen *g, Stage1Air *executable, IrInstGen
     return nullptr;
 }
 
-static LLVMValueRef ir_render_resume(CodeGen *g, Stage1Air *executable, IrInstGenResume *instruction) {
+static LLVMValueRef ir_render_resume(CodeGen *g, Stage1Air *executable, Stage1AirInstResume *instruction) {
     LLVMValueRef frame = ir_llvm_value(g, instruction->frame);
     ZigType *frame_type = instruction->frame->value->type;
     assert(frame_type->id == ZigTypeIdAnyFrame);
@@ -6765,14 +6765,14 @@ static LLVMValueRef ir_render_resume(CodeGen *g, Stage1Air *executable, IrInstGe
 }
 
 static LLVMValueRef ir_render_frame_size(CodeGen *g, Stage1Air *executable,
-        IrInstGenFrameSize *instruction)
+        Stage1AirInstFrameSize *instruction)
 {
     LLVMValueRef fn_val = ir_llvm_value(g, instruction->fn);
     return gen_frame_size(g, fn_val);
 }
 
 static LLVMValueRef ir_render_spill_begin(CodeGen *g, Stage1Air *executable,
-        IrInstGenSpillBegin *instruction)
+        Stage1AirInstSpillBegin *instruction)
 {
     if (!fn_is_async(g->cur_fn))
         return nullptr;
@@ -6791,7 +6791,7 @@ static LLVMValueRef ir_render_spill_begin(CodeGen *g, Stage1Air *executable,
     zig_unreachable();
 }
 
-static LLVMValueRef ir_render_spill_end(CodeGen *g, Stage1Air *executable, IrInstGenSpillEnd *instruction) {
+static LLVMValueRef ir_render_spill_end(CodeGen *g, Stage1Air *executable, Stage1AirInstSpillEnd *instruction) {
     if (!fn_is_async(g->cur_fn))
         return ir_llvm_value(g, instruction->begin->operand);
 
@@ -6808,14 +6808,14 @@ static LLVMValueRef ir_render_spill_end(CodeGen *g, Stage1Air *executable, IrIns
 }
 
 static LLVMValueRef ir_render_vector_extract_elem(CodeGen *g, Stage1Air *executable,
-        IrInstGenVectorExtractElem *instruction)
+        Stage1AirInstVectorExtractElem *instruction)
 {
     LLVMValueRef vector = ir_llvm_value(g, instruction->vector);
     LLVMValueRef index = ir_llvm_value(g, instruction->index);
     return LLVMBuildExtractElement(g->builder, vector, index, "");
 }
 
-static void set_debug_location(CodeGen *g, IrInstGen *instruction) {
+static void set_debug_location(CodeGen *g, Stage1AirInst *instruction) {
     AstNode *source_node = instruction->source_node;
     Scope *scope = instruction->scope;
 
@@ -6826,187 +6826,187 @@ static void set_debug_location(CodeGen *g, IrInstGen *instruction) {
             node_column_onebased(source_node), get_di_scope(g, scope));
 }
 
-static LLVMValueRef ir_render_instruction(CodeGen *g, Stage1Air *executable, IrInstGen *instruction) {
+static LLVMValueRef ir_render_instruction(CodeGen *g, Stage1Air *executable, Stage1AirInst *instruction) {
     switch (instruction->id) {
-        case IrInstGenIdInvalid:
-        case IrInstGenIdConst:
-        case IrInstGenIdAlloca:
+        case Stage1AirInstIdInvalid:
+        case Stage1AirInstIdConst:
+        case Stage1AirInstIdAlloca:
             zig_unreachable();
 
-        case IrInstGenIdDeclVar:
-            return ir_render_decl_var(g, executable, (IrInstGenDeclVar *)instruction);
-        case IrInstGenIdReturn:
-            return ir_render_return(g, executable, (IrInstGenReturn *)instruction);
-        case IrInstGenIdBinOp:
-            return ir_render_bin_op(g, executable, (IrInstGenBinOp *)instruction);
-        case IrInstGenIdCast:
-            return ir_render_cast(g, executable, (IrInstGenCast *)instruction);
-        case IrInstGenIdUnreachable:
-            return ir_render_unreachable(g, executable, (IrInstGenUnreachable *)instruction);
-        case IrInstGenIdCondBr:
-            return ir_render_cond_br(g, executable, (IrInstGenCondBr *)instruction);
-        case IrInstGenIdBr:
-            return ir_render_br(g, executable, (IrInstGenBr *)instruction);
-        case IrInstGenIdBinaryNot:
-            return ir_render_binary_not(g, executable, (IrInstGenBinaryNot *)instruction);
-        case IrInstGenIdNegation:
-            return ir_render_negation(g, executable, (IrInstGenNegation *)instruction);
-        case IrInstGenIdLoadPtr:
-            return ir_render_load_ptr(g, executable, (IrInstGenLoadPtr *)instruction);
-        case IrInstGenIdStorePtr:
-            return ir_render_store_ptr(g, executable, (IrInstGenStorePtr *)instruction);
-        case IrInstGenIdVectorStoreElem:
-            return ir_render_vector_store_elem(g, executable, (IrInstGenVectorStoreElem *)instruction);
-        case IrInstGenIdVarPtr:
-            return ir_render_var_ptr(g, executable, (IrInstGenVarPtr *)instruction);
-        case IrInstGenIdReturnPtr:
-            return ir_render_return_ptr(g, executable, (IrInstGenReturnPtr *)instruction);
-        case IrInstGenIdElemPtr:
-            return ir_render_elem_ptr(g, executable, (IrInstGenElemPtr *)instruction);
-        case IrInstGenIdCall:
-            return ir_render_call(g, executable, (IrInstGenCall *)instruction);
-        case IrInstGenIdStructFieldPtr:
-            return ir_render_struct_field_ptr(g, executable, (IrInstGenStructFieldPtr *)instruction);
-        case IrInstGenIdUnionFieldPtr:
-            return ir_render_union_field_ptr(g, executable, (IrInstGenUnionFieldPtr *)instruction);
-        case IrInstGenIdAsm:
-            return ir_render_asm_gen(g, executable, (IrInstGenAsm *)instruction);
-        case IrInstGenIdTestNonNull:
-            return ir_render_test_non_null(g, executable, (IrInstGenTestNonNull *)instruction);
-        case IrInstGenIdOptionalUnwrapPtr:
-            return ir_render_optional_unwrap_ptr(g, executable, (IrInstGenOptionalUnwrapPtr *)instruction);
-        case IrInstGenIdClz:
-            return ir_render_clz(g, executable, (IrInstGenClz *)instruction);
-        case IrInstGenIdCtz:
-            return ir_render_ctz(g, executable, (IrInstGenCtz *)instruction);
-        case IrInstGenIdPopCount:
-            return ir_render_pop_count(g, executable, (IrInstGenPopCount *)instruction);
-        case IrInstGenIdSwitchBr:
-            return ir_render_switch_br(g, executable, (IrInstGenSwitchBr *)instruction);
-        case IrInstGenIdBswap:
-            return ir_render_bswap(g, executable, (IrInstGenBswap *)instruction);
-        case IrInstGenIdBitReverse:
-            return ir_render_bit_reverse(g, executable, (IrInstGenBitReverse *)instruction);
-        case IrInstGenIdPhi:
-            return ir_render_phi(g, executable, (IrInstGenPhi *)instruction);
-        case IrInstGenIdRef:
-            return ir_render_ref(g, executable, (IrInstGenRef *)instruction);
-        case IrInstGenIdErrName:
-            return ir_render_err_name(g, executable, (IrInstGenErrName *)instruction);
-        case IrInstGenIdCmpxchg:
-            return ir_render_cmpxchg(g, executable, (IrInstGenCmpxchg *)instruction);
-        case IrInstGenIdFence:
-            return ir_render_fence(g, executable, (IrInstGenFence *)instruction);
-        case IrInstGenIdReduce:
-            return ir_render_reduce(g, executable, (IrInstGenReduce *)instruction);
-        case IrInstGenIdTruncate:
-            return ir_render_truncate(g, executable, (IrInstGenTruncate *)instruction);
-        case IrInstGenIdBoolNot:
-            return ir_render_bool_not(g, executable, (IrInstGenBoolNot *)instruction);
-        case IrInstGenIdMemset:
-            return ir_render_memset(g, executable, (IrInstGenMemset *)instruction);
-        case IrInstGenIdMemcpy:
-            return ir_render_memcpy(g, executable, (IrInstGenMemcpy *)instruction);
-        case IrInstGenIdSlice:
-            return ir_render_slice(g, executable, (IrInstGenSlice *)instruction);
-        case IrInstGenIdBreakpoint:
-            return ir_render_breakpoint(g, executable, (IrInstGenBreakpoint *)instruction);
-        case IrInstGenIdReturnAddress:
-            return ir_render_return_address(g, executable, (IrInstGenReturnAddress *)instruction);
-        case IrInstGenIdFrameAddress:
-            return ir_render_frame_address(g, executable, (IrInstGenFrameAddress *)instruction);
-        case IrInstGenIdFrameHandle:
-            return ir_render_handle(g, executable, (IrInstGenFrameHandle *)instruction);
-        case IrInstGenIdOverflowOp:
-            return ir_render_overflow_op(g, executable, (IrInstGenOverflowOp *)instruction);
-        case IrInstGenIdTestErr:
-            return ir_render_test_err(g, executable, (IrInstGenTestErr *)instruction);
-        case IrInstGenIdUnwrapErrCode:
-            return ir_render_unwrap_err_code(g, executable, (IrInstGenUnwrapErrCode *)instruction);
-        case IrInstGenIdUnwrapErrPayload:
-            return ir_render_unwrap_err_payload(g, executable, (IrInstGenUnwrapErrPayload *)instruction);
-        case IrInstGenIdOptionalWrap:
-            return ir_render_optional_wrap(g, executable, (IrInstGenOptionalWrap *)instruction);
-        case IrInstGenIdErrWrapCode:
-            return ir_render_err_wrap_code(g, executable, (IrInstGenErrWrapCode *)instruction);
-        case IrInstGenIdErrWrapPayload:
-            return ir_render_err_wrap_payload(g, executable, (IrInstGenErrWrapPayload *)instruction);
-        case IrInstGenIdUnionTag:
-            return ir_render_union_tag(g, executable, (IrInstGenUnionTag *)instruction);
-        case IrInstGenIdPtrCast:
-            return ir_render_ptr_cast(g, executable, (IrInstGenPtrCast *)instruction);
-        case IrInstGenIdBitCast:
-            return ir_render_bit_cast(g, executable, (IrInstGenBitCast *)instruction);
-        case IrInstGenIdWidenOrShorten:
-            return ir_render_widen_or_shorten(g, executable, (IrInstGenWidenOrShorten *)instruction);
-        case IrInstGenIdPtrToInt:
-            return ir_render_ptr_to_int(g, executable, (IrInstGenPtrToInt *)instruction);
-        case IrInstGenIdIntToPtr:
-            return ir_render_int_to_ptr(g, executable, (IrInstGenIntToPtr *)instruction);
-        case IrInstGenIdIntToEnum:
-            return ir_render_int_to_enum(g, executable, (IrInstGenIntToEnum *)instruction);
-        case IrInstGenIdIntToErr:
-            return ir_render_int_to_err(g, executable, (IrInstGenIntToErr *)instruction);
-        case IrInstGenIdErrToInt:
-            return ir_render_err_to_int(g, executable, (IrInstGenErrToInt *)instruction);
-        case IrInstGenIdPanic:
-            return ir_render_panic(g, executable, (IrInstGenPanic *)instruction);
-        case IrInstGenIdTagName:
-            return ir_render_enum_tag_name(g, executable, (IrInstGenTagName *)instruction);
-        case IrInstGenIdFieldParentPtr:
-            return ir_render_field_parent_ptr(g, executable, (IrInstGenFieldParentPtr *)instruction);
-        case IrInstGenIdAlignCast:
-            return ir_render_align_cast(g, executable, (IrInstGenAlignCast *)instruction);
-        case IrInstGenIdErrorReturnTrace:
-            return ir_render_error_return_trace(g, executable, (IrInstGenErrorReturnTrace *)instruction);
-        case IrInstGenIdAtomicRmw:
-            return ir_render_atomic_rmw(g, executable, (IrInstGenAtomicRmw *)instruction);
-        case IrInstGenIdAtomicLoad:
-            return ir_render_atomic_load(g, executable, (IrInstGenAtomicLoad *)instruction);
-        case IrInstGenIdAtomicStore:
-            return ir_render_atomic_store(g, executable, (IrInstGenAtomicStore *)instruction);
-        case IrInstGenIdSaveErrRetAddr:
-            return ir_render_save_err_ret_addr(g, executable, (IrInstGenSaveErrRetAddr *)instruction);
-        case IrInstGenIdFloatOp:
-            return ir_render_float_op(g, executable, (IrInstGenFloatOp *)instruction);
-        case IrInstGenIdMulAdd:
-            return ir_render_mul_add(g, executable, (IrInstGenMulAdd *)instruction);
-        case IrInstGenIdArrayToVector:
-            return ir_render_array_to_vector(g, executable, (IrInstGenArrayToVector *)instruction);
-        case IrInstGenIdVectorToArray:
-            return ir_render_vector_to_array(g, executable, (IrInstGenVectorToArray *)instruction);
-        case IrInstGenIdAssertZero:
-            return ir_render_assert_zero(g, executable, (IrInstGenAssertZero *)instruction);
-        case IrInstGenIdAssertNonNull:
-            return ir_render_assert_non_null(g, executable, (IrInstGenAssertNonNull *)instruction);
-        case IrInstGenIdPtrOfArrayToSlice:
-            return ir_render_ptr_of_array_to_slice(g, executable, (IrInstGenPtrOfArrayToSlice *)instruction);
-        case IrInstGenIdSuspendBegin:
-            return ir_render_suspend_begin(g, executable, (IrInstGenSuspendBegin *)instruction);
-        case IrInstGenIdSuspendFinish:
-            return ir_render_suspend_finish(g, executable, (IrInstGenSuspendFinish *)instruction);
-        case IrInstGenIdResume:
-            return ir_render_resume(g, executable, (IrInstGenResume *)instruction);
-        case IrInstGenIdFrameSize:
-            return ir_render_frame_size(g, executable, (IrInstGenFrameSize *)instruction);
-        case IrInstGenIdAwait:
-            return ir_render_await(g, executable, (IrInstGenAwait *)instruction);
-        case IrInstGenIdSpillBegin:
-            return ir_render_spill_begin(g, executable, (IrInstGenSpillBegin *)instruction);
-        case IrInstGenIdSpillEnd:
-            return ir_render_spill_end(g, executable, (IrInstGenSpillEnd *)instruction);
-        case IrInstGenIdShuffleVector:
-            return ir_render_shuffle_vector(g, executable, (IrInstGenShuffleVector *) instruction);
-        case IrInstGenIdSplat:
-            return ir_render_splat(g, executable, (IrInstGenSplat *) instruction);
-        case IrInstGenIdVectorExtractElem:
-            return ir_render_vector_extract_elem(g, executable, (IrInstGenVectorExtractElem *) instruction);
-        case IrInstGenIdWasmMemorySize:
-            return ir_render_wasm_memory_size(g, executable, (IrInstGenWasmMemorySize *) instruction);
-        case IrInstGenIdWasmMemoryGrow:
-            return ir_render_wasm_memory_grow(g, executable, (IrInstGenWasmMemoryGrow *) instruction);
-        case IrInstGenIdExtern:
-            return ir_render_extern(g, executable, (IrInstGenExtern *) instruction);
+        case Stage1AirInstIdDeclVar:
+            return ir_render_decl_var(g, executable, (Stage1AirInstDeclVar *)instruction);
+        case Stage1AirInstIdReturn:
+            return ir_render_return(g, executable, (Stage1AirInstReturn *)instruction);
+        case Stage1AirInstIdBinOp:
+            return ir_render_bin_op(g, executable, (Stage1AirInstBinOp *)instruction);
+        case Stage1AirInstIdCast:
+            return ir_render_cast(g, executable, (Stage1AirInstCast *)instruction);
+        case Stage1AirInstIdUnreachable:
+            return ir_render_unreachable(g, executable, (Stage1AirInstUnreachable *)instruction);
+        case Stage1AirInstIdCondBr:
+            return ir_render_cond_br(g, executable, (Stage1AirInstCondBr *)instruction);
+        case Stage1AirInstIdBr:
+            return ir_render_br(g, executable, (Stage1AirInstBr *)instruction);
+        case Stage1AirInstIdBinaryNot:
+            return ir_render_binary_not(g, executable, (Stage1AirInstBinaryNot *)instruction);
+        case Stage1AirInstIdNegation:
+            return ir_render_negation(g, executable, (Stage1AirInstNegation *)instruction);
+        case Stage1AirInstIdLoadPtr:
+            return ir_render_load_ptr(g, executable, (Stage1AirInstLoadPtr *)instruction);
+        case Stage1AirInstIdStorePtr:
+            return ir_render_store_ptr(g, executable, (Stage1AirInstStorePtr *)instruction);
+        case Stage1AirInstIdVectorStoreElem:
+            return ir_render_vector_store_elem(g, executable, (Stage1AirInstVectorStoreElem *)instruction);
+        case Stage1AirInstIdVarPtr:
+            return ir_render_var_ptr(g, executable, (Stage1AirInstVarPtr *)instruction);
+        case Stage1AirInstIdReturnPtr:
+            return ir_render_return_ptr(g, executable, (Stage1AirInstReturnPtr *)instruction);
+        case Stage1AirInstIdElemPtr:
+            return ir_render_elem_ptr(g, executable, (Stage1AirInstElemPtr *)instruction);
+        case Stage1AirInstIdCall:
+            return ir_render_call(g, executable, (Stage1AirInstCall *)instruction);
+        case Stage1AirInstIdStructFieldPtr:
+            return ir_render_struct_field_ptr(g, executable, (Stage1AirInstStructFieldPtr *)instruction);
+        case Stage1AirInstIdUnionFieldPtr:
+            return ir_render_union_field_ptr(g, executable, (Stage1AirInstUnionFieldPtr *)instruction);
+        case Stage1AirInstIdAsm:
+            return ir_render_asm_gen(g, executable, (Stage1AirInstAsm *)instruction);
+        case Stage1AirInstIdTestNonNull:
+            return ir_render_test_non_null(g, executable, (Stage1AirInstTestNonNull *)instruction);
+        case Stage1AirInstIdOptionalUnwrapPtr:
+            return ir_render_optional_unwrap_ptr(g, executable, (Stage1AirInstOptionalUnwrapPtr *)instruction);
+        case Stage1AirInstIdClz:
+            return ir_render_clz(g, executable, (Stage1AirInstClz *)instruction);
+        case Stage1AirInstIdCtz:
+            return ir_render_ctz(g, executable, (Stage1AirInstCtz *)instruction);
+        case Stage1AirInstIdPopCount:
+            return ir_render_pop_count(g, executable, (Stage1AirInstPopCount *)instruction);
+        case Stage1AirInstIdSwitchBr:
+            return ir_render_switch_br(g, executable, (Stage1AirInstSwitchBr *)instruction);
+        case Stage1AirInstIdBswap:
+            return ir_render_bswap(g, executable, (Stage1AirInstBswap *)instruction);
+        case Stage1AirInstIdBitReverse:
+            return ir_render_bit_reverse(g, executable, (Stage1AirInstBitReverse *)instruction);
+        case Stage1AirInstIdPhi:
+            return ir_render_phi(g, executable, (Stage1AirInstPhi *)instruction);
+        case Stage1AirInstIdRef:
+            return ir_render_ref(g, executable, (Stage1AirInstRef *)instruction);
+        case Stage1AirInstIdErrName:
+            return ir_render_err_name(g, executable, (Stage1AirInstErrName *)instruction);
+        case Stage1AirInstIdCmpxchg:
+            return ir_render_cmpxchg(g, executable, (Stage1AirInstCmpxchg *)instruction);
+        case Stage1AirInstIdFence:
+            return ir_render_fence(g, executable, (Stage1AirInstFence *)instruction);
+        case Stage1AirInstIdReduce:
+            return ir_render_reduce(g, executable, (Stage1AirInstReduce *)instruction);
+        case Stage1AirInstIdTruncate:
+            return ir_render_truncate(g, executable, (Stage1AirInstTruncate *)instruction);
+        case Stage1AirInstIdBoolNot:
+            return ir_render_bool_not(g, executable, (Stage1AirInstBoolNot *)instruction);
+        case Stage1AirInstIdMemset:
+            return ir_render_memset(g, executable, (Stage1AirInstMemset *)instruction);
+        case Stage1AirInstIdMemcpy:
+            return ir_render_memcpy(g, executable, (Stage1AirInstMemcpy *)instruction);
+        case Stage1AirInstIdSlice:
+            return ir_render_slice(g, executable, (Stage1AirInstSlice *)instruction);
+        case Stage1AirInstIdBreakpoint:
+            return ir_render_breakpoint(g, executable, (Stage1AirInstBreakpoint *)instruction);
+        case Stage1AirInstIdReturnAddress:
+            return ir_render_return_address(g, executable, (Stage1AirInstReturnAddress *)instruction);
+        case Stage1AirInstIdFrameAddress:
+            return ir_render_frame_address(g, executable, (Stage1AirInstFrameAddress *)instruction);
+        case Stage1AirInstIdFrameHandle:
+            return ir_render_handle(g, executable, (Stage1AirInstFrameHandle *)instruction);
+        case Stage1AirInstIdOverflowOp:
+            return ir_render_overflow_op(g, executable, (Stage1AirInstOverflowOp *)instruction);
+        case Stage1AirInstIdTestErr:
+            return ir_render_test_err(g, executable, (Stage1AirInstTestErr *)instruction);
+        case Stage1AirInstIdUnwrapErrCode:
+            return ir_render_unwrap_err_code(g, executable, (Stage1AirInstUnwrapErrCode *)instruction);
+        case Stage1AirInstIdUnwrapErrPayload:
+            return ir_render_unwrap_err_payload(g, executable, (Stage1AirInstUnwrapErrPayload *)instruction);
+        case Stage1AirInstIdOptionalWrap:
+            return ir_render_optional_wrap(g, executable, (Stage1AirInstOptionalWrap *)instruction);
+        case Stage1AirInstIdErrWrapCode:
+            return ir_render_err_wrap_code(g, executable, (Stage1AirInstErrWrapCode *)instruction);
+        case Stage1AirInstIdErrWrapPayload:
+            return ir_render_err_wrap_payload(g, executable, (Stage1AirInstErrWrapPayload *)instruction);
+        case Stage1AirInstIdUnionTag:
+            return ir_render_union_tag(g, executable, (Stage1AirInstUnionTag *)instruction);
+        case Stage1AirInstIdPtrCast:
+            return ir_render_ptr_cast(g, executable, (Stage1AirInstPtrCast *)instruction);
+        case Stage1AirInstIdBitCast:
+            return ir_render_bit_cast(g, executable, (Stage1AirInstBitCast *)instruction);
+        case Stage1AirInstIdWidenOrShorten:
+            return ir_render_widen_or_shorten(g, executable, (Stage1AirInstWidenOrShorten *)instruction);
+        case Stage1AirInstIdPtrToInt:
+            return ir_render_ptr_to_int(g, executable, (Stage1AirInstPtrToInt *)instruction);
+        case Stage1AirInstIdIntToPtr:
+            return ir_render_int_to_ptr(g, executable, (Stage1AirInstIntToPtr *)instruction);
+        case Stage1AirInstIdIntToEnum:
+            return ir_render_int_to_enum(g, executable, (Stage1AirInstIntToEnum *)instruction);
+        case Stage1AirInstIdIntToErr:
+            return ir_render_int_to_err(g, executable, (Stage1AirInstIntToErr *)instruction);
+        case Stage1AirInstIdErrToInt:
+            return ir_render_err_to_int(g, executable, (Stage1AirInstErrToInt *)instruction);
+        case Stage1AirInstIdPanic:
+            return ir_render_panic(g, executable, (Stage1AirInstPanic *)instruction);
+        case Stage1AirInstIdTagName:
+            return ir_render_enum_tag_name(g, executable, (Stage1AirInstTagName *)instruction);
+        case Stage1AirInstIdFieldParentPtr:
+            return ir_render_field_parent_ptr(g, executable, (Stage1AirInstFieldParentPtr *)instruction);
+        case Stage1AirInstIdAlignCast:
+            return ir_render_align_cast(g, executable, (Stage1AirInstAlignCast *)instruction);
+        case Stage1AirInstIdErrorReturnTrace:
+            return ir_render_error_return_trace(g, executable, (Stage1AirInstErrorReturnTrace *)instruction);
+        case Stage1AirInstIdAtomicRmw:
+            return ir_render_atomic_rmw(g, executable, (Stage1AirInstAtomicRmw *)instruction);
+        case Stage1AirInstIdAtomicLoad:
+            return ir_render_atomic_load(g, executable, (Stage1AirInstAtomicLoad *)instruction);
+        case Stage1AirInstIdAtomicStore:
+            return ir_render_atomic_store(g, executable, (Stage1AirInstAtomicStore *)instruction);
+        case Stage1AirInstIdSaveErrRetAddr:
+            return ir_render_save_err_ret_addr(g, executable, (Stage1AirInstSaveErrRetAddr *)instruction);
+        case Stage1AirInstIdFloatOp:
+            return ir_render_float_op(g, executable, (Stage1AirInstFloatOp *)instruction);
+        case Stage1AirInstIdMulAdd:
+            return ir_render_mul_add(g, executable, (Stage1AirInstMulAdd *)instruction);
+        case Stage1AirInstIdArrayToVector:
+            return ir_render_array_to_vector(g, executable, (Stage1AirInstArrayToVector *)instruction);
+        case Stage1AirInstIdVectorToArray:
+            return ir_render_vector_to_array(g, executable, (Stage1AirInstVectorToArray *)instruction);
+        case Stage1AirInstIdAssertZero:
+            return ir_render_assert_zero(g, executable, (Stage1AirInstAssertZero *)instruction);
+        case Stage1AirInstIdAssertNonNull:
+            return ir_render_assert_non_null(g, executable, (Stage1AirInstAssertNonNull *)instruction);
+        case Stage1AirInstIdPtrOfArrayToSlice:
+            return ir_render_ptr_of_array_to_slice(g, executable, (Stage1AirInstPtrOfArrayToSlice *)instruction);
+        case Stage1AirInstIdSuspendBegin:
+            return ir_render_suspend_begin(g, executable, (Stage1AirInstSuspendBegin *)instruction);
+        case Stage1AirInstIdSuspendFinish:
+            return ir_render_suspend_finish(g, executable, (Stage1AirInstSuspendFinish *)instruction);
+        case Stage1AirInstIdResume:
+            return ir_render_resume(g, executable, (Stage1AirInstResume *)instruction);
+        case Stage1AirInstIdFrameSize:
+            return ir_render_frame_size(g, executable, (Stage1AirInstFrameSize *)instruction);
+        case Stage1AirInstIdAwait:
+            return ir_render_await(g, executable, (Stage1AirInstAwait *)instruction);
+        case Stage1AirInstIdSpillBegin:
+            return ir_render_spill_begin(g, executable, (Stage1AirInstSpillBegin *)instruction);
+        case Stage1AirInstIdSpillEnd:
+            return ir_render_spill_end(g, executable, (Stage1AirInstSpillEnd *)instruction);
+        case Stage1AirInstIdShuffleVector:
+            return ir_render_shuffle_vector(g, executable, (Stage1AirInstShuffleVector *) instruction);
+        case Stage1AirInstIdSplat:
+            return ir_render_splat(g, executable, (Stage1AirInstSplat *) instruction);
+        case Stage1AirInstIdVectorExtractElem:
+            return ir_render_vector_extract_elem(g, executable, (Stage1AirInstVectorExtractElem *) instruction);
+        case Stage1AirInstIdWasmMemorySize:
+            return ir_render_wasm_memory_size(g, executable, (Stage1AirInstWasmMemorySize *) instruction);
+        case Stage1AirInstIdWasmMemoryGrow:
+            return ir_render_wasm_memory_grow(g, executable, (Stage1AirInstWasmMemoryGrow *) instruction);
+        case Stage1AirInstIdExtern:
+            return ir_render_extern(g, executable, (Stage1AirInstExtern *) instruction);
     }
     zig_unreachable();
 }
@@ -7018,14 +7018,14 @@ static void ir_render(CodeGen *g, ZigFn *fn_entry) {
     assert(executable->basic_block_list.length > 0);
 
     for (size_t block_i = 0; block_i < executable->basic_block_list.length; block_i += 1) {
-        IrBasicBlockGen *current_block = executable->basic_block_list.at(block_i);
+        Stage1AirBasicBlock *current_block = executable->basic_block_list.at(block_i);
         if (get_scope_typeof(current_block->scope) != nullptr) {
             LLVMBuildBr(g->builder, current_block->llvm_block);
         }
         assert(current_block->llvm_block);
         LLVMPositionBuilderAtEnd(g->builder, current_block->llvm_block);
         for (size_t instr_i = 0; instr_i < current_block->instruction_list.length; instr_i += 1) {
-            IrInstGen *instruction = current_block->instruction_list.at(instr_i);
+            Stage1AirInst *instruction = current_block->instruction_list.at(instr_i);
             if (instruction->ref_count == 0 && !ir_inst_gen_has_side_effects(instruction))
                 continue;
             if (get_scope_typeof(instruction->scope) != nullptr)
@@ -8021,7 +8021,7 @@ static void build_all_basic_blocks(CodeGen *g, ZigFn *fn) {
         g->cur_preamble_llvm_block = first_bb;
     }
     for (size_t block_i = 0; block_i < executable->basic_block_list.length; block_i += 1) {
-        IrBasicBlockGen *bb = executable->basic_block_list.at(block_i);
+        Stage1AirBasicBlock *bb = executable->basic_block_list.at(block_i);
         bb->llvm_block = LLVMAppendBasicBlock(fn_val, bb->name_hint);
     }
     if (first_bb == nullptr) {
@@ -8243,10 +8243,10 @@ static void do_code_gen(CodeGen *g) {
         if (!is_async) {
             // allocate async frames for nosuspend calls & awaits to async functions
             ZigType *largest_call_frame_type = nullptr;
-            IrInstGen *all_calls_alloca = ir_create_alloca(g, &fn_table_entry->fndef_scope->base,
+            Stage1AirInst *all_calls_alloca = ir_create_alloca(g, &fn_table_entry->fndef_scope->base,
                     fn_table_entry->body_node, fn_table_entry, g->builtin_types.entry_void, "@async_call_frame");
             for (size_t i = 0; i < fn_table_entry->call_list.length; i += 1) {
-                IrInstGenCall *call = fn_table_entry->call_list.at(i);
+                Stage1AirInstCall *call = fn_table_entry->call_list.at(i);
                 if (call->fn_entry == nullptr)
                     continue;
                 if (!fn_is_async(call->fn_entry))
@@ -8268,7 +8268,7 @@ static void do_code_gen(CodeGen *g) {
             }
             // allocate temporary stack data
             for (size_t alloca_i = 0; alloca_i < fn_table_entry->alloca_gen_list.length; alloca_i += 1) {
-                IrInstGenAlloca *instruction = fn_table_entry->alloca_gen_list.at(alloca_i);
+                Stage1AirInstAlloca *instruction = fn_table_entry->alloca_gen_list.at(alloca_i);
                 ZigType *ptr_type = instruction->base.value->type;
                 assert(ptr_type->id == ZigTypeIdPointer);
                 ZigType *child_type = ptr_type->data.pointer.child_type;
@@ -8422,7 +8422,7 @@ static void do_code_gen(CodeGen *g) {
             g->cur_async_switch_instr = switch_instr;
 
             LLVMValueRef zero = LLVMConstNull(usize_type_ref);
-            IrBasicBlockGen *entry_block = executable->basic_block_list.at(0);
+            Stage1AirBasicBlock *entry_block = executable->basic_block_list.at(0);
             LLVMAddCase(switch_instr, zero, entry_block->llvm_block);
             g->cur_resume_block_count += 1;
 
@@ -9379,7 +9379,7 @@ static void init(CodeGen *g) {
     define_builtin_types(g);
     define_intern_values(g);
 
-    IrInstGen *sentinel_instructions = heap::c_allocator.allocate<IrInstGen>(2);
+    Stage1AirInst *sentinel_instructions = heap::c_allocator.allocate<Stage1AirInst>(2);
     g->invalid_inst_gen = &sentinel_instructions[0];
     g->invalid_inst_gen->value = g->pass1_arena->create<ZigValue>();
     g->invalid_inst_gen->value->type = g->builtin_types.entry_invalid;
@@ -9388,7 +9388,7 @@ static void init(CodeGen *g) {
     g->unreach_instruction->value = g->pass1_arena->create<ZigValue>();
     g->unreach_instruction->value->type = g->builtin_types.entry_unreachable;
 
-    g->invalid_inst_src = heap::c_allocator.create<IrInstSrc>();
+    g->invalid_inst_src = heap::c_allocator.create<Stage1ZirInst>();
 
     define_builtin_fns(g);
     Error err;

--- a/src/stage1/ir.hpp
+++ b/src/stage1/ir.hpp
@@ -10,7 +10,7 @@
 
 #include "all_types.hpp"
 
-IrInstGen *ir_create_alloca(CodeGen *g, Scope *scope, AstNode *source_node, ZigFn *fn,
+Stage1AirInst *ir_create_alloca(CodeGen *g, Scope *scope, AstNode *source_node, ZigFn *fn,
         ZigType *var_type, const char *name_hint);
 
 Error ir_eval_const_value(CodeGen *codegen, Scope *scope, AstNode *node,
@@ -25,7 +25,7 @@ ZigType *ir_analyze(CodeGen *codegen, Stage1Zir *stage1_zir, Stage1Air *stage1_a
         ZigType *expected_type, AstNode *expected_type_source_node, ZigValue *result_ptr,
         ZigFn *fn);
 
-bool ir_inst_gen_has_side_effects(IrInstGen *inst);
+bool ir_inst_gen_has_side_effects(Stage1AirInst *inst);
 
 struct IrAnalyze;
 ZigValue *const_ptr_pointee(IrAnalyze *ira, CodeGen *codegen, ZigValue *const_val,

--- a/src/stage1/ir_print.hpp
+++ b/src/stage1/ir_print.hpp
@@ -14,12 +14,12 @@
 
 void ir_print_src(CodeGen *codegen, FILE *f, Stage1Zir *executable, int indent_size);
 void ir_print_gen(CodeGen *codegen, FILE *f, Stage1Air *executable, int indent_size);
-void ir_print_inst_src(CodeGen *codegen, FILE *f, IrInstSrc *inst, int indent_size);
-void ir_print_inst_gen(CodeGen *codegen, FILE *f, IrInstGen *inst, int indent_size);
+void ir_print_inst_src(CodeGen *codegen, FILE *f, Stage1ZirInst *inst, int indent_size);
+void ir_print_inst_gen(CodeGen *codegen, FILE *f, Stage1AirInst *inst, int indent_size);
 void ir_print_basic_block_src(CodeGen *codegen, FILE *f, Stage1ZirBasicBlock *bb, int indent_size);
-void ir_print_basic_block_gen(CodeGen *codegen, FILE *f, IrBasicBlockGen *bb, int indent_size);
+void ir_print_basic_block_gen(CodeGen *codegen, FILE *f, Stage1AirBasicBlock *bb, int indent_size);
 
-const char* ir_inst_src_type_str(IrInstSrcId id);
-const char* ir_inst_gen_type_str(IrInstGenId id);
+const char* ir_inst_src_type_str(Stage1ZirInstId id);
+const char* ir_inst_gen_type_str(Stage1AirInstId id);
 
 #endif


### PR DESCRIPTION
In preparation for a major refactor of the memory layout, this initial PR changes the names of the IR instructions in stage 1 to better match stage 2.  There are no behavioral changes in this PR, only name changes.