### PR TITLE
std: make IntegerBitSet and ArrayBitSet have defined memory layout

### DIFF
--- a/lib/std/bit_set.zig
+++ b/lib/std/bit_set.zig
@@ -50,7 +50,7 @@ pub fn StaticBitSet(comptime size: usize) type {
 /// This set is good for sets with a small size, but may generate
 /// inefficient code for larger sets, especially in debug mode.
 pub fn IntegerBitSet(comptime size: u16) type {
-    return struct {
+    return packed struct {
         const Self = @This();
 
         // TODO: Make this a comptime field once those are fixed
@@ -262,7 +262,7 @@ pub fn ArrayBitSet(comptime MaskIntType: type, comptime size: usize) type {
             ", which contains padding bits.  Please round this up to an unpadded integer size (i.e. " ++ @typeName(FixedMaskType) ++ ").");
     }
 
-    return struct {
+    return extern struct {
         const Self = @This();
 
         // TODO: Make this a comptime field once those are fixed


### PR DESCRIPTION
This is useful for wrapping C libraries and native interfaces that make use of bit sets. There's not really any alternative way the compiler could lay these out anyway since they only have a single field each, so this shouldn't affect performance.