### PR TITLE
stage2: wasm - Implement memcpy instruction

### DIFF
--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -340,7 +340,6 @@ fn f2(x: bool) []const u8 {
 test "memcpy and memset intrinsics" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     try testMemcpyMemset();
     // TODO add comptime test coverage


### PR DESCRIPTION
This implements the `memcpy` instruction, as well as improves the inline memcpy function.
We feature-detect for the availability of wasm's built-in instruction `memory.copy`. When the feature 'bulk-memory' is not enabled, we perform the operation ourselves.
When the length is comptime-known, we perform an inline loop, whereas we emit a regular runtime loop into the binary when the length is runtime known.

The same changes were made to the inline memset function and instructions such as `airWrapErrUnionErr` now use this to set the entire payload to 'undefined'.
