### PR TITLE
libstd: handle all rmdirZ syscall errors (#10145)

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2562,7 +2562,7 @@ pub fn rmdirZ(dir_path: [*:0]const u8) DeleteDirError!void {
         .PERM => return error.AccessDenied,
         .BUSY => return error.FileBusy,
         .FAULT => unreachable,
-        .INVAL => unreachable,
+        .INVAL => return error.BadPathName,
         .LOOP => return error.SymLinkLoop,
         .NAMETOOLONG => return error.NameTooLong,
         .NOENT => return error.FileNotFound,


### PR DESCRIPTION
Both FAULT and INVAL were marked unreachable which prevents handling
of the error at a higher level.

It seems like they should map to BadPathError based on the man page for
rmdir (and an incomplete understanding of DeleteDirError), which says:

```
EFAULT pathname points outside your accessible address space.
EINVAL pathname has .  as last component.
```