### PR TITLE
added 'negation' and 'mulitply by i' for complex numbers

### DIFF
--- a/lib/std/math/complex.zig
+++ b/lib/std/math/complex.zig
@@ -166,7 +166,7 @@ test "complex.neg" {
     const a = Complex(f32).init(5, 3);
     const c = a.neg();
 
-    try testing.expect(c.re == -5 and c.im == 3);
+    try testing.expect(c.re == -5 and c.im == -3);
 }
 
 test "complex.mulbyi" {

--- a/lib/std/math/complex.zig
+++ b/lib/std/math/complex.zig
@@ -103,7 +103,7 @@ pub fn Complex(comptime T: type) type {
                 .im = self.re,
             };
         }
-        
+
         /// Returns the reciprocal of a complex number.
         pub fn reciprocal(self: Self) Self {
             const m = self.re * self.re + self.im * self.im;
@@ -117,7 +117,6 @@ pub fn Complex(comptime T: type) type {
         pub fn magnitude(self: Self) T {
             return math.sqrt(self.re * self.re + self.im * self.im);
         }
-
     };
 }
 
@@ -161,6 +160,20 @@ test "complex.conjugate" {
     const c = a.conjugate();
 
     try testing.expect(c.re == 5 and c.im == -3);
+}
+
+test "complex.neg" {
+    const a = Complex(f32).init(5, 3);
+    const c = a.neg();
+
+    try testing.expect(c.re == -5 and c.im == 3);
+}
+
+test "complex.mulbyi" {
+    const a = Complex(f32).init(5, 3);
+    const c = a.mulbyi();
+
+    try testing.expect(c.re == -3 and c.im == 5);
 }
 
 test "complex.reciprocal" {

--- a/lib/std/math/complex.zig
+++ b/lib/std/math/complex.zig
@@ -88,6 +88,22 @@ pub fn Complex(comptime T: type) type {
             };
         }
 
+        /// Returns the negation of a complex number.
+        pub fn neg(self: Self) Self {
+            return Self{
+                .re = -self.re,
+                .im = -self.im,
+            };
+        }
+
+        /// Returns the product of complex number and i=sqrt(-1)
+        pub fn mulbyi(self: Self) Self {
+            return Self{
+                .re = -self.im,
+                .im = self.re,
+            };
+        }
+        
         /// Returns the reciprocal of a complex number.
         pub fn reciprocal(self: Self) Self {
             const m = self.re * self.re + self.im * self.im;
@@ -101,6 +117,7 @@ pub fn Complex(comptime T: type) type {
         pub fn magnitude(self: Self) T {
             return math.sqrt(self.re * self.re + self.im * self.im);
         }
+
     };
 }
 


### PR DESCRIPTION
Added methods to the complex number structure:

1) negation - simply negate the real part, and negate the imaginary part.  This is needed for stringing together mathematical operations without invoking a complex multiply (which may be costly).

2) mulbyi - multiplies a complex number by i=sqrt(-1).  BUT, this is done without invoking a complex multiply (which may be costly with its 4 required operations).  Effectively, this "rotates" any number on the complex plane by 90 degrees.  The operation is found often (such as in FFT routines).  Can be common in inner loops.  

NOTE A: I think that the name "mulbyi" is not optimal, but other names I had considered (muli, rot90, imul, imult) all were a bit underwhelming.

NOTE B: It understood that one may create their own complex struct and implement these additions themselves... but splintering off the standard complex struct for these basic, and useful mathematical operations is not attractive.
