### PR TITLE
StackIterator should not try to check memory validity on freestanding

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -425,6 +425,9 @@ pub const StackIterator = struct {
     }
 
     fn isValidMemory(address: usize) bool {
+        // We are unable to determine validity of memory for freestanding targets
+        if (native_os == .freestanding) return true;
+
         const aligned_address = address & ~@intCast(usize, (mem.page_size - 1));
 
         // If the address does not span 2 pages, query only the first one


### PR DESCRIPTION
Without this check errors like the below are received for freestanding targets:
```
zig build run
/home/lee/src/github.com/leecannon/zig/lib/std/os.zig:91:23: error: container 'std.os.system' has no member called 'MSF'
pub const MSF = system.MSF;
                      ^
/home/lee/src/github.com/leecannon/zig/lib/std/os.zig:235:25: error: container 'std.os.system' has no member called 'getErrno'
pub const errno = system.getErrno;
                        ^
RGOS...The step exited with error code 1
error: the following build command failed with exit code 1:
/home/lee/src/github.com/leecannon/RGOS/zig-cache/o/b8b4c6bd414cf6b0763ae8a1db37ffdd/build /home/lee/src/github.com/leecannon/zig/build/zig /home/lee/src/github.com/leecannon/RGOS /home/lee/src/github.com/leecannon/RGOS/zig-cache /home/lee/.cache/zig run
```