### PR TITLE
std: define static error set for fs.Dir.copyFile

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2137,7 +2137,7 @@ pub const Dir = struct {
         defer atomic_file.deinit();
 
         try copy_file(in_file.handle, atomic_file.file.handle);
-        return try atomic_file.finish();
+        try atomic_file.finish();
     }
 
     pub const AtomicFileOptions = struct {


### PR DESCRIPTION
complex and needed to define set in consumer functions