### PR TITLE
std.log: simplify to 4 distinct log levels

### DIFF
--- a/lib/std/heap/logging_allocator.zig
+++ b/lib/std/heap/logging_allocator.zig
@@ -40,12 +40,8 @@ pub fn ScopedLoggingAllocator(
         // This function is required as the `std.log.log` function is not public
         inline fn logHelper(comptime log_level: std.log.Level, comptime format: []const u8, args: anytype) void {
             switch (log_level) {
-                .emerg => log.emerg(format, args),
-                .alert => log.alert(format, args),
-                .crit => log.crit(format, args),
                 .err => log.err(format, args),
                 .warn => log.warn(format, args),
-                .notice => log.notice(format, args),
                 .info => log.info(format, args),
                 .debug => log.debug(format, args),
             }
@@ -120,6 +116,6 @@ pub fn ScopedLoggingAllocator(
 /// This allocator is used in front of another allocator and logs to `std.log`
 /// on every call to the allocator.
 /// For logging to a `std.io.Writer` see `std.heap.LogToWriterAllocator`
-pub fn loggingAllocator(parent_allocator: *Allocator) LoggingAllocator(.debug, .crit) {
-    return LoggingAllocator(.debug, .crit).init(parent_allocator);
+pub fn loggingAllocator(parent_allocator: *Allocator) LoggingAllocator(.debug, .err) {
+    return LoggingAllocator(.debug, .err).init(parent_allocator);
 }

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -4398,7 +4398,7 @@ test "zig fmt: regression test for #5722" {
         \\    while (it.next()) |node|
         \\        view_tags.append(node.view.current_tags) catch {
         \\            c.wl_resource_post_no_memory(self.wl_resource);
-        \\            log.crit(.river_status, "out of memory", .{});
+        \\            log.err(.river_status, "out of memory", .{});
         \\            return;
         \\        };
         \\}

--- a/src/main.zig
+++ b/src/main.zig
@@ -27,7 +27,7 @@ const crash_report = @import("crash_report.zig");
 pub usingnamespace crash_report.root_decls;
 
 pub fn fatal(comptime format: []const u8, args: anytype) noreturn {
-    std.log.emerg(format, args);
+    std.log.err(format, args);
     process.exit(1);
 }
 
@@ -94,7 +94,7 @@ const usage = if (debug_extensions_enabled) debug_usage else normal_usage;
 pub const log_level: std.log.Level = switch (builtin.mode) {
     .Debug => .debug,
     .ReleaseSafe, .ReleaseFast => .info,
-    .ReleaseSmall => .crit,
+    .ReleaseSmall => .err,
 };
 
 var log_scopes: std.ArrayListUnmanaged([]const u8) = .{};
@@ -120,14 +120,7 @@ pub fn log(
         } else return;
     }
 
-    // We only recognize 4 log levels in this application.
-    const level_txt = switch (level) {
-        .emerg, .alert, .crit, .err => "error",
-        .warn => "warning",
-        .notice, .info => "info",
-        .debug => "debug",
-    };
-    const prefix1 = level_txt;
+    const prefix1 = comptime level.asText();
     const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
 
     // Print the message to stderr, silently ignoring any errors

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -435,8 +435,8 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\pub const log_level: std.log.Level = .debug;
         \\
         \\pub const scope_levels = [_]std.log.ScopeLevel{
-        \\    .{ .scope = .a, .level = .alert },
-        \\    .{ .scope = .c, .level = .emerg },
+        \\    .{ .scope = .a, .level = .warn },
+        \\    .{ .scope = .c, .level = .err },
         \\};
         \\
         \\const loga = std.log.scoped(.a);
@@ -452,10 +452,6 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    logb.info("", .{});
         \\    logc.info("", .{});
         \\
-        \\    loga.notice("", .{});
-        \\    logb.notice("", .{});
-        \\    logc.notice("", .{});
-        \\
         \\    loga.warn("", .{});
         \\    logb.warn("", .{});
         \\    logc.warn("", .{});
@@ -463,18 +459,6 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    loga.err("", .{});
         \\    logb.err("", .{});
         \\    logc.err("", .{});
-        \\
-        \\    loga.crit("", .{});
-        \\    logb.crit("", .{});
-        \\    logc.crit("", .{});
-        \\
-        \\    loga.alert("", .{});
-        \\    logb.alert("", .{});
-        \\    logc.alert("", .{});
-        \\
-        \\    loga.emerg("", .{});
-        \\    logb.emerg("", .{});
-        \\    logc.emerg("", .{});
         \\}
         \\pub fn log(
         \\    comptime level: std.log.Level,
@@ -483,22 +467,18 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    args: anytype,
         \\) void {
         \\    const level_txt = comptime level.asText();
-        \\    const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
+        \\    const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "):";
         \\    const stdout = std.io.getStdOut().writer();
         \\    nosuspend stdout.print(level_txt ++ prefix2 ++ format ++ "\n", args) catch return;
         \\}
     ,
-        \\debug(b): 
-        \\info(b): 
-        \\notice(b): 
-        \\warning(b): 
-        \\error(b): 
-        \\critical(b): 
-        \\alert(a): 
-        \\alert(b): 
-        \\emergency(a): 
-        \\emergency(b): 
-        \\emergency(c): 
+        \\debug(b):
+        \\info(b):
+        \\warning(a):
+        \\warning(b):
+        \\error(a):
+        \\error(b):
+        \\error(c):
         \\
     );
 
@@ -534,7 +514,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
     ,
         \\debug: alloc - success - len: 10, ptr_align: 1, len_align: 0
         \\debug: shrink - success - 10 to 5, len_align: 0, buf_align: 1
-        \\critical: expand - failure: OutOfMemory - 5 to 20, len_align: 0, buf_align: 1
+        \\error: expand - failure: OutOfMemory - 5 to 20, len_align: 0, buf_align: 1
         \\debug: free - success - len: 5
         \\
     );


### PR DESCRIPTION
Over the last year of using std.log in practice, it has become clear to
me that having the current 8 distinct log levels does more harm than
good. It is too subjective which level a given message should have which
makes filtering based on log level weaker as not all messages will have
been assigned the log level one might expect.

Instead, more granular filtering should be achieved by leveraging the
logging scope feature. Filtering based on a combination of scope and log
level should be sufficiently powerful for all use-cases.

Note that the self hosted compiler has already limited itself to 4
distinct log levels for many months and implemented granular filtering
based on both log scope and level. This has worked very well in practice
while working on the self hosted compiler.