### PR TITLE
link/include: fix invalid file path concatenation when cross-compiling for Windows -> Mac

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -491,7 +491,7 @@ fn resolveSearchDir(
 ) !?[]const u8 {
     var candidates = std.ArrayList([]const u8).init(arena);
 
-    if (fs.path.isAbsolute(dir)) {
+    if (!fs.path.isAbsolute(dir)) {
         if (syslibroot) |root| {
             const full_path = try fs.path.join(arena, &[_][]const u8{ root, dir });
             try candidates.append(full_path);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -491,9 +491,21 @@ fn resolveSearchDir(
 ) !?[]const u8 {
     var candidates = std.ArrayList([]const u8).init(arena);
 
-    if (!fs.path.isAbsolute(dir)) {
+    if (fs.path.isAbsolute(dir)) {
         if (syslibroot) |root| {
-            const full_path = try fs.path.join(arena, &[_][]const u8{ root, dir });
+            const common_dir = if (std.Target.current.os.tag == .windows) blk: {
+                // We need to check for disk designator and strip it out from dir path so
+                // that we can concat dir with syslibroot.
+                // TODO we should backport this mechanism to 'MachO.Dylib.parseDependentLibs()'
+                const disk_designator = fs.path.diskDesignatorWindows(dir);
+
+                if (mem.indexOf(u8, dir, disk_designator)) |where| {
+                    break :blk dir[where + disk_designator.len ..];
+                }
+
+                break :blk dir;
+            } else dir;
+            const full_path = try fs.path.join(arena, &[_][]const u8{ root, common_dir });
             try candidates.append(full_path);
         }
     }


### PR DESCRIPTION
While investigating hexops/mach#8 with @slimsag, we found that zld is forming invalid file paths (absolute paths concatenated together), which hits the unreachable `OBJECT_NAME_INVALID` case in `openDirAccessMaskW`:
https://github.com/ziglang/zig/blob/0c091feb5ae52caf1ebf885c0de55b3159207001/lib/std/fs.zig#L1522

This is caused by appending `dir` (which is guaranteed to be absolute) to `root`, which is not valid on Windows.
https://github.com/ziglang/zig/blob/0c091feb5ae52caf1ebf885c0de55b3159207001/src/link/MachO.zig#L494-L499

Also fixes the same fundamental issue with include directories.

Fixes hexops/mach#8

Co-authored-by: Stephen Gutekanst <stephen@hexops.com>
Signed-off-by: Stephen Gutekanst <stephen@hexops.com>
Signed-off-by: Andrew Gutekanst <andrew.gutekanst@gmail.com>