### PR TITLE
CBE: fix renderValue() for struct fields with no runtime bits

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -821,12 +821,14 @@ pub const DeclGen = struct {
                 try dg.renderTypecast(writer, ty);
                 try writer.writeAll("){");
 
-                for (field_vals) |field_val, i| {
-                    const field_ty = ty.structFieldType(i);
+                var i: usize = 0;
+                for (field_vals) |field_val, field_index| {
+                    const field_ty = ty.structFieldType(field_index);
                     if (!field_ty.hasRuntimeBits()) continue;
 
                     if (i != 0) try writer.writeAll(",");
                     try dg.renderValue(writer, field_ty, field_val, location);
+                    i += 1;
                 }
 
                 try writer.writeAll("}");

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -299,7 +299,6 @@ test "struct point to self" {
 
 test "void struct fields" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     const foo = VoidStructFieldsFoo{


### PR DESCRIPTION
These shouldn't count towards the total emitted, or the stray comma
separators would cause compilation errors.