### PR TITLE
Stage2: wasm - Implement unions

### DIFF
--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -173,6 +173,10 @@ pub fn emitMir(emit: *Emit) InnerError!void {
             .i64_trunc_f32_u => try emit.emitTag(tag),
             .i64_trunc_f64_s => try emit.emitTag(tag),
             .i64_trunc_f64_u => try emit.emitTag(tag),
+            .i32_rem_s => try emit.emitTag(tag),
+            .i32_rem_u => try emit.emitTag(tag),
+            .i64_rem_s => try emit.emitTag(tag),
+            .i64_rem_u => try emit.emitTag(tag),
 
             .extended => try emit.emitExtended(inst),
         }

--- a/src/arch/wasm/Mir.zig
+++ b/src/arch/wasm/Mir.zig
@@ -327,6 +327,10 @@ pub const Inst = struct {
         /// Uses `tag`
         i32_div_u = 0x6E,
         /// Uses `tag`
+        i32_rem_s = 0x6F,
+        /// Uses `tag`
+        i32_rem_u = 0x70,
+        /// Uses `tag`
         i32_and = 0x71,
         /// Uses `tag`
         i32_or = 0x72,
@@ -348,6 +352,10 @@ pub const Inst = struct {
         i64_div_s = 0x7F,
         /// Uses `tag`
         i64_div_u = 0x80,
+        /// Uses `tag`
+        i64_rem_s = 0x81,
+        /// Uses `tag`
+        i64_rem_u = 0x82,
         /// Uses `tag`
         i64_and = 0x83,
         /// Uses `tag`

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -3,18 +3,34 @@ const builtin = @import("builtin");
 test {
     // Tests that pass for stage1, llvm backend, C backend, wasm backend, arm backend and x86_64 backend.
     _ = @import("behavior/align.zig");
+    _ = @import("behavior/alignof.zig");
     _ = @import("behavior/array.zig");
+    _ = @import("behavior/bit_shifting.zig");
     _ = @import("behavior/bool.zig");
+    _ = @import("behavior/bugs/394.zig");
     _ = @import("behavior/bugs/655.zig");
+    _ = @import("behavior/bugs/656.zig");
     _ = @import("behavior/bugs/679.zig");
     _ = @import("behavior/bugs/1111.zig");
+    _ = @import("behavior/bugs/1277.zig");
+    _ = @import("behavior/bugs/1310.zig");
+    _ = @import("behavior/bugs/1381.zig");
+    _ = @import("behavior/bugs/1500.zig");
+    _ = @import("behavior/bugs/1735.zig");
+    _ = @import("behavior/bugs/2006.zig");
     _ = @import("behavior/bugs/2346.zig");
+    _ = @import("behavior/bugs/3112.zig");
+    _ = @import("behavior/bugs/3367.zig");
     _ = @import("behavior/bugs/6850.zig");
+    _ = @import("behavior/bugs/7250.zig");
     _ = @import("behavior/cast.zig");
     _ = @import("behavior/comptime_memory.zig");
     _ = @import("behavior/fn_in_struct_in_comptime.zig");
+    _ = @import("behavior/generics_llvm.zig");
     _ = @import("behavior/hasdecl.zig");
     _ = @import("behavior/hasfield.zig");
+    _ = @import("behavior/namespace_depends_on_compile_var.zig");
+    _ = @import("behavior/optional_llvm.zig");
     _ = @import("behavior/prefetch.zig");
     _ = @import("behavior/pub_enum.zig");
     _ = @import("behavior/slice_sentinel_comptime.zig");
@@ -60,6 +76,7 @@ test {
         _ = @import("behavior/type_info.zig");
         _ = @import("behavior/undefined.zig");
         _ = @import("behavior/underscore.zig");
+        _ = @import("behavior/union.zig");
         _ = @import("behavior/usingnamespace.zig");
         _ = @import("behavior/void.zig");
         _ = @import("behavior/while.zig");
@@ -68,30 +85,16 @@ test {
             // Tests that pass for stage1, llvm backend, C backend
             _ = @import("behavior/cast_int.zig");
             _ = @import("behavior/int128.zig");
-            _ = @import("behavior/union.zig");
             _ = @import("behavior/translate_c_macros.zig");
 
             if (builtin.zig_backend != .stage2_c) {
                 // Tests that pass for stage1 and the llvm backend.
-                _ = @import("behavior/alignof.zig");
                 _ = @import("behavior/array_llvm.zig");
                 _ = @import("behavior/atomics.zig");
                 _ = @import("behavior/basic_llvm.zig");
-                _ = @import("behavior/bit_shifting.zig");
-                _ = @import("behavior/bugs/394.zig");
-                _ = @import("behavior/bugs/656.zig");
-                _ = @import("behavior/bugs/1277.zig");
-                _ = @import("behavior/bugs/1310.zig");
-                _ = @import("behavior/bugs/1381.zig");
-                _ = @import("behavior/bugs/1500.zig");
-                _ = @import("behavior/bugs/1735.zig");
                 _ = @import("behavior/bugs/1741.zig");
-                _ = @import("behavior/bugs/2006.zig");
                 _ = @import("behavior/bugs/2578.zig");
                 _ = @import("behavior/bugs/3007.zig");
-                _ = @import("behavior/bugs/3112.zig");
-                _ = @import("behavior/bugs/3367.zig");
-                _ = @import("behavior/bugs/7250.zig");
                 _ = @import("behavior/bugs/9584.zig");
                 _ = @import("behavior/cast_llvm.zig");
                 _ = @import("behavior/enum_llvm.zig");
@@ -99,13 +102,10 @@ test {
                 _ = @import("behavior/eval.zig");
                 _ = @import("behavior/floatop.zig");
                 _ = @import("behavior/fn.zig");
-                _ = @import("behavior/generics_llvm.zig");
                 _ = @import("behavior/math.zig");
                 _ = @import("behavior/maximum_minimum.zig");
                 _ = @import("behavior/merge_error_sets.zig");
-                _ = @import("behavior/namespace_depends_on_compile_var.zig");
                 _ = @import("behavior/null_llvm.zig");
-                _ = @import("behavior/optional_llvm.zig");
                 _ = @import("behavior/popcount.zig");
                 _ = @import("behavior/saturating_arithmetic.zig");
                 _ = @import("behavior/sizeof_and_typeof.zig");

--- a/test/behavior/alignof.zig
+++ b/test/behavior/alignof.zig
@@ -11,6 +11,9 @@ const Foo = struct {
 };
 
 test "@alignOf(T) before referencing T" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     comptime try expect(@alignOf(Foo) != maxInt(usize));
     if (native_arch == .x86_64) {
         comptime try expect(@alignOf(Foo) == 4);
@@ -18,6 +21,9 @@ test "@alignOf(T) before referencing T" {
 }
 
 test "comparison of @alignOf(T) against zero" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     {
         const T = struct { x: u32 };
         try expect(!(@alignOf(T) == 0));

--- a/test/behavior/bit_shifting.zig
+++ b/test/behavior/bit_shifting.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const expect = std.testing.expect;
+const builtin = @import("builtin");
 
 fn ShardedTable(comptime Key: type, comptime mask_bit_count: comptime_int, comptime V: type) type {
     const key_bits = @typeInfo(Key).Int.bits;
@@ -60,6 +61,9 @@ fn ShardedTable(comptime Key: type, comptime mask_bit_count: comptime_int, compt
 }
 
 test "sharded table" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     // realistic 16-way sharding
     try testShardedTable(u32, 4, 8);
 

--- a/test/behavior/bugs/1277.zig
+++ b/test/behavior/bugs/1277.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const S = struct {
     f: ?fn () i32,
@@ -11,5 +12,7 @@ fn f() i32 {
 }
 
 test "don't emit an LLVM global for a const function when it's in an optional in a struct" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     try std.testing.expect(s.f.?() == 1234);
 }

--- a/test/behavior/bugs/1310.zig
+++ b/test/behavior/bugs/1310.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const expect = std.testing.expect;
+const builtin = @import("builtin");
 
 pub const VM = ?[*]const struct_InvocationTable_;
 pub const struct_InvocationTable_ = extern struct {
@@ -22,5 +23,7 @@ fn agent_callback(_vm: [*]VM, options: [*]u8) callconv(.C) i32 {
 }
 
 test "fixed" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     try expect(agent_callback(undefined, undefined) == 11);
 }

--- a/test/behavior/bugs/1381.zig
+++ b/test/behavior/bugs/1381.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const B = union(enum) {
     D: u8,
@@ -11,6 +12,8 @@ const A = union(enum) {
 };
 
 test "union that needs padding bytes inside an array" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     var as = [_]A{
         A{ .B = B{ .D = 1 } },
         A{ .B = B{ .D = 1 } },

--- a/test/behavior/bugs/1500.zig
+++ b/test/behavior/bugs/1500.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const A = struct {
     b: B,
 };
@@ -5,6 +6,9 @@ const A = struct {
 const B = *const fn (A) void;
 
 test "allow these dependencies" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     var a: A = undefined;
     var b: B = undefined;
     if (false) {

--- a/test/behavior/bugs/1735.zig
+++ b/test/behavior/bugs/1735.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const mystruct = struct {
     pending: ?listofstructs,
@@ -41,6 +42,9 @@ const a = struct {
 };
 
 test "initialization" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     var t = a.init();
     try std.testing.expect(t.foo.len == 0);
 }

--- a/test/behavior/bugs/2006.zig
+++ b/test/behavior/bugs/2006.zig
@@ -1,10 +1,14 @@
 const std = @import("std");
 const expect = std.testing.expect;
+const builtin = @import("builtin");
 
 const S = struct {
     p: *S,
 };
 test "bug 2006" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     var a: S = undefined;
     a = S{ .p = undefined };
     try expect(@sizeOf(S) != 0);

--- a/test/behavior/bugs/3112.zig
+++ b/test/behavior/bugs/3112.zig
@@ -13,7 +13,9 @@ fn prev(p: ?State) void {
 
 test "zig test crash" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     var global: State = undefined;
     global.enter = prev;
     global.enter(null);

--- a/test/behavior/bugs/3367.zig
+++ b/test/behavior/bugs/3367.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const Foo = struct {
     usingnamespace Mixin;
 };
@@ -9,6 +10,9 @@ const Mixin = struct {
 };
 
 test "container member access usingnamespace decls" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     var foo = Foo{};
     foo.two();
 }

--- a/test/behavior/bugs/394.zig
+++ b/test/behavior/bugs/394.zig
@@ -8,8 +8,11 @@ const S = struct {
 };
 
 const expect = @import("std").testing.expect;
+const builtin = @import("builtin");
 
 test "bug 394 fixed" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     const x = S{
         .x = 3,
         .y = E{ .B = 1 },

--- a/test/behavior/bugs/656.zig
+++ b/test/behavior/bugs/656.zig
@@ -1,4 +1,5 @@
 const expect = @import("std").testing.expect;
+const builtin = @import("builtin");
 
 const PrefixOp = union(enum) {
     Return,
@@ -10,6 +11,8 @@ const Value = struct {
 };
 
 test "optional if after an if in a switch prong of a switch with 2 prongs in an else" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     try foo(false, true);
 }
 

--- a/test/behavior/bugs/7250.zig
+++ b/test/behavior/bugs/7250.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const nrfx_uart_t = extern struct {
     p_reg: [*c]u32,
     drv_inst_idx: u8,
@@ -13,5 +14,8 @@ threadlocal var g_uart0 = nrfx_uart_t{
 };
 
 test "reference a global threadlocal variable" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     _ = nrfx_uart_rx(&g_uart0);
 }

--- a/test/behavior/generics_llvm.zig
+++ b/test/behavior/generics_llvm.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const expect = std.testing.expect;
+const builtin = @import("builtin");
 
 const foos = [_]fn (anytype) bool{
     foo1,
@@ -14,11 +15,17 @@ fn foo2(arg: anytype) bool {
 }
 
 test "array of generic fns" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     try expect(foos[0](true));
     try expect(!foos[1](true));
 }
 
 test "generic struct" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     var a1 = GenNode(i32){
         .value = 13,
         .next = null,

--- a/test/behavior/namespace_depends_on_compile_var.zig
+++ b/test/behavior/namespace_depends_on_compile_var.zig
@@ -3,6 +3,9 @@ const builtin = @import("builtin");
 const expect = std.testing.expect;
 
 test "namespace depends on compile var" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (some_namespace.a_bool) {
         try expect(some_namespace.a_bool);
     } else {

--- a/test/behavior/optional_llvm.zig
+++ b/test/behavior/optional_llvm.zig
@@ -2,8 +2,12 @@ const std = @import("std");
 const testing = std.testing;
 const expect = testing.expect;
 const expectEqual = testing.expectEqual;
+const builtin = @import("builtin");
 
 test "self-referential struct through a slice of optional" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     const S = struct {
         const Node = struct {
             children: []?Node,

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -362,6 +362,8 @@ pub const FooUnion = union(enum) {
 var glbl_array: [2]FooUnion = undefined;
 
 test "initialize global array of union" {
+    if (@import("builtin").zig_backend == .stage2_wasm) return error.SkipZigTest;
+
     glbl_array[1] = FooUnion{ .U1 = 2 };
     glbl_array[0] = FooUnion{ .U0 = 1 };
     try expect(glbl_array[0].U0 == 1);


### PR DESCRIPTION
This PR implements unions for the wasm backend.

Besides unions, the following was done as well:
- genTypedValue for enums (needed for tagged unions and was previously always emitting 'undefined' as value).
- Directly use Type.abiSize() to determine load/store instruction rather than an own variant.
(Thanks to previous refactor PR this was now possible).
- Implement the `rem` instruction: Only had to be enabled and will allow better test runner features.
- Function calling through decl_ref.

Note that this moves all the behavior tests to the outer branch and each test case has been disabled individually for all non-passing backends.
