### PR TITLE
Normalized C++ compilation options for single-threaded targets

### DIFF
--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -1,6 +1,7 @@
 const std = @import("../std.zig");
 const builtin = @import("builtin");
 const build = std.build;
+const CrossTarget = std.zig.CrossTarget;
 const Step = build.Step;
 const Builder = build.Builder;
 const LibExeObjStep = build.LibExeObjStep;
@@ -142,6 +143,23 @@ pub fn expectStdErrEqual(self: *RunStep, bytes: []const u8) void {
     self.stderr_action = .{ .expect_exact = self.builder.dupe(bytes) };
 }
 
+/// Returns true if the step could be run, otherwise false
+pub fn isRunnable(
+    self: *RunStep,
+) bool {
+    for (self.argv.items) |arg| {
+        switch (arg) {
+            .artifact => |artifact| {
+                _ = self.getExternalExecutor(artifact) catch {
+                    return false;
+                };
+            },
+            else => {},
+        }
+    }
+    return true;
+}
+
 pub fn expectStdOutEqual(self: *RunStep, bytes: []const u8) void {
     self.stdout_action = .{ .expect_exact = self.builder.dupe(bytes) };
 }
@@ -152,6 +170,57 @@ fn stdIoActionToBehavior(action: StdIoAction) std.ChildProcess.StdIo {
         .inherit => .Inherit,
         .expect_exact, .expect_matches => .Pipe,
     };
