### PR TITLE
distinguish between unexpected child process exit code and unclean exit

### DIFF
--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -229,7 +229,7 @@ fn make(step: *Step) !void {
                     printCmd(cwd, argv);
                 }
 
-                return error.UncleanExit;
+                return error.UnexpectedExitCode;
             }
         },
         else => {


### PR DESCRIPTION
This modifies the error for an unexpected exit code from the ChildProcess of RunStep to be `UnexpectedExitCode` rather than `UncleanExit`.  This allows the handler of the error to distinguish between an error reported by the `ChildProcess`, and an error executing the ChildProcess.  This is an important distinction when it comes to know what information to report to the user.  For example, if you have a `ChildProcess` that you know reports its own errors, an unexpected exit code would mean the error is already reported, but an unclean exit would mean that child process may not have been able to report an error.