### PR TITLE
stage2 codegen: re-allocate result register in finishAir

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -970,6 +970,20 @@ fn Function(comptime arch: std.Target.Cpu.Arch) type {
                 log.debug("%{d} => {}", .{ inst, result });
                 const branch = &self.branch_stack.items[self.branch_stack.items.len - 1];
                 branch.inst_table.putAssumeCapacityNoClobber(inst, result);
+
+                switch (result) {
+                    .register => |reg| {
+                        // In some cases (such as bitcast), an operand
+                        // may be the same MCValue as the result. If
+                        // that operand died and was a register, it
+                        // was freed by processDeath. We have to
+                        // "re-allocate" the register.
+                        if (self.register_manager.isRegFree(reg)) {
+                            self.register_manager.getRegAssumeFree(reg, inst);
+                        }
+                    },
+                    else => {},
+                }
             }
             self.finishAirBookkeeping();
         }

--- a/test/stage2/arm.zig
+++ b/test/stage2/arm.zig
@@ -319,6 +319,22 @@ pub fn addCases(ctx: *TestContext) !void {
         ,
             "",
         );
+
+        case.addCompareOutput(
+            \\const Number = enum { one, two, three };
+            \\
+            \\pub fn main() void {
+            \\    var x: Number = .one;
+            \\    var y = Number.two;
+            \\    assert(@enumToInt(x) < @enumToInt(y));
+            \\}
+            \\
+            \\fn assert(ok: bool) void {
+            \\    if (!ok) unreachable; // assertion failure
+            \\}
+        ,
+            "",
+        );
     }
 
     {


### PR DESCRIPTION
The attached test case now works. Previously, both operands, even though they are different values, were allocated to the same register because of a small bug with `bitcast` and `finishAir`.