### PR TITLE
stage2: apply type coercion in if expressions

### DIFF
--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -693,3 +693,9 @@ test "variable name containing underscores does not shadow int primitive" {
     _ = u6__4;
     _ = i2_04_8;
 }
+
+test "if expression type coercion" {
+    var cond: bool = true;
+    const x: u16 = if (cond) 1 else 0;
+    try expect(@as(u16, x) == 1);
+}


### PR DESCRIPTION
An attempt to address https://github.com/ziglang/zig/issues/10816 by imitating what's already happening for [switch expressions](https://github.com/ziglang/zig/blob/master/src/AstGen.zig#L5936-L5959).
 
With this commit applied, `ast-check -t` now produces the output expected in the issue:

```
# Source bytes:       378B
# Tokens:             38 (214B)
# AST Nodes:          19 (367B)
# Total ZIR bytes:    542B
# Instructions:       24 (216B)
# String Table Bytes: 66B
# Extra Data Items:   49 (196B)
%0 = extended(struct_decl(parent, Auto, {
  [41] export entry line(2) hash(7a2ff26191c0207ee25eab8aafc47359): %1 = block_inline({
    %22 = func(ret_ty={
      %2 = break_inline(%22, @Ref.void_type)
    }, body={
      %3 = dbg_stmt(2, 5)
      %4 = alloc_mut(@Ref.bool_type) node_offset:4:5
      %5 = store_node(%4, @Ref.bool_true) node_offset:4:22
      %6 = dbg_stmt(3, 5)
      %11 = block({
        %8 = load(%4) node_offset:5:75
        %9 = as_node(@Ref.bool_type, %8) node_offset:5:75
        %10 = condbr(%9, {
          %12 = int(32768)
          %13 = as(@Ref.u16_type, %12)
          %15 = break(%11, %13)
        }, {
          %14 = as(@Ref.u16_type, @Ref.zero)
          %16 = break(%11, %14)
        }) node_offset:5:71
      }) node_offset:5:71
      %18 = dbg_stmt(4, 5)
      %19 = as_node(@Ref.u16_type, %11) node_offset:6:18
      %20 = ensure_result_non_error(%19) node_offset:6:9
      %21 = ret_coerce(@Ref.void_value) token_offset:9:1
    }) (lbrace=1:24,rbrace=7:1) node_offset:3:8
    %23 = break_inline(%1, %22)
  }) node_offset:3:8
}, {}, {})
```

However, I am currently unable to run the stage2 behavior tests, even on `master`. Running `./stage2/bin/zig test test/behavior.zig -Itest -fLLVM` result in the following error:

<details>

