### PR TITLE
translate-c: Fix macro define of float constant using scientific notation

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -5602,16 +5602,18 @@ fn parseCNumLit(c: *Context, m: *MacroCtx) ParseError!Node {
         },
         .FloatLiteral => |suffix| {
             if (suffix != .none) lit_bytes = lit_bytes[0 .. lit_bytes.len - 1];
-            const dot_index = mem.indexOfScalar(u8, lit_bytes, '.').?;
-            if (dot_index == 0) {
-                lit_bytes = try std.fmt.allocPrint(c.arena, "0{s}", .{lit_bytes});
-            } else if (dot_index + 1 == lit_bytes.len or !std.ascii.isDigit(lit_bytes[dot_index + 1])) {
-                // If the literal lacks a digit after the `.`, we need to
-                // add one since `1.` or `1.e10` would be invalid syntax in Zig.
-                lit_bytes = try std.fmt.allocPrint(c.arena, "{s}0{s}", .{
-                    lit_bytes[0 .. dot_index + 1],
-                    lit_bytes[dot_index + 1 ..],
-                });
+
+            if (mem.indexOfScalar(u8, lit_bytes, '.')) |dot_index| {
+                if (dot_index == 0) {
+                    lit_bytes = try std.fmt.allocPrint(c.arena, "0{s}", .{lit_bytes});
+                } else if (dot_index + 1 == lit_bytes.len or !std.ascii.isDigit(lit_bytes[dot_index + 1])) {
+                    // If the literal lacks a digit after the `.`, we need to
+                    // add one since `1.` or `1.e10` would be invalid syntax in Zig.
+                    lit_bytes = try std.fmt.allocPrint(c.arena, "{s}0{s}", .{
+                        lit_bytes[0 .. dot_index + 1],
+                        lit_bytes[dot_index + 1 ..],
+                    });
+                }
             }
 
             if (suffix == .none)

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1135,11 +1135,15 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\#define bar 16.e-2l
         \\#define FOO 0.12345
         \\#define BAR .12345
+        \\#define baz 1e1
+        \\#define BAZ 42e-3f
     , &[_][]const u8{
         "pub const foo = @as(f32, 3.14);",
         "pub const bar = @as(c_longdouble, 16.0e-2);",
         "pub const FOO = 0.12345;",
         "pub const BAR = 0.12345;",
+        "pub const baz = 1e1;",
+        "pub const BAZ = @as(f32, 42e-3);",
     });
 
     cases.add("comments",


### PR DESCRIPTION
Fixes compiler attempting to use null value when translating macro define of float constant using scientific notation with no decimal point.

Fixes #10574.