### PR TITLE
stdlib std.os: Update CWD emulation to match wasi-libc behavior

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -11279,7 +11279,7 @@ pub fn main() !void {
     var preopens = PreopenList.init(gpa);
     defer preopens.deinit();
 
-    try preopens.populate();
+    try preopens.populate(null);
 
     for (preopens.asSlice()) |preopen, i| {
         std.debug.print("{}: {}\n", .{ i, preopen });

--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -735,7 +735,7 @@ pub fn resolvePosix(allocator: Allocator, paths: []const []const u8) ![]u8 {
 
 test "resolve" {
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     const cwd = try process.getCwdAlloc(testing.allocator);
     defer testing.allocator.free(cwd);
@@ -756,7 +756,7 @@ test "resolveWindows" {
         return error.SkipZigTest;
     }
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
     if (native_os == .windows) {
         const cwd = try process.getCwdAlloc(testing.allocator);
         defer testing.allocator.free(cwd);
@@ -802,7 +802,7 @@ test "resolveWindows" {
 
 test "resolvePosix" {
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     try testResolvePosix(&[_][]const u8{ "/a/b", "c" }, "/a/b/c");
     try testResolvePosix(&[_][]const u8{ "/a/b", "c", "//d", "e///" }, "/d/e");
@@ -1216,7 +1216,7 @@ test "relative" {
         return error.SkipZigTest;
     }
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     try testRelativeWindows("c:/blah\\blah", "d:/games", "D:\\games");
     try testRelativeWindows("c:/aaaa/bbbb", "c:/aaaa", "..");

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -47,7 +47,7 @@ fn testReadLink(dir: Dir, target_path: []const u8, symlink_path: []const u8) !vo
 
 test "accessAbsolute" {
     if (builtin.os.tag == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
@@ -66,7 +66,7 @@ test "accessAbsolute" {
 
 test "openDirAbsolute" {
     if (builtin.os.tag == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
@@ -103,7 +103,7 @@ test "openDir cwd parent .." {
 
 test "readLinkAbsolute" {
     if (builtin.os.tag == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
@@ -535,7 +535,7 @@ test "rename" {
 
 test "renameAbsolute" {
     if (builtin.os.tag == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     var tmp_dir = tmpDir(.{});
     defer tmp_dir.cleanup();
@@ -980,7 +980,7 @@ test "open file with exclusive nonblocking lock twice (absolute paths)" {
 
 test "walker" {
     if (builtin.os.tag == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     var tmp = tmpDir(.{ .iterate = true });
     defer tmp.cleanup();
@@ -1031,7 +1031,7 @@ test "walker" {
 
 test ". and .. in fs.Dir functions" {
     if (builtin.os.tag == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
@@ -1060,7 +1060,7 @@ test ". and .. in fs.Dir functions" {
 
 test ". and .. in absolute functions" {
     if (builtin.os.tag == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (builtin.os.tag == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     var tmp = tmpDir(.{});
     defer tmp.cleanup();

--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -3,6 +3,8 @@ const builtin = @import("builtin");
 const os = std.os;
 const mem = std.mem;
 const math = std.math;
+const fs = std.fs;
+const assert = std.debug.assert;
 const Allocator = mem.Allocator;
 const wasi = std.os.wasi;
 const fd_t = wasi.fd_t;
@@ -34,16 +36,27 @@ pub const PreopenType = union(PreopenTypeTag) {
 
     // Checks whether `other` refers to a subdirectory of `self` and, if so,
     // returns the relative path to `other` from `self`
+    //
+    // Expects `other` to be a canonical path, not containing "." or ".."
     pub fn getRelativePath(self: Self, other: PreopenType) ?[]const u8 {
         if (std.meta.activeTag(self) != std.meta.activeTag(other)) return null;
 
         switch (self) {
-            PreopenTypeTag.Dir => |this_path| {
+            PreopenTypeTag.Dir => |self_path| {
                 const other_path = other.Dir;
-                if (mem.indexOfDiff(u8, this_path, other_path)) |index| {
-                    if (index < this_path.len) return null;
+                if (mem.indexOfDiff(u8, self_path, other_path)) |index| {
+                    if (index < self_path.len) return null;
                 }
-                return other_path[this_path.len..];
+
+                const rel_path = other_path[self_path.len..];
+                if (rel_path.len == 0) {
+                    return rel_path;
+                } else if (rel_path[0] == '/') {
+                    return rel_path[1..];
+                } else {
+                    if (self_path[self_path.len - 1] != '/') return null;
+                    return rel_path;
+                }
             },
         }
     }
@@ -130,7 +143,22 @@ pub const PreopenList = struct {
     /// the preopen list still contains all valid preopened file descriptors that are valid
     /// for use. Therefore, it is fine to call `find`, `asSlice`, or `toOwnedSlice`. Finally,
     /// `deinit` still must be called!
-    pub fn populate(self: *Self) Error!void {
+    ///
+    /// Usage of `cwd_root`:
+    ///     If provided, `cwd_root` is inserted as prefix for any Preopens that
+    ///     begin with "." and all paths are normalized as POSIX-style absolute
+    ///     paths. `cwd_root` must be an absolute path.
+    ///
+    ///     For example:
+    ///        "./foo/bar" -> "{cwd_root}/foo/bar"
+    ///        "foo/bar"   -> "/foo/bar"
+    ///        "/foo/bar"  -> "/foo/bar"
+    ///
+    ///     If `cwd_root` is not provided, all preopen directories are unmodified.
+    ///
+    pub fn populate(self: *Self, cwd_root: ?[]const u8) Error!void {
+        if (cwd_root) |root| assert(fs.path.isAbsolute(root));
+
         // Clear contents if we're being called again
         for (self.toOwnedSlice()) |preopen| {
             switch (preopen.@"type") {
@@ -140,6 +168,7 @@ pub const PreopenList = struct {
         errdefer self.deinit();
         var fd: fd_t = 3; // start fd has to be beyond stdio fds
 
+        var path_buf: [fs.MAX_PATH_BYTES]u8 = undefined;
         while (true) {
             var buf: prestat_t = undefined;
             switch (wasi.fd_prestat_get(fd, &buf)) {
@@ -156,14 +185,34 @@ pub const PreopenList = struct {
                 else => |err| return os.unexpectedErrno(err),
             }
             const preopen_len = buf.u.dir.pr_name_len;
-            const path_buf = try self.buffer.allocator.alloc(u8, preopen_len);
-            mem.set(u8, path_buf, 0);
-            switch (wasi.fd_prestat_dir_name(fd, path_buf.ptr, preopen_len)) {
+
+            mem.set(u8, path_buf[0..preopen_len], 0);
+            switch (wasi.fd_prestat_dir_name(fd, &path_buf, preopen_len)) {
                 .SUCCESS => {},
                 else => |err| return os.unexpectedErrno(err),
             }
 
-            const preopen = Preopen.new(fd, PreopenType{ .Dir = path_buf });
+            // Unfortunately, WASI runtimes (e.g. wasmer) are not consistent about whether the
+            // NULL sentinel is included in the reported Preopen name_len
+            const raw_path = if (path_buf[preopen_len - 1] == 0) blk: {
+                break :blk path_buf[0 .. preopen_len - 1];
+            } else path_buf[0..preopen_len];
+
+            // If we were provided a CWD root to resolve against, we try to treat Preopen dirs as
+            // POSIX paths, relative to "/" or `cwd_root` depending on whether they start with "."
+            const path = if (cwd_root) |cwd| blk: {
+                const resolve_paths: [][]const u8 = if (raw_path[0] == '.') &.{ cwd, raw_path } else &.{ "/", raw_path };
+                break :blk fs.path.resolve(self.buffer.allocator, resolve_paths) catch |err| switch (err) {
+                    error.CurrentWorkingDirectoryUnlinked => unreachable, // root is absolute, so CWD not queried
+                    else => |e| return e,
+                };
+            } else blk: {
+                // If we were provided no CWD root, we preserve the preopen dir without resolving
+                break :blk try self.buffer.allocator.dupe(u8, raw_path);
+            };
+            errdefer self.buffer.allocator.free(path);
+            const preopen = Preopen.new(fd, .{ .Dir = path });
+
             try self.buffer.append(preopen);
             fd = try math.add(fd_t, fd, 1);
         }
@@ -171,27 +220,22 @@ pub const PreopenList = struct {
 
     /// Find a preopen which includes access to `preopen_type`.
     ///
-    /// If the preopen exists, `relative_path` is updated to point to the relative
-    /// portion of `preopen_type` and the matching Preopen is returned. If multiple
-    /// preopens match the provided resource, the most recent one is used.
+    /// If multiple preopens match the provided resource, the most specific
+    /// match is returned. More recent preopens take priority, as well.
     pub fn findContaining(self: Self, preopen_type: PreopenType) ?PreopenUri {
-        // Search in reverse, so that most recently added preopens take precedence
-        var k: usize = self.buffer.items.len;
-        while (k > 0) {
-            k -= 1;
+        var best_match: ?PreopenUri = null;
 
-            const preopen = self.buffer.items[k];
-            if (preopen.@"type".getRelativePath(preopen_type)) |rel_path_orig| {
-                var rel_path = rel_path_orig;
-                while (rel_path.len > 0 and rel_path[0] == '/') rel_path = rel_path[1..];
-
-                return PreopenUri{
-                    .base = preopen,
-                    .relative_path = if (rel_path.len == 0) "." else rel_path,
-                };
+        for (self.buffer.items) |preopen| {
+            if (preopen.@"type".getRelativePath(preopen_type)) |rel_path| {
+                if (best_match == null or rel_path.len <= best_match.?.relative_path.len) {
+                    best_match = PreopenUri{
+                        .base = preopen,
+                        .relative_path = if (rel_path.len == 0) "." else rel_path,
+                    };
+                }
             }
         }
-        return null;
+        return best_match;
     }
 
     /// Find preopen by fd. If the preopen exists, return it.
@@ -233,8 +277,20 @@ test "extracting WASI preopens" {
     var preopens = PreopenList.init(std.testing.allocator);
     defer preopens.deinit();
 
-    try preopens.populate();
+    try preopens.populate(null);
 
     const preopen = preopens.find(PreopenType{ .Dir = "." }) orelse unreachable;
     try std.testing.expect(preopen.@"type".eql(PreopenType{ .Dir = "." }));
+
+    const po_type1 = PreopenType{ .Dir = "/" };
+    try std.testing.expect(std.mem.eql(u8, po_type1.getRelativePath(.{ .Dir = "/" }).?, ""));
+    try std.testing.expect(std.mem.eql(u8, po_type1.getRelativePath(.{ .Dir = "/test/foobar" }).?, "test/foobar"));
+
+    const po_type2 = PreopenType{ .Dir = "/test/foo" };
+    try std.testing.expect(po_type2.getRelativePath(.{ .Dir = "/test/foobar" }) == null);
+
+    const po_type3 = PreopenType{ .Dir = "/test" };
+    try std.testing.expect(std.mem.eql(u8, po_type3.getRelativePath(.{ .Dir = "/test" }).?, ""));
+    try std.testing.expect(std.mem.eql(u8, po_type3.getRelativePath(.{ .Dir = "/test/" }).?, ""));
+    try std.testing.expect(std.mem.eql(u8, po_type3.getRelativePath(.{ .Dir = "/test/foo/bar" }).?, "foo/bar"));
 }

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -49,7 +49,7 @@ test "chdir smoke test" {
 
 test "open smoke test" {
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     // TODO verify file attributes using `fstat`
 
@@ -104,7 +104,7 @@ test "open smoke test" {
 
 test "openat smoke test" {
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     // TODO verify file attributes using `fstatat`
 
@@ -141,7 +141,7 @@ test "openat smoke test" {
 
 test "symlink with relative paths" {
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     const cwd = fs.cwd();
     cwd.deleteFile("file.txt") catch {};
@@ -197,7 +197,7 @@ test "link with relative paths" {
             if (builtin.link_libc) {
                 return error.SkipZigTest;
             } else {
-                try os.initPreopensWasi(std.heap.page_allocator, ".");
+                try os.initPreopensWasi(std.heap.page_allocator, "/");
             }
         },
         .linux, .solaris => {},
@@ -237,7 +237,7 @@ test "link with relative paths" {
 
 test "linkat with different directories" {
     switch (native_os) {
-        .wasi => if (!builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "."),
+        .wasi => if (!builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/"),
         .linux, .solaris => {},
         else => return error.SkipZigTest,
     }
@@ -898,7 +898,7 @@ test "POSIX file locking with fcntl" {
 
 test "rename smoke test" {
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
@@ -955,7 +955,7 @@ test "rename smoke test" {
 
 test "access smoke test" {
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
-    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, ".");
+    if (native_os == .wasi and !builtin.link_libc) try os.initPreopensWasi(std.heap.page_allocator, "/");
 
     var tmp = tmpDir(.{});
     defer tmp.cleanup();

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -380,7 +380,7 @@ fn getCwdOrWasiPreopen() std.fs.Dir {
     if (builtin.os.tag == .wasi and !builtin.link_libc) {
         var preopens = std.fs.wasi.PreopenList.init(allocator);
         defer preopens.deinit();
-        preopens.populate() catch
+        preopens.populate(null) catch
             @panic("unable to make tmp dir for testing: unable to populate preopens");
         const preopen = preopens.find(std.fs.wasi.PreopenType{ .Dir = "." }) orelse
             @panic("unable to make tmp dir for testing: didn't find '.' in the preopens");


### PR DESCRIPTION
Dependent on #11021 .

Some more work is needed to align our CWD treatment on WASI with wasi-libc. This is particularly important for runtimes like wasmer, which inserts a special "/" Preopen by default and also strips leading slashes from other Preopens

Here's the idea behind these changes:
1. We store the CWD as a simple `[]const u8`. We lookup Preopens for every absolute or CWD-referenced file operation, based on the Preopen with the longest match (i.e. most specific path)
2. Preorders are normalized to POSIX absolute paths at init time, based on the `cwd_root` parameter of `initPreopensWasi`.  cwd_root is used _only_ for any Preopens that start with "." so that:
```
   "./foo/bar" ~ canonicalizes to ~> "{cwd_root}/foo/bar"
   "foo/bar"   ~ canonicalizes to ~> "/foo/bar"
   "/foo/bar"  ~ canonicalizes to ~> "/foo/bar"
```

The intention is that:
 - Using "/" as `cwd_root` gives behavior similar to wasi-libc
 - Applications can provide a unique prefix, such as "/preopens/cwd" to prevent name collisions, esp. with the "." Preopen

These changes come at a performance cost, since we no longer cache any matching Preopen for the CWD, but the implementation is also much simpler and the compatibility gain from matching wasi-libc's behavior seems worth it.

Another consequence is that we no longer support `fchdir` on WASI