### PR TITLE
Fix darwin ulock usage on macOS

### DIFF
--- a/lib/std/Thread/Futex.zig
+++ b/lib/std/Thread/Futex.zig
@@ -180,23 +180,22 @@ const DarwinFutex = struct {
     const darwin = std.os.darwin;
 
     fn wait(ptr: *const Atomic(u32), expect: u32, timeout: ?u64) error{TimedOut}!void {
-        // ulock_wait() uses micro-second timeouts, where 0 = INIFITE or no-timeout
-        var timeout_us: u32 = 0;
-        if (timeout) |timeout_ns| {
-            timeout_us = @intCast(u32, timeout_ns / std.time.ns_per_us);
-        }
-
         // Darwin XNU 7195.50.7.100.1 introduced __ulock_wait2 and migrated code paths (notably pthread_cond_t) towards it:
         // https://github.com/apple/darwin-xnu/commit/d4061fb0260b3ed486147341b72468f836ed6c8f#diff-08f993cc40af475663274687b7c326cc6c3031e0db3ac8de7b24624610616be6
         //
         // This XNU version appears to correspond to 11.0.1:
         // https://kernelshaman.blogspot.com/2021/01/building-xnu-for-macos-big-sur-1101.html
+        //
+        // ulock_wait() uses 32-bit micro-second timeouts, where 0 = INIFITE or no-timeout
+        // ulock_wait2() uses 64-bit nano-second timeouts (with the same convention)
+        const timeout_ns: u64 = timeout orelse 0;
         const addr = @ptrCast(*const c_void, ptr);
         const flags = darwin.UL_COMPARE_AND_WAIT | darwin.ULF_NO_ERRNO;
         const status = blk: {
             if (target.os.version_range.semver.max.major >= 11) {
-                break :blk darwin.__ulock_wait2(flags, addr, expect, timeout_us, 0);
+                break :blk darwin.__ulock_wait2(flags, addr, expect, timeout_ns, 0);
             } else {
+                const timeout_us = @intCast(u32, timeout_ns / std.time.ns_per_us);
                 break :blk darwin.__ulock_wait(flags, addr, expect, timeout_us);
             }
         };
@@ -204,7 +203,10 @@ const DarwinFutex = struct {
         if (status >= 0) return;
         switch (-status) {
             darwin.EINTR => {},
-            darwin.EFAULT => unreachable,
+            // Address of the futex is paged out. This is unlikely, but possible in theory, and
+            // pthread/libdispatch on darwin bother to handle it. In this case we'll return
+            // without waiting, but the caller should retry anyway.
+            darwin.EFAULT => {},
             darwin.ETIMEDOUT => return error.TimedOut,
             else => unreachable,
         }
@@ -223,6 +225,7 @@ const DarwinFutex = struct {
             if (status >= 0) return;
             switch (-status) {
                 darwin.EINTR => continue, // spurious wake()
+                darwin.EFAULT => continue, // address of the lock was paged out
                 darwin.ENOENT => return, // nothing was woken up
                 darwin.EALREADY => unreachable, // only for ULF_WAKE_THREAD
                 else => unreachable,

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -246,7 +246,7 @@ pub const UL_COMPARE_AND_WAIT64 = 5;
 pub const UL_COMPARE_AND_WAIT64_SHARED = 6;
 pub const ULF_WAIT_ADAPTIVE_SPIN = 0x40000;
 
-pub extern "c" fn __ulock_wait2(op: u32, addr: ?*const c_void, val: u64, timeout_us: u32, val2: u64) c_int;
+pub extern "c" fn __ulock_wait2(op: u32, addr: ?*const c_void, val: u64, timeout_ns: u64, val2: u64) c_int;
 pub extern "c" fn __ulock_wait(op: u32, addr: ?*const c_void, val: u64, timeout_us: u32) c_int;
 pub extern "c" fn __ulock_wake(op: u32, addr: ?*const c_void, val: u64) c_int;
 


### PR DESCRIPTION
I was doing macOS ulock stuff, and was linked to Zig's DarwinFutex implementation by @kprotty. There were a few bugs I noticed:

- `__ulock_wait2` actually timeout as a `u64`, not `u32` (this likely happens to work on at least x86_64 because of how the ABI works, but I can't say about others, and it's still UB either way).
- Semantically, `__ulock_wait2`'s timeout is in units of nanoseconds (this would just lead to waking up early which callers have to handle, but still).
- EFAULT is not handled, but seems like it should be? At least [almost](https://github.com/apple/darwin-libpthread/blob/2b46cbcc56ba33791296cd9714b2c90dae185ec7/src/pthread_cancelable.c#L290) [all](https://github.com/apple/darwin-libpthread/blob/2b46cbcc56ba33791296cd9714b2c90dae185ec7/src/pthread_dependency.c#L83) [uses](https://github.com/apple/darwin-libplatform/blob/215b09856ab5765b7462a91be7076183076600df/src/os/lock.c#L541) [in](https://github.com/apple/darwin-libpthread/blob/2b46cbcc56ba33791296cd9714b2c90dae185ec7/src/pthread_cond.c#L717) [system](https://github.com/apple/darwin-libpthread/blob/2b46cbcc56ba33791296cd9714b2c90dae185ec7/src/pthread_mutex.c#L1087) [libraries](https://github.com/apple/darwin-libplatform/blob/215b09856ab5765b7462a91be7076183076600df/src/os/lock.c#1165) [/ tests](https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/tests/ulock.c#L39) have it handled.

r? @kprotty