### PR TITLE
stage2 ARM: fix stack alignment

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -4916,7 +4916,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                             }
 
                             result.stack_byte_count = nsaa;
-                            result.stack_align = 4;
+                            result.stack_align = 8;
                         },
                         else => return self.fail("TODO implement function parameters for {} on arm", .{cc}),
                     }


### PR DESCRIPTION
Acording to the [AAPCS32](https://github.com/ARM-software/abi-aa/blob/main/aapcs32/aapcs32.rst#6212stack-constraints-at-a-public-interface), the stack alignment at public interfaces should be 8, not 4.