### PR TITLE
Stage2: wasm-linker - Only export symbols notated as such

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2659,6 +2659,8 @@ pub const LibExeObjStep = struct {
                         try zig_args.append(bin_name);
                         try zig_args.append("--test-cmd");
                         try zig_args.append("--dir=.");
+                        try zig_args.append("--test-cmd");
+                        try zig_args.append("--allow-unknown-exports"); // TODO: Remove when stage2 is default compiler
                         try zig_args.append("--test-cmd-bin");
                     } else {
                         try zig_args.append("--test-no-exec");

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1882,9 +1882,9 @@ pub fn destroy(self: *Compilation) void {
     self.astgen_wait_group.deinit();
 
     for (self.export_symbol_names.items) |symbol_name| {
-        self.gpa.free(symbol_name);
+        gpa.free(symbol_name);
     }
-    self.export_symbol_names.deinit(self.gpa);
+    self.export_symbol_names.deinit(gpa);
 
     // This destroys `self`.
     self.arena_state.promote(gpa).deinit();

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -165,6 +165,10 @@ emit_docs: ?EmitLoc,
 work_queue_wait_group: WaitGroup,
 astgen_wait_group: WaitGroup,
 
+/// Exported symbol names. This is only for when the target is wasm.
+/// TODO: Remove this when Stage2 becomes the default compiler as it will already have this information.
+export_symbol_names: std.ArrayListUnmanaged([]const u8) = .{},
+
 pub const SemaError = Module.SemaError;
 
 pub const CRTFile = struct {
@@ -1876,6 +1880,11 @@ pub fn destroy(self: *Compilation) void {
 
     self.work_queue_wait_group.deinit();
     self.astgen_wait_group.deinit();
+
+    for (self.export_symbol_names.items) |symbol_name| {
+        self.gpa.free(symbol_name);
+    }
+    self.export_symbol_names.deinit(self.gpa);
 
     // This destroys `self`.
     self.arena_state.promote(gpa).deinit();

--- a/src/stage1.zig
+++ b/src/stage1.zig
@@ -468,13 +468,9 @@ export fn stage2_fetch_file(
     return contents.ptr;
 }
 
-export fn stage2_append_symbol(stage1: *Module, name_ptr: ?[*:0]const u8) Error {
+export fn stage2_append_symbol(stage1: *Module, name_ptr: [*c]const u8, name_len: usize) Error {
+    if (name_len == 0) return Error.None;
     const comp = @intToPtr(*Compilation, stage1.userdata);
-
-    if (name_ptr) |unwrapped_name| {
-        const symbol_name = std.mem.sliceTo(unwrapped_name, 0);
-        if (symbol_name.len == 0) return Error.None;
-        comp.export_symbol_names.append(comp.gpa, symbol_name) catch return Error.OutOfMemory;
-    }
+    comp.export_symbol_names.append(comp.gpa, name_ptr[0..name_len]) catch return Error.OutOfMemory;
     return Error.None;
 }

--- a/src/stage1.zig
+++ b/src/stage1.zig
@@ -467,3 +467,14 @@ export fn stage2_fetch_file(
     if (contents.len == 0) return @intToPtr(?[*]const u8, 0x1);
     return contents.ptr;
 }
+
+export fn stage2_append_symbol(stage1: *Module, name_ptr: ?[*:0]const u8) Error {
+    const comp = @intToPtr(*Compilation, stage1.userdata);
+
+    if (name_ptr) |unwrapped_name| {
+        const symbol_name = std.mem.sliceTo(unwrapped_name, 0);
+        if (symbol_name.len == 0) return Error.None;
+        comp.export_symbol_names.append(comp.gpa, symbol_name) catch return Error.OutOfMemory;
+    }
+    return Error.None;
+}

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -9905,6 +9905,18 @@ void codegen_build_object(CodeGen *g) {
 
     codegen_add_time_event(g, "Done");
     codegen_switch_sub_prog_node(g, nullptr);
+   
+    // append all export symbols to stage2 so we can provide them to the linker
+    if (target_is_wasm(g->zig_target)){
+        Error err;
+        auto export_it = g->exported_symbol_names.entry_iterator();
+        decltype(g->exported_symbol_names)::Entry *curr_entry = nullptr;
+        while ((curr_entry = export_it.next()) != nullptr) {
+            if ((err = stage2_append_symbol(&g->stage1, buf_ptr(curr_entry->key)))) {
+                fprintf(stderr, "Unable to export symbol '%s': %s\n", buf_ptr(curr_entry->key), err_str(err));
+            }
+        }
+    }
 }
 
 ZigPackage *codegen_create_package(CodeGen *g, const char *root_src_dir, const char *root_src_path,

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -9912,7 +9912,7 @@ void codegen_build_object(CodeGen *g) {
         auto export_it = g->exported_symbol_names.entry_iterator();
         decltype(g->exported_symbol_names)::Entry *curr_entry = nullptr;
         while ((curr_entry = export_it.next()) != nullptr) {
-            if ((err = stage2_append_symbol(&g->stage1, buf_ptr(curr_entry->key)))) {
+            if ((err = stage2_append_symbol(&g->stage1, buf_ptr(curr_entry->key), buf_len(curr_entry->key)))) {
                 fprintf(stderr, "Unable to export symbol '%s': %s\n", buf_ptr(curr_entry->key), err_str(err));
             }
         }

--- a/src/stage1/stage2.h
+++ b/src/stage1/stage2.h
@@ -182,4 +182,7 @@ ZIG_EXTERN_C const char *stage2_add_link_lib(struct ZigStage1 *stage1,
         const char *lib_name_ptr, size_t lib_name_len,
         const char *symbol_name_ptr, size_t symbol_name_len);
 
+// ABI warning
+ZIG_EXTERN_C enum Error stage2_append_symbol(struct ZigStage1 *stage1, const char *name_ptr);
+
 #endif

--- a/src/stage1/stage2.h
+++ b/src/stage1/stage2.h
@@ -183,6 +183,6 @@ ZIG_EXTERN_C const char *stage2_add_link_lib(struct ZigStage1 *stage1,
         const char *symbol_name_ptr, size_t symbol_name_len);
 
 // ABI warning
-ZIG_EXTERN_C enum Error stage2_append_symbol(struct ZigStage1 *stage1, const char *name_ptr);
+ZIG_EXTERN_C enum Error stage2_append_symbol(struct ZigStage1 *stage1, const char *name_ptr, size_t name_len);
 
 #endif

--- a/src/stage1/zig0.cpp
+++ b/src/stage1/zig0.cpp
@@ -555,7 +555,7 @@ struct Stage2SemVer stage2_version(void) {
     return {ZIG_VERSION_MAJOR, ZIG_VERSION_MINOR, ZIG_VERSION_PATCH};
 }
 
-Error stage2_append_symbol(struct ZigStage1 *stage1, const char *name_ptr)
+Error stage2_append_symbol(struct ZigStage1 *stage1, const char *name_ptr, size_t name_len)
 {
     return ErrorNone;
 }

--- a/src/stage1/zig0.cpp
+++ b/src/stage1/zig0.cpp
@@ -554,3 +554,8 @@ const char *stage2_version_string(void) {
 struct Stage2SemVer stage2_version(void) {
     return {ZIG_VERSION_MAJOR, ZIG_VERSION_MINOR, ZIG_VERSION_PATCH};
 }
+
+Error stage2_append_symbol(struct ZigStage1 *stage1, const char *name_ptr)
+{
+    return ErrorNone;
+}


### PR DESCRIPTION
This exposes a function from stage2 to stage1 to append symbols to automatically export them.
Stage1 will only call this function when the target is wasm.

The linker will then only append `--export=<symbol>` for when the user has not done so manually and did not provide the `-rdynamic` flag also. This allows the user to still override the default behavior do they wish to.

I also went ahead and implemented the same behavior for the LLVM backend when using stage2, meaning we can remove all stage1 related code for this without losing the behavior when stage2 becomes the default compiler.

Closes #2910 
Closes #7133 
