### PR TITLE
zig fmt: remove trailing whitespace on doc comments

### DIFF
--- a/lib/std/Thread/Futex.zig
+++ b/lib/std/Thread/Futex.zig
@@ -1,7 +1,7 @@
 //! Futex is a mechanism used to block (`wait`) and unblock (`wake`) threads using a 32bit memory address as hints.
 //! Blocking a thread is acknowledged only if the 32bit memory address is equal to a given value.
 //! This check helps avoid block/unblock deadlocks which occur if a `wake()` happens before a `wait()`.
-//! Using Futex, other Thread synchronization primitives can be built which efficiently wait for cross-thread events or signals.  
+//! Using Futex, other Thread synchronization primitives can be built which efficiently wait for cross-thread events or signals.
 
 const std = @import("../std.zig");
 const builtin = @import("builtin");
@@ -20,7 +20,7 @@ const spinLoopHint = std.atomic.spinLoopHint;
 /// - The value at `ptr` is no longer equal to `expect`.
 /// - The caller is unblocked by a matching `wake()`.
 /// - The caller is unblocked spuriously by an arbitrary internal signal.
-/// 
+///
 /// If `timeout` is provided, and the caller is blocked for longer than `timeout` nanoseconds`, `error.TimedOut` is returned.
 ///
 /// The checking of `ptr` and `expect`, along with blocking the caller, is done atomically

