### PR TITLE
Added documentation for implicit struct pointer dereferencing

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3159,7 +3159,12 @@ test "linked list" {
         .last = &node,
         .len = 1,
     };
+    
+    // When using a pointer to a struct, fields can be accessed directly,
+    // without explicitly dereferencing the pointer.
+    // So you can do
     try expect(list2.first.?.data == 1234);
+    // instead of try expect(list2.first.?.*.data == 1234);
 }
       {#code_end#}
 


### PR DESCRIPTION
This PR adds a note to the language reference about implicit dereferencing of pointers to structs when accessing fields.

This PR is intended to resolve issue #10325 