### PR TITLE
elf: add amd64 relocation types

### DIFF
--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -1601,3 +1601,90 @@ pub const SHN_LIVEPATCH = 0xff20;
 pub const SHN_ABS = 0xfff1;
 pub const SHN_COMMON = 0xfff2;
 pub const SHN_HIRESERVE = 0xffff;
+
+/// AMD x86-64 relocations.
+/// No reloc
+pub const R_X86_64_NONE = 0;
+/// Direct 64 bit
+pub const R_X86_64_64 = 1;
+/// PC relative 32 bit signed
+pub const R_X86_64_PC32 = 2;
+/// 32 bit GOT entry
+pub const R_X86_64_GOT32 = 3;
+/// 32 bit PLT address
+pub const R_X86_64_PLT32 = 4;
+/// Copy symbol at runtime
+pub const R_X86_64_COPY = 5;
+/// Create GOT entry
+pub const R_X86_64_GLOB_DAT = 6;
+/// Create PLT entry
+pub const R_X86_64_JUMP_SLOT = 7;
+/// Adjust by program base
+pub const R_X86_64_RELATIVE = 8;
+/// 32 bit signed PC relative offset to GOT
+pub const R_X86_64_GOTPCREL = 9;
+/// Direct 32 bit zero extended
+pub const R_X86_64_32 = 10;
+/// Direct 32 bit sign extended
+pub const R_X86_64_32S = 11;
+/// Direct 16 bit zero extended
+pub const R_X86_64_16 = 12;
+/// 16 bit sign extended pc relative
+pub const R_X86_64_PC16 = 13;
+/// Direct 8 bit sign extended
+pub const R_X86_64_8 = 14;
+/// 8 bit sign extended pc relative
+pub const R_X86_64_PC8 = 15;
+/// ID of module containing symbol
+pub const R_X86_64_DTPMOD64 = 16;
+/// Offset in module's TLS block
+pub const R_X86_64_DTPOFF64 = 17;
+/// Offset in initial TLS block
+pub const R_X86_64_TPOFF64 = 18;
+/// 32 bit signed PC relative offset to two GOT entries for GD symbol
+pub const R_X86_64_TLSGD = 19;
+/// 32 bit signed PC relative offset to two GOT entries for LD symbol
+pub const R_X86_64_TLSLD = 20;
+/// Offset in TLS block
+pub const R_X86_64_DTPOFF32 = 21;
+/// 32 bit signed PC relative offset to GOT entry for IE symbol
+pub const R_X86_64_GOTTPOFF = 22;
+/// Offset in initial TLS block
+pub const R_X86_64_TPOFF32 = 23;
+/// PC relative 64 bit
+pub const R_X86_64_PC64 = 24;
+/// 64 bit offset to GOT
+pub const R_X86_64_GOTOFF64 = 25;
+/// 32 bit signed pc relative offset to GOT
+pub const R_X86_64_GOTPC32 = 26;
+/// 64 bit GOT entry offset
+pub const R_X86_64_GOT64 = 27;
+/// 64 bit PC relative offset to GOT entry
+pub const R_X86_64_GOTPCREL64 = 28;
+/// 64 bit PC relative offset to GOT
+pub const R_X86_64_GOTPC64 = 29;
+/// Like GOT64, says PLT entry needed
+pub const R_X86_64_GOTPLT64 = 30;
+/// 64-bit GOT relative offset to PLT entry
+pub const R_X86_64_PLTOFF64 = 31;
+/// Size of symbol plus 32-bit addend
+pub const R_X86_64_SIZE32 = 32;
+/// Size of symbol plus 64-bit addend
+pub const R_X86_64_SIZE64 = 33;
+/// GOT offset for TLS descriptor
+pub const R_X86_64_GOTPC32_TLSDESC = 34;
+/// Marker for call through TLS descriptor
+pub const R_X86_64_TLSDESC_CALL = 35;
+/// TLS descriptor
+pub const R_X86_64_TLSDESC = 36;
+/// Adjust indirectly by program base
+pub const R_X86_64_IRELATIVE = 37;
+/// 64-bit adjust by program base
+pub const R_X86_64_RELATIVE64 = 38;
+/// 39 Reserved was R_X86_64_PC32_BND 
+/// 40 Reserved was R_X86_64_PLT32_BND
+/// Load from 32 bit signed pc relative offset to GOT entry without REX prefix, relaxable
+pub const R_X86_64_GOTPCRELX = 41;
+/// Load from 32 bit signed PC relative offset to GOT entry with REX prefix, relaxable
+pub const R_X86_64_REX_GOTPCRELX = 42;
+pub const R_X86_64_NUM = 43;


### PR DESCRIPTION
I believe these are Linux specific so they will need to be os-gated
in `elf.zig` at some point, but I reckon it should be fine to have
them as-is right now since the ELF linker work will mainly be done
on x86-64 Linux at first.