### PR TITLE
zig fmt: respect trailing commas in inline assembly

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -702,7 +702,7 @@ const LinuxThreadImpl = struct {
                     \\  int $128
                     :
                     : [ptr] "r" (@ptrToInt(self.mapped.ptr)),
-                      [len] "r" (self.mapped.len)
+                      [len] "r" (self.mapped.len),
                     : "memory"
                 ),
                 .x86_64 => asm volatile (
@@ -715,7 +715,7 @@ const LinuxThreadImpl = struct {
                     \\  syscall
                     :
                     : [ptr] "r" (@ptrToInt(self.mapped.ptr)),
-                      [len] "r" (self.mapped.len)
+                      [len] "r" (self.mapped.len),
                     : "memory"
                 ),
                 .arm, .armeb, .thumb, .thumbeb => asm volatile (
@@ -728,7 +728,7 @@ const LinuxThreadImpl = struct {
                     \\  svc 0
                     :
                     : [ptr] "r" (@ptrToInt(self.mapped.ptr)),
-                      [len] "r" (self.mapped.len)
+                      [len] "r" (self.mapped.len),
                     : "memory"
                 ),
                 .aarch64, .aarch64_be, .aarch64_32 => asm volatile (
@@ -741,7 +741,7 @@ const LinuxThreadImpl = struct {
                     \\  svc 0
                     :
                     : [ptr] "r" (@ptrToInt(self.mapped.ptr)),
-                      [len] "r" (self.mapped.len)
+                      [len] "r" (self.mapped.len),
                     : "memory"
                 ),
                 .mips, .mipsel => asm volatile (
@@ -755,7 +755,7 @@ const LinuxThreadImpl = struct {
                     \\  syscall
                     :
                     : [ptr] "r" (@ptrToInt(self.mapped.ptr)),
-                      [len] "r" (self.mapped.len)
+                      [len] "r" (self.mapped.len),
                     : "memory"
                 ),
                 .mips64, .mips64el => asm volatile (
@@ -768,7 +768,7 @@ const LinuxThreadImpl = struct {
                     \\  syscall
                     :
                     : [ptr] "r" (@ptrToInt(self.mapped.ptr)),
-                      [len] "r" (self.mapped.len)
+                      [len] "r" (self.mapped.len),
                     : "memory"
                 ),
                 .powerpc, .powerpcle, .powerpc64, .powerpc64le => asm volatile (
@@ -782,7 +782,7 @@ const LinuxThreadImpl = struct {
                     \\  blr
                     :
                     : [ptr] "r" (@ptrToInt(self.mapped.ptr)),
-                      [len] "r" (self.mapped.len)
+                      [len] "r" (self.mapped.len),
                     : "memory"
                 ),
                 .riscv64 => asm volatile (
@@ -795,7 +795,7 @@ const LinuxThreadImpl = struct {
                     \\  ecall
                     :
                     : [ptr] "r" (@ptrToInt(self.mapped.ptr)),
-                      [len] "r" (self.mapped.len)
+                      [len] "r" (self.mapped.len),
                     : "memory"
                 ),
                 .sparcv9 => asm volatile (
@@ -821,7 +821,7 @@ const LinuxThreadImpl = struct {
                     \\  t 0x6d
                     :
                     : [ptr] "r" (@ptrToInt(self.mapped.ptr)),
-                      [len] "r" (self.mapped.len)
+                      [len] "r" (self.mapped.len),
                     : "memory"
                 ),
                 else => |cpu_arch| @compileError("Unsupported linux arch: " ++ @tagName(cpu_arch)),

--- a/lib/std/atomic/Atomic.zig
+++ b/lib/std/atomic/Atomic.zig
@@ -182,69 +182,69 @@ pub fn Atomic(comptime T: type) type {
                         2 => switch (op) {
                             .Set => asm volatile ("lock btsw %[bit], %[ptr]"
                                 // LLVM doesn't support u1 flag register return values
-                                : [result] "={@ccc}" (-> u8)
+                                : [result] "={@ccc}" (-> u8),
                                 : [ptr] "*p" (&self.value),
-                                  [bit] "X" (@as(T, bit))
+                                  [bit] "X" (@as(T, bit)),
                                 : "cc", "memory"
                             ),
                             .Reset => asm volatile ("lock btrw %[bit], %[ptr]"
                                 // LLVM doesn't support u1 flag register return values
-                                : [result] "={@ccc}" (-> u8)
+                                : [result] "={@ccc}" (-> u8),
                                 : [ptr] "*p" (&self.value),
-                                  [bit] "X" (@as(T, bit))
+                                  [bit] "X" (@as(T, bit)),
                                 : "cc", "memory"
                             ),
                             .Toggle => asm volatile ("lock btcw %[bit], %[ptr]"
                                 // LLVM doesn't support u1 flag register return values
-                                : [result] "={@ccc}" (-> u8)
+                                : [result] "={@ccc}" (-> u8),
                                 : [ptr] "*p" (&self.value),
-                                  [bit] "X" (@as(T, bit))
+                                  [bit] "X" (@as(T, bit)),
                                 : "cc", "memory"
                             ),
                         },
                         4 => switch (op) {
                             .Set => asm volatile ("lock btsl %[bit], %[ptr]"
                                 // LLVM doesn't support u1 flag register return values
-                                : [result] "={@ccc}" (-> u8)
+                                : [result] "={@ccc}" (-> u8),
                                 : [ptr] "*p" (&self.value),
-                                  [bit] "X" (@as(T, bit))
+                                  [bit] "X" (@as(T, bit)),
                                 : "cc", "memory"
                             ),
                             .Reset => asm volatile ("lock btrl %[bit], %[ptr]"
                                 // LLVM doesn't support u1 flag register return values
-                                : [result] "={@ccc}" (-> u8)
+                                : [result] "={@ccc}" (-> u8),
                                 : [ptr] "*p" (&self.value),
-                                  [bit] "X" (@as(T, bit))
+                                  [bit] "X" (@as(T, bit)),
                                 : "cc", "memory"
                             ),
                             .Toggle => asm volatile ("lock btcl %[bit], %[ptr]"
                                 // LLVM doesn't support u1 flag register return values
-                                : [result] "={@ccc}" (-> u8)
+                                : [result] "={@ccc}" (-> u8),
                                 : [ptr] "*p" (&self.value),
-                                  [bit] "X" (@as(T, bit))
+                                  [bit] "X" (@as(T, bit)),
                                 : "cc", "memory"
                             ),
                         },
                         8 => switch (op) {
                             .Set => asm volatile ("lock btsq %[bit], %[ptr]"
                                 // LLVM doesn't support u1 flag register return values
-                                : [result] "={@ccc}" (-> u8)
+                                : [result] "={@ccc}" (-> u8),
                                 : [ptr] "*p" (&self.value),
-                                  [bit] "X" (@as(T, bit))
+                                  [bit] "X" (@as(T, bit)),
                                 : "cc", "memory"
                             ),
                             .Reset => asm volatile ("lock btrq %[bit], %[ptr]"
                                 // LLVM doesn't support u1 flag register return values
-                                : [result] "={@ccc}" (-> u8)
+                                : [result] "={@ccc}" (-> u8),
                                 : [ptr] "*p" (&self.value),
-                                  [bit] "X" (@as(T, bit))
+                                  [bit] "X" (@as(T, bit)),
                                 : "cc", "memory"
                             ),
                             .Toggle => asm volatile ("lock btcq %[bit], %[ptr]"
                                 // LLVM doesn't support u1 flag register return values
-                                : [result] "={@ccc}" (-> u8)
+                                : [result] "={@ccc}" (-> u8),
                                 : [ptr] "*p" (&self.value),
-                                  [bit] "X" (@as(T, bit))
+                                  [bit] "X" (@as(T, bit)),
                                 : "cc", "memory"
                             ),
                         },

--- a/lib/std/crypto/aes/aesni.zig
+++ b/lib/std/crypto/aes/aesni.zig
@@ -40,9 +40,9 @@ pub const Block = struct {
         return Block{
             .repr = asm (
                 \\ vaesenc %[rk], %[in], %[out]
-                : [out] "=x" (-> BlockVec)
+                : [out] "=x" (-> BlockVec),
                 : [in] "x" (block.repr),
-                  [rk] "x" (round_key.repr)
+                  [rk] "x" (round_key.repr),
             ),
         };
     }
@@ -52,9 +52,9 @@ pub const Block = struct {
         return Block{
             .repr = asm (
                 \\ vaesenclast %[rk], %[in], %[out]
-                : [out] "=x" (-> BlockVec)
+                : [out] "=x" (-> BlockVec),
                 : [in] "x" (block.repr),
-                  [rk] "x" (round_key.repr)
+                  [rk] "x" (round_key.repr),
             ),
         };
     }
@@ -64,9 +64,9 @@ pub const Block = struct {
         return Block{
             .repr = asm (
                 \\ vaesdec %[rk], %[in], %[out]
-                : [out] "=x" (-> BlockVec)
+                : [out] "=x" (-> BlockVec),
                 : [in] "x" (block.repr),
-                  [rk] "x" (inv_round_key.repr)
+                  [rk] "x" (inv_round_key.repr),
             ),
         };
     }
@@ -76,9 +76,9 @@ pub const Block = struct {
         return Block{
             .repr = asm (
                 \\ vaesdeclast %[rk], %[in], %[out]
-                : [out] "=x" (-> BlockVec)
+                : [out] "=x" (-> BlockVec),
                 : [in] "x" (block.repr),
-                  [rk] "x" (inv_round_key.repr)
+                  [rk] "x" (inv_round_key.repr),
             ),
         };
     }
@@ -196,11 +196,11 @@ fn KeySchedule(comptime Aes: type) type {
                 \\ vpxor   %[ts], %[r], %[r]
                 : [r] "=&x" (-> BlockVec),
                   [s] "=&x" (s),
-                  [ts] "=&x" (ts)
+                  [ts] "=&x" (ts),
                 : [rc] "n" (rc),
                   [t] "x" (t),
                   [tx] "x" (tx),
-                  [mask] "n" (@as(u8, if (second) 0xaa else 0xff))
+                  [mask] "n" (@as(u8, if (second) 0xaa else 0xff)),
             );
         }
 
@@ -241,8 +241,8 @@ fn KeySchedule(comptime Aes: type) type {
                 inv_round_keys[i] = Block{
                     .repr = asm (
                         \\ vaesimc %[rk], %[inv_rk]
-                        : [inv_rk] "=x" (-> BlockVec)
-                        : [rk] "x" (round_keys[rounds - i].repr)
+                        : [inv_rk] "=x" (-> BlockVec),
+                        : [rk] "x" (round_keys[rounds - i].repr),
                     ),
                 };
             }

--- a/lib/std/crypto/aes/armcrypto.zig
+++ b/lib/std/crypto/aes/armcrypto.zig
@@ -45,10 +45,10 @@ pub const Block = struct {
                 \\ aese  %[out].16b, %[zero].16b
                 \\ aesmc %[out].16b, %[out].16b
                 \\ eor   %[out].16b, %[out].16b, %[rk].16b
-                : [out] "=&x" (-> BlockVec)
+                : [out] "=&x" (-> BlockVec),
                 : [in] "x" (block.repr),
                   [rk] "x" (round_key.repr),
-                  [zero] "x" (zero)
+                  [zero] "x" (zero),
             ),
         };
     }
@@ -60,10 +60,10 @@ pub const Block = struct {
                 \\ mov   %[out].16b, %[in].16b
                 \\ aese  %[out].16b, %[zero].16b
                 \\ eor   %[out].16b, %[out].16b, %[rk].16b
-                : [out] "=&x" (-> BlockVec)
+                : [out] "=&x" (-> BlockVec),
                 : [in] "x" (block.repr),
                   [rk] "x" (round_key.repr),
-                  [zero] "x" (zero)
+                  [zero] "x" (zero),
             ),
         };
     }
@@ -76,10 +76,10 @@ pub const Block = struct {
                 \\ aesd  %[out].16b, %[zero].16b
                 \\ aesimc %[out].16b, %[out].16b
                 \\ eor   %[out].16b, %[out].16b, %[rk].16b
-                : [out] "=&x" (-> BlockVec)
+                : [out] "=&x" (-> BlockVec),
                 : [in] "x" (block.repr),
                   [rk] "x" (inv_round_key.repr),
-                  [zero] "x" (zero)
+                  [zero] "x" (zero),
             ),
         };
     }
@@ -91,10 +91,10 @@ pub const Block = struct {
                 \\ mov   %[out].16b, %[in].16b
                 \\ aesd  %[out].16b, %[zero].16b
                 \\ eor   %[out].16b, %[out].16b, %[rk].16b
-                : [out] "=&x" (-> BlockVec)
+                : [out] "=&x" (-> BlockVec),
                 : [in] "x" (block.repr),
                   [rk] "x" (inv_round_key.repr),
-                  [zero] "x" (zero)
+                  [zero] "x" (zero),
             ),
         };
     }
