### PR TITLE
Allocgate: fixups

### DIFF
--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -627,6 +627,8 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
                 self.total_requested_bytes -= entry.value_ptr.requested_size;
             }
 
+            if (!config.never_unmap) self.backing_allocator.rawFree(old_mem, old_align, ret_addr);
+
             if (config.verbose_log) {
                 log.info("large free {d} bytes at {*}", .{ old_mem.len, old_mem.ptr });
             }

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4775,10 +4775,10 @@ pub fn populateTestFunctions(mod: *Module) !void {
             const test_name_decl = n: {
                 var name_decl_arena = std.heap.ArenaAllocator.init(gpa);
                 errdefer name_decl_arena.deinit();
-                const bytes = try arena.dupe(u8, test_name_slice);
+                const bytes = try name_decl_arena.allocator().dupe(u8, test_name_slice);
                 const test_name_decl = try mod.createAnonymousDeclFromDecl(array_decl, array_decl.src_namespace, null, .{
-                    .ty = try Type.Tag.array_u8.create(arena, bytes.len),
-                    .val = try Value.Tag.bytes.create(arena, bytes),
+                    .ty = try Type.Tag.array_u8.create(name_decl_arena.allocator(), bytes.len),
+                    .val = try Value.Tag.bytes.create(name_decl_arena.allocator(), bytes),
                 });
                 try test_name_decl.finalizeNewArena(&name_decl_arena);
                 break :n test_name_decl;


### PR DESCRIPTION
- GPA was not actually freeing
- incorrect allocator used in `populateTestFunctions`