### PR TITLE
Removed dead code in std.os.read

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -385,7 +385,6 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
             else => |err| return unexpectedErrno(err),
         }
     }
-    return index;
 }
 
 /// Number of bytes read is returned. Upon reading end-of-file, zero is returned.


### PR DESCRIPTION
This function never reaches this point (the index variable doesn't exist).