### PR TITLE
Constant data in rodata

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -54,13 +54,14 @@ phdr_load_re_index: ?u16 = null,
 /// The index into the program headers of the global offset table.
 /// It needs PT_LOAD and Read flags.
 phdr_got_index: ?u16 = null,
+/// The index into the program headers of a PT_LOAD program header with Read flag
+phdr_load_ro_index: ?u16 = null,
 entry_addr: ?u64 = null,
 
 debug_strtab: std.ArrayListUnmanaged(u8) = std.ArrayListUnmanaged(u8){},
 shstrtab: std.ArrayListUnmanaged(u8) = std.ArrayListUnmanaged(u8){},
 shstrtab_index: ?u16 = null,
 
-text_section_index: ?u16 = null,
 symtab_section_index: ?u16 = null,
 got_section_index: ?u16 = null,
 debug_info_section_index: ?u16 = null,
@@ -115,8 +116,8 @@ error_flags: File.ErrorFlags = File.ErrorFlags{},
 /// overcapacity can be negative. A simple way to have negative overcapacity is to
 /// allocate a fresh text block, which will have ideal capacity, and then grow it
 /// by 1 byte. It will then have -1 overcapacity.
-text_block_free_list: std.ArrayListUnmanaged(*TextBlock) = .{},
-last_text_block: ?*TextBlock = null,
+text_block_list: TextBlockList = .{},
+rodata_block_list: TextBlockList = .{},
 
 /// A list of `SrcFn` whose Line Number Programs have surplus capacity.
 /// This is the same concept as `text_block_free_list`; see those doc comments.
@@ -202,6 +203,14 @@ pub const TextBlock = struct {
         const surplus = cap - ideal_cap;
         return surplus >= min_text_capacity;
     }
+};
+
+/// A list of text blocks in a specific section
+const TextBlockList = struct {
+    free_list: std.ArrayListUnmanaged(*TextBlock) = .{},
+    last_block: ?*TextBlock = null,
+    phdr_index: ?u16 = null,
+    section_index: ?u16 = null,
 };
 
 pub const Export = struct {
@@ -314,7 +323,8 @@ pub fn deinit(self: *Elf) void {
     self.global_symbol_free_list.deinit(self.base.allocator);
     self.local_symbol_free_list.deinit(self.base.allocator);
     self.offset_table_free_list.deinit(self.base.allocator);
-    self.text_block_free_list.deinit(self.base.allocator);
+    self.text_block_list.free_list.deinit(self.base.allocator);
+    self.rodata_block_list.free_list.deinit(self.base.allocator);
     self.dbg_line_fn_free_list.deinit(self.base.allocator);
     self.dbg_info_decl_free_list.deinit(self.base.allocator);
     self.offset_table.deinit(self.base.allocator);
@@ -450,6 +460,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
     const ptr_size: u8 = self.ptrWidthBytes();
     if (self.phdr_load_re_index == null) {
         self.phdr_load_re_index = @intCast(u16, self.program_headers.items.len);
+        self.text_block_list.phdr_index = self.phdr_load_re_index;
         const file_size = self.base.options.program_code_size_hint;
         const p_align = 0x1000;
         const off = self.findFreeSpace(file_size, p_align);
@@ -492,6 +503,29 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         });
         self.phdr_table_dirty = true;
     }
+    if (self.phdr_load_ro_index == null) {
+        self.phdr_load_ro_index = @intCast(u16, self.program_headers.items.len);
+        self.rodata_block_list.phdr_index = self.phdr_load_ro_index;
+        // TODO Find a hint about how much data need to be in rodata ?
+        const file_size = 1024;
+        // Same reason as for GOT
+        const p_align = if (self.base.options.target.os.tag == .linux) 0x1000 else @as(u16, ptr_size);
+        const off = self.findFreeSpace(file_size, p_align);
+        log.debug("found PT_LOAD free space 0x{x} to 0x{x}\n", .{ off, off + file_size });
+        // TODO Same as for GOT
+        const rodata_addr: u32 = if (self.base.options.target.cpu.arch.ptrBitWidth() >= 32) 0x6000000 else 0xD000;
+        try self.program_headers.append(self.base.allocator, .{
+            .p_type = elf.PT_LOAD,
+            .p_offset = off,
+            .p_filesz = file_size,
+            .p_vaddr = rodata_addr,
+            .p_paddr = rodata_addr,
+            .p_memsz = file_size,
+            .p_align = p_align,
+            .p_flags = elf.PF_R,
+        });
+        self.phdr_table_dirty = true;
+    }
     if (self.shstrtab_index == null) {
         self.shstrtab_index = @intCast(u16, self.sections.items.len);
         assert(self.shstrtab.items.len == 0);
@@ -513,8 +547,8 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         self.shstrtab_dirty = true;
         self.shdr_table_dirty = true;
     }
