### PR TITLE
std: add `writer` methods on all crypto.hash types

### DIFF
--- a/lib/std/crypto/blake2.zig
+++ b/lib/std/crypto/blake2.zig
@@ -184,6 +184,18 @@ pub fn Blake2s(comptime out_bits: usize) type {
                 r.* ^= v[i] ^ v[i + 8];
             }
         }
+
+        pub const Error = error{};
+        pub const Writer = std.io.Writer(*Self, Error, write);
+
+        fn write(self: *Self, bytes: []const u8) Error!usize {
+            self.update(bytes);
+            return bytes.len;
+        }
+
+        pub fn writer(self: *Self) Writer {
+            return .{ .context = self };
+        }
     };
 }
 

--- a/lib/std/crypto/blake3.zig
+++ b/lib/std/crypto/blake3.zig
@@ -472,6 +472,18 @@ pub const Blake3 = struct {
         }
         output.rootOutputBytes(out_slice);
     }
+
+    pub const Error = error{};
+    pub const Writer = std.io.Writer(*Blake3, Error, write);
+
+    fn write(self: *Blake3, bytes: []const u8) Error!usize {
+        self.update(bytes);
+        return bytes.len;
+    }
+
+    pub fn writer(self: *Blake3) Writer {
+        return .{ .context = self };
+    }
 };
 
 // Use named type declarations to workaround crash with anonymous structs (issue #4373).

--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -257,6 +257,18 @@ pub const Hash = struct {
 
         self.state.squeeze(out);
     }
+
+    pub const Error = error{};
+    pub const Writer = std.io.Writer(*Self, Error, write);
+
+    fn write(self: *Self, bytes: []const u8) Error!usize {
+        self.update(bytes);
+        return bytes.len;
+    }
+
+    pub fn writer(self: *Self) Writer {
+        return .{ .context = self };
+    }
 };
 
 pub fn hash(out: []u8, in: []const u8, options: Hash.Options) void {

--- a/lib/std/crypto/sha1.zig
+++ b/lib/std/crypto/sha1.zig
@@ -256,6 +256,18 @@ pub const Sha1 = struct {
         d.s[3] +%= v[3];
         d.s[4] +%= v[4];
     }
+
+    pub const Error = error{};
+    pub const Writer = std.io.Writer(*Self, Error, write);
+
+    fn write(self: *Self, bytes: []const u8) Error!usize {
+        self.update(bytes);
+        return bytes.len;
+    }
+
+    pub fn writer(self: *Self) Writer {
+        return .{ .context = self };
+    }
 };
 
 const htest = @import("test.zig");

--- a/lib/std/crypto/sha2.zig
+++ b/lib/std/crypto/sha2.zig
@@ -277,6 +277,18 @@ fn Sha2x32(comptime params: Sha2Params32) type {
             d.s[6] +%= v[6];
             d.s[7] +%= v[7];
         }
+
+        pub const Error = error{};
+        pub const Writer = std.io.Writer(*Self, Error, write);
+
+        fn write(self: *Self, bytes: []const u8) Error!usize {
+            self.update(bytes);
+            return bytes.len;
+        }
+
+        pub fn writer(self: *Self) Writer {
+            return .{ .context = self };
+        }
     };
 }
 

--- a/lib/std/crypto/sha3.zig
+++ b/lib/std/crypto/sha3.zig
@@ -78,6 +78,18 @@ fn Keccak(comptime bits: usize, comptime delim: u8) type {
 
             mem.copy(u8, out[op..], d.s[0..len]);
         }
+
+        pub const Error = error{};
+        pub const Writer = std.io.Writer(*Self, Error, write);
+
+        fn write(self: *Self, bytes: []const u8) Error!usize {
+            self.update(bytes);
+            return bytes.len;
+        }
+
+        pub fn writer(self: *Self) Writer {
+            return .{ .context = self };
+        }
     };
 }
 

--- a/lib/std/crypto/siphash.zig
+++ b/lib/std/crypto/siphash.zig
@@ -231,6 +231,18 @@ fn SipHash(comptime T: type, comptime c_rounds: usize, comptime d_rounds: usize)
         pub fn toInt(msg: []const u8, key: *const [key_length]u8) T {
             return State.hash(msg, key);
         }
+
+        pub const Error = error{};
+        pub const Writer = std.io.Writer(*Self, Error, write);
+
+        fn write(self: *Self, bytes: []const u8) Error!usize {
+            self.update(bytes);
+            return bytes.len;
+        }
+
+        pub fn writer(self: *Self) Writer {
+            return .{ .context = self };
+        }
     };
 }
 


### PR DESCRIPTION
This enables many use cases but the one piqued my interest in this is if you're hashing many files in sequence. since the hash types are able to take in a continuous stream of bytes through `.update`, one can setup a `std.fifo.LinearFifo` and hash the files' contents with zero allocations by doing `try fifo.pump(file.reader(), hasher.writer());`