### PR TITLE
C backend:  Improve lowering of Zig types to C types

### DIFF
--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -362,7 +362,7 @@ fn flushDecl(self: *C, f: *Flush, decl: *const Module.Decl) FlushDeclError!void 
     const decl_block = self.decl_table.getPtr(decl).?;
     const gpa = self.base.allocator;
 
-    if (decl_block.fwd_decl.items.len != 0) {
+    if (decl_block.typedefs.count() != 0) {
         try f.typedefs.ensureUnusedCapacity(gpa, @intCast(u32, decl_block.typedefs.count()));
         var it = decl_block.typedefs.iterator();
         while (it.next()) |new| {
@@ -371,6 +371,9 @@ fn flushDecl(self: *C, f: *Flush, decl: *const Module.Decl) FlushDeclError!void 
                 try f.err_typedef_buf.appendSlice(gpa, new.value_ptr.rendered);
             }
         }
+    }
+
+    if (decl_block.fwd_decl.items.len != 0) {
         const buf = decl_block.fwd_decl.items;
         try f.all_buffers.append(gpa, .{
             .iov_base = buf.ptr,

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -250,3 +250,45 @@ test "volatile load and store" {
     ptr.* += 1;
     try expect(ptr.* == 1235);
 }
+
+fn fA() []const u8 {
+    return "a";
+}
+fn fB() []const u8 {
+    return "b";
+}
+
+test "call function pointer in struct" {
+    try expect(mem.eql(u8, f3(true), "a"));
+    try expect(mem.eql(u8, f3(false), "b"));
+}
+
+fn f3(x: bool) []const u8 {
+    var wrapper: FnPtrWrapper = .{
+        .fn_ptr = fB,
+    };
+
+    if (x) {
+        wrapper.fn_ptr = fA;
+    }
+
+    return wrapper.fn_ptr();
+}
+
+const FnPtrWrapper = struct {
+    fn_ptr: fn () []const u8,
+};
+
+test "const ptr from var variable" {
+    var x: u64 = undefined;
+    var y: u64 = undefined;
+
+    x = 78;
+    copy(&x, &y);
+
+    try expect(x == y);
+}
+
+fn copy(src: *const u64, dst: *u64) void {
+    dst.* = src.*;
+}


### PR DESCRIPTION
Working towards #10061.

I think when rendering Zig types as C types there are three different "kinds" of C types we render to:
1. primitive non-pointer C types (e.g. uint8_t).  We just print these out.
2. typedef'd types.  We also just print out the names of these when rendering a type, however, we need to make sure that we have a copy of the rendered typedef in the TypedefMap
3/ pointers -- this is the recursive case, as we have to first render the element type of the pointer

The only issue with this is that function pointers have weird syntax.  However, this can be avoided if we typedef function pointers.  Then they can be composed with pointers just like any other type, e.g. we can render "a pointer to a const pointer to a function pointer" as

```
typedef void (*func)(void);
func * const * f;
```
I think this approach should let us straightforwardly render any Zig type without too many special cases.

I want to take another pass through the code to tidy things up and look to add some tests, but I thought I would get some feedback to check I am on the right track and I haven't missed anything.  Thanks for your help in advance :)

So far I have:

1. Changed function pointers to be typedef'd so then we can treat them the same as other types.
2. Distinguished between const slices (zig_L prefix) and mut slices (zig_M prefix).  I think we need to do this if we want to avoid too much special casing.
3. Changed Zig "const pointers" so that they are lowered to C "pointers to const" (e.g. const char *) rather than C "const pointers" (e.g. char * const).  Please let me know if I have misunderstood Zig's semantics here.
4. Ensured that all typedefs are "linked" even if the decl doesn't have any forward declarations -- not sure if this is the correct thing to do