### PR TITLE
stage2 RISCV64: implement basic function prologue and epilogue

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -130,6 +130,14 @@ fn exit2(code: usize) noreturn {
                     : "memory", "cc"
                 );
             },
+            .riscv64 => {
+                asm volatile ("ecall"
+                    :
+                    : [number] "{a7}" (94),
+                      [arg1] "{a0}" (0),
+                    : "rcx", "r11", "memory"
+                );
+            },
             else => @compileError("TODO"),
         },
         // exits(0)

--- a/src/arch/riscv64/Emit.zig
+++ b/src/arch/riscv64/Emit.zig
@@ -46,6 +46,7 @@ pub fn emitMir(
             .addi => try emit.mirIType(inst),
             .jalr => try emit.mirIType(inst),
             .ld => try emit.mirIType(inst),
+            .sd => try emit.mirIType(inst),
 
             .ebreak => try emit.mirSystem(inst),
             .ecall => try emit.mirSystem(inst),
@@ -54,6 +55,9 @@ pub fn emitMir(
 
             .dbg_prologue_end => try emit.mirDebugPrologueEnd(),
             .dbg_epilogue_begin => try emit.mirDebugEpilogueBegin(),
+
+            .nop => try emit.mirNop(inst),
+            .ret => try emit.mirNop(inst),
 
             .lui => try emit.mirUType(inst),
         }
@@ -135,6 +139,7 @@ fn mirIType(emit: *Emit, inst: Mir.Inst.Index) !void {
         .addi => try emit.writeInstruction(Instruction.addi(i_type.rd, i_type.rs1, i_type.imm12)),
         .jalr => try emit.writeInstruction(Instruction.jalr(i_type.rd, i_type.imm12, i_type.rs1)),
         .ld => try emit.writeInstruction(Instruction.ld(i_type.rd, i_type.imm12, i_type.rs1)),
+        .sd => try emit.writeInstruction(Instruction.sd(i_type.rd, i_type.imm12, i_type.rs1)),
         else => unreachable,
     }
 }
@@ -187,6 +192,16 @@ fn mirUType(emit: *Emit, inst: Mir.Inst.Index) !void {
 
     switch (tag) {
         .lui => try emit.writeInstruction(Instruction.lui(u_type.rd, u_type.imm20)),
+        else => unreachable,
+    }
+}
+
+fn mirNop(emit: *Emit, inst: Mir.Inst.Index) !void {
+    const tag = emit.mir.instructions.items(.tag)[inst];
+
+    switch (tag) {
+        .nop => try emit.writeInstruction(Instruction.addi(.zero, .zero, 0)),
+        .ret => try emit.writeInstruction(Instruction.jalr(.zero, 0, .ra)),
         else => unreachable,
     }
 }

--- a/src/arch/riscv64/Mir.zig
+++ b/src/arch/riscv64/Mir.zig
@@ -36,6 +36,9 @@ pub const Inst = struct {
         jalr,
         ld,
         lui,
+        nop,
+        ret,
+        sd,
     };
 
     /// The position of an MIR instruction within the `Mir` instructions array.

--- a/test/stage2/riscv64.zig
+++ b/test/stage2/riscv64.zig
@@ -11,10 +11,8 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("riscv64 hello world", linux_riscv64);
         // Regular old hello world
         case.addCompareOutput(
-            \\pub export fn _start() noreturn {
+            \\pub fn main() void {
             \\    print();
-            \\
-            \\    exit();
             \\}
             \\
             \\fn print() void {
@@ -27,16 +25,6 @@ pub fn addCases(ctx: *TestContext) !void {
             \\        : "rcx", "r11", "memory"
             \\    );
             \\    return;
-            \\}
-            \\
-            \\fn exit() noreturn {
-            \\    asm volatile ("ecall"
-            \\        :
-            \\        : [number] "{a7}" (94),
-            \\          [arg1] "{a0}" (0)
-            \\        : "rcx", "r11", "memory"
-            \\    );
-            \\    unreachable;
             \\}
         ,
             "Hello, World!\n",


### PR DESCRIPTION
This enables us to use `pub fn main() void` in the stage2 tests.