### PR TITLE
parse.zig: better c pointer prefix parsing, don't index out of bounds on eof

### DIFF
--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -1584,18 +1584,13 @@ const Parser = struct {
                     _ = p.nextToken();
                     const asterisk = p.nextToken();
                     var sentinel: Node.Index = 0;
-                    prefix: {
-                        if (p.eatToken(.identifier)) |ident| {
-                            const token_slice = p.source[p.token_starts[ident]..][0..2];
-                            if (!std.mem.eql(u8, token_slice, "c]")) {
-                                p.tok_i -= 1;
-                            } else {
-                                break :prefix;
-                            }
+                    if (p.eatToken(.identifier)) |ident| {
+                        const ident_slice = p.source[p.token_starts[ident]..p.token_starts[ident + 1]];
+                        if (!std.mem.eql(u8, std.mem.trimRight(u8, ident_slice, &std.ascii.spaces), "c")) {
+                            p.tok_i -= 1;
                         }
-                        if (p.eatToken(.colon)) |_| {
-                            sentinel = try p.expectExpr();
-                        }
+                    } else if (p.eatToken(.colon)) |_| {
+                        sentinel = try p.expectExpr();
                     }
                     _ = try p.expectToken(.r_bracket);
                     const mods = try p.parsePtrModifiers();

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5259,6 +5259,14 @@ test "recovery: nonfinal varargs" {
     });
 }
 
+test "recovery: eof in c pointer" {
+    try testError(
+        \\const Ptr = [*c
+    , &[_]Error{
+        .expected_token,
+    });
+}
+
 const std = @import("std");
 const mem = std.mem;
 const print = std.debug.print;


### PR DESCRIPTION
When `parseTypeExpr` sees an `.l_bracket` followed by  an `.asterisk` followed by an `.identifier`, it makes the slice `p.source[p.token_starts[ident]..][0..2]`. This will index past the end of `p.source` if the identifier is one character long and followed immediately by EOF. For example, 
```
_ = try parse(std.testing.allocator, "const Ptr = [*c");
```
will currently panic instead of returning an `expected_token` error for the missing right bracket.

A smaller issue is that because the slice is compared against `"c]"`, no whitespace is allowed between the `c` and the `]`, despite whitespace being allowed almost everywhere else. For example,

```
std.debug.assert((try parse(std.testing.allocator, "const Ptr = [    *  \n   c] u8;")).errors.len == 0);
std.debug.assert((try parse(std.testing.allocator, "const Ptr = [    *  \n   c ] u8;")).errors.len == 1);
```

To fix both issues, we can look at just the slice of `p.source` covered by the identifier. Because a `TokenList` retains only the start position of a token, this slice actually extends from start of the identifier token to the start of the next token and may include whitespace after the identifier. So we do have to `trimRight` any whitespace before comparing against `"c"`.