### PR TITLE
stage2: Implement Sema.floatToInt

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9659,7 +9659,7 @@ fn zirFloatToInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
             error.FloatCannotFit => {
                 return sema.fail(block, operand_src, "integer value {d} cannot be stored in type '{}'", .{ std.math.floor(val.toFloat(f64)), dest_ty });
             },
-            else => |e| return e
+            else => |e| return e,
         };
         return sema.addConstant(dest_ty, result_val);
     }
@@ -12459,7 +12459,7 @@ fn coerceNum(
                     error.FloatCannotFit => {
                         return sema.fail(block, inst_src, "integer value {d} cannot be stored in type '{}'", .{ std.math.floor(val.toFloat(f64)), dest_ty });
                     },
-                    else => |e| return e
+                    else => |e| return e,
                 };
                 return try sema.addConstant(dest_ty, result_val);
             },

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9657,7 +9657,7 @@ fn zirFloatToInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
         const target = sema.mod.getTarget();
         const result_val = val.floatToInt(sema.arena, dest_ty, target) catch |err| switch (err) {
             error.FloatCannotFit => {
-                return sema.fail(block, operand_src, "integer value {} cannot be stored in type '{}'", .{ std.math.floor(val.toFloat(f64)), dest_ty });
+                return sema.fail(block, operand_src, "integer value {d} cannot be stored in type '{}'", .{ std.math.floor(val.toFloat(f64)), dest_ty });
             },
             else => |e| return e
         };
