### PR TITLE
stage2: store externs lib name as part of decl

### DIFF
--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -1574,8 +1574,15 @@ fn airCall(self: *Self, inst: Air.Inst.Index) !void {
                     .data = .{ .reg = .x30 },
                 });
             } else if (func_value.castTag(.extern_fn)) |func_payload| {
-                const decl = func_payload.data;
-                const n_strx = try macho_file.addExternFn(mem.sliceTo(decl.name, 0));
+                const extern_fn = func_payload.data;
+                const decl_name = extern_fn.owner_decl.name;
+                if (extern_fn.lib_name) |lib_name| {
+                    log.debug("TODO enforce that '{s}' is expected in '{s}' library", .{
+                        decl_name,
+                        lib_name,
+                    });
+                }
+                const n_strx = try macho_file.addExternFn(mem.sliceTo(decl_name, 0));
 
                 _ = try self.addInst(.{
                     .tag = .call_extern,

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -952,7 +952,7 @@ pub const DeclGen = struct {
             _ = func_payload;
             return self.fail("TODO wasm backend genDecl function pointer", .{});
         } else if (decl.val.castTag(.extern_fn)) |extern_fn| {
-            const ext_decl = extern_fn.data;
+            const ext_decl = extern_fn.data.owner_decl;
             var func_type = try genFunctype(self.gpa, ext_decl.ty, self.target());
             func_type.deinit(self.gpa);
             ext_decl.fn_link.wasm.type_index = try self.bin_file.putOrGetFuncType(func_type);
@@ -978,7 +978,7 @@ pub const DeclGen = struct {
         switch (ty.zigTypeTag()) {
             .Fn => {
                 const fn_decl = switch (val.tag()) {
-                    .extern_fn => val.castTag(.extern_fn).?.data,
+                    .extern_fn => val.castTag(.extern_fn).?.data.owner_decl,
                     .function => val.castTag(.function).?.data.owner_decl,
                     else => unreachable,
                 };
@@ -1776,7 +1776,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
         if (func_val.castTag(.function)) |func| {
             break :blk func.data.owner_decl;
         } else if (func_val.castTag(.extern_fn)) |ext_fn| {
-            break :blk ext_fn.data;
+            break :blk ext_fn.data.owner_decl;
         } else if (func_val.castTag(.decl_ref)) |decl_ref| {
             break :blk decl_ref.data;
         }

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -2516,8 +2516,15 @@ fn airCall(self: *Self, inst: Air.Inst.Index) !void {
                     .data = undefined,
                 });
             } else if (func_value.castTag(.extern_fn)) |func_payload| {
-                const decl = func_payload.data;
-                const n_strx = try macho_file.addExternFn(mem.sliceTo(decl.name, 0));
+                const extern_fn = func_payload.data;
+                const decl_name = extern_fn.owner_decl.name;
+                if (extern_fn.lib_name) |lib_name| {
+                    log.debug("TODO enforce that '{s}' is expected in '{s}' library", .{
+                        decl_name,
+                        lib_name,
+                    });
+                }
+                const n_strx = try macho_file.addExternFn(mem.sliceTo(decl_name, 0));
                 _ = try self.addInst(.{
                     .tag = .call_extern,
                     .ops = undefined,

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -542,8 +542,8 @@ pub const DeclGen = struct {
                     try dg.renderDeclName(func.owner_decl, writer);
                 },
                 .extern_fn => {
-                    const decl = val.castTag(.extern_fn).?.data;
-                    try dg.renderDeclName(decl, writer);
+                    const extern_fn = val.castTag(.extern_fn).?.data;
+                    try dg.renderDeclName(extern_fn.owner_decl, writer);
                 },
                 .int_u64, .one => {
                     try writer.writeAll("((");
@@ -681,7 +681,7 @@ pub const DeclGen = struct {
                     return dg.renderDeclValue(writer, ty, val, decl);
                 },
                 .extern_fn => {
-                    const decl = val.castTag(.extern_fn).?.data;
+                    const decl = val.castTag(.extern_fn).?.data.owner_decl;
                     return dg.renderDeclValue(writer, ty, val, decl);
                 },
                 else => unreachable,
@@ -2442,7 +2442,7 @@ fn airCall(f: *Function, inst: Air.Inst.Index) !CValue {
             const fn_decl = fn_decl: {
                 const callee_val = f.air.value(pl_op.operand) orelse break :known;
                 break :fn_decl switch (callee_val.tag()) {
-                    .extern_fn => callee_val.castTag(.extern_fn).?.data,
+                    .extern_fn => callee_val.castTag(.extern_fn).?.data.owner_decl,
                     .function => callee_val.castTag(.function).?.data.owner_decl,
                     .decl_ref => callee_val.castTag(.decl_ref).?.data,
                     else => break :known,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -622,7 +622,7 @@ pub const DeclGen = struct {
             _ = func_payload;
             @panic("TODO llvm backend genDecl function pointer");
         } else if (decl.val.castTag(.extern_fn)) |extern_fn| {
-            _ = try dg.resolveLlvmFunction(extern_fn.data);
+            _ = try dg.resolveLlvmFunction(extern_fn.data.owner_decl);
         } else {
             const target = dg.module.getTarget();
             const global = try dg.resolveGlobalDecl(decl);
@@ -1410,7 +1410,7 @@ pub const DeclGen = struct {
             },
             .Fn => {
                 const fn_decl = switch (tv.val.tag()) {
-                    .extern_fn => tv.val.castTag(.extern_fn).?.data,
+                    .extern_fn => tv.val.castTag(.extern_fn).?.data.owner_decl,
                     .function => tv.val.castTag(.function).?.data.owner_decl,
                     else => unreachable,
                 };


### PR DESCRIPTION
* add new `Decl` subtype, `Decl.ExternFn` - `ExternFn` will contain a maybe-lib-name if it was defined with the `extern` keyword like so

```zig
extern "c" fn write(usize, usize, usize) usize;
```

`lib_name` will live as long as `ExternFn` decl does.

---

TODO
- [x] handle lib name in extern variable