### PR TITLE
stage2: wasm - fix incremental compilation

### DIFF
--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -504,7 +504,7 @@ pub fn updateFunc(self: *Wasm, module: *Module, func: *Module.Fn, air: Air, live
     const decl = func.owner_decl;
     assert(decl.link.wasm.sym_index != 0); // Must call allocateDeclIndexes()
 
-    decl.link.wasm.clear(self.base.allocator);
+    decl.link.wasm.clear();
 
     var code_writer = std.ArrayList(u8).init(self.base.allocator);
     defer code_writer.deinit();
@@ -542,7 +542,7 @@ pub fn updateDecl(self: *Wasm, module: *Module, decl: *Module.Decl) !void {
 
     assert(decl.link.wasm.sym_index != 0); // Must call allocateDeclIndexes()
 
-    decl.link.wasm.clear(self.base.allocator);
+    decl.link.wasm.clear();
 
     if (decl.isExtern()) {
         return self.addOrUpdateImport(decl);
@@ -827,7 +827,7 @@ pub fn freeDecl(self: *Wasm, decl: *Module.Decl) void {
         assert(self.imports.remove(atom.symbolLoc()));
     }
     assert(self.resolved_symbols.swapRemove(atom.symbolLoc()));
-    assert(self.symbol_atom.remove(atom.symbolLoc()));
+    _ = self.symbol_atom.remove(atom.symbolLoc()); // not all decl's exist in symbol_atom
     atom.deinit(self.base.allocator);
 }
 

--- a/src/link/Wasm/Atom.zig
+++ b/src/link/Wasm/Atom.zig
@@ -62,14 +62,9 @@ pub fn deinit(self: *Atom, gpa: Allocator) void {
 
 /// Sets the length of relocations and code to '0',
 /// effectively resetting them and allowing them to be re-populated.
-pub fn clear(self: *Atom, gpa: Allocator) void {
+pub fn clear(self: *Atom) void {
     self.relocs.clearRetainingCapacity();
     self.code.clearRetainingCapacity();
-
-    // locals will be re-generated
-    for (self.locals.items) |*local| {
-        local.deinit(gpa);
-    }
 }
 
 pub fn format(self: Atom, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {


### PR DESCRIPTION
- atoms may have relocations, so freeing them when we update the parent atom will cause segfaults.
- Not all declarations will live in symbol_atom as they may already been freed by `resetState`.

Fixes the test error caused by #11070 