### PR TITLE
Force static libncurses in CMakeLists when static zig on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,10 @@ endif()
 
 if(APPLE AND ZIG_STATIC)
     list(REMOVE_ITEM LLVM_LIBRARIES "-lcurses")
-    find_library(CURSES NAMES libcurses.a curses libcurses libncurses.a ncurses libncurses)
+    find_library(CURSES NAMES libcurses.a libncurses.a
+      PATHS
+        /usr/local/opt/ncurses/lib
+        /opt/homebrew/opt/ncurses/lib)
     list(APPEND LLVM_LIBRARIES "${CURSES}")
 endif()
 

--- a/ci/azure/macos_arm64_script
+++ b/ci/azure/macos_arm64_script
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-brew update && brew install s3cmd
+brew update && brew install ncurses s3cmd
 
 ZIGDIR="$(pwd)"
 

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-brew update && brew install s3cmd
+brew update && brew install ncurses s3cmd
 
 ZIGDIR="$(pwd)"
 ARCH="x86_64"


### PR DESCRIPTION
Add additional search paths pointing at homebrew prefixes as Apple
doesn't ship a static libncurses for linking - only a stub for dynamic
linking `libncurses.tbd`.

Fixes #7428 