### PR TITLE
Stage2: wasm - Implement optional equality, casts and more

### DIFF
--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -161,6 +161,18 @@ pub fn emitMir(emit: *Emit) InnerError!void {
             .i64_extend8_s => try emit.emitTag(tag),
             .i64_extend16_s => try emit.emitTag(tag),
             .i64_extend32_s => try emit.emitTag(tag),
+            .i32_reinterpret_f32 => try emit.emitTag(tag),
+            .i64_reinterpret_f64 => try emit.emitTag(tag),
+            .f32_reinterpret_i32 => try emit.emitTag(tag),
+            .f64_reinterpret_i64 => try emit.emitTag(tag),
+            .i32_trunc_f32_s => try emit.emitTag(tag),
+            .i32_trunc_f32_u => try emit.emitTag(tag),
+            .i32_trunc_f64_s => try emit.emitTag(tag),
+            .i32_trunc_f64_u => try emit.emitTag(tag),
+            .i64_trunc_f32_s => try emit.emitTag(tag),
+            .i64_trunc_f32_u => try emit.emitTag(tag),
+            .i64_trunc_f64_s => try emit.emitTag(tag),
+            .i64_trunc_f64_u => try emit.emitTag(tag),
 
             .extended => try emit.emitExtended(inst),
         }

--- a/src/arch/wasm/Mir.zig
+++ b/src/arch/wasm/Mir.zig
@@ -363,9 +363,33 @@ pub const Inst = struct {
         /// Uses `tag`
         i32_wrap_i64 = 0xA7,
         /// Uses `tag`
+        i32_trunc_f32_s = 0xA8,
+        /// Uses `tag`
+        i32_trunc_f32_u = 0xA9,
+        /// Uses `tag`
+        i32_trunc_f64_s = 0xAA,
+        /// Uses `tag`
+        i32_trunc_f64_u = 0xAB,
+        /// Uses `tag`
         i64_extend_i32_s = 0xAC,
         /// Uses `tag`
         i64_extend_i32_u = 0xAD,
+        /// Uses `tag`
+        i64_trunc_f32_s = 0xAE,
+        /// Uses `tag`
+        i64_trunc_f32_u = 0xAF,
+        /// Uses `tag`
+        i64_trunc_f64_s = 0xB0,
+        /// Uses `tag`
+        i64_trunc_f64_u = 0xB1,
+        /// Uses `tag`
+        i32_reinterpret_f32 = 0xBC,
+        /// Uses `tag`
+        i64_reinterpret_f64 = 0xBD,
+        /// Uses `tag`
+        f32_reinterpret_i32 = 0xBE,
+        /// Uses `tag`
+        f64_reinterpret_i64 = 0xBF,
         /// Uses `tag`
         i32_extend8_s = 0xC0,
         /// Uses `tag`

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -20,8 +20,8 @@ test {
 
         if (builtin.zig_backend != .stage2_arm and builtin.zig_backend != .stage2_x86_64) {
             // Tests that pass for stage1, llvm backend, C backend, wasm backend.
+            _ = @import("behavior/align.zig");
             _ = @import("behavior/array.zig");
-            _ = @import("behavior/bugs/3586.zig");
             _ = @import("behavior/basic.zig");
             _ = @import("behavior/bitcast.zig");
             _ = @import("behavior/bugs/624.zig");
@@ -31,12 +31,14 @@ test {
             _ = @import("behavior/bugs/2692.zig");
             _ = @import("behavior/bugs/2889.zig");
             _ = @import("behavior/bugs/3046.zig");
+            _ = @import("behavior/bugs/3586.zig");
             _ = @import("behavior/bugs/4560.zig");
             _ = @import("behavior/bugs/4769_a.zig");
             _ = @import("behavior/bugs/4769_b.zig");
             _ = @import("behavior/bugs/4954.zig");
             _ = @import("behavior/byval_arg_var.zig");
             _ = @import("behavior/call.zig");
+            _ = @import("behavior/cast.zig");
             _ = @import("behavior/defer.zig");
             _ = @import("behavior/enum.zig");
             _ = @import("behavior/error.zig");
@@ -48,12 +50,15 @@ test {
             _ = @import("behavior/inttoptr.zig");
             _ = @import("behavior/member_func.zig");
             _ = @import("behavior/null.zig");
+            _ = @import("behavior/optional.zig");
             _ = @import("behavior/pointers.zig");
             _ = @import("behavior/ptrcast.zig");
             _ = @import("behavior/ref_var_in_if_after_if_2nd_switch_prong.zig");
+            _ = @import("behavior/src.zig");
             _ = @import("behavior/struct.zig");
             _ = @import("behavior/this.zig");
             _ = @import("behavior/truncate.zig");
+            _ = @import("behavior/try.zig");
             _ = @import("behavior/undefined.zig");
             _ = @import("behavior/underscore.zig");
             _ = @import("behavior/usingnamespace.zig");
@@ -62,13 +67,9 @@ test {
 
             if (builtin.zig_backend != .stage2_wasm) {
                 // Tests that pass for stage1, llvm backend, C backend
-                _ = @import("behavior/align.zig");
-                _ = @import("behavior/cast.zig");
+                _ = @import("behavior/cast_int.zig");
                 _ = @import("behavior/int128.zig");
-                _ = @import("behavior/optional.zig");
                 _ = @import("behavior/translate_c_macros.zig");
-                _ = @import("behavior/try.zig");
-                _ = @import("behavior/src.zig");
 
                 if (builtin.zig_backend != .stage2_c) {
                     // Tests that pass for stage1 and the llvm backend.

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -43,13 +43,6 @@ fn testResolveUndefWithInt(b: bool, x: i32) !void {
     }
 }
 
-test "@intCast i32 to u7" {
-    var x: u128 = maxInt(u128);
-    var y: i32 = 120;
-    var z = x >> @intCast(u7, y);
-    try expect(z == 0xff);
-}
-
 test "@intCast to comptime_int" {
     try expect(@intCast(comptime_int, 0) == 0);
 }

--- a/test/behavior/cast_int.zig
+++ b/test/behavior/cast_int.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+const expect = std.testing.expect;
+const maxInt = std.math.maxInt;
+
+test "@intCast i32 to u7" {
+    var x: u128 = maxInt(u128);
+    var y: i32 = 120;
+    var z = x >> @intCast(u7, y);
+    try expect(z == 0xff);
+}


### PR DESCRIPTION
This implements the following:
- float_to_int and bitshifting to get `cast.zig` behavior tests passing.
- Optional comparison (`?u32 == u32`) to get `optionals.zig` passing.
- Basic 128 bit integer support for loading, storing and comparing.
(Equality comparison is currently implemented in the wasm backend itself, until compiler-rt is supported).
