### PR TITLE
Fix rlimit_resource for MIPS and SPARC

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -4197,65 +4197,68 @@ pub const ifreq = extern struct {
 };
 
 // doc comments copied from musl
-pub const rlimit_resource = enum(c_int) {
-    /// Per-process CPU limit, in seconds.
-    CPU,
+pub const rlimit_resource = if (native_arch.isMIPS() or native_arch.isSPARC())
+    arch_bits.rlimit_resource
+else
+    enum(c_int) {
+        /// Per-process CPU limit, in seconds.
+        CPU,
 
-    /// Largest file that can be created, in bytes.
-    FSIZE,
+        /// Largest file that can be created, in bytes.
+        FSIZE,
 
-    /// Maximum size of data segment, in bytes.
-    DATA,
+        /// Maximum size of data segment, in bytes.
+        DATA,
 
-    /// Maximum size of stack segment, in bytes.
-    STACK,
+        /// Maximum size of stack segment, in bytes.
+        STACK,
 
-    /// Largest core file that can be created, in bytes.
-    CORE,
+        /// Largest core file that can be created, in bytes.
+        CORE,
 
-    /// Largest resident set size, in bytes.
-    /// This affects swapping; processes that are exceeding their
-    /// resident set size will be more likely to have physical memory
-    /// taken from them.
-    RSS,
+        /// Largest resident set size, in bytes.
+        /// This affects swapping; processes that are exceeding their
+        /// resident set size will be more likely to have physical memory
+        /// taken from them.
+        RSS,
 
-    /// Number of processes.
-    NPROC,
+        /// Number of processes.
+        NPROC,
 
-    /// Number of open files.
-    NOFILE,
+        /// Number of open files.
+        NOFILE,
 
-    /// Locked-in-memory address space.
-    MEMLOCK,
+        /// Locked-in-memory address space.
+        MEMLOCK,
 
-    /// Address space limit.
-    AS,
+        /// Address space limit.
+        AS,
 
-    /// Maximum number of file locks.
-    LOCKS,
+        /// Maximum number of file locks.
+        LOCKS,
 
-    /// Maximum number of pending signals.
-    SIGPENDING,
+        /// Maximum number of pending signals.
+        SIGPENDING,
 
-    /// Maximum bytes in POSIX message queues.
-    MSGQUEUE,
+        /// Maximum bytes in POSIX message queues.
+        MSGQUEUE,
 
-    /// Maximum nice priority allowed to raise to.
-    /// Nice levels 19 .. -20 correspond to 0 .. 39
-    /// values of this resource limit.
-    NICE,
+        /// Maximum nice priority allowed to raise to.
+        /// Nice levels 19 .. -20 correspond to 0 .. 39
+        /// values of this resource limit.
+        NICE,
 
-    /// Maximum realtime priority allowed for non-priviledged
-    /// processes.
-    RTPRIO,
+        /// Maximum realtime priority allowed for non-priviledged
+        /// processes.
+        RTPRIO,
 
-    /// Maximum CPU time in µs that a process scheduled under a real-time
-    /// scheduling policy may consume without making a blocking system
-    /// call before being forcibly descheduled.
-    RTTIME,
+        /// Maximum CPU time in µs that a process scheduled under a real-time
+        /// scheduling policy may consume without making a blocking system
+        /// call before being forcibly descheduled.
+        RTTIME,
 
-    _,
-};
+        _,
+    };
 
 pub const rlim_t = u64;
 

--- a/lib/std/os/linux/mips.zig
+++ b/lib/std/os/linux/mips.zig
@@ -769,3 +769,63 @@ pub const timezone = extern struct {
 };
 
 pub const Elf_Symndx = u32;
+
+pub const rlimit_resource = enum(c_int) {
+    /// Per-process CPU limit, in seconds.
+    CPU,
+
+    /// Largest file that can be created, in bytes.
+    FSIZE,
+
+    /// Maximum size of data segment, in bytes.
+    DATA,
+
+    /// Maximum size of stack segment, in bytes.
+    STACK,
+
+    /// Largest core file that can be created, in bytes.
+    CORE,
+
+    /// Number of open files.
+    NOFILE,
+
+    /// Address space limit.
+    AS,
+
+    /// Largest resident set size, in bytes.
+    /// This affects swapping; processes that are exceeding their
+    /// resident set size will be more likely to have physical memory
+    /// taken from them.
+    RSS,
+
+    /// Number of processes.
+    NPROC,
+
+    /// Locked-in-memory address space.
+    MEMLOCK,
+
+    /// Maximum number of file locks.
+    LOCKS,
+
+    /// Maximum number of pending signals.
+    SIGPENDING,
+
+    /// Maximum bytes in POSIX message queues.
+    MSGQUEUE,
+
+    /// Maximum nice priority allowed to raise to.
+    /// Nice levels 19 .. -20 correspond to 0 .. 39
+    /// values of this resource limit.
+    NICE,
+
+    /// Maximum realtime priority allowed for non-priviledged
+    /// processes.
+    RTPRIO,
+
+    /// Maximum CPU time in µs that a process scheduled under a real-time
+    /// scheduling policy may consume without making a blocking system
+    /// call before being forcibly descheduled.
+    RTTIME,
+
+    _,
+};

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -828,3 +828,63 @@ pub const ucontext_t = extern struct {
     stack: stack_t,
     sigmask: sigset_t,
 };
