### PR TITLE
std.io: Add `Reader.readLEB128` and `Writer.writeLEB128`

### DIFF
--- a/lib/std/io/reader.zig
+++ b/lib/std/io/reader.zig
@@ -274,6 +274,16 @@ pub fn Reader(
             return mem.readInt(T, &bytes, endian);
         }
 
+        /// Reads a LEB128 (Little Endian Base 128) value.
+        ///
+        /// See also: `std.leb` and https://en.wikipedia.org/wiki/LEB128
+        pub fn readLEB128(self: Self, comptime T: type) !T {
+            if (comptime std.meta.trait.isUnsignedInt(T))
+                return std.leb.readULEB128(T, self)
+            else
+                return std.leb.readILEB128(T, self);
+        }
+
         pub fn readVarInt(self: Self, comptime ReturnType: type, endian: std.builtin.Endian, size: usize) !ReturnType {
             assert(size <= @sizeOf(ReturnType));
             var bytes_buf: [@sizeOf(ReturnType)]u8 = undefined;

--- a/lib/std/io/writer.zig
+++ b/lib/std/io/writer.zig
@@ -82,6 +82,16 @@ pub fn Writer(
             return self.writeAll(&bytes);
         }
 
+        /// Writes a LEB128 (Little Endian Base 128) value.
+        ///
+        /// See also: `std.leb` and https://en.wikipedia.org/wiki/LEB128
+        pub fn writeLEB128(self: Self, comptime T: type) Error!void {
+            if (comptime std.meta.trait.isUnsignedInt(T))
+                return std.leb.writeULEB128(self, T)
+            else
+                return std.leb.writeILEB128(self, T);
+        }
+
         pub fn writeStruct(self: Self, value: anytype) Error!void {
             // Only extern and packed structs have defined in-memory layout.
             comptime assert(@typeInfo(@TypeOf(value)).Struct.layout != .Auto);


### PR DESCRIPTION
I think it'd be pretty nice to add some helpers for reading and writing LEB128 values.
LEB128 values in the wild definitely happen and this makes parsing such byte streams using `std.io.Reader` easier and it makes this functionality more accessible. All kinds of byte formats use LEB128 values because they're so efficient.
It also takes the burden of the choice between the unsigned or signed version off your shoulders.

Additionally, this might also encourage the usage of LEB128 a little bit, when for example creating your own format.

Later, for consistency, I also added `std.io.Writer.writeLEB128`.