### PR TITLE
stage2: wasm-linker - Fix segment alignment/size

### DIFF
--- a/src/link/Wasm/Atom.zig
+++ b/src/link/Wasm/Atom.zig
@@ -158,7 +158,7 @@ fn relocationValue(self: Atom, relocation: types.Relocation, wasm_bin: *const Wa
         .R_WASM_TABLE_INDEX_I64,
         .R_WASM_TABLE_INDEX_SLEB,
         .R_WASM_TABLE_INDEX_SLEB64,
-        => return wasm_bin.function_table.get(relocation.index) orelse 0,
+        => return wasm_bin.function_table.get(target_loc) orelse 0,
         .R_WASM_TYPE_INDEX_LEB => return wasm_bin.functions.items[symbol.index].type_index,
         .R_WASM_GLOBAL_INDEX_I32,
         .R_WASM_GLOBAL_INDEX_LEB,

--- a/src/link/Wasm/Object.zig
+++ b/src/link/Wasm/Object.zig
@@ -851,15 +851,12 @@ pub fn parseIntoAtoms(self: *Object, gpa: Allocator, object_index: u16, wasm_bin
                 reloc.offset -= relocatable_data.offset;
                 try atom.relocs.append(gpa, reloc);
 
-                // TODO: Automatically append the target symbol to the indirect
-                // function table when the relocation is a table index.
-                //
-                // if (relocation.isTableIndex()) {
-                //     try wasm_bin.elements.appendSymbol(gpa, .{
-                //         .file = object_index,
-                //         .sym_index = relocation.index,
-                //     });
-                // }
+                if (relocation.isTableIndex()) {
+                    try wasm_bin.function_table.putNoClobber(gpa, .{
+                        .file = object_index,
+                        .index = relocation.index,
+                    }, 0);
+                }
             }
         }
 

--- a/src/link/Wasm/Object.zig
+++ b/src/link/Wasm/Object.zig
@@ -133,6 +133,9 @@ pub fn deinit(self: *Object, gpa: Allocator) void {
     gpa.free(self.memories);
     gpa.free(self.globals);
     gpa.free(self.exports);
+    for (self.elements) |el| {
+        gpa.free(el.func_indexes);
+    }
     gpa.free(self.elements);
     gpa.free(self.features);
     for (self.relocations.values()) |val| {

--- a/src/link/Wasm/Object.zig
+++ b/src/link/Wasm/Object.zig
@@ -865,11 +865,6 @@ pub fn parseIntoAtoms(self: *Object, gpa: Allocator, object_index: u16, wasm_bin
 
         const segment: *Wasm.Segment = &wasm_bin.segments.items[final_index];
         segment.alignment = std.math.max(segment.alignment, atom.alignment);
-        segment.size = std.mem.alignForwardGeneric(
-            u32,
-            std.mem.alignForwardGeneric(u32, segment.size, atom.alignment) + atom.size,
-            segment.alignment,
-        );
 
         if (wasm_bin.atoms.getPtr(final_index)) |last| {
             last.*.next = atom;

--- a/src/link/Wasm/types.zig
+++ b/src/link/Wasm/types.zig
@@ -67,6 +67,18 @@ pub const Relocation = struct {
         };
     }
 
+    /// Returns true when the relocation represents a table index relocatable
+    pub fn isTableIndex(self: Relocation) bool {
+        return switch (self.relocation_type) {
+            .R_WASM_TABLE_INDEX_I32,
+            .R_WASM_TABLE_INDEX_I64,
+            .R_WASM_TABLE_INDEX_SLEB,
+            .R_WASM_TABLE_INDEX_SLEB64,
+            => true,
+            else => false,
+        };
+    }
+
     pub fn format(self: Relocation, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
         _ = fmt;
         _ = options;


### PR DESCRIPTION
Previously, the data segments were being aligned twice. This caused us to over-align the segment and therefore allocate a much larger size for each segment than was required. This fix ensures we align and set the size just once, ensuring semantically correct binaries as well as smaller binaries.