### PR TITLE
stage2: avoid inferred struct in os_version_check.zig

### DIFF
--- a/lib/std/special/compiler_rt/os_version_check.zig
+++ b/lib/std/special/compiler_rt/os_version_check.zig
@@ -22,12 +22,11 @@ inline fn constructVersion(major: u32, minor: u32, subminor: u32) u32 {
 
 // Darwin-only
 pub fn __isPlatformVersionAtLeast(platform: u32, major: u32, minor: u32, subminor: u32) callconv(.C) i32 {
-    return @boolToInt(_availability_version_check(1, &[_]dyld_build_version_t{
-        .{
-            .platform = platform,
-            .version = constructVersion(major, minor, subminor),
-        },
-    }));
+    const build_version = dyld_build_version_t{
+        .platform = platform,
+        .version = constructVersion(major, minor, subminor),
+    };
+    return @boolToInt(_availability_version_check(1, &[_]dyld_build_version_t{build_version}));
 }
 
 // _availability_version_check darwin API support.


### PR DESCRIPTION
Before this commit, compiling an empty main with Stage 2 on macOS x86_64 results in

```
../stage2/bin/zig build-exe -ODebug -fLLVM empty_main.zig
error: sub-compilation of compiler_rt failed
    [...]/zig/stage2/lib/zig/std/special/compiler_rt/os_version_check.zig:26:10: error: TODO: Sema.zirStructInit for runtime-known struct values
```

By assigning the value to a variable we can sidestep the issue for now.