### PR TITLE
stage2: wasm - Implement more builtins

### DIFF
--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1317,6 +1317,7 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .mul_with_overflow => self.airBinOpOverflow(inst, .mul),
 
         .clz => self.airClz(inst),
+        .ctz => self.airCtz(inst),
 
         .cmp_eq => self.airCmp(inst, .eq),
         .cmp_gte => self.airCmp(inst, .gte),
@@ -1440,7 +1441,6 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .shl_sat,
         .ret_addr,
         .frame_addr,
-        .ctz,
         .byte_swap,
         .bit_reverse,
         .is_err_ptr,
@@ -3970,6 +3970,47 @@ fn airClz(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
                 const val: i64 = -@intCast(i64, wasm_bits - int_info.bits);
                 return self.wrapBinOp(tmp, .{ .imm64 = @bitCast(u64, val) }, ty, .add);
             }
+        },
+        else => unreachable,
+    }
+
+    const result = try self.allocLocal(result_ty);
+    try self.addLabel(.local_set, result.local);
+    return result;
+}
+
+fn airCtz(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
+    if (self.liveness.isUnused(inst)) return WValue{ .none = {} };
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const ty = self.air.typeOf(ty_op.operand);
+    const result_ty = self.air.typeOfIndex(inst);
+
+    if (ty.zigTypeTag() == .Vector) {
+        return self.fail("TODO: `@ctz` for vectors", .{});
+    }
+
+    const operand = try self.resolveInst(ty_op.operand);
+    const int_info = ty.intInfo(self.target);
+    const wasm_bits = toWasmBits(int_info.bits) orelse {
+        return self.fail("TODO: `@clz` for integers with bitsize '{d}'", .{int_info.bits});
+    };
+
+    switch (wasm_bits) {
+        32 => {
+            if (wasm_bits != int_info.bits) {
+                const val: u32 = @as(u32, 1) << @intCast(u5, int_info.bits);
+                const bin_op = try self.binOp(operand, .{ .imm32 = val }, ty, .@"or");
+                try self.emitWValue(bin_op);
+            } else try self.emitWValue(operand);
+            try self.addTag(.i32_ctz);
+        },
+        64 => {
+            if (wasm_bits != int_info.bits) {
+                const val: u64 = @as(u64, 1) << @intCast(u6, int_info.bits);
+                const bin_op = try self.binOp(operand, .{ .imm64 = val }, ty, .@"or");
+                try self.emitWValue(bin_op);
+            } else try self.emitWValue(operand);
+            try self.addTag(.i64_ctz);
         },
         else => unreachable,
     }

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1316,6 +1316,8 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .shl_with_overflow => self.airBinOpOverflow(inst, .shl),
         .mul_with_overflow => self.airBinOpOverflow(inst, .mul),
 
+        .clz => self.airClz(inst),
+
         .cmp_eq => self.airCmp(inst, .eq),
         .cmp_gte => self.airCmp(inst, .gte),
         .cmp_gt => self.airCmp(inst, .gt),
@@ -1438,7 +1440,6 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .shl_sat,
         .ret_addr,
         .frame_addr,
-        .clz,
         .ctz,
         .byte_swap,
         .bit_reverse,
@@ -3931,4 +3932,49 @@ fn airMulAdd(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
 
     const mul_result = try self.binOp(lhs, rhs, ty, .mul);
     return self.binOp(mul_result, addend, ty, .add);
+}
+
+fn airClz(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
+    if (self.liveness.isUnused(inst)) return WValue{ .none = {} };
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const ty = self.air.typeOf(ty_op.operand);
+    const result_ty = self.air.typeOfIndex(inst);
+    if (ty.zigTypeTag() == .Vector) {
+        return self.fail("TODO: `@clz` for vectors", .{});
+    }
+
+    const operand = try self.resolveInst(ty_op.operand);
+    const int_info = ty.intInfo(self.target);
+    const wasm_bits = toWasmBits(int_info.bits) orelse {
+        return self.fail("TODO: `@clz` for integers with bitsize '{d}'", .{int_info.bits});
+    };
+
+    try self.emitWValue(operand);
+    switch (wasm_bits) {
+        32 => {
+            try self.addTag(.i32_clz);
+
+            if (wasm_bits != int_info.bits) {
+                const tmp = try self.allocLocal(ty);
+                try self.addLabel(.local_set, tmp.local);
+                const val: i32 = -@intCast(i32, wasm_bits - int_info.bits);
+                return self.wrapBinOp(tmp, .{ .imm32 = @bitCast(u32, val) }, ty, .add);
+            }
+        },
+        64 => {
+            try self.addTag(.i64_clz);
+
+            if (wasm_bits != int_info.bits) {
+                const tmp = try self.allocLocal(ty);
+                try self.addLabel(.local_set, tmp.local);
+                const val: i64 = -@intCast(i64, wasm_bits - int_info.bits);
+                return self.wrapBinOp(tmp, .{ .imm64 = @bitCast(u64, val) }, ty, .add);
+            }
+        },
+        else => unreachable,
+    }
+
+    const result = try self.allocLocal(result_ty);
+    try self.addLabel(.local_set, result.local);
+    return result;
 }

--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -217,6 +217,10 @@ pub fn emitMir(emit: *Emit) InnerError!void {
             .i64_rem_u => try emit.emitTag(tag),
             .i32_popcnt => try emit.emitTag(tag),
             .i64_popcnt => try emit.emitTag(tag),
+            .i32_clz => try emit.emitTag(tag),
+            .i32_ctz => try emit.emitTag(tag),
+            .i64_clz => try emit.emitTag(tag),
+            .i64_ctz => try emit.emitTag(tag),
 
             .extended => try emit.emitExtended(inst),
         }

--- a/src/arch/wasm/Mir.zig
+++ b/src/arch/wasm/Mir.zig
@@ -317,6 +317,10 @@ pub const Inst = struct {
         /// Uses `tag`
         f64_ge = 0x66,
         /// Uses `tag`
+        i32_clz = 0x67,
+        /// Uses `tag`
+        i32_ctz = 0x68,
+        /// Uses `tag`
         i32_popcnt = 0x69,
         /// Uses `tag`
         i32_add = 0x6A,
@@ -344,6 +348,10 @@ pub const Inst = struct {
         i32_shr_s = 0x75,
         /// Uses `tag`
         i32_shr_u = 0x76,
+        /// Uses `tag`
+        i64_clz = 0x79,
+        /// Uses `tag`
+        i64_ctz = 0x7A,
         /// Uses `tag`
         i64_popcnt = 0x7B,
         /// Uses `tag`

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -544,6 +544,7 @@ fn testTrunc() !void {
 }
 
 test "negation f16" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -60,7 +60,6 @@ fn assertFalse(b: bool) !void {
 }
 
 test "@clz" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -137,7 +136,6 @@ fn expectVectorsEqual(a: anytype, b: anytype) !void {
 }
 
 test "@ctz" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/maximum_minimum.zig
+++ b/test/behavior/maximum_minimum.zig
@@ -5,6 +5,24 @@ const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 
 test "@maximum" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        fn doTheTest() !void {
+            var x: i32 = 10;
+            var y: f32 = 0.68;
+            try expect(@as(i32, 10) == @maximum(@as(i32, -3), x));
+            try expect(@as(f32, 3.2) == @maximum(@as(f32, 3.2), y));
+        }
+    };
+    try S.doTheTest();
+    comptime try S.doTheTest();
+}
+
+test "@maximum on vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
@@ -13,9 +31,6 @@ test "@maximum" {
 
     const S = struct {
         fn doTheTest() !void {
-            try expect(@as(i32, 10) == @maximum(@as(i32, -3), @as(i32, 10)));
-            try expect(@as(f32, 3.2) == @maximum(@as(f32, 3.2), @as(f32, 0.68)));
-
             var a: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
             var b: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
             var x = @maximum(a, b);
@@ -37,6 +52,24 @@ test "@maximum" {
 }
 
 test "@minimum" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        fn doTheTest() !void {
+            var x: i32 = 10;
+            var y: f32 = 0.68;
+            try expect(@as(i32, -3) == @minimum(@as(i32, -3), x));
+            try expect(@as(f32, 0.68) == @minimum(@as(f32, 3.2), y));
+        }
+    };
+    try S.doTheTest();
+    comptime try S.doTheTest();
+}
+
+test "@minimum for vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -45,9 +78,6 @@ test "@minimum" {
 
     const S = struct {
         fn doTheTest() !void {
-            try expect(@as(i32, -3) == @minimum(@as(i32, -3), @as(i32, 10)));
-            try expect(@as(f32, 0.68) == @minimum(@as(f32, 3.2), @as(f32, 0.68)));
-
             var a: @Vector(4, i32) = [4]i32{ 2147483647, -2, 30, 40 };
             var b: @Vector(4, i32) = [4]i32{ 1, 2147483647, 3, 4 };
             var x = @minimum(a, b);

--- a/test/behavior/muladd.zig
+++ b/test/behavior/muladd.zig
@@ -3,7 +3,6 @@ const expect = @import("std").testing.expect;
 
 test "@mulAdd" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -13,12 +12,6 @@ test "@mulAdd" {
 }
 
 fn testMulAdd() !void {
-    {
-        var a: f16 = 5.5;
-        var b: f16 = 2.5;
-        var c: f16 = 6.25;
-        try expect(@mulAdd(f16, a, b, c) == 20);
-    }
     {
         var a: f32 = 5.5;
         var b: f32 = 2.5;
@@ -31,6 +24,23 @@ fn testMulAdd() !void {
         var c: f64 = 6.25;
         try expect(@mulAdd(f64, a, b, c) == 20);
     }
+}
+
+test "@mulAdd f16" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    comptime try testMulAdd16();
+    try testMulAdd16();
+}
+
+fn testMulAdd16() !void {
+    var a: f16 = 5.5;
+    var b: f16 = 2.5;
+    var c: f16 = 6.25;
+    try expect(@mulAdd(f16, a, b, c) == 20);
 }
 
 test "@mulAdd f80" {


### PR DESCRIPTION
Implements the following builtins for the wasm backend for types with bitsize <= 64.
- `@maximum` 
- `@minimum`
- `@mulAdd`
- `@clz`
- `@ctz`
