### PR TITLE
io_uring: improve IO_Uring.copy_cqe

### DIFF
--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -300,9 +300,10 @@ pub const IO_Uring = struct {
     /// A convenience method for `copy_cqes()` for when you don't need to batch or peek.
     pub fn copy_cqe(ring: *IO_Uring) !io_uring_cqe {
         var cqes: [1]io_uring_cqe = undefined;
-        const count = try ring.copy_cqes(&cqes, 1);
-        assert(count == 1);
-        return cqes[0];
+        while (true) {
+            const count = try ring.copy_cqes(&cqes, 1);
+            if (count > 0) return cqes[0];
+        }
     }
 
     /// Matches the implementation of cq_ring_needs_flush() in liburing.


### PR DESCRIPTION
This is an attempt to fix a bug I encountered while trying to reproduce #10462.

The following code can trivially trigger [this assert](https://github.com/ziglang/zig/blob/master/lib/std/os/linux/io_uring.zig#L304) on my machine:
```zig
const std = @import("std");
const os = std.os;
const testing = std.testing;

pub fn main() anyerror!void {
    var ring = try os.linux.IO_Uring.init(4, 0);
    defer ring.deinit();

    const path = "test_io_uring_write_read_fixed";
    const file = try std.fs.cwd().createFile(path, .{ .read = true, .truncate = true });
    defer file.close();
    defer std.fs.cwd().deleteFile(path) catch {};

    const fd = file.handle;

    var i: usize = 0;
    while (i < 10000000) : (i += 1) {
        const sqe_write = try ring.write(0x45454545, fd, "foobar", 3);
        sqe_write.flags |= os.linux.IOSQE_IO_LINK;
        const sqe_write2 = try ring.write(0x45454545, fd, "hello", 3);
        sqe_write2.flags |= os.linux.IOSQE_IO_LINK;
        const sqe_write3 = try ring.write(0x45454545, fd, "barbaz", 3);
        sqe_write3.flags |= os.linux.IOSQE_IO_LINK;

        var buf: [32]u8 = undefined;
        _ = try ring.read(0x12121212, fd, &buf, 0);

        _ = try ring.submit();
        _ = try ring.copy_cqe();
        _ = try ring.copy_cqe();
        _ = try ring.copy_cqe();
        _ = try ring.copy_cqe();

        if (i % 10000 == 0) {
            std.debug.print("iter: {d}\n", .{i});
        }
    }
}
```
```
iter: 0
thread 36799 panic: reached unreachable code
/home/vincent/dev/devtools/zig/lib/std/debug.zig:224:14: 0x2058cb in std.debug.assert (zig-debug-io_uring-readwrite-fixed)
    if (!ok) unreachable; // assertion failure
             ^
/home/vincent/dev/devtools/zig/lib/std/os/linux/io_uring.zig:304:15: 0x235b2e in std.os.linux.io_uring.IO_Uring.copy_cqe (zig-debug-io_uring-readwrite-fixed)
        assert(count == 1);
              ^
/home/vincent/tmp/zig-debug-io_uring-readwrite-fixed/src/main.zig:31:30: 0x22dff3 in main (zig-debug-io_uring-readwrite-fixed)
        _ = try ring.copy_cqe();
                             ^
/home/vincent/dev/devtools/zig/lib/std/start.zig:553:37: 0x226e8a in std.start.callMain (zig-debug-io_uring-readwrite-fixed)
            const result = root.main() catch |err| {
                                    ^
/home/vincent/dev/devtools/zig/lib/std/start.zig:495:12: 0x207a5e in std.start.callMainWithArgs (zig-debug-io_uring-readwrite-fixed)
    return @call(.{ .modifier = .always_inline }, callMain, .{});
           ^
/home/vincent/dev/devtools/zig/lib/std/start.zig:409:17: 0x206af6 in std.start.posixCallMainAndExit (zig-debug-io_uring-readwrite-fixed)
    std.os.exit(@call(.{ .modifier = .always_inline }, callMainWithArgs, .{ argc, argv, envp }));
                ^
/home/vincent/dev/devtools/zig/lib/std/start.zig:322:5: 0x206902 in std.start._start (zig-debug-io_uring-readwrite-fixed)
    @call(.{ .modifier = .never_inline }, posixCallMainAndExit, .{});
    ^
fish: Job 1, './zig-out/bin/zig-debug-io_urin…' terminated by signal SIGABRT (Abort)
```

[copy_cqe](https://github.com/ziglang/zig/blob/master/lib/std/os/linux/io_uring.zig#L299-L306) assumes that [copy_cqes](https://github.com/ziglang/zig/blob/master/lib/std/os/linux/io_uring.zig#L271-L279) will only return when at least one CQE is available before returning but that's not always the case as shown with this panic.
I can't figure out _why_ [this code](https://github.com/ziglang/zig/blob/master/lib/std/os/linux/io_uring.zig#L275-L276) fails because invoking `io_uring_enter` like this should wait according to the manpage:
```
IORING_ENTER_GETEVENTS
    If this flag is set, then the system call will wait for the specificied number of events in min_complete before returning.
    This flag can be set along with to_submit to both submit and complete events in a single system call.
```
and then we would expect [copy_cqes_ready](https://github.com/ziglang/zig/blob/master/lib/std/os/linux/io_uring.zig#L281-L297) to have at least as many as `min_complete` available but this is apparently not always the case.

liburing does something similar to this commit in [_io_uring_get_cqe](https://github.com/axboe/liburing/blob/master/src/queue.c#L79-L126) which is its equivalent to `copy_cqe`, so maybe I'm missing something which would explain why waiting doesn't work like we think.

With this fix I'm unable to reproduce the crash above.

Note that this may be a fix for #10462 but since there are no stacktraces I can't be sure it's the same crash.