### PR TITLE
cbe: undefined

### DIFF
--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -62,6 +62,7 @@ test {
             _ = @import("behavior/this.zig");
             _ = @import("behavior/translate_c_macros.zig");
             _ = @import("behavior/while.zig");
+            _ = @import("behavior/undefined.zig");
             _ = @import("behavior/void.zig");
 
             if (builtin.object_format != .c) {
@@ -102,7 +103,6 @@ test {
                 _ = @import("behavior/slice.zig");
                 _ = @import("behavior/struct_llvm.zig");
                 _ = @import("behavior/switch.zig");
-                _ = @import("behavior/undefined.zig");
                 _ = @import("behavior/union.zig");
                 _ = @import("behavior/widening.zig");
 


### PR DESCRIPTION
The tests in `undefined.zig` pass on the C backend without modification.

Since this is so simple it feels silly creating a PR, but I noticed something in the generated C code that might be worth looking at. The test "init static array to undefined" evaluates the `expect` equalities at comptime so the generated C tests aren't fully testing C's behavior. For example:

```c
uint16_t const t0 = testing_expect(true);
```

I will update the test to address this if needed.