### PR TITLE
dwarf+debug: clean up resources mgmt

### DIFF
--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -764,7 +764,6 @@ pub const Pdb = struct {
                                 const flags = @ptrCast(*LineNumberEntry.Flags, &line_num_entry.Flags);
 
                                 return debug.LineInfo{
-                                    .allocator = self.allocator,
                                     .file_name = source_file_name,
                                     .line = flags.Start,
                                     .column = column,

--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -498,6 +498,15 @@ pub const Pdb = struct {
         symbols: []u8,
         subsect_info: []u8,
         checksum_offset: ?usize,
+
+        pub fn deinit(self: *Module, allocator: mem.Allocator) void {
+            allocator.free(self.module_name);
+            allocator.free(self.obj_file_name);
+            if (self.populated) {
+                allocator.free(self.symbols);
+                allocator.free(self.subsect_info);
+            }
+        }
     };
 
     pub fn init(allocator: mem.Allocator, path: []const u8) !Pdb {
@@ -519,6 +528,10 @@ pub const Pdb = struct {
 
     pub fn deinit(self: *Pdb) void {
         self.in_file.close();
+        self.msf.deinit(self.allocator);
+        for (self.modules) |*module| {
+            module.deinit(self.allocator);
+        }
         self.allocator.free(self.modules);
         self.allocator.free(self.sect_contribs);
     }
@@ -940,6 +953,14 @@ const Msf = struct {
             .directory = directory,
             .streams = streams,
         };
+    }
+
+    fn deinit(self: *Msf, allocator: mem.Allocator) void {
+        allocator.free(self.directory.blocks);
+        for (self.streams) |*stream| {
+            allocator.free(stream.blocks);
+        }
+        allocator.free(self.streams);
     }
 };
 

--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -131,9 +131,7 @@ const DebugInfo = struct {
         allocator.free(self.debug_line);
         allocator.free(self.debug_line_str);
         allocator.free(self.debug_ranges);
-        self.inner.abbrev_table_list.deinit();
-        self.inner.compile_unit_list.deinit();
-        self.inner.func_list.deinit();
+        self.inner.deinit(allocator);
     }
 };
 


### PR DESCRIPTION
Fixes #4353

While not a complete rewrite as suggested in #4353, it does clean up the problems with resources in non-terminating scenarios, i.e., you can use the modules with your custom allocator, and properly deinit any allocated resources. Another by-product of this PR is the fact that the MachO linker no longer leaks memory courtesy of relying on `std.dwarf` module - this is a prereq for my work on the linker test harness which will by default target stage2 LLVM backend. Anyhow, I will most likely look into cleaning up the design of `std.dwarf` (if needed) when I get to working on translating DWARF info from relocatable object files into relocated sections part of the output dSYM bundle for stage2 (LLVM and native backends).

### Changes
---
* dwarf: clean up allocations in `std.dwarf` module - while this code probably could do with some love and a redesign, this commit fixes the allocations by making sure we explicitly pass an allocator where required, and we use arenas for temporary or narrowly-scoped objects such as a `Die` (for `Die` in particular, not every `FormValue` will be allocated - we could duplicate, or we can use an arena which is the proposal of this commit).
* debug: fix resource (de)allocation for MachO targets - with this change, it is now possible to safely call `var di = std.debug.openSelfDebugInfo(gpa)`. Calling then `di.deinit()` on the object will correctly free all allocated resources.
* debug: fix resource (de)allocation for Elf and Coff targets - With this change, it is now possible to safely call `var di = std.debug.openSelfDebugInfo(gpa)`. Calling then `di.deinit()` on the object will correctly free all allocated resources.
* debug: ensure we store the result of `mmap` with correct alignment.
* debug: add smoke test (a modification of the failing test case from #4353 description)