### PR TITLE
stage2: rename Isel back to Emit, and fix immediate casts in Emit for x86 64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,7 +578,7 @@ set(ZIG_STAGE2_SOURCES
     "${CMAKE_SOURCE_DIR}/src/arch/wasm/Emit.zig"
     "${CMAKE_SOURCE_DIR}/src/arch/wasm/Mir.zig"
     "${CMAKE_SOURCE_DIR}/src/arch/x86_64/CodeGen.zig"
-    "${CMAKE_SOURCE_DIR}/src/arch/x86_64/Isel.zig"
+    "${CMAKE_SOURCE_DIR}/src/arch/x86_64/Emit.zig"
     "${CMAKE_SOURCE_DIR}/src/arch/x86_64/Mir.zig"
     "${CMAKE_SOURCE_DIR}/src/arch/x86_64/bits.zig"
     "${CMAKE_SOURCE_DIR}/src/clang.zig"

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -17,7 +17,7 @@ const DW = std.dwarf;
 const ErrorMsg = Module.ErrorMsg;
 const FnResult = @import("../../codegen.zig").FnResult;
 const GenerateSymbolError = @import("../../codegen.zig").GenerateSymbolError;
-const Isel = @import("Isel.zig");
+const Emit = @import("Emit.zig");
 const Liveness = @import("../../Liveness.zig");
 const Mir = @import("Mir.zig");
 const Module = @import("../../Module.zig");
@@ -309,7 +309,7 @@ pub fn generate(
     };
     defer mir.deinit(bin_file.allocator);
 
-    var isel = Isel{
+    var emit = Emit{
         .mir = mir,
         .bin_file = bin_file,
         .debug_output = debug_output,
@@ -320,9 +320,9 @@ pub fn generate(
         .prev_di_line = module_fn.lbrace_line,
         .prev_di_column = module_fn.lbrace_column,
     };
-    defer isel.deinit();
-    isel.lowerMir() catch |err| switch (err) {
-        error.IselFail => return FnResult{ .fail = isel.err_msg.? },
+    defer emit.deinit();
+    emit.lowerMir() catch |err| switch (err) {
+        error.EmitFail => return FnResult{ .fail = emit.err_msg.? },
         else => |e| return e,
     };
 

--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -492,20 +492,6 @@ inline fn immOpSize(u_imm: u32) u8 {
     return 32;
 }
 
-inline fn imm64OpSize(u_imm: u64) u8 {
-    const imm = @bitCast(i64, u_imm);
-    if (math.minInt(i8) <= imm and imm <= math.maxInt(i8)) {
-        return 8;
-    }
-    if (math.minInt(i16) <= imm and imm <= math.maxInt(i16)) {
-        return 16;
-    }
-    if (math.minInt(i32) <= imm and imm <= math.maxInt(i32)) {
-        return 32;
-    }
-    return 64;
-}
-
 fn mirArithScaleSrc(emit: *Emit, tag: Tag, inst: Mir.Inst.Index) InnerError!void {
     const ops = Mir.Ops.decode(emit.mir.instructions.items(.ops)[inst]);
     const scale = ops.flags;
@@ -1485,9 +1471,6 @@ fn lowerToTdFdEnc(tag: Tag, reg: Register, moffs: u64, code: *std.ArrayList(u8),
     if (reg.lowId() != Register.rax.lowId()) {
         return error.RaxOperandExpected;
     }
-    if (reg.size() != imm64OpSize(moffs)) {
-        return error.OperandSizeMismatch;
-    }
     const opc = if (td)
         getOpCode(tag, .td, reg.size() == 8).?
     else
@@ -1510,9 +1493,6 @@ fn lowerToTdFdEnc(tag: Tag, reg: Register, moffs: u64, code: *std.ArrayList(u8),
 }
 
 fn lowerToOiEnc(tag: Tag, reg: Register, imm: u64, code: *std.ArrayList(u8)) LoweringError!void {
-    if (reg.size() != imm64OpSize(imm)) {
-        return error.OperandSizeMismatch;
-    }
     const opc = getOpCode(tag, .oi, reg.size() == 8).?;
     const encoder = try Encoder.init(code, 10);
     if (reg.size() == 16) {

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -302,7 +302,7 @@ pub const Inst = struct {
         /// Another instruction.
         inst: Index,
         /// A 32-bit immediate value.
-        imm: i32,
+        imm: u32,
         /// An extern function.
         /// Index into the linker's string table.
         extern_fn: u32,
@@ -324,8 +324,8 @@ pub const Inst = struct {
 };
 
 pub const ImmPair = struct {
-    dest_off: i32,
-    operand: i32,
+    dest_off: u32,
+    operand: u32,
 };
 
 pub const Imm64 = struct {

--- a/test/stage2/x86_64.zig
+++ b/test/stage2/x86_64.zig
@@ -1767,6 +1767,40 @@ pub fn addCases(ctx: *TestContext) !void {
                 \\    if (!ok) unreachable;
                 \\}
             , "");
+            case.addCompareOutput(
+                \\pub fn main() void {
+                \\    var x: u8 = undefined;
+                \\    const maybe_x = byPtr(&x);
+                \\    assert(maybe_x != null);
+                \\    maybe_x.?.* = 255;
+                \\    assert(x == 255);
+                \\}
+                \\
+                \\fn byPtr(x: *u8) ?*u8 {
+                \\    return x;
+                \\}
+                \\
+                \\fn assert(ok: bool) void {
+                \\    if (!ok) unreachable;
+                \\}
+            , "");
+            case.addCompareOutput(
+                \\pub fn main() void {
+                \\    var x: i8 = undefined;
+                \\    const maybe_x = byPtr(&x);
+                \\    assert(maybe_x != null);
+                \\    maybe_x.?.* = -1;
+                \\    assert(x == -1);
+                \\}
+                \\
+                \\fn byPtr(x: *i8) ?*i8 {
+                \\    return x;
+                \\}
+                \\
+                \\fn assert(ok: bool) void {
+                \\    if (!ok) unreachable;
+                \\}
+            , "");
         }
 
         {

--- a/test/stage2/x86_64.zig
+++ b/test/stage2/x86_64.zig
@@ -1700,6 +1700,36 @@ pub fn addCases(ctx: *TestContext) !void {
                 \\    if (!ok) unreachable;
                 \\}
             , "");
+            case.addCompareOutput(
+                \\pub fn main() void {
+                \\    var x: u16 = undefined;
+                \\    set(&x);
+                \\    assert(x == 123);
+                \\}
+                \\
+                \\fn set(x: *u16) void {
+                \\    x.* = 123;
+                \\}
+                \\
+                \\fn assert(ok: bool) void {
+                \\    if (!ok) unreachable;
+                \\}
+            , "");
+            case.addCompareOutput(
+                \\pub fn main() void {
+                \\    var x: u8 = undefined;
+                \\    set(&x);
+                \\    assert(x == 123);
+                \\}
+                \\
+                \\fn set(x: *u8) void {
+                \\    x.* = 123;
+                \\}
+                \\
+                \\fn assert(ok: bool) void {
+                \\    if (!ok) unreachable;
+                \\}
+            , "");
         }
 
         {


### PR DESCRIPTION
* refactor handling of immediates in x86_64 backend
* rename Isel to Emit for x86_64
* implement signed compare