### PR TITLE
File.close invalidates

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -80,7 +80,7 @@ pub fn setName(self: Thread, name: []const u8) SetNameError!void {
             var buf: [32]u8 = undefined;
             const path = try std.fmt.bufPrint(&buf, "/proc/self/task/{d}/comm", .{self.getHandle()});
 
-            const file = try std.fs.cwd().openFile(path, .{ .write = true });
+            var file = try std.fs.cwd().openFile(path, .{ .write = true });
             defer file.close();
 
             try file.writer().writeAll(name);
@@ -168,7 +168,7 @@ pub fn getName(self: Thread, buffer_ptr: *[max_name_len:0]u8) GetNameError!?[]co
             var buf: [32]u8 = undefined;
             const path = try std.fmt.bufPrint(&buf, "/proc/self/task/{d}/comm", .{self.getHandle()});
 
-            const file = try std.fs.cwd().openFile(path, .{});
+            var file = try std.fs.cwd().openFile(path, .{});
             defer file.close();
 
             const data_len = try file.reader().readAll(buffer_ptr[0 .. max_name_len + 1]);

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -3129,7 +3129,7 @@ fn findVcpkgRoot(allocator: *Allocator) !?[]const u8 {
     const path_file = try fs.path.join(allocator, &[_][]const u8{ appdata_path, "vcpkg.path.txt" });
     defer allocator.free(path_file);
 
-    const file = fs.cwd().openFile(path_file, .{}) catch return null;
+    var file = fs.cwd().openFile(path_file, .{}) catch return null;
     defer file.close();
 
     const size = @intCast(usize, try file.getEndPos());

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -179,7 +179,7 @@ pub const File = struct {
 
     /// Upon success, the stream is in an uninitialized state. To continue using it,
     /// you must use the open() function.
-    pub fn close(self: File) void {
+    pub fn close(self: *File) void {
         if (is_windows) {
             windows.CloseHandle(self.handle);
         } else if (self.capable_io_mode != self.intended_io_mode) {
@@ -187,6 +187,7 @@ pub const File = struct {
         } else {
             os.close(self.handle);
         }
+        self.* = undefined;
     }
 
     /// Test whether the file refers to a terminal.

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -151,7 +151,7 @@ test "Dir.Iterator" {
     defer tmp_dir.cleanup();
 
     // First, create a couple of entries to iterate over.
-    const file = try tmp_dir.dir.createFile("some_file", .{});
+    var file = try tmp_dir.dir.createFile("some_file", .{});
     file.close();
 
     try tmp_dir.dir.makeDir("some_dir");
@@ -523,7 +523,7 @@ test "renameAbsolute" {
 test "openSelfExe" {
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
-    const self_exe_file = try std.fs.openSelfExe(.{});
+    var self_exe_file = try std.fs.openSelfExe(.{});
     self_exe_file.close();
 }
 
@@ -803,10 +803,10 @@ test "open file with exclusive nonblocking lock twice" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    const file1 = try tmp.dir.createFile(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
+    var file1 = try tmp.dir.createFile(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
     defer file1.close();
 
-    const file2 = tmp.dir.createFile(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
+    var file2 = tmp.dir.createFile(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
     try testing.expectError(error.WouldBlock, file2);
 }
 
@@ -818,10 +818,10 @@ test "open file with shared and exclusive nonblocking lock" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    const file1 = try tmp.dir.createFile(filename, .{ .lock = .Shared, .lock_nonblocking = true });
+    var file1 = try tmp.dir.createFile(filename, .{ .lock = .Shared, .lock_nonblocking = true });
     defer file1.close();
 
-    const file2 = tmp.dir.createFile(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
+    var file2 = tmp.dir.createFile(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
     try testing.expectError(error.WouldBlock, file2);
 }
 
@@ -833,10 +833,10 @@ test "open file with exclusive and shared nonblocking lock" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    const file1 = try tmp.dir.createFile(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
+    var file1 = try tmp.dir.createFile(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
     defer file1.close();
 
-    const file2 = tmp.dir.createFile(filename, .{ .lock = .Shared, .lock_nonblocking = true });
+    var file2 = tmp.dir.createFile(filename, .{ .lock = .Shared, .lock_nonblocking = true });
     try testing.expectError(error.WouldBlock, file2);
 }
 
@@ -853,12 +853,12 @@ test "open file with exclusive lock twice, make sure it waits" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    const file = try tmp.dir.createFile(filename, .{ .lock = .Exclusive });
+    var file = try tmp.dir.createFile(filename, .{ .lock = .Exclusive });
     errdefer file.close();
 
     const S = struct {
         fn checkFn(dir: *fs.Dir, evt: *std.Thread.ResetEvent) !void {
-            const file1 = try dir.createFile(filename, .{ .lock = .Exclusive });
+            var file1 = try dir.createFile(filename, .{ .lock = .Exclusive });
             defer file1.close();
             evt.set();
         }
@@ -892,9 +892,9 @@ test "open file with exclusive nonblocking lock twice (absolute paths)" {
     const filename = try fs.path.resolve(allocator, &file_paths);
     defer allocator.free(filename);
 
-    const file1 = try fs.createFileAbsolute(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
+    var file1 = try fs.createFileAbsolute(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
 
-    const file2 = fs.createFileAbsolute(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
+    var file2 = fs.createFileAbsolute(filename, .{ .lock = .Exclusive, .lock_nonblocking = true });
     file1.close();
     try testing.expectError(error.WouldBlock, file2);
 
@@ -962,13 +962,13 @@ test ". and .. in fs.Dir functions" {
     var created_subdir = try tmp.dir.openDir("./subdir", .{});
     created_subdir.close();
 
-    const created_file = try tmp.dir.createFile("./subdir/../file", .{});
+    var created_file = try tmp.dir.createFile("./subdir/../file", .{});
     created_file.close();
     try tmp.dir.access("./subdir/../file", .{});
 
     try tmp.dir.copyFile("./subdir/../file", tmp.dir, "./subdir/../copy", .{});
     try tmp.dir.rename("./subdir/../copy", "./subdir/../rename");
-    const renamed_file = try tmp.dir.openFile("./subdir/../rename", .{});
+    var renamed_file = try tmp.dir.openFile("./subdir/../rename", .{});
     renamed_file.close();
     try tmp.dir.deleteFile("./subdir/../rename");
 
@@ -1001,7 +1001,7 @@ test ". and .. in absolute functions" {
     created_subdir.close();
 
     const created_file_path = try fs.path.join(allocator, &[_][]const u8{ subdir_path, "../file" });
-    const created_file = try fs.createFileAbsolute(created_file_path, .{});
+    var created_file = try fs.createFileAbsolute(created_file_path, .{});
     created_file.close();
     try fs.accessAbsolute(created_file_path, .{});
 
@@ -1009,12 +1009,12 @@ test ". and .. in absolute functions" {
     try fs.copyFileAbsolute(created_file_path, copied_file_path, .{});
     const renamed_file_path = try fs.path.join(allocator, &[_][]const u8{ subdir_path, "../rename" });
     try fs.renameAbsolute(copied_file_path, renamed_file_path);
-    const renamed_file = try fs.openFileAbsolute(renamed_file_path, .{});
+    var renamed_file = try fs.openFileAbsolute(renamed_file_path, .{});
     renamed_file.close();
     try fs.deleteFileAbsolute(renamed_file_path);
 
     const update_file_path = try fs.path.join(allocator, &[_][]const u8{ subdir_path, "../update" });
-    const update_file = try fs.createFileAbsolute(update_file_path, .{});
+    var update_file = try fs.createFileAbsolute(update_file_path, .{});
     try update_file.writeAll("something");
     update_file.close();
     const prev_status = try fs.updateFileAbsolute(created_file_path, update_file_path, .{});
@@ -1030,7 +1030,7 @@ test "chmod" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    const file = try tmp.dir.createFile("test_file", .{ .mode = 0o600 });
+    var file = try tmp.dir.createFile("test_file", .{ .mode = 0o600 });
     defer file.close();
     try testing.expect((try file.stat()).mode & 0o7777 == 0o600);
 
@@ -1052,7 +1052,7 @@ test "chown" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    const file = try tmp.dir.createFile("test_file", .{});
+    var file = try tmp.dir.createFile("test_file", .{});
     defer file.close();
     try file.chown(null, null);
 

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1114,7 +1114,7 @@ fn linuxLookupNameFromHosts(
     family: os.sa_family_t,
     port: u16,
 ) !void {
-    const file = fs.openFileAbsoluteZ("/etc/hosts", .{}) catch |err| switch (err) {
+    var file = fs.openFileAbsoluteZ("/etc/hosts", .{}) catch |err| switch (err) {
         error.FileNotFound,
         error.NotDir,
         error.AccessDenied,
@@ -1313,7 +1313,7 @@ fn getResolvConf(allocator: *mem.Allocator, rc: *ResolvConf) !void {
     };
     errdefer rc.deinit();
 
-    const file = fs.openFileAbsoluteZ("/etc/resolv.conf", .{}) catch |err| switch (err) {
+    var file = fs.openFileAbsoluteZ("/etc/resolv.conf", .{}) catch |err| switch (err) {
         error.FileNotFound,
         error.NotDir,
         error.AccessDenied,

--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -1413,7 +1413,7 @@ test "writev/fsync/readv" {
     defer ring.deinit();
 
     const path = "test_io_uring_writev_fsync_readv";
-    const file = try std.fs.cwd().createFile(path, .{ .read = true, .truncate = true });
+    var file = try std.fs.cwd().createFile(path, .{ .read = true, .truncate = true });
     defer file.close();
     defer std.fs.cwd().deleteFile(path) catch {};
     const fd = file.handle;
@@ -1481,7 +1481,7 @@ test "write/read" {
     defer ring.deinit();
 
     const path = "test_io_uring_write_read";
-    const file = try std.fs.cwd().createFile(path, .{ .read = true, .truncate = true });
+    var file = try std.fs.cwd().createFile(path, .{ .read = true, .truncate = true });
     defer file.close();
     defer std.fs.cwd().deleteFile(path) catch {};
     const fd = file.handle;
@@ -1527,7 +1527,7 @@ test "write_fixed/read_fixed" {
     defer ring.deinit();
 
     const path = "test_io_uring_write_read_fixed";
-    const file = try std.fs.cwd().createFile(path, .{ .read = true, .truncate = true });
+    var file = try std.fs.cwd().createFile(path, .{ .read = true, .truncate = true });
     defer file.close();
     defer std.fs.cwd().deleteFile(path) catch {};
     const fd = file.handle;
@@ -1633,7 +1633,7 @@ test "close" {
     defer ring.deinit();
 
     const path = "test_io_uring_close";
-    const file = try std.fs.cwd().createFile(path, .{});
+    var file = try std.fs.cwd().createFile(path, .{});
     errdefer file.close();
     defer std.fs.cwd().deleteFile(path) catch {};
 
@@ -1914,7 +1914,7 @@ test "fallocate" {
     defer ring.deinit();
 
     const path = "test_io_uring_fallocate";
-    const file = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o666 });
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o666 });
     defer file.close();
     defer std.fs.cwd().deleteFile(path) catch {};
 
@@ -1958,7 +1958,7 @@ test "statx" {
     defer ring.deinit();
 
     const path = "test_io_uring_statx";
-    const file = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o666 });
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o666 });
     defer file.close();
     defer std.fs.cwd().deleteFile(path) catch {};
 

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -9,7 +9,7 @@ const fs = std.fs;
 
 test "fallocate" {
     const path = "test_fallocate";
-    const file = try fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o666 });
+    var file = try fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o666 });
     defer file.close();
     defer fs.cwd().deleteFile(path) catch {};
 

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -200,10 +200,10 @@ test "link with relative paths" {
     try cwd.writeFile("example.txt", "example");
     try os.link("example.txt", "new.txt", 0);
 
-    const efd = try cwd.openFile("example.txt", .{});
+    var efd = try cwd.openFile("example.txt", .{});
     defer efd.close();
 
-    const nfd = try cwd.openFile("new.txt", .{});
+    var nfd = try cwd.openFile("new.txt", .{});
     defer nfd.close();
 
     {
@@ -238,10 +238,10 @@ test "linkat with different directories" {
     try cwd.writeFile("example.txt", "example");
     try os.linkat(cwd.fd, "example.txt", tmp.dir.fd, "new.txt", 0);
 
-    const efd = try cwd.openFile("example.txt", .{});
+    var efd = try cwd.openFile("example.txt", .{});
     defer efd.close();
 
-    const nfd = try tmp.dir.openFile("new.txt", .{});
+    var nfd = try tmp.dir.openFile("new.txt", .{});
 
     {
         defer nfd.close();
@@ -274,7 +274,7 @@ test "fstatat" {
     try tmp.dir.writeFile("file.txt", contents);
 
     // fetch file's info on the opened fd directly
-    const file = try tmp.dir.openFile("file.txt", .{});
+    var file = try tmp.dir.openFile("file.txt", .{});
     const stat = try os.fstat(file.handle);
     defer file.close();
 
@@ -537,7 +537,7 @@ test "mmap" {
 
     // Create a file used for testing mmap() calls with a file descriptor
     {
-        const file = try tmp.dir.createFile(test_out_file, .{});
+        var file = try tmp.dir.createFile(test_out_file, .{});
         defer file.close();
 
         const stream = file.writer();
@@ -550,7 +550,7 @@ test "mmap" {
 
     // Map the whole file
     {
-        const file = try tmp.dir.openFile(test_out_file, .{});
+        var file = try tmp.dir.openFile(test_out_file, .{});
         defer file.close();
 
         const data = try os.mmap(
@@ -574,7 +574,7 @@ test "mmap" {
 
     // Map the upper half of the file
     {
-        const file = try tmp.dir.openFile(test_out_file, .{});
+        var file = try tmp.dir.openFile(test_out_file, .{});
         defer file.close();
 
         const data = try os.mmap(
@@ -616,7 +616,7 @@ test "fcntl" {
 
     const test_out_file = "os_tmp_test";
 
-    const file = try tmp.dir.createFile(test_out_file, .{});
+    var file = try tmp.dir.createFile(test_out_file, .{});
     defer {
         file.close();
         tmp.dir.deleteFile(test_out_file) catch {};
@@ -655,7 +655,7 @@ test "sync" {
     defer tmp.cleanup();
 
     const test_out_file = "os_tmp_test";
-    const file = try tmp.dir.createFile(test_out_file, .{});
+    var file = try tmp.dir.createFile(test_out_file, .{});
     defer {
         file.close();
         tmp.dir.deleteFile(test_out_file) catch {};
@@ -675,7 +675,7 @@ test "fsync" {
     defer tmp.cleanup();
 
     const test_out_file = "os_tmp_test";
-    const file = try tmp.dir.createFile(test_out_file, .{});
+    var file = try tmp.dir.createFile(test_out_file, .{});
     defer {
         file.close();
         tmp.dir.deleteFile(test_out_file) catch {};

--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -502,7 +502,7 @@ pub const Pdb = struct {
     };
 
     pub fn init(allocator: *mem.Allocator, path: []const u8) !Pdb {
-        const file = try fs.cwd().openFile(path, .{ .intended_io_mode = .blocking });
+        var file = try fs.cwd().openFile(path, .{ .intended_io_mode = .blocking });
         errdefer file.close();
 
         return Pdb{

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -555,7 +555,7 @@ pub const NativeTargetInfo = struct {
             return result;
         }
 
-        const env_file = std.fs.openFileAbsoluteZ("/usr/bin/env", .{}) catch |err| switch (err) {
+        var env_file = std.fs.openFileAbsoluteZ("/usr/bin/env", .{}) catch |err| switch (err) {
             error.NoSpaceLeft => unreachable,
             error.NameTooLong => unreachable,
             error.PathAlreadyExists => unreachable,

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -391,7 +391,7 @@ pub const Manifest = struct {
                 cache_hash_file.path = try self.cache.gpa.dupe(u8, file_path);
             }
 
-            const this_file = fs.cwd().openFile(cache_hash_file.path.?, .{ .read = true }) catch |err| switch (err) {
+            var this_file = fs.cwd().openFile(cache_hash_file.path.?, .{ .read = true }) catch |err| switch (err) {
                 error.FileNotFound => {
                     try self.upgradeToExclusiveLock();
                     return false;
@@ -478,7 +478,7 @@ pub const Manifest = struct {
     }
 
     fn populateFileHash(self: *Manifest, ch_file: *File) !void {
-        const file = try fs.cwd().openFile(ch_file.path.?, .{});
+        var file = try fs.cwd().openFile(ch_file.path.?, .{});
         defer file.close();
 
         ch_file.stat = try file.stat();
@@ -692,7 +692,7 @@ pub const Manifest = struct {
     /// `Manifest.hit` must be called first.
     /// Don't forget to call `writeManifest` before this!
     pub fn deinit(self: *Manifest) void {
-        if (self.manifest_file) |file| {
+        if (self.manifest_file) |*file| {
             file.close();
         }
         for (self.files.items) |*file| {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2498,7 +2498,7 @@ pub fn astGenFile(mod: *Module, file: *File) !void {
     const zir_dir = cache_directory.handle;
 
     var cache_file: ?std.fs.File = null;
-    defer if (cache_file) |f| f.close();
+    defer if (cache_file) |*f| f.close();
 
     // Determine whether we need to reload the file from disk and redo parsing and AstGen.
     switch (file.status) {
@@ -2652,7 +2652,7 @@ pub fn astGenFile(mod: *Module, file: *File) !void {
             log.debug("metadata changed: {s}", .{file.sub_file_path});
         },
     }
-    if (cache_file) |f| {
+    if (cache_file) |*f| {
         f.close();
         cache_file = null;
     }

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -896,7 +896,7 @@ pub fn buildSharedObjects(comp: *Compilation) !void {
         }
         // No need to write the manifest because there are no file inputs associated with this cache hash.
         // However we do need to write the ok file now.
-        if (o_directory.handle.createFile(ok_basename, .{})) |file| {
+        if (o_directory.handle.createFile(ok_basename, .{})) |*file| {
             file.close();
         } else |err| {
             std.log.warn("glibc shared objects: failed to mark completion: {s}", .{@errorName(err)});

--- a/src/introspect.zig
+++ b/src/introspect.zig
@@ -14,7 +14,7 @@ fn testZigInstallPrefix(base_dir: fs.Dir) ?Compilation.Directory {
         // Try lib/zig/std/std.zig
         const lib_zig = "lib" ++ fs.path.sep_str ++ "zig";
         var test_zig_dir = base_dir.openDir(lib_zig, .{}) catch break :zig_dir;
-        const file = test_zig_dir.openFile(test_index_file, .{}) catch {
+        var file = test_zig_dir.openFile(test_index_file, .{}) catch {
             test_zig_dir.close();
             break :zig_dir;
         };
@@ -24,7 +24,7 @@ fn testZigInstallPrefix(base_dir: fs.Dir) ?Compilation.Directory {
 
     // Try lib/std/std.zig
     var test_zig_dir = base_dir.openDir("lib", .{}) catch return null;
-    const file = test_zig_dir.openFile(test_index_file, .{}) catch {
+    var file = test_zig_dir.openFile(test_index_file, .{}) catch {
         test_zig_dir.close();
         return null;
     };

--- a/src/link.zig
+++ b/src/link.zig
@@ -316,7 +316,7 @@ pub const File = struct {
             .Exe => {},
         }
         switch (base.tag) {
-            .macho => if (base.file) |f| {
+            .macho => if (base.file) |*f| {
                 if (base.intermediary_basename != null) {
                     // The file we have open is not the final file that we want to
                     // make executable, so we don't have to close it.
@@ -338,7 +338,7 @@ pub const File = struct {
                 f.close();
                 base.file = null;
             },
-            .coff, .elf, .plan9 => if (base.file) |f| {
+            .coff, .elf, .plan9 => if (base.file) |*f| {
                 if (base.intermediary_basename != null) {
                     // The file we have open is not the final file that we want to
                     // make executable, so we don't have to close it.
@@ -470,7 +470,7 @@ pub const File = struct {
 
     pub fn destroy(base: *File) void {
         base.releaseLock();
-        if (base.file) |f| f.close();
+        if (base.file) |*f| f.close();
         if (base.intermediary_basename) |sub_path| base.allocator.free(sub_path);
         base.options.system_libs.deinit(base.allocator);
         switch (base.tag) {

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -53,7 +53,7 @@ pub fn openPath(gpa: *Allocator, sub_path: []const u8, options: link.Options) !*
     if (options.use_llvm) return error.LLVMHasNoCBackend;
     if (options.use_lld) return error.LLDHasNoCBackend;
 
-    const file = try options.emit.?.directory.handle.createFile(sub_path, .{
+    var file = try options.emit.?.directory.handle.createFile(sub_path, .{
         // Truncation is done on `flush`.
         .truncate = false,
         .mode = link.determineMode(options),
@@ -421,7 +421,7 @@ pub fn flushEmitH(module: *Module) !void {
     }
 
     const directory = emit_h.loc.directory orelse module.comp.local_cache_directory;
-    const file = try directory.handle.createFile(emit_h.loc.basename, .{
+    var file = try directory.handle.createFile(emit_h.loc.basename, .{
         // We set the end position explicitly below; by not truncating the file, we possibly
         // make it easier on the file system by doing 1 reallocation instead of two.
         .truncate = false,

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -136,7 +136,7 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
         return self;
     }
 
-    const file = try options.emit.?.directory.handle.createFile(sub_path, .{
+    var file = try options.emit.?.directory.handle.createFile(sub_path, .{
         .truncate = false,
         .read = true,
         .mode = link.determineMode(options),

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -239,7 +239,7 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
         return self;
     }
 
-    const file = try options.emit.?.directory.handle.createFile(sub_path, .{
+    var file = try options.emit.?.directory.handle.createFile(sub_path, .{
         .truncate = false,
         .read = true,
         .mode = link.determineMode(options),

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -287,7 +287,7 @@ pub fn openPath(allocator: *Allocator, options: link.Options) !*MachO {
         return createEmpty(allocator, options);
     }
     const emit = options.emit.?;
-    const file = try emit.directory.handle.createFile(emit.sub_path, .{
+    var file = try emit.directory.handle.createFile(emit.sub_path, .{
         .truncate = false,
         .read = true,
         .mode = link.determineMode(options),
@@ -1063,7 +1063,7 @@ fn resolveLib(
         const full_path = try fs.path.join(arena, &[_][]const u8{ dir, search_name });
 
         // Check if the file exists.
-        const tmp = fs.cwd().openFile(full_path, .{}) catch |err| switch (err) {
+        var tmp = fs.cwd().openFile(full_path, .{}) catch |err| switch (err) {
             error.FileNotFound => continue,
             else => |e| return e,
         };
@@ -1088,7 +1088,7 @@ fn resolveFramework(
         const full_path = try fs.path.join(arena, &[_][]const u8{ dir, prefix_path, search_name });
 
         // Check if the file exists.
-        const tmp = fs.cwd().openFile(full_path, .{}) catch |err| switch (err) {
+        var tmp = fs.cwd().openFile(full_path, .{}) catch |err| switch (err) {
             error.FileNotFound => continue,
             else => |e| return e,
         };
@@ -1101,7 +1101,7 @@ fn resolveFramework(
 }
 
 fn parseObject(self: *MachO, path: []const u8) !bool {
-    const file = fs.cwd().openFile(path, .{}) catch |err| switch (err) {
+    var file = fs.cwd().openFile(path, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => |e| return e,
     };
@@ -1129,7 +1129,7 @@ fn parseObject(self: *MachO, path: []const u8) !bool {
 }
 
 fn parseArchive(self: *MachO, path: []const u8) !bool {
-    const file = fs.cwd().openFile(path, .{}) catch |err| switch (err) {
+    var file = fs.cwd().openFile(path, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => |e| return e,
     };
@@ -1171,7 +1171,7 @@ const DylibCreateOpts = struct {
 };
 
 pub fn parseDylib(self: *MachO, path: []const u8, opts: DylibCreateOpts) ParseDylibError!bool {
-    const file = fs.cwd().openFile(path, .{}) catch |err| switch (err) {
+    var file = fs.cwd().openFile(path, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => |e| return e,
     };

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -625,7 +625,7 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
     if (options.use_llvm)
         return error.LLVMBackendDoesNotSupportPlan9;
     assert(options.object_format == .plan9);
-    const file = try options.emit.?.directory.handle.createFile(sub_path, .{
+    var file = try options.emit.?.directory.handle.createFile(sub_path, .{
         .read = true,
         .mode = link.determineMode(options),
     });

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -94,7 +94,7 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
     if (options.use_lld) return error.LLD_LinkingIsTODO_ForSpirV; // TODO: LLD Doesn't support SpirV at all.
 
     // TODO: read the file and keep valid parts instead of truncating
-    const file = try options.emit.?.directory.handle.createFile(sub_path, .{ .truncate = true, .read = true });
+    var file = try options.emit.?.directory.handle.createFile(sub_path, .{ .truncate = true, .read = true });
     errdefer file.close();
 
     const spirv = try createEmpty(allocator, options);

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -129,7 +129,7 @@ pub fn openPath(allocator: *Allocator, sub_path: []const u8, options: link.Optio
     }
 
     // TODO: read the file and keep valid parts instead of truncating
-    const file = try options.emit.?.directory.handle.createFile(sub_path, .{ .truncate = true, .read = true });
+    var file = try options.emit.?.directory.handle.createFile(sub_path, .{ .truncate = true, .read = true });
     errdefer file.close();
 
     const wasm_bin = try createEmpty(allocator, options);

--- a/src/main.zig
+++ b/src/main.zig
@@ -2797,7 +2797,7 @@ fn cmdTranslateC(comp: *Compilation, arena: *Allocator, enable_cache: bool) !voi
         return cleanExit();
     } else {
         const out_zig_path = try fs.path.join(arena, &[_][]const u8{ "o", &digest, translated_zig_basename });
-        const zig_file = comp.local_cache_directory.handle.openFile(out_zig_path, .{}) catch |err| {
+        var zig_file = comp.local_cache_directory.handle.openFile(out_zig_path, .{}) catch |err| {
             fatal("unable to open cached translated zig file '{s}{s}{s}': {s}", .{ comp.local_cache_directory.path, fs.path.sep_str, out_zig_path, @errorName(err) });
         };
         defer zig_file.close();
@@ -3542,7 +3542,7 @@ fn fmtPathFile(
     dir: fs.Dir,
     sub_path: []const u8,
 ) FmtError!void {
-    const source_file = try dir.openFile(sub_path, .{});
+    var source_file = try dir.openFile(sub_path, .{});
     var file_closed = false;
     errdefer if (!file_closed) source_file.close();
 

--- a/test/standalone/cat/main.zig
+++ b/test/standalone/cat/main.zig
@@ -25,7 +25,7 @@ pub fn main() !void {
         } else if (mem.startsWith(u8, arg, "-")) {
             return usage(exe);
         } else {
-            const file = cwd.openFile(arg, .{}) catch |err| {
+            var file = cwd.openFile(arg, .{}) catch |err| {
                 warn("Unable to open file: {s}\n", .{@errorName(err)});
                 return err;
             };

--- a/tools/update_glibc.zig
+++ b/tools/update_glibc.zig
@@ -237,7 +237,7 @@ pub fn main() !void {
     };
     {
         const vers_txt_path = try fs.path.join(allocator, &[_][]const u8{ glibc_out_dir, "vers.txt" });
-        const vers_txt_file = try fs.cwd().createFile(vers_txt_path, .{});
+        var vers_txt_file = try fs.cwd().createFile(vers_txt_path, .{});
         defer vers_txt_file.close();
         var buffered = std.io.bufferedWriter(vers_txt_file.writer());
         const vers_txt = buffered.writer();
@@ -249,7 +249,7 @@ pub fn main() !void {
     }
     {
         const fns_txt_path = try fs.path.join(allocator, &[_][]const u8{ glibc_out_dir, "fns.txt" });
-        const fns_txt_file = try fs.cwd().createFile(fns_txt_path, .{});
+        var fns_txt_file = try fs.cwd().createFile(fns_txt_path, .{});
         defer fns_txt_file.close();
         var buffered = std.io.bufferedWriter(fns_txt_file.writer());
         const fns_txt = buffered.writer();
@@ -280,7 +280,7 @@ pub fn main() !void {
 
     {
         const abilist_txt_path = try fs.path.join(allocator, &[_][]const u8{ glibc_out_dir, "abi.txt" });
-        const abilist_txt_file = try fs.cwd().createFile(abilist_txt_path, .{});
+        var abilist_txt_file = try fs.cwd().createFile(abilist_txt_path, .{});
         defer abilist_txt_file.close();
         var buffered = std.io.bufferedWriter(abilist_txt_file.writer());
         const abilist_txt = buffered.writer();


### PR DESCRIPTION
This change is the polar opposite of https://github.com/ziglang/zig/pull/10213 but one that Andrew has expressed he would like.  Instead of providing 2 ways to cleanup a file (one that invalidates and one that doesn't), this PR modifies `File.close` to always invalidate.  Note this is a breaking change that now requires all instances of `File` that you want to close to be mutable.  This means no more `const file = `, you must always use `var file =`.  I've argued this reduces code readability, but that's my opinion, you can see for yourselves whether or not you agree and whether it would justify a second way to cleanup files (i.e. adding a `closeConst` for const files).

Also note that if we start requiring files to be mutable, we will be introducing "ownership" semantics to `File`.  Namely, passing a `File` by value vs by reference has a new meaning, and having a `File` field as a value or a reference has new meaning.  This adds complexity to how `File` is interpreted that doesn't exist today with immutable instances of `File`.