+
+pub const rlimit_resource = enum(c_int) {
+    /// Per-process CPU limit, in seconds.
+    CPU,
+
+    /// Largest file that can be created, in bytes.
+    FSIZE,
+
+    /// Maximum size of data segment, in bytes.
+    DATA,
+
+    /// Maximum size of stack segment, in bytes.
+    STACK,
+
+    /// Largest core file that can be created, in bytes.
+    CORE,
+
+    /// Largest resident set size, in bytes.
+    /// This affects swapping; processes that are exceeding their
+    /// resident set size will be more likely to have physical memory
+    /// taken from them.
+    RSS,
+
+    /// Number of open files.
+    NOFILE,
+
+    /// Number of processes.
+    NPROC,
+
+    /// Locked-in-memory address space.
+    MEMLOCK,
+
+    /// Address space limit.
+    AS,
+
+    /// Maximum number of file locks.
+    LOCKS,
+
+    /// Maximum number of pending signals.
+    SIGPENDING,
+
+    /// Maximum bytes in POSIX message queues.
+    MSGQUEUE,
+
+    /// Maximum nice priority allowed to raise to.
+    /// Nice levels 19 .. -20 correspond to 0 .. 39
+    /// values of this resource limit.
+    NICE,
+
+    /// Maximum realtime priority allowed for non-priviledged
+    /// processes.
+    RTPRIO,
+
+    /// Maximum CPU time in µs that a process scheduled under a real-time
+    /// scheduling policy may consume without making a blocking system
+    /// call before being forcibly descheduled.
+    RTTIME,
+
+    _,
+};

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -693,7 +693,19 @@ test "getrlimit and setrlimit" {
     inline for (std.meta.fields(os.rlimit_resource)) |field| {
         const resource = @intToEnum(os.rlimit_resource, field.value);
         const limit = try os.getrlimit(resource);
-        try os.setrlimit(resource, limit);
+
+        // On 32 bit MIPS musl includes a fix which changes limits greater than -1UL/2 to RLIM_INFINITY.
+        // See http://git.musl-libc.org/cgit/musl/commit/src/misc/getrlimit.c?id=8258014fd1e34e942a549c88c7e022a00445c352
+        //
+        // This happens for example if RLIMIT_MEMLOCK is bigger than ~2GiB.
+        // In that case the following the limit would be RLIM_INFINITY and the following setrlimit fails with EPERM.
+        if (comptime builtin.cpu.arch.isMIPS() and builtin.link_libc) {
+            if (limit.cur != os.linux.RLIM.INFINITY) {
+                try os.setrlimit(resource, limit);
+            }
+        } else {
+            try os.setrlimit(resource, limit);
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes the definition of `rlimit_resource` for the MIPS and SPARC architectures.

I took the values from the glibc headers:
 * [MIPS](https://github.com/ziglang/zig/blob/master/lib/libc/include/mips-linux-gnu/bits/resource.h)
 * [SPARC](https://github.com/ziglang/zig/blob/master/lib/libc/include/sparcv9-linux-gnu/bits/resource.h)

I'm not sure the second commit should be included. It prevents a test failure on MIPS because of some behaviour [in musl](http://git.musl-libc.org/cgit/musl/commit/src/misc/getrlimit.c?id=8258014fd1e34e942a549c88c7e022a00445c352) which makes it so that `RLIM_INFINITY` is returned instead of the actual value if it goes above `2147483647` (only for MIPS 32 bit).

On my desktop this is the case for `RLIMIT_MEMLOCK`, so what happens is that the test then tries to setrlimit `RLIMIT_MEMLOCK` to `RLIM_INFINITY` and it fails with a permission denied.
It's easy to workaround this with systemd-run but I'd like the opinion of other people on this.