### PR TITLE
os.flock: FreeBSD can return EOPNOTSUPP

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -852,6 +852,7 @@ pub const File = struct {
 
     pub const LockError = error{
         SystemResources,
+        FileLocksNotSupported,
     } || os.UnexpectedError;
 
     /// Blocks when an incompatible lock is held by another process.
@@ -914,6 +915,7 @@ pub const File = struct {
             return os.flock(file.handle, os.LOCK.UN) catch |err| switch (err) {
                 error.WouldBlock => unreachable, // unlocking can't block
                 error.SystemResources => unreachable, // We are deallocating resources.
+                error.FileLocksNotSupported => unreachable, // We already got the lock.
                 error.Unexpected => unreachable, // Resource deallocation must succeed.
             };
         }


### PR DESCRIPTION
`openatZ` can already return `error.FileLocksNotSupported`.