### PR TITLE
stage2: add more union compile errors / improve error messages

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -22215,7 +22215,22 @@ fn semaUnionFields(block: *Block, mod: *Module, union_obj: *Module.Union) Compil
         }
 
         const gop = union_obj.fields.getOrPutAssumeCapacity(field_name);
-        assert(!gop.found_existing);
+        if (gop.found_existing) {
+            const msg = msg: {
+                const tree = try sema.getAstTree(&block_scope);
+                const field_src = enumFieldSrcLoc(decl, tree.*, union_obj.node_offset, field_i);
+                const msg = try sema.errMsg(&block_scope, field_src, "duplicate union field: '{s}'", .{field_name});
+                errdefer msg.destroy(gpa);
+
+                const prev_field_index = union_obj.fields.getIndex(field_name).?;
+                const prev_field_src = enumFieldSrcLoc(decl, tree.*, union_obj.node_offset, prev_field_index);
+                try sema.mod.errNoteNonLazy(prev_field_src.toSrcLoc(decl), msg, "other field here", .{});
+                try sema.errNote(&block_scope, src, msg, "union declared here", .{});
+                break :msg msg;
+            };
+            return sema.failWithOwnedErrorMsg(&block_scope, msg);
+        }
+
         gop.value_ptr.* = .{
             .ty = try field_ty.copy(decl_arena_allocator),
             .abi_align = 0,

--- a/src/type.zig
+++ b/src/type.zig
@@ -5305,6 +5305,50 @@ pub const Type = extern union {
         }
     }
 
