### PR TITLE
re-enable f80 tests on freebsd

### DIFF
--- a/lib/std/math/fabs.zig
+++ b/lib/std/math/fabs.zig
@@ -21,8 +21,8 @@ pub fn fabs(x: anytype) @TypeOf(x) {
 }
 
 test "math.fabs" {
-    // TODO add support for f80 & c_longdouble here
-    inline for ([_]type{ f16, f32, f64, f128 }) |T| {
+    // TODO add support for c_longdouble here
+    inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         // normals
         try expect(fabs(@as(T, 1.0)) == 1.0);
         try expect(fabs(@as(T, -1.0)) == 1.0);

--- a/lib/std/math/isfinite.zig
+++ b/lib/std/math/isfinite.zig
@@ -14,9 +14,6 @@ pub fn isFinite(x: anytype) bool {
 }
 
 test "math.isFinite" {
-    // TODO remove when #11391 is resolved
-    if (@import("builtin").os.tag == .freebsd) return error.SkipZigTest;
-
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         // normals
         try expect(isFinite(@as(T, 1.0)));

--- a/lib/std/math/isinf.zig
+++ b/lib/std/math/isinf.zig
@@ -24,9 +24,6 @@ pub fn isNegativeInf(x: anytype) bool {
 }
 
 test "math.isInf" {
-    // TODO remove when #11391 is resolved
-    if (@import("builtin").os.tag == .freebsd) return error.SkipZigTest;
-
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         try expect(!isInf(@as(T, 0.0)));
         try expect(!isInf(@as(T, -0.0)));
@@ -38,9 +35,6 @@ test "math.isInf" {
 }
 
 test "math.isPositiveInf" {
-    // TODO remove when #11391 is resolved
-    if (@import("builtin").os.tag == .freebsd) return error.SkipZigTest;
-
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         try expect(!isPositiveInf(@as(T, 0.0)));
         try expect(!isPositiveInf(@as(T, -0.0)));
@@ -52,9 +46,6 @@ test "math.isPositiveInf" {
 }
 
 test "math.isNegativeInf" {
-    // TODO remove when #11391 is resolved
-    if (@import("builtin").os.tag == .freebsd) return error.SkipZigTest;
-
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         try expect(!isNegativeInf(@as(T, 0.0)));
         try expect(!isNegativeInf(@as(T, -0.0)));

--- a/lib/std/math/isnormal.zig
+++ b/lib/std/math/isnormal.zig
@@ -23,9 +23,6 @@ pub fn isNormal(x: anytype) bool {
 }
 
 test "math.isNormal" {
-    // TODO remove when #11391 is resolved
-    if (@import("builtin").os.tag == .freebsd) return error.SkipZigTest;
-
     // TODO add `c_longdouble' when math.inf(T) supports it
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         const TBits = std.meta.Int(.unsigned, @bitSizeOf(T));


### PR DESCRIPTION
- Enables tests skipped due to #11391 being open, which was fixed by 319b5cbce5d4c43de8a6848ac5f5c8879ab9806e.
- Enables f80 testing on `fabs` which I did not add in cb019b80ac8ae8ffd7f7dd619c4da29a83668cde because that same issue was open.