### PR TITLE
fix(uefi MemoryDescriptor): padding after memory type

### DIFF
--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -179,6 +179,7 @@ pub const MemoryType = enum(u32) {
 
 pub const MemoryDescriptor = extern struct {
     type: MemoryType,
+    padding: u32,
     physical_start: u64,
     virtual_start: u64,
     number_of_pages: usize,


### PR DESCRIPTION
not 100% certain, just noticed that this is implemented slightly differently in rust
https://docs.rs/uefi/0.11.0/src/uefi/table/boot.rs.html#715