### PR TITLE
std: Fix path resolution on Windows

### DIFF
--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -592,6 +592,11 @@ pub fn resolveWindows(allocator: *Allocator, paths: []const []const u8) ![]u8 {
         result_disk_designator = parsed_cwd.disk_designator;
         if (parsed_cwd.kind == WindowsPath.Kind.Drive) {
             result[0] = asciiUpper(result[0]);
+            // Remove the trailing slash if present, eg. if the cwd is a root
+            // directory.
+            if (cwd.len > 0 and cwd[cwd.len - 1] == sep_windows) {
+                result_index -= 1;
+            }
         }
         have_drive_kind = parsed_cwd.kind;
     }

--- a/src/stage1/os.cpp
+++ b/src/stage1/os.cpp
@@ -473,6 +473,11 @@ static Buf os_path_resolve_windows(Buf **paths_ptr, size_t paths_len) {
         result_disk_designator = parsed_cwd.disk_designator;
         if (parsed_cwd.kind == WindowsPathKindDrive) {
             result.ptr[0] = asciiUpper(result.ptr[0]);
+            // Remove the trailing slash if present, eg. if the cwd is a root
+            // directory.
+            if (buf_ends_with_mem(&cwd, "\\", 1)) {
+                result_index -= 1;
+            }
         }
         have_drive_kind = parsed_cwd.kind;
     }


### PR DESCRIPTION
GetCurrentDirectory returns a path with a trailing slash iff the cwd is
a root directory, making the code in `resolveWindows` return an invalid
path with two consecutive slashes.

Closes #10093