### PR TITLE
stage2: @errorName sema+llvm

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -501,6 +501,10 @@ pub const Inst = struct {
         /// Uses the `un_op` field.
         tag_name,
 
+        /// Given an error value, return the error name. Result type is always `[:0] const u8`.
+        /// Uses the `un_op` field.
+        error_name,
+
         pub fn fromCmpOp(op: std.math.CompareOperator) Tag {
             return switch (op) {
                 .lt => .cmp_lt,
@@ -816,7 +820,7 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
 
         .bool_to_int => return Type.initTag(.u1),
 
-        .tag_name => return Type.initTag(.const_slice_u8_sentinel_0),
+        .tag_name, .error_name => return Type.initTag(.const_slice_u8_sentinel_0),
 
         .call => {
             const callee_ty = air.typeOf(datas[inst].pl_op.operand);

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -334,6 +334,7 @@ fn analyzeInst(
         .ret,
         .ret_load,
         .tag_name,
+        .error_name,
         => {
             const operand = inst_datas[inst].un_op;
             return trackOperands(a, new_set, inst, main_tomb, .{ operand, .none, .none });

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -592,6 +592,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .ctz             => try self.airCtz(inst),
             .popcount        => try self.airPopcount(inst),
             .tag_name        => try self.airTagName(inst),
+            .error_name      => try self.airErrorName(inst),
 
             .atomic_store_unordered => try self.airAtomicStore(inst, .Unordered),
             .atomic_store_monotonic => try self.airAtomicStore(inst, .Monotonic),
@@ -2553,6 +2554,16 @@ fn airTagName(self: *Self, inst: Air.Inst.Index) !void {
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else {
         _ = operand;
         return self.fail("TODO implement airTagName for aarch64", .{});
+    };
+    return self.finishAir(inst, result, .{ un_op, .none, .none });
+}
+
+fn airErrorName(self: *Self, inst: Air.Inst.Index) !void {
+    const un_op = self.air.instructions.items(.data)[inst].un_op;
+    const operand = try self.resolveInst(un_op);
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else {
+        _ = operand;
+        return self.fail("TODO implement airErrorName for aarch64", .{});
     };
     return self.finishAir(inst, result, .{ un_op, .none, .none });
 }

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -590,6 +590,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .ctz             => try self.airCtz(inst),
             .popcount        => try self.airPopcount(inst),
             .tag_name        => try self.airTagName(inst),
+            .error_name      => try self.airErrorName(inst),
 
             .atomic_store_unordered => try self.airAtomicStore(inst, .Unordered),
             .atomic_store_monotonic => try self.airAtomicStore(inst, .Monotonic),
@@ -3678,6 +3679,16 @@ fn airTagName(self: *Self, inst: Air.Inst.Index) !void {
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else {
         _ = operand;
         return self.fail("TODO implement airTagName for arm", .{});
+    };
+    return self.finishAir(inst, result, .{ un_op, .none, .none });
+}
+
+fn airErrorName(self: *Self, inst: Air.Inst.Index) !void {
+    const un_op = self.air.instructions.items(.data)[inst].un_op;
+    const operand = try self.resolveInst(un_op);
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else {
+        _ = operand;
+        return self.fail("TODO implement airErrorName for arm", .{});
     };
     return self.finishAir(inst, result, .{ un_op, .none, .none });
 }

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -571,6 +571,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .ctz             => try self.airCtz(inst),
             .popcount        => try self.airPopcount(inst),
             .tag_name        => try self.airTagName(inst),
+            .error_name      => try self.airErrorName(inst),
 
             .atomic_store_unordered => try self.airAtomicStore(inst, .Unordered),
             .atomic_store_monotonic => try self.airAtomicStore(inst, .Monotonic),
@@ -2052,6 +2053,16 @@ fn airTagName(self: *Self, inst: Air.Inst.Index) !void {
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else {
         _ = operand;
         return self.fail("TODO implement airTagName for riscv64", .{});
+    };
+    return self.finishAir(inst, result, .{ un_op, .none, .none });
+}
+
+fn airErrorName(self: *Self, inst: Air.Inst.Index) !void {
+    const un_op = self.air.instructions.items(.data)[inst].un_op;
+    const operand = try self.resolveInst(un_op);
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else {
+        _ = operand;
+        return self.fail("TODO implement airErrorName for riscv64", .{});
     };
     return self.finishAir(inst, result, .{ un_op, .none, .none });
 }

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -635,6 +635,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .ctz             => try self.airCtz(inst),
             .popcount        => try self.airPopcount(inst),
             .tag_name        => try self.airTagName(inst),
+            .error_name,     => try self.airErrorName(inst),
 
             .atomic_store_unordered => try self.airAtomicStore(inst, .Unordered),
             .atomic_store_monotonic => try self.airAtomicStore(inst, .Monotonic),
@@ -3645,6 +3646,16 @@ fn airTagName(self: *Self, inst: Air.Inst.Index) !void {
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else {
         _ = operand;
         return self.fail("TODO implement airTagName for x86_64", .{});
+    };
+    return self.finishAir(inst, result, .{ un_op, .none, .none });
+}
+
+fn airErrorName(self: *Self, inst: Air.Inst.Index) !void {
+    const un_op = self.air.instructions.items(.data)[inst].un_op;
+    const operand = try self.resolveInst(un_op);
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else {
+        _ = operand;
+        return self.fail("TODO implement airErrorName for x86_64", .{});
     };
     return self.finishAir(inst, result, .{ un_op, .none, .none });
 }

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1244,6 +1244,7 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .ctz              => try airBuiltinCall(f, inst, "ctz"),
             .popcount         => try airBuiltinCall(f, inst, "popcount"),
             .tag_name         => try airTagName(f, inst),
+            .error_name       => try airErrorName(f, inst),
 
             .int_to_float,
             .float_to_int,
@@ -2996,6 +2997,22 @@ fn airTagName(f: *Function, inst: Air.Inst.Index) !CValue {
     return f.fail("TODO: C backend: implement airTagName", .{});
     //try writer.writeAll(";\n");
     //return local;
+}
+
+fn airErrorName(f: *Function, inst: Air.Inst.Index) !CValue {
+    if (f.liveness.isUnused(inst)) return CValue.none;
+
+    const un_op = f.air.instructions.items(.data)[inst].un_op;
+    const writer = f.object.writer();
+    const inst_ty = f.air.typeOfIndex(inst);
+    const operand = try f.resolveInst(un_op);
+    const local = try f.allocLocal(inst_ty, .Const);
+
+    try writer.writeAll(" = ");
+
+    _ = operand;
+    _ = local;
+    return f.fail("TODO: C backend: implement airErrorName", .{});
 }
 
 fn toMemoryOrder(order: std.builtin.AtomicOrder) [:0]const u8 {

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -156,6 +156,7 @@ const Writer = struct {
             .ret,
             .ret_load,
             .tag_name,
+            .error_name,
             => try w.writeUnOp(s, inst),
 
             .breakpoint,

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -89,6 +89,7 @@ test {
                 _ = @import("behavior/bugs/9584.zig");
                 _ = @import("behavior/cast_llvm.zig");
                 _ = @import("behavior/enum_llvm.zig");
+                _ = @import("behavior/error_llvm.zig");
                 _ = @import("behavior/eval.zig");
                 _ = @import("behavior/floatop.zig");
                 _ = @import("behavior/fn.zig");

--- a/test/behavior/error_llvm.zig
+++ b/test/behavior/error_llvm.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const expect = std.testing.expect;
+const mem = std.mem;
+
+fn gimmeItBroke() anyerror {
+    return error.ItBroke;
+}
+
+test "@errorName" {
+    try expect(mem.eql(u8, @errorName(error.AnError), "AnError"));
+    try expect(mem.eql(u8, @errorName(error.ALongerErrorName), "ALongerErrorName"));
+    try expect(mem.eql(u8, @errorName(gimmeItBroke()), "ItBroke"));
+}
+
+test "@errorName sentinel length matches slice length" {
+    const name = testBuiltinErrorName(error.FooBar);
+    const length: usize = 6;
+    try expect(length == std.mem.indexOfSentinel(u8, 0, name.ptr));
+    try expect(length == name.len);
+}
+
+pub fn testBuiltinErrorName(err: anyerror) [:0]const u8 {
+    return @errorName(err);
+}

--- a/test/behavior/error_stage1.zig
+++ b/test/behavior/error_stage1.zig
@@ -4,27 +4,6 @@ const expectError = std.testing.expectError;
 const expectEqual = std.testing.expectEqual;
 const mem = std.mem;
 
-fn gimmeItBroke() anyerror {
-    return error.ItBroke;
-}
-
-test "@errorName" {
-    try expect(mem.eql(u8, @errorName(error.AnError), "AnError"));
-    try expect(mem.eql(u8, @errorName(error.ALongerErrorName), "ALongerErrorName"));
-    try expect(mem.eql(u8, @errorName(gimmeItBroke()), "ItBroke"));
-}
-
-test "@errorName sentinel length matches slice length" {
-    const name = testBuiltinErrorName(error.FooBar);
-    const length: usize = 6;
-    try expectEqual(length, std.mem.indexOfSentinel(u8, 0, name.ptr));
-    try expectEqual(length, name.len);
-}
-
-pub fn testBuiltinErrorName(err: anyerror) [:0]const u8 {
-    return @errorName(err);
-}
-
 test "error union type " {
     try testErrorUnionType();
     comptime try testErrorUnionType();


### PR DESCRIPTION
Implements `@errorName`. To this end i added a new air instruction, `error_name`, which is similar in semantics to `tag_name`. In the LLVM backend, `error_name` is implemented similar to the stage 1 compiler, by using an array of slices. Note that in the stage 2 compiler this comes with a number of caveats:
* In the stage 1 compiler, this table is directly emitted as an LLVM global array. In the stage 2 compiler, we only know the Module's complete global error set when all functions are analyzed. In order to avoid that, the error table is only generated right before `flushModule` is called, and `error_name` is generated by looking up a global pointer instead of an array. When generating the actual table, this global pointer is then updated with the address of the array. In theory this should resolve to the same number of loads, though this trades an `getelementptr` index for an extra load.
* The table is only emitted if any `error_name` instruction is processed. When using `--watch`, this may lead to a case where a user removes all instances of `@errorName` from their codebase, at which point the error name table is still emitted. I believe that for now this is an acceptable loss considering the extra complexity that would require.
* Currently, the error name table is updated unconditionally, and there is no check for whether it was actually modified.