### PR TITLE
Fix float formatting for 0.0 when precision is 0

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1200,8 +1200,6 @@ pub fn formatFloatDecimal(
                 while (i < precision) : (i += 1) {
                     try writer.writeAll("0");
                 }
-            } else {
-                try writer.writeAll(".0");
             }
         }
 

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2196,6 +2196,7 @@ test "float.hexadecimal.precision" {
 test "float.decimal" {
     try expectFmt("f64: 152314000000000000000000000000", "f64: {d}", .{@as(f64, 1.52314e+29)});
     try expectFmt("f32: 0", "f32: {d}", .{@as(f32, 0.0)});
+    try expectFmt("f32: 0", "f32: {d:.0}", .{@as(f32, 0.0)});
     try expectFmt("f32: 1.1", "f32: {d:.1}", .{@as(f32, 1.1234)});
     try expectFmt("f32: 1234.57", "f32: {d:.2}", .{@as(f32, 1234.567)});
     // -11.1234 is converted to f64 -11.12339... internally (errol3() function takes f64).


### PR DESCRIPTION
With precision 0 (`{d:.0}`), floats will format 0.0 as `0.0` instead of 0, but any other number will completely cut off the decimal point, this corrects 0.0 to also cut off the decimal point.