### PR TITLE
stage2: Change semantics of AIR arithmetic overflow instructions

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -134,28 +134,24 @@ pub const Inst = struct {
         /// Uses the `bin_op` field.
         min,
         /// Integer addition with overflow. Both operands are guaranteed to be the same type,
-        /// and the result is bool. The wrapped value is written to the pointer given by the in
-        /// operand of the `pl_op` field. Payload is `Bin` with `lhs` and `rhs` the relevant types
-        /// of the operation.
-        /// Uses the `pl_op` field with payload `Bin`.
+        /// and the result is a tuple with .{res, ov}. The wrapped value is written to res
+        /// and if an overflow happens, ov is 1. Otherwise ov is 0.
+        /// Uses the `ty_pl` field. Payload is `Bin`.
         add_with_overflow,
         /// Integer subtraction with overflow. Both operands are guaranteed to be the same type,
-        /// and the result is bool. The wrapped value is written to the pointer given by the in
-        /// operand of the `pl_op` field. Payload is `Bin` with `lhs` and `rhs` the relevant types
-        /// of the operation.
-        /// Uses the `pl_op` field with payload `Bin`.
+        /// and the result is a tuple with .{res, ov}. The wrapped value is written to res
+        /// and if an overflow happens, ov is 1. Otherwise ov is 0.
+        /// Uses the `ty_pl` field. Payload is `Bin`.
         sub_with_overflow,
         /// Integer multiplication with overflow. Both operands are guaranteed to be the same type,
-        /// and the result is bool. The wrapped value is written to the pointer given by the in
-        /// operand of the `pl_op` field. Payload is `Bin` with `lhs` and `rhs` the relevant types
-        /// of the operation.
-        /// Uses the `pl_op` field with payload `Bin`.
+        /// and the result is a tuple with .{res, ov}. The wrapped value is written to res
+        /// and if an overflow happens, ov is 1. Otherwise ov is 0.
+        /// Uses the `ty_pl` field. Payload is `Bin`.
         mul_with_overflow,
         /// Integer left-shift with overflow. Both operands are guaranteed to be the same type,
-        /// and the result is bool. The wrapped value is written to the pointer given by the in
-        /// operand of the `pl_op` field. Payload is `Bin` with `lhs` and `rhs` the relevant types
-        /// of the operation.
-        /// Uses the `pl_op` field with payload `Bin`.
+        /// and the result is a tuple with .{res, ov}. The wrapped value is written to res
+        /// and if an overflow happens, ov is 1. Otherwise ov is 0.
+        /// Uses the `ty_pl` field. Payload is `Bin`.
         shl_with_overflow,
         /// Allocates stack local memory.
         /// Uses the `ty` field.
@@ -964,6 +960,10 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .union_init,
         .field_parent_ptr,
         .cmp_vector,
+        .add_with_overflow,
+        .sub_with_overflow,
+        .mul_with_overflow,
+        .shl_with_overflow,
         => return air.getRefType(datas[inst].ty_pl.ty),
 
         .not,
@@ -1074,12 +1074,6 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
             const extra = air.extraData(Air.Bin, datas[inst].pl_op.payload).data;
             return air.typeOf(extra.lhs);
         },
-
-        .add_with_overflow,
-        .sub_with_overflow,
-        .mul_with_overflow,
-        .shl_with_overflow,
-        => return Type.bool,
     }
 }
 

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -508,14 +508,19 @@ fn analyzeInst(
         },
         .memset,
         .memcpy,
+        => {
+            const pl_op = inst_datas[inst].pl_op;
+            const extra = a.air.extraData(Air.Bin, pl_op.payload).data;
+            return trackOperands(a, new_set, inst, main_tomb, .{ pl_op.operand, extra.lhs, extra.rhs });
+        },
         .add_with_overflow,
         .sub_with_overflow,
         .mul_with_overflow,
         .shl_with_overflow,
         => {
-            const pl_op = inst_datas[inst].pl_op;
-            const extra = a.air.extraData(Air.Bin, pl_op.payload).data;
-            return trackOperands(a, new_set, inst, main_tomb, .{ pl_op.operand, extra.lhs, extra.rhs });
+            const ty_pl = inst_datas[inst].ty_pl;
+            const extra = a.air.extraData(Air.Bin, ty_pl.payload).data;
+            return trackOperands(a, new_set, inst, main_tomb, .{ extra.lhs, extra.rhs, .none });
         },
         .br => {
             const br = inst_datas[inst].br;

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -473,14 +473,12 @@ const Writer = struct {
     }
 
     fn writeOverflow(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
-        const pl_op = w.air.instructions.items(.data)[inst].pl_op;
-        const extra = w.air.extraData(Air.Bin, pl_op.payload).data;
+        const ty_pl = w.air.instructions.items(.data)[inst].ty_pl;
+        const extra = w.air.extraData(Air.Bin, ty_pl.payload).data;
 
-        try w.writeOperand(s, inst, 0, pl_op.operand);
+        try w.writeOperand(s, inst, 0, extra.lhs);
         try s.writeAll(", ");
-        try w.writeOperand(s, inst, 1, extra.lhs);
-        try s.writeAll(", ");
-        try w.writeOperand(s, inst, 2, extra.rhs);
+        try w.writeOperand(s, inst, 1, extra.rhs);
     }
 
     fn writeMemset(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {


### PR DESCRIPTION
This partially implements #10248 but retains compatibility with the current signature and semantics of `@addWithOverflow` and similar builtins.

This paves the way for implementing these AIR instructions efficiently in self-hosted backends and should also help unblocking https://github.com/ziglang/zig/pull/11174.