### PR TITLE
Add sem_open sem_close C definition to standard library

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -239,6 +239,8 @@ pub extern "c" fn pthread_getspecific(key: c.pthread_key_t) ?*anyopaque;
 pub extern "c" fn pthread_setspecific(key: c.pthread_key_t, value: ?*anyopaque) c_int;
 pub extern "c" fn sem_init(sem: *c.sem_t, pshared: c_int, value: c_uint) c_int;
 pub extern "c" fn sem_destroy(sem: *c.sem_t) c_int;
+pub extern "c" fn sem_open(name: [*:0]const u8, flag: c_int, mode: c.mode_t, value: c_uint) *c.sem_t;
+pub extern "c" fn sem_close(sem: *c.sem_t) c_int;
 pub extern "c" fn sem_post(sem: *c.sem_t) c_int;
 pub extern "c" fn sem_wait(sem: *c.sem_t) c_int;
 pub extern "c" fn sem_trywait(sem: *c.sem_t) c_int;


### PR DESCRIPTION
Current `Thread.Semaphore` in standard library cannot be used across process.

Here's a simple example for using semaphore with current API:
```zig
const std = @import("std");
const PROT = std.os.PROT;
const MAP = std.os.MAP;
const sem_t = std.c.sem_t;

// make sure child always prints first
pub fn main() anyerror!void {
    var shm_addr = try std.os.mmap(null, @sizeOf(sem_t), PROT.READ | PROT.WRITE, MAP.SHARED | MAP.ANONYMOUS, 0, 0);
    var semaphore = @ptrCast(*sem_t, &shm_addr[0]);
    if (std.c.sem_init(semaphore, 1, 0) != 0) return error.SemaphoreFailed;
    const pid = try std.os.fork();
    if (pid == 0) {
        std.debug.print("child\n", .{});
        if (std.c.sem_post(semaphore) != 0) return error.SemaphoreFailed;
    } else {
        if (std.c.sem_wait(semaphore) != 0) return error.SemaphoreFailed;
        std.debug.print("parent\n", .{});
    }
}
```

I'd like to know how to achieve similar result without depending on libc or libpthread (at least on Linux). The following doesn't work:

```zig
const std = @import("std");
const PROT = std.os.PROT;
const MAP = std.os.MAP;
const Semaphore = std.Thread.Semaphore;

// make sure child always prints first
// now with zig's semaphore
pub fn main() anyerror!void {
    var shm_addr = try std.os.mmap(null, @sizeOf(Semaphore), PROT.READ | PROT.WRITE, MAP.SHARED | MAP.ANONYMOUS, -1, 0);
    var semaphore = @ptrCast(*Semaphore, &shm_addr[0]);
    semaphore.* = Semaphore{};
    
    const pid = try std.os.fork();
    if (pid == 0) {
        std.debug.print("child\n", .{});
        semaphore.post();
    } else {
        semaphore.wait();
        std.debug.print("parent\n", .{});
    }
}
```