### PR TITLE
Add line numbers to langref

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -274,6 +274,19 @@
         color: #fff;
       }
     }
+
+    pre {
+      counter-reset: line;
+    }
+    pre span.line:before {
+      counter-increment: line;
+      content: counter(line);
+      display: inline-block;
+      padding-right: 1em;
+      width: 2em;
+      text-align: right;
+      color: #999;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
#9870

![line numbers on code](https://user-images.githubusercontent.com/6010774/135678195-3bbd2b2d-cf87-4802-a48e-d174d5f95217.png)

![line numbers on shell results](https://user-images.githubusercontent.com/6010774/135678403-c6930e00-0cfe-4f0e-a68c-2ce401843eaa.png)

Line numbers are added using css `:before`, so they cannot be selected and are not copied.