### PR TITLE
stage1: deal with BPF not supporting @returnAddress()

### DIFF
--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -118,6 +118,11 @@ const sys_can_stack_trace = switch (builtin.cpu.arch) {
     .wasm64,
     => builtin.os.tag == .emscripten,
 
+    // `@returnAddress()` is unsupported in LLVM 13.
+    .bpfel,
+    .bpfeb,
+    => false,
+
     else => true,
 };
 const default_test_stack_trace_frames: usize = if (builtin.is_test) 8 else 4;

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -6208,7 +6208,7 @@ static LLVMValueRef ir_render_breakpoint(CodeGen *g, Stage1Air *executable, Stag
 static LLVMValueRef ir_render_return_address(CodeGen *g, Stage1Air *executable,
         Stage1AirInstReturnAddress *instruction)
 {
-    if (target_is_wasm(g->zig_target) && g->zig_target->os != OsEmscripten) {
+    if ((target_is_wasm(g->zig_target) && g->zig_target->os != OsEmscripten) || target_is_bpf(g->zig_target)) {
         // I got this error from LLVM 10:
         // "Non-Emscripten WebAssembly hasn't implemented __builtin_return_address"
         return LLVMConstNull(get_llvm_type(g, instruction->base.value->type));

--- a/src/stage1/target.cpp
+++ b/src/stage1/target.cpp
@@ -940,6 +940,10 @@ bool target_is_wasm(const ZigTarget *target) {
     return target->arch == ZigLLVM_wasm32 || target->arch == ZigLLVM_wasm64;
 }
 
+bool target_is_bpf(const ZigTarget *target) {
+    return target->arch == ZigLLVM_bpfel || target->arch == ZigLLVM_bpfeb;
+}
+
 ZigLLVM_EnvironmentType target_default_abi(ZigLLVM_ArchType arch, Os os) {
     if (arch == ZigLLVM_wasm32 || arch == ZigLLVM_wasm64) {
         return ZigLLVM_Musl;

--- a/src/stage1/target.hpp
+++ b/src/stage1/target.hpp
@@ -75,6 +75,7 @@ bool target_allows_addr_zero(const ZigTarget *target);
 bool target_has_valgrind_support(const ZigTarget *target);
 bool target_os_is_darwin(Os os);
 bool target_is_wasm(const ZigTarget *target);
+bool target_is_bpf(const ZigTarget *target);
 bool target_is_riscv(const ZigTarget *target);
 bool target_is_sparc(const ZigTarget *target);
 bool target_is_android(const ZigTarget *target);


### PR DESCRIPTION
Make `@returnAddress()` return for the BPF target, as the BPF target for the time being does not support probing for the return address. Stack traces for the general purpose allocator for the BPF target is also set to not be captured.