### PR TITLE
Ip4Address parser: reject 0-prefixed components

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -34,6 +34,7 @@ pub const Address = extern union {
             error.InvalidEnd,
             error.InvalidCharacter,
             error.Incomplete,
+            error.NonCanonical,
             => {},
         }
 
@@ -204,6 +205,7 @@ pub const Ip4Address = extern struct {
         var x: u8 = 0;
         var index: u8 = 0;
         var saw_any_digits = false;
+        var has_zero_prefix = false;
         for (buf) |c| {
             if (c == '.') {
                 if (!saw_any_digits) {
@@ -216,7 +218,13 @@ pub const Ip4Address = extern struct {
                 index += 1;
                 x = 0;
                 saw_any_digits = false;
+                has_zero_prefix = false;
             } else if (c >= '0' and c <= '9') {
+                if (c == '0' and !saw_any_digits) {
+                    has_zero_prefix = true;
+                } else if (has_zero_prefix) {
+                    return error.NonCanonical;
+                }
                 saw_any_digits = true;
                 x = try std.math.mul(u8, x, 10);
                 x = try std.math.add(u8, x, c - '0');
@@ -1149,6 +1157,7 @@ fn linuxLookupNameFromHosts(
             error.Incomplete,
             error.InvalidIPAddressFormat,
             error.InvalidIpv4Mapping,
+            error.NonCanonical,
             => continue,
         };
         try addrs.append(LookupAddr{ .addr = addr });

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -56,6 +56,7 @@ pub const Address = extern union {
             error.InvalidEnd,
             error.InvalidCharacter,
             error.Incomplete,
+            error.NonCanonical,
             => {},
         }
 

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -92,6 +92,7 @@ test "parse and render IPv4 addresses" {
     try testing.expectError(error.InvalidEnd, net.Address.parseIp4("127.0.0.1.1", 0));
     try testing.expectError(error.Incomplete, net.Address.parseIp4("127.0.0.", 0));
     try testing.expectError(error.InvalidCharacter, net.Address.parseIp4("100..0.1", 0));
+    try testing.expectError(error.NonCanonical, net.Address.parseIp4("127.01.0.1", 0));
 }
 
 test "resolve DNS" {


### PR DESCRIPTION
Octal is hardly useful to anything besides file permissions, but aging standards still use it.

127.0.026.1 can be parsed as 127.0.22.1, not 127.0.26.1.

Some parsers support octal, some don't, and the confusion can lead to vulnerabilities.

Reject 0-prefixed IPv4 components. This align to what the Go language did to fix CVE-2021-29923.