### PR TITLE
Sema: Fix memory leak

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7058,6 +7058,7 @@ fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
                 sema.air_extra.appendSliceAssumeCapacity(prev_then_body);
                 sema.air_extra.appendSliceAssumeCapacity(cond_body);
             }
+            gpa.free(prev_then_body);
             prev_then_body = case_block.instructions.toOwnedSlice(gpa);
             prev_cond_br = new_cond_br;
         }


### PR DESCRIPTION
Fixes a memory leak when generating the instructions for a switch case's body.
As `prev_then_body` is being overwritten, we only free the last case, but never the previous instruction lists that were overwritten. This change ensures it will be freed before we overwrite it.