### PR TITLE
further parser error improvements

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10405,7 +10405,7 @@ pub fn main() !void {
       <p>String literals such as {#syntax#}"foo"{#endsyntax#} are in the global constant data section.
       This is why it is an error to pass a string literal to a mutable slice, like this:
       </p>
-      {#code_begin|test_err|expected type '[]u8'#}
+      {#code_begin|test_err|cannot cast pointer to array literal to slice type '[]u8'#}
 fn foo(s: []u8) void {
     _ = s;
 }

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -66,20 +66,11 @@ pub fn renderToArrayList(tree: Ast, buffer: *std.ArrayList(u8)) RenderError!void
 
 /// Returns an extra offset for column and byte offset of errors that
 /// should point after the token in the error message.
-pub fn errorOffset(tree: Ast, error_tag: Error.Tag, token: TokenIndex) u32 {
-    return switch (error_tag) {
-        .expected_semi_after_decl,
-        .expected_semi_after_stmt,
-        .expected_comma_after_field,
-        .expected_comma_after_arg,
-        .expected_comma_after_param,
-        .expected_comma_after_initializer,
-        .expected_comma_after_switch_prong,
-        .expected_semi_or_else,
-        .expected_semi_or_lbrace,
-        => @intCast(u32, tree.tokenSlice(token).len),
-        else => 0,
-    };
+pub fn errorOffset(tree: Ast, parse_error: Error) u32 {
+    return if (parse_error.token_is_prev)
+        @intCast(u32, tree.tokenSlice(parse_error.token).len)
+    else
+        0;
 }
 
 pub fn tokenLocation(self: Ast, start_offset: ByteOffset, token_index: TokenIndex) Location {
@@ -162,22 +153,22 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
         },
         .expected_block => {
             return stream.print("expected block or field, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_block_or_assignment => {
             return stream.print("expected block or assignment, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_block_or_expr => {
             return stream.print("expected block or expression, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_block_or_field => {
             return stream.print("expected block or field, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_container_members => {
@@ -187,42 +178,42 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
         },
         .expected_expr => {
             return stream.print("expected expression, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_expr_or_assignment => {
             return stream.print("expected expression or assignment, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_fn => {
             return stream.print("expected function, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_inlinable => {
             return stream.print("expected 'while' or 'for', found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_labelable => {
             return stream.print("expected 'while', 'for', 'inline', 'suspend', or '{{', found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_param_list => {
             return stream.print("expected parameter list, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_prefix_expr => {
             return stream.print("expected prefix expression, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_primary_type_expr => {
             return stream.print("expected primary type expression, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_pub_item => {
@@ -230,7 +221,7 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
         },
         .expected_return_type => {
             return stream.print("expected return type expression, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_semi_or_else => {
@@ -244,39 +235,34 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
                 token_tags[parse_error.token].symbol(),
             });
         },
-        .expected_string_literal => {
-            return stream.print("expected string literal, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
-            });
-        },
         .expected_suffix_op => {
             return stream.print("expected pointer dereference, optional unwrap, or field access, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_type_expr => {
             return stream.print("expected type expression, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_var_decl => {
             return stream.print("expected variable declaration, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_var_decl_or_fn => {
             return stream.print("expected variable declaration or function, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_loop_payload => {
             return stream.print("expected loop payload, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .expected_container => {
             return stream.print("expected a struct, enum or union, found '{s}'", .{
-                token_tags[parse_error.token].symbol(),
+                token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)].symbol(),
             });
         },
         .extern_fn_body => {
@@ -341,9 +327,12 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
         .expected_comma_after_switch_prong => {
             return stream.writeAll("expected ',' after switch prong");
         },
+        .expected_initializer => {
+            return stream.writeAll("expected field initializer");
+        },
 
         .expected_token => {
-            const found_tag = token_tags[parse_error.token];
+            const found_tag = token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)];
             const expected_symbol = parse_error.extra.expected_tag.symbol();
             switch (found_tag) {
                 .invalid => return stream.print("expected '{s}', found invalid bytes", .{
@@ -2483,6 +2472,7 @@ pub const full = struct {
 
 pub const Error = struct {
     tag: Tag,
+    token_is_prev: bool = false,
     token: TokenIndex,
     extra: union {
         none: void,
@@ -2511,7 +2501,6 @@ pub const Error = struct {
         expected_semi_or_else,
         expected_semi_or_lbrace,
         expected_statement,
-        expected_string_literal,
         expected_suffix_op,
         expected_type_expr,
         expected_var_decl,
@@ -2539,6 +2528,7 @@ pub const Error = struct {
         expected_comma_after_param,
         expected_comma_after_initializer,
         expected_comma_after_switch_prong,
+        expected_initializer,
 
         /// `expected_tag` is populated.
         expected_token,

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -300,6 +300,9 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
         .varargs_nonfinal => {
             return stream.writeAll("function prototype has parameter after varargs");
         },
+        .expected_continue_expr => {
+            return stream.writeAll("expected ':' before while continue expression");
+        },
 
         .expected_semi_after_decl => {
             return stream.writeAll("expected ';' after declaration");
@@ -2467,6 +2470,7 @@ pub const full = struct {
 
 pub const Error = struct {
     tag: Tag,
+    /// True if `token` points to the token before the token causing an issue.
     token_is_prev: bool = false,
     token: TokenIndex,
     extra: union {
@@ -2513,8 +2517,7 @@ pub const Error = struct {
         same_line_doc_comment,
         unattached_doc_comment,
         varargs_nonfinal,
-
-        // these have `token` set to token after which a semicolon was expected
+        expected_continue_expr,
         expected_semi_after_decl,
         expected_semi_after_stmt,
         expected_comma_after_field,

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -291,11 +291,6 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
         .invalid_bit_range => {
             return stream.writeAll("bit range not allowed on slices and arrays");
         },
-        .invalid_token => {
-            return stream.print("invalid token: '{s}'", .{
-                token_tags[parse_error.token].symbol(),
-            });
-        },
         .same_line_doc_comment => {
             return stream.writeAll("same line documentation comment");
         },
@@ -2515,7 +2510,6 @@ pub const Error = struct {
         extra_volatile_qualifier,
         ptr_mod_on_array_child_type,
         invalid_bit_range,
-        invalid_token,
         same_line_doc_comment,
         unattached_doc_comment,
         varargs_nonfinal,

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -329,6 +329,13 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
             return stream.writeAll("expected field initializer");
         },
 
+        .previous_field => {
+            return stream.writeAll("field before declarations here");
+        },
+        .next_field => {
+            return stream.writeAll("field after declarations here");
+        },
+
         .expected_token => {
             const found_tag = token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)];
             const expected_symbol = parse_error.extra.expected_tag.symbol();
@@ -2470,6 +2477,7 @@ pub const full = struct {
 
 pub const Error = struct {
     tag: Tag,
+    is_note: bool = false,
     /// True if `token` points to the token before the token causing an issue.
     token_is_prev: bool = false,
     token: TokenIndex,
@@ -2526,6 +2534,9 @@ pub const Error = struct {
         expected_comma_after_initializer,
         expected_comma_after_switch_prong,
         expected_initializer,
+
+        previous_field,
+        next_field,
 
         /// `expected_tag` is populated.
         expected_token,

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -2943,7 +2943,12 @@ const Parser = struct {
 
     /// WhileContinueExpr <- COLON LPAREN AssignExpr RPAREN
     fn parseWhileContinueExpr(p: *Parser) !Node.Index {
-        _ = p.eatToken(.colon) orelse return null_node;
+        _ = p.eatToken(.colon) orelse {
+            if (p.token_tags[p.tok_i] == .l_paren and
+                p.tokensOnSameLine(p.tok_i - 1, p.tok_i))
+                return p.fail(.expected_continue_expr);
+            return null_node;
+        };
         _ = try p.expectToken(.l_paren);
         const node = try p.parseAssignExpr();
         if (node == 0) return p.fail(.expected_expr_or_assignment);

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5018,6 +5018,25 @@ test "zig fmt: make single-line if no trailing comma" {
     );
 }
 
+test "zig fmt: while continue expr" {
+    try testCanonical(
+        \\test {
+        \\    while (i > 0)
+        \\        (i * 2);
+        \\}
+        \\
+    );
+    try testError(
+        \\test {
+        \\    while (i > 0) (i -= 1) {
+        \\        print("test123", .{});
+        \\    }
+        \\}
+    , &[_]Error{
+        .expected_continue_expr,
+    });
+}
+
 test "zig fmt: error for invalid bit range" {
     try testError(
         \\var x: []align(0:0:0)u8 = bar;

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -226,6 +226,8 @@ test "zig fmt: decl between fields" {
         \\};
     , &[_]Error{
         .decl_between_fields,
+        .previous_field,
+        .next_field,
     });
 }
 

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5057,7 +5057,9 @@ test "recovery: block statements" {
         \\    inline;
         \\}
     , &[_]Error{
-        .invalid_token,
+        .expected_expr,
+        .expected_semi_after_stmt,
+        .expected_statement,
         .expected_inlinable,
     });
 }
@@ -5076,7 +5078,7 @@ test "recovery: missing comma" {
     , &[_]Error{
         .expected_comma_after_switch_prong,
         .expected_comma_after_switch_prong,
-        .invalid_token,
+        .expected_expr,
     });
 }
 

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -322,7 +322,18 @@ pub const Token = struct {
         }
 
         pub fn symbol(tag: Tag) []const u8 {
-            return tag.lexeme() orelse @tagName(tag);
+            return tag.lexeme() orelse switch (tag) {
+                .invalid => "invalid bytes",
+                .identifier => "an identifier",
+                .string_literal, .multiline_string_literal_line => "a string literal",
+                .char_literal => "a character literal",
+                .eof => "EOF",
+                .builtin => "a builtin function",
+                .integer_literal => "an integer literal",
+                .float_literal => "a floating point literal",
+                .doc_comment, .container_doc_comment => "a document comment",
+                else => unreachable,
+            };
         }
     };
 };

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3014,6 +3014,17 @@ pub fn astGenFile(mod: *Module, file: *File) !void {
                 .parent_decl_node = 0,
                 .lazy = .{ .byte_abs = byte_abs },
             }, err_msg, "invalid byte: '{'}'", .{std.zig.fmtEscapes(source[byte_abs..][0..1])});
+        } else if (parse_err.tag == .decl_between_fields) {
+            try mod.errNoteNonLazy(.{
+                .file_scope = file,
+                .parent_decl_node = 0,
+                .lazy = .{ .byte_abs = token_starts[file.tree.errors[1].token] },
+            }, err_msg, "field before declarations here", .{});
+            try mod.errNoteNonLazy(.{
+                .file_scope = file,
+                .parent_decl_node = 0,
+                .lazy = .{ .byte_abs = token_starts[file.tree.errors[2].token] },
+            }, err_msg, "field after declarations here", .{});
         }
 
         {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2995,7 +2995,7 @@ pub fn astGenFile(mod: *Module, file: *File) !void {
         const token_starts = file.tree.tokens.items(.start);
         const token_tags = file.tree.tokens.items(.tag);
 
-        const extra_offset = file.tree.errorOffset(parse_err.tag, parse_err.token);
+        const extra_offset = file.tree.errorOffset(parse_err);
         try file.tree.renderError(parse_err, msg.writer());
         const err_msg = try gpa.create(ErrorMsg);
         err_msg.* = .{
@@ -3006,9 +3006,9 @@ pub fn astGenFile(mod: *Module, file: *File) !void {
             },
             .msg = msg.toOwnedSlice(),
         };
-        if (token_tags[parse_err.token] == .invalid) {
-            const bad_off = @intCast(u32, file.tree.tokenSlice(parse_err.token).len);
-            const byte_abs = token_starts[parse_err.token] + bad_off;
+        if (token_tags[parse_err.token + @boolToInt(parse_err.token_is_prev)] == .invalid) {
+            const bad_off = @intCast(u32, file.tree.tokenSlice(parse_err.token + @boolToInt(parse_err.token_is_prev)).len);
+            const byte_abs = token_starts[parse_err.token + @boolToInt(parse_err.token_is_prev)] + bad_off;
             try mod.errNoteNonLazy(.{
                 .file_scope = file,
                 .parent_decl_node = 0,

--- a/src/main.zig
+++ b/src/main.zig
@@ -4063,9 +4063,9 @@ fn printErrMsgToStdErr(
     var notes_buffer: [1]Compilation.AllErrors.Message = undefined;
     var notes_len: usize = 0;
 
-    if (token_tags[parse_error.token] == .invalid) {
-        const bad_off = @intCast(u32, tree.tokenSlice(parse_error.token).len);
-        const byte_offset = @intCast(u32, start_loc.line_start) + bad_off;
+    if (token_tags[parse_error.token + @boolToInt(parse_error.token_is_prev)] == .invalid) {
+        const bad_off = @intCast(u32, tree.tokenSlice(parse_error.token + @boolToInt(parse_error.token_is_prev)).len);
+        const byte_offset = @intCast(u32, start_loc.line_start) + @intCast(u32, start_loc.column) + bad_off;
         notes_buffer[notes_len] = .{
             .src = .{
                 .src_path = path,
@@ -4081,7 +4081,7 @@ fn printErrMsgToStdErr(
         notes_len += 1;
     }
 
-    const extra_offset = tree.errorOffset(parse_error.tag, parse_error.token);
+    const extra_offset = tree.errorOffset(parse_error);
     const message: Compilation.AllErrors.Message = .{
         .src = .{
             .src_path = path,

--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -7843,7 +7843,7 @@ static Stage1AirInst *ir_analyze_cast(IrAnalyze *ira, Scope *scope, AstNode *sou
         bool const_ok = (slice_ptr_type->data.pointer.is_const || array_type->data.array.len == 0
                 || !actual_type->data.pointer.is_const);
 
-        if (const_ok && types_match_const_cast_only(ira, slice_ptr_type->data.pointer.child_type,
+        if (types_match_const_cast_only(ira, slice_ptr_type->data.pointer.child_type,
             array_type->data.array.child_type, source_node,
             !slice_ptr_type->data.pointer.is_const).id == ConstCastResultIdOk &&
             (slice_ptr_type->data.pointer.sentinel == nullptr ||
@@ -7851,6 +7851,14 @@ static Stage1AirInst *ir_analyze_cast(IrAnalyze *ira, Scope *scope, AstNode *sou
               const_values_equal(ira->codegen, array_type->data.array.sentinel,
                   slice_ptr_type->data.pointer.sentinel))))
         {
+            if (!const_ok) {
+                ErrorMsg *msg = ir_add_error_node(ira, source_node,
+                    buf_sprintf("cannot cast pointer to array literal to slice type '%s'",
+                        buf_ptr(&wanted_type->name)));
+                add_error_note(ira->codegen, msg, source_node,
+                    buf_sprintf("cast discards const qualifier"));
+                return ira->codegen->invalid_inst_gen;
+            }
             // If the pointers both have ABI align, it works.
             // Or if the array length is 0, alignment doesn't matter.
             bool ok_align = array_type->data.array.len == 0 ||
@@ -8208,8 +8216,16 @@ static Stage1AirInst *ir_analyze_cast(IrAnalyze *ira, Scope *scope, AstNode *sou
             ZigType *wanted_child = wanted_type->data.pointer.child_type;
             bool const_ok = (!actual_type->data.pointer.is_const || wanted_type->data.pointer.is_const);
             if (wanted_child->id == ZigTypeIdArray && (is_array_init || field_count == 0) &&
-                wanted_child->data.array.len == field_count && (const_ok || field_count == 0))
+                wanted_child->data.array.len == field_count)
             {
+                if (!const_ok && field_count != 0) {
+                    ErrorMsg *msg = ir_add_error_node(ira, source_node,
+                        buf_sprintf("cannot cast pointer to array literal to '%s'",
+                            buf_ptr(&wanted_type->name)));
+                    add_error_note(ira->codegen, msg, source_node,
+                        buf_sprintf("cast discards const qualifier"));
+                    return ira->codegen->invalid_inst_gen;
+                }
                 Stage1AirInst *res = ir_analyze_struct_literal_to_array(ira, scope, source_node, value, anon_type, wanted_child);
                 if (res->value->type->id == ZigTypeIdPointer)
                     return res;
@@ -8241,6 +8257,13 @@ static Stage1AirInst *ir_analyze_cast(IrAnalyze *ira, Scope *scope, AstNode *sou
                     res = ir_get_ref(ira, scope, source_node, res, actual_type->data.pointer.is_const, actual_type->data.pointer.is_volatile);
 
                 return ir_resolve_ptr_of_array_to_slice(ira, scope, source_node, res, wanted_type, nullptr);
+            } else if (!slice_type->data.pointer.is_const && actual_type->data.pointer.is_const && field_count != 0) {
+                ErrorMsg *msg = ir_add_error_node(ira, source_node,
+                    buf_sprintf("cannot cast pointer to array literal to slice type '%s'",
+                        buf_ptr(&wanted_type->name)));
+                add_error_note(ira->codegen, msg, source_node,
+                    buf_sprintf("cast discards const qualifier"));
+                return ira->codegen->invalid_inst_gen;
             }
         }
     }
@@ -15068,7 +15091,7 @@ static Stage1AirInst *ir_analyze_instruction_elem_ptr(IrAnalyze *ira, Stage1ZirI
                         return ira->codegen->invalid_inst_gen;
                     if (actual_array_type->id != ZigTypeIdArray) {
                         ir_add_error_node(ira, elem_ptr_instruction->init_array_type_source_node,
-                            buf_sprintf("array literal requires address-of operator to coerce to slice type '%s'",
+                            buf_sprintf("array literal requires address-of operator (&) to coerce to slice type '%s'",
                                 buf_ptr(&actual_array_type->name)));
                         return ira->codegen->invalid_inst_gen;
                     }
@@ -17473,7 +17496,7 @@ static Stage1AirInst *ir_analyze_instruction_container_init_list(IrAnalyze *ira,
 
     if (is_slice(container_type)) {
         ir_add_error_node(ira, instruction->init_array_type_source_node,
-            buf_sprintf("array literal requires address-of operator to coerce to slice type '%s'",
+            buf_sprintf("array literal requires address-of operator (&) to coerce to slice type '%s'",
                 buf_ptr(&container_type->name)));
         return ira->codegen->invalid_inst_gen;
     }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -86,9 +86,12 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = c;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:31: error: expected type '[][]const u8', found '*const struct:2:31'",
-        "tmp.zig:6:33: error: expected type '*[2][]const u8', found '*const struct:6:33'",
+        "tmp.zig:2:31: error: cannot cast pointer to array literal to slice type '[][]const u8'",
+        "tmp.zig:2:31: note: cast discards const qualifier",
+        "tmp.zig:6:33: error: cannot cast pointer to array literal to '*[2][]const u8'",
+        "tmp.zig:6:33: note: cast discards const qualifier",
         "tmp.zig:11:21: error: expected type '*S', found '*const struct:11:21'",
+        "tmp.zig:11:21: note: cast discards const qualifier",
     });
 
     ctx.objErrStage1("@Type() union payload is undefined",
@@ -1962,7 +1965,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = geo_data;
         \\}
     , &[_][]const u8{
-        "tmp.zig:4:30: error: array literal requires address-of operator to coerce to slice type '[][2]f32'",
+        "tmp.zig:4:30: error: array literal requires address-of operator (&) to coerce to slice type '[][2]f32'",
     });
 
     ctx.objErrStage1("slicing of global undefined pointer",
@@ -2537,7 +2540,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = x;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:15: error: array literal requires address-of operator to coerce to slice type '[]u8'",
+        "tmp.zig:2:15: error: array literal requires address-of operator (&) to coerce to slice type '[]u8'",
     });
 
     ctx.objErrStage1("slice passed as array init type",
@@ -2546,7 +2549,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = x;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:15: error: array literal requires address-of operator to coerce to slice type '[]u8'",
+        "tmp.zig:2:15: error: array literal requires address-of operator (&) to coerce to slice type '[]u8'",
     });
 
     ctx.objErrStage1("inferred array size invalid here",
@@ -3493,7 +3496,8 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = sliceA;
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:27: error: expected type '[]u8', found '*const [1]u8'",
+        "tmp.zig:3:27: error: cannot cast pointer to array literal to slice type '[]u8'",
+        "tmp.zig:3:27: note: cast discards const qualifier",
     });
 
     ctx.objErrStage1("deref slice and get len field",
@@ -8717,7 +8721,8 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    comptime ignore(@typeInfo(MyStruct).Struct.fields[0]);
         \\}
     , &[_][]const u8{
-        ":5:28: error: expected type '[]u8', found '*const [3:0]u8'",
+        ":5:28: error: cannot cast pointer to array literal to slice type '[]u8'",
+        ":5:28: note: cast discards const qualifier",
     });
 
     ctx.objErrStage1("integer underflow error",

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1540,7 +1540,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    std.debug.assert(bad_float < 1.0);
         \\}
     , &[_][]const u8{
-        "tmp.zig:5:29: error: invalid token: '.'",
+        "tmp.zig:5:29: error: expected expression, found '.'",
     });
 
     ctx.objErrStage1("invalid exponent in float literal - 1",
@@ -1549,7 +1549,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:28: note: invalid byte: 'a'",
     });
 
@@ -1559,7 +1559,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:29: note: invalid byte: 'F'",
     });
 
@@ -1569,7 +1569,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:23: note: invalid byte: '_'",
     });
 
@@ -1579,7 +1579,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:23: note: invalid byte: '.'",
     });
 
@@ -1589,7 +1589,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:25: note: invalid byte: ';'",
     });
 
@@ -1599,7 +1599,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:25: note: invalid byte: '_'",
     });
 
@@ -1609,7 +1609,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:26: note: invalid byte: '_'",
     });
 
@@ -1619,7 +1619,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:26: note: invalid byte: '_'",
     });
 
@@ -1629,7 +1629,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:28: note: invalid byte: ';'",
     });
 
@@ -1639,7 +1639,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:23: note: invalid byte: '_'",
     });
 
@@ -1649,7 +1649,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:25: note: invalid byte: '_'",
     });
 
@@ -1659,7 +1659,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:28: note: invalid byte: '_'",
     });
 
@@ -1669,7 +1669,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:23: note: invalid byte: 'x'",
     });
 
@@ -1679,7 +1679,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:23: note: invalid byte: '_'",
     });
 
@@ -1689,7 +1689,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:27: note: invalid byte: 'p'",
     });
 
@@ -1699,7 +1699,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:26: note: invalid byte: ';'",
     });
 
@@ -1709,7 +1709,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:28: note: invalid byte: ';'",
     });
 
@@ -1719,7 +1719,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:28: note: invalid byte: ';'",
     });
 
@@ -1729,7 +1729,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = bad;
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:21: error: expected expression, found 'invalid'",
+        "tmp.zig:2:21: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:28: note: invalid byte: ';'",
     });
 
@@ -2171,7 +2171,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = x;
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:6: error: expected ',' after field",
+        "tmp.zig:3:7: error: expected ',' after field",
     });
 
     ctx.objErrStage1("bad alignment type",
@@ -5733,7 +5733,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\const foo = "a
         \\b";
     , &[_][]const u8{
-        "tmp.zig:1:13: error: expected expression, found 'invalid'",
+        "tmp.zig:1:13: error: expected expression, found 'invalid bytes'",
         "tmp.zig:1:15: note: invalid byte: '\\n'",
     });
 
