### PR TITLE
AstGen: labeled blocks should always complete with a normal break

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -1939,7 +1939,7 @@ fn blockExpr(
     if (token_tags[lbrace - 1] == .colon and
         token_tags[lbrace - 2] == .identifier)
     {
-        return labeledBlockExpr(gz, scope, rl, block_node, statements, .block);
+        return labeledBlockExpr(gz, scope, rl, block_node, statements);
     }
 
     try blockExprStmts(gz, scope, statements);
@@ -1984,12 +1984,9 @@ fn labeledBlockExpr(
     rl: ResultLoc,
     block_node: Ast.Node.Index,
     statements: []const Ast.Node.Index,
-    zir_tag: Zir.Inst.Tag,
 ) InnerError!Zir.Inst.Ref {
     const tracy = trace(@src());
     defer tracy.end();
-
-    assert(zir_tag == .block);
 
     const astgen = gz.astgen;
     const tree = astgen.tree;
@@ -2004,7 +2001,7 @@ fn labeledBlockExpr(
 
     // Reserve the Block ZIR instruction index so that we can put it into the GenZir struct
     // so that break statements can reference it.
-    const block_inst = try gz.makeBlockInst(zir_tag, block_node);
+    const block_inst = try gz.makeBlockInst(.block, block_node);
     try gz.instructions.append(astgen.gpa, block_inst);
 
     var block_scope = gz.makeSubBlock(parent_scope);

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -2018,7 +2018,7 @@ fn labeledBlockExpr(
 
     try blockExprStmts(&block_scope, &block_scope.base, statements);
     if (!block_scope.endsWithNoReturn()) {
-        _ = try block_scope.addBreak(.break_inline, block_inst, .void_value);
+        _ = try block_scope.addBreak(.@"break", block_inst, .void_value);
     }
 
     if (!block_scope.label.?.used) {

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -70,6 +70,7 @@ test {
     _ = @import("behavior/bugs/11165.zig");
     _ = @import("behavior/bugs/11181.zig");
     _ = @import("behavior/bugs/11182.zig");
+    _ = @import("behavior/bugs/11213.zig");
     _ = @import("behavior/call.zig");
     _ = @import("behavior/cast.zig");
     _ = @import("behavior/comptime_memory.zig");

--- a/test/behavior/bugs/11213.zig
+++ b/test/behavior/bugs/11213.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const testing = std.testing;
+
+test {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+
+    const g: error{Test}!void = error.Test;
+
+    var v: u32 = 0;
+    hash(&v, g);
+    try testing.expect(v == 1);
+}
+
+fn hash(v: *u32, key: anytype) void {
+    const Key = @TypeOf(key);
+
+    if (@typeInfo(Key) == .ErrorSet) {
+        v.* += 1;
+        return;
+    }
+
+    switch (@typeInfo(Key)) {
+        .ErrorUnion => blk: {
+            const payload = key catch |err| {
+                hash(v, err);
+                break :blk;
+            };
+
+            hash(v, payload);
+        },
+
+        else => unreachable,
+    }
+}


### PR DESCRIPTION
They aren't inline blocks by nature of being labeled.

I'm not sure I fully grokked `break_inline` properly in this case, so I'm not 100% confident in this fix. It fixes the previous issue and all previous behavior tests continue to pass.

Fixes #11213