### PR TITLE
stage1+target: Bringup SerenityOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(ZIG_TARGET_MCPU "baseline" CACHE STRING "-mcpu parameter to output binaries 
 set(ZIG_EXECUTABLE "" CACHE STRING "(when cross compiling) path to already-built zig binary")
 set(ZIG_SINGLE_THREADED off CACHE BOOL "limit the zig compiler to use only 1 thread")
 set(ZIG_OMIT_STAGE2 off CACHE BOOL "omit the stage2 backend from stage1")
+set(ZIG_SERENITY_BUILD off CACHE BOOL "Build Zig for SerenityOS (requires patched LLVM)")
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     set(ZIG_ENABLE_LOGGING ON CACHE BOOL "enable logging")
@@ -713,6 +714,10 @@ if(ZIG_STATIC)
     set(EXE_CFLAGS "${EXE_CFLAGS} -DZIG_LINK_MODE=Static")
 else()
     set(EXE_CFLAGS "${EXE_CFLAGS} -DZIG_LINK_MODE=Dynamic")
+endif()
+
+if(ZIG_SERENITY_BUILD)
+    set(EXE_CFLAGS "${EXE_CFLAGS} -DZIG_SERENITY_BUILD")
 endif()
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")

--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -584,7 +584,7 @@ const PosixThreadImpl = struct {
                 };
                 return @intCast(usize, count);
             },
