### PR TITLE
C backend: implement signed trunc

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1389,7 +1389,14 @@ fn airTrunc(f: *Function, inst: Air.Inst.Index) !CValue {
             return local;
         },
         .signed => {
-            return f.fail("TODO: C backend: implement trunc for signed integers", .{});
+            const operand_ty = f.air.typeOf(ty_op.operand);
+            const c_bits = toCIntBits(operand_ty.intInfo(target).bits) orelse
+                return f.fail("TODO: C backend: implement integer types larger than 128 bits", .{});
+            const shift_rhs = c_bits - dest_bits;
+            try writer.print("(int{d}_t)((uint{d}_t)", .{ c_bits, c_bits });
+            try f.writeCValue(writer, operand);
+            try writer.print(" << {d}) >> {d};\n", .{ shift_rhs, shift_rhs });
+            return local;
         },
     }
 }

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -5,6 +5,7 @@ test {
     _ = @import("behavior/basic.zig");
     _ = @import("behavior/bool.zig");
     _ = @import("behavior/if.zig");
+    _ = @import("behavior/truncate.zig");
 
     if (builtin.object_format != .c) {
         // Tests that pass for stage1 and stage2 but not the C backend.
@@ -59,7 +60,6 @@ test {
         _ = @import("behavior/switch.zig");
         _ = @import("behavior/this.zig");
         _ = @import("behavior/translate_c_macros.zig");
-        _ = @import("behavior/truncate.zig");
         _ = @import("behavior/underscore.zig");
         _ = @import("behavior/union.zig");
         _ = @import("behavior/usingnamespace.zig");

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -27,8 +27,11 @@ test "truncate to non-power-of-two integers" {
     try testTrunc(u32, u1, 0b10110, 0b0);
     try testTrunc(u32, u2, 0b10101, 0b01);
     try testTrunc(u32, u2, 0b10110, 0b10);
-    // TODO add test coverage for this!
-    // try testTrunc(i32, i3, -4, -4);
+    try testTrunc(i32, i5, -4, -4);
+    try testTrunc(i32, i5, 4, 4);
+    try testTrunc(i32, i5, -28, 4);
+    try testTrunc(i32, i5, 28, -4);
+    try testTrunc(i32, i5, std.math.maxInt(i32), -1);
 }
 
 fn testTrunc(comptime Big: type, comptime Little: type, big: Big, little: Little) !void {


### PR DESCRIPTION
Andrew was very close on the recent "adding to the C backend" stream. 

Unfortunately in C, `x << y` is undefined if `x < 0`. The code written on the stream would have worked without the undefined behavior sanitizer that `zig run` provides by default. Thankfully all we have to do is cast to unsigned and back to signed before the right shift.

All of the tests in `behavior/truncate.zig` passed without other changes.

Also, to verify the test cases I just plugged it into some handwritten LLVM IR in the compiler explorer: https://godbolt.org/z/vzvncr4a1