### PR TITLE
CBE: fix C output after PR #11302, reenable tests

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -433,7 +433,6 @@ pub const DeclGen = struct {
         if (is_signed) try writer.writeAll("(int128_t)");
         if (is_neg) try writer.writeByte('-');
 
-        assert(high > 0);
         try writer.print("(((uint128_t)0x{x}u<<64)", .{high});
 
         if (low > 0)
@@ -571,6 +570,11 @@ pub const DeclGen = struct {
                     32 => return writer.writeAll("(void *)0xaaaaaaaa"),
                     64 => return writer.writeAll("(void *)0xaaaaaaaaaaaaaaaa"),
                     else => unreachable,
+                },
+                .Struct => {
+                    try writer.writeByte('(');
+                    try dg.renderTypecast(writer, ty);
+                    return writer.writeAll("){0xaa}");
                 },
                 else => {
                     // This should lower to 0xaa bytes in safe modes, and for unsafe modes should

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -443,7 +443,6 @@ fn copyWithPartialInline(s: []u32, b: []u8) void {
 test "binary math operator in partially inlined function" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
     var s: [4]u32 = undefined;
     var b: [16]u8 = undefined;

--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -75,7 +75,6 @@ test "return inner function which references comptime variable of outer function
 }
 
 test "discard the result of a function that returns a struct" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
 

--- a/test/behavior/for.zig
+++ b/test/behavior/for.zig
@@ -69,7 +69,6 @@ test "basic for loop" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
 
     const expected_result = [_]u8{ 9, 8, 7, 6, 0, 1, 2, 3 } ** 3;
 

--- a/test/behavior/int128.zig
+++ b/test/behavior/int128.zig
@@ -46,7 +46,6 @@ test "int128" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
     var buff: i128 = -1;
     try expect(buff < 0 and (buff + 1) == 0);

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -74,8 +74,6 @@ fn assertLenIsZero(msg: []const u8) !void {
 }
 
 test "access len index of sentinel-terminated slice" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-
     const S = struct {
         fn doTheTest() !void {
             var slice: [:0]const u8 = "hello";


### PR DESCRIPTION
Commit 052079c99455d01312d377d72fa1b8b5c0b22aad surfaced two issues with the generated C code:

  - `renderInt128()` contained a seemingly unnecessary assertion to verify that the high 64 bits of the number were nonzero, dating back to 9bf1681990fe87a6b2e5fc644a89f1aece304579. I removed it.
  - `renderValue()` didn't have any special handling for undefined structs, falling back to printing `{}` which generated invalid expressions such as `return {}` for functions returning structs, whereas `return (S){}` is the correct form. I changed it accordingly.

At the same time I'm reenabling the relevant tests.