### PR TITLE
stage2: fix print_zir for .builtin_src

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -7223,14 +7223,11 @@ fn builtinCall(
         .src => {
             const token_starts = tree.tokens.items(.start);
             const node_start = token_starts[tree.firstToken(node)];
-
             astgen.advanceSourceCursor(node_start);
-
             const result = try gz.addExtendedPayload(.builtin_src, Zir.Inst.LineColumn{
-                .line = @intCast(u32, astgen.source_line),
-                .column = @intCast(u32, astgen.source_column),
+                .line = astgen.source_line,
+                .column = astgen.source_column,
             });
-
             return rvalue(gz, rl, result, node);
         },
 

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -1587,7 +1587,7 @@ pub const Inst = struct {
         /// `operand` is `src_node: i32`.
         ret_addr,
         /// Implements the `@src` builtin.
-        /// `operand` is payload index to `ColumnLine`.
+        /// `operand` is payload index to `LineColumn`.
         builtin_src,
         /// Implements the `@errorReturnTrace` builtin.
         /// `operand` is `src_node: i32`.

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -461,8 +461,13 @@ const Writer = struct {
             .error_return_trace,
             .frame,
             .frame_address,
-            .builtin_src,
             => try self.writeExtNode(stream, extended),
+
+            .builtin_src => {
+                try stream.writeAll("))");
+                const inst_data = self.code.extraData(Zir.Inst.LineColumn, extended.operand).data;
+                try stream.print(":{d}:{d}", .{ inst_data.line + 1, inst_data.column + 1 });
+            },
 
             .dbg_block_begin,
             .dbg_block_end,


### PR DESCRIPTION
fix the line and column printed in Zir for calls to `@src()`

also fixes #11354