### PR TITLE
TracyAllocator: correct order of free and alloc

### DIFF
--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -145,8 +145,8 @@ pub fn TracyAllocator(comptime name: ?[:0]const u8) type {
                     freeNamed(buf.ptr, n);
                     allocNamed(buf.ptr, resized_len, n);
                 } else {
-                    alloc(buf.ptr, resized_len);
                     free(buf.ptr);
+                    alloc(buf.ptr, resized_len);
                 }
 
                 return resized_len;


### PR DESCRIPTION
Issue noticed by @miscco on [this](https://github.com/ziglang/zig/commit/7d1f47313d798ce42f519b770edb2f1dae17199e#r61488504) commit