### PR TITLE
Add -Denable-macos-sdk explicit flag to build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -61,6 +61,7 @@ pub fn build(b: *Builder) !void {
     const omit_stage2 = b.option(bool, "omit-stage2", "Do not include stage2 behind a feature flag inside stage1") orelse false;
     const static_llvm = b.option(bool, "static-llvm", "Disable integration with system-installed LLVM, Clang, LLD, and libc++") orelse false;
     const enable_llvm = b.option(bool, "enable-llvm", "Build self-hosted compiler with LLVM backend enabled") orelse (is_stage1 or static_llvm);
+    const enable_macos_sdk = b.option(bool, "enable-macos-sdk", "Run tests requiring presence of macOS SDK and frameworks") orelse false;
     const config_h_path_option = b.option([]const u8, "config_h", "Path to the generated config.h");
 
     if (!skip_install_lib_files) {
@@ -340,7 +341,7 @@ pub fn build(b: *Builder) !void {
     ));
 
     toolchain_step.dependOn(tests.addCompareOutputTests(b, test_filter, modes));
-    toolchain_step.dependOn(tests.addStandaloneTests(b, test_filter, modes, skip_non_native, target));
+    toolchain_step.dependOn(tests.addStandaloneTests(b, test_filter, modes, skip_non_native, enable_macos_sdk, target));
     toolchain_step.dependOn(tests.addStackTraceTests(b, test_filter, modes));
     toolchain_step.dependOn(tests.addCliTests(b, test_filter, modes));
     toolchain_step.dependOn(tests.addAssembleAndLinkTests(b, test_filter, modes));

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -57,7 +57,7 @@ make $JOBS install
 # TODO figure out why this causes a segmentation fault
 # release/bin/zig test ../test/behavior.zig -fno-stage1 -fLLVM -I ../test
 
-release/bin/zig build test-toolchain
+release/bin/zig build test-toolchain -Denable-macos-sdk
 release/bin/zig build test-std
 release/bin/zig build docs
 

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -38,9 +38,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
         cases.addBuildFile("test/standalone/pie/build.zig", .{});
     }
     // Try to build and run an Objective-C executable.
-    if (std.Target.current.os.tag == .macos) {
-        cases.addBuildFile("test/standalone/objc/build.zig", .{ .build_modes = true });
-    }
+    cases.addBuildFile("test/standalone/objc/build.zig", .{ .build_modes = true, .requires_macos_sdk = true });
 
     // Ensure the development tools are buildable.
     cases.add("tools/gen_spirv_spec.zig");

--- a/test/standalone/objc/build.zig
+++ b/test/standalone/objc/build.zig
@@ -1,5 +1,15 @@
 const std = @import("std");
 const Builder = std.build.Builder;
+const CrossTarget = std.zig.CrossTarget;
+
+fn isRunnableTarget(t: CrossTarget) bool {
+    // TODO I think we might be able to run this on Linux via Darling.
+    // Add a check for that here, and return true if Darling is available.
+    if (t.isNative() and t.getOsTag() == .macos)
+        return true
+    else
+        return false;
+}
 
 pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();
@@ -15,8 +25,12 @@ pub fn build(b: *Builder) void {
     exe.setBuildMode(mode);
     exe.setTarget(target);
     exe.linkLibC();
+    // TODO when we figure out how to ship framework stubs for cross-compilation,
+    // populate paths to the sysroot here.
     exe.linkFramework("Foundation");
 
-    const run_cmd = exe.run();
-    test_step.dependOn(&run_cmd.step);
+    if (isRunnableTarget(target)) {
+        const run_cmd = exe.run();
+        test_step.dependOn(&run_cmd.step);
+    }
 }


### PR DESCRIPTION
This way, we can explicitly signal if a test requires the presence
of macOS SDK to build. For instance, when testing our in-house
MachO linker for correctly linking Objective-C, we require the
presence of the SDK on the host system, and we can enforce this
with `-Denable-macos-sdk` flag to `zig build test-standalone`.