### PR TITLE
astgen.zig: keep source cursor increasing monotonically as much as possible

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -10566,6 +10566,7 @@ fn advanceSourceCursor(astgen: *AstGen, source: []const u8, end: usize) void {
     var i = astgen.source_offset;
     var line = astgen.source_line;
     var column = astgen.source_column;
+    assert(i <= end);
     while (i < end) : (i += 1) {
         if (source[i] == '\n') {
             line += 1;

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -6016,17 +6016,17 @@ fn switchExpr(
                 break :blk &case_scope.base;
             }
             const capture = if (case_node == special_node) capture: {
-               const capture_tag: Zir.Inst.Tag = if (is_ptr)
-                   .switch_capture_else_ref
-               else
-                   .switch_capture_else;
-               break :capture try case_scope.add(.{
-                   .tag = capture_tag,
-                   .data = .{ .switch_capture = .{
-                       .switch_inst = switch_block,
-                       .prong_index = undefined,
-                   } },
-               });
+                const capture_tag: Zir.Inst.Tag = if (is_ptr)
+                    .switch_capture_else_ref
+                else
+                    .switch_capture_else;
+                break :capture try case_scope.add(.{
+                    .tag = capture_tag,
+                    .data = .{ .switch_capture = .{
+                        .switch_inst = switch_block,
+                        .prong_index = undefined,
+                    } },
+                });
             } else capture: {
                 const is_multi_case_bits: u2 = @boolToInt(is_multi_case);
                 const is_ptr_bits: u2 = @boolToInt(is_ptr);
@@ -6160,8 +6160,7 @@ fn switchExpr(
     const zir_datas = astgen.instructions.items(.data);
     zir_datas[switch_block].pl_node.payload_index = @intCast(u32, payload_index);
     // Documentation for this: `Zir.Inst.SwitchBlock` and `Zir.Inst.SwitchBlockMulti`.
-    try astgen.extra.ensureUnusedCapacity(gpa,
-        @as(usize, 2) + // operand, scalar_cases_len
+    try astgen.extra.ensureUnusedCapacity(gpa, @as(usize, 2) + // operand, scalar_cases_len
         @boolToInt(multi_cases_len != 0) +
         special_case_payload.items.len +
         scalar_cases_payload.items.len +

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -1913,8 +1913,8 @@ const Writer = struct {
         try stream.writeAll(") ");
         if (body.len != 0) {
             try stream.print("(lbrace={d}:{d},rbrace={d}:{d}) ", .{
-                src_locs.lbrace_line, @truncate(u16, src_locs.columns),
-                src_locs.rbrace_line, @truncate(u16, src_locs.columns >> 16),
+                src_locs.lbrace_line + 1, @truncate(u16, src_locs.columns) + 1,
+                src_locs.rbrace_line + 1, @truncate(u16, src_locs.columns >> 16) + 1,
             });
         }
         try self.writeSrc(stream, src);
@@ -1928,7 +1928,7 @@ const Writer = struct {
 
     fn writeDbgStmt(self: *Writer, stream: anytype, inst: Zir.Inst.Index) !void {
         const inst_data = self.code.instructions.items(.data)[inst].dbg_stmt;
-        try stream.print("{d}, {d})", .{ inst_data.line, inst_data.column });
+        try stream.print("{d}, {d})", .{ inst_data.line + 1, inst_data.column + 1 });
     }
 
     fn writeInstRef(self: *Writer, stream: anytype, ref: Zir.Inst.Ref) !void {


### PR DESCRIPTION
Fixes #9672. As noted in https://github.com/ziglang/zig/pull/9673#discussion_r703763079, AstGen's source cursor should preferably never be reset to 0. One alternative is to allow `advanceSourceCursor` to also search backward for desired offsets and rewind the cursor. This significantly reduces the number of redundantly scanned bytes but doesn't address the root cause. For that, there are three things that currently break the desired monotonicity of the source cursor, two easily fixed, one not:

1. `fnDecl` (when the body isn't empty) and `testDecl` only call `addFunc` after having already called `expr` on their body nodes. In general, this will advance the source cursor probably many times as the constituent statements are generated. But it's `addFunc` that does the work of finding the opening and closing braces to fill in the function's `SrcLocs`, and at this point it's too late for the opening braces without resetting or rewinding the source cursor. The obvious fix is to have `fnDecl` / `testDecl` find the opening brace themselves and pass the line and column of it to `addFunc`. Since `addFunc` already takes most of its arguments in a struct, I added defaults for the new arguments to reduce the noise in other places that call `addFunc`.

2. `switchExpr` doesn't process its cases in strict source order. Instead the special `else` / `_` case is always done first because it comes first in the trailing extra data in the ZIR. But unless it is also lexically the first case, this will advance the source cursor past the actual first case. The simplest fix is to collect the special case payload in its own `ArrayList`, as the scalar and multi cases do, and process all cases in order in the main for loop. Then the extra data is copied all at once at the end of the function. This also removes a bit of repetition in `switchExpr`.

3. Defer statements, by the nature of their current implementation, require some backtracking of the source cursor. The problem is that a defer statement's body won't actually be generated until a later return statement or try statement or similar calls `genDefers`. By this point the cursor is likely well past the defer's location. And worse, a given defer statement can be regenerated many times. A defer statement at the top of a function with 10 returns will have its expression turned into ZIR afresh 10 times, always with source cursor too far ahead. The simplest mitigation is to save the defer statement's source offset, line, and column in the `Scope.Defer` returned from `makeDeferScope`. Then we wrap all the calls to `unusedResultExpr` from `genDefers` with a helper that saves the current source cursor, sets the cursor the one cached in the defer scope, processes the expression, and then finally restores the previous cursor. Some bytes in the source will still be redundantly scanned by `advanceSourceCursor`, but it will much less than with cursor resetting and still significantly less than with cursor rewinding. And in the case of a defer statement with a single expression, the cursor often doesn't need to be advanced at all.

For a sense of scale, I made builds that count redundantly scanned bytes: one with of these changes, one with of a version of `advanceSourceCursor` that resets the cursor to 0 when the desired `end` is less than the current `source_offset`, and one with an `advanceSourceCursor` that searches backwards when `end` is less than the current offset. Then I had each run ast-check against most of the .zig files in this repo. Many files don't need to rescan any bytes with all the above changes. For example, `std/array_hash_map.zig` will rescan 20,751,654 bytes with cursor resetting; will rescan only 440,705 bytes with cursor rewinding; and will rescan 0 bytes with the above fixes. A significant case was `src/Sema.zig`, which rescanned 401,181,359 bytes with cursor resetting; only 5,552,284 with cursor rewinding; and finally 18,047 with the new fixes. Over all 890 files tested -- a combined 14,218,363 bytes -- these fixes do a cumulative 60,149 bytes of redundant scanning; cursor rewinding does 71,503,770 bytes; and the O(N^2) worst case of cursor resetting does 1,911,917,938 bytes.