### PR TITLE
Make mem.Allocator functions generic

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -745,8 +745,8 @@ pub const FixedBufferAllocator = struct {
         return Allocator.init(
             self,
             threadSafeAlloc,
-            Allocator.NoResize(FixedBufferAllocator).noResize,
-            Allocator.NoOpFree(FixedBufferAllocator).noOpFree,
+            Allocator.noResize(FixedBufferAllocator),
+            Allocator.noOpFree(FixedBufferAllocator),
         );
     }
 

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -151,8 +151,8 @@ const fail_allocator = Allocator{
 
 const failAllocator_vtable = Allocator.VTable{
     .alloc = failAllocatorAlloc,
-    .resize = Allocator.NoResize(anyopaque).noResize,
-    .free = Allocator.NoOpFree(anyopaque).noOpFree,
+    .resize = Allocator.noResize(anyopaque),
+    .free = Allocator.noOpFree(anyopaque),
 };
 
 fn failAllocatorAlloc(_: *anyopaque, n: usize, alignment: u29, len_align: u29, ra: usize) Allocator.Error![]u8 {

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -106,8 +106,8 @@ pub fn init(
     };
 }
 
-/// Set resizeFn to `NoResize(AllocatorType)` if in-place resize is not supported.
-pub fn NoResize(comptime AllocatorType: type) ResizeFnType(*AllocatorType) {
+/// Set resizeFn to `noResize(AllocatorType)` if in-place resize is not supported.
+pub fn noResize(comptime AllocatorType: type) ResizeFnType(*AllocatorType) {
     const erased = struct {
         pub fn f(
             self: *AllocatorType,
@@ -127,8 +127,8 @@ pub fn NoResize(comptime AllocatorType: type) ResizeFnType(*AllocatorType) {
     return erased.f;
 }
 
-/// Set freeFn to `NoOpFree(AllocatorType)` if free is a no-op.
-pub fn NoOpFree(comptime AllocatorType: type) FreeFnType(*AllocatorType) {
+/// Set freeFn to `noOpFree(AllocatorType)` if free is a no-op.
+pub fn noOpFree(comptime AllocatorType: type) FreeFnType(*AllocatorType) {
     const erased = struct {
         fn f(
             self: *AllocatorType,
@@ -145,8 +145,8 @@ pub fn NoOpFree(comptime AllocatorType: type) FreeFnType(*AllocatorType) {
     return erased.f;
 }
 
-/// Set freeFn to `PanicFree(AllocatorType)` if free is not a supported operation.
-pub fn PanicFree(comptime AllocatorType: type) FreeFnType(*AllocatorType) {
+/// Set freeFn to `panicFree(AllocatorType)` if free is not a supported operation.
+pub fn panicFree(comptime AllocatorType: type) FreeFnType(*AllocatorType) {
     const erased = struct {
         pub fn f(
             self: *AllocatorType,
@@ -166,9 +166,9 @@ pub fn PanicFree(comptime AllocatorType: type) FreeFnType(*AllocatorType) {
 
 test {
     const Foo = struct {};
-    _ = NoResize(Foo);
-    _ = NoOpFree(Foo);
-    _ = PanicFree(Foo);
+    _ = noResize(Foo);
+    _ = noOpFree(Foo);
+    _ = panicFree(Foo);
 }
 
 /// This function is not intended to be called except from within the implementation of an Allocator

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -9,15 +9,15 @@ const builtin = @import("builtin");
 
 pub const Error = error{OutOfMemory};
 
-pub fn AllocFnType(PointerType: anytype) type {
+pub fn AllocFnType(comptime PointerType: type) type {
     return fn (ptr: PointerType, len: usize, ptr_align: u29, len_align: u29, ret_addr: usize) Error![]u8;
 }
 
-pub fn ResizeFnType(PointerType: anytype) type {
+pub fn ResizeFnType(comptime PointerType: type) type {
     return fn (ptr: PointerType, buf: []u8, buf_align: u29, new_len: usize, len_align: u29, ret_addr: usize) ?usize;
 }
 
-pub fn FreeFnType(PointerType: anytype) type {
+pub fn FreeFnType(comptime PointerType: type) type {
     return fn (ptr: PointerType, buf: []u8, buf_align: u29, ret_addr: usize) void;
 }
 


### PR DESCRIPTION
Now the interface functions can be described shorter, like `std.mem.Allocator.AllocFnType(Foo)`.