### PR TITLE
Update comment: s/var/anytype/

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -259,7 +259,7 @@ pub const TypeInfo = union(enum) {
         /// This field is an optional type.
         /// The type of the sentinel is the element type of the array, which is
         /// the value of the `child` field in this struct. However there is no way
-        /// to refer to that type here, so we use `var`.
+        /// to refer to that type here, so we use `anytype`.
         sentinel: anytype,
     };
 


### PR DESCRIPTION
I took a glance through `rg '[^\s]\bvar\b[^\s]'` and it seems that this is the only one left.