### PR TITLE
std.rand.Random: add enumValue()

### DIFF
--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -50,7 +50,7 @@ pub const Random = struct {
     /// Returns a random value from an enum, evenly distributed.
     pub fn enumValue(r: *Random, comptime EnumType: type) EnumType {
         if (comptime !std.meta.trait.is(.Enum)(EnumType)) {
-            @compileError("Random.enumValue requires an enum type, not a "++@typeName(EnumType));
+            @compileError("Random.enumValue requires an enum type, not a " ++ @typeName(EnumType));
         }
 
         // We won't use int -> enum casting because enum elements can have

--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -57,9 +57,6 @@ pub const Random = struct {
         //  arbitrary values.  Instead we'll randomly pick one of the type's
         //  fields (values).
         const options = comptime std.meta.fields(EnumType);
-        if (options.len == 0) {
-            @compileError("Cannot get a random value from an empty enum");
-        }
         const index = r.uintLessThan(u64, options.len);
         inline for (options) |field, i| {
             if (i == index) {
@@ -67,8 +64,7 @@ pub const Random = struct {
             }
         }
 
-        // The above loop should be exhaustive
-        unreachable;
+        unreachable; // The above loop should be exhaustive
     }
 
     /// Returns a random int `i` such that `0 <= i <= maxInt(T)`.

--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -54,17 +54,10 @@ pub const Random = struct {
         }
 
         // We won't use int -> enum casting because enum elements can have
-        //  arbitrary values.  Instead we'll randomly pick one of the type's
-        //  fields (values).
-        const options = comptime std.meta.fields(EnumType);
-        const index = r.uintLessThan(u64, options.len);
-        inline for (options) |field, i| {
-            if (i == index) {
-                return @field(EnumType, field.name);
-            }
-        }
-
-        unreachable; // The above loop should be exhaustive
+        //  arbitrary values.  Instead we'll randomly pick one of the type's values.
+        const values = std.enums.values(EnumType);
+        const index = r.uintLessThan(usize, values.len);
+        return values[index];
     }
 
     /// Returns a random int `i` such that `0 <= i <= maxInt(T)`.


### PR DESCRIPTION
This PR adds an `enumValue` method to `Random` analogous to the existing `boolean` and `int` methods:  given an enum type, it returns a random value from that enum.

A note on the test: using the `SequentialPrng` (as used by the other tests in the file) causes the method to always return the enum's first value.  I pulled on this thread for a while and couldn't figure out why.  Using the method with the default rng gives the expected nice random distribution, so I'm not sure what's going on.  I would like to make the test better and make sure I'm not missing anything, so any suggestions are very welcome.