### PR TITLE
std: Single-threaded `panicImpl` sleep is unreachable

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -340,6 +340,7 @@ pub fn panicImpl(trace: ?*const std.builtin.StackTrace, first_trace_addr: ?usize
             if (panicking.fetchSub(1, .SeqCst) != 1) {
                 // Another thread is panicking, wait for the last one to finish
                 // and call abort()
+                if (builtin.single_threaded) unreachable;
 
                 // Sleep forever without hammering the CPU
                 var futex = std.atomic.Atomic(u32).init(0);


### PR DESCRIPTION
Adding `unreachable` prevents the futex code from being inspected during
a single-threaded build. Without futex, first draft BYOS packages don't
need to implement `nanosleep` to get a single-threaded "hello world"
program working.

Use of `assert()` did not achieve the desired effect of avoiding futex
in a single-threaded build.