### PR TITLE
stage1: improve packed struct array padding error message

### DIFF
--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -1777,11 +1777,12 @@ static Error emit_error_unless_type_allowed_in_packed_container(CodeGen *g, ZigT
             if ((err = emit_error_unless_type_allowed_in_packed_container(g, elem_type, source_node, container_name)))
                 return err;
             // TODO revisit this when doing https://github.com/ziglang/zig/issues/1512
-            if (type_size(g, type_entry) * 8 == type_size_bits(g, type_entry))
-                return ErrorNone;
+            size_t abi_size_in_bits = type_size(g, type_entry) * 8;
+            size_t size_in_bits = type_size_bits(g, type_entry);
+            if (abi_size_in_bits == size_in_bits) return ErrorNone;
             add_node_error(g, source_node,
-                buf_sprintf("array of '%s' not allowed in packed %s due to padding bits",
-                    buf_ptr(&elem_type->name), container_name));
+                buf_sprintf("array of '%s' not allowed in packed %s due to padding bits (must be padded from %zu to %zu bits)",
+                    buf_ptr(&elem_type->name), container_name, size_in_bits, abi_size_in_bits));
             return ErrorSemanticAnalyzeFail;
         }
         case ZigTypeIdStruct:

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2995,7 +2995,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\};
     , &[_][]const u8{
         "tmp.zig:2:5: error: type 'anyerror' not allowed in packed struct; no guaranteed in-memory representation",
-        "tmp.zig:5:5: error: array of 'u24' not allowed in packed struct due to padding bits",
+        "tmp.zig:5:5: error: array of 'u24' not allowed in packed struct due to padding bits (must be padded from 48 to 64 bits)",
         "tmp.zig:8:5: error: type 'anyerror' not allowed in packed struct; no guaranteed in-memory representation",
         "tmp.zig:11:5: error: non-packed, non-extern struct 'S' not allowed in packed struct; no guaranteed in-memory representation",
         "tmp.zig:14:5: error: non-packed, non-extern struct 'U' not allowed in packed struct; no guaranteed in-memory representation",


### PR DESCRIPTION
I've been getting the `"array of 'Foo' not allowed in packed struct due to padding bits"` error message a bunch during development and usually end up adding a `@compileLog(@sizeOf(Foo), @bitSizeOf(Foo))` to my code before rerunning the compiler to have it tell me what it doesn't like. Given that the compiler has this information already I'm hoping we can expose it through the error message to begin with. Extremely indifferent to the wording of the hint (open to suggestions!), I'm just hoping to expose the two sizes.

(edit: failing CI test is same general OOM that is already failing at HEAD)