### PR TITLE
stage2: x86_64: implement `@floatToInt` for `f32` and `f64`

### DIFF
--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -257,6 +257,15 @@ pub const Inst = struct {
         movabs,
 
         /// ops flags:  form:
+        ///      0b00    word ptr [reg1 + imm32]
+        ///      0b01    dword ptr [reg1 + imm32]
+        ///      0b10    qword ptr [reg1 + imm32]
+        /// Notes:
+        ///   * source is always ST(0)
+        ///   * only supports memory operands as destination
+        fisttp,
+
+        /// ops flags:  form:
         ///      0b00    inst
         ///      0b01    reg1
         ///      0b01    [imm32] if reg1 is none

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -266,6 +266,11 @@ pub const Inst = struct {
         fisttp,
 
         /// ops flags:  form:
+        ///      0b01    dword ptr [reg1 + imm32]
+        ///      0b10    qword ptr [reg1 + imm32]
+        fld,
+
+        /// ops flags:  form:
         ///      0b00    inst
         ///      0b01    reg1
         ///      0b01    [imm32] if reg1 is none

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -118,7 +118,6 @@ test "@intToFloat" {
 
 test "@floatToInt" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     try testFloatToInts();


### PR DESCRIPTION
stage1 and LLVM backend both use the `vcvt` group of instructions for these operations. Those require AVX512, so I opted `fisttp`/`fld` instead.

the `@floatToInt` test from `test/behavior/cast.zig` now passes for x86_64 backend.