### PR TITLE
Path rename

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -385,7 +385,7 @@ pub const Builder = struct {
     pub fn dupePkg(self: *Builder, package: Pkg) Pkg {
         var the_copy = Pkg{
             .name = self.dupe(package.name),
-            .path = package.path.dupe(self),
+            .source = package.source.dupe(self),
         };
 
         if (package.dependencies) |dependencies| {
@@ -1353,7 +1353,7 @@ pub const Target = @compileError("deprecated; Use `std.zig.CrossTarget`");
 
 pub const Pkg = struct {
     name: []const u8,
-    path: FileSource,
+    source: FileSource,
     dependencies: ?[]const Pkg = null,
 };
 
@@ -2226,7 +2226,7 @@ pub const LibExeObjStep = struct {
     }
 
     fn addRecursiveBuildDeps(self: *LibExeObjStep, package: Pkg) void {
-        package.path.addStepDependencies(&self.step);
+        package.source.addStepDependencies(&self.step);
         if (package.dependencies) |deps| {
             for (deps) |dep| {
                 self.addRecursiveBuildDeps(dep);
@@ -2237,7 +2237,7 @@ pub const LibExeObjStep = struct {
     pub fn addPackagePath(self: *LibExeObjStep, name: []const u8, pkg_index_path: []const u8) void {
         self.addPackage(Pkg{
             .name = self.builder.dupe(name),
-            .path = .{ .path = self.builder.dupe(pkg_index_path) },
+            .source = .{ .path = self.builder.dupe(pkg_index_path) },
         });
     }
 
@@ -2298,7 +2298,7 @@ pub const LibExeObjStep = struct {
 
         try zig_args.append("--pkg-begin");
         try zig_args.append(pkg.name);
-        try zig_args.append(builder.pathFromRoot(pkg.path.getPath(self.builder)));
+        try zig_args.append(builder.pathFromRoot(pkg.source.getPath(self.builder)));
 
         if (pkg.dependencies) |dependencies| {
             for (dependencies) |sub_pkg| {
@@ -3521,11 +3521,11 @@ test "Builder.dupePkg()" {
 
     var pkg_dep = Pkg{
         .name = "pkg_dep",
-        .path = .{ .path = "/not/a/pkg_dep.zig" },
+        .source = .{ .path = "/not/a/pkg_dep.zig" },
     };
     var pkg_top = Pkg{
         .name = "pkg_top",
-        .path = .{ .path = "/not/a/pkg_top.zig" },
+        .source = .{ .path = "/not/a/pkg_top.zig" },
         .dependencies = &[_]Pkg{pkg_dep},
     };
     const dupe = builder.dupePkg(pkg_top);
@@ -3566,11 +3566,11 @@ test "LibExeObjStep.addPackage" {
 
     const pkg_dep = Pkg{
         .name = "pkg_dep",
-        .path = .{ .path = "/not/a/pkg_dep.zig" },
+        .source = .{ .path = "/not/a/pkg_dep.zig" },
     };
     const pkg_top = Pkg{
         .name = "pkg_dep",
-        .path = .{ .path = "/not/a/pkg_top.zig" },
+        .source = .{ .path = "/not/a/pkg_top.zig" },
         .dependencies = &[_]Pkg{pkg_dep},
     };
 

--- a/lib/std/build/OptionsStep.zig
+++ b/lib/std/build/OptionsStep.zig
@@ -200,7 +200,7 @@ pub fn addOptionArtifact(self: *OptionsStep, name: []const u8, artifact: *LibExe
 }
 
 pub fn getPackage(self: *OptionsStep, package_name: []const u8) build.Pkg {
-    return .{ .name = package_name, .path = self.getSource() };
+    return .{ .name = package_name, .source = self.getSource() };
 }
 
 pub fn getSource(self: *OptionsStep) FileSource {


### PR DESCRIPTION
Currently the naming scheme for the source of `std.build.Pkg` is extremely redundant and inconsistent with the struct used to contain the source (`FileSource` in specific). This merge request is breaking change discussed in the Discord that changes the `std.build.Pkg.path` field to be named `std.build.Pkg.source`, making it easier to read in the long run, as well as being consistent.

```zig
const Pkg = @import("std").build.Pkg;

// old
const hello = Pkg{ .name = "hello", .path = .{ .path = "lib/hello.zig" } };

// new
const hello = Pkg{ .name = "hello", .source = .{ .path = "lib/hello.zig" } };
```

I have ran tests to ensure everything builds correctly, as well as built stage 2 and 3 to ensure all stages build.