### PR TITLE
stage1: fix @errorName null termination

### DIFF
--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -8193,7 +8193,7 @@ static void generate_error_name_table(CodeGen *g) {
 
         g->largest_err_name_len = max(g->largest_err_name_len, buf_len(name));
 
-        LLVMValueRef str_init = LLVMConstString(buf_ptr(name), (unsigned)buf_len(name), true);
+        LLVMValueRef str_init = LLVMConstString(buf_ptr(name), (unsigned)buf_len(name), false);
         LLVMValueRef str_global = LLVMAddGlobal(g->module, LLVMTypeOf(str_init), "");
         LLVMSetInitializer(str_global, str_init);
         LLVMSetLinkage(str_global, LLVMPrivateLinkage);

--- a/test/behavior/error_stage1.zig
+++ b/test/behavior/error_stage1.zig
@@ -14,6 +14,17 @@ test "@errorName" {
     try expect(mem.eql(u8, @errorName(gimmeItBroke()), "ItBroke"));
 }
 
+test "@errorName sentinel length matches slice length" {
+    const name = testBuiltinErrorName(error.FooBar);
+    const length: usize = 6;
+    try expectEqual(length, std.mem.indexOfSentinel(u8, 0, name.ptr));
+    try expectEqual(length, name.len);
+}
+
+pub fn testBuiltinErrorName(err: anyerror) [:0]const u8 {
+    return @errorName(err);
+}
+
 test "error union type " {
     try testErrorUnionType();
     comptime try testErrorUnionType();


### PR DESCRIPTION
Fixes #10468 

If I interpret src/Sema.zig correctly `@errorName` is not yet implemented in stage2.