### PR TITLE
Make prominent_compile_errors also work for test steps

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2842,7 +2842,7 @@ pub const LibExeObjStep = struct {
         }
 
         if (self.kind == .@"test") {
-            try builder.spawnChild(zig_args.items);
+            _ = try builder.execFromStep(zig_args.items, step);
         } else {
             try zig_args.append("--enable-cache");
 


### PR DESCRIPTION
Seems like the right solution, but who knows :shrug: 