### PR TITLE
Implement f128 @rem

### DIFF
--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -759,6 +759,9 @@ comptime {
         @export(__unordtf2, .{ .name = "__unordkf2", .linkage = linkage });
     }
 
+    const fmodl = @import("compiler_rt/floatfmodl.zig").fmodl;
+    @export(fmodl, .{ .name = "fmodl", .linkage = linkage });
+
     @export(floorf, .{ .name = "floorf", .linkage = linkage });
     @export(floor, .{ .name = "floor", .linkage = linkage });
     @export(floorl, .{ .name = "floorl", .linkage = linkage });

--- a/lib/std/special/compiler_rt/floatfmodl.zig
+++ b/lib/std/special/compiler_rt/floatfmodl.zig
@@ -40,7 +40,7 @@ pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
 
     const sign_a = a_ptr.parts.exp_and_sign & 0x8000;
     var exp_a = @intCast(i32, (a_ptr.parts.exp_and_sign & 0x7fff));
-    const exp_b = b_ptr.parts.exp_and_sign & 0x7fff;
+    var exp_b = b_ptr.parts.exp_and_sign & 0x7fff;
 
     if (b == 0 or std.math.isNan(b) or exp_a == 0x7fff) {
         return (a * b) / (a * b);
@@ -58,12 +58,12 @@ pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
 
     if (exp_a == 0) {
         amod *= 0x1p120;
-        a_ptr.parts.exp_and_sign -= 120;
+        exp_a = a_ptr.parts.exp_and_sign - 120;
     }
 
     if (exp_b == 0) {
         bmod *= 0x1p120;
-        b_ptr.parts.exp_and_sign -= 120;
+        exp_b = b_ptr.parts.exp_and_sign - 120;
     }
 
     // OR in extra non-stored mantissa digit
@@ -115,7 +115,7 @@ pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
 
     // Combine the exponent with the sign, normalize if happend to be denormalized
     if (exp_a <= 0) {
-        a_ptr.parts.exp_and_sign = @truncate(u16, @intCast(u32, exp_a + 120) | sign_a);
+        a_ptr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, @intCast(u32, exp_a + 120) | sign_a));
         amod *= 0x1p-120;
     } else {
         a_ptr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, @intCast(u32, exp_a) | sign_a));

--- a/lib/std/special/compiler_rt/floatfmodl.zig
+++ b/lib/std/special/compiler_rt/floatfmodl.zig
@@ -42,8 +42,8 @@ pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
     var exp_a = @intCast(i32, (a_ptr.parts.exp_and_sign & 0x7fff));
     const exp_b = b_ptr.parts.exp_and_sign & 0x7fff;
 
-    if(b == 0 or std.math.isNan(b) or exp_a == 0x7fff) {
-        return (a*b)/(a*b);
+    if (b == 0 or std.math.isNan(b) or exp_a == 0x7fff) {
+        return (a * b) / (a * b);
     }
 
     // Remove the sign from both
@@ -51,17 +51,17 @@ pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
     b_ptr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, exp_b));
     if (amod <= bmod) {
         if (amod == bmod) {
-            return 0*a;
+            return 0 * a;
         }
         return a;
     }
 