--- a/lib/std/compress/deflate/compressor.zig
+++ b/lib/std/compress/deflate/compressor.zig
@@ -219,7 +219,7 @@ const CompressorOptions = struct {
 ///
 /// `dictionary` is optional and initializes the new `Compressor` with a preset dictionary.
 /// The returned Compressor behaves as if the dictionary had been written to it without producing
-/// any compressed output. The compressed data written to hm_bw can only be decompressed by a 
+/// any compressed output. The compressed data written to hm_bw can only be decompressed by a
 /// Decompressor initialized with the same dictionary.
 ///
 /// The compressed data will be passed to the provided `writer`, see `writer()` and `write()`.

--- a/lib/std/crypto/argon2.zig
+++ b/lib/std/crypto/argon2.zig
@@ -34,18 +34,18 @@ const max_hash_len = 64;
 
 /// Argon2 type
 pub const Mode = enum {
-    /// Argon2d is faster and uses data-depending memory access, which makes it highly resistant 
-    /// against GPU cracking attacks and suitable for applications with no threats from side-channel 
+    /// Argon2d is faster and uses data-depending memory access, which makes it highly resistant
+    /// against GPU cracking attacks and suitable for applications with no threats from side-channel
     /// timing attacks (eg. cryptocurrencies).
     argon2d,
 
-    /// Argon2i instead uses data-independent memory access, which is preferred for password 
-    /// hashing and password-based key derivation, but it is slower as it makes more passes over 
+    /// Argon2i instead uses data-independent memory access, which is preferred for password
+    /// hashing and password-based key derivation, but it is slower as it makes more passes over
     /// the memory to protect from tradeoff attacks.
     argon2i,
 
-    /// Argon2id is a hybrid of Argon2i and Argon2d, using a combination of data-depending and 
-    /// data-independent memory accesses, which gives some of Argon2i's resistance to side-channel 
+    /// Argon2id is a hybrid of Argon2i and Argon2d, using a combination of data-depending and
+    /// data-independent memory accesses, which gives some of Argon2i's resistance to side-channel
     /// cache timing attacks and much of Argon2d's resistance to GPU cracking attacks.
     argon2id,
 };
@@ -54,7 +54,7 @@ pub const Mode = enum {
 pub const Params = struct {
     const Self = @This();
 
-    /// A [t]ime cost, which defines the amount of computation realized and therefore the execution 
+    /// A [t]ime cost, which defines the amount of computation realized and therefore the execution
     /// time, given in number of iterations.
     t: u32,
 
@@ -64,16 +64,16 @@ pub const Params = struct {
     /// A [p]arallelism degree, which defines the number of parallel threads.
     p: u24,
 
-    /// The [secret] parameter, which is used for keyed hashing. This allows a secret key to be input 
-    /// at hashing time (from some external location) and be folded into the value of the hash. This 
-    /// means that even if your salts and hashes are compromised, an attacker cannot brute-force to 
+    /// The [secret] parameter, which is used for keyed hashing. This allows a secret key to be input
+    /// at hashing time (from some external location) and be folded into the value of the hash. This
+    /// means that even if your salts and hashes are compromised, an attacker cannot brute-force to
     /// find the password without the key.
     secret: ?[]const u8 = null,
 
-    /// The [ad] parameter, which is used to fold any additional data into the hash value. Functionally, 
-    /// this behaves almost exactly like the secret or salt parameters; the ad parameter is folding 
-    /// into the value of the hash. However, this parameter is used for different data. The salt 
-    /// should be a random string stored alongside your password. The secret should be a random key 
+    /// The [ad] parameter, which is used to fold any additional data into the hash value. Functionally,
+    /// this behaves almost exactly like the secret or salt parameters; the ad parameter is folding
+    /// into the value of the hash. However, this parameter is used for different data. The salt
+    /// should be a random string stored alongside your password. The secret should be a random key
     /// only usable at hashing time. The ad is for any other data.
     ad: ?[]const u8 = null,
 

--- a/lib/std/crypto/scrypt.zig
+++ b/lib/std/crypto/scrypt.zig
@@ -131,7 +131,7 @@ pub const Params = struct {
     r: u30,
 
     /// The [p]arallelization parameter.
-    /// A large value of [p] can be used to increase the computational cost of scrypt without 
+    /// A large value of [p] can be used to increase the computational cost of scrypt without
     /// increasing the memory usage.
     p: u30,
 
@@ -326,7 +326,7 @@ const crypt_format = struct {
         try out.writeAll(hash_str);
     }
 
-    /// Custom codec that maps 6 bits into 8 like regular Base64, but uses its own alphabet, 
+    /// Custom codec that maps 6 bits into 8 like regular Base64, but uses its own alphabet,
     /// encodes bits in little-endian, and can also encode integers.
     fn CustomB64Codec(comptime map: [64]u8) type {
         return struct {

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -437,7 +437,7 @@ test "max3" {
     try testing.expect(max3(@as(i32, 2), @as(i32, 1), @as(i32, 0)) == 2);
 }
 
-/// Limit val to the inclusive range [lower, upper]. 
+/// Limit val to the inclusive range [lower, upper].
 pub fn clamp(val: anytype, lower: anytype, upper: anytype) @TypeOf(val, lower, upper) {
     assert(lower <= upper);
     return max(lower, min(val, upper));

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -1750,8 +1750,8 @@ pub const Mutable = struct {
     /// Read the value of `x` from `buffer`
     /// Asserts that `buffer`, `abi_size`, and `bit_count` are large enough to store the value.
     ///
-    /// The contents of `buffer` are interpreted as if they were the contents of 
-    /// @ptrCast(*[abi_size]const u8, &x). Byte ordering is determined by `endian` 
+    /// The contents of `buffer` are interpreted as if they were the contents of
+    /// @ptrCast(*[abi_size]const u8, &x). Byte ordering is determined by `endian`
     /// and any required padding bits are expected on the MSB end.
     pub fn readTwosComplement(
         x: *Mutable,

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -50,7 +50,7 @@ pub const VTable = struct {
         else => *const resizeProto,
     },
 
-    /// Free and invalidate a buffer. `buf.len` must equal the most recent length returned by `alloc` or `resize`. 
+    /// Free and invalidate a buffer. `buf.len` must equal the most recent length returned by `alloc` or `resize`.
     /// `buf_align` must equal the same value that was passed as the `ptr_align` parameter to the original `alloc` call.
     ///
     /// `ret_addr` is optionally provided as the first return address of the allocation call stack.
@@ -603,7 +603,7 @@ test "allocBytes non-zero len_align" {
 /// allocation could not be granted this function returns `error.OutOfMemory`.
 /// When the size/alignment is less than or equal to the previous allocation,
 /// this function returns `error.OutOfMemory` when the allocator decides the client
-/// would be better off keeping the extra alignment/size. 
+/// would be better off keeping the extra alignment/size.
 /// Clients will call `resizeFn` when they require the allocator to track a new alignment/size,
 /// and so this function should only return success when the allocator considers
 /// the reallocation desirable from the allocator's perspective.

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1441,7 +1441,7 @@ var wasi_cwd = if (builtin.os.tag == .wasi and !builtin.link_libc) struct {
 /// Note that `cwd_init` corresponds to a Preopen directory, not necessarily
 /// a POSIX path. For example, "." matches a Preopen provided with `--dir=.`
 ///
-/// This must be called before using any relative or absolute paths with `std.os` 
+/// This must be called before using any relative or absolute paths with `std.os`
 /// functions, if you are on WASI without linking libc.
 ///
 /// `alloc` must not be a temporary or leak-detecting allocator, since `std.os`
@@ -1475,7 +1475,7 @@ pub fn initPreopensWasi(alloc: Allocator, cwd_init: ?[]const u8) !void {
 
 /// Resolve a relative or absolute path to an handle (`fd_t`) and a relative subpath.
 ///
-/// For absolute paths, this automatically searches among available Preopens to find 
+/// For absolute paths, this automatically searches among available Preopens to find
 /// a match. For relative paths, it uses the "emulated" CWD.
 pub fn resolvePathWasi(path: []const u8, out_buffer: *[MAX_PATH_BYTES]u8) !RelativePathWasi {
     // Note: Due to WASI's "sandboxed" file handles, operations with this RelativePathWasi

--- a/lib/std/os/uefi/pool_allocator.zig
+++ b/lib/std/os/uefi/pool_allocator.zig
@@ -90,7 +90,7 @@ const pool_allocator_vtable = Allocator.VTable{
     .free = UefiPoolAllocator.free,
 };
 
-/// Asserts allocations are 8 byte aligned and calls `boot_services.allocatePool`. 
+/// Asserts allocations are 8 byte aligned and calls `boot_services.allocatePool`.
 pub const raw_pool_allocator = Allocator{
     .ptr = undefined,
     .vtable = &raw_pool_allocator_table,

--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -67,7 +67,7 @@ pub const BootServices = extern struct {
     /// Reinstalls a protocol interface on a device handle
     reinstallProtocolInterface: fn (handle: Handle, protocol: *align(8) const Guid, old_interface: *anyopaque, new_interface: *anyopaque) callconv(.C) Status,
 
-    /// Removes a protocol interface from a device handle. Usage of 
+    /// Removes a protocol interface from a device handle. Usage of
     /// uninstallMultipleProtocolInterfaces is recommended over this.
     uninstallProtocolInterface: fn (handle: Handle, protocol: *align(8) const Guid, interface: *anyopaque) callconv(.C) Status,
 

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -182,7 +182,7 @@ pub fn PackedIntIo(comptime Int: type, comptime endian: Endian) type {
 
 /// Creates a bit-packed array of `Int`. Non-byte-multiple integers
 /// will take up less memory in PackedIntArray than in a normal array.
-/// Elements are packed using native endianess and without storing any 
+/// Elements are packed using native endianess and without storing any
 /// meta data. PackedArray(i3, 8) will occupy exactly 3 bytes
 /// of memory.
 pub fn PackedIntArray(comptime Int: type, comptime int_count: usize) type {

--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -296,7 +296,7 @@ test "vector searching" {
 pub fn prefixScanWithFunc(
     comptime hop: isize,
     vec: anytype,
-    /// The error type that `func` might return. Set this to `void` if `func` doesn't return an error union. 
+    /// The error type that `func` might return. Set this to `void` if `func` doesn't return an error union.
     comptime ErrorType: type,
     comptime func: fn (@TypeOf(vec), @TypeOf(vec)) if (ErrorType == void) @TypeOf(vec) else ErrorType!@TypeOf(vec),
     /// When one operand of the operation performed by `func` is this value, the result must equal the other operand.

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -147,7 +147,7 @@ pub const s_per_day = s_per_hour * 24;
 pub const s_per_week = s_per_day * 7;
 
 /// An Instant represents a timestamp with respect to the currently
-/// executing program that ticks during suspend and can be used to 
+/// executing program that ticks during suspend and can be used to
 /// record elapsed time unlike `nanoTimestamp`.
 ///
 /// It tries to sample the system's fastest and most precise timer available.
@@ -256,7 +256,7 @@ pub const Instant = struct {
 ///
 /// Monotonicity is ensured by saturating on the most previous sample.
 /// This means that while timings reported are monotonic,
-/// they're not guaranteed to tick at a steady rate as this is up to the underlying system.  
+/// they're not guaranteed to tick at a steady rate as this is up to the underlying system.
 pub const Timer = struct {
     started: Instant,
     previous: Instant,
@@ -290,7 +290,7 @@ pub const Timer = struct {
         return current.since(self.started);
     }
 
-    /// Returns an Instant sampled at the callsite that is 
+    /// Returns an Instant sampled at the callsite that is
     /// guaranteed to be monotonic with respect to the timer's starting point.
     fn sample(self: *Timer) Instant {
         const current = Instant.now() catch unreachable;

--- a/lib/std/x/net/tcp.zig
+++ b/lib/std/x/net/tcp.zig
@@ -186,7 +186,7 @@ pub const Client = struct {
 
     /// Have keep-alive messages be sent periodically. The timing in which keep-alive messages are sent are
     /// dependant on operating system settings. It returns `error.UnsupportedSocketOption` if the host does
-    /// not support periodically sending keep-alive messages on connection-oriented sockets. 
+    /// not support periodically sending keep-alive messages on connection-oriented sockets.
     pub fn setKeepAlive(self: Client, enabled: bool) !void {
         return self.socket.setKeepAlive(enabled);
     }

--- a/lib/std/x/os/socket_posix.zig
+++ b/lib/std/x/os/socket_posix.zig
@@ -205,7 +205,7 @@ pub fn Mixin(comptime Socket: type) type {
 
         /// On connection-oriented sockets, have keep-alive messages be sent periodically. The timing in which keep-alive
         /// messages are sent are dependant on operating system settings. It returns `error.UnsupportedSocketOption` if
-        /// the host does not support periodically sending keep-alive messages on connection-oriented sockets. 
+        /// the host does not support periodically sending keep-alive messages on connection-oriented sockets.
         pub fn setKeepAlive(self: Socket, enabled: bool) !void {
             if (@hasDecl(os.SO, "KEEPALIVE")) {
                 return self.setOption(os.SOL.SOCKET, os.SO.KEEPALIVE, mem.asBytes(&@as(u32, @boolToInt(enabled))));
@@ -243,7 +243,7 @@ pub fn Mixin(comptime Socket: type) type {
 
         /// WARNING: Timeouts only affect blocking sockets. It is undefined behavior if a timeout is
         /// set on a non-blocking socket.
-        /// 
+        ///
         /// Set a timeout on the socket that is to occur if no messages are successfully written
         /// to its bound destination after a specified number of milliseconds. A subsequent write
         /// to the socket will thereafter return `error.WouldBlock` should the timeout be exceeded.
@@ -258,7 +258,7 @@ pub fn Mixin(comptime Socket: type) type {
 
         /// WARNING: Timeouts only affect blocking sockets. It is undefined behavior if a timeout is
         /// set on a non-blocking socket.
-        /// 
+        ///
         /// Set a timeout on the socket that is to occur if no messages are successfully read
         /// from its bound destination after a specified number of milliseconds. A subsequent
         /// read from the socket will thereafter return `error.WouldBlock` should the timeout be

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -4712,6 +4712,28 @@ test "zig fmt: space after top level doc comment" {
     );
 }
 
+test "zig fmt: remove trailing whitespace after container doc comment" {
+    try testTransform(
+        \\//! top level doc comment 
+        \\
+    ,
+        \\//! top level doc comment
+        \\
+    );
+}
+
+test "zig fmt: remove trailing whitespace after doc comment" {
+    try testTransform(
+        \\/// doc comment 
+        \\a = 0,
+        \\
+    ,
+        \\/// doc comment
+        \\a = 0,
+        \\
+    );
+}
+
 test "zig fmt: for loop with ptr payload and index" {
     try testCanonical(
         \\test {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2506,9 +2506,15 @@ fn renderContainerDocComments(ais: *Ais, tree: Ast, start_token: Ast.TokenIndex)
 
 fn tokenSliceForRender(tree: Ast, token_index: Ast.TokenIndex) []const u8 {
     var ret = tree.tokenSlice(token_index);
-    if (tree.tokens.items(.tag)[token_index] == .multiline_string_literal_line) {
-        assert(ret[ret.len - 1] == '\n');
-        ret.len -= 1;
+    switch (tree.tokens.items(.tag)[token_index]) {
+        .multiline_string_literal_line => {
+            assert(ret[ret.len - 1] == '\n');
+            ret.len -= 1;
+        },
+        .container_doc_comment, .doc_comment => {
+            ret = mem.trimRight(u8, ret, &std.ascii.spaces);
+        },
+        else => {}
     }
     return ret;
 }

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2514,7 +2514,7 @@ fn tokenSliceForRender(tree: Ast, token_index: Ast.TokenIndex) []const u8 {
         .container_doc_comment, .doc_comment => {
             ret = mem.trimRight(u8, ret, &std.ascii.spaces);
         },
-        else => {}
+        else => {},
     }
     return ret;
 }

--- a/lib/std/zig/string_literal.zig
+++ b/lib/std/zig/string_literal.zig
@@ -61,7 +61,7 @@ pub fn parseCharLiteral(slice: []const u8) ParsedCharLiteral {
     }
 }
 
-/// Parse an escape sequence from `slice[offset..]`. If parsing is successful, 
+/// Parse an escape sequence from `slice[offset..]`. If parsing is successful,
 /// offset is updated to reflect the characters consumed.
 fn parseEscapeSequence(slice: []const u8, offset: *usize) ParsedCharLiteral {
     assert(slice.len > offset.*);

--- a/src/arch/wasm/Mir.zig
+++ b/src/arch/wasm/Mir.zig
@@ -10,7 +10,7 @@ const Mir = @This();
 
 const std = @import("std");
 
-/// A struct of array that represents each individual wasm 
+/// A struct of array that represents each individual wasm
 instructions: std.MultiArrayList(Inst).Slice,
 /// A slice of indexes where the meaning of the data is determined by the
 /// `Inst.Tag` value.
@@ -530,7 +530,7 @@ pub const Inst = struct {
         /// Contains an u32 index into a wasm section entry, such as a local.
         /// Note: This is not an index to another instruction.
         ///
-        /// Used by e.g. `local_get`, `local_set`, etc. 
+        /// Used by e.g. `local_get`, `local_set`, etc.
         label: u32,
         /// A 32-bit immediate value.
         ///

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -368,7 +368,7 @@ pub const Inst = struct {
         arg_dbg_info,
 
         /// push registers from the callee_preserved_regs
-        /// data is the bitfield of which regs to push 
+        /// data is the bitfield of which regs to push
         /// for example on x86_64, the callee_preserved_regs are [_]Register{ .rcx, .rsi, .rdi, .r8, .r9, .r10, .r11 };    };
         /// so to push rcx and r8 one would make data 0b00000000_00000000_00000000_00001001 (the first and fourth bits are set)
         /// ops is unused

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -154,7 +154,7 @@ atom_by_index_table: std.AutoHashMapUnmanaged(u32, *TextBlock) = .{},
 /// const Foo = struct{
 ///     a: u8,
 /// };
-/// 
+///
 /// pub fn main() void {
 ///     var foo = Foo{ .a = 1 };
 ///     _ = foo;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -232,7 +232,7 @@ atom_by_index_table: std.AutoHashMapUnmanaged(u32, *Atom) = .{},
 /// const Foo = struct{
 ///     a: u8,
 /// };
-/// 
+///
 /// pub fn main() void {
 ///     var foo = Foo{ .a = 1 };
 ///     _ = foo;


### PR DESCRIPTION
Fixes #11353 

The renderer treats comments and doc comments differently since doc comments are parsed into the Ast. This commit adds a check after getting the text for the doc comment and trims whitespace at the end before rendering.