### PR TITLE
astgen.zig: fix false positive in breakExpr's checking for store_to_block_ptr

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -1691,9 +1691,9 @@ fn breakExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) Inn
                     return Zir.Inst.Ref.unreachable_value;
                 }
                 block_gz.break_count += 1;
-                const prev_rvalue_rl_count = block_gz.rvalue_rl_count;
                 const operand = try expr(parent_gz, parent_scope, block_gz.break_result_loc, rhs);
-                const have_store_to_block = block_gz.rvalue_rl_count != prev_rvalue_rl_count;
+                // if list grew as much as rvalue_rl_count, then a break inside operand already saved the store_to_block_ptr
+                const have_store_to_block = block_gz.rvalue_rl_count > block_gz.labeled_store_to_block_ptr_list.items.len;
 
                 const br = try parent_gz.addBreak(.@"break", block_inst, operand);
 

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -112,6 +112,7 @@ test {
         _ = @import("behavior/bugs/7047.zig");
         _ = @import("behavior/bugs/7250.zig");
         _ = @import("behavior/bugs/9584.zig");
+        _ = @import("behavior/bugs/9967.zig");
         _ = @import("behavior/byteswap.zig");
         _ = @import("behavior/byval_arg_var.zig");
         _ = @import("behavior/call_stage1.zig");

--- a/test/behavior/bugs/9967.zig
+++ b/test/behavior/bugs/9967.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+
+test "nested breaks to same labeled block" {
+    const a = blk: {
+        break :blk break :blk @as(u32, 1);
+    };
+    try std.testing.expectEqual(a, 1);
+}


### PR DESCRIPTION
Fixes #9967. If a break statement has another break to the same block nested somewhere in its operand expression, then the check for the whether the operand emitted a `store_to_block_ptr` instruction can yield a false positive. For example, as well the case given in #9967, a simple way to fail the assert in `breakExpr` is:

```zig
test "" {
    const a = blk: {
        break :blk break :blk @as(u32, 1);
    };
    _ = a;
}
```

In `breakExpr`, the target block's `rvalue_rl_count` is saved immediately before `expr` is called on the operand and then compared to the possibly larger value immediately after `expr`. If they are not equal, the assumption is `expr` must have ended with a call to `rvalue` that increased `rvalue_rl_count` and emitted a `store_to_block_ptr` instruction. Thus, the second to last instruction in `astgen.instructions` (skipping the `break` just added) must be that `store_to_block_ptr`. However, in the case that the operand is a complex expression with another break to the same block nested inside it, then `rvalue_rl_count` will still be larger than the saved previous value, but the final instruction added for the operand could be anything. In #9967, for example, the operand is a switch expression, so potentially many other cases could have been emitted.

Fortunately, when `have_store_to_block` is a true positive, the `store_to_block_ptr` instruction will always be appended to `block_gz.labeled_store_to_block_ptr_list`. Thus, rather than saving the previous value of `rvalue_rl_count`, we can just check if it is larger than the list's length after `expr` returns. In the example above, the inner break with increase `rvalue_rl_count` to one but the length of `labeled_store_to_block_ptr_list` will also be one, so the outer break will not erroneously assume the last instruction was `store_to_block_ptr`. On the other hand, if both break operands indeed emit `store_to_block_ptr` instructions, as in:

```zig
test "" {
    var b = true;
    const a = blk: {
        break :blk if(b) break :blk @as(u32, 1) else @as(u32, 0);
    };
    _ = a;
}
```

then after the outer break's operand `expr` call returns, `rvalue_rl_count` will be two but `labeled_store_to_block_ptr_list` will only have the one instruction saved by the inner break, so `have_store_to_block` will still be true.

I made this change and also added a test under behavior/bugs.