### PR TITLE
stage2: improve handling of the generated file builtin.zig

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2170,6 +2170,16 @@ pub const Dir = struct {
         return file.stat();
     }
 
+    pub const StatFileError = File.OpenError || StatError;
+
+    // TODO: improve this to use the fstatat syscall instead of making 2 syscalls here.
+    pub fn statFile(self: Dir, sub_path: []const u8) StatFileError!File.Stat {
+        var file = try self.openFile(sub_path, .{});
+        defer file.close();
+
+        return file.stat();
+    }
+
     pub const ChmodError = File.ChmodError;
 
     /// Changes the mode of the directory.


### PR DESCRIPTION
All Zig code is eligible to `@import("builtin")` which is mapped to a
generated file, build.zig, based on the target and other settings.

Zig invocations which share the same target settings will generate the
same builtin.zig file and thus the path to builtin.zig is in a shared
cache folder, and different projects can sometimes use the same file.

Before this commit, this led to race conditions where multiple
invocations of `zig` would race to write this file. If one process
wanted to *read* the file while the other process *wrote* the file, the
reading process could observe a truncated or partially written
builtin.zig file.

This commit makes the following improvements:
 - limitations:
   - avoid clobbering the inode, mtime in the hot path
   - avoid creating a partially written file
   - builtin.zig needs to be on disk for debug info / stack trace purposes
   - don't mark the task as complete until the file is finished being populated
     (possibly by an external process)
 - strategy:
   - create the `@import("builtin")` `Module.File` during the AstGen
     work, based on generating the contents in memory rather than
     loading from disk.
   - write builtin.zig in a separate task that doesn't have
     to complete until the end of the AstGen work queue so that it
     can be done in parallel with everything else.
   - when writing the file, first stat the file path. If it exists, we are done.
   - otherwise, write the file to a temp file in the same directory and atomically
     rename it into place (clobbering the inode, mtime in the cold path).
 - summary:
   - all limitations respected
   - hot path: one stat() syscall that happens in a worker thread

This required adding a missing function to the standard library:
`std.fs.Dir.statFile`. In this commit, it does open() and then fstat()
which is two syscalls. It should be improved in a future commit to only
make one.

Fixes #9439.