### PR TITLE
Correct documentation for Random.int

### DIFF
--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -53,7 +53,7 @@ pub const Random = struct {
         return values[index];
     }
 
-    /// Returns a random int `i` such that `0 <= i <= maxInt(T)`.
+    /// Returns a random int `i` such that `minInt(T) <= i <= maxInt(T)`.
     /// `i` is evenly distributed.
     pub fn int(r: *Random, comptime T: type) T {
         const bits = @typeInfo(T).Int.bits;


### PR DESCRIPTION
The documentation previously stated that `Random.int` returns an int between zero and `maxInt(T)`, which is incorrect, since negative integers may be returned for signed types.