-            .solaris => {
+            .solaris, .serenity => {
                 // The "proper" way to get the cpu count would be to query
                 // /dev/kstat via ioctls, and traverse a linked list for each
                 // cpu.

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -54,6 +54,7 @@ pub usingnamespace switch (builtin.os.tag) {
     .minix => @import("c/minix.zig"),
     .emscripten => @import("c/emscripten.zig"),
     .wasi => @import("c/wasi.zig"),
+    .serenity => @import("c/serenity.zig"),
     else => struct {},
 };
 

--- a/lib/std/c/serenity-constants.zig
+++ b/lib/std/c/serenity-constants.zig
@@ -1,0 +1,3 @@
+// NOTE: This is just a stub file so the install step does not fail.
+//       If you want to actually build Zig with SerenityOS target
+//       support, use the ports system in the SerenityOS repository.

--- a/lib/std/c/serenity.zig
+++ b/lib/std/c/serenity.zig
@@ -1,0 +1,375 @@
+const std = @import("std");
+
+const SerenityConstants = @import("serenity-constants.zig");
+
+pub const PATH_MAX = SerenityConstants.PATH_MAX;
+
+pub const fd_t = i32;
+pub const dev_t = u32;
+pub const ino_t = u64;
+pub const mode_t = u16;
+pub const uid_t = u32;
+pub const gid_t = u32;
+pub const nlink_t = u32;
+pub const off_t = i64;
+pub const blksize_t = u32;
+pub const blkcnt_t = u32;
+pub const pid_t = c_int;
+pub const nfds_t = c_uint;
+pub const time_t = i64;
+
+pub const timespec = extern struct {
+    tv_sec: time_t,
+    tv_nsec: c_long,
+};
+
+pub const sem_t = extern struct {
+    value: u32,
+};
+
+pub const pthread_mutex_t = extern struct {
+    lock: u32 = 0,
+    owner: i32 = 0,
+    level: i32 = 0,
+    type: i32 = SerenityConstants.__PTHREAD_MUTEX_NORMAL,
+};
+
+pub const pthread_attr_t = *anyopaque;
+
+pub const pollfd = extern struct {
+    fd: c_int,
+    events: c_short,
+    revents: c_short,
+};
+
+pub extern "c" fn __errno_location() *c_int;
+pub const _errno = __errno_location;
+
+pub const AT = struct {
+    pub const FDCWD = SerenityConstants.AT_FDCWD;
+    pub const SYMLINK_NOFOLLOW = SerenityConstants.AT_SYMLINK_NOFOLLOW;
+    pub const REMOVEDIR = SerenityConstants.AT_REMOVEDIR;
+};
+
+pub const E = enum(i32) {
+    SUCCESS = SerenityConstants.ESUCCESS,
+    PERM = SerenityConstants.EPERM,
+    NOENT = SerenityConstants.ENOENT,
+    SRCH = SerenityConstants.ESRCH,
+    INTR = SerenityConstants.EINTR,
+    IO = SerenityConstants.EIO,
+    NXIO = SerenityConstants.ENXIO,
+    @"2BIG" = SerenityConstants.E2BIG,
+    NOEXEC = SerenityConstants.ENOEXEC,
+    BADF = SerenityConstants.EBADF,
+    CHILD = SerenityConstants.ECHILD,
+    AGAIN = SerenityConstants.EAGAIN,
+    NOMEM = SerenityConstants.ENOMEM,
+    ACCES = SerenityConstants.EACCES,
+    FAULT = SerenityConstants.EFAULT,
+    NOTBLK = SerenityConstants.ENOTBLK,
+    BUSY = SerenityConstants.EBUSY,
+    EXIST = SerenityConstants.EEXIST,
+    XDEV = SerenityConstants.EXDEV,
+    NODEV = SerenityConstants.ENODEV,
+    NOTDIR = SerenityConstants.ENOTDIR,
+    ISDIR = SerenityConstants.EISDIR,
+    INVAL = SerenityConstants.EINVAL,
+    NFILE = SerenityConstants.ENFILE,
+    MFILE = SerenityConstants.EMFILE,
+    NOTTY = SerenityConstants.ENOTTY,
+    TXTBSY = SerenityConstants.ETXTBSY,
+    FBIG = SerenityConstants.EFBIG,
+    NOSPC = SerenityConstants.ENOSPC,
+    SPIPE = SerenityConstants.ESPIPE,
+    ROFS = SerenityConstants.EROFS,
+    MLINK = SerenityConstants.EMLINK,
+    PIPE = SerenityConstants.EPIPE,
+    RANGE = SerenityConstants.ERANGE,
+    NAMETOOLONG = SerenityConstants.ENAMETOOLONG,
+    LOOP = SerenityConstants.ELOOP,
+    OVERFLOW = SerenityConstants.EOVERFLOW,
+    OPNOTSUPP = SerenityConstants.EOPNOTSUPP,
+    NOSYS = SerenityConstants.ENOSYS,
+    NOTIMPL = SerenityConstants.ENOTIMPL,
+    AFNOSUPPORT = SerenityConstants.EAFNOSUPPORT,
+    NOTSOCK = SerenityConstants.ENOTSOCK,
+    ADDRINUSE = SerenityConstants.EADDRINUSE,
+    NOTEMPTY = SerenityConstants.ENOTEMPTY,
+    DOM = SerenityConstants.EDOM,
+    CONNREFUSED = SerenityConstants.ECONNREFUSED,
+    HOSTDOWN = SerenityConstants.EHOSTDOWN,
+    ADDRNOTAVAIL = SerenityConstants.EADDRNOTAVAIL,
+    ISCONN = SerenityConstants.EISCONN,
+    CONNABORTED = SerenityConstants.ECONNABORTED,
+    ALREADY = SerenityConstants.EALREADY,
+    CONNRESET = SerenityConstants.ECONNRESET,
+    DESTADDRREQ = SerenityConstants.EDESTADDRREQ,
+    HOSTUNREACH = SerenityConstants.EHOSTUNREACH,
+    ILSEQ = SerenityConstants.EILSEQ,
+    MSGSIZE = SerenityConstants.EMSGSIZE,
+    NETDOWN = SerenityConstants.ENETDOWN,
+    NETUNREACH = SerenityConstants.ENETUNREACH,
+    NETRESET = SerenityConstants.ENETRESET,
+    NOBUFS = SerenityConstants.ENOBUFS,
+    NOLCK = SerenityConstants.ENOLCK,
+    NOMSG = SerenityConstants.ENOMSG,
+    NOPROTOOPT = SerenityConstants.ENOPROTOOPT,
+    NOTCONN = SerenityConstants.ENOTCONN,
+    SHUTDOWN = SerenityConstants.ESHUTDOWN,
+    TOOMANYREFS = SerenityConstants.ETOOMANYREFS,
+    SOCKTNOSUPPORT = SerenityConstants.ESOCKTNOSUPPORT,
+    PROTONOSUPPORT = SerenityConstants.EPROTONOSUPPORT,
+    DEADLK = SerenityConstants.EDEADLK,
+    TIMEDOUT = SerenityConstants.ETIMEDOUT,
+    PROTOTYPE = SerenityConstants.EPROTOTYPE,
+    INPROGRESS = SerenityConstants.EINPROGRESS,
+    NOTHREAD = SerenityConstants.ENOTHREAD,
+    PROTO = SerenityConstants.EPROTO,
+    NOTSUP = SerenityConstants.ENOTSUP,
+    PFNOSUPPORT = SerenityConstants.EPFNOSUPPORT,
+    DIRINTOSELF = SerenityConstants.EDIRINTOSELF,
+    DQUOT = SerenityConstants.EDQUOT,
+    NOTRECOVERABLE = SerenityConstants.ENOTRECOVERABLE,
+    CANCELED = SerenityConstants.ECANCELED,
+    PROMISEVIOLATION = SerenityConstants.EPROMISEVIOLATION,
+};
+
+pub const Stat = struct {
+    dev: dev_t,
+    ino: ino_t,
+    mode: mode_t,
+    nlink: nlink_t,
+    uid: uid_t,
+    gid: gid_t,
+    rdev: dev_t,
+    size: off_t,
+    blksize: blksize_t,
+    blocks: blkcnt_t,
+    atim: timespec,
+    mtim: timespec,
+    ctim: timespec,
+
+    pub fn atime(self: @This()) timespec {
+        return self.atim;
+    }
+    pub fn mtime(self: @This()) timespec {
+        return self.mtim;
+    }
+    pub fn ctime(self: @This()) timespec {
+        return self.ctim;
+    }
+};
+
+pub const LOCK = struct {
+    pub const SH = SerenityConstants.LOCK_SH;
+    pub const EX = SerenityConstants.LOCK_EX;
+    pub const NB = SerenityConstants.LOCK_NB;
+    pub const UN = SerenityConstants.LOCK_UN;
+};
+
+pub const STDIN_FILENO = SerenityConstants.STDIN_FILENO;
+pub const STDOUT_FILENO = SerenityConstants.STDOUT_FILENO;
+pub const STDERR_FILENO = SerenityConstants.STDERR_FILENO;
+
+pub const O = struct {
+    pub const RDONLY = @as(u32, SerenityConstants.O_RDONLY);
+    pub const WRONLY = @as(u32, SerenityConstants.O_WRONLY);
+    pub const RDWR = @as(u32, SerenityConstants.O_RDWR);
+    pub const ACCMODE = @as(u32, SerenityConstants.O_ACCMODE);
+    pub const EXEC = @as(u32, SerenityConstants.O_EXEC);
+    pub const CREAT = @as(u32, SerenityConstants.O_CREAT);
+    pub const EXCL = @as(u32, SerenityConstants.O_EXCL);
+    pub const NOCTTY = @as(u32, SerenityConstants.O_NOCTTY);
+    pub const TRUNC = @as(u32, SerenityConstants.O_TRUNC);
+    pub const APPEND = @as(u32, SerenityConstants.O_APPEND);
+    pub const NONBLOCK = @as(u32, SerenityConstants.O_NONBLOCK);
+    pub const DIRECTORY = @as(u32, SerenityConstants.O_DIRECTORY);
+    pub const NOFOLLOW = @as(u32, SerenityConstants.O_NOFOLLOW);
+    pub const CLOEXEC = @as(u32, SerenityConstants.O_CLOEXEC);
+    pub const DIRECT = @as(u32, SerenityConstants.O_DIRECT);
+};
+
+pub const R_OK = SerenityConstants.R_OK;
+pub const W_OK = SerenityConstants.W_OK;
+pub const X_OK = SerenityConstants.X_OK;
+pub const F_OK = SerenityConstants.F_OK;
+
+pub const S = struct {
+    pub const IFMT = SerenityConstants.S_IFMT;
+    pub const IFDIR = SerenityConstants.S_IFDIR;
+    pub const IFCHR = SerenityConstants.S_IFCHR;
+    pub const IFBLK = SerenityConstants.S_IFBLK;
+    pub const IFREG = SerenityConstants.S_IFREG;
+    pub const IFIFO = SerenityConstants.S_IFIFO;
+    pub const IFLNK = SerenityConstants.S_IFLNK;
+    pub const IFSOCK = SerenityConstants.S_IFSOCK;
+    pub const ISUID = SerenityConstants.S_ISUID;
+    pub const ISGID = SerenityConstants.S_ISGID;
+    pub const ISVTX = SerenityConstants.S_ISVTX;
+    pub const IRUSR = SerenityConstants.S_IRUSR;
+    pub const IWUSR = SerenityConstants.S_IWUSR;
+    pub const IXUSR = SerenityConstants.S_IXUSR;
+    pub const IREAD = SerenityConstants.S_IREAD;
+    pub const IWRITE = SerenityConstants.S_IWRITE;
+    pub const IEXEC = SerenityConstants.S_IEXEC;
+    pub const IRGRP = SerenityConstants.S_IRGRP;
+    pub const IWGRP = SerenityConstants.S_IWGRP;
+    pub const IXGRP = SerenityConstants.S_IXGRP;
+    pub const IROTH = SerenityConstants.S_IROTH;
+    pub const IWOTH = SerenityConstants.S_IWOTH;
+    pub const IXOTH = SerenityConstants.S_IXOTH;
+
+    pub fn ISDIR(m: u32) bool {
+        return m & IFMT == IFDIR;
+    }
+
+    pub fn ISCHR(m: u32) bool {
+        return m & IFMT == IFCHR;
+    }
+
+    pub fn ISBLK(m: u32) bool {
+        return m & IFMT == IFBLK;
+    }
+
+    pub fn ISREG(m: u32) bool {
+        return m & IFMT == IFREG;
+    }
+
+    pub fn ISFIFO(m: u32) bool {
+        return m & IFMT == IFIFO;
+    }
+
+    pub fn ISLNK(m: u32) bool {
+        return m & IFMT == IFLNK;
+    }
+
+    pub fn ISSOCK(m: u32) bool {
+        return m & IFMT == IFSOCK;
+    }
+};
+
+pub const POLL = struct {
+    pub const IN = SerenityConstants.POLLIN;
+    pub const RDNORM = SerenityConstants.POLLRDNORM;
+    pub const PRI = SerenityConstants.POLLPRI;
+    pub const OUT = SerenityConstants.POLLOUT;
+    pub const WRNORM = SerenityConstants.POLLWRNORM;
+    pub const ERR = SerenityConstants.POLLERR;
+    pub const HUP = SerenityConstants.POLLHUP;
+    pub const NVAL = SerenityConstants.POLLNVAL;
+    pub const WRBAND = SerenityConstants.POLLWRBAND;
+    pub const RDHUP = SerenityConstants.POLLRDHUP;
+};
+
+pub const SEEK = struct {
+    pub const SET = SerenityConstants.SEEK_SET;
+    pub const CUR = SerenityConstants.SEEK_CUR;
+    pub const END = SerenityConstants.SEEK_END;
+};
+
+pub const F = struct {
+    pub const DUPFD = SerenityConstants.F_DUPFD;
+    pub const GETFD = SerenityConstants.F_GETFD;
+    pub const SETFD = SerenityConstants.F_SETFD;
+    pub const GETFL = SerenityConstants.F_GETFL;
+    pub const SETFL = SerenityConstants.F_SETFL;
+    pub const ISTTY = SerenityConstants.F_ISTTY;
+    pub const GETLK = SerenityConstants.F_GETLK;
+    pub const SETLK = SerenityConstants.F_SETLK;
+    pub const SETLKW = SerenityConstants.F_SETLKW;
+};
+
+// FIXME: This value isn't defined on SerenityOS, so here's a random bogus value.
+pub const IOV_MAX = 8;
+
+pub const W = struct {
+    pub const NOHANG = SerenityConstants.WNOHANG;
+    pub const UNTRACED = SerenityConstants.WUNTRACED;
+    pub const STOPPED = SerenityConstants.WSTOPPED;
+    pub const EXITED = SerenityConstants.WEXITED;
+    pub const CONTINUED = SerenityConstants.WCONTINUED;
+    pub const NOWAIT = SerenityConstants.WNOWAIT;
+
+    pub fn EXITSTATUS(s: u32) u8 {
+        return @intCast(u8, (s & 0xff00) >> 8);
+    }
+
+    pub fn TERMSIG(s: u32) u32 {
+        return s & 0x7f;
+    }
+
+    pub fn STOPSIG(s: u32) u32 {
+        return EXITSTATUS(s);
+    }
+
+    pub fn IFEXITED(s: u32) bool {
+        return TERMSIG(s) == 0;
+    }
+
+    pub fn IFSTOPPED(s: u32) bool {
+        return s & 0xff == 0x7f;
+    }
+
+    pub fn IFSIGNALED(s: u32) bool {
+        return (@intCast(u8, ((s & 0x7f) + 1)) >> 1) > 0;
+    }
+};
+
+pub const FD_CLOEXEC = SerenityConstants.FD_CLOEXEC;
+
+pub const CLOCK = struct {
+    pub const REALTIME = SerenityConstants.CLOCK_REALTIME;
+    pub const MONOTONIC = SerenityConstants.CLOCK_MONOTONIC;
+    pub const MONOTONIC_RAW = SerenityConstants.CLOCK_MONOTONIC_RAW;
+    pub const REALTIME_COARSE = SerenityConstants.CLOCK_REALTIME_COARSE;
+    pub const MONOTONIC_COARSE = SerenityConstants.CLOCK_MONOTONIC_COARSE;
+};
+
+pub const dirent = extern struct {
+    d_ino: ino_t,
+    d_off: off_t,
+    d_reclen: c_ushort,
+    d_type: u8,
+    d_name: [256]u8,
+};
+pub const DIR = opaque {};
+
+pub extern "c" fn fdopendir(fd: fd_t) *DIR;
+pub extern "c" fn readdir_r(dir: *DIR, entry: *dirent, result: *?*dirent) i32;
+
+pub extern "c" fn sysconf(sc: c_int) i64;
+pub const _SC = struct {
+    pub const NPROCESSORS_ONLN = SerenityConstants._SC_NPROCESSORS_ONLN;
+};
+
+pub const dl_phdr_info = extern struct {
+    dlpi_addr: std.elf.Addr,
+    dlpi_name: ?[*:0]const u8,
+    dlpi_phdr: [*]std.elf.Phdr,
+    dlpi_phnum: std.elf.Half,
+};
+pub const dl_iterate_phdr_callback = fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int;
+pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
+
+pub const PROT = struct {
+    pub const READ = SerenityConstants.PROT_READ;
+    pub const WRITE = SerenityConstants.PROT_WRITE;
+    pub const EXEC = SerenityConstants.PROT_EXEC;
+    pub const NONE = SerenityConstants.PROT_NONE;
+};
+
+pub const MAP = struct {
+    pub const FILE = SerenityConstants.MAP_FILE;
+    pub const SHARED = SerenityConstants.MAP_SHARED;
+    pub const PRIVATE = SerenityConstants.MAP_PRIVATE;
+    pub const FIXED = SerenityConstants.MAP_FIXED;
+    pub const ANONYMOUS = SerenityConstants.MAP_ANONYMOUS;
+    pub const ANON = SerenityConstants.MAP_ANON;
+    pub const STACK = SerenityConstants.MAP_STACK;
+    pub const NORESERVE = SerenityConstants.MAP_NORESERVE;
+    pub const RANDOMIZED = SerenityConstants.MAP_RANDOMIZED;
+    pub const PURGEABLE = SerenityConstants.MAP_PURGEABLE;
+    pub const FIXED_NOREPLACE = SerenityConstants.MAP_FIXED_NOREPLACE;
+    pub const FAILED = SerenityConstants.MAP_FAILED;
+};

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -715,6 +715,7 @@ pub fn openSelfDebugInfo(allocator: mem.Allocator) anyerror!DebugInfo {
             .macos,
             .windows,
             .solaris,
+            .serenity,
             => return DebugInfo.init(allocator),
             else => return error.UnsupportedDebugInfo,
         }
@@ -1561,7 +1562,7 @@ pub const ModuleDebugInfo = switch (native_os) {
             };
         }
     },
