### PR TITLE
Make mem.split and mem.tokenize generic instead of assuming u8

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -187,7 +187,7 @@ pub fn build(b: *Builder) !void {
             },
             2 => {
                 // Untagged development build (e.g. 0.8.0-684-gbbe2cca1a).
-                var it = mem.split(git_describe, "-");
+                var it = mem.split(u8, git_describe, "-");
                 const tagged_ancestor = it.next() orelse unreachable;
                 const commit_height = it.next() orelse unreachable;
                 const commit_id = it.next() orelse unreachable;
@@ -479,7 +479,7 @@ fn addCxxKnownPath(
         ctx.cxx_compiler,
         b.fmt("-print-file-name={s}", .{objname}),
     });
-    const path_unpadded = mem.tokenize(path_padded, "\r\n").next().?;
+    const path_unpadded = mem.tokenize(u8, path_padded, "\r\n").next().?;
     if (mem.eql(u8, path_unpadded, objname)) {
         if (errtxt) |msg| {
             warn("{s}", .{msg});
@@ -502,7 +502,7 @@ fn addCxxKnownPath(
 }
 
 fn addCMakeLibraryList(exe: *std.build.LibExeObjStep, list: []const u8) void {
-    var it = mem.tokenize(list, ";");
+    var it = mem.tokenize(u8, list, ";");
     while (it.next()) |lib| {
         if (mem.startsWith(u8, lib, "-l")) {
             exe.linkSystemLibrary(lib["-l".len..]);
@@ -596,11 +596,11 @@ fn findAndParseConfigH(b: *Builder, config_h_path_option: ?[]const u8) ?CMakeCon
         },
     };
 
-    var lines_it = mem.tokenize(config_h_text, "\r\n");
+    var lines_it = mem.tokenize(u8, config_h_text, "\r\n");
     while (lines_it.next()) |line| {
         inline for (mappings) |mapping| {
             if (mem.startsWith(u8, line, mapping.prefix)) {
-                var it = mem.split(line, "\"");
+                var it = mem.split(u8, line, "\"");
                 _ = it.next().?; // skip the stuff before the quote
                 const quoted = it.next().?; // the stuff inside the quote
                 @field(ctx, mapping.field) = toNativePathSep(b, quoted);

--- a/lib/std/SemanticVersion.zig
+++ b/lib/std/SemanticVersion.zig
@@ -48,8 +48,8 @@ pub fn order(lhs: Version, rhs: Version) std.math.Order {
     if (lhs.pre == null and rhs.pre != null) return .gt;
 
     // Iterate over pre-release identifiers until a difference is found.
-    var lhs_pre_it = std.mem.split(lhs.pre.?, ".");
-    var rhs_pre_it = std.mem.split(rhs.pre.?, ".");
+    var lhs_pre_it = std.mem.split(u8, lhs.pre.?, ".");
+    var rhs_pre_it = std.mem.split(u8, rhs.pre.?, ".");
     while (true) {
         const next_lid = lhs_pre_it.next();
         const next_rid = rhs_pre_it.next();
@@ -92,7 +92,7 @@ pub fn parse(text: []const u8) !Version {
     // Parse the required major, minor, and patch numbers.
     const extra_index = std.mem.indexOfAny(u8, text, "-+");
     const required = text[0..(extra_index orelse text.len)];
-    var it = std.mem.split(required, ".");
+    var it = std.mem.split(u8, required, ".");
     var ver = Version{
         .major = try parseNum(it.next() orelse return error.InvalidVersion),
         .minor = try parseNum(it.next() orelse return error.InvalidVersion),
@@ -114,7 +114,7 @@ pub fn parse(text: []const u8) !Version {
     // Check validity of optional pre-release identifiers.
     // See: https://semver.org/#spec-item-9
     if (ver.pre) |pre| {
-        it = std.mem.split(pre, ".");
+        it = std.mem.split(u8, pre, ".");
         while (it.next()) |id| {
             // Identifiers MUST NOT be empty.
             if (id.len == 0) return error.InvalidVersion;
@@ -133,7 +133,7 @@ pub fn parse(text: []const u8) !Version {
     // Check validity of optional build metadata identifiers.
     // See: https://semver.org/#spec-item-10
     if (ver.build) |build| {
-        it = std.mem.split(build, ".");
+        it = std.mem.split(u8, build, ".");
         while (it.next()) |id| {
             // Identifiers MUST NOT be empty.
             if (id.len == 0) return error.InvalidVersion;

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1085,7 +1085,7 @@ pub const Builder = struct {
                 if (fs.path.isAbsolute(name)) {
                     return name;
                 }
-                var it = mem.tokenize(PATH, &[_]u8{fs.path.delimiter});
+                var it = mem.tokenize(u8, PATH, &[_]u8{fs.path.delimiter});
                 while (it.next()) |path| {
                     const full_path = try fs.path.join(self.allocator, &[_][]const u8{
                         path,
@@ -1211,10 +1211,10 @@ pub const Builder = struct {
         const stdout = try self.execAllowFail(&[_][]const u8{ "pkg-config", "--list-all" }, out_code, .Ignore);
         var list = ArrayList(PkgConfigPkg).init(self.allocator);
         errdefer list.deinit();
-        var line_it = mem.tokenize(stdout, "\r\n");
+        var line_it = mem.tokenize(u8, stdout, "\r\n");
         while (line_it.next()) |line| {
             if (mem.trim(u8, line, " \t").len == 0) continue;
-            var tok_it = mem.tokenize(line, " \t");
+            var tok_it = mem.tokenize(u8, line, " \t");
             try list.append(PkgConfigPkg{
                 .name = tok_it.next() orelse return error.PkgConfigInvalidOutput,
                 .desc = tok_it.rest(),
@@ -1872,7 +1872,7 @@ pub const LibExeObjStep = struct {
             error.FileNotFound => return error.PkgConfigNotInstalled,
             else => return err,
         };
-        var it = mem.tokenize(stdout, " \r\n\t");
+        var it = mem.tokenize(u8, stdout, " \r\n\t");
         while (it.next()) |tok| {
             if (mem.eql(u8, tok, "-I")) {
                 const dir = it.next() orelse return error.PkgConfigInvalidOutput;

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -509,7 +509,7 @@ pub const Version = struct {
         // found no digits or '.' before unexpected character
         if (end == 0) return error.InvalidVersion;
 
-        var it = std.mem.split(text[0..end], ".");
+        var it = std.mem.split(u8, text[0..end], ".");
         // substring is not empty, first call will succeed
         const major = it.next().?;
         if (major.len == 0) return error.InvalidVersion;

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -836,12 +836,12 @@ pub const ChildProcess = struct {
 
             const app_name = self.argv[0];
 
-            var it = mem.tokenize(PATH, ";");
+            var it = mem.tokenize(u8, PATH, ";");
             retry: while (it.next()) |search_path| {
                 const path_no_ext = try fs.path.join(self.allocator, &[_][]const u8{ search_path, app_name });
                 defer self.allocator.free(path_no_ext);
 
-                var ext_it = mem.tokenize(PATHEXT, ";");
+                var ext_it = mem.tokenize(u8, PATHEXT, ";");
                 while (ext_it.next()) |app_ext| {
                     const joined_path = try mem.concat(self.allocator, u8, &[_][]const u8{ path_no_ext, app_ext });
                     defer self.allocator.free(joined_path);

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2455,7 +2455,7 @@ pub fn selfExePath(out_buffer: []u8) SelfExePathError![]u8 {
             } else if (argv0.len != 0) {
                 // argv[0] is not empty (and not a path): search it inside PATH
                 const PATH = std.os.getenvZ("PATH") orelse return error.FileNotFound;
-                var path_it = mem.tokenize(PATH, &[_]u8{path.delimiter});
+                var path_it = mem.tokenize(u8, PATH, &[_]u8{path.delimiter});
                 while (path_it.next()) |a_path| {
                     var resolved_path_buf: [MAX_PATH_BYTES - 1:0]u8 = undefined;
                     const resolved_path = std.fmt.bufPrintZ(&resolved_path_buf, "{s}/{s}", .{

--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -345,7 +345,7 @@ pub fn windowsParsePath(path: []const u8) WindowsPath {
                 return relative_path;
             }
 
-            var it = mem.tokenize(path, &[_]u8{this_sep});
+            var it = mem.tokenize(u8, path, &[_]u8{this_sep});
             _ = (it.next() orelse return relative_path);
             _ = (it.next() orelse return relative_path);
             return WindowsPath{
@@ -407,8 +407,8 @@ fn networkShareServersEql(ns1: []const u8, ns2: []const u8) bool {
     const sep1 = ns1[0];
     const sep2 = ns2[0];
 
-    var it1 = mem.tokenize(ns1, &[_]u8{sep1});
-    var it2 = mem.tokenize(ns2, &[_]u8{sep2});
+    var it1 = mem.tokenize(u8, ns1, &[_]u8{sep1});
+    var it2 = mem.tokenize(u8, ns2, &[_]u8{sep2});
 
     // TODO ASCII is wrong, we actually need full unicode support to compare paths.
     return asciiEqlIgnoreCase(it1.next().?, it2.next().?);
@@ -428,8 +428,8 @@ fn compareDiskDesignators(kind: WindowsPath.Kind, p1: []const u8, p2: []const u8
             const sep1 = p1[0];
             const sep2 = p2[0];
 
-            var it1 = mem.tokenize(p1, &[_]u8{sep1});
-            var it2 = mem.tokenize(p2, &[_]u8{sep2});
+            var it1 = mem.tokenize(u8, p1, &[_]u8{sep1});
+            var it2 = mem.tokenize(u8, p2, &[_]u8{sep2});
 
             // TODO ASCII is wrong, we actually need full unicode support to compare paths.
             return asciiEqlIgnoreCase(it1.next().?, it2.next().?) and asciiEqlIgnoreCase(it1.next().?, it2.next().?);
@@ -551,7 +551,7 @@ pub fn resolveWindows(allocator: *Allocator, paths: []const []const u8) ![]u8 {
             },
             WindowsPath.Kind.NetworkShare => {
                 result = try allocator.alloc(u8, max_size);
-                var it = mem.tokenize(paths[first_index], "/\\");
+                var it = mem.tokenize(u8, paths[first_index], "/\\");
                 const server_name = it.next().?;
                 const other_name = it.next().?;
 
@@ -618,7 +618,7 @@ pub fn resolveWindows(allocator: *Allocator, paths: []const []const u8) ![]u8 {
         if (!correct_disk_designator) {
             continue;
         }
-        var it = mem.tokenize(p[parsed.disk_designator.len..], "/\\");
+        var it = mem.tokenize(u8, p[parsed.disk_designator.len..], "/\\");
         while (it.next()) |component| {
             if (mem.eql(u8, component, ".")) {
                 continue;
@@ -687,7 +687,7 @@ pub fn resolvePosix(allocator: *Allocator, paths: []const []const u8) ![]u8 {
     errdefer allocator.free(result);
 
     for (paths[first_index..]) |p| {
-        var it = mem.tokenize(p, "/");
+        var it = mem.tokenize(u8, p, "/");
         while (it.next()) |component| {
             if (mem.eql(u8, component, ".")) {
                 continue;
@@ -1101,8 +1101,8 @@ pub fn relativeWindows(allocator: *Allocator, from: []const u8, to: []const u8) 
         return resolved_to;
     }
 
-    var from_it = mem.tokenize(resolved_from, "/\\");
-    var to_it = mem.tokenize(resolved_to, "/\\");
+    var from_it = mem.tokenize(u8, resolved_from, "/\\");
+    var to_it = mem.tokenize(u8, resolved_to, "/\\");
     while (true) {
         const from_component = from_it.next() orelse return allocator.dupe(u8, to_it.rest());
         const to_rest = to_it.rest();
@@ -1131,7 +1131,7 @@ pub fn relativeWindows(allocator: *Allocator, from: []const u8, to: []const u8) 
         // shave off the trailing slash
         result_index -= 1;
 
-        var rest_it = mem.tokenize(to_rest, "/\\");
+        var rest_it = mem.tokenize(u8, to_rest, "/\\");
         while (rest_it.next()) |to_component| {
             result[result_index] = '\\';
             result_index += 1;
@@ -1152,8 +1152,8 @@ pub fn relativePosix(allocator: *Allocator, from: []const u8, to: []const u8) ![
     const resolved_to = try resolvePosix(allocator, &[_][]const u8{to});
     defer allocator.free(resolved_to);
 
-    var from_it = mem.tokenize(resolved_from, "/");
-    var to_it = mem.tokenize(resolved_to, "/");
+    var from_it = mem.tokenize(u8, resolved_from, "/");
+    var to_it = mem.tokenize(u8, resolved_to, "/");
     while (true) {
         const from_component = from_it.next() orelse return allocator.dupe(u8, to_it.rest());
         const to_rest = to_it.rest();

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1575,8 +1575,8 @@ test "bswapAllFields" {
 /// If `delimiter_bytes` does not exist in buffer,
 /// the iterator will return `buffer`, null, in that order.
 /// See also the related function `split`.
-pub fn tokenize(buffer: []const u8, delimiter_bytes: []const u8) TokenIterator {
-    return TokenIterator{
+pub fn tokenize(comptime T: type, buffer: []const T, delimiter_bytes: []const T) TokenIterator(T) {
+    return .{
         .index = 0,
         .buffer = buffer,
         .delimiter_bytes = delimiter_bytes,
@@ -1584,51 +1584,71 @@ pub fn tokenize(buffer: []const u8, delimiter_bytes: []const u8) TokenIterator {
 }
 
 test "mem.tokenize" {
-    var it = tokenize("   abc def   ghi  ", " ");
+    var it = tokenize(u8, "   abc def   ghi  ", " ");
     try testing.expect(eql(u8, it.next().?, "abc"));
     try testing.expect(eql(u8, it.next().?, "def"));
     try testing.expect(eql(u8, it.next().?, "ghi"));
     try testing.expect(it.next() == null);
 
-    it = tokenize("..\\bob", "\\");
+    it = tokenize(u8, "..\\bob", "\\");
     try testing.expect(eql(u8, it.next().?, ".."));
     try testing.expect(eql(u8, "..", "..\\bob"[0..it.index]));
     try testing.expect(eql(u8, it.next().?, "bob"));
     try testing.expect(it.next() == null);
 
-    it = tokenize("//a/b", "/");
+    it = tokenize(u8, "//a/b", "/");
     try testing.expect(eql(u8, it.next().?, "a"));
     try testing.expect(eql(u8, it.next().?, "b"));
     try testing.expect(eql(u8, "//a/b", "//a/b"[0..it.index]));
     try testing.expect(it.next() == null);
 
-    it = tokenize("|", "|");
+    it = tokenize(u8, "|", "|");
     try testing.expect(it.next() == null);
 
-    it = tokenize("", "|");
+    it = tokenize(u8, "", "|");
     try testing.expect(it.next() == null);
 
-    it = tokenize("hello", "");
+    it = tokenize(u8, "hello", "");
     try testing.expect(eql(u8, it.next().?, "hello"));
     try testing.expect(it.next() == null);
 
-    it = tokenize("hello", " ");
+    it = tokenize(u8, "hello", " ");
     try testing.expect(eql(u8, it.next().?, "hello"));
     try testing.expect(it.next() == null);
+
+    var it16 = tokenize(
+        u16,
+        std.unicode.utf8ToUtf16LeStringLiteral("hello"),
+        std.unicode.utf8ToUtf16LeStringLiteral(" "),
+    );
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("hello")));
+    try testing.expect(it16.next() == null);
 }
 
 test "mem.tokenize (multibyte)" {
-    var it = tokenize("a|b,c/d e", " /,|");
+    var it = tokenize(u8, "a|b,c/d e", " /,|");
     try testing.expect(eql(u8, it.next().?, "a"));
     try testing.expect(eql(u8, it.next().?, "b"));
     try testing.expect(eql(u8, it.next().?, "c"));
     try testing.expect(eql(u8, it.next().?, "d"));
     try testing.expect(eql(u8, it.next().?, "e"));
     try testing.expect(it.next() == null);
+
+    var it16 = tokenize(
+        u16,
+        std.unicode.utf8ToUtf16LeStringLiteral("a|b,c/d e"),
+        std.unicode.utf8ToUtf16LeStringLiteral(" /,|"),
+    );
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("a")));
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("b")));
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("c")));
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("d")));
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("e")));
+    try testing.expect(it16.next() == null);
 }
 
 test "mem.tokenize (reset)" {
-    var it = tokenize("   abc def   ghi  ", " ");
+    var it = tokenize(u8, "   abc def   ghi  ", " ");
     try testing.expect(eql(u8, it.next().?, "abc"));
     try testing.expect(eql(u8, it.next().?, "def"));
     try testing.expect(eql(u8, it.next().?, "ghi"));
@@ -1649,9 +1669,9 @@ test "mem.tokenize (reset)" {
 /// the iterator will return `buffer`, null, in that order.
 /// The delimiter length must not be zero.
 /// See also the related function `tokenize`.
-pub fn split(buffer: []const u8, delimiter: []const u8) SplitIterator {
+pub fn split(comptime T: type, buffer: []const T, delimiter: []const T) SplitIterator(T) {
     assert(delimiter.len != 0);
-    return SplitIterator{
+    return .{
         .index = 0,
         .buffer = buffer,
         .delimiter = delimiter,
@@ -1661,35 +1681,55 @@ pub fn split(buffer: []const u8, delimiter: []const u8) SplitIterator {
 pub const separate = @compileError("deprecated: renamed to split (behavior remains unchanged)");
 
 test "mem.split" {
-    var it = split("abc|def||ghi", "|");
+    var it = split(u8, "abc|def||ghi", "|");
     try testing.expect(eql(u8, it.next().?, "abc"));
     try testing.expect(eql(u8, it.next().?, "def"));
     try testing.expect(eql(u8, it.next().?, ""));
     try testing.expect(eql(u8, it.next().?, "ghi"));
     try testing.expect(it.next() == null);
 
-    it = split("", "|");
+    it = split(u8, "", "|");
     try testing.expect(eql(u8, it.next().?, ""));
     try testing.expect(it.next() == null);
 
-    it = split("|", "|");
+    it = split(u8, "|", "|");
     try testing.expect(eql(u8, it.next().?, ""));
     try testing.expect(eql(u8, it.next().?, ""));
     try testing.expect(it.next() == null);
 
-    it = split("hello", " ");
+    it = split(u8, "hello", " ");
     try testing.expect(eql(u8, it.next().?, "hello"));
     try testing.expect(it.next() == null);
+
+    var it16 = split(
+        u16,
+        std.unicode.utf8ToUtf16LeStringLiteral("hello"),
+        std.unicode.utf8ToUtf16LeStringLiteral(" "),
+    );
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("hello")));
+    try testing.expect(it16.next() == null);
 }
 
 test "mem.split (multibyte)" {
-    var it = split("a, b ,, c, d, e", ", ");
+    var it = split(u8, "a, b ,, c, d, e", ", ");
     try testing.expect(eql(u8, it.next().?, "a"));
     try testing.expect(eql(u8, it.next().?, "b ,"));
     try testing.expect(eql(u8, it.next().?, "c"));
     try testing.expect(eql(u8, it.next().?, "d"));
     try testing.expect(eql(u8, it.next().?, "e"));
     try testing.expect(it.next() == null);
+
+    var it16 = split(
+        u16,
+        std.unicode.utf8ToUtf16LeStringLiteral("a, b ,, c, d, e"),
+        std.unicode.utf8ToUtf16LeStringLiteral(", "),
+    );
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("a")));
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("b ,")));
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("c")));
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("d")));
+    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("e")));
+    try testing.expect(it16.next() == null);
 }
 
 pub fn startsWith(comptime T: type, haystack: []const T, needle: []const T) bool {
@@ -1710,75 +1750,83 @@ test "mem.endsWith" {
     try testing.expect(!endsWith(u8, "Bob", "Bo"));
 }
 
-pub const TokenIterator = struct {
-    buffer: []const u8,
-    delimiter_bytes: []const u8,
-    index: usize,
+pub fn TokenIterator(comptime T: type) type {
+    return struct {
+        buffer: []const T,
+        delimiter_bytes: []const T,
+        index: usize,
 
-    /// Returns a slice of the next token, or null if tokenization is complete.
-    pub fn next(self: *TokenIterator) ?[]const u8 {
-        // move to beginning of token
-        while (self.index < self.buffer.len and self.isSplitByte(self.buffer[self.index])) : (self.index += 1) {}
-        const start = self.index;
-        if (start == self.buffer.len) {
-            return null;
-        }
+        const Self = @This();
 
-        // move to end of token
-        while (self.index < self.buffer.len and !self.isSplitByte(self.buffer[self.index])) : (self.index += 1) {}
-        const end = self.index;
-
-        return self.buffer[start..end];
-    }
-
-    /// Returns a slice of the remaining bytes. Does not affect iterator state.
-    pub fn rest(self: TokenIterator) []const u8 {
-        // move to beginning of token
-        var index: usize = self.index;
-        while (index < self.buffer.len and self.isSplitByte(self.buffer[index])) : (index += 1) {}
-        return self.buffer[index..];
-    }
-
-    /// Resets the iterator to the initial token.
-    pub fn reset(self: *TokenIterator) void {
-        self.index = 0;
-    }
-
-    fn isSplitByte(self: TokenIterator, byte: u8) bool {
-        for (self.delimiter_bytes) |delimiter_byte| {
-            if (byte == delimiter_byte) {
-                return true;
+        /// Returns a slice of the next token, or null if tokenization is complete.
+        pub fn next(self: *Self) ?[]const T {
+            // move to beginning of token
+            while (self.index < self.buffer.len and self.isSplitByte(self.buffer[self.index])) : (self.index += 1) {}
+            const start = self.index;
+            if (start == self.buffer.len) {
+                return null;
             }
+
+            // move to end of token
+            while (self.index < self.buffer.len and !self.isSplitByte(self.buffer[self.index])) : (self.index += 1) {}
+            const end = self.index;
+
+            return self.buffer[start..end];
         }
-        return false;
-    }
-};
 
-pub const SplitIterator = struct {
-    buffer: []const u8,
-    index: ?usize,
-    delimiter: []const u8,
+        /// Returns a slice of the remaining bytes. Does not affect iterator state.
+        pub fn rest(self: Self) []const T {
+            // move to beginning of token
+            var index: usize = self.index;
+            while (index < self.buffer.len and self.isSplitByte(self.buffer[index])) : (index += 1) {}
+            return self.buffer[index..];
+        }
 
-    /// Returns a slice of the next field, or null if splitting is complete.
-    pub fn next(self: *SplitIterator) ?[]const u8 {
-        const start = self.index orelse return null;
-        const end = if (indexOfPos(u8, self.buffer, start, self.delimiter)) |delim_start| blk: {
-            self.index = delim_start + self.delimiter.len;
-            break :blk delim_start;
-        } else blk: {
-            self.index = null;
-            break :blk self.buffer.len;
-        };
-        return self.buffer[start..end];
-    }
+        /// Resets the iterator to the initial token.
+        pub fn reset(self: *Self) void {
+            self.index = 0;
+        }
 
-    /// Returns a slice of the remaining bytes. Does not affect iterator state.
-    pub fn rest(self: SplitIterator) []const u8 {
-        const end = self.buffer.len;
-        const start = self.index orelse end;
-        return self.buffer[start..end];
-    }
-};
+        fn isSplitByte(self: Self, byte: T) bool {
+            for (self.delimiter_bytes) |delimiter_byte| {
+                if (byte == delimiter_byte) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    };
+}
+
+pub fn SplitIterator(comptime T: type) type {
+    return struct {
+        buffer: []const T,
+        index: ?usize,
+        delimiter: []const T,
+
+        const Self = @This();
+
+        /// Returns a slice of the next field, or null if splitting is complete.
+        pub fn next(self: *Self) ?[]const T {
+            const start = self.index orelse return null;
+            const end = if (indexOfPos(T, self.buffer, start, self.delimiter)) |delim_start| blk: {
+                self.index = delim_start + self.delimiter.len;
+                break :blk delim_start;
+            } else blk: {
+                self.index = null;
+                break :blk self.buffer.len;
+            };
+            return self.buffer[start..end];
+        }
+
+        /// Returns a slice of the remaining bytes. Does not affect iterator state.
+        pub fn rest(self: Self) []const T {
+            const end = self.buffer.len;
+            const start = self.index orelse end;
+            return self.buffer[start..end];
+        }
+    };
+}
 
 /// Naively combines a series of slices with a separator.
 /// Allocates memory for the result, which must be freed by the caller.

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1130,9 +1130,9 @@ fn linuxLookupNameFromHosts(
         },
         else => |e| return e,
     }) |line| {
-        const no_comment_line = mem.split(line, "#").next().?;
+        const no_comment_line = mem.split(u8, line, "#").next().?;
 
-        var line_it = mem.tokenize(no_comment_line, " \t");
+        var line_it = mem.tokenize(u8, no_comment_line, " \t");
         const ip_text = line_it.next() orelse continue;
         var first_name_text: ?[]const u8 = null;
         while (line_it.next()) |name_text| {
@@ -1211,7 +1211,7 @@ fn linuxLookupNameFromDnsSearch(
     mem.copy(u8, canon.items, canon_name);
     try canon.append('.');
 
-    var tok_it = mem.tokenize(search, " \t");
+    var tok_it = mem.tokenize(u8, search, " \t");
     while (tok_it.next()) |tok| {
         canon.shrinkRetainingCapacity(canon_name.len + 1);
         try canon.appendSlice(tok);
@@ -1328,13 +1328,13 @@ fn getResolvConf(allocator: *mem.Allocator, rc: *ResolvConf) !void {
         },
         else => |e| return e,
     }) |line| {
-        const no_comment_line = mem.split(line, "#").next().?;
-        var line_it = mem.tokenize(no_comment_line, " \t");
+        const no_comment_line = mem.split(u8, line, "#").next().?;
+        var line_it = mem.tokenize(u8, no_comment_line, " \t");
 
         const token = line_it.next() orelse continue;
         if (mem.eql(u8, token, "options")) {
             while (line_it.next()) |sub_tok| {
-                var colon_it = mem.split(sub_tok, ":");
+                var colon_it = mem.split(u8, sub_tok, ":");
                 const name = colon_it.next().?;
                 const value_txt = colon_it.next() orelse continue;
                 const value = std.fmt.parseInt(u8, value_txt, 10) catch |err| switch (err) {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1378,7 +1378,7 @@ pub fn execvpeZ_expandArg0(
     // Use of MAX_PATH_BYTES here is valid as the path_buf will be passed
     // directly to the operating system in execveZ.
     var path_buf: [MAX_PATH_BYTES]u8 = undefined;
-    var it = mem.tokenize(PATH, ":");
+    var it = mem.tokenize(u8, PATH, ":");
     var seen_eacces = false;
     var err: ExecveError = undefined;
 

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -109,7 +109,7 @@ pub fn getEnvMap(allocator: *Allocator) !BufMap {
 
         for (environ) |env| {
             const pair = mem.spanZ(env);
-            var parts = mem.split(pair, "=");
+            var parts = mem.split(u8, pair, "=");
             const key = parts.next().?;
             const value = parts.next().?;
             try result.put(key, value);

--- a/lib/std/zig/cross_target.zig
+++ b/lib/std/zig/cross_target.zig
@@ -233,7 +233,7 @@ pub const CrossTarget = struct {
             .dynamic_linker = DynamicLinker.init(args.dynamic_linker),
         };
 
-        var it = mem.split(args.arch_os_abi, "-");
+        var it = mem.split(u8, args.arch_os_abi, "-");
         const arch_name = it.next().?;
         const arch_is_native = mem.eql(u8, arch_name, "native");
         if (!arch_is_native) {
@@ -251,7 +251,7 @@ pub const CrossTarget = struct {
 
         const opt_abi_text = it.next();
         if (opt_abi_text) |abi_text| {
-            var abi_it = mem.split(abi_text, ".");
+            var abi_it = mem.split(u8, abi_text, ".");
             const abi = std.meta.stringToEnum(Target.Abi, abi_it.next().?) orelse
                 return error.UnknownApplicationBinaryInterface;
             result.abi = abi;
@@ -699,7 +699,7 @@ pub const CrossTarget = struct {
     }
 
     fn parseOs(result: *CrossTarget, diags: *ParseOptions.Diagnostics, text: []const u8) !void {
-        var it = mem.split(text, ".");
+        var it = mem.split(u8, text, ".");
         const os_name = it.next().?;
         diags.os_name = os_name;
         const os_is_native = mem.eql(u8, os_name, "native");
@@ -757,7 +757,7 @@ pub const CrossTarget = struct {
             .linux,
             .dragonfly,
             => {
-                var range_it = mem.split(version_text, "...");
+                var range_it = mem.split(u8, version_text, "...");
 
                 const min_text = range_it.next().?;
                 const min_ver = SemVer.parse(min_text) catch |err| switch (err) {
@@ -777,7 +777,7 @@ pub const CrossTarget = struct {
             },
 
             .windows => {
-                var range_it = mem.split(version_text, "...");
+                var range_it = mem.split(u8, version_text, "...");
 
                 const min_text = range_it.next().?;
                 const min_ver = std.meta.stringToEnum(Target.Os.WindowsVersion, min_text) orelse

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -44,7 +44,7 @@ pub const NativePaths = struct {
             defer allocator.free(nix_cflags_compile);
 
             is_nix = true;
-            var it = mem.tokenize(nix_cflags_compile, " ");
+            var it = mem.tokenize(u8, nix_cflags_compile, " ");
             while (true) {
                 const word = it.next() orelse break;
                 if (mem.eql(u8, word, "-isystem")) {
@@ -69,7 +69,7 @@ pub const NativePaths = struct {
             defer allocator.free(nix_ldflags);
 
             is_nix = true;
-            var it = mem.tokenize(nix_ldflags, " ");
+            var it = mem.tokenize(u8, nix_ldflags, " ");
             while (true) {
                 const word = it.next() orelse break;
                 if (mem.eql(u8, word, "-rpath")) {
@@ -839,7 +839,7 @@ pub const NativeTargetInfo = struct {
                         error.Overflow => return error.InvalidElfFile,
                     };
                     const rpath_list = mem.spanZ(std.meta.assumeSentinel(strtab[rpoff_usize..].ptr, 0));
-                    var it = mem.tokenize(rpath_list, ":");
+                    var it = mem.tokenize(u8, rpath_list, ":");
                     while (it.next()) |rpath| {
                         var dir = fs.cwd().openDir(rpath, .{}) catch |err| switch (err) {
                             error.NameTooLong => unreachable,

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -356,7 +356,7 @@ pub const Manifest = struct {
 
         const input_file_count = self.files.items.len;
         var any_file_changed = false;
-        var line_iter = mem.tokenize(file_contents, "\n");
+        var line_iter = mem.tokenize(u8, file_contents, "\n");
         var idx: usize = 0;
         while (line_iter.next()) |line| {
             defer idx += 1;
@@ -373,7 +373,7 @@ pub const Manifest = struct {
                 break :blk new;
             };
 
-            var iter = mem.tokenize(line, " ");
+            var iter = mem.tokenize(u8, line, " ");
             const size = iter.next() orelse return error.InvalidFormat;
             const inode = iter.next() orelse return error.InvalidFormat;
             const mtime_nsec_str = iter.next() orelse return error.InvalidFormat;

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3341,7 +3341,7 @@ pub fn hasSharedLibraryExt(filename: []const u8) bool {
         return true;
     }
     // Look for .so.X, .so.X.Y, .so.X.Y.Z
-    var it = mem.split(filename, ".");
+    var it = mem.split(u8, filename, ".");
     _ = it.next().?;
     var so_txt = it.next() orelse return false;
     while (!mem.eql(u8, so_txt, "so")) {
@@ -4086,7 +4086,7 @@ fn updateStage1Module(comp: *Compilation, main_progress_node: *std.Progress.Node
             };
 
             if (directory.handle.readFileAlloc(comp.gpa, libs_txt_basename, 10 * 1024 * 1024)) |libs_txt| {
-                var it = mem.tokenize(libs_txt, "\n");
+                var it = mem.tokenize(u8, libs_txt, "\n");
                 while (it.next()) |lib_name| {
                     try comp.stage1AddLinkLib(lib_name);
                 }

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -3656,7 +3656,7 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                     }
 
                     {
-                        var iter = std.mem.tokenize(asm_source, "\n\r");
+                        var iter = std.mem.tokenize(u8, asm_source, "\n\r");
                         while (iter.next()) |ins| {
                             if (mem.eql(u8, ins, "syscall")) {
                                 try self.code.appendSlice(&[_]u8{ 0x0f, 0x05 });

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -107,7 +107,7 @@ pub fn loadMetaData(gpa: *Allocator, zig_lib_dir: std.fs.Dir) LoadMetaDataError!
     defer gpa.free(abi_txt_contents);
 
     {
-        var it = mem.tokenize(vers_txt_contents, "\r\n");
+        var it = mem.tokenize(u8, vers_txt_contents, "\r\n");
         var line_i: usize = 1;
         while (it.next()) |line| : (line_i += 1) {
             const prefix = "GLIBC_";
@@ -124,10 +124,10 @@ pub fn loadMetaData(gpa: *Allocator, zig_lib_dir: std.fs.Dir) LoadMetaDataError!
         }
     }
     {
-        var file_it = mem.tokenize(fns_txt_contents, "\r\n");
+        var file_it = mem.tokenize(u8, fns_txt_contents, "\r\n");
         var line_i: usize = 1;
         while (file_it.next()) |line| : (line_i += 1) {
-            var line_it = mem.tokenize(line, " ");
+            var line_it = mem.tokenize(u8, line, " ");
             const fn_name = line_it.next() orelse {
                 std.log.err("fns.txt:{d}: expected function name", .{line_i});
                 return error.ZigInstallationCorrupt;
@@ -147,7 +147,7 @@ pub fn loadMetaData(gpa: *Allocator, zig_lib_dir: std.fs.Dir) LoadMetaDataError!
         }
     }
     {
-        var file_it = mem.split(abi_txt_contents, "\n");
+        var file_it = mem.split(u8, abi_txt_contents, "\n");
         var line_i: usize = 0;
         while (true) {
             const ver_list_base: []VerList = blk: {
@@ -155,9 +155,9 @@ pub fn loadMetaData(gpa: *Allocator, zig_lib_dir: std.fs.Dir) LoadMetaDataError!
                 if (line.len == 0) break;
                 line_i += 1;
                 const ver_list_base = try arena.alloc(VerList, all_functions.items.len);
-                var line_it = mem.tokenize(line, " ");
+                var line_it = mem.tokenize(u8, line, " ");
                 while (line_it.next()) |target_string| {
-                    var component_it = mem.tokenize(target_string, "-");
+                    var component_it = mem.tokenize(u8, target_string, "-");
                     const arch_name = component_it.next() orelse {
                         std.log.err("abi.txt:{d}: expected arch name", .{line_i});
                         return error.ZigInstallationCorrupt;
@@ -203,7 +203,7 @@ pub fn loadMetaData(gpa: *Allocator, zig_lib_dir: std.fs.Dir) LoadMetaDataError!
                     .versions = undefined,
                     .len = 0,
                 };
-                var line_it = mem.tokenize(line, " ");
+                var line_it = mem.tokenize(u8, line, " ");
                 while (line_it.next()) |version_index_string| {
                     if (ver_list.len >= ver_list.versions.len) {
                         // If this happens with legit data, increase the array len in the type.

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -60,10 +60,10 @@ pub const LibCInstallation = struct {
         const contents = try std.fs.cwd().readFileAlloc(allocator, libc_file, std.math.maxInt(usize));
         defer allocator.free(contents);
 
-        var it = std.mem.tokenize(contents, "\n");
+        var it = std.mem.tokenize(u8, contents, "\n");
         while (it.next()) |line| {
             if (line.len == 0 or line[0] == '#') continue;
-            var line_it = std.mem.split(line, "=");
+            var line_it = std.mem.split(u8, line, "=");
             const name = line_it.next() orelse {
                 log.err("missing equal sign after field name\n", .{});
                 return error.ParseError;
@@ -298,7 +298,7 @@ pub const LibCInstallation = struct {
             },
         }
 
-        var it = std.mem.tokenize(exec_res.stderr, "\n\r");
+        var it = std.mem.tokenize(u8, exec_res.stderr, "\n\r");
         var search_paths = std.ArrayList([]const u8).init(allocator);
         defer search_paths.deinit();
         while (it.next()) |line| {
@@ -616,7 +616,7 @@ fn ccPrintFileName(args: CCPrintFileNameOptions) ![:0]u8 {
         },
     }
 
-    var it = std.mem.tokenize(exec_res.stdout, "\n\r");
+    var it = std.mem.tokenize(u8, exec_res.stdout, "\n\r");
     const line = it.next() orelse return error.LibCRuntimeNotFound;
     // When this command fails, it returns exit code 0 and duplicates the input file name.
     // So we detect failure by checking if the output matches exactly the input.
@@ -695,7 +695,7 @@ fn appendCcExe(args: *std.ArrayList([]const u8), skip_cc_env_var: bool) !void {
         return;
     };
     // Respect space-separated flags to the C compiler.
-    var it = std.mem.tokenize(cc_env_var, " ");
+    var it = std.mem.tokenize(u8, cc_env_var, " ");
     while (it.next()) |arg| {
         try args.append(arg);
     }

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -106,7 +106,7 @@ pub const Id = struct {
         var out: u32 = 0;
         var values: [3][]const u8 = undefined;
 
-        var split = mem.split(string, ".");
+        var split = mem.split(u8, string, ".");
         var count: u4 = 0;
         while (split.next()) |value| {
             if (count > 2) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1200,7 +1200,7 @@ fn buildOutputType(
                     },
                     .rdynamic => rdynamic = true,
                     .wl => {
-                        var split_it = mem.split(it.only_arg, ",");
+                        var split_it = mem.split(u8, it.only_arg, ",");
                         while (split_it.next()) |linker_arg| {
                             // Handle nested-joined args like `-Wl,-rpath=foo`.
                             // Must be prefixed with 1 or 2 dashes.
@@ -3655,7 +3655,7 @@ pub const ClangArgIterator = struct {
             defer allocator.free(resp_contents);
             // TODO is there a specification for this file format? Let's find it and make this parsing more robust
             // at the very least I'm guessing this needs to handle quotes and `#` comments.
-            var it = mem.tokenize(resp_contents, " \t\r\n");
+            var it = mem.tokenize(u8, resp_contents, " \t\r\n");
             var resp_arg_list = std.ArrayList([]const u8).init(allocator);
             defer resp_arg_list.deinit();
             {

--- a/src/test.zig
+++ b/src/test.zig
@@ -228,7 +228,7 @@ pub const TestContext = struct {
                     continue;
                 }
                 // example: "file.zig:1:2: error: bad thing happened"
-                var it = std.mem.split(err_msg_line, ":");
+                var it = std.mem.split(u8, err_msg_line, ":");
                 const src_path = it.next() orelse @panic("missing colon");
                 const line_text = it.next() orelse @panic("missing line");
                 const col_text = it.next() orelse @panic("missing column");
@@ -779,7 +779,7 @@ pub const TestContext = struct {
                     }
                     var ok = true;
                     if (case.expect_exact) {
-                        var err_iter = std.mem.split(result.stderr, "\n");
+                        var err_iter = std.mem.split(u8, result.stderr, "\n");
                         var i: usize = 0;
                         ok = while (err_iter.next()) |line| : (i += 1) {
                             if (i >= case_error_list.len) break false;

--- a/test/behavior/bugs/6456.zig
+++ b/test/behavior/bugs/6456.zig
@@ -13,7 +13,7 @@ test "issue 6456" {
     comptime {
         var fields: []const StructField = &[0]StructField{};
 
-        var it = std.mem.tokenize(text, "\n");
+        var it = std.mem.tokenize(u8, text, "\n");
         while (it.next()) |name| {
             fields = fields ++ &[_]StructField{StructField{
                 .alignment = 0,

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -768,7 +768,7 @@ pub const StackTracesContext = struct {
                 var buf = ArrayList(u8).init(b.allocator);
                 defer buf.deinit();
                 if (stderr.len != 0 and stderr[stderr.len - 1] == '\n') stderr = stderr[0 .. stderr.len - 1];
-                var it = mem.split(stderr, "\n");
+                var it = mem.split(u8, stderr, "\n");
                 process_lines: while (it.next()) |line| {
                     if (line.len == 0) continue;
 

--- a/tools/update_glibc.zig
+++ b/tools/update_glibc.zig
@@ -188,9 +188,9 @@ pub fn main() !void {
                 std.debug.warn("unable to open {s}: {}\n", .{ abi_list_filename, err });
                 std.process.exit(1);
             };
-            var lines_it = std.mem.tokenize(contents, "\n");
+            var lines_it = std.mem.tokenize(u8, contents, "\n");
             while (lines_it.next()) |line| {
-                var tok_it = std.mem.tokenize(line, " ");
+                var tok_it = std.mem.tokenize(u8, line, " ");
                 const ver = tok_it.next().?;
                 const name = tok_it.next().?;
                 const category = tok_it.next().?;
@@ -319,8 +319,8 @@ pub fn strCmpLessThan(context: void, a: []const u8, b: []const u8) bool {
 pub fn versionLessThan(context: void, a: []const u8, b: []const u8) bool {
     _ = context;
     const sep_chars = "GLIBC_.";
-    var a_tokens = std.mem.tokenize(a, sep_chars);
-    var b_tokens = std.mem.tokenize(b, sep_chars);
+    var a_tokens = std.mem.tokenize(u8, a, sep_chars);
+    var b_tokens = std.mem.tokenize(u8, b, sep_chars);
 
     while (true) {
         const a_next = a_tokens.next();

--- a/tools/update_spirv_features.zig
+++ b/tools/update_spirv_features.zig
@@ -19,7 +19,7 @@ const Version = struct {
     minor: u32,
 
     fn parse(str: []const u8) !Version {
-        var it = std.mem.split(str, ".");
+        var it = std.mem.split(u8, str, ".");
 
         const major = it.next() orelse return error.InvalidVersion;
         const minor = it.next() orelse return error.InvalidVersion;


### PR DESCRIPTION
- More in line with the rest of the `mem` functions, most of which take a type
- Allows `split`/`tokenize` to be used for things like UTF-16 strings