### PR TITLE
Remove/replace std.Target.current and std.builtin deprecated fields with @import("builtin") fields.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = std.builtin;
 const Builder = std.build.Builder;
 const tests = @import("test/tests.zig");
 const BufMap = std.BufMap;
@@ -263,22 +262,22 @@ pub fn build(b: *Builder) !void {
         toolchain_step.dependOn(test_stage2_step);
     }
 
-    var chosen_modes: [4]builtin.Mode = undefined;
+    var chosen_modes: [4]std.builtin.Mode = undefined;
     var chosen_mode_index: usize = 0;
     if (!skip_debug) {
-        chosen_modes[chosen_mode_index] = builtin.Mode.Debug;
+        chosen_modes[chosen_mode_index] = std.builtin.Mode.Debug;
         chosen_mode_index += 1;
     }
     if (!skip_release_safe) {
-        chosen_modes[chosen_mode_index] = builtin.Mode.ReleaseSafe;
+        chosen_modes[chosen_mode_index] = std.builtin.Mode.ReleaseSafe;
         chosen_mode_index += 1;
     }
     if (!skip_release_fast) {
-        chosen_modes[chosen_mode_index] = builtin.Mode.ReleaseFast;
+        chosen_modes[chosen_mode_index] = std.builtin.Mode.ReleaseFast;
         chosen_mode_index += 1;
     }
     if (!skip_release_small) {
-        chosen_modes[chosen_mode_index] = builtin.Mode.ReleaseSmall;
+        chosen_modes[chosen_mode_index] = std.builtin.Mode.ReleaseSmall;
         chosen_mode_index += 1;
     }
     const modes = chosen_modes[0..chosen_mode_index];

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const io = std.io;
 const fs = std.fs;
 const process = std.process;
