### PR TITLE
CBE: Add basic slice support

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1049,6 +1049,7 @@ pub fn genDecl(o: *Object) !void {
             try fwd_decl_writer.writeAll(mem.span(o.dg.decl.name));
             var render_ty = tv.ty;
             while (render_ty.zigTypeTag() == .Array) {
+                // Extern global array in C doesn't care about the size.
                 try fwd_decl_writer.writeAll("[]");
                 render_ty = render_ty.elemType();
             }

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -658,11 +658,7 @@ pub const DeclGen = struct {
         try bw.writeAll("ptr; size_t len; } ");
         const name_index = buffer.items.len;
         if (t.isConstPtr()) {
-            if (t.tag() == .const_slice_u8_sentinel_0) {
-                try bw.print("zig_LS_{s};\n", .{typeToCIdentifier(elem_type)});
-            } else {
-                try bw.print("zig_L_{s};\n", .{typeToCIdentifier(elem_type)});
-            }
+            try bw.print("zig_L_{s};\n", .{typeToCIdentifier(elem_type)});
         } else {
             try bw.print("zig_M_{s};\n", .{typeToCIdentifier(elem_type)});
         }

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -336,6 +336,9 @@ const Flush = struct {
         Type.HashContext64,
         std.hash_map.default_max_load_percentage,
     );
+    /// In addition to Typedefs, who indexing by Type, we also need
+    /// a map to avoid identical typedef statements created from
+    /// different Type-s.
     const RenderedTypedefs = std.StringHashMapUnmanaged(void);
 
     fn deinit(f: *Flush, gpa: Allocator) void {

--- a/src/type.zig
+++ b/src/type.zig
@@ -694,8 +694,8 @@ pub const Type = extern union {
             => {}, // The zig type tag is all that is needed to distinguish.
 
             .Pointer => {
+                // Basic hashing for simple types.
                 // TODO implement more pointer type hashing
-                // Basic hashing for small types.
                 std.hash.autoHash(hasher, self.tag());
             },
             .Int => {

--- a/src/type.zig
+++ b/src/type.zig
@@ -695,6 +695,8 @@ pub const Type = extern union {
 
             .Pointer => {
                 // TODO implement more pointer type hashing
+                // Basic hashing for small types.
+                std.hash.autoHash(hasher, self.tag());
             },
             .Int => {
                 // Detect that e.g. u64 != usize, even if the bits match on a particular target.

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -58,6 +58,7 @@ test {
             _ = @import("behavior/member_func.zig");
             _ = @import("behavior/null.zig");
             _ = @import("behavior/optional.zig");
+            _ = @import("behavior/slice.zig");
             _ = @import("behavior/struct.zig");
             _ = @import("behavior/this.zig");
             _ = @import("behavior/translate_c_macros.zig");
@@ -99,7 +100,6 @@ test {
                 _ = @import("behavior/popcount.zig");
                 _ = @import("behavior/saturating_arithmetic.zig");
                 _ = @import("behavior/sizeof_and_typeof.zig");
-                _ = @import("behavior/slice.zig");
                 _ = @import("behavior/struct_llvm.zig");
                 _ = @import("behavior/switch.zig");
                 _ = @import("behavior/undefined.zig");

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -165,6 +165,9 @@ test "slicing zero length array" {
     try expect(mem.eql(u8, s1, ""));
 
     if (builtin.object_format == .c) {
+        // Zero-sized array cannot be codegen-ed in CBE,
+        // so we need to use sentinel array, who has at least
+        // one element.
         const s2 = ([_:0xde]u32{})[0..];
         try expect(s2.len == 0);
         try expect(mem.eql(u32, s2, &[_:0xde]u32{}));

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -164,7 +164,7 @@ test "slicing zero length array" {
     try expect(s1.len == 0);
     try expect(mem.eql(u8, s1, ""));
 
-    if (builtin.zig_is_stage2) {
+    if (builtin.object_format == .c) {
         const s2 = ([_:0xde]u32{})[0..];
         try expect(s2.len == 0);
         try expect(mem.eql(u32, s2, &[_:0xde]u32{}));

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const expect = std.testing.expect;
 const expectEqualSlices = std.testing.expectEqualSlices;
 const expectEqual = std.testing.expectEqual;
@@ -160,9 +161,16 @@ test "comptime pointer cast array and then slice" {
 
 test "slicing zero length array" {
     const s1 = ""[0..];
-    const s2 = ([_]u32{})[0..];
     try expect(s1.len == 0);
-    try expect(s2.len == 0);
     try expect(mem.eql(u8, s1, ""));
-    try expect(mem.eql(u32, s2, &[_]u32{}));
+
+    if (builtin.zig_is_stage2) {
+        const s2 = ([_:0xde]u32{})[0..];
+        try expect(s2.len == 0);
+        try expect(mem.eql(u32, s2, &[_:0xde]u32{}));
+    } else {
+        const s2 = ([_]u32{})[0..];
+        try expect(s2.len == 0);
+        try expect(mem.eql(u32, s2, &[_]u32{}));
+    }
 }


### PR DESCRIPTION
Details:
  - Add codegen support for slicing of element pointers.
  - Basic Type.hash for .Pointer types.
  - Fix incorrect codegen on global array variables. Nevertheless, the initialization for such variables is still buggy.
  - Zero-length global array will not be codegen-ed by stage2, thus updating related test cases to use sentinel array instead.
  - Use HashMap to avoid duplicated typedef bodies.

Now test/behavior/slice.zig (as well as other existing tests) should pass.
I bumped into the problem mentioned in the third bullet point, I can file a separate issue for that.