### PR TITLE
Fix startup procedure for async WinMain

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -485,9 +485,9 @@ inline fn initEventLoopAndCallWinMain() std.os.windows.INT {
             };
             defer loop.deinit();
 
-            var result: u8 = undefined;
-            var frame: @Frame(callMainAsync) = undefined;
-            _ = @asyncCall(&frame, &result, callMainAsync, .{loop});
+            var result: std.os.windows.INT = undefined;
+            var frame: @Frame(callWinMainAsync) = undefined;
+            _ = @asyncCall(&frame, &result, callWinMainAsync, .{loop});
             loop.run();
             return result;
         }
@@ -504,6 +504,14 @@ fn callMainAsync(loop: *std.event.Loop) callconv(.Async) u8 {
     loop.beginOneEvent();
     defer loop.finishOneEvent();
     return callMain();
+}
+
+fn callWinMainAsync(loop: *std.event.Loop) callconv(.Async) std.os.windows.INT {
+    // This prevents the event loop from terminating at least until main() has returned.
+    // TODO This shouldn't be needed here; it should be in the event loop code.
+    loop.beginOneEvent();
+    defer loop.finishOneEvent();
+    return call_wWinMain();
 }
 
 // This is not marked inline because it is called with @asyncCall when


### PR DESCRIPTION
This fixes the:
`root source file has no member called 'main'`
issue when defining:
`pub const io_mode = .evented;`
and using `wWinMain`, `--subsystem windows`, e.g.:
`pub fn wWinMain(instance: win.HINSTANCE, prevInstance: ?win.HINSTANCE, cmdLine: win.PWSTR, showCode: c_int) c_int`

`initEventLoopAndCallWinMain` was calling `callMainAsync` instead of the `WinMain`.