### PR TITLE
Don't invoke linker when just building an object

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -474,6 +474,10 @@ pub const File = struct {
             try fs.cwd().copyFile(cached_pp_file_path, fs.cwd(), full_out_path, .{});
             return;
         }
+
+        if (base.options.output_mode == .Obj)
+            return;
+
         const use_lld = build_options.have_llvm and base.options.use_lld;
         if (use_lld and base.options.output_mode == .Lib and base.options.link_mode == .Static) {
             return base.linkAsArchive(comp);


### PR DESCRIPTION
This is an attempt to address #8940, before this patch if you try to make a BPF object you get the following error:
```
ld.lld: error: internal linker error: cannot read addend for relocation R_BPF_64_NODYLD32
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.


ld.lld: error: probe:(.debug_info+0x6): relocation R_BPF_64_ABS32 out of range: 276824064 is not in [-524288, 524287]; consider recompiling with -fdebug-types-section to reduce size of debug sections
ld.lld: error: /home/mknight/code/zig-bpf-intro/zig-cache/o/5b6131127baab3cca09863748393a523/probe.o:(.debug_str): offset is outside the section
```
And now it's working as expected. In the past LLD was just crashing and I think we're getting more information due to improvements that came with llvm13. I think the specifics of this linking error is a red herring because we shouldn't be invoking the linker at all.

I've made this change apply to all linking formats but I'm not sure if that's correct.