### PR TITLE
Support -Wl,--soname

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1527,7 +1527,9 @@ fn buildOutputType(
             var i: usize = 0;
             while (i < linker_args.items.len) : (i += 1) {
                 const arg = linker_args.items[i];
-                if (mem.eql(u8, arg, "-soname")) {
+                if (mem.eql(u8, arg, "-soname") or
+                    mem.eql(u8, arg, "--soname"))
+                {
                     i += 1;
                     if (i >= linker_args.items.len) {
                         fatal("expected linker arg after '{s}'", .{arg});


### PR DESCRIPTION
Some projects ([elfutils](https://sourceware.org/elfutils/) in my case) pass `-Wl,--soname` rather than `-Wl,-soname` to the C compiler. `--soname` appears to be supported by GNU ld but undocumented, so I've just updated the linker argument processing logic to handle `-soname` and `--soname` the same way.

There were also a couple of other linker args that weren't supported but didn't seem to negatively affect the final output:
* `-rpath-link`
* `--build-id`
* `--no-undefined`
* `--enable-new-dtags`

I may circle back and add support for those as well if there is interest.