### PR TITLE
std.bounded_array: fix `self` parameter type in `constSlice`

### DIFF
--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -34,7 +34,7 @@ pub fn BoundedArray(comptime T: type, comptime capacity: usize) type {
         }
 
         /// View the internal array as a constant slice whose size was previously set.
-        pub fn constSlice(self: Self) []const T {
+        pub fn constSlice(self: *const Self) []const T {
             return self.buffer[0..self.len];
         }
 


### PR DESCRIPTION
A minimal fix for a correctness issue I noticed, though it didn't lead to a bug for me (yet).
Because `.buffer` is an inline array field, we actually require `self` to be passed as a pointer to return a slice from it.
If the compiler decided to pass the object by copying, we would return a pointer to to-be-destroyed stack memory.

All other methods looked fine to me.
From a performance perspective, `*const Self` might be the saner default to use for `get`, but it's correct as-is, so I refrained from changing that one on that hunch alone.