### PR TITLE
stage2: reify error sets

### DIFF
--- a/src/value.zig
+++ b/src/value.zig
@@ -2506,6 +2506,15 @@ pub const Value = extern union {
         };
     }
 
+    /// Value of the optional, null if optional has no payload.
+    pub fn optionalValue(val: Value) ?Value {
+        if (val.isNull()) return null;
+
+        // Valid for optional representation to be the direct value
+        // and not use opt_payload.
+        return if (val.castTag(.opt_payload)) |p| p.data else val;
+    }
+
     /// Valid for all types. Asserts the value is not undefined.
     pub fn isFloat(self: Value) bool {
         return switch (self.tag()) {

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -240,12 +240,19 @@ fn add(a: i32, b: i32) i32 {
 }
 
 test "Type.ErrorSet" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    try testing.expect(@Type(TypeInfo{ .ErrorSet = null }) == anyerror);
 
     // error sets don't compare equal so just check if they compile
     _ = @Type(@typeInfo(error{}));
     _ = @Type(@typeInfo(error{A}));
     _ = @Type(@typeInfo(error{ A, B, C }));
+    _ = @Type(TypeInfo{
+        .ErrorSet = &[_]TypeInfo.Error{
+            .{ .name = "A" },
+            .{ .name = "B" },
+            .{ .name = "C" },
+        },
+    });
 }
 
 test "Type.Struct" {


### PR DESCRIPTION
`@Type()` for error sets.

This also fixes a bug in @typeInfo for error sets where I wasn't wrapping the payload properly. This test also catches that.

Question: I create an `error_set_merged` since that only requires a name map. Should I be creating a full `error_set` decl for this? That requires a full `Module.ErrorSet`. I'm sure I can do that but wasn't sure what you wanted here.