### PR TITLE
stage2: fix typo in riscv64/Emit.zig

### DIFF
--- a/src/arch/riscv64/Emit.zig
+++ b/src/arch/riscv64/Emit.zig
@@ -1,4 +1,4 @@
-//! This file contains the functionality for lowering AArch64 MIR into
+//! This file contains the functionality for lowering RISCV64 MIR into
 //! machine code
 
 const Emit = @This();


### PR DESCRIPTION
Found this while i was reading stage2 backends. 