### PR TITLE
x64: print test runner results on macos

### DIFF
--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -143,7 +143,7 @@ pub fn main2() anyerror!void {
     }
     if (builtin.zig_backend == .stage2_llvm or
         builtin.zig_backend == .stage2_wasm or
-        (builtin.zig_backend == .stage2_x86_64 and builtin.os.tag != .macos))
+        builtin.zig_backend == .stage2_x86_64)
     {
         const passed = builtin.test_functions.len - skipped - failed;
         const stderr = std.io.getStdErr();


### PR DESCRIPTION
Turns out, there were a couple of things that needed rectifying both in the codegen as well as in the linker itself. Here's a summary breakdown:

* synthesizing `__mh_execute_header` in the linker assumed it was always done first (before resolving any other symbol) - this is obviously not true in general incremental setting, and lead to incorrectly handled symbol aliasing where Zig's libstd export a dummy weak `__mh_execute_header` symbol, and then the linker tried to synthesize the correct one which lead to trapping. This is now rectified so that we correctly check if the symbol was already defined.
* another issue was that incorrect names for decls were used in the linker leading to false collisions - turns out we need to use the fully qualified decl name via `Decl.getFullyQualifiedName` helper to disambiguate the local from a potential export or import (e.g., `File.write` vs `_write`).
* the codegen didn't take into account functions with multiple return points and only fixed up the last seen MIR instruction if the address register `rdi` was spilled in the prologue - now we store all places for backpatching later.

With this, we can now do the following on macOS when testing x64 behavior tests:
<img width="652" alt="Screenshot 2022-02-23 at 19 52 39" src="https://user-images.githubusercontent.com/1519747/155387712-9bb508f7-0a93-4871-b6ea-e92d0a845006.png">
