### PR TITLE
stage2: native backends: lower const slices

### DIFF
--- a/src/arch/aarch64/Mir.zig
+++ b/src/arch/aarch64/Mir.zig
@@ -134,7 +134,12 @@ pub const Inst = struct {
         /// An extern function
         ///
         /// Used by e.g. call_extern
-        extern_fn: u32,
+        extern_fn: struct {
+            /// Index of the containing atom.
+            atom_index: u32,
+            /// Index into the linker's string table.
+            sym_name: u32,
+        },
         /// A 16-bit immediate value.
         ///
         /// Used by e.g. svc
@@ -278,6 +283,7 @@ pub fn extraData(mir: Mir, comptime T: type, index: usize) struct { data: T, end
 }
 
 pub const LoadMemory = struct {
+    atom_index: u32,
     register: u32,
     addr: u32,
 };

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -185,7 +185,7 @@ pub const Inst = struct {
         ///      0b00  reg1, [rip + reloc] // via GOT emits X86_64_RELOC_GOT relocation
         ///      0b01  reg1, [rip + reloc] // direct load emits X86_64_RELOC_SIGNED relocation
         /// Notes:
-        /// * `Data` contains `linker_sym_index` 
+        /// * `Data` contains `load_reloc`
         lea_pie,
 
         /// ops flags: form:
@@ -350,10 +350,19 @@ pub const Inst = struct {
         /// A 32-bit immediate value.
         imm: u32,
         /// An extern function.
-        /// Index into the linker's string table.
-        extern_fn: u32,
-        /// Entry in the linker's symbol table.
-        linker_sym_index: u32,
+        extern_fn: struct {
+            /// Index of the containing atom.
+            atom_index: u32,
+            /// Index into the linker's string table.
+            sym_name: u32,
+        },
+        /// PIE load relocation.
+        load_reloc: struct {
+            /// Index of the containing atom.
+            atom_index: u32,
+            /// Index into the linker's symbol table.
+            sym_index: u32,
+        },
         /// Index into `extra`. Meaning of what can be found there is context-dependent.
         payload: u32,
     };
@@ -362,7 +371,7 @@ pub const Inst = struct {
     // Note that in Debug builds, Zig is allowed to insert a secret field for safety checks.
     comptime {
         if (builtin.mode != .Debug) {
-            assert(@sizeOf(Inst) == 8);
+            assert(@sizeOf(Data) == 8);
         }
     }
 };

--- a/src/arch/x86_64/PrintMir.zig
+++ b/src/arch/x86_64/PrintMir.zig
@@ -450,6 +450,7 @@ fn mirLea(print: *const Print, inst: Mir.Inst.Index, w: anytype) !void {
 
 fn mirLeaPie(print: *const Print, inst: Mir.Inst.Index, w: anytype) !void {
     const ops = Mir.Ops.decode(print.mir.instructions.items(.ops)[inst]);
+    const load_reloc = print.mir.instructions.items(.data)[inst].load_reloc;
     try w.print("lea {s}, ", .{@tagName(ops.reg1)});
     switch (ops.reg1.size()) {
         8 => try w.print("byte ptr ", .{}),
@@ -459,9 +460,8 @@ fn mirLeaPie(print: *const Print, inst: Mir.Inst.Index, w: anytype) !void {
         else => unreachable,
     }
     try w.print("[rip + 0x0] ", .{});
-    const sym_index = print.mir.instructions.items(.data)[inst].linker_sym_index;
     if (print.bin_file.cast(link.File.MachO)) |macho_file| {
-        const target = macho_file.locals.items[sym_index];
+        const target = macho_file.locals.items[load_reloc.sym_index];
         const target_name = macho_file.getString(target.n_strx);
         try w.print("target@{s}", .{target_name});
     } else {

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -142,6 +142,7 @@ pub fn generateFunction(
 
 pub fn generateSymbol(
     bin_file: *link.File,
+    parent_atom_index: u32,
     src_loc: Module.SrcLoc,
     typed_value: TypedValue,
     code: *std.ArrayList(u8),
@@ -177,7 +178,7 @@ pub fn generateSymbol(
                 if (typed_value.ty.sentinel()) |sentinel| {
                     try code.ensureUnusedCapacity(payload.data.len + 1);
                     code.appendSliceAssumeCapacity(payload.data);
-                    switch (try generateSymbol(bin_file, src_loc, .{
+                    switch (try generateSymbol(bin_file, parent_atom_index, src_loc, .{
                         .ty = typed_value.ty.elemType(),
                         .val = sentinel,
                     }, code, debug_output)) {
@@ -197,7 +198,7 @@ pub fn generateSymbol(
                 const elem_vals = typed_value.val.castTag(.array).?.data;
                 const elem_ty = typed_value.ty.elemType();
                 for (elem_vals) |elem_val| {
-                    switch (try generateSymbol(bin_file, src_loc, .{
+                    switch (try generateSymbol(bin_file, parent_atom_index, src_loc, .{
                         .ty = elem_ty,
                         .val = elem_val,
                     }, code, debug_output)) {
@@ -223,11 +224,11 @@ pub fn generateSymbol(
         .Pointer => switch (typed_value.val.tag()) {
             .variable => {
                 const decl = typed_value.val.castTag(.variable).?.data.owner_decl;
-                return lowerDeclRef(bin_file, src_loc, typed_value, decl, code, debug_output);
+                return lowerDeclRef(bin_file, parent_atom_index, src_loc, typed_value, decl, code, debug_output);
             },
             .decl_ref => {
                 const decl = typed_value.val.castTag(.decl_ref).?.data;
-                return lowerDeclRef(bin_file, src_loc, typed_value, decl, code, debug_output);
+                return lowerDeclRef(bin_file, parent_atom_index, src_loc, typed_value, decl, code, debug_output);
             },
             .slice => {
                 const slice = typed_value.val.castTag(.slice).?.data;
@@ -235,7 +236,7 @@ pub fn generateSymbol(
                 // generate ptr
                 var buf: Type.SlicePtrFieldTypeBuffer = undefined;
                 const slice_ptr_field_type = typed_value.ty.slicePtrFieldType(&buf);
-                switch (try generateSymbol(bin_file, src_loc, .{
+                switch (try generateSymbol(bin_file, parent_atom_index, src_loc, .{
                     .ty = slice_ptr_field_type,
                     .val = slice.ptr,
                 }, code, debug_output)) {
@@ -247,7 +248,7 @@ pub fn generateSymbol(
                 }
 
                 // generate length
-                switch (try generateSymbol(bin_file, src_loc, .{
+                switch (try generateSymbol(bin_file, parent_atom_index, src_loc, .{
                     .ty = Type.initTag(.usize),
                     .val = slice.len,
                 }, code, debug_output)) {
@@ -391,7 +392,7 @@ pub fn generateSymbol(
                 const field_ty = typed_value.ty.structFieldType(index);
                 if (!field_ty.hasRuntimeBits()) continue;
 
-                switch (try generateSymbol(bin_file, src_loc, .{
+                switch (try generateSymbol(bin_file, parent_atom_index, src_loc, .{
                     .ty = field_ty,
                     .val = field_val,
                 }, code, debug_output)) {
@@ -446,6 +447,7 @@ pub fn generateSymbol(
 
 fn lowerDeclRef(
     bin_file: *link.File,
+    parent_atom_index: u32,
     src_loc: Module.SrcLoc,
     typed_value: TypedValue,
     decl: *Module.Decl,
@@ -456,7 +458,7 @@ fn lowerDeclRef(
         // generate ptr
         var buf: Type.SlicePtrFieldTypeBuffer = undefined;
         const slice_ptr_field_type = typed_value.ty.slicePtrFieldType(&buf);
-        switch (try generateSymbol(bin_file, src_loc, .{
+        switch (try generateSymbol(bin_file, parent_atom_index, src_loc, .{
             .ty = slice_ptr_field_type,
             .val = typed_value.val,
         }, code, debug_output)) {
@@ -472,7 +474,7 @@ fn lowerDeclRef(
             .base = .{ .tag = .int_u64 },
             .data = typed_value.val.sliceLen(),
         };
-        switch (try generateSymbol(bin_file, src_loc, .{
+        switch (try generateSymbol(bin_file, parent_atom_index, src_loc, .{
             .ty = Type.initTag(.usize),
             .val = Value.initPayload(&slice_len.base),
         }, code, debug_output)) {
@@ -495,15 +497,7 @@ fn lowerDeclRef(
     }
 
     decl.markAlive();
-    const vaddr = vaddr: {
-        if (bin_file.cast(link.File.MachO)) |macho_file| {
-            break :vaddr try macho_file.getDeclVAddrWithReloc(decl, code.items.len);
-        }
-        // TODO handle the dependency of this symbol on the decl's vaddr.
-        // If the decl changes vaddr, then this symbol needs to get regenerated.
-        break :vaddr bin_file.getDeclVAddr(decl);
-    };
-
+    const vaddr = try bin_file.getDeclVAddr(decl, parent_atom_index, code.items.len);
     const endian = target.cpu.arch.endian();
     switch (ptr_width) {
         16 => mem.writeInt(u16, try code.addManyAsArray(2), @intCast(u16, vaddr), endian),

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -230,7 +230,6 @@ pub fn generateSymbol(
                 return lowerDeclRef(bin_file, src_loc, typed_value, decl, code, debug_output);
             },
             .slice => {
-                // TODO populate .debug_info for the slice
                 const slice = typed_value.val.castTag(.slice).?.data;
 
                 // generate ptr

--- a/src/link.zig
+++ b/src/link.zig
@@ -684,12 +684,16 @@ pub const File = struct {
         }
     }
 
-    pub fn getDeclVAddr(base: *File, decl: *const Module.Decl) u64 {
+    /// Get allocated `Decl`'s address in virtual memory.
+    /// The linker is passed information about the containing atom, `parent_atom_index`, and offset within it's
+    /// memory buffer, `offset`, so that it can make a note of potential relocation sites, should the
+    /// `Decl`'s address was not yet resolved, or the containing atom gets moved in virtual memory.
+    pub fn getDeclVAddr(base: *File, decl: *const Module.Decl, parent_atom_index: u32, offset: u64) !u64 {
         switch (base.tag) {
-            .coff => return @fieldParentPtr(Coff, "base", base).getDeclVAddr(decl),
-            .elf => return @fieldParentPtr(Elf, "base", base).getDeclVAddr(decl),
-            .macho => return @fieldParentPtr(MachO, "base", base).getDeclVAddr(decl),
-            .plan9 => return @fieldParentPtr(Plan9, "base", base).getDeclVAddr(decl),
+            .coff => return @fieldParentPtr(Coff, "base", base).getDeclVAddr(decl, parent_atom_index, offset),
+            .elf => return @fieldParentPtr(Elf, "base", base).getDeclVAddr(decl, parent_atom_index, offset),
+            .macho => return @fieldParentPtr(MachO, "base", base).getDeclVAddr(decl, parent_atom_index, offset),
+            .plan9 => return @fieldParentPtr(Plan9, "base", base).getDeclVAddr(decl, parent_atom_index, offset),
             .c => unreachable,
             .wasm => unreachable,
             .spirv => unreachable,

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -726,7 +726,7 @@ pub fn updateDecl(self: *Coff, module: *Module, decl: *Module.Decl) !void {
     var code_buffer = std.ArrayList(u8).init(self.base.allocator);
     defer code_buffer.deinit();
 
-    const res = try codegen.generateSymbol(&self.base, decl.srcLoc(), .{
+    const res = try codegen.generateSymbol(&self.base, 0, decl.srcLoc(), .{
         .ty = decl.ty,
         .val = decl.val,
     }, &code_buffer, .none);
@@ -751,7 +751,7 @@ fn finishUpdateDecl(self: *Coff, module: *Module, decl: *Module.Decl, code: []co
         const need_realloc = code.len > capacity or
             !mem.isAlignedGeneric(u32, decl.link.coff.text_offset, required_alignment);
         if (need_realloc) {
-            const curr_vaddr = self.getDeclVAddr(decl);
+            const curr_vaddr = self.text_section_virtual_address + decl.link.coff.text_offset;
             const vaddr = try self.growTextBlock(&decl.link.coff, code.len, required_alignment);
             log.debug("growing {s} from 0x{x} to 0x{x}\n", .{ decl.name, curr_vaddr, vaddr });
             if (vaddr != curr_vaddr) {
@@ -1465,7 +1465,9 @@ fn findLib(self: *Coff, arena: Allocator, name: []const u8) !?[]const u8 {
     return null;
 }
 
-pub fn getDeclVAddr(self: *Coff, decl: *const Module.Decl) u64 {
+pub fn getDeclVAddr(self: *Coff, decl: *const Module.Decl, parent_atom_index: u32, offset: u64) !u64 {
+    _ = parent_atom_index;
+    _ = offset;
     assert(self.llvm_object == null);
     return self.text_section_virtual_address + decl.link.coff.text_offset;
 }

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -302,7 +302,9 @@ pub fn updateDecl(self: *Plan9, module: *Module, decl: *Module.Decl) !void {
     var code_buffer = std.ArrayList(u8).init(self.base.allocator);
     defer code_buffer.deinit();
     const decl_val = if (decl.val.castTag(.variable)) |payload| payload.data.init else decl.val;
-    const res = try codegen.generateSymbol(&self.base, @intCast(u32, decl.link.plan9.sym_index.?), decl.srcLoc(), .{
+    // TODO we need the symbol index for symbol in the table of locals for the containing atom
+    const sym_index = decl.link.plan9.sym_index orelse 0;
+    const res = try codegen.generateSymbol(&self.base, @intCast(u32, sym_index), decl.srcLoc(), .{
         .ty = decl.ty,
         .val = decl_val,
     }, &code_buffer, .{ .none = .{} });

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -302,7 +302,7 @@ pub fn updateDecl(self: *Plan9, module: *Module, decl: *Module.Decl) !void {
     var code_buffer = std.ArrayList(u8).init(self.base.allocator);
     defer code_buffer.deinit();
     const decl_val = if (decl.val.castTag(.variable)) |payload| payload.data.init else decl.val;
-    const res = try codegen.generateSymbol(&self.base, decl.srcLoc(), .{
+    const res = try codegen.generateSymbol(&self.base, @intCast(u32, decl.link.plan9.sym_index.?), decl.srcLoc(), .{
         .ty = decl.ty,
         .val = decl_val,
     }, &code_buffer, .{ .none = .{} });
@@ -749,7 +749,9 @@ pub fn allocateDeclIndexes(self: *Plan9, decl: *Module.Decl) !void {
     _ = self;
     _ = decl;
 }
-pub fn getDeclVAddr(self: *Plan9, decl: *const Module.Decl) u64 {
+pub fn getDeclVAddr(self: *Plan9, decl: *const Module.Decl, parent_atom_index: u32, offset: u64) !u64 {
+    _ = parent_atom_index;
+    _ = offset;
     if (decl.ty.zigTypeTag() == .Fn) {
         var start = self.bases.text;
         var it_file = self.fn_decl_table.iterator();

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -38,6 +38,7 @@ test {
     _ = @import("behavior/optional.zig");
     _ = @import("behavior/prefetch.zig");
     _ = @import("behavior/pub_enum.zig");
+    _ = @import("behavior/slice.zig");
     _ = @import("behavior/slice_sentinel_comptime.zig");
     _ = @import("behavior/type.zig");
     _ = @import("behavior/truncate.zig");
@@ -76,7 +77,6 @@ test {
         _ = @import("behavior/pointers.zig");
         _ = @import("behavior/ptrcast.zig");
         _ = @import("behavior/ref_var_in_if_after_if_2nd_switch_prong.zig");
-        _ = @import("behavior/slice.zig");
         _ = @import("behavior/src.zig");
         _ = @import("behavior/this.zig");
         _ = @import("behavior/try.zig");

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -120,14 +120,12 @@ test "return string from function" {
 
 test "hex escape" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     try expect(mem.eql(u8, "\x68\x65\x6c\x6c\x6f", "hello"));
 }
 
 test "multiline string" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const s1 =
         \\one
@@ -140,7 +138,6 @@ test "multiline string" {
 
 test "multiline string comments at start" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const s1 =
         //\\one
@@ -153,7 +150,6 @@ test "multiline string comments at start" {
 
 test "multiline string comments at end" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const s1 =
         \\one
@@ -166,7 +162,6 @@ test "multiline string comments at end" {
 
 test "multiline string comments in middle" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const s1 =
         \\one
@@ -179,7 +174,6 @@ test "multiline string comments in middle" {
 
 test "multiline string comments at multiple places" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const s1 =
         \\one
@@ -193,14 +187,11 @@ test "multiline string comments at multiple places" {
 }
 
 test "string concatenation" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-
     try expect(mem.eql(u8, "OK" ++ " IT " ++ "WORKED", "OK IT WORKED"));
 }
 
 test "array mult operator" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     try expect(mem.eql(u8, "ab" ** 5, "ababababab"));
 }

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -27,7 +27,10 @@ comptime {
 }
 
 test "slicing" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+
     var array: [20]i32 = undefined;
 
     array[5] = 1234;
@@ -45,6 +48,8 @@ test "slicing" {
 
 test "const slice" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     comptime {
         const a = "1234567890";
         try expect(a.len == 10);
@@ -56,6 +61,8 @@ test "const slice" {
 
 test "comptime slice of undefined pointer of length 0" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const slice1 = @as([*]i32, undefined)[0..0];
     try expect(slice1.len == 0);
     const slice2 = @as([*]i32, undefined)[100..100];
@@ -64,6 +71,8 @@ test "comptime slice of undefined pointer of length 0" {
 
 test "implicitly cast array of size 0 to slice" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     var msg = [_]u8{};
     try assertLenIsZero(&msg);
 }
@@ -74,6 +83,8 @@ fn assertLenIsZero(msg: []const u8) !void {
 
 test "access len index of sentinel-terminated slice" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const S = struct {
         fn doTheTest() !void {
             var slice: [:0]const u8 = "hello";
@@ -88,6 +99,8 @@ test "access len index of sentinel-terminated slice" {
 
 test "comptime slice of slice preserves comptime var" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     comptime {
         var buff: [10]u8 = undefined;
         buff[0..][0..][0] = 1;
@@ -97,6 +110,8 @@ test "comptime slice of slice preserves comptime var" {
 
 test "slice of type" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     comptime {
         var types_array = [_]type{ i32, f64, type };
         for (types_array) |T, i| {
@@ -120,6 +135,9 @@ test "slice of type" {
 
 test "generic malloc free" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     const a = memAlloc(u8, 10) catch unreachable;
     memFree(u8, a);
 }
@@ -133,6 +151,8 @@ fn memFree(comptime T: type, memory: []T) void {
 
 test "slice of hardcoded address to pointer" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const S = struct {
         fn doTheTest() !void {
             const pointer = @intToPtr([*]u8, 0x04)[0..2];
@@ -148,6 +168,8 @@ test "slice of hardcoded address to pointer" {
 
 test "comptime slice of pointer preserves comptime var" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     comptime {
         var buff: [10]u8 = undefined;
         var a = @ptrCast([*]u8, &buff);
@@ -158,6 +180,8 @@ test "comptime slice of pointer preserves comptime var" {
 
 test "comptime pointer cast array and then slice" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     const array = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
 
     const ptrA: [*]const u8 = @ptrCast([*]const u8, &array);
@@ -172,6 +196,9 @@ test "comptime pointer cast array and then slice" {
 
 test "slicing zero length array" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     const s1 = ""[0..];
     const s2 = ([_]u32{})[0..];
     try expect(s1.len == 0);
@@ -185,6 +212,8 @@ const y = x[0x100..];
 test "compile time slice of pointer to hard coded address" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     try expect(@ptrToInt(x) == 0x1000);
     try expect(x.len == 0x500);
@@ -194,6 +223,9 @@ test "compile time slice of pointer to hard coded address" {
 }
 
 test "slice string literal has correct type" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     comptime {
         try expect(@TypeOf("aoeu"[0..]) == *const [4:0]u8);
         const array = [_]i32{ 1, 2, 3, 4 };
@@ -207,6 +239,7 @@ test "slice string literal has correct type" {
 
 test "result location zero sized array inside struct field implicit cast to slice" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const E = struct {
         entries: []u32,
@@ -216,6 +249,9 @@ test "result location zero sized array inside struct field implicit cast to slic
 }
 
 test "runtime safety lets us slice from len..len" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     var an_array = [_]u8{ 1, 2, 3 };
     try expect(mem.eql(u8, sliceFromLenToLen(an_array[0..], 3, 3), ""));
 }
@@ -225,6 +261,9 @@ fn sliceFromLenToLen(a_slice: []u8, start: usize, end: usize) []u8 {
 }
 
 test "C pointer" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     var buf: [*c]const u8 = "kjdhfkjdhfdkjhfkfjhdfkjdhfkdjhfdkjhf";
     var len: u32 = 10;
     var slice = buf[0..len];
@@ -232,6 +271,9 @@ test "C pointer" {
 }
 
 test "C pointer slice access" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     var buf: [10]u32 = [1]u32{42} ** 10;
     const c_ptr = @ptrCast([*c]const u32, &buf);
 
@@ -245,6 +287,8 @@ test "C pointer slice access" {
 }
 
 test "comptime slices are disambiguated" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
     try expect(sliceSum(&[_]u8{ 1, 2 }) == 3);
     try expect(sliceSum(&[_]u8{ 3, 4 }) == 7);
 }
@@ -258,6 +302,9 @@ fn sliceSum(comptime q: []const u8) i32 {
 }
 
 test "slice type with custom alignment" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     const LazilyResolvedType = struct {
         anything: i32,
     };
@@ -269,6 +316,8 @@ test "slice type with custom alignment" {
 }
 
 test "obtaining a null terminated slice" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
     // here we have a normal array
@@ -294,6 +343,7 @@ test "obtaining a null terminated slice" {
 
 test "empty array to slice" {
     if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {
@@ -312,6 +362,9 @@ test "empty array to slice" {
 }
 
 test "@ptrCast slice to pointer" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     const S = struct {
         fn doTheTest() !void {
             var array align(@alignOf(u16)) = [5]u8{ 0xff, 0xff, 0xff, 0xff, 0xff };
@@ -327,6 +380,7 @@ test "@ptrCast slice to pointer" {
 
 test "slice syntax resulting in pointer-to-array" {
     if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {
@@ -475,6 +529,7 @@ test "slice syntax resulting in pointer-to-array" {
 
 test "type coercion of pointer to anon struct literal to pointer to slice" {
     if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const S = struct {
         const U = union {
@@ -508,6 +563,7 @@ test "type coercion of pointer to anon struct literal to pointer to slice" {
 
 test "array concat of slices gives slice" {
     if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     comptime {
         var a: []const u8 = "aoeu";
@@ -519,6 +575,7 @@ test "array concat of slices gives slice" {
 
 test "slice bounds in comptime concatenation" {
     if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const bs = comptime blk: {
         const b = "........1........";
@@ -535,6 +592,7 @@ test "slice bounds in comptime concatenation" {
 
 test "slice sentinel access at comptime" {
     if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     {
         const str0 = &[_:0]u8{ '1', '2', '3' };


### PR DESCRIPTION
* x64 + arm codegen: handle lowering of const slice pointers
* elf: store pointer relocations indexed by containing atom - in `getDeclVAddr` it may happen that the target `Decl` has not been allocated space in virtual memory. In this case, we store a relocation in the linker-global table which we will iterate over when flushing the module, and fill in any missing addresses in the final binary. Note that for optimisation, if the address was resolved at the time of a call to `getDeclVAddr`, we skip relocating this atom.
* macho: correctly lower slices including relocation and rebasing tracking
* x64 + aarch64 - expand `Mir` instructions requiring the knowledge of the containing atom to pass the symbol index into the linker's table from codegen via mir to the emitter, to then utilise it in the linker when allocating memory
* x64: pass more behavior tests