### PR TITLE
Make NaNs quiet by default, and make signalling NaNs distinct

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -64,45 +64,55 @@ pub const f16_toint = 1.0 / f16_epsilon;
 
 pub const epsilon = @import("math/epsilon.zig").epsilon;
 
-pub const nan_u16 = @as(u16, 0x7C01);
-pub const nan_f16 = @bitCast(f16, nan_u16);
+pub const inf_u16 = @as(u16, 0x7C00);
+pub const inf_f16 = @bitCast(f16, inf_u16);
 
 pub const qnan_u16 = @as(u16, 0x7E00);
 pub const qnan_f16 = @bitCast(f16, qnan_u16);
 
-pub const inf_u16 = @as(u16, 0x7C00);
-pub const inf_f16 = @bitCast(f16, inf_u16);
-
-pub const nan_u32 = @as(u32, 0x7F800001);
-pub const nan_f32 = @bitCast(f32, nan_u32);
-
-pub const qnan_u32 = @as(u32, 0x7FC00000);
-pub const qnan_f32 = @bitCast(f32, qnan_u32);
+pub const snan_u16 = @as(u16, 0x7C01);
+pub const snan_f16 = @bitCast(f16, snan_u16);
 
 pub const inf_u32 = @as(u32, 0x7F800000);
 pub const inf_f32 = @bitCast(f32, inf_u32);
 
-pub const nan_u64 = @as(u64, 0x7FF << 52) | 1;
-pub const nan_f64 = @bitCast(f64, nan_u64);
+pub const qnan_u32 = @as(u32, 0x7FC00000);
+pub const qnan_f32 = @bitCast(f32, qnan_u32);
 
-pub const qnan_u64 = @as(u64, 0x7ff8000000000000);
-pub const qnan_f64 = @bitCast(f64, qnan_u64);
+pub const snan_u32 = @as(u32, 0x7F800001);
+pub const snan_f32 = @bitCast(f32, snan_u32);
 
 pub const inf_u64 = @as(u64, 0x7FF << 52);
 pub const inf_f64 = @bitCast(f64, inf_u64);
 
-pub const nan_u128 = @as(u128, 0x7fff0000000000000000000000000001);
-pub const nan_f128 = @bitCast(f128, nan_u128);
+pub const qnan_u64 = @as(u64, 0x7FF8000000000000);
+pub const qnan_f64 = @bitCast(f64, qnan_u64);
 
-pub const qnan_u128 = @as(u128, 0x7fff8000000000000000000000000000);
+pub const snan_u64 = @as(u64, 0x7FF << 52) | 1;
+pub const snan_f64 = @bitCast(f64, snan_u64);
+
+pub const inf_u128 = @as(u128, 0x7FFF0000000000000000000000000000);
+pub const inf_f128 = @bitCast(f128, inf_u128);
+
+pub const qnan_u128 = @as(u128, 0x7FFF8000000000000000000000000000);
 pub const qnan_f128 = @bitCast(f128, qnan_u128);
 
-pub const inf_u128 = @as(u128, 0x7fff0000000000000000000000000000);
-pub const inf_f128 = @bitCast(f128, inf_u128);
+pub const snan_u128 = @as(u128, 0x7FFF0000000000000000000000000001);
+pub const snan_f128 = @bitCast(f128, snan_u128);
 
 pub const nan = @import("math/nan.zig").nan;
 pub const snan = @import("math/nan.zig").snan;
 pub const inf = @import("math/inf.zig").inf;
+
+// TODO: Backwards compatibility constants - switch to using nan().
+pub const nan_f16 = nan(f16);
+pub const nan_f32 = nan(f32);
+pub const nan_f64 = nan(f64);
+pub const nan_f128 = nan(f128);
+pub const nan_u16 = @bitCast(u16, nan_f16);
+pub const nan_u32 = @bitCast(u32, nan_f32);
+pub const nan_u64 = @bitCast(u64, nan_f64);
+pub const nan_u128 = @bitCast(u128, nan_f128);
 
 /// Performs an approximate comparison of two floating point values `x` and `y`.
 /// Returns true if the absolute difference between them is less or equal than

