### PR TITLE
link: windows-gnu: look for Unix-style static library names

### DIFF
--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1297,8 +1297,13 @@ fn linkWithLLD(self: *Coff, comp: *Compilation) !void {
                 continue;
             }
             if (target.abi.isGnu()) {
-                const fallback_name = try allocPrint(arena, "lib{s}.dll.a", .{key});
+                const fallback_name = try allocPrint(arena, "lib{s}.a", .{key});
                 if (try self.findLib(arena, fallback_name)) |full_path| {
+                    argv.appendAssumeCapacity(full_path);
+                    continue;
+                }
+                const fallback_implib_name = try allocPrint(arena, "lib{s}.dll.a", .{key});
+                if (try self.findLib(arena, fallback_implib_name)) |full_path| {
                     argv.appendAssumeCapacity(full_path);
                     continue;
                 }


### PR DESCRIPTION
Zig already looks for MinGW-style import library names `lib${name}.dll.a`, so this feels only consistent and simplifies porting existing MinGW projects.