### PR TITLE
stage2: fix debug line info in Elf

### DIFF
--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -768,7 +768,6 @@ fn dbgAdvancePCAndLine(emit: *Emit, line: u32, column: u32) InnerError!void {
             emit.prev_di_pc = emit.code.items.len;
             emit.prev_di_line = line;
             emit.prev_di_column = column;
-            emit.prev_di_pc = emit.code.items.len;
         },
         .plan9 => |dbg_out| {
             if (delta_pc <= 0) return; // only do this when the pc changes


### PR DESCRIPTION
~~Since `Module.Decl.src_line` is relative to the parent decl already, there's no need to add `Module.Fn.lbrace_line` to it anymore.~~ See below for an update.

cc @joachimschmidt557 this should also improve debugging experience of ARM targeting Linux.

EDIT: Since `Module.Fn.lbrace_line` is relative to the parent decl already, there's no need to add `Module.Decl.src_line` to it anymore. This begs a question however, do we need `Module.Decl.src_line` at all? It seems it is used to signify the start line number for the decl declaration, but perhaps, for functions, `Module.Fn.lbrace_line` is sufficient? Anyhow, @joachimschmidt557 and I went over this on a couple of edge case examples such as putting a function inside an inner `struct`, or forcing the signature of a function span multiple lines, and in all cases, using `lbrace_line` worked as expected and desired.