### PR TITLE
Stage2: linker - Emit symbol names

### DIFF
--- a/lib/std/wasm.zig
+++ b/lib/std/wasm.zig
@@ -406,6 +406,22 @@ pub fn externalKind(val: ExternalKind) u8 {
     return @enumToInt(val);
 }
 
+/// Defines the enum values for each subsection id for the "Names" custom section
+/// as described by:
+/// https://webassembly.github.io/spec/core/appendix/custom.html?highlight=name#name-section
+pub const NameSubsection = enum(u8) {
+    module,
+    function,
+    local,
+    label,
+    type,
+    table,
+    memory,
+    global,
+    elem_segment,
+    data_segment,
+};
+
 // type constants
 pub const element_type: u8 = 0x70;
 pub const function_type: u8 = 0x60;

--- a/src/link/Wasm/Symbol.zig
+++ b/src/link/Wasm/Symbol.zig
@@ -25,6 +25,9 @@ pub const Tag = enum {
     section,
     event,
     table,
+    /// synthetic kind used by the wasm linker during incremental compilation
+    /// to notate a symbol has been freed, but still lives in the symbol list.
+    dead,
 
     /// From a given symbol tag, returns the `ExternalType`
     /// Asserts the given tag can be represented as an external type.


### PR DESCRIPTION
The self-hosted linker will now emit names for all function, global and data segment symbols.
This increases the ability to debug wasm modules tremendously as tools like wasm2wat and browsers can use this information to generate named functions, globals etc, rather than placeholders such as `$f1`.
