### PR TITLE
compiler_rt: Implement atomic operations and __eabi_read_tp for ARM older than v7.

### DIFF
--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -520,6 +520,137 @@ comptime {
         if (os_tag == .linux) {
             const __aeabi_read_tp = @import("compiler_rt/arm.zig").__aeabi_read_tp;
             @export(__aeabi_read_tp, .{ .name = "__aeabi_read_tp", .linkage = linkage });
+
+            const __sync_synchronize = @import("compiler_rt/arm.zig").__sync_synchronize;
+            @export(__sync_synchronize, .{ .name = "__sync_synchronize", .linkage = linkage });
+
+            if (arch.endian() == .Little) {
+                const __sync_val_compare_and_swap_1 = @import("compiler_rt/arm.zig").__sync_val_compare_and_swap_1;
+                @export(__sync_val_compare_and_swap_1, .{ .name = "__sync_val_compare_and_swap_1", .linkage = linkage });
+                const __sync_val_compare_and_swap_2 = @import("compiler_rt/arm.zig").__sync_val_compare_and_swap_2;
+                @export(__sync_val_compare_and_swap_2, .{ .name = "__sync_val_compare_and_swap_2", .linkage = linkage });
+                const __sync_val_compare_and_swap_4 = @import("compiler_rt/arm.zig").__sync_val_compare_and_swap_4;
+                @export(__sync_val_compare_and_swap_4, .{ .name = "__sync_val_compare_and_swap_4", .linkage = linkage });
+
+                const __sync_add_and_fetch_1 = @import("compiler_rt/arm.zig").__sync_add_and_fetch_1;
+                @export(__sync_add_and_fetch_1, .{ .name = "__sync_add_and_fetch_1", .linkage = linkage });
+                const __sync_add_and_fetch_2 = @import("compiler_rt/arm.zig").__sync_add_and_fetch_2;
+                @export(__sync_add_and_fetch_2, .{ .name = "__sync_add_and_fetch_2", .linkage = linkage });
+                const __sync_add_and_fetch_4 = @import("compiler_rt/arm.zig").__sync_add_and_fetch_4;
+                @export(__sync_add_and_fetch_4, .{ .name = "__sync_add_and_fetch_4", .linkage = linkage });
+
+                const __sync_sub_and_fetch_1 = @import("compiler_rt/arm.zig").__sync_sub_and_fetch_1;
+                @export(__sync_sub_and_fetch_1, .{ .name = "__sync_sub_and_fetch_1", .linkage = linkage });
+                const __sync_sub_and_fetch_2 = @import("compiler_rt/arm.zig").__sync_sub_and_fetch_2;
+                @export(__sync_sub_and_fetch_2, .{ .name = "__sync_sub_and_fetch_2", .linkage = linkage });
+                const __sync_sub_and_fetch_4 = @import("compiler_rt/arm.zig").__sync_sub_and_fetch_4;
+                @export(__sync_sub_and_fetch_4, .{ .name = "__sync_sub_and_fetch_4", .linkage = linkage });
+
+                const __sync_or_and_fetch_1 = @import("compiler_rt/arm.zig").__sync_or_and_fetch_1;
+                @export(__sync_or_and_fetch_1, .{ .name = "__sync_or_and_fetch_1", .linkage = linkage });
+                const __sync_or_and_fetch_2 = @import("compiler_rt/arm.zig").__sync_or_and_fetch_2;
+                @export(__sync_or_and_fetch_2, .{ .name = "__sync_or_and_fetch_2", .linkage = linkage });
+                const __sync_or_and_fetch_4 = @import("compiler_rt/arm.zig").__sync_or_and_fetch_4;
+                @export(__sync_or_and_fetch_4, .{ .name = "__sync_or_and_fetch_4", .linkage = linkage });
+
+                const __sync_and_and_fetch_1 = @import("compiler_rt/arm.zig").__sync_and_and_fetch_1;
+                @export(__sync_and_and_fetch_1, .{ .name = "__sync_and_and_fetch_1", .linkage = linkage });
+                const __sync_and_and_fetch_2 = @import("compiler_rt/arm.zig").__sync_and_and_fetch_2;
+                @export(__sync_and_and_fetch_2, .{ .name = "__sync_and_and_fetch_2", .linkage = linkage });
+                const __sync_and_and_fetch_4 = @import("compiler_rt/arm.zig").__sync_and_and_fetch_4;
+                @export(__sync_and_and_fetch_4, .{ .name = "__sync_and_and_fetch_4", .linkage = linkage });
+
+                const __sync_xor_and_fetch_1 = @import("compiler_rt/arm.zig").__sync_xor_and_fetch_1;
+                @export(__sync_xor_and_fetch_1, .{ .name = "__sync_xor_and_fetch_1", .linkage = linkage });
+                const __sync_xor_and_fetch_2 = @import("compiler_rt/arm.zig").__sync_xor_and_fetch_2;
+                @export(__sync_xor_and_fetch_2, .{ .name = "__sync_xor_and_fetch_2", .linkage = linkage });
+                const __sync_xor_and_fetch_4 = @import("compiler_rt/arm.zig").__sync_xor_and_fetch_4;
+                @export(__sync_xor_and_fetch_4, .{ .name = "__sync_xor_and_fetch_4", .linkage = linkage });
+
+                const __sync_nand_and_fetch_1 = @import("compiler_rt/arm.zig").__sync_nand_and_fetch_1;
+                @export(__sync_nand_and_fetch_1, .{ .name = "__sync_nand_and_fetch_1", .linkage = linkage });
+                const __sync_nand_and_fetch_2 = @import("compiler_rt/arm.zig").__sync_nand_and_fetch_2;
+                @export(__sync_nand_and_fetch_2, .{ .name = "__sync_nand_and_fetch_2", .linkage = linkage });
+                const __sync_nand_and_fetch_4 = @import("compiler_rt/arm.zig").__sync_nand_and_fetch_4;
+                @export(__sync_nand_and_fetch_4, .{ .name = "__sync_nand_and_fetch_4", .linkage = linkage });
+
+                const __sync_fetch_and_add_1 = @import("compiler_rt/arm.zig").__sync_fetch_and_add_1;
+                @export(__sync_fetch_and_add_1, .{ .name = "__sync_fetch_and_add_1", .linkage = linkage });
+                const __sync_fetch_and_add_2 = @import("compiler_rt/arm.zig").__sync_fetch_and_add_2;
+                @export(__sync_fetch_and_add_2, .{ .name = "__sync_fetch_and_add_2", .linkage = linkage });
+                const __sync_fetch_and_add_4 = @import("compiler_rt/arm.zig").__sync_fetch_and_add_4;
+                @export(__sync_fetch_and_add_4, .{ .name = "__sync_fetch_and_add_4", .linkage = linkage });
+
+                const __sync_fetch_and_sub_1 = @import("compiler_rt/arm.zig").__sync_fetch_and_sub_1;
+                @export(__sync_fetch_and_sub_1, .{ .name = "__sync_fetch_and_sub_1", .linkage = linkage });
+                const __sync_fetch_and_sub_2 = @import("compiler_rt/arm.zig").__sync_fetch_and_sub_2;
+                @export(__sync_fetch_and_sub_2, .{ .name = "__sync_fetch_and_sub_2", .linkage = linkage });
+                const __sync_fetch_and_sub_4 = @import("compiler_rt/arm.zig").__sync_fetch_and_sub_4;
+                @export(__sync_fetch_and_sub_4, .{ .name = "__sync_fetch_and_sub_4", .linkage = linkage });
+
+                const __sync_fetch_and_or_1 = @import("compiler_rt/arm.zig").__sync_fetch_and_or_1;
+                @export(__sync_fetch_and_or_1, .{ .name = "__sync_fetch_and_or_1", .linkage = linkage });
+                const __sync_fetch_and_or_2 = @import("compiler_rt/arm.zig").__sync_fetch_and_or_2;
+                @export(__sync_fetch_and_or_2, .{ .name = "__sync_fetch_and_or_2", .linkage = linkage });
+                const __sync_fetch_and_or_4 = @import("compiler_rt/arm.zig").__sync_fetch_and_or_4;
+                @export(__sync_fetch_and_or_4, .{ .name = "__sync_fetch_and_or_4", .linkage = linkage });
+
+                const __sync_fetch_and_and_1 = @import("compiler_rt/arm.zig").__sync_fetch_and_and_1;
+                @export(__sync_fetch_and_and_1, .{ .name = "__sync_fetch_and_and_1", .linkage = linkage });
+                const __sync_fetch_and_and_2 = @import("compiler_rt/arm.zig").__sync_fetch_and_and_2;
+                @export(__sync_fetch_and_and_2, .{ .name = "__sync_fetch_and_and_2", .linkage = linkage });
+                const __sync_fetch_and_and_4 = @import("compiler_rt/arm.zig").__sync_fetch_and_and_4;
+                @export(__sync_fetch_and_and_4, .{ .name = "__sync_fetch_and_and_4", .linkage = linkage });
+
+                const __sync_fetch_and_xor_1 = @import("compiler_rt/arm.zig").__sync_fetch_and_xor_1;
+                @export(__sync_fetch_and_xor_1, .{ .name = "__sync_fetch_and_xor_1", .linkage = linkage });
+                const __sync_fetch_and_xor_2 = @import("compiler_rt/arm.zig").__sync_fetch_and_xor_2;
+                @export(__sync_fetch_and_xor_2, .{ .name = "__sync_fetch_and_xor_2", .linkage = linkage });
+                const __sync_fetch_and_xor_4 = @import("compiler_rt/arm.zig").__sync_fetch_and_xor_4;
+                @export(__sync_fetch_and_xor_4, .{ .name = "__sync_fetch_and_xor_4", .linkage = linkage });
+
+                const __sync_fetch_and_nand_1 = @import("compiler_rt/arm.zig").__sync_fetch_and_nand_1;
+                @export(__sync_fetch_and_nand_1, .{ .name = "__sync_fetch_and_nand_1", .linkage = linkage });
+                const __sync_fetch_and_nand_2 = @import("compiler_rt/arm.zig").__sync_fetch_and_nand_2;
+                @export(__sync_fetch_and_nand_2, .{ .name = "__sync_fetch_and_nand_2", .linkage = linkage });
+                const __sync_fetch_and_nand_4 = @import("compiler_rt/arm.zig").__sync_fetch_and_nand_4;
+                @export(__sync_fetch_and_nand_4, .{ .name = "__sync_fetch_and_nand_4", .linkage = linkage });
+
+                const __sync_fetch_and_max_1 = @import("compiler_rt/arm.zig").__sync_fetch_and_max_1;
+                @export(__sync_fetch_and_max_1, .{ .name = "__sync_fetch_and_max_1", .linkage = linkage });
+                const __sync_fetch_and_max_2 = @import("compiler_rt/arm.zig").__sync_fetch_and_max_2;
+                @export(__sync_fetch_and_max_2, .{ .name = "__sync_fetch_and_max_2", .linkage = linkage });
+                const __sync_fetch_and_max_4 = @import("compiler_rt/arm.zig").__sync_fetch_and_max_4;
+                @export(__sync_fetch_and_max_4, .{ .name = "__sync_fetch_and_max_4", .linkage = linkage });
+
+                const __sync_fetch_and_umax_1 = @import("compiler_rt/arm.zig").__sync_fetch_and_umax_1;
+                @export(__sync_fetch_and_umax_1, .{ .name = "__sync_fetch_and_umax_1", .linkage = linkage });
+                const __sync_fetch_and_umax_2 = @import("compiler_rt/arm.zig").__sync_fetch_and_umax_2;
+                @export(__sync_fetch_and_umax_2, .{ .name = "__sync_fetch_and_umax_2", .linkage = linkage });
+                const __sync_fetch_and_umax_4 = @import("compiler_rt/arm.zig").__sync_fetch_and_umax_4;
+                @export(__sync_fetch_and_umax_4, .{ .name = "__sync_fetch_and_umax_4", .linkage = linkage });
+
+                const __sync_fetch_and_min_1 = @import("compiler_rt/arm.zig").__sync_fetch_and_min_1;
+                @export(__sync_fetch_and_min_1, .{ .name = "__sync_fetch_and_min_1", .linkage = linkage });
+                const __sync_fetch_and_min_2 = @import("compiler_rt/arm.zig").__sync_fetch_and_min_2;
+                @export(__sync_fetch_and_min_2, .{ .name = "__sync_fetch_and_min_2", .linkage = linkage });
+                const __sync_fetch_and_min_4 = @import("compiler_rt/arm.zig").__sync_fetch_and_min_4;
+                @export(__sync_fetch_and_min_4, .{ .name = "__sync_fetch_and_min_4", .linkage = linkage });
+
+                const __sync_fetch_and_umin_1 = @import("compiler_rt/arm.zig").__sync_fetch_and_umin_1;
+                @export(__sync_fetch_and_umin_1, .{ .name = "__sync_fetch_and_umin_1", .linkage = linkage });
+                const __sync_fetch_and_umin_2 = @import("compiler_rt/arm.zig").__sync_fetch_and_umin_2;
+                @export(__sync_fetch_and_umin_2, .{ .name = "__sync_fetch_and_umin_2", .linkage = linkage });
+                const __sync_fetch_and_umin_4 = @import("compiler_rt/arm.zig").__sync_fetch_and_umin_4;
+                @export(__sync_fetch_and_umin_4, .{ .name = "__sync_fetch_and_umin_4", .linkage = linkage });
+
+                const __sync_lock_test_and_set_1 = @import("compiler_rt/arm.zig").__sync_lock_test_and_set_1;
+                @export(__sync_lock_test_and_set_1, .{ .name = "__sync_lock_test_and_set_1", .linkage = linkage });
+                const __sync_lock_test_and_set_2 = @import("compiler_rt/arm.zig").__sync_lock_test_and_set_2;
+                @export(__sync_lock_test_and_set_2, .{ .name = "__sync_lock_test_and_set_2", .linkage = linkage });
+                const __sync_lock_test_and_set_4 = @import("compiler_rt/arm.zig").__sync_lock_test_and_set_4;
+                @export(__sync_lock_test_and_set_4, .{ .name = "__sync_lock_test_and_set_4", .linkage = linkage });
+            }
         }
 
         const __aeabi_f2d = @import("compiler_rt/extendXfYf2.zig").__aeabi_f2d;

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -384,18 +384,6 @@ fn posixCallMainAndExit() noreturn {
             std.os.linux.pie.relocate(phdrs);
         }
 
-        // ARMv6 targets (and earlier) have no support for TLS in hardware.
-        // FIXME: Elide the check for targets >= ARMv7 when the target feature API
-        // becomes less verbose (and more usable).
-        if (comptime native_arch.isARM()) {
-            if (at_hwcap & std.os.linux.HWCAP.TLS == 0) {
-                // FIXME: Make __aeabi_read_tp call the kernel helper kuser_get_tls
-                // For the time being use a simple abort instead of a @panic call to
-                // keep the binary bloat under control.
-                std.os.abort();
-            }
-        }
-
         // Initialize the TLS area.
         std.os.linux.tls.initStaticTLS(phdrs);
 


### PR DESCRIPTION
This PR implements most of the builtins from https://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html.
I omitted big-endian support and: 
- `__sync_lock_release`
- `__sync_bool_compare_and_swap`
I also implemented additional ones that i found in the LLVM test cases:
- `__sync_fetch_and_max`
- `__sync_fetch_and_umax`
- `__sync_fetch_and_min`
- `__sync_fetch_and_umin`

And also added support for thumb2 and <ARMv6 in `__aeabi_read_tp` using the `kuser_get_tls` helper