### PR TITLE
Dry run of spawn

### DIFF
--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -153,6 +153,10 @@ fn stdIoActionToBehavior(action: StdIoAction) std.ChildProcess.StdIo {
 }
 
 fn make(step: *Step) !void {
+    if (!os.can_spawn()) {
+        std.debug.print("Unable to spawn {s}: the current OS doesn't support it\n", .{argv[0]});
+        return;
+    }
     const self = @fieldParentPtr(RunStep, "step", step);
 
     const cwd = if (self.cwd) |cwd| self.builder.pathFromRoot(cwd) else self.builder.build_root;

--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -176,7 +176,7 @@ fn make(step: *Step) !void {
 
     const argv = argv_list.items;
 
-    if (!os.can_spawn()) {
+    if (!os.can_spawn) {
         std.debug.print("Unable to spawn {s}: the current OS doesn't support it\n", .{argv[0]});
         return;
     }

--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -1,6 +1,7 @@
 const std = @import("../std.zig");
 const builtin = @import("builtin");
 const build = std.build;
+const os = std.os;
 const Step = build.Step;
 const Builder = build.Builder;
 const LibExeObjStep = build.LibExeObjStep;
@@ -153,10 +154,6 @@ fn stdIoActionToBehavior(action: StdIoAction) std.ChildProcess.StdIo {
 }
 
 fn make(step: *Step) !void {
-    if (!os.can_spawn()) {
-        std.debug.print("Unable to spawn {s}: the current OS doesn't support it\n", .{argv[0]});
-        return;
-    }
     const self = @fieldParentPtr(RunStep, "step", step);
 
     const cwd = if (self.cwd) |cwd| self.builder.pathFromRoot(cwd) else self.builder.build_root;
@@ -178,6 +175,11 @@ fn make(step: *Step) !void {
     }
 
     const argv = argv_list.items;
+
+    if (!os.can_spawn()) {
+        std.debug.print("Unable to spawn {s}: the current OS doesn't support it\n", .{argv[0]});
+        return;
+    }
 
     const child = std.ChildProcess.init(argv, self.builder.allocator) catch unreachable;
     defer child.deinit();

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -6507,3 +6507,10 @@ pub fn perf_event_open(
         else => |err| return unexpectedErrno(err),
     }
 }
+
+/// Return if the current OS can spawn or not.
+/// This is useful to enable compiling Zig to WASI, where spawn is not available.
+const can_spawn = switch (builtin.os.tag) {
+    .wasi => false,
+    else => true,
+};

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -6510,7 +6510,7 @@ pub fn perf_event_open(
 
 /// Return if the current OS can spawn or not.
 /// This is useful to enable compiling Zig to WASI, where spawn is not available.
-const can_spawn = switch (builtin.os.tag) {
+pub const can_spawn = switch (builtin.os.tag) {
     .wasi => false,
     else => true,
 };


### PR DESCRIPTION
This PR is in-progress for fixing #10750.
Places where spawn should now work:
* [ ] `zig test` - instead print a message about not being able to spawn child processes and exit success.
* [x] `zig run` - instead print "unable to spawn child processes" and exit failure.
* [ ] for clang we can invoke clang_main directly instead of as a child process
* [ ] for lld we can invoke the lld library functions instead of as child process
* [ ] same thing for `zig ar`, `zig dlltool`, etc.
* [ ] for detecting native libc, just return error.LibcNotDetected or whatever the appropriate error is.

Note: This is the first time I'm trying Zig so I want to make sure I do things according to what's expected, looking forward to the feedback!