### PR TITLE
stage2: correct comptime-known inferred alloc type, plus comptime array init sentinels

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2623,10 +2623,9 @@ fn zirResolveInferredAlloc(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Com
                 // block so that codegen does not see it.
                 block.instructions.shrinkRetainingCapacity(block.instructions.items.len - 3);
                 sema.air_values.items[value_index] = try Value.Tag.decl_ref.create(sema.arena, new_decl);
-                // Would be nice if we could just assign `bitcast_ty_ref` to
-                // `air_datas[ptr_inst].ty_pl.ty`, wouldn't it? Alas, that is almost correct,
-                // except that the pointer is mutable and we need to make it constant here.
-                air_datas[ptr_inst].ty_pl.ty = try sema.addType(final_ptr_ty);
+                // if bitcast ty ref needs to be made const, make_ptr_const
+                // ZIR handles it later, so we can just use the ty ref here.
+                air_datas[ptr_inst].ty_pl.ty = air_datas[bitcast_inst].ty_op.ty;
 
                 return;
             }

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -317,7 +317,11 @@ test "allow any sentinel" {
 }
 
 test "pointer sentinel with enums" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const S = struct {
         const Number = enum {
@@ -336,7 +340,11 @@ test "pointer sentinel with enums" {
 }
 
 test "pointer sentinel with optional element" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const S = struct {
         fn doTheTest() !void {
@@ -349,7 +357,11 @@ test "pointer sentinel with optional element" {
 }
 
 test "pointer sentinel with +inf" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const S = struct {
         fn doTheTest() !void {


### PR DESCRIPTION
Two changes in here, both needed to get the tests passing in this PR.

At least 3 more passing tests!

1. For inferred allocs with values known at comptime _but not forced comptime_ (i.e. not in a `comptime {}` block), we were setting the incorrect type, causing cascading errors. We can now set the type to the bitcast type. The previous comment noted we can't do that due to constness, but @Vexu's recent `make_const_ptr` work fixes this.

2. A mistake from my prior PR on sentinel array initialization, I was not adding the sentinel to the end of the array value for comptime. Bonus: this solidifies that adding the sentinel as the final op in the `array_init_sent` ZIR is correct.

Tests used during debugging/development are below. First two are the inferred alloc commit, last one is the sentinel bug. The real behavior tests exercise both at once.

```zig
test "inferred alloc with sentinel" {
    const ary = [_:0]u8{42};
    const ptr: [*:0]const u8 = &ary;
    try expect(ptr[1] == 0);
}

test "inferred alloc with sentinel at comptime" {
    comptime {
        const ary = [_:0]u8{42};
        const ptr: [*:0]const u8 = &ary;
        try expect(ptr[1] == 0);
    }
}

test "comptime sentinel array init" {
    comptime {
        var ptr: [*:0]const u8 = &[_:0]u8{1};
        try expect(ptr[1] == 0);
    }
}
```