### PR TITLE
Stage2: fix comptime unreachable, adjust Zir.Extended

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -740,7 +740,7 @@ fn expr(gz: *GenZir, scope: *Scope, rl: ResultLoc, node: Ast.Node.Index) InnerEr
             _ = try gz.addAsIndex(.{
                 .tag = .@"unreachable",
                 .data = .{ .@"unreachable" = .{
-                    .safety = true,
+                    .force_comptime = gz.force_comptime,
                     .src_node = gz.nodeIndexToRelative(node),
                 } },
             });

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1532,10 +1532,10 @@ pub const Fn = struct {
         switch (zir_tags[func.zir_body_inst]) {
             .func => return false,
             .func_inferred => return true,
-            .extended => {
-                const extended = zir.instructions.items(.data)[func.zir_body_inst].extended;
-                const small = @bitCast(Zir.Inst.ExtendedFunc.Small, extended.small);
-                return small.is_inferred_error;
+            .func_extended => {
+                const inst_data = zir.instructions.items(.data)[func.zir_body_inst].pl_node;
+                const extra = zir.extraData(Zir.Inst.ExtendedFunc, inst_data.payload_index);
+                return extra.data.bits.is_inferred_error;
             },
             else => unreachable,
         }

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2502,11 +2502,7 @@ pub const Inst = struct {
             /// Offset from Decl AST node index.
             /// `Tag` determines which kind of AST node this points to.
             src_node: i32,
-            /// `false`: Not safety checked - the compiler will assume the
-            /// correctness of this instruction.
-            /// `true`: In safety-checked modes, this will generate a call
-            /// to the panic function unless it can be proven unreachable by the compiler.
-            safety: bool,
+            force_comptime: bool,
 
             pub fn src(self: @This()) LazySrcLoc {
                 return .{ .node_offset = self.src_node };

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -2091,8 +2091,6 @@ const Writer = struct {
 
     fn writeUnreachable(self: *Writer, stream: anytype, inst: Zir.Inst.Index) !void {
         const inst_data = self.code.instructions.items(.data)[inst].@"unreachable";
-        const safety_str = if (inst_data.safety) "safe" else "unsafe";
-        try stream.print("{s}) ", .{safety_str});
         try self.writeSrc(stream, inst_data.src());
     }
 

--- a/test/compile_errors/stage2/comptime_unreachable.zig
+++ b/test/compile_errors/stage2/comptime_unreachable.zig
@@ -1,0 +1,7 @@
+pub export fn entry() void {
+    comptime unreachable;
+}
+
+// error
+//
+// :2:14: error: reached unreachable code

--- a/test/incremental/x86_64-linux/comptime_var.3.zig
+++ b/test/incremental/x86_64-linux/comptime_var.3.zig
@@ -7,4 +7,4 @@ pub fn main() void {}
 
 // error
 //
-// :4:17: error: unable to resolve comptime value
+// :4:17: error: reached unreachable code

--- a/test/incremental/x86_64-macos/comptime_var.3.zig
+++ b/test/incremental/x86_64-macos/comptime_var.3.zig
@@ -7,4 +7,4 @@ pub fn main() void {}
 
 // error
 //
-// :4:17: error: unable to resolve comptime value
+// :4:17: error: reached unreachable code


### PR DESCRIPTION
This reduces the amount of `.extended` instructions from 212702 down to 6711 (in `zig fmt --ast-check src lib/std`).