### PR TITLE
turn echo back on in windows_msvc_script.bat

### DIFF
--- a/ci/azure/windows_msvc_script.bat
+++ b/ci/azure/windows_msvc_script.bat
@@ -15,6 +15,9 @@ SET "ZIGPREFIXPATH=%SRCROOT%\llvm+clang+lld-13.0.0-x86_64-windows-msvc-release-m
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
 
+REM vcvarsall.bat turns echo off, turn it back on so we can see commands in ci logs
+echo on
+
 REM Make the `zig version` number consistent.
 REM This will affect the cmake command below.
 git.exe config core.abbrev 9


### PR DESCRIPTION
Zig turns echo on at the start of the msvc build script, but then `vcvarsall.bat` turns echo off (because otherwise it would print thousands of commands to the screen).  This PR turns it back after calling `vcvarsall.bat` on so we can see the rest of the batch commands in the CI logs.

This will help triage an intemittent failure on Windows where the CI sometimes gets stuck somewhere between "test-std" and "docs".  It's unclear exactly where but this change should make it clear and help us triage other CI failures in the future.