### PR TITLE
std.build.InstallRawStep: allow custom dest_dir

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -994,12 +994,8 @@ pub const Builder = struct {
     }
 
     /// Output format (BIN vs Intel HEX) determined by filename
-    pub fn installRaw(self: *Builder, artifact: *LibExeObjStep, dest_filename: []const u8) void {
-        self.getInstallStep().dependOn(&self.addInstallRaw(artifact, dest_filename).step);
-    }
-
-    pub fn installRawWithFormat(self: *Builder, artifact: *LibExeObjStep, dest_filename: []const u8, format: InstallRawStep.RawFormat) void {
-        self.getInstallStep().dependOn(&self.addInstallRawWithFormat(artifact, dest_filename, format).step);
+    pub fn installRaw(self: *Builder, artifact: *LibExeObjStep, dest_filename: []const u8, options: InstallRawStep.CreateOptions) void {
+        self.getInstallStep().dependOn(&self.addInstallRaw(artifact, dest_filename, options).step);
     }
 
     ///`dest_rel_path` is relative to install prefix path
@@ -1017,12 +1013,8 @@ pub const Builder = struct {
         return self.addInstallFileWithDir(source.dupe(self), .lib, dest_rel_path);
     }
 
-    pub fn addInstallRaw(self: *Builder, artifact: *LibExeObjStep, dest_filename: []const u8) *InstallRawStep {
-        return InstallRawStep.create(self, artifact, dest_filename, null);
-    }
-
-    pub fn addInstallRawWithFormat(self: *Builder, artifact: *LibExeObjStep, dest_filename: []const u8, format: InstallRawStep.RawFormat) *InstallRawStep {
-        return InstallRawStep.create(self, artifact, dest_filename, format);
+    pub fn addInstallRaw(self: *Builder, artifact: *LibExeObjStep, dest_filename: []const u8, options: InstallRawStep.CreateOptions) *InstallRawStep {
+        return InstallRawStep.create(self, artifact, dest_filename, options);
     }
 
     pub fn addInstallFileWithDir(
@@ -1718,12 +1710,8 @@ pub const LibExeObjStep = struct {
         self.builder.installArtifact(self);
     }
 
-    pub fn installRaw(self: *LibExeObjStep, dest_filename: []const u8) void {
-        self.builder.installRaw(self, dest_filename);
-    }
-
-    pub fn installRawWithFormat(self: *LibExeObjStep, dest_filename: []const u8, format: InstallRawStep.RawFormat) void {
-        self.builder.installRawWithFormat(self, dest_filename, format);
+    pub fn installRaw(self: *LibExeObjStep, dest_filename: []const u8, options: InstallRawStep.CreateOptions) void {
+        self.builder.installRaw(self, dest_filename, options);
     }
 
     /// Creates a `RunStep` with an executable built with `addExecutable`.

--- a/test/standalone/install_raw_hex/build.zig
+++ b/test/standalone/install_raw_hex/build.zig
@@ -20,10 +20,10 @@ pub fn build(b: *Builder) void {
     const test_step = b.step("test", "Test the program");
     b.default_step.dependOn(test_step);
 
-    const hex_step = b.addInstallRaw(elf, "hello.hex");
+    const hex_step = b.addInstallRaw(elf, "hello.hex", .{});
     test_step.dependOn(&hex_step.step);
 
-    const explicit_format_hex_step = b.addInstallRawWithFormat(elf, "hello.foo", .hex);
+    const explicit_format_hex_step = b.addInstallRaw(elf, "hello.foo", .{ .format = .hex });
     test_step.dependOn(&explicit_format_hex_step.step);
 
     const expected_hex = &[_][]const u8{


### PR DESCRIPTION
I'm working on a build.zig file where I'm leveraging InstallRawStep but I'd like to change the install dir.  This allows the install dir to be changed and also enhances InstallRawStep to add more options in the future by putting them into a struct with default values.  This also removes the need for the extra `addInstallRawWithFormat` functions by putting the format option in the new options struct.