### PR TITLE
stage2: bit_not on u0 is always 0

### DIFF
--- a/src/value.zig
+++ b/src/value.zig
@@ -2977,6 +2977,11 @@ pub const Value = extern union {
 
         const info = ty.intInfo(target);
 
+        if (info.bits == 0) {
+            assert(val.isZero()); // Sema should guarantee
+            return val;
+        }
+
         // TODO is this a performance issue? maybe we should try the operation without
         // resorting to BigInt first.
         var val_space: Value.BigIntSpace = undefined;

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -375,6 +375,9 @@ test "binary not" {
     try expect(comptime x: {
         break :x ~@as(u64, 2147483647) == 18446744071562067968;
     });
+    try expect(comptime x: {
+        break :x ~@as(u0, 0) == 0;
+    });
     try testBinaryNot(0b1010101010101010);
 }
 


### PR DESCRIPTION
A simple one, exercised by some stdlib tests (bit sets). 

Might be more useful to fix `std.math.big.int` to not crash in this case, but this is probably something that should avoid all the BigInt machinery anyways (as the TODO below my changes implies...)