### PR TITLE
stage2: peer resolve error sets and error unions 

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -17763,7 +17763,7 @@ fn resolvePeerTypes(
                     }
 
                     // Merge errors
-                    err_set_ty = try err_set_ty.?.errorSetMerge(sema.arena, candidate_ty);
+                    err_set_ty = try candidate_ty.errorSetMerge(sema.arena, err_set_ty.?);
                     chosen = candidate;
                     chosen_i = candidate_i + 1;
                     continue;
@@ -17850,7 +17850,7 @@ fn resolvePeerTypes(
                     }
 
                     // Not a superset, create merged error set
-                    err_set_ty = try err_set_ty.?.errorSetMerge(sema.arena, eu_set_ty);
+                    err_set_ty = try eu_set_ty.errorSetMerge(sema.arena, err_set_ty.?);
                     chosen = candidate;
                     chosen_i = candidate_i + 1;
                     continue;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -17612,9 +17612,8 @@ fn resolvePeerTypes(
     var chosen = instructions[0];
     var err_set_ty: ?Type = blk: {
         const chosen_ty = sema.typeOf(chosen);
-
-        // TODO: is this the right handling of generic poison?
-        if (chosen_ty.tag() == .generic_poison or chosen_ty.zigTypeTag() != .ErrorSet)
+        const chosen_ty_tag = try chosen_ty.zigTypeTagOrPoison();
+        if (chosen_ty_tag != .ErrorSet)
             break :blk null;
 
         // If our chosen type is inferred, we have to resolve it now.

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -17738,23 +17738,17 @@ fn resolvePeerTypes(
                     // If chosen is superset of candidate, keep it.
                     // If candidate is superset of chosen, switch it.
                     // If neither is a superset, merge errors.
-                    var prev_is_superset = true;
                     for (candidate_ty.errorSetNames()) |name| {
                         if (!err_set_ty.?.errorSetHasField(name)) {
-                            prev_is_superset = false;
                             break;
                         }
-                    }
-                    if (prev_is_superset) continue; // use previous
+                    } else continue;
 
-                    var cand_is_superset = true;
                     for (err_set_ty.?.errorSetNames()) |name| {
                         if (!candidate_ty.errorSetHasField(name)) {
-                            cand_is_superset = false;
                             break;
                         }
-                    }
-                    if (cand_is_superset) {
+                    } else {
                         // Swap to candidate
                         err_set_ty = candidate_ty;
                         chosen = candidate;
@@ -17801,14 +17795,11 @@ fn resolvePeerTypes(
                 }
 
                 // If previous is superset, keep the previous
-                var prev_is_superset = true;
                 for (candidate_ty.errorSetNames()) |name| {
                     if (!err_set_ty.?.errorSetHasField(name)) {
-                        prev_is_superset = false;
                         break;
                     }
-                }
-                if (prev_is_superset) continue; // use previous
+                } else continue;
 
                 // Merge
                 err_set_ty = try err_set_ty.?.errorSetMerge(sema.arena, candidate_ty);
@@ -17834,14 +17825,11 @@ fn resolvePeerTypes(
                     }
 
                     // If candidate is a superset of the error type, then use it.
-                    var cand_is_superset = true;
                     for (err_set_ty.?.errorSetNames()) |name| {
                         if (!eu_set_ty.errorSetHasField(name)) {
-                            cand_is_superset = false;
                             break;
                         }
-                    }
-                    if (cand_is_superset) {
+                    } else {
                         // Swap to candidate
                         err_set_ty = eu_set_ty;
                         chosen = candidate;
@@ -17901,23 +17889,17 @@ fn resolvePeerTypes(
                         if (err_set_ty == null) err_set_ty = chosen_set_ty;
 
                         // If the previous error set type is a superset, we're done.
-                        var prev_is_superset = true;
                         for (candidate_set_ty.errorSetNames()) |name| {
                             if (!chosen_set_ty.errorSetHasField(name)) {
-                                prev_is_superset = false;
                                 break;
                             }
-                        }
-                        if (prev_is_superset) continue; // use previous
+                        } else continue;
 
-                        var cand_is_superset = true;
                         for (chosen_set_ty.errorSetNames()) |name| {
                             if (!candidate_set_ty.errorSetHasField(name)) {
-                                cand_is_superset = false;
                                 break;
                             }
-                        }
-                        if (cand_is_superset) {
+                        } else {
                             err_set_ty = candidate_ty;
                             continue;
                         }

--- a/src/type.zig
+++ b/src/type.zig
@@ -4216,6 +4216,23 @@ pub const Type = extern union {
         };
     }
 
+    /// Merge ty with ty2.
+    /// Asserts that ty and ty2 are both error sets and are resolved.
+    pub fn errorSetMerge(ty: Type, arena: Allocator, ty2: Type) !Type {
+        const lhs_names = ty.errorSetNames();
+        const rhs_names = ty2.errorSetNames();
+        var names = Module.ErrorSet.NameMap{};
+        try names.ensureUnusedCapacity(arena, @intCast(u32, lhs_names.len + rhs_names.len));
+        for (lhs_names) |name| {
+            names.putAssumeCapacityNoClobber(name, {});
+        }
+        for (rhs_names) |name| {
+            names.putAssumeCapacity(name, {});
+        }
+
+        return try Tag.error_set_merged.create(arena, names);
+    }
+
     pub fn enumFields(ty: Type) Module.EnumFull.NameMap {
         return switch (ty.tag()) {
             .enum_full, .enum_nonexhaustive => ty.cast(Payload.EnumFull).?.data.fields,

--- a/src/type.zig
+++ b/src/type.zig
@@ -4216,18 +4216,18 @@ pub const Type = extern union {
         };
     }
 
-    /// Merge ty with ty2.
-    /// Asserts that ty and ty2 are both error sets and are resolved.
-    pub fn errorSetMerge(ty: Type, arena: Allocator, ty2: Type) !Type {
-        const lhs_names = ty.errorSetNames();
-        const rhs_names = ty2.errorSetNames();
-        var names = Module.ErrorSet.NameMap{};
-        try names.ensureUnusedCapacity(arena, @intCast(u32, lhs_names.len + rhs_names.len));
+    /// Merge lhs with rhs.
+    /// Asserts that lhs and rhs are both error sets and are resolved.
+    pub fn errorSetMerge(lhs: Type, arena: Allocator, rhs: Type) !Type {
+        const lhs_names = lhs.errorSetNames();
+        const rhs_names = rhs.errorSetNames();
+        var names: Module.ErrorSet.NameMap = .{};
+        try names.ensureUnusedCapacity(arena, lhs_names.len);
         for (lhs_names) |name| {
             names.putAssumeCapacityNoClobber(name, {});
         }
         for (rhs_names) |name| {
-            names.putAssumeCapacity(name, {});
+            try names.put(arena, name, {});
         }
 
         return try Tag.error_set_merged.create(arena, names);

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -591,11 +591,10 @@ test "@floatCast cast down" {
 }
 
 test "peer type resolution: unreachable, error set, unreachable" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     const Error = error{
         FileDescriptorAlreadyPresentInSet,
@@ -620,11 +619,6 @@ test "peer type resolution: unreachable, error set, unreachable" {
 }
 
 test "peer cast: error set any anyerror" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-
     const a: error{ One, Two } = undefined;
     const b: anyerror = undefined;
     try expect(@TypeOf(a, b) == anyerror);
@@ -632,11 +626,9 @@ test "peer cast: error set any anyerror" {
 }
 
 test "peer type resolution: error set supersets" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     const a: error{ One, Two } = undefined;
     const b: error{One} = undefined;
@@ -663,29 +655,20 @@ test "peer type resolution: error set supersets" {
 }
 
 test "peer type resolution: disjoint error sets" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage1) {
+        // stage1 gets the order of the error names wrong after merging the sets.
+        return error.SkipZigTest;
+    }
+
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     const a: error{ One, Two } = undefined;
     const b: error{Three} = undefined;
 
-    // note: order of error set made to match stage1 during stage2 dev
-
     {
         const ty = @TypeOf(a, b);
-        const error_set_info = @typeInfo(ty);
-        try expect(error_set_info == .ErrorSet);
-        try expect(error_set_info.ErrorSet.?.len == 3);
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[0].name, "Three"));
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "One"));
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Two"));
-    }
-
-    {
-        const ty = @TypeOf(b, a);
         const error_set_info = @typeInfo(ty);
         try expect(error_set_info == .ErrorSet);
         try expect(error_set_info.ErrorSet.?.len == 3);
@@ -693,19 +676,30 @@ test "peer type resolution: disjoint error sets" {
         try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "Two"));
         try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Three"));
     }