@@ -216,11 +216,11 @@ fn KeySchedule(comptime Aes: type) type {
                   [v1] "=&x" (v1),
                   [v2] "=&x" (v2),
                   [v3] "=&x" (v3),
-                  [v4] "=&x" (v4)
+                  [v4] "=&x" (v4),
                 : [rc] "N" (rc),
                   [t] "x" (t),
                   [zero] "x" (zero),
-                  [mask] "x" (mask1)
+                  [mask] "x" (mask1),
             );
         }
 
@@ -246,12 +246,12 @@ fn KeySchedule(comptime Aes: type) type {
                   [v1] "=&x" (v1),
                   [v2] "=&x" (v2),
                   [v3] "=&x" (v3),
-                  [v4] "=&x" (v4)
+                  [v4] "=&x" (v4),
                 : [rc] "N" (if (second) @as(u8, 0) else rc),
                   [t] "x" (t),
                   [tx] "x" (tx),
                   [zero] "x" (zero),
-                  [mask] "x" (if (second) mask2 else mask1)
+                  [mask] "x" (if (second) mask2 else mask1),
             );
         }
 
@@ -292,8 +292,8 @@ fn KeySchedule(comptime Aes: type) type {
                 inv_round_keys[i] = Block{
                     .repr = asm (
                         \\ aesimc %[inv_rk].16b, %[rk].16b
-                        : [inv_rk] "=x" (-> BlockVec)
-                        : [rk] "x" (round_keys[rounds - i].repr)
+                        : [inv_rk] "=x" (-> BlockVec),
+                        : [rk] "x" (round_keys[rounds - i].repr),
                     ),
                 };
             }

--- a/lib/std/crypto/ghash.zig
+++ b/lib/std/crypto/ghash.zig
@@ -99,9 +99,9 @@ pub const Ghash = struct {
         const Vector = std.meta.Vector;
         const product = asm (
             \\ vpclmulqdq $0x00, %[x], %[y], %[out]
-            : [out] "=x" (-> Vector(2, u64))
+            : [out] "=x" (-> Vector(2, u64)),
             : [x] "x" (@bitCast(Vector(2, u64), @as(u128, x))),
-              [y] "x" (@bitCast(Vector(2, u64), @as(u128, y)))
+              [y] "x" (@bitCast(Vector(2, u64), @as(u128, y))),
         );
         return product[0];
     }
@@ -110,9 +110,9 @@ pub const Ghash = struct {
         const Vector = std.meta.Vector;
         const product = asm (
             \\ pmull %[out].1q, %[x].1d, %[y].1d
-            : [out] "=w" (-> Vector(2, u64))
+            : [out] "=w" (-> Vector(2, u64)),
             : [x] "w" (@bitCast(Vector(2, u64), @as(u128, x))),
-              [y] "w" (@bitCast(Vector(2, u64), @as(u128, y)))
+              [y] "w" (@bitCast(Vector(2, u64), @as(u128, y))),
         );
         return product[0];
     }

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1639,7 +1639,7 @@ fn handleSegfaultWindowsExtra(info: *windows.EXCEPTION_POINTERS, comptime msg: u
 
 pub fn dumpStackPointerAddr(prefix: []const u8) void {
     const sp = asm (""
-        : [argc] "={rsp}" (-> usize)
+        : [argc] "={rsp}" (-> usize),
     );
     std.debug.warn("{} sp = 0x{x}\n", .{ prefix, sp });
 }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2865,7 +2865,7 @@ pub fn alignForwardGeneric(comptime T: type, addr: T, alignment: T) T {
 pub fn doNotOptimizeAway(val: anytype) void {
     asm volatile (""
         :
-        : [val] "rm" (val)
+        : [val] "rm" (val),
         : "memory"
     );
 }

--- a/lib/std/os/linux/arm-eabi.zig
+++ b/lib/std/os/linux/arm-eabi.zig
@@ -7,63 +7,63 @@ usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile ("svc #0"
-        : [ret] "={r0}" (-> usize)
-        : [number] "{r7}" (@enumToInt(number))
+        : [ret] "={r0}" (-> usize),
+        : [number] "{r7}" (@enumToInt(number)),
         : "memory"
     );
 }
 
 pub fn syscall1(number: SYS, arg1: usize) usize {
     return asm volatile ("svc #0"
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [number] "{r7}" (@enumToInt(number)),
-          [arg1] "{r0}" (arg1)
+          [arg1] "{r0}" (arg1),
         : "memory"
     );
 }
 
 pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
     return asm volatile ("svc #0"
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [number] "{r7}" (@enumToInt(number)),
           [arg1] "{r0}" (arg1),
-          [arg2] "{r1}" (arg2)
+          [arg2] "{r1}" (arg2),
         : "memory"
     );
 }
 
 pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
     return asm volatile ("svc #0"
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [number] "{r7}" (@enumToInt(number)),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
-          [arg3] "{r2}" (arg3)
+          [arg3] "{r2}" (arg3),
         : "memory"
     );
 }
 
 pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize) usize {
     return asm volatile ("svc #0"
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [number] "{r7}" (@enumToInt(number)),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
           [arg3] "{r2}" (arg3),
-          [arg4] "{r3}" (arg4)
+          [arg4] "{r3}" (arg4),
         : "memory"
     );
 }
 
 pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) usize {
     return asm volatile ("svc #0"
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [number] "{r7}" (@enumToInt(number)),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
           [arg3] "{r2}" (arg3),
           [arg4] "{r3}" (arg4),
-          [arg5] "{r4}" (arg5)
+          [arg5] "{r4}" (arg5),
         : "memory"
     );
 }
