### PR TITLE
Sema: Fix many-pointer array concatenation at comptime 

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9113,8 +9113,8 @@ fn zirArrayCat(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
             const rhs_len = try sema.usizeCast(block, lhs_src, rhs_info.len);
             const final_len = lhs_len + rhs_len;
             const final_len_including_sent = final_len + @boolToInt(res_sent != null);
-            const lhs_single_ptr = lhs_ty.zigTypeTag() == .Pointer and !lhs_ty.isSlice();
-            const rhs_single_ptr = rhs_ty.zigTypeTag() == .Pointer and !rhs_ty.isSlice();
+            const lhs_single_ptr = lhs_ty.isSinglePointer();
+            const rhs_single_ptr = rhs_ty.isSinglePointer();
             const lhs_sub_val = if (lhs_single_ptr) (try sema.pointerDeref(block, lhs_src, lhs_val, lhs_ty)).? else lhs_val;
             const rhs_sub_val = if (rhs_single_ptr) (try sema.pointerDeref(block, rhs_src, rhs_val, rhs_ty)).? else rhs_val;
             var anon_decl = try block.startAnonDecl(LazySrcLoc.unneeded);

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -709,6 +709,31 @@ test "string concatenation" {
     try expect(b[len] == 0);
 }
 
+fn manyptrConcat(comptime s: [*:0]const u8) [*:0]const u8 {
+    return "very " ++ s;
+}
+
+test "comptime manyptr concatenation" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
+    const s = "epic";
+    const actual = manyptrConcat(s);
+    const expected = "very epic";
+
+    const len = mem.len(actual);
+    const len_with_null = len + 1;
+    {
+        var i: u32 = 0;
+        while (i < len_with_null) : (i += 1) {
+            try expect(actual[i] == expected[i]);
+        }
+    }
+    try expect(actual[len] == 0);
+    try expect(expected[len] == 0);
+}
+
 test "thread local variable" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO


### PR DESCRIPTION
This allows the following code to now compile properly:

```zig
export fn _start() void {
    _ = doTheTest("bar");
}

fn doTheTest(comptime s: [*:0]const u8) [*:0]const u8 {
        return "foo" ++ s;
}
```