### PR TITLE
stage2: Resolve alignment for union field in `@TypeInfo`

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1125,6 +1125,8 @@ pub const Union = struct {
         abi_align: Value,
 
         /// Returns the field alignment, assuming the union is not packed.
+        /// Keep implementation in sync with `Sema.unionFieldAlignment`.
+        /// Prefer to call that function instead of this one during Sema.
         pub fn normalAlignment(field: Field, target: Target) u32 {
             if (field.abi_align.tag() == .abi_align_default) {
                 return field.ty.abiAlignment(target);

--- a/src/type.zig
+++ b/src/type.zig
@@ -1619,10 +1619,6 @@ pub const Type = extern union {
 
             // These types have more than one possible value, so the result is the same as
             // asking whether they are comptime-only types.
-            //
-            // If we get an error that the comptimeOnly status hasn't been
-            // resolved yet, then we assume that there are runtime bits,
-            // just like we do for structs below
             .anyframe_T,
             .optional,
             .optional_single_mut_pointer,
@@ -1636,7 +1632,7 @@ pub const Type = extern union {
             .const_slice,
             .mut_slice,
             .pointer,
-            => !(ty.comptimeOnly() catch return true),
+            => !ty.comptimeOnly(),
 
             .@"struct" => {
                 const struct_obj = ty.castTag(.@"struct").?.data;
@@ -1732,7 +1728,7 @@ pub const Type = extern union {
                     .Inline => return false,
                     else => {},
                 }
-                if (fn_info.return_type.comptimeOnly() catch unreachable) return false;
+                if (fn_info.return_type.comptimeOnly()) return false;
                 return true;
             },
             else => return ty.hasRuntimeBits(),
@@ -3614,7 +3610,7 @@ pub const Type = extern union {
 
     /// During semantic analysis, instead call `Sema.typeRequiresComptime` which
     /// resolves field types rather than asserting they are already resolved.
-    pub fn comptimeOnly(ty: Type) error{StatusNotResolved}!bool {
+    pub fn comptimeOnly(ty: Type) bool {
         return switch (ty.tag()) {
             .u1,
             .u8,
@@ -3735,7 +3731,7 @@ pub const Type = extern union {
             .tuple => {
                 const tuple = ty.castTag(.tuple).?.data;
                 for (tuple.types) |field_ty| {
-                    if (try field_ty.comptimeOnly()) return true;
+                    if (field_ty.comptimeOnly()) return true;
                 }
                 return false;
             },
@@ -3743,20 +3739,18 @@ pub const Type = extern union {
             .@"struct" => {
                 const struct_obj = ty.castTag(.@"struct").?.data;
                 switch (struct_obj.requires_comptime) {
-                    .wip => unreachable,
+                    .wip, .unknown => unreachable, // This function asserts types already resolved.
                     .no => return false,
                     .yes => return true,
-                    .unknown => return error.StatusNotResolved,
                 }
             },
 
             .@"union", .union_tagged => {
                 const union_obj = ty.cast(Type.Payload.Union).?.data;
                 switch (union_obj.requires_comptime) {
-                    .wip => unreachable,
+                    .wip, .unknown => unreachable, // This function asserts types already resolved.
                     .no => return false,
                     .yes => return true,
-                    .unknown => return error.StatusNotResolved,
                 }
             },
 

--- a/test/behavior/type_info.zig
+++ b/test/behavior/type_info.zig
@@ -249,8 +249,6 @@ fn testEnum() !void {
 }
 
 test "type info: union info" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     try testUnion();
     comptime try testUnion();
 }
@@ -436,8 +434,6 @@ fn testAnyFrame() !void {
 }
 
 test "type info: pass to function" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     _ = passTypeInfo(@typeInfo(void));
     _ = comptime passTypeInfo(@typeInfo(void));
 }
@@ -448,8 +444,6 @@ fn passTypeInfo(comptime info: TypeInfo) type {
 }
 
 test "type info: TypeId -> TypeInfo impl cast" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     _ = passTypeInfo(TypeId.Void);
     _ = comptime passTypeInfo(TypeId.Void);
 }


### PR DESCRIPTION
This also includes two other small fixes:
 1. Instantiate void TypeInfo fields as `void`
 2. Return an error in `type.comptimeOnly` when encountering unresolved comptime requirements

The problem behind (2) is that type.hasRuntimeBits() can hit an `unreachable` because "requires_comptime" is not resolved for some child structs.

Since we already approximate (i.e. return `true`, even though the type may end up comptime-only) when encountering unknown comptime requirements in other branches, this PR updates the function to approximate in all branches.