### PR TITLE
stage2: handle name-qualified imports in sema, add a zerofill sections workaround to incremental macho

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5567,11 +5567,6 @@ fn funcCommon(
     if (opt_lib_name) |lib_name| blk: {
         const lib_name_src: LazySrcLoc = .{ .node_offset_lib_name = src_node_offset };
         log.debug("extern fn symbol expected in lib '{s}'", .{lib_name});
-        mod.comp.stage1AddLinkLib(lib_name) catch |err| {
-            return sema.fail(block, lib_name_src, "unable to add link lib '{s}': {s}", .{
-                lib_name, @errorName(err),
-            });
-        };
         if (target_util.is_libc_lib_name(target, lib_name)) {
             if (!mod.comp.bin_file.options.link_libc) {
                 return sema.fail(
@@ -5581,6 +5576,7 @@ fn funcCommon(
                     .{},
                 );
             }
+            mod.comp.bin_file.options.link_libc = true;
             break :blk;
         }
         if (target_util.is_libcpp_lib_name(target, lib_name)) {
@@ -5592,6 +5588,11 @@ fn funcCommon(
                     .{},
                 );
             }
+            mod.comp.bin_file.options.link_libcpp = true;
+            break :blk;
+        }
+        if (mem.eql(u8, lib_name, "unwind")) {
+            mod.comp.bin_file.options.link_libunwind = true;
             break :blk;
         }
         if (!target.isWasm() and !mod.comp.bin_file.options.pic) {
@@ -5602,6 +5603,11 @@ fn funcCommon(
                 .{ lib_name, lib_name },
             );
         }
+        mod.comp.stage1AddLinkLib(lib_name) catch |err| {
+            return sema.fail(block, lib_name_src, "unable to add link lib '{s}': {s}", .{
+                lib_name, @errorName(err),
+            });
+        };
     }
 
     if (is_extern) {

--- a/test/stage2/aarch64.zig
+++ b/test/stage2/aarch64.zig
@@ -121,8 +121,8 @@ pub fn addCases(ctx: *TestContext) !void {
 
         // Regular old hello world
         case.addCompareOutput(
-            \\extern fn write(usize, usize, usize) usize;
-            \\extern fn exit(usize) noreturn;
+            \\extern "c" fn write(usize, usize, usize) usize;
+            \\extern "c" fn exit(usize) noreturn;
             \\
             \\pub export fn main() noreturn {
             \\    print();
@@ -141,7 +141,7 @@ pub fn addCases(ctx: *TestContext) !void {
 
         // Now using start.zig without an explicit extern exit fn
         case.addCompareOutput(
-            \\extern fn write(usize, usize, usize) usize;
+            \\extern "c" fn write(usize, usize, usize) usize;
             \\
             \\pub fn main() void {
             \\    print();
@@ -158,7 +158,7 @@ pub fn addCases(ctx: *TestContext) !void {
 
         // Print it 4 times and force growth and realloc.
         case.addCompareOutput(
-            \\extern fn write(usize, usize, usize) usize;
+            \\extern "c" fn write(usize, usize, usize) usize;
             \\
             \\pub fn main() void {
             \\    print();
@@ -182,7 +182,7 @@ pub fn addCases(ctx: *TestContext) !void {
 
         // Print it once, and change the message.
         case.addCompareOutput(
-            \\extern fn write(usize, usize, usize) usize;
+            \\extern "c" fn write(usize, usize, usize) usize;
             \\
             \\pub fn main() void {
             \\    print();
@@ -199,7 +199,7 @@ pub fn addCases(ctx: *TestContext) !void {
 
         // Now we print it twice.
         case.addCompareOutput(
-            \\extern fn write(usize, usize, usize) usize;
+            \\extern "c" fn write(usize, usize, usize) usize;
             \\
             \\pub fn main() void {
             \\    print();

--- a/test/stage2/x86_64.zig
+++ b/test/stage2/x86_64.zig
@@ -328,7 +328,7 @@ pub fn addCases(ctx: *TestContext) !void {
                 .macos => {
                     // While loops
                     case.addCompareOutput(
-                        \\extern fn write(usize, usize, usize) usize;
+                        \\extern "c" fn write(usize, usize, usize) usize;
                         \\
                         \\pub fn main() void {
                         \\    var i: u32 = 0;
@@ -349,7 +349,7 @@ pub fn addCases(ctx: *TestContext) !void {
 
                     // inline while requires the condition to be comptime known.
                     case.addError(
-                        \\extern fn write(usize, usize, usize) usize;
+                        \\extern "c" fn write(usize, usize, usize) usize;
                         \\
                         \\pub fn main() void {
                         \\    var i: u32 = 0;
@@ -652,7 +652,7 @@ pub fn addCases(ctx: *TestContext) !void {
                 .macos => {
                     // Basic for loop
                     case.addCompareOutput(
-                        \\extern fn write(usize, usize, usize) usize;
+                        \\extern "c" fn write(usize, usize, usize) usize;
                         \\
                         \\pub fn main() void {
                         \\    for ("hello") |_| print();
@@ -736,7 +736,7 @@ pub fn addCases(ctx: *TestContext) !void {
                 }),
                 .macos => try case.files.append(.{
                     .src = 
-                    \\extern fn write(usize, usize, usize) usize;
+                    \\extern "c" fn write(usize, usize, usize) usize;
                     \\
                     \\pub fn print() void {
                     \\    _ = write(1, @ptrToInt("Hello, World!\n"), 14);
@@ -814,7 +814,7 @@ pub fn addCases(ctx: *TestContext) !void {
                 }),
                 .macos => try case.files.append(.{
                     .src = 
-                    \\extern fn write(usize, usize, usize) usize;
+                    \\extern "c" fn write(usize, usize, usize) usize;
                     \\fn print() void {
                     \\    _ = write(1, @ptrToInt("Hello, World!\n"), 14);
                     \\}
@@ -1478,7 +1478,7 @@ pub fn addCases(ctx: *TestContext) !void {
                     \\}
                 , "HelloHello, World!\n"),
                 .macos => case.addCompareOutput(
-                    \\extern fn write(usize, usize, usize) usize;
+                    \\extern "c" fn write(usize, usize, usize) usize;
                     \\
                     \\pub fn main() void {
                     \\    comptime var len: u32 = 5;
@@ -1550,7 +1550,7 @@ pub fn addCases(ctx: *TestContext) !void {
                     \\}
                 , "HeHelHellHello"),
                 .macos => case.addCompareOutput(
-                    \\extern fn write(usize, usize, usize) usize;
+                    \\extern "c" fn write(usize, usize, usize) usize;
                     \\
                     \\pub fn main() void {
                     \\    comptime var i: u64 = 2;
@@ -2117,8 +2117,8 @@ fn addMacOsTestCases(ctx: *TestContext) !void {
 
         // Regular old hello world
         case.addCompareOutput(
-            \\extern fn write(usize, usize, usize) usize;
-            \\extern fn exit(usize) noreturn;
+            \\extern "c" fn write(usize, usize, usize) usize;
+            \\extern "c" fn exit(usize) noreturn;
             \\
             \\pub export fn main() noreturn {
             \\    print();
@@ -2137,7 +2137,7 @@ fn addMacOsTestCases(ctx: *TestContext) !void {
 
         // Now using start.zig without an explicit extern exit fn
         case.addCompareOutput(
-            \\extern fn write(usize, usize, usize) usize;
+            \\extern "c" fn write(usize, usize, usize) usize;
             \\
             \\pub fn main() void {
             \\    print();
@@ -2154,7 +2154,7 @@ fn addMacOsTestCases(ctx: *TestContext) !void {
 
         // Print it 4 times and force growth and realloc.
         case.addCompareOutput(
-            \\extern fn write(usize, usize, usize) usize;
+            \\extern "c" fn write(usize, usize, usize) usize;
             \\
             \\pub fn main() void {
             \\    print();
@@ -2178,7 +2178,7 @@ fn addMacOsTestCases(ctx: *TestContext) !void {
 
         // Print it once, and change the message.
         case.addCompareOutput(
-            \\extern fn write(usize, usize, usize) usize;
+            \\extern "c" fn write(usize, usize, usize) usize;
             \\
             \\pub fn main() void {
             \\    print();
@@ -2195,7 +2195,7 @@ fn addMacOsTestCases(ctx: *TestContext) !void {
 
         // Now we print it twice.
         case.addCompareOutput(
-            \\extern fn write(usize, usize, usize) usize;
+            \\extern "c" fn write(usize, usize, usize) usize;
             \\
             \\pub fn main() void {
             \\    print();


### PR DESCRIPTION
Fixes #10765

Changes:

* sema: do not pass libc or libc++ to the linker as system libs on the linker line `-lc` and `-lc++` - they are handled separately via link options flags
* macho: handle bss like normal section in stage2 - this is just a temporary workaround until I work out how to manage non-physical sections between incremental updates
* update stage2 tests to use name-qualified import lib names for externs:

From:

```zig
extern fn write(...);
```

to

```zig
extern "c" fn write(...);
```

cc @schmee 