### PR TITLE
std.math.float: fix f80-backed c_longdouble consts

### DIFF
--- a/lib/std/math/float.zig
+++ b/lib/std/math/float.zig
@@ -4,7 +4,7 @@ const expect = std.testing.expect;
 
 /// Creates a raw "1.0" mantissa for floating point type T. Used to dedupe f80 logic.
 fn mantissaOne(comptime T: type) comptime_int {
-    return if (T == f80) 1 << floatFractionalBits(T) else 0;
+    return if (@typeInfo(T).Float.bits == 80) 1 << floatFractionalBits(T) else 0;
 }
 
 /// Creates floating point type T from an unbiased exponent and raw mantissa.


### PR DESCRIPTION
319555a6690a43de143698f13d6d107a7873dce0 introduced this change:
```diff
-    return if (T == f80) 1 << floatFractionalBits(T) else 0;
+    return if (floatMantissaDigits(T) == 64) 1 << 63 else 0;
```
However, this prevents an `f80` backed `c_longdouble` from getting the explicit integer part since it's not `== f80`. There's not a lot of test coverage for `c_longdouble` at the moment but I noticed this at a second glance so I thought I'd make a quick PR.