### PR TITLE
stage2: sentinel-terminated array initialization

### DIFF
--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -710,12 +710,20 @@ pub const Inst = struct {
         /// Array initialization syntax.
         /// Uses the `pl_node` field. Payload is `MultiOp`.
         array_init,
+        /// Array initialization with sentinel.
+        /// Uses the `pl_node` field. Payload is `MultiOp`.
+        /// Final op in MultiOp is the sentinel.
+        array_init_sent,
         /// Anonymous array initialization syntax.
         /// Uses the `pl_node` field. Payload is `MultiOp`.
         array_init_anon,
         /// Array initialization syntax, make the result a pointer.
         /// Uses the `pl_node` field. Payload is `MultiOp`.
         array_init_ref,
+        /// Array initialization with sentinel.
+        /// Uses the `pl_node` field. Payload is `MultiOp`.
+        /// Final op in MultiOp is the sentinel.
+        array_init_sent_ref,
         /// Anonymous array initialization syntax, make the result a pointer.
         /// Uses the `pl_node` field. Payload is `MultiOp`.
         array_init_anon_ref,
@@ -1119,8 +1127,10 @@ pub const Inst = struct {
                 .struct_init_anon,
                 .struct_init_anon_ref,
                 .array_init,
+                .array_init_sent,
                 .array_init_anon,
                 .array_init_ref,
+                .array_init_sent_ref,
                 .array_init_anon_ref,
                 .union_init,
                 .field_type,
@@ -1377,8 +1387,10 @@ pub const Inst = struct {
                 .struct_init_anon = .pl_node,
                 .struct_init_anon_ref = .pl_node,
                 .array_init = .pl_node,
+                .array_init_sent = .pl_node,
                 .array_init_anon = .pl_node,
                 .array_init_ref = .pl_node,
+                .array_init_sent_ref = .pl_node,
                 .array_init_anon_ref = .pl_node,
                 .union_init = .pl_node,
                 .type_info = .un_node,

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -270,6 +270,14 @@ test "assign null directly to C pointer and test null equality" {
     comptime try expect((y1 orelse &othery) == y1);
 }
 
+test "array initialization types" {
+    const E = enum { A, B, C };
+    try expect(@TypeOf([_]u8{}) == [0]u8);
+    try expect(@TypeOf([_:0]u8{}) == [0:0]u8);
+    try expect(@TypeOf([_:.A]E{}) == [0:.A]E);
+    try expect(@TypeOf([_:0]u8{ 1, 2, 3 }) == [3:0]u8);
+}
+
 test "null terminated pointer" {
     if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
 


### PR DESCRIPTION
Array types with sentinels were not being typed correctly in the translation from ZIR to Sema (comptime). This uses a new ZIR inst `array_init_sent` (and a ref equivalent) to represent array init expressions that terminate in a a sentinel value.

The sentinel value is the last value in the `MultiOp` payload. This makes it a bit more awkward to deal with (lots of "len - 1") but makes it so that the payload matches the fact that sentinels appear at the end of arrays. However, this is not a hill I want to die on so if we want to change it to index 0, I'm happy to do so.

This makes the following work properly:

    try expect(@typeof([_:0]u8{}) == [0:0]u8);

Also see the new test added.

## Example ZIR

```zig
test "hello" {
    const E = enum { A, B, C };
    [_]u8{1};
    [_:0]u8{1};
    &[_:.A]E{1};
}
```

```
  [158] test "hello" line(7) hash(d854033f4f724756eb51a767d7de6355): %26 = block_inline({
    %51 = extended(func(test, ret_ty=void, inferror, body={
      %27 = dbg_stmt(2, 5)
      %28 = extended(enum_decl(anon, {}, {}, {
        A,
        B,
        C,
      }) node_offset:9:15
      %29 = dbg_stmt(3, 5)
      %30 = int(1)
      %31 = array_type(%30, @Ref.u8_type)
      %32 = as_node(@Ref.u8_type, @Ref.one) node_offset:10:11
      %33 = array_init(.{%32}) node_offset:10:10
      %34 = ensure_result_used(%33) node_offset:10:10
      %35 = dbg_stmt(4, 5)
      %36 = int(1)
      %37 = as_node(@Ref.u8_type, @Ref.zero) node_offset:11:8
      %38 = array_type_sentinel(%36, %37, @Ref.u8_type) node_offset:11:5
      %39 = as_node(@Ref.u8_type, @Ref.one) node_offset:11:13
      %40 = array_init_sent(%37, .{%39}) node_offset:11:12
      %41 = ensure_result_used(%40) node_offset:11:12
      %42 = dbg_stmt(5, 5)
      %43 = int(1)
      %44 = enum_literal("A") token_offset:12:10
      %45 = as_node(%28, %44) node_offset:12:10
      %46 = array_type_sentinel(%43, %45, %28) node_offset:12:6
      %47 = as_node(%28, @Ref.one) node_offset:12:14
      %48 = array_init_sent_ref(%45, .{%47}) node_offset:12:13
      %49 = ensure_result_used(%48) node_offset:12:5
      %50 = ret_tok(@Ref.void_value) token_offset:13:1
    }) (lbrace=1:11,rbrace=6:1) node_offset:8:1
    %52 = break_inline(%26, %51)
  }) node_offset:8:1
}, {}, {})
```