### PR TITLE
std: rename `sched_yield` to `yield` and move it to `std.Thread`

### DIFF
--- a/lib/std/Thread/StaticResetEvent.zig
+++ b/lib/std/Thread/StaticResetEvent.zig
@@ -181,7 +181,7 @@ pub const AtomicEvent = struct {
                 timer = time.Timer.start() catch return error.TimedOut;
 
             while (@atomicLoad(u32, waiters, .Acquire) != WAKE) {
-                std.os.sched_yield() catch std.atomic.spinLoopHint();
+                std.Thread.yield() catch std.atomic.spinLoopHint();
                 if (timeout) |timeout_ns| {
                     if (timer.read() >= timeout_ns)
                         return error.TimedOut;
@@ -293,7 +293,7 @@ pub const AtomicEvent = struct {
                         return @intToPtr(?windows.HANDLE, handle);
                     },
                     LOADING => {
-                        std.os.sched_yield() catch std.atomic.spinLoopHint();
+                        std.Thread.yield() catch std.atomic.spinLoopHint();
                         handle = @atomicLoad(usize, &event_handle, .Monotonic);
                     },
                     else => {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -6067,25 +6067,6 @@ pub fn dn_expand(
     return error.InvalidDnsPacket;
 }
 
-pub const SchedYieldError = error{
-    /// The system is not configured to allow yielding
-    SystemCannotYield,
-};
-
-pub fn sched_yield() SchedYieldError!void {
-    if (builtin.os.tag == .windows) {
-        // The return value has to do with how many other threads there are; it is not
-        // an error condition on Windows.
-        _ = windows.kernel32.SwitchToThread();
-        return;
-    }
-    switch (errno(system.sched_yield())) {
-        .SUCCESS => return,
-        .NOSYS => return error.SystemCannotYield,
-        else => return error.SystemCannotYield,
-    }
-}
-
 pub const SetSockOptError = error{
     /// The socket is already connected, and a specified option cannot be set while the socket is connected.
     AlreadyConnected,


### PR DESCRIPTION
I was doing a bit of Threading stuff in zig and was looking for a yield method in `std.Thread` and took me a couple of minutes to figure out it is in `std.os` under a different name. I think it is better for the function to be under the `Thread` namespace similar to how Rust and C++ provide it.