### PR TITLE
Fix OptionsStep with enums after #11226

### DIFF
--- a/lib/std/build/OptionsStep.zig
+++ b/lib/std/build/OptionsStep.zig
@@ -119,12 +119,17 @@ pub fn addOption(self: *OptionsStep, comptime T: type, name: []const u8, value: 
                 out.print("    {},\n", .{std.zig.fmtId(field.name)}) catch unreachable;
             }
             out.writeAll("};\n") catch unreachable;
-            out.print("pub const {}: {s} = {s}.{s};\n", .{ std.zig.fmtId(name), @typeName(T), @typeName(T), std.zig.fmtId(@tagName(value)) }) catch unreachable;
+            out.print("pub const {}: {s} = {s}.{s};\n", .{
+                std.zig.fmtId(name),
+                std.zig.fmtId(@typeName(T)),
+                std.zig.fmtId(@typeName(T)),
+                std.zig.fmtId(@tagName(value)),
+            }) catch unreachable;
             return;
         },
         else => {},
     }
-    out.print("pub const {}: {s} = ", .{ std.zig.fmtId(name), @typeName(T) }) catch unreachable;
+    out.print("pub const {}: {s} = ", .{ std.zig.fmtId(name), std.zig.fmtId(@typeName(T)) }) catch unreachable;
     printLiteral(out, value, 0) catch unreachable;
     out.writeAll(";\n") catch unreachable;
 }


### PR DESCRIPTION
Due to #11226 `OptionsStep` can generate invalid code as seen here: https://github.com/ziglang/zig/issues/11240

## Before this PR
```zig
pub const @".@build.src.shared.ZigVersion" = enum {
    master,
    @"0.7.0",
    @"0.7.1",
    @"0.8.0",
    @"0.8.1",
    @"0.9.0",
};
pub const data_version: .@build.src.shared.ZigVersion = .@build.src.shared.ZigVersion.master;
pub const @"std.log.Level" = enum {
    err,
    warn,
    info,
    debug,
};
pub const log_level: std.log.Level = std.log.Level.info;
```

## With this PR
```zig
pub const ZigVersion = enum {
    master,
    @"0.7.0",
    @"0.7.1",
    @"0.8.0",
    @"0.8.1",
    @"0.9.0",
};
pub const data_version: ZigVersion = ZigVersion.master;
pub const Level = enum {
    err,
    warn,
    info,
    debug,
};
pub const log_level: Level = Level.info;
```

Closes #11240