### PR TITLE
ci linux: bump qemu-6.1.0.1

### DIFF
--- a/ci/azure/linux_script
+++ b/ci/azure/linux_script
@@ -20,7 +20,7 @@ cd $HOME
 wget -nv "https://ziglang.org/deps/$CACHE_BASENAME.tar.xz"
 tar xf "$CACHE_BASENAME.tar.xz"
 
-QEMUBASE="qemu-linux-x86_64-5.2.0.1"
+QEMUBASE="qemu-linux-x86_64-6.1.0.1"
 wget -nv "https://ziglang.org/deps/$QEMUBASE.tar.xz"
 tar xf "$QEMUBASE.tar.xz"
 export PATH="$(pwd)/$QEMUBASE/bin:$PATH"


### PR DESCRIPTION
closes #8653

- updated https://github.com/ziglang/qemu-static/commit/4ee3dad0a7d38fb7ed801326d7bdc3dc8421ee09
- uploaded binary artifact to http://ziglang.org/deps/qemu-linux-x86_64-6.1.0.1.tar.xz
- MD5 (qemu-linux-x86_64-6.1.0.1.tar.xz) = 68ef0bef20512e995b51100d5cde9d12