### PR TITLE
Fixed progress indicator for `zig test`

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -261,6 +261,7 @@ fn refreshWithHeldLock(self: *Progress) void {
             need_ellipse = false;
             const eti = @atomicLoad(usize, &node.unprotected_estimated_total_items, .Monotonic);
             const completed_items = @atomicLoad(usize, &node.unprotected_completed_items, .Monotonic);
+            const current_item = completed_items + 1;
             if (node.name.len != 0 or eti > 0) {
                 if (node.name.len != 0) {
                     self.bufWrite(&end, "{s}", .{node.name});
@@ -268,11 +269,11 @@ fn refreshWithHeldLock(self: *Progress) void {
                 }
                 if (eti > 0) {
                     if (need_ellipse) self.bufWrite(&end, " ", .{});
-                    self.bufWrite(&end, "[{d}/{d}] ", .{ completed_items, eti });
+                    self.bufWrite(&end, "[{d}/{d}] ", .{ current_item, eti });
                     need_ellipse = false;
                 } else if (completed_items != 0) {
                     if (need_ellipse) self.bufWrite(&end, " ", .{});
-                    self.bufWrite(&end, "[{d}] ", .{completed_items});
+                    self.bufWrite(&end, "[{d}] ", .{current_item});
                     need_ellipse = false;
                 }
             }

--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -82,18 +82,18 @@ pub fn main() void {
         } else |err| switch (err) {
             error.SkipZigTest => {
                 skip_count += 1;
-                test_node.end();
                 progress.log("{s}... SKIP\n", .{test_fn.name});
                 if (!have_tty) std.debug.print("SKIP\n", .{});
+                test_node.end();
             },
             else => {
                 fail_count += 1;
-                test_node.end();
                 progress.log("{s}... FAIL ({s})\n", .{ test_fn.name, @errorName(err) });
                 if (!have_tty) std.debug.print("FAIL ({s})\n", .{@errorName(err)});
                 if (@errorReturnTrace()) |trace| {
                     std.debug.dumpStackTrace(trace.*);
                 }
+                test_node.end();
             },
         }
     }


### PR DESCRIPTION
This is a fix for https://github.com/ziglang/zig/issues/10773
Now the progress always starts with 1. The counter is updated last, after every test related message has been printed.