### PR TITLE
macos: improved SDK detection and linker integration with _mh_execute_header

### DIFF
--- a/lib/std/zig/system/darwin.zig
+++ b/lib/std/zig/system/darwin.zig
@@ -2,14 +2,15 @@ const std = @import("std");
 const mem = std.mem;
 const Allocator = mem.Allocator;
 const Target = std.Target;
+const Version = std.builtin.Version;
 
 pub const macos = @import("darwin/macos.zig");
 
-/// Detect SDK path on Darwin.
-/// Calls `xcrun --sdk <target_sdk> --show-sdk-path` which result can be used to specify
-/// `--sysroot` of the compiler.
-/// The caller needs to free the resulting path slice.
-pub fn getSDKPath(allocator: *Allocator, target: Target) !?[]u8 {
+/// Detect SDK on Darwin.
+/// Calls `xcrun --sdk <target_sdk> --show-sdk-path` which fetches the path to the SDK sysroot (if any).
+/// Subsequently calls `xcrun --sdk <target_sdk> --show-sdk-version` which fetches version of the SDK.
+/// The caller needs to deinit the resulting struct.
+pub fn getDarwinSDK(allocator: *Allocator, target: Target) !?DarwinSDK {
     const is_simulator_abi = target.abi == .simulator;
     const sdk = switch (target.os.tag) {
         .macos => "macosx",
@@ -18,21 +19,54 @@ pub fn getSDKPath(allocator: *Allocator, target: Target) !?[]u8 {
         .tvos => if (is_simulator_abi) "appletvsimulator" else "appletvos",
         else => return null,
     };
-
-    const argv = &[_][]const u8{ "xcrun", "--sdk", sdk, "--show-sdk-path" };
-    const result = try std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv });
-    defer {
-        allocator.free(result.stderr);
-        allocator.free(result.stdout);
-    }
-    if (result.stderr.len != 0 or result.term.Exited != 0) {
-        // We don't actually care if there were errors as this is best-effort check anyhow
-        // and in the worst case the user can specify the sysroot manually.
-        return null;
-    }
-    const sysroot = try allocator.dupe(u8, mem.trimRight(u8, result.stdout, "\r\n"));
-    return sysroot;
+    const path = path: {
+        const argv = &[_][]const u8{ "xcrun", "--sdk", sdk, "--show-sdk-path" };
+        const result = try std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv });
+        defer {
+            allocator.free(result.stderr);
+            allocator.free(result.stdout);
+        }
+        if (result.stderr.len != 0 or result.term.Exited != 0) {
+            // We don't actually care if there were errors as this is best-effort check anyhow
+            // and in the worst case the user can specify the sysroot manually.
+            return null;
+        }
+        const path = try allocator.dupe(u8, mem.trimRight(u8, result.stdout, "\r\n"));
+        break :path path;
+    };
+    const version = version: {
+        const argv = &[_][]const u8{ "xcrun", "--sdk", sdk, "--show-sdk-version" };
+        const result = try std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv });
+        defer {
+            allocator.free(result.stderr);
+            allocator.free(result.stdout);
+        }
+        if (result.stderr.len != 0 or result.term.Exited != 0) {
+            // We don't actually care if there were errors as this is best-effort check anyhow
+            // and in the worst case the user can specify the sysroot manually.
+            return null;
+        }
+        const raw_version = mem.trimRight(u8, result.stdout, "\r\n");
+        const version = Version.parse(raw_version) catch Version{
+            .major = 0,
+            .minor = 0,
+        };
+        break :version version;
+    };
+    return DarwinSDK{
+        .path = path,
+        .version = version,
+    };
 }
+
+pub const DarwinSDK = struct {
+    path: []const u8,
+    version: Version,
+
+    pub fn deinit(self: DarwinSDK, allocator: *Allocator) void {
+        allocator.free(self.path);
+    }
+};
 
 test "" {
     _ = @import("darwin/macos.zig");

--- a/lib/std/zig/system/darwin.zig
+++ b/lib/std/zig/system/darwin.zig
@@ -6,11 +6,30 @@ const Version = std.builtin.Version;
 
 pub const macos = @import("darwin/macos.zig");
 
+/// Check if SDK is installed on Darwin without triggering CLT installation popup window.
+/// Note: simply invoking `xcrun` will inevitably trigger the CLT installation popup.
+/// Therefore, we resort to the same tool used by Homebrew, namely, invoking `xcode-select --print-path`
+/// and checking if the status is nonzero or the returned string in nonempty.
+/// https://github.com/Homebrew/brew/blob/e119bdc571dcb000305411bc1e26678b132afb98/Library/Homebrew/brew.sh#L630
+pub fn isDarwinSDKInstalled(allocator: *Allocator) bool {
+    const argv = &[_][]const u8{ "/usr/bin/xcode-select", "--print-path" };
+    const result = std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv }) catch return false;
+    defer {
+        allocator.free(result.stderr);
+        allocator.free(result.stdout);
+    }
+    if (result.stderr.len != 0 or result.term.Exited != 0) {
+        // We don't actually care if there were errors as this is best-effort check anyhow.
+        return false;
+    }
+    return result.stdout.len > 0;
+}
+
 /// Detect SDK on Darwin.
 /// Calls `xcrun --sdk <target_sdk> --show-sdk-path` which fetches the path to the SDK sysroot (if any).
 /// Subsequently calls `xcrun --sdk <target_sdk> --show-sdk-version` which fetches version of the SDK.
 /// The caller needs to deinit the resulting struct.
