### PR TITLE
Implement `@byteSwap` for vectors

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3205,14 +3205,11 @@ fn zirValidateArrayInit(
         // instruction after it within the same block.
         // Possible performance enhancement: save the `block_index` between iterations
         // of the for loop.
-        const next_air_inst = inst: {
-            var block_index = block.instructions.items.len - 1;
-            while (block.instructions.items[block_index] != elem_ptr_air_inst) {
-                block_index -= 1;
-            }
-            first_block_index = @minimum(first_block_index, block_index);
-            break :inst block.instructions.items[block_index + 1];
-        };
+        var block_index = block.instructions.items.len - 1;
+        while (block.instructions.items[block_index] != elem_ptr_air_inst) {
+            block_index -= 1;
+        }
+        first_block_index = @minimum(first_block_index, block_index);
 
         // Array has one possible value, so value is always comptime-known
         if (opt_opv) |opv| {
@@ -3222,6 +3219,7 @@ fn zirValidateArrayInit(
 
         // If the next instructon is a store with a comptime operand, this element
         // is comptime.
+        const next_air_inst = block.instructions.items[block_index + 1];
         switch (air_tags[next_air_inst]) {
             .store => {
                 const bin_op = air_datas[next_air_inst].bin_op;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -13491,30 +13491,77 @@ fn zirByteSwap(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
     const operand_src: LazySrcLoc = .{ .node_offset_builtin_call_arg1 = inst_data.src_node };
     const operand = sema.resolveInst(inst_data.operand);
     const operand_ty = sema.typeOf(operand);
-    // TODO implement support for vectors
-    if (operand_ty.zigTypeTag() != .Int) {
-        return sema.fail(block, ty_src, "expected integer type, found '{}'", .{
-            operand_ty,
-        });
+
+    const scalar_ty = if (operand_ty.zigTypeTag() == .Vector)
+        operand_ty.elemType2()
+    else
+        operand_ty;
+
+    switch (operand_ty.zigTypeTag()) {
+        .Int, .ComptimeInt => {},
+        .Vector => {
+            switch (scalar_ty.zigTypeTag()) {
+                .Int, .ComptimeInt => {},
+                else => return sema.fail(block, ty_src, "expected vector of integer type, found vector of '{}'", .{scalar_ty}),
+            }
+        },
+        else => return sema.fail(block, ty_src, "expected integer type or vector of integer type, found '{}'", .{operand_ty}),
     }
+
     const target = sema.mod.getTarget();
-    const bits = operand_ty.intInfo(target).bits;
-    if (bits == 0) return Air.Inst.Ref.zero;
-    if (operand_ty.intInfo(target).bits % 8 != 0) {
-        return sema.fail(block, ty_src, "@byteSwap requires the number of bits to be evenly divisible by 8, but {} has {} bits", .{
-            operand_ty,
-            operand_ty.intInfo(target).bits,
-        });
+    const bits = scalar_ty.intInfo(target).bits;
+    if (bits % 8 != 0) {
+        return sema.fail(
+            block,
+            ty_src,
+            "@byteSwap requires the number of bits to be evenly divisible by 8, but {} has {} bits",
+            .{ scalar_ty, bits },
+        );
     }
 
-    const runtime_src = if (try sema.resolveMaybeUndefVal(block, operand_src, operand)) |val| {
-        if (val.isUndef()) return sema.addConstUndef(operand_ty);
-        const result_val = try val.byteSwap(operand_ty, target, sema.arena);
-        return sema.addConstant(operand_ty, result_val);
-    } else operand_src;
+    switch (operand_ty.zigTypeTag()) {
+        .Int, .ComptimeInt => {
+            if (bits == 0) return Air.Inst.Ref.zero;
 
-    try sema.requireRuntimeBlock(block, runtime_src);
-    return block.addTyOp(.byte_swap, operand_ty, operand);
+            const runtime_src = if (try sema.resolveMaybeUndefVal(block, operand_src, operand)) |val| {
+                if (val.isUndef()) return sema.addConstUndef(operand_ty);
+                const result_val = try val.byteSwap(operand_ty, target, sema.arena);
+                return sema.addConstant(operand_ty, result_val);
+            } else operand_src;
+
+            try sema.requireRuntimeBlock(block, runtime_src);
+            return block.addTyOp(.byte_swap, operand_ty, operand);
+        },
+        .Vector => {
+            if (bits == 0) {
+                return sema.addConstant(
+                    operand_ty,
+                    try Value.Tag.repeated.create(sema.arena, Value.zero),
+                );
+            }
+
+            const runtime_src = if (try sema.resolveMaybeUndefVal(block, operand_src, operand)) |val| {
+                if (val.isUndef())
+                    return sema.addConstUndef(operand_ty);
+
+                const vec_len = operand_ty.vectorLen();
+                var elem_buf: Value.ElemValueBuffer = undefined;
+                const elems = try sema.arena.alloc(Value, vec_len);
+                for (elems) |*elem, i| {
+                    const elem_val = val.elemValueBuffer(i, &elem_buf);
+                    elem.* = try elem_val.byteSwap(operand_ty, target, sema.arena);
+                }
+                return sema.addConstant(
+                    operand_ty,
+                    try Value.Tag.aggregate.create(sema.arena, elems),
+                );
+            } else operand_src;
+
+            try sema.requireRuntimeBlock(block, runtime_src);
+            return block.addTyOp(.byte_swap, operand_ty, operand);
+        },
+        else => unreachable,
+    }
 }
 
 fn zirBitReverse(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {

--- a/test/behavior/byteswap.zig
+++ b/test/behavior/byteswap.zig
@@ -52,32 +52,77 @@ test "@byteSwap integers" {
     try ByteSwapIntTest.run();
 }
 
-test "@byteSwap vectors" {
-    if (builtin.zig_backend == .stage2_llvm) return error.SkipZigTest;
+fn vector8() !void {
+    var v = @Vector(2, u8){ 0x12, 0x13 };
+    var result = @byteSwap(u8, v);
+    try expect(result[0] == 0x12);
+    try expect(result[1] == 0x13);
+}
+
+test "@byteSwap vectors u8" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
 
-    const ByteSwapVectorTest = struct {
-        fn run() !void {
-            try t(u8, 2, [_]u8{ 0x12, 0x13 }, [_]u8{ 0x12, 0x13 });
-            try t(u16, 2, [_]u16{ 0x1234, 0x2345 }, [_]u16{ 0x3412, 0x4523 });
-            try t(u24, 2, [_]u24{ 0x123456, 0x234567 }, [_]u24{ 0x563412, 0x674523 });
-        }
+    comptime try vector8();
+    try vector8();
+}
 
-        fn t(
-            comptime I: type,
-            comptime n: comptime_int,
-            input: std.meta.Vector(n, I),
-            expected_vector: std.meta.Vector(n, I),
-        ) !void {
-            const actual_output: [n]I = @byteSwap(I, input);
-            const expected_output: [n]I = expected_vector;
-            try std.testing.expectEqual(expected_output, actual_output);
-        }
-    };
-    comptime try ByteSwapVectorTest.run();
-    try ByteSwapVectorTest.run();
+fn vector16() !void {
+    var v = @Vector(2, u16){ 0x1234, 0x2345 };
+    var result = @byteSwap(u16, v);
+    try expect(result[0] == 0x3412);
+    try expect(result[1] == 0x4523);
+}
+
+test "@byteSwap vectors u16" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+
+    comptime try vector16();
+    try vector16();
+}
+
+fn vector24() !void {
+    var v = @Vector(2, u24){ 0x123456, 0x234567 };
+    var result = @byteSwap(u24, v);
+    try expect(result[0] == 0x563412);
+    try expect(result[1] == 0x674523);
+}
+
+test "@byteSwap vectors u24" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+
+    comptime try vector24();
+    try vector24();
+}
+
+fn vector0() !void {
+    var v = @Vector(2, u0){ 0, 0 };
+    var result = @byteSwap(u0, v);
+    try expect(result[0] == 0);
+    try expect(result[1] == 0);
+}
+
+test "@byteSwap vectors u0" {
+    // TODO: vector initialization for @Vector(x, u0) currently fails.
+    if (builtin.zig_backend == .stage2_llvm) return error.SkipZigTest;
+
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+
+    comptime try vector0();
+    try vector0();
 }

--- a/test/behavior/byteswap.zig
+++ b/test/behavior/byteswap.zig
@@ -114,9 +114,6 @@ fn vector0() !void {
 }
 
 test "@byteSwap vectors u0" {
-    // TODO: vector initialization for @Vector(x, u0) currently fails.
-    if (builtin.zig_backend == .stage2_llvm) return error.SkipZigTest;
-
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;


### PR DESCRIPTION
Made the behavior tests for this a little more primitive to exercise as little extra functionality as possible.

~I did a test for `Vector(2, u0)`, which works in stage1, but currently fails in stage2 with an index out of bounds in `Sema.zirValidateArrayInit`. I tried to fix it but it seems like it has rabbit hole potential, so I'll leave it for another PR. Full error below.~

<details>

```
$ zig test test/behavior/byteswap.zig -Itest -fLLVM
thread 6462457 panic: index out of bounds
Analyzing test/behavior/byteswap.zig: byteswap.zig:test.@byteSwap vectors u0
      %1059 = dbg_stmt(5, 5)
      %1067 = block({
        %1060 = dbg_stmt(5, 9)
        %1061 = decl_val("builtin") token_offset:113:9
        %1062 = field_val(%1061, "zig_backend") node_offset:113:16
        %1063 = enum_literal("stage2_wasm") token_offset:113:33
        %1064 = cmp_eq(%1062, %1063) node_offset:113:29
        %1065 = as_node(@Ref.bool_type, %1064) node_offset:113:29
        %1066 = condbr(%1065, {
          %1068 = ret_err_value("SkipZigTest") token_offset:113:59
        }, {
          %1069 = break(%1067, @Ref.void_value)
        }) node_offset:113:5
      }) node_offset:113:5
      %1070 = ensure_result_used(%1067) node_offset:113:5
      %1071 = dbg_stmt(6, 5)
      %1079 = block({
        %1072 = dbg_stmt(6, 9)
        %1073 = decl_val("builtin") token_offset:114:9
        %1074 = field_val(%1073, "zig_backend") node_offset:114:16
        %1075 = enum_literal("stage2_c") token_offset:114:33
        %1076 = cmp_eq(%1074, %1075) node_offset:114:29
        %1077 = as_node(@Ref.bool_type, %1076) node_offset:114:29
        %1078 = condbr(%1077, {
          %1080 = ret_err_value("SkipZigTest") token_offset:114:56
        }, {
          %1081 = break(%1079, @Ref.void_value)
        }) node_offset:114:5
      }) node_offset:114:5
      %1082 = ensure_result_used(%1079) node_offset:114:5
      %1083 = dbg_stmt(7, 5)
      %1091 = block({
        %1084 = dbg_stmt(7, 9)
        %1085 = decl_val("builtin") token_offset:115:9
        %1086 = field_val(%1085, "zig_backend") node_offset:115:16
        %1087 = enum_literal("stage2_x86_64") token_offset:115:33
        %1088 = cmp_eq(%1086, %1087) node_offset:115:29
        %1089 = as_node(@Ref.bool_type, %1088) node_offset:115:29
        %1090 = condbr(%1089, {
          %1092 = ret_err_value("SkipZigTest") token_offset:115:61
        }, {
          %1093 = break(%1091, @Ref.void_value)
        }) node_offset:115:5
      }) node_offset:115:5
      %1094 = ensure_result_used(%1091) node_offset:115:5
      %1095 = dbg_stmt(8, 5)
      %1103 = block({
        %1096 = dbg_stmt(8, 9)
        %1097 = decl_val("builtin") token_offset:116:9
        %1098 = field_val(%1097, "zig_backend") node_offset:116:16
        %1099 = enum_literal("stage2_arm") token_offset:116:33
        %1100 = cmp_eq(%1098, %1099) node_offset:116:29
        %1101 = as_node(@Ref.bool_type, %1100) node_offset:116:29
        %1102 = condbr(%1101, {
          %1104 = ret_err_value("SkipZigTest") token_offset:116:58
        }, {
          %1105 = break(%1103, @Ref.void_value)
        }) node_offset:116:5
      }) node_offset:116:5
      %1106 = ensure_result_used(%1103) node_offset:116:5
      %1107 = dbg_stmt(9, 5)
      %1115 = block({
        %1108 = dbg_stmt(9, 9)
        %1109 = decl_val("builtin") token_offset:117:9
        %1110 = field_val(%1109, "zig_backend") node_offset:117:16
        %1111 = enum_literal("stage2_aarch64") token_offset:117:33
        %1112 = cmp_eq(%1110, %1111) node_offset:117:29
        %1113 = as_node(@Ref.bool_type, %1112) node_offset:117:29
        %1114 = condbr(%1113, {
          %1116 = ret_err_value("SkipZigTest") token_offset:117:62
        }, {
          %1117 = break(%1115, @Ref.void_value)
        }) node_offset:117:5
      }) node_offset:117:5
      %1118 = ensure_result_used(%1115) node_offset:117:5
      %1119 = dbg_stmt(11, 5)
      %1120 = alloc_inferred_mut() node_offset:119:5
      %1121 = int(2)
      %1122 = int_type(u0) node_offset:119:24
      %1123 = vector_type(%1121, %1122) node_offset:119:13
      %1124 = validate_array_init_ty(%1123) node_offset:119:27
      %1125 = elem_type(%1123) node_offset:119:13
      %1126 = coerce_result_ptr(%1123, %1120)
      %1127 = elem_ptr_imm(%1126, 0) node_offset:119:29
      %1128 = store_node(%1127, @Ref.zero) node_offset:119:29
      %1129 = elem_ptr_imm(%1126, 1) node_offset:119:32
      %1130 = store_node(%1129, @Ref.zero) node_offset:119:32
    > %1131 = validate_array_init({
        %1127 = elem_ptr_imm(%1126, 0) node_offset:119:29
        %1129 = elem_ptr_imm(%1126, 1) node_offset:119:32
      }) node_offset:119:27
      %1132 = resolve_inferred_alloc(%1120) node_offset:119:5
      %1133 = dbg_var_ptr(%1120, "v")
      %1134 = dbg_stmt(12, 5)
      %1135 = alloc_inferred_mut() node_offset:120:5
      %1136 = int_type(u0) node_offset:120:28
      %1137 = load(%1120) node_offset:120:32
      %1138 = byte_swap(%1137) node_offset:120:18
      %1139 = store_to_inferred_ptr(%1135, %1138)
      %1140 = resolve_inferred_alloc(%1135) node_offset:120:5
      %1141 = dbg_var_ptr(%1135, "result")
      %1142 = dbg_stmt(13, 5)
      %1151 = block({
        %1143 = decl_val("expect") token_offset:121:9
        %1144 = dbg_stmt(13, 15)
        %1145 = load(%1135) node_offset:121:16
        %1146 = elem_val(%1145, @Ref.zero)
        %1147 = cmp_eq(%1146, @Ref.zero) node_offset:121:26
        %1148 = call(.auto, %1143, [%1147]) node_offset:121:15
        %1149 = is_non_err(%1148) node_offset:121:5
        %1150 = condbr(%1149, {
          %1152 = err_union_payload_unsafe(%1148) node_offset:121:5
          %1155 = break(%1151, %1152)
        }, {
          %1153 = err_union_code(%1148) node_offset:121:5
          %1154 = ret_node(%1153) node_offset:121:5
        }) node_offset:121:5
      }) node_offset:121:5
      %1156 = ensure_result_used(%1151) node_offset:121:5
      %1157 = dbg_stmt(14, 5)
      %1166 = block({
        %1158 = decl_val("expect") token_offset:122:9
        %1159 = dbg_stmt(14, 15)
        %1160 = load(%1135) node_offset:122:16
        %1161 = elem_val(%1160, @Ref.one)
        %1162 = cmp_eq(%1161, @Ref.zero) node_offset:122:26
        %1163 = call(.auto, %1158, [%1162]) node_offset:122:15
        %1164 = is_non_err(%1163) node_offset:122:5
        %1165 = condbr(%1164, {
          %1167 = err_union_payload_unsafe(%1163) node_offset:122:5
          %1170 = break(%1166, %1167)
        }, {
          %1168 = err_union_code(%1163) node_offset:122:5
          %1169 = ret_node(%1168) node_offset:122:5
        }) node_offset:122:5
      }) node_offset:122:5
      %1171 = ensure_result_used(%1166) node_offset:122:5
      %1172 = ret_tok(@Ref.void_value) token_offset:123:1
    For full context, use the command
      zig ast-check -t test/behavior/byteswap.zig


/Users/<USER>/repos/zig/src/Sema.zig:3214:49: 0x107ef2f51 in Sema.zirValidateArrayInit (zig)
            break :inst block.instructions.items[block_index + 1];
                                                ^
/Users/<USER>/repos/zig/src/Sema.zig:956:46: 0x107d594ec in Sema.analyzeBodyInner (zig)
                try sema.zirValidateArrayInit(block, inst, false);
                                             ^
/Users/<USER>/repos/zig/src/Sema.zig:541:30: 0x107d440db in Sema.analyzeBody (zig)
    _ = sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                             ^
/Users/<USER>/repos/zig/src/Module.zig:4804:21: 0x107b998eb in Module.analyzeFnBody (zig)
    sema.analyzeBody(&inner_block, fn_info.body) catch |err| switch (err) {
                    ^
/Users/<USER>/repos/zig/src/Module.zig:3595:40: 0x107b7b267 in Module.ensureFuncBodyAnalyzed (zig)
            var air = mod.analyzeFnBody(decl, func, sema_arena) catch |err| switch (err) {
                                       ^
/Users/<USER>/repos/zig/src/Compilation.zig:2732:42: 0x1079443ab in Compilation.processOneJob (zig)
            module.ensureFuncBodyAnalyzed(func) catch |err| switch (err) {
                                         ^
/Users/<USER>/repos/zig/src/Compilation.zig:2678:30: 0x107930ea3 in Compilation.performAllTheWork (zig)
            try processOneJob(self, work_item, main_progress_node);
                             ^
/Users/<USER>/repos/zig/src/Compilation.zig:2083:31: 0x10792a07a in Compilation.update (zig)
    try comp.performAllTheWork();
                              ^
/Users/<USER>/repos/zig/src/main.zig:3094:20: 0x107895660 in updateModule (zig)
    try comp.update();
                   ^
/Users/<USER>/repos/zig/src/main.zig:2781:17: 0x10781ffdd in buildOutputType (zig)
    updateModule(gpa, comp, hook) catch |err| switch (err) {
                ^
/Users/<USER>/repos/zig/src/main.zig:216:31: 0x107805d5d in mainArgs (zig)
        return buildOutputType(gpa, arena, args, .zig_test);
                              ^
/Users/<USER>/repos/zig/src/main.zig:165:20: 0x107804ce2 in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:575:37: 0x107cfc1b8 in std.start.callMain (zig)
            const result = root.main() catch |err| {
                                    ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:509:12: 0x1078075f7 in std.start.callMainWithArgs (zig)
    return @call(.{ .modifier = .always_inline }, callMain, .{});
           ^
/Users/<USER>/repos/zig/build/lib/zig/std/start.zig:474:12: 0x107807535 in std.start.main (zig)
    return @call(.{ .modifier = .always_inline }, callMainWithArgs, .{ @intCast(usize, c_argc), c_argv, envp });
           ^
???:?:?: 0x7fff68290cc8 in ??? (???)
???:?:?: 0x4 in ??? (???)
zsh: abort      ~/repos/zig/stage2/bin/zig test test/behavior/byteswap.zig -Itest -fLLVM
```

</details>

EDIT: found the issue with `u0`, see https://github.com/ziglang/zig/pull/11206/commits/72735185d2d517099c5573715f442e5aa1721308.