### PR TITLE
Remove a std.debug.print from the dwarf.zig file

### DIFF
--- a/lib/std/dwarf.zig
+++ b/lib/std/dwarf.zig
@@ -514,7 +514,6 @@ fn parseFormValue(allocator: mem.Allocator, in_stream: anytype, form_id: u64, en
         FORM.implicit_const => FormValue{ .Const = Constant{ .signed = true, .payload = undefined } },
 
         else => {
-            std.debug.print("dwarf: unhandled form_id: 0x{x}\n", .{form_id});
             return error.InvalidDebugInfo;
         },
     };


### PR DESCRIPTION
This was causing freestanding builds to fail due to the use of `std.debug.print`

Unsure if this is the correct path to take (as potentially valuable output is lost) - happy to accept feedback and adjust as needed.