### PR TITLE
stage2: Add `union` support to C backend

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -408,6 +408,18 @@ pub const DeclGen = struct {
                     try dg.renderValue(writer, Type.usize, slice.len);
                     try writer.writeAll("}");
                 },
+                .elem_ptr => {
+                    const elem_ptr = val.castTag(.elem_ptr).?.data;
+                    var arena = std.heap.ArenaAllocator.init(dg.module.gpa);
+                    defer arena.deinit();
+                    const elem_ptr_ty = try ty.elemPtrType(arena.allocator());
+
+                    try writer.writeAll("(&((");
+                    try dg.renderType(writer, ty);
+                    try writer.writeByte(')');
+                    try dg.renderValue(writer, elem_ptr_ty, elem_ptr.array_ptr);
+                    try writer.print(")[{d}])", .{elem_ptr.index});
+                },
                 .function => {
                     const func = val.castTag(.function).?.data;
                     try dg.renderDeclName(func.owner_decl, writer);

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -542,6 +542,15 @@ pub const DeclGen = struct {
                                     return writer.print("{d}", .{field_index});
                                 }
                             },
+                            .enum_numbered => {
+                                const enum_obj = ty.castTag(.enum_numbered).?.data;
+                                if (enum_obj.values.count() != 0) {
+                                    const tag_val = enum_obj.values.keys()[field_index];
+                                    return dg.renderValue(writer, enum_obj.tag_ty, tag_val);
+                                } else {
+                                    return writer.print("{d}", .{field_index});
+                                }
+                            },
                             else => unreachable,
                         }
                     },

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1230,8 +1230,7 @@ pub fn genDecl(o: *Object) !void {
             try fwd_decl_writer.writeAll("zig_threadlocal ");
         }
 
-        const decl_c_value: CValue = if (is_global) .{ .bytes = mem.span(o.dg.decl.name) }
-            else .{ .decl = o.dg.decl };
+        const decl_c_value: CValue = if (is_global) .{ .bytes = mem.span(o.dg.decl.name) } else .{ .decl = o.dg.decl };
 
         try o.dg.renderTypeAndName(fwd_decl_writer, o.dg.decl.ty, decl_c_value, .Mut, o.dg.decl.align_val);
         try fwd_decl_writer.writeAll(";\n");
@@ -2770,7 +2769,7 @@ fn structFieldPtr(f: *Function, inst: Air.Inst.Index, struct_ptr_ty: Type, struc
     const writer = f.object.writer();
     const struct_ty = struct_ptr_ty.elemType();
     var field_name: []const u8 = undefined;
-    var field_val_ty: Type = undefined; 
+    var field_val_ty: Type = undefined;
 
     switch (struct_ty.tag()) {
         .@"struct" => {
@@ -3167,7 +3166,7 @@ fn airSetUnionTag(f: *Function, inst: Air.Inst.Index) !CValue {
     const union_ty = f.air.typeOf(bin_op.lhs).childType();
     const target = f.object.dg.module.getTarget();
     const layout = union_ty.unionGetLayout(target);
-    if (layout.tag_size == 0)  return CValue.none;
+    if (layout.tag_size == 0) return CValue.none;
 
     try f.writeCValue(writer, union_ptr);
     try writer.writeAll("->tag = ");
@@ -3190,7 +3189,7 @@ fn airGetUnionTag(f: *Function, inst: Air.Inst.Index) !CValue {
 
     const target = f.object.dg.module.getTarget();
     const layout = un_ty.unionGetLayout(target);
-    if (layout.tag_size == 0)  return CValue.none;
+    if (layout.tag_size == 0) return CValue.none;
 
     try writer.writeAll(" = ");
     try f.writeCValue(writer, operand);

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -67,7 +67,7 @@ test {
             // Tests that pass for stage1, llvm backend, C backend
             _ = @import("behavior/cast_int.zig");
             _ = @import("behavior/int128.zig");
-	    _ = @import("behavior/union.zig");
+            _ = @import("behavior/union.zig");
             _ = @import("behavior/translate_c_macros.zig");
 
             if (builtin.zig_backend != .stage2_c) {

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -67,7 +67,8 @@ test {
             // Tests that pass for stage1, llvm backend, C backend
             _ = @import("behavior/cast_int.zig");
             _ = @import("behavior/int128.zig");
-            _ = @import("behavior/translate_c_macros.zig");
+	    _ = @import("behavior/union.zig");
+//            _ = @import("behavior/translate_c_macros.zig");
 
             if (builtin.zig_backend != .stage2_c) {
                 // Tests that pass for stage1 and the llvm backend.
@@ -110,7 +111,6 @@ test {
                 _ = @import("behavior/slice.zig");
                 _ = @import("behavior/struct_llvm.zig");
                 _ = @import("behavior/switch.zig");
-                _ = @import("behavior/union.zig");
                 _ = @import("behavior/widening.zig");
 
                 if (builtin.zig_backend != .stage1) {

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -68,7 +68,7 @@ test {
             _ = @import("behavior/cast_int.zig");
             _ = @import("behavior/int128.zig");
 	    _ = @import("behavior/union.zig");
-//            _ = @import("behavior/translate_c_macros.zig");
+            _ = @import("behavior/translate_c_macros.zig");
 
             if (builtin.zig_backend != .stage2_c) {
                 // Tests that pass for stage1 and the llvm backend.


### PR DESCRIPTION
This PR adds basic support for `union` to the C backend.

There are some differences vs. the union encoding in the LLVM backend:
  - The payload/tag fields are not ordered based on their alignment
  - Tagged unions with a 0-bit payload are not lowered directly to their tag type. 
      Instead, they become a struct with an empty union as their payload field

Some additional fixes were needed to get `test/behavior/union.zig` to pass:
 - Rendering `.elem_ptr` + `.enum_numbered` types
 - (Not) rendering `void` function args
 - Add `__` prefix to rendered identifiers, to avoid conflicts with reserved C keywords
 
This is also my first Zig PR, so I hope I haven't missed any important steps/guidelines.
Please let me know if anything needs fixing 👍 