### PR TITLE
stage2: wasm - reduce instruction count for `@maximum` and `@minimum`

### DIFF
--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -96,6 +96,8 @@ pub fn emitMir(emit: *Emit) InnerError!void {
             .@"return" => try emit.emitTag(tag),
             .@"unreachable" => try emit.emitTag(tag),
 
+            .select => try emit.emitTag(tag),
+
             // arithmetic
             .i32_eqz => try emit.emitTag(tag),
             .i32_eq => try emit.emitTag(tag),

--- a/src/arch/wasm/Mir.zig
+++ b/src/arch/wasm/Mir.zig
@@ -77,6 +77,10 @@ pub const Inst = struct {
         ///
         /// Uses `label`
         call_indirect = 0x11,
+        /// Pops three values from the stack and pushes
+        /// the first or second value dependent on the third value.
+        /// Uses `tag`
+        select = 0x1B,
         /// Loads a local at given index onto the stack.
         ///
         /// Uses `label`


### PR DESCRIPTION
Rather than using blocks and control flow to check which operand is maximum or minimum, we use wasm's `select` instruction which returns us the operand based on the 3rd operand. (In this case, we can use the comparison between lhs and rhs to determine which operand to select). This saves us the need for control flow, as well as reduces the instruction count from 13 to 7 per `@maximum` or `@minimum` callsite.
