### PR TITLE
stage2: elem vals of many pointers need not deref pointers

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -15617,15 +15617,13 @@ fn elemVal(
                 return block.addBinOp(.slice_elem_val, array, elem_index);
             },
             .Many, .C => {
-                const maybe_ptr_val = try sema.resolveDefinedValue(block, array_src, array);
+                const maybe_array_val = try sema.resolveDefinedValue(block, array_src, array);
                 const maybe_index_val = try sema.resolveDefinedValue(block, elem_index_src, elem_index);
 
                 const runtime_src = rs: {
-                    const ptr_val = maybe_ptr_val orelse break :rs array_src;
+                    const array_val = maybe_array_val orelse break :rs array_src;
                     const index_val = maybe_index_val orelse break :rs elem_index_src;
                     const index = @intCast(usize, index_val.toUnsignedInt());
-                    const maybe_array_val = try sema.pointerDeref(block, array_src, ptr_val, array_ty);
-                    const array_val = maybe_array_val orelse break :rs array_src;
                     const elem_val = try array_val.elemValue(sema.arena, index);
                     return sema.addConstant(array_ty.elemType2(), elem_val);
                 };

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -521,7 +521,11 @@ fn testCastPtrOfArrayToSliceAndPtr() !void {
 }
 
 test "cast *[1][*]const u8 to [*]const ?[*]const u8" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const window_name = [1][*]const u8{"window name"};
     const x: [*]const ?[*]const u8 = &window_name;

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -279,7 +279,11 @@ test "array initialization types" {
 }
 
 test "null terminated pointer" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const S = struct {
         fn doTheTest() !void {
@@ -295,7 +299,11 @@ test "null terminated pointer" {
 }
 
 test "allow any sentinel" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const S = struct {
         fn doTheTest() !void {


### PR DESCRIPTION
By the time zirElemVal is reached for a many pointer at comptime, a load has already happened, making sure the operand is already dereferenced. This fixes a comptime-only failure scenario with elemval.

This makes `mem.sliceTo` now work in comptime (found 3 tests that now pass, at least...) 🥳 

Here is a minimal test case in case you want to compare. No need to add this test case since other tests exercise this, but this was what I used during debugging:

```zig
test "A" {
    comptime {
        var a: [*]const u8 = &[_]u8{1,2,3};
        try expect(a[1] == 2);
    }
}

test "B" {
    comptime {
        var array_with_zero = [_:0]u8{ 'h', 'e', 'l', 'l', 'o' };
        var zero_ptr: [*:0]const u8 = @ptrCast([*:0]const u8, &array_with_zero);
        try expect(zero_ptr[5] == 0);
    }
}
```