### PR TITLE
stage2: Improve `@ptrCast` support for sliced/optional operands

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2882,7 +2882,7 @@ pub const FuncGen = struct {
         const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
         const ptr_ty = self.air.typeOf(bin_op.lhs);
         const elem_ty = ptr_ty.childType();
-        if (!elem_ty.hasRuntimeBits()) return null;
+        if (!elem_ty.hasRuntimeBits()) return self.dg.lowerPtrToVoid(ptr_ty);
 
         const base_ptr = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);

--- a/src/type.zig
+++ b/src/type.zig
@@ -5287,8 +5287,10 @@ pub const Type = extern union {
         // type, we change it to 0 here. If this causes an assertion trip because the
         // pointee type needs to be resolved more, that needs to be done before calling
         // this ptr() function.
-        if (d.@"align" != 0 and d.@"align" == d.pointee_type.abiAlignment(target)) {
-            d.@"align" = 0;
+        if (d.@"align" != 0) {
+            if (d.pointee_type.zigTypeTag() == .Opaque or d.@"align" == d.pointee_type.abiAlignment(target)) {
+                d.@"align" = 0;
+            }
         }
 
         // Canonicalize host_size. If it matches the bit size of the pointee type,

--- a/src/type.zig
+++ b/src/type.zig
@@ -2245,6 +2245,7 @@ pub const Type = extern union {
             .prefetch_options,
             .export_options,
             .extern_options,
+            .@"opaque",
             => return 1,
 
             .fn_noreturn_no_args, // represents machine code; not a pointer
@@ -2432,7 +2433,6 @@ pub const Type = extern union {
             .noreturn,
             .inferred_alloc_const,
             .inferred_alloc_mut,
-            .@"opaque",
             .var_args_param,
             .bound_fn,
             => unreachable,
@@ -5287,10 +5287,8 @@ pub const Type = extern union {
         // type, we change it to 0 here. If this causes an assertion trip because the
         // pointee type needs to be resolved more, that needs to be done before calling
         // this ptr() function.
-        if (d.@"align" != 0) {
-            if (d.pointee_type.zigTypeTag() == .Opaque or d.@"align" == d.pointee_type.abiAlignment(target)) {
-                d.@"align" = 0;
-            }
+        if (d.@"align" != 0 and d.@"align" == d.pointee_type.abiAlignment(target)) {
+            d.@"align" = 0;
         }
 
         // Canonicalize host_size. If it matches the bit size of the pointee type,

--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -273,7 +273,10 @@ test "0-bit child type coerced to optional return ptr result location" {
 }
 
 test "0-bit child type coerced to optional" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     const S = struct {
         fn doTheTest() !void {

--- a/test/behavior/ptrcast.zig
+++ b/test/behavior/ptrcast.zig
@@ -4,7 +4,9 @@ const expect = std.testing.expect;
 const native_endian = builtin.target.cpu.arch.endian();
 
 test "reinterpret bytes as integer with nonzero offset" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     try testReinterpretBytesAsInteger();
     comptime try testReinterpretBytesAsInteger();
@@ -43,7 +45,6 @@ fn testReinterpretBytesAsExternStruct() !void {
 test "reinterpret struct field at comptime" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
@@ -75,7 +76,9 @@ test "comptime ptrcast keeps larger alignment" {
 }
 
 test "implicit optional pointer to optional anyopaque pointer" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     var buf: [4]u8 = "aoeu".*;
     var x: ?[*]u8 = &buf;

--- a/test/behavior/ptrcast.zig
+++ b/test/behavior/ptrcast.zig
@@ -67,8 +67,6 @@ const Bytes = struct {
 };
 
 test "comptime ptrcast keeps larger alignment" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     comptime {
         const a: u32 = 1234;
         const p = @ptrCast([*]const u8, &a);


### PR DESCRIPTION
Various changes to fix some small tests in `behavior/optional.zig` and `behavior/ptrcast.zig`

**Aside:** The last remaining test in ptrcast seems quite tricky: A field_ptr fails to be dereferenced because Sema.beginComptimePtrLoad assumes that it can recurse to a root decl_ref and ask for its type to get the parent struct/array type. However, this seems incorrect for reinterpreted memory, where a pointer intentionally disagrees about its target vs. the containing decl