### PR TITLE
Move fs.Walker to fs.Dir.Walker

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -3015,7 +3015,8 @@ pub const InstallDirStep = struct {
         const self = @fieldParentPtr(InstallDirStep, "step", step);
         const dest_prefix = self.builder.getInstallPath(self.options.install_dir, self.options.install_subdir);
         const full_src_dir = self.builder.pathFromRoot(self.options.source_dir);
-        var it = try fs.walkPath(self.builder.allocator, full_src_dir);
+        const src_dir = try std.fs.cwd().openDir(full_src_dir, .{ .iterate = true });
+        var it = try src_dir.walk(self.builder.allocator);
         next_entry: while (try it.next()) |entry| {
             for (self.options.exclude_extensions) |ext| {
                 if (mem.endsWith(u8, entry.path, ext)) {
@@ -3023,9 +3024,12 @@ pub const InstallDirStep = struct {
                 }
             }
 
-            const rel_path = entry.path[full_src_dir.len + 1 ..];
+            const full_path = try fs.path.join(self.builder.allocator, &[_][]const u8{
+                full_src_dir, entry.path,
+            });
+
             const dest_path = try fs.path.join(self.builder.allocator, &[_][]const u8{
-                dest_prefix, rel_path,
+                dest_prefix, entry.path,
             });
 
             switch (entry.kind) {
@@ -3038,7 +3042,7 @@ pub const InstallDirStep = struct {
                         }
                     }
 
-                    try self.builder.updateFile(entry.path, dest_path);
+                    try self.builder.updateFile(full_path, dest_path);
                 },
                 else => continue,
             }

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -927,8 +927,9 @@ test "walker" {
     }
 
     const tmp_path = try fs.path.join(allocator, &[_][]const u8{ "zig-cache", "tmp", tmp.sub_path[0..] });
+    const tmp_dir = try fs.cwd().openDir(tmp_path, .{ .iterate = true });
 
-    var walker = try fs.walkPath(testing.allocator, tmp_path);
+    var walker = try tmp_dir.walk(testing.allocator);
     defer walker.deinit();
 
     i = 0;
@@ -941,7 +942,7 @@ test "walker" {
             try fs.path.join(allocator, &[_][]const u8{ expected_dir_name, name });
 
         var entry = (try walker.next()).?;
-        try testing.expectEqualStrings(expected_dir_name, try fs.path.relative(allocator, tmp_path, entry.path));
+        try testing.expectEqualStrings(expected_dir_name, entry.path);
     }
 }
 


### PR DESCRIPTION
I have moved `fs.Walker` to `fs.Dir.Walker`. Paths of entries are relative to the `Dir`. I've walked away from more drastic changes which were badly thought-out and included in the original PR. This code passes tests on my machine, and *should* pass CI checks now, but there's only way to find out...