### PR TITLE
std: work around current packed struct situation

### DIFF
--- a/lib/std/os/uefi/protocols/edid_override_protocol.zig
+++ b/lib/std/os/uefi/protocols/edid_override_protocol.zig
@@ -8,7 +8,15 @@ pub const EdidOverrideProtocol = extern struct {
     _get_edid: fn (*const EdidOverrideProtocol, Handle, *u32, *usize, *?[*]u8) callconv(.C) Status,
 
     /// Returns policy information and potentially a replacement EDID for the specified video output device.
-    pub fn getEdid(self: *const EdidOverrideProtocol, handle: Handle, attributes: *EdidOverrideProtocolAttributes, edid_size: *usize, edid: *?[*]u8) Status {
+    pub fn getEdid(
+        self: *const EdidOverrideProtocol,
+        handle: Handle,
+        /// The align(4) here should really be part of the EdidOverrideProtocolAttributes type.
+        /// TODO remove this workaround when packed(u32) structs are implemented.
+        attributes: *align(4) EdidOverrideProtocolAttributes,
+        edid_size: *usize,
+        edid: *?[*]u8,
+    ) Status {
         return self._get_edid(self, handle, @ptrCast(*u32, attributes), edid_size, edid);
     }
 


### PR DESCRIPTION
As of 6249a24, align() is not allowed on packed struct fields
and as such the align(4) was removed from the first field of
EdidOverrideProtocolAttributes. The endgame here is packed struct
backed by explicit integers, in this case a u32, but until that
is implemented put the align(4) on the pointer to avoid breaking
someone's UEFI code in a hard to debug way.