### PR TITLE
stage2,x64: pass all args on stack in debug and if not extern fn

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -1604,6 +1604,12 @@ fn airArrayElemVal(self: *Self, inst: Air.Inst.Index) !void {
                     .stack_offset => |off| {
                         break :inner off;
                     },
+                    .memory,
+                    .got_load,
+                    .direct_load,
+                    => {
+                        break :blk try self.loadMemPtrIntoRegister(Type.usize, array);
+                    },
                     else => return self.fail("TODO implement array_elem_val when array is {}", .{array}),
                 }
             };
@@ -1845,6 +1851,42 @@ fn airLoad(self: *Self, inst: Air.Inst.Index) !void {
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 
+fn loadMemPtrIntoRegister(self: *Self, ptr_ty: Type, ptr: MCValue) InnerError!Register {
+    switch (ptr) {
+        .got_load,
+        .direct_load,
+        => |sym_index| {
+            const flags: u2 = switch (ptr) {
+                .got_load => 0b00,
+                .direct_load => 0b01,
+                else => unreachable,
+            };
+            const reg = try self.register_manager.allocReg(null);
+            _ = try self.addInst(.{
+                .tag = .lea_pie,
+                .ops = (Mir.Ops{
+                    .reg1 = reg.to64(),
+                    .flags = flags,
+                }).encode(),
+                .data = .{
+                    .load_reloc = .{
+                        .atom_index = self.mod_fn.owner_decl.link.macho.local_sym_index,
+                        .sym_index = sym_index,
+                    },
+                },
+            });
+            return reg.to64();
+        },
+        .memory => |addr| {
+            // TODO: in case the address fits in an imm32 we can use [ds:imm32]
+            // instead of wasting an instruction copying the address to a register
+            const reg = try self.copyToTmpRegister(ptr_ty, .{ .immediate = addr });
+            return reg.to64();
+        },
+        else => unreachable,
+    }
+}
+
 fn store(self: *Self, ptr: MCValue, value: MCValue, ptr_ty: Type, value_ty: Type) InnerError!void {
     _ = ptr_ty;
     const abi_size = value_ty.abiSize(self.target.*);
@@ -1955,41 +1997,7 @@ fn store(self: *Self, ptr: MCValue, value: MCValue, ptr_ty: Type, value_ty: Type
             value.freezeIfRegister(&self.register_manager);
             defer value.unfreezeIfRegister(&self.register_manager);
 
-            const addr_reg: Register = blk: {
-                switch (ptr) {
-                    .got_load,
-                    .direct_load,
-                    => |sym_index| {
-                        const flags: u2 = switch (ptr) {
-                            .got_load => 0b00,
-                            .direct_load => 0b01,
-                            else => unreachable,
-                        };
-                        const addr_reg = try self.register_manager.allocReg(null);
-                        _ = try self.addInst(.{
-                            .tag = .lea_pie,
-                            .ops = (Mir.Ops{
-                                .reg1 = addr_reg.to64(),
-                                .flags = flags,
-                            }).encode(),
-                            .data = .{
-                                .load_reloc = .{
-                                    .atom_index = self.mod_fn.owner_decl.link.macho.local_sym_index,
-                                    .sym_index = sym_index,
-                                },
-                            },
-                        });
-                        break :blk addr_reg;
-                    },
-                    .memory => |addr| {
-                        // TODO: in case the address fits in an imm32 we can use [ds:imm32]
-                        // instead of wasting an instruction copying the address to a register
-                        const addr_reg = try self.copyToTmpRegister(ptr_ty, .{ .immediate = addr });
-                        break :blk addr_reg;
-                    },
-                    else => unreachable,
-                }
-            };
+            const addr_reg = try self.loadMemPtrIntoRegister(ptr_ty, ptr);
 
             // to get the actual address of the value we want to modify we have to go through the GOT
             // mov reg, [reg]
@@ -3831,33 +3839,11 @@ fn genInlineMemcpy(self: *Self, stack_offset: i32, stack_reg: Register, ty: Type
 
     const addr_reg: Register = blk: {
         switch (val) {
-            .memory => |addr| {
-                const reg = try self.copyToTmpRegister(Type.usize, .{ .immediate = addr });
-                break :blk reg;
-            },
+            .memory,
             .direct_load,
             .got_load,
-            => |sym_index| {
-                const flags: u2 = switch (val) {
-                    .got_load => 0b00,
-                    .direct_load => 0b01,
-                    else => unreachable,
-                };
-                const addr_reg = (try self.register_manager.allocReg(null)).to64();
-                _ = try self.addInst(.{
-                    .tag = .lea_pie,
-                    .ops = (Mir.Ops{
-                        .reg1 = addr_reg,
-                        .flags = flags,
-                    }).encode(),
-                    .data = .{
-                        .load_reloc = .{
-                            .atom_index = self.mod_fn.owner_decl.link.macho.local_sym_index,
-                            .sym_index = sym_index,
-                        },
-                    },
-                });
-                break :blk addr_reg;
+            => {
+                break :blk try self.loadMemPtrIntoRegister(Type.usize, val);
             },
             .stack_offset => |off| {
                 const addr_reg = (try self.register_manager.allocReg(null)).to64();

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -1737,6 +1737,10 @@ fn load(self: *Self, dst_mcv: MCValue, ptr: MCValue, ptr_ty: Type) InnerError!vo
         .immediate => |imm| {
             try self.setRegOrMem(elem_ty, dst_mcv, .{ .memory = imm });
         },
+        .stack_offset => {
+            const reg = try self.copyToTmpRegister(ptr_ty, ptr);
+            try self.load(dst_mcv, .{ .register = reg }, ptr_ty);
+        },
         .ptr_stack_offset => |off| {
             try self.setRegOrMem(elem_ty, dst_mcv, .{ .stack_offset = off });
         },
@@ -1787,9 +1791,6 @@ fn load(self: *Self, dst_mcv: MCValue, ptr: MCValue, ptr_ty: Type) InnerError!vo
             const reg = try self.copyToTmpRegister(ptr_ty, ptr);
             try self.load(dst_mcv, .{ .register = reg }, ptr_ty);
         },
-        .stack_offset => {
-            return self.fail("TODO implement loading from MCValue.stack_offset", .{});
-        },
     }
 }
 
@@ -1831,6 +1832,10 @@ fn store(self: *Self, ptr: MCValue, value: MCValue, ptr_ty: Type, value_ty: Type
         .compare_flags_signed => unreachable,
         .immediate => |imm| {
             try self.setRegOrMem(value_ty, .{ .memory = imm }, value);
+        },
+        .stack_offset => {
+            const reg = try self.copyToTmpRegister(ptr_ty, ptr);
+            try self.store(.{ .register = reg }, value, ptr_ty, value_ty);
         },
         .ptr_stack_offset => |off| {
             try self.genSetStack(value_ty, off, value);
@@ -1908,6 +1913,10 @@ fn store(self: *Self, ptr: MCValue, value: MCValue, ptr_ty: Type, value_ty: Type
                         }).encode(),
                         .data = .{ .imm = 0 },
                     });
+                },
+                .stack_offset => {
+                    const tmp_reg = try self.copyToTmpRegister(value_ty, value);
+                    return self.store(ptr, .{ .register = tmp_reg }, ptr_ty, value_ty);
                 },
                 else => |other| {
                     return self.fail("TODO implement set pointee with {}", .{other});
@@ -2019,9 +2028,6 @@ fn store(self: *Self, ptr: MCValue, value: MCValue, ptr_ty: Type, value_ty: Type
                 },
                 else => return self.fail("TODO implement storing {} to MCValue.memory", .{value}),
             }
-        },
-        .stack_offset => {
-            return self.fail("TODO implement storing to MCValue.stack_offset", .{});
         },
     }
 }
