### PR TITLE
CBE: handle returning `undefined` for ErrorUnion

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -580,7 +580,7 @@ pub const DeclGen = struct {
                     64 => return writer.writeAll("(void *)0xaaaaaaaaaaaaaaaa"),
                     else => unreachable,
                 },
-                .Struct => {
+                .Struct, .ErrorUnion => {
                     try writer.writeByte('(');
                     try dg.renderTypecast(writer, ty);
                     return writer.writeAll("){0xaa}");

--- a/test/behavior/sizeof_and_typeof.zig
+++ b/test/behavior/sizeof_and_typeof.zig
@@ -187,7 +187,6 @@ test "@sizeOf(T) == 0 doesn't force resolving struct size" {
 
 test "@TypeOf() has no runtime side effects" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     const S = struct {
         fn foo(comptime T: type, ptr: *T) T {
             ptr.* += 1;
@@ -203,7 +202,6 @@ test "@TypeOf() has no runtime side effects" {
 test "branching logic inside @TypeOf" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     const S = struct {
         var data: i32 = 0;
         fn foo() anyerror!i32 {


### PR DESCRIPTION
Just like for `Struct` in 8238d4b33585a715c58ab559cd001dd3ea1db55b, in the case of `ErrorUnion` struct we need to return a compound literal `(T){...}` instead of just `{}`, which is invalid code when used in e.g. a `return` expression.