### PR TITLE
CLI: remove remainders of --verbose-ast and --verbose-tokenize

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -34,8 +34,6 @@ pub const Builder = struct {
     available_options_map: AvailableOptionsMap,
     available_options_list: ArrayList(AvailableOption),
     verbose: bool,
-    verbose_tokenize: bool,
-    verbose_ast: bool,
     verbose_link: bool,
     verbose_cc: bool,
     verbose_air: bool,
@@ -172,8 +170,6 @@ pub const Builder = struct {
             .cache_root = try fs.path.relative(allocator, build_root, cache_root),
             .global_cache_root = global_cache_root,
             .verbose = false,
-            .verbose_tokenize = false,
-            .verbose_ast = false,
             .verbose_link = false,
             .verbose_cc = false,
             .verbose_air = false,
@@ -2405,8 +2401,6 @@ pub const LibExeObjStep = struct {
             try zig_args.append(log_scope);
         }
 
-        if (builder.verbose_tokenize) zig_args.append("--verbose-tokenize") catch unreachable;
-        if (builder.verbose_ast) zig_args.append("--verbose-ast") catch unreachable;
         if (builder.verbose_cimport) zig_args.append("--verbose-cimport") catch unreachable;
         if (builder.verbose_air) zig_args.append("--verbose-air") catch unreachable;
         if (builder.verbose_llvm_ir) zig_args.append("--verbose-llvm-ir") catch unreachable;

--- a/lib/std/special/build_runner.zig
+++ b/lib/std/special/build_runner.zig
@@ -147,10 +147,6 @@ pub fn main() !void {
                     std.debug.print("Expected argument after --glibc-runtimes\n\n", .{});
                     return usageAndErr(builder, false, stderr_stream);
                 };
-            } else if (mem.eql(u8, arg, "--verbose-tokenize")) {
-                builder.verbose_tokenize = true;
-            } else if (mem.eql(u8, arg, "--verbose-ast")) {
-                builder.verbose_ast = true;
             } else if (mem.eql(u8, arg, "--verbose-link")) {
                 builder.verbose_link = true;
             } else if (mem.eql(u8, arg, "--verbose-air")) {
@@ -310,8 +306,6 @@ fn usage(builder: *Builder, already_ran_build: bool, out_stream: anytype) !void 
         \\  --cache-dir [path]           Override path to zig cache directory
         \\  --zig-lib-dir [arg]          Override path to Zig lib directory
         \\  --debug-log [scope]          Enable debugging the compiler
-        \\  --verbose-tokenize           Enable compiler debug output for tokenization
-        \\  --verbose-ast                Enable compiler debug output for parsing into an AST
         \\  --verbose-link               Enable compiler debug output for linking
         \\  --verbose-air                Enable compiler debug output for Zig AIR
         \\  --verbose-llvm-ir            Enable compiler debug output for LLVM IR

--- a/src/stage1/zig0.cpp
+++ b/src/stage1/zig0.cpp
@@ -51,8 +51,6 @@ static int print_full_usage(const char *arg0, FILE *file, int return_code) {
         "  --strip                      exclude debug symbols\n"
         "  -target [name]               <arch>-<os>-<abi> see the targets command\n"
         "  -mcpu [cpu]                  specify target CPU and feature set\n"
-        "  --verbose-tokenize           enable compiler debug output for tokenization\n"
-        "  --verbose-ast                enable compiler debug output for AST parsing\n"
         "  --verbose-ir                 enable compiler debug output for Zig IR\n"
         "  --verbose-llvm-ir            enable compiler debug output for LLVM IR\n"
         "  --verbose-cimport            enable compiler debug output for C imports\n"


### PR DESCRIPTION
These options were removed in 5e63baae8 but some remainders were left in.