### PR TITLE
stage2 ARM: Implement calling with stack parameters

### DIFF
--- a/src/arch/arm/Mir.zig
+++ b/src/arch/arm/Mir.zig
@@ -51,10 +51,16 @@ pub const Inst = struct {
         eor,
         /// Load Register
         ldr,
+        /// Load Register
+        ldr_stack_argument,
         /// Load Register Byte
         ldrb,
+        /// Load Register Byte
+        ldrb_stack_argument,
         /// Load Register Halfword
         ldrh,
+        /// Load Register Halfword
+        ldrh_stack_argument,
         /// Logical Shift Left
         lsl,
         /// Logical Shift Right
@@ -124,6 +130,13 @@ pub const Inst = struct {
         ///
         /// Used by e.g. blx
         reg: Register,
+        /// A register and a stack offset
+        ///
+        /// Used by e.g. ldr_stack_argument
+        r_stack_offset: struct {
+            rt: Register,
+            stack_offset: u32,
+        },
         /// A register and a 16-bit unsigned immediate
         ///
         /// Used by e.g. movw

--- a/test/stage2/arm.zig
+++ b/test/stage2/arm.zig
@@ -72,6 +72,22 @@ pub fn addCases(ctx: *TestContext) !void {
         ,
             "Hello, World!\n",
         );
+
+        case.addCompareOutput(
+            \\pub fn main() void {
+            \\    assert(add(1, 2, 3, 4, 5, 6) == 21);
+            \\}
+            \\
+            \\fn add(a: u32, b: u32, c: u32, d: u32, e: u32, f: u32) u32 {
+            \\    return a + b + c + d + e + f;
+            \\}
+            \\
+            \\pub fn assert(ok: bool) void {
+            \\    if (!ok) unreachable; // assertion failure
+            \\}
+        ,
+            "",
+        );
     }
 
     {
@@ -465,12 +481,12 @@ pub fn addCases(ctx: *TestContext) !void {
             \\        const j = i + d; // 110
             \\        const k = i + j; // 210
             \\        const l = k + c; // 217
-            \\        const m = l * d; // 2170     
-            \\        const n = m + e; // 2184     
-            \\        const o = n * f; // 52416    
-            \\        const p = o + g; // 52454    
-            \\        const q = p * h; // 3252148  
-            \\        const r = q + i; // 3252248  
+            \\        const m = l * d; // 2170
+            \\        const n = m + e; // 2184
+            \\        const o = n * f; // 52416
+            \\        const p = o + g; // 52454
+            \\        const q = p * h; // 3252148
+            \\        const r = q + i; // 3252248
             \\        const s = r * j; // 357747280
             \\        const t = s + k; // 357747490
             \\        break :blk t;


### PR DESCRIPTION
This required adding a new MIR pseudo-instruction as the stack space occupied by the callee-saved registers is not known during codegen, but known during MIR emit.