### PR TITLE
stage2: Make page_allocator work

### DIFF
--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -590,8 +590,9 @@ test "big.int addWrap single-single, unsigned" {
     var b = try Managed.initSet(testing.allocator, 10);
     defer b.deinit();
 
-    try a.addWrap(a.toConst(), b.toConst(), .unsigned, 17);
+    const wrapped = try a.addWrap(a.toConst(), b.toConst(), .unsigned, 17);
 
+    try testing.expect(wrapped);
     try testing.expect((try a.to(u17)) == 9);
 }
 
@@ -602,8 +603,9 @@ test "big.int subWrap single-single, unsigned" {
     var b = try Managed.initSet(testing.allocator, maxInt(u17));
     defer b.deinit();
 
-    try a.subWrap(a.toConst(), b.toConst(), .unsigned, 17);
+    const wrapped = try a.subWrap(a.toConst(), b.toConst(), .unsigned, 17);
 
+    try testing.expect(wrapped);
     try testing.expect((try a.to(u17)) == 1);
 }
 
@@ -614,8 +616,9 @@ test "big.int addWrap multi-multi, unsigned, limb aligned" {
     var b = try Managed.initSet(testing.allocator, maxInt(DoubleLimb));
     defer b.deinit();
 
-    try a.addWrap(a.toConst(), b.toConst(), .unsigned, @bitSizeOf(DoubleLimb));
+    const wrapped = try a.addWrap(a.toConst(), b.toConst(), .unsigned, @bitSizeOf(DoubleLimb));
 
+    try testing.expect(wrapped);
     try testing.expect((try a.to(DoubleLimb)) == maxInt(DoubleLimb) - 1);
 }
 
@@ -626,8 +629,9 @@ test "big.int subWrap single-multi, unsigned, limb aligned" {
     var b = try Managed.initSet(testing.allocator, maxInt(DoubleLimb) + 100);
     defer b.deinit();
 
-    try a.subWrap(a.toConst(), b.toConst(), .unsigned, @bitSizeOf(DoubleLimb));
+    const wrapped = try a.subWrap(a.toConst(), b.toConst(), .unsigned, @bitSizeOf(DoubleLimb));
 
+    try testing.expect(wrapped);
     try testing.expect((try a.to(DoubleLimb)) == maxInt(DoubleLimb) - 88);
 }
 
@@ -638,8 +642,9 @@ test "big.int addWrap single-single, signed" {
     var b = try Managed.initSet(testing.allocator, 1 + 1 + maxInt(u21));
     defer b.deinit();
 
-    try a.addWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(i21));
+    const wrapped = try a.addWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(i21));
 
+    try testing.expect(wrapped);
     try testing.expect((try a.to(i21)) == minInt(i21));
 }
 
@@ -650,8 +655,9 @@ test "big.int subWrap single-single, signed" {
     var b = try Managed.initSet(testing.allocator, 1);
     defer b.deinit();
 
-    try a.subWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(i21));
+    const wrapped = try a.subWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(i21));
 
+    try testing.expect(wrapped);
     try testing.expect((try a.to(i21)) == maxInt(i21));
 }
 
@@ -662,8 +668,9 @@ test "big.int addWrap multi-multi, signed, limb aligned" {
     var b = try Managed.initSet(testing.allocator, maxInt(SignedDoubleLimb));
     defer b.deinit();
 
-    try a.addWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(SignedDoubleLimb));
+    const wrapped = try a.addWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(SignedDoubleLimb));
 
+    try testing.expect(wrapped);
     try testing.expect((try a.to(SignedDoubleLimb)) == -2);
 }
 
@@ -674,8 +681,9 @@ test "big.int subWrap single-multi, signed, limb aligned" {
     var b = try Managed.initSet(testing.allocator, 1);
     defer b.deinit();
 
-    try a.subWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(SignedDoubleLimb));
+    const wrapped = try a.subWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(SignedDoubleLimb));
 
