### PR TITLE
compiler_rt: fix generic __clzsi2

### DIFF
--- a/lib/std/special/compiler_rt/clzsi2.zig
+++ b/lib/std/special/compiler_rt/clzsi2.zig
@@ -14,13 +14,16 @@ fn __clzsi2_generic(a: i32) callconv(.C) i32 {
 
     // Count first bit set using binary search, from Hacker's Delight
     var y: u32 = 0;
-    inline for ([_]i32{ 16, 8, 4, 2, 1 }) |shift| {
+    inline for ([_]i32{ 16, 8, 4, 2 }) |shift| {
         y = x >> shift;
         if (y != 0) {
             n = n - shift;
             x = y;
         }
     }
+    y = x >> 1;
+    if (y != 0)
+        return n - 2;
 
     return n - @bitCast(i32, x);
 }


### PR DESCRIPTION
Example for failure: 1..1 (32 1's)
After applying shifts 16,8,4,2,1 we have y=0..0 (31 0's) and 1.
n=32-16-8-4-2-1=1, which is not 0.