### PR TITLE
use safe invalidation only in safe modes

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -182,11 +182,11 @@ pub const AtomicFile = struct {
     pub fn deinit(self: *AtomicFile) void {
         if (self.file_open) {
             self.file.close();
-            self.file_open = false;
+            self.file_open = if (std.debug.runtime_safety) false else undefined;
         }
         if (self.file_exists) {
             self.dir.deleteFile(&self.tmp_path_buf) catch {};
-            self.file_exists = false;
+            self.file_exists = if (std.debug.runtime_safety) false else undefined;
         }
         if (self.close_dir_on_deinit) {
             self.dir.close();

--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -125,7 +125,7 @@ pub const IO_Uring = struct {
         self.cq.deinit();
         self.sq.deinit();
         os.close(self.fd);
-        self.fd = -1;
+        self.fd = if (std.debug.runtime_safety) -1 else undefined;
     }
 
     /// Returns a pointer to a vacant SQE, or an error if the submission queue is full.


### PR DESCRIPTION
I found 2 cases in std where there are "safer" values than "undefined" when it comes invalidation.  I've modified those 2 cases to only do this when runtime_safety is enabled, so we can have the extra safety without paying the cost in release mode.

Note that setting values to `undefined` can aid in "optimize-ability".