### PR TITLE
Fix windows.WSAIoctl() OVERLAPPED argument types

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1421,8 +1421,8 @@ pub fn WSAIoctl(
     dwIoControlCode: DWORD,
     inBuffer: ?[]const u8,
     outBuffer: []u8,
-    overlapped: ?*ws2_32.WSAOVERLAPPED,
-    completionRoutine: ?ws2_32.WSAOVERLAPPED_COMPLETION_ROUTINE,
+    overlapped: ?*OVERLAPPED,
+    completionRoutine: ?ws2_32.LPWSAOVERLAPPED_COMPLETION_ROUTINE,
 ) !DWORD {
     var bytes: DWORD = undefined;
     switch (ws2_32.WSAIoctl(

--- a/lib/std/os/windows/ws2_32.zig
+++ b/lib/std/os/windows/ws2_32.zig
@@ -1070,14 +1070,6 @@ pub const WSANETWORKEVENTS = extern struct {
     iErrorCode: [10]i32,
 };
 
-pub const WSAOVERLAPPED = extern struct {
-    Internal: DWORD,
-    InternalHigh: DWORD,
-    Offset: DWORD,
-    OffsetHigh: DWORD,
-    hEvent: ?WSAEVENT,
-};
-
 pub const addrinfo = addrinfoa;
 
 pub const addrinfoa = extern struct {


### PR DESCRIPTION
The std.os.windows.WSAIoctl() function has incorrect types and doesn't compile.

This change removes the old WIN16 version of WSAOVERLAPPED. The correct version is OVERLAPPED (with DWORD_PTR fields instead of DWORD).

Also, this fixes std.os.windows.WSAIoctl to add the required "LP" for WSAOVERLAPPED_COMPLETION_ROUTINE.