### PR TITLE
stage2: enable zig test on x86_64-macos

### DIFF
--- a/test/stage2/x86_64.zig
+++ b/test/stage2/x86_64.zig
@@ -1761,6 +1761,25 @@ pub fn addCases(ctx: *TestContext) !void {
                 \\}
             , "");
         }
+
+        {
+            var case = ctx.exe("access slice element by index - slice_elem_val", target);
+            case.addCompareOutput(
+                \\var array = [_]usize{ 0, 42, 123, 34 };
+                \\var slice: []const usize = &array;
+                \\
+                \\pub fn main() void {
+                \\    assert(slice[0] == 0);
+                \\    assert(slice[1] == 42);
+                \\    assert(slice[2] == 123);
+                \\    assert(slice[3] == 34);
+                \\}
+                \\
+                \\fn assert(ok: bool) void {
+                \\    if (!ok) unreachable;
+                \\}
+            , "");
+        }
     }
 }
 
@@ -2011,26 +2030,6 @@ fn addLinuxTestCases(ctx: *TestContext) !void {
             \\    if (fd != 42)
             \\        unreachable;
             \\    return 0;
-            \\}
-        , "");
-    }
-
-    {
-        // TODO fixing this will enable zig test on macOS
-        var case = ctx.exe("access slice element by index - slice_elem_val", linux_x64);
-        case.addCompareOutput(
-            \\var array = [_]usize{ 0, 42, 123, 34 };
-            \\var slice: []const usize = &array;
-            \\
-            \\pub fn main() void {
-            \\    assert(slice[0] == 0);
-            \\    assert(slice[1] == 42);
-            \\    assert(slice[2] == 123);
-            \\    assert(slice[3] == 34);
-            \\}
-            \\
-            \\fn assert(ok: bool) void {
-            \\    if (!ok) unreachable;
             \\}
         , "");
     }


### PR DESCRIPTION
Put `Decl`s in different MachO sections.

Use `getDeclVAddrWithReloc` when targeting MachO backend rather than `getDeclVAddr` - this fn returns a zero vaddr and instead creates a relocation on the linker side which will get automatically updated whenever the target decl is moved in memory. This fn also records a rebase of the target pointer so that its value is correctly slid in presence of ASLR.

This commit enables `zig test` on x86_64-macos.