### PR TITLE
add support for compiling Objective-C++ code

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -296,6 +296,7 @@ const usage_build_generic =
     \\                      .c    C source code (requires LLVM extensions)
     \\        .cxx .cc .C .cpp    C++ source code (requires LLVM extensions)
     \\                      .m    Objective-C source code (requires LLVM extensions)
+    \\                     .mm    Objective-C++ source code (requires LLVM extensions)
     \\                     .bc    LLVM IR Module (requires LLVM extensions)
     \\
     \\General Options:
@@ -1190,7 +1191,7 @@ fn buildOutputType(
                     .object, .static_library, .shared_library => {
                         try link_objects.append(arg);
                     },
-                    .assembly, .c, .cpp, .h, .ll, .bc, .m => {
+                    .assembly, .c, .cpp, .h, .ll, .bc, .m, .mm => {
                         try c_source_files.append(.{
                             .src_path = arg,
                             .extra_flags = try arena.dupe([]const u8, extra_cflags.items),
@@ -1256,7 +1257,7 @@ fn buildOutputType(
                     .positional => {
                         const file_ext = Compilation.classifyFileExt(mem.spanZ(it.only_arg));
                         switch (file_ext) {
-                            .assembly, .c, .cpp, .ll, .bc, .h, .m => try c_source_files.append(.{ .src_path = it.only_arg }),
+                            .assembly, .c, .cpp, .ll, .bc, .h, .m, .mm => try c_source_files.append(.{ .src_path = it.only_arg }),
                             .unknown, .shared_library, .object, .static_library => {
                                 try link_objects.append(it.only_arg);
                             },

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -69,6 +69,11 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
         .build_modes = true,
         .requires_macos_sdk = true,
     });
+    // Try to build and run an Objective-C++ executable.
+    cases.addBuildFile("test/standalone/objcpp/build.zig", .{
+        .build_modes = true,
+        .requires_macos_sdk = true,
+    });
 
     // Ensure the development tools are buildable.
     cases.add("tools/gen_spirv_spec.zig");

--- a/test/standalone/objcpp/Foo.h
+++ b/test/standalone/objcpp/Foo.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface Foo : NSObject
+
+- (NSString *)name;
+
+@end

--- a/test/standalone/objcpp/Foo.mm
+++ b/test/standalone/objcpp/Foo.mm
@@ -1,0 +1,11 @@
+#import "Foo.h"
+
+@implementation Foo
+
+- (NSString *)name
+{
+      NSString *str = [[NSString alloc] initWithFormat:@"Zig"];
+      return str;
+}
+
+@end

--- a/test/standalone/objcpp/build.zig
+++ b/test/standalone/objcpp/build.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+const CrossTarget = std.zig.CrossTarget;
+
+fn isRunnableTarget(t: CrossTarget) bool {
+    // TODO I think we might be able to run this on Linux via Darling.
+    // Add a check for that here, and return true if Darling is available.
+    if (t.isNative() and t.getOsTag() == .macos)
+        return true
+    else
+        return false;
+}
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const target = b.standardTargetOptions(.{});
+
+    const test_step = b.step("test", "Test the program");
+
+    const exe = b.addExecutable("test", null);
+    b.default_step.dependOn(&exe.step);
+    exe.addIncludeDir(".");
+    exe.addCSourceFile("Foo.mm", &[0][]const u8{});
+    exe.addCSourceFile("test.mm", &[0][]const u8{});
+    exe.setBuildMode(mode);
+    exe.setTarget(target);
+    exe.linkLibCpp();
+    // TODO when we figure out how to ship framework stubs for cross-compilation,
+    // populate paths to the sysroot here.
+    exe.linkFramework("Foundation");
+
+    if (isRunnableTarget(target)) {
+        const run_cmd = exe.run();
+        test_step.dependOn(&run_cmd.step);
+    }
+}

--- a/test/standalone/objcpp/test.mm
+++ b/test/standalone/objcpp/test.mm
@@ -1,0 +1,14 @@
+#import "Foo.h"
+#import <assert.h>
+#include <iostream>
+
+int main(int argc, char *argv[])
+{
+  @autoreleasepool {
+      Foo *foo = [[Foo alloc] init];
+      NSString *result = [foo name];
+      std::cout << "Hello from C++ and " << [result UTF8String];
+      assert([result isEqualToString:@"Zig"]);
+      return 0;
+  }
+}


### PR DESCRIPTION
Prior to this change, calling `step.addCSourceFiles` with Obj-C++ file extensions (`.mm`) would result in an error due to Zig not being aware of that extension. Clang supports an `-ObjC++` compilation mode flag, but it was only possible to use if you violated standards and renamed your `.mm` Obj-C++ files to `.m` (Obj-C) to workaround Zig being unaware of the extension.

This change makes Zig aware of `.mm` files so they can be compiled, enabling compilation of projects such as [Google's Dawn WebGPU implementation](https://dawn.googlesource.com/dawn/) using only a `build.zig` file.

Helps hexops/mach#21

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>