### PR TITLE
stage1: comptime @rem() fix

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -309,9 +309,7 @@ pub fn zeroes(comptime T: type) T {
             if (comptime meta.containerLayout(T) == .Extern) {
                 // The C language specification states that (global) unions
                 // should be zero initialized to the first named member.
-                var item: T = undefined;
-                @field(item, info.fields[0].name) = zeroes(@TypeOf(@field(item, info.fields[0].name)));
-                return item;
+                return @unionInit(T, info.fields[0].name, zeroes(info.fields[0].field_type));
             }
 
             @compileError("Can't set a " ++ @typeName(T) ++ " to zero.");
@@ -417,6 +415,9 @@ test "mem.zeroes" {
 
     var c = zeroes(C_union);
     try testing.expectEqual(@as(u8, 0), c.a);
+
+    comptime var comptime_union = zeroes(C_union);
+    try testing.expectEqual(@as(u8, 0), comptime_union.a);
 }
 
 /// Initializes all fields of the struct with their default value, or zero values if no default value is present.

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -747,6 +747,9 @@ comptime {
         @export(__unordtf2, .{ .name = "__unordkf2", .linkage = linkage });
     }
 
+    const fmodl = @import("compiler_rt/floatfmodl.zig").fmodl;
+    @export(fmodl, .{ .name = "fmodl", .linkage = linkage });
+
     @export(floorf, .{ .name = "floorf", .linkage = linkage });
     @export(floor, .{ .name = "floor", .linkage = linkage });
     @export(floorl, .{ .name = "floorl", .linkage = linkage });

--- a/lib/std/special/compiler_rt/floatfmodl.zig
+++ b/lib/std/special/compiler_rt/floatfmodl.zig
@@ -1,0 +1,129 @@
+const builtin = @import("builtin");
+const std = @import("std");
+
+// fmodl - floating modulo large, returns the remainder of division for f128 types
+// Logic and flow heavily inspired by MUSL fmodl for 113 mantissa digits
+pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
+    @setRuntimeSafety(false);
+    const ReinterpretUnion = packed union {
+        u64s: switch (builtin.cpu.arch.endian()) {
+            .Little => extern struct {
+                low: u64,
+                high: u64,
+            },
+            .Big => extern struct {
+                high: u64,
+                low: u64,
+            },
+        },
+
+        parts: switch (builtin.cpu.arch.endian()) {
+            .Little => extern struct {
+                mantissa_low: u64,
+                mantissa_mid: u32,
+                mantissa_high: u16,
+                exp_and_sign: u16,
+            },
+            .Big => extern struct {
+                exp_and_sign: u16,
+                mantissa_high: u16,
+                mantissa_mid: u32,
+                mantissa_low: u64,
+            },
+        },
+    };
+
+    var amod = a;
+    var bmod = b;
+    const a_ptr = @ptrCast(*ReinterpretUnion, &amod);
+    const b_ptr = @ptrCast(*ReinterpretUnion, &bmod);
+
+    const sign_a = a_ptr.parts.exp_and_sign & 0x8000;
+    var exp_a = @intCast(i32, (a_ptr.parts.exp_and_sign & 0x7fff));
+    const exp_b = b_ptr.parts.exp_and_sign & 0x7fff;
+
+    if(b == 0 or std.math.isNan(b) or exp_a == 0x7fff) {
+        return (a*b)/(a*b);
+    }
+
+    // Remove the sign from both
+    a_ptr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, exp_a));
+    b_ptr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, exp_b));
+    if (amod <= bmod) {
+        if (amod == bmod) {
+            return 0*a;
+        }
+        return a;
+    }
+
+    if(exp_a == 0){
+        amod *= 0x1p120;
+        a_ptr.parts.exp_and_sign -= 120;
+    }
+
+    if(exp_b == 0){
+        bmod *= 0x1p120;
+        b_ptr.parts.exp_and_sign -= 120;
+    }
+
+    // OR in extra non-stored mantissa digit
+    var highA: u64 = (a_ptr.u64s.high & (std.math.maxInt(u64) >> 16)) | 1 << 48;
+    var highB: u64 = (b_ptr.u64s.high & (std.math.maxInt(u64) >> 16)) | 1 << 48;
+    var lowA: u64 = a_ptr.u64s.low;
+    var lowB: u64 = b_ptr.u64s.low;
+
+    while (exp_a > exp_b) : (exp_a -= 1) {
+        var high = highA - highB;
+        var low = lowA - lowB;
+        if (lowA < lowB) {
+            high -= 1;
+        }
+        if (high >> 63 == 0) {
+            if ((high | low) == 0) {
+                return 0 * a;
+            }
+            highA = 2 * high + (low >> 63);
+            lowA = 2 * low;
+        } else {
+            highA = 2 * highA + (lowA >> 63);
+            lowA = 2 * lowA;
+        }
+    }
+
+    var high: u64 = highA - highB;
+    var low: u64 = lowA - lowB;
+    if (lowA < lowB) {
+        high -= 1;
+    }
+    if (high >> 63 == 0) {
+        if ((high | low) == 0) {
+            return 0 * a;
+        }
+        highA = high;
+        lowA = low;
+    }
+
+    while (highA >> 48 == 0) {
+        highA = 2 * highA + (lowA >> 63);
+        lowA = 2 * lowA;
+        exp_a -= 1;
+    }
+    
+    // Overwrite the current amod with the values in highA and lowA
+    a_ptr.u64s.high = highA;
+    a_ptr.u64s.low = lowA;
+
+    // Combine the exponent with the sign, normalize if happend to be denormalized
+    if (exp_a <= 0) {
+        a_ptr.parts.exp_and_sign = @truncate(u16, @intCast(u32, exp_a + 120) | sign_a);
+        amod *= 0x1p-120;
+    } else {
+        a_ptr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, @intCast(u32, exp_a) | sign_a));
+    }
+
+    return amod;
+}
+
+test {
+    _ = @import("floatfmodl_test.zig");
+}

