### PR TITLE
Add @select

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7125,6 +7125,7 @@ fn func(y: *i32) void {
       an integer or an enum.
       </p>
       {#header_close#}
+
       {#header_open|@bitCast#}
       <pre>{#syntax#}@bitCast(comptime DestType: type, value: anytype) DestType{#endsyntax#}</pre>
       <p>
@@ -8171,6 +8172,15 @@ test "@wasmMemoryGrow" {
       a calling function, the returned address will apply to the calling function.
       </p>
       {#header_close#}
+
+      {#header_open|@select#}
+      <pre>{#syntax#}@select(comptime T: type, pred: std.meta.Vector(len, bool), a: std.meta.Vector(len, T), b: std.meta.Vector(len, T)) std.meta.Vector(len, T){#endsyntax#}</pre>
+      <p>
+      Selects values element-wise from {#syntax#}a{#endsyntax#} or {#syntax#}b{#endsyntax#} based on {#syntax#}pred{#endsyntax#}. If {#syntax#}pred[i]{#endsyntax#} is {#syntax#}true{#endsyntax#}, the corresponding element in the result will be {#syntax#}a[i]{#endsyntax#} and otherwise {#syntax#}b[i]{#endsyntax#}.
+      </p>
+      {#see_also|SIMD|Vectors#}
+      {#header_close#}
+
       {#header_open|@setAlignStack#}
       <pre>{#syntax#}@setAlignStack(comptime alignment: u29){#endsyntax#}</pre>
       <p>

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -2090,6 +2090,7 @@ fn unusedResultExpr(gz: *GenZir, scope: *Scope, statement: ast.Node.Index) Inner
             .splat,
             .reduce,
             .shuffle,
+            .select,
             .atomic_load,
             .atomic_rmw,
             .atomic_store,
@@ -7372,6 +7373,15 @@ fn builtinCall(
                 .a = try expr(gz, scope, .none, params[1]),
                 .b = try expr(gz, scope, .none, params[2]),
                 .mask = try comptimeExpr(gz, scope, .none, params[3]),
+            });
+            return rvalue(gz, rl, result, node);
+        },
+        .select => {
+            const result = try gz.addPlNode(.select, node, Zir.Inst.Select{
+                .elem_type = try typeExpr(gz, scope, params[0]),
+                .pred = try expr(gz, scope, .none, params[1]),
+                .a = try expr(gz, scope, .none, params[2]),
+                .b = try expr(gz, scope, .none, params[3]),
             });
             return rvalue(gz, rl, result, node);
         },

--- a/src/BuiltinFn.zig
+++ b/src/BuiltinFn.zig
@@ -69,6 +69,7 @@ pub const Tag = enum {
     ptr_to_int,
     rem,
     return_address,
+    select,
     set_align_stack,
     set_cold,
     set_eval_branch_quota,
@@ -599,6 +600,13 @@ pub const list = list: {
             .{
                 .tag = .return_address,
                 .param_count = 0,
+            },
+        },
+        .{
+            "@select",
+            .{
+                .tag = .select,
+                .param_count = 4,
             },
         },
         .{

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -338,6 +338,7 @@ pub fn analyzeBody(
             .splat                        => try sema.zirSplat(block, inst),
             .reduce                       => try sema.zirReduce(block, inst),
             .shuffle                      => try sema.zirShuffle(block, inst),
+            .select                       => try sema.zirSelect(block, inst),
             .atomic_load                  => try sema.zirAtomicLoad(block, inst),
             .atomic_rmw                   => try sema.zirAtomicRmw(block, inst),
             .atomic_store                 => try sema.zirAtomicStore(block, inst),
@@ -6097,6 +6098,12 @@ fn zirShuffle(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) CompileErr
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src = inst_data.src();
     return sema.mod.fail(&block.base, src, "TODO: Sema.zirShuffle", .{});
+}
+
+fn zirSelect(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
+    const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
+    const src = inst_data.src();
+    return sema.mod.fail(&block.base, src, "TODO: Sema.zirSelect", .{});
 }
 
 fn zirAtomicLoad(sema: *Sema, block: *Scope.Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -890,6 +890,9 @@ pub const Inst = struct {
         /// Implements the `@shuffle` builtin.
         /// Uses the `pl_node` union field with payload `Shuffle`.
         shuffle,
+        /// Implements the `@select` builtin.
+        /// Uses the `pl_node` union field with payload `Select`.
+        select,
         /// Implements the `@atomicLoad` builtin.
         /// Uses the `pl_node` union field with payload `Bin`.
         atomic_load,
@@ -1181,6 +1184,7 @@ pub const Inst = struct {
                 .splat,
                 .reduce,
                 .shuffle,
+                .select,
                 .atomic_load,
                 .atomic_rmw,
                 .atomic_store,
@@ -1451,6 +1455,7 @@ pub const Inst = struct {
                 .splat = .pl_node,
                 .reduce = .pl_node,
                 .shuffle = .pl_node,
+                .select = .pl_node,
                 .atomic_load = .pl_node,
                 .atomic_rmw = .pl_node,
                 .atomic_store = .pl_node,
@@ -2725,6 +2730,13 @@ pub const Inst = struct {
         mask: Ref,
     };
 
+    pub const Select = struct {
+        elem_type: Ref,
+        pred: Ref,
+        a: Ref,
+        b: Ref,
+    };
+
     pub const AsyncCall = struct {
         frame_buffer: Ref,
         result_ptr: Ref,
@@ -2935,6 +2947,7 @@ const Writer = struct {
             .cmpxchg_strong,
             .cmpxchg_weak,
             .shuffle,
+            .select,
             .atomic_rmw,
             .atomic_store,
             .mul_add,

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -1755,6 +1755,7 @@ enum BuiltinFnId {
     BuiltinFnIdIntToEnum,
     BuiltinFnIdVectorType,
     BuiltinFnIdShuffle,
+    BuiltinFnIdSelect,
     BuiltinFnIdSplat,
     BuiltinFnIdSetCold,
     BuiltinFnIdSetRuntimeSafety,
@@ -2541,6 +2542,7 @@ enum Stage1ZirInstId : uint8_t {
     Stage1ZirInstIdBoolToInt,
     Stage1ZirInstIdVectorType,
     Stage1ZirInstIdShuffleVector,
+    Stage1ZirInstIdSelect,
     Stage1ZirInstIdSplat,
     Stage1ZirInstIdBoolNot,
     Stage1ZirInstIdMemset,
@@ -2661,6 +2663,7 @@ enum Stage1AirInstId : uint8_t {
     Stage1AirInstIdReduce,
     Stage1AirInstIdTruncate,
     Stage1AirInstIdShuffleVector,
+    Stage1AirInstIdSelect,
     Stage1AirInstIdSplat,
     Stage1AirInstIdBoolNot,
     Stage1AirInstIdMemset,
@@ -4290,6 +4293,23 @@ struct Stage1AirInstShuffleVector {
     Stage1AirInst *a;
     Stage1AirInst *b;
     Stage1AirInst *mask; // This is in zig-format, not llvm format
+};
+
+struct Stage1ZirInstSelect {
+    Stage1ZirInst base;
+
+    Stage1ZirInst *scalar_type;
+    Stage1ZirInst *pred; // This is in zig-format, not llvm format
+    Stage1ZirInst *a;
+    Stage1ZirInst *b;
+};
+
+struct Stage1AirInstSelect {
+    Stage1AirInst base;
+
+    Stage1AirInst *pred;  // This is in zig-format, not llvm format
+    Stage1AirInst *a;
+    Stage1AirInst *b;
 };
 
 struct Stage1ZirInstSplat {

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -5144,6 +5144,13 @@ static LLVMValueRef ir_render_shuffle_vector(CodeGen *g, Stage1Air *executable, 
         llvm_mask_value, "");
 }
 
+static LLVMValueRef ir_render_select(CodeGen *g, Stage1Air *executable, Stage1AirInstSelect *instruction) {
+    LLVMValueRef pred = ir_llvm_value(g, instruction->pred);
+    LLVMValueRef a = ir_llvm_value(g, instruction->a);
+    LLVMValueRef b = ir_llvm_value(g, instruction->b);
+    return LLVMBuildSelect(g->builder, pred, a, b, "");
+}
+
 static LLVMValueRef ir_render_splat(CodeGen *g, Stage1Air *executable, Stage1AirInstSplat *instruction) {
     ZigType *result_type = instruction->base.value->type;
     ir_assert(result_type->id == ZigTypeIdVector, &instruction->base);
@@ -6997,6 +7004,8 @@ static LLVMValueRef ir_render_instruction(CodeGen *g, Stage1Air *executable, Sta
             return ir_render_spill_end(g, executable, (Stage1AirInstSpillEnd *)instruction);
         case Stage1AirInstIdShuffleVector:
             return ir_render_shuffle_vector(g, executable, (Stage1AirInstShuffleVector *) instruction);
+        case Stage1AirInstIdSelect:
+            return ir_render_select(g, executable, (Stage1AirInstSelect *) instruction);
         case Stage1AirInstIdSplat:
             return ir_render_splat(g, executable, (Stage1AirInstSplat *) instruction);
         case Stage1AirInstIdVectorExtractElem:
@@ -8902,6 +8911,7 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdCompileLog, "compileLog", SIZE_MAX);
     create_builtin_fn(g, BuiltinFnIdVectorType, "Vector", 2);
     create_builtin_fn(g, BuiltinFnIdShuffle, "shuffle", 4);
+    create_builtin_fn(g, BuiltinFnIdSelect, "select", 4);
     create_builtin_fn(g, BuiltinFnIdSplat, "splat", 2);
     create_builtin_fn(g, BuiltinFnIdSetCold, "setCold", 1);
     create_builtin_fn(g, BuiltinFnIdSetRuntimeSafety, "setRuntimeSafety", 1);

--- a/src/stage1/ir_print.cpp
+++ b/src/stage1/ir_print.cpp
@@ -93,6 +93,8 @@ const char* ir_inst_src_type_str(Stage1ZirInstId id) {
             return "SrcInvalid";
         case Stage1ZirInstIdShuffleVector:
             return "SrcShuffle";
+        case Stage1ZirInstIdSelect:
+            return "SrcSelect";
         case Stage1ZirInstIdSplat:
             return "SrcSplat";
         case Stage1ZirInstIdDeclVar:
@@ -379,6 +381,8 @@ const char* ir_inst_gen_type_str(Stage1AirInstId id) {
             return "GenInvalid";
         case Stage1AirInstIdShuffleVector:
             return "GenShuffle";
+        case Stage1AirInstIdSelect:
+            return "GenSelect";
         case Stage1AirInstIdSplat:
             return "GenSplat";
         case Stage1AirInstIdDeclVar:
@@ -1722,6 +1726,28 @@ static void ir_print_shuffle_vector(IrPrintGen *irp, Stage1AirInstShuffleVector 
     fprintf(irp->f, ")");
 }
 
+static void ir_print_select(IrPrintSrc *irp, Stage1ZirInstSelect *instruction) {
+    fprintf(irp->f, "@select(");
+    ir_print_other_inst_src(irp, instruction->scalar_type);
+    fprintf(irp->f, ", ");
+    ir_print_other_inst_src(irp, instruction->pred);
+    fprintf(irp->f, ", ");
+    ir_print_other_inst_src(irp, instruction->a);
+    fprintf(irp->f, ", ");
+    ir_print_other_inst_src(irp, instruction->b);
+    fprintf(irp->f, ")");
+}
+
+static void ir_print_select(IrPrintGen *irp, Stage1AirInstSelect *instruction) {
+    fprintf(irp->f, "@select(");
+    ir_print_other_inst_gen(irp, instruction->pred);
+    fprintf(irp->f, ", ");
+    ir_print_other_inst_gen(irp, instruction->a);
+    fprintf(irp->f, ", ");
+    ir_print_other_inst_gen(irp, instruction->b);
+    fprintf(irp->f, ")");
+}
+
 static void ir_print_splat_src(IrPrintSrc *irp, Stage1ZirInstSplat *instruction) {
     fprintf(irp->f, "@splat(");
     ir_print_other_inst_src(irp, instruction->len);
@@ -2836,6 +2862,9 @@ static void ir_print_inst_src(IrPrintSrc *irp, Stage1ZirInst *instruction, bool 
         case Stage1ZirInstIdShuffleVector:
             ir_print_shuffle_vector(irp, (Stage1ZirInstShuffleVector *)instruction);
             break;
+        case Stage1ZirInstIdSelect:
+            ir_print_select(irp, (Stage1ZirInstSelect *)instruction);
+            break;
         case Stage1ZirInstIdSplat:
             ir_print_splat_src(irp, (Stage1ZirInstSplat *)instruction);
             break;
@@ -3177,6 +3206,9 @@ static void ir_print_inst_gen(IrPrintGen *irp, Stage1AirInst *instruction, bool 
             break;
         case Stage1AirInstIdShuffleVector:
             ir_print_shuffle_vector(irp, (Stage1AirInstShuffleVector *)instruction);
+            break;
+        case Stage1AirInstIdSelect:
+            ir_print_select(irp, (Stage1AirInstSelect *)instruction);
             break;
         case Stage1AirInstIdSplat:
             ir_print_splat_gen(irp, (Stage1AirInstSplat *)instruction);

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -118,6 +118,7 @@ test {
         _ = @import("behavior/ref_var_in_if_after_if_2nd_switch_prong.zig");
         _ = @import("behavior/reflection.zig");
         _ = @import("behavior/shuffle.zig");
+        _ = @import("behavior/select.zig");
         _ = @import("behavior/sizeof_and_typeof.zig");
         _ = @import("behavior/slice.zig");
         _ = @import("behavior/slice_sentinel_comptime.zig");

--- a/test/behavior/select.zig
+++ b/test/behavior/select.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const mem = std.mem;
+const expect = std.testing.expect;
+const Vector = std.meta.Vector;
+
+test "@select" {
+    const S = struct {
+        fn doTheTest() !void {
+            var a: Vector(4, bool) = [4]bool{ true, false, true, false };
+            var b: Vector(4, i32) = [4]i32{ -1, 4, 999, -31 };
+            var c: Vector(4, i32) = [4]i32{ -5, 1, 0, 1234 };
+            var abc = @select(i32, a, b, c);
+            try expect(mem.eql(i32, &@as([4]i32, abc), &[4]i32{ -1, 1, 999, 1234 }));
+
+            var x: Vector(4, bool) = [4]bool{ false, false, false, true };
+            var y: Vector(4, f32) = [4]f32{ 0.001, 33.4, 836, -3381.233 };
+            var z: Vector(4, f32) = [4]f32{ 0.0, 312.1, -145.9, 9993.55 };
+            var xyz = @select(f32, x, y, z);
+            try expect(mem.eql(f32, &@as([4]f32, xyz), &[4]f32{ 0.0, 312.1, -145.9, -3381.233 }));
+        }
+    };
+    try S.doTheTest();
+    comptime try S.doTheTest();
+}


### PR DESCRIPTION
```zig
@select(
    comptime T: type,
    pred: std.meta.Vector(len, bool),
    a: std.meta.Vector(len, T),
    b: std.meta.Vector(len, T)
) std.meta.Vector(len, T)
```

Constructs a vector from a & b, based on the values in the predicate vector. For indices where the predicate value is true, the corresponding element from the a vector is selected, and otherwise from.

See also #903