### PR TITLE
stage2: Implement wasm builtins

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -584,11 +584,11 @@ pub const Inst = struct {
         field_parent_ptr,
 
         /// Implements @wasmMemorySize builtin.
-        /// Uses the `ty_pl` field, payload is `WasmMemoryIndex`.
+        /// Uses the `ty_pl` field, payload represents the index of the target memory.
         wasm_memory_size,
 
         /// Implements @wasmMemoryGrow builtin.
-        /// Uses the `pl_op` field, payload is `WasmMemoryIndex`.
+        /// Uses the `pl_op` field, payload represents the index of the target memory.
         wasm_memory_grow,
 
         pub fn fromCmpOp(op: std.math.CompareOperator) Tag {
@@ -723,12 +723,6 @@ pub const Bin = struct {
 pub const FieldParentPtr = struct {
     field_ptr: Inst.Ref,
     field_index: u32,
-};
-
-/// Wasm's memory instructions require a comptime-known index
-/// which represents the memory it operates on.
-pub const WasmMemoryIndex = struct {
-    index: u32,
 };
 
 /// Trailing:

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -584,10 +584,13 @@ pub const Inst = struct {
         field_parent_ptr,
 
         /// Implements @wasmMemorySize builtin.
-        /// Uses the `ty_pl` field, payload represents the index of the target memory.
+        /// Result type is always `u32`,
+        /// Uses the `pl_op` field, payload represents the index of the target memory.
+        /// The operand is unused and always set to `Ref.none`.
         wasm_memory_size,
 
         /// Implements @wasmMemoryGrow builtin.
+        /// Result type is always `i32`,
         /// Uses the `pl_op` field, payload represents the index of the target memory.
         wasm_memory_grow,
 
@@ -626,6 +629,7 @@ pub const Inst = struct {
     pub const Data = union {
         no_op: void,
         un_op: Ref,
+
         bin_op: struct {
             lhs: Ref,
             rhs: Ref,
@@ -885,7 +889,6 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .aggregate_init,
         .union_init,
         .field_parent_ptr,
-        .wasm_memory_size,
         => return air.getRefType(datas[inst].ty_pl.ty),
 
         .not,
@@ -954,7 +957,8 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .frame_addr,
         => return Type.initTag(.usize),
 
-        .wasm_memory_grow => return Type.initTag(.i32),
+        .wasm_memory_grow => return Type.i32,
+        .wasm_memory_size => return Type.u32,
 
         .bool_to_int => return Type.initTag(.u1),
 

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -587,6 +587,10 @@ pub const Inst = struct {
         /// Uses the `ty_pl` field, payload is `WasmMemoryIndex`.
         wasm_memory_size,
 
+        /// Implements @wasmMemoryGrow builtin.
+        /// Uses the `pl_op` field, payload is `WasmMemoryIndex`.
+        wasm_memory_grow,
+
         pub fn fromCmpOp(op: std.math.CompareOperator) Tag {
             return switch (op) {
                 .lt => .cmp_lt,
@@ -955,6 +959,8 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .ret_addr,
         .frame_addr,
         => return Type.initTag(.usize),
+
+        .wasm_memory_grow => return Type.initTag(.i32),
 
         .bool_to_int => return Type.initTag(.u1),
 

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -583,6 +583,10 @@ pub const Inst = struct {
         /// Uses the `ty_pl` field.
         field_parent_ptr,
 
+        /// Implements @wasmMemorySize builtin.
+        /// Uses the `ty_pl` field, payload is `WasmMemoryIndex`.
+        wasm_memory_size,
+
         pub fn fromCmpOp(op: std.math.CompareOperator) Tag {
             return switch (op) {
                 .lt => .cmp_lt,
@@ -715,6 +719,12 @@ pub const Bin = struct {
 pub const FieldParentPtr = struct {
     field_ptr: Inst.Ref,
     field_index: u32,
+};
+
+/// Wasm's memory instructions require a comptime-known index
+/// which represents the memory it operates on.
+pub const WasmMemoryIndex = struct {
+    index: u32,
 };
 
 /// Trailing:
@@ -877,6 +887,7 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .aggregate_init,
         .union_init,
         .field_parent_ptr,
+        .wasm_memory_size,
         => return air.getRefType(datas[inst].ty_pl.ty),
 
         .not,

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -7148,7 +7148,7 @@ fn builtinCall(
             return rvalue(gz, rl, result, node);
         },
         .wasm_memory_grow => {
-            const index_arg = try expr(gz, scope, .{ .ty = .u32_type }, params[0]);
+            const index_arg = try comptimeExpr(gz, scope, .{ .ty = .u32_type }, params[0]);
             const delta_arg = try expr(gz, scope, .{ .ty = .u32_type }, params[1]);
             const result = try gz.addExtendedPayload(.wasm_memory_grow, Zir.Inst.BinNode{
                 .node = gz.nodeIndexToRelative(node),

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -7140,7 +7140,7 @@ fn builtinCall(
         // zig fmt: on
 
         .wasm_memory_size => {
-            const operand = try comptimeExpr(gz, scope, .{ .ty = .u32_type }, params[0]);
+            const operand = try comptimeExpr(gz, scope, .{ .coerced_ty = .u32_type }, params[0]);
             const result = try gz.addExtendedPayload(.wasm_memory_size, Zir.Inst.UnNode{
                 .node = gz.nodeIndexToRelative(node),
                 .operand = operand,
@@ -7148,8 +7148,8 @@ fn builtinCall(
             return rvalue(gz, rl, result, node);
         },
         .wasm_memory_grow => {
-            const index_arg = try comptimeExpr(gz, scope, .{ .ty = .u32_type }, params[0]);
-            const delta_arg = try expr(gz, scope, .{ .ty = .u32_type }, params[1]);
+            const index_arg = try comptimeExpr(gz, scope, .{ .coerced_ty = .u32_type }, params[0]);
+            const delta_arg = try expr(gz, scope, .{ .coerced_ty = .u32_type }, params[1]);
             const result = try gz.addExtendedPayload(.wasm_memory_grow, Zir.Inst.BinNode{
                 .node = gz.nodeIndexToRelative(node),
                 .lhs = index_arg,

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -7140,7 +7140,7 @@ fn builtinCall(
         // zig fmt: on
 
         .wasm_memory_size => {
-            const operand = try expr(gz, scope, .{ .ty = .u32_type }, params[0]);
+            const operand = try comptimeExpr(gz, scope, .{ .ty = .u32_type }, params[0]);
             const result = try gz.addExtendedPayload(.wasm_memory_size, Zir.Inst.UnNode{
                 .node = gz.nodeIndexToRelative(node),
                 .operand = operand,

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -318,6 +318,7 @@ fn analyzeInst(
         .fence,
         .ret_addr,
         .frame_addr,
+        .wasm_memory_size,
         => return trackOperands(a, new_set, inst, main_tomb, .{ .none, .none, .none }),
 
         .not,

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -707,6 +707,10 @@ fn analyzeInst(
 
             return trackOperands(a, new_set, inst, main_tomb, .{ condition, .none, .none });
         },
+        .wasm_memory_grow => {
+            const pl_op = inst_datas[inst].pl_op;
+            return trackOperands(a, new_set, inst, main_tomb, .{ pl_op.operand, .none, .none });
+        },
     }
 }
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -14034,7 +14034,7 @@ fn zirWasmMemorySize(
 ) CompileError!Air.Inst.Ref {
     const extra = sema.code.extraData(Zir.Inst.UnNode, extended.operand).data;
     const src: LazySrcLoc = .{ .node_offset = extra.node };
-    if (!sema.mod.getTarget().isWasm()) {
+    if (!sema.mod.getTarget().isWasm() and sema.mod.comp.bin_file.options.object_format != .c) {
         return sema.fail(block, src, "builtin '@wasmMemorySize' is a wasm feature only", .{});
     }
 
@@ -14045,7 +14045,7 @@ fn zirWasmMemorySize(
         .tag = .wasm_memory_size,
         .data = .{ .ty_pl = .{
             .ty = try sema.addType(Type.u32),
-            .payload = try sema.addExtra(Air.WasmMemoryIndex{ .index = index }),
+            .payload = index,
         } },
     });
 }
@@ -14057,7 +14057,7 @@ fn zirWasmMemoryGrow(
 ) CompileError!Air.Inst.Ref {
     const extra = sema.code.extraData(Zir.Inst.BinNode, extended.operand).data;
     const src: LazySrcLoc = .{ .node_offset = extra.node };
-    if (!sema.mod.getTarget().isWasm()) {
+    if (!sema.mod.getTarget().isWasm() and sema.mod.comp.bin_file.options.object_format != .c) {
         return sema.fail(block, src, "builtin '@wasmMemoryGrow' is a wasm feature only", .{});
     }
 
@@ -14070,7 +14070,7 @@ fn zirWasmMemoryGrow(
         .tag = .wasm_memory_grow,
         .data = .{ .pl_op = .{
             .operand = delta_arg,
-            .payload = try sema.addExtra(Air.WasmMemoryIndex{ .index = index }),
+            .payload = index,
         } },
     });
 }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -14034,7 +14034,17 @@ fn zirWasmMemorySize(
 ) CompileError!Air.Inst.Ref {
     const extra = sema.code.extraData(Zir.Inst.UnNode, extended.operand).data;
     const src: LazySrcLoc = .{ .node_offset = extra.node };
-    return sema.fail(block, src, "TODO: implement Sema.zirWasmMemorySize", .{});
+
+    const operand = try sema.resolveInt(block, src, extra.operand, Type.u32);
+    const index = @intCast(u32, operand);
+    try sema.requireRuntimeBlock(block, src);
+    return block.addInst(.{
+        .tag = .wasm_memory_size,
+        .data = .{ .ty_pl = .{
+            .ty = try sema.addType(Type.u32),
+            .payload = try sema.addExtra(Air.WasmMemoryIndex{ .index = index }),
+        } },
+    });
 }
 
 fn zirWasmMemoryGrow(

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -671,6 +671,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
             .wrap_errunion_err     => try self.airWrapErrUnionErr(inst),
+
+            .wasm_memory_size => unreachable,
+            .wasm_memory_grow => unreachable,
             // zig fmt: on
         }
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -669,6 +669,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
             .wrap_errunion_err     => try self.airWrapErrUnionErr(inst),
+
+            .wasm_memory_size => unreachable,
+            .wasm_memory_grow => unreachable,
             // zig fmt: on
         }
 

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -642,6 +642,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
             .wrap_errunion_err     => try self.airWrapErrUnionErr(inst),
+
+            .wasm_memory_size => unreachable,
+            .wasm_memory_grow => unreachable,
             // zig fmt: on
         }
         if (std.debug.runtime_safety) {

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3430,10 +3430,12 @@ fn airPrefetch(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
 }
 
 fn airWasmMemorySize(self: *Self, inst: Air.Inst.Index) !WValue {
-    const ty_pl = self.air.instructions.items(.data)[inst].ty_pl;
+    if (self.liveness.isUnused(inst)) return WValue{ .none = {} };
+
+    const pl_op = self.air.instructions.items(.data)[inst].pl_op;
 
     const result = try self.allocLocal(self.air.typeOfIndex(inst));
-    try self.addLabel(.memory_size, ty_pl.payload);
+    try self.addLabel(.memory_size, pl_op.payload);
     try self.addLabel(.local_set, result.local);
     return result;
 }

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1672,6 +1672,7 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .wrap_errunion_err => self.airWrapErrUnionErr(inst),
 
         .wasm_memory_size => self.airWasmMemorySize(inst),
+        .wasm_memory_grow => self.airWasmMemoryGrow(inst),
 
         .add_sat,
         .sub_sat,
@@ -3434,6 +3435,18 @@ fn airWasmMemorySize(self: *Self, inst: Air.Inst.Index) !WValue {
 
     const result = try self.allocLocal(Type.usize);
     try self.addLabel(.memory_size, extra.index);
+    try self.addLabel(.local_set, result.local);
+    return result;
+}
+
+fn airWasmMemoryGrow(self: *Self, inst: Air.Inst.Index) !WValue {
+    const pl_op = self.air.instructions.items(.data)[inst].pl_op;
+    const extra = self.air.extraData(Air.WasmMemoryIndex, pl_op.payload).data;
+    const operand = try self.resolveInst(pl_op.operand);
+
+    const result = try self.allocLocal(Type.usize);
+    try self.emitWValue(operand);
+    try self.addLabel(.memory_grow, extra.index);
     try self.addLabel(.local_set, result.local);
     return result;
 }

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1671,6 +1671,8 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .wrap_errunion_payload => self.airWrapErrUnionPayload(inst),
         .wrap_errunion_err => self.airWrapErrUnionErr(inst),
 
+        .wasm_memory_size => self.airWasmMemorySize(inst),
+
         .add_sat,
         .sub_sat,
         .mul_sat,
@@ -3424,6 +3426,16 @@ fn airPrefetch(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
     const prefetch = self.air.instructions.items(.data)[inst].prefetch;
     _ = prefetch;
     return WValue{ .none = {} };
+}
+
+fn airWasmMemorySize(self: *Self, inst: Air.Inst.Index) !WValue {
+    const ty_pl = self.air.instructions.items(.data)[inst].ty_pl;
+    const extra = self.air.extraData(Air.WasmMemoryIndex, ty_pl.payload).data;
+
+    const result = try self.allocLocal(Type.usize);
+    try self.addLabel(.memory_size, extra.index);
+    try self.addLabel(.local_set, result.local);
+    return result;
 }
 
 fn cmpOptionals(self: *Self, lhs: WValue, rhs: WValue, operand_ty: Type, op: std.math.CompareOperator) InnerError!WValue {

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3431,22 +3431,20 @@ fn airPrefetch(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
 
 fn airWasmMemorySize(self: *Self, inst: Air.Inst.Index) !WValue {
     const ty_pl = self.air.instructions.items(.data)[inst].ty_pl;
-    const extra = self.air.extraData(Air.WasmMemoryIndex, ty_pl.payload).data;
 
-    const result = try self.allocLocal(Type.usize);
-    try self.addLabel(.memory_size, extra.index);
+    const result = try self.allocLocal(self.air.typeOfIndex(inst));
+    try self.addLabel(.memory_size, ty_pl.payload);
     try self.addLabel(.local_set, result.local);
     return result;
 }
 
 fn airWasmMemoryGrow(self: *Self, inst: Air.Inst.Index) !WValue {
     const pl_op = self.air.instructions.items(.data)[inst].pl_op;
-    const extra = self.air.extraData(Air.WasmMemoryIndex, pl_op.payload).data;
     const operand = try self.resolveInst(pl_op.operand);
 
-    const result = try self.allocLocal(Type.usize);
+    const result = try self.allocLocal(self.air.typeOfIndex(inst));
     try self.emitWValue(operand);
-    try self.addLabel(.memory_grow, extra.index);
+    try self.addLabel(.memory_grow, pl_op.payload);
     try self.addLabel(.local_set, result.local);
     return result;
 }

--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -89,10 +89,10 @@ pub fn emitMir(emit: *Emit) InnerError!void {
             .local_set => try emit.emitLabel(tag, inst),
             .local_tee => try emit.emitLabel(tag, inst),
             .memory_grow => try emit.emitLabel(tag, inst),
+            .memory_size => try emit.emitLabel(tag, inst),
 
             // no-ops
             .end => try emit.emitTag(tag),
-            .memory_size => try emit.emitTag(tag),
             .@"return" => try emit.emitTag(tag),
             .@"unreachable" => try emit.emitTag(tag),
 

--- a/src/arch/wasm/Mir.zig
+++ b/src/arch/wasm/Mir.zig
@@ -226,9 +226,9 @@ pub const Inst = struct {
         i64_store32 = 0x3E,
         /// Returns the memory size in amount of pages.
         ///
-        /// Uses `nop`
+        /// Uses `label`
         memory_size = 0x3F,
-        /// Increases the memory at by given number of pages.
+        /// Increases the memory by given number of pages.
         ///
         /// Uses `label`
         memory_grow = 0x40,

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -759,6 +759,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
             .wrap_errunion_err     => try self.airWrapErrUnionErr(inst),
+
+            .wasm_memory_size => unreachable,
+            .wasm_memory_grow => unreachable,
             // zig fmt: on
         }
 

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1758,6 +1758,9 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .wrap_errunion_payload       => try airWrapErrUnionPay(f, inst),
             .wrap_errunion_err           => try airWrapErrUnionErr(f, inst),
             .errunion_payload_ptr_set    => try airErrUnionPayloadPtrSet(f, inst),
+
+            .wasm_memory_size => unreachable,
+            .wasm_memory_grow => unreachable,
             // zig fmt: on
         };
         switch (result_value) {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -3592,14 +3592,16 @@ fn airPrefetch(f: *Function, inst: Air.Inst.Index) !CValue {
 }
 
 fn airWasmMemorySize(f: *Function, inst: Air.Inst.Index) !CValue {
-    const ty_pl = f.air.instructions.items(.data)[inst].ty_pl;
+    if (f.liveness.isUnused(inst)) return CValue.none;
+
+    const pl_op = f.air.instructions.items(.data)[inst].pl_op;
 
     const writer = f.object.writer();
     const inst_ty = f.air.typeOfIndex(inst);
     const local = try f.allocLocal(inst_ty, .Const);
 
     try writer.writeAll(" = ");
-    try writer.print("zig_wasm_memory_size({d});\n", .{ty_pl.payload});
+    try writer.print("zig_wasm_memory_size({d});\n", .{pl_op.payload});
 
     return local;
 }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2314,6 +2314,8 @@ pub const FuncGen = struct {
                 .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
                 .wrap_errunion_err     => try self.airWrapErrUnionErr(inst),
 
+                .wasm_memory_size => try self.airWasmMemorySize(inst),
+
                 .constant => unreachable,
                 .const_ty => unreachable,
                 .unreach  => self.airUnreach(inst),
@@ -3472,6 +3474,11 @@ pub const FuncGen = struct {
         const partial = self.builder.buildInsertValue(err_un_llvm_ty.getUndef(), operand, 0, "");
         // TODO set payload bytes to undef
         return partial;
+    }
+
+    fn airWasmMemorySize(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {
+        _ = inst;
+        return self.todo("`@wasmMemorySize()`", .{});
     }
 
     fn airMin(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3478,7 +3478,12 @@ pub const FuncGen = struct {
 
     fn airWasmMemorySize(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {
         _ = inst;
-        return self.todo("`@wasmMemorySize()`", .{});
+        return self.todo("implement builtin `@wasmMemorySize()`", .{});
+    }
+
+    fn airWasmMemoryGrow(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {
+        _ = inst;
+        return self.todo("implement builtin `@wasmMemoryGrow()`", .{});
     }
 
     fn airMin(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2315,6 +2315,7 @@ pub const FuncGen = struct {
                 .wrap_errunion_err     => try self.airWrapErrUnionErr(inst),
 
                 .wasm_memory_size => try self.airWasmMemorySize(inst),
+                .wasm_memory_grow => try self.airWasmMemoryGrow(inst),
 
                 .constant => unreachable,
                 .const_ty => unreachable,

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -91,14 +91,10 @@
 
 #if defined(__clang__)
 #define zig_wasm_memory_size(index) __builtin_wasm_memory_size(index)
-#else
-#define zig_wasm_memory_size(index) 0
-#endif
-
-#if defined(__clang__)
 #define zig_wasm_memory_grow(index, delta) __builtin_wasm_memory_grow(index, delta)
 #else
-#define zig_wasm_memory_grow(index, delta) 0
+#define zig_wasm_memory_size(index) zig_unimplemented()
+#define zig_wasm_memory_grow(index, delta) zig_unimplemented()
 #endif
 
 #if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)

--- a/src/link/C/zig.h
+++ b/src/link/C/zig.h
@@ -89,6 +89,18 @@
 #define zig_prefetch(addr, rw, locality)
 #endif
 
+#if defined(__clang__)
+#define zig_wasm_memory_size(index) __builtin_wasm_memory_size(index)
+#else
+#define zig_wasm_memory_size(index) 0
+#endif
+
+#if defined(__clang__)
+#define zig_wasm_memory_grow(index, delta) __builtin_wasm_memory_grow(index, delta)
+#else
+#define zig_wasm_memory_grow(index, delta) 0
+#endif
+
 #if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
 #include <stdatomic.h>
 #define zig_cmpxchg_strong(obj, expected, desired, succ, fail) atomic_compare_exchange_strong_explicit(obj, &(expected), desired, succ, fail)

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -627,16 +627,12 @@ const Writer = struct {
 
     fn writeWasmMemorySize(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
         const ty_pl = w.air.instructions.items(.data)[inst].ty_pl;
-        const extra = w.air.extraData(Air.WasmMemoryIndex, ty_pl.payload).data;
-
-        try s.print("{d}", .{extra.index});
+        try s.print("{d}", .{ty_pl.payload});
     }
 
     fn writeWasmMemoryGrow(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
         const pl_op = w.air.instructions.items(.data)[inst].pl_op;
-        const extra = w.air.extraData(Air.WasmMemoryIndex, pl_op.payload).data;
-
-        try s.print("{d}, ", .{extra.index});
+        try s.print("{d}, ", .{pl_op.payload});
         try w.writeOperand(s, inst, 0, pl_op.operand);
     }
 

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -250,6 +250,7 @@ const Writer = struct {
             .memcpy => try w.writeMemcpy(s, inst),
             .memset => try w.writeMemset(s, inst),
             .field_parent_ptr => try w.writeFieldParentPtr(s, inst),
+            .wasm_memory_size => try w.writeWasmMemorySize(s, inst),
 
             .add_with_overflow,
             .sub_with_overflow,
@@ -621,6 +622,13 @@ const Writer = struct {
         try s.writeAll("\n");
         try s.writeByteNTimes(' ', old_indent);
         try s.writeAll("}");
+    }
+
+    fn writeWasmMemorySize(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
+        const pl_op = w.air.instructions.items(.data)[inst].ty_pl;
+        const extra = w.air.extraData(Air.WasmMemoryIndex, pl_op.payload).data;
+
+        try s.print(", {d}", .{extra.index});
     }
 
     fn writeOperand(

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -251,6 +251,7 @@ const Writer = struct {
             .memset => try w.writeMemset(s, inst),
             .field_parent_ptr => try w.writeFieldParentPtr(s, inst),
             .wasm_memory_size => try w.writeWasmMemorySize(s, inst),
+            .wasm_memory_grow => try w.writeWasmMemoryGrow(s, inst),
 
             .add_with_overflow,
             .sub_with_overflow,
@@ -625,10 +626,18 @@ const Writer = struct {
     }
 
     fn writeWasmMemorySize(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
-        const pl_op = w.air.instructions.items(.data)[inst].ty_pl;
+        const ty_pl = w.air.instructions.items(.data)[inst].ty_pl;
+        const extra = w.air.extraData(Air.WasmMemoryIndex, ty_pl.payload).data;
+
+        try s.print("{d}", .{extra.index});
+    }
+
+    fn writeWasmMemoryGrow(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
+        const pl_op = w.air.instructions.items(.data)[inst].pl_op;
         const extra = w.air.extraData(Air.WasmMemoryIndex, pl_op.payload).data;
 
-        try s.print(", {d}", .{extra.index});
+        try s.print("{d}, ", .{extra.index});
+        try w.writeOperand(s, inst, 0, pl_op.operand);
     }
 
     fn writeOperand(

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -626,8 +626,8 @@ const Writer = struct {
     }
 
     fn writeWasmMemorySize(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
-        const ty_pl = w.air.instructions.items(.data)[inst].ty_pl;
-        try s.print("{d}", .{ty_pl.payload});
+        const pl_op = w.air.instructions.items(.data)[inst].pl_op;
+        try s.print("{d}", .{pl_op.payload});
     }
 
     fn writeWasmMemoryGrow(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {

--- a/src/type.zig
+++ b/src/type.zig
@@ -5256,6 +5256,8 @@ pub const Type = extern union {
     pub const @"u32" = initTag(.u32);
     pub const @"u64" = initTag(.u64);
 
+    pub const @"i32" = initTag(.i32);
+
     pub const @"f16" = initTag(.f16);
     pub const @"f32" = initTag(.f32);
     pub const @"f64" = initTag(.f64);

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -96,7 +96,7 @@ test {
     _ = @import("behavior/void.zig");
     _ = @import("behavior/while.zig");
 
-    if (builtin.zig_backend == .stage2_wasm) {
+    if (builtin.stage2_arch == .wasm32) {
         _ = @import("behavior/wasm.zig");
     }
 
@@ -172,9 +172,6 @@ test {
                 _ = @import("behavior/struct_contains_slice_of_itself.zig");
                 _ = @import("behavior/typename.zig");
                 _ = @import("behavior/vector.zig");
-                if (builtin.target.cpu.arch == .wasm32) {
-                    _ = @import("behavior/wasm.zig");
-                }
             }
         }
     }

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -96,6 +96,10 @@ test {
     _ = @import("behavior/void.zig");
     _ = @import("behavior/while.zig");
 
+    if (builtin.zig_backend == .stage2_wasm) {
+        _ = @import("behavior/wasm.zig");
+    }
+
     if (builtin.zig_backend != .stage1) {
         _ = @import("behavior/decltest.zig");
     }

--- a/test/behavior/wasm.zig
+++ b/test/behavior/wasm.zig
@@ -3,8 +3,6 @@ const expect = std.testing.expect;
 const builtin = @import("builtin");
 
 test "memory size and grow" {
-    if (builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // TODO
-
     var prev = @wasmMemorySize(0);
     try expect(prev == @wasmMemoryGrow(0, 1));
     try expect(prev + 1 == @wasmMemorySize(0));

--- a/test/behavior/wasm.zig
+++ b/test/behavior/wasm.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
 const expect = std.testing.expect;
+const builtin = @import("builtin");
 
 test "memory size and grow" {
+    if (builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // TODO
+
     var prev = @wasmMemorySize(0);
     try expect(prev == @wasmMemoryGrow(0, 1));
     try expect(prev + 1 == @wasmMemorySize(0));


### PR DESCRIPTION
This implements the [@wasmMemorySize](https://ziglang.org/documentation/master/#wasmMemorySize) and [@wasmMemoryGrow](https://ziglang.org/documentation/master/#wasmMemoryGrow) builtins. Note that the implementation differs from stage1 whereas in stage2 it ensures the `index` argument is a comptime-known value. This is required, as the index is part of the instruction encoding, and therefore cannot be a runtime value. For stage1, this is only enforced by AstGen whereas in stage2 Sema also resolves it as a comptime value. I figured it wouldn't be worth the effort to correct this in stage1 when AstGen already enforces it there now as well. (This does however make this PR a breaking change).

Unfortunately, I have to perform quite some fixes within the self-hosted linker to ensure the LLVM backend can target wasm. For this reason, I'm leaving this builtin as a TODO for the LLVM backend. I plan on revisiting this soon.

@andrewrk I would appreciate it if you could review this PR to ensure it's in line with your thoughts.