### PR TITLE
std: make `fs.openFileZ` `unreachable` if both `write` and `read` are…

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -79,7 +79,7 @@ pub fn setName(self: Thread, name: []const u8) SetNameError!void {
             var buf: [32]u8 = undefined;
             const path = try std.fmt.bufPrint(&buf, "/proc/self/task/{d}/comm", .{self.getHandle()});
 
-            const file = try std.fs.cwd().openFile(path, .{ .write = true });
+            const file = try std.fs.cwd().openFile(path, .{ .read = false, .write = true });
             defer file.close();
 
             try file.writer().writeAll(name);

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -992,8 +992,10 @@ pub const Dir = struct {
             @as(u32, os.O.RDWR)
         else if (flags.write)
             @as(u32, os.O.WRONLY)
+        else if (flags.read)
+            @as(u32, os.O.RDONLY)
         else
-            @as(u32, os.O.RDONLY);
+            unreachable; // A file must be opened as read-only, write-only, or read/write.
         const fd = if (flags.intended_io_mode != .blocking)
             try std.event.Loop.instance.?.openatZ(self.fd, sub_path, os_flags, 0)
         else


### PR DESCRIPTION
Closes #10540.

Needs checking to make sure this behavior is correct for platforms other than Linux.