### PR TITLE
Adds Linux support for POSIX file locking with fcntl

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -357,11 +357,11 @@ pub const off_t = i64;
 pub const ino_t = u64;
 
 pub const Flock = extern struct {
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
-    l_type: i16,
-    l_whence: i16,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
+    type: i16,
+    whence: i16,
 };
 
 pub const Stat = extern struct {

--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -929,11 +929,11 @@ pub const LOCK = struct {
 };
 
 pub const Flock = extern struct {
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
-    l_type: c_short,
-    l_whence: c_short,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
+    type: c_short,
+    whence: c_short,
 };
 
 pub const addrinfo = extern struct {

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -193,12 +193,12 @@ pub const dl_phdr_info = extern struct {
 };
 
 pub const Flock = extern struct {
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
-    l_type: i16,
-    l_whence: i16,
-    l_sysid: i32,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
+    type: i16,
+    whence: i16,
+    sysid: i32,
     __unused: [4]u8,
 };
 

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -159,11 +159,11 @@ pub const dl_phdr_info = extern struct {
 };
 
 pub const Flock = extern struct {
-    l_type: c_short,
-    l_whence: c_short,
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
+    type: c_short,
+    whence: c_short,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
 };
 
 pub const msghdr = extern struct {

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -169,11 +169,11 @@ pub const dl_phdr_info = extern struct {
 };
 
 pub const Flock = extern struct {
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
-    l_type: i16,
-    l_whence: i16,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
+    type: i16,
+    whence: i16,
 };
 
 pub const addrinfo = extern struct {

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -94,11 +94,11 @@ pub const dl_phdr_info = extern struct {
 };
 
 pub const Flock = extern struct {
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
-    l_type: c_short,
-    l_whence: c_short,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
+    type: c_short,
+    whence: c_short,
 };
 
 pub const addrinfo = extern struct {

--- a/lib/std/c/solaris.zig
+++ b/lib/std/c/solaris.zig
@@ -116,13 +116,13 @@ pub const RTLD = struct {
 };
 
 pub const Flock = extern struct {
-    l_type: c_short,
-    l_whence: c_short,
-    l_start: off_t,
+    type: c_short,
+    whence: c_short,
+    start: off_t,
     // len == 0 means until end of file.
-    l_len: off_t,
-    l_sysid: c_int,
-    l_pid: pid_t,
+    len: off_t,
+    sysid: c_int,
+    pid: pid_t,
     __pad: [4]c_long,
 };
 

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1045,6 +1045,8 @@ pub const Dir = struct {
                 error.FileBusy => unreachable,
                 error.Locked => unreachable,
                 error.PermissionDenied => unreachable,
+                error.DeadLock => unreachable,
+                error.LockedRegionLimitExceeded => unreachable,
                 else => |e| return e,
             };
             fl_flags &= ~@as(usize, os.O.NONBLOCK);
@@ -1052,6 +1054,8 @@ pub const Dir = struct {
                 error.FileBusy => unreachable,
                 error.Locked => unreachable,
                 error.PermissionDenied => unreachable,
+                error.DeadLock => unreachable,
+                error.LockedRegionLimitExceeded => unreachable,
                 else => |e| return e,
             };
         }
@@ -1197,6 +1201,8 @@ pub const Dir = struct {
                 error.FileBusy => unreachable,
                 error.Locked => unreachable,
                 error.PermissionDenied => unreachable,
+                error.DeadLock => unreachable,
+                error.LockedRegionLimitExceeded => unreachable,
                 else => |e| return e,
             };
             fl_flags &= ~@as(usize, os.O.NONBLOCK);
@@ -1204,6 +1210,8 @@ pub const Dir = struct {
                 error.FileBusy => unreachable,
                 error.Locked => unreachable,
                 error.PermissionDenied => unreachable,
+                error.DeadLock => unreachable,
+                error.LockedRegionLimitExceeded => unreachable,
                 else => |e| return e,
             };
         }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4509,6 +4509,8 @@ pub const FcntlError = error{
     FileBusy,
     ProcessFdQuotaExceeded,
     Locked,
+    DeadLock,
+    LockedRegionLimitExceeded,
 } || UnexpectedError;
 
 pub fn fcntl(fd: fd_t, cmd: i32, arg: usize) FcntlError!usize {
@@ -4517,13 +4519,15 @@ pub fn fcntl(fd: fd_t, cmd: i32, arg: usize) FcntlError!usize {
         switch (errno(rc)) {
             .SUCCESS => return @intCast(usize, rc),
             .INTR => continue,
-            .ACCES => return error.Locked,
+            .AGAIN, .ACCES => return error.Locked,
             .BADF => unreachable,
             .BUSY => return error.FileBusy,
             .INVAL => unreachable, // invalid parameters
             .PERM => return error.PermissionDenied,
             .MFILE => return error.ProcessFdQuotaExceeded,
             .NOTDIR => unreachable, // invalid parameter
+            .DEADLK => return error.DeadLock,
+            .NOLCK => return error.LockedRegionLimitExceeded,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -4538,6 +4542,8 @@ fn setSockFlags(sock: socket_t, flags: u32) !void {
                 error.FileBusy => unreachable,
                 error.Locked => unreachable,
                 error.PermissionDenied => unreachable,
+                error.DeadLock => unreachable,
+                error.LockedRegionLimitExceeded => unreachable,
                 else => |e| return e,
             };
             fd_flags |= FD_CLOEXEC;
@@ -4545,6 +4551,8 @@ fn setSockFlags(sock: socket_t, flags: u32) !void {
                 error.FileBusy => unreachable,
                 error.Locked => unreachable,
                 error.PermissionDenied => unreachable,
+                error.DeadLock => unreachable,
+                error.LockedRegionLimitExceeded => unreachable,
                 else => |e| return e,
             };
         }
@@ -4566,6 +4574,8 @@ fn setSockFlags(sock: socket_t, flags: u32) !void {
                 error.FileBusy => unreachable,
                 error.Locked => unreachable,
                 error.PermissionDenied => unreachable,
+                error.DeadLock => unreachable,
+                error.LockedRegionLimitExceeded => unreachable,
                 else => |e| return e,
             };
             fl_flags |= O.NONBLOCK;
@@ -4573,6 +4583,8 @@ fn setSockFlags(sock: socket_t, flags: u32) !void {
                 error.FileBusy => unreachable,
                 error.Locked => unreachable,
                 error.PermissionDenied => unreachable,
+                error.DeadLock => unreachable,
+                error.LockedRegionLimitExceeded => unreachable,
                 else => |e| return e,
             };
         }

--- a/lib/std/os/linux/arm-eabi.zig
+++ b/lib/std/os/linux/arm-eabi.zig
@@ -638,12 +638,12 @@ pub const HWCAP = struct {
 };
 
 pub const Flock = extern struct {
-    l_type: i16,
-    l_whence: i16,
+    type: i16,
+    whence: i16,
     __pad0: [4]u8,
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
     __unused: [4]u8,
 };
 

--- a/lib/std/os/linux/arm64.zig
+++ b/lib/std/os/linux/arm64.zig
@@ -490,11 +490,11 @@ pub const VDSO = struct {
 };
 
 pub const Flock = extern struct {
-    l_type: i16,
-    l_whence: i16,
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
+    type: i16,
+    whence: i16,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
     __unused: [4]u8,
 };
 

--- a/lib/std/os/linux/mips.zig
+++ b/lib/std/os/linux/mips.zig
@@ -707,12 +707,12 @@ pub const VDSO = struct {
 };
 
 pub const Flock = extern struct {
-    l_type: i16,
-    l_whence: i16,
+    type: i16,
+    whence: i16,
     __pad0: [4]u8,
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
     __unused: [4]u8,
 };
 

--- a/lib/std/os/linux/powerpc.zig
+++ b/lib/std/os/linux/powerpc.zig
@@ -643,11 +643,11 @@ pub const VDSO = struct {
 };
 
 pub const Flock = extern struct {
-    l_type: i16,
-    l_whence: i16,
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
+    type: i16,
+    whence: i16,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
 };
 
 pub const msghdr = extern struct {

--- a/lib/std/os/linux/powerpc64.zig
+++ b/lib/std/os/linux/powerpc64.zig
@@ -617,11 +617,11 @@ pub const VDSO = struct {
 };
 
 pub const Flock = extern struct {
-    l_type: i16,
-    l_whence: i16,
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
+    type: i16,
+    whence: i16,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
     __unused: [4]u8,
 };
 

--- a/lib/std/os/linux/riscv64.zig
+++ b/lib/std/os/linux/riscv64.zig
@@ -480,11 +480,11 @@ pub const timeval = extern struct {
 };
 
 pub const Flock = extern struct {
-    l_type: i16,
-    l_whence: i16,
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
+    type: i16,
+    whence: i16,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
     __unused: [4]u8,
 };
 

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -648,11 +648,11 @@ pub const VDSO = struct {
 };
 
 pub const Flock = extern struct {
-    l_type: i16,
-    l_whence: i16,
-    l_start: off_t,
-    l_len: off_t,
-    l_pid: pid_t,
+    type: i16,
+    whence: i16,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
 };
 
 pub const msghdr = extern struct {


### PR DESCRIPTION
On Linux, locking fails with EAGAIN (vs. EACCES on other systems).
This commit also adds FcntlErrors for EDEADLK and ENOLCK.