### PR TITLE
ci: azure: windows probe systeminfo

### DIFF
--- a/ci/azure/pipelines.yml
+++ b/ci/azure/pipelines.yml
@@ -37,6 +37,10 @@ jobs:
     vmImage: 'windows-2019'
   timeoutInMinutes: 360
   steps:
+  - script: systeminfo
+    displayName: Probe host information
+    continueOnError: true
+    timeoutInMinutes: 1
   - powershell: |
       (New-Object Net.WebClient).DownloadFile("https://github.com/msys2/msys2-installer/releases/download/2021-07-25/msys2-base-x86_64-20210725.sfx.exe", "sfx.exe")
       .\sfx.exe -y -o\


### PR DESCRIPTION
Run `systeminfo` as first step to see important host details which may
effect the pipeline. Of particular interest, this command will display
OS version, CPU model, physical RAM, and VRAM (swap is VRAM - RAM).