### PR TITLE
Add test coverage for recent glibc version problems with `zig cc`

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -60,6 +60,9 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
         .build_modes = true,
         .cross_targets = true,
     });
+    if (builtin.os.tag == .linux) {
+        cases.addBuildFile("test/standalone/c_glibc_versions/build.zig", .{});
+    }
 
     if (builtin.os.tag == .windows) {
         cases.addC("test/standalone/issue_9402/main.zig");

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -62,6 +62,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     });
     if (builtin.os.tag == .linux) {
         cases.addBuildFile("test/standalone/c_glibc_versions/build.zig", .{});
+        cases.addBuildFile("test/standalone/c_glibc_libcxx_interaction/build.zig", .{});
     }
 
     if (builtin.os.tag == .windows) {

--- a/test/standalone/c_glibc_libcxx_interaction/build.zig
+++ b/test/standalone/c_glibc_libcxx_interaction/build.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const standardTarget = b.standardTargetOptions(.{});
+
+    // Compile a small example using std::condition_variable with different versions of glibc.
+    // libc++ has different implementations of the wait_for method depending on the version of
+    // glibc. For glibc >= 2.30 it uses pthread_cond_clockwait, which is not available earlier.
+    // libc++ should recognize the version of glibc during compilation so that it can choose the
+    // correct implementation, otherwise we get undefined symbols.
+    const glibc_major_version = 2;
+    for ([_]u8{ 13, 29, 30 }) |glibc_minor_version| {
+        const exe_name = b.fmt("glibc_libcxx_interaction_{d}.{d}", .{ glibc_major_version, glibc_minor_version });
+        const exe = b.addExecutable(exe_name, null);
+        b.default_step.dependOn(&exe.step);
+
+        exe.addCSourceFile("std_condition_variable.cpp", &[_][]const u8{});
+        exe.setBuildMode(mode);
+        exe.linkLibC();
+        exe.linkSystemLibrary("c++");
+
+        var target = standardTarget;
+        target.glibc_version = std.builtin.Version{ .major = glibc_major_version, .minor = glibc_minor_version };
+        exe.setTarget(target);
+    }
+}

--- a/test/standalone/c_glibc_libcxx_interaction/std_condition_variable.cpp
+++ b/test/standalone/c_glibc_libcxx_interaction/std_condition_variable.cpp
@@ -1,0 +1,13 @@
+#include <condition_variable>
+#include <mutex>
+
+int main()
+{
+    std::mutex mutex;
+    std::unique_lock<std::mutex> lock(mutex);
+
+    std::condition_variable cv;
+    cv.wait_for(lock, std::chrono::seconds(1));
+
+    return 0;
+}

--- a/test/standalone/c_glibc_versions/assert_glibc_version.c
+++ b/test/standalone/c_glibc_versions/assert_glibc_version.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+#if !defined(EXPECTED_GLIBC_MAJOR) || !defined(EXPECTED_GLIBC_MINOR)
+    #error "expected glibc version not defined"
+#endif
+
+    _Static_assert(__GLIBC__ == EXPECTED_GLIBC_MAJOR, "unexpected major version of glibc");
+    _Static_assert(__GLIBC_MINOR__ == EXPECTED_GLIBC_MINOR, "unexpected minor version of glibc");
+
+    return 0;
+}

--- a/test/standalone/c_glibc_versions/build.zig
+++ b/test/standalone/c_glibc_versions/build.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const standardTarget = b.standardTargetOptions(.{});
+
+    const glibc_major_version = 2;
+    for ([_]u8{ 13, 25, 31, 34 }) |glibc_minor_version| {
+        const exe_name = b.fmt("assert_glibc_version_{d}.{d}", .{ glibc_major_version, glibc_minor_version });
+        const exe = b.addExecutable(exe_name, null);
+        b.default_step.dependOn(&exe.step);
+
+        exe.addCSourceFile("assert_glibc_version.c", &[_][]const u8{"-std=c11"});
+        exe.setBuildMode(mode);
+        exe.linkLibC();
+
+        var target = standardTarget;
+        target.glibc_version = std.builtin.Version{ .major = glibc_major_version, .minor = glibc_minor_version };
+        exe.setTarget(target);
+
+        exe.defineCMacro("EXPECTED_GLIBC_MAJOR", b.fmt("{d}", .{glibc_major_version}));
+        exe.defineCMacro("EXPECTED_GLIBC_MINOR", b.fmt("{d}", .{glibc_minor_version}));
+    }
+}


### PR DESCRIPTION
Adds test coverage for #10641 and the related issues. Both tests fail without that fix.

I am not sure whether I integrated this into the overall test system correctly, since I only ran the tests individually.