### PR TITLE
Add std.meta.Float(), inspired by std.meta.Int()

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -866,6 +866,19 @@ pub fn Int(comptime signedness: std.builtin.Signedness, comptime bit_count: u16)
     });
 }
 
+pub fn Float(comptime bit_count: u8) type {
+    return @Type(TypeInfo{
+        .Float = .{ .bits = bit_count },
+    });
+}
+
+test "std.meta.Float" {
+    try testing.expectEqual(f16, Float(16));
+    try testing.expectEqual(f32, Float(32));
+    try testing.expectEqual(f64, Float(64));
+    try testing.expectEqual(f128, Float(128));
+}
+
 pub fn Vector(comptime len: u32, comptime child: type) type {
     return @Type(TypeInfo{
         .Vector = .{


### PR DESCRIPTION
Add `std.meta.Float(bit_count)` as a convenient alternative to `@Type(.{ .Float = .{ .bits = bit_count } });` (needing to look up which fields are required by the `Float` type). This seems to fit naturally alongside `std.meta.Int(sign, bits)`.

If an unsupported number of bits is given this results in a compile error, e.g.: "error: 15-bit float unsupported".

Feel free to close if not a desirable addition.