### PR TITLE
Add missing package to the langref that's always available

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8518,6 +8518,9 @@ test "@hasDecl" {
           <li>{#syntax#}@import("builtin"){#endsyntax#} - Target-specific information
               The command <code>zig build-exe --show-builtin</code> outputs the source to stdout for reference.
           </li>
+          <li>{#syntax#}@import("root"){#endsyntax#} - Points to the root source file
+              This is usually `src/main.zig` but it depends on what file is chosen to be built.
+          </li>
       </ul>
       {#see_also|Compile Variables|@embedFile#}
       {#header_close#}


### PR DESCRIPTION
I noticed this is missing and thought I should add it.