### PR TITLE
zig-fmt: Resolve #11131 loss of comment on switch cases 

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -1791,6 +1791,19 @@ test "zig fmt: switch comment before prong" {
     );
 }
 
+test "zig fmt: switch comment after prong" {
+    try testCanonical(
+        \\comptime {
+        \\    switch (a) {
+        \\        0,
+        \\        // hi
+        \\        => {},
+        \\    }
+        \\}
+        \\
+    );
+}
+
 test "zig fmt: struct literal no trailing comma" {
     try testTransform(
         \\const a = foo{ .x = 1, .y = 2 };

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1505,7 +1505,7 @@ fn renderSwitchCase(
     const node_tags = tree.nodes.items(.tag);
     const token_tags = tree.tokens.items(.tag);
     const trailing_comma = token_tags[switch_case.ast.arrow_token - 1] == .comma;
-    const has_comment = blk: {
+    const has_comment_before_arrow = blk: {
         if (switch_case.ast.values.len == 0) break :blk false;
         break :blk hasComment(tree, tree.firstToken(switch_case.ast.values[0]), switch_case.ast.arrow_token);
     };
@@ -1513,10 +1513,10 @@ fn renderSwitchCase(
     // Render everything before the arrow
     if (switch_case.ast.values.len == 0) {
         try renderToken(ais, tree, switch_case.ast.arrow_token - 1, .space); // else keyword
-    } else if (switch_case.ast.values.len == 1 and !has_comment) {
+    } else if (switch_case.ast.values.len == 1 and !has_comment_before_arrow) {
         // render on one line and drop the trailing comma if any
         try renderExpression(gpa, ais, tree, switch_case.ast.values[0], .space);
-    } else if (trailing_comma or has_comment) {
+    } else if (trailing_comma or has_comment_before_arrow) {
         // Render each value on a new line
         try renderExpressions(gpa, ais, tree, switch_case.ast.values, .comma);
     } else {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1505,16 +1505,18 @@ fn renderSwitchCase(
     const node_tags = tree.nodes.items(.tag);
     const token_tags = tree.tokens.items(.tag);
     const trailing_comma = token_tags[switch_case.ast.arrow_token - 1] == .comma;
+    const has_comment = blk: {
+        if (switch_case.ast.values.len == 0) break :blk false;
+        break :blk hasComment(tree, tree.firstToken(switch_case.ast.values[0]), switch_case.ast.arrow_token);
+    };
 
     // Render everything before the arrow
     if (switch_case.ast.values.len == 0) {
         try renderToken(ais, tree, switch_case.ast.arrow_token - 1, .space); // else keyword
-    } else if (switch_case.ast.values.len == 1) {
+    } else if (switch_case.ast.values.len == 1 and !has_comment) {
         // render on one line and drop the trailing comma if any
         try renderExpression(gpa, ais, tree, switch_case.ast.values[0], .space);
-    } else if (trailing_comma or
-        hasComment(tree, tree.firstToken(switch_case.ast.values[0]), switch_case.ast.arrow_token))
-    {
+    } else if (trailing_comma or has_comment) {
         // Render each value on a new line
         try renderExpressions(gpa, ais, tree, switch_case.ast.values, .comma);
     } else {


### PR DESCRIPTION
This now checks for the presence of a comment before throwing everything on one line and dropping the comment from the switch case entirely, as mentioned in https://github.com/ziglang/zig/issues/11131

After verifying the issue being fixed, I tested for potential regressions by running it on `Sema.zig` and seeing if there was any formatting changes in the git diff. 

~~If there is a test suite (I was unable to find any sorry) for `zig fmt`, please let me know!~~