### PR TITLE
std: ppoll: cast number of fds to nfds_t

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -5823,7 +5823,8 @@ pub fn ppoll(fds: []pollfd, timeout: ?*const timespec, mask: ?*const sigset_t) P
         ts_ptr = &ts;
         ts = timeout_ns.*;
     }
-    const rc = system.ppoll(fds.ptr, fds.len, ts_ptr, mask);
+    const fds_count = math.cast(nfds_t, fds.len) catch return error.SystemResources;
+    const rc = system.ppoll(fds.ptr, fds_count, ts_ptr, mask);
     switch (errno(rc)) {
         .SUCCESS => return @intCast(usize, rc),
         .FAULT => unreachable,


### PR DESCRIPTION
On some systems, the type of the length of a slice is different from the `nfds_t` type, so cast the slice length to `nfds_t`. This is already done in poll, so just copy that implementation for ppoll.
