### PR TITLE
actually fix child process deadlock on windows

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -354,7 +354,7 @@ pub const ChildProcess = struct {
 
         // TODO collect output in a deadlock-avoiding way on Windows.
         // https://github.com/ziglang/zig/issues/6343
-        if (builtin.os.tag == .windows or builtin.os.tag == .haiku) {
+        if (builtin.os.tag == .haiku) {
             const stdout_in = child.stdout.?.reader();
             const stderr_in = child.stderr.?.reader();
 


### PR DESCRIPTION
Looks like I forgot to remove windows from this workaround condition when I finished implementing the child process output collection on windows.

I'm not sure how windows got into the `if` condition since this would have broken my deadlock testing.  My guess is that maybe I messed something up when I merged LemonBoy's commits into my PR.