### PR TITLE
std: adding RomuTrio RNG to Zig

### DIFF
--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -26,6 +26,7 @@ pub const Pcg = @import("rand/Pcg.zig");
 pub const Xoroshiro128 = @import("rand/Xoroshiro128.zig");
 pub const Xoshiro256 = @import("rand/Xoshiro256.zig");
 pub const Sfc64 = @import("rand/Sfc64.zig");
+pub const RomuTrio = @import("rand/RomuTrio.zig");
 
 pub const Random = struct {
     ptr: *anyopaque,

--- a/lib/std/rand/RomuTrio.zig
+++ b/lib/std/rand/RomuTrio.zig
@@ -1,0 +1,132 @@
+// Website: romu-random.org
+// Reference paper:   http://arxiv.org/abs/2002.11331
+// Beware: this PRNG is trivially predictable. While fast, it should *never* be used for cryptographic purposes.
+
+const std = @import("std");
+const Random = std.rand.Random;
+const math = std.math;
+const RomuTrio = @This();
+
+x_state: u64,
+y_state: u64,
+z_state: u64, // set to nonzero seed
+
+pub fn init(init_s: u64) RomuTrio {
+    var x = RomuTrio{ .x_state = undefined, .y_state = undefined, .z_state = undefined };
+    x.seed(init_s);
+    return x;
+}
+
+pub fn random(self: *RomuTrio) Random {
+    return Random.init(self, fill);
+}
+
+fn next(self: *RomuTrio) u64 {
+    const xp = self.x_state;
+    const yp = self.y_state;
+    const zp = self.z_state;
+    self.x_state = 15241094284759029579 *% zp;
+    self.y_state = yp -% xp;
+    self.y_state = std.math.rotl(u64, self.y_state, 12);
+    self.z_state = zp -% yp;
+    self.z_state = std.math.rotl(u64, self.z_state, 44);
+    return xp;
+}
+
+pub fn seedWithBuf(self: *RomuTrio, buf: [24]u8) void {
+    const seed_buf = @bitCast([3]u64, buf);
+    self.x_state = seed_buf[0];
+    self.y_state = seed_buf[1];
+    self.z_state = seed_buf[2];
+}
+
+pub fn seed(self: *RomuTrio, init_s: u64) void {
+    // RomuTrio requires 192-bits of seed.
+    var gen = std.rand.SplitMix64.init(init_s);
+
+    self.x_state = gen.next();
+    self.y_state = gen.next();
+    self.z_state = gen.next();
+}
+
+pub fn fill(self: *RomuTrio, buf: []u8) void {
+    var i: usize = 0;
+    const aligned_len = buf.len - (buf.len & 7);
+
+    // Complete 8 byte segments.
+    while (i < aligned_len) : (i += 8) {
+        var n = self.next();
+        comptime var j: usize = 0;
+        inline while (j < 8) : (j += 1) {
+            buf[i + j] = @truncate(u8, n);
+            n >>= 8;
+        }
+    }
+
+    // Remaining. (cuts the stream)
+    if (i != buf.len) {
+        var n = self.next();
+        while (i < buf.len) : (i += 1) {
+            buf[i] = @truncate(u8, n);
+            n >>= 8;
+        }
+    }
+}
+
+test "RomuTrio sequence" {
+    // Unfortunately there does not seem to be an official test sequence.
+    var r = RomuTrio.init(0);
+
+    const seq = [_]u64{
+        16294208416658607535,
+        13964609475759908645,
+        4703697494102998476,
+        3425221541186733346,
+        2285772463536419399,
+        9454187757529463048,
+        13695907680080547496,
+        8328236714879408626,
+        12323357569716880909,
+        12375466223337721820,
+    };
+
+    for (seq) |s| {
+        try std.testing.expectEqual(s, r.next());
+    }
+}
+
+test "RomuTrio fill" {
+    // Unfortunately there does not seem to be an official test sequence.
+    var r = RomuTrio.init(0);
+
+    const seq = [_]u64{
+        16294208416658607535,
+        13964609475759908645,
+        4703697494102998476,
+        3425221541186733346,
+        2285772463536419399,
+        9454187757529463048,
+        13695907680080547496,
+        8328236714879408626,
+        12323357569716880909,
+        12375466223337721820,
+    };
+
+    for (seq) |s| {
+        var buf0: [8]u8 = undefined;
+        var buf1: [7]u8 = undefined;
+        std.mem.writeIntLittle(u64, &buf0, s);
+        r.fill(&buf1);
+        try std.testing.expect(std.mem.eql(u8, buf0[0..7], buf1[0..]));
+    }
+}
+
+test "RomuTrio buf seeding test" {
+    const buf0 = [24]u8{ 175, 205, 29, 123, 57, 168, 32, 226, 37, 39, 185, 157, 84, 66, 204, 193, 204, 125, 231, 26, 243, 227, 70, 65 };
+    const resulting_state = .{ .x = 16294208416658607535, .y = 13964609475759908645, .z = 4703697494102998476 };
+    var r = RomuTrio.init(0);
+    r.seedWithBuf(buf0);
+    try std.testing.expect(r.x_state == resulting_state.x);
+    try std.testing.expect(r.y_state == resulting_state.y);
+    try std.testing.expect(r.z_state == resulting_state.z);
+}


### PR DESCRIPTION
this is an implementation of [Romu-rng](https://www.romu-random.org/romupaper.pdf).

I tested this RNG in some research code of mine and it improves performance substantially without compromising results (while I noticed some biases with the smallest Xoroshiro).

There is some controversy regarding this RNG family (mostly theoretical arguments) but empirically this RNG is proven to be exceptionally good.

Francesco

------- added buffered benchmark --

```zig
on Mac M1 Air 2020

-------- TESTING BUF [64]u8
rng:        Romu192    time minimum 6.9940 ms;  time maximum 7.3120 ms;
rng:     Xoshiro256    time minimum 8.3250 ms;  time maximum 8.5200 ms;
rng:          Sfc64    time minimum 13.3090 ms;  time maximum 13.7180 ms;
rng:   Xoroshiro128    time minimum 12.6660 ms;  time maximum 12.7310 ms;
rng:            Pcg    time minimum 16.6220 ms;  time maximum 16.6960 ms;
-------- TESTING BUF [128]u8
rng:        Romu192    time minimum 13.3800 ms;  time maximum 13.7570 ms;
rng:     Xoshiro256    time minimum 17.8500 ms;  time maximum 18.3760 ms;
rng:          Sfc64    time minimum 16.3480 ms;  time maximum 16.7290 ms;
rng:   Xoroshiro128    time minimum 25.0390 ms;  time maximum 25.5200 ms;
rng:            Pcg    time minimum 33.3030 ms;  time maximum 33.7300 ms;
-------- TESTING BUF [256]u8
rng:        Romu192    time minimum 26.8540 ms;  time maximum 27.0120 ms;
rng:     Xoshiro256    time minimum 35.7290 ms;  time maximum 36.5140 ms;
rng:          Sfc64    time minimum 32.0140 ms;  time maximum 32.3860 ms;
rng:   Xoroshiro128    time minimum 50.0900 ms;  time maximum 50.6170 ms;
rng:            Pcg    time minimum 66.7040 ms;  time maximum 67.0500 ms;
-------- TESTING BUF [512]u8
rng:        Romu192    time minimum 53.8040 ms;  time maximum 54.4070 ms;
rng:     Xoshiro256    time minimum 71.6470 ms;  time maximum 72.2740 ms;
rng:          Sfc64    time minimum 95.8960 ms;  time maximum 96.4480 ms;
rng:   Xoroshiro128    time minimum 100.3050 ms;  time maximum 102.8360 ms;
rng:            Pcg    time minimum 133.8940 ms;  time maximum 134.3190 ms;
-------- TESTING BUF [137]u8
rng:        Romu192    time minimum 15.5610 ms;  time maximum 15.9290 ms;
rng:     Xoshiro256    time minimum 20.1840 ms;  time maximum 20.5610 ms;
rng:          Sfc64    time minimum 24.8630 ms;  time maximum 25.1870 ms;
rng:   Xoroshiro128    time minimum 28.2710 ms;  time maximum 28.7210 ms;
rng:            Pcg    time minimum 34.2720 ms;  time maximum 34.6240 ms;
-------- TESTING BUF [277]u8
rng:        Romu192    time minimum 30.4900 ms;  time maximum 30.8370 ms;
rng:     Xoshiro256    time minimum 39.4700 ms;  time maximum 39.7890 ms;
rng:          Sfc64    time minimum 48.0680 ms;  time maximum 48.6400 ms;
rng:   Xoroshiro128    time minimum 55.0160 ms;  time maximum 55.3480 ms;
rng:            Pcg    time minimum 68.1490 ms;  time maximum 68.5410 ms;
-------- TESTING BUF [497]u8
rng:        Romu192    time minimum 52.4180 ms;  time maximum 52.8140 ms;
rng:     Xoshiro256    time minimum 68.5960 ms;  time maximum 69.6380 ms;
rng:          Sfc64    time minimum 86.3800 ms;  time maximum 86.7680 ms;
rng:   Xoroshiro128    time minimum 98.7140 ms;  time maximum 106.2700 ms;
rng:            Pcg    time minimum 122.7280 ms;  time maximum 124.0430 ms;

On OS: Linux (x86_64-pc-linux-gnu)  CPU: AMD Ryzen 7 4700U with Radeon Graphics

-------- TESTING BUF [64]u8
rng:        Romu192    time minimum 8.6315 ms;  time maximum 8.7183 ms;
rng:     Xoshiro256    time minimum 9.1984 ms;  time maximum 9.2284 ms;
rng:          Sfc64    time minimum 17.5599 ms;  time maximum 17.6318 ms;
rng:   Xoroshiro128    time minimum 12.8833 ms;  time maximum 12.9547 ms;
rng:            Pcg    time minimum 27.0608 ms;  time maximum 27.1868 ms;
-------- TESTING BUF [128]u8
rng:        Romu192    time minimum 37.4872 ms;  time maximum 38.9835 ms;
rng:     Xoshiro256    time minimum 26.9969 ms;  time maximum 34.9097 ms;
rng:          Sfc64    time minimum 31.0459 ms;  time maximum 31.1009 ms;
rng:   Xoroshiro128    time minimum 25.0730 ms;  time maximum 25.1417 ms;
rng:            Pcg    time minimum 32.1322 ms;  time maximum 32.1972 ms;
-------- TESTING BUF [256]u8
rng:        Romu192    time minimum 46.1221 ms;  time maximum 46.2384 ms;
rng:     Xoshiro256    time minimum 53.7923 ms;  time maximum 53.9084 ms;
rng:          Sfc64    time minimum 61.6676 ms;  time maximum 61.7641 ms;
rng:   Xoroshiro128    time minimum 49.9532 ms;  time maximum 50.0272 ms;
rng:            Pcg    time minimum 65.3041 ms;  time maximum 66.3564 ms;
-------- TESTING BUF [512]u8
rng:        Romu192    time minimum 92.0510 ms;  time maximum 92.1681 ms;
rng:     Xoshiro256    time minimum 111.7199 ms;  time maximum 112.2481 ms;
rng:          Sfc64    time minimum 107.3704 ms;  time maximum 107.4942 ms;
rng:   Xoroshiro128    time minimum 99.6814 ms;  time maximum 99.8514 ms;
rng:            Pcg    time minimum 129.1609 ms;  time maximum 129.6407 ms;
-------- TESTING BUF [137]u8
rng:        Romu192    time minimum 25.0819 ms;  time maximum 25.1507 ms;
rng:     Xoshiro256    time minimum 29.3857 ms;  time maximum 29.4477 ms;
rng:          Sfc64    time minimum 29.2849 ms;  time maximum 29.3260 ms;
rng:   Xoroshiro128    time minimum 27.3558 ms;  time maximum 27.4143 ms;
rng:            Pcg    time minimum 35.1998 ms;  time maximum 35.3434 ms;
-------- TESTING BUF [277]u8
rng:        Romu192    time minimum 49.9756 ms;  time maximum 51.1119 ms;
rng:     Xoshiro256    time minimum 58.3561 ms;  time maximum 58.4289 ms;
rng:          Sfc64    time minimum 58.0889 ms;  time maximum 58.1751 ms;
rng:   Xoroshiro128    time minimum 54.2740 ms;  time maximum 54.3497 ms;
rng:            Pcg    time minimum 69.3251 ms;  time maximum 69.5570 ms;
-------- TESTING BUF [497]u8
rng:        Romu192    time minimum 89.6752 ms;  time maximum 89.7666 ms;
rng:     Xoshiro256    time minimum 104.7192 ms;  time maximum 104.8414 ms;
rng:          Sfc64    time minimum 105.1792 ms;  time maximum 105.3909 ms;
rng:   Xoroshiro128    time minimum 97.3344 ms;  time maximum 97.4398 ms;
rng:            Pcg    time minimum 126.5300 ms;  time maximum 126.6182 ms;

```

------- added microbenchmark ------

output on Mac M1 Air 2020
```zig
rng:        Romu192    time 9.8170 ms; result = 0.99995
rng:     Xoshiro256    time 13.6650 ms; result = 1.00005
rng:          Sfc64    time 15.3970 ms; result = 1.00036
rng:   Xoroshiro128    time 18.1640 ms; result = 0.99994
rng:            Pcg    time 29.5900 ms; result = 0.99972
```
output on   OS: Linux (x86_64-pc-linux-gnu)
  CPU: AMD Ryzen 7 4700U with Radeon Graphics
  WORD_SIZE: 64
```zig
rng:        Romu192    time 15.0481 ms; result = 0.99995
rng:     Xoshiro256    time 20.0626 ms; result = 1.00005
rng:          Sfc64    time 21.1309 ms; result = 1.00036
rng:   Xoroshiro128    time 20.6466 ms; result = 0.99994
rng:            Pcg    time 52.2123 ms; result = 0.99972
```


code

```zig
const std = @import("std");
const Romu192 = @import("Romu192.zig");

pub fn main() !void {
    const MAXITERS = 10000000;
    const MAXBESTTIME_NS = 100000000000;
    const rngs = .{ Romu192, std.rand.Xoshiro256, std.rand.Sfc64, std.rand.Xoroshiro128, std.rand.Pcg };
    inline for (rngs) |rng_struct| {
        var besttime: i128 = MAXBESTTIME_NS;
        var k: usize = 0;
        var j: u64 = 0;
        while (k < 50) : (k += 1) {
            var i: usize = 0;
            const rng = rng_struct.init(123).random();
            j = 0;
            const t0 = std.time.nanoTimestamp();
            while (i < MAXITERS) : (i += 1) {
                j = j + (rng.uintAtMostBiased(u64, 0xd33db33f) & 2);
            }
            const t1 = std.time.nanoTimestamp();
            besttime = std.math.min(besttime, t1 - t0);
        }
        const result = @intToFloat(f64, j) / MAXITERS;
        const btime_ms = @intToFloat(f64, besttime) / 1e6;
        std.debug.print("rng:{any:15}    time {d:.4} ms; result = {d:.5}\n", .{ rng_struct, btime_ms, result });
    }
}
```


buffered version of the benchmark confirms results:

```zig
const std = @import("std");
const Romu192 = @import("Romu192.zig");

pub fn main() !void {
    const buf_lens = .{ 64, 128, 256, 512, 137, 277, 497 };
    const fill_iterations = 1000000;
    const MAXBESTTIME_NS = 100000000000;
    const rngs = .{ Romu192, std.rand.Xoshiro256, std.rand.Sfc64, std.rand.Xoroshiro128, std.rand.Pcg };

    inline for (buf_lens) |blen| {
        std.debug.print("-------- TESTING BUF [{}]u8\n", .{blen});

        inline for (rngs) |rng_struct| {
            var besttime: i128 = MAXBESTTIME_NS;
            var worsttime: i128 = 0;
            var k: usize = 0;
            while (k < 50) : (k += 1) {
                const rng = rng_struct.init(123).random();
                const t0 = std.time.nanoTimestamp();
                var buf: [blen]u8 = undefined;
                var q: usize = 0;
                while (q < fill_iterations) : (q += 1) {
                    rng.bytes(&buf);
                }
                std.mem.doNotOptimizeAway(buf);

                const t1 = std.time.nanoTimestamp();
                if (k>10) { 
                    // 10 warmup steps per generator
                    besttime = std.math.min(besttime, t1 - t0);
                    worsttime = std.math.max(worsttime, t1 - t0);
                }
            }
            const btime_ms = @intToFloat(f64, besttime) / 1e6;
            const wtime_ms = @intToFloat(f64, worsttime) / 1e6;
            std.debug.print("rng:{any:15}    time minimum {d:.4} ms;  time maximum {d:.4} ms;\n", .{ rng_struct, btime_ms, wtime_ms });
        }
    }
}
```