### PR TITLE
Remove resolved_path from import table on error

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3502,6 +3502,7 @@ pub fn importFile(
     defer if (!keep_resolved_path) gpa.free(resolved_path);
 
     const gop = try mod.import_table.getOrPut(gpa, resolved_path);
+    errdefer _ = mod.import_table.pop();
     if (gop.found_existing) return ImportFileResult{
         .file = gop.value_ptr.*,
         .is_new = false,


### PR DESCRIPTION
This PR fixes a case where stage1 segfaults due to an undefined import table entry being left behind when `Module.importFile()` returns an error. The credit for this fix should go to @FlandreScarlet but it has been almost three months since the fix was proposed so I submitted a PR instead.

Fixes #9404 