### PR TITLE
std: Fix using `fs.Dir.Iterator` twice

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -180,6 +180,42 @@ test "Dir.Iterator" {
     try testing.expect(contains(&entries, Dir.Entry{ .name = "some_dir", .kind = Dir.Entry.Kind.Directory }));
 }
 
+// TODO Only passes on Windows, see https://github.com/ziglang/zig/issues/10317
+test "Dir.Iterator twice" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp_dir = tmpDir(.{ .iterate = true });
+    defer tmp_dir.cleanup();
+
+    // First, create a couple of entries to iterate over.
+    const file = try tmp_dir.dir.createFile("some_file", .{});
+    file.close();
+
+    try tmp_dir.dir.makeDir("some_dir");
+
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var i: u8 = 0;
+    while (i < 2) : (i += 1) {
+        var entries = std.ArrayList(Dir.Entry).init(allocator);
+
+        // Create iterator.
+        var iter = tmp_dir.dir.iterate();
+        while (try iter.next()) |entry| {
+            // We cannot just store `entry` as on Windows, we're re-using the name buffer
+            // which means we'll actually share the `name` pointer between entries!
+            const name = try allocator.dupe(u8, entry.name);
+            try entries.append(Dir.Entry{ .name = name, .kind = entry.kind });
+        }
+
+        try testing.expect(entries.items.len == 2); // note that the Iterator skips '.' and '..'
+        try testing.expect(contains(&entries, Dir.Entry{ .name = "some_file", .kind = Dir.Entry.Kind.File }));
+        try testing.expect(contains(&entries, Dir.Entry{ .name = "some_dir", .kind = Dir.Entry.Kind.Directory }));
+    }
+}
+
 fn entryEql(lhs: Dir.Entry, rhs: Dir.Entry) bool {
     return mem.eql(u8, lhs.name, rhs.name) and lhs.kind == rhs.kind;
 }

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -180,10 +180,7 @@ test "Dir.Iterator" {
     try testing.expect(contains(&entries, Dir.Entry{ .name = "some_dir", .kind = Dir.Entry.Kind.Directory }));
 }
 
-// TODO Only passes on Windows, see https://github.com/ziglang/zig/issues/10317
 test "Dir.Iterator twice" {
-    if (builtin.os.tag != .windows) return error.SkipZigTest;
-
     var tmp_dir = tmpDir(.{ .iterate = true });
     defer tmp_dir.cleanup();
 


### PR DESCRIPTION
This fixes the use of multiple `Iterator`s in a row on a directory. Previously, on many platforms, using an `Iterator` on an already-iterated directory would give no entries.

Fixing this involved seeking to the beginning of the directory on the first call of `next()`.

cc: @nektro @squeek502 
fixes #10317