### PR TITLE
stage2: add type checking for @bitCast

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -3251,8 +3251,20 @@ pub const Type = extern union {
                 const int_tag_ty = ty.intTagType(&buffer);
                 return int_tag_ty.bitSize(target);
             },
+
             .@"union", .union_tagged => {
-                @panic("TODO bitSize unions");
+                const union_obj = ty.cast(Payload.Union).?.data;
+
+                const fields = union_obj.fields;
+                if (fields.count() == 0) return 0;
+
+                assert(union_obj.haveFieldTypes());
+
+                var size: u64 = 0;
+                for (fields.values()) |field| {
+                    size = @maximum(size, field.ty.bitSize(target));
+                }
+                return size;
             },
 
             .vector => {


### PR DESCRIPTION
I wasn't too sure about how to split up the check between `sema.zirBitcast` and `sema.bitCast`, so it's very possible that things need to move around a bit.

I added more detailed error messages for a couple of cases cause I think it will be very common for people to mix up `@bitCast` and `@ptrCast`. As far as I know the compiler error tests are not implemented yet for stage2 so sadly there's no tests in this PR. I'll happily add them once these tests are enabled for stage2.

One improvement I would like to make but couldn't figure out is to elide the entire call to `@bitCast` if the thing you're bitcasting already has the correct type. So in other words,

```zig
if (operand_ty == dest_ty) {
  // What do I return here???
}
```

If anyone has any hints of what to do there please let me know!