### PR TITLE
CBE: pass math.zig and popcount.zig

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1145,9 +1145,9 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             // that wrapping is UB.
             .div_float, .div_exact, => try airBinOp( f, inst, " / "),
             .div_trunc => try airDivTrunc(f, inst),
-            .div_floor                         => try airBinOp( f, inst, " divfloor "),
-            .rem           => try airBinOp( f, inst, " % "),
-            .mod           => try airBinOp( f, inst, " mod "), // TODO implement modulus division
+            .div_floor => try airDivFloor(f, inst),
+            .rem => try airBinOp( f, inst, " % "),
+            .mod => try airBinOp( f, inst, " mod "), // TODO implement modulus division
 
             .addwrap => try airWrapOp(f, inst, " + ", "addw_"),
             .subwrap => try airWrapOp(f, inst, " - ", "subw_"),
@@ -1961,6 +1961,70 @@ fn airDivTrunc(f: *Function, inst: Air.Inst.Index) !CValue {
             const bin_op = f.air.instructions.items(.data)[inst].bin_op;
             const lhs = try f.resolveInst(bin_op.lhs);
             const rhs = try f.resolveInst(bin_op.rhs);
+            const local = try f.allocLocal(inst_ty, .Const);
+            try writer.print(" = {s}(", .{trunc_func});
+            try f.writeCValue(writer, lhs);
+            try writer.writeAll(" / ");
+            try f.writeCValue(writer, rhs);
+            try writer.writeAll(");\n");
+            return local;
+        },
+        else => unreachable,
+    }
+}
+
+fn airDivFloor(f: *Function, inst: Air.Inst.Index) !CValue {
+    if (f.liveness.isUnused(inst))
+        return CValue.none;
+
+    const writer = f.object.writer();
+    const bin_op = f.air.instructions.items(.data)[inst].bin_op;
+    const lhs = try f.resolveInst(bin_op.lhs);
+    const rhs = try f.resolveInst(bin_op.rhs);
+    const inst_ty = f.air.typeOfIndex(inst);
+
+    switch (inst_ty.zigTypeTag()) {
+        .Int => {
+            const intInfo = inst_ty.intInfo(f.object.dg.module.getTarget());
+            const c_bits = toCIntBits(intInfo.bits) orelse
+                return f.object.dg.fail("TODO: C backend: implement integer types larger than 128 bits", .{});
+            const size_prefix = switch (c_bits) {
+                1 => "8",
+                8 => "8",
+                16 => "16",
+                32 => "32",
+                64 => "64",
+                128 => "128",
+                else => unreachable,
+            };
+
+            const local = try f.allocLocal(inst_ty, .Const);
+            if (intInfo.signedness == .unsigned) {
+                try writer.writeAll(" = ");
+                try f.writeCValue(writer, lhs);
+                try writer.writeAll(" / ");
+                try f.writeCValue(writer, rhs);
+                try writer.writeAll(";\n");
+            } else {
+                try writer.print(" = zig_divfloor_s{s}(", .{size_prefix});
+                try f.writeCValue(writer, lhs);
+                try writer.writeAll(", ");
+                try f.writeCValue(writer, rhs);
+                try writer.writeAll(");\n");
+            }
+            return local;
+        },
+        .Float => {
+            const float_bits = inst_ty.floatBits(f.object.dg.module.getTarget());
+            if (float_bits == 16 or float_bits == 128) {
+                return f.object.dg.fail("TODO: implement divTrunc for f16 and f128", .{});
+            }
+            const trunc_func = switch (float_bits) {
+                32 => "floorf",
+                64 => "floor",
+                else => unreachable,
+            };
+
             const local = try f.allocLocal(inst_ty, .Const);
             try writer.print(" = {s}(", .{trunc_func});
             try f.writeCValue(writer, lhs);

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1225,7 +1225,7 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .get_union_tag    => try airGetUnionTag(f, inst),
             .clz              => try airBuiltinCall(f, inst, "zig_clz"),
             .ctz              => try airBuiltinCall(f, inst, "ctz"),
-            .popcount         => try airBuiltinCall(f, inst, "popcount"),
+            .popcount         => try airBuiltinCall(f, inst, "zig_popcount"),
 
             .int_to_float,
             .float_to_int,

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -127,6 +127,8 @@
 #define int128_t __int128
 #define uint128_t unsigned __int128
 
+ZIG_EXTERN_C float floorf (float arg);
+ZIG_EXTERN_C double floor (double arg);
 ZIG_EXTERN_C void *memcpy (void *ZIG_RESTRICT, const void *ZIG_RESTRICT, size_t);
 ZIG_EXTERN_C void *memset (void *, int, size_t);
 ZIG_EXTERN_C float truncf (float arg);
@@ -489,3 +491,25 @@ zig_clz(u64, uint64_t, 64)
 zig_clz(s64, int64_t, 64)
 zig_clz(u128, uint128_t, 128)
 zig_clz(s128, int128_t, 128)
+
+#define zig_divfloor_s(bits, T) \
+    static inline T zig_divfloor_s##bits(T a, T b) { \
+        /* if (b == 0) error */ \
+        T div = a/b; \
+        if ((a >= 0 && b > 0) || (a <= 0 && b < 0)) { \
+            return div;  \
+        } else { \
+            T remainder = a % b; \
+            if (remainder % b != 0) { \
+                return div - 1; \
+            } else { \
+                return div; \
+            } \
+        } \
+    }
+
+zig_divfloor_s(8, int8_t)
+zig_divfloor_s(16, int16_t)
+zig_divfloor_s(32, int32_t)
+zig_divfloor_s(64, int64_t)
+zig_divfloor_s(128, int128_t)

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -535,3 +535,20 @@ zig_divfloor_s(16, int16_t)
 zig_divfloor_s(32, int32_t)
 zig_divfloor_s(64, int64_t)
 zig_divfloor_s(128, int128_t)
+
+#define zig_mod_s(bits, T) \
+    static inline T zig_mod_s##bits(T a, T b) { \
+        if ((a >= 0 && b > 0) || (a <= 0 && b < 0)) { \
+            return a % b;  \
+        } else { \
+            T floored_div = zig_divfloor_s##bits(a, b); \
+            T trunc_div = a / b; \
+            return (a%b) - (floored_div-trunc_div)*b; \
+        } \
+    }
+
+zig_mod_s(8, int8_t)
+zig_mod_s(16, int16_t)
+zig_mod_s(32, int32_t)
+zig_mod_s(64, int64_t)
+zig_mod_s(128, int128_t)

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -126,8 +126,11 @@
 
 #define int128_t __int128
 #define uint128_t unsigned __int128
+
 ZIG_EXTERN_C void *memcpy (void *ZIG_RESTRICT, const void *ZIG_RESTRICT, size_t);
 ZIG_EXTERN_C void *memset (void *, int, size_t);
+ZIG_EXTERN_C float truncf (float arg);
+ZIG_EXTERN_C double trunc (double arg);
 
 static inline uint8_t zig_addw_u8(uint8_t lhs, uint8_t rhs, uint8_t max) {
     uint8_t thresh = max - rhs;

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -492,6 +492,28 @@ zig_clz(s64, int64_t, 64)
 zig_clz(u128, uint128_t, 128)
 zig_clz(s128, int128_t, 128)
 
+#define zig_popcount(ZT, T, bits) \
+    static inline uint8_t zig_popcount_##ZT(T x) { \
+        uint8_t count = 0; \
+        for (uint8_t i = bits; i > 0; i--) { \
+            if ((x >> (i-1)) & 1) { \
+                count++; \
+            } \
+        }  \
+        return count; \
+    }
+
+zig_popcount(u8, uint8_t, 8)
+zig_popcount(s8, int8_t, 8)
+zig_popcount(u16, uint16_t, 16)
+zig_popcount(s16, int16_t, 16)
+zig_popcount(u32, uint32_t, 32)
+zig_popcount(s32, int32_t, 32)
+zig_popcount(u64, uint64_t, 64)
+zig_popcount(s64, int64_t, 64)
+zig_popcount(u128, uint128_t, 128)
+zig_popcount(s128, int128_t, 128)
+
 #define zig_divfloor_s(bits, T) \
     static inline T zig_divfloor_s##bits(T a, T b) { \
         /* if (b == 0) error */ \

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -374,6 +374,52 @@ static inline float zig_bitcast_f64_u64(uint64_t arg) {
     return dest;
 }
 
+#define zig_clz(ZT, T, bits) \
+    static inline uint8_t zig_clz_##ZT(T x) { \
+        uint8_t count = 0; \
+        for (uint8_t i = bits; i > 0; i--) { \
+            if ((x >> (i-1)) & 1) { \
+                break; \
+            } \
+            count++; \
+        }  \
+        return count; \
+    }
+
+zig_clz(u8, uint8_t, 8)
+zig_clz(s8, int8_t, 8)
+zig_clz(u16, uint16_t, 16)
+zig_clz(s16, int16_t, 16)
+zig_clz(u32, uint32_t, 32)
+zig_clz(s32, int32_t, 32)
+zig_clz(u64, uint64_t, 64)
+zig_clz(s64, int64_t, 64)
+zig_clz(u128, uint128_t, 128)
+zig_clz(s128, int128_t, 128)
+zig_clz(ll, unsigned long long, sizeof(unsigned long long) * CHAR_BIT);
+
+#define zig_popcount(ZT, T, bits) \
+    static inline uint8_t zig_popcount_##ZT(T x) { \
+        uint8_t count = 0; \
+        for (uint8_t i = bits; i > 0; i--) { \
+            if ((x >> (i-1)) & 1) { \
+                count++; \
+            } \
+        }  \
+        return count; \
+    }
+
+zig_popcount(u8, uint8_t, 8)
+zig_popcount(s8, int8_t, 8)
+zig_popcount(u16, uint16_t, 16)
+zig_popcount(s16, int16_t, 16)
+zig_popcount(u32, uint32_t, 32)
+zig_popcount(s32, int32_t, 32)
+zig_popcount(u64, uint64_t, 64)
+zig_popcount(s64, int64_t, 64)
+zig_popcount(u128, uint128_t, 128)
+zig_popcount(s128, int128_t, 128)
+
 #define zig_add_sat_u(ZT, T) static inline T zig_adds_##ZT(T x, T y, T max) { \
     return (x > max - y) ? max : x + y; \
 }
