### PR TITLE
compiler: Fix 'reached unreachable code' on some Linux environments

### DIFF
--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -617,6 +617,7 @@ pub const NativeTargetInfo = struct {
             error.FileNotFound => return error.GnuLibCVersionUnavailable,
             error.SystemResources => return error.SystemResources,
             error.NotDir => return error.GnuLibCVersionUnavailable,
+            error.NotSymLink => return error.GnuLibCVersionUnavailable,
             error.Unexpected => return error.GnuLibCVersionUnavailable,
             error.InvalidUtf8 => unreachable, // Windows only
             error.BadPathName => unreachable, // Windows only
@@ -893,6 +894,7 @@ pub const NativeTargetInfo = struct {
                             error.AccessDenied,
                             error.FileNotFound,
                             error.NotDir,
+                            error.NotSymLink,
                             => continue,
 
                             error.SystemResources,


### PR DESCRIPTION
When building Zig from source, I encountered a strange error when I tried to use it to compile any thing (using `build-exe`, `run` or `build`, any build command):
```
$ build/zig test lib/std/os.zig
thread 121479 panic: reached unreachable code
???:?:?: 0x55acbdafc006 in ??? (???)
???:?:?: 0x55acbdd4e28f in ??? (???)
...
```

After debugging with `valgrind`, I found that it was due to `std.zig.system.NativeTargetInfo.glibcVerFromSO` not handling the (seemingly rare) case where it tries to readlink a file that is not a symbolic link. And the problem was that `std.os.readlink` actually returned `unreachable` in that case.

Both readlink and readlinkat return EINVAL if bufsiz is not positive, which is in fact impossible (which I believe is why `unreachable` was originally put) however it also returns EINVAL in the case that the named file is not a symbolic link. This is an error that should be handled like file not found or not dir errors are.

So, in this pull request, I change `std.os.readlinkZ`, `std.os.readlinkatZ` and `std.os.readlinkatWasi` to return `error.NotSymLink` when EINVAL is returned (and since bufsiz < 0 is in fact not a possible state, it's the only case where EINVAL is returned).

Making the corresponding changes in `std.zig.system.NativeTargetInfo.glibcVerFromSO` allows the compiler to now work :)