### PR TITLE
stage2: cmp between nans

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -15771,6 +15771,13 @@ fn cmpNumeric(
                 if (lhs_val.isUndef() or rhs_val.isUndef()) {
                     return sema.addConstUndef(Type.initTag(.bool));
                 }
+                if (lhs_val.isNan() or rhs_val.isNan()) {
+                    if(op == std.math.CompareOperator.neq) {
+                        return Air.Inst.Ref.bool_true;
+                    } else {
+                        return Air.Inst.Ref.bool_false;
+                    }
+                }
                 if (Value.compareHetero(lhs_val, op, rhs_val)) {
                     return Air.Inst.Ref.bool_true;
                 } else {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -15772,7 +15772,7 @@ fn cmpNumeric(
                     return sema.addConstUndef(Type.initTag(.bool));
                 }
                 if (lhs_val.isNan() or rhs_val.isNan()) {
-                    if(op == std.math.CompareOperator.neq) {
+                    if (op == std.math.CompareOperator.neq) {
                         return Air.Inst.Ref.bool_true;
                     } else {
                         return Air.Inst.Ref.bool_false;

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -979,13 +979,11 @@ test "vector integer addition" {
 }
 
 test "NaN comparison" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     try testNanEqNan(f16);
     try testNanEqNan(f32);
     try testNanEqNan(f64);
     try testNanEqNan(f128);
-    if (has_f80_rt) try testNanEqNan(f80);
+    if (has_f80_rt and (builtin.zig_backend == .stage1)) try testNanEqNan(f80);
     comptime try testNanEqNan(f16);
     comptime try testNanEqNan(f32);
     comptime try testNanEqNan(f64);

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -983,12 +983,12 @@ test "NaN comparison" {
     try testNanEqNan(f32);
     try testNanEqNan(f64);
     try testNanEqNan(f128);
-    if (has_f80_rt and (builtin.zig_backend == .stage1)) try testNanEqNan(f80);
+    if (has_f80_rt and (builtin.zig_backend == .stage1)) try testNanEqNan(f80); // TODO
     comptime try testNanEqNan(f16);
     comptime try testNanEqNan(f32);
     comptime try testNanEqNan(f64);
     comptime try testNanEqNan(f128);
-    // comptime try testNanEqNan(f80);
+    // comptime try testNanEqNan(f80); // TODO
 }
 
 fn testNanEqNan(comptime F: type) !void {


### PR DESCRIPTION
Catching the cmp in Sema stops it's being ordered against zero (which results in a hard crash). Also supported the logic of `(nan != nan) == true` is easier and less hacky compred to if it was to be handled lower down the chain. `float80` has been ommited as it does not seem to be supported that well in stage2 (crashes trying to access to `math.nan_f80`, no ability to `@bitCast` into `f80`).