@@ -281,7 +281,7 @@ const Code = struct {
     name: []const u8,
     source_token: Token,
     is_inline: bool,
-    mode: builtin.Mode,
+    mode: std.builtin.Mode,
     link_objects: []const []const u8,
     target_str: ?[]const u8,
     link_libc: bool,
@@ -531,7 +531,7 @@ fn genToc(allocator: *Allocator, tokenizer: *Tokenizer) !Toc {
                         return parseError(tokenizer, code_kind_tok, "unrecognized code kind: {s}", .{code_kind_str});
                     }
 
-                    var mode: builtin.Mode = .Debug;
+                    var mode: std.builtin.Mode = .Debug;
                     var link_objects = std.ArrayList([]const u8).init(allocator);
                     defer link_objects.deinit();
                     var target_str: ?[]const u8 = null;
@@ -1191,7 +1191,7 @@ fn genHtml(
                             if (mem.startsWith(u8, triple, "wasm32") or
                                 mem.startsWith(u8, triple, "riscv64-linux") or
                                 (mem.startsWith(u8, triple, "x86_64-linux") and
-                                std.Target.current.os.tag != .linux or std.Target.current.cpu.arch != .x86_64))
+                                builtin.os.tag != .linux or builtin.cpu.arch != .x86_64))
                             {
                                 // skip execution
                                 try out.print("</code></pre>\n", .{});
@@ -1467,7 +1467,7 @@ fn genHtml(
                     Code.Id.Lib => {
                         const bin_basename = try std.zig.binNameAlloc(allocator, .{
                             .root_name = code.name,
-                            .target = std.Target.current,
+                            .target = builtin.target,
                             .output_mode = .Lib,
                         });
 

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2299,7 +2299,7 @@ test "variable alignment" {
     const align_of_i32 = @alignOf(@TypeOf(x));
     try expect(@TypeOf(&x) == *i32);
     try expect(*i32 == *align(align_of_i32) i32);
-    if (std.Target.current.cpu.arch == .x86_64) {
+    if (@import("builtin").cpu.arch == .x86_64) {
         try expect(@typeInfo(*i32).Pointer.alignment == 4);
     }
 }
@@ -3529,7 +3529,7 @@ test "switch simple" {
 }
 
 // Switch expressions can be used outside a function:
-const os_msg = switch (std.Target.current.os.tag) {
+const os_msg = switch (@import("builtin").os.tag) {
     .linux => "we found a linux user",
     else => "not a linux user",
 };
@@ -3537,7 +3537,7 @@ const os_msg = switch (std.Target.current.os.tag) {
 // Inside a function, switch statements implicitly are compile-time
 // evaluated if the target expression is compile-time known.
 test "switch inside function" {
-    switch (std.Target.current.os.tag) {
+    switch (@import("builtin").os.tag) {
         .fuchsia => {
             // On an OS other than fuchsia, block is not even analyzed,
             // so this compile error is not triggered.
@@ -5310,7 +5310,7 @@ test "implicit unsigned integer to signed integer" {
 test "float widening" {
     // Note: there is an open issue preventing this from working on aarch64:
     // https://github.com/ziglang/zig/issues/3282
-    if (std.Target.current.cpu.arch == .aarch64) return error.SkipZigTest;
+    if (@import("builtin").cpu.arch == .aarch64) return error.SkipZigTest;
 
     var a: f16 = 12.34;
     var b: f32 = a;
@@ -7082,7 +7082,7 @@ fn func(y: *i32) void {
       {#header_close#}
 
       {#header_open|@atomicLoad#}
-      <pre>{#syntax#}@atomicLoad(comptime T: type, ptr: *const T, comptime ordering: builtin.AtomicOrder) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@atomicLoad(comptime T: type, ptr: *const T, comptime ordering: std.builtin.AtomicOrder) T{#endsyntax#}</pre>
       <p>
       This builtin function atomically dereferences a pointer and returns the value.
       </p>
@@ -7092,7 +7092,7 @@ fn func(y: *i32) void {
       </p>
       {#header_close#}
       {#header_open|@atomicRmw#}
-      <pre>{#syntax#}@atomicRmw(comptime T: type, ptr: *T, comptime op: builtin.AtomicRmwOp, operand: T, comptime ordering: builtin.AtomicOrder) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@atomicRmw(comptime T: type, ptr: *T, comptime op: std.builtin.AtomicRmwOp, operand: T, comptime ordering: std.builtin.AtomicOrder) T{#endsyntax#}</pre>
       <p>
       This builtin function atomically modifies memory and then returns the previous value.
       </p>
@@ -7118,7 +7118,7 @@ fn func(y: *i32) void {
       </ul>
       {#header_close#}
       {#header_open|@atomicStore#}
-      <pre>{#syntax#}@atomicStore(comptime T: type, ptr: *T, value: T, comptime ordering: builtin.AtomicOrder) void{#endsyntax#}</pre>
+      <pre>{#syntax#}@atomicStore(comptime T: type, ptr: *T, value: T, comptime ordering: std.builtin.AtomicOrder) void{#endsyntax#}</pre>
       <p>
       This builtin function atomically stores a value.
       </p>
@@ -9785,7 +9785,7 @@ test "string literal to constant slice" {
       </p>
       {#code_begin|syntax#}
 const builtin = @import("builtin");
-const separator = if (builtin.os.tag == builtin.Os.windows) '\\' else '/';
+const separator = if (builtin.os.tag == std.builtin.Os.windows) '\\' else '/';
       {#code_end#}
       <p>
       Example of what is imported with {#syntax#}@import("builtin"){#endsyntax#}:
@@ -9949,7 +9949,7 @@ pub fn main() void {
 const builtin = @import("builtin");
 
 const c = @cImport({
-    @cDefine("NDEBUG", builtin.mode == .ReleaseFast);
+    @cDefine("NDEBUG", @import("builtin").mode == .ReleaseFast);
     if (something) {
         @cDefine("_GNU_SOURCE", {});
     }

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -13,6 +13,7 @@
 //! * `initial_delay_ms`
 
 const std = @import("std");
+const builtin = @import("builtin");
 const windows = std.os.windows;
 const testing = std.testing;
 const assert = std.debug.assert;
@@ -146,10 +147,10 @@ pub fn start(self: *Progress, name: []const u8, estimated_total_items: usize) !*
     if (stderr.supportsAnsiEscapeCodes()) {
         self.terminal = stderr;
         self.supports_ansi_escape_codes = true;
-    } else if (std.builtin.os.tag == .windows and stderr.isTty()) {
+    } else if (builtin.os.tag == .windows and stderr.isTty()) {
         self.is_windows_terminal = true;
         self.terminal = stderr;
-    } else if (std.builtin.os.tag != .windows) {
+    } else if (builtin.os.tag != .windows) {
         // we are in a "dumb" terminal like in acme or writing to a file
         self.terminal = stderr;
     }
@@ -211,7 +212,7 @@ fn refreshWithHeldLock(self: *Progress) void {
         const seq_before = DECSC ++ ED;
         std.mem.copy(u8, self.output_buffer[end..], seq_before);
         end += seq_before.len;
-    } else if (std.builtin.os.tag == .windows) winapi: {
+    } else if (builtin.os.tag == .windows) winapi: {
         std.debug.assert(self.is_windows_terminal);
 
         var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
@@ -300,7 +301,7 @@ fn refreshWithHeldLock(self: *Progress) void {
         self.terminal = null;
     };
 
-    if (std.builtin.os.tag == .windows) {
+    if (builtin.os.tag == .windows) {
         if (self.is_windows_terminal) {
             const res = windows.kernel32.SetConsoleCursorPosition(file.handle, saved_cursor_pos);
             std.debug.assert(res == windows.TRUE);

--- a/lib/std/Thread/AutoResetEvent.zig
+++ b/lib/std/Thread/AutoResetEvent.zig
@@ -32,7 +32,7 @@
 state: usize = UNSET,
 
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const testing = std.testing;
 const assert = std.debug.assert;
 const StaticResetEvent = std.Thread.StaticResetEvent;

--- a/lib/std/Thread/Condition.zig
+++ b/lib/std/Thread/Condition.zig
@@ -11,6 +11,7 @@
 impl: Impl = .{},
 
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const Condition = @This();
 const windows = std.os.windows;
 const linux = std.os.linux;
@@ -29,9 +30,9 @@ pub fn broadcast(cond: *Condition) void {
     cond.impl.broadcast();
 }
 
-const Impl = if (std.builtin.single_threaded)
+const Impl = if (builtin.single_threaded)
     SingleThreadedCondition
-else if (std.Target.current.os.tag == .windows)
+else if (builtin.os.tag == .windows)
     WindowsCondition
 else if (std.Thread.use_pthreads)
     PthreadCondition
@@ -107,7 +108,7 @@ pub const AtomicCondition = struct {
 
         fn wait(cond: *@This()) void {
             while (@atomicLoad(i32, &cond.futex, .Acquire) == 0) {
-                switch (std.Target.current.os.tag) {
+                switch (builtin.os.tag) {
                     .linux => {
                         switch (linux.getErrno(linux.futex_wait(
                             &cond.futex,
@@ -129,7 +130,7 @@ pub const AtomicCondition = struct {
         fn notify(cond: *@This()) void {
             @atomicStore(i32, &cond.futex, 1, .Release);
 
-            switch (std.Target.current.os.tag) {
+            switch (builtin.os.tag) {
                 .linux => {
                     switch (linux.getErrno(linux.futex_wake(
                         &cond.futex,

--- a/lib/std/Thread/Futex.zig
+++ b/lib/std/Thread/Futex.zig
@@ -10,10 +10,11 @@
 //! Using Futex, other Thread synchronization primitives can be built which efficiently wait for cross-thread events or signals.  
 
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const Futex = @This();
 
-const target = std.Target.current;
-const single_threaded = std.builtin.single_threaded;
+const target = builtin.target;
+const single_threaded = builtin.single_threaded;
 
 const assert = std.debug.assert;
 const testing = std.testing;
@@ -76,7 +77,7 @@ else if (target.os.tag == .linux)
     LinuxFutex
 else if (target.isDarwin())
     DarwinFutex
-else if (std.builtin.link_libc)
+else if (builtin.link_libc)
     PosixFutex
 else
     UnsupportedFutex;

--- a/lib/std/Thread/Mutex.zig
+++ b/lib/std/Thread/Mutex.zig
@@ -30,7 +30,7 @@ impl: Impl = .{},
 
 const Mutex = @This();
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const os = std.os;
 const assert = std.debug.assert;
 const windows = os.windows;
@@ -135,7 +135,7 @@ pub const AtomicMutex = struct {
                 .unlocked => return,
                 else => {},
             }
-            switch (std.Target.current.os.tag) {
+            switch (builtin.os.tag) {
                 .linux => {
                     switch (linux.getErrno(linux.futex_wait(
                         @ptrCast(*const i32, &m.state),
@@ -157,7 +157,7 @@ pub const AtomicMutex = struct {
     fn unlockSlow(m: *AtomicMutex) void {
         @setCold(true);
 
-        switch (std.Target.current.os.tag) {
+        switch (builtin.os.tag) {
             .linux => {
                 switch (linux.getErrno(linux.futex_wake(
                     @ptrCast(*const i32, &m.state),

--- a/lib/std/Thread/ResetEvent.zig
+++ b/lib/std/Thread/ResetEvent.zig
@@ -14,7 +14,7 @@
 
 const ResetEvent = @This();
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const testing = std.testing;
 const assert = std.debug.assert;
 const c = std.c;
@@ -25,7 +25,7 @@ impl: Impl,
 
 pub const Impl = if (builtin.single_threaded)
     std.Thread.StaticResetEvent.DebugEvent
-else if (std.Target.current.isDarwin())
+else if (builtin.target.isDarwin())
     DarwinEvent
 else if (std.Thread.use_pthreads)
     PosixEvent

--- a/lib/std/Thread/RwLock.zig
+++ b/lib/std/Thread/RwLock.zig
@@ -13,7 +13,7 @@ impl: Impl,
 
 const RwLock = @This();
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const Mutex = std.Thread.Mutex;
 const Semaphore = std.Semaphore;
@@ -165,7 +165,7 @@ pub const PthreadRwLock = struct {
     }
 
     pub fn deinit(rwl: *PthreadRwLock) void {
-        const safe_rc = switch (std.builtin.os.tag) {
+        const safe_rc = switch (builtin.os.tag) {
             .dragonfly, .netbsd => std.os.EAGAIN,
             else => 0,
         };

--- a/lib/std/Thread/StaticResetEvent.zig
+++ b/lib/std/Thread/StaticResetEvent.zig
@@ -14,6 +14,7 @@
 //! the logic needs stronger API guarantees.
 
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const StaticResetEvent = @This();
 const assert = std.debug.assert;
 const os = std.os;
@@ -24,7 +25,7 @@ const testing = std.testing;
 
 impl: Impl = .{},
 
-pub const Impl = if (std.builtin.single_threaded)
+pub const Impl = if (builtin.single_threaded)
     DebugEvent
 else
     AtomicEvent;
@@ -168,7 +169,7 @@ pub const AtomicEvent = struct {
         @atomicStore(u32, &ev.waiters, 0, .Monotonic);
     }
 
-    pub const Futex = switch (std.Target.current.os.tag) {
+    pub const Futex = switch (builtin.os.tag) {
         .windows => WindowsFutex,
         .linux => LinuxFutex,
         else => SpinFutex,
@@ -328,7 +329,7 @@ test "basic usage" {
     try testing.expectEqual(TimedWaitResult.event_set, event.timedWait(1));
 
     // test cross-thread signaling
-    if (std.builtin.single_threaded)
+    if (builtin.single_threaded)
         return;
 
     const Context = struct {

--- a/lib/std/atomic.zig
+++ b/lib/std/atomic.zig
@@ -5,7 +5,7 @@
 // and substantial portions of the software.
 
 const std = @import("std.zig");
-const target = std.Target.current;
+const target = @import("builtin").target;
 
 pub const Ordering = std.builtin.AtomicOrder;
 

--- a/lib/std/atomic/Atomic.zig
+++ b/lib/std/atomic/Atomic.zig
@@ -5,9 +5,10 @@
 // and substantial portions of the software.
 
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 
 const testing = std.testing;
-const target = std.Target.current;
+const target = builtin.target;
 const Ordering = std.atomic.Ordering;
 
 pub fn Atomic(comptime T: type) type {

--- a/lib/std/atomic/queue.zig
+++ b/lib/std/atomic/queue.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
 

--- a/lib/std/atomic/stack.zig
+++ b/lib/std/atomic/stack.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const assert = std.debug.assert;
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const expect = std.testing.expect;
 
 /// Many reader, many writer, non-allocating, thread-safe

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const io = std.io;
 const fs = std.fs;
 const mem = std.mem;
@@ -64,7 +64,7 @@ pub const Builder = struct {
     build_root: []const u8,
     cache_root: []const u8,
     global_cache_root: []const u8,
-    release_mode: ?builtin.Mode,
+    release_mode: ?std.builtin.Mode,
     is_release: bool,
     override_lib_dir: ?[]const u8,
     vcpkg_root: VcpkgRoot,
@@ -617,18 +617,18 @@ pub const Builder = struct {
     }
 
     /// This provides the -Drelease option to the build user and does not give them the choice.
-    pub fn setPreferredReleaseMode(self: *Builder, mode: builtin.Mode) void {
+    pub fn setPreferredReleaseMode(self: *Builder, mode: std.builtin.Mode) void {
         if (self.release_mode != null) {
             @panic("setPreferredReleaseMode must be called before standardReleaseOptions and may not be called twice");
         }
         const description = self.fmt("Create a release build ({s})", .{@tagName(mode)});
         self.is_release = self.option(bool, "release", description) orelse false;
-        self.release_mode = if (self.is_release) mode else builtin.Mode.Debug;
+        self.release_mode = if (self.is_release) mode else std.builtin.Mode.Debug;
     }
 
     /// If you call this without first calling `setPreferredReleaseMode` then it gives the build user
     /// the choice of what kind of release.
-    pub fn standardReleaseOptions(self: *Builder) builtin.Mode {
+    pub fn standardReleaseOptions(self: *Builder) std.builtin.Mode {
         if (self.release_mode) |mode| return mode;
 
         const release_safe = self.option(bool, "release-safe", "Optimizations on and safety on") orelse false;
@@ -636,17 +636,17 @@ pub const Builder = struct {
         const release_small = self.option(bool, "release-small", "Size optimizations on and safety off") orelse false;
 
         const mode = if (release_safe and !release_fast and !release_small)
-            builtin.Mode.ReleaseSafe
+            std.builtin.Mode.ReleaseSafe
         else if (release_fast and !release_safe and !release_small)
-            builtin.Mode.ReleaseFast
+            std.builtin.Mode.ReleaseFast
         else if (release_small and !release_fast and !release_safe)
-            builtin.Mode.ReleaseSmall
+            std.builtin.Mode.ReleaseSmall
         else if (!release_fast and !release_safe and !release_small)
-            builtin.Mode.Debug
+            std.builtin.Mode.Debug
         else x: {
             warn("Multiple release modes (of -Drelease-safe, -Drelease-fast and -Drelease-small)\n\n", .{});
             self.markInvalidUserInput();
-            break :x builtin.Mode.Debug;
+            break :x std.builtin.Mode.Debug;
         };
         self.is_release = mode != .Debug;
         self.release_mode = mode;
@@ -1256,7 +1256,7 @@ test "builder.findProgram compiles" {
 }
 
 /// Deprecated. Use `std.builtin.Version`.
-pub const Version = builtin.Version;
+pub const Version = std.builtin.Version;
 
 /// Deprecated. Use `std.zig.CrossTarget`.
 pub const Target = std.zig.CrossTarget;
@@ -1394,7 +1394,7 @@ pub const LibExeObjStep = struct {
     out_filename: []const u8,
     linkage: ?Linkage = null,
     version: ?Version,
-    build_mode: builtin.Mode,
+    build_mode: std.builtin.Mode,
     kind: Kind,
     major_only_filename: ?[]const u8,
     name_only_filename: ?[]const u8,
@@ -1423,7 +1423,7 @@ pub const LibExeObjStep = struct {
     filter: ?[]const u8,
     single_threaded: bool,
     test_evented_io: bool = false,
-    code_model: builtin.CodeModel = .default,
+    code_model: std.builtin.CodeModel = .default,
 
     root_src: ?FileSource,
     out_h_filename: []const u8,
@@ -1577,7 +1577,7 @@ pub const LibExeObjStep = struct {
             .builder = builder,
             .verbose_link = false,
             .verbose_cc = false,
-            .build_mode = builtin.Mode.Debug,
+            .build_mode = std.builtin.Mode.Debug,
             .linkage = linkage,
             .kind = kind,
             .root_src = root_src,
@@ -1965,7 +1965,7 @@ pub const LibExeObjStep = struct {
         self.verbose_cc = value;
     }
 
-    pub fn setBuildMode(self: *LibExeObjStep, mode: builtin.Mode) void {
+    pub fn setBuildMode(self: *LibExeObjStep, mode: std.builtin.Mode) void {
         self.build_mode = mode;
     }
 
@@ -3352,7 +3352,7 @@ test "LibExeObjStep.addPackage" {
 test {
     // The only purpose of this test is to get all these untested functions
     // to be referenced to avoid regression so it is okay to skip some targets.
-    if (comptime std.Target.current.cpu.arch.ptrBitWidth() == 64) {
+    if (comptime builtin.cpu.arch.ptrBitWidth() == 64) {
         std.testing.refAllDecls(@This());
         std.testing.refAllDecls(Builder);
 

--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const build = std.build;
 const Step = build.Step;
 const Builder = build.Builder;

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -5,35 +5,13 @@
 // and substantial portions of the software.
 const builtin = @import("builtin");
 
-// These are all deprecated.
-pub const zig_version = builtin.zig_version;
-pub const zig_is_stage2 = builtin.zig_is_stage2;
-pub const output_mode = builtin.output_mode;
-pub const link_mode = builtin.link_mode;
-pub const is_test = builtin.is_test;
-pub const single_threaded = builtin.single_threaded;
-pub const abi = builtin.abi;
-pub const cpu = builtin.cpu;
-pub const os = builtin.os;
-pub const target = builtin.target;
-pub const object_format = builtin.object_format;
-pub const mode = builtin.mode;
-pub const link_libc = builtin.link_libc;
-pub const link_libcpp = builtin.link_libcpp;
-pub const have_error_return_tracing = builtin.have_error_return_tracing;
-pub const valgrind_support = builtin.valgrind_support;
-pub const position_independent_code = builtin.position_independent_code;
-pub const position_independent_executable = builtin.position_independent_executable;
-pub const strip_debug_info = builtin.strip_debug_info;
-pub const code_model = builtin.code_model;
-
 /// `explicit_subsystem` is missing when the subsystem is automatically detected,
 /// so Zig standard library has the subsystem detection logic here. This should generally be
 /// used rather than `explicit_subsystem`.
 /// On non-Windows targets, this is `null`.
 pub const subsystem: ?std.Target.SubSystem = blk: {
     if (@hasDecl(builtin, "explicit_subsystem")) break :blk explicit_subsystem;
-    switch (os.tag) {
+    switch (builtin.os.tag) {
         .windows => {
             if (is_test) {
                 break :blk std.Target.SubSystem.Console;
@@ -688,7 +666,7 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace) noreturn
         root.os.panic(msg, error_return_trace);
         unreachable;
     }
-    switch (os.tag) {
+    switch (builtin.os.tag) {
         .freestanding => {
             while (true) {
                 @breakpoint();

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const page_size = std.mem.page_size;
 
 pub const tokenizer = @import("c/tokenizer.zig");
@@ -17,7 +17,7 @@ test {
 
 pub usingnamespace @import("os/bits.zig");
 
-pub usingnamespace switch (std.Target.current.os.tag) {
+pub usingnamespace switch (builtin.os.tag) {
     .linux => @import("c/linux.zig"),
     .windows => @import("c/windows.zig"),
     .macos, .ios, .tvos, .watchos => @import("c/darwin.zig"),
@@ -49,13 +49,13 @@ pub fn getErrno(rc: anytype) c_int {
 /// If linking gnu libc (glibc), the `ok` value will be true if the target
 /// version is greater than or equal to `glibc_version`.
 /// If linking a libc other than these, returns `false`.
-pub fn versionCheck(glibc_version: builtin.Version) type {
+pub fn versionCheck(glibc_version: std.builtin.Version) type {
     return struct {
         pub const ok = blk: {
             if (!builtin.link_libc) break :blk false;
-            if (std.Target.current.abi.isMusl()) break :blk true;
-            if (std.Target.current.isGnuLibC()) {
-                const ver = std.Target.current.os.version_range.linux.glibc;
+            if (builtin.abi.isMusl()) break :blk true;
+            if (builtin.target.isGnuLibC()) {
+                const ver = builtin.os.version_range.linux.glibc;
                 const order = ver.order(glibc_version);
                 break :blk switch (order) {
                     .gt, .eq => true,
@@ -381,9 +381,9 @@ pub extern "c" fn openlog(ident: [*:0]const u8, logopt: c_int, facility: c_int) 
 pub extern "c" fn closelog() void;
 pub extern "c" fn setlogmask(maskpri: c_int) c_int;
 
-pub const max_align_t = if (std.Target.current.abi == .msvc)
+pub const max_align_t = if (builtin.abi == .msvc)
     f64
-else if (std.Target.current.isDarwin())
+else if (builtin.target.isDarwin())
     c_longdouble
 else
     extern struct {

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -7,7 +7,7 @@ const std = @import("../std.zig");
 const assert = std.debug.assert;
 const builtin = @import("builtin");
 const macho = std.macho;
-const native_arch = builtin.target.cpu.arch;
+const native_arch = builtin.cpu.arch;
 
 usingnamespace @import("../os/bits.zig");
 
@@ -72,7 +72,7 @@ const mach_hdr = if (@sizeOf(usize) == 8) mach_header_64 else mach_header;
 var dummy_execute_header: mach_hdr = undefined;
 pub extern var _mh_execute_header: mach_hdr;
 comptime {
-    if (std.Target.current.isDarwin()) {
+    if (builtin.target.isDarwin()) {
         @export(dummy_execute_header, .{ .name = "_mh_execute_header", .linkage = .Weak });
     }
 }

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -4,10 +4,11 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const maxInt = std.math.maxInt;
-const abi = std.Target.current.abi;
-const arch = std.Target.current.cpu.arch;
-const os_tag = std.Target.current.os.tag;
+const abi = builtin.abi;
+const arch = builtin.cpu.arch;
+const os_tag = builtin.os.tag;
 usingnamespace std.c;
 
 pub const _errno = switch (abi) {

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 
 usingnamespace std.c;
 
@@ -56,7 +56,7 @@ pub const pthread_cond_t = extern struct {
 
 pub const pthread_rwlock_t = extern struct {
     ptr_magic: c_uint = 0x99990009,
-    ptr_interlock: switch (std.builtin.cpu.arch) {
+    ptr_interlock: switch (builtin.cpu.arch) {
         .aarch64, .sparc, .x86_64, .i386 => u8,
         .arm, .powerpc => c_int,
         else => unreachable,

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std.zig");
+const builtin = @import("builtin");
 const cstr = std.cstr;
 const unicode = std.unicode;
 const io = std.io;
@@ -16,8 +17,7 @@ const mem = std.mem;
 const math = std.math;
 const debug = std.debug;
 const BufMap = std.BufMap;
-const builtin = std.builtin;
-const Os = builtin.Os;
+const Os = std.builtin.Os;
 const TailQueue = std.TailQueue;
 const maxInt = std.math.maxInt;
 const assert = std.debug.assert;
@@ -564,9 +564,9 @@ pub const ChildProcess = struct {
             if (self.env_map) |env_map| {
                 const envp_buf = try createNullDelimitedEnvMap(arena, env_map);
                 break :m envp_buf.ptr;
-            } else if (std.builtin.link_libc) {
+            } else if (builtin.link_libc) {
                 break :m std.c.environ;
-            } else if (std.builtin.output_mode == .Exe) {
+            } else if (builtin.output_mode == .Exe) {
                 // Then we have Zig start code and this works.
                 // TODO type-safety for null-termination of `os.environ`.
                 break :m @ptrCast([*:null]?[*:0]u8, os.environ.ptr);

--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -158,7 +158,7 @@ const std = @import("std.zig");
 pub const errors = @import("crypto/errors.zig");
 
 test "crypto" {
-    const please_windows_dont_oom = std.Target.current.os.tag == .windows;
+    const please_windows_dont_oom = @import("builtin").os.tag == .windows;
     if (please_windows_dont_oom) return error.SkipZigTest;
 
     inline for (std.meta.declarations(@This())) |decl| {

--- a/lib/std/crypto/aes.zig
+++ b/lib/std/crypto/aes.zig
@@ -6,14 +6,14 @@
 
 const std = @import("../std.zig");
 const testing = std.testing;
-const builtin = std.builtin;
+const builtin = @import("builtin");
 
-const has_aesni = std.Target.x86.featureSetHas(std.Target.current.cpu.features, .aes);
-const has_avx = std.Target.x86.featureSetHas(std.Target.current.cpu.features, .avx);
-const has_armaes = std.Target.aarch64.featureSetHas(std.Target.current.cpu.features, .aes);
-const impl = if (std.Target.current.cpu.arch == .x86_64 and has_aesni and has_avx) impl: {
+const has_aesni = std.Target.x86.featureSetHas(builtin.cpu.features, .aes);
+const has_avx = std.Target.x86.featureSetHas(builtin.cpu.features, .avx);
+const has_armaes = std.Target.aarch64.featureSetHas(builtin.cpu.features, .aes);
+const impl = if (builtin.cpu.arch == .x86_64 and has_aesni and has_avx) impl: {
     break :impl @import("aes/aesni.zig");
-} else if (std.Target.current.cpu.arch == .aarch64 and has_armaes)
+} else if (builtin.cpu.arch == .aarch64 and has_armaes)
 impl: {
     break :impl @import("aes/armcrypto.zig");
 } else impl: {
@@ -47,7 +47,7 @@ test "ctr" {
 
     var out: [exp_out.len]u8 = undefined;
     var ctx = Aes128.initEnc(key);
-    ctr(AesEncryptCtx(Aes128), ctx, out[0..], in[0..], iv, builtin.Endian.Big);
+    ctr(AesEncryptCtx(Aes128), ctx, out[0..], in[0..], iv, std.builtin.Endian.Big);
     try testing.expectEqualSlices(u8, exp_out[0..], out[0..]);
 }
 

--- a/lib/std/crypto/aes/aesni.zig
+++ b/lib/std/crypto/aes/aesni.zig
@@ -5,6 +5,7 @@
 // and substantial portions of the software.
 
 const std = @import("../../std.zig");
+const builtin = @import("builtin");
 const mem = std.mem;
 const debug = std.debug;
 const Vector = std.meta.Vector;
@@ -103,7 +104,7 @@ pub const Block = struct {
         const cpu = std.Target.x86.cpu;
 
         /// The recommended number of AES encryption/decryption to perform in parallel for the chosen implementation.
-        pub const optimal_parallel_blocks = switch (std.Target.current.cpu.model) {
+        pub const optimal_parallel_blocks = switch (builtin.cpu.model) {
             &cpu.westmere => 6,
             &cpu.sandybridge, &cpu.ivybridge => 8,
             &cpu.haswell, &cpu.broadwell => 7,

--- a/lib/std/crypto/aes_gcm.zig
+++ b/lib/std/crypto/aes_gcm.zig
@@ -46,7 +46,7 @@ fn AesGcm(comptime Aes: anytype) type {
             mac.pad();
 
             mem.writeIntBig(u32, j[nonce_length..][0..4], 2);
-            modes.ctr(@TypeOf(aes), aes, c, m, j, builtin.Endian.Big);
+            modes.ctr(@TypeOf(aes), aes, c, m, j, std.builtin.Endian.Big);
             mac.update(c[0..m.len][0..]);
             mac.pad();
 
@@ -100,7 +100,7 @@ fn AesGcm(comptime Aes: anytype) type {
             }
 
             mem.writeIntBig(u32, j[nonce_length..][0..4], 2);
-            modes.ctr(@TypeOf(aes), aes, m, c, j, builtin.Endian.Big);
+            modes.ctr(@TypeOf(aes), aes, m, c, j, std.builtin.Endian.Big);
         }
     };
 }

--- a/lib/std/crypto/aes_ocb.zig
+++ b/lib/std/crypto/aes_ocb.zig
@@ -5,6 +5,7 @@
 // and substantial portions of the software.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const crypto = std.crypto;
 const aes = crypto.core.aes;
 const assert = std.debug.assert;
@@ -106,9 +107,9 @@ fn AesOcb(comptime Aes: anytype) type {
             return offset;
         }
 
-        const has_aesni = std.Target.x86.featureSetHas(std.Target.current.cpu.features, .aes);
-        const has_armaes = std.Target.aarch64.featureSetHas(std.Target.current.cpu.features, .aes);
-        const wb: usize = if ((std.Target.current.cpu.arch == .x86_64 and has_aesni) or (std.Target.current.cpu.arch == .aarch64 and has_armaes)) 4 else 0;
+        const has_aesni = std.Target.x86.featureSetHas(builtin.cpu.features, .aes);
+        const has_armaes = std.Target.aarch64.featureSetHas(builtin.cpu.features, .aes);
+        const wb: usize = if ((builtin.cpu.arch == .x86_64 and has_aesni) or (builtin.cpu.arch == .aarch64 and has_armaes)) 4 else 0;
 
         /// c: ciphertext: output buffer should be of size m.len
         /// tag: authentication tag: output MAC

--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -6,7 +6,7 @@
 // zig run benchmark.zig --release-fast --zig-lib-dir ..
 
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const mem = std.mem;
 const time = std.time;
 const Timer = time.Timer;

--- a/lib/std/crypto/blake3.zig
+++ b/lib/std/crypto/blake3.zig
@@ -7,6 +7,7 @@
 // Source: https://github.com/BLAKE3-team/BLAKE3
 
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const fmt = std.fmt;
 const math = std.math;
 const mem = std.mem;
@@ -205,7 +206,7 @@ const CompressGeneric = struct {
     }
 };
 
-const compress = if (std.Target.current.cpu.arch == .x86_64) CompressVectorized.compress else CompressGeneric.compress;
+const compress = if (builtin.cpu.arch == .x86_64) CompressVectorized.compress else CompressGeneric.compress;
 
 fn first8Words(words: [16]u32) [8]u32 {
     return @ptrCast(*const [8]u32, &words).*;

--- a/lib/std/crypto/chacha20.zig
+++ b/lib/std/crypto/chacha20.zig
@@ -6,6 +6,7 @@
 // Based on public domain Supercop by Daniel J. Bernstein
 
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const math = std.math;
 const mem = std.mem;
 const assert = std.debug.assert;
@@ -364,7 +365,7 @@ fn ChaChaNonVecImpl(comptime rounds_nb: usize) type {
 }
 
 fn ChaChaImpl(comptime rounds_nb: usize) type {
-    return if (std.Target.current.cpu.arch == .x86_64) ChaChaVecImpl(rounds_nb) else ChaChaNonVecImpl(rounds_nb);
+    return if (builtin.cpu.arch == .x86_64) ChaChaVecImpl(rounds_nb) else ChaChaNonVecImpl(rounds_nb);
 }
 
 fn keyToWords(key: [32]u8) [8]u32 {

--- a/lib/std/crypto/ghash.zig
+++ b/lib/std/crypto/ghash.zig
@@ -7,6 +7,7 @@
 // Adapted from BearSSL's ctmul64 implementation originally written by Thomas Pornin <pornin@bolet.org>
 
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
@@ -50,7 +51,7 @@ pub const Ghash = struct {
         const h2 = h0 ^ h1;
         const h2r = h0r ^ h1r;
 
-        if (std.builtin.mode == .ReleaseSmall) {
+        if (builtin.mode == .ReleaseSmall) {
             return Ghash{
                 .h0 = h0,
                 .h1 = h1,
@@ -137,12 +138,12 @@ pub const Ghash = struct {
         return z0 | z1 | z2 | z3;
     }
 
-    const has_pclmul = std.Target.x86.featureSetHas(std.Target.current.cpu.features, .pclmul);
-    const has_avx = std.Target.x86.featureSetHas(std.Target.current.cpu.features, .avx);
-    const has_armaes = std.Target.aarch64.featureSetHas(std.Target.current.cpu.features, .aes);
-    const clmul = if (std.Target.current.cpu.arch == .x86_64 and has_pclmul and has_avx) impl: {
+    const has_pclmul = std.Target.x86.featureSetHas(builtin.cpu.features, .pclmul);
+    const has_avx = std.Target.x86.featureSetHas(builtin.cpu.features, .avx);
+    const has_armaes = std.Target.aarch64.featureSetHas(builtin.cpu.features, .aes);
+    const clmul = if (builtin.cpu.arch == .x86_64 and has_pclmul and has_avx) impl: {
         break :impl clmul_pclmul;
-    } else if (std.Target.current.cpu.arch == .aarch64 and has_armaes) impl: {
+    } else if (builtin.cpu.arch == .aarch64 and has_armaes) impl: {
         break :impl clmul_pmull;
     } else impl: {
         break :impl clmul_soft;
@@ -156,7 +157,7 @@ pub const Ghash = struct {
         var i: usize = 0;
 
         // 2-blocks aggregated reduction
-        if (std.builtin.mode != .ReleaseSmall) {
+        if (builtin.mode != .ReleaseSmall) {
             while (i + 32 <= msg.len) : (i += 32) {
                 // B0 * H^2 unreduced
                 y1 ^= mem.readIntBig(u64, msg[i..][0..8]);

--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -13,6 +13,7 @@
 // https://csrc.nist.gov/CSRC/media/Projects/Lightweight-Cryptography/documents/round-1/spec-doc/gimli-spec.pdf
 
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const mem = std.mem;
 const math = std.math;
 const debug = std.debug;
@@ -157,9 +158,9 @@ pub const State = struct {
         self.endianSwap();
     }
 
-    pub const permute = if (std.Target.current.cpu.arch == .x86_64) impl: {
+    pub const permute = if (builtin.cpu.arch == .x86_64) impl: {
         break :impl permute_vectorized;
-    } else if (std.builtin.mode == .ReleaseSmall) impl: {
+    } else if (builtin.mode == .ReleaseSmall) impl: {
         break :impl permute_small;
     } else impl: {
         break :impl permute_unrolled;

--- a/lib/std/crypto/modes.zig
+++ b/lib/std/crypto/modes.zig
@@ -16,7 +16,7 @@ const debug = std.debug;
 ///
 /// Important: the counter mode doesn't provide authenticated encryption: the ciphertext can be trivially modified without this being detected.
 /// As a result, applications should generally never use it directly, but only in a construction that includes a MAC.
-pub fn ctr(comptime BlockCipher: anytype, block_cipher: BlockCipher, dst: []u8, src: []const u8, iv: [BlockCipher.block_length]u8, endian: builtin.Endian) void {
+pub fn ctr(comptime BlockCipher: anytype, block_cipher: BlockCipher, dst: []u8, src: []const u8, iv: [BlockCipher.block_length]u8, endian: std.builtin.Endian) void {
     debug.assert(dst.len >= src.len);
     const block_length = BlockCipher.block_length;
     var counter: [BlockCipher.block_length]u8 = undefined;

--- a/lib/std/crypto/pcurves/common.zig
+++ b/lib/std/crypto/pcurves/common.zig
@@ -51,7 +51,7 @@ pub fn Field(comptime params: FieldParams) type {
         };
 
         /// Reject non-canonical encodings of an element.
-        pub fn rejectNonCanonical(s_: [encoded_length]u8, endian: builtin.Endian) NonCanonicalError!void {
+        pub fn rejectNonCanonical(s_: [encoded_length]u8, endian: std.builtin.Endian) NonCanonicalError!void {
             var s = if (endian == .Little) s_ else orderSwap(s_);
             const field_order_s = comptime fos: {
                 var fos: [encoded_length]u8 = undefined;
@@ -71,7 +71,7 @@ pub fn Field(comptime params: FieldParams) type {
         }
 
         /// Unpack a field element.
-        pub fn fromBytes(s_: [encoded_length]u8, endian: builtin.Endian) NonCanonicalError!Fe {
+        pub fn fromBytes(s_: [encoded_length]u8, endian: std.builtin.Endian) NonCanonicalError!Fe {
             var s = if (endian == .Little) s_ else orderSwap(s_);
             try rejectNonCanonical(s, .Little);
             var limbs_z: NonMontgomeryDomainFieldElement = undefined;
@@ -82,7 +82,7 @@ pub fn Field(comptime params: FieldParams) type {
         }
 
         /// Pack a field element.
-        pub fn toBytes(fe: Fe, endian: builtin.Endian) [encoded_length]u8 {
+        pub fn toBytes(fe: Fe, endian: std.builtin.Endian) [encoded_length]u8 {
             var limbs_z: NonMontgomeryDomainFieldElement = undefined;
             fiat.fromMontgomery(&limbs_z, fe.limbs);
             var s: [encoded_length]u8 = undefined;

--- a/lib/std/crypto/pcurves/p256.zig
+++ b/lib/std/crypto/pcurves/p256.zig
@@ -65,7 +65,7 @@ pub const P256 = struct {
     }
 
     /// Create a point from serialized affine coordinates.
-    pub fn fromSerializedAffineCoordinates(xs: [32]u8, ys: [32]u8, endian: builtin.Endian) (NonCanonicalError || EncodingError)!P256 {
+    pub fn fromSerializedAffineCoordinates(xs: [32]u8, ys: [32]u8, endian: std.builtin.Endian) (NonCanonicalError || EncodingError)!P256 {
         const x = try Fe.fromBytes(xs, endian);
         const y = try Fe.fromBytes(ys, endian);
         return fromAffineCoordinates(.{ .x = x, .y = y });
@@ -402,7 +402,7 @@ pub const P256 = struct {
 
     /// Multiply an elliptic curve point by a scalar.
     /// Return error.IdentityElement if the result is the identity element.
-    pub fn mul(p: P256, s_: [32]u8, endian: builtin.Endian) IdentityElementError!P256 {
+    pub fn mul(p: P256, s_: [32]u8, endian: std.builtin.Endian) IdentityElementError!P256 {
         const s = if (endian == .Little) s_ else Fe.orderSwap(s_);
         if (p.is_base) {
             return pcMul16(&basePointPc, s, false);
@@ -414,7 +414,7 @@ pub const P256 = struct {
 
     /// Multiply an elliptic curve point by a *PUBLIC* scalar *IN VARIABLE TIME*
     /// This can be used for signature verification.
-    pub fn mulPublic(p: P256, s_: [32]u8, endian: builtin.Endian) IdentityElementError!P256 {
+    pub fn mulPublic(p: P256, s_: [32]u8, endian: std.builtin.Endian) IdentityElementError!P256 {
         const s = if (endian == .Little) s_ else Fe.orderSwap(s_);
         if (p.is_base) {
             return pcMul16(&basePointPc, s, true);
@@ -426,7 +426,7 @@ pub const P256 = struct {
 
     /// Double-base multiplication of public parameters - Compute (p1*s1)+(p2*s2) *IN VARIABLE TIME*
     /// This can be used for signature verification.
-    pub fn mulDoubleBasePublic(p1: P256, s1_: [32]u8, p2: P256, s2_: [32]u8, endian: builtin.Endian) IdentityElementError!P256 {
+    pub fn mulDoubleBasePublic(p1: P256, s1_: [32]u8, p2: P256, s2_: [32]u8, endian: std.builtin.Endian) IdentityElementError!P256 {
         const s1 = if (endian == .Little) s1_ else Fe.orderSwap(s1_);
         const s2 = if (endian == .Little) s2_ else Fe.orderSwap(s2_);
         try p1.rejectIdentity();

--- a/lib/std/crypto/pcurves/p256/p256_64.zig
+++ b/lib/std/crypto/pcurves/p256/p256_64.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/lib/std/crypto/pcurves/p256/p256_scalar_64.zig
+++ b/lib/std/crypto/pcurves/p256/p256_scalar_64.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/lib/std/crypto/pcurves/p256/scalar.zig
+++ b/lib/std/crypto/pcurves/p256/scalar.zig
@@ -32,47 +32,47 @@ const Fe = Field(.{
 });
 
 /// Reject a scalar whose encoding is not canonical.
-pub fn rejectNonCanonical(s: CompressedScalar, endian: builtin.Endian) NonCanonicalError!void {
+pub fn rejectNonCanonical(s: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!void {
     return Fe.rejectNonCanonical(s, endian);
 }
 
 /// Reduce a 48-bytes scalar to the field size.
-pub fn reduce48(s: [48]u8, endian: builtin.Endian) CompressedScalar {
+pub fn reduce48(s: [48]u8, endian: std.builtin.Endian) CompressedScalar {
     return Scalar.fromBytes48(s, endian).toBytes(endian);
 }
 
 /// Reduce a 64-bytes scalar to the field size.
-pub fn reduce64(s: [64]u8, endian: builtin.Endian) CompressedScalar {
+pub fn reduce64(s: [64]u8, endian: std.builtin.Endian) CompressedScalar {
     return ScalarDouble.fromBytes64(s, endian).toBytes(endian);
 }
 
 /// Return a*b (mod L)
-pub fn mul(a: CompressedScalar, b: CompressedScalar, endian: builtin.Endian) NonCanonicalError!CompressedScalar {
+pub fn mul(a: CompressedScalar, b: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!CompressedScalar {
     return (try Scalar.fromBytes(a, endian)).mul(try Scalar.fromBytes(b, endian)).toBytes(endian);
 }
 
 /// Return a*b+c (mod L)
-pub fn mulAdd(a: CompressedScalar, b: CompressedScalar, c: CompressedScalar, endian: builtin.Endian) NonCanonicalError!CompressedScalar {
+pub fn mulAdd(a: CompressedScalar, b: CompressedScalar, c: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!CompressedScalar {
     return (try Scalar.fromBytes(a, endian)).mul(try Scalar.fromBytes(b, endian)).add(try Scalar.fromBytes(c, endian)).toBytes(endian);
 }
 
 /// Return a+b (mod L)
-pub fn add(a: CompressedScalar, b: CompressedScalar, endian: builtin.Endian) NonCanonicalError!CompressedScalar {
+pub fn add(a: CompressedScalar, b: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!CompressedScalar {
     return (try Scalar.fromBytes(a, endian)).add(try Scalar.fromBytes(b, endian)).toBytes(endian);
 }
 
 /// Return -s (mod L)
-pub fn neg(s: CompressedScalar, endian: builtin.Endian) NonCanonicalError!CompressedScalar {
+pub fn neg(s: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!CompressedScalar {
     return (try Scalar.fromBytes(s, endian)).neg().toBytes(endian);
 }
 
 /// Return (a-b) (mod L)
-pub fn sub(a: CompressedScalar, b: CompressedScalar, endian: builtin.Endian) NonCanonicalError!CompressedScalar {
+pub fn sub(a: CompressedScalar, b: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!CompressedScalar {
     return (try Scalar.fromBytes(a, endian)).sub(try Scalar.fromBytes(b.endian)).toBytes(endian);
 }
 
 /// Return a random scalar
-pub fn random(endian: builtin.Endian) CompressedScalar {
+pub fn random(endian: std.builtin.Endian) CompressedScalar {
     return Scalar.random().toBytes(endian);
 }
 
@@ -87,24 +87,24 @@ pub const Scalar = struct {
     pub const one = Scalar{ .fe = Fe.one };
 
     /// Unpack a serialized representation of a scalar.
-    pub fn fromBytes(s: CompressedScalar, endian: builtin.Endian) NonCanonicalError!Scalar {
+    pub fn fromBytes(s: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!Scalar {
         return Scalar{ .fe = try Fe.fromBytes(s, endian) };
     }
 
     /// Reduce a 384 bit input to the field size.
-    pub fn fromBytes48(s: [48]u8, endian: builtin.Endian) Scalar {
+    pub fn fromBytes48(s: [48]u8, endian: std.builtin.Endian) Scalar {
         const t = ScalarDouble.fromBytes(384, s, endian);
         return t.reduce(384);
     }
 
     /// Reduce a 512 bit input to the field size.
-    pub fn fromBytes64(s: [64]u8, endian: builtin.Endian) Scalar {
+    pub fn fromBytes64(s: [64]u8, endian: std.builtin.Endian) Scalar {
         const t = ScalarDouble.fromBytes(512, s, endian);
         return t.reduce(512);
     }
 
     /// Pack a scalar into bytes.
-    pub fn toBytes(n: Scalar, endian: builtin.Endian) CompressedScalar {
+    pub fn toBytes(n: Scalar, endian: std.builtin.Endian) CompressedScalar {
         return n.fe.toBytes(endian);
     }
 
@@ -186,7 +186,7 @@ const ScalarDouble = struct {
     x2: Fe,
     x3: Fe,
 
-    fn fromBytes(comptime bits: usize, s_: [bits / 8]u8, endian: builtin.Endian) ScalarDouble {
+    fn fromBytes(comptime bits: usize, s_: [bits / 8]u8, endian: std.builtin.Endian) ScalarDouble {
         debug.assert(bits > 0 and bits <= 512 and bits >= Fe.saturated_bits and bits <= Fe.saturated_bits * 3);
 
         var s = s_;

--- a/lib/std/crypto/salsa20.zig
+++ b/lib/std/crypto/salsa20.zig
@@ -5,6 +5,7 @@
 // and substantial portions of the software.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const crypto = std.crypto;
 const debug = std.debug;
 const math = std.math;
@@ -310,7 +311,7 @@ const Salsa20NonVecImpl = struct {
     }
 };
 
-const Salsa20Impl = if (std.Target.current.cpu.arch == .x86_64) Salsa20VecImpl else Salsa20NonVecImpl;
+const Salsa20Impl = if (builtin.cpu.arch == .x86_64) Salsa20VecImpl else Salsa20NonVecImpl;
 
 fn keyToWords(key: [32]u8) [8]u32 {
     var k: [8]u32 = undefined;

--- a/lib/std/cstr.zig
+++ b/lib/std/cstr.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const debug = std.debug;
 const mem = std.mem;
 const testing = std.testing;

--- a/lib/std/dwarf.zig
+++ b/lib/std/dwarf.zig
@@ -243,7 +243,7 @@ const LineNumberProgram = struct {
     }
 };
 
-fn readUnitLength(in_stream: anytype, endian: builtin.Endian, is_64: *bool) !u64 {
+fn readUnitLength(in_stream: anytype, endian: std.builtin.Endian, is_64: *bool) !u64 {
     const first_32_bits = try in_stream.readInt(u32, endian);
     is_64.* = (first_32_bits == 0xffffffff);
     if (is_64.*) {
@@ -264,7 +264,7 @@ fn readAllocBytes(allocator: *mem.Allocator, in_stream: anytype, size: usize) ![
 }
 
 // TODO the nosuspends here are workarounds
-fn readAddress(in_stream: anytype, endian: builtin.Endian, is_64: bool) !u64 {
+fn readAddress(in_stream: anytype, endian: std.builtin.Endian, is_64: bool) !u64 {
     return nosuspend if (is_64)
         try in_stream.readInt(u64, endian)
     else
@@ -277,12 +277,12 @@ fn parseFormValueBlockLen(allocator: *mem.Allocator, in_stream: anytype, size: u
 }
 
 // TODO the nosuspends here are workarounds
-fn parseFormValueBlock(allocator: *mem.Allocator, in_stream: anytype, endian: builtin.Endian, size: usize) !FormValue {
+fn parseFormValueBlock(allocator: *mem.Allocator, in_stream: anytype, endian: std.builtin.Endian, size: usize) !FormValue {
     const block_len = try nosuspend in_stream.readVarInt(usize, endian, size);
     return parseFormValueBlockLen(allocator, in_stream, block_len);
 }
 
-fn parseFormValueConstant(allocator: *mem.Allocator, in_stream: anytype, signed: bool, endian: builtin.Endian, comptime size: i32) !FormValue {
+fn parseFormValueConstant(allocator: *mem.Allocator, in_stream: anytype, signed: bool, endian: std.builtin.Endian, comptime size: i32) !FormValue {
     _ = allocator;
     // TODO: Please forgive me, I've worked around zig not properly spilling some intermediate values here.
     // `nosuspend` should be removed from all the function calls once it is fixed.
@@ -310,7 +310,7 @@ fn parseFormValueConstant(allocator: *mem.Allocator, in_stream: anytype, signed:
 }
 
 // TODO the nosuspends here are workarounds
-fn parseFormValueRef(allocator: *mem.Allocator, in_stream: anytype, endian: builtin.Endian, size: i32) !FormValue {
+fn parseFormValueRef(allocator: *mem.Allocator, in_stream: anytype, endian: std.builtin.Endian, size: i32) !FormValue {
     _ = allocator;
     return FormValue{
         .Ref = switch (size) {
@@ -325,7 +325,7 @@ fn parseFormValueRef(allocator: *mem.Allocator, in_stream: anytype, endian: buil
 }
 
 // TODO the nosuspends here are workarounds
-fn parseFormValue(allocator: *mem.Allocator, in_stream: anytype, form_id: u64, endian: builtin.Endian, is_64: bool) anyerror!FormValue {
+fn parseFormValue(allocator: *mem.Allocator, in_stream: anytype, form_id: u64, endian: std.builtin.Endian, is_64: bool) anyerror!FormValue {
     return switch (form_id) {
         FORM_addr => FormValue{ .Address = try readAddress(in_stream, endian, @sizeOf(usize) == 8) },
         FORM_block1 => parseFormValueBlock(allocator, in_stream, endian, 1),
@@ -382,7 +382,7 @@ fn getAbbrevTableEntry(abbrev_table: *const AbbrevTable, abbrev_code: u64) ?*con
 }
 
 pub const DwarfInfo = struct {
-    endian: builtin.Endian,
+    endian: std.builtin.Endian,
     // No memory is owned by the DwarfInfo
     debug_info: []const u8,
     debug_abbrev: []const u8,

--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -3,7 +3,7 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-const builtin = std.builtin;
+const builtin = @import("builtin");
 
 const std = @import("std.zig");
 const mem = std.mem;

--- a/lib/std/event/channel.zig
+++ b/lib/std/event/channel.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const testing = std.testing;
 const Loop = std.event.Loop;

--- a/lib/std/event/future.zig
+++ b/lib/std/event/future.zig
@@ -4,9 +4,9 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const testing = std.testing;
-const builtin = std.builtin;
 const Lock = std.event.Lock;
 
 /// This is a value that starts out unavailable, until resolve() is called

--- a/lib/std/event/group.zig
+++ b/lib/std/event/group.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const Lock = std.event.Lock;
 const testing = std.testing;
 const Allocator = std.mem.Allocator;

--- a/lib/std/event/lock.zig
+++ b/lib/std/event/lock.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const testing = std.testing;
 const mem = std.mem;

--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const root = @import("root");
 const assert = std.debug.assert;
 const testing = std.testing;
@@ -14,7 +14,7 @@ const windows = os.windows;
 const maxInt = std.math.maxInt;
 const Thread = std.Thread;
 
-const is_windows = std.Target.current.os.tag == .windows;
+const is_windows = builtin.os.tag == .windows;
 
 pub const Loop = struct {
     next_tick_queue: std.atomic.Queue(anyframe),
@@ -196,7 +196,7 @@ pub const Loop = struct {
             self.fs_thread.join();
         };
 
-        if (!std.builtin.single_threaded)
+        if (!builtin.single_threaded)
             try self.delay_queue.init();
     }
 
@@ -767,7 +767,7 @@ pub const Loop = struct {
     }
 
     pub fn sleep(self: *Loop, nanoseconds: u64) void {
-        if (std.builtin.single_threaded)
+        if (builtin.single_threaded)
             @compileError("TODO: integrate timers with epoll/kevent/iocp for single-threaded");
 
         suspend {

--- a/lib/std/event/rwlock.zig
+++ b/lib/std/event/rwlock.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const testing = std.testing;
 const mem = std.mem;

--- a/lib/std/event/wait_group.zig
+++ b/lib/std/event/wait_group.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const Loop = std.event.Loop;
 
 /// A WaitGroup keeps track and waits for a group of async tasks to finish.

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2137,7 +2137,7 @@ test "float.special" {
     try expectFmt("f64: nan", "f64: {}", .{math.nan_f64});
     // negative nan is not defined by IEE 754,
     // and ARM thus normalizes it to positive nan
-    if (builtin.target.cpu.arch != .arm) {
+    if (builtin.cpu.arch != .arm) {
         try expectFmt("f64: -nan", "f64: {}", .{-math.nan_f64});
     }
     try expectFmt("f64: inf", "f64: {}", .{math.inf_f64});
@@ -2148,7 +2148,7 @@ test "float.hexadecimal.special" {
     try expectFmt("f64: nan", "f64: {x}", .{math.nan_f64});
     // negative nan is not defined by IEE 754,
     // and ARM thus normalizes it to positive nan
-    if (builtin.target.cpu.arch != .arm) {
+    if (builtin.cpu.arch != .arm) {
         try expectFmt("f64: -nan", "f64: {x}", .{-math.nan_f64});
     }
     try expectFmt("f64: inf", "f64: {x}", .{math.inf_f64});
@@ -2502,11 +2502,11 @@ test "positional/alignment/width/precision" {
 }
 
 test "vector" {
-    if (builtin.target.cpu.arch == .mipsel or builtin.target.cpu.arch == .mips) {
+    if (builtin.cpu.arch == .mipsel or builtin.cpu.arch == .mips) {
         // https://github.com/ziglang/zig/issues/3317
         return error.SkipZigTest;
     }
-    if (builtin.target.cpu.arch == .riscv64) {
+    if (builtin.cpu.arch == .riscv64) {
         // https://github.com/ziglang/zig/issues/4486
         return error.SkipZigTest;
     }

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const root = @import("root");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const std = @import("std.zig");
 const os = std.os;
 const mem = std.mem;
@@ -14,7 +14,7 @@ const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const math = std.math;
 
-const is_darwin = std.Target.current.os.tag.isDarwin();
+const is_darwin = builtin.os.tag.isDarwin();
 
 pub const path = @import("fs/path.zig");
 pub const File = @import("fs/file.zig").File;
@@ -2538,7 +2538,7 @@ const CopyFileError = error{SystemResources} || os.CopyFileRangeError || os.Send
 // The copy starts at offset 0, the initial offsets are preserved.
 // No metadata is transferred over.
 fn copy_file(fd_in: os.fd_t, fd_out: os.fd_t) CopyFileError!void {
-    if (comptime std.Target.current.isDarwin()) {
+    if (comptime builtin.target.isDarwin()) {
         const rc = os.system.fcopyfile(fd_in, fd_out, null, os.system.COPYFILE_DATA);
         switch (os.errno(rc)) {
             0 => return,
@@ -2551,7 +2551,7 @@ fn copy_file(fd_in: os.fd_t, fd_out: os.fd_t) CopyFileError!void {
         }
     }
 
-    if (std.Target.current.os.tag == .linux) {
+    if (builtin.os.tag == .linux) {
         // Try copy_file_range first as that works at the FS level and is the
         // most efficient method (if available).
         var offset: u64 = 0;

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -4,16 +4,16 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const os = std.os;
 const io = std.io;
 const mem = std.mem;
 const math = std.math;
 const assert = std.debug.assert;
 const windows = os.windows;
-const Os = builtin.Os;
+const Os = std.builtin.Os;
 const maxInt = std.math.maxInt;
-const is_windows = std.Target.current.os.tag == .windows;
+const is_windows = builtin.os.tag == .windows;
 
 pub const File = struct {
     /// The OS-specific file descriptor or file handle.

--- a/lib/std/fs/get_app_data_dir.zig
+++ b/lib/std/fs/get_app_data_dir.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const unicode = std.unicode;
 const mem = std.mem;
 const fs = std.fs;

--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -15,7 +15,7 @@ const math = std.math;
 const windows = std.os.windows;
 const fs = std.fs;
 const process = std.process;
-const native_os = builtin.target.os.tag;
+const native_os = builtin.os.tag;
 
 pub const sep_windows = '\\';
 pub const sep_posix = '/';
@@ -707,7 +707,7 @@ test "resolve" {
 }
 
 test "resolveWindows" {
-    if (builtin.target.cpu.arch == .aarch64) {
+    if (builtin.cpu.arch == .aarch64) {
         // TODO https://github.com/ziglang/zig/issues/3288
         return error.SkipZigTest;
     }
@@ -1165,7 +1165,7 @@ pub fn relativePosix(allocator: *Allocator, from: []const u8, to: []const u8) ![
 }
 
 test "relative" {
-    if (builtin.target.cpu.arch == .aarch64) {
+    if (builtin.cpu.arch == .aarch64) {
         // TODO https://github.com/ziglang/zig/issues/3288
         return error.SkipZigTest;
     }

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -5,7 +5,7 @@
 // and substantial portions of the software.
 const std = @import("../std.zig");
 const testing = std.testing;
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const fs = std.fs;
 const mem = std.mem;
 const wasi = std.os.wasi;

--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
+const builtin = @import("builtin");
 const os = std.os;
 const mem = std.mem;
 const math = std.math;
@@ -169,7 +170,7 @@ pub const PreopenList = struct {
 };
 
 test "extracting WASI preopens" {
-    if (std.builtin.os.tag != .wasi) return error.SkipZigTest;
+    if (builtin.os.tag != .wasi) return error.SkipZigTest;
 
     var preopens = PreopenList.init(std.testing.allocator);
     defer preopens.deinit();

--- a/lib/std/fs/watch.zig
+++ b/lib/std/fs/watch.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const event = std.event;
 const assert = std.debug.assert;
 const testing = std.testing;
@@ -255,7 +255,7 @@ pub fn Watch(comptime V: type) type {
             };
 
             // @TODO Can I close this fd and get an error from bsdWaitKev?
-            const flags = if (comptime std.Target.current.isDarwin()) os.O_SYMLINK | os.O_EVTONLY else 0;
+            const flags = if (comptime builtin.target.isDarwin()) os.O_SYMLINK | os.O_EVTONLY else 0;
             const fd = try os.open(realpath, flags, 0);
             gop.value_ptr.putter_frame = async self.kqPutEvents(fd, gop.key_ptr.*, gop.value_ptr.*);
             return null;

--- a/lib/std/hash/auto_hash.zig
+++ b/lib/std/hash/auto_hash.zig
@@ -7,7 +7,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const mem = std.mem;
 const meta = std.meta;
-const builtin = std.builtin;
+const builtin = @import("builtin");
 
 /// Describes how pointer types should be hashed.
 pub const HashStrategy = enum {
@@ -241,7 +241,7 @@ fn testHashDeepRecursive(key: anytype) u64 {
 
 test "typeContainsSlice" {
     comptime {
-        try testing.expect(!typeContainsSlice(meta.Tag(builtin.TypeInfo)));
+        try testing.expect(!typeContainsSlice(meta.Tag(std.builtin.TypeInfo)));
 
         try testing.expect(typeContainsSlice([]const u8));
         try testing.expect(!typeContainsSlice(u8));
@@ -408,7 +408,7 @@ test "testHash union" {
 
 test "testHash vector" {
     // Disabled because of #3317
-    if (builtin.target.cpu.arch == .mipsel or builtin.target.cpu.arch == .mips) return error.SkipZigTest;
+    if (builtin.cpu.arch == .mipsel or builtin.cpu.arch == .mips) return error.SkipZigTest;
 
     const a: meta.Vector(4, u32) = [_]u32{ 1, 2, 3, 4 };
     const b: meta.Vector(4, u32) = [_]u32{ 1, 2, 3, 5 };

--- a/lib/std/hash/benchmark.zig
+++ b/lib/std/hash/benchmark.zig
@@ -5,7 +5,7 @@
 // and substantial portions of the software.
 // zig run benchmark.zig --release-fast --zig-lib-dir ..
 
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const std = @import("std");
 const time = std.time;
 const Timer = time.Timer;

--- a/lib/std/hash/crc.zig
+++ b/lib/std/hash/crc.zig
@@ -102,7 +102,7 @@ pub fn Crc32WithPoly(comptime poly: Polynomial) type {
     };
 }
 
-const please_windows_dont_oom = std.Target.current.os.tag == .windows;
+const please_windows_dont_oom = @import("builtin").os.tag == .windows;
 
 test "crc32 ieee" {
     if (please_windows_dont_oom) return error.SkipZigTest;

--- a/lib/std/hash/murmur.zig
+++ b/lib/std/hash/murmur.zig
@@ -6,7 +6,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const testing = std.testing;
-const native_endian = builtin.target.cpu.arch.endian();
+const native_endian = builtin.cpu.arch.endian();
 
 const default_seed: u32 = 0xc70f6907;
 

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const root = @import("root");
 const c = std.c;
 

--- a/lib/std/io/bit_reader.zig
+++ b/lib/std/io/bit_reader.zig
@@ -13,7 +13,7 @@ const meta = std.meta;
 const math = std.math;
 
 /// Creates a stream which allows for reading bit fields from another stream
-pub fn BitReader(endian: builtin.Endian, comptime ReaderType: type) type {
+pub fn BitReader(endian: std.builtin.Endian, comptime ReaderType: type) type {
     return struct {
         forward_reader: ReaderType,
         bit_buffer: u7,
@@ -167,7 +167,7 @@ pub fn BitReader(endian: builtin.Endian, comptime ReaderType: type) type {
 }
 
 pub fn bitReader(
-    comptime endian: builtin.Endian,
+    comptime endian: std.builtin.Endian,
     underlying_stream: anytype,
 ) BitReader(endian, @TypeOf(underlying_stream)) {
     return BitReader(endian, @TypeOf(underlying_stream)).init(underlying_stream);

--- a/lib/std/io/bit_writer.zig
+++ b/lib/std/io/bit_writer.zig
@@ -13,7 +13,7 @@ const meta = std.meta;
 const math = std.math;
 
 /// Creates a stream which allows for writing bit fields to another stream
-pub fn BitWriter(endian: builtin.Endian, comptime WriterType: type) type {
+pub fn BitWriter(endian: std.builtin.Endian, comptime WriterType: type) type {
     return struct {
         forward_writer: WriterType,
         bit_buffer: u8,
@@ -143,7 +143,7 @@ pub fn BitWriter(endian: builtin.Endian, comptime WriterType: type) type {
 }
 
 pub fn bitWriter(
-    comptime endian: builtin.Endian,
+    comptime endian: std.builtin.Endian,
     underlying_stream: anytype,
 ) BitWriter(endian, @TypeOf(underlying_stream)) {
     return BitWriter(endian, @TypeOf(underlying_stream)).init(underlying_stream);

--- a/lib/std/io/c_writer.zig
+++ b/lib/std/io/c_writer.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const io = std.io;
 const testing = std.testing;
 

--- a/lib/std/io/reader.zig
+++ b/lib/std/io/reader.zig
@@ -253,12 +253,12 @@ pub fn Reader(
             return mem.readIntBig(T, &bytes);
         }
 
-        pub fn readInt(self: Self, comptime T: type, endian: builtin.Endian) !T {
+        pub fn readInt(self: Self, comptime T: type, endian: std.builtin.Endian) !T {
             const bytes = try self.readBytesNoEof((@typeInfo(T).Int.bits + 7) / 8);
             return mem.readInt(T, &bytes, endian);
         }
 
-        pub fn readVarInt(self: Self, comptime ReturnType: type, endian: builtin.Endian, size: usize) !ReturnType {
+        pub fn readVarInt(self: Self, comptime ReturnType: type, endian: std.builtin.Endian, size: usize) !ReturnType {
             assert(size <= @sizeOf(ReturnType));
             var bytes_buf: [@sizeOf(ReturnType)]u8 = undefined;
             const bytes = bytes_buf[0..size];
@@ -298,7 +298,7 @@ pub fn Reader(
 
         pub fn readStruct(self: Self, comptime T: type) !T {
             // Only extern and packed structs have defined in-memory layout.
-            comptime assert(@typeInfo(T).Struct.layout != builtin.TypeInfo.ContainerLayout.Auto);
+            comptime assert(@typeInfo(T).Struct.layout != std.builtin.TypeInfo.ContainerLayout.Auto);
             var res: [1]T = undefined;
             try self.readNoEof(mem.sliceAsBytes(res[0..]));
             return res[0];
@@ -307,7 +307,7 @@ pub fn Reader(
         /// Reads an integer with the same size as the given enum's tag type. If the integer matches
         /// an enum tag, casts the integer to the enum tag and returns it. Otherwise, returns an error.
         /// TODO optimization taking advantage of most fields being in order
-        pub fn readEnum(self: Self, comptime Enum: type, endian: builtin.Endian) !Enum {
+        pub fn readEnum(self: Self, comptime Enum: type, endian: std.builtin.Endian) !Enum {
             const E = error{
                 /// An integer was read, but it did not match any of the tags in the supplied enum.
                 InvalidValue,

--- a/lib/std/io/stream_source.zig
+++ b/lib/std/io/stream_source.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const io = std.io;
 
 /// Provides `io.Reader`, `io.Writer`, and `io.SeekableStream` for in-memory buffers as
@@ -11,7 +12,7 @@ const io = std.io;
 /// For memory sources, if the supplied byte buffer is const, then `io.Writer` is not available.
 /// The error set of the stream functions is the error set of the corresponding file functions.
 pub const StreamSource = union(enum) {
-    const has_file = (std.builtin.os.tag != .freestanding);
+    const has_file = (builtin.os.tag != .freestanding);
 
     /// The stream access is redirected to this buffer.
     buffer: io.FixedBufferStream([]u8),

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -15,7 +15,7 @@ const expectError = std.testing.expectError;
 const mem = std.mem;
 const fs = std.fs;
 const File = std.fs.File;
-const native_endian = builtin.target.cpu.arch.endian();
+const native_endian = builtin.cpu.arch.endian();
 
 const tmpDir = std.testing.tmpDir;
 

--- a/lib/std/io/writer.zig
+++ b/lib/std/io/writer.zig
@@ -82,7 +82,7 @@ pub fn Writer(
         }
 
         /// TODO audit non-power-of-two int sizes
-        pub fn writeInt(self: Self, comptime T: type, value: T, endian: builtin.Endian) Error!void {
+        pub fn writeInt(self: Self, comptime T: type, value: T, endian: std.builtin.Endian) Error!void {
             var bytes: [(@typeInfo(T).Int.bits + 7) / 8]u8 = undefined;
             mem.writeInt(T, &bytes, value, endian);
             return self.writeAll(&bytes);
@@ -90,7 +90,7 @@ pub fn Writer(
 
         pub fn writeStruct(self: Self, value: anytype) Error!void {
             // Only extern and packed structs have defined in-memory layout.
-            comptime assert(@typeInfo(@TypeOf(value)).Struct.layout != builtin.TypeInfo.ContainerLayout.Auto);
+            comptime assert(@typeInfo(@TypeOf(value)).Struct.layout != std.builtin.TypeInfo.ContainerLayout.Auto);
             return self.writeAll(mem.asBytes(&value));
         }
     };

--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -75,7 +75,7 @@
 //! ```
 
 const std = @import("std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const root = @import("root");
 
 pub const Level = enum {
@@ -145,7 +145,7 @@ fn log(
             if (@typeInfo(@TypeOf(root.log)) != .Fn)
                 @compileError("Expected root.log to be a function");
             root.log(message_level, scope, format, args);
-        } else if (std.Target.current.os.tag == .freestanding) {
+        } else if (builtin.os.tag == .freestanding) {
             // On freestanding one must provide a log function; we do not have
             // any I/O configured.
             return;

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std.zig");
+const builtin = @import("builtin");
 const debug = std.debug;
 const assert = debug.assert;
 const math = std.math;
@@ -12,13 +13,13 @@ const meta = std.meta;
 const trait = meta.trait;
 const testing = std.testing;
 const Endian = std.builtin.Endian;
-const native_endian = std.Target.current.cpu.arch.endian();
+const native_endian = builtin.cpu.arch.endian();
 
 /// Compile time known minimum page size.
 /// https://github.com/ziglang/zig/issues/4082
-pub const page_size = switch (std.Target.current.cpu.arch) {
+pub const page_size = switch (builtin.cpu.arch) {
     .wasm32, .wasm64 => 64 * 1024,
-    .aarch64 => switch (std.Target.current.os.tag) {
+    .aarch64 => switch (builtin.os.tag) {
         .macos, .ios, .watchos, .tvos => 16 * 1024,
         else => 4 * 1024,
     },

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -14,7 +14,7 @@ const root = @import("root");
 pub const trait = @import("meta/trait.zig");
 pub const TrailerFlags = @import("meta/trailer_flags.zig").TrailerFlags;
 
-const TypeInfo = builtin.TypeInfo;
+const TypeInfo = std.builtin.TypeInfo;
 
 pub fn tagName(v: anytype) []const u8 {
     const T = @TypeOf(v);
@@ -860,7 +860,7 @@ pub fn declList(comptime Namespace: type, comptime Decl: type) []const *const De
 
 pub const IntType = @compileError("replaced by std.meta.Int");
 
-pub fn Int(comptime signedness: builtin.Signedness, comptime bit_count: u16) type {
+pub fn Int(comptime signedness: std.builtin.Signedness, comptime bit_count: u16) type {
     return @Type(TypeInfo{
         .Int = .{
             .signedness = signedness,

--- a/lib/std/meta/trait.zig
+++ b/lib/std/meta/trait.zig
@@ -103,7 +103,7 @@ test "std.meta.trait.hasField" {
     try testing.expect(!hasField("value")(u8));
 }
 
-pub fn is(comptime id: builtin.TypeId) TraitFn {
+pub fn is(comptime id: std.builtin.TypeId) TraitFn {
     const Closure = struct {
         pub fn trait(comptime T: type) bool {
             return id == @typeInfo(T);
@@ -120,7 +120,7 @@ test "std.meta.trait.is" {
     try testing.expect(!is(.Optional)(anyerror));
 }
 
-pub fn isPtrTo(comptime id: builtin.TypeId) TraitFn {
+pub fn isPtrTo(comptime id: std.builtin.TypeId) TraitFn {
     const Closure = struct {
         pub fn trait(comptime T: type) bool {
             if (!comptime isSingleItemPtr(T)) return false;
@@ -136,7 +136,7 @@ test "std.meta.trait.isPtrTo" {
     try testing.expect(!isPtrTo(.Struct)(**struct {}));
 }
 
-pub fn isSliceOf(comptime id: builtin.TypeId) TraitFn {
+pub fn isSliceOf(comptime id: std.builtin.TypeId) TraitFn {
     const Closure = struct {
         pub fn trait(comptime T: type) bool {
             if (!comptime isSlice(T)) return false;

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const net = std.net;
 const mem = std.mem;
 const testing = std.testing;
@@ -40,7 +40,7 @@ test "parse and render IPv6 addresses" {
         var newIp = std.fmt.bufPrint(buffer[0..], "{}", .{addr}) catch unreachable;
         try std.testing.expect(std.mem.eql(u8, printed[i], newIp[1 .. newIp.len - 3]));
 
-        if (std.builtin.os.tag == .linux) {
+        if (builtin.os.tag == .linux) {
             var addr_via_resolve = net.Address.resolveIp6(ip, 0) catch unreachable;
             var newResolvedIp = std.fmt.bufPrint(buffer[0..], "{}", .{addr_via_resolve}) catch unreachable;
             try std.testing.expect(std.mem.eql(u8, printed[i], newResolvedIp[1 .. newResolvedIp.len - 3]));
@@ -54,7 +54,7 @@ test "parse and render IPv6 addresses" {
     try testing.expectError(error.Incomplete, net.Address.parseIp6("FF01:", 0));
     try testing.expectError(error.InvalidIpv4Mapping, net.Address.parseIp6("::123.123.123.123", 0));
     // TODO Make this test pass on other operating systems.
-    if (std.builtin.os.tag == .linux) {
+    if (builtin.os.tag == .linux) {
         try testing.expectError(error.Incomplete, net.Address.resolveIp6("ff01::fb%", 0));
         try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%wlp3s0s0s0s0s0s0s0s0", 0));
         try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%12345678901234", 0));
@@ -62,7 +62,7 @@ test "parse and render IPv6 addresses" {
 }
 
 test "invalid but parseable IPv6 scope ids" {
-    if (std.builtin.os.tag != .linux) {
+    if (builtin.os.tag != .linux) {
         // Currently, resolveIp6 with alphanumerical scope IDs only works on Linux.
         // TODO Make this test pass on other operating systems.
         return error.SkipZigTest;
@@ -97,11 +97,11 @@ test "parse and render IPv4 addresses" {
 test "resolve DNS" {
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
-    if (std.builtin.os.tag == .windows) {
+    if (builtin.os.tag == .windows) {
         _ = try std.os.windows.WSAStartup(2, 2);
     }
     defer {
-        if (std.builtin.os.tag == .windows) {
+        if (builtin.os.tag == .windows) {
             std.os.windows.WSACleanup() catch unreachable;
         }
     }
@@ -134,11 +134,11 @@ test "listen on a port, send bytes, receive bytes" {
     if (builtin.single_threaded) return error.SkipZigTest;
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
-    if (std.builtin.os.tag == .windows) {
+    if (builtin.os.tag == .windows) {
         _ = try std.os.windows.WSAStartup(2, 2);
     }
     defer {
-        if (std.builtin.os.tag == .windows) {
+        if (builtin.os.tag == .windows) {
             std.os.windows.WSACleanup() catch unreachable;
         }
     }
@@ -176,7 +176,7 @@ test "listen on a port, send bytes, receive bytes" {
 test "listen on a port, send bytes, receive bytes" {
     if (!std.io.is_async) return error.SkipZigTest;
 
-    if (std.builtin.os.tag != .linux and !std.builtin.os.tag.isDarwin()) {
+    if (builtin.os.tag != .linux and !builtin.os.tag.isDarwin()) {
         // TODO build abstractions for other operating systems
         return error.SkipZigTest;
     }
@@ -198,7 +198,7 @@ test "listen on a port, send bytes, receive bytes" {
 test "listen on ipv4 try connect on ipv6 then ipv4" {
     if (!std.io.is_async) return error.SkipZigTest;
 
-    if (std.builtin.os.tag != .linux and !std.builtin.os.tag.isDarwin()) {
+    if (builtin.os.tag != .linux and !builtin.os.tag.isDarwin()) {
         // TODO build abstractions for other operating systems
         return error.SkipZigTest;
     }
@@ -258,11 +258,11 @@ test "listen on a unix socket, send bytes, receive bytes" {
     if (builtin.single_threaded) return error.SkipZigTest;
     if (!net.has_unix_sockets) return error.SkipZigTest;
 
-    if (std.builtin.os.tag == .windows) {
+    if (builtin.os.tag == .windows) {
         _ = try std.os.windows.WSAStartup(2, 2);
     }
     defer {
-        if (std.builtin.os.tag == .windows) {
+        if (builtin.os.tag == .windows) {
             std.os.windows.WSACleanup() catch unreachable;
         }
     }

--- a/lib/std/once.zig
+++ b/lib/std/once.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const testing = std.testing;
 
 pub fn once(comptime f: fn () void) Once(f) {

--- a/lib/std/os/bits.zig
+++ b/lib/std/os/bits.zig
@@ -11,7 +11,7 @@
 const std = @import("std");
 const root = @import("root");
 
-pub usingnamespace switch (std.Target.current.os.tag) {
+pub usingnamespace switch (@import("builtin").os.tag) {
     .macos, .ios, .tvos, .watchos => @import("bits/darwin.zig"),
     .dragonfly => @import("bits/dragonfly.zig"),
     .freebsd => @import("bits/freebsd.zig"),

--- a/lib/std/os/bits/freebsd.zig
+++ b/lib/std/os/bits/freebsd.zig
@@ -836,7 +836,7 @@ pub const sigset_t = extern struct {
 
 pub const empty_sigset = sigset_t{ .__bits = [_]u32{0} ** _SIG_WORDS };
 
-pub usingnamespace switch (builtin.target.cpu.arch) {
+pub usingnamespace switch (builtin.cpu.arch) {
     .x86_64 => struct {
         pub const ucontext_t = extern struct {
             sigmask: sigset_t,
@@ -1005,7 +1005,7 @@ pub const EOWNERDEAD = 96; // Previous owner died
 
 pub const ELAST = 96; // Must be equal largest errno
 
-pub const MINSIGSTKSZ = switch (builtin.target.cpu.arch) {
+pub const MINSIGSTKSZ = switch (builtin.cpu.arch) {
     .i386, .x86_64 => 2048,
     .arm, .aarch64 => 4096,
     else => @compileError("MINSIGSTKSZ not defined for this architecture"),

--- a/lib/std/os/bits/netbsd.zig
+++ b/lib/std/os/bits/netbsd.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const maxInt = std.math.maxInt;
 
 pub const blkcnt_t = i64;

--- a/lib/std/os/bits/openbsd.zig
+++ b/lib/std/os/bits/openbsd.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const maxInt = std.math.maxInt;
 
 pub const blkcnt_t = i64;
@@ -765,7 +765,7 @@ comptime {
         std.debug.assert(@sizeOf(siginfo_t) == 136);
 }
 
-pub usingnamespace switch (builtin.target.cpu.arch) {
+pub usingnamespace switch (builtin.cpu.arch) {
     .x86_64 => struct {
         pub const ucontext_t = extern struct {
             sc_rdi: c_long,
@@ -942,7 +942,7 @@ pub const EPROTO = 95; // Protocol error
 
 pub const ELAST = 95; // Must equal largest errno
 
-const _MAX_PAGE_SHIFT = switch (builtin.target.cpu.arch) {
+const _MAX_PAGE_SHIFT = switch (builtin.cpu.arch) {
     .i386 => 12,
     .sparcv9 => 13,
 };

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -16,7 +16,8 @@ const maxInt = std.math.maxInt;
 const elf = std.elf;
 const vdso = @import("linux/vdso.zig");
 const dl = @import("../dynamic_library.zig");
-const native_arch = std.Target.current.cpu.arch;
+const builtin = @import("builtin");
+const native_arch = builtin.cpu.arch;
 const native_endian = native_arch.endian();
 
 pub usingnamespace switch (native_arch) {
@@ -55,10 +56,10 @@ pub fn getauxval(index: usize) usize {
 // Some architectures (and some syscalls) require 64bit parameters to be passed
 // in a even-aligned register pair.
 const require_aligned_register_pair =
-    std.Target.current.cpu.arch.isPPC() or
-    std.Target.current.cpu.arch.isMIPS() or
-    std.Target.current.cpu.arch.isARM() or
-    std.Target.current.cpu.arch.isThumb();
+    native_arch.isPPC() or
+    native_arch.isMIPS() or
+    native_arch.isARM() or
+    native_arch.isThumb();
 
 // Split a 64bit value into a {LSB,MSB} pair.
 // The LE/BE variants specify the endianness to assume.
@@ -1465,7 +1466,7 @@ pub fn process_vm_writev(pid: pid_t, local: [*]const iovec, local_count: usize, 
 }
 
 pub fn fadvise(fd: fd_t, offset: i64, len: i64, advice: usize) usize {
-    if (comptime std.Target.current.cpu.arch.isMIPS()) {
+    if (comptime native_arch.isMIPS()) {
         // MIPS requires a 7 argument syscall
 
         const offset_halves = splitValue64(offset);
@@ -1481,7 +1482,7 @@ pub fn fadvise(fd: fd_t, offset: i64, len: i64, advice: usize) usize {
             length_halves[1],
             advice,
         );
-    } else if (comptime std.Target.current.cpu.arch.isARM()) {
+    } else if (comptime native_arch.isARM()) {
         // ARM reorders the arguments
 
         const offset_halves = splitValue64(offset);
@@ -1524,7 +1525,7 @@ pub fn fadvise(fd: fd_t, offset: i64, len: i64, advice: usize) usize {
 }
 
 test {
-    if (std.Target.current.os.tag == .linux) {
+    if (builtin.os.tag == .linux) {
         _ = @import("linux/test.zig");
     }
 }

--- a/lib/std/os/linux/bpf/kern.zig
+++ b/lib/std/os/linux/bpf/kern.zig
@@ -4,8 +4,9 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../../../std.zig");
+const builtin = @import("builtin");
 
-const in_bpf_program = switch (std.builtin.cpu.arch) {
+const in_bpf_program = switch (builtin.cpu.arch) {
     .bpfel, .bpfeb => true,
     else => false,
 };

--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -5,7 +5,7 @@
 // and substantial portions of the software.
 const std = @import("../../std.zig");
 const assert = std.debug.assert;
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const mem = std.mem;
 const net = std.net;
 const os = std.os;

--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const elf = std.elf;
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 
 const R_AMD64_RELATIVE = 8;

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("../../std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const linux = std.os.linux;
 const mem = std.mem;
 const elf = std.elf;

--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -9,7 +9,7 @@ const mem = std.mem;
 const elf = std.elf;
 const math = std.math;
 const assert = std.debug.assert;
-const native_arch = std.Target.current.cpu.arch;
+const native_arch = @import("builtin").cpu.arch;
 
 // This file implements the two TLS variants [1] used by ELF-based systems.
 //

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -21,7 +21,7 @@ const a = std.testing.allocator;
 const builtin = @import("builtin");
 const AtomicRmwOp = std.builtin.AtomicRmwOp;
 const AtomicOrder = std.builtin.AtomicOrder;
-const native_os = builtin.target.os.tag;
+const native_os = builtin.os.tag;
 const tmpDir = std.testing.tmpDir;
 const Dir = std.fs.Dir;
 const ArenaAllocator = std.heap.ArenaAllocator;
@@ -718,7 +718,7 @@ test "sigaction" {
         return error.SkipZigTest;
 
     // https://github.com/ziglang/zig/issues/7427
-    if (native_os == .linux and builtin.target.cpu.arch == .i386)
+    if (native_os == .linux and builtin.cpu.arch == .i386)
         return error.SkipZigTest;
 
     const S = struct {

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1022,7 +1022,7 @@ pub fn QueryObjectName(
     }
 }
 test "QueryObjectName" {
-    if (comptime builtin.target.os.tag != .windows)
+    if (comptime builtin.os.tag != .windows)
         return;
 
     //any file will do; canonicalization works on NTFS junctions and symlinks, hardlinks remain separate paths.
@@ -1176,7 +1176,7 @@ pub fn GetFinalPathNameByHandle(
 }
 
 test "GetFinalPathNameByHandle" {
-    if (comptime builtin.target.os.tag != .windows)
+    if (comptime builtin.os.tag != .windows)
         return;
 
     //any file will do
@@ -1721,7 +1721,7 @@ pub fn UnlockFile(
 }
 
 pub fn teb() *TEB {
-    return switch (builtin.target.cpu.arch) {
+    return switch (builtin.cpu.arch) {
         .i386 => asm volatile (
             \\ movl %%fs:0x18, %[ptr]
             : [ptr] "=r" (-> *TEB)

--- a/lib/std/os/windows/bits.zig
+++ b/lib/std/os/windows/bits.zig
@@ -6,9 +6,10 @@
 // Platform-dependent types and values that are used along with OS-specific APIs.
 
 const std = @import("../../std.zig");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const maxInt = std.math.maxInt;
-const arch = std.Target.current.cpu.arch;
+const arch = builtin.cpu.arch;
 
 pub usingnamespace @import("win32error.zig");
 pub usingnamespace @import("ntstatus.zig");

--- a/lib/std/os/windows/user32.zig
+++ b/lib/std/os/windows/user32.zig
@@ -5,7 +5,7 @@
 // and substantial portions of the software.
 usingnamespace @import("bits.zig");
 const std = @import("std");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const windows = @import("../windows.zig");
 const unexpectedError = windows.unexpectedError;
@@ -14,7 +14,7 @@ const SetLastError = windows.kernel32.SetLastError;
 
 fn selectSymbol(comptime function_static: anytype, function_dynamic: @TypeOf(function_static), comptime os: std.Target.Os.WindowsVersion) @TypeOf(function_static) {
     comptime {
-        const sym_ok = std.Target.current.os.isAtLeast(.windows, os);
+        const sym_ok = builtin.os.isAtLeast(.windows, os);
         if (sym_ok == true) return function_static;
         if (sym_ok == null) return function_dynamic;
         if (sym_ok == false) @compileError("Target OS range does not support function, at least " ++ @tagName(os) ++ " is required");

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -7,7 +7,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const debug = std.debug;
 const testing = std.testing;
-const native_endian = builtin.target.cpu.arch.endian();
+const native_endian = builtin.cpu.arch.endian();
 const Endian = std.builtin.Endian;
 
 pub fn PackedIntIo(comptime Int: type, comptime endian: Endian) type {
@@ -341,7 +341,7 @@ const we_are_testing_this_with_stage1_which_leaks_comptime_memory = true;
 
 test "PackedIntArray" {
     // TODO @setEvalBranchQuota generates panics in wasm32. Investigate.
-    if (builtin.target.cpu.arch == .wasm32) return error.SkipZigTest;
+    if (builtin.cpu.arch == .wasm32) return error.SkipZigTest;
     if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
 
     @setEvalBranchQuota(10000);
@@ -405,7 +405,7 @@ test "PackedIntArray initAllTo" {
 
 test "PackedIntSlice" {
     // TODO @setEvalBranchQuota generates panics in wasm32. Investigate.
-    if (builtin.target.cpu.arch == .wasm32) return error.SkipZigTest;
+    if (builtin.cpu.arch == .wasm32) return error.SkipZigTest;
     if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
 
     @setEvalBranchQuota(10000);
@@ -652,7 +652,7 @@ test "PackedInt(Array/Slice)Endian" {
 test "PackedIntArray at end of available memory" {
     if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
 
-    switch (builtin.target.os.tag) {
+    switch (builtin.os.tag) {
         .linux, .macos, .ios, .freebsd, .netbsd, .openbsd, .windows => {},
         else => return,
     }
@@ -673,7 +673,7 @@ test "PackedIntArray at end of available memory" {
 test "PackedIntSlice at end of available memory" {
     if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
 
-    switch (builtin.target.os.tag) {
+    switch (builtin.os.tag) {
         .linux, .macos, .ios, .freebsd, .netbsd, .openbsd, .windows => {},
         else => return,
     }

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const os = std.os;
 const fs = std.fs;
 const BufMap = std.BufMap;
@@ -867,9 +867,9 @@ pub fn execve(
         if (env_map) |m| {
             const envp_buf = try child_process.createNullDelimitedEnvMap(arena, m);
             break :m envp_buf.ptr;
-        } else if (std.builtin.link_libc) {
+        } else if (builtin.link_libc) {
             break :m std.c.environ;
-        } else if (std.builtin.output_mode == .Exe) {
+        } else if (builtin.output_mode == .Exe) {
             // Then we have Zig start code and this works.
             // TODO type-safety for null-termination of `os.environ`.
             break :m @ptrCast([*:null]?[*:0]u8, os.environ.ptr);

--- a/lib/std/rand/ziggurat.zig
+++ b/lib/std/rand/ziggurat.zig
@@ -131,7 +131,7 @@ fn norm_zero_case(random: *Random, u: f64) f64 {
     }
 }
 
-const please_windows_dont_oom = std.Target.current.os.tag == .windows;
+const please_windows_dont_oom = @import("builtin").target.os.tag == .windows;
 
 test "normal dist sanity" {
     if (please_windows_dont_oom) return error.SkipZigTest;

--- a/lib/std/special/c.zig
+++ b/lib/std/special/c.zig
@@ -10,12 +10,12 @@
 // such as memcpy, memset, and some math functions.
 
 const std = @import("std");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const maxInt = std.math.maxInt;
 const isNan = std.math.isNan;
-const native_arch = std.Target.current.cpu.arch;
-const native_abi = std.Target.current.abi;
-const native_os = std.Target.current.os.tag;
+const native_arch = builtin.cpu.arch;
+const native_abi = builtin.abi;
+const native_os = builtin.os.tag;
 
 const is_wasm = switch (native_arch) {
     .wasm32, .wasm64 => true,
@@ -173,7 +173,7 @@ test "strncmp" {
 
 // Avoid dragging in the runtime safety mechanisms into this .o file,
 // unless we're trying to test this file.
-pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
+pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace) noreturn {
     _ = error_return_trace;
     if (builtin.is_test) {
         @setCold(true);

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -4,18 +4,18 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const is_test = builtin.is_test;
-const os_tag = std.Target.current.os.tag;
-const arch = std.Target.current.cpu.arch;
-const abi = std.Target.current.abi;
+const os_tag = builtin.os.tag;
+const arch = builtin.cpu.arch;
+const abi = builtin.abi;
 
 const is_gnu = abi.isGnu();
 const is_mingw = os_tag == .windows and is_gnu;
 
 comptime {
-    const linkage = if (is_test) builtin.GlobalLinkage.Internal else builtin.GlobalLinkage.Weak;
-    const strong_linkage = if (is_test) builtin.GlobalLinkage.Internal else builtin.GlobalLinkage.Strong;
+    const linkage = if (is_test) std.builtin.GlobalLinkage.Internal else std.builtin.GlobalLinkage.Weak;
+    const strong_linkage = if (is_test) std.builtin.GlobalLinkage.Internal else std.builtin.GlobalLinkage.Strong;
 
     switch (arch) {
         .i386,
@@ -601,7 +601,7 @@ pub usingnamespace @import("compiler_rt/atomics.zig");
 
 // Avoid dragging in the runtime safety mechanisms into this .o file,
 // unless we're trying to test this file.
-pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
+pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace) noreturn {
     _ = error_return_trace;
     @setCold(true);
     if (is_test) {

--- a/lib/std/special/compiler_rt/atomics.zig
+++ b/lib/std/special/compiler_rt/atomics.zig
@@ -4,10 +4,10 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
-const builtin = std.builtin;
-const arch = std.Target.current.cpu.arch;
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 
-const linkage: builtin.GlobalLinkage = if (builtin.is_test) .Internal else .Weak;
+const linkage: std.builtin.GlobalLinkage = if (builtin.is_test) .Internal else .Weak;
 
 // This parameter is true iff the target architecture supports the bare minimum
 // to implement the atomic load/store intrinsics.
@@ -21,7 +21,7 @@ const supports_atomic_ops = switch (arch) {
     // operations (unless we're targeting Linux, the kernel provides a way to
     // perform CAS operations).
     // XXX: The Linux code path is not implemented yet.
-    !std.Target.arm.featureSetHas(std.Target.current.cpu.features, .has_v6m),
+    !std.Target.arm.featureSetHas(builtin.cpu.features, .has_v6m),
     else => true,
 };
 
@@ -262,7 +262,7 @@ comptime {
     }
 }
 
-fn fetchFn(comptime T: type, comptime op: builtin.AtomicRmwOp) fn (*T, T, i32) callconv(.C) T {
+fn fetchFn(comptime T: type, comptime op: std.builtin.AtomicRmwOp) fn (*T, T, i32) callconv(.C) T {
     return struct {
         pub fn fetch_op_N(ptr: *T, val: T, model: i32) callconv(.C) T {
             _ = model;

--- a/lib/std/special/compiler_rt/clear_cache.zig
+++ b/lib/std/special/compiler_rt/clear_cache.zig
@@ -4,8 +4,9 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
-const arch = std.builtin.cpu.arch;
-const os = std.builtin.os.tag;
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
+const os = builtin.os.tag;
 
 // Ported from llvm-project d32170dbd5b0d54436537b6b75beaf44324e0c28
 
@@ -161,7 +162,7 @@ pub fn clear_cache(start: usize, end: usize) callconv(.C) void {
     }
 }
 
-const linkage = if (std.builtin.is_test) std.builtin.GlobalLinkage.Internal else std.builtin.GlobalLinkage.Weak;
+const linkage = if (builtin.is_test) std.builtin.GlobalLinkage.Internal else std.builtin.GlobalLinkage.Weak;
 
 fn exportIt() void {
     @export(clear_cache, .{ .name = "__clear_cache", .linkage = linkage });

--- a/lib/std/special/compiler_rt/clzsi2.zig
+++ b/lib/std/special/compiler_rt/clzsi2.zig
@@ -4,7 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 
 fn __clzsi2_generic(a: i32) callconv(.C) i32 {
     @setRuntimeSafety(builtin.is_test);
@@ -109,16 +109,16 @@ fn __clzsi2_arm32() callconv(.Naked) void {
 }
 
 pub const __clzsi2 = impl: {
-    switch (std.Target.current.cpu.arch) {
+    switch (builtin.cpu.arch) {
         .arm, .armeb, .thumb, .thumbeb => {
             const use_thumb1 =
-                (std.Target.current.cpu.arch.isThumb() or
-                std.Target.arm.featureSetHas(std.Target.current.cpu.features, .noarm)) and
-                !std.Target.arm.featureSetHas(std.Target.current.cpu.features, .thumb2);
+                (builtin.cpu.arch.isThumb() or
+                std.Target.arm.featureSetHas(builtin.cpu.features, .noarm)) and
+                !std.Target.arm.featureSetHas(builtin.cpu.features, .thumb2);
 
             if (use_thumb1) break :impl __clzsi2_thumb1
             // From here on we're either targeting Thumb2 or ARM.
-            else if (!std.Target.current.cpu.arch.isThumb()) break :impl __clzsi2_arm32
+            else if (!builtin.cpu.arch.isThumb()) break :impl __clzsi2_arm32
             // Use the generic implementation otherwise.
             else break :impl __clzsi2_generic;
         },

--- a/lib/std/special/compiler_rt/emutls.zig
+++ b/lib/std/special/compiler_rt/emutls.zig
@@ -21,7 +21,7 @@ const expect = std.testing.expect;
 const gcc_word = usize;
 
 comptime {
-    assert(std.builtin.link_libc);
+    assert(@import("builtin").link_libc);
 }
 
 /// public entrypoint for generated code using EmulatedTLS

--- a/lib/std/special/compiler_rt/extendXfYf2_test.zig
+++ b/lib/std/special/compiler_rt/extendXfYf2_test.zig
@@ -96,7 +96,7 @@ test "extendhfsf2" {
     try test__extendhfsf2(0x7f00, 0x7fe00000); // sNaN
     // On x86 the NaN becomes quiet because the return is pushed on the x87
     // stack due to ABI requirements
-    if (builtin.target.cpu.arch != .i386 and builtin.target.os.tag == .windows)
+    if (builtin.cpu.arch != .i386 and builtin.os.tag == .windows)
         try test__extendhfsf2(0x7c01, 0x7f802000); // sNaN
 
     try test__extendhfsf2(0, 0); // 0

--- a/lib/std/special/compiler_rt/muldi3.zig
+++ b/lib/std/special/compiler_rt/muldi3.zig
@@ -4,8 +4,9 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
-const is_test = std.builtin.is_test;
-const native_endian = std.Target.current.cpu.arch.endian();
+const builtin = @import("builtin");
+const is_test = builtin.is_test;
+const native_endian = builtin.cpu.arch.endian();
 
 // Ported from
 // https://github.com/llvm/llvm-project/blob/llvmorg-9.0.0/compiler-rt/lib/builtins/muldi3.c

--- a/lib/std/special/compiler_rt/multi3.zig
+++ b/lib/std/special/compiler_rt/multi3.zig
@@ -5,8 +5,9 @@
 // and substantial portions of the software.
 const compiler_rt = @import("../compiler_rt.zig");
 const std = @import("std");
-const is_test = std.builtin.is_test;
-const native_endian = std.Target.current.cpu.arch.endian();
+const builtin = @import("builtin");
+const is_test = builtin.is_test;
+const native_endian = builtin.cpu.arch.endian();
 
 // Ported from git@github.com:llvm-project/llvm-project-20170507.git
 // ae684fad6d34858c014c94da69c15e7774a633c3

--- a/lib/std/special/compiler_rt/shift.zig
+++ b/lib/std/special/compiler_rt/shift.zig
@@ -5,7 +5,7 @@
 // and substantial portions of the software.
 const std = @import("std");
 const Log2Int = std.math.Log2Int;
-const native_endian = std.Target.current.cpu.arch.endian();
+const native_endian = @import("builtin").cpu.arch.endian();
 
 fn Dwords(comptime T: type, comptime signed_half: bool) type {
     return extern union {

--- a/lib/std/special/compiler_rt/stack_probe.zig
+++ b/lib/std/special/compiler_rt/stack_probe.zig
@@ -3,7 +3,7 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-const native_arch = @import("std").Target.current.cpu.arch;
+const native_arch = @import("builtin").target.cpu.arch;
 
 // Zig's own stack-probe routine (available only on x86 and x86_64)
 pub fn zig_probe_stack() callconv(.Naked) void {

--- a/lib/std/special/compiler_rt/udivmod.zig
+++ b/lib/std/special/compiler_rt/udivmod.zig
@@ -5,7 +5,7 @@
 // and substantial portions of the software.
 const builtin = @import("builtin");
 const is_test = builtin.is_test;
-const native_endian = @import("std").Target.current.cpu.arch.endian();
+const native_endian = builtin.cpu.arch.endian();
 
 const low = switch (native_endian) {
     .Big => 1,

--- a/lib/std/start_windows_tls.zig
+++ b/lib/std/start_windows_tls.zig
@@ -13,7 +13,7 @@ export var __xl_a: std.os.windows.PIMAGE_TLS_CALLBACK linksection(".CRT$XLA") = 
 export var __xl_z: std.os.windows.PIMAGE_TLS_CALLBACK linksection(".CRT$XLZ") = null;
 
 comptime {
-    if (builtin.target.cpu.arch == .i386) {
+    if (builtin.cpu.arch == .i386) {
         // The __tls_array is the offset of the ThreadLocalStoragePointer field
         // in the TEB block whose base address held in the %fs segment.
         asm (

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -99,7 +99,7 @@ comptime {
 }
 
 test {
-    if (builtin.os.tag == .windows) {
+    if (@import("builtin").os.tag == .windows) {
         // We only test the Windows-relevant stuff to save memory because the CI
         // server is hitting OOM. TODO revert this after stage2 arrives.
         _ = ChildProcess;

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -991,7 +991,7 @@ pub const Target = struct {
                 };
             }
 
-            pub fn endian(arch: Arch) builtin.Endian {
+            pub fn endian(arch: Arch) std.builtin.Endian {
                 return switch (arch) {
                     .avr,
                     .arm,
@@ -1273,8 +1273,6 @@ pub const Target = struct {
             return Model.baseline(arch).toCpu(arch);
         }
     };
-
-    pub const current = builtin.target;
 
     pub const stack_align = 16;
 

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std.zig");
+const builtin = @import("builtin");
 const math = std.math;
 const print = std.debug.print;
 
@@ -326,7 +327,7 @@ pub const TmpDir = struct {
 };
 
 fn getCwdOrWasiPreopen() std.fs.Dir {
-    if (std.builtin.os.tag == .wasi) {
+    if (builtin.os.tag == .wasi) {
         var preopens = std.fs.wasi.PreopenList.init(allocator);
         defer preopens.deinit();
         preopens.populate() catch
@@ -468,7 +469,7 @@ test {
 
 /// Given a type, reference all the declarations inside, so that the semantic analyzer sees them.
 pub fn refAllDecls(comptime T: type) void {
-    if (!std.builtin.is_test) return;
+    if (!builtin.is_test) return;
     inline for (std.meta.declarations(T)) |decl| {
         _ = decl;
     }

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -4,12 +4,12 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std.zig");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const testing = std.testing;
 const os = std.os;
 const math = std.math;
-const is_windows = std.Target.current.os.tag == .windows;
+const is_windows = builtin.os.tag == .windows;
 
 pub const epoch = @import("time/epoch.zig");
 
@@ -178,7 +178,7 @@ pub const Timer = struct {
                 .resolution = @divFloor(ns_per_s, freq),
                 .start_time = os.windows.QueryPerformanceCounter(),
             };
-        } else if (comptime std.Target.current.isDarwin()) {
+        } else if (comptime builtin.target.isDarwin()) {
             var freq: os.darwin.mach_timebase_info_data = undefined;
             os.darwin.mach_timebase_info(&freq);
 
@@ -232,7 +232,7 @@ pub const Timer = struct {
         if (is_windows) {
             return os.windows.QueryPerformanceCounter();
         }
-        if (comptime std.Target.current.isDarwin()) {
+        if (comptime builtin.target.isDarwin()) {
             return os.darwin.mach_absolute_time();
         }
         var ts: os.timespec = undefined;
@@ -244,7 +244,7 @@ pub const Timer = struct {
         if (is_windows) {
             return safeMulDiv(duration, ns_per_s, self.frequency);
         }
-        if (comptime std.Target.current.isDarwin()) {
+        if (comptime builtin.target.isDarwin()) {
             return safeMulDiv(duration, self.frequency.numer, self.frequency.denom);
         }
         return duration;

--- a/lib/std/valgrind.zig
+++ b/lib/std/valgrind.zig
@@ -12,7 +12,7 @@ pub fn doClientRequest(default: usize, request: usize, a1: usize, a2: usize, a3:
         return default;
     }
 
-    switch (builtin.target.cpu.arch) {
+    switch (builtin.cpu.arch) {
         .i386 => {
             return asm volatile (
                 \\ roll $3,  %%edi ; roll $13, %%edi

--- a/lib/std/x/net/tcp.zig
+++ b/lib/std/x/net/tcp.zig
@@ -13,7 +13,7 @@ const ip = std.x.net.ip;
 const fmt = std.fmt;
 const mem = std.mem;
 const testing = std.testing;
-const native_os = std.Target.current.os;
+const native_os = @import("builtin").os;
 
 const IPv4 = std.x.os.IPv4;
 const IPv6 = std.x.os.IPv6;

--- a/lib/std/x/os/io.zig
+++ b/lib/std/x/os/io.zig
@@ -3,7 +3,7 @@ const std = @import("../../std.zig");
 const os = std.os;
 const mem = std.mem;
 const testing = std.testing;
-const native_os = std.Target.current.os;
+const native_os = @import("builtin").os;
 
 /// POSIX `iovec`, or Windows `WSABUF`. The difference between the two are the ordering
 /// of fields, alongside the length being represented as either a ULONG or a size_t.

--- a/lib/std/x/os/net.zig
+++ b/lib/std/x/os/net.zig
@@ -11,7 +11,7 @@ const fmt = std.fmt;
 const mem = std.mem;
 const math = std.math;
 const testing = std.testing;
-const native_os = std.Target.current.os;
+const native_os = @import("builtin").os;
 
 /// Resolves a network interface name into a scope/zone ID. It returns
 /// an error if either resolution fails, or if the interface name is

--- a/lib/std/x/os/socket.zig
+++ b/lib/std/x/os/socket.zig
@@ -12,8 +12,9 @@ const fmt = std.fmt;
 const mem = std.mem;
 const time = std.time;
 const meta = std.meta;
-const native_os = std.Target.current.os;
-const native_endian = std.Target.current.cpu.arch.endian();
+const native_target = @import("builtin").target;
+const native_os = native_target.os;
+const native_endian = native_target.cpu.arch.endian();
 
 const Buffer = std.x.os.Buffer;
 

--- a/lib/std/zig/system/linux.zig
+++ b/lib/std/zig/system/linux.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const mem = std.mem;
 const io = std.io;
 const fs = std.fs;
@@ -450,7 +451,7 @@ pub fn detectNativeCpuAndFeatures() ?Target.Cpu {
     };
     defer f.close();
 
-    const current_arch = std.Target.current.cpu.arch;
+    const current_arch = builtin.cpu.arch;
     switch (current_arch) {
         .arm, .armeb, .thumb, .thumbeb, .aarch64, .aarch64_be, .aarch64_32 => {
             return ArmCpuinfoParser.parse(current_arch, f.reader()) catch null;

--- a/lib/std/zig/system/macos.zig
+++ b/lib/std/zig/system/macos.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const mem = std.mem;
 const testing = std.testing;
@@ -413,7 +414,7 @@ fn testVersionEquality(expected: std.builtin.Version, got: std.builtin.Version) 
 /// `-syslibroot` param of the linker.
 /// The caller needs to free the resulting path slice.
 pub fn getSDKPath(allocator: *mem.Allocator) ![]u8 {
-    assert(Target.current.isDarwin());
+    assert(builtin.target.isDarwin());
     const argv = &[_][]const u8{ "xcrun", "--show-sdk-path" };
     const result = try std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv });
     defer {
@@ -441,7 +442,7 @@ pub fn detectNativeCpuAndFeatures() ?Target.Cpu {
         error.Unexpected => unreachable, // EFAULT: stack should be safe, EISDIR/ENOTDIR: constant, known good value
     };
 
-    const current_arch = Target.current.cpu.arch;
+    const current_arch = builtin.cpu.arch;
     switch (current_arch) {
         .aarch64, .aarch64_be, .aarch64_32 => {
             const model = switch (cpu_family) {

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -4,6 +4,7 @@ hash: HashHelper = .{},
 
 const Cache = @This();
 const std = @import("std");
+const builtin = @import("builtin");
 const crypto = std.crypto;
 const fs = std.fs;
 const assert = std.debug.assert;
@@ -713,7 +714,7 @@ pub const Manifest = struct {
 /// uses the file contents. Windows supports symlinks but only with elevated privileges, so
 /// it is treated as not supporting symlinks.
 pub fn readSmallFile(dir: fs.Dir, sub_path: []const u8, buffer: []u8) ![]u8 {
-    if (std.Target.current.os.tag == .windows) {
+    if (builtin.os.tag == .windows) {
         return dir.readFile(sub_path, buffer);
     } else {
         return dir.readLink(sub_path, buffer);
@@ -726,7 +727,7 @@ pub fn readSmallFile(dir: fs.Dir, sub_path: []const u8, buffer: []u8) ![]u8 {
 /// `data` must be a valid UTF-8 encoded file path and 255 bytes or fewer.
 pub fn writeSmallFile(dir: fs.Dir, sub_path: []const u8, data: []const u8) !void {
     assert(data.len <= 255);
-    if (std.Target.current.os.tag == .windows) {
+    if (builtin.os.tag == .windows) {
         return dir.writeFile(sub_path, data);
     } else {
         return dir.symLink(data, sub_path, .{});
@@ -778,7 +779,7 @@ fn isProblematicTimestamp(fs_clock: i128) bool {
 }
 
 test "cache file and then recall it" {
-    if (std.Target.current.os.tag == .wasi) {
+    if (builtin.os.tag == .wasi) {
         // https://github.com/ziglang/zig/issues/5437
         return error.SkipZigTest;
     }
@@ -856,7 +857,7 @@ test "give nonproblematic timestamp" {
 }
 
 test "check that changing a file makes cache fail" {
-    if (std.Target.current.os.tag == .wasi) {
+    if (builtin.os.tag == .wasi) {
         // https://github.com/ziglang/zig/issues/5437
         return error.SkipZigTest;
     }
@@ -932,7 +933,7 @@ test "check that changing a file makes cache fail" {
 }
 
 test "no file inputs" {
-    if (std.Target.current.os.tag == .wasi) {
+    if (builtin.os.tag == .wasi) {
         // https://github.com/ziglang/zig/issues/5437
         return error.SkipZigTest;
     }
@@ -977,7 +978,7 @@ test "no file inputs" {
 }
 
 test "Manifest with files added after initial hash work" {
-    if (std.Target.current.os.tag == .wasi) {
+    if (builtin.os.tag == .wasi) {
         // https://github.com/ziglang/zig/issues/5437
         return error.SkipZigTest;
     }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1,6 +1,7 @@
 const Compilation = @This();
 
 const std = @import("std");
+const builtin = @import("builtin");
 const mem = std.mem;
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
@@ -905,9 +906,9 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
 
         const darwin_can_use_system_sdk =
             // comptime conditions
-            ((build_options.have_llvm and comptime std.Target.current.isDarwin()) and
+            ((build_options.have_llvm and comptime builtin.target.isDarwin()) and
             // runtime conditions
-            (use_lld and std.builtin.os.tag == .macos and options.target.isDarwin()));
+            (use_lld and builtin.os.tag == .macos and options.target.isDarwin()));
 
         const sysroot = blk: {
             if (options.sysroot) |sysroot| {
@@ -2025,7 +2026,7 @@ pub fn performAllTheWork(self: *Compilation) error{ TimerUnsupported, OutOfMemor
                     log.debug("analyze liveness of {s}", .{decl.name});
                     try liveness.analyze(module.gpa, &decl_arena.allocator, func.body);
 
-                    if (std.builtin.mode == .Debug and self.verbose_air) {
+                    if (builtin.mode == .Debug and self.verbose_air) {
                         func.dump(module.*);
                     }
                 }
@@ -3404,7 +3405,7 @@ fn detectLibCIncludeDirs(
     // native abi, fall back to using the system libc installation.
     // On windows, instead of the native (mingw) abi, we want to check
     // for the MSVC abi as a fallback.
-    const use_system_abi = if (std.Target.current.os.tag == .windows)
+    const use_system_abi = if (builtin.os.tag == .windows)
         target.abi == .msvc
     else
         is_native_abi;

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 const std = @import("std");
+const builtin = @import("builtin");
 const ThreadPool = @This();
 
 lock: std.Thread.Mutex = .{},
@@ -57,7 +58,7 @@ pub fn init(self: *ThreadPool, allocator: *std.mem.Allocator) !void {
         .allocator = allocator,
         .workers = &[_]Worker{},
     };
-    if (std.builtin.single_threaded)
+    if (builtin.single_threaded)
         return;
 
     const worker_count = std.math.max(1, std.Thread.getCpuCount() catch 1);
@@ -100,7 +101,7 @@ pub fn deinit(self: *ThreadPool) void {
 }
 
 pub fn spawn(self: *ThreadPool, comptime func: anytype, args: anytype) !void {
-    if (std.builtin.single_threaded) {
+    if (builtin.single_threaded) {
         @call(.{}, func, args);
         return;
     }

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -11,6 +11,7 @@
 //!    inline assembly is not an exception.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const mem = std.mem;
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
@@ -2150,7 +2151,7 @@ pub const Inst = struct {
         // bigger than expected. Note that in Debug builds, Zig is allowed
         // to insert a secret field for safety checks.
         comptime {
-            if (std.builtin.mode != .Debug) {
+            if (builtin.mode != .Debug) {
                 assert(@sizeOf(Data) == 8);
             }
         }

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const mem = std.mem;
 const math = std.math;
 const assert = std.debug.assert;
@@ -427,7 +428,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
             code: *std.ArrayList(u8),
             debug_output: DebugInfoOutput,
         ) GenerateSymbolError!Result {
-            if (build_options.skip_non_native and std.Target.current.cpu.arch != arch) {
+            if (build_options.skip_non_native and builtin.cpu.arch != arch) {
                 @panic("Attempted to compile for architecture that was disabled by build configuration");
             }
 

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const mem = std.mem;
 const log = std.log.scoped(.c);
@@ -600,7 +601,7 @@ pub const DeclGen = struct {
                 dg.typedefs.putAssumeCapacityNoClobber(t, .{ .name = name, .rendered = rendered });
             },
             .ErrorSet => {
-                comptime std.debug.assert(Type.initTag(.anyerror).abiSize(std.Target.current) == 2);
+                comptime std.debug.assert(Type.initTag(.anyerror).abiSize(builtin.target) == 2);
                 try w.writeAll("uint16_t");
             },
             .ErrorUnion => {

--- a/src/introspect.zig
+++ b/src/introspect.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const mem = std.mem;
 const fs = std.fs;
 const Compilation = @import("Compilation.zig");
@@ -71,7 +72,7 @@ pub fn resolveGlobalCacheDir(allocator: *mem.Allocator) ![]u8 {
 
     const appname = "zig";
 
-    if (std.Target.current.os.tag != .windows) {
+    if (builtin.os.tag != .windows) {
         if (std.os.getenv("XDG_CACHE_HOME")) |cache_root| {
             return fs.path.join(allocator, &[_][]const u8{ cache_root, appname });
         } else if (std.os.getenv("HOME")) |home| {

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -6,9 +6,9 @@ const Allocator = std.mem.Allocator;
 const Batch = std.event.Batch;
 const build_options = @import("build_options");
 
-const is_darwin = Target.current.isDarwin();
-const is_windows = Target.current.os.tag == .windows;
-const is_haiku = Target.current.os.tag == .haiku;
+const is_darwin = builtin.target.isDarwin();
+const is_windows = builtin.os.tag == .windows;
+const is_haiku = builtin.os.tag == .haiku;
 
 const log = std.log.scoped(.libc_installation);
 
@@ -97,25 +97,25 @@ pub const LibCInstallation = struct {
             return error.ParseError;
         }
         if (self.crt_dir == null and !is_darwin) {
-            log.err("crt_dir may not be empty for {s}\n", .{@tagName(Target.current.os.tag)});
+            log.err("crt_dir may not be empty for {s}\n", .{@tagName(builtin.os.tag)});
             return error.ParseError;
         }
         if (self.msvc_lib_dir == null and is_windows) {
             log.err("msvc_lib_dir may not be empty for {s}-{s}\n", .{
-                @tagName(Target.current.os.tag),
-                @tagName(Target.current.abi),
+                @tagName(builtin.os.tag),
+                @tagName(builtin.abi),
             });
             return error.ParseError;
         }
         if (self.kernel32_lib_dir == null and is_windows) {
             log.err("kernel32_lib_dir may not be empty for {s}-{s}\n", .{
-                @tagName(Target.current.os.tag),
-                @tagName(Target.current.abi),
+                @tagName(builtin.os.tag),
+                @tagName(builtin.abi),
             });
             return error.ParseError;
         }
         if (self.gcc_dir == null and is_haiku) {
-            log.err("gcc_dir may not be empty for {s}\n", .{@tagName(Target.current.os.tag)});
+            log.err("gcc_dir may not be empty for {s}\n", .{@tagName(builtin.os.tag)});
             return error.ParseError;
         }
 
@@ -213,7 +213,7 @@ pub const LibCInstallation = struct {
                 var batch = Batch(FindError!void, 2, .auto_async).init();
                 errdefer batch.wait() catch {};
                 batch.add(&async self.findNativeIncludeDirPosix(args));
-                switch (Target.current.os.tag) {
+                switch (builtin.os.tag) {
                     .freebsd, .netbsd, .openbsd, .dragonfly => self.crt_dir = try std.mem.dupeZ(args.allocator, u8, "/usr/lib"),
                     .linux => batch.add(&async self.findNativeCrtDirPosix(args)),
                     else => {},
@@ -412,7 +412,7 @@ pub const LibCInstallation = struct {
         var result_buf = std.ArrayList(u8).init(allocator);
         defer result_buf.deinit();
 
-        const arch_sub_dir = switch (builtin.target.cpu.arch) {
+        const arch_sub_dir = switch (builtin.cpu.arch) {
             .i386 => "x86",
             .x86_64 => "x64",
             .arm, .armeb => "arm",
@@ -475,7 +475,7 @@ pub const LibCInstallation = struct {
         var result_buf = std.ArrayList(u8).init(allocator);
         defer result_buf.deinit();
 
-        const arch_sub_dir = switch (builtin.target.cpu.arch) {
+        const arch_sub_dir = switch (builtin.cpu.arch) {
             .i386 => "x86",
             .x86_64 => "x64",
             .arm, .armeb => "arm",

--- a/src/link.zig
+++ b/src/link.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const mem = std.mem;
 const Allocator = std.mem.Allocator;
 const fs = std.fs;
@@ -15,7 +16,7 @@ const build_options = @import("build_options");
 const LibCInstallation = @import("libc_installation.zig").LibCInstallation;
 const wasi_libc = @import("wasi_libc.zig");
 
-pub const producer_string = if (std.builtin.is_test) "zig test" else "zig " ++ build_options.version;
+pub const producer_string = if (builtin.is_test) "zig test" else "zig " ++ build_options.version;
 
 pub const Emit = struct {
     /// Where the output will go.
@@ -278,7 +279,7 @@ pub const File = struct {
                     // make executable, so we don't have to close it.
                     return;
                 }
-                if (comptime std.Target.current.isDarwin() and std.Target.current.cpu.arch == .aarch64) {
+                if (comptime builtin.target.isDarwin() and builtin.cpu.arch == .aarch64) {
                     if (base.options.target.cpu.arch != .aarch64) return; // If we're not targeting aarch64, nothing to do.
                     // XNU starting with Big Sur running on arm64 is caching inodes of running binaries.
                     // Any change to the binary will effectively invalidate the kernel's cache
@@ -674,7 +675,7 @@ pub fn determineMode(options: Options) fs.File.Mode {
     // with 0o755 permissions, but it works appropriately if the system is configured
     // more leniently. As another data point, C's fopen seems to open files with the
     // 666 mode.
-    const executable_mode = if (std.Target.current.os.tag == .windows) 0 else 0o777;
+    const executable_mode = if (builtin.os.tag == .windows) 0 else 0o777;
     switch (options.effectiveOutputMode()) {
         .Lib => return switch (options.link_mode) {
             .Dynamic => executable_mode,

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1,6 +1,7 @@
 const Elf = @This();
 
 const std = @import("std");
+const builtin = @import("builtin");
 const mem = std.mem;
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
@@ -753,7 +754,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
     const module = self.base.options.module orelse return error.LinkingWithoutZigSourceUnimplemented;
 
     const target_endian = self.base.options.target.cpu.arch.endian();
-    const foreign_endian = target_endian != std.Target.current.cpu.arch.endian();
+    const foreign_endian = target_endian != builtin.cpu.arch.endian();
     const ptr_width_bytes: u8 = self.ptrWidthBytes();
     const init_len_size: usize = switch (self.ptr_width) {
         .p32 => 4,
@@ -2750,7 +2751,7 @@ pub fn deleteExport(self: *Elf, exp: Export) void {
 }
 
 fn writeProgHeader(self: *Elf, index: usize) !void {
-    const foreign_endian = self.base.options.target.cpu.arch.endian() != std.Target.current.cpu.arch.endian();
+    const foreign_endian = self.base.options.target.cpu.arch.endian() != builtin.cpu.arch.endian();
     const offset = self.program_headers.items[index].p_offset;
     switch (self.ptr_width) {
         .p32 => {
@@ -2771,7 +2772,7 @@ fn writeProgHeader(self: *Elf, index: usize) !void {
 }
 
 fn writeSectHeader(self: *Elf, index: usize) !void {
-    const foreign_endian = self.base.options.target.cpu.arch.endian() != std.Target.current.cpu.arch.endian();
+    const foreign_endian = self.base.options.target.cpu.arch.endian() != builtin.cpu.arch.endian();
     switch (self.ptr_width) {
         .p32 => {
             var shdr: [1]elf.Elf32_Shdr = undefined;
@@ -2869,7 +2870,7 @@ fn writeSymbol(self: *Elf, index: usize) !void {
         syms_sect.sh_size = needed_size; // anticipating adding the global symbols later
         self.shdr_table_dirty = true; // TODO look into only writing one section
     }
-    const foreign_endian = self.base.options.target.cpu.arch.endian() != std.Target.current.cpu.arch.endian();
+    const foreign_endian = self.base.options.target.cpu.arch.endian() != builtin.cpu.arch.endian();
     switch (self.ptr_width) {
         .p32 => {
             var sym = [1]elf.Elf32_Sym{
@@ -2905,7 +2906,7 @@ fn writeAllGlobalSymbols(self: *Elf) !void {
         .p32 => @sizeOf(elf.Elf32_Sym),
         .p64 => @sizeOf(elf.Elf64_Sym),
     };
-    const foreign_endian = self.base.options.target.cpu.arch.endian() != std.Target.current.cpu.arch.endian();
+    const foreign_endian = self.base.options.target.cpu.arch.endian() != builtin.cpu.arch.endian();
     const global_syms_off = syms_sect.sh_offset + self.local_symbols.items.len * sym_size;
     switch (self.ptr_width) {
         .p32 => {

--- a/src/link/MachO/Zld.zig
+++ b/src/link/MachO/Zld.zig
@@ -1,6 +1,7 @@
 const Zld = @This();
 
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const leb = std.leb;
 const mem = std.mem;
@@ -220,7 +221,7 @@ pub fn link(self: *Zld, files: []const []const u8, output: Output, args: LinkArg
     self.file = try fs.cwd().createFile(self.output.?.path, .{
         .truncate = true,
         .read = true,
-        .mode = if (std.Target.current.os.tag == .windows) 0 else 0o777,
+        .mode = if (builtin.os.tag == .windows) 0 else 0o777,
     });
 
     try self.populateMetadata();
@@ -2389,7 +2390,7 @@ fn flush(self: *Zld) !void {
         try self.writeCodeSignature();
     }
 
-    if (comptime std.Target.current.isDarwin() and std.Target.current.cpu.arch == .aarch64) {
+    if (comptime builtin.target.isDarwin() and builtin.cpu.arch == .aarch64) {
         const out_path = self.output.?.path;
         try fs.cwd().copyFile(out_path, fs.cwd(), out_path, .{});
     }

--- a/src/link/MachO/fat.zig
+++ b/src/link/MachO/fat.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const log = std.log.scoped(.archive);
 const macho = std.macho;
 const mem = std.mem;
-const native_endian = builtin.target.cpu.arch.endian();
+const native_endian = builtin.cpu.arch.endian();
 
 const Arch = std.Target.Cpu.Arch;
 
@@ -25,7 +25,7 @@ fn readFatStruct(reader: anytype, comptime T: type) !T {
     // Fat structures (fat_header & fat_arch) are always written and read to/from
     // disk in big endian order.
     var res = try reader.readStruct(T);
-    if (native_endian != builtin.Endian.Big) {
+    if (native_endian != std.builtin.Endian.Big) {
         mem.bswapAllFields(T, &res);
     }
     return res;

--- a/src/test.zig
+++ b/src/test.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const link = @import("link.zig");
 const Compilation = @import("Compilation.zig");
 const Allocator = std.mem.Allocator;
@@ -640,7 +641,7 @@ pub const TestContext = struct {
         var fail_count: usize = 0;
 
         for (self.cases.items) |case| {
-            if (build_options.skip_non_native and case.target.getCpuArch() != std.Target.current.cpu.arch)
+            if (build_options.skip_non_native and case.target.getCpuArch() != builtin.cpu.arch)
                 continue;
 
             // Skip tests that require LLVM backend when it is not available

--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -1,6 +1,7 @@
 pub const std = @import("std");
+const builtin = @import("builtin");
 
-pub const enable = if (std.builtin.is_test) false else @import("build_options").enable_tracy;
+pub const enable = if (builtin.is_test) false else @import("build_options").enable_tracy;
 
 extern fn ___tracy_emit_zone_begin_callstack(
     srcloc: *const ___tracy_source_location_data,

--- a/test/assemble_and_link.zig
+++ b/test/assemble_and_link.zig
@@ -1,8 +1,9 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.CompareOutputContext) void {
-    if (std.Target.current.os.tag == .linux and std.Target.current.cpu.arch == .x86_64) {
+    if (builtin.os.tag == .linux and builtin.cpu.arch == .x86_64) {
         cases.addAsm("hello world linux x86_64",
             \\.text
             \\.globl _start

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -142,7 +142,7 @@ comptime {
         _ = @import("behavior/var_args.zig");
         _ = @import("behavior/vector.zig");
         _ = @import("behavior/void.zig");
-        if (builtin.target.cpu.arch == .wasm32) {
+        if (builtin.cpu.arch == .wasm32) {
             _ = @import("behavior/wasm.zig");
         }
         _ = @import("behavior/while.zig");

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const expect = std.testing.expect;
 const builtin = @import("builtin");
-const native_arch = builtin.target.cpu.arch;
+const native_arch = builtin.cpu.arch;
 
 var foo: u8 align(4) = 100;
 

--- a/test/behavior/alignof.zig
+++ b/test/behavior/alignof.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const expect = std.testing.expect;
 const builtin = @import("builtin");
-const native_arch = builtin.target.cpu.arch;
+const native_arch = builtin.cpu.arch;
 const maxInt = std.math.maxInt;
 
 const Foo = struct {

--- a/test/behavior/asm.zig
+++ b/test/behavior/asm.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const expect = std.testing.expect;
 
-const is_x86_64_linux = std.Target.current.cpu.arch == .x86_64 and std.Target.current.os.tag == .linux;
+const is_x86_64_linux = builtin.cpu.arch == .x86_64 and builtin.os.tag == .linux;
 
 comptime {
     if (is_x86_64_linux) {

--- a/test/behavior/async_fn.zig
+++ b/test/behavior/async_fn.zig
@@ -112,7 +112,7 @@ test "calling an inferred async function" {
 }
 
 test "@frameSize" {
-    if (builtin.target.cpu.arch == .thumb or builtin.target.cpu.arch == .thumbeb)
+    if (builtin.cpu.arch == .thumb or builtin.cpu.arch == .thumbeb)
         return error.SkipZigTest;
 
     const S = struct {

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const maxInt = std.math.maxInt;
-const native_endian = builtin.target.cpu.arch.endian();
+const native_endian = builtin.cpu.arch.endian();
 
 test "@bitCast i32 -> u32" {
     try testBitCast_i32_u32();

--- a/test/behavior/byteswap.zig
+++ b/test/behavior/byteswap.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const expect = std.testing.expect;
 
 test "@byteSwap integers" {
@@ -40,7 +41,7 @@ test "@byteSwap integers" {
 
 test "@byteSwap vectors" {
     // https://github.com/ziglang/zig/issues/3317
-    if (std.Target.current.cpu.arch == .mipsel or std.Target.current.cpu.arch == .mips) return error.SkipZigTest;
+    if (builtin.cpu.arch == .mipsel or builtin.cpu.arch == .mips) return error.SkipZigTest;
 
     const ByteSwapVectorTest = struct {
         fn run() !void {

--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -196,9 +196,9 @@ test "return inner function which references comptime variable of outer function
 
 test "extern struct with stdcallcc fn pointer" {
     const S = extern struct {
-        ptr: fn () callconv(if (builtin.target.cpu.arch == .i386) .Stdcall else .C) i32,
+        ptr: fn () callconv(if (builtin.cpu.arch == .i386) .Stdcall else .C) i32,
 
-        fn foo() callconv(if (builtin.target.cpu.arch == .i386) .Stdcall else .C) i32 {
+        fn foo() callconv(if (builtin.cpu.arch == .i386) .Stdcall else .C) i32 {
             return 1234;
         }
     };

--- a/test/behavior/namespace_depends_on_compile_var.zig
+++ b/test/behavior/namespace_depends_on_compile_var.zig
@@ -8,7 +8,7 @@ test "namespace depends on compile var" {
         try expect(!some_namespace.a_bool);
     }
 }
-const some_namespace = switch (std.builtin.os.tag) {
+const some_namespace = switch (@import("builtin").os.tag) {
     .linux => @import("namespace_depends_on_compile_var/a.zig"),
     else => @import("namespace_depends_on_compile_var/b.zig"),
 };

--- a/test/behavior/ptrcast.zig
+++ b/test/behavior/ptrcast.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const expect = std.testing.expect;
-const native_endian = builtin.target.cpu.arch.endian();
+const native_endian = builtin.cpu.arch.endian();
 
 test "reinterpret bytes as integer with nonzero offset" {
     try testReinterpretBytesAsInteger();

--- a/test/behavior/shuffle.zig
+++ b/test/behavior/shuffle.zig
@@ -36,7 +36,7 @@ test "@shuffle" {
 
             // bool
             // https://github.com/ziglang/zig/issues/3317
-            if (builtin.target.cpu.arch != .mipsel and builtin.target.cpu.arch != .mips) {
+            if (builtin.cpu.arch != .mipsel and builtin.cpu.arch != .mips) {
                 var x2: Vector(4, bool) = [4]bool{ false, true, false, true };
                 var v4: Vector(2, bool) = [2]bool{ true, false };
                 const mask5: Vector(4, i32) = [4]i32{ 0, ~@as(i32, 1), 1, 2 };

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const native_endian = builtin.target.cpu.arch.endian();
+const native_endian = builtin.cpu.arch.endian();
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectEqualSlices = std.testing.expectEqualSlices;

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -427,7 +427,7 @@ test "Type.Union from regular enum" {
 
 test "Type.Fn" {
     // wasm doesn't support align attributes on functions
-    if (builtin.target.cpu.arch == .wasm32 or builtin.target.cpu.arch == .wasm64) return error.SkipZigTest;
+    if (builtin.cpu.arch == .wasm32 or builtin.cpu.arch == .wasm64) return error.SkipZigTest;
 
     const foo = struct {
         fn func(a: usize, b: bool) align(4) callconv(.C) usize {
@@ -443,7 +443,7 @@ test "Type.Fn" {
 
 test "Type.BoundFn" {
     // wasm doesn't support align attributes on functions
-    if (builtin.target.cpu.arch == .wasm32 or builtin.target.cpu.arch == .wasm64) return error.SkipZigTest;
+    if (builtin.cpu.arch == .wasm32 or builtin.cpu.arch == .wasm64) return error.SkipZigTest;
 
     const TestStruct = packed struct {
         pub fn foo(self: *const @This()) align(4) callconv(.Unspecified) void {

--- a/test/behavior/type_info.zig
+++ b/test/behavior/type_info.zig
@@ -300,7 +300,7 @@ fn testOpaque() !void {
 
 test "type info: function type info" {
     // wasm doesn't support align attributes on functions
-    if (builtin.target.cpu.arch == .wasm32 or builtin.target.cpu.arch == .wasm64) return error.SkipZigTest;
+    if (builtin.cpu.arch == .wasm32 or builtin.cpu.arch == .wasm64) return error.SkipZigTest;
     try testFunction();
     comptime try testFunction();
 }

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -348,7 +348,7 @@ test "vector division operators" {
 
         fn doTheTest() !void {
             // https://github.com/ziglang/zig/issues/4952
-            if (builtin.target.os.tag != .windows) {
+            if (builtin.os.tag != .windows) {
                 try doTheTestDiv(f16, [4]f16{ 4.0, -4.0, 4.0, -4.0 }, [4]f16{ 1.0, 2.0, -1.0, -2.0 });
             }
 
@@ -356,7 +356,7 @@ test "vector division operators" {
             try doTheTestDiv(f64, [4]f64{ 4.0, -4.0, 4.0, -4.0 }, [4]f64{ 1.0, 2.0, -1.0, -2.0 });
 
             // https://github.com/ziglang/zig/issues/4952
-            if (builtin.target.os.tag != .windows) {
+            if (builtin.os.tag != .windows) {
                 try doTheTestMod(f16, [4]f16{ 4.0, -4.0, 4.0, -4.0 }, [4]f16{ 1.0, 2.0, 0.5, 3.0 });
             }
             try doTheTestMod(f32, [4]f32{ 4.0, -4.0, 4.0, -4.0 }, [4]f32{ 1.0, 2.0, 0.5, 3.0 });
@@ -473,7 +473,7 @@ test "vector shift operators" {
         }
     };
 
-    switch (builtin.target.cpu.arch) {
+    switch (builtin.cpu.arch) {
         .i386,
         .aarch64,
         .aarch64_be,
@@ -549,7 +549,7 @@ test "vector reduce operation" {
 
             // LLVM 11 ERROR: Cannot select type
             // https://github.com/ziglang/zig/issues/7138
-            if (builtin.target.cpu.arch != .aarch64) {
+            if (builtin.cpu.arch != .aarch64) {
                 try doTheTestReduce(.Min, [4]i64{ 1234567, -386, 0, 3 }, @as(i64, -386));
                 try doTheTestReduce(.Min, [4]u64{ 99, 9999, 9, 99999 }, @as(u64, 9));
             }
@@ -567,7 +567,7 @@ test "vector reduce operation" {
 
             // LLVM 11 ERROR: Cannot select type
             // https://github.com/ziglang/zig/issues/7138
-            if (builtin.target.cpu.arch != .aarch64) {
+            if (builtin.cpu.arch != .aarch64) {
                 try doTheTestReduce(.Max, [4]i64{ 1234567, -386, 0, 3 }, @as(i64, 1234567));
                 try doTheTestReduce(.Max, [4]u64{ 99, 9999, 9, 99999 }, @as(u64, 99999));
             }

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const testing = std.testing;
 const process = std.process;
 const fs = std.fs;
@@ -104,7 +105,7 @@ fn testZigInitExe(zig_exe: []const u8, dir_path: []const u8) !void {
 }
 
 fn testGodboltApi(zig_exe: []const u8, dir_path: []const u8) anyerror!void {
-    if (std.Target.current.os.tag != .linux or std.Target.current.cpu.arch != .x86_64) return;
+    if (builtin.os.tag != .linux or builtin.cpu.arch != .x86_64) return;
 
     const example_zig_path = try fs.path.join(a, &[_][]const u8{ dir_path, "example.zig" });
     const example_s_path = try fs.path.join(a, &[_][]const u8{ dir_path, "example.s" });

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const os = std.os;
 const tests = @import("tests.zig");
 
@@ -133,7 +134,8 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
 
     cases.addC("number literals",
         \\const std = @import("std");
-        \\const is_windows = std.Target.current.os.tag == .windows;
+        \\const builtin = @import("builtin");
+        \\const is_windows = builtin.os.tag == .windows;
         \\const c = @cImport({
         \\    if (is_windows) {
         \\        // See https://github.com/ziglang/zig/issues/515
@@ -312,7 +314,8 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
 
     cases.addC("casting between float and integer types",
         \\const std = @import("std");
-        \\const is_windows = std.Target.current.os.tag == .windows;
+        \\const builtin = @import("builtin");
+        \\const is_windows = builtin.os.tag == .windows;
         \\const c = @cImport({
         \\    if (is_windows) {
         \\        // See https://github.com/ziglang/zig/issues/515

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const TestContext = @import("../src/test.zig").TestContext;
 
 pub fn addCases(ctx: *TestContext) !void {
@@ -2042,7 +2043,7 @@ pub fn addCases(ctx: *TestContext) !void {
     ctx.objErrStage1("attempt to create 17 bit float type",
         \\const builtin = @import("std").builtin;
         \\comptime {
-        \\    _ = @Type(builtin.TypeInfo { .Float = builtin.TypeInfo.Float { .bits = 17 } });
+        \\    _ = @Type(builtin.TypeInfo { .Float = std.builtin.TypeInfo.Float { .bits = 17 } });
         \\}
     , &[_][]const u8{
         "tmp.zig:3:32: error: 17-bit float unsupported",
@@ -2058,7 +2059,7 @@ pub fn addCases(ctx: *TestContext) !void {
 
     ctx.objErrStage1("@Type with non-constant expression",
         \\const builtin = @import("std").builtin;
-        \\var globalTypeInfo : builtin.TypeInfo = undefined;
+        \\var globalTypeInfo : std.builtin.TypeInfo = undefined;
         \\export fn entry() void {
         \\    _ = @Type(globalTypeInfo);
         \\}
@@ -2878,7 +2879,7 @@ pub fn addCases(ctx: *TestContext) !void {
         "tmp.zig:2:18: error: invalid operands to binary expression: 'error{A}' and 'error{B}'",
     });
 
-    if (std.Target.current.os.tag == .linux) {
+    if (builtin.os.tag == .linux) {
         ctx.testErrStage1("implicit dependency on libc",
             \\extern "c" fn exit(u8) void;
             \\export fn entry() void {
@@ -6848,7 +6849,7 @@ pub fn addCases(ctx: *TestContext) !void {
     ctx.objErrStage1("invalid member of builtin enum",
         \\const builtin = @import("std").builtin;
         \\export fn entry() void {
-        \\    const foo = builtin.Mode.x86;
+        \\    const foo = std.builtin.Mode.x86;
         \\    _ = foo;
         \\}
     , &[_][]const u8{
@@ -8786,9 +8787,10 @@ pub fn addCases(ctx: *TestContext) !void {
 
     ctx.objErrStage1("Issue #9165: windows tcp server compilation error",
         \\const std = @import("std");
+        \\const builtin = @import("builtin");
         \\pub const io_mode = .evented;
         \\pub fn main() !void {
-        \\    if (std.builtin.os.tag == .windows) {
+        \\    if (builtin.os.tag == .windows) {
         \\        _ = try (std.net.StreamServer.init(.{})).accept();
         \\    } else {
         \\        @compileError("Unsupported OS");

--- a/test/src/compare_output.zig
+++ b/test/src/compare_output.zig
@@ -8,7 +8,7 @@ const fmt = std.fmt;
 const mem = std.mem;
 const fs = std.fs;
 const warn = std.debug.warn;
-const Mode = builtin.Mode;
+const Mode = std.builtin.Mode;
 
 pub const CompareOutputContext = struct {
     b: *build.Builder,

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.StandaloneContext) void {
@@ -25,16 +26,16 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/brace_expansion/build.zig", .{});
     cases.addBuildFile("test/standalone/empty_env/build.zig", .{});
     cases.addBuildFile("test/standalone/issue_7030/build.zig", .{});
-    if (std.Target.current.os.tag != .wasi) {
+    if (builtin.os.tag != .wasi) {
         cases.addBuildFile("test/standalone/load_dynamic_library/build.zig", .{});
     }
-    if (std.Target.current.cpu.arch == .x86_64) { // TODO add C ABI support for other architectures
+    if (builtin.cpu.arch == .x86_64) { // TODO add C ABI support for other architectures
         cases.addBuildFile("test/stage1/c_abi/build.zig", .{});
     }
     cases.addBuildFile("test/standalone/c_compiler/build.zig", .{ .build_modes = true, .cross_targets = true });
 
     // Try to build and run a PIE executable.
-    if (std.Target.current.os.tag == .linux) {
+    if (builtin.os.tag == .linux) {
         cases.addBuildFile("test/standalone/pie/build.zig", .{});
     }
 

--- a/test/standalone/c_compiler/build.zig
+++ b/test/standalone/c_compiler/build.zig
@@ -1,12 +1,13 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Builder = std.build.Builder;
 const CrossTarget = std.zig.CrossTarget;
 
 fn isRunnableTarget(t: CrossTarget) bool {
     if (t.isNative()) return true;
 
-    return (t.getOsTag() == std.Target.current.os.tag and
-        t.getCpuArch() == std.Target.current.cpu.arch);
+    return (t.getOsTag() == builtin.os.tag and
+        t.getCpuArch() == builtin.cpu.arch);
 }
 
 pub fn build(b: *Builder) void {

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const debug = std.debug;
 const warn = debug.warn;
 const build = std.build;
@@ -9,7 +9,7 @@ const fs = std.fs;
 const mem = std.mem;
 const fmt = std.fmt;
 const ArrayList = std.ArrayList;
-const Mode = builtin.Mode;
+const Mode = std.builtin.Mode;
 const LibExeObjStep = build.LibExeObjStep;
 
 // Cases
@@ -29,7 +29,7 @@ pub const CompareOutputContext = @import("src/compare_output.zig").CompareOutput
 
 const TestTarget = struct {
     target: CrossTarget = @as(CrossTarget, .{}),
-    mode: builtin.Mode = .Debug,
+    mode: std.builtin.Mode = .Debug,
     link_libc: bool = false,
     single_threaded: bool = false,
     disable_native: bool = false,
@@ -512,8 +512,8 @@ pub fn addPkgTests(
             continue;
 
         if (test_target.disable_native and
-            test_target.target.getOsTag() == std.Target.current.os.tag and
-            test_target.target.getCpuArch() == std.Target.current.cpu.arch)
+            test_target.target.getOsTag() == builtin.os.tag and
+            test_target.target.getCpuArch() == builtin.cpu.arch)
         {
             continue;
         }
@@ -765,7 +765,7 @@ pub const StackTracesContext = struct {
                     if (line.len == 0) continue;
 
                     // offset search past `[drive]:` on windows
-                    var pos: usize = if (std.Target.current.os.tag == .windows) 2 else 0;
+                    var pos: usize = if (builtin.os.tag == .windows) 2 else 0;
                     // locate delims/anchor
                     const delims = [_][]const u8{ ":", ":", ":", " in ", "(", ")" };
                     var marks = [_]usize{0} ** delims.len;
@@ -1028,7 +1028,7 @@ pub const GenHContext = struct {
     pub fn addCase(self: *GenHContext, case: *const TestCase) void {
         const b = self.b;
 
-        const mode = builtin.Mode.Debug;
+        const mode = std.builtin.Mode.Debug;
         const annotated_case_name = fmt.allocPrint(self.b.allocator, "gen-h {s} ({s})", .{ case.name, @tagName(mode) }) catch unreachable;
         if (self.test_filter) |filter| {
             if (mem.indexOf(u8, annotated_case_name, filter) == null) return;

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1,9 +1,10 @@
 const tests = @import("tests.zig");
 const std = @import("std");
+const builtin = @import("builtin");
 const CrossTarget = std.zig.CrossTarget;
 
 pub fn addCases(cases: *tests.TranslateCContext) void {
-    const default_enum_type = if (std.Target.current.abi == .msvc) "c_int" else "c_uint";
+    const default_enum_type = if (builtin.abi == .msvc) "c_int" else "c_uint";
 
     cases.add("field access is grouped if necessary",
         \\unsigned long foo(unsigned long x) {
@@ -1148,7 +1149,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn foo() void {}
     });
 
-    if (std.Target.current.os.tag != .windows) {
+    if (builtin.os.tag != .windows) {
         // Windows treats this as an enum with type c_int
         cases.add("big negative enum init values when C ABI supports long long enums",
             \\enum EnumWithInits {
@@ -1553,7 +1554,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     });
 
-    if (std.Target.current.os.tag != .windows) {
+    if (builtin.os.tag != .windows) {
         // sysv_abi not currently supported on windows
         cases.add("Macro qualified functions",
             \\void __attribute__((sysv_abi)) foo(void);
@@ -2145,7 +2146,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     });
 
-    if (std.Target.current.os.tag != .windows) {
+    if (builtin.os.tag != .windows) {
         // When clang uses the <arch>-windows-none triple it behaves as MSVC and
         // interprets the inner `struct Bar` as an anonymous structure
         cases.add("type referenced struct",
@@ -3378,7 +3379,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const FOO = @import("std").zig.c_translation.cast(c_int, @import("std").zig.c_translation.promoteIntLiteral(c_int, 0x8000, .hexadecimal));
     });
 
-    if (std.Target.current.abi == .msvc) {
+    if (builtin.abi == .msvc) {
         cases.add("nameless struct fields",
             \\typedef struct NAMED
             \\{

--- a/tools/merge_anal_dumps.zig
+++ b/tools/merge_anal_dumps.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const json = std.json;
 const mem = std.mem;
 const fieldIndex = std.meta.fieldIndex;
-const TypeId = builtin.TypeId;
+const TypeId = std.builtin.TypeId;
 
 pub fn main() anyerror!void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const fs = std.fs;
 const mem = std.mem;
 const json = std.json;
@@ -805,7 +806,7 @@ pub fn main() anyerror!void {
     const root_progress = try progress.start("", llvm_targets.len);
     defer root_progress.end();
 
-    if (std.builtin.single_threaded) {
+    if (builtin.single_threaded) {
         for (llvm_targets) |llvm_target| {
             try processOneTarget(Job{
                 .llvm_tblgen_exe = llvm_tblgen_exe,


### PR DESCRIPTION
Closes #9321.

Replaces ```std.Target.current``` with ```@import("builtin")``` fields. 

Removes the current field from the Target struct and deprecated std.builtin fields.