### PR TITLE
Normalize some build function names

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -155,11 +155,11 @@ pub fn build(b: *Builder) !void {
         const cmake_cfg = if (static_llvm) null else findAndParseConfigH(b, config_h_path_option);
 
         if (is_stage1) {
-            exe.addIncludeDir("src");
-            exe.addIncludeDir("deps/SoftFloat-3e/source/include");
+            exe.addIncludePath("src");
+            exe.addIncludePath("deps/SoftFloat-3e/source/include");
 
-            test_stage2.addIncludeDir("src");
-            test_stage2.addIncludeDir("deps/SoftFloat-3e/source/include");
+            test_stage2.addIncludePath("src");
+            test_stage2.addIncludePath("deps/SoftFloat-3e/source/include");
             // This is intentionally a dummy path. stage1.zig tries to @import("compiler_rt") in case
             // of being built by cmake. But when built by zig it's gonna get a compiler_rt so that
             // is pointless.
@@ -170,9 +170,9 @@ pub fn build(b: *Builder) !void {
             const softfloat = b.addStaticLibrary("softfloat", null);
             softfloat.setBuildMode(.ReleaseFast);
             softfloat.setTarget(target);
-            softfloat.addIncludeDir("deps/SoftFloat-3e-prebuilt");
-            softfloat.addIncludeDir("deps/SoftFloat-3e/source/8086");
-            softfloat.addIncludeDir("deps/SoftFloat-3e/source/include");
+            softfloat.addIncludePath("deps/SoftFloat-3e-prebuilt");
+            softfloat.addIncludePath("deps/SoftFloat-3e/source/8086");
+            softfloat.addIncludePath("deps/SoftFloat-3e/source/include");
             softfloat.addCSourceFiles(&softfloat_sources, &[_][]const u8{ "-std=c99", "-O3" });
             softfloat.single_threaded = single_threaded;
 
@@ -282,7 +282,7 @@ pub fn build(b: *Builder) !void {
         else
             &[_][]const u8{ "-DTRACY_ENABLE=1", "-fno-sanitize=undefined" };
 
-        exe.addIncludeDir(tracy_path);
+        exe.addIncludePath(tracy_path);
         exe.addCSourceFile(client_cpp, tracy_c_flags);
         if (!enable_llvm) {
             exe.linkSystemLibraryName("c++");
@@ -445,7 +445,7 @@ fn addCmakeCfgOptionsToExe(
         b.fmt("{s}{s}{s}", .{ exe.target.libPrefix(), "zigcpp", exe.target.staticLibSuffix() }),
     }) catch unreachable);
     assert(cfg.lld_include_dir.len != 0);
-    exe.addIncludeDir(cfg.lld_include_dir);
+    exe.addIncludePath(cfg.lld_include_dir);
     addCMakeLibraryList(exe, cfg.clang_libraries);
     addCMakeLibraryList(exe, cfg.lld_libraries);
     addCMakeLibraryList(exe, cfg.llvm_libraries);
@@ -546,9 +546,9 @@ fn addCxxKnownPath(
     if (need_cpp_includes) {
         // I used these temporarily for testing something but we obviously need a
         // more general purpose solution here.
-        //exe.addIncludeDir("/nix/store/fvf3qjqa5qpcjjkq37pb6ypnk1mzhf5h-gcc-9.3.0/lib/gcc/x86_64-unknown-linux-gnu/9.3.0/../../../../include/c++/9.3.0");
-        //exe.addIncludeDir("/nix/store/fvf3qjqa5qpcjjkq37pb6ypnk1mzhf5h-gcc-9.3.0/lib/gcc/x86_64-unknown-linux-gnu/9.3.0/../../../../include/c++/9.3.0/x86_64-unknown-linux-gnu");
-        //exe.addIncludeDir("/nix/store/fvf3qjqa5qpcjjkq37pb6ypnk1mzhf5h-gcc-9.3.0/lib/gcc/x86_64-unknown-linux-gnu/9.3.0/../../../../include/c++/9.3.0/backward");
+        //exe.addIncludePath("/nix/store/fvf3qjqa5qpcjjkq37pb6ypnk1mzhf5h-gcc-9.3.0/lib/gcc/x86_64-unknown-linux-gnu/9.3.0/../../../../include/c++/9.3.0");
+        //exe.addIncludePath("/nix/store/fvf3qjqa5qpcjjkq37pb6ypnk1mzhf5h-gcc-9.3.0/lib/gcc/x86_64-unknown-linux-gnu/9.3.0/../../../../include/c++/9.3.0/x86_64-unknown-linux-gnu");
+        //exe.addIncludePath("/nix/store/fvf3qjqa5qpcjjkq37pb6ypnk1mzhf5h-gcc-9.3.0/lib/gcc/x86_64-unknown-linux-gnu/9.3.0/../../../../include/c++/9.3.0/backward");
     }
 }
 

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2114,15 +2114,30 @@ pub const LibExeObjStep = struct {
         self.linkLibraryOrObject(obj);
     }
 
+    /// TODO deprecated, use `addSystemIncludePath`.
     pub fn addSystemIncludeDir(self: *LibExeObjStep, path: []const u8) void {
+        self.addSystemIncludePath(path);
+    }
+
+    pub fn addSystemIncludePath(self: *LibExeObjStep, path: []const u8) void {
         self.include_dirs.append(IncludeDir{ .raw_path_system = self.builder.dupe(path) }) catch unreachable;
     }
 
+    /// TODO deprecated, use `addIncludePath`.
     pub fn addIncludeDir(self: *LibExeObjStep, path: []const u8) void {
+        self.addIncludePath(path);
+    }
+
+    pub fn addIncludePath(self: *LibExeObjStep, path: []const u8) void {
         self.include_dirs.append(IncludeDir{ .raw_path = self.builder.dupe(path) }) catch unreachable;
     }
 
+    /// TODO deprecated, use `addLibraryPath`.
     pub fn addLibPath(self: *LibExeObjStep, path: []const u8) void {
+        self.addLibraryPath(path);
+    }
+
+    pub fn addLibraryPath(self: *LibExeObjStep, path: []const u8) void {
         self.lib_paths.append(self.builder.dupe(path)) catch unreachable;
     }
 
@@ -2130,7 +2145,12 @@ pub const LibExeObjStep = struct {
         self.rpaths.append(self.builder.dupe(path)) catch unreachable;
     }
 
+    /// TODO deprecated, use `addFrameworkPath`.
     pub fn addFrameworkDir(self: *LibExeObjStep, dir_path: []const u8) void {
+        self.addFrameworkPath(dir_path);
+    }
+
+    pub fn addFrameworkPath(self: *LibExeObjStep, dir_path: []const u8) void {
         self.framework_dirs.append(self.builder.dupe(dir_path)) catch unreachable;
     }
 

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1947,14 +1947,14 @@ pub const LibExeObjStep = struct {
         while (it.next()) |tok| {
             if (mem.eql(u8, tok, "-I")) {
                 const dir = it.next() orelse return error.PkgConfigInvalidOutput;
-                self.addIncludeDir(dir);
+                self.addIncludePath(dir);
             } else if (mem.startsWith(u8, tok, "-I")) {
-                self.addIncludeDir(tok["-I".len..]);
+                self.addIncludePath(tok["-I".len..]);
             } else if (mem.eql(u8, tok, "-L")) {
                 const dir = it.next() orelse return error.PkgConfigInvalidOutput;
-                self.addLibPath(dir);
+                self.addLibraryPath(dir);
             } else if (mem.startsWith(u8, tok, "-L")) {
-                self.addLibPath(tok["-L".len..]);
+                self.addLibraryPath(tok["-L".len..]);
             } else if (mem.eql(u8, tok, "-l")) {
                 const lib = it.next() orelse return error.PkgConfigInvalidOutput;
                 self.linkSystemLibraryName(lib);

--- a/test/standalone/issue_794/build.zig
+++ b/test/standalone/issue_794/build.zig
@@ -2,7 +2,7 @@ const Builder = @import("std").build.Builder;
 
 pub fn build(b: *Builder) void {
     const test_artifact = b.addTest("main.zig");
-    test_artifact.addIncludeDir("a_directory");
+    test_artifact.addIncludePath("a_directory");
 
     b.default_step.dependOn(&test_artifact.step);
 

--- a/test/standalone/issue_9812/build.zig
+++ b/test/standalone/issue_9812/build.zig
@@ -8,7 +8,7 @@ pub fn build(b: *std.build.Builder) !void {
         "-std=c99",
         "-fno-sanitize=undefined",
     });
-    zip_add.addIncludeDir("vendor/kuba-zip");
+    zip_add.addIncludePath("vendor/kuba-zip");
     zip_add.linkLibC();
 
     const test_step = b.step("test", "Test it");

--- a/test/standalone/link_interdependent_static_c_libs/build.zig
+++ b/test/standalone/link_interdependent_static_c_libs/build.zig
@@ -6,18 +6,18 @@ pub fn build(b: *Builder) void {
     const lib_a = b.addStaticLibrary("a", null);
     lib_a.addCSourceFile("a.c", &[_][]const u8{});
     lib_a.setBuildMode(mode);
-    lib_a.addIncludeDir(".");
+    lib_a.addIncludePath(".");
 
     const lib_b = b.addStaticLibrary("b", null);
     lib_b.addCSourceFile("b.c", &[_][]const u8{});
     lib_b.setBuildMode(mode);
-    lib_b.addIncludeDir(".");
+    lib_b.addIncludePath(".");
 
     const test_exe = b.addTest("main.zig");
     test_exe.setBuildMode(mode);
     test_exe.linkLibrary(lib_a);
     test_exe.linkLibrary(lib_b);
-    test_exe.addIncludeDir(".");
+    test_exe.addIncludePath(".");
 
     const test_step = b.step("test", "Test it");
     test_step.dependOn(&test_exe.step);

--- a/test/standalone/link_static_lib_as_system_lib/build.zig
+++ b/test/standalone/link_static_lib_as_system_lib/build.zig
@@ -7,15 +7,15 @@ pub fn build(b: *Builder) void {
     const lib_a = b.addStaticLibrary("a", null);
     lib_a.addCSourceFile("a.c", &[_][]const u8{});
     lib_a.setBuildMode(mode);
-    lib_a.addIncludeDir(".");
+    lib_a.addIncludePath(".");
     lib_a.install();
 
     const test_exe = b.addTest("main.zig");
     test_exe.setBuildMode(mode);
     test_exe.linkSystemLibrary("a"); // force linking liba.a as -la
-    test_exe.addSystemIncludeDir(".");
+    test_exe.addSystemIncludePath(".");
     const search_path = std.fs.path.join(b.allocator, &[_][]const u8{ b.install_path, "lib" }) catch unreachable;
-    test_exe.addLibPath(search_path);
+    test_exe.addLibraryPath(search_path);
 
     const test_step = b.step("test", "Test it");
     test_step.dependOn(b.getInstallStep());

--- a/test/standalone/objc/build.zig
+++ b/test/standalone/objc/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *Builder) void {
 
     const exe = b.addExecutable("test", null);
     b.default_step.dependOn(&exe.step);
-    exe.addIncludeDir(".");
+    exe.addIncludePath(".");
     exe.addCSourceFile("Foo.m", &[0][]const u8{});
     exe.addCSourceFile("test.m", &[0][]const u8{});
     exe.setBuildMode(mode);

--- a/test/standalone/objcpp/build.zig
+++ b/test/standalone/objcpp/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *Builder) void {
 
     const exe = b.addExecutable("test", null);
     b.default_step.dependOn(&exe.step);
-    exe.addIncludeDir(".");
+    exe.addIncludePath(".");
     exe.addCSourceFile("Foo.mm", &[0][]const u8{});
     exe.addCSourceFile("test.mm", &[0][]const u8{});
     exe.setBuildMode(mode);

--- a/test/standalone/static_c_lib/build.zig
+++ b/test/standalone/static_c_lib/build.zig
@@ -6,12 +6,12 @@ pub fn build(b: *Builder) void {
     const foo = b.addStaticLibrary("foo", null);
     foo.addCSourceFile("foo.c", &[_][]const u8{});
     foo.setBuildMode(mode);
-    foo.addIncludeDir(".");
+    foo.addIncludePath(".");
 
     const test_exe = b.addTest("foo.zig");
     test_exe.setBuildMode(mode);
     test_exe.linkLibrary(foo);
-    test_exe.addIncludeDir(".");
+    test_exe.addIncludePath(".");
 
     const test_step = b.step("test", "Test it");
     test_step.dependOn(&test_exe.step);

--- a/test/standalone/use_alias/build.zig
+++ b/test/standalone/use_alias/build.zig
@@ -3,7 +3,7 @@ const Builder = @import("std").build.Builder;
 pub fn build(b: *Builder) void {
     const main = b.addTest("main.zig");
     main.setBuildMode(b.standardReleaseOptions());
-    main.addIncludeDir(".");
+    main.addIncludePath(".");
 
     const test_step = b.step("test", "Test it");
     test_step.dependOn(&main.step);

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -578,7 +578,7 @@ pub fn addPkgTests(
             these_tests.linkSystemLibrary("c");
         }
         these_tests.overrideZigLibDir("lib");
-        these_tests.addIncludeDir("test");
+        these_tests.addIncludePath("test");
 
         step.dependOn(&these_tests.step);
     }


### PR DESCRIPTION
An attempt to normalize some of the function names in build.zig.  I've elected to normalize `add*Dir` to `add*Path`.  Also I've replaced the "Lib" abbreviation with "Library" to make it more consistent with using "Include" rather than "Inc".

The PR does not remove the old names, only adds the new normalized ones to faciliate a transition period.

This PR is structured as a proposal where only the necessary changes have been submitted.  Follow up changes would be to substitute the new names with the old through the whole repository, and another change might include renaming the fields of the `Builder` type to correspond with the function names changes.