### PR TITLE
Print enum values for build options in help output

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -95,7 +95,7 @@ pub const Builder = struct {
         type_id: TypeId,
         description: []const u8,
         /// If the `type_id` is `enum` this provides the list of enum options
-        enum_options: ?[][]const u8,
+        enum_options: ?[]const []const u8,
     };
 
     const UserInputOption = struct {

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -94,6 +94,8 @@ pub const Builder = struct {
         name: []const u8,
         type_id: TypeId,
         description: []const u8,
+        /// If the `type_id` is `enum` this provides the list of enum options
+        enum_options: ?[][]const u8,
     };
 
     const UserInputOption = struct {
@@ -482,10 +484,21 @@ pub const Builder = struct {
         const name = self.dupe(name_raw);
         const description = self.dupe(description_raw);
         const type_id = comptime typeToEnum(T);
+        const enum_options = if (type_id == .@"enum") blk: {
+            const fields = comptime std.meta.fields(T);
+            var options = ArrayList([]const u8).initCapacity(self.allocator, fields.len) catch unreachable;
+
+            inline for (fields) |field| {
+                options.appendAssumeCapacity(field.name);
+            }
+
+            break :blk options.toOwnedSlice();
+        } else null;
         const available_option = AvailableOption{
             .name = name,
             .type_id = type_id,
             .description = description,
+            .enum_options = enum_options,
         };
         if ((self.available_options_map.fetchPut(name, available_option) catch unreachable) != null) {
             panic("Option '{s}' declared twice", .{name});

--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -245,6 +245,13 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
             });
             defer allocator.free(name);
             try out_stream.print("{s:<30} {s}\n", .{ name, option.description });
+            if (option.enum_options) |enum_options| {
+                const padding = " " ** 33;
+                try out_stream.writeAll(padding ++ "Supported Values:\n");
+                for (enum_options) |enum_option| {
+                    try out_stream.print(padding ++ "  {s}\n", .{enum_option});
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR prints possible enum values for build options in the output of `zig build -h`.

With this change:
```
Project-Specific Options:
  -Dtarget=[string]            The CPU architecture, OS, and ABI to build for
  -Dcpu=[string]               Target CPU features to add or subtract
  -Drelease-safe=[bool]        Optimizations on and safety on
  -Drelease-fast=[bool]        Optimizations on and safety off
  -Drelease-small=[bool]       Size optimizations on and safety off
  -Dlibrary_version=[enum]     Available version of libgit2
                                 Supported Values:
                                   pre_1.0
                                   1.0.0
                                   1.0.1
                                   1.1.0
                                   1.1.1
                                   master
```

Status quo:
```
Project-Specific Options:
  -Dtarget=[string]            The CPU architecture, OS, and ABI to build for
  -Dcpu=[string]               Target CPU features to add or subtract
  -Drelease-safe=[bool]        Optimizations on and safety on
  -Drelease-fast=[bool]        Optimizations on and safety off
  -Drelease-small=[bool]       Size optimizations on and safety off
  -Dlibrary_version=[enum]     Available version of libgit2
```

I'm welcome to formatting recommendations as I realise large enums could easily become unwieldy, maybe printing multiple per line upto some line length e.g.
```
Supported Values: pre_1.0 | 1.0.0 | 1.0.1
                  1.1.0 | 1.1.1 | master
``` 