### PR TITLE
Stage2: wasm-linker - Place stack at the beginning of the linear memory

### DIFF
--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -494,9 +494,21 @@ fn setupMemory(self: *Wasm) !void {
     log.debug("Setting up memory layout", .{});
     const page_size = 64 * 1024;
     const stack_size = self.base.options.stack_size_override orelse page_size * 1;
-    const stack_alignment = 16;
-    var memory_ptr: u64 = self.base.options.global_base orelse 1024;
-    memory_ptr = std.mem.alignForwardGeneric(u64, memory_ptr, stack_alignment);
+    const stack_alignment = 16; // wasm's stack alignment as specified by tool-convention
+    // Always place the stack at the start by default
+    // unless the user specified the global-base flag
+    var place_stack_first = true;
+    var memory_ptr: u64 = if (self.base.options.global_base) |base| blk: {
+        place_stack_first = false;
+        break :blk base;
+    } else 0;
+
+    if (place_stack_first) {
+        memory_ptr = std.mem.alignForwardGeneric(u64, memory_ptr, stack_alignment);
+        memory_ptr += stack_size;
+        // We always put the stack pointer global at index 0
+        self.globals.items[0].init.i32_const = @bitCast(i32, @intCast(u32, memory_ptr));
+    }
 
     var offset: u32 = @intCast(u32, memory_ptr);
     for (self.segments.items) |*segment, i| {
@@ -510,8 +522,11 @@ fn setupMemory(self: *Wasm) !void {
         offset += segment.size;
     }
 
-    memory_ptr = std.mem.alignForwardGeneric(u64, memory_ptr, stack_alignment);
-    memory_ptr += stack_size;
+    if (!place_stack_first) {
+        memory_ptr = std.mem.alignForwardGeneric(u64, memory_ptr, stack_alignment);
+        memory_ptr += stack_size;
+        self.globals.items[0].init.i32_const = @bitCast(i32, @intCast(u32, memory_ptr));
+    }
 
     // Setup the max amount of pages
     // For now we only support wasm32 by setting the maximum allowed memory size 2^32-1
@@ -554,9 +569,6 @@ fn setupMemory(self: *Wasm) !void {
         self.memories.limits.max = @intCast(u32, max_memory / page_size);
         log.debug("Maximum memory pages: {d}", .{self.memories.limits.max});
     }
-
-    // We always put the stack pointer global at index 0
-    self.globals.items[0].init.i32_const = @bitCast(i32, @intCast(u32, memory_ptr));
 }
 
 fn resetState(self: *Wasm) void {


### PR DESCRIPTION
By placing the stack at the start of the memory section, we prevent the runtime from silently overwriting the static memory and instead trap on a stack overflow.

We do, however, allow users to overwrite this behavior by setting the `global-base` flag, which puts the stack at the end of the memory section and the static data at the base that was specified.
The reason a user would want to do this is when they need to put the static data at a specific address. Another benefit of doing so it has a side effect of lower binary size.
(Having the stack in front, means that accessing the memory after the stack has a bigger offset when loading/storing from memory. Bigger offsets mean it takes more bytes to represent the instruction).
Note: While we used to append this flag by default to wasm-ld, we only did this for `build-exe` and had no way to overwrite such behavior.

This PR implements it for both the self-hosted linker and the linker frontend for stage1.

Closes #10567 

