### PR TITLE
correct `@frameSize()` params in documentation

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8664,7 +8664,7 @@ fn func() void {
       {#header_close#}
 
       {#header_open|@frameSize#}
-      <pre>{#syntax#}@frameSize() usize{#endsyntax#}</pre>
+      <pre>{#syntax#}@frameSize(func: anytype) usize{#endsyntax#}</pre>
       <p>
       This is the same as {#syntax#}@sizeOf(@Frame(func)){#endsyntax#}, where {#syntax#}func{#endsyntax#}
       may be runtime-known.


### PR DESCRIPTION
The documentation omitted the primary parameter, making it difficult to
understand what this function actually does.