### PR TITLE
Fix linking errors with floorl on MSVC

### DIFF
--- a/src/stage1/os.cpp
+++ b/src/stage1/os.cpp
@@ -41,6 +41,7 @@
 #include <io.h>
 #include <fcntl.h>
 #include <ntsecapi.h>
+#include <math.h>
 
 // Workaround an upstream LLVM issue.
 // See https://github.com/ziglang/zig/issues/7614#issuecomment-752939981


### PR DESCRIPTION
Fix linking errors with floorl on MSVC by including math.h in a .cpp file. floorl is a force inline function defined in a header thus not visible for the linker.