### PR TITLE
std: crypto - Fix p256 scalar divStep compile error

### DIFF
--- a/lib/std/crypto/pcurves/p256/p256_scalar_64.zig
+++ b/lib/std/crypto/pcurves/p256/p256_scalar_64.zig
@@ -1766,7 +1766,7 @@ pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[
     var x1: u64 = undefined;
     var x2: u1 = undefined;
     addcarryxU64(&x1, &x2, 0x0, (~arg1), @as(u64, 0x1));
-    const x3 = (@as(u1, (x1 >> 63)) & @as(u1, ((arg3[0]) & @as(u64, 0x1))));
+    const x3 = @truncate(u1, (x1 >> 63)) & @truncate(u1, ((arg3[0]) & @as(u64, 0x1)));
     var x4: u64 = undefined;
     var x5: u1 = undefined;
     addcarryxU64(&x4, &x5, 0x0, (~arg1), @as(u64, 0x1));
@@ -1880,7 +1880,7 @@ pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[
     cmovznzU64(&x72, x3, (arg5[2]), x66);
     var x73: u64 = undefined;
     cmovznzU64(&x73, x3, (arg5[3]), x68);
-    const x74 = @as(u1, (x22 & @as(u64, 0x1)));
+    const x74 = @truncate(u1, (x22 & @as(u64, 0x1)));
     var x75: u64 = undefined;
     cmovznzU64(&x75, x74, @as(u64, 0x0), x7);
     var x76: u64 = undefined;

--- a/lib/std/crypto/pcurves/tests.zig
+++ b/lib/std/crypto/pcurves/tests.zig
@@ -111,3 +111,16 @@ test "p256 double base multiplication" {
     const pr2 = (try p1.mul(s1, .Little)).add(try p2.mul(s2, .Little));
     try testing.expect(pr1.equivalent(pr2));
 }
+
+test "p256 scalar inverse" {
+    const expected = "3b549196a13c898a6f6e84dfb3a22c40a8b9b17fb88e408ea674e451cd01d0a6";
+    var out: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&out, expected);
+
+    const scalar = try P256.scalar.Scalar.fromBytes(.{
+        0x94, 0xa1, 0xbb, 0xb1, 0x4b, 0x90, 0x6a, 0x61, 0xa2, 0x80, 0xf2, 0x45, 0xf9, 0xe9, 0x3c, 0x7f,
+        0x3b, 0x4a, 0x62, 0x47, 0x82, 0x4f, 0x5d, 0x33, 0xb9, 0x67, 0x07, 0x87, 0x64, 0x2a, 0x68, 0xde,
+    }, .Big);
+    const inverse = scalar.invert();
+    try std.testing.expectEqualSlices(u8, &out, &inverse.toBytes(.Big));
+}


### PR DESCRIPTION
Seems we had an oopsie in 6dbdac4b605fb56b4180b6c66154275c22954a8d where `@as` was used for a non-coercable type. This PR updates it to use `@truncate` (as we don't care about the other bits).
Also, added a test case that uses divStep.

cc @jedisct1 

