### PR TITLE
std: replace other uses of `std.meta.Vector` with `@Vector`

### DIFF
--- a/lib/std/crypto/aes/aesni.zig
+++ b/lib/std/crypto/aes/aesni.zig
@@ -2,9 +2,7 @@ const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const mem = std.mem;
 const debug = std.debug;
-const Vector = std.meta.Vector;
-
-const BlockVec = Vector(2, u64);
+const BlockVec = @Vector(2, u64);
 
 /// A single AES block.
 pub const Block = struct {

--- a/lib/std/crypto/aes/armcrypto.zig
+++ b/lib/std/crypto/aes/armcrypto.zig
@@ -1,9 +1,7 @@
 const std = @import("../../std.zig");
 const mem = std.mem;
 const debug = std.debug;
-const Vector = std.meta.Vector;
-
-const BlockVec = Vector(2, u64);
+const BlockVec = @Vector(2, u64);
 
 /// A single AES block.
 pub const Block = struct {
@@ -29,7 +27,7 @@ pub const Block = struct {
         return mem.toBytes(x);
     }
 
-    const zero = Vector(2, u64){ 0, 0 };
+    const zero = @Vector(2, u64){ 0, 0 };
 
     /// Encrypt a block with a round key.
     pub inline fn encrypt(block: Block, round_key: Block) Block {
@@ -182,7 +180,7 @@ fn KeySchedule(comptime Aes: type) type {
     return struct {
         const Self = @This();
 
-        const zero = Vector(2, u64){ 0, 0 };
+        const zero = @Vector(2, u64){ 0, 0 };
         const mask1 = @Vector(16, u8){ 13, 14, 15, 12, 13, 14, 15, 12, 13, 14, 15, 12, 13, 14, 15, 12 };
         const mask2 = @Vector(16, u8){ 12, 13, 14, 15, 12, 13, 14, 15, 12, 13, 14, 15, 12, 13, 14, 15 };
 

--- a/lib/std/crypto/chacha20.zig
+++ b/lib/std/crypto/chacha20.zig
@@ -7,7 +7,6 @@ const mem = std.mem;
 const assert = std.debug.assert;
 const testing = std.testing;
 const maxInt = math.maxInt;
-const Vector = std.meta.Vector;
 const Poly1305 = std.crypto.onetimeauth.Poly1305;
 const AuthenticationError = std.crypto.errors.AuthenticationError;
 
@@ -79,7 +78,7 @@ pub const XChaCha8Poly1305 = XChaChaPoly1305(8);
 // Vectorized implementation of the core function
 fn ChaChaVecImpl(comptime rounds_nb: usize) type {
     return struct {
-        const Lane = Vector(4, u32);
+        const Lane = @Vector(4, u32);
         const BlockVec = [4]Lane;
 
         fn initContext(key: [8]u32, d: [4]u32) BlockVec {

--- a/lib/std/crypto/ghash.zig
+++ b/lib/std/crypto/ghash.zig
@@ -92,23 +92,21 @@ pub const Ghash = struct {
     }
 
     inline fn clmul_pclmul(x: u64, y: u64) u64 {
-        const Vector = std.meta.Vector;
         const product = asm (
             \\ vpclmulqdq $0x00, %[x], %[y], %[out]
-            : [out] "=x" (-> Vector(2, u64)),
-            : [x] "x" (@bitCast(Vector(2, u64), @as(u128, x))),
-              [y] "x" (@bitCast(Vector(2, u64), @as(u128, y))),
+            : [out] "=x" (-> @Vector(2, u64)),
+            : [x] "x" (@bitCast(@Vector(2, u64), @as(u128, x))),
+              [y] "x" (@bitCast(@Vector(2, u64), @as(u128, y))),
         );
         return product[0];
     }
 
     inline fn clmul_pmull(x: u64, y: u64) u64 {
-        const Vector = std.meta.Vector;
         const product = asm (
             \\ pmull %[out].1q, %[x].1d, %[y].1d
-            : [out] "=w" (-> Vector(2, u64)),
-            : [x] "w" (@bitCast(Vector(2, u64), @as(u128, x))),
-              [y] "w" (@bitCast(Vector(2, u64), @as(u128, y))),
+            : [out] "=w" (-> @Vector(2, u64)),
+            : [x] "w" (@bitCast(@Vector(2, u64), @as(u128, x))),
+              [y] "w" (@bitCast(@Vector(2, u64), @as(u128, y))),
         );
         return product[0];
     }

--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -15,7 +15,6 @@ const debug = std.debug;
 const assert = std.debug.assert;
 const testing = std.testing;
 const htest = @import("test.zig");
-const Vector = std.meta.Vector;
 const AuthenticationError = std.crypto.errors.AuthenticationError;
 
 pub const State = struct {
@@ -111,7 +110,7 @@ pub const State = struct {
         self.endianSwap();
     }
 
-    const Lane = Vector(4, u32);
+    const Lane = @Vector(4, u32);
 
     inline fn shift(x: Lane, comptime n: comptime_int) Lane {
         return x << @splat(4, @as(u5, n));

--- a/lib/std/crypto/salsa20.zig
+++ b/lib/std/crypto/salsa20.zig
@@ -5,7 +5,6 @@ const debug = std.debug;
 const math = std.math;
 const mem = std.mem;
 const utils = std.crypto.utils;
-const Vector = std.meta.Vector;
 
 const Poly1305 = crypto.onetimeauth.Poly1305;
 const Blake2b = crypto.hash.blake2.Blake2b;
@@ -16,8 +15,8 @@ const IdentityElementError = crypto.errors.IdentityElementError;
 const WeakPublicKeyError = crypto.errors.WeakPublicKeyError;
 
 const Salsa20VecImpl = struct {
-    const Lane = Vector(4, u32);
-    const Half = Vector(2, u32);
+    const Lane = @Vector(4, u32);
+    const Half = @Vector(2, u32);
     const BlockVec = [4]Lane;
 
     fn initContext(key: [8]u32, d: [4]u32) BlockVec {

--- a/lib/std/crypto/utils.zig
+++ b/lib/std/crypto/utils.zig
@@ -149,11 +149,11 @@ test "crypto.utils.timingSafeEql (vectors)" {
     var b: [100]u8 = undefined;
     random.bytes(a[0..]);
     random.bytes(b[0..]);
-    const v1: std.meta.Vector(100, u8) = a;
-    const v2: std.meta.Vector(100, u8) = b;
-    try testing.expect(!timingSafeEql(std.meta.Vector(100, u8), v1, v2));
-    const v3: std.meta.Vector(100, u8) = a;
-    try testing.expect(timingSafeEql(std.meta.Vector(100, u8), v1, v3));
+    const v1: @Vector(100, u8) = a;
+    const v2: @Vector(100, u8) = b;
+    try testing.expect(!timingSafeEql(@Vector(100, u8), v1, v2));
+    const v3: @Vector(100, u8) = a;
+    try testing.expect(timingSafeEql(@Vector(100, u8), v1, v3));
 }
 
 test "crypto.utils.timingSafeCompare" {

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2594,9 +2594,9 @@ test "vector" {
         return error.SkipZigTest;
     }
 
-    const vbool: std.meta.Vector(4, bool) = [_]bool{ true, false, true, false };
-    const vi64: std.meta.Vector(4, i64) = [_]i64{ -2, -1, 0, 1 };
-    const vu64: std.meta.Vector(4, u64) = [_]u64{ 1000, 2000, 3000, 4000 };
+    const vbool: @Vector(4, bool) = [_]bool{ true, false, true, false };
+    const vi64: @Vector(4, i64) = [_]i64{ -2, -1, 0, 1 };
+    const vu64: @Vector(4, u64) = [_]u64{ 1000, 2000, 3000, 4000 };
 
     try expectFmt("{ true, false, true, false }", "{}", .{vbool});
     try expectFmt("{ -2, -1, 0, 1 }", "{}", .{vi64});

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -524,9 +524,9 @@ test "shl" {
     try testing.expect(shl(u8, 0b11111111, 8) == 0);
     try testing.expect(shl(u8, 0b11111111, 9) == 0);
     try testing.expect(shl(u8, 0b11111111, -2) == 0b00111111);
-    try testing.expect(shl(std.meta.Vector(1, u32), std.meta.Vector(1, u32){42}, @as(usize, 1))[0] == @as(u32, 42) << 1);
-    try testing.expect(shl(std.meta.Vector(1, u32), std.meta.Vector(1, u32){42}, @as(isize, -1))[0] == @as(u32, 42) >> 1);
-    try testing.expect(shl(std.meta.Vector(1, u32), std.meta.Vector(1, u32){42}, 33)[0] == 0);
+    try testing.expect(shl(@Vector(1, u32), @Vector(1, u32){42}, @as(usize, 1))[0] == @as(u32, 42) << 1);
+    try testing.expect(shl(@Vector(1, u32), @Vector(1, u32){42}, @as(isize, -1))[0] == @as(u32, 42) >> 1);
+    try testing.expect(shl(@Vector(1, u32), @Vector(1, u32){42}, 33)[0] == 0);
 }
 
 /// Shifts right. Overflowed bits are truncated.
@@ -564,9 +564,9 @@ test "shr" {
     try testing.expect(shr(u8, 0b11111111, 8) == 0);
     try testing.expect(shr(u8, 0b11111111, 9) == 0);
     try testing.expect(shr(u8, 0b11111111, -2) == 0b11111100);
-    try testing.expect(shr(std.meta.Vector(1, u32), std.meta.Vector(1, u32){42}, @as(usize, 1))[0] == @as(u32, 42) >> 1);
-    try testing.expect(shr(std.meta.Vector(1, u32), std.meta.Vector(1, u32){42}, @as(isize, -1))[0] == @as(u32, 42) << 1);
-    try testing.expect(shr(std.meta.Vector(1, u32), std.meta.Vector(1, u32){42}, 33)[0] == 0);
+    try testing.expect(shr(@Vector(1, u32), @Vector(1, u32){42}, @as(usize, 1))[0] == @as(u32, 42) >> 1);
+    try testing.expect(shr(@Vector(1, u32), @Vector(1, u32){42}, @as(isize, -1))[0] == @as(u32, 42) << 1);
+    try testing.expect(shr(@Vector(1, u32), @Vector(1, u32){42}, 33)[0] == 0);
 }
 
 /// Rotates right. Only unsigned values can be rotated.  Negative shift
@@ -593,8 +593,8 @@ test "rotr" {
     try testing.expect(rotr(u8, 0b00000001, @as(usize, 8)) == 0b00000001);
     try testing.expect(rotr(u8, 0b00000001, @as(usize, 4)) == 0b00010000);
     try testing.expect(rotr(u8, 0b00000001, @as(isize, -1)) == 0b00000010);
-    try testing.expect(rotr(std.meta.Vector(1, u32), std.meta.Vector(1, u32){1}, @as(usize, 1))[0] == @as(u32, 1) << 31);
-    try testing.expect(rotr(std.meta.Vector(1, u32), std.meta.Vector(1, u32){1}, @as(isize, -1))[0] == @as(u32, 1) << 1);
+    try testing.expect(rotr(@Vector(1, u32), @Vector(1, u32){1}, @as(usize, 1))[0] == @as(u32, 1) << 31);
+    try testing.expect(rotr(@Vector(1, u32), @Vector(1, u32){1}, @as(isize, -1))[0] == @as(u32, 1) << 1);
 }
 
 /// Rotates left. Only unsigned values can be rotated.  Negative shift
@@ -621,8 +621,8 @@ test "rotl" {
     try testing.expect(rotl(u8, 0b00000001, @as(usize, 8)) == 0b00000001);
     try testing.expect(rotl(u8, 0b00000001, @as(usize, 4)) == 0b00010000);
     try testing.expect(rotl(u8, 0b00000001, @as(isize, -1)) == 0b10000000);
-    try testing.expect(rotl(std.meta.Vector(1, u32), std.meta.Vector(1, u32){1 << 31}, @as(usize, 1))[0] == 1);
-    try testing.expect(rotl(std.meta.Vector(1, u32), std.meta.Vector(1, u32){1 << 31}, @as(isize, -1))[0] == @as(u32, 1) << 30);
+    try testing.expect(rotl(@Vector(1, u32), @Vector(1, u32){1 << 31}, @as(usize, 1))[0] == 1);
+    try testing.expect(rotl(@Vector(1, u32), @Vector(1, u32){1 << 31}, @as(isize, -1))[0] == @as(u32, 1) << 30);
 }
 
 /// Returns an unsigned int type that can hold the number of bits in T

--- a/lib/std/special/compiler_rt/multi3.zig
+++ b/lib/std/special/compiler_rt/multi3.zig
@@ -17,7 +17,7 @@ pub fn __multi3(a: i128, b: i128) callconv(.C) i128 {
     return r.all;
 }
 
-const v128 = std.meta.Vector(2, u64);
+const v128 = @Vector(2, u64);
 pub fn __multi3_windows_x86_64(a: v128, b: v128) callconv(.C) v128 {
     return @bitCast(v128, @call(.{ .modifier = .always_inline }, __multi3, .{
         @bitCast(i128, a),

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -673,8 +673,7 @@ pub const Target = struct {
 
                 /// Adds the specified feature set but not its dependencies.
                 pub fn addFeatureSet(set: *Set, other_set: Set) void {
-                    set.ints = @as(std.meta.Vector(usize_count, usize), set.ints) |
-                        @as(std.meta.Vector(usize_count, usize), other_set.ints);
+                    set.ints = @as(@Vector(usize_count, usize), set.ints) | @as(@Vector(usize_count, usize), other_set.ints);
                 }
 
                 /// Removes the specified feature but not its dependents.
@@ -686,8 +685,7 @@ pub const Target = struct {
 
                 /// Removes the specified feature but not its dependents.
                 pub fn removeFeatureSet(set: *Set, other_set: Set) void {
-                    set.ints = @as(std.meta.Vector(usize_count, usize), set.ints) &
-                        ~@as(std.meta.Vector(usize_count, usize), other_set.ints);
+                    set.ints = @as(@Vector(usize_count, usize), set.ints) & ~@as(@Vector(usize_count, usize), other_set.ints);
                 }
 
                 pub fn populateDependencies(set: *Set, all_features_list: []const Cpu.Feature) void {
@@ -716,7 +714,7 @@ pub const Target = struct {
                 }
 
                 pub fn isSuperSetOf(set: Set, other_set: Set) bool {
-                    const V = std.meta.Vector(usize_count, usize);
+                    const V = @Vector(usize_count, usize);
                     const set_v: V = set.ints;
                     const other_v: V = other_set.ints;
                     return @reduce(.And, (set_v & other_v) == other_v);

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -4,7 +4,6 @@ const expect = std.testing.expect;
 const math = std.math;
 const pi = std.math.pi;
 const e = std.math.e;
-const Vector = std.meta.Vector;
 const has_f80_rt = switch (builtin.cpu.arch) {
     .x86_64, .i386 => true,
     else => false,

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -119,7 +119,7 @@ fn testSqrt() !void {
     try expect(math.approxEqAbs(f32, @sqrt(@as(f32, 2.0)), 1.4142135623730950, epsilon));
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
         var result = @sqrt(v);
         try expect(math.approxEqAbs(f32, @sqrt(@as(f32, 1.1)), result[0], epsilon));
         try expect(math.approxEqAbs(f32, @sqrt(@as(f32, 2.2)), result[1], epsilon));
@@ -199,7 +199,7 @@ fn testSin() !void {
     }
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
         var result = @sin(v);
         try expect(math.approxEqAbs(f32, @sin(@as(f32, 1.1)), result[0], epsilon));
         try expect(math.approxEqAbs(f32, @sin(@as(f32, 2.2)), result[1], epsilon));
@@ -233,7 +233,7 @@ fn testCos() !void {
     }
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 3.3, 4.4 };
         var result = @cos(v);
         try expect(math.approxEqAbs(f32, @cos(@as(f32, 1.1)), result[0], epsilon));
         try expect(math.approxEqAbs(f32, @cos(@as(f32, 2.2)), result[1], epsilon));
@@ -262,7 +262,7 @@ fn testExp() !void {
     }
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
         var result = @exp(v);
         try expect(math.approxEqAbs(f32, @exp(@as(f32, 1.1)), result[0], epsilon));
         try expect(math.approxEqAbs(f32, @exp(@as(f32, 2.2)), result[1], epsilon));
@@ -291,7 +291,7 @@ fn testExp2() !void {
     }
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
         var result = @exp2(v);
         try expect(math.approxEqAbs(f32, @exp2(@as(f32, 1.1)), result[0], epsilon));
         try expect(math.approxEqAbs(f32, @exp2(@as(f32, 2.2)), result[1], epsilon));
@@ -331,7 +331,7 @@ fn testLog() !void {
     }
 }
 
-test "@log with vectors" {
+test "@log with @vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -368,7 +368,7 @@ fn testLog2() !void {
     }
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
         var result = @log2(v);
         try expect(@log2(@as(f32, 1.1)) == result[0]);
         try expect(@log2(@as(f32, 2.2)) == result[1]);
@@ -397,7 +397,7 @@ fn testLog10() !void {
     }
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, 2.2, 0.3, 0.4 };
         var result = @log10(v);
         try expect(@log10(@as(f32, 1.1)) == result[0]);
         try expect(@log10(@as(f32, 2.2)) == result[1]);
@@ -435,7 +435,7 @@ fn testFabs() !void {
     // }
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
         var result = @fabs(v);
         try expect(math.approxEqAbs(f32, @fabs(@as(f32, 1.1)), result[0], epsilon));
         try expect(math.approxEqAbs(f32, @fabs(@as(f32, -2.2)), result[1], epsilon));
@@ -468,7 +468,7 @@ fn testFloor() !void {
     // }
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
         var result = @floor(v);
         try expect(math.approxEqAbs(f32, @floor(@as(f32, 1.1)), result[0], epsilon));
         try expect(math.approxEqAbs(f32, @floor(@as(f32, -2.2)), result[1], epsilon));
@@ -501,7 +501,7 @@ fn testCeil() !void {
     // }
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
         var result = @ceil(v);
         try expect(math.approxEqAbs(f32, @ceil(@as(f32, 1.1)), result[0], epsilon));
         try expect(math.approxEqAbs(f32, @ceil(@as(f32, -2.2)), result[1], epsilon));
@@ -534,7 +534,7 @@ fn testTrunc() !void {
     // }
 
     {
-        var v: Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
+        var v: @Vector(4, f32) = [_]f32{ 1.1, -2.2, 0.3, -0.4 };
         var result = @trunc(v);
         try expect(math.approxEqAbs(f32, @trunc(@as(f32, 1.1)), result[0], epsilon));
         try expect(math.approxEqAbs(f32, @trunc(@as(f32, -2.2)), result[1], epsilon));

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -1282,8 +1282,8 @@ test "vector integer addition" {
 
     const S = struct {
         fn doTheTest() !void {
-            var a: std.meta.Vector(4, i32) = [_]i32{ 1, 2, 3, 4 };
-            var b: std.meta.Vector(4, i32) = [_]i32{ 5, 6, 7, 8 };
+            var a: @Vector(4, i32) = [_]i32{ 1, 2, 3, 4 };
+            var b: @Vector(4, i32) = [_]i32{ 5, 6, 7, 8 };
             var result = a + b;
             var result_array: [4]i32 = result;
             const expected = [_]i32{ 6, 8, 10, 12 };
@@ -1340,8 +1340,8 @@ test "vector comparison" {
 
     const S = struct {
         fn doTheTest() !void {
-            var a: std.meta.Vector(6, i32) = [_]i32{ 1, 3, -1, 5, 7, 9 };
-            var b: std.meta.Vector(6, i32) = [_]i32{ -1, 3, 0, 6, 10, -10 };
+            var a: @Vector(6, i32) = [_]i32{ 1, 3, -1, 5, 7, 9 };
+            var b: @Vector(6, i32) = [_]i32{ -1, 3, 0, 6, 10, -10 };
             try expect(mem.eql(bool, &@as([6]bool, a < b), &[_]bool{ false, false, true, true, true, false }));
             try expect(mem.eql(bool, &@as([6]bool, a <= b), &[_]bool{ false, true, true, true, true, false }));
             try expect(mem.eql(bool, &@as([6]bool, a == b), &[_]bool{ false, true, false, false, false, false }));

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -223,9 +223,9 @@ test "Type.Vector" {
         @Vector(0, u8),
         @Vector(4, u8),
         @Vector(8, *u8),
-        std.meta.Vector(0, u8),
-        std.meta.Vector(4, u8),
-        std.meta.Vector(8, *u8),
+        @Vector(0, u8),
+        @Vector(4, u8),
+        @Vector(8, *u8),
     });
 }
 

--- a/test/behavior/type_info.zig
+++ b/test/behavior/type_info.zig
@@ -447,7 +447,7 @@ test "type info: vectors" {
 }
 
 fn testVector() !void {
-    const vec_info = @typeInfo(std.meta.Vector(4, i32));
+    const vec_info = @typeInfo(@Vector(4, i32));
     try expect(vec_info == .Vector);
     try expect(vec_info.Vector.len == 4);
     try expect(vec_info.Vector.child == i32);

--- a/test/runtime_safety.zig
+++ b/test/runtime_safety.zig
@@ -711,12 +711,12 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    std.os.exit(126);
         \\}
         \\pub fn main() void {
-        \\    var a: std.meta.Vector(4, i32) = [_]i32{ 1, 2, 2147483643, 4 };
-        \\    var b: std.meta.Vector(4, i32) = [_]i32{ 5, 6, 7, 8 };
+        \\    var a: @Vector(4, i32) = [_]i32{ 1, 2, 2147483643, 4 };
+        \\    var b: @Vector(4, i32) = [_]i32{ 5, 6, 7, 8 };
         \\    const x = add(a, b);
         \\    _ = x;
         \\}
-        \\fn add(a: std.meta.Vector(4, i32), b: std.meta.Vector(4, i32)) std.meta.Vector(4, i32) {
+        \\fn add(a: @Vector(4, i32), b: @Vector(4, i32)) @Vector(4, i32) {
         \\    return a + b;
         \\}
     );
@@ -729,12 +729,12 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    std.os.exit(126);
         \\}
         \\pub fn main() void {
-        \\    var a: std.meta.Vector(4, u32) = [_]u32{ 1, 2, 8, 4 };
-        \\    var b: std.meta.Vector(4, u32) = [_]u32{ 5, 6, 7, 8 };
+        \\    var a: @Vector(4, u32) = [_]u32{ 1, 2, 8, 4 };
+        \\    var b: @Vector(4, u32) = [_]u32{ 5, 6, 7, 8 };
         \\    const x = sub(b, a);
         \\    _ = x;
         \\}
-        \\fn sub(a: std.meta.Vector(4, u32), b: std.meta.Vector(4, u32)) std.meta.Vector(4, u32) {
+        \\fn sub(a: @Vector(4, u32), b: @Vector(4, u32)) @Vector(4, u32) {
         \\    return a - b;
         \\}
     );
@@ -747,12 +747,12 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    std.os.exit(126);
         \\}
         \\pub fn main() void {
-        \\    var a: std.meta.Vector(4, u8) = [_]u8{ 1, 2, 200, 4 };
-        \\    var b: std.meta.Vector(4, u8) = [_]u8{ 5, 6, 2, 8 };
+        \\    var a: @Vector(4, u8) = [_]u8{ 1, 2, 200, 4 };
+        \\    var b: @Vector(4, u8) = [_]u8{ 5, 6, 2, 8 };
         \\    const x = mul(b, a);
         \\    _ = x;
         \\}
-        \\fn mul(a: std.meta.Vector(4, u8), b: std.meta.Vector(4, u8)) std.meta.Vector(4, u8) {
+        \\fn mul(a: @Vector(4, u8), b: @Vector(4, u8)) @Vector(4, u8) {
         \\    return a * b;
         \\}
     );
@@ -765,11 +765,11 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    std.os.exit(126);
         \\}
         \\pub fn main() void {
-        \\    var a: std.meta.Vector(4, i16) = [_]i16{ 1, -32768, 200, 4 };
+        \\    var a: @Vector(4, i16) = [_]i16{ 1, -32768, 200, 4 };
         \\    const x = neg(a);
         \\    _ = x;
         \\}
-        \\fn neg(a: std.meta.Vector(4, i16)) std.meta.Vector(4, i16) {
+        \\fn neg(a: @Vector(4, i16)) @Vector(4, i16) {
         \\    return -a;
         \\}
     );
@@ -846,12 +846,12 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    std.os.exit(126);
         \\}
         \\pub fn main() !void {
-        \\    var a: std.meta.Vector(4, i16) = [_]i16{ 1, 2, -32768, 4 };
-        \\    var b: std.meta.Vector(4, i16) = [_]i16{ 1, 2, -1, 4 };
+        \\    var a: @Vector(4, i16) = [_]i16{ 1, 2, -32768, 4 };
+        \\    var b: @Vector(4, i16) = [_]i16{ 1, 2, -1, 4 };
         \\    const x = div(a, b);
         \\    if (x[2] == 32767) return error.Whatever;
         \\}
-        \\fn div(a: std.meta.Vector(4, i16), b: std.meta.Vector(4, i16)) std.meta.Vector(4, i16) {
+        \\fn div(a: @Vector(4, i16), b: @Vector(4, i16)) @Vector(4, i16) {
         \\    return @divTrunc(a, b);
         \\}
     );
@@ -944,12 +944,12 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    std.os.exit(126);
         \\}
         \\pub fn main() void {
-        \\    var a: std.meta.Vector(4, i32) = [4]i32{111, 222, 333, 444};
-        \\    var b: std.meta.Vector(4, i32) = [4]i32{111, 0, 333, 444};
+        \\    var a: @Vector(4, i32) = [4]i32{111, 222, 333, 444};
+        \\    var b: @Vector(4, i32) = [4]i32{111, 0, 333, 444};
         \\    const x = div0(a, b);
         \\    _ = x;
         \\}
-        \\fn div0(a: std.meta.Vector(4, i32), b: std.meta.Vector(4, i32)) std.meta.Vector(4, i32) {
+        \\fn div0(a: @Vector(4, i32), b: @Vector(4, i32)) @Vector(4, i32) {
         \\    return @divTrunc(a, b);
         \\}
     );
@@ -978,12 +978,12 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    std.os.exit(126);
         \\}
         \\pub fn main() !void {
-        \\    var a: std.meta.Vector(4, i32) = [4]i32{111, 222, 333, 444};
-        \\    var b: std.meta.Vector(4, i32) = [4]i32{111, 222, 333, 441};
+        \\    var a: @Vector(4, i32) = [4]i32{111, 222, 333, 444};
+        \\    var b: @Vector(4, i32) = [4]i32{111, 222, 333, 441};
         \\    const x = divExact(a, b);
         \\    _ = x;
         \\}
-        \\fn divExact(a: std.meta.Vector(4, i32), b: std.meta.Vector(4, i32)) std.meta.Vector(4, i32) {
+        \\fn divExact(a: @Vector(4, i32), b: @Vector(4, i32)) @Vector(4, i32) {
         \\    return @divExact(a, b);
         \\}
     );


### PR DESCRIPTION
followup to https://github.com/ziglang/zig/commit/7be340e3cc62285d77cbd13f19f4ff0a2a982e82