### PR TITLE
std.mem.zeroInit: Fix behaviour with empty initialiser

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -515,6 +515,17 @@ test "zeroInit" {
         .b = 0,
         .a = 0,
     }, c);
+
+    const Foo = struct {
+        foo: u8 = 69,
+        bar: u8,
+    };
+
+    const f = zeroInit(Foo, .{});
+    try testing.expectEqual(Foo{
+        .foo = 69,
+        .bar = 0,
+    }, f);
 }
 
 /// Compares two slices of numbers lexicographically. O(n).

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -432,7 +432,7 @@ pub fn zeroInit(comptime T: type, init: anytype) T {
                 .Struct => |init_info| {
                     var value = std.mem.zeroes(T);
 
-                    if (init_info.is_tuple) {
+                    if (init_info.is_tuple and init_info.fields.len != 0) {
                         inline for (init_info.fields) |field, i| {
                             @field(value, struct_info.fields[i].name) = @field(init, field.name);
                         }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -526,6 +526,17 @@ test "zeroInit" {
         .foo = 69,
         .bar = 0,
     }, f);
+
+    const Bar = struct {
+        foo: u32 = 666,
+        bar: u32 = 420,
+    };
+
+    const b = zeroInit(Bar, .{69});
+    try testing.expectEqual(Bar{
+        .foo = 69,
+        .bar = 420,
+    }, b);
 }
 
 /// Compares two slices of numbers lexicographically. O(n).


### PR DESCRIPTION
Closes #11323

Issue was that if an empty tuple was passed as the initialiser, `zeroInit` would return a zeroed struct. Correct behaviour is to return the struct with default field values, with the rest being zeroed. This PR fixes this behaviour and implements a test case to prevent future regressions.