```
$ ./stage2/bin/zig test test/behavior.zig -Itest -fLLVM
panic: reached unreachable code
Analyzing /Users/<USER>/repos/zig/stage2/lib/zig/std/special/compiler_rt/extend_f80.zig: compiler_rt/extend_f80.zig:extendF80
      %86 = dbg_stmt(2, 5)
      %87 = decl_val("builtin")
      %88 = field_val(%87, "is_test")
      %89 = as_node(@Ref.bool_type, %88)
      %90 = set_runtime_safety(%89)
      %91 = dbg_stmt(4, 5)
      %93 = decl_ref("std")
      %94 = field_ptr(%93, "meta")
      %95 = field_call_bind(%94, "Int")
      %96 = enum_literal("unsigned")
      %97 = type_info(%74)
      %98 = field_val(%97, "Float")
      %99 = field_val(%98, "bits")
      %100 = call(.auto, %95, [%96, %99])
      %102 = dbg_stmt(5, 5)
      %104 = decl_ref("std")
      %105 = field_ptr(%104, "math")
      %106 = field_call_bind(%105, "floatMantissaBits")
      %107 = call(.auto, %106, [%74])
      %109 = dbg_stmt(6, 5)
      %110 = int(9223372036854775808)
      %111 = dbg_stmt(7, 5)
      %112 = decl_ref("std")
      %113 = field_ptr(%112, "math")
      %114 = field_call_bind(%113, "floatMantissaBits")
      %115 = call(.auto, %114, [@Ref.f80_type])
      %116 = sub(%115, @Ref.one)
      %117 = dbg_stmt(9, 5)
      %118 = int(16383)
      %119 = dbg_stmt(11, 5)
      %120 = bit_size_of(%74)
      %121 = dbg_stmt(12, 5)
      %122 = sub(%120, %107)
      %123 = sub(%122, @Ref.one)
      %124 = dbg_stmt(13, 5)
      %125 = typeof_log2_int_type(@Ref.one)
      %126 = as_node(%125, %123)
      %127 = shl(@Ref.one, %126)
      %128 = sub(%127, @Ref.one)
      %129 = dbg_stmt(14, 5)
      %130 = typeof_log2_int_type(%128)
      %131 = as_node(%130, @Ref.one)
      %132 = shr(%128, %131)
      %133 = dbg_stmt(16, 5)
      %134 = typeof_log2_int_type(@Ref.one)
      %135 = as_node(%134, %107)
      %136 = shl(@Ref.one, %135)
      %137 = dbg_stmt(17, 5)
      %138 = typeof_log2_int_type(%128)
      %139 = as_node(%138, %107)
      %140 = shl(%128, %139)
      %141 = dbg_stmt(18, 5)
      %142 = typeof_log2_int_type(@Ref.one)
      %143 = add(%107, %123)
      %144 = as_node(%142, %143)
      %145 = shl(@Ref.one, %144)
      %146 = dbg_stmt(19, 5)
      %147 = sub(%145, @Ref.one)
      %148 = dbg_stmt(20, 5)
      %149 = typeof_log2_int_type(@Ref.one)
      %150 = sub(%107, @Ref.one)
      %151 = as_node(%149, %150)
      %152 = shl(@Ref.one, %151)
      %153 = dbg_stmt(21, 5)
      %154 = sub(%152, @Ref.one)
      %155 = dbg_stmt(23, 5)
      %156 = int(16)
      %157 = as_node(@Ref.u16_type, %156)
      %158 = decl_val("std")
      %159 = field_val(%158, "math")
      %160 = field_val(%159, "F80Repr")
      %161 = extended(alloc(,ty=%160,align=%157))
      %162 = store_node(%161, @Ref.undef)
      %163 = dbg_stmt(26, 5)
      %164 = bit_and(%84, %147)
      %165 = dbg_stmt(27, 5)
      %171 = block({
        %167 = bit_and(%84, %145)
        %168 = cmp_neq(%167, @Ref.zero)
        %169 = as_node(@Ref.bool_type, %168)
        %170 = condbr(%169, {
          %172 = int(32768)
          %175 = break(%171, %172)
        }, {
          %176 = break(%171, @Ref.zero)
        })
      })
      %178 = dbg_stmt(29, 5)
      %184 = block({
        %179 = subwrap(%164, %136)
        %180 = sub(%140, %136)
        %181 = cmp_lt(%179, %180)
        %182 = as_node(@Ref.bool_type, %181)
        %183 = condbr(%182, {
          %185 = dbg_stmt(33, 9)
          %186 = field_ptr(%161, "exp")
          %187 = typeof_log2_int_type(%164)
          %188 = as_node(%187, %107)
          %189 = shr(%164, %188)
          %190 = int_cast(@Ref.u16_type, %189)
          %191 = store_node(%186, %190)
          %192 = dbg_stmt(34, 9)
          %193 = field_ptr(%161, "exp")
          %194 = load(%193)
          %195 = typeof(%194)
          %196 = sub(%118, %132)
          %197 = add(%194, %196)
          %198 = store(%193, %197)
          %199 = dbg_stmt(35, 9)
          %200 = field_ptr(%161, "fraction")
          %201 = as_node(@Ref.u64_type, %164)
          %202 = typeof_log2_int_type(%201)
          %203 = sub(%116, %107)
          %204 = as_node(%202, %203)
          %205 = shl(%201, %204)
          %206 = store_node(%200, %205)
          %207 = dbg_stmt(36, 9)
          %208 = field_ptr(%161, "fraction")
          %209 = load(%208)
          %210 = typeof(%209)
          %211 = bit_or(%209, %110)
          %212 = store(%208, %211)
          %310 = break(%184, @Ref.void_value)
        }, {
          %216 = block({
            %213 = cmp_gte(%164, %140)
            %214 = as_node(@Ref.bool_type, %213)
            %215 = condbr(%214, {
              %217 = dbg_stmt(42, 9)
              %218 = field_ptr(%161, "exp")
              %219 = int(32767)
              %220 = store_node(%218, %219)
              %221 = dbg_stmt(43, 9)
              %222 = field_ptr(%161, "fraction")
              %223 = store_node(%222, %110)
              %224 = dbg_stmt(44, 9)
              %225 = field_ptr(%161, "fraction")
              %226 = load(%225)
              %227 = typeof(%226)
              %228 = bit_and(%164, %152)
              %229 = as_node(@Ref.u64_type, %228)
              %230 = typeof_log2_int_type(%229)
              %231 = sub(%116, %107)
              %232 = as_node(%230, %231)
              %233 = shl(%229, %232)
              %234 = bit_or(%226, %233)
              %235 = store(%225, %234)
              %236 = dbg_stmt(45, 9)
              %237 = field_ptr(%161, "fraction")
              %238 = load(%237)
              %239 = typeof(%238)
              %240 = bit_and(%164, %154)
              %241 = as_node(@Ref.u64_type, %240)
              %242 = typeof_log2_int_type(%241)
              %243 = sub(%116, %107)
              %244 = as_node(%242, %243)
              %245 = shl(%241, %244)
              %246 = bit_or(%238, %245)
              %247 = store(%237, %246)
              %308 = break(%216, @Ref.void_value)
            }, {
              %251 = block({
                %248 = cmp_neq(%164, @Ref.zero)
                %249 = as_node(@Ref.bool_type, %248)
                %250 = condbr(%249, {
                  %252 = dbg_stmt(50, 9)
                  %253 = clz(%164)
                  %254 = as_node(%100, %136)
                  %255 = clz(%254)
                  %256 = sub(%253, %255)
                  %257 = as_node(@Ref.u16_type, %256)
                  %258 = dbg_stmt(53, 9)
                  %259 = field_ptr(%161, "fraction")
                  %260 = as_node(@Ref.u64_type, %164)
                  %261 = typeof_log2_int_type(%260)
                  %262 = int_type(u6)
                  %263 = sub(%116, %107)
                  %264 = add(%263, %257)
                  %265 = int_cast(%262, %264)
                  %266 = as_node(%261, %265)
                  %267 = shl(%260, %266)
                  %268 = store_node(%259, %267)
                  %269 = dbg_stmt(54, 9)
                  %270 = field_ptr(%161, "fraction")
                  %271 = load(%270)
                  %272 = typeof(%271)
                  %273 = bit_or(%271, %110)
                  %274 = store(%270, %273)
                  %275 = dbg_stmt(55, 9)
                  %276 = field_ptr(%161, "exp")
                  %277 = typeof_log2_int_type(%164)
                  %278 = int_type(u4)
                  %279 = sub(%107, %257)
                  %280 = int_cast(%278, %279)
                  %281 = as_node(%277, %280)
                  %282 = shr(%164, %281)
                  %283 = truncate(@Ref.u16_type, %282)
                  %284 = store_node(%276, %283)
                  %285 = dbg_stmt(56, 9)
                  %286 = field_ptr(%161, "exp")
                  %287 = load(%286)
                  %288 = typeof(%287)
                  %289 = xor(%287, @Ref.one)
                  %290 = store(%286, %289)
                  %291 = dbg_stmt(57, 9)
                  %292 = field_ptr(%161, "exp")
                  %293 = load(%292)
                  %294 = typeof(%293)
                  %295 = sub(%118, %132)
                  %296 = sub(%295, %257)
                  %297 = add(%296, @Ref.one)
                  %298 = bit_or(%293, %297)
                  %299 = store(%292, %298)
                  %306 = break(%251, @Ref.void_value)
                }, {
                  %300 = dbg_stmt(60, 9)
                  %301 = field_ptr(%161, "exp")
                  %302 = store_node(%301, @Ref.zero)
                  %303 = dbg_stmt(61, 9)
                  %304 = field_ptr(%161, "fraction")
                  %305 = store_node(%304, @Ref.zero)
                  %307 = break(%251, @Ref.void_value)
                })
              })
              %309 = break(%216, %251)
            })
          })
          %311 = break(%184, %216)
        })
      })
      %312 = ensure_result_used(%184)
      %313 = dbg_stmt(64, 5)
      %314 = field_ptr(%161, "exp")
      %315 = load(%314)
      %316 = typeof(%315)
    > %317 = bit_or(%315, %171)
      %318 = store(%314, %317)
      %319 = dbg_stmt(65, 5)
      %320 = extended(ret_type())
      %321 = ptr_type_simple(@Ref.f80_type, const, One)
      %322 = ptr_cast(%321, %161)
      %323 = load(%322)
      %324 = as_node(%320, %323)
      %325 = ret_node(%324)
    For full context, use the command
      zig ast-check -t /Users/<USER>/repos/zig/stage2/lib/zig/std/special/compiler_rt/extend_f80.zig

  in /Users/<USER>/repos/zig/stage2/lib/zig/std/special/compiler_rt/extend_f80.zig: compiler_rt/extend_f80.zig:__extendhfxf2
    > %37 = call(.auto, %35, [@Ref.f16_type, %36])

/Users/<USER>/repos/zig/src/type.zig:3170:21: 0x10cb1eebb in type.Type.intInfo (zig)
            else => unreachable,
                    ^
/Users/<USER>/repos/zig/src/Sema.zig:14184:49: 0x10d0cbf1e in Sema.coerce (zig)
                const src_info = inst_ty.intInfo(target);
                                                ^
/Users/<USER>/repos/zig/src/Sema.zig:7600:39: 0x10cf74521 in Sema.zirBitwise (zig)
    const casted_rhs = try sema.coerce(block, resolved_type, rhs, rhs_src);
                                      ^
/Users/<USER>/repos/zig/src/Sema.zig:600:65: 0x10cdc7fcf in Sema.analyzeBodyInner (zig)
            .bit_or                       => try sema.zirBitwise(block, inst, .bit_or),
                                                                ^
/Users/<USER>/repos/zig/src/Sema.zig:522:33: 0x10cc274ca in Sema.analyzeBody (zig)
    return sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                                ^
/Users/<USER>/repos/zig/src/Sema.zig:4369:37: 0x10d0d5eba in Sema.analyzeCall (zig)
                _ = sema.analyzeBody(&child_block, fn_info.body) catch |err| switch (err) {
                                    ^
/Users/<USER>/repos/zig/src/Sema.zig:4023:28: 0x10cf7847b in Sema.zirCall (zig)
    return sema.analyzeCall(block, func, func_src, call_src, modifier, ensure_result_used, resolved_args);
                           ^
/Users/<USER>/repos/zig/src/Sema.zig:607:62: 0x10cdc8549 in Sema.analyzeBodyInner (zig)
            .call                         => try sema.zirCall(block, inst),
                                                             ^
/Users/<USER>/repos/zig/src/Sema.zig:522:33: 0x10cc274ca in Sema.analyzeBody (zig)
    return sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                                ^
/Users/<USER>/repos/zig/src/Module.zig:4565:25: 0x10cc0399e in Module.analyzeFnBody (zig)
    _ = sema.analyzeBody(&inner_block, fn_info.body) catch |err| switch (err) {
                        ^
/Users/<USER>/repos/zig/src/Compilation.zig:2756:47: 0x10c9dedfd in Compilation.processOneJob (zig)
                var air = module.analyzeFnBody(decl, func, sema_arena) catch |err| switch (err) {
                                              ^
/Users/<USER>/repos/zig/src/Compilation.zig:2675:30: 0x10c9c91ad in Compilation.performAllTheWork (zig)
            try processOneJob(self, work_item, main_progress_node);
                             ^
/Users/<USER>/repos/zig/src/Compilation.zig:2081:31: 0x10c9c260a in Compilation.update (zig)
    try comp.performAllTheWork();
                              ^
/Users/<USER>/repos/zig/src/Compilation.zig:4892:31: 0x10cc222a2 in Compilation.buildOutputFromZig (zig)
    try sub_compilation.update();
                              ^
/Users/<USER>/repos/zig/src/Compilation.zig:3062:36: 0x10c9de5c9 in Compilation.processOneJob (zig)
            comp.buildOutputFromZig(
                                   ^
/Users/<USER>/repos/zig/src/Compilation.zig:2675:30: 0x10c9c91ad in Compilation.performAllTheWork (zig)
            try processOneJob(self, work_item, main_progress_node);
                             ^
/Users/<USER>/repos/zig/src/Compilation.zig:2081:31: 0x10c9c260a in Compilation.update (zig)
    try comp.performAllTheWork();
                              ^
/Users/<USER>/repos/zig/src/main.zig:2956:20: 0x10c927cb0 in updateModule (zig)
    try comp.update();
                   ^
/Users/<USER>/repos/zig/src/main.zig:2646:17: 0x10c8afa89 in buildOutputType (zig)
    updateModule(gpa, comp, hook) catch |err| switch (err) {
                ^
/Users/<USER>/repos/zig/src/main.zig:216:31: 0x10c89561d in mainArgs (zig)
        return buildOutputType(gpa, arena, args, .zig_test);
                              ^
/Users/<USER>/repos/zig/src/main.zig:165:20: 0x10c8945a2 in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:561:37: 0x10cd87918 in std.start.callMain (zig)
            const result = root.main() catch |err| {
                                    ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:495:12: 0x10c896e57 in std.start.callMainWithArgs (zig)
    return @call(.{ .modifier = .always_inline }, callMain, .{});
           ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:460:12: 0x10c896d95 in std.start.main (zig)
    return @call(.{ .modifier = .always_inline }, callMainWithArgs, .{ @intCast(usize, c_argc), c_argv, envp });
           ^
???:?:?: 0x7fff68290cc8 in ??? (???)
???:?:?: 0x4 in ??? (???)
zsh: abort      ./stage2/bin/zig test test/behavior.zig -Itest -fLLVM
```

