### PR TITLE
Langref: fix HTML escaped symbol WASM JavaScript code example

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10543,8 +10543,8 @@ const typedArray = new Uint8Array(source);
 
 WebAssembly.instantiate(typedArray, {
   env: {
-    print: (result) =&gt; { console.log(`The result is ${result}`); }
-  }}).then(result =&gt; {
+    print: (result) => { console.log(`The result is ${result}`); }
+  }}).then(result => {
   const add = result.instance.exports.add;
   add(1, 2);
 });{#end_syntax_block#}


### PR DESCRIPTION
docgen HTML escapes characters inside of `syntax_block`s. This commit replaces the escaped
greater than with the `>` character. No other occurrences were found.

Fixes #9840