### PR TITLE
stage2: resolve type fully when resolving inferred allocs

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2672,11 +2672,16 @@ fn zirResolveInferredAlloc(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Com
                 // ZIR handles it later, so we can just use the ty ref here.
                 air_datas[ptr_inst].ty_pl.ty = air_datas[bitcast_inst].ty_op.ty;
 
+                // Unless the block is comptime, `alloc_inferred` always produces
+                // a runtime constant. The final inferred type needs to be
+                // fully resolved so it can be lowered in codegen.
+                try sema.resolveTypeFully(block, ty_src, final_elem_ty);
+
                 return;
             }
 
             try sema.requireRuntimeBlock(block, src);
-            try sema.resolveTypeLayout(block, ty_src, final_elem_ty);
+            try sema.resolveTypeFully(block, ty_src, final_elem_ty);
 
             // Change it to a normal alloc.
             sema.air_instructions.set(ptr_inst, .{

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -64,6 +64,7 @@ test {
     _ = @import("behavior/bugs/11046.zig");
     _ = @import("behavior/bugs/11139.zig");
     _ = @import("behavior/bugs/11165.zig");
+    _ = @import("behavior/bugs/11181.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/cast.zig");
     _ = @import("behavior/comptime_memory.zig");

--- a/test/behavior/bugs/11181.zig
+++ b/test/behavior/bugs/11181.zig
@@ -1,0 +1,31 @@
+const builtin = @import("builtin");
+
+test "const inferred array of slices" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
+    const T = struct { v: bool };
+
+    const decls = [_][]const T{
+        &[_]T{
+            .{ .v = false },
+        },
+    };
+    _ = decls;
+}
+
+test "var inferred array of slices" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
+    const T = struct { v: bool };
+
+    var decls = [_][]const T{
+        &[_]T{
+            .{ .v = false },
+        },
+    };
+    _ = decls;
+}


### PR DESCRIPTION
We must resolve the type fully so that pointer children (i.e. slices)
are resolved. Additionally, we must resolve even if we can know the
value at comptime because the `alloc_inferred` ZIR always produces a
constant in the AIR.

Fixes #11181