### PR TITLE
os.getenvW: Fix case-insensitivity for Unicode env var names

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1715,15 +1715,13 @@ pub fn getenvZ(key: [*:0]const u8) ?[]const u8 {
 
 /// Windows-only. Get an environment variable with a null-terminated, WTF-16 encoded name.
 /// See also `getenv`.
-/// This function first attempts a case-sensitive lookup. If no match is found, and `key`
-/// is ASCII, then it attempts a second case-insensitive lookup.
+/// This function performs a Unicode-aware case-insensitive lookup using RtlEqualUnicodeString.
 pub fn getenvW(key: [*:0]const u16) ?[:0]const u16 {
     if (builtin.os.tag != .windows) {
         @compileError("std.os.getenvW is a Windows-only API");
     }
     const key_slice = mem.sliceTo(key, 0);
     const ptr = windows.peb().ProcessParameters.Environment;
-    var ascii_match: ?[:0]const u16 = null;
     var i: usize = 0;
     while (ptr[i] != 0) {
         const key_start = i;
@@ -1737,22 +1735,25 @@ pub fn getenvW(key: [*:0]const u16) ?[:0]const u16 {
         while (ptr[i] != 0) : (i += 1) {}
         const this_value = ptr[value_start..i :0];
 
-        if (mem.eql(u16, key_slice, this_key)) return this_value;
-
-        ascii_check: {
-            if (ascii_match != null) break :ascii_check;
-            if (key_slice.len != this_key.len) break :ascii_check;
-            for (key_slice) |a_c, key_index| {
-                const a = math.cast(u8, a_c) catch break :ascii_check;
-                const b = math.cast(u8, this_key[key_index]) catch break :ascii_check;
-                if (std.ascii.toLower(a) != std.ascii.toLower(b)) break :ascii_check;
-            }
-            ascii_match = this_value;
+        const key_string_bytes = @intCast(u16, key_slice.len * 2);
+        const key_string = windows.UNICODE_STRING{
+            .Length = key_string_bytes,
+            .MaximumLength = key_string_bytes,
+            .Buffer = @intToPtr([*]u16, @ptrToInt(key)),
+        };
+        const this_key_string_bytes = @intCast(u16, this_key.len * 2);
+        const this_key_string = windows.UNICODE_STRING{
+            .Length = this_key_string_bytes,
+            .MaximumLength = this_key_string_bytes,
+            .Buffer = this_key.ptr,
+        };
+        if (windows.ntdll.RtlEqualUnicodeString(&key_string, &this_key_string, windows.TRUE) == windows.TRUE) {
+            return this_value;
         }
 
         i += 1; // skip over null byte
     }
-    return ascii_match;
+    return null;
 }
 
 pub const GetCwdError = error{

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1726,6 +1726,12 @@ pub fn getenvW(key: [*:0]const u16) ?[:0]const u16 {
     while (ptr[i] != 0) {
         const key_start = i;
 
+        // There are some special environment variables that start with =,
+        // so we need a special case to not treat = as a key/value separator
+        // if it's the first character.
+        // https://devblogs.microsoft.com/oldnewthing/20100506-00/?p=14133
+        if (ptr[key_start] == '=') i += 1;
+
         while (ptr[i] != 0 and ptr[i] != '=') : (i += 1) {}
         const this_key = ptr[key_start..i];
 

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -223,6 +223,12 @@ pub extern "ntdll" fn RtlWaitOnAddress(
     Timeout: ?*const LARGE_INTEGER,
 ) callconv(WINAPI) NTSTATUS;
 
+pub extern "ntdll" fn RtlEqualUnicodeString(
+    String1: *const UNICODE_STRING,
+    String2: *const UNICODE_STRING,
+    CaseInSensitive: BOOLEAN,
+) callconv(WINAPI) BOOLEAN;
+
 pub extern "ntdll" fn NtLockFile(
     FileHandle: HANDLE,
     Event: ?HANDLE,


### PR DESCRIPTION
Windows does Unicode-aware case-insensitive comparisons for environment variable names. Before, os.getenvW was only doing ASCII case-insensitivity. We can take advantage of [RtlEqualUnicodeString in NtDll](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlequalunicodestring) to get the proper Unicode case insensitivity (note that this is what [ReactOS uses for its environment variable case insensitivity](https://github.com/reactos/reactos/blob/3fa57b8ff7fcee47b8e2ed869aecaf4515603f3f/sdk/lib/rtl/env.c#L560)).

This should be a more complete fix for part of https://github.com/ziglang/zig/issues/4603, and an improvement on https://github.com/ziglang/zig/pull/4608.

Example with the following test code and the env var `СЛАВЬСЯ` (set as all uppercase, but the test code uses all lowercase):

```zig
const std = @import("std");
const testing = std.testing;

test {
    const cyrillic = try std.process.getEnvVarOwned(testing.allocator, "славься");
    defer testing.allocator.free(cyrillic);

    std.debug.print("value is {s}\n", .{cyrillic});
}
```

Before this PR, the test would fail:

```
> set СЛАВЬСЯ=1
> echo %славься%
1
> zig test env.zig
Test [0/1] testTest [1/1] test ""... FAIL (EnvironmentVariableNotFound)
FAIL (EnvironmentVariableNotFound)
C:\Users\Ryan\Programming\Zig\zig\lib\std\process.zig:163:53: 0x7ff73c352430 in std.process.getEnvVarOwned (test.obj)
            break :blk std.os.getenvW(key_w) orelse return error.EnvironmentVariableNotFound;
                                                    ^
C:\Users\Ryan\Programming\Zig\tmp\env.zig:5:22: 0x7ff73c351c59 in test "" (test.obj)
    const cyrillic = try std.process.getEnvVarOwned(testing.allocator, "славься");
                     ^
0 passed; 0 skipped; 1 failed.
```

After this PR, the test passes:

```
> set СЛАВЬСЯ=1
> echo %славься%
1
> zig test env.zig
Test [0/1] test ""... 1/1 test ""... value is 1
OK
All 1 tests passed.
```
