### PR TITLE
Re-Adding baseline option for build.zig in stdlib

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2555,6 +2555,12 @@ pub const LibExeObjStep = struct {
                 if (cross.cpu.model != std.Target.Cpu.baseline(cross.cpu.arch).model) {
                     try zig_args.append("-mcpu");
                     try zig_args.append(cross.cpu.model.name);
+                } else {
+                    // baseline must be passed for a compilation for binray compatible
+                    // ie: the compiling plateform may have more CPU features than target
+                    // use then baseline
+                    try zig_args.append("-mcpu");
+                    try zig_args.append("baseline");
                 }
             } else {
                 var mcpu_buffer = std.ArrayList(u8).init(builder.allocator);


### PR DESCRIPTION

I've been struggled, but with @ifreund 's lights and help, it seems properly identify , and a fix is proposed. 
discovered on 0.8.0, but still present on master.

This fix, re-add the baseline mcpu option for stdlib/build, permitting to remove the CPU feature for backward CPU compatibility.
When, the -Dtarget and -Dcpu is passed, and cpu parameter is equals to `baseline`, the option is not properly passed to the zig build-exe.

As a consequence, the binary generated cannot be used on older CPU than the build plateform, zig, and llvm compile it with all the cpu features of the **build plateform** (not backward compatible if the build plateform is newer than the other arch CPU targeted).

to reproduce
- add thoses lines in the project's build.zig
    const target = b.standardTargetOptions(.{    });
    exe.setTarget(target);

- build the project using 

```
use@alexa:~/iotmonitor$ zig build -Dcpu=baseline -Dtarget=native-native-gnu --verbose
```

verbose result : 
```
/home/use/zig/build/zig build-exe /home/use/iotmonitor/iotmonitor.zig -lc /home/use/iotmonitor/paho.mqtt.c/src/libpaho-mqtt3c.a -lleveldb --cache-dir /home/use/iotmonitor/zig-cache --global-cache-dir /home/use/.cache/zig --name iotmonitor **-target native-native-gnu** --pkg-begin toml /home/use/iotmonitor/zig-toml/src/toml.zig --pkg-end --pkg-begin routez /home/use/iotmonitor/routez/src/routez.zig --pkg-begin zuri /home/use/iotmonitor/routez/zuri/src/zuri.zig --pkg-end --pkg-end --pkg-begin tracy /home/use/iotmonitor/nozig-tracy/src/lib.zig --pkg-end -L paho.mqtt.c/build/output -L paho.mqtt.c/src --enable-cache 
```

the target option is passed BUT not the `-mcpu=` option needed to reset the natively detected CPU Features, is missing
this pull request re-add the baseline option. 
The binary generated is now compatible with lower CPU features, when using zig build



