### PR TITLE
FIX typo in doc comment for std.math.hypot

### DIFF
--- a/lib/std/math/hypot.zig
+++ b/lib/std/math/hypot.zig
@@ -14,7 +14,7 @@ const math = std.math;
 const expect = std.testing.expect;
 const maxInt = std.math.maxInt;
 
-/// Returns sqrt(x * x + y * y), avoiding unncessary overflow and underflow.
+/// Returns sqrt(x * x + y * y), avoiding unnecessary overflow and underflow.
 ///
 /// Special Cases:
 ///  - hypot(+-inf, y)  = +inf


### PR DESCRIPTION
Just a simple typo.