### PR TITLE
translate-c: create `inline fn` for always_inline

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -536,6 +536,9 @@ pub const FunctionDecl = opaque {
     pub const isInlineSpecified = ZigClangFunctionDecl_isInlineSpecified;
     extern fn ZigClangFunctionDecl_isInlineSpecified(*const FunctionDecl) bool;
 
+    pub const hasAlwaysInlineAttr = ZigClangFunctionDecl_hasAlwaysInlineAttr;
+    extern fn ZigClangFunctionDecl_hasAlwaysInlineAttr(*const FunctionDecl) bool;
+
     pub const isDefined = ZigClangFunctionDecl_isDefined;
     extern fn ZigClangFunctionDecl_isDefined(*const FunctionDecl) bool;
 

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -540,6 +540,7 @@ pub const Payload = struct {
             is_pub: bool,
             is_extern: bool,
             is_export: bool,
+            is_inline: bool,
             is_var_args: bool,
             name: ?[]const u8,
             linksection_string: ?[]const u8,
@@ -2614,6 +2615,7 @@ fn renderFunc(c: *Context, node: Node) !NodeIndex {
     if (payload.is_pub) _ = try c.addToken(.keyword_pub, "pub");
     if (payload.is_extern) _ = try c.addToken(.keyword_extern, "extern");
     if (payload.is_export) _ = try c.addToken(.keyword_export, "export");
+    if (payload.is_inline) _ = try c.addToken(.keyword_inline, "inline");
     const fn_token = try c.addToken(.keyword_fn, "fn");
     if (payload.name) |some| _ = try c.addIdentifier(some);
 

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2120,6 +2120,11 @@ bool ZigClangFunctionDecl_isInlineSpecified(const struct ZigClangFunctionDecl *s
     return casted->isInlineSpecified();
 }
 
+bool ZigClangFunctionDecl_hasAlwaysInlineAttr(const struct ZigClangFunctionDecl *self) {
+    auto casted = reinterpret_cast<const clang::FunctionDecl *>(self);
+    return casted->hasAttr<clang::AlwaysInlineAttr>();
+}
+
 const char* ZigClangFunctionDecl_getSectionAttribute(const struct ZigClangFunctionDecl *self, size_t *len) {
     auto casted = reinterpret_cast<const clang::FunctionDecl *>(self);
     if (const clang::SectionAttr *SA = casted->getAttr<clang::SectionAttr>()) {

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -1111,6 +1111,7 @@ ZIG_EXTERN_C bool ZigClangFunctionDecl_doesDeclarationForceExternallyVisibleDefi
 ZIG_EXTERN_C bool ZigClangFunctionDecl_isThisDeclarationADefinition(const struct ZigClangFunctionDecl *);
 ZIG_EXTERN_C bool ZigClangFunctionDecl_doesThisDeclarationHaveABody(const struct ZigClangFunctionDecl *);
 ZIG_EXTERN_C bool ZigClangFunctionDecl_isInlineSpecified(const struct ZigClangFunctionDecl *);
+ZIG_EXTERN_C bool ZigClangFunctionDecl_hasAlwaysInlineAttr(const struct ZigClangFunctionDecl *);
 ZIG_EXTERN_C bool ZigClangFunctionDecl_isDefined(const struct ZigClangFunctionDecl *);
 ZIG_EXTERN_C const struct ZigClangFunctionDecl* ZigClangFunctionDecl_getDefinition(const struct ZigClangFunctionDecl *);
 ZIG_EXTERN_C const char* ZigClangFunctionDecl_getSectionAttribute(const struct ZigClangFunctionDecl *, size_t *);

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -849,6 +849,16 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub extern fn foo() noreturn;
     });
 
+    cases.add("always_inline attribute",
+        \\__attribute__((always_inline)) int foo() {
+        \\    return 5;
+        \\}
+    , &[_][]const u8{
+        \\pub inline fn foo() c_int {
+        \\    return 5;
+        \\}
+    });
+
     cases.add("add, sub, mul, div, rem",
         \\int s() {
         \\    int a, b, c;


### PR DESCRIPTION
An attempt at translating C `always_inline` to Zig `inline fn` in translate-c.

The intent is to slightly improve my workaround for https://github.com/ziglang/translate-c/issues/154.