### PR TITLE
[doc update] add size_t

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -672,8 +672,8 @@ pub fn main() void {
         </tr>
         <tr>
             <th scope="row">{#syntax#}usize{#endsyntax#}</th>
-          <td><code class="c">uintptr_t</code></td>
-          <td>unsigned pointer sized integer</td>
+          <td><code class="c">uintptr_t</code> or <code class="c">size_t</code></td>
+          <td>unsigned pointer sized integer. Also see <a href="https://github.com/ziglang/zig/issues/5185">#5185</a></td>
         </tr>
 
         <tr>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -672,7 +672,7 @@ pub fn main() void {
         </tr>
         <tr>
             <th scope="row">{#syntax#}usize{#endsyntax#}</th>
-          <td><code class="c">uintptr_t</code> or <code class="c">size_t</code></td>
+          <td><code class="c">uintptr_t</code>, <code class="c">size_t</code></td>
           <td>unsigned pointer sized integer. Also see <a href="https://github.com/ziglang/zig/issues/5185">#5185</a></td>
         </tr>
 


### PR DESCRIPTION
For those souls looking for a zig `size_t` equivalent, and not
lucky/educated enough (that was me yesterday) to know it's the same as
`uintptr_t`.

From a recent discussion on IRC.