@@ -7638,7 +7638,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    const a = '\U1234';
         \\}
     , &[_][]const u8{
-        "tmp.zig:2:15: error: expected expression, found 'invalid'",
+        "tmp.zig:2:15: error: expected expression, found 'invalid bytes'",
         "tmp.zig:2:18: note: invalid byte: '1'",
     });
 
@@ -7654,7 +7654,7 @@ pub fn addCases(ctx: *TestContext) !void {
         "fn foo() bool {\r\n" ++
         "    return true;\r\n" ++
         "}\r\n", &[_][]const u8{
-        "tmp.zig:1:1: error: expected test, comptime, var decl, or container field, found 'invalid'",
+        "tmp.zig:1:1: error: expected test, comptime, var decl, or container field, found 'invalid bytes'",
         "tmp.zig:1:1: note: invalid byte: '\\xff'",
     });
 

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -877,6 +877,8 @@ pub fn addCases(ctx: *TestContext) !void {
         \\}
     , &[_][]const u8{
         "tmp.zig:6:5: error: declarations are not allowed between container fields",
+        "tmp.zig:5:5: note: field before declarations here",
+        "tmp.zig:9:5: note: field after declarations here",
     });
 
     ctx.objErrStage1("non-extern function with var args",

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -4869,11 +4869,11 @@ pub fn addCases(ctx: *TestContext) !void {
         \\export fn entry() void {
         \\    while(true) {}
         \\    var good = {};
-        \\    while(true) ({})
+        \\    while(true) 1
         \\    var bad = {};
         \\}
     , &[_][]const u8{
-        "tmp.zig:4:21: error: expected ';' or 'else' after statement",
+        "tmp.zig:4:18: error: expected ';' or 'else' after statement",
     });
 
     ctx.objErrStage1("implicit semicolon - while expression",

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -693,7 +693,7 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    _ = E1.a;
             \\}
         , &.{
-            ":3:6: error: expected ',' after field",
+            ":3:7: error: expected ',' after field",
         });
 
         // Redundant non-exhaustive enum mark.


### PR DESCRIPTION
Continuation to #10879.

Also included is better error message when casting tuple to slice/ptr to array discards const qualifier.

Closes  #416
Closes #5739
Closes  #10511
Closes  #10529