### PR TITLE
Fixes invalid errno definition for ***-linux-android

### DIFF
--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -103,11 +103,8 @@ pub const PR = linux.PR;
 
 pub const _errno = switch (native_abi) {
     .android => struct {
-        extern "c" var __errno: c_int;
-        fn getErrno() *c_int {
-            return &__errno;
-        }
-    }.getErrno,
+        extern fn __errno() *c_int;
+    }.__errno,
     else => struct {
         extern "c" fn __errno_location() *c_int;
     }.__errno_location,


### PR DESCRIPTION
From the NDK headers:
```c
/**
 * Returns the address of the calling thread's `errno` storage.
 * Non-portable and should not be used directly. Use `errno` instead.
 *
 * @private
 */
int* __errno(void) __attribute_const__;

/**
 * [errno(3)](http://man7.org/linux/man-pages/man3/errno.3.html) is the last error on the calling
 * thread.
 */
#define errno (*__errno())
```

This bug pretty much killed any android app that yielded errors. If you had no errors, nothing would happen, but with an error, the `errno` value would always be wrong, making zig assert a panic.

I tested this change on a android device and can confirm that it works indeed! \o/