### PR TITLE
Fix "unused local constant" error

### DIFF
--- a/test/behavior/bugs/3779.zig
+++ b/test/behavior/bugs/3779.zig
@@ -53,5 +53,8 @@ test "@src() returns a struct containing 0-terminated string slices" {
     try std.testing.expect(std.mem.endsWith(u8, src.fn_name, "testFnForSrc"));
 
     const ptr_src_file: [*:0]const u8 = src.file;
+    _ = ptr_src_file; // unused
+
     const ptr_src_fn_name: [*:0]const u8 = src.fn_name;
+    _ = ptr_src_fn_name; // unused
 }


### PR DESCRIPTION
Amends b009aca38a861f74fd5378db19c65db286ad397e.
The PR predated the introduction of unused variable/constant checks,
thus the build checks weren't reporting this failure until later when
merged into master.