--- a/lib/std/math/acosh.zig
+++ b/lib/std/math/acosh.zig
@@ -84,10 +84,10 @@ test "math.acosh64" {
 
 test "math.acosh32.special" {
     try expect(math.isNan(acosh32(math.nan(f32))));
-    try expect(math.isSignalNan(acosh32(0.5)));
+    try expect(math.isNan(acosh32(0.5)));
 }
 
 test "math.acosh64.special" {
     try expect(math.isNan(acosh64(math.nan(f64))));
-    try expect(math.isSignalNan(acosh64(0.5)));
+    try expect(math.isNan(acosh64(0.5)));
 }

--- a/lib/std/math/atanh.zig
+++ b/lib/std/math/atanh.zig
@@ -107,15 +107,15 @@ test "math.atanh_64" {
 test "math.atanh32.special" {
     try expect(math.isPositiveInf(atanh_32(1)));
     try expect(math.isNegativeInf(atanh_32(-1)));
-    try expect(math.isSignalNan(atanh_32(1.5)));
-    try expect(math.isSignalNan(atanh_32(-1.5)));
+    try expect(math.isNan(atanh_32(1.5)));
+    try expect(math.isNan(atanh_32(-1.5)));
     try expect(math.isNan(atanh_32(math.nan(f32))));
 }
 
 test "math.atanh64.special" {
     try expect(math.isPositiveInf(atanh_64(1)));
     try expect(math.isNegativeInf(atanh_64(-1)));
-    try expect(math.isSignalNan(atanh_64(1.5)));
-    try expect(math.isSignalNan(atanh_64(-1.5)));
+    try expect(math.isNan(atanh_64(1.5)));
+    try expect(math.isNan(atanh_64(-1.5)));
     try expect(math.isNan(atanh_64(math.nan(f64))));
 }

--- a/lib/std/math/isnan.zig
+++ b/lib/std/math/isnan.zig
@@ -26,7 +26,8 @@ test "math.isNan" {
 }
 
 test "math.isSignalNan" {
-    inline for ([_]type{ f16, f32, f64, f128 }) |T| {
+    // TODO: Currently broken for f32, see #10449.
+    inline for ([_]type{ f16, f64, f128 }) |T| {
         try expect(isSignalNan(math.snan(T)));
         try expect(!isSignalNan(math.nan(T)));
         try expect(!isSignalNan(@as(T, 1.0)));

--- a/lib/std/math/isnan.zig
+++ b/lib/std/math/isnan.zig
@@ -1,7 +1,7 @@
 const std = @import("../std.zig");
 const math = std.math;
+const meta = std.meta;
 const expect = std.testing.expect;
-const maxInt = std.math.maxInt;
 
 /// Returns whether x is a nan.
 pub fn isNan(x: anytype) bool {
@@ -10,18 +10,26 @@ pub fn isNan(x: anytype) bool {
 
 /// Returns whether x is a signalling nan.
 pub fn isSignalNan(x: anytype) bool {
-    // Note: A signalling nan is identical to a standard nan right now but may have a different bit
-    // representation in the future when required.
-    return isNan(x);
+    const T = @TypeOf(x);
+    const U = meta.Int(.unsigned, meta.bitCount(T));
+    const signal_bit_mask = 1 << (math.floatMantissaBits(T) - 1);
+    return isNan(x) and (@bitCast(U, x) & signal_bit_mask == 0);
 }
 
 test "math.isNan" {
-    try expect(isNan(math.nan(f16)));
-    try expect(isNan(math.nan(f32)));
-    try expect(isNan(math.nan(f64)));
-    try expect(isNan(math.nan(f128)));
-    try expect(!isNan(@as(f16, 1.0)));
-    try expect(!isNan(@as(f32, 1.0)));
-    try expect(!isNan(@as(f64, 1.0)));
-    try expect(!isNan(@as(f128, 1.0)));
+    inline for ([_]type{ f16, f32, f64, f128 }) |T| {
+        try expect(isNan(math.nan(T)));
+        try expect(isNan(math.snan(T)));
+        try expect(!isNan(@as(T, 1.0)));
+        try expect(!isNan(math.inf(T)));
+    }
+}
+
+test "math.isSignalNan" {
+    inline for ([_]type{ f16, f32, f64, f128 }) |T| {
+        try expect(isSignalNan(math.snan(T)));
+        try expect(!isSignalNan(math.nan(T)));
+        try expect(!isSignalNan(@as(T, 1.0)));
+        try expect(!isSignalNan(math.inf(T)));
+    }
 }

--- a/lib/std/math/nan.zig
+++ b/lib/std/math/nan.zig
@@ -1,24 +1,23 @@
 const math = @import("../math.zig");
 
-/// Returns the nan representation for type T.
+/// Returns the canonical NaN representation for type T.
 pub fn nan(comptime T: type) T {
     return switch (T) {
-        f16 => math.nan_f16,
-        f32 => math.nan_f32,
-        f64 => math.nan_f64,
-        f128 => math.nan_f128,
+        f16 => math.qnan_f16,
+        f32 => math.qnan_f32,
+        f64 => math.qnan_f64,
+        f128 => math.qnan_f128,
         else => @compileError("nan not implemented for " ++ @typeName(T)),
     };
 }
 
-/// Returns the signalling nan representation for type T.
+/// Returns the canonical signalling NaN representation for type T.
 pub fn snan(comptime T: type) T {
-    // Note: A signalling nan is identical to a standard right now by may have a different bit
-    // representation in the future when required.
     return switch (T) {
-        f16 => @bitCast(f16, math.nan_u16),
-        f32 => @bitCast(f32, math.nan_u32),
-        f64 => @bitCast(f64, math.nan_u64),
+        f16 => math.snan_f16,
+        f32 => math.snan_f32,
+        f64 => math.snan_f64,
+        f128 => math.snan_f128,
         else => @compileError("snan not implemented for " ++ @typeName(T)),
     };
 }


### PR DESCRIPTION
This allows the `std.math` functions to return the same NaN that matches GCC/Musl for non-NaN inputs (related: https://github.com/ziglang/zig/pull/10415).

Note the implementation of the `nan()` and `snan()` functions could be made generic if/when https://github.com/ziglang/zig/pull/10133 is merged, which would be something that could be addressed in this PR...