### PR TITLE
std.time.epoch: fix issue in documentation

### DIFF
--- a/lib/std/time/epoch.zig
+++ b/lib/std/time/epoch.zig
@@ -154,7 +154,7 @@ pub const EpochDay = struct {
 pub const DaySeconds = struct {
     secs: u17, // max is 24*60*60 = 86400
 
-    /// the number of hours past the start of the day (0 to 11)
+    /// the number of hours past the start of the day (0 to 23)
     pub fn getHoursIntoDay(self: DaySeconds) u5 {
         return @intCast(u5, @divTrunc(self.secs, 3600));
     }


### PR DESCRIPTION
std.time.epoch.DaySeconds.getHoursIntoDay said that hours goes from
0-11. should be 0-23.