### PR TITLE
linux: Add landlock syscall support

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -2442,3 +2442,36 @@ pub const __kernel_timespec = extern struct {
     tv_sec: i64,
     tv_nsec: i64,
 };
+
+pub const LANDLOCK_ACCESS_FS_EXECUTE = @as(u64, 1 << 0);
+pub const LANDLOCK_ACCESS_FS_WRITE_FILE = @as(u64, 1 << 1);
+pub const LANDLOCK_ACCESS_FS_READ_FILE = @as(u64, 1 << 2);
+pub const LANDLOCK_ACCESS_FS_READ_DIR = @as(u64, 1 << 3);
+pub const LANDLOCK_ACCESS_FS_REMOVE_DIR = @as(u64, 1 << 4);
+pub const LANDLOCK_ACCESS_FS_REMOVE_FILE = @as(u64, 1 << 5);
+pub const LANDLOCK_ACCESS_FS_MAKE_CHAR = @as(u64, 1 << 6);
+pub const LANDLOCK_ACCESS_FS_MAKE_DIR = @as(u64, 1 << 7);
+pub const LANDLOCK_ACCESS_FS_MAKE_REG = @as(u64, 1 << 8);
+pub const LANDLOCK_ACCESS_FS_MAKE_SOCK = @as(u64, 1 << 9);
+pub const LANDLOCK_ACCESS_FS_MAKE_FIFO = @as(u64, 1 << 10);
+pub const LANDLOCK_ACCESS_FS_MAKE_BLOCK = @as(u64, 1 << 11);
+pub const LANDLOCK_ACCESS_FS_MAKE_SYM = @as(u64, 1 << 12);
+
+pub const LANDLOCK_CREATE_RULESET_VERSION = @as(u32, 1 << 0);
+
+pub const landlock_ruleset_attr = extern struct {
+    handled_access_fs: u64,
+};
+
+pub const landlock_rule_type = enum(c_int) {
+    PATH_BENEATH = 1,
+};
+
+pub const landlock_rule = union(landlock_rule_type) {
+    PATH_BENEATH: PathBeneath,
+
+    pub const PathBeneath = packed struct {
+        allowed_access: u64,
+        parent_fd: fd_t,
+    };
+};

