### PR TITLE
mingw.zig: fix logic to add crt sources

### DIFF
--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -187,27 +187,25 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile) !void {
                     };
                 }
             } else if (target.cpu.arch.isARM()) {
-                if (target.cpu.arch.ptrBitWidth() == 32) {
-                    for (mingwex_arm32_src) |dep| {
-                        (try c_source_files.addOne()).* = .{
-                            .src_path = try comp.zig_lib_directory.join(arena, &[_][]const u8{
-                                "libc", "mingw", dep,
-                            }),
-                            .extra_flags = extra_flags,
-                        };
-                    }
-                } else {
-                    for (mingwex_arm64_src) |dep| {
-                        (try c_source_files.addOne()).* = .{
-                            .src_path = try comp.zig_lib_directory.join(arena, &[_][]const u8{
-                                "libc", "mingw", dep,
-                            }),
-                            .extra_flags = extra_flags,
-                        };
-                    }
+                for (mingwex_arm32_src) |dep| {
+                    (try c_source_files.addOne()).* = .{
+                        .src_path = try comp.zig_lib_directory.join(arena, &[_][]const u8{
+                            "libc", "mingw", dep,
+                        }),
+                        .extra_flags = extra_flags,
+                    };
+                }
+            } else if (target.cpu.arch.isAARCH64()) {
+                for (mingwex_arm64_src) |dep| {
+                    (try c_source_files.addOne()).* = .{
+                        .src_path = try comp.zig_lib_directory.join(arena, &[_][]const u8{
+                            "libc", "mingw", dep,
+                        }),
+                        .extra_flags = extra_flags,
+                    };
                 }
             } else {
-                unreachable;
+                @panic("unsupported arch");
             }
             return comp.build_crt_file("mingwex", .Lib, c_source_files.items);
         },


### PR DESCRIPTION
The current version of code uses isARM to check if we are compiling to any arm target then checks the target bit width to either add the 32-bit sources or 64-bit source.  However, isARM only returns true for 32-bit targets, and isAARCH64 is for the 64-bit targets.

I also replaced the unreachable with a @panic when we receive an unsupported arch because this code is reachable and should turn into an error.  With the current unreachable statement, the released compiler on windows was silently hitting the unreachable and falling through to the `isARM` case.

This is one of the errors contributing to https://github.com/ziglang/zig/issues/9519

It would be great if I could also add a regression test for this, not sure how though...any guidance here would be very helpful.