### PR TITLE
implement more io_uring opcodes

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -3576,6 +3576,12 @@ pub const IORING_OP = enum(u8) {
     PROVIDE_BUFFERS,
     REMOVE_BUFFERS,
     TEE,
+    SHUTDOWN,
+    RENAMEAT,
+    UNLINKAT,
+    MKDIRAT,
+    SYMLINKAT,
+    LINKAT,
 
     _,
 };


### PR DESCRIPTION
This adds more io_uring opcodes.

The following are available since kernel 5.11:
* shutdown (equivalent to [this](https://github.com/axboe/liburing/blob/master/src/include/liburing.h#L652-L656) from liburing)
* renameat (equivalent to [this](https://github.com/axboe/liburing/blob/master/src/include/liburing.h#L665-L672) from liburing)
* unlinkat (equivalent to [this](https://github.com/axboe/liburing/blob/master/src/include/liburing.h#L658-L663) from liburing)

The following are available since kernel 5.15:
* mkdirat (equivalent to [this](https://github.com/axboe/liburing/blob/master/src/include/liburing.h#L682-L686) from liburing)
* symlinkat (equivalent to [this](https://github.com/axboe/liburing/blob/master/src/include/liburing.h#L688-L693) from liburing)
* linkat (equivalent to [this](https://github.com/axboe/liburing/blob/master/src/include/liburing.h#L695-L702) from liburing)