### PR TITLE
Make linux syscalls accessible with non-Linux target OS

### DIFF
--- a/lib/std/os/bits.zig
+++ b/lib/std/os/bits.zig
@@ -25,32 +25,3 @@ pub usingnamespace switch (std.Target.current.os.tag) {
 };
 
 pub usingnamespace if (@hasDecl(root, "os") and @hasDecl(root.os, "bits")) root.os.bits else struct {};
-
-pub const iovec = extern struct {
-    iov_base: [*]u8,
-    iov_len: usize,
-};
-
-pub const iovec_const = extern struct {
-    iov_base: [*]const u8,
-    iov_len: usize,
-};
-
-// syslog
-
-/// system is unusable
-pub const LOG_EMERG = 0;
-/// action must be taken immediately
-pub const LOG_ALERT = 1;
-/// critical conditions
-pub const LOG_CRIT = 2;
-/// error conditions
-pub const LOG_ERR = 3;
-/// warning conditions
-pub const LOG_WARNING = 4;
-/// normal but significant condition
-pub const LOG_NOTICE = 5;
-/// informational
-pub const LOG_INFO = 6;
-/// debug-level messages
-pub const LOG_DEBUG = 7;

--- a/lib/std/os/bits/darwin.zig
+++ b/lib/std/os/bits/darwin.zig
@@ -7,6 +7,8 @@ const std = @import("../../std.zig");
 const assert = std.debug.assert;
 const maxInt = std.math.maxInt;
 
+pub usingnamespace @import("posix.zig");
+
 // See: https://opensource.apple.com/source/xnu/xnu-6153.141.1/bsd/sys/_types.h.auto.html
 // TODO: audit mode_t/pid_t, should likely be u16/i32
 pub const fd_t = c_int;

--- a/lib/std/os/bits/dragonfly.zig
+++ b/lib/std/os/bits/dragonfly.zig
@@ -6,6 +6,8 @@
 const std = @import("../../std.zig");
 const maxInt = std.math.maxInt;
 
+pub usingnamespace @import("posix.zig");
+
 pub fn S_ISCHR(m: u32) bool {
     return m & S_IFMT == S_IFCHR;
 }

--- a/lib/std/os/bits/freebsd.zig
+++ b/lib/std/os/bits/freebsd.zig
@@ -7,6 +7,8 @@ const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const maxInt = std.math.maxInt;
 
+pub usingnamespace @import("posix.zig");
+
 pub const blksize_t = i32;
 pub const blkcnt_t = i64;
 pub const clockid_t = i32;

--- a/lib/std/os/bits/haiku.zig
+++ b/lib/std/os/bits/haiku.zig
@@ -6,6 +6,8 @@
 const std = @import("../../std.zig");
 const maxInt = std.math.maxInt;
 
+pub usingnamespace @import("posix.zig");
+
 pub const fd_t = c_int;
 pub const pid_t = c_int;
 pub const uid_t = u32;

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -6,7 +6,7 @@
 const std = @import("../../std.zig");
 const maxInt = std.math.maxInt;
 const arch = @import("builtin").target.cpu.arch;
