### PR TITLE
Zig fmt: Keep callconv(.Inline) on function pointer types

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -2879,6 +2879,9 @@ test "zig fmt: functions" {
         \\pub export fn puts(s: *const u8) align(2 + 2) c_int;
         \\pub inline fn puts(s: *const u8) align(2 + 2) c_int;
         \\pub noinline fn puts(s: *const u8) align(2 + 2) c_int;
+        \\pub fn callInlineFn(func: fn () callconv(.Inline) void) void {
+        \\    func();
+        \\}
         \\
     );
 }

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1417,9 +1417,9 @@ fn renderFnProto(gpa: *Allocator, ais: *Ais, tree: Ast, fn_proto: Ast.full.FnPro
         try renderToken(ais, tree, section_rparen, .space); // )
     }
 
-    if (fn_proto.ast.callconv_expr != 0 and
-        !mem.eql(u8, "Inline", tree.tokenSlice(tree.nodes.items(.main_token)[fn_proto.ast.callconv_expr])))
-    {
+    const is_callconv_inline = mem.eql(u8, "Inline", tree.tokenSlice(tree.nodes.items(.main_token)[fn_proto.ast.callconv_expr]));
+    const is_declaration = fn_proto.name_token != null;
+    if (fn_proto.ast.callconv_expr != 0 and !(is_declaration and is_callconv_inline)) {
         const callconv_lparen = tree.firstToken(fn_proto.ast.callconv_expr) - 1;
         const callconv_rparen = tree.lastToken(fn_proto.ast.callconv_expr) + 1;
 


### PR DESCRIPTION
Should close #9658.

This is my first PR. Here are some of the things I am not so sure about:

- Is the test I've added a good example/enough and is it in the right place?
- My definition of `is_declaration` is only dependent on whether `fn_proto` has a `name_token`
- I'm unable to run `build test-std -Dskip-release` locally because of a lot of `No such file or directory` messages about files in `lib/libc/wasi/libc-bottom-half`

Thanks for any help/tips etc.!