### PR TITLE
stage2: make tests/behaviour/void.zig work with c backend

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -302,7 +302,11 @@ pub const DeclGen = struct {
                         else => return dg.fail("TODO float types > 64 bits are not support in renderValue() as of now", .{}),
                     }
                 },
-
+                .Pointer => switch (dg.module.getTarget().cpu.arch.ptrBitWidth()) {
+                    32 => return writer.writeAll("(void *)0xaaaaaaaa"),
+                    64 => return writer.writeAll("(void *)0xaaaaaaaaaaaaaaaa"),
+                    else => unreachable,
+                },
                 else => {
                     // This should lower to 0xaa bytes in safe modes, and for unsafe modes should
                     // lower to leaving variables uninitialized (that might need to be implemented
@@ -685,6 +689,7 @@ pub const DeclGen = struct {
             var it = struct_obj.fields.iterator();
             while (it.next()) |entry| {
                 const field_ty = entry.value_ptr.ty;
+                if (!field_ty.hasCodeGenBits()) continue;
                 const name: CValue = .{ .bytes = entry.key_ptr.* };
                 try buffer.append(' ');
                 try dg.renderTypeAndName(buffer.writer(), field_ty, name, .Mut);
@@ -1399,9 +1404,19 @@ fn airAlloc(f: *Function, inst: Air.Inst.Index) !CValue {
     const writer = f.object.writer();
     const inst_ty = f.air.typeOfIndex(inst);
 
-    // First line: the variable used as data storage.
     const elem_type = inst_ty.elemType();
     const mutability: Mutability = if (inst_ty.isConstPtr()) .Const else .Mut;
+    if (!elem_type.hasCodeGenBits()) {
+        const target = f.object.dg.module.getTarget();
+        const literal = switch (target.cpu.arch.ptrBitWidth()) {
+            32 => "(void *)0xaaaaaaaa",
+            64 => "(void *)0xaaaaaaaaaaaaaaaa",
+            else => unreachable,
+        };
+        return CValue{ .bytes = literal };
+    }
+
+    // First line: the variable used as data storage.
     const local = try f.allocLocal(elem_type, mutability);
     try writer.writeAll(";\n");
 

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -55,6 +55,7 @@ test {
         _ = @import("behavior/translate_c_macros.zig");
         _ = @import("behavior/underscore.zig");
         _ = @import("behavior/while.zig");
+        _ = @import("behavior/void.zig");
 
         if (builtin.object_format != .c) {
             // Tests that pass for stage1 and stage2 but not the C backend and wasm backend.
@@ -93,7 +94,6 @@ test {
             _ = @import("behavior/switch.zig");
             _ = @import("behavior/undefined.zig");
             _ = @import("behavior/union.zig");
-            _ = @import("behavior/void.zig");
             _ = @import("behavior/widening.zig");
 
             if (builtin.zig_is_stage2) {


### PR DESCRIPTION
* fix initialisation of void* fields of structs (initialises to NULL rather than {})
* don't generate fields where the type does not have codegen bits
* in airAlloc generate a void* local if the element type does not have codegen bits