### PR TITLE
Add minimal support to Zig toolchain to support building iOS binaries

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2672,7 +2672,11 @@ pub const LibExeObjStep = struct {
                     try zig_args.append(self.builder.pathFromRoot(include_path));
                 },
                 .raw_path_system => |include_path| {
-                    try zig_args.append("-isystem");
+                    if (builder.sysroot != null) {
+                        try zig_args.append("-iwithsysroot");
+                    } else {
+                        try zig_args.append("-isystem");
+                    }
                     try zig_args.append(self.builder.pathFromRoot(include_path));
                 },
                 .other_step => |other| if (other.emit_h) {
@@ -2700,6 +2704,12 @@ pub const LibExeObjStep = struct {
 
         if (self.target.isDarwin()) {
             for (self.framework_dirs.items) |dir| {
+                if (builder.sysroot != null) {
+                    try zig_args.append("-iframeworkwithsysroot");
+                } else {
+                    try zig_args.append("-iframework");
+                }
+                try zig_args.append(dir);
                 try zig_args.append("-F");
                 try zig_args.append(dir);
             }

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -116,6 +116,21 @@ pub const build_tool_version = extern struct {
     version: u32,
 };
 
+pub const PLATFORM_MACOS: u32 = 0x1;
+pub const PLATFORM_IOS: u32 = 0x2;
+pub const PLATFORM_TVOS: u32 = 0x3;
+pub const PLATFORM_WATCHOS: u32 = 0x4;
+pub const PLATFORM_BRIDGEOS: u32 = 0x5;
+pub const PLATFORM_MACCATALYST: u32 = 0x6;
+pub const PLATFORM_IOSSIMULATOR: u32 = 0x7;
+pub const PLATFORM_TVOSSIMULATOR: u32 = 0x8;
+pub const PLATFORM_WATCHOSSIMULATOR: u32 = 0x9;
+pub const PLATFORM_DRIVERKIT: u32 = 0x10;
+
+pub const TOOL_CLANG: u32 = 0x1;
+pub const TOOL_SWIFT: u32 = 0x2;
+pub const TOOL_LD: u32 = 0x3;
+
 /// The entry_point_command is a replacement for thread_command.
 /// It is used for main executables to specify the location (file offset)
 /// of main(). If -stack_size was used at link time, the stacksize

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -13,12 +13,10 @@ const assert = std.debug.assert;
 const process = std.process;
 const Target = std.Target;
 const CrossTarget = std.zig.CrossTarget;
-const macos = @import("system/macos.zig");
 const native_endian = std.Target.current.cpu.arch.endian();
 const linux = @import("system/linux.zig");
 pub const windows = @import("system/windows.zig");
-
-pub const getSDKPath = macos.getSDKPath;
+pub const darwin = @import("system/darwin.zig");
 
 pub const NativePaths = struct {
     include_dirs: ArrayList([:0]u8),
@@ -255,7 +253,7 @@ pub const NativeTargetInfo = struct {
                     os.version_range.windows.min = detected_version;
                     os.version_range.windows.max = detected_version;
                 },
-                .macos => try macos.detect(&os),
+                .macos => try darwin.macos.detect(&os),
                 .freebsd, .netbsd, .dragonfly => {
                     const key = switch (Target.current.os.tag) {
                         .freebsd => "kern.osreldate",
@@ -972,7 +970,7 @@ pub const NativeTargetInfo = struct {
 
         switch (std.Target.current.os.tag) {
             .linux => return linux.detectNativeCpuAndFeatures(),
-            .macos => return macos.detectNativeCpuAndFeatures(),
+            .macos => return darwin.macos.detectNativeCpuAndFeatures(),
             else => {},
         }
 
@@ -983,6 +981,6 @@ pub const NativeTargetInfo = struct {
 };
 
 test {
-    _ = @import("system/macos.zig");
+    _ = @import("system/darwin.zig");
     _ = @import("system/linux.zig");
 }

--- a/lib/std/zig/system/darwin.zig
+++ b/lib/std/zig/system/darwin.zig
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2015-2021 Zig Contributors
+// This file is part of [zig](https://ziglang.org/), which is MIT licensed.
+// The MIT license requires this copyright notice to be included in all copies
+// and substantial portions of the software.
+const std = @import("std");
+const mem = std.mem;
+const Allocator = mem.Allocator;
+const Target = std.Target;
+
+pub const macos = @import("darwin/macos.zig");
+
+/// Detect SDK path on Darwin.
+/// Calls `xcrun --sdk <target_sdk> --show-sdk-path` which result can be used to specify
+/// `--sysroot` of the compiler.
+/// The caller needs to free the resulting path slice.
+pub fn getSDKPath(allocator: *Allocator, target: Target) !?[]u8 {
+    const is_simulator_abi = target.abi == .simulator;
+    const sdk = switch (target.os.tag) {
+        .macos => "macosx",
+        .ios => if (is_simulator_abi) "iphonesimulator" else "iphoneos",
+        .watchos => if (is_simulator_abi) "watchsimulator" else "watchos",
+        .tvos => if (is_simulator_abi) "appletvsimulator" else "appletvos",
+        else => return null,
+    };
+
+    const argv = &[_][]const u8{ "xcrun", "--sdk", sdk, "--show-sdk-path" };
+    const result = try std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv });
+    defer {
+        allocator.free(result.stderr);
+        allocator.free(result.stdout);
+    }
+    if (result.stderr.len != 0 or result.term.Exited != 0) {
+        // We don't actually care if there were errors as this is best-effort check anyhow
+        // and in the worst case the user can specify the sysroot manually.
+        return null;
+    }
+    const sysroot = try allocator.dupe(u8, mem.trimRight(u8, result.stdout, "\r\n"));
+    return sysroot;
+}
+
+test "" {
+    _ = @import("darwin/macos.zig");
+}

--- a/lib/std/zig/system/darwin/macos.zig
+++ b/lib/std/zig/system/darwin/macos.zig
@@ -408,28 +408,6 @@ fn testVersionEquality(expected: std.builtin.Version, got: std.builtin.Version) 
     try testing.expectEqualStrings(s_expected, s_got);
 }
 
-/// Detect SDK path on Darwin.
-/// Calls `xcrun --show-sdk-path` which result can be used to specify
-/// `-syslibroot` param of the linker.
-/// The caller needs to free the resulting path slice.
-pub fn getSDKPath(allocator: *mem.Allocator) ![]u8 {
-    assert(Target.current.isDarwin());
-    const argv = &[_][]const u8{ "xcrun", "--show-sdk-path" };
-    const result = try std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv });
-    defer {
-        allocator.free(result.stderr);
-        allocator.free(result.stdout);
-    }
-    if (result.stderr.len != 0) {
-        std.log.err("unexpected 'xcrun --show-sdk-path' stderr: {s}", .{result.stderr});
-    }
-    if (result.term.Exited != 0) {
-        return error.ProcessTerminated;
-    }
-    const syslibroot = mem.trimRight(u8, result.stdout, "\r\n");
-    return mem.dupe(allocator, u8, syslibroot);
-}
-
 pub fn detectNativeCpuAndFeatures() ?Target.Cpu {
     var cpu_family: os.CPUFAMILY = undefined;
     var len: usize = @sizeOf(os.CPUFAMILY);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -944,8 +944,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
             if (options.sysroot) |sysroot| {
                 break :blk sysroot;
             } else if (darwin_can_use_system_sdk) {
-                const at_least_big_sur = options.target.os.getVersionRange().semver.min.major >= 11;
-                break :blk if (at_least_big_sur) try std.zig.system.getSDKPath(arena) else null;
+                break :blk try std.zig.system.darwin.getSDKPath(arena, options.target);
             } else {
                 break :blk null;
             }

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2736,14 +2736,15 @@ fn populateMetadata(self: *MachO) !void {
         ));
         const ver = self.base.options.target.os.version_range.semver.min;
         const version = ver.major << 16 | ver.minor << 8 | ver.patch;
+        const is_simulator_abi = self.base.options.target.abi == .simulator;
         var cmd = commands.emptyGenericCommandWithData(macho.build_version_command{
             .cmd = macho.LC_BUILD_VERSION,
             .cmdsize = cmdsize,
             .platform = switch (self.base.options.target.os.tag) {
                 .macos => macho.PLATFORM_MACOS,
-                .ios => macho.PLATFORM_IOSSIMULATOR,
-                .watchos => macho.PLATFORM_WATCHOS,
-                .tvos => macho.PLATFORM_TVOS,
+                .ios => if (is_simulator_abi) macho.PLATFORM_IOSSIMULATOR else macho.PLATFORM_IOS,
+                .watchos => if (is_simulator_abi) macho.PLATFORM_WATCHOSSIMULATOR else macho.PLATFORM_WATCHOS,
+                .tvos => if (is_simulator_abi) macho.PLATFORM_TVOSSIMULATOR else macho.PLATFORM_TVOS,
                 else => unreachable,
             },
             .minos = version,
@@ -4355,14 +4356,15 @@ pub fn populateMissingMetadata(self: *MachO) !void {
         ));
         const ver = self.base.options.target.os.version_range.semver.min;
         const version = ver.major << 16 | ver.minor << 8 | ver.patch;
+        const is_simulator_abi = self.base.options.target.abi == .simulator;
         var cmd = commands.emptyGenericCommandWithData(macho.build_version_command{
             .cmd = macho.LC_BUILD_VERSION,
             .cmdsize = cmdsize,
             .platform = switch (self.base.options.target.os.tag) {
                 .macos => macho.PLATFORM_MACOS,
-                .ios => macho.PLATFORM_IOSSIMULATOR,
-                .watchos => macho.PLATFORM_WATCHOS,
-                .tvos => macho.PLATFORM_TVOS,
+                .ios => if (is_simulator_abi) macho.PLATFORM_IOSSIMULATOR else macho.PLATFORM_IOS,
+                .watchos => if (is_simulator_abi) macho.PLATFORM_WATCHOSSIMULATOR else macho.PLATFORM_WATCHOS,
+                .tvos => if (is_simulator_abi) macho.PLATFORM_TVOSSIMULATOR else macho.PLATFORM_TVOS,
                 else => unreachable,
             },
             .minos = version,

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -340,10 +340,16 @@ fn targetToAppleString(allocator: *Allocator, target: std.Target) ![]const u8 {
         .x86_64 => "x86_64",
         else => unreachable,
     };
-    if (target.os.tag == .ios) {
-        return std.fmt.allocPrint(allocator, "{s}-{s}-simulator", .{ arch, @tagName(target.os.tag) });
+    const os = @tagName(target.os.tag);
+    const abi: ?[]const u8 = switch (target.abi) {
+        .gnu => null,
+        .simulator => "simulator",
+        else => unreachable,
+    };
+    if (abi) |x| {
+        return std.fmt.allocPrint(allocator, "{s}-{s}-{s}", .{ arch, os, x });
     }
-    return std.fmt.allocPrint(allocator, "{s}-{s}", .{ arch, @tagName(target.os.tag) });
+    return std.fmt.allocPrint(allocator, "{s}-{s}", .{ arch, os });
 }
 
 pub fn parseFromStub(self: *Dylib, allocator: *Allocator, target: std.Target, lib_stub: LibStub) !void {

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -340,6 +340,9 @@ fn targetToAppleString(allocator: *Allocator, target: std.Target) ![]const u8 {
         .x86_64 => "x86_64",
         else => unreachable,
     };
+    if (target.os.tag == .ios) {
+        return std.fmt.allocPrint(allocator, "{s}-{s}-simulator", .{ arch, @tagName(target.os.tag) });
+    }
     return std.fmt.allocPrint(allocator, "{s}-{s}", .{ arch, @tagName(target.os.tag) });
 }
 

--- a/src/link/MachO/commands.zig
+++ b/src/link/MachO/commands.zig
@@ -43,6 +43,7 @@ pub const LoadCommand = union(enum) {
     Main: macho.entry_point_command,
     VersionMin: macho.version_min_command,
     SourceVersion: macho.source_version_command,
+    BuildVersion: GenericCommandWithData(macho.build_version_command),
     Uuid: macho.uuid_command,
     LinkeditData: macho.linkedit_data_command,
     Rpath: GenericCommandWithData(macho.rpath_command),
@@ -97,6 +98,9 @@ pub const LoadCommand = union(enum) {
             macho.LC_SOURCE_VERSION => LoadCommand{
                 .SourceVersion = try stream.reader().readStruct(macho.source_version_command),
             },
+            macho.LC_BUILD_VERSION => LoadCommand{
+                .BuildVersion = try GenericCommandWithData(macho.build_version_command).read(allocator, stream.reader()),
+            },
             macho.LC_UUID => LoadCommand{
                 .Uuid = try stream.reader().readStruct(macho.uuid_command),
             },
@@ -129,6 +133,7 @@ pub const LoadCommand = union(enum) {
             .Dylinker => |x| x.write(writer),
             .Dylib => |x| x.write(writer),
             .Rpath => |x| x.write(writer),
+            .BuildVersion => |x| x.write(writer),
             .Unknown => |x| x.write(writer),
         };
     }
@@ -147,6 +152,7 @@ pub const LoadCommand = union(enum) {
             .Dylinker => |x| x.inner.cmd,
             .Dylib => |x| x.inner.cmd,
             .Rpath => |x| x.inner.cmd,
+            .BuildVersion => |x| x.inner.cmd,
             .Unknown => |x| x.inner.cmd,
         };
     }
@@ -165,6 +171,7 @@ pub const LoadCommand = union(enum) {
             .Dylinker => |x| x.inner.cmdsize,
             .Dylib => |x| x.inner.cmdsize,
             .Rpath => |x| x.inner.cmdsize,
+            .BuildVersion => |x| x.inner.cmdsize,
             .Unknown => |x| x.inner.cmdsize,
         };
     }
@@ -193,6 +200,7 @@ pub const LoadCommand = union(enum) {
             .Main => |x| meta.eql(x, other.Main),
             .VersionMin => |x| meta.eql(x, other.VersionMin),
             .SourceVersion => |x| meta.eql(x, other.SourceVersion),
+            .BuildVersion => |x| x.eql(other.BuildVersion),
             .Uuid => |x| meta.eql(x, other.Uuid),
             .LinkeditData => |x| meta.eql(x, other.LinkeditData),
             .Segment => |x| x.eql(other.Segment),

--- a/src/link/MachO/commands.zig
+++ b/src/link/MachO/commands.zig
@@ -182,6 +182,7 @@ pub const LoadCommand = union(enum) {
             .Dylinker => |*x| x.deinit(allocator),
             .Dylib => |*x| x.deinit(allocator),
             .Rpath => |*x| x.deinit(allocator),
+            .BuildVersion => |*x| x.deinit(allocator),
             .Unknown => |*x| x.deinit(allocator),
             else => {},
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -1678,7 +1678,9 @@ fn buildOutputType(
             want_native_include_dirs = true;
     }
 
-    if (sysroot == null and cross_target.isNativeOs() and
+    const is_darwin_on_darwin = (comptime std.Target.current.isDarwin()) and cross_target.isDarwin();
+
+    if (sysroot == null and (cross_target.isNativeOs() or is_darwin_on_darwin) and
         (system_libs.items.len != 0 or want_native_include_dirs))
     {
         const paths = std.zig.system.NativePaths.detect(arena, target_info) catch |err| {
@@ -1689,16 +1691,18 @@ fn buildOutputType(
         }
 
         const has_sysroot = if (comptime std.Target.current.isDarwin()) outer: {
-            const min = target_info.target.os.getVersionRange().semver.min;
-            const at_least_mojave = min.major >= 11 or (min.major >= 10 and min.minor >= 14);
-            if (at_least_mojave) {
-                const sdk_path = try std.zig.system.getSDKPath(arena);
+            const should_get_sdk_path = if (cross_target.isNativeOs() and target_info.target.os.tag == .macos) inner: {
+                const min = target_info.target.os.getVersionRange().semver.min;
+                const at_least_mojave = min.major >= 11 or (min.major >= 10 and min.minor >= 14);
+                break :inner at_least_mojave;
+            } else true;
+            if (!should_get_sdk_path) break :outer false;
+            if (try std.zig.system.darwin.getSDKPath(arena, target_info.target)) |sdk_path| {
                 try clang_argv.ensureCapacity(clang_argv.items.len + 2);
                 clang_argv.appendAssumeCapacity("-isysroot");
                 clang_argv.appendAssumeCapacity(sdk_path);
                 break :outer true;
-            }
-            break :outer false;
+            } else break :outer false;
         } else false;
 
         try clang_argv.ensureCapacity(clang_argv.items.len + paths.include_dirs.items.len * 2);

--- a/src/main.zig
+++ b/src/main.zig
@@ -830,7 +830,10 @@ fn buildOutputType(
                     } else if (mem.eql(u8, arg, "-D") or
                         mem.eql(u8, arg, "-isystem") or
                         mem.eql(u8, arg, "-I") or
-                        mem.eql(u8, arg, "-dirafter"))
+                        mem.eql(u8, arg, "-dirafter") or
+                        mem.eql(u8, arg, "-iwithsysroot") or
+                        mem.eql(u8, arg, "-iframework") or
+                        mem.eql(u8, arg, "-iframeworkwithsysroot"))
                     {
                         if (i + 1 >= args.len) fatal("expected parameter after {s}", .{arg});
                         i += 1;
@@ -873,6 +876,8 @@ fn buildOutputType(
                         if (i + 1 >= args.len) fatal("expected parameter after {s}", .{arg});
                         i += 1;
                         sysroot = args[i];
+                        try clang_argv.append("-isysroot");
+                        try clang_argv.append(args[i]);
                     } else if (mem.eql(u8, arg, "--libc")) {
                         if (i + 1 >= args.len) fatal("expected parameter after {s}", .{arg});
                         i += 1;


### PR DESCRIPTION
With this change, it is possible to successfully target iOS and iPhone Simulator platforms. See [kubkon/zig-ios-example](https://github.com/kubkon/zig-ios-example) for a complete project example how.

Major changes include:
* ensure we correctly transfer `-iwithsysroot` and `-iframeworkwithsysroot` flags with values from `build.zig` and that they are correctly transferred forward to `zig cc`
* move `std.zig.system.macos` into `std.zig.system.darwin.macos` since we now special-case all Apple platforms when building from another Apple platform (usually macOS) - `std.zig.system.darwin.getSDKPath` now takes two args as input: allocator and `Target`, and based on the target it will invoke `xcrun --sdk <sdk_name> --show-sdk-path` with the appropriate `sdk_name` such as `iphonesimulator` or `iphoneos`, etc. With this change, we make Zig auto-invoke `getSDKPath` when targeting an Apple platform from an Apple platform, meaning that we no longer constrain ourselves to running natively but also when targeting `ios` from `macos`, etc.
* try to look for `libSystem.tbd` in the provided syslibroot
* take into account `.simulator` ABI when targeting iOS - `.simulator` ABI signals that the binary is meant to be run on Apple iPhone Simulator rather than on a real device and therefore it should be linked against a completely standalone set of libraries and frameworks known as `iphonesimulator` SDK
* swap out `VERSION_MIN` load command for `BUILD_VERSION` - turns out, the latter is required to make the app get properly launched on the iPhone Simulator, while presence of the former generates a sigkill-equivalent for some reason

I could use some input here on the validity of treating `std.build.addSystemIncludeDir` and `std.build.addFrameworkDir` differently based on the presence of the sysroot on the command line - if there is no sysroot present, we convert them into `-isystem` and `-iframework`; if the sysroot is present however, we change that to `-iwithsysroot` and `-iframeworkwithsysroot`. This can trigger a weird error if we are auto-detecting sysroots by Zig (when targeting iOS for instance) and the user adds explicit system search paths to their `build.zig` as then we get conflicting search dirs for the headers which can lead to a compile error.

---

UPDATE: turns out that when linking against simulator ABI such as `aarch64-ios-simulator`, several libc functions such as `fstat`, etc., are provided by the host (`aarch64-macos`), and thus, it is necessary to take that into account when linking against tbd stubs. This has now been added in 83f1203.