### PR TITLE
Use `debug.assert` instead of `testing.expect`.

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -648,7 +648,7 @@ const TagPayloadType = TagPayload;
 ///Given a tagged union type, and an enum, return the type of the union
 /// field corresponding to the enum tag.
 pub fn TagPayload(comptime U: type, tag: Tag(U)) type {
-    try testing.expect(trait.is(.Union)(U));
+    comptime debug.assert(trait.is(.Union)(U));
 
     const info = @typeInfo(U).Union;
 


### PR DESCRIPTION
`testing.expect` and friends are intended to be used only in tests; this change reflects that intention.