### PR TITLE
FIX resize() for non u8 element types.

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -147,6 +147,30 @@ test "mem.Allocator basics" {
     try testing.expectError(error.OutOfMemory, failAllocator.allocSentinel(u8, 1, 0));
 }
 
+test "Allocator.resize" {
+
+    const primitiveIntTypes = .{i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, isize, usize,};
+    inline for (primitiveIntTypes) |T| {
+        var values = try testing.allocator.alloc(T,100);
+        defer testing.allocator.free(values);
+        
+        for (values) |*v,i| v.* = @intCast(T,i);
+        values = try testing.allocator.resize(values,values.len + 10);
+        try testing.expect(values.len==110);
+    }
+
+    const primitiveFloatTypes = .{f16, f32, f64, f128,};
+    inline for (primitiveFloatTypes) |T| {
+        var values = try testing.allocator.alloc(T,100);
+        defer testing.allocator.free(values);
+        
+        for (values) |*v,i| v.* = @intToFloat(T,i);
+        values = try testing.allocator.resize(values,values.len + 10);
+        try testing.expect(values.len==110);
+    }
+
+}
+
 /// Copy all of source into dest at position 0.
 /// dest.len must be >= source.len.
 /// If the slices overlap, dest.ptr must be <= src.ptr.

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2900,7 +2900,7 @@ pub fn alignForwardGeneric(comptime T: type, addr: T, alignment: T) T {
 pub fn doNotOptimizeAway(val: anytype) void {
     asm volatile (""
         :
-        : [val] "rm" (val)
+        : [val] "rm" (val),
         : "memory"
     );
 }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -148,27 +148,43 @@ test "mem.Allocator basics" {
 }
 
 test "Allocator.resize" {
-
-    const primitiveIntTypes = .{i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, isize, usize,};
+    const primitiveIntTypes = .{
+        i8,
+        u8,
+        i16,
+        u16,
+        i32,
+        u32,
+        i64,
+        u64,
+        i128,
+        u128,
+        isize,
+        usize,
+    };
     inline for (primitiveIntTypes) |T| {
-        var values = try testing.allocator.alloc(T,100);
+        var values = try testing.allocator.alloc(T, 100);
         defer testing.allocator.free(values);
-        
-        for (values) |*v,i| v.* = @intCast(T,i);
-        values = try testing.allocator.resize(values,values.len + 10);
-        try testing.expect(values.len==110);
+
+        for (values) |*v, i| v.* = @intCast(T, i);
+        values = try testing.allocator.resize(values, values.len + 10);
+        try testing.expect(values.len == 110);
     }
 
-    const primitiveFloatTypes = .{f16, f32, f64, f128,};
+    const primitiveFloatTypes = .{
+        f16,
+        f32,
+        f64,
+        f128,
+    };
     inline for (primitiveFloatTypes) |T| {
-        var values = try testing.allocator.alloc(T,100);
+        var values = try testing.allocator.alloc(T, 100);
         defer testing.allocator.free(values);
-        
-        for (values) |*v,i| v.* = @intToFloat(T,i);
-        values = try testing.allocator.resize(values,values.len + 10);
-        try testing.expect(values.len==110);
-    }
 
+        for (values) |*v, i| v.* = @intToFloat(T, i);
+        values = try testing.allocator.resize(values, values.len + 10);
+        try testing.expect(values.len == 110);
+    }
 }
 
 /// Copy all of source into dest at position 0.
@@ -2884,7 +2900,7 @@ pub fn alignForwardGeneric(comptime T: type, addr: T, alignment: T) T {
 pub fn doNotOptimizeAway(val: anytype) void {
     asm volatile (""
         :
-        : [val] "rm" (val),
+        : [val] "rm" (val)
         : "memory"
     );
 }

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -313,7 +313,7 @@ pub fn resize(self: *Allocator, old_mem: anytype, new_n: usize) Error!@TypeOf(ol
     const new_byte_count = math.mul(usize, @sizeOf(T), new_n) catch return Error.OutOfMemory;
     const rc = try self.resizeFn(self, old_byte_slice, Slice.alignment, new_byte_count, 0, @returnAddress());
     assert(rc == new_byte_count);
-    const new_byte_slice = old_mem.ptr[0..new_byte_count];
+    const new_byte_slice = old_byte_slice.ptr[0..new_byte_count];
     return mem.bytesAsSlice(T, new_byte_slice);
 }
 


### PR DESCRIPTION
Looks like a simple typo that breaks `resize()` on slices of non u8 types?

Fixes, e.g. 

```zig
  var pts = try gpa.allocator.alloc(f32,100);
  pts = try gpa.allocator.resize(pts, pts.len+1);
```