### PR TITLE
zig cc: Treat cu files as C++ source files

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4198,7 +4198,10 @@ pub fn hasCppExt(filename: []const u8) bool {
     return mem.endsWith(u8, filename, ".C") or
         mem.endsWith(u8, filename, ".cc") or
         mem.endsWith(u8, filename, ".cpp") or
-        mem.endsWith(u8, filename, ".cxx");
+        mem.endsWith(u8, filename, ".cxx") or
+        mem.endsWith(u8, filename, ".cu") or
+        // .stub files are compiled by nvcc when using `zig c++` as the host compiler. They contain C++ code.
+        mem.endsWith(u8, filename, ".stub");
 }
 
 pub fn hasObjCExt(filename: []const u8) bool {


### PR DESCRIPTION
First step towards #10634.

Treating stub files as C++ allows to use zig c++ as a host
compiler for nvcc.

Treating cu files as C++ allow using zig c++ as a host compiler in
CMake. CMake calls the host compiler with -E on a cu file to identify
the compiler.

Using zig c++ to directly compile CUDA code is untested.