### PR TITLE
Enable passing 'Dir.rename directories' fs test on Windows

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -434,9 +434,6 @@ test "Dir.rename files" {
 }
 
 test "Dir.rename directories" {
-    // TODO: Fix on Windows, see https://github.com/ziglang/zig/issues/6364
-    if (builtin.os.tag == .windows) return error.SkipZigTest;
-
     var tmp_dir = tmpDir(.{});
     defer tmp_dir.cleanup();
 


### PR DESCRIPTION
Follow up to https://github.com/ziglang/zig/pull/11413#issuecomment-1096056393 and https://github.com/ziglang/zig/pull/11416 (tangentially)

Looks like d3f87f8ac01039722197a13a12342fc747a90567 fixed the standard cases of dir renaming, but the edge cases (renaming onto an existing empty/non-empty directory) are still behaving differently than on non-Windows.