### PR TITLE
astgen.zig: fix emitting wrong error unwrapping instructions in tryExpr

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -4912,7 +4912,7 @@ fn tryExpr(
         .ref => .ref,
         else => .none,
     };
-    const err_ops = switch (rl) {
+    const err_ops = switch (operand_rl) {
         // zig fmt: off
         .ref => [3]Zir.Inst.Tag{ .is_non_err_ptr, .err_union_code_ptr, .err_union_payload_unsafe_ptr },
         else => [3]Zir.Inst.Tag{ .is_non_err,     .err_union_code,     .err_union_payload_unsafe },

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -501,6 +501,19 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    return 69 - i;
             \\}
         , "");
+        case.addCompareOutput(
+            \\const E = error{e};
+            \\const S = struct { x: u32 };
+            \\fn f() E!u32 {
+            \\    const x = (try @as(E!S, S{ .x = 1 })).x;
+            \\    return x;
+            \\}
+            \\pub export fn main() c_int {
+            \\    const x = f() catch @as(u32, 0);
+            \\    if (x != 1) unreachable;
+            \\    return 0;
+            \\}
+        , "");
     }
 
     {


### PR DESCRIPTION
Likely just due to a typo, `tryExpr` decides whether to use the `*_ptr` variants of the error unwrapping instructions based on the ResultLoc passed to it rather than one it actually uses for the `expr` call on the operand. For example, in

```zig
const S = struct { x: u32 };
fn f(a: u32) !S { return .{ .x = a }; }
fn g(a: u32) !u32 {
    return (try f(a)).x;
}
```

the field access in `g` will eventually result in `tryExpr` being called with a ResultLoc of `.none_or_ref`. Then the `block_scope.break_result_loc` and thus `operand_rl` will be `.ref`, but because the switch for `err_ops` looks at the passed in `.none_of_ref`, the non-ptr variants of the error unwrapping instructions will be used on `operand`. This emits ZIR that looks like

```
%28 = block({
  %23 = decl_val("f") token_offset:4:17
  %24 = call(.auto, %23, [%19]) node_offset:4:18
  %25 = ref(%24) token_offset:4:17
  %26 = is_non_err(%25) node_offset:4:13
  %27 = condbr(%26, {
    %29 = err_union_payload_unsafe(%25) node_offset:4:13
    %30 = ref(%29) token_offset:4:13
    %33 = break(%28, %30)
  }, {
    %31 = err_union_code(%25) node_offset:4:13
    %32 = ret_node(%31) node_offset:4:13
  }) node_offset:4:13
}) node_offset:4:13
```

where the non-ptr variants `is_non_err`, `err_union_payload_unsafe`, and `err_union_code` are all used on the pointer type resulting from `%25 = ref(%24)`.

This fixes the typo and adds a test in cbe.zig. 
