### PR TITLE
fs: Use `OpenMode` enum instead of read/write flags.

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -45,7 +45,7 @@ pub fn main() !void {
         }
     }
 
-    var in_file = try fs.cwd().openFile(in_file_name, .{ .read = true });
+    var in_file = try fs.cwd().openFile(in_file_name, .{ .mode = .read_only });
     defer in_file.close();
 
     var out_file = try fs.cwd().createFile(out_file_name, .{});
@@ -1866,7 +1866,7 @@ test "shell parsed" {
         // intentional space after "--build-option1 \"
         const shell_out =
             \\$ zig build test.zig \
-            \\ --build-option1 \ 
+            \\ --build-option1 \
             \\ --build-option2
             \\$ ./test
         ;

--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -79,7 +79,7 @@ pub fn setName(self: Thread, name: []const u8) SetNameError!void {
             var buf: [32]u8 = undefined;
             const path = try std.fmt.bufPrint(&buf, "/proc/self/task/{d}/comm", .{self.getHandle()});
 
-            const file = try std.fs.cwd().openFile(path, .{ .mode = .read_write });
+            const file = try std.fs.cwd().openFile(path, .{ .mode = .write_only });
             defer file.close();
 
             try file.writer().writeAll(name);

--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -79,7 +79,7 @@ pub fn setName(self: Thread, name: []const u8) SetNameError!void {
             var buf: [32]u8 = undefined;
             const path = try std.fmt.bufPrint(&buf, "/proc/self/task/{d}/comm", .{self.getHandle()});
 
-            const file = try std.fs.cwd().openFile(path, .{ .write = true });
+            const file = try std.fs.cwd().openFile(path, .{ .mode = .read_write });
             defer file.close();
 
             try file.writer().writeAll(name);

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -69,12 +69,17 @@ pub const File = struct {
         Unexpected,
     } || os.OpenError || os.FlockError;
 
+    pub const OpenMode = enum {
+        read_only,
+        write_only,
+        read_write,
+    };
+
     pub const Lock = enum { None, Shared, Exclusive };
 
     /// TODO https://github.com/ziglang/zig/issues/3802
     pub const OpenFlags = struct {
-        read: bool = true,
-        write: bool = false,
+        mode: OpenMode = .read_only,
 
         /// Open the file with an advisory lock to coordinate with other processes
         /// accessing it at the same time. An exclusive lock will prevent other
@@ -118,6 +123,14 @@ pub const File = struct {
         /// Set this to allow the opened file to automatically become the
         /// controlling TTY for the current process.
         allow_ctty: bool = false,
+
+        pub fn isRead(self: OpenFlags) bool {
+            return self.mode != .write_only;
+        }
+
+        pub fn isWrite(self: OpenFlags) bool {
+            return self.mode != .read_only;
+        }
     };
 
     /// TODO https://github.com/ziglang/zig/issues/3802

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -319,9 +319,9 @@ test "file operations on directories" {
             try testing.expectError(error.IsDir, tmp_dir.dir.readFileAlloc(testing.allocator, test_dir_name, std.math.maxInt(usize)));
         },
     }
-    // Note: The `.write = true` is necessary to ensure the error occurs on all platforms.
+    // Note: The `.mode = .read_write` is necessary to ensure the error occurs on all platforms.
     // TODO: Add a read-only test as well, see https://github.com/ziglang/zig/issues/5732
-    try testing.expectError(error.IsDir, tmp_dir.dir.openFile(test_dir_name, .{ .write = true }));
+    try testing.expectError(error.IsDir, tmp_dir.dir.openFile(test_dir_name, .{ .mode = .read_write }));
 
     switch (builtin.os.tag) {
         .wasi, .freebsd, .netbsd, .openbsd, .dragonfly => {},

--- a/lib/std/fs/watch.zig
+++ b/lib/std/fs/watch.zig
@@ -678,7 +678,7 @@ fn testWriteWatchWriteDelete(allocator: Allocator) !void {
     };
 
     // overwrite line 2
-    const file = try std.fs.cwd().openFile(file_path, .{ .read = true, .write = true });
+    const file = try std.fs.cwd().openFile(file_path, .{ .mode = .read_write });
     {
         defer file.close();
         const write_contents = "lorem ipsum";

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -308,8 +308,7 @@ pub const Manifest = struct {
             // comparing the hashes on the files used for the cached item
             while (true) {
                 if (self.cache.manifest_dir.openFile(&manifest_file_path, .{
-                    .read = true,
-                    .write = true,
+                    .mode = .read_write,
                     .lock = .Exclusive,
                     .lock_nonblocking = self.want_shared_lock,
                 })) |manifest_file| {
@@ -410,7 +409,7 @@ pub const Manifest = struct {
                 cache_hash_file.path = try self.cache.gpa.dupe(u8, file_path);
             }
 
-            const this_file = fs.cwd().openFile(cache_hash_file.path.?, .{ .read = true }) catch |err| switch (err) {
+            const this_file = fs.cwd().openFile(cache_hash_file.path.?, .{ .mode = .read_only }) catch |err| switch (err) {
                 error.FileNotFound => {
                     try self.upgradeToExclusiveLock();
                     return false;

--- a/src/test.zig
+++ b/src/test.zig
@@ -958,14 +958,14 @@ pub const TestContext = struct {
 
             switch (update.case) {
                 .Header => |expected_output| {
-                    var file = try tmp.dir.openFile("test_case.h", .{ .read = true });
+                    var file = try tmp.dir.openFile("test_case.h", .{ .mode = .read_only });
                     defer file.close();
                     const out = try file.reader().readAllAlloc(arena, 5 * 1024 * 1024);
 
                     try std.testing.expectEqualStrings(expected_output, out);
                 },
                 .CompareObjectFile => |expected_output| {
-                    var file = try tmp.dir.openFile(bin_name, .{ .read = true });
+                    var file = try tmp.dir.openFile(bin_name, .{ .mode = .read_only });
                     defer file.close();
                     const out = try file.reader().readAllAlloc(arena, 5 * 1024 * 1024);
 


### PR DESCRIPTION
Closes #10540, and is an alternate solution to #10541.