### PR TITLE
Add `zld.id` to list of files to skip updating in `build.zig`

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2802,6 +2802,7 @@ pub const LibExeObjStep = struct {
                         mem.eql(u8, entry.name, "llvm-ar.id") or
                         mem.eql(u8, entry.name, "libs.txt") or
                         mem.eql(u8, entry.name, "builtin.zig") or
+                        mem.eql(u8, entry.name, "zld.id") or
                         mem.eql(u8, entry.name, "lld.id")) continue;
 
                     _ = try src_dir.updateFile(entry.name, dest_dir, entry.name, .{});


### PR DESCRIPTION
After upgrading to the latest `HEAD` of Zig, building errored with `FileNotFound`.

After some digging, I added this log to `src_dir.updateFile(entry.name, dest_dir, entry.name, .{})`

![image](https://user-images.githubusercontent.com/709451/127081493-0e8aac60-4549-4469-9f21-bd3de8ad5408.png)

It printed this path:
```
/Users/jarred/Code/esdev/build/debug/macos-x86_64/zld.id
```

After adding `zld.id` to the list, it builds successfully.

cc @kubkon 
