### PR TITLE
langref- fix use after block error code

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3426,6 +3426,7 @@ test "call foo" {
 test "access variable after block scope" {
     {
         var x: i32 = 1;
+        _ = x;
     }
     x += 1;
 }

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3422,7 +3422,7 @@ test "call foo" {
       <p>
       Blocks are used to limit the scope of variable declarations:
       </p>
-      {#code_begin|test_err|unused local variable#}
+      {#code_begin|test_err|use of undeclared identifier 'x'#}
 test "access variable after block scope" {
     {
         var x: i32 = 1;


### PR DESCRIPTION
https://ziglang.org/documentation/master/#blocks currently has the error `error: unused local variable`. It should say `error: use of undeclared identifier 'x'`. This change fixes that.