### PR TITLE
Stage2: wasm - Implement 'zig test'

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -30,6 +30,8 @@ comptime {
                 }
             } else if (builtin.os.tag == .windows) {
                 @export(wWinMainCRTStartup2, .{ .name = "wWinMainCRTStartup" });
+            } else if (builtin.os.tag == .wasi) {
+                @export(wasmMain2, .{ .name = "_start" });
             } else {
                 if (!@hasDecl(root, "_start")) {
                     @export(_start2, .{ .name = "_start" });
@@ -96,6 +98,11 @@ fn callMain2() noreturn {
     @setAlignStack(16);
     root.main();
     exit2(0);
+}
+
+fn wasmMain2() u8 {
+    root.main();
+    return 0;
 }
 
 fn wWinMainCRTStartup2() callconv(.C) noreturn {

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -101,8 +101,19 @@ fn callMain2() noreturn {
 }
 
 fn wasmMain2() u8 {
-    root.main();
-    return 0;
+    switch (@typeInfo(@typeInfo(@TypeOf(root.main)).Fn.return_type.?)) {
+        .Void => {
+            root.main();
+            return 0;
+        },
+        .Int => |info| {
+            if (info.bits != 8 or info.signedness == .signed) {
+                @compileError(bad_main_ret);
+            }
+            return root.main();
+        },
+        else => @compileError("Bad return type main"),
+    }
 }
 
 fn wWinMainCRTStartup2() callconv(.C) noreturn {

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -30,7 +30,7 @@ comptime {
                 }
             } else if (builtin.os.tag == .windows) {
                 @export(wWinMainCRTStartup2, .{ .name = "wWinMainCRTStartup" });
-            } else if (builtin.os.tag == .wasi) {
+            } else if (builtin.os.tag == .wasi and @hasDecl(root, "main")) {
                 @export(wasmMain2, .{ .name = "_start" });
             } else {
                 if (!@hasDecl(root, "_start")) {

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -812,7 +812,7 @@ pub fn genFunc(self: *Self) InnerError!Result {
 /// Generates the wasm bytecode for the declaration belonging to `Context`
 pub fn genDecl(self: *Self, ty: Type, val: Value) InnerError!Result {
     if (val.isUndef()) {
-        try self.code.appendNTimes(0xaa, ty.abiSize(self.target));
+        try self.code.appendNTimes(0xaa, @intCast(usize, ty.abiSize(self.target)));
         return Result.appended;
     }
     switch (ty.zigTypeTag()) {
@@ -833,7 +833,7 @@ pub fn genDecl(self: *Self, ty: Type, val: Value) InnerError!Result {
                 } else if (!val.isNull()) {
                     return try self.genDecl(payload_type, val);
                 } else {
-                    try self.code.appendNTimes(0, ty.abiSize(self.target));
+                    try self.code.appendNTimes(0, @intCast(usize, ty.abiSize(self.target)));
                     return Result.appended;
                 }
             }
@@ -882,7 +882,7 @@ pub fn genDecl(self: *Self, ty: Type, val: Value) InnerError!Result {
         },
         .Int => {
             const info = ty.intInfo(self.target);
-            const abi_size = ty.abiSize(self.target);
+            const abi_size = @intCast(usize, ty.abiSize(self.target));
             // todo: Implement integer sizes larger than 64bits
             if (info.bits > 64) return self.fail("TODO: Implement genDecl for integer bit size: {d}", .{info.bits});
             var buf: [8]u8 = undefined;
@@ -916,8 +916,8 @@ pub fn genDecl(self: *Self, ty: Type, val: Value) InnerError!Result {
         },
         .Union => {
             // TODO: Implement Union declarations
-            const abi_size = ty.abiSize(self.target);
-            try self.code.writer().writeByteNTimes(0xaa, abi_size);
+            const abi_size = @intCast(usize, ty.abiSize(self.target));
+            try self.code.appendNTimes(0xaa, abi_size);
             return Result.appended;
         },
         .Pointer => switch (val.tag()) {
@@ -973,7 +973,7 @@ fn lowerDeclRef(self: *Self, decl: *Module.Decl) InnerError!Result {
             .relocation_type = .R_WASM_MEMORY_ADDR_I32,
         });
     }
-    const ptr_width = self.target.cpu.arch.ptrBitWidth() / 8;
+    const ptr_width = @intCast(usize, self.target.cpu.arch.ptrBitWidth() / 8);
     try self.code.appendNTimes(0xaa, ptr_width);
 
     return Result.appended;

--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -47,6 +47,7 @@ pub fn emitMir(emit: *Emit) InnerError!void {
 
             // relocatables
             .call => try emit.emitCall(inst),
+            .call_indirect => try emit.emitCallIndirect(inst),
             .global_get => try emit.emitGlobal(tag, inst),
             .global_set => try emit.emitGlobal(tag, inst),
             .memory_address => try emit.emitMemAddress(inst),
@@ -274,6 +275,13 @@ fn emitCall(emit: *Emit, inst: Mir.Inst.Index) !void {
         .index = label,
         .relocation_type = .R_WASM_FUNCTION_INDEX_LEB,
     });
+}
+
+fn emitCallIndirect(emit: *Emit, inst: Mir.Inst.Index) !void {
+    const label = emit.mir.instructions.items(.data)[inst].label;
+    try emit.code.append(std.wasm.opcode(.call_indirect));
+    try leb128.writeULEB128(emit.code.writer(), @as(u32, 0)); // TODO: Emit relocation for table index
+    try leb128.writeULEB128(emit.code.writer(), label);
 }
 
 fn emitMemAddress(emit: *Emit, inst: Mir.Inst.Index) !void {

--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -257,7 +257,7 @@ fn emitMemArg(emit: *Emit, tag: Mir.Inst.Tag, inst: Mir.Inst.Index) !void {
     try emit.code.append(@enumToInt(tag));
 
     // wasm encodes alignment as power of 2, rather than natural alignment
-    const encoded_alignment = mem_arg.alignment >> 1;
+    const encoded_alignment = @ctz(u32, mem_arg.alignment);
     try leb128.writeULEB128(emit.code.writer(), encoded_alignment);
     try leb128.writeULEB128(emit.code.writer(), mem_arg.offset);
 }

--- a/src/arch/wasm/Mir.zig
+++ b/src/arch/wasm/Mir.zig
@@ -69,6 +69,11 @@ pub const Inst = struct {
         ///
         /// Uses `label`
         call = 0x10,
+        /// Calls a function pointer by its function signature
+        /// and index into the function table.
+        ///
+        /// Uses `label`
+        call_indirect = 0x11,
         /// Loads a local at given index onto the stack.
         ///
         /// Uses `label`

--- a/src/link/Wasm/Atom.zig
+++ b/src/link/Wasm/Atom.zig
@@ -129,7 +129,7 @@ fn relocationValue(relocation: types.Relocation, wasm_bin: *const Wasm) !u64 {
         .R_WASM_TABLE_INDEX_I64,
         .R_WASM_TABLE_INDEX_SLEB,
         .R_WASM_TABLE_INDEX_SLEB64,
-        => return error.TodoImplementTableIndex, // find table index from a function symbol
+        => return wasm_bin.function_table.get(relocation.index) orelse 0,
         .R_WASM_TYPE_INDEX_LEB => wasm_bin.functions.items[symbol.index].type_index,
         .R_WASM_GLOBAL_INDEX_I32,
         .R_WASM_GLOBAL_INDEX_LEB,

--- a/src/link/Wasm/Atom.zig
+++ b/src/link/Wasm/Atom.zig
@@ -83,7 +83,7 @@ pub fn resolveRelocs(self: *Atom, wasm_bin: *const Wasm) !void {
 
     for (self.relocs.items) |reloc| {
         const value = try relocationValue(reloc, wasm_bin);
-        log.debug("Relocating '{s}' referenced in '{s}' offset=0x{x:0>8} value={d}\n", .{
+        log.debug("Relocating '{s}' referenced in '{s}' offset=0x{x:0>8} value={d}", .{
             wasm_bin.symbols.items[reloc.index].name,
             symbol.name,
             reloc.offset,
@@ -152,9 +152,7 @@ fn relocationValue(relocation: types.Relocation, wasm_bin: *const Wasm) !u64 {
                 target_atom = target_atom.next orelse break;
             }
             const segment = wasm_bin.segments.items[atom_index];
-            const base = wasm_bin.base.options.global_base orelse 1024;
-            const offset = target_atom.offset + segment.offset;
-            break :blk offset + base + (relocation.addend orelse 0);
+            break :blk target_atom.offset + segment.offset + (relocation.addend orelse 0);
         },
         .R_WASM_EVENT_INDEX_LEB => symbol.index,
         .R_WASM_SECTION_OFFSET_I32,

--- a/test/cases.zig
+++ b/test/cases.zig
@@ -26,7 +26,7 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("hello world with updates", linux_x64);
 
         case.addError("", &[_][]const u8{
-            ":97:9: error: struct 'tmp.tmp' has no member named 'main'",
+            ":99:9: error: struct 'tmp.tmp' has no member named 'main'",
         });
 
         // Incorrect return type

--- a/test/stage2/darwin.zig
+++ b/test/stage2/darwin.zig
@@ -14,7 +14,7 @@ pub fn addCases(ctx: *TestContext) !void {
         {
             var case = ctx.exe("darwin hello world with updates", target);
             case.addError("", &[_][]const u8{
-                ":97:9: error: struct 'tmp.tmp' has no member named 'main'",
+                ":99:9: error: struct 'tmp.tmp' has no member named 'main'",
             });
 
             // Incorrect return type

--- a/test/stage2/wasm.zig
+++ b/test/stage2/wasm.zig
@@ -11,7 +11,7 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("wasm function calls", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    foo();
             \\    bar();
             \\    return 42;
@@ -26,7 +26,7 @@ pub fn addCases(ctx: *TestContext) !void {
         );
 
         case.addCompareOutput(
-            \\pub export fn _start() i64 {
+            \\pub fn main() u8 {
             \\    bar();
             \\    foo();
             \\    foo();
@@ -44,10 +44,10 @@ pub fn addCases(ctx: *TestContext) !void {
         );
 
         case.addCompareOutput(
-            \\pub export fn _start() f32 {
+            \\pub fn main() void {
             \\    bar();
             \\    foo();
-            \\    return 42.0;
+            \\    return;
             \\}
             \\fn foo() void {
             \\    bar();
@@ -56,15 +56,15 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
             \\fn bar() void {}
         ,
-            "42\n",
+            "0\n",
         );
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    foo(10, 20);
             \\    return 5;
             \\}
-            \\fn foo(x: u32, y: u32) void { _ = x; _ = y; }
+            \\fn foo(x: u8, y: u8) void { _ = x; _ = y; }
         , "5\n");
     }
 
@@ -72,10 +72,10 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("wasm locals", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
             \\    var y: f32 = 42.0;
-            \\    var x: u32 = 10;
+            \\    var x: u8 = 10;
             \\    if (false) {
             \\      y;
             \\      x;
@@ -85,18 +85,18 @@ pub fn addCases(ctx: *TestContext) !void {
         , "5\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
             \\    var y: f32 = 42.0;
             \\    _ = y;
-            \\    var x: u32 = 10;
+            \\    var x: u8 = 10;
             \\    foo(i, x);
             \\    i = x;
             \\    return i;
             \\}
-            \\fn foo(x: u32, y: u32) void {
+            \\fn foo(x: u8, y: u8) void {
             \\    _  = y;
-            \\    var i: u32 = 10;
+            \\    var i: u8 = 10;
             \\    i = x;
             \\}
         , "10\n");
@@ -106,228 +106,246 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("wasm binary operands", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
             \\    i += 20;
             \\    return i;
             \\}
         , "25\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() i32 {
+            \\pub fn main() void {
             \\    var i: i32 = 2147483647;
-            \\    return i +% 1;
-            \\}
-        , "-2147483648\n");
-
-        case.addCompareOutput(
-            \\pub export fn _start() i32 {
-            \\    var i: i4 = 7;
-            \\    return i +% 1;
+            \\    if (i +% 1 != -2147483648) unreachable;
+            \\    return;
             \\}
         , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
+            \\pub fn main() void {
+            \\    var i: i4 = 7;
+            \\    if (i +% 1 != 0) unreachable;
+            \\    return;
+            \\}
+        , "0\n");
+
+        case.addCompareOutput(
+            \\pub fn main() u8 {
             \\    var i: u8 = 255;
             \\    return i +% 1;
             \\}
         , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
             \\    i += 20;
-            \\    var result: u32 = foo(i, 10);
+            \\    var result: u8 = foo(i, 10);
             \\    return result;
             \\}
-            \\fn foo(x: u32, y: u32) u32 {
+            \\fn foo(x: u8, y: u8) u8 {
             \\    return x + y;
             \\}
         , "35\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 20;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 20;
             \\    i -= 5;
             \\    return i;
             \\}
         , "15\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() i32 {
+            \\pub fn main() void {
             \\    var i: i32 = -2147483648;
-            \\    return i -% 1;
+            \\    if (i -% 1 != 2147483647) unreachable;
+            \\    return;
             \\}
-        , "2147483647\n");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() i32 {
+            \\pub fn main() void {
             \\    var i: i7 = -64;
-            \\    return i -% 1;
+            \\    if (i -% 1 != 63) unreachable;
+            \\    return;
             \\}
-        , "63\n");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    var i: u4 = 0;
             \\    return i -% 1;
             \\}
         , "15\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
             \\    i -= 3;
-            \\    var result: u32 = foo(i, 10);
+            \\    var result: u8 = foo(i, 10);
             \\    return result;
             \\}
-            \\fn foo(x: u32, y: u32) u32 {
+            \\fn foo(x: u8, y: u8) u8 {
             \\    return y - x;
             \\}
         , "8\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
+            \\pub fn main() void {
             \\    var i: u32 = 5;
             \\    i *= 7;
             \\    var result: u32 = foo(i, 10);
-            \\    return result;
+            \\    if (result != 350) unreachable;
+            \\    return;
             \\}
             \\fn foo(x: u32, y: u32) u32 {
             \\    return x * y;
             \\}
-        , "350\n");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() i32 {
+            \\pub fn main() void {
             \\    var i: i32 = 2147483647;
-            \\    return i *% 2;
+            \\    const result = i *% 2;
+            \\    if (result != -2) unreachable;
+            \\    return;
             \\}
-        , "-2\n");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
+            \\pub fn main() void {
             \\    var i: u3 = 3;
-            \\    return i *% 3;
+            \\    if (i *% 3 != 1) unreachable;
+            \\    return;
             \\}
-        , "1\n");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() i32 {
+            \\pub fn main() void {
             \\    var i: i4 = 3;
-            \\    return i *% 3;
+            \\    if (i *% 3 != 1) unreachable;
+            \\    return;
             \\}
-        , "1\n");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
+            \\pub fn main() void {
             \\    var i: u32 = 352;
             \\    i /= 7; // i = 50
             \\    var result: u32 = foo(i, 7);
-            \\    return result;
+            \\    if (result != 7) unreachable;
+            \\    return;
             \\}
             \\fn foo(x: u32, y: u32) u32 {
             \\    return x / y;
             \\}
-        , "7\n");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
             \\    i &= 6;
             \\    return i;
             \\}
         , "4\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
             \\    i |= 6;
             \\    return i;
             \\}
         , "7\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
             \\    i ^= 6;
             \\    return i;
             \\}
         , "3\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() bool {
+            \\pub fn main() void {
             \\    var b: bool = false;
             \\    b = b or false;
-            \\    return b;
+            \\    if (b) unreachable;
+            \\    return;
             \\}
         , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() bool {
+            \\pub fn main() void {
             \\    var b: bool = true;
             \\    b = b or false;
-            \\    return b;
+            \\    if (!b) unreachable;
+            \\    return;
             \\}
-        , "1\n");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() bool {
+            \\pub fn main() void {
             \\    var b: bool = false;
             \\    b = b or true;
-            \\    return b;
+            \\    if (!b) unreachable;
+            \\    return;
             \\}
-        , "1\n");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() bool {
+            \\pub fn main() void {
             \\    var b: bool = true;
             \\    b = b or true;
-            \\    return b;
+            \\    if (!b) unreachable;
+            \\    return;
             \\}
-        , "1\n");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() bool {
+            \\pub fn main() void {
             \\    var b: bool = false;
             \\    b = b and false;
-            \\    return b;
+            \\    if (b) unreachable;
+            \\    return;
             \\}
         , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() bool {
+            \\pub fn main() void {
             \\    var b: bool = true;
             \\    b = b and false;
-            \\    return b;
+            \\    if (b) unreachable;
+            \\    return;
             \\}
         , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() bool {
+            \\pub fn main() void {
             \\    var b: bool = false;
             \\    b = b and true;
-            \\    return b;
+            \\    if (b) unreachable;
+            \\    return;
             \\}
         , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() bool {
+            \\pub fn main() void {
             \\    var b: bool = true;
             \\    b = b and true;
-            \\    return b;
+            \\    if (!b) unreachable;
+            \\    return;
             \\}
-        , "1\n");
+        , "0\n");
     }
 
     {
         var case = ctx.exe("wasm conditions", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
-            \\    if (i > @as(u32, 4)) {
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
+            \\    if (i > @as(u8, 4)) {
             \\        i += 10;
             \\    }
             \\    return i;
@@ -335,9 +353,9 @@ pub fn addCases(ctx: *TestContext) !void {
         , "15\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
-            \\    if (i < @as(u32, 4)) {
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
+            \\    if (i < @as(u8, 4)) {
             \\        i += 10;
             \\    } else {
             \\        i = 2;
@@ -347,11 +365,11 @@ pub fn addCases(ctx: *TestContext) !void {
         , "2\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 5;
-            \\    if (i < @as(u32, 4)) {
+            \\pub fn main() u8 {
+            \\    var i: u8 = 5;
+            \\    if (i < @as(u8, 4)) {
             \\        i += 10;
-            \\    } else if(i == @as(u32, 5)) {
+            \\    } else if(i == @as(u8, 5)) {
             \\        i = 20;
             \\    }
             \\    return i;
@@ -359,12 +377,12 @@ pub fn addCases(ctx: *TestContext) !void {
         , "20\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 11;
-            \\    if (i < @as(u32, 4)) {
+            \\pub fn main() u8 {
+            \\    var i: u8 = 11;
+            \\    if (i < @as(u8, 4)) {
             \\        i += 10;
             \\    } else {
-            \\        if (i > @as(u32, 10)) {
+            \\        if (i > @as(u8, 10)) {
             \\            i += 20;
             \\        } else {
             \\            i = 20;
@@ -375,7 +393,7 @@ pub fn addCases(ctx: *TestContext) !void {
         , "31\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() void {
+            \\pub fn main() void {
             \\    assert(foo(true) != @as(i32, 30));
             \\}
             \\
@@ -387,10 +405,10 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    const x = if(ok) @as(i32, 20) else @as(i32, 10);
             \\    return x;
             \\}
-        , "");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() void {
+            \\pub fn main() void {
             \\    assert(foo(false) == @as(i32, 20));
             \\    assert(foo(true) == @as(i32, 30));
             \\}
@@ -407,16 +425,16 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    };
             \\    return val + 10;
             \\}
-        , "");
+        , "0\n");
     }
 
     {
         var case = ctx.exe("wasm while loops", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 0;
-            \\    while(i < @as(u32, 5)){
+            \\pub fn main() u8 {
+            \\    var i: u8 = 0;
+            \\    while(i < @as(u8, 5)){
             \\        i += 1;
             \\    }
             \\
@@ -425,10 +443,10 @@ pub fn addCases(ctx: *TestContext) !void {
         , "5\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 0;
-            \\    while(i < @as(u32, 10)){
-            \\        var x: u32 = 1;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 0;
+            \\    while(i < @as(u8, 10)){
+            \\        var x: u8 = 1;
             \\        i += x;
             \\    }
             \\    return i;
@@ -436,12 +454,12 @@ pub fn addCases(ctx: *TestContext) !void {
         , "10\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var i: u32 = 0;
-            \\    while(i < @as(u32, 10)){
-            \\        var x: u32 = 1;
+            \\pub fn main() u8 {
+            \\    var i: u8 = 0;
+            \\    while(i < @as(u8, 10)){
+            \\        var x: u8 = 1;
             \\        i += x;
-            \\        if (i == @as(u32, 5)) break;
+            \\        if (i == @as(u8, 5)) break;
             \\    }
             \\    return i;
             \\}
@@ -454,7 +472,7 @@ pub fn addCases(ctx: *TestContext) !void {
         case.addCompareOutput(
             \\const Number = enum { One, Two, Three };
             \\
-            \\pub export fn _start() i32 {
+            \\pub fn main() void {
             \\    var number1 = Number.One;
             \\    var number2: Number = .Two;
             \\    if (false) {
@@ -462,47 +480,52 @@ pub fn addCases(ctx: *TestContext) !void {
             \\        number2;
             \\    }
             \\    const number3 = @intToEnum(Number, 2);
-            \\
-            \\    return @enumToInt(number3);
+            \\    if (@enumToInt(number3) != 2) {
+            \\        unreachable;
+            \\    }
+            \\    return;
             \\}
-        , "2\n");
+        , "0\n");
 
         case.addCompareOutput(
             \\const Number = enum { One, Two, Three };
             \\
-            \\pub export fn _start() i32 {
+            \\pub fn main() void {
             \\    var number1 = Number.One;
             \\    var number2: Number = .Two;
             \\    const number3 = @intToEnum(Number, 2);
-            \\    if (number1 == number2) return 1;
-            \\    if (number2 == number3) return 1;
-            \\    if (@enumToInt(number1) != 0) return 1;
-            \\    if (@enumToInt(number2) != 1) return 1;
-            \\    if (@enumToInt(number3) != 2) return 1;
+            \\    assert(number1 != number2);
+            \\    assert(number2 != number3);
+            \\    assert(@enumToInt(number1) == 0);
+            \\    assert(@enumToInt(number2) == 1);
+            \\    assert(@enumToInt(number3) == 2);
             \\    var x: Number = .Two;
-            \\    if (number2 != x) return 1;
+            \\    assert(number2 == x);
             \\
-            \\    return @enumToInt(number3);
+            \\    return;
             \\}
-        , "2\n");
+            \\fn assert(val: bool) void {
+            \\    if(!val) unreachable;
+            \\}
+        , "0\n");
     }
 
     {
         var case = ctx.exe("wasm structs", wasi);
 
         case.addCompareOutput(
-            \\const Example = struct { x: u32 };
+            \\const Example = struct { x: u8 };
             \\
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    var example: Example = .{ .x = 5 };
             \\    return example.x;
             \\}
         , "5\n");
 
         case.addCompareOutput(
-            \\const Example = struct { x: u32 };
+            \\const Example = struct { x: u8 };
             \\
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    var example: Example = .{ .x = 5 };
             \\    example.x = 10;
             \\    return example.x;
@@ -510,18 +533,18 @@ pub fn addCases(ctx: *TestContext) !void {
         , "10\n");
 
         case.addCompareOutput(
-            \\const Example = struct { x: u32, y: u32 };
+            \\const Example = struct { x: u8, y: u8 };
             \\
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    var example: Example = .{ .x = 5, .y = 10 };
             \\    return example.y + example.x;
             \\}
         , "15\n");
 
         case.addCompareOutput(
-            \\const Example = struct { x: u32, y: u32 };
+            \\const Example = struct { x: u8, y: u8 };
             \\
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    var example: Example = .{ .x = 5, .y = 10 };
             \\    var example2: Example = .{ .x = 10, .y = 20 };
             \\
@@ -531,9 +554,9 @@ pub fn addCases(ctx: *TestContext) !void {
         , "30\n");
 
         case.addCompareOutput(
-            \\const Example = struct { x: u32, y: u32 };
+            \\const Example = struct { x: u8, y: u8 };
             \\
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    var example: Example = .{ .x = 5, .y = 10 };
             \\
             \\    example = .{ .x = 10, .y = 20 };
@@ -546,9 +569,9 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("wasm switch", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var val: u32 = 1;
-            \\    var a: u32 = switch (val) {
+            \\pub fn main() u8 {
+            \\    var val: u8 = 1;
+            \\    var a: u8 = switch (val) {
             \\        0, 1 => 2,
             \\        2 => 3,
             \\        3 => 4,
@@ -560,9 +583,9 @@ pub fn addCases(ctx: *TestContext) !void {
         , "2\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var val: u32 = 2;
-            \\    var a: u32 = switch (val) {
+            \\pub fn main() u8 {
+            \\    var val: u8 = 2;
+            \\    var a: u8 = switch (val) {
             \\        0, 1 => 2,
             \\        2 => 3,
             \\        3 => 4,
@@ -574,9 +597,9 @@ pub fn addCases(ctx: *TestContext) !void {
         , "3\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var val: u32 = 10;
-            \\    var a: u32 = switch (val) {
+            \\pub fn main() u8 {
+            \\    var val: u8 = 10;
+            \\    var a: u8 = switch (val) {
             \\        0, 1 => 2,
             \\        2 => 3,
             \\        3 => 4,
@@ -590,9 +613,9 @@ pub fn addCases(ctx: *TestContext) !void {
         case.addCompareOutput(
             \\const MyEnum = enum { One, Two, Three };
             \\
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    var val: MyEnum = .Two;
-            \\    var a: u32 = switch (val) {
+            \\    var a: u8 = switch (val) {
             \\        .One => 1,
             \\        .Two => 2,
             \\        .Three => 3,
@@ -607,7 +630,7 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("wasm error unions", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() void {
+            \\pub fn main() void {
             \\    var e1 = error.Foo;
             \\    var e2 = error.Bar;
             \\    assert(e1 != e2);
@@ -618,32 +641,32 @@ pub fn addCases(ctx: *TestContext) !void {
             \\fn assert(b: bool) void {
             \\    if (!b) unreachable;
             \\}
-        , "");
+        , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var e: anyerror!u32 = 5;
+            \\pub fn main() u8 {
+            \\    var e: anyerror!u8 = 5;
             \\    const i = e catch 10;
             \\    return i;
             \\}
         , "5\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var e: anyerror!u32 = error.Foo;
+            \\pub fn main() u8 {
+            \\    var e: anyerror!u8 = error.Foo;
             \\    const i = e catch 10;
             \\    return i;
             \\}
         , "10\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    var e = foo();
             \\    const i = e catch 69;
             \\    return i;
             \\}
             \\
-            \\fn foo() anyerror!u32 {
+            \\fn foo() anyerror!u8 {
             \\    return 5;
             \\}
         , "5\n");
@@ -653,24 +676,24 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("wasm error union part 2", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    var e = foo();
             \\    const i = e catch 69;
             \\    return i;
             \\}
             \\
-            \\fn foo() anyerror!u32 {
+            \\fn foo() anyerror!u8 {
             \\    return error.Bruh;
             \\}
         , "69\n");
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
+            \\pub fn main() u8 {
             \\    var e = foo();
             \\    const i = e catch 42;
             \\    return i;
             \\}
             \\
-            \\fn foo() anyerror!u32 {
+            \\fn foo() anyerror!u8 {
             \\    return error.Dab;
             \\}
         , "42\n");
@@ -680,20 +703,22 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("wasm integer widening", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() u64 {
-            \\    var x: u32 = 5;
-            \\    return x;
+            \\pub fn main() void{
+            \\    var x: u8 = 5;
+            \\    var y: u64 = x;
+            \\    _ = y;
+            \\    return;
             \\}
-        , "5\n");
+        , "0\n");
     }
 
     {
         var case = ctx.exe("wasm optionals", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var x: ?u32 = 5;
-            \\    var y: u32 = 0;
+            \\pub fn main() u8 {
+            \\    var x: ?u8 = 5;
+            \\    var y: u8 = 0;
             \\    if (x) |val| {
             \\        y = val;
             \\    }
@@ -702,9 +727,9 @@ pub fn addCases(ctx: *TestContext) !void {
         , "5\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var x: ?u32 = null;
-            \\    var y: u32 = 0;
+            \\pub fn main() u8 {
+            \\    var x: ?u8 = null;
+            \\    var y: u8 = 0;
             \\    if (x) |val| {
             \\        y = val;
             \\    }
@@ -713,23 +738,23 @@ pub fn addCases(ctx: *TestContext) !void {
         , "0\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var x: ?u32 = 5;
+            \\pub fn main() u8 {
+            \\    var x: ?u8 = 5;
             \\    return x.?;
             \\}
         , "5\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var x: u32 = 5;
-            \\    var y: ?u32 = x;
+            \\pub fn main() u8 {
+            \\    var x: u8 = 5;
+            \\    var y: ?u8 = x;
             \\    return y.?;
             \\}
         , "5\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var val: ?u32 = 5;
+            \\pub fn main() u8 {
+            \\    var val: ?u8 = 5;
             \\    while (val) |*v| {
             \\        v.* -= 1;
             \\        if (v.* == 2) {
@@ -745,32 +770,32 @@ pub fn addCases(ctx: *TestContext) !void {
         var case = ctx.exe("wasm pointers", wasi);
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var x: u32 = 0;
+            \\pub fn main() u8 {
+            \\    var x: u8 = 0;
             \\
             \\    foo(&x);
             \\    return x;
             \\}
             \\
-            \\fn foo(x: *u32)void {
+            \\fn foo(x: *u8)void {
             \\    x.* = 2;
             \\}
         , "2\n");
 
         case.addCompareOutput(
-            \\pub export fn _start() u32 {
-            \\    var x: u32 = 0;
+            \\pub fn main() u8 {
+            \\    var x: u8 = 0;
             \\
             \\    foo(&x);
             \\    bar(&x);
             \\    return x;
             \\}
             \\
-            \\fn foo(x: *u32)void {
+            \\fn foo(x: *u8)void {
             \\    x.* = 2;
             \\}
             \\
-            \\fn bar(x: *u32) void {
+            \\fn bar(x: *u8) void {
             \\    x.* += 2;
             \\}
         , "4\n");


### PR DESCRIPTION
This implements all the required instructions and declaration codegen to be able to use `zig test` using `wasm32-wasi` as a target.

A simple example:
```zig
// test.zig
test {
    var i: u32 = 5;
    if (i != 5) unreachable;
}
```
```sh
zig test test.zig -target wasm32-wasi --test-cmd wasmtime --test-cmd-bin
0
```

The temporary _start supports both `u8` and `void` as return type, to also support our old wasm stage2 testing backend. In a followup PR I'll be updating the `behaviour.zig` file to track progress on the wasm backend.
This is a huge milestone for the wasm backend and the backend is now in a state where contributing
is a lot easier.
