### PR TITLE
std.BufSet.clone: fix key ownership

### DIFF
--- a/lib/std/buf_set.zig
+++ b/lib/std/buf_set.zig
@@ -78,7 +78,7 @@ pub const BufSet = struct {
     ) Allocator.Error!BufSet {
         var cloned_hashmap = try self.hash_map.cloneWithAllocator(new_allocator);
         var cloned = BufSet{ .hash_map = cloned_hashmap };
-        var it = self.hash_map.keyIterator();
+        var it = cloned.hash_map.keyIterator();
         while (it.next()) |key_ptr| {
             key_ptr.* = try cloned.copy(key_ptr.*);
         }
@@ -131,4 +131,17 @@ test "BufSet clone" {
         error.OutOfMemory,
         original.cloneWithAllocator(testing.failing_allocator),
     );
+}
+
+test "BufSet.clone with arena" {
+    var allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var buf = BufSet.init(allocator);
+    defer buf.deinit();
+    try buf.insert("member1");
+    try buf.insert("member2");
+
+    _ = try buf.cloneWithAllocator(arena.allocator());
 }


### PR DESCRIPTION
This was introduced in d1a46548349a902c30057b3ba66ebad9bc25bdd2: when a
BufSet clones the keys, it used to assign the new pointers to the old
struct. Fix that by assigning the pointers to the correct, i.e. the new,
struct.

This caused double-free when using arena allocator for the new struct,
also in the test case.