### PR TITLE
Language reference: define the inferred error set syntax more explicitly

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4955,7 +4955,7 @@ test "merge error sets" {
       {#header_open|Inferred Error Sets#}
       <p>
       Because many functions in Zig return a possible error, Zig supports inferring the error set.
-      To infer the error set for a function, use this syntax:
+      To infer the error set for a function, prepend the {#syntax#}!{#endsyntax#} operator to the function’s return type, like {#syntax#}!T{#endsyntax#}:
       </p>
 {#code_begin|test|inferred_error_sets#}
 // With an inferred error set


### PR DESCRIPTION
This edit to the [Inferred Error Sets] section allows the reader to understand the syntax the section is talking about more quickly. They don’t have to read the whole code block and then understand which part of it demonstrates the feature being described.

[Inferred Error Sets]: https://ziglang.org/documentation/master/#Inferred-Error-Sets

## Before

> <img width="776" alt="Inferred Error Sets before – “use this syntax”" src="https://user-images.githubusercontent.com/79168/132996658-0f4b75ec-966a-4bdd-8f3f-e41891ae09ef.png">

## After

> <img width="776" alt="Inferred Error Sets after – “prepend the ! operator to the function’s return type, like !T”" src="https://user-images.githubusercontent.com/79168/132996657-7efae22f-81d8-4697-9a78-5f201c981717.png">

The above screenshot was made by editing the documentation page using the browser devtools. I didn’t test this change by compiling the documentation, as I think the change’s simplicity doesn’t warrant setting up a local environment.

<!--

## Other descriptions of `!`, for comparison

If you’re worried about consistency or if you’re wondering if my explanation could be improved, you might compare my description of this operator to the description earlier in this document, in the [Error Union Type] section. For convenience, here are the parts where that section describes the operator:

[Error Union Type]: https://ziglang.org/documentation/master/#Error-Union-Type

> An error set type and normal type can be combined with the `!` binary operator to form an error union type. […]
>
> Here is a function to parse a string into a 64-bit integer:
>
> ```zig
> // …
> pub fn parseU64(buf: []const u8, radix: u8) !u64 {
> // …
> ```
>
> Notice the return type is `!u64`. This means that the function either returns an unsigned 64 bit integer, or an error. We left off the error set to the left of the `!`, so the error set is inferred.

I avoided describing `!` as an unary operator so as not to confuse people who read that section’s description of it as a binary operator. I’m pretty sure that section’s description of the operator as “binary” is confusing, but I’m not sure how to describe it more accurately.

See also @EleanorNB’s description of the operator in https://github.com/ziglang/zig/issues/7463:

> `!T` is a strange beast. It's written as a unary operator, but it doesn't work like any other operator in the language; namely, it's ambiguous with the same sigil and arity (unlike `*`, which is also two operators but with different arities and hence unambiguous), and its interpretation is dependent on surrounding context.

---

I think that section’s explanation is confusing, but I’m not sure how to improve it. Is `!` both a binary and an unary operator, or are there two operators of different arities with the same name? Thus, I just edited the Inferred Error Sets section and tried not to conflict with the … section.

-->