### PR TITLE
tokenizer: Fix index-out-of-bounds on string_literal_backslash right before EOF

### DIFF
--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -700,7 +700,7 @@ pub const Tokenizer = struct {
                 },
 
                 .string_literal_backslash => switch (c) {
-                    '\n' => {
+                    0, '\n' => {
                         result.tag = .invalid;
                         break;
                     },
@@ -1917,6 +1917,10 @@ test "tokenizer - multi line string literal with only 1 backslash" {
 test "tokenizer - invalid builtin identifiers" {
     try testTokenize("@()", &.{ .invalid, .l_paren, .r_paren });
     try testTokenize("@0()", &.{ .invalid, .integer_literal, .l_paren, .r_paren });
+}
+
+test "tokenizer - backslash before eof in string literal" {
+    try testTokenize("\"\\", &.{.invalid});
 }
 
 fn testTokenize(source: [:0]const u8, expected_tokens: []const Token.Tag) !void {


### PR DESCRIPTION
Before this fix, the added test would fail with something like:

```
thread 3287298 panic: index out of bounds
/home/ryan/Programming/zig/zig/build/lib/zig/std/zig/tokenizer.zig:408:34: 0x21511f in std.zig.tokenizer.Tokenizer.next (fuzz-debug)
            const c = self.buffer[self.index];
                                 ^
/home/ryan/Programming/zig/zig/build/lib/zig/std/zig/parse.zig:24:37: 0x20af60 in std.zig.parse.parse (fuzz-debug)
        const token = tokenizer.next();
                                    ^
```

This was found by fuzzing the tokenizer with https://github.com/squeek502/zig-std-lib-fuzzing

(this is just the beginning, there are lots more tokenizer crashes that have been found)