### PR TITLE
Don't strip by default in cc or c++

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1308,7 +1308,7 @@ fn buildOutputType(
         .cc, .cpp => {
             emit_h = .no;
             soname = .no;
-            strip = true;
+            strip = false;
             ensure_libc_on_non_freestanding = true;
             ensure_libcpp_on_non_freestanding = arg_mode == .cpp;
             want_native_include_dirs = true;


### PR DESCRIPTION
gcc and clang do not strip by default, so it seems like `zig cc` and `zig c++` should match that behavior. For reference, current behavior been around ever since `zig cc` and `zig c++` were first added: https://github.com/ziglang/zig/commit/ead50ea6657d31632f5661f788b035a66c344d13.

If there's concern about making this change directly, we could add a flag to explicitly disable stripping, since currently it looks like the only way to do that is to enable some level of debuginfo in this invocation of the compiler.

Closes #11194.