### PR TITLE
stage2: wasm-linker - Implement string interning

### DIFF
--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -248,7 +248,7 @@ fn parseObjectFile(self: *Wasm, path: []const u8) !bool {
 
     var object = Object.create(self.base.allocator, file, path) catch |err| switch (err) {
         error.InvalidMagicByte, error.NotObjectFile => {
-            log.warn("Self hosted linker does not support non-object file parsing", .{});
+            log.warn("Self hosted linker does not support non-object file parsing: {s}", .{@errorName(err)});
             return false;
         },
         else => |e| return e,
@@ -356,6 +356,10 @@ pub fn deinit(self: *Wasm) void {
     self.symbol_atom.deinit(gpa);
     self.export_names.deinit(gpa);
     self.atoms.deinit(gpa);
+    for (self.managed_atoms.items) |managed_atom| {
+        managed_atom.deinit(gpa);
+        gpa.destroy(managed_atom);
+    }
     self.managed_atoms.deinit(gpa);
     self.segments.deinit(gpa);
     self.data_segments.deinit(gpa);

--- a/src/link/Wasm/Atom.zig
+++ b/src/link/Wasm/Atom.zig
@@ -103,17 +103,17 @@ pub fn symbolLoc(self: Atom) Wasm.SymbolLoc {
 /// at the calculated offset.
 pub fn resolveRelocs(self: *Atom, wasm_bin: *const Wasm) !void {
     if (self.relocs.items.len == 0) return;
-    const symbol = self.symbolLoc().getSymbol(wasm_bin).*;
+    const symbol_name = self.symbolLoc().getName(wasm_bin);
     log.debug("Resolving relocs in atom '{s}' count({d})", .{
-        symbol.name,
+        symbol_name,
         self.relocs.items.len,
     });
 
     for (self.relocs.items) |reloc| {
         const value = try self.relocationValue(reloc, wasm_bin);
         log.debug("Relocating '{s}' referenced in '{s}' offset=0x{x:0>8} value={d}", .{
-            (Wasm.SymbolLoc{ .file = self.file, .index = reloc.index }).getSymbol(wasm_bin).name,
-            symbol.name,
+            (Wasm.SymbolLoc{ .file = self.file, .index = reloc.index }).getName(wasm_bin),
+            symbol_name,
             reloc.offset,
             value,
         });

--- a/src/link/Wasm/Symbol.zig
+++ b/src/link/Wasm/Symbol.zig
@@ -1,5 +1,8 @@
-//! Wasm symbols describing its kind,
-//! name and its properties.
+//! Represents a wasm symbol. Containing all of its properties,
+//! as well as providing helper methods to determine its functionality
+//! and how it will/must be linked.
+//! The name of the symbol can be found by providing the offset, found
+//! on the `name` field, to a string table in the wasm binary or object file.
 const Symbol = @This();
 
 const std = @import("std");
@@ -8,15 +11,15 @@ const types = @import("types.zig");
 /// Bitfield containings flags for a symbol
 /// Can contain any of the flags defined in `Flag`
 flags: u32,
-/// Symbol name, when undefined this will be taken from the import.
-name: [*:0]const u8,
-/// An union that represents both the type of symbol
-/// as well as the data it holds.
-tag: Tag,
+/// Symbol name, when the symbol is undefined the name will be taken from the import.
+/// Note: This is an index into the string table.
+name: u32,
 /// Index into the list of objects based on set `tag`
 /// NOTE: This will be set to `undefined` when `tag` is `data`
 /// and the symbol is undefined.
 index: u32,
+/// Represents the kind of the symbol, such as a function or global.
+tag: Tag,
 
 pub const Tag = enum {
     function,
@@ -164,7 +167,7 @@ pub fn format(self: Symbol, comptime fmt: []const u8, options: std.fmt.FormatOpt
     const binding: []const u8 = if (self.isLocal()) "local" else "global";
 
     try writer.print(
-        "{c} binding={s} visible={s} id={d} name={s}",
+        "{c} binding={s} visible={s} id={d} name_offset={d}",
         .{ kind_fmt, binding, visible, self.index, self.name },
     );
 }

--- a/src/link/Wasm/types.zig
+++ b/src/link/Wasm/types.zig
@@ -78,6 +78,26 @@ pub const Relocation = struct {
     }
 };
 
+/// Unlike the `Import` object defined by the wasm spec, and existing
+/// in the std.wasm namespace, this construct saves the 'module name' and 'name'
+/// of the import using offsets into a string table, rather than the slices itself.
+/// This saves us (potentially) 24 bytes per import on 64bit machines.
+pub const Import = struct {
+    module_name: u32,
+    name: u32,
+    kind: std.wasm.Import.Kind,
+};
+
+/// Unlike the `Export` object defined by the wasm spec, and existing
+/// in the std.wasm namespace, this construct saves the 'name'
+/// of the export using offsets into a string table, rather than the slice itself.
+/// This saves us (potentially) 12 bytes per export on 64bit machines.
+pub const Export = struct {
+    name: u32,
+    index: u32,
+    kind: std.wasm.ExternalKind,
+};
+
 pub const SubsectionType = enum(u8) {
     WASM_SEGMENT_INFO = 5,
     WASM_INIT_FUNCS = 6,


### PR DESCRIPTION
From now on, all strings in the linker will be interned. The benefits of interning, while using only Zig code and not linking any other object files are nearly non-existing as most symbol names are already unique for Zig code. However, it does save memory when using WASI functions as they all reference library names that will be interned. The benefits of this become clear when trying to link with other object files, as at such point you'll have multiple symbols containing the same name.

A nice side-effect of this change is it opens up the ability to provide a better data-oriented design for symbols. Since strings are now an offset into a string table, we could also potentially look into preserving this table throughout the entire pipeline. This would mean the linker could re-use those offsets, rather than allocate memory for the strings by the linker, truly providing the benefits of string interning.

Unlike other binary formats, wasm does not contain a string table itself. This means that when parsing an object file, we create such table of our own and use that instead. In the future, I'll be looking into a way to share those string tables between the different object files/final binary so the strings are also de-duplicated between the tables themselves.