### PR TITLE
cross_target: Fixed targets with vendor for Clang

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -7,6 +7,7 @@ const Version = std.builtin.Version;
 /// was solved.
 pub const Target = struct {
     cpu: Cpu,
+    vendor: ?Vendor = null,
     os: Os,
     abi: Abi,
 
@@ -447,6 +448,24 @@ pub const Target = struct {
     pub const ve = @import("target/ve.zig");
     pub const wasm = @import("target/wasm.zig");
     pub const x86 = @import("target/x86.zig");
+
+    pub const Vendor = enum {
+        unknownvendor, 
+        apple, 
+        pc, 
+        scei,
+        freescale,
+        ibm, 
+        imaginationtechnologies, 
+        mipstechnologies,  
+        nvidia, 
+        csr, 
+        myriad, 
+        amd, 
+        mesa, 
+        suse, 
+        openembedded 
+    };
 
     pub const Abi = enum {
         none,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1705,10 +1705,16 @@ fn buildOutputType(
         }
     };
 
+    const clang_passthrough_mode = switch (arg_mode) {
+        .cc, .cpp, .translate_c => true,
+        else => false,
+    };
+
     const cross_target = try parseCrossTargetOrReportFatalError(arena, .{
         .arch_os_abi = target_arch_os_abi,
         .cpu_features = target_mcpu,
         .dynamic_linker = target_dynamic_linker,
+        .clang_passthrough = clang_passthrough_mode,
     });
 
     const target_info = try detectNativeTargetInfo(gpa, cross_target);
@@ -2104,11 +2110,6 @@ fn buildOutputType(
         const argv = [_][*:0]const u8{ "zig (LLVM option parsing)", "--x86-asm-syntax=intel" };
         @import("codegen/llvm/bindings.zig").ParseCommandLineOptions(argv.len, &argv);
     }
-
-    const clang_passthrough_mode = switch (arg_mode) {
-        .cc, .cpp, .translate_c => true,
-        else => false,
-    };
 
     gimmeMoreOfThoseSweetSweetFileDescriptors();
 


### PR DESCRIPTION
Should be at least a temporary fix for #7360.

Of LemonBoy's options listed in his comment, I picked the second. parse it, but Zig doesn't do anything with it.