+
+    {
+        const ty = @TypeOf(b, a);
+        const error_set_info = @typeInfo(ty);
+        try expect(error_set_info == .ErrorSet);
+        try expect(error_set_info.ErrorSet.?.len == 3);
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[0].name, "Three"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "One"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Two"));
+    }
 }
 
 test "peer type resolution: error union and error set" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage1) {
+        // stage1 gets the order of the error names wrong after merging the sets.
+        return error.SkipZigTest;
+    }
+
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     const a: error{Three} = undefined;
     const b: error{ One, Two }!u32 = undefined;
-
-    // note: order of error set made to match stage1 during stage2 dev
 
     {
         const ty = @TypeOf(a, b);
@@ -714,9 +708,9 @@ test "peer type resolution: error union and error set" {
 
         const error_set_info = @typeInfo(info.ErrorUnion.error_set);
         try expect(error_set_info.ErrorSet.?.len == 3);
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[0].name, "One"));
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "Two"));
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Three"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[0].name, "Three"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "One"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Two"));
     }
 
     {
@@ -733,16 +727,12 @@ test "peer type resolution: error union and error set" {
 }
 
 test "peer type resolution: error union after non-error" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     const a: u32 = undefined;
     const b: error{ One, Two }!u32 = undefined;
-
-    // note: order of error set made to match stage1 during stage2 dev
 
     {
         const ty = @TypeOf(a, b);

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -595,6 +595,7 @@ test "peer type resolution: unreachable, error set, unreachable" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const Error = error{
         FileDescriptorAlreadyPresentInSet,
@@ -635,6 +636,7 @@ test "peer type resolution: error set supersets" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const a: error{ One, Two } = undefined;
     const b: error{One} = undefined;
@@ -665,6 +667,7 @@ test "peer type resolution: disjoint error sets" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const a: error{ One, Two } = undefined;
     const b: error{Three} = undefined;
@@ -697,6 +700,7 @@ test "peer type resolution: error union and error set" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const a: error{Three} = undefined;
     const b: error{ One, Two }!u32 = undefined;
@@ -733,6 +737,7 @@ test "peer type resolution: error union after non-error" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const a: u32 = undefined;
     const b: error{ One, Two }!u32 = undefined;

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -669,16 +669,16 @@ test "peer type resolution: disjoint error sets" {
     const a: error{ One, Two } = undefined;
     const b: error{Three} = undefined;
 
-    // note: order of error set members doesn't member, may want to sort
+    // note: order of error set made to match stage1 during stage2 dev
 
     {
         const ty = @TypeOf(a, b);
         const error_set_info = @typeInfo(ty);
         try expect(error_set_info == .ErrorSet);
         try expect(error_set_info.ErrorSet.?.len == 3);
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[0].name, "One"));
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "Two"));
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Three"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[0].name, "Three"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "One"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Two"));
     }
 
     {
@@ -686,9 +686,9 @@ test "peer type resolution: disjoint error sets" {
         const error_set_info = @typeInfo(ty);
         try expect(error_set_info == .ErrorSet);
         try expect(error_set_info.ErrorSet.?.len == 3);
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[0].name, "Three"));
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "One"));
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Two"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[0].name, "One"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "Two"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Three"));
     }
 }
 
