### PR TITLE
stage2: Do not strip by default for wasm

### DIFF
--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -871,7 +871,8 @@ fn genFunc(self: *Self) InnerError!void {
     // we emit an unreachable instruction to tell the stack validator that part will never be reached.
     if (func_type.returns.len != 0 and self.air.instructions.len > 0) {
         const inst = @intCast(u32, self.air.instructions.len - 1);
-        if (self.air.typeOfIndex(inst).isNoReturn()) {
+        const last_inst_ty = self.air.typeOfIndex(inst);
+        if (last_inst_ty.zigTypeTag() == .Void or last_inst_ty.isNoReturn()) {
             try self.addTag(.@"unreachable");
         }
     }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -291,7 +291,7 @@ pub const Object = struct {
                 0, // runtime version
                 "", // split name
                 0, // dwo id
-                true, // emit debug info
+                target_util.hasDebugInfo(options.target), // emit debug info
             );
         }
 

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -1897,7 +1897,7 @@ pub fn flushModule(self: *Wasm, comp: *Compilation, prog_node: *std.Progress.Nod
         if (data_section_index) |data_index| {
             try self.emitDataRelocations(file, arena, data_index, symbol_table);
         }
-    } else {
+    } else if (!self.base.options.strip) {
         try self.emitNameSection(file, arena);
     }
 }


### PR DESCRIPTION
For wasm, we do not wish to strip by default, as it also strips away useful sections such as the 'name' section. This section provides functions with names, which can be used during debugging. Other tools also use this information to generate code (such as WAT).
DWARF info is out-of-scope for this PR, so we do strip debug info by default for wasm still.

Fixes #11420 