### PR TITLE
File/Dir deinit invalidates, close doesn't

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1070,7 +1070,7 @@ pub const Builder = struct {
             warn("truncate {s}\n", .{dest_path});
         }
         const cwd = fs.cwd();
-        var src_file = cwd.createFile(dest_path, .{}) catch |err| switch (err) {
+        const src_file = cwd.createFile(dest_path, .{}) catch |err| switch (err) {
             error.FileNotFound => blk: {
                 if (fs.path.dirname(dest_path)) |dirname| {
                     try cwd.makePath(dirname);
@@ -2735,13 +2735,13 @@ pub const LibExeObjStep = struct {
             const build_output_dir = mem.trimRight(u8, output_dir_nl, "\r\n");
 
             if (self.output_dir) |output_dir| {
-                var src_dir = try std.fs.cwd().openDir(build_output_dir, .{ .iterate = true });
+                const src_dir = try std.fs.cwd().openDir(build_output_dir, .{ .iterate = true });
                 defer src_dir.close();
 
                 // Create the output directory if it doesn't exist.
                 try std.fs.cwd().makePath(output_dir);
 
-                var dest_dir = try std.fs.cwd().openDir(output_dir, .{});
+                const dest_dir = try std.fs.cwd().openDir(output_dir, .{});
                 defer dest_dir.close();
 
                 var it = src_dir.iterate();
@@ -2951,7 +2951,7 @@ pub const InstallDirStep = struct {
         const self = @fieldParentPtr(InstallDirStep, "step", step);
         const dest_prefix = self.builder.getInstallPath(self.options.install_dir, self.options.install_subdir);
         const full_src_dir = self.builder.pathFromRoot(self.options.source_dir);
-        var src_dir = try std.fs.cwd().openDir(full_src_dir, .{ .iterate = true });
+        const src_dir = try std.fs.cwd().openDir(full_src_dir, .{ .iterate = true });
         defer src_dir.close();
         var it = try src_dir.walk(self.builder.allocator);
         next_entry: while (try it.next()) |entry| {

--- a/lib/std/build/InstallRawStep.zig
+++ b/lib/std/build/InstallRawStep.zig
@@ -300,10 +300,10 @@ fn containsValidAddressRange(segments: []*BinaryElfSegment) bool {
 }
 
 fn emitRaw(allocator: *Allocator, elf_path: []const u8, raw_path: []const u8, format: RawFormat) !void {
-    var elf_file = try fs.cwd().openFile(elf_path, .{});
+    const elf_file = try fs.cwd().openFile(elf_path, .{});
     defer elf_file.close();
 
-    var out_file = try fs.cwd().createFile(raw_path, .{});
+    const out_file = try fs.cwd().createFile(raw_path, .{});
     defer out_file.close();
 
     var binary_elf_output = try BinaryElfOutput.parse(allocator, elf_file);

--- a/lib/std/build/WriteFileStep.zig
+++ b/lib/std/build/WriteFileStep.zig
@@ -94,7 +94,7 @@ fn make(step: *Step) !void {
         warn("unable to make path {s}: {s}\n", .{ self.output_dir, @errorName(err) });
         return err;
     };
-    var dir = try fs.cwd().openDir(self.output_dir, .{});
+    const dir = try fs.cwd().openDir(self.output_dir, .{});
     defer dir.close();
     {
         var it = self.files.first;

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -917,7 +917,7 @@ fn readMachODebugInfo(allocator: *mem.Allocator, macho_file: File) !ModuleDebugI
 fn printLineFromFileAnyOs(out_stream: anytype, line_info: LineInfo) !void {
     // Need this to always block even in async I/O mode, because this could potentially
     // be called from e.g. the event loop code crashing.
-    var f = try fs.cwd().openFile(line_info.file_name, .{ .intended_io_mode = .blocking });
+    const f = try fs.cwd().openFile(line_info.file_name, .{ .intended_io_mode = .blocking });
     defer f.close();
     // TODO fstat and make sure that the file has the correct size
 

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -189,6 +189,12 @@ pub const File = struct {
         }
     }
 
+    /// Close and invalidate the file.
+    pub fn deinit(self: *File) void {
+        self.close();
+        self.* = undefined;
+    }
+
     /// Test whether the file refers to a terminal.
     /// See also `supportsAnsiEscapeCodes`.
     pub fn isTty(self: File) bool {

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -24,7 +24,7 @@ test "write a file, read it, then delete it" {
     random.bytes(data[0..]);
     const tmp_file_name = "temp_test_file.txt";
     {
-        var file = try tmp.dir.createFile(tmp_file_name, .{});
+        const file = try tmp.dir.createFile(tmp_file_name, .{});
         defer file.close();
 
         var buf_stream = io.bufferedWriter(file.writer());
@@ -41,7 +41,7 @@ test "write a file, read it, then delete it" {
     }
 
     {
-        var file = try tmp.dir.openFile(tmp_file_name, .{});
+        const file = try tmp.dir.openFile(tmp_file_name, .{});
         defer file.close();
 
         const file_size = try file.getEndPos();
@@ -66,7 +66,7 @@ test "BitStreams with File Stream" {
 
     const tmp_file_name = "temp_test_file.txt";
     {
-        var file = try tmp.dir.createFile(tmp_file_name, .{});
+        const file = try tmp.dir.createFile(tmp_file_name, .{});
         defer file.close();
 
         var bit_stream = io.bitWriter(native_endian, file.writer());
@@ -80,7 +80,7 @@ test "BitStreams with File Stream" {
         try bit_stream.flushBits();
     }
     {
-        var file = try tmp.dir.openFile(tmp_file_name, .{});
+        const file = try tmp.dir.openFile(tmp_file_name, .{});
         defer file.close();
 
         var bit_stream = io.bitReader(native_endian, file.reader());
@@ -110,7 +110,7 @@ test "File seek ops" {
     defer tmp.cleanup();
 
     const tmp_file_name = "temp_test_file.txt";
-    var file = try tmp.dir.createFile(tmp_file_name, .{});
+    const file = try tmp.dir.createFile(tmp_file_name, .{});
     defer {
         file.close();
         tmp.dir.deleteFile(tmp_file_name) catch {};
@@ -137,7 +137,7 @@ test "setEndPos" {
     defer tmp.cleanup();
 
     const tmp_file_name = "temp_test_file.txt";
-    var file = try tmp.dir.createFile(tmp_file_name, .{});
+    const file = try tmp.dir.createFile(tmp_file_name, .{});
     defer {
         file.close();
         tmp.dir.deleteFile(tmp_file_name) catch {};
@@ -163,7 +163,7 @@ test "updateTimes" {
     defer tmp.cleanup();
 
     const tmp_file_name = "just_a_temporary_file.txt";
-    var file = try tmp.dir.createFile(tmp_file_name, .{ .read = true });
+    const file = try tmp.dir.createFile(tmp_file_name, .{ .read = true });
     defer {
         file.close();
         tmp.dir.deleteFile(tmp_file_name) catch {};

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -773,7 +773,7 @@ test "dup & dup2" {
     defer tmp.cleanup();
 
     {
-        var file = try tmp.dir.createFile("os_dup_test", .{});
+        const file = try tmp.dir.createFile("os_dup_test", .{});
         defer file.close();
 
         var duped = std.fs.File{ .handle = try std.os.dup(file.handle) };
@@ -788,7 +788,7 @@ test "dup & dup2" {
         try dup2ed.writeAll("dup2");
     }
 
-    var file = try tmp.dir.openFile("os_dup_test", .{});
+    const file = try tmp.dir.openFile("os_dup_test", .{});
     defer file.close();
 
     var buf: [7]u8 = undefined;
@@ -801,7 +801,7 @@ test "writev longer than IOV_MAX" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    var file = try tmp.dir.createFile("pwritev", .{});
+    const file = try tmp.dir.createFile("pwritev", .{});
     defer file.close();
 
     const iovecs = [_]os.iovec_const{.{ .iov_base = "a", .iov_len = 1 }} ** (os.IOV_MAX + 1);

--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -522,6 +522,7 @@ pub const Pdb = struct {
         self.in_file.close();
         self.allocator.free(self.modules);
         self.allocator.free(self.sect_contribs);
+        self.* = undefined;
     }
 
     pub fn parseDbiStream(self: *Pdb) !void {

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -859,7 +859,7 @@ pub const NativeTargetInfo = struct {
                     const rpath_list = mem.spanZ(std.meta.assumeSentinel(strtab[rpoff_usize..].ptr, 0));
                     var it = mem.tokenize(u8, rpath_list, ":");
                     while (it.next()) |rpath| {
-                        var dir = fs.cwd().openDir(rpath, .{}) catch |err| switch (err) {
+                        const dir = fs.cwd().openDir(rpath, .{}) catch |err| switch (err) {
                             error.NameTooLong => unreachable,
                             error.InvalidUtf8 => unreachable,
                             error.BadPathName => unreachable,

--- a/lib/std/zig/system/linux.zig
+++ b/lib/std/zig/system/linux.zig
@@ -446,7 +446,7 @@ fn CpuinfoParser(comptime impl: anytype) type {
 }
 
 pub fn detectNativeCpuAndFeatures() ?Target.Cpu {
-    var f = fs.openFileAbsolute("/proc/cpuinfo", .{ .intended_io_mode = .blocking }) catch |err| switch (err) {
+    const f = fs.openFileAbsolute("/proc/cpuinfo", .{ .intended_io_mode = .blocking }) catch |err| switch (err) {
         else => return null,
     };
     defer f.close();


### PR DESCRIPTION
Andrew has stated that Zig requires a way to close and invalidate a File.  These are my proposed changes to address that without requiring all `File` instances to be mutable. This PR provides that by adding the "deinit" function to File which will call "close" and then invalidate.  At the same time, I've modified Dir to use the same pattern, where deinit will close and invalidate whereas close will only release the OS resource.  Because Dir did not do this before, zig code was unable to use "const dir" but can now do so with this change.  I've gone through std looking for ".close(" calls and modified the respective Dir or File handles to be const when possible.  I also found a few places where tests were using mutable files, in those cases I modified them to call `deinit` to invalidate the file. To me this makes the code more readable because using const reduces the mental load when reading code.  When I see `var dir` or `var file` my brain makes a mental note that the code can modify the file handle, but with `const` I know it won't.