### PR TITLE
translate-c: add missing builtins used by CRuby

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,7 @@ set(ZIG_STAGE2_SOURCES
     "${CMAKE_SOURCE_DIR}/lib/std/zig.zig"
     "${CMAKE_SOURCE_DIR}/lib/std/zig/Ast.zig"
     "${CMAKE_SOURCE_DIR}/lib/std/zig/CrossTarget.zig"
+    "${CMAKE_SOURCE_DIR}/lib/std/zig/c_builtins.zig"
     "${CMAKE_SOURCE_DIR}/lib/std/zig/parse.zig"
     "${CMAKE_SOURCE_DIR}/lib/std/zig/render.zig"
     "${CMAKE_SOURCE_DIR}/lib/std/zig/string_literal.zig"

--- a/lib/std/zig/c_builtins.zig
+++ b/lib/std/zig/c_builtins.zig
@@ -245,31 +245,8 @@ pub inline fn __builtin_constant_p(expr: anytype) c_int {
     _ = expr;
     return @boolToInt(false);
 }
-
-fn multiplyAs(a: anytype, b: anytype, comptime T: type) !T {
-    const allocator = std.heap.c_allocator;
-    var big_a = try std.math.big.int.Managed.initSet(allocator, a);
-    defer big_a.deinit();
-    var big_b = try std.math.big.int.Managed.initSet(allocator, b);
-    defer big_b.deinit();
-    var product = try std.math.big.int.Managed.init(allocator);
-    defer product.deinit();
-    try product.mul(big_a.toConst(), big_b.toConst());
-    return try product.to(T);
-}
-
-pub fn __builtin_mul_overflow(a: anytype, b: anytype, result: anytype) c_int {
-    const ResultType = @TypeOf(result);
-    const result_type_info = @typeInfo(ResultType);
-    if (result_type_info != .Pointer) {
-        @compileError("Expected pointer, found " ++ @typeName(ResultType));
-    }
-    if (multiplyAs(a, b, result_type_info.Pointer.child)) |product| {
-        result.* = product;
-        return @boolToInt(false);
-    } else |_| {
-        return @boolToInt(true);
-    }
+pub fn __builtin_mul_overflow(a: anytype, b: anytype, result: *@TypeOf(a, b)) c_int {
+    return @boolToInt(@mulWithOverflow(@TypeOf(a, b), a, b, result));
 }
 
 // __builtin_alloca_with_align is not currently implemented.


### PR DESCRIPTION
I added these builtins used in the [CRuby header files](https://github.com/ruby/ruby/tree/master/include):

- `__has_builtin` - Always returns true because unimplemented builtins give an "undefined identifier" error before it can be called.
- `__builtin_assume`
- `__builtin_unreachable`
- `__builtin_constant_p` - With a C compiler, this returns a non-zero value (`true`) if the given expression is known to be constant at compile time. AFAICT it's not possible to check for this in Zig, so we just return `false` (zero).
- `__builtin_mul_overflow`