### PR TITLE
Fixed compile error: 'bMenu' needs to be casted.

### DIFF
--- a/lib/std/os/windows/user32.zig
+++ b/lib/std/os/windows/user32.zig
@@ -1336,7 +1336,7 @@ pub extern "user32" fn AdjustWindowRectEx(lpRect: *RECT, dwStyle: DWORD, bMenu: 
 pub fn adjustWindowRectEx(lpRect: *RECT, dwStyle: u32, bMenu: bool, dwExStyle: u32) !void {
     assert(dwStyle & WS_OVERLAPPED == 0);
 
-    if (AdjustWindowRectEx(lpRect, dwStyle, bMenu, dwExStyle) == 0) {
+    if (AdjustWindowRectEx(lpRect, dwStyle, @boolToInt(bMenu), dwExStyle) == 0) {
         switch (GetLastError()) {
             .INVALID_PARAMETER => unreachable,
             else => |err| return windows.unexpectedError(err),


### PR DESCRIPTION
Fixed compile error in windows.user32.adjustWindowRectEx function.