### PR TITLE
Better documentation, minor cleanups.

### DIFF
--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -1,3 +1,7 @@
+//! An set of array and slice types that bit-pack integer elements. A normal [12]u3
+//! takes up 12 bytes of memory since u3's alignment is 1. PackedArray(u3, 12) only
+//! takes up 4 bytes of memory.
+
 const std = @import("std");
 const builtin = @import("builtin");
 const debug = std.debug;
@@ -5,8 +9,10 @@ const testing = std.testing;
 const native_endian = builtin.target.cpu.arch.endian();
 const Endian = std.builtin.Endian;
 
+/// Provides a set of functions for reading and writing packed integers from a
+/// slice of bytes.
 pub fn PackedIntIo(comptime Int: type, comptime endian: Endian) type {
-    //The general technique employed here is to cast bytes in the array to a container
+    // The general technique employed here is to cast bytes in the array to a container
     // integer (having bits % 8 == 0) large enough to contain the number of bits we want,
     // then we can retrieve or store the new value with a relative minimum of masking
     // and shifting. In this worst case, this means that we'll need an integer that's
@@ -18,13 +24,13 @@ pub fn PackedIntIo(comptime Int: type, comptime endian: Endian) type {
     // mean the OS fatally kills the program. Thus, we use a larger container (MaxIo)
     // most of the time, but a smaller container (MinIo) when touching the last byte
     // of the memory.
-    const int_bits = comptime std.meta.bitCount(Int);
+    const int_bits = @bitSizeOf(Int);
 
-    //in the best case, this is the number of bytes we need to touch
-    // to read or write a value, as bits
+    // In the best case, this is the number of bytes we need to touch
+    // to read or write a value, as bits.
     const min_io_bits = ((int_bits + 7) / 8) * 8;
 
-    //in the worst case, this is the number of bytes we need to touch
+    // In the worst case, this is the number of bytes we need to touch
     // to read or write a value, as bits. To calculate for int_bits > 1,
     // set aside 2 bits to touch the first and last bytes, then divide
     // by 8 to see how many bytes can be filled up inbetween.
@@ -34,30 +40,32 @@ pub fn PackedIntIo(comptime Int: type, comptime endian: Endian) type {
         else => ((int_bits - 2) / 8 + 2) * 8,
     };
 
-    //we bitcast the desired Int type to an unsigned version of itself
+    // We bitcast the desired Int type to an unsigned version of itself
     // to avoid issues with shifting signed ints.
     const UnInt = std.meta.Int(.unsigned, int_bits);
 
-    //The maximum container int type
+    // The maximum container int type
     const MinIo = std.meta.Int(.unsigned, min_io_bits);
 
-    //The minimum container int type
+    // The minimum container int type
     const MaxIo = std.meta.Int(.unsigned, max_io_bits);
 
     return struct {
+        /// Retrieves the integer at `index` from the packed data beginning at `bit_offset`
+        /// within `bytes`.
         pub fn get(bytes: []const u8, index: usize, bit_offset: u7) Int {
             if (int_bits == 0) return 0;
 
             const bit_index = (index * int_bits) + bit_offset;
             const max_end_byte = (bit_index + max_io_bits) / 8;
 
-            //Using the larger container size will potentially read out of bounds
+            //using the larger container size will potentially read out of bounds
             if (max_end_byte > bytes.len) return getBits(bytes, MinIo, bit_index);
             return getBits(bytes, MaxIo, bit_index);
         }
 
         fn getBits(bytes: []const u8, comptime Container: type, bit_index: usize) Int {
-            const container_bits = comptime std.meta.bitCount(Container);
+            const container_bits = @bitSizeOf(Container);
             const Shift = std.math.Log2Int(Container);
 
             const start_byte = bit_index / 8;
@@ -86,19 +94,21 @@ pub fn PackedIntIo(comptime Int: type, comptime endian: Endian) type {
             return @bitCast(Int, @truncate(UnInt, value));
         }
 
+        /// Sets the integer at `index` to `val` within the packed data beginning
+        /// at `bit_offset` into `bytes`.
         pub fn set(bytes: []u8, index: usize, bit_offset: u3, int: Int) void {
             if (int_bits == 0) return;
 
             const bit_index = (index * int_bits) + bit_offset;
             const max_end_byte = (bit_index + max_io_bits) / 8;
 
-            //Using the larger container size will potentially write out of bounds
+            //using the larger container size will potentially write out of bounds
             if (max_end_byte > bytes.len) return setBits(bytes, MinIo, bit_index, int);
             setBits(bytes, MaxIo, bit_index, int);
         }
 
         fn setBits(bytes: []u8, comptime Container: type, bit_index: usize, int: Int) void {
-            const container_bits = comptime std.meta.bitCount(Container);
+            const container_bits = @bitSizeOf(Container);
             const Shift = std.math.Log2Int(Container);
 
             const start_byte = bit_index / 8;
@@ -132,7 +142,9 @@ pub fn PackedIntIo(comptime Int: type, comptime endian: Endian) type {
             target_ptr.* = target;
         }
 
-        fn slice(bytes: []u8, bit_offset: u3, start: usize, end: usize) PackedIntSliceEndian(Int, endian) {
+        /// Provides a PackedIntSlice of the packed integers in `bytes` (which begins at `bit_offset`)
+        /// from the element specified by `start` to the element specified by `end`.
+        pub fn slice(bytes: []u8, bit_offset: u3, start: usize, end: usize) PackedIntSliceEndian(Int, endian) {
             debug.assert(end >= start);
 
             const length = end - start;
@@ -148,8 +160,11 @@ pub fn PackedIntIo(comptime Int: type, comptime endian: Endian) type {
             return new_slice;
         }
 
-        fn sliceCast(bytes: []u8, comptime NewInt: type, comptime new_endian: Endian, bit_offset: u3, old_len: usize) PackedIntSliceEndian(NewInt, new_endian) {
-            const new_int_bits = comptime std.meta.bitCount(NewInt);
+        /// Recasts a packed slice to a version with elements of type `NewInt` and endianness `new_endian`.
+        /// Slice will begin at `bit_offset` within `bytes` and the new length will be automatically
+        /// calculated from `old_len` using the sizes of the current integer type and `NewInt`.
+        pub fn sliceCast(bytes: []u8, comptime NewInt: type, comptime new_endian: Endian, bit_offset: u3, old_len: usize) PackedIntSliceEndian(NewInt, new_endian) {
+            const new_int_bits = @bitSizeOf(NewInt);
             const New = PackedIntSliceEndian(NewInt, new_endian);
 
             const total_bits = (old_len * int_bits);
@@ -165,18 +180,21 @@ pub fn PackedIntIo(comptime Int: type, comptime endian: Endian) type {
     };
 }
 
-///Creates a bit-packed array of integers of type Int. Bits
-/// are packed using native endianess and without storing any meta
-/// data. PackedIntArray(i3, 8) will occupy exactly 3 bytes of memory.
+/// Creates a bit-packed array of `Int`. Non-byte-multiple integers
+/// will take up less memory in PackedIntArray than in a normal array.
+/// Elements are packed using native endianess and without storing any 
+/// meta data. PackedArray(i3, 8) will occupy exactly 3 bytes
+/// of memory.
 pub fn PackedIntArray(comptime Int: type, comptime int_count: usize) type {
     return PackedIntArrayEndian(Int, native_endian, int_count);
 }
 
-///Creates a bit-packed array of integers of type Int. Bits
-/// are packed using specified endianess and without storing any meta
-/// data.
+/// Creates a bit-packed array of `Int` with bit order specified by `endian`.
+/// Non-byte-multiple integers will take up less memory in PackedIntArrayEndian
+/// than in a normal array. Elements are packed without storing any meta data.
+/// PackedIntArrayEndian(i3, 8) will occupy exactly 3 bytes of memory.
 pub fn PackedIntArrayEndian(comptime Int: type, comptime endian: Endian, comptime int_count: usize) type {
-    const int_bits = comptime std.meta.bitCount(Int);
+    const int_bits = @bitSizeOf(Int);
     const total_bits = int_bits * int_count;
     const total_bytes = (total_bits + 7) / 8;
 
@@ -185,15 +203,12 @@ pub fn PackedIntArrayEndian(comptime Int: type, comptime endian: Endian, comptim
     return struct {
         const Self = @This();
 
+        /// The byte buffer containing the packed data.
         bytes: [total_bytes]u8,
+        /// The number of elements in the packed array.
+        comptime len: usize = int_count,
 
-        ///Returns the number of elements in the packed array
-        pub fn len(self: Self) usize {
-            _ = self;
-            return int_count;
-        }
-
-        ///Initialize a packed array using an unpacked array
+        /// Initialize a packed array using an unpacked array
         /// or, more likely, an array literal.
         pub fn init(ints: [int_count]Int) Self {
             var self = @as(Self, undefined);
@@ -201,27 +216,27 @@ pub fn PackedIntArrayEndian(comptime Int: type, comptime endian: Endian, comptim
             return self;
         }
 
-        ///Initialize all entries of a packed array to the same value
+        /// Initialize all entries of a packed array to the same value.
         pub fn initAllTo(int: Int) Self {
             // TODO: use `var self = @as(Self, undefined);` https://github.com/ziglang/zig/issues/7635
-            var self = Self{ .bytes = [_]u8{0} ** total_bytes };
+            var self = Self{ .bytes = [_]u8{0} ** total_bytes, .len = int_count };
             self.setAll(int);
             return self;
         }
 
-        ///Return the Int stored at index
+        /// Return the integer stored at `index`.
         pub fn get(self: Self, index: usize) Int {
             debug.assert(index < int_count);
             return Io.get(&self.bytes, index, 0);
         }
 
-        ///Copy int into the array at index
+        ///Copy the value of `int` into the array at `index`.
         pub fn set(self: *Self, index: usize, int: Int) void {
             debug.assert(index < int_count);
             return Io.set(&self.bytes, index, 0, int);
         }
 
-        ///Set all entries of a packed array to the same value
+        /// Set all entries of a packed array to the value of `int`.
         pub fn setAll(self: *Self, int: Int) void {
             var i: usize = 0;
             while (i < int_count) : (i += 1) {
@@ -229,105 +244,96 @@ pub fn PackedIntArrayEndian(comptime Int: type, comptime endian: Endian, comptim
             }
         }
 
-        ///Create a PackedIntSlice of the array from given start to given end
+        /// Create a PackedIntSlice of the array from `start` to `end`.
         pub fn slice(self: *Self, start: usize, end: usize) PackedIntSliceEndian(Int, endian) {
             debug.assert(start < int_count);
             debug.assert(end <= int_count);
             return Io.slice(&self.bytes, 0, start, end);
         }
 
-        ///Create a PackedIntSlice of the array using NewInt as the bit width integer.
-        /// NewInt's bit width must fit evenly within the array's Int's total bits.
+        /// Create a PackedIntSlice of the array using `NewInt` as the integer type.
+        /// `NewInt`'s bit width must fit evenly within the array's `Int`'s total bits.
         pub fn sliceCast(self: *Self, comptime NewInt: type) PackedIntSlice(NewInt) {
             return self.sliceCastEndian(NewInt, endian);
         }
 
-        ///Create a PackedIntSlice of the array using NewInt as the bit width integer
-        /// and new_endian as the new endianess. NewInt's bit width must fit evenly within
-        /// the array's Int's total bits.
+        /// Create a PackedIntSliceEndian of the array using `NewInt` as the integer type
+        /// and `new_endian` as the new endianess. `NewInt`'s bit width must fit evenly
+        /// within the array's `Int`'s total bits.
         pub fn sliceCastEndian(self: *Self, comptime NewInt: type, comptime new_endian: Endian) PackedIntSliceEndian(NewInt, new_endian) {
             return Io.sliceCast(&self.bytes, NewInt, new_endian, 0, int_count);
         }
     };
 }
 
-///Uses a slice as a bit-packed block of int_count integers of type Int.
-/// Bits are packed using native endianess and without storing any meta
-/// data.
+/// A type representing a sub range of a PackedIntArray.
 pub fn PackedIntSlice(comptime Int: type) type {
     return PackedIntSliceEndian(Int, native_endian);
 }
 
-///Uses a slice as a bit-packed block of int_count integers of type Int.
-/// Bits are packed using specified endianess and without storing any meta
-/// data.
+/// A type representing a sub range of a PackedIntArrayEndian.
 pub fn PackedIntSliceEndian(comptime Int: type, comptime endian: Endian) type {
-    const int_bits = comptime std.meta.bitCount(Int);
+    const int_bits = @bitSizeOf(Int);
     const Io = PackedIntIo(Int, endian);
 
     return struct {
         const Self = @This();
 
         bytes: []u8,
-        int_count: usize,
         bit_offset: u3,
+        len: usize,
 
-        ///Returns the number of elements in the packed slice
-        pub fn len(self: Self) usize {
-            return self.int_count;
-        }
-
-        ///Calculates the number of bytes required to store a desired count
-        /// of Ints
+        /// Calculates the number of bytes required to store a desired count
+        /// of `Int`s.
         pub fn bytesRequired(int_count: usize) usize {
             const total_bits = int_bits * int_count;
             const total_bytes = (total_bits + 7) / 8;
             return total_bytes;
         }
 
-        ///Initialize a packed slice using the memory at bytes, with int_count
-        /// elements. bytes must be large enough to accomodate the requested
+        /// Initialize a packed slice using the memory at `bytes`, with `int_count`
+        /// elements. `bytes` must be large enough to accomodate the requested
         /// count.
         pub fn init(bytes: []u8, int_count: usize) Self {
             debug.assert(bytes.len >= bytesRequired(int_count));
 
             return Self{
                 .bytes = bytes,
-                .int_count = int_count,
+                .len = int_count,
                 .bit_offset = 0,
             };
         }
 
-        ///Return the Int stored at index
+        /// Return the integer stored at `index`.
         pub fn get(self: Self, index: usize) Int {
-            debug.assert(index < self.int_count);
+            debug.assert(index < self.len);
             return Io.get(self.bytes, index, self.bit_offset);
         }
 
-        ///Copy int into the array at index
+        /// Copy `int` into the slice at `index`.
         pub fn set(self: *Self, index: usize, int: Int) void {
-            debug.assert(index < self.int_count);
+            debug.assert(index < self.len);
             return Io.set(self.bytes, index, self.bit_offset, int);
         }
 
-        ///Create a PackedIntSlice of this slice from given start to given end
+        /// Create a PackedIntSlice of this slice from `start` to `end`.
         pub fn slice(self: Self, start: usize, end: usize) PackedIntSliceEndian(Int, endian) {
-            debug.assert(start < self.int_count);
-            debug.assert(end <= self.int_count);
+            debug.assert(start < self.len);
+            debug.assert(end <= self.len);
             return Io.slice(self.bytes, self.bit_offset, start, end);
         }
 
-        ///Create a PackedIntSlice of this slice using NewInt as the bit width integer.
-        /// NewInt's bit width must fit evenly within this slice's Int's total bits.
+        /// Create a PackedIntSlice of the sclice using `NewInt` as the integer type.
+        /// `NewInt`'s bit width must fit evenly within the slice's `Int`'s total bits.
         pub fn sliceCast(self: Self, comptime NewInt: type) PackedIntSliceEndian(NewInt, endian) {
             return self.sliceCastEndian(NewInt, endian);
         }
 
-        ///Create a PackedIntSlice of this slice using NewInt as the bit width integer
-        /// and new_endian as the new endianess. NewInt's bit width must fit evenly within
-        /// this slice's Int's total bits.
+        /// Create a PackedIntSliceEndian of the slice using `NewInt` as the integer type
+        /// and `new_endian` as the new endianess. `NewInt`'s bit width must fit evenly
+        /// within the slice's `Int`'s total bits.
         pub fn sliceCastEndian(self: Self, comptime NewInt: type, comptime new_endian: Endian) PackedIntSliceEndian(NewInt, new_endian) {
-            return Io.sliceCast(self.bytes, NewInt, new_endian, self.bit_offset, self.int_count);
+            return Io.sliceCast(self.bytes, NewInt, new_endian, self.bit_offset, self.len);
         }
     };
 }
@@ -358,7 +364,7 @@ test "PackedIntArray" {
         //write values, counting up
         var i = @as(usize, 0);
         var count = @as(I, 0);
-        while (i < data.len()) : (i += 1) {
+        while (i < data.len) : (i += 1) {
             data.set(i, count);
             if (bits > 0) count +%= 1;
         }
@@ -366,7 +372,7 @@ test "PackedIntArray" {
         //read and verify values
         i = 0;
         count = 0;
-        while (i < data.len()) : (i += 1) {
+        while (i < data.len) : (i += 1) {
             const val = data.get(i);
             try testing.expect(val == count);
             if (bits > 0) count +%= 1;
@@ -383,19 +389,17 @@ test "PackedIntIo" {
 }
 
 test "PackedIntArray init" {
-    if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
     const PackedArray = PackedIntArray(u3, 8);
     var packed_array = PackedArray.init([_]u3{ 0, 1, 2, 3, 4, 5, 6, 7 });
     var i = @as(usize, 0);
-    while (i < packed_array.len()) : (i += 1) try testing.expectEqual(@intCast(u3, i), packed_array.get(i));
+    while (i < packed_array.len) : (i += 1) try testing.expectEqual(@intCast(u3, i), packed_array.get(i));
 }
 
 test "PackedIntArray initAllTo" {
-    if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
     const PackedArray = PackedIntArray(u3, 8);
     var packed_array = PackedArray.initAllTo(5);
     var i = @as(usize, 0);
-    while (i < packed_array.len()) : (i += 1) try testing.expectEqual(@as(u3, 5), packed_array.get(i));
+    while (i < packed_array.len) : (i += 1) try testing.expectEqual(@as(u3, 5), packed_array.get(i));
 }
 
 test "PackedIntSlice" {
@@ -423,7 +427,7 @@ test "PackedIntSlice" {
         //write values, counting up
         var i = @as(usize, 0);
         var count = @as(I, 0);
-        while (i < data.len()) : (i += 1) {
+        while (i < data.len) : (i += 1) {
             data.set(i, count);
             if (bits > 0) count +%= 1;
         }
@@ -431,7 +435,7 @@ test "PackedIntSlice" {
         //read and verify values
         i = 0;
         count = 0;
-        while (i < data.len()) : (i += 1) {
+        while (i < data.len) : (i += 1) {
             const val = data.get(i);
             try testing.expect(val == count);
             if (bits > 0) count +%= 1;
@@ -454,14 +458,14 @@ test "PackedIntSlice of PackedInt(Array/Slice)" {
         const limit = (1 << bits);
 
         var i = @as(usize, 0);
-        while (i < packed_array.len()) : (i += 1) {
+        while (i < packed_array.len) : (i += 1) {
             packed_array.set(i, @intCast(Int, i % limit));
         }
 
         //slice of array
         var packed_slice = packed_array.slice(2, 5);
-        try testing.expect(packed_slice.len() == 3);
-        const ps_bit_count = (bits * packed_slice.len()) + packed_slice.bit_offset;
+        try testing.expect(packed_slice.len == 3);
+        const ps_bit_count = (bits * packed_slice.len) + packed_slice.bit_offset;
         const ps_expected_bytes = (ps_bit_count + 7) / 8;
         try testing.expect(packed_slice.bytes.len == ps_expected_bytes);
         try testing.expect(packed_slice.get(0) == 2 % limit);
@@ -475,8 +479,8 @@ test "PackedIntSlice of PackedInt(Array/Slice)" {
 
         //slice of a slice
         const packed_slice_two = packed_slice.slice(0, 3);
-        try testing.expect(packed_slice_two.len() == 3);
-        const ps2_bit_count = (bits * packed_slice_two.len()) + packed_slice_two.bit_offset;
+        try testing.expect(packed_slice_two.len == 3);
+        const ps2_bit_count = (bits * packed_slice_two.len) + packed_slice_two.bit_offset;
         const ps2_expected_bytes = (ps2_bit_count + 7) / 8;
         try testing.expect(packed_slice_two.bytes.len == ps2_expected_bytes);
         try testing.expect(packed_slice_two.get(1) == 7 % limit);
@@ -484,21 +488,21 @@ test "PackedIntSlice of PackedInt(Array/Slice)" {
 
         //size one case
         const packed_slice_three = packed_slice_two.slice(1, 2);
-        try testing.expect(packed_slice_three.len() == 1);
-        const ps3_bit_count = (bits * packed_slice_three.len()) + packed_slice_three.bit_offset;
+        try testing.expect(packed_slice_three.len == 1);
+        const ps3_bit_count = (bits * packed_slice_three.len) + packed_slice_three.bit_offset;
         const ps3_expected_bytes = (ps3_bit_count + 7) / 8;
         try testing.expect(packed_slice_three.bytes.len == ps3_expected_bytes);
         try testing.expect(packed_slice_three.get(0) == 7 % limit);
 
         //empty slice case
         const packed_slice_empty = packed_slice.slice(0, 0);
-        try testing.expect(packed_slice_empty.len() == 0);
+        try testing.expect(packed_slice_empty.len == 0);
         try testing.expect(packed_slice_empty.bytes.len == 0);
 
         //slicing at byte boundaries
         const packed_slice_edge = packed_array.slice(8, 16);
-        try testing.expect(packed_slice_edge.len() == 8);
-        const pse_bit_count = (bits * packed_slice_edge.len()) + packed_slice_edge.bit_offset;
+        try testing.expect(packed_slice_edge.len == 8);
+        const pse_bit_count = (bits * packed_slice_edge.len) + packed_slice_edge.bit_offset;
         const pse_expected_bytes = (pse_bit_count + 7) / 8;
         try testing.expect(packed_slice_edge.bytes.len == pse_expected_bytes);
         try testing.expect(packed_slice_edge.bit_offset == 0);
@@ -506,45 +510,40 @@ test "PackedIntSlice of PackedInt(Array/Slice)" {
 }
 
 test "PackedIntSlice accumulating bit offsets" {
-    if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
     //bit_offset is u3, so standard debugging asserts should catch
     // anything
     {
         const PackedArray = PackedIntArray(u3, 16);
         var packed_array = @as(PackedArray, undefined);
 
-        var packed_slice = packed_array.slice(0, packed_array.len());
+        var packed_slice = packed_array.slice(0, packed_array.len);
         var i = @as(usize, 0);
-        while (i < packed_array.len() - 1) : (i += 1) {
-            packed_slice = packed_slice.slice(1, packed_slice.len());
+        while (i < packed_array.len - 1) : (i += 1) {
+            packed_slice = packed_slice.slice(1, packed_slice.len);
         }
     }
     {
         const PackedArray = PackedIntArray(u11, 88);
         var packed_array = @as(PackedArray, undefined);
 
-        var packed_slice = packed_array.slice(0, packed_array.len());
+        var packed_slice = packed_array.slice(0, packed_array.len);
         var i = @as(usize, 0);
-        while (i < packed_array.len() - 1) : (i += 1) {
-            packed_slice = packed_slice.slice(1, packed_slice.len());
+        while (i < packed_array.len - 1) : (i += 1) {
+            packed_slice = packed_slice.slice(1, packed_slice.len);
         }
     }
 }
 
-//@NOTE: As I do not have a big endian system to test this on,
-// big endian values were not tested
 test "PackedInt(Array/Slice) sliceCast" {
-    if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
-
     const PackedArray = PackedIntArray(u1, 16);
     var packed_array = PackedArray.init([_]u1{ 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 });
     const packed_slice_cast_2 = packed_array.sliceCast(u2);
     const packed_slice_cast_4 = packed_slice_cast_2.sliceCast(u4);
-    var packed_slice_cast_9 = packed_array.slice(0, (packed_array.len() / 9) * 9).sliceCast(u9);
+    var packed_slice_cast_9 = packed_array.slice(0, (packed_array.len / 9) * 9).sliceCast(u9);
     const packed_slice_cast_3 = packed_slice_cast_9.sliceCast(u3);
 
     var i = @as(usize, 0);
-    while (i < packed_slice_cast_2.len()) : (i += 1) {
+    while (i < packed_slice_cast_2.len) : (i += 1) {
         const val = switch (native_endian) {
             .Big => 0b01,
             .Little => 0b10,
@@ -552,7 +551,7 @@ test "PackedInt(Array/Slice) sliceCast" {
         try testing.expect(packed_slice_cast_2.get(i) == val);
     }
     i = 0;
-    while (i < packed_slice_cast_4.len()) : (i += 1) {
+    while (i < packed_slice_cast_4.len) : (i += 1) {
         const val = switch (native_endian) {
             .Big => 0b0101,
             .Little => 0b1010,
@@ -560,13 +559,13 @@ test "PackedInt(Array/Slice) sliceCast" {
         try testing.expect(packed_slice_cast_4.get(i) == val);
     }
     i = 0;
-    while (i < packed_slice_cast_9.len()) : (i += 1) {
+    while (i < packed_slice_cast_9.len) : (i += 1) {
         const val = 0b010101010;
         try testing.expect(packed_slice_cast_9.get(i) == val);
         packed_slice_cast_9.set(i, 0b111000111);
     }
     i = 0;
-    while (i < packed_slice_cast_3.len()) : (i += 1) {
+    while (i < packed_slice_cast_3.len) : (i += 1) {
         const val = switch (native_endian) {
             .Big => if (i % 2 == 0) @as(u3, 0b111) else @as(u3, 0b000),
             .Little => if (i % 2 == 0) @as(u3, 0b111) else @as(u3, 0b000),
@@ -576,8 +575,6 @@ test "PackedInt(Array/Slice) sliceCast" {
 }
 
 test "PackedInt(Array/Slice)Endian" {
-    if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
-
     {
         const PackedArrayBe = PackedIntArrayEndian(u4, .Big, 8);
         var packed_array_be = PackedArrayBe.init([_]u4{ 0, 1, 2, 3, 4, 5, 6, 7 });
@@ -585,20 +582,20 @@ test "PackedInt(Array/Slice)Endian" {
         try testing.expect(packed_array_be.bytes[1] == 0b00100011);
 
         var i = @as(usize, 0);
-        while (i < packed_array_be.len()) : (i += 1) {
+        while (i < packed_array_be.len) : (i += 1) {
             try testing.expect(packed_array_be.get(i) == i);
         }
 
         var packed_slice_le = packed_array_be.sliceCastEndian(u4, .Little);
         i = 0;
-        while (i < packed_slice_le.len()) : (i += 1) {
+        while (i < packed_slice_le.len) : (i += 1) {
             const val = if (i % 2 == 0) i + 1 else i - 1;
             try testing.expect(packed_slice_le.get(i) == val);
         }
 
         var packed_slice_le_shift = packed_array_be.slice(1, 5).sliceCastEndian(u4, .Little);
         i = 0;
-        while (i < packed_slice_le_shift.len()) : (i += 1) {
+        while (i < packed_slice_le_shift.len) : (i += 1) {
             const val = if (i % 2 == 0) i else i + 2;
             try testing.expect(packed_slice_le_shift.get(i) == val);
         }
@@ -614,7 +611,7 @@ test "PackedInt(Array/Slice)Endian" {
         try testing.expect(packed_array_be.bytes[4] == 0b00000000);
 
         var i = @as(usize, 0);
-        while (i < packed_array_be.len()) : (i += 1) {
+        while (i < packed_array_be.len) : (i += 1) {
             try testing.expect(packed_array_be.get(i) == i);
         }
 
@@ -639,14 +636,12 @@ test "PackedInt(Array/Slice)Endian" {
 //@NOTE: Need to manually update this list as more posix os's get
 // added to DirectAllocator.
 
-//These tests prove we aren't accidentally accessing memory past
+// These tests prove we aren't accidentally accessing memory past
 // the end of the array/slice by placing it at the end of a page
 // and reading the last element. The assumption is that the page
 // after this one is not mapped and will cause a segfault if we
 // don't account for the bounds.
 test "PackedIntArray at end of available memory" {
-    if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
-
     switch (builtin.target.os.tag) {
         .linux, .macos, .ios, .freebsd, .netbsd, .openbsd, .windows => {},
         else => return,
@@ -666,8 +661,6 @@ test "PackedIntArray at end of available memory" {
 }
 
 test "PackedIntSlice at end of available memory" {
-    if (we_are_testing_this_with_stage1_which_leaks_comptime_memory) return error.SkipZigTest;
-
     switch (builtin.target.os.tag) {
         .linux, .macos, .ios, .freebsd, .netbsd, .openbsd, .windows => {},
         else => return,


### PR DESCRIPTION
Use of `len` field instead of function, @bitSizeOf instead of meta.bitCount. Also removed unnecessary test skips.