### PR TITLE
std: change error union hashing to use if/else format

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -1788,8 +1788,14 @@ pub const Type = extern union {
                     continue;
                 },
                 .error_set => {
-                    const error_set = ty.castTag(.error_set).?.data;
-                    return writer.writeAll(std.mem.sliceTo(error_set.owner_decl.name, 0));
+                    const names = ty.castTag(.error_set).?.data.names.keys();
+                    try writer.writeAll("error{");
+                    for (names) |name, i| {
+                        if (i != 0) try writer.writeByte(',');
+                        try writer.writeAll(name);
+                    }
+                    try writer.writeAll("}");
+                    return;
                 },
                 .error_set_inferred => {
                     const func = ty.castTag(.error_set_inferred).?.data.func;


### PR DESCRIPTION
Test fails on stage2 without this change, but logically it should
be equivalent. I wasn't able to reduce this to an isolated case
demonstrating any issues with the compiler. I'm going to keep seeking
that out, but in the mean time I felt it was probably worthwhile for the
auto_hash tests to pass since we use auto hash significantly in the
compiler so this should help it compile itself.