### PR TITLE
std: Use truncating cast in WIFSTOPPED for Linux, FreeBSD and DragonFly

### DIFF
--- a/lib/std/os/bits/dragonfly.zig
+++ b/lib/std/os/bits/dragonfly.zig
@@ -353,7 +353,7 @@ pub fn WIFEXITED(s: u32) bool {
     return WTERMSIG(s) == 0;
 }
 pub fn WIFSTOPPED(s: u32) bool {
-    return @intCast(u16, (((s & 0xffff) *% 0x10001) >> 8)) > 0x7f00;
+    return @truncate(u16, (((s & 0xffff) *% 0x10001) >> 8)) > 0x7f00;
 }
 pub fn WIFSIGNALED(s: u32) bool {
     return (s & 0xffff) -% 1 < 0xff;

--- a/lib/std/os/bits/freebsd.zig
+++ b/lib/std/os/bits/freebsd.zig
@@ -746,7 +746,7 @@ pub fn WIFEXITED(s: u32) bool {
     return WTERMSIG(s) == 0;
 }
 pub fn WIFSTOPPED(s: u32) bool {
-    return @intCast(u16, (((s & 0xffff) *% 0x10001) >> 8)) > 0x7f00;
+    return @truncate(u16, (((s & 0xffff) *% 0x10001) >> 8)) > 0x7f00;
 }
 pub fn WIFSIGNALED(s: u32) bool {
     return (s & 0xffff) -% 1 < 0xff;

--- a/lib/std/os/bits/linux.zig
+++ b/lib/std/os/bits/linux.zig
@@ -1071,7 +1071,7 @@ pub fn WIFEXITED(s: u32) bool {
     return WTERMSIG(s) == 0;
 }
 pub fn WIFSTOPPED(s: u32) bool {
-    return @intCast(u16, ((s & 0xffff) *% 0x10001) >> 8) > 0x7f00;
+    return @truncate(u16, ((s & 0xffff) *% 0x10001) >> 8) > 0x7f00;
 }
 pub fn WIFSIGNALED(s: u32) bool {
     return (s & 0xffff) -% 1 < 0xff;


### PR DESCRIPTION
The WIFSTOPPED function takes the status from wait(2) and checks if a process was stopped.
The Zig implementations of WIFSTOPPED for Linux [[0]], FreeBSD [[1]] and DragonFly BSD [[2]] are based on the musl [[3]] implementation, but due to the `@intCast` integer cast they will not work for all valid status values.

Zig:
```zig
pub fn WIFSTOPPED(s: u32) bool {
    return @intCast(u16, ((s & 0xffff) *% 0x10001) >> 8) > 0x7f00;
}
```

musl:
```c
#define WIFSTOPPED(s) ((short)((((s)&0xffff)*0x10001)>>8) > 0x7f00)
```

As an example, using ptrace and waiting for a process that stops with a SIGTRAP will return the status value 0x57f (the low byte 0x7f = process stopped, and the signal number is 5 for SIGTRAP). These particular values are the same on all three of the mentioned platforms (I tested on DragonFly because I hadn't used that before, but it behaves the same as expected).

With `s = 0x57f`, the intermediate value before the cast is `(((s)&0xffff)*0x10001)>>8 = 0x57f05`, which will not work as-is with the `@intCast` to `u16`.

Changing to `@truncate` will match the behavior of the explicit cast in the musl version. It also works as intended with `WSTOPSIG` which is used after `WIFSTOPPED` to return the signal number.

[0]: https://github.com/ziglang/zig/blob/master/lib/std/os/bits/linux.zig#L1068
[1]: https://github.com/ziglang/zig/blob/master/lib/std/os/bits/freebsd.zig#L743
[2]: https://github.com/ziglang/zig/blob/master/lib/std/os/bits/dragonfly.zig#L350
[3]: https://github.com/ziglang/zig/blob/master/lib/libc/musl/include/sys/wait.h#L53
