### PR TITLE
Make opaque_decl an extended instruction, adjust union/enum tag astgen.

### DIFF
--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -307,10 +307,6 @@ const Writer = struct {
             .condbr_inline,
             => try self.writePlNodeCondBr(stream, inst),
 
-            .opaque_decl => try self.writeOpaqueDecl(stream, inst, .parent),
-            .opaque_decl_anon => try self.writeOpaqueDecl(stream, inst, .anon),
-            .opaque_decl_func => try self.writeOpaqueDecl(stream, inst, .func),
-
             .error_set_decl => try self.writeErrorSetDecl(stream, inst, .parent),
             .error_set_decl_anon => try self.writeErrorSetDecl(stream, inst, .anon),
             .error_set_decl_func => try self.writeErrorSetDecl(stream, inst, .func),
@@ -412,6 +408,7 @@ const Writer = struct {
             .struct_decl => try self.writeStructDecl(stream, extended),
             .union_decl => try self.writeUnionDecl(stream, extended),
             .enum_decl => try self.writeEnumDecl(stream, extended),
+            .opaque_decl => try self.writeOpaqueDecl(stream, extended),
 
             .c_undef, .c_include => {
                 const inst_data = self.code.extraData(Zir.Inst.UnNode, extended.operand).data;
@@ -1365,26 +1362,36 @@ const Writer = struct {
     fn writeOpaqueDecl(
         self: *Writer,
         stream: anytype,
-        inst: Zir.Inst.Index,
-        name_strategy: Zir.Inst.NameStrategy,
+        extended: Zir.Inst.Extended.InstData,
     ) !void {
-        const inst_data = self.code.instructions.items(.data)[inst].pl_node;
-        const extra = self.code.extraData(Zir.Inst.OpaqueDecl, inst_data.payload_index);
-        const decls_len = extra.data.decls_len;
+        const small = @bitCast(Zir.Inst.OpaqueDecl.Small, extended.small);
+        var extra_index: usize = extended.operand;
 
-        try stream.print("{s}, ", .{@tagName(name_strategy)});
+        const src_node: ?i32 = if (small.has_src_node) blk: {
+            const src_node = @bitCast(i32, self.code.extra[extra_index]);
+            extra_index += 1;
+            break :blk src_node;
+        } else null;
+
+        const decls_len = if (small.has_decls_len) blk: {
+            const decls_len = self.code.extra[extra_index];
+            extra_index += 1;
+            break :blk decls_len;
+        } else 0;
+
+        try stream.print("{s}, ", .{@tagName(small.name_strategy)});
 
         if (decls_len == 0) {
-            try stream.writeAll("}) ");
+            try stream.writeAll("{})");
         } else {
-            try stream.writeAll("\n");
+            try stream.writeAll("{\n");
             self.indent += 2;
-            _ = try self.writeDecls(stream, decls_len, extra.end);
+            _ = try self.writeDecls(stream, decls_len, extra_index);
             self.indent -= 2;
             try stream.writeByteNTimes(' ', self.indent);
-            try stream.writeAll("}) ");
+            try stream.writeAll("})");
         }
-        try self.writeSrc(stream, inst_data.src());
+        try self.writeSrcNode(stream, src_node);
     }
 
     fn writeErrorSetDecl(


### PR DESCRIPTION
These changes are an initial step towards comptime closures.