### PR TITLE
macos: fix stack traces for Zig linked with any linker including Apple's ld64

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1412,7 +1412,6 @@ pub const ModuleDebugInfo = switch (native_os) {
             nosuspend {
                 // Translate the VA into an address into this object
                 const relocated_address = address - self.base_address;
-                assert(relocated_address >= 0x100000000);
 
                 // Find the .o file where this symbol is defined
                 const symbol = machoSearchSymbols(self.symbols, relocated_address) orelse

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -744,6 +744,55 @@ pub const nlist_64 = extern struct {
     n_sect: u8,
     n_desc: u16,
     n_value: u64,
+
+    pub fn stab(sym: nlist_64) bool {
+        return (N_STAB & sym.n_type) != 0;
+    }
+
+    pub fn pext(sym: nlist_64) bool {
+        return (N_PEXT & sym.n_type) != 0;
+    }
+
+    pub fn ext(sym: nlist_64) bool {
+        return (N_EXT & sym.n_type) != 0;
+    }
+
+    pub fn sect(sym: nlist_64) bool {
+        const type_ = N_TYPE & sym.n_type;
+        return type_ == N_SECT;
+    }
+
+    pub fn undf(sym: nlist_64) bool {
+        const type_ = N_TYPE & sym.n_type;
+        return type_ == N_UNDF;
+    }
+
+    pub fn indr(sym: nlist_64) bool {
+        const type_ = N_TYPE & sym.n_type;
+        return type_ == N_INDR;
+    }
+
+    pub fn abs(sym: nlist_64) bool {
+        const type_ = N_TYPE & sym.n_type;
+        return type_ == N_ABS;
+    }
+
+    pub fn weakDef(sym: nlist_64) bool {
+        return (sym.n_desc & N_WEAK_DEF) != 0;
+    }
+
+    pub fn weakRef(sym: nlist_64) bool {
+        return (sym.n_desc & N_WEAK_REF) != 0;
+    }
+
+    pub fn discarded(sym: nlist_64) bool {
+        return (sym.n_desc & N_DESC_DISCARDED) != 0;
+    }
+
+    pub fn tentative(sym: nlist_64) bool {
+        if (!sym.undf()) return false;
+        return sym.n_value != 0;
+    }
 };
 
 /// Format of a relocation entry of a Mach-O file.  Modified from the 4.3BSD

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -295,7 +295,7 @@ pub fn parseRelocs(self: *Atom, relocs: []macho.relocation_info, context: RelocC
 
             assert(subtractor == null);
             const sym = context.object.symtab.items[rel.r_symbolnum];
-            if (MachO.symbolIsSect(sym) and !MachO.symbolIsExt(sym)) {
+            if (sym.sect() and !sym.ext()) {
                 subtractor = context.object.symbol_mapping.get(rel.r_symbolnum).?;
             } else {
                 const sym_name = context.object.getString(sym.n_strx);
@@ -362,7 +362,7 @@ pub fn parseRelocs(self: *Atom, relocs: []macho.relocation_info, context: RelocC
             const sym = context.object.symtab.items[rel.r_symbolnum];
             const sym_name = context.object.getString(sym.n_strx);
 
-            if (MachO.symbolIsSect(sym) and !MachO.symbolIsExt(sym)) {
+            if (sym.sect() and !sym.ext()) {
                 const sym_index = context.object.symbol_mapping.get(rel.r_symbolnum) orelse unreachable;
                 break :target Relocation.Target{ .local = sym_index };
             }

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -226,7 +226,7 @@ fn parseSymbols(self: *Dylib, allocator: *Allocator) !void {
     _ = try self.file.preadAll(strtab, symtab_cmd.stroff + self.library_offset);
 
     for (slice) |sym| {
-        const add_to_symtab = MachO.symbolIsExt(sym) and (MachO.symbolIsSect(sym) or MachO.symbolIsIndr(sym));
+        const add_to_symtab = sym.ext() and (sym.sect() or sym.indr());
 
         if (!add_to_symtab) continue;
 

--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -338,8 +338,8 @@ const NlistWithIndex = struct {
         // afterwards by address in each group. Normally, dysymtab should
         // be enough to guarantee the sort, but turns out not every compiler
         // is kind enough to specify the symbols in the correct order.
-        if (MachO.symbolIsSect(lhs.nlist)) {
-            if (MachO.symbolIsSect(rhs.nlist)) {
+        if (lhs.nlist.sect()) {
+            if (rhs.nlist.sect()) {
                 // Same group, sort by address.
                 return lhs.nlist.n_value < rhs.nlist.n_value;
             } else {
@@ -414,7 +414,7 @@ pub fn parseIntoAtoms(self: *Object, allocator: *Allocator, macho_file: *MachO) 
         var iundefsym: usize = sorted_all_nlists.items.len;
         while (iundefsym > 0) : (iundefsym -= 1) {
             const nlist = sorted_all_nlists.items[iundefsym];
-            if (MachO.symbolIsSect(nlist.nlist)) break;
+            if (nlist.nlist.sect()) break;
         }
         break :blk iundefsym;
     };


### PR DESCRIPTION
Fixes #10225

In order to be linker-independent, when parsing debug info in each linked OSO, we also create a quick lookup table for symbols defined within the OSO. We then use this lookup to map symbol from the EXE to its defined address within the original OSO which we can then use to extract its associated DWARF info (if any).

This unifies stack trace printing regardless of the linker used to perform the final linking. For example, given this simple test case:

```zig
pub fn main() void {
    unreachable;
}
```

* with `zld`:

```
$ zig build-exe main.zig
$ ./main
thread 669054 panic: reached unreachable code
/Users/kubkon/dev/examples/stack-traces/main.zig:2:5: 0x1000e9cdb in main (main)
    unreachable;
    ^
/Users/kubkon/dev/zig/build/lib/zig/std/start.zig:543:22: 0x1000eb8eb in std.start.callMain (main)
            root.main();
                     ^
/Users/kubkon/dev/zig/build/lib/zig/std/start.zig:495:12: 0x1000e9ea3 in std.start.callMainWithArgs (main)
    return @call(.{ .modifier = .always_inline }, callMain, .{});
           ^
/Users/kubkon/dev/zig/build/lib/zig/std/start.zig:460:12: 0x1000e9dcf in std.start.main (main)
    return @call(.{ .modifier = .always_inline }, callMainWithArgs, .{ @intCast(usize, c_argc), c_argv, envp });
           ^
???:?:?: 0x1001e50f3 in ??? (???)
???:?:?: 0xb828ffffffffffff in ??? (???)
[1]    11173 abort      ./main

```

* with Apple's `ld64`:

```
$ zig build-obj main.zig
$ ld -syslibroot $(xcrun --show-sdk-path) -lSystem -adhoc_codesign -o main main.o
$ ./main
thread 668552 panic: reached unreachable code
/Users/kubkon/dev/examples/stack-traces/main.zig:2:5: 0x10218bae3 in main (main)
    unreachable;
    ^
/Users/kubkon/dev/zig/build/lib/zig/std/start.zig:543:22: 0x10218d687 in std.start.callMain (main)
            root.main();
                     ^
/Users/kubkon/dev/zig/build/lib/zig/std/start.zig:495:12: 0x10218bcab in std.start.callMainWithArgs (main)
    return @call(.{ .modifier = .always_inline }, callMain, .{});
           ^
/Users/kubkon/dev/zig/build/lib/zig/std/start.zig:460:12: 0x10218bbd7 in std.start.main (main)
    return @call(.{ .modifier = .always_inline }, callMainWithArgs, .{ @intCast(usize, c_argc), c_argv, envp });
           ^
???:?:?: 0x1022f50f3 in ??? (???)
???:?:?: 0x7446ffffffffffff in ??? (???)
[1]    11146 abort      ./main

```

The implications of this are that we now get correct stack traces when using stage1 compiler built with Apple's system tools! Something we've had broken for a very long time!

EDIT: I have also removed the assertion checking that the address is `>= 0x10000000`. I don't think we can guarantee that especially for system dyld dylibs which can be loaded at any address (perhaps even some OS preferential low memory address). 

Incidentally, this fixes stack trace tests on x86_64 macOS 12.