@@ -444,14 +490,14 @@ zig_mul_sat_s(long,      long, long long)
 
 #define zig_shl_sat_u(ZT, T, bits) static inline T zig_shls_##ZT(T x, T y, T max) { \
     if(x == 0) return 0; \
-    T bits_set = 64 - __builtin_clzll(x); \
+    T bits_set = 64 - zig_clz_ll(x); \
     return (bits_set + y > bits) ? max : x << y; \
 }
 
 #define zig_shl_sat_s(ZT, T, bits) static inline T zig_shls_##ZT(T x, T y, T min, T max) { \
     if(x == 0) return 0; \
     T x_twos_comp = x < 0 ? -x : x; \
-    T bits_set = 64 - __builtin_clzll(x_twos_comp); \
+    T bits_set = 64 - zig_clz_ll(x_twos_comp); \
     T min_or_max = (x < 0) ? min : max; \
     return (y + bits_set > bits ) ?  min_or_max : x << y; \
 }
@@ -468,51 +514,6 @@ zig_shl_sat_s(isize, intptr_t, ((sizeof(intptr_t)) * CHAR_BIT - 1))
 zig_shl_sat_s(short,    short, ((sizeof(short   )) * CHAR_BIT - 1))
 zig_shl_sat_s(int,        int, ((sizeof(int     )) * CHAR_BIT - 1))
 zig_shl_sat_s(long,      long, ((sizeof(long    )) * CHAR_BIT - 1))
