### PR TITLE
std: Progress.completed_items doesn't need to be +1, fixes #10277

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -266,11 +266,11 @@ fn refreshWithHeldLock(self: *Progress) void {
                 }
                 if (eti > 0) {
                     if (need_ellipse) self.bufWrite(&end, " ", .{});
-                    self.bufWrite(&end, "[{d}/{d}] ", .{ completed_items + 1, eti });
+                    self.bufWrite(&end, "[{d}/{d}] ", .{ completed_items, eti });
                     need_ellipse = false;
                 } else if (completed_items != 0) {
                     if (need_ellipse) self.bufWrite(&end, " ", .{});
-                    self.bufWrite(&end, "[{d}] ", .{completed_items + 1});
+                    self.bufWrite(&end, "[{d}] ", .{completed_items});
                     need_ellipse = false;
                 }
             }


### PR DESCRIPTION
`Progress.completed_items` was unnecessarily `+ 1`d making it so it would start at `2` and go up to `total + 1` after a single item had been completed

New output:

![image](https://user-images.githubusercontent.com/5464072/144848618-eab2ba95-10d6-4c0e-8c4a-ca8627c85347.png)
