### PR TITLE
stage2: add error set type equality

### DIFF
--- a/test/cases.zig
+++ b/test/cases.zig
@@ -1568,6 +1568,24 @@ pub fn addCases(ctx: *TestContext) !void {
         });
     }
     {
+        var case = ctx.exe("error set equality", linux_x64);
+
+        case.addCompareOutput(
+            \\pub fn main() void {
+            \\    assert(@TypeOf(error.Foo) == @TypeOf(error.Foo));
+            \\    assert(@TypeOf(error.Bar) != @TypeOf(error.Foo));
+            \\    assert(anyerror == anyerror);
+            \\    assert(error{Foo} != error{Foo});
+            \\    // TODO put inferred error sets here when @typeInfo works
+            \\}
+            \\fn assert(b: bool) void {
+            \\    if (!b) unreachable;
+            \\}
+        ,
+            "",
+        );
+    }
+    {
         var case = ctx.exe("inline assembly", linux_x64);
 
         case.addError(


### PR DESCRIPTION
This right now uses the status quo from stage1 where decl equality is checked, not the actual set equality is checked.
Should this be changed? Since #7533 is not accepted I did not implement it.