### PR TITLE
Re-enable 128-bit cmpxchg test

### DIFF
--- a/test/behavior/atomics.zig
+++ b/test/behavior/atomics.zig
@@ -74,26 +74,22 @@ test "cmpxchg with ptr" {
     try expect(x == &data2);
 }
 
-// TODO this test is disabled until this issue is resolved:
-// https://github.com/ziglang/zig/issues/2883
-// otherwise cross compiling will result in:
-// lld: error: undefined symbol: __sync_val_compare_and_swap_16
-//test "128-bit cmpxchg" {
-//    var x: u128 align(16) = 1234; // TODO: https://github.com/ziglang/zig/issues/2987
-//    if (@cmpxchgWeak(u128, &x, 99, 5678, .SeqCst, .SeqCst)) |x1| {
-//        try expect(x1 == 1234);
-//    } else {
-//        @panic("cmpxchg should have failed");
-//    }
-//
-//    while (@cmpxchgWeak(u128, &x, 1234, 5678, .SeqCst, .SeqCst)) |x1| {
-//        try expect(x1 == 1234);
-//    }
-//    try expect(x == 5678);
-//
-//    try expect(@cmpxchgStrong(u128, &x, 5678, 42, .SeqCst, .SeqCst) == null);
-//    try expect(x == 42);
-//}
+test "128-bit cmpxchg" {
+   var x: u128 = 1234;
+   if (@cmpxchgWeak(u128, &x, 99, 5678, .SeqCst, .SeqCst)) |x1| {
+       try expect(x1 == 1234);
+   } else {
+       @panic("cmpxchg should have failed");
+   }
+
+   while (@cmpxchgWeak(u128, &x, 1234, 5678, .SeqCst, .SeqCst)) |x1| {
+       try expect(x1 == 1234);
+   }
+   try expect(x == 5678);
+
+   try expect(@cmpxchgStrong(u128, &x, 5678, 42, .SeqCst, .SeqCst) == null);
+   try expect(x == 42);
+}
 
 test "cmpxchg with ignored result" {
     var x: i32 = 1234;


### PR DESCRIPTION
The mentioned issues are resolved, so this can be re-enabled now(?)