### PR TITLE
fmt: Refactor parsing of placeholders into its own function

### DIFF
--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -5876,49 +5876,7 @@ static bool can_mutate_comptime_var_state(ZigValue *value) {
     zig_unreachable();
 }
 
-static bool return_type_is_cacheable(ZigType *return_type) {
-    switch (return_type->id) {
-        case ZigTypeIdInvalid:
-            zig_unreachable();
-        case ZigTypeIdMetaType:
-        case ZigTypeIdVoid:
-        case ZigTypeIdBool:
-        case ZigTypeIdUnreachable:
-        case ZigTypeIdInt:
-        case ZigTypeIdFloat:
-        case ZigTypeIdComptimeFloat:
-        case ZigTypeIdComptimeInt:
-        case ZigTypeIdEnumLiteral:
-        case ZigTypeIdUndefined:
-        case ZigTypeIdNull:
-        case ZigTypeIdBoundFn:
-        case ZigTypeIdFn:
-        case ZigTypeIdOpaque:
-        case ZigTypeIdErrorSet:
-        case ZigTypeIdEnum:
-        case ZigTypeIdPointer:
-        case ZigTypeIdVector:
-        case ZigTypeIdFnFrame:
-        case ZigTypeIdAnyFrame:
-            return true;
-
-        case ZigTypeIdArray:
-        case ZigTypeIdStruct:
-        case ZigTypeIdUnion:
-            return false;
-
-        case ZigTypeIdOptional:
-            return return_type_is_cacheable(return_type->data.maybe.child_type);
-
-        case ZigTypeIdErrorUnion:
-            return return_type_is_cacheable(return_type->data.error_union.payload_type);
-    }
-    zig_unreachable();
-}
-
 bool fn_eval_cacheable(Scope *scope, ZigType *return_type) {
-    if (!return_type_is_cacheable(return_type))
-        return false;
     while (scope) {
         if (scope->id == ScopeIdVarDecl) {
             ScopeVarDecl *var_scope = (ScopeVarDecl *)scope;


### PR DESCRIPTION
The current logic for parsing the format string in the format API is extremly inefficient and is a
big cause for the huge memory usage of the stage 1 compiler. This PR makes an attempt at improving
this by moving the logic for parsing the placeholders into its own function which the compiler can
then cache. This then causes the compiler to generate a lot less IR instructions, which improves
the memory usage by quite a bit. In theory, this is also an improvement for stage 2. As far as I
understand, then sematics of comptime arguments have not changed between the compilers, so stage 2
would produce a lot of IR instructions for the old format API as well.

related #6485 #9635 #9056

### Building stage 1

```
zig-master on  master
$ mkdir build
$ cd build
$ cmake .. -G Ninja -DZIG_PREFER_CLANG_CPP_DYLIB=on -DCMAKE_BUILD_TYPE=Release
...

$ $(which time) -v ninja
        Command being timed: "ninja"
        User time (seconds): 200.03
        System time (seconds): 5.08
        Percent of CPU this job got: 139%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 2:26.73
...
        Maximum resident set size (kbytes): 7873888
...


zig on  better-fmt-parsing
$ mkdir build
$ cd build
$ cmake .. -G Ninja -DZIG_PREFER_CLANG_CPP_DYLIB=on -DCMAKE_BUILD_TYPE=Release
...

$ $(which time) -v ninja
        Command being timed: "ninja"
        User time (seconds): 191.63
        System time (seconds): 4.38
        Percent of CPU this job got: 142%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 2:17.30
...
        Maximum resident set size (kbytes): 5265844
...
```

Uses about 2.5 gigs less memory and finishes about 10 seconds faster

### Building stage 2
```
zig-master on  master
$ $(which time) -v ./build/zig build
        Command being timed: "./build/zig build"
        User time (seconds): 24.21
        System time (seconds): 2.52
        Percent of CPU this job got: 101%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.38
...
        Maximum resident set size (kbytes): 7617472
...

$ ll zig-out/bin/zig
.rwxr-xr-x 30M hejsil  1 Jan 18:03 zig-out/bin/zig


zig on  better-fmt-parsing
$ $(which time) -v ./build/zig build
        Command being timed: "./build/zig build"
        User time (seconds): 20.84
        System time (seconds): 1.87
        Percent of CPU this job got: 101%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:22.30
...
        Maximum resident set size (kbytes): 5309092
...

$ ll zig-out/bin/zig
.rwxr-xr-x 27M hejsil  1 Jan 18:03 zig-out/bin/zig

```

Uses about 2.3 gigs less memory, finishes about 4 seconds faster and the binary is 3 megs smaller.

