### PR TITLE
macho: handle -install_name option for dylibs/MachO

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1537,6 +1537,9 @@ pub const LibExeObjStep = struct {
     /// Permit read-only relocations in read-only segments. Disallowed by default.
     link_z_notext: bool = false,
 
+    /// (Darwin) Install name for the dylib
+    install_name: ?[]const u8 = null,
+
     /// Position Independent Code
     force_pic: ?bool = null,
 
@@ -2450,6 +2453,16 @@ pub const LibExeObjStep = struct {
             if (self.version) |version| {
                 zig_args.append("--version") catch unreachable;
                 zig_args.append(builder.fmt("{}", .{version})) catch unreachable;
+            }
+
+            if (self.target.isDarwin()) {
+                const install_name = self.install_name orelse builder.fmt("@rpath/{s}{s}{s}", .{
+                    self.target.libPrefix(),
+                    self.name,
+                    self.target.dynamicLibSuffix(),
+                });
+                try zig_args.append("-install_name");
+                try zig_args.append(install_name);
             }
         }
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -780,6 +780,8 @@ pub const InitOptions = struct {
     enable_link_snapshots: bool = false,
     /// (Darwin) Path and version of the native SDK if detected.
     native_darwin_sdk: ?std.zig.system.darwin.DarwinSDK = null,
+    /// (Darwin) Install name of the dylib
+    install_name: ?[]const u8 = null,
 };
 
 fn addPackageTableToCacheHash(
@@ -1509,6 +1511,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .use_stage1 = use_stage1,
             .enable_link_snapshots = options.enable_link_snapshots,
             .native_darwin_sdk = options.native_darwin_sdk,
+            .install_name = options.install_name,
         });
         errdefer bin_file.destroy();
         comp.* = .{

--- a/src/link.zig
+++ b/src/link.zig
@@ -157,6 +157,9 @@ pub const Options = struct {
     /// (Darwin) Path and version of the native SDK if detected.
     native_darwin_sdk: ?std.zig.system.darwin.DarwinSDK = null,
 
+    /// (Darwin) Install name for the dylib
+    install_name: ?[]const u8 = null,
+
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;
     }


### PR DESCRIPTION
Given that this change is small when it comes to the amount of the required code edits, I've decided to go straight for a PR rather than submitting an issue first. I reckon with the code changes in this PR, it will be easier to discuss this proposal. This proposal changes the default behaviour for the ID of the created dynamic library targeting darwin in the following way:

The status quo for the `build.zig` build system is preserved in the sense that, if the user does not explicitly override
`dylib.setInstallName(...);` in their build script, the default of `@rpath/libname.dylib` applies. However, should they want to override the default behaviour, they can either:

1) unset it with

```dylib.setIntallName(null);```

2) set it to an explicit string with

```dylib.setInstallName("somename.dylib");```

When it comes to the command line however, the default is not to use `@rpath` for the install name when creating a dylib. The user will now be required to explicitly specify the `@rpath` as part of the desired install name should they choose so like so:

1) with `build-lib`

```
zig build-lib -dynamic foo.zig -install_name @rpath/libfoo.dylib
```

2) with `cc`

```
zig cc -shared foo.c -o libfoo.dylib -Wl,"-install_name=@rpath/libfoo.dylib"
```

I think this is a reasonable new default which effectively gives the user full control over the dylib's install name when building the library via the command line primitives such as `zig build-lib -dynamic` and `zig cc -shared`, and at the same time, Zig's build system still makes the inclusion of the `@rpath/` prefix in the generated dylib's install name the default.