### PR TITLE
C Backend: f16 and f128 support

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -422,6 +422,9 @@ pub const DeclGen = struct {
         const is_neg = int_val < 0;
         comptime assert(int_info.bits > 64 and int_info.bits <= 128);
 
+        // TODO support big endian arch
+        comptime assert(builtin.cpu.arch.endian() == .Little);
+
         // Clang and GCC don't support 128-bit integer constants but will hopefully unfold them
         // if we construct one manually.
         const magnitude = std.math.absCast(int_val);

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -165,6 +165,17 @@
 
 #define int128_t __int128
 #define uint128_t unsigned __int128
+
+#if defined(__aarch64__)
+#define ZIG_HAS_FLOAT128
+#define float128_t long double
+#elif defined(__FreeBSD__) || defined(__APPLE__)
+#define float128_t ZIG_UNSUPPORTED_SYMBOL_ON_TARGET_float128_t
+#else
+#define ZIG_HAS_FLOAT128
+#define float128_t __float128
+#endif
+
 ZIG_EXTERN_C void *memcpy (void *ZIG_RESTRICT, const void *ZIG_RESTRICT, size_t);
 ZIG_EXTERN_C void *memset (void *, int, size_t);
 
@@ -407,6 +418,14 @@ static inline double zig_bitcast_f64_u64(uint64_t arg) {
     memcpy(&dest, &arg, sizeof dest);
     return dest;
 }
+
+#if defined(ZIG_HAS_FLOAT128)
+static inline float128_t zig_bitcast_f128_u128(uint128_t arg) {
+    float128_t dest;
+    memcpy(&dest, &arg, sizeof dest);
+    return dest;
+}
+#endif
 
 #define zig_add_sat_u(ZT, T) static inline T zig_adds_##ZT(T x, T y, T max) { \
     return (x > max - y) ? max : x + y; \

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -176,6 +176,16 @@
 #define float128_t __float128
 #endif
 
+#if defined(__clang__)
+#define float16_t __fp16
+#elif defined(__GNUC__) && (defined(__arm__) || defined(__aarch64__))
+#define float16_t __fp16
+#elif defined(__GNUC__) && defined(__i386__) && defined(__SSE2__)
+#define float16_t _Float16
+#else
+#define float16_t ZIG_UNSUPPORTED_SYMBOL_ON_TARGET_float16_t
+#endif
+
 ZIG_EXTERN_C void *memcpy (void *ZIG_RESTRICT, const void *ZIG_RESTRICT, size_t);
 ZIG_EXTERN_C void *memset (void *, int, size_t);
 

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -402,7 +402,7 @@ static inline float zig_bitcast_f32_u32(uint32_t arg) {
     return dest;
 }
 
-static inline float zig_bitcast_f64_u64(uint64_t arg) {
+static inline double zig_bitcast_f64_u64(uint64_t arg) {
     double dest;
     memcpy(&dest, &arg, sizeof dest);
     return dest;

--- a/src/value.zig
+++ b/src/value.zig
@@ -2897,7 +2897,7 @@ pub const Value = extern union {
     pub fn floatToIntScalar(val: Value, arena: Allocator, int_ty: Type, target: Target) error{ FloatCannotFit, OutOfMemory }!Value {
         const Limb = std.math.big.Limb;
 
-        var value = val.toFloat(f64); // TODO: f128 ?
+        var value = val.toFloat(f128);
         if (std.math.isNan(value) or std.math.isInf(value)) {
             return error.FloatCannotFit;
         }
@@ -2909,7 +2909,7 @@ pub const Value = extern union {
 
         var rational = try std.math.big.Rational.init(arena);
         defer rational.deinit();
-        rational.setFloat(f64, floored) catch |err| switch (err) {
+        rational.setFloat(f128, floored) catch |err| switch (err) {
             error.NonFiniteFloat => unreachable,
             error.OutOfMemory => return error.OutOfMemory,
         };

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -697,6 +697,46 @@ test "f128 at compile time is lossy" {
     try expect(@as(f128, 10384593717069655257060992658440192.0) + 1 == 10384593717069655257060992658440192.0);
 }
 
+test "f16 special values" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+
+    const f16_inf = @bitCast(f16, @as(u16, 0x7c00));
+    const f16_nan = @bitCast(f16, @as(u16, 0x7c01));
+
+    var buf: f16 = math.f16_true_min;
+    try expect(math.f16_true_min == buf);
+
+    buf = math.f16_min;
+    try expect(math.f16_min == buf);
+
+    buf = math.f16_max;
+    try expect(math.f16_max == buf);
+
+    buf = -math.f16_max;
+    try expect(-math.f16_max == buf);
+
+    buf = 0;
+    try expect(@as(f16, 0) == buf);
+
+    buf = -0;
+    try expect(@as(f16, -0) == buf);
+
+    buf = -1;
+    try expect(@as(f16, -1) == buf);
+
+    buf = f16_inf;
+    try expect(f16_inf == buf);
+
+    buf = -f16_inf;
+    try expect(-f16_inf == buf);
+
+    buf = f16_nan;
+    try expect(math.isNan(buf));
+}
+
 test "f128 special values" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -696,3 +696,53 @@ test "f128 at compile time is lossy" {
 
     try expect(@as(f128, 10384593717069655257060992658440192.0) + 1 == 10384593717069655257060992658440192.0);
 }
+
+test "f128 special values" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.cpu.arch == .i386) return error.SkipZigTest; // TODO
+
+    const f128_true_min = @bitCast(f128, @as(u128, 0x00000000000000000000000000000001));
+    const f128_min = @bitCast(f128, @as(u128, 0x00010000000000000000000000000000));
+    const f128_max = @bitCast(f128, @as(u128, 0x7ffeffffffffffffffffffffffffffff));
+    const f128_inf = @bitCast(f128, @as(u128, 0x7fff0000000000000000000000000000));
+    const f128_nan = @bitCast(f128, @as(u128, 0x7fff0000000000000000000000000001));
+
+    var buf = f128_true_min;
+    try expect(f128_true_min == buf);
+
+    buf = f128_min;
+    try expect(f128_min == buf);
+
+    buf = f128_max;
+    try expect(f128_max == buf);
+
+    buf = -f128_max;
+    try expect(-f128_max == buf);
+
+    buf = 0;
+    try expect(@as(f128, 0) == buf);
+
+    buf = -0;
+    try expect(@as(f128, -0) == buf);
+
+    buf = -1;
+    try expect(@as(f128, -1) == buf);
+
+    buf = @as(f128, math.f64_max) + 42.0;
+    try expect(@floatCast(f64, buf - 42.0) == math.f64_max);
+
+    buf = @as(f128, math.f64_min) - f128_min;
+    try expect(@floatCast(f64, buf + f128_min) == math.f64_min);
+
+    buf = f128_inf;
+    try expect(f128_inf == buf);
+
+    buf = -f128_inf;
+    try expect(-f128_inf == buf);
+
+    buf = f128_nan;
+    try expect(math.isNan(buf));
+}


### PR DESCRIPTION
- 128-bit floats: use `__float128` type, re-use 128-bit int literal trick for floats
- 16-bit floats: use either `__fp16` or `_Float16` when supported

Compiler support is not super robust, but since `__int128` is also used without any `#if defined` guard, I did the same for `__float128`.

Support for 16-bit floats is a bit more documented from what I found and I tried to make the `#if defined` guards match actual compiler support. See https://gcc.gnu.org/onlinedocs/gcc/Half-Precision.html and https://clang.llvm.org/docs/LanguageExtensions.html#id12. (I didn't found any doc for the Microsoft compiler.)

Note/Question: The `TODO: f128 ?` comment in `Value.floatToInt()` leads me to think there was maybe a reason (performance related?) not to directly use a f128 instead of a f64, so it may require some rework.