### PR TITLE
stage2: Properly "flatten" elem_ptrs before deref

### DIFF
--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 
@@ -829,4 +830,24 @@ test "const type-annotated local initialized with function call has correct type
     const x: u64 = S.foo();
     try expect(@TypeOf(x) == u64);
     try expect(x == 1234);
+}
+
+test "comptime pointer load through elem_ptr" {
+    const S = struct {
+        x: usize,
+    };
+
+    comptime {
+        var array: [10]S = undefined;
+        for (array) |*elem, i| {
+            elem.* = .{
+                .x = i,
+            };
+        }
+        var ptr = @ptrCast([*]S, &array);
+        var x = ptr[0].x;
+        assert(x == 0);
+        ptr += 1;
+        assert(ptr[1].x == 2);
+    }
 }


### PR DESCRIPTION
Resolves #11272 - `tokenizer` is 100% ✅ 

Sema.pointerDeref() assumes that elem_ptrs have been "flattened" when they were created. That is, an elem_ptr should never be the array_ptr of another elem_ptr if they share the same types.

Value.elemPtr does this already, but a couple of places in Sema were bypassing this logic.
