### PR TITLE
Update the documentation for std.mem.sliceTo for readability

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -720,7 +720,7 @@ fn SliceTo(comptime T: type, comptime end: meta.Elem(T)) type {
     @compileError("invalid type given to std.mem.sliceTo: " ++ @typeName(T));
 }
 
-/// Takes a pointer to an array, an array, a sentinel-terminated pointer, or a slice and
+/// Takes an array, a pointer to an array, a sentinel-terminated pointer, or a slice and
 /// iterates searching for the first occurrence of `end`, returning the scanned slice.
 /// If `end` is not found, the full length of the array/slice/sentinel terminated pointer is returned.
 /// If the pointer type is sentinel terminated and `end` matches that terminator, the


### PR DESCRIPTION
Closes #10670

This PR looks to make the `std.mem.sliceTo` documentation comment more readable by listing `an array` before, `a pointer to an array`. 