### PR TITLE
Some stuff related to zir ref

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -698,7 +698,13 @@ fn expr(gz: *GenZir, scope: *Scope, rl: ResultLoc, node: ast.Node.Index) InnerEr
                 .lhs = lhs,
                 .start = start,
             });
-            return rvalue(gz, rl, result, node);
+            switch (rl) {
+                .ref, .none_or_ref => return result,
+                else => {
+                    const dereffed = try gz.addUnNode(.load, result, node);
+                    return rvalue(gz, rl, dereffed, node);
+                },
+            }
         },
         .slice => {
             const lhs = try expr(gz, scope, .ref, node_datas[node].lhs);
@@ -710,7 +716,13 @@ fn expr(gz: *GenZir, scope: *Scope, rl: ResultLoc, node: ast.Node.Index) InnerEr
                 .start = start,
                 .end = end,
             });
-            return rvalue(gz, rl, result, node);
+            switch (rl) {
+                .ref, .none_or_ref => return result,
+                else => {
+                    const dereffed = try gz.addUnNode(.load, result, node);
+                    return rvalue(gz, rl, dereffed, node);
+                },
+            }
         },
         .slice_sentinel => {
             const lhs = try expr(gz, scope, .ref, node_datas[node].lhs);
@@ -724,7 +736,13 @@ fn expr(gz: *GenZir, scope: *Scope, rl: ResultLoc, node: ast.Node.Index) InnerEr
                 .end = end,
                 .sentinel = sentinel,
             });
-            return rvalue(gz, rl, result, node);
+            switch (rl) {
+                .ref, .none_or_ref => return result,
+                else => {
+                    const dereffed = try gz.addUnNode(.load, result, node);
+                    return rvalue(gz, rl, dereffed, node);
+                },
+            }
         },
 
         .deref => {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -8818,9 +8818,12 @@ fn analyzeRef(
 
     try sema.requireRuntimeBlock(block, src);
     const ptr_type = try Module.simplePtrType(sema.arena, operand_ty, false, .One);
-    const alloc = try block.addTy(.alloc, ptr_type);
+    const mut_ptr_type = try Module.simplePtrType(sema.arena, operand_ty, true, .One);
+    const alloc = try block.addTy(.alloc, mut_ptr_type);
     try sema.storePtr(block, src, alloc, operand);
-    return alloc;
+
+    // TODO: Replace with sema.coerce when that supports adding pointer constness.
+    return sema.bitcast(block, ptr_type, alloc, src);
 }
 
 fn analyzeLoad(

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -495,12 +495,15 @@ pub const Inst = struct {
         /// Uses the `ptr_type` union field.
         ptr_type,
         /// Slice operation `lhs[rhs..]`. No sentinel and no end offset.
+        /// Returns a pointer to the subslice.
         /// Uses the `pl_node` field. AST node is the slice syntax. Payload is `SliceStart`.
         slice_start,
         /// Slice operation `array_ptr[start..end]`. No sentinel.
+        /// Returns a pointer to the subslice.
         /// Uses the `pl_node` field. AST node is the slice syntax. Payload is `SliceEnd`.
         slice_end,
         /// Slice operation `array_ptr[start..end:sentinel]`.
+        /// Returns a pointer to the subslice.
         /// Uses the `pl_node` field. AST node is the slice syntax. Payload is `SliceSentinel`.
         slice_sentinel,
         /// Write a value to a pointer. For loading, see `load`.


### PR DESCRIPTION
* for expressions previously used the `.none_or_ref` result location. Like the other capturing statements, we already know what result type the user wants due to the asterisk in the capturing expression.
* analyzeRef attempted to store the temporary to a const pointer, after which storePtr returned an error. This is fixed by making the temporary mutable, and bitcasting it back to an immutable pointer. The bitcast could be replaced by `Sema.coerce` when that is supports adding const to pointers.
* slicing returned an rvalue rather than an lvalue, while it could always return an lvalue. This causes some unexpected behaviour when writing `x[1..][1..]` for example. It seems that Sema already used the correct semantics here, as it always returns a pointer to the result.

This should fix a bunch of expressions in which a pointer relative to the inner value is returned, like `&x[1..][0].?`.