### PR TITLE
stage2: decl equality so &a == &a in comptime

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -810,6 +810,21 @@ pub const Decl = struct {
         // as also alive, so that any Decl referenced does not get garbage collected.
         decl.val.markReferencedDeclsAlive();
     }
+
+    /// Two decls are considering equal if they were created in the same
+    /// scope from the exact same AST node.
+    pub fn eql(decl: *Decl, decl2: *Decl) bool {
+        // In most cases, the decls are pointer equivalent. Trivial.
+        if (decl == decl2) return true;
+
+        // In some cases, decls aren't pointer equiv but still equal.
+        // Example: &a == &a creates two decls, but are equal so long
+        // as its created in the same scope from the same node.
+        // TODO would be much better to intern decls rather than store
+        // duplicates and perform this comparison.
+        return decl.src_scope == decl2.src_scope and
+            decl.src_node == decl2.src_node;
+    }
 };
 
 /// This state is attached to every Decl when Module emit_h is non-null.

--- a/src/value.zig
+++ b/src/value.zig
@@ -1788,8 +1788,8 @@ pub const Value = extern union {
         if (lhs.pointerDecl()) |lhs_decl| {
             if (rhs.pointerDecl()) |rhs_decl| {
                 switch (op) {
-                    .eq => return lhs_decl == rhs_decl,
-                    .neq => return lhs_decl != rhs_decl,
+                    .eq => return lhs_decl.eql(rhs_decl),
+                    .neq => return !lhs_decl.eql(rhs_decl),
                     else => {},
                 }
             } else {
@@ -1936,7 +1936,7 @@ pub const Value = extern union {
 
         if (a.pointerDecl()) |a_decl| {
             if (b.pointerDecl()) |b_decl| {
-                return a_decl == b_decl;
+                return a_decl.eql(b_decl);
             } else {
                 return false;
             }

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -206,7 +206,11 @@ test "allowzero pointer and slice" {
 }
 
 test "assign null directly to C pointer and test null equality" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
 
     var x: [*c]i32 = null;
     try expect(x == null);


### PR DESCRIPTION
In stage2, decl ref equality was `decl == decl2` (pointer comparison).
But it is possible for two identical decls to have two separate pointers
via the `ref` ZIR. Each `ref` ZIR creates a new anonymous decl.
Therefore, `&a == &a` would return false in comptime.

This modifies the comparison so that if the pointers are not equivalent
(they are in the fast path), then we check if they were created in the
same scope from the same AST node. If so, we assume they're equivalent.

A better solution would probably be to intern decls so that we don't create
unnecessary decls, but that felt a lot harder to do. 

This definitely feels like the _wrong_ solution or at the very least a 
highly _suspect_ solution but existing tests continue to pass and the new 
test I found failing works, so I'm not sure. I'm opening this PR for discussion,
I'm not confident in this one. 😄 

This was the exact test that was failing before for stage2, passing stage1:

```zig
test "comptime decl equality" {
  var a: i32 = undefined;
  try expect(&a == &a);
  try expect(@ptrToInt(&a) == @ptrToInt(&a));
}
```