### PR TITLE
std.os.uefi: fix GUID formatting

### DIFF
--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -139,3 +139,14 @@ pub const TimeCapabilities = extern struct {
 
 /// File Handle as specified in the EFI Shell Spec
 pub const FileHandle = *opaque {};
+
+test "GUID formatting" {
+    var bytes = [_]u8{ 137, 60, 203, 50, 128, 128, 124, 66, 186, 19, 80, 73, 135, 59, 194, 135 };
+
+    var guid = @bitCast(Guid, bytes);
+
+    var str = try std.fmt.allocPrint(std.testing.allocator, "{}", .{guid});
+    defer std.testing.allocator.free(str);
+
+    try std.testing.expect(std.mem.eql(u8, str, "32cb3c89-8080-427c-ba13-5049873bc287"));
+}

--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -53,13 +53,19 @@ pub const Guid = extern struct {
     ) !void {
         _ = options;
         if (f.len == 0) {
-            return std.fmt.format(writer, "{x:0>8}-{x:0>4}-{x:0>4}-{x:0>2}{x:0>2}-{x:0>12}", .{
-                self.time_low,
-                self.time_mid,
-                self.time_high_and_version,
-                self.clock_seq_high_and_reserved,
-                self.clock_seq_low,
-                self.node,
+            const fmt = std.fmt.fmtSliceHexLower;
+
+            const time_low = @byteSwap(u32, self.time_low);
+            const time_mid = @byteSwap(u16, self.time_mid);
+            const time_high_and_version = @byteSwap(u16, self.time_high_and_version);
+
+            return std.fmt.format(writer, "{:0>8}-{:0>4}-{:0>4}-{:0>2}{:0>2}-{:0>12}", .{
+                fmt(std.mem.asBytes(&time_low)),
+                fmt(std.mem.asBytes(&time_mid)),
+                fmt(std.mem.asBytes(&time_high_and_version)),
+                fmt(std.mem.asBytes(&self.clock_seq_high_and_reserved)),
+                fmt(std.mem.asBytes(&self.clock_seq_low)),
+                fmt(std.mem.asBytes(&self.node)),
             });
         } else {
             @compileError("Unknown format character: '" ++ f ++ "'");


### PR DESCRIPTION
the `@byteSwap` looks sus but it's actually how GUIDs are formatted
![text representation for GUIDs, shows the first few fields byteswapped](https://user-images.githubusercontent.com/10470872/163689579-886666e3-5520-400b-9a01-f7952d97528f.png)
Also swaps to using fmtSliceHexLower over the deprecated {x}