### PR TITLE
translate-c: Use @Vector for vector expressions

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -1441,7 +1441,7 @@ fn makeShuffleMask(c: *Context, scope: *Scope, expr: *const clang.ShuffleVectorE
     assert(num_subexprs >= 3); // two source vectors + at least 1 index expression
     const mask_len = num_subexprs - 2;
 
-    const mask_type = try Tag.std_meta_vector.create(c.arena, .{
+    const mask_type = try Tag.vector.create(c.arena, .{
         .lhs = try transCreateNodeNumber(c, mask_len, .int),
         .rhs = try Tag.type.create(c.arena, "i32"),
     });
@@ -4800,7 +4800,7 @@ fn transType(c: *Context, scope: *Scope, ty: *const clang.Type, source_loc: clan
             const vector_ty = @ptrCast(*const clang.VectorType, ty);
             const num_elements = vector_ty.getNumElements();
             const element_qt = vector_ty.getElementType();
-            return Tag.std_meta_vector.create(c.arena, .{
+            return Tag.vector.create(c.arena, .{
                 .lhs = try transCreateNodeNumber(c, num_elements, .int),
                 .rhs = try transQualType(c, scope, element_qt, source_loc),
             });

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -192,8 +192,8 @@ pub const Node = extern union {
         helpers_shuffle_vector_index,
         /// @import("std").zig.c_translation.Macro.<operand>
         helpers_macro,
-        /// @import("std").meta.Vector(lhs, rhs)
-        std_meta_vector,
+        /// @Vector(lhs, rhs)
+        vector,
         /// @import("std").mem.zeroes(operand)
         std_mem_zeroes,
         /// @import("std").mem.zeroInit(lhs, rhs)
@@ -322,7 +322,7 @@ pub const Node = extern union {
                 .std_mem_zeroinit,
                 .helpers_flexible_array_type,
                 .helpers_shuffle_vector_index,
-                .std_meta_vector,
+                .vector,
                 .ptr_cast,
                 .div_exact,
                 .offset_of,
@@ -899,10 +899,9 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
             const import_node = try renderStdImport(c, &.{ "zig", "c_translation", "shuffleVectorIndex" });
             return renderCall(c, import_node, &.{ payload.lhs, payload.rhs });
         },
-        .std_meta_vector => {
-            const payload = node.castTag(.std_meta_vector).?.data;
-            const import_node = try renderStdImport(c, &.{ "meta", "Vector" });
-            return renderCall(c, import_node, &.{ payload.lhs, payload.rhs });
+        .vector => {
+            const payload = node.castTag(.vector).?.data;
+            return renderBuiltinCall(c, "@Vector", &.{ payload.lhs, payload.rhs });
         },
         .call => {
             const payload = node.castTag(.call).?.data;
@@ -2221,7 +2220,7 @@ fn renderNodeGrouped(c: *Context, node: Node) !NodeIndex {
         .typeof,
         .typeinfo,
         .std_meta_alignment,
-        .std_meta_vector,
+        .vector,
         .helpers_sizeof,
         .helpers_cast,
         .helpers_promoteIntLiteral,


### PR DESCRIPTION
Removes translate-c usage of std.meta.Vector, which was deprecated in d42d31f72f