### PR TITLE
Add `std.unicode.replacement_character`

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -968,10 +968,10 @@ pub fn formatUnicodeCodepoint(
     writer: anytype,
 ) !void {
     var buf: [4]u8 = undefined;
-    const len = std.unicode.utf8Encode(c, &buf) catch |err| switch (err) {
+    const len = unicode.utf8Encode(c, &buf) catch |err| switch (err) {
         error.Utf8CannotEncodeSurrogateHalf, error.CodepointTooLarge => {
-            // In case of error output the replacement char U+FFFD
-            return formatBuf(&[_]u8{ 0xef, 0xbf, 0xbd }, options, writer);
+            const len = unicode.utf8Encode(unicode.replacement_character, &buf) catch unreachable;
+            return formatBuf(buf[0..len], options, writer);
         },
     };
     return formatBuf(buf[0..len], options, writer);

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -3,6 +3,11 @@ const assert = std.debug.assert;
 const testing = std.testing;
 const mem = std.mem;
 
+/// Use this to replace an unknown, unrecognized, or unrepresentable character.
+///
+/// See also: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+pub const replacement_character: u21 = 0xFFFD;
+
 /// Returns how many bytes the UTF-8 representation would require
 /// for the given codepoint.
 pub fn utf8CodepointSequenceLength(c: u21) !u3 {
@@ -777,15 +782,14 @@ fn formatUtf16le(
     options: std.fmt.FormatOptions,
     writer: anytype,
 ) !void {
-    const unknown_codepoint = 0xfffd;
     _ = fmt;
     _ = options;
     var buf: [300]u8 = undefined; // just a random size I chose
     var it = Utf16LeIterator.init(utf16le);
     var u8len: usize = 0;
-    while (it.nextCodepoint() catch unknown_codepoint) |codepoint| {
+    while (it.nextCodepoint() catch replacement_character) |codepoint| {
         u8len += utf8Encode(codepoint, buf[u8len..]) catch
-            utf8Encode(unknown_codepoint, buf[u8len..]) catch unreachable;
+            utf8Encode(replacement_character, buf[u8len..]) catch unreachable;
         if (u8len + 3 >= buf.len) {
             try writer.writeAll(buf[0..u8len]);
             u8len = 0;


### PR DESCRIPTION
This is a possible improvement I found while working on an `std.unicode.Char` and `std.unicode.Codepoint` (https://github.com/r00ster91/zig/commit/02da6dc26e011bcebc25b899f275e5d2c6c8ca44) which, after some discussion, seemed better not to pull. Instead, it's only this.

There are already 2 places within `std` where code related to this is kind of duplicated and I thought this constant could be useful to general applications as well.
For reference here is what this looks like in other languages:
* https://doc.rust-lang.org/std/primitive.char.html#associatedconstant.REPLACEMENT_CHARACTER
* https://crystal-lang.org/api/Char.html#REPLACEMENT

The problem this solves is that you don't have to memorize or look up this constant yourself. I would understand if that alone doesn't justify adding this to `std`.