@@ -78,14 +78,14 @@ pub fn syscall6(
     arg6: usize,
 ) usize {
     return asm volatile ("svc #0"
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [number] "{r7}" (@enumToInt(number)),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
           [arg3] "{r2}" (arg3),
           [arg4] "{r3}" (arg4),
           [arg5] "{r4}" (arg5),
-          [arg6] "{r5}" (arg6)
+          [arg6] "{r5}" (arg6),
         : "memory"
     );
 }
@@ -96,7 +96,7 @@ pub extern fn clone(func: fn (arg: usize) callconv(.C) u8, stack: usize, flags: 
 pub fn restore() callconv(.Naked) void {
     return asm volatile ("svc #0"
         :
-        : [number] "{r7}" (@enumToInt(SYS.sigreturn))
+        : [number] "{r7}" (@enumToInt(SYS.sigreturn)),
         : "memory"
     );
 }
@@ -104,7 +104,7 @@ pub fn restore() callconv(.Naked) void {
 pub fn restore_rt() callconv(.Naked) void {
     return asm volatile ("svc #0"
         :
-        : [number] "{r7}" (@enumToInt(SYS.rt_sigreturn))
+        : [number] "{r7}" (@enumToInt(SYS.rt_sigreturn)),
         : "memory"
     );
 }

--- a/lib/std/os/linux/arm64.zig
+++ b/lib/std/os/linux/arm64.zig
@@ -7,63 +7,63 @@ usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile ("svc #0"
-        : [ret] "={x0}" (-> usize)
-        : [number] "{x8}" (@enumToInt(number))
+        : [ret] "={x0}" (-> usize),
+        : [number] "{x8}" (@enumToInt(number)),
         : "memory", "cc"
     );
 }
 
 pub fn syscall1(number: SYS, arg1: usize) usize {
     return asm volatile ("svc #0"
-        : [ret] "={x0}" (-> usize)
+        : [ret] "={x0}" (-> usize),
         : [number] "{x8}" (@enumToInt(number)),
-          [arg1] "{x0}" (arg1)
+          [arg1] "{x0}" (arg1),
         : "memory", "cc"
     );
 }
 
 pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
     return asm volatile ("svc #0"
-        : [ret] "={x0}" (-> usize)
+        : [ret] "={x0}" (-> usize),
         : [number] "{x8}" (@enumToInt(number)),
           [arg1] "{x0}" (arg1),
-          [arg2] "{x1}" (arg2)
+          [arg2] "{x1}" (arg2),
         : "memory", "cc"
     );
 }
 
 pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
     return asm volatile ("svc #0"
-        : [ret] "={x0}" (-> usize)
+        : [ret] "={x0}" (-> usize),
         : [number] "{x8}" (@enumToInt(number)),
           [arg1] "{x0}" (arg1),
           [arg2] "{x1}" (arg2),
-          [arg3] "{x2}" (arg3)
+          [arg3] "{x2}" (arg3),
         : "memory", "cc"
     );
 }
 
 pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize) usize {
     return asm volatile ("svc #0"
-        : [ret] "={x0}" (-> usize)
+        : [ret] "={x0}" (-> usize),
         : [number] "{x8}" (@enumToInt(number)),
           [arg1] "{x0}" (arg1),
           [arg2] "{x1}" (arg2),
           [arg3] "{x2}" (arg3),
-          [arg4] "{x3}" (arg4)
+          [arg4] "{x3}" (arg4),
         : "memory", "cc"
     );
 }
 
 pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) usize {
     return asm volatile ("svc #0"
-        : [ret] "={x0}" (-> usize)
+        : [ret] "={x0}" (-> usize),
         : [number] "{x8}" (@enumToInt(number)),
           [arg1] "{x0}" (arg1),
           [arg2] "{x1}" (arg2),
           [arg3] "{x2}" (arg3),
           [arg4] "{x3}" (arg4),
-          [arg5] "{x4}" (arg5)
+          [arg5] "{x4}" (arg5),
         : "memory", "cc"
     );
 }
@@ -78,14 +78,14 @@ pub fn syscall6(
     arg6: usize,
 ) usize {
     return asm volatile ("svc #0"
-        : [ret] "={x0}" (-> usize)
+        : [ret] "={x0}" (-> usize),
         : [number] "{x8}" (@enumToInt(number)),
           [arg1] "{x0}" (arg1),
           [arg2] "{x1}" (arg2),
           [arg3] "{x2}" (arg3),
           [arg4] "{x3}" (arg4),
           [arg5] "{x4}" (arg5),
-          [arg6] "{x5}" (arg6)
+          [arg6] "{x5}" (arg6),
         : "memory", "cc"
     );
 }
@@ -98,7 +98,7 @@ pub const restore = restore_rt;
 pub fn restore_rt() callconv(.Naked) void {
     return asm volatile ("svc #0"
         :
-        : [number] "{x8}" (@enumToInt(SYS.rt_sigreturn))
+        : [number] "{x8}" (@enumToInt(SYS.rt_sigreturn)),
         : "memory", "cc"
     );
 }

--- a/lib/std/os/linux/i386.zig
+++ b/lib/std/os/linux/i386.zig
@@ -7,63 +7,63 @@ usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile ("int $0x80"
-        : [ret] "={eax}" (-> usize)
-        : [number] "{eax}" (@enumToInt(number))
+        : [ret] "={eax}" (-> usize),
+        : [number] "{eax}" (@enumToInt(number)),
         : "memory"
     );
 }
 
 pub fn syscall1(number: SYS, arg1: usize) usize {
     return asm volatile ("int $0x80"
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [number] "{eax}" (@enumToInt(number)),
-          [arg1] "{ebx}" (arg1)
+          [arg1] "{ebx}" (arg1),
         : "memory"
     );
 }
 
 pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
     return asm volatile ("int $0x80"
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [number] "{eax}" (@enumToInt(number)),
           [arg1] "{ebx}" (arg1),
-          [arg2] "{ecx}" (arg2)
+          [arg2] "{ecx}" (arg2),
         : "memory"
     );
 }
 
 pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
     return asm volatile ("int $0x80"
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [number] "{eax}" (@enumToInt(number)),
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
-          [arg3] "{edx}" (arg3)
+          [arg3] "{edx}" (arg3),
         : "memory"
     );
 }
 
 pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize) usize {
     return asm volatile ("int $0x80"
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [number] "{eax}" (@enumToInt(number)),
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
           [arg3] "{edx}" (arg3),
-          [arg4] "{esi}" (arg4)
+          [arg4] "{esi}" (arg4),
         : "memory"
     );
 }
 
 pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) usize {
     return asm volatile ("int $0x80"
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [number] "{eax}" (@enumToInt(number)),
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
           [arg3] "{edx}" (arg3),
           [arg4] "{esi}" (arg4),
-          [arg5] "{edi}" (arg5)
+          [arg5] "{edi}" (arg5),
         : "memory"
     );
 }
@@ -88,24 +88,24 @@ pub fn syscall6(
         \\ int  $0x80
         \\ pop  %%ebp
         \\ add  $4, %%esp
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [number] "{eax}" (@enumToInt(number)),
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
           [arg3] "{edx}" (arg3),
           [arg4] "{esi}" (arg4),
           [arg5] "{edi}" (arg5),
-          [arg6] "rm" (arg6)
+          [arg6] "rm" (arg6),
         : "memory"
     );
 }
 
 pub fn socketcall(call: usize, args: [*]usize) usize {
     return asm volatile ("int $0x80"
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [number] "{eax}" (@enumToInt(SYS.socketcall)),
           [arg1] "{ebx}" (call),
-          [arg2] "{ecx}" (@ptrToInt(args))
+          [arg2] "{ecx}" (@ptrToInt(args)),
         : "memory"
     );
 }
@@ -116,7 +116,7 @@ pub extern fn clone(func: fn (arg: usize) callconv(.C) u8, stack: usize, flags: 
 pub fn restore() callconv(.Naked) void {
     return asm volatile ("int $0x80"
         :
-        : [number] "{eax}" (@enumToInt(SYS.sigreturn))
+        : [number] "{eax}" (@enumToInt(SYS.sigreturn)),
         : "memory"
     );
 }
@@ -124,7 +124,7 @@ pub fn restore() callconv(.Naked) void {
 pub fn restore_rt() callconv(.Naked) void {
     return asm volatile ("int $0x80"
         :
-        : [number] "{eax}" (@enumToInt(SYS.rt_sigreturn))
+        : [number] "{eax}" (@enumToInt(SYS.rt_sigreturn)),
         : "memory"
     );
 }

--- a/lib/std/os/linux/mips.zig
+++ b/lib/std/os/linux/mips.zig
@@ -11,8 +11,8 @@ pub fn syscall0(number: SYS) usize {
         \\ blez $7, 1f
         \\ subu $2, $0, $2
         \\ 1:
-        : [ret] "={$2}" (-> usize)
-        : [number] "{$2}" (@enumToInt(number))
+        : [ret] "={$2}" (-> usize),
+        : [number] "{$2}" (@enumToInt(number)),
         : "memory", "cc", "$7"
     );
 }
@@ -30,9 +30,9 @@ pub fn syscall_pipe(fd: *[2]i32) usize {
         \\ sw $2, 0($4)
         \\ sw $3, 4($4)
         \\ 2:
-        : [ret] "={$2}" (-> usize)
+        : [ret] "={$2}" (-> usize),
         : [number] "{$2}" (@enumToInt(SYS.pipe)),
-          [fd] "{$4}" (fd)
+          [fd] "{$4}" (fd),
         : "memory", "cc", "$7"
     );
 }
