### PR TITLE
macho: fail if requested -framework is not found

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -751,7 +751,6 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
                 }
             }
 
-            var framework_not_found = false;
             for (self.base.options.frameworks) |framework| {
                 for (&[_][]const u8{ ".tbd", ".dylib", "" }) |ext| {
                     if (try resolveFramework(arena, framework_dirs.items, framework, ext)) |full_path| {
@@ -760,14 +759,13 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
                     }
                 } else {
                     log.warn("framework not found for '-framework {s}'", .{framework});
-                    framework_not_found = true;
-                }
-            }
-
-            if (framework_not_found) {
-                log.warn("Framework search paths:", .{});
-                for (framework_dirs.items) |dir| {
-                    log.warn("  {s}", .{dir});
+                    log.warn("Framework search paths:", .{});
+                    for (framework_dirs.items) |dir| {
+                        log.warn("  {s}", .{dir});
+                    } else {
+                        log.warn("  <empty>. Consider specifying --sysroot", .{});
+                    }
+                    return error.FrameworkNotFound;
                 }
             }
 


### PR DESCRIPTION
If `-framework` is requested, but not found, the linker will err
instead of creating a strange executable.

https://github.com/ziglang/zig/issues/10299#issuecomment-990404953

Refs #9542
Refs #10299
Refs #10158