### PR TITLE
Fix test label off-by-one error (#10277).

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -266,11 +266,11 @@ fn refreshWithHeldLock(self: *Progress) void {
                 }
                 if (eti > 0) {
                     if (need_ellipse) self.bufWrite(&end, " ", .{});
-                    self.bufWrite(&end, "[{d}/{d}] ", .{ completed_items + 1, eti });
+                    self.bufWrite(&end, "[{d}/{d}] ", .{ completed_items, eti });
                     need_ellipse = false;
                 } else if (completed_items != 0) {
                     if (need_ellipse) self.bufWrite(&end, " ", .{});
-                    self.bufWrite(&end, "[{d}] ", .{completed_items + 1});
+                    self.bufWrite(&end, "[{d}] ", .{completed_items});
                     need_ellipse = false;
                 }
             }


### PR DESCRIPTION
The console test# label [test#/#tests] was being generated inside
refreshWithHeldLock (in lib/std/Progress.zig), using the number of
completed items. This was being incremented by 1 when displayed,
which is not required.