### PR TITLE
elf: add basic handling of .data section

### DIFF
--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -14,6 +14,7 @@ test {
     _ = @import("behavior/bugs/1277.zig");
     _ = @import("behavior/bugs/1310.zig");
     _ = @import("behavior/bugs/1381.zig");
+    _ = @import("behavior/bugs/1486.zig");
     _ = @import("behavior/bugs/1500.zig");
     _ = @import("behavior/bugs/1735.zig");
     _ = @import("behavior/bugs/2006.zig");
@@ -43,7 +44,6 @@ test {
         _ = @import("behavior/bugs/624.zig");
         _ = @import("behavior/bugs/704.zig");
         _ = @import("behavior/bugs/1076.zig");
-        _ = @import("behavior/bugs/1486.zig");
         _ = @import("behavior/bugs/2692.zig");
         _ = @import("behavior/bugs/2889.zig");
         _ = @import("behavior/bugs/3046.zig");

--- a/test/behavior/bugs/1486.zig
+++ b/test/behavior/bugs/1486.zig
@@ -1,9 +1,13 @@
-const expect = @import("std").testing.expect;
+const std = @import("std");
+const builtin = @import("builtin");
+const expect = std.testing.expect;
 
 const ptr = &global;
-var global: u64 = 123;
+var global: usize = 123;
 
 test "constant pointer to global variable causes runtime load" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     global = 1234;
     try expect(&global == ptr);
     try expect(ptr.* == 1234);


### PR DESCRIPTION
With special dedication to @joachimschmidt557 ;-)

This is the first commit in what probably will be a series of commits and rewrites of the ELF linker. For now, refactors how we handle different phdrs and shdrs with a caveat that, in incremental context, there is always a one-to-one mapping between the two, while in traditional context, we will have one-to-many (for better filesize results).