### PR TITLE
stage2: sparcv9: Implement basic function calls and returns

### DIFF
--- a/lib/std/zig/system/NativeTargetInfo.zig
+++ b/lib/std/zig/system/NativeTargetInfo.zig
@@ -931,6 +931,7 @@ pub fn getExternalExecutor(
             .riscv64 => Executor{ .qemu = "qemu-riscv64" },
             .s390x => Executor{ .qemu = "qemu-s390x" },
             .sparc => Executor{ .qemu = "qemu-sparc" },
+            .sparcv9 => Executor{ .qemu = "qemu-sparc64" },
             .x86_64 => Executor{ .qemu = "qemu-x86_64" },
             else => return bad_result,
         };

--- a/src/arch/sparcv9/CodeGen.zig
+++ b/src/arch/sparcv9/CodeGen.zig
@@ -1,5 +1,7 @@
 //! SPARCv9 codegen.
 //! This lowers AIR into MIR.
+//! For now this only implements medium/low code model with absolute addressing.
+//! TODO add support for other code models.
 const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.codegen);
@@ -884,7 +886,14 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallOptions.
 
                 _ = try self.addInst(.{
                     .tag = .jmpl,
-                    .data = .{ .branch_link_indirect = .{ .reg = .o7 } },
+                    .data = .{
+                        .arithmetic_3op = .{
+                            .is_imm = false,
+                            .rd = .o7,
+                            .rs1 = .o7,
+                            .rs2_or_imm = .{ .rs2 = .g0 },
+                        },
+                    },
                 });
             } else if (func_value.castTag(.extern_fn)) |_| {
                 return self.fail("TODO implement calling extern functions", .{});
@@ -899,7 +908,14 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallOptions.
 
         _ = try self.addInst(.{
             .tag = .jmpl,
-            .data = .{ .branch_link_indirect = .{ .reg = .o7 } },
+            .data = .{
+                .arithmetic_3op = .{
+                    .is_imm = false,
+                    .rd = .o7,
+                    .rs1 = .o7,
+                    .rs2_or_imm = .{ .rs2 = .g0 },
+                },
+            },
         });
     }
 

--- a/src/arch/sparcv9/CodeGen.zig
+++ b/src/arch/sparcv9/CodeGen.zig
@@ -394,7 +394,11 @@ fn gen(self: *Self) !void {
             },
         });
 
-        // TODO Find a way to fill this slot
+        // Branches in SPARC have a delay slot, that is, the instruction
+        // following it will unconditionally be executed.
+        // See: Section 3.2.3 Control Transfer in SPARCv9 manual.
+        // See also: https://arcb.csc.ncsu.edu/~mueller/codeopt/codeopt00/notes/delaybra.html
+        // TODO Find a way to fill this delay slot
         // nop
         _ = try self.addInst(.{
             .tag = .nop,
@@ -895,6 +899,12 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallOptions.
                         },
                     },
                 });
+
+                // TODO Find a way to fill this delay slot
+                _ = try self.addInst(.{
+                    .tag = .nop,
+                    .data = .{ .nop = {} },
+                });
             } else if (func_value.castTag(.extern_fn)) |_| {
                 return self.fail("TODO implement calling extern functions", .{});
             } else {
@@ -916,6 +926,12 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallOptions.
                     .rs2_or_imm = .{ .rs2 = .g0 },
                 },
             },
+        });
+
+        // TODO Find a way to fill this delay slot
+        _ = try self.addInst(.{
+            .tag = .nop,
+            .data = .{ .nop = {} },
         });
     }
 

