### PR TITLE
std.testing: add writeZigFile for TmpDir

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -1353,23 +1353,16 @@ test "build and call child_process" {
     var it = try std.process.argsWithAllocator(allocator);
     defer it.deinit(); // no-op unless WASI or Windows
     const testargs = try testing.getTestArgs(&it);
-
     var tmp = testing.tmpDir(.{ .no_follow = true }); // ie zig-cache/tmp/8DLgoSEqz593PAEE
     defer tmp.cleanup();
-    const tmpdirpath = try tmp.getFullPath(allocator);
-    defer allocator.free(tmpdirpath);
     const child_name = "child"; // no need for suffixes (.exe, .wasm) due to '-femit-bin'
-    const suffix_zig = ".zig";
-    const child_path = try fs.path.join(allocator, &[_][]const u8{ tmpdirpath, child_name });
-    defer allocator.free(child_path);
-    const child_zig = try mem.concat(allocator, u8, &[_][]const u8{ child_path, suffix_zig });
-    defer allocator.free(child_zig);
+    const zigfile_path = try tmp.writeZigFile(allocator, childstr, child_name);
+    defer allocator.free(zigfile_path);
 
-    try tmp.dir.writeFile("child.zig", childstr);
-    try testing.buildExe(testargs.zigexec, child_zig, child_path);
-
+    const binary = zigfile_path[0 .. zigfile_path.len - 4]; // '.zig' is 4 characters
+    try testing.buildExe(testargs.zigexec, zigfile_path, binary);
     // spawn compiled file as child_process with argument 'hello world' + expect success
-    const args = [_][]const u8{ child_path, "hello world" };
+    const args = [_][]const u8{ binary, "hello world" };
     var child_proc = try ChildProcess.init(&args, allocator);
     defer child_proc.deinit();
     const ret_val = try child_proc.spawnAndWait();

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -374,6 +374,42 @@ pub const TmpDir = struct {
         self.parent_dir.close();
         self.* = undefined;
     }
+
+    /// Writes program string as zig file into tmp directory
+    /// Caller owns memory
+    ///
+    /// ```
+    /// const progstr = "pub fn main() void {}\n";
+    /// var it = try std.process.argsWithAllocator(std.testing.allocator);
+    /// defer it.deinit(); // no-op unless WASI or Windows
+    /// const testargs = try std.testing.getTestArgs(&it);
+    /// var tmp = std.testing.tmpDir(.{ .no_follow = true }); // ie zig-cache/tmp/8DLgoSEqz593PAEE
+    /// defer tmp.cleanup();
+    /// const zigfile_path = try tmp.writeZigFile(std.testing.allocator, progstr, "bruh");
+    /// defer std.testing.allocator.free(zigfile_path);
+    /// const binary = zigfile_path[0 .. zigfile_path.len - 4]; // '.zig' is 4 characters
+    /// try std.testing.buildExe(testargs.zigexec, zigfile_path, binary);
+    /// ```
+    pub fn writeZigFile(
+        self: *TmpDir,
+        alloc: std.mem.Allocator,
+        progstr: []const u8,
+        filename: []const u8,
+    ) ![]const u8 {
+        const tmpdir_path = try self.getFullPath(alloc);
+        defer alloc.free(tmpdir_path);
+        const suffix_zig = ".zig";
+        const zigfile_path = try std.mem.concat(alloc, u8, &[_][]const u8{
+            tmpdir_path,
+            std.fs.path.sep_str,
+            filename,
+            suffix_zig,
+        });
+        const zigfile = try std.mem.concat(alloc, u8, &[_][]const u8{ filename, suffix_zig });
+        defer alloc.free(zigfile);
+        try self.dir.writeFile(zigfile, progstr);
+        return zigfile_path;
+    }
 };
 
 fn getCwdOrWasiPreopen() std.fs.Dir {

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -405,6 +405,7 @@ pub const TmpDir = struct {
             filename,
             suffix_zig,
         });
+        errdefer alloc.free(zigfile_path);
         const zigfile = try std.mem.concat(alloc, u8, &[_][]const u8{ filename, suffix_zig });
         defer alloc.free(zigfile);
         try self.dir.writeFile(zigfile, progstr);


### PR DESCRIPTION
* remove need for manual string concatenation for building binaries in test blocks
* include small program snippet to show how to get binary path with subslicing