### PR TITLE
stage 2 stuff

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3888,6 +3888,14 @@ fn analyzeCall(
 
                 if (is_comptime_call) {
                     const arg_val = try sema.resolveConstMaybeUndefVal(&child_block, arg_src, casted_arg);
+                    switch (arg_val.tag()) {
+                        .generic_poison, .generic_poison_type => {
+                            // This function is currently evaluated as part of an as-of-yet unresolvable
+                            // parameter or return type.
+                            return error.GenericPoison;
+                        },
+                        else => {},
+                    }
                     memoized_call_key.args[arg_i] = .{
                         .ty = param_ty,
                         .val = arg_val,
@@ -3905,6 +3913,14 @@ fn analyzeCall(
                 if (is_comptime_call) {
                     const arg_src = call_src; // TODO: better source location
                     const arg_val = try sema.resolveConstMaybeUndefVal(&child_block, arg_src, uncasted_arg);
+                    switch (arg_val.tag()) {
+                        .generic_poison, .generic_poison_type => {
+                            // This function is currently evaluated as part of an as-of-yet unresolvable
+                            // parameter or return type.
+                            return error.GenericPoison;
+                        },
+                        else => {},
+                    }
                     memoized_call_key.args[arg_i] = .{
                         .ty = sema.typeOf(uncasted_arg),
                         .val = arg_val,

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -57,3 +57,48 @@ test "Type.EnumLiteral" {
         @TypeOf(.Dummy),
     });
 }
+
+test "Type.Pointer" {
+    try testTypes(&[_]type{
+        // One Value Pointer Types
+        *u8,                               *const u8,
+        *volatile u8,                      *const volatile u8,
+        *align(4) u8,                      *align(4) const u8,
+        *align(4) volatile u8,             *align(4) const volatile u8,
+        *align(8) u8,                      *align(8) const u8,
+        *align(8) volatile u8,             *align(8) const volatile u8,
+        *allowzero u8,                     *allowzero const u8,
+        *allowzero volatile u8,            *allowzero const volatile u8,
+        *allowzero align(4) u8,            *allowzero align(4) const u8,
+        *allowzero align(4) volatile u8,   *allowzero align(4) const volatile u8,
+        // Many Values Pointer Types
+        [*]u8,                             [*]const u8,
+        [*]volatile u8,                    [*]const volatile u8,
+        [*]align(4) u8,                    [*]align(4) const u8,
+        [*]align(4) volatile u8,           [*]align(4) const volatile u8,
+        [*]align(8) u8,                    [*]align(8) const u8,
+        [*]align(8) volatile u8,           [*]align(8) const volatile u8,
+        [*]allowzero u8,                   [*]allowzero const u8,
+        [*]allowzero volatile u8,          [*]allowzero const volatile u8,
+        [*]allowzero align(4) u8,          [*]allowzero align(4) const u8,
+        [*]allowzero align(4) volatile u8, [*]allowzero align(4) const volatile u8,
+        // Slice Types
+        []u8,                              []const u8,
+        []volatile u8,                     []const volatile u8,
+        []align(4) u8,                     []align(4) const u8,
+        []align(4) volatile u8,            []align(4) const volatile u8,
+        []align(8) u8,                     []align(8) const u8,
+        []align(8) volatile u8,            []align(8) const volatile u8,
+        []allowzero u8,                    []allowzero const u8,
+        []allowzero volatile u8,           []allowzero const volatile u8,
+        []allowzero align(4) u8,           []allowzero align(4) const u8,
+        []allowzero align(4) volatile u8,  []allowzero align(4) const volatile u8,
+        // C Pointer Types
+        [*c]u8,                            [*c]const u8,
+        [*c]volatile u8,                   [*c]const volatile u8,
+        [*c]align(4) u8,                   [*c]align(4) const u8,
+        [*c]align(4) volatile u8,          [*c]align(4) const volatile u8,
+        [*c]align(8) u8,                   [*c]align(8) const u8,
+        [*c]align(8) volatile u8,          [*c]align(8) const volatile u8,
+    });
+}

--- a/test/behavior/type_info.zig
+++ b/test/behavior/type_info.zig
@@ -34,3 +34,26 @@ fn testOptional() !void {
     try expect(null_info == .Optional);
     try expect(null_info.Optional.child == void);
 }
+
+test "type info: C pointer type info" {
+    try testCPtr();
+    comptime try testCPtr();
+}
+
+fn testCPtr() !void {
+    const ptr_info = @typeInfo([*c]align(4) const i8);
+    try expect(ptr_info == .Pointer);
+    try expect(ptr_info.Pointer.size == .C);
+    try expect(ptr_info.Pointer.is_const);
+    try expect(!ptr_info.Pointer.is_volatile);
+    try expect(ptr_info.Pointer.alignment == 4);
+    try expect(ptr_info.Pointer.child == i8);
+}
+
+test "type info: value is correctly copied" {
+    comptime {
+        var ptrInfo = @typeInfo([]u32);
+        ptrInfo.Pointer.size = .One;
+        try expect(@typeInfo([]u32).Pointer.size == .Slice);
+    }
+}

--- a/test/behavior/type_info_stage1.zig
+++ b/test/behavior/type_info_stage1.zig
@@ -68,21 +68,6 @@ fn testNullTerminatedPtr() !void {
     try expect(@typeInfo([:0]u8).Pointer.sentinel != null);
 }
 
-test "type info: C pointer type info" {
-    try testCPtr();
-    comptime try testCPtr();
-}
-
-fn testCPtr() !void {
-    const ptr_info = @typeInfo([*c]align(4) const i8);
-    try expect(ptr_info == .Pointer);
-    try expect(ptr_info.Pointer.size == .C);
-    try expect(ptr_info.Pointer.is_const);
-    try expect(!ptr_info.Pointer.is_volatile);
-    try expect(ptr_info.Pointer.alignment == 4);
-    try expect(ptr_info.Pointer.child == i8);
-}
-
 test "type info: slice type info" {
     try testSlice();
     comptime try testSlice();
@@ -395,7 +380,7 @@ test "@typeInfo does not force declarations into existence" {
     comptime try expect(@typeInfo(S).Struct.fields.len == 1);
 }
 
-test "defaut value for a var-typed field" {
+test "default value for a var-typed field" {
     const S = struct { x: anytype };
     try expect(@typeInfo(S).Struct.fields[0].default_value == null);
 }
@@ -410,14 +395,6 @@ test "type info for async frames" {
             try expect(frame.function == add);
         },
         else => unreachable,
-    }
-}
-
-test "type info: value is correctly copied" {
-    comptime {
-        var ptrInfo = @typeInfo([]u32);
-        ptrInfo.Pointer.size = .One;
-        try expect(@typeInfo([]u32).Pointer.size == .Slice);
     }
 }
 

--- a/test/behavior/type_stage1.zig
+++ b/test/behavior/type_stage1.zig
@@ -17,51 +17,6 @@ test "Type.Float" {
     try testTypes(&[_]type{ f16, f32, f64, f128 });
 }
 
-test "Type.Pointer" {
-    try testTypes(&[_]type{
-        // One Value Pointer Types
-        *u8,                               *const u8,
-        *volatile u8,                      *const volatile u8,
-        *align(4) u8,                      *align(4) const u8,
-        *align(4) volatile u8,             *align(4) const volatile u8,
-        *align(8) u8,                      *align(8) const u8,
-        *align(8) volatile u8,             *align(8) const volatile u8,
-        *allowzero u8,                     *allowzero const u8,
-        *allowzero volatile u8,            *allowzero const volatile u8,
-        *allowzero align(4) u8,            *allowzero align(4) const u8,
-        *allowzero align(4) volatile u8,   *allowzero align(4) const volatile u8,
-        // Many Values Pointer Types
-        [*]u8,                             [*]const u8,
-        [*]volatile u8,                    [*]const volatile u8,
-        [*]align(4) u8,                    [*]align(4) const u8,
-        [*]align(4) volatile u8,           [*]align(4) const volatile u8,
-        [*]align(8) u8,                    [*]align(8) const u8,
-        [*]align(8) volatile u8,           [*]align(8) const volatile u8,
-        [*]allowzero u8,                   [*]allowzero const u8,
-        [*]allowzero volatile u8,          [*]allowzero const volatile u8,
-        [*]allowzero align(4) u8,          [*]allowzero align(4) const u8,
-        [*]allowzero align(4) volatile u8, [*]allowzero align(4) const volatile u8,
-        // Slice Types
-        []u8,                              []const u8,
-        []volatile u8,                     []const volatile u8,
-        []align(4) u8,                     []align(4) const u8,
-        []align(4) volatile u8,            []align(4) const volatile u8,
-        []align(8) u8,                     []align(8) const u8,
-        []align(8) volatile u8,            []align(8) const volatile u8,
-        []allowzero u8,                    []allowzero const u8,
-        []allowzero volatile u8,           []allowzero const volatile u8,
-        []allowzero align(4) u8,           []allowzero align(4) const u8,
-        []allowzero align(4) volatile u8,  []allowzero align(4) const volatile u8,
-        // C Pointer Types
-        [*c]u8,                            [*c]const u8,
-        [*c]volatile u8,                   [*c]const volatile u8,
-        [*c]align(4) u8,                   [*c]align(4) const u8,
-        [*c]align(4) volatile u8,          [*c]align(4) const volatile u8,
-        [*c]align(8) u8,                   [*c]align(8) const u8,
-        [*c]align(8) volatile u8,          [*c]align(8) const volatile u8,
-    });
-}
-
 test "Type.Array" {
     try testing.expect([123]u8 == @Type(TypeInfo{
         .Array = TypeInfo.Array{
@@ -102,6 +57,7 @@ test "@Type create slice with null sentinel" {
     });
     try testing.expect(Slice == []align(8) const *i32);
 }
+
 test "@Type picks up the sentinel value from TypeInfo" {
     try testTypes(&[_]type{
         [11:0]u8,                            [4:10]u8,


### PR DESCRIPTION
* Fixes a bug where comptime and inline functions would be called with generic poison arguments if the call appears in a non-evaluating context such as return types and depends on the type of another parameter.
* Implements `@Type` for pointers. One complication appears here with type info for sentinels, since those are of `anytype`. I temporarily hacked around that here by allowing coercions from `T` to `noreturn`, though i did not include that here since i felt it was kind of a hack. As a result, `@Type` for pointers without sentinels works, but only with type info created by `@typeInfo`.
* Moves a bunch of tests that now pass. 