### PR TITLE
dwarf: emit debug info for local variables on x86_64

### DIFF
--- a/src/arch/arm/Emit.zig
+++ b/src/arch/arm/Emit.zig
@@ -411,7 +411,7 @@ fn genArgDbgInfo(self: *Emit, inst: Air.Inst.Index, arg_index: u32) !void {
                 .dwarf => |dw| {
                     const dbg_info = &dw.dbg_info;
                     try dbg_info.ensureUnusedCapacity(3);
-                    dbg_info.appendAssumeCapacity(link.File.Dwarf.abbrev_parameter);
+                    dbg_info.appendAssumeCapacity(@enumToInt(link.File.Dwarf.AbbrevKind.parameter));
                     dbg_info.appendSliceAssumeCapacity(&[2]u8{ // DW.AT.location, DW.FORM.exprloc
                         1, // ULEB128 dwarf expression length
                         reg.dwarfLocOp(),
@@ -443,7 +443,7 @@ fn genArgDbgInfo(self: *Emit, inst: Air.Inst.Index, arg_index: u32) !void {
                     };
 
                     const dbg_info = &dw.dbg_info;
-                    try dbg_info.append(link.File.Dwarf.abbrev_parameter);
+                    try dbg_info.append(@enumToInt(link.File.Dwarf.AbbrevKind.parameter));
 
                     // Get length of the LEB128 stack offset
                     var counting_writer = std.io.countingWriter(std.io.null_writer);

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1574,7 +1574,7 @@ fn genArgDbgInfo(self: *Self, inst: Air.Inst.Index, mcv: MCValue, arg_index: u32
                 .dwarf => |dw| {
                     const dbg_info = &dw.dbg_info;
                     try dbg_info.ensureUnusedCapacity(3);
-                    dbg_info.appendAssumeCapacity(link.File.Dwarf.abbrev_parameter);
+                    dbg_info.appendAssumeCapacity(@enumToInt(link.File.Dwarf.AbbrevKind.parameter));
                     dbg_info.appendSliceAssumeCapacity(&[2]u8{ // DW.AT.location, DW.FORM.exprloc
                         1, // ULEB128 dwarf expression length
                         reg.dwarfLocOp(),

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -16,7 +16,6 @@ const Air = @import("../../Air.zig");
 const CodeGen = @import("CodeGen.zig");
 const Register = bits.Register;
 
-function: *const CodeGen,
 instructions: std.MultiArrayList(Inst).Slice,
 /// The meaning of this data is determined by `Inst.Tag` value.
 extra: []const u32,
@@ -364,9 +363,6 @@ pub const Inst = struct {
         /// update debug line
         dbg_line,
 
-        /// arg debug info
-        arg_dbg_info,
-
         /// push registers from the callee_preserved_regs
         /// data is the bitfield of which regs to push 
         /// for example on x86_64, the callee_preserved_regs are [_]Register{ .rcx, .rsi, .rdi, .r8, .r9, .r10, .r11 };    };
@@ -453,18 +449,6 @@ pub const DbgLineColumn = struct {
     column: u32,
 };
 
-pub const ArgDbgInfo = struct {
-    air_inst: Air.Inst.Index,
-    arg_index: u32,
-    max_stack: u32,
-};
-
-pub fn deinit(mir: *Mir, gpa: std.mem.Allocator) void {
-    mir.instructions.deinit(gpa);
-    gpa.free(mir.extra);
-    mir.* = undefined;
-}
-
 pub const Ops = struct {
     reg1: Register = .none,
     reg2: Register = .none,
@@ -489,6 +473,12 @@ pub const Ops = struct {
         };
     }
 };
+
+pub fn deinit(mir: *Mir, gpa: std.mem.Allocator) void {
+    mir.instructions.deinit(gpa);
+    gpa.free(mir.extra);
+    mir.* = undefined;
+}
 
 pub fn extraData(mir: Mir, comptime T: type, index: usize) struct { data: T, end: usize } {
     const fields = std.meta.fields(T);

--- a/src/arch/x86_64/PrintMir.zig
+++ b/src/arch/x86_64/PrintMir.zig
@@ -147,7 +147,7 @@ pub fn printMir(print: *const Print, w: anytype, mir_to_air_map: std.AutoHashMap
 
             .call_extern => try print.mirCallExtern(inst, w),
 
-            .dbg_line, .dbg_prologue_end, .dbg_epilogue_begin, .arg_dbg_info => try w.print("{s}\n", .{@tagName(tag)}),
+            .dbg_line, .dbg_prologue_end, .dbg_epilogue_begin => try w.print("{s}\n", .{@tagName(tag)}),
 
             .push_regs_from_callee_preserved_regs => try print.mirPushPopRegsFromCalleePreservedRegs(.push, inst, w),
             .pop_regs_from_callee_preserved_regs => try print.mirPushPopRegsFromCalleePreservedRegs(.pop, inst, w),


### PR DESCRIPTION
Add support for emitting debug info for local variables within a subprogram.
This required moving bits responsible for populating the debug info back to
`CodeGen` from `Emit` as we require the operand to be resolved at callsite
plus we need to know its type. Without enforcing this, we could end up
with a `dead` mcv.

cc @joachimschmidt557 