### PR TITLE
stdlib: fix ChildProcess.killPosix

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -161,7 +161,7 @@ pub const ChildProcess = struct {
             self.cleanupStreams();
             return term;
         }
-        try os.kill(self.pid, os.SIGTERM);
+        try os.kill(self.pid, os.SIG.TERM);
         self.waitUnwrapped();
         return self.term.?;
     }


### PR DESCRIPTION
`ChildProcess.killPosix` uses `os.SIGTERM` but it  no longer exists since https://github.com/ziglang/zig/pull/9618 merged, so this PR fixes it. (I would expect this kind of regression to be captured by `testing.refAllDecls(@This())` but not sure why it didn't.) 