-usingnamespace @import("../bits.zig");
+pub usingnamespace @import("posix.zig");
 
 pub usingnamespace switch (arch) {
     .mips, .mipsel => @import("linux/errno-mips.zig"),

--- a/lib/std/os/bits/netbsd.zig
+++ b/lib/std/os/bits/netbsd.zig
@@ -7,6 +7,8 @@ const std = @import("../../std.zig");
 const builtin = std.builtin;
 const maxInt = std.math.maxInt;
 
+pub usingnamespace @import("posix.zig");
+
 pub const blkcnt_t = i64;
 pub const blksize_t = i32;
 pub const clock_t = u32;

--- a/lib/std/os/bits/openbsd.zig
+++ b/lib/std/os/bits/openbsd.zig
@@ -7,6 +7,8 @@ const std = @import("../../std.zig");
 const builtin = std.builtin;
 const maxInt = std.math.maxInt;
 
+pub usingnamespace @import("posix.zig");
+
 pub const blkcnt_t = i64;
 pub const blksize_t = i32;
 pub const clock_t = i64;

--- a/lib/std/os/bits/posix.zig
+++ b/lib/std/os/bits/posix.zig
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2015-2021 Zig Contributors
+// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
+// The MIT license requires this copyright notice to be included in all copies
+// and substantial portions of the software.
+
+pub const iovec = extern struct {
+    iov_base: [*]u8,
+    iov_len: usize,
+};
+
+pub const iovec_const = extern struct {
+    iov_base: [*]const u8,
+    iov_len: usize,
+};
+
+// syslog
+
+/// system is unusable
+pub const LOG_EMERG = 0;
+/// action must be taken immediately
+pub const LOG_ALERT = 1;
+/// critical conditions
+pub const LOG_CRIT = 2;
+/// error conditions
+pub const LOG_ERR = 3;
+/// warning conditions
+pub const LOG_WARNING = 4;
+/// normal but significant condition
+pub const LOG_NOTICE = 5;
+/// informational
+pub const LOG_INFO = 6;
+/// debug-level messages
+pub const LOG_DEBUG = 7;

--- a/lib/std/os/bits/wasi.zig
+++ b/lib/std/os/bits/wasi.zig
@@ -4,6 +4,10 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 // Convenience types and consts used by std.os module
+const posix = @import("posix.zig");
+pub const iovec = posix.iovec;
+pub const iovec_const = posix.iovec_const;
+
 pub const STDIN_FILENO = 0;
 pub const STDOUT_FILENO = 1;
 pub const STDERR_FILENO = 2;

--- a/lib/std/os/bits/windows.zig
+++ b/lib/std/os/bits/windows.zig
@@ -8,6 +8,11 @@
 usingnamespace @import("../windows/bits.zig");
 const ws2_32 = @import("../windows/ws2_32.zig");
 
+// TODO: Stop using os.iovec in std.fs et al on Windows in the future
+const posix = @import("posix.zig");
+pub const iovec = posix.iovec;
+pub const iovec_const = posix.iovec_const;
+
 pub const fd_t = HANDLE;
 pub const ino_t = LARGE_INTEGER;
 pub const pid_t = HANDLE;

--- a/lib/std/os/linux/arm-eabi.zig
+++ b/lib/std/os/linux/arm-eabi.zig
@@ -3,7 +3,6 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-usingnamespace @import("../bits.zig");
 usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {

--- a/lib/std/os/linux/arm-eabi.zig
+++ b/lib/std/os/linux/arm-eabi.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 usingnamespace @import("../bits.zig");
+usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile ("svc #0"

--- a/lib/std/os/linux/arm64.zig
+++ b/lib/std/os/linux/arm64.zig
@@ -3,7 +3,6 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-usingnamespace @import("../bits.zig");
 usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {

--- a/lib/std/os/linux/arm64.zig
+++ b/lib/std/os/linux/arm64.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 usingnamespace @import("../bits.zig");
+usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile ("svc #0"

--- a/lib/std/os/linux/i386.zig
+++ b/lib/std/os/linux/i386.zig
@@ -3,7 +3,6 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-usingnamespace @import("../bits.zig");
 usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {

--- a/lib/std/os/linux/i386.zig
+++ b/lib/std/os/linux/i386.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 usingnamespace @import("../bits.zig");
+usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile ("int $0x80"

--- a/lib/std/os/linux/mips.zig
+++ b/lib/std/os/linux/mips.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 usingnamespace @import("../bits.zig");
+usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile (

--- a/lib/std/os/linux/mips.zig
+++ b/lib/std/os/linux/mips.zig
@@ -3,7 +3,6 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-usingnamespace @import("../bits.zig");
 usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {

--- a/lib/std/os/linux/powerpc.zig
+++ b/lib/std/os/linux/powerpc.zig
@@ -5,6 +5,7 @@
 // and substantial portions of the software.
 
 usingnamespace @import("../bits.zig");
+usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile (

--- a/lib/std/os/linux/powerpc.zig
+++ b/lib/std/os/linux/powerpc.zig
@@ -4,7 +4,6 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 
-usingnamespace @import("../bits.zig");
 usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {

--- a/lib/std/os/linux/powerpc64.zig
+++ b/lib/std/os/linux/powerpc64.zig
@@ -5,6 +5,7 @@
 // and substantial portions of the software.
 
 usingnamespace @import("../bits.zig");
+usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile (

--- a/lib/std/os/linux/powerpc64.zig
+++ b/lib/std/os/linux/powerpc64.zig
@@ -4,7 +4,6 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 
-usingnamespace @import("../bits.zig");
 usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {

--- a/lib/std/os/linux/riscv64.zig
+++ b/lib/std/os/linux/riscv64.zig
@@ -3,7 +3,6 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-usingnamespace @import("../bits.zig");
 usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {

--- a/lib/std/os/linux/riscv64.zig
+++ b/lib/std/os/linux/riscv64.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 usingnamespace @import("../bits.zig");
+usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile ("ecall"

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -1,4 +1,3 @@
-usingnamespace @import("../bits.zig");
 usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall_pipe(fd: *[2]i32) usize {

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -1,4 +1,5 @@
 usingnamespace @import("../bits.zig");
+usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall_pipe(fd: *[2]i32) usize {
     return asm volatile (

--- a/lib/std/os/linux/thumb.zig
+++ b/lib/std/os/linux/thumb.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 usingnamespace @import("../bits.zig");
+usingnamespace @import("../bits/linux.zig");
 
 // The syscall interface is identical to the ARM one but we're facing an extra
 // challenge: r7, the register where the syscall number is stored, may be

--- a/lib/std/os/linux/thumb.zig
+++ b/lib/std/os/linux/thumb.zig
@@ -3,7 +3,6 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-usingnamespace @import("../bits.zig");
 usingnamespace @import("../bits/linux.zig");
 
 // The syscall interface is identical to the ARM one but we're facing an extra

--- a/lib/std/os/linux/x86_64.zig
+++ b/lib/std/os/linux/x86_64.zig
@@ -3,7 +3,6 @@
 // This file is part of [zig](https://ziglang.org/), which is MIT licensed.
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
-usingnamespace @import("../bits.zig");
 usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {

--- a/lib/std/os/linux/x86_64.zig
+++ b/lib/std/os/linux/x86_64.zig
@@ -4,6 +4,7 @@
 // The MIT license requires this copyright notice to be included in all copies
 // and substantial portions of the software.
 usingnamespace @import("../bits.zig");
+usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile ("syscall"


### PR DESCRIPTION
It is of my opinion that explicitly doing `std.os.linux.exit(0);` in your code should do a Linux syscall, no matter what the current target may be (like freestanding). I hit the following issue when trying to make the above call in a freestanding executable for my own operating system (where I support a couple of Linux syscalls):

```
/mnt/gentoo/zig-linux-x86_64-0.9.0-dev.185+e125ead2b/lib/std/os/linux/x86_64.zig:16:25: error: use of undeclared identifier 'SYS'
pub fn syscall1(number: SYS, arg1: usize) usize {
                        ^
/mnt/gentoo/zig-linux-x86_64-0.9.0-dev.185+e125ead2b/lib/std/os/linux.zig:639:9: note: referenced here
    _ = syscall1(.exit, @bitCast(usize, @as(isize, status)));
        ^
```
For some reason, it seems to be grabbing the linux syscall numbers from `std.os.bits`, even though that makes no sense when I'm explicitly invoking a linux syscall.

This PR makes the linux syscalls always grab `bits/linux.zig`, no matter the target OS tag.