@@ -12457,7 +12457,7 @@ fn coerceNum(
                 }
                 const result_val = val.floatToInt(sema.arena, dest_ty, target) catch |err| switch (err) {
                     error.FloatCannotFit => {
-                        return sema.fail(block, inst_src, "integer value {} cannot be stored in type '{}'", .{ std.math.floor(val.toFloat(f64)), dest_ty });
+                        return sema.fail(block, inst_src, "integer value {d} cannot be stored in type '{}'", .{ std.math.floor(val.toFloat(f64)), dest_ty });
                     },
                     else => |e| return e
                 };

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9643,9 +9643,30 @@ fn zirFrameSize(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
 
 fn zirFloatToInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
-    const src = inst_data.src();
-    // TODO don't forget the safety check!
-    return sema.fail(block, src, "TODO: Sema.zirFloatToInt", .{});
+    const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
+    const ty_src: LazySrcLoc = .{ .node_offset_builtin_call_arg0 = inst_data.src_node };
+    const operand_src: LazySrcLoc = .{ .node_offset_builtin_call_arg1 = inst_data.src_node };
+    const dest_ty = try sema.resolveType(block, ty_src, extra.lhs);
+    const operand = sema.resolveInst(extra.rhs);
+    const operand_ty = sema.typeOf(operand);
+
+    _ = try sema.checkIntType(block, ty_src, dest_ty);
+    try sema.checkFloatType(block, operand_src, operand_ty);
+
+    if (try sema.resolveMaybeUndefVal(block, operand_src, operand)) |val| {
+        const target = sema.mod.getTarget();
+        const result_val = val.floatToInt(sema.arena, dest_ty, target) catch |err| switch (err) {
+            error.FloatCannotFit => {
+                // TODO before commit
+                sema.fail(block, undefined, "integer value {} cannot be stored in type '{}'", .{ std.math.floor(operand_src.toFloat(f64)), dest_ty });
+            },
+            else => |e| return e
+        };
+        return sema.addConstant(dest_ty, result_val);
+    }
+
+    try sema.requireRuntimeBlock(block, operand_src);
+    return block.addTyOp(.float_to_int, dest_ty, operand);
 }
 
 fn zirIntToFloat(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
@@ -12435,7 +12456,13 @@ fn coerceNum(
                 if (val.floatHasFraction()) {
                     return sema.fail(block, inst_src, "fractional component prevents float value {} from coercion to type '{}'", .{ val, dest_ty });
                 }
-                return sema.fail(block, inst_src, "TODO float to int", .{});
+                const result_val = val.floatToInt(sema.arena, dest_ty, target) catch |err| switch (err) {
+                    error.FloatCannotFit => {
+                        sema.fail(block, inst_src, "integer value {} cannot be stored in type '{}'", .{ std.math.floor(val.toFloat(f64)), dest_ty });
+                    },
+                    else => |e| return e
+                };
+                return try sema.addConstant(dest_ty, result_val);
             },
             .Int, .ComptimeInt => {
                 if (!val.intFitsInType(dest_ty, target)) {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9657,8 +9657,7 @@ fn zirFloatToInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
         const target = sema.mod.getTarget();
         const result_val = val.floatToInt(sema.arena, dest_ty, target) catch |err| switch (err) {
             error.FloatCannotFit => {
-                // TODO before commit
-                sema.fail(block, undefined, "integer value {} cannot be stored in type '{}'", .{ std.math.floor(operand_src.toFloat(f64)), dest_ty });
+                return sema.fail(block, operand_src, "integer value {} cannot be stored in type '{}'", .{ std.math.floor(val.toFloat(f64)), dest_ty });
             },
             else => |e| return e
         };
@@ -12458,7 +12457,7 @@ fn coerceNum(
                 }
                 const result_val = val.floatToInt(sema.arena, dest_ty, target) catch |err| switch (err) {
                     error.FloatCannotFit => {
-                        sema.fail(block, inst_src, "integer value {} cannot be stored in type '{}'", .{ std.math.floor(val.toFloat(f64)), dest_ty });
+                        return sema.fail(block, inst_src, "integer value {} cannot be stored in type '{}'", .{ std.math.floor(val.toFloat(f64)), dest_ty });
                     },
                     else => |e| return e
                 };

--- a/src/value.zig
+++ b/src/value.zig
@@ -1929,6 +1929,84 @@ pub const Value = extern union {
         }
     }
 
+    pub fn floatToInt(val: Value, arena: *Allocator, dest_ty: Type, target: Target) error{ FloatCannotFit, OutOfMemory }!Value {
+        _ = arena; _ = dest_ty; _ = target;
+        const Limb = std.math.big.Limb;
+
+        var value = val.toFloat(f64); // TODO: f128 ?
+        var isNegative = std.math.signbit(value);
+
+        if (std.math.isNan(value) or std.math.isInf(value)) {
+            return error.FloatCannotFit;
+        }
+
+        if (value < 0) {
+            value = std.math.fabs(value);
+            isNegative = true;
+        }
+
+        var floored = std.math.floor(value);
+
+        // Convert to rational to avoid problems with the way we convert it to a big int
+        // due to floating point precision
+        var rational = try std.math.big.Rational.init(arena);
+        defer rational.deinit();
+        rational.setFloat(f64, floored) catch |err| switch (err) {
+            error.NonFiniteFloat => unreachable,
+            error.OutOfMemory => return error.OutOfMemory
+        };
+
+        // The maximum value of a Limb, as a Rational.
+        var maxLimb = try std.math.big.Rational.init(arena);
+        defer maxLimb.deinit();
+        try maxLimb.setInt(std.math.maxInt(Limb));
+
+        // Big int representing the maximum value of a limb.
+        var tempLimbs: [1]std.math.big.Limb = undefined;
+        var limbInt = BigIntMutable.init(&tempLimbs, std.math.maxInt(Limb));
+
+        const limbs = try arena.alloc(
+            Limb,
+            calcLimbLenFloat(floored),
+        );
+        errdefer arena.free(limbs);
+
+        var result_bigint = BigIntMutable.init(limbs, 0);
+
+        // Add rational to the big int, in increments of Limb
+        while ((try rational.order(maxLimb)) != .lt) {
+            result_bigint.add(result_bigint.toConst(), limbInt.toConst());
+            try rational.sub(rational, maxLimb);
+        }
+
+        // Add the remaining value (which is guarenteed to be smaller or equals to the max size of a limb)
+        limbInt.set(@floatToInt(Limb, std.math.floor(try rational.toFloat(f32))));
+        //result_bigint.add(result_bigint.toConst(), limbInt.toConst());
+
+        //const maxValue = std.math.powi(2, );
+        const maxInt = (try dest_ty.maxInt(arena, target)).toUnsignedInt();
+        const minInt = (try dest_ty.minInt(arena, target)).toSignedInt();
+
+        std.log.info("{}: max = {d} min = {d}", .{ dest_ty, maxInt, minInt });
+
+        const result_limbs = result_bigint.limbs[0..result_bigint.len];
+        if (isNegative) {
+            return Value.Tag.int_big_negative.create(arena, result_limbs);
+        } else {
+            return Value.Tag.int_big_positive.create(arena, result_limbs);
+        }
+    }
+
+    fn calcLimbLenFloat(scalar: anytype) usize {
+        if (scalar == 0) {
+            return 1;
+        }
+
+        const w_value = std.math.fabs(scalar);
+        return @divFloor(@floatToInt(std.math.big.Limb, std.math.log2(w_value)),
+            @typeInfo(std.math.big.Limb).Int.bits) + 1;
+    }
+
     /// Supports both floats and ints; handles undefined.
     pub fn numberAddWrap(
         lhs: Value,

--- a/src/value.zig
+++ b/src/value.zig
@@ -1942,8 +1942,6 @@ pub const Value = extern union {
 
         const floored = std.math.floor(value);
 
-        // Convert to rational to avoid problems with the way we convert it to a big int
-        // due to floating point precision
         var rational = try std.math.big.Rational.init(arena);
         defer rational.deinit();
         rational.setFloat(f64, floored) catch |err| switch (err) {
@@ -1953,11 +1951,10 @@ pub const Value = extern union {
 
         // The float is reduced in rational.setFloat, so we assert that denominator is equal to one
         const bigOne = std.math.big.int.Const{ .limbs = &.{1}, .positive = true };
-        assert(rational.q.toConst().eqAbs(bigOne)); // asserts denominator is one
+        assert(rational.q.toConst().eqAbs(bigOne));
 
         const result_limbs = try arena.dupe(Limb, rational.p.toConst().limbs);
-        const result =
-            if (isNegative)
+        const result = if (isNegative)
             try Value.Tag.int_big_negative.create(arena, result_limbs)
         else
             try Value.Tag.int_big_positive.create(arena, result_limbs);

--- a/src/value.zig
+++ b/src/value.zig
@@ -1936,7 +1936,7 @@ pub const Value = extern union {
         if (std.math.isNan(value) or std.math.isInf(value)) {
             return error.FloatCannotFit;
         }
-        
+
         const isNegative = std.math.signbit(value);
         value = std.math.fabs(value);
 
@@ -1948,7 +1948,7 @@ pub const Value = extern union {
         defer rational.deinit();
         rational.setFloat(f64, floored) catch |err| switch (err) {
             error.NonFiniteFloat => unreachable,
-            error.OutOfMemory => return error.OutOfMemory
+            error.OutOfMemory => return error.OutOfMemory,
         };
 
         // The float is reduced in rational.setFloat, so we assert that denominator is equal to one
@@ -1956,11 +1956,11 @@ pub const Value = extern union {
         assert(rational.q.toConst().eqAbs(bigOne)); // asserts denominator is one
 
         const result_limbs = try arena.dupe(Limb, rational.p.toConst().limbs);
-        const result = 
+        const result =
             if (isNegative)
-                try Value.Tag.int_big_negative.create(arena, result_limbs)
-            else
-                try Value.Tag.int_big_positive.create(arena, result_limbs);
+            try Value.Tag.int_big_negative.create(arena, result_limbs)
+        else
+            try Value.Tag.int_big_positive.create(arena, result_limbs);
 
         if (result.intFitsInType(dest_ty, target)) {
             return result;
@@ -1975,8 +1975,7 @@ pub const Value = extern union {
         }
 
         const w_value = std.math.fabs(scalar);
-        return @divFloor(@floatToInt(std.math.big.Limb, std.math.log2(w_value)),
-            @typeInfo(std.math.big.Limb).Int.bits) + 1;
+        return @divFloor(@floatToInt(std.math.big.Limb, std.math.log2(w_value)), @typeInfo(std.math.big.Limb).Int.bits) + 1;
     }
 
     /// Supports both floats and ints; handles undefined.

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -107,6 +107,28 @@ test "comptime_int @intToFloat" {
     }
 }
 
+test "@floatToInt" {
+    try testFloatToInts();
+    comptime try testFloatToInts();
+}
+
+fn testFloatToInts() !void {
+    const x = @as(i32, 1e4);
+    try expect(x == 10000);
+    const y = @floatToInt(i32, @as(f32, 1e4));
+    try expect(y == 10000);
+    try expectFloatToInt(f16, 255.1, u8, 255);
+    try expectFloatToInt(f16, 127.2, i8, 127);
+    try expectFloatToInt(f16, -128.2, i8, -128);
+    try expectFloatToInt(f32, 255.1, u8, 255);
+    try expectFloatToInt(f32, 127.2, i8, 127);
+    try expectFloatToInt(f32, -128.2, i8, -128);
+}
+
+fn expectFloatToInt(comptime F: type, f: F, comptime I: type, i: I) !void {
+    try expect(@floatToInt(I, f) == i);
+}
+
 test "implicit cast from [*]T to ?*c_void" {
     var a = [_]u8{ 3, 2, 1 };
     var runtime_zero: usize = 0;

--- a/test/behavior/cast_stage1.zig
+++ b/test/behavior/cast_stage1.zig
@@ -191,29 +191,6 @@ fn testPeerErrorAndArray2(x: u8) anyerror![]const u8 {
     };
 }
 
-test "@floatToInt" {
-    try testFloatToInts();
-    comptime try testFloatToInts();
-}
-
-fn testFloatToInts() !void {
-    const x = @as(i32, 1e4);
-    try expect(x == 10000);
-    const y = @floatToInt(i32, @as(f32, 1e4));
-    try expect(y == 10000);
-    try expectFloatToInt(f16, 255.1, u8, 255);
-    try expectFloatToInt(f16, 127.2, i8, 127);
-    try expectFloatToInt(f16, -128.2, i8, -128);
-    try expectFloatToInt(f32, 255.1, u8, 255);
-    try expectFloatToInt(f32, 127.2, i8, 127);
-    try expectFloatToInt(f32, -128.2, i8, -128);
-    try expectFloatToInt(comptime_int, 1234, i16, 1234);
-}
-
-fn expectFloatToInt(comptime F: type, f: F, comptime I: type, i: I) !void {
-    try expect(@floatToInt(I, f) == i);
-}
-
 test "cast u128 to f128 and back" {
     comptime try testCast128();
     try testCast128();
@@ -638,6 +615,13 @@ test "comptime float casts" {
     const b = @floatToInt(comptime_int, 2);
     try expect(b == 2);
     try expect(@TypeOf(b) == comptime_int);
+
+    try expectFloatToInt(comptime_int, 1234, i16, 1234);
+    try expectFloatToInt(comptime_float, 12.3, comptime_int, 12);
+}
+
+fn expectFloatToInt(comptime F: type, f: F, comptime I: type, i: I) !void {
+    try expect(@floatToInt(I, f) == i);
 }
 
 test "cast from ?[*]T to ??[*]T" {


### PR DESCRIPTION
This is my first attempt to contribute to Sema so I surely got a few things wrong.

As a quick overview of my changes:
- The code in `zirFloatToInt` is made by inspiring a lot from `zirIntToFloat`
- Both `zirFloatToInt` and `coerceNum` will handle the `error.FloatCannotFit` error by printing an error message similar to what stage1 printed.

`Value.floatToInt` is implemented by first checking if its NaN or Infinity (but I found that stage1 didn't check it and accepted compiling `@floatToInt(u64, std.math.inf_f64)`) making the float an absolute number and flooring the float.
Then, all it does is convert the floored float into a `std.math.big.Rational` which will perform necessary computations and reduce it. So that we can just take the `rational.p` field and we have our converted big int.

As an arbitrary milestone, this pull request allows compiling the `std.math.cos` and `std.math.sin` functions (alongside some other math functions) with the LLVM backend and the C backend (with my C backend float support pull request).