### PR TITLE
fmt: allow uppercase prefix to be parsed in std.fmt.parseInt()

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1716,14 +1716,17 @@ test "parseInt" {
     try std.testing.expect((try parseInt(i32, "1_1_1", 0)) == 111);
     try std.testing.expect((try parseInt(i32, "1_1_1", 0)) == 111);
     try std.testing.expect((try parseInt(i32, "+0b111", 0)) == 7);
+    try std.testing.expect((try parseInt(i32, "+0B111", 0)) == 7);
     try std.testing.expect((try parseInt(i32, "+0b1_11", 0)) == 7);
     try std.testing.expect((try parseInt(i32, "+0o111", 0)) == 73);
+    try std.testing.expect((try parseInt(i32, "+0O111", 0)) == 73);
     try std.testing.expect((try parseInt(i32, "+0o11_1", 0)) == 73);
     try std.testing.expect((try parseInt(i32, "+0x111", 0)) == 273);
     try std.testing.expect((try parseInt(i32, "-0b111", 0)) == -7);
     try std.testing.expect((try parseInt(i32, "-0b11_1", 0)) == -7);
     try std.testing.expect((try parseInt(i32, "-0o111", 0)) == -73);
     try std.testing.expect((try parseInt(i32, "-0x111", 0)) == -273);
+    try std.testing.expect((try parseInt(i32, "-0X111", 0)) == -273);
     try std.testing.expect((try parseInt(i32, "-0x1_11", 0)) == -273);
 
     // bare binary/octal/decimal prefix is invalid
@@ -1747,7 +1750,7 @@ fn parseWithSign(
         buf_radix = 10;
         // Detect the radix by looking at buf prefix.
         if (buf.len > 2 and buf[0] == '0') {
-            switch (buf[1]) {
+            switch (std.ascii.toLower(buf[1])) {
                 'b' => {
                     buf_radix = 2;
                     buf_start = buf[2..];


### PR DESCRIPTION
This is a very minor inconsistency in std.fmt.parseInt()

std.fmt.parseHexFloat allow both 0x and 0X as prefix, so in order to
keep things consistent. This commit modifies std.fmt.parseWithSign to
check for the prefix case insensitively in order to allow both upper
case and lower case prefix.

This change now allows: 0O, 0B and 0X as prefixes for parsing.