-    if(exp_a == 0){
+    if (exp_a == 0) {
         amod *= 0x1p120;
         a_ptr.parts.exp_and_sign -= 120;
     }
 
-    if(exp_b == 0){
+    if (exp_b == 0) {
         bmod *= 0x1p120;
         b_ptr.parts.exp_and_sign -= 120;
     }
@@ -108,7 +108,7 @@ pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
         lowA = 2 * lowA;
         exp_a -= 1;
     }
-    
+
     // Overwrite the current amod with the values in highA and lowA
     a_ptr.u64s.high = highA;
     a_ptr.u64s.low = lowA;

--- a/lib/std/special/compiler_rt/floatfmodl.zig
+++ b/lib/std/special/compiler_rt/floatfmodl.zig
@@ -42,6 +42,16 @@ pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
     var expA = @intCast(i32, (aPtr.parts.exp_and_sign & 0x7fff));
     var expB = bPtr.parts.exp_and_sign & 0x7fff;
 
+    // There are 3 cases where the answer is undefined, check for:
+    //   - fmodl(val, 0)
+    //   - fmodl(val, NaN)
+    //   - fmodl(inf, val)
+    // The sign on checked values does not matter.
+    // Doing (a * b) / (a * b) procudes undefined results
+    // because the three cases always produce undefined calculations:
+    //   - 0 / 0
+    //   - val * NaN
+    //   - inf / inf
     if (b == 0 or std.math.isNan(b) or expA == 0x7fff) {
         return (a * b) / (a * b);
     }

--- a/lib/std/special/compiler_rt/floatfmodl.zig
+++ b/lib/std/special/compiler_rt/floatfmodl.zig
@@ -1,0 +1,129 @@
+const builtin = @import("builtin");
+const std = @import("std");
+
+// fmodl - floating modulo large, returns the remainder of division for f128 types
+// Logic and flow heavily inspired by MUSL fmodl for 113 mantissa digits
+pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
+    @setRuntimeSafety(false);
+    const ReinterpretUnion = packed union {
+        u64s: switch (builtin.cpu.arch.endian()) {
+            .Little => extern struct {
+                low: u64,
+                high: u64,
+            },
+            .Big => extern struct {
+                high: u64,
+                low: u64,
+            },
+        },
+
+        parts: switch (builtin.cpu.arch.endian()) {
+            .Little => extern struct {
+                mantissa_low: u64,
+                mantissa_mid: u32,
+                mantissa_high: u16,
+                exp_and_sign: u16,
+            },
+            .Big => extern struct {
+                exp_and_sign: u16,
+                mantissa_high: u16,
+                mantissa_mid: u32,
+                mantissa_low: u64,
+            },
+        },
+    };
+
+    var amod = a;
+    var bmod = b;
+    const a_ptr = @ptrCast(*ReinterpretUnion, &amod);
+    const b_ptr = @ptrCast(*ReinterpretUnion, &bmod);
+
+    const sign_a = a_ptr.parts.exp_and_sign & 0x8000;
+    var exp_a = @intCast(i32, (a_ptr.parts.exp_and_sign & 0x7fff));
+    const exp_b = b_ptr.parts.exp_and_sign & 0x7fff;
+
+    if(b == 0 or std.math.isNan(b) or exp_a == 0x7fff) {
+        return (a*b)/(a*b);
+    }
+
+    // Remove the sign from both
+    a_ptr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, exp_a));
+    b_ptr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, exp_b));
+    if (amod <= bmod) {
+        if (amod == bmod) {
+            return 0*a;
+        }
+        return a;
+    }
+
+    if(exp_a == 0){
+        amod *= 0x1p120;
+        a_ptr.parts.exp_and_sign -= 120;
+    }
+
+    if(exp_b == 0){
+        bmod *= 0x1p120;
+        b_ptr.parts.exp_and_sign -= 120;
+    }
+
+    // OR in extra non-stored mantissa digit
+    var highA: u64 = (a_ptr.u64s.high & (std.math.maxInt(u64) >> 16)) | 1 << 48;
+    var highB: u64 = (b_ptr.u64s.high & (std.math.maxInt(u64) >> 16)) | 1 << 48;
+    var lowA: u64 = a_ptr.u64s.low;
+    var lowB: u64 = b_ptr.u64s.low;
+
+    while (exp_a > exp_b) : (exp_a -= 1) {
+        var high = highA - highB;
+        var low = lowA - lowB;
+        if (lowA < lowB) {
+            high -= 1;
+        }
+        if (high >> 63 == 0) {
+            if ((high | low) == 0) {
+                return 0 * a;
+            }
+            highA = 2 * high + (low >> 63);
+            lowA = 2 * low;
+        } else {
+            highA = 2 * highA + (lowA >> 63);
+            lowA = 2 * lowA;
+        }
+    }
+
+    var high: u64 = highA - highB;
+    var low: u64 = lowA - lowB;
+    if (lowA < lowB) {
+        high -= 1;
+    }
+    if (high >> 63 == 0) {
+        if ((high | low) == 0) {
+            return 0 * a;
+        }
+        highA = high;
+        lowA = low;
+    }
+
+    while (highA >> 48 == 0) {
+        highA = 2 * highA + (lowA >> 63);
+        lowA = 2 * lowA;
+        exp_a -= 1;
+    }
+    
+    // Overwrite the current amod with the values in highA and lowA
+    a_ptr.u64s.high = highA;
+    a_ptr.u64s.low = lowA;
+
+    // Combine the exponent with the sign, normalize if happend to be denormalized
+    if (exp_a <= 0) {
+        a_ptr.parts.exp_and_sign = @truncate(u16, @intCast(u32, exp_a + 120) | sign_a);
+        amod *= 0x1p-120;
+    } else {
+        a_ptr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, @intCast(u32, exp_a) | sign_a));
+    }
+
+    return amod;
+}
+
+test {
+    _ = @import("floatfmodl_test.zig");
+}

