### PR TITLE
stage2: tiny improvements all over the place

### DIFF
--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -970,6 +970,8 @@ pub const DeclGen = struct {
 
     /// Generates the wasm bytecode for the declaration belonging to `Context`
     fn genTypedValue(self: *DeclGen, ty: Type, val: Value) InnerError!Result {
+        log.debug("genTypedValue: ty = {}, val = {}", .{ ty, val });
+
         const writer = self.code.writer();
         if (val.isUndef()) {
             try writer.writeByteNTimes(0xaa, @intCast(usize, ty.abiSize(self.target())));

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -150,6 +150,8 @@ pub fn generateSymbol(
     const tracy = trace(@src());
     defer tracy.end();
 
+    log.debug("generateSymbol: ty = {}, val = {}", .{ typed_value.ty, typed_value.val });
+
     if (typed_value.val.isUndefDeep()) {
         const target = bin_file.options.target;
         const abi_size = try math.cast(usize, typed_value.ty.abiSize(target));
@@ -483,6 +485,18 @@ fn lowerDeclRef(
         }
 
         return Result{ .appended = {} };
+    }
+
+    const is_fn_body = decl.ty.zigTypeTag() == .Fn;
+    if (!is_fn_body and !decl.ty.hasRuntimeBits()) {
+        return Result{
+            .fail = try ErrorMsg.create(
+                bin_file.allocator,
+                src_loc,
+                "TODO handle void types when lowering decl ref",
+                .{},
+            ),
+        };
     }
 
     if (decl.analysis != .complete) return error.AnalysisFail;

--- a/src/value.zig
+++ b/src/value.zig
@@ -711,7 +711,10 @@ pub const Value = extern union {
                 const decl = val.castTag(.decl_ref_mut).?.data.decl;
                 return out_stream.print("(decl_ref_mut '{s}')", .{decl.name});
             },
-            .decl_ref => return out_stream.writeAll("(decl ref)"),
+            .decl_ref => {
+                const decl = val.castTag(.decl_ref).?.data;
+                return out_stream.print("(decl ref '{s}')", .{decl.name});
+            },
             .elem_ptr => {
                 const elem_ptr = val.castTag(.elem_ptr).?.data;
                 try out_stream.print("&[{}] ", .{elem_ptr.index});

--- a/test/behavior/bugs/1025.zig
+++ b/test/behavior/bugs/1025.zig
@@ -9,7 +9,6 @@ fn getA() A {
 }
 
 test "bug 1025" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     const a = getA();
     try @import("std").testing.expect(a.B == u8);
 }

--- a/test/behavior/bugs/1277.zig
+++ b/test/behavior/bugs/1277.zig
@@ -13,6 +13,5 @@ fn f() i32 {
 
 test "don't emit an LLVM global for a const function when it's in an optional in a struct" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     try std.testing.expect(s.f.?() == 1234);
 }

--- a/test/behavior/bugs/1310.zig
+++ b/test/behavior/bugs/1310.zig
@@ -24,6 +24,5 @@ fn agent_callback(_vm: [*]VM, options: [*]u8) callconv(.C) i32 {
 
 test "fixed" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     try expect(agent_callback(undefined, undefined) == 11);
 }

--- a/test/behavior/bugs/1500.zig
+++ b/test/behavior/bugs/1500.zig
@@ -7,7 +7,6 @@ const B = *const fn (A) void;
 
 test "allow these dependencies" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     var a: A = undefined;
     var b: B = undefined;
     if (false) {


### PR DESCRIPTION
* pass more x64 behavior tests
* return with a TODO error when lowering a decl with no runtime bits
* insert some debug logs for tracing recursive descent down the
type-value tree when lowering types
* print `Decl`'s name when print debugging `decl_ref` value