@@ -2452,7 +2458,18 @@ fn genIMulOpMir(self: *Self, dst_ty: Type, dst_mcv: MCValue, src_mcv: MCValue) !
                         return self.genIMulOpMir(dst_ty, dst_mcv, MCValue{ .register = src_reg });
                     }
                 },
-                .embedded_in_code, .memory, .stack_offset => {
+                .stack_offset => |off| {
+                    _ = try self.addInst(.{
+                        .tag = .imul_complex,
+                        .ops = (Mir.Ops{
+                            .reg1 = dst_reg,
+                            .reg2 = .rbp,
+                            .flags = 0b01,
+                        }).encode(),
+                        .data = .{ .imm = @bitCast(u32, -off) },
+                    });
+                },
+                .embedded_in_code, .memory => {
                     return self.fail("TODO implement x86 multiply source memory", .{});
                 },
                 .got_load, .direct_load => {
@@ -3520,6 +3537,13 @@ fn genSetStackArg(self: *Self, ty: Type, stack_offset: i32, mcv: MCValue) InnerE
         .dead => unreachable,
         .ptr_embedded_in_code => unreachable,
         .unreach, .none => return,
+        .undef => {
+            if (abi_size <= 8) {
+                const reg = try self.copyToTmpRegister(ty, mcv);
+                return self.genSetStackArg(ty, stack_offset, MCValue{ .register = reg });
+            }
+            try self.genInlineMemset(stack_offset, .rsp, ty, .{ .immediate = 0xaa });
+        },
         .compare_flags_unsigned,
         .compare_flags_signed,
         => {
@@ -3598,7 +3622,6 @@ fn genSetStackArg(self: *Self, ty: Type, stack_offset: i32, mcv: MCValue) InnerE
 
             try self.genInlineMemcpy(stack_offset, .rsp, ty, mcv);
         },
-        else => return self.fail("TODO implement args on stack for {}", .{mcv}),
     }
 }
 
