### PR TITLE
stage2: Add limited WASI support for selfExePath and globalCacheDir

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2547,6 +2547,15 @@ pub const SelfExePathError = os.ReadLinkError || os.SysCtlError || os.RealPathEr
 /// `selfExePath` except allocates the result on the heap.
 /// Caller owns returned memory.
 pub fn selfExePathAlloc(allocator: Allocator) ![]u8 {
+    if (builtin.os.tag == .wasi) {
+        var args = try std.process.argsWithAllocator(allocator);
+        defer args.deinit();
+        // On WASI, argv[0] is always just the basename of the current executable
+        const exe_name = args.next() orelse return error.FileNotFound;
+
+        var buf: [MAX_PATH_BYTES]u8 = undefined;
+        return allocator.dupe(u8, try selfExePathWasi(&buf, exe_name));
+    }
     // Use of MAX_PATH_BYTES here is justified as, at least on one tested Linux
     // system, readlink will completely fail to return a result larger than
     // PATH_MAX even if given a sufficiently large buffer. This makes it
@@ -2643,8 +2652,43 @@ pub fn selfExePath(out_buffer: []u8) SelfExePathError![]u8 {
             const end_index = std.unicode.utf16leToUtf8(out_buffer, utf16le_slice) catch unreachable;
             return out_buffer[0..end_index];
         },
+        .wasi => @compileError("std.fs.selfExePath not supported for WASI. Use std.fs.selfExePathAlloc instead."),
         else => @compileError("std.fs.selfExePath not supported for this target"),
     }
+}
+
+/// WASI-specific implementation of selfExePath
+///
+/// On WASI argv0 is always just the executable basename, so this function relies
+/// using a fixed executable directory path: "/zig"
+///
+/// This path can be configured in wasmtime using `--mapdir=/zig::/path/to/zig/dir/`
+fn selfExePathWasi(out_buffer: []u8, exe_name: []const u8) SelfExePathError![]const u8 {
+    var allocator = std.heap.FixedBufferAllocator.init(out_buffer);
+    var alloc = allocator.allocator();
+
+    // Check these paths:
+    //  1. "/zig/{exe_name}"
+    //  2. "/zig/bin/{exe_name}"
+    const base_paths_to_check = &[_][]const u8{ "/zig", "/zig/bin" };
+
+    for (base_paths_to_check) |base_path| {
+        const test_path = path.join(alloc, &.{ base_path, path.basename(exe_name) }) catch continue;
+
+        // Make sure it's a file we're pointing to
+        const file = os.fstatat(os.wasi.AT.FDCWD, test_path, 0) catch continue;
+        if (file.filetype != .REGULAR_FILE) continue;
+
+        // Path seems to be valid, let's try to turn it into an absolute path
+        var real_path_buf: [MAX_PATH_BYTES]u8 = undefined;
+        if (os.realpath(test_path, &real_path_buf)) |real_path| {
+            if (real_path.len > out_buffer.len)
+                return error.NameTooLong;
+            mem.copy(u8, out_buffer, real_path);
+            return out_buffer[0..real_path.len];
+        } else |_| continue;
+    }
+    return error.FileNotFound;
 }
 
 /// The result is UTF16LE-encoded.

--- a/src/main.zig
+++ b/src/main.zig
@@ -162,6 +162,16 @@ pub fn main() anyerror!void {
         return mainArgs(gpa_tracy.allocator(), arena, args);
     }
 
+    // WASI: `--dir` instructs the WASM runtime to "preopen" a directory, making
+    // it available to the us, the guest program. This is the only way for us to
+    // access files/dirs on the host filesystem
+    if (builtin.os.tag == .wasi) {
+        // This sets our CWD to "/preopens/cwd"
+        // Dot-prefixed preopens like `--dir=.` are "mounted" at "/preopens/cwd"
+        // Other preopens like `--dir=lib` are "mounted" at "/"
+        try std.os.initPreopensWasi(std.heap.page_allocator, "/preopens/cwd");
+    }
+
     return mainArgs(gpa, arena, args);
 }
 


### PR DESCRIPTION
Dependent on #11053. Resolves #10716.

This PR adds support for locating the Zig executable and the library and global cache directories, based on looking in the fixed "/zig" and "/cache" directories. It also bypasses the file-locking in "src/Cache.zig" and initializes the WASI preopens on startup.

The expected directories can be provided on the command-line using `--mapdir`, as follows:

```
wasmtime --mapdir=/cwd::. --mapdir=/cache::"$HOME/.cache/zig" --mapdir=/zig::./stage2-wasm/ ./stage2-wasm/bin/zig.wasm
```

The reason for the fixed directories is that argv[0] on WASI is just the basename (any absolute/relative path information is deleted by the runtime) and there is no WASI-equivalent to procfs.

This is enough to get stage2 running without LLVM on WASI:
```bash
$ ./build/zig build -Dtarget=wasm32-wasi --zig-lib-dir lib --prefix $(pwd)/stage2-wasm -Dsingle-threaded -Drelease
$ alias zigwasm="wasmtime --mapdir=/cwd::\$(pwd) --mapdir=/cache::\"$HOME/.cache/zig\" --mapdir=/zig::$(pwd)/stage2-wasm/ $(pwd)/stage2-wasm/bin/zig.wasm"
$ zigwasm build-exe ./simple_hello.zig -target x86_64-linux
$ chmod +x ./simple_hello
$ ./simple_hello
Hello, world!
```

This should be considered highly experimental - I haven't even checked the behavior tests or anything.