--- a/lib/std/os/bits/linux/arm-eabi.zig
+++ b/lib/std/os/bits/linux/arm-eabi.zig
@@ -411,6 +411,10 @@ pub const SYS = enum(usize) {
     faccessat2 = 439,
     process_madvise = 440,
     epoll_pwait2 = 441,
+    mount_setattr = 442,
+    landlock_create_ruleset = 444,
+    landlock_add_rule = 445,
+    landlock_restrict_self = 446,
 
     breakpoint = 0x0f0001,
     cacheflush = 0x0f0002,

--- a/lib/std/os/bits/linux/arm64.zig
+++ b/lib/std/os/bits/linux/arm64.zig
@@ -314,6 +314,10 @@ pub const SYS = enum(usize) {
     faccessat2 = 439,
     process_madvise = 440,
     epoll_pwait2 = 441,
+    mount_setattr = 442,
+    landlock_create_ruleset = 444,
+    landlock_add_rule = 445,
+    landlock_restrict_self = 446,
 
     _,
 };

--- a/lib/std/os/bits/linux/i386.zig
+++ b/lib/std/os/bits/linux/i386.zig
@@ -449,6 +449,10 @@ pub const SYS = enum(usize) {
     faccessat2 = 439,
     process_madvise = 440,
     epoll_pwait2 = 441,
+    mount_setattr = 442,
+    landlock_create_ruleset = 444,
+    landlock_add_rule = 445,
+    landlock_restrict_self = 446,
 
     _,
 };

--- a/lib/std/os/bits/linux/mips.zig
+++ b/lib/std/os/bits/linux/mips.zig
@@ -431,6 +431,10 @@ pub const SYS = enum(usize) {
     faccessat2 = Linux + 439,
     process_madvise = Linux + 440,
     epoll_pwait2 = Linux + 441,
+    mount_setattr = Linux + 442,
+    landlock_create_ruleset = Linux + 444,
+    landlock_add_rule = Linux + 445,
+    landlock_restrict_self = Linux + 446,
 
     _,
 };

--- a/lib/std/os/bits/linux/powerpc.zig
+++ b/lib/std/os/bits/linux/powerpc.zig
@@ -437,6 +437,11 @@ pub const SYS = enum(usize) {
     pidfd_getfd = 438,
     faccessat2 = 439,
     process_madvise = 440,
+    epoll_pwait2 = 441,
+    mount_setattr = 442,
+    landlock_create_ruleset = 444,
+    landlock_add_rule = 445,
+    landlock_restrict_self = 446,
 };
 
 pub const O_CREAT = 0o100;

--- a/lib/std/os/bits/linux/powerpc64.zig
+++ b/lib/std/os/bits/linux/powerpc64.zig
@@ -410,6 +410,10 @@ pub const SYS = enum(usize) {
     faccessat2 = 439,
     process_madvise = 440,
     epoll_pwait2 = 441,
+    mount_setattr = 442,
+    landlock_create_ruleset = 444,
+    landlock_add_rule = 445,
+    landlock_restrict_self = 446,
 
     _,
 };

--- a/lib/std/os/bits/linux/riscv64.zig
+++ b/lib/std/os/bits/linux/riscv64.zig
@@ -311,6 +311,10 @@ pub const SYS = enum(usize) {
     faccessat2 = 439,
     process_madvise = 440,
     epoll_pwait2 = 441,
+    mount_setattr = 442,
+    landlock_create_ruleset = 444,
+    landlock_add_rule = 445,
+    landlock_restrict_self = 446,
 
     _,
 };

--- a/lib/std/os/bits/linux/sparc64.zig
+++ b/lib/std/os/bits/linux/sparc64.zig
@@ -388,6 +388,10 @@ pub const SYS = enum(usize) {
     faccessat2 = 439,
     process_madvise = 440,
     epoll_pwait2 = 441,
+    mount_setattr = 442,
+    landlock_create_ruleset = 444,
+    landlock_add_rule = 445,
+    landlock_restrict_self = 446,
 
     _,
 };

--- a/lib/std/os/bits/linux/x86_64.zig
+++ b/lib/std/os/bits/linux/x86_64.zig
@@ -375,6 +375,10 @@ pub const SYS = enum(usize) {
     faccessat2 = 439,
     process_madvise = 440,
     epoll_pwait2 = 441,
+    mount_setattr = 442,
+    landlock_create_ruleset = 444,
+    landlock_add_rule = 445,
+    landlock_restrict_self = 446,
 
     _,
 };


### PR DESCRIPTION
This PR adds support Linux syscall bindings for the latest security module: Landlock. It's a simpler filesystem capability api compared to the existing Seccomp interface. This demo program shows how it works (requires a system running a 5.13 kernel):

```zig
const std = @import("std");
const os = std.os;
const linux = os.linux;

pub const Landlock = struct {
    fd: os.fd_t,

    pub fn init(max_rules: u64) !Landlock {
        const ruleset: linux.landlock_ruleset_attr = .{
            .handled_access_fs = max_rules,
        };
        const rc = linux.landlock_create_ruleset(&ruleset, 0);
        return switch (os.errno(rc)) {
            0 => Landlock{ .fd = @intCast(os.fd_t, rc) },
            else => |err| os.unexpectedErrno(err),
        };
    }

    pub fn append(self: *Landlock, fd: os.fd_t, rules: u64) !void {
        const rc = linux.landlock_add_rule(
            self.fd,
            .{ .PATH_BENEATH = .{
                .allowed_access = rules,
                .parent_fd = fd,
            } },
        );

        return switch (os.errno(rc)) {
            0 => {},
            else => |err| os.unexpectedErrno(err),
        };
    }

    pub fn lock(self: *Landlock) !void {
        _ = try os.prctl(.SET_NO_NEW_PRIVS, .{ 1, 0, 0, 0 });

        const rc = linux.landlock_restrict_self(self.fd);
        return switch (os.errno(rc)) {
            0 => {},
            else => |err| os.unexpectedErrno(err),
        };
    }
};

const FifoType = std.fifo.LinearFifo(u8, std.fifo.LinearFifoBufferType{ .Static = 4096 });

pub fn main() !void {
    var ll = try Landlock.init(os.LANDLOCK_ACCESS_FS_READ_FILE |
        os.LANDLOCK_ACCESS_FS_WRITE_FILE |
        os.LANDLOCK_ACCESS_FS_READ_DIR);
    var fifo = FifoType.init();

    const etc = try std.fs.openDirAbsolute("/etc", .{});
    const self = try std.fs.openSelfExe(.{});

    try ll.append(os.STDOUT_FILENO, os.LANDLOCK_ACCESS_FS_WRITE_FILE);
    try ll.append(os.STDERR_FILENO, os.LANDLOCK_ACCESS_FS_WRITE_FILE);
    try ll.append(etc.fd, os.LANDLOCK_ACCESS_FS_READ_DIR | os.LANDLOCK_ACCESS_FS_READ_FILE);
    // for the panic handler
    try ll.append(self.handle, os.LANDLOCK_ACCESS_FS_READ_FILE);

    try ll.lock();

    const passwd = try etc.openFile("passwd", .{});
    try fifo.pump(passwd.reader(), std.io.getStdOut().writer());

    // The panic handler can't read the source files, so we just get the filenames.
    _ = try std.fs.openFileAbsolute("/bin/bash", .{});
}
```

You can verify that everything is working by running it through `strace`.