### PR TITLE
add pathJoin to builder

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -204,10 +204,10 @@ pub const Builder = struct {
     pub fn resolveInstallPrefix(self: *Builder, install_prefix: ?[]const u8, dir_list: DirList) void {
         if (self.dest_dir) |dest_dir| {
             self.install_prefix = install_prefix orelse "/usr";
-            self.install_path = self.pathJoin(&[_][]const u8{ dest_dir, self.install_prefix });
+            self.install_path = self.pathJoin(&.{ dest_dir, self.install_prefix });
         } else {
             self.install_prefix = install_prefix orelse
-                (self.pathJoin(&[_][]const u8{ self.build_root, "zig-out" }));
+                (self.pathJoin(&.{ self.build_root, "zig-out" }));
             self.install_path = self.install_prefix;
         }
 
@@ -1103,7 +1103,7 @@ pub const Builder = struct {
                 if (fs.path.isAbsolute(name)) {
                     return name;
                 }
-                const full_path = self.pathJoin(&[_][]const u8{
+                const full_path = self.pathJoin(&.{
                     search_prefix,
                     "bin",
                     self.fmt("{s}{s}", .{ name, exe_extension }),
@@ -1118,7 +1118,7 @@ pub const Builder = struct {
                 }
                 var it = mem.tokenize(u8, PATH, &[_]u8{fs.path.delimiter});
                 while (it.next()) |path| {
-                    const full_path = self.pathJoin(&[_][]const u8{
+                    const full_path = self.pathJoin(&.{
                         path,
                         self.fmt("{s}{s}", .{ name, exe_extension }),
                     });
@@ -1131,7 +1131,7 @@ pub const Builder = struct {
                 return name;
             }
             for (paths) |path| {
-                const full_path = self.pathJoin(&[_][]const u8{
+                const full_path = self.pathJoin(&.{
                     path,
                     self.fmt("{s}{s}", .{ name, exe_extension }),
                 });
@@ -1230,7 +1230,7 @@ pub const Builder = struct {
             .bin => self.exe_dir,
             .lib => self.lib_dir,
             .header => self.h_dir,
-            .custom => |path| self.pathJoin(&[_][]const u8{ self.install_path, path }),
+            .custom => |path| self.pathJoin(&.{ self.install_path, path }),
         };
         return fs.path.resolve(
             self.allocator,
@@ -1707,7 +1707,7 @@ pub const LibExeObjStep = struct {
             }
             if (self.output_dir != null) {
                 self.output_lib_path_source.path = self.builder.pathJoin(
-                    &[_][]const u8{ self.output_dir.?, self.out_lib_filename },
+                    &.{ self.output_dir.?, self.out_lib_filename },
                 );
             }
         }
@@ -2135,14 +2135,14 @@ pub const LibExeObjStep = struct {
                 const triplet = try self.target.vcpkgTriplet(allocator, if (linkage == .static) .Static else .Dynamic);
                 defer self.builder.allocator.free(triplet);
 
-                const include_path = self.pathJoin(&[_][]const u8{ root, "installed", triplet, "include" });
+                const include_path = self.builder.pathJoin(&.{ root, "installed", triplet, "include" });
                 errdefer allocator.free(include_path);
                 try self.include_dirs.append(IncludeDir{ .raw_path = include_path });
 
-                const lib_path = self.pathJoin(&[_][]const u8{ root, "installed", triplet, "lib" });
+                const lib_path = self.builder.pathJoin(&.{ root, "installed", triplet, "lib" });
                 try self.lib_paths.append(lib_path);
 
-                self.vcpkg_bin_path = self.pathJoin(&[_][]const u8{ root, "installed", triplet, "bin" });
+                self.vcpkg_bin_path = self.builder.pathJoin(&.{ root, "installed", triplet, "bin" });
             },
         }
     }
@@ -2642,11 +2642,11 @@ pub const LibExeObjStep = struct {
 
         for (builder.search_prefixes.items) |search_prefix| {
             try zig_args.append("-L");
-            try zig_args.append(builder.pathJoin(&[_][]const u8{
+            try zig_args.append(builder.pathJoin(&.{
                 search_prefix, "lib",
             }));
             try zig_args.append("-isystem");
-            try zig_args.append(builder.pathJoin(&[_][]const u8{
+            try zig_args.append(builder.pathJoin(&.{
                 search_prefix, "include",
             }));
         }
@@ -2752,18 +2752,18 @@ pub const LibExeObjStep = struct {
         // Update generated files
         if (self.output_dir != null) {
             self.output_path_source.path = builder.pathJoin(
-                &[_][]const u8{ self.output_dir.?, self.out_filename },
+                &.{ self.output_dir.?, self.out_filename },
             );
 
             if (self.emit_h) {
                 self.output_h_path_source.path = builder.pathJoin(
-                    &[_][]const u8{ self.output_dir.?, self.out_h_filename },
+                    &.{ self.output_dir.?, self.out_h_filename },
                 );
             }
 
             if (self.target.isWindows() or self.target.isUefi()) {
                 self.output_pdb_path_source.path = builder.pathJoin(
-                    &[_][]const u8{ self.output_dir.?, self.out_pdb_filename },
+                    &.{ self.output_dir.?, self.out_pdb_filename },
                 );
             }
         }
@@ -2945,11 +2945,11 @@ pub const InstallDirStep = struct {
                 }
             }
 
-            const full_path = self.builder.pathJoin(&[_][]const u8{
+            const full_path = self.builder.pathJoin(&.{
                 full_src_dir, entry.path,
             });
 
-            const dest_path = self.builder.pathJoin(&[_][]const u8{
+            const dest_path = self.builder.pathJoin(&.{
                 dest_prefix, entry.path,
             });
 

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -204,10 +204,10 @@ pub const Builder = struct {
     pub fn resolveInstallPrefix(self: *Builder, install_prefix: ?[]const u8, dir_list: DirList) void {
         if (self.dest_dir) |dest_dir| {
             self.install_prefix = install_prefix orelse "/usr";
-            self.install_path = fs.path.join(self.allocator, &[_][]const u8{ dest_dir, self.install_prefix }) catch unreachable;
+            self.install_path = self.pathJoin(&[_][]const u8{ dest_dir, self.install_prefix });
         } else {
             self.install_prefix = install_prefix orelse
-                (fs.path.join(self.allocator, &[_][]const u8{ self.build_root, "zig-out" }) catch unreachable);
+                (self.pathJoin(&[_][]const u8{ self.build_root, "zig-out" }));
             self.install_path = self.install_prefix;
         }
 
@@ -230,9 +230,9 @@ pub const Builder = struct {
             h_list[1] = dir;
         }
 
-        self.lib_dir = fs.path.join(self.allocator, &lib_list) catch unreachable;
-        self.exe_dir = fs.path.join(self.allocator, &exe_list) catch unreachable;
-        self.h_dir = fs.path.join(self.allocator, &h_list) catch unreachable;
+        self.lib_dir = self.pathJoin(&lib_list);
+        self.exe_dir = self.pathJoin(&exe_list);
+        self.h_dir = self.pathJoin(&h_list);
     }
 
     fn convertOptionalPathToFileSource(path: ?[]const u8) ?FileSource {
@@ -1086,6 +1086,11 @@ pub const Builder = struct {
         return fs.path.resolve(self.allocator, &[_][]const u8{ self.build_root, rel_path }) catch unreachable;
     }
 
+    /// Shorthand for `std.fs.path.join(builder.allocator, paths) catch unreachable`
+    pub fn pathJoin(self: *Builder, paths: []const []const u8) []u8 {
+        return fs.path.join(self.allocator, paths) catch unreachable;
+    }
+
     pub fn fmt(self: *Builder, comptime format: []const u8, args: anytype) []u8 {
         return fmt_lib.allocPrint(self.allocator, format, args) catch unreachable;
     }
@@ -1098,7 +1103,7 @@ pub const Builder = struct {
                 if (fs.path.isAbsolute(name)) {
                     return name;
                 }
-                const full_path = try fs.path.join(self.allocator, &[_][]const u8{
+                const full_path = self.pathJoin(&[_][]const u8{
                     search_prefix,
                     "bin",
                     self.fmt("{s}{s}", .{ name, exe_extension }),
@@ -1113,7 +1118,7 @@ pub const Builder = struct {
                 }
                 var it = mem.tokenize(u8, PATH, &[_]u8{fs.path.delimiter});
                 while (it.next()) |path| {
-                    const full_path = try fs.path.join(self.allocator, &[_][]const u8{
+                    const full_path = self.pathJoin(&[_][]const u8{
                         path,
                         self.fmt("{s}{s}", .{ name, exe_extension }),
                     });
@@ -1126,7 +1131,7 @@ pub const Builder = struct {
                 return name;
             }
             for (paths) |path| {
-                const full_path = try fs.path.join(self.allocator, &[_][]const u8{
+                const full_path = self.pathJoin(&[_][]const u8{
                     path,
                     self.fmt("{s}{s}", .{ name, exe_extension }),
                 });
@@ -1225,7 +1230,7 @@ pub const Builder = struct {
             .bin => self.exe_dir,
             .lib => self.lib_dir,
             .header => self.h_dir,
-            .custom => |path| fs.path.join(self.allocator, &[_][]const u8{ self.install_path, path }) catch unreachable,
+            .custom => |path| self.pathJoin(&[_][]const u8{ self.install_path, path }),
         };
         return fs.path.resolve(
             self.allocator,
@@ -1701,11 +1706,9 @@ pub const LibExeObjStep = struct {
                 }
             }
             if (self.output_dir != null) {
-                self.output_lib_path_source.path =
-                    fs.path.join(
-                    self.builder.allocator,
+                self.output_lib_path_source.path = self.builder.pathJoin(
                     &[_][]const u8{ self.output_dir.?, self.out_lib_filename },
-                ) catch unreachable;
+                );
             }
         }
     }
@@ -2132,14 +2135,14 @@ pub const LibExeObjStep = struct {
                 const triplet = try self.target.vcpkgTriplet(allocator, if (linkage == .static) .Static else .Dynamic);
                 defer self.builder.allocator.free(triplet);
 
-                const include_path = try fs.path.join(allocator, &[_][]const u8{ root, "installed", triplet, "include" });
+                const include_path = self.pathJoin(&[_][]const u8{ root, "installed", triplet, "include" });
                 errdefer allocator.free(include_path);
                 try self.include_dirs.append(IncludeDir{ .raw_path = include_path });
 
-                const lib_path = try fs.path.join(allocator, &[_][]const u8{ root, "installed", triplet, "lib" });
+                const lib_path = self.pathJoin(&[_][]const u8{ root, "installed", triplet, "lib" });
                 try self.lib_paths.append(lib_path);
 
-                self.vcpkg_bin_path = try fs.path.join(allocator, &[_][]const u8{ root, "installed", triplet, "bin" });
+                self.vcpkg_bin_path = self.pathJoin(&[_][]const u8{ root, "installed", triplet, "bin" });
             },
         }
     }
@@ -2639,11 +2642,11 @@ pub const LibExeObjStep = struct {
 
         for (builder.search_prefixes.items) |search_prefix| {
             try zig_args.append("-L");
-            try zig_args.append(try fs.path.join(builder.allocator, &[_][]const u8{
+            try zig_args.append(builder.pathJoin(&[_][]const u8{
                 search_prefix, "lib",
             }));
             try zig_args.append("-isystem");
-            try zig_args.append(try fs.path.join(builder.allocator, &[_][]const u8{
+            try zig_args.append(builder.pathJoin(&[_][]const u8{
                 search_prefix, "include",
             }));
         }
@@ -2748,26 +2751,20 @@ pub const LibExeObjStep = struct {
 
         // Update generated files
         if (self.output_dir != null) {
-            self.output_path_source.path =
-                fs.path.join(
-                self.builder.allocator,
+            self.output_path_source.path = builder.pathJoin(
                 &[_][]const u8{ self.output_dir.?, self.out_filename },
-            ) catch unreachable;
+            );
 
             if (self.emit_h) {
-                self.output_h_path_source.path =
-                    fs.path.join(
-                    self.builder.allocator,
+                self.output_h_path_source.path = builder.pathJoin(
                     &[_][]const u8{ self.output_dir.?, self.out_h_filename },
-                ) catch unreachable;
+                );
             }
 
             if (self.target.isWindows() or self.target.isUefi()) {
-                self.output_pdb_path_source.path =
-                    fs.path.join(
-                    self.builder.allocator,
+                self.output_pdb_path_source.path = builder.pathJoin(
                     &[_][]const u8{ self.output_dir.?, self.out_pdb_filename },
-                ) catch unreachable;
+                );
             }
         }
 
@@ -2948,11 +2945,11 @@ pub const InstallDirStep = struct {
                 }
             }
 
-            const full_path = try fs.path.join(self.builder.allocator, &[_][]const u8{
+            const full_path = self.builder.pathJoin(&[_][]const u8{
                 full_src_dir, entry.path,
             });
 
-            const dest_path = try fs.path.join(self.builder.allocator, &[_][]const u8{
+            const dest_path = self.builder.pathJoin(&[_][]const u8{
                 dest_prefix, entry.path,
             });
 


### PR DESCRIPTION
Added a public convenience function to `Builder`.   Now instead of doing this:
```zig
    std.fs.path.join(builder.allocator, &[_][]const u8 { "foo", "bar", "baz"}) catch unreacahble
    // or with this shorthand
    std.fs.path.join(builder.allocator, &.{ "foo", "bar", "baz"}) catch unreacahble
```
`build.zig` files can now do this:
```zig
    builder.pathJoin(&[_][]const u8 { "foo", "bar", "baz"})
    // or with this shorthand
    builder.pathJoin(&.{ "foo", "bar", "baz"})
```

I've found this is a common operation, and this convenience function sits alongside existing ones like `builder.pathFromRoot` and `builder.fmt`.