### PR TITLE
Add error message to test runner for bad arguments

### DIFF
--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -13,6 +13,12 @@ fn processArgs() void {
     const args = std.process.argsAlloc(&args_allocator.allocator) catch {
         @panic("Too many bytes passed over the CLI to the test runner");
     };
+    if (args.len != 2) {
+        const self_name = if (args.len >= 1) args[0] else if (builtin.os.tag == .windows) "test.exe" else "test";
+        const zig_ext = if (builtin.os.tag == .windows) ".exe" else "";
+        std.debug.print("Usage: {s} path/to/zig{s}\n", .{ self_name, zig_ext });
+        @panic("Wrong number of command line arguments");
+    }
     std.testing.zig_exe_path = args[1];
 }
 


### PR DESCRIPTION
When a test fails, the first thing to do is debug it.  In order to debug tests, you might use something like `zig test foo.zig -femit-bin=test.exe && lldb test.exe`.  Unfortunately, this will crash in the panic handler due to an array out of bounds, which is caused by a lack of parameter validation in the test runner.

This PR adds a nicer error message so you can see that the invocation of test.exe requires a path to zig.