### PR TITLE
Use cl::expandResponseFiles to expand a response file

### DIFF
--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -908,7 +908,7 @@ pub const WriteImportLibrary = ZigLLVMWriteImportLibrary;
 extern fn ZigLLVMWriteImportLibrary(
     def_path: [*:0]const u8,
     arch: ArchType,
-    output_lib_path: [*c]const u8,
+    output_lib_path: [*:0]const u8,
     kill_at: bool,
 ) bool;
 
@@ -931,3 +931,10 @@ pub const Linkage = enum(c_uint) {
     LinkerPrivate,
     LinkerPrivateWeak,
 };
+
+pub const ExpandResponseFile = ZigLLVMExpandResponseFile;
+extern fn ZigLLVMExpandResponseFile(
+    response_file: [*:0]const u8,
+    tokens: *[*][*:0]u8,
+    token_count: *usize,
+) bool;

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -539,4 +539,7 @@ ZIG_EXTERN_C void ZigLLVMGetNativeTarget(enum ZigLLVM_ArchType *arch_type,
 ZIG_EXTERN_C unsigned ZigLLVMDataLayoutGetStackAlignment(LLVMTargetDataRef TD);
 ZIG_EXTERN_C unsigned ZigLLVMDataLayoutGetProgramAddressSpace(LLVMTargetDataRef TD);
 
+ZIG_EXTERN_C bool ZigLLVMExpandResponseFile(const char *response_file, char ***tokens,
+        size_t *token_count);
+
 #endif


### PR DESCRIPTION
This PR will address the TODO for more robust response file parsing.

https://github.com/ziglang/zig/blob/7b8cb881df7e034a8626caabf355055ee81a0fef/src/main.zig#L3647-L3648

For example, `clang` and `gcc` can handle quotes very well.

    $ cat argsfile
    '-o'
    test
    test.c
    $ gcc @argsfile

    $ cat argsfile2
    -o
    'te st'
    test.c
    $ gcc @argsfile

But `zig cc` can't.

    $ zig cc @argsfile
    error: FileNotFound
    $ zig cc @argsfile2
    error: FileNotFound

This PR will change the code to use LLVM `cl::expandResponseFiles` via C interop.