-pub fn getDarwinSDK(allocator: *Allocator, target: Target) !?DarwinSDK {
+pub fn getDarwinSDK(allocator: *Allocator, target: Target) ?DarwinSDK {
     const is_simulator_abi = target.abi == .simulator;
     const sdk = switch (target.os.tag) {
         .macos => "macosx",
@@ -20,8 +39,8 @@ pub fn getDarwinSDK(allocator: *Allocator, target: Target) !?DarwinSDK {
         else => return null,
     };
     const path = path: {
-        const argv = &[_][]const u8{ "xcrun", "--sdk", sdk, "--show-sdk-path" };
-        const result = try std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv });
+        const argv = &[_][]const u8{ "/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path" };
+        const result = std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv }) catch return null;
         defer {
             allocator.free(result.stderr);
             allocator.free(result.stdout);
@@ -31,12 +50,12 @@ pub fn getDarwinSDK(allocator: *Allocator, target: Target) !?DarwinSDK {
             // and in the worst case the user can specify the sysroot manually.
             return null;
         }
-        const path = try allocator.dupe(u8, mem.trimRight(u8, result.stdout, "\r\n"));
+        const path = allocator.dupe(u8, mem.trimRight(u8, result.stdout, "\r\n")) catch return null;
         break :path path;
     };
     const version = version: {
-        const argv = &[_][]const u8{ "xcrun", "--sdk", sdk, "--show-sdk-version" };
-        const result = try std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv });
+        const argv = &[_][]const u8{ "/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-version" };
+        const result = std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv }) catch return null;
         defer {
             allocator.free(result.stderr);
             allocator.free(result.stdout);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -773,6 +773,8 @@ pub const InitOptions = struct {
     wasi_exec_model: ?std.builtin.WasiExecModel = null,
     /// (Zig compiler development) Enable dumping linker's state as JSON.
     enable_link_snapshots: bool = false,
+    /// (Darwin). Path to native macOS SDK if detected.
+    native_macos_sdk_path: ?[]const u8 = null,
 };
 
 fn addPackageTableToCacheHash(
@@ -962,18 +964,11 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
             break :blk false;
         };
 
-        const darwin_use_system_sdk = blk: {
-            if (comptime !builtin.target.isDarwin()) break :blk false;
-            if (!options.is_native_os) break :blk false;
-            if (builtin.os.tag != .macos or !options.target.isDarwin()) break :blk false;
-            break :blk options.frameworks.len > 0 or options.framework_dirs.len > 0;
-        };
-
         const sysroot = blk: {
             if (options.sysroot) |sysroot| {
                 break :blk sysroot;
-            } else if (darwin_use_system_sdk) {
-                break :blk try std.zig.system.darwin.getSDKPath(arena, options.target);
+            } else if (options.native_macos_sdk_path) |sdk_path| {
+                break :blk sdk_path;
             } else {
                 break :blk null;
             }
@@ -1060,6 +1055,7 @@ pub fn create(gpa: *Allocator, options: InitOptions) !*Compilation {
             link_libc,
             options.system_lib_names.len != 0 or options.frameworks.len != 0,
             options.libc_installation,
+            options.native_macos_sdk_path != null,
         );
 
         const must_pie = target_util.requiresPIE(options.target);
@@ -3776,6 +3772,37 @@ const LibCDirs = struct {
     libc_installation: ?*const LibCInstallation,
 };
 
+fn getZigShippedLibCIncludeDirsDarwin(arena: *Allocator, zig_lib_dir: []const u8, target: Target) !LibCDirs {
+    const arch_name = @tagName(target.cpu.arch);
+    const os_name = try std.fmt.allocPrint(arena, "{s}.{d}", .{
+        @tagName(target.os.tag),
+        target.os.version_range.semver.min.major,
+    });
+    const s = std.fs.path.sep_str;
+    const list = try arena.alloc([]const u8, 3);
+
+    list[0] = try std.fmt.allocPrint(
+        arena,
+        "{s}" ++ s ++ "libc" ++ s ++ "include" ++ s ++ "{s}-{s}-gnu",
+        .{ zig_lib_dir, arch_name, os_name },
+    );
+    list[1] = try std.fmt.allocPrint(
+        arena,
+        "{s}" ++ s ++ "libc" ++ s ++ "include" ++ s ++ "any-{s}-any",
+        .{ zig_lib_dir, os_name },
+    );
+    list[2] = try std.fmt.allocPrint(
+        arena,
+        "{s}" ++ s ++ "libc" ++ s ++ "include" ++ s ++ "any-macos-any",
+        .{zig_lib_dir},
+    );
+
+    return LibCDirs{
+        .libc_include_dir_list = list,
+        .libc_installation = null,
+    };
+}
+
 fn detectLibCIncludeDirs(
     arena: *Allocator,
     zig_lib_dir: []const u8,
@@ -3784,6 +3811,7 @@ fn detectLibCIncludeDirs(
     link_libc: bool,
     link_system_libs: bool,
     libc_installation: ?*const LibCInstallation,
+    has_macos_sdk: bool,
 ) !LibCDirs {
     if (!link_libc) {
         return LibCDirs{
@@ -3800,11 +3828,14 @@ fn detectLibCIncludeDirs(
     // using the system libc installation.
     if (link_system_libs and is_native_abi and !target.isMinGW()) {
         if (target.isDarwin()) {
-            // For Darwin/macOS, we are all set with getSDKPath found earlier.
-            return LibCDirs{
-                .libc_include_dir_list = &[0][]u8{},
-                .libc_installation = null,
-            };
+            return if (has_macos_sdk)
+                // For Darwin/macOS, we are all set with getSDKPath found earlier.
+                LibCDirs{
+                    .libc_include_dir_list = &[0][]u8{},
+                    .libc_installation = null,
+                }
+            else
+                getZigShippedLibCIncludeDirsDarwin(arena, zig_lib_dir, target);
         }
         const libc = try arena.create(LibCInstallation);
         libc.* = try LibCInstallation.findNative(.{ .allocator = arena, .verbose = true });
@@ -3815,36 +3846,7 @@ fn detectLibCIncludeDirs(
     // default if possible.
     if (target_util.canBuildLibC(target)) {
         switch (target.os.tag) {
-            .macos => {
-                const arch_name = @tagName(target.cpu.arch);
-                const os_name = try std.fmt.allocPrint(arena, "{s}.{d}", .{
-                    @tagName(target.os.tag),
-                    target.os.version_range.semver.min.major,
-                });
-                const s = std.fs.path.sep_str;
-                const list = try arena.alloc([]const u8, 3);
-
-                list[0] = try std.fmt.allocPrint(
-                    arena,
-                    "{s}" ++ s ++ "libc" ++ s ++ "include" ++ s ++ "{s}-{s}-gnu",
-                    .{ zig_lib_dir, arch_name, os_name },
-                );
-                list[1] = try std.fmt.allocPrint(
-                    arena,
-                    "{s}" ++ s ++ "libc" ++ s ++ "include" ++ s ++ "any-{s}-any",
-                    .{ zig_lib_dir, os_name },
-                );
-                list[2] = try std.fmt.allocPrint(
-                    arena,
-                    "{s}" ++ s ++ "libc" ++ s ++ "include" ++ s ++ "any-macos-any",
-                    .{zig_lib_dir},
-                );
-
-                return LibCDirs{
-                    .libc_include_dir_list = list,
-                    .libc_installation = null,
-                };
-            },
+            .macos => return getZigShippedLibCIncludeDirsDarwin(arena, zig_lib_dir, target),
             else => {
                 const generic_name = target_util.libCGenericName(target);
                 // Some architectures are handled by the same set of headers.

--- a/src/link.zig
+++ b/src/link.zig
@@ -153,6 +153,9 @@ pub const Options = struct {
     /// (Zig compiler development) Enable dumping of linker's state as JSON.
     enable_link_snapshots: bool = false,
 
+    /// (Darwin) Path and version of the native SDK if detected.
+    native_darwin_sdk: ?std.zig.system.darwin.DarwinSDK = null,
+
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -663,7 +663,7 @@ fn buildOutputType(
     var minor_subsystem_version: ?u32 = null;
     var wasi_exec_model: ?std.builtin.WasiExecModel = null;
     var enable_link_snapshots: bool = false;
-    var native_macos_sdk_path: ?[]const u8 = null;
+    var native_darwin_sdk: ?std.zig.system.darwin.DarwinSDK = null;
 
     var system_libs = std.StringArrayHashMap(Compilation.SystemLib).init(gpa);
     defer system_libs.deinit();
@@ -1858,11 +1858,11 @@ fn buildOutputType(
         }
 
         const has_sysroot = if (comptime builtin.target.isDarwin()) outer: {
-            if (try std.zig.system.darwin.getSDKPath(arena, target_info.target)) |sdk_path| {
-                native_macos_sdk_path = sdk_path;
+            if (try std.zig.system.darwin.getDarwinSDK(arena, target_info.target)) |sdk| {
+                native_darwin_sdk = sdk;
                 try clang_argv.ensureUnusedCapacity(2);
                 clang_argv.appendAssumeCapacity("-isysroot");
-                clang_argv.appendAssumeCapacity(sdk_path);
+                clang_argv.appendAssumeCapacity(sdk.path);
                 break :outer true;
             } else break :outer false;
         } else false;
@@ -2342,7 +2342,7 @@ fn buildOutputType(
         .wasi_exec_model = wasi_exec_model,
         .debug_compile_errors = debug_compile_errors,
         .enable_link_snapshots = enable_link_snapshots,
-        .native_macos_sdk_path = native_macos_sdk_path,
+        .native_darwin_sdk = native_darwin_sdk,
     }) catch |err| {
         fatal("unable to create compilation: {s}", .{@errorName(err)});
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -1858,7 +1858,9 @@ fn buildOutputType(
         }
 
         const has_sysroot = if (comptime builtin.target.isDarwin()) outer: {
-            if (try std.zig.system.darwin.getDarwinSDK(arena, target_info.target)) |sdk| {
+            if (std.zig.system.darwin.isDarwinSDKInstalled(arena)) {
+                const sdk = std.zig.system.darwin.getDarwinSDK(arena, target_info.target) orelse
+                    break :outer false;
                 native_darwin_sdk = sdk;
                 try clang_argv.ensureUnusedCapacity(2);
                 clang_argv.appendAssumeCapacity("-isysroot");

--- a/src/main.zig
+++ b/src/main.zig
@@ -663,6 +663,7 @@ fn buildOutputType(
     var minor_subsystem_version: ?u32 = null;
     var wasi_exec_model: ?std.builtin.WasiExecModel = null;
     var enable_link_snapshots: bool = false;
+    var native_macos_sdk_path: ?[]const u8 = null;
 
     var system_libs = std.StringArrayHashMap(Compilation.SystemLib).init(gpa);
     defer system_libs.deinit();
@@ -1858,6 +1859,7 @@ fn buildOutputType(
 
         const has_sysroot = if (comptime builtin.target.isDarwin()) outer: {
             if (try std.zig.system.darwin.getSDKPath(arena, target_info.target)) |sdk_path| {
+                native_macos_sdk_path = sdk_path;
                 try clang_argv.ensureUnusedCapacity(2);
                 clang_argv.appendAssumeCapacity("-isysroot");
                 clang_argv.appendAssumeCapacity(sdk_path);
@@ -2340,6 +2342,7 @@ fn buildOutputType(
         .wasi_exec_model = wasi_exec_model,
         .debug_compile_errors = debug_compile_errors,
         .enable_link_snapshots = enable_link_snapshots,
+        .native_macos_sdk_path = native_macos_sdk_path,
     }) catch |err| {
         fatal("unable to create compilation: {s}", .{@errorName(err)});
     };


### PR DESCRIPTION
~~If Zig didn't detect native SDK, always use shipped libc headers when targeting macOS.~~

~~Fixes #10217~~

~~cc @slimsag~~

EDIT: Turns out this PR leads naturally to a fix of another long-standing issue, so I've now converged the two, one on top of the other.

Changes / fixes:
* always use Zig shipped libc headers when no native SDK - if Zig didn't detect native SDK, always use shipped libc headers when targeting macOS - fixes #10217 
* extract native SDK path *and* version info, and route that info all the way to the linker so that it can correctly populate `LC_BUILD_VERSION` load command
* fix version info encoded as part of `LC_BUILD_VERSION` load command - Apple strips off patch info from platform and SDK version info - without this, non-Zig tools may complain that the there's a mismatch between OS and platform as reported in #1982 
* define `__mh_execute_header` as a linker synthetic global symbol - fixes #1982 
* EDIT2: add a helper `std.zig.system.darwin.isDarwinSDKInstalled` which checks for the presence of the SDK tooling without triggering the CLT installation popup - I believe this is a much better UX on a bare macOS system

cc @andrewrk @slimsag 