### PR TITLE
tokenizer: Fix index-out-of-bounds on unfinished unicode escapes before EOF

### DIFF
--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -772,6 +772,10 @@ pub const Tokenizer = struct {
                 },
 
                 .char_literal_unicode_escape_saw_u => switch (c) {
+                    0 => {
+                        result.tag = .invalid;
+                        break;
+                    },
                     '{' => {
                         state = .char_literal_unicode_escape;
                     },
@@ -782,6 +786,10 @@ pub const Tokenizer = struct {
                 },
 
                 .char_literal_unicode_escape => switch (c) {
+                    0 => {
+                        result.tag = .invalid;
+                        break;
+                    },
                     '0'...'9', 'a'...'f', 'A'...'F' => {},
                     '}' => {
                         state = .char_literal_end; // too many/few digits handled later
@@ -1922,8 +1930,10 @@ test "tokenizer - invalid builtin identifiers" {
     try testTokenize("@0()", &.{ .invalid, .integer_literal, .l_paren, .r_paren });
 }
 
-test "tokenizer - backslash before eof in string literal" {
+test "tokenizer - invalid token with unfinished escape right before eof" {
     try testTokenize("\"\\", &.{.invalid});
+    try testTokenize("'\\", &.{.invalid});
+    try testTokenize("'\\u", &.{.invalid});
 }
 
 fn testTokenize(source: [:0]const u8, expected_tokens: []const Token.Tag) !void {


### PR DESCRIPTION
Follow up to https://github.com/ziglang/zig/pull/9808, pretty much the same bug but with char literals (also found [via fuzzing](https://github.com/squeek502/zig-std-lib-fuzzing)).

Turns out these were the only other crashes found by the fuzzer, they were just being repeated a ton so I thought there'd be a lot more fixes necessary. The tokenizer fuzzer is now running cleanly so far with these fixes.