### PR TITLE
elf: use fully qualified decl names in the linker

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2577,7 +2577,10 @@ pub fn allocateDeclIndexes(self: *Elf, decl: *Module.Decl) !void {
     try self.offset_table.ensureUnusedCapacity(self.base.allocator, 1);
     try self.decls.putNoClobber(self.base.allocator, decl, null);
 
-    log.debug("allocating symbol indexes for {s}", .{decl.name});
+    const decl_name = try decl.getFullyQualifiedName(self.base.allocator);
+    defer self.base.allocator.free(decl_name);
+
+    log.debug("allocating symbol indexes for {s}", .{decl_name});
     decl.link.elf.local_sym_index = try self.allocateLocalSymbol();
     try self.atom_by_index_table.putNoClobber(self.base.allocator, decl.link.elf.local_sym_index, &decl.link.elf);
 
@@ -2676,7 +2679,10 @@ fn getDeclPhdrIndex(self: *Elf, decl: *Module.Decl) !u16 {
 }
 
 fn updateDeclCode(self: *Elf, decl: *Module.Decl, code: []const u8, stt_bits: u8) !*elf.Elf64_Sym {
-    log.debug("updateDeclCode {s}{*}", .{ mem.sliceTo(decl.name, 0), decl });
+    const decl_name = try decl.getFullyQualifiedName(self.base.allocator);
+    defer self.base.allocator.free(decl_name);
+
+    log.debug("updateDeclCode {s}{*}", .{ decl_name, decl });
     const required_alignment = decl.ty.abiAlignment(self.base.options.target);
 
     const decl_ptr = self.decls.getPtr(decl).?;
@@ -2694,7 +2700,7 @@ fn updateDeclCode(self: *Elf, decl: *Module.Decl, code: []const u8, stt_bits: u8
             !mem.isAlignedGeneric(u64, local_sym.st_value, required_alignment);
         if (need_realloc) {
             const vaddr = try self.growTextBlock(&decl.link.elf, code.len, required_alignment, phdr_index);
-            log.debug("growing {s} from 0x{x} to 0x{x}", .{ decl.name, local_sym.st_value, vaddr });
+            log.debug("growing {s} from 0x{x} to 0x{x}", .{ decl_name, local_sym.st_value, vaddr });
             if (vaddr != local_sym.st_value) {
                 local_sym.st_value = vaddr;
 
@@ -2706,14 +2712,13 @@ fn updateDeclCode(self: *Elf, decl: *Module.Decl, code: []const u8, stt_bits: u8
             self.shrinkTextBlock(&decl.link.elf, code.len, phdr_index);
         }
         local_sym.st_size = code.len;
-        local_sym.st_name = try self.updateString(local_sym.st_name, mem.sliceTo(decl.name, 0));
+        local_sym.st_name = try self.updateString(local_sym.st_name, decl_name);
         local_sym.st_info = (elf.STB_LOCAL << 4) | stt_bits;
         local_sym.st_other = 0;
         local_sym.st_shndx = shdr_index;
         // TODO this write could be avoided if no fields of the symbol were changed.
         try self.writeSymbol(decl.link.elf.local_sym_index);
     } else {
-        const decl_name = mem.sliceTo(decl.name, 0);
         const name_str_index = try self.makeString(decl_name);
         const vaddr = try self.allocateTextBlock(&decl.link.elf, code.len, required_alignment, phdr_index);
         errdefer self.freeTextBlock(&decl.link.elf, phdr_index);
@@ -2823,7 +2828,10 @@ pub fn updateFunc(self: *Elf, module: *Module, func: *Module.Fn, air: Air, liven
     const decl = func.owner_decl;
     self.freeUnnamedConsts(decl);
 
-    log.debug("updateFunc {s}{*}", .{ decl.name, func.owner_decl });
+    const decl_name = try decl.getFullyQualifiedName(self.base.allocator);
+    defer self.base.allocator.free(decl_name);
+
+    log.debug("updateFunc {s}{*}", .{ decl_name, func.owner_decl });
     log.debug("  (decl.src_line={d}, func.lbrace_line={d}, func.rbrace_line={d})", .{
         decl.src_line,
         func.lbrace_line,
@@ -2860,7 +2868,7 @@ pub fn updateFunc(self: *Elf, module: *Module, func: *Module.Fn, air: Air, liven
     dbg_line_buffer.appendAssumeCapacity(DW.LNS.copy);
 
     // .debug_info subprogram
-    const decl_name_with_null = decl.name[0 .. mem.sliceTo(decl.name, 0).len + 1];
+    const decl_name_with_null = decl_name[0 .. decl_name.len + 1];
     try dbg_info_buffer.ensureUnusedCapacity(25 + decl_name_with_null.len);
 
     const fn_ret_type = decl.ty.fnReturnType();
@@ -3107,9 +3115,13 @@ pub fn lowerUnnamedConst(self: *Elf, typed_value: TypedValue, decl: *Module.Decl
     try self.managed_atoms.append(self.base.allocator, atom);
 
     const name_str_index = blk: {
+        const decl_name = try decl.getFullyQualifiedName(self.base.allocator);
+        defer self.base.allocator.free(decl_name);
+
         const index = unnamed_consts.items.len;
-        const name = try std.fmt.allocPrint(self.base.allocator, "__unnamed_{s}_{d}", .{ decl.name, index });
+        const name = try std.fmt.allocPrint(self.base.allocator, "__unnamed_{s}_{d}", .{ decl_name, index });
         defer self.base.allocator.free(name);
+
         break :blk try self.makeString(name);
     };
     const name = self.getString(name_str_index);
@@ -3511,7 +3523,10 @@ pub fn updateDeclLineNumber(self: *Elf, module: *Module, decl: *const Module.Dec
     const tracy = trace(@src());
     defer tracy.end();
 
-    log.debug("updateDeclLineNumber {s}{*}", .{ decl.name, decl });
+    const decl_name = try decl.getFullyQualifiedName(self.base.allocator);
+    defer self.base.allocator.free(decl_name);
+
+    log.debug("updateDeclLineNumber {s}{*}", .{ decl_name, decl });
 
     if (self.llvm_object) |_| return;
 


### PR DESCRIPTION
Matches the fixes introduced to MachO linker in #10976 