### PR TITLE
stage2: make formatted printing work

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -270,7 +270,7 @@ fn refreshWithHeldLock(self: *Progress) void {
                 if (eti > 0) {
                     if (need_ellipse) self.bufWrite(&end, " ", .{});
                     if (builtin.zig_backend == .stage2_llvm) {
-                        self.bufWrite(&end, "[{d}/ ", .{current_item});
+                        self.bufWrite(&end, "[{d}/", .{current_item});
                         self.bufWrite(&end, "{d}] ", .{eti});
                     } else {
                         self.bufWrite(&end, "[{d}/{d}] ", .{ current_item, eti });

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -269,12 +269,7 @@ fn refreshWithHeldLock(self: *Progress) void {
                 }
                 if (eti > 0) {
                     if (need_ellipse) self.bufWrite(&end, " ", .{});
-                    if (builtin.zig_backend == .stage2_llvm) {
-                        self.bufWrite(&end, "[{d}/", .{current_item});
-                        self.bufWrite(&end, "{d}] ", .{eti});
-                    } else {
-                        self.bufWrite(&end, "[{d}/{d}] ", .{ current_item, eti });
-                    }
+                    self.bufWrite(&end, "[{d}/{d}] ", .{ current_item, eti });
                     need_ellipse = false;
                 } else if (completed_items != 0) {
                     if (need_ellipse) self.bufWrite(&end, " ", .{});

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -289,10 +289,9 @@ fn refreshWithHeldLock(self: *Progress) void {
         }
     }
 
-    _ = file.write(self.output_buffer[0..end]) catch blk: {
+    _ = file.write(self.output_buffer[0..end]) catch {
         // Stop trying to write to this file once it errors.
         self.terminal = null;
-        break :blk 0; // TODO stage2 requires this
     };
     if (self.timer) |*timer| {
         self.prev_refresh_timestamp = timer.read();

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -871,7 +871,7 @@ var vdso_clock_gettime = @ptrCast(?*const anyopaque, init_vdso_clock_gettime);
 const vdso_clock_gettime_ty = fn (i32, *timespec) callconv(.C) usize;
 
 pub fn clock_gettime(clk_id: i32, tp: *timespec) usize {
-    if (@hasDecl(VDSO, "CGT_SYM")) {
+    if (@hasDecl(VDSO, "CGT_SYM") and builtin.zig_backend == .stage1) {
         const ptr = @atomicLoad(?*const anyopaque, &vdso_clock_gettime, .Unordered);
         if (ptr) |fn_ptr| {
             const f = @ptrCast(vdso_clock_gettime_ty, fn_ptr);

--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -66,9 +66,7 @@ pub fn main() void {
                 std.debug.print("{d}/{d} {s}... ", .{ i + 1, test_fn_list.len, test_fn.name });
             }
         }
-        const result = if (builtin.zig_backend == .stage2_llvm)
-            test_fn.func()
-        else if (test_fn.async_frame_size) |size| switch (io_mode) {
+        const result = if (test_fn.async_frame_size) |size| switch (io_mode) {
             .evented => blk: {
                 if (async_frame_buffer.len < size) {
                     std.heap.page_allocator.free(async_frame_buffer);

--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -58,13 +58,7 @@ pub fn main() void {
         test_node.activate();
         progress.refresh();
         if (!have_tty) {
-            if (builtin.zig_backend == .stage2_llvm) {
-                std.debug.print("{d}/", .{i + 1});
-                std.debug.print("{d} ", .{test_fn_list.len});
-                std.debug.print("{s}... ", .{test_fn.name});
-            } else {
-                std.debug.print("{d}/{d} {s}... ", .{ i + 1, test_fn_list.len, test_fn.name });
-            }
+            std.debug.print("{d}/{d} {s}... ", .{ i + 1, test_fn_list.len, test_fn.name });
         }
         const result = if (test_fn.async_frame_size) |size| switch (io_mode) {
             .evented => blk: {
@@ -109,13 +103,7 @@ pub fn main() void {
     if (ok_count == test_fn_list.len) {
         std.debug.print("All {d} tests passed.\n", .{ok_count});
     } else {
-        if (builtin.zig_backend == .stage2_llvm) {
-            std.debug.print("{d} passed; ", .{ok_count});
-            std.debug.print("{d} skipped; ", .{skip_count});
-            std.debug.print("{d} failed.\n", .{fail_count});
-        } else {
-            std.debug.print("{d} passed; {d} skipped; {d} failed.\n", .{ ok_count, skip_count, fail_count });
-        }
+        std.debug.print("{d} passed; {d} skipped; {d} failed.\n", .{ ok_count, skip_count, fail_count });
     }
     if (log_err_count != 0) {
         std.debug.print("{d} errors were logged.\n", .{log_err_count});

--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -141,8 +141,20 @@ pub fn main2() anyerror!void {
             }
         };
     }
-    if (builtin.zig_backend == .stage2_llvm or
-        builtin.zig_backend == .stage2_wasm or
+    if (builtin.zig_backend == .stage2_llvm) {
+        const stderr = std.io.getStdErr().writer();
+        const ok_count = builtin.test_functions.len - skipped - failed;
+        if (ok_count == builtin.test_functions.len) {
+            try stderr.print("All {d} tests passed.\n", .{ok_count});
+        } else {
+            try stderr.print("{d} passed; ", .{ok_count});
+            try stderr.print("{d} skipped; ", .{skipped});
+            try stderr.print("{d} failed.\n", .{failed});
+        }
+        if (failed != 0) {
+            std.process.exit(1);
+        }
+    } else if (builtin.zig_backend == .stage2_wasm or
         builtin.zig_backend == .stage2_x86_64)
     {
         const passed = builtin.test_functions.len - skipped - failed;

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3762,7 +3762,7 @@ fn semaDecl(mod: *Module, decl: *Decl) !bool {
     // Note this resolves the type of the Decl, not the value; if this Decl
     // is a struct, for example, this resolves `type` (which needs no resolution),
     // not the struct itself.
-    try sema.resolveTypeLayout(&block_scope, src, decl_tv.ty);
+    try sema.resolveTypeFully(&block_scope, src, decl_tv.ty);
 
     const decl_arena_state = try decl_arena_allocator.create(std.heap.ArenaAllocator.State);
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -10975,8 +10975,7 @@ fn zirCondbr(
 
     if (try sema.resolveDefinedValue(parent_block, src, cond)) |cond_val| {
         const body = if (cond_val.toBool()) then_body else else_body;
-        _ = try sema.analyzeBody(parent_block, body);
-        return always_noreturn;
+        return sema.analyzeBodyInner(parent_block, body);
     }
 
     const gpa = sema.gpa;

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3892,7 +3892,7 @@ pub const FuncGen = struct {
             return self.builder.buildBitCast(operand, llvm_dest_ty.pointerType(0), "");
         }
 
-        if (operand_ty.zigTypeTag() == .Int and inst_ty.zigTypeTag() == .Pointer) {
+        if (operand_ty.zigTypeTag() == .Int and inst_ty.isPtrAtRuntime()) {
             return self.builder.buildIntToPtr(operand, llvm_dest_ty, "");
         }
 

--- a/src/type.zig
+++ b/src/type.zig
@@ -2602,7 +2602,7 @@ pub const Type = extern union {
                 const payload = self.castTag(.pointer).?.data;
                 return payload.@"allowzero";
             },
-            else => false,
+            else => return self.zigTypeTag() == .Optional,
         };
     }
 

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -125,6 +125,7 @@ test {
             _ = @import("behavior/widening.zig");
             _ = @import("behavior/bugs/421.zig");
             _ = @import("behavior/bugs/726.zig");
+            _ = @import("behavior/bugs/828.zig");
             _ = @import("behavior/bugs/1421.zig");
             _ = @import("behavior/bugs/1442.zig");
             _ = @import("behavior/bugs/1607.zig");
@@ -132,6 +133,7 @@ test {
             _ = @import("behavior/bugs/3384.zig");
             _ = @import("behavior/bugs/3742.zig");
             _ = @import("behavior/bugs/5398.zig");
+            _ = @import("behavior/bugs/5413.zig");
             _ = @import("behavior/bugs/5487.zig");
             _ = @import("behavior/struct_contains_null_ptr_itself.zig");
             _ = @import("behavior/switch_prong_err_enum.zig");
@@ -148,12 +150,10 @@ test {
                 _ = @import("behavior/await_struct.zig");
                 _ = @import("behavior/bugs/529.zig");
                 _ = @import("behavior/bugs/718.zig");
-                _ = @import("behavior/bugs/828.zig");
                 _ = @import("behavior/bugs/920.zig");
                 _ = @import("behavior/bugs/1120.zig");
                 _ = @import("behavior/bugs/1851.zig");
                 _ = @import("behavior/bugs/3779.zig");
-                _ = @import("behavior/bugs/5413.zig");
                 _ = @import("behavior/bugs/6456.zig");
                 _ = @import("behavior/bugs/6781.zig");
                 _ = @import("behavior/bugs/7003.zig");

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -819,3 +819,37 @@ test "if expression type coercion" {
     const x: u16 = if (cond) 1 else 0;
     try expect(@as(u16, x) == 1);
 }
+
+test "discarding the result of various expressions" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        fn foo() !u32 {
+            return 1;
+        }
+        fn bar() ?u32 {
+            return 1;
+        }
+    };
+    _ = S.bar() orelse {
+        // do nothing
+    };
+    _ = S.foo() catch {
+        // do nothing
+    };
+    _ = switch (1) {
+        1 => 1,
+        2 => {},
+        else => return,
+    };
+    _ = try S.foo();
+    _ = if (S.bar()) |some| some else {};
+    _ = blk: {
+        if (S.bar()) |some| break :blk some;
+        break :blk;
+    };
+    _ = while (S.bar()) |some| break some else {};
+    _ = for ("foo") |char| break char else {};
+}


### PR DESCRIPTION
Not sure how correct my fix is but the issue is that `zirCondbr` must not handle `error.ComptimeBreak` when a comptime known argument causes it to be inlined.

Current limitations:
* ~~only works for one argument likely due to behavior tested in `test/behavior/bugs/828.zig`~~
* the argument tuple cannot mix comptime and non comptime arguments since the comptime argument forces the entire tuple to be comptime only