### PR TITLE
translate-c: allow string literals to be used as `char *`

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -721,27 +721,13 @@ fn transQualTypeMaybeInitialized(c: *Context, scope: *Scope, qt: clang.QualType,
 
 /// This is used in global scope to convert a string literal `S` to [*c]u8:
 /// &(struct {
-///     var static: @TypeOf(S.*) = S.*;
+///     var static = S.*;
 /// }).static;
 fn stringLiteralToCharStar(c: *Context, str: Node) Error!Node {
     const var_name = Scope.Block.StaticInnerName;
 
-    const derefed = try Tag.deref.create(c.arena, str);
-    const var_type = try Tag.typeof.create(c.arena, derefed);
-
     const variables = try c.arena.alloc(Node, 1);
-    variables[0] = try Tag.var_decl.create(c.arena, .{
-        .is_pub = false,
-        .is_const = false,
-        .is_extern = false,
-        .is_export = false,
-        .is_threadlocal = false,
-        .linksection_string = null,
-        .alignment = null,
-        .name = var_name,
-        .type = var_type,
-        .init = derefed,
-    });
+    variables[0] = try Tag.mut_str.create(c.arena, .{ .name = var_name, .init = str });
 
     const anon_struct = try Tag.@"struct".create(c.arena, .{
         .layout = .none,

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -719,6 +719,44 @@ fn transQualTypeMaybeInitialized(c: *Context, scope: *Scope, qt: clang.QualType,
         transQualType(c, scope, qt, loc);
 }
 
+/// This is used in global scope to convert a string literal `S` to [*c]u8:
+/// &(struct {
+///     var static: @TypeOf(S.*) = S.*;
+/// }).static;
+fn stringLiteralToCharStar(c: *Context, str: Node) Error!Node {
+    const var_name = Scope.Block.StaticInnerName;
+
+    const derefed = try Tag.deref.create(c.arena, str);
+    const var_type = try Tag.typeof.create(c.arena, derefed);
+
+    const variables = try c.arena.alloc(Node, 1);
+    variables[0] = try Tag.var_decl.create(c.arena, .{
+        .is_pub = false,
+        .is_const = false,
+        .is_extern = false,
+        .is_export = false,
+        .is_threadlocal = false,
+        .linksection_string = null,
+        .alignment = null,
+        .name = var_name,
+        .type = var_type,
+        .init = derefed,
+    });
+
+    const anon_struct = try Tag.@"struct".create(c.arena, .{
+        .layout = .none,
+        .fields = &.{},
+        .functions = &.{},
+        .variables = variables,
+    });
+
+    const member_access = try Tag.field_access.create(c.arena, .{
+        .lhs = anon_struct,
+        .field_name = var_name,
+    });
+    return Tag.address_of.create(c.arena, member_access);
+}
+
 /// if mangled_name is not null, this var decl was declared in a block scope.
 fn visitVarDecl(c: *Context, var_decl: *const clang.VarDecl, mangled_name: ?[]const u8) Error!void {
     const var_name = mangled_name orelse try c.str(@ptrCast(*const clang.NamedDecl, var_decl).getName_bytes_begin());
@@ -779,6 +817,8 @@ fn visitVarDecl(c: *Context, var_decl: *const clang.VarDecl, mangled_name: ?[]co
             };
             if (!qualTypeIsBoolean(qual_type) and isBoolRes(init_node.?)) {
                 init_node = try Tag.bool_to_int.create(c.arena, init_node.?);
+            } else if (init_node.?.tag() == .string_literal and qualTypeIsCharStar(qual_type)) {
+                init_node = try stringLiteralToCharStar(c, init_node.?);
             }
         } else {
             init_node = Tag.undefined_literal.init();
@@ -1101,9 +1141,10 @@ fn transRecordDecl(c: *Context, scope: *Scope, record_decl: *const clang.RecordD
         record_payload.* = .{
             .base = .{ .tag = ([2]Tag{ .@"struct", .@"union" })[@boolToInt(is_union)] },
             .data = .{
-                .is_packed = is_packed,
+                .layout = if (is_packed) .@"packed" else .@"extern",
                 .fields = try c.arena.dupe(ast.Payload.Record.Field, fields.items),
                 .functions = try c.arena.dupe(Node, functions.items),
+                .variables = &.{},
             },
         };
         break :blk Node.initPayload(&record_payload.base);
@@ -1805,6 +1846,9 @@ fn transDeclStmtOne(
                 Tag.undefined_literal.init();
             if (!qualTypeIsBoolean(qual_type) and isBoolRes(init_node)) {
                 init_node = try Tag.bool_to_int.create(c.arena, init_node);
+            } else if (init_node.tag() == .string_literal and qualTypeIsCharStar(qual_type)) {
+                const dst_type_node = try transQualType(c, scope, qual_type, loc);
+                init_node = try removeCVQualifiers(c, dst_type_node, init_node);
             }
 
             const var_name: []const u8 = if (is_static_local) Scope.Block.StaticInnerName else mangled_name;
@@ -2522,9 +2566,19 @@ fn transInitListExprRecord(
             raw_name = try mem.dupe(c.arena, u8, name);
         }
 
+        var init_expr = try transExpr(c, scope, elem_expr, .used);
+        const field_qt = field_decl.getType();
+        if (init_expr.tag() == .string_literal and qualTypeIsCharStar(field_qt)) {
+            if (scope.id == .root) {
+                init_expr = try stringLiteralToCharStar(c, init_expr);
+            } else {
+                const dst_type_node = try transQualType(c, scope, field_qt, loc);
+                init_expr = try removeCVQualifiers(c, dst_type_node, init_expr);
+            }
+        }
         try field_inits.append(.{
             .name = raw_name,
-            .value = try transExpr(c, scope, elem_expr, .used),
+            .value = init_expr,
         });
     }
     if (ty_node.castTag(.identifier)) |ident_node| {
@@ -3459,6 +3513,10 @@ fn transCallExpr(c: *Context, scope: *Scope, stmt: *const clang.CallExpr, result
                         const param_qt = fn_proto.getParamType(@intCast(c_uint, i));
                         if (isBoolRes(arg) and cIsNativeInt(param_qt)) {
                             arg = try Tag.bool_to_int.create(c.arena, arg);
+                        } else if (arg.tag() == .string_literal and qualTypeIsCharStar(param_qt)) {
+                            const loc = @ptrCast(*const clang.Stmt, stmt).getBeginLoc();
+                            const dst_type_node = try transQualType(c, scope, param_qt, loc);
+                            arg = try removeCVQualifiers(c, dst_type_node, arg);
                         }
                     }
                 },
@@ -3835,6 +3893,12 @@ fn transCreateCompoundAssign(
     return block_scope.complete(c);
 }
 
+// Casting away const or volatile requires us to use @intToPtr
+fn removeCVQualifiers(c: *Context, dst_type_node: Node, expr: Node) Error!Node {
+    const ptr_to_int = try Tag.ptr_to_int.create(c.arena, expr);
+    return Tag.int_to_ptr.create(c.arena, .{ .lhs = dst_type_node, .rhs = ptr_to_int });
+}
+
 fn transCPtrCast(
     c: *Context,
     scope: *Scope,
@@ -3854,10 +3918,7 @@ fn transCPtrCast(
         (src_child_type.isVolatileQualified() and
         !child_type.isVolatileQualified())))
     {
-        // Casting away const or volatile requires us to use @intToPtr
-        const ptr_to_int = try Tag.ptr_to_int.create(c.arena, expr);
-        const int_to_ptr = try Tag.int_to_ptr.create(c.arena, .{ .lhs = dst_type_node, .rhs = ptr_to_int });
-        return int_to_ptr;
+        return removeCVQualifiers(c, dst_type_node, expr);
     } else {
         // Implicit downcasting from higher to lower alignment values is forbidden,
         // use @alignCast to side-step this problem
@@ -4215,6 +4276,26 @@ fn typeIsOpaque(c: *Context, ty: *const clang.Type, loc: clang.SourceLocation) b
         },
         else => return false,
     }
+}
+
+/// plain `char *` (not const; not explicitly signed or unsigned)
+fn qualTypeIsCharStar(qt: clang.QualType) bool {
+    if (qualTypeIsPtr(qt)) {
+        const child_qt = qualTypeCanon(qt).getPointeeType();
+        return cIsUnqualifiedChar(child_qt) and !child_qt.isConstQualified();
+    }
+    return false;
+}
+
+/// C `char` without explicit signed or unsigned qualifier
+fn cIsUnqualifiedChar(qt: clang.QualType) bool {
+    const c_type = qualTypeCanon(qt);
+    if (c_type.getTypeClass() != .Builtin) return false;
+    const builtin_ty = @ptrCast(*const clang.BuiltinType, c_type);
+    return switch (builtin_ty.getKind()) {
+        .Char_S, .Char_U => true,
+        else => false,
+    };
 }
 
 fn cIsInteger(qt: clang.QualType) bool {

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -62,6 +62,8 @@ pub const Node = extern union {
         var_decl,
         /// const name = struct { init }
         static_local_var,
+        /// var name = init.*
+        mut_str,
         func,
         warning,
         @"struct",
@@ -361,7 +363,7 @@ pub const Node = extern union {
                 .array_type, .null_sentinel_array_type => Payload.Array,
                 .arg_redecl, .alias, .fail_decl => Payload.ArgRedecl,
                 .log2_int_type => Payload.Log2IntType,
-                .var_simple, .pub_var_simple, .static_local_var => Payload.SimpleVarDecl,
+                .var_simple, .pub_var_simple, .static_local_var, .mut_str => Payload.SimpleVarDecl,
                 .enum_constant => Payload.EnumConstant,
                 .array_filler => Payload.ArrayFiller,
                 .pub_inline_fn => Payload.PubInlineFn,
@@ -1230,6 +1232,7 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
                 },
             });
             _ = try c.addToken(.r_brace, "}");
+            _ = try c.addToken(.semicolon, ";");
 
             return c.addNode(.{
                 .tag = .simple_var_decl,
@@ -1238,6 +1241,29 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
                     .lhs = 0,
                     .rhs = container_def,
                 },
+            });
+        },
+        .mut_str => {
+            const payload = node.castTag(.mut_str).?.data;
+
+            const var_tok = try c.addToken(.keyword_var, "var");
+            _ = try c.addIdentifier(payload.name);
+            _ = try c.addToken(.equal, "=");
+
+            const deref = try c.addNode(.{
+                .tag = .deref,
+                .data = .{
+                    .lhs = try renderNodeGrouped(c, payload.init),
+                    .rhs = undefined,
+                },
+                .main_token = try c.addToken(.period_asterisk, ".*"),
+            });
+            _ = try c.addToken(.semicolon, ";");
+
+            return c.addNode(.{
+                .tag = .simple_var_decl,
+                .main_token = var_tok,
+                .data = .{ .lhs = 0, .rhs = deref },
             });
         },
         .var_decl => return renderVar(c, node),
@@ -2145,7 +2171,7 @@ fn renderNullSentinelArrayType(c: *Context, len: usize, elem_type: Node) !NodeIn
 fn addSemicolonIfNeeded(c: *Context, node: Node) !void {
     switch (node.tag()) {
         .warning => unreachable,
-        .var_decl, .var_simple, .arg_redecl, .alias, .block, .empty_block, .block_single, .@"switch" => {},
+        .var_decl, .var_simple, .arg_redecl, .alias, .block, .empty_block, .block_single, .@"switch", .static_local_var, .mut_str => {},
         .while_true => {
             const payload = node.castTag(.while_true).?.data;
             return addSemicolonIfNotBlock(c, payload);
@@ -2240,6 +2266,7 @@ fn renderNodeGrouped(c: *Context, node: Node) !NodeIndex {
         .offset_of,
         .shuffle,
         .static_local_var,
+        .mut_str,
         => {
             // no grouping needed
             return renderNode(c, node);

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1749,4 +1749,22 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Allow non-const char* string literals. Issue #9126",
+        \\#include <stdlib.h>
+        \\int func(char *x) { return x[0]; }
+        \\struct S { char *member; };
+        \\struct S global_struct = { .member = "global" };
+        \\char *g = "global";
+        \\int main(void) {
+        \\   if (g[0] != 'g') abort();
+        \\   if (global_struct.member[0] != 'g') abort();
+        \\   char *string = "hello";
+        \\   if (string[0] != 'h') abort();
+        \\   struct S s = {.member = "hello"};
+        \\   if (s.member[0] != 'h') abort();
+        \\   if (func("foo") != 'f') abort();
+        \\   return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
In C the type of string literals is `char *`, so when using them in
a non-const context we have to cast the const away.

Fixes #9126