### PR TITLE
stage2 x86_64: implement MIR for x86_64 native backend in self-hosted compiler

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -440,6 +440,14 @@ fn gen(self: *Self) !void {
             0x5d, // pop rbp
             0xc3, // ret
         });
+
+        _ = try self.addInst(.{
+            .tag = .ret,
+            .ops = Mir.genOps(.{
+                .flags = 0b11,
+            }),
+            .data = undefined,
+        });
     } else {
         try self.dbgSetPrologueEnd();
         try self.genBody(self.air.getMainBody());

--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -1,0 +1,56 @@
+//! This file contains the functionality for lowering x86_64 MIR into
+//! machine code
+
+const Emit = @This();
+const std = @import("std");
+const math = std.math;
+const Mir = @import("Mir.zig");
+const bits = @import("bits.zig");
+const link = @import("../../link.zig");
+const Module = @import("../../Module.zig");
+const ErrorMsg = Module.ErrorMsg;
+const assert = std.debug.assert;
+const DW = std.dwarf;
+const leb128 = std.leb;
+const Instruction = bits.Instruction;
+const Register = bits.Register;
+const DebugInfoOutput = @import("../../codegen.zig").DebugInfoOutput;
+
+mir: Mir,
+bin_file: *link.File,
+debug_output: DebugInfoOutput,
+target: *const std.Target,
+err_msg: ?*ErrorMsg = null,
+src_loc: Module.SrcLoc,
+code: *std.ArrayList(u8),
+
+prev_di_line: u32,
+prev_di_column: u32,
+/// Relative to the beginning of `code`.
+prev_di_pc: usize,
+
+const InnerError = error{
+    OutOfMemory,
+    EmitFail,
+};
+
+pub fn emitMir(emit: *Emit) !void {
+    const mir_tags = emit.mir.instructions.items(.tag);
+
+    for (mir_tags) |tag, index| {
+        const inst = @intCast(u32, index);
+        _ = inst;
+        switch (tag) {
+            else => {
+                return emit.fail("Implement MIR->Isel lowering for x86_64 for pseudo-inst: {s}", .{tag});
+            },
+        }
+    }
+}
+
+fn fail(emit: *Emit, comptime format: []const u8, args: anytype) InnerError {
+    @setCold(true);
+    assert(emit.err_msg == null);
+    emit.err_msg = try ErrorMsg.create(emit.bin_file.allocator, emit.src_loc, format, args);
+    return error.EmitFail;
+}

--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -3,7 +3,9 @@
 
 const Emit = @This();
 const std = @import("std");
+const log = std.log.scoped(.codegen);
 const math = std.math;
+const mem = std.mem;
 const Mir = @import("Mir.zig");
 const bits = @import("bits.zig");
 const link = @import("../../link.zig");
@@ -39,8 +41,8 @@ pub fn emitMir(emit: *Emit) !void {
 
     for (mir_tags) |tag, index| {
         const inst = @intCast(u32, index);
-        _ = inst;
         switch (tag) {
+            .push => try emit.mirPush(inst),
             else => {
                 return emit.fail("Implement MIR->Isel lowering for x86_64 for pseudo-inst: {s}", .{tag});
             },
@@ -53,4 +55,28 @@ fn fail(emit: *Emit, comptime format: []const u8, args: anytype) InnerError {
     assert(emit.err_msg == null);
     emit.err_msg = try ErrorMsg.create(emit.bin_file.allocator, emit.src_loc, format, args);
     return error.EmitFail;
+}
+
+fn mirPush(emit: *Emit, inst: Mir.Inst.Index) !void {
+    const tag = emit.mir.instructions.items(.tag)[inst];
+    const ops = emit.mir.instructions.items(.ops)[inst];
+    assert(tag == .push);
+    const flag = @truncate(u1, ops);
+    const reg = @intToEnum(Register, @truncate(u7, ops >> 9));
+    if (flag == 0b0) {
+        // PUSH reg
+        try emit.code.append(0x50 | @intCast(u8, reg.lowId()));
+    } else {
+        // PUSH r/m64
+        const imm = emit.mir.instructions.items(.data)[inst].imm;
+        const mod: u2 = if (@truncate(i8, imm) == imm) 0b01 else 0b10;
+        const mod_rm = (@intCast(u8, mod) << 6) | (@intCast(u8, Register.rsi.lowId()) << 3) | reg.lowId();
+        try emit.code.ensureUnusedCapacity(2);
+        emit.code.appendSliceAssumeCapacity(&.{ 0xff, mod_rm });
+        if (mod == 0b01) {
+            mem.writeIntLittle(i8, try emit.code.addOne(), @intCast(i8, imm));
+        } else {
+            mem.writeIntLittle(i32, try emit.code.addManyAsArray(4), imm);
+        }
+    }
 }

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -216,10 +216,10 @@ pub fn genOps(opts: struct {
 }) u16 {
     var ops: u16 = 0;
     if (opts.reg1) |reg1| {
-        ops |= @truncate(u3, reg1.id());
+        ops |= @intCast(u16, @enumToInt(reg1)) << 9;
     }
     if (opts.reg2) |reg2| {
-        ops |= @truncate(u3, reg2.id());
+        ops |= @intCast(u16, @enumToInt(reg2)) << 2;
     }
     ops |= opts.flags;
     return ops;

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -159,6 +159,19 @@ pub const Inst = struct {
         ///       0b10  retn imm16
         ///       0b11  retn
         ret,
+
+        /// Pseudo-instructions
+        /// call extern
+        call_extern,
+
+        /// end of prologue
+        dbg_prologue_end,
+
+        /// start of epilogue
+        dbg_epilogue_begin,
+
+        /// update debug line
+        dbg_line,
     };
 
     /// The position of an MIR instruction within the `Mir` instructions array.
@@ -194,4 +207,20 @@ pub fn deinit(mir: *Mir, gpa: *std.mem.Allocator) void {
     mir.instructions.deinit(gpa);
     gpa.free(mir.extra);
     mir.* = undefined;
+}
+
+pub fn genOps(opts: struct {
+    reg1: ?Register = null,
+    reg2: ?Register = null,
+    flags: u2 = 0,
+}) u16 {
+    var ops: u16 = 0;
+    if (opts.reg1) |reg1| {
+        ops |= @truncate(u3, reg1.id());
+    }
+    if (opts.reg2) |reg2| {
+        ops |= @truncate(u3, reg2.id());
+    }
+    ops |= opts.flags;
+    return ops;
 }

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -1,0 +1,197 @@
+//! Machine Intermediate Representation.
+//! This data is produced by x86_64 Codegen and consumed by x86_64 Isel.
+//! These instructions have a 1:1 correspondence with machine code instructions
+//! for the target. MIR can be lowered to source-annotated textual assembly code
+//! instructions, or it can be lowered to machine code.
+//! The main purpose of MIR is to postpone the assignment of offsets until Isel,
+//! so that, for example, the smaller encodings of jump instructions can be used.
+
+const Mir = @This();
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+
+const bits = @import("bits.zig");
+const Register = bits.Register;
+
+instructions: std.MultiArrayList(Inst).Slice,
+/// The meaning of this data is determined by `Inst.Tag` value.
+extra: []const u32,
+
+pub const Inst = struct {
+    tag: Tag,
+    /// This is 3 fields, and the meaning of each depends on `tag`.
+    /// reg1: Register
+    /// reg2: Register
+    /// flags: u2
+    ops: u16,
+    /// The meaning of this depends on `tag` and `ops`.
+    data: Data,
+
+    pub const Tag = enum(u16) {
+        /// ops flags:  form:
+        ///       0b00  reg1, reg2
+        ///       0b00  reg1, imm32
+        ///       0b01  reg1, [reg2 + imm32]
+        ///       0b10  [reg1 + imm32], reg2
+        ///       0b10  [reg1 + 0], imm32
+        ///       0b11  [reg1 + imm32], imm32
+        /// Notes:
+        ///  * If reg2 is `none` then it means Data field `imm` is used as the immediate.
+        ///  * When two imm32 values are required, Data field `payload` points at `ImmPair`.
+        adc,
+
+        /// form: reg1, [reg2 + scale*rcx + imm32]
+        /// ops flags  scale
+        ///      0b00      1
+        ///      0b01      2
+        ///      0b10      4
+        ///      0b11      8
+        adc_scale_src,
+
+        /// form: [reg1 + scale*rax + imm32], reg2
+        /// form: [reg1 + scale*rax + 0], imm32
+        /// ops flags  scale
+        ///      0b00      1
+        ///      0b01      2
+        ///      0b10      4
+        ///      0b11      8
+        /// Notes:
+        ///  * If reg2 is `none` then it means Data field `imm` is used as the immediate.
+        adc_scale_dst,
+
+        /// form: [reg1 + scale*rax + imm32], imm32
+        /// ops flags  scale
+        ///      0b00      1
+        ///      0b01      2
+        ///      0b10      4
+        ///      0b11      8
+        /// Notes:
+        ///  * Data field `payload` points at `ImmPair`.
+        adc_scale_imm,
+
+        // The following instructions all have the same encoding as `adc`.
+
+        add,
+        add_scale_src,
+        add_scale_dst,
+        add_scale_imm,
+        sub,
+        sub_scale_src,
+        sub_scale_dst,
+        sub_scale_imm,
+        xor,
+        xor_scale_src,
+        xor_scale_dst,
+        xor_scale_imm,
+        @"and",
+        and_scale_src,
+        and_scale_dst,
+        and_scale_imm,
+        @"or",
+        or_scale_src,
+        or_scale_dst,
+        or_scale_imm,
+        rol,
+        rol_scale_src,
+        rol_scale_dst,
+        rol_scale_imm,
+        ror,
+        ror_scale_src,
+        ror_scale_dst,
+        ror_scale_imm,
+        rcl,
+        rcl_scale_src,
+        rcl_scale_dst,
+        rcl_scale_imm,
+        rcr,
+        rcr_scale_src,
+        rcr_scale_dst,
+        rcr_scale_imm,
+        shl,
+        shl_scale_src,
+        shl_scale_dst,
+        shl_scale_imm,
+        sal,
+        sal_scale_src,
+        sal_scale_dst,
+        sal_scale_imm,
+        shr,
+        shr_scale_src,
+        shr_scale_dst,
+        shr_scale_imm,
+        sar,
+        sar_scale_src,
+        sar_scale_dst,
+        sar_scale_imm,
+        sbb,
+        sbb_scale_src,
+        sbb_scale_dst,
+        sbb_scale_imm,
+        cmp,
+        cmp_scale_src,
+        cmp_scale_dst,
+        cmp_scale_imm,
+        mov,
+        mov_scale_src,
+        mov_scale_dst,
+        mov_scale_imm,
+        lea,
+        lea_scale_src,
+        lea_scale_dst,
+        lea_scale_imm,
+
+        /// ops flags: 0bX0:
+        /// - Uses the `inst` Data tag as the jump target.
+        /// - reg1 and reg2 are ignored.
+        /// ops flags: 0bX1:
+        /// - reg1 is the jump target.
+        /// - reg2 and data are ignored.
+        jmp,
+
+        /// ops flags:  form:
+        ///       0bX0   reg1
+        ///       0bX1   [reg1 + imm32]
+        push,
+        /// ops flags:  form:
+        ///       0b00  retf imm16
+        ///       0b01  retf
+        ///       0b10  retn imm16
+        ///       0b11  retn
+        ret,
+    };
+
+    /// The position of an MIR instruction within the `Mir` instructions array.
+    pub const Index = u32;
+
+    /// All instructions have a 4-byte payload, which is contained within
+    /// this union. `Tag` determines which union field is active, as well as
+    /// how to interpret the data within.
+    pub const Data = union {
+        /// Another instruction.
+        inst: Index,
+        /// A 32-bit immediate value.
+        imm: i32,
+        /// Index into `extra`. Meaning of what can be found there is context-dependent.
+        payload: u32,
+    };
+
+    // Make sure we don't accidentally make instructions bigger than expected.
+    // Note that in Debug builds, Zig is allowed to insert a secret field for safety checks.
+    comptime {
+        if (builtin.mode != .Debug) {
+            assert(@sizeOf(Inst) == 8);
+        }
+    }
+};
+
+pub const ImmPair = struct {
+    dest_off: i32,
+    operand: i32,
+};
+
+pub fn deinit(mir: *Mir, gpa: *std.mem.Allocator) void {
+    mir.instructions.deinit(gpa);
+    gpa.free(mir.extra);
+    mir.* = undefined;
+}

--- a/src/arch/x86_64/bits.zig
+++ b/src/arch/x86_64/bits.zig
@@ -22,7 +22,7 @@ const DW = std.dwarf;
 ///
 /// The ID can be easily determined by figuring out what range the register is
 /// in, and then subtracting the base.
-pub const Register = enum(u8) {
+pub const Register = enum(u7) {
     // 0 through 15, 64-bit registers. 8-15 are extended.
     // id is just the int value.
     rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi,
@@ -73,7 +73,7 @@ pub const Register = enum(u8) {
     }
 
     /// Like id, but only returns the lower 3 bits.
-    pub fn low_id(self: Register) u3 {
+    pub fn lowId(self: Register) u3 {
         return @truncate(u3, @enumToInt(self));
     }
 
@@ -577,8 +577,8 @@ test "x86_64 Encoder helpers" {
         });
         encoder.opcode_2byte(0x0f, 0xaf);
         encoder.modRm_direct(
-            Register.eax.low_id(),
-            Register.edi.low_id(),
+            Register.eax.lowId(),
+            Register.edi.lowId(),
         );
 
         try testing.expectEqualSlices(u8, &[_]u8{ 0x0f, 0xaf, 0xc7 }, code.items);
@@ -597,8 +597,8 @@ test "x86_64 Encoder helpers" {
         });
         encoder.opcode_1byte(0x89);
         encoder.modRm_direct(
-            Register.edi.low_id(),
-            Register.eax.low_id(),
+            Register.edi.lowId(),
+            Register.eax.lowId(),
         );
 
         try testing.expectEqualSlices(u8, &[_]u8{ 0x89, 0xf8 }, code.items);
@@ -624,7 +624,7 @@ test "x86_64 Encoder helpers" {
         encoder.opcode_1byte(0x81);
         encoder.modRm_direct(
             0,
-            Register.rcx.low_id(),
+            Register.rcx.lowId(),
         );
         encoder.imm32(2147483647);
 


### PR DESCRIPTION
Implements MIR and lowering for:
- [x] push
- [x] ret
- [ ] adc
- [ ] adc_scale_src
- [ ] adc_scale_dst
- [ ] adc_scale_imm
- [ ] add
- [ ] add_scale_src
- [ ] add_scale_dst
- [ ] add_scale_imm
- [ ] sub
- [ ] sub_scale_src
- [ ] sub_scale_dst
- [ ] sub_scale_imm
- [ ] xor
- [ ] xor_scale_src
- [ ] xor_scale_dst
- [ ] xor_scale_imm
- [ ] and
- [ ] and_scale_src
- [ ] and_scale_dst
- [ ] and_scale_imm
- [ ] or
- [ ] or_scale_src
- [ ] or_scale_dst
- [ ] or_scale_imm
- [ ] rol
- [ ] rol_scale_src
- [ ] rol_scale_dst
- [ ] rol_scale_imm
- [ ] ror
- [ ] ror_scale_src
- [ ] ror_scale_dst
- [ ] ror_scale_imm
- [ ] rcl
- [ ] rcl_scale_src
- [ ] rcl_scale_dst
- [ ] rcl_scale_imm
- [ ] rcr
- [ ] rcr_scale_src
- [ ] rcr_scale_dst
- [ ] rcr_scale_imm
- [ ] shl
- [ ] shl_scale_src
- [ ] shl_scale_dst
- [ ] shl_scale_imm
- [ ] sal
- [ ] sal_scale_src
- [ ] sal_scale_dst
- [ ] sal_scale_imm
- [ ] shr
- [ ] shr_scale_src
- [ ] shr_scale_dst
- [ ] shr_scale_imm
- [ ] sar
- [ ] sar_scale_src
- [ ] sar_scale_dst
- [ ] sar_scale_imm
- [ ] sbb
- [ ] sbb_scale_src
- [ ] sbb_scale_dst
- [ ] sbb_scale_imm
- [ ] cmp
- [ ] cmp_scale_src
- [ ] cmp_scale_dst
- [ ] cmp_scale_imm
- [ ] mov
- [ ] mov_scale_src
- [ ] mov_scale_dst
- [ ] mov_scale_imm
- [ ] mov
- [ ] lea_scale_src
- [ ] lea_scale_dst
- [ ] lea_scale_imm
- [ ] jmp
- [ ] call_extern
- [ ] dbg_prologue_end
- [ ] dbg_epilogue_begin
- [ ] dbg_line

Then:
- [ ] passes all stage2 tests for x86_64