### PR TITLE
wasm-linker: Implement relocatable object files

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4516,6 +4516,9 @@ fn deleteDeclExports(mod: *Module, decl: *Decl) void {
         if (mod.comp.bin_file.cast(link.File.MachO)) |macho| {
             macho.deleteExport(exp.link.macho);
         }
+        if (mod.comp.bin_file.cast(link.File.Wasm)) |wasm| {
+            wasm.deleteExport(exp.link.wasm);
+        }
         if (mod.failed_exports.fetchSwapRemove(exp)) |failed_kv| {
             failed_kv.value.destroy(mod.gpa);
         }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3919,7 +3919,7 @@ pub fn analyzeExport(
             .macho => .{ .macho = .{} },
             .plan9 => .{ .plan9 = null },
             .c => .{ .c = {} },
-            .wasm => .{ .wasm = {} },
+            .wasm => .{ .wasm = .{} },
             .spirv => .{ .spirv = {} },
             .nvptx => .{ .nvptx = {} },
         },

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1320,14 +1320,18 @@ pub const DeclGen = struct {
         }
 
         decl.markAlive();
-        try writer.writeIntLittle(u32, try self.bin_file.getDeclVAddr(
-            self.decl, // The decl containing the source symbol index
-            decl.ty, // type we generate the address of
-            self.symbol_index, // source symbol index
-            decl.link.wasm.sym_index, // target symbol index
-            @intCast(u32, self.code.items.len), // offset
-            @intCast(u32, offset), // addend
-        ));
+        if (decl.link.wasm.sym_index == 0) {
+            try writer.writeIntLittle(u32, 0);
+        } else {
+            try writer.writeIntLittle(u32, try self.bin_file.getDeclVAddr(
+                self.decl, // The decl containing the source symbol index
+                decl.ty, // type we generate the address of
+                self.symbol_index, // source symbol index
+                decl.link.wasm.sym_index, // target symbol index
+                @intCast(u32, self.code.items.len), // offset
+                @intCast(u32, offset), // addend
+            ));
+        }
         return Result{ .appended = {} };
     }
 };

--- a/src/link.zig
+++ b/src/link.zig
@@ -237,7 +237,7 @@ pub const File = struct {
         macho: MachO.Export,
         plan9: Plan9.Export,
         c: void,
-        wasm: void,
+        wasm: Wasm.Export,
         spirv: void,
         nvptx: void,
     };

--- a/src/link/Wasm/Atom.zig
+++ b/src/link/Wasm/Atom.zig
@@ -173,7 +173,6 @@ fn relocationValue(self: Atom, relocation: types.Relocation, wasm_bin: *const Wa
             if (symbol.isUndefined() and (symbol.tag == .data or symbol.isWeak())) {
                 return 0;
             }
-
             const merge_segment = wasm_bin.base.options.output_mode != .Obj;
             const segment_name = wasm_bin.segment_info.items[symbol.index].outputName(merge_segment);
             const atom_index = wasm_bin.data_segments.get(segment_name).?;

--- a/src/link/Wasm/Symbol.zig
+++ b/src/link/Wasm/Symbol.zig
@@ -104,6 +104,14 @@ pub fn setUndefined(self: *Symbol, is_undefined: bool) void {
     }
 }
 
+pub fn setGlobal(self: *Symbol, is_global: bool) void {
+    if (is_global) {
+        self.flags &= ~@enumToInt(Flag.WASM_SYM_BINDING_LOCAL);
+    } else {
+        self.setFlag(.WASM_SYM_BINDING_LOCAL);
+    }
+}
+
 pub fn isDefined(self: Symbol) bool {
     return !self.isUndefined();
 }

--- a/src/link/Wasm/types.zig
+++ b/src/link/Wasm/types.zig
@@ -93,7 +93,8 @@ pub const Segment = struct {
     /// Bitfield containing flags for a segment
     flags: u32,
 
-    pub fn outputName(self: Segment) []const u8 {
+    pub fn outputName(self: Segment, merge_segments: bool) []const u8 {
+        if (!merge_segments) return self.name;
         if (std.mem.startsWith(u8, self.name, ".rodata.")) {
             return ".rodata";
         } else if (std.mem.startsWith(u8, self.name, ".text.")) {


### PR DESCRIPTION
This PR implements emitting a relocatable object file using `build-obj`.
We now emit relocations and metadata such as a symbol table and segment information when using build-obj.
COMDAT information (link once) and init functions (constructors) are currently not implemented yet.

For implementation details, refer to each individual commit.

The self-hosted wasm linker is now one step closer to being useful :)
