### PR TITLE
stage2: fix build on Arch Linux

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -154,6 +154,7 @@ pub fn build(b: *Builder) !void {
 
     b.default_step.dependOn(&exe.step);
     exe.single_threaded = single_threaded;
+    exe.linkSystemLibrary("c_nonshared");
 
     if (target.isWindows() and target.getAbi() == .gnu) {
         // LTO is currently broken on mingw, this can be removed when it's fixed.


### PR DESCRIPTION
Prior to this commit, building on Arch Linux would result in
the following linker error:

	undefined symbol: __libc_single_threaded

Updates ziglang/zig#11137.