### PR TITLE
Add more entries to the list of stage1+stage2+CBE passing tests

### DIFF
--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -13,6 +13,7 @@ test {
     _ = @import("behavior/bugs/2889.zig");
     _ = @import("behavior/bugs/4560.zig");
     _ = @import("behavior/bugs/4769_a.zig");
+    _ = @import("behavior/bugs/4769_b.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
@@ -41,7 +42,6 @@ test {
         _ = @import("behavior/bugs/2692.zig");
         _ = @import("behavior/bugs/3112.zig");
         _ = @import("behavior/bugs/3586.zig");
-        _ = @import("behavior/bugs/4769_b.zig");
         _ = @import("behavior/bugs/6850.zig");
         _ = @import("behavior/cast.zig");
         _ = @import("behavior/error.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -6,6 +6,7 @@ test {
     _ = @import("behavior/bitcast.zig");
     _ = @import("behavior/bool.zig");
     _ = @import("behavior/bugs/655.zig");
+    _ = @import("behavior/bugs/679.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
@@ -27,7 +28,6 @@ test {
         _ = @import("behavior/basic_llvm.zig");
         _ = @import("behavior/bugs/394.zig");
         _ = @import("behavior/bugs/624.zig");
-        _ = @import("behavior/bugs/679.zig");
         _ = @import("behavior/bugs/704.zig");
         _ = @import("behavior/bugs/1277.zig");
         _ = @import("behavior/bugs/1486.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -10,6 +10,7 @@ test {
     _ = @import("behavior/hasdecl.zig");
     _ = @import("behavior/hasfield.zig");
     _ = @import("behavior/if.zig");
+    _ = @import("behavior/ptrcast.zig");
     _ = @import("behavior/truncate.zig");
     _ = @import("behavior/null.zig");
 
@@ -53,7 +54,6 @@ test {
         _ = @import("behavior/optional.zig");
         _ = @import("behavior/pointers.zig");
         _ = @import("behavior/popcount.zig");
-        _ = @import("behavior/ptrcast.zig");
         _ = @import("behavior/pub_enum.zig");
         _ = @import("behavior/saturating_arithmetic.zig");
         _ = @import("behavior/sizeof_and_typeof.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -12,6 +12,7 @@ test {
     _ = @import("behavior/bugs/2346.zig");
     _ = @import("behavior/bugs/2889.zig");
     _ = @import("behavior/bugs/4560.zig");
+    _ = @import("behavior/bugs/4769_a.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
@@ -40,7 +41,6 @@ test {
         _ = @import("behavior/bugs/2692.zig");
         _ = @import("behavior/bugs/3112.zig");
         _ = @import("behavior/bugs/3586.zig");
-        _ = @import("behavior/bugs/4769_a.zig");
         _ = @import("behavior/bugs/4769_b.zig");
         _ = @import("behavior/bugs/6850.zig");
         _ = @import("behavior/cast.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -7,6 +7,7 @@ test {
     _ = @import("behavior/bool.zig");
     _ = @import("behavior/bugs/655.zig");
     _ = @import("behavior/bugs/679.zig");
+    _ = @import("behavior/bugs/704.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
@@ -28,7 +29,6 @@ test {
         _ = @import("behavior/basic_llvm.zig");
         _ = @import("behavior/bugs/394.zig");
         _ = @import("behavior/bugs/624.zig");
-        _ = @import("behavior/bugs/704.zig");
         _ = @import("behavior/bugs/1277.zig");
         _ = @import("behavior/bugs/1486.zig");
         _ = @import("behavior/bugs/1500.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -10,6 +10,7 @@ test {
     _ = @import("behavior/bugs/704.zig");
     _ = @import("behavior/bugs/1486.zig");
     _ = @import("behavior/bugs/2346.zig");
+    _ = @import("behavior/bugs/2889.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
@@ -36,7 +37,6 @@ test {
         _ = @import("behavior/bugs/1741.zig");
         _ = @import("behavior/bugs/2006.zig");
         _ = @import("behavior/bugs/2692.zig");
-        _ = @import("behavior/bugs/2889.zig");
         _ = @import("behavior/bugs/3112.zig");
         _ = @import("behavior/bugs/3586.zig");
         _ = @import("behavior/bugs/4560.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -5,6 +5,7 @@ test {
     _ = @import("behavior/basic.zig");
     _ = @import("behavior/bool.zig");
     _ = @import("behavior/call.zig");
+    _ = @import("behavior/enum.zig");
     _ = @import("behavior/if.zig");
     _ = @import("behavior/truncate.zig");
     _ = @import("behavior/null.zig");
@@ -37,7 +38,6 @@ test {
         _ = @import("behavior/bugs/6850.zig");
         _ = @import("behavior/cast.zig");
         _ = @import("behavior/defer.zig");
-        _ = @import("behavior/enum.zig");
         _ = @import("behavior/error.zig");
         _ = @import("behavior/eval.zig");
         _ = @import("behavior/floatop.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -4,6 +4,7 @@ test {
     // Tests that pass for stage1, stage2, and the C backend.
     _ = @import("behavior/basic.zig");
     _ = @import("behavior/bool.zig");
+    _ = @import("behavior/call.zig");
     _ = @import("behavior/if.zig");
     _ = @import("behavior/truncate.zig");
     _ = @import("behavior/null.zig");
@@ -34,7 +35,6 @@ test {
         _ = @import("behavior/bugs/4769_a.zig");
         _ = @import("behavior/bugs/4769_b.zig");
         _ = @import("behavior/bugs/6850.zig");
-        _ = @import("behavior/call.zig");
         _ = @import("behavior/cast.zig");
         _ = @import("behavior/defer.zig");
         _ = @import("behavior/enum.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -11,6 +11,7 @@ test {
     _ = @import("behavior/bugs/1486.zig");
     _ = @import("behavior/bugs/2346.zig");
     _ = @import("behavior/bugs/2889.zig");
+    _ = @import("behavior/bugs/4560.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
@@ -39,7 +40,6 @@ test {
         _ = @import("behavior/bugs/2692.zig");
         _ = @import("behavior/bugs/3112.zig");
         _ = @import("behavior/bugs/3586.zig");
-        _ = @import("behavior/bugs/4560.zig");
         _ = @import("behavior/bugs/4769_a.zig");
         _ = @import("behavior/bugs/4769_b.zig");
         _ = @import("behavior/bugs/6850.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 test {
     // Tests that pass for stage1, stage2, and the C backend.
     _ = @import("behavior/basic.zig");
+    _ = @import("behavior/bitcast.zig");
     _ = @import("behavior/bool.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
@@ -20,7 +21,6 @@ test {
         _ = @import("behavior/array.zig");
         _ = @import("behavior/atomics.zig");
         _ = @import("behavior/basic_llvm.zig");
-        _ = @import("behavior/bitcast.zig");
         _ = @import("behavior/bugs/394.zig");
         _ = @import("behavior/bugs/624.zig");
         _ = @import("behavior/bugs/655.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -14,6 +14,7 @@ test {
     _ = @import("behavior/bugs/4560.zig");
     _ = @import("behavior/bugs/4769_a.zig");
     _ = @import("behavior/bugs/4769_b.zig");
+    _ = @import("behavior/bugs/6850.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
@@ -42,7 +43,6 @@ test {
         _ = @import("behavior/bugs/2692.zig");
         _ = @import("behavior/bugs/3112.zig");
         _ = @import("behavior/bugs/3586.zig");
-        _ = @import("behavior/bugs/6850.zig");
         _ = @import("behavior/cast.zig");
         _ = @import("behavior/error.zig");
         _ = @import("behavior/eval.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -11,10 +11,11 @@ test {
     _ = @import("behavior/hasdecl.zig");
     _ = @import("behavior/hasfield.zig");
     _ = @import("behavior/if.zig");
+    _ = @import("behavior/null.zig");
     _ = @import("behavior/ptrcast.zig");
     _ = @import("behavior/pub_enum.zig");
     _ = @import("behavior/truncate.zig");
-    _ = @import("behavior/null.zig");
+    _ = @import("behavior/underscore.zig");
 
     if (builtin.object_format != .c) {
         // Tests that pass for stage1 and stage2 but not the C backend.
@@ -62,7 +63,6 @@ test {
         _ = @import("behavior/switch.zig");
         _ = @import("behavior/this.zig");
         _ = @import("behavior/translate_c_macros.zig");
-        _ = @import("behavior/underscore.zig");
         _ = @import("behavior/union.zig");
         _ = @import("behavior/usingnamespace.zig");
         _ = @import("behavior/while.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -12,6 +12,7 @@ test {
     _ = @import("behavior/hasfield.zig");
     _ = @import("behavior/if.zig");
     _ = @import("behavior/ptrcast.zig");
+    _ = @import("behavior/pub_enum.zig");
     _ = @import("behavior/truncate.zig");
     _ = @import("behavior/null.zig");
 
@@ -54,7 +55,6 @@ test {
         _ = @import("behavior/optional.zig");
         _ = @import("behavior/pointers.zig");
         _ = @import("behavior/popcount.zig");
-        _ = @import("behavior/pub_enum.zig");
         _ = @import("behavior/saturating_arithmetic.zig");
         _ = @import("behavior/sizeof_and_typeof.zig");
         _ = @import("behavior/slice.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -5,6 +5,7 @@ test {
     _ = @import("behavior/basic.zig");
     _ = @import("behavior/bool.zig");
     _ = @import("behavior/call.zig");
+    _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
     _ = @import("behavior/if.zig");
     _ = @import("behavior/truncate.zig");
@@ -37,7 +38,6 @@ test {
         _ = @import("behavior/bugs/4769_b.zig");
         _ = @import("behavior/bugs/6850.zig");
         _ = @import("behavior/cast.zig");
-        _ = @import("behavior/defer.zig");
         _ = @import("behavior/error.zig");
         _ = @import("behavior/eval.zig");
         _ = @import("behavior/floatop.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -7,6 +7,7 @@ test {
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
+    _ = @import("behavior/hasdecl.zig");
     _ = @import("behavior/if.zig");
     _ = @import("behavior/truncate.zig");
     _ = @import("behavior/null.zig");
@@ -44,7 +45,6 @@ test {
         _ = @import("behavior/fn.zig");
         _ = @import("behavior/for.zig");
         _ = @import("behavior/generics.zig");
-        _ = @import("behavior/hasdecl.zig");
         _ = @import("behavior/hasfield.zig");
         _ = @import("behavior/math.zig");
         _ = @import("behavior/maximum_minimum.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -8,6 +8,7 @@ test {
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
     _ = @import("behavior/hasdecl.zig");
+    _ = @import("behavior/hasfield.zig");
     _ = @import("behavior/if.zig");
     _ = @import("behavior/truncate.zig");
     _ = @import("behavior/null.zig");
@@ -45,7 +46,6 @@ test {
         _ = @import("behavior/fn.zig");
         _ = @import("behavior/for.zig");
         _ = @import("behavior/generics.zig");
-        _ = @import("behavior/hasfield.zig");
         _ = @import("behavior/math.zig");
         _ = @import("behavior/maximum_minimum.zig");
         _ = @import("behavior/member_func.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -16,6 +16,7 @@ test {
     _ = @import("behavior/pub_enum.zig");
     _ = @import("behavior/truncate.zig");
     _ = @import("behavior/underscore.zig");
+    _ = @import("behavior/usingnamespace.zig");
 
     if (builtin.object_format != .c) {
         // Tests that pass for stage1 and stage2 but not the C backend.
@@ -64,7 +65,6 @@ test {
         _ = @import("behavior/this.zig");
         _ = @import("behavior/translate_c_macros.zig");
         _ = @import("behavior/union.zig");
-        _ = @import("behavior/usingnamespace.zig");
         _ = @import("behavior/while.zig");
         _ = @import("behavior/widening.zig");
 

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -9,6 +9,7 @@ test {
     _ = @import("behavior/bugs/679.zig");
     _ = @import("behavior/bugs/704.zig");
     _ = @import("behavior/bugs/1486.zig");
+    _ = @import("behavior/bugs/2346.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
@@ -34,7 +35,6 @@ test {
         _ = @import("behavior/bugs/1500.zig");
         _ = @import("behavior/bugs/1741.zig");
         _ = @import("behavior/bugs/2006.zig");
-        _ = @import("behavior/bugs/2346.zig");
         _ = @import("behavior/bugs/2692.zig");
         _ = @import("behavior/bugs/2889.zig");
         _ = @import("behavior/bugs/3112.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -5,6 +5,7 @@ test {
     _ = @import("behavior/basic.zig");
     _ = @import("behavior/bitcast.zig");
     _ = @import("behavior/bool.zig");
+    _ = @import("behavior/bugs/655.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
@@ -26,7 +27,6 @@ test {
         _ = @import("behavior/basic_llvm.zig");
         _ = @import("behavior/bugs/394.zig");
         _ = @import("behavior/bugs/624.zig");
-        _ = @import("behavior/bugs/655.zig");
         _ = @import("behavior/bugs/679.zig");
         _ = @import("behavior/bugs/704.zig");
         _ = @import("behavior/bugs/1277.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -8,6 +8,7 @@ test {
     _ = @import("behavior/bugs/655.zig");
     _ = @import("behavior/bugs/679.zig");
     _ = @import("behavior/bugs/704.zig");
+    _ = @import("behavior/bugs/1486.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
@@ -30,7 +31,6 @@ test {
         _ = @import("behavior/bugs/394.zig");
         _ = @import("behavior/bugs/624.zig");
         _ = @import("behavior/bugs/1277.zig");
-        _ = @import("behavior/bugs/1486.zig");
         _ = @import("behavior/bugs/1500.zig");
         _ = @import("behavior/bugs/1741.zig");
         _ = @import("behavior/bugs/2006.zig");


### PR DESCRIPTION
All of these seem to be passing with both `zig test -fLLVM ${test}` and `zig test -ofmt=c ${test}` on a stage2 build.