### PR TITLE
CI: add non-LLVM backends to the test matrix

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -445,6 +445,9 @@ pub fn build(b: *Builder) !void {
         false, // skip_single_threaded
         skip_non_native,
         skip_libc,
+        skip_stage1,
+        omit_stage2,
+        is_stage1,
     ));
 
     toolchain_step.dependOn(tests.addPkgTests(
@@ -457,6 +460,9 @@ pub fn build(b: *Builder) !void {
         true, // skip_single_threaded
         skip_non_native,
         true, // skip_libc
+        skip_stage1,
+        omit_stage2 or true, // TODO get these all passing
+        is_stage1,
     ));
 
     toolchain_step.dependOn(tests.addPkgTests(
@@ -469,6 +475,9 @@ pub fn build(b: *Builder) !void {
         true, // skip_single_threaded
         skip_non_native,
         true, // skip_libc
+        skip_stage1,
+        omit_stage2 or true, // TODO get these all passing
+        is_stage1,
     ));
 
     toolchain_step.dependOn(tests.addCompareOutputTests(b, test_filter, modes));
@@ -494,6 +503,9 @@ pub fn build(b: *Builder) !void {
         false,
         skip_non_native,
         skip_libc,
+        skip_stage1,
+        omit_stage2 or true, // TODO get these all passing
+        is_stage1,
     );
 
     const test_step = b.step("test", "Run all the tests");

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -58,12 +58,23 @@ make $JOBS install
 # Build stage2 standalone so that we can test stage2 against stage2 compiler-rt.
 release/bin/zig build -p stage2 -Denable-llvm
 
-stage2/bin/zig test ../test/behavior.zig -I../test -fLLVM
-stage2/bin/zig test ../test/behavior.zig -I../test -fno-LLVM
+stage2/bin/zig build test-behavior
 
-release/bin/zig build test-toolchain -Denable-macos-sdk
-release/bin/zig build test-std
-release/bin/zig build docs
+release/bin/zig build test-behavior         -Denable-macos-sdk -Domit-stage2
+release/bin/zig build test-compiler-rt      -Denable-macos-sdk
+release/bin/zig build test-std              -Denable-macos-sdk
+release/bin/zig build test-minilibc         -Denable-macos-sdk
+release/bin/zig build test-compare-output   -Denable-macos-sdk
+release/bin/zig build test-standalone       -Denable-macos-sdk
+release/bin/zig build test-stack-traces     -Denable-macos-sdk
+release/bin/zig build test-cli              -Denable-macos-sdk
+release/bin/zig build test-asm-link         -Denable-macos-sdk
+release/bin/zig build test-runtime-safety   -Denable-macos-sdk
+release/bin/zig build test-translate-c      -Denable-macos-sdk
+release/bin/zig build test-run-translated-c -Denable-macos-sdk
+release/bin/zig build docs                  -Denable-macos-sdk
+release/bin/zig build test-fmt              -Denable-macos-sdk
+release/bin/zig build test-stage2           -Denable-macos-sdk
 
 if [ "${BUILD_REASON}" != "PullRequest" ]; then
   mv ../LICENSE release/

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -58,8 +58,7 @@ make $JOBS install
 # Build stage2 standalone so that we can test stage2 against stage2 compiler-rt.
 release/bin/zig build -p stage2 -Denable-llvm
 
-# TODO: enable this
-#stage2/bin/zig build test-behavior
+stage2/bin/zig build test-behavior
 
 # TODO: upgrade these to test stage2 instead of stage1
 # TODO: upgrade these to test stage3 instead of stage2

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -58,8 +58,11 @@ make $JOBS install
 # Build stage2 standalone so that we can test stage2 against stage2 compiler-rt.
 release/bin/zig build -p stage2 -Denable-llvm
 
-stage2/bin/zig build test-behavior
+# TODO: enable this
+#stage2/bin/zig build test-behavior
 
+# TODO: upgrade these to test stage2 instead of stage1
+# TODO: upgrade these to test stage3 instead of stage2
 release/bin/zig build test-behavior         -Denable-macos-sdk -Domit-stage2
 release/bin/zig build test-compiler-rt      -Denable-macos-sdk
 release/bin/zig build test-std              -Denable-macos-sdk

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1590,6 +1590,8 @@ pub const LibExeObjStep = struct {
 
     want_lto: ?bool = null,
     use_stage1: ?bool = null,
+    use_llvm: ?bool = null,
+    ofmt: ?std.Target.ObjectFormat = null,
 
     output_path_source: GeneratedFile,
     output_lib_path_source: GeneratedFile,
@@ -2349,6 +2351,18 @@ pub const LibExeObjStep = struct {
             } else {
                 try zig_args.append("-fno-stage1");
             }
+        }
+
+        if (self.use_llvm) |use_llvm| {
+            if (use_llvm) {
+                try zig_args.append("-fLLVM");
+            } else {
+                try zig_args.append("-fno-LLVM");
+            }
+        }
+
+        if (self.ofmt) |ofmt| {
+            try zig_args.append(try std.fmt.allocPrint(builder.allocator, "-ofmt={s}", .{@tagName(ofmt)}));
         }
 
         if (self.entry_symbol_name) |entry| {

--- a/lib/std/os/linux/arm-eabi.zig
+++ b/lib/std/os/linux/arm-eabi.zig
@@ -99,7 +99,10 @@ pub fn syscall6(
 
 /// This matches the libc clone function.
 pub extern fn clone(
-    func: fn (arg: usize) callconv(.C) u8,
+    func: switch (@import("builtin").zig_backend) {
+        .stage1 => fn (arg: usize) callconv(.C) u8,
+        else => *const fn (arg: usize) callconv(.C) u8,
+    },
     stack: usize,
     flags: u32,
     arg: usize,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4229,41 +4229,166 @@ pub const FuncGen = struct {
         return self.builder.buildInsertValue(partial, len, 1, "");
     }
 
+    inline fn isPowerOfTwo(bits: u64) bool {
+        return bits != 0 and ((bits & (~bits + 1)) == bits);
+    }
+
+    fn intTypeFromBitsAndSignRounded(self: *FuncGen, bits: u16, signed: bool) error{OutOfMemory}!Type {
+        const next_pow_two = math.log2_int_ceil(u16, bits);
+        const rounded_bits = @as(u32, 1) << next_pow_two;
+        return switch (rounded_bits) {
+            8, 16, 32 => if (signed) Type.initTag(.i32) else Type.initTag(.u32),
+            64 => if (signed) Type.initTag(.i64) else Type.initTag(.u64),
+            128 => if (signed) Type.initTag(.i128) else Type.initTag(.u128),
+            else => |big| if (signed)
+                Type.Tag.int_signed.create(
+                    self.dg.object.type_map_arena.allocator(),
+                    @intCast(u16, big),
+                )
+            else
+                Type.Tag.int_unsigned.create(
+                    self.dg.object.type_map_arena.allocator(),
+                    @intCast(u16, big),
+                ),
+        };
+    }
+
     fn airIntToFloat(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {
         if (self.liveness.isUnused(inst))
             return null;
 
+        const target = self.dg.module.getTarget();
         const ty_op = self.air.instructions.items(.data)[inst].ty_op;
-        const operand = try self.resolveInst(ty_op.operand);
-        const operand_ty = self.air.typeOf(ty_op.operand);
-        const operand_scalar_ty = operand_ty.scalarType();
+
+        var operand = try self.resolveInst(ty_op.operand);
+        var operand_ty = self.air.typeOf(ty_op.operand);
+        var operand_scalar_ty = operand_ty.scalarType();
+
+        {
+            const operand_bits = @intCast(u16, operand_scalar_ty.bitSize(target));
+            const is_signed = operand_scalar_ty.isSignedInt();
+
+            if (!isPowerOfTwo(operand_bits) or operand_bits < 32) {
+                const wider_ty = try self.intTypeFromBitsAndSignRounded(operand_bits, is_signed);
+                const wider_llvm_ty = try self.dg.llvmType(wider_ty);
+                if (is_signed) {
+                    operand = self.builder.buildSExt(operand, wider_llvm_ty, "");
+                } else {
+                    operand = self.builder.buildZExt(operand, wider_llvm_ty, "");
+                }
+                operand_ty = wider_ty;
+                operand_scalar_ty = operand_ty.scalarType();
+            }
+        }
+
         const dest_ty = self.air.typeOfIndex(inst);
+        const dest_scalar_ty = dest_ty.scalarType();
         const dest_llvm_ty = try self.dg.llvmType(dest_ty);
 
-        if (operand_scalar_ty.isSignedInt()) {
-            return self.builder.buildSIToFP(operand, dest_llvm_ty, "");
-        } else {
-            return self.builder.buildUIToFP(operand, dest_llvm_ty, "");
+        if (intrinsicsAllowed(dest_scalar_ty, target)) {
+            if (operand_scalar_ty.isSignedInt()) {
+                return self.builder.buildSIToFP(operand, dest_llvm_ty, "");
+            } else {
+                return self.builder.buildUIToFP(operand, dest_llvm_ty, "");
+            }
         }
+
+        const operand_bits = @intCast(u16, operand_scalar_ty.bitSize(target));
+        const compiler_rt_operand_abbrev = compilerRtIntAbbrev(operand_bits);
+
+        const dest_bits = dest_scalar_ty.floatBits(target);
+        const compiler_rt_dest_abbrev = compilerRtFloatAbbrev(dest_bits);
+
+        var fn_name_buf: [64]u8 = undefined;
+        const fn_name = if (operand_scalar_ty.isSignedInt())
+            std.fmt.bufPrintZ(&fn_name_buf, "__float{s}i{s}f", .{
+                compiler_rt_operand_abbrev,
+                compiler_rt_dest_abbrev,
+            }) catch unreachable
+        else
+            std.fmt.bufPrintZ(&fn_name_buf, "__floatun{s}i{s}f", .{
+                compiler_rt_operand_abbrev,
+                compiler_rt_dest_abbrev,
+            }) catch unreachable;
+
+        const operand_llvm_ty = try self.dg.llvmType(operand_ty);
+        const param_types = [1]*const llvm.Type{operand_llvm_ty};
+        const libc_fn = self.getLibcFunction(fn_name, &param_types, dest_llvm_ty);
+        const params = [1]*const llvm.Value{operand};
+
+        return self.builder.buildCall(libc_fn, &params, params.len, .C, .Auto, "");
     }
 
     fn airFloatToInt(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {
         if (self.liveness.isUnused(inst))
             return null;
 
+        const target = self.dg.module.getTarget();
         const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+
         const operand = try self.resolveInst(ty_op.operand);
-        const dest_ty = self.air.typeOfIndex(inst);
-        const dest_scalar_ty = dest_ty.scalarType();
+        const operand_ty = self.air.typeOf(ty_op.operand);
+        const operand_scalar_ty = operand_ty.scalarType();
+
+        var dest_ty = self.air.typeOfIndex(inst);
+        var dest_scalar_ty = dest_ty.scalarType();
+
+        if (intrinsicsAllowed(operand_scalar_ty, target)) {
+            // TODO set fast math flag
+            const dest_llvm_ty = try self.dg.llvmType(dest_ty);
+            if (dest_scalar_ty.isSignedInt()) {
+                return self.builder.buildFPToSI(operand, dest_llvm_ty, "");
+            } else {
+                return self.builder.buildFPToUI(operand, dest_llvm_ty, "");
+            }
+        }
+
+        const needs_truncating = blk: {
+            const dest_bits = @intCast(u16, dest_scalar_ty.bitSize(target));
+
+            if (!isPowerOfTwo(dest_bits) or dest_bits < 32) {
+                dest_ty = try self.intTypeFromBitsAndSignRounded(dest_bits, dest_scalar_ty.isSignedInt());
+                dest_scalar_ty = dest_ty.scalarType();
+                break :blk true;
+            }
+
+            break :blk false;
+        };
+
         const dest_llvm_ty = try self.dg.llvmType(dest_ty);
 
-        // TODO set fast math flag
+        const operand_bits = operand_scalar_ty.floatBits(target);
+        const compiler_rt_operand_abbrev = compilerRtFloatAbbrev(operand_bits);
 
-        if (dest_scalar_ty.isSignedInt()) {
-            return self.builder.buildFPToSI(operand, dest_llvm_ty, "");
-        } else {
-            return self.builder.buildFPToUI(operand, dest_llvm_ty, "");
+        const dest_bits = @intCast(u16, dest_scalar_ty.bitSize(target));
+        const compiler_rt_dest_abbrev = compilerRtIntAbbrev(dest_bits);
+
+        var fn_name_buf: [64]u8 = undefined;
+        const fn_name = if (dest_scalar_ty.isSignedInt())
+            std.fmt.bufPrintZ(&fn_name_buf, "__fix{s}f{s}i", .{
+                compiler_rt_operand_abbrev,
+                compiler_rt_dest_abbrev,
+            }) catch unreachable
+        else
+            std.fmt.bufPrintZ(&fn_name_buf, "__fixun{s}f{s}i", .{
+                compiler_rt_operand_abbrev,
+                compiler_rt_dest_abbrev,
+            }) catch unreachable;
+
+        const operand_llvm_ty = try self.dg.llvmType(operand_ty);
+        const param_types = [1]*const llvm.Type{operand_llvm_ty};
+        const libc_fn = self.getLibcFunction(fn_name, &param_types, dest_llvm_ty);
+        const params = [1]*const llvm.Value{operand};
+
+        const result = self.builder.buildCall(libc_fn, &params, params.len, .C, .Auto, "");
+
+        if (needs_truncating) {
+            const requested_ty = self.air.typeOfIndex(inst);
+            const requested_llvm_ty = try self.dg.llvmType(requested_ty);
+            return self.builder.buildTrunc(result, requested_llvm_ty, "");
         }
+
+        return result;
     }
 
     fn airSliceField(self: *FuncGen, inst: Air.Inst.Index, index: c_uint) !?*const llvm.Value {
@@ -5612,6 +5737,16 @@ pub const FuncGen = struct {
             80 => "x",
             128 => "t",
             else => unreachable,
+        };
+    }
+
+    fn compilerRtIntAbbrev(bits: u16) []const u8 {
+        return switch (bits) {
+            16 => "h",
+            32 => "s",
+            64 => "d",
+            128 => "t",
+            else => "o", // Non-standard
         };
     }
 

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -476,6 +476,14 @@ pub const Builder = opaque {
         Name: [*:0]const u8,
     ) *const Value;
 
+    pub const buildSExtOrBitCast = LLVMBuildSExtOrBitCast;
+    extern fn LLVMBuildSExtOrBitCast(
+        *const Builder,
+        Val: *const Value,
+        DestTy: *const Type,
+        Name: [*:0]const u8,
+    ) *const Value;
+
     pub const buildCall = ZigLLVMBuildCall;
     extern fn ZigLLVMBuildCall(
         *const Builder,

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -392,8 +392,9 @@ pub fn createEmpty(gpa: Allocator, options: link.Options) !*MachO {
     // Adhoc code signature is required when targeting aarch64-macos either directly or indirectly via the simulator
     // ABI such as aarch64-ios-simulator, etc.
     const requires_adhoc_codesig = cpu_arch == .aarch64 and (os_tag == .macos or abi == .simulator);
+    const use_llvm = build_options.have_llvm and options.use_llvm;
     const use_stage1 = build_options.is_stage1 and options.use_stage1;
-    const needs_prealloc = !(use_stage1 or options.cache_mode == .whole);
+    const needs_prealloc = !(use_stage1 or use_llvm or options.cache_mode == .whole);
 
     const self = try gpa.create(MachO);
     errdefer gpa.destroy(self);
@@ -410,7 +411,6 @@ pub fn createEmpty(gpa: Allocator, options: link.Options) !*MachO {
         .needs_prealloc = needs_prealloc,
     };
 
-    const use_llvm = build_options.have_llvm and options.use_llvm;
     if (use_llvm and !use_stage1) {
         self.llvm_object = try LlvmObject.create(gpa, options);
     }
@@ -571,7 +571,8 @@ pub fn flushModule(self: *MachO, comp: *Compilation, prog_node: *std.Progress.No
         if (mem.eql(u8, prev_digest, &digest)) {
             // Hot diggity dog! The output binary is already there.
 
-            if (use_stage1) {
+            const use_llvm = build_options.have_llvm and self.base.options.use_llvm;
+            if (use_llvm or use_stage1) {
                 log.debug("MachO Zld digest={s} match - skipping invocation", .{std.fmt.fmtSliceHexLower(&digest)});
                 self.base.lock = man.toOwnedLock();
                 return;
@@ -1025,7 +1026,8 @@ pub fn flushModule(self: *MachO, comp: *Compilation, prog_node: *std.Progress.No
         try self.createTentativeDefAtoms();
         try self.parseObjectsIntoAtoms();
 
-        if (use_stage1) {
+        const use_llvm = build_options.have_llvm and self.base.options.use_llvm;
+        if (use_llvm or use_stage1) {
             try self.sortSections();
             try self.allocateTextSegment();
             try self.allocateDataConstSegment();
@@ -1041,7 +1043,7 @@ pub fn flushModule(self: *MachO, comp: *Compilation, prog_node: *std.Progress.No
             self.logSectionOrdinals();
         }
 
-        if (use_stage1) {
+        if (use_llvm or use_stage1) {
             try self.writeAllAtoms();
         } else {
             try self.writeAtoms();
@@ -4930,12 +4932,13 @@ fn allocateSegment(self: *MachO, index: u16, offset: u64) !void {
     var start: u64 = offset;
     for (seg.sections.items) |*sect, sect_id| {
         const is_zerofill = sect.flags == macho.S_ZEROFILL or sect.flags == macho.S_THREAD_LOCAL_ZEROFILL;
+        const use_llvm = build_options.have_llvm and self.base.options.use_llvm;
         const use_stage1 = build_options.is_stage1 and self.base.options.use_stage1;
         const alignment = try math.powi(u32, 2, sect.@"align");
         const start_aligned = mem.alignForwardGeneric(u64, start, alignment);
 
         // TODO handle zerofill sections in stage2
-        sect.offset = if (is_zerofill and use_stage1) 0 else @intCast(u32, seg.inner.fileoff + start_aligned);
+        sect.offset = if (is_zerofill and (use_stage1 or use_llvm)) 0 else @intCast(u32, seg.inner.fileoff + start_aligned);
         sect.addr = seg.inner.vmaddr + start_aligned;
 
         // Recalculate section size given the allocated start address
@@ -4963,7 +4966,7 @@ fn allocateSegment(self: *MachO, index: u16, offset: u64) !void {
 
         start = start_aligned + sect.size;
 
-        if (!(is_zerofill and use_stage1)) {
+        if (!(is_zerofill and (use_stage1 or use_llvm))) {
             seg.inner.filesize = start;
         }
         seg.inner.vmsize = start;
@@ -5012,10 +5015,11 @@ fn initSection(
         sect.addr = seg.inner.vmaddr + off - seg.inner.fileoff;
 
         const is_zerofill = opts.flags == macho.S_ZEROFILL or opts.flags == macho.S_THREAD_LOCAL_ZEROFILL;
+        const use_llvm = build_options.have_llvm and self.base.options.use_llvm;
         const use_stage1 = build_options.is_stage1 and self.base.options.use_stage1;
 
         // TODO handle zerofill in stage2
-        if (!(is_zerofill and use_stage1)) {
+        if (!(is_zerofill and (use_stage1 or use_llvm))) {
             sect.offset = @intCast(u32, off);
         }
     }

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -519,7 +519,8 @@ pub fn flushModule(self: *MachO, comp: *Compilation, prog_node: *std.Progress.No
     var needs_full_relink = true;
 
     cache: {
-        if (use_stage1 and self.base.options.disable_lld_caching) break :cache;
+        if ((use_stage1 and self.base.options.disable_lld_caching) or self.base.options.cache_mode == .whole)
+            break :cache;
 
         man = comp.cache_parent.obtain();
 
@@ -1099,7 +1100,8 @@ pub fn flushModule(self: *MachO, comp: *Compilation, prog_node: *std.Progress.No
     }
 
     cache: {
-        if (use_stage1 and self.base.options.disable_lld_caching) break :cache;
+        if ((use_stage1 and self.base.options.disable_lld_caching) or self.base.options.cache_mode == .whole)
+            break :cache;
         // Update the file with the digest. If it fails we can continue; it only
         // means that the next invocation will have an unnecessary cache miss.
         Cache.writeSmallFile(cache_dir_handle, id_symlink_basename, &digest) catch |err| {

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -112,6 +112,42 @@ test "@intToFloat" {
     comptime try S.doTheTest();
 }
 
+test "@intToFloat(f80)" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        fn doTheTest(comptime Int: type) !void {
+            try testIntToFloat(Int, -2);
+        }
+
+        fn testIntToFloat(comptime Int: type, k: Int) !void {
+            const f = @intToFloat(f80, k);
+            const i = @floatToInt(Int, f);
+            try expect(i == k);
+        }
+    };
+    try S.doTheTest(i31);
+    try S.doTheTest(i32);
+    try S.doTheTest(i45);
+    try S.doTheTest(i64);
+    try S.doTheTest(i80);
+    try S.doTheTest(i128);
+    // try S.doTheTest(i256); // TODO missing compiler_rt symbols
+    comptime try S.doTheTest(i31);
+    comptime try S.doTheTest(i32);
+    comptime try S.doTheTest(i45);
+    comptime try S.doTheTest(i64);
+    comptime try S.doTheTest(i80);
+    comptime try S.doTheTest(i128);
+    comptime try S.doTheTest(i256);
+}
+
 test "@floatToInt" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -34,6 +34,7 @@ const TestTarget = struct {
     link_libc: bool = false,
     single_threaded: bool = false,
     disable_native: bool = false,
+    backend: ?std.builtin.CompilerBackend = null,
 };
 
 const test_targets = blk: {
@@ -42,15 +43,73 @@ const test_targets = blk: {
     // lot of branches)
     @setEvalBranchQuota(50000);
     break :blk [_]TestTarget{
-        TestTarget{},
-        TestTarget{
+        .{},
+        .{
             .link_libc = true,
         },
-        TestTarget{
+        .{
             .single_threaded = true,
         },
 
-        TestTarget{
+        .{
+            .link_libc = true,
+            .backend = .stage2_c,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .linux,
+                .abi = .none,
+            },
+            .backend = .stage2_x86_64,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .aarch64,
+                .os_tag = .linux,
+            },
+            .backend = .stage2_aarch64,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .wasm32,
+                .os_tag = .wasi,
+            },
+            .single_threaded = true,
+            .backend = .stage2_wasm,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .arm,
+                .os_tag = .linux,
+            },
+            .backend = .stage2_wasm,
+        },
+        .{
+            .target = CrossTarget.parse(.{
+                .arch_os_abi = "arm-linux-none",
+                .cpu_features = "generic+v8a",
+            }) catch unreachable,
+            .backend = .stage2_arm,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .aarch64,
+                .os_tag = .macos,
+                .abi = .gnu,
+            },
+            .backend = .stage2_aarch64,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .macos,
+                .abi = .gnu,
+            },
+            .backend = .stage2_x86_64,
+        },
+
+        .{
             .target = .{
                 .cpu_arch = .wasm32,
                 .os_tag = .wasi,
@@ -58,7 +117,7 @@ const test_targets = blk: {
             .link_libc = false,
             .single_threaded = true,
         },
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .wasm32,
                 .os_tag = .wasi,
@@ -67,14 +126,14 @@ const test_targets = blk: {
             .single_threaded = true,
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .x86_64,
                 .os_tag = .linux,
                 .abi = .none,
             },
         },
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .x86_64,
                 .os_tag = .linux,
@@ -82,7 +141,7 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .x86_64,
                 .os_tag = .linux,
@@ -91,14 +150,14 @@ const test_targets = blk: {
             .link_libc = true,
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .i386,
                 .os_tag = .linux,
                 .abi = .none,
             },
         },
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .i386,
                 .os_tag = .linux,
@@ -106,7 +165,7 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .i386,
                 .os_tag = .linux,
@@ -115,14 +174,14 @@ const test_targets = blk: {
             .link_libc = true,
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .aarch64,
                 .os_tag = .linux,
                 .abi = .none,
             },
         },
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .aarch64,
                 .os_tag = .linux,
@@ -130,7 +189,7 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .aarch64,
                 .os_tag = .linux,
@@ -138,7 +197,7 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .aarch64,
                 .os_tag = .windows,
@@ -147,13 +206,13 @@ const test_targets = blk: {
             .link_libc = true,
         },
 
-        TestTarget{
+        .{
             .target = CrossTarget.parse(.{
                 .arch_os_abi = "arm-linux-none",
                 .cpu_features = "generic+v8a",
             }) catch unreachable,
         },
-        TestTarget{
+        .{
             .target = CrossTarget.parse(.{
                 .arch_os_abi = "arm-linux-musleabihf",
                 .cpu_features = "generic+v8a",
@@ -161,7 +220,7 @@ const test_targets = blk: {
             .link_libc = true,
         },
         // https://github.com/ziglang/zig/issues/3287
-        //TestTarget{
+        //.{
         //    .target = CrossTarget.parse(.{
         //        .arch_os_abi = "arm-linux-gnueabihf",
         //        .cpu_features = "generic+v8a",
@@ -169,7 +228,7 @@ const test_targets = blk: {
         //    .link_libc = true,
         //},
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .mips,
                 .os_tag = .linux,
@@ -177,7 +236,7 @@ const test_targets = blk: {
             },
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .mips,
                 .os_tag = .linux,
@@ -187,7 +246,7 @@ const test_targets = blk: {
         },
 
         // https://github.com/ziglang/zig/issues/4927
-        //TestTarget{
+        //.{
         //    .target = .{
         //        .cpu_arch = .mips,
         //        .os_tag = .linux,
@@ -196,7 +255,7 @@ const test_targets = blk: {
         //    .link_libc = true,
         //},
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .mipsel,
                 .os_tag = .linux,
@@ -204,7 +263,7 @@ const test_targets = blk: {
             },
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .mipsel,
                 .os_tag = .linux,
@@ -214,7 +273,7 @@ const test_targets = blk: {
         },
 
         // https://github.com/ziglang/zig/issues/4927
-        //TestTarget{
+        //.{
         //    .target = .{
         //        .cpu_arch = .mipsel,
         //        .os_tag = .linux,
@@ -223,14 +282,14 @@ const test_targets = blk: {
         //    .link_libc = true,
         //},
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .powerpc,
                 .os_tag = .linux,
                 .abi = .none,
             },
         },
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .powerpc,
                 .os_tag = .linux,
@@ -239,7 +298,7 @@ const test_targets = blk: {
             .link_libc = true,
         },
         // https://github.com/ziglang/zig/issues/2256
-        //TestTarget{
+        //.{
         //    .target = .{
         //        .cpu_arch = .powerpc,
         //        .os_tag = .linux,
@@ -248,7 +307,7 @@ const test_targets = blk: {
         //    .link_libc = true,
         //},
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .riscv64,
                 .os_tag = .linux,
@@ -256,7 +315,7 @@ const test_targets = blk: {
             },
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .riscv64,
                 .os_tag = .linux,
@@ -266,7 +325,7 @@ const test_targets = blk: {
         },
 
         // https://github.com/ziglang/zig/issues/3340
-        //TestTarget{
+        //.{
         //    .target = .{
         //        .cpu_arch = .riscv64,
         //        .os = .linux,
@@ -275,7 +334,7 @@ const test_targets = blk: {
         //    .link_libc = true,
         //},
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .x86_64,
                 .os_tag = .macos,
@@ -283,7 +342,7 @@ const test_targets = blk: {
             },
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .aarch64,
                 .os_tag = .macos,
@@ -291,7 +350,7 @@ const test_targets = blk: {
             },
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .i386,
                 .os_tag = .windows,
@@ -299,7 +358,7 @@ const test_targets = blk: {
             },
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .x86_64,
                 .os_tag = .windows,
@@ -307,7 +366,7 @@ const test_targets = blk: {
             },
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .i386,
                 .os_tag = .windows,
@@ -316,7 +375,7 @@ const test_targets = blk: {
             .link_libc = true,
         },
 
-        TestTarget{
+        .{
             .target = .{
                 .cpu_arch = .x86_64,
                 .os_tag = .windows,
@@ -326,38 +385,38 @@ const test_targets = blk: {
         },
 
         // Do the release tests last because they take a long time
-        TestTarget{
+        .{
             .mode = .ReleaseFast,
         },
-        TestTarget{
+        .{
             .link_libc = true,
             .mode = .ReleaseFast,
         },
-        TestTarget{
+        .{
             .mode = .ReleaseFast,
             .single_threaded = true,
         },
 
-        TestTarget{
+        .{
             .mode = .ReleaseSafe,
         },
-        TestTarget{
+        .{
             .link_libc = true,
             .mode = .ReleaseSafe,
         },
-        TestTarget{
+        .{
             .mode = .ReleaseSafe,
             .single_threaded = true,
         },
 
-        TestTarget{
+        .{
             .mode = .ReleaseSmall,
         },
-        TestTarget{
+        .{
             .link_libc = true,
             .mode = .ReleaseSmall,
         },
-        TestTarget{
+        .{
             .mode = .ReleaseSmall,
             .single_threaded = true,
         },
@@ -524,6 +583,9 @@ pub fn addPkgTests(
     skip_single_threaded: bool,
     skip_non_native: bool,
     skip_libc: bool,
+    skip_stage1: bool,
+    skip_stage2: bool,
+    is_stage1: bool,
 ) *build.Step {
     const step = b.step(b.fmt("test-{s}", .{name}), desc);
 
@@ -549,6 +611,11 @@ pub fn addPkgTests(
             continue;
         }
 
+        if (test_target.backend) |backend| switch (backend) {
+            .stage1 => if (skip_stage1) continue,
+            else => if (skip_stage2) continue,
+        } else if (is_stage1 and skip_stage1) continue;
+
         const want_this_mode = for (modes) |m| {
             if (m == test_target.mode) break true;
         } else false;
@@ -565,12 +632,14 @@ pub fn addPkgTests(
 
         const these_tests = b.addTest(root_src);
         const single_threaded_txt = if (test_target.single_threaded) "single" else "multi";
-        these_tests.setNamePrefix(b.fmt("{s}-{s}-{s}-{s}-{s} ", .{
+        const backend_txt = if (test_target.backend) |backend| @tagName(backend) else "default";
+        these_tests.setNamePrefix(b.fmt("{s}-{s}-{s}-{s}-{s}-{s} ", .{
             name,
             triple_prefix,
             @tagName(test_target.mode),
             libc_prefix,
             single_threaded_txt,
+            backend_txt,
         }));
         these_tests.single_threaded = test_target.single_threaded;
         these_tests.setFilter(test_filter);
@@ -581,6 +650,24 @@ pub fn addPkgTests(
         }
         these_tests.overrideZigLibDir("lib");
         these_tests.addIncludePath("test");
+        if (test_target.backend) |backend| switch (backend) {
+            .stage1 => {
+                these_tests.use_stage1 = true;
+            },
+            .stage2_llvm => {
+                these_tests.use_stage1 = false;
+                these_tests.use_llvm = true;
+            },
+            .stage2_c => {
+                these_tests.use_stage1 = false;
+                these_tests.use_llvm = false;
+                these_tests.ofmt = .c;
+            },
+            else => {
+                these_tests.use_stage1 = false;
+                these_tests.use_llvm = false;
+            },
+        };
 
         step.dependOn(&these_tests.step);
     }


### PR DESCRIPTION
We can't yet run the behavior tests with stage3, but at least we can run
them with stage2, and we can use the proper test matrix.

This commit also adds use_llvm and ofmt to the zig build system.