+    try testing.expect(wrapped);
     try testing.expect((try a.to(SignedDoubleLimb)) == maxInt(SignedDoubleLimb));
 }
 

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4968,7 +4968,11 @@ pub fn toPosixPath(file_path: []const u8) ![MAX_PATH_BYTES - 1:0]u8 {
 /// if this happens the fix is to add the error code to the corresponding
 /// switch expression, possibly introduce a new error in the error set, and
 /// send a patch to Zig.
-pub const unexpected_error_tracing = builtin.mode == .Debug;
+/// The self-hosted compiler is not fully capable of handle the related code.
+/// Until then, unexpected error tracing is disabled for the self-hosted compiler.
+/// TODO remove this once self-hosted is capable enough to handle printing and
+/// stack trace dumping.
+pub const unexpected_error_tracing = !builtin.zig_is_stage2 and builtin.mode == .Debug;
 
 pub const UnexpectedError = error{
     /// The Operating System returned an undocumented error code.

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -195,6 +195,9 @@ pub const Inst = struct {
         /// Lowers to a hardware trap instruction, or the next best thing.
         /// Result type is always void.
         breakpoint,
+        /// Yields the return address of the current function.
+        /// Uses the `no_op` field.
+        ret_addr,
         /// Function call.
         /// Result type is the return type of the function being called.
         /// Uses the `pl_op` field with the `Call` payload. operand is the callee.
@@ -785,6 +788,7 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
 
         .ptrtoint,
         .slice_len,
+        .ret_addr,
         => return Type.initTag(.usize),
 
         .bool_to_int => return Type.initTag(.u1),

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -141,6 +141,12 @@ pub const Inst = struct {
         /// of the operation.
         /// Uses the `pl_op` field with payload `Bin`.
         add_with_overflow,
+        /// Integer multiplication with overflow. Both operands are guaranteed to be the same type,
+        /// and the result is bool. The wrapped value is written to the pointer given by the in
+        /// operand of the `pl_op` field. Payload is `Bin` with `lhs` and `rhs` the relevant types
+        /// of the operation.
+        /// Uses the `pl_op` field with payload `Bin`.
+        mul_with_overflow,
         /// Allocates stack local memory.
         /// Uses the `ty` field.
         alloc,
@@ -815,7 +821,9 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
             return ptr_ty.elemType();
         },
 
-        .add_with_overflow => return Type.initTag(.bool),
+        .add_with_overflow,
+        .mul_with_overflow,
+        => return Type.initTag(.bool),
     }
 }
 

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -141,6 +141,12 @@ pub const Inst = struct {
         /// of the operation.
         /// Uses the `pl_op` field with payload `Bin`.
         add_with_overflow,
+        /// Integer subtraction with overflow. Both operands are guaranteed to be the same type,
+        /// and the result is bool. The wrapped value is written to the pointer given by the in
+        /// operand of the `pl_op` field. Payload is `Bin` with `lhs` and `rhs` the relevant types
+        /// of the operation.
+        /// Uses the `pl_op` field with payload `Bin`.
+        sub_with_overflow,
         /// Integer multiplication with overflow. Both operands are guaranteed to be the same type,
         /// and the result is bool. The wrapped value is written to the pointer given by the in
         /// operand of the `pl_op` field. Payload is `Bin` with `lhs` and `rhs` the relevant types
@@ -822,6 +828,7 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         },
 
         .add_with_overflow,
+        .sub_with_overflow,
         .mul_with_overflow,
         => return Type.initTag(.bool),
     }

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -153,6 +153,12 @@ pub const Inst = struct {
         /// of the operation.
         /// Uses the `pl_op` field with payload `Bin`.
         mul_with_overflow,
+        /// Integer left-shift with overflow. Both operands are guaranteed to be the same type,
+        /// and the result is bool. The wrapped value is written to the pointer given by the in
+        /// operand of the `pl_op` field. Payload is `Bin` with `lhs` and `rhs` the relevant types
+        /// of the operation.
+        /// Uses the `pl_op` field with payload `Bin`.
+        shl_with_overflow,
         /// Allocates stack local memory.
         /// Uses the `ty` field.
         alloc,
@@ -830,6 +836,7 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .add_with_overflow,
         .sub_with_overflow,
         .mul_with_overflow,
+        .shl_with_overflow,
         => return Type.initTag(.bool),
     }
 }

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -135,6 +135,12 @@ pub const Inst = struct {
         /// is the same as both operands.
         /// Uses the `bin_op` field.
         min,
+        /// Integer addition with overflow. Both operands are guaranteed to be the same type,
+        /// and the result is bool. The wrapped value is written to the pointer given by the in
+        /// operand of the `pl_op` field. Payload is `Bin` with `lhs` and `rhs` the relevant types
+        /// of the operation.
+        /// Uses the `pl_op` field with payload `Bin`.
+        add_with_overflow,
         /// Allocates stack local memory.
         /// Uses the `ty` field.
         alloc,
@@ -804,6 +810,8 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
             const ptr_ty = air.typeOf(datas[inst].pl_op.operand);
             return ptr_ty.elemType();
         },
