### PR TITLE
stage2: error return traces

### DIFF
--- a/lib/compiler_rt.zig
+++ b/lib/compiler_rt.zig
@@ -198,19 +198,17 @@ comptime {
     const __trunctfxf2 = @import("compiler_rt/trunc_f80.zig").__trunctfxf2;
     @export(__trunctfxf2, .{ .name = "__trunctfxf2", .linkage = linkage });
 
-    if (builtin.zig_backend == .stage1) { // TODO
-        switch (arch) {
-            .i386,
-            .x86_64,
-            => {
-                const zig_probe_stack = @import("compiler_rt/stack_probe.zig").zig_probe_stack;
-                @export(zig_probe_stack, .{
-                    .name = "__zig_probe_stack",
-                    .linkage = linkage,
-                });
-            },
-            else => {},
-        }
+    switch (arch) {
+        .i386,
+        .x86_64,
+        => {
+            const zig_probe_stack = @import("compiler_rt/stack_probe.zig").zig_probe_stack;
+            @export(zig_probe_stack, .{
+                .name = "__zig_probe_stack",
+                .linkage = linkage,
+            });
+        },
+        else => {},
     }
 
     const __unordsf2 = @import("compiler_rt/compareXf2.zig").__unordsf2;

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -847,7 +847,13 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace) noreturn
 }
 
 pub fn panicUnwrapError(st: ?*StackTrace, err: anyerror) noreturn {
+    @setCold(true);
     std.debug.panicExtra(st, "attempt to unwrap error: {s}", .{@errorName(err)});
+}
+
+pub fn panicOutOfBounds(index: usize, len: usize) noreturn {
+    @setCold(true);
+    std.debug.panic("attempt to index out of bound: index {d}, len {d}", .{ index, len });
 }
 
 pub noinline fn returnError(maybe_st: ?*StackTrace) void {

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -846,5 +846,16 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace) noreturn
     }
 }
 
+pub noinline fn returnError(maybe_st: ?*StackTrace) void {
+    @setCold(true);
+    const st = maybe_st orelse return;
+    addErrRetTraceAddr(st, @returnAddress());
+}
+
+pub inline fn addErrRetTraceAddr(st: *StackTrace, addr: usize) void {
+    st.instruction_addresses[st.index & (st.instruction_addresses.len - 1)] = addr;
+    st.index +%= 1;
+}
+
 const std = @import("std.zig");
 const root = @import("root");

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -846,6 +846,10 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace) noreturn
     }
 }
 
