### PR TITLE
Stage2 fixes to get `zig2 build --help` working

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1885,7 +1885,9 @@ pub fn bufPrintZ(buf: []u8, comptime fmt: []const u8, args: anytype) BufPrintErr
 /// Count the characters needed for format. Useful for preallocating memory
 pub fn count(comptime fmt: []const u8, args: anytype) u64 {
     var counting_writer = std.io.countingWriter(std.io.null_writer);
-    format(counting_writer.writer(), fmt, args) catch |err| switch (err) {};
+    // TODO https://github.com/ziglang/zig/issues/11306
+    // format(counting_writer.writer(), fmt, args) catch |err| switch (err) {};
+    format(counting_writer.writer(), fmt, args) catch unreachable;
     return counting_writer.bytes_written;
 }
 

--- a/lib/std/zig/system/x86.zig
+++ b/lib/std/zig/system/x86.zig
@@ -30,6 +30,8 @@ pub fn detectNativeCpuAndFeatures(arch: Target.Cpu.Arch, os: Target.Os, cross_ta
         .features = Target.Cpu.Feature.Set.empty,
     };
 
+    if (@import("builtin").zig_backend != .stage1) return cpu; // TODO
+
     // First we detect features, to use as hints when detecting CPU Model.
     detectNativeFeatures(&cpu, os.tag);
 


### PR DESCRIPTION
With these fixes applied `zig2 build --help` works. ~~successfully miscompile most of the time.~~ It was branching on undefined values whose debug info was getting optimized away.

Closes  #11326
Closes  #11327