### PR TITLE
Allocator: shrink can fail

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -96,7 +96,7 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
         /// The caller owns the returned memory. Empties this ArrayList.
         pub fn toOwnedSlice(self: *Self) Slice {
             const allocator = self.allocator;
-            const result = allocator.shrink(self.allocatedSlice(), self.items.len);
+            const result = allocator.realloc(self.allocatedSlice(), self.items.len) catch unreachable;
             self.* = init(allocator);
             return result;
         }
@@ -484,7 +484,7 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
 
         /// The caller owns the returned memory. ArrayList becomes empty.
         pub fn toOwnedSlice(self: *Self, allocator: Allocator) Slice {
-            const result = allocator.shrink(self.allocatedSlice(), self.items.len);
+            const result = allocator.realloc(self.allocatedSlice(), self.items.len) catch unreachable;
             self.* = Self{};
             return result;
         }

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -1276,7 +1276,7 @@ pub fn createWindowsEnvBlock(allocator: mem.Allocator, env_map: *const BufMap) !
     i += 1;
     result[i] = 0;
     i += 1;
-    return allocator.shrink(result, i);
+    return allocator.realloc(result, i);
 }
 
 pub fn createNullDelimitedEnvMap(arena: mem.Allocator, env_map: *const std.BufMap) ![:null]?[*:0]u8 {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1023,7 +1023,7 @@ fn readMachODebugInfo(allocator: mem.Allocator, macho_file: File) !ModuleDebugIn
     }
     assert(state == .oso_close);
 
-    const symbols = allocator.shrink(symbols_buf, symbol_index);
+    const symbols = try allocator.realloc(symbols_buf, symbol_index);
 
     // Even though lld emits symbols in ascending order, this debug code
     // should work for programs linked in any valid way.

--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -661,7 +661,7 @@ pub fn resolveWindows(allocator: Allocator, paths: []const []const u8) ![]u8 {
         result_index += 1;
     }
 
-    return allocator.shrink(result, result_index);
+    return allocator.realloc(result, result_index);
 }
 
 /// This function is like a series of `cd` statements executed one after another.
@@ -730,7 +730,7 @@ pub fn resolvePosix(allocator: Allocator, paths: []const []const u8) ![]u8 {
         result_index += 1;
     }
 
-    return allocator.shrink(result, result_index);
+    return allocator.realloc(result, result_index);
 }
 
 test "resolve" {
@@ -1200,7 +1200,7 @@ pub fn relativePosix(allocator: Allocator, from: []const u8, to: []const u8) ![]
         }
         if (to_rest.len == 0) {
             // shave off the trailing slash
-            return allocator.shrink(result, result_index - 1);
+            return allocator.realloc(result, result_index - 1);
         }
 
         mem.copy(u8, result[result_index..], to_rest);

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -1116,11 +1116,11 @@ pub fn testAllocator(base_allocator: mem.Allocator) !void {
         allocator.destroy(item);
     }
 
-    slice = allocator.shrink(slice, 50);
+    slice = allocator.tryShrink(slice, 50) orelse return error.OutOfMemory; // this allocator does not support this shrink
     try testing.expect(slice.len == 50);
-    slice = allocator.shrink(slice, 25);
+    slice = allocator.tryShrink(slice, 25) orelse return error.OutOfMemory; // this allocator does not support this shrink
     try testing.expect(slice.len == 25);
-    slice = allocator.shrink(slice, 0);
+    slice = allocator.tryShrink(slice, 0) orelse return error.OutOfMemory; // this allocator does not support this shrink
     try testing.expect(slice.len == 0);
     slice = try allocator.realloc(slice, 10);
     try testing.expect(slice.len == 10);
