### PR TITLE
Cmake: Specify LLVM versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,9 +104,9 @@ else()
     set(ZIG_USE_LLVM_CONFIG OFF CACHE BOOL "use llvm-config to find LLVM libraries")
 endif()
 
-find_package(llvm)
-find_package(clang)
-find_package(lld)
+find_package(llvm 13)
+find_package(clang 13)
+find_package(lld 13)
 
 if(ZIG_STATIC_ZLIB)
     list(REMOVE_ITEM LLVM_LIBRARIES "-lz")


### PR DESCRIPTION
Systems with multiple LLVM toolchains installed (e.g. one globally and one in `$HOME/local`) would get confused and fail to compile.  Being explicit about the version required will force CMake to find the right version of LLVM.

Not sure this is the intended way of doing this (I try my best to avoid CMake).