### PR TITLE
stage2: sentinel compare during peer type resolution should use elem type

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -17619,21 +17619,18 @@ fn resolvePeerTypes(
                     const chosen_child_ty = chosen_ty.childType();
                     const candidate_child_ty = candidate_ty.childType();
                     if (chosen_child_ty.zigTypeTag() == .Array and candidate_child_ty.zigTypeTag() == .Array) {
-                        // If there is a sentinel, it must match
-                        if (chosen_child_ty.sentinel()) |chosen_sentinel| {
-                            if (candidate_child_ty.sentinel()) |candidate_sentinel| {
-                                if (!chosen_sentinel.eql(candidate_sentinel, chosen_child_ty)) {
-                                    continue;
-                                }
-                            } else {
-                                continue;
-                            }
-                        }
-
                         // If we can cerce the element types, then we can do this.
                         const chosen_elem_ty = chosen_child_ty.elemType2();
                         const candidate_elem_ty = candidate_child_ty.elemType2();
                         if ((try sema.coerceInMemoryAllowed(block, candidate_elem_ty, chosen_elem_ty, false, target, src, src)) == .ok) {
+                            // If there is a sentinel, it must match
+                            if (chosen_child_ty.sentinel()) |chosen_sentinel| {
+                                if (candidate_child_ty.sentinel()) |candidate_sentinel| {
+                                    if (!chosen_sentinel.eql(candidate_sentinel, chosen_elem_ty))
+                                        continue;
+                                } else continue;
+                            }
+
                             chosen = candidate;
                             chosen_i = candidate_i + 1;
 

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -658,7 +658,11 @@ test "peer cast *[N]T to [*]T" {
 }
 
 test "peer resolution of string literals" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const S = struct {
         const E = enum { a, b, c, d };


### PR DESCRIPTION
We were using the array type, not the element type. Also, we should do
the sentinel comparison after we verify that the element types of both
are compatible.

1 more passing test.