### PR TITLE
Add std.debug.println

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -73,6 +73,10 @@ pub fn print(comptime fmt: []const u8, args: anytype) void {
     nosuspend stderr.print(fmt, args) catch return;
 }
 
+pub fn println(comptime fmt: []const u8, args: anytype) void {
+    print(fmt ++ "\n", args);
+}
+
 pub fn getStderrMutex() *std.Thread.Mutex {
     return &stderr_mutex;
 }


### PR DESCRIPTION
Add a `println` shortcut to `std.debug`.