### PR TITLE
Fixed typo in fmt.zig deprecation error message

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -896,7 +896,7 @@ pub fn formatText(
     } else if (comptime (std.mem.eql(u8, fmt, "e"))) {
         @compileError("specifier 'e' has been deprecated, wrap your argument in std.fmt.fmtSliceEscapeLower instead");
     } else if (comptime (std.mem.eql(u8, fmt, "E"))) {
-        @compileError("specifier 'X' has been deprecated, wrap your argument in std.fmt.fmtSliceEscapeUpper instead");
+        @compileError("specifier 'E' has been deprecated, wrap your argument in std.fmt.fmtSliceEscapeUpper instead");
     } else if (comptime std.mem.eql(u8, fmt, "z")) {
         @compileError("specifier 'z' has been deprecated, wrap your argument in std.zig.fmtId instead");
     } else if (comptime std.mem.eql(u8, fmt, "Z")) {


### PR DESCRIPTION
Fixed typo in deprecation error for `E` format specifier where it would instead complain about a specifier of `X`.