### PR TITLE
Wasm: add support for debug information

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -114,6 +114,10 @@ pub fn detectTTYConfig() TTY.Config {
 pub fn dumpCurrentStackTrace(start_addr: ?usize) void {
     nosuspend {
         const stderr = io.getStdErr().writer();
+        if (comptime builtin.target.isWasm()) {
+            stderr.print("Unable to dump stack trace: not implemented for Wasm\n", .{}) catch return;
+            return;
+        }
         if (builtin.strip_debug_info) {
             stderr.print("Unable to dump stack trace: debug info stripped\n", .{}) catch return;
             return;

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -871,7 +871,8 @@ fn genFunc(self: *Self) InnerError!void {
     // we emit an unreachable instruction to tell the stack validator that part will never be reached.
     if (func_type.returns.len != 0 and self.air.instructions.len > 0) {
         const inst = @intCast(u32, self.air.instructions.len - 1);
-        if (self.air.typeOfIndex(inst).isNoReturn()) {
+        const last_inst_ty = self.air.typeOfIndex(inst);
+        if (!last_inst_ty.hasRuntimeBitsIgnoreComptime() or last_inst_ty.isNoReturn()) {
             try self.addTag(.@"unreachable");
         }
     }

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -1897,7 +1897,7 @@ pub fn flushModule(self: *Wasm, comp: *Compilation, prog_node: *std.Progress.Nod
         if (data_section_index) |data_index| {
             try self.emitDataRelocations(file, arena, data_index, symbol_table);
         }
-    } else {
+    } else if (!self.base.options.strip) {
         try self.emitNameSection(file, arena);
     }
 }

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -2645,6 +2645,9 @@ static LLVMValueRef ir_render_save_err_ret_addr(CodeGen *g, Stage1Air *executabl
         Stage1AirInstSaveErrRetAddr *save_err_ret_addr_instruction)
 {
     assert(g->have_err_ret_tracing);
+    if ((target_is_wasm(g->zig_target) && g->zig_target->os != OsEmscripten) || target_is_bpf(g->zig_target)) {
+        return nullptr;
+    }
 
     LLVMValueRef return_err_fn = get_return_err_fn(g);
     bool is_llvm_alloca;

--- a/src/stage1/target.cpp
+++ b/src/stage1/target.cpp
@@ -1000,7 +1000,7 @@ ZigLLVM_EnvironmentType target_default_abi(ZigLLVM_ArchType arch, Os os) {
 }
 
 bool target_has_debug_info(const ZigTarget *target) {
-    return !target_is_wasm(target);
+    return true;
 }
 
 bool target_long_double_is_f128(const ZigTarget *target) {

--- a/src/target.zig
+++ b/src/target.zig
@@ -455,7 +455,8 @@ pub fn classifyCompilerRtLibName(target: std.Target, name: []const u8) CompilerR
 }
 
 pub fn hasDebugInfo(target: std.Target) bool {
-    return !target.cpu.arch.isWasm();
+    _ = target;
+    return true;
 }
 
 pub fn defaultCompilerRtOptimizeMode(target: std.Target) std.builtin.Mode {


### PR DESCRIPTION
This adds support for DWARF information for the wasm target. This does, however, not add support for stack traces yet. This implements support for both stage1 and stage2 (LLVM-backend).

Closes #11330 
Fixes #11420 

Here's an example of what it would look like in Chrome:
![image](https://user-images.githubusercontent.com/4252848/163801403-583a7d3d-ba17-49a7-ad3a-a50186792512.png)

I tried to find some information regarding targets that do not support any form of debug information, but couldn't find anything about that. So for now, I changed `hasDebugInfo` to always return true.
