### PR TITLE
Add CANNOT_DELETE as a possible error in os.windows.DeleteFile

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -900,6 +900,7 @@ pub fn DeleteFile(sub_path_w: []const u16, options: DeleteFileOptions) DeleteFil
         .FILE_IS_A_DIRECTORY => return error.IsDir,
         .NOT_A_DIRECTORY => return error.NotDir,
         .SHARING_VIOLATION => return error.FileBusy,
+        .CANNOT_DELETE => return error.AccessDenied,
         else => return unexpectedStatus(rc),
     }
 }


### PR DESCRIPTION
Can happen when e.g. trying to delete a file with the Read Only flag set

(was being triggered by the test added in #10486)