### PR TITLE
translate-c: Handle typedef'ed void return type for functions.

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -4824,11 +4824,18 @@ fn qualTypeWasDemotedToOpaque(c: *Context, qt: clang.QualType) bool {
 
 fn isAnyopaque(qt: clang.QualType) bool {
     const ty = qt.getTypePtr();
-    if (ty.getTypeClass() == .Builtin) {
-        const builtin_ty = @ptrCast(*const clang.BuiltinType, ty);
-        return builtin_ty.getKind() == .Void;
+    switch (ty.getTypeClass()) {
+        .Builtin => {
+            const builtin_ty = @ptrCast(*const clang.BuiltinType, ty);
+            return builtin_ty.getKind() == .Void;
+        },
+        .Typedef => {
+            const typedef_ty = @ptrCast(*const clang.TypedefType, ty);
+            const typedef_decl = typedef_ty.getDecl();
+            return isAnyopaque(typedef_decl.getUnderlyingType());
+        },
+        else => return false,
     }
-    return false;
 }
 
 const FnDeclContext = struct {

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1809,4 +1809,14 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Typedef'ed void used as return type. Issue #10356",
+        \\typedef void V;
+        \\V foo(V *f) {}
+        \\int main(void) {
+        \\    int x = 0;
+        \\    foo(&x);
+        \\    return 0;
+        \\}
+    , "");
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -814,7 +814,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     , &[_][]const u8{
         \\pub const Foo = anyopaque;
         ,
-        \\pub extern fn fun(a: ?*Foo) Foo;
+        \\pub extern fn fun(a: ?*Foo) void;
     });
 
     cases.add("duplicate typedef",


### PR DESCRIPTION
Fixes #10356