### PR TITLE
Fix ensureTotalCapacity calls that should be ensureUnusedCapacity calls

### DIFF
--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -629,7 +629,7 @@ pub const DeclGen = struct {
             const params = decl.ty.fnParamLen();
             var i: usize = 0;
 
-            try self.args.ensureTotalCapacity(params);
+            try self.args.ensureUnusedCapacity(params);
             while (i < params) : (i += 1) {
                 const param_type_id = self.spv.types.get(decl.ty.fnParamType(i)).?;
                 const arg_result_id = self.spv.allocResultId();

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -180,7 +180,7 @@ pub fn parse(self: *Dylib, allocator: *Allocator, target: std.Target) !void {
 fn readLoadCommands(self: *Dylib, allocator: *Allocator, reader: anytype) !void {
     const should_lookup_reexports = self.header.?.flags & macho.MH_NO_REEXPORTED_DYLIBS == 0;
 
-    try self.load_commands.ensureTotalCapacity(allocator, self.header.?.ncmds);
+    try self.load_commands.ensureUnusedCapacity(allocator, self.header.?.ncmds);
 
     var i: u16 = 0;
     while (i < self.header.?.ncmds) : (i += 1) {

--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -267,7 +267,7 @@ pub fn readLoadCommands(self: *Object, allocator: *Allocator, reader: anytype) !
     const header = self.header orelse unreachable; // Unreachable here signifies a fatal unexplored condition.
     const offset = self.file_offset orelse 0;
 
-    try self.load_commands.ensureTotalCapacity(allocator, header.ncmds);
+    try self.load_commands.ensureUnusedCapacity(allocator, header.ncmds);
 
     var i: u16 = 0;
     while (i < header.ncmds) : (i += 1) {


### PR DESCRIPTION
If these functions are called more than once, then the array list would no longer be guaranteed to have enough capacity during the appendAssumeCapacity calls. With ensureUnusedCapacity, they will always be guaranteed to have enough capacity regardless of how many times the function is called.

(these are tangential fixes from exploring #9775, and something of a follow-up to #9788)