### PR TITLE
stage2: fix typo

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -8323,7 +8323,7 @@ fn coerceNum(
             return sema.mod.fail(&block.base, inst_src, "TODO float to int", .{});
         } else if (src_zig_tag == .Int or src_zig_tag == .ComptimeInt) {
             if (!val.intFitsInType(dest_type, target)) {
-                return sema.mod.fail(&block.base, inst_src, "type {} cannot represent integer value {}", .{ inst_ty, val });
+                return sema.mod.fail(&block.base, inst_src, "type {} cannot represent integer value {}", .{ dest_type, val });
             }
             return try sema.addConstant(dest_type, val);
         }


### PR DESCRIPTION
this made errors go from stuff like:
> type comptime_int cannot represent integer value 40
to
> type u5 cannot represent integer value 40
which makes much more sense