### PR TITLE
Add Stage2 support for Nvptx target

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -147,6 +147,7 @@ pub const CallingConvention = enum {
     AAPCS,
     AAPCSVFP,
     SysV,
+    PtxKernel,
 };
 
 /// This data structure is used by the Zig language code generation and

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -579,6 +579,8 @@ pub const Target = struct {
         raw,
         /// Plan 9 from Bell Labs
         plan9,
+        /// Nvidia PTX format
+        nvptx,
 
         pub fn fileExt(of: ObjectFormat, cpu_arch: Cpu.Arch) [:0]const u8 {
             return switch (of) {
@@ -589,6 +591,7 @@ pub const Target = struct {
                 .hex => ".ihex",
                 .raw => ".bin",
                 .plan9 => plan9Ext(cpu_arch),
+                .nvptx => ".ptx",
             };
         }
     };
@@ -1391,6 +1394,7 @@ pub const Target = struct {
             else => return switch (cpu_arch) {
                 .wasm32, .wasm64 => .wasm,
                 .spirv32, .spirv64 => .spirv,
+                .nvptx, .nvptx64 => .nvptx,
                 else => .elf,
             },
         };

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -181,6 +181,7 @@ pub fn binNameAlloc(allocator: std.mem.Allocator, options: BinNameOptions) error
             .Obj => return std.fmt.allocPrint(allocator, "{s}{s}", .{ root_name, ofmt.fileExt(target.cpu.arch) }),
             .Lib => return std.fmt.allocPrint(allocator, "{s}{s}.a", .{ target.libPrefix(), root_name }),
         },
+        .nvptx => return std.fmt.allocPrint(allocator, "{s}", .{root_name}),
     }
 }
 

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4163,7 +4163,7 @@ fn scanDecl(iter: *ScanDeclIter, decl_sub_index: usize, flags: u4) SemaError!voi
                 // in `Decl` to notice that the line number did not change.
                 mod.comp.work_queue.writeItemAssumeCapacity(.{ .update_line_number = decl });
             },
-            .c, .wasm, .spirv => {},
+            .c, .wasm, .spirv, .nvptx => {},
         }
     }
 }
@@ -4237,6 +4237,7 @@ pub fn clearDecl(
                 .c => .{ .c = {} },
                 .wasm => .{ .wasm = link.File.Wasm.DeclBlock.empty },
                 .spirv => .{ .spirv = {} },
+                .nvptx => .{ .nvptx = {} },
             };
             decl.fn_link = switch (mod.comp.bin_file.tag) {
                 .coff => .{ .coff = {} },
@@ -4246,6 +4247,7 @@ pub fn clearDecl(
                 .c => .{ .c = {} },
                 .wasm => .{ .wasm = link.File.Wasm.FnData.empty },
                 .spirv => .{ .spirv = .{} },
+                .nvptx => .{ .nvptx = .{} },
             };
         }
         if (decl.getInnerNamespace()) |namespace| {
@@ -4573,6 +4575,7 @@ pub fn allocateNewDecl(
             .c => .{ .c = {} },
             .wasm => .{ .wasm = link.File.Wasm.DeclBlock.empty },
             .spirv => .{ .spirv = {} },
+            .nvptx => .{ .nvptx = {} },
         },
         .fn_link = switch (mod.comp.bin_file.tag) {
             .coff => .{ .coff = {} },
@@ -4582,6 +4585,7 @@ pub fn allocateNewDecl(
             .c => .{ .c = {} },
             .wasm => .{ .wasm = link.File.Wasm.FnData.empty },
             .spirv => .{ .spirv = .{} },
+            .nvptx => .{ .nvptx = .{} },
         },
         .generation = 0,
         .is_pub = false,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3704,6 +3704,7 @@ pub fn analyzeExport(
             .c => .{ .c = {} },
             .wasm => .{ .wasm = {} },
             .spirv => .{ .spirv = {} },
+            .nvptx => .{ .nvptx = {} },
         },
         .owner_decl = owner_decl,
         .src_decl = src_decl,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -378,7 +378,7 @@ pub const Object = struct {
         const mod = comp.bin_file.options.module.?;
         const cache_dir = mod.zig_cache_artifact_directory;
 
-        const emit_bin_path: ?[*:0]const u8 = if (comp.bin_file.options.emit) |emit|
+        var emit_bin_path: ?[*:0]const u8 = if (comp.bin_file.options.emit) |emit|
             try emit.basenamePath(arena, try arena.dupeZ(u8, comp.bin_file.intermediary_basename.?))
         else
             null;
@@ -5049,6 +5049,10 @@ fn toLlvmCallConv(cc: std.builtin.CallingConvention, target: std.Target) llvm.Ca
         },
         .Signal => .AVR_SIGNAL,
         .SysV => .X86_64_SysV,
+        .PtxKernel => return switch (target.cpu.arch) {
+            .nvptx, .nvptx64 => .PTX_Kernel,
+            else => unreachable,
+        },
     };
 }
 

