### PR TITLE
Add argument for `fillFn` to `Random.init`

### DIFF
--- a/lib/std/rand/Gimli.zig
+++ b/lib/std/rand/Gimli.zig
@@ -21,7 +21,7 @@ pub fn init(secret_seed: [secret_seed_length]u8) Gimli {
 }
 
 pub fn random(self: *Gimli) Random {
-    return Random.init(self);
+    return Random.init(self, fill);
 }
 
 pub fn fill(self: *Gimli, buf: []u8) void {

--- a/lib/std/rand/Isaac64.zig
+++ b/lib/std/rand/Isaac64.zig
@@ -31,7 +31,7 @@ pub fn init(init_s: u64) Isaac64 {
 }
 
 pub fn random(self: *Isaac64) Random {
-    return Random.init(self);
+    return Random.init(self, fill);
 }
 
 fn step(self: *Isaac64, mix: u64, base: usize, comptime m1: usize, comptime m2: usize) void {

--- a/lib/std/rand/Pcg.zig
+++ b/lib/std/rand/Pcg.zig
@@ -22,7 +22,7 @@ pub fn init(init_s: u64) Pcg {
 }
 
 pub fn random(self: *Pcg) Random {
-    return Random.init(self);
+    return Random.init(self, fill);
 }
 
 fn next(self: *Pcg) u32 {

--- a/lib/std/rand/Sfc64.zig
+++ b/lib/std/rand/Sfc64.zig
@@ -24,7 +24,7 @@ pub fn init(init_s: u64) Sfc64 {
 }
 
 pub fn random(self: *Sfc64) Random {
-    return Random.init(self);
+    return Random.init(self, fill);
 }
 
 fn next(self: *Sfc64) u64 {

--- a/lib/std/rand/Xoroshiro128.zig
+++ b/lib/std/rand/Xoroshiro128.zig
@@ -17,7 +17,7 @@ pub fn init(init_s: u64) Xoroshiro128 {
 }
 
 pub fn random(self: *Xoroshiro128) Random {
-    return Random.init(self);
+    return Random.init(self, fill);
 }
 
 fn next(self: *Xoroshiro128) u64 {

--- a/lib/std/rand/Xoshiro256.zig
+++ b/lib/std/rand/Xoshiro256.zig
@@ -19,7 +19,7 @@ pub fn init(init_s: u64) Xoshiro256 {
 }
 
 pub fn random(self: *Xoshiro256) Random {
-    return Random.init(self);
+    return Random.init(self, fill);
 }
 
 fn next(self: *Xoshiro256) u64 {


### PR DESCRIPTION
As suggested by @leecannon, this provides more flexibility to the `Random` interface. For exmaple, this allows for an implementation to provide multiple different fill functions. 