### PR TITLE
stage2,x64: pass more tests with structs

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -4692,11 +4692,17 @@ fn parseRegName(name: []const u8) ?Register {
 
 fn registerAlias(reg: Register, size_bytes: u32) Register {
     // For x86_64 we have to pick a smaller register alias depending on abi size.
-    switch (size_bytes) {
-        1 => return reg.to8(),
-        2 => return reg.to16(),
-        4 => return reg.to32(),
-        8 => return reg.to64(),
-        else => unreachable,
+    if (size_bytes == 0) {
+        unreachable; // should be comptime known
+    } else if (size_bytes <= 1) {
+        return reg.to8();
+    } else if (size_bytes <= 2) {
+        return reg.to16();
+    } else if (size_bytes <= 4) {
+        return reg.to32();
+    } else if (size_bytes <= 8) {
+        return reg.to64();
+    } else {
+        unreachable; // TODO handle floating-point registers
     }
 }

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -142,30 +142,6 @@ pub const Inst = struct {
         rcr_scale_dst,
         rcr_scale_imm,
         rcr_mem_index_imm,
-        shl,
-        shl_mem_imm,
-        shl_scale_src,
-        shl_scale_dst,
-        shl_scale_imm,
-        shl_mem_index_imm,
-        sal,
-        sal_mem_imm,
-        sal_scale_src,
-        sal_scale_dst,
-        sal_scale_imm,
-        sal_mem_index_imm,
-        shr,
-        shr_mem_imm,
-        shr_scale_src,
-        shr_scale_dst,
-        shr_scale_imm,
-        shr_mem_index_imm,
-        sar,
-        sar_mem_imm,
-        sar_scale_src,
-        sar_scale_dst,
-        sar_scale_imm,
-        sar_mem_index_imm,
         sbb,
         sbb_mem_imm,
         sbb_scale_src,
@@ -211,6 +187,37 @@ pub const Inst = struct {
         /// Notes:
         /// * `Data` contains `linker_sym_index` 
         lea_pie,
+
+        /// ops flags: form:
+        ///      0b00  reg1, 1
+        ///      0b01  reg1, .cl
+        ///      0b10  reg1, imm8
+        /// Notes:
+        ///   * If flags == 0b10, uses `imm`.
+        shl,
+        shl_mem_imm,
+        shl_scale_src,
+        shl_scale_dst,
+        shl_scale_imm,
+        shl_mem_index_imm,
+        sal,
+        sal_mem_imm,
+        sal_scale_src,
+        sal_scale_dst,
+        sal_scale_imm,
+        sal_mem_index_imm,
+        shr,
+        shr_mem_imm,
+        shr_scale_src,
+        shr_scale_dst,
+        shr_scale_imm,
+        shr_mem_index_imm,
+        sar,
+        sar_mem_imm,
+        sar_scale_src,
+        sar_scale_dst,
+        sar_scale_imm,
+        sar_mem_index_imm,
 
         /// ops flags: form:
         ///      0bX0  reg1

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -372,7 +372,6 @@ pub fn generateSymbol(
             return Result{ .appended = {} };
         },
         .Struct => {
-            // TODO debug info
             const struct_obj = typed_value.ty.castTag(.@"struct").?.data;
             if (struct_obj.layout == .Packed) {
                 return Result{

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -9,7 +9,7 @@ const maxInt = std.math.maxInt;
 top_level_field: i32,
 
 test "top level fields" {
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     var instance = @This(){
         .top_level_field = 1234,
@@ -176,7 +176,7 @@ const MemberFnTestFoo = struct {
 };
 
 test "call member function directly" {
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const instance = MemberFnTestFoo{ .x = 1234 };
     const result = MemberFnTestFoo.member(instance);
@@ -184,7 +184,7 @@ test "call member function directly" {
 }
 
 test "store member function in variable" {
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const instance = MemberFnTestFoo{ .x = 1234 };
     const memberFn = MemberFnTestFoo.member;
@@ -206,7 +206,7 @@ const MemberFnRand = struct {
 };
 
 test "return struct byval from function" {
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const bar = makeBar2(1234, 5678);
     try expect(bar.y == 5678);


### PR DESCRIPTION
* implement `genSetStack` for memory operand (non-PIE only for now)
* fix `registerAlias` helper function for composite types with non-power-of-two ABI sizes
* implement `struct_field_val` for structs/unions small enough to fit in a register
* implement lowering of shift ops in `Emit`
* pass more struct tests