### PR TITLE
x64: implement add, sub and mul with overflow

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -3254,6 +3254,7 @@ fn genBinMathOpMir(self: *Self, mir_tag: Mir.Inst.Tag, dst_ty: Type, dst_mcv: MC
 
 // Performs integer multiplication between dst_mcv and src_mcv, storing the result in dst_mcv.
 fn genIMulOpMir(self: *Self, dst_ty: Type, dst_mcv: MCValue, src_mcv: MCValue) !void {
+    const abi_size = @intCast(u32, dst_ty.abiSize(self.target.*));
     switch (dst_mcv) {
         .none => unreachable,
         .undef => unreachable,
@@ -3276,8 +3277,8 @@ fn genIMulOpMir(self: *Self, dst_ty: Type, dst_mcv: MCValue, src_mcv: MCValue) !
                     _ = try self.addInst(.{
                         .tag = .imul_complex,
                         .ops = (Mir.Ops{
-                            .reg1 = registerAlias(dst_reg, @divExact(src_reg.size(), 8)),
-                            .reg2 = src_reg,
+                            .reg1 = registerAlias(dst_reg, abi_size),
+                            .reg2 = registerAlias(src_reg, abi_size),
                         }).encode(),
                         .data = undefined,
                     });
@@ -3305,7 +3306,7 @@ fn genIMulOpMir(self: *Self, dst_ty: Type, dst_mcv: MCValue, src_mcv: MCValue) !
                     _ = try self.addInst(.{
                         .tag = .imul_complex,
                         .ops = (Mir.Ops{
-                            .reg1 = registerAlias(dst_reg, @intCast(u32, dst_ty.abiSize(self.target.*))),
+                            .reg1 = registerAlias(dst_reg, abi_size),
                             .reg2 = .rbp,
                             .flags = 0b01,
                         }).encode(),
@@ -3342,8 +3343,8 @@ fn genIMulOpMir(self: *Self, dst_ty: Type, dst_mcv: MCValue, src_mcv: MCValue) !
                     _ = try self.addInst(.{
                         .tag = .imul_complex,
                         .ops = (Mir.Ops{
-                            .reg1 = registerAlias(dst_reg, @divExact(src_reg.size(), 8)),
-                            .reg2 = src_reg,
+                            .reg1 = registerAlias(dst_reg, abi_size),
+                            .reg2 = registerAlias(src_reg, abi_size),
                         }).encode(),
                         .data = undefined,
                     });

--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -165,6 +165,7 @@ pub fn lowerMir(emit: *Emit) InnerError!void {
             .cond_set_byte_greater_less,
             .cond_set_byte_above_below,
             .cond_set_byte_eq_ne,
+            .cond_set_byte_overflow,
             => try emit.mirCondSetByte(tag, inst),
 
             .cond_mov_eq => try emit.mirCondMov(.cmove, inst),
@@ -377,6 +378,12 @@ fn mirCondSetByte(emit: *Emit, mir_tag: Mir.Inst.Tag, inst: Mir.Inst.Index) Inne
         .cond_set_byte_eq_ne => switch (@truncate(u1, ops.flags)) {
             0b0 => Tag.setne,
             0b1 => Tag.sete,
+        },
+        .cond_set_byte_overflow => switch (ops.flags) {
+            0b00 => Tag.seto,
+            0b01 => Tag.setno,
+            0b10 => Tag.setc,
+            0b11 => Tag.setnc,
         },
         else => unreachable,
     };

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -309,6 +309,13 @@ pub const Inst = struct {
         cond_mov_lt,
         cond_mov_below,
 
+        /// ops flags:
+        ///     0b00 reg1 if OF = 1
+        ///     0b01 reg1 if OF = 0
+        ///     0b10 reg1 if CF = 1
+        ///     0b11 reg1 if CF = 0
+        cond_set_byte_overflow,
+
         /// ops flags:  form:
         ///       0b00   reg1
         ///       0b01   [reg1 + imm32]

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -639,7 +639,6 @@ test "128-bit multiplication" {
 
 test "@addWithOverflow" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
@@ -684,7 +683,6 @@ test "small int addition" {
 
 test "@mulWithOverflow" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
@@ -698,14 +696,16 @@ test "@mulWithOverflow" {
     var b: u8 = 2;
     try expect(!@mulWithOverflow(u8, a, b, &result));
     try expect(result == 246);
-    b = 4;
-    try expect(@mulWithOverflow(u8, a, b, &result));
-    try expect(result == 236);
+
+    if (builtin.zig_backend != .stage2_x86_64) { // TODO fix mul/imul on x86_64
+        b = 4;
+        try expect(@mulWithOverflow(u8, a, b, &result));
+        try expect(result == 236);
+    }
 }
 
 test "@subWithOverflow" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
@@ -747,7 +747,6 @@ test "@shlWithOverflow" {
 
 test "overflow arithmetic with u0 values" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
     var result: u0 = undefined;
     try expect(!@addWithOverflow(u0, 0, 0, &result));


### PR DESCRIPTION
Partially implements `add_with_overflow`, `sub_with_overflow` and `mul_with_overflow`. Things still missing:
* non-byte-sized integers need truncation added (AFAICT)
* multiplication currently doesn't handle byte-sized ints at all

All in all, this should unblock #11316 and in the meantime I will work on rectifying the above points.