### PR TITLE
stage2: add error for returning pointer to local variable

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -486,6 +486,36 @@ pub const Type = extern union {
 
             .pointer => return self.castTag(.pointer).?.*,
 
+            .optional_single_mut_pointer => return .{ .data = .{
+                .pointee_type = self.castPointer().?.data,
+                .sentinel = null,
+                .@"align" = 0,
+                .@"addrspace" = .generic,
+                .bit_offset = 0,
+                .host_size = 0,
+                .@"allowzero" = false,
+                .mutable = true,
+                .@"volatile" = false,
+                .size = .One,
+            } },
+            .optional_single_const_pointer => return .{ .data = .{
+                .pointee_type = self.castPointer().?.data,
+                .sentinel = null,
+                .@"align" = 0,
+                .@"addrspace" = .generic,
+                .bit_offset = 0,
+                .host_size = 0,
+                .@"allowzero" = false,
+                .mutable = false,
+                .@"volatile" = false,
+                .size = .One,
+            } },
+            .optional => {
+                var buf: Payload.ElemType = undefined;
+                const child_type = self.optionalChild(&buf);
+                return child_type.ptrInfo();
+            },
+
             else => unreachable,
         }
     }


### PR DESCRIPTION
The check does not apply to inline functions and wont apply to functions called at comptime depending on #11152.
Most simple cases are caught but it is easy to bypass if needed.

Some cases might be too aggressive but they are easy to remove if deemed so.

Closes  #2646