### PR TITLE
linux: Add recent clone/clone3 and missing signalfd flags.

### DIFF
--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -887,6 +887,7 @@ pub const CLONE_VM = 0x00000100;
 pub const CLONE_FS = 0x00000200;
 pub const CLONE_FILES = 0x00000400;
 pub const CLONE_SIGHAND = 0x00000800;
+pub const CLONE_PIDFD = 0x00001000;
 pub const CLONE_PTRACE = 0x00002000;
 pub const CLONE_VFORK = 0x00004000;
 pub const CLONE_PARENT = 0x00008000;
@@ -911,6 +912,8 @@ pub const CLONE_IO = 0x80000000;
 
 /// Clear any signal handler and reset to SIG_DFL.
 pub const CLONE_CLEAR_SIGHAND = 0x100000000;
+/// Clone into a specific cgroup given the right permissions.
+pub const CLONE_INTO_CGROUP = 0x200000000;
 
 // cloning flags intersect with CSIGNAL so can be used with unshare and clone3 syscalls only.
 
@@ -1130,6 +1133,9 @@ pub const SIG_DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
 pub const SIG_IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
 
 pub const empty_sigset = [_]u32{0} ** @typeInfo(sigset_t).Array.len;
+
+pub const SFD_CLOEXEC = O_CLOEXEC;
+pub const SFD_NONBLOCK = O_NONBLOCK;
 
 pub const signalfd_siginfo = extern struct {
     signo: u32,


### PR DESCRIPTION
The following flags have been introduced:
- [CLONE_PIDFD (>=5.2)](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/sched.h#n15)
- [CLONE_INTO_CGROUP (>=5.7)](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/sched.h#n38)
- [SFD_CLOEXEC and SFD_NONBLOCK (>=2.6.27)](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/signalfd.h#n17)