### PR TITLE
std: Skip `comptime` struct fields in `mem.zeroes()`

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -344,6 +344,8 @@ test "mem.zeroes" {
     try testing.expect(a.y == 10);
 
     const ZigStruct = struct {
+        comptime comptime_field: u8 = 5,
+        
         integral_types: struct {
             integer_0: i0,
             integer_8: i8,
@@ -378,6 +380,7 @@ test "mem.zeroes" {
     };
 
     const b = zeroes(ZigStruct);
+    try testing.expectEqual(@as(u8, 5), b.comptime_field);
     try testing.expectEqual(@as(i8, 0), b.integral_types.integer_0);
     try testing.expectEqual(@as(i8, 0), b.integral_types.integer_8);
     try testing.expectEqual(@as(i16, 0), b.integral_types.integer_16);

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -275,7 +275,9 @@ pub fn zeroes(comptime T: type) T {
             } else {
                 var structure: T = undefined;
                 inline for (struct_info.fields) |field| {
-                    @field(structure, field.name) = zeroes(@TypeOf(@field(structure, field.name)));
+                    if (!field.is_comptime) {
+                        @field(structure, field.name) = zeroes(@TypeOf(@field(structure, field.name)));
+                    }
                 }
                 return structure;
             }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -345,7 +345,7 @@ test "mem.zeroes" {
 
     const ZigStruct = struct {
         comptime comptime_field: u8 = 5,
-        
+
         integral_types: struct {
             integer_0: i0,
             integer_8: i8,


### PR DESCRIPTION
closes #9934 