### PR TITLE
add constant for haiku

### DIFF
--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -410,6 +410,12 @@ pub const MAP = struct {
     pub const NORESERVE = 0x10;
 };
 
+pub const MSF = struct {
+    pub const ASYNC = 1;
+    pub const INVALIDATE = 2;
+    pub const SYNC = 4;
+};
+
 pub const W = struct {
     pub const NOHANG = 0x1;
     pub const UNTRACED = 0x2;


### PR DESCRIPTION
the following patch syncs what appears to be a missing constant for haiku that prevents zig build from running (see following for an example that illustrates the problem). this re-enables zig build functionality on haiku. 

```
> mkdir helloworld

> cd helloworld

> zig init-exe
info: Created build.zig
info: Created src/main.zig
info: Next, try `zig build --help` or `zig build run`

> zig build run
/boot/home/src/git/zig/lib/std/os.zig:91:23: error: container 'std.c' has no member called 'MSF'
pub const MSF = system.MSF;
                      ^

> uname -a
Haiku shredder 1 hrev55891 Feb 19 2022 08:17:46 x86_64 x86_64 Haiku
```