### PR TITLE
Use lowercase in shasum for windows builds

### DIFF
--- a/ci/azure/pipelines.yml
+++ b/ci/azure/pipelines.yml
@@ -137,7 +137,7 @@ jobs:
       --acl public-read `
       --cache-control 'public, max-age=31536000, immutable'
 
-      Set-Variable -Name SHASUM -Value (Get-FileHash "$TARBALL" -Algorithm SHA256 | select-object -ExpandProperty Hash)
+      Set-Variable -Name SHASUM -Value (Get-FileHash "$TARBALL" -Algorithm SHA256 | select-object -ExpandProperty Hash).ToLower()
       Set-Variable -Name BYTESIZE -Value (Get-Item "$TARBALL").length
 
       Set-Variable -Name JSONFILE -Value "windows-${Env:BUILD_SOURCEBRANCHNAME}.json"


### PR DESCRIPTION
The shasum generated for windows builds is showing as uppercase, this change makes it lowercase like all the other builds.

![ziglang org download index json 2022-02-20](https://user-images.githubusercontent.com/104643/154873275-9aeb586d-54c6-4c47-bfb9-4fedb1afb1a4.png)
