### PR TITLE
stage2: impl isNull/isNonNull, genSetReg for ptr_stack_offset, loading-storing via pointer (in register)

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -2909,7 +2909,9 @@ fn genSetStack(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerErro
 fn genSetReg(self: *Self, ty: Type, reg: Register, mcv: MCValue) InnerError!void {
     switch (mcv) {
         .dead => unreachable,
-        .ptr_stack_offset => unreachable,
+        .ptr_stack_offset => |off| {
+            return self.genSetReg(ty.elemType(), reg, .{ .stack_offset = off });
+        },
         .ptr_embedded_in_code => unreachable,
         .unreach, .none => return, // Nothing to do.
         .undef => {

--- a/test/stage2/x86_64.zig
+++ b/test/stage2/x86_64.zig
@@ -1662,27 +1662,80 @@ pub fn addCases(ctx: *TestContext) !void {
                 "",
             );
         }
-    }
+        {
+            var case = ctx.exe("issue 7187: miscompilation with bool return type", target);
+            case.addCompareOutput(
+                \\pub fn main() void {
+                \\    var x: usize = 1;
+                \\    var y: bool = getFalse();
+                \\    _ = y;
+                \\
+                \\    assert(x == 1);
+                \\}
+                \\
+                \\fn getFalse() bool {
+                \\    return false;
+                \\}
+                \\
+                \\fn assert(ok: bool) void {
+                \\    if (!ok) unreachable;
+                \\}
+            , "");
+        }
 
-    {
-        var case = ctx.exe("issue 7187: miscompilation with bool return type", linux_x64);
-        case.addCompareOutput(
-            \\pub fn main() void {
-            \\    var x: usize = 1;
-            \\    var y: bool = getFalse();
-            \\    _ = y;
-            \\
-            \\    assert(x == 1);
-            \\}
-            \\
-            \\fn getFalse() bool {
-            \\    return false;
-            \\}
-            \\
-            \\fn assert(ok: bool) void {
-            \\    if (!ok) unreachable;
-            \\}
-        , "");
+        {
+            var case = ctx.exe("load-store via pointer deref", target);
+            case.addCompareOutput(
+                \\pub fn main() void {
+                \\    var x: u32 = undefined;
+                \\    set(&x);
+                \\    assert(x == 123);
+                \\}
+                \\
+                \\fn set(x: *u32) void {
+                \\    x.* = 123;
+                \\}
+                \\
+                \\fn assert(ok: bool) void {
+                \\    if (!ok) unreachable;
+                \\}
+            , "");
+        }
+
+        {
+            var case = ctx.exe("optional payload", target);
+            case.addCompareOutput(
+                \\pub fn main() void {
+                \\    var x: u32 = undefined;
+                \\    const maybe_x = byPtr(&x);
+                \\    assert(maybe_x != null);
+                \\}
+                \\
+                \\fn byPtr(x: *u32) ?*u32 {
+                \\    return x;
+                \\}
+                \\
+                \\fn assert(ok: bool) void {
+                \\    if (!ok) unreachable;
+                \\}
+            , "");
+            case.addCompareOutput(
+                \\pub fn main() void {
+                \\    var x: u32 = undefined;
+                \\    const maybe_x = byPtr(&x);
+                \\    assert(maybe_x == null);
+                \\}
+                \\
+                \\fn byPtr(x: *u32) ?*u32 {
+                \\    _ = x;
+                \\    return null;
+                \\}
+                \\
+                \\fn assert(ok: bool) void {
+                \\    if (!ok) unreachable;
+                \\}
+            , "");
+        }
     }
 }
 


### PR DESCRIPTION
Implements:
* `isNull` and `isNonNull`
* `genSetReg` for `ptr_stack_offset`
* load address (pointer) to a stack variable in a register via
  `lea` instruction
* store value on the stack via a pointer stored in a register via
  `mov [reg], imm` instruction
* the lowerings naturally are handled automatically by Mir -> Isel
  layer
* add initial (without safety) implementation of `.optional_payload`
* add matching stage2 test cases