### PR TITLE
Astgen: fix lrbrace Zir symbols

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -10130,7 +10130,7 @@ fn detectLocalShadowing(
     };
 }
 
-fn advanceSourceCursor(astgen: *AstGen, source: []const u8, end: usize) void {
+fn advanceSourceCursor(astgen: *AstGen, source: []const u8, end: ast.ByteOffset) void {
     var i = astgen.source_offset;
     var line = astgen.source_line;
     var column = astgen.source_column;

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -2582,11 +2582,10 @@ fn emitDbgNode(gz: *GenZir, node: ast.Node.Index) !void {
 
     const astgen = gz.astgen;
     const tree = astgen.tree;
-    const source = tree.source;
     const token_starts = tree.tokens.items(.start);
     const node_start = token_starts[tree.firstToken(node)];
 
-    astgen.advanceSourceCursor(source, node_start);
+    astgen.advanceSourceCursor(node_start);
     const line = @intCast(u32, astgen.source_line);
     const column = @intCast(u32, astgen.source_column);
 
@@ -9060,11 +9059,10 @@ const GenZir = struct {
     fn calcLine(gz: GenZir, node: ast.Node.Index) u32 {
         const astgen = gz.astgen;
         const tree = astgen.tree;
-        const source = tree.source;
         const token_starts = tree.tokens.items(.start);
         const node_start = token_starts[tree.firstToken(node)];
 
-        astgen.advanceSourceCursor(source, node_start);
+        astgen.advanceSourceCursor(node_start);
 
         return @intCast(u32, gz.decl_line + astgen.source_line);
     }
@@ -9203,11 +9201,11 @@ const GenZir = struct {
             const lbrace_start = token_starts[tree.firstToken(block)];
             const rbrace_start = token_starts[tree.lastToken(block)];
 
-            astgen.advanceSourceCursor(tree.source, lbrace_start);
+            astgen.advanceSourceCursor(lbrace_start);
             const lbrace_line = @intCast(u32, astgen.source_line);
             const lbrace_column = @intCast(u32, astgen.source_column);
 
-            astgen.advanceSourceCursor(tree.source, rbrace_start);
+            astgen.advanceSourceCursor(rbrace_start);
             const rbrace_line = @intCast(u32, astgen.source_line);
             const rbrace_column = @intCast(u32, astgen.source_column);
 
@@ -10130,12 +10128,12 @@ fn detectLocalShadowing(
     };
 }
 
-fn advanceSourceCursor(astgen: *AstGen, source: []const u8, end: ast.ByteOffset) void {
+fn advanceSourceCursor(astgen: *AstGen, end: ast.ByteOffset) void {
     var i = astgen.source_offset;
     var line = astgen.source_line;
     var column = astgen.source_column;
     while (i < end) : (i += 1) {
-        if (source[i] == '\n') {
+        if (astgen.tree.source[i] == '\n') {
             line += 1;
             column = 0;
         } else {

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -10132,6 +10132,13 @@ fn advanceSourceCursor(astgen: *AstGen, end: ast.ByteOffset) void {
     var i = astgen.source_offset;
     var line = astgen.source_line;
     var column = astgen.source_column;
+    if (end < i) {
+        // there are some cases where this function is not monotonically through the source
+        // in those cases, reset i back to the beginning to ensure we get a correct result
+        i = 0;
+        line = 1;
+        column = 1;
+    }
     while (i < end) : (i += 1) {
         if (astgen.tree.source[i] == '\n') {
             line += 1;

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -24,9 +24,9 @@ string_bytes: ArrayListUnmanaged(u8) = .{},
 /// would be O(N^2).
 source_offset: u32 = 0,
 /// Tracks the current line of `source_offset`.
-source_line: u32 = 0,
+source_line: u32 = 1,
 /// Tracks the current column of `source_offset`.
-source_column: u32 = 0,
+source_column: u32 = 1,
 /// Used for temporary allocations; freed after AstGen is complete.
 /// The resulting ZIR code has no references to anything in this arena.
 arena: *Allocator,
@@ -10135,7 +10135,7 @@ fn advanceSourceCursor(astgen: *AstGen, end: ast.ByteOffset) void {
     while (i < end) : (i += 1) {
         if (astgen.tree.source[i] == '\n') {
             line += 1;
-            column = 0;
+            column = 1;
         } else {
             column += 1;
         }


### PR DESCRIPTION
Fixes #9672

https://github.com/ziglang/zig/commit/73f77f30804f3a512fbb35caad3d87ff2778ecc0 is correct in observing AstGen progresses through the source monotonically, however it also assumes that all calls to `AstGen.advanceSourceCursor` are as well. When determining the line/column position for functions, the search for `lbrace` causes it to find a source position far back from the end of the function where it is now at near `rbrace`. This PR checks this condition and adjusts the local variables accordingly so that it may  always return a correct result and the marching performance improvements can still be taken advantage of.