### PR TITLE
zig cc: Don't link libc if provided `-nostdinc`

### DIFF
--- a/src/clang_options_data.zig
+++ b/src/clang_options_data.zig
@@ -4412,7 +4412,7 @@ flagpd1("nostartfiles"),
 .{
     .name = "nostdinc++",
     .syntax = .flag,
-    .zig_equivalent = .nostdlib_cpp,
+    .zig_equivalent = .nostdlibinc_cpp,
     .pd1 = true,
     .pd2 = false,
     .psl = false,

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -49,6 +49,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/issue_7030/build.zig", .{});
     cases.addBuildFile("test/standalone/install_raw_hex/build.zig", .{});
     cases.addBuildFile("test/standalone/issue_9812/build.zig", .{});
+    cases.addBuildFile("test/standalone/issue_11328/build.zig", .{});
     if (builtin.os.tag != .wasi) {
         cases.addBuildFile("test/standalone/load_dynamic_library/build.zig", .{});
     }

--- a/test/standalone/issue_11328/build.zig
+++ b/test/standalone/issue_11328/build.zig
@@ -1,0 +1,19 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const test_step = b.step("test", "Test the program");
+
+    {
+        const run = b.addSystemCommand(&[_][]const u8{
+            b.zig_exe,
+            "cc",
+            "-nostdinc",
+            b.pathFromRoot("hello.c"),
+        });
+        run.expected_exit_code = 1;
+        run.stderr_action = .{ .expect_matches = &[_][]const u8{"'stdio.h' file not found"} };
+        test_step.dependOn(&run.step);
+    }
+
+    b.default_step.dependOn(test_step);
+}

--- a/test/standalone/issue_11328/hello.c
+++ b/test/standalone/issue_11328/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+  printf("hello\n");
+  return 0;
+}

--- a/tools/update_clang_options.zig
+++ b/tools/update_clang_options.zig
@@ -124,7 +124,7 @@ const known_options = [_]KnownOpt{
     },
     .{
         .name = "nostdinc++",
-        .ident = "nostdlib_cpp",
+        .ident = "nostdlibinc_cpp",
     },
     .{
         .name = "nostdlibinc",


### PR DESCRIPTION
Resolves #11328. Thanks to @marler8997 for the report and the test case

Linking libc in Zig pulls in the `#include` headers. To make sure these headers are not pulled in, we need to refrain from linking libc/libcpp if we were provided `-nostdinc`, `-nostdinc++` or synonymous flags.

I also noticed that we were treating `-nostdinc++` as if it were `-nostdlib++`, so this fixes that as well.