### PR TITLE
Add inotify_rm_watch definition to c/linux.zig

### DIFF
--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -94,7 +94,8 @@ pub extern "c" fn epoll_pwait(
     sigmask: *const sigset_t,
 ) c_int;
 pub extern "c" fn inotify_init1(flags: c_uint) c_int;
-pub extern "c" fn inotify_add_watch(fd: fd_t, pathname: [*]const u8, mask: u32) c_int;
+pub extern "c" fn inotify_add_watch(fd: fd_t, pathname: [*:0]const u8, mask: u32) c_int;
+pub extern "c" fn inotify_rm_watch(fd: fd_t, wd: c_int) c_int;
 
 /// See std.elf for constants for this
 pub extern "c" fn getauxval(__type: c_ulong) c_ulong;


### PR DESCRIPTION
Also make inotify_add_watch's pathname marked as nul-terminated

Fixes inotify_rm_watch when linking against libc. Before:

```
lib/zig/std/os.zig:3699:25: error: container 'std.c' has no member called 'inotify_rm_watch'
```