### PR TITLE
fix nvptx test failure #10968

### DIFF
--- a/src/test.zig
+++ b/src/test.zig
@@ -175,6 +175,7 @@ pub const TestContext = struct {
         is_test: bool = false,
         expect_exact: bool = false,
         backend: Backend = .stage2,
+        link_libc: bool = false,
 
         files: std.ArrayList(File),
 
@@ -331,6 +332,7 @@ pub const TestContext = struct {
             .output_mode = .Exe,
             .files = std.ArrayList(File).init(ctx.cases.allocator),
             .backend = .llvm,
+            .link_libc = true,
         }) catch @panic("out of memory");
         return &ctx.cases.items[ctx.cases.items.len - 1];
     }
@@ -888,11 +890,6 @@ pub const TestContext = struct {
             .llvm => true,
             else => null,
         };
-        const use_stage1: ?bool = switch (case.backend) {
-            .stage1 => true,
-            else => null,
-        };
-        const link_libc = case.backend == .llvm;
         const comp = try Compilation.create(allocator, .{
             .local_cache_directory = zig_cache_directory,
             .global_cache_directory = global_cache_directory,
@@ -914,9 +911,9 @@ pub const TestContext = struct {
             .is_native_os = case.target.isNativeOs(),
             .is_native_abi = case.target.isNativeAbi(),
             .dynamic_linker = target_info.dynamic_linker.get(),
-            .link_libc = link_libc,
+            .link_libc = case.link_libc,
             .use_llvm = use_llvm,
-            .use_stage1 = use_stage1,
+            .use_stage1 = null, // We already handled stage1 tests
             .self_exe_path = std.testing.zig_exe_path,
         });
         defer comp.destroy();
@@ -1145,7 +1142,7 @@ pub const TestContext = struct {
                                 "-lc",
                                 exe_path,
                             });
-                        } else switch (host.getExternalExecutor(target_info, .{ .link_libc = link_libc })) {
+                        } else switch (host.getExternalExecutor(target_info, .{ .link_libc = case.link_libc })) {
                             .native => try argv.append(exe_path),
                             .bad_dl, .bad_os_or_cpu => return, // Pass test.
 
@@ -1156,8 +1153,7 @@ pub const TestContext = struct {
                             },
 
                             .qemu => |qemu_bin_name| if (enable_qemu) {
-                                // TODO Ability for test cases to specify whether to link libc.
-                                const need_cross_glibc = false; // target.isGnuLibC() and self.is_linking_libc;
+                                const need_cross_glibc = target.isGnuLibC() and case.link_libc;
                                 const glibc_dir_arg = if (need_cross_glibc)
                                     glibc_runtimes_dir orelse return // glibc dir not available; pass test
                                 else

--- a/test/cases.zig
+++ b/test/cases.zig
@@ -16,6 +16,5 @@ pub fn addCases(ctx: *TestContext) !void {
     try @import("stage2/riscv64.zig").addCases(ctx);
     try @import("stage2/plan9.zig").addCases(ctx);
     try @import("stage2/x86_64.zig").addCases(ctx);
-    // TODO https://github.com/ziglang/zig/issues/10968
-    //try @import("stage2/nvptx.zig").addCases(ctx);
+    try @import("stage2/nvptx.zig").addCases(ctx);
 }

--- a/test/stage2/nvptx.zig
+++ b/test/stage2/nvptx.zig
@@ -1,21 +1,16 @@
 const std = @import("std");
 const TestContext = @import("../../src/test.zig").TestContext;
 
-const nvptx = std.zig.CrossTarget{
-    .cpu_arch = .nvptx64,
-    .os_tag = .cuda,
-};
-
 pub fn addCases(ctx: *TestContext) !void {
     {
-        var case = ctx.exeUsingLlvmBackend("simple addition and subtraction", nvptx);
+        var case = addPtx(ctx, "nvptx: simple addition and subtraction");
 
         case.compiles(
             \\fn add(a: i32, b: i32) i32 {
             \\    return a + b;
             \\}
             \\
-            \\pub export fn main(a: i32, out: *i32) callconv(.PtxKernel) void {
+            \\pub export fn add_and_substract(a: i32, out: *i32) callconv(.PtxKernel) void {
             \\    const x = add(a, 7);
             \\    var y = add(2, 0);
             \\    y -= x;
@@ -25,28 +20,28 @@ pub fn addCases(ctx: *TestContext) !void {
     }
 
     {
-        var case = ctx.exeUsingLlvmBackend("read special registers", nvptx);
+        var case = addPtx(ctx, "nvptx: read special registers");
 
         case.compiles(
-            \\fn tid() usize {
+            \\fn threadIdX() usize {
             \\     var tid = asm volatile ("mov.u32 \t$0, %tid.x;"
             \\         : [ret] "=r" (-> u32),
             \\     );
             \\     return @as(usize, tid);
             \\}
             \\
-            \\pub export fn main(a: []const i32, out: []i32) callconv(.PtxKernel) void {
-            \\    const i = tid();
+            \\pub export fn special_reg(a: []const i32, out: []i32) callconv(.PtxKernel) void {
+            \\    const i = threadIdX();
             \\    out[i] = a[i] + 7;
             \\}
         );
     }
 
     {
-        var case = ctx.exeUsingLlvmBackend("address spaces", nvptx);
+        var case = addPtx(ctx, "nvptx: address spaces");
 
         case.compiles(
-            \\var x: u32 addrspace(.global) = 0;
+            \\var x: i32 addrspace(.global) = 0;
             \\
             \\pub export fn increment(out: *i32) callconv(.PtxKernel) void {
             \\    x += 1;
@@ -54,4 +49,25 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         );
     }
+}
+
+const nvptx_target = std.zig.CrossTarget{
+    .cpu_arch = .nvptx64,
+    .os_tag = .cuda,
+};
+
+pub fn addPtx(
+    ctx: *TestContext,
+    name: []const u8,
+) *TestContext.Case {
+    ctx.cases.append(TestContext.Case{
+        .name = name,
+        .target = nvptx_target,
+        .updates = std.ArrayList(TestContext.Update).init(ctx.cases.allocator),
+        .output_mode = .Obj,
+        .files = std.ArrayList(TestContext.File).init(ctx.cases.allocator),
+        .link_libc = false,
+        .backend = .llvm,
+    }) catch @panic("out of memory");
+    return &ctx.cases.items[ctx.cases.items.len - 1];
 }


### PR DESCRIPTION
Fixes #10968

Allow test cases to chose whether to link libc or not.
default behavior is to not link libc, except for `exeUsingLLVMBackend`

Ptx backend doesn't support linking, so we should not try to link libc.

Also the `link/nvptx.zig` error handling was wrong, so I simplified the code to remove the errdefer that could segfault.

Since there was a TODO in `test.zig` about linking libc, I also implemented it. @andrewrk Let me know if that still makes sense.

https://github.com/ziglang/zig/blob/f6aaab9406807305c2b48fcd742449c9e91f1851/src/test.zig#L1159-L1160
