### PR TITLE
Linux/sparc64 bits: Add missing C type definitions

### DIFF
--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -674,6 +674,10 @@ pub const msghdr_const = extern struct {
 pub const off_t = i64;
 pub const ino_t = u64;
 pub const mode_t = u32;
+pub const dev_t = usize;
+pub const nlink_t = u32;
+pub const blksize_t = isize;
+pub const blkcnt_t = isize;
 
 // The `stat64` definition used by the kernel.
 pub const Stat = extern struct {


### PR DESCRIPTION
This makes stage1 Zig buildable again on SPARC.