### PR TITLE
stage2 ARM: spill insts currently in compare flags if necessary

### DIFF
--- a/test/stage2/arm.zig
+++ b/test/stage2/arm.zig
@@ -547,4 +547,25 @@ pub fn addCases(ctx: *TestContext) !void {
             ,
         );
     }
+
+    {
+        var case = ctx.exe("save compare flags", linux_arm);
+        case.addCompareOutput(
+            \\pub fn main() void {
+            \\    foo(2, 1);
+            \\}
+            \\
+            \\fn foo(x: u32, y: u32) void {
+            \\    const b = x > y;
+            \\    assert(b);
+            \\    assert(b);
+            \\}
+            \\
+            \\pub fn assert(ok: bool) void {
+            \\    if (!ok) unreachable; // assertion failure
+            \\}
+        ,
+            "",
+        );
+    }
 }


### PR DESCRIPTION
This fixes an issue discussed some time ago in [a stage2 meeting](https://github.com/ziglang/zig/wiki/Self-Hosted-Compiler-Meetings#2021-07-29). The attached test which previously failed case now works.