### PR TITLE
add parentheses to langref `or` example

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1741,7 +1741,7 @@ unwrapped == 1234{#endsyntax#}</pre>
                           without evaluating {#syntax#}b{#endsyntax#}. Otherwise, returns {#syntax#}b{#endsyntax#}.
           </td>
           <td>
-            <pre>{#syntax#}false or true == true{#endsyntax#}</pre>
+            <pre>{#syntax#}(false or true) == true{#endsyntax#}</pre>
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
There was a similar issue for `and` in the past (#3272) but the same goes for `or`, only that the `or` example happens to work. Nevertheless I believe it doesn't show what was intended here.