### PR TITLE
stage2: always use GPA in debug builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -112,6 +112,7 @@ pub fn build(b: *Builder) !void {
     const tracy = b.option([]const u8, "tracy", "Enable Tracy integration. Supply path to Tracy source");
     const tracy_callstack = b.option(bool, "tracy-callstack", "Include callstack information with Tracy data. Does nothing if -Dtracy is not provided") orelse false;
     const tracy_allocation = b.option(bool, "tracy-allocation", "Include allocation information with Tracy data. Does nothing if -Dtracy is not provided") orelse false;
+    const force_gpa = b.option(bool, "force-gpa", "Force the compiler to use GeneralPurposeAllocator") orelse false;
     const link_libc = b.option(bool, "force-link-libc", "Force self-hosted compiler to link libc") orelse enable_llvm;
     const strip = b.option(bool, "strip", "Omit debug information") orelse false;
 
@@ -150,6 +151,7 @@ pub fn build(b: *Builder) !void {
     exe_options.addOption(bool, "llvm_has_csky", llvm_has_csky);
     exe_options.addOption(bool, "llvm_has_ve", llvm_has_ve);
     exe_options.addOption(bool, "llvm_has_arc", llvm_has_arc);
+    exe_options.addOption(bool, "force_gpa", force_gpa);
 
     if (enable_llvm) {
         const cmake_cfg = if (static_llvm) null else findAndParseConfigH(b, config_h_path_option);

--- a/src/main.zig
+++ b/src/main.zig
@@ -137,7 +137,7 @@ pub fn main() anyerror!void {
 
     var gpa_need_deinit = false;
     const gpa = gpa: {
-        if (!builtin.link_libc) {
+        if (build_options.force_gpa or !builtin.link_libc) {
             gpa_need_deinit = true;
             break :gpa general_purpose_allocator.allocator();
         }


### PR DESCRIPTION
This PR makes debug builds of the compiler use `GeneralPurposeAllocator` even when linking libc.

Without this change debug builds on targets that always link libc or when the compiler links libc for tracy would use `c_allocator` meaning the issues checked by `GeneralPurposeAllocator.deinit()` are not caught.