### PR TITLE
Fixed compilation with std.thread.Condition without libc

### DIFF
--- a/lib/std/Thread/Condition.zig
+++ b/lib/std/Thread/Condition.zig
@@ -157,9 +157,9 @@ pub const AtomicCondition = struct {
             @atomicStore(bool, &cond.pending, true, .SeqCst);
         }
 
-        mutex.unlock();
+        mutex.force_release_internal();
         waiter.data.wait();
-        mutex.lock();
+        _ = mutex.acquire();
     }
 
     pub fn signal(cond: *AtomicCondition) void {

--- a/lib/std/Thread/Mutex.zig
+++ b/lib/std/Thread/Mutex.zig
@@ -50,6 +50,15 @@ pub fn acquire(m: *Mutex) Impl.Held {
     return m.impl.acquire();
 }
 
+/// This is required to get AtomicCondition to work properly
+/// but isn't meant to be called from user code
+pub fn force_release_internal(m: *Mutex) void {
+    if(Impl == AtomicMutex){
+        var releaser = AtomicMutex.Held {.mutex = m.impl};
+        releaser.release();
+    }
+}
+
 const Impl = if (builtin.single_threaded)
     Dummy
 else if (builtin.os.tag == .windows)


### PR DESCRIPTION
Right now using `std.thread.Condition` will error because of compilation errors. Looks like the API for `Mutex` changed and `AtomicCondition` wasn't updated as well.

See: https://zigforum.org/t/condition-variables-are-non-workable/651

```
~/zig/lib/std/Thread/Condition.zig:160:14: error: no member named 'unlock' in struct 'std.Thread.Mutex'
        mutex.unlock();
             ^
```

This PR introduce a new api `force_release_internal` and tries to mimics the same pattern that was already in the code.
I don't like this approach, but I'm not familiar enough with Zig to provide a better alternative.