--- a/lib/std/special/compiler_rt/floatfmodl.zig
+++ b/lib/std/special/compiler_rt/floatfmodl.zig
@@ -5,42 +5,29 @@ const std = @import("std");
 // Logic and flow heavily inspired by MUSL fmodl for 113 mantissa digits
 pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
     @setRuntimeSafety(builtin.is_test);
-    const ReinterpretUnion = packed union {
-        u64s: switch (builtin.cpu.arch.endian()) {
-            .Little => extern struct {
-                low: u64,
-                high: u64,
-            },
-            .Big => extern struct {
-                high: u64,
-                low: u64,
-            },
-        },
-
-        parts: switch (builtin.cpu.arch.endian()) {
-            .Little => extern struct {
-                mantissa_low: u64,
-                mantissa_mid: u32,
-                mantissa_high: u16,
-                exp_and_sign: u16,
-            },
-            .Big => extern struct {
-                exp_and_sign: u16,
-                mantissa_high: u16,
-                mantissa_mid: u32,
-                mantissa_low: u64,
-            },
-        },
-    };
-
     var amod = a;
     var bmod = b;
-    const aPtr = @ptrCast(*ReinterpretUnion, &amod);
-    const bPtr = @ptrCast(*ReinterpretUnion, &bmod);
+    const aPtr_u64 = @ptrCast([*]u64, &amod);
+    const bPtr_u64 = @ptrCast([*]u64, &bmod);
+    const aPtr_u16 = @ptrCast([*]u16, &amod);
+    const bPtr_u16 = @ptrCast([*]u16, &bmod);
 
-    const signA = aPtr.parts.exp_and_sign & 0x8000;
-    var expA = @intCast(i32, (aPtr.parts.exp_and_sign & 0x7fff));
-    var expB = bPtr.parts.exp_and_sign & 0x7fff;
+    const exp_and_sign_index = comptime switch (builtin.target.cpu.arch.endian()) {
+        .Little => 7,
+        .Big => 0,
+    };
+    const low_index = comptime switch (builtin.target.cpu.arch.endian()) {
+        .Little => 0,
+        .Big => 1,
+    };
+    const high_index = comptime switch (builtin.target.cpu.arch.endian()) {
+        .Little => 1,
+        .Big => 0,
+    };
+
+    const signA = aPtr_u16[exp_and_sign_index] & 0x8000;
+    var expA = @intCast(i32, (aPtr_u16[exp_and_sign_index] & 0x7fff));
+    var expB = bPtr_u16[exp_and_sign_index] & 0x7fff;
 
     // There are 3 cases where the answer is undefined, check for:
     //   - fmodl(val, 0)
@@ -57,8 +44,8 @@ pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
     }
 
     // Remove the sign from both