@@ -43,9 +43,9 @@ pub fn syscall1(number: SYS, arg1: usize) usize {
         \\ blez $7, 1f
         \\ subu $2, $0, $2
         \\ 1:
-        : [ret] "={$2}" (-> usize)
+        : [ret] "={$2}" (-> usize),
         : [number] "{$2}" (@enumToInt(number)),
-          [arg1] "{$4}" (arg1)
+          [arg1] "{$4}" (arg1),
         : "memory", "cc", "$7"
     );
 }
@@ -56,10 +56,10 @@ pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
         \\ blez $7, 1f
         \\ subu $2, $0, $2
         \\ 1:
-        : [ret] "={$2}" (-> usize)
+        : [ret] "={$2}" (-> usize),
         : [number] "{$2}" (@enumToInt(number)),
           [arg1] "{$4}" (arg1),
-          [arg2] "{$5}" (arg2)
+          [arg2] "{$5}" (arg2),
         : "memory", "cc", "$7"
     );
 }
@@ -70,11 +70,11 @@ pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
         \\ blez $7, 1f
         \\ subu $2, $0, $2
         \\ 1:
-        : [ret] "={$2}" (-> usize)
+        : [ret] "={$2}" (-> usize),
         : [number] "{$2}" (@enumToInt(number)),
           [arg1] "{$4}" (arg1),
           [arg2] "{$5}" (arg2),
-          [arg3] "{$6}" (arg3)
+          [arg3] "{$6}" (arg3),
         : "memory", "cc", "$7"
     );
 }
@@ -85,12 +85,12 @@ pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize)
         \\ blez $7, 1f
         \\ subu $2, $0, $2
         \\ 1:
-        : [ret] "={$2}" (-> usize)
+        : [ret] "={$2}" (-> usize),
         : [number] "{$2}" (@enumToInt(number)),
           [arg1] "{$4}" (arg1),
           [arg2] "{$5}" (arg2),
           [arg3] "{$6}" (arg3),
-          [arg4] "{$7}" (arg4)
+          [arg4] "{$7}" (arg4),
         : "memory", "cc", "$7"
     );
 }
@@ -105,13 +105,13 @@ pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
         \\ blez $7, 1f
         \\ subu $2, $0, $2
         \\ 1:
-        : [ret] "={$2}" (-> usize)
+        : [ret] "={$2}" (-> usize),
         : [number] "{$2}" (@enumToInt(number)),
           [arg1] "{$4}" (arg1),
           [arg2] "{$5}" (arg2),
           [arg3] "{$6}" (arg3),
           [arg4] "{$7}" (arg4),
-          [arg5] "r" (arg5)
+          [arg5] "r" (arg5),
         : "memory", "cc", "$7"
     );
 }
@@ -138,14 +138,14 @@ pub fn syscall6(
         \\ blez $7, 1f
         \\ subu $2, $0, $2
         \\ 1:
-        : [ret] "={$2}" (-> usize)
+        : [ret] "={$2}" (-> usize),
         : [number] "{$2}" (@enumToInt(number)),
           [arg1] "{$4}" (arg1),
           [arg2] "{$5}" (arg2),
           [arg3] "{$6}" (arg3),
           [arg4] "{$7}" (arg4),
           [arg5] "r" (arg5),
-          [arg6] "r" (arg6)
+          [arg6] "r" (arg6),
         : "memory", "cc", "$7"
     );
 }
@@ -171,7 +171,7 @@ pub fn syscall7(
         \\ blez $7, 1f
         \\ subu $2, $0, $2
         \\ 1:
-        : [ret] "={$2}" (-> usize)
+        : [ret] "={$2}" (-> usize),
         : [number] "{$2}" (@enumToInt(number)),
           [arg1] "{$4}" (arg1),
           [arg2] "{$5}" (arg2),
@@ -179,7 +179,7 @@ pub fn syscall7(
           [arg4] "{$7}" (arg4),
           [arg5] "r" (arg5),
           [arg6] "r" (arg6),
-          [arg7] "r" (arg7)
+          [arg7] "r" (arg7),
         : "memory", "cc", "$7"
     );
 }
