### PR TITLE
stage2 ARM: move genArgDbgInfo back to CodeGen

### DIFF
--- a/src/arch/arm/Mir.zig
+++ b/src/arch/arm/Mir.zig
@@ -12,7 +12,6 @@ const builtin = @import("builtin");
 const assert = std.debug.assert;
 
 const bits = @import("bits.zig");
-const Air = @import("../../Air.zig");
 const Register = bits.Register;
 
 instructions: std.MultiArrayList(Inst).Slice,
@@ -44,8 +43,6 @@ pub const Inst = struct {
         bx,
         /// Compare
         cmp,
-        /// Pseudo-instruction: Argument
-        dbg_arg,
         /// Pseudo-instruction: End of prologue
         dbg_prologue_end,
         /// Pseudo-instruction: Beginning of epilogue
@@ -238,13 +235,6 @@ pub const Inst = struct {
         dbg_line_column: struct {
             line: u32,
             column: u32,
-        },
-        /// Debug info: argument
-        ///
-        /// Used by e.g. dbg_arg
-        dbg_arg_info: struct {
-            air_inst: Air.Inst.Index,
-            arg_index: u32,
         },
     };
 


### PR DESCRIPTION
This removes the questionable Air -> Mir dependency that existed
before. The x86_64 backend also performed this change.

cc @kubkon 