### PR TITLE
stage2: add compiler test to ensure typed null doesn't coerce to any

### DIFF
--- a/test/behavior/bugs/6456.zig
+++ b/test/behavior/bugs/6456.zig
@@ -19,7 +19,7 @@ test "issue 6456" {
                 .alignment = 0,
                 .name = name,
                 .field_type = usize,
-                .default_value = @as(?usize, null),
+                .default_value = &@as(?usize, null),
                 .is_comptime = false,
             }};
         }

--- a/test/stage2/llvm.zig
+++ b/test/stage2/llvm.zig
@@ -422,4 +422,17 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , "");
     }
+
+    {
+        // This worked in stage1 and we expressly do not want this to work in stage2
+        var case = ctx.exeUsingLlvmBackend("any typed null to any typed optional", linux_x64);
+        case.addError(
+            \\pub export fn main() void {
+            \\    var a: ?*anyopaque = undefined;
+            \\    a = @as(?usize, null);
+            \\}
+        , &[_][]const u8{
+            ":3:21: error: expected pointer type, found '?usize'",
+        });
+    }
 }


### PR DESCRIPTION
In stage1, this behavior was allowed (by accident?) and also
accidentally exercised by the behavior test changed in this commit. In
discussion on Discord, Andrew decided this should not be allowed in
stage2 since there is currently on real world reason to allow this
strange edge case.

I've added the compiler test to solidify that this behavior should NOT
occur and updated the behavior test to the new valid semantics.