### PR TITLE
CBE: add .optional_single_mut_pointer and .optional_single_const_pointer to Type.childType

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -2485,6 +2485,8 @@ pub const Type = extern union {
             .vector => ty.castTag(.vector).?.data.elem_type,
             .array => ty.castTag(.array).?.data.elem_type,
             .array_sentinel => ty.castTag(.array_sentinel).?.data.elem_type,
+            .optional_single_mut_pointer,
+            .optional_single_const_pointer,
             .single_const_pointer,
             .single_mut_pointer,
             .many_const_pointer,

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -2,6 +2,7 @@ const builtin = @import("builtin");
 
 test {
     // Tests that pass for stage1, stage2, and the C backend.
+    _ = @import("behavior/align.zig");
     _ = @import("behavior/basic.zig");
     _ = @import("behavior/bitcast.zig");
     _ = @import("behavior/bool.zig");
@@ -22,6 +23,7 @@ test {
     _ = @import("behavior/cast.zig");
     _ = @import("behavior/defer.zig");
     _ = @import("behavior/enum.zig");
+    _ = @import("behavior/error.zig");
     _ = @import("behavior/hasdecl.zig");
     _ = @import("behavior/hasfield.zig");
     _ = @import("behavior/if.zig");
@@ -42,7 +44,6 @@ test {
 
     if (builtin.object_format != .c) {
         // Tests that pass for stage1 and stage2 but not the C backend.
-        _ = @import("behavior/align.zig");
         _ = @import("behavior/array.zig");
         _ = @import("behavior/atomics.zig");
         _ = @import("behavior/basic_llvm.zig");
@@ -53,7 +54,6 @@ test {
         _ = @import("behavior/bugs/2006.zig");
         _ = @import("behavior/bugs/3112.zig");
         _ = @import("behavior/cast_llvm.zig");
-        _ = @import("behavior/error.zig");
         _ = @import("behavior/eval.zig");
         _ = @import("behavior/floatop.zig");
         _ = @import("behavior/fn.zig");


### PR DESCRIPTION
Also adds newly-passing behavioral tests `align.zig` and `error.zig` to the top of the list.