### PR TITLE
std.json: fix compile error for comptime fields

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1766,7 +1766,7 @@ fn parseInternal(
                                     }
                                 }
                                 if (field.is_comptime) {
-                                    if (!try parsesTo(field.field_type, field.default_value.?, tokens, child_options)) {
+                                    if (!try parsesTo(field.field_type, @ptrCast(*const field.field_type, field.default_value.?).*, tokens, child_options)) {
                                         return error.UnexpectedValue;
                                     }
                                 } else {

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -466,6 +466,8 @@ test {
 pub fn refAllDecls(comptime T: type) void {
     if (!builtin.is_test) return;
     inline for (comptime std.meta.declarations(T)) |decl| {
+        if (decl.is_pub and @typeInfo(@TypeOf(@field(T, decl.name))) == .Struct)
+            _ = @hasDecl(@field(T, decl.name), "foo");
         _ = decl;
     }
 }

--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -166,7 +166,7 @@ pub fn sizeof(target: anytype) usize {
                 const array_info = @typeInfo(ptr.child).Array;
                 if ((array_info.child == u8 or array_info.child == u16) and
                     array_info.sentinel != null and
-                    array_info.sentinel.? == 0)
+                    @ptrCast(*const array_info.child, array_info.sentinel.?).* == 0)
                 {
                     // length of the string plus one for the null terminator.
                     return (array_info.len + 1) * @sizeOf(array_info.child);

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -585,15 +585,6 @@ test "zig fmt: asm expression with comptime content" {
     );
 }
 
-test "zig fmt: anytype struct field" {
-    try testCanonical(
-        \\pub const Pointer = struct {
-        \\    sentinel: anytype,
-        \\};
-        \\
-    );
-}
-
 test "zig fmt: array types last token" {
     try testCanonical(
         \\test {
@@ -4146,6 +4137,17 @@ test "zig fmt: container doc comments" {
         \\//! Nothing here
         \\
     );
+}
+
+test "zig fmt: anytype struct field" {
+    try testError(
+        \\pub const Pointer = struct {
+        \\    sentinel: anytype,
+        \\};
+        \\
+    , &[_]Error{
+        .expected_type_expr,
+    });
 }
 
 test "zig fmt: extern without container keyword returns error" {


### PR DESCRIPTION
This is covered by an existing test which was already failing.