### PR TITLE
fmt: fix out-of-bounds array write in float printing

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2297,6 +2297,7 @@ test "float.decimal" {
     try expectFmt("f64: 0.00030000", "f64: {d:.8}", .{@as(f64, 0.0003)});
     try expectFmt("f64: 0.00000", "f64: {d:.5}", .{@as(f64, 1.40130e-45)});
     try expectFmt("f64: 0.00000", "f64: {d:.5}", .{@as(f64, 9.999960e-40)});
+    try expectFmt("f64: 10000000000000.00", "f64: {d:.2}", .{@as(f64, 9999999999999.999)});
 }
 
 test "float.libc.sanity" {

--- a/lib/std/fmt/errol.zig
+++ b/lib/std/fmt/errol.zig
@@ -92,7 +92,10 @@ pub fn errol3(value: f64, buffer: []u8) FloatDecimal {
         };
     }
 
-    return errol3u(value, buffer);
+    // We generate digits starting at index 1. If rounding a buffer later then it may be
+    // required to generate a preceding digit in some cases (9.999) in which case we use
+    // the 0-index for this extra digit.
+    return errol3u(value, buffer[1..]);
 }
 
 /// Uncorrected Errol3 double to ASCII conversion.
@@ -162,11 +165,7 @@ fn errol3u(val: f64, buffer: []u8) FloatDecimal {
     }
 
     // digit generation
-
-    // We generate digits starting at index 1. If rounding a buffer later then it may be
-    // required to generate a preceding digit in some cases (9.999) in which case we use
-    // the 0-index for this extra digit.
-    var buf_index: usize = 1;
+    var buf_index: usize = 0;
     while (true) {
         var hdig = @floatToInt(u8, math.floor(high.val));
         if ((high.val == @intToFloat(f64, hdig)) and (high.off < 0)) hdig -= 1;
@@ -192,7 +191,7 @@ fn errol3u(val: f64, buffer: []u8) FloatDecimal {
     buf_index += 1;
 
     return FloatDecimal{
-        .digits = buffer[1..buf_index],
+        .digits = buffer[0..buf_index],
         .exp = exp,
     };
 }


### PR DESCRIPTION
This commit fixes an out of bounds write that can occur when formatting certain float values. The write messes up the stack and causes incorrect results, segfaults, or nothing at all, depending on the optimization mode used.

The `errol` function writes the digits of the float into `buffer` starting from index 1, leaving index 0 untouched, and returns `buffer[1..]` and the exponent. This is because `roundToPrecision` relies on index 0 being unused in case the rounding adds a digit (e.g rounding 999.99 to 1000.00). When this happens, pointer arithmetic is used [here](https://github.com/ziglang/zig/blob/0e6d2184cacf2dd1fad7508b2f9ae99d78763148/lib/std/fmt/errol.zig#L61-L65) to access index 0 and put the ones digit in the right place.

However, `errol3u` contains two special cases: `errolInt` and `errolFixed`, which return from the function early. For these two special cases index 0 was never reserved, and the return value contains `buffer` instead of `buffer[1..]`. This causes the pointer arithmetic in `roundToPrecision` to write out of bounds, which in the case of `std.fmt.formatFloatDecimal` messes up the stack and causes undefined behavior.

The fix is to move the slicing of `buffer` to `buffer[1..]` from `errol3u` to `errol` so that both the default and the special cases operate on the sliced buffer.

## Example

I discovered this issue when I started getting segfaults in one of my projects after bumping the Zig version. After a lot of headscratching I managed to come up with the following minimal repro:

```zig
const std = @import("std");
const debug = std.debug;

fn foo() f64 {
    return 9999999999999.999;
}

pub fn main() !void {
    debug.print("{d:.2}\n", .{foo()});
    debug.print("{d:.2}\n", .{foo()}); // The second call is necessary for ReleaseFast to segfault!
}
```

The behavior of this example depends on the optimization modes:

- Debug/ReleaseSafe: returns the correct result (`"10000000000000.00"`).
- ReleaseSmall: if calling `debug.print` once, segfaults because the `context` pointer in `writer` is clobbered. If called twice, exits without printing anything.
- ReleaseFast: if called once, outputs the correct value. If called twice, segfaults due to `precision` being clobbered.
