### PR TITLE
Make `std.meta.trait.isContainer` true for opaques

### DIFF
--- a/lib/std/meta/trait.zig
+++ b/lib/std/meta/trait.zig
@@ -354,7 +354,7 @@ test "std.meta.trait.isConstPtr" {
 
 pub fn isContainer(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .Struct, .Union, .Enum => true,
+        .Struct, .Union, .Enum, .Opaque => true,
         else => false,
     };
 }
@@ -368,10 +368,12 @@ test "std.meta.trait.isContainer" {
         A,
         B,
     };
+    const TestOpaque = opaque {};
 
     try testing.expect(isContainer(TestStruct));
     try testing.expect(isContainer(TestUnion));
     try testing.expect(isContainer(TestEnum));
+    try testing.expect(isContainer(TestOpaque));
     try testing.expect(!isContainer(u8));
 }
 


### PR DESCRIPTION
Makes `std.meta.trait.hasFn` work as expected for opaque types with function declarations. Alternative is to add clause directly to `std.meta.trait.hasFn` to account for opaque types.