### PR TITLE
stage2 llvm: properly align error union payload

### DIFF
--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -644,3 +644,21 @@ test "coerce error set to the current inferred error set" {
     };
     S.foo() catch {};
 }
+
+test "error union payload is properly aligned" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        a: u128,
+        b: u128,
+        c: u128,
+        fn foo() error{}!@This() {
+            return @This(){ .a = 1, .b = 2, .c = 3 };
+        }
+    };
+    const blk = S.foo() catch unreachable;
+    if (blk.a != 1) unreachable;
+}


### PR DESCRIPTION
I'm not sure if the order of the fields is important or not because this would likely be easier solved by swapping the order.

Closes #11340

`-Dskip-install-lib-files` is still required due to #11375.