### PR TITLE
Add mask before truncating dereferenced bit pointers

### DIFF
--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -71,6 +71,7 @@ test {
         _ = @import("behavior/bugs/7047.zig");
         _ = @import("behavior/bugs/7003.zig");
         _ = @import("behavior/bugs/7250.zig");
+        _ = @import("behavior/bugs/9584.zig");
         _ = @import("behavior/bugs/394.zig");
         _ = @import("behavior/bugs/421.zig");
         _ = @import("behavior/bugs/529.zig");

--- a/test/behavior/bugs/9584.zig
+++ b/test/behavior/bugs/9584.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+
+const A = packed struct {
+    a: bool,
+    b: bool,
+    c: bool,
+    d: bool,
+
+    e: bool,
+    f: bool,
+    g: bool,
+    h: bool,
+};
+
+const X = union {
+    x: A,
+    y: u64,
+};
+
+pub fn a(
+    x0: i32,
+    x1: i32,
+    x2: i32,
+    x3: i32,
+    x4: i32,
+    flag_a: bool,
+    flag_b: bool,
+) !void {
+    _ = x0;
+    _ = x1;
+    _ = x2;
+    _ = x3;
+    _ = x4;
+    _ = flag_a;
+    // With this bug present, `flag_b` would actually contain the value 17.
+    // Note: this bug only presents itself on debug mode.
+    try std.testing.expect(@ptrCast(*const u8, &flag_b).* == 1);
+}
+
+pub fn b(x: *X) !void {
+    try a(0, 1, 2, 3, 4, x.x.a, x.x.b);
+}
+
+test "bug 9584" {
+    var flags = A{
+        .a = false,
+        .b = true,
+        .c = false,
+        .d = false,
+
+        .e = false,
+        .f = true,
+        .g = false,
+        .h = false,
+    };
+    var x = X{
+        .x = flags,
+    };
+    try b(&x);
+}


### PR DESCRIPTION
Loading the value of a non-power-of-2 int larger than 8 bits yields something as follows in stage 1:
```llvm
%1 = load i8, i8* %the_ptr, align 1
%2 = lshr i8 %1, 1
%3 = trunc i8 %2 to i1
```
Unfortunately, LLVM does not always clear the upper bits of the resulting value after the truncate, as is evident in this snippet:
```zig
const std = @import("std");

const A = packed struct {
    a: bool,
    b: bool,
    c: bool,
    d: bool,

    e: bool,
    f: bool,
    g: bool,
    h: bool,
};

const X = union {
    x: A,
    y: u64,
};

pub fn a(
    x0: i32,
    x1: i32,
    x2: i32,
    x3: i32,
    x4: i32,
    flag_a: bool,
    flag_b: bool,
) void {
    @breakpoint();
    _ = x0;
    _ = x1;
    _ = x2;
    _ = x3;
    _ = x4;
    _ = flag_a;
    std.debug.print("{}\n", .{@ptrCast(*const u8, &flag_b).*});
}

pub fn b(x: *X) void {
    a(0, 1, 2, 3, 4, x.x.a, x.x.b);
}

pub fn main() void {
    var flags = A{
        .a = false,
        .b = true,
        .c = false,
        .d = false,

        .e = false,
        .f = true,
        .g = false,
        .h = false,
    };
    var x = X{
        .x = flags,
    };
    b(&x);
}
```
Above program yields `17`, instead of the expected `1`. Note that the many arguments are required to force `flag_b` to be placed on the stack, and the union is also required. 

Of course, the upper bits of the result of the truncate are undefined, which would be fine, if llvm didn't try to use them afterwards. With this patch, LLVM is explicitly instructed to generate a masking operation before the truncate. This is also what clang itself seems to do when naively translating above snippet to C.

