### PR TITLE
std.fs: Handle EINVAL from linux.getdents64

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -605,7 +605,7 @@ pub const Dir = struct {
                             .BADF => unreachable, // Dir is invalid or was opened without iteration ability
                             .FAULT => unreachable,
                             .NOTDIR => unreachable,
-                            .INVAL => unreachable,
+                            .INVAL => return error.Unexpected, // Linux may in some cases return EINVAL when reading /proc/$PID/net.
                             else => |err| return os.unexpectedErrno(err),
                         }
                         if (rc == 0) return null;


### PR DESCRIPTION
Fixes #11178.

As per discussion on IRC, return error.Unexpected directly rather than calling `os.unexpectedErrno()` to avoid a stack trace in debugging mode. It may be an unexpected error, but it's known to happen and won't need further patching in Zig.