### PR TITLE
build.RunStep: detect bad exe even if we don't run

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1735,7 +1735,7 @@ pub const LibExeObjStep = struct {
         // Consider that this is declarative; the run step may not be run unless a user
         // option is supplied.
         const run_step = RunStep.create(exe.builder, exe.builder.fmt("run {s}", .{exe.step.name}));
-        run_step.addArtifactArg(exe);
+        run_step.addArtifactArg(exe) catch unreachable;
 
         if (exe.vcpkg_bin_path) |path| {
             run_step.addPathDir(path);

--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -62,7 +62,18 @@ pub fn create(builder: *Builder, name: []const u8) *RunStep {
     return self;
 }
 
-pub fn addArtifactArg(self: *RunStep, artifact: *LibExeObjStep) void {
+pub fn addArtifactArg(self: *RunStep, artifact: *LibExeObjStep) !void {
+    if (self.argv.items.len == 0) {
+        const artifact_target = artifact.target.toTarget();
+        if (!builtin.target.canExecBinariesOf(artifact_target)) {
+            warn("Cannot run '{s}', incompatible target\n", .{artifact.name});
+            return error.CannotRunForeignExe;
+        }
+    }
+    self.addArtifactArgNoCheck(artifact);
+}
+
+pub fn addArtifactArgNoCheck(self: *RunStep, artifact: *LibExeObjStep) void {
     self.argv.append(Arg{ .artifact = artifact }) catch unreachable;
     self.step.dependOn(&artifact.step);
 }

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -30,6 +30,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/issue_7030/build.zig", .{});
     cases.addBuildFile("test/standalone/install_raw_hex/build.zig", .{});
     cases.addBuildFile("test/standalone/issue_9812/build.zig", .{});
+    cases.addBuildFile("test/standalone/run_foreign/build.zig", .{});
     if (builtin.os.tag != .wasi) {
         cases.addBuildFile("test/standalone/load_dynamic_library/build.zig", .{});
     }

--- a/test/standalone/load_dynamic_library/build.zig
+++ b/test/standalone/load_dynamic_library/build.zig
@@ -10,7 +10,7 @@ pub fn build(b: *Builder) void {
     main.setBuildMode(opts);
 
     const run = main.run();
-    run.addArtifactArg(lib);
+    run.addArtifactArg(lib) catch unreachable;
 
     const test_step = b.step("test", "Test the program");
     test_step.dependOn(&run.step);

--- a/test/standalone/run_foreign/build.zig
+++ b/test/standalone/run_foreign/build.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const test_step = b.step("test", "Test the program");
+
+    {
+        const run_step = b.addSystemCommand(&[_][]const u8 {
+            b.zig_exe,
+            "build",
+            "--build-file", b.pathFromRoot("buildhello.zig"),
+            "run",
+        });
+        run_step.stdout_action = .{ .expect_exact = "hello\n" };
+        test_step.dependOn(&run_step.step);
+    }
+
+    {
+        const run_step = b.addSystemCommand(&[_][]const u8 {
+            b.zig_exe,
+            "build",
+            "--build-file", b.pathFromRoot("buildhello.zig"),
+            b.fmt("-Dtarget=native-{s}", .{if (builtin.os.tag == .windows) "linux" else "windows"}),
+            // this tests that we don't need to provide "run" for the build to fail
+        });
+        run_step.expected_exit_code = 1;
+        run_step.stderr_action = .{ .expect_matches = &[_][]const u8 {
+            "Cannot run 'hello', incompatible target",
+        } };
+        test_step.dependOn(&run_step.step);
+    }
+}

--- a/test/standalone/run_foreign/buildhello.zig
+++ b/test/standalone/run_foreign/buildhello.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const exe = b.addExecutable("hello", "hello.zig");
+    exe.setTarget(b.standardTargetOptions(.{}));
+    b.step("run", "Run the exe").dependOn(&exe.run().step);
+}

--- a/test/standalone/run_foreign/hello.zig
+++ b/test/standalone/run_foreign/hello.zig
@@ -1,0 +1,4 @@
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writer().print("hello\n", .{});
+}


### PR DESCRIPTION
This change attempts to find errors earlier.  This change modifies RunStep to detect if it's requested to run an incompatible exe.  This means we would detect an invalid build configuration for a run step even if that run step isn't executed.