### PR TITLE
Recursively append include dirs of library dependencies

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2666,7 +2666,7 @@ pub const LibExeObjStep = struct {
             try self.makePackageCmd(pkg, &zig_args);
         }
 
-        recursivelyAppendIncludeDirs(step, builder, &zig_args) catch unreachable;
+        try recursivelyAppendIncludeDirs(step, builder, &zig_args);
 
         for (self.lib_paths.items) |lib_path| {
             try zig_args.append("-L");


### PR DESCRIPTION
This commit makes the build system append the include directories of libraries that the LibExeObjStep is being linked against recursively.