### PR TITLE
stage2: fix (recursively) marking decls as alive, and improve DWARF for local vars

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -203,7 +203,6 @@ pub fn generateSymbol(
         },
         .Array => switch (typed_value.val.tag()) {
             .bytes => {
-                // TODO populate .debug_info for the array
                 const payload = typed_value.val.castTag(.bytes).?;
                 const len = @intCast(usize, typed_value.ty.arrayLenIncludingSentinel());
                 // The bytes payload already includes the sentinel, if any
@@ -212,7 +211,6 @@ pub fn generateSymbol(
                 return Result{ .appended = {} };
             },
             .aggregate => {
-                // TODO populate .debug_info for the array
                 const elem_vals = typed_value.val.castTag(.aggregate).?.data;
                 const elem_ty = typed_value.ty.elemType();
                 const len = @intCast(usize, typed_value.ty.arrayLenIncludingSentinel());


### PR DESCRIPTION
* x64: recursively mark decls as alive when lowering
* x64: generate debug info for local vars at hardcoded memory address (non-PIE)
* dwarf: generate debug info for arrays
* x64: deref memory address if referenced via GOT when computing the exprloc for a local variable stored in memory
* x64+macho: resolve debug info relocs for RIP-based addressing after symbols were allocated VM addresses - sometimes we will want to generate debug info for a constant that has been lowered to memory and not copied anywhere else. For this we will need to defer resolution on PIE platforms until all locals (including GOT entries) have been allocated.

cc @joachimschmidt557 @Luukdegram @andrewrk this fixes the compiler panic we discussed during the Zig Meetup in Milan.