### PR TITLE
Fix bug in PriorityQueue::removeIndex()

### DIFF
--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -100,7 +100,7 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
             const item = self.items[index];
             self.items[index] = last;
             self.len -= 1;
-            siftDown(self, 0);
+            siftDown(self, index);
             return item;
         }
 
@@ -460,22 +460,25 @@ test "std.PriorityQueue: remove at index" {
     var queue = PQlt.init(testing.allocator, {});
     defer queue.deinit();
 
-    try queue.add(3);
-    try queue.add(2);
-    try queue.add(1);
+    const items = [_]u32{ 2, 1, 8, 9, 3, 4, 5 };
+    for (items) |e| {
+        _ = try queue.add(e);
+    }
 
     var it = queue.iterator();
-    var elem = it.next();
     var idx: usize = 0;
-    const two_idx = while (elem != null) : (elem = it.next()) {
-        if (elem.? == 2)
+    const two_idx = while (it.next()) |elem| {
+        if (elem == 2)
             break idx;
         idx += 1;
     } else unreachable;
-
+    var sorted_items = [_]u32{ 1, 3, 4, 5, 8, 9 };
     try expectEqual(queue.removeIndex(two_idx), 2);
-    try expectEqual(queue.remove(), 1);
-    try expectEqual(queue.remove(), 3);
+
+    var i: usize = 0;
+    while (queue.removeOrNull()) |n| : (i += 1) {
+        try expectEqual(n, sorted_items[i]);
+    }
     try expectEqual(queue.removeOrNull(), null);
 }
 


### PR DESCRIPTION
Fix to call siftDown on the removed index instead of always on index 0.
Updated test to a test that fails before and passes now.

PriorityDequeue does not have this issue.