### PR TITLE
Rename mem.bswapAllFields to byteSwapAllFields

### DIFF
--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -424,7 +424,7 @@ pub fn ProgramHeaderIterator(ParseSource: anytype) type {
                 if (self.elf_header.endian == native_endian) return phdr;
 
                 // Convert fields to native endianness.
-                mem.bswapAllFields(Elf64_Phdr, &phdr);
+                mem.byteSwapAllFields(Elf64_Phdr, &phdr);
                 return phdr;
             }
 
@@ -436,7 +436,7 @@ pub fn ProgramHeaderIterator(ParseSource: anytype) type {
             // ELF endianness does NOT match native endianness.
             if (self.elf_header.endian != native_endian) {
                 // Convert fields to native endianness.
-                mem.bswapAllFields(Elf32_Phdr, &phdr);
+                mem.byteSwapAllFields(Elf32_Phdr, &phdr);
             }
 
             // Convert 32-bit header to 64-bit.
@@ -474,7 +474,7 @@ pub fn SectionHeaderIterator(ParseSource: anytype) type {
                 if (self.elf_header.endian == native_endian) return shdr;
 
                 // Convert fields to native endianness.
-                mem.bswapAllFields(Elf64_Shdr, &shdr);
+                mem.byteSwapAllFields(Elf64_Shdr, &shdr);
                 return shdr;
             }
 
@@ -486,7 +486,7 @@ pub fn SectionHeaderIterator(ParseSource: anytype) type {
             // ELF endianness does NOT match native endianness.
             if (self.elf_header.endian != native_endian) {
                 // Convert fields to native endianness.
-                mem.bswapAllFields(Elf32_Shdr, &shdr);
+                mem.byteSwapAllFields(Elf32_Shdr, &shdr);
             }
 
             // Convert 32-bit header to 64-bit.

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1522,16 +1522,19 @@ test "writeIntBig and writeIntLittle" {
     try testing.expect(eql(u8, buf2[0..], &[_]u8{ 0xfc, 0xff }));
 }
 
+/// TODO delete this deprecated declaration after 0.10.0 is released
+pub const bswapAllFields = @compileError("bswapAllFields has been renamed to byteSwapAllFields");
+
 /// Swap the byte order of all the members of the fields of a struct
 /// (Changing their endianess)
-pub fn bswapAllFields(comptime S: type, ptr: *S) void {
-    if (@typeInfo(S) != .Struct) @compileError("bswapAllFields expects a struct as the first argument");
+pub fn byteSwapAllFields(comptime S: type, ptr: *S) void {
+    if (@typeInfo(S) != .Struct) @compileError("byteSwapAllFields expects a struct as the first argument");
     inline for (std.meta.fields(S)) |f| {
         @field(ptr, f.name) = @byteSwap(f.field_type, @field(ptr, f.name));
     }
 }
 
-test "bswapAllFields" {
+test "byteSwapAllFields" {
     const T = extern struct {
         f0: u8,
         f1: u16,
@@ -1542,7 +1545,7 @@ test "bswapAllFields" {
         .f1 = 0x1234,
         .f2 = 0x12345678,
     };
-    bswapAllFields(T, &s);
+    byteSwapAllFields(T, &s);
     try std.testing.expectEqual(T{
         .f0 = 0x12,
         .f1 = 0x3412,

--- a/lib/std/tz.zig
+++ b/lib/std/tz.zig
@@ -60,7 +60,7 @@ pub const Tz = struct {
         if (legacy_header.version != 0 and legacy_header.version != '2' and legacy_header.version != '3') return error.BadVersion;
 
         if (builtin.target.cpu.arch.endian() != std.builtin.Endian.Big) {
-            std.mem.bswapAllFields(@TypeOf(legacy_header.counts), &legacy_header.counts);
+            std.mem.byteSwapAllFields(@TypeOf(legacy_header.counts), &legacy_header.counts);
         }
 
         if (legacy_header.version == 0) {
@@ -74,7 +74,7 @@ pub const Tz = struct {
             if (!std.mem.eql(u8, &header.magic, "TZif")) return error.BadHeader;
             if (header.version != '2' and header.version != '3') return error.BadVersion;
             if (builtin.target.cpu.arch.endian() != std.builtin.Endian.Big) {
-                std.mem.bswapAllFields(@TypeOf(header.counts), &header.counts);
+                std.mem.byteSwapAllFields(@TypeOf(header.counts), &header.counts);
             }
 
             return parseBlock(allocator, reader, header, false);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1204,7 +1204,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
                 for (buf) |*phdr, i| {
                     phdr.* = progHeaderTo32(self.program_headers.items[i]);
                     if (foreign_endian) {
-                        mem.bswapAllFields(elf.Elf32_Phdr, phdr);
+                        mem.byteSwapAllFields(elf.Elf32_Phdr, phdr);
                     }
                 }
                 try self.base.file.?.pwriteAll(mem.sliceAsBytes(buf), self.phdr_table_offset.?);
@@ -1216,7 +1216,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
                 for (buf) |*phdr, i| {
                     phdr.* = self.program_headers.items[i];
                     if (foreign_endian) {
-                        mem.bswapAllFields(elf.Elf64_Phdr, phdr);
+                        mem.byteSwapAllFields(elf.Elf64_Phdr, phdr);
                     }
                 }
                 try self.base.file.?.pwriteAll(mem.sliceAsBytes(buf), self.phdr_table_offset.?);
@@ -1293,7 +1293,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
                     shdr.* = sectHeaderTo32(self.sections.items[i]);
                     log.debug("writing section {}", .{shdr.*});
                     if (foreign_endian) {
-                        mem.bswapAllFields(elf.Elf32_Shdr, shdr);
+                        mem.byteSwapAllFields(elf.Elf32_Shdr, shdr);
                     }
                 }
                 try self.base.file.?.pwriteAll(mem.sliceAsBytes(buf), self.shdr_table_offset.?);
@@ -1306,7 +1306,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation) !void {
                     shdr.* = self.sections.items[i];
                     log.debug("writing section {}", .{shdr.*});
                     if (foreign_endian) {
-                        mem.bswapAllFields(elf.Elf64_Shdr, shdr);
+                        mem.byteSwapAllFields(elf.Elf64_Shdr, shdr);
                     }
                 }
                 try self.base.file.?.pwriteAll(mem.sliceAsBytes(buf), self.shdr_table_offset.?);
@@ -3086,14 +3086,14 @@ fn writeProgHeader(self: *Elf, index: usize) !void {
         .p32 => {
             var phdr = [1]elf.Elf32_Phdr{progHeaderTo32(self.program_headers.items[index])};
             if (foreign_endian) {
-                mem.bswapAllFields(elf.Elf32_Phdr, &phdr[0]);
+                mem.byteSwapAllFields(elf.Elf32_Phdr, &phdr[0]);
             }
             return self.base.file.?.pwriteAll(mem.sliceAsBytes(&phdr), offset);
         },
         .p64 => {
             var phdr = [1]elf.Elf64_Phdr{self.program_headers.items[index]};
             if (foreign_endian) {
-                mem.bswapAllFields(elf.Elf64_Phdr, &phdr[0]);
+                mem.byteSwapAllFields(elf.Elf64_Phdr, &phdr[0]);
             }
             return self.base.file.?.pwriteAll(mem.sliceAsBytes(&phdr), offset);
         },
@@ -3107,7 +3107,7 @@ fn writeSectHeader(self: *Elf, index: usize) !void {
             var shdr: [1]elf.Elf32_Shdr = undefined;
             shdr[0] = sectHeaderTo32(self.sections.items[index]);
             if (foreign_endian) {
-                mem.bswapAllFields(elf.Elf32_Shdr, &shdr[0]);
+                mem.byteSwapAllFields(elf.Elf32_Shdr, &shdr[0]);
             }
             const offset = self.shdr_table_offset.? + index * @sizeOf(elf.Elf32_Shdr);
             return self.base.file.?.pwriteAll(mem.sliceAsBytes(&shdr), offset);
@@ -3115,7 +3115,7 @@ fn writeSectHeader(self: *Elf, index: usize) !void {
         .p64 => {
             var shdr = [1]elf.Elf64_Shdr{self.sections.items[index]};
             if (foreign_endian) {
-                mem.bswapAllFields(elf.Elf64_Shdr, &shdr[0]);
+                mem.byteSwapAllFields(elf.Elf64_Shdr, &shdr[0]);
             }
             const offset = self.shdr_table_offset.? + index * @sizeOf(elf.Elf64_Shdr);
             return self.base.file.?.pwriteAll(mem.sliceAsBytes(&shdr), offset);
@@ -3213,7 +3213,7 @@ fn writeSymbol(self: *Elf, index: usize) !void {
                 },
             };
             if (foreign_endian) {
-                mem.bswapAllFields(elf.Elf32_Sym, &sym[0]);
+                mem.byteSwapAllFields(elf.Elf32_Sym, &sym[0]);
             }
             const off = syms_sect.sh_offset + @sizeOf(elf.Elf32_Sym) * index;
             try self.base.file.?.pwriteAll(mem.sliceAsBytes(sym[0..1]), off);
@@ -3221,7 +3221,7 @@ fn writeSymbol(self: *Elf, index: usize) !void {
         .p64 => {
             var sym = [1]elf.Elf64_Sym{self.local_symbols.items[index]};
             if (foreign_endian) {
-                mem.bswapAllFields(elf.Elf64_Sym, &sym[0]);
+                mem.byteSwapAllFields(elf.Elf64_Sym, &sym[0]);
             }
             const off = syms_sect.sh_offset + @sizeOf(elf.Elf64_Sym) * index;
             try self.base.file.?.pwriteAll(mem.sliceAsBytes(sym[0..1]), off);
@@ -3252,7 +3252,7 @@ fn writeAllGlobalSymbols(self: *Elf) !void {
                     .st_shndx = self.global_symbols.items[i].st_shndx,
                 };
                 if (foreign_endian) {
-                    mem.bswapAllFields(elf.Elf32_Sym, sym);
+                    mem.byteSwapAllFields(elf.Elf32_Sym, sym);
                 }
             }
             try self.base.file.?.pwriteAll(mem.sliceAsBytes(buf), global_syms_off);
@@ -3271,7 +3271,7 @@ fn writeAllGlobalSymbols(self: *Elf) !void {
                     .st_shndx = self.global_symbols.items[i].st_shndx,
                 };
                 if (foreign_endian) {
-                    mem.bswapAllFields(elf.Elf64_Sym, sym);
+                    mem.byteSwapAllFields(elf.Elf64_Sym, sym);
                 }
             }
             try self.base.file.?.pwriteAll(mem.sliceAsBytes(buf), global_syms_off);

--- a/src/link/MachO/fat.zig
+++ b/src/link/MachO/fat.zig
@@ -24,7 +24,7 @@ fn readFatStruct(reader: anytype, comptime T: type) !T {
     // disk in big endian order.
     var res = try reader.readStruct(T);
     if (native_endian != std.builtin.Endian.Big) {
-        mem.bswapAllFields(T, &res);
+        mem.byteSwapAllFields(T, &res);
     }
     return res;
 }


### PR DESCRIPTION
To match the renaming of `@bswap` to `@byteSwap` in https://github.com/ziglang/zig/commit/1fdb24827fb51351d5e31103069619668fae31c4.