### PR TITLE
InstallRawStep: handle empty segments

### DIFF
--- a/lib/std/build/InstallRawStep.zig
+++ b/lib/std/build/InstallRawStep.zig
@@ -96,8 +96,7 @@ const BinaryElfOutput = struct {
 
         sort.sort(*BinaryElfSegment, self.segments.items, {}, segmentSortCompare);
 
-        if (self.segments.items.len > 0) {
-            const firstSegment = self.segments.items[0];
+        for (self.segments.items) |firstSegment, i| {
             if (firstSegment.firstSection) |firstSection| {
                 const diff = firstSection.elfOffset - firstSegment.elfOffset;
 
@@ -107,9 +106,10 @@ const BinaryElfOutput = struct {
 
                 const basePhysicalAddress = firstSegment.physicalAddress;
 
-                for (self.segments.items) |segment| {
+                for (self.segments.items[i + 1 ..]) |segment| {
                     segment.binaryOffset = segment.physicalAddress - basePhysicalAddress;
                 }
+                break;
             }
         }
 


### PR DESCRIPTION
This fixes InstallRawStep to handle the cases when there are empty segments (segments with no sections).  Before this change, if the lowest segment was empty (it had no sections), then the fixup of binaryOffsets for each section is skipped.  This fixes that by looping through each segment until a non-empty one is found and then fixing up the sections. This fixed an issue I was having with `InstallRawStep` for a bootloader I'm writing.