### PR TITLE
Stage2: wasm - Refactor lowering constants

### DIFF
--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -323,6 +323,7 @@ pub fn createLocalSymbol(self: *Wasm, decl: *Module.Decl, ty: Type) !u32 {
 
     var atom = Atom.empty;
     atom.alignment = ty.abiAlignment(self.base.options.target);
+    try self.symbols.ensureUnusedCapacity(self.base.allocator, 1);
 
     if (self.symbols_free_list.popOrNull()) |index| {
         atom.sym_index = index;

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -146,13 +146,6 @@ test "void arrays" {
 test "nested arrays" {
     if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_wasm) {
-        // TODO this is a recent stage2 test case regression due to an enhancement;
-        // now arrays are properly detected as comptime. This exercised a new code
-        // path in the wasm backend that is not yet implemented.
-        return error.SkipZigTest;
-    }
-
     const array_of_strings = [_][]const u8{ "hello", "this", "is", "my", "thing" };
     for (array_of_strings) |s, i| {
         if (i == 0) try expect(mem.eql(u8, s, "hello"));

--- a/test/behavior/for.zig
+++ b/test/behavior/for.zig
@@ -62,12 +62,6 @@ test "ignore lval with underscore (for loop)" {
 }
 
 test "basic for loop" {
-    if (@import("builtin").zig_backend == .stage2_wasm) {
-        // TODO this is a recent stage2 test case regression due to an enhancement;
-        // now arrays are properly detected as comptime. This exercised a new code
-        // path in the wasm backend that is not yet implemented.
-        return error.SkipZigTest;
-    }
     const expected_result = [_]u8{ 9, 8, 7, 6, 0, 1, 2, 3 } ** 3;
 
     var buffer: [expected_result.len]u8 = undefined;


### PR DESCRIPTION
Previously, the wasm backend would lower any type of constant to a stack value. For types such as structs, we'd then store it in the 'virtual' stack in the data section. This meant that lowering larger constants was done during runtime.
Not only was this inefficient, but it also meant that constants were not memoized, but regenerated on each reference. Making the binaries larger, and runtime slower.

After this PR, however, we now lower constants that are passed by reference (such as structs, arrays, etc) to bytes and store them in the `rodata` section. The linker generates a relocation for this constant and rewrites its actual address when we emit the final binary data. This means that now we re-use code (in `genTypedValue`), rather than implement the same logic twice. Constants are now also memoized, meaning that no matter how often they are referenced, once emit, will be a simple `i32.const <address>`.
Besides those changes, it allowed me to refactor `store()` as well as we no longer need to make any assumptions on how many values will be on the stack, nor do we have to check the active tag of the `WValue` any longer. This simplifies the code a lot while also making it more efficient. 