--- a/src/link/NvPtx.zig
+++ b/src/link/NvPtx.zig
@@ -1,0 +1,115 @@
+//! NVidia PTX (Paralle Thread Execution)
+//! https://docs.nvidia.com/cuda/parallel-thread-execution/index.html
+//! For this we rely on the nvptx backend of LLVM
+//! Kernel functions need to be marked both as "export" and "callconv(.PtxKernel)"
+
+const NvPtx = @This();
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
+const log = std.log.scoped(.link);
+
+const Module = @import("../Module.zig");
+const Compilation = @import("../Compilation.zig");
+const link = @import("../link.zig");
+const trace = @import("../tracy.zig").trace;
+const build_options = @import("build_options");
+const Air = @import("../Air.zig");
+const Liveness = @import("../Liveness.zig");
+const LlvmObject = @import("../codegen/llvm.zig").Object;
+
+base: link.File,
+llvm_object: *LlvmObject,
+
+pub fn createEmpty(gpa: Allocator, options: link.Options) !*NvPtx {
+    const nvptx = try gpa.create(NvPtx);
+    nvptx.* = .{
+        .base = .{
+            .tag = .nvptx,
+            .options = options,
+            .file = null,
+            .allocator = gpa,
+        },
+        .llvm_object = undefined,
+    };
+
+    if (!build_options.have_llvm) return error.TODOArchNotSupported;
+
+    switch (options.target.cpu.arch) {
+        .nvptx, .nvptx64 => {},
+        else => return error.TODOArchNotSupported,
+    }
+
+    switch (options.target.os.tag) {
+        // TODO: does it also work with nvcl ?
+        .cuda => {},
+        else => return error.TODOOsNotSupported,
+    }
+
+    return nvptx;
+}
+
+pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Options) !*NvPtx {
+    assert(options.object_format == .nvptx);
+    if (!build_options.have_llvm or !options.use_llvm) return error.NvptxRequiresLlvm;
+
+    const nvptx = try createEmpty(allocator, options);
+    errdefer nvptx.base.destroy();
+    log.info("Opening .ptx target file {s}", .{sub_path});
+    nvptx.llvm_object = try LlvmObject.create(allocator, options);
+    return nvptx;
+}
+
+pub fn deinit(self: *NvPtx) void {
+    self.llvm_object.destroy(self.base.allocator);
+}
+
+pub fn updateFunc(self: *NvPtx, module: *Module, func: *Module.Fn, air: Air, liveness: Liveness) !void {
+    try self.llvm_object.updateFunc(module, func, air, liveness);
+}
+
+pub fn updateDecl(self: *NvPtx, module: *Module, decl: *Module.Decl) !void {
+    return self.llvm_object.updateDecl(module, decl);
+}
+
+pub fn updateDeclExports(
+    self: *NvPtx,
+    module: *Module,
+    decl: *const Module.Decl,
+    exports: []const *Module.Export,
+) !void {
+    if (build_options.skip_non_native and builtin.object_format != .nvptx) {
+        @panic("Attempted to compile for object format that was disabled by build configuration");
+    }
+    return self.llvm_object.updateDeclExports(module, decl, exports);
+}
+
+pub fn freeDecl(self: *NvPtx, decl: *Module.Decl) void {
+    return self.llvm_object.freeDecl(decl);
+}
+
+pub fn flush(self: *NvPtx, comp: *Compilation) !void {
+    return self.flushModule(comp);
+}
+
+pub fn flushModule(self: *NvPtx, comp: *Compilation) !void {
+    if (build_options.skip_non_native or !build_options.have_llvm) {
+        @panic("Attempted to compile for architecture that was disabled by build configuration");
+    }
+    const tracy = trace(@src());
+    defer tracy.end();
+
+    var hack_comp = comp;
+    if (comp.bin_file.options.emit) |emit| {
+        hack_comp.emit_asm = .{
+            .directory = emit.directory,
+            .basename = comp.bin_file.intermediary_basename.?,
+        };
+        hack_comp.bin_file.options.emit = null;
+    }
+
+    return try self.llvm_object.flushModule(hack_comp);
+}

