### PR TITLE
linux: add mknod and mknodat syscalls

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -253,6 +253,18 @@ pub fn mkdirat(dirfd: i32, path: [*:0]const u8, mode: u32) usize {
     return syscall3(.mkdirat, @bitCast(usize, @as(isize, dirfd)), @ptrToInt(path), mode);
 }
 
+pub fn mknod(path: [*:0]const u8, mode: u32, dev: u32) usize {
+    if (@hasField(SYS, "mknod")) {
+        return syscall3(.mknod, @ptrToInt(path), mode, dev);
+    } else {
+        return mknodat(AT_FDCWD, path, mode, dev);
+    }
+}
+
+pub fn mknodat(dirfd: i32, path: [*:0]const u8, mode: u32, dev: u32) usize {
+    return syscall4(.mknodat, @bitCast(usize, @as(isize, dirfd)), @ptrToInt(path), mode, dev);
+}
+
 pub fn mount(special: [*:0]const u8, dir: [*:0]const u8, fstype: [*:0]const u8, flags: u32, data: usize) usize {
     return syscall5(.mount, @ptrToInt(special), @ptrToInt(dir), @ptrToInt(fstype), flags, data);
 }


### PR DESCRIPTION
mknod and mknodat are used among other things to create named pipes (FIFOs) on Linux.

I used the same type `u32` for the `mode` parameter as the mkdir and mkdirat syscalls, although that parameter should be a `u16` as seen here: https://elixir.bootlin.com/linux/v5.13/source/include/linux/types.h#L19 which is the type used in the syscall https://elixir.bootlin.com/linux/v5.13/source/fs/namei.c#L3767
Any reasons it’s a `u32` here?