@@ -1156,19 +1156,19 @@ pub fn testAllocatorAligned(base_allocator: mem.Allocator) !void {
         slice = try allocator.realloc(slice, 100);
         try testing.expect(slice.len == 100);
         // shrink
-        slice = allocator.shrink(slice, 10);
+        slice = allocator.tryShrink(slice, 10) orelse return error.OutOfMemory; // this allocator does not support this shrink
         try testing.expect(slice.len == 10);
         // go to zero
-        slice = allocator.shrink(slice, 0);
+        slice = allocator.tryShrink(slice, 0) orelse return error.OutOfMemory; // this allocator does not support this shrink
         try testing.expect(slice.len == 0);
         // realloc from zero
         slice = try allocator.realloc(slice, 100);
         try testing.expect(slice.len == 100);
         // shrink with shrink
-        slice = allocator.shrink(slice, 10);
+        slice = allocator.tryShrink(slice, 10) orelse return error.OutOfMemory; // this allocator does not support this shrink
         try testing.expect(slice.len == 10);
         // shrink to zero
-        slice = allocator.shrink(slice, 0);
+        slice = allocator.tryShrink(slice, 0) orelse return error.OutOfMemory; // this allocator does not support this shrink
         try testing.expect(slice.len == 0);
     }
 }
@@ -1190,13 +1190,13 @@ pub fn testAllocatorLargeAlignment(base_allocator: mem.Allocator) !void {
     var slice = try allocator.alignedAlloc(u8, large_align, 500);
     try testing.expect(@ptrToInt(slice.ptr) & align_mask == @ptrToInt(slice.ptr));
 
-    slice = allocator.shrink(slice, 100);
+    slice = allocator.tryShrink(slice, 100) orelse return error.OutOfMemory; // this allocator does not support this shrink
     try testing.expect(@ptrToInt(slice.ptr) & align_mask == @ptrToInt(slice.ptr));
 
     slice = try allocator.realloc(slice, 5000);
     try testing.expect(@ptrToInt(slice.ptr) & align_mask == @ptrToInt(slice.ptr));
 
-    slice = allocator.shrink(slice, 10);
+    slice = allocator.tryShrink(slice, 10) orelse return error.OutOfMemory; // this allocator does not support this shrink
     try testing.expect(@ptrToInt(slice.ptr) & align_mask == @ptrToInt(slice.ptr));
 
     slice = try allocator.realloc(slice, 20000);

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -1020,13 +1020,13 @@ test "shrink" {
 
     mem.set(u8, slice, 0x11);
 
-    slice = allocator.shrink(slice, 17);
+    slice = allocator.tryShrink(slice, 17) orelse unreachable; // GPA supports shrink
 
     for (slice) |b| {
         try std.testing.expect(b == 0x11);
     }
 
-    slice = allocator.shrink(slice, 16);
+    slice = allocator.tryShrink(slice, 16) orelse unreachable; // GPA supports shrink
 
     for (slice) |b| {
         try std.testing.expect(b == 0x11);
@@ -1082,7 +1082,7 @@ test "shrink large object to large object" {
     try std.testing.expect(slice[0] == 0x12);
     try std.testing.expect(slice[60] == 0x34);
 
-    slice = allocator.shrink(slice, page_size * 2 + 1);
+    slice = allocator.tryShrink(slice, page_size * 2 + 1) orelse unreachable; // GPA supports shrink
     try std.testing.expect(slice[0] == 0x12);
     try std.testing.expect(slice[60] == 0x34);
 
@@ -1217,7 +1217,7 @@ test "large object shrinks to small but allocation fails during shrink" {
 
     // Next allocation will fail in the backing allocator of the GeneralPurposeAllocator
 
-    slice = allocator.shrink(slice, 4);
+    slice = allocator.tryShrink(slice, 4) orelse unreachable; // GPA supports shrink
     try std.testing.expect(slice[0] == 0x12);
     try std.testing.expect(slice[3] == 0x34);
 }

--- a/lib/std/heap/log_to_writer_allocator.zig
+++ b/lib/std/heap/log_to_writer_allocator.zig
@@ -94,7 +94,7 @@ test "LogToWriterAllocator" {
     const allocator = logToWriterAllocator(fixedBufferAllocator.allocator(), fbs.writer()).allocator();
 
     var a = try allocator.alloc(u8, 10);
-    a = allocator.shrink(a, 5);
+    a = allocator.tryShrink(a, 5) orelse return error.OutOfMemory; // this allocator does not support this shrink
     try std.testing.expect(a.len == 5);
     try std.testing.expect(allocator.resize(a, 20) == null);
     allocator.free(a);

--- a/lib/std/heap/log_to_writer_allocator.zig
+++ b/lib/std/heap/log_to_writer_allocator.zig
@@ -47,19 +47,16 @@ pub fn LogToWriterAllocator(comptime Writer: type) type {
             ra: usize,
         ) ?usize {
             if (new_len <= buf.len) {
-                self.writer.print("shrink: {} to {}\n", .{ buf.len, new_len }) catch {};
+                self.writer.print("shrink: {} to {}", .{ buf.len, new_len }) catch {};
             } else {
                 self.writer.print("expand: {} to {}", .{ buf.len, new_len }) catch {};
             }
 
             if (self.parent_allocator.rawResize(buf, buf_align, new_len, len_align, ra)) |resized_len| {
-                if (new_len > buf.len) {
-                    self.writer.print(" success!\n", .{}) catch {};
-                }
+                self.writer.print(" success!\n", .{}) catch {};
                 return resized_len;
             }
 
-            std.debug.assert(new_len > buf.len);
             self.writer.print(" failure!\n", .{}) catch {};
             return null;
         }
@@ -101,7 +98,7 @@ test "LogToWriterAllocator" {
 
     try std.testing.expectEqualSlices(u8,
         \\alloc : 10 success!
-        \\shrink: 10 to 5
+        \\shrink: 10 to 5 success!
         \\expand: 5 to 20 failure!
         \\free  : 5
         \\

--- a/lib/std/heap/logging_allocator.zig
+++ b/lib/std/heap/logging_allocator.zig
@@ -96,12 +96,20 @@ pub fn ScopedLoggingAllocator(
                 return resized_len;
             }
 
-            std.debug.assert(new_len > buf.len);
-            logHelper(
-                failure_log_level,
-                "expand - failure - {} to {}, len_align: {}, buf_align: {}",
-                .{ buf.len, new_len, len_align, buf_align },
-            );
+            if (new_len > buf.len) {
+                logHelper(
+                    failure_log_level,
+                    "expand - failure - {} to {}, len_align: {}, buf_align: {}",
+                    .{ buf.len, new_len, len_align, buf_align },
+                );
+            } else {
+                logHelper(
+                    failure_log_level,
+                    "shrink - failure - {} to {}, len_align: {}, buf_align: {}",
+                    .{ buf.len, new_len, len_align, buf_align },
+                );
+            }
+
             return null;
         }
 

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -2089,7 +2089,7 @@ pub const Const = struct {
         const limbs = try allocator.alloc(Limb, calcToStringLimbsBufferLen(self.limbs.len, base));
         defer allocator.free(limbs);
 
-        return allocator.shrink(string, self.toString(string, base, case, limbs));
+        return allocator.realloc(string, self.toString(string, base, case, limbs));
     }
 
     /// Converts self to a string in the requested base.

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4260,7 +4260,11 @@ pub fn analyzeExport(
     }
     eo_gop.value_ptr.* = try gpa.realloc(eo_gop.value_ptr.*, eo_gop.value_ptr.len + 1);
     eo_gop.value_ptr.*[eo_gop.value_ptr.len - 1] = new_export;
-    errdefer eo_gop.value_ptr.* = gpa.shrink(eo_gop.value_ptr.*, eo_gop.value_ptr.len - 1);
+    errdefer {
+        if (gpa.tryShrink(eo_gop.value_ptr.*, eo_gop.value_ptr.len - 1)) |shrunk| {
+            eo_gop.value_ptr.* = shrunk;
+        }
+    }
 
     // Add to exported_decl table.
     const de_gop = mod.decl_exports.getOrPutAssumeCapacity(exported_decl);
@@ -4269,7 +4273,11 @@ pub fn analyzeExport(
     }
     de_gop.value_ptr.* = try gpa.realloc(de_gop.value_ptr.*, de_gop.value_ptr.len + 1);
     de_gop.value_ptr.*[de_gop.value_ptr.len - 1] = new_export;
-    errdefer de_gop.value_ptr.* = gpa.shrink(de_gop.value_ptr.*, de_gop.value_ptr.len - 1);
+    errdefer {
+        if (gpa.tryShrink(de_gop.value_ptr.*, de_gop.value_ptr.len - 1)) |shrunk| {
+            eo_gop.value_ptr.* = shrunk;
+        }
+    }
 }
 
 fn zirSetAlignStack(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4261,9 +4261,9 @@ pub fn analyzeExport(
     eo_gop.value_ptr.* = try gpa.realloc(eo_gop.value_ptr.*, eo_gop.value_ptr.len + 1);
     eo_gop.value_ptr.*[eo_gop.value_ptr.len - 1] = new_export;
     errdefer {
-        if (gpa.tryShrink(eo_gop.value_ptr.*, eo_gop.value_ptr.len - 1)) |shrunk| {
+        if (gpa.realloc(eo_gop.value_ptr.*, eo_gop.value_ptr.len - 1)) |shrunk| {
             eo_gop.value_ptr.* = shrunk;
-        }
+        } else |_| {}
     }
 
     // Add to exported_decl table.
@@ -4274,9 +4274,9 @@ pub fn analyzeExport(
     de_gop.value_ptr.* = try gpa.realloc(de_gop.value_ptr.*, de_gop.value_ptr.len + 1);
     de_gop.value_ptr.*[de_gop.value_ptr.len - 1] = new_export;
     errdefer {
-        if (gpa.tryShrink(de_gop.value_ptr.*, de_gop.value_ptr.len - 1)) |shrunk| {
-            eo_gop.value_ptr.* = shrunk;
-        }
+        if (gpa.realloc(de_gop.value_ptr.*, de_gop.value_ptr.len - 1)) |shrunk| {
+            de_gop.value_ptr.* = shrunk;
+        } else |_| {}
     }
 }
 

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -498,7 +498,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    const allocator = std.heap.loggingAllocator(fixedBufferAllocator.allocator()).allocator();
         \\
         \\    var a = try allocator.alloc(u8, 10);
-        \\    a = allocator.shrink(a, 5);
+        \\    a = allocator.tryShrink(a, 5) orelse return error.OutOfMemory; // this allocator does not support this shrink
         \\    try std.testing.expect(a.len == 5);
         \\    try std.testing.expect(allocator.resize(a, 20) == null);
         \\    allocator.free(a);


### PR DESCRIPTION
Assuming that every allocator supports all shrinks is incorrect.

Imagine an allocator with a cache of 8 byte slabs and a cache of 16 byte slabs.
The user requests an allocation of 10 bytes, which is serviced from the 16 byte area, then if the user tries to shrink that allocation to 2 bytes the allocator has to reject that resize as when that memory is freed the slice will have a length associated with an 8 byte slab.
However if the resize was 10 to 9 bytes that would be successful as the information regarding the source slab size is not lost.

The only other way around this is to pass only the pointer of the slice into free and make it a requirement of allocators to function without the length. 

## Problems
Due to these problems this PR will stay draft

- `toOwnedSlice`
Now that shrink can fail the only way to maintain the status quo signature of `toOwnedSlice` is `catch unreachable`, this doesn't seem very zig-like.
We can't `catch self.items` as when that is passed to free the length is not the length of the actual allocation.

- `analyzeExport`
What do we set `eo_gop.value_ptr`/`de_gop.value_ptr` to if the realloc fails?