### PR TITLE
compiler_rt: disable spinlocks for atomic instrinsics for bpf

### DIFF
--- a/lib/std/special/compiler_rt/atomics.zig
+++ b/lib/std/special/compiler_rt/atomics.zig
@@ -10,7 +10,7 @@ const linkage: std.builtin.GlobalLinkage = if (builtin.is_test) .Internal else .
 // detail to keep the export logic clean and because we need some kind of CAS to
 // implement the spinlocks.
 const supports_atomic_ops = switch (arch) {
-    .msp430, .avr => false,
+    .msp430, .avr, .bpfel, .bpfeb => false,
     .arm, .armeb, .thumb, .thumbeb =>
     // The ARM v6m ISA has no ldrex/strex and so it's impossible to do CAS
     // operations (unless we're targeting Linux, the kernel provides a way to


### PR DESCRIPTION
The BPF target does not support mutable global variables. Mark the BPF target as a target that does not support atomic variables in order to avoid including the global spinlock table provided in compiler_rt.