--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -83,7 +83,8 @@ enum CallingConvention {
     CallingConventionAPCS,
     CallingConventionAAPCS,
     CallingConventionAAPCSVFP,
-    CallingConventionSysV
+    CallingConventionSysV,
+    CallingConventionPtxKernel
 };
 
 // Stage 1 supports only the generic address space

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -209,6 +209,11 @@ static ZigLLVM_CallingConv get_llvm_cc(CodeGen *g, CallingConvention cc) {
         case CallingConventionSysV:
             assert(g->zig_target->arch == ZigLLVM_x86_64);
             return ZigLLVM_X86_64_SysV;
+        case CallingConventionPtxKernel:
+            assert(g->zig_target->arch == ZigLLVM_nvptx ||
+                g->zig_target->arch == ZigLLVM_nvptx64);
+                return ZigLLVM_PTX_Kernel;
+
     }
     zig_unreachable();
 }
@@ -354,6 +359,7 @@ static bool cc_want_sret_attr(CallingConvention cc) {
         case CallingConventionAAPCS:
         case CallingConventionAAPCSVFP:
         case CallingConventionSysV:
+        case CallingConventionPtxKernel:
             return true;
         case CallingConventionAsync:
         case CallingConventionUnspecified:

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -11483,6 +11483,7 @@ static Stage1AirInst *ir_analyze_instruction_export(IrAnalyze *ira, Stage1ZirIns
                 case CallingConventionAAPCS:
                 case CallingConventionAAPCSVFP:
                 case CallingConventionSysV:
+                case CallingConventionPtxKernel:
                     add_fn_export(ira->codegen, fn_entry, buf_ptr(symbol_name), global_linkage_id, cc);
                     fn_entry->section_name = section_name;
                     break;


### PR DESCRIPTION
Nvptx aka [NVidia Parallel Thread Execution](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html) is a high-level assembly for Nvidia GPUs.
This PR aims to allow Stage 2 to generate this format, and therefore enable GPU programming in Zig.
This is a follow up on issue #10064 , and contains work presented at last [Zig Rush](https://youtu.be/rvfsWm6TckA?t=5351)

## Overview

To generate the .ptx file we leverage the Nvptx LLVM backend.
The main thing we need to do is to ask LLVM to produce the assembly instead of the binary.
That's why we have a custom Linker that just pass most function calls to LLVM. 
Only we intercept `flushModule` and modify the `Compilation` object to ask for assembly instead of binary.

In NVPTX functions that can be launched from the host (CPU) are named kernel and need to be declared as such.
For this LLVM expects the function to use the `PTX_Kernel` calling convention.
Therefore I added the `.PtxKernel`  calling convention to Zig (both Stage1 and Stage2)

The main trick here is that kernel need to be called from CPU code, so you want to be able to access the signature of the kernel from the CPU code. That's why I convert the calling convention `.PtxKernel` into `.Fast` when compiled for another target.
The function itself will still probably be impossible to compile, but at least the CPU code can import it.

## Help needed

I was only able to implement the CC conversion for stage1 using `get_llvm_cc`.
But in Stage2, implementing the equivalent in `toLlvmCallConv` doesn't work as expected because
it doesn't change the `.cc` attribute of the function. Is it possible ? Or is it a better place to do that ?
Right now I need to compile device code with Stage2 and host code with Stage1.

## Demo 

You can find sample code that leverage this PR here:

Kernel (compiled with stage2 for Nvptx target): https://github.com/gwenzek/cudaz/blob/4dd5a6b2eef966afa11135fbe286e51c1fe5056d/CS344/src/hw1_pure_kernel.zig#L5

Caller code (compiled with stage1 for : https://github.com/gwenzek/cudaz/blob/4dd5a6b2eef966afa11135fbe286e51c1fe5056d/CS344/src/hw1_pure.zig#L44

Note that PTX has a lot of intrinsics but for now I didn't need to add them to Zig language, because I can use Zig inline assembly to generate the corresponding PTX code directly.

Tagging @Snektron that helped me previously on this topic.