### PR TITLE
macho: handle TAPI v3 and simplify handling of dependent dynamic libraries

### DIFF
--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -153,32 +153,6 @@ pub fn deinit(self: *Object, allocator: *Allocator) void {
     }
 }
 
-pub fn createAndParseFromPath(allocator: *Allocator, target: std.Target, path: []const u8) !?Object {
-    const file = fs.cwd().openFile(path, .{}) catch |err| switch (err) {
-        error.FileNotFound => return null,
-        else => |e| return e,
-    };
-    errdefer file.close();
-
-    const name = try allocator.dupe(u8, path);
-    errdefer allocator.free(name);
-
-    var object = Object{
-        .name = name,
-        .file = file,
-    };
-
-    object.parse(allocator, target) catch |err| switch (err) {
-        error.EndOfStream, error.NotObject => {
-            object.deinit(allocator);
-            return null;
-        },
-        else => |e| return e,
-    };
-
-    return object;
-}
-
 pub fn parse(self: *Object, allocator: *Allocator, target: std.Target) !void {
     const reader = self.file.reader();
     if (self.file_offset) |offset| {

--- a/src/link/tapi.zig
+++ b/src/link/tapi.zig
@@ -6,55 +6,94 @@ const log = std.log.scoped(.tapi);
 const Allocator = mem.Allocator;
 const Yaml = @import("tapi/yaml.zig").Yaml;
 
+const VersionField = union(enum) {
+    string: []const u8,
+    float: f64,
+    int: u64,
+};
+
+pub const TbdV3 = struct {
+    archs: []const []const u8,
+    uuids: []const []const u8,
+    platform: []const u8,
+    install_name: []const u8,
+    current_version: ?VersionField,
+    compatibility_version: ?VersionField,
+    objc_constraint: []const u8,
+    exports: ?[]const struct {
+        archs: []const []const u8,
+        re_exports: ?[]const []const u8,
+        symbols: ?[]const []const u8,
+    },
+};
+
+pub const TbdV4 = struct {
+    tbd_version: u3,
+    targets: []const []const u8,
+    uuids: []const struct {
+        target: []const u8,
+        value: []const u8,
+    },
+    install_name: []const u8,
+    current_version: ?VersionField,
+    compatibility_version: ?VersionField,
+    reexported_libraries: ?[]const struct {
+        targets: []const []const u8,
+        libraries: []const []const u8,
+    },
+    parent_umbrella: ?[]const struct {
+        targets: []const []const u8,
+        umbrella: []const u8,
+    },
+    exports: ?[]const struct {
+        targets: []const []const u8,
+        symbols: ?[]const []const u8,
+        objc_classes: ?[]const []const u8,
+    },
+    reexports: ?[]const struct {
+        targets: []const []const u8,
+        symbols: ?[]const []const u8,
+        objc_classes: ?[]const []const u8,
+    },
+    allowable_clients: ?[]const struct {
+        targets: []const []const u8,
+        clients: []const []const u8,
+    },
+    objc_classes: ?[]const []const u8,
+};
+
+pub const Tbd = union(enum) {
+    v3: TbdV3,
+    v4: TbdV4,
+
+    pub fn currentVersion(self: Tbd) ?VersionField {
+        return switch (self) {
+            .v3 => |v3| v3.current_version,
+            .v4 => |v4| v4.current_version,
+        };
+    }
+
+    pub fn compatibilityVersion(self: Tbd) ?VersionField {
+        return switch (self) {
+            .v3 => |v3| v3.compatibility_version,
+            .v4 => |v4| v4.compatibility_version,
+        };
+    }
+
+    pub fn installName(self: Tbd) []const u8 {
+        return switch (self) {
+            .v3 => |v3| v3.install_name,
+            .v4 => |v4| v4.install_name,
+        };
+    }
+};
+
 pub const LibStub = struct {
     /// Underlying memory for stub's contents.
     yaml: Yaml,
 
     /// Typed contents of the tbd file.
     inner: []Tbd,
-
-    const Tbd = struct {
-        tbd_version: u3,
-        targets: []const []const u8,
-        uuids: []const struct {
-            target: []const u8,
-            value: []const u8,
-        },
-        install_name: []const u8,
-        current_version: ?union(enum) {
-            string: []const u8,
-            float: f64,
-            int: u64,
-        },
-        compatibility_version: ?union(enum) {
-            string: []const u8,
-            float: f64,
-            int: u64,
-        },
-        reexported_libraries: ?[]const struct {
-            targets: []const []const u8,
-            libraries: []const []const u8,
-        },
-        parent_umbrella: ?[]const struct {
-            targets: []const []const u8,
-            umbrella: []const u8,
-        },
-        exports: ?[]const struct {
-            targets: []const []const u8,
-            symbols: ?[]const []const u8,
-            objc_classes: ?[]const []const u8,
-        },
-        reexports: ?[]const struct {
-            targets: []const []const u8,
-            symbols: ?[]const []const u8,
-            objc_classes: ?[]const []const u8,
-        },
-        allowable_clients: ?[]const struct {
-            targets: []const []const u8,
-            clients: []const []const u8,
-        },
-        objc_classes: ?[]const []const u8,
-    };
 
     pub fn loadFromFile(allocator: *Allocator, file: fs.File) !LibStub {
         const source = try file.readToEndAlloc(allocator, std.math.maxInt(u32));
@@ -65,16 +104,41 @@ pub const LibStub = struct {
             .inner = undefined,
         };
 
-        lib_stub.inner = lib_stub.yaml.parse([]Tbd) catch |err| blk: {
-            switch (err) {
-                error.TypeMismatch => {
-                    // TODO clean this up.
-                    var out = try lib_stub.yaml.arena.allocator.alloc(Tbd, 1);
-                    out[0] = try lib_stub.yaml.parse(Tbd);
-                    break :blk out;
-                },
-                else => |e| return e,
+        // TODO clean this up.
+        lib_stub.inner = blk: {
+            err: {
+                const inner = lib_stub.yaml.parse([]TbdV4) catch |err| switch (err) {
+                    error.TypeMismatch => break :err,
+                    else => |e| return e,
+                };
+                var out = try lib_stub.yaml.arena.allocator.alloc(Tbd, inner.len);
+                for (inner) |doc, i| {
+                    out[i] = .{ .v4 = doc };
+                }
+                break :blk out;
             }
+
+            err: {
+                const inner = lib_stub.yaml.parse(TbdV4) catch |err| switch (err) {
+                    error.TypeMismatch => break :err,
+                    else => |e| return e,
+                };
+                var out = try lib_stub.yaml.arena.allocator.alloc(Tbd, 1);
+                out[0] = .{ .v4 = inner };
+                break :blk out;
+            }
+
+            err: {
+                const inner = lib_stub.yaml.parse(TbdV3) catch |err| switch (err) {
+                    error.TypeMismatch => break :err,
+                    else => |e| return e,
+                };
+                var out = try lib_stub.yaml.arena.allocator.alloc(Tbd, 1);
+                out[0] = .{ .v3 = inner };
+                break :blk out;
+            }
+
+            return error.TypeMismatch;
         };
 
         return lib_stub;

--- a/src/link/tapi.zig
+++ b/src/link/tapi.zig
@@ -105,7 +105,7 @@ pub const LibStub = struct {
             .inner = undefined,
         };
 
-        // TODO clean this up.
+        // TODO revisit this logic in the hope of simplifying it.
         lib_stub.inner = blk: {
             err: {
                 log.debug("trying to parse as []TbdV4", .{});
@@ -133,8 +133,7 @@ pub const LibStub = struct {
                 break :blk out;
             }
 
-            // TODO this is clunky. Perhaps an optional would be better here?
-            return error.TypeMismatch;
+            return error.NotLibStub;
         };
 
         return lib_stub;

--- a/src/link/tapi/yaml.zig
+++ b/src/link/tapi/yaml.zig
@@ -371,7 +371,7 @@ pub const Yaml = struct {
             }
 
             const unwrapped = value orelse {
-                log.err("missing struct field: {s}: {s}", .{ field.name, @typeName(field.field_type) });
+                log.debug("missing struct field: {s}: {s}", .{ field.name, @typeName(field.field_type) });
                 return error.StructFieldMissing;
             };
             @field(parsed, field.name) = try self.parseValue(field.field_type, unwrapped);


### PR DESCRIPTION
Previously, we would potentially unnecessarily re-parse the same dynamic library a few times if it happened to have been re-exported by some different dynamic library. This PR ensures we don't unnecessarily do that.

Secondly, by landing the basic iOS support PR #9532, we now need to handle TAPI v3 to properly handle native linking on Mojave as we do link against the system provided libs on that OS which happen to be encoded as TAPI v3.