### PR TITLE
link: debug info for non-pointer optionals

### DIFF
--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -1019,7 +1019,14 @@ fn genArgDbgInfo(emit: *Emit, inst: Air.Inst.Index, mcv: MCValue, max_stack: u32
             switch (emit.debug_output) {
                 .dwarf => |dbg_out| {
                     try dbg_out.dbg_info.ensureUnusedCapacity(3);
-                    dbg_out.dbg_info.appendAssumeCapacity(link.File.Elf.abbrev_parameter);
+
+                    // TODO this will go away once we pull DWARF into a cross-platform module.
+                    if (emit.bin_file.cast(link.File.MachO)) |_| {
+                        dbg_out.dbg_info.appendAssumeCapacity(link.File.MachO.DebugSymbols.abbrev_parameter);
+                    } else if (emit.bin_file.cast(link.File.Elf)) |_| {
+                        dbg_out.dbg_info.appendAssumeCapacity(link.File.Elf.abbrev_parameter);
+                    } else return emit.fail("TODO DWARF in non-MachO and non-ELF backend", .{});
+
                     dbg_out.dbg_info.appendSliceAssumeCapacity(&[2]u8{ // DW.AT.location, DW.FORM.exprloc
                         1, // ULEB128 dwarf expression length
                         reg.dwarfLocOp(),
@@ -1042,7 +1049,14 @@ fn genArgDbgInfo(emit: *Emit, inst: Air.Inst.Index, mcv: MCValue, max_stack: u32
                     // for example when -fomit-frame-pointer is set.
                     const disp = @intCast(i32, max_stack) - off + 16;
                     try dbg_out.dbg_info.ensureUnusedCapacity(8);
-                    dbg_out.dbg_info.appendAssumeCapacity(link.File.Elf.abbrev_parameter);
+
+                    // TODO this will go away once we pull DWARF into a cross-platform module.
+                    if (emit.bin_file.cast(link.File.MachO)) |_| {
+                        dbg_out.dbg_info.appendAssumeCapacity(link.File.MachO.DebugSymbols.abbrev_parameter);
+                    } else if (emit.bin_file.cast(link.File.Elf)) |_| {
+                        dbg_out.dbg_info.appendAssumeCapacity(link.File.Elf.abbrev_parameter);
+                    } else return emit.fail("TODO DWARF in non-MachO and non-ELF backend", .{});
+
                     const fixup = dbg_out.dbg_info.items.len;
                     dbg_out.dbg_info.appendSliceAssumeCapacity(&[2]u8{ // DW.AT.location, DW.FORM.exprloc
                         1, // we will backpatch it after we encode the displacement in LEB128

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -639,7 +639,6 @@ pub fn generateSymbol(
             return Result{ .appended = {} };
         },
         .Optional => {
-            // TODO generate debug info for optionals
             var opt_buf: Type.Payload.ElemType = undefined;
             const payload_type = typed_value.ty.optionalChild(&opt_buf);
             const is_pl = !typed_value.val.isNull();

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -27,7 +27,6 @@ const Atom = @import("MachO/Atom.zig");
 const Cache = @import("../Cache.zig");
 const CodeSignature = @import("MachO/CodeSignature.zig");
 const Compilation = @import("../Compilation.zig");
-const DebugSymbols = @import("MachO/DebugSymbols.zig");
 const Dylib = @import("MachO/Dylib.zig");
 const File = link.File;
 const Object = @import("MachO/Object.zig");
@@ -43,6 +42,7 @@ const TypedValue = @import("../TypedValue.zig");
 const Value = @import("../value.zig").Value;
 
 pub const TextBlock = Atom;
+pub const DebugSymbols = @import("MachO/DebugSymbols.zig");
 
 pub const base_tag: File.Tag = File.Tag.macho;
 

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -78,16 +78,15 @@ debug_aranges_section_dirty: bool = false,
 debug_info_header_dirty: bool = false,
 debug_line_header_dirty: bool = false,
 
-const abbrev_compile_unit = 1;
-const abbrev_subprogram = 2;
-const abbrev_subprogram_retvoid = 3;
-const abbrev_base_type = 4;
-const abbrev_ptr_type = 5;
-const abbrev_struct_type = 6;
-const abbrev_anon_struct_type = 7;
-const abbrev_struct_member = 8;
-const abbrev_pad1 = 9;
-const abbrev_parameter = 10;
+pub const abbrev_compile_unit = 1;
+pub const abbrev_subprogram = 2;
+pub const abbrev_subprogram_retvoid = 3;
+pub const abbrev_base_type = 4;
+pub const abbrev_ptr_type = 5;
+pub const abbrev_struct_type = 6;
+pub const abbrev_struct_member = 7;
+pub const abbrev_pad1 = 8;
+pub const abbrev_parameter = 9;
 
 /// The reloc offset for the virtual address of a function in its Line Number Program.
 /// Size is a virtual address integer.
@@ -351,13 +350,6 @@ pub fn flushModule(self: *DebugSymbols, allocator: Allocator, options: link.Opti
             DW.FORM.sdata,
             DW.AT.name,
             DW.FORM.string,
-            0,
-            0, // table sentinel
-            abbrev_anon_struct_type,
-            DW.TAG.structure_type,
-            DW.CHILDREN.yes, // header
-            DW.AT.byte_size,
-            DW.FORM.sdata,
             0,
             0, // table sentinel
             abbrev_struct_member,

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -1126,18 +1126,6 @@ pub fn commitDeclDebugInfo(
                 mem.writeIntLittle(u32, ptr, @intCast(u32, text_block.size));
             }
 
-            {
-                // Advance line and PC.
-                // TODO encapsulate logic in a helper function.
-                try dbg_line_buffer.append(DW.LNS.advance_pc);
-                try leb.writeULEB128(dbg_line_buffer.writer(), text_block.size);
-
-                try dbg_line_buffer.append(DW.LNS.advance_line);
-                const func = decl.val.castTag(.function).?.data;
-                const line_off = @intCast(u28, func.rbrace_line - func.lbrace_line);
-                try leb.writeULEB128(dbg_line_buffer.writer(), line_off);
-            }
-
             try dbg_line_buffer.appendSlice(&[_]u8{ DW.LNS.extended_op, 1, DW.LNE.end_sequence });
 
             // Now we have the full contents and may allocate a region to store it.


### PR DESCRIPTION
But also:
* migrate to named struct for slices - `lldb` kindly hinted me that we should name the structs with the typename, so we now get a slice recognise by its type, say `[]const u8` or whatnot
* when padding out compiled machine code section in MachO, write NOPs instead of `0x0` - while this is not strictly required, it un-breaks helper utilities for analysing MachO binaries such as MachOView.app which now properly displays the start and end of each atom with the compiled machine code section
* remove `anon_struct_type` abbrev type from DWARF as we don't actually need it any longer since slices and optionals are named struct where name is their actual type
* fix incorrect line and PC advancement in MachO DWARF - a left-over after one of my earlier cleanups

This is probably my last update to debug info in its current form. I think it's high time I investigated separating DWARF from the linking backends and made it reusable across targets: MachO, ELF, COFF, Wasm, etc. So this is what I'll be working on next.