### PR TITLE
Add missing `!void` in `std.MultiArrayList.insert`

### DIFF
--- a/lib/std/multi_array_list.zig
+++ b/lib/std/multi_array_list.zig
@@ -188,7 +188,7 @@ pub fn MultiArrayList(comptime S: type) type {
         /// after and including the specified index back by one and
         /// sets the given index to the specified element.  May reallocate
         /// and invalidate iterators.
-        pub fn insert(self: *Self, gpa: Allocator, index: usize, elem: S) void {
+        pub fn insert(self: *Self, gpa: Allocator, index: usize, elem: S) !void {
             try self.ensureUnusedCapacity(gpa, 1);
             self.insertAssumeCapacity(index, elem);
         }


### PR DESCRIPTION
Calling `insert` on a `std.MultiArrayList` currently fails with a compiler error due to using a `try` without the `!` annotation on the return type

This code:
```zig
this.list.insert(allocator, 0, listener);
```

Produces this error:

```zig
/Users/jarred/Build/zig/lib/std/multi_array_list.zig:192:13: error: expected type 'void', found '@typeInfo(@typeInfo(@TypeOf(std.multi_array_list.MultiArrayList(src.javascript.jsc.node.types.Listener).ensureUnusedCapacity)).Fn.return_type.?).ErrorUnion.error_set'
            try self.ensureUnusedCapacity(gpa, 1);
```

Instead, it should produce this error:
```zig
./src/javascript/jsc/node/types.zig:955:33: error: error is ignored. consider using `try`, `catch`, or `if`
                this.list.insert(allocator, 0, listener);
                                ^
```