### PR TITLE
Don't define valgrind_support on macOS

### DIFF
--- a/src/stage1/target.cpp
+++ b/src/stage1/target.cpp
@@ -919,7 +919,7 @@ bool target_has_valgrind_support(const ZigTarget *target) {
         case ZigLLVM_UnknownArch:
             zig_unreachable();
         case ZigLLVM_x86_64:
-            return (target->os == OsLinux || target_os_is_darwin(target->os) || target->os == OsSolaris ||
+            return (target->os == OsLinux || target->os == OsSolaris ||
                 (target->os == OsWindows && target->abi != ZigLLVM_MSVC));
         default:
             return false;

--- a/src/target.zig
+++ b/src/target.zig
@@ -163,7 +163,7 @@ pub fn isSingleThreaded(target: std.Target) bool {
 pub fn hasValgrindSupport(target: std.Target) bool {
     switch (target.cpu.arch) {
         .x86_64 => {
-            return target.os.tag == .linux or target.isDarwin() or target.os.tag == .solaris or
+            return target.os.tag == .linux or target.os.tag == .solaris or
                 (target.os.tag == .windows and target.abi != .msvc);
         },
         else => return false,


### PR DESCRIPTION
Unfortunately, Valgrind for macOS has been broken for years, and the Homebrew formula is only for Linux.