+pub fn panicUnwrapError(st: ?*StackTrace, err: anyerror) noreturn {
+    std.debug.panicExtra(st, "attempt to unwrap error: {s}", .{@errorName(err)});
+}
+
 pub noinline fn returnError(maybe_st: ?*StackTrace) void {
     @setCold(true);
     const st = maybe_st orelse return;

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -92,9 +92,9 @@ pub fn main() void {
                 fail_count += 1;
                 progress.log("FAIL ({s})\n", .{@errorName(err)});
                 if (!have_tty) std.debug.print("FAIL ({s})\n", .{@errorName(err)});
-                if (builtin.zig_backend != .stage2_llvm) if (@errorReturnTrace()) |trace| {
+                if (@errorReturnTrace()) |trace| {
                     std.debug.dumpStackTrace(trace.*);
-                };
+                }
                 test_node.end();
             },
         }

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -649,6 +649,12 @@ pub const Inst = struct {
         /// flush().
         cmp_lt_errors_len,
 
+        /// Returns pointer to current error return trace.
+        err_return_trace,
+
+        /// Sets the operand as the current error return trace,
+        set_err_return_trace,
+
         pub fn fromCmpOp(op: std.math.CompareOperator) Tag {
             return switch (op) {
                 .lt => .cmp_lt,
@@ -961,6 +967,7 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .alloc,
         .ret_ptr,
         .arg,
+        .err_return_trace,
         => return datas[inst].ty,
 
         .assembly,
@@ -1048,6 +1055,7 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .memcpy,
         .set_union_tag,
         .prefetch,
+        .set_err_return_trace,
         => return Type.void,
 
         .ptrtoint,

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1457,7 +1457,8 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
         errdefer if (module) |zm| zm.deinit();
 
         const error_return_tracing = !strip and switch (options.optimize_mode) {
-            .Debug, .ReleaseSafe => true,
+            .Debug, .ReleaseSafe => (!options.target.isWasm() or options.target.os.tag == .emscripten) and
+                !options.target.cpu.arch.isBpf(),
             .ReleaseFast, .ReleaseSmall => false,
         };
 

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -362,6 +362,7 @@ fn analyzeInst(
         .ret_addr,
         .frame_addr,
         .wasm_memory_size,
+        .err_return_trace,
         => return trackOperands(a, new_set, inst, main_tomb, .{ .none, .none, .none }),
 
         .not,
@@ -434,6 +435,7 @@ fn analyzeInst(
         .round,
         .trunc_float,
         .cmp_lt_errors_len,
+        .set_err_return_trace,
         => {
             const operand = inst_datas[inst].un_op;
             return trackOperands(a, new_set, inst, main_tomb, .{ operand, .none, .none });

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1427,6 +1427,7 @@ pub const Fn = struct {
     state: Analysis,
     is_cold: bool = false,
     is_noinline: bool = false,
+    calls_or_awaits_errorable_fn: bool = false,
 
     /// Any inferred error sets that this function owns, both its own inferred error set and
     /// inferred error sets of any inline/comptime functions called. Not to be confused
@@ -4838,6 +4839,9 @@ pub fn analyzeFnBody(mod: *Module, func: *Fn, arena: Allocator) SemaError!Air {
     };
     defer sema.deinit();
 
+    // reset in case case calls to errorable functions are removed.
+    func.calls_or_awaits_errorable_fn = false;
+
     // First few indexes of extra are reserved and set at the end.
     const reserved_count = @typeInfo(Air.ExtraIndex).Enum.fields.len;
     try sema.air_extra.ensureTotalCapacity(gpa, reserved_count);
@@ -4936,6 +4940,8 @@ pub fn analyzeFnBody(mod: *Module, func: *Fn, arena: Allocator) SemaError!Air {
     func.state = .in_progress;
     log.debug("set {s} to in_progress", .{decl.name});
 
+    const last_arg_index = inner_block.instructions.items.len;
+
     sema.analyzeBody(&inner_block, fn_info.body) catch |err| switch (err) {
         // TODO make these unreachable instead of @panic
         error.NeededSourceLocation => @panic("zig compiler bug: NeededSourceLocation"),
@@ -4943,6 +4949,21 @@ pub fn analyzeFnBody(mod: *Module, func: *Fn, arena: Allocator) SemaError!Air {
         error.ComptimeReturn => @panic("zig compiler bug: ComptimeReturn"),
         else => |e| return e,
     };
+
+    // If we don't get an error return trace from a caller, create our own.
+    if (func.calls_or_awaits_errorable_fn and
+        mod.comp.bin_file.options.error_return_tracing and
+        !sema.fn_ret_ty.isError())
+    {
+        sema.setupErrorReturnTrace(&inner_block, last_arg_index) catch |err| switch (err) {
+            // TODO make these unreachable instead of @panic
+            error.NeededSourceLocation => @panic("zig compiler bug: NeededSourceLocation"),
+            error.GenericPoison => @panic("zig compiler bug: GenericPoison"),
+            error.ComptimeReturn => @panic("zig compiler bug: ComptimeReturn"),
+            error.ComptimeBreak => @panic("zig compiler bug: ComptimeBreak"),
+            else => |e| return e,
+        };
+    }
 
     try wip_captures.finalize();
 

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4839,7 +4839,7 @@ pub fn analyzeFnBody(mod: *Module, func: *Fn, arena: Allocator) SemaError!Air {
     };
     defer sema.deinit();
 
-    // reset in case case calls to errorable functions are removed.
+    // reset in case calls to errorable functions are removed.
     func.calls_or_awaits_errorable_fn = false;
 
     // First few indexes of extra are reserved and set at the end.

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -12658,7 +12658,8 @@ fn analyzeRet(
     const backend_supports_error_return_tracing =
         sema.mod.comp.bin_file.options.use_llvm;
 
-    if (sema.fn_ret_ty.isError() and sema.mod.comp.bin_file.options.error_return_tracing and
+    if ((sema.fn_ret_ty.zigTypeTag() == .ErrorSet or sema.typeOf(uncasted_operand).zigTypeTag() == .ErrorUnion) and
+        sema.mod.comp.bin_file.options.error_return_tracing and
         backend_supports_error_return_tracing)
     {
         const return_err_fn = try sema.getBuiltin(block, src, "returnError");

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -718,6 +718,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .unwrap_errunion_err_ptr    => try self.airUnwrapErrErrPtr(inst),
             .unwrap_errunion_payload_ptr=> try self.airUnwrapErrPayloadPtr(inst),
             .errunion_payload_ptr_set   => try self.airErrUnionPayloadPtrSet(inst),
+            .err_return_trace           => try self.airErrReturnTrace(inst),
+            .set_err_return_trace       => try self.airSetErrReturnTrace(inst),
 
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
@@ -2327,6 +2329,24 @@ fn airUnwrapErrPayloadPtr(self: *Self, inst: Air.Inst.Index) !void {
 fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement .errunion_payload_ptr_set for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement airErrReturnTrace for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airSetErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -2333,21 +2333,17 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    _ = inst;
     const result: MCValue = if (self.liveness.isUnused(inst))
         .dead
     else
         return self.fail("TODO implement airErrReturnTrace for {}", .{self.target.cpu.arch});
-    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+    return self.finishAir(inst, result, .{ .none, .none, .none });
 }
 
 fn airSetErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
-    const result: MCValue = if (self.liveness.isUnused(inst))
-        .dead
-    else
-        return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
-    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+    _ = inst;
+    return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
 }
 
 fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -725,6 +725,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .unwrap_errunion_err_ptr    => try self.airUnwrapErrErrPtr(inst),
             .unwrap_errunion_payload_ptr=> try self.airUnwrapErrPayloadPtr(inst),
             .errunion_payload_ptr_set   => try self.airErrUnionPayloadPtrSet(inst),
+            .err_return_trace           => try self.airErrReturnTrace(inst),
+            .set_err_return_trace       => try self.airSetErrReturnTrace(inst),
 
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
@@ -1840,6 +1842,24 @@ fn airUnwrapErrPayloadPtr(self: *Self, inst: Air.Inst.Index) !void {
 fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement .errunion_payload_ptr_set for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement airErrReturnTrace for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airSetErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -1846,21 +1846,17 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    _ = inst;
     const result: MCValue = if (self.liveness.isUnused(inst))
         .dead
     else
         return self.fail("TODO implement airErrReturnTrace for {}", .{self.target.cpu.arch});
-    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+    return self.finishAir(inst, result, .{ .none, .none, .none });
 }
 
 fn airSetErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
-    const result: MCValue = if (self.liveness.isUnused(inst))
-        .dead
-    else
-        return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
-    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+    _ = inst;
+    return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
 }
 
 /// T to E!T

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -654,6 +654,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .unwrap_errunion_err_ptr    => try self.airUnwrapErrErrPtr(inst),
             .unwrap_errunion_payload_ptr=> try self.airUnwrapErrPayloadPtr(inst),
             .errunion_payload_ptr_set   => try self.airErrUnionPayloadPtrSet(inst),
+            .err_return_trace           => try self.airErrReturnTrace(inst),
+            .set_err_return_trace       => try self.airSetErrReturnTrace(inst),
 
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
@@ -1264,6 +1266,24 @@ fn airUnwrapErrPayloadPtr(self: *Self, inst: Air.Inst.Index) !void {
 fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else return self.fail("TODO implement .errunion_payload_ptr_set for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement airErrReturnTrace for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airSetErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1270,21 +1270,17 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    _ = inst;
     const result: MCValue = if (self.liveness.isUnused(inst))
         .dead
     else
         return self.fail("TODO implement airErrReturnTrace for {}", .{self.target.cpu.arch});
-    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+    return self.finishAir(inst, result, .{ .none, .none, .none });
 }
 
 fn airSetErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
-    const result: MCValue = if (self.liveness.isUnused(inst))
-        .dead
-    else
-        return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
-    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+    _ = inst;
+    return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
 }
 
 fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -630,6 +630,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .unwrap_errunion_err_ptr    => @panic("TODO try self.airUnwrapErrErrPtr(inst)"),
             .unwrap_errunion_payload_ptr=> @panic("TODO try self.airUnwrapErrPayloadPtr(inst)"),
             .errunion_payload_ptr_set   => @panic("TODO try self.airErrUnionPayloadPtrSet(inst)"),
+            .err_return_trace           => @panic("TODO try self.airErrReturnTrace(inst)"),
+            .set_err_return_trace       => @panic("TODO try self.airSetErrReturnTrace(inst)"),
 
             .wrap_optional         => @panic("TODO try self.airWrapOptional(inst)"),
             .wrap_errunion_payload => @panic("TODO try self.airWrapErrUnionPayload(inst)"),

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1612,6 +1612,8 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .atomic_store_seq_cst,
         .atomic_rmw,
         .tag_name,
+        .err_return_trace,
+        .set_err_return_trace,
         => |tag| return self.fail("TODO: Implement wasm inst: {s}", .{@tagName(tag)}),
     };
 }

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -1858,21 +1858,17 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    _ = inst;
     const result: MCValue = if (self.liveness.isUnused(inst))
         .dead
     else
         return self.fail("TODO implement airErrReturnTrace for {}", .{self.target.cpu.arch});
-    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+    return self.finishAir(inst, result, .{ .none, .none, .none });
 }
 
 fn airSetErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
-    const result: MCValue = if (self.liveness.isUnused(inst))
-        .dead
-    else
-        return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
-    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+    _ = inst;
+    return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
 }
 
 fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -749,6 +749,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .unwrap_errunion_err_ptr    => try self.airUnwrapErrErrPtr(inst),
             .unwrap_errunion_payload_ptr=> try self.airUnwrapErrPayloadPtr(inst),
             .errunion_payload_ptr_set   => try self.airErrUnionPayloadPtrSet(inst),
+            .err_return_trace           => try self.airErrReturnTrace(inst),
+            .set_err_return_trace       => try self.airSetErrReturnTrace(inst),
 
             .wrap_optional         => try self.airWrapOptional(inst),
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
@@ -1852,6 +1854,24 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
         .dead
     else
         return self.fail("TODO implement .errunion_payload_ptr_set for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement airErrReturnTrace for {}", .{self.target.cpu.arch});
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
+}
+
+fn airSetErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+    const result: MCValue = if (self.liveness.isUnused(inst))
+        .dead
+    else
+        return self.fail("TODO implement airSetErrReturnTrace for {}", .{self.target.cpu.arch});
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1911,6 +1911,8 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .wrap_errunion_payload       => try airWrapErrUnionPay(f, inst),
             .wrap_errunion_err           => try airWrapErrUnionErr(f, inst),
             .errunion_payload_ptr_set    => try airErrUnionPayloadPtrSet(f, inst),
+            .err_return_trace            => try airErrReturnTrace(f, inst),
+            .set_err_return_trace        => try airSetErrReturnTrace(f, inst),
 
             .wasm_memory_size => try airWasmMemorySize(f, inst),
             .wasm_memory_grow => try airWasmMemoryGrow(f, inst),
@@ -3445,6 +3447,38 @@ fn airErrUnionPayloadPtrSet(f: *Function, inst: Air.Inst.Index) !CValue {
     try f.writeCValueDeref(writer, operand);
     try writer.writeAll(").payload;\n");
     return local;
+}
+
+fn airErrReturnTrace(f: *Function, inst: Air.Inst.Index) !CValue {
+    if (f.liveness.isUnused(inst)) return CValue.none;
+
+    const un_op = f.air.instructions.items(.data)[inst].un_op;
+    const writer = f.object.writer();
+    const inst_ty = f.air.typeOfIndex(inst);
+    const operand = try f.resolveInst(un_op);
+    const local = try f.allocLocal(inst_ty, .Const);
+
+    try writer.writeAll(" = ");
+
+    _ = operand;
+    _ = local;
+    return f.fail("TODO: C backend: implement airErrReturnTrace", .{});
+}
+
+fn airSetErrReturnTrace(f: *Function, inst: Air.Inst.Index) !CValue {
+    if (f.liveness.isUnused(inst)) return CValue.none;
+
+    const un_op = f.air.instructions.items(.data)[inst].un_op;
+    const writer = f.object.writer();
+    const inst_ty = f.air.typeOfIndex(inst);
+    const operand = try f.resolveInst(un_op);
+    const local = try f.allocLocal(inst_ty, .Const);
+
+    try writer.writeAll(" = ");
+
+    _ = operand;
+    _ = local;
+    return f.fail("TODO: C backend: implement airSetErrReturnTrace", .{});
 }
 
 fn airWrapErrUnionPay(f: *Function, inst: Air.Inst.Index) !CValue {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -3451,33 +3451,11 @@ fn airErrUnionPayloadPtrSet(f: *Function, inst: Air.Inst.Index) !CValue {
 
 fn airErrReturnTrace(f: *Function, inst: Air.Inst.Index) !CValue {
     if (f.liveness.isUnused(inst)) return CValue.none;
-
-    const un_op = f.air.instructions.items(.data)[inst].un_op;
-    const writer = f.object.writer();
-    const inst_ty = f.air.typeOfIndex(inst);
-    const operand = try f.resolveInst(un_op);
-    const local = try f.allocLocal(inst_ty, .Const);
-
-    try writer.writeAll(" = ");
-
-    _ = operand;
-    _ = local;
     return f.fail("TODO: C backend: implement airErrReturnTrace", .{});
 }
 
 fn airSetErrReturnTrace(f: *Function, inst: Air.Inst.Index) !CValue {
-    if (f.liveness.isUnused(inst)) return CValue.none;
-
-    const un_op = f.air.instructions.items(.data)[inst].un_op;
-    const writer = f.object.writer();
-    const inst_ty = f.air.typeOfIndex(inst);
-    const operand = try f.resolveInst(un_op);
-    const local = try f.allocLocal(inst_ty, .Const);
-
-    try writer.writeAll(" = ");
-
-    _ = operand;
-    _ = local;
+    _ = inst;
     return f.fail("TODO: C backend: implement airSetErrReturnTrace", .{});
 }
 

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -637,7 +637,7 @@ pub const Object = struct {
         const gpa = dg.gpa;
 
         const err_return_tracing = fn_info.return_type.isError() and
-            dg.module.comp.bin_file.options.error_return_tracing;
+            dg.module.comp.bin_file.options.error_return_tracing and false;
 
         const err_ret_trace = if (err_return_tracing)
             llvm_func.getParam(@boolToInt(ret_ptr != null))
@@ -1765,7 +1765,7 @@ pub const Object = struct {
                 }
 
                 if (fn_info.return_type.isError() and
-                    o.module.comp.bin_file.options.error_return_tracing)
+                    o.module.comp.bin_file.options.error_return_tracing and false)
                 {
                     var ptr_ty_payload: Type.Payload.ElemType = .{
                         .base = .{ .tag = .single_mut_pointer },
@@ -2018,7 +2018,7 @@ pub const DeclGen = struct {
         }
 
         const err_return_tracing = fn_info.return_type.isError() and
-            dg.module.comp.bin_file.options.error_return_tracing;
+            dg.module.comp.bin_file.options.error_return_tracing and false;
 
         if (err_return_tracing) {
             dg.addArgAttr(llvm_fn, @boolToInt(sret), "nonnull");
@@ -2484,7 +2484,7 @@ pub const DeclGen = struct {
                 }
 
                 if (fn_info.return_type.isError() and
-                    dg.module.comp.bin_file.options.error_return_tracing)
+                    dg.module.comp.bin_file.options.error_return_tracing and false)
                 {
                     var ptr_ty_payload: Type.Payload.ElemType = .{
                         .base = .{ .tag = .single_mut_pointer },
@@ -3796,7 +3796,7 @@ pub const FuncGen = struct {
         };
 
         if (fn_info.return_type.isError() and
-            self.dg.module.comp.bin_file.options.error_return_tracing)
+            self.dg.module.comp.bin_file.options.error_return_tracing and false)
         {
             try llvm_args.append(self.err_ret_trace.?);
         }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -637,7 +637,7 @@ pub const Object = struct {
         const gpa = dg.gpa;
 
         const err_return_tracing = fn_info.return_type.isError() and
-            dg.module.comp.bin_file.options.error_return_tracing and false;
+            dg.module.comp.bin_file.options.error_return_tracing;
 
         const err_ret_trace = if (err_return_tracing)
             llvm_func.getParam(@boolToInt(ret_ptr != null))
@@ -698,6 +698,9 @@ pub const Object = struct {
 
             const lexical_block = dib.createLexicalBlock(subprogram.toScope(), di_file.?, line_number, 1);
             di_scope = lexical_block.toScope();
+
+            // Setup a debug location in case there is a call to `returnError` before a `.dbg_stmt`.
+            builder.setCurrentDebugLocation(line_number + func.lbrace_line, func.lbrace_column, di_scope.?, null);
         }
 
         var fg: FuncGen = .{
@@ -1765,7 +1768,7 @@ pub const Object = struct {
                 }
 
                 if (fn_info.return_type.isError() and
-                    o.module.comp.bin_file.options.error_return_tracing and false)
+                    o.module.comp.bin_file.options.error_return_tracing)
                 {
                     var ptr_ty_payload: Type.Payload.ElemType = .{
                         .base = .{ .tag = .single_mut_pointer },
@@ -2018,7 +2021,7 @@ pub const DeclGen = struct {
         }
 
         const err_return_tracing = fn_info.return_type.isError() and
-            dg.module.comp.bin_file.options.error_return_tracing and false;
+            dg.module.comp.bin_file.options.error_return_tracing;
 
         if (err_return_tracing) {
             dg.addArgAttr(llvm_fn, @boolToInt(sret), "nonnull");
@@ -2484,7 +2487,7 @@ pub const DeclGen = struct {
                 }
 
                 if (fn_info.return_type.isError() and
-                    dg.module.comp.bin_file.options.error_return_tracing and false)
+                    dg.module.comp.bin_file.options.error_return_tracing)
                 {
                     var ptr_ty_payload: Type.Payload.ElemType = .{
                         .base = .{ .tag = .single_mut_pointer },
@@ -3796,7 +3799,7 @@ pub const FuncGen = struct {
         };
 
         if (fn_info.return_type.isError() and
-            self.dg.module.comp.bin_file.options.error_return_tracing and false)
+            self.dg.module.comp.bin_file.options.error_return_tracing)
         {
             try llvm_args.append(self.err_ret_trace.?);
         }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -698,9 +698,6 @@ pub const Object = struct {
 
             const lexical_block = dib.createLexicalBlock(subprogram.toScope(), di_file.?, line_number, 1);
             di_scope = lexical_block.toScope();
-
-            // Setup a debug location in case there is a call to `returnError` before a `.dbg_stmt`.
-            builder.setCurrentDebugLocation(line_number + func.lbrace_line, func.lbrace_column, di_scope.?, null);
         }
 
         var fg: FuncGen = .{

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -170,6 +170,7 @@ const Writer = struct {
             .round,
             .trunc_float,
             .cmp_lt_errors_len,
+            .set_err_return_trace,
             => try w.writeUnOp(s, inst),
 
             .breakpoint,
@@ -182,6 +183,7 @@ const Writer = struct {
             .alloc,
             .ret_ptr,
             .arg,
+            .err_return_trace,
             => try w.writeTy(s, inst),
 
             .not,

--- a/src/type.zig
+++ b/src/type.zig
@@ -4093,6 +4093,13 @@ pub const Type = extern union {
         };
     }
 
+    pub fn isError(ty: Type) bool {
+        return switch (ty.zigTypeTag()) {
+            .ErrorUnion, .ErrorSet => true,
+            else => false,
+        };
+    }
+
     /// Returns whether ty, which must be an error set, includes an error `name`.
     /// Might return a false negative if `ty` is an inferred error set and not fully
     /// resolved yet.


### PR DESCRIPTION
~~Currently disabled on all targets because LLVM is being a dick and I'm too tired to fight it.~~
```sh-session
$ zig2 test test/behavior.zig -I test -fLLVM    -target aarch64-linux
LLVM Emit Object... 
inlinable function call in a function with debug info must have a !dbg location
  call fastcc void @builtin.returnError(%builtin.StackTrace* %0) #13
inlinable function call in a function with debug info must have a !dbg location
  call fastcc void @builtin.returnError(%builtin.StackTrace* %0) #13
inlinable function call in a function with debug info must have a !dbg location
  call fastcc void @builtin.returnError(%builtin.StackTrace* %0) #13
inlinable function call in a function with debug info must have a !dbg location
  call fastcc void @builtin.returnError(%builtin.StackTrace* %0) #13
```
Not that it was that useful anyways:
```sh-session
$ zig2 run a.zig
error: Foo
???:?:?: 0x20b078 in ??? (???)
???:?:?: 0x20b145 in ??? (???)
```

I tried to do as much as possible in Sema without touching parameters, if that is also desired it should be done alongside the `begin_call/end_call` change.

Closes  #11259
Closes #11084