### PR TITLE
stage2: fix crash that could happen if `as` zir fails

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6336,7 +6336,7 @@ fn zirAs(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst
     defer tracy.end();
 
     const bin_inst = sema.code.instructions.items(.data)[inst].bin;
-    return sema.analyzeAs(block, .unneeded, bin_inst.lhs, bin_inst.rhs);
+    return sema.analyzeAs(block, sema.src, bin_inst.lhs, bin_inst.rhs);
 }
 
 fn zirAsNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {


### PR DESCRIPTION
Example scenario:

    test {
        const a: i32 = blk: {
            if (false) break :blk 24;
        };
        _ = a;
    }

Prior to this, this would panic the compiler with a source needed error.
This provides the source as `sema.src`. This is not ideal, since the
line it points to is pretty far from the true issue. (One block out)

But, this prevents the compiler from straight up crashing and follows a
pattern used by similar ZIR which don't provide a src loc.