+}
+
+fn getExternalExecutor(self: *RunStep, artifact: *LibExeObjStep) !?[]const u8 {
+    const need_cross_glibc = artifact.target.isGnuLibC() and artifact.is_linking_libc;
+    const executor = self.builder.host.getExternalExecutor(artifact.target_info, .{
+        .qemu_fixes_dl = need_cross_glibc and self.builder.glibc_runtimes_dir != null,
+        .link_libc = artifact.is_linking_libc,
+    });
+    switch (executor) {
+        .bad_dl, .bad_os_or_cpu => {
+            return error.NoExecutable;
+        },
+        .native => {
+            return null;
+        },
+        .rosetta => {
+            if (self.builder.enable_rosetta) {
+                return null;
+            } else {
+                return error.RosettaNotEnabled;
+            }
+        },
+        .qemu => |bin_name| {
+            if (self.builder.enable_qemu) {
+                return bin_name;
+            } else {
+                return error.QemuNotEnabled;
+            }
+        },
+        .wine => |bin_name| {
+            if (self.builder.enable_wine) {
+                return bin_name;
+            } else {
+                return error.WineNotEnabled;
+            }
+        },
+        .wasmtime => |bin_name| {
+            if (self.builder.enable_wasmtime) {
+                return bin_name;
+            } else {
+                return error.WasmtimeNotEnabled;
+            }
+        },
+        .darling => |bin_name| {
+            if (self.builder.enable_darling) {
+                return bin_name;
+            } else {
+                return error.DarlingNotEnabled;
+            }
+        },
+    }
 }
 
 fn make(step: *Step) !void {
@@ -168,6 +237,9 @@ fn make(step: *Step) !void {
                 if (artifact.target.isWindows()) {
                     // On Windows we don't have rpaths so we have to add .dll search paths to PATH
                     self.addPathForDynLibs(artifact);
+                }
+                if (try self.getExternalExecutor(artifact)) |executor| {
+                    try argv_list.append(executor);
                 }
                 const executable_path = artifact.installed_path orelse artifact.getOutputSource().getPath(self.builder);
                 try argv_list.append(executable_path);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3815,7 +3815,7 @@ pub fn addCCArgs(
 
         if (comp.bin_file.options.single_threaded) {
             try argv.append("-D_LIBCPP_HAS_NO_THREADS");
-        } else {}
+        }
     }
 
     if (comp.bin_file.options.link_libunwind) {

--- a/test/standalone/c_compiler/build.zig
+++ b/test/standalone/c_compiler/build.zig
@@ -1,19 +1,20 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const Builder = std.build.Builder;
 const CrossTarget = std.zig.CrossTarget;
-
-// TODO integrate this with the std.build executor API
-fn isRunnableTarget(t: CrossTarget) bool {
-    if (t.isNative()) return true;
-
-    return (t.getOsTag() == builtin.os.tag and
-        t.getCpuArch() == builtin.cpu.arch);
-}
 
 pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
+
+    const is_wine_enabled = b.option(bool, "enable-wine", "Use Wine to run cross compiled Windows tests") orelse false;
+    const is_qemu_enabled = b.option(bool, "enable-qemu", "Use QEMU to run cross compiled foreign architecture tests") orelse false;
+    const is_wasmtime_enabled = b.option(bool, "enable-wasmtime", "Use Wasmtime to enable and run WASI libstd tests") orelse false;
+    const is_darling_enabled = b.option(bool, "enable-darling", "[Experimental] Use Darling to run cross compiled macOS tests") orelse false;
+    const single_threaded = b.option(bool, "single-threaded", "Test single threaded mode") orelse false;
+    b.enable_wine = is_wine_enabled;
+    b.enable_qemu = is_qemu_enabled;
+    b.enable_wasmtime = is_wasmtime_enabled;
+    b.enable_darling = is_darling_enabled;
 
     const test_step = b.step("test", "Test the program");
 
@@ -29,9 +30,16 @@ pub fn build(b: *Builder) void {
     exe_cpp.addCSourceFile("test.cpp", &[0][]const u8{});
     exe_cpp.setBuildMode(mode);
     exe_cpp.setTarget(target);
-    exe_cpp.linkSystemLibrary("c++");
+    exe_cpp.linkLibCpp();
+    exe_cpp.single_threaded = single_threaded;
+    const os_tag = target.getOsTag();
+    // macos C++ exceptions could be compiled, but not being catched,
+    // additional support is required, possibly unwind + DWARF CFI
+    if (target.getCpuArch().isWasm() or os_tag == .macos) {
+        exe_cpp.defineCMacro("_LIBCPP_NO_EXCEPTIONS", null);
+    }
 
-    switch (target.getOsTag()) {
+    switch (os_tag) {
         .windows => {
             // https://github.com/ziglang/zig/issues/8531
             exe_cpp.want_lto = false;
@@ -44,13 +52,17 @@ pub fn build(b: *Builder) void {
         else => {},
     }
 
-    if (isRunnableTarget(target)) {
-        const run_c_cmd = exe_c.run();
+    const run_c_cmd = exe_c.run();
+    if (run_c_cmd.isRunnable()) {
         test_step.dependOn(&run_c_cmd.step);
-        const run_cpp_cmd = exe_cpp.run();
-        test_step.dependOn(&run_cpp_cmd.step);
     } else {
         test_step.dependOn(&exe_c.step);
+    }
+
+    const run_cpp_cmd = exe_cpp.run();
+    if (run_cpp_cmd.isRunnable()) {
+        test_step.dependOn(&run_cpp_cmd.step);
+    } else {
         test_step.dependOn(&exe_cpp.step);
     }
 }

--- a/test/standalone/c_compiler/test.c
+++ b/test/standalone/c_compiler/test.c
@@ -1,25 +1,28 @@
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-typedef struct  {
-    int val;
+typedef struct {
+  int val;
 } STest;
 
 int getVal(STest* data) { return data->val; }
 
 int main (int argc, char *argv[])
 {
-	STest* data = (STest*)malloc(sizeof(STest));
-    data->val = 123;
+  STest* data = (STest*)malloc(sizeof(STest));
+  data->val = 123;
 
-    assert(getVal(data) != 456);
-    int ok = (getVal(data) == 123);
+  assert(getVal(data) != 456);
+  int ok = (getVal(data) == 123);
 
-    if (argc>1) fprintf(stdout, "val=%d\n", data->val);
+  if (argc > 1) {
+    fprintf(stdout, "val=%d\n", data->val);
+  }
 
-    free(data);
+  free(data);
 
-    if (!ok) abort();
+  if (!ok) abort();
 
-	return 0;
+  return EXIT_SUCCESS;
 }

--- a/test/standalone/c_compiler/test.cpp
+++ b/test/standalone/c_compiler/test.cpp
@@ -1,15 +1,33 @@
-#include <iostream>
 #include <cassert>
+#include <iostream>
+
+#ifndef _LIBCPP_HAS_NO_THREADS
+#include <future>
+#endif
+
+thread_local unsigned int tls_counter = 1;
+
+// a non-optimized way of checking for prime numbers:
+bool is_prime(int x) {
+  for (int i = 2; i <x ; ++i) {
+    if (x % i == 0) {
+      return false;
+    }
+  }
+  return true;
+}
 
 class CTest {
 public:
-	CTest(int val) : m_val(val) {};
-	virtual ~CTest() {}
+  CTest(int val) : m_val(val) {
+    tls_counter++;
+  };
+  virtual ~CTest() {}
 
-	virtual int getVal() const { return m_val; }
-	virtual void printVal() { std::cout << "val=" << m_val << std::endl; }
+  virtual int getVal() const { return m_val; }
+  virtual void printVal() { std::cout << "val=" << m_val << std::endl; }
 private:
-	int m_val;
+  int m_val;
 };
 
 
@@ -18,16 +36,30 @@ CTest global(runtime_val);	// test if global initializers are called.
 
 int main (int argc, char *argv[])
 {
-	assert(global.getVal() == 456);
+  assert(global.getVal() == 456);
+  auto t = std::make_unique<CTest>(123);
+  assert(t->getVal() != 456);
+  assert(tls_counter == 2);
+  if (argc > 1) {
+    t->printVal();
+  }
+  bool ok = t->getVal() == 123;
 
-	auto* t = new CTest(123);
-	assert(t->getVal()!=456);
+  if (!ok) abort();
 
-	if (argc>1) t->printVal();
-	bool ok = t->getVal() == 123;
-	delete t;
+#ifndef _LIBCPP_HAS_NO_THREADS
+  std::future<bool> fut = std::async(is_prime, 313);
+  bool ret = fut.get();
+  assert(ret);
+#endif
 
-	if (!ok) abort();
+#ifndef _LIBCPP_NO_EXCEPTIONS
+  try {
+    throw 20;
+  } catch (int e) {
+    assert(e == 20);
+  }
+#endif
 
-	return 0;
+  return EXIT_SUCCESS;
 }

--- a/test/standalone/c_compiler/test.cpp
+++ b/test/standalone/c_compiler/test.cpp
@@ -30,13 +30,25 @@ private:
   int m_val;
 };
 
+class GlobalConstructorTest {
+public:
+  GlobalConstructorTest(int val) : m_val(val) {};
+  virtual ~GlobalConstructorTest() {}
+
+  virtual int getVal() const { return m_val; }
+  virtual void printVal() { std::cout << "val=" << m_val << std::endl; }
+private:
+  int m_val;
+};
+
 
 volatile int runtime_val = 456;
-CTest global(runtime_val);	// test if global initializers are called.
+GlobalConstructorTest global(runtime_val);	// test if global initializers are called.
 
 int main (int argc, char *argv[])
 {
   assert(global.getVal() == 456);
+
   auto t = std::make_unique<CTest>(123);
   assert(t->getVal() != 456);
   assert(tls_counter == 2);
@@ -53,7 +65,9 @@ int main (int argc, char *argv[])
   assert(ret);
 #endif
 
-#ifndef _LIBCPP_NO_EXCEPTIONS
+#if !defined(__wasm__) && !defined(__APPLE__)
+  // WASM and macOS are not passing this yet.
+  // TODO file an issue for this and link it here.
   try {
     throw 20;
   } catch (int e) {


### PR DESCRIPTION
The PR contains two major changes:

1. C++ is compiled without threading support for single-threaded targets (was already partially implemented for WASM, now it's applied to all single-threaded targets).
2. RunStep has been extended to run artifacts with the external executors if enabled.

The reason for (1) is that the current functionality is a little bit confusing as C++ standard library is compiled with the threading support even if an artifact is explicitly flagged to use the single-threaded mode. I've discovered that during dealing with #6573. The original LLVM commit referenced there is being abandoned, and the only way to use C++ for ARM in Zig is using modified standard library, hence this PR.

There are few reason for (2), but none of them are critical, therefore the change could be dropped:

- `.enable_qemu` and similar flags could be applied to the executable, but the corresponding RunStep if invoked would give the `IncorrectExe` error. It's not immediately obvious that the RunStep is applicable for native targets only, and `.enable_qemu` is no-op for executables, but for tests only. In theory, those flags should be applied to tests and run steps only, but it's out of scope of this PR.
- some tests involve running the actual executables, e.g. the integration tests like the `c_compiler` modified in this PR. It's handy to have this ability out-of-box.
- some build processes require cross-platform runs. One particular example here is one of my project that has the pure Zig build process for LuaJIT: `buildvm` should be invoked on the target platform (please see https://github.com/LuaJIT/LuaJIT/issues/664 for the reference). I could successfully compile and use LuaJIT on ARM, but need to use the external executor for `buildvm`. The first commit uses `ExecutorRunStep` that is partially taken from the project.

Testing done by:
 - running the full test suite: `zig build test`
 - running the `c_compiler` test with 3 targets (x86_64 Linux host, arm-linux-musleabi, wasm32-wasi):

```sh
cd test/standalone/c_compiler
zig build test
zig build test -Dtarget=arm-linux-musleabi -Denable-qemu -Dsingle-threaded
zig build test -Dtarget=wasm32-wasi -Denable-wasmtime -Dsingle-threaded
zig build test -Dtarget=x86_64-windows-gnu -Denable-wine
zig build test -Dtarget=x86_64-windows-gnu -Denable-wine -Dsingle-threaded
zig build test -Dtarget=x86_64-macos-gnu -Denable-darling
zig build test -Dtarget=x86_64-macos-gnu -Denable-darling -Dsingle-threaded
```

Additional notes:

- for WASM target the `-fno-exceptions` flag is applied to C++ standard library only, not the final executables. If could be addressed in this or another PR if you want;
- macos doesn't properly support C++ exceptions, additional work is required (probably libunwind and DWARF CFI should be added), and for now I've just disabled testing it; 
- `_LIBCPP_HAS_NO_THREADS` is added for `buildLibCXXABI`  for single-threaded targets too as it uses C++ standard library;
- `test.c/test.cpp` code have mixed spaces/tabs, I've restyled the code for the consistency;
- RunStep.getExternalExecutor is a little bit verbose, but I anticipate that other changes could be required so left it as is for now