-
-#define zig_clz(ZT, T, bits) \
-    static inline uint8_t zig_clz_##ZT(T x) { \
-        uint8_t count = 0; \
-        for (uint8_t i = bits; i > 0; i--) { \
-            if ((x >> (i-1)) & 1) { \
-                break; \
-            } \
-            count++; \
-        }  \
-        return count; \
-    }
-
-zig_clz(u8, uint8_t, 8)
-zig_clz(s8, int8_t, 8)
-zig_clz(u16, uint16_t, 16)
-zig_clz(s16, int16_t, 16)
-zig_clz(u32, uint32_t, 32)
-zig_clz(s32, int32_t, 32)
-zig_clz(u64, uint64_t, 64)
-zig_clz(s64, int64_t, 64)
-zig_clz(u128, uint128_t, 128)
-zig_clz(s128, int128_t, 128)
-
-#define zig_popcount(ZT, T, bits) \
-    static inline uint8_t zig_popcount_##ZT(T x) { \
-        uint8_t count = 0; \
-        for (uint8_t i = bits; i > 0; i--) { \
-            if ((x >> (i-1)) & 1) { \
-                count++; \
-            } \
-        }  \
-        return count; \
-    }
-
-zig_popcount(u8, uint8_t, 8)
-zig_popcount(s8, int8_t, 8)
-zig_popcount(u16, uint16_t, 16)
-zig_popcount(s16, int16_t, 16)
-zig_popcount(u32, uint32_t, 32)
-zig_popcount(s32, int32_t, 32)
-zig_popcount(u64, uint64_t, 64)
-zig_popcount(s64, int64_t, 64)
-zig_popcount(u128, uint128_t, 128)
-zig_popcount(s128, int128_t, 128)
 
 #define zig_divfloor_s(bits, T) \
     static inline T zig_divfloor_s##bits(T a, T b) { \

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -463,3 +463,26 @@ zig_shl_sat_s(isize, intptr_t, ((sizeof(intptr_t)) * CHAR_BIT - 1))
 zig_shl_sat_s(short,    short, ((sizeof(short   )) * CHAR_BIT - 1))
 zig_shl_sat_s(int,        int, ((sizeof(int     )) * CHAR_BIT - 1))
 zig_shl_sat_s(long,      long, ((sizeof(long    )) * CHAR_BIT - 1))
