### PR TITLE
stage2: codegen of arrays should use type length, not value length

### DIFF
--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -62,6 +62,7 @@ test {
     _ = @import("behavior/bugs/11100.zig");
     _ = @import("behavior/bugs/10970.zig");
     _ = @import("behavior/bugs/11046.zig");
+    _ = @import("behavior/bugs/11165.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/cast.zig");
     _ = @import("behavior/comptime_memory.zig");

--- a/test/behavior/bugs/11165.zig
+++ b/test/behavior/bugs/11165.zig
@@ -1,6 +1,9 @@
 const builtin = @import("builtin");
 
 test "bytes" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
     const S = struct {
         a: u32,
         c: [5]u8,
@@ -16,11 +19,14 @@ test "bytes" {
     };
     _ = s_1;
 
-    const u_2 = U{ .s = s_1 };
+    var u_2 = U{ .s = s_1 };
     _ = u_2;
 }
 
 test "aggregate" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
     const S = struct {
         a: u32,
         c: [5]u8,
@@ -37,6 +43,6 @@ test "aggregate" {
     };
     _ = s_1;
 
-    const u_2 = U{ .s = s_1 };
+    var u_2 = U{ .s = s_1 };
     _ = u_2;
 }

--- a/test/behavior/bugs/11165.zig
+++ b/test/behavior/bugs/11165.zig
@@ -1,0 +1,42 @@
+const builtin = @import("builtin");
+
+test "bytes" {
+    const S = struct {
+        a: u32,
+        c: [5]u8,
+    };
+
+    const U = union {
+        s: S,
+    };
+
+    const s_1 = S{
+        .a = undefined,
+        .c = "12345".*, // this caused problems
+    };
+    _ = s_1;
+
+    const u_2 = U{ .s = s_1 };
+    _ = u_2;
+}
+
+test "aggregate" {
+    const S = struct {
+        a: u32,
+        c: [5]u8,
+    };
+
+    const U = union {
+        s: S,
+    };
+
+    const c = [5:0]u8{ 1, 2, 3, 4, 5 };
+    const s_1 = S{
+        .a = undefined,
+        .c = c, // this caused problems
+    };
+    _ = s_1;
+
+    const u_2 = U{ .s = s_1 };
+    _ = u_2;
+}


### PR DESCRIPTION
It is possible for the value length to be longer than the type because
we allow in-memory coercing of types such as `[5:0]u8` to `[5]u8`. In
such a case, the value length is 6 but the type length if 5.

The `.repeated` value type already got this right, so this is extending
similar logic out to `.aggregate` and `.bytes`. Both scenarios are
tested in behavior tests.

Fixes #11165