### PR TITLE
std: expose `ChildProcess`'s `exec` function

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -1326,7 +1326,7 @@ fn genHtml(
                         try shell_out.print("\n", .{});
 
                         if (expected_outcome == .BuildFail) {
-                            const result = try ChildProcess.exec(.{
+                            const result = try ChildProcess.initAndExec(.{
                                 .allocator = allocator,
                                 .argv = build_args.items,
                                 .env_map = &env_map,
@@ -1386,7 +1386,7 @@ fn genHtml(
                         var exited_with_signal = false;
 
                         const result = if (expected_outcome == ExpectedOutcome.Fail) blk: {
-                            const result = try ChildProcess.exec(.{
+                            const result = try ChildProcess.initAndExec(.{
                                 .allocator = allocator,
                                 .argv = run_args,
                                 .env_map = &env_map,
@@ -1490,7 +1490,7 @@ fn genHtml(
                                 try shell_out.print("-O {s} ", .{@tagName(code.mode)});
                             },
                         }
-                        const result = try ChildProcess.exec(.{
+                        const result = try ChildProcess.initAndExec(.{
                             .allocator = allocator,
                             .argv = test_args.items,
                             .env_map = &env_map,
@@ -1546,7 +1546,7 @@ fn genHtml(
                             },
                         }
 
-                        const result = try ChildProcess.exec(.{
+                        const result = try ChildProcess.initAndExec(.{
                             .allocator = allocator,
                             .argv = test_args.items,
                             .env_map = &env_map,
@@ -1615,7 +1615,7 @@ fn genHtml(
                         }
 
                         if (maybe_error_match) |error_match| {
-                            const result = try ChildProcess.exec(.{
+                            const result = try ChildProcess.initAndExec(.{
                                 .allocator = allocator,
                                 .argv = build_args.items,
                                 .env_map = &env_map,
@@ -1709,7 +1709,7 @@ fn genHtml(
 }
 
 fn exec(allocator: Allocator, env_map: *std.BufMap, args: []const []const u8) !ChildProcess.ExecResult {
-    const result = try ChildProcess.exec(.{
+    const result = try ChildProcess.initAndExec(.{
         .allocator = allocator,
         .argv = args,
         .env_map = env_map,

--- a/lib/std/zig/system/darwin.zig
+++ b/lib/std/zig/system/darwin.zig
@@ -13,7 +13,7 @@ pub const macos = @import("darwin/macos.zig");
 /// https://github.com/Homebrew/brew/blob/e119bdc571dcb000305411bc1e26678b132afb98/Library/Homebrew/brew.sh#L630
 pub fn isDarwinSDKInstalled(allocator: Allocator) bool {
     const argv = &[_][]const u8{ "/usr/bin/xcode-select", "--print-path" };
-    const result = std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv }) catch return false;
+    const result = std.ChildProcess.initAndExec(.{ .allocator = allocator, .argv = argv }) catch return false;
     defer {
         allocator.free(result.stderr);
         allocator.free(result.stdout);
@@ -40,7 +40,7 @@ pub fn getDarwinSDK(allocator: Allocator, target: Target) ?DarwinSDK {
     };
     const path = path: {
         const argv = &[_][]const u8{ "/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path" };
-        const result = std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv }) catch return null;
+        const result = std.ChildProcess.initAndExec(.{ .allocator = allocator, .argv = argv }) catch return null;
         defer {
             allocator.free(result.stderr);
             allocator.free(result.stdout);
@@ -55,7 +55,7 @@ pub fn getDarwinSDK(allocator: Allocator, target: Target) ?DarwinSDK {
     };
     const version = version: {
         const argv = &[_][]const u8{ "/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-version" };
-        const result = std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv }) catch return null;
+        const result = std.ChildProcess.initAndExec(.{ .allocator = allocator, .argv = argv }) catch return null;
         defer {
             allocator.free(result.stderr);
             allocator.free(result.stdout);

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -275,7 +275,7 @@ pub const LibCInstallation = struct {
             dev_null,
         });
 
-        const exec_res = std.ChildProcess.exec(.{
+        const exec_res = std.ChildProcess.initAndExec(.{
             .allocator = allocator,
             .argv = argv.items,
             .max_output_bytes = 1024 * 1024,
@@ -596,7 +596,7 @@ fn ccPrintFileName(args: CCPrintFileNameOptions) ![:0]u8 {
     try appendCcExe(&argv, skip_cc_env_var);
     try argv.append(arg1);
 
-    const exec_res = std.ChildProcess.exec(.{
+    const exec_res = std.ChildProcess.initAndExec(.{
         .allocator = allocator,
         .argv = argv.items,
         .max_output_bytes = 1024 * 1024,

--- a/src/test.zig
+++ b/src/test.zig
@@ -764,7 +764,7 @@ pub const TestContext = struct {
             try zig_args.append("-O");
             try zig_args.append(@tagName(case.optimize_mode));
 
-            const result = try std.ChildProcess.exec(.{
+            const result = try std.ChildProcess.initAndExec(.{
                 .allocator = arena,
                 .argv = zig_args.items,
             });
@@ -1195,7 +1195,7 @@ pub const TestContext = struct {
 
                         try comp.makeBinFileExecutable();
 
-                        break :x std.ChildProcess.exec(.{
+                        break :x std.ChildProcess.initAndExec(.{
                             .allocator = allocator,
                             .argv = argv.items,
                             .cwd_dir = tmp.dir,

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -56,7 +56,7 @@ fn printCmd(cwd: []const u8, argv: []const []const u8) void {
 
 fn exec(cwd: []const u8, expect_0: bool, argv: []const []const u8) !ChildProcess.ExecResult {
     const max_output_size = 100 * 1024;
-    const result = ChildProcess.exec(.{
+    const result = ChildProcess.initAndExec(.{
         .allocator = a,
         .argv = argv,
         .cwd = cwd,

--- a/tools/update_clang_options.zig
+++ b/tools/update_clang_options.zig
@@ -496,7 +496,7 @@ pub fn main() anyerror!void {
         try std.fmt.allocPrint(allocator, "-I={s}/clang/include/clang/Driver", .{llvm_src_root}),
     };
 
-    const child_result = try std.ChildProcess.exec(.{
+    const child_result = try std.ChildProcess.initAndExec(.{
         .allocator = allocator,
         .argv = &child_args,
         .max_output_bytes = 100 * 1024 * 1024,

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -868,7 +868,7 @@ fn processOneTarget(job: Job) anyerror!void {
         }),
     };
 
-    const child_result = try std.ChildProcess.exec(.{
+    const child_result = try std.ChildProcess.initAndExec(.{
         .allocator = arena,
         .argv = &child_args,
         .max_output_bytes = 200 * 1024 * 1024,


### PR DESCRIPTION
found this as a cleaner solution than exposing `collectOutputPosix` and `collectOutputWindows` separately.

`spawnAndWait` alone does not solve this use case since it does not collect any output

what this does instead is rename `exec` to `initAndExec` and makes `exec` a standalone method to get the term and output

edit: feel free to squash commit this