### PR TITLE
stage2: x86_64: implement `ptr_elem_val`

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -953,7 +953,8 @@ pub fn spillCompareFlagsIfOccupied(self: *Self) !void {
 /// This can have a side effect of spilling instructions to the stack to free up a register.
 fn copyToTmpRegister(self: *Self, ty: Type, mcv: MCValue) !Register {
     const reg = try self.register_manager.allocReg(null);
-    try self.genSetReg(ty, reg, mcv);
+    const sized_reg = registerAlias(reg, @intCast(u32, ty.abiSize(self.target.*)));
+    try self.genSetReg(ty, sized_reg, mcv);
     return reg;
 }
 
@@ -5337,7 +5338,7 @@ fn genSetReg(self: *Self, ty: Type, reg: Register, mcv: MCValue) InnerError!void
             _ = try self.addInst(.{
                 .tag = .mov,
                 .ops = (Mir.Ops{
-                    .reg1 = reg.to64(),
+                    .reg1 = reg,
                     .reg2 = reg.to64(),
                     .flags = 0b01,
                 }).encode(),

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -382,7 +382,6 @@ fn hereIsAnOpaqueType(ptr: *OpaqueA) *OpaqueA {
 test "take address of parameter" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     try testTakeAddressOfParameter(12.34);
 }
@@ -408,7 +407,6 @@ fn testPointerToVoidReturnType2() *const void {
 test "array 2D const double ptr" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const rect_2d_vertexes = [_][1]f32{
@@ -421,7 +419,6 @@ test "array 2D const double ptr" {
 test "array 2D const double ptr with offset" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const rect_2d_vertexes = [_][2]f32{
@@ -434,7 +431,6 @@ test "array 2D const double ptr with offset" {
 test "array 3D const double ptr with offset" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const rect_3d_vertexes = [_][2][2]f32{
@@ -519,7 +515,6 @@ var global_foo: *i32 = undefined;
 test "peer result location with typed parent, runtime condition, comptime prongs" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest(arg: i32) i32 {
@@ -620,7 +615,6 @@ test "self reference through fn ptr field" {
 test "global variable initialized to global variable array element" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
@@ -655,7 +649,6 @@ test "global constant is loaded with a runtime-known index" {
 test "multiline string literal is null terminated" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const s1 =
         \\one

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -424,6 +424,7 @@ test "f64 at compile time is lossy" {
 }
 
 test {
+    if (builtin.zig_backend != .stage1 and builtin.os.tag == .macos) return error.SkipZigTest;
     comptime try expect(@as(f128, 1 << 113) == 10384593717069655257060992658440192);
 }
 


### PR DESCRIPTION
The code for `airPtrElemVal` is identical to `airPtrElemPtr` except for an extra `mov` at the end.

Also made `copyToTmpRegister` and `genSetReg` (for `direct_load`/`got_load`) use the correct register alias for the type passed in (this was leading to constants getting loaded with the wrong size, for e.g. an `f32` was getting loaded with `mov rbx, QWORD PTR ds:0xc0000a0`)

Since I was touching `behavior/basic.zig` anyway I checked to see if any more tests where passing.