### PR TITLE
child_process: collectOutputWindows handle broken_pipe from ReadFile

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -288,10 +288,8 @@ pub const ChildProcess = struct {
                 else => |err| return windows.unexpectedError(err),
             }
         }
-        if (wait_object_count == 0)
-            return;
 
-        while (true) {
+        while (wait_object_count > 0) {
             const status = windows.kernel32.WaitForMultipleObjects(wait_object_count, &wait_objects, 0, windows.INFINITE);
             if (status == windows.WAIT_FAILED) {
                 switch (windows.kernel32.GetLastError()) {
@@ -315,11 +313,7 @@ pub const ChildProcess = struct {
             var read_bytes: u32 = undefined;
             if (windows.kernel32.GetOverlappedResult(handles[i], &overlapped[i], &read_bytes, 0) == 0) {
                 switch (windows.kernel32.GetLastError()) {
-                    .BROKEN_PIPE => {
-                        if (wait_object_count == 0)
-                            break;
-                        continue;
-                    },
+                    .BROKEN_PIPE => continue,
                     else => |err| return windows.unexpectedError(err),
                 }
             }

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -270,12 +270,14 @@ pub const ChildProcess = struct {
             try buf.ensureTotalCapacity(new_capacity);
             const next_buf = buf.unusedCapacitySlice();
             if (next_buf.len == 0) return .full;
-            const read_result = windows.kernel32.ReadFile(handle, next_buf.ptr, math.cast(u32, next_buf.len) catch maxInt(u32), null, overlapped);
+            var read_bytes: u32 = undefined;
+            const read_result = windows.kernel32.ReadFile(handle, next_buf.ptr, math.cast(u32, next_buf.len) catch maxInt(u32), &read_bytes, overlapped);
             if (read_result == 0) return switch (windows.kernel32.GetLastError()) {
                 .IO_PENDING => .pending,
                 .BROKEN_PIPE => .closed,
                 else => |err| windows.unexpectedError(err),
             };
+            buf.items.len += read_bytes;
         }
     }
 


### PR DESCRIPTION
This was found on a user's machine when calling "git" as a child process from msys.  Instead of getting `BROKEN_PIPE` on `GetOverlappedResult` like we currently expect, it would occur on `ReadFile` which we are currently ignoring, which would then cause collectOutputWindows to hang because the async operation was never started.

With this patch, `zig build` no longer hangs on their machine when collecting output from child processes.  This bug could also be causing intermittent "hangs" in the CI on windows.