### PR TITLE
std.system: fix slice bounds in preadMin()

### DIFF
--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -922,7 +922,7 @@ pub const NativeTargetInfo = struct {
     fn preadMin(file: fs.File, buf: []u8, offset: u64, min_read_len: usize) !usize {
         var i: usize = 0;
         while (i < min_read_len) {
-            const len = file.pread(buf[i .. buf.len - i], offset + i) catch |err| switch (err) {
+            const len = file.pread(buf[i..], offset + i) catch |err| switch (err) {
                 error.OperationAborted => unreachable, // Windows-only
                 error.WouldBlock => unreachable, // Did not request blocking mode
                 error.NotOpenForReading => unreachable,


### PR DESCRIPTION
If a partial read occurs past the halfway point, buf.len - i will be
less than i, which is illegal. The end bound is also entirely unecessary
in this case, so just remove it.

Thanks to @sheeldotme for reporting this on IRC and providing this stack trace: https://gist.githubusercontent.com/sheeldotme/825d1c0414cb34ce2c2e35f49f866049/raw/90b7e7c0f371495b6a5f382e45581012ae07829a/log.txt