### PR TITLE
azure pipeline fix removal of recently run exe

### DIFF
--- a/ci/azure/pipelines.yml
+++ b/ci/azure/pipelines.yml
@@ -40,7 +40,6 @@ jobs:
   - powershell: |
       (New-Object Net.WebClient).DownloadFile("https://github.com/msys2/msys2-installer/releases/download/2021-06-04/msys2-base-x86_64-20210604.sfx.exe", "sfx.exe")
       .\sfx.exe -y -o\
-      del sfx.exe
     displayName: Download/Extract/Install MSYS2
   - script: |
       @REM install updated filesystem package first without dependency checking


### PR DESCRIPTION
Recently there's been an intermittent build issue on windows, the following are all runs that reproduced it recently:

https://dev.azure.com/ziglang/zig/_build/results?buildId=16801&view=logs&j=3e8797c7-5b0a-5f2c-07a4-1bc5e60a122e&t=e20ebee5-9d72-5103-f7c4-43227f669eab&l=137
https://dev.azure.com/ziglang/zig/_build/results?buildId=16799&view=logs&j=3e8797c7-5b0a-5f2c-07a4-1bc5e60a122e&t=e20ebee5-9d72-5103-f7c4-43227f669eab
https://dev.azure.com/ziglang/zig/_build/results?buildId=16798&view=logs&j=3e8797c7-5b0a-5f2c-07a4-1bc5e60a122e&t=e20ebee5-9d72-5103-f7c4-43227f669eab
https://dev.azure.com/ziglang/zig/_build/results?buildId=16797&view=logs&j=3e8797c7-5b0a-5f2c-07a4-1bc5e60a122e&t=e20ebee5-9d72-5103-f7c4-43227f669eab
https://dev.azure.com/ziglang/zig/_build/results?buildId=16792&view=logs&j=3e8797c7-5b0a-5f2c-07a4-1bc5e60a122e&t=e20ebee5-9d72-5103-f7c4-43227f669eab

```
del : Cannot remove item D:\a\1\s\sfx.exe: The process cannot access the file 'D:\a\1\s\sfx.exe' because it is being used by another process.
```
Windows will keep a hold of recently run exeutables even after their process has exited.  To avoid this I've just removed the deletion of the exe file.  It's about 70 MB so it's probably OK.