### PR TITLE
zig fmt: fix formatting for single-line containers with comments

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -329,6 +329,50 @@ test "zig fmt: container declaration, transform trailing comma" {
     );
 }
 
+test "zig fmt: container declaration, comment, add trailing comma" {
+    try testTransform(
+        \\const X = struct {
+        \\    foo: i32, // foo
+        \\    bar: i8
+        \\};
+    ,
+        \\const X = struct {
+        \\    foo: i32, // foo
+        \\    bar: i8,
+        \\};
+        \\
+    );
+    try testTransform(
+        \\const X = struct {
+        \\    foo: i32 // foo
+        \\};
+    ,
+        \\const X = struct {
+        \\    foo: i32, // foo
+        \\};
+        \\
+    );
+}
+
+test "zig fmt: container declaration, multiline string, add trailing comma" {
+    try testTransform(
+        \\const X = struct {
+        \\    foo: []const u8 =
+        \\        \\ foo
+        \\    ,
+        \\    bar: i8
+        \\};
+    ,
+        \\const X = struct {
+        \\    foo: []const u8 =
+        \\        \\ foo
+        \\    ,
+        \\    bar: i8,
+        \\};
+        \\
+    );
+}
+
 test "zig fmt: remove empty lines at start/end of container decl" {
     try testTransform(
         \\const X = struct {


### PR DESCRIPTION
Fixes #8810 (building on top of https://github.com/ziglang/zig/pull/8813 which has been closed for a while).

* Prevent a single-line container declaration if it contains a comment or multiline string.
* If a container declaration cannot be single-line, ensure container fields are rendered with a trailing comma.
* If `Space.comma` is passed to `renderExpressionComma` or `renderTokenComma`, and there already exists a comma in the source, then render one comma instead of two.