### PR TITLE
stage2 AArch64: fix loading/storing to/from stack

### DIFF
--- a/src/arch/aarch64/Emit.zig
+++ b/src/arch/aarch64/Emit.zig
@@ -42,6 +42,8 @@ branch_forward_origins: std.AutoHashMapUnmanaged(Mir.Inst.Index, std.ArrayListUn
 /// instruction
 code_offset_mapping: std.AutoHashMapUnmanaged(Mir.Inst.Index, usize) = .{},
 
+stack_size: u32,
+
 const InnerError = error{
     OutOfMemory,
     EmitFail,
@@ -102,6 +104,13 @@ pub fn emitMir(
 
             .ldp => try emit.mirLoadStoreRegisterPair(inst),
             .stp => try emit.mirLoadStoreRegisterPair(inst),
+
+            .ldr_stack => try emit.mirLoadStoreStack(inst),
+            .ldrb_stack => try emit.mirLoadStoreStack(inst),
+            .ldrh_stack => try emit.mirLoadStoreStack(inst),
+            .str_stack => try emit.mirLoadStoreStack(inst),
+            .strb_stack => try emit.mirLoadStoreStack(inst),
+            .strh_stack => try emit.mirLoadStoreStack(inst),
 
             .ldr => try emit.mirLoadStoreRegister(inst),
             .ldrb => try emit.mirLoadStoreRegister(inst),
@@ -647,6 +656,79 @@ fn mirLoadStoreRegisterPair(emit: *Emit, inst: Mir.Inst.Index) !void {
             load_store_register_pair.rt2,
             load_store_register_pair.rn,
             load_store_register_pair.offset,
+        )),
+        else => unreachable,
+    }
+}
+
+fn mirLoadStoreStack(emit: *Emit, inst: Mir.Inst.Index) !void {
+    const tag = emit.mir.instructions.items(.tag)[inst];
+    const load_store_stack = emit.mir.instructions.items(.data)[inst].load_store_stack;
+
+    const raw_offset = emit.stack_size - load_store_stack.offset;
+    const offset = switch (tag) {
+        .ldrb_stack, .strb_stack => blk: {
+            if (math.cast(u12, raw_offset)) |imm| {
+                break :blk Instruction.LoadStoreOffset.imm(imm);
+            } else |_| {
+                return emit.fail("TODO load/store stack byte with larger offset", .{});
+            }
+        },
+        .ldrh_stack, .strh_stack => blk: {
+            assert(std.mem.isAlignedGeneric(u32, raw_offset, 2)); // misaligned stack entry
+            if (math.cast(u12, @divExact(raw_offset, 2))) |imm| {
+                break :blk Instruction.LoadStoreOffset.imm(imm);
+            } else |_| {
+                return emit.fail("TODO load/store stack halfword with larger offset", .{});
+            }
+        },
+        .ldr_stack, .str_stack => blk: {
+            const alignment: u32 = switch (load_store_stack.rt.size()) {
+                32 => 4,
+                64 => 8,
+                else => unreachable,
+            };
+
+            assert(std.mem.isAlignedGeneric(u32, raw_offset, alignment)); // misaligned stack entry
+            if (math.cast(u12, @divExact(raw_offset, alignment))) |imm| {
+                break :blk Instruction.LoadStoreOffset.imm(imm);
+            } else |_| {
+                return emit.fail("TODO load/store stack with larger offset", .{});
+            }
+        },
+        else => unreachable,
+    };
+
+    switch (tag) {
+        .ldr_stack => try emit.writeInstruction(Instruction.ldr(
+            load_store_stack.rt,
+            Register.sp,
+            offset,
+        )),
+        .ldrb_stack => try emit.writeInstruction(Instruction.ldrb(
+            load_store_stack.rt,
+            Register.sp,
+            offset,
+        )),
+        .ldrh_stack => try emit.writeInstruction(Instruction.ldrh(
+            load_store_stack.rt,
+            Register.sp,
+            offset,
+        )),
+        .str_stack => try emit.writeInstruction(Instruction.str(
+            load_store_stack.rt,
+            Register.sp,
+            offset,
+        )),
+        .strb_stack => try emit.writeInstruction(Instruction.strb(
+            load_store_stack.rt,
+            Register.sp,
+            offset,
+        )),
+        .strh_stack => try emit.writeInstruction(Instruction.strh(
+            load_store_stack.rt,
+            Register.sp,
+            offset,
         )),
         else => unreachable,
     }

--- a/src/arch/aarch64/Emit.zig
+++ b/src/arch/aarch64/Emit.zig
@@ -587,12 +587,11 @@ fn mirLoadMemory(emit: *Emit, inst: Mir.Inst.Index) !void {
         try emit.writeInstruction(Instruction.adrp(reg, 0));
 
         // ldr reg, reg, offset
-        try emit.writeInstruction(Instruction.ldr(reg, .{
-            .register = .{
-                .rn = reg,
-                .offset = Instruction.LoadStoreOffset.imm(0),
-            },
-        }));
+        try emit.writeInstruction(Instruction.ldr(
+            reg,
+            reg,
+            Instruction.LoadStoreOffset.imm(0),
+        ));
 
         if (emit.bin_file.cast(link.File.MachO)) |macho_file| {
             // TODO I think the reloc might be in the wrong place.
@@ -626,7 +625,8 @@ fn mirLoadMemory(emit: *Emit, inst: Mir.Inst.Index) !void {
         try emit.moveImmediate(reg, addr);
         try emit.writeInstruction(Instruction.ldr(
             reg,
-            .{ .register = .{ .rn = reg, .offset = Instruction.LoadStoreOffset.none } },
+            reg,
+            Instruction.LoadStoreOffset.none,
         ));
     }
 }
@@ -659,32 +659,33 @@ fn mirLoadStoreRegister(emit: *Emit, inst: Mir.Inst.Index) !void {
     switch (tag) {
         .ldr => try emit.writeInstruction(Instruction.ldr(
             load_store_register.rt,
-            .{ .register = .{ .rn = load_store_register.rn, .offset = load_store_register.offset } },
+            load_store_register.rn,
+            load_store_register.offset,
         )),
         .ldrb => try emit.writeInstruction(Instruction.ldrb(
             load_store_register.rt,
             load_store_register.rn,
-            .{ .offset = load_store_register.offset },
+            load_store_register.offset,
         )),
         .ldrh => try emit.writeInstruction(Instruction.ldrh(
             load_store_register.rt,
             load_store_register.rn,
-            .{ .offset = load_store_register.offset },
+            load_store_register.offset,
         )),
         .str => try emit.writeInstruction(Instruction.str(
             load_store_register.rt,
             load_store_register.rn,
-            .{ .offset = load_store_register.offset },
+            load_store_register.offset,
         )),
         .strb => try emit.writeInstruction(Instruction.strb(
             load_store_register.rt,
             load_store_register.rn,
-            .{ .offset = load_store_register.offset },
+            load_store_register.offset,
         )),
         .strh => try emit.writeInstruction(Instruction.strh(
             load_store_register.rt,
             load_store_register.rn,
-            .{ .offset = load_store_register.offset },
+            load_store_register.offset,
         )),
         else => unreachable,
     }

--- a/src/arch/aarch64/Mir.zig
+++ b/src/arch/aarch64/Mir.zig
@@ -56,12 +56,18 @@ pub const Inst = struct {
         load_memory,
         /// Load Pair of Registers
         ldp,
+        /// Pseudo-instruction: Load from stack
+        ldr_stack,
         /// Load Register
         // TODO: split into ldr_immediate and ldr_register
         ldr,
+        /// Pseudo-instruction: Load byte from stack
+        ldrb_stack,
         /// Load Register Byte
         // TODO: split into ldrb_immediate and ldrb_register
         ldrb,
+        /// Pseudo-instruction: Load halfword from stack
+        ldrh_stack,
         /// Load Register Halfword
         // TODO: split into ldrh_immediate and ldrh_register
         ldrh,
@@ -79,12 +85,18 @@ pub const Inst = struct {
         ret,
         /// Store Pair of Registers
         stp,
+        /// Pseudo-instruction: Store to stack
+        str_stack,
         /// Store Register
         // TODO: split into str_immediate and str_register
         str,
+        /// Pseudo-instruction: Store byte to stack
+        strb_stack,
         /// Store Register Byte
         // TODO: split into strb_immediate and strb_register
         strb,
+        /// Pseudo-instruction: Store halfword to stack
+        strh_stack,
         /// Store Register Halfword
         // TODO: split into strh_immediate and strh_register
         strh,
@@ -175,13 +187,20 @@ pub const Inst = struct {
             rm: Register,
             cond: bits.Instruction.Condition,
         },
-        /// Three registers and a LoadStoreOffset
+        /// Two registers and a LoadStoreOffset
         ///
         /// Used by e.g. str_register
         load_store_register: struct {
             rt: Register,
             rn: Register,
             offset: bits.Instruction.LoadStoreOffset,
+        },
+        /// A registers and a stack offset
+        ///
+        /// Used by e.g. str_register
+        load_store_stack: struct {
+            rt: Register,
+            offset: u32,
         },
         /// Three registers and a LoadStorePairOffset
         ///

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2041,12 +2041,11 @@ fn createStubHelperPreambleAtom(self: *MachO) !void {
                 .@"type" = @enumToInt(macho.reloc_type_arm64.ARM64_RELOC_GOT_LOAD_PAGE21),
             });
             // ldr x16, [x16, 0]
-            mem.writeIntLittle(u32, atom.code.items[16..][0..4], aarch64.Instruction.ldr(.x16, .{
-                .register = .{
-                    .rn = .x16,
-                    .offset = aarch64.Instruction.LoadStoreOffset.imm(0),
-                },
-            }).toU32());
+            mem.writeIntLittle(u32, atom.code.items[16..][0..4], aarch64.Instruction.ldr(
+                .x16,
+                .x16,
+                aarch64.Instruction.LoadStoreOffset.imm(0),
+            ).toU32());
             atom.relocs.appendAssumeCapacity(.{
                 .offset = 16,
                 .target = .{ .global = self.undefs.items[self.dyld_stub_binder_index.?].n_strx },
@@ -2119,9 +2118,10 @@ pub fn createStubHelperAtom(self: *MachO) !*Atom {
                 break :blk try math.cast(u18, div_res);
             };
             // ldr w16, literal
-            mem.writeIntLittle(u32, atom.code.items[0..4], aarch64.Instruction.ldr(.w16, .{
-                .literal = literal,
-            }).toU32());
+            mem.writeIntLittle(u32, atom.code.items[0..4], aarch64.Instruction.ldrLiteral(
+                .w16,
+                literal,
+            ).toU32());
             // b disp
             mem.writeIntLittle(u32, atom.code.items[4..8], aarch64.Instruction.b(0).toU32());
             atom.relocs.appendAssumeCapacity(.{
@@ -2222,12 +2222,11 @@ pub fn createStubAtom(self: *MachO, laptr_sym_index: u32) !*Atom {
                 .@"type" = @enumToInt(macho.reloc_type_arm64.ARM64_RELOC_PAGE21),
             });
             // ldr x16, x16, offset
-            mem.writeIntLittle(u32, atom.code.items[4..8], aarch64.Instruction.ldr(.x16, .{
-                .register = .{
-                    .rn = .x16,
-                    .offset = aarch64.Instruction.LoadStoreOffset.imm(0),
-                },
-            }).toU32());
+            mem.writeIntLittle(u32, atom.code.items[4..8], aarch64.Instruction.ldr(
+                .x16,
+                .x16,
+                aarch64.Instruction.LoadStoreOffset.imm(0),
+            ).toU32());
             atom.relocs.appendAssumeCapacity(.{
                 .offset = 4,
                 .target = .{ .local = laptr_sym_index },


### PR DESCRIPTION
Previously, `genSetReg` and `genSetStack` used the post-index variant of `ldr` and `str` instructions (and all their variants). This was incorrect as the offset is applied to the address after loading. Instead, this PR introduces new pseudo-instructions for loading from an offset from `sp`, not `fp`. That way, the unsigned immediate variant of `ldr`/`str` can be used for correct loading and storing to/from the stack.

cc @kubkon 