### PR TITLE
Change `ArgIterator.next()` return type

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -27,18 +27,18 @@ pub fn main() !void {
 
     if (!args_it.skip()) @panic("expected self arg");
 
-    const zig_exe = try (args_it.next(allocator) orelse @panic("expected zig exe arg"));
+    const zig_exe = (try args_it.next(allocator)) orelse @panic("expected zig exe arg");
     defer allocator.free(zig_exe);
 
-    const in_file_name = try (args_it.next(allocator) orelse @panic("expected input arg"));
+    const in_file_name = (try args_it.next(allocator)) orelse @panic("expected input arg");
     defer allocator.free(in_file_name);
 
-    const out_file_name = try (args_it.next(allocator) orelse @panic("expected output arg"));
+    const out_file_name = (try args_it.next(allocator)) orelse @panic("expected output arg");
     defer allocator.free(out_file_name);
 
     var do_code_tests = true;
-    if (args_it.next(allocator)) |arg| {
-        if (mem.eql(u8, try arg, "--skip-code-tests")) {
+    if (try args_it.next(allocator)) |arg| {
+        if (mem.eql(u8, arg, "--skip-code-tests")) {
             do_code_tests = false;
         } else {
             @panic("unrecognized arg");

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -18,14 +18,14 @@ pub fn main() !void {
 
     a = arena.allocator();
 
-    const zig_exe_rel = try (arg_it.next(a) orelse {
+    const zig_exe_rel = (try arg_it.next(a)) orelse {
         std.debug.print("Expected first argument to be path to zig compiler\n", .{});
         return error.InvalidArgs;
-    });
-    const cache_root = try (arg_it.next(a) orelse {
+    };
+    const cache_root = (try arg_it.next(a)) orelse {
         std.debug.print("Expected second argument to be cache root directory path\n", .{});
         return error.InvalidArgs;
-    });
+    };
     const zig_exe = try fs.path.resolve(a, &[_][]const u8{zig_exe_rel});
 
     const dir_path = try fs.path.join(a, &[_][]const u8{ cache_root, "clitest" });

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -362,8 +362,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\    const stdout = io.getStdOut().writer();
             \\    var index: usize = 0;
             \\    _ = args_it.skip();
-            \\    while (args_it.next(allocator)) |arg_or_err| : (index += 1) {
-            \\        const arg = try arg_or_err;
+            \\    while (try args_it.next(allocator)) |arg| : (index += 1) {
             \\        try stdout.print("{}: {s}\n", .{index, arg});
             \\    }
             \\}
@@ -401,8 +400,7 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
             \\    const stdout = io.getStdOut().writer();
             \\    var index: usize = 0;
             \\    _ = args_it.skip();
-            \\    while (args_it.next(allocator)) |arg_or_err| : (index += 1) {
-            \\        const arg = try arg_or_err;
+            \\    while (try args_it.next(allocator)) |arg| : (index += 1) {
             \\        try stdout.print("{}: {s}\n", .{index, arg});
             \\    }
             \\}


### PR DESCRIPTION
I'm making this PR after receiving positive feedback regarding this from people on the Discord, including @SpexGuy and @N00byEdge. 

This changes the return type of `ArgIterator.next()` from `?(NextError![:0]u8)` to `NextError!?[:0]u8`. This change makes the `ArgIterator` much cleaner to use in `while` loops or `if` statements. For example:
```zig
while (it.next(allocator)) |arg_or_err| {
    const arg = try arg_or_err;
```
Is now:
```zig
while (try it.next(allocator)) |arg| {
```

This is much better, as it storing an error union in a variable is usually a bad thing to do, and discourages handling the error immediately. Additionally, the convention in the std library is to use this order (`!?` as opposed to `?!`) -- I couldn't find any examples of the opposite order besides this one with grep.