### PR TITLE
Trim quotes in rsp file argument

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3654,7 +3654,7 @@ pub const ClangArgIterator = struct {
             };
             defer allocator.free(resp_contents);
             // TODO is there a specification for this file format? Let's find it and make this parsing more robust
-            // at the very least I'm guessing this needs to handle quotes and `#` comments.
+            // at the very least I'm guessing this needs to handle spaces in quotes and `#` comments.
             var it = mem.tokenize(u8, resp_contents, " \t\r\n");
             var resp_arg_list = std.ArrayList([]const u8).init(allocator);
             defer resp_arg_list.deinit();
@@ -3665,7 +3665,7 @@ pub const ClangArgIterator = struct {
                     }
                 }
                 while (it.next()) |token| {
-                    const dupe_token = try mem.dupeZ(allocator, u8, token);
+                    const dupe_token = try mem.dupeZ(allocator, u8, mem.trim(u8, token, "'\""));
                     errdefer allocator.free(dupe_token);
                     try resp_arg_list.append(dupe_token);
                 }


### PR DESCRIPTION
I'm trying to use zig cc to compile v programs, but it fails because v-generated .rsp files always contain quotes, and that's the only gap.  The fix in this PR works for basic cases but it does not handle spaces in quotes properly.

When I try gcc and clang, I found they support both single quote and double quote, so I trim both in this PR, also I found neither of them support # comments although it's documented [here](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files?view=vs-2019&redirectedfrom=MSDN&viewFallbackFrom=vs-2015)

Also include repro steps
- install [v compiler](https://vlang.io/)
- write a simple program ```hello.v```
```v
fn main() {
        println('Hello world')
}
```
- compile with zig cc ```v -cc "zig cc" -keepc -v .```
- get ```error: FileNotFound``` from the last step, with ```-v```, it prints the path to the intermediate .rsp file and .c file, with ```-keepc``` it won't auto-delete those intermediate files