### PR TITLE
stage2: is_non_error always returns comptime true for empty error set

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -17926,6 +17926,15 @@ fn analyzeIsNonErr(
     if (ot != .ErrorSet and ot != .ErrorUnion) return Air.Inst.Ref.bool_true;
     if (ot == .ErrorSet) return Air.Inst.Ref.bool_false;
     assert(ot == .ErrorUnion);
+
+    // exception if the error union error set is known to be empty,
+    // we allow the comparison but always make it comptime known.
+    const set_ty = operand_ty.errorUnionSet();
+    switch (set_ty.tag()) {
+        .anyerror, .error_set_inferred => {},
+        else => if (set_ty.errorSetNames().len == 0) return Air.Inst.Ref.bool_true,
+    }
+
     const result_ty = Type.bool;
     if (try sema.resolveMaybeUndefVal(block, src, operand)) |err_union| {
         if (err_union.isUndef()) {

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -215,7 +215,11 @@ fn testExplicitErrorSetCast(set1: Set1) !void {
 }
 
 test "comptime test error for empty error set" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     try testComptimeTestErrorEmptySet(1234);
     comptime try testComptimeTestErrorEmptySet(1234);


### PR DESCRIPTION
This was a special case of the stage1 compiler that was exercised by the behavior tests.