### PR TITLE
Adds ability to iterate overs lines in a reader:

### DIFF
--- a/lib/std/io/reader.zig
+++ b/lib/std/io/reader.zig
@@ -175,9 +175,12 @@ pub fn Reader(
                 return self.reader.readUntilDelimiterAlloc(self.allocator, '\n', self.max_size);
             }
         };
-        // Creates a LinesIterator using given allocator.
-        pub fn readLinesAlloc(self: Self, allocator: mem.Allocator) LinesIterator {
-            return LinesIterator.init(allocator, self, std.math.maxInt(usize));
+        /// Creates a new `LinesIterator` using given allocator. LinesIterator stores a reference
+        /// to the `io.Reader` and also the allocator, for each call to `next` method on Iterator 
+        /// it will allocate enough memory to read a line and if memory space for given line is 
+        /// larger than `max_size` it will return `error.StreamTooLong`.
+        pub fn readLinesAlloc(self: Self, allocator: mem.Allocator, max_size: usize) LinesIterator {
+            return LinesIterator.init(allocator, self, max_size);
         }
 
         /// Allocates enough memory to read until `delimiter` or end-of-stream.

--- a/lib/std/io/reader.zig
+++ b/lib/std/io/reader.zig
@@ -667,7 +667,7 @@ test "Reader.readUntilDelimiterOrEof writes all bytes read to the output buffer"
 test "Reader.readLinesAlloc read lines from reader" {
     const a = std.testing.allocator;
     const reader = std.io.fixedBufferStream("0000\n12345").reader();
-    var lines = reader.readLinesAlloc(a);
+    var lines = reader.readLinesAlloc(a, std.math.maxInt(usize));
 
     const first_line = lines.next();
     const second_line = lines.next();


### PR DESCRIPTION
This PR will add LinesIterator struct and a method on `reader` called `readLinesAlloc` that will get an Allocator and returns an iterator that for each `.next()` call will alocate enough memory, check with `max_size` and read the line into alocated space and return that line to the user.
```zig
for (reader.readLinesAlloc()) |line| {
     // do smth with the line
}
```