### PR TITLE
stage2: handle more MCValue types in `struct_field_ptr` in x86_64 and pad out nonpacked struct fields when lowering to bytes (all targets incl wasm32)

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -680,6 +680,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .wrap_errunion_err     => try self.airWrapErrUnionErr(inst),
             // zig fmt: on
         }
+
+        assert(!self.register_manager.frozenRegsExist());
+
         if (std.debug.runtime_safety) {
             if (self.air_bookkeeping < old_air_bookkeeping + 1) {
                 std.debug.panic("in codegen.zig, handling of AIR instruction %{d} ('{}') did not do proper bookkeeping. Look for a missing call to finishAir.", .{ inst, air_tags[inst] });
@@ -827,9 +830,9 @@ fn copyToTmpRegister(self: *Self, ty: Type, mcv: MCValue) !Register {
 /// Allocates a new register and copies `mcv` into it.
 /// `reg_owner` is the instruction that gets associated with the register in the register table.
 /// This can have a side effect of spilling instructions to the stack to free up a register.
-fn copyToNewRegister(self: *Self, reg_owner: Air.Inst.Index, mcv: MCValue) !MCValue {
+fn copyToNewRegister(self: *Self, reg_owner: Air.Inst.Index, ty: Type, mcv: MCValue) !MCValue {
     const reg = try self.register_manager.allocReg(reg_owner, &.{});
-    try self.genSetReg(self.air.typeOfIndex(reg_owner), reg, mcv);
+    try self.genSetReg(ty, reg, mcv);
     return MCValue{ .register = reg };
 }
 
@@ -838,11 +841,12 @@ fn copyToNewRegister(self: *Self, reg_owner: Air.Inst.Index, mcv: MCValue) !MCVa
 fn copyToNewRegisterWithExceptions(
     self: *Self,
     reg_owner: Air.Inst.Index,
+    ty: Type,
     mcv: MCValue,
     exceptions: []const Register,
 ) !MCValue {
     const reg = try self.register_manager.allocReg(reg_owner, exceptions);
-    try self.genSetReg(self.air.typeOfIndex(reg_owner), reg, mcv);
+    try self.genSetReg(ty, reg, mcv);
     return MCValue{ .register = reg };
 }
 
@@ -892,13 +896,10 @@ fn airIntCast(self: *Self, inst: Air.Inst.Index) !void {
         if (operand_abi_size > 8 or dest_abi_size > 8) {
             return self.fail("TODO implement intCast for abi sizes larger than 8", .{});
         }
-        const reg = switch (operand) {
-            .register => |src_reg| try self.register_manager.allocReg(inst, &.{src_reg}),
-            else => try self.register_manager.allocReg(inst, &.{}),
-        };
-        try self.genSetReg(dest_ty, reg, .{ .immediate = 0 });
-        try self.genSetReg(dest_ty, reg, operand);
-        break :blk .{ .register = registerAlias(reg, @intCast(u32, dest_abi_size)) };
+
+        if (operand.isRegister()) self.register_manager.freezeRegs(&.{operand.register});
+        defer if (operand.isRegister()) self.register_manager.unfreezeRegs(&.{operand.register});
+        break :blk try self.copyToNewRegister(inst, dest_ty, operand);
     };
 
     return self.finishAir(inst, dst_mcv, .{ ty_op.operand, .none, .none });
@@ -1208,7 +1209,7 @@ fn airOptionalPayload(self: *Self, inst: Air.Inst.Index) !void {
         if (self.reuseOperand(inst, ty_op.operand, 0, operand)) {
             break :result operand;
         }
-        break :result try self.copyToNewRegister(inst, operand);
+        break :result try self.copyToNewRegister(inst, self.air.typeOfIndex(inst), operand);
     };
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
@@ -1479,16 +1480,11 @@ fn airPtrElemPtr(self: *Self, inst: Air.Inst.Index) !void {
         const index_ty = self.air.typeOf(extra.rhs);
         const index = try self.resolveInst(extra.rhs);
         const offset_reg = try self.elemOffset(index_ty, index, elem_abi_size);
-        const dst_mcv = blk: {
-            switch (ptr) {
-                .ptr_stack_offset => {
-                    const reg = try self.register_manager.allocReg(inst, &.{offset_reg});
-                    try self.genSetReg(ptr_ty, reg, ptr);
-                    break :blk .{ .register = reg };
-                },
-                else => return self.fail("TODO implement ptr_elem_ptr when ptr is {}", .{ptr}),
-            }
-        };
+
+        self.register_manager.freezeRegs(&.{offset_reg});
+        defer self.register_manager.unfreezeRegs(&.{offset_reg});
+
+        const dst_mcv = try self.copyToNewRegister(inst, ptr_ty, ptr);
         try self.genBinMathOpMir(.add, ptr_ty, dst_mcv, .{ .register = offset_reg });
         break :result dst_mcv;
     };
@@ -1859,13 +1855,14 @@ fn genBinMathOp(self: *Self, inst: Air.Inst.Index, op_lhs: Air.Inst.Ref, op_rhs:
     // Source operand can be an immediate, 8 bits or 32 bits.
     // So, if either one of the operands dies with this instruction, we can use it
     // as the result MCValue.
+    const dst_ty = self.air.typeOfIndex(inst);
     var dst_mcv: MCValue = undefined;
     var src_mcv: MCValue = undefined;
     if (self.reuseOperand(inst, op_lhs, 0, lhs)) {
         // LHS dies; use it as the destination.
         // Both operands cannot be memory.
         if (lhs.isMemory() and rhs.isMemory()) {
-            dst_mcv = try self.copyToNewRegister(inst, lhs);
+            dst_mcv = try self.copyToNewRegister(inst, dst_ty, lhs);
             src_mcv = rhs;
         } else {
             dst_mcv = lhs;
@@ -1875,7 +1872,7 @@ fn genBinMathOp(self: *Self, inst: Air.Inst.Index, op_lhs: Air.Inst.Ref, op_rhs:
         // RHS dies; use it as the destination.
         // Both operands cannot be memory.
         if (lhs.isMemory() and rhs.isMemory()) {
-            dst_mcv = try self.copyToNewRegister(inst, rhs);
+            dst_mcv = try self.copyToNewRegister(inst, dst_ty, rhs);
             src_mcv = lhs;
         } else {
             dst_mcv = rhs;
@@ -1887,18 +1884,18 @@ fn genBinMathOp(self: *Self, inst: Air.Inst.Index, op_lhs: Air.Inst.Ref, op_rhs:
                 // If the allocated register is the same as the rhs register, don't allocate that one
                 // and instead spill a subsequent one. Otherwise, this can result in a miscompilation
                 // in the presence of several binary operations performed in a single block.
-                try self.copyToNewRegisterWithExceptions(inst, lhs, &.{rhs.register})
+                try self.copyToNewRegisterWithExceptions(inst, dst_ty, lhs, &.{rhs.register})
             else
-                try self.copyToNewRegister(inst, lhs);
+                try self.copyToNewRegister(inst, dst_ty, lhs);
             src_mcv = rhs;
         } else {
             dst_mcv = if (lhs.isRegister())
                 // If the allocated register is the same as the rhs register, don't allocate that one
                 // and instead spill a subsequent one. Otherwise, this can result in a miscompilation
                 // in the presence of several binary operations performed in a single block.
-                try self.copyToNewRegisterWithExceptions(inst, rhs, &.{lhs.register})
+                try self.copyToNewRegisterWithExceptions(inst, dst_ty, rhs, &.{lhs.register})
             else
-                try self.copyToNewRegister(inst, rhs);
+                try self.copyToNewRegister(inst, dst_ty, rhs);
             src_mcv = lhs;
         }
     }
@@ -1917,7 +1914,6 @@ fn genBinMathOp(self: *Self, inst: Air.Inst.Index, op_lhs: Air.Inst.Ref, op_rhs:
     }
 
     // Now for step 2, we assing an MIR instruction
-    const dst_ty = self.air.typeOfIndex(inst);
     const air_tags = self.air.instructions.items(.tag);
     switch (air_tags[inst]) {
         .add, .addwrap, .ptr_add => try self.genBinMathOpMir(.add, dst_ty, dst_mcv, src_mcv),
@@ -2417,7 +2413,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index) !void {
             .register => |reg| {
                 if (Register.allocIndex(reg) == null) {
                     // Save function return value in a callee saved register
-                    break :result try self.copyToNewRegister(inst, info.return_value);
+                    break :result try self.copyToNewRegister(inst, self.air.typeOfIndex(inst), info.return_value);
                 }
             },
             else => {},
@@ -2494,7 +2490,7 @@ fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
         // Either one, but not both, can be a memory operand.
         // Source operand can be an immediate, 8 bits or 32 bits.
         const dst_mcv = if (lhs.isImmediate() or (lhs.isMemory() and rhs.isMemory()))
-            try self.copyToNewRegister(inst, lhs)
+            try self.copyToNewRegister(inst, ty, lhs)
         else
             lhs;
         // This instruction supports only signed 32-bit immediates at most.

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2367,6 +2367,7 @@ fn deinitRelocs(gpa: Allocator, table: *File.DbgInfoTypeRelocsTable) void {
 }
 
 fn updateDeclCode(self: *Elf, decl: *Module.Decl, code: []const u8, stt_bits: u8) !*elf.Elf64_Sym {
+    log.debug("updateDeclCode {s}{*}", .{ mem.sliceTo(decl.name, 0), decl });
     const required_alignment = decl.ty.abiAlignment(self.base.options.target);
 
     const block_list = self.getDeclBlockList(decl);

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -34,6 +34,7 @@ test {
     _ = @import("behavior/slice_sentinel_comptime.zig");
     _ = @import("behavior/type.zig");
     _ = @import("behavior/truncate.zig");
+    _ = @import("behavior/struct.zig");
 
     if (builtin.zig_backend != .stage2_arm and builtin.zig_backend != .stage2_x86_64) {
         // Tests that pass for stage1, llvm backend, C backend, wasm backend.
@@ -69,7 +70,6 @@ test {
         _ = @import("behavior/ptrcast.zig");
         _ = @import("behavior/ref_var_in_if_after_if_2nd_switch_prong.zig");
         _ = @import("behavior/src.zig");
-        _ = @import("behavior/struct.zig");
         _ = @import("behavior/this.zig");
         _ = @import("behavior/try.zig");
         _ = @import("behavior/type_info.zig");

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -5,8 +5,6 @@ const maxInt = std.math.maxInt;
 const builtin = @import("builtin");
 
 test "int to ptr cast" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-
     const x = @as(usize, 13);
     const y = @intToPtr(*u8, x);
     const z = @ptrToInt(y);
@@ -14,8 +12,6 @@ test "int to ptr cast" {
 }
 
 test "integer literal to pointer cast" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-
     const vga_mem = @intToPtr(*u16, 0xB8000);
     try expect(@ptrToInt(vga_mem) == 0xB8000);
 }

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -9,6 +9,8 @@ const maxInt = std.math.maxInt;
 top_level_field: i32,
 
 test "top level fields" {
+    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     var instance = @This(){
         .top_level_field = 1234,
     };
@@ -29,6 +31,8 @@ const StructFoo = struct {
 };
 
 test "structs" {
+    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     var foo: StructFoo = undefined;
     @memset(@ptrCast([*]u8, &foo), 0, @sizeOf(StructFoo));
     foo.a += 1;
@@ -45,6 +49,8 @@ fn testMutation(foo: *StructFoo) void {
 }
 
 test "struct byval assign" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     var foo1: StructFoo = undefined;
     var foo2: StructFoo = undefined;
 
@@ -56,6 +62,8 @@ test "struct byval assign" {
 }
 
 test "call struct static method" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const result = StructWithNoFields.add(3, 4);
     try expect(result == 7);
 }
@@ -85,6 +93,8 @@ const Val = struct {
 };
 
 test "fn call of struct field" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const Foo = struct {
         ptr: fn () i32,
     };
@@ -114,12 +124,16 @@ const MemberFnTestFoo = struct {
 };
 
 test "call member function directly" {
+    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const instance = MemberFnTestFoo{ .x = 1234 };
     const result = MemberFnTestFoo.member(instance);
     try expect(result == 1234);
 }
 
 test "store member function in variable" {
+    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const instance = MemberFnTestFoo{ .x = 1234 };
     const memberFn = MemberFnTestFoo.member;
     const result = memberFn(instance);
@@ -127,6 +141,8 @@ test "store member function in variable" {
 }
 
 test "member functions" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const r = MemberFnRand{ .seed = 1234 };
     try expect(r.getSeed() == 1234);
 }
@@ -138,6 +154,8 @@ const MemberFnRand = struct {
 };
 
 test "return struct byval from function" {
+    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const bar = makeBar2(1234, 5678);
     try expect(bar.y == 5678);
 }
@@ -153,6 +171,8 @@ fn makeBar2(x: i32, y: i32) Bar {
 }
 
 test "call method with mutable reference to struct with no fields" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const S = struct {
         fn doC(s: *const @This()) bool {
             _ = s;
@@ -172,6 +192,8 @@ test "call method with mutable reference to struct with no fields" {
 }
 
 test "usingnamespace within struct scope" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const S = struct {
         usingnamespace struct {
             pub fn inner() i32 {
@@ -183,6 +205,8 @@ test "usingnamespace within struct scope" {
 }
 
 test "struct field init with catch" {
+    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const S = struct {
         fn doTheTest() !void {
             var x: anyerror!isize = 1;

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -18,6 +18,39 @@ test "top level fields" {
     try expect(@as(i32, 1235) == instance.top_level_field);
 }
 
+const StructWithFields = struct {
+    a: u8,
+    b: u32,
+    c: u64,
+    d: u32,
+
+    fn first(self: *const StructWithFields) u8 {
+        return self.a;
+    }
+
+    fn second(self: *const StructWithFields) u32 {
+        return self.b;
+    }
+
+    fn third(self: *const StructWithFields) u64 {
+        return self.c;
+    }
+
+    fn fourth(self: *const StructWithFields) u32 {
+        return self.d;
+    }
+};
+
+test "non-packed struct has fields padded out to the required alignment" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
+    const foo = StructWithFields{ .a = 5, .b = 1, .c = 10, .d = 2 };
+    try expect(foo.first() == 5);
+    try expect(foo.second() == 1);
+    try expect(foo.third() == 10);
+    try expect(foo.fourth() == 2);
+}
+
 const StructWithNoFields = struct {
     fn add(a: i32, b: i32) i32 {
         return a + b;


### PR DESCRIPTION
* start moving to new regalloc freeze API
* handle `struct_field_ptr` for `register` mcv
* handle `struct_field_ptr` for `stack_offset` mcv
* pass more behaviour tests

UPDATE:
Additionally,
* pad out (non-packed) struct fields when lowering to bytes to be saved in the binary - prior to this change, fields would be saved at non-aligned addresses leading to wrong accesses
* add a matching test case to `behavior/struct.zig` tests
* fix offset to field calculation in `struct_field_ptr` on `x86_64`