--- a/lib/std/special/compiler_rt/floatfmodl_test.zig
+++ b/lib/std/special/compiler_rt/floatfmodl_test.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const fmodl = @import("floatfmodl.zig");
+const testing = std.testing;
+
+fn test_fmodl(a: f128, b: f128, exp: f128) !void {
+    const res = fmodl.fmodl(a, b);
+    try testing.expect(exp == res);
+}
+
+test "fmodl" {
+    try test_fmodl(6.8, 4.0, 2.8);
+    try test_fmodl(-5.0, 3.0, -2.0);
+    try test_fmodl(1.0, 2.0, 1.0);
+    try test_fmodl(3.0, 2.0, 1.0);
+}

--- a/src/value.zig
+++ b/src/value.zig
@@ -1425,8 +1425,7 @@ pub const Value = extern union {
             .float_64 => @rem(self.castTag(.float_64).?.data, 1) != 0,
             //.float_80 => @rem(self.castTag(.float_80).?.data, 1) != 0,
             .float_80 => @panic("TODO implement __remx in compiler-rt"),
-            //.float_128 => @rem(self.castTag(.float_128).?.data, 1) != 0,
-            .float_128 => @panic("TODO implement fmodl in compiler-rt"),
+            .float_128 => @rem(self.castTag(.float_128).?.data, 1) != 0,
 
             else => unreachable,
         };
@@ -2829,9 +2828,6 @@ pub const Value = extern union {
                 return Value.Tag.float_80.create(arena, @rem(lhs_val, rhs_val));
             },
             128 => {
-                if (true) {
-                    @panic("TODO implement compiler_rt fmodl");
-                }
                 const lhs_val = lhs.toFloat(f128);
                 const rhs_val = rhs.toFloat(f128);
                 return Value.Tag.float_128.create(arena, @rem(lhs_val, rhs_val));
@@ -2866,9 +2862,6 @@ pub const Value = extern union {
                 return Value.Tag.float_80.create(arena, @mod(lhs_val, rhs_val));
             },
             128 => {
-                if (true) {
-                    @panic("TODO implement compiler_rt fmodl");
-                }
                 const lhs_val = lhs.toFloat(f128);
                 const rhs_val = rhs.toFloat(f128);
                 return Value.Tag.float_128.create(arena, @mod(lhs_val, rhs_val));

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -791,6 +791,33 @@ fn remdiv(comptime T: type) !void {
     try expect(@as(T, 1) == @as(T, 7) % @as(T, 3));
 }
 
+test "float remainder division using @rem" {
+    comptime try frem(f16);
+    comptime try frem(f32);
+    comptime try frem(f64);
+    comptime try frem(f128);
+    try frem(f16);
+    try frem(f32);
+    try frem(f64);
+    try frem(f128);
+}
+
+fn frem(comptime T: type) !void {
+    const Case = struct { a: T, b: T, exp: T };
+    const cases: []const Case = &[_]Case {
+        .{ .a = 6.9, .b = 4.0, .exp = 2.9 },
+        .{ .a = -6.9, .b = 4.0, .exp = -2.9 },
+        .{ .a = -5.0, .b = 3.0, .exp = -2.0 },
+        .{ .a = 3.0, .b = 2.0, .exp = 1.0 },
+        .{ .a = 1.0, .b = 2.0, .exp = 1.0 },
+    };
+
+    const epsilon = 1e30;
+    for (cases) |case| {
+        try expect((@rem(case.a, case.b) - case.exp) < epsilon);
+    }
+}
+
 test "@sqrt" {
     if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
 

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -1819,4 +1819,14 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\    return 0;
         \\}
     , "");
+
+    cases.add("Zero-initialization of global union. Issue #10797",
+        \\#include <stdlib.h>
+        \\union U { int x; double y; };
+        \\union U u;
+        \\int main(void) {
+        \\    if (u.x != 0) abort();
+        \\    return 0;
+        \\}
+    , "");
 }


### PR DESCRIPTION
Fixing comptime issue described in #10819.

Before:
```
[f16]  comptime @rem(6.9e+00, 4.0e+00) = -1.1015625e+00
[f64]  comptime @rem(6.9e+00, 4.0e+00) = 2.9000000000000004e+00
[f80]  comptime @rem(6.9e+00, 4.0e+00) = -1.1e+00
[f128] comptime @rem(6.9e+00, 4.0e+00) = -1.1e+00
```

After:
```
[f16]  comptime @rem(6.9e+00, 4.0e+00) = 2.8984375e+00
[f64]  comptime @rem(6.9e+00, 4.0e+00) = 2.9000000000000004e+00
[f80]  comptime @rem(6.9e+00, 4.0e+00) = 2.9e+00
[f128] comptime @rem(6.9e+00, 4.0e+00) = 2.9e+00
```