### PR TITLE
stage2 x86_64 codegen: don't count return registers as callee-preserved

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -1902,10 +1902,10 @@ fn airCall(self: *Self, inst: Air.Inst.Index) !void {
                     try self.register_manager.getReg(reg, null);
                     try self.genSetReg(arg_ty, reg, arg_mcv);
                 },
-                .stack_offset => {
+                .stack_offset => |off| {
                     // Here we need to emit instructions like this:
                     // mov     qword ptr [rsp + stack_offset], x
-                    return self.fail("TODO implement calling with parameters in memory", .{});
+                    try self.genSetStack(arg_ty, off, arg_mcv);
                 },
                 .ptr_stack_offset => {
                     return self.fail("TODO implement calling with MCValue.ptr_stack_offset arg", .{});

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -264,8 +264,21 @@ pub const Inst = struct {
 
         /// arg debug info
         arg_dbg_info,
-    };
 
+        /// push registers from the callee_preserved_regs
+        /// data is the bitfield of which regs to push 
+        /// for example on x86_64, the callee_preserved_regs are [_]Register{ .rcx, .rsi, .rdi, .r8, .r9, .r10, .r11 };    };
+        /// so to push rcx and r8 one would make data 0b00000000_00000000_00000000_00001001 (the first and fourth bits are set)
+        /// ops is unused
+        push_regs_from_callee_preserved_regs,
+
+        /// pop registers from the callee_preserved_regs
+        /// data is the bitfield of which regs to pop
+        /// for example on x86_64, the callee_preserved_regs are [_]Register{ .rcx, .rsi, .rdi, .r8, .r9, .r10, .r11 };    };
+        /// so to pop rcx and r8 one would make data 0b00000000_00000000_00000000_00001001 (the first and fourth bits are set)
+        /// ops is unused
+        pop_regs_from_callee_preserved_regs,
+    };
     /// The position of an MIR instruction within the `Mir` instructions array.
     pub const Index = u32;
 
@@ -284,6 +297,8 @@ pub const Inst = struct {
         got_entry: u32,
         /// Index into `extra`. Meaning of what can be found there is context-dependent.
         payload: u32,
+        /// A bitfield of which callee_preserved_regs to push
+        regs_to_push_or_pop: u32,
     };
 
     // Make sure we don't accidentally make instructions bigger than expected.

--- a/src/arch/x86_64/bits.zig
+++ b/src/arch/x86_64/bits.zig
@@ -84,15 +84,13 @@ pub const Register = enum(u7) {
     /// Returns the index into `callee_preserved_regs`.
     pub fn allocIndex(self: Register) ?u4 {
         return switch (self) {
-            .rax, .eax, .ax, .al => 0,
-            .rcx, .ecx, .cx, .cl => 1,
-            .rdx, .edx, .dx, .dl => 2,
-            .rsi, .esi, .si  => 3,
-            .rdi, .edi, .di => 4,
-            .r8, .r8d, .r8w, .r8b => 5,
-            .r9, .r9d, .r9w, .r9b => 6,
-            .r10, .r10d, .r10w, .r10b => 7,
-            .r11, .r11d, .r11w, .r11b => 8,
+            .rcx, .ecx, .cx, .cl => 0,
+            .rsi, .esi, .si  => 1,
+            .rdi, .edi, .di => 2,
+            .r8, .r8d, .r8w, .r8b => 3,
+            .r9, .r9d, .r9w, .r9b => 4,
+            .r10, .r10d, .r10w, .r10b => 5,
+            .r11, .r11d, .r11w, .r11b => 6,
             else => null,
         };
     }
@@ -145,7 +143,8 @@ pub const Register = enum(u7) {
 // zig fmt: on
 
 /// These registers belong to the called function.
-pub const callee_preserved_regs = [_]Register{ .rax, .rcx, .rdx, .rsi, .rdi, .r8, .r9, .r10, .r11 };
+/// TODO should the return_regs be in this array?
+pub const callee_preserved_regs = [_]Register{ .rcx, .rsi, .rdi, .r8, .r9, .r10, .r11 };
 pub const c_abi_int_param_regs = [_]Register{ .rdi, .rsi, .rdx, .rcx, .r8, .r9 };
 pub const c_abi_int_return_regs = [_]Register{ .rax, .rdx };
 

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2604,7 +2604,7 @@ fn addDbgInfoType(self: *Elf, ty: Type, dbg_info_buffer: *std.ArrayList(u8)) !vo
                 // DW.AT.name,  DW.FORM.string
                 try dbg_info_buffer.writer().print("{}\x00", .{ty});
             } else {
-                log.err("TODO implement .debug_info for type '{}'", .{ty});
+                log.warn("TODO implement .debug_info for type '{}'", .{ty});
                 try dbg_info_buffer.append(abbrev_pad1);
             }
         },

--- a/test/cases.zig
+++ b/test/cases.zig
@@ -1819,4 +1819,36 @@ pub fn addCases(ctx: *TestContext) !void {
             ":2:28: error: cannot set address space of local variable 'foo'",
         });
     }
+    {
+        var case = ctx.exe("issue 10138: callee preserved regs working", linux_x64);
+        case.addCompareOutput(
+            \\pub fn main() void {
+            \\    const fd = open();
+            \\    _ = write(fd, "a", 1);
+            \\    _ = close(fd);
+            \\}
+            \\
+            \\fn open() usize {
+            \\    return 42;
+            \\}
+            \\
+            \\fn write(fd: usize, a: [*]const u8, len: usize) usize {
+            \\    return syscall4(.WRITE, fd, @ptrToInt(a), len);
+            \\}
+            \\
+            \\fn syscall4(n: enum { WRITE }, a: usize, b: usize, c: usize) usize {
+            \\    _ = n;
+            \\    _ = a;
+            \\    _ = b;
+            \\    _ = c;
+            \\    return 23;
+            \\}
+            \\
+            \\fn close(fd: usize) usize {
+            \\    if (fd != 42)
+            \\        unreachable;
+            \\    return 0;
+            \\}
+        , "");
+    }
 }


### PR DESCRIPTION
Attempts to close https://github.com/ziglang/zig/issues/10138
It fixes the test case in #10138 (now in close fd is 42)