### PR TITLE
ci: linux: pass VERSION on_master_success

### DIFF
--- a/ci/zinc/linux_on_master_sucess.sh
+++ b/ci/zinc/linux_on_master_sucess.sh
@@ -2,7 +2,7 @@
 
 . ./ci/zinc/linux_base.sh
 
-VERSION=$($RELEASE_STAGING/zig version)
+VERSION=$(cat $WORKSPACE/env.version)
 
 # Avoid leaking oauth token.
 set +x

--- a/ci/zinc/linux_package.sh
+++ b/ci/zinc/linux_package.sh
@@ -36,5 +36,8 @@ s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" "
 # Publish manifest.
 s3cmd put -P --add-header="cache-control: max-age=0, must-revalidate" "$MANIFEST" "s3://ziglang.org/builds/$ARCH-linux-$VERSION.json"
 
+# Forward value to on_master_script
+echo "$VERSION" > $WORKSPACE/env.version
+
 # Explicit exit helps show last command duration.
 exit


### PR DESCRIPTION
Cache the VERSION value for use with linux_on_mster_success.
This replaces 117c0460d3f5ff05d5e2c51c2aa376b56be13096 .