### PR TITLE
stage2: add debug info for globals in the LLVM backend

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -663,7 +663,7 @@ pub const Decl = struct {
         return (try decl.typedValue()).val;
     }
 
-    pub fn isFunction(decl: *Decl) !bool {
+    pub fn isFunction(decl: Decl) !bool {
         const tv = try decl.typedValue();
         return tv.ty.zigTypeTag() == .Fn;
     }

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -855,7 +855,17 @@ pub const Builder = opaque {
     extern fn LLVMBuildShuffleVector(*const Builder, V1: *const Value, V2: *const Value, Mask: *const Value, Name: [*:0]const u8) *const Value;
 };
 
-pub const DIScope = opaque {};
+pub const MDString = opaque {
+    pub const get = LLVMMDStringInContext2;
+    extern fn LLVMMDStringInContext2(C: *const Context, Str: [*]const u8, SLen: usize) *MDString;
+};
+
+pub const DIScope = opaque {
+    pub const toNode = ZigLLVMScopeToNode;
+    extern fn ZigLLVMScopeToNode(scope: *DIScope) *DINode;
+};
+
+pub const DINode = opaque {};
 pub const Metadata = opaque {};
 
 pub const IntPredicate = enum(c_uint) {
@@ -1421,28 +1431,52 @@ pub const address_space = struct {
 
 pub const DIEnumerator = opaque {};
 pub const DILocalVariable = opaque {};
-pub const DIGlobalVariable = opaque {};
 pub const DILocation = opaque {};
 
+pub const DIGlobalVariable = opaque {
+    pub const toNode = ZigLLVMGlobalVariableToNode;
+    extern fn ZigLLVMGlobalVariableToNode(global_variable: *DIGlobalVariable) *DINode;
+
+    pub const replaceLinkageName = ZigLLVMGlobalVariableReplaceLinkageName;
+    extern fn ZigLLVMGlobalVariableReplaceLinkageName(global_variable: *DIGlobalVariable, linkage_name: *MDString) void;
+};
 pub const DIType = opaque {
     pub const toScope = ZigLLVMTypeToScope;
     extern fn ZigLLVMTypeToScope(ty: *DIType) *DIScope;
+
+    pub const toNode = ZigLLVMTypeToNode;
+    extern fn ZigLLVMTypeToNode(ty: *DIType) *DINode;
 };
 pub const DIFile = opaque {
     pub const toScope = ZigLLVMFileToScope;
     extern fn ZigLLVMFileToScope(difile: *DIFile) *DIScope;
+
+    pub const toNode = ZigLLVMFileToNode;
+    extern fn ZigLLVMFileToNode(difile: *DIFile) *DINode;
 };
 pub const DILexicalBlock = opaque {
     pub const toScope = ZigLLVMLexicalBlockToScope;
     extern fn ZigLLVMLexicalBlockToScope(lexical_block: *DILexicalBlock) *DIScope;
+
+    pub const toNode = ZigLLVMLexicalBlockToNode;
+    extern fn ZigLLVMLexicalBlockToNode(lexical_block: *DILexicalBlock) *DINode;
 };
 pub const DICompileUnit = opaque {
     pub const toScope = ZigLLVMCompileUnitToScope;
     extern fn ZigLLVMCompileUnitToScope(compile_unit: *DICompileUnit) *DIScope;
+
+    pub const toNode = ZigLLVMCompileUnitToNode;
+    extern fn ZigLLVMCompileUnitToNode(compile_unit: *DICompileUnit) *DINode;
 };
 pub const DISubprogram = opaque {
     pub const toScope = ZigLLVMSubprogramToScope;
     extern fn ZigLLVMSubprogramToScope(subprogram: *DISubprogram) *DIScope;
+
+    pub const toNode = ZigLLVMSubprogramToNode;
+    extern fn ZigLLVMSubprogramToNode(subprogram: *DISubprogram) *DINode;
+
+    pub const replaceLinkageName = ZigLLVMSubprogramReplaceLinkageName;
+    extern fn ZigLLVMSubprogramReplaceLinkageName(subprogram: *DISubprogram, linkage_name: *MDString) void;
 };
 
 pub const getDebugLoc = ZigLLVMGetDebugLoc;

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -840,7 +840,7 @@ ZigLLVMDIGlobalVariable *ZigLLVMCreateGlobalVariable(ZigLLVMDIBuilder *dbuilder,
         line_no,
         reinterpret_cast<DIType*>(di_type),
         is_local_to_unit);
-    return reinterpret_cast<ZigLLVMDIGlobalVariable*>(result);
+    return reinterpret_cast<ZigLLVMDIGlobalVariable*>(result->getVariable());
 }
 
 ZigLLVMDILocalVariable *ZigLLVMCreateParameterVariable(ZigLLVMDIBuilder *dbuilder,
@@ -883,6 +883,56 @@ ZigLLVMDIScope *ZigLLVMSubprogramToScope(ZigLLVMDISubprogram *subprogram) {
 ZigLLVMDIScope *ZigLLVMTypeToScope(ZigLLVMDIType *type) {
     DIScope *scope = reinterpret_cast<DIType*>(type);
     return reinterpret_cast<ZigLLVMDIScope*>(scope);
+}
+
+ZigLLVMDINode *ZigLLVMLexicalBlockToNode(ZigLLVMDILexicalBlock *lexical_block) {
+    DINode *node = reinterpret_cast<DILexicalBlock*>(lexical_block);
+    return reinterpret_cast<ZigLLVMDINode*>(node);
+}
+
+ZigLLVMDINode *ZigLLVMCompileUnitToNode(ZigLLVMDICompileUnit *compile_unit) {
+    DINode *node = reinterpret_cast<DICompileUnit*>(compile_unit);
+    return reinterpret_cast<ZigLLVMDINode*>(node);
+}
+
+ZigLLVMDINode *ZigLLVMFileToNode(ZigLLVMDIFile *difile) {
+    DINode *node = reinterpret_cast<DIFile*>(difile);
+    return reinterpret_cast<ZigLLVMDINode*>(node);
+}
+
+ZigLLVMDINode *ZigLLVMSubprogramToNode(ZigLLVMDISubprogram *subprogram) {
+    DINode *node = reinterpret_cast<DISubprogram*>(subprogram);
+    return reinterpret_cast<ZigLLVMDINode*>(node);
+}
+
+ZigLLVMDINode *ZigLLVMTypeToNode(ZigLLVMDIType *type) {
+    DINode *node = reinterpret_cast<DIType*>(type);
+    return reinterpret_cast<ZigLLVMDINode*>(node);
+}
+
+ZigLLVMDINode *ZigLLVMScopeToNode(ZigLLVMDIScope *scope) {
+    DINode *node = reinterpret_cast<DIScope*>(scope);
+    return reinterpret_cast<ZigLLVMDINode*>(node);
+}
+
+ZigLLVMDINode *ZigLLVMGlobalVariableToNode(ZigLLVMDIGlobalVariable *global_variable) {
+    DINode *node = reinterpret_cast<DIGlobalVariable*>(global_variable);
+    return reinterpret_cast<ZigLLVMDINode*>(node);
+}
+
+void ZigLLVMSubprogramReplaceLinkageName(ZigLLVMDISubprogram *subprogram,
+        ZigLLVMMDString *linkage_name)
+{
+    MDString *linkage_name_md = reinterpret_cast<MDString*>(linkage_name);
+    reinterpret_cast<DISubprogram*>(subprogram)->replaceLinkageName(linkage_name_md);
+}
+
+void ZigLLVMGlobalVariableReplaceLinkageName(ZigLLVMDIGlobalVariable *global_variable,
+        ZigLLVMMDString *linkage_name)
+{
+    Metadata *linkage_name_md = reinterpret_cast<MDString*>(linkage_name);
+    // NOTE: Operand index must match llvm::DIGlobalVariable
+    reinterpret_cast<DIGlobalVariable*>(global_variable)->replaceOperandWith(5, linkage_name_md);
 }
 
 ZigLLVMDICompileUnit *ZigLLVMCreateCompileUnit(ZigLLVMDIBuilder *dibuilder,

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -38,6 +38,8 @@ struct ZigLLVMDIGlobalVariable;
 struct ZigLLVMDILocation;
 struct ZigLLVMDIEnumerator;
 struct ZigLLVMInsertionPoint;
+struct ZigLLVMDINode;
+struct ZigLLVMMDString;
 
 ZIG_EXTERN_C void ZigLLVMInitializeLoopStrengthReducePass(LLVMPassRegistryRef R);
 ZIG_EXTERN_C void ZigLLVMInitializeLowerIntrinsicsPass(LLVMPassRegistryRef R);
@@ -237,6 +239,19 @@ ZIG_EXTERN_C struct ZigLLVMDIScope *ZigLLVMCompileUnitToScope(struct ZigLLVMDICo
 ZIG_EXTERN_C struct ZigLLVMDIScope *ZigLLVMFileToScope(struct ZigLLVMDIFile *difile);
 ZIG_EXTERN_C struct ZigLLVMDIScope *ZigLLVMSubprogramToScope(struct ZigLLVMDISubprogram *subprogram);
 ZIG_EXTERN_C struct ZigLLVMDIScope *ZigLLVMTypeToScope(struct ZigLLVMDIType *type);
+
+ZIG_EXTERN_C struct ZigLLVMDINode *ZigLLVMLexicalBlockToNode(struct ZigLLVMDILexicalBlock *lexical_block);
+ZIG_EXTERN_C struct ZigLLVMDINode *ZigLLVMCompileUnitToNode(struct ZigLLVMDICompileUnit *compile_unit);
+ZIG_EXTERN_C struct ZigLLVMDINode *ZigLLVMFileToNode(struct ZigLLVMDIFile *difile);
+ZIG_EXTERN_C struct ZigLLVMDINode *ZigLLVMSubprogramToNode(struct ZigLLVMDISubprogram *subprogram);
+ZIG_EXTERN_C struct ZigLLVMDINode *ZigLLVMTypeToNode(struct ZigLLVMDIType *type);
+ZIG_EXTERN_C struct ZigLLVMDINode *ZigLLVMScopeToNode(struct ZigLLVMDIScope *scope);
+ZIG_EXTERN_C struct ZigLLVMDINode *ZigLLVMGlobalVariableToNode(struct ZigLLVMDIGlobalVariable *global_variable);
+
+ZIG_EXTERN_C void ZigLLVMSubprogramReplaceLinkageName(struct ZigLLVMDISubprogram *subprogram,
+        struct ZigLLVMMDString *linkage_name);
+ZIG_EXTERN_C void ZigLLVMGlobalVariableReplaceLinkageName(struct ZigLLVMDIGlobalVariable *global_variable,
+        struct ZigLLVMMDString *linkage_name);
 
 ZIG_EXTERN_C struct ZigLLVMDILocalVariable *ZigLLVMCreateAutoVariable(struct ZigLLVMDIBuilder *dbuilder,
         struct ZigLLVMDIScope *scope, const char *name, struct ZigLLVMDIFile *file, unsigned line_no,


### PR DESCRIPTION
LLVM backend: generate `DIGlobalVariable`s for non-function globals and
rename linkage names when exporting functions and globals.

`zig_llvm.cpp`: add some wrappers to convert a handful of DI classes
into `DINode`s since `DIGlobalVariable` is not a `DIScope` like the others.

`zig_llvm.cpp`: add some wrappers to allow replacing the `LinkageName` of
`DISubprogram` and `DIGlobalVariable`.

`zig_llvm.cpp`: fix DI class mixup causing nonsense reinterpret_cast.

The end result is that GDB is now usable since you now no longer need
to manually cast every global nor fully qualify every export.

Closes #11097.