@@ -190,7 +190,7 @@ pub extern fn clone(func: fn (arg: usize) callconv(.C) u8, stack: usize, flags: 
 pub fn restore() callconv(.Naked) void {
     return asm volatile ("syscall"
         :
-        : [number] "{$2}" (@enumToInt(SYS.sigreturn))
+        : [number] "{$2}" (@enumToInt(SYS.sigreturn)),
         : "memory", "cc", "$7"
     );
 }
@@ -198,7 +198,7 @@ pub fn restore() callconv(.Naked) void {
 pub fn restore_rt() callconv(.Naked) void {
     return asm volatile ("syscall"
         :
-        : [number] "{$2}" (@enumToInt(SYS.rt_sigreturn))
+        : [number] "{$2}" (@enumToInt(SYS.rt_sigreturn)),
         : "memory", "cc", "$7"
     );
 }

--- a/lib/std/os/linux/powerpc.zig
+++ b/lib/std/os/linux/powerpc.zig
@@ -12,8 +12,8 @@ pub fn syscall0(number: SYS) usize {
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
-        : [number] "{r0}" (@enumToInt(number))
+        : [ret] "={r3}" (-> usize),
+        : [number] "{r0}" (@enumToInt(number)),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -24,9 +24,9 @@ pub fn syscall1(number: SYS, arg1: usize) usize {
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
-          [arg1] "{r3}" (arg1)
+          [arg1] "{r3}" (arg1),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -37,10 +37,10 @@ pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
           [arg1] "{r3}" (arg1),
-          [arg2] "{r4}" (arg2)
+          [arg2] "{r4}" (arg2),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -51,11 +51,11 @@ pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
-          [arg3] "{r5}" (arg3)
+          [arg3] "{r5}" (arg3),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -66,12 +66,12 @@ pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize)
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
-          [arg4] "{r6}" (arg4)
+          [arg4] "{r6}" (arg4),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -82,13 +82,13 @@ pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
           [arg4] "{r6}" (arg4),
-          [arg5] "{r7}" (arg5)
+          [arg5] "{r7}" (arg5),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -107,14 +107,14 @@ pub fn syscall6(
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
           [arg4] "{r6}" (arg4),
           [arg5] "{r7}" (arg5),
-          [arg6] "{r8}" (arg6)
+          [arg6] "{r8}" (arg6),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -127,7 +127,7 @@ pub const restore = restore_rt;
 pub fn restore_rt() callconv(.Naked) void {
     return asm volatile ("sc"
         :
-        : [number] "{r0}" (@enumToInt(SYS.rt_sigreturn))
+        : [number] "{r0}" (@enumToInt(SYS.rt_sigreturn)),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }

--- a/lib/std/os/linux/powerpc64.zig
+++ b/lib/std/os/linux/powerpc64.zig
@@ -12,8 +12,8 @@ pub fn syscall0(number: SYS) usize {
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
-        : [number] "{r0}" (@enumToInt(number))
+        : [ret] "={r3}" (-> usize),
+        : [number] "{r0}" (@enumToInt(number)),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -24,9 +24,9 @@ pub fn syscall1(number: SYS, arg1: usize) usize {
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
-          [arg1] "{r3}" (arg1)
+          [arg1] "{r3}" (arg1),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -37,10 +37,10 @@ pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
           [arg1] "{r3}" (arg1),
-          [arg2] "{r4}" (arg2)
+          [arg2] "{r4}" (arg2),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -51,11 +51,11 @@ pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
-          [arg3] "{r5}" (arg3)
+          [arg3] "{r5}" (arg3),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -66,12 +66,12 @@ pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize)
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
-          [arg4] "{r6}" (arg4)
+          [arg4] "{r6}" (arg4),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -82,13 +82,13 @@ pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
           [arg4] "{r6}" (arg4),
-          [arg5] "{r7}" (arg5)
+          [arg5] "{r7}" (arg5),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -107,14 +107,14 @@ pub fn syscall6(
         \\ bns+ 1f
         \\ neg 3, 3
         \\ 1:
-        : [ret] "={r3}" (-> usize)
+        : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@enumToInt(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
           [arg4] "{r6}" (arg4),
           [arg5] "{r7}" (arg5),
-          [arg6] "{r8}" (arg6)
+          [arg6] "{r8}" (arg6),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
@@ -127,7 +127,7 @@ pub const restore = restore_rt;
 pub fn restore_rt() callconv(.Naked) void {
     return asm volatile ("sc"
         :
-        : [number] "{r0}" (@enumToInt(SYS.rt_sigreturn))
+        : [number] "{r0}" (@enumToInt(SYS.rt_sigreturn)),
         : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }

--- a/lib/std/os/linux/riscv64.zig
+++ b/lib/std/os/linux/riscv64.zig
@@ -7,63 +7,63 @@ usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile ("ecall"
-        : [ret] "={x10}" (-> usize)
-        : [number] "{x17}" (@enumToInt(number))
+        : [ret] "={x10}" (-> usize),
+        : [number] "{x17}" (@enumToInt(number)),
         : "memory"
     );
 }
 
 pub fn syscall1(number: SYS, arg1: usize) usize {
     return asm volatile ("ecall"
-        : [ret] "={x10}" (-> usize)
+        : [ret] "={x10}" (-> usize),
         : [number] "{x17}" (@enumToInt(number)),
-          [arg1] "{x10}" (arg1)
+          [arg1] "{x10}" (arg1),
         : "memory"
     );
 }
 
 pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
     return asm volatile ("ecall"
-        : [ret] "={x10}" (-> usize)
+        : [ret] "={x10}" (-> usize),
         : [number] "{x17}" (@enumToInt(number)),
           [arg1] "{x10}" (arg1),
-          [arg2] "{x11}" (arg2)
+          [arg2] "{x11}" (arg2),
         : "memory"
     );
 }
 
 pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
     return asm volatile ("ecall"
-        : [ret] "={x10}" (-> usize)
+        : [ret] "={x10}" (-> usize),
         : [number] "{x17}" (@enumToInt(number)),
           [arg1] "{x10}" (arg1),
           [arg2] "{x11}" (arg2),
-          [arg3] "{x12}" (arg3)
+          [arg3] "{x12}" (arg3),
         : "memory"
     );
 }
 
 pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize) usize {
     return asm volatile ("ecall"
-        : [ret] "={x10}" (-> usize)
+        : [ret] "={x10}" (-> usize),
         : [number] "{x17}" (@enumToInt(number)),
           [arg1] "{x10}" (arg1),
           [arg2] "{x11}" (arg2),
           [arg3] "{x12}" (arg3),
-          [arg4] "{x13}" (arg4)
+          [arg4] "{x13}" (arg4),
         : "memory"
     );
 }
 
 pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) usize {
     return asm volatile ("ecall"
-        : [ret] "={x10}" (-> usize)
+        : [ret] "={x10}" (-> usize),
         : [number] "{x17}" (@enumToInt(number)),
           [arg1] "{x10}" (arg1),
           [arg2] "{x11}" (arg2),
           [arg3] "{x12}" (arg3),
           [arg4] "{x13}" (arg4),
-          [arg5] "{x14}" (arg5)
+          [arg5] "{x14}" (arg5),
         : "memory"
     );
 }
@@ -78,14 +78,14 @@ pub fn syscall6(
     arg6: usize,
 ) usize {
     return asm volatile ("ecall"
-        : [ret] "={x10}" (-> usize)
+        : [ret] "={x10}" (-> usize),
         : [number] "{x17}" (@enumToInt(number)),
           [arg1] "{x10}" (arg1),
           [arg2] "{x11}" (arg2),
           [arg3] "{x12}" (arg3),
           [arg4] "{x13}" (arg4),
           [arg5] "{x14}" (arg5),
-          [arg6] "{x15}" (arg6)
+          [arg6] "{x15}" (arg6),
         : "memory"
     );
 }
@@ -97,7 +97,7 @@ pub const restore = restore_rt;
 pub fn restore_rt() callconv(.Naked) void {
     return asm volatile ("ecall"
         :
-        : [number] "{x17}" (@enumToInt(SYS.rt_sigreturn))
+        : [number] "{x17}" (@enumToInt(SYS.rt_sigreturn)),
         : "memory"
     );
 }

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -14,9 +14,9 @@ pub fn syscall_pipe(fd: *[2]i32) usize {
         \\ st %%o1, [%%g3+4]
         \\ clr %%o0
         \\2:
-        : [ret] "={o0}" (-> usize)
+        : [ret] "={o0}" (-> usize),
         : [number] "{g1}" (@enumToInt(SYS.pipe)),
-          [arg] "r" (fd)
+          [arg] "r" (fd),
         : "memory", "g3"
     );
 }
@@ -38,8 +38,8 @@ pub fn syscall_fork() usize {
         \\ dec %%o1
         \\ and %%o1, %%o0, %%o0
         \\ 2:
-        : [ret] "={o0}" (-> usize)
-        : [number] "{g1}" (@enumToInt(SYS.fork))
+        : [ret] "={o0}" (-> usize),
+        : [number] "{g1}" (@enumToInt(SYS.fork)),
         : "memory", "xcc", "o1", "o2", "o3", "o4", "o5", "o7"
     );
 }
@@ -51,8 +51,8 @@ pub fn syscall0(number: SYS) usize {
         \\ nop
         \\ neg %%o0
         \\ 1:
-        : [ret] "={o0}" (-> usize)
-        : [number] "{g1}" (@enumToInt(number))
+        : [ret] "={o0}" (-> usize),
+        : [number] "{g1}" (@enumToInt(number)),
         : "memory", "xcc", "o1", "o2", "o3", "o4", "o5", "o7"
     );
 }
@@ -64,9 +64,9 @@ pub fn syscall1(number: SYS, arg1: usize) usize {
         \\ nop
         \\ neg %%o0
         \\ 1:
-        : [ret] "={o0}" (-> usize)
+        : [ret] "={o0}" (-> usize),
         : [number] "{g1}" (@enumToInt(number)),
-          [arg1] "{o0}" (arg1)
+          [arg1] "{o0}" (arg1),
         : "memory", "xcc", "o1", "o2", "o3", "o4", "o5", "o7"
     );
 }
@@ -78,10 +78,10 @@ pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
         \\ nop
         \\ neg %%o0
         \\ 1:
-        : [ret] "={o0}" (-> usize)
+        : [ret] "={o0}" (-> usize),
         : [number] "{g1}" (@enumToInt(number)),
           [arg1] "{o0}" (arg1),
-          [arg2] "{o1}" (arg2)
+          [arg2] "{o1}" (arg2),
         : "memory", "xcc", "o1", "o2", "o3", "o4", "o5", "o7"
     );
 }
@@ -93,11 +93,11 @@ pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
         \\ nop
         \\ neg %%o0
         \\ 1:
-        : [ret] "={o0}" (-> usize)
+        : [ret] "={o0}" (-> usize),
         : [number] "{g1}" (@enumToInt(number)),
           [arg1] "{o0}" (arg1),
           [arg2] "{o1}" (arg2),
-          [arg3] "{o2}" (arg3)
+          [arg3] "{o2}" (arg3),
         : "memory", "xcc", "o1", "o2", "o3", "o4", "o5", "o7"
     );
 }
@@ -109,12 +109,12 @@ pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize)
         \\ nop
         \\ neg %%o0
         \\ 1:
-        : [ret] "={o0}" (-> usize)
+        : [ret] "={o0}" (-> usize),
         : [number] "{g1}" (@enumToInt(number)),
           [arg1] "{o0}" (arg1),
           [arg2] "{o1}" (arg2),
           [arg3] "{o2}" (arg3),
-          [arg4] "{o3}" (arg4)
+          [arg4] "{o3}" (arg4),
         : "memory", "xcc", "o1", "o2", "o3", "o4", "o5", "o7"
     );
 }
@@ -126,13 +126,13 @@ pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
         \\ nop
         \\ neg %%o0
         \\ 1:
-        : [ret] "={o0}" (-> usize)
+        : [ret] "={o0}" (-> usize),
         : [number] "{g1}" (@enumToInt(number)),
           [arg1] "{o0}" (arg1),
           [arg2] "{o1}" (arg2),
           [arg3] "{o2}" (arg3),
           [arg4] "{o3}" (arg4),
-          [arg5] "{o4}" (arg5)
+          [arg5] "{o4}" (arg5),
         : "memory", "xcc", "o1", "o2", "o3", "o4", "o5", "o7"
     );
 }
@@ -152,14 +152,14 @@ pub fn syscall6(
         \\ nop
         \\ neg %%o0
         \\ 1:
-        : [ret] "={o0}" (-> usize)
+        : [ret] "={o0}" (-> usize),
         : [number] "{g1}" (@enumToInt(number)),
           [arg1] "{o0}" (arg1),
           [arg2] "{o1}" (arg2),
           [arg3] "{o2}" (arg3),
           [arg4] "{o3}" (arg4),
           [arg5] "{o4}" (arg5),
-          [arg6] "{o5}" (arg6)
+          [arg6] "{o5}" (arg6),
         : "memory", "xcc", "o1", "o2", "o3", "o4", "o5", "o7"
     );
 }
@@ -172,7 +172,7 @@ pub const restore = restore_rt;
 pub fn restore_rt() callconv(.Naked) void {
     return asm volatile ("t 0x6d"
         :
-        : [number] "{g1}" (@enumToInt(SYS.rt_sigreturn))
+        : [number] "{g1}" (@enumToInt(SYS.rt_sigreturn)),
         : "memory", "xcc", "o0", "o1", "o2", "o3", "o4", "o5", "o7"
     );
 }

