### PR TITLE
add print field to RunStep

### DIFF
--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -37,6 +37,9 @@ stdin_behavior: std.ChildProcess.StdIo = .Inherit,
 
 expected_exit_code: u8 = 0,
 
+/// Print the command before running it
+print: bool,
+
 pub const StdIoAction = union(enum) {
     inherit,
     ignore,
@@ -58,6 +61,7 @@ pub fn create(builder: *Builder, name: []const u8) *RunStep {
         .argv = ArrayList(Arg).init(builder.allocator),
         .cwd = null,
         .env_map = null,
+        .print = builder.verbose,
     };
     return self;
 }
@@ -180,6 +184,9 @@ fn make(step: *Step) !void {
     child.stdin_behavior = self.stdin_behavior;
     child.stdout_behavior = stdIoActionToBehavior(self.stdout_action);
     child.stderr_behavior = stdIoActionToBehavior(self.stderr_action);
+
+    if (self.print)
+        printCmd(cwd, argv);
 
     child.spawn() catch |err| {
         warn("Unable to spawn {s}: {s}\n", .{ argv[0], @errorName(err) });


### PR DESCRIPTION
A new print field is added to RunStep that will control whether it prints the cmd before running it.  By default it will be set to `builder.verbose`.  This makes the default match what one would expect the `zig build --verbose` flag to do (see below) while still allowing each build to customize it:

```
  --verbose                    Print commands before executing them
```