### PR TITLE
std: correct rounding in parse_hex_float.zig

### DIFF
--- a/lib/std/fmt/parse_hex_float.zig
+++ b/lib/std/fmt/parse_hex_float.zig
@@ -206,13 +206,11 @@ pub fn parseHexFloat(comptime T: type, s: []const u8) !T {
     //   - we've truncated more than 0.5ULP (R=S=1)
     //   - we've truncated exactly 0.5ULP (R=1 S=0)
     // Were are going to increase the mantissa (round up)
-    var exactly_half = (mantissa & 0b11) == 0b10;
-    var more_than_half = (mantissa & 0b11) == 0b11;
+    const guard_bit_and_half_or_more = (mantissa & 0b110) == 0b110;
     mantissa >>= 2;
-    var guardBit = mantissa & 1 == 1;
     exponent += 2;
 
-    if (guardBit and (exactly_half or more_than_half)) {
+    if (guard_bit_and_half_or_more) {
         mantissa += 1;
     }
 

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -632,11 +632,6 @@ test "allow signed integer division/remainder when values are comptime known and
 }
 
 test "quad hex float literal parsing accurate" {
-    if (builtin.zig_backend != .stage1) {
-        // TODO https://github.com/ziglang/zig/issues/10737
-        return error.SkipZigTest;
-    }
-
     const a: f128 = 0x1.1111222233334444555566667777p+0;
 
     // implied 1 is dropped, with an exponent of 0 (0x3fff) after biasing.


### PR DESCRIPTION
Addressing #10737, corrected the rounding logic in float128 parsing. Using [golang logic](https://github.com/golang/go/blob/a5c0b190809436fd196a348f85eca0416f4de7fe/src/strconv/atof.go#L528) (original source as the comment says) no longer produces the off-by-one error.