### PR TITLE
stage2: fix behavior test failures on aarch64-macos (LLVM+native), and other minor fixes

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -30,8 +30,8 @@ comptime {
         builtin.zig_backend == .stage2_arm or
         builtin.zig_backend == .stage2_riscv64 or
         builtin.zig_backend == .stage2_sparcv9 or
-        (builtin.zig_backend == .stage2_llvm and native_os != .linux) or
-        (builtin.zig_backend == .stage2_llvm and native_arch != .x86_64))
+        (builtin.zig_backend == .stage2_llvm and native_os != .linux and native_os != .macos) or
+        (builtin.zig_backend == .stage2_llvm and native_arch != .x86_64 and native_arch != .aarch64))
     {
         if (builtin.output_mode == .Exe) {
             if ((builtin.link_libc or builtin.object_format == .c) and @hasDecl(root, "main")) {

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1718,8 +1718,17 @@ pub const Target = struct {
         }
         return switch (F) {
             f128 => switch (target.cpu.arch) {
+                .aarch64 => {
+                    // According to Apple's official guide:
+                    // > The long double type is a double precision IEEE754 binary floating-point type,
+                    // > which makes it identical to the double type. This behavior contrasts to the
+                    // > standard specification, in which a long double is a quad-precision, IEEE754
+                    // > binary, floating-point type.
+                    // https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
+                    return !target.isDarwin();
+                },
+
                 .riscv64,
-                .aarch64,
                 .aarch64_be,
                 .aarch64_32,
                 .s390x,

--- a/src/link.zig
+++ b/src/link.zig
@@ -352,11 +352,6 @@ pub const File = struct {
         }
         switch (base.tag) {
             .macho => if (base.file) |f| {
-                if (base.intermediary_basename != null) {
-                    // The file we have open is not the final file that we want to
-                    // make executable, so we don't have to close it.
-                    return;
-                }
                 if (comptime builtin.target.isDarwin() and builtin.target.cpu.arch == .aarch64) {
                     if (base.options.target.cpu.arch == .aarch64) {
                         // XNU starting with Big Sur running on arm64 is caching inodes of running binaries.
@@ -371,8 +366,10 @@ pub const File = struct {
                         try emit.directory.handle.copyFile(emit.sub_path, emit.directory.handle, emit.sub_path, .{});
                     }
                 }
-                f.close();
-                base.file = null;
+                if (base.intermediary_basename == null) {
+                    f.close();
+                    base.file = null;
+                }
             },
             .coff, .elf, .plan9 => if (base.file) |f| {
                 if (base.intermediary_basename != null) {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -423,7 +423,7 @@ pub fn flush(self: *MachO, comp: *Compilation) !void {
     if (self.base.options.emit == null) {
         if (build_options.have_llvm) {
             if (self.llvm_object) |llvm_object| {
-                return try llvm_object.flushModule(comp);
+                try llvm_object.flushModule(comp);
             }
         }
         return;
@@ -1116,7 +1116,8 @@ pub fn flushObject(self: *MachO, comp: *Compilation) !void {
     defer tracy.end();
 
     if (build_options.have_llvm)
-        if (self.llvm_object) |llvm_object| return llvm_object.flushModule(comp);
+        if (self.llvm_object) |llvm_object|
+            return llvm_object.flushModule(comp);
 
     return error.TODOImplementWritingObjFiles;
 }

--- a/src/stage1/target.cpp
+++ b/src/stage1/target.cpp
@@ -1008,8 +1008,16 @@ bool target_long_double_is_f128(const ZigTarget *target) {
         return false;
     }
     switch (target->arch) {
-        case ZigLLVM_riscv64:
         case ZigLLVM_aarch64:
+            // According to Apple's official guide:
+            // > The long double type is a double precision IEEE754 binary floating-point type,
+            // > which makes it identical to the double type. This behavior contrasts to the
+            // > standard specification, in which a long double is a quad-precision, IEEE754
+            // > binary, floating-point type.
+            // https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
+            return !target_os_is_darwin(target->os);
+
+        case ZigLLVM_riscv64:
         case ZigLLVM_aarch64_be:
         case ZigLLVM_aarch64_32:
         case ZigLLVM_systemz:

--- a/src/type.zig
+++ b/src/type.zig
@@ -6155,7 +6155,6 @@ pub const CType = enum {
             },
 
             .linux,
-            .macos,
             .freebsd,
             .netbsd,
             .dragonfly,
@@ -6198,7 +6197,7 @@ pub const CType = enum {
                 .longlong, .ulonglong, .longdouble => return 64,
             },
 
-            .ios, .tvos, .watchos => switch (self) {
+            .macos, .ios, .tvos, .watchos => switch (self) {
                 .short, .ushort => return 16,
                 .int, .uint => return 32,
                 .long, .ulong, .longlong, .ulonglong => return 64,

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -79,19 +79,16 @@ test "comptime_int @intToFloat" {
         try expect(result == 1234.0);
     }
 
-    if (!((builtin.zig_backend == .stage2_aarch64 or builtin.zig_backend == .stage2_x86_64) and builtin.os.tag == .macos)) {
-        // TODO investigate why this traps on x86_64-macos and aarch64-macos
-        {
-            const result = @intToFloat(f128, 1234);
-            try expect(@TypeOf(result) == f128);
-            try expect(result == 1234.0);
-        }
-        // big comptime_int (> 64 bits) to f128 conversion
-        {
-            const result = @intToFloat(f128, 0x1_0000_0000_0000_0000);
-            try expect(@TypeOf(result) == f128);
-            try expect(result == 0x1_0000_0000_0000_0000.0);
-        }
+    {
+        const result = @intToFloat(f128, 1234);
+        try expect(@TypeOf(result) == f128);
+        try expect(result == 1234.0);
+    }
+    // big comptime_int (> 64 bits) to f128 conversion
+    {
+        const result = @intToFloat(f128, 0x1_0000_0000_0000_0000);
+        try expect(@TypeOf(result) == f128);
+        try expect(result == 0x1_0000_0000_0000_0000.0);
     }
 }
 


### PR DESCRIPTION
Turns out, `c_longdouble` is not `f128` but rather `f64` on aarch64 Darwin:

> The long double type is a double precision IEEE754 binary floating-point type, which makes it identical to the double type. This behavior contrasts to the standard specification, in which a long double is a quad-precision, IEEE754 binary, floating-point type.

[Writing ARM64 Code for Apple Platforms](https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms)

I am leaving this PR as draft until @andrewrk and myself work out how to handle premature exit from `link.makeExecutable` function for stage2. This premature exit means we don't move the final executable in place leading to a sigkill from the kernel as we have overwritten the contents of a file/inode that was already run and cached by the kernel. In layman's terms, running `zig test` multiple times leads to a sigkill on second run.

I also need to verify that the now uncommented behavior tests pass on x86_64 Darwin too.