### PR TITLE
stage2: support anon init through error unions and optionals

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -429,6 +429,9 @@ pub const Inst = struct {
         /// *(E!T) -> E. If the value is not an error, undefined behavior.
         /// Uses the `ty_op` field.
         unwrap_errunion_err_ptr,
+        /// *(E!T) => *T. Sets the value to non-error with an undefined payload value.
+        /// Uses the `ty_op` field.
+        errunion_payload_ptr_set,
         /// wrap from T to E!T
         /// Uses the `ty_op` field.
         wrap_errunion_payload,
@@ -865,6 +868,7 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .optional_payload,
         .optional_payload_ptr,
         .optional_payload_ptr_set,
+        .errunion_payload_ptr_set,
         .wrap_optional,
         .unwrap_errunion_payload,
         .unwrap_errunion_err,

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -293,6 +293,7 @@ fn analyzeInst(
         .optional_payload,
         .optional_payload_ptr,
         .optional_payload_ptr_set,
+        .errunion_payload_ptr_set,
         .wrap_optional,
         .unwrap_errunion_payload,
         .unwrap_errunion_err,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1636,7 +1636,13 @@ fn zirCoerceResultPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileE
                 return sema.fail(block, src, "TODO coerce_result_ptr wrap_errunion_err", .{});
             },
             .wrap_errunion_payload => {
-                return sema.fail(block, src, "TODO coerce_result_ptr wrap_errunion_payload", .{});
+                const ty_op = air_datas[trash_inst].ty_op;
+                const payload_ty = sema.getTmpAir().typeOf(ty_op.operand);
+                const ptr_payload_ty = try Type.ptr(sema.arena, .{
+                    .pointee_type = payload_ty,
+                    .@"addrspace" = addr_space,
+                });
+                new_ptr = try block.addTyOp(.errunion_payload_ptr_set, ptr_payload_ty, new_ptr);
             },
             else => {
                 if (std.debug.runtime_safety) {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -739,6 +739,8 @@ fn analyzeBodyInner(
             .@"await"                     => try sema.zirAwait(block, inst, false),
             .await_nosuspend              => try sema.zirAwait(block, inst, true),
             .extended                     => try sema.zirExtended(block, inst),
+            .array_base_ptr               => try sema.zirArrayBasePtr(block, inst),
+            .field_base_ptr               => try sema.zirFieldBasePtr(block, inst),
 
             .clz       => try sema.zirBitCount(block, inst, .clz,      Value.clz),
             .ctz       => try sema.zirBitCount(block, inst, .ctz,      Value.ctz),
@@ -2584,6 +2586,59 @@ fn zirResolveInferredAlloc(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Com
     }
 }
 
+fn zirArrayBasePtr(
+    sema: *Sema,
+    block: *Block,
+    inst: Zir.Inst.Index,
+) CompileError!Air.Inst.Ref {
+    const inst_data = sema.code.instructions.items(.data)[inst].un_node;
+    const src = inst_data.src();
+
+    const start_ptr = sema.resolveInst(inst_data.operand);
+    var base_ptr = start_ptr;
+    while (true) switch (sema.typeOf(base_ptr).childType().zigTypeTag()) {
+        .ErrorUnion => base_ptr = try sema.analyzeErrUnionPayloadPtr(block, src, base_ptr, false),
+        .Optional => base_ptr = try sema.analyzeOptionalPayloadPtr(block, src, base_ptr, false),
+        else => break,
+    };
+
+    const elem_ty = sema.typeOf(base_ptr).childType();
+    switch (elem_ty.zigTypeTag()) {
+        .Array, .Vector => return base_ptr,
+        .Struct => if (elem_ty.isTuple()) return base_ptr,
+        else => {},
+    }
+    return sema.fail(block, src, "type '{}' does not support array initialization syntax", .{
+        sema.typeOf(start_ptr).childType(),
+    });
+}
+
+fn zirFieldBasePtr(
+    sema: *Sema,
+    block: *Block,
+    inst: Zir.Inst.Index,
+) CompileError!Air.Inst.Ref {
+    const inst_data = sema.code.instructions.items(.data)[inst].un_node;
+    const src = inst_data.src();
+
+    const start_ptr = sema.resolveInst(inst_data.operand);
+    var base_ptr = start_ptr;
+    while (true) switch (sema.typeOf(base_ptr).childType().zigTypeTag()) {
+        .ErrorUnion => base_ptr = try sema.analyzeErrUnionPayloadPtr(block, src, base_ptr, false),
+        .Optional => base_ptr = try sema.analyzeOptionalPayloadPtr(block, src, base_ptr, false),
+        else => break,
+    };
+
+    const elem_ty = sema.typeOf(base_ptr).childType();
+    switch (elem_ty.zigTypeTag()) {
+        .Struct, .Union => return base_ptr,
+        else => {},
+    }
+    return sema.fail(block, src, "type '{}' does not support struct initialization syntax", .{
+        sema.typeOf(start_ptr).childType(),
+    });
+}
+
 fn zirValidateStructInit(
     sema: *Sema,
     block: *Block,
@@ -4377,7 +4432,9 @@ fn analyzeCall(
                 if (payload.data.error_set.tag() == .error_set_inferred) {
                     const node = try sema.gpa.create(Module.Fn.InferredErrorSetListNode);
                     node.data = .{ .func = module_fn };
-                    parent_func.?.inferred_error_sets.prepend(node);
+                    if (parent_func) |some| {
+                        some.inferred_error_sets.prepend(node);
+                    }
 
                     const error_set_ty = try Type.Tag.error_set_inferred.create(sema.arena, &node.data);
                     break :blk try Type.Tag.error_union.create(sema.arena, .{
@@ -5198,9 +5255,20 @@ fn zirOptionalPayloadPtr(
 
     const inst_data = sema.code.instructions.items(.data)[inst].un_node;
     const optional_ptr = sema.resolveInst(inst_data.operand);
+    const src = inst_data.src();
+
+    return sema.analyzeOptionalPayloadPtr(block, src, optional_ptr, safety_check);
+}
+
+fn analyzeOptionalPayloadPtr(
+    sema: *Sema,
+    block: *Block,
+    src: LazySrcLoc,
+    optional_ptr: Air.Inst.Ref,
+    safety_check: bool,
+) CompileError!Air.Inst.Ref {
     const optional_ptr_ty = sema.typeOf(optional_ptr);
     assert(optional_ptr_ty.zigTypeTag() == .Pointer);
-    const src = inst_data.src();
 
     const opt_type = optional_ptr_ty.elemType();
     if (opt_type.zigTypeTag() != .Optional) {
@@ -5216,8 +5284,10 @@ fn zirOptionalPayloadPtr(
 
     if (try sema.resolveDefinedValue(block, src, optional_ptr)) |pointer_val| {
         if (try sema.pointerDeref(block, src, pointer_val, optional_ptr_ty)) |val| {
-            if (val.isNull()) {
-                return sema.fail(block, src, "unable to unwrap null", .{});
+            if (safety_check) {
+                if (val.isNull()) {
+                    return sema.fail(block, src, "unable to unwrap null", .{});
+                }
             }
             // The same Value represents the pointer to the optional and the payload.
             return sema.addConstant(
@@ -5333,8 +5403,19 @@ fn zirErrUnionPayloadPtr(
     defer tracy.end();
 
     const inst_data = sema.code.instructions.items(.data)[inst].un_node;
-    const src = inst_data.src();
     const operand = sema.resolveInst(inst_data.operand);
+    const src = inst_data.src();
+
+    return sema.analyzeErrUnionPayloadPtr(block, src, operand, safety_check);
+}
+
+fn analyzeErrUnionPayloadPtr(
+    sema: *Sema,
+    block: *Block,
+    src: LazySrcLoc,
+    operand: Air.Inst.Ref,
+    safety_check: bool,
+) CompileError!Air.Inst.Ref {
     const operand_ty = sema.typeOf(operand);
     assert(operand_ty.zigTypeTag() == .Pointer);
 
@@ -5350,9 +5431,12 @@ fn zirErrUnionPayloadPtr(
 
     if (try sema.resolveDefinedValue(block, src, operand)) |pointer_val| {
         if (try sema.pointerDeref(block, src, pointer_val, operand_ty)) |val| {
-            if (val.getError()) |name| {
-                return sema.fail(block, src, "caught unexpected error '{s}'", .{name});
+            if (safety_check) {
+                if (val.getError()) |name| {
+                    return sema.fail(block, src, "caught unexpected error '{s}'", .{name});
+                }
             }
+
             return sema.addConstant(
                 operand_pointer_ty,
                 try Value.Tag.eu_payload_ptr.create(sema.arena, pointer_val),
@@ -12859,7 +12943,7 @@ fn zirCUndef(
     extended: Zir.Inst.Extended.InstData,
 ) CompileError!Air.Inst.Ref {
     const extra = sema.code.extraData(Zir.Inst.UnNode, extended.operand).data;
-    const src: LazySrcLoc = .{ .node_offset = extra.node };
+    const src: LazySrcLoc = .{ .node_offset_builtin_call_arg0 = extra.node };
 
     const name = try sema.resolveConstString(block, src, extra.operand);
     try block.c_import_buf.?.writer().print("#undefine {s}\n", .{name});
@@ -12872,7 +12956,7 @@ fn zirCInclude(
     extended: Zir.Inst.Extended.InstData,
 ) CompileError!Air.Inst.Ref {
     const extra = sema.code.extraData(Zir.Inst.UnNode, extended.operand).data;
-    const src: LazySrcLoc = .{ .node_offset = extra.node };
+    const src: LazySrcLoc = .{ .node_offset_builtin_call_arg0 = extra.node };
 
     const name = try sema.resolveConstString(block, src, extra.operand);
     try block.c_import_buf.?.writer().print("#include <{s}>\n", .{name});
@@ -12885,12 +12969,13 @@ fn zirCDefine(
     extended: Zir.Inst.Extended.InstData,
 ) CompileError!Air.Inst.Ref {
     const extra = sema.code.extraData(Zir.Inst.BinNode, extended.operand).data;
-    const src: LazySrcLoc = .{ .node_offset = extra.node };
+    const name_src: LazySrcLoc = .{ .node_offset_builtin_call_arg0 = extra.node };
+    const val_src: LazySrcLoc = .{ .node_offset_builtin_call_arg1 = extra.node };
 
-    const name = try sema.resolveConstString(block, src, extra.lhs);
+    const name = try sema.resolveConstString(block, name_src, extra.lhs);
     const rhs = sema.resolveInst(extra.rhs);
     if (sema.typeOf(rhs).zigTypeTag() != .Void) {
-        const value = try sema.resolveConstString(block, src, extra.rhs);
+        const value = try sema.resolveConstString(block, val_src, extra.rhs);
         try block.c_import_buf.?.writer().print("#define {s} {s}\n", .{ name, value });
     } else {
         try block.c_import_buf.?.writer().print("#define {s}\n", .{name});

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -655,6 +655,12 @@ pub const Inst = struct {
         ///   *?S returns *S
         /// Uses the `un_node` field.
         field_base_ptr,
+        /// Checks that the type supports array init syntax.
+        /// Uses the `un_node` field.
+        validate_array_init_ty,
+        /// Checks that the type supports struct init syntax.
+        /// Uses the `un_node` field.
+        validate_struct_init_ty,
         /// Given a set of `field_ptr` instructions, assumes they are all part of a struct
         /// initialization expression, and emits compile errors for duplicate fields
         /// as well as missing fields, if applicable.
@@ -1101,6 +1107,8 @@ pub const Inst = struct {
                 .switch_cond_ref,
                 .array_base_ptr,
                 .field_base_ptr,
+                .validate_array_init_ty,
+                .validate_struct_init_ty,
                 .validate_struct_init,
                 .validate_struct_init_comptime,
                 .validate_array_init,
@@ -1356,6 +1364,8 @@ pub const Inst = struct {
                 .switch_capture_multi_ref = .switch_capture,
                 .array_base_ptr = .un_node,
                 .field_base_ptr = .un_node,
+                .validate_array_init_ty = .un_node,
+                .validate_struct_init_ty = .un_node,
                 .validate_struct_init = .pl_node,
                 .validate_struct_init_comptime = .pl_node,
                 .validate_array_init = .pl_node,

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -643,6 +643,18 @@ pub const Inst = struct {
         /// Result is a pointer to the value.
         /// Uses the `switch_capture` field.
         switch_capture_multi_ref,
+        /// Given a
+        ///   *A returns *A
+        ///   *E!A returns *A
+        ///   *?A returns *A
+        /// Uses the `un_node` field.
+        array_base_ptr,
+        /// Given a
+        ///   *S returns *S
+        ///   *E!S returns *S
+        ///   *?S returns *S
+        /// Uses the `un_node` field.
+        field_base_ptr,
         /// Given a set of `field_ptr` instructions, assumes they are all part of a struct
         /// initialization expression, and emits compile errors for duplicate fields
         /// as well as missing fields, if applicable.
@@ -1087,6 +1099,8 @@ pub const Inst = struct {
                 .switch_block,
                 .switch_cond,
                 .switch_cond_ref,
+                .array_base_ptr,
+                .field_base_ptr,
                 .validate_struct_init,
                 .validate_struct_init_comptime,
                 .validate_array_init,
@@ -1340,6 +1354,8 @@ pub const Inst = struct {
                 .switch_capture_ref = .switch_capture,
                 .switch_capture_multi = .switch_capture,
                 .switch_capture_multi_ref = .switch_capture,
+                .array_base_ptr = .un_node,
+                .field_base_ptr = .un_node,
                 .validate_struct_init = .pl_node,
                 .validate_struct_init_comptime = .pl_node,
                 .validate_array_init = .pl_node,

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -662,6 +662,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .unwrap_errunion_payload    => try self.airUnwrapErrPayload(inst),
             .unwrap_errunion_err_ptr    => try self.airUnwrapErrErrPtr(inst),
             .unwrap_errunion_payload_ptr=> try self.airUnwrapErrPayloadPtr(inst),
+            .errunion_payload_ptr_set   => try self.airErrUnionPayloadPtrSet(inst),
 
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
@@ -1440,6 +1441,12 @@ fn airUnwrapErrErrPtr(self: *Self, inst: Air.Inst.Index) !void {
 fn airUnwrapErrPayloadPtr(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement unwrap error union payload ptr for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement .errunion_payload_ptr_set for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -646,6 +646,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .unwrap_errunion_payload    => try self.airUnwrapErrPayload(inst),
             .unwrap_errunion_err_ptr    => try self.airUnwrapErrErrPtr(inst),
             .unwrap_errunion_payload_ptr=> try self.airUnwrapErrPayloadPtr(inst),
+            .errunion_payload_ptr_set   => try self.airErrUnionPayloadPtrSet(inst),
 
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
@@ -1125,6 +1126,12 @@ fn airUnwrapErrErrPtr(self: *Self, inst: Air.Inst.Index) !void {
 fn airUnwrapErrPayloadPtr(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement unwrap error union payload ptr for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement .errunion_payload_ptr_set for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -633,6 +633,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .unwrap_errunion_payload    => try self.airUnwrapErrPayload(inst),
             .unwrap_errunion_err_ptr    => try self.airUnwrapErrErrPtr(inst),
             .unwrap_errunion_payload_ptr=> try self.airUnwrapErrPayloadPtr(inst),
+            .errunion_payload_ptr_set   => try self.airErrUnionPayloadPtrSet(inst),
 
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
@@ -1062,6 +1063,12 @@ fn airUnwrapErrErrPtr(self: *Self, inst: Air.Inst.Index) !void {
 fn airUnwrapErrPayloadPtr(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement unwrap error union payload ptr for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement .errunion_payload_ptr_set for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1725,6 +1725,7 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .atomic_rmw,
         .tag_name,
         .error_name,
+        .errunion_payload_ptr_set,
 
         // For these 4, probably best to wait until https://github.com/ziglang/zig/issues/10248
         // is implemented in the frontend before implementing them here in the wasm backend.

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -727,6 +727,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .unwrap_errunion_payload    => try self.airUnwrapErrPayload(inst),
             .unwrap_errunion_err_ptr    => try self.airUnwrapErrErrPtr(inst),
             .unwrap_errunion_payload_ptr=> try self.airUnwrapErrPayloadPtr(inst),
+            .errunion_payload_ptr_set   => try self.airErrUnionPayloadPtrSet(inst),
 
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
@@ -1403,6 +1404,15 @@ fn airUnwrapErrPayloadPtr(self: *Self, inst: Air.Inst.Index) !void {
         .dead
     else
         return self.fail("TODO implement unwrap error union payload ptr for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement .errunion_payload_ptr_set for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1753,6 +1753,7 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .unwrap_errunion_err_ptr     => try airUnwrapErrUnionErr(f, inst),
             .wrap_errunion_payload       => try airWrapErrUnionPay(f, inst),
             .wrap_errunion_err           => try airWrapErrUnionErr(f, inst),
+            .errunion_payload_ptr_set    => try airErrUnionPayloadPtrSet(f, inst),
             // zig fmt: on
         };
         switch (result_value) {
@@ -3164,6 +3165,7 @@ fn airWrapOptional(f: *Function, inst: Air.Inst.Index) !CValue {
     try writer.writeAll("};\n");
     return local;
 }
+
 fn airWrapErrUnionErr(f: *Function, inst: Air.Inst.Index) !CValue {
     if (f.liveness.isUnused(inst)) return CValue.none;
 
@@ -3181,6 +3183,11 @@ fn airWrapErrUnionErr(f: *Function, inst: Air.Inst.Index) !CValue {
     try f.writeCValue(writer, operand);
     try writer.writeAll(" };\n");
     return local;
+}
+
+fn airErrUnionPayloadPtrSet(f: *Function, inst: Air.Inst.Index) !CValue {
+    _ = inst;
+    return f.fail("TODO: C backend: implement airErrUnionPayloadPtrSet", .{});
 }
 
 fn airWrapErrUnionPay(f: *Function, inst: Air.Inst.Index) !CValue {

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -189,6 +189,7 @@ const Writer = struct {
             .optional_payload,
             .optional_payload_ptr,
             .optional_payload_ptr_set,
+            .errunion_payload_ptr_set,
             .wrap_optional,
             .unwrap_errunion_payload,
             .unwrap_errunion_err,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -237,6 +237,8 @@ const Writer = struct {
             .switch_cond_ref,
             .array_base_ptr,
             .field_base_ptr,
+            .validate_array_init_ty,
+            .validate_struct_init_ty,
             => try self.writeUnNode(stream, inst),
 
             .ref,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -235,6 +235,8 @@ const Writer = struct {
             .fence,
             .switch_cond,
             .switch_cond_ref,
+            .array_base_ptr,
+            .field_base_ptr,
             => try self.writeUnNode(stream, inst),
 
             .ref,

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -118,6 +118,7 @@ test {
                 _ = @import("behavior/sizeof_and_typeof.zig");
                 _ = @import("behavior/switch.zig");
                 _ = @import("behavior/widening.zig");
+                _ = @import("behavior/bugs/1442.zig");
 
                 if (builtin.zig_backend == .stage1) {
                     // Tests that only pass for the stage1 backend.
@@ -134,7 +135,6 @@ test {
                     _ = @import("behavior/bugs/920.zig");
                     _ = @import("behavior/bugs/1120.zig");
                     _ = @import("behavior/bugs/1421.zig");
-                    _ = @import("behavior/bugs/1442.zig");
                     _ = @import("behavior/bugs/1607.zig");
                     _ = @import("behavior/bugs/1851.zig");
                     _ = @import("behavior/bugs/2114.zig");

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1199,3 +1199,64 @@ test "for loop over pointers to struct, getting field from struct pointer" {
     };
     try S.doTheTest();
 }
+
+test "anon init through error unions and optionals" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    if (true) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        a: u32,
+
+        fn foo() anyerror!?anyerror!@This() {
+            return @This(){ .a = 1 };
+        }
+        fn bar() ?anyerror![2]u8 {
+            return [2]u8{ 1, 2 };
+        }
+
+        fn doTheTest() !void {
+            var a = ((foo() catch unreachable).?) catch unreachable;
+            var b = (bar().?) catch unreachable;
+            try expect(a.a + b[1] == 3);
+        }
+    };
+
+    try S.doTheTest();
+    comptime try S.doTheTest();
+}
+
+test "anon init through optional" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    // not sure why this is needed, we only do the test at comptime
+    if (builtin.zig_backend != .stage2_llvm) return error.SkipZigTest;
+
+    const S = struct {
+        a: u32,
+
+        fn doTheTest() !void {
+            var s: ?@This() = null;
+            s = .{ .a = 1 };
+            try expect(s.?.a == 1);
+        }
+    };
+    // try S.doTheTest(); // TODO
+    comptime try S.doTheTest();
+}
+
+test "anon init through error union" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    // not sure why this is needed, we only do the test at comptime
+    if (builtin.zig_backend != .stage2_llvm) return error.SkipZigTest;
+
+    const S = struct {
+        a: u32,
+
+        fn doTheTest() !void {
+            var s: anyerror!@This() = error.Foo;
+            s = .{ .a = 1 };
+            try expect((try s).a == 1);
+        }
+    };
+    // try S.doTheTest(); // TODO
+    comptime try S.doTheTest();
+}

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1202,33 +1202,32 @@ test "for loop over pointers to struct, getting field from struct pointer" {
 
 test "anon init through error unions and optionals" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-    if (true) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend != .stage2_llvm) return error.SkipZigTest; // TODO
 
     const S = struct {
         a: u32,
 
         fn foo() anyerror!?anyerror!@This() {
-            return @This(){ .a = 1 };
+            return .{ .a = 1 };
         }
         fn bar() ?anyerror![2]u8 {
-            return [2]u8{ 1, 2 };
+            return .{ 1, 2 };
         }
 
         fn doTheTest() !void {
-            var a = ((foo() catch unreachable).?) catch unreachable;
-            var b = (bar().?) catch unreachable;
+            var a = try (try foo()).?;
+            var b = try bar().?;
             try expect(a.a + b[1] == 3);
         }
     };
 
     try S.doTheTest();
-    comptime try S.doTheTest();
+    // comptime try S.doTheTest(); // TODO
 }
 
 test "anon init through optional" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-    // not sure why this is needed, we only do the test at comptime
-    if (builtin.zig_backend != .stage2_llvm) return error.SkipZigTest;
+    if (builtin.zig_backend != .stage2_llvm) return error.SkipZigTest; // TODO
 
     const S = struct {
         a: u32,
@@ -1239,14 +1238,14 @@ test "anon init through optional" {
             try expect(s.?.a == 1);
         }
     };
-    // try S.doTheTest(); // TODO
+
+    try S.doTheTest();
     comptime try S.doTheTest();
 }
 
 test "anon init through error union" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-    // not sure why this is needed, we only do the test at comptime
-    if (builtin.zig_backend != .stage2_llvm) return error.SkipZigTest;
+    if (builtin.zig_backend != .stage2_llvm) return error.SkipZigTest; // TODO
 
     const S = struct {
         a: u32,
@@ -1257,6 +1256,7 @@ test "anon init through error union" {
             try expect((try s).a == 1);
         }
     };
-    // try S.doTheTest(); // TODO
+
+    try S.doTheTest();
     comptime try S.doTheTest();
 }

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1222,7 +1222,7 @@ test "anon init through error unions and optionals" {
     };
 
     try S.doTheTest();
-    // comptime try S.doTheTest(); // TODO
+    comptime try S.doTheTest();
 }
 
 test "anon init through optional" {


### PR DESCRIPTION
~~No idea if this actually works since I can't get LLVM to work with stage2.~~ Keep forgetting I can use stage1 with `-fno-stage1`.