@@ -3617,7 +3640,7 @@ fn genSetStack(self: *Self, ty: Type, stack_offset: i32, mcv: MCValue) InnerErro
                 2 => return self.genSetStack(ty, stack_offset, .{ .immediate = 0xaaaa }),
                 4 => return self.genSetStack(ty, stack_offset, .{ .immediate = 0xaaaaaaaa }),
                 8 => return self.genSetStack(ty, stack_offset, .{ .immediate = 0xaaaaaaaaaaaaaaaa }),
-                else => return self.genInlineMemset(ty, stack_offset, .{ .immediate = 0xaa }),
+                else => return self.genInlineMemset(stack_offset, .rbp, ty, .{ .immediate = 0xaa }),
             }
         },
         .compare_flags_unsigned,
@@ -3943,12 +3966,20 @@ fn genInlineMemcpy(self: *Self, stack_offset: i32, stack_reg: Register, ty: Type
     try self.performReloc(loop_reloc);
 }
 
-fn genInlineMemset(self: *Self, ty: Type, stack_offset: i32, value: MCValue) InnerError!void {
+fn genInlineMemset(
+    self: *Self,
+    stack_offset: i32,
+    stack_register: Register,
+    ty: Type,
+    value: MCValue,
+) InnerError!void {
     try self.register_manager.getReg(.rax, null);
+
     const abi_size = ty.abiSize(self.target.*);
     if (stack_offset > 128) {
         return self.fail("TODO inline memset with large stack offset", .{});
     }
+
     const negative_offset = @bitCast(u32, -stack_offset);
 
     // We are actually counting `abi_size` bytes; however, we reuse the index register
@@ -4005,7 +4036,7 @@ fn genInlineMemset(self: *Self, ty: Type, stack_offset: i32, value: MCValue) Inn
             _ = try self.addInst(.{
                 .tag = .mov_mem_index_imm,
                 .ops = (Mir.Ops{
-                    .reg1 = .rbp,
+                    .reg1 = stack_register.to64(),
                 }).encode(),
                 .data = .{ .payload = payload },
             });
@@ -4731,20 +4762,40 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
             var next_int_reg: usize = 0;
             var by_reg = std.AutoHashMap(usize, usize).init(self.bin_file.allocator);
             defer by_reg.deinit();
-            for (param_types) |ty, i| {
-                if (!ty.hasRuntimeBits()) continue;
-                const param_size = @intCast(u32, ty.abiSize(self.target.*));
-                const pass_in_reg = switch (ty.zigTypeTag()) {
-                    .Bool => true,
-                    .Int, .Enum => param_size <= 8,
-                    .Pointer => ty.ptrSize() != .Slice,
-                    .Optional => ty.isPtrLikeOptional(),
-                    else => false,
-                };
-                if (pass_in_reg) {
-                    if (next_int_reg >= c_abi_int_param_regs.len) break;
-                    try by_reg.putNoClobber(i, next_int_reg);
-                    next_int_reg += 1;
+
+            // If we want debug output, we store all args on stack for better liveness of args
+            // in debugging contexts such as previewing the args in the debugger anywhere in
+            // the procedure. Passing the args via registers can lead to reusing the register
+            // for local ops thus clobbering the input arg forever.
+            // This of course excludes C ABI calls.
+            const omit_args_in_registers = blk: {
+                if (cc == .C) break :blk false;
+                switch (self.bin_file.options.optimize_mode) {
+                    .Debug => break :blk true,
+                    else => break :blk false,
+                }
+            };
+            if (!omit_args_in_registers) {
+                for (param_types) |ty, i| {
+                    if (!ty.hasRuntimeBits()) continue;
+                    const param_size = @intCast(u32, ty.abiSize(self.target.*));
+                    // For simplicity of codegen, slices and other types are always pushed onto the stack.
+                    // TODO: look into optimizing this by passing things as registers sometimes,
+                    // such as ptr and len of slices as separate registers.
+                    // TODO: also we need to honor the C ABI for relevant types rather than passing on
+                    // the stack here.
+                    const pass_in_reg = switch (ty.zigTypeTag()) {
+                        .Bool => true,
+                        .Int, .Enum => param_size <= 8,
+                        .Pointer => ty.ptrSize() != .Slice,
+                        .Optional => ty.isPtrLikeOptional(),
+                        else => false,
+                    };
+                    if (pass_in_reg) {
+                        if (next_int_reg >= c_abi_int_param_regs.len) break;
+                        try by_reg.putNoClobber(i, next_int_reg);
+                        next_int_reg += 1;
+                    }
                 }
             }
 
@@ -4765,11 +4816,6 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
                     result.args[i] = .{ .register = aliased_reg };
                     next_int_reg += 1;
                 } else {
-                    // For simplicity of codegen, slices and other types are always pushed onto the stack.
-                    // TODO: look into optimizing this by passing things as registers sometimes,
-                    // such as ptr and len of slices as separate registers.
-                    // TODO: also we need to honor the C ABI for relevant types rather than passing on
-                    // the stack here.
                     const offset = mem.alignForwardGeneric(u32, next_stack_offset + param_size, param_align);
                     result.args[i] = .{ .stack_offset = @intCast(i32, offset) };
                     next_stack_offset = offset;

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -153,7 +153,7 @@ test "void arrays" {
 
 test "nested arrays" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const array_of_strings = [_][]const u8{ "hello", "this", "is", "my", "thing" };
     for (array_of_strings) |s, i| {
@@ -525,8 +525,8 @@ test "zero-sized array with recursive type definition" {
 test "type coercion of anon struct literal to array" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
     const S = struct {
         const U = union {
@@ -543,8 +543,8 @@ test "type coercion of anon struct literal to array" {
             try expect(arr1[1] == 56);
             try expect(arr1[2] == 54);
 
-            if (@import("builtin").zig_backend == .stage2_llvm) return error.SkipZigTest; // TODO
-            if (@import("builtin").zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+            if (builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // TODO
+            if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
             var x2: U = .{ .a = 42 };
             const t2 = .{ x2, .{ .b = true }, .{ .c = "hello" } };

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -8,7 +8,6 @@ const expectEqual = testing.expectEqual;
 test "array to slice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const a: u32 align(4) = 3;
     const b: u32 align(8) = 4;
@@ -62,7 +61,7 @@ test "array init with mult" {
 
 test "array literal with explicit type" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const hex_mult: [4]u16 = .{ 4096, 256, 16, 1 };
 
@@ -71,7 +70,7 @@ test "array literal with explicit type" {
 }
 
 test "array literal with inferred length" {
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const hex_mult = [_]u16{ 4096, 256, 16, 1 };
 
@@ -92,7 +91,7 @@ const some_array = [_]u8{ 0, 1, 2, 3 };
 
 test "array literal with specified size" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     var array = [2]u8{ 1, 2 };
     try expect(array[0] == 1);
@@ -101,7 +100,7 @@ test "array literal with specified size" {
 
 test "array len field" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     var arr = [4]u8{ 0, 0, 0, 0 };
     var ptr = &arr;
@@ -143,7 +142,7 @@ test "array with sentinels" {
 
 test "void arrays" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     var array: [4]void = undefined;
     array[0] = void{};
@@ -222,7 +221,7 @@ test "implicit cast zero sized array ptr to slice" {
 
 test "anonymous list literal syntax" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64 or builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {
@@ -282,7 +281,6 @@ test "read/write through global variable array of struct fields initialized via 
 test "implicit cast single-item pointer" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     try testImplicitCastSingleItemPtr();
@@ -303,7 +301,6 @@ fn testArrayByValAtComptime(b: [2]u8) u8 {
 test "comptime evaluating function that takes array by value" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     const arr = [_]u8{ 1, 2 };
@@ -316,7 +313,6 @@ test "comptime evaluating function that takes array by value" {
 test "runtime initialize array elem and then implicit cast to slice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     var two: i32 = 2;
@@ -327,7 +323,6 @@ test "runtime initialize array elem and then implicit cast to slice" {
 test "array literal as argument to function" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     const S = struct {
@@ -418,7 +413,6 @@ test "double nested array to const slice cast in array literal" {
 test "anonymous literal in array" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     const S = struct {
@@ -444,7 +438,6 @@ test "anonymous literal in array" {
 test "access the null element of a null terminated array" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     const S = struct {
@@ -462,7 +455,6 @@ test "access the null element of a null terminated array" {
 test "type deduction for array subscript expression" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     const S = struct {

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -261,7 +261,6 @@ fn sliceFromLenToLen(a_slice: []u8, start: usize, end: usize) []u8 {
 test "C pointer" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     var buf: [*c]const u8 = "kjdhfkjdhfdkjhfkfjhdfkjdhfkdjhfdkjhf";
     var len: u32 = 10;
@@ -302,7 +301,6 @@ fn sliceSum(comptime q: []const u8) i32 {
 test "slice type with custom alignment" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const LazilyResolvedType = struct {
         anything: i32,
@@ -317,7 +315,6 @@ test "slice type with custom alignment" {
 test "obtaining a null terminated slice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
     // here we have a normal array


### PR DESCRIPTION
If the function call is not extern and we are compiling in debug,
pass function params always on stack. This will improve debugging
capabilities since the params will not be volatile and possibly
clobbered by the procedure code.