### PR TITLE
[stage2-air]: Fix test-stage2 compile errors

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1048,7 +1048,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
 
         pub fn spillInstruction(self: *Self, reg: Register, inst: Air.Inst.Index) !void {
             const stack_mcv = try self.allocRegOrMem(inst, false);
-            log.debug("spilling {*} to stack mcv {any}", .{ inst, stack_mcv });
+            log.debug("spilling {d} to stack mcv {any}", .{ inst, stack_mcv });
             const reg_mcv = self.getResolvedInstValue(inst);
             assert(reg == toCanonicalReg(reg_mcv.register));
             const branch = &self.branch_stack.items[self.branch_stack.items.len - 1];
@@ -3113,7 +3113,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                         }
                     }
                 };
-                log.debug("consolidating else_entry {*} {}=>{}", .{ else_key, else_value, canon_mcv });
+                log.debug("consolidating else_entry {d} {}=>{}", .{ else_key, else_value, canon_mcv });
                 // TODO make sure the destination stack offset / register does not already have something
                 // going on there.
                 try self.setRegOrMem(self.air.typeOfIndex(else_key), canon_mcv, else_value);
@@ -3140,7 +3140,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                         }
                     }
                 };
-                log.debug("consolidating then_entry {*} {}=>{}", .{ then_key, parent_mcv, then_value });
+                log.debug("consolidating then_entry {d} {}=>{}", .{ then_key, parent_mcv, then_value });
                 // TODO make sure the destination stack offset / register does not already have something
                 // going on there.
                 try self.setRegOrMem(self.air.typeOfIndex(then_key), parent_mcv, then_value);

--- a/src/register_manager.zig
+++ b/src/register_manager.zig
@@ -296,15 +296,11 @@ test "tryAllocReg: no spilling" {
     };
     defer function.deinit();
 
-    var mock_instruction = ir.Inst{
-        .tag = .breakpoint,
-        .ty = Type.initTag(.void),
-        .src = .unneeded,
-    };
+    const mock_instruction: Air.Inst.Index = 1;
 
-    try expectEqual(@as(?MockRegister1, .r2), function.register_manager.tryAllocReg(&mock_instruction, &.{}));
-    try expectEqual(@as(?MockRegister1, .r3), function.register_manager.tryAllocReg(&mock_instruction, &.{}));
-    try expectEqual(@as(?MockRegister1, null), function.register_manager.tryAllocReg(&mock_instruction, &.{}));
+    try expectEqual(@as(?MockRegister1, .r2), function.register_manager.tryAllocReg(mock_instruction, &.{}));
+    try expectEqual(@as(?MockRegister1, .r3), function.register_manager.tryAllocReg(mock_instruction, &.{}));
+    try expectEqual(@as(?MockRegister1, null), function.register_manager.tryAllocReg(mock_instruction, &.{}));
 
     try expect(function.register_manager.isRegAllocated(.r2));
     try expect(function.register_manager.isRegAllocated(.r3));
@@ -328,28 +324,24 @@ test "allocReg: spilling" {
     };
     defer function.deinit();
 
-    var mock_instruction = ir.Inst{
-        .tag = .breakpoint,
-        .ty = Type.initTag(.void),
-        .src = .unneeded,
-    };
+    const mock_instruction: Air.Inst.Index = 1;
 
-    try expectEqual(@as(?MockRegister1, .r2), try function.register_manager.allocReg(&mock_instruction, &.{}));
-    try expectEqual(@as(?MockRegister1, .r3), try function.register_manager.allocReg(&mock_instruction, &.{}));
+    try expectEqual(@as(?MockRegister1, .r2), try function.register_manager.allocReg(mock_instruction, &.{}));
+    try expectEqual(@as(?MockRegister1, .r3), try function.register_manager.allocReg(mock_instruction, &.{}));
 
     // Spill a register
-    try expectEqual(@as(?MockRegister1, .r2), try function.register_manager.allocReg(&mock_instruction, &.{}));
+    try expectEqual(@as(?MockRegister1, .r2), try function.register_manager.allocReg(mock_instruction, &.{}));
     try expectEqualSlices(MockRegister1, &[_]MockRegister1{.r2}, function.spilled.items);
 
     // No spilling necessary
     function.register_manager.freeReg(.r3);
-    try expectEqual(@as(?MockRegister1, .r3), try function.register_manager.allocReg(&mock_instruction, &.{}));
+    try expectEqual(@as(?MockRegister1, .r3), try function.register_manager.allocReg(mock_instruction, &.{}));
     try expectEqualSlices(MockRegister1, &[_]MockRegister1{.r2}, function.spilled.items);
 
     // Exceptions
     function.register_manager.freeReg(.r2);
     function.register_manager.freeReg(.r3);
-    try expectEqual(@as(?MockRegister1, .r3), try function.register_manager.allocReg(&mock_instruction, &.{.r2}));
+    try expectEqual(@as(?MockRegister1, .r3), try function.register_manager.allocReg(mock_instruction, &.{.r2}));
 }
 
 test "tryAllocRegs" {
@@ -377,16 +369,12 @@ test "allocRegs" {
     };
     defer function.deinit();
 
-    var mock_instruction = ir.Inst{
-        .tag = .breakpoint,
-        .ty = Type.initTag(.void),
-        .src = .unneeded,
-    };
+    const mock_instruction: Air.Inst.Index = 1;
 
     try expectEqual([_]MockRegister2{ .r0, .r1, .r2 }, try function.register_manager.allocRegs(3, .{
-        &mock_instruction,
-        &mock_instruction,
-        &mock_instruction,
+        mock_instruction,
+        mock_instruction,
+        mock_instruction,
     }, &.{}));
 
     // Exceptions
@@ -402,13 +390,9 @@ test "getReg" {
     };
     defer function.deinit();
 
-    var mock_instruction = ir.Inst{
-        .tag = .breakpoint,
-        .ty = Type.initTag(.void),
-        .src = .unneeded,
-    };
+    const mock_instruction: Air.Inst.Index = 1;
 
-    try function.register_manager.getReg(.r3, &mock_instruction);
+    try function.register_manager.getReg(.r3, mock_instruction);
 
     try expect(!function.register_manager.isRegAllocated(.r2));
     try expect(function.register_manager.isRegAllocated(.r3));
@@ -416,7 +400,7 @@ test "getReg" {
     try expect(!function.register_manager.isRegFree(.r3));
 
     // Spill r3
-    try function.register_manager.getReg(.r3, &mock_instruction);
+    try function.register_manager.getReg(.r3, mock_instruction);
 
     try expect(!function.register_manager.isRegAllocated(.r2));
     try expect(function.register_manager.isRegAllocated(.r3));


### PR DESCRIPTION
Fix compile errors when running `./zig build test-stage2 -Dskip-compile-errors -Dskip-non-native` on the `stage2-air` branch, on WSL1.