### PR TITLE
stage2: C backend: fix codegen for field_ptr/elem_ptr values

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -464,7 +464,7 @@ pub const DeclGen = struct {
                     .variable => ptr_val.castTag(.variable).?.data.owner_decl,
                     else => unreachable,
                 };
-                try dg.renderDeclValue(writer, decl.ty, ptr_val, decl);
+                try dg.renderDeclName(decl, writer);
                 return decl.ty;
             },
             .field_ptr => {
@@ -490,7 +490,7 @@ pub const DeclGen = struct {
             },
             .elem_ptr => {
                 const elem_ptr = ptr_val.castTag(.elem_ptr).?.data;
-                try writer.writeAll("&(*");
+                try writer.writeAll("&(");
                 const container_ty = try dg.renderChildPtr(writer, elem_ptr.array_ptr);
                 try writer.print(")[{d}]", .{elem_ptr.index});
                 return container_ty.childType();

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -389,19 +389,19 @@ pub const DeclGen = struct {
             // Determine if we must pointer cast.
             if (ty.eql(decl.ty)) {
                 try writer.writeByte('&');
-                try dg.renderDeclName(decl, writer);
+                try dg.renderDeclName(writer, decl);
                 return;
             }
 
             try writer.writeAll("((");
             try dg.renderTypecast(writer, ty);
             try writer.writeAll(")&");
-            try dg.renderDeclName(decl, writer);
+            try dg.renderDeclName(writer, decl);
             try writer.writeByte(')');
             return;
         }
 
-        try dg.renderDeclName(decl, writer);
+        try dg.renderDeclName(writer, decl);
     }
 
     fn renderInt128(
@@ -464,7 +464,7 @@ pub const DeclGen = struct {
                     .variable => ptr_val.castTag(.variable).?.data.owner_decl,
                     else => unreachable,
                 };
-                try dg.renderDeclName(decl, writer);
+                try dg.renderDeclName(writer, decl);
                 return decl.ty;
             },
             .field_ptr => {
@@ -599,11 +599,11 @@ pub const DeclGen = struct {
                 },
                 .function => {
                     const func = val.castTag(.function).?.data;
-                    try dg.renderDeclName(func.owner_decl, writer);
+                    try dg.renderDeclName(writer, func.owner_decl);
                 },
                 .extern_fn => {
                     const extern_fn = val.castTag(.extern_fn).?.data;
-                    try dg.renderDeclName(extern_fn.owner_decl, writer);
+                    try dg.renderDeclName(writer, extern_fn.owner_decl);
                 },
                 .int_u64, .one => {
                     try writer.writeAll("((");
@@ -834,7 +834,7 @@ pub const DeclGen = struct {
             try w.writeAll("void");
         }
         try w.writeAll(" ");
-        try dg.renderDeclName(dg.decl, w);
+        try dg.renderDeclName(w, dg.decl);
         try w.writeAll("(");
         const param_len = dg.decl.ty.fnParamLen();
 
@@ -1058,7 +1058,7 @@ pub const DeclGen = struct {
         if (err_set_type.castTag(.error_set_inferred)) |inf_err_set_payload| {
             const func = inf_err_set_payload.data.func;
             try bw.writeAll("zig_E_");
-            try dg.renderDeclName(func.owner_decl, bw);
+            try dg.renderDeclName(bw, func.owner_decl);
             try bw.writeAll(";\n");
         } else {
             try bw.print("zig_E_{s}_{s};\n", .{
@@ -1391,10 +1391,10 @@ pub const DeclGen = struct {
             .local_ref => |i| return w.print("&t{d}", .{i}),
             .constant => unreachable,
             .arg => |i| return w.print("a{d}", .{i}),
-            .decl => |decl| return dg.renderDeclName(decl, w),
+            .decl => |decl| return dg.renderDeclName(w, decl),
             .decl_ref => |decl| {
                 try w.writeByte('&');
-                return dg.renderDeclName(decl, w);
+                return dg.renderDeclName(w, decl);
             },
             .undefined_ptr => {
                 const target = dg.module.getTarget();
@@ -1418,10 +1418,10 @@ pub const DeclGen = struct {
             .arg => |i| return w.print("(*a{d})", .{i}),
             .decl => |decl| {
                 try w.writeAll("(*");
-                try dg.renderDeclName(decl, w);
+                try dg.renderDeclName(w, decl);
                 return w.writeByte(')');
             },
-            .decl_ref => |decl| return dg.renderDeclName(decl, w),
+            .decl_ref => |decl| return dg.renderDeclName(w, decl),
             .undefined_ptr => unreachable,
             .identifier => |ident| return w.print("(*{ })", .{fmtIdent(ident)}),
             .bytes => |bytes| {
@@ -1432,7 +1432,7 @@ pub const DeclGen = struct {
         }
     }
 
-    fn renderDeclName(dg: DeclGen, decl: *Decl, writer: anytype) !void {
+    fn renderDeclName(dg: DeclGen, writer: anytype, decl: *Decl) !void {
         if (dg.module.decl_exports.get(decl)) |exports| {
             return writer.writeAll(exports[0].options.name);
         } else if (decl.val.tag() == .extern_fn) {
@@ -2585,7 +2585,7 @@ fn airCall(f: *Function, inst: Air.Inst.Index) !CValue {
                     else => break :known,
                 };
             };
-            try f.object.dg.renderDeclName(fn_decl, writer);
+            try f.object.dg.renderDeclName(writer, fn_decl);
             break :callee;
         }
         // Fall back to function pointer call.

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -100,19 +100,19 @@ test {
 
         if (builtin.zig_backend != .stage2_wasm) {
             // Tests that pass for stage1, llvm backend, C backend
+            _ = @import("behavior/bugs/9584.zig");
             _ = @import("behavior/cast_int.zig");
+            _ = @import("behavior/eval.zig");
             _ = @import("behavior/int128.zig");
+            _ = @import("behavior/merge_error_sets.zig");
             _ = @import("behavior/translate_c_macros.zig");
 
             if (builtin.zig_backend != .stage2_c) {
                 // Tests that pass for stage1 and the llvm backend.
                 _ = @import("behavior/atomics.zig");
-                _ = @import("behavior/bugs/9584.zig");
-                _ = @import("behavior/eval.zig");
                 _ = @import("behavior/floatop.zig");
                 _ = @import("behavior/math.zig");
                 _ = @import("behavior/maximum_minimum.zig");
-                _ = @import("behavior/merge_error_sets.zig");
                 _ = @import("behavior/popcount.zig");
                 _ = @import("behavior/saturating_arithmetic.zig");
                 _ = @import("behavior/sizeof_and_typeof.zig");


### PR DESCRIPTION
Codegen for `field_ptr` and `elem_ptr` resulted in invalid C programs with misplaced referencing/dereferencing operators. This is fixed by this pull request. As a result, a few more behavior tests are passing now.

Additionally, I changed the order of parameters in `renderDeclName` so it is consistent with the other `render` functions.