### PR TITLE
stage2: Array len field should be a usize not comptime_int

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -14729,7 +14729,7 @@ fn fieldVal(
         .Array => {
             if (mem.eql(u8, field_name, "len")) {
                 return sema.addConstant(
-                    Type.comptime_int,
+                    Type.usize,
                     try Value.Tag.int_u64.create(arena, inner_ty.arrayLen()),
                 );
             } else {
@@ -14767,7 +14767,7 @@ fn fieldVal(
             } else if (ptr_info.pointee_type.zigTypeTag() == .Array) {
                 if (mem.eql(u8, field_name, "len")) {
                     return sema.addConstant(
-                        Type.comptime_int,
+                        Type.usize,
                         try Value.Tag.int_u64.create(arena, ptr_info.pointee_type.arrayLen()),
                     );
                 } else {
@@ -14912,7 +14912,7 @@ fn fieldPtr(
                 var anon_decl = try block.startAnonDecl(src);
                 defer anon_decl.deinit();
                 return sema.analyzeDeclRef(try anon_decl.finish(
-                    Type.initTag(.comptime_int),
+                    Type.usize,
                     try Value.Tag.int_u64.create(anon_decl.arena(), inner_ty.arrayLen()),
                 ));
             } else {

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -104,6 +104,7 @@ test "array len field" {
     comptime try expect(arr.len == 4);
     try expect(ptr.len == 4);
     comptime try expect(ptr.len == 4);
+    try expect(@TypeOf(arr.len) == usize);
 }
 
 test "array with sentinels" {


### PR DESCRIPTION
Matches behavior of stage1, makes `std.mem` tests move forward a bit more when paired with #11122 