### PR TITLE
Move zig exe path to formal test args

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -45,6 +45,8 @@ pub fn build(b: *Builder) !void {
     test_stage2.addPackagePath("test_cases", "test/cases.zig");
     test_stage2.single_threaded = single_threaded;
 
+    test_stage2.addTestArg("zig_exe_path", b.zig_exe);
+
     const fmt_build_zig = b.addFmt(&[_][]const u8{"build.zig"});
 
     const skip_debug = b.option(bool, "skip-debug", "Main test suite skips debug builds") orelse false;

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -453,7 +453,7 @@ pub const ArgIterator = struct {
 
     /// Initialize the args iterator.
     pub fn init() ArgIterator {
-        if (builtin.os.tag == .wasi) {
+        if (InnerType == ArgIteratorWasi) {
             @compileError("In WASI, use initWithAllocator instead.");
         }
 
@@ -508,7 +508,12 @@ pub const ArgIterator = struct {
     }
 };
 
+/// Create an ArgIterator on Windows or Posix.  If you are targeting wasi and
+/// not linking libc, you must use argsWithAllocator instead.
 pub fn args() ArgIterator {
+    if (ArgIterator.InnerType == ArgIteratorWasi) {
+        @compileError("In WASI, use argsWithAllocator instead.");
+    }
     return ArgIterator.init();
 }
 

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -518,7 +518,7 @@ pub fn argsWithAllocator(allocator: mem.Allocator) ArgIterator.InitError!ArgIter
 }
 
 test "args iterator" {
-    var ga = std.testing.allocator;
+    const ga = std.testing.allocator;
     var it = if (builtin.os.tag == .wasi) try argsWithAllocator(ga) else args();
     defer it.deinit(); // no-op unless WASI
 
@@ -533,7 +533,6 @@ test "args iterator" {
     const given_suffix = std.fs.path.basename(prog_name);
 
     try testing.expect(mem.eql(u8, expected_suffix, given_suffix));
-    try testing.expect(it.skip()); // Skip over zig_exe_path, passed to the test runner
     try testing.expect((try it.next(ga)) == null);
     try testing.expect(!it.skip());
 }

--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -17,9 +17,8 @@ fn nextArg(args: *std.process.ArgIterator) ?[]const u8 {
 
 fn processArgs() void {
     var args = std.process.args();
-    const test_exe_path = nextArg(&args)
-        orelse @panic("No self executable in arguments");
-    
+    const test_exe_path = nextArg(&args) orelse @panic("No self executable in arguments");
+
     while (nextArg(&args)) |arg| {
         if (std.mem.eql(u8, arg, "--test-arg")) {
             const key = nextArg(&args) orelse @panic("--test-arg requires two arguments, but none were provided.");
@@ -29,7 +28,8 @@ fn processArgs() void {
             gop.value_ptr.* = value;
         } else if (std.mem.eql(u8, arg, "--help")) {
             const exe_name = std.fs.path.basename(test_exe_path);
-            std.debug.print("Usage: {s} [options]\n{s}", .{ exe_name,
+            std.debug.print("Usage: {s} [options]\n{s}", .{
+                exe_name,
                 \\
                 \\Options:
                 \\    -h, --help                  Print this help and exit

--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -16,7 +16,11 @@ fn nextArg(args: *std.process.ArgIterator) ?[]const u8 {
 }
 
 fn processArgs() void {
-    var args = std.process.args();
+    var args = std.process.argsWithAllocator(args_allocator.allocator()) catch |err| {
+        std.debug.panic("Error creating os args iterator: {}", .{err});
+    };
+    defer args.deinit();
+
     const test_exe_path = nextArg(&args) orelse @panic("No self executable in arguments");
 
     while (nextArg(&args)) |arg| {

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -18,9 +18,15 @@ pub var base_allocator_instance = std.heap.FixedBufferAllocator.init("");
 /// TODO https://github.com/ziglang/zig/issues/5738
 pub var log_level = std.log.Level.warn;
 
-/// This is available to any test that wants to execute Zig in a child process.
-/// It will be the same executable that is running `zig test`.
-pub var zig_exe_path: []const u8 = undefined;
+/// This function attempts to find a test argument, specified by the `--test-arg` parameter.
+/// The returned string has global lifetime and does not need to be freed.
+pub fn getTestArgument(name: []const u8) ?[]const u8 {
+    if (!builtin.is_test) {
+        @compileError("std.testing.getTestArgument can only be used in test builds.");
+    }
+    // root in a test build is std/special/test_runner.zig
+    return @import("root").test_args.get(name);
+}
 
 /// This function is intended to be used only in tests. It prints diagnostics to stderr
 /// and then aborts when actual_error_union is not expected_error.

--- a/src/main.zig
+++ b/src/main.zig
@@ -2599,7 +2599,7 @@ fn buildOutputType(
         const c_code_path = try fs.path.join(arena, &[_][]const u8{
             c_code_directory.path orelse ".", c_code_loc.basename,
         });
-        try test_exec_args.appendSlice(&.{
+        try test_exec_args.appendSlice(&[_]TestExecArg{
             .{ .arg = self_exe_path },
             .{ .arg = "run" },
             .{ .arg = "-lc" },

--- a/src/main.zig
+++ b/src/main.zig
@@ -980,7 +980,7 @@ fn buildOutputType(
                         try test_exec_args.append(.{ .arg = args[i] });
                     } else if (mem.eql(u8, arg, "--test-arg")) {
                         if (i + 2 >= args.len) fatal("expected two parameters after {s}", .{arg});
-                        try test_runner_args.appendSlice(args[i..i+3]);
+                        try test_runner_args.appendSlice(args[i .. i + 3]);
                         i += 2;
                     } else if (mem.eql(u8, arg, "--cache-dir")) {
                         if (i + 1 >= args.len) fatal("expected parameter after {s}", .{arg});
@@ -2599,7 +2599,7 @@ fn buildOutputType(
         const c_code_path = try fs.path.join(arena, &[_][]const u8{
             c_code_directory.path orelse ".", c_code_loc.basename,
         });
-        try test_exec_args.appendSlice(&.{ 
+        try test_exec_args.appendSlice(&.{
             .{ .arg = self_exe_path },
             .{ .arg = "run" },
             .{ .arg = "-lc" },


### PR DESCRIPTION
This is one attempt at removing the implicit zig exe path parameter for tests.  It creates a more general system of "test arguments" which are specified at runtime for the test runner, through the command line.  This means the zig exe parameter only exists for the zig compiler tests (as configured by build.zig), not all tests built by zig.

It also splits the binary from the arguments for custom test executors.  This allows you to construct a command where it must be split, like `emulator <test_bin> <emulator_args> -- <test_args>`.

If this is the wrong direction, I'm happy to make changes.  But it seems much easier to me than getting test executors to honor environment variables or other methods of passing in information.