### PR TITLE
ci drone: enable more testsuite

### DIFF
--- a/ci/drone/drone.yml
+++ b/ci/drone/drone.yml
@@ -32,12 +32,44 @@ steps:
   commands:
   - ./ci/drone/linux_script_test 3
 
+- name: test-4
+  depends_on:
+  - build
+  image: ziglang/static-base:llvm13-aarch64-1
+  commands:
+  - ./ci/drone/linux_script_test 4
+
+- name: test-5
+  depends_on:
+  - build
+  image: ziglang/static-base:llvm13-aarch64-1
+  commands:
+  - ./ci/drone/linux_script_test 5
+
+- name: test-6
+  depends_on:
+  - build
+  image: ziglang/static-base:llvm13-aarch64-1
+  commands:
+  - ./ci/drone/linux_script_test 6
+
+- name: test-7
+  depends_on:
+  - build
+  image: ziglang/static-base:llvm13-aarch64-1
+  commands:
+  - ./ci/drone/linux_script_test 7
+
 - name: finalize
   depends_on:
   - build
   - test-1
   - test-2
   - test-3
+  - test-4
+  - test-5
+  - test-6
+  - test-7
   image: ziglang/static-base:llvm13-aarch64-1
   environment:
     SRHT_OAUTH_TOKEN:

--- a/ci/drone/linux_script_build
+++ b/ci/drone/linux_script_build
@@ -2,6 +2,13 @@
 
 . ./ci/drone/linux_script_base
 
+# Probe CPU/brand details.
+# TODO: `lscpu` is changing package names in EDGE to `util-linux-misc`
+apk update
+apk add util-linux
+echo "lscpu:"
+lscpu | sed 's,^,  : ,'
+
 PREFIX="/deps/local"
 ZIG="$PREFIX/bin/zig"
 TARGET="$TRIPLEARCH-linux-musl"
@@ -13,7 +20,6 @@ export CXX="$ZIG c++ -target $TARGET -mcpu=$MCPU"
 # The `CMAKE_AR` parameter will consider any spaces to
 # be part of the executable path rather than CLI args, so we have
 # to create wrapper scripts for `zig ar` and zig ranlib`.
-
 cat <<'ENDFILE' >$PREFIX/bin/ar
 #!/bin/sh
 /deps/local/bin/zig ar $@

--- a/ci/drone/linux_script_finalize
+++ b/ci/drone/linux_script_finalize
@@ -13,8 +13,7 @@ pip3 install s3cmd
 cd build
 
 mv ../LICENSE "$DISTDIR/"
-# docs are disabled due to: https://github.com/ziglang/zig/issues/8597
-#mv ../zig-cache/langref.html "$DISTDIR/"
+mv ../zig-cache/langref.html "$DISTDIR/"
 mv "$DISTDIR/bin/zig" "$DISTDIR/"
 rmdir "$DISTDIR/bin"
 

--- a/ci/drone/linux_script_test
+++ b/ci/drone/linux_script_test
@@ -2,29 +2,44 @@
 
 . ./ci/drone/linux_script_base
 
-# only release-fast builds of test suite due to: https://github.com/ziglang/zig/issues/8597
-#
-# Some test suite components will be missing because they do not support
-# forcing -OReleaseFast
-#
-# see `zig build --help` for the full list of test-* components
+BUILD_FLAGS="-Dskip-non-native"
+
 case "$1" in
   1)
-    steps="\
-      test-stage2 \
-      test-fmt \
-      test-behavior"
+    ./build/zig build $BUILD_FLAGS test-behavior
+    ./build/zig build $BUILD_FLAGS test-compiler-rt
+    ./build/zig build $BUILD_FLAGS test-fmt
+    ./build/zig build $BUILD_FLAGS docs
     ;;
   2)
-    steps="test-std"
+    # Debug
+    ./build/zig build $BUILD_FLAGS test-std -Dskip-release-safe -Dskip-release-fast -Dskip-release-small
     ;;
   3)
-    steps="\
-      test-compiler-rt \
-      test-minilibc \
-      test-compare-output \
-      test-translate-c \
-      test-run-translated-c"
+    # ReleaseSafe
+    ./build/zig build $BUILD_FLAGS test-std -Dskip-debug -Dskip-release-fast -Dskip-release-small
+    ;;
+  4)
+    # Releasefast
+    ./build/zig build $BUILD_FLAGS test-std -Dskip-debug -Dskip-release-safe -Dskip-release-small
+    ;;
+  5)
+    # ReleaseSmall
+    ./build/zig build $BUILD_FLAGS test-std -Dskip-debug -Dskip-release-safe -Dskip-release-fast
+    ;;
+  6)
+    ./build/zig build $BUILD_FLAGS test-minilibc
+    ./build/zig build $BUILD_FLAGS test-compare-output
+    ./build/zig build $BUILD_FLAGS test-standalone -Dskip-release-safe
+    ./build/zig build $BUILD_FLAGS test-stack-traces
+    ./build/zig build $BUILD_FLAGS test-cli
+    ./build/zig build $BUILD_FLAGS test-asm-link
+    ./build/zig build $BUILD_FLAGS test-runtime-safety
+    ./build/zig build $BUILD_FLAGS test-translate-c
+    ;;
+  7)
+    ./build/zig build $BUILD_FLAGS # test building self-hosted without LLVM
+    ./build/zig build $BUILD_FLAGS test-stage2
     ;;
   '')
     echo "error: expecting test group argument"
@@ -35,12 +50,3 @@ case "$1" in
     exit 1
     ;;
 esac
-
-# only release-fast builds of test suite due to: https://github.com/ziglang/zig/issues/8597
-./build/zig build \
-  -Drelease \
-  -Dskip-debug \
-  -Dskip-release-small \
-  -Dskip-release-safe \
-  -Dskip-non-native \
-  $steps


### PR DESCRIPTION
Upstream LLVM fixes #8597, no longer need `-Dskip-debug` and others.

Additionally, due to the nature of drone.io server pool, it is beneficial to know which aarch64 CPU brand is in use.

- drop `-Dskip-debug` and others
- invoke `lscpu` prior to build
- enable more testsuite consistent with ci azure
- remove workaround for (already closed) #6830

closes #8597