### PR TITLE
stage2,x64: refactor stack mgmt mechanics, implement slice, fix ptr_add and ptr_sub

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -966,7 +966,7 @@ fn airTrunc(self: *Self, inst: Air.Inst.Index) !void {
     const reg: Register = blk: {
         if (operand.isRegister()) {
             if (self.reuseOperand(inst, ty_op.operand, 0, operand)) {
-                break :blk operand.register;
+                break :blk operand.register.to64();
             }
         }
         const mcv = try self.copyToNewRegister(inst, src_ty, operand);
@@ -2300,7 +2300,6 @@ fn genBinMathOp(self: *Self, inst: Air.Inst.Index, op_lhs: Air.Inst.Ref, op_rhs:
     const mcvs = try self.mcvsForBinMathOp(inst, op_lhs, op_rhs);
     const dst_mcv = mcvs.dst;
     const src_mcv = mcvs.src;
-    log.warn("dst_mcv = {}, src_mcv = {}", .{ dst_mcv, src_mcv });
     const tag = self.air.instructions.items(.tag)[inst];
     switch (tag) {
         .add, .addwrap => try self.genBinMathOpMir(.add, dst_ty, dst_mcv, src_mcv),

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -413,6 +413,7 @@ pub const DbgLineColumn = struct {
 pub const ArgDbgInfo = struct {
     air_inst: Air.Inst.Index,
     arg_index: u32,
+    max_stack: u32,
 };
 
 pub fn deinit(mir: *Mir, gpa: std.mem.Allocator) void {

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -106,7 +106,6 @@ fn fnWithAlignedStack() i32 {
 test "implicitly decreasing slice alignment" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const a: u32 align(4) = 3;
     const b: u32 align(8) = 4;
@@ -274,7 +273,6 @@ fn whyWouldYouEverDoThis(comptime align_bytes: u8) align(align_bytes) u8 {
 test "runtime known array index has best alignment possible" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     // take full advantage of over-alignment

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -106,6 +106,7 @@ fn fnWithAlignedStack() i32 {
 test "implicitly decreasing slice alignment" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const a: u32 align(4) = 3;
     const b: u32 align(8) = 4;

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -8,6 +8,7 @@ const expectEqual = testing.expectEqual;
 test "array to slice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const a: u32 align(4) = 3;
     const b: u32 align(8) = 4;

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -199,7 +199,7 @@ fn MakeType(comptime T: type) type {
 
 test "implicit cast from *[N]T to [*c]T" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     var x: [4]u16 = [4]u16{ 0, 1, 2, 3 };
     var y: [*c]u16 = &x;
@@ -274,7 +274,7 @@ test "*const ?[*]const T to [*c]const [*c]const T" {
 
 test "array coersion to undefined at runtime" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     @setRuntimeSafety(true);
 
@@ -339,7 +339,6 @@ test "peer type unsigned int to signed" {
 test "expected [*c]const u8, found [*:0]const u8" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     var a: [*:0]const u8 = "hello";
     var b: [*c]const u8 = a;

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -29,7 +29,6 @@ comptime {
 test "slicing" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
     var array: [20]i32 = undefined;
@@ -223,7 +222,6 @@ test "compile time slice of pointer to hard coded address" {
 test "slice string literal has correct type" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     comptime {
         try expect(@TypeOf("aoeu"[0..]) == *const [4:0]u8);
@@ -365,7 +363,6 @@ test "empty array to slice" {
 test "@ptrCast slice to pointer" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {


### PR DESCRIPTION
* implements `slice` AIR tag
* correctly implements `ptr_add` and `ptr_sub` tags
* fixes signed truncate
* overhauls stack handling mechanics - this is a pretty exciting change: now, the abstracted stack offsets grow in the same direction as the real stack values in hardware, and allocating stack memory is done by the taking the last stack offset, adding required abi size and aligning to the required abi align. Stack handling is now more natural as it aligns itself with how it works in hardware; hence stepping through the debugger and printing out different stack values is intuitive. Finally, the stack pointers are now correctly aligned to the required (and not necessarily natural) alignment.
* better encapsulates inline memcpy - easier reuse within codegen than before
* handles storing non power of 2 values to stack from register - this actually requires storing and shifting mechanics so that we
don't accidentally clobber anything else on the stack.