</details>

I suspect this is what prompted https://github.com/ziglang/zig/issues/10816 in the first place. The error seems to stem from the f80 support in compiler-rt that was recently merged: https://github.com/ziglang/zig/pull/10738 

Unfortunately, the stage2 behavior tests still fail on my machine after this commit, but now with a different error: 


<details>

```
$ ./stage2/bin/zig test test/behavior.zig -Itest -fLLVM
AST Lowering [605] behavior/vector.zig... panic: TODO implement writeToMemory for more types
Analyzing /Users/<USER>/repos/zig/stage2/lib/zig/std/math.zig: math.zig:qnan_f80
      %314 = ptr_type_simple(@Ref.f80_type, const, One)
      %315 = decl_val("F80Repr")
      %316 = field_type(%315, fraction)
      %317 = int(13835058055282163712)
      %318 = as_node(%316, %317)
      %319 = field_type(%315, exp)
      %320 = int(32767)
      %321 = as_node(%319, %320)
      %322 = struct_init_ref([%316, %318], [%319, %321])
      %323 = ptr_cast(%314, %322)
    > %324 = load(%323)
      %325 = break_inline(%313, %324)
    For full context, use the command
      zig ast-check -t /Users/<USER>/repos/zig/stage2/lib/zig/std/math.zig

  in /Users/<USER>/repos/zig/stage2/lib/zig/std/special/compiler_rt/addXf3.zig: compiler_rt/addXf3.zig:__addxf3
    > %1018 = field_val(%1017, "qnan_f80") node_offset:252:32
  in /Users/<USER>/repos/zig/stage2/lib/zig/std/special/compiler_rt/addXf3.zig: compiler_rt/addXf3.zig:__addxf3
    > %1012 = condbr(%1011, {%1014..%1020}, {%1021}) node_offset:250:13
  in /Users/<USER>/repos/zig/stage2/lib/zig/std/special/compiler_rt/addXf3.zig: compiler_rt/addXf3.zig:__addxf3
    > %1013 = block({%1001..%1012}) node_offset:250:13
  in /Users/<USER>/repos/zig/stage2/lib/zig/std/special/compiler_rt/addXf3.zig: compiler_rt/addXf3.zig:__addxf3
    > %998 = condbr(%997, {%1000..%1026}, {%1027..%1048}) node_offset:249:9
  in /Users/<USER>/repos/zig/stage2/lib/zig/std/special/compiler_rt/addXf3.zig: compiler_rt/addXf3.zig:__addxf3
    > %999 = block({%993..%998}) node_offset:249:9
  in /Users/<USER>/repos/zig/stage2/lib/zig/std/special/compiler_rt/addXf3.zig: compiler_rt/addXf3.zig:__addxf3
    > %990 = condbr(%989, {%992..%1050}, {%1051}) node_offset:248:5
  in /Users/<USER>/repos/zig/stage2/lib/zig/std/special/compiler_rt/addXf3.zig: compiler_rt/addXf3.zig:__addxf3
    > %991 = block({%987..%990}) node_offset:248:5

/Users/<USER>/repos/zig/src/value.zig:1067:21: 0x1105f6b8a in value.Value.writeToMemory (zig)
            else => @panic("TODO implement writeToMemory for more types"),
                    ^
/Users/<USER>/repos/zig/src/Sema.zig:15147:22: 0x1105bbc07 in Sema.bitCastVal (zig)
    val.writeToMemory(old_ty, target, buffer);
                     ^
/Users/<USER>/repos/zig/src/Sema.zig:17584:35: 0x1103fdf89 in Sema.pointerDeref (zig)
        return try sema.bitCastVal(block, src, parent.val, parent.ty, load_ty);
                                  ^
/Users/<USER>/repos/zig/src/Sema.zig:15513:34: 0x1104125b7 in Sema.analyzeLoad (zig)
        if (try sema.pointerDeref(block, ptr_src, ptr_val, ptr_ty)) |elem_val| {
                                 ^
/Users/<USER>/repos/zig/src/Sema.zig:8994:28: 0x1102b15c7 in Sema.zirLoad (zig)
    return sema.analyzeLoad(block, src, ptr, ptr_src);
                           ^
/Users/<USER>/repos/zig/src/Sema.zig:618:62: 0x1100fea45 in Sema.analyzeBodyInner (zig)
            .load                         => try sema.zirLoad(block, inst),
                                                             ^
/Users/<USER>/repos/zig/src/Sema.zig:522:33: 0x10ff5d10a in Sema.analyzeBody (zig)
    return sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                                ^
/Users/<USER>/repos/zig/src/Module.zig:3628:45: 0x10ff69ec8 in Module.semaDecl (zig)
    const break_index = try sema.analyzeBody(&block_scope, body);
                                            ^
/Users/<USER>/repos/zig/src/Module.zig:3359:38: 0x10ff3c42c in Module.ensureDeclAnalyzed (zig)
    const type_changed = mod.semaDecl(decl) catch |err| switch (err) {
                                     ^
/Users/<USER>/repos/zig/src/Sema.zig:15426:32: 0x110430853 in Sema.ensureDeclAnalyzed (zig)
    sema.mod.ensureDeclAnalyzed(decl) catch |err| {
                               ^
/Users/<USER>/repos/zig/src/Sema.zig:15438:32: 0x1103fe4fa in Sema.analyzeDeclRef (zig)
    try sema.ensureDeclAnalyzed(decl);
                               ^
/Users/<USER>/repos/zig/src/Sema.zig:15415:45: 0x1103feba2 in Sema.analyzeDeclVal (zig)
    const decl_ref = try sema.analyzeDeclRef(decl);
                                            ^
/Users/<USER>/repos/zig/src/Sema.zig:13529:35: 0x1105ce568 in Sema.namespaceLookupVal (zig)
    return try sema.analyzeDeclVal(block, src, decl);
                                  ^
/Users/<USER>/repos/zig/src/Sema.zig:13112:56: 0x11041aa84 in Sema.fieldVal (zig)
                        if (try sema.namespaceLookupVal(block, src, namespace, field_name)) |inst| {
                                                       ^
/Users/<USER>/repos/zig/src/Sema.zig:5825:25: 0x1102b6338 in Sema.zirFieldVal (zig)
    return sema.fieldVal(block, src, object, field_name, field_name_src);
                        ^
/Users/<USER>/repos/zig/src/Sema.zig:640:66: 0x1100ffb71 in Sema.analyzeBodyInner (zig)
            .field_val                    => try sema.zirFieldVal(block, inst),
                                                                 ^
/Users/<USER>/repos/zig/src/Sema.zig:522:33: 0x10ff5d10a in Sema.analyzeBody (zig)
    return sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                                ^
/Users/<USER>/repos/zig/src/Sema.zig:10257:29: 0x1102f1bea in Sema.zirCondbr (zig)
    _ = try sema.analyzeBody(&sub_block, then_body);
                            ^
/Users/<USER>/repos/zig/src/Sema.zig:1060:61: 0x110109669 in Sema.analyzeBodyInner (zig)
                if (!block.is_comptime) break sema.zirCondbr(block, inst);
                                                            ^
/Users/<USER>/repos/zig/src/Sema.zig:522:33: 0x10ff5d10a in Sema.analyzeBody (zig)
    return sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                                ^
/Users/<USER>/repos/zig/src/Sema.zig:3511:29: 0x1102efef2 in Sema.zirBlock (zig)
    _ = try sema.analyzeBody(&child_block, body);
                            ^
/Users/<USER>/repos/zig/src/Sema.zig:1015:69: 0x110108ac7 in Sema.analyzeBodyInner (zig)
                if (!block.is_comptime) break :blk try sema.zirBlock(block, inst);
                                                                    ^
/Users/<USER>/repos/zig/src/Sema.zig:522:33: 0x10ff5d10a in Sema.analyzeBody (zig)
    return sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                                ^
/Users/<USER>/repos/zig/src/Sema.zig:10257:29: 0x1102f1bea in Sema.zirCondbr (zig)
    _ = try sema.analyzeBody(&sub_block, then_body);
                            ^
/Users/<USER>/repos/zig/src/Sema.zig:1060:61: 0x110109669 in Sema.analyzeBodyInner (zig)
                if (!block.is_comptime) break sema.zirCondbr(block, inst);
                                                            ^
/Users/<USER>/repos/zig/src/Sema.zig:522:33: 0x10ff5d10a in Sema.analyzeBody (zig)
    return sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                                ^
/Users/<USER>/repos/zig/src/Sema.zig:3511:29: 0x1102efef2 in Sema.zirBlock (zig)
    _ = try sema.analyzeBody(&child_block, body);
                            ^
/Users/<USER>/repos/zig/src/Sema.zig:1015:69: 0x110108ac7 in Sema.analyzeBodyInner (zig)
                if (!block.is_comptime) break :blk try sema.zirBlock(block, inst);
                                                                    ^
/Users/<USER>/repos/zig/src/Sema.zig:522:33: 0x10ff5d10a in Sema.analyzeBody (zig)
    return sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                                ^
/Users/<USER>/repos/zig/src/Sema.zig:10257:29: 0x1102f1bea in Sema.zirCondbr (zig)
    _ = try sema.analyzeBody(&sub_block, then_body);
                            ^
/Users/<USER>/repos/zig/src/Sema.zig:1060:61: 0x110109669 in Sema.analyzeBodyInner (zig)
                if (!block.is_comptime) break sema.zirCondbr(block, inst);
                                                            ^
/Users/<USER>/repos/zig/src/Sema.zig:522:33: 0x10ff5d10a in Sema.analyzeBody (zig)
    return sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                                ^
/Users/<USER>/repos/zig/src/Sema.zig:3511:29: 0x1102efef2 in Sema.zirBlock (zig)
    _ = try sema.analyzeBody(&child_block, body);
                            ^
/Users/<USER>/repos/zig/src/Sema.zig:1015:69: 0x110108ac7 in Sema.analyzeBodyInner (zig)
                if (!block.is_comptime) break :blk try sema.zirBlock(block, inst);
                                                                    ^
/Users/<USER>/repos/zig/src/Sema.zig:522:33: 0x10ff5d10a in Sema.analyzeBody (zig)
    return sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                                ^
/Users/<USER>/repos/zig/src/Module.zig:4565:25: 0x10ff395de in Module.analyzeFnBody (zig)
    _ = sema.analyzeBody(&inner_block, fn_info.body) catch |err| switch (err) {
                        ^
/Users/<USER>/repos/zig/src/Compilation.zig:2756:47: 0x10fd14a3d in Compilation.processOneJob (zig)
                var air = module.analyzeFnBody(decl, func, sema_arena) catch |err| switch (err) {
                                              ^
/Users/<USER>/repos/zig/src/Compilation.zig:2675:30: 0x10fcfeded in Compilation.performAllTheWork (zig)
            try processOneJob(self, work_item, main_progress_node);
                             ^
/Users/<USER>/repos/zig/src/Compilation.zig:2081:31: 0x10fcf824a in Compilation.update (zig)
    try comp.performAllTheWork();
                              ^
/Users/<USER>/repos/zig/src/Compilation.zig:4892:31: 0x10ff57ee2 in Compilation.buildOutputFromZig (zig)
    try sub_compilation.update();
                              ^
/Users/<USER>/repos/zig/src/Compilation.zig:3062:36: 0x10fd14209 in Compilation.processOneJob (zig)
            comp.buildOutputFromZig(
                                   ^
/Users/<USER>/repos/zig/src/Compilation.zig:2675:30: 0x10fcfeded in Compilation.performAllTheWork (zig)
            try processOneJob(self, work_item, main_progress_node);
                             ^
/Users/<USER>/repos/zig/src/Compilation.zig:2081:31: 0x10fcf824a in Compilation.update (zig)
    try comp.performAllTheWork();
                              ^
/Users/<USER>/repos/zig/src/main.zig:2956:20: 0x10fc5d8f0 in updateModule (zig)
    try comp.update();
                   ^
/Users/<USER>/repos/zig/src/main.zig:2646:17: 0x10fbe56c9 in buildOutputType (zig)
    updateModule(gpa, comp, hook) catch |err| switch (err) {
                ^
/Users/<USER>/repos/zig/src/main.zig:216:31: 0x10fbcb25d in mainArgs (zig)
        return buildOutputType(gpa, arena, args, .zig_test);
                              ^
/Users/<USER>/repos/zig/src/main.zig:165:20: 0x10fbca1e2 in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:561:37: 0x1100bd558 in std.start.callMain (zig)
            const result = root.main() catch |err| {
                                    ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:495:12: 0x10fbcca97 in std.start.callMainWithArgs (zig)
    return @call(.{ .modifier = .always_inline }, callMain, .{});
           ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:460:12: 0x10fbcc9d5 in std.start.main (zig)
    return @call(.{ .modifier = .always_inline }, callMainWithArgs, .{ @intCast(usize, c_argc), c_argv, envp });
           ^
???:?:?: 0x7fff68290cc8 in ??? (???)
???:?:?: 0x4 in ??? (???)
zsh: abort      ./stage2/bin/zig test test/behavior.zig -Itest -fLLVM
```

</details>

Although the error is different, it still appears to emanate from https://github.com/ziglang/zig/pull/10738. The failing file is `addXf3.zig`, and the result of `ast-check -t` in both master and this branch is identical. So it is unlikely this failure has been introduced in this PR, but rather it's exposed now since we get further in the compilation. Should I open a separate issue for this?

I tried reverting https://github.com/ziglang/zig/pull/10738 locally, and if I do that the behavior tests pass on both master and this branch.