### PR TITLE
std: clarify that os.getenv unsupported on Windows

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1655,7 +1655,10 @@ pub fn execvpeZ(
 
 /// Get an environment variable.
 /// See also `getenvZ`.
+///
+/// This API is not supported on Windows, see std.process.getEnvVarOwned for cross-platform API or std.os.getenvW for Windows-specific API.
 pub fn getenv(key: []const u8) ?[]const u8 {
+    if (builtin.os.tag == .windows) @compileError("std.os.getenv is unavailable for Windows because environment string is in WTF-16 format. See std.process.getEnvVarOwned for cross-platform API or std.os.getenvW for Windows-specific API.");
     if (builtin.link_libc) {
         var small_key_buf: [64]u8 = undefined;
         if (key.len < small_key_buf.len) {
@@ -1680,9 +1683,6 @@ pub fn getenv(key: []const u8) ?[]const u8 {
             return value;
         }
         return null;
-    }
-    if (builtin.os.tag == .windows) {
-        @compileError("std.os.getenv is unavailable for Windows because environment string is in WTF-16 format. See std.process.getEnvVarOwned for cross-platform API or std.os.getenvW for Windows-specific API.");
     }
     // TODO see https://github.com/ziglang/zig/issues/4524
     for (environ) |ptr| {


### PR DESCRIPTION
The compile error here would not be reached prior to a linker error:

```
lld-link: error: undefined symbol: environ
```

Fixed this, and clarified that `std.process.getEnvVarOwned` is the cross-platform API.

Fixes #8456

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>