### PR TITLE
Fix args when calling clang::ASTUnit::LoadFromCommandLine.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2557,6 +2557,7 @@ pub fn cImport(comp: *Compilation, c_src: []const u8) !CImportResult {
         var argv = std.ArrayList([]const u8).init(comp.gpa);
         defer argv.deinit();
 
+        try argv.append(""); // argv[0] is program name, actual args start at [1]
         try comp.addTranslateCCArgs(arena, &argv, .c, out_dep_path);
 
         try argv.append(out_h_path);

--- a/src/main.zig
+++ b/src/main.zig
@@ -2492,6 +2492,7 @@ fn cmdTranslateC(comp: *Compilation, arena: *Allocator, enable_cache: bool) !voi
 
     const digest = if (try man.hit()) man.final() else digest: {
         var argv = std.ArrayList([]const u8).init(arena);
+        try argv.append(""); // argv[0] is program name, actual args start at [1]
 
         var zig_cache_tmp_dir = try comp.local_cache_directory.handle.makeOpenPath("tmp", .{});
         defer zig_cache_tmp_dir.close();


### PR DESCRIPTION
`clang::ASTUnit::LoadFromCommandLine` interprets the first argument as the name of program (just like the `main` function).

Currently, the first 2 arguments we pass to this function is `"-x"` and `"c"` which are interpreted as a program name and an unused linker input, resulting in a _"linker input unused"_ warning from clang.

This PR shifts the arguments passing `""` for the first argument making `"-x c"` interpreted as intended.

Let me know if you prefer this to be fixed at the 2 callsites of `translate_c.translate` where the args get assembled.