### PR TITLE
std.time.Clock: unified time abstraction

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -1,7 +1,7 @@
 const std = @import("../std.zig");
 const assert = std.debug.assert;
 const macho = std.macho;
-const native_arch = builtin.target.cpu.arch;
+const native_arch = std.Target.current.cpu.arch;
 const maxInt = std.math.maxInt;
 const iovec_const = std.os.iovec_const;
 

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -1,6 +1,5 @@
 const std = @import("../std.zig");
 const assert = std.debug.assert;
-const builtin = @import("builtin");
 const macho = std.macho;
 const native_arch = builtin.target.cpu.arch;
 const maxInt = std.math.maxInt;
@@ -44,7 +43,8 @@ pub const fstat = if (native_arch == .aarch64) private.fstat else private.@"fsta
 pub const fstatat = if (native_arch == .aarch64) private.fstatat else private.@"fstatat$INODE64";
 
 pub extern "c" fn mach_absolute_time() u64;
-pub extern "c" fn mach_timebase_info(tinfo: ?*mach_timebase_info_data) void;
+pub extern "c" fn mach_continuous_time() u64;
+pub extern "c" fn mach_timebase_info(tinfo: ?*mach_timebase_info_data) kern_return_t;
 
 pub extern "c" fn malloc_size(?*const c_void) usize;
 pub extern "c" fn posix_memalign(memptr: *?*c_void, alignment: usize, size: usize) c_int;
@@ -206,6 +206,7 @@ pub extern "c" fn dispatch_semaphore_signal(dsema: dispatch_semaphore_t) isize;
 pub const dispatch_time_t = u64;
 pub const DISPATCH_TIME_NOW = @as(dispatch_time_t, 0);
 pub const DISPATCH_TIME_FOREVER = ~@as(dispatch_time_t, 0);
+pub const DISPATCH_MONOTONICTIME_NOW = @as(dispatch_time_t, 1 << 63); // available(macos=10.14, ios=12.0, tvos=12.0, watchos=5.00)
 pub extern "c" fn dispatch_time(when: dispatch_time_t, delta: i64) dispatch_time_t;
 
 const dispatch_once_t = usize;

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -1,7 +1,7 @@
 const std = @import("../std.zig");
 const assert = std.debug.assert;
 const macho = std.macho;
-const native_arch = std.Target.current.cpu.arch;
+const native_arch = std.builtin.target.cpu.arch;
 const maxInt = std.math.maxInt;
 const iovec_const = std.os.iovec_const;
 

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -42,6 +42,7 @@ const ULONG_PTR = windows.ULONG_PTR;
 const FILE_NOTIFY_INFORMATION = windows.FILE_NOTIFY_INFORMATION;
 const HANDLER_ROUTINE = windows.HANDLER_ROUTINE;
 const ULONG = windows.ULONG;
