### PR TITLE
macho: create LlvmObject in createEmpty only

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -321,7 +321,6 @@ pub fn openPath(allocator: Allocator, options: link.Options) !*MachO {
         // TODO this intermediary_basename isn't enough; in the case of `zig build-exe`,
         // we also want to put the intermediary object file in the cache while the
         // main emit directory is the cwd.
-        self.llvm_object = try LlvmObject.create(allocator, options);
         self.base.intermediary_basename = try std.fmt.allocPrint(allocator, "{s}{s}", .{
             emit.sub_path, options.object_format.fileExt(options.target.cpu.arch),
         });


### PR DESCRIPTION
Prior to this change we would also create it in `openPath`, but as `openPath` internally calls `createEmpty` we would end up with a memory leak.