### PR TITLE
Fix C include files not being in `whole` cache

### DIFF
--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -665,7 +665,7 @@ pub const Manifest = struct {
         self.hash.hasher.update(&ch_file.bin_digest);
     }
 
-    pub fn addDepFilePost(self: *Manifest, dir: fs.Dir, dep_file_basename: []const u8) !void {
+    fn addDepFilePostCommon(self: *Manifest, dir: fs.Dir, dep_file_basename: []const u8, comptime is_post_contents: bool) !void {
         assert(self.manifest_file != null);
 
         const dep_file_contents = try dir.readFileAlloc(self.cache.gpa, dep_file_basename, manifest_file_size_max);
@@ -690,7 +690,28 @@ pub const Manifest = struct {
         while (true) {
             switch (it.next() orelse return) {
                 .target, .target_must_resolve => return,
-                .prereq => |bytes| try self.addFilePost(bytes),
+                .prereq => |file_path| if (is_post_contents) {
+                    const resolved_path = try fs.path.resolve(self.cache.gpa, &[_][]const u8{file_path});
+                    errdefer self.cache.gpa.free(resolved_path);
+
+                    const file = try fs.cwd().openFile(resolved_path, .{ .mode = .read_only });
+                    const file_stat = try file.stat();
+
+                    const contents = try self.cache.gpa.alloc(u8, @intCast(usize, file_stat.size));
+                    defer self.cache.gpa.free(contents);
+
+                    _ = try file.readAll(contents);
+
+                    try self.addFilePostContents(
+                        resolved_path,
+                        contents,
+                        .{
+                            .size = file_stat.size,
+                            .inode = file_stat.inode,
+                            .mtime = file_stat.mtime,
+                        },
+                    );
+                } else try self.addFilePost(file_path),
                 else => |err| {
                     try err.printError(error_buf.writer());
                     log.err("failed parsing {s}: {s}", .{ dep_file_basename, error_buf.items });
@@ -698,6 +719,14 @@ pub const Manifest = struct {
                 },
             }
         }
+    }
+
+    pub fn addDepFilePost(self: *Manifest, dir: fs.Dir, dep_file_basename: []const u8) !void {
+        try self.addDepFilePostCommon(dir, dep_file_basename, false);
+    }
+
+    pub fn addDepFilePostContents(self: *Manifest, dir: fs.Dir, dep_file_basename: []const u8) !void {
+        try self.addDepFilePostCommon(dir, dep_file_basename, true);
     }
 
     /// Returns a hex encoded hash of the inputs.

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -695,6 +695,7 @@ pub const Manifest = struct {
                     errdefer self.cache.gpa.free(resolved_path);
 
                     const file = try fs.cwd().openFile(resolved_path, .{ .mode = .read_only });
+                    defer file.close();
                     const file_stat = try file.stat();
 
                     const contents = try self.cache.gpa.alloc(u8, @intCast(usize, file_stat.size));

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1961,8 +1961,8 @@ pub fn update(comp: *Compilation) !void {
         // We are about to obtain this lock, so here we give other processes a chance first.
         comp.bin_file.releaseLock();
 
-        comp.whole_cache_manifest = &man;
         man = comp.cache_parent.obtain();
+        comp.whole_cache_manifest = &man;
         try comp.addNonIncrementalStuffToCacheManifest(&man);
 
         const is_hit = man.hit() catch |err| {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3673,6 +3673,9 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
             const dep_basename = std.fs.path.basename(dep_file_path);
             // Add the files depended on to the cache system.
             try man.addDepFilePost(zig_cache_tmp_dir, dep_basename);
+            if (comp.whole_cache_manifest) |whole_cache_manifest| {
+                try whole_cache_manifest.addDepFilePost(zig_cache_tmp_dir, dep_basename);
+            }
             // Just to save disk space, we delete the file because it is never needed again.
             zig_cache_tmp_dir.deleteFile(dep_basename) catch |err| {
                 log.warn("failed to delete '{s}': {s}", .{ dep_file_path, @errorName(err) });

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3679,7 +3679,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
             if (comp.whole_cache_manifest) |whole_cache_manifest| {
                 comp.whole_cache_manifest_mutex.lock();
                 defer comp.whole_cache_manifest_mutex.unlock();
-                try whole_cache_manifest.addDepFilePostContents(zig_cache_tmp_dir, dep_basename);
+                try whole_cache_manifest.addDepFilePost(zig_cache_tmp_dir, dep_basename);
             }
             // Just to save disk space, we delete the file because it is never needed again.
             zig_cache_tmp_dir.deleteFile(dep_basename) catch |err| {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3788,6 +3788,8 @@ pub fn semaFile(mod: *Module, file: *File) SemaError!void {
             });
             errdefer gpa.free(resolved_path);
 
+            mod.comp.whole_cache_manifest_mutex.lock();
+            defer mod.comp.whole_cache_manifest_mutex.unlock();
             try man.addFilePostContents(resolved_path, source.bytes, source.stat);
         }
     } else {
@@ -4263,6 +4265,8 @@ pub fn embedFile(mod: *Module, cur_file: *File, rel_file_path: []const u8) !*Emb
     if (mod.comp.whole_cache_manifest) |man| {
         const copied_resolved_path = try gpa.dupe(u8, resolved_path);
         errdefer gpa.free(copied_resolved_path);
+        mod.comp.whole_cache_manifest_mutex.lock();
+        defer mod.comp.whole_cache_manifest_mutex.unlock();
         try man.addFilePostContents(copied_resolved_path, bytes, stat);
     }
 

--- a/src/stage1.zig
+++ b/src/stage1.zig
@@ -455,10 +455,11 @@ export fn stage2_fetch_file(
     const comp = @intToPtr(*Compilation, stage1.userdata);
     const file_path = path_ptr[0..path_len];
     const max_file_size = std.math.maxInt(u32);
-    const contents = if (comp.whole_cache_manifest) |man|
-        man.addFilePostFetch(file_path, max_file_size) catch return null
-    else
-        std.fs.cwd().readFileAlloc(comp.gpa, file_path, max_file_size) catch return null;
+    const contents = if (comp.whole_cache_manifest) |man| blk: {
+        comp.whole_cache_manifest_mutex.lock();
+        defer comp.whole_cache_manifest_mutex.unlock();
+        break :blk man.addFilePostFetch(file_path, max_file_size) catch return null;
+    } else std.fs.cwd().readFileAlloc(comp.gpa, file_path, max_file_size) catch return null;
     result_len.* = contents.len;
     // TODO https://github.com/ziglang/zig/issues/3328#issuecomment-716749475
     if (contents.len == 0) return @intToPtr(?[*]const u8, 0x1);


### PR DESCRIPTION
Adapting the logic used for @import and @embedFile, we needed to ensure that the include files generated by the clang dependency file are added to the whole cache manifest in addition to the c-object specific ones.

Due to the fact that these are scheduled on worker threads - the whole cache needs to be locked with a mutex on access, a heavy handed solution but workable in the short term.

This resolves  #11063
