### PR TITLE
astgen.zig: fixes for error propagation `ret` and return types in `fnDecl` and `fnProtoExpr`

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -1156,16 +1156,6 @@ fn fnProtoExpr(
         return astgen.failNode(fn_proto.ast.section_expr, "linksection not allowed on function prototypes", .{});
     }
 
-    const maybe_bang = tree.firstToken(fn_proto.ast.return_type) - 1;
-    const is_inferred_error = token_tags[maybe_bang] == .bang;
-    if (is_inferred_error) {
-        return astgen.failTok(maybe_bang, "function prototype may not have inferred error set", .{});
-    }
-    var ret_gz = gz.makeSubBlock(scope);
-    defer ret_gz.instructions.deinit(gpa);
-    const ret_ty = try expr(&ret_gz, scope, coerced_type_rl, fn_proto.ast.return_type);
-    const ret_br = try ret_gz.addBreak(.break_inline, 0, ret_ty);
-
     const cc: Zir.Inst.Ref = if (fn_proto.ast.callconv_expr != 0)
         try expr(
             gz,
@@ -1175,6 +1165,16 @@ fn fnProtoExpr(
         )
     else
         Zir.Inst.Ref.none;
+
+    const maybe_bang = tree.firstToken(fn_proto.ast.return_type) - 1;
+    const is_inferred_error = token_tags[maybe_bang] == .bang;
+    if (is_inferred_error) {
+        return astgen.failTok(maybe_bang, "function prototype may not have inferred error set", .{});
+    }
+    var ret_gz = gz.makeSubBlock(scope);
+    defer ret_gz.instructions.deinit(gpa);
+    const ret_ty = try expr(&ret_gz, scope, coerced_type_rl, fn_proto.ast.return_type);
+    const ret_br = try ret_gz.addBreak(.break_inline, 0, ret_ty);
 
     const result = try gz.addFunc(.{
         .src_node = fn_proto.ast.proto_node,
@@ -3182,11 +3182,6 @@ fn fnDecl(
         break :inst try comptimeExpr(&decl_gz, params_scope, .{ .ty = .const_slice_u8_type }, fn_proto.ast.section_expr);
     };
 
-    var ret_gz = decl_gz.makeSubBlock(params_scope);
-    defer ret_gz.instructions.deinit(gpa);
-    const ret_ty = try expr(&ret_gz, params_scope, coerced_type_rl, fn_proto.ast.return_type);
-    const ret_br = try ret_gz.addBreak(.break_inline, 0, ret_ty);
-
     const cc: Zir.Inst.Ref = blk: {
         if (fn_proto.ast.callconv_expr != 0) {
             if (has_inline_keyword) {
@@ -3211,6 +3206,11 @@ fn fnDecl(
             break :blk .none;
         }
     };
+
+    var ret_gz = decl_gz.makeSubBlock(params_scope);
+    defer ret_gz.instructions.deinit(gpa);
+    const ret_ty = try expr(&ret_gz, params_scope, coerced_type_rl, fn_proto.ast.return_type);
+    const ret_br = try ret_gz.addBreak(.break_inline, 0, ret_ty);
 
     const func_inst: Zir.Inst.Ref = if (body_node == 0) func: {
         if (!is_extern) {

--- a/test/behavior/fn_stage1.zig
+++ b/test/behavior/fn_stage1.zig
@@ -204,3 +204,19 @@ test "function with inferred error set but returning no error" {
     const return_ty = @typeInfo(@TypeOf(S.foo)).Fn.return_type.?;
     try expectEqual(0, @typeInfo(@typeInfo(return_ty).ErrorUnion.error_set).ErrorSet.?.len);
 }
+
+const nComplexCallconv = 100;
+fn fComplexCallconvRet(x: u32) callconv(blk: {
+    const s: struct { n: u32 } = .{ .n = nComplexCallconv };
+    break :blk switch (s.n) {
+        0 => .C,
+        1 => .Inline,
+        else => .Unspecified,
+    };
+}) struct { x: u32 } {
+    return .{ .x = x * x };
+}
+
+test "function with complex callconv and return type expressions" {
+    try expect(fComplexCallconvRet(3).x == 9);
+}


### PR DESCRIPTION
Currently, when `ret` calls `nodeMayEvalToError` on an `orelse` or `catch` expression, only the right hand side is looked at. An expression like `f(x) orelse 0` will always return `.never`. But if, for example, the return type of `f` is `?(SomeError!u32)` then `f(x)` may be an error after unwrapping the optional and `nodeMayEvalToError` is wrong. On the other hand, if `f` returns `ErrorA!ErrorB!u32` then `nodeMayEvalToError` should not consider `f(x) catch 0` to never be an error because as far as I can tell nested error unions are never collapsed and `is_non_err` is not recursive. The same problems exist when the RHS of an `orelse` or a `catch` is an `.error_value`, only with `nodeMayEvalToError` returing `.always` instead of `.maybe`. Finally, for `builtin_call*`, `nodeMayEvalToError` also ignores some possible sources of errors, namely `@as` with an error type, `@call`, `@field`, and `@intToError`.

As an example, for

```zig
var n: u32 = 0;
const E = error{e};
const S = struct { x: u32 };
fn f(x: u32) E!S {
    return if (x > 3) S{ .x = x } else error.e;
}
fn g(x: u32) ?(E!S) {
    return if (x == 0) null else f(x);
}
fn h(x: u32) E!S {
    errdefer n = 1;
    return g(x) orelse S{ .x = 0 };
}
```

the emitted ZIR for the body of `h` is

```
%68 = extended(ret_ptr()) node_offset:12:5
%73 = block({
  %69 = decl_val("g") token_offset:12:12
  %70 = call(.auto, %69, [%62]) node_offset:12:13
  %71 = is_non_null(%70) node_offset:12:17
  %72 = condbr(%71, {
    %74 = optional_payload_unsafe(%70) node_offset:12:17
    %75 = store_node(%68, %74) node_offset:12:17
    %81 = break(%73, @Ref.void_value)
  }, {
    %76 = decl_val("S") token_offset:12:24
    %77 = coerce_result_ptr(%76, %68)
    %78 = field_ptr(%77, "x") node_offset:12:32
    %79 = store_node(%78, @Ref.zero) node_offset:12:32
    %80 = validate_struct_init({
      %78 = field_ptr(%77, "x") node_offset:12:32
    }) node_offset:12:25
    %82 = break(%73, @Ref.void_value)
  }) node_offset:12:17
}) node_offset:12:17
%83 = ret_load(%68) node_offset:12:5
```

Because `nodeMayEvalToError` has returned `.never` for `f(x) orelse S{.x=0}`, the `errdefer` will never run even when `g(x)` returns an error. After fixing the problems in `nodeMayEvalToError`, ZIR to check for an error return and run the errdefer is emitted:

```
%68 = extended(ret_ptr()) node_offset:12:5
%73 = block({
  [...]
}) node_offset:12:17
%83 = is_non_err(%73) node_offset:12:5
%84 = condbr(%83, {
  %85 = ret_load(%68) node_offset:12:5
}, {
  %86 = dbg_stmt(11, 14)
  %87 = dbg_stmt(11, 14)
  %88 = decl_ref("n") token_offset:11:14
  %89 = store_node(%88, @Ref.one) node_offset:11:18
  %90 = ret_load(%68) node_offset:12:5
}) node_offset:12:5
```

However, this has another problem. The instruction `%83 = is_non_err(%73)` is checking the result of the block emitted by `orelseCatchExpr`, but all branches there still end in `break(%73, @Ref.void_value)` (at `%81` and `%82`) because `ret` called `orelseCatchExpr` with a `.ptr` ResultLoc. Thus instruction `%83` will always be true and again the `errdefer` will never run. 

In this case, when `ret` is using a `.ptr` ResultLoc, a load from the `.ret_ptr` instruction should be emitted and used by any further `.is_non_err` or `.err_union_code` instructions. (The helper `addRet` already handles the actual return instruction by ignoring `operand` when the ResultLoc is `.ptr` and emitting a `.ret_load` from that pointer directly.) With this change, the above ZIR becomes

```
%68 = extended(ret_ptr()) node_offset:12:5
%73 = block({
  [...]
}) node_offset:12:17
%83 = load(%68) node_offset:12:5
%84 = is_non_err(%83) node_offset:12:5
%85 = condbr(%84,
  [...]
) node_offset:12:5
```

which I believe is correct. I'm not sure how to add tests for these changes because stage2 isn't able to run any of the examples I can construct that actually hit these problems.

Unrelated to the above changes, I also noticed that `fnDecl` and `fnProtoExpr` are emitting ZIR for their return type expressions before their callconv expressions, even though callconv comes first lexically. In the unlikely cases that both expression are complex enough to need to advance the source cursor, this will break monotonicity and trigger the assert for it in `advanceSourceCursor`.  I fixed this and added a test case to behavior/fn_stage1.zig as I don't see anywhere for direct tests of AstGen.