### PR TITLE
stage2,x64: implement integer division

### DIFF
--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -220,8 +220,11 @@ pub const Inst = struct {
         sar_mem_index_imm,
 
         /// ops flags: form:
-        ///      0bX0  reg1
-        ///      0bX1  [reg1 + imm32]
+        ///      0b00  reg1
+        ///      0b00  byte ptr [reg2 + imm32]
+        ///      0b01  word ptr [reg2 + imm32]
+        ///      0b10  dword ptr [reg2 + imm32]
+        ///      0b11  qword ptr [reg2 + imm32]
         imul,
         idiv,
 

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -227,6 +227,7 @@ pub const Inst = struct {
         ///      0b11  qword ptr [reg2 + imm32]
         imul,
         idiv,
+        div,
 
         /// ops flags: form:
         ///      0b00  AX      <- AL

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -286,6 +286,13 @@ pub const Inst = struct {
         cond_jmp_eq_ne,
         cond_set_byte_eq_ne,
 
+        /// ops flags:
+        ///     0b00 reg1, reg2,
+        ///     0b01 reg1, word ptr  [reg2 + imm]
+        ///     0b10 reg1, dword ptr [reg2 + imm]
+        ///     0b11 reg1, qword ptr [reg2 + imm]
+        cond_mov_eq,
+
         /// ops flags:  form:
         ///       0b00   reg1
         ///       0b01   [reg1 + imm32]

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -228,6 +228,13 @@ pub const Inst = struct {
         imul,
         idiv,
 
+        /// ops flags: form:
+        ///      0b00  AX      <- AL
+        ///      0b01  DX:AX   <- AX
+        ///      0b10  EDX:EAX <- EAX
+        ///      0b11  RDX:RAX <- RAX
+        cwd,
+
         /// ops flags:  form:
         ///      0b00  reg1, reg2
         ///      0b01  reg1, [reg2 + imm32]

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -50,6 +50,7 @@ test {
     _ = @import("behavior/tuple.zig");
     _ = @import("behavior/type.zig");
     _ = @import("behavior/var_args.zig");
+    _ = @import("behavior/int_div.zig");
 
     // tests that don't pass for stage1
     if (builtin.zig_backend != .stage1) {

--- a/test/behavior/int_div.zig
+++ b/test/behavior/int_div.zig
@@ -1,0 +1,93 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const expect = std.testing.expect;
+
+test "integer division" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
+    try testDivision();
+    comptime try testDivision();
+}
+fn testDivision() !void {
+    try expect(div(u32, 13, 3) == 4);
+    try expect(div(u64, 13, 3) == 4);
+    try expect(div(u8, 13, 3) == 4);
+
+    try expect(divExact(u32, 55, 11) == 5);
+    try expect(divExact(i32, -55, 11) == -5);
+    try expect(divExact(i64, -55, 11) == -5);
+    try expect(divExact(i16, -55, 11) == -5);
+
+    try expect(divFloor(i8, 5, 3) == 1);
+    try expect(divFloor(i16, -5, 3) == -2);
+    try expect(divFloor(i64, -0x80000000, -2) == 0x40000000);
+    try expect(divFloor(i32, 0, -0x80000000) == 0);
+    try expect(divFloor(i64, -0x40000001, 0x40000000) == -2);
+    try expect(divFloor(i32, -0x80000000, 1) == -0x80000000);
+    try expect(divFloor(i32, 10, 12) == 0);
+    try expect(divFloor(i32, -14, 12) == -2);
+    try expect(divFloor(i32, -2, 12) == -1);
+
+    try expect(divTrunc(i32, 5, 3) == 1);
+    try expect(divTrunc(i32, -5, 3) == -1);
+    try expect(divTrunc(i32, 9, -10) == 0);
+    try expect(divTrunc(i32, -9, 10) == 0);
+    try expect(divTrunc(i32, 10, 12) == 0);
+    try expect(divTrunc(i32, -14, 12) == -1);
+    try expect(divTrunc(i32, -2, 12) == 0);
+
+    try expect(mod(u32, 10, 12) == 10);
+    try expect(mod(i32, 10, 12) == 10);
+    try expect(mod(i64, -14, 12) == 10);
+    try expect(mod(i16, -2, 12) == 10);
+    try expect(mod(i8, -2, 12) == 10);
+
+    try expect(rem(i32, 10, 12) == 10);
+    try expect(rem(i32, -14, 12) == -2);
+    try expect(rem(i32, -2, 12) == -2);
+
+    comptime {
+        try expect(
+            1194735857077236777412821811143690633098347576 % 508740759824825164163191790951174292733114988 == 177254337427586449086438229241342047632117600,
+        );
+        try expect(
+            @rem(-1194735857077236777412821811143690633098347576, 508740759824825164163191790951174292733114988) == -177254337427586449086438229241342047632117600,
+        );
+        try expect(
+            1194735857077236777412821811143690633098347576 / 508740759824825164163191790951174292733114988 == 2,
+        );
+        try expect(
+            @divTrunc(-1194735857077236777412821811143690633098347576, 508740759824825164163191790951174292733114988) == -2,
+        );
+        try expect(
+            @divTrunc(1194735857077236777412821811143690633098347576, -508740759824825164163191790951174292733114988) == -2,
+        );
+        try expect(
+            @divTrunc(-1194735857077236777412821811143690633098347576, -508740759824825164163191790951174292733114988) == 2,
+        );
+        try expect(
+            4126227191251978491697987544882340798050766755606969681711 % 10 == 1,
+        );
+    }
+}
+fn div(comptime T: type, a: T, b: T) T {
+    return a / b;
+}
+fn divExact(comptime T: type, a: T, b: T) T {
+    return @divExact(a, b);
+}
+fn divFloor(comptime T: type, a: T, b: T) T {
+    return @divFloor(a, b);
+}
+fn divTrunc(comptime T: type, a: T, b: T) T {
+    return @divTrunc(a, b);
+}
+fn mod(comptime T: type, a: T, b: T) T {
+    return @mod(a, b);
+}
+fn rem(comptime T: type, a: T, b: T) T {
+    return @rem(a, b);
+}


### PR DESCRIPTION
* add lowering for single operand `imul` and `idiv`
* implement `div_exact` for signed and unsigned integers
* add unsigned `div`
* implement the rest of builtins for integers: `div_trunc`, `div_floor`, `mod`, and `rem`
* pull out integer division tests into a standalone test unit