### PR TITLE
translate-c: Perform `isPrimitive` check for record fields

### DIFF
--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -1994,7 +1994,7 @@ fn renderRecord(c: *Context, node: Node) !NodeIndex {
     members[1] = 0;
 
     for (payload.fields) |field, i| {
-        const name_tok = try c.addTokenFmt(.identifier, "{s}", .{std.zig.fmtId(field.name)});
+        const name_tok = try c.addIdentifier(field.name);
         _ = try c.addToken(.colon, ":");
         const type_expr = try renderNode(c, field.type);
 
@@ -2074,7 +2074,7 @@ fn renderFieldAccess(c: *Context, lhs: NodeIndex, field_name: []const u8) !NodeI
         .main_token = try c.addToken(.period, "."),
         .data = .{
             .lhs = lhs,
-            .rhs = try c.addTokenFmt(.identifier, "{s}", .{std.zig.fmtId(field_name)}),
+            .rhs = try c.addIdentifier(field_name),
         },
     });
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -328,7 +328,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const LIGHTGRAY = @import("std").mem.zeroInit(CLITERAL(Color), .{ @as(c_int, 200), @as(c_int, 200), @as(c_int, 200), @as(c_int, 255) });
         ,
         \\pub const struct_boom_t = extern struct {
-        \\    i1: c_int,
+        \\    @"i1": c_int,
         \\};
         \\pub const boom_t = struct_boom_t;
         ,
@@ -1038,13 +1038,15 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const foo = "a string";
     });
 
-    cases.add("zig keywords in C code",
+    cases.add("zig keywords and primitives in C code",
         \\struct comptime {
         \\    int defer;
+        \\    int null;
         \\};
     , &[_][]const u8{
         \\pub const struct_comptime = extern struct {
         \\    @"defer": c_int,
+        \\    @"null": c_int,
         \\};
         ,
         \\pub const @"comptime" = struct_comptime;


### PR DESCRIPTION
A check was being performed when converting C identifiers since the code uses `zig.fmt.fmtId`. However, a check for primitives(eg. `null`, `undefined`) is also required.

This PR makes the change to use the `addIdentifier` wrapping method which escapes the token if it is a Zig primitive.

Related: https://github.com/ziglang/zig/pull/9928