-    if (self.text_section_index == null) {
-        self.text_section_index = @intCast(u16, self.sections.items.len);
+    if (self.text_block_list.section_index == null) {
+        self.text_block_list.section_index = @intCast(u16, self.sections.items.len);
         const phdr = &self.program_headers.items[self.phdr_load_re_index.?];
 
         try self.sections.append(self.base.allocator, .{
@@ -537,6 +571,24 @@ pub fn populateMissingMetadata(self: *Elf) !void {
 
         try self.sections.append(self.base.allocator, .{
             .sh_name = try self.makeString(".got"),
+            .sh_type = elf.SHT_PROGBITS,
+            .sh_flags = elf.SHF_ALLOC,
+            .sh_addr = phdr.p_vaddr,
+            .sh_offset = phdr.p_offset,
+            .sh_size = phdr.p_filesz,
+            .sh_link = 0,
+            .sh_info = 0,
+            .sh_addralign = phdr.p_align,
+            .sh_entsize = 0,
+        });
+        self.shdr_table_dirty = true;
+    }
+    if (self.rodata_block_list.section_index == null) {
+        self.rodata_block_list.section_index = @intCast(u16, self.sections.items.len);
+        const phdr = &self.program_headers.items[self.phdr_load_ro_index.?];
+
+        try self.sections.append(self.base.allocator, .{
+            .sh_name = try self.makeString(".rodata"),
             .sh_type = elf.SHT_PROGBITS,
             .sh_flags = elf.SHF_ALLOC,
             .sh_addr = phdr.p_vaddr,
@@ -1894,17 +1946,17 @@ fn writeElfHeader(self: *Elf) !void {
     try self.base.file.?.pwriteAll(hdr_buf[0..index], 0);
 }
 
-fn freeTextBlock(self: *Elf, text_block: *TextBlock) void {
+fn freeTextBlock(self: *Elf, block_list: *TextBlockList, text_block: *TextBlock) void {
     var already_have_free_list_node = false;
     {
         var i: usize = 0;
         // TODO turn text_block_free_list into a hash map
-        while (i < self.text_block_free_list.items.len) {
-            if (self.text_block_free_list.items[i] == text_block) {
-                _ = self.text_block_free_list.swapRemove(i);
+        while (i < block_list.free_list.items.len) {
+            if (block_list.free_list.items[i] == text_block) {
+                _ = block_list.free_list.swapRemove(i);
                 continue;
             }
-            if (self.text_block_free_list.items[i] == text_block.prev) {
+            if (block_list.free_list.items[i] == text_block.prev) {
                 already_have_free_list_node = true;
             }
             i += 1;
@@ -1912,9 +1964,9 @@ fn freeTextBlock(self: *Elf, text_block: *TextBlock) void {
     }
     // TODO process free list for dbg info just like we do above for vaddrs
 
-    if (self.last_text_block == text_block) {
+    if (block_list.last_block == text_block) {
         // TODO shrink the .text section size here
-        self.last_text_block = text_block.prev;
+        block_list.last_block = text_block.prev;
     }
     if (self.dbg_info_decl_first == text_block) {
         self.dbg_info_decl_first = text_block.dbg_info_next;
@@ -1930,7 +1982,7 @@ fn freeTextBlock(self: *Elf, text_block: *TextBlock) void {
         if (!already_have_free_list_node and prev.freeListEligible(self.*)) {
             // The free list is heuristics, it doesn't have to be perfect, so we can
             // ignore the OOM here.
-            self.text_block_free_list.append(self.base.allocator, prev) catch {};
+            block_list.free_list.append(self.base.allocator, prev) catch {};
         }
     } else {
         text_block.prev = null;
@@ -1957,25 +2009,24 @@ fn freeTextBlock(self: *Elf, text_block: *TextBlock) void {
     }
 }
 
-fn shrinkTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64) void {
+fn shrinkTextBlock(self: *Elf, block_list: *TextBlockList, text_block: *TextBlock, new_block_size: u64) void {
     _ = self;
+    _ = block_list;
     _ = text_block;
     _ = new_block_size;
-    // TODO check the new capacity, and if it crosses the size threshold into a big enough
-    // capacity, insert a free list node for it.
 }
 
-fn growTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, alignment: u64) !u64 {
+fn growTextBlock(self: *Elf, block_list: *TextBlockList, text_block: *TextBlock, new_block_size: u64, alignment: u64) !u64 {
     const sym = self.local_symbols.items[text_block.local_sym_index];
     const align_ok = mem.alignBackwardGeneric(u64, sym.st_value, alignment) == sym.st_value;
     const need_realloc = !align_ok or new_block_size > text_block.capacity(self.*);
     if (!need_realloc) return sym.st_value;
-    return self.allocateTextBlock(text_block, new_block_size, alignment);
+    return self.allocateTextBlock(block_list, text_block, new_block_size, alignment);
 }
 
-fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, alignment: u64) !u64 {
-    const phdr = &self.program_headers.items[self.phdr_load_re_index.?];
-    const shdr = &self.sections.items[self.text_section_index.?];
+fn allocateTextBlock(self: *Elf, block_list: *TextBlockList, text_block: *TextBlock, new_block_size: u64, alignment: u64) !u64 {
+    const phdr = &self.program_headers.items[block_list.phdr_index.?];
+    const shdr = &self.sections.items[block_list.section_index.?];
     const new_block_ideal_capacity = padToIdeal(new_block_size);
 
     // We use these to indicate our intention to update metadata, placing the new block,
@@ -1990,8 +2041,8 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
     // The list is unordered. We'll just take the first thing that works.
     const vaddr = blk: {
         var i: usize = 0;
-        while (i < self.text_block_free_list.items.len) {
-            const big_block = self.text_block_free_list.items[i];
+        while (i < block_list.free_list.items.len) {
+            const big_block = block_list.free_list.items[i];
             // We now have a pointer to a live text block that has too much capacity.
             // Is it enough that we could fit this new text block?
             const sym = self.local_symbols.items[big_block.local_sym_index];
@@ -2006,7 +2057,7 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
                 // should be deleted because the block that it points to has grown to take up
                 // more of the extra capacity.
                 if (!big_block.freeListEligible(self.*)) {
-                    _ = self.text_block_free_list.swapRemove(i);
+                    _ = block_list.free_list.swapRemove(i);
                 } else {
                     i += 1;
                 }
@@ -2024,7 +2075,7 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
                 free_list_removal = i;
             }
             break :blk new_start_vaddr;
-        } else if (self.last_text_block) |last| {
+        } else if (block_list.last_block) |last| {
             const sym = self.local_symbols.items[last.local_sym_index];
             const ideal_capacity = padToIdeal(sym.st_size);
             const ideal_capacity_end_vaddr = sym.st_value + ideal_capacity;
@@ -2044,7 +2095,7 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
         if (needed_size > text_capacity) {
             // Must move the entire text section.
             const new_offset = self.findFreeSpace(needed_size, 0x1000);
-            const text_size = if (self.last_text_block) |last| blk: {
+            const text_size = if (block_list.last_block) |last| blk: {
                 const sym = self.local_symbols.items[last.local_sym_index];
                 break :blk (sym.st_value + sym.st_size) - phdr.p_vaddr;
             } else 0;
@@ -2053,7 +2104,7 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
             shdr.sh_offset = new_offset;
             phdr.p_offset = new_offset;
         }
-        self.last_text_block = text_block;
+        block_list.last_block = text_block;
 
         shdr.sh_size = needed_size;
         phdr.p_memsz = needed_size;
@@ -2091,9 +2142,17 @@ fn allocateTextBlock(self: *Elf, text_block: *TextBlock, new_block_size: u64, al
         text_block.next = null;
     }
     if (free_list_removal) |i| {
-        _ = self.text_block_free_list.swapRemove(i);
+        _ = block_list.free_list.swapRemove(i);
     }
     return vaddr;
+}
+
+/// Get the block list corresponding to a specific decl
+/// For example, if the decl is a function, it returns the list of the section .text
+fn getDeclBlockList(self: *Elf, decl: *const Module.Decl) *TextBlockList {
+    // const is_fn = decl.val.tag() == .function;
+    const is_fn = decl.ty.zigTypeTag() == .Fn;
+    return if (is_fn) &self.text_block_list else &self.rodata_block_list;
 }
 
 pub fn allocateDeclIndexes(self: *Elf, decl: *Module.Decl) !void {
@@ -2139,8 +2198,10 @@ pub fn freeDecl(self: *Elf, decl: *Module.Decl) void {
         if (self.llvm_object) |llvm_object| return llvm_object.freeDecl(decl);
     }
 
+    const block_list = self.getDeclBlockList(decl);
+
     // Appending to free lists is allowed to fail because the free lists are heuristics based anyway.
-    self.freeTextBlock(&decl.link.elf);
+    self.freeTextBlock(block_list, &decl.link.elf);
     if (decl.link.elf.local_sym_index != 0) {
         self.local_symbol_free_list.append(self.base.allocator, decl.link.elf.local_sym_index) catch {};
         self.offset_table_free_list.append(self.base.allocator, decl.link.elf.offset_table_index) catch {};
@@ -2183,6 +2244,8 @@ fn deinitRelocs(gpa: *Allocator, table: *File.DbgInfoTypeRelocsTable) void {
 fn updateDeclCode(self: *Elf, decl: *Module.Decl, code: []const u8, stt_bits: u8) !*elf.Elf64_Sym {
     const required_alignment = decl.ty.abiAlignment(self.base.options.target);
 
+    const block_list = self.getDeclBlockList(decl);
+
     assert(decl.link.elf.local_sym_index != 0); // Caller forgot to allocateDeclIndexes()
     const local_sym = &self.local_symbols.items[decl.link.elf.local_sym_index];
     if (local_sym.st_size != 0) {
@@ -2190,7 +2253,7 @@ fn updateDeclCode(self: *Elf, decl: *Module.Decl, code: []const u8, stt_bits: u8
         const need_realloc = code.len > capacity or
             !mem.isAlignedGeneric(u64, local_sym.st_value, required_alignment);
         if (need_realloc) {
-            const vaddr = try self.growTextBlock(&decl.link.elf, code.len, required_alignment);
+            const vaddr = try self.growTextBlock(block_list, &decl.link.elf, code.len, required_alignment);
             log.debug("growing {s} from 0x{x} to 0x{x}", .{ decl.name, local_sym.st_value, vaddr });
             if (vaddr != local_sym.st_value) {
                 local_sym.st_value = vaddr;
@@ -2200,27 +2263,28 @@ fn updateDeclCode(self: *Elf, decl: *Module.Decl, code: []const u8, stt_bits: u8
                 try self.writeOffsetTableEntry(decl.link.elf.offset_table_index);
             }
         } else if (code.len < local_sym.st_size) {
-            self.shrinkTextBlock(&decl.link.elf, code.len);
+            self.shrinkTextBlock(block_list, &decl.link.elf, code.len);
         }
         local_sym.st_size = code.len;
         local_sym.st_name = try self.updateString(local_sym.st_name, mem.spanZ(decl.name));
         local_sym.st_info = (elf.STB_LOCAL << 4) | stt_bits;
         local_sym.st_other = 0;
-        local_sym.st_shndx = self.text_section_index.?;
+        local_sym.st_shndx = block_list.section_index.?;
         // TODO this write could be avoided if no fields of the symbol were changed.
         try self.writeSymbol(decl.link.elf.local_sym_index);
     } else {
         const decl_name = mem.spanZ(decl.name);
         const name_str_index = try self.makeString(decl_name);
-        const vaddr = try self.allocateTextBlock(&decl.link.elf, code.len, required_alignment);
+        const vaddr = try self.allocateTextBlock(block_list, &decl.link.elf, code.len, required_alignment);
+        errdefer self.freeTextBlock(block_list, &decl.link.elf);
         log.debug("allocated text block for {s} at 0x{x}", .{ decl_name, vaddr });
-        errdefer self.freeTextBlock(&decl.link.elf);
+        errdefer self.freeTextBlock(block_list, &decl.link.elf);
 
         local_sym.* = .{
             .st_name = name_str_index,
             .st_info = (elf.STB_LOCAL << 4) | stt_bits,
             .st_other = 0,
-            .st_shndx = self.text_section_index.?,
+            .st_shndx = block_list.section_index.?,
             .st_value = vaddr,
             .st_size = code.len,
         };
@@ -2230,8 +2294,8 @@ fn updateDeclCode(self: *Elf, decl: *Module.Decl, code: []const u8, stt_bits: u8
         try self.writeOffsetTableEntry(decl.link.elf.offset_table_index);
     }
 
-    const section_offset = local_sym.st_value - self.program_headers.items[self.phdr_load_re_index.?].p_vaddr;
-    const file_offset = self.sections.items[self.text_section_index.?].sh_offset + section_offset;
+    const section_offset = local_sym.st_value - self.program_headers.items[block_list.phdr_index.?].p_vaddr;
+    const file_offset = self.sections.items[block_list.section_index.?].sh_offset + section_offset;
     try self.base.file.?.pwriteAll(code, file_offset);
 
     return local_sym;
@@ -2739,6 +2803,8 @@ pub fn updateDeclExports(
     if (decl.link.elf.local_sym_index == 0) return;
     const decl_sym = self.local_symbols.items[decl.link.elf.local_sym_index];
 
+    const block_list = self.getDeclBlockList(decl);
+
     for (exports) |exp| {
         if (exp.options.section) |section_name| {
             if (!mem.eql(u8, section_name, ".text")) {
@@ -2775,7 +2841,7 @@ pub fn updateDeclExports(
                 .st_name = try self.updateString(sym.st_name, exp.options.name),
                 .st_info = (stb_bits << 4) | stt_bits,
                 .st_other = 0,
-                .st_shndx = self.text_section_index.?,
+                .st_shndx = block_list.section_index.?,
                 .st_value = decl_sym.st_value,
                 .st_size = decl_sym.st_size,
             };
@@ -2789,7 +2855,7 @@ pub fn updateDeclExports(
                 .st_name = name,
                 .st_info = (stb_bits << 4) | stt_bits,
                 .st_other = 0,
-                .st_shndx = self.text_section_index.?,
+                .st_shndx = block_list.section_index.?,
                 .st_value = decl_sym.st_value,
                 .st_size = decl_sym.st_size,
             };


### PR DESCRIPTION
Closes #6029 .

# Unresolved questions

Should the `TextBlock` and `TextBlockList` be renamed to something like `DeclBlock` and `DeclBlockList` as they're no longer only in the `.text` section ?

# Testing

I'd like to add tests to this PR, but I don't really know how. Should I use the `Case.addCompareObjectFile` method ?

I used the hello world example for testing :

```zig
pub export fn _start() noreturn {
    print();

    exit();
}

fn print() void {
    asm volatile ("syscall"
        :
        : [number] "{rax}" (1),
          [arg1] "{rdi}" (1),
          [arg2] "{rsi}" (@ptrToInt("Hello, World!\n")),
          [arg3] "{rdx}" (14)
        : "rcx", "r11", "memory"
    );
    return;
}

fn exit() noreturn {
    asm volatile ("syscall"
        :
        : [number] "{rax}" (231),
          [arg1] "{rdi}" (0)
        : "rcx", "r11", "memory"
    );
    unreachable;
}
```

Compiling this example without this PR produces this output when displaying sections with `readelf`:

```
> readelf -x .rodata -x .text hello
readelf: Warning: Section '.rodata' was not dumped because it does not exist!

Hex dump of section '.text':
  0x08000000 aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa ................
  0x08000010 aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa ................
  0x08000020 aaaaaaaa aaaaaaaa 48c7c001 00000048 ........H......H
  0x08000030 c7c70100 00554889 e54883ec 00ff1425 .....UH..H.....%
  0x08000040 18000004 ff142520 0000045d c3000f05 ......% ...]....
  0x08000050 5dc30000 00554889 e54883ec 0048c7c0 ]....UH..H...H..
  0x08000060 01000000 48c7c701 00000048 8b342528 ....H......H.4%(
  0x08000070 00000448 c7c20e00 00000f05 5dc30000 ...H........]...
  0x08000080 00000000 00000000 00000055 4889e548 ...........UH..H
  0x08000090 83ec0048 c7c0e700 00004831 ff0f05cc ...H......H1....
  0x080000a0 5dc3726c 64210a00 0048656c 6c6f2c20 ].rld!...Hello,
  0x080000b0 576f726c 64210a00 00                World!...
```

With this PR, all the declarations that are not functions are put in the `.rodata` section :
```
> readelf -x .rodata -x .text hello

Hex dump of section '.text':
  0x08000000 554889e5 4883ec00 ff142518 000004ff UH..H.....%.....
  0x08000010 14252000 00045dc3 aaaaaaaa aaaaaaaa .% ...].........
  0x08000020 554889e5 4883ec00 48c7c001 00000048 UH..H...H......H
  0x08000030 c7c70100 0000488b 34252800 000448c7 ......H.4%(...H.
  0x08000040 c20e0000 000f055d c300045d c3000f05 .......]...]....
  0x08000050 5dc30000 00555548 89e54883 ec0048c7 ]....UUH..H...H.
  0x08000060 c0e70000 004831ff 0f05cc5d c3       .....H1....].


Hex dump of section '.rodata':
  0x06000000 aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa ................
  0x06000010 aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa ................
  0x06000020 aaaaaaaa aaaaaaaa 00000000 00000000 ................
  0x06000030 00000000 0048656c 6c6f2c20 576f726c .....Hello, Worl
  0x06000040 64210a00 00                         d!...
```