@@ -701,7 +701,7 @@ test "peer type resolution: error union and error set" {
     const a: error{Three} = undefined;
     const b: error{ One, Two }!u32 = undefined;
 
-    // note: order of error set members doesn't member, may want to sort
+    // note: order of error set made to match stage1 during stage2 dev
 
     {
         const ty = @TypeOf(a, b);
@@ -710,9 +710,9 @@ test "peer type resolution: error union and error set" {
 
         const error_set_info = @typeInfo(info.ErrorUnion.error_set);
         try expect(error_set_info.ErrorSet.?.len == 3);
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[0].name, "Three"));
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "One"));
-        try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Two"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[0].name, "One"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[1].name, "Two"));
+        try expect(mem.eql(u8, error_set_info.ErrorSet.?[2].name, "Three"));
     }
 
     {
@@ -737,7 +737,7 @@ test "peer type resolution: error union after non-error" {
     const a: u32 = undefined;
     const b: error{ One, Two }!u32 = undefined;
 
-    // note: order of error set members doesn't member, may want to sort
+    // note: order of error set made to match stage1 during stage2 dev
 
     {
         const ty = @TypeOf(a, b);

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -591,7 +591,10 @@ test "@floatCast cast down" {
 }
 
 test "peer type resolution: unreachable, error set, unreachable" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
     const Error = error{
         FileDescriptorAlreadyPresentInSet,
@@ -616,6 +619,11 @@ test "peer type resolution: unreachable, error set, unreachable" {
 }
 
 test "peer cast: error set any anyerror" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+
     const a: error{ One, Two } = undefined;
     const b: anyerror = undefined;
     try expect(@TypeOf(a, b) == anyerror);
@@ -623,6 +631,11 @@ test "peer cast: error set any anyerror" {
 }
 
 test "peer type resolution: error set supersets" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+
     const a: error{ One, Two } = undefined;
     const b: error{One} = undefined;
 
@@ -648,6 +661,11 @@ test "peer type resolution: error set supersets" {
 }
 
 test "peer type resolution: disjoint error sets" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+
     const a: error{ One, Two } = undefined;
     const b: error{Three} = undefined;
 
@@ -675,6 +693,11 @@ test "peer type resolution: disjoint error sets" {
 }
 
 test "peer type resolution: error union and error set" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+
     const a: error{Three} = undefined;
     const b: error{ One, Two }!u32 = undefined;
 
@@ -706,6 +729,11 @@ test "peer type resolution: error union and error set" {
 }
 
 test "peer type resolution: error union after non-error" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+
     const a: u32 = undefined;
     const b: error{ One, Two }!u32 = undefined;
 

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -264,8 +264,6 @@ fn testErrToIntWithOnePossibleValue(
 }
 
 test "error union peer type resolution" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     try testErrorUnionPeerTypeResolution(1);
 }
 

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -264,6 +264,12 @@ fn testErrToIntWithOnePossibleValue(
 }
 
 test "error union peer type resolution" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+
     try testErrorUnionPeerTypeResolution(1);
 }
 

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -264,11 +264,8 @@ fn testErrToIntWithOnePossibleValue(
 }
 
 test "error union peer type resolution" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     try testErrorUnionPeerTypeResolution(1);
 }


### PR DESCRIPTION
I surprisingly could only find 1 test that passes thanks to this (no new failures). But I added a number of new cases to better cover error union/set peer resolution in various cases and these also pass in stage1.

One question: note the TODO in Sema L17404 I added. A generic poison is making its way through somehow if I don't guard against it. Is the way I'm guarding fine? 