### PR TITLE
stage2: Fix memory leak in Sema

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5070,6 +5070,7 @@ fn instantiateGenericCall(
         };
         const new_func_val = child_sema.resolveConstValue(&child_block, .unneeded, new_func_inst) catch unreachable;
         const new_func = new_func_val.castTag(.function).?.data;
+        errdefer new_func.deinit(gpa);
         assert(new_func == new_module_func);
 
         arg_i = 0;


### PR DESCRIPTION
When a generic call evaluates to a generic type, the call will be re-generated. However, the old function was not freed before being re-generated, causing a memory leak. So rather than only returning an error, we first free the old value. 
