### PR TITLE
stage2: resolve panic on array-like tuple initialization

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -4092,15 +4092,17 @@ fn structDeclInner(
         const doc_comment_index = try astgen.docCommentAsString(member.firstToken());
         wip_members.appendToField(doc_comment_index);
 
-        known_non_opv = known_non_opv or
-            nodeImpliesMoreThanOnePossibleValue(tree, member.ast.type_expr);
-        known_comptime_only = known_comptime_only or
-            nodeImpliesComptimeOnly(tree, member.ast.type_expr);
-
         const have_align = member.ast.align_expr != 0;
         const have_value = member.ast.value_expr != 0;
         const is_comptime = member.comptime_token != null;
         const unused = false;
+
+        if (!is_comptime) {
+            known_non_opv = known_non_opv or
+                nodeImpliesMoreThanOnePossibleValue(tree, member.ast.type_expr);
+            known_comptime_only = known_comptime_only or
+                nodeImpliesComptimeOnly(tree, member.ast.type_expr);
+        }
         wip_members.nextField(bits_per_field, .{ have_align, have_value, is_comptime, unused });
 
         if (have_align) {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -20860,6 +20860,7 @@ pub fn typeHasOnePossibleValue(
             const resolved_ty = try sema.resolveTypeFields(block, src, ty);
             const s = resolved_ty.castTag(.@"struct").?.data;
             for (s.fields.values()) |value| {
+                if (value.is_comptime) continue;
                 if ((try sema.typeHasOnePossibleValue(block, src, value.ty)) == null) {
                     return null;
                 }
@@ -21532,6 +21533,7 @@ fn typeRequiresComptime(sema: *Sema, block: *Block, src: LazySrcLoc, ty: Type) C
 
                     struct_obj.requires_comptime = .wip;
                     for (struct_obj.fields.values()) |field| {
+                        if (field.is_comptime) continue;
                         if (try sema.typeRequiresComptime(block, src, field.ty)) {
                             struct_obj.requires_comptime = .yes;
                             return true;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3203,11 +3203,6 @@ fn zirValidateArrayInit(
 
         // Determine whether the value stored to this pointer is comptime-known.
 
-        if (opt_opv) |opv| {
-            element_vals[i] = opv;
-            continue;
-        }
-
         const elem_ptr_air_ref = sema.inst_map.get(elem_ptr).?;
         const elem_ptr_air_inst = Air.refToIndex(elem_ptr_air_ref).?;
         // Find the block index of the elem_ptr so that we can look at the next
@@ -3222,6 +3217,12 @@ fn zirValidateArrayInit(
             first_block_index = @minimum(first_block_index, block_index);
             break :inst block.instructions.items[block_index + 1];
         };
+
+        // Array has one possible value, so value is always comptime-known
+        if (opt_opv) |opv| {
+            element_vals[i] = opv;
+            continue;
+        }
 
         // If the next instructon is a store with a comptime operand, this element
         // is comptime.

--- a/src/type.zig
+++ b/src/type.zig
@@ -2098,6 +2098,7 @@ pub const Type = extern union {
                 }
                 assert(struct_obj.haveFieldTypes());
                 for (struct_obj.fields.values()) |value| {
+                    if (value.is_comptime) continue;
                     if (value.ty.hasRuntimeBitsAdvanced(ignore_comptime_only))
                         return true;
                 } else {

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -65,8 +65,11 @@ test {
     _ = @import("behavior/bugs/10970.zig");
     _ = @import("behavior/bugs/11046.zig");
     _ = @import("behavior/bugs/11139.zig");
+    _ = @import("behavior/bugs/11159.zig");
+    _ = @import("behavior/bugs/11162.zig");
     _ = @import("behavior/bugs/11165.zig");
     _ = @import("behavior/bugs/11181.zig");
+    _ = @import("behavior/bugs/11182.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/cast.zig");
     _ = @import("behavior/comptime_memory.zig");

--- a/test/behavior/bugs/11159.zig
+++ b/test/behavior/bugs/11159.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+test {
+    const T = @TypeOf(.{ @as(i32, 0), @as(u32, 0) });
+    var a: T = .{ 0, 0 };
+    _ = a;
+}
+
+test {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        comptime x: i32 = 0,
+        comptime y: u32 = 0,
+    };
+    var a: S = .{};
+    _ = a;
+    var b = S{};
+    _ = b;
+}

--- a/test/behavior/bugs/11162.zig
+++ b/test/behavior/bugs/11162.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const expect = std.testing.expect;
+
+test {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+
+    var x: u32 = 15;
+    const T = @TypeOf(.{ @as(i32, -1234), @as(u32, 5678), x });
+    var a: T = .{ -1234, 5678, x + 1 };
+
+    try expect(a[0] == -1234);
+    try expect(a[1] == 5678);
+    try expect(a[2] == 16);
+}

--- a/test/behavior/bugs/11182.zig
+++ b/test/behavior/bugs/11182.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+test {
+    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+
+    const T = @TypeOf(.{ @as(i32, 0), @as(u32, 0) });
+    var a = T{ 0, 0 };
+    _ = a;
+}


### PR DESCRIPTION
This resolves https://github.com/ziglang/zig/issues/11159

Assorted fixes here:
  1. Comptime fields should not affect whether a type has runtime bits
  2. We were not correctly deleting the field stores after recognizing that an array initializer was a comptime-known value.
  3. LLVM was not checking that the stored type had no runtime bits, and so would generate an invalid store.

This also adds several test cases for related bugs, just to check these in for later work. Initializing tuples with mixed comptime/runtime fields is unfortunately still broken (on both stage1 and stage2) - that will have to be tackled later, probably with https://github.com/ziglang/zig/issues/11162