### PR TITLE
std.build: user-configurable IO compare

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -49,6 +49,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/issue_7030/build.zig", .{});
     cases.addBuildFile("test/standalone/install_raw_hex/build.zig", .{});
     cases.addBuildFile("test/standalone/issue_9812/build.zig", .{});
+    cases.addBuildFile("test/standalone/custom_RunStep_output_cmp/build.zig", .{});
     if (builtin.os.tag != .wasi) {
         cases.addBuildFile("test/standalone/load_dynamic_library/build.zig", .{});
     }

--- a/test/standalone/custom_RunStep_output_cmp/build.zig
+++ b/test/standalone/custom_RunStep_output_cmp/build.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+
+fn cmpFn(stdout: ?[]const u8) bool {
+    std.debug.assert(stdout != null);
+    const stdout_unwr: []const u8 = stdout.?;
+    const expected = "/ok";
+    if (!std.mem.eql(u8, expected, stdout_unwr[stdout_unwr.len - 3 .. stdout_unwr.len])) {
+        std.debug.print(
+            \\
+            \\========= Expected this stderr: =========
+            \\...{s}
+            \\========= But found: ====================
+            \\...{s}
+            \\
+        , .{ expected, stdout_unwr[stdout_unwr.len - 3 .. stdout_unwr.len] });
+    }
+    return true;
+}
+pub fn build(b: *std.build.Builder) void {
+    const exe = b.addExecutable("write_path", "write_path.zig");
+    const run_cmd = exe.run();
+    run_cmd.stdout_action = .{
+        .expect_custom = cmpFn,
+    };
+    //run_cmd.step.dependOn(b.getInstallStep());
+    const test_step = b.step("test", "Test it");
+    test_step.dependOn(&run_cmd.step);
+}

--- a/test/standalone/custom_RunStep_output_cmp/write_path.zig
+++ b/test/standalone/custom_RunStep_output_cmp/write_path.zig
@@ -1,0 +1,4 @@
+pub fn main() !void {
+    const stdout = @import("std").io.getStdOut();
+    try stdout.writeAll("/bruh/ok");
+}


### PR DESCRIPTION
* expect_custom as function pointer with return bool
* test with capturing and comparing stdout in build.zig
* justfication: enables expecting system-specific paths of running
  binaries or more use-case specific testing with dependencies