--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -30,13 +30,13 @@ fn getDynamicSymbol() [*]elf.Dyn {
             \\ call 1f
             \\ 1: pop %[ret]
             \\ lea _DYNAMIC-1b(%[ret]), %[ret]
-            : [ret] "=r" (-> [*]elf.Dyn)
+            : [ret] "=r" (-> [*]elf.Dyn),
         ),
         .x86_64 => asm volatile (
             \\ .weak _DYNAMIC
             \\ .hidden _DYNAMIC
             \\ lea _DYNAMIC(%%rip), %[ret]
-            : [ret] "=r" (-> [*]elf.Dyn)
+            : [ret] "=r" (-> [*]elf.Dyn),
         ),
         // Work around the limited offset range of `ldr`
         .arm => asm volatile (
@@ -47,7 +47,7 @@ fn getDynamicSymbol() [*]elf.Dyn {
             \\ b 2f
             \\ 1: .word _DYNAMIC-1b
             \\ 2:
-            : [ret] "=r" (-> [*]elf.Dyn)
+            : [ret] "=r" (-> [*]elf.Dyn),
         ),
         // A simple `adr` is not enough as it has a limited offset range
         .aarch64 => asm volatile (
@@ -55,13 +55,13 @@ fn getDynamicSymbol() [*]elf.Dyn {
             \\ .hidden _DYNAMIC
             \\ adrp %[ret], _DYNAMIC
             \\ add %[ret], %[ret], #:lo12:_DYNAMIC
-            : [ret] "=r" (-> [*]elf.Dyn)
+            : [ret] "=r" (-> [*]elf.Dyn),
         ),
         .riscv64 => asm volatile (
             \\ .weak _DYNAMIC
             \\ .hidden _DYNAMIC
             \\ lla %[ret], _DYNAMIC
-            : [ret] "=r" (-> [*]elf.Dyn)
+            : [ret] "=r" (-> [*]elf.Dyn),
         ),
         else => {
             @compileError("PIE startup is not yet supported for this target!");

--- a/lib/std/os/linux/thumb.zig
+++ b/lib/std/os/linux/thumb.zig
@@ -20,8 +20,8 @@ pub fn syscall0(number: SYS) usize {
         \\ ldr r7, [%[tmp]]
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
-        : [ret] "={r0}" (-> usize)
-        : [tmp] "{r1}" (buf)
+        : [ret] "={r0}" (-> usize),
+        : [tmp] "{r1}" (buf),
         : "memory"
     );
 }
@@ -35,9 +35,9 @@ pub fn syscall1(number: SYS, arg1: usize) usize {
         \\ ldr r7, [%[tmp]]
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [tmp] "{r1}" (buf),
-          [arg1] "{r0}" (arg1)
+          [arg1] "{r0}" (arg1),
         : "memory"
     );
 }
@@ -51,10 +51,10 @@ pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
         \\ ldr r7, [%[tmp]]
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [tmp] "{r2}" (buf),
           [arg1] "{r0}" (arg1),
-          [arg2] "{r1}" (arg2)
+          [arg2] "{r1}" (arg2),
         : "memory"
     );
 }
@@ -68,11 +68,11 @@ pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
         \\ ldr r7, [%[tmp]]
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [tmp] "{r3}" (buf),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
-          [arg3] "{r2}" (arg3)
+          [arg3] "{r2}" (arg3),
         : "memory"
     );
 }
@@ -86,12 +86,12 @@ pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize)
         \\ ldr r7, [%[tmp]]
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [tmp] "{r4}" (buf),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
           [arg3] "{r2}" (arg3),
-          [arg4] "{r3}" (arg4)
+          [arg4] "{r3}" (arg4),
         : "memory"
     );
 }
@@ -105,13 +105,13 @@ pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
         \\ ldr r7, [%[tmp]]
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [tmp] "{r5}" (buf),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
           [arg3] "{r2}" (arg3),
           [arg4] "{r3}" (arg4),
-          [arg5] "{r4}" (arg5)
+          [arg5] "{r4}" (arg5),
         : "memory"
     );
 }
@@ -133,14 +133,14 @@ pub fn syscall6(
         \\ ldr r7, [%[tmp]]
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
-        : [ret] "={r0}" (-> usize)
+        : [ret] "={r0}" (-> usize),
         : [tmp] "{r6}" (buf),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
           [arg3] "{r2}" (arg3),
           [arg4] "{r3}" (arg4),
           [arg5] "{r4}" (arg5),
-          [arg6] "{r5}" (arg6)
+          [arg6] "{r5}" (arg6),
         : "memory"
     );
 }
@@ -153,7 +153,7 @@ pub fn restore() callconv(.Naked) void {
         \\ mov r7, %[number]
         \\ svc #0
         :
-        : [number] "I" (@enumToInt(SYS.sigreturn))
+        : [number] "I" (@enumToInt(SYS.sigreturn)),
     );
 }
 
@@ -162,7 +162,7 @@ pub fn restore_rt() callconv(.Naked) void {
         \\ mov r7, %[number]
         \\ svc #0
         :
-        : [number] "I" (@enumToInt(SYS.rt_sigreturn))
+        : [number] "I" (@enumToInt(SYS.rt_sigreturn)),
         : "memory"
     );
 }

--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -136,7 +136,7 @@ pub fn setThreadPointer(addr: usize) void {
             // Update the %gs selector
             asm volatile ("movl %[gs_val], %%gs"
                 :
-                : [gs_val] "r" (gdt_entry_number << 3 | 3)
+                : [gs_val] "r" (gdt_entry_number << 3 | 3),
             );
         },
         .x86_64 => {
@@ -147,7 +147,7 @@ pub fn setThreadPointer(addr: usize) void {
             asm volatile (
                 \\ msr tpidr_el0, %[addr]
                 :
-                : [addr] "r" (addr)
+                : [addr] "r" (addr),
             );
         },
         .arm, .thumb => {
@@ -158,7 +158,7 @@ pub fn setThreadPointer(addr: usize) void {
             asm volatile (
                 \\ mv tp, %[addr]
                 :
-                : [addr] "r" (addr)
+                : [addr] "r" (addr),
             );
         },
         .mips, .mipsel => {
@@ -169,21 +169,21 @@ pub fn setThreadPointer(addr: usize) void {
             asm volatile (
                 \\ mr 2, %[addr]
                 :
-                : [addr] "r" (addr)
+                : [addr] "r" (addr),
             );
         },
         .powerpc64, .powerpc64le => {
             asm volatile (
                 \\ mr 13, %[addr]
                 :
-                : [addr] "r" (addr)
+                : [addr] "r" (addr),
             );
         },
         .sparcv9 => {
             asm volatile (
                 \\ mov %[addr], %%g7
                 :
-                : [addr] "r" (addr)
+                : [addr] "r" (addr),
             );
         },
         else => @compileError("Unsupported architecture"),

--- a/lib/std/os/linux/x86_64.zig
+++ b/lib/std/os/linux/x86_64.zig
@@ -7,63 +7,63 @@ usingnamespace @import("../bits/linux.zig");
 
 pub fn syscall0(number: SYS) usize {
     return asm volatile ("syscall"
-        : [ret] "={rax}" (-> usize)
-        : [number] "{rax}" (@enumToInt(number))
+        : [ret] "={rax}" (-> usize),
+        : [number] "{rax}" (@enumToInt(number)),
         : "rcx", "r11", "memory"
     );
 }
 
 pub fn syscall1(number: SYS, arg1: usize) usize {
     return asm volatile ("syscall"
-        : [ret] "={rax}" (-> usize)
+        : [ret] "={rax}" (-> usize),
         : [number] "{rax}" (@enumToInt(number)),
-          [arg1] "{rdi}" (arg1)
+          [arg1] "{rdi}" (arg1),
         : "rcx", "r11", "memory"
     );
 }
 
 pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
     return asm volatile ("syscall"
-        : [ret] "={rax}" (-> usize)
+        : [ret] "={rax}" (-> usize),
         : [number] "{rax}" (@enumToInt(number)),
           [arg1] "{rdi}" (arg1),
-          [arg2] "{rsi}" (arg2)
+          [arg2] "{rsi}" (arg2),
         : "rcx", "r11", "memory"
     );
 }
 
 pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
     return asm volatile ("syscall"
-        : [ret] "={rax}" (-> usize)
+        : [ret] "={rax}" (-> usize),
         : [number] "{rax}" (@enumToInt(number)),
           [arg1] "{rdi}" (arg1),
           [arg2] "{rsi}" (arg2),
-          [arg3] "{rdx}" (arg3)
+          [arg3] "{rdx}" (arg3),
         : "rcx", "r11", "memory"
     );
 }
 
 pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize) usize {
     return asm volatile ("syscall"
-        : [ret] "={rax}" (-> usize)
+        : [ret] "={rax}" (-> usize),
         : [number] "{rax}" (@enumToInt(number)),
           [arg1] "{rdi}" (arg1),
           [arg2] "{rsi}" (arg2),
           [arg3] "{rdx}" (arg3),
-          [arg4] "{r10}" (arg4)
+          [arg4] "{r10}" (arg4),
         : "rcx", "r11", "memory"
     );
 }
 
 pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) usize {
     return asm volatile ("syscall"
-        : [ret] "={rax}" (-> usize)
+        : [ret] "={rax}" (-> usize),
         : [number] "{rax}" (@enumToInt(number)),
           [arg1] "{rdi}" (arg1),
           [arg2] "{rsi}" (arg2),
           [arg3] "{rdx}" (arg3),
           [arg4] "{r10}" (arg4),
-          [arg5] "{r8}" (arg5)
+          [arg5] "{r8}" (arg5),
         : "rcx", "r11", "memory"
     );
 }
