### PR TITLE
Fix frexp() segfault on Windows

### DIFF
--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -702,6 +702,7 @@ const mingwex_generic_src = [_][]const u8{
     "math" ++ path.sep_str ++ "fpclassify.c",
     "math" ++ path.sep_str ++ "fpclassifyf.c",
     "math" ++ path.sep_str ++ "fpclassifyl.c",
+    "math" ++ path.sep_str ++ "frexp.c",
     "math" ++ path.sep_str ++ "frexpf.c",
     "math" ++ path.sep_str ++ "frexpl.c",
     "math" ++ path.sep_str ++ "hypot.c",


### PR DESCRIPTION
Fixes #9845.

EDIT: I believe this only affects `*-windows-gnu` targets (the default). The tl;dr is that `frexp()` in mingw's math.h is not dllimported, and the linker accepts the `frexp()` implementation from msvcrt.dll. Because of the mismatch, mingw tries to fix up the call address at runtime and fails. More details can be found in the excellent writeup in the linked issue.

Making mingw's `frexp()` available causes the linker to pick the correct implementation.