--- a/src/arch/sparcv9/CodeGen.zig
+++ b/src/arch/sparcv9/CodeGen.zig
@@ -780,16 +780,6 @@ fn airArg(self: *Self, inst: Air.Inst.Index) !void {
     // TODO Copy registers to the stack
     const mcv = result;
 
-    _ = try self.addInst(.{
-        .tag = .dbg_arg,
-        .data = .{
-            .dbg_arg_info = .{
-                .air_inst = inst,
-                .arg_index = arg_index,
-            },
-        },
-    });
-
     if (self.liveness.isUnused(inst))
         return self.finishAirBookkeeping();
 
@@ -1050,9 +1040,7 @@ fn airSwitch(self: *Self, inst: Air.Inst.Index) !void {
 
 fn addInst(self: *Self, inst: Mir.Inst) error{OutOfMemory}!Mir.Inst.Index {
     const gpa = self.gpa;
-
     try self.mir_instructions.ensureUnusedCapacity(gpa, 1);
-
     const result_index = @intCast(Air.Inst.Index, self.mir_instructions.len);
     self.mir_instructions.appendAssumeCapacity(inst);
     return result_index;

--- a/src/arch/sparcv9/CodeGen.zig
+++ b/src/arch/sparcv9/CodeGen.zig
@@ -1185,48 +1185,17 @@ fn genLoad(self: *Self, value_reg: Register, addr_reg: Register, comptime off_ty
     const rs2_or_imm = if (is_imm) .{ .imm = off } else .{ .rs2 = off };
 
     switch (abi_size) {
-        1 => {
+        1, 2, 4, 8 => {
+            const tag: Mir.Inst.Tag = switch (abi_size) {
+                1 => .ldub,
+                2 => .lduh,
+                4 => .lduw,
+                8 => .ldx,
+                else => unreachable, // unexpected abi size
+            };
+
             _ = try self.addInst(.{
-                .tag = .ldub,
-                .data = .{
-                    .arithmetic_3op = .{
-                        .is_imm = is_imm,
-                        .rd = value_reg,
-                        .rs1 = addr_reg,
-                        .rs2_or_imm = rs2_or_imm,
-                    },
-                },
-            });
-        },
-        2 => {
-            _ = try self.addInst(.{
-                .tag = .lduh,
-                .data = .{
-                    .arithmetic_3op = .{
-                        .is_imm = is_imm,
-                        .rd = value_reg,
-                        .rs1 = addr_reg,
-                        .rs2_or_imm = rs2_or_imm,
-                    },
-                },
-            });
-        },
-        4 => {
-            _ = try self.addInst(.{
-                .tag = .lduw,
-                .data = .{
-                    .arithmetic_3op = .{
-                        .is_imm = is_imm,
-                        .rd = value_reg,
-                        .rs1 = addr_reg,
-                        .rs2_or_imm = rs2_or_imm,
-                    },
-                },
-            });
-        },
-        8 => {
-            _ = try self.addInst(.{
-                .tag = .ldx,
+                .tag = tag,
                 .data = .{
                     .arithmetic_3op = .{
                         .is_imm = is_imm,
@@ -1436,48 +1405,17 @@ fn genStore(self: *Self, value_reg: Register, addr_reg: Register, comptime off_t
     const rs2_or_imm = if (is_imm) .{ .imm = off } else .{ .rs2 = off };
 
     switch (abi_size) {
-        1 => {
+        1, 2, 4, 8 => {
+            const tag: Mir.Inst.Tag = switch (abi_size) {
+                1 => .stb,
+                2 => .sth,
+                4 => .stw,
+                8 => .stx,
+                else => unreachable, // unexpected abi size
+            };
+
             _ = try self.addInst(.{
-                .tag = .stb,
-                .data = .{
-                    .arithmetic_3op = .{
-                        .is_imm = is_imm,
-                        .rd = value_reg,
-                        .rs1 = addr_reg,
-                        .rs2_or_imm = rs2_or_imm,
-                    },
-                },
-            });
-        },
-        2 => {
-            _ = try self.addInst(.{
-                .tag = .sth,
-                .data = .{
-                    .arithmetic_3op = .{
-                        .is_imm = is_imm,
-                        .rd = value_reg,
-                        .rs1 = addr_reg,
-                        .rs2_or_imm = rs2_or_imm,
-                    },
-                },
-            });
-        },
-        4 => {
-            _ = try self.addInst(.{
-                .tag = .stw,
-                .data = .{
-                    .arithmetic_3op = .{
-                        .is_imm = is_imm,
-                        .rd = value_reg,
-                        .rs1 = addr_reg,
-                        .rs2_or_imm = rs2_or_imm,
-                    },
-                },
-            });
-        },
-        8 => {
-            _ = try self.addInst(.{
-                .tag = .stx,
+                .tag = tag,
                 .data = .{
                     .arithmetic_3op = .{
                         .is_imm = is_imm,

--- a/src/arch/sparcv9/Emit.zig
+++ b/src/arch/sparcv9/Emit.zig
@@ -56,8 +56,7 @@ pub fn emitMir(
 
             .call => @panic("TODO implement sparcv9 call"),
 
-            .jmpl => @panic("TODO implement sparcv9 jmpl"),
-            .jmpl_i => @panic("TODO implement sparcv9 jmpl to reg"),
+            .jmpl => try emit.mirArithmetic3Op(inst),
 
             .ldub => try emit.mirArithmetic3Op(inst),
             .lduh => try emit.mirArithmetic3Op(inst),
@@ -163,6 +162,7 @@ fn mirArithmetic3Op(emit: *Emit, inst: Mir.Inst.Index) !void {
         const imm = data.rs2_or_imm.imm;
         switch (tag) {
             .add => try emit.writeInstruction(Instruction.add(i13, rs1, imm, rd)),
+            .jmpl => try emit.writeInstruction(Instruction.jmpl(i13, rs1, imm, rd)),
             .ldub => try emit.writeInstruction(Instruction.ldub(i13, rs1, imm, rd)),
             .lduh => try emit.writeInstruction(Instruction.lduh(i13, rs1, imm, rd)),
             .lduw => try emit.writeInstruction(Instruction.lduw(i13, rs1, imm, rd)),
@@ -177,6 +177,7 @@ fn mirArithmetic3Op(emit: *Emit, inst: Mir.Inst.Index) !void {
         const rs2 = data.rs2_or_imm.rs2;
         switch (tag) {
             .add => try emit.writeInstruction(Instruction.add(Register, rs1, rs2, rd)),
+            .jmpl => try emit.writeInstruction(Instruction.jmpl(Register, rs1, rs2, rd)),
             .ldub => try emit.writeInstruction(Instruction.ldub(Register, rs1, rs2, rd)),
             .lduh => try emit.writeInstruction(Instruction.lduh(Register, rs1, rs2, rd)),
             .lduw => try emit.writeInstruction(Instruction.lduw(Register, rs1, rs2, rd)),

--- a/src/arch/sparcv9/Emit.zig
+++ b/src/arch/sparcv9/Emit.zig
@@ -76,6 +76,11 @@ pub fn emitMir(
 
             .sllx => @panic("TODO implement sparcv9 sllx"),
 
+            .stb => try emit.mirArithmetic3Op(inst),
+            .sth => try emit.mirArithmetic3Op(inst),
+            .stw => try emit.mirArithmetic3Op(inst),
+            .stx => try emit.mirArithmetic3Op(inst),
+
             .sub => try emit.mirArithmetic3Op(inst),
 
             .tcc => try emit.mirTrap(inst),
@@ -170,6 +175,10 @@ fn mirArithmetic3Op(emit: *Emit, inst: Mir.Inst.Index) !void {
             .@"or" => try emit.writeInstruction(Instruction.@"or"(i13, rs1, imm, rd)),
             .save => try emit.writeInstruction(Instruction.save(i13, rs1, imm, rd)),
             .restore => try emit.writeInstruction(Instruction.restore(i13, rs1, imm, rd)),
+            .stb => try emit.writeInstruction(Instruction.stb(i13, rs1, imm, rd)),
+            .sth => try emit.writeInstruction(Instruction.sth(i13, rs1, imm, rd)),
+            .stw => try emit.writeInstruction(Instruction.stw(i13, rs1, imm, rd)),
+            .stx => try emit.writeInstruction(Instruction.stx(i13, rs1, imm, rd)),
             .sub => try emit.writeInstruction(Instruction.sub(i13, rs1, imm, rd)),
             else => unreachable,
         }
@@ -185,6 +194,10 @@ fn mirArithmetic3Op(emit: *Emit, inst: Mir.Inst.Index) !void {
             .@"or" => try emit.writeInstruction(Instruction.@"or"(Register, rs1, rs2, rd)),
             .save => try emit.writeInstruction(Instruction.save(Register, rs1, rs2, rd)),
             .restore => try emit.writeInstruction(Instruction.restore(Register, rs1, rs2, rd)),
+            .stb => try emit.writeInstruction(Instruction.stb(Register, rs1, rs2, rd)),
+            .sth => try emit.writeInstruction(Instruction.sth(Register, rs1, rs2, rd)),
+            .stw => try emit.writeInstruction(Instruction.stw(Register, rs1, rs2, rd)),
+            .stx => try emit.writeInstruction(Instruction.stx(Register, rs1, rs2, rd)),
             .sub => try emit.writeInstruction(Instruction.sub(Register, rs1, rs2, rd)),
             else => unreachable,
         }

--- a/src/arch/sparcv9/Emit.zig
+++ b/src/arch/sparcv9/Emit.zig
@@ -45,7 +45,6 @@ pub fn emitMir(
     for (mir_tags) |tag, index| {
         const inst = @intCast(u32, index);
         switch (tag) {
-            .dbg_arg => try emit.mirDbgArg(inst),
             .dbg_line => try emit.mirDbgLine(inst),
             .dbg_prologue_end => try emit.mirDebugPrologueEnd(),
             .dbg_epilogue_begin => try emit.mirDebugEpilogueBegin(),
@@ -90,17 +89,6 @@ pub fn emitMir(
 
 pub fn deinit(emit: *Emit) void {
     emit.* = undefined;
-}
-
-fn mirDbgArg(emit: *Emit, inst: Mir.Inst.Index) !void {
-    const tag = emit.mir.instructions.items(.tag)[inst];
-    const dbg_arg_info = emit.mir.instructions.items(.data)[inst].dbg_arg_info;
-    _ = dbg_arg_info;
-
-    switch (tag) {
-        .dbg_arg => {}, // TODO try emit.genArgDbgInfo(dbg_arg_info.air_inst, dbg_arg_info.arg_index),
-        else => unreachable,
-    }
 }
 
 fn mirDbgLine(emit: *Emit, inst: Mir.Inst.Index) !void {

--- a/src/arch/sparcv9/Mir.zig
+++ b/src/arch/sparcv9/Mir.zig
@@ -75,7 +75,7 @@ pub const Inst = struct {
         nop,
 
         /// A.45 RETURN
-        /// This Thisuses the arithmetic_2op field.
+        /// This uses the arithmetic_2op field.
         @"return",
 
         /// A.46 SAVE and RESTORE

--- a/src/arch/sparcv9/Mir.zig
+++ b/src/arch/sparcv9/Mir.zig
@@ -54,11 +54,8 @@ pub const Inst = struct {
         call,
 
         /// A.24 Jump and Link
-        /// jmpl (far direct jump) uses the branch_link field,
-        /// while jmpl_i (indirect jump) uses the branch_link_indirect field.
-        /// Those two MIR instructions will be lowered into SPARCv9 jmpl instruction.
+        /// It uses the arithmetic_3op field.
         jmpl,
-        jmpl_i,
 
         /// A.27 Load Integer
         /// Those uses the arithmetic_3op field.
@@ -164,13 +161,6 @@ pub const Inst = struct {
         /// Used by e.g. call
         branch_link: struct {
             inst: Index,
-            link: Register = .o7,
-        },
-
-        /// Indirect branch and link (always unconditional).
-        /// Used by e.g. jmpl_i
-        branch_link_indirect: struct {
-            reg: Register,
             link: Register = .o7,
         },
 

--- a/src/arch/sparcv9/Mir.zig
+++ b/src/arch/sparcv9/Mir.zig
@@ -39,24 +39,24 @@ pub const Inst = struct {
         // in The SPARC Architecture Manual, Version 9.
 
         /// A.2 Add
-        /// Those uses the arithmetic_3op field.
+        /// This uses the arithmetic_3op field.
         // TODO add other operations.
         add,
 
         /// A.7 Branch on Integer Condition Codes with Prediction (BPcc)
-        /// It uses the branch_predict field.
+        /// This uses the branch_predict field.
         bpcc,
 
         /// A.8 Call and Link
-        /// It uses the branch_link field.
+        /// This uses the branch_link field.
         call,
 
         /// A.24 Jump and Link
-        /// It uses the arithmetic_3op field.
+        /// This uses the arithmetic_3op field.
         jmpl,
 
         /// A.27 Load Integer
-        /// Those uses the arithmetic_3op field.
+        /// This uses the arithmetic_3op field.
         /// Note that the ldd variant of this instruction is deprecated, so do not emit
         /// it unless specifically requested (e.g. by inline assembly).
         // TODO add other operations.
@@ -66,29 +66,29 @@ pub const Inst = struct {
         ldx,
 
         /// A.31 Logical Operations
-        /// Those uses the arithmetic_3op field.
+        /// This uses the arithmetic_3op field.
         // TODO add other operations.
         @"or",
 
         /// A.40 No Operation
-        /// It uses the nop field.
+        /// This uses the nop field.
         nop,
 
         /// A.45 RETURN
-        /// It uses the arithmetic_2op field.
+        /// This Thisuses the arithmetic_2op field.
         @"return",
 
         /// A.46 SAVE and RESTORE
-        /// Those uses the arithmetic_3op field.
+        /// This uses the arithmetic_3op field.
         save,
         restore,
 
         /// A.48 SETHI
-        /// It uses the sethi field.
+        /// This uses the sethi field.
         sethi,
 
         /// A.49 Shift
-        /// Those uses the shift field.
+        /// This uses the shift field.
         // TODO add other operations.
         sllx,
 
@@ -103,12 +103,12 @@ pub const Inst = struct {
         stx,
 
         /// A.56 Subtract
-        /// Those uses the arithmetic_3op field.
+        /// This uses the arithmetic_3op field.
         // TODO add other operations.
         sub,
 
         /// A.61 Trap on Integer Condition Codes (Tcc)
-        /// It uses the trap field.
+        /// This uses the trap field.
         tcc,
     };
 

--- a/src/arch/sparcv9/Mir.zig
+++ b/src/arch/sparcv9/Mir.zig
@@ -28,8 +28,6 @@ pub const Inst = struct {
     data: Data,
 
     pub const Tag = enum(u16) {
-        /// Pseudo-instruction: Argument
-        dbg_arg,
         /// Pseudo-instruction: End of prologue
         dbg_prologue_end,
         /// Pseudo-instruction: Beginning of epilogue
@@ -122,14 +120,6 @@ pub const Inst = struct {
     /// how to interpret the data within.
     // TODO this is a quick-n-dirty solution that needs to be cleaned up.
     pub const Data = union {
-        /// Debug info: argument
-        ///
-        /// Used by e.g. dbg_arg
-        dbg_arg_info: struct {
-            air_inst: Air.Inst.Index,
-            arg_index: usize,
-        },
-
         /// Debug info: line and column
         ///
         /// Used by e.g. dbg_line
@@ -234,10 +224,7 @@ pub const Inst = struct {
     // Note that in Debug builds, Zig is allowed to insert a secret field for safety checks.
     comptime {
         if (builtin.mode != .Debug) {
-            // TODO clean up the definition of Data before enabling this.
-            // I'll do that after the PoC backend can produce usable binaries.
-
-            // assert(@sizeOf(Data) == 8);
+            assert(@sizeOf(Data) == 8);
         }
     }
 };

--- a/src/arch/sparcv9/Mir.zig
+++ b/src/arch/sparcv9/Mir.zig
@@ -94,6 +94,16 @@ pub const Inst = struct {
         // TODO add other operations.
         sllx,
 
+        /// A.54 Store Integer
+        /// This uses the arithmetic_3op field.
+        /// Note that the std variant of this instruction is deprecated, so do not emit
+        /// it unless specifically requested (e.g. by inline assembly).
+        // TODO add other operations.
+        stb,
+        sth,
+        stw,
+        stx,
+
         /// A.56 Subtract
         /// Those uses the arithmetic_3op field.
         // TODO add other operations.

--- a/src/arch/sparcv9/abi.zig
+++ b/src/arch/sparcv9/abi.zig
@@ -1,6 +1,11 @@
 const bits = @import("bits.zig");
 const Register = bits.Register;
 
+// On SPARCv9, %sp points to top of stack + stack bias,
+// and %fp points to top of previous frame + stack bias.
+// See: Registers and the Stack Frame, page 3P-8, SCD 2.4.1.
+pub const stack_bias = 2047;
+
 // There are no callee-preserved registers since the windowing
 // mechanism already takes care of them.
 // We still need to preserve %o0-%o5, %g1, %g4, and %g5 before calling

--- a/src/arch/sparcv9/abi.zig
+++ b/src/arch/sparcv9/abi.zig
@@ -1,10 +1,17 @@
 const bits = @import("bits.zig");
 const Register = bits.Register;
 
+// SPARCv9 stack constants.
+// See: Registers and the Stack Frame, page 3P-8, SCD 2.4.1.
+
 // On SPARCv9, %sp points to top of stack + stack bias,
 // and %fp points to top of previous frame + stack bias.
-// See: Registers and the Stack Frame, page 3P-8, SCD 2.4.1.
 pub const stack_bias = 2047;
+
+// The first 176 bytes of the stack is reserved for register saving purposes.
+// SPARCv9 requires to reserve space in the stack for the first six arguments,
+// even though they are usually passed in registers.
+pub const stack_save_area = 176;
 
 // There are no callee-preserved registers since the windowing
 // mechanism already takes care of them.

--- a/src/arch/sparcv9/bits.zig
+++ b/src/arch/sparcv9/bits.zig
@@ -1059,6 +1059,38 @@ pub const Instruction = union(enum) {
         return format2a(0b100, imm, rd);
     }
 
+    pub fn stb(comptime s2: type, rs1: Register, rs2: s2, rd: Register) Instruction {
+        return switch (s2) {
+            Register => format3a(0b11, 0b00_0101, rs1, rs2, rd),
+            i13 => format3b(0b11, 0b00_0101, rs1, rs2, rd),
+            else => unreachable,
+        };
+    }
+
+    pub fn sth(comptime s2: type, rs1: Register, rs2: s2, rd: Register) Instruction {
+        return switch (s2) {
+            Register => format3a(0b11, 0b00_0110, rs1, rs2, rd),
+            i13 => format3b(0b11, 0b00_0110, rs1, rs2, rd),
+            else => unreachable,
+        };
+    }
+
+    pub fn stw(comptime s2: type, rs1: Register, rs2: s2, rd: Register) Instruction {
+        return switch (s2) {
+            Register => format3a(0b11, 0b00_0100, rs1, rs2, rd),
+            i13 => format3b(0b11, 0b00_0100, rs1, rs2, rd),
+            else => unreachable,
+        };
+    }
+
+    pub fn stx(comptime s2: type, rs1: Register, rs2: s2, rd: Register) Instruction {
+        return switch (s2) {
+            Register => format3a(0b11, 0b00_1110, rs1, rs2, rd),
+            i13 => format3b(0b11, 0b00_1110, rs1, rs2, rd),
+            else => unreachable,
+        };
+    }
+
     pub fn sub(comptime s2: type, rs1: Register, rs2: s2, rd: Register) Instruction {
         return switch (s2) {
             Register => format3a(0b10, 0b00_0100, rs1, rs2, rd),

--- a/src/arch/sparcv9/bits.zig
+++ b/src/arch/sparcv9/bits.zig
@@ -271,6 +271,8 @@ pub const Instruction = union(enum) {
         rd: u5,
         op3: u6,
         rs1: u5,
+        // See Errata 58 of SPARCv9 specification
+        // https://sparc.org/errata-for-v9/#58
         i: u1 = 0b1,
         reserved: u8 = 0b00000000,
         rs2: u5,
@@ -977,10 +979,10 @@ pub const Instruction = union(enum) {
         };
     }
 
-    pub fn @"or"(comptime s2: type, rs1: Register, rs2: s2, rd: Register) Instruction {
+    pub fn jmpl(comptime s2: type, rs1: Register, rs2: s2, rd: Register) Instruction {
         return switch (s2) {
-            Register => format3a(0b10, 0b00_0010, rs1, rs2, rd),
-            i13 => format3b(0b10, 0b00_0010, rs1, rs2, rd),
+            Register => format3a(0b10, 0b11_1000, rs1, rs2, rd),
+            i13 => format3b(0b10, 0b11_1000, rs1, rs2, rd),
             else => unreachable,
         };
     }
@@ -1013,6 +1015,14 @@ pub const Instruction = union(enum) {
         return switch (s2) {
             Register => format3a(0b11, 0b00_1011, rs1, rs2, rd),
             i13 => format3b(0b11, 0b00_1011, rs1, rs2, rd),
+            else => unreachable,
+        };
+    }
+
+    pub fn @"or"(comptime s2: type, rs1: Register, rs2: s2, rd: Register) Instruction {
+        return switch (s2) {
+            Register => format3a(0b10, 0b00_0010, rs1, rs2, rd),
+            i13 => format3b(0b10, 0b00_0010, rs1, rs2, rd),
             else => unreachable,
         };
     }

--- a/test/cases/sparcv9-linux/hello_world.zig
+++ b/test/cases/sparcv9-linux/hello_world.zig
@@ -1,23 +1,18 @@
 const msg = "Hello, World!\n";
 
-pub export fn _start() noreturn {
+fn length() usize {
+    return msg.len;
+}
+
+pub fn main() void {
     asm volatile ("ta 0x6d"
         :
         : [number] "{g1}" (4),
           [arg1] "{o0}" (1),
           [arg2] "{o1}" (@ptrToInt(msg)),
-          [arg3] "{o2}" (msg.len),
+          [arg3] "{o2}" (length()),
         : "o0", "o1", "o2", "o3", "o4", "o5", "o6", "o7", "memory"
     );
-
-    asm volatile ("ta 0x6d"
-        :
-        : [number] "{g1}" (1),
-          [arg1] "{o0}" (0),
-        : "o0", "o1", "o2", "o3", "o4", "o5", "o6", "o7", "memory"
-    );
-
-    unreachable;
 }
 
 // run


### PR DESCRIPTION
This implements basic function calls/returns on SPARCv9, such that the basic implementation of `_start` from the stdlib works.