### PR TITLE
Add `std.fs.File.sync`

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -199,6 +199,14 @@ pub const File = struct {
             os.close(self.handle);
         }
     }
+    
+    pub const SyncError = os.SyncError;
+
+    /// Blocks until all pending file contents and metadata modifications
+    /// have been synchronized with the underlying filesystem.
+    pub fn sync(self: File) SyncError!void {
+        return os.fsync(self.handle);
+    }
 
     /// Test whether the file refers to a terminal.
     /// See also `supportsAnsiEscapeCodes`.


### PR DESCRIPTION
This is a simple wrapper around `std.os.fsync` for convenience. It seemed like this could be added.

I thought it was simple enough that no test for this was needed in https://github.com/ziglang/zig/blob/master/lib/std/fs/test.zig and there's already a test [here](https://github.com/ziglang/zig/blob/f654e16d06460a5f44fd8089538a41fc1936ea0b/lib/std/os/test.zig#L678) so I hope it's okay.