### PR TITLE
Make anonymous struct docs consistent with example

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3453,7 +3453,7 @@ test "aligned struct fields" {
           that variable.</li>
           <li>If the struct is in the {#syntax#}return{#endsyntax#} expression, it gets named after
           the function it is returning from, with the parameter values serialized.</li>
-          <li>Otherwise, the struct gets a name such as <code>(anonymous struct at file.zig:7:38)</code>.</li>
+          <li>Otherwise, the struct gets a name such as <code>struct:6:53</code>.</li>
           <li>If the struct is declared inside another struct, it gets named after both the parent
           struct and the name inferred by the previous rules, separated by a dot.</li>
       </ul>


### PR DESCRIPTION
A minor change in the documentation of:
- https://ziglang.org/documentation/master/#Struct-Naming

to make the text consistent with the actual result of its example:
```
$ ./struct_name
variable: Foo
anonymous: struct:6:53
function: List(i32)
```

It's my first contribution to this project (hello everyone!) I hope I made the change in the right place.
