### PR TITLE
macho: do not write out ZEROFILL physically to file

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -919,17 +919,6 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
             try self.parseDependentLibs(self.base.options.sysroot, &dependent_libs);
         }
 
-        if (self.bss_section_index) |idx| {
-            const seg = &self.load_commands.items[self.data_segment_cmd_index.?].segment;
-            const sect = &seg.sections.items[idx];
-            sect.offset = self.bss_file_offset;
-        }
-        if (self.tlv_bss_section_index) |idx| {
-            const seg = &self.load_commands.items[self.data_segment_cmd_index.?].segment;
-            const sect = &seg.sections.items[idx];
-            sect.offset = self.tlv_bss_file_offset;
-        }
-
         try self.createMhExecuteHeaderAtom();
         for (self.objects.items) |*object, object_id| {
             if (object.analyzed) continue;
@@ -1020,18 +1009,6 @@ pub fn flushModule(self: *MachO, comp: *Compilation) !void {
             const seg = &self.load_commands.items[self.data_segment_cmd_index.?].segment;
             const sect = &seg.sections.items[id];
             sect.size = self.rustc_section_size;
-        }
-        if (self.bss_section_index) |idx| {
-            const seg = &self.load_commands.items[self.data_segment_cmd_index.?].segment;
-            const sect = &seg.sections.items[idx];
-            self.bss_file_offset = sect.offset;
-            sect.offset = 0;
-        }
-        if (self.tlv_bss_section_index) |idx| {
-            const seg = &self.load_commands.items[self.data_segment_cmd_index.?].segment;
-            const sect = &seg.sections.items[idx];
-            self.tlv_bss_file_offset = sect.offset;
-            sect.offset = 0;
         }
 
         try self.setEntryPoint();
@@ -2127,6 +2104,8 @@ fn writeAllAtoms(self: *MachO) !void {
         const sect = seg.sections.items[match.sect];
         var atom: *Atom = entry.value_ptr.*;
 
+        if (sect.flags == macho.S_ZEROFILL or sect.flags == macho.S_THREAD_LOCAL_ZEROFILL) continue;
+
         var buffer = std.ArrayList(u8).init(self.base.allocator);
         defer buffer.deinit();
         try buffer.ensureTotalCapacity(try math.cast(usize, sect.size));
@@ -2178,6 +2157,8 @@ fn writeAtoms(self: *MachO) !void {
         const seg = self.load_commands.items[match.seg].segment;
         const sect = seg.sections.items[match.sect];
         var atom: *Atom = entry.value_ptr.*;
+
+        if (sect.flags == macho.S_ZEROFILL or sect.flags == macho.S_THREAD_LOCAL_ZEROFILL) continue;
 
         log.debug("writing atoms in {s},{s}", .{ sect.segName(), sect.sectName() });
 
@@ -4463,9 +4444,6 @@ fn populateMissingMetadata(self: *MachO) !void {
                 .flags = macho.S_THREAD_LOCAL_ZEROFILL,
             },
         );
-        const seg = self.load_commands.items[self.data_segment_cmd_index.?].segment;
-        const sect = seg.sections.items[self.tlv_bss_section_index.?];
-        self.tlv_bss_file_offset = sect.offset;
     }
 
     if (self.bss_section_index == null) {
@@ -4480,9 +4458,6 @@ fn populateMissingMetadata(self: *MachO) !void {
                 .flags = macho.S_ZEROFILL,
             },
         );
-        const seg = self.load_commands.items[self.data_segment_cmd_index.?].segment;
-        const sect = seg.sections.items[self.bss_section_index.?];
-        self.bss_file_offset = sect.offset;
     }
 
     if (self.linkedit_segment_cmd_index == null) {
@@ -4782,9 +4757,10 @@ fn allocateSegment(self: *MachO, index: u16, offset: u64) !void {
     // Allocate the sections according to their alignment at the beginning of the segment.
     var start: u64 = offset;
     for (seg.sections.items) |*sect, sect_id| {
+        const is_zerofill = sect.flags == macho.S_ZEROFILL or sect.flags == macho.S_THREAD_LOCAL_ZEROFILL;
         const alignment = try math.powi(u32, 2, sect.@"align");
         const start_aligned = mem.alignForwardGeneric(u64, start, alignment);
-        sect.offset = @intCast(u32, seg.inner.fileoff + start_aligned);
+        sect.offset = if (is_zerofill) 0 else @intCast(u32, seg.inner.fileoff + start_aligned);
         sect.addr = seg.inner.vmaddr + start_aligned;
 
         // Recalculate section size given the allocated start address
@@ -4811,11 +4787,15 @@ fn allocateSegment(self: *MachO, index: u16, offset: u64) !void {
         } else 0;
 
         start = start_aligned + sect.size;
+
+        if (!is_zerofill) {
+            seg.inner.filesize = start;
+        }
+        seg.inner.vmsize = start;
     }
 
-    const seg_size_aligned = mem.alignForwardGeneric(u64, start, self.page_size);
-    seg.inner.filesize = seg_size_aligned;
-    seg.inner.vmsize = seg_size_aligned;
+    seg.inner.filesize = mem.alignForwardGeneric(u64, seg.inner.filesize, self.page_size);
+    seg.inner.vmsize = mem.alignForwardGeneric(u64, seg.inner.vmsize, self.page_size);
 }
 
 const InitSectionOpts = struct {
@@ -4853,8 +4833,12 @@ fn initSection(
             off,
             off + size,
         });
+
         sect.addr = seg.inner.vmaddr + off - seg.inner.fileoff;
-        sect.offset = @intCast(u32, off);
+
+        if (opts.flags != macho.S_ZEROFILL and opts.flags != macho.S_THREAD_LOCAL_ZEROFILL) {
+            sect.offset = @intCast(u32, off);
+        }
     }
 
     const index = @intCast(u16, seg.sections.items.len);


