### PR TITLE
stage1: make type names more unique

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3454,6 +3454,8 @@ test "aligned struct fields" {
           <li>If the struct is in the {#syntax#}return{#endsyntax#} expression, it gets named after
           the function it is returning from, with the parameter values serialized.</li>
           <li>Otherwise, the struct gets a name such as <code>(anonymous struct at file.zig:7:38)</code>.</li>
+          <li>If the struct is declared inside another struct, it gets named after both the parent
+          struct and the name inferred by the previous rules, separated by a dot.</li>
       </ul>
       {#code_begin|exe|struct_name#}
 const std = @import("std");

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2188,7 +2188,7 @@ test "enum" {
     try expectFmt("enum: Enum.Two\n", "enum: {X}\n", .{Enum.Two});
 
     // test very large enum to verify ct branch quota is large enough
-    try expectFmt("enum: Win32Error.INVALID_FUNCTION\n", "enum: {}\n", .{std.os.windows.Win32Error.INVALID_FUNCTION});
+    try expectFmt("enum: os.windows.win32error.Win32Error.INVALID_FUNCTION\n", "enum: {}\n", .{std.os.windows.Win32Error.INVALID_FUNCTION});
 }
 
 test "non-exhaustive enum" {

--- a/src/stage1/astgen.cpp
+++ b/src/stage1/astgen.cpp
@@ -7680,11 +7680,14 @@ Buf *get_anon_type_name(CodeGen *codegen, Stage1Zir *exec, const char *kind_name
 
     if (!force_generic) {
         if (exec != nullptr && exec->name != nullptr) {
-            ZigType *import = get_scope_import(scope);
+            buf_resize(out_bare_name, 0);
+            if (scope->id == ScopeIdDecls) {
+                ScopeDecls *decls_scope = reinterpret_cast<ScopeDecls *>(scope);
+                append_namespace_qualification(codegen, out_bare_name, decls_scope->container_type);
+            }
+            buf_append_buf(out_bare_name, exec->name);
             Buf *namespace_name = buf_alloc();
-            append_namespace_qualification(codegen, namespace_name, import);
-            buf_append_buf(namespace_name, exec->name);
-            buf_init_from_buf(out_bare_name, exec->name);
+            buf_append_buf(namespace_name, out_bare_name);
             return namespace_name;
         }
         if (exec != nullptr && exec->name_fn != nullptr) {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -267,7 +267,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    });
         \\}
     , &[_][]const u8{
-        "tmp.zig:3:31: error: expected type 'std.builtin.Type', found 'std.builtin.Int'",
+        "tmp.zig:3:31: error: expected type 'std.builtin.Type', found 'std.builtin.Type.Int'",
     });
 
     ctx.objErrStage1("indexing a undefined slice at comptime",
@@ -3461,7 +3461,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = field;
         \\}
     , &[_][]const u8{
-        "tmp.zig:9:51: error: values of type 'std.builtin.StructField' must be comptime known, but index value is runtime known",
+        "tmp.zig:9:51: error: values of type 'std.builtin.Type.StructField' must be comptime known, but index value is runtime known",
     });
 
     ctx.objErrStage1("compile log statement inside function which must be comptime evaluated",


### PR DESCRIPTION
This pull request attempts to remedy some issues that prevent the changes in #11191 from being able to properly debug some types. The issues there were caused by the fact that type names for dependent types, those declared in a generic struct for example, get a name based solely on the namespace and the name of the struct, and not the parent type. This caused, for example, that there would not be unique names for different kinds of [ArrayHashMap.Data structs](https://github.com/ziglang/zig/blob/ad5770eba40e0cc425c7a1eab4d37c6f9788d670/lib/std/array_hash_map.zig#L500) for different instances of `ArrayHashMap`. All of them would simply be called `std.array_hash_map.Data`. Since the printers for the scripts in #11191 work based on regexes and looking up member function names, this breaks printing of those types in projects where more than one `ArrayHashMap` is used:
```
dependencies = AutoArrayHashMapUnmanaged(*Module.Decl,void) of length 4 = {
    [<error reading variable: Cannot access memory at address 0x8bf9f10>] = {needed = false}, 
    [<error reading variable: Cannot access memory at address 0x8c01740>] = {needed = false}, Python Exception <class 'OverflowError'>: Python int too large to convert to C long
[] = {needed = false}, Python Exception <class 'OverflowError'>: Python int too large to convert to C long
[] = {
      needed = false}}}
```

This change simply prepends the name of the parent scope onto the name of any structs, so generating a more unique name for structs:
```
dependencies = AutoArrayHashMapUnmanaged(*Module.Decl,void) of length 4 = {0x8bf9f10, 0x8bed3d0, 0x8c01740, 0x8c02bd0}}
```
<details closed>
<summary>To compare, the following program:</summary>

```zig
const std = @import("std");

const X = i32;

pub fn main() void {
    const A = namespace.Test(X);
    const B = namespace.Test(A);
    const C = B.DependentFunc(i32);
    const D = C.Dependent;
    const E = D.Dependent;

    var x = A.a(undefined);
    var y = B.a(A{.inner = 123});
    var z = C{.inner = undefined};
    var v = D{.inner = 123};
    var w = E{.inner = 123};
    var q = B.Dependent.DependentFunc(i32){.inner = 123};
    var r = B.Dependent.DependentFunc(i32).Dependent{.inner = 123};
    var s = B.Dependent.DependentFunc(i32).Dependent.Dependent{.inner = 123};
    var t = B.Dependent.DependentFunc(i32).Dependent.Dependent.DependentFunc(i32){.inner = 123};

    var u = std.AutoArrayHashMap(i32, i32).init(std.heap.page_allocator);
    var i = @TypeOf((namespace{.anonymous = .{}}).anonymous).AnonymousDependent{.inner = 123};

    std.debug.print("{s}\n{s}\n{s}\n{s}\n{s}\n{s}\n{s}\n{s}\n{s}\n{s}\n{s}\n{s}\n", .{
        @typeName(@TypeOf(x)),
        @typeName(@TypeOf(y)),
        @typeName(@TypeOf(z)),
        @typeName(@TypeOf(v)),
        @typeName(@TypeOf(w)),
        @typeName(@TypeOf(q)),
        @typeName(@TypeOf(r)),
        @typeName(@TypeOf(s)),
        @typeName(@TypeOf(t)),
        @typeName(@TypeOf(u)),
        @typeName(@TypeOf(u.unmanaged.entries)),
        @typeName(@TypeOf(i)),
    });
}

const namespace = struct {
    anonymous: struct {
        const AnonymousDependent = struct {
            inner: i32,
        };
    },

    pub fn Test(comptime T: type) type {
        return struct {
            inner: T,
            const Dependent = struct {
                inner: T,

                pub fn DependentFunc(comptime U: type) type {
                    return struct {
                        inner: U,

                        const Dependent = struct {
                            inner: U,

                            const Dependent = struct {
                                inner: U,

                                pub fn DependentFunc(comptime V: type) type {
                                    return struct {
                                        inner: V,
                                    };
                                }
                            };
                        };
                    };
                }
            };

            pub fn DependentFunc(comptime U: type) type {
                return struct {
                    inner: U,

                    const Dependent = struct {
                        inner: U,

                        const Dependent = struct {
                            inner: U,
                        };
                    };
                };
            }

            fn a(x: T) Dependent {
                return .{.inner = x};
            }
        };
    }
};
```

</details>

<details open>
<summary>Yields the following on master with stage 1:</summary>

```zig
Dependent
Dependent
namespace.Test(namespace.Test(i32)).DependentFunc(i32)
Dependent
Dependent
Dependent.DependentFunc(i32)
Dependent
Dependent
Dependent.DependentFunc(i32)
std.array_hash_map.ArrayHashMap(i32,i32,std.array_hash_map.AutoContext(i32),false)
std.multi_array_list.MultiArrayList(std.array_hash_map.Data)
AnonymousDependent
```

</details>
<details open>
<summary>The following on master with stage 2:</summary>

```zig
a.namespace.Test(i32).Dependent
a.namespace.Test(a.namespace.Test(i32)).Dependent
a.namespace.Test(a.namespace.Test(i32)).DependentFunc(i32)
a.namespace.Test(a.namespace.Test(i32)).DependentFunc(i32).Dependent
a.namespace.Test(a.namespace.Test(i32)).DependentFunc(i32).Dependent.Dependent
a.namespace.Test(a.namespace.Test(i32)).Dependent.DependentFunc(i32)
a.namespace.Test(a.namespace.Test(i32)).Dependent.DependentFunc(i32).Dependent
a.namespace.Test(a.namespace.Test(i32)).Dependent.DependentFunc(i32).Dependent.Dependent
a.namespace.Test(a.namespace.Test(i32)).Dependent.DependentFunc(i32).Dependent.Dependent.DependentFunc(i32)
array_hash_map.ArrayHashMap(i32,i32,array_hash_map.AutoContext(i32),false)
multi_array_list.MultiArrayList(array_hash_map.ArrayHashMapUnmanaged(i32,i32,array_hash_map.AutoContext(i32),false).Data)
a.namespace.namespace__struct_152.AnonymousDependent
```

</details>
<details open>
<summary>and the following with this patch:</summary>

```zig
namespace.Test(i32).Dependent
namespace.Test(namespace.Test(i32)).Dependent
namespace.Test(namespace.Test(i32)).DependentFunc(i32)
namespace.Test(namespace.Test(i32)).DependentFunc(i32).Dependent
namespace.Test(namespace.Test(i32)).DependentFunc(i32).Dependent.Dependent
namespace.Test(namespace.Test(i32)).Dependent.DependentFunc(i32)
namespace.Test(namespace.Test(i32)).Dependent.DependentFunc(i32).Dependent
namespace.Test(namespace.Test(i32)).Dependent.DependentFunc(i32).Dependent.Dependent
namespace.Test(namespace.Test(i32)).Dependent.DependentFunc(i32).Dependent.Dependent.DependentFunc(i32)
std.array_hash_map.ArrayHashMap(i32,i32,std.array_hash_map.AutoContext(i32),false)
std.multi_array_list.MultiArrayList(std.array_hash_map.ArrayHashMapUnmanaged(i32,i32,std.array_hash_map.AutoContext(i32),false).Data)
struct:42:16.AnonymousDependent
```

</details>

So they are not 100% similar, and I also do not guarantee that the types are completely unique. Also I kind of hacked this functionality into stage 1 and it seems to work in the scenarios I can think of, but there might be some case I missed where it explodes. In particular, I removed the part where it would return a different namespace name since that would include the namespace twice on some types, and it seems to be fine to just return the same name for both the namespace type and the bare name.