### PR TITLE
cmake: also check Homebrew install paths when looking for LLVM

### DIFF
--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -14,6 +14,8 @@ find_path(CLANG_INCLUDE_DIRS NAMES clang/Frontend/ASTUnit.h
     /usr/lib/llvm-12.0/include
     /usr/local/llvm120/include
     /usr/local/llvm12/include
+    /usr/local/opt/llvm@12/include
+    /opt/homebrew/opt/llvm@12/include
     /mingw64/include
 )
 
@@ -30,6 +32,8 @@ if(ZIG_PREFER_CLANG_CPP_DYLIB)
       /usr/lib/llvm-12/lib
       /usr/local/llvm120/lib
       /usr/local/llvm12/lib
+      /usr/local/opt/llvm@12/lib
+      /opt/homebrew/opt/llvm@12/lib
   )
 endif()
 
@@ -44,6 +48,8 @@ if(NOT CLANG_LIBRARIES)
         /usr/lib/llvm-12.0/lib
         /usr/local/llvm120/lib
         /usr/local/llvm12/lib
+        /usr/local/opt/llvm@12/lib
+        /opt/homebrew/opt/llvm@12/lib
         /mingw64/lib
         /c/msys64/mingw64/lib
         c:\\msys64\\mingw64\\lib

--- a/cmake/Findlld.cmake
+++ b/cmake/Findlld.cmake
@@ -11,6 +11,8 @@ find_path(LLD_INCLUDE_DIRS NAMES lld/Common/Driver.h
         /usr/lib/llvm-12/include
         /usr/local/llvm120/include
         /usr/local/llvm12/include
+        /usr/local/opt/llvm@12/include
+        /opt/homebrew/opt/llvm@12/include
         /mingw64/include)
 
 find_library(LLD_LIBRARY NAMES lld-12.0 lld120 lld
@@ -18,6 +20,8 @@ find_library(LLD_LIBRARY NAMES lld-12.0 lld120 lld
         /usr/lib/llvm-12/lib
         /usr/local/llvm120/lib
         /usr/local/llvm12/lib
+        /usr/local/opt/llvm@12/lib
+        /opt/homebrew/opt/llvm@12/lib
 )
 if(EXISTS ${LLD_LIBRARY})
     set(LLD_LIBRARIES ${LLD_LIBRARY})
@@ -30,6 +34,8 @@ else()
                 /usr/lib/llvm-12/lib
                 /usr/local/llvm120/lib
                 /usr/local/llvm12/lib
+                /usr/local/opt/llvm@12/lib
+                /opt/homebrew/opt/llvm@12/lib
                 /mingw64/lib
                 /c/msys64/mingw64/lib
                 c:/msys64/mingw64/lib)

--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -14,6 +14,8 @@ find_path(LLVM_INCLUDE_DIRS NAMES llvm/IR/IRBuilder.h
     /usr/lib/llvm-12.0/include
     /usr/local/llvm12/include
     /usr/local/llvm120/include
+    /usr/local/opt/llvm@12/include
+    /opt/homebrew/opt/llvm@12/include
     /mingw64/include
 )
 
@@ -31,6 +33,8 @@ if(ZIG_PREFER_CLANG_CPP_DYLIB)
       /usr/lib/llvm-12/lib
       /usr/local/llvm12/lib
       /usr/local/llvm120/lib
+      /usr/local/opt/llvm@12/lib
+      /opt/homebrew/opt/llvm@12/lib
   )
 
   find_program(LLVM_CONFIG_EXE
@@ -185,6 +189,8 @@ else()
       /usr/lib/llvm-12.0/lib
       /usr/local/llvm120/lib
       /usr/local/llvm12/lib
+      /usr/local/opt/llvm@12/lib
+      /opt/homebrew/opt/llvm@12/lib
       /mingw64/lib
       /c/msys64/mingw64/lib
       c:\\msys64\\mingw64\\lib)


### PR DESCRIPTION
- On Intel Macs, the path is `/usr/local/opt/llvm@12`
- On Silicon Macs, the path is `/opt/homebrew/opt/llvm@12`

This makes specifying CMAKE_PREFIX_PATH optional for Homebrew LLVM.