### PR TITLE
more haiku support 

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -577,11 +577,12 @@ const PosixThreadImpl = struct {
                 };
             },
             .haiku => {
-                var count: u32 = undefined;
-                var system_info: os.system_info = undefined;
-                _ = os.system.get_system_info(&system_info); // always returns B_OK
-                count = system_info.cpu_count;
-                return @intCast(usize, count);
+                var system_info: os.system.system_info = undefined;
+                const rc = os.system.get_system_info(&system_info); // always returns B_OK
+                return switch (os.errno(rc)) {
+                    .SUCCESS => @intCast(usize, system_info.cpu_count),
+                    else => |err| os.unexpectedErrno(err),
+                };
             },
             else => {
                 var count: c_int = undefined;

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -145,28 +145,29 @@ pub const Kevent = extern struct {
 // include/dlfcn.h
 
 pub const POLL = struct {
-    pub const IN = 0x0001;
-    pub const ERR = 0x0004;
-    pub const NVAL = 0x1000;
-    pub const HUP = 0x0080;
+    /// input available
+    pub const IN = 70;
+    /// output available
+    pub const OUT = 71;
+    /// input message available
+    pub const MSG = 72;
+    /// I/O error
+    pub const ERR = 73;
+    /// high priority input available
+    pub const PRI = 74;
+    /// device disconnected
+    pub const HUP = 75;
 };
 
 pub const RTLD = struct {
-    /// Bind function calls lazily.
-    pub const LAZY = 1;
-    /// Bind function calls immediately.
-    pub const NOW = 2;
-    pub const MODEMASK = 0x3;
-    /// Make symbols globally available.
-    pub const GLOBAL = 0x100;
-    /// Opposite of GLOBAL, and the default.
+    /// relocations are performed as needed
+    pub const LAZY = 0;
+    /// the file gets relocated at load time
+    pub const NOW = 1;
+    /// all symbols are available
+    pub const GLOBAL = 2;
+    /// symbols are not available for relocating any other object
     pub const LOCAL = 0;
-    /// Trace loaded objects and exit.
-    pub const TRACE = 0x200;
-    /// Do not remove members.
-    pub const NODELETE = 0x01000;
-    /// Do not load if not already loaded.
-    pub const NOLOAD = 0x02000;
 };
 
 pub const dl_phdr_info = extern struct {
@@ -407,18 +408,11 @@ pub const sockaddr = extern struct {
     };
 };
 
-pub const CTL = struct {
-    pub const KERN = 1;
-    pub const DEBUG = 5;
-};
+pub const CTL = struct {};
 
-pub const KERN = struct {
-    pub const PROC = 14; // struct: process entries
-    pub const PROC_PATHNAME = 12; // path to executable
-    pub const IOV_MAX = 1024;
-};
+pub const KERN = struct {};
 
-pub const IOV_MAX = KERN.IOV_MAX;
+pub const IOV_MAX = 1024;
 
 pub const PATH_MAX = 1024;
 
@@ -427,36 +421,46 @@ pub const STDOUT_FILENO = 1;
 pub const STDERR_FILENO = 2;
 
 pub const PROT = struct {
-    pub const NONE = 0;
-    pub const READ = 1;
-    pub const WRITE = 2;
-    pub const EXEC = 4;
+    pub const READ = 0x01;
+    pub const WRITE = 0x02;
+    pub const EXEC = 0x04;
+    pub const NONE = 0x00;
 };
 
 pub const CLOCK = struct {
+    /// system-wide monotonic clock (aka system time)
     pub const MONOTONIC = 0;
+    /// system-wide real time clock
     pub const REALTIME = -1;
+    /// clock measuring the used CPU time of the current process
     pub const PROCESS_CPUTIME_ID = -2;
+    /// clock measuring the used CPU time of the current thread
     pub const THREAD_CPUTIME_ID = -3;
 };
 
 pub const MAP = struct {
+    /// mmap() error return code
     pub const FAILED = @intToPtr(*c_void, maxInt(usize));
-    pub const SHARED = 0x0001;
-    pub const PRIVATE = 0x0002;
-    pub const FIXED = 0x0004;
+    /// changes are seen by others
+    pub const SHARED = 0x01;
+    /// changes are only seen by caller
+    pub const PRIVATE = 0x02;
+    /// require mapping to specified addr
+    pub const FIXED = 0x04;
+    /// no underlying object
     pub const ANONYMOUS = 0x0008;
     pub const ANON = ANONYMOUS;
+    /// don't commit memory
     pub const NORESERVE = 0x10;
 };
 
 pub const W = struct {
     pub const NOHANG = 0x1;
     pub const UNTRACED = 0x2;
-    pub const STOPPED = 0x10;
     pub const CONTINUED = 0x4;
-    pub const NOWAIT = 0x20;
     pub const EXITED = 0x08;
+    pub const STOPPED = 0x10;
+    pub const NOWAIT = 0x20;
 
     pub fn EXITSTATUS(s: u32) u8 {
         return @intCast(u8, s & 0xff);
@@ -467,11 +471,11 @@ pub const W = struct {
     }
 
     pub fn STOPSIG(s: u32) u32 {
-        return EXITSTATUS(s);
+        return (s >> 16) & 0xff;
     }
 
     pub fn IFEXITED(s: u32) bool {
-        return TERMSIG(s) == 0;
+        return (s & ~@as(u32, 0xff)) == 0;
     }
 
     pub fn IFSTOPPED(s: u32) bool {
@@ -535,28 +539,9 @@ pub const SIG = struct {
     pub const RESERVED1 = 31;
     pub const RESERVED2 = 32;
 
-    // TODO: check
-    pub const RTMIN = 65;
-    pub const RTMAX = 126;
-
     pub const BLOCK = 1;
     pub const UNBLOCK = 2;
     pub const SETMASK = 3;
-
-    pub const WORDS = 4;
-    pub const MAXSIG = 128;
-    pub inline fn IDX(sig: usize) usize {
-        return sig - 1;
-    }
-    pub inline fn WORD(sig: usize) usize {
-        return IDX(sig) >> 5;
-    }
-    pub inline fn BIT(sig: usize) usize {
-        return 1 << (IDX(sig) & 31);
-    }
-    pub inline fn VALID(sig: usize) usize {
-        return sig <= MAXSIG and sig > 0;
-    }
 };
 
 // access function
@@ -570,57 +555,49 @@ pub const O = struct {
     pub const WRONLY = 0x0001;
     pub const RDWR = 0x0002;
     pub const ACCMODE = 0x0003;
+    pub const RWMASK = ACCMODE;
 
+    pub const EXCL = 0x0100;
     pub const CREAT = 0x0200;
-    pub const EXCL = 0x0800;
-    pub const NOCTTY = 0x8000;
     pub const TRUNC = 0x0400;
-    pub const APPEND = 0x0008;
-    pub const NONBLOCK = 0x0004;
-    pub const DSYNC = 0o10000;
-    pub const SYNC = 0x0080;
-    pub const RSYNC = 0o4010000;
-    pub const DIRECTORY = 0x20000;
-    pub const NOFOLLOW = 0x0100;
-    pub const CLOEXEC = 0x00000040;
+    pub const NOCTTY = 0x1000;
+    pub const NOTRAVERSE = 0x2000;
 
-    pub const ASYNC = 0x0040;
-    pub const DIRECT = 0x00010000;
-    pub const NOATIME = 0o1000000;
-    pub const PATH = 0o10000000;
-    pub const TMPFILE = 0o20200000;
+    pub const CLOEXEC = 0x00000040;
+    pub const NONBLOCK = 0x00000080;
     pub const NDELAY = NONBLOCK;
+    pub const APPEND = 0x00000800;
+    pub const SYNC = 0x00010000;
+    pub const RSYNC = 0x00020000;
+    pub const DSYNC = 0x00040000;
+    pub const NOFOLLOW = 0x00080000;
+    pub const DIRECT = 0x00100000;
+    pub const NOCACHE = DIRECT;
+    pub const DIRECTORY = 0x00200000;
 };
 
 pub const F = struct {
-    pub const DUPFD = 0;
-    pub const GETFD = 1;
-    pub const SETFD = 2;
-    pub const GETFL = 3;
-    pub const SETFL = 4;
+    pub const DUPFD = 0x0001;
+    pub const GETFD = 0x0002;
+    pub const SETFD = 0x0004;
+    pub const GETFL = 0x0008;
+    pub const SETFL = 0x0010;
 
-    pub const GETOWN = 5;
-    pub const SETOWN = 6;
+    pub const GETLK = 0x0020;
+    pub const SETLK = 0x0080;
+    pub const SETLKW = 0x0100;
+    pub const DUPFD_CLOEXEC = 0x0200;
 
-    pub const GETLK = 11;
-    pub const SETLK = 12;
-    pub const SETLKW = 13;
-
-    pub const RDLCK = 1;
-    pub const WRLCK = 3;
-    pub const UNLCK = 2;
-
-    pub const SETOWN_EX = 15;
-    pub const GETOWN_EX = 16;
-
-    pub const GETOWNER_UIDS = 17;
+    pub const RDLCK = 0x0040;
+    pub const UNLCK = 0x0200;
+    pub const WRLCK = 0x0400;
 };
 
 pub const LOCK = struct {
-    pub const SH = 1;
-    pub const EX = 2;
-    pub const UN = 8;
-    pub const NB = 4;
+    pub const SH = 0x01;
+    pub const EX = 0x02;
+    pub const NB = 0x04;
+    pub const UN = 0x08;
 };
 
 pub const FD_CLOEXEC = 1;
@@ -635,161 +612,66 @@ pub const SOCK = struct {
     pub const STREAM = 1;
     pub const DGRAM = 2;
     pub const RAW = 3;
-    pub const RDM = 4;
     pub const SEQPACKET = 5;
-
-    pub const CLOEXEC = 0x10000000;
-    pub const NONBLOCK = 0x20000000;
 };
 
 pub const SO = struct {
-    pub const DEBUG = 0x00000001;
-    pub const ACCEPTCONN = 0x00000002;
-    pub const REUSEADDR = 0x00000004;
-    pub const KEEPALIVE = 0x00000008;
-    pub const DONTROUTE = 0x00000010;
-    pub const BROADCAST = 0x00000020;
-    pub const USELOOPBACK = 0x00000040;
-    pub const LINGER = 0x00000080;
-    pub const OOBINLINE = 0x00000100;
-    pub const REUSEPORT = 0x00000200;
-    pub const TIMESTAMP = 0x00000400;
-    pub const NOSIGPIPE = 0x00000800;
-    pub const ACCEPTFILTER = 0x00001000;
-    pub const BINTIME = 0x00002000;
-    pub const NO_OFFLOAD = 0x00004000;
-    pub const NO_DDP = 0x00008000;
-    pub const REUSEPORT_LB = 0x00010000;
+    pub const ACCEPTCONN = 0x00000001;
+    pub const BROADCAST = 0x00000002;
+    pub const DEBUG = 0x00000004;
+    pub const DONTROUTE = 0x00000008;
+    pub const KEEPALIVE = 0x00000010;
+    pub const OOBINLINE = 0x00000020;
+    pub const REUSEADDR = 0x00000040;
+    pub const REUSEPORT = 0x00000080;
+    pub const USELOOPBACK = 0x00000100;
+    pub const LINGER = 0x00000200;
 
-    pub const SNDBUF = 0x1001;
-    pub const RCVBUF = 0x1002;
-    pub const SNDLOWAT = 0x1003;
-    pub const RCVLOWAT = 0x1004;
-    pub const SNDTIMEO = 0x1005;
-    pub const RCVTIMEO = 0x1006;
-    pub const ERROR = 0x1007;
-    pub const TYPE = 0x1008;
-    pub const LABEL = 0x1009;
-    pub const PEERLABEL = 0x1010;
-    pub const LISTENQLIMIT = 0x1011;
-    pub const LISTENQLEN = 0x1012;
-    pub const LISTENINCQLEN = 0x1013;
-    pub const SETFIB = 0x1014;
-    pub const USER_COOKIE = 0x1015;
-    pub const PROTOCOL = 0x1016;
-    pub const PROTOTYPE = PROTOCOL;
-    pub const TS_CLOCK = 0x1017;
-    pub const MAX_PACING_RATE = 0x1018;
-    pub const DOMAIN = 0x1019;
+    pub const SNDBUF = 0x40000001;
+    pub const SNDLOWAT = 0x40000002;
+    pub const SNDTIMEO = 0x40000003;
+    pub const RCVBUF = 0x40000004;
+    pub const RCVLOWAT = 0x40000005;
+    pub const RCVTIMEO = 0x40000006;
+    pub const ERROR = 0x40000007;
+    pub const TYPE = 0x40000008;
+    pub const NONBLOCK = 0x40000009;
+    pub const BINDTODEVICE = 0x4000000a;
+    pub const PEERCRED = 0x4000000b;
 };
 
 pub const SOL = struct {
-    pub const SOCKET = 0xffff;
+    pub const SOCKET = -1;
 };
 
 pub const PF = struct {
     pub const UNSPEC = AF.UNSPEC;
-    pub const LOCAL = AF.LOCAL;
-    pub const UNIX = PF.LOCAL;
     pub const INET = AF.INET;
-    pub const IMPLINK = AF.IMPLINK;
-    pub const PUP = AF.PUP;
-    pub const CHAOS = AF.CHAOS;
-    pub const NETBIOS = AF.NETBIOS;
-    pub const ISO = AF.ISO;
-    pub const OSI = AF.ISO;
-    pub const ECMA = AF.ECMA;
-    pub const DATAKIT = AF.DATAKIT;
-    pub const CCITT = AF.CCITT;
-    pub const DECnet = AF.DECnet;
-    pub const DLI = AF.DLI;
-    pub const LAT = AF.LAT;
-    pub const HYLINK = AF.HYLINK;
-    pub const APPLETALK = AF.APPLETALK;
     pub const ROUTE = AF.ROUTE;
     pub const LINK = AF.LINK;
-    pub const XTP = AF.pseudo_XTP;
-    pub const COIP = AF.COIP;
-    pub const CNT = AF.CNT;
-    pub const SIP = AF.SIP;
-    pub const IPX = AF.IPX;
-    pub const RTIP = AF.pseudo_RTIP;
-    pub const PIP = AF.pseudo_PIP;
-    pub const ISDN = AF.ISDN;
-    pub const KEY = AF.pseudo_KEY;
-    pub const INET6 = AF.pseudo_INET6;
-    pub const NATM = AF.NATM;
-    pub const ATM = AF.ATM;
-    pub const NETGRAPH = AF.NETGRAPH;
-    pub const SLOW = AF.SLOW;
-    pub const SCLUSTER = AF.SCLUSTER;
-    pub const ARP = AF.ARP;
+    pub const INET6 = AF.INET6;
+    pub const LOCAL = AF.LOCAL;
+    pub const UNIX = AF.UNIX;
     pub const BLUETOOTH = AF.BLUETOOTH;
-    pub const IEEE80211 = AF.IEEE80211;
-    pub const INET_SDP = AF.INET_SDP;
-    pub const INET6_SDP = AF.INET6_SDP;
-    pub const MAX = AF.MAX;
 };
 
 pub const AF = struct {
     pub const UNSPEC = 0;
-    pub const UNIX = 1;
-    pub const LOCAL = UNIX;
-    pub const FILE = LOCAL;
-    pub const INET = 2;
-    pub const IMPLINK = 3;
-    pub const PUP = 4;
-    pub const CHAOS = 5;
-    pub const NETBIOS = 6;
-    pub const ISO = 7;
-    pub const OSI = ISO;
-    pub const ECMA = 8;
-    pub const DATAKIT = 9;
-    pub const CCITT = 10;
-    pub const SNA = 11;
-    pub const DECnet = 12;
-    pub const DLI = 13;
-    pub const LAT = 14;
-    pub const HYLINK = 15;
-    pub const APPLETALK = 16;
-    pub const ROUTE = 17;
-    pub const LINK = 18;
-    pub const pseudo_XTP = 19;
-    pub const COIP = 20;
-    pub const CNT = 21;
-    pub const pseudo_RTIP = 22;
-    pub const IPX = 23;
-    pub const SIP = 24;
-    pub const pseudo_PIP = 25;
-    pub const ISDN = 26;
-    pub const E164 = ISDN;
-    pub const pseudo_KEY = 27;
-    pub const INET6 = 28;
-    pub const NATM = 29;
-    pub const ATM = 30;
-    pub const pseudo_HDRCMPLT = 31;
-    pub const NETGRAPH = 32;
-    pub const SLOW = 33;
-    pub const SCLUSTER = 34;
-    pub const ARP = 35;
-    pub const BLUETOOTH = 36;
-    pub const IEEE80211 = 37;
-    pub const INET_SDP = 40;
-    pub const INET6_SDP = 42;
-    pub const MAX = 42;
+    pub const INET = 1;
+    pub const APPLETALK = 2;
+    pub const ROUTE = 3;
+    pub const LINK = 4;
+    pub const INET6 = 5;
+    pub const DLI = 6;
+    pub const IPX = 7;
+    pub const NOTIFY = 8;
+    pub const LOCAL = 9;
+    pub const UNIX = LOCAL;
+    pub const BLUETOOTH = 10;
+    pub const MAX = 11;
 };
 
-pub const DT = struct {
-    pub const UNKNOWN = 0;
-    pub const FIFO = 1;
-    pub const CHR = 2;
-    pub const DIR = 4;
-    pub const BLK = 6;
-    pub const REG = 8;
-    pub const LNK = 10;
-    pub const SOCK = 12;
-    pub const WHT = 14;
-};
+pub const DT = struct {};
 
 /// add event to kq (implies enable)
 pub const EV_ADD = 0x0001;
@@ -855,26 +737,32 @@ pub const EVFILT_EMPTY = -13;
 pub const T = struct {
     pub const CGETA = 0x8000;
     pub const CSETA = 0x8001;
-    pub const CSETAW = 0x8004;
-    pub const CSETAF = 0x8003;
+    pub const CSETAF = 0x8002;
+    pub const CSETAW = 0x8003;
+    pub const CWAITEVENT = 0x8004;
     pub const CSBRK = 08005;
-    pub const CXONC = 0x8007;
     pub const CFLSH = 0x8006;
-
-    pub const IOCSCTTY = 0x8017;
-    pub const IOCGPGRP = 0x8015;
-    pub const IOCSPGRP = 0x8016;
+    pub const CXONC = 0x8007;
+    pub const CQUERYCONNECTED = 0x8008;
+    pub const CGETBITS = 0x8009;
+    pub const CSETDTR = 0x8010;
+    pub const CSETRTS = 0x8011;
     pub const IOCGWINSZ = 0x8012;
     pub const IOCSWINSZ = 0x8013;
+    pub const CVTIME = 0x8014;
+    pub const IOCGPGRP = 0x8015;
+    pub const IOCSPGRP = 0x8016;
+    pub const IOCSCTTY = 0x8017;
     pub const IOCMGET = 0x8018;
-    pub const IOCMBIS = 0x8022;
-    pub const IOCMBIC = 0x8023;
     pub const IOCMSET = 0x8019;
-    pub const FIONREAD = 0xbe000001;
-    pub const FIONBIO = 0xbe000000;
     pub const IOCSBRK = 0x8020;
     pub const IOCCBRK = 0x8021;
+    pub const IOCMBIS = 0x8022;
+    pub const IOCMBIC = 0x8023;
     pub const IOCGSID = 0x8024;
+
+    pub const FIONREAD = 0xbe000001;
+    pub const FIONBIO = 0xbe000000;
 };
 
 pub const winsize = extern struct {
@@ -904,140 +792,105 @@ pub const sigset_t = extern struct {
     __bits: [SIG.WORDS]u32,
 };
 
+const B_POSIX_ERROR_BASE = -2147454976;
+
 pub const E = enum(i32) {
-    /// No error occurred.
-    SUCCESS = 0,
-    PERM = -0x7ffffff1, // Operation not permitted
-    NOENT = -0x7fff9ffd, // No such file or directory
-    SRCH = -0x7fff8ff3, // No such process
+    @"2BIG" = B_POSIX_ERROR_BASE + 1,
+    CHILD = B_POSIX_ERROR_BASE + 2,
+    DEADLK = B_POSIX_ERROR_BASE + 3,
+    FBIG = B_POSIX_ERROR_BASE + 4,
+    MLINK = B_POSIX_ERROR_BASE + 5,
+    NFILE = B_POSIX_ERROR_BASE + 6,
+    NODEV = B_POSIX_ERROR_BASE + 7,
+    NOLCK = B_POSIX_ERROR_BASE + 8,
+    NOSYS = B_POSIX_ERROR_BASE + 9,
+    NOTTY = B_POSIX_ERROR_BASE + 10,
+    NXIO = B_POSIX_ERROR_BASE + 11,
+    SPIPE = B_POSIX_ERROR_BASE + 12,
+    SRCH = B_POSIX_ERROR_BASE + 13,
+    FPOS = B_POSIX_ERROR_BASE + 14,
+    SIGPARM = B_POSIX_ERROR_BASE + 15,
+    DOM = B_POSIX_ERROR_BASE + 16,
+    RANGE = B_POSIX_ERROR_BASE + 17,
+    PROTOTYPE = B_POSIX_ERROR_BASE + 18,
+    PROTONOSUPPORT = B_POSIX_ERROR_BASE + 19,
+    PFNOSUPPORT = B_POSIX_ERROR_BASE + 20,
+    AFNOSUPPORT = B_POSIX_ERROR_BASE + 21,
+    ADDRINUSE = B_POSIX_ERROR_BASE + 22,
+    ADDRNOTAVAIL = B_POSIX_ERROR_BASE + 23,
+    NETDOWN = B_POSIX_ERROR_BASE + 24,
+    NETUNREACH = B_POSIX_ERROR_BASE + 25,
+    NETRESET = B_POSIX_ERROR_BASE + 26,
+    CONNABORTED = B_POSIX_ERROR_BASE + 27,
+    CONNRESET = B_POSIX_ERROR_BASE + 28,
+    ISCONN = B_POSIX_ERROR_BASE + 29,
+    NOTCONN = B_POSIX_ERROR_BASE + 30,
+    SHUTDOWN = B_POSIX_ERROR_BASE + 31,
+    CONNREFUSED = B_POSIX_ERROR_BASE + 32,
+    HOSTUNREACH = B_POSIX_ERROR_BASE + 33,
+    NOPROTOOPT = B_POSIX_ERROR_BASE + 34,
+    NOBUFS = B_POSIX_ERROR_BASE + 35,
+    INPROGRESS = B_POSIX_ERROR_BASE + 36,
+    ALREADY = B_POSIX_ERROR_BASE + 37,
+    ILSEQ = B_POSIX_ERROR_BASE + 38,
+    NOMSG = B_POSIX_ERROR_BASE + 39,
+    STALE = B_POSIX_ERROR_BASE + 40,
+    OVERFLOW = B_POSIX_ERROR_BASE + 41,
+    MSGSIZE = B_POSIX_ERROR_BASE + 42,
+    OPNOTSUPP = B_POSIX_ERROR_BASE + 43,
+    NOTSOCK = B_POSIX_ERROR_BASE + 44,
+    HOSTDOWN = B_POSIX_ERROR_BASE + 45,
+    BADMSG = B_POSIX_ERROR_BASE + 46,
+    CANCELED = B_POSIX_ERROR_BASE + 47,
+    DESTADDRREQ = B_POSIX_ERROR_BASE + 48,
+    DQUOT = B_POSIX_ERROR_BASE + 49,
+    IDRM = B_POSIX_ERROR_BASE + 50,
+    MULTIHOP = B_POSIX_ERROR_BASE + 51,
+    NODATA = B_POSIX_ERROR_BASE + 52,
+    NOLINK = B_POSIX_ERROR_BASE + 53,
+    NOSR = B_POSIX_ERROR_BASE + 54,
+    NOSTR = B_POSIX_ERROR_BASE + 55,
+    NOTSUP = B_POSIX_ERROR_BASE + 56,
+    PROTO = B_POSIX_ERROR_BASE + 57,
+    TIME = B_POSIX_ERROR_BASE + 58,
+    TXTBSY = B_POSIX_ERROR_BASE + 59,
+    NOATTR = B_POSIX_ERROR_BASE + 60,
+    NOTRECOVERABLE = B_POSIX_ERROR_BASE + 61,
+    OWNERDEAD = B_POSIX_ERROR_BASE + 62,
+
+    ACCES = -0x7ffffffe, // Permission denied
     INTR = -0x7ffffff6, // Interrupted system call
     IO = -0x7fffffff, // Input/output error
-    NXIO = -0x7fff8ff5, // Device not configured
-    @"2BIG" = -0x7fff8fff, // Argument list too long
-    NOEXEC = -0x7fffecfe, // Exec format error
-    CHILD = -0x7fff8ffe, // No child processes
-    DEADLK = -0x7fff8ffd, // Resource deadlock avoided
-    NOMEM = -0x80000000, // Cannot allocate memory
-    ACCES = -0x7ffffffe, // Permission denied
-    FAULT = -0x7fffecff, // Bad address
     BUSY = -0x7ffffff2, // Device busy
+    FAULT = -0x7fffecff, // Bad address
+    TIMEDOUT = -2147483639, // Operation timed out
+    AGAIN = -0x7ffffff5,
+    BADF = -0x7fffa000, // Bad file descriptor
     EXIST = -0x7fff9ffe, // File exists
-    XDEV = -0x7fff9ff5, // Cross-device link
-    NODEV = -0x7fff8ff9, // Operation not supported by device
+    INVAL = -0x7ffffffb, // Invalid argument
+    NAMETOOLONG = -2147459068, // File name too long
+    NOENT = -0x7fff9ffd, // No such file or directory
+    PERM = -0x7ffffff1, // Operation not permitted
     NOTDIR = -0x7fff9ffb, // Not a directory
     ISDIR = -0x7fff9ff7, // Is a directory
-    INVAL = -0x7ffffffb, // Invalid argument
-    NFILE = -0x7fff8ffa, // Too many open files in system
-    MFILE = -0x7fff9ff6, // Too many open files
-    NOTTY = -0x7fff8ff6, // Inappropriate ioctl for device
-    TXTBSY = -0x7fff8fc5, // Text file busy
-    FBIG = -0x7fff8ffc, // File too large
+    NOTEMPTY = -2147459066, // Directory not empty
     NOSPC = -0x7fff9ff9, // No space left on device
-    SPIPE = -0x7fff8ff4, // Illegal seek
     ROFS = -0x7fff9ff8, // Read-only filesystem
-    MLINK = -0x7fff8ffb, // Too many links
+    MFILE = -0x7fff9ff6, // Too many open files
+    XDEV = -0x7fff9ff5, // Cross-device link
+    NOEXEC = -0x7fffecfe, // Exec format error
     PIPE = -0x7fff9ff3, // Broken pipe
-    BADF = -0x7fffa000, // Bad file descriptor
-
-    // math software
-    DOM = 33, // Numerical argument out of domain
-    RANGE = 34, // Result too large
-
-    // non-blocking and interrupt i/o
-
-    /// Also used for `WOULDBLOCK`.
-    AGAIN = -0x7ffffff5,
-    INPROGRESS = -0x7fff8fdc,
-    ALREADY = -0x7fff8fdb,
-
-    // ipc/network software -- argument errors
-    NOTSOCK = 38, // Socket operation on non-socket
-    DESTADDRREQ = 39, // Destination address required
-    MSGSIZE = 40, // Message too long
-    PROTOTYPE = 41, // Protocol wrong type for socket
-    NOPROTOOPT = 42, // Protocol not available
-    PROTONOSUPPORT = 43, // Protocol not supported
-    SOCKTNOSUPPORT = 44, // Socket type not supported
-    /// Also used for `NOTSUP`.
-    OPNOTSUPP = 45, // Operation not supported
-    PFNOSUPPORT = 46, // Protocol family not supported
-    AFNOSUPPORT = 47, // Address family not supported by protocol family
-    ADDRINUSE = 48, // Address already in use
-    ADDRNOTAVAIL = 49, // Can't assign requested address
-
-    // ipc/network software -- operational errors
-    NETDOWN = 50, // Network is down
-    NETUNREACH = 51, // Network is unreachable
-    NETRESET = 52, // Network dropped connection on reset
-    CONNABORTED = 53, // Software caused connection abort
-    CONNRESET = 54, // Connection reset by peer
-    NOBUFS = 55, // No buffer space available
-    ISCONN = 56, // Socket is already connected
-    NOTCONN = 57, // Socket is not connected
-    SHUTDOWN = 58, // Can't send after socket shutdown
-    TOOMANYREFS = 59, // Too many references: can't splice
-    TIMEDOUT = 60, // Operation timed out
-    CONNREFUSED = 61, // Connection refused
-
-    LOOP = 62, // Too many levels of symbolic links
-    NAMETOOLONG = 63, // File name too long
-
-    // should be rearranged
-    HOSTDOWN = 64, // Host is down
-    HOSTUNREACH = 65, // No route to host
-    NOTEMPTY = 66, // Directory not empty
-
-    // quotas & mush
-    PROCLIM = 67, // Too many processes
-    USERS = 68, // Too many users
-    DQUOT = 69, // Disc quota exceeded
-
-    // Network File System
-    STALE = 70, // Stale NFS file handle
-    REMOTE = 71, // Too many levels of remote in path
-    BADRPC = 72, // RPC struct is bad
-    RPCMISMATCH = 73, // RPC version wrong
-    PROGUNAVAIL = 74, // RPC prog. not avail
-    PROGMISMATCH = 75, // Program version wrong
-    PROCUNAVAIL = 76, // Bad procedure for program
-
-    NOLCK = 77, // No locks available
-    NOSYS = 78, // Function not implemented
-
-    FTYPE = 79, // Inappropriate file type or format
-    AUTH = 80, // Authentication error
-    NEEDAUTH = 81, // Need authenticator
-    IDRM = 82, // Identifier removed
-    NOMSG = 83, // No message of desired type
-    OVERFLOW = 84, // Value too large to be stored in data type
-    CANCELED = 85, // Operation canceled
-    ILSEQ = 86, // Illegal byte sequence
-    NOATTR = 87, // Attribute not found
-
-    DOOFUS = 88, // Programming error
-
-    BADMSG = 89, // Bad message
-    MULTIHOP = 90, // Multihop attempted
-    NOLINK = 91, // Link has been severed
-    PROTO = 92, // Protocol error
-
-    NOTCAPABLE = 93, // Capabilities insufficient
-    CAPMODE = 94, // Not permitted in capability mode
-    NOTRECOVERABLE = 95, // State not recoverable
-    OWNERDEAD = 96, // Previous owner died
-
+    NOMEM = -0x80000000, // Cannot allocate memory
+    LOOP = -2147459060, // Too many levels of symbolic links
+    SUCCESS = 0,
     _,
 };
 
-pub const MINSIGSTKSZ = switch (builtin.cpu.arch) {
-    .i386, .x86_64 => 2048,
-    .arm, .aarch64 => 4096,
-    else => @compileError("MINSIGSTKSZ not defined for this architecture"),
-};
-pub const SIGSTKSZ = MINSIGSTKSZ + 32768;
+pub const MINSIGSTKSZ = 8192;
+pub const SIGSTKSZ = 16384;
 
-pub const SS_ONSTACK = 1;
-pub const SS_DISABLE = 4;
+pub const SS_ONSTACK = 0x1;
+pub const SS_DISABLE = 0x2;
 
 pub const stack_t = extern struct {
     sp: [*]u8,
@@ -1047,16 +900,16 @@ pub const stack_t = extern struct {
 
 pub const S = struct {
     pub const IFMT = 0o170000;
-
-    pub const IFIFO = 0o010000;
-    pub const IFCHR = 0o020000;
-    pub const IFDIR = 0o040000;
-    pub const IFBLK = 0o060000;
-    pub const IFREG = 0o100000;
-    pub const IFLNK = 0o120000;
     pub const IFSOCK = 0o140000;
-    pub const IFWHT = 0o160000;
+    pub const IFLNK = 0o120000;
+    pub const IFREG = 0o100000;
+    pub const IFBLK = 0o060000;
+    pub const IFDIR = 0o040000;
+    pub const IFCHR = 0o020000;
+    pub const IFIFO = 0o010000;
+    pub const INDEX_DIR = 04000000000;
 
+    pub const IUMSK = 0o7777;
     pub const ISUID = 0o4000;
     pub const ISGID = 0o2000;
     pub const ISVTX = 0o1000;
@@ -1073,22 +926,6 @@ pub const S = struct {
     pub const IWOTH = 0o002;
     pub const IXOTH = 0o001;
 
-    pub fn ISFIFO(m: u32) bool {
-        return m & IFMT == IFIFO;
-    }
-
-    pub fn ISCHR(m: u32) bool {
-        return m & IFMT == IFCHR;
-    }
-
-    pub fn ISDIR(m: u32) bool {
-        return m & IFMT == IFDIR;
-    }
-
-    pub fn ISBLK(m: u32) bool {
-        return m & IFMT == IFBLK;
-    }
-
     pub fn ISREG(m: u32) bool {
         return m & IFMT == IFREG;
     }
@@ -1097,32 +934,39 @@ pub const S = struct {
         return m & IFMT == IFLNK;
     }
 
+    pub fn ISBLK(m: u32) bool {
+        return m & IFMT == IFBLK;
+    }
+
+    pub fn ISDIR(m: u32) bool {
+        return m & IFMT == IFDIR;
+    }
+
+    pub fn ISCHR(m: u32) bool {
+        return m & IFMT == IFCHR;
+    }
+
+    pub fn ISFIFO(m: u32) bool {
+        return m & IFMT == IFIFO;
+    }
+
     pub fn ISSOCK(m: u32) bool {
         return m & IFMT == IFSOCK;
     }
 
-    pub fn IWHT(m: u32) bool {
-        return m & IFMT == IFWHT;
+    pub fn ISINDEX(m: u32) bool {
+        return m & INDEX_DIR == INDEX_DIR;
     }
 };
 
 pub const HOST_NAME_MAX = 255;
 
 pub const AT = struct {
-    /// Magic value that specify the use of the current working directory
-    /// to determine the target of relative file paths in the openat() and
-    /// similar syscalls.
-    pub const FDCWD = -100;
-    /// Check access using effective user and group ID
-    pub const EACCESS = 0x0100;
-    /// Do not follow symbolic links
-    pub const SYMLINK_NOFOLLOW = 0x0200;
-    /// Follow symbolic link
-    pub const SYMLINK_FOLLOW = 0x0400;
-    /// Remove directory instead of file
-    pub const REMOVEDIR = 0x0800;
-    /// Fail if not under dirfd
-    pub const BENEATH = 0x1000;
+    pub const FDCWD = -1;
+    pub const SYMLINK_NOFOLLOW = 0x01;
+    pub const SYMLINK_FOLLOW = 0x02;
+    pub const REMOVEDIR = 0x04;
+    pub const EACCESS = 0x08;
 };
 
 pub const addrinfo = extern struct {
@@ -1137,238 +981,23 @@ pub const addrinfo = extern struct {
 };
 
 pub const IPPROTO = struct {
-    /// dummy for IP
     pub const IP = 0;
-    /// control message protocol
-    pub const ICMP = 1;
-    /// tcp
-    pub const TCP = 6;
-    /// user datagram protocol
-    pub const UDP = 17;
-    /// IP6 header
-    pub const IPV6 = 41;
-    /// raw IP packet
-    pub const RAW = 255;
-    /// IP6 hop-by-hop options
     pub const HOPOPTS = 0;
-    /// group mgmt protocol
+    pub const ICMP = 1;
     pub const IGMP = 2;
-    /// gateway^2 (deprecated)
-    pub const GGP = 3;
-    /// IPv4 encapsulation
-    pub const IPV4 = 4;
-    /// for compatibility
-    pub const IPIP = IPV4;
-    /// Stream protocol II
-    pub const ST = 7;
-    /// exterior gateway protocol
-    pub const EGP = 8;
-    /// private interior gateway
-    pub const PIGP = 9;
-    /// BBN RCC Monitoring
-    pub const RCCMON = 10;
-    /// network voice protocol
-    pub const NVPII = 11;
-    /// pup
-    pub const PUP = 12;
-    /// Argus
-    pub const ARGUS = 13;
-    /// EMCON
-    pub const EMCON = 14;
-    /// Cross Net Debugger
-    pub const XNET = 15;
-    /// Chaos
-    pub const CHAOS = 16;
-    /// Multiplexing
-    pub const MUX = 18;
-    /// DCN Measurement Subsystems
-    pub const MEAS = 19;
-    /// Host Monitoring
-    pub const HMP = 20;
-    /// Packet Radio Measurement
-    pub const PRM = 21;
-    /// xns idp
-    pub const IDP = 22;
-    /// Trunk-1
-    pub const TRUNK1 = 23;
-    /// Trunk-2
-    pub const TRUNK2 = 24;
-    /// Leaf-1
-    pub const LEAF1 = 25;
-    /// Leaf-2
-    pub const LEAF2 = 26;
-    /// Reliable Data
-    pub const RDP = 27;
-    /// Reliable Transaction
-    pub const IRTP = 28;
-    /// tp-4 w/ class negotiation
-    pub const TP = 29;
-    /// Bulk Data Transfer
-    pub const BLT = 30;
-    /// Network Services
-    pub const NSP = 31;
-    /// Merit Internodal
-    pub const INP = 32;
-    /// Datagram Congestion Control Protocol
-    pub const DCCP = 33;
-    /// Third Party Connect
-    pub const @"3PC" = 34;
-    /// InterDomain Policy Routing
-    pub const IDPR = 35;
-    /// XTP
-    pub const XTP = 36;
-    /// Datagram Delivery
-    pub const DDP = 37;
-    /// Control Message Transport
-    pub const CMTP = 38;
-    /// TP++ Transport
-    pub const TPXX = 39;
-    /// IL transport protocol
-    pub const IL = 40;
-    /// Source Demand Routing
-    pub const SDRP = 42;
-    /// IP6 routing header
+    pub const TCP = 6;
+    pub const UDP = 17;
+    pub const IPV6 = 41;
     pub const ROUTING = 43;
-    /// IP6 fragmentation header
     pub const FRAGMENT = 44;
-    /// InterDomain Routing
-    pub const IDRP = 45;
-    /// resource reservation
-    pub const RSVP = 46;
-    /// General Routing Encap.
-    pub const GRE = 47;
-    /// Mobile Host Routing
-    pub const MHRP = 48;
-    /// BHA
-    pub const BHA = 49;
-    /// IP6 Encap Sec. Payload
     pub const ESP = 50;
-    /// IP6 Auth Header
     pub const AH = 51;
-    /// Integ. Net Layer Security
-    pub const INLSP = 52;
-    /// IP with encryption
-    pub const SWIPE = 53;
-    /// Next Hop Resolution
-    pub const NHRP = 54;
-    /// IP Mobility
-    pub const MOBILE = 55;
-    /// Transport Layer Security
-    pub const TLSP = 56;
-    /// SKIP
-    pub const SKIP = 57;
-    /// ICMP6
     pub const ICMPV6 = 58;
-    /// IP6 no next header
     pub const NONE = 59;
-    /// IP6 destination option
     pub const DSTOPTS = 60;
-    /// any host internal protocol
-    pub const AHIP = 61;
-    /// CFTP
-    pub const CFTP = 62;
-    /// "hello" routing protocol
-    pub const HELLO = 63;
-    /// SATNET/Backroom EXPAK
-    pub const SATEXPAK = 64;
-    /// Kryptolan
-    pub const KRYPTOLAN = 65;
-    /// Remote Virtual Disk
-    pub const RVD = 66;
-    /// Pluribus Packet Core
-    pub const IPPC = 67;
-    /// Any distributed FS
-    pub const ADFS = 68;
-    /// Satnet Monitoring
-    pub const SATMON = 69;
-    /// VISA Protocol
-    pub const VISA = 70;
-    /// Packet Core Utility
-    pub const IPCV = 71;
-    /// Comp. Prot. Net. Executive
-    pub const CPNX = 72;
-    /// Comp. Prot. HeartBeat
-    pub const CPHB = 73;
-    /// Wang Span Network
-    pub const WSN = 74;
-    /// Packet Video Protocol
-    pub const PVP = 75;
-    /// BackRoom SATNET Monitoring
-    pub const BRSATMON = 76;
-    /// Sun net disk proto (temp.)
-    pub const ND = 77;
-    /// WIDEBAND Monitoring
-    pub const WBMON = 78;
-    /// WIDEBAND EXPAK
-    pub const WBEXPAK = 79;
-    /// ISO cnlp
-    pub const EON = 80;
-    /// VMTP
-    pub const VMTP = 81;
-    /// Secure VMTP
-    pub const SVMTP = 82;
-    /// Banyon VINES
-    pub const VINES = 83;
-    /// TTP
-    pub const TTP = 84;
-    /// NSFNET-IGP
-    pub const IGP = 85;
-    /// dissimilar gateway prot.
-    pub const DGP = 86;
-    /// TCF
-    pub const TCF = 87;
-    /// Cisco/GXS IGRP
-    pub const IGRP = 88;
-    /// OSPFIGP
-    pub const OSPFIGP = 89;
-    /// Strite RPC protocol
-    pub const SRPC = 90;
-    /// Locus Address Resoloution
-    pub const LARP = 91;
-    /// Multicast Transport
-    pub const MTP = 92;
-    /// AX.25 Frames
-    pub const AX25 = 93;
-    /// IP encapsulated in IP
-    pub const IPEIP = 94;
-    /// Mobile Int.ing control
-    pub const MICP = 95;
-    /// Semaphore Comm. security
-    pub const SCCSP = 96;
-    /// Ethernet IP encapsulation
     pub const ETHERIP = 97;
-    /// encapsulation header
-    pub const ENCAP = 98;
-    /// any private encr. scheme
-    pub const APES = 99;
-    /// GMTP
-    pub const GMTP = 100;
-    /// payload compression (IPComp)
-    pub const IPCOMP = 108;
-    /// SCTP
-    pub const SCTP = 132;
-    /// IPv6 Mobility Header
-    pub const MH = 135;
-    /// UDP-Lite
-    pub const UDPLITE = 136;
-    /// IP6 Host Identity Protocol
-    pub const HIP = 139;
-    /// IP6 Shim6 Protocol
-    pub const SHIM6 = 140;
-    /// Protocol Independent Mcast
-    pub const PIM = 103;
-    /// CARP
-    pub const CARP = 112;
-    /// PGM
-    pub const PGM = 113;
-    /// MPLS-in-IP
-    pub const MPLS = 137;
-    /// PFSYNC
-    pub const PFSYNC = 240;
-    /// Reserved
-    pub const RESERVED_253 = 253;
-    /// Reserved
-    pub const RESERVED_254 = 254;
+    pub const RAW = 255;
+    pub const MAX = 256;
 };
 
 pub const rlimit_resource = enum(c_int) {

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -446,7 +446,6 @@ pub const MAP = struct {
     pub const ANON = 0x0008;
     pub const ANONYMOUS = ANON;
     pub const FILE = 0;
-
 };
 
 pub const W = struct {
@@ -569,7 +568,6 @@ pub const O = struct {
     pub const WRONLY = 0x0001;
     pub const RDWR = 0x0002;
     pub const ACCMODE = 0x0003;
-
 
     pub const CREAT = 0x0200;
     pub const EXCL = 0x0800;
@@ -1439,5 +1437,4 @@ pub const termios = extern struct {
     cc_t: [NCCS]cc_t,
 };
 
-pub const MSG_NOSIGNAL   = 0x0800;
-
+pub const MSG_NOSIGNAL = 0x0800;

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -28,12 +28,12 @@ pub extern "c" fn _kern_read_stat(fd: c_int, path_ptr: [*]u8, traverse_link: boo
 pub extern "c" fn _kern_get_current_team() i32;
 
 pub const sem_t = extern struct {
-    _magic: u32,
-    _kern: extern struct {
-        _count: u32,
-        _flags: u32,
+    type: i32,
+    u: extern union {
+        named_sem_id: ?i32,
+        unnamed_sem: ?i32,
     },
-    _padding: u32,
+    padding: [2]i32,
 };
 
 pub const pthread_attr_t = extern struct {
@@ -51,21 +51,13 @@ pub const pthread_mutex_t = extern struct {
     owner: i32 = -1,
     owner_count: i32 = 0,
 };
+
 pub const pthread_cond_t = extern struct {
     flags: u32 = 0,
     unused: i32 = -42,
     mutex: ?*c_void = null,
     waiter_count: i32 = 0,
     lock: i32 = 0,
-};
-pub const pthread_rwlock_t = extern struct {
-    flags: u32 = 0,
-    owner: i32 = -1,
-    lock_sem: i32 = 0,
-    lock_count: i32 = 0,
-    reader_count: i32 = 0,
-    writer_count: i32 = 0,
-    waiters: [2]?*c_void = [_]?*c_void{ null, null },
 };
 
 pub const EAI = enum(c_int) {
@@ -130,17 +122,6 @@ pub const mode_t = c_uint;
 
 pub const socklen_t = u32;
 
-/// Renamed from `kevent` to `Kevent` to avoid conflict with function name.
-pub const Kevent = extern struct {
-    ident: usize,
-    filter: i16,
-    flags: u16,
-    fflags: u32,
-    data: i64,
-    udata: usize,
-    // TODO ext
-};
-
 // Modes and flags for dlopen()
 // include/dlfcn.h
 
@@ -178,13 +159,11 @@ pub const dl_phdr_info = extern struct {
 };
 
 pub const Flock = extern struct {
+    l_type: c_short,
+    l_whence: c_short,
     l_start: off_t,
     l_len: off_t,
     l_pid: pid_t,
-    l_type: i16,
-    l_whence: i16,
-    l_sysid: i32,
-    __unused: [4]u8,
 };
 
 pub const msghdr = extern struct {
@@ -196,29 +175,6 @@ pub const msghdr = extern struct {
 
     /// scatter/gather array
     msg_iov: [*]iovec,
-
-    /// # elements in msg_iov
-    msg_iovlen: i32,
-
-    /// ancillary data
-    msg_control: ?*c_void,
-
-    /// ancillary data buffer len
-    msg_controllen: socklen_t,
-
-    /// flags on received message
-    msg_flags: i32,
-};
-
-pub const msghdr_const = extern struct {
-    /// optional address
-    msg_name: ?*const sockaddr,
-
-    /// size of address
-    msg_namelen: socklen_t,
-
-    /// scatter/gather array
-    msg_iov: [*]iovec_const,
 
     /// # elements in msg_iov
     msg_iovlen: i32,
@@ -1001,24 +957,15 @@ pub const IPPROTO = struct {
 };
 
 pub const rlimit_resource = enum(c_int) {
-    CPU = 0,
-    FSIZE = 1,
+    CORE = 0,
+    CPU = 1,
     DATA = 2,
-    STACK = 3,
-    CORE = 4,
-    RSS = 5,
-    MEMLOCK = 6,
-    NPROC = 7,
-    NOFILE = 8,
-    SBSIZE = 9,
-    VMEM = 10,
-    NPTS = 11,
-    SWAP = 12,
-    KQUEUES = 13,
-    UMTXP = 14,
+    FSIZE = 3,
+    NOFILE = 4,
+    STACK = 5,
+    AS = 6,
+    NOVMON = 7,
     _,
-
-    pub const AS: rlimit_resource = .VMEM;
 };
 
 pub const rlim_t = i64;
@@ -1055,7 +1002,7 @@ pub const cc_t = u8;
 pub const speed_t = u8;
 pub const tcflag_t = u32;
 
-pub const NCCS = 32;
+pub const NCCS = 11;
 
 pub const termios = extern struct {
     c_iflag: tcflag_t,

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -292,9 +292,11 @@ pub const dirent = extern struct {
     }
 };
 
+pub const B_OS_NAME_LENGTH = 32; // OS.h
+
 pub const area_info = extern struct {
     area: u32,
-    name: [32]u8,
+    name: [B_OS_NAME_LENGTH]u8,
     size: usize,
     lock: u32,
     protection: u32,
@@ -306,6 +308,8 @@ pub const area_info = extern struct {
     address: *c_void,
 };
 
+pub const MAXPATHLEN = PATH_MAX;
+
 pub const image_info = extern struct {
     id: u32,
     image_type: u32,
@@ -315,7 +319,7 @@ pub const image_info = extern struct {
     term_routine: *c_void,
     device: i32,
     node: i64,
-    name: [1024]u8,
+    name: [MAXPATHLEN]u8,
     text: *c_void,
     data: *c_void,
     text_size: i32,
@@ -441,11 +445,9 @@ pub const MAP = struct {
     pub const SHARED = 0x0001;
     pub const PRIVATE = 0x0002;
     pub const FIXED = 0x0004;
-    pub const STACK = 0x0400;
-    pub const NOSYNC = 0x0800;
-    pub const ANON = 0x0008;
-    pub const ANONYMOUS = ANON;
-    pub const FILE = 0;
+    pub const ANONYMOUS = 0x0008;
+    pub const ANON = ANONYMOUS;
+    pub const NORESERVE = 0x10;
 };
 
 pub const W = struct {

--- a/lib/std/crypto/tlcsprng.zig
+++ b/lib/std/crypto/tlcsprng.zig
@@ -40,6 +40,7 @@ const maybe_have_wipe_on_fork = builtin.os.isAtLeast(.linux, .{
     .major = 4,
     .minor = 14,
 }) orelse true;
+const is_haiku = builtin.os.tag == .haiku;
 
 const Context = struct {
     init_state: enum(u8) { uninitialized = 0, initialized, failed },
@@ -72,7 +73,7 @@ fn tlsCsprngFill(_: *c_void, buffer: []u8) void {
 
     if (wipe_mem.len == 0) {
         // Not initialized yet.
-        if (want_fork_safety and maybe_have_wipe_on_fork) {
+        if (want_fork_safety and maybe_have_wipe_on_fork or is_haiku) {
             // Allocate a per-process page, madvise operates with page
             // granularity.
             wipe_mem = os.mmap(

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3836,6 +3836,15 @@ fn detectLibCFromLibCInstallation(arena: *Allocator, target: Target, lci: *const
             list.appendAssumeCapacity(shared_dir);
         }
     }
+    if (target.os.tag == .haiku) {
+        const include_dir_path = lci.include_dir orelse return error.LibCInstallationNotAvailable;
+        const os_dir = try std.fs.path.join(arena, &[_][]const u8{ include_dir_path, "os" });
+        list.appendAssumeCapacity(os_dir);
+
+        const config_dir = try std.fs.path.join(arena, &[_][]const u8{ include_dir_path, "config" });
+        list.appendAssumeCapacity(config_dir);
+    }
+
     return LibCDirs{
         .libc_include_dir_list = list.items,
         .libc_installation = lci,

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -321,7 +321,7 @@ pub const LibCInstallation = struct {
         const sys_include_dir_example_file = if (is_windows)
             "sys\\types.h"
         else if (is_haiku)
-            "posix/errno.h"
+            "errno.h"
         else
             "sys/errno.h";
 


### PR DESCRIPTION
Hello and happy halloween!

I was able to finally get some time to sit down and do some more continued work on improving Haiku support for Zig. The following changesets should allow

`zig build in a (simple) zig project works
`

Running make install to install Zig after compiling probably doesn't work and is on the list of things todo. Debug still remains on the open list of items to tackle at some point but wanted to attempt with smaller changesets. Also included in the changes are some better error checking for some syscalls to Haiku and an attempted cleanup of some defines and constants in the Haiku support section that came across from an older copy and paste. 

Getting Zig to compile on Haiku also meant using the current used version of LLVM (13) which is currently a (hopefully) pending port for Haiku. I am attaching some patches that I used to get LLVM to build on Haiku as well for reference but not including it in the PR changesets directly.


Sample Runs

```
~/src/git/zig/build> uname -a
Haiku shredder 1 hrev55602 Oct 29 2021 07:10:38 x86_64 x86_64 Haiku

~/src/git/zig/build> ./zig version
0.9.0-dev.1463+d97928bf5

## compiling with  simple program
~/src/git/zig/build> cd hellohaiku

~/src/git/zig/build/hellohaiku> cat src/main.zig 
const std = @import("std");
const thread = std.Thread;

pub fn main() anyerror!void {
    std.log.info("All your codebase are belong to us.", .{});
    std.log.info("Num CPUs: {d}.", .{thread.getCpuCount()});
}

~/src/git/zig/build/hellohaiku> ../zig build run
info: All your codebase are belong to us.
info: Num CPUs: 16.


### try using zig build on some other zig codebases

~/src/git/zig/build/ziglings> ../zig build 8
Compiling 008_quiz.zig...
Checking 008_quiz.zig...
PASSED: Program in Zig!


~/src/git/zig/build/ziglings> ../zig build 31
Compiling 031_switch2.zig...
Checking 031_switch2.zig...
PASSED: ZIG!!
```