### PR TITLE
Use -isysroot on Mojave too

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1664,8 +1664,8 @@ fn buildOutputType(
 
         const has_sysroot = if (comptime std.Target.current.isDarwin()) outer: {
             const min = target_info.target.os.getVersionRange().semver.min;
-            const at_least_catalina = min.major >= 11 or (min.major >= 10 and min.minor >= 15);
-            if (at_least_catalina) {
+            const at_least_mojave = min.major >= 11 or (min.major >= 10 and min.minor >= 14);
+            if (at_least_mojave) {
                 const sdk_path = try std.zig.system.getSDKPath(arena);
                 try clang_argv.ensureCapacity(clang_argv.items.len + 2);
                 clang_argv.appendAssumeCapacity("-isysroot");


### PR DESCRIPTION
This is an extension of #7957 that fixes #8999

This statement from https://github.com/ziglang/zig/pull/7957#issuecomment-773878375 is incorrect (although close):

> Technically speaking, if memory serves, Catalina was the first macOS to ship without `/usr/include`

`/usr/include` was first removed in Mojave, see: https://apple.stackexchange.com/questions/337940/