### PR TITLE
compiler_rt: simplify popcount "magic constants"

### DIFF
--- a/lib/std/special/compiler_rt/popcount.zig
+++ b/lib/std/special/compiler_rt/popcount.zig
@@ -9,45 +9,26 @@ const std = @import("std");
 //   SWAR-Masks and factors can be defined as 2-adic fractions
 // TAOCP: Combinational Algorithms, Bitwise Tricks And Techniques,
 //   subsubsection "Working with the rightmost bits" and "Sideways addition".
-fn popcountXi2_generic(comptime T: type) fn (a: T) callconv(.C) i32 {
-    return struct {
-        fn f(a: T) callconv(.C) i32 {
-            @setRuntimeSafety(builtin.is_test);
 
-            var x = switch (@bitSizeOf(T)) {
-                32 => @bitCast(u32, a),
-                64 => @bitCast(u64, a),
-                128 => @bitCast(u128, a),
+fn popcountXi2_generic(comptime ST: type) fn (a: ST) callconv(.C) i32 {
+    return struct {
+        fn f(a: ST) callconv(.C) i32 {
+            @setRuntimeSafety(builtin.is_test);
+            const UT = switch (ST) {
+                i32 => u32,
+                i64 => u64,
+                i128 => u128,
                 else => unreachable,
             };
-            const k1 = switch (@bitSizeOf(T)) { // -1/3
-                32 => @as(u32, 0x55555555),
-                64 => @as(u64, 0x55555555_55555555),
-                128 => @as(u128, 0x55555555_55555555_55555555_55555555),
-                else => unreachable,
-            };
-            const k2 = switch (@bitSizeOf(T)) { // -1/5
-                32 => @as(u32, 0x33333333),
-                64 => @as(u64, 0x33333333_33333333),
-                128 => @as(u128, 0x33333333_33333333_33333333_33333333),
-                else => unreachable,
-            };
-            const k4 = switch (@bitSizeOf(T)) { // -1/17
-                32 => @as(u32, 0x0f0f0f0f),
-                64 => @as(u64, 0x0f0f0f0f_0f0f0f0f),
-                128 => @as(u128, 0x0f0f0f0f_0f0f0f0f_0f0f0f0f_0f0f0f0f),
-                else => unreachable,
-            };
-            const kf = switch (@bitSizeOf(T)) { // -1/255
-                32 => @as(u32, 0x01010101),
-                64 => @as(u64, 0x01010101_01010101),
-                128 => @as(u128, 0x01010101_01010101_01010101_01010101),
-                else => unreachable,
-            };
-            x = x - ((x >> 1) & k1); // aggregate duos
-            x = (x & k2) + ((x >> 2) & k2); // aggregate nibbles
-            x = (x + (x >> 4)) & k4; // aggregate bytes
-            x = (x *% kf) >> @bitSizeOf(T) - 8; // 8 most significant bits of x + (x<<8) + (x<<16) + ..
+            var x = @bitCast(UT, a);
+            x -= (x >> 1) & (~@as(UT, 0) / 3); // 0x55...55, aggregate duos
+            x = ((x >> 2) & (~@as(UT, 0) / 5)) // 0x33...33, aggregate nibbles
+            + (x & (~@as(UT, 0) / 5));
+            x += x >> 4;
+            x &= ~@as(UT, 0) / 17; // 0x0F...0F, aggregate bytes
+            // 8 most significant bits of x + (x<<8) + (x<<16) + ..
+            x *%= ~@as(UT, 0) / 255; // 0x01...01
+            x >>= (@bitSizeOf(ST) - 8);
             return @intCast(i32, x);
         }
     }.f;


### PR DESCRIPTION
- magic constants are nicer to construct ie with
  (~@as(unsigned type, 0) / 3) == 0x55...55
- thanks to Stefan Kanthak for the idea