### PR TITLE
stage2: Zir - rename the 'ret_coerce' tag to 'ret_tok'

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -2303,7 +2303,7 @@ fn unusedResultExpr(gz: *GenZir, scope: *Scope, statement: Ast.Node.Index) Inner
             .compile_error,
             .ret_node,
             .ret_load,
-            .ret_coerce,
+            .ret_tok,
             .ret_err_value,
             .@"unreachable",
             .repeat,
@@ -3420,8 +3420,8 @@ fn fnDecl(
 
         if (!fn_gz.endsWithNoReturn()) {
             // Since we are adding the return instruction here, we must handle the coercion.
-            // We do this by using the `ret_coerce` instruction.
-            _ = try fn_gz.addUnTok(.ret_coerce, .void_value, tree.lastToken(body_node));
+            // We do this by using the `ret_tok` instruction.
+            _ = try fn_gz.addUnTok(.ret_tok, .void_value, tree.lastToken(body_node));
         }
 
         break :func try decl_gz.addFunc(.{
@@ -3850,8 +3850,8 @@ fn testDecl(
     const block_result = try expr(&fn_block, &fn_block.base, .none, body_node);
     if (fn_block.isEmpty() or !fn_block.refIsNoReturn(block_result)) {
         // Since we are adding the return instruction here, we must handle the coercion.
-        // We do this by using the `ret_coerce` instruction.
-        _ = try fn_block.addUnTok(.ret_coerce, .void_value, tree.lastToken(body_node));
+        // We do this by using the `ret_tok` instruction.
+        _ = try fn_block.addUnTok(.ret_tok, .void_value, tree.lastToken(body_node));
     }
 
     const func_inst = try decl_block.addFunc(.{

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -812,7 +812,7 @@ fn analyzeBodyInner(
             // These functions match the return type of analyzeBody so that we can
             // tail call them here.
             .compile_error  => break sema.zirCompileError(block, inst),
-            .ret_coerce     => break sema.zirRetCoerce(block, inst),
+            .ret_tok        => break sema.zirRetTok(block, inst),
             .ret_node       => break sema.zirRetNode(block, inst),
             .ret_load       => break sema.zirRetLoad(block, inst),
             .ret_err_value  => break sema.zirRetErrValue(block, inst),
@@ -11189,7 +11189,7 @@ fn zirRetErrValue(
     return sema.analyzeRet(block, result_inst, src);
 }
 
-fn zirRetCoerce(
+fn zirRetTok(
     sema: *Sema,
     block: *Block,
     inst: Zir.Inst.Index,

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -477,9 +477,7 @@ pub const Inst = struct {
         /// Includes an operand as the return value.
         /// Includes a token source location.
         /// Uses the `un_tok` union field.
-        /// The operand needs to get coerced to the function's return type.
-        /// TODO rename this to `ret_tok` because coercion is now done unconditionally in Sema.
-        ret_coerce,
+        ret_tok,
         /// Sends control flow back to the function's callee.
         /// The return operand is `error.foo` where `foo` is given by the string.
         /// If the current function has an inferred error set, the error given by the
@@ -1217,7 +1215,7 @@ pub const Inst = struct {
                 .compile_error,
                 .ret_node,
                 .ret_load,
-                .ret_coerce,
+                .ret_tok,
                 .ret_err_value,
                 .@"unreachable",
                 .repeat,
@@ -1323,7 +1321,7 @@ pub const Inst = struct {
                 .ref = .un_tok,
                 .ret_node = .un_node,
                 .ret_load = .un_node,
-                .ret_coerce = .un_tok,
+                .ret_tok = .un_tok,
                 .ret_err_value = .str_tok,
                 .ret_err_value_code = .str_tok,
                 .ptr_type_simple = .ptr_type_simple,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -241,7 +241,7 @@ const Writer = struct {
             => try self.writeUnNode(stream, inst),
 
             .ref,
-            .ret_coerce,
+            .ret_tok,
             .ensure_err_payload_void,
             .closure_capture,
             => try self.writeUnTok(stream, inst),


### PR DESCRIPTION
This contains no functional changes and is a simple rename of the Zir tag `ret_coerce` to `ret_tok` as suggested in an Andrew TODO

> TODO rename this to `ret_tok` because coercion is now done unconditionally in Sema.

I found this comment while perusing the source to look at more meaningful contribution, but figured I might as well start with this to better familiarise myself. 
If this comment was no longer accurate or this Yak does not need shaving feel free to close!

- These changes successfully compile with `./build/zig build --zig-lib-dir lib --prefix $(pwd)/stage2 -Denable-llvm -Dconfig_h=build/config.h`
- Functional tests pass with `849 passed; 158 skipped; 0 failed.` when running ` ./stage2/bin/zig test ./test/behavior.zig -I ./test -fLLVM`
- No other references to `ret_coerce` exist in this repository as far as I can tell