### PR TITLE
Do not generate ref before elem_ptr and field_ptr

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -4854,7 +4854,7 @@ fn fieldAccess(
     const str_index = try astgen.identAsString(field_ident);
     switch (rl) {
         .ref => return gz.addPlNode(.field_ptr, node, Zir.Inst.Field{
-            .lhs = try expr(gz, scope, .ref, object_node),
+            .lhs = try expr(gz, scope, .none_or_ref, object_node),
             .field_name_start = str_index,
         }),
         else => return rvalue(gz, rl, try gz.addPlNode(.field_val, node, Zir.Inst.Field{
@@ -4876,7 +4876,7 @@ fn arrayAccess(
     switch (rl) {
         .ref => return gz.addBin(
             .elem_ptr,
-            try expr(gz, scope, .ref, node_datas[node].lhs),
+            try expr(gz, scope, .none_or_ref, node_datas[node].lhs),
             try expr(gz, scope, .{ .ty = .usize_type }, node_datas[node].rhs),
         ),
         else => return rvalue(gz, rl, try gz.addBin(


### PR DESCRIPTION
Previously AstGen would emit a Zir `ref` instruction before any `elem_ptr` and `field_ptr` instruction. This instruction is now omitted, and the relevant instructions in Sema are updated to account for this change.

`analyzeRef` is modified such that it now stores intermediates to a pointer, after which the pointer is casted to a constant version. This would otherwise fail the first check of `storePtr`. I've used `Sema.bitcast` here for now, though i guess in the future `Sema.coerce` would be more correct.

This should now more correctly handle taking addresses of values. Previously statements like `&x`, `&x.y` and `&x[0]` would fail because of the above problem.

Marked as wip because there are still some source locations that need to be fixed in the functions in Sema.