### PR TITLE
std: Do not allocate the result for ChildProcess.init

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -971,9 +971,7 @@ pub const Builder = struct {
         if (!std.process.can_spawn)
             return error.ExecNotSupported;
 
-        const child = std.ChildProcess.init(argv, self.allocator) catch unreachable;
-        defer child.deinit();
-
+        var child = std.ChildProcess.init(argv, self.allocator);
         child.cwd = cwd;
         child.env_map = env_map;
 
@@ -1187,9 +1185,7 @@ pub const Builder = struct {
             return error.ExecNotSupported;
 
         const max_output_size = 400 * 1024;
-        const child = try std.ChildProcess.init(argv, self.allocator);
-        defer child.deinit();
-
+        var child = std.ChildProcess.init(argv, self.allocator);
         child.stdin_behavior = .Ignore;
         child.stdout_behavior = .Pipe;
         child.stderr_behavior = stderr_behavior;

--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -184,9 +184,7 @@ fn make(step: *Step) !void {
         return ExecError.ExecNotSupported;
     }
 
-    const child = std.ChildProcess.init(argv, self.builder.allocator) catch unreachable;
-    defer child.deinit();
-
+    var child = std.ChildProcess.init(argv, self.builder.allocator);
     child.cwd = cwd;
     child.env_map = self.env_map orelse self.builder.env_map;
 

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -442,10 +442,11 @@ pub fn buildExe(zigexec: []const u8, zigfile: []const u8, binfile: []const u8) !
     const flag_emit = "-femit-bin=";
     const cmd_emit = try std.mem.concat(allocator, u8, &[_][]const u8{ flag_emit, binfile });
     defer allocator.free(cmd_emit);
+
     const args = [_][]const u8{ zigexec, "build-exe", zigfile, cmd_emit };
-    var procCompileChild = try std.ChildProcess.init(&args, allocator);
-    defer procCompileChild.deinit();
+    var procCompileChild = std.ChildProcess.init(&args, allocator);
     try procCompileChild.spawn();
+
     const ret_val = try procCompileChild.wait();
     try expectEqual(ret_val, .{ .Exited = 0 });
 }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3611,9 +3611,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
         }
 
         if (std.process.can_spawn) {
-            const child = try std.ChildProcess.init(argv.items, arena);
-            defer child.deinit();
-
+            var child = std.ChildProcess.init(argv.items, arena);
             if (comp.clang_passthrough_mode) {
                 child.stdin_behavior = .Inherit;
                 child.stdout_behavior = .Inherit;

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1390,9 +1390,7 @@ fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Node) !
             // If possible, we run LLD as a child process because it does not always
             // behave properly as a library, unfortunately.
             // https://github.com/ziglang/zig/issues/3825
-            const child = try std.ChildProcess.init(argv.items, arena);
-            defer child.deinit();
-
+            var child = std.ChildProcess.init(argv.items, arena);
             if (comp.clang_passthrough_mode) {
                 child.stdin_behavior = .Inherit;
                 child.stdout_behavior = .Inherit;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1754,9 +1754,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
             // If possible, we run LLD as a child process because it does not always
             // behave properly as a library, unfortunately.
             // https://github.com/ziglang/zig/issues/3825
-            const child = try std.ChildProcess.init(argv.items, arena);
-            defer child.deinit();
-
+            var child = std.ChildProcess.init(argv.items, arena);
             if (comp.clang_passthrough_mode) {
                 child.stdin_behavior = .Inherit;
                 child.stdout_behavior = .Inherit;

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -2405,9 +2405,7 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) !
             // If possible, we run LLD as a child process because it does not always
             // behave properly as a library, unfortunately.
             // https://github.com/ziglang/zig/issues/3825
-            const child = try std.ChildProcess.init(argv.items, arena);
-            defer child.deinit();
-
+            var child = std.ChildProcess.init(argv.items, arena);
             if (comp.clang_passthrough_mode) {
                 child.stdin_behavior = .Inherit;
                 child.stdout_behavior = .Inherit;

--- a/src/main.zig
+++ b/src/main.zig
@@ -3012,9 +3012,7 @@ fn runOrTest(
         const cmd = try std.mem.join(arena, " ", argv.items);
         fatal("the following command failed to execve with '{s}':\n{s}", .{ @errorName(err), cmd });
     } else if (std.process.can_spawn) {
-        const child = try std.ChildProcess.init(argv.items, gpa);
-        defer child.deinit();
-
+        var child = std.ChildProcess.init(argv.items, gpa);
         child.stdin_behavior = .Inherit;
         child.stdout_behavior = .Inherit;
         child.stderr_behavior = .Inherit;
@@ -3700,9 +3698,7 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
     };
 
     if (std.process.can_spawn) {
-        const child = try std.ChildProcess.init(child_argv, gpa);
-        defer child.deinit();
-
+        var child = std.ChildProcess.init(child_argv, gpa);
         child.stdin_behavior = .Inherit;
         child.stdout_behavior = .Inherit;
         child.stderr_behavior = .Inherit;

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -369,9 +369,7 @@ pub fn buildImportLib(comp: *Compilation, lib_name: []const u8) !void {
     }
 
     if (std.process.can_spawn) {
-        const child = try std.ChildProcess.init(&args, arena);
-        defer child.deinit();
-
+        var child = std.ChildProcess.init(&args, arena);
         child.stdin_behavior = .Ignore;
         child.stdout_behavior = .Pipe;
         child.stderr_behavior = .Pipe;

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -731,9 +731,7 @@ pub const StackTracesContext = struct {
                 return ExecError.ExecNotSupported;
             }
 
-            const child = std.ChildProcess.init(args.items, b.allocator) catch unreachable;
-            defer child.deinit();
-
+            var child = std.ChildProcess.init(args.items, b.allocator);
             child.stdin_behavior = .Ignore;
             child.stdout_behavior = .Pipe;
             child.stderr_behavior = .Pipe;


### PR DESCRIPTION
Instead, just return ChildProcess directly. This structure does not
require a stable address, so we can put it on the stack just fine. If
someone wants it on the heap they should do.

```zig
const proc = try allocator.create(ChildProcess);
proc.* = ChildProcess.init(args, allocator);
```