-    aPtr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, expA));
-    bPtr.parts.exp_and_sign = @bitCast(u16, @intCast(i16, expB));
+    aPtr_u16[exp_and_sign_index] = @bitCast(u16, @intCast(i16, expA));
+    bPtr_u16[exp_and_sign_index] = @bitCast(u16, @intCast(i16, expB));
     if (amod <= bmod) {
         if (amod == bmod) {
             return 0 * a;
@@ -68,19 +55,19 @@ pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
 
     if (expA == 0) {
         amod *= 0x1p120;
-        expA = aPtr.parts.exp_and_sign -% 120;
+        expA = aPtr_u16[exp_and_sign_index] -% 120;
     }
 
     if (expB == 0) {
         bmod *= 0x1p120;
-        expB = bPtr.parts.exp_and_sign -% 120;
+        expB = bPtr_u16[exp_and_sign_index] -% 120;
     }
 
     // OR in extra non-stored mantissa digit
-    var highA: u64 = (aPtr.u64s.high & (std.math.maxInt(u64) >> 16)) | 1 << 48;
-    var highB: u64 = (bPtr.u64s.high & (std.math.maxInt(u64) >> 16)) | 1 << 48;
-    var lowA: u64 = aPtr.u64s.low;
-    var lowB: u64 = bPtr.u64s.low;
+    var highA: u64 = (aPtr_u64[high_index] & (std.math.maxInt(u64) >> 16)) | 1 << 48;
+    var highB: u64 = (bPtr_u64[high_index] & (std.math.maxInt(u64) >> 16)) | 1 << 48;
+    var lowA: u64 = aPtr_u64[low_index];
+    var lowB: u64 = bPtr_u64[low_index];
 
     while (expA > expB) : (expA -= 1) {
         var high = highA -% highB;
@@ -120,15 +107,15 @@ pub fn fmodl(a: f128, b: f128) callconv(.C) f128 {
     }
 
     // Overwrite the current amod with the values in highA and lowA
-    aPtr.u64s.high = highA;
-    aPtr.u64s.low = lowA;
+    aPtr_u64[high_index] = highA;
+    aPtr_u64[low_index] = lowA;
 
     // Combine the exponent with the sign, normalize if happend to be denormalized
     if (expA <= 0) {
-        aPtr.parts.exp_and_sign = @truncate(u16, @bitCast(u32, (expA +% 120))) | signA;
+        aPtr_u16[exp_and_sign_index] = @truncate(u16, @bitCast(u32, (expA +% 120))) | signA;
         amod *= 0x1p-120;
     } else {
-        aPtr.parts.exp_and_sign = @truncate(u16, @bitCast(u32, expA)) | signA;
+        aPtr_u16[exp_and_sign_index] = @truncate(u16, @bitCast(u32, expA)) | signA;
     }
 
     return amod;

--- a/lib/std/special/compiler_rt/floatfmodl_test.zig
+++ b/lib/std/special/compiler_rt/floatfmodl_test.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const fmodl = @import("floatfmodl.zig");
+const testing = std.testing;
+
+fn test_fmodl(a: f128, b: f128, exp: f128) !void {
+    const res = fmodl.fmodl(a, b);
+    try testing.expect(exp == res);
+}
+
+test "fmodl" {
+    try test_fmodl(6.8, 4.0, 2.8);
+    try test_fmodl(-5.0, 3.0, -2.0);
+    try test_fmodl(1.0, 2.0, 1.0);
+    try test_fmodl(3.0, 2.0, 1.0);
+}

--- a/lib/std/special/compiler_rt/floatfmodl_test.zig
+++ b/lib/std/special/compiler_rt/floatfmodl_test.zig
@@ -7,9 +7,40 @@ fn test_fmodl(a: f128, b: f128, exp: f128) !void {
     try testing.expect(exp == res);
 }
 
+fn test_fmodl_nans() !void {
+    try testing.expect(std.math.isNan(fmodl.fmodl(1.0, std.math.nan_f128)));
+    try testing.expect(std.math.isNan(fmodl.fmodl(1.0, -std.math.nan_f128)));
+    try testing.expect(std.math.isNan(fmodl.fmodl(std.math.nan_f128, 1.0)));
+    try testing.expect(std.math.isNan(fmodl.fmodl(-std.math.nan_f128, 1.0)));
+}
+
+fn test_fmodl_infs() !void {
+    try testing.expect(fmodl.fmodl(1.0, std.math.inf_f128) == 1.0);
+    try testing.expect(fmodl.fmodl(1.0, -std.math.inf_f128) == 1.0);
+    try testing.expect(std.math.isNan(fmodl.fmodl(std.math.inf_f128, 1.0)));
+    try testing.expect(std.math.isNan(fmodl.fmodl(-std.math.inf_f128, 1.0)));
+}
+
 test "fmodl" {
     try test_fmodl(6.8, 4.0, 2.8);
-    try test_fmodl(-5.0, 3.0, -2.0);
-    try test_fmodl(1.0, 2.0, 1.0);
+    try test_fmodl(6.8, -4.0, 2.8);
+    try test_fmodl(-6.8, 4.0, -2.8);
+    try test_fmodl(-6.8, -4.0, -2.8);
     try test_fmodl(3.0, 2.0, 1.0);
+    try test_fmodl(-5.0, 3.0, -2.0);
+    try test_fmodl(3.0, 2.0, 1.0);
+    try test_fmodl(1.0, 2.0, 1.0);
+    try test_fmodl(0.0, 1.0, 0.0);
+    try test_fmodl(-0.0, 1.0, -0.0);
+    try test_fmodl(7046119.0, 5558362.0, 1487757.0);
+    try test_fmodl(9010357.0, 1957236.0, 1181413.0);
+
+    // Denormals
+    const a: f128 = 0xedcb34a235253948765432134674p-16494;
+    const b: f128 = 0x5d2e38791cfbc0737402da5a9518p-16494;
+    const exp: f128 = 0x336ec3affb2db8618e4e7d5e1c44p-16494;
+    try test_fmodl(a, b, exp);
+
+    try test_fmodl_nans();
+    try test_fmodl_infs();
 }

--- a/src/value.zig
+++ b/src/value.zig
@@ -1428,8 +1428,7 @@ pub const Value = extern union {
             .float_64 => @rem(self.castTag(.float_64).?.data, 1) != 0,
             //.float_80 => @rem(self.castTag(.float_80).?.data, 1) != 0,
             .float_80 => @panic("TODO implement __remx in compiler-rt"),
-            //.float_128 => @rem(self.castTag(.float_128).?.data, 1) != 0,
-            .float_128 => @panic("TODO implement fmodl in compiler-rt"),
+            .float_128 => @rem(self.castTag(.float_128).?.data, 1) != 0,
 
             else => unreachable,
         };
@@ -2834,9 +2833,6 @@ pub const Value = extern union {
                 return Value.Tag.float_80.create(arena, @rem(lhs_val, rhs_val));
             },
             128 => {
-                if (true) {
-                    @panic("TODO implement compiler_rt fmodl");
-                }
                 const lhs_val = lhs.toFloat(f128);
                 const rhs_val = rhs.toFloat(f128);
                 return Value.Tag.float_128.create(arena, @rem(lhs_val, rhs_val));
@@ -2871,9 +2867,6 @@ pub const Value = extern union {
                 return Value.Tag.float_80.create(arena, @mod(lhs_val, rhs_val));
             },
             128 => {
-                if (true) {
-                    @panic("TODO implement compiler_rt fmodl");
-                }
                 const lhs_val = lhs.toFloat(f128);
                 const rhs_val = rhs.toFloat(f128);
                 return Value.Tag.float_128.create(arena, @mod(lhs_val, rhs_val));

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -791,6 +791,33 @@ fn remdiv(comptime T: type) !void {
     try expect(@as(T, 1) == @as(T, 7) % @as(T, 3));
 }
 
+test "float remainder division using @rem" {
+    comptime try frem(f16);
+    comptime try frem(f32);
+    comptime try frem(f64);
+    comptime try frem(f128);
+    try frem(f16);
+    try frem(f32);
+    try frem(f64);
+    try frem(f128);
+}
+
+fn frem(comptime T: type) !void {
+    const Case = struct { a: T, b: T, exp: T };
+    const cases: []const Case = &[_]Case {
+        .{ .a = 6.9, .b = 4.0, .exp = 2.9 },
+        .{ .a = -6.9, .b = 4.0, .exp = -2.9 },
+        .{ .a = -5.0, .b = 3.0, .exp = -2.0 },
+        .{ .a = 3.0, .b = 2.0, .exp = 1.0 },
+        .{ .a = 1.0, .b = 2.0, .exp = 1.0 },
+    };
+
+    const epsilon = 1e30;
+    for (cases) |case| {
+        try expect((@rem(case.a, case.b) - case.exp) < epsilon);
+    }
+}
+
 test "@sqrt" {
     try testSqrt(f64, 12.0);
     comptime try testSqrt(f64, 12.0);

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -803,19 +803,50 @@ test "float remainder division using @rem" {
 }
 
 fn frem(comptime T: type) !void {
-    const Case = struct { a: T, b: T, exp: T };
-    const cases: []const Case = &[_]Case{
-        .{ .a = 6.9, .b = 4.0, .exp = 2.9 },
-        .{ .a = -6.9, .b = 4.0, .exp = -2.9 },
-        .{ .a = -5.0, .b = 3.0, .exp = -2.0 },
-        .{ .a = 3.0, .b = 2.0, .exp = 1.0 },
-        .{ .a = 1.0, .b = 2.0, .exp = 1.0 },
+    const epsilon = switch (T) {
+        f16 => 1.0,
+        f32 => 0.001,
+        f64 => 0.00001,
+        f128 => 0.0000001,
+        else => unreachable,
     };
 
-    const epsilon = 1e30;
-    for (cases) |case| {
-        try expect((@rem(case.a, case.b) - case.exp) < epsilon);
-    }
+    try expect(std.math.fabs(@rem(@as(T, 6.9), @as(T, 4.0)) - @as(T, 2.9)) < epsilon);
+    try expect(std.math.fabs(@rem(@as(T, -6.9), @as(T, 4.0)) - @as(T, -2.9)) < epsilon);
+    try expect(std.math.fabs(@rem(@as(T, -5.0), @as(T, 3.0)) - @as(T, -2.0)) < epsilon);
+    try expect(std.math.fabs(@rem(@as(T, 3.0), @as(T, 2.0)) - @as(T, 1.0)) < epsilon);
+    try expect(std.math.fabs(@rem(@as(T, 1.0), @as(T, 2.0)) - @as(T, 1.0)) < epsilon);
+    try expect(std.math.fabs(@rem(@as(T, 0.0), @as(T, 1.0)) - @as(T, 0.0)) < epsilon);
+    try expect(std.math.fabs(@rem(@as(T, -0.0), @as(T, 1.0)) - @as(T, -0.0)) < epsilon);
+}
+
+test "float modulo division using @mod" {
+    comptime try fmod(f16);
+    comptime try fmod(f32);
+    comptime try fmod(f64);
+    comptime try fmod(f128);
+    try fmod(f16);
+    try fmod(f32);
+    try fmod(f64);
+    try fmod(f128);
+}
+
+fn fmod(comptime T: type) !void {
+    const epsilon = switch (T) {
+        f16 => 1.0,
+        f32 => 0.001,
+        f64 => 0.00001,
+        f128 => 0.0000001,
+        else => unreachable,
+    };
+
+    try expect(std.math.fabs(@mod(@as(T, 6.9), @as(T, 4.0)) - @as(T, 2.9)) < epsilon);
+    try expect(std.math.fabs(@mod(@as(T, -6.9), @as(T, 4.0)) - @as(T, 1.1)) < epsilon);
+    try expect(std.math.fabs(@mod(@as(T, -5.0), @as(T, 3.0)) - @as(T, 1.0)) < epsilon);
+    try expect(std.math.fabs(@mod(@as(T, 3.0), @as(T, 2.0)) - @as(T, 1.0)) < epsilon);
+    try expect(std.math.fabs(@mod(@as(T, 1.0), @as(T, 2.0)) - @as(T, 1.0)) < epsilon);
+    try expect(std.math.fabs(@mod(@as(T, 0.0), @as(T, 1.0)) - @as(T, 0.0)) < epsilon);
+    try expect(std.math.fabs(@mod(@as(T, -0.0), @as(T, 1.0)) - @as(T, -0.0)) < epsilon);
 }
 
 test "@sqrt" {

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -775,8 +775,6 @@ test "comptime float rem int" {
 }
 
 test "remainder division" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     comptime try remdiv(f16);
     comptime try remdiv(f32);
     comptime try remdiv(f64);

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -804,7 +804,7 @@ test "float remainder division using @rem" {
 
 fn frem(comptime T: type) !void {
     const Case = struct { a: T, b: T, exp: T };
-    const cases: []const Case = &[_]Case {
+    const cases: []const Case = &[_]Case{
         .{ .a = 6.9, .b = 4.0, .exp = 2.9 },
         .{ .a = -6.9, .b = 4.0, .exp = -2.9 },
         .{ .a = -5.0, .b = 3.0, .exp = -2.0 },


### PR DESCRIPTION
This contains code from #10827. Also as suggested by @matu3ba, added regression tests.

Presented example code in the closing issue now results in
```
[f16]  @rem(6.9e+00, 4.0e+00) = 2.8984375e+00
[f64]  @rem(6.9e+00, 4.0e+00) = 2.9000000000000004e+00
[f80]  @rem(6.9e+00, 4.0e+00) = -nan
[f128] @rem(6.9e+00, 4.0e+00) = 2.9e+00
[f16]  comptime @rem(6.9e+00, 4.0e+00) = 2.8984375e+00
[f64]  comptime @rem(6.9e+00, 4.0e+00) = 2.9000000000000004e+00
[f80]  comptime @rem(6.9e+00, 4.0e+00) = 2.9e+00
[f128] comptime @rem(6.9e+00, 4.0e+00) = 2.9e+00
```

Closes #10819.