### PR TITLE
add -femit-llvm-bc CLI option and implement it, and improve -fcompiler-rt support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -796,6 +796,7 @@ set(BUILD_ZIG1_ARGS
     --name zig1
     --zig-lib-dir "${CMAKE_SOURCE_DIR}/lib"
     "-femit-bin=${ZIG1_OBJECT}"
+    -fcompiler-rt
     "${ZIG1_RELEASE_ARG}"
     "${ZIG1_SINGLE_THREADED_ARG}"
     -lc

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const io = std.io;
 const fs = std.fs;
 const process = std.process;
@@ -13,7 +13,7 @@ const Allocator = std.mem.Allocator;
 const max_doc_file_size = 10 * 1024 * 1024;
 
 const exe_ext = @as(std.zig.CrossTarget, .{}).exeFileExt();
-const obj_ext = @as(std.zig.CrossTarget, .{}).oFileExt();
+const obj_ext = builtin.object_format.fileExt(builtin.cpu.arch);
 const tmp_dir_name = "docgen_tmp";
 const test_out_path = tmp_dir_name ++ fs.path.sep_str ++ "test" ++ exe_ext;
 
@@ -281,7 +281,7 @@ const Code = struct {
     name: []const u8,
     source_token: Token,
     is_inline: bool,
-    mode: builtin.Mode,
+    mode: std.builtin.Mode,
     link_objects: []const []const u8,
     target_str: ?[]const u8,
     link_libc: bool,
@@ -531,7 +531,7 @@ fn genToc(allocator: *Allocator, tokenizer: *Tokenizer) !Toc {
                         return parseError(tokenizer, code_kind_tok, "unrecognized code kind: {s}", .{code_kind_str});
                     }
 
-                    var mode: builtin.Mode = .Debug;
+                    var mode: std.builtin.Mode = .Debug;
                     var link_objects = std.ArrayList([]const u8).init(allocator);
                     defer link_objects.deinit();
                     var target_str: ?[]const u8 = null;

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -549,15 +549,36 @@ pub const Target = struct {
     };
 
     pub const ObjectFormat = enum {
+        /// Common Object File Format (Windows)
         coff,
+        /// Executable and Linking Format
         elf,
+        /// macOS relocatables
         macho,
+        /// WebAssembly
         wasm,
+        /// C source code
         c,
+        /// Standard, Portable Intermediate Representation V
         spirv,
+        /// Intel IHEX
         hex,
+        /// Machine code with no metadata.
         raw,
+        /// Plan 9 from Bell Labs
         plan9,
+
+        pub fn fileExt(of: ObjectFormat, cpu_arch: Cpu.Arch) [:0]const u8 {
+            return switch (of) {
+                .coff => ".obj",
+                .elf, .macho, .wasm => ".o",
+                .c => ".c",
+                .spirv => ".spv",
+                .hex => ".ihex",
+                .raw => ".bin",
+                .plan9 => plan9Ext(cpu_arch),
+            };
+        }
     };
 
     pub const SubSystem = enum {
@@ -1289,30 +1310,16 @@ pub const Target = struct {
         return linuxTripleSimple(allocator, self.cpu.arch, self.os.tag, self.abi);
     }
 
-    pub fn oFileExt_os_abi(os_tag: Os.Tag, abi: Abi) [:0]const u8 {
-        if (abi == .msvc) {
-            return ".obj";
-        }
-        switch (os_tag) {
-            .windows, .uefi => return ".obj",
-            else => return ".o",
-        }
-    }
-
-    pub fn oFileExt(self: Target) [:0]const u8 {
-        return oFileExt_os_abi(self.os.tag, self.abi);
-    }
-
     pub fn exeFileExtSimple(cpu_arch: Cpu.Arch, os_tag: Os.Tag) [:0]const u8 {
-        switch (os_tag) {
-            .windows => return ".exe",
-            .uefi => return ".efi",
-            else => if (cpu_arch.isWasm()) {
-                return ".wasm";
-            } else {
-                return "";
+        return switch (os_tag) {
+            .windows => ".exe",
+            .uefi => ".efi",
+            .plan9 => plan9Ext(cpu_arch),
+            else => switch (cpu_arch) {
+                .wasm32, .wasm64 => ".wasm",
+                else => "",
             },
-        }
+        };
     }
 
     pub fn exeFileExt(self: Target) [:0]const u8 {
@@ -1352,20 +1359,16 @@ pub const Target = struct {
     }
 
     pub fn getObjectFormatSimple(os_tag: Os.Tag, cpu_arch: Cpu.Arch) ObjectFormat {
-        if (os_tag == .windows or os_tag == .uefi) {
-            return .coff;
-        } else if (os_tag.isDarwin()) {
-            return .macho;
-        }
-        if (cpu_arch.isWasm()) {
-            return .wasm;
-        }
-        if (cpu_arch.isSPIRV()) {
-            return .spirv;
-        }
-        if (os_tag == .plan9)
-            return .plan9;
-        return .elf;
+        return switch (os_tag) {
+            .windows, .uefi => .coff,
+            .ios, .macos, .watchos, .tvos => .macho,
+            .plan9 => .plan9,
+            else => return switch (cpu_arch) {
+                .wasm32, .wasm64 => .wasm,
+                .spirv32, .spirv64 => .spirv,
+                else => .elf,
+            },
+        };
     }
 
     pub fn getObjectFormat(self: Target) ObjectFormat {
@@ -1675,6 +1678,30 @@ pub const Target = struct {
             return true;
 
         return false;
+    }
+
+    /// 0c spim    little-endian MIPS 3000 family
+    /// 1c 68000   Motorola MC68000
+    /// 2c 68020   Motorola MC68020
+    /// 5c arm     little-endian ARM
+    /// 6c amd64   AMD64 and compatibles (e.g., Intel EM64T)
+    /// 7c arm64   ARM64 (ARMv8)
+    /// 8c 386     Intel i386, i486, Pentium, etc.
+    /// kc sparc   Sun SPARC
+    /// qc power   Power PC
+    /// vc mips    big-endian MIPS 3000 family
+    pub fn plan9Ext(cpu_arch: Cpu.Arch) [:0]const u8 {
+        return switch (cpu_arch) {
+            .arm => ".5",
+            .x86_64 => ".6",
+            .aarch64 => ".7",
+            .i386 => ".8",
+            .sparc => ".k",
+            .powerpc, .powerpcle => ".q",
+            .mips, .mipsel => ".v",
+            // ISAs without designated characters get 'X' for lack of a better option.
+            else => ".X",
+        };
     }
 };
 

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -550,7 +550,6 @@ pub const Target = struct {
 
     pub const ObjectFormat = enum {
         coff,
-        pe,
         elf,
         macho,
         wasm,

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -108,7 +108,8 @@ pub const BinNameOptions = struct {
 pub fn binNameAlloc(allocator: *std.mem.Allocator, options: BinNameOptions) error{OutOfMemory}![]u8 {
     const root_name = options.root_name;
     const target = options.target;
-    switch (options.object_format orelse target.getObjectFormat()) {
+    const ofmt = options.object_format orelse target.getObjectFormat();
+    switch (ofmt) {
         .coff => switch (options.output_mode) {
             .Exe => return std.fmt.allocPrint(allocator, "{s}{s}", .{ root_name, target.exeFileExt() }),
             .Lib => {
@@ -118,7 +119,7 @@ pub fn binNameAlloc(allocator: *std.mem.Allocator, options: BinNameOptions) erro
                 };
                 return std.fmt.allocPrint(allocator, "{s}{s}", .{ root_name, suffix });
             },
-            .Obj => return std.fmt.allocPrint(allocator, "{s}{s}", .{ root_name, target.oFileExt() }),
+            .Obj => return std.fmt.allocPrint(allocator, "{s}.obj", .{root_name}),
         },
         .elf => switch (options.output_mode) {
             .Exe => return allocator.dupe(u8, root_name),
@@ -140,7 +141,7 @@ pub fn binNameAlloc(allocator: *std.mem.Allocator, options: BinNameOptions) erro
                     },
                 }
             },
-            .Obj => return std.fmt.allocPrint(allocator, "{s}{s}", .{ root_name, target.oFileExt() }),
+            .Obj => return std.fmt.allocPrint(allocator, "{s}.o", .{root_name}),
         },
         .macho => switch (options.output_mode) {
             .Exe => return allocator.dupe(u8, root_name),
@@ -163,7 +164,7 @@ pub fn binNameAlloc(allocator: *std.mem.Allocator, options: BinNameOptions) erro
                 }
                 return std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ target.libPrefix(), root_name, suffix });
             },
-            .Obj => return std.fmt.allocPrint(allocator, "{s}{s}", .{ root_name, target.oFileExt() }),
+            .Obj => return std.fmt.allocPrint(allocator, "{s}.o", .{root_name}),
         },
         .wasm => switch (options.output_mode) {
             .Exe => return std.fmt.allocPrint(allocator, "{s}{s}", .{ root_name, target.exeFileExt() }),
@@ -175,36 +176,15 @@ pub fn binNameAlloc(allocator: *std.mem.Allocator, options: BinNameOptions) erro
                     .Dynamic => return std.fmt.allocPrint(allocator, "{s}.wasm", .{root_name}),
                 }
             },
-            .Obj => return std.fmt.allocPrint(allocator, "{s}{s}", .{ root_name, target.oFileExt() }),
+            .Obj => return std.fmt.allocPrint(allocator, "{s}.o", .{root_name}),
         },
         .c => return std.fmt.allocPrint(allocator, "{s}.c", .{root_name}),
         .spirv => return std.fmt.allocPrint(allocator, "{s}.spv", .{root_name}),
         .hex => return std.fmt.allocPrint(allocator, "{s}.ihex", .{root_name}),
         .raw => return std.fmt.allocPrint(allocator, "{s}.bin", .{root_name}),
-        .plan9 => {
-            // copied from 2c(1)
-            // 0c spim    little-endian MIPS 3000 family
-            // 1c 68000   Motorola MC68000
-            // 2c 68020   Motorola MC68020
-            // 5c arm     little-endian ARM
-            // 6c amd64   AMD64 and compatibles (e.g., Intel EM64T)
-            // 7c arm64   ARM64 (ARMv8)
-            // 8c 386     Intel i386, i486, Pentium, etc.
-            // kc sparc   Sun SPARC
-            // qc power   Power PC
-            // vc mips    big-endian MIPS 3000 family
-            const char: u8 = switch (target.cpu.arch) {
-                .arm => '5',
-                .x86_64 => '6',
-                .aarch64 => '7',
-                .i386 => '8',
-                .sparc => 'k',
-                .powerpc, .powerpcle => 'q',
-                .mips, .mipsel => 'v',
-                else => 'X', // this arch does not have a char or maybe was not ported to plan9 so we just use X
-            };
-            return std.fmt.allocPrint(allocator, "{s}.{c}", .{ root_name, char });
-        },
+        .plan9 => return std.fmt.allocPrint(allocator, "{s}{s}", .{
+            root_name, ofmt.fileExt(target.cpu.arch),
+        }),
     }
 }
 

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -109,7 +109,7 @@ pub fn binNameAlloc(allocator: *std.mem.Allocator, options: BinNameOptions) erro
     const root_name = options.root_name;
     const target = options.target;
     switch (options.object_format orelse target.getObjectFormat()) {
-        .coff, .pe => switch (options.output_mode) {
+        .coff => switch (options.output_mode) {
             .Exe => return std.fmt.allocPrint(allocator, "{s}{s}", .{ root_name, target.exeFileExt() }),
             .Lib => {
                 const suffix = switch (options.link_mode orelse .Static) {

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -473,10 +473,6 @@ pub const CrossTarget = struct {
         return self.getOsTag() == .windows;
     }
 
-    pub fn oFileExt(self: CrossTarget) [:0]const u8 {
-        return Target.oFileExt_os_abi(self.getOsTag(), self.getAbi());
-    }
-
     pub fn exeFileExt(self: CrossTarget) [:0]const u8 {
         return Target.exeFileExtSimple(self.getCpuArch(), self.getOsTag());
     }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3023,7 +3023,7 @@ pub fn addCCArgs(
             if (!comp.bin_file.options.strip) {
                 try argv.append("-g");
                 switch (comp.bin_file.options.object_format) {
-                    .coff, .pe => try argv.append("-gcodeview"),
+                    .coff => try argv.append("-gcodeview"),
                     else => {},
                 }
             }

--- a/src/link.zig
+++ b/src/link.zig
@@ -206,7 +206,8 @@ pub const File = struct {
         const use_lld = build_options.have_llvm and options.use_lld; // comptime known false when !have_llvm
         const sub_path = if (use_lld) blk: {
             if (options.module == null) {
-                // No point in opening a file, we would not write anything to it. Initialize with empty.
+                // No point in opening a file, we would not write anything to it.
+                // Initialize with empty.
                 return switch (options.object_format) {
                     .coff => &(try Coff.createEmpty(allocator, options)).base,
                     .elf => &(try Elf.createEmpty(allocator, options)).base,
@@ -219,8 +220,11 @@ pub const File = struct {
                     .raw => return error.RawObjectFormatUnimplemented,
                 };
             }
-            // Open a temporary object file, not the final output file because we want to link with LLD.
-            break :blk try std.fmt.allocPrint(allocator, "{s}{s}", .{ emit.sub_path, options.target.oFileExt() });
+            // Open a temporary object file, not the final output file because we
+            // want to link with LLD.
+            break :blk try std.fmt.allocPrint(allocator, "{s}{s}", .{
+                emit.sub_path, options.object_format.fileExt(options.target.cpu.arch),
+            });
         } else emit.sub_path;
         errdefer if (use_lld) allocator.free(sub_path);
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -191,7 +191,7 @@ pub const File = struct {
         const use_stage1 = build_options.is_stage1 and options.use_stage1;
         if (use_stage1 or options.emit == null) {
             return switch (options.object_format) {
-                .coff, .pe => &(try Coff.createEmpty(allocator, options)).base,
+                .coff => &(try Coff.createEmpty(allocator, options)).base,
                 .elf => &(try Elf.createEmpty(allocator, options)).base,
                 .macho => &(try MachO.createEmpty(allocator, options)).base,
                 .wasm => &(try Wasm.createEmpty(allocator, options)).base,
@@ -208,7 +208,7 @@ pub const File = struct {
             if (options.module == null) {
                 // No point in opening a file, we would not write anything to it. Initialize with empty.
                 return switch (options.object_format) {
-                    .coff, .pe => &(try Coff.createEmpty(allocator, options)).base,
+                    .coff => &(try Coff.createEmpty(allocator, options)).base,
                     .elf => &(try Elf.createEmpty(allocator, options)).base,
                     .macho => &(try MachO.createEmpty(allocator, options)).base,
                     .plan9 => &(try Plan9.createEmpty(allocator, options)).base,
@@ -225,7 +225,7 @@ pub const File = struct {
         errdefer if (use_lld) allocator.free(sub_path);
 
         const file: *File = switch (options.object_format) {
-            .coff, .pe => &(try Coff.openPath(allocator, sub_path, options)).base,
+            .coff => &(try Coff.openPath(allocator, sub_path, options)).base,
             .elf => &(try Elf.openPath(allocator, sub_path, options)).base,
             .macho => &(try MachO.openPath(allocator, sub_path, options)).base,
             .plan9 => &(try Plan9.openPath(allocator, sub_path, options)).base,

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -657,10 +657,7 @@ fn writeOffsetTableEntry(self: *Coff, index: usize) !void {
 }
 
 pub fn updateFunc(self: *Coff, module: *Module, func: *Module.Fn, air: Air, liveness: Liveness) !void {
-    if (build_options.skip_non_native and
-        builtin.object_format != .coff and
-        builtin.object_format != .pe)
-    {
+    if (build_options.skip_non_native and builtin.object_format != .coff) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
     if (build_options.have_llvm) {
@@ -697,7 +694,7 @@ pub fn updateFunc(self: *Coff, module: *Module, func: *Module.Fn, air: Air, live
 }
 
 pub fn updateDecl(self: *Coff, module: *Module, decl: *Module.Decl) !void {
-    if (build_options.skip_non_native and builtin.object_format != .coff and builtin.object_format != .pe) {
+    if (build_options.skip_non_native and builtin.object_format != .coff) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
     if (build_options.have_llvm) {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -25,9 +25,9 @@ const target_util = @import("../target.zig");
 const glibc = @import("../glibc.zig");
 const musl = @import("../musl.zig");
 const Cache = @import("../Cache.zig");
-const llvm_backend = @import("../codegen/llvm.zig");
 const Air = @import("../Air.zig");
 const Liveness = @import("../Liveness.zig");
+const LlvmObject = @import("../codegen/llvm.zig").Object;
 
 const default_entry_addr = 0x8000000;
 
@@ -38,7 +38,7 @@ base: File,
 ptr_width: PtrWidth,
 
 /// If this is not null, an object file is created by LLVM and linked with LLD afterwards.
-llvm_object: ?*llvm_backend.Object = null,
+llvm_object: ?*LlvmObject = null,
 
 /// Stored in native-endian format, depending on target endianness needs to be bswapped on read/write.
 /// Same order as in the file.
@@ -235,7 +235,7 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
         const self = try createEmpty(allocator, options);
         errdefer self.base.destroy();
 
-        self.llvm_object = try llvm_backend.Object.create(allocator, sub_path, options);
+        self.llvm_object = try LlvmObject.create(allocator, options);
         return self;
     }
 
@@ -301,9 +301,9 @@ pub fn createEmpty(gpa: *Allocator, options: link.Options) !*Elf {
 }
 
 pub fn deinit(self: *Elf) void {
-    if (build_options.have_llvm)
-        if (self.llvm_object) |ir_module|
-            ir_module.deinit(self.base.allocator);
+    if (build_options.have_llvm) {
+        if (self.llvm_object) |llvm_object| llvm_object.destroy(self.base.allocator);
+    }
 
     self.sections.deinit(self.base.allocator);
     self.program_headers.deinit(self.base.allocator);
@@ -750,8 +750,8 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
     if (build_options.have_llvm)
         if (self.llvm_object) |llvm_object| return try llvm_object.flushModule(comp);
 
-    // TODO This linker code currently assumes there is only 1 compilation unit and it corresponds to the
-    // Zig source code.
+    // TODO This linker code currently assumes there is only 1 compilation unit and it
+    // corresponds to the Zig source code.
     const module = self.base.options.module orelse return error.LinkingWithoutZigSourceUnimplemented;
 
     const target_endian = self.base.options.target.cpu.arch.endian();

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1289,6 +1289,10 @@ fn linkWithLLD(self: *Elf, comp: *Compilation) !void {
         // TODO: remove when stage2 can build compiler_rt.zig
         if (!build_options.is_stage1) break :blk null;
 
+        // In the case of build-obj we include the compiler-rt symbols directly alongside
+        // the symbols of the root source file, in the same compilation unit.
+        if (is_obj) break :blk null;
+
         if (is_exe_or_dyn_lib) {
             break :blk comp.compiler_rt_static_lib.?.full_object_path;
         } else {

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -19,7 +19,7 @@ const build_options = @import("build_options");
 const wasi_libc = @import("../wasi_libc.zig");
 const Cache = @import("../Cache.zig");
 const TypedValue = @import("../TypedValue.zig");
-const llvm_backend = @import("../codegen/llvm.zig");
+const LlvmObject = @import("../codegen/llvm.zig").Object;
 const Air = @import("../Air.zig");
 const Liveness = @import("../Liveness.zig");
 
@@ -27,7 +27,7 @@ pub const base_tag = link.File.Tag.wasm;
 
 base: link.File,
 /// If this is not null, an object file is created by LLVM and linked with LLD afterwards.
-llvm_object: ?*llvm_backend.Object = null,
+llvm_object: ?*LlvmObject = null,
 /// List of all function Decls to be written to the output file. The index of
 /// each Decl in this list at the time of writing the binary is used as the
 /// function index. In the event where ext_funcs' size is not 0, the index of
@@ -121,7 +121,7 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
         const self = try createEmpty(allocator, options);
         errdefer self.base.destroy();
 
-        self.llvm_object = try llvm_backend.Object.create(allocator, sub_path, options);
+        self.llvm_object = try LlvmObject.create(allocator, options);
         return self;
     }
 
@@ -153,6 +153,9 @@ pub fn createEmpty(gpa: *Allocator, options: link.Options) !*Wasm {
 }
 
 pub fn deinit(self: *Wasm) void {
+    if (build_options.have_llvm) {
+        if (self.llvm_object) |llvm_object| llvm_object.destroy(self.base.allocator);
+    }
     for (self.symbols.items) |decl| {
         decl.fn_link.wasm.functype.deinit(self.base.allocator);
         decl.fn_link.wasm.code.deinit(self.base.allocator);

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -645,7 +645,9 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation) !void {
         break :blk full_obj_path;
     } else null;
 
-    const compiler_rt_path: ?[]const u8 = if (self.base.options.include_compiler_rt)
+    const is_obj = self.base.options.output_mode == .Obj;
+
+    const compiler_rt_path: ?[]const u8 = if (self.base.options.include_compiler_rt and !is_obj)
         comp.compiler_rt_static_lib.?.full_object_path
     else
         null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -385,8 +385,8 @@ const usage_build_generic =
     \\  --dynamic-linker [path]        Set the dynamic interpreter path (usually ld.so)
     \\  --sysroot [path]               Set the system root directory (usually /)
     \\  --version [ver]                Dynamic library semver
-    \\  -fsoname[=name]                (Linux) Override the default SONAME value
-    \\  -fno-soname                    (Linux) Disable emitting a SONAME
+    \\  -fsoname[=name]                Override the default SONAME value
+    \\  -fno-soname                    Disable emitting a SONAME
     \\  -fLLD                          Force using LLD as the linker
     \\  -fno-LLD                       Prevent using LLD as the linker
     \\  -fcompiler-rt                  Always include compiler-rt symbols in output

--- a/src/stage1.zig
+++ b/src/stage1.zig
@@ -21,7 +21,6 @@ comptime {
     assert(build_options.is_stage1);
     assert(build_options.have_llvm);
     if (!builtin.is_test) {
-        _ = @import("compiler_rt");
         @export(main, .{ .name = "main" });
     }
 }
@@ -126,6 +125,7 @@ pub const Module = extern struct {
     valgrind_enabled: bool,
     tsan_enabled: bool,
     function_sections: bool,
+    include_compiler_rt: bool,
     enable_stack_probing: bool,
     red_zone: bool,
     enable_time_report: bool,

--- a/src/stage1.zig
+++ b/src/stage1.zig
@@ -95,6 +95,8 @@ pub const Module = extern struct {
     emit_asm_len: usize,
     emit_llvm_ir_ptr: [*]const u8,
     emit_llvm_ir_len: usize,
+    emit_bitcode_ptr: [*]const u8,
+    emit_bitcode_len: usize,
     emit_analysis_json_ptr: [*]const u8,
     emit_analysis_json_len: usize,
     emit_docs_ptr: [*]const u8,

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -2150,6 +2150,7 @@ struct CodeGen {
     bool have_stack_probing;
     bool red_zone;
     bool function_sections;
+    bool include_compiler_rt;
     bool test_is_evented;
     bool valgrind_enabled;
     bool tsan_enabled;

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -2090,6 +2090,7 @@ struct CodeGen {
     Buf h_file_output_path;
     Buf asm_file_output_path;
     Buf llvm_ir_file_output_path;
+    Buf bitcode_file_output_path;
     Buf analysis_json_output_path;
     Buf docs_output_path;
 

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -9542,6 +9542,22 @@ static void gen_root_source(CodeGen *g) {
     g->panic_fn = panic_fn_val->data.x_ptr.data.fn.fn_entry;
     assert(g->panic_fn != nullptr);
 
+    if (g->include_compiler_rt) {
+        Buf *import_target_path;
+        Buf full_path = BUF_INIT;
+        ZigType *compiler_rt_import;
+        if ((err = analyze_import(g, std_import, buf_create_from_str("./special/compiler_rt.zig"),
+            &compiler_rt_import, &import_target_path, &full_path)))
+        {
+            if (err == ErrorFileNotFound) {
+                fprintf(stderr, "unable to find '%s'", buf_ptr(import_target_path));
+            } else {
+                fprintf(stderr, "unable to open '%s': %s\n", buf_ptr(&full_path), err_str(err));
+            }
+            exit(1);
+        }
+    }
+
     if (!g->error_during_imports) {
         semantic_analyze(g);
     }

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -8506,19 +8506,22 @@ static void zig_llvm_emit_output(CodeGen *g) {
     const char *asm_filename = nullptr;
     const char *bin_filename = nullptr;
     const char *llvm_ir_filename = nullptr;
+    const char *bitcode_filename = nullptr;
 
     if (buf_len(&g->o_file_output_path) != 0) bin_filename = buf_ptr(&g->o_file_output_path);
     if (buf_len(&g->asm_file_output_path) != 0) asm_filename = buf_ptr(&g->asm_file_output_path);
     if (buf_len(&g->llvm_ir_file_output_path) != 0) llvm_ir_filename = buf_ptr(&g->llvm_ir_file_output_path);
+    if (buf_len(&g->bitcode_file_output_path) != 0) bitcode_filename = buf_ptr(&g->bitcode_file_output_path);
 
-    // Unfortunately, LLVM shits the bed when we ask for both binary and assembly. So we call the entire
-    // pipeline multiple times if this is requested.
+    // Unfortunately, LLVM shits the bed when we ask for both binary and assembly.
+    // So we call the entire pipeline multiple times if this is requested.
     if (asm_filename != nullptr && bin_filename != nullptr) {
         if (ZigLLVMTargetMachineEmitToFile(g->target_machine, g->module, &err_msg,
             g->build_mode == BuildModeDebug, is_small, g->enable_time_report, g->tsan_enabled,
-            g->have_lto, nullptr, bin_filename, llvm_ir_filename))
+            g->have_lto, nullptr, bin_filename, llvm_ir_filename, nullptr))
         {
-            fprintf(stderr, "LLVM failed to emit file: %s\n", err_msg);
+            fprintf(stderr, "LLVM failed to emit bin=%s, ir=%s: %s\n",
+                    bin_filename, llvm_ir_filename, err_msg);
             exit(1);
         }
         bin_filename = nullptr;
@@ -8527,9 +8530,11 @@ static void zig_llvm_emit_output(CodeGen *g) {
 
     if (ZigLLVMTargetMachineEmitToFile(g->target_machine, g->module, &err_msg,
         g->build_mode == BuildModeDebug, is_small, g->enable_time_report, g->tsan_enabled,
-        g->have_lto, asm_filename, bin_filename, llvm_ir_filename))
+        g->have_lto, asm_filename, bin_filename, llvm_ir_filename, bitcode_filename))
     {
-        fprintf(stderr, "LLVM failed to emit file: %s\n", err_msg);
+        fprintf(stderr, "LLVM failed to emit asm=%s, bin=%s, ir=%s, bc=%s: %s\n",
+                asm_filename, bin_filename, llvm_ir_filename, bitcode_filename,
+                err_msg);
         exit(1);
     }
 

--- a/src/stage1/stage1.cpp
+++ b/src/stage1/stage1.cpp
@@ -101,6 +101,7 @@ void zig_stage1_build_object(struct ZigStage1 *stage1) {
     g->link_libc = stage1->link_libc;
     g->link_libcpp = stage1->link_libcpp;
     g->function_sections = stage1->function_sections;
+    g->include_compiler_rt = stage1->include_compiler_rt;
 
     g->subsystem = stage1->subsystem;
 

--- a/src/stage1/stage1.cpp
+++ b/src/stage1/stage1.cpp
@@ -73,6 +73,7 @@ void zig_stage1_build_object(struct ZigStage1 *stage1) {
     buf_init_from_mem(&g->h_file_output_path, stage1->emit_h_ptr, stage1->emit_h_len);
     buf_init_from_mem(&g->asm_file_output_path, stage1->emit_asm_ptr, stage1->emit_asm_len);
     buf_init_from_mem(&g->llvm_ir_file_output_path, stage1->emit_llvm_ir_ptr, stage1->emit_llvm_ir_len);
+    buf_init_from_mem(&g->bitcode_file_output_path, stage1->emit_bitcode_ptr, stage1->emit_bitcode_len);
     buf_init_from_mem(&g->analysis_json_output_path, stage1->emit_analysis_json_ptr, stage1->emit_analysis_json_len);
     buf_init_from_mem(&g->docs_output_path, stage1->emit_docs_ptr, stage1->emit_docs_len);
 

--- a/src/stage1/stage1.h
+++ b/src/stage1/stage1.h
@@ -157,6 +157,9 @@ struct ZigStage1 {
     const char *emit_llvm_ir_ptr;
     size_t emit_llvm_ir_len;
 
+    const char *emit_bitcode_ptr;
+    size_t emit_bitcode_len;
+
     const char *emit_analysis_json_ptr;
     size_t emit_analysis_json_len;
 

--- a/src/stage1/stage1.h
+++ b/src/stage1/stage1.h
@@ -196,6 +196,7 @@ struct ZigStage1 {
     bool valgrind_enabled;
     bool tsan_enabled;
     bool function_sections;
+    bool include_compiler_rt;
     bool enable_stack_probing;
     bool red_zone;
     bool enable_time_report;

--- a/src/stage1/zig0.cpp
+++ b/src/stage1/zig0.cpp
@@ -39,6 +39,7 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  --color [auto|off|on]        enable or disable colored error messages\n"
         "  --name [name]                override output name\n"
         "  -femit-bin=[path]            Output machine code\n"
+        "  -fcompiler-rt                Always include compiler-rt symbols in output\n"
         "  --pkg-begin [name] [path]    make pkg available to import and push current pkg\n"
         "  --pkg-end                    pop current pkg\n"
         "  -ODebug                      build with optimizations off and safety on\n"
@@ -266,6 +267,7 @@ int main(int argc, char **argv) {
     const char *mcpu = nullptr;
     bool single_threaded = false;
     bool is_test_build = false;
+    bool include_compiler_rt = false;
 
     for (int i = 1; i < argc; i += 1) {
         char *arg = argv[i];
@@ -334,6 +336,8 @@ int main(int argc, char **argv) {
                 mcpu = arg + strlen("-mcpu=");
             } else if (str_starts_with(arg, "-femit-bin=")) {
                 emit_bin_path = arg + strlen("-femit-bin=");
+            } else if (strcmp(arg, "-fcompiler-rt") == 0) {
+                include_compiler_rt = true;
             } else if (i + 1 >= argc) {
                 fprintf(stderr, "Expected another argument after %s\n", arg);
                 return print_error_usage(arg0);
@@ -468,6 +472,7 @@ int main(int argc, char **argv) {
     stage1->subsystem = subsystem;
     stage1->pic = true;
     stage1->is_single_threaded = single_threaded;
+    stage1->include_compiler_rt = include_compiler_rt;
 
     zig_stage1_build_object(stage1);
 

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -49,7 +49,8 @@ ZIG_EXTERN_C char *ZigLLVMGetNativeFeatures(void);
 ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
         char **error_message, bool is_debug,
         bool is_small, bool time_report, bool tsan, bool lto,
-        const char *asm_filename, const char *bin_filename, const char *llvm_ir_filename);
+        const char *asm_filename, const char *bin_filename,
+        const char *llvm_ir_filename, const char *bitcode_filename);
 
 
 enum ZigLLVMABIType {


### PR DESCRIPTION
### Emitting LLVM bitcode & improvements to stage2 LLVM backend

* Added doc comments for `std.Target.ObjectFormat` enum
* `std.Target.oFileExt` is removed because it is incorrect for Plan-9
  targets. Instead, use `std.Target.ObjectFormat.fileExt` and pass a
  CPU architecture.
* Added `Compilation.Directory.joinZ` for when a null byte is desired.
* Improvements to `Compilation.create` logic for computing `use_llvm`
  and reporting errors in contradictory flags. `-femit-llvm-ir` and
  `-femit-llvm-bc` will now imply `-fLLVM`.
* Fix compilation when passing `.bc` files on the command line.
* Improvements to the stage2 LLVM backend:
  - cleaned up error messages and error reporting. Properly bubble up
    some errors rather than dumping to stderr; others turn into panics.
  - properly call ZigLLVMCreateTargetMachine and
    ZigLLVMTargetMachineEmitToFile and implement calculation of the
    respective parameters (cpu features, code model, abi name, lto,
    tsan, etc).
  - LLVM module verification only runs in debug builds of the compiler
  - use LLVMDumpModule rather than printToString because in the case
    that we incorrectly pass a null pointer to LLVM it may crash during
    dumping the module and having it partially printed is helpful in
    this case.
  - support -femit-asm, -fno-emit-bin, -femit-llvm-ir, -femit-llvm-bc
  - Support LLVM backend when used with Mach-O and WASM linkers.

### support -fcompiler-rt in conjunction with build-obj
    
When using `build-exe` or `build-lib -dynamic`, `-fcompiler-rt` means building
compiler-rt into a static library and then linking it into the executable.

When using `build-lib`, `-fcompiler-rt` means building compiler-rt into an
object file and then adding it into the static archive.

Before this commit, when using `build-obj`, zig would build compiler-rt
into an object file, and then on ELF, use `lld -r` to merge it into the
main object file. Other linker backends of LLD do not support `-r` to
merge objects, so this failed with error messages for those targets.

Now, `-fcompiler-rt` when used with `build-obj` acts as if the user puts
`_ = @import("compiler_rt");` inside their root source file. The symbols
of compiler-rt go into the same compilation unit as the root source file.

This is hooked up for stage1 only for now. Once stage2 is capable of
building compiler-rt, it should be hooked up there as well.

