### PR TITLE
fix std.process.argsAlloc buffer size

### DIFF
--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -557,9 +557,8 @@ pub fn argsAlloc(allocator: mem.Allocator) ![][:0]u8 {
 
     const contents_slice = contents.items;
     const slice_sizes = slice_list.items;
-    const contents_size_bytes = try math.add(usize, contents_slice.len, slice_sizes.len);
     const slice_list_bytes = try math.mul(usize, @sizeOf([]u8), slice_sizes.len);
-    const total_bytes = try math.add(usize, slice_list_bytes, contents_size_bytes);
+    const total_bytes = try math.add(usize, slice_list_bytes, contents_slice.len);
     const buf = try allocator.alignedAlloc(u8, @alignOf([]u8), total_bytes);
     errdefer allocator.free(buf);
 


### PR DESCRIPTION
The buffer allocated by `argsAlloc()` was allocating more bytes than needed. Since the buffer size is recalculated from the actual arguments length in `argsFree()`, a slice with a different length was passed to `allocator.free()`, triggering an error when using `std.heap.GeneralPurposeAllocator` with a large enough argument payload (>2048 bytes on my setup).

    
The buffer `buf` contains N (= `slice_sizes.len`) slices followed by the N null-terminated arguments. The N null-terminated arguments are stored in the `contents` array list. Thus, `buf` size should be:
```zig
@sizeOf([]u8) * slice_sizes.len + contents_slice.len
```
Instead of:
```zig
@sizeOf([]u8) * slice_sizes.len + contents_slice.len + slice_sizes.len
```