### PR TITLE
Add NotDir as possible error for os.inotify_add_watch

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3667,6 +3667,7 @@ pub const INotifyAddWatchError = error{
     FileNotFound,
     SystemResources,
     UserResourceLimitReached,
+    NotDir,
 } || UnexpectedError;
 
 /// add a watch to an initialized inotify instance
@@ -3690,6 +3691,7 @@ pub fn inotify_add_watchZ(inotify_fd: i32, pathname: [*:0]const u8, mask: u32) I
         ENOENT => return error.FileNotFound,
         ENOMEM => return error.SystemResources,
         ENOSPC => return error.UserResourceLimitReached,
+        ENOTDIR => return error.NotDir,
         else => |err| return unexpectedErrno(err),
     }
 }


### PR DESCRIPTION
Possible when "mask contains IN_ONLYDIR and pathname is not a directory."

https://man7.org/linux/man-pages/man2/inotify_add_watch.2.html