### PR DESCRIPTION
Fixes #9527 

Prior to this change, `__DATA,__bss` and `__DATA,__thread_bss` would get actually, physically written out to the output file, unnecessarily filling the output file with 0s.

This fix does not yet fully cover incremental side of the linker - in case we introduce a section in `__DATA` segment, we do not yet reorder the zerofills to be at the end of the segment (thus allowing us to conserve the filesize space), nor do we take into account that there is no need to grow zerofills in filesize when expanding the zerofill sections.

---

Quick verification using `bloaty` on the following Zig source:

```zig
$ cat hello.zig
const std = @import("std");

var arr: [2000000]u8 = undefined;

pub fn main() void {
    arr[100] = 42;
    std.log.info("All your codebase are belong to us!", .{});
}

$ zig build-exe hello.zig
```

**Before this change:**

```
❯ bloaty hello -d symbols -n 5
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  81.8%  1.91Mi  81.8%  1.91Mi    _arr
  13.8%   328Ki  13.8%   328Ki    [1242 Others]
   2.2%  52.2Ki   2.3%  53.9Ki    [__LINKEDIT]
   1.3%  30.0Ki   1.3%  30.0Ki    _std.sort.sort
   0.5%  12.3Ki   0.5%  12.3Ki    _std.dwarf.DwarfInfo.getLineNumberInfo
   0.4%  10.1Ki   0.4%  10.1Ki    _std.hash.wyhash.WyhashStateless.final
 100.0%  2.33Mi 100.0%  2.33Mi    TOTAL
```

**After this change:**

```
$ bloaty hello -d symbols -n 5
    FILE SIZE        VM SIZE    
 --------------  -------------- 
   0.8%  3.58Ki  81.8%  1.91Mi    _arr
  74.9%   322Ki  13.8%   328Ki    [1242 Others]
  12.1%  52.2Ki   2.3%  53.9Ki    [__LINKEDIT]
   7.0%  30.0Ki   1.3%  30.0Ki    _std.sort.sort
   2.9%  12.3Ki   0.5%  12.3Ki    _std.dwarf.DwarfInfo.getLineNumberInfo
   2.3%  10.1Ki   0.4%  10.1Ki    _std.hash.wyhash.WyhashStateless.final
 100.0%   430Ki 100.0%  2.33Mi    TOTAL
```