### PR TITLE
net.Address: Fix writing 0-bytes when formatting Unix addresses

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -157,7 +157,7 @@ pub const Address = extern union {
                     unreachable;
                 }
 
-                try std.fmt.format(out_stream, "{s}", .{&self.un.path});
+                try std.fmt.format(out_stream, "{s}", .{std.mem.sliceTo(&self.un.path, 0)});
             },
             else => unreachable,
         }

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -90,6 +90,19 @@ test "parse and render IPv4 addresses" {
     try testing.expectError(error.NonCanonical, net.Address.parseIp4("127.01.0.1", 0));
 }
 
+test "parse and render UNIX addresses" {
+    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+    if (!net.has_unix_sockets) return error.SkipZigTest;
+
+    var buffer: [14]u8 = undefined;
+    const addr = net.Address.initUnix("/tmp/testpath") catch unreachable;
+    const fmt_addr = std.fmt.bufPrint(buffer[0..], "{}", .{addr}) catch unreachable;
+    try std.testing.expectEqualSlices(u8, "/tmp/testpath", fmt_addr);
+
+    const too_long = [_]u8{'a'} ** (addr.un.path.len + 1);
+    try testing.expectError(error.NameTooLong, net.Address.initUnix(too_long[0..]));
+}
+
 test "resolve DNS" {
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 


### PR DESCRIPTION
The entire 'path' array would get written to the formatting function,
when it should instead be treated as a regular zero-terminated string.

Note that this doesn't handle abstract paths on Linux, those paths
*start* with a \0 byte and are hence treated as empty strings instead.
But fixing that would require more adjustments than just formatting, in
particular to getOsSockLen().