### PR TITLE
stage2: Move `selfExePathWasi` to `introspect.zig`

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2547,15 +2547,6 @@ pub const SelfExePathError = os.ReadLinkError || os.SysCtlError || os.RealPathEr
 /// `selfExePath` except allocates the result on the heap.
 /// Caller owns returned memory.
 pub fn selfExePathAlloc(allocator: Allocator) ![]u8 {
-    if (builtin.os.tag == .wasi) {
-        var args = try std.process.argsWithAllocator(allocator);
-        defer args.deinit();
-        // On WASI, argv[0] is always just the basename of the current executable
-        const exe_name = args.next() orelse return error.FileNotFound;
-
-        var buf: [MAX_PATH_BYTES]u8 = undefined;
-        return allocator.dupe(u8, try selfExePathWasi(&buf, exe_name));
-    }
     // Use of MAX_PATH_BYTES here is justified as, at least on one tested Linux
     // system, readlink will completely fail to return a result larger than
     // PATH_MAX even if given a sufficiently large buffer. This makes it
@@ -2655,43 +2646,6 @@ pub fn selfExePath(out_buffer: []u8) SelfExePathError![]u8 {
         .wasi => @compileError("std.fs.selfExePath not supported for WASI. Use std.fs.selfExePathAlloc instead."),
         else => @compileError("std.fs.selfExePath not supported for this target"),
     }
-}
-
-/// WASI-specific implementation of selfExePath
-///
-/// On WASI argv0 is always just the executable basename, so this function relies
-/// using a fixed executable directory path: "/zig"
-///
-/// This path can be configured in wasmtime using `--mapdir=/zig::/path/to/zig/dir/`
-fn selfExePathWasi(out_buffer: []u8, argv0: []const u8) SelfExePathError![]const u8 {
-    var allocator = std.heap.FixedBufferAllocator.init(out_buffer);
-    var alloc = allocator.allocator();
-
-    // Check these paths:
-    //  1. "/zig/{exe_name}"
-    //  2. "/zig/bin/{exe_name}"
-    const base_paths_to_check = &[_][]const u8{ "/zig", "/zig/bin" };
-    const exe_names_to_check = &[_][]const u8{ path.basename(argv0), "zig.wasm" };
-
-    for (base_paths_to_check) |base_path| {
-        for (exe_names_to_check) |exe_name| {
-            const test_path = path.join(alloc, &.{ base_path, exe_name }) catch continue;
-
-            // Make sure it's a file we're pointing to
-            const file = os.fstatat(os.wasi.AT.FDCWD, test_path, 0) catch continue;
-            if (file.filetype != .REGULAR_FILE) continue;
-
-            // Path seems to be valid, let's try to turn it into an absolute path
-            var real_path_buf: [MAX_PATH_BYTES]u8 = undefined;
-            if (os.realpath(test_path, &real_path_buf)) |real_path| {
-                if (real_path.len > out_buffer.len)
-                    return error.NameTooLong;
-                mem.copy(u8, out_buffer, real_path);
-                return out_buffer[0..real_path.len];
-            } else |_| continue;
-        }
-    }
-    return error.FileNotFound;
 }
 
 /// The result is UTF16LE-encoded.

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -762,7 +762,11 @@ pub const Manifest = struct {
 
     fn downgradeToSharedLock(self: *Manifest) !void {
         if (!self.have_exclusive_lock) return;
-        if (std.process.can_spawn or !builtin.single_threaded) { // Some targets (WASI) do not support flock
+
+        // WASI does not currently support flock, so we bypass it here.
+        // TODO: If/when flock is supported on WASI, this check should be removed.
+        //       See https://github.com/WebAssembly/wasi-filesystem/issues/2
+        if (builtin.os.tag != .wasi or std.process.can_spawn or !builtin.single_threaded) {
             const manifest_file = self.manifest_file.?;
             try manifest_file.downgradeLock();
         }
@@ -771,7 +775,11 @@ pub const Manifest = struct {
 
     fn upgradeToExclusiveLock(self: *Manifest) !void {
         if (self.have_exclusive_lock) return;
-        if (std.process.can_spawn or !builtin.single_threaded) { // Some targets (WASI) do not support flock
+
+        // WASI does not currently support flock, so we bypass it here.
+        // TODO: If/when flock is supported on WASI, this check should be removed.
+        //       See https://github.com/WebAssembly/wasi-filesystem/issues/2
+        if (builtin.os.tag != .wasi or std.process.can_spawn or !builtin.single_threaded) {
             const manifest_file = self.manifest_file.?;
             // Here we intentionally have a period where the lock is released, in case there are
             // other processes holding a shared lock.

--- a/src/main.zig
+++ b/src/main.zig
@@ -2526,7 +2526,7 @@ fn buildOutputType(
         pkg_tree_root.table = .{};
     }
 
-    const self_exe_path = try fs.selfExePathAlloc(arena);
+    const self_exe_path = try introspect.findZigExePath(arena);
     var zig_lib_directory: Compilation.Directory = if (override_lib_dir) |lib_dir| .{
         .path = lib_dir,
         .handle = fs.cwd().openDir(lib_dir, .{}) catch |err| {
@@ -3395,7 +3395,7 @@ pub fn cmdInit(
             }
         }
     }
-    const self_exe_path = try fs.selfExePathAlloc(arena);
+    const self_exe_path = try introspect.findZigExePath(arena);
     var zig_lib_directory = introspect.findZigLibDirFromSelfExe(arena, self_exe_path) catch |err| {
         fatal("unable to find zig installation directory: {s}\n", .{@errorName(err)});
     };
@@ -3475,7 +3475,7 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
     // We want to release all the locks before executing the child process, so we make a nice
     // big block here to ensure the cleanup gets run when we extract out our argv.
     const child_argv = argv: {
-        const self_exe_path = try fs.selfExePathAlloc(arena);
+        const self_exe_path = try introspect.findZigExePath(arena);
 
         var build_file: ?[]const u8 = null;
         var override_lib_dir: ?[]const u8 = null;

--- a/src/print_env.zig
+++ b/src/print_env.zig
@@ -6,7 +6,7 @@ const fatal = @import("main.zig").fatal;
 
 pub fn cmdEnv(gpa: Allocator, args: []const []const u8, stdout: std.fs.File.Writer) !void {
     _ = args;
-    const self_exe_path = try std.fs.selfExePathAlloc(gpa);
+    const self_exe_path = try introspect.findZigExePath(gpa);
     defer gpa.free(self_exe_path);
 
     var zig_lib_directory = introspect.findZigLibDirFromSelfExe(gpa, self_exe_path) catch |err| {


### PR DESCRIPTION
Follow-up to #11024. Also updates the guard around the `flock` bypass to be WASI-specific.

Thanks to @andrewrk for the input behind these changes.