### PR TITLE
std.process: add option to support single quotes to ArgIteratorGeneral

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4226,7 +4226,7 @@ pub const ClangArgIterator = struct {
         };
     }
 
-    const ArgIteratorResponseFile = process.ArgIteratorGeneral(.{ .comments_supported = true });
+    const ArgIteratorResponseFile = process.ArgIteratorGeneral(.{ .comments = true, .single_quotes = true });
 
     /// Initialize the arguments from a Response File. "*.rsp"
     fn initArgIteratorResponseFile(allocator: Allocator, resp_file_path: []const u8) !ArgIteratorResponseFile {


### PR DESCRIPTION
Closes  #10787

Not sure whether we should accept single quotes for windows, I'm guessing not?