@@ -78,14 +78,14 @@ pub fn syscall6(
     arg6: usize,
 ) usize {
     return asm volatile ("syscall"
-        : [ret] "={rax}" (-> usize)
+        : [ret] "={rax}" (-> usize),
         : [number] "{rax}" (@enumToInt(number)),
           [arg1] "{rdi}" (arg1),
           [arg2] "{rsi}" (arg2),
           [arg3] "{rdx}" (arg3),
           [arg4] "{r10}" (arg4),
           [arg5] "{r8}" (arg5),
-          [arg6] "{r9}" (arg6)
+          [arg6] "{r9}" (arg6),
         : "rcx", "r11", "memory"
     );
 }
@@ -98,7 +98,7 @@ pub const restore = restore_rt;
 pub fn restore_rt() callconv(.Naked) void {
     return asm volatile ("syscall"
         :
-        : [number] "{rax}" (@enumToInt(SYS.rt_sigreturn))
+        : [number] "{rax}" (@enumToInt(SYS.rt_sigreturn)),
         : "rcx", "r11", "memory"
     );
 }

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1728,15 +1728,15 @@ pub fn teb() *TEB {
     return switch (builtin.target.cpu.arch) {
         .i386 => asm volatile (
             \\ movl %%fs:0x18, %[ptr]
-            : [ptr] "=r" (-> *TEB)
+            : [ptr] "=r" (-> *TEB),
         ),
         .x86_64 => asm volatile (
             \\ movq %%gs:0x30, %[ptr]
-            : [ptr] "=r" (-> *TEB)
+            : [ptr] "=r" (-> *TEB),
         ),
         .aarch64 => asm volatile (
             \\ mov %[ptr], x18
-            : [ptr] "=r" (-> *TEB)
+            : [ptr] "=r" (-> *TEB),
         ),
         else => @compileError("unsupported arch"),
     };

--- a/lib/std/special/compiler_rt/clear_cache.zig
+++ b/lib/std/special/compiler_rt/clear_cache.zig
@@ -93,7 +93,7 @@ pub fn clear_cache(start: usize, end: usize) callconv(.C) void {
         asm volatile (
             \\mrs %[x], ctr_el0
             \\
-            : [x] "=r" (ctr_el0)
+            : [x] "=r" (ctr_el0),
         );
         // The DC and IC instructions must use 64-bit registers so we don't use
         // uintptr_t in case this runs in an IPL32 environment.
@@ -106,7 +106,7 @@ pub fn clear_cache(start: usize, end: usize) callconv(.C) void {
             while (addr < end) : (addr += dcache_line_size) {
                 asm volatile ("dc cvau, %[addr]"
                     :
-                    : [addr] "r" (addr)
+                    : [addr] "r" (addr),
                 );
             }
         }
@@ -119,7 +119,7 @@ pub fn clear_cache(start: usize, end: usize) callconv(.C) void {
             while (addr < end) : (addr += icache_line_size) {
                 asm volatile ("ic ivau, %[addr]"
                     :
-                    : [addr] "r" (addr)
+                    : [addr] "r" (addr),
                 );
             }
         }

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -103,7 +103,7 @@ fn exit2(code: usize) noreturn {
                 asm volatile ("syscall"
                     :
                     : [number] "{rax}" (231),
-                      [arg1] "{rdi}" (code)
+                      [arg1] "{rdi}" (code),
                     : "rcx", "r11", "memory"
                 );
             },
@@ -111,7 +111,7 @@ fn exit2(code: usize) noreturn {
                 asm volatile ("svc #0"
                     :
                     : [number] "{r7}" (1),
-                      [arg1] "{r0}" (code)
+                      [arg1] "{r0}" (code),
                     : "memory"
                 );
             },
@@ -119,7 +119,7 @@ fn exit2(code: usize) noreturn {
                 asm volatile ("svc #0"
                     :
                     : [number] "{x8}" (93),
-                      [arg1] "{x0}" (code)
+                      [arg1] "{x0}" (code),
                     : "memory", "cc"
                 );
             },
@@ -133,7 +133,7 @@ fn exit2(code: usize) noreturn {
                     \\push $0
                     \\syscall
                     :
-                    : [syscall_number] "{rbp}" (8)
+                    : [syscall_number] "{rbp}" (8),
                     : "rcx", "r11", "memory"
                 );
             },
@@ -142,7 +142,7 @@ fn exit2(code: usize) noreturn {
             .aarch64 => {
                 asm volatile ("svc #0"
                     :
-                    : [exit] "{x0}" (0x08)
+                    : [exit] "{x0}" (0x08),
                     : "memory", "cc"
                 );
             },
@@ -213,34 +213,34 @@ fn _start() callconv(.Naked) noreturn {
         .x86_64 => {
             argc_argv_ptr = asm volatile (
                 \\ xor %%rbp, %%rbp
-                : [argc] "={rsp}" (-> [*]usize)
+                : [argc] "={rsp}" (-> [*]usize),
             );
         },
         .i386 => {
             argc_argv_ptr = asm volatile (
                 \\ xor %%ebp, %%ebp
-                : [argc] "={esp}" (-> [*]usize)
+                : [argc] "={esp}" (-> [*]usize),
             );
         },
         .aarch64, .aarch64_be, .arm, .armeb, .thumb => {
             argc_argv_ptr = asm volatile (
                 \\ mov fp, #0
                 \\ mov lr, #0
-                : [argc] "={sp}" (-> [*]usize)
+                : [argc] "={sp}" (-> [*]usize),
             );
         },
         .riscv64 => {
             argc_argv_ptr = asm volatile (
                 \\ li s0, 0
                 \\ li ra, 0
-                : [argc] "={sp}" (-> [*]usize)
+                : [argc] "={sp}" (-> [*]usize),
             );
         },
         .mips, .mipsel => {
             // The lr is already zeroed on entry, as specified by the ABI.
             argc_argv_ptr = asm volatile (
                 \\ move $fp, $0
-                : [argc] "={sp}" (-> [*]usize)
+                : [argc] "={sp}" (-> [*]usize),
             );
         },
         .powerpc => {
@@ -251,7 +251,7 @@ fn _start() callconv(.Naked) noreturn {
                 \\ stwu 1,-16(1)
                 \\ stw 0, 0(1)
                 \\ mtlr 0
-                : [argc] "={r4}" (-> [*]usize)
+                : [argc] "={r4}" (-> [*]usize),
                 :
                 : "r0"
             );
@@ -264,7 +264,7 @@ fn _start() callconv(.Naked) noreturn {
                 \\ li 0, 0
                 \\ stdu 0, -32(1)
                 \\ mtlr 0
-                : [argc] "={r4}" (-> [*]usize)
+                : [argc] "={r4}" (-> [*]usize),
                 :
                 : "r0"
             );
@@ -274,7 +274,7 @@ fn _start() callconv(.Naked) noreturn {
             argc_argv_ptr = asm (
                 \\ mov %%g0, %%i6
                 \\ add %%o6, 2175, %[argc]
-                : [argc] "=r" (-> [*]usize)
+                : [argc] "=r" (-> [*]usize),
             );
         },
         else => @compileError("unsupported arch"),

--- a/lib/std/valgrind.zig
+++ b/lib/std/valgrind.zig
@@ -18,9 +18,9 @@ pub fn doClientRequest(default: usize, request: usize, a1: usize, a2: usize, a3:
                 \\ roll $3,  %%edi ; roll $13, %%edi
                 \\ roll $29, %%edi ; roll $19, %%edi
                 \\ xchgl %%ebx,%%ebx
-                : [_] "={edx}" (-> usize)
+                : [_] "={edx}" (-> usize),
                 : [_] "{eax}" (&[_]usize{ request, a1, a2, a3, a4, a5 }),
-                  [_] "0" (default)
+                  [_] "0" (default),
                 : "cc", "memory"
             );
         },
@@ -29,9 +29,9 @@ pub fn doClientRequest(default: usize, request: usize, a1: usize, a2: usize, a3:
                 \\ rolq $3,  %%rdi ; rolq $13, %%rdi
                 \\ rolq $61, %%rdi ; rolq $51, %%rdi
                 \\ xchgq %%rbx,%%rbx
-                : [_] "={rdx}" (-> usize)
+                : [_] "={rdx}" (-> usize),
                 : [_] "{rax}" (&[_]usize{ request, a1, a2, a3, a4, a5 }),
-                  [_] "0" (default)
+                  [_] "0" (default),
                 : "cc", "memory"
             );
         },

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5,7 +5,7 @@
 // and substantial portions of the software.
 
 test "zig fmt: preserves clobbers in inline asm with stray comma" {
-    try testTransform(
+    try testCanonical(
         \\fn foo() void {
         \\    asm volatile (""
         \\        : [_] "" (-> type),
@@ -15,20 +15,6 @@ test "zig fmt: preserves clobbers in inline asm with stray comma" {
         \\    asm volatile (""
         \\        :
         \\        : [_] "" (type),
-        \\        : "clobber"
-        \\    );
-        \\}
-        \\
-    ,
-        \\fn foo() void {
-        \\    asm volatile (""
-        \\        : [_] "" (-> type)
-        \\        :
-        \\        : "clobber"
-        \\    );
-        \\    asm volatile (""
-        \\        :
-        \\        : [_] "" (type)
         \\        : "clobber"
         \\    );
         \\}
@@ -514,15 +500,15 @@ test "zig fmt: asm expression with comptime content" {
         \\pub fn main() void {
         \\    asm volatile ("foo" ++ "bar");
         \\    asm volatile ("foo" ++ "bar"
-        \\        : [_] "" (x)
+        \\        : [_] "" (x),
         \\    );
         \\    asm volatile ("foo" ++ "bar"
-        \\        : [_] "" (x)
-        \\        : [_] "" (y)
+        \\        : [_] "" (x),
+        \\        : [_] "" (y),
         \\    );
         \\    asm volatile ("foo" ++ "bar"
-        \\        : [_] "" (x)
-        \\        : [_] "" (y)
+        \\        : [_] "" (x),
+        \\        : [_] "" (y),
         \\        : "h", "e", "l", "l", "o"
         \\    );
         \\}
@@ -2064,11 +2050,11 @@ test "zig fmt: simple asm" {
         \\    );
         \\
         \\    asm ("not real assembly"
-        \\        : [a] "x" (x)
+        \\        : [a] "x" (x),
         \\    );
         \\    asm ("not real assembly"
-        \\        : [a] "x" (-> i32)
-        \\        : [a] "x" (1)
+        \\        : [a] "x" (-> i32),
+        \\        : [a] "x" (1),
         \\    );
         \\    asm ("still not real assembly" ::: "a", "b");
         \\}
@@ -3718,9 +3704,9 @@ test "zig fmt: inline asm" {
     try testCanonical(
         \\pub fn syscall1(number: usize, arg1: usize) usize {
         \\    return asm volatile ("syscall"
-        \\        : [ret] "={rax}" (-> usize)
+        \\        : [ret] "={rax}" (-> usize),
         \\        : [number] "{rax}" (number),
-        \\          [arg1] "{rdi}" (arg1)
+        \\          [arg1] "{rdi}" (arg1),
         \\        : "rcx", "r11"
         \\    );
         \\}
@@ -3823,14 +3809,14 @@ test "zig fmt: inline asm parameter alignment" {
         \\        \\ foo
         \\        \\ bar
         \\        : [_] "" (-> usize),
-        \\          [_] "" (-> usize)
+        \\          [_] "" (-> usize),
         \\    );
         \\    asm volatile (
         \\        \\ foo
         \\        \\ bar
         \\        :
         \\        : [_] "" (0),
-        \\          [_] "" (0)
+        \\          [_] "" (0),
         \\    );
         \\    asm volatile (
         \\        \\ foo
@@ -3840,9 +3826,9 @@ test "zig fmt: inline asm parameter alignment" {
         \\        \\ foo
         \\        \\ bar
         \\        : [_] "" (-> usize),
-        \\          [_] "" (-> usize)
+        \\          [_] "" (-> usize),
         \\        : [_] "" (0),
-        \\          [_] "" (0)
+        \\          [_] "" (0),
         \\        : "", ""
         \\    );
         \\}

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1953,13 +1953,13 @@ fn renderAsm(
                 try renderToken(ais, tree, comma, .newline); // ,
                 try renderExtraNewlineToken(ais, tree, tree.firstToken(next_asm_output));
             } else if (asm_node.inputs.len == 0 and asm_node.first_clobber == null) {
-                try renderAsmOutput(gpa, ais, tree, asm_output, .newline);
+                try renderAsmOutput(gpa, ais, tree, asm_output, .comma);
                 ais.popIndent();
                 ais.setIndentDelta(indent_delta);
                 ais.popIndent();
                 return renderToken(ais, tree, asm_node.ast.rparen, space); // rparen
             } else {
-                try renderAsmOutput(gpa, ais, tree, asm_output, .newline);
+                try renderAsmOutput(gpa, ais, tree, asm_output, .comma);
                 const comma_or_colon = tree.lastToken(asm_output) + 1;
                 ais.popIndent();
                 break :colon2 switch (token_tags[comma_or_colon]) {
@@ -1985,13 +1985,13 @@ fn renderAsm(
                 try renderToken(ais, tree, first_token - 1, .newline); // ,
                 try renderExtraNewlineToken(ais, tree, first_token);
             } else if (asm_node.first_clobber == null) {
-                try renderAsmInput(gpa, ais, tree, asm_input, .newline);
+                try renderAsmInput(gpa, ais, tree, asm_input, .comma);
                 ais.popIndent();
                 ais.setIndentDelta(indent_delta);
                 ais.popIndent();
                 return renderToken(ais, tree, asm_node.ast.rparen, space); // rparen
             } else {
-                try renderAsmInput(gpa, ais, tree, asm_input, .newline);
+                try renderAsmInput(gpa, ais, tree, asm_input, .comma);
                 const comma_or_colon = tree.lastToken(asm_input) + 1;
                 ais.popIndent();
                 break :colon3 switch (token_tags[comma_or_colon]) {

--- a/lib/std/zig/system/x86.zig
+++ b/lib/std/zig/system/x86.zig
@@ -548,7 +548,7 @@ fn cpuid(leaf_id: u32, subid: u32) CpuidLeaf {
         :
         : [leaf_id] "{eax}" (leaf_id),
           [subid] "{ecx}" (subid),
-          [leaf_ptr] "r" (&cpuid_leaf)
+          [leaf_ptr] "r" (&cpuid_leaf),
         : "eax", "ebx", "ecx", "edx"
     );
 
@@ -560,7 +560,7 @@ fn getXCR0() u32 {
     return asm volatile (
         \\ xor %%ecx, %%ecx
         \\ xgetbv
-        : [ret] "={eax}" (-> u32)
+        : [ret] "={eax}" (-> u32),
         :
         : "eax", "edx", "ecx"
     );

--- a/test/behavior/asm.zig
+++ b/test/behavior/asm.zig
@@ -23,12 +23,12 @@ test "output constraint modifiers" {
     // This is only testing compilation.
     var a: u32 = 3;
     asm volatile (""
-        : [_] "=m,r" (a)
+        : [_] "=m,r" (a),
         :
         : ""
     );
     asm volatile (""
-        : [_] "=r,m" (a)
+        : [_] "=r,m" (a),
         :
         : ""
     );
@@ -38,8 +38,8 @@ test "alternative constraints" {
     // Make sure we allow commas as a separator for alternative constraints.
     var a: u32 = 3;
     asm volatile (""
-        : [_] "=r,m" (a)
-        : [_] "r,m" (a)
+        : [_] "=r,m" (a),
+        : [_] "r,m" (a),
         : ""
     );
 }
@@ -47,42 +47,42 @@ test "alternative constraints" {
 test "sized integer/float in asm input" {
     asm volatile (""
         :
-        : [_] "m" (@as(usize, 3))
+        : [_] "m" (@as(usize, 3)),
         : ""
     );
     asm volatile (""
         :
-        : [_] "m" (@as(i15, -3))
+        : [_] "m" (@as(i15, -3)),
         : ""
     );
     asm volatile (""
         :
-        : [_] "m" (@as(u3, 3))
+        : [_] "m" (@as(u3, 3)),
         : ""
     );
     asm volatile (""
         :
-        : [_] "m" (@as(i3, 3))
+        : [_] "m" (@as(i3, 3)),
         : ""
     );
     asm volatile (""
         :
-        : [_] "m" (@as(u121, 3))
+        : [_] "m" (@as(u121, 3)),
         : ""
     );
     asm volatile (""
         :
-        : [_] "m" (@as(i121, 3))
+        : [_] "m" (@as(i121, 3)),
         : ""
     );
     asm volatile (""
         :
-        : [_] "m" (@as(f32, 3.17))
+        : [_] "m" (@as(f32, 3.17)),
         : ""
     );
     asm volatile (""
         :
-        : [_] "m" (@as(f64, 3.17))
+        : [_] "m" (@as(f64, 3.17)),
         : ""
     );
 }
@@ -90,15 +90,15 @@ test "sized integer/float in asm input" {
 test "struct/array/union types as input values" {
     asm volatile (""
         :
-        : [_] "m" (@as([1]u32, undefined))
+        : [_] "m" (@as([1]u32, undefined)),
     ); // fails
     asm volatile (""
         :
-        : [_] "m" (@as(struct { x: u32, y: u8 }, undefined))
+        : [_] "m" (@as(struct { x: u32, y: u8 }, undefined)),
     ); // fails
     asm volatile (""
         :
-        : [_] "m" (@as(union { x: u32, y: u8 }, undefined))
+        : [_] "m" (@as(union { x: u32, y: u8 }, undefined)),
     ); // fails
 }
 


### PR DESCRIPTION
Fixes #9476.