### PR TITLE
std: fix crypto and hash benchmark

### DIFF
--- a/lib/std/hash/benchmark.zig
+++ b/lib/std/hash/benchmark.zig
@@ -230,7 +230,7 @@ pub fn main() !void {
     inline for (hashes) |H| {
         if (filter == null or std.mem.indexOf(u8, H.name, filter.?) != null) {
             if (!test_iterative_only or H.has_iterative_api) {
-                try stdout.print("{}\n", .{H.name});
+                try stdout.print("{s}\n", .{H.name});
 
                 // Always reseed prior to every call so we are hashing the same buffer contents.
                 // This allows easier comparison between different implementations.


### PR DESCRIPTION
Hi! 

I stumbled upon crypto and hash benchmarks in std lib and noticed they don't compile. This PR should've fixed it.
Test run results on my box:

```
# zigstage2 run -O ReleaseFast --zig-lib-dir ../.. benchmark.zig  -- --key-size 128
wyhash
   iterative:  8516 MiB/s [84b9fcc452c9983b]
  small keys: 10375 MiB/s [c5c45b09b8000000]
fnv1a
   iterative:  1072 MiB/s [1e3d9d378e4b7325]
  small keys:  1319 MiB/s [a799f41e7c700000]
adler32
   iterative:  2865 MiB/s [a302147400000000]
  small keys:  2862 MiB/s [95923dd300000000]
crc32-slicing-by-8
   iterative:  2832 MiB/s [ab94acd000000000]
  small keys:  3456 MiB/s [9c2cae1900000000]
crc32-half-byte-lookup
   iterative:   266 MiB/s [ab94acd000000000]
  small keys:   279 MiB/s [9c2cae1900000000]
cityhash-32
  small keys:  6425 MiB/s [a22f04f100000000]
cityhash-64
  small keys: 16707 MiB/s [4efcdec62d500000]
murmur2-32
  small keys:  5448 MiB/s [99b2d09c00000000]
murmur2-64
  small keys: 11055 MiB/s [b7bf5c5e7a000000]
murmur3-32
  small keys:  4323 MiB/s [427a915800000000]
```

```
# zig run -O ReleaseFast  --zig-lib-dir ../.. benchmark.zig
              md5:        561 MiB/s
             sha1:        615 MiB/s
           sha256:        318 MiB/s
           sha512:        460 MiB/s
         sha3-256:        427 MiB/s
         sha3-512:        229 MiB/s
       gimli-hash:        318 MiB/s
          blake2s:        556 MiB/s
          blake2b:        949 MiB/s
           blake3:        927 MiB/s
            ghash:       1805 MiB/s
         poly1305:       2177 MiB/s
         hmac-md5:        706 MiB/s
        hmac-sha1:        729 MiB/s
      hmac-sha256:        339 MiB/s
      hmac-sha512:        489 MiB/s
      siphash-2-4:       2706 MiB/s
      siphash-1-3:       5106 MiB/s
   siphash128-2-4:       2653 MiB/s
   siphash128-1-3:       5024 MiB/s
           x25519:      25852 exchanges/s
          ed25519:      22013 signatures/s
          ed25519:      17240 verifications/s
          ed25519:      38144 verifications/s (batch)
chacha20Poly1305:        556 MiB/s
xchacha20Poly1305:        554 MiB/s
xchacha8Poly1305:        872 MiB/s
xsalsa20Poly1305:        513 MiB/s
       gimli-aead:        274 MiB/s
       aegis-128l:      16928 MiB/s
        aegis-256:      10071 MiB/s
       aes128-gcm:       1386 MiB/s
       aes256-gcm:       1315 MiB/s
       aes128-ocb:       6787 MiB/s
       aes256-ocb:       4459 MiB/s
        isapa128a:        128 MiB/s
    aes128-single:  107339395 ops/s
    aes256-single:   77576997 ops/s
         aes128-8:  450189360 ops/s
         aes256-8:  321546122 ops/s
           bcrypt:      0.191 s/ops
           scrypt:      0.031 s/ops
           argon2:      0.087 s/ops
```

Cheers!
