### PR TITLE
make some errors point to the end of the previous token

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -70,6 +70,13 @@ pub fn errorOffset(tree:Ast, error_tag: Error.Tag, token: TokenIndex) u32 {
     return switch (error_tag) {
         .expected_semi_after_decl,
         .expected_semi_after_stmt,
+        .expected_comma_after_field,
+        .expected_comma_after_arg,
+        .expected_comma_after_param,
+        .expected_comma_after_initializer,
+        .expected_comma_after_switch_prong,
+        .expected_semi_or_else,
+        .expected_semi_or_lbrace,
         => @intCast(u32, tree.tokenSlice(token).len),
         else => 0,
     };
@@ -227,14 +234,10 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
             });
         },
         .expected_semi_or_else => {
-            return stream.print("expected ';' or 'else', found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
-            });
+            return stream.writeAll("expected ';' or 'else' after statement");
         },
         .expected_semi_or_lbrace => {
-            return stream.print("expected ';' or '{{', found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
-            });
+            return stream.writeAll("expected ';' or block after function prototype");
         },
         .expected_statement => {
             return stream.print("expected statement, found '{s}'", .{
@@ -322,6 +325,21 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
         },
         .expected_semi_after_stmt => {
             return stream.writeAll("expected ';' after statement");
+        },
+        .expected_comma_after_field => {
+            return stream.writeAll("expected ',' after field");
+        },
+        .expected_comma_after_arg => {
+            return stream.writeAll("expected ',' after argument");
+        },
+        .expected_comma_after_param => {
+            return stream.writeAll("expected ',' after parameter");
+        },
+        .expected_comma_after_initializer => {
+            return stream.writeAll("expected ',' after initializer");
+        },
+        .expected_comma_after_switch_prong => {
+            return stream.writeAll("expected ',' after switch prong");
         },
 
         .expected_token => {
@@ -2516,6 +2534,11 @@ pub const Error = struct {
         // these have `token` set to token after which a semicolon was expected
         expected_semi_after_decl,
         expected_semi_after_stmt,
+        expected_comma_after_field,
+        expected_comma_after_arg,
+        expected_comma_after_param,
+        expected_comma_after_initializer,
+        expected_comma_after_switch_prong,
 
         /// `expected_tag` is populated.
         expected_token,

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -66,7 +66,7 @@ pub fn renderToArrayList(tree: Ast, buffer: *std.ArrayList(u8)) RenderError!void
 
 /// Returns an extra offset for column and byte offset of errors that
 /// should point after the token in the error message.
-pub fn errorOffset(tree:Ast, error_tag: Error.Tag, token: TokenIndex) u32 {
+pub fn errorOffset(tree: Ast, error_tag: Error.Tag, token: TokenIndex) u32 {
     return switch (error_tag) {
         .expected_semi_after_decl,
         .expected_semi_after_stmt,

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -3229,6 +3229,10 @@ const Parser = struct {
                         .rhs = p.nextToken(),
                     },
                 }),
+                .l_brace => {
+                    // this a misplaced `.{`, handle the error somewhere else
+                    return null_node;
+                },
                 else => {
                     p.tok_i += 1;
                     try p.warn(.expected_suffix_op);

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2995,13 +2995,14 @@ pub fn astGenFile(mod: *Module, file: *File) !void {
         const token_starts = file.tree.tokens.items(.start);
         const token_tags = file.tree.tokens.items(.tag);
 
+        const extra_offset = file.tree.errorOffset(parse_err.tag, parse_err.token);
         try file.tree.renderError(parse_err, msg.writer());
         const err_msg = try gpa.create(ErrorMsg);
         err_msg.* = .{
             .src_loc = .{
                 .file_scope = file,
                 .parent_decl_node = 0,
-                .lazy = .{ .byte_abs = token_starts[parse_err.token] },
+                .lazy = .{ .byte_abs = token_starts[parse_err.token] + extra_offset },
             },
             .msg = msg.toOwnedSlice(),
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -4040,13 +4040,14 @@ fn printErrMsgToStdErr(
         notes_len += 1;
     }
 
+    const extra_offset = tree.errorOffset(parse_error.tag, parse_error.token);
     const message: Compilation.AllErrors.Message = .{
         .src = .{
             .src_path = path,
             .msg = text,
-            .byte_offset = @intCast(u32, start_loc.line_start),
+            .byte_offset = @intCast(u32, start_loc.line_start) + extra_offset,
             .line = @intCast(u32, start_loc.line),
-            .column = @intCast(u32, start_loc.column),
+            .column = @intCast(u32, start_loc.column) + extra_offset,
             .source_line = source_line,
             .notes = notes_buffer[0..notes_len],
         },

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -2171,7 +2171,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = x;
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:7: error: expected ',', found 'align'",
+        "tmp.zig:3:6: error: expected ',' after field",
     });
 
     ctx.objErrStage1("bad alignment type",
@@ -4704,7 +4704,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:9: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - block expr",
@@ -4715,7 +4715,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:11: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - comptime statement",
@@ -4726,7 +4726,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:18: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - comptime expression",
@@ -4737,7 +4737,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:20: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - defer",
@@ -4748,7 +4748,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:15: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - if statement",
@@ -4759,7 +4759,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';' or 'else', found 'var'",
+        "tmp.zig:4:18: error: expected ';' or 'else' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - if expression",
@@ -4770,7 +4770,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:20: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - if-else statement",
@@ -4781,7 +4781,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:28: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - if-else expression",
@@ -4792,7 +4792,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:28: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - if-else-if statement",
@@ -4803,7 +4803,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';' or 'else', found 'var'",
+        "tmp.zig:4:37: error: expected ';' or 'else' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - if-else-if expression",
@@ -4814,7 +4814,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:37: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - if-else-if-else statement",
@@ -4825,7 +4825,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:47: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - if-else-if-else expression",
@@ -4836,7 +4836,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:45: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - test statement",
@@ -4847,7 +4847,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';' or 'else', found 'var'",
+        "tmp.zig:4:24: error: expected ';' or 'else' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - test expression",
@@ -4858,7 +4858,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:26: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - while statement",
@@ -4869,7 +4869,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';' or 'else', found 'var'",
+        "tmp.zig:4:21: error: expected ';' or 'else' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - while expression",
@@ -4880,7 +4880,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:23: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - while-continue statement",
@@ -4891,7 +4891,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';' or 'else', found 'var'",
+        "tmp.zig:4:26: error: expected ';' or 'else' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - while-continue expression",
@@ -4902,7 +4902,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:28: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - for statement",
@@ -4913,7 +4913,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';' or 'else', found 'var'",
+        "tmp.zig:4:24: error: expected ';' or 'else' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - for expression",
@@ -4924,7 +4924,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:5: error: expected ';', found 'var'",
+        "tmp.zig:4:26: error: expected ';' after statement",
     });
 
     ctx.objErrStage1("multiple function definitions",

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -693,7 +693,7 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    _ = E1.a;
             \\}
         , &.{
-            ":3:7: error: expected ',', found 'align'",
+            ":3:6: error: expected ',' after field",
         });
 
         // Redundant non-exhaustive enum mark.


### PR DESCRIPTION
```zig
// a.zig
pub fn main() void {
    var a
}
// before
// a.zig:3:1: error: expected ';', found '}'
// }
// ^
// after
// a.zig:2:10: error: expected ';' after declaration
//     var a
//          ^
```
This should probably be applied to all expected_* errors but these seem like the biggest offenders.