### PR TITLE
std.fmt: add support for printing slices of strings

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -544,6 +544,13 @@ pub fn formatType(
                             return formatText(value, actual_fmt, options, writer);
                         }
                     }
+                    if (comptime std.meta.trait.isZigString(info.child)) {
+                        for (value) |item, i| {
+                            if (i != 0) try formatText(", ", actual_fmt, options, writer);
+                            try formatText(item, actual_fmt, options, writer);
+                        }
+                        return;
+                    }
                     @compileError("Unknown format string: '" ++ actual_fmt ++ "'");
                 },
                 .Enum, .Union, .Struct => {


### PR DESCRIPTION
```zig
const std = @import("std");

const T = struct {
    a: i32,
    b: i32,
    c: i32,
};

pub fn main() void {
    std.log.info("{s}", .{std.meta.fieldNames(T)});
}
```

Before: `error: Unknown format string: 's'`

After: `info: a, b, c`

I decided to leave out the square brackets from the formatter so that each user may choose whichever bracket type makes the most sense for them (or keep with none at all)