### PR TITLE
Make json parser return a null terminated string for []u8 types

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -2248,13 +2248,13 @@ test "parse into struct with strings and arrays with sentinels" {
     ), options);
     defer parseFree(T, r, options);
 
-    try testing.expectEqualSlicesSentinel("zig", r.language);
+    try testing.expectEqualSentinel("zig", r.language);
 
     const data = [_:99]i32{ 1, 2, 3 };
     const simple_data = [_]i32{ 4, 5, 6 };
 
-    try testing.expectEqualSlicesSentinel(data[0..data.len], r.data);
-    try testing.expectEqualSlicesSentinel(simple_data, r.simple_data);
+    try testing.expectEqualSentinel(data[0..data.len], r.data);
+    try testing.expectEqualSentinel(simple_data, r.simple_data);
 }
 
 test "parse into struct with duplicate field" {

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1873,10 +1873,10 @@ fn parseInternal(
                             }
 
                             if (ptrInfo.sentinel) |some| {
-                                const char = @ptrCast(*const u8, some).*;
-                                try arraylist.append(char);
+                                const sentinel_value = @ptrCast(*const ptrInfo.child, some).*;
+                                try arraylist.append(sentinel_value);
                                 const output = arraylist.toOwnedSlice();
-                                return output[0 .. output.len - 1 :char];
+                                return output[0 .. output.len - 1 :sentinel_value];
                             }
 
                             return arraylist.toOwnedSlice();

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -339,11 +339,6 @@ pub fn expectEqualSentinel(comptime T: type, comptime sentinel: T, expected: [:s
         std.debug.print("expectEqualSentinel: 'actual' sentinel in memory is different from its type sentinel. type sentinel {}, in memory sentinel {}\n", .{ sentinel, actual_value_sentinel });
         return error.TestExpectedEqual;
     }
-
-    if (!std.meta.eql(expected_value_sentinel, actual_value_sentinel)) {
-        std.debug.print("expectEqualSentinel: 'expected' and 'actual' parameters have different sentinels in memory. expected {}, found {}\n", .{ expected_value_sentinel, actual_value_sentinel });
-        return error.TestExpectedEqual;
-    }
 }
 
 /// This function is intended to be used only in tests. When `ok` is false, the test fails.

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -330,6 +330,16 @@ pub fn expectEqualSentinel(comptime T: type, comptime sentinel: T, expected: [:s
         }
     };
 
+    if (!std.meta.eql(sentinel, expected_value_sentinel)) {
+        std.debug.print("expectEqualSentinel: 'expected' sentinel in memory is different from its type sentinel. type sentinel {}, in memory sentinel {}\n", .{ sentinel, expected_value_sentinel });
+        return error.TestExpectedEqual;
+    }
+
+    if (!std.meta.eql(sentinel, actual_value_sentinel)) {
+        std.debug.print("expectEqualSentinel: 'actual' sentinel in memory is different from its type sentinel. type sentinel {}, in memory sentinel {}\n", .{ sentinel, actual_value_sentinel });
+        return error.TestExpectedEqual;
+    }
+
     if (!std.meta.eql(expected_value_sentinel, actual_value_sentinel)) {
         std.debug.print("expectEqualSentinel: 'expected' and 'actual' parameters have different sentinels in memory. expected {}, found {}\n", .{ expected_value_sentinel, actual_value_sentinel });
         return error.TestExpectedEqual;

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -301,79 +301,38 @@ pub fn expectEqualSlices(comptime T: type, expected: []const T, actual: []const 
 
 /// This function is intended to be used only in tests. Checks that two slices or two arrays are equal,
 /// including that their sentinel (if any) are the same. Will error if given another type.
-pub fn expectEqualSentinel(expected: anytype, actual: anytype) !void {
-    switch (@typeInfo(@TypeOf(expected))) {
-        .Pointer, .Array => {},
-        else => @compileError("expectEqualSentinel: 'expected' parameter is of type '" ++ @typeName(@TypeOf(expected)) ++ "' but this function only works on pointers or arrays."),
-    }
+pub fn expectEqualSentinel(comptime T: type, comptime sentinel: T, expected: [:sentinel]const T, actual: [:sentinel]const T) !void {
+    try expectEqualSlices(T, expected, actual);
 
-    switch (@typeInfo(@TypeOf(actual))) {
-        .Pointer, .Array => {},
-        else => @compileError("expectEqualSentinel: 'actual' parameter is of type '" ++ @typeName(@TypeOf(actual)) ++ "' but this function only works on pointers or arrays."),
-    }
+    const expected_value_sentinel = blk: {
+        switch (@typeInfo(@TypeOf(expected))) {
+            .Pointer => {
+                break :blk expected[expected.len];
+            },
+            .Array => |array_info| {
+                const indexable_outside_of_bounds = @as([]const array_info.child, &expected);
+                break :blk indexable_outside_of_bounds[indexable_outside_of_bounds.len];
+            },
+            else => {},
+        }
+    };
 
-    // The next two blocks are copy pasted from `expectEqualSlices` because trying to leverage it forces us to do an unnecessary amount of type manipulation.
-    if (expected.len != actual.len) {
-        std.debug.print("expectEqualSentinel: values differ in length. expected {d}, found {d}\n", .{ expected.len, actual.len });
+    const actual_value_sentinel = blk: {
+        switch (@typeInfo(@TypeOf(actual))) {
+            .Pointer => {
+                break :blk actual[actual.len];
+            },
+            .Array => |array_info| {
+                const indexable_outside_of_bounds = @as([]const array_info.child, &actual);
+                break :blk indexable_outside_of_bounds[indexable_outside_of_bounds.len];
+            },
+            else => {},
+        }
+    };
+
+    if (!std.meta.eql(expected_value_sentinel, actual_value_sentinel)) {
+        std.debug.print("expectEqualSentinel: 'expected' and 'actual' parameters have different sentinels in memory. expected {}, found {}\n", .{ expected_value_sentinel, actual_value_sentinel });
         return error.TestExpectedEqual;
-    }
-    var i: usize = 0;
-    while (i < expected.len) : (i += 1) {
-        if (!std.meta.eql(expected[i], actual[i])) {
-            std.debug.print("expectEqualSentinel: values differ at index {}. expected {any}, found {any}\n", .{ i, expected[i], actual[i] });
-            return error.TestExpectedEqual;
-        }
-    }
-
-    const expected_type_sentinel = std.meta.sentinel(@TypeOf(expected));
-    const actual_type_sentinel = std.meta.sentinel(@TypeOf(actual));
-    if (!std.meta.eql(expected_type_sentinel, actual_type_sentinel)) {
-        std.debug.print("expectEqualSentinel: types have different sentinels. expected {}, found {}\n", .{ expected_type_sentinel, actual_type_sentinel });
-        return error.TestExpectedEqual;
-    }
-
-    // We only performn the in-memory sentinel checks if there are any sentinels.
-    if (expected_type_sentinel != null) {
-        const expected_value_sentinel = blk: {
-            switch (@typeInfo(@TypeOf(expected))) {
-                .Pointer => {
-                    break :blk expected[expected.len];
-                },
-                .Array => |array_info| {
-                    const indexable_outside_of_bounds_expected = @as([]const array_info.child, &expected);
-                    break :blk indexable_outside_of_bounds_expected[indexable_outside_of_bounds_expected.len];
-                },
-                else => {},
-            }
-        };
-
-        const actual_value_sentinel = blk: {
-            switch (@typeInfo(@TypeOf(actual))) {
-                .Pointer => {
-                    break :blk actual[actual.len];
-                },
-                .Array => |array_info| {
-                    const indexable_outside_of_bounds_actual = @as([]const array_info.child, &actual);
-                    break :blk indexable_outside_of_bounds_actual[indexable_outside_of_bounds_actual.len];
-                },
-                else => {},
-            }
-        };
-
-        if (!std.meta.eql(expected_type_sentinel, expected_value_sentinel)) {
-            std.debug.print("expectEqualSentinel: type and value have different sentinels for 'expected' parameter. type sentinel {}, value sentinel {}\n", .{ expected_type_sentinel, expected_value_sentinel });
-            return error.TestExpectedEqual;
-        }
-
-        if (!std.meta.eql(actual_type_sentinel, actual_value_sentinel)) {
-            std.debug.print("expectEqualSentinel: type and value have different sentinels for 'actual' parameter. type sentinel {}, value sentinel {}\n", .{ actual_type_sentinel, actual_value_sentinel });
-            return error.TestExpectedEqual;
-        }
-
-        if (!std.meta.eql(expected_value_sentinel, actual_value_sentinel)) {
-            std.debug.print("expectEqualSentinel: 'expected' and 'actual' parameters have different sentinels in memory. expected {}, found {}\n", .{ expected_value_sentinel, actual_value_sentinel });
-            return error.TestExpectedEqual;
-        }
     }
 }
 


### PR DESCRIPTION
Hey all, this is my first time contributing to Zig so adjust your expectations accordingly heh.
I wanted to contribute and picked this issue [#9743](https://github.com/ziglang/zig/issues/9743) to fix.
My fix only partially fixes the issue, because there's the 2nd part where if you mark the struct field as a null terminating slice `u8[:0]` you get yelled at that the types don't match with what the function returns:
`./zig/build/lib/zig/std/json.zig:1874:58: error: expected type '[:0]u8', found '[]u8'` <- something like that 

I don't know enough about the language to tell exactly what the expectation is, and how to handle a polymorphic case like this. But I can fix that part in another PR.

I'd love some feedback on how to improve this!