### PR TITLE
stage2: do not attempt to delete anonymous decls

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3312,29 +3312,29 @@ fn updateZirRefs(gpa: Allocator, file: *File, old_zir: Zir) !void {
                     file.sub_file_path, decl, decl.name, old_zir_decl_index, new_zir_decl_index,
                 });
             }
-        }
 
-        if (!decl.owns_tv) continue;
+            if (!decl.owns_tv) continue;
 
-        if (decl.getStruct()) |struct_obj| {
-            struct_obj.zir_index = inst_map.get(struct_obj.zir_index) orelse {
-                try file.deleted_decls.append(gpa, decl);
-                continue;
-            };
-        }
+            if (decl.getStruct()) |struct_obj| {
+                struct_obj.zir_index = inst_map.get(struct_obj.zir_index) orelse {
+                    try file.deleted_decls.append(gpa, decl);
+                    continue;
+                };
+            }
 
-        if (decl.getUnion()) |union_obj| {
-            union_obj.zir_index = inst_map.get(union_obj.zir_index) orelse {
-                try file.deleted_decls.append(gpa, decl);
-                continue;
-            };
-        }
+            if (decl.getUnion()) |union_obj| {
+                union_obj.zir_index = inst_map.get(union_obj.zir_index) orelse {
+                    try file.deleted_decls.append(gpa, decl);
+                    continue;
+                };
+            }
 
-        if (decl.getFunction()) |func| {
-            func.zir_body_inst = inst_map.get(func.zir_body_inst) orelse {
-                try file.deleted_decls.append(gpa, decl);
-                continue;
-            };
+            if (decl.getFunction()) |func| {
+                func.zir_body_inst = inst_map.get(func.zir_body_inst) orelse {
+                    try file.deleted_decls.append(gpa, decl);
+                    continue;
+                };
+            }
         }
 
         if (decl.getInnerNamespace()) |namespace| {

--- a/test/compile_errors/stage2/union_inactive_field_1.zig
+++ b/test/compile_errors/stage2/union_inactive_field_1.zig
@@ -1,0 +1,13 @@
+const U = union {
+    a: void,
+    b: u64,
+};
+comptime {
+    var u: U = .{.a = {}};
+    const v = u.b;
+    _ = v;
+}
+
+// use of non-active union field - 1
+//
+// :7:16: error: access of inactive union field

--- a/test/compile_errors/stage2/union_inactive_field_2.zig
+++ b/test/compile_errors/stage2/union_inactive_field_2.zig
@@ -1,0 +1,13 @@
+const U = union {
+    a: void,
+    b: u64,
+};
+comptime {
+    var u: U = .{.a = {}};
+    const v = u.b;
+    _ = v;
+}
+
+// use of non-active union field - 2
+//
+// :7:16: error: access of inactive union field


### PR DESCRIPTION
Resolves #11290. The signature of that issue has changed since it was created, but another change was needed to handle incremental updates for anonymous decls correctly.

Anonymous decls will always be cleaned up by `deleteUnusedDecl` and should never enqueued manually for deletion (if I understand correctly)