### PR TITLE
compiler_rt: export floorl

### DIFF
--- a/lib/std/special/c_stage1.zig
+++ b/lib/std/special/c_stage1.zig
@@ -639,21 +639,6 @@ export fn fmod(x: f64, y: f64) f64 {
     return generic_fmod(f64, x, y);
 }
 
-// TODO add intrinsics for these (and probably the double version too)
-// and have the math stuff use the intrinsic. same as @mod and @rem
-export fn floorf(x: f32) f32 {
-    return math.floor(x);
-}
-export fn floor(x: f64) f64 {
-    return math.floor(x);
-}
-export fn floorl(x: c_longdouble) c_longdouble {
-    if (!long_double_is_f128) {
-        @panic("TODO implement this");
-    }
-    return math.floor(x);
-}
-
 export fn ceilf(x: f32) f32 {
     return math.ceil(x);
 }

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -630,11 +630,31 @@ comptime {
         _ = @import("compiler_rt/atomics.zig");
 
         @export(fmaq, .{ .name = "fmaq", .linkage = linkage });
+        @export(floorf, .{ .name = "floorf", .linkage = linkage });
+        @export(floor, .{ .name = "floor", .linkage = linkage });
+        @export(floorl, .{ .name = "floorl", .linkage = linkage });
     }
 }
 
+const math = std.math;
+
 fn fmaq(a: f128, b: f128, c: f128) callconv(.C) f128 {
-    return std.math.fma(f128, a, b, c);
+    return math.fma(f128, a, b, c);
+}
+
+// TODO add intrinsics for these (and probably the double version too)
+// and have the math stuff use the intrinsic. same as @mod and @rem
+fn floorf(x: f32) callconv(.C) f32 {
+    return math.floor(x);
+}
+fn floor(x: f64) callconv(.C) f64 {
+    return math.floor(x);
+}
+fn floorl(x: c_longdouble) callconv(.C) c_longdouble {
+    if (!long_double_is_f128) {
+        @panic("TODO implement this");
+    }
+    return math.floor(x);
 }
 
 // Avoid dragging in the runtime safety mechanisms into this .o file,


### PR DESCRIPTION
This fixes a linker error when compiling with VS2022 on Windows:

```
zig1.obj : LNK2019: unresolved external symbol floorl referenced in function Sema.coerceInMemoryAllowedPtrs [D:\zig\build\zig.vcxproj]
```

I'm not entirely sure this is the correct place to export or if it should go into one of the conditional branches above.

E: So actually this is the classic C thing where long double isn't necessarily bigger than double, this will probably require some more thought. I'm going to have a closer look at what andrew suggested in IRC (related: #7265) since it looks like there's a better way to write this already in `std/special/c_stage1.zig`.