### PR TITLE
stage2: wasm - Use `br_table` when possible for switch

### DIFF
--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -479,68 +479,66 @@ pub fn addCases(ctx: *TestContext) !void {
         , "30\n");
     }
 
-    // This test case is disabled until the codegen for switch is reworked
-    // to take advantage of br_table rather than a series of br_if opcodes.
-    //{
-    //    var case = ctx.exe("wasm switch", wasi);
+    {
+        var case = ctx.exe("wasm switch", wasi);
 
-    //    case.addCompareOutput(
-    //        \\pub export fn _start() u32 {
-    //        \\    var val: u32 = 1;
-    //        \\    var a: u32 = switch (val) {
-    //        \\        0, 1 => 2,
-    //        \\        2 => 3,
-    //        \\        3 => 4,
-    //        \\        else => 5,
-    //        \\    };
-    //        \\
-    //        \\    return a;
-    //        \\}
-    //    , "2\n");
+        case.addCompareOutput(
+            \\pub export fn _start() u32 {
+            \\    var val: u32 = 1;
+            \\    var a: u32 = switch (val) {
+            \\        0, 1 => 2,
+            \\        2 => 3,
+            \\        3 => 4,
+            \\        else => 5,
+            \\    };
+            \\
+            \\    return a;
+            \\}
+        , "2\n");
 
-    //    case.addCompareOutput(
-    //        \\pub export fn _start() u32 {
-    //        \\    var val: u32 = 2;
-    //        \\    var a: u32 = switch (val) {
-    //        \\        0, 1 => 2,
-    //        \\        2 => 3,
-    //        \\        3 => 4,
-    //        \\        else => 5,
-    //        \\    };
-    //        \\
-    //        \\    return a;
-    //        \\}
-    //    , "3\n");
+        case.addCompareOutput(
+            \\pub export fn _start() u32 {
+            \\    var val: u32 = 2;
+            \\    var a: u32 = switch (val) {
+            \\        0, 1 => 2,
+            \\        2 => 3,
+            \\        3 => 4,
+            \\        else => 5,
+            \\    };
+            \\
+            \\    return a;
+            \\}
+        , "3\n");
 
-    //    case.addCompareOutput(
-    //        \\pub export fn _start() u32 {
-    //        \\    var val: u32 = 10;
-    //        \\    var a: u32 = switch (val) {
-    //        \\        0, 1 => 2,
-    //        \\        2 => 3,
-    //        \\        3 => 4,
-    //        \\        else => 5,
-    //        \\    };
-    //        \\
-    //        \\    return a;
-    //        \\}
-    //    , "5\n");
+        case.addCompareOutput(
+            \\pub export fn _start() u32 {
+            \\    var val: u32 = 10;
+            \\    var a: u32 = switch (val) {
+            \\        0, 1 => 2,
+            \\        2 => 3,
+            \\        3 => 4,
+            \\        else => 5,
+            \\    };
+            \\
+            \\    return a;
+            \\}
+        , "5\n");
 
-    //    case.addCompareOutput(
-    //        \\const MyEnum = enum { One, Two, Three };
-    //        \\
-    //        \\pub export fn _start() u32 {
-    //        \\    var val: MyEnum = .Two;
-    //        \\    var a: u32 = switch (val) {
-    //        \\        .One => 1,
-    //        \\        .Two => 2,
-    //        \\        .Three => 3,
-    //        \\    };
-    //        \\
-    //        \\    return a;
-    //        \\}
-    //    , "2\n");
-    //}
+        case.addCompareOutput(
+            \\const MyEnum = enum { One, Two, Three };
+            \\
+            \\pub export fn _start() u32 {
+            \\    var val: MyEnum = .Two;
+            \\    var a: u32 = switch (val) {
+            \\        .One => 1,
+            \\        .Two => 2,
+            \\        .Three => 3,
+            \\    };
+            \\
+            \\    return a;
+            \\}
+        , "2\n");
+    }
 
     {
         var case = ctx.exe("wasm error unions", wasi);


### PR DESCRIPTION
Contains the following:
- Rewrite switch_br to use `br_table` instead
- When prongs are sparse values, use if/else-chain
- Allow negative values (Emit the actual bits of integers, rather than the value it represents).
- Support multi-value prongs
- Re-enable switch test cases and fix regressions

Currently, this works by calculating the highest and lowest value of the prongs.
When the difference between them exceeds 50, we use an if/else-chain.
This is something that still requires benchmarking (in the future), LLVM seems to switch from br_table to if/else-chain between 40-45.

br_table is essentially a jump table where it takes the stack value as an index, into a vector of labels.
Each label represents a branch it will jump to, the last label is the default for any values that go out of bounds. 
As the index is limited to 2^32-1, we resort to an if/else-chain for switches over targets with a bitsize over 32.

One more edge case that had to be handled cases where we use an if/else-chain and also have multi-value prongs.
For those cases, we emit an extra block and jump out of that extra block if we match to any value. (to the body the case targets).
When no value is matched, it will instead jump back out 1 further. (to the next case).

