### PR TITLE
Windows async networking

### DIFF
--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -973,7 +973,7 @@ pub const Loop = struct {
         while (true) {
             return os.accept(sockfd, addr, addr_size, flags | os.SOCK.NONBLOCK) catch |err| switch (err) {
                 error.WouldBlock => {
-                    if(is_windows) unreachable;
+                    if (is_windows) unreachable;
                     self.waitUntilFdReadable(sockfd);
                     continue;
                 },

--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -973,6 +973,7 @@ pub const Loop = struct {
         while (true) {
             return os.accept(sockfd, addr, addr_size, flags | os.SOCK.NONBLOCK) catch |err| switch (err) {
                 error.WouldBlock => {
+                    if(is_windows) unreachable;
                     self.waitUntilFdReadable(sockfd);
                     continue;
                 },

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1728,6 +1728,16 @@ pub const StreamServer = struct {
 
         const sockfd = try os.socket(address.any.family, sock_flags, proto);
         self.sockfd = sockfd;
+
+        if (std.io.is_async and builtin.os.tag == .windows) {
+            _ = os.windows.CreateIoCompletionPort(
+                sockfd,
+                std.event.Loop.instance.?.os_data.io_port,
+                0,
+                0,
+            ) catch undefined;
+        }
+
         errdefer {
             os.closeSocket(sockfd);
             self.sockfd = null;

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2875,10 +2875,10 @@ pub fn socket(domain: u32, socket_type: u32, protocol: u32) SocketError!socket_t
         // NOTE: windows translates the SOCK.NONBLOCK/SOCK.CLOEXEC flags into
         // windows-analagous operations
         const filtered_sock_type = socket_type & ~@as(u32, SOCK.NONBLOCK | SOCK.CLOEXEC);
-        const flags: u32 = if ((socket_type & SOCK.CLOEXEC) != 0)
-            windows.ws2_32.WSA_FLAG_NO_HANDLE_INHERIT
-        else
-            0;
+        const handleInherit : u32 = if ((socket_type & SOCK.CLOEXEC) != 0) windows.ws2_32.WSA_FLAG_NO_HANDLE_INHERIT else 0;
+        const enableOverlapped : u32 = if ((socket_type & SOCK.NONBLOCK) != 0) windows.ws2_32.WSA_FLAG_OVERLAPPED else 0;
+        const flags: u32 = handleInherit | enableOverlapped;
+        
         const rc = try windows.WSASocketW(
             @bitCast(i32, domain),
             @bitCast(i32, filtered_sock_type),

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2311,6 +2311,15 @@ pub const TransferType = enum(u2) {
     METHOD_NEITHER = 3,
 };
 
+pub const FileType = enum(DWORD) 
+{
+    FILE_TYPE_UNKNOWN = 0x0000,
+    FILE_TYPE_DISK = 0x0001,
+    FILE_TYPE_CHAR = 0x0002,
+    FILE_TYPE_PIPE = 0x0003,
+    FILE_TYPE_REMOTE = 0x8000,
+};
+
 pub const FILE_ANY_ACCESS = 0;
 pub const FILE_READ_ACCESS = 1;
 pub const FILE_WRITE_ACCESS = 2;

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1401,7 +1401,8 @@ pub fn closesocket(s: ws2_32.SOCKET) !void {
 }
 
 pub fn acceptEx(listening_s: ws2_32.SOCKET, accepting_s: ws2_32.SOCKET, name: ?*ws2_32.sockaddr, namelen: ?*ws2_32.socklen_t) ?ws2_32.WinsockError {
-    assert(std.io.is_async);
+    if(!std.io.is_async) unreachable;
+
     _ = namelen;
 
     const loop = std.event.Loop.instance.?;

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1430,7 +1430,7 @@ pub fn acceptEx(listening_s: ws2_32.SOCKET, accepting_s: ws2_32.SOCKET, name: ?*
     var bytesRead: u32 = 0;
 
     loop.beginOneEvent();
-    
+
     suspend {
         if (ws2_32.AcceptEx(
             listening_s,
@@ -1450,8 +1450,7 @@ pub fn acceptEx(listening_s: ws2_32.SOCKET, accepting_s: ws2_32.SOCKET, name: ?*
                     return err;
                 },
             }
-        }
-        else {
+        } else {
             //Completed synchroniously
             resume @frame();
             loop.finishOneEvent();

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -362,6 +362,10 @@ pub fn GetQueuedCompletionStatus(
             .ABANDONED_WAIT_0 => return GetQueuedCompletionStatusResult.Aborted,
             .OPERATION_ABORTED => return GetQueuedCompletionStatusResult.Cancelled,
             .HANDLE_EOF => return GetQueuedCompletionStatusResult.EOF,
+            
+            //Ignore socket errors, they will be handled at frame callsite
+            .NETNAME_DELETED, .CONNECTION_ABORTED => {},
+
             else => |err| {
                 if (std.debug.runtime_safety) {
                     @setEvalBranchQuota(2500);

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -199,9 +199,7 @@ pub extern "kernel32" fn GetFileInformationByHandleEx(
     in_dwBufferSize: DWORD,
 ) callconv(WINAPI) BOOL;
 
-pub extern "kernel32" fn GetFileType(
-    hFile: HANDLE
-) callconv(WINAPI) FileType;
+pub extern "kernel32" fn GetFileType(hFile: HANDLE) callconv(WINAPI) FileType;
 
 pub extern "kernel32" fn GetFinalPathNameByHandleW(
     hFile: HANDLE,

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -56,6 +56,7 @@ const LPOVERLAPPED_COMPLETION_ROUTINE = windows.LPOVERLAPPED_COMPLETION_ROUTINE;
 const UCHAR = windows.UCHAR;
 const FARPROC = windows.FARPROC;
 const INIT_ONCE_FN = windows.INIT_ONCE_FN;
+const FileType = windows.FileType;
 
 pub extern "kernel32" fn AddVectoredExceptionHandler(First: c_ulong, Handler: ?VECTORED_EXCEPTION_HANDLER) callconv(WINAPI) ?*c_void;
 pub extern "kernel32" fn RemoveVectoredExceptionHandler(Handle: HANDLE) callconv(WINAPI) c_ulong;
@@ -198,18 +199,9 @@ pub extern "kernel32" fn GetFileInformationByHandleEx(
     in_dwBufferSize: DWORD,
 ) callconv(WINAPI) BOOL;
 
-const WindowsFDTypes = enum(DWORD) 
-{
-    FILE_TYPE_UNKNOWN = 0x0000,
-    FILE_TYPE_DISK = 0x0001,
-    FILE_TYPE_CHAR = 0x0002,
-    FILE_TYPE_PIPE = 0x0003,
-    FILE_TYPE_REMOTE = 0x8000,
-};
-
 pub extern "kernel32" fn GetFileType(
     hFile: HANDLE
-) callconv(WINAPI) WindowsFDTypes;
+) callconv(WINAPI) FileType;
 
 pub extern "kernel32" fn GetFinalPathNameByHandleW(
     hFile: HANDLE,

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -198,6 +198,19 @@ pub extern "kernel32" fn GetFileInformationByHandleEx(
     in_dwBufferSize: DWORD,
 ) callconv(WINAPI) BOOL;
 
+const WindowsFDTypes = enum(DWORD) 
+{
+    FILE_TYPE_UNKNOWN = 0x0000,
+    FILE_TYPE_DISK = 0x0001,
+    FILE_TYPE_CHAR = 0x0002,
+    FILE_TYPE_PIPE = 0x0003,
+    FILE_TYPE_REMOTE = 0x8000,
+};
+
+pub extern "kernel32" fn GetFileType(
+    hFile: HANDLE
+) callconv(WINAPI) WindowsFDTypes;
+
 pub extern "kernel32" fn GetFinalPathNameByHandleW(
     hFile: HANDLE,
     lpszFilePath: [*]u16,


### PR DESCRIPTION
- **Ignores** unknown errors in windows `GetQueuedCompletionStatus` logic
- Adds `kernel32.GetFileType` function and `FileType` enum, for fd checking
- Adds `WSA_FLAG_OVERLAPPED` to socket if requesting `SOCK.NONBLOCK` in windows
- Adds listening socket to IOCP if `io_mode` is `.evented`
- Fixes windows `WriteFile` and `ReadFile` for sockets, by ignoring `offset` and `SetFilePointerEx` calls if fd is a [pipe device](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfilepointerex#remarks)
- Adds and calls `windows.acceptEx` from `os.accept` if `io_mode` is `.evented`