### PR TITLE
stage1: implement casting from u0

### DIFF
--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -1707,7 +1707,6 @@ static LLVMValueRef gen_widen_or_shorten(CodeGen *g, bool want_runtime_safety, Z
         ZigType *wanted_type, LLVMValueRef expr_val)
 {
     assert(actual_type->id == wanted_type->id);
-    assert(expr_val != nullptr);
 
     ZigType *scalar_actual_type = (actual_type->id == ZigTypeIdVector) ?
         actual_type->data.vector.elem_type : actual_type;
@@ -1731,6 +1730,19 @@ static LLVMValueRef gen_widen_or_shorten(CodeGen *g, bool want_runtime_safety, Z
         wanted_bits = scalar_wanted_type->data.integral.bit_count;
     } else {
         zig_unreachable();
+    }
+
+    if (expr_val == nullptr) {
+        if (scalar_actual_type->id == ZigTypeIdInt && actual_bits == 0) {
+            if (wanted_bits == 0) {
+                return expr_val;
+            } else {
+                LLVMValueRef zero = LLVMConstNull(get_llvm_type(g, wanted_type));
+                return zero;
+            }
+        } else {
+            zig_unreachable();
+        }
     }
 
     if (scalar_actual_type->id == ZigTypeIdInt && want_runtime_safety && (

--- a/test/behavior/widening.zig
+++ b/test/behavior/widening.zig
@@ -20,6 +20,14 @@ test "integer widening" {
     try expect(f == a);
 }
 
+fn a() u0 {
+    return 0;
+}
+test "integer widening u0 to u8" {
+    const b: u8 = a();
+    try expect(b == 0);
+}
+
 test "implicit unsigned integer to signed integer" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO

--- a/test/behavior/widening.zig
+++ b/test/behavior/widening.zig
@@ -20,12 +20,12 @@ test "integer widening" {
     try expect(f == a);
 }
 
-fn a() u0 {
+fn zero() u0 {
     return 0;
 }
 test "integer widening u0 to u8" {
-    const b: u8 = a();
-    try expect(b == 0);
+    const a: u8 = zero();
+    try expect(a == 0);
 }
 
 test "implicit unsigned integer to signed integer" {


### PR DESCRIPTION
This PR is an attempt to fix #11317. It implements special case of `u0` in `gen_widen_or_shorten`. 