### PR TITLE
std.fmt: add name of type in unsupport format string compile error

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -544,7 +544,7 @@ pub fn formatType(
                             return formatText(value, actual_fmt, options, writer);
                         }
                     }
-                    @compileError("Unknown format string: '" ++ actual_fmt ++ "'");
+                    @compileError("Unknown format string: '" ++ actual_fmt ++ "' for type '" ++ @typeName(T) ++ "'");
                 },
                 .Enum, .Union, .Struct => {
                     return formatType(value.*, actual_fmt, options, writer, max_depth);
@@ -562,7 +562,7 @@ pub fn formatType(
                         return formatText(mem.span(value), actual_fmt, options, writer);
                     }
                 }
-                @compileError("Unknown format string: '" ++ actual_fmt ++ "'");
+                @compileError("Unknown format string: '" ++ actual_fmt ++ "' for type '" ++ @typeName(T) ++ "'");
             },
             .Slice => {
                 if (actual_fmt.len == 0)


### PR DESCRIPTION
## Examples

Before: `error: Unknown format string: 's'` + error return trace

After: `error: Unknown format string: 's' for type '*const [3][]const u8'` + error return trace