### PR TITLE
naive attempt to port posix_spawn from musl

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -3044,6 +3044,9 @@ pub const winsize = extern struct {
 /// As signal numbers are sequential, NSIG is one greater than the largest defined signal number.
 pub const NSIG = if (is_mips) 128 else 65;
 
+// TODO document or fix this for 32 bit systems
+// see https://unix.stackexchange.com/a/399356
+// sigset_t is 128 bytes on 64 bit Linux, Linux reserves 1024 bit
 pub const sigset_t = [1024 / 32]u32;
 
 pub const all_mask: sigset_t = [_]u32{0xffffffff} ** sigset_t.len;

--- a/lib/std/os/posix_spawn.zig
+++ b/lib/std/os/posix_spawn.zig
@@ -279,4 +279,9 @@ const posix_spawn = if (builtin.target.isDarwin()) struct {
             }
         }
     }
+} else if (builtin.target.os.tag == .linux)
+{
+    // TODO .ios, .macos, .watchos, .tvos => true,
+    //switch (tag) { ... };
+    //@panic("successful chosen tag .linux");
 } else struct {};


### PR DESCRIPTION
* feasible, but some threading stuff needs to be ported first:
  - missing pieces in Zig libstd for finishing:
    + pthread_setcancelstate
    + pthread_sigmask
    
(or whatever Zig wants to use instead inside Thread.zig)