+const ULONGLONG = windows.ULONGLONG;
 const PVOID = windows.PVOID;
 const LPSTR = windows.LPSTR;
 const PENUM_PAGE_FILE_CALLBACKA = windows.PENUM_PAGE_FILE_CALLBACKA;

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -225,6 +225,10 @@ pub extern "kernel32" fn GetQueuedCompletionStatusEx(
 
 pub extern "kernel32" fn GetSystemInfo(lpSystemInfo: *SYSTEM_INFO) callconv(WINAPI) void;
 pub extern "kernel32" fn GetSystemTimeAsFileTime(*FILETIME) callconv(WINAPI) void;
+pub extern "kernel32" fn GetSystemTimePreciseAsFileTime(*FILETIME) callconv(WINAPI) void;
+
+pub extern "kernel32" fn GetThreadTimes(HANDLE, *FILETIME, *FILETIME, *FILETIME, *FILETIME) callconv(WINAPI) BOOL;
+pub extern "kernel32" fn GetProcessTimes(HANDLE, *FILETIME, *FILETIME, *FILETIME, *FILETIME) callconv(WINAPI) BOOL;
 
 pub extern "kernel32" fn HeapCreate(flOptions: DWORD, dwInitialSize: SIZE_T, dwMaximumSize: SIZE_T) callconv(WINAPI) ?HANDLE;
 pub extern "kernel32" fn HeapDestroy(hHeap: HANDLE) callconv(WINAPI) BOOL;

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -259,8 +259,10 @@ pub extern "kernel32" fn MoveFileExW(
 pub extern "kernel32" fn PostQueuedCompletionStatus(CompletionPort: HANDLE, dwNumberOfBytesTransferred: DWORD, dwCompletionKey: ULONG_PTR, lpOverlapped: ?*OVERLAPPED) callconv(WINAPI) BOOL;
 
 pub extern "kernel32" fn QueryPerformanceCounter(lpPerformanceCount: *LARGE_INTEGER) callconv(WINAPI) BOOL;
-
 pub extern "kernel32" fn QueryPerformanceFrequency(lpFrequency: *LARGE_INTEGER) callconv(WINAPI) BOOL;
+
+pub extern "kernel32" fn QueryInterruptTimePrecise(lpPrecise: *ULONGLONG) callconv(WINAPI) void;
+pub extern "kernel32" fn QueryUnbiasedInterruptTimePrecise(lpPrecise: *ULONGLONG) callconv(WINAPI) void;
 
 pub extern "kernel32" fn ReadDirectoryChangesW(
     hDirectory: HANDLE,

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -4,7 +4,7 @@ const assert = std.debug.assert;
 const testing = std.testing;
 const os = std.os;
 const math = std.math;
-const target = std.Target.current;
+const target = builtin.target;
 
 pub const epoch = @import("time/epoch.zig");
 
@@ -169,8 +169,8 @@ pub const Timer = struct {
     }
 
     /// Returns the current value of the Timer's clock.
-    /// Should not error out since the existence of the clock was checked at start().
     fn clockNative() i128 {
+        // Must not fail since existence of the clock was checked at start().
         return Clock.read(clock_id) catch unreachable;
     }
 
@@ -265,7 +265,7 @@ pub const Clock = struct {
                     // At some point we may change our minds on CLOCK.MONOTONIC_RAW,
                     // but for now we're sticking with CLOCK.MONOTONIC standard.
                     // For more information, see: https://github.com/ziglang/zig/pull/933
-                    .linux => os.CLOCK.MONOTONIC, // doesn't count time suspended
+                    .linux => os.CLOCK.MONOTONIC,
                     // Platforms like wasi and netbsd don't support getting time without suspend
                     else => null,
                 },

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -249,28 +249,28 @@ pub const Clock = struct {
         // https://www.freebsd.org/cgi/man.cgi?query=clock_gettime
         fn toOsClockId(id: Id) ?i32 {
             return switch (id) {
-                .realtime => os.CLOCK_REALTIME,
+                .realtime => os.CLOCK.REALTIME,
                 .monotonic => switch (target.os.tag) {
                     // Calls mach_continuous_time() internally
-                    .macos, .tvos, .ios, .watchos => os.CLOCK_MONOTONIC_RAW,
-                    // Unlike CLOCK_MONOTONIC, this actually counts time suspended (true POSIX MONOTONIC)
-                    .linux => os.CLOCK_BOOTTIME,
-                    else => os.CLOCK_MONOTONIC,
+                    .macos, .tvos, .ios, .watchos => os.CLOCK.MONOTONIC_RAW,
+                    // Unlike CLOCK.MONOTONIC, this actually counts time suspended (true POSIX MONOTONIC)
+                    .linux => os.CLOCK.BOOTTIME,
+                    else => os.CLOCK.MONOTONIC,
                 },
                 .uptime => switch (target.os.tag) {
-                    .openbsd, .freebsd, .kfreebsd, .dragonfly => os.CLOCK_UPTIME,
+                    .openbsd, .freebsd, .kfreebsd, .dragonfly => os.CLOCK.UPTIME,
                     // Calls mach_absolute_time() internally
-                    .macos, .tvos, .ios, .watchos => os.CLOCK_UPTIME_RAW,
-                    // CLOCK_MONOTONIC on linux actually doesn't count time suspended (not POSIX compliant).
-                    // At some point we may change our minds on CLOCK_MONOTONIC_RAW,
-                    // but for now we're sticking with CLOCK_MONOTONIC standard.
+                    .macos, .tvos, .ios, .watchos => os.CLOCK.UPTIME_RAW,
+                    // CLOCK.MONOTONIC on linux actually doesn't count time suspended (not POSIX compliant).
+                    // At some point we may change our minds on CLOCK.MONOTONIC_RAW,
+                    // but for now we're sticking with CLOCK.MONOTONIC standard.
                     // For more information, see: https://github.com/ziglang/zig/pull/933
-                    .linux => os.CLOCK_MONOTONIC, // doesn't count time suspended
+                    .linux => os.CLOCK.MONOTONIC, // doesn't count time suspended
                     // Platforms like wasi and netbsd don't support getting time without suspend
                     else => null,
                 },
-                .thread_cputime => os.CLOCK_THREAD_CPUTIME_ID,
-                .process_cputime => os.CLOCK_PROCESS_CPUTIME_ID,
+                .thread_cputime => os.CLOCK.THREAD_CPUTIME_ID,
+                .process_cputime => os.CLOCK.PROCESS_CPUTIME_ID,
             };
         }
     };

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -260,7 +260,7 @@ pub const Clock = struct {
                 .monotonic => getInterruptTime(),
                 .uptime => getUnbiasedInterruptTime(),
                 .thread_cputime => getCpuTime("GetThreadTimes", "GetCurrentThread"),
-                .thread_cputime => getCpuTime("GetProcessTimes", "GetCurrentProcess"),
+                .process_cputime => getCpuTime("GetProcessTimes", "GetCurrentProcess"),
             };
         }
 
@@ -353,8 +353,8 @@ pub const Clock = struct {
 
                 fn initDeltaOnce(once: *os.windows.INIT_ONCE, param: ?*c_void, ctx: ?*c_void) callconv(.C) void {
                     _ = .{ once, ctx };
-                    const current = @ptrCast(*u64, @alignCast(@alignOf(u64), param)).*;
-                    delta.storeUnchecked(current);
+                    const current_ptr = @ptrCast(*u64, @alignCast(@alignOf(u64), param));
+                    delta.storeUnchecked(current_ptr.*);
                 }
             };
 

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -58,26 +58,32 @@ test "sleep" {
 
 /// Get a calendar timestamp, in seconds, relative to UTC 1970-01-01.
 /// Precision of timing depends on the hardware and operating system.
+/// The return value is signed because it is possible to have a date that is
+/// before the epoch.
 /// See `std.os.clock_gettime` for a POSIX timestamp.
-pub fn timestamp() u64 {
+pub fn timestamp() i64 {
     return @divFloor(milliTimestamp(), ms_per_s);
 }
 
 /// Get a calendar timestamp, in milliseconds, relative to UTC 1970-01-01.
 /// Precision of timing depends on the hardware and operating system.
+/// The return value is signed because it is possible to have a date that is
+/// before the epoch.
 /// See `std.os.clock_gettime` for a POSIX timestamp.
-pub fn milliTimestamp() u64 {
-    return @divFloor(nanoTimestamp(), ns_per_ms);
+pub fn milliTimestamp() i64 {
+    return @intCast(i64, @divFloor(nanoTimestamp(), ns_per_ms));
 }
 
 /// Get a calendar timestamp, in nanoseconds, relative to UTC 1970-01-01.
 /// Precision of timing depends on the hardware and operating system.
+/// The return value is signed because it is possible to have a date that is
+/// before the epoch.
 /// On Windows this has a maximum granularity of 100 nanoseconds.
 /// See `std.os.clock_gettime` for a POSIX timestamp.
-pub fn nanoTimestamp() u64 {
-    return Clock.read(.realtime) catch {
+pub fn nanoTimestamp() i128 {
+    return Clock.read(.realtime) catch |err| switch (err) {
         // "Precision of timing depends on hardware and OS".
-        return 0;
+        error.UnsupportedClock, error.Unexpected => 0,
     };
 }
 
@@ -125,47 +131,57 @@ pub const s_per_week = s_per_day * 7;
 
 /// A high-performance timer that tries to be monotonically increasing.
 /// Timer.start() must be called to initialize the struct, which gives 
-/// the user an opportunity to check for the existnece of monotonic clocks 
-/// without forcing them to check for error on each read.
+/// the user an opportunity to check for the existence of such timers 
+/// without forcing them to check for an error on each read.
 pub const Timer = struct {
-    start_time: u64,
+    start_time: i128,
 
     pub const Error = error{TimerUnsupported};
 
-    /// At some point we may change our minds, but for now we're
-    /// sticking with posix standard MONOTONIC.
-    /// For more information, see: https://github.com/ziglang/zig/pull/933
+    // This is a clock source which is supported on most platforms and is mostly monotonic.
     const clock_id = Clock.Id.monotonic;
 
     /// Initialize the timer structure.
     pub fn start() Error!Timer {
-        // We assume that if the system is blocking us from using clock_gettime
+        // We assume that if the system is blocking us from using the Clock
         // (i.e. with use of linux seccomp), it should at least block us consistently.
-        const start_time = Clock.read(clock_id) catch return error.TimerUnsupported;
-        return Timer{ .start_time = start_time };
+        return Timer{
+            .start_time = Clock.read(clock_id) catch return error.TimerUnsupported,
+        };
     }
 
     /// Reads the timer value since start or the last reset in nanoseconds
     pub fn read(self: Timer) u64 {
-        const current = Clock.read(clock_id) catch 0;
-        if (current < self.start_time) return 0;
-        return current - self.start_time;
+        const current = clockNative();
+        return self.toDurationNanos(current);
     }
 
     /// Resets the timer value to 0/now.
     pub fn reset(self: *Timer) void {
-        self.start_time = Clock.read(clock_id) catch 0;
+        self.start_time = clockNative();
     }
 
     /// Returns the current value of the timer in nanoseconds, then resets it
     pub fn lap(self: *Timer) u64 {
-        const current = Clock.read(clock_id) catch 0;
-        defer if (current > self.start_time) {
-            self.start_time = current;
-        };
+        const current = clockNative();
+        defer self.start_time = current;
+        return self.toDurationNanos(current);
+    }
 
+    /// Returns the current value of the Timer's clock.
+    /// Should not error out since the existence of the clock was checked at start().
+    fn clockNative() i128 {
+        return Clock.read(clock_id) catch unreachable;
+    }
+
+    /// Converts a reading from the Timer's clock to nanoseconds since the start_time.
+    fn toDurationNanos(self: Timer, current: i128) u64 {
+        // Handle cases where the clock goes backwards
         if (current < self.start_time) return 0;
-        return current - self.start_time;
+
+        // Saturating subtraction from the current time to handle overflows.
+        const duration = current - self.start_time;
+        return std.math.cast(u64, duration) catch std.math.maxInt(u64);
     }
 };
 
@@ -205,7 +221,7 @@ pub const Clock = struct {
     pub const Error = error{UnsupportedClock} || os.UnexpectedError;
 
     /// Reads the current value of the clock source represented by the `id`.
-    pub fn read(id: Id) Error!u64 {
+    pub fn read(id: Id) Error!i128 {
         return Impl.read(id);
     }
 
@@ -215,11 +231,11 @@ pub const Clock = struct {
     };
 
     const PosixImpl = struct {
-        pub fn read(id: Id) Error!u64 {
+        pub fn read(id: Id) Error!i128 {
             const clock_id = toOsClockId(id) orelse return error.UnsupportedClock;
             var ts: os.timespec = undefined;
             try os.clock_gettime(clock_id, &ts);
-            return @intCast(u64, ts.tv_sec) * ns_per_s + @intCast(u64, ts.tv_nsec);
+            return (@as(i128, ts.tv_sec) * ns_per_s) + ts.tv_nsec;
         }
 
         // https://github.com/polazarus/oclock-testing/blob/master/docs/clock_gettime.md
@@ -235,15 +251,23 @@ pub const Clock = struct {
             return switch (id) {
                 .realtime => os.CLOCK_REALTIME,
                 .monotonic => switch (target.os.tag) {
-                    .macos, .tvos, .ios, .watchos => os.CLOCK_MONOTONIC_RAW, // mach_continuous_time
-                    .linux => os.CLOCK_BOOTTIME, // actually counts time suspended
+                    // Calls mach_continuous_time() internally
+                    .macos, .tvos, .ios, .watchos => os.CLOCK_MONOTONIC_RAW,
+                    // Unlike CLOCK_MONOTONIC, this actually counts time suspended (true POSIX MONOTONIC)
+                    .linux => os.CLOCK_BOOTTIME,
                     else => os.CLOCK_MONOTONIC,
                 },
                 .uptime => switch (target.os.tag) {
                     .openbsd, .freebsd, .kfreebsd, .dragonfly => os.CLOCK_UPTIME,
-                    .macos, .tvos, .ios, .watchos => os.CLOCK_UPTIME_RAW, // mach_absolute_time
+                    // Calls mach_absolute_time() internally
+                    .macos, .tvos, .ios, .watchos => os.CLOCK_UPTIME_RAW,
+                    // CLOCK_MONOTONIC on linux actually doesn't count time suspended (not POSIX compliant).
+                    // At some point we may change our minds on CLOCK_MONOTONIC_RAW.
+                    // but for now we're sticking with CLOCK_MONOTONIC standard.
+                    // For more information, see: https://github.com/ziglang/zig/pull/933
                     .linux => os.CLOCK_MONOTONIC, // doesn't count time suspended
-                    else => null,
+                    // wasi and netbsd don't support getting time without suspend
+                    else => null, 
                 },
                 .thread_cputime => os.CLOCK_THREAD_CPUTIME_ID,
                 .process_cputime => os.CLOCK_PROCESS_CPUTIME_ID,
@@ -252,7 +276,9 @@ pub const Clock = struct {
     };
 
     const WindowsImpl = struct {
-        pub fn read(id: Id) Error!u64 {
+        const is_windows_10 = target.os.isAtLeast(.windows, .win10) orelse false;
+
+        pub fn read(id: Id) Error!i128 {
             return switch (id) {
                 .realtime => getSystemTime(),
                 .monotonic => getInterruptTime(),
@@ -262,34 +288,47 @@ pub const Clock = struct {
             };
         }
 
-        fn getSystemTime() u64 {
+        fn getSystemTime() i128 {
             var ft: os.windows.FILETIME = undefined;
             os.windows.kernel32.GetSystemTimePreciseAsFileTime(&ft);
-            var system_time = (@as(u64, ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+            const ft64 = (@as(u64, ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
 
-            // Returns 0 if the current time is before the Unix Epoch (Jan 1 1970).
-            // This can happen since windows' starting epoch is Jan 01, 1601.
-            const utc_epoch = -(epoch.windows * (ns_per_s / 100));
-            if (system_time <= utc_epoch) {
-                return 0;
+            // FileTime has a granularity of 100ns and uses the NTFS/Windows epoch
+            // which is 1601-01-01
+            const epoch_adj = epoch.windows * (ns_per_s / 100);
+            return @as(i128, @bitCast(i64, ft64) + epoch_adj) * 100;
+        }
+
+        fn getInterruptTime() i128 {
+            // TODO: Disabled for now as lld-link fails to find the symbol
+            //
+            // Use the QueryInterruptTimePrecise() function when available.
+            // Don't use the non-Precise variant as it's less granular (0.5ms-16ms) than QPC (<=1us)
+            // https://docs.microsoft.com/en-us/windows/win32/api/realtimeapiset/nf-realtimeapiset-queryinterrupttimeprecise#remarks
+            if (false and is_windows_10) {
+                var interrupt_time: os.windows.ULONGLONG = undefined;
+                os.windows.kernel32.QueryInterruptTimePrecise(&interrupt_time);
+                return interrupt_time * 100;
             }
 
-            const utc_now = system_time - utc_epoch;
-            return utc_now * 100;
-        }
-
-        /// Could be replaced with QueryInterruptTimePrecise() (only on Windows 10+)
-        fn getInterruptTime() u64 {
             const counter = os.windows.QueryPerformanceCounter();
-            const qpc = getDeltaTime(struct {}, counter);
-            return getQPCInterruptTime(qpc) * 100;
+            return getQPCInterruptTime(counter, 0);
         }
 
-        /// Could be replaced with kernel32.QueryUnbiasedInterruptTimePrecise() (only on Windows 10+)
-        fn getUnbiasedInterruptTime() u64 {
+        fn getUnbiasedInterruptTime() i128 {
+            // TODO: Disabled for now as lld-link fails to find the symbol
+            //
+            // Use the QueryUnbiasedInterruptTimePrecise() functions when available.
+            // Don't use the non-Precise variant as it's less granular (0.5ms-16ms) than QPC (<=1us)
+            // https://docs.microsoft.com/en-us/windows/win32/api/realtimeapiset/nf-realtimeapiset-queryinterrupttimeprecise#remarks
+            if (false and is_windows_10) {
+                var interrupt_time: os.windows.ULONGLONG = undefined;
+                os.windows.kernel32.QueryUnbiasedInterruptTimePrecise(&interrupt_time);
+                return interrupt_time * 100;
+            }
+
             // Compute the unbiased (without suspend) time by sampling the current interrupt time
             // then subtracting the InterruptTimeBias while accounting for possibly suspending mid-sample.
-            //
             // https://stackoverflow.com/questions/24330496/how-do-i-create-monotonic-clock-on-windows-which-doesnt-tick-during-suspend
             // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntexapi_x/kuser_shared_data/index.htm
             const KUSER_SHARED_DATA = 0x7ffe0000;
@@ -298,97 +337,45 @@ pub const Clock = struct {
             while (true) {
                 const bias = InterruptTimeBias.*;
                 const counter = os.windows.QueryPerformanceCounter();
-                if (bias != InterruptTimeBias.*) {
-                    continue;
+                if (bias == InterruptTimeBias.*) {
+                    return getQPCInterruptTime(counter, bias);
                 }
-
-                const qpc = getDeltaTime(struct {}, counter);
-                const qpc_bias = getDeltaTime(struct {}, bias);
-                return (getQPCInterruptTime(qpc) - qpc_bias) * 100;
             }
         }
 
-        fn getQPCInterruptTime(qpc: u64) u64 {
-            // doesn't need to be cached. It just reads from KUSER_SHARED_DATA:
+        fn getQPCInterruptTime(qpc: u64, bias: u64) i128 {
+            // QueryPerofrmanceFrequency() doesn't need to be cached. 
+            // It just reads from KUSER_SHARED_DATA.
             // See the QpcFrequency offset in:
             // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntexapi_x/kuser_shared_data/index.htm
             const frequency = os.windows.QueryPerformanceFrequency();
 
-            // Interrupt time in units of 100ns
+            // Convert QPC in units of 100ns since this is the granularity of InterruptTimeBias.
             const scale = ns_per_s / 100;
 
-            // Try to do qpc * scale / frequency
-            var qpc_scaled: u64 = undefined;
-            if (!@mulWithOverflow(u64, qpc, scale, &qpc_scaled)) {
-                return qpc_scaled / frequency;
-            }
-
-            // Does qpc * scale / frequency without overflowing too early
-            const div = qpc / frequency;
-            const rem = qpc % frequency;
-            return (div * scale) + (rem * scale) / frequency;
-        }
-
-        /// Globally caches the first `current` supplied using `UniqueType` as a key.
-        /// Future calls with the same `UniqueType` return the saturating difference 
-        /// between their given `current` and the first cached `current`.
-        ///
-        /// ```
-        /// cached = globals[UniqueType]
-        /// if cached == 0:
-        ///     cached = globals[UniqueType] = current
-        /// if current < cached:
-        ///     return 0
-        /// return current - cached
-        /// ```
-        fn getDeltaTime(comptime UniqueType: type, current: u64) u64 {
-            _ = UniqueType;
-
-            const Atomic = std.atomic.Atomic;
-            const Static = struct {
-                var delta = Atomic(u64).init(0);
-                var delta_once = os.windows.INIT_ONCE_STATIC_INIT;
-
-                fn initDeltaOnce(once: *os.windows.INIT_ONCE, param: ?*c_void, ctx: ?*c_void) callconv(.C) os.windows.BOOL {
-                    _ = once;
-                    _ = ctx;
-                    const current_ptr = @ptrCast(*u64, @alignCast(@alignOf(u64), param));
-                    delta.storeUnchecked(current_ptr.*);
-                    return os.windows.TRUE;
-                }
-            };
-
-            const delta = blk: {
-                // Use 64bit atomics when available to set delta if it hasn't been already
-                if (@sizeOf(usize) >= @sizeOf(u64)) {
-                    const delta = Static.delta.load(.Monotonic);
-                    if (delta != 0) break :blk delta;
-                    break :blk Static.delta.compareAndSwap(
-                        delta,
-                        current,
-                        .Monotonic,
-                        .Monotonic,
-                    ) orelse current;
+            // Performs (qpc * scale) / frequency without overflow.
+            var interrupt_time = blk: {
+                const overflow_limit = @divFloor(std.math.maxInt(u64), scale);
+                if (qpc <= overflow_limit) {
+                    break :blk (qpc * scale) / frequency;
                 }
 
-                // 64bit atomics aren't supported. Use INIT_ONCE instead
-                var init_with = current;
-                os.windows.InitOnceExecuteOnce(
-                    &Static.delta_once,
-                    Static.initDeltaOnce,
-                    @ptrCast(*c_void, &init_with),
-                    null,
-                );
-                break :blk Static.delta.loadUnchecked();
+                // Computes (qpc * scale) / frequency without overflow
+                // as long as both (scale * frequency) and the final result fit into an i64
+                // which should be the case for time conversions with QPC.
+                const quotient = qpc / frequency;
+                const remainder = qpc % frequency;
+                break :blk (quotient * scale) + (remainder * scale) / frequency;
             };
 
-            if (current < delta) return 0;
-            return current - delta;
+            // Finally subtract the bias (zero for .monotonic) and scale back up to nanoseconds
+            interrupt_time -= bias;
+            return interrupt_time * 100;
         }
 
         /// Calls either GetThreadTimes or GetProcessTimes and returns
         /// the amount of nanoseconds spent in userspace and the the kernel.
-        fn getCpuTime(comptime GetTimesFn: []const u8, comptime GetCurrentFn: []const u8) !u64 {
+        fn getCpuTime(comptime GetTimesFn: []const u8, comptime GetCurrentFn: []const u8) !i128 {
             var creation_time: os.windows.FILETIME = undefined;
             var exit_time: os.windows.FILETIME = undefined;
             var kernel_time: os.windows.FILETIME = undefined;
@@ -407,7 +394,7 @@ pub const Clock = struct {
                 return os.windows.unexpectedError(err);
             }
 
-            var cpu_time = (@as(u64, kernel_time.dwHighDateTime) << 32) | kernel_time.dwLowDateTime;
+            var cpu_time: i128 = (@as(u64, kernel_time.dwHighDateTime) << 32) | kernel_time.dwLowDateTime;
             cpu_time += (@as(u64, user_time.dwHighDateTime) << 32) | user_time.dwLowDateTime;
             return cpu_time * 100;
         }
@@ -415,20 +402,14 @@ pub const Clock = struct {
 };
 
 test "Clock" {
-    comptime var clock_ids: []const Clock.Id = &[_]Clock.Id{};
     inline for (std.meta.fields(Clock.Id)) |field| {
         const clock_id = @field(Clock.Id, field.name);
-        clock_ids = clock_ids ++ [_]Clock.Id{clock_id};
-    }
 
-    for (clock_ids) |clock_id| {
-        _ = Clock.read(clock_id) catch |err| {
-            // Only return errors for clock sources that we use personally.
-            // The rest are just tested for their code paths
-            switch (clock_id) {
-                .realtime, .monotonic => return err,
-                else => continue,
-            }
+        // Only return errors for clock sources that we use personally.
+        // The rest are just tested for their code paths
+        _ = switch (clock_id) {
+            .realtime, .monotonic => try Clock.read(clock_id),
+            else => Clock.read(clock_id) catch undefined,
         };
     }
 }

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -262,11 +262,11 @@ pub const Clock = struct {
                     // Calls mach_absolute_time() internally
                     .macos, .tvos, .ios, .watchos => os.CLOCK_UPTIME_RAW,
                     // CLOCK_MONOTONIC on linux actually doesn't count time suspended (not POSIX compliant).
-                    // At some point we may change our minds on CLOCK_MONOTONIC_RAW.
+                    // At some point we may change our minds on CLOCK_MONOTONIC_RAW,
                     // but for now we're sticking with CLOCK_MONOTONIC standard.
                     // For more information, see: https://github.com/ziglang/zig/pull/933
                     .linux => os.CLOCK_MONOTONIC, // doesn't count time suspended
-                    // wasi and netbsd don't support getting time without suspend
+                    // Platforms like wasi and netbsd don't support getting time without suspend
                     else => null,
                 },
                 .thread_cputime => os.CLOCK_THREAD_CPUTIME_ID,

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -4,23 +4,25 @@ const assert = std.debug.assert;
 const testing = std.testing;
 const os = std.os;
 const math = std.math;
-const is_windows = std.Target.current.os.tag == .windows;
+const target = std.Target.current;
 
 pub const epoch = @import("time/epoch.zig");
 
 /// Spurious wakeups are possible and no precision of timing is guaranteed.
 pub fn sleep(nanoseconds: u64) void {
     // TODO: opting out of async sleeping?
-    if (std.io.is_async)
+    if (std.io.is_async) {
         return std.event.Loop.instance.?.sleep(nanoseconds);
+    }
 
-    if (is_windows) {
+    if (target.os.tag == .windows) {
         const big_ms_from_ns = nanoseconds / ns_per_ms;
         const ms = math.cast(os.windows.DWORD, big_ms_from_ns) catch math.maxInt(os.windows.DWORD);
         os.windows.kernel32.Sleep(ms);
         return;
     }
-    if (builtin.os.tag == .wasi) {
+
+    if (target.os.tag == .wasi) {
         const w = std.os.wasi;
         const userdata: w.userdata_t = 0x0123_45678;
         const clock = w.subscription_clock_t{
@@ -50,51 +52,45 @@ pub fn sleep(nanoseconds: u64) void {
     std.os.nanosleep(s, ns);
 }
 
+test "sleep" {
+    sleep(1);
+}
+
 /// Get a calendar timestamp, in seconds, relative to UTC 1970-01-01.
 /// Precision of timing depends on the hardware and operating system.
-/// The return value is signed because it is possible to have a date that is
-/// before the epoch.
 /// See `std.os.clock_gettime` for a POSIX timestamp.
-pub fn timestamp() i64 {
+pub fn timestamp() u64 {
     return @divFloor(milliTimestamp(), ms_per_s);
 }
 
 /// Get a calendar timestamp, in milliseconds, relative to UTC 1970-01-01.
 /// Precision of timing depends on the hardware and operating system.
-/// The return value is signed because it is possible to have a date that is
-/// before the epoch.
 /// See `std.os.clock_gettime` for a POSIX timestamp.
-pub fn milliTimestamp() i64 {
-    return @intCast(i64, @divFloor(nanoTimestamp(), ns_per_ms));
+pub fn milliTimestamp() u64 {
+    return @divFloor(nanoTimestamp(), ns_per_ms);
 }
 
 /// Get a calendar timestamp, in nanoseconds, relative to UTC 1970-01-01.
 /// Precision of timing depends on the hardware and operating system.
 /// On Windows this has a maximum granularity of 100 nanoseconds.
-/// The return value is signed because it is possible to have a date that is
-/// before the epoch.
 /// See `std.os.clock_gettime` for a POSIX timestamp.
-pub fn nanoTimestamp() i128 {
-    if (is_windows) {
-        // FileTime has a granularity of 100 nanoseconds and uses the NTFS/Windows epoch,
-        // which is 1601-01-01.
-        const epoch_adj = epoch.windows * (ns_per_s / 100);
-        var ft: os.windows.FILETIME = undefined;
-        os.windows.kernel32.GetSystemTimeAsFileTime(&ft);
-        const ft64 = (@as(u64, ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
-        return @as(i128, @bitCast(i64, ft64) + epoch_adj) * 100;
-    }
-    if (builtin.os.tag == .wasi and !builtin.link_libc) {
-        var ns: os.wasi.timestamp_t = undefined;
-        const err = os.wasi.clock_time_get(os.wasi.CLOCK.REALTIME, 1, &ns);
-        assert(err == .SUCCESS);
-        return ns;
-    }
-    var ts: os.timespec = undefined;
-    os.clock_gettime(os.CLOCK.REALTIME, &ts) catch |err| switch (err) {
-        error.UnsupportedClock, error.Unexpected => return 0, // "Precision of timing depends on hardware and OS".
+pub fn nanoTimestamp() u64 {
+    return Clock.read(.realtime) catch {
+        // "Precision of timing depends on hardware and OS".
+        return 0;
     };
-    return (@as(i128, ts.tv_sec) * ns_per_s) + ts.tv_nsec;
+}
+
+test "timestamp" {
+    const margin = ns_per_ms * 50;
+
+    const time_0 = milliTimestamp();
+    sleep(ns_per_ms);
+    const time_1 = milliTimestamp();
+    const interval = time_1 - time_0;
+    try testing.expect(interval > 0);
+    // Tests should not depend on timings: skip test if outside margin.
+    if (!(interval < margin)) return error.SkipZigTest;
 }
 
 // Divisions of a nanosecond.
@@ -127,147 +123,51 @@ pub const s_per_hour = s_per_min * 60;
 pub const s_per_day = s_per_hour * 24;
 pub const s_per_week = s_per_day * 7;
 
-/// A monotonic high-performance timer.
-/// Timer.start() must be called to initialize the struct, which captures
-/// the counter frequency on windows and darwin, records the resolution,
-/// and gives the user an opportunity to check for the existnece of
-/// monotonic clocks without forcing them to check for error on each read.
-/// .resolution is in nanoseconds on all platforms but .start_time's meaning
-/// depends on the OS. On Windows and Darwin it is a hardware counter
-/// value that requires calculation to convert to a meaninful unit.
+/// A high-performance timer that tries to be monotonically increasing.
+/// Timer.start() must be called to initialize the struct, which gives 
+/// the user an opportunity to check for the existnece of monotonic clocks 
+/// without forcing them to check for error on each read.
 pub const Timer = struct {
-    ///if we used resolution's value when performing the
-    ///  performance counter calc on windows/darwin, it would
-    ///  be less precise
-    frequency: switch (builtin.os.tag) {
-        .windows => u64,
-        .macos, .ios, .tvos, .watchos => os.darwin.mach_timebase_info_data,
-        else => void,
-    },
-    resolution: u64,
     start_time: u64,
 
     pub const Error = error{TimerUnsupported};
 
-    /// At some point we may change our minds on RAW, but for now we're
-    /// sticking with posix standard MONOTONIC. For more information, see:
-    /// https://github.com/ziglang/zig/pull/933
-    const monotonic_clock_id = os.CLOCK.MONOTONIC;
+    /// At some point we may change our minds, but for now we're
+    /// sticking with posix standard MONOTONIC.
+    /// For more information, see: https://github.com/ziglang/zig/pull/933
+    const clock_id = Clock.Id.monotonic;
 
     /// Initialize the timer structure.
-    /// Can only fail when running in a hostile environment that intentionally injects
-    /// error values into syscalls, such as using seccomp on Linux to intercept
-    /// `clock_gettime`.
     pub fn start() Error!Timer {
-        // This gives us an opportunity to grab the counter frequency in windows.
-        // On Windows: QueryPerformanceCounter will succeed on anything >= XP/2000.
-        // On Posix: CLOCK.MONOTONIC will only fail if the monotonic counter is not
-        // supported, or if the timespec pointer is out of bounds, which should be
-        // impossible here barring cosmic rays or other such occurrences of
-        // incredibly bad luck.
-        // On Darwin: This cannot fail, as far as I am able to tell.
-        if (is_windows) {
-            const freq = os.windows.QueryPerformanceFrequency();
-            return Timer{
-                .frequency = freq,
-                .resolution = @divFloor(ns_per_s, freq),
-                .start_time = os.windows.QueryPerformanceCounter(),
-            };
-        } else if (comptime std.Target.current.isDarwin()) {
-            var freq: os.darwin.mach_timebase_info_data = undefined;
-            os.darwin.mach_timebase_info(&freq);
-
-            return Timer{
-                .frequency = freq,
-                .resolution = @divFloor(freq.numer, freq.denom),
-                .start_time = os.darwin.mach_absolute_time(),
-            };
-        } else {
-            // On Linux, seccomp can do arbitrary things to our ability to call
-            // syscalls, including return any errno value it wants and
-            // inconsistently throwing errors. Since we can't account for
-            // abuses of seccomp in a reasonable way, we'll assume that if
-            // seccomp is going to block us it will at least do so consistently
-            var res: os.timespec = undefined;
-            os.clock_getres(monotonic_clock_id, &res) catch return error.TimerUnsupported;
-
-            var ts: os.timespec = undefined;
-            os.clock_gettime(monotonic_clock_id, &ts) catch return error.TimerUnsupported;
-
-            return Timer{
-                .resolution = @intCast(u64, res.tv_sec) * ns_per_s + @intCast(u64, res.tv_nsec),
-                .start_time = @intCast(u64, ts.tv_sec) * ns_per_s + @intCast(u64, ts.tv_nsec),
-                .frequency = {},
-            };
-        }
+        // We assume that if the system is blocking us from using clock_gettime
+        // (i.e. with use of linux seccomp), it should at least block us consistently.
+        const start_time = Clock.read(clock_id) catch return error.TimerUnsupported;
+        return Timer{ .start_time = start_time };
     }
 
     /// Reads the timer value since start or the last reset in nanoseconds
     pub fn read(self: Timer) u64 {
-        var clock = clockNative() - self.start_time;
-        return self.nativeDurationToNanos(clock);
+        const current = Clock.read(clock_id) catch 0;
+        if (current < self.start_time) return 0;
+        return current - self.start_time;
     }
 
     /// Resets the timer value to 0/now.
     pub fn reset(self: *Timer) void {
-        self.start_time = clockNative();
+        self.start_time = Clock.read(clock_id) catch 0;
     }
 
     /// Returns the current value of the timer in nanoseconds, then resets it
     pub fn lap(self: *Timer) u64 {
-        var now = clockNative();
-        var lap_time = self.nativeDurationToNanos(now - self.start_time);
-        self.start_time = now;
-        return lap_time;
-    }
+        const current = Clock.read(clock_id) catch 0;
+        defer if (current > self.start_time) {
+            self.start_time = current;
+        };
 
-    fn clockNative() u64 {
-        if (is_windows) {
-            return os.windows.QueryPerformanceCounter();
-        }
-        if (comptime std.Target.current.isDarwin()) {
-            return os.darwin.mach_absolute_time();
-        }
-        var ts: os.timespec = undefined;
-        os.clock_gettime(monotonic_clock_id, &ts) catch unreachable;
-        return @intCast(u64, ts.tv_sec) * @as(u64, ns_per_s) + @intCast(u64, ts.tv_nsec);
-    }
-
-    fn nativeDurationToNanos(self: Timer, duration: u64) u64 {
-        if (is_windows) {
-            return safeMulDiv(duration, ns_per_s, self.frequency);
-        }
-        if (comptime std.Target.current.isDarwin()) {
-            return safeMulDiv(duration, self.frequency.numer, self.frequency.denom);
-        }
-        return duration;
+        if (current < self.start_time) return 0;
+        return current - self.start_time;
     }
 };
-
-// Calculate (a * b) / c without risk of overflowing too early because of the
-// multiplication.
-fn safeMulDiv(a: u64, b: u64, c: u64) u64 {
-    const q = a / c;
-    const r = a % c;
-    // (a * b) / c == (a / c) * b + ((a % c) * b) / c
-    return (q * b) + (r * b) / c;
-}
-
-test "sleep" {
-    sleep(1);
-}
-
-test "timestamp" {
-    const margin = ns_per_ms * 50;
-
-    const time_0 = milliTimestamp();
-    sleep(ns_per_ms);
-    const time_1 = milliTimestamp();
-    const interval = time_1 - time_0;
-    try testing.expect(interval > 0);
-    // Tests should not depend on timings: skip test if outside margin.
-    if (!(interval < margin)) return error.SkipZigTest;
-}
 
 test "Timer" {
     const margin = ns_per_ms * 150;
@@ -284,4 +184,233 @@ test "Timer" {
 
     timer.reset();
     try testing.expect(timer.read() < time_1);
+}
+
+pub const Clock = struct {
+    pub const Id = enum {
+        /// Returns nanoseconds since Unix Epoch (Jan 1 1970)
+        realtime,
+        /// Returns nanoseconds since an arbitrary point in time. Increments while suspended
+        monotonic,
+        /// Returns nanoseconds since an arbitrary point in time. Pauses while suspended.
+        uptime,
+        /// Returns nanoseconds of cpu time spent by the caller's thread.
+        thread_cputime,
+        /// Returns nanoseconds of cpu time spent all threads in the caller's process
+        process_cputime,
+    };
+
+    pub const Error = error{
+        UnsupportedClock
+    } || os.UnexpectedError;
+
+    pub fn read(id: Id) Error!u64 {
+        return Impl.read(id);
+    }
+
+    const Impl = switch (target.os.tag) {
+        .windows => WindowsImpl,
+        else => PosixImpl,
+    };
+
+    const PosixImpl = struct {
+        pub fn read(id: Id) Error!u64 {
+            const clock_id = toOsClockId(id) orelse return error.UnsupportedClock;
+            var ts: os.timespec = undefined;
+            try os.clock_gettime(clock_id, &ts);
+            return @intCast(u64, ts.tv_sec) * ns_per_s + @intCast(u64, ts.tv_nsec);
+        }
+
+        // https://github.com/polazarus/oclock-testing/blob/master/docs/clock_gettime.md
+        //
+        // https://linux.die.net/man/2/clock_gettime
+        // https://opensource.apple.com/source/Libc/Libc-1439.40.11/gen/clock_gettime.c.auto.html
+        // https://man.openbsd.org/clock_gettime.2
+        // https://man.netbsd.org/amd64/clock_gettime.2
+        // https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#-clockid-variant
+        // https://man.dragonflybsd.org/?command=clock_gettime&section=2
+        // https://www.freebsd.org/cgi/man.cgi?query=clock_gettime
+        fn toOsClockId(id: Id) ?i32 {
+            return switch (id) {
+                .realtime => os.CLOCK_REALTIME,
+                .monotonic => switch (target.os.tag) {
+                    .macos, .tvos, .ios, .watchos => os.CLOCK_MONOTONIC_RAW, // mach_continuous_time
+                    .linux => os.CLOCK_BOOTTIME, // actually counts time suspended
+                    else => os.CLOCK_MONOTONIC,
+                },
+                .uptime => switch (target.os.tag) {
+                    .openbsd, .freebsd, .kfreebsd, .dragonfly => os.CLOCK_UPTIME,
+                    .macos, .tvos, .ios, .watchos => os.CLOCK_UPTIME_RAW, // mach_absolute_time
+                    .linux => os.CLOCK_MONOTONIC, // doesn't count time suspended
+                    else => null,
+                },
+                .thread_cputime => os.CLOCK_THREAD_CPUTIME_ID,
+                .process_cputime => os.CLOCK_PROCESS_CPUTIME_ID,
+            };
+        }
+    };
+
+    const WindowsImpl = struct {
+        pub fn read(id: Id) Error!u64 {
+            return switch (id) {
+                .realtime => getSystemTime(),
+                .monotonic => getInterruptTime(),
+                .uptime => getUnbiasedInterruptTime(),
+                .thread_cputime => getCpuTime("GetThreadTimes", "GetCurrentThread"),
+                .thread_cputime => getCpuTime("GetProcessTimes", "GetCurrentProcess"),
+            };
+        }
+
+        fn getSystemTime() u64 {
+            var ft: os.windows.FILETIME = undefined;
+            os.windows.kernel32.GetSystemTimePreciseAsFileTime(&ft);
+            var system_time = (@as(u64, ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+
+            const utc_epoch = -(epoch.windows * (ns_per_s / 100));
+            if (system_time <= utc_epoch) {
+                return 0;
+            }
+
+            const utc_now = system_time - utc_epoch;
+            return utc_now * 100;
+        }
+
+        fn getInterruptTime() u64 {
+            const counter = os.windows.QueryPerformanceCounter();
+            const qpc = getDeltaTime(struct{}, counter);
+            return getQPCInterruptTime(qpc) * 100;
+        }
+
+        fn getUnbiasedInterruptTime() u64 {
+            // Compute the unbiased (without suspend) time by sampling the current interrupt time
+            // then subtracting the InterruptTimeBias while accounting for racy updates.
+            // https://stackoverflow.com/questions/24330496/how-do-i-create-monotonic-clock-on-windows-which-doesnt-tick-during-suspend
+            // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntexapi_x/kuser_shared_data/index.htm
+            const KUSER_SHARED_DATA = 0x7ffe0000;
+            const InterruptTimeBias = @intToPtr(*volatile u64, KUSER_SHARED_DATA + 0x3b0);
+
+            while (true) {
+                const bias = InterruptTimeBias.*;
+                const counter = os.windows.QueryPerformanceCounter();
+                if (bias != InterruptTimeBias.*) {
+                    continue;
+                }
+
+                const qpc = getDeltaTime(struct{}, counter);
+                const qpc_bias = getDeltaTime(struct{}, bias);
+                return (getQPCInterruptTime(qpc) - qpc_bias) * 100;
+            }
+        }
+
+        fn getQPCInterruptTime(qpc: u64) u64 {
+            // doesn't need to be cached. It just reads from KUSER_SHARED_DATA:
+            // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntexapi_x/kuser_shared_data/index.htm
+            const frequency = os.windows.QueryPerformanceFrequency();
+
+            // Interrupt time in units of 100ns 
+            const scale = ns_per_s / 100; 
+
+            // Try to do qpc * scale / frequency
+            var qpc_scaled: u64 = undefined;
+            if (!@mulWithOverflow(u64, qpc, scale, &qpc_scaled)) {
+                return qpc_scaled / frequency;
+            }
+
+            // Does qpc * scale / frequency without overflowing too early
+            const div = qpc / frequency;
+            const rem = qpc % frequency;
+            return (div * scale) + (rem * scale) / frequency;
+        }
+
+        fn getDeltaTime(comptime UniqueType: type, current: u64) u64 {
+            _ = UniqueType;
+
+            const Atomic = std.atomic.Atomic;
+            const Static = struct {
+                var delta = Atomic(u64).init(0);
+                var delta_sync = Atomic(u64).init(0);
+            };
+
+            const delta = blk: {
+                // Use 64bit atomics when available to set delta if it hasn't been already
+                if (@sizeOf(usize) >= @sizeOf(u64)) {
+                    const delta = Static.delta.load(.Monotonic);
+                    if (delta != 0) break :blk delta;
+                    break :blk Static.delta.compareAndSwap(
+                        delta,
+                        current,
+                        .Monotonic,
+                        .Monotonic,
+                    ) orelse current;
+                }
+
+                // 64-bit atomics aren't available so we need to use mutual exclusion.
+                // It's relatively OK to spin here since windows employ dynamic priority boosting
+                // to avoid priority inversion so the owning thread will eventually get scheduled.
+                // https://docs.microsoft.com/en-us/windows/win32/procthread/priority-inversion
+                var delta_sync = Static.delta_sync.load(.Acquire);
+                while (true) {
+                    delta_sync = switch (delta_sync) {
+                        0 => Static.delta_sync(0, 1, .Acquire, .Acquire) orelse {
+                            Static.delta.storeUnchecked(current);
+                            Static.delta_sync.store(2, .Release);
+                            break :blk current;
+                        },
+                        1 => sync: {
+                            std.atomic.spinLoopHint();
+                            break :sync Static.delta_sync.load(.Acquire);
+                        },
+                        2 => break :blk Static.delta.loadUnchecked(),
+                        else => unreachable,
+                    };
+                }
+            };
+
+            if (current < delta) return 0;
+            return current - delta;
+        }
+
+        fn getCpuTime(comptime GetTimesFn: []const u8, comptime GetCurrentFn: []const u8) !u64 {
+            var creation_time: os.windows.FILETIME = undefined;
+            var exit_time: os.windows.FILETIME = undefined;
+            var kernel_time: os.windows.FILETIME = undefined;
+            var user_time: os.windows.FILETIME = undefined;
+
+            const result = @field(os.windows.kernel32, GetTimesFn)(
+                @field(os.windows.kernel32, GetCurrentFn)(),
+                &creation_time,
+                &exit_time,
+                &kernel_time,
+                &user_time,
+            );
+
+            if (result == 0) {
+                const err = os.windows.kernel32.GetLastError();
+                return os.windows.unexpectedError(err);
+            }
+
+            var cpu_time = (@as(u64, kernel_time.dwHighDateTime) << 32) | kernel_time.dwLowDateTime;
+            cpu_time += (@as(u64, user_time.dwHighDateTime) << 32) | user_time.dwLowDateTime;
+            return cpu_time * 100;
+        }
+    };
+};
+
+test "Clock" {
+    comptime var clock_ids: []const Clock.Id = &[_]Clock.Id{};
+    inline for (std.meta.fields(Clock.Id)) |field| {
+        const clock_id = @field(Clock.Id, field.name);
+        clock_ids = clock_ids ++ [_]Clock.Id{ clock_id };
+    }
+
+    for (clock_ids) |clock_id| {
+        _ = Clock.read(clock_id) catch |err| {
+            // Only return errors for clock sources that we use personally.
+            // The rest are just tested for their code paths
+            switch (clock_id) {
+                .realtime, .monotonic => return err,
+                else => continue,
+            }
+        };
+    }
 }

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -349,10 +349,12 @@ pub const Clock = struct {
                 var delta = Atomic(u64).init(0);
                 var delta_once = os.windows.INIT_ONCE_STATIC_INIT;
 
-                fn initDeltaOnce(once: *os.windows.INIT_ONCE, param: ?*c_void, ctx: ?*c_void) callconv(.C) void {
-                    _ = .{ once, ctx };
+                fn initDeltaOnce(once: *os.windows.INIT_ONCE, param: ?*c_void, ctx: ?*c_void) callconv(.C) os.windows.BOOL {
+                    _ = once;
+                    _ = ctx;
                     const current_ptr = @ptrCast(*u64, @alignCast(@alignOf(u64), param));
                     delta.storeUnchecked(current_ptr.*);
+                    return os.windows.TRUE;
                 }
             };
 

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -202,9 +202,7 @@ pub const Clock = struct {
         process_cputime,
     };
 
-    pub const Error = error{
-        UnsupportedClock
-    } || os.UnexpectedError;
+    pub const Error = error{UnsupportedClock} || os.UnexpectedError;
 
     /// Reads the current value of the clock source represented by the `id`.
     pub fn read(id: Id) Error!u64 {
@@ -283,7 +281,7 @@ pub const Clock = struct {
         /// Could be replaced with QueryInterruptTimePrecise() (only on Windows 10+)
         fn getInterruptTime() u64 {
             const counter = os.windows.QueryPerformanceCounter();
-            const qpc = getDeltaTime(struct{}, counter);
+            const qpc = getDeltaTime(struct {}, counter);
             return getQPCInterruptTime(qpc) * 100;
         }
 
@@ -304,8 +302,8 @@ pub const Clock = struct {
                     continue;
                 }
 
-                const qpc = getDeltaTime(struct{}, counter);
-                const qpc_bias = getDeltaTime(struct{}, bias);
+                const qpc = getDeltaTime(struct {}, counter);
+                const qpc_bias = getDeltaTime(struct {}, bias);
                 return (getQPCInterruptTime(qpc) - qpc_bias) * 100;
             }
         }
@@ -316,8 +314,8 @@ pub const Clock = struct {
             // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntexapi_x/kuser_shared_data/index.htm
             const frequency = os.windows.QueryPerformanceFrequency();
 
-            // Interrupt time in units of 100ns 
-            const scale = ns_per_s / 100; 
+            // Interrupt time in units of 100ns
+            const scale = ns_per_s / 100;
 
             // Try to do qpc * scale / frequency
             var qpc_scaled: u64 = undefined;
@@ -372,7 +370,7 @@ pub const Clock = struct {
                 }
 
                 // 64bit atomics aren't supported. Use INIT_ONCE instead
-                var init_with = current; 
+                var init_with = current;
                 os.windows.InitOnceExecuteOnce(
                     &Static.delta_once,
                     Static.initDeltaOnce,
@@ -418,7 +416,7 @@ test "Clock" {
     comptime var clock_ids: []const Clock.Id = &[_]Clock.Id{};
     inline for (std.meta.fields(Clock.Id)) |field| {
         const clock_id = @field(Clock.Id, field.name);
-        clock_ids = clock_ids ++ [_]Clock.Id{ clock_id };
+        clock_ids = clock_ids ++ [_]Clock.Id{clock_id};
     }
 
     for (clock_ids) |clock_id| {

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -267,7 +267,7 @@ pub const Clock = struct {
                     // For more information, see: https://github.com/ziglang/zig/pull/933
                     .linux => os.CLOCK_MONOTONIC, // doesn't count time suspended
                     // wasi and netbsd don't support getting time without suspend
-                    else => null, 
+                    else => null,
                 },
                 .thread_cputime => os.CLOCK_THREAD_CPUTIME_ID,
                 .process_cputime => os.CLOCK_PROCESS_CPUTIME_ID,
@@ -344,7 +344,7 @@ pub const Clock = struct {
         }
 
         fn getQPCInterruptTime(qpc: u64, bias: u64) i128 {
-            // QueryPerofrmanceFrequency() doesn't need to be cached. 
+            // QueryPerofrmanceFrequency() doesn't need to be cached.
             // It just reads from KUSER_SHARED_DATA.
             // See the QpcFrequency offset in:
             // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntexapi_x/kuser_shared_data/index.htm


### PR DESCRIPTION
There are some slight inconsistencies with the current timer APIs in use:
* `std.time.Timer` uses `QueryPerformanceCounter()` on windows which counts time when suspended while the other OS functions used don't.
* `std.time` doesn't expose a cross-platform way to get which includes/exclusives when system is suspended.
* Documentation implies the Timer source is monotonically increasing but it can sometimes [go backwards](https://doc.rust-lang.org/src/std/time.rs.html#223-247)

This PR abstracts all the timer logic out into its own struct `std.time.Clock` with clock_ids modeled after POSIX [`clock_gettime`](https://pubs.opengroup.org/onlinepubs/9699919799/) ~~with variations of the clock_ids optimized for either speed or precision inspired by [freebsd/dragonfly](https://www.freebsd.org/cgi/man.cgi?query=clock_gettime)~~ (omitted due not added complexity for windows & not really useful broadly).

The Clock abstraction removes the need to do if checks in each `std.time` function, exposes the extra clock sources which account for system suspend, and keeps a "familiar" API for all clock sources not just monotonic and realtime. I marked this PR as a draft as there's still some docs to change and it needs more feedback on whether this is even a decent abstraction. 