### PR TITLE
std/fs: Support `XDG_DATA_HOME`

### DIFF
--- a/lib/std/fs/get_app_data_dir.zig
+++ b/lib/std/fs/get_app_data_dir.zig
@@ -45,6 +45,10 @@ pub fn getAppDataDir(allocator: mem.Allocator, appname: []const u8) GetAppDataDi
             return fs.path.join(allocator, &[_][]const u8{ home_dir, "Library", "Application Support", appname });
         },
         .linux, .freebsd, .netbsd, .dragonfly, .openbsd, .solaris => {
+            if (os.getenv("XDG_DATA_HOME")) |xdg| {
+                return fs.path.join(allocator, &[_][]const u8{ xdg, appname });
+            }
+
             const home_dir = os.getenv("HOME") orelse {
                 // TODO look in /etc/passwd
                 return error.AppDataDirUnavailable;


### PR DESCRIPTION
This is generally used to specify where to put user-specific data on linux, with the default being ~/.local/share as per the [xdg base dir spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).