+
+        .add_with_overflow => return Type.initTag(.bool),
     }
 }
 

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -387,7 +387,8 @@ fn analyzeInst(
         .add_with_overflow,
         .sub_with_overflow,
         .mul_with_overflow,
-         => {
+        .shl_with_overflow,
+        => {
             const pl_op = inst_datas[inst].pl_op;
             const extra = a.air.extraData(Air.Bin, pl_op.payload).data;
             return trackOperands(a, new_set, inst, main_tomb, .{ pl_op.operand, extra.lhs, extra.rhs });

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -382,7 +382,12 @@ fn analyzeInst(
             const extra = a.air.extraData(Air.AtomicRmw, pl_op.payload).data;
             return trackOperands(a, new_set, inst, main_tomb, .{ pl_op.operand, extra.operand, .none });
         },
-        .memset, .memcpy, .add_with_overflow, .mul_with_overflow => {
+        .memset,
+        .memcpy,
+        .add_with_overflow,
+        .sub_with_overflow,
+        .mul_with_overflow,
+         => {
             const pl_op = inst_datas[inst].pl_op;
             const extra = a.air.extraData(Air.Bin, pl_op.payload).data;
             return trackOperands(a, new_set, inst, main_tomb, .{ pl_op.operand, extra.lhs, extra.rhs });

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -281,6 +281,7 @@ fn analyzeInst(
         .dbg_stmt,
         .unreach,
         .fence,
+        .ret_addr,
         => return trackOperands(a, new_set, inst, main_tomb, .{ .none, .none, .none }),
 
         .not,

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -381,7 +381,7 @@ fn analyzeInst(
             const extra = a.air.extraData(Air.AtomicRmw, pl_op.payload).data;
             return trackOperands(a, new_set, inst, main_tomb, .{ pl_op.operand, extra.operand, .none });
         },
-        .memset, .memcpy => {
+        .memset, .memcpy, .add_with_overflow => {
             const pl_op = inst_datas[inst].pl_op;
             const extra = a.air.extraData(Air.Bin, pl_op.payload).data;
             return trackOperands(a, new_set, inst, main_tomb, .{ pl_op.operand, extra.lhs, extra.rhs });

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -382,7 +382,7 @@ fn analyzeInst(
             const extra = a.air.extraData(Air.AtomicRmw, pl_op.payload).data;
             return trackOperands(a, new_set, inst, main_tomb, .{ pl_op.operand, extra.operand, .none });
         },
-        .memset, .memcpy, .add_with_overflow => {
+        .memset, .memcpy, .add_with_overflow, .mul_with_overflow => {
             const pl_op = inst_datas[inst].pl_op;
             const extra = a.air.extraData(Air.Bin, pl_op.payload).data;
             return trackOperands(a, new_set, inst, main_tomb, .{ pl_op.operand, extra.lhs, extra.rhs });

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -796,15 +796,11 @@ pub const ErrorSet = struct {
     owner_decl: *Decl,
     /// Offset from Decl node index, points to the error set AST node.
     node_offset: i32,
-    names_len: u32,
     /// The string bytes are stored in the owner Decl arena.
     /// They are in the same order they appear in the AST.
-    /// The length is given by `names_len`.
-    names_ptr: [*]const []const u8,
+    names: NameMap,
 
-    pub fn names(self: ErrorSet) []const []const u8 {
-        return self.names_ptr[0..self.names_len];
-    }
+    pub const NameMap = std.StringArrayHashMapUnmanaged(void);
 
     pub fn srcLoc(self: ErrorSet) SrcLoc {
         return .{

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -8739,8 +8739,12 @@ fn zirRetAddr(
     block: *Block,
     extended: Zir.Inst.Extended.InstData,
 ) CompileError!Air.Inst.Ref {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const src: LazySrcLoc = .{ .node_offset = @bitCast(i32, extended.operand) };
-    return sema.fail(block, src, "TODO: implement Sema.zirRetAddr", .{});
+    try sema.requireRuntimeBlock(block, src);
+    return try block.addNoOp(.ret_addr);
 }
 
 fn zirBuiltinSrc(

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -940,6 +940,15 @@ pub fn analyzeBody(
                 const inst_data = datas[inst].pl_node;
                 const extra = sema.code.extraData(Zir.Inst.Block, inst_data.payload_index);
                 const inline_body = sema.code.extra[extra.end..][0..extra.data.body_len];
+                // If this block contains a function prototype, we need to reset the
+                // current list of parameters and restore it later.
+                // Note: this probably needs to be resolved in a more general manner.
+                const prev_params = block.params;
+                block.params = .{};
+                defer {
+                    block.params.deinit(sema.gpa);
+                    block.params = prev_params;
+                }
                 const break_inst = try sema.analyzeBody(block, inline_body);
                 const break_data = datas[break_inst].@"break";
                 if (inst == break_data.block_inst) {
@@ -953,6 +962,15 @@ pub fn analyzeBody(
                 const inst_data = datas[inst].pl_node;
                 const extra = sema.code.extraData(Zir.Inst.Block, inst_data.payload_index);
                 const inline_body = sema.code.extra[extra.end..][0..extra.data.body_len];
+                // If this block contains a function prototype, we need to reset the
+                // current list of parameters and restore it later.
+                // Note: this probably needs to be resolved in a more general manner.
+                const prev_params = block.params;
+                block.params = .{};
+                defer {
+                    block.params.deinit(sema.gpa);
+                    block.params = prev_params;
+                }
                 const break_inst = try sema.analyzeBody(block, inline_body);
                 const break_data = datas[break_inst].@"break";
                 if (inst == break_data.block_inst) {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -8881,7 +8881,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
         },
         .Pointer => {
             const info = ty.ptrInfo().data;
-            const field_values = try sema.arena.alloc(Value, 7);
+            const field_values = try sema.arena.alloc(Value, 8);
             // size: Size,
             field_values[0] = try Value.Tag.enum_field_index.create(sema.arena, @enumToInt(info.size));
             // is_const: bool,
@@ -8890,12 +8890,14 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
             field_values[2] = if (info.@"volatile") Value.initTag(.bool_true) else Value.initTag(.bool_false);
             // alignment: comptime_int,
             field_values[3] = try Value.Tag.int_u64.create(sema.arena, info.@"align");
+            // address_space: AddressSpace
+            field_values[4] = try Value.Tag.enum_field_index.create(sema.arena, @enumToInt(info.@"addrspace"));
             // child: type,
-            field_values[4] = try Value.Tag.ty.create(sema.arena, info.pointee_type);
+            field_values[5] = try Value.Tag.ty.create(sema.arena, info.pointee_type);
             // is_allowzero: bool,
-            field_values[5] = if (info.@"allowzero") Value.initTag(.bool_true) else Value.initTag(.bool_false);
+            field_values[6] = if (info.@"allowzero") Value.initTag(.bool_true) else Value.initTag(.bool_false);
             // sentinel: anytype,
-            field_values[6] = if (info.sentinel) |some| try Value.Tag.opt_payload.create(sema.arena, some) else Value.@"null";
+            field_values[7] = if (info.sentinel) |some| try Value.Tag.opt_payload.create(sema.arena, some) else Value.@"null";
 
             return sema.addConstant(
                 type_info_ty,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -13990,6 +13990,13 @@ fn wrapErrorUnion(
                 if (data.errors.contains(expected_name)) break :ok;
                 return sema.failWithErrorSetCodeMissing(block, inst_src, dest_err_set_ty, inst_ty);
             },
+            .error_set_merged => {
+                const expected_name = val.castTag(.@"error").?.data.name;
+                const error_set = dest_err_set_ty.castTag(.error_set_merged).?.data;
+                if (!error_set.contains(expected_name)) {
+                    return sema.failWithErrorSetCodeMissing(block, inst_src, dest_err_set_ty, inst_ty);
+                }
+            },
             else => unreachable,
         }
         return sema.addConstant(dest_ty, val);

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5381,7 +5381,7 @@ fn zirPtrToInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
     const inst_data = sema.code.instructions.items(.data)[inst].un_node;
     const ptr = sema.resolveInst(inst_data.operand);
     const ptr_ty = sema.typeOf(ptr);
-    if (ptr_ty.zigTypeTag() != .Pointer) {
+    if (!ptr_ty.isPtrAtRuntime()) {
         const ptr_src: LazySrcLoc = .{ .node_offset_builtin_call_arg0 = inst_data.src_node };
         return sema.fail(block, ptr_src, "expected pointer, found '{}'", .{ptr_ty});
     }

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -547,6 +547,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .block           => try self.airBlock(inst),
                     .br              => try self.airBr(inst),
                     .breakpoint      => try self.airBreakpoint(),
+                    .ret_addr        => try self.airRetAddr(),
                     .fence           => try self.airFence(),
                     .call            => try self.airCall(inst),
                     .cond_br         => try self.airCondBr(inst),
@@ -1414,6 +1415,10 @@ fn airBreakpoint(self: *Self) !void {
         .data = .{ .imm16 = 1 },
     });
     return self.finishAirBookkeeping();
+}
+
+fn airRetAddr(self: *Self) !void {
+    return self.fail("TODO implement airRetAddr for {}", .{self.target.cpu.arch});
 }
 
 fn airFence(self: *Self) !void {

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -522,6 +522,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .slice           => try self.airSlice(inst),
 
                     .add_with_overflow => try self.airAddWithOverflow(inst),
+                    .sub_with_overflow => try self.airSubWithOverflow(inst),
                     .mul_with_overflow => try self.airMulWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
@@ -975,6 +976,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
     return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airSubResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -524,6 +524,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .add_with_overflow => try self.airAddWithOverflow(inst),
                     .sub_with_overflow => try self.airSubWithOverflow(inst),
                     .mul_with_overflow => try self.airMulWithOverflow(inst),
+                    .shl_with_overflow => try self.airShlWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
@@ -975,17 +976,22 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airAddWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airSubResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airSubWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airMulResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airMulWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airShlWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airShlWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -522,6 +522,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .slice           => try self.airSlice(inst),
 
                     .add_with_overflow => try self.airAddWithOverflow(inst),
+                    .mul_with_overflow => try self.airMulWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
@@ -974,6 +975,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
     return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airMulResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -521,6 +521,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .max             => try self.airMax(inst),
                     .slice           => try self.airSlice(inst),
 
+                    .add_with_overflow => try self.airAddWithOverflow(inst),
+
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
                     .cmp_lt  => try self.airCmp(inst, .lt),
@@ -966,6 +968,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
     const bin_op = self.air.instructions.items(.data)[inst].bin_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement mul_sat for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ bin_op.lhs, bin_op.rhs, .none });
+}
+
+fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -520,6 +520,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .slice           => try self.airSlice(inst),
 
                     .add_with_overflow => try self.airAddWithOverflow(inst),
+                    .mul_with_overflow => try self.airMulWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
@@ -1004,6 +1005,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
     return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airMulResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -520,6 +520,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .slice           => try self.airSlice(inst),
 
                     .add_with_overflow => try self.airAddWithOverflow(inst),
+                    .sub_with_overflow => try self.airSubWithOverflow(inst),
                     .mul_with_overflow => try self.airMulWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
@@ -1005,6 +1006,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
     return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airSubResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -545,6 +545,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .block           => try self.airBlock(inst),
                     .br              => try self.airBr(inst),
                     .breakpoint      => try self.airBreakpoint(),
+                    .ret_addr        => try self.airRetAddr(),
                     .fence           => try self.airFence(),
                     .call            => try self.airCall(inst),
                     .cond_br         => try self.airCondBr(inst),
@@ -1848,6 +1849,10 @@ fn airBreakpoint(self: *Self) !void {
         .data = .{ .imm16 = 0 },
     });
     return self.finishAirBookkeeping();
+}
+
+fn airRetAddr(self: *Self) !void {
+    return self.fail("TODO implement airRetAddr for {}", .{self.target.cpu.arch});
 }
 
 fn airFence(self: *Self) !void {

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -522,6 +522,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .add_with_overflow => try self.airAddWithOverflow(inst),
                     .sub_with_overflow => try self.airSubWithOverflow(inst),
                     .mul_with_overflow => try self.airMulWithOverflow(inst),
+                    .shl_with_overflow => try self.airShlWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
@@ -1005,17 +1006,22 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airAddWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airSubResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airSubWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airMulResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airMulWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airShlWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airShlWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -519,6 +519,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .max             => try self.airMax(inst),
                     .slice           => try self.airSlice(inst),
 
+                    .add_with_overflow => try self.airAddWithOverflow(inst),
+
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
                     .cmp_lt  => try self.airCmp(inst, .lt),
@@ -996,6 +998,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
     const bin_op = self.air.instructions.items(.data)[inst].bin_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement mul_sat for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ bin_op.lhs, bin_op.rhs, .none });
+}
+
+fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -503,6 +503,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .add_with_overflow => try self.airAddWithOverflow(inst),
                     .sub_with_overflow => try self.airSubWithOverflow(inst),
                     .mul_with_overflow => try self.airMulWithOverflow(inst),
+                    .shl_with_overflow => try self.airShlWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
@@ -920,17 +921,22 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airAddWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airSubResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airSubWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airMulResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airMulWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airShlWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airShlWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -501,6 +501,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .slice           => try self.airSlice(inst),
 
                     .add_with_overflow => try self.airAddWithOverflow(inst),
+                    .mul_with_overflow => try self.airMulWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
@@ -919,6 +920,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
     return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airMulResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -526,6 +526,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .block           => try self.airBlock(inst),
                     .br              => try self.airBr(inst),
                     .breakpoint      => try self.airBreakpoint(),
+                    .ret_addr        => try self.airRetAddr(),
                     .fence           => try self.airFence(),
                     .call            => try self.airCall(inst),
                     .cond_br         => try self.airCondBr(inst),
@@ -1352,6 +1353,10 @@ fn airBreakpoint(self: *Self) !void {
         .data = .{ .nop = {} },
     });
     return self.finishAirBookkeeping();
+}
+
+fn airRetAddr(self: *Self) !void {
+    return self.fail("TODO implement airRetAddr for {}", .{self.target.cpu.arch});
 }
 
 fn airFence(self: *Self) !void {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -500,6 +500,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .max             => try self.airMax(inst),
                     .slice           => try self.airSlice(inst),
 
+                    .add_with_overflow => try self.airAddWithOverflow(inst),
+
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
                     .cmp_lt  => try self.airCmp(inst, .lt),
@@ -911,6 +913,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
     const bin_op = self.air.instructions.items(.data)[inst].bin_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement mul_sat for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ bin_op.lhs, bin_op.rhs, .none });
+}
+
+fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -501,6 +501,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .slice           => try self.airSlice(inst),
 
                     .add_with_overflow => try self.airAddWithOverflow(inst),
+                    .sub_with_overflow => try self.airSubWithOverflow(inst),
                     .mul_with_overflow => try self.airMulWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
@@ -920,6 +921,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
     return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airSubResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -554,6 +554,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .slice           => try self.airSlice(inst),
 
                     .add_with_overflow => try self.airAddWithOverflow(inst),
+                    .sub_with_overflow => try self.airSubWithOverflow(inst),
                     .mul_with_overflow => try self.airMulWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
@@ -1034,6 +1035,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
     return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airSubResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -579,6 +579,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .block           => try self.airBlock(inst),
                     .br              => try self.airBr(inst),
                     .breakpoint      => try self.airBreakpoint(),
+                    .ret_addr        => try self.airRetAddr(),
                     .fence           => try self.airFence(),
                     .call            => try self.airCall(inst),
                     .cond_br         => try self.airCondBr(inst),
@@ -1837,6 +1838,10 @@ fn airBreakpoint(self: *Self) !void {
         .data = undefined,
     });
     return self.finishAirBookkeeping();
+}
+
+fn airRetAddr(self: *Self) !void {
+    return self.fail("TODO implement airRetAddr for {}", .{self.target.cpu.arch});
 }
 
 fn airFence(self: *Self) !void {

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -556,6 +556,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .add_with_overflow => try self.airAddWithOverflow(inst),
                     .sub_with_overflow => try self.airSubWithOverflow(inst),
                     .mul_with_overflow => try self.airMulWithOverflow(inst),
+                    .shl_with_overflow => try self.airShlWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
@@ -1034,17 +1035,22 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airAddWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airSubResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airSubWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
-    return self.fail("TODO implement airMulResultWithOverflow for {}", .{self.target.cpu.arch});
+    return self.fail("TODO implement airMulWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airShlWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airShlWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -553,6 +553,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .max             => try self.airMax(inst),
                     .slice           => try self.airSlice(inst),
 
+                    .add_with_overflow => try self.airAddWithOverflow(inst),
+
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
                     .cmp_lt  => try self.airCmp(inst, .lt),
@@ -1025,6 +1027,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
     else
         return self.fail("TODO implement mul_sat for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ bin_op.lhs, bin_op.rhs, .none });
+}
+
+fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -554,6 +554,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
                     .slice           => try self.airSlice(inst),
 
                     .add_with_overflow => try self.airAddWithOverflow(inst),
+                    .mul_with_overflow => try self.airMulWithOverflow(inst),
 
                     .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
@@ -1033,6 +1034,11 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 fn airAddWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     _ = inst;
     return self.fail("TODO implement airAddResultWithOverflow for {}", .{self.target.cpu.arch});
+}
+
+fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
+    _ = inst;
+    return self.fail("TODO implement airMulResultWithOverflow for {}", .{self.target.cpu.arch});
 }
 
 fn airDiv(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -722,7 +722,7 @@ pub const DeclGen = struct {
         try bw.writeAll(" payload; uint16_t error; } ");
         const name_index = buffer.items.len;
         if (err_set_type.castTag(.error_set_inferred)) |inf_err_set_payload| {
-            const func = inf_err_set_payload.data;
+            const func = inf_err_set_payload.data.func;
             try bw.writeAll("zig_E_");
             try dg.renderDeclName(func.owner_decl, bw);
             try bw.writeAll(";\n");

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1155,6 +1155,8 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .mul_sat => try airSatOp(f, inst, "muls_"),
             .shl_sat => try airSatOp(f, inst, "shls_"),
 
+            .add_with_overflow => try airAddWithOverflow(f, inst),
+
             .min => try airMinMax(f, inst, "<"),
             .max => try airMinMax(f, inst, ">"),
 
@@ -1862,6 +1864,12 @@ fn airSatOp(f: *Function, inst: Air.Inst.Index, fn_op: [*:0]const u8) !CValue {
     try f.object.indent_writer.insertNewline();
 
     return ret;
+}
+
+fn airAddWithOverflow(f: *Function, inst: Air.Inst.Index) !CValue {
+    _ = f;
+    _ = inst;
+    return f.fail("TODO add with overflow", .{});
 }
 
 fn airNot(f: *Function, inst: Air.Inst.Index) !CValue {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1159,6 +1159,7 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .add_with_overflow => try airAddWithOverflow(f, inst),
             .sub_with_overflow => try airSubWithOverflow(f, inst),
             .mul_with_overflow => try airMulWithOverflow(f, inst),
+            .shl_with_overflow => try airShlWithOverflow(f, inst),
 
             .min => try airMinMax(f, inst, "<"),
             .max => try airMinMax(f, inst, ">"),
@@ -1885,6 +1886,12 @@ fn airMulWithOverflow(f: *Function, inst: Air.Inst.Index) !CValue {
     _ = f;
     _ = inst;
     return f.fail("TODO mul with overflow", .{});
+}
+
+fn airShlWithOverflow(f: *Function, inst: Air.Inst.Index) !CValue {
+    _ = f;
+    _ = inst;
+    return f.fail("TODO shl with overflow", .{});
 }
 
 fn airNot(f: *Function, inst: Air.Inst.Index) !CValue {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1157,6 +1157,7 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .shl_sat => try airSatOp(f, inst, "shls_"),
 
             .add_with_overflow => try airAddWithOverflow(f, inst),
+            .mul_with_overflow => try airMulWithOverflow(f, inst),
 
             .min => try airMinMax(f, inst, "<"),
             .max => try airMinMax(f, inst, ">"),
@@ -1871,6 +1872,12 @@ fn airAddWithOverflow(f: *Function, inst: Air.Inst.Index) !CValue {
     _ = f;
     _ = inst;
     return f.fail("TODO add with overflow", .{});
+}
+
+fn airMulWithOverflow(f: *Function, inst: Air.Inst.Index) !CValue {
+    _ = f;
+    _ = inst;
+    return f.fail("TODO mul with overflow", .{});
 }
 
 fn airNot(f: *Function, inst: Air.Inst.Index) !CValue {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1125,6 +1125,7 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .arg      => airArg(f),
 
             .breakpoint => try airBreakpoint(f),
+            .ret_addr   => try airRetAddr(f),
             .unreach    => try airUnreach(f),
             .fence      => try airFence(f, inst),
 
@@ -2189,6 +2190,10 @@ fn airBitcast(f: *Function, inst: Air.Inst.Index) !CValue {
 fn airBreakpoint(f: *Function) !CValue {
     try f.object.writer().writeAll("zig_breakpoint();\n");
     return CValue.none;
+}
+
+fn airRetAddr(f: *Function) !CValue {
+    return f.fail("TODO implement codegen for airRetAddr", .{});
 }
 
 fn airFence(f: *Function, inst: Air.Inst.Index) !CValue {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1157,6 +1157,7 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .shl_sat => try airSatOp(f, inst, "shls_"),
 
             .add_with_overflow => try airAddWithOverflow(f, inst),
+            .sub_with_overflow => try airSubWithOverflow(f, inst),
             .mul_with_overflow => try airMulWithOverflow(f, inst),
 
             .min => try airMinMax(f, inst, "<"),
@@ -1872,6 +1873,12 @@ fn airAddWithOverflow(f: *Function, inst: Air.Inst.Index) !CValue {
     _ = f;
     _ = inst;
     return f.fail("TODO add with overflow", .{});
+}
+
+fn airSubWithOverflow(f: *Function, inst: Air.Inst.Index) !CValue {
+    _ = f;
+    _ = inst;
+    return f.fail("TODO sub with overflow", .{});
 }
 
 fn airMulWithOverflow(f: *Function, inst: Air.Inst.Index) !CValue {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -722,7 +722,7 @@ pub const DeclGen = struct {
         try bw.writeAll(" payload; uint16_t error; } ");
         const name_index = buffer.items.len;
         if (err_set_type.castTag(.error_set_inferred)) |inf_err_set_payload| {
-            const func = inf_err_set_payload.data.func;
+            const func = inf_err_set_payload.data;
             try bw.writeAll("zig_E_");
             try dg.renderDeclName(func.owner_decl, bw);
             try bw.writeAll(";\n");

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1719,6 +1719,7 @@ pub const FuncGen = struct {
                 .slice     => try self.airSlice(inst),
 
                 .add_with_overflow => try self.airOverflow(inst, "llvm.sadd.with.overflow", "llvm.uadd.with.overflow"),
+                .sub_with_overflow => try self.airOverflow(inst, "llvm.ssub.with.overflow", "llvm.usub.with.overflow"),
                 .mul_with_overflow => try self.airOverflow(inst, "llvm.smul.with.overflow", "llvm.umul.with.overflow"),
 
                 .bit_and, .bool_and => try self.airAnd(inst),

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1747,6 +1747,7 @@ pub const FuncGen = struct {
                 .br             => try self.airBr(inst),
                 .switch_br      => try self.airSwitchBr(inst),
                 .breakpoint     => try self.airBreakpoint(inst),
+                .ret_addr       => try self.airRetAddr(inst),
                 .call           => try self.airCall(inst),
                 .cond_br        => try self.airCondBr(inst),
                 .intcast        => try self.airIntCast(inst),
@@ -3548,6 +3549,15 @@ pub const FuncGen = struct {
         const llvm_fn = self.getIntrinsic("llvm.debugtrap", &.{});
         _ = self.builder.buildCall(llvm_fn, undefined, 0, .C, .Auto, "");
         return null;
+    }
+
+    fn airRetAddr(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {
+        _ = inst;
+        const i32_zero = self.context.intType(32).constNull();
+        const usize_llvm_ty = try self.dg.llvmType(Type.usize);
+        const llvm_fn = self.getIntrinsic("llvm.returnaddress", &.{});
+        const ptr_val = self.builder.buildCall(llvm_fn, &[_]*const llvm.Value{i32_zero}, 1, .Fast, .Auto, "");
+        return self.builder.buildPtrToInt(ptr_val, usize_llvm_ty, "");
     }
 
     fn airFence(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -229,7 +229,10 @@ const Writer = struct {
             .atomic_rmw => try w.writeAtomicRmw(s, inst),
             .memcpy => try w.writeMemcpy(s, inst),
             .memset => try w.writeMemset(s, inst),
-            .add_with_overflow => try w.writeAddWithOverflow(s, inst),
+
+            .add_with_overflow,
+            .mul_with_overflow,
+            => try w.writeOverflow(s, inst),
         }
     }
 
@@ -350,7 +353,7 @@ const Writer = struct {
         try s.print(", {s}, {s}", .{ @tagName(extra.op()), @tagName(extra.ordering()) });
     }
 
-    fn writeAddWithOverflow(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
+    fn writeOverflow(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
         const pl_op = w.air.instructions.items(.data)[inst].pl_op;
         const extra = w.air.extraData(Air.Bin, pl_op.payload).data;
 

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -159,6 +159,7 @@ const Writer = struct {
 
             .breakpoint,
             .unreach,
+            .ret_addr,
             => try w.writeNoOp(s, inst),
 
             .const_ty,

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -231,6 +231,7 @@ const Writer = struct {
             .memset => try w.writeMemset(s, inst),
 
             .add_with_overflow,
+            .sub_with_overflow,
             .mul_with_overflow,
             => try w.writeOverflow(s, inst),
         }

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -233,6 +233,7 @@ const Writer = struct {
             .add_with_overflow,
             .sub_with_overflow,
             .mul_with_overflow,
+            .shl_with_overflow,
             => try w.writeOverflow(s, inst),
         }
     }

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -228,6 +228,7 @@ const Writer = struct {
             .atomic_rmw => try w.writeAtomicRmw(s, inst),
             .memcpy => try w.writeMemcpy(s, inst),
             .memset => try w.writeMemset(s, inst),
+            .add_with_overflow => try w.writeAddWithOverflow(s, inst),
         }
     }
 
@@ -346,6 +347,17 @@ const Writer = struct {
         try s.writeAll(", ");
         try w.writeOperand(s, inst, 1, extra.operand);
         try s.print(", {s}, {s}", .{ @tagName(extra.op()), @tagName(extra.ordering()) });
+    }
+
+    fn writeAddWithOverflow(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
+        const pl_op = w.air.instructions.items(.data)[inst].pl_op;
+        const extra = w.air.extraData(Air.Bin, pl_op.payload).data;
+
+        try w.writeOperand(s, inst, 0, pl_op.operand);
+        try s.writeAll(", ");
+        try w.writeOperand(s, inst, 1, extra.lhs);
+        try s.writeAll(", ");
+        try w.writeOperand(s, inst, 2, extra.rhs);
     }
 
     fn writeMemset(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {

--- a/src/type.zig
+++ b/src/type.zig
@@ -1575,6 +1575,7 @@ pub const Type = extern union {
             .extern_options,
             .@"anyframe",
             .anyframe_T,
+            .anyopaque,
             .@"opaque",
             .single_const_pointer,
             .single_mut_pointer,
@@ -1654,7 +1655,6 @@ pub const Type = extern union {
                 return payload.error_set.hasCodeGenBits() or payload.payload.hasCodeGenBits();
             },
 
-            .anyopaque,
             .void,
             .type,
             .comptime_int,

--- a/src/type.zig
+++ b/src/type.zig
@@ -2869,7 +2869,7 @@ pub const Type = extern union {
     pub fn isAnyError(ty: Type) bool {
         return switch (ty.tag()) {
             .anyerror => true,
-            .error_set_inferred => ty.castTag(.error_set_inferred).?.data.inferred_error_set.is_anyerror,
+            .error_set_inferred => ty.castTag(.error_set_inferred).?.data.is_anyerror,
             else => false,
         };
     }
@@ -4156,7 +4156,7 @@ pub const Type = extern union {
             pub const base_tag = Tag.error_set_inferred;
 
             base: Payload = Payload{ .tag = base_tag },
-            data: *Module.Fn,
+            data: *Module.Fn.InferredErrorSet,
         };
 
         pub const Pointer = struct {

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -451,3 +451,19 @@ test "comptime bitwise operators" {
         try expect(~@as(u128, 0) == 0xffffffffffffffffffffffffffffffff);
     }
 }
+
+test "comptime shlWithOverflow" {
+    const ct_shifted: u64 = comptime amt: {
+        var amt = @as(u64, 0);
+        _ = @shlWithOverflow(u64, ~@as(u64, 0), 16, &amt);
+        break :amt amt;
+    };
+
+    const rt_shifted: u64 = amt: {
+        var amt = @as(u64, 0);
+        _ = @shlWithOverflow(u64, ~@as(u64, 0), 16, &amt);
+        break :amt amt;
+    };
+
+    try expect(ct_shifted == rt_shifted);
+}

--- a/test/behavior/eval_stage1.zig
+++ b/test/behavior/eval_stage1.zig
@@ -162,22 +162,6 @@ test "const ptr to comptime mutable data is not memoized" {
     }
 }
 
-test "comptime shlWithOverflow" {
-    const ct_shifted: u64 = comptime amt: {
-        var amt = @as(u64, 0);
-        _ = @shlWithOverflow(u64, ~@as(u64, 0), 16, &amt);
-        break :amt amt;
-    };
-
-    const rt_shifted: u64 = amt: {
-        var amt = @as(u64, 0);
-        _ = @shlWithOverflow(u64, ~@as(u64, 0), 16, &amt);
-        break :amt amt;
-    };
-
-    try expect(ct_shifted == rt_shifted);
-}
-
 test "runtime 128 bit integer division" {
     var a: u128 = 152313999999999991610955792383;
     var b: u128 = 10000000000000000000;

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -495,3 +495,19 @@ test "@mulWithOverflow" {
     try expect(@mulWithOverflow(u8, a, b, &result));
     try expect(result == 236);
 }
+
+test "@subWithOverflow" {
+    var result: u8 = undefined;
+    try expect(@subWithOverflow(u8, 1, 2, &result));
+    try expect(result == 255);
+    try expect(!@subWithOverflow(u8, 1, 1, &result));
+    try expect(result == 0);
+
+    var a: u8 = 1;
+    var b: u8 = 2;
+    try expect(@subWithOverflow(u8, a, b, &result));
+    try expect(result == 255);
+    b = 1;
+    try expect(!@subWithOverflow(u8, a, b, &result));
+    try expect(result == 0);
+}

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -511,3 +511,31 @@ test "@subWithOverflow" {
     try expect(!@subWithOverflow(u8, a, b, &result));
     try expect(result == 0);
 }
+
+test "@shlWithOverflow" {
+    var result: u16 = undefined;
+    try expect(@shlWithOverflow(u16, 0b0010111111111111, 3, &result));
+    try expect(result == 0b0111111111111000);
+    try expect(!@shlWithOverflow(u16, 0b0010111111111111, 2, &result));
+    try expect(result == 0b1011111111111100);
+
+    var a: u16 = 0b0000_0000_0000_0011;
+    var b: u4 = 15;
+    try expect(@shlWithOverflow(u16, a, b, &result));
+    try expect(result == 0b1000_0000_0000_0000);
+    b = 14;
+    try expect(!@shlWithOverflow(u16, a, b, &result));
+    try expect(result == 0b1100_0000_0000_0000);
+}
+
+test "overflow arithmetic with u0 values" {
+    var result: u0 = undefined;
+    try expect(!@addWithOverflow(u0, 0, 0, &result));
+    try expect(result == 0);
+    try expect(!@subWithOverflow(u0, 0, 0, &result));
+    try expect(result == 0);
+    try expect(!@mulWithOverflow(u0, 0, 0, &result));
+    try expect(result == 0);
+    try expect(!@shlWithOverflow(u0, 0, 0, &result));
+    try expect(result == 0);
+}

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -444,3 +444,30 @@ test "128-bit multiplication" {
     var c = a * b;
     try expect(c == 6);
 }
+
+test "@addWithOverflow" {
+    var result: u8 = undefined;
+    try expect(@addWithOverflow(u8, 250, 100, &result));
+    try expect(result == 94);
+    try expect(!@addWithOverflow(u8, 100, 150, &result));
+    try expect(result == 250);
+}
+
+test "small int addition" {
+    var x: u2 = 0;
+    try expect(x == 0);
+
+    x += 1;
+    try expect(x == 1);
+
+    x += 1;
+    try expect(x == 2);
+
+    x += 1;
+    try expect(x == 3);
+
+    var result: @TypeOf(x) = 3;
+    try expect(@addWithOverflow(@TypeOf(x), x, 1, &result));
+
+    try expect(result == 0);
+}

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -451,6 +451,14 @@ test "@addWithOverflow" {
     try expect(result == 94);
     try expect(!@addWithOverflow(u8, 100, 150, &result));
     try expect(result == 250);
+
+    var a: u8 = 200;
+    var b: u8 = 99;
+    try expect(@addWithOverflow(u8, a, b, &result));
+    try expect(result == 43);
+    b = 55;
+    try expect(!@addWithOverflow(u8, a, b, &result));
+    try expect(result == 255);
 }
 
 test "small int addition" {
@@ -470,4 +478,20 @@ test "small int addition" {
     try expect(@addWithOverflow(@TypeOf(x), x, 1, &result));
 
     try expect(result == 0);
+}
+
+test "@mulWithOverflow" {
+    var result: u8 = undefined;
+    try expect(@mulWithOverflow(u8, 86, 3, &result));
+    try expect(result == 2);
+    try expect(!@mulWithOverflow(u8, 85, 3, &result));
+    try expect(result == 255);
+
+    var a: u8 = 123;
+    var b: u8 = 2;
+    try expect(!@mulWithOverflow(u8, a, b, &result));
+    try expect(result == 246);
+    b = 4;
+    try expect(@mulWithOverflow(u8, a, b, &result));
+    try expect(result == 236);
 }

--- a/test/behavior/math_stage1.zig
+++ b/test/behavior/math_stage1.zig
@@ -6,14 +6,6 @@ const maxInt = std.math.maxInt;
 const minInt = std.math.minInt;
 const mem = std.mem;
 
-test "@subWithOverflow" {
-    var result: u8 = undefined;
-    try expect(@subWithOverflow(u8, 1, 2, &result));
-    try expect(result == 255);
-    try expect(!@subWithOverflow(u8, 1, 1, &result));
-    try expect(result == 0);
-}
-
 test "@shlWithOverflow" {
     var result: u16 = undefined;
     try expect(@shlWithOverflow(u16, 0b0010111111111111, 3, &result));

--- a/test/behavior/math_stage1.zig
+++ b/test/behavior/math_stage1.zig
@@ -6,14 +6,6 @@ const maxInt = std.math.maxInt;
 const minInt = std.math.minInt;
 const mem = std.mem;
 
-test "@addWithOverflow" {
-    var result: u8 = undefined;
-    try expect(@addWithOverflow(u8, 250, 100, &result));
-    try expect(result == 94);
-    try expect(!@addWithOverflow(u8, 100, 150, &result));
-    try expect(result == 250);
-}
-
 test "@mulWithOverflow" {
     var result: u8 = undefined;
     try expect(@mulWithOverflow(u8, 86, 3, &result));
@@ -88,25 +80,6 @@ fn testCtzVectors() !void {
     try expectEqual(@ctz(u8, @splat(64, @as(u8, 0b10001010))), @splat(64, @as(u4, 1)));
     try expectEqual(@ctz(u8, @splat(64, @as(u8, 0b00000000))), @splat(64, @as(u4, 8)));
     try expectEqual(@ctz(u16, @splat(64, @as(u16, 0b00000000))), @splat(64, @as(u5, 16)));
-}
-
-test "small int addition" {
-    var x: u2 = 0;
-    try expect(x == 0);
-
-    x += 1;
-    try expect(x == 1);
-
-    x += 1;
-    try expect(x == 2);
-
-    x += 1;
-    try expect(x == 3);
-
-    var result: @TypeOf(x) = 3;
-    try expect(@addWithOverflow(@TypeOf(x), x, 1, &result));
-
-    try expect(result == 0);
 }
 
 test "allow signed integer division/remainder when values are comptime known and positive or exact" {

--- a/test/behavior/math_stage1.zig
+++ b/test/behavior/math_stage1.zig
@@ -6,26 +6,6 @@ const maxInt = std.math.maxInt;
 const minInt = std.math.minInt;
 const mem = std.mem;
 
-test "@shlWithOverflow" {
-    var result: u16 = undefined;
-    try expect(@shlWithOverflow(u16, 0b0010111111111111, 3, &result));
-    try expect(result == 0b0111111111111000);
-    try expect(!@shlWithOverflow(u16, 0b0010111111111111, 2, &result));
-    try expect(result == 0b1011111111111100);
-}
-
-test "overflow arithmetic with u0 values" {
-    var result: u0 = undefined;
-    try expect(!@addWithOverflow(u0, 0, 0, &result));
-    try expect(result == 0);
-    try expect(!@subWithOverflow(u0, 0, 0, &result));
-    try expect(result == 0);
-    try expect(!@mulWithOverflow(u0, 0, 0, &result));
-    try expect(result == 0);
-    try expect(!@shlWithOverflow(u0, 0, 0, &result));
-    try expect(result == 0);
-}
-
 test "@clz vectors" {
     try testClzVectors();
     comptime try testClzVectors();

--- a/test/behavior/math_stage1.zig
+++ b/test/behavior/math_stage1.zig
@@ -6,14 +6,6 @@ const maxInt = std.math.maxInt;
 const minInt = std.math.minInt;
 const mem = std.mem;
 
-test "@mulWithOverflow" {
-    var result: u8 = undefined;
-    try expect(@mulWithOverflow(u8, 86, 3, &result));
-    try expect(result == 2);
-    try expect(!@mulWithOverflow(u8, 85, 3, &result));
-    try expect(result == 255);
-}
-
 test "@subWithOverflow" {
     var result: u8 = undefined;
     try expect(@subWithOverflow(u8, 1, 2, &result));


### PR DESCRIPTION
This PR includes a bunch of things that are required for `page_allocator` to compile under stage 2. This includes the allocator itself as well as the allocation function:
```zig
const std = @import("std");
const expect = std.testing.expect;

test "page allocator" {
    const msg = "hello from heap memory\n";
    const allocator = std.heap.page_allocator;
    const mem = try allocator.alloc(u8, msg.len);
    for (msg) |c, i| mem[i] = c;
    asm volatile ("syscall"
        :
        : [number] "{rax}" (1),
          [arg1] "{rdi}" (1),
          [arg2] "{rsi}" (@ptrToInt(mem.ptr)),
          [arg3] "{rdx}" (msg.len),
        : "rcx", "r11", "memory"
    );
}
```
(freeing does not work yet)

Error set related changes:
* Replaced the plain arrays used for the error values of `Module.ErrorSet` and Type `merged_error_set` with hash maps. This is to make error set subset checks easier, though it might become a problem for error set hashing.
* Moved error set state into `Module.Fn`. This was previously causing some problems after an error set was copied, losing a proper reference to the original error set as well as creating memory errors. Note that any individual function might have multiple inferred error sets associated with it; its own for runtime invocations of the function and those of inline/comptime functions which return inferred error sets.
* Error set coercion.
* Allow merged error sets to cast to `E!T`.

Other stage 2 additions:
* Allow `@ptrToInt` on anything that is a pointer at runtime, as `@ptrToInt(pointer_like_optional)` was used somewhere.
* Implemented built-in functions `@returnAddress()`, `@addWithOverflow()`, `@mulWithOverflow()`, `@subWithOverflow()` and `@shlWithOverflow` (sema and LLVM codegen). Each also has a corresponding new AIR instruction.
* Disabled a standard library feature for stage 2 builds where a message would be printed when an unexpected errno was returned from a syscall. This relieves a dependency on `std.fmt` and stack trace related code for `page_allocator` on stage 2 builds.
* Made `anyopaque` a sized type for the time being, as this was causing `*anyopaque` to be recognized as zero-sized type. I guess this isn't really the proper fix for this, though.

Some bugs fixed:
* ZIR function prototypes are now wrapped in blocks with their `param` instructions. The parameters were prior to this emitted in a block higher, which caused function pointers in the same block to pick up each others parameters.
* A similar problem with the `params` list of Block. My current fix just includes saving and restoring the list on any `block_inline` and `block` ZIR instruction, though it feels kind of hacky and a better solution is probably required for this in time.
* `addrspace` pointer information was not yet written into pointer `@typeInfo`, which caused some problems.

Tests pass locally:
```
$ ./zig build -p zig-out -Denable-llvm -Dskip-compile-errors test-stage2 -fqemu -fwasmtime -fwine
All 90 tests passed.
$ ./zig-out/bin/zig test ../test/behavior.zig -I ../test -fLLVM
$ ./zig-out/bin/zig test ../test/behavior.zig -I ../test -ofmt=c
```
