### PR TITLE
stage2: add referenced by trace to compile errors

### DIFF
--- a/src/test.zig
+++ b/src/test.zig
@@ -102,6 +102,7 @@ const ErrorMsg = union(enum) {
                     .kind = kind,
                 },
             },
+            .ref => unreachable,
         }
     }
 
@@ -1467,6 +1468,7 @@ pub const TestContext = struct {
                             .plain => |plain| {
                                 print("error: {s}\n{s}\n", .{ plain.msg, hr });
                             },
+                            .ref => unreachable,
                         }
                     }
                     // TODO print generated C code
@@ -1548,6 +1550,7 @@ pub const TestContext = struct {
                                         break;
                                     }
                                 },
+                                .ref => unreachable,
                             }
                         } else {
                             print(
@@ -1596,6 +1599,7 @@ pub const TestContext = struct {
                                         break;
                                     }
                                 },
+                                .ref => unreachable,
                             }
                         } else {
                             print(


### PR DESCRIPTION
This is useful information to have but the way stage1 handled it was quite noisy so I tried to make it as condensed as possible. If it is still too much a flag to disable them could be added for those who want it.
![Screenshot from 2022-04-26 22-51-30](https://user-images.githubusercontent.com/15308111/165384708-39f57684-474b-4ff6-bcc4-63ec314eae14.png)
