### PR TITLE
Format enum stringifications as valid Zig code

### DIFF
--- a/lib/std/build/OptionsStep.zig
+++ b/lib/std/build/OptionsStep.zig
@@ -233,6 +233,10 @@ test "OptionsStep" {
     );
     defer builder.destroy();
 
+    const KeywordEnum = enum {
+        @"0.8.1",
+    };
+
     const options = builder.addOptions();
 
     options.addOption(usize, "option1", 1);
@@ -240,6 +244,7 @@ test "OptionsStep" {
     options.addOption([]const u8, "string", "zigisthebest");
     options.addOption(?[]const u8, "optional_string", null);
     options.addOption(std.SemanticVersion, "semantic_version", try std.SemanticVersion.parse("0.1.2-foo+bar"));
+    options.addOption(KeywordEnum, "keyword_enum", .@"0.8.1");
 
     try std.testing.expectEqualStrings(
         \\pub const option1: usize = 1;
@@ -253,6 +258,10 @@ test "OptionsStep" {
         \\    .pre = "foo",
         \\    .build = "bar",
         \\};
+        \\pub const KeywordEnum = enum {
+        \\    @"0.8.1",
+        \\};
+        \\pub const keyword_enum: KeywordEnum = KeywordEnum.@"0.8.1";
         \\
     , options.contents.items);
 }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -458,7 +458,7 @@ pub fn formatType(
             try writer.writeAll(@typeName(T));
             if (enumInfo.is_exhaustive) {
                 try writer.writeAll(".");
-                try writer.writeAll(@tagName(value));
+                try std.zig.fmtId(@tagName(value)).format("", options, writer);
                 return;
             }
 


### PR DESCRIPTION
- Wrap printed enum variants with @"" if they overlap with Zig syntax
- Add a test

I couldn't find a use-case for outputting the names as invalid Zig code (e.g. `ZigVersion.0.8.1`), so I changed the stdlib `fmt` code directly.

Admittedly, it is the only place where the module depends on the `std.zig` module, but moving the logic to `OptionsStep.zig` would lead to code duplication down the line I think.

Fixes #10013 