### PR TITLE
Linux/SPARCv9 thread and sigreturn-related fixes

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -806,8 +806,10 @@ const LinuxThreadImpl = struct {
                     \\  1:
                     \\  cmp %%sp, 0
                     \\  beq 2f
+                    \\  nop
                     \\  restore
                     \\  ba 1f
+                    \\  nop
                     \\  2:
                     \\  mov 73, %%g1
                     \\  mov %[ptr], %%o0

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -169,7 +169,9 @@ pub extern fn clone(func: fn (arg: usize) callconv(.C) u8, stack: usize, flags: 
 
 pub const restore = restore_rt;
 
-pub fn restore_rt() callconv(.Naked) void {
+// Need to use C ABI here instead of naked
+// to prevent an infinite loop when calling rt_sigreturn.
+pub fn restore_rt() callconv(.C) void {
     return asm volatile ("t 0x6d"
         :
         : [number] "{g1}" (@enumToInt(SYS.rt_sigreturn))


### PR DESCRIPTION
- Account for the branch delay in freeAndExit(). I forgot to do this in my first PR for it, my bad.
- Use C calling convention for the implementation of restore_rt(). This is needed to prevent an infinite loop when calling rt_sigreturn().

With those two changes, now almost all testcases in test-std passes (12 are still failing, mostly related to sockets and bigints).