### PR TITLE
stage2: `@TypeOf` improvements

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -13427,7 +13427,7 @@ fn zirBuiltinExtern(
 }
 
 fn requireFunctionBlock(sema: *Sema, block: *Block, src: LazySrcLoc) !void {
-    if (sema.func == null) {
+    if (sema.func == null and !block.is_typeof) {
         return sema.fail(block, src, "instruction illegal outside function body", .{});
     }
 }
@@ -14194,7 +14194,8 @@ fn fieldCallBind(
                         if (first_param_tag == .var_args_param or
                             first_param_tag == .generic_poison or (
                                 first_param_type.zigTypeTag() == .Pointer and
-                                first_param_type.ptrSize() == .One and
+                                (first_param_type.ptrSize() == .One or
+                                first_param_type.ptrSize() == .C) and
                                 first_param_type.childType().eql(concrete_ty)))
                         {
                             // zig fmt: on

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -547,6 +547,9 @@ pub const Inst = struct {
         /// Returns the type of a value.
         /// Uses the `un_node` field.
         typeof,
+        /// Implements `@TypeOf` for one operand.
+        /// Uses the `pl_node` field.
+        typeof_builtin,
         /// Given a value, look at the type of it, which must be an integer type.
         /// Returns the integer type for the RHS of a shift operation.
         /// Uses the `un_node` field.
@@ -1067,6 +1070,7 @@ pub const Inst = struct {
                 .negate,
                 .negate_wrap,
                 .typeof,
+                .typeof_builtin,
                 .xor,
                 .optional_type,
                 .optional_payload_safe,
@@ -1429,6 +1433,7 @@ pub const Inst = struct {
                 .ptr_cast = .pl_node,
                 .truncate = .pl_node,
                 .align_cast = .pl_node,
+                .typeof_builtin = .pl_node,
 
                 .has_decl = .pl_node,
                 .has_field = .pl_node,
@@ -2389,6 +2394,12 @@ pub const Inst = struct {
                     @compileError("Call.Flags.PackedModifier needs to be updated!");
             }
         };
+    };
+
+    pub const TypeOfPeer = struct {
+        src_node: i32,
+        body_len: u32,
+        body_index: u32,
     };
 
     pub const BuiltinCall = struct {

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -38,6 +38,7 @@ test {
     _ = @import("behavior/bugs/3112.zig");
     _ = @import("behavior/bugs/3367.zig");
     _ = @import("behavior/bugs/3586.zig");
+    _ = @import("behavior/bugs/4328.zig");
     _ = @import("behavior/bugs/4560.zig");
     _ = @import("behavior/bugs/4769_a.zig");
     _ = @import("behavior/bugs/4769_b.zig");
@@ -150,7 +151,6 @@ test {
                 _ = @import("behavior/bugs/1851.zig");
                 _ = @import("behavior/bugs/3384.zig");
                 _ = @import("behavior/bugs/3779.zig");
-                _ = @import("behavior/bugs/4328.zig");
                 _ = @import("behavior/bugs/5398.zig");
                 _ = @import("behavior/bugs/5413.zig");
                 _ = @import("behavior/bugs/5487.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -102,6 +102,7 @@ test {
         builtin.zig_backend != .stage2_wasm)
     {
         // Tests that pass for stage1, llvm backend, C backend
+        _ = @import("behavior/bugs/5474.zig");
         _ = @import("behavior/bugs/9584.zig");
         _ = @import("behavior/bugs/10970.zig");
         _ = @import("behavior/cast_int.zig");
@@ -152,7 +153,6 @@ test {
                 _ = @import("behavior/bugs/4328.zig");
                 _ = @import("behavior/bugs/5398.zig");
                 _ = @import("behavior/bugs/5413.zig");
-                _ = @import("behavior/bugs/5474.zig");
                 _ = @import("behavior/bugs/5487.zig");
                 _ = @import("behavior/bugs/6456.zig");
                 _ = @import("behavior/bugs/6781.zig");

--- a/test/behavior/bugs/4328.zig
+++ b/test/behavior/bugs/4328.zig
@@ -1,4 +1,5 @@
-const expectEqual = @import("std").testing.expectEqual;
+const expect = @import("std").testing.expect;
+const builtin = @import("builtin");
 
 const FILE = extern struct {
     dummy_field: u8,
@@ -16,18 +17,20 @@ const S = extern struct {
 };
 
 test "Extern function calls in @TypeOf" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+
     const Test = struct {
         fn test_fn_1(a: anytype, b: anytype) @TypeOf(printf("%d %s\n", a, b)) {
             return 0;
         }
 
-        fn test_fn_2(a: anytype) @TypeOf((S{ .state = 0 }).s_do_thing(a)) {
+        fn test_fn_2(s: anytype, a: anytype) @TypeOf(s.s_do_thing(a)) {
             return 1;
         }
 
         fn doTheTest() !void {
-            try expectEqual(c_int, @TypeOf(test_fn_1(0, 42)));
-            try expectEqual(c_short, @TypeOf(test_fn_2(0)));
+            try expect(@TypeOf(test_fn_1(0, 42)) == c_int);
+            try expect(@TypeOf(test_fn_2(&S{ .state = 1 }, 0)) == c_short);
         }
     };
 
@@ -36,13 +39,15 @@ test "Extern function calls in @TypeOf" {
 }
 
 test "Peer resolution of extern function calls in @TypeOf" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+
     const Test = struct {
         fn test_fn() @TypeOf(ftell(null), fputs(null, null)) {
             return 0;
         }
 
         fn doTheTest() !void {
-            try expectEqual(c_long, @TypeOf(test_fn()));
+            try expect(@TypeOf(test_fn()) == c_long);
         }
     };
 
@@ -51,6 +56,10 @@ test "Peer resolution of extern function calls in @TypeOf" {
 }
 
 test "Extern function calls, dereferences and field access in @TypeOf" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+
     const Test = struct {
         fn test_fn_1(a: c_long) @TypeOf(fopen("test", "r").*) {
             _ = a;
@@ -63,8 +72,8 @@ test "Extern function calls, dereferences and field access in @TypeOf" {
         }
 
         fn doTheTest() !void {
-            try expectEqual(FILE, @TypeOf(test_fn_1(0)));
-            try expectEqual(u8, @TypeOf(test_fn_2(0)));
+            try expect(@TypeOf(test_fn_1(0)) == FILE);
+            try expect(@TypeOf(test_fn_2(0)) == u8);
         }
     };
 

--- a/test/behavior/bugs/5474.zig
+++ b/test/behavior/bugs/5474.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 // baseline (control) struct with array of scalar
 const Box0 = struct {
@@ -25,33 +26,36 @@ const Box2 = struct {
     };
 };
 
-fn doTest() !void {
-    // var
-    {
-        var box0: Box0 = .{ .items = undefined };
-        try std.testing.expect(@typeInfo(@TypeOf(box0.items[0..])).Pointer.is_const == false);
+fn mutable() !void {
+    var box0: Box0 = .{ .items = undefined };
+    try std.testing.expect(@typeInfo(@TypeOf(box0.items[0..])).Pointer.is_const == false);
 
-        var box1: Box1 = .{ .items = undefined };
-        try std.testing.expect(@typeInfo(@TypeOf(box1.items[0..])).Pointer.is_const == false);
+    var box1: Box1 = .{ .items = undefined };
+    try std.testing.expect(@typeInfo(@TypeOf(box1.items[0..])).Pointer.is_const == false);
 
-        var box2: Box2 = .{ .items = undefined };
-        try std.testing.expect(@typeInfo(@TypeOf(box2.items[0..])).Pointer.is_const == false);
-    }
-
-    // const
-    {
-        const box0: Box0 = .{ .items = undefined };
-        try std.testing.expect(@typeInfo(@TypeOf(box0.items[0..])).Pointer.is_const == true);
-
-        const box1: Box1 = .{ .items = undefined };
-        try std.testing.expect(@typeInfo(@TypeOf(box1.items[0..])).Pointer.is_const == true);
-
-        const box2: Box2 = .{ .items = undefined };
-        try std.testing.expect(@typeInfo(@TypeOf(box2.items[0..])).Pointer.is_const == true);
-    }
+    var box2: Box2 = .{ .items = undefined };
+    try std.testing.expect(@typeInfo(@TypeOf(box2.items[0..])).Pointer.is_const == false);
 }
 
-test "pointer-to-array constness for zero-size elements" {
-    try doTest();
-    comptime try doTest();
+fn constant() !void {
+    const box0: Box0 = .{ .items = undefined };
+    try std.testing.expect(@typeInfo(@TypeOf(box0.items[0..])).Pointer.is_const == true);
+
+    const box1: Box1 = .{ .items = undefined };
+    try std.testing.expect(@typeInfo(@TypeOf(box1.items[0..])).Pointer.is_const == true);
+
+    const box2: Box2 = .{ .items = undefined };
+    try std.testing.expect(@typeInfo(@TypeOf(box2.items[0..])).Pointer.is_const == true);
+}
+
+test "pointer-to-array constness for zero-size elements, var" {
+    try mutable();
+    comptime try mutable();
+}
+
+test "pointer-to-array constness for zero-size elements, const" {
+    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+
+    try constant();
+    comptime try constant();
 }


### PR DESCRIPTION
Arguments to `@TypeOf` need to be analyzed in their own block so that we don't end up with trash instructions in codegen. This also makes it easy to avoid issues with some instructions requiring a runtime block when we only care about their type.