### PR TITLE
debug: implement segfault handler for macOS aarch64

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -6,6 +6,26 @@ const native_arch = builtin.target.cpu.arch;
 const maxInt = std.math.maxInt;
 const iovec_const = std.os.iovec_const;
 
+const arch_bits = switch (native_arch) {
+    .aarch64 => @import("darwin/aarch64.zig"),
+    .x86_64 => @import("darwin/x86_64.zig"),
+    else => struct {},
+};
+
+pub const ucontext_t = extern struct {
+    onstack: c_int,
+    sigmask: sigset_t,
+    stack: stack_t,
+    link: ?*ucontext_t,
+    mcsize: u64,
+    mcontext: *mcontext_t,
+};
+
+pub const mcontext_t = extern struct {
+    es: arch_bits.exception_state,
+    ss: arch_bits.thread_state,
+};
+
 extern "c" fn __error() *c_int;
 pub extern "c" fn NSVersionOfRunTimeLibrary(library_name: [*:0]const u8) u32;
 pub extern "c" fn _NSGetExecutablePath(buf: [*:0]u8, bufsize: *u32) c_int;
@@ -476,51 +496,6 @@ pub const SIG = struct {
     pub const USR1 = 30;
     /// user defined signal 2
     pub const USR2 = 31;
-};
-
-pub const ucontext_t = extern struct {
-    onstack: c_int,
-    sigmask: sigset_t,
-    stack: stack_t,
-    link: ?*ucontext_t,
-    mcsize: u64,
-    mcontext: *mcontext_t,
-};
-
-pub const exception_state = extern struct {
-    trapno: u16,
-    cpu: u16,
-    err: u32,
-    faultvaddr: u64,
-};
-
-pub const thread_state = extern struct {
-    rax: u64,
-    rbx: u64,
-    rcx: u64,
-    rdx: u64,
-    rdi: u64,
-    rsi: u64,
-    rbp: u64,
-    rsp: u64,
-    r8: u64,
-    r9: u64,
-    r10: u64,
-    r11: u64,
-    r12: u64,
-    r13: u64,
-    r14: u64,
-    r15: u64,
-    rip: u64,
-    rflags: u64,
-    cs: u64,
-    fs: u64,
-    gs: u64,
-};
-
-pub const mcontext_t = extern struct {
-    es: exception_state,
-    ss: thread_state,
 };
 
 pub const siginfo_t = extern struct {

--- a/lib/std/c/darwin/aarch64.zig
+++ b/lib/std/c/darwin/aarch64.zig
@@ -1,0 +1,18 @@
+// See C headers in
+// lib/libc/include/aarch64-macos.12-gnu/mach/arm/_structs.h
+
+pub const exception_state = extern struct {
+    far: u64, // Virtual Fault Address
+    esr: u32, // Exception syndrome
+    exception: u32, // Number of arm exception taken
+};
+
+pub const thread_state = extern struct {
+    regs: [29]u64, // General purpose registers
+    fp: u64, // Frame pointer x29
+    lr: u64, // Link register x30
+    sp: u64, // Stack pointer x31
+    pc: u64, // Program counter
+    cpsr: u32, // Current program status register
+    __pad: u32,
+};

--- a/lib/std/c/darwin/x86_64.zig
+++ b/lib/std/c/darwin/x86_64.zig
@@ -1,0 +1,30 @@
+pub const exception_state = extern struct {
+    trapno: u16,
+    cpu: u16,
+    err: u32,
+    faultvaddr: u64,
+};
+
+pub const thread_state = extern struct {
+    rax: u64,
+    rbx: u64,
+    rcx: u64,
+    rdx: u64,
+    rdi: u64,
+    rsi: u64,
+    rbp: u64,
+    rsp: u64,
+    r8: u64,
+    r9: u64,
+    r10: u64,
+    r11: u64,
+    r12: u64,
+    r13: u64,
+    r14: u64,
+    r15: u64,
+    rip: u64,
+    rflags: u64,
+    cs: u64,
+    fs: u64,
+    gs: u64,
+};


### PR DESCRIPTION
Produces the following output on a M1 MacBook Pro, macOS Monterey 12.2:
 
```
$ cat segfault.zig
const std = @import("std");

pub fn main() void {
    const a = @intToPtr(*u8, 123123).*;
    std.debug.print("{d}", .{a});
}

$ ./build/zig build-exe segfault.zig && ./segfault
Segmentation fault at address 0x1e0f3
/Users/<USER>/repos/zig/segfault.zig:4:37: 0x104a6077c in main (segfault)
    const a = @intToPtr(*u8, 123123).*;
                                    ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:551:22: 0x104a626cf in std.start.callMain (segfault)
            root.main();
                     ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:495:12: 0x104a60a83 in std.start.callMainWithArgs (segfault)
    return @call(.{ .modifier = .always_inline }, callMain, .{});
           ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:460:12: 0x104a609af in std.start.main (segfault)
    return @call(.{ .modifier = .always_inline }, callMainWithArgs, .{ @intCast(usize, c_argc), c_argv, envp });
           ^
???:?:?: 0x104b650f3 in ??? (???)
???:?:?: 0xec757fffffffffff in ??? (???)
zsh: abort      ./segfault
```

Closes https://github.com/ziglang/zig/issues/5716.
Closes https://github.com/ziglang/zig/issues/10609.