### PR TITLE
stage2: coerce [*:0]u8 to other valid pointer types

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -19937,6 +19937,7 @@ fn typePtrOrOptionalPtrTy(
         .many_mut_pointer,
         .manyptr_u8,
         .manyptr_const_u8,
+        .manyptr_const_u8_sentinel_0,
         => return ty,
 
         .pointer => switch (ty.ptrSize()) {


### PR DESCRIPTION
A `manyptr_const_u8_sentinel_0` is a pointer type.

This makes the following work properly (as it does in stage1, too):

```zig
  var zero_ptr: [*:0]const u8 = undefined;
  var no_zero_ptr: [*]const u8 = zero_ptr;
```

Prior to this this would fail with an "expected type" error since
coercion failed.

No test, the "null terminated pointer" test is closer to passing with this but still has some other issues and I didn't feel it was worth making a dedicated test for this one small change since that test clearly will exercise it once it is passing.