### PR TITLE
Optional TypeScript for Autodocs development

### DIFF
--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -1,5 +1,184 @@
 'use strict';
 
+/**
+ * @typedef {
+    | "Type"
+    | "Void"
+    | "Bool"
+    | "NoReturn"
+    | "Int"
+    | "Float"
+    | "Pointer"
+    | "Array"
+    | "Struct"
+    | "ComptimeFloat"
+    | "ComptimeInt"
+    | "Undefined"
+    | "Null"
+    | "Optional"
+    | "ErrorUnion"
+    | "ErrorSet"
+    | "Enum"
+    | "Union"
+    | "Fn"
+    | "BoundFn"
+    | "Opaque"
+    | "Frame"
+    | "AnyFrame"
+    | "Vector"
+    | "EnumLiteral"
+    | "ComptimeExpr"
+    | "Unanalyzed"
+   } TypeKind
+*/
+
+/**
+ * @typedef {
+    | WalkResult
+    | { unspecified: {} }
+    | { anytype: {} }
+    | { type: number }
+    | { comptimeExpr: number }
+    | { call: number }
+    | { hasCte: boolean; declPath: number[] }
+   } TypeRef
+*/
+
+/**
+ * @typedef {
+    | { void: {} }
+    | { unreachable: {} }
+    | { anytype: {} }
+    | { type: number }
+    | { comptimeExpr: number }
+    | { call: number }
+    | { int: { typeRef: TypeRef; value: number } }
+    | { float: { typeRef: TypeRef; value: number } }
+    | { bool: boolean }
+    | { undefined: TypeRef }
+    | { null: TypeRef }
+    | { typeOf: WalkResult }
+    | { compileError: string }
+    | { string: string }
+    | { struct: Struct }
+    | { hasCte: boolean; declPath: number[] }
+    | { array: ZigArray }
+    | { enumLiteral: string }
+   } WalkResult
+*/
+
+/**
+ * @typedef {
+     { kind: number } & (
+        | { name: string } // Type, Void, Bool, NoReturn, Int, Float, ComptimeExpr, ComptimeFloat, ComptimeInt, Undefined, Null, ErrorUnion, BoundFn, Opaque, Frame, AnyFrame, Vector, EnumLiteral
+        | { name: string; child: TypeRef } // Optional
+        | { len: WalkResult; child: TypeRef } // Array
+        | { name: string; fields: { name: string; docs: string }[] } // ErrorSet
+        | { size: "One" | "Many" | "Slice" | "C"; child: TypeRef } // Pointer
+        | { name: string; src?: number; privDecls: number[]; pubDecls: number[]; fields?: TypeRef[] } // Struct, Enum, Union
+        | { name: string; src?: number; ret: TypeRef; params?: TypeRef[] } // Fn
+     )
+   } Type
+*/
+
+/**
+ * @typedef {{
+       name: string,
+       src: number | null,
+       ret: TypeRef,
+       params: TypeRef[] | null,
+   }} Fn
+*/
+
+/**
+ * @typedef {{
+       func: TypeRef,
+       args: WalkResult[],
+       ret: WalkResult,
+   }} Call
+*/
+
+/**
+ * @typedef {{
+       file: number,
+       line: number,
+       col: number,
+       name?: string,
+       docs?: string,
+       fields?: number[],
+       comptime: boolean,
+   }} AstNode
+*/
+
+/**
+ * @typedef {{
+      name: string,
+      kind: string,
+      src: number,
+      value: WalkResult,
+      decltest?: number,
+   }} Decl
+*/
+
+/**
+ * @typedef {{
+      name: string,
+      file: number,
+      main: number,
+      table: { root: number },
+   }} Package
+*/
+
+/**
+ * @typedef {{
+      name: string,
+      src?: number,
+      privDecls: number[],
+      pubDecls: number[],
+      fields?: TypeRef[],
+   }} Struct
+*/
+
+/**
+ * @typedef {{
+      len: WalkResult,
+      child: TypeRef,
+  }} ZigArray
+*/
+
+/**
+ * @typedef {{
+      code: string,
+      typeRef: TypeRef,
+   }} ComptimeExpr
+*/
+
+/**
+ * @typedef {{
+       typeKinds: TypeKind[];
+       rootPkg: number;
+       params: {
+           zigId: string;
+           zigVersion: string;
+           target: string;
+           rootName: string;
+           builds: { target: string };
+       };
+       packages: Package[];
+       errors: {};
+       astNodes: AstNode[];
+       calls: Call[];
+       files: Record<string, number>;
+       types: Type[];
+       decls: Decl[];
+       comptimeExprs: ComptimeExpr[];
+       fns: Fn[];
+   }} DocData
+*/
+
+/** @type {DocData} */
+var zigAnalysis;
+
 (function() {
     var domStatus = document.getElementById("status");
     var domSectNav = document.getElementById("sectNav");

--- a/lib/std/special/docs/main.js
+++ b/lib/std/special/docs/main.js
@@ -1,4 +1,4 @@
-//'use strict';
+'use strict';
 
 (function() {
     var domStatus = document.getElementById("status");
@@ -1543,6 +1543,7 @@
         if (location.hash[0] === '#' && location.hash.length > 1) {
             var query = location.hash.substring(1);
             var qpos = query.indexOf("?");
+            var nonSearchPart;
             if (qpos === -1) {
                 nonSearchPart = query;
             } else {

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -210,7 +210,10 @@ pub fn generateZirData(self: *Autodoc) !void {
     const data_js_f = output_dir.createFile("data.js", .{}) catch unreachable;
     defer data_js_f.close();
     const out = data_js_f.writer();
-    out.print("zigAnalysis=", .{}) catch unreachable;
+    out.print(
+        \\ /** @type {{DocData}} */
+        \\ var zigAnalysis=
+    , .{}) catch unreachable;
     std.json.stringify(
         data,
         .{


### PR DESCRIPTION
Okay, so this *should* be a minimal working setup to check the Autodocs javascript file for type errors.
The `analysis.d.ts` file is for declaring what the structure of the eventual `zigAnalysis` object will be, and currently needs to be hand edited and checked for consistency with the actual `DocData` struct. I did preemptively include a type comment for the generated file, although I'm not sure if that will be the best way to ensure consistency.
In order to install and use TypeScript, just go to the `lib/std/special/docs` folder and run
```sh
npm install
```
then
```sh
npm exec tsc
```
in order to get it to type check the `main.js` file.
If you want it in watch mode:
```sh
npm exec tsc -- --watch
```
Also fixed the problem causing strict mode to error.
Also also note that there has been no fixes for the `main.js` just yet, so expect hundreds of errors.