### PR TITLE
std/special: fix 'zig test --test-evented-io

### DIFF
--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -56,7 +56,7 @@ pub fn main() void {
             .evented => blk: {
                 if (async_frame_buffer.len < size) {
                     std.heap.page_allocator.free(async_frame_buffer);
-                    async_frame_buffer = try std.heap.page_allocator.alignedAlloc(u8, std.Target.stack_align, size);
+                    async_frame_buffer = std.heap.page_allocator.alignedAlloc(u8, std.Target.stack_align, size) catch @panic("out of memory");
                 }
                 const casted_fn = @ptrCast(fn () callconv(.Async) anyerror!void, test_fn.func);
                 break :blk await @asyncCall(async_frame_buffer, {}, casted_fn, .{});


### PR DESCRIPTION
Investigating hexops/zorex#4, I found that `--test-evented-io` is currently broken in the latest Zig nightly. See #9779 for a small reproduction.

The issue is that allocation errors here are not correctly handled, as this function returns `void` and all other error cases `@panic`, the allocation failure should also use `@panic`.

Fixes #9779
Helps hexops/zorex#4

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>