### PR TITLE
glibc: fix passing of __GNU_MINOR__

### DIFF
--- a/lib/libc/include/generic-glibc/features.h
+++ b/lib/libc/include/generic-glibc/features.h
@@ -477,7 +477,7 @@
 /* Major and minor version number of the GNU C library package.  Use
    these macros to test for features in specific releases.  */
 #define	__GLIBC__	2
-#define	__GLIBC_MINOR__	34
+/* Zig patch: we pass `-D__GLIBC_MINOR__=XX` depending on the target. */
 
 #define __GLIBC_PREREQ(maj, min) \
 	((__GLIBC__ << 16) + __GLIBC_MINOR__ >= ((maj) << 16) + (min))


### PR DESCRIPTION
This was originally introduced in 4d48948b526337947ef59a83f7dbc81b70aa5723 but broken immediately afterwards in c8af00c66e8b6f62e4dd6ac4d86a3de03e9ea354.

In my use case, this fixes an undefined symbol when compiling libc++ with older versions of glibc (see #10614). libc++ checks for the existence of features using `__GLIBC_PREREQ`, which always passed since `__GNU_MINOR__` was hardcoded in the header.

I would also like to add a test for this, but I only found a single test that compiles a C++ file in `test/standalone/c_compiler`. Are you interested in more small tests which try to compile code with different versions of glibc?

Closes #10614 and if I am not mistaken the original change already closed #7508.