### PR TITLE
refAllDecls handle pub instances of structs

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -466,13 +466,6 @@ test {
 pub fn refAllDecls(comptime T: type) void {
     if (!builtin.is_test) return;
     inline for (comptime std.meta.declarations(T)) |decl| {
-        if (decl.is_pub) {
-            const decl_value = @field(T, decl.name);
-            const type_of_decl = @TypeOf(decl_value);
-            if (type_of_decl == type and @typeInfo(type_of_decl) == .Struct) {
-                _ = @hasDecl(decl_value, "foo");
-            }
-        }
-        _ = decl;
+        if (decl.is_pub) _ = @field(T, decl.name);
     }
 }

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -466,8 +466,13 @@ test {
 pub fn refAllDecls(comptime T: type) void {
     if (!builtin.is_test) return;
     inline for (comptime std.meta.declarations(T)) |decl| {
-        if (decl.is_pub and @typeInfo(@TypeOf(@field(T, decl.name))) == .Struct)
-            _ = @hasDecl(@field(T, decl.name), "foo");
+        if (decl.is_pub) {
+            const decl_value = @field(T, decl.name);
+            const type_of_decl = @TypeOf(decl_value);
+            if (type_of_decl == type and @typeInfo(type_of_decl) == .Struct) {
+                _ = @hasDecl(decl_value, "foo");
+            }
+        }
         _ = decl;
     }
 }


### PR DESCRIPTION
To prevent calling `@hasDecl` on an instance of a struct we need to check the `@TypeOf` the decl is actually `type`.

This PR closes #10908