### PR TITLE
Revert "ignore target lib dirs when invoked with -feach-lib-rpath"

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2197,6 +2197,10 @@ fn buildOutputType(
             clang_argv.appendAssumeCapacity(framework_dir);
             framework_dirs.appendAssumeCapacity(framework_dir);
         }
+
+        for (paths.lib_dirs.items) |lib_dir| {
+            try lib_dirs.append(lib_dir);
+        }
         for (paths.rpaths.items) |rpath| {
             try rpath_list.append(rpath);
         }


### PR DESCRIPTION
Reverts ziglang/zig#10621

Introduced a regression when building stage2 on nixOS where the linker would fail to find relevant LLVM dynamic libraries as some search dirs were missing.