### PR TITLE
stage2: Track parent type for `.elem_ptr`, `.field_ptr`, and `.*_payload_ptr`

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -885,7 +885,6 @@ pub const Struct = struct {
     /// one possible value.
     known_non_opv: bool,
     requires_comptime: PropertyBoolean = .unknown,
-    has_well_defined_layout: PropertyBoolean = .unknown,
 
     pub const Fields = std.StringArrayHashMapUnmanaged(Field);
 
@@ -1080,8 +1079,6 @@ pub const EnumFull = struct {
     /// An integer type which is used for the numerical value of the enum.
     /// Whether zig chooses this type or the user specifies it, it is stored here.
     tag_ty: Type,
-    /// true if zig inferred this tag type, false if user specified it
-    tag_ty_inferred: bool,
     /// Set of field names in declaration order.
     fields: NameMap,
     /// Maps integer tag value to field index.
@@ -1092,6 +1089,8 @@ pub const EnumFull = struct {
     namespace: Namespace,
     /// Offset from `owner_decl`, points to the enum decl AST node.
     node_offset: i32,
+    /// true if zig inferred this tag type, false if user specified it
+    tag_ty_inferred: bool,
 
     pub const NameMap = std.StringArrayHashMapUnmanaged(void);
     pub const ValueMap = std.ArrayHashMapUnmanaged(Value, void, Value.ArrayHashContext, false);
@@ -1136,7 +1135,6 @@ pub const Union = struct {
         fully_resolved,
     },
     requires_comptime: PropertyBoolean = .unknown,
-    has_well_defined_layout: PropertyBoolean = .unknown,
 
     pub const Field = struct {
         /// undefined until `status` is `have_field_types` or `have_layout`.

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -852,7 +852,7 @@ pub const ErrorSet = struct {
     }
 };
 
-pub const RequiresComptime = enum { no, yes, unknown, wip };
+pub const PropertyBoolean = enum { no, yes, unknown, wip };
 
 /// Represents the data that a struct declaration provides.
 pub const Struct = struct {
@@ -884,7 +884,8 @@ pub const Struct = struct {
     /// If false, resolving the fields is necessary to determine whether the type has only
     /// one possible value.
     known_non_opv: bool,
-    requires_comptime: RequiresComptime = .unknown,
+    requires_comptime: PropertyBoolean = .unknown,
+    has_well_defined_layout: PropertyBoolean = .unknown,
 
     pub const Fields = std.StringArrayHashMapUnmanaged(Field);
 
@@ -1079,6 +1080,8 @@ pub const EnumFull = struct {
     /// An integer type which is used for the numerical value of the enum.
     /// Whether zig chooses this type or the user specifies it, it is stored here.
     tag_ty: Type,
+    /// true if zig inferred this tag type, false if user specified it
+    tag_ty_inferred: bool,
     /// Set of field names in declaration order.
     fields: NameMap,
     /// Maps integer tag value to field index.
@@ -1132,7 +1135,8 @@ pub const Union = struct {
         // which `have_layout` does not ensure.
         fully_resolved,
     },
-    requires_comptime: RequiresComptime = .unknown,
+    requires_comptime: PropertyBoolean = .unknown,
+    has_well_defined_layout: PropertyBoolean = .unknown,
 
     pub const Field = struct {
         /// undefined until `status` is `have_field_types` or `have_layout`.

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1518,26 +1518,8 @@ pub const DeclGen = struct {
                     const llvm_int = llvm_usize.constInt(tv.val.toUnsignedInt(), .False);
                     return llvm_int.constIntToPtr(try dg.llvmType(tv.ty));
                 },
-                .field_ptr, .opt_payload_ptr, .eu_payload_ptr => {
-                    const parent = try dg.lowerParentPtr(tv.val, tv.ty);
-                    return parent.llvm_ptr.constBitCast(try dg.llvmType(tv.ty));
-                },
-                .elem_ptr => {
-                    const elem_ptr = tv.val.castTag(.elem_ptr).?.data;
-                    const parent = try dg.lowerParentPtr(elem_ptr.array_ptr, tv.ty);
-                    const llvm_usize = try dg.llvmType(Type.usize);
-                    if (parent.llvm_ptr.typeOf().getElementType().getTypeKind() == .Array) {
-                        const indices: [2]*const llvm.Value = .{
-                            llvm_usize.constInt(0, .False),
-                            llvm_usize.constInt(elem_ptr.index, .False),
-                        };
-                        return parent.llvm_ptr.constInBoundsGEP(&indices, indices.len);
-                    } else {
-                        const indices: [1]*const llvm.Value = .{
-                            llvm_usize.constInt(elem_ptr.index, .False),
-                        };
-                        return parent.llvm_ptr.constInBoundsGEP(&indices, indices.len);
-                    }
+                .field_ptr, .opt_payload_ptr, .eu_payload_ptr, .elem_ptr => {
+                    return dg.lowerParentPtr(tv.val, tv.ty.childType());
                 },
                 .null_value, .zero => {
                     const llvm_type = try dg.llvmType(tv.ty);
@@ -2786,7 +2768,7 @@ pub const DeclGen = struct {
         llvm_ptr: *const llvm.Value,
     };
 
-    fn lowerParentPtrDecl(dg: *DeclGen, ptr_val: Value, decl: *Module.Decl) Error!ParentPtr {
+    fn lowerParentPtrDecl(dg: *DeclGen, ptr_val: Value, decl: *Module.Decl, ptr_child_ty: Type) Error!*const llvm.Value {
         decl.markAlive();
         var ptr_ty_payload: Type.Payload.ElemType = .{
             .base = .{ .tag = .single_mut_pointer },
@@ -2794,123 +2776,104 @@ pub const DeclGen = struct {
         };
         const ptr_ty = Type.initPayload(&ptr_ty_payload.base);
         const llvm_ptr = try dg.lowerDeclRefValue(.{ .ty = ptr_ty, .val = ptr_val }, decl);
-        return ParentPtr{
-            .llvm_ptr = llvm_ptr,
-            .ty = decl.ty,
-        };
+
+        if (ptr_child_ty.eql(decl.ty)) {
+            return llvm_ptr;
+        } else {
+            return llvm_ptr.constBitCast((try dg.llvmType(ptr_child_ty)).pointerType(0));
+        }
     }
 
-    fn lowerParentPtr(dg: *DeclGen, ptr_val: Value, base_ty: Type) Error!ParentPtr {
-        switch (ptr_val.tag()) {
+    fn lowerParentPtr(dg: *DeclGen, ptr_val: Value, ptr_child_ty: Type) Error!*const llvm.Value {
+        var bitcast_needed: bool = undefined;
+        const llvm_ptr = switch (ptr_val.tag()) {
             .decl_ref_mut => {
                 const decl = ptr_val.castTag(.decl_ref_mut).?.data.decl;
-                return dg.lowerParentPtrDecl(ptr_val, decl);
+                return dg.lowerParentPtrDecl(ptr_val, decl, ptr_child_ty);
             },
             .decl_ref => {
                 const decl = ptr_val.castTag(.decl_ref).?.data;
-                return dg.lowerParentPtrDecl(ptr_val, decl);
+                return dg.lowerParentPtrDecl(ptr_val, decl, ptr_child_ty);
             },
             .variable => {
                 const decl = ptr_val.castTag(.variable).?.data.owner_decl;
-                return dg.lowerParentPtrDecl(ptr_val, decl);
+                return dg.lowerParentPtrDecl(ptr_val, decl, ptr_child_ty);
             },
             .int_i64 => {
                 const int = ptr_val.castTag(.int_i64).?.data;
                 const llvm_usize = try dg.llvmType(Type.usize);
                 const llvm_int = llvm_usize.constInt(@bitCast(u64, int), .False);
-                return ParentPtr{
-                    .llvm_ptr = llvm_int.constIntToPtr(try dg.llvmType(base_ty)),
-                    .ty = base_ty,
-                };
+                return llvm_int.constIntToPtr((try dg.llvmType(ptr_child_ty)).pointerType(0));
             },
             .int_u64 => {
                 const int = ptr_val.castTag(.int_u64).?.data;
                 const llvm_usize = try dg.llvmType(Type.usize);
                 const llvm_int = llvm_usize.constInt(int, .False);
-                return ParentPtr{
-                    .llvm_ptr = llvm_int.constIntToPtr(try dg.llvmType(base_ty)),
-                    .ty = base_ty,
-                };
+                return llvm_int.constIntToPtr((try dg.llvmType(ptr_child_ty)).pointerType(0));
             },
-            .field_ptr => {
+            .field_ptr => blk: {
                 const field_ptr = ptr_val.castTag(.field_ptr).?.data;
-                const parent = try dg.lowerParentPtr(field_ptr.container_ptr, base_ty);
+                const parent_llvm_ptr = try dg.lowerParentPtr(field_ptr.container_ptr, field_ptr.container_ty);
+                const parent_ty = field_ptr.container_ty;
+
                 const field_index = @intCast(u32, field_ptr.field_index);
                 const llvm_u32 = dg.context.intType(32);
                 const target = dg.module.getTarget();
-                switch (parent.ty.zigTypeTag()) {
+                switch (parent_ty.zigTypeTag()) {
                     .Union => {
-                        const fields = parent.ty.unionFields();
-                        const layout = parent.ty.unionGetLayout(target);
-                        const field_ty = fields.values()[field_index].ty;
+                        bitcast_needed = true;
+
+                        const layout = parent_ty.unionGetLayout(target);
                         if (layout.payload_size == 0) {
                             // In this case a pointer to the union and a pointer to any
                             // (void) payload is the same.
-                            return ParentPtr{
-                                .llvm_ptr = parent.llvm_ptr,
-                                .ty = field_ty,
-                            };
+                            break :blk parent_llvm_ptr;
                         }
-                        if (layout.tag_size == 0) {
-                            const indices: [2]*const llvm.Value = .{
-                                llvm_u32.constInt(0, .False),
-                                llvm_u32.constInt(0, .False),
-                            };
-                            return ParentPtr{
-                                .llvm_ptr = parent.llvm_ptr.constInBoundsGEP(&indices, indices.len),
-                                .ty = field_ty,
-                            };
-                        }
-                        const llvm_pl_index = @boolToInt(layout.tag_align >= layout.payload_align);
+                        const llvm_pl_index = if (layout.tag_size == 0) 0 else @boolToInt(layout.tag_align >= layout.payload_align);
                         const indices: [2]*const llvm.Value = .{
                             llvm_u32.constInt(0, .False),
                             llvm_u32.constInt(llvm_pl_index, .False),
                         };
-                        return ParentPtr{
-                            .llvm_ptr = parent.llvm_ptr.constInBoundsGEP(&indices, indices.len),
-                            .ty = field_ty,
-                        };
+                        break :blk parent_llvm_ptr.constInBoundsGEP(&indices, indices.len);
                     },
                     .Struct => {
+                        const field_ty = parent_ty.structFieldType(field_index);
+                        bitcast_needed = !field_ty.eql(ptr_child_ty);
+
                         var ty_buf: Type.Payload.Pointer = undefined;
-                        const llvm_field_index = llvmFieldIndex(parent.ty, field_index, target, &ty_buf).?;
+                        const llvm_field_index = llvmFieldIndex(parent_ty, field_index, target, &ty_buf).?;
                         const indices: [2]*const llvm.Value = .{
                             llvm_u32.constInt(0, .False),
                             llvm_u32.constInt(llvm_field_index, .False),
                         };
-                        return ParentPtr{
-                            .llvm_ptr = parent.llvm_ptr.constInBoundsGEP(&indices, indices.len),
-                            .ty = parent.ty.structFieldType(field_index),
-                        };
+                        break :blk parent_llvm_ptr.constInBoundsGEP(&indices, indices.len);
                     },
                     else => unreachable,
                 }
             },
-            .elem_ptr => {
+            .elem_ptr => blk: {
                 const elem_ptr = ptr_val.castTag(.elem_ptr).?.data;
-                const parent = try dg.lowerParentPtr(elem_ptr.array_ptr, base_ty);
+                const parent_llvm_ptr = try dg.lowerParentPtr(elem_ptr.array_ptr, elem_ptr.elem_ty);
+                bitcast_needed = !elem_ptr.elem_ty.eql(ptr_child_ty);
+
                 const llvm_usize = try dg.llvmType(Type.usize);
-                const indices: [2]*const llvm.Value = .{
-                    llvm_usize.constInt(0, .False),
+                const indices: [1]*const llvm.Value = .{
                     llvm_usize.constInt(elem_ptr.index, .False),
                 };
-                return ParentPtr{
-                    .llvm_ptr = parent.llvm_ptr.constInBoundsGEP(&indices, indices.len),
-                    .ty = parent.ty.childType(),
-                };
+                break :blk parent_llvm_ptr.constInBoundsGEP(&indices, indices.len);
             },
-            .opt_payload_ptr => {
+            .opt_payload_ptr => blk: {
                 const opt_payload_ptr = ptr_val.castTag(.opt_payload_ptr).?.data;
-                const parent = try dg.lowerParentPtr(opt_payload_ptr.container_ptr, base_ty);
+                const parent_llvm_ptr = try dg.lowerParentPtr(opt_payload_ptr.container_ptr, opt_payload_ptr.container_ty);
                 var buf: Type.Payload.ElemType = undefined;
-                const payload_ty = parent.ty.optionalChild(&buf);
-                if (!payload_ty.hasRuntimeBitsIgnoreComptime() or parent.ty.isPtrLikeOptional()) {
+
+                const payload_ty = opt_payload_ptr.container_ty.optionalChild(&buf);
+                bitcast_needed = !payload_ty.eql(ptr_child_ty);
+
+                if (!payload_ty.hasRuntimeBitsIgnoreComptime() or payload_ty.isPtrLikeOptional()) {
                     // In this case, we represent pointer to optional the same as pointer
                     // to the payload.
-                    return ParentPtr{
-                        .llvm_ptr = parent.llvm_ptr,
-                        .ty = payload_ty,
-                    };
+                    break :blk parent_llvm_ptr;
                 }
 
                 const llvm_u32 = dg.context.intType(32);
@@ -2918,22 +2881,19 @@ pub const DeclGen = struct {
                     llvm_u32.constInt(0, .False),
                     llvm_u32.constInt(0, .False),
                 };
-                return ParentPtr{
-                    .llvm_ptr = parent.llvm_ptr.constInBoundsGEP(&indices, indices.len),
-                    .ty = payload_ty,
-                };
+                break :blk parent_llvm_ptr.constInBoundsGEP(&indices, indices.len);
             },
-            .eu_payload_ptr => {
+            .eu_payload_ptr => blk: {
                 const eu_payload_ptr = ptr_val.castTag(.eu_payload_ptr).?.data;
-                const parent = try dg.lowerParentPtr(eu_payload_ptr.container_ptr, base_ty);
-                const payload_ty = parent.ty.errorUnionPayload();
+                const parent_llvm_ptr = try dg.lowerParentPtr(eu_payload_ptr.container_ptr, eu_payload_ptr.container_ty);
+
+                const payload_ty = eu_payload_ptr.container_ty.errorUnionPayload();
+                bitcast_needed = !payload_ty.eql(ptr_child_ty);
+
                 if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
                     // In this case, we represent pointer to error union the same as pointer
                     // to the payload.
-                    return ParentPtr{
-                        .llvm_ptr = parent.llvm_ptr,
-                        .ty = payload_ty,
-                    };
+                    break :blk parent_llvm_ptr;
                 }
 
                 const llvm_u32 = dg.context.intType(32);
@@ -2941,12 +2901,14 @@ pub const DeclGen = struct {
                     llvm_u32.constInt(0, .False),
                     llvm_u32.constInt(1, .False),
                 };
-                return ParentPtr{
-                    .llvm_ptr = parent.llvm_ptr.constInBoundsGEP(&indices, indices.len),
-                    .ty = payload_ty,
-                };
+                break :blk parent_llvm_ptr.constInBoundsGEP(&indices, indices.len);
             },
             else => unreachable,
+        };
+        if (bitcast_needed) {
+            return llvm_ptr.constBitCast((try dg.llvmType(ptr_child_ty)).pointerType(0));
+        } else {
+            return llvm_ptr;
         }
     }
 

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2829,7 +2829,10 @@ pub const DeclGen = struct {
                             // (void) payload is the same.
                             break :blk parent_llvm_ptr;
                         }
-                        const llvm_pl_index = if (layout.tag_size == 0) 0 else @boolToInt(layout.tag_align >= layout.payload_align);
+                        const llvm_pl_index = if (layout.tag_size == 0)
+                            0
+                        else
+                            @boolToInt(layout.tag_align >= layout.payload_align);
                         const indices: [2]*const llvm.Value = .{
                             llvm_u32.constInt(0, .False),
                             llvm_u32.constInt(llvm_pl_index, .False),

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2901,7 +2901,7 @@ pub const DeclGen = struct {
             },
             .opt_payload_ptr => {
                 const opt_payload_ptr = ptr_val.castTag(.opt_payload_ptr).?.data;
-                const parent = try dg.lowerParentPtr(opt_payload_ptr, base_ty);
+                const parent = try dg.lowerParentPtr(opt_payload_ptr.container_ptr, base_ty);
                 var buf: Type.Payload.ElemType = undefined;
                 const payload_ty = parent.ty.optionalChild(&buf);
                 if (!payload_ty.hasRuntimeBitsIgnoreComptime() or parent.ty.isPtrLikeOptional()) {
@@ -2925,7 +2925,7 @@ pub const DeclGen = struct {
             },
             .eu_payload_ptr => {
                 const eu_payload_ptr = ptr_val.castTag(.eu_payload_ptr).?.data;
-                const parent = try dg.lowerParentPtr(eu_payload_ptr, base_ty);
+                const parent = try dg.lowerParentPtr(eu_payload_ptr.container_ptr, base_ty);
                 const payload_ty = parent.ty.errorUnionPayload();
                 if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
                     // In this case, we represent pointer to error union the same as pointer

--- a/src/type.zig
+++ b/src/type.zig
@@ -4786,7 +4786,7 @@ pub const Type = extern union {
                         return field_offset.offset;
                 }
 
-                return std.mem.alignForwardGeneric(u64, it.offset, it.big_align);
+                return std.mem.alignForwardGeneric(u64, it.offset, @maximum(it.big_align, 1));
             },
 
             .tuple, .anon_struct => {
@@ -4809,7 +4809,7 @@ pub const Type = extern union {
                     if (i == index) return offset;
                     offset += field_ty.abiSize(target);
                 }
-                offset = std.mem.alignForwardGeneric(u64, offset, big_align);
+                offset = std.mem.alignForwardGeneric(u64, offset, @maximum(big_align, 1));
                 return offset;
             },
 

--- a/src/type.zig
+++ b/src/type.zig
@@ -4400,6 +4400,13 @@ pub const Type = extern union {
         };
     }
 
+    pub fn isArrayLike(ty: Type) bool {
+        return switch (ty.zigTypeTag()) {
+            .Array, .Vector => true,
+            else => false,
+        };
+    }
+
     pub fn isIndexable(ty: Type) bool {
         return switch (ty.zigTypeTag()) {
             .Array, .Vector => true,

--- a/src/value.zig
+++ b/src/value.zig
@@ -2417,7 +2417,7 @@ pub const Value = extern union {
         return switch (val.tag()) {
             .empty_array_sentinel => if (start == 0 and end == 1) val else Value.initTag(.empty_array),
             .bytes => Tag.bytes.create(arena, val.castTag(.bytes).?.data[start..end]),
-            .array => Tag.array.create(arena, val.castTag(.array).?.data[start..end]),
+            .aggregate => Tag.aggregate.create(arena, val.castTag(.aggregate).?.data[start..end]),
             .slice => sliceArray(val.castTag(.slice).?.data.ptr, arena, start, end),
 
             .decl_ref => sliceArray(val.castTag(.decl_ref).?.data.val, arena, start, end),
@@ -2466,7 +2466,7 @@ pub const Value = extern union {
     pub fn elemPtr(val: Value, ty: Type, arena: Allocator, index: usize) Allocator.Error!Value {
         const elem_ty = ty.elemType2();
         const ptr_val = switch (val.tag()) {
-            .slice => val.slicePtr(),
+            .slice => val.castTag(.slice).?.data.ptr,
             else => val,
         };
 

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -62,6 +62,7 @@ test {
     _ = @import("behavior/bugs/11100.zig");
     _ = @import("behavior/bugs/10970.zig");
     _ = @import("behavior/bugs/11046.zig");
+    _ = @import("behavior/bugs/11139.zig");
     _ = @import("behavior/bugs/11165.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/cast.zig");

--- a/test/behavior/bugs/11139.zig
+++ b/test/behavior/bugs/11139.zig
@@ -3,9 +3,9 @@ const builtin = @import("builtin");
 const expect = std.testing.expect;
 
 test "store array of array of structs at comptime" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     try expect(storeArrayOfArrayOfStructs() == 15);
     comptime try expect(storeArrayOfArrayOfStructs() == 15);

--- a/test/behavior/bugs/11139.zig
+++ b/test/behavior/bugs/11139.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const expect = std.testing.expect;
+
+test "store array of array of structs at comptime" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
+    try expect(storeArrayOfArrayOfStructs() == 15);
+    comptime try expect(storeArrayOfArrayOfStructs() == 15);
+}
+
+fn storeArrayOfArrayOfStructs() u8 {
+    const S = struct {
+        x: u8,
+    };
+
+    var cases = [_][1]S{
+        [_]S{
+            S{ .x = 15 },
+        },
+    };
+    return cases[0][0].x;
+}

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -871,7 +871,7 @@ test "peer cast [N:x]T to [N]T" {
 }
 
 test "peer cast *[N:x]T to *[N]T" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
@@ -887,9 +887,9 @@ test "peer cast *[N:x]T to *[N]T" {
 }
 
 test "peer cast [*:x]T to [*]T" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
     const S = struct {
         fn doTheTest() !void {

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -887,7 +887,9 @@ test "peer cast *[N:x]T to *[N]T" {
 }
 
 test "peer cast [*:x]T to [*]T" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {

--- a/test/behavior/ptrcast.zig
+++ b/test/behavior/ptrcast.zig
@@ -23,9 +23,9 @@ fn testReinterpretBytesAsInteger() !void {
 
 test "reinterpret an array over multiple elements, with no well-defined layout" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     try testReinterpretWithOffsetAndNoWellDefinedLayout();
     comptime try testReinterpretWithOffsetAndNoWellDefinedLayout();
@@ -40,9 +40,9 @@ fn testReinterpretWithOffsetAndNoWellDefinedLayout() !void {
 }
 
 test "reinterpret bytes inside auto-layout struct as integer with nonzero offset" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     try testReinterpretStructWrappedBytesAsInteger();
     comptime try testReinterpretStructWrappedBytesAsInteger();
@@ -59,9 +59,9 @@ fn testReinterpretStructWrappedBytesAsInteger() !void {
 }
 
 test "reinterpret bytes of an array into an extern struct" {
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     try testReinterpretBytesAsExternStruct();
     comptime try testReinterpretBytesAsExternStruct();
@@ -83,8 +83,8 @@ fn testReinterpretBytesAsExternStruct() !void {
 
 test "reinterpret bytes of an extern struct into another" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     try testReinterpretExternStructAsExternStruct();
     comptime try testReinterpretExternStructAsExternStruct();
@@ -109,11 +109,11 @@ fn testReinterpretExternStructAsExternStruct() !void {
 
 test "lower reinterpreted comptime field ptr" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     // Test lowering a field ptr
     comptime var bytes align(2) = [_]u8{ 1, 2, 3, 4, 5, 6 };

--- a/test/behavior/ptrcast.zig
+++ b/test/behavior/ptrcast.zig
@@ -21,8 +21,47 @@ fn testReinterpretBytesAsInteger() !void {
     try expect(@ptrCast(*align(1) const u32, bytes[1..5]).* == expected);
 }
 
+test "reinterpret an array over multiple elements, with no well-defined layout" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+
+    try testReinterpretWithOffsetAndNoWellDefinedLayout();
+    comptime try testReinterpretWithOffsetAndNoWellDefinedLayout();
+}
+
+fn testReinterpretWithOffsetAndNoWellDefinedLayout() !void {
+    const bytes: ?[5]?u8 = [5]?u8{ 0x12, 0x34, 0x56, 0x78, 0x9a };
+    const ptr = &bytes.?[1];
+    const copy: [4]?u8 = @ptrCast(*const [4]?u8, ptr).*;
+    _ = copy;
+    //try expect(@ptrCast(*align(1)?u8, bytes[1..5]).* == );
+}
+
+test "reinterpret bytes inside auto-layout struct as integer with nonzero offset" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+
+    try testReinterpretStructWrappedBytesAsInteger();
+    comptime try testReinterpretStructWrappedBytesAsInteger();
+}
+
+fn testReinterpretStructWrappedBytesAsInteger() !void {
+    const S = struct { bytes: [5:0]u8 };
+    const obj = S{ .bytes = "\x12\x34\x56\x78\xab".* };
+    const expected = switch (native_endian) {
+        .Little => 0xab785634,
+        .Big => 0x345678ab,
+    };
+    try expect(@ptrCast(*align(1) const u32, obj.bytes[1..5]).* == expected);
+}
+
 test "reinterpret bytes of an array into an extern struct" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     try testReinterpretBytesAsExternStruct();
     comptime try testReinterpretBytesAsExternStruct();
@@ -40,6 +79,57 @@ fn testReinterpretBytesAsExternStruct() !void {
     var ptr = @ptrCast(*const S, &bytes);
     var val = ptr.c;
     try expect(val == 5);
+}
+
+test "reinterpret bytes of an extern struct into another" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+
+    try testReinterpretExternStructAsExternStruct();
+    comptime try testReinterpretExternStructAsExternStruct();
+}
+
+fn testReinterpretExternStructAsExternStruct() !void {
+    const S1 = extern struct {
+        a: u8,
+        b: u16,
+        c: u8,
+    };
+    comptime var bytes align(2) = S1{ .a = 0, .b = 0, .c = 5 };
+
+    const S2 = extern struct {
+        a: u32 align(2),
+        c: u8,
+    };
+    var ptr = @ptrCast(*const S2, &bytes);
+    var val = ptr.c;
+    try expect(val == 5);
+}
+
+test "lower reinterpreted comptime field ptr" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+
+    // Test lowering a field ptr
+    comptime var bytes align(2) = [_]u8{ 1, 2, 3, 4, 5, 6 };
+    const S = extern struct {
+        a: u32 align(2),
+        c: u8,
+    };
+    comptime var ptr = @ptrCast(*const S, &bytes);
+    var val = &ptr.c;
+    try expect(val.* == 5);
+
+    // Test lowering an elem ptr
+    comptime var src_value = S{ .a = 15, .c = 5 };
+    comptime var ptr2 = @ptrCast(*[@sizeOf(S)]u8, &src_value);
+    var val2 = &ptr2[4];
+    try expect(val2.* == 5);
 }
 
 test "reinterpret struct field at comptime" {


### PR DESCRIPTION
This PR resolves the "tricky" situation noted in #11043. Also resolves #11139.

Parent pointer values (`.elem_ptr`, `.field_ptr`, `.eu_payload_ptr`, and `.union_payload_ptr`) don't have any way of recovering the type that they were constructed with. If you create a .field_ptr from the result of a bit-cast (e.g. `&@bitCast(T, ptr).foo`), it can't be lowered or dereferenced correctly, since we cannot recover `T`

This ended up being a pretty scruffy yak. Major changes:
   - Add `container_ty`/`elem_ty` to parent pointer Values
   - Implement `Type.hasWellDefinedLayout` and `Sema.typeHasWellDefinedLayout`, so that we can anticipate when bitcasting in Sema is legal
   - Update Sema `pointerDeref` to bitcast if parent pointer type diverges from the backing decl type
   - Update LLVM `lowerParentPtr` to bitcast if parent pointer type diverges from the backing decl type
   
I haven't gotten around to updating `beginComptimePtrMutation` - its behavior is unchanged since it doesn't use the tracked container type information yet.
  