### PR TITLE
deprecate TypeInfo in favor of Type

### DIFF
--- a/lib/std/bit_set.zig
+++ b/lib/std/bit_set.zig
@@ -252,7 +252,7 @@ pub fn IntegerBitSet(comptime size: u16) type {
 /// This set is good for sets with a larger size, but may use
 /// more bytes than necessary if your set is small.
 pub fn ArrayBitSet(comptime MaskIntType: type, comptime size: usize) type {
-    const mask_info: std.builtin.TypeInfo = @typeInfo(MaskIntType);
+    const mask_info: std.builtin.Type = @typeInfo(MaskIntType);
 
     // Make sure the mask int is indeed an int
     if (mask_info != .Int) @compileError("ArrayBitSet can only operate on integer masks, but was passed " ++ @typeName(MaskIntType));

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -174,12 +174,14 @@ pub const SourceLocation = struct {
     column: u32,
 };
 
-pub const TypeId = std.meta.Tag(TypeInfo);
+pub const TypeId = std.meta.Tag(Type);
+
+/// TODO deprecated, use `Type`
+pub const TypeInfo = Type;
 
 /// This data structure is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
-/// TODO: rename to `Type` because "info" is redundant.
-pub const TypeInfo = union(enum) {
+pub const Type = union(enum) {
     Type: void,
     Void: void,
     Bool: void,

--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -3,14 +3,14 @@
 const std = @import("std.zig");
 const assert = std.debug.assert;
 const testing = std.testing;
-const EnumField = std.builtin.TypeInfo.EnumField;
+const EnumField = std.builtin.Type.EnumField;
 
 /// Returns a struct with a field matching each unique named enum element.
 /// If the enum is extern and has multiple names for the same value, only
 /// the first name is used.  Each field is of type Data and has the provided
 /// default, which may be undefined.
 pub fn EnumFieldStruct(comptime E: type, comptime Data: type, comptime field_default: ?Data) type {
-    const StructField = std.builtin.TypeInfo.StructField;
+    const StructField = std.builtin.Type.StructField;
     var fields: []const StructField = &[_]StructField{};
     for (std.meta.fields(E)) |field| {
         fields = fields ++ &[_]StructField{.{
@@ -24,7 +24,7 @@ pub fn EnumFieldStruct(comptime E: type, comptime Data: type, comptime field_def
     return @Type(.{ .Struct = .{
         .layout = .Auto,
         .fields = fields,
-        .decls = &[_]std.builtin.TypeInfo.Declaration{},
+        .decls = &.{},
         .is_tuple = false,
     } });
 }

--- a/lib/std/hash/auto_hash.zig
+++ b/lib/std/hash/auto_hash.zig
@@ -233,7 +233,7 @@ fn testHashDeepRecursive(key: anytype) u64 {
 
 test "typeContainsSlice" {
     comptime {
-        try testing.expect(!typeContainsSlice(meta.Tag(std.builtin.TypeInfo)));
+        try testing.expect(!typeContainsSlice(meta.Tag(std.builtin.Type)));
 
         try testing.expect(typeContainsSlice([]const u8));
         try testing.expect(!typeContainsSlice(u8));

--- a/lib/std/io/fixed_buffer_stream.zig
+++ b/lib/std/io/fixed_buffer_stream.zig
@@ -120,7 +120,7 @@ pub fn fixedBufferStream(buffer: anytype) FixedBufferStream(NonSentinelSpan(@Typ
 fn NonSentinelSpan(comptime T: type) type {
     var ptr_info = @typeInfo(mem.Span(T)).Pointer;
     ptr_info.sentinel = null;
-    return @Type(std.builtin.TypeInfo{ .Pointer = ptr_info });
+    return @Type(.{ .Pointer = ptr_info });
 }
 
 test "FixedBufferStream output" {

--- a/lib/std/io/reader.zig
+++ b/lib/std/io/reader.zig
@@ -314,7 +314,7 @@ pub fn Reader(
 
         pub fn readStruct(self: Self, comptime T: type) !T {
             // Only extern and packed structs have defined in-memory layout.
-            comptime assert(@typeInfo(T).Struct.layout != std.builtin.TypeInfo.ContainerLayout.Auto);
+            comptime assert(@typeInfo(T).Struct.layout != .Auto);
             var res: [1]T = undefined;
             try self.readNoEof(mem.sliceAsBytes(res[0..]));
             return res[0];

--- a/lib/std/io/writer.zig
+++ b/lib/std/io/writer.zig
@@ -84,7 +84,7 @@ pub fn Writer(
 
         pub fn writeStruct(self: Self, value: anytype) Error!void {
             // Only extern and packed structs have defined in-memory layout.
-            comptime assert(@typeInfo(@TypeOf(value)).Struct.layout != std.builtin.TypeInfo.ContainerLayout.Auto);
+            comptime assert(@typeInfo(@TypeOf(value)).Struct.layout != .Auto);
             return self.writeAll(mem.asBytes(&value));
         }
     };

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -138,11 +138,10 @@ const AggregateContainerType = enum(u1) { object, array };
 fn AggregateContainerStack(comptime n: usize) type {
     return struct {
         const Self = @This();
-        const TypeInfo = std.builtin.TypeInfo;
 
         const element_bitcount = 8 * @sizeOf(usize);
         const element_count = n / element_bitcount;
-        const ElementType = @Type(TypeInfo{ .Int = TypeInfo.Int{ .signedness = .unsigned, .bits = element_bitcount } });
+        const ElementType = @Type(.{ .Int = .{ .signedness = .unsigned, .bits = element_bitcount } });
         const ElementShiftAmountType = std.math.Log2Int(ElementType);
 
         comptime {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -608,7 +608,7 @@ pub fn Span(comptime T: type) type {
                 .Many, .Slice => {},
             }
             new_ptr_info.size = .Slice;
-            return @Type(std.builtin.TypeInfo{ .Pointer = new_ptr_info });
+            return @Type(.{ .Pointer = new_ptr_info });
         },
         else => @compileError("invalid type given to std.mem.Span"),
     }
@@ -720,7 +720,7 @@ fn SliceTo(comptime T: type, comptime end: meta.Elem(T)) type {
                     new_ptr_info.is_allowzero = false;
                 },
             }
-            return @Type(std.builtin.TypeInfo{ .Pointer = new_ptr_info });
+            return @Type(.{ .Pointer = new_ptr_info });
         },
         else => {},
     }
@@ -2588,7 +2588,7 @@ test "alignPointer" {
 
 fn CopyPtrAttrs(
     comptime source: type,
-    comptime size: std.builtin.TypeInfo.Pointer.Size,
+    comptime size: std.builtin.Type.Pointer.Size,
     comptime child: type,
 ) type {
     const info = @typeInfo(source).Pointer;

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -8,7 +8,7 @@ const root = @import("root");
 pub const trait = @import("meta/trait.zig");
 pub const TrailerFlags = @import("meta/trailer_flags.zig").TrailerFlags;
 
-const TypeInfo = std.builtin.TypeInfo;
+const Type = std.builtin.Type;
 
 pub fn tagName(v: anytype) []const u8 {
     const T = @TypeOf(v);
@@ -335,7 +335,7 @@ test "std.meta.assumeSentinel" {
     try testing.expect(?[*:0]u8 == @TypeOf(assumeSentinel(@as(?[*]u8, undefined), 0)));
 }
 
-pub fn containerLayout(comptime T: type) TypeInfo.ContainerLayout {
+pub fn containerLayout(comptime T: type) Type.ContainerLayout {
     return switch (@typeInfo(T)) {
         .Struct => |info| info.layout,
         .Enum => |info| info.layout,
@@ -370,9 +370,9 @@ test "std.meta.containerLayout" {
     try testing.expect(containerLayout(U3) == .Extern);
 }
 
-/// Instead of this function, prefer to use e.g. `@TypeInfo(foo).Struct.decls`
+/// Instead of this function, prefer to use e.g. `@typeInfo(foo).Struct.decls`
 /// directly when you know what kind of type it is.
-pub fn declarations(comptime T: type) []const TypeInfo.Declaration {
+pub fn declarations(comptime T: type) []const Type.Declaration {
     return switch (@typeInfo(T)) {
         .Struct => |info| info.decls,
         .Enum => |info| info.decls,
@@ -400,7 +400,7 @@ test "std.meta.declarations" {
         fn a() void {}
     };
 
-    const decls = comptime [_][]const TypeInfo.Declaration{
+    const decls = comptime [_][]const Type.Declaration{
         declarations(E1),
         declarations(S1),
         declarations(U1),
@@ -413,7 +413,7 @@ test "std.meta.declarations" {
     }
 }
 
-pub fn declarationInfo(comptime T: type, comptime decl_name: []const u8) TypeInfo.Declaration {
+pub fn declarationInfo(comptime T: type, comptime decl_name: []const u8) Type.Declaration {
     inline for (comptime declarations(T)) |decl| {
         if (comptime mem.eql(u8, decl.name, decl_name))
             return decl;
@@ -437,7 +437,7 @@ test "std.meta.declarationInfo" {
         fn a() void {}
     };
 
-    const infos = comptime [_]TypeInfo.Declaration{
+    const infos = comptime [_]Type.Declaration{
         declarationInfo(E1, "a"),
         declarationInfo(S1, "a"),
         declarationInfo(U1, "a"),
@@ -450,10 +450,10 @@ test "std.meta.declarationInfo" {
 }
 
 pub fn fields(comptime T: type) switch (@typeInfo(T)) {
-    .Struct => []const TypeInfo.StructField,
-    .Union => []const TypeInfo.UnionField,
-    .ErrorSet => []const TypeInfo.Error,
-    .Enum => []const TypeInfo.EnumField,
+    .Struct => []const Type.StructField,
+    .Union => []const Type.UnionField,
+    .ErrorSet => []const Type.Error,
+    .Enum => []const Type.EnumField,
     else => @compileError("Expected struct, union, error set or enum type, found '" ++ @typeName(T) ++ "'"),
 } {
     return switch (@typeInfo(T)) {
@@ -495,10 +495,10 @@ test "std.meta.fields" {
 }
 
 pub fn fieldInfo(comptime T: type, comptime field: FieldEnum(T)) switch (@typeInfo(T)) {
-    .Struct => TypeInfo.StructField,
-    .Union => TypeInfo.UnionField,
-    .ErrorSet => TypeInfo.Error,
-    .Enum => TypeInfo.EnumField,
+    .Struct => Type.StructField,
+    .Union => Type.UnionField,
+    .ErrorSet => Type.Error,
+    .Enum => Type.EnumField,
     else => @compileError("Expected struct, union, error set or enum type, found '" ++ @typeName(T) ++ "'"),
 } {
     return fields(T)[@enumToInt(field)];
@@ -570,8 +570,8 @@ test "std.meta.fieldNames" {
 
 pub fn FieldEnum(comptime T: type) type {
     const fieldInfos = fields(T);
-    var enumFields: [fieldInfos.len]std.builtin.TypeInfo.EnumField = undefined;
-    var decls = [_]std.builtin.TypeInfo.Declaration{};
+    var enumFields: [fieldInfos.len]std.builtin.Type.EnumField = undefined;
+    var decls = [_]std.builtin.Type.Declaration{};
     inline for (fieldInfos) |field, i| {
         enumFields[i] = .{
             .name = field.name,
@@ -594,8 +594,8 @@ fn expectEqualEnum(expected: anytype, actual: @TypeOf(expected)) !void {
     // testing.expectEqual(@typeInfo(expected).Enum, @typeInfo(actual).Enum);
     try testing.expectEqual(@typeInfo(expected).Enum.layout, @typeInfo(actual).Enum.layout);
     try testing.expectEqual(@typeInfo(expected).Enum.tag_type, @typeInfo(actual).Enum.tag_type);
-    comptime try testing.expectEqualSlices(std.builtin.TypeInfo.EnumField, @typeInfo(expected).Enum.fields, @typeInfo(actual).Enum.fields);
-    comptime try testing.expectEqualSlices(std.builtin.TypeInfo.Declaration, @typeInfo(expected).Enum.decls, @typeInfo(actual).Enum.decls);
+    comptime try testing.expectEqualSlices(std.builtin.Type.EnumField, @typeInfo(expected).Enum.fields, @typeInfo(actual).Enum.fields);
+    comptime try testing.expectEqualSlices(std.builtin.Type.Declaration, @typeInfo(expected).Enum.decls, @typeInfo(actual).Enum.decls);
     try testing.expectEqual(@typeInfo(expected).Enum.is_exhaustive, @typeInfo(actual).Enum.is_exhaustive);
 }
 
@@ -607,8 +607,8 @@ test "std.meta.FieldEnum" {
 
 pub fn DeclEnum(comptime T: type) type {
     const fieldInfos = std.meta.declarations(T);
-    var enumDecls: [fieldInfos.len]std.builtin.TypeInfo.EnumField = undefined;
-    var decls = [_]std.builtin.TypeInfo.Declaration{};
+    var enumDecls: [fieldInfos.len]std.builtin.Type.EnumField = undefined;
+    var decls = [_]std.builtin.Type.Declaration{};
     inline for (fieldInfos) |field, i| {
         enumDecls[i] = .{ .name = field.name, .value = i };
     }
@@ -909,7 +909,7 @@ pub fn declList(comptime Namespace: type, comptime Decl: type) []const *const De
 pub const IntType = @compileError("replaced by std.meta.Int");
 
 pub fn Int(comptime signedness: std.builtin.Signedness, comptime bit_count: u16) type {
-    return @Type(TypeInfo{
+    return @Type(.{
         .Int = .{
             .signedness = signedness,
             .bits = bit_count,
@@ -918,7 +918,7 @@ pub fn Int(comptime signedness: std.builtin.Signedness, comptime bit_count: u16)
 }
 
 pub fn Float(comptime bit_count: u8) type {
-    return @Type(TypeInfo{
+    return @Type(.{
         .Float = .{ .bits = bit_count },
     });
 }
@@ -931,7 +931,7 @@ test "std.meta.Float" {
 }
 
 pub fn Vector(comptime len: u32, comptime child: type) type {
-    return @Type(TypeInfo{
+    return @Type(.{
         .Vector = .{
             .len = len,
             .child = child,
@@ -957,12 +957,12 @@ pub fn ArgsTuple(comptime Function: type) type {
     if (function_info.is_var_args)
         @compileError("Cannot create ArgsTuple for variadic function");
 
-    var argument_field_list: [function_info.args.len]std.builtin.TypeInfo.StructField = undefined;
+    var argument_field_list: [function_info.args.len]std.builtin.Type.StructField = undefined;
     inline for (function_info.args) |arg, i| {
         const T = arg.arg_type.?;
         @setEvalBranchQuota(10_000);
         var num_buf: [128]u8 = undefined;
-        argument_field_list[i] = std.builtin.TypeInfo.StructField{
+        argument_field_list[i] = .{
             .name = std.fmt.bufPrint(&num_buf, "{d}", .{i}) catch unreachable,
             .field_type = T,
             .default_value = @as(?T, null),
@@ -971,11 +971,11 @@ pub fn ArgsTuple(comptime Function: type) type {
         };
     }
 
-    return @Type(std.builtin.TypeInfo{
-        .Struct = std.builtin.TypeInfo.Struct{
+    return @Type(.{
+        .Struct = .{
             .is_tuple = true,
             .layout = .Auto,
-            .decls = &[_]std.builtin.TypeInfo.Declaration{},
+            .decls = &.{},
             .fields = &argument_field_list,
         },
     });
@@ -989,11 +989,11 @@ pub fn ArgsTuple(comptime Function: type) type {
 /// - `Tuple(&[_]type {f32})` ⇒ `tuple { f32 }`
 /// - `Tuple(&[_]type {f32,u32})` ⇒ `tuple { f32, u32 }`
 pub fn Tuple(comptime types: []const type) type {
-    var tuple_fields: [types.len]std.builtin.TypeInfo.StructField = undefined;
+    var tuple_fields: [types.len]std.builtin.Type.StructField = undefined;
     inline for (types) |T, i| {
         @setEvalBranchQuota(10_000);
         var num_buf: [128]u8 = undefined;
-        tuple_fields[i] = std.builtin.TypeInfo.StructField{
+        tuple_fields[i] = .{
             .name = std.fmt.bufPrint(&num_buf, "{d}", .{i}) catch unreachable,
             .field_type = T,
             .default_value = @as(?T, null),
@@ -1002,11 +1002,11 @@ pub fn Tuple(comptime types: []const type) type {
         };
     }
 
-    return @Type(std.builtin.TypeInfo{
-        .Struct = std.builtin.TypeInfo.Struct{
+    return @Type(.{
+        .Struct = .{
             .is_tuple = true,
             .layout = .Auto,
-            .decls = &[_]std.builtin.TypeInfo.Declaration{},
+            .decls = &.{},
             .fields = &tuple_fields,
         },
     });

--- a/lib/std/meta/trailer_flags.zig
+++ b/lib/std/meta/trailer_flags.zig
@@ -3,7 +3,7 @@ const meta = std.meta;
 const testing = std.testing;
 const mem = std.mem;
 const assert = std.debug.assert;
-const TypeInfo = std.builtin.TypeInfo;
+const Type = std.builtin.Type;
 
 /// This is useful for saving memory when allocating an object that has many
 /// optional components. The optional objects are allocated sequentially in
@@ -19,9 +19,9 @@ pub fn TrailerFlags(comptime Fields: type) type {
         pub const FieldEnum = std.meta.FieldEnum(Fields);
 
         pub const InitStruct = blk: {
-            comptime var fields: [bit_count]TypeInfo.StructField = undefined;
+            comptime var fields: [bit_count]Type.StructField = undefined;
             inline for (@typeInfo(Fields).Struct.fields) |struct_field, i| {
-                fields[i] = TypeInfo.StructField{
+                fields[i] = Type.StructField{
                     .name = struct_field.name,
                     .field_type = ?struct_field.field_type,
                     .default_value = @as(
@@ -36,7 +36,7 @@ pub fn TrailerFlags(comptime Fields: type) type {
                 .Struct = .{
                     .layout = .Auto,
                     .fields = &fields,
-                    .decls = &[_]TypeInfo.Declaration{},
+                    .decls = &.{},
                     .is_tuple = false,
                 },
             });

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -1961,7 +1961,7 @@ fn fullPtrType(tree: Ast, info: full.PtrType.Components) full.PtrType {
     const token_tags = tree.tokens.items(.tag);
     // TODO: looks like stage1 isn't quite smart enough to handle enum
     // literals in some places here
-    const Size = std.builtin.TypeInfo.Pointer.Size;
+    const Size = std.builtin.Type.Pointer.Size;
     const size: Size = switch (token_tags[info.main_token]) {
         .asterisk,
         .asterisk_asterisk,
@@ -2392,7 +2392,7 @@ pub const full = struct {
     };
 
     pub const PtrType = struct {
-        size: std.builtin.TypeInfo.Pointer.Size,
+        size: std.builtin.Type.Pointer.Size,
         allowzero_token: ?TokenIndex,
         const_token: ?TokenIndex,
         volatile_token: ?TokenIndex,

--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -88,7 +88,7 @@ fn castToPtr(comptime DestType: type, comptime SourceType: type, target: anytype
     return @as(DestType, target);
 }
 
-fn ptrInfo(comptime PtrType: type) std.builtin.TypeInfo.Pointer {
+fn ptrInfo(comptime PtrType: type) std.builtin.Type.Pointer {
     return switch (@typeInfo(PtrType)) {
         .Optional => |opt_info| @typeInfo(opt_info.child).Pointer,
         .Pointer => |ptr_info| ptr_info,

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -3940,7 +3940,7 @@ fn structDeclInner(
     scope: *Scope,
     node: Ast.Node.Index,
     container_decl: Ast.full.ContainerDecl,
-    layout: std.builtin.TypeInfo.ContainerLayout,
+    layout: std.builtin.Type.ContainerLayout,
 ) InnerError!Zir.Inst.Ref {
     const decl_inst = try gz.reserveInstructionIndex();
 
@@ -4076,7 +4076,7 @@ fn unionDeclInner(
     scope: *Scope,
     node: Ast.Node.Index,
     members: []const Ast.Node.Index,
-    layout: std.builtin.TypeInfo.ContainerLayout,
+    layout: std.builtin.Type.ContainerLayout,
     arg_node: Ast.Node.Index,
     have_auto_enum: bool,
 ) InnerError!Zir.Inst.Ref {
@@ -4242,10 +4242,10 @@ fn containerDecl(
     switch (token_tags[container_decl.ast.main_token]) {
         .keyword_struct => {
             const layout = if (container_decl.layout_token) |t| switch (token_tags[t]) {
-                .keyword_packed => std.builtin.TypeInfo.ContainerLayout.Packed,
-                .keyword_extern => std.builtin.TypeInfo.ContainerLayout.Extern,
+                .keyword_packed => std.builtin.Type.ContainerLayout.Packed,
+                .keyword_extern => std.builtin.Type.ContainerLayout.Extern,
                 else => unreachable,
-            } else std.builtin.TypeInfo.ContainerLayout.Auto;
+            } else std.builtin.Type.ContainerLayout.Auto;
 
             assert(container_decl.ast.arg == 0);
 
@@ -4254,10 +4254,10 @@ fn containerDecl(
         },
         .keyword_union => {
             const layout = if (container_decl.layout_token) |t| switch (token_tags[t]) {
-                .keyword_packed => std.builtin.TypeInfo.ContainerLayout.Packed,
-                .keyword_extern => std.builtin.TypeInfo.ContainerLayout.Extern,
+                .keyword_packed => std.builtin.Type.ContainerLayout.Packed,
+                .keyword_extern => std.builtin.Type.ContainerLayout.Extern,
                 else => unreachable,
-            } else std.builtin.TypeInfo.ContainerLayout.Auto;
+            } else std.builtin.Type.ContainerLayout.Auto;
 
             const have_auto_enum = container_decl.ast.enum_token != null;
 
@@ -10495,7 +10495,7 @@ const GenZir = struct {
         body_len: u32,
         fields_len: u32,
         decls_len: u32,
-        layout: std.builtin.TypeInfo.ContainerLayout,
+        layout: std.builtin.Type.ContainerLayout,
         known_non_opv: bool,
         known_comptime_only: bool,
     }) !void {
@@ -10543,7 +10543,7 @@ const GenZir = struct {
         body_len: u32,
         fields_len: u32,
         decls_len: u32,
-        layout: std.builtin.TypeInfo.ContainerLayout,
+        layout: std.builtin.Type.ContainerLayout,
         auto_enum_tag: bool,
     }) !void {
         const astgen = gz.astgen;

--- a/src/InternArena.zig
+++ b/src/InternArena.zig
@@ -30,7 +30,7 @@ pub const Key = union(enum) {
         elem_type: Index,
         sentinel: Index,
         alignment: u16,
-        size: std.builtin.TypeInfo.Pointer.Size,
+        size: std.builtin.Type.Pointer.Size,
         is_const: bool,
         is_volatile: bool,
         is_allowzero: bool,

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -853,7 +853,7 @@ pub const Struct = struct {
     /// Index of the struct_decl ZIR instruction.
     zir_index: Zir.Inst.Index,
 
-    layout: std.builtin.TypeInfo.ContainerLayout,
+    layout: std.builtin.Type.ContainerLayout,
     status: enum {
         none,
         field_types_wip,
@@ -1105,7 +1105,7 @@ pub const Union = struct {
     /// Index of the union_decl ZIR instruction.
     zir_index: Zir.Inst.Index,
 
-    layout: std.builtin.TypeInfo.ContainerLayout,
+    layout: std.builtin.Type.ContainerLayout,
     status: enum {
         none,
         field_types_wip,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -10068,7 +10068,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
     const inst_data = sema.code.instructions.items(.data)[inst].un_node;
     const src = inst_data.src();
     const ty = try sema.resolveType(block, src, inst_data.operand);
-    const type_info_ty = try sema.getBuiltinType(block, src, "TypeInfo");
+    const type_info_ty = try sema.getBuiltinType(block, src, "Type");
     const target = sema.mod.getTarget();
 
     switch (ty.zigTypeTag()) {
@@ -10413,7 +10413,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
                 break :v try Value.Tag.opt_payload.create(sema.arena, slice_val);
             } else Value.@"null";
 
-            // Construct TypeInfo{ .ErrorSet = errors_val }
+            // Construct Type{ .ErrorSet = errors_val }
             return sema.addConstant(
                 type_info_ty,
                 try Value.Tag.@"union".create(sema.arena, .{
@@ -10516,7 +10516,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
                 // layout: ContainerLayout,
                 try Value.Tag.enum_field_index.create(
                     sema.arena,
-                    @enumToInt(std.builtin.TypeInfo.ContainerLayout.Auto),
+                    @enumToInt(std.builtin.Type.ContainerLayout.Auto),
                 ),
 
                 // tag_type: type,
@@ -12186,7 +12186,7 @@ fn zirTagName(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
 fn zirReify(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].un_node;
     const src = inst_data.src();
-    const type_info_ty = try sema.resolveBuiltinTypeFields(block, src, "TypeInfo");
+    const type_info_ty = try sema.resolveBuiltinTypeFields(block, src, "Type");
     const uncasted_operand = sema.resolveInst(inst_data.operand);
     const operand_src: LazySrcLoc = .{ .node_offset_builtin_call_arg0 = inst_data.src_node };
     const type_info = try sema.coerce(block, type_info_ty, uncasted_operand, operand_src);
@@ -12265,7 +12265,7 @@ fn zirReify(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.I
             var buffer: Value.ToTypeBuffer = undefined;
             const child_ty = child_val.toType(&buffer);
 
-            const ptr_size = size_val.toEnum(std.builtin.TypeInfo.Pointer.Size);
+            const ptr_size = size_val.toEnum(std.builtin.Type.Pointer.Size);
 
             var actual_sentinel: ?Value = null;
             if (!sentinel_val.isNull()) {
@@ -18850,7 +18850,7 @@ fn resolveTypeFields(sema: *Sema, block: *Block, src: LazySrcLoc, ty: Type) Comp
             try sema.resolveTypeFieldsUnion(block, src, ty, union_obj);
             return ty;
         },
-        .type_info => return sema.resolveBuiltinTypeFields(block, src, "TypeInfo"),
+        .type_info => return sema.resolveBuiltinTypeFields(block, src, "Type"),
         .extern_options => return sema.resolveBuiltinTypeFields(block, src, "ExternOptions"),
         .export_options => return sema.resolveBuiltinTypeFields(block, src, "ExportOptions"),
         .atomic_order => return sema.resolveBuiltinTypeFields(block, src, "AtomicOrder"),

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2157,7 +2157,7 @@ pub const Inst = struct {
             is_allowzero: bool,
             is_mutable: bool,
             is_volatile: bool,
-            size: std.builtin.TypeInfo.Pointer.Size,
+            size: std.builtin.Type.Pointer.Size,
             elem_type: Ref,
         },
         ptr_type: struct {
@@ -2171,7 +2171,7 @@ pub const Inst = struct {
                 has_bit_range: bool,
                 _: u1 = undefined,
             },
-            size: std.builtin.TypeInfo.Pointer.Size,
+            size: std.builtin.Type.Pointer.Size,
             /// Index into extra. See `PtrType`.
             payload_index: u32,
         },
@@ -2659,7 +2659,7 @@ pub const Inst = struct {
             known_non_opv: bool,
             known_comptime_only: bool,
             name_strategy: NameStrategy,
-            layout: std.builtin.TypeInfo.ContainerLayout,
+            layout: std.builtin.Type.ContainerLayout,
             _: u6 = undefined,
         };
     };
@@ -2778,7 +2778,7 @@ pub const Inst = struct {
             has_fields_len: bool,
             has_decls_len: bool,
             name_strategy: NameStrategy,
-            layout: std.builtin.TypeInfo.ContainerLayout,
+            layout: std.builtin.Type.ContainerLayout,
             /// has_tag_type | auto_enum_tag | result
             /// -------------------------------------
             ///    false     | false         |  union { }

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -17971,7 +17971,7 @@ static void ensure_field_index(ZigType *type, const char *field_name, size_t ind
 
 static ZigType *ir_type_info_get_type(IrAnalyze *ira, const char *type_name, ZigType *root) {
     Error err;
-    ZigType *type_info_type = get_builtin_type(ira->codegen, "TypeInfo");
+    ZigType *type_info_type = get_builtin_type(ira->codegen, "Type");
     assert(type_info_type->id == ZigTypeIdUnion);
     if ((err = type_resolve(ira->codegen, type_info_type, ResolveStatusSizeKnown))) {
         zig_unreachable();
@@ -18403,7 +18403,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, Scope *scope, AstNode *sour
                 fields[1]->special = ConstValSpecialStatic;
                 fields[1]->type = g->builtin_types.entry_type;
                 fields[1]->data.x_type = type_entry->data.enumeration.tag_int_type;
-                // fields: []TypeInfo.EnumField
+                // fields: []Type.EnumField
                 ensure_field_index(result->type, "fields", 2);
 
                 ZigType *type_info_enum_field_type = ir_type_info_get_type(ira, "EnumField", nullptr);
@@ -18429,7 +18429,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, Scope *scope, AstNode *sour
                     enum_field_val->parent.data.p_array.array_val = enum_field_array;
                     enum_field_val->parent.data.p_array.elem_index = enum_field_index;
                 }
-                // decls: []TypeInfo.Declaration
+                // decls: []Type.Declaration
                 ensure_field_index(result->type, "decls", 3);
                 if ((err = ir_make_type_info_decls(ira, source_node, fields[3],
                             type_entry->data.enumeration.decls_scope, false)))
@@ -18553,7 +18553,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, Scope *scope, AstNode *sour
                 } else {
                     fields[1]->data.x_optional = nullptr;
                 }
-                // fields: []TypeInfo.UnionField
+                // fields: []Type.UnionField
                 ensure_field_index(result->type, "fields", 2);
 
                 ZigType *type_info_union_field_type = ir_type_info_get_type(ira, "UnionField", nullptr);
@@ -18595,7 +18595,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, Scope *scope, AstNode *sour
                     union_field_val->parent.data.p_array.array_val = union_field_array;
                     union_field_val->parent.data.p_array.elem_index = union_field_index;
                 }
-                // decls: []TypeInfo.Declaration
+                // decls: []Type.Declaration
                 ensure_field_index(result->type, "decls", 3);
                 if ((err = ir_make_type_info_decls(ira, source_node, fields[3],
                                 type_entry->data.unionation.decls_scope, false)))
@@ -18629,7 +18629,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, Scope *scope, AstNode *sour
                 fields[0]->special = ConstValSpecialStatic;
                 fields[0]->type = ir_type_info_get_type(ira, "ContainerLayout", nullptr);
                 bigint_init_unsigned(&fields[0]->data.x_enum_tag, type_entry->data.structure.layout);
-                // fields: []TypeInfo.StructField
+                // fields: []Type.StructField
                 ensure_field_index(result->type, "fields", 1);
 
                 ZigType *type_info_struct_field_type = ir_type_info_get_type(ira, "StructField", nullptr);
@@ -18690,7 +18690,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, Scope *scope, AstNode *sour
                     struct_field_val->parent.data.p_array.array_val = struct_field_array;
                     struct_field_val->parent.data.p_array.elem_index = struct_field_index;
                 }
-                // decls: []TypeInfo.Declaration
+                // decls: []Type.Declaration
                 ensure_field_index(result->type, "decls", 2);
                 if ((err = ir_make_type_info_decls(ira, source_node, fields[2],
                                 type_entry->data.structure.decls_scope, false)))
@@ -18715,7 +18715,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, Scope *scope, AstNode *sour
                 ZigValue **fields = alloc_const_vals_ptrs(g, 7);
                 result->data.x_struct.fields = fields;
 
-                // calling_convention: TypeInfo.CallingConvention
+                // calling_convention: Type.CallingConvention
                 ensure_field_index(result->type, "calling_convention", 0);
                 fields[0]->special = ConstValSpecialStatic;
                 fields[0]->type = get_builtin_type(g, "CallingConvention");
@@ -18750,7 +18750,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, Scope *scope, AstNode *sour
                     return_type->data.x_type = type_entry->data.fn.fn_type_id.return_type;
                     fields[4]->data.x_optional = return_type;
                 }
-                // args: []TypeInfo.Fn.Param
+                // args: []Type.Fn.Param
                 ZigType *type_info_fn_arg_type = ir_type_info_get_type(ira, "Param", result->type);
                 if ((err = type_resolve(g, type_info_fn_arg_type, ResolveStatusSizeKnown))) {
                     zig_unreachable();
@@ -18821,7 +18821,7 @@ static Error ir_make_type_info_value(IrAnalyze *ira, Scope *scope, AstNode *sour
                 ZigValue **fields = alloc_const_vals_ptrs(g, 1);
                 result->data.x_struct.fields = fields;
 
-                // decls: []TypeInfo.Declaration
+                // decls: []Type.Declaration
                 ensure_field_index(result->type, "decls", 0);
                 if ((err = ir_make_type_info_decls(ira, source_node, fields[0],
                             type_entry->data.opaque.decls_scope, false)))
@@ -19194,7 +19194,7 @@ static ZigType *type_info_to_type(IrAnalyze *ira, Scope *scope, AstNode *source_
             ZigValue *decls_len_value = decls_value->data.x_struct.fields[slice_len_index];
             size_t decls_len = bigint_as_usize(&decls_len_value->data.x_bigint);
             if (decls_len != 0) {
-                ir_add_error_node(ira, source_node, buf_create_from_str("TypeInfo.Struct.decls must be empty for @Type"));
+                ir_add_error_node(ira, source_node, buf_create_from_str("Type.Struct.decls must be empty for @Type"));
                 return ira->codegen->invalid_inst_gen->value->type;
             }
 
@@ -19311,7 +19311,7 @@ static ZigType *type_info_to_type(IrAnalyze *ira, Scope *scope, AstNode *source_
             ZigValue *decls_len_value = decls_value->data.x_struct.fields[slice_len_index];
             size_t decls_len = bigint_as_usize(&decls_len_value->data.x_bigint);
             if (decls_len != 0) {
-                ir_add_error_node(ira, source_node, buf_create_from_str("TypeInfo.Struct.decls must be empty for @Type"));
+                ir_add_error_node(ira, source_node, buf_create_from_str("Type.Struct.decls must be empty for @Type"));
                 return ira->codegen->invalid_inst_gen->value->type;
             }
 
@@ -19395,7 +19395,7 @@ static ZigType *type_info_to_type(IrAnalyze *ira, Scope *scope, AstNode *source_
                 return ira->codegen->invalid_inst_gen->value->type;
             if (tag_type->id != ZigTypeIdInt) {
                 ir_add_error_node(ira, source_node, buf_sprintf(
-                    "TypeInfo.Enum.tag_type must be an integer type, not '%s'", buf_ptr(&tag_type->name)));
+                    "Type.Enum.tag_type must be an integer type, not '%s'", buf_ptr(&tag_type->name)));
                 return ira->codegen->invalid_inst_gen->value->type;
             }
 
@@ -19418,7 +19418,7 @@ static ZigType *type_info_to_type(IrAnalyze *ira, Scope *scope, AstNode *source_
             ZigValue *decls_len_value = decls_value->data.x_struct.fields[slice_len_index];
             size_t decls_len = bigint_as_usize(&decls_len_value->data.x_bigint);
             if (decls_len != 0) {
-                ir_add_error_node(ira, source_node, buf_create_from_str("TypeInfo.Enum.decls must be empty for @Type"));
+                ir_add_error_node(ira, source_node, buf_create_from_str("Type.Enum.decls must be empty for @Type"));
                 return ira->codegen->invalid_inst_gen->value->type;
             }
 
@@ -19505,7 +19505,7 @@ static ZigType *type_info_to_type(IrAnalyze *ira, Scope *scope, AstNode *source_
             ZigValue *decls_len_value = decls_value->data.x_struct.fields[slice_len_index];
             size_t decls_len = bigint_as_usize(&decls_len_value->data.x_bigint);
             if (decls_len != 0) {
-                ir_add_error_node(ira, source_node, buf_create_from_str("TypeInfo.Union.decls must be empty for @Type"));
+                ir_add_error_node(ira, source_node, buf_create_from_str("Type.Union.decls must be empty for @Type"));
                 return ira->codegen->invalid_inst_gen->value->type;
             }
 
@@ -19571,7 +19571,7 @@ static ZigType *type_info_to_type(IrAnalyze *ira, Scope *scope, AstNode *source_
             if ((err = get_const_field_bool(ira, source_node, payload, "is_generic", 2, &is_generic)))
                 return ira->codegen->invalid_inst_gen->value->type;
             if (is_generic) {
-                ir_add_error_node(ira, source_node, buf_sprintf("TypeInfo.Fn.is_generic must be false for @Type"));
+                ir_add_error_node(ira, source_node, buf_sprintf("Type.Fn.is_generic must be false for @Type"));
                 return ira->codegen->invalid_inst_gen->value->type;
             }
 
@@ -19585,7 +19585,7 @@ static ZigType *type_info_to_type(IrAnalyze *ira, Scope *scope, AstNode *source_
 
             ZigType *return_type = get_const_field_meta_type_optional(ira, source_node, payload, "return_type", 4);
             if (return_type == nullptr) {
-                ir_add_error_node(ira, source_node, buf_sprintf("TypeInfo.Fn.return_type must be non-null for @Type"));
+                ir_add_error_node(ira, source_node, buf_sprintf("Type.Fn.return_type must be non-null for @Type"));
                 return ira->codegen->invalid_inst_gen->value->type;
             }
 
@@ -19620,7 +19620,7 @@ static ZigType *type_info_to_type(IrAnalyze *ira, Scope *scope, AstNode *source_
                 if ((err = get_const_field_bool(ira, source_node, arg_value, "is_generic", 0, &is_generic)))
                     return ira->codegen->invalid_inst_gen->value->type;
                 if (is_generic) {
-                    ir_add_error_node(ira, source_node, buf_sprintf("TypeInfo.Fn.Param.is_generic must be false for @Type"));
+                    ir_add_error_node(ira, source_node, buf_sprintf("Type.Fn.Param.is_generic must be false for @Type"));
                     return ira->codegen->invalid_inst_gen->value->type;
                 }
                 if ((err = get_const_field_bool(ira, source_node, arg_value, "is_noalias", 1, &info->is_noalias)))
@@ -19628,7 +19628,7 @@ static ZigType *type_info_to_type(IrAnalyze *ira, Scope *scope, AstNode *source_
                 ZigType *type = get_const_field_meta_type_optional(
                     ira, source_node, arg_value, "arg_type", 2);
                 if (type == nullptr) {
-                    ir_add_error_node(ira, source_node, buf_sprintf("TypeInfo.Fn.Param.arg_type must be non-null for @Type"));
+                    ir_add_error_node(ira, source_node, buf_sprintf("Type.Fn.Param.arg_type must be non-null for @Type"));
                     return ira->codegen->invalid_inst_gen->value->type;
                 }
                 info->type = type;

--- a/src/type.zig
+++ b/src/type.zig
@@ -1527,7 +1527,7 @@ pub const Type = extern union {
                 .prefetch_options => return writer.writeAll("std.builtin.PrefetchOptions"),
                 .export_options => return writer.writeAll("std.builtin.ExportOptions"),
                 .extern_options => return writer.writeAll("std.builtin.ExternOptions"),
-                .type_info => return writer.writeAll("std.builtin.TypeInfo"),
+                .type_info => return writer.writeAll("std.builtin.Type"),
                 .function => {
                     const payload = ty.castTag(.function).?.data;
                     try writer.writeAll("fn(");
@@ -1866,7 +1866,7 @@ pub const Type = extern union {
             .prefetch_options => return "PrefetchOptions",
             .export_options => return "ExportOptions",
             .extern_options => return "ExternOptions",
-            .type_info => return "TypeInfo",
+            .type_info => return "Type",
 
             else => {
                 // TODO this is wasteful and also an incorrect implementation of `@typeName`
@@ -2856,7 +2856,7 @@ pub const Type = extern union {
     }
 
     /// Asserts the `Type` is a pointer.
-    pub fn ptrSize(self: Type) std.builtin.TypeInfo.Pointer.Size {
+    pub fn ptrSize(self: Type) std.builtin.Type.Pointer.Size {
         return switch (self.tag()) {
             .const_slice,
             .mut_slice,
@@ -3392,7 +3392,7 @@ pub const Type = extern union {
         }
     }
 
-    pub fn containerLayout(ty: Type) std.builtin.TypeInfo.ContainerLayout {
+    pub fn containerLayout(ty: Type) std.builtin.Type.ContainerLayout {
         return switch (ty.tag()) {
             .tuple, .empty_struct_literal, .anon_struct => .Auto,
             .@"struct" => ty.castTag(.@"struct").?.data.layout,
@@ -5165,7 +5165,7 @@ pub const Type = extern union {
                 @"allowzero": bool = false,
                 mutable: bool = true, // TODO rename this to const, not mutable
                 @"volatile": bool = false,
-                size: std.builtin.TypeInfo.Pointer.Size = .One,
+                size: std.builtin.Type.Pointer.Size = .One,
             };
         };
 

--- a/src/value.zig
+++ b/src/value.zig
@@ -673,7 +673,7 @@ pub const Value = extern union {
             .prefetch_options_type => return out_stream.writeAll("std.builtin.PrefetchOptions"),
             .export_options_type => return out_stream.writeAll("std.builtin.ExportOptions"),
             .extern_options_type => return out_stream.writeAll("std.builtin.ExternOptions"),
-            .type_info_type => return out_stream.writeAll("std.builtin.TypeInfo"),
+            .type_info_type => return out_stream.writeAll("std.builtin.Type"),
             .abi_align_default => return out_stream.writeAll("(default ABI alignment)"),
 
             .empty_struct_value => return out_stream.writeAll("struct {}{}"),

--- a/test/behavior/bugs/1421.zig
+++ b/test/behavior/bugs/1421.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const expect = std.testing.expect;
 
 const S = struct {
-    fn method() std.builtin.TypeInfo {
+    fn method() std.builtin.Type {
         return @typeInfo(S);
     }
 };

--- a/test/behavior/bugs/6456.zig
+++ b/test/behavior/bugs/6456.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const testing = std.testing;
-const StructField = std.builtin.TypeInfo.StructField;
-const Declaration = std.builtin.TypeInfo.Declaration;
+const StructField = std.builtin.Type.StructField;
+const Declaration = std.builtin.Type.Declaration;
 
 const text =
     \\f1

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -125,23 +125,23 @@ test "tuple initializer for var" {
 test "array-like initializer for tuple types" {
     if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
 
-    const T = @Type(std.builtin.TypeInfo{
-        .Struct = std.builtin.TypeInfo.Struct{
+    const T = @Type(.{
+        .Struct = .{
             .is_tuple = true,
             .layout = .Auto,
-            .decls = &[_]std.builtin.TypeInfo.Declaration{},
-            .fields = &[_]std.builtin.TypeInfo.StructField{
+            .decls = &.{},
+            .fields = &.{
                 .{
                     .name = "0",
                     .field_type = i32,
-                    .default_value = @as(?i32, null),
+                    .default_value = null,
                     .is_comptime = false,
                     .alignment = @alignOf(i32),
                 },
                 .{
                     .name = "1",
                     .field_type = u8,
-                    .default_value = @as(?i32, null),
+                    .default_value = null,
                     .is_comptime = false,
                     .alignment = @alignOf(i32),
                 },

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const TypeInfo = std.builtin.TypeInfo;
+const Type = std.builtin.Type;
 const testing = std.testing;
 
 fn testTypes(comptime types: []const type) !void {
@@ -10,32 +10,32 @@ fn testTypes(comptime types: []const type) !void {
 }
 
 test "Type.MetaType" {
-    try testing.expect(type == @Type(TypeInfo{ .Type = undefined }));
+    try testing.expect(type == @Type(.{ .Type = {} }));
     try testTypes(&[_]type{type});
 }
 
 test "Type.Void" {
-    try testing.expect(void == @Type(TypeInfo{ .Void = undefined }));
+    try testing.expect(void == @Type(.{ .Void = {} }));
     try testTypes(&[_]type{void});
 }
 
 test "Type.Bool" {
-    try testing.expect(bool == @Type(TypeInfo{ .Bool = undefined }));
+    try testing.expect(bool == @Type(.{ .Bool = {} }));
     try testTypes(&[_]type{bool});
 }
 
 test "Type.NoReturn" {
-    try testing.expect(noreturn == @Type(TypeInfo{ .NoReturn = undefined }));
+    try testing.expect(noreturn == @Type(.{ .NoReturn = {} }));
     try testTypes(&[_]type{noreturn});
 }
 
 test "Type.Int" {
-    try testing.expect(u1 == @Type(TypeInfo{ .Int = TypeInfo.Int{ .signedness = .unsigned, .bits = 1 } }));
-    try testing.expect(i1 == @Type(TypeInfo{ .Int = TypeInfo.Int{ .signedness = .signed, .bits = 1 } }));
-    try testing.expect(u8 == @Type(TypeInfo{ .Int = TypeInfo.Int{ .signedness = .unsigned, .bits = 8 } }));
-    try testing.expect(i8 == @Type(TypeInfo{ .Int = TypeInfo.Int{ .signedness = .signed, .bits = 8 } }));
-    try testing.expect(u64 == @Type(TypeInfo{ .Int = TypeInfo.Int{ .signedness = .unsigned, .bits = 64 } }));
-    try testing.expect(i64 == @Type(TypeInfo{ .Int = TypeInfo.Int{ .signedness = .signed, .bits = 64 } }));
+    try testing.expect(u1 == @Type(.{ .Int = .{ .signedness = .unsigned, .bits = 1 } }));
+    try testing.expect(i1 == @Type(.{ .Int = .{ .signedness = .signed, .bits = 1 } }));
+    try testing.expect(u8 == @Type(.{ .Int = .{ .signedness = .unsigned, .bits = 8 } }));
+    try testing.expect(i8 == @Type(.{ .Int = .{ .signedness = .signed, .bits = 8 } }));
+    try testing.expect(u64 == @Type(.{ .Int = .{ .signedness = .unsigned, .bits = 64 } }));
+    try testing.expect(i64 == @Type(.{ .Int = .{ .signedness = .signed, .bits = 64 } }));
     try testTypes(&[_]type{ u8, u32, i64 });
 }
 
@@ -104,31 +104,31 @@ test "Type.Pointer" {
 }
 
 test "Type.Float" {
-    try testing.expect(f16 == @Type(TypeInfo{ .Float = TypeInfo.Float{ .bits = 16 } }));
-    try testing.expect(f32 == @Type(TypeInfo{ .Float = TypeInfo.Float{ .bits = 32 } }));
-    try testing.expect(f64 == @Type(TypeInfo{ .Float = TypeInfo.Float{ .bits = 64 } }));
-    try testing.expect(f80 == @Type(TypeInfo{ .Float = TypeInfo.Float{ .bits = 80 } }));
-    try testing.expect(f128 == @Type(TypeInfo{ .Float = TypeInfo.Float{ .bits = 128 } }));
+    try testing.expect(f16 == @Type(.{ .Float = .{ .bits = 16 } }));
+    try testing.expect(f32 == @Type(.{ .Float = .{ .bits = 32 } }));
+    try testing.expect(f64 == @Type(.{ .Float = .{ .bits = 64 } }));
+    try testing.expect(f80 == @Type(.{ .Float = .{ .bits = 80 } }));
+    try testing.expect(f128 == @Type(.{ .Float = .{ .bits = 128 } }));
     try testTypes(&[_]type{ f16, f32, f64, f80, f128 });
 }
 
 test "Type.Array" {
-    try testing.expect([123]u8 == @Type(TypeInfo{
-        .Array = TypeInfo.Array{
+    try testing.expect([123]u8 == @Type(.{
+        .Array = .{
             .len = 123,
             .child = u8,
             .sentinel = null,
         },
     }));
-    try testing.expect([2]u32 == @Type(TypeInfo{
-        .Array = TypeInfo.Array{
+    try testing.expect([2]u32 == @Type(.{
+        .Array = .{
             .len = 2,
             .child = u32,
             .sentinel = null,
         },
     }));
-    try testing.expect([2:0]u32 == @Type(TypeInfo{
-        .Array = TypeInfo.Array{
+    try testing.expect([2:0]u32 == @Type(.{
+        .Array = .{
             .len = 2,
             .child = u32,
             .sentinel = &@as(u32, 0),
@@ -138,7 +138,7 @@ test "Type.Array" {
 }
 
 test "@Type create slice with null sentinel" {
-    const Slice = @Type(TypeInfo{
+    const Slice = @Type(.{
         .Pointer = .{
             .size = .Slice,
             .is_const = true,
@@ -153,7 +153,7 @@ test "@Type create slice with null sentinel" {
     try testing.expect(Slice == []align(8) const *i32);
 }
 
-test "@Type picks up the sentinel value from TypeInfo" {
+test "@Type picks up the sentinel value from Type" {
     try testTypes(&[_]type{
         [11:0]u8,                            [4:10]u8,
         [*:0]u8,                             [*:0]const u8,
@@ -203,13 +203,13 @@ test "Type.Opaque" {
 
     const Opaque = @Type(.{
         .Opaque = .{
-            .decls = &[_]TypeInfo.Declaration{},
+            .decls = &.{},
         },
     });
     try testing.expect(Opaque != opaque {});
     try testing.expectEqualSlices(
-        TypeInfo.Declaration,
-        &[_]TypeInfo.Declaration{},
+        Type.Declaration,
+        &.{},
         @typeInfo(Opaque).Opaque.decls,
     );
 }
@@ -240,14 +240,14 @@ fn add(a: i32, b: i32) i32 {
 }
 
 test "Type.ErrorSet" {
-    try testing.expect(@Type(TypeInfo{ .ErrorSet = null }) == anyerror);
+    try testing.expect(@Type(.{ .ErrorSet = null }) == anyerror);
 
     // error sets don't compare equal so just check if they compile
     _ = @Type(@typeInfo(error{}));
     _ = @Type(@typeInfo(error{A}));
     _ = @Type(@typeInfo(error{ A, B, C }));
-    _ = @Type(TypeInfo{
-        .ErrorSet = &[_]TypeInfo.Error{
+    _ = @Type(.{
+        .ErrorSet = &[_]Type.Error{
             .{ .name = "A" },
             .{ .name = "B" },
             .{ .name = "C" },
@@ -260,14 +260,14 @@ test "Type.Struct" {
 
     const A = @Type(@typeInfo(struct { x: u8, y: u32 }));
     const infoA = @typeInfo(A).Struct;
-    try testing.expectEqual(TypeInfo.ContainerLayout.Auto, infoA.layout);
+    try testing.expectEqual(Type.ContainerLayout.Auto, infoA.layout);
     try testing.expectEqualSlices(u8, "x", infoA.fields[0].name);
     try testing.expectEqual(u8, infoA.fields[0].field_type);
     try testing.expectEqual(@as(?*const anyopaque, null), infoA.fields[0].default_value);
     try testing.expectEqualSlices(u8, "y", infoA.fields[1].name);
     try testing.expectEqual(u32, infoA.fields[1].field_type);
     try testing.expectEqual(@as(?*const anyopaque, null), infoA.fields[1].default_value);
-    try testing.expectEqualSlices(TypeInfo.Declaration, &[_]TypeInfo.Declaration{}, infoA.decls);
+    try testing.expectEqualSlices(Type.Declaration, &.{}, infoA.decls);
     try testing.expectEqual(@as(bool, false), infoA.is_tuple);
 
     var a = A{ .x = 0, .y = 1 };
@@ -278,7 +278,7 @@ test "Type.Struct" {
 
     const B = @Type(@typeInfo(extern struct { x: u8, y: u32 = 5 }));
     const infoB = @typeInfo(B).Struct;
-    try testing.expectEqual(TypeInfo.ContainerLayout.Extern, infoB.layout);
+    try testing.expectEqual(Type.ContainerLayout.Extern, infoB.layout);
     try testing.expectEqualSlices(u8, "x", infoB.fields[0].name);
     try testing.expectEqual(u8, infoB.fields[0].field_type);
     try testing.expectEqual(@as(?*const anyopaque, null), infoB.fields[0].default_value);
@@ -290,7 +290,7 @@ test "Type.Struct" {
 
     const C = @Type(@typeInfo(packed struct { x: u8 = 3, y: u32 = 5 }));
     const infoC = @typeInfo(C).Struct;
-    try testing.expectEqual(TypeInfo.ContainerLayout.Packed, infoC.layout);
+    try testing.expectEqual(Type.ContainerLayout.Packed, infoC.layout);
     try testing.expectEqualSlices(u8, "x", infoC.fields[0].name);
     try testing.expectEqual(u8, infoC.fields[0].field_type);
     try testing.expectEqual(@as(u8, 3), @ptrCast(*const u8, infoC.fields[0].default_value.?).*);
@@ -308,11 +308,11 @@ test "Type.Enum" {
         .Enum = .{
             .layout = .Auto,
             .tag_type = u8,
-            .fields = &[_]TypeInfo.EnumField{
+            .fields = &.{
                 .{ .name = "a", .value = 1 },
                 .{ .name = "b", .value = 5 },
             },
-            .decls = &[_]TypeInfo.Declaration{},
+            .decls = &.{},
             .is_exhaustive = true,
         },
     });
@@ -323,11 +323,11 @@ test "Type.Enum" {
         .Enum = .{
             .layout = .Extern,
             .tag_type = u32,
-            .fields = &[_]TypeInfo.EnumField{
+            .fields = &.{
                 .{ .name = "a", .value = 1 },
                 .{ .name = "b", .value = 5 },
             },
-            .decls = &[_]TypeInfo.Declaration{},
+            .decls = &.{},
             .is_exhaustive = false,
         },
     });
@@ -344,11 +344,11 @@ test "Type.Union" {
         .Union = .{
             .layout = .Auto,
             .tag_type = null,
-            .fields = &[_]TypeInfo.UnionField{
+            .fields = &.{
                 .{ .name = "int", .field_type = i32, .alignment = @alignOf(f32) },
                 .{ .name = "float", .field_type = f32, .alignment = @alignOf(f32) },
             },
-            .decls = &[_]TypeInfo.Declaration{},
+            .decls = &.{},
         },
     });
     var untagged = Untagged{ .int = 1 };
@@ -360,11 +360,11 @@ test "Type.Union" {
         .Union = .{
             .layout = .Packed,
             .tag_type = null,
-            .fields = &[_]TypeInfo.UnionField{
+            .fields = &.{
                 .{ .name = "signed", .field_type = i32, .alignment = @alignOf(i32) },
                 .{ .name = "unsigned", .field_type = u32, .alignment = @alignOf(u32) },
             },
-            .decls = &[_]TypeInfo.Declaration{},
+            .decls = &.{},
         },
     });
     var packed_untagged = PackedUntagged{ .signed = -1 };
@@ -375,11 +375,11 @@ test "Type.Union" {
         .Enum = .{
             .layout = .Auto,
             .tag_type = u1,
-            .fields = &[_]TypeInfo.EnumField{
+            .fields = &.{
                 .{ .name = "signed", .value = 0 },
                 .{ .name = "unsigned", .value = 1 },
             },
-            .decls = &[_]TypeInfo.Declaration{},
+            .decls = &.{},
             .is_exhaustive = true,
         },
     });
@@ -387,11 +387,11 @@ test "Type.Union" {
         .Union = .{
             .layout = .Auto,
             .tag_type = Tag,
-            .fields = &[_]TypeInfo.UnionField{
+            .fields = &.{
                 .{ .name = "signed", .field_type = i32, .alignment = @alignOf(i32) },
                 .{ .name = "unsigned", .field_type = u32, .alignment = @alignOf(u32) },
             },
-            .decls = &[_]TypeInfo.Declaration{},
+            .decls = &.{},
         },
     });
     var tagged = Tagged{ .signed = -1 };
@@ -407,10 +407,10 @@ test "Type.Union from Type.Enum" {
         .Enum = .{
             .layout = .Auto,
             .tag_type = u0,
-            .fields = &[_]TypeInfo.EnumField{
+            .fields = &.{
                 .{ .name = "working_as_expected", .value = 0 },
             },
-            .decls = &[_]TypeInfo.Declaration{},
+            .decls = &.{},
             .is_exhaustive = true,
         },
     });
@@ -418,10 +418,10 @@ test "Type.Union from Type.Enum" {
         .Union = .{
             .layout = .Auto,
             .tag_type = Tag,
-            .fields = &[_]TypeInfo.UnionField{
+            .fields = &.{
                 .{ .name = "working_as_expected", .field_type = u32, .alignment = @alignOf(u32) },
             },
-            .decls = &[_]TypeInfo.Declaration{},
+            .decls = &.{},
         },
     });
     _ = T;
@@ -436,10 +436,10 @@ test "Type.Union from regular enum" {
         .Union = .{
             .layout = .Auto,
             .tag_type = E,
-            .fields = &[_]TypeInfo.UnionField{
+            .fields = &.{
                 .{ .name = "working_as_expected", .field_type = u32, .alignment = @alignOf(u32) },
             },
-            .decls = &[_]TypeInfo.Declaration{},
+            .decls = &.{},
         },
     });
     _ = T;

--- a/test/behavior/type_info.zig
+++ b/test/behavior/type_info.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const mem = std.mem;
 
-const TypeInfo = std.builtin.TypeInfo;
+const Type = std.builtin.Type;
 const TypeId = std.builtin.TypeId;
 
 const expect = std.testing.expect;
@@ -64,7 +64,7 @@ test "type info: tag type, void info" {
 }
 
 fn testBasic() !void {
-    try expect(@typeInfo(TypeInfo).Union.tag_type == TypeId);
+    try expect(@typeInfo(Type).Union.tag_type == TypeId);
     const void_info = @typeInfo(void);
     try expect(void_info == TypeId.Void);
     try expect(void_info.Void == {});
@@ -78,7 +78,7 @@ test "type info: pointer type info" {
 fn testPointer() !void {
     const u32_ptr_info = @typeInfo(*u32);
     try expect(u32_ptr_info == .Pointer);
-    try expect(u32_ptr_info.Pointer.size == TypeInfo.Pointer.Size.One);
+    try expect(u32_ptr_info.Pointer.size == .One);
     try expect(u32_ptr_info.Pointer.is_const == false);
     try expect(u32_ptr_info.Pointer.is_volatile == false);
     try expect(u32_ptr_info.Pointer.alignment == @alignOf(u32));
@@ -94,7 +94,7 @@ test "type info: unknown length pointer type info" {
 fn testUnknownLenPtr() !void {
     const u32_ptr_info = @typeInfo([*]const volatile f64);
     try expect(u32_ptr_info == .Pointer);
-    try expect(u32_ptr_info.Pointer.size == TypeInfo.Pointer.Size.Many);
+    try expect(u32_ptr_info.Pointer.size == .Many);
     try expect(u32_ptr_info.Pointer.is_const == true);
     try expect(u32_ptr_info.Pointer.is_volatile == true);
     try expect(u32_ptr_info.Pointer.sentinel == null);
@@ -110,7 +110,7 @@ test "type info: null terminated pointer type info" {
 fn testNullTerminatedPtr() !void {
     const ptr_info = @typeInfo([*:0]u8);
     try expect(ptr_info == .Pointer);
-    try expect(ptr_info.Pointer.size == TypeInfo.Pointer.Size.Many);
+    try expect(ptr_info.Pointer.size == .Many);
     try expect(ptr_info.Pointer.is_const == false);
     try expect(ptr_info.Pointer.is_volatile == false);
     try expect(@ptrCast(*const u8, ptr_info.Pointer.sentinel.?).* == 0);
@@ -254,7 +254,7 @@ test "type info: union info" {
 }
 
 fn testUnion() !void {
-    const typeinfo_info = @typeInfo(TypeInfo);
+    const typeinfo_info = @typeInfo(Type);
     try expect(typeinfo_info == .Union);
     try expect(typeinfo_info.Union.layout == .Auto);
     try expect(typeinfo_info.Union.tag_type.? == TypeId);
@@ -437,12 +437,12 @@ test "type info: pass to function" {
     _ = comptime passTypeInfo(@typeInfo(void));
 }
 
-fn passTypeInfo(comptime info: TypeInfo) type {
+fn passTypeInfo(comptime info: Type) type {
     _ = info;
     return void;
 }
 
-test "type info: TypeId -> TypeInfo impl cast" {
+test "type info: TypeId -> Type impl cast" {
     _ = passTypeInfo(TypeId.Void);
     _ = comptime passTypeInfo(TypeId.Void);
 }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -95,12 +95,12 @@ pub fn addCases(ctx: *TestContext) !void {
     });
 
     ctx.objErrStage1("@Type() union payload is undefined",
-        \\const Foo = @Type(@import("std").builtin.TypeInfo{
+        \\const Foo = @Type(.{
         \\    .Struct = undefined,
         \\});
         \\comptime { _ = Foo; }
     , &[_][]const u8{
-        "tmp.zig:1:50: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:1:20: error: use of undefined value here causes undefined behavior",
     });
 
     ctx.objErrStage1("wrong initializer for union payload of type 'type'",
@@ -258,16 +258,16 @@ pub fn addCases(ctx: *TestContext) !void {
         "tmp.zig:8:12: note: called from here",
     });
 
-    ctx.objErrStage1("@Type with TypeInfo.Int",
+    ctx.objErrStage1("@Type with Type.Int",
         \\const builtin = @import("std").builtin;
         \\export fn entry() void {
-        \\    _ = @Type(builtin.TypeInfo.Int {
+        \\    _ = @Type(builtin.Type.Int{
         \\        .signedness = .signed,
         \\        .bits = 8,
         \\    });
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:36: error: expected type 'std.builtin.TypeInfo', found 'std.builtin.Int'",
+        "tmp.zig:3:31: error: expected type 'std.builtin.Type', found 'std.builtin.Int'",
     });
 
     ctx.objErrStage1("indexing a undefined slice at comptime",
@@ -293,13 +293,12 @@ pub fn addCases(ctx: *TestContext) !void {
     });
 
     ctx.objErrStage1("@Type for exhaustive enum with undefined tag type",
-        \\const TypeInfo = @import("std").builtin.TypeInfo;
         \\const Tag = @Type(.{
         \\    .Enum = .{
         \\        .layout = .Auto,
         \\        .tag_type = undefined,
-        \\        .fields = &[_]TypeInfo.EnumField{},
-        \\        .decls = &[_]TypeInfo.Declaration{},
+        \\        .fields = &.{},
+        \\        .decls = &.{},
         \\        .is_exhaustive = false,
         \\    },
         \\});
@@ -307,7 +306,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = @intToEnum(Tag, 0);
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:20: error: use of undefined value here causes undefined behavior",
+        "tmp.zig:1:20: error: use of undefined value here causes undefined behavior",
     });
 
     ctx.objErrStage1("extern struct with non-extern-compatible integer tag type",
@@ -324,13 +323,12 @@ pub fn addCases(ctx: *TestContext) !void {
     });
 
     ctx.objErrStage1("@Type for exhaustive enum with non-integer tag type",
-        \\const TypeInfo = @import("std").builtin.TypeInfo;
         \\const Tag = @Type(.{
         \\    .Enum = .{
         \\        .layout = .Auto,
         \\        .tag_type = bool,
-        \\        .fields = &[_]TypeInfo.EnumField{},
-        \\        .decls = &[_]TypeInfo.Declaration{},
+        \\        .fields = &.{},
+        \\        .decls = &.{},
         \\        .is_exhaustive = false,
         \\    },
         \\});
@@ -338,7 +336,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = @intToEnum(Tag, 0);
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:20: error: TypeInfo.Enum.tag_type must be an integer type, not 'bool'",
+        "tmp.zig:1:20: error: Type.Enum.tag_type must be an integer type, not 'bool'",
     });
 
     ctx.objErrStage1("extern struct with extern-compatible but inferred integer tag type",
@@ -384,17 +382,16 @@ pub fn addCases(ctx: *TestContext) !void {
     });
 
     ctx.objErrStage1("@Type for tagged union with extra enum field",
-        \\const TypeInfo = @import("std").builtin.TypeInfo;
         \\const Tag = @Type(.{
         \\    .Enum = .{
         \\        .layout = .Auto,
         \\        .tag_type = u2,
-        \\        .fields = &[_]TypeInfo.EnumField{
+        \\        .fields = &.{
         \\            .{ .name = "signed", .value = 0 },
         \\            .{ .name = "unsigned", .value = 1 },
         \\            .{ .name = "arst", .value = 2 },
         \\        },
-        \\        .decls = &[_]TypeInfo.Declaration{},
+        \\        .decls = &.{},
         \\        .is_exhaustive = true,
         \\    },
         \\});
@@ -402,11 +399,11 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    .Union = .{
         \\        .layout = .Auto,
         \\        .tag_type = Tag,
-        \\        .fields = &[_]TypeInfo.UnionField{
+        \\        .fields = &.{
         \\            .{ .name = "signed", .field_type = i32, .alignment = @alignOf(i32) },
         \\            .{ .name = "unsigned", .field_type = u32, .alignment = @alignOf(u32) },
         \\        },
-        \\        .decls = &[_]TypeInfo.Declaration{},
+        \\        .decls = &.{},
         \\    },
         \\});
         \\export fn entry() void {
@@ -414,7 +411,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    tagged = .{ .unsigned = 1 };
         \\}
     , &[_][]const u8{
-        "tmp.zig:15:23: error: enum field missing: 'arst'",
+        "tmp.zig:14:23: error: enum field missing: 'arst'",
     });
 
     ctx.objErrStage1("field access of opaque type",
@@ -450,12 +447,12 @@ pub fn addCases(ctx: *TestContext) !void {
         \\        .is_generic = true,
         \\        .is_var_args = false,
         \\        .return_type = u0,
-        \\        .args = &[_]@import("std").builtin.TypeInfo.Fn.Param{},
+        \\        .args = &.{},
         \\    },
         \\});
         \\comptime { _ = Foo; }
     , &[_][]const u8{
-        "tmp.zig:1:20: error: TypeInfo.Fn.is_generic must be false for @Type",
+        "tmp.zig:1:20: error: Type.Fn.is_generic must be false for @Type",
     });
 
     ctx.objErrStage1("@Type(.Fn) with is_var_args = true and non-C callconv",
@@ -466,7 +463,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\        .is_generic = false,
         \\        .is_var_args = true,
         \\        .return_type = u0,
-        \\        .args = &[_]@import("std").builtin.TypeInfo.Fn.Param{},
+        \\        .args = &.{},
         \\    },
         \\});
         \\comptime { _ = Foo; }
@@ -482,31 +479,30 @@ pub fn addCases(ctx: *TestContext) !void {
         \\        .is_generic = false,
         \\        .is_var_args = false,
         \\        .return_type = null,
-        \\        .args = &[_]@import("std").builtin.TypeInfo.Fn.Param{},
+        \\        .args = &.{},
         \\    },
         \\});
         \\comptime { _ = Foo; }
     , &[_][]const u8{
-        "tmp.zig:1:20: error: TypeInfo.Fn.return_type must be non-null for @Type",
+        "tmp.zig:1:20: error: Type.Fn.return_type must be non-null for @Type",
     });
 
     ctx.objErrStage1("@Type for union with opaque field",
-        \\const TypeInfo = @import("std").builtin.TypeInfo;
         \\const Untagged = @Type(.{
         \\    .Union = .{
         \\        .layout = .Auto,
         \\        .tag_type = null,
-        \\        .fields = &[_]TypeInfo.UnionField{
+        \\        .fields = &.{
         \\            .{ .name = "foo", .field_type = opaque {}, .alignment = 1 },
         \\        },
-        \\        .decls = &[_]TypeInfo.Declaration{},
+        \\        .decls = &.{},
         \\    },
         \\});
         \\export fn entry() void {
         \\    _ = Untagged{};
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:25: error: opaque types have unknown size and therefore cannot be directly embedded in unions",
+        "tmp.zig:1:25: error: opaque types have unknown size and therefore cannot be directly embedded in unions",
     });
 
     ctx.objErrStage1("slice sentinel mismatch",
@@ -528,30 +524,28 @@ pub fn addCases(ctx: *TestContext) !void {
     });
 
     ctx.objErrStage1("@Type for union with zero fields",
-        \\const TypeInfo = @import("std").builtin.TypeInfo;
         \\const Untagged = @Type(.{
         \\    .Union = .{
         \\        .layout = .Auto,
         \\        .tag_type = null,
-        \\        .fields = &[_]TypeInfo.UnionField{},
-        \\        .decls = &[_]TypeInfo.Declaration{},
+        \\        .fields = &.{},
+        \\        .decls = &.{},
         \\    },
         \\});
         \\export fn entry() void {
         \\    _ = Untagged{};
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:25: error: unions must have 1 or more fields",
+        "tmp.zig:1:25: error: unions must have 1 or more fields",
     });
 
     ctx.objErrStage1("@Type for exhaustive enum with zero fields",
-        \\const TypeInfo = @import("std").builtin.TypeInfo;
         \\const Tag = @Type(.{
         \\    .Enum = .{
         \\        .layout = .Auto,
         \\        .tag_type = u1,
-        \\        .fields = &[_]TypeInfo.EnumField{},
-        \\        .decls = &[_]TypeInfo.Declaration{},
+        \\        .fields = &.{},
+        \\        .decls = &.{},
         \\        .is_exhaustive = true,
         \\    },
         \\});
@@ -559,20 +553,19 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = @intToEnum(Tag, 0);
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:20: error: enums must have 1 or more fields",
+        "tmp.zig:1:20: error: enums must have 1 or more fields",
     });
 
     ctx.objErrStage1("@Type for tagged union with extra union field",
-        \\const TypeInfo = @import("std").builtin.TypeInfo;
         \\const Tag = @Type(.{
         \\    .Enum = .{
         \\        .layout = .Auto,
         \\        .tag_type = u1,
-        \\        .fields = &[_]TypeInfo.EnumField{
+        \\        .fields = &.{
         \\            .{ .name = "signed", .value = 0 },
         \\            .{ .name = "unsigned", .value = 1 },
         \\        },
-        \\        .decls = &[_]TypeInfo.Declaration{},
+        \\        .decls = &.{},
         \\        .is_exhaustive = true,
         \\    },
         \\});
@@ -580,12 +573,12 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    .Union = .{
         \\        .layout = .Auto,
         \\        .tag_type = Tag,
-        \\        .fields = &[_]TypeInfo.UnionField{
+        \\        .fields = &.{
         \\            .{ .name = "signed", .field_type = i32, .alignment = @alignOf(i32) },
         \\            .{ .name = "unsigned", .field_type = u32, .alignment = @alignOf(u32) },
         \\            .{ .name = "arst", .field_type = f32, .alignment = @alignOf(f32) },
         \\        },
-        \\        .decls = &[_]TypeInfo.Declaration{},
+        \\        .decls = &.{},
         \\    },
         \\});
         \\export fn entry() void {
@@ -593,8 +586,8 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    tagged = .{ .unsigned = 1 };
         \\}
     , &[_][]const u8{
-        "tmp.zig:14:23: error: enum field not found: 'arst'",
-        "tmp.zig:2:20: note: enum declared here",
+        "tmp.zig:13:23: error: enum field not found: 'arst'",
+        "tmp.zig:1:20: note: enum declared here",
     });
 
     ctx.objErrStage1("@Type with undefined",
@@ -621,7 +614,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = @Type(@typeInfo(struct { const foo = 1; }));
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:15: error: TypeInfo.Struct.decls must be empty for @Type",
+        "tmp.zig:2:15: error: Type.Struct.decls must be empty for @Type",
     });
 
     ctx.objErrStage1("enum with declarations unavailable for @Type",
@@ -629,7 +622,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = @Type(@typeInfo(enum { foo, const bar = 1; }));
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:15: error: TypeInfo.Enum.decls must be empty for @Type",
+        "tmp.zig:2:15: error: Type.Enum.decls must be empty for @Type",
     });
 
     ctx.testErrStage1("reject extern variables with initializers",
@@ -2081,10 +2074,10 @@ pub fn addCases(ctx: *TestContext) !void {
     ctx.objErrStage1("attempt to create 17 bit float type",
         \\const builtin = @import("std").builtin;
         \\comptime {
-        \\    _ = @Type(builtin.TypeInfo { .Float = builtin.TypeInfo.Float { .bits = 17 } });
+        \\    _ = @Type(.{ .Float = .{ .bits = 17 } });
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:32: error: 17-bit float unsupported",
+        "tmp.zig:3:16: error: 17-bit float unsupported",
     });
 
     ctx.objErrStage1("wrong type for @Type",
@@ -2092,12 +2085,12 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = @Type(0);
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:15: error: expected type 'std.builtin.TypeInfo', found 'comptime_int'",
+        "tmp.zig:2:15: error: expected type 'std.builtin.Type', found 'comptime_int'",
     });
 
     ctx.objErrStage1("@Type with non-constant expression",
         \\const builtin = @import("std").builtin;
-        \\var globalTypeInfo : builtin.TypeInfo = undefined;
+        \\var globalTypeInfo : builtin.Type = undefined;
         \\export fn entry() void {
         \\    _ = @Type(globalTypeInfo);
         \\}
@@ -8156,12 +8149,12 @@ pub fn addCases(ctx: *TestContext) !void {
     ctx.testErrStage1("nested vectors",
         \\export fn entry() void {
         \\    const V1 = @import("std").meta.Vector(4, u8);
-        \\    const V2 = @Type(@import("std").builtin.TypeInfo{ .Vector = .{ .len = 4, .child = V1 } });
+        \\    const V2 = @Type(.{ .Vector = .{ .len = 4, .child = V1 } });
         \\    var v: V2 = undefined;
         \\    _ = v;
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:53: error: vector element type must be integer, float, bool, or pointer; '@Vector(4, u8)' is invalid",
+        "tmp.zig:3:23: error: vector element type must be integer, float, bool, or pointer; '@Vector(4, u8)' is invalid",
     });
 
     ctx.testErrStage1("bad @splat type",


### PR DESCRIPTION
I started by trying to rename `TypeInfo` to `Type`, but I ended up needing to more changes to get that to work, so instead I just created a new `Type = TypeInfo` alias.  This way code can start transitioning to using `Type` now and we can do the same in Zig iteratively without making a huge change that constantly breaks with merge conflicts.