### PR TITLE
stage2 llvm: Implement `@bitReverse`, `@byteSwap` built-ins

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -236,6 +236,12 @@ pub const Inst = struct {
         /// Result type will always be an unsigned integer big enough to fit the answer.
         /// Uses the `ty_op` field.
         popcount,
+        /// Reverse the bytes in an integer according to its representation in twos complement.
+        /// Uses the `ty_op` field.
+        byte_swap,
+        /// Reverse the bits in an integer according to its representation in twos complement.
+        /// Uses the `ty_op` field.
+        bit_reverse,
 
         /// Square root of a floating point number.
         /// Uses the `un_op` field.
@@ -874,6 +880,8 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .clz,
         .ctz,
         .popcount,
+        .byte_swap,
+        .bit_reverse,
         => return air.getRefType(datas[inst].ty_op.ty),
 
         .loop,

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -318,6 +318,8 @@ fn analyzeInst(
         .clz,
         .ctz,
         .popcount,
+        .byte_swap,
+        .bit_reverse,
         .splat,
         => {
             const o = inst_datas[inst].ty_op;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -11701,14 +11701,60 @@ fn zirBitCount(
 
 fn zirByteSwap(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].un_node;
-    const src = inst_data.src();
-    return sema.fail(block, src, "TODO: Sema.zirByteSwap", .{});
+    const ty_src: LazySrcLoc = .{ .node_offset_builtin_call_arg0 = inst_data.src_node };
+    const operand_src: LazySrcLoc = .{ .node_offset_builtin_call_arg1 = inst_data.src_node };
+    const operand = sema.resolveInst(inst_data.operand);
+    const operand_ty = sema.typeOf(operand);
+    // TODO implement support for vectors
+    if (operand_ty.zigTypeTag() != .Int) {
+        return sema.fail(block, ty_src, "expected integer type, found '{}'", .{
+            operand_ty,
+        });
+    }
+    const target = sema.mod.getTarget();
+    const bits = operand_ty.intInfo(target).bits;
+    if (bits == 0) return Air.Inst.Ref.zero;
+    if (operand_ty.intInfo(target).bits % 8 != 0) {
+        return sema.fail(block, ty_src, "@byteSwap requires the number of bits to be evenly divisible by 8, but {} has {} bits", .{
+            operand_ty,
+            operand_ty.intInfo(target).bits,
+        });
+    }
+
+    const runtime_src = if (try sema.resolveMaybeUndefVal(block, operand_src, operand)) |val| {
+        if (val.isUndef()) return sema.addConstUndef(operand_ty);
+        const result_val = try val.byteSwap(operand_ty, target, sema.arena);
+        return sema.addConstant(operand_ty, result_val);
+    } else operand_src;
+
+    try sema.requireRuntimeBlock(block, runtime_src);
+    return block.addTyOp(.byte_swap, operand_ty, operand);
 }
 
 fn zirBitReverse(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].un_node;
-    const src = inst_data.src();
-    return sema.fail(block, src, "TODO: Sema.zirBitReverse", .{});
+    const ty_src: LazySrcLoc = .{ .node_offset_builtin_call_arg0 = inst_data.src_node };
+    const operand_src: LazySrcLoc = .{ .node_offset_builtin_call_arg1 = inst_data.src_node };
+    const operand = sema.resolveInst(inst_data.operand);
+    const operand_ty = sema.typeOf(operand);
+    // TODO implement support for vectors
+    if (operand_ty.zigTypeTag() != .Int) {
+        return sema.fail(block, ty_src, "expected integer type, found '{}'", .{
+            operand_ty,
+        });
+    }
+    const target = sema.mod.getTarget();
+    const bits = operand_ty.intInfo(target).bits;
+    if (bits == 0) return Air.Inst.Ref.zero;
+
+    const runtime_src = if (try sema.resolveMaybeUndefVal(block, operand_src, operand)) |val| {
+        if (val.isUndef()) return sema.addConstUndef(operand_ty);
+        const result_val = try val.bitReverse(operand_ty, target, sema.arena);
+        return sema.addConstant(operand_ty, result_val);
+    } else operand_src;
+
+    try sema.requireRuntimeBlock(block, runtime_src);
+    return block.addTyOp(.bit_reverse, operand_ty, operand);
 }
 
 fn zirBitOffsetOf(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -621,6 +621,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .clz             => try self.airClz(inst),
             .ctz             => try self.airCtz(inst),
             .popcount        => try self.airPopcount(inst),
+            .byte_swap       => try self.airByteSwap(inst),
+            .bit_reverse     => try self.airBitReverse(inst),
             .tag_name        => try self.airTagName(inst),
             .error_name      => try self.airErrorName(inst),
             .splat           => try self.airSplat(inst),
@@ -1679,6 +1681,18 @@ fn airCtz(self: *Self, inst: Air.Inst.Index) !void {
 fn airPopcount(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement airPopcount for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airByteSwap(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement airByteSwap for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airBitReverse(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement airBitReverse for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -605,6 +605,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .clz             => try self.airClz(inst),
             .ctz             => try self.airCtz(inst),
             .popcount        => try self.airPopcount(inst),
+            .byte_swap       => try self.airByteSwap(inst),
+            .bit_reverse     => try self.airBitReverse(inst),
             .tag_name        => try self.airTagName(inst),
             .error_name      => try self.airErrorName(inst),
             .splat           => try self.airSplat(inst),
@@ -1389,6 +1391,20 @@ fn airPopcount(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     _ = ty_op;
     return self.fail("TODO implement airPopcount for {}", .{self.target.cpu.arch});
+    // return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airByteSwap(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    _ = ty_op;
+    return self.fail("TODO implement airByteSwap for {}", .{self.target.cpu.arch});
+    // return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airBitReverse(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    _ = ty_op;
+    return self.fail("TODO implement airBitReverse for {}", .{self.target.cpu.arch});
     // return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -592,6 +592,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .clz             => try self.airClz(inst),
             .ctz             => try self.airCtz(inst),
             .popcount        => try self.airPopcount(inst),
+            .byte_swap       => try self.airByteSwap(inst),
+            .bit_reverse     => try self.airBitReverse(inst),
             .tag_name        => try self.airTagName(inst),
             .error_name      => try self.airErrorName(inst),
             .splat           => try self.airSplat(inst),
@@ -1178,6 +1180,18 @@ fn airCtz(self: *Self, inst: Air.Inst.Index) !void {
 fn airPopcount(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement airPopcount for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airByteSwap(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement airByteSwap for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airBitReverse(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement airBitReverse for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1687,6 +1687,8 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .clz,
         .ctz,
         .popcount,
+        .byte_swap,
+        .bit_reverse,
         .is_err_ptr,
         .is_non_err_ptr,
         .fptrunc,

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -686,6 +686,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .clz             => try self.airClz(inst),
             .ctz             => try self.airCtz(inst),
             .popcount        => try self.airPopcount(inst),
+            .byte_swap       => try self.airByteSwap(inst),
+            .bit_reverse     => try self.airBitReverse(inst),
             .tag_name        => try self.airTagName(inst),
             .error_name      => try self.airErrorName(inst),
             .splat           => try self.airSplat(inst),
@@ -1713,6 +1715,24 @@ fn airPopcount(self: *Self, inst: Air.Inst.Index) !void {
         .dead
     else
         return self.fail("TODO implement airPopcount for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airByteSwap(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement airByteSwap for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airBitReverse(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement airBitReverse for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1709,6 +1709,8 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .clz              => try airBuiltinCall(f, inst, "clz"),
             .ctz              => try airBuiltinCall(f, inst, "ctz"),
             .popcount         => try airBuiltinCall(f, inst, "popcount"),
+            .byte_swap        => try airBuiltinCall(f, inst, "byte_swap"),
+            .bit_reverse      => try airBuiltinCall(f, inst, "bit_reverse"),
             .tag_name         => try airTagName(f, inst),
             .error_name       => try airErrorName(f, inst),
             .splat            => try airSplat(f, inst),

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4390,7 +4390,7 @@ pub const FuncGen = struct {
         var operand_llvm_ty = try self.dg.llvmType(operand_ty);
 
         if (bits % 16 == 8) {
-            // If not an even byte-multiple, we need zero-extend + shift-left 1 byte 
+            // If not an even byte-multiple, we need zero-extend + shift-left 1 byte
             // The truncated result at the end will be the correct bswap
             operand_llvm_ty = self.context.intType(bits + 8);
             const extended = self.builder.buildZExt(operand, operand_llvm_ty, "");

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -216,6 +216,8 @@ const Writer = struct {
             .clz,
             .ctz,
             .popcount,
+            .byte_swap,
+            .bit_reverse,
             => try w.writeTyOp(s, inst),
 
             .block,

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -105,6 +105,8 @@ test {
             if (builtin.zig_backend != .stage2_c) {
                 // Tests that pass for stage1 and the llvm backend.
                 _ = @import("behavior/atomics.zig");
+                _ = @import("behavior/bitreverse.zig");
+                _ = @import("behavior/byteswap.zig");
                 _ = @import("behavior/bugs/9584.zig");
                 _ = @import("behavior/eval.zig");
                 _ = @import("behavior/floatop.zig");
@@ -124,7 +126,6 @@ test {
                         _ = @import("behavior/async_fn.zig");
                     }
                     _ = @import("behavior/await_struct.zig");
-                    _ = @import("behavior/bitreverse.zig");
                     _ = @import("behavior/bugs/421.zig");
                     _ = @import("behavior/bugs/529.zig");
                     _ = @import("behavior/bugs/718.zig");
@@ -151,7 +152,6 @@ test {
                     _ = @import("behavior/bugs/7027.zig");
                     _ = @import("behavior/bugs/7047.zig");
                     _ = @import("behavior/bugs/10147.zig");
-                    _ = @import("behavior/byteswap.zig");
                     _ = @import("behavior/const_slice_child.zig");
                     _ = @import("behavior/export_self_referential_type_info.zig");
                     _ = @import("behavior/field_parent_ptr.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -6,6 +6,8 @@ test {
     _ = @import("behavior/array.zig");
     _ = @import("behavior/basic.zig");
     _ = @import("behavior/bit_shifting.zig");
+    _ = @import("behavior/bitreverse.zig");
+    _ = @import("behavior/byteswap.zig");
     _ = @import("behavior/bool.zig");
     _ = @import("behavior/bugs/394.zig");
     _ = @import("behavior/bugs/655.zig");
@@ -105,8 +107,6 @@ test {
             if (builtin.zig_backend != .stage2_c) {
                 // Tests that pass for stage1 and the llvm backend.
                 _ = @import("behavior/atomics.zig");
-                _ = @import("behavior/bitreverse.zig");
-                _ = @import("behavior/byteswap.zig");
                 _ = @import("behavior/bugs/9584.zig");
                 _ = @import("behavior/eval.zig");
                 _ = @import("behavior/floatop.zig");

--- a/test/behavior/bitreverse.zig
+++ b/test/behavior/bitreverse.zig
@@ -24,9 +24,13 @@ fn testBitReverse() !void {
     try expect(@bitReverse(u48, @as(u48, 0x123456789abc)) == 0x3d591e6a2c48);
     try expect(@bitReverse(u56, @as(u56, 0x123456789abcde)) == 0x7b3d591e6a2c48);
     try expect(@bitReverse(u64, @as(u64, 0x123456789abcdef1)) == 0x8f7b3d591e6a2c48);
-    try expect(@bitReverse(u95, @as(u95, 0x123456789abcdef111213141)) == 0x4146424447bd9eac8f351624);
     try expect(@bitReverse(u96, @as(u96, 0x123456789abcdef111213141)) == 0x828c84888f7b3d591e6a2c48);
     try expect(@bitReverse(u128, @as(u128, 0x123456789abcdef11121314151617181)) == 0x818e868a828c84888f7b3d591e6a2c48);
+
+    if (builtin.zig_backend != .stage1) {
+        // Currently failing on stage1 for big-endian targets
+        try expect(@bitReverse(u95, @as(u95, 0x123456789abcdef111213141)) == 0x4146424447bd9eac8f351624);
+    }
 
     // using runtime uints, unsigned
     var num0: u0 = 0;

--- a/test/behavior/bitreverse.zig
+++ b/test/behavior/bitreverse.zig
@@ -3,10 +3,24 @@ const builtin = @import("builtin");
 const expect = std.testing.expect;
 const minInt = std.math.minInt;
 
+test "@bitReverse large exotic integer" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    // Currently failing on stage1 for big-endian targets
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+
+    try expect(@bitReverse(u95, @as(u95, 0x123456789abcdef111213141)) == 0x4146424447bd9eac8f351624);
+}
+
 test "@bitReverse" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
 
     comptime try testBitReverse();
     try testBitReverse();
@@ -26,11 +40,6 @@ fn testBitReverse() !void {
     try expect(@bitReverse(u64, @as(u64, 0x123456789abcdef1)) == 0x8f7b3d591e6a2c48);
     try expect(@bitReverse(u96, @as(u96, 0x123456789abcdef111213141)) == 0x828c84888f7b3d591e6a2c48);
     try expect(@bitReverse(u128, @as(u128, 0x123456789abcdef11121314151617181)) == 0x818e868a828c84888f7b3d591e6a2c48);
-
-    if (builtin.zig_backend != .stage1) {
-        // Currently failing on stage1 for big-endian targets
-        try expect(@bitReverse(u95, @as(u95, 0x123456789abcdef111213141)) == 0x4146424447bd9eac8f351624);
-    }
 
     // using runtime uints, unsigned
     var num0: u0 = 0;

--- a/test/behavior/bitreverse.zig
+++ b/test/behavior/bitreverse.zig
@@ -1,25 +1,32 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const expect = std.testing.expect;
 const minInt = std.math.minInt;
 
 test "@bitReverse" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     comptime try testBitReverse();
     try testBitReverse();
 }
 
 fn testBitReverse() !void {
     // using comptime_ints, unsigned
-    try expect(@bitReverse(u0, 0) == 0);
-    try expect(@bitReverse(u5, 0x12) == 0x9);
-    try expect(@bitReverse(u8, 0x12) == 0x48);
-    try expect(@bitReverse(u16, 0x1234) == 0x2c48);
-    try expect(@bitReverse(u24, 0x123456) == 0x6a2c48);
-    try expect(@bitReverse(u32, 0x12345678) == 0x1e6a2c48);
-    try expect(@bitReverse(u40, 0x123456789a) == 0x591e6a2c48);
-    try expect(@bitReverse(u48, 0x123456789abc) == 0x3d591e6a2c48);
-    try expect(@bitReverse(u56, 0x123456789abcde) == 0x7b3d591e6a2c48);
-    try expect(@bitReverse(u64, 0x123456789abcdef1) == 0x8f7b3d591e6a2c48);
-    try expect(@bitReverse(u128, 0x123456789abcdef11121314151617181) == 0x818e868a828c84888f7b3d591e6a2c48);
+    try expect(@bitReverse(u0, @as(u0, 0)) == 0);
+    try expect(@bitReverse(u5, @as(u5, 0x12)) == 0x9);
+    try expect(@bitReverse(u8, @as(u8, 0x12)) == 0x48);
+    try expect(@bitReverse(u16, @as(u16, 0x1234)) == 0x2c48);
+    try expect(@bitReverse(u24, @as(u24, 0x123456)) == 0x6a2c48);
+    try expect(@bitReverse(u32, @as(u32, 0x12345678)) == 0x1e6a2c48);
+    try expect(@bitReverse(u40, @as(u40, 0x123456789a)) == 0x591e6a2c48);
+    try expect(@bitReverse(u48, @as(u48, 0x123456789abc)) == 0x3d591e6a2c48);
+    try expect(@bitReverse(u56, @as(u56, 0x123456789abcde)) == 0x7b3d591e6a2c48);
+    try expect(@bitReverse(u64, @as(u64, 0x123456789abcdef1)) == 0x8f7b3d591e6a2c48);
+    try expect(@bitReverse(u95, @as(u95, 0x123456789abcdef111213141)) == 0x4146424447bd9eac8f351624);
+    try expect(@bitReverse(u96, @as(u96, 0x123456789abcdef111213141)) == 0x828c84888f7b3d591e6a2c48);
+    try expect(@bitReverse(u128, @as(u128, 0x123456789abcdef11121314151617181)) == 0x818e868a828c84888f7b3d591e6a2c48);
 
     // using runtime uints, unsigned
     var num0: u0 = 0;
@@ -50,11 +57,16 @@ fn testBitReverse() !void {
     try expect(@bitReverse(i8, @bitCast(i8, @as(u8, 0x92))) == @bitCast(i8, @as(u8, 0x49)));
     try expect(@bitReverse(i16, @bitCast(i16, @as(u16, 0x1234))) == @bitCast(i16, @as(u16, 0x2c48)));
     try expect(@bitReverse(i24, @bitCast(i24, @as(u24, 0x123456))) == @bitCast(i24, @as(u24, 0x6a2c48)));
+    try expect(@bitReverse(i24, @bitCast(i24, @as(u24, 0x12345f))) == @bitCast(i24, @as(u24, 0xfa2c48)));
+    try expect(@bitReverse(i24, @bitCast(i24, @as(u24, 0xf23456))) == @bitCast(i24, @as(u24, 0x6a2c4f)));
     try expect(@bitReverse(i32, @bitCast(i32, @as(u32, 0x12345678))) == @bitCast(i32, @as(u32, 0x1e6a2c48)));
+    try expect(@bitReverse(i32, @bitCast(i32, @as(u32, 0xf2345678))) == @bitCast(i32, @as(u32, 0x1e6a2c4f)));
+    try expect(@bitReverse(i32, @bitCast(i32, @as(u32, 0x1234567f))) == @bitCast(i32, @as(u32, 0xfe6a2c48)));
     try expect(@bitReverse(i40, @bitCast(i40, @as(u40, 0x123456789a))) == @bitCast(i40, @as(u40, 0x591e6a2c48)));
     try expect(@bitReverse(i48, @bitCast(i48, @as(u48, 0x123456789abc))) == @bitCast(i48, @as(u48, 0x3d591e6a2c48)));
     try expect(@bitReverse(i56, @bitCast(i56, @as(u56, 0x123456789abcde))) == @bitCast(i56, @as(u56, 0x7b3d591e6a2c48)));
     try expect(@bitReverse(i64, @bitCast(i64, @as(u64, 0x123456789abcdef1))) == @bitCast(i64, @as(u64, 0x8f7b3d591e6a2c48)));
+    try expect(@bitReverse(i96, @bitCast(i96, @as(u96, 0x123456789abcdef111213141))) == @bitCast(i96, @as(u96, 0x828c84888f7b3d591e6a2c48)));
     try expect(@bitReverse(i128, @bitCast(i128, @as(u128, 0x123456789abcdef11121314151617181))) == @bitCast(i128, @as(u128, 0x818e868a828c84888f7b3d591e6a2c48)));
 
     // using signed, negative. Compare to runtime ints returned from llvm.

--- a/test/behavior/byteswap.zig
+++ b/test/behavior/byteswap.zig
@@ -1,18 +1,29 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const expect = std.testing.expect;
 
 test "@byteSwap integers" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     const ByteSwapIntTest = struct {
         fn run() !void {
             try t(u0, 0, 0);
             try t(u8, 0x12, 0x12);
             try t(u16, 0x1234, 0x3412);
             try t(u24, 0x123456, 0x563412);
+            try t(i24, @bitCast(i24, @as(u24, 0xf23456)), 0x5634f2);
+            try t(i24, 0x1234f6, @bitCast(i24, @as(u24, 0xf63412)));
             try t(u32, 0x12345678, 0x78563412);
+            try t(i32, @bitCast(i32, @as(u32, 0xf2345678)), 0x785634f2);
+            try t(i32, 0x123456f8, @bitCast(i32, @as(u32, 0xf8563412)));
             try t(u40, 0x123456789a, 0x9a78563412);
             try t(i48, 0x123456789abc, @bitCast(i48, @as(u48, 0xbc9a78563412)));
             try t(u56, 0x123456789abcde, 0xdebc9a78563412);
             try t(u64, 0x123456789abcdef1, 0xf1debc9a78563412);
+            try t(u88, 0x123456789abcdef1112131, 0x312111f1debc9a78563412);
+            try t(u96, 0x123456789abcdef111213141, 0x41312111f1debc9a78563412);
             try t(u128, 0x123456789abcdef11121314151617181, 0x8171615141312111f1debc9a78563412);
 
             try t(u0, @as(u0, 0), 0);
@@ -24,6 +35,8 @@ test "@byteSwap integers" {
             try t(i48, @bitCast(i48, @as(u48, 0x123456789abc)), @bitCast(i48, @as(u48, 0xbc9a78563412)));
             try t(i56, @bitCast(i56, @as(u56, 0x123456789abcde)), @bitCast(i56, @as(u56, 0xdebc9a78563412)));
             try t(i64, @bitCast(i64, @as(u64, 0x123456789abcdef1)), @bitCast(i64, @as(u64, 0xf1debc9a78563412)));
+            try t(i88, @bitCast(i88, @as(u88, 0x123456789abcdef1112131)), @bitCast(i88, @as(u88, 0x312111f1debc9a78563412)));
+            try t(i96, @bitCast(i96, @as(u96, 0x123456789abcdef111213141)), @bitCast(i96, @as(u96, 0x41312111f1debc9a78563412)));
             try t(
                 i128,
                 @bitCast(i128, @as(u128, 0x123456789abcdef11121314151617181)),
@@ -31,7 +44,7 @@ test "@byteSwap integers" {
             );
         }
         fn t(comptime I: type, input: I, expected_output: I) !void {
-            try std.testing.expectEqual(expected_output, @byteSwap(I, input));
+            try std.testing.expect(expected_output == @byteSwap(I, input));
         }
     };
     comptime try ByteSwapIntTest.run();
@@ -39,6 +52,11 @@ test "@byteSwap integers" {
 }
 
 test "@byteSwap vectors" {
+    if (builtin.zig_backend == .stage2_llvm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     const ByteSwapVectorTest = struct {
         fn run() !void {
             try t(u8, 2, [_]u8{ 0x12, 0x13 }, [_]u8{ 0x12, 0x13 });

--- a/test/behavior/byteswap.zig
+++ b/test/behavior/byteswap.zig
@@ -6,6 +6,8 @@ test "@byteSwap integers" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
 
     const ByteSwapIntTest = struct {
         fn run() !void {
@@ -56,6 +58,8 @@ test "@byteSwap vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
 
     const ByteSwapVectorTest = struct {
         fn run() !void {


### PR DESCRIPTION
Dependent on #10858

This implements `@bitReverse` and `@byteSwap` for Sema and the LLVM back-end. Vector support is not included as part of this PR.

To make sure the endian-specific logic was properly tested, I added `bitSwap` and `bitReverse` tests to `std.math.big.int`. These are essentially copied from the existing behavior tests, with a few additions for completeness.