### PR TITLE
stage1: fix bigint_init_bigfloat for single-limb negative floats

### DIFF
--- a/src/stage1/bigint.cpp
+++ b/src/stage1/bigint.cpp
@@ -219,7 +219,7 @@ void bigint_init_bigfloat(BigInt *dest, const BigFloat *op) {
     ui64_to_f128M(UINT64_MAX, &max_u64);
     if (f128M_le(&abs_val, &max_u64)) {
         dest->digit_count = 1;
-        dest->data.digit = f128M_to_ui64(&op->value, softfloat_round_minMag, false);
+        dest->data.digit = f128M_to_ui64(&abs_val, softfloat_round_minMag, false);
         bigint_normalize(dest);
         return;
     }

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -66,3 +66,9 @@ fn testDifferentSizedFloatComparisons() !void {
 //    try expect(@nearbyint(a) == -4);
 //    }
 //}
+
+test "negative f128 floatToInt at compile-time" {
+    const a: f128 = -2;
+    var b = @floatToInt(i64, a);
+    try expect(@as(i64, -2) == b);
+}


### PR DESCRIPTION
Fixes #10592.