+
+#define zig_clz(ZT, T, bits) \
+    static inline uint8_t zig_clz_##ZT(T x) { \
+        uint8_t count = 0; \
+        for (uint8_t i = bits; i > 0; i--) { \
+            if ((x >> (i-1)) & 1) { \
+                break; \
+            } \
+            count++; \
+        }  \
+        return count; \
+    }
+
+zig_clz(u8, uint8_t, 8)
+zig_clz(s8, int8_t, 8)
+zig_clz(u16, uint16_t, 16)
+zig_clz(s16, int16_t, 16)
+zig_clz(u32, uint32_t, 32)
+zig_clz(s32, int32_t, 32)
+zig_clz(u64, uint64_t, 64)
+zig_clz(s64, int64_t, 64)
+zig_clz(u128, uint128_t, 128)
+zig_clz(s128, int128_t, 128)

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -28,6 +28,7 @@ test {
     _ = @import("behavior/int128.zig");
     _ = @import("behavior/null.zig");
     _ = @import("behavior/pointers.zig");
+    _ = @import("behavior/popcount.zig");
     _ = @import("behavior/ptrcast.zig");
     _ = @import("behavior/pub_enum.zig");
     _ = @import("behavior/struct.zig");
@@ -62,7 +63,6 @@ test {
         _ = @import("behavior/maximum_minimum.zig");
         _ = @import("behavior/null_llvm.zig");
         _ = @import("behavior/optional.zig");
-        _ = @import("behavior/popcount.zig");
         _ = @import("behavior/saturating_arithmetic.zig");
         _ = @import("behavior/sizeof_and_typeof.zig");
         _ = @import("behavior/slice.zig");

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -300,17 +300,13 @@ fn testDivision() !void {
     try expect(divTrunc(i32, -14, 12) == -1);
     try expect(divTrunc(i32, -2, 12) == 0);
 
-    try expect(mod(i32, 10, 12) == 10);
-    try expect(mod(i32, -14, 12) == 10);
-    try expect(mod(i32, -2, 12) == 10);
+    try expect(divExact2(i32, i16, 10, 5) == 2);
+    try expect(divFloor2(i64, i16, 33, 7) == 4);
+    try expect(divTrunc2(i64, i16, 33, 7) == 4);
+
+    try expect(divTrunc2(f64, f32, 33.0, 7.0) == 4.0);
 
     comptime {
-        try expect(
-            1194735857077236777412821811143690633098347576 % 508740759824825164163191790951174292733114988 == 177254337427586449086438229241342047632117600,
-        );
-        try expect(
-            @rem(-1194735857077236777412821811143690633098347576, 508740759824825164163191790951174292733114988) == -177254337427586449086438229241342047632117600,
-        );
         try expect(
             1194735857077236777412821811143690633098347576 / 508740759824825164163191790951174292733114988 == 2,
         );
@@ -323,15 +319,17 @@ fn testDivision() !void {
         try expect(
             @divTrunc(-1194735857077236777412821811143690633098347576, -508740759824825164163191790951174292733114988) == 2,
         );
-        try expect(
-            4126227191251978491697987544882340798050766755606969681711 % 10 == 1,
-        );
     }
 }
+
 fn div(comptime T: type, a: T, b: T) T {
     return a / b;
 }
+
 fn divExact(comptime T: type, a: T, b: T) T {
+    return @divExact(a, b);
+}
+fn divExact2(comptime T1: type, comptime T2: type, a: T1, b: T2) @TypeOf(a, b) {
     return @divExact(a, b);
 }
 fn divFloor(comptime T: type, a: T, b: T) T {
@@ -339,6 +337,47 @@ fn divFloor(comptime T: type, a: T, b: T) T {
 }
 fn divTrunc(comptime T: type, a: T, b: T) T {
     return @divTrunc(a, b);
+}
+// these versions test for correct result when peer type resolution is involved
+fn divFloor2(comptime T1: type, comptime T2: type, a: T1, b: T2) @TypeOf(a, b) {
+    return @divFloor(a, b);
+}
+fn divTrunc2(comptime T1: type, comptime T2: type, a: T1, b: T2) @TypeOf(a, b) {
+    return @divTrunc(a, b);
+}
+
+test "remainder and mod" {
+    try testRemainderAndMod();
+    comptime try testRemainderAndMod();
+}
+
+fn testRemainderAndMod() !void {
+    try expect(rem(i32, -2, 5) == -2);
+    try expect(rem(i32, -7, 2) == -1);
+    try expect(rem(i32, -7, 2) == -1);
+
+    try expect(mod(i8, 127, 2) == 1);
+    try expect(mod(i8, -127, 2) == 1);
+    try expect(mod(i8, -128, 3) == 1);
+    try expect(mod(i32, 10, 12) == 10);
+    try expect(mod(i32, -14, 12) == 10);
+    try expect(mod(i32, -2, 12) == 10);
+
+    comptime {
+        try expect(
+            4126227191251978491697987544882340798050766755606969681711 % 10 == 1,
+        );
+        try expect(
+            1194735857077236777412821811143690633098347576 % 508740759824825164163191790951174292733114988 == 177254337427586449086438229241342047632117600,
+        );
+        try expect(
+            @rem(-1194735857077236777412821811143690633098347576, 508740759824825164163191790951174292733114988) == -177254337427586449086438229241342047632117600,
+        );
+    }
+}
+
+fn rem(comptime T: type, a: T, b: T) T {
+    return @rem(a, b);
 }
 fn mod(comptime T: type, a: T, b: T) T {
     return @mod(a, b);


### PR DESCRIPTION
Summary:
- every commit is reviewable independently
- math.zig is till not passing because of f16 and f128; those are my next TODO, i can either continue here and wait for this to be merged or do a followup, as the reviewer prefers
- @clz and @popcount are implemented as naive functions in zig.h, I hope not to offend anyone, I'll open a follow up issues for converting them to a more efficient implementation that use intrinsics/LUTs (reference to: https://github.com/ziglang/zig/pull/9687)
- floored division and mod for integers are implemented ad hoc in zig.h, implementation is not efficient but correct
- the commit that substitutes the clz intrinsic in zig_sub_sat_u/s is droppable (cc @travisstaloch)

The last commit fixes the following scenario that occurred in math.zig:
```zig
test "xor" () {
}
fn test_xor() {
// ...
}
```
Currently those two get converted to the same function name and it won't compile. I'm not really sure about the fix, particularly whether it could happen for other reason, so I'm open for a better solution