### PR TITLE
ignore target lib dirs when invoked with -feach-lib-rpath

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2077,10 +2077,6 @@ fn buildOutputType(
             clang_argv.appendAssumeCapacity(framework_dir);
             framework_dirs.appendAssumeCapacity(framework_dir);
         }
-
-        for (paths.lib_dirs.items) |lib_dir| {
-            try lib_dirs.append(lib_dir);
-        }
         for (paths.rpaths.items) |rpath| {
             try rpath_list.append(rpath);
         }


### PR DESCRIPTION
since the native paths are expected to be linked by default adding them to the rpath is pointless.

