### PR TITLE
astgen: clean up source line calculation and management

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -375,6 +375,7 @@ pub const Decl = struct {
     src_node: Ast.Node.Index,
     /// Line number corresponding to `src_node`. Stored separately so that source files
     /// do not need to be loaded into memory in order to compute debug line numbers.
+    /// This value is absolute.
     src_line: u32,
     /// Index to ZIR `extra` array to the entry in the parent's decl structure
     /// (the part that says "for every decls_len"). The first item at this index is
@@ -4122,7 +4123,8 @@ fn scanDecl(iter: *ScanDeclIter, decl_sub_index: usize, flags: u4) SemaError!voi
     const has_linksection_or_addrspace = (flags & 0b1000) != 0;
     // zig fmt: on
 
-    const line = iter.parent_decl.relativeToLine(zir.extra[decl_sub_index + 4]);
+    const line_off = zir.extra[decl_sub_index + 4];
+    const line = iter.parent_decl.relativeToLine(line_off);
     const decl_name_index = zir.extra[decl_sub_index + 5];
     const decl_index = zir.extra[decl_sub_index + 6];
     const decl_block_inst_data = zir.instructions.items(.data)[decl_index].pl_node;

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2304,9 +2304,9 @@ pub const Inst = struct {
         body_len: u32,
 
         pub const SrcLocs = struct {
-            /// Absolute line index in the source file.
+            /// Line index in the source file relative to the parent decl.
             lbrace_line: u32,
-            /// Absolute line index in the source file.
+            /// Line index in the source file relative to the parent decl.
             rbrace_line: u32,
             /// lbrace_column is least significant bits u16
             /// rbrace_column is most significant bits u16

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2496,7 +2496,13 @@ pub fn updateFunc(self: *Elf, module: *Module, func: *Module.Fn, air: Air, liven
     defer deinitRelocs(self.base.allocator, &dbg_info_type_relocs);
 
     const decl = func.owner_decl;
-    const line_off = @intCast(u28, decl.src_line + func.lbrace_line);
+    log.debug("updateFunc {s}{*}", .{ decl.name, func.owner_decl });
+    log.debug("  (decl.src_line={d}, func.lbrace_line={d}, func.rbrace_line={d})", .{
+        decl.src_line,
+        func.lbrace_line,
+        func.rbrace_line,
+    });
+    const line = @intCast(u28, decl.src_line + func.lbrace_line);
 
     const ptr_width_bytes = self.ptrWidthBytes();
     dbg_line_buffer.appendSliceAssumeCapacity(&[_]u8{
@@ -2513,7 +2519,7 @@ pub fn updateFunc(self: *Elf, module: *Module, func: *Module.Fn, air: Air, liven
     // to this function's begin curly.
     assert(self.getRelocDbgLineOff() == dbg_line_buffer.items.len);
     // Here we use a ULEB128-fixed-4 to make sure this field can be overwritten later.
-    leb128.writeUnsignedFixed(4, dbg_line_buffer.addManyAsArrayAssumeCapacity(4), line_off);
+    leb128.writeUnsignedFixed(4, dbg_line_buffer.addManyAsArrayAssumeCapacity(4), line);
 
     dbg_line_buffer.appendAssumeCapacity(DW.LNS.set_file);
     assert(self.getRelocDbgFileIndex() == dbg_line_buffer.items.len);
@@ -3059,15 +3065,22 @@ pub fn updateDeclLineNumber(self: *Elf, module: *Module, decl: *const Module.Dec
     const tracy = trace(@src());
     defer tracy.end();
 
+    log.debug("updateDeclLineNumber {s}{*}", .{ decl.name, decl });
+
     if (self.llvm_object) |_| return;
 
     const func = decl.val.castTag(.function).?.data;
-    const casted_line_off = @intCast(u28, decl.src_line + func.lbrace_line);
+    log.debug("  (decl.src_line={d}, func.lbrace_line={d}, func.rbrace_line={d})", .{
+        decl.src_line,
+        func.lbrace_line,
+        func.rbrace_line,
+    });
+    const line = @intCast(u28, decl.src_line + func.lbrace_line);
 
     const shdr = &self.sections.items[self.debug_line_section_index.?];
     const file_pos = shdr.sh_offset + decl.fn_link.elf.off + self.getRelocDbgLineOff();
     var data: [4]u8 = undefined;
-    leb128.writeUnsignedFixed(4, &data, casted_line_off);
+    leb128.writeUnsignedFixed(4, &data, line);
     try self.base.file.?.pwriteAll(&data, file_pos);
 }
 


### PR DESCRIPTION
Clarify that `astgen.advanceSourceCursor` already increments absolute
values of the line and columns numbers; i.e., `GenZir.calcLine` is thus
not only obsolete but wrong by design.

Incidentally, this clean up allows for specifying the `FnDecl` line
numbers for DWARF use correctly as relative values with respect to
the start of the parent `Decl`. This `Decl` in turn has its line number
information specified relatively to its parent `Decl`, and so on, until
we reach the global scope.

Supersedes #10676 