### PR TITLE
std: Declare FOLDERID_{Program,RoamingApp}Data for Windows

### DIFF
--- a/lib/std/os/windows/bits.zig
+++ b/lib/std/os/windows/bits.zig
@@ -755,7 +755,9 @@ pub const GUID = extern struct {
     }
 };
 
+pub const FOLDERID_ProgramData = GUID.parse("{62AB5D82-FDC1-4DC3-A9DD-070D1D495D97}");
 pub const FOLDERID_LocalAppData = GUID.parse("{F1B32785-6FBA-4FCF-9D55-7B8E7F157091}");
+pub const FOLDERID_RoamingAppData = GUID.parse("{3EB685DB-65F9-4CF6-A03A-E3EF65729F3D}");
 
 pub const KF_FLAG_DEFAULT = 0;
 pub const KF_FLAG_NO_APPCONTAINER_REDIRECTION = 65536;


### PR DESCRIPTION
The values are taken from [mingw-w64's knownfolders.h](https://github.com/ziglang/zig/blob/85755c51d529e7d9b406c6bdf69ce0a0f33f3353/lib/libc/include/any-windows-any/knownfolders.h#L73), and they are the system-wide and roaming counterpart of `FOLDERID_LocalAppData`: https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-vista/cc766489(v=ws.10)

Context: I'm writing [a tiny library](https://git.sr.ht/~cnx/zig-loca) to determine data, config, etc. directories across platforms.  Would it be a good idea to include it in Zig std?