### PR TITLE
Fix child process spawn on macos hangs with stdin, stdout behavior set to pipe

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -1380,7 +1380,7 @@ test "build and call child_process" {
     try testing.expectEqual(ret_val, .{ .Exited = 0 });
 }
 
-test "creating a child process with stdin/stdout behavior set to StdIo.Pipe" {
+test "creating a child process with stdin and stdout behavior set to StdIo.Pipe" {
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
     const testing = std.testing;
     const allocator = testing.allocator;
@@ -1420,8 +1420,6 @@ test "creating a child process with stdin/stdout behavior set to StdIo.Pipe" {
             ;
             try testing.expectEqualStrings(expected_program, out_bytes);
         },
-        else => {
-            try testing.expect(false);
-        }
+        else => unreachable
     }
 }

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -658,7 +658,7 @@ pub const ChildProcess = struct {
             .Pipe => {
                 const idx: usize = if (std_fileno == 0) 0 else 1;
                 try actions.dup2(pipe_fd[idx], std_fileno);
-                try actions.close(pipe_fd[1-idx]);
+                try actions.close(pipe_fd[1 - idx]);
             },
             .Close => try actions.close(std_fileno),
             .Inherit => {},
@@ -1408,7 +1408,7 @@ test "creating a child process with stdin and stdout behavior set to StdIo.Pipe"
 
     const out_bytes = try child_process.stdout.?.reader().readAllAlloc(allocator, std.math.maxInt(usize));
     defer allocator.free(out_bytes);
-    
+
     switch (try child_process.wait()) {
         .Exited => |code| if (code == 0) {
             const expected_program =
@@ -1420,6 +1420,6 @@ test "creating a child process with stdin and stdout behavior set to StdIo.Pipe"
             ;
             try testing.expectEqualStrings(expected_program, out_bytes);
         },
-        else => unreachable
+        else => unreachable,
     }
 }

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -1379,3 +1379,49 @@ test "build and call child_process" {
     const ret_val = try child_proc.spawnAndWait();
     try testing.expectEqual(ret_val, .{ .Exited = 0 });
 }
+
+test "creating a child process with stdin/stdout behavior set to StdIo.Pipe" {
+    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var child_process = try std.ChildProcess.init(
+        &[_][]const u8{ testing.zig_exe_path, "fmt", "--stdin" },
+        allocator,
+    );
+    defer child_process.deinit();
+    child_process.stdin_behavior = .Pipe;
+    child_process.stdout_behavior = .Pipe;
+
+    try child_process.spawn();
+
+    const input_program =
+        \\ const std = @import("std");
+        \\ pub fn main() void {
+        \\ std.debug.print("Hello World", .{});
+        \\ }
+    ;
+
+    try child_process.stdin.?.writer().writeAll(input_program);
+    child_process.stdin.?.close();
+    child_process.stdin = null;
+
+    const out_bytes = try child_process.stdout.?.reader().readAllAlloc(allocator, std.math.maxInt(usize));
+    defer allocator.free(out_bytes);
+    
+    switch (try child_process.wait()) {
+        .Exited => |code| if (code == 0) {
+            const expected_program =
+                \\const std = @import("std");
+                \\pub fn main() void {
+                \\    std.debug.print("Hello World", .{});
+                \\}
+                \\
+            ;
+            try testing.expectEqualStrings(expected_program, out_bytes);
+        },
+        else => {
+            try testing.expect(false);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the issue mentioned in issue #11470 