### PR TITLE
ci: remove extra zig directory in windows builds

### DIFF
--- a/ci/azure/windows_upload
+++ b/ci/azure/windows_upload
@@ -11,6 +11,11 @@ if [ "${BUILD_REASON}" != "PullRequest" ]; then
   mv dist/bin/zig.exe dist/
   rmdir dist/bin
 
+  # Remove the unnecessary zig dir in $prefix/lib/zig/std/std.zig
+  mv dist/lib/zig dist/lib2
+  rmdir dist/lib
+  mv dist/lib2 dist/lib
+
   VERSION=$(dist/zig.exe version)
   DIRNAME="zig-windows-x86_64-$VERSION"
   TARBALL="$DIRNAME.zip"


### PR DESCRIPTION
From $prefix/lib/zig/std/std.zig to $prefix/lib/std/std.zig

This is to match the directory structure of the Linux builds.