### PR TITLE
Set the Storage socket sizes to be system defined

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -291,6 +291,7 @@ pub const sockaddr = extern struct {
     family: sa_family_t,
     data: [14]u8,
 
+    pub const SS_MAXSIZE = 128;
     pub const storage = std.x.os.Socket.Address.Native.Storage;
     pub const in = extern struct {
         len: u8 = @sizeOf(in),

--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -465,6 +465,7 @@ pub const sockaddr = extern struct {
     family: u8,
     data: [14]u8,
 
+    pub const SS_MAXSIZE = 128;
     pub const storage = std.x.os.Socket.Address.Native.Storage;
 
     pub const in = extern struct {

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -323,6 +323,7 @@ pub const sockaddr = extern struct {
     /// actually longer; address value
     data: [14]u8,
 
+    pub const SS_MAXSIZE = 128;
     pub const storage = std.x.os.Socket.Address.Native.Storage;
 
     pub const in = extern struct {

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -339,6 +339,7 @@ pub const sockaddr = extern struct {
     /// actually longer; address value
     data: [14]u8,
 
+    pub const SS_MAXSIZE = 128;
     pub const storage = std.x.os.Socket.Address.Native.Storage;
 
     pub const in = extern struct {

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -476,6 +476,7 @@ pub const sockaddr = extern struct {
     /// actually longer; address value
     data: [14]u8,
 
+    pub const SS_MAXSIZE = 128;
     pub const storage = std.x.os.Socket.Address.Native.Storage;
 
     pub const in = extern struct {

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -279,6 +279,7 @@ pub const sockaddr = extern struct {
     /// actually longer; address value
     data: [14]u8,
 
+    pub const SS_MAXSIZE = 256;
     pub const storage = std.x.os.Socket.Address.Native.Storage;
 
     pub const in = extern struct {

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -2923,6 +2923,7 @@ pub const sockaddr = extern struct {
     family: sa_family_t,
     data: [14]u8,
 
+    pub const SS_MAXSIZE = 128;
     pub const storage = std.x.os.Socket.Address.Native.Storage;
 
     /// IPv4 socket address

--- a/lib/std/os/windows/ws2_32.zig
+++ b/lib/std/os/windows/ws2_32.zig
@@ -1105,6 +1105,7 @@ pub const sockaddr = extern struct {
     family: ADDRESS_FAMILY,
     data: [14]u8,
 
+    pub const SS_MAXSIZE = 128;
     pub const storage = std.x.os.Socket.Address.Native.Storage;
 
     /// IPv4 socket address

--- a/lib/std/x/os/socket.zig
+++ b/lib/std/x/os/socket.zig
@@ -37,7 +37,7 @@ pub const Socket = struct {
 
             /// POSIX `sockaddr.storage`. The expected size and alignment is specified in IETF RFC 2553.
             pub const Storage = extern struct {
-                pub const expected_size = 128;
+                pub const expected_size = os.sockaddr.SS_MAXSIZE;
                 pub const expected_alignment = 8;
 
                 pub const padding_size = expected_size -


### PR DESCRIPTION
Some systems (Solaris, OpenBSD, AIX) change their definitions of
sockaddr_storage to be larger than 128 bytes. This commit adds a new
constant in the `sockaddr` struct that defines the size for every system.

Fixes #9759