### PR TITLE
Builder: add build_args and addBuild

### DIFF
--- a/lib/std/build/OptionsStep.zig
+++ b/lib/std/build/OptionsStep.zig
@@ -230,6 +230,7 @@ test "OptionsStep" {
         "test",
         "test",
         "test",
+        &[_][:0]const u8{},
     );
     defer builder.destroy();
 

--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -47,6 +47,7 @@ pub fn main() !void {
         build_root,
         cache_root,
         global_cache_root,
+        args[arg_idx..],
     );
     defer builder.destroy();
 

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -30,6 +30,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/issue_7030/build.zig", .{});
     cases.addBuildFile("test/standalone/install_raw_hex/build.zig", .{});
     cases.addBuildFile("test/standalone/issue_9812/build.zig", .{});
+    cases.addBuildFile("test/standalone/buildstep/build.zig", .{});
     if (builtin.os.tag != .wasi) {
         cases.addBuildFile("test/standalone/load_dynamic_library/build.zig", .{});
     }

--- a/test/standalone/buildstep/.gitignore
+++ b/test/standalone/buildstep/.gitignore
@@ -1,0 +1,1 @@
+/config.zig

--- a/test/standalone/buildstep/build.zig
+++ b/test/standalone/buildstep/build.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) !void {
+    {
+        const config_filename = b.pathFromRoot("config.zig");
+        const config_file = try std.fs.cwd().createFile(config_filename, .{});
+        defer config_file.close();
+        try config_file.writer().writeAll(
+            \\pub const step_name = "foo";
+            \\
+        );
+    }
+
+    const test_step = b.step("test", "Test the program");
+    b.default_step.dependOn(test_step);
+
+    {
+        const build_step = b.addBuild(.{ .path = "buildconfigured.zig" }, .{});
+        build_step.addArgs(b.build_args);
+        test_step.dependOn(&build_step.step);
+    }
+    {
+        const build_step = b.addBuild(.{ .path = "buildconfigured.zig" }, .{});
+        build_step.addArg("foo");
+        test_step.dependOn(&build_step.step);
+    }
+    {
+        const build_step = b.addBuild(.{ .path = "buildconfigured.zig" }, .{});
+        build_step.addArg("doesnotexist");
+        build_step.expected_exit_code = 1;
+        build_step.stderr_action = .{ .expect_matches = &[_][]const u8{
+            "Cannot run step 'doesnotexist' because it does not exist",
+        } };
+        test_step.dependOn(&build_step.step);
+    }
+}

--- a/test/standalone/buildstep/buildconfigured.zig
+++ b/test/standalone/buildstep/buildconfigured.zig
@@ -1,0 +1,8 @@
+const config = @import("config.zig");
+
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    _ = b.step("test", "Test the program");
+    _ = b.step(config.step_name, "the configured step");
+}


### PR DESCRIPTION
Status: I converted this back to a draft to wait for #9989. If that gets integrated then I'll update this PR to leverage it.  After playing with this I realize that it's a bit unruly without #9989 to reduce build error noise.

This change adds the "build_args" field to the zig Builder. This provide access to the command-line arguments that were passed to the current "zig build" instance.  These arguments are forwarded to the build_runner after a fixed set of arguments passed from zig itelf.  Builds no longer need to know this internal detail to access these arguments.

Along with this, I've also added a convenient "addBuild" function to Builder that will create a RunStep to execute "zig build".

I've also preserved the original `cache_root` command-line parameter in the new `cache_root_cmdline` field.

Making these new pieces available supplies a more robust interface that enables build.zig files to bootstrap themselves.  This provides a pathway to address https://github.com/ziglang/zig/issues/8070

Here is a real-world build file that can already make use of this: https://github.com/marler8997/maros/blob/master/build.zig

Another use case I already have for this is my implemenation of `zig toolchain`: https://github.com/marler8997/zig-toolchain/blob/dc2dbe137654f4d2f691c5b716975410c8ff4694/zig-toolchain.zig#L147

That example would be slightly modified to leverage `zig build` instead of `zig build-exe`.

If accepted, I may also use this in my ziget/zigup projects.