-    .linux, .netbsd, .freebsd, .dragonfly, .openbsd, .haiku, .solaris => struct {
+    .linux, .netbsd, .freebsd, .dragonfly, .openbsd, .haiku, .solaris, .serenity => struct {
         base_address: usize,
         dwarf: DW.DwarfInfo,
         mapped_memory: []const u8,

--- a/lib/std/fs/get_app_data_dir.zig
+++ b/lib/std/fs/get_app_data_dir.zig
@@ -44,7 +44,7 @@ pub fn getAppDataDir(allocator: mem.Allocator, appname: []const u8) GetAppDataDi
             };
             return fs.path.join(allocator, &[_][]const u8{ home_dir, "Library", "Application Support", appname });
         },
-        .linux, .freebsd, .netbsd, .dragonfly, .openbsd, .solaris => {
+        .linux, .freebsd, .netbsd, .dragonfly, .openbsd, .solaris, .serenity => {
             if (os.getenv("XDG_DATA_HOME")) |xdg| {
                 return fs.path.join(allocator, &[_][]const u8{ xdg, appname });
             }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -56,7 +56,7 @@ test {
 /// When not linking libc, it is the OS-specific system interface.
 pub const system = if (@hasDecl(root, "os") and root.os != @This())
     root.os.system
-else if (builtin.link_libc or is_windows)
+else if (builtin.link_libc or is_windows or builtin.os.tag == .serenity)
     std.c
 else switch (builtin.os.tag) {
     .linux => linux,
@@ -4272,6 +4272,9 @@ pub fn sysctlbynameZ(
         @panic("unsupported"); // TODO should be compile error, not panic
     }
     if (builtin.os.tag == .haiku) {
+        @panic("unsupported"); // TODO should be compile error, not panic
+    }
+    if (builtin.os.tag == .serenity) {
         @panic("unsupported"); // TODO should be compile error, not panic
     }
 

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -885,6 +885,7 @@ pub fn getSelfExeSharedLibPaths(allocator: Allocator) error{OutOfMemory}![][:0]u
         .dragonfly,
         .openbsd,
         .solaris,
+        .serenity,
         => {
             var paths = List.init(allocator);
             errdefer {

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -55,6 +55,7 @@ pub const Target = struct {
             glsl450,
             vulkan,
             plan9,
+            serenity,
             other,
 
             pub fn isDarwin(tag: Tag) bool {
@@ -257,6 +258,7 @@ pub const Target = struct {
                     .glsl450, // TODO: GLSL versions
                     .vulkan,
                     .plan9,
+                    .serenity,
                     .other,
                     => return .{ .none = {} },
 
@@ -401,6 +403,7 @@ pub const Target = struct {
                 .openbsd,
                 .haiku,
                 .solaris,
+                .serenity,
                 => true,
 
                 .linux,
@@ -531,6 +534,7 @@ pub const Target = struct {
                 .glsl450,
                 .vulkan,
                 .plan9, // TODO specify abi
+                .serenity,
                 => return .none,
             }
         }
@@ -1663,6 +1667,8 @@ pub const Target = struct {
 
             // TODO revisit when multi-arch for Haiku is available
             .haiku => return copy(&result, "/system/runtime_loader"),
+
+            .serenity => return copy(&result, "/usr/lib/Loader.so"),
 
             // TODO go over each item in this list and either move it to the above list, or
             // implement the standard dynamic linker path code for it.

--- a/lib/std/zig/CrossTarget.zig
+++ b/lib/std/zig/CrossTarget.zig
@@ -131,6 +131,7 @@ fn updateOsVersionRange(self: *CrossTarget, os: Target.Os) void {
         .glsl450,
         .vulkan,
         .plan9,
+        .serenity,
         .other,
         => {
             self.os_version_min = .{ .none = {} };
@@ -676,6 +677,7 @@ fn parseOs(result: *CrossTarget, diags: *ParseOptions.Diagnostics, text: []const
         .glsl450,
         .vulkan,
         .plan9,
+        .serenity,
         .other,
         => return error.InvalidOperatingSystemVersion,
 

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -122,6 +122,7 @@ pub fn targetTriple(allocator: Allocator, target: std.Target) ![:0]u8 {
         .wasi => "wasi",
         .emscripten => "emscripten",
         .uefi => "windows",
+        .serenity => "serenity",
 
         .opencl,
         .glsl450,

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -1130,6 +1130,7 @@ pub const OSType = enum(c_int) {
     Hurd,
     WASI,
     Emscripten,
+    Serenity,
 };
 
 pub const ArchType = enum(c_int) {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -4104,6 +4104,15 @@ const CsuObjects = struct {
                         if (result.crt0 != null and link_options.target.isGnuLibC()) result.crt0 = "Scrt1.o";
                     }
                 },
+                .serenity => switch (mode) {
+                    // zig fmt: off
+                    .dynamic_lib => result.set( "crt0_shared.o", "crti.o", null, null, "crtn.o" ),
+                    .dynamic_exe => result.set( "crt0.o",        "crti.o", null, null, "crtn.o" ),
+                    .dynamic_pie => result.set( "crt0.o",        "crti.o", null, null, "crtn.o" ),
+                    .static_exe  => result.set( "crt0.o",        "crti.o", null, null, "crtn.o" ),
+                    .static_pie  => result.set( "crt0.o",        "crti.o", null, null, "crtn.o" ),
+                    // zig fmt: on
+                },
                 .dragonfly => switch (mode) {
                     // zig fmt: off
                     .dynamic_lib => result.set( null,      "crti.o", "crtbeginS.o",  "crtendS.o", "crtn.o" ),

--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -8338,6 +8338,11 @@ static X64CABIClass type_system_V_abi_x86_64_class(CodeGen *g, ZigType *ty, size
         case ZigTypeIdVector:
             return X64CABIClass_SSE;
         case ZigTypeIdStruct: {
+            // HACK: i386 System V ABI requires all structs to be returned
+            //       through memory.
+            if (g->zig_target->arch == ZigLLVM_x86)
+                return X64CABIClass_MEMORY;
+
             // "If the size of an object is larger than four eightbytes, or it contains unaligned
             // fields, it has class MEMORY"
             if (ty_size > 32)

--- a/src/stage1/analyze.cpp
+++ b/src/stage1/analyze.cpp
@@ -8677,12 +8677,19 @@ static LLVMTypeRef llvm_int_for_size(size_t size) {
 }
 
 static LLVMTypeRef llvm_sse_for_size(size_t size) {
-    if (size > 4)
-        return LLVMDoubleType();
-    else 
-        return LLVMFloatType();
+    switch (size) {
+        case 4: // f32
+            return LLVMFloatType();
+        case 8: // f64
+            return LLVMDoubleType();
+        case 10: // f80
+            return LLVMX86FP80Type();
+        case 16: // f128
+            return LLVMFP128Type();
+        default:
+            zig_unreachable();
+    };
 }
-
 // Since it's not possible to control calling convention or register
 // allocation in LLVM, clang seems to use intermediate types to manipulate
 // LLVM into doing the right thing. It uses a float to force SSE registers,

--- a/src/stage1/stage1.h
+++ b/src/stage1/stage1.h
@@ -98,6 +98,7 @@ enum Os {
     OsGLSL450,
     OsVulkan,
     OsPlan9,
+    OsSerenity,
     OsOther,
 };
 

--- a/src/stage1/target.cpp
+++ b/src/stage1/target.cpp
@@ -127,6 +127,7 @@ static const Os os_list[] = {
     OsGLSL450,
     OsVulkan,
     OsPlan9,
+    OsSerenity,
     OsOther,
 };
 
@@ -218,6 +219,10 @@ Os target_os_enum(size_t index) {
 
 ZigLLVM_OSType get_llvm_os_type(Os os_type) {
     switch (os_type) {
+        case OsSerenity:
+#ifdef ZIG_SERENITY_BUILD
+            return ZigLLVM_Serenity;
+#endif
         case OsFreestanding:
         case OsOpenCL:
         case OsGLSL450:
@@ -345,6 +350,7 @@ const char *target_os_name(Os os_type) {
         case OsOpenCL:
         case OsGLSL450:
         case OsVulkan:
+        case OsSerenity:
             return ZigLLVMGetOSTypeName(get_llvm_os_type(os_type));
     }
     zig_unreachable();
@@ -682,6 +688,7 @@ uint32_t target_c_type_size_in_bits(const ZigTarget *target, CIntType id) {
         case OsPlan9:
         case OsCUDA:
         case OsNVCL:
+        case OsSerenity:
             switch (id) {
                 case CIntTypeShort:
                 case CIntTypeUShort:
@@ -994,6 +1001,7 @@ ZigLLVM_EnvironmentType target_default_abi(ZigLLVM_ArchType arch, Os os) {
         case OsGLSL450:
         case OsVulkan:
         case OsPlan9:
+        case OsSerenity:
             return ZigLLVM_UnknownEnvironment;
     }
     zig_unreachable();

--- a/src/stage1/zig0.cpp
+++ b/src/stage1/zig0.cpp
@@ -133,6 +133,10 @@ static Os get_zig_os_type(ZigLLVM_OSType os_type) {
             return OsWASI;
         case ZigLLVM_Emscripten:
             return OsEmscripten;
+#ifdef ZIG_SERENITY_BUILD
+        case ZigLLVM_Serenity:
+            return OsSerenity;
+#endif
     }
     zig_unreachable();
 }

--- a/src/target.zig
+++ b/src/target.zig
@@ -168,7 +168,7 @@ pub fn libcNeedsLibUnwind(target: std.Target) bool {
 }
 
 pub fn requiresPIE(target: std.Target) bool {
-    return target.isAndroid() or target.isDarwin() or target.os.tag == .openbsd;
+    return target.isAndroid() or target.isDarwin() or target.os.tag == .openbsd or target.os.tag == .serenity;
 }
 
 /// This function returns whether non-pic code is completely invalid on the given target.
@@ -310,6 +310,7 @@ pub fn osToLLVM(os_tag: std.Target.Os.Tag) llvm.OSType {
         .hurd => .Hurd,
         .wasi => .WASI,
         .emscripten => .Emscripten,
+        .serenity => .Serenity,
     };
 }
 
@@ -487,6 +488,12 @@ pub fn libcFullLinkFlags(target: std.Target) []const []const u8 {
             "-lroot",
             "-lpthread",
             "-lc",
+        },
+        .serenity => &[_][]const u8{
+            "-lc",
+            "-lm",
+            "-ldl",
+            "-lpthread",
         },
         else => switch (target.abi) {
             .android => &[_][]const u8{

--- a/src/type.zig
+++ b/src/type.zig
@@ -5008,6 +5008,7 @@ pub const CType = enum {
             .emscripten,
             .plan9,
             .solaris,
+            .serenity,
             => switch (self) {
                 .short,
                 .ushort,

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -1435,6 +1435,9 @@ static_assert((Triple::OSType)ZigLLVM_HermitCore == Triple::HermitCore, "");
 static_assert((Triple::OSType)ZigLLVM_Hurd == Triple::Hurd, "");
 static_assert((Triple::OSType)ZigLLVM_WASI == Triple::WASI, "");
 static_assert((Triple::OSType)ZigLLVM_Emscripten == Triple::Emscripten, "");
+#ifdef ZIG_SERENITY_BUILD
+static_assert((Triple::OSType)ZigLLVM_Serenity == Triple::Serenity, "");
+#endif
 static_assert((Triple::OSType)ZigLLVM_LastOSType == Triple::LastOSType, "");
 
 static_assert((Triple::EnvironmentType)ZigLLVM_UnknownEnvironment == Triple::UnknownEnvironment, "");

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -416,8 +416,13 @@ enum ZigLLVM_OSType {
     ZigLLVM_Hurd,       // GNU/Hurd
     ZigLLVM_WASI,       // Experimental WebAssembly OS
     ZigLLVM_Emscripten,
+#ifdef ZIG_SERENITY_BUILD
+    ZigLLVM_Serenity,   // Well hello friends! :^)
 
-    ZigLLVM_LastOSType = ZigLLVM_Emscripten
+    ZigLLVM_LastOSType = ZigLLVM_Serenity,
+#else
+    ZigLLVM_LastOSType = ZigLLVM_Emscripten,
+#endif
 };
 
 // Synchronize with target.cpp::abi_list


### PR DESCRIPTION
Well hello friends! This is a Zig target for SerenityOS which allows you to build C, C++ and Zig binaries for SerenityOS. To build a binary for the Serenity target, you will need a program (WIP) which can generate the current constants from the SerenityOS repository. This process will be done automatically when using the package script when building the zig port on the Serenity repository.

This PR also contains a few auxiliary fixes which fix some compiler bugs and fix a segfault on i386 targets.