### PR TITLE
compiler_rt: atomics: Add TAS lock support for SPARC

### DIFF
--- a/lib/std/special/compiler_rt/atomics.zig
+++ b/lib/std/special/compiler_rt/atomics.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
+const cpu = builtin.cpu;
+const arch = cpu.arch;
 
 const linkage: std.builtin.GlobalLinkage = if (builtin.is_test) .Internal else .Weak;
 
@@ -27,9 +28,7 @@ const largest_atomic_size = switch (arch) {
     // On SPARC systems that lacks CAS and/or swap instructions, the only
     // available atomic operation is a test-and-set (`ldstub`), so we force
     // every atomic memory access to go through the lock.
-    // XXX: Check the presence of CAS/swap instructions and set this parameter
-    // accordingly.
-    .sparc, .sparcel, .sparcv9 => 0,
+    .sparc, .sparcel => if (cpu.features.featureSetHas(.hasleoncasa)) @sizeOf(usize) else 0,
 
     // XXX: On x86/x86_64 we could check the presence of cmpxchg8b/cmpxchg16b
     // and set this parameter accordingly.

--- a/lib/std/special/compiler_rt/atomics.zig
+++ b/lib/std/special/compiler_rt/atomics.zig
@@ -72,7 +72,7 @@ const SpinlockTable = struct {
         }
         fn release(self: *@This()) void {
             if (comptime arch.isSPARC()) {
-                _ = asm volatile ("clr [%[addr]]"
+                _ = asm volatile ("clrb [%[addr]]"
                     :
                     : [addr] "r" (&self.v),
                     : "memory"


### PR DESCRIPTION
Some SPARC CPUs (particularly old and/or embedded ones) only has atomic TAS instruction available (`ldstub`). This adds support for emitting that instruction in the spinlock.