### PR TITLE
add compiler_rt ceilf/ceil/ceill

### DIFF
--- a/lib/std/special/c.zig
+++ b/lib/std/special/c.zig
@@ -83,10 +83,6 @@ comptime {
     @export(log10, .{ .name = "log10", .linkage = .Strong });
     @export(log10f, .{ .name = "log10f", .linkage = .Strong });
 
-    @export(ceil, .{ .name = "ceil", .linkage = .Strong });
-    @export(ceilf, .{ .name = "ceilf", .linkage = .Strong });
-    @export(ceill, .{ .name = "ceill", .linkage = .Strong });
-
     @export(fmod, .{ .name = "fmod", .linkage = .Strong });
     @export(fmodf, .{ .name = "fmodf", .linkage = .Strong });
 
@@ -427,21 +423,6 @@ fn log10(a: f64) callconv(.C) f64 {
 
 fn log10f(a: f32) callconv(.C) f32 {
     return math.log10(a);
-}
-
-fn ceilf(x: f32) callconv(.C) f32 {
-    return math.ceil(x);
-}
-
-fn ceil(x: f64) callconv(.C) f64 {
-    return math.ceil(x);
-}
-
-fn ceill(x: c_longdouble) callconv(.C) c_longdouble {
-    if (!long_double_is_f128) {
-        @panic("TODO implement this");
-    }
-    return math.ceil(x);
 }
 
 fn fmodf(x: f32, y: f32) callconv(.C) f32 {

--- a/lib/std/special/compiler_rt.zig
+++ b/lib/std/special/compiler_rt.zig
@@ -680,6 +680,10 @@ comptime {
         @export(floor, .{ .name = "floor", .linkage = linkage });
         @export(floorl, .{ .name = "floorl", .linkage = linkage });
 
+        @export(ceilf, .{ .name = "ceilf", .linkage = linkage });
+        @export(ceil, .{ .name = "ceil", .linkage = linkage });
+        @export(ceill, .{ .name = "ceill", .linkage = linkage });
+
         @export(fma, .{ .name = "fma", .linkage = linkage });
         @export(fmaf, .{ .name = "fmaf", .linkage = linkage });
         @export(fmal, .{ .name = "fmal", .linkage = linkage });
@@ -809,6 +813,19 @@ fn floorl(x: c_longdouble) callconv(.C) c_longdouble {
         @panic("TODO implement this");
     }
     return math.floor(x);
+}
+
+fn ceilf(x: f32) callconv(.C) f32 {
+    return math.ceil(x);
+}
+fn ceil(x: f64) callconv(.C) f64 {
+    return math.ceil(x);
+}
+fn ceill(x: c_longdouble) callconv(.C) c_longdouble {
+    if (!long_double_is_f128) {
+        @panic("TODO implement this");
+    }
+    return math.ceil(x);
 }
 
 // Avoid dragging in the runtime safety mechanisms into this .o file,


### PR DESCRIPTION
Greetings.

I noticed that msvc stage1 build is broken due to [this commit](https://github.com/ziglang/zig/commit/b2a1b4c085b93d508c51307f40444252b8cd4d52). The error messages is like:

```
zig1.obj : error LNK2019: unresolved external symbol ceill referenced in function std.mem.sliceAsBytes.8517 [E:\zig\build-debug\zig.vcxproj]
```

I figured that it's missing these set of methods in `compiler_rt.zig`. This PR should fix the build.
Cheers!
