### PR TITLE
Fix overflow in std.math.isNormal when applied to -Inf or a negative NaN

### DIFF
--- a/lib/std/math/isnormal.zig
+++ b/lib/std/math/isnormal.zig
@@ -34,6 +34,10 @@ test "math.isNormal" {
     try expect(!isNormal(math.nan(f32)));
     try expect(!isNormal(math.nan(f64)));
     try expect(!isNormal(math.nan(f128)));
+    try expect(!isNormal(-math.nan(f16)));
+    try expect(!isNormal(-math.nan(f32)));
+    try expect(!isNormal(-math.nan(f64)));
+    try expect(!isNormal(-math.nan(f128)));
     try expect(!isNormal(math.inf(f16)));
     try expect(!isNormal(math.inf(f32)));
     try expect(!isNormal(math.inf(f64)));

--- a/lib/std/math/isnormal.zig
+++ b/lib/std/math/isnormal.zig
@@ -9,19 +9,19 @@ pub fn isNormal(x: anytype) bool {
     switch (T) {
         f16 => {
             const bits = @bitCast(u16, x);
-            return (bits + (1 << 10)) & (maxInt(u16) >> 1) >= (1 << 11);
+            return (bits +% (1 << 10)) & (maxInt(u16) >> 1) >= (1 << 11);
         },
         f32 => {
             const bits = @bitCast(u32, x);
-            return (bits + (1 << 23)) & (maxInt(u32) >> 1) >= (1 << 24);
+            return (bits +% (1 << 23)) & (maxInt(u32) >> 1) >= (1 << 24);
         },
         f64 => {
             const bits = @bitCast(u64, x);
-            return (bits + (1 << 52)) & (maxInt(u64) >> 1) >= (1 << 53);
+            return (bits +% (1 << 52)) & (maxInt(u64) >> 1) >= (1 << 53);
         },
         f128 => {
             const bits = @bitCast(u128, x);
-            return (bits + (1 << 112)) & (maxInt(u128) >> 1) >= (1 << 113);
+            return (bits +% (1 << 112)) & (maxInt(u128) >> 1) >= (1 << 113);
         },
         else => {
             @compileError("isNormal not implemented for " ++ @typeName(T));
@@ -34,6 +34,14 @@ test "math.isNormal" {
     try expect(!isNormal(math.nan(f32)));
     try expect(!isNormal(math.nan(f64)));
     try expect(!isNormal(math.nan(f128)));
+    try expect(!isNormal(math.inf(f16)));
+    try expect(!isNormal(math.inf(f32)));
+    try expect(!isNormal(math.inf(f64)));
+    try expect(!isNormal(math.inf(f128)));
+    try expect(!isNormal(-math.inf(f16)));
+    try expect(!isNormal(-math.inf(f32)));
+    try expect(!isNormal(-math.inf(f64)));
+    try expect(!isNormal(-math.inf(f128)));
     try expect(!isNormal(@as(f16, 0)));
     try expect(!isNormal(@as(f32, 0)));
     try expect(!isNormal(@as(f64, 0)));


### PR DESCRIPTION
These cases had all the top bits set, so adding would cause an overflow, despite the high bits being immediately masked out.

I'm having trouble with fully building and testing my local copy of `zig`, so apologies if I've made basic errors, but I figured this was a simple enough fix that it more worth submitting an untested PR than opening an issue; I also tested outside of `std`.