### PR TITLE
Fix a bug in std.Thread.Condition and add a basic Condition test.

### DIFF
--- a/lib/std/Thread/Condition.zig
+++ b/lib/std/Thread/Condition.zig
@@ -106,7 +106,7 @@ pub const AtomicCondition = struct {
                     .linux => {
                         switch (linux.getErrno(linux.futex_wait(
                             &cond.futex,
-                            linux.FUTEX_PRIVATE_FLAG | linux.FUTEX_WAIT,
+                            linux.FUTEX.PRIVATE_FLAG | linux.FUTEX.WAIT,
                             0,
                             null,
                         ))) {
@@ -128,7 +128,7 @@ pub const AtomicCondition = struct {
                 .linux => {
                     switch (linux.getErrno(linux.futex_wake(
                         &cond.futex,
-                        linux.FUTEX_PRIVATE_FLAG | linux.FUTEX_WAKE,
+                        linux.FUTEX.PRIVATE_FLAG | linux.FUTEX.WAKE,
                         1,
                     ))) {
                         .SUCCESS => {},


### PR DESCRIPTION
Condition in 0.9 is broken. This fixes it and adds a test to hopefully not have that happen again.