### PR TITLE
translate_c: prevent a while under an if from stealing the else

### DIFF
--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1767,4 +1767,21 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\   return 0;
         \\}
     , "");
+
+    cases.add("Ensure while loop under an if doesn't steal the else. Issue #9953",
+        \\#include <stdio.h>
+        \\void doWork(int id) { }
+        \\int reallyDelete(int id) { printf("deleted %d\n", id); return 1; }
+        \\int process(int id, int n, int delete) {
+        \\    if(!delete)
+        \\        while(n-- > 0) doWork(id);
+        \\    else
+        \\        return reallyDelete(id);
+        \\    return 0;
+        \\}
+        \\int main(void) {
+        \\    process(99, 3, 0);
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
Fixes #9953. The problem is that when `while` is output under an `if` without an enclosing block, an `else` branch will be later parsed as a part of the `while` rather than the containing `if`. So when there is an `else`, `transIfStmt` has to always wrap the `then` expression in a block if it will translate to a while loop and is otherwise considered by `maybeBlockify` to not need a block. (This excludes switch statements, which are wrapped in a while loop after translation but which `maybeBlockify` always wraps in a block.) 

For the case in #9953, the translated Zig code doesn't compile because an `if` statement without an `else` requires a terminating semicolon. However, if the `else` statement is of a class that does not need a block, then Zig code that is syntactically valid but which has very different behavior will be output. For example,

```c
int process(int id, int n, int delete) {
    if(!delete)
        while(n-- > 0) doWork(id);
    else
        return reallyDelete(id);
    return 0;
}
```

will translate in part to

```zig
if (!(delete != 0)) while ((blk: {
    const ref = &n;
    const tmp = ref.*;
    ref.* -= 1;
    break :blk tmp;
}) > @as(c_int, 0)) {
    doWork(id);
} else return reallyDelete(id);
```

Thus, a call to `process` with the `delete` parameter set to 0 will nonetheless call `reallyDelete` after the while loop finishes because the else will be parsed as part of the while statement.



