### PR TITLE
macho: allow undefined symbols in dylibs

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1703,6 +1703,16 @@ fn buildOutputType(
                     }
                     emit_implib = .{ .yes = linker_args.items[i] };
                     emit_implib_arg_provided = true;
+                } else if (mem.eql(u8, arg, "-undefined")) {
+                    i += 1;
+                    if (i >= linker_args.items.len) {
+                        fatal("expected linker arg after '{s}'", .{arg});
+                    }
+                    if (mem.eql(u8, "dynamic_lookup", linker_args.items[i])) {
+                        linker_allow_shlib_undefined = true;
+                    } else {
+                        fatal("unsupported -undefined option '{s}'", .{linker_args.items[i]});
+                    }
                 } else {
                     warn("unsupported linker arg: {s}", .{arg});
                 }


### PR DESCRIPTION
We now respect both `-fallow-shlib-undefined` and `-Wl,"-undefined=dynamic_lookup"` flags. This is the first step towards solving issues #8180. We currently do not expose any other ld64 equivalent flag for `-undefined` flag - we basically throw an error should the user specify a different flag. Support for those is conditional on closing #8180. As a result of this change, it is now possible to generate a valid native Node.js addon with Zig for macOS.

You can also check whether the option is on by requesting `--verbose-link` when building a shared object like so:

```
$ zig build-lib -dynamic example.zig -I$(brew --prefix node)/include/node -fallow-shlib-undefined -femit-bin=example.node --verbose-link
zig ld -dynamic -dylib -install_name @rpath/example.node zig-cache/o/f33f9be186fda290c12c65772584b1cb/example.o /Users/kubkon/.cache/zig/o/7d88bd701accf5f7b37248e431dd6be8/libcompiler_rt.a -o example.node -lSystem -lc -undefined dynamic_lookup
```

Fixes #3000

cc @jorangreef @ifreund 