+    pub fn getNodeOffset(ty: Type) i32 {
+        switch (ty.tag()) {
+            .enum_full, .enum_nonexhaustive => {
+                const enum_full = ty.cast(Payload.EnumFull).?.data;
+                return enum_full.node_offset;
+            },
+            .enum_numbered => return ty.castTag(.enum_numbered).?.data.node_offset,
+            .enum_simple => {
+                const enum_simple = ty.castTag(.enum_simple).?.data;
+                return enum_simple.node_offset;
+            },
+            .@"struct" => {
+                const struct_obj = ty.castTag(.@"struct").?.data;
+                return struct_obj.node_offset;
+            },
+            .error_set => {
+                const error_set = ty.castTag(.error_set).?.data;
+                return error_set.node_offset;
+            },
+            .@"union", .union_tagged => {
+                const union_obj = ty.cast(Payload.Union).?.data;
+                return union_obj.node_offset;
+            },
+            .@"opaque" => {
+                const opaque_obj = ty.cast(Payload.Opaque).?.data;
+                return opaque_obj.node_offset;
+            },
+            .atomic_order,
+            .atomic_rmw_op,
+            .calling_convention,
+            .address_space,
+            .float_mode,
+            .reduce_op,
+            .call_options,
+            .prefetch_options,
+            .export_options,
+            .extern_options,
+            .type_info,
+            => unreachable, // These need to be resolved earlier.
+
+            else => unreachable,
+        }
+    }
+
     /// Asserts the type is an enum.
     pub fn enumHasInt(ty: Type, int: Value, target: Target) bool {
         const S = struct {

--- a/test/compile_errors/stage2/struct_duplicate_field_name.zig
+++ b/test/compile_errors/stage2/struct_duplicate_field_name.zig
@@ -1,0 +1,15 @@
+const S = struct {
+    foo: u32,
+    foo: u32,
+};
+
+export fn entry() void {
+    const s: S = .{ .foo = 100 };
+    _ = s;
+}
+
+// duplicate struct field name
+//
+// :3:5: error: duplicate struct field: 'foo'
+// :2:5: note: other field here
+// :1:11: note: struct declared here

--- a/test/compile_errors/stage2/union_access_of_inactive_field.zig
+++ b/test/compile_errors/stage2/union_access_of_inactive_field.zig
@@ -1,0 +1,14 @@
+const U = union {
+    a: void,
+    b: u64,
+};
+comptime {
+    var u: U = .{.a = {}};
+    const v = u.b;
+    _ = v;
+}
+
+// access of inactive union field
+//
+// :7:16: error: access of union field 'b' while field 'a' is active
+// :1:11: note: union declared here

--- a/test/compile_errors/stage2/union_duplicate_enum_field.zig
+++ b/test/compile_errors/stage2/union_duplicate_enum_field.zig
@@ -1,0 +1,16 @@
+const E = enum {a, b};
+const U = union(E) {
+    a: u32,
+    a: u32,
+};
+
+export fn foo() void {
+    var u: U = .{ .a = 123 };
+    _ = u;
+}
+
+// union with enum and duplicate fields
+//
+// :4:5: error: duplicate union field: 'a'
+// :3:5: note: other field here
+// :2:11: note: union declared here

--- a/test/compile_errors/stage2/union_duplicate_field_definition.zig
+++ b/test/compile_errors/stage2/union_duplicate_field_definition.zig
@@ -1,0 +1,15 @@
+const U = union {
+    foo: u32,
+    foo: u32,
+};
+
+export fn entry() void {
+    const u: U = .{ .foo = 100 };
+    _ = u;
+}
+
+// duplicate union field name
+//
+// :3:5: error: duplicate union field: 'foo'
+// :2:5: note: other field here
+// :1:11: note: union declared here

--- a/test/compile_errors/stage2/union_enum_field_missing.zig
+++ b/test/compile_errors/stage2/union_enum_field_missing.zig
@@ -1,0 +1,20 @@
+const E = enum {
+    a,
+    b,
+    c,
+};
+
+const U = union(E) {
+    a: i32,
+    b: f64,
+};
+
+export fn entry() usize {
+    return @sizeOf(U);
+}
+
+// enum field missing in union
+//
+// :7:1: error: enum field(s) missing in union
+// :4:5: note: field 'c' missing, declared here
+// :1:11: note: enum declared here

--- a/test/compile_errors/stage2/union_extra_field.zig
+++ b/test/compile_errors/stage2/union_extra_field.zig
@@ -1,0 +1,19 @@
+const E = enum {
+    a,
+    b,
+    c,
+};
+const U = union(E) {
+    a: i32,
+    b: f64,
+    c: f64,
+    d: f64,
+};
+export fn entry() usize {
+    return @sizeOf(U);
+}
+
+// union extra field
+//
+// :6:1: error: enum 'tmp.E' hs no field named 'd'
+// :1:11: note: enum declared here

--- a/test/compile_errors/stage2/union_extra_field.zig
+++ b/test/compile_errors/stage2/union_extra_field.zig
@@ -15,5 +15,5 @@ export fn entry() usize {
 
 // union extra field
 //
-// :6:1: error: enum 'tmp.E' hs no field named 'd'
+// :6:1: error: enum 'tmp.E' has no field named 'd'
 // :1:11: note: enum declared here

--- a/test/compile_errors/stage2/union_runtime_coercion_from_enum.zig
+++ b/test/compile_errors/stage2/union_runtime_coercion_from_enum.zig
@@ -1,0 +1,22 @@
+const E = enum {
+    a,
+    b,
+};
+const U = union(E) {
+    a: u32,
+    b: u64,
+};
+fn foo() E {
+    return E.b;
+}
+export fn doTheTest() u64 {
+    var u: U = foo();
+    return u.b;
+}
+
+// runtime coercion from enum to union
+//
+// :13:19: error: runtime coercion from enum 'tmp.E' to union 'tmp.U' which has non-void fields
+// :6:5: note: field 'a' has type 'u32'
+// :7:5: note: field 'b' has type 'u64'
+// :5:11: note: union declared here


### PR DESCRIPTION
To match stage1. For the most part, the error